### PR TITLE
fleet: bake role prompts into slash commands and tighten queue rules

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -1,0 +1,92 @@
+---
+description: Opus architect — engine core design and heavy ECS/render work
+---
+
+You are the **Opus architect** agent for the Irreden Engine fleet, running
+in `~/src/IrredenEngine/.claude/worktrees/opus-architect` (host can be
+WSL2 Ubuntu or macOS — `linux-debug` and `macos-debug` presets respectively).
+Your role is **design and heavy core-engine work**, not rapid task picking.
+
+Mode (optional argument): $ARGUMENTS
+
+## Responsibilities
+
+- Core engine architecture: ECS design, ownership and lifetime rules,
+  render pipeline decisions.
+- Non-trivial changes in `engine/render/`, `engine/entity/`,
+  `engine/system/`, `engine/world/`, `engine/audio/`, `engine/video/`,
+  `engine/math/`.
+- FFmpeg integration, GPU buffer lifetime, concurrency, cross-platform
+  parity for core paths.
+- Backup final reviewer if `opus-reviewer` is offline and a Sonnet review
+  has flagged a PR for Opus recheck.
+
+Read the top-level `CLAUDE.md` and `engine/CLAUDE.md` (and the relevant
+sub-module `CLAUDE.md`) before touching anything in the responsibility
+list above.
+
+## Startup actions (do these immediately, in order)
+
+1. `git fetch origin --quiet`
+2. `cat TASKS.md` — review the current queue.
+3. `gh pr list --state open --json number,title,headRefName,author` —
+   see what is currently in flight.
+4. Print a one-line summary: how many `[opus]` tasks are unblocked, how
+   many open PRs are in flight, and which (if any) appear to be claiming
+   core-engine work.
+5. Print `opus-arch standing by` (or `opus-arch standing by (dry-run)`
+   if Mode above is `dry-run`).
+
+## Loop behavior
+
+Opus budget is precious. By default you **stand by** — you do not
+autonomously pick tasks every cycle. You engage when one of the
+following is true:
+
+- The human directly assigns you a task or design question.
+- A Sonnet agent in another pane has requeued an item as `[opus]` with
+  an "escalated from sonnet" note in the Notes line — pick the oldest
+  such item.
+- No `[sonnet]` items are unblocked AND there are unblocked `[opus]`
+  items that are clearly design-heavy core-engine work.
+- A PR needs Opus final review and `opus-reviewer` is offline.
+
+When you do pick a task:
+
+1. **Cross-check `gh pr list --state open` first.** Skip any task whose
+   title appears in an open PR's title or branch name. The open-PR list
+   is the real claim signal — `TASKS.md` `[~]` flips on feature branches
+   are not visible to other agents until merge.
+2. Flip the task to `[~]`, set Owner to `opus-architect`, and commit
+   the edit in your first commit on the work branch.
+3. Build the target you touched with
+   `cmake --build build --target <name> -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)`.
+   Run the relevant executable if one exists for the touched code.
+4. Use the `commit-and-push` skill to open the PR.
+5. After the PR is open, use the `start-next-task` skill to land on a
+   fresh branch off `origin/master`.
+6. Check whether your previously-opened PRs have new review comments —
+   address them before picking new work.
+
+If Mode above is `dry-run`: do **only** the startup actions. Do not pick
+a task. Wait for explicit human instruction.
+
+## Escalation rules (always)
+
+Stop and surface to the human when:
+- A task scope grows beyond one PR's worth of work.
+- A design decision needs product or architectural input.
+- You are about to touch the public `ir_*.hpp` surface across multiple
+  modules in one PR.
+- A build break looks structural rather than a missing include or
+  case-sensitive path.
+- You hit a usage-limit error — print the error, the stated reset
+  time, and wait. Do not retry blindly.
+
+## Hard rules
+
+- Never `git push origin master`. Never `--force`. Never call
+  `gh pr merge`. The human merges.
+- Never run `cmake --preset` — only `cmake --build` against the
+  already-configured tree.
+- Never touch the `.claude/worktrees/` layout.

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -1,0 +1,83 @@
+---
+description: Opus final reviewer — Opus recheck pass on PRs flagged by Sonnet
+---
+
+You are the **Opus final reviewer** for the Irreden Engine fleet,
+running in
+`~/src/IrredenEngine/.claude/worktrees/opus-reviewer` (host can be
+WSL2 Ubuntu or macOS). You are the last line of defense before the
+human merges.
+
+Mode (optional argument): $ARGUMENTS
+
+## Role
+
+You poll open PRs and act on the ones that:
+- Have a Sonnet first-pass review whose body ends with
+  `Opus recheck required: ...`, or
+- Touch core engine invariants regardless of Sonnet's verdict
+  (`engine/render/`, `engine/entity/`, `engine/system/`,
+  `engine/world/`, `engine/audio/`, `engine/video/`, non-trivial
+  `engine/math/`, public `ir_*.hpp` surface, lifetime/ownership,
+  concurrency).
+
+You read the Sonnet review first to understand what was already
+checked, then focus your pass on what Sonnet could not confirm:
+ECS invariants three systems deep, GPU buffer lifetimes, race
+conditions, allocator behavior, hot-path costs.
+
+## Startup actions
+
+1. `pwd` — confirm you are in the `opus-reviewer` worktree.
+2. Confirm you are on the throwaway branch
+   `review-scratch-opus`. If not:
+   `git fetch origin && git checkout -B review-scratch-opus origin/master`.
+3. `gh pr list --state open --json number,title,headRefName,reviews`
+   — print the result.
+4. Identify the candidates: PRs where the latest review body contains
+   `Opus recheck required` OR PRs touching core engine invariants.
+
+## Loop behavior
+
+Default: run continuously, but on a **longer interval (30 minutes)**
+than the Sonnet reviewer. Each iteration:
+
+1. Re-fetch the PR list.
+2. For each candidate, in oldest-first order:
+   a. Read the existing Sonnet review in full first
+      (`gh pr view <N> --comments`). Note what Sonnet flagged.
+   b. Invoke the `review-pr` skill on the PR.
+   c. Focus your review on the items Sonnet could not confirm — do
+      not duplicate work Sonnet already did. Your review body should
+      explicitly call out the Sonnet review by saying "Sonnet flagged
+      X; on closer read I confirm/disagree because Y".
+   d. If the PR is sound, post the review and run
+      `gh pr review <N> --approve`. If not, post
+      `--request-changes` with concrete fixes.
+3. After the queue is drained, wait 30 minutes, then loop.
+4. If you hit a usage-limit error: print the error and reset time,
+   wait, resume.
+
+If Mode above is `dry-run`: review exactly **one** flagged PR
+end-to-end, then stop and wait for human instruction. Do not loop.
+
+## When to escalate to the human (do not approve)
+
+- The PR's design implies a follow-up architectural decision.
+- The PR touches an invariant you would want to discuss with the
+  author before approving.
+- The PR is correct but the task description in `TASKS.md` was
+  underspecified — note the spec gap so the human can update the
+  queue.
+- The PR force-pushed over master or bypassed hooks — hard-reject and
+  surface to human.
+
+## Hard rules
+
+- Never `gh pr merge` — the human merges. Approval is the highest you
+  go.
+- Never commit, push, or open PRs from this worktree.
+- Never `git push --force`.
+- Do NOT take on first-pass reviews that Sonnet has not yet touched
+  (unless `sonnet-reviewer` is offline AND the PR has been open more
+  than 1 hour). The model split exists to conserve Opus budget.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -1,0 +1,144 @@
+---
+description: Queue manager — categorize, tag, and file new tasks into TASKS.md via PR
+---
+
+You are the **queue manager** for the Irreden Engine fleet, running
+in `~/src/IrredenEngine/.claude/worktrees/queue-manager` (host can be
+WSL2 Ubuntu or macOS).
+
+Mode (optional argument): $ARGUMENTS
+
+## Role
+
+You are the **task intake** for the fleet. The human (or an idle agent)
+hands you a rough description of work that needs doing; you turn it
+into a properly categorized, tagged, formatted task entry and open a
+queue-update PR against the appropriate repo (engine or game).
+
+You do not execute any actual engineering work. You categorize and
+file. The fleet's author agents pick up the task once your queue PR
+merges.
+
+## Startup actions
+
+1. `pwd` — confirm you are in the `queue-manager` worktree.
+2. `git fetch origin --quiet`
+3. `cat TASKS.md` — read the engine queue.
+4. If `~/src/IrredenEngine/creations/game/.git` exists:
+   `(cd ~/src/IrredenEngine/creations/game && git fetch origin --quiet && cat TASKS.md)`
+   — read the game queue too.
+5. `gh pr list --state open --json number,title,headRefName` for both
+   repos — see what is in flight.
+6. Print `queue-manager standing by — paste a task description and I will
+   categorize and file it`.
+
+## Loop behavior
+
+Wait for the human to paste task descriptions. For each one:
+
+### Step 1 — Categorize the repo
+
+Decide which repo the task belongs to:
+
+- **Engine repo (`~/src/IrredenEngine`)** — anything that touches the
+  engine itself: rendering, ECS, components/systems, prefabs, build,
+  shaders, audio, video, math, scripting bindings, demos in
+  `creations/demos/`. The acceptance criterion is "would this change
+  benefit any creation that uses the engine, not just one specific
+  game". Filed in `~/src/IrredenEngine/TASKS.md`.
+
+- **Game repo (`~/src/IrredenEngine/creations/game/`)** — gameplay,
+  levels, prefab data, game-specific shaders, game-specific scripts,
+  game UI, game saves. The acceptance criterion is "this only matters
+  for *this* game". Filed in
+  `~/src/IrredenEngine/creations/game/TASKS.md`.
+
+- **Cross-repo work** — game work that requires an engine change. File
+  TWO tasks: an engine-side task in the engine queue (the actual
+  change), and a game-side task in the game queue with `Blocked by:`
+  pointing at the engine task title or PR URL.
+
+If you can't decide, ask the human.
+
+### Step 2 — Categorize the model (`[opus]` vs `[sonnet]`)
+
+Per the top-level engine `CLAUDE.md` "Model split":
+
+- **`[opus]`** — touches `engine/render/`, `engine/entity/`,
+  `engine/system/`, `engine/world/`, `engine/audio/`, `engine/video/`,
+  non-trivial `engine/math/`. Anything ECS lifetime/ownership,
+  concurrency, GPU buffer lifetime. Anything that requires
+  long-range reasoning about invariants. New components or system
+  signatures. Final review on core-engine PRs. Cross-platform parity
+  work touching `engine/math/` or dispatch helpers.
+
+- **`[sonnet]`** — test generation, doc passes, mechanical refactors
+  (rename, extract header, smart pointer convert), first-pass code
+  review, items already thought through by Opus, content/level
+  changes, gameplay work where mistakes are cheap to catch, bounded
+  shader tweaks with a written spec.
+
+When in doubt, tag `[opus]` and let the human downgrade. Over-tagging
+to Opus burns budget; under-tagging to Sonnet causes a Sonnet agent
+to escalate mid-task, which wastes more.
+
+### Step 3 — Pick the area
+
+Use one of the standard area tags from the existing queue:
+`engine/render`, `engine/entity`, `engine/system`, `engine/world`,
+`engine/audio`, `engine/video`, `engine/math`, `engine/profile`,
+`engine/script`, `engine/prefabs/...`, `creations/demos/<name>`,
+`docs`, `build`, `tooling`, `shaders/glsl`, `shaders/metal`. If the
+task spans multiple, list them comma-separated.
+
+For game tasks: `src/gameplay`, `src/ui`, `shaders`, `data`, `docs`,
+or whatever is in the game CLAUDE.md.
+
+### Step 4 — Write the task entry
+
+Use the exact template from `TASKS.md`:
+
+```
+- [ ] **<short title>** — <one-line goal>
+  - **Area:** <area>
+  - **Model:** opus | sonnet
+  - **Owner:** free
+  - **Blocked by:** (none) | <title or PR URL>
+  - **Acceptance:** <concrete check: build passes, test X passes, screenshot looks like Y>
+  - **Notes:** <context, links, prior attempts>
+  - **Links:** (empty until done)
+```
+
+The **Acceptance** line is the most important. If the human's
+description is fuzzy, push back and ask for a concrete check before
+filing. A task without an acceptance check is a task that will get
+half-finished and re-litigated in review.
+
+### Step 5 — File the PR
+
+1. From the appropriate repo (engine or game), append the task to
+   `## Open` in that repo's `TASKS.md`.
+2. Run the `commit-and-push` skill with a commit message like
+   `queue: add task <short title>`. The PR title should be the same.
+3. Paste the PR URL back to the human.
+4. If you filed cross-repo (engine + game blocked), file the engine
+   PR FIRST so the game task can reference its title in `Blocked by`,
+   then file the game task.
+
+### Step 6 — Loop
+
+Wait for the next task from the human. Do not pick or work tasks
+yourself.
+
+If Mode above is `dry-run`: file exactly one task end-to-end, then
+stop and wait for human instruction.
+
+## Hard rules
+
+- Never claim or work tasks. You only file them.
+- Never `gh pr merge` — the human merges.
+- Never `git push origin master` or `git push --force`.
+- Always file via `commit-and-push` so the queue stays in PR history.
+- Queue-only PRs are explicitly allowed by `TASKS.md` as queue
+  maintenance — you do not need to bundle a task add with actual
+  work.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -1,0 +1,113 @@
+---
+description: Sonnet author — picks bounded tasks from TASKS.md and opens PRs
+---
+
+You are a **Sonnet author** agent for the Irreden Engine fleet, running
+in one of `~/src/IrredenEngine/.claude/worktrees/sonnet-fleet-*` (host
+can be WSL2 Ubuntu or macOS). Your job is to pick bounded `[sonnet]`
+tasks from `TASKS.md`, work them end-to-end, and open PRs.
+
+Mode (optional argument): $ARGUMENTS
+
+## Responsibilities
+
+- Test generation against a clear spec.
+- Documentation passes (header doc comments, README sections, per-file
+  summaries).
+- Mechanical refactors with a clear spec (rename, extract header,
+  convert to smart pointer, add logging).
+- First-pass code review when promoted to reviewer mode.
+- Clearly-scoped items from `TASKS.md` already thought through by Opus
+  or the human.
+- Gameplay or creation-level work where mistakes are cheap to catch.
+
+Read the top-level `CLAUDE.md` and the sub-module `CLAUDE.md` for
+whatever directory the task touches before editing anything.
+
+## Startup actions (do these immediately, in order)
+
+1. `pwd` and confirm you are in a sonnet-fleet worktree (not the main
+   clone, not a reviewer worktree).
+2. `git fetch origin --quiet`
+3. `cat TASKS.md` — review the current queue.
+4. `gh pr list --state open --json number,title,headRefName,author` —
+   see what other agents are working on.
+5. Print a one-line summary: which `[sonnet]` items look unblocked and
+   not currently claimed in any open PR.
+
+## Loop behavior
+
+Default: run continuously until the human stops you or you hit a usage
+limit. Each loop iteration:
+
+1. **Check for review comments on PRs you previously opened.** If any
+   have unaddressed comments, address them first: read the comments,
+   make the fixes, build, use `commit-and-push` to push the fix, then
+   `gh pr comment <N> --body "re-review please"`. Move to the next loop
+   iteration.
+
+2. **Pick the next task.** Find the first `[ ]` `[sonnet]`-tagged item
+   in `## Open` whose:
+   - **Owner** is `free` (or your worktree name)
+   - **Blocked by** is empty (or only references already-merged work)
+   - **Title is NOT referenced in any open PR's title or branch name**
+     (cross-check with the `gh pr list` output)
+
+   Print the task and explain why you picked it.
+
+3. **Claim it.** Flip `[ ]` → `[~]`, set Owner to your worktree name.
+   Commit that edit as the first commit on your work branch (the
+   branch the worktree is already on — it was prepared fresh by
+   `fleet-up` or `start-next-task`).
+
+4. **Work it.** Read every `CLAUDE.md` on the path to the file(s) you
+   touch first. Follow naming conventions, the no-`getComponent`-in-tick
+   rule, early returns, `unique_ptr` over `shared_ptr`, and the rest of
+   the engine style guide.
+
+5. **Build and run.**
+   `cmake --build build --target <name> -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)`.
+   If the touched code has an executable target, run it once. Untested
+   commits are the single biggest waste of reviewer-agent time.
+
+6. **Stop and escalate if the task is subtler than expected.** If the
+   work touches:
+   - Core ECS types (`engine/entity/`)
+   - Render pipeline state, GPU buffer lifetime, shader compilation
+   - Concurrency, threading, or anything race-prone
+   - The public `ir_*.hpp` surface across multiple modules
+   - Lifetime/ownership decisions
+
+   STOP. Requeue the task as `[opus]` with a note in **Notes:**
+   ("escalated from sonnet — touches X invariant, deferring to opus
+   architect"). Open a queue-update PR with the requeue. Move on to the
+   next task.
+
+7. **Open the PR.** Use the `commit-and-push` skill. Paste the PR URL.
+
+8. **Reset.** Use the `start-next-task` skill to land on a fresh branch
+   off `origin/master`. Loop back to step 1.
+
+If Mode above is `dry-run`: do exactly **one** task end-to-end (steps
+1-7), print the PR URL, then stop and wait for human instruction. Do
+not loop.
+
+## Usage-limit handling
+
+If you hit a usage-limit error:
+1. Print the error and the stated reset time.
+2. Wait until that reset time.
+3. Resume from where you stopped.
+
+Do NOT switch to `/model opus` to keep working — that defeats the
+budget split. Just wait.
+
+## Hard rules
+
+- Never `git push origin master`. Never `--force`. Never call
+  `gh pr merge`. The human merges.
+- Never run `cmake --preset` — only `cmake --build` against the
+  already-configured tree.
+- Never touch the `.claude/worktrees/` layout.
+- Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
+  `xcode-select` — those are human-initiated.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -1,0 +1,83 @@
+---
+description: Sonnet first-pass PR reviewer — polls open PRs and posts structured reviews
+---
+
+You are the **Sonnet first-pass reviewer** for the Irreden Engine
+fleet, running in
+`~/src/IrredenEngine/.claude/worktrees/sonnet-reviewer` (host can be
+WSL2 Ubuntu or macOS).
+
+Mode (optional argument): $ARGUMENTS
+
+## Role
+
+You poll open PRs on `github.com/jakildev/IrredenEngine`, run the
+`review-pr` skill on any that have not been reviewed by this fleet
+yet, and post a structured first-pass review. You also flag PRs that
+need an Opus final pass.
+
+You are NOT an author. You never commit, push, or open PRs from this
+worktree. The `review-pr` skill documents this as an anti-pattern;
+treat it as a hard rule for this role.
+
+## Startup actions
+
+1. `pwd` — confirm you are in the `sonnet-reviewer` worktree.
+2. Confirm you are on the throwaway branch:
+   `git branch --show-current` should report something like
+   `review-scratch-sonnet`. If not, run
+   `git fetch origin && git checkout -B review-scratch-sonnet origin/master`.
+   `gh pr checkout` will rewrite this branch on each review.
+3. `gh pr list --state open --json number,title,headRefName,author,reviews`
+   — print the result so we both see the current PR queue.
+4. List the PRs that have **no review yet from this fleet** (filter
+   out PRs whose `reviews` array contains a review by your GitHub
+   user). These are your candidates.
+
+## Loop behavior
+
+Default: run continuously until the human stops you or you hit a
+usage limit. Each iteration:
+
+1. Re-fetch the PR list with `gh pr list ...`.
+2. For each unreviewed PR, in oldest-first order:
+   a. Invoke the `review-pr` skill with the PR number.
+   b. The skill checks out the PR, reads the diff in context, writes
+      a structured review, and posts it.
+   c. The review body MUST end with one of these explicit lines:
+      - `Opus recheck not required.`
+      - `Opus recheck required: <reason>` — use this if the PR touches
+        any of: `engine/render/`, `engine/entity/`, `engine/system/`,
+        `engine/world/`, `engine/audio/`, `engine/video/`, non-trivial
+        `engine/math/`, public `ir_*.hpp` surface across multiple
+        modules, lifetime/ownership decisions, or concurrency. Also
+        flag for Opus recheck if you're uncertain — better to escalate
+        than to approve something subtle by mistake.
+3. After the queue is drained, wait 10 minutes, then loop.
+4. If you hit a usage-limit error: print the error and reset time,
+   wait, resume.
+
+If Mode above is `dry-run`: review exactly **one** PR end-to-end
+(complete one iteration of step 2 with one PR), then stop and wait
+for human instruction. Do not loop.
+
+## Escalation
+
+- A PR that looks structurally broken (wrong file edited, force-pushed
+  over master, mass deletions): post a "needs revision — please
+  reopen scoped" review and **also** flag it for Opus recheck and
+  call out the human in the body.
+- A PR whose intent is unclear from the diff alone: post questions
+  rather than guessing.
+- A PR that touches `.claude/worktrees/` layout, force pushes, or
+  bypasses hooks (`--no-verify`): hard-reject with a "needs revert"
+  comment and flag for Opus recheck.
+
+## Hard rules
+
+- Never commit, push, or open PRs from this worktree.
+- Never `gh pr merge` — the human merges.
+- Never `gh pr review --approve` from this role; use
+  `--request-changes` or `--comment`. The Opus reviewer is the only
+  agent allowed to approve.
+- Never `git push --force` (you have no reason to push at all).

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ creations/*
 !creations/demos/
 !creations/demos/**
 
-# claude code: share skills, ignore worktrees and local session state
+# claude code: share skills + role slash commands, ignore worktrees and local session state
 .claude/*
 !.claude/skills/
 !.claude/skills/**
+!.claude/commands/
+!.claude/commands/**

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,21 +7,58 @@ append here, and the next unblocked item is what an idle agent should pick up.
 
 1. **Picking a task:** skim the `## Open` section. Find the first `[ ]` item
    whose **Owner** is `free` or your worktree name, and whose **Blocked by**
-   list is empty. Change its status to `[~]` (in progress), set Owner to your
-   worktree, and push the edit in your first commit so other agents see it.
+   list is empty. **Then cross-check `gh pr list --state open`** — if any
+   open PR's title or branch name looks like it's already working on that
+   task, skip to the next candidate. The open-PR list is the authoritative
+   claim signal; the `[~]` flip on a feature branch is invisible to other
+   agents until merge, so two agents can race to claim the same task in the
+   ~minutes-to-hours window between picking and merging. Cross-checking
+   `gh pr list` closes most of that race.
+
+   Once you've picked, change the status to `[~]` (in progress), set Owner
+   to your worktree, and push the edit in your first commit so other agents
+   see it once your PR merges.
 2. **Finishing a task:** change `[~]` to `[x]`, set the final commit or PR
    URL in the **Links** line, and move the item to `## Done — last 20` at
    the bottom. Keep only the last 20 done items; prune older ones.
 3. **Adding a task:** append to `## Open` with the template below. Err on the
    side of creating small tasks (one PR's worth of work). If a task needs
    research first, file it as `Research:` — the deliverable is a short
-   findings note, not code.
+   findings note, not code. The fastest way to add a task is to ask the
+   `queue-manager` pane in the fleet — paste a rough description and it
+   will categorize, tag, format, and file the queue-update PR for you.
 4. **Blocking on another task:** put the blocking task's title in
-   **Blocked by**. An agent should skip blocked items.
+   **Blocked by**. An agent should skip blocked items. For cross-repo
+   blocks (game blocked on engine), put the engine PR URL in **Blocked by**
+   so any agent can resolve it without context.
 5. **Touching this file:** always stage and commit `TASKS.md` edits in the
-   same PR as the work they describe, so history stays consistent. Don't
-   land a TASKS change as its own drive-by PR unless it's purely queue
-   maintenance.
+   same PR as the work they describe, so history stays consistent.
+   Queue-maintenance-only PRs (e.g. `queue: add task X`, batched task
+   adds) are also explicitly allowed and merge fast.
+
+### Race conditions and how the fleet handles them
+
+`TASKS.md` is git-versioned, which means an agent's `[~]` claim only
+becomes visible to other agents after its PR merges. Between picking and
+merging, two agents can independently pick the same task. The fleet
+defends against this in three layers:
+
+1. **Pre-pick `gh pr list` cross-check** (rule 1 above) — closes most
+   of the window.
+2. **Merge conflict on the second `[~]` flip** — both PRs edit the same
+   line in `TASKS.md`, so whichever one merges second will hit a
+   GitHub-side merge conflict and refuse to auto-merge. The human
+   reviewer sees the conflict before merging and rejects the loser.
+3. **Loser requeues and picks again** — the agent whose PR conflicts
+   uses `start-next-task` to reset to a fresh branch off `origin/master`,
+   picks the next available task, and moves on. The work isn't lost; it
+   just gets rescheduled.
+
+Don't try to engineer this away with file locking or external state. The
+PR-list cross-check plus GitHub's merge-conflict detection handles it
+cheaply. If collisions become frequent enough to be painful, the upgrade
+path is GitHub Issues as the queue with labels for claims — but only do
+that when the pain is real.
 
 This file is the **engine-level** task queue. Private creations that live
 under `creations/` may define their own `TASKS.md` inside their own

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -350,21 +350,35 @@ clone gets its own independent set of worktrees — they don't share.
 
 A reasonable starting setup with the model split in mind:
 
-| Worktree              | Model  | Role                                |
-|-----------------------|--------|-------------------------------------|
-| `opus-architect`      | Opus   | Core engine work, ECS/render/audio  |
-| `sonnet-fleet-1`      | Sonnet | TASKS.md items, tests, docs         |
-| `sonnet-fleet-2`      | Sonnet | TASKS.md items, tests, docs         |
-| `sonnet-reviewer`     | Sonnet | First-pass PR review                |
-| `opus-reviewer`       | Opus   | Second-pass review + merge sign-off |
+| Worktree            | Repo   | Model  | Role                                                |
+|---------------------|--------|--------|-----------------------------------------------------|
+| `opus-architect`    | engine | Opus   | Core engine work, ECS/render/audio. Stand-by.       |
+| `sonnet-fleet-1`    | engine | Sonnet | TASKS.md `[sonnet]` items, tests, docs              |
+| `sonnet-fleet-2`    | engine | Sonnet | TASKS.md `[sonnet]` items, tests, docs              |
+| `sonnet-reviewer`   | engine | Sonnet | First-pass PR review (polling loop)                 |
+| `opus-reviewer`     | engine | Opus   | Final review on flagged PRs (polling loop)          |
+| `queue-manager`     | engine | Sonnet | Task intake — categorizes and files new tasks       |
+| `game-architect`    | game   | Opus   | Game-side architect / stand-by, cross-repo aware    |
 
-Create them once. Each worktree needs its own seed branch — git
-refuses to check out `master` in a second worktree while the main
-clone still has it checked out, so we create each worktree on a
-`fleet/<role>` branch that starts from `origin/master`. The seed
-branch is just a parking spot; `start-next-task` moves the worktree
-off it onto a real `claude/<area>-<topic>` branch as soon as the
-first task starts.
+The first six live in `~/src/IrredenEngine/.claude/worktrees/`. The
+last (`game-architect`) lives inside the game repo at
+`~/src/IrredenEngine/creations/game/.claude/worktrees/game-architect`,
+because the game is its own git repo with its own PR namespace.
+
+You don't have to create these by hand — `fleet-up` (described in §5)
+creates any missing worktrees on first run. The manual `git worktree
+add` commands below are documented for completeness, in case you want
+to bootstrap by hand or recover from a broken state.
+
+Each worktree needs its own seed branch — git refuses to check out
+`master` in a second worktree while the main clone still has it
+checked out, so we create each worktree on a `fleet/<role>` branch
+that starts from `origin/master`. The seed branch is just a parking
+spot; `fleet-up` resets it to a fresh `claude/<role>-scratch` branch
+on every invocation, and `start-next-task` will move it onto a real
+`claude/<area>-<topic>` branch as soon as a task starts.
+
+Manual bootstrap (only if `fleet-up` won't be doing it):
 
 ```bash
 cd ~/src/IrredenEngine
@@ -375,6 +389,11 @@ git worktree add -b fleet/sonnet-fleet-1  .claude/worktrees/sonnet-fleet-1  orig
 git worktree add -b fleet/sonnet-fleet-2  .claude/worktrees/sonnet-fleet-2  origin/master
 git worktree add -b fleet/sonnet-reviewer .claude/worktrees/sonnet-reviewer origin/master
 git worktree add -b fleet/opus-reviewer   .claude/worktrees/opus-reviewer   origin/master
+git worktree add -b fleet/queue-manager   .claude/worktrees/queue-manager   origin/master
+
+cd ~/src/IrredenEngine/creations/game
+git fetch origin master
+git worktree add -b fleet/game-architect  .claude/worktrees/game-architect  origin/master
 ```
 
 Verify:
@@ -383,10 +402,13 @@ Verify:
 git worktree list
 ```
 
-You should see the main clone on `master` plus five worktrees each on
-their own `fleet/*` seed branch. The `fleet/` prefix keeps these
-distinct from `claude/<area>-<topic>` agent branches so `gh pr list`
-and branch-completion never confuse them.
+You should see the main clone on `master` plus six engine worktrees
+(`opus-architect`, `sonnet-fleet-1`, `sonnet-fleet-2`, `sonnet-reviewer`,
+`opus-reviewer`, `queue-manager`) each on their own `fleet/*` seed
+branch, plus a seventh `game-architect` worktree under
+`creations/game/` if the game repo is present. The `fleet/` prefix
+keeps these distinct from `claude/<area>-<topic>` agent branches so
+`gh pr list` and branch-completion never confuse them.
 
 These worktrees live forever. Each agent session opens the worktree
 it wants and the `start-next-task` skill creates a fresh
@@ -413,15 +435,28 @@ no persistent role in the fleet.
 
 ## 5. tmux session layout
 
-tmux is how you keep all five fleet sessions visible and
-attachable/detachable from one terminal, on either host. A simple
-starting layout is one tmux session named `fleet` with one window per
-worktree role. On macOS, if you want `pbcopy`/`pbpaste` to work inside
-tmux, also `brew install reattach-to-user-namespace` — otherwise the
-tmux config below works identically on both hosts.
+tmux is how you keep all the fleet agents visible and
+attachable/detachable from one terminal, on either host. The `fleet-up`
+script creates **one tmux session** named `fleet` with **one window**
+named `agents` containing **seven tiled panes** — one per worktree
+role — and auto-launches `claude` in each pane with the matching
+**role slash command**.
 
-First-time setup: drop a minimal `~/.tmux.conf` that makes prefix `C-a`
-(easier to reach than default `C-b`) and gives you mouse scroll:
+**Key terminology:** in tmux a *window* fills the whole terminal (only
+one shows at a time); a *pane* is a split inside a window. The fleet
+uses one window with multiple panes so you can see all agents
+simultaneously. The default tmux prefix is `C-b` (Ctrl+B); the config
+below remaps it to `C-a` (Ctrl+A) which is easier to reach. **`C-a`
+means hold Control, press A.**
+
+On macOS, if you want `pbcopy`/`pbpaste` to work inside tmux, also
+`brew install reattach-to-user-namespace` — otherwise the tmux config
+below works identically on both hosts.
+
+### Step 5a — `~/.tmux.conf`
+
+First-time setup: drop a minimal `~/.tmux.conf` that makes prefix
+`C-a` and gives you mouse scroll:
 
 ```bash
 cat > ~/.tmux.conf <<'EOF'
@@ -436,60 +471,125 @@ set -g status-right "#(whoami)@#H | %Y-%m-%d %H:%M"
 EOF
 ```
 
-Create a helper script that spins up the whole fleet layout in one
-command. Save as `~/bin/fleet-up`:
+### Step 5b — role slash commands at `~/.claude/commands/`
+
+Each pane in the fleet runs `claude` with a role-specific slash command
+as its initial prompt. The role files live at:
+
+- `~/.claude/commands/role-opus-architect.md`
+- `~/.claude/commands/role-sonnet-author.md`
+- `~/.claude/commands/role-sonnet-reviewer.md`
+- `~/.claude/commands/role-opus-reviewer.md`
+- `~/.claude/commands/role-queue-manager.md`
+- `~/.claude/commands/role-game-architect.md`
+
+Each one is a markdown file with frontmatter that Claude Code
+auto-discovers and exposes as a slash command (`/role-opus-architect`,
+etc.). Inside Claude, typing the command at the prompt is the same as
+the agent receiving that command's body as instructions.
+
+The same files are also checked into the repos for version control:
+- engine: `.claude/commands/role-*.md` (everything except game-architect)
+- game: `.claude/commands/role-game-architect.md`
+
+Treat the in-repo copies as the source of truth and the user-level
+copies (`~/.claude/commands/`) as the runtime cache. If you edit one,
+copy to the other:
 
 ```bash
-mkdir -p ~/bin
-cat > ~/bin/fleet-up <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-
-REPO="$HOME/src/IrredenEngine"
-SESSION="fleet"
-
-if tmux has-session -t "$SESSION" 2>/dev/null; then
-    echo "fleet session already exists — attach with: tmux attach -t $SESSION"
-    exit 0
-fi
-
-# opus-architect: first window
-tmux new-session -d -s "$SESSION" -n opus-arch \
-    -c "$REPO/.claude/worktrees/opus-architect"
-
-# sonnet fleet and reviewers in subsequent windows
-tmux new-window -t "$SESSION":2 -n sonnet-1 \
-    -c "$REPO/.claude/worktrees/sonnet-fleet-1"
-tmux new-window -t "$SESSION":3 -n sonnet-2 \
-    -c "$REPO/.claude/worktrees/sonnet-fleet-2"
-tmux new-window -t "$SESSION":4 -n sonnet-rev \
-    -c "$REPO/.claude/worktrees/sonnet-reviewer"
-tmux new-window -t "$SESSION":5 -n opus-rev \
-    -c "$REPO/.claude/worktrees/opus-reviewer"
-
-tmux select-window -t "$SESSION":1
-echo "fleet session created. attach with: tmux attach -t $SESSION"
-EOF
-chmod +x ~/bin/fleet-up
+# repo → runtime
+cp ~/src/IrredenEngine/.claude/commands/role-*.md ~/.claude/commands/
+cp ~/src/IrredenEngine/creations/game/.claude/commands/role-*.md ~/.claude/commands/
 ```
 
-Add `~/bin` to PATH if it isn't already (`echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc`).
+(A later improvement would be a `sync-roles` script or git hook; for
+now, manual cp is fine.)
 
-After that, the daily ritual is:
+### Step 5c — `~/bin/fleet-up`
+
+The `fleet-up` script does four things in order:
+
+1. Ensures all 7 worktrees exist (creates any that are missing).
+2. Resets each worktree to a fresh branch off `origin/master`,
+   skipping any that have uncommitted changes.
+3. Creates the tmux session with 7 tiled panes.
+4. In each pane, runs `claude --model <m> "/role-<role> dry-run"`
+   with the appropriate model and role.
+
+Source lives at `~/bin/fleet-up`. The current version handles all of
+the above; if you need to recreate it from scratch, the relevant
+shape is:
 
 ```bash
-fleet-up                # creates the tmux session with one window per worktree
+#!/usr/bin/env bash
+set -euo pipefail
+ENGINE="$HOME/src/IrredenEngine"
+GAME="$ENGINE/creations/game"
+SESSION="fleet"
+MODE="${1:-dry-run}"
+
+# (1) ensure worktrees, (2) reset to fresh branches, (3) tmux session
+# with 7 tiled panes, each running:
+#     claude --model <m> "/role-<role> ${MODE}"; exec $SHELL
+```
+
+The trailing `exec $SHELL` keeps the pane alive with a usable shell
+if claude exits or errors out, instead of letting the pane vanish.
+
+Make sure `~/bin` is on PATH:
+
+```bash
+echo 'export PATH="$HOME/bin:$PATH"' >> ~/.zshrc   # or ~/.bashrc
+```
+
+### Step 5d — daily ritual
+
+```bash
+fleet-up                # creates the session, prepares worktrees, launches claude in each pane
 tmux attach -t fleet    # attach to it
 ```
 
-Inside each window, launch Claude Code with the role in mind:
+By default `fleet-up` starts every agent in **dry-run mode**. Each
+agent runs its startup actions (fetch, read TASKS, list open PRs,
+print a summary) and then **stands by** for explicit human
+instruction. This is the safe default — no work happens until you
+authorize it.
+
+When you've validated everything looks healthy, promote a pane to its
+normal loop by typing in it:
+
+> exit dry-run mode and begin your normal loop
+
+You can also start the whole fleet in live mode from the get-go:
 
 ```bash
-claude                  # starts a session in the current worktree directory
+fleet-up live           # all panes go straight to their normal loop
 ```
 
-Navigate windows with `C-a 1` / `C-a 2` / … or cycle with `C-a n`.
-Detach with `C-a d`, reattach later with `tmux attach -t fleet`.
+Don't do that until you've successfully run `fleet-up dry-run` end to
+end at least once on this machine.
+
+### Tmux navigation cheat sheet
+
+Prefix is `C-a` (Ctrl+A). To send a command, hold Control, press A,
+release, then press the next key.
+
+| Binding             | Effect                                            |
+|---------------------|---------------------------------------------------|
+| `C-a d`             | detach (leaves session running)                   |
+| `C-a` then arrow    | move focus between panes                          |
+| `C-a o`             | cycle panes                                       |
+| `C-a z`             | zoom/unzoom current pane (fullscreen toggle)      |
+| `C-a space`         | cycle pane layouts (tiled / even-horizontal / …)  |
+| `C-a %`             | split pane vertical                               |
+| `C-a "`             | split pane horizontal                             |
+| `C-a {` / `C-a }`   | swap current pane with prev/next                  |
+| `C-a x`             | kill current pane (confirms)                      |
+| `C-a [`             | enter scroll/copy mode (`q` to exit)              |
+| `C-a ?`             | list all bindings                                 |
+| mouse               | click focuses, drag borders resizes, wheel scrolls |
+
+Reattach after a detach: `tmux attach -t fleet`.
 
 ### Persistence across reboots (optional)
 
@@ -925,29 +1025,106 @@ translation cheatsheet.
 
 ---
 
-## 12. Session starter prompts
+## 12. Role slash commands (replaces the old paste-prompts ritual)
 
-When kicking off a worktree session in its tmux window, start with a
-one-liner that tells the agent which role it's in, and which host it
-is running on (so it knows which preset to build against). Examples:
+Each fleet pane runs `claude` with a **role slash command** as its
+initial prompt. The role files at `~/.claude/commands/role-*.md`
+define what each agent does, in much more detail than a one-line
+prompt — they include startup actions, the loop the agent runs, the
+escalation rules, the hard rules, and a `dry-run` mode.
 
-- **Opus architect session:**
-  > "You are the Opus architect agent in `~/src/IrredenEngine/.claude/worktrees/opus-architect`, running on `<WSL/Ubuntu | macOS>`. Pick the next unblocked `[opus]` task from `TASKS.md`, complete it, and open a PR via the `commit-and-push` skill. Build the target you touched with `cmake --build build --target <name>` (use `-j$(nproc)` on WSL or `-j$(sysctl -n hw.ncpu)` on macOS) and run the relevant executable before declaring done."
+You don't need to paste prompts into each pane every morning anymore.
+`fleet-up` does it for you: each pane is launched with
+`claude --model <m> "/role-<role> dry-run"` baked in. The role files
+are the source of truth for agent behavior; if an agent is doing the
+wrong thing repeatedly, edit its role file once and the change applies
+to every future fleet-up.
 
-- **Sonnet fleet session:**
-  > "You are a Sonnet fleet agent in `~/src/IrredenEngine/.claude/worktrees/sonnet-fleet-1`, running on `<WSL/Ubuntu | macOS>`. Pick the next unblocked `[sonnet]` task from `TASKS.md`, complete it, and open a PR via the `commit-and-push` skill. If the task turns out to touch core engine invariants (rendering, ECS, ownership, concurrency), stop and requeue it as `[opus]` with a note instead of charging ahead. Build and run before declaring done."
+### Available roles
 
-- **Sonnet reviewer session:**
-  > "You are a Sonnet first-pass reviewer in `~/src/IrredenEngine/.claude/worktrees/sonnet-reviewer`, running on `<WSL/Ubuntu | macOS>`. Review the oldest unreviewed open PR using the `review-pr` skill. Post a first-pass review and end with an explicit escalation line saying whether Opus recheck is required."
+| Slash command              | Model  | Worktree           | Loop?         |
+|----------------------------|--------|--------------------|---------------|
+| `/role-opus-architect`     | Opus   | `opus-architect`   | Stand-by      |
+| `/role-sonnet-author`      | Sonnet | `sonnet-fleet-*`   | Continuous    |
+| `/role-sonnet-reviewer`    | Sonnet | `sonnet-reviewer`  | Polling 10min |
+| `/role-opus-reviewer`      | Opus   | `opus-reviewer`    | Polling 30min |
+| `/role-queue-manager`      | Sonnet | `queue-manager`    | On demand     |
+| `/role-game-architect`     | Opus   | `game-architect`   | Stand-by      |
 
-- **Opus reviewer session:**
-  > "You are the Opus final reviewer in `~/src/IrredenEngine/.claude/worktrees/opus-reviewer`, running on `<WSL/Ubuntu | macOS>`. Review any open PR that has a Sonnet first-pass review flagged for Opus escalation, or any open PR touching core engine invariants. Post a final review and, if approving, use `gh pr review <N> --approve`. Do not merge — I merge."
+Each command takes one optional argument: `dry-run` or `live`.
+`dry-run` means "do startup actions and then stop." `live` (or no
+argument when invoked from inside an interactive session) means "run
+your normal loop."
 
-- **Backend-parity session (Mac or WSL, whichever lags):**
-  > "You are running on `<macOS | WSL/Ubuntu>` to bring the `<Metal | OpenGL>` backend into parity with the leading side. Run the `backend-parity` skill. Either pick a specific PR/commit range the user gives you, or do a full audit if they said 'audit'. Port one logical feature per PR, build-clean and smoke-run the target on this host, then open the PR via `commit-and-push`."
+### Role file shape (for editing)
 
-Save these as Claude Code custom commands (or just paste them) so you
-don't retype them each morning.
+The role files are markdown with frontmatter:
+
+```markdown
+---
+description: <short description shown in /help>
+---
+
+You are the <role> for the fleet, running on macOS in <worktree>.
+
+Mode (optional argument): $ARGUMENTS
+
+## Responsibilities
+...
+
+## Startup actions
+...
+
+## Loop behavior
+...
+
+## Hard rules
+...
+```
+
+`$ARGUMENTS` is substituted with whatever was passed to the slash
+command — that's how `dry-run` vs `live` flows through.
+
+To edit a role's behavior:
+
+```bash
+$EDITOR ~/src/IrredenEngine/.claude/commands/role-sonnet-author.md
+# then mirror to runtime location:
+cp ~/src/IrredenEngine/.claude/commands/role-sonnet-author.md \
+   ~/.claude/commands/
+```
+
+The next `fleet-up` (or any new `claude "/role-..."` invocation) picks
+up the change.
+
+### Inserting a task while the fleet is running
+
+If you want to add a task to the queue while agents are working:
+
+1. Switch to the `queue-manager` pane (`C-a` then click, or `C-a` then
+   arrow keys).
+2. Type a rough description of the task. Don't worry about format,
+   tags, or repo — just describe what you want done.
+3. The queue-manager will categorize (engine vs game), tag (`[opus]`
+   vs `[sonnet]`), pick an Area, draft the entry using the TASKS.md
+   template, and open a queue-update PR. Paste the PR URL.
+4. Once the queue PR merges, the next sonnet-fleet pane on its
+   `start-next-task` cycle will see the new task and pick it up
+   automatically.
+
+The queue-manager will push back if your description is missing a
+concrete Acceptance criterion. That's intentional — tasks without
+acceptance checks are tasks that get half-finished.
+
+### Backend-parity sessions (still ad-hoc, not a fleet pane)
+
+`backend-parity` work isn't a permanent role — it's run on demand on
+whichever host is lagging. From any worktree on the lagging host,
+just type:
+
+> Run the backend-parity skill. <pick a feature, PR range, or "audit">
+
+The skill flow is documented in `.claude/skills/backend-parity/SKILL.md`.
 
 ---
 
@@ -967,30 +1144,178 @@ A few things should stay manual even with a fleet running:
   the apt list in this document.
 - **Editing this document.** (Or they can, but you sign off.)
 
-The `commit-and-push` and `review-pr` skills enforce most of this, but
-a human check is the last line of defense.
+The `commit-and-push` and `review-pr` skills document most of this as
+hard-rule anti-patterns, and the role files reinforce them, but a human
+check is the last line of defense.
 
 ---
 
-## 14. Dry run
+## 14. Dry run — first time bringing up the fleet
 
-Before handing work to the fleet, do one manual end-to-end run with
-yourself in the loop:
+Before handing real work to the fleet, do one manual end-to-end run
+with yourself in the loop. The point is to uncover workflow bugs in
+the role files, the skills, or the permissions setup — not to
+complete an actual task. Anything that breaks here is a real fleet
+bug worth fixing before unattended runs.
 
-1. `fleet-up && tmux attach -t fleet`
-2. In the `opus-arch` window, run `claude` and ask it to pick the
-   example `TASKS.md` item (`benchmark IRShapeDebug at zoom 4`) and
-   work through it.
-3. Watch the `commit-and-push` skill open a PR.
-4. `C-a 4` → `sonnet-rev` window → `claude` → ask it to review the
-   PR.
-5. `C-a 5` → `opus-rev` window → `claude` → ask it to re-review.
-6. Merge manually on GitHub.
-7. Back in `opus-arch`, run `start-next-task`, verify the branch
-   resets cleanly.
+### Step 1 — bring the fleet up in dry-run mode
 
-If any of those steps fail, fix the skill — not the task. The point of
-the dry run is to uncover workflow bugs, not to complete a task.
+```bash
+fleet-up                # defaults to dry-run mode
+tmux attach -t fleet
+```
+
+Each pane will:
+1. Start `claude` with the right model.
+2. Auto-execute its `/role-<x> dry-run` command.
+3. The agent does its startup actions: `git fetch`, reads `TASKS.md`,
+   runs `gh pr list`, prints a one-line summary.
+4. The agent prints `<role> standing by (dry-run)` and waits.
+
+Walk through every pane (`C-a` then arrow, or click) and confirm
+each one printed its standing-by line. If any pane shows an error
+instead, that's the first thing to fix.
+
+### Step 2 — drive one author task through the full cycle
+
+Switch to **sonnet-fleet-1** and type:
+
+> exit dry-run mode and do exactly ONE task end-to-end. Pick the
+> "Example: unit tests for engine/math/physics.hpp" task — it's
+> bounded, sonnet-tagged, and has a concrete acceptance check.
+> Build with `-j$(nproc 2>/dev/null || sysctl -n hw.ncpu)`. After
+> `commit-and-push`, stop and wait — do not pick another task or loop.
+
+Watch the agent:
+- Cross-check `gh pr list` (it should mention this in its picking step).
+- Flip the task to `[~]` in `TASKS.md` and commit.
+- Read `engine/math/CLAUDE.md` for the helper specs.
+- Write the test file, build the test target, run it.
+- Call `commit-and-push`. A PR opens.
+- Stop and print the PR URL.
+
+If the agent prompts for permission on commands that should be in
+your allowlist, **note them down** — they go into `~/.claude/settings.json`
+(or your `permissions.allow` list) for next time. Don't fix them mid-run;
+finish the dry run first.
+
+### Step 3 — watch the Sonnet reviewer pick it up
+
+Switch to **sonnet-reviewer** and type:
+
+> exit dry-run mode and review exactly ONE PR — the one sonnet-fleet-1
+> just opened. Use the `review-pr` skill. End with the explicit
+> "Opus recheck not required" or "Opus recheck required" line. Stop
+> after the review posts.
+
+Watch the agent:
+- `gh pr checkout` the new PR.
+- Read the diff in context.
+- Post a structured review via `review-pr`.
+- End with the recheck-line. For physics tests it should be
+  "Opus recheck not required" — physics.hpp is math-only and touches no
+  invariants.
+
+### Step 4 — Opus reviewer stays idle (no escalation)
+
+Switch to **opus-reviewer**. It should still be standing by — the
+Sonnet review didn't flag for Opus recheck, so there's nothing for
+Opus to do. Confirm the pane is healthy and waiting.
+
+### Step 5 — you merge
+
+From a separate terminal (or any pane that isn't running an agent —
+`C-a c` to open a fresh window inside the fleet session):
+
+```bash
+gh pr merge <N> --squash
+```
+
+Or merge through the GitHub web UI. **Agents never merge.**
+
+### Step 6 — test `start-next-task`
+
+Switch back to **sonnet-fleet-1** and type:
+
+> run the `start-next-task` skill
+
+It should rebase onto the merged master, land on a fresh `claude/...`
+branch, and the `[x]` Done move from the merged PR should now be
+visible in `TASKS.md`.
+
+### Step 7 — test the queue-manager
+
+Switch to **queue-manager** and type a rough task:
+
+> add a task: I want exhaustive tests for engine/common/ir_constants.hpp.
+> Sonnet should be able to handle this. Acceptance is "test binary
+> builds and all assertions pass".
+
+Watch the queue-manager:
+- Categorize as engine repo, `[sonnet]`, area `engine/common`.
+- Format the task using the template.
+- Append to `TASKS.md`.
+- Call `commit-and-push` with a `queue: add task ...` PR.
+- Paste the PR URL.
+
+This validates the task-intake flow. You can merge that queue PR
+or close it — the point was to see the flow work, not to land the
+task.
+
+### Step 8 — test the game-architect (cross-repo awareness)
+
+Switch to **game-architect** and type:
+
+> read the engine TASKS.md and the game TASKS.md, then describe a
+> hypothetical game task that would require an engine change. Don't
+> file it — just walk me through what the cross-repo flow would look
+> like.
+
+The game-arch should:
+- Reference the cross-repo escalation flow from the game `CLAUDE.md`.
+- Explain that it would file the engine task FIRST, then the blocked
+  game task with `Blocked by:` pointing at the engine PR URL.
+- NOT actually file anything.
+
+This validates the agent has read the game `CLAUDE.md` correctly.
+
+### What to look for
+
+- Did `commit-and-push` open a PR cleanly without permission prompts?
+- Did `review-pr` check out the PR, post the review, and detach cleanly?
+- Did the `[~]` → `[x]` move land in the merged commit, and did the
+  Done list pick it up?
+- Did `gh pr list` show the claim quickly enough that
+  `sonnet-fleet-2` would not have picked the same task?
+  (Test: while sonnet-fleet-1 is mid-task, switch to sonnet-fleet-2
+  and ask it to "list candidate tasks." It should NOT include the
+  in-flight task.)
+- Did the build go cleanly with
+  `-j$(nproc 2>/dev/null || sysctl -n hw.ncpu)`? On macOS,
+  hitting an Objective-C++ flag, missing Metal shader, or FFmpeg
+  `pkg-config` issue is realistic on first run; on Linux/WSL, expect
+  case-sensitive include drift, missing `#include` for headers Windows
+  was transitively pulling in, and EOL trouble. Either way, when it
+  happens, file the build break as its own task per §10 rather than
+  working around it.
+
+### After the dry run
+
+If everything went clean, you can promote the fleet to live mode:
+
+```bash
+tmux kill-session -t fleet
+fleet-up live
+tmux attach -t fleet
+```
+
+All panes will start their normal continuous loops immediately. You
+can then walk away (or watch) and let the fleet drain `TASKS.md`
+overnight.
+
+If something broke, fix the role file, the skill, or the permissions
+list — and run the dry run again. Don't go to `fleet-up live` until
+the dry run passes end-to-end.
 
 ---
 


### PR DESCRIPTION
## Summary
- Move all six fleet role prompts into versioned `.claude/commands/role-*.md` slash commands so `fleet-up` can launch each pane with `claude --model X "/role-Y dry-run"` instead of pasting a long prompt every morning. Five engine roles ship here (`opus-architect`, `sonnet-author`, `sonnet-reviewer`, `opus-reviewer`, `queue-manager`); the sixth (`game-architect`) lives in the game repo.
- Tighten `TASKS.md` rule 1 to require a `gh pr list --state open` cross-check before claiming a task. The `[~]` flip on a feature branch is invisible to other agents until merge — the open-PR list is the real claim signal. New "Race conditions" subsection documents the three-layer defense: pre-pick PR-list check, GitHub merge-conflict detection on the second `[~]` flip, loser requeues via `start-next-task`.
- Rewrite `docs/AGENT_FLEET_SETUP.md` §5 (tmux.conf, slash-command discovery, fleet-up behavior, daily ritual), §12 (role slash-command table replacing the old "session starter prompts"), and §14 (8-step dry-run walkthrough that exercises every pane: sonnet author through full PR cycle, sonnet reviewer pick-up, queue-manager intake, game-architect cross-repo escalation).
- Open `.gitignore` to allow `.claude/commands/` so slash commands ship with the repo.

## Test plan
- [ ] `fleet-up dry-run` brings up all 7 panes with each printing its `standing by (dry-run)` line
- [ ] `cat .claude/commands/role-*.md` resolves from any worktree once this PR merges and the runtime cache at `~/.claude/commands/` is in sync
- [ ] One sonnet-author pane can complete the §14 dry-run end-to-end (pick task, claim, build, commit, PR)
- [ ] `queue-manager` pane can categorize a free-text task description and file a queue-only PR
- [ ] `gh pr list` cross-check prevents two sonnet panes from claiming the same task

## Notes for reviewer
- Check `.claude/commands/role-queue-manager.md` Step 2 against the engine `CLAUDE.md` "Model split" section — they should not drift.
- The game-architect role file is intentionally NOT in this PR; it lives in `creations/game/.claude/commands/role-game-architect.md` because that role operates against `github.com/jakildev/irreden`.
- Build commands in role files use `-j$(nproc 2>/dev/null || sysctl -n hw.ncpu)` so the same role file works on both Linux/WSL fleet hosts and macOS.
- The "Race conditions" subsection credits GitHub's merge-conflict detection (not `commit-and-push` rebase) — `commit-and-push` does not actually rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)