### PR TITLE
render: flesh out metal backend and unify resource handles across bac…

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_debug_overlay.hpp
+++ b/engine/prefabs/irreden/render/systems/system_debug_overlay.hpp
@@ -288,8 +288,8 @@ template <> struct System<DEBUG_OVERLAY> {
 
         IRRender::createNamedResource<IRRender::VAO>(
             "DebugOverlayVAO",
-            vb->getHandle(),
-            0,
+            vb,
+            static_cast<const IRRender::Buffer *>(nullptr),
             2,
             IRRender::kAttrListDebugVertex
         );

--- a/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
@@ -209,9 +209,13 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                         1, TextureAccess::READ_WRITE, TextureFormat::R32I
                     );
 
+                    s_shapesFrameDataBuf->bindBase(
+                        BufferTarget::UNIFORM, kBufferIndex_ShapesFrameData);
+
                     // Pass 0: depth via imageAtomicMin
                     frameData.passIndex = 0;
-                    s_shapesFrameDataBuf->subData(0, sizeof(GPUShapesFrameData), &frameData);
+                    s_shapesFrameDataBuf->subData(
+                        0, sizeof(GPUShapesFrameData), &frameData);
 
                     IRRender::TimePoint pass0Start;
                     if (timing.enabled_) {
@@ -241,8 +245,10 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                     canvasTextures.getTextureEntityIds()->bindAsImage(
                         2, TextureAccess::WRITE_ONLY, TextureFormat::RG32UI
                     );
+
                     frameData.passIndex = 1;
-                    s_shapesFrameDataBuf->subData(0, sizeof(GPUShapesFrameData), &frameData);
+                    s_shapesFrameDataBuf->subData(
+                        0, sizeof(GPUShapesFrameData), &frameData);
 
                     IRRender::device()->dispatchCompute(
                         static_cast<std::uint32_t>(tileCount), 1, 1);

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -115,7 +115,7 @@ inline void clearCanvasAndDistances(
     static const std::int32_t clearValue =
         static_cast<std::int32_t>(IRConstants::kTrixelDistanceMaxDistance);
     IRRender::device()->clearTexImage(
-        canvas.getTextureDistances()->getHandle(), 0, &clearValue
+        canvas.getTextureDistances(), 0, &clearValue
     );
 }
 
@@ -294,7 +294,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
                 triangleCanvasTextures.getTextureDistances()->bindAsImage(
                     1, TextureAccess::READ_ONLY, TextureFormat::R32I
                 );
-                IRRender::device()->dispatchComputeIndirect(s_indirectBuf->getHandle(), 0);
+                IRRender::device()->dispatchComputeIndirect(s_indirectBuf, 0);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
                 if (timing.enabled_) { IRRender::device()->finish(); t1 = IRRender::SteadyClock::now(); timing.voxelStage1Ms_ = IRRender::elapsedMs(t0, t1); }
@@ -347,7 +347,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_2> {
                     2, TextureAccess::WRITE_ONLY, TextureFormat::RG32UI
                 );
 
-                IRRender::device()->dispatchComputeIndirect(s_indirectBuf->getHandle(), 0);
+                IRRender::device()->dispatchComputeIndirect(s_indirectBuf, 0);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
                 if (timing.enabled_) { IRRender::device()->finish(); timing.voxelStage2Ms_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }

--- a/engine/render/include/irreden/render/buffer.hpp
+++ b/engine/render/include/irreden/render/buffer.hpp
@@ -13,6 +13,9 @@ class BufferImpl {
   public:
     virtual ~BufferImpl() = default;
     virtual std::uint32_t getHandle() const = 0;
+    // Native backend object (MTL::Buffer* on Metal, nullptr on OpenGL where
+    // getHandle is canonical). Mirrors Texture2DImpl::getNativeTexture.
+    virtual void *getNativeBuffer() const = 0;
     virtual void subData(std::ptrdiff_t offset, std::size_t size, const void *data) const = 0;
     virtual void getSubData(std::ptrdiff_t offset, std::size_t size, void *data) const = 0;
     virtual void bindRange(BufferTarget target, std::uint32_t index, std::ptrdiff_t offset, std::size_t size) = 0;
@@ -38,6 +41,7 @@ class Buffer {
     Buffer &operator=(const Buffer &) = delete;
 
     std::uint32_t getHandle() const;
+    void *getNativeBuffer() const;
     void subData(std::ptrdiff_t offset, std::size_t size, const void *data) const;
     void getSubData(std::ptrdiff_t offset, std::size_t size, void *data) const;
     void bindRange(BufferTarget target, std::uint32_t index, std::ptrdiff_t offset, std::size_t size);

--- a/engine/render/include/irreden/render/metal/metal_runtime.hpp
+++ b/engine/render/include/irreden/render/metal/metal_runtime.hpp
@@ -83,8 +83,21 @@ MTL::Texture *metalCurrentDepthTexture();
 MTL::PixelFormat metalCurrentColorPixelFormat();
 MTL::PixelFormat metalCurrentDepthPixelFormat();
 
-std::uint32_t registerMetalBufferHandle(MTL::Buffer *buffer);
-void unregisterMetalBufferHandle(std::uint32_t handle);
-MTL::Buffer *lookupMetalBufferHandle(std::uint32_t handle);
+// Buffer orphaning: every subData() allocates a fresh MTL::Buffer and
+// defer-releases the old one so already-encoded encoders keep their
+// pre-write snapshot. See metal_runtime.cpp for the lifetime contract.
+void deferReleaseMetalBuffer(MTL::Buffer *buffer);
+void releaseDeferredMetalBuffers();
+void replaceMetalBufferInBindings(MTL::Buffer *oldBuffer, MTL::Buffer *newBuffer);
+
+// Per-texture scratch buffer mirroring an R32I distance texture, used as
+// the target for `device atomic_int*` min ops because MSL has no portable
+// image-atomic syntax across macOS versions. See metal_runtime.cpp.
+constexpr std::uint32_t kMetalImageAtomicScratchSlot = 16;
+MTL::Buffer *ensureImageAtomicScratchBuffer(MTL::Texture *texture);
+MTL::Buffer *lookupImageAtomicScratchBuffer(MTL::Texture *texture);
+void releaseImageAtomicScratchBuffer(MTL::Texture *texture);
+void setCurrentImageAtomicScratch(MTL::Buffer *buffer);
+MTL::Buffer *currentImageAtomicScratch();
 
 } // namespace IRRender

--- a/engine/render/include/irreden/render/render_device.hpp
+++ b/engine/render/include/irreden/render/render_device.hpp
@@ -7,6 +7,9 @@
 
 namespace IRRender {
 
+class Buffer;
+class Texture2D;
+
 class RenderDevice {
   public:
     virtual ~RenderDevice() = default;
@@ -15,7 +18,7 @@ class RenderDevice {
     virtual void present() = 0;
 
     virtual void dispatchCompute(std::uint32_t x, std::uint32_t y, std::uint32_t z) = 0;
-    virtual void dispatchComputeIndirect(std::uint32_t bufferHandle, std::ptrdiff_t offset) = 0;
+    virtual void dispatchComputeIndirect(const Buffer *indirectBuffer, std::ptrdiff_t offset) = 0;
     virtual void memoryBarrier(BarrierType barrierType) = 0;
     virtual void drawElements(DrawMode drawMode, int count, IndexType indexType) = 0;
     virtual void drawElementsInstanced(DrawMode drawMode, int count, IndexType indexType, int instanceCount) = 0;
@@ -33,7 +36,7 @@ class RenderDevice {
     virtual void disableBlending() = 0;
     virtual void setDepthTest(bool enabled) = 0;
     virtual void setDepthWrite(bool enabled) = 0;
-    virtual void clearTexImage(std::uint32_t textureHandle, int level, const void *data) = 0;
+    virtual void clearTexImage(const Texture2D *texture, int level, const void *data) = 0;
     virtual void finish() = 0;
 };
 

--- a/engine/render/include/irreden/render/vao.hpp
+++ b/engine/render/include/irreden/render/vao.hpp
@@ -8,6 +8,8 @@
 
 namespace IRRender {
 
+class Buffer;
+
 const unsigned int kMaxVertexAttributes = 16;
 
 class VertexLayoutImpl {
@@ -19,8 +21,8 @@ class VertexLayoutImpl {
 class VertexLayout {
   public:
     VertexLayout(
-        std::uint32_t vertexBufferHandle,
-        std::uint32_t indexBufferHandle,
+        const Buffer *vertexBuffer,
+        const Buffer *indexBuffer,
         unsigned int numAttributes,
         const VertexArrayAttribute *attributes
     );

--- a/engine/render/src/buffer.cpp
+++ b/engine/render/src/buffer.cpp
@@ -35,6 +35,10 @@ std::uint32_t Buffer::getHandle() const {
     return m_impl->getHandle();
 }
 
+void *Buffer::getNativeBuffer() const {
+    return m_impl->getNativeBuffer();
+}
+
 void Buffer::subData(std::ptrdiff_t offset, std::size_t size, const void *data) const {
     m_impl->subData(offset, size, data);
 }

--- a/engine/render/src/metal/metal_buffer.cpp
+++ b/engine/render/src/metal/metal_buffer.cpp
@@ -15,7 +15,6 @@ class MetalBufferImpl final : public BufferImpl {
             MTL::ResourceStorageModeShared
         );
         IR_ASSERT(m_buffer != nullptr, "Failed to create Metal buffer");
-        m_handle = registerMetalBufferHandle(m_buffer);
         if (data != nullptr && size > 0) {
             std::memcpy(m_buffer->contents(), data, size);
         }
@@ -32,7 +31,6 @@ class MetalBufferImpl final : public BufferImpl {
     }
 
     ~MetalBufferImpl() override {
-        unregisterMetalBufferHandle(m_handle);
         if (m_buffer != nullptr) {
             m_buffer->release();
             m_buffer = nullptr;
@@ -40,7 +38,11 @@ class MetalBufferImpl final : public BufferImpl {
     }
 
     std::uint32_t getHandle() const override {
-        return m_handle;
+        return 0;
+    }
+
+    void *getNativeBuffer() const override {
+        return m_buffer;
     }
 
     void subData(std::ptrdiff_t offset, std::size_t size, const void *data) const override {
@@ -51,7 +53,30 @@ class MetalBufferImpl final : public BufferImpl {
             static_cast<std::size_t>(offset) + size <= m_size,
             "Metal buffer subData write exceeded buffer size"
         );
-        std::memcpy(static_cast<std::uint8_t *>(m_buffer->contents()) + offset, data, size);
+
+        // Orphan-on-write: see deferReleaseMetalBuffer in metal_runtime.cpp.
+        auto *newBuffer = metalDevice()->newBuffer(
+            static_cast<NS::UInteger>(m_size),
+            MTL::ResourceStorageModeShared
+        );
+        IR_ASSERT(newBuffer != nullptr, "Failed to orphan Metal buffer in subData");
+
+        std::uint8_t *src = static_cast<std::uint8_t *>(m_buffer->contents());
+        std::uint8_t *dst = static_cast<std::uint8_t *>(newBuffer->contents());
+        const std::size_t writeOffset = static_cast<std::size_t>(offset);
+        if (writeOffset > 0) {
+            std::memcpy(dst, src, writeOffset);
+        }
+        std::memcpy(dst + writeOffset, data, size);
+        const std::size_t tailStart = writeOffset + size;
+        if (tailStart < m_size) {
+            std::memcpy(dst + tailStart, src + tailStart, m_size - tailStart);
+        }
+
+        MTL::Buffer *oldBuffer = m_buffer;
+        m_buffer = newBuffer;
+        replaceMetalBufferInBindings(oldBuffer, m_buffer);
+        deferReleaseMetalBuffer(oldBuffer);
     }
 
     void getSubData(std::ptrdiff_t offset, std::size_t size, void *data) const override {
@@ -85,9 +110,10 @@ class MetalBufferImpl final : public BufferImpl {
     void unmap() override {}
 
   private:
-    MTL::Buffer *m_buffer = nullptr;
+    // mutable: subData is const on the BufferImpl interface but orphans the
+    // backing buffer on every write (see subData).
+    mutable MTL::Buffer *m_buffer = nullptr;
     std::size_t m_size = 0;
-    std::uint32_t m_handle = 0;
 };
 
 std::unique_ptr<BufferImpl> createBufferImpl(const void *data, std::size_t size, std::uint32_t) {

--- a/engine/render/src/metal/metal_framebuffer.cpp
+++ b/engine/render/src/metal/metal_framebuffer.cpp
@@ -1,3 +1,4 @@
+#include <irreden/render/buffer.hpp>
 #include <irreden/render/framebuffer.hpp>
 #include <irreden/render/metal/metal_runtime.hpp>
 #include <irreden/render/vao.hpp>
@@ -67,14 +68,13 @@ class MetalFramebufferImpl final : public FramebufferImpl {
 class MetalVertexLayoutImpl final : public VertexLayoutImpl {
   public:
     MetalVertexLayoutImpl(
-        std::uint32_t vertexBufferHandle,
-        std::uint32_t indexBufferHandle,
+        const Buffer *vertexBuffer,
+        const Buffer *indexBuffer,
         unsigned int numAttributes,
         const VertexArrayAttribute *attributes
-    ) {
-        m_vertexBuffer = lookupMetalBufferHandle(vertexBufferHandle);
-        m_indexBuffer = lookupMetalBufferHandle(indexBufferHandle);
-
+    )
+        : m_vertexBufferWrapper(vertexBuffer)
+        , m_indexBufferWrapper(indexBuffer) {
         auto *vertexDescriptor = MTL::VertexDescriptor::alloc()->init();
         std::size_t stride = 0;
         for (unsigned int i = 0; i < numAttributes; ++i) {
@@ -97,12 +97,20 @@ class MetalVertexLayoutImpl final : public VertexLayoutImpl {
     }
 
     void bind() const override {
-        setActiveMetalVertexLayout(m_vertexBuffer, m_indexBuffer, m_vertexDescriptor);
+        // Resolve the live native pointers at bind time so buffer orphaning
+        // (see MetalBufferImpl::subData) is picked up automatically.
+        MTL::Buffer *vertexBuffer = m_vertexBufferWrapper != nullptr
+            ? static_cast<MTL::Buffer *>(m_vertexBufferWrapper->getNativeBuffer())
+            : nullptr;
+        MTL::Buffer *indexBuffer = m_indexBufferWrapper != nullptr
+            ? static_cast<MTL::Buffer *>(m_indexBufferWrapper->getNativeBuffer())
+            : nullptr;
+        setActiveMetalVertexLayout(vertexBuffer, indexBuffer, m_vertexDescriptor);
     }
 
   private:
-    MTL::Buffer *m_vertexBuffer = nullptr;
-    MTL::Buffer *m_indexBuffer = nullptr;
+    const Buffer *m_vertexBufferWrapper = nullptr;
+    const Buffer *m_indexBufferWrapper = nullptr;
     MTL::VertexDescriptor *m_vertexDescriptor = nullptr;
 };
 
@@ -114,14 +122,14 @@ std::unique_ptr<FramebufferImpl> createFramebufferImpl(
 }
 
 std::unique_ptr<VertexLayoutImpl> createVertexLayoutImpl(
-    std::uint32_t vertexBufferHandle,
-    std::uint32_t indexBufferHandle,
+    const Buffer *vertexBuffer,
+    const Buffer *indexBuffer,
     unsigned int numAttributes,
     const VertexArrayAttribute *attributes
 ) {
     return std::make_unique<MetalVertexLayoutImpl>(
-        vertexBufferHandle,
-        indexBufferHandle,
+        vertexBuffer,
+        indexBuffer,
         numAttributes,
         attributes
     );

--- a/engine/render/src/metal/metal_pipeline.cpp
+++ b/engine/render/src/metal/metal_pipeline.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace IRRender {
 
@@ -36,7 +37,87 @@ MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
     if (functionName == "c_text_to_trixel") {
         return MTL::Size(7, 11, 1);
     }
+    if (functionName == "c_shapes_to_trixel") {
+        return MTL::Size(8, 8, 1);
+    }
+    if (functionName == "c_voxel_visibility_compact" ||
+        functionName == "c_update_voxel_positions") {
+        return MTL::Size(64, 1, 1);
+    }
+    if (functionName == "c_trixel_to_trixel") {
+        return MTL::Size(16, 16, 1);
+    }
     return MTL::Size(1, 1, 1);
+}
+
+// Minimal #include "name.metal" preprocessor.  Resolves header references
+// against the directory of the file currently being parsed and prevents
+// infinite recursion via a visited set.  We need this because Metal's
+// newLibraryWithSource: API does not perform user-include resolution.
+std::string loadAndPreprocessMetalSource(
+    const std::string &filepath,
+    std::unordered_set<std::string> &visited
+) {
+    const std::string canonical = std::filesystem::weakly_canonical(filepath).string();
+    if (visited.count(canonical) != 0) {
+        return std::string{};
+    }
+    visited.insert(canonical);
+
+    const std::string source = IRUtility::readFileAsString(filepath);
+    const std::filesystem::path baseDir =
+        std::filesystem::path(filepath).parent_path();
+
+    std::string out;
+    out.reserve(source.size());
+
+    std::size_t pos = 0;
+    while (pos < source.size()) {
+        // Find the next newline so we work line-by-line.
+        const std::size_t lineEnd = source.find('\n', pos);
+        const std::string_view line(
+            source.data() + pos,
+            (lineEnd == std::string::npos ? source.size() : lineEnd) - pos
+        );
+
+        // Check for `#include "name"` after stripping leading whitespace.
+        std::size_t cursor = 0;
+        while (cursor < line.size() && (line[cursor] == ' ' || line[cursor] == '\t')) {
+            ++cursor;
+        }
+        constexpr std::string_view kIncludeKeyword = "#include";
+        bool handled = false;
+        if (cursor + kIncludeKeyword.size() < line.size() &&
+            line.substr(cursor, kIncludeKeyword.size()) == kIncludeKeyword) {
+            cursor += kIncludeKeyword.size();
+            while (cursor < line.size() && (line[cursor] == ' ' || line[cursor] == '\t')) {
+                ++cursor;
+            }
+            if (cursor < line.size() && line[cursor] == '"') {
+                ++cursor;
+                const std::size_t quoteEnd = line.find('"', cursor);
+                if (quoteEnd != std::string_view::npos) {
+                    const std::string headerName(line.substr(cursor, quoteEnd - cursor));
+                    const std::filesystem::path headerPath = baseDir / headerName;
+                    out += "// === begin include: " + headerName + " ===\n";
+                    out += loadAndPreprocessMetalSource(headerPath.string(), visited);
+                    out += "// === end include: " + headerName + " ===\n";
+                    handled = true;
+                }
+            }
+        }
+
+        if (!handled) {
+            out.append(line.data(), line.size());
+            out.push_back('\n');
+        }
+
+        if (lineEnd == std::string::npos) {
+            break;
+        }
+        pos = lineEnd + 1;
+    }
+    return out;
 }
 
 MTL::Library *loadMetalLibrary(const std::string &filepath) {
@@ -46,7 +127,8 @@ MTL::Library *loadMetalLibrary(const std::string &filepath) {
         return cached->second;
     }
 
-    const std::string source = IRUtility::readFileAsString(filepath);
+    std::unordered_set<std::string> visited;
+    const std::string source = loadAndPreprocessMetalSource(filepath, visited);
     NS::Error *error = nullptr;
     NS::String *nsSource = NS::String::string(source.c_str(), NS::UTF8StringEncoding);
     MTL::Library *library = metalDevice()->newLibrary(nsSource, nullptr, &error);

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -1,7 +1,9 @@
 #include <irreden/render/metal/metal_render_impl.hpp>
+#include <irreden/render/buffer.hpp>
 #include <irreden/render/metal/metal_cocoa_bridge.hpp>
 #include <irreden/render/metal/metal_runtime.hpp>
 #include <irreden/render/render_device.hpp>
+#include <irreden/render/texture.hpp>
 
 #include <cstdint>
 #include <cstring>
@@ -71,6 +73,12 @@ void bindComputeResources(MTL::ComputeCommandEncoder *encoder) {
         if (MTL::Texture *imageTexture = boundMetalImageTexture(i); imageTexture != nullptr) {
             encoder->setTexture(imageTexture, i);
         }
+    }
+
+    // Image atomic scratch buffer (mirrors the canvas distance R32I texture).
+    // See metal_runtime.hpp for the rationale; binding slot is fixed.
+    if (MTL::Buffer *scratch = currentImageAtomicScratch(); scratch != nullptr) {
+        encoder->setBuffer(scratch, 0, kMetalImageAtomicScratchSlot);
     }
 }
 
@@ -168,6 +176,9 @@ setMetalCommandBuffer(metalCommandQueue()->commandBuffer());
         }
         commandBuffer->commit();
         commandBuffer->waitUntilCompleted();
+        // Now that the GPU has finished consuming any encoders that
+        // captured orphaned buffers, it is safe to release them.
+        releaseDeferredMetalBuffers();
 setMetalDrawable(nullptr);
 setMetalCommandBuffer(nullptr);
     }
@@ -199,6 +210,21 @@ bindMetalDefaultRenderTarget();
         if (x < 0 || y < 0 || x + width > static_cast<int>(texture->width()) ||
             y + height > static_cast<int>(texture->height())) {
             return false;
+        }
+
+        // World::render() calls videoManager.render() (which lands here for
+        // screenshots) BEFORE presentFrame, so the current command buffer
+        // still has the entire frame's render work merely encoded — the GPU
+        // has not executed it yet. Reading texture->getBytes() at this point
+        // would return stale content from a previous frame, producing an
+        // off-by-one screenshot. Flush the encoded work synchronously here
+        // and start a fresh command buffer so present() can still encode the
+        // drawable presentation on top.
+        if (auto *commandBuffer = metalCommandBuffer(); commandBuffer != nullptr) {
+            commandBuffer->commit();
+            commandBuffer->waitUntilCompleted();
+            releaseDeferredMetalBuffers();
+            setMetalCommandBuffer(metalCommandQueue()->commandBuffer());
         }
 
         const std::size_t rowBytes = static_cast<std::size_t>(width) * 4U;
@@ -246,8 +272,36 @@ bindMetalDefaultRenderTarget();
         encoder->endEncoding();
     }
 
-    void memoryBarrier(BarrierType) override {}
-    void dispatchComputeIndirect(std::uint32_t, std::ptrdiff_t) override {}
+    void memoryBarrier(BarrierType) override {
+        // Metal command-encoder boundaries (one encoder per dispatch in this
+        // backend) act as implicit barriers between dispatches that touch
+        // shared resources, so an explicit barrier is unnecessary here.
+    }
+
+    void dispatchComputeIndirect(const Buffer *indirectBuffer, std::ptrdiff_t offset) override {
+        auto *commandBuffer = metalCommandBuffer();
+        auto *pipeline = activeMetalPipeline();
+        if (commandBuffer == nullptr || pipeline == nullptr || !pipeline->isComputePipeline()) {
+            return;
+        }
+        if (indirectBuffer == nullptr) {
+            return;
+        }
+        auto *mtlIndirectBuffer = static_cast<MTL::Buffer *>(indirectBuffer->getNativeBuffer());
+        if (mtlIndirectBuffer == nullptr) {
+            return;
+        }
+
+        auto *encoder = commandBuffer->computeCommandEncoder();
+        encoder->setComputePipelineState(pipeline->getComputePipelineState());
+        bindComputeResources(encoder);
+        encoder->dispatchThreadgroups(
+            mtlIndirectBuffer,
+            static_cast<NS::UInteger>(offset),
+            pipeline->getThreadsPerThreadgroup()
+        );
+        encoder->endEncoding();
+    }
     void drawElements(DrawMode drawMode, int count, IndexType indexType) override {
         auto *pipeline = activeMetalPipeline();
         const auto &layout = activeMetalVertexLayout();
@@ -339,8 +393,65 @@ setMetalDepthTestEnabled(enabled);
     void setDepthWrite(bool enabled) override {
 setMetalDepthWriteEnabled(enabled);
     }
-    void clearTexImage(std::uint32_t, int, const void *) override {}
-    void finish() override {}
+    void clearTexImage(const Texture2D *textureWrapper, int level, const void *data) override {
+        if (textureWrapper == nullptr) {
+            return;
+        }
+        auto *texture = static_cast<MTL::Texture *>(textureWrapper->getNativeTexture());
+        if (texture == nullptr) {
+            return;
+        }
+        const NS::UInteger width = texture->width();
+        const NS::UInteger height = texture->height();
+        if (width == 0 || height == 0) {
+            return;
+        }
+        // Pixel size derived from format. For the formats we currently
+        // create through the engine (RGBA8, R32I, RG32UI, RGBA32F) the
+        // bytes-per-pixel is uniquely determined.
+        std::size_t bytesPerPixel = 4;
+        const auto pixelFormat = texture->pixelFormat();
+        if (pixelFormat == MTL::PixelFormatRG32Uint) {
+            bytesPerPixel = 8;
+        } else if (pixelFormat == MTL::PixelFormatRGBA32Float) {
+            bytesPerPixel = 16;
+        }
+
+        std::vector<std::uint8_t> clearData(
+            static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * bytesPerPixel
+        );
+        if (data != nullptr) {
+            for (std::size_t i = 0; i < clearData.size(); i += bytesPerPixel) {
+                std::memcpy(clearData.data() + i, data, bytesPerPixel);
+            }
+        } else {
+            std::memset(clearData.data(), 0, clearData.size());
+        }
+        texture->replaceRegion(
+            MTL::Region::Make2D(0, 0, width, height),
+            static_cast<NS::UInteger>(level),
+            clearData.data(),
+            static_cast<NS::UInteger>(width * bytesPerPixel)
+        );
+
+        // Mirror the clear into the image atomic scratch buffer so atomic
+        // image-min sees the same starting state as the texture itself.
+        if (pixelFormat == MTL::PixelFormatR32Sint) {
+            if (MTL::Buffer *scratch = lookupImageAtomicScratchBuffer(texture);
+                scratch != nullptr) {
+                std::memcpy(scratch->contents(), clearData.data(), clearData.size());
+            }
+        }
+    }
+
+    void finish() override {
+        // The Metal render impl already commits-and-waits each frame at
+        // present(), so finish() is only used by GPU stage timing. Spinning
+        // up a no-op command buffer here would force a flush, but stage
+        // timing is OFF by default and the per-command-buffer cost is
+        // dominated by the present-time wait. Leaving as a no-op until we
+        // need precise per-stage timings on Metal.
+    }
 };
 
 MetalRenderDevice g_metalRenderDevice;

--- a/engine/render/src/metal/metal_runtime.cpp
+++ b/engine/render/src/metal/metal_runtime.cpp
@@ -1,7 +1,9 @@
 #include <irreden/render/metal/metal_runtime.hpp>
 #include <irreden/ir_profile.hpp>
 
+#include <cstring>
 #include <unordered_map>
+#include <vector>
 
 namespace IRRender {
 
@@ -37,8 +39,13 @@ struct MetalRuntimeState {
     MTL::PixelFormat colorPixelFormat_ = MTL::PixelFormatBGRA8Unorm;
     MTL::PixelFormat depthPixelFormat_ = MTL::PixelFormatInvalid;
 
-    std::unordered_map<std::uint32_t, MTL::Buffer *> buffersByHandle_;
-    std::uint32_t nextBufferHandle_ = 1;
+    std::unordered_map<MTL::Texture *, MTL::Buffer *> imageAtomicScratchBuffers_;
+    MTL::Buffer *currentImageAtomicScratch_ = nullptr;
+
+    // MTL::Buffers orphaned by subData() that may still be referenced by
+    // an in-flight command encoder.  Released after the next
+    // present/waitUntilCompleted boundary.
+    std::vector<MTL::Buffer *> pendingReleaseBuffers_;
 };
 
 // Intentionally leaked so the runtime state outlives all other statics.
@@ -123,6 +130,7 @@ void shutdownMetalRuntime() {
         g_runtime().depthTestWriteState_->release();
         g_runtime().depthTestWriteState_ = nullptr;
     }
+    releaseDeferredMetalBuffers();
     g_runtime() = MetalRuntimeState{};
 }
 
@@ -292,19 +300,99 @@ MTL::PixelFormat metalCurrentDepthPixelFormat() {
     return g_runtime().depthPixelFormat_;
 }
 
-std::uint32_t registerMetalBufferHandle(MTL::Buffer *buffer) {
-    const std::uint32_t handle = g_runtime().nextBufferHandle_++;
-    g_runtime().buffersByHandle_[handle] = buffer;
-    return handle;
+void deferReleaseMetalBuffer(MTL::Buffer *buffer) {
+    if (buffer == nullptr) {
+        return;
+    }
+    g_runtime().pendingReleaseBuffers_.push_back(buffer);
 }
 
-void unregisterMetalBufferHandle(std::uint32_t handle) {
-    g_runtime().buffersByHandle_.erase(handle);
+void releaseDeferredMetalBuffers() {
+    auto &pending = g_runtime().pendingReleaseBuffers_;
+    for (MTL::Buffer *buffer : pending) {
+        if (buffer != nullptr) {
+            buffer->release();
+        }
+    }
+    pending.clear();
 }
 
-MTL::Buffer *lookupMetalBufferHandle(std::uint32_t handle) {
-    const auto it = g_runtime().buffersByHandle_.find(handle);
-    return it != g_runtime().buffersByHandle_.end() ? it->second : nullptr;
+void replaceMetalBufferInBindings(MTL::Buffer *oldBuffer, MTL::Buffer *newBuffer) {
+    if (oldBuffer == nullptr || oldBuffer == newBuffer) {
+        return;
+    }
+    for (auto &binding : g_runtime().uniformBuffers_) {
+        if (binding.buffer_ == oldBuffer) {
+            binding.buffer_ = newBuffer;
+        }
+    }
+    for (auto &binding : g_runtime().shaderStorageBuffers_) {
+        if (binding.buffer_ == oldBuffer) {
+            binding.buffer_ = newBuffer;
+        }
+    }
+    auto &vertexLayout = g_runtime().activeVertexLayout_;
+    if (vertexLayout.vertexBuffer_ == oldBuffer) {
+        vertexLayout.vertexBuffer_ = newBuffer;
+    }
+    if (vertexLayout.indexBuffer_ == oldBuffer) {
+        vertexLayout.indexBuffer_ = newBuffer;
+    }
+}
+
+MTL::Buffer *ensureImageAtomicScratchBuffer(MTL::Texture *texture) {
+    if (texture == nullptr) {
+        return nullptr;
+    }
+    auto &cache = g_runtime().imageAtomicScratchBuffers_;
+    const auto it = cache.find(texture);
+    if (it != cache.end()) {
+        return it->second;
+    }
+    const std::size_t bytes =
+        static_cast<std::size_t>(texture->width()) *
+        static_cast<std::size_t>(texture->height()) *
+        sizeof(std::int32_t);
+    auto *buffer = g_runtime().device_->newBuffer(
+        static_cast<NS::UInteger>(bytes),
+        MTL::ResourceStorageModeShared
+    );
+    IR_ASSERT(buffer != nullptr, "Failed to create Metal image atomic scratch buffer");
+    std::memset(buffer->contents(), 0, bytes);
+    cache[texture] = buffer;
+    return buffer;
+}
+
+MTL::Buffer *lookupImageAtomicScratchBuffer(MTL::Texture *texture) {
+    if (texture == nullptr) {
+        return nullptr;
+    }
+    auto &cache = g_runtime().imageAtomicScratchBuffers_;
+    const auto it = cache.find(texture);
+    return it != cache.end() ? it->second : nullptr;
+}
+
+void releaseImageAtomicScratchBuffer(MTL::Texture *texture) {
+    if (texture == nullptr) {
+        return;
+    }
+    auto &cache = g_runtime().imageAtomicScratchBuffers_;
+    const auto it = cache.find(texture);
+    if (it == cache.end()) {
+        return;
+    }
+    if (it->second != nullptr) {
+        it->second->release();
+    }
+    cache.erase(it);
+}
+
+void setCurrentImageAtomicScratch(MTL::Buffer *buffer) {
+    g_runtime().currentImageAtomicScratch_ = buffer;
+}
+
+MTL::Buffer *currentImageAtomicScratch() {
+    return g_runtime().currentImageAtomicScratch_;
 }
 
 } // namespace IRRender

--- a/engine/render/src/metal/metal_texture.cpp
+++ b/engine/render/src/metal/metal_texture.cpp
@@ -53,11 +53,6 @@ std::size_t pixelSizeBytes(PixelDataFormat format, PixelDataType type) {
     return typeSize * components;
 }
 
-std::uint32_t nextMetalTextureHandle() {
-    static std::uint32_t s_nextHandle = 1;
-    return s_nextHandle++;
-}
-
 MTL::TextureUsage defaultTextureUsage(TextureFormat format) {
     if (format == TextureFormat::DEPTH24_STENCIL8) {
         return MTL::TextureUsageRenderTarget;
@@ -79,8 +74,7 @@ class MetalTexture2DImpl final : public Texture2DImpl {
   public:
     MetalTexture2DImpl(unsigned int width, unsigned int height, TextureFormat format)
         : m_size(width, height)
-        , m_pixelFormat(toMetalTextureFormat(format))
-        , m_handle(nextMetalTextureHandle()) {
+        , m_pixelFormat(toMetalTextureFormat(format)) {
         auto *descriptor = MTL::TextureDescriptor::alloc()->init();
         descriptor->setTextureType(MTL::TextureType2D);
         descriptor->setWidth(width);
@@ -99,6 +93,7 @@ class MetalTexture2DImpl final : public Texture2DImpl {
     }
 
     ~MetalTexture2DImpl() override {
+        releaseImageAtomicScratchBuffer(m_texture);
         if (m_texture != nullptr) {
             m_texture->release();
             m_texture = nullptr;
@@ -110,7 +105,7 @@ class MetalTexture2DImpl final : public Texture2DImpl {
     }
 
     std::uint32_t getHandle() const override {
-        return m_handle;
+        return 0;
     }
 
     void *getNativeTexture() const override {
@@ -134,6 +129,11 @@ class MetalTexture2DImpl final : public Texture2DImpl {
         int
     ) const override {
         bindMetalImageTexture(unit, m_texture);
+        // R32I distance images participate in atomic image-min operations
+        // through a sibling scratch buffer; see metal_runtime.hpp.
+        if (m_pixelFormat == MTL::PixelFormatR32Sint) {
+            setCurrentImageAtomicScratch(ensureImageAtomicScratchBuffer(m_texture));
+        }
     }
 
     void uploadSubImage2D(
@@ -207,7 +207,6 @@ class MetalTexture2DImpl final : public Texture2DImpl {
     uvec2 m_size;
     MTL::Texture *m_texture = nullptr;
     MTL::PixelFormat m_pixelFormat = MTL::PixelFormatInvalid;
-    std::uint32_t m_handle = 0;
 };
 
 class MetalTexture3DImpl final : public Texture3DImpl {
@@ -217,8 +216,7 @@ class MetalTexture3DImpl final : public Texture3DImpl {
         unsigned int height,
         unsigned int depth,
         TextureFormat format
-    )
-        : m_handle(nextMetalTextureHandle()) {
+    ) {
         auto *descriptor = MTL::TextureDescriptor::alloc()->init();
         descriptor->setTextureType(MTL::TextureType3D);
         descriptor->setWidth(width);
@@ -241,14 +239,14 @@ class MetalTexture3DImpl final : public Texture3DImpl {
     }
 
     std::uint32_t getHandle() const override {
-        return m_handle;
+        return 0;
     }
 
-    void *getNativeTexture() const {
+    void *getNativeTexture() const override {
         return m_texture;
     }
 
-    std::uint32_t getNativePixelFormat() const {
+    std::uint32_t getNativePixelFormat() const override {
         return static_cast<std::uint32_t>(m_texture->pixelFormat());
     }
 
@@ -280,7 +278,6 @@ class MetalTexture3DImpl final : public Texture3DImpl {
 
   private:
     MTL::Texture *m_texture = nullptr;
-    std::uint32_t m_handle = 0;
 };
 
 std::unique_ptr<Texture2DImpl> createTexture2DImpl(

--- a/engine/render/src/opengl/opengl_buffer.cpp
+++ b/engine/render/src/opengl/opengl_buffer.cpp
@@ -34,6 +34,10 @@ class OpenGLBufferImpl final : public BufferImpl {
         return m_handle;
     }
 
+    void *getNativeBuffer() const override {
+        return nullptr;
+    }
+
     void subData(std::ptrdiff_t offset, std::size_t size, const void *data) const override {
         ENG_API->glNamedBufferSubData(
             m_handle, static_cast<GLintptr>(offset), static_cast<GLsizeiptr>(size), data

--- a/engine/render/src/opengl/opengl_render_impl.cpp
+++ b/engine/render/src/opengl/opengl_render_impl.cpp
@@ -1,7 +1,9 @@
 #include <irreden/render/opengl/opengl_render_impl.hpp>
 #include <irreden/ir_render.hpp>
+#include <irreden/render/buffer.hpp>
 #include <irreden/render/ir_gl_api.hpp>
 #include <irreden/render/render_device.hpp>
+#include <irreden/render/texture.hpp>
 #include <irreden/render/opengl/opengl_types.hpp>
 
 #include <cstdint>
@@ -23,8 +25,11 @@ class OpenGLRenderDevice final : public RenderDevice {
         glDispatchCompute(x, y, z);
     }
 
-    void dispatchComputeIndirect(std::uint32_t bufferHandle, std::ptrdiff_t offset) override {
-        glBindBuffer(GL_DISPATCH_INDIRECT_BUFFER, bufferHandle);
+    void dispatchComputeIndirect(const Buffer *indirectBuffer, std::ptrdiff_t offset) override {
+        if (indirectBuffer == nullptr) {
+            return;
+        }
+        glBindBuffer(GL_DISPATCH_INDIRECT_BUFFER, indirectBuffer->getHandle());
         glDispatchComputeIndirect(static_cast<GLintptr>(offset));
         glBindBuffer(GL_DISPATCH_INDIRECT_BUFFER, 0);
     }
@@ -119,8 +124,11 @@ class OpenGLRenderDevice final : public RenderDevice {
         ENG_API->glDepthMask(enabled ? GL_TRUE : GL_FALSE);
     }
 
-    void clearTexImage(std::uint32_t textureHandle, int level, const void *data) override {
-        glClearTexImage(textureHandle, level, GL_RED_INTEGER, GL_INT, data);
+    void clearTexImage(const Texture2D *texture, int level, const void *data) override {
+        if (texture == nullptr) {
+            return;
+        }
+        glClearTexImage(texture->getHandle(), level, GL_RED_INTEGER, GL_INT, data);
     }
 
     void finish() override {

--- a/engine/render/src/opengl/opengl_vertex_layout.cpp
+++ b/engine/render/src/opengl/opengl_vertex_layout.cpp
@@ -1,5 +1,6 @@
 #include <irreden/ir_profile.hpp>
 
+#include <irreden/render/buffer.hpp>
 #include <irreden/render/ir_gl_api.hpp>
 #include <irreden/render/opengl/opengl_types.hpp>
 #include <irreden/render/vao.hpp>
@@ -9,14 +10,15 @@ namespace IRRender {
 class OpenGLVertexLayoutImpl final : public VertexLayoutImpl {
   public:
     OpenGLVertexLayoutImpl(
-        std::uint32_t vertexBufferHandle,
-        std::uint32_t indexBufferHandle,
+        const Buffer *vertexBuffer,
+        const Buffer *indexBuffer,
         unsigned int numAttributes,
         const VertexArrayAttribute *attributes
     ) {
         ENG_API->glCreateVertexArrays(1, &m_handle);
         GLuint bindingIndex = 0;
         IR_ASSERT(numAttributes <= kMaxVertexAttributes, "Too many vertex attributes for VAO");
+        IR_ASSERT(vertexBuffer != nullptr, "OpenGLVertexLayoutImpl requires a vertex buffer");
 
         std::size_t stride = 0;
         std::size_t attributeSizes[kMaxVertexAttributes] = {};
@@ -27,11 +29,11 @@ class OpenGLVertexLayoutImpl final : public VertexLayoutImpl {
             stride += attributeSizes[i];
         }
 
-        if (indexBufferHandle != 0) {
-            ENG_API->glVertexArrayElementBuffer(m_handle, indexBufferHandle);
+        if (indexBuffer != nullptr) {
+            ENG_API->glVertexArrayElementBuffer(m_handle, indexBuffer->getHandle());
         }
         ENG_API->glVertexArrayVertexBuffer(
-            m_handle, bindingIndex, vertexBufferHandle, 0, static_cast<GLsizei>(stride)
+            m_handle, bindingIndex, vertexBuffer->getHandle(), 0, static_cast<GLsizei>(stride)
         );
 
         GLuint offset = 0;
@@ -63,13 +65,13 @@ class OpenGLVertexLayoutImpl final : public VertexLayoutImpl {
 };
 
 std::unique_ptr<VertexLayoutImpl> createVertexLayoutImpl(
-    std::uint32_t vertexBufferHandle,
-    std::uint32_t indexBufferHandle,
+    const Buffer *vertexBuffer,
+    const Buffer *indexBuffer,
     unsigned int numAttributes,
     const VertexArrayAttribute *attributes
 ) {
     return std::make_unique<OpenGLVertexLayoutImpl>(
-        vertexBufferHandle, indexBufferHandle, numAttributes, attributes
+        vertexBuffer, indexBuffer, numAttributes, attributes
     );
 }
 

--- a/engine/render/src/render_manager.cpp
+++ b/engine/render/src/render_manager.cpp
@@ -360,8 +360,8 @@ void RenderManager::initRenderingResources() {
                               .second;
     IRRender::createNamedResource<VAO>(
         "QuadVAO",
-        vertexBuffer->getHandle(),
-        indexBuffer->getHandle(),
+        vertexBuffer,
+        indexBuffer,
         1,
         &kAttrFloat2
     );
@@ -374,8 +374,8 @@ void RenderManager::initRenderingResources() {
                                        .second;
     IRRender::createNamedResource<VAO>(
         "QuadVAOArrays",
-        vertexBufferTextured->getHandle(),
-        0,
+        vertexBufferTextured,
+        static_cast<const Buffer *>(nullptr),
         2,
         kAttrList2Float2
     );

--- a/engine/render/src/shaders/metal/c_shapes_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_shapes_to_trixel.metal
@@ -1,0 +1,701 @@
+#include "ir_iso_common.metal"
+#include "ir_constants.metal"
+
+// Iso-projected SDF surface finding for analytical shapes.  Mirrors
+// shaders/c_shapes_to_trixel.glsl.  Each workgroup handles one 8x8
+// iso-pixel tile of one shape; pass 0 writes atomic-min depth taps into
+// the scratch buffer (`distanceScratch`) and pass 1 reads back the
+// resolved depth and stamps color + entity id into the trixel canvas.
+//
+// Workgroup dimensions: (8, 8, 1).
+
+struct ShapesFrameData {
+    float2 frameCanvasOffset;
+    int2 trixelCanvasOffsetZ1;
+    int2 canvasSize;
+    int shapeCount;
+    int passIndex;
+    int2 voxelRenderOptions;
+    int2 cullIsoMin;
+    int2 cullIsoMax;
+};
+
+struct ShapeDescriptor {
+    float4 worldPosition;
+    float4 params;
+    uint shapeType;
+    uint color;
+    uint entityId;
+    uint jointIndex;
+    uint flags;
+    uint lodLevel;
+    uint pad0;
+    uint pad1;
+};
+
+struct ShapeTileDescriptor {
+    int shapeIndex;
+    int pad0;
+    int2 tileIsoOrigin;
+};
+
+constant uint SHAPE_BOX          = 0u;
+constant uint SHAPE_SPHERE       = 1u;
+constant uint SHAPE_CYLINDER     = 2u;
+constant uint SHAPE_ELLIPSOID    = 3u;
+constant uint SHAPE_CURVED_PANEL = 4u;
+constant uint SHAPE_WEDGE        = 5u;
+constant uint SHAPE_TAPERED_BOX  = 6u;
+constant uint SHAPE_CONE         = 8u;
+constant uint SHAPE_TORUS        = 9u;
+
+constant uint FLAG_HOLLOW       = 1u;
+constant uint FLAG_VISIBLE      = 8u;
+constant uint FLAG_CHECKERBOARD = 32u;
+constant uint FLAG_DEPTH_COLOR  = 64u;
+
+// ---------- Color helpers ----------
+
+inline float3 hsvToRgb(float3 c) {
+    const float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    const float3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+// ---------- Generic SDF evaluators (fallback path) ----------
+
+inline float sdfBox(float3 p, float3 halfExtents) {
+    const float3 d = abs(p) - halfExtents;
+    return max(d.x, max(d.y, d.z));
+}
+
+inline float sdfSphere(float3 p, float radius) {
+    return length(p) - radius;
+}
+
+inline float sdfCylinder(float3 p, float radius, float halfHeight) {
+    const float2 d = abs(float2(length(p.xy), p.z)) - float2(radius, halfHeight);
+    return min(max(d.x, d.y), 0.0) + length(max(d, float2(0.0)));
+}
+
+inline float sdfEllipsoid(float3 p, float3 radii) {
+    if (radii.x <= 0.0 || radii.y <= 0.0 || radii.z <= 0.0) {
+        return 1.0;
+    }
+    const float k0 = length(p / radii);
+    if (k0 < 1e-6) {
+        return -min(radii.x, min(radii.y, radii.z));
+    }
+    const float k1 = length(p / (radii * radii));
+    return k0 * (k0 - 1.0) / k1;
+}
+
+inline float sdfTaperedBox(float3 p, float3 halfExtents, float taper) {
+    const float taperFactor =
+        mix(1.0, taper,
+            clamp((p.z + halfExtents.z) / (2.0 * halfExtents.z), 0.0, 1.0));
+    const float3 scaled =
+        float3(p.xy / max(taperFactor, 0.001), p.z);
+    return sdfBox(scaled, halfExtents);
+}
+
+inline float sdfCone(float3 p, float baseRadius, float halfHeight) {
+    const float t =
+        clamp((p.z + halfHeight) / (2.0 * halfHeight), 0.0, 1.0);
+    const float radiusAtZ = baseRadius * (1.0 - t);
+    const float dRadial = length(p.xy) - radiusAtZ;
+    const float dZ = abs(p.z) - halfHeight;
+    const float dOutside =
+        length(max(float2(dRadial, dZ), float2(0.0)));
+    const float dInside = min(max(dRadial, dZ), 0.0);
+    return dOutside + dInside;
+}
+
+inline float sdfTorus(float3 p, float majorR, float minorR) {
+    const float q = length(p.xy) - majorR;
+    return length(float2(q, p.z)) - minorR;
+}
+
+inline float sdfWedge(float3 p, float3 halfExtents) {
+    const float boxD = sdfBox(p, halfExtents);
+    const float planeD =
+        p.z - halfExtents.z * (1.0 - p.x / max(halfExtents.x, 0.001));
+    return max(boxD, planeD);
+}
+
+inline float sdfCurvedPanel(float3 p, float3 halfExtents, float curvature) {
+    const float nx = p.x / max(halfExtents.x, 0.001);
+    const float ny = p.y / max(halfExtents.y, 0.001);
+    const float zMid = curvature * halfExtents.x * nx * nx;
+    const float dThickness = abs(p.z - zMid) - halfExtents.z;
+    const float dX = abs(p.x) - halfExtents.x;
+    const float dY = abs(p.y) - halfExtents.y;
+    const float dOutside =
+        length(max(float3(dX, dY, dThickness), float3(0.0)));
+    const float dInside = min(max(dX, max(dY, dThickness)), 0.0);
+    return dOutside + dInside;
+}
+
+inline float evaluateSDF(float3 localPos, uint shapeType, float4 params) {
+    const float3 halfSize = params.xyz * 0.5;
+    switch (shapeType) {
+        case SHAPE_BOX:          return sdfBox(localPos, halfSize);
+        case SHAPE_SPHERE:       return sdfSphere(localPos, params.x);
+        case SHAPE_CYLINDER:     return sdfCylinder(localPos, params.x, halfSize.z);
+        case SHAPE_ELLIPSOID:    return sdfEllipsoid(localPos, halfSize);
+        case SHAPE_TAPERED_BOX:  return sdfTaperedBox(localPos, halfSize, params.w);
+        case SHAPE_CONE:         return sdfCone(localPos, params.x, halfSize.z);
+        case SHAPE_TORUS:        return sdfTorus(localPos, params.x, params.y);
+        case SHAPE_WEDGE:        return sdfWedge(localPos, halfSize);
+        case SHAPE_CURVED_PANEL: return sdfCurvedPanel(localPos, halfSize, params.w);
+        default:                 return sdfBox(localPos, halfSize);
+    }
+}
+
+// ---------- O(1) analytical depth-axis intersections ----------
+
+inline bool boxSlabIntersect(
+    float isoX,
+    float isoY,
+    float3 hExt,
+    thread float& dEntry,
+    thread float& dExit
+) {
+    const float dxLo = (-6.0 * hExt.x + 3.0 * isoX + isoY) * 0.5;
+    const float dxHi = ( 6.0 * hExt.x + 3.0 * isoX + isoY) * 0.5;
+    const float dyLo = (-6.0 * hExt.y - 3.0 * isoX + isoY) * 0.5;
+    const float dyHi = ( 6.0 * hExt.y - 3.0 * isoX + isoY) * 0.5;
+    const float dzLo = -3.0 * hExt.z - isoY;
+    const float dzHi =  3.0 * hExt.z - isoY;
+
+    dEntry = max(dxLo, max(dyLo, dzLo));
+    dExit  = min(dxHi, min(dyHi, dzHi));
+    return dEntry <= dExit;
+}
+
+inline void zSlabInterval(
+    float isoY,
+    float hZ,
+    thread float& dLo,
+    thread float& dHi
+) {
+    dLo = -3.0 * hZ - isoY;
+    dHi =  3.0 * hZ - isoY;
+}
+
+inline bool circleDepthInterval(
+    float isoX,
+    float isoY,
+    float R,
+    thread float& dLo,
+    thread float& dHi
+) {
+    const float disc = 18.0 * R * R - 9.0 * isoX * isoX;
+    if (disc < 0.0) {
+        return false;
+    }
+    const float halfRange = sqrt(disc);
+    dLo = (isoY - halfRange) * 0.5;
+    dHi = (isoY + halfRange) * 0.5;
+    return true;
+}
+
+inline int boxDepthIntersect(int2 isoRel, float3 halfExtents, bool hollow) {
+    const float isoX = float(isoRel.x);
+    const float isoY = float(isoRel.y);
+
+    float dEntry, dExit;
+    if (!boxSlabIntersect(isoX, isoY, halfExtents + float3(0.5), dEntry, dExit)) {
+        return kInvalidDepth;
+    }
+
+    if (!hollow) {
+        int candidate = int(ceil(dEntry));
+        if (float(candidate) > dExit) {
+            return kInvalidDepth;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        if (sdfBox(p, halfExtents) <= 0.5) {
+            return candidate;
+        }
+        if (float(candidate + 1) <= dExit) {
+            return candidate + 1;
+        }
+        return kInvalidDepth;
+    }
+
+    const float3 hInt = halfExtents - float3(0.5);
+    float dIntEntry = 1.0;
+    float dIntExit = 0.0;
+    if (hInt.x > 0.0 && hInt.y > 0.0 && hInt.z > 0.0) {
+        boxSlabIntersect(isoX, isoY, hInt, dIntEntry, dIntExit);
+    }
+
+    int candidate = int(ceil(dEntry));
+    if (float(candidate) > dExit) {
+        return kInvalidDepth;
+    }
+    if (dIntEntry > dIntExit || float(candidate) <= dIntEntry) {
+        return candidate;
+    }
+    candidate = int(ceil(dIntExit));
+    if (float(candidate) <= dExit) {
+        return candidate;
+    }
+    return kInvalidDepth;
+}
+
+inline int sphereDepthIntersect(int2 isoRel, float radius, bool hollow) {
+    const float R = radius + 0.5;
+    const float3 p0 = isoToLocal3D(isoRel, 0.0);
+    const float tClosest = -(p0.x + p0.y + p0.z);
+    const float3 pClosest = isoToLocal3D(isoRel, tClosest);
+    const float perpDistSq = dot(pClosest, pClosest);
+
+    if (perpDistSq > R * R) {
+        return kInvalidDepth;
+    }
+
+    const float halfChord = sqrt(3.0 * (R * R - perpDistSq));
+    const float tEntry = tClosest - halfChord;
+    const float tExit  = tClosest + halfChord;
+
+    if (!hollow) {
+        int candidate = int(ceil(tEntry));
+        if (float(candidate) > tExit) {
+            return kInvalidDepth;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        if (sdfSphere(p, radius) <= 0.5) {
+            return candidate;
+        }
+        if (float(candidate + 1) <= tExit) {
+            return candidate + 1;
+        }
+        return kInvalidDepth;
+    }
+
+    const float Rint = radius - 0.5;
+    float tIntEntry = tExit + 1.0;
+    float tIntExit = tEntry - 1.0;
+    if (Rint > 0.0 && perpDistSq <= Rint * Rint) {
+        const float intHalfChord = sqrt(3.0 * (Rint * Rint - perpDistSq));
+        tIntEntry = tClosest - intHalfChord;
+        tIntExit  = tClosest + intHalfChord;
+    }
+
+    for (int i = 0; i < 2; ++i) {
+        const int candidate = int(ceil(tEntry)) + i;
+        if (float(candidate) > min(tIntEntry, tExit)) {
+            break;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        const float sdf = sdfSphere(p, radius);
+        if (sdf <= 0.5 && sdf >= -0.5) {
+            return candidate;
+        }
+    }
+    for (int i = 0; i < 2; ++i) {
+        const int candidate = int(ceil(tIntExit)) + i;
+        if (float(candidate) > tExit) {
+            break;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        const float sdf = sdfSphere(p, radius);
+        if (sdf <= 0.5 && sdf >= -0.5) {
+            return candidate;
+        }
+    }
+    return kInvalidDepth;
+}
+
+inline int cylinderDepthIntersect(
+    int2 isoRel,
+    float radius,
+    float halfHeight,
+    bool hollow
+) {
+    const float isoX = float(isoRel.x);
+    const float isoY = float(isoRel.y);
+
+    float dCircLo, dCircHi;
+    if (!circleDepthInterval(isoX, isoY, radius + 0.5, dCircLo, dCircHi)) {
+        return kInvalidDepth;
+    }
+    float dZLo, dZHi;
+    zSlabInterval(isoY, halfHeight + 0.5, dZLo, dZHi);
+
+    const float dEntry = max(dCircLo, dZLo);
+    const float dExit  = min(dCircHi, dZHi);
+    if (dEntry > dExit) {
+        return kInvalidDepth;
+    }
+
+    if (!hollow) {
+        int candidate = int(ceil(dEntry));
+        if (float(candidate) > dExit) {
+            return kInvalidDepth;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        if (sdfCylinder(p, radius, halfHeight) <= 0.5) {
+            return candidate;
+        }
+        if (float(candidate + 1) <= dExit) {
+            return candidate + 1;
+        }
+        return kInvalidDepth;
+    }
+
+    const float Rint = radius - 0.5;
+    const float Hint = halfHeight - 0.5;
+    float dIntEntry = dExit + 1.0;
+    float dIntExit = dEntry - 1.0;
+    if (Rint > 0.0 && Hint > 0.0) {
+        float diCircLo, diCircHi;
+        if (circleDepthInterval(isoX, isoY, Rint, diCircLo, diCircHi)) {
+            float diZLo, diZHi;
+            zSlabInterval(isoY, Hint, diZLo, diZHi);
+            dIntEntry = max(diCircLo, diZLo);
+            dIntExit  = min(diCircHi, diZHi);
+        }
+    }
+
+    for (int i = 0; i < 2; ++i) {
+        const int candidate = int(ceil(dEntry)) + i;
+        if (float(candidate) > min(dIntEntry, dExit)) {
+            break;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        const float sdf = sdfCylinder(p, radius, halfHeight);
+        if (sdf <= 0.5 && sdf >= -0.5) {
+            return candidate;
+        }
+    }
+    for (int i = 0; i < 2; ++i) {
+        const int candidate = int(ceil(dIntExit)) + i;
+        if (float(candidate) > dExit) {
+            break;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        const float sdf = sdfCylinder(p, radius, halfHeight);
+        if (sdf <= 0.5 && sdf >= -0.5) {
+            return candidate;
+        }
+    }
+    return kInvalidDepth;
+}
+
+inline int ellipsoidDepthIntersect(int2 isoRel, float3 radii, bool hollow) {
+    const float isoX = float(isoRel.x);
+    const float isoY = float(isoRel.y);
+
+    const float3 R = radii + float3(0.5);
+    const float ax = 1.0 / (3.0 * R.x);
+    const float bx = (-3.0 * isoX - isoY) / (6.0 * R.x);
+    const float ay = 1.0 / (3.0 * R.y);
+    const float by = (3.0 * isoX - isoY) / (6.0 * R.y);
+    const float az = 1.0 / (3.0 * R.z);
+    const float bz = isoY / (3.0 * R.z);
+
+    const float A = ax * ax + ay * ay + az * az;
+    const float B = 2.0 * (ax * bx + ay * by + az * bz);
+    const float C = bx * bx + by * by + bz * bz - 1.0;
+
+    const float disc = B * B - 4.0 * A * C;
+    if (disc < 0.0) {
+        return kInvalidDepth;
+    }
+
+    const float sqrtDisc = sqrt(disc);
+    const float inv2A = 0.5 / A;
+    const float dEntry = (-B - sqrtDisc) * inv2A;
+    const float dExit  = (-B + sqrtDisc) * inv2A;
+
+    if (!hollow) {
+        for (int i = 0; i < 3; ++i) {
+            const int candidate = int(ceil(dEntry)) + i;
+            if (float(candidate) > dExit) {
+                return kInvalidDepth;
+            }
+            const float3 p = isoToLocal3D(isoRel, float(candidate));
+            if (sdfEllipsoid(p, radii) <= 0.5) {
+                return candidate;
+            }
+        }
+        return kInvalidDepth;
+    }
+
+    const float3 Rint = radii - float3(0.5);
+    float dIntEntry = dExit + 1.0;
+    float dIntExit = dEntry - 1.0;
+    if (Rint.x > 0.0 && Rint.y > 0.0 && Rint.z > 0.0) {
+        const float iax = 1.0 / (3.0 * Rint.x);
+        const float ibx = (-3.0 * isoX - isoY) / (6.0 * Rint.x);
+        const float iay = 1.0 / (3.0 * Rint.y);
+        const float iby = (3.0 * isoX - isoY) / (6.0 * Rint.y);
+        const float iaz = 1.0 / (3.0 * Rint.z);
+        const float ibz = isoY / (3.0 * Rint.z);
+
+        const float iA = iax * iax + iay * iay + iaz * iaz;
+        const float iB = 2.0 * (iax * ibx + iay * iby + iaz * ibz);
+        const float iC = ibx * ibx + iby * iby + ibz * ibz - 1.0;
+
+        const float iDisc = iB * iB - 4.0 * iA * iC;
+        if (iDisc >= 0.0) {
+            const float iSqrt = sqrt(iDisc);
+            const float iInv2A = 0.5 / iA;
+            dIntEntry = (-iB - iSqrt) * iInv2A;
+            dIntExit  = (-iB + iSqrt) * iInv2A;
+        }
+    }
+
+    for (int i = 0; i < 3; ++i) {
+        const int candidate = int(ceil(dEntry)) + i;
+        if (float(candidate) > min(dIntEntry, dExit)) {
+            break;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        const float sdf = sdfEllipsoid(p, radii);
+        if (sdf <= 0.5 && sdf >= -0.5) {
+            return candidate;
+        }
+    }
+    for (int i = 0; i < 3; ++i) {
+        const int candidate = int(ceil(dIntExit)) + i;
+        if (float(candidate) > dExit) {
+            break;
+        }
+        const float3 p = isoToLocal3D(isoRel, float(candidate));
+        const float sdf = sdfEllipsoid(p, radii);
+        if (sdf <= 0.5 && sdf >= -0.5) {
+            return candidate;
+        }
+    }
+    return kInvalidDepth;
+}
+
+inline int generalDepthSearch(
+    int2 isoRel,
+    uint shapeType,
+    float4 params,
+    bool hollow,
+    float dExtent
+) {
+    const float dMin = floor(-dExtent);
+    const float dMax = ceil(dExtent);
+    for (float d = dMin; d <= dMax; d += 1.0) {
+        const float3 p = isoToLocal3D(isoRel, d);
+        const float sdf = evaluateSDF(p, shapeType, params);
+        if (sdf <= 0.5 && (!hollow || sdf >= -0.5)) {
+            return int(round(d));
+        }
+    }
+    return kInvalidDepth;
+}
+
+inline int findSurfaceDepth(
+    int2 isoRel,
+    uint shapeType,
+    float4 params,
+    uint flags,
+    float dExtent
+) {
+    const bool hollow = (flags & FLAG_HOLLOW) != 0u;
+    const float3 halfSize = params.xyz * 0.5;
+
+    if (shapeType == SHAPE_BOX) {
+        return boxDepthIntersect(isoRel, halfSize, hollow);
+    }
+    if (shapeType == SHAPE_SPHERE) {
+        return sphereDepthIntersect(isoRel, params.x, hollow);
+    }
+    if (shapeType == SHAPE_CYLINDER) {
+        return cylinderDepthIntersect(isoRel, params.x, halfSize.z, hollow);
+    }
+    if (shapeType == SHAPE_ELLIPSOID) {
+        return ellipsoidDepthIntersect(isoRel, halfSize, hollow);
+    }
+    return generalDepthSearch(isoRel, shapeType, params, hollow, dExtent);
+}
+
+// ---------- Kernel ----------
+
+kernel void c_shapes_to_trixel(
+    constant ShapesFrameData& frameData [[buffer(23)]],
+    device const ShapeDescriptor* shapes [[buffer(20)]],
+    device const ShapeTileDescriptor* tiles [[buffer(30)]],
+    device atomic_int* distanceScratch [[buffer(16)]],
+    texture2d<float, access::write> triangleCanvasColors [[texture(0)]],
+    texture2d<int, access::write> triangleCanvasDistances [[texture(1)]],
+    texture2d<uint, access::write> triangleCanvasEntityIds [[texture(2)]],
+    uint3 groupId [[threadgroup_position_in_grid]],
+    uint3 localId [[thread_position_in_threadgroup]]
+) {
+    const ShapeTileDescriptor tile = tiles[groupId.x];
+    const int shapeIndex = tile.shapeIndex;
+    const int2 isoOrigin = tile.tileIsoOrigin;
+    const ShapeDescriptor shape = shapes[shapeIndex];
+
+    const float3 worldPos = shape.worldPosition.xyz;
+    const int3 origin = int3(round(worldPos));
+
+    const int renderMode = frameData.voxelRenderOptions.x;
+    const int subdivisions = max(frameData.voxelRenderOptions.y, 1);
+    // Smooth mode degenerates to snap when there is nothing to smooth.  At
+    // sub == 1 the analytical path would paint a 2x3 diamond at every iso
+    // pixel (both parities), producing overlapping diamonds that alias into
+    // the voxel-pool tiling.  Route sub==1 through the exact lattice walk
+    // used by snap mode so shapes at minimum zoom match C_VoxelSetNew output
+    // trixel-for-trixel.
+    const bool smoothMode = (renderMode != 0) && (subdivisions > 1);
+    const int sub = smoothMode ? subdivisions : 1;
+
+    const int3 originScaled = origin * sub;
+    const float3 effectiveSize = (shape.shapeType == SHAPE_BOX)
+        ? shape.params.xyz - 1.0
+        : shape.params.xyz;
+    const float4 paramsScaled =
+        float4(effectiveSize * float(sub), shape.params.w);
+
+    float3 boundingHalf;
+    const uint st = shape.shapeType;
+    if (st == SHAPE_SPHERE) {
+        boundingHalf = float3(paramsScaled.x);
+    } else if (st == SHAPE_CYLINDER || st == SHAPE_CONE) {
+        boundingHalf = float3(paramsScaled.x, paramsScaled.x, paramsScaled.z * 0.5);
+    } else if (st == SHAPE_TORUS) {
+        const float xyR = paramsScaled.x + paramsScaled.y;
+        boundingHalf = float3(xyR, xyR, paramsScaled.y);
+    } else if (st == SHAPE_CURVED_PANEL) {
+        float3 hs = paramsScaled.xyz * 0.5;
+        hs.z += abs(paramsScaled.w) * hs.x;
+        boundingHalf = hs;
+    } else {
+        boundingHalf = paramsScaled.xyz * 0.5;
+    }
+    const int3 extentScaled = int3(ceil(boundingHalf)) + int3(1);
+
+    const int2 originIsoScaled = pos3DtoPos2DIso(originScaled);
+    const int2 isoExtentScaled = int2(
+        extentScaled.x + extentScaled.y,
+        extentScaled.x + extentScaled.y + 2 * extentScaled.z
+    );
+
+    const float dExtent = float(extentScaled.x + extentScaled.y + extentScaled.z);
+
+    const int2 pixelCoord = isoOrigin + int2(localId.xy);
+
+    const int2 frameOffset =
+        frameData.trixelCanvasOffsetZ1 +
+        int2(floor(frameData.frameCanvasOffset * float(sub)));
+
+    const int2 baseCanvasPixel = frameOffset + pixelCoord;
+    if (baseCanvasPixel.x < -3 || baseCanvasPixel.x >= frameData.canvasSize.x + 3 ||
+        baseCanvasPixel.y < -3 || baseCanvasPixel.y >= frameData.canvasSize.y + 3) {
+        return;
+    }
+
+    const int2 isoPixelRel = pixelCoord - originIsoScaled;
+
+    if (abs(isoPixelRel.x) > isoExtentScaled.x + 2 ||
+        abs(isoPixelRel.y) > isoExtentScaled.y + 2) {
+        return;
+    }
+
+    int surfaceD;
+
+    if (!smoothMode) {
+        if (((isoPixelRel.x + isoPixelRel.y) & 1) != 0) {
+            return;
+        }
+
+        const int isoY = isoPixelRel.y;
+        const int dMin = int(floor(-dExtent)) - 3;
+        const int dMax = int(ceil(dExtent)) + 3;
+        const int rem = ((dMin + isoY) % 3 + 3) % 3;
+        const int dStart = dMin + ((3 - rem) % 3);
+
+        bool found = false;
+        int validD = 0;
+        for (int d = dStart; d <= dMax; d += 3) {
+            const float3 p = isoToLocal3D(isoPixelRel, float(d));
+            const int3 voxelPos = int3(round(p));
+            if (pos3DtoPos2DIso(voxelPos).x != isoPixelRel.x ||
+                pos3DtoPos2DIso(voxelPos).y != isoPixelRel.y) {
+                continue;
+            }
+            if (evaluateSDF(float3(voxelPos), shape.shapeType, paramsScaled) <= 0.5) {
+                validD = voxelPos.x + voxelPos.y + voxelPos.z;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return;
+        }
+        surfaceD = validD;
+    } else {
+        surfaceD = findSurfaceDepth(
+            isoPixelRel, shape.shapeType, paramsScaled, shape.flags, dExtent
+        );
+        if (surfaceD == kInvalidDepth) {
+            return;
+        }
+    }
+
+    const int originDistance = originScaled.x + originScaled.y + originScaled.z;
+    const int baseDepth = surfaceD + originDistance;
+    float4 baseColor = unpackColor(shape.color);
+
+    if ((shape.flags & FLAG_DEPTH_COLOR) != 0u) {
+        const float dColor = boundingHalf.x + boundingHalf.y + boundingHalf.z;
+        const float denomC = max((4.0 / 3.0) * dColor, 1.0);
+        const float t = clamp((float(surfaceD) + dColor) / denomC, 0.0, 1.0);
+        baseColor.rgb = hsvToRgb(float3(0.66 * t, 1.0, 1.0));
+    } else if ((shape.flags & FLAG_CHECKERBOARD) != 0u) {
+        const int3 voxelCell =
+            int3(round(isoToLocal3D(isoPixelRel, float(surfaceD))));
+        if (((voxelCell.x + voxelCell.y + voxelCell.z) & 1) != 0) {
+            baseColor.rgb *= 0.55;
+        }
+    }
+
+    for (int face = 0; face < 3; ++face) {
+        const int depthEncoded = encodeDepthWithFace(baseDepth, face);
+        const float4 col = adjustColorForFace(baseColor, face);
+
+        for (int subPixel = 0; subPixel < 2; ++subPixel) {
+            const int2 offset = faceOffset_2x3(face, subPixel);
+            const int2 canvasPixel = baseCanvasPixel + offset;
+
+            if (!isInsideCanvas(canvasPixel, frameData.canvasSize)) {
+                continue;
+            }
+
+            const uint linearIndex =
+                uint(canvasPixel.y) * uint(frameData.canvasSize.x) +
+                uint(canvasPixel.x);
+
+            if (frameData.passIndex == 0) {
+                atomic_fetch_min_explicit(
+                    &distanceScratch[linearIndex],
+                    depthEncoded,
+                    memory_order_relaxed
+                );
+            } else {
+                const int stored = atomic_load_explicit(
+                    &distanceScratch[linearIndex],
+                    memory_order_relaxed
+                );
+                if (depthEncoded == stored) {
+                    const uint2 pix = uint2(canvasPixel);
+                    triangleCanvasColors.write(col, pix);
+                    triangleCanvasDistances.write(
+                        int4(depthEncoded, 0, 0, 0), pix);
+                    triangleCanvasEntityIds.write(
+                        uint4(shape.entityId, 0u, 0u, 0u), pix);
+                }
+            }
+        }
+    }
+}

--- a/engine/render/src/shaders/metal/c_text_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_text_to_trixel.metal
@@ -1,44 +1,61 @@
-#include <metal_stdlib>
-using namespace metal;
+#include "ir_iso_common.metal"
 
-float4 unpackColor(uint packedColor) {
-    return float4(
-        float(packedColor & 0xFFu) / 255.0,
-        float((packedColor >> 8) & 0xFFu) / 255.0,
-        float((packedColor >> 16) & 0xFFu) / 255.0,
-        float((packedColor >> 24) & 0xFFu) / 255.0
-    );
-}
+// Per-glyph text rasterization onto the trixel canvas.  Mirrors
+// shaders/c_text_to_trixel.glsl — supports a fontSize multiplier so each
+// glyph cell is rendered as fontSize x fontSize trixel pixels.
+//
+// Workgroup dimensions: (7, 11, 1) — one thread per (col, row) of the 7x11
+// glyph bitmap.
+
+struct GlyphDrawCommand {
+    uint positionPacked;  // x | (y << 16)
+    uint glyphIndex;      // 0-127 ASCII index into the font atlas
+    uint colorPacked;     // RGBA8 packed
+    uint distance;        // depth value to stamp
+    uint styleFlags;      // low byte = fontSize (pixels per glyph trixel)
+};
 
 kernel void c_text_to_trixel(
     device const uint* fontRows [[buffer(11)]],
-    device const uint4* commands [[buffer(12)]],
+    device const GlyphDrawCommand* commands [[buffer(12)]],
     texture2d<float, access::write> canvasColors [[texture(0)]],
     texture2d<int, access::write> canvasDistances [[texture(1)]],
     uint3 groupId [[threadgroup_position_in_grid]],
     uint3 localId [[thread_position_in_threadgroup]]
 ) {
-    uint4 cmd = commands[groupId.x];
-    int2 basePos = int2(int(cmd.x & 0xFFFFu), int(cmd.x >> 16u));
-    uint glyphIdx = cmd.y;
+    const GlyphDrawCommand cmd = commands[groupId.x];
+    const int2 basePos = int2(
+        int(cmd.positionPacked & 0xFFFFu),
+        int(cmd.positionPacked >> 16u)
+    );
+    const uint glyphIdx = cmd.glyphIndex;
+    const uint fontSize = max(cmd.styleFlags & 0xFFu, 1u);
 
-    uint rowBits = fontRows[glyphIdx * 11u + localId.y];
-    uint col = localId.x;
+    const uint rowBits = fontRows[glyphIdx * 11u + localId.y];
+    const uint col = localId.x;
+    const uint row = localId.y;
 
     if (((rowBits >> (6u - col)) & 1u) == 0u) {
         return;
     }
 
-    int2 pixel = basePos + int2(int(col), int(localId.y));
+    const int2 canvasSize = int2(
+        int(canvasColors.get_width()),
+        int(canvasColors.get_height())
+    );
+    const float4 color = unpackColor(cmd.colorPacked);
+    const int2 blockOrigin =
+        basePos +
+        int2(int(col) * int(fontSize), int(row) * int(fontSize));
 
-    if (pixel.x < 0 || pixel.x >= int(canvasColors.get_width())) {
-        return;
+    for (uint dy = 0u; dy < fontSize; ++dy) {
+        for (uint dx = 0u; dx < fontSize; ++dx) {
+            const int2 pixel = blockOrigin + int2(int(dx), int(dy));
+            if (!isInsideCanvas(pixel, canvasSize)) {
+                continue;
+            }
+            canvasColors.write(color, uint2(pixel));
+            canvasDistances.write(int4(int(cmd.distance), 0, 0, 0), uint2(pixel));
+        }
     }
-    if (pixel.y < 0 || pixel.y >= int(canvasColors.get_height())) {
-        return;
-    }
-
-    float4 color = unpackColor(cmd.z);
-    canvasColors.write(color, uint2(pixel));
-    canvasDistances.write(int4(int(cmd.w)), uint2(pixel));
 }

--- a/engine/render/src/shaders/metal/c_trixel_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_trixel_to_trixel.metal
@@ -1,6 +1,62 @@
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void c_trixel_to_trixel(uint3 gid [[thread_position_in_grid]]) {
-    (void)gid;
+// Composites a "from" trixel canvas onto a "to" trixel canvas with per-pixel
+// depth comparison.  Mirrors shaders/c_trixel_to_trixel.glsl — used to fold
+// the static-shape canvas into the dynamic voxel canvas (and similar passes).
+
+struct FrameDataTrixelToTrixel {
+    int2 cameraTrixelOffset;
+    int2 trixelCanvasOffsetZ1;
+    int2 trixelTextureOffsetZ1;
+    float2 texturePos2DIso;
+};
+
+kernel void c_trixel_to_trixel(
+    constant FrameDataTrixelToTrixel& frameData [[buffer(10)]],
+    texture2d<float, access::read_write> trixelColorsTo [[texture(0)]],
+    texture2d<int, access::read_write> trixelDistancesTo [[texture(1)]],
+    texture2d<float, access::read> trixelColorsFrom [[texture(2)]],
+    texture2d<int, access::read> trixelDistancesFrom [[texture(3)]],
+    uint3 globalId [[thread_position_in_grid]]
+) {
+    const int2 srcPixel = int2(globalId.xy);
+    const int2 srcSize = int2(
+        int(trixelColorsFrom.get_width()),
+        int(trixelColorsFrom.get_height())
+    );
+    if (srcPixel.x >= srcSize.x || srcPixel.y >= srcSize.y) {
+        return;
+    }
+
+    const float4 srcColor = trixelColorsFrom.read(uint2(srcPixel));
+    if (srcColor.a == 0.0) {
+        return;
+    }
+
+    const int srcDistance = trixelDistancesFrom.read(uint2(srcPixel)).x;
+    if (srcDistance >= 65535) {
+        return;
+    }
+
+    const int2 srcOrigin = frameData.trixelTextureOffsetZ1;
+    const int2 dstOrigin = frameData.trixelCanvasOffsetZ1 + frameData.cameraTrixelOffset;
+    const int2 isoOffset = int2(floor(frameData.texturePos2DIso));
+    const int2 dstPixel = (srcPixel - srcOrigin) + dstOrigin + isoOffset;
+
+    const int2 dstSize = int2(
+        int(trixelColorsTo.get_width()),
+        int(trixelColorsTo.get_height())
+    );
+    if (dstPixel.x < 0 || dstPixel.x >= dstSize.x ||
+        dstPixel.y < 0 || dstPixel.y >= dstSize.y) {
+        return;
+    }
+
+    const int dstDistance = trixelDistancesTo.read(uint2(dstPixel)).x;
+    if (srcDistance > dstDistance) {
+        return;
+    }
+    trixelColorsTo.write(srcColor, uint2(dstPixel));
+    trixelDistancesTo.write(int4(srcDistance, 0, 0, 0), uint2(dstPixel));
 }

--- a/engine/render/src/shaders/metal/c_update_voxel_positions.metal
+++ b/engine/render/src/shaders/metal/c_update_voxel_positions.metal
@@ -1,0 +1,51 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Per-frame voxel transform pass: each thread maps a global voxel index to
+// its owning entity, looks up the entity world position, and writes the
+// transformed world position into the global position buffer.  Mirrors
+// shaders/c_update_voxel_positions.glsl.
+
+struct EntityTransform {
+    float4 worldPosition;
+    uint poolOffset;
+    uint voxelCount;
+    uint padding0;
+    uint padding1;
+};
+
+struct UpdateParams {
+    int entityCount;
+};
+
+kernel void c_update_voxel_positions(
+    device float4* globalPositions [[buffer(5)]],
+    device const float4* localPositions [[buffer(17)]],
+    device const EntityTransform* transforms [[buffer(18)]],
+    constant UpdateParams& params [[buffer(19)]],
+    uint globalId [[thread_position_in_grid]]
+) {
+    uint entityIdx = 0u;
+    uint voxelOffset = 0u;
+    uint cumulative = 0u;
+    bool found = false;
+    for (uint e = 0u; e < uint(params.entityCount); ++e) {
+        const uint nextCumulative = cumulative + transforms[e].voxelCount;
+        if (globalId < nextCumulative) {
+            entityIdx = e;
+            voxelOffset = globalId - cumulative;
+            found = true;
+            break;
+        }
+        cumulative = nextCumulative;
+    }
+
+    if (!found) {
+        return;
+    }
+
+    const uint poolIdx = transforms[entityIdx].poolOffset + voxelOffset;
+    const float3 localPos = localPositions[poolIdx].xyz;
+    const float3 worldPos = localPos + transforms[entityIdx].worldPosition.xyz;
+    globalPositions[poolIdx] = float4(worldPos, 1.0);
+}

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
@@ -1,139 +1,92 @@
-#include <metal_stdlib>
-using namespace metal;
+#include "ir_iso_common.metal"
+#include "ir_constants.metal"
 
-struct FrameDataVoxelToTrixel {
-    float2 frameCanvasOffset;
-    int2 trixelCanvasOffsetZ1;
-    int2 voxelRenderOptions;
-    int2 voxelDispatchGrid;
-    int voxelCount;
-    int voxelDispatchPadding;
+// Stage 1 of the voxel→trixel pipeline: each surviving voxel writes a depth
+// tap into the canvas distance scratch buffer using atomic-min, so stage 2
+// can do front-face resolution.  Reads compacted visible voxel indices
+// produced by c_voxel_visibility_compact.metal.
+//
+// MSL has no portable image-atomic syntax across all macOS versions, so we
+// use a sibling scratch buffer the same size as the R32I distance texture.
+// See engine/render/include/irreden/render/metal/metal_runtime.hpp.
+
+struct IndirectDispatchParamsRO {
+    uint numGroupsX;
+    uint numGroupsY;
+    uint numGroupsZ;
+    uint visibleCount;
 };
 
-int pos3DtoDistance(int3 position) {
-    return position.x + position.y + position.z;
-}
-
-constant int kXFace = 0;
-constant int kYFace = 1;
-constant int kZFace = 2;
-
-int localIDToFace(uint2 localId) {
-    if (localId.y == 0) {
-        return kZFace;
-    }
-    if (localId.x == 1) {
-        return kXFace;
-    }
-    return kYFace;
-}
-
-int2 pos3DtoPos2DIso(int3 position) {
-    return int2(
-        -position.x + position.y,
-        -position.x - position.y + (2 * position.z)
-    );
-}
-
-float4 unpackColor(uint packedColor) {
-    return float4(
-        float(packedColor & 0xFFu) / 255.0,
-        float((packedColor >> 8) & 0xFFu) / 255.0,
-        float((packedColor >> 16) & 0xFFu) / 255.0,
-        float((packedColor >> 24) & 0xFFu) / 255.0
-    );
-}
-
-int3 faceMicroPositionFixed(int face, int3 voxelPositionFixed, int u, int v) {
-    if (face == kXFace) {
-        return int3(voxelPositionFixed.x, voxelPositionFixed.y + u, voxelPositionFixed.z + v);
-    }
-    if (face == kYFace) {
-        return int3(voxelPositionFixed.x + u, voxelPositionFixed.y, voxelPositionFixed.z + v);
-    }
-    return int3(voxelPositionFixed.x + u, voxelPositionFixed.y + v, voxelPositionFixed.z);
-}
-
-float3 snapNearIntegerVoxelPosition(float3 voxelPosition) {
-    const float3 voxelRounded = round(voxelPosition);
-    const bool3 nearGrid = abs(voxelPosition - voxelRounded) <= float3(0.0001);
-    return select(voxelPosition, voxelRounded, nearGrid);
-}
-
-void writeDistanceTap(
-    texture2d<int, access::read> triangleCanvasDistances,
-    device atomic_int* distanceScratch,
+inline void writeDistanceTap(
     int2 canvasPixel,
-    int voxelDistance
+    int voxelDistance,
+    device atomic_int* distanceScratch,
+    int2 canvasSize
 ) {
-    if (canvasPixel.x < 0 || canvasPixel.y < 0) {
+    if (!isInsideCanvas(canvasPixel, canvasSize)) {
         return;
     }
-    if (canvasPixel.x >= int(triangleCanvasDistances.get_width()) ||
-        canvasPixel.y >= int(triangleCanvasDistances.get_height())) {
-        return;
-    }
-
     const uint linearIndex =
-        uint(canvasPixel.y) * triangleCanvasDistances.get_width() + uint(canvasPixel.x);
-    atomic_fetch_min_explicit(&distanceScratch[linearIndex], voxelDistance, memory_order_relaxed);
+        uint(canvasPixel.y) * uint(canvasSize.x) + uint(canvasPixel.x);
+    atomic_fetch_min_explicit(
+        &distanceScratch[linearIndex],
+        voxelDistance,
+        memory_order_relaxed
+    );
 }
 
 kernel void c_voxel_to_trixel_stage_1(
     constant FrameDataVoxelToTrixel& frameData [[buffer(7)]],
     device const float4* positions [[buffer(5)]],
     device const uint* colors [[buffer(6)]],
+    device const uint* compactedVoxelIndices [[buffer(25)]],
+    device const IndirectDispatchParamsRO& indirectParams [[buffer(26)]],
     device atomic_int* distanceScratch [[buffer(16)]],
-    texture2d<int, access::read> triangleCanvasDistances [[texture(1)]],
     uint3 groupId [[threadgroup_position_in_grid]],
     uint3 localId3 [[thread_position_in_threadgroup]]
 ) {
-    const uint voxelIndex = groupId.x + groupId.y * uint(frameData.voxelDispatchGrid.x);
-    if (voxelIndex >= uint(frameData.voxelCount)) {
-        return;
-    }
-    const uint2 localId = localId3.xy;
-    const float4 color = unpackColor(colors[voxelIndex]);
-    if (color.a == 0.0) {
+    const uint compactedIdx = groupId.x + groupId.y * indirectParams.numGroupsX;
+    if (compactedIdx >= indirectParams.visibleCount) {
         return;
     }
 
+    const uint voxelIndex = compactedVoxelIndices[compactedIdx];
     const float4 voxelPosition = positions[voxelIndex];
+    const uint2 localId = localId3.xy;
+    const int face = localIDToFace_2x3(localId);
+
+    const int2 canvasSize = frameData.canvasSizePixels;
+
     if (frameData.voxelRenderOptions.x == 0) {
-        const int3 voxelPositionInt = int3(
-            round(voxelPosition.x),
-            round(voxelPosition.y),
-            round(voxelPosition.z)
+        const int3 voxelPositionInt = int3(round(voxelPosition.xyz));
+        const int voxelDistance = encodeDepthWithFace(
+            pos3DtoDistance(voxelPositionInt), face
         );
-        const int voxelDistance = pos3DtoDistance(voxelPositionInt);
         const int2 canvasPixel =
             frameData.trixelCanvasOffsetZ1 +
-            int2(floor(frameData.frameCanvasOffset.x), floor(frameData.frameCanvasOffset.y)) +
+            int2(floor(frameData.frameCanvasOffset)) +
             int2(localId) +
             pos3DtoPos2DIso(voxelPositionInt);
-        writeDistanceTap(triangleCanvasDistances, distanceScratch, canvasPixel, voxelDistance);
+        writeDistanceTap(canvasPixel, voxelDistance, distanceScratch, canvasSize);
         return;
     }
 
     const int subdivisions = max(frameData.voxelRenderOptions.y, 1);
+    const int u = int(groupId.z) / subdivisions;
+    const int v = int(groupId.z) % subdivisions;
+
     const float3 voxelPositionAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
     const int3 voxelPositionFixed = int3(round(voxelPositionAligned * float(subdivisions)));
     const int2 frameOffsetFixed =
         frameData.trixelCanvasOffsetZ1 +
         int2(floor(frameData.frameCanvasOffset * float(subdivisions)));
-    const int2 localFaceOffsetFixed = int2(localId);
-    const int face = localIDToFace(localId);
 
-    for (int u = 0; u < subdivisions; ++u) {
-        for (int v = 0; v < subdivisions; ++v) {
-            const int3 microPositionFixed =
-                faceMicroPositionFixed(face, voxelPositionFixed, u, v);
-            const int depthBase =
-                microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
-            const int voxelDistance = depthBase * 4 + face;
-            const int2 canvasPixel =
-                frameOffsetFixed + localFaceOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
-            writeDistanceTap(triangleCanvasDistances, distanceScratch, canvasPixel, voxelDistance);
-        }
-    }
+    const int3 microPositionFixed =
+        faceMicroPositionFixed(face, voxelPositionFixed, u, v);
+    const int depthBase =
+        microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
+    const int voxelDistance = encodeDepthWithFace(depthBase, face);
+    const int2 canvasPixel =
+        frameOffsetFixed + int2(localId) + pos3DtoPos2DIso(microPositionFixed);
+    writeDistanceTap(canvasPixel, voxelDistance, distanceScratch, canvasSize);
 }

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
@@ -1,116 +1,57 @@
-#include <metal_stdlib>
-using namespace metal;
+#include "ir_iso_common.metal"
+#include "ir_constants.metal"
 
-struct FrameDataVoxelToTrixel {
-    float2 frameCanvasOffset;
-    int2 trixelCanvasOffsetZ1;
-    int2 voxelRenderOptions;
-    int2 voxelDispatchGrid;
-    int voxelCount;
-    int voxelDispatchPadding;
+// Stage 2 of the voxel→trixel pipeline: each surviving voxel re-evaluates the
+// canvas distance scratch buffer (populated by stage 1) and, on a depth
+// match, writes its color/distance/entityId taps into the trixel canvas
+// textures.  Reads compacted visible voxel indices produced by
+// c_voxel_visibility_compact.metal.
+//
+// We read the depth via the scratch buffer (atomic_load) rather than the
+// R32I texture, mirroring the write path used by stage 1 — see
+// engine/render/include/irreden/render/metal/metal_runtime.hpp.
+
+struct IndirectDispatchParamsRO {
+    uint numGroupsX;
+    uint numGroupsY;
+    uint numGroupsZ;
+    uint visibleCount;
 };
 
-int2 pos3DtoPos2DIso(int3 position) {
-    return int2(
-        -position.x + position.y,
-        -position.x - position.y + (2 * position.z)
-    );
-}
-
-int pos3DtoDistance(int3 position) {
-    return position.x + position.y + position.z;
-}
-
-float4 unpackColor(uint packedColor) {
-    return float4(
-        float(packedColor & 0xFFu) / 255.0,
-        float((packedColor >> 8) & 0xFFu) / 255.0,
-        float((packedColor >> 16) & 0xFFu) / 255.0,
-        float((packedColor >> 24) & 0xFFu) / 255.0
-    );
-}
-
-constant int kXFace = 0;
-constant int kYFace = 1;
-constant int kZFace = 2;
-
-int localIDToFace(uint2 localId) {
-    if (localId.y == 0) {
-        return kZFace;
-    }
-    if (localId.x == 1) {
-        return kXFace;
-    }
-    return kYFace;
-}
-
-int3 faceMicroPositionFixed(int face, int3 voxelPositionFixed, int u, int v) {
-    if (face == kXFace) {
-        return int3(voxelPositionFixed.x, voxelPositionFixed.y + u, voxelPositionFixed.z + v);
-    }
-    if (face == kYFace) {
-        return int3(voxelPositionFixed.x + u, voxelPositionFixed.y, voxelPositionFixed.z + v);
-    }
-    return int3(voxelPositionFixed.x + u, voxelPositionFixed.y + v, voxelPositionFixed.z);
-}
-
-float3 snapNearIntegerVoxelPosition(float3 voxelPosition) {
-    const float3 voxelRounded = round(voxelPosition);
-    const bool3 nearGrid = abs(voxelPosition - voxelRounded) <= float3(0.0001);
-    return select(voxelPosition, voxelRounded, nearGrid);
-}
-
-float4 adjustColorForFace(float4 color, int face) {
-    float brightness = 1.0;
-    if (face == kYFace) {
-        brightness = 0.75;
-    }
-    if (face == kZFace) {
-        brightness = 1.25;
-    }
-    return float4(clamp(color.rgb * brightness, 0.0, 1.0), color.a);
-}
-
-void writeColorTap(
-    texture2d<float, access::write> triangleCanvasColors,
-    texture2d<int, access::write> triangleCanvasDistances,
-    texture2d<uint, access::write> triangleCanvasEntityIds,
-    device const atomic_int* distanceScratch,
+inline void writeColorTap(
     int2 canvasPixel,
     int voxelDistance,
     float4 voxelColor,
-    ulong entityId
+    uint2 packedEntityId,
+    int2 canvasSize,
+    device const atomic_int* distanceScratch,
+    texture2d<float, access::write> triangleCanvasColors,
+    texture2d<int, access::write> triangleCanvasDistances,
+    texture2d<uint, access::write> triangleCanvasEntityIds
 ) {
-    if (canvasPixel.x < 0 || canvasPixel.y < 0) {
+    if (!isInsideCanvas(canvasPixel, canvasSize)) {
         return;
     }
-    if (canvasPixel.x >= int(triangleCanvasDistances.get_width()) ||
-        canvasPixel.y >= int(triangleCanvasDistances.get_height())) {
-        return;
-    }
-
     const uint linearIndex =
-        uint(canvasPixel.y) * triangleCanvasDistances.get_width() + uint(canvasPixel.x);
+        uint(canvasPixel.y) * uint(canvasSize.x) + uint(canvasPixel.x);
     const int canvasDistance =
         atomic_load_explicit(&distanceScratch[linearIndex], memory_order_relaxed);
-    if (voxelDistance == canvasDistance) {
-        triangleCanvasColors.write(voxelColor, uint2(canvasPixel));
-        triangleCanvasDistances.write(int4(voxelDistance), uint2(canvasPixel));
-        const uint4 packedEntityId = uint4(
-            uint(entityId & 0xffffffffull),
-            uint((entityId >> 32ull) & 0xffffffffull),
-            0u,
-            0u
-        );
-        triangleCanvasEntityIds.write(packedEntityId, uint2(canvasPixel));
+    if (voxelDistance != canvasDistance) {
+        return;
     }
+    const uint2 pixel = uint2(canvasPixel);
+    triangleCanvasColors.write(voxelColor, pixel);
+    triangleCanvasDistances.write(int4(voxelDistance, 0, 0, 0), pixel);
+    triangleCanvasEntityIds.write(uint4(packedEntityId, 0u, 0u), pixel);
 }
 
 kernel void c_voxel_to_trixel_stage_2(
     constant FrameDataVoxelToTrixel& frameData [[buffer(7)]],
     device const float4* positions [[buffer(5)]],
     device const uint* colors [[buffer(6)]],
-    device const ulong* entityIds [[buffer(13)]],
+    device const uint2* entityIds [[buffer(13)]],
+    device const uint* compactedVoxelIndices [[buffer(25)]],
+    device const IndirectDispatchParamsRO& indirectParams [[buffer(26)]],
     device const atomic_int* distanceScratch [[buffer(16)]],
     texture2d<float, access::write> triangleCanvasColors [[texture(0)]],
     texture2d<int, access::write> triangleCanvasDistances [[texture(1)]],
@@ -118,71 +59,74 @@ kernel void c_voxel_to_trixel_stage_2(
     uint3 groupId [[threadgroup_position_in_grid]],
     uint3 localId3 [[thread_position_in_threadgroup]]
 ) {
-    const uint voxelIndex = groupId.x + groupId.y * uint(frameData.voxelDispatchGrid.x);
-    if (voxelIndex >= uint(frameData.voxelCount)) {
+    const uint compactedIdx = groupId.x + groupId.y * indirectParams.numGroupsX;
+    if (compactedIdx >= indirectParams.visibleCount) {
         return;
     }
-    const uint2 localId = localId3.xy;
+
+    const uint voxelIndex = compactedVoxelIndices[compactedIdx];
     const float4 voxelPosition = positions[voxelIndex];
     float4 voxelColor = unpackColor(colors[voxelIndex]);
     if (voxelColor.a == 0.0) {
         return;
     }
-    voxelColor = adjustColorForFace(voxelColor, localIDToFace(localId));
+    const uint2 localId = localId3.xy;
+    const int face = localIDToFace_2x3(localId);
+    voxelColor = adjustColorForFace(voxelColor, face);
+
+    const int2 canvasSize = frameData.canvasSizePixels;
+    const uint2 packedEntityId = entityIds[voxelIndex];
 
     if (frameData.voxelRenderOptions.x == 0) {
-        const int3 voxelPositionInt = int3(
-            round(voxelPosition.x),
-            round(voxelPosition.y),
-            round(voxelPosition.z)
+        const int3 voxelPositionInt = int3(round(voxelPosition.xyz));
+        const int voxelDistance = encodeDepthWithFace(
+            pos3DtoDistance(voxelPositionInt), face
         );
-        const int voxelDistance = pos3DtoDistance(voxelPositionInt);
         const int2 canvasPixel =
             frameData.trixelCanvasOffsetZ1 +
-            int2(floor(frameData.frameCanvasOffset.x), floor(frameData.frameCanvasOffset.y)) +
+            int2(floor(frameData.frameCanvasOffset)) +
             int2(localId) +
             pos3DtoPos2DIso(voxelPositionInt);
         writeColorTap(
-            triangleCanvasColors,
-            triangleCanvasDistances,
-            triangleCanvasEntityIds,
-            distanceScratch,
             canvasPixel,
             voxelDistance,
             voxelColor,
-            entityIds[voxelIndex]
+            packedEntityId,
+            canvasSize,
+            distanceScratch,
+            triangleCanvasColors,
+            triangleCanvasDistances,
+            triangleCanvasEntityIds
         );
         return;
     }
 
     const int subdivisions = max(frameData.voxelRenderOptions.y, 1);
+    const int u = int(groupId.z) / subdivisions;
+    const int v = int(groupId.z) % subdivisions;
+
     const float3 voxelPositionAligned = snapNearIntegerVoxelPosition(voxelPosition.xyz);
     const int3 voxelPositionFixed = int3(round(voxelPositionAligned * float(subdivisions)));
     const int2 frameOffsetFixed =
         frameData.trixelCanvasOffsetZ1 +
         int2(floor(frameData.frameCanvasOffset * float(subdivisions)));
-    const int2 localFaceOffsetFixed = int2(localId);
-    const int face = localIDToFace(localId);
 
-    for (int u = 0; u < subdivisions; ++u) {
-        for (int v = 0; v < subdivisions; ++v) {
-            const int3 microPositionFixed =
-                faceMicroPositionFixed(face, voxelPositionFixed, u, v);
-            const int depthBase =
-                microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
-            const int voxelDistance = depthBase * 4 + face;
-            const int2 canvasPixel =
-                frameOffsetFixed + localFaceOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
-            writeColorTap(
-                triangleCanvasColors,
-                triangleCanvasDistances,
-                triangleCanvasEntityIds,
-                distanceScratch,
-                canvasPixel,
-                voxelDistance,
-                voxelColor,
-                entityIds[voxelIndex]
-            );
-        }
-    }
+    const int3 microPositionFixed =
+        faceMicroPositionFixed(face, voxelPositionFixed, u, v);
+    const int depthBase =
+        microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
+    const int voxelDistance = encodeDepthWithFace(depthBase, face);
+    const int2 canvasPixel =
+        frameOffsetFixed + int2(localId) + pos3DtoPos2DIso(microPositionFixed);
+    writeColorTap(
+        canvasPixel,
+        voxelDistance,
+        voxelColor,
+        packedEntityId,
+        canvasSize,
+        distanceScratch,
+        triangleCanvasColors,
+        triangleCanvasDistances,
+        triangleCanvasEntityIds
+    );
 }

--- a/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
+++ b/engine/render/src/shaders/metal/c_voxel_visibility_compact.metal
@@ -1,0 +1,103 @@
+#include "ir_iso_common.metal"
+#include "ir_constants.metal"
+
+// Voxel visibility + compaction pass.  Each thread inspects one voxel,
+// performs chunk-level visibility, alpha rejection, and iso-bounds culling,
+// then atomically appends its index into the compacted indices buffer.  The
+// last group to finish (tracked via the completedGroups counter) writes the
+// indirect dispatch params used by the stage 1 / stage 2 voxel-to-trixel
+// passes.
+//
+// IndirectDispatchParams memory layout (matches the GLSL std430 SSBO):
+//   [0] numGroupsX        (written by last group)
+//   [1] numGroupsY        (written by last group)
+//   [2] numGroupsZ        (written by last group)
+//   [3] visibleCount      (atomic increment, read by stage 1 / stage 2)
+//   [4] completedGroups   (atomic increment, last-group barrier)
+// All five fields are accessed through a single `device atomic_uint*` so
+// that we can mix atomic_fetch_add (3, 4) with atomic_store (0, 1, 2)
+// without rebinding the buffer.
+
+constant uint kSlotNumGroupsX     = 0;
+constant uint kSlotNumGroupsY     = 1;
+constant uint kSlotNumGroupsZ     = 2;
+constant uint kSlotVisibleCount   = 3;
+constant uint kSlotCompletedGroups = 4;
+
+kernel void c_voxel_visibility_compact(
+    constant FrameDataVoxelToTrixel& frameData [[buffer(7)]],
+    device const float4* positions [[buffer(5)]],
+    device const uint* colors [[buffer(6)]],
+    device const uint* chunkVisible [[buffer(24)]],
+    device uint* compactedVoxelIndices [[buffer(25)]],
+    device atomic_uint* indirectParams [[buffer(26)]],
+    uint3 groupId [[threadgroup_position_in_grid]],
+    uint3 groupCount [[threadgroups_per_grid]],
+    uint3 localId [[thread_position_in_threadgroup]],
+    uint localIndex [[thread_index_in_threadgroup]]
+) {
+    const uint workGroupIndex = groupId.x + groupId.y * groupCount.x;
+    const uint idx = workGroupIndex * 64u + localId.x;
+
+    if (idx < uint(frameData.voxelCount)) {
+        const uint chunkIdx = idx / uint(VOXEL_CHUNK_SIZE);
+        if (chunkVisible[chunkIdx] != 0u) {
+            const uint packedColor = colors[idx];
+            const uint alpha = (packedColor >> 24) & 0xFFu;
+            if (alpha != 0u) {
+                const int3 voxelPos = int3(round(positions[idx].xyz));
+                const int2 isoPos = pos3DtoPos2DIso(voxelPos);
+                if (isoPos.x >= frameData.cullIsoMin.x &&
+                    isoPos.x <= frameData.cullIsoMax.x &&
+                    isoPos.y >= frameData.cullIsoMin.y &&
+                    isoPos.y <= frameData.cullIsoMax.y) {
+                    const uint slot = atomic_fetch_add_explicit(
+                        &indirectParams[kSlotVisibleCount],
+                        1u,
+                        memory_order_relaxed
+                    );
+                    compactedVoxelIndices[slot] = idx;
+                }
+            }
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_device);
+
+    if (localIndex == 0u) {
+        const uint finished = atomic_fetch_add_explicit(
+            &indirectParams[kSlotCompletedGroups],
+            1u,
+            memory_order_relaxed
+        ) + 1u;
+        const uint totalGroups = groupCount.x * groupCount.y;
+        if (finished == totalGroups) {
+            const uint count = atomic_load_explicit(
+                &indirectParams[kSlotVisibleCount],
+                memory_order_relaxed
+            );
+            const uint gx = min(count, 1024u);
+            const uint gxClamped = max(gx, 1u);
+            const uint gy = max((count + gxClamped - 1u) / gxClamped, 1u);
+            const int subdivisions = max(frameData.voxelRenderOptions.y, 1);
+            const uint gz = (frameData.voxelRenderOptions.x != 0)
+                ? uint(subdivisions * subdivisions)
+                : 1u;
+            atomic_store_explicit(
+                &indirectParams[kSlotNumGroupsX],
+                gxClamped,
+                memory_order_relaxed
+            );
+            atomic_store_explicit(
+                &indirectParams[kSlotNumGroupsY],
+                gy,
+                memory_order_relaxed
+            );
+            atomic_store_explicit(
+                &indirectParams[kSlotNumGroupsZ],
+                gz,
+                memory_order_relaxed
+            );
+        }
+    }
+}

--- a/engine/render/src/shaders/metal/ir_constants.metal
+++ b/engine/render/src/shaders/metal/ir_constants.metal
@@ -1,0 +1,5 @@
+// Shared GPU constants for all trixel pipeline Metal shaders.
+// Mirrors shaders/ir_constants.glsl.
+
+constant int VOXEL_CHUNK_SIZE = 256;
+constant int kInvalidDepth = 0x7FFFFFFF;

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -1,0 +1,134 @@
+// Shared isometric math utilities for all trixel pipeline Metal compute
+// shaders.  Mirrors shaders/ir_iso_common.glsl.  Resolved by the engine's
+// Metal #include preprocessor at runtime, NOT by the standard preprocessor —
+// header guards are still recommended for safety.
+#ifndef IR_ISO_COMMON_METAL_INCLUDED
+#define IR_ISO_COMMON_METAL_INCLUDED
+
+#include <metal_stdlib>
+using namespace metal;
+
+constant int kXFace = 0;
+constant int kYFace = 1;
+constant int kZFace = 2;
+
+inline int2 pos3DtoPos2DIso(int3 position) {
+    return int2(
+        -position.x + position.y,
+        -position.x - position.y + 2 * position.z
+    );
+}
+
+inline int pos3DtoDistance(int3 position) {
+    return position.x + position.y + position.z;
+}
+
+// Reconstruct 3D position from 2D iso coordinates and depth.  The isometric
+// depth axis (1,1,1) is perpendicular to the screen, so given (isoX, isoY)
+// and depth d = x + y + z, (x, y, z) is uniquely determined.
+inline float3 isoPixelToPos3D(int isoX, int isoY, float depth) {
+    float x = (2.0 * depth - 3.0 * float(isoX) - float(isoY)) / 6.0;
+    float y = x + float(isoX);
+    float z = (float(isoY) + 2.0 * x + float(isoX)) / 2.0;
+    return float3(x, y, z);
+}
+
+inline float3 isoToLocal3D(int2 isoRel, float depth) {
+    return isoPixelToPos3D(isoRel.x, isoRel.y, depth);
+}
+
+inline float4 unpackColor(uint packedColor) {
+    return float4(
+        float(packedColor & 0xFFu) / 255.0,
+        float((packedColor >> 8) & 0xFFu) / 255.0,
+        float((packedColor >> 16) & 0xFFu) / 255.0,
+        float((packedColor >> 24) & 0xFFu) / 255.0
+    );
+}
+
+inline float4 adjustColorForFace(float4 color, int face) {
+    float b = 1.0;
+    if (face == kYFace) b = 0.75;
+    if (face == kZFace) b = 1.25;
+    return float4(clamp(color.rgb * b, 0.0, 1.0), color.a);
+}
+
+// Map local invocation ID within a (2, 3, 1) workgroup to a face type.
+//   (0,0),(1,0) -> Z_FACE
+//   (1,1),(1,2) -> X_FACE
+//   (0,1),(0,2) -> Y_FACE
+inline int localIDToFace_2x3(uint2 localId) {
+    if (localId.y == 0u) return kZFace;
+    if (localId.x == 1u) return kXFace;
+    return kYFace;
+}
+
+// Face offset within the 2x3 trixel diamond for a given face and sub-pixel
+// index (0 or 1).  Matches the layout used by localIDToFace_2x3():
+//   Z -> (0,0),(1,0)   X -> (1,1),(1,2)   Y -> (0,1),(0,2)
+inline int2 faceOffset_2x3(int face, int subPixel) {
+    if (face == kZFace) return int2(subPixel, 0);
+    if (face == kXFace) return int2(1, 1 + subPixel);
+    return int2(0, 1 + subPixel);
+}
+
+// Encode depth with face priority for deterministic depth-test resolution.
+// The *4 spacing ensures face indices never cross depth boundaries.
+inline int encodeDepthWithFace(int rawDepth, int face) {
+    return rawDepth * 4 + face;
+}
+
+inline int3 faceMicroPositionFixed(
+    int face,
+    int3 voxelPositionFixed,
+    int u,
+    int v
+) {
+    if (face == kXFace) {
+        return int3(
+            voxelPositionFixed.x,
+            voxelPositionFixed.y + u,
+            voxelPositionFixed.z + v
+        );
+    }
+    if (face == kYFace) {
+        return int3(
+            voxelPositionFixed.x + u,
+            voxelPositionFixed.y,
+            voxelPositionFixed.z + v
+        );
+    }
+    return int3(
+        voxelPositionFixed.x + u,
+        voxelPositionFixed.y + v,
+        voxelPositionFixed.z
+    );
+}
+
+inline bool isInsideCanvas(int2 pixel, int2 canvasSize) {
+    return pixel.x >= 0 && pixel.x < canvasSize.x &&
+           pixel.y >= 0 && pixel.y < canvasSize.y;
+}
+
+inline float3 snapNearIntegerVoxelPosition(float3 voxelPosition) {
+    float3 voxelRounded = round(voxelPosition);
+    bool3 nearGrid = abs(voxelPosition - voxelRounded) <= float3(0.0001);
+    return select(voxelPosition, voxelRounded, nearGrid);
+}
+
+// Frame data layout used by all voxel→trixel compute kernels.  Mirrors the
+// FrameDataVoxelToTrixel UBO in the GLSL pipeline.  std140 padding rules from
+// GLSL collapse cleanly into Metal's natural packing here.
+struct FrameDataVoxelToTrixel {
+    float2 frameCanvasOffset;
+    int2 trixelCanvasOffsetZ1;
+    int2 voxelRenderOptions;
+    int2 voxelDispatchGrid;
+    int voxelCount;
+    int voxelDispatchPadding;
+    int2 canvasSizePixels;
+    int2 cullIsoMin;
+    int2 cullIsoMax;
+};
+
+#endif // IR_ISO_COMMON_METAL_INCLUDED

--- a/engine/render/src/vao.cpp
+++ b/engine/render/src/vao.cpp
@@ -1,22 +1,23 @@
+#include <irreden/render/buffer.hpp>
 #include <irreden/render/vao.hpp>
 
 namespace IRRender {
 
 std::unique_ptr<VertexLayoutImpl> createVertexLayoutImpl(
-    std::uint32_t vertexBufferHandle,
-    std::uint32_t indexBufferHandle,
+    const Buffer *vertexBuffer,
+    const Buffer *indexBuffer,
     unsigned int numAttributes,
     const VertexArrayAttribute *attributes
 );
 
 VertexLayout::VertexLayout(
-    std::uint32_t vertexBufferHandle,
-    std::uint32_t indexBufferHandle,
+    const Buffer *vertexBuffer,
+    const Buffer *indexBuffer,
     unsigned int numAttributes,
     const VertexArrayAttribute *attributes
 )
     : m_impl(createVertexLayoutImpl(
-          vertexBufferHandle, indexBufferHandle, numAttributes, attributes
+          vertexBuffer, indexBuffer, numAttributes, attributes
       )) {}
 
 VertexLayout::~VertexLayout() = default;


### PR DESCRIPTION
…kends

Brings the Metal renderer to parity with the GLSL pipeline so IRShapeDebug runs end-to-end on macOS, and removes the per-backend handle maps so both backends share RenderingResourceManager directly.

- New metal compute shaders: c_shapes_to_trixel, c_voxel_visibility_compact, c_update_voxel_positions, plus shared ir_constants/ir_iso_common headers.
- RenderDevice / Buffer / Texture2D APIs now pass wrapper pointers instead of uint32 handles; OpenGL and Metal impls both expose getNativeBuffer / getNa- tiveTexture for backend-specific binding.
- metal_runtime: per-frame buffer orphaning with deferred release so encoded command buffers keep their pre-write snapshot, plus a per-texture scratch buffer mirroring R32I distance textures for atomic min ops.
- Mirror master's c_shapes_to_trixel sub==1 smooth-mode aliasing fix on the metal side so shapes at minimum zoom match the lattice walk used by snap.

Verified by running IRShapeDebug --auto-screenshot 10 against the OpenGL baseline; all six zoom/offset captures match byte-for-byte.