### PR TITLE
docs: fix agent-fleet worktree create commands

### DIFF
--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -358,22 +358,51 @@ A reasonable starting setup with the model split in mind:
 | `sonnet-reviewer`     | Sonnet | First-pass PR review                |
 | `opus-reviewer`       | Opus   | Second-pass review + merge sign-off |
 
-Create them once:
+Create them once. Each worktree needs its own seed branch — git
+refuses to check out `master` in a second worktree while the main
+clone still has it checked out, so we create each worktree on a
+`fleet/<role>` branch that starts from `origin/master`. The seed
+branch is just a parking spot; `start-next-task` moves the worktree
+off it onto a real `claude/<area>-<topic>` branch as soon as the
+first task starts.
 
 ```bash
 cd ~/src/IrredenEngine
+git fetch origin master
 
-git worktree add .claude/worktrees/opus-architect master
-git worktree add .claude/worktrees/sonnet-fleet-1 master
-git worktree add .claude/worktrees/sonnet-fleet-2 master
-git worktree add .claude/worktrees/sonnet-reviewer master
-git worktree add .claude/worktrees/opus-reviewer master
+git worktree add -b fleet/opus-architect  .claude/worktrees/opus-architect  origin/master
+git worktree add -b fleet/sonnet-fleet-1  .claude/worktrees/sonnet-fleet-1  origin/master
+git worktree add -b fleet/sonnet-fleet-2  .claude/worktrees/sonnet-fleet-2  origin/master
+git worktree add -b fleet/sonnet-reviewer .claude/worktrees/sonnet-reviewer origin/master
+git worktree add -b fleet/opus-reviewer   .claude/worktrees/opus-reviewer   origin/master
 ```
 
-These live forever. Each agent session opens the worktree it wants and
-the `start-next-task` skill resets its branch back to `origin/master`
-after each PR, so the worktree itself is reused but the branch name
-changes each task.
+Verify:
+
+```bash
+git worktree list
+```
+
+You should see the main clone on `master` plus five worktrees each on
+their own `fleet/*` seed branch. The `fleet/` prefix keeps these
+distinct from `claude/<area>-<topic>` agent branches so `gh pr list`
+and branch-completion never confuse them.
+
+These worktrees live forever. Each agent session opens the worktree
+it wants and the `start-next-task` skill creates a fresh
+`claude/<area>-<topic>` branch off `origin/master` inside it after
+each PR, so the worktree is reused but the branch name changes each
+task. The initial `fleet/<role>` seed branches stay in `git branch`
+output as harmless markers of which worktree exists — if you ever
+want to remove a worktree entirely, `git worktree remove <path> &&
+git branch -D fleet/<role>`.
+
+**Common first-run error:** if you see `fatal: 'master' is already
+checked out at '<main clone>'`, you ran `git worktree add <path>
+master` (checking out the `master` branch directly) instead of
+`git worktree add -b fleet/<role> <path> origin/master` (creating a
+new seed branch starting from `origin/master`). Fix by using the
+`-b` form above.
 
 You can delete the old ephemeral worktrees (`adoring-gates`,
 `goofy-jones`, `vectorized-sauteeing-yeti`) from the Windows-native


### PR DESCRIPTION
## Summary
- `docs/AGENT_FLEET_SETUP.md` §4 told new fleet hosts to run `git worktree add .claude/worktrees/<role> master`, which always fails with `fatal: 'master' is already checked out at '<main clone>'` because git refuses to check out a branch in two worktrees at once.
- Replaced with the `git worktree add -b fleet/<role> <path> origin/master` form that creates a dedicated per-worktree seed branch. The `fleet/` prefix stays out of the `claude/<area>-<topic>` namespace used by agent branches.
- Added a `git worktree list` verification step, an explanation of the seed-branch lifecycle (overwritten by `start-next-task` on first use), and a "Common first-run error" callout for anyone who hits the original bad command from muscle memory.

Discovered while trying to bootstrap the WSL fleet on `~/src/IrredenEngine` — the error was repro'd immediately on the first of the five documented commands.

## Test plan
- [ ] Follow the updated §4 on a fresh fleet host: `git worktree list` shows the main clone on `master` plus five worktrees each on their own `fleet/*` seed branch.
- [ ] `cd` into one of the new worktrees, run the `start-next-task` skill, confirm it creates a fresh `claude/<area>-<topic>` branch off `origin/master` as documented.
- [ ] `git branch -v` on the main clone shows the five `fleet/*` seed branches sitting at `origin/master`'s HEAD with no stray commits.

## Notes for reviewer
Docs-only change; no build or tests. The `-b fleet/<role>` form is one of two equivalent fixes — the other is `git worktree add --detach <path> origin/master`, which avoids the seed branches entirely. I went with `-b` because the named branches make `git worktree list` / `git branch -v` self-describing and give a clean removal target (`git branch -D fleet/<role>`) when retiring a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)