### PR TITLE
fleet: version fleet-up and add per-machine installer

### DIFF
--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -493,54 +493,48 @@ The same files are also checked into the repos for version control:
 - game: `.claude/commands/role-game-architect.md`
 
 Treat the in-repo copies as the source of truth and the user-level
-copies (`~/.claude/commands/`) as the runtime cache. If you edit one,
-copy to the other:
+copies (`~/.claude/commands/`) as the runtime cache. `scripts/fleet/install.sh`
+(described in §5c) creates `~/.claude/commands/role-*.md` as **symlinks**
+into the repo copies — edit the repo file, commit, and every machine
+that has run `install.sh` picks up the new version on its next `git pull`.
+Re-running `install.sh` is only required when a role file is **added**
+or **removed**, not when an existing one is edited.
+
+### Step 5c — `scripts/fleet/install.sh` and `fleet-up`
+
+The fleet launcher and its installer live in the engine repo under
+[`scripts/fleet/`](../scripts/fleet/). Two files:
+
+- **`scripts/fleet/fleet-up`** — the launcher. Does four things in
+  order:
+  1. Ensures all 7 worktrees exist (creates any that are missing).
+  2. Resets each worktree to a fresh branch off `origin/master`,
+     skipping any that have uncommitted changes.
+  3. Creates the tmux session with 7 tiled panes.
+  4. In each pane, runs `claude --model <m> "/role-<role> <mode>"`
+     with the appropriate model and role. Default mode is `dry-run`;
+     pass `live` to skip dry-run.
+- **`scripts/fleet/install.sh`** — the one-time per-machine installer.
+  Symlinks `scripts/fleet/fleet-up` into `~/bin/fleet-up` and symlinks
+  each `.claude/commands/role-*.md` into `~/.claude/commands/`. Picks
+  up `creations/game/.claude/commands/role-game-architect.md` too if
+  the game repo is cloned.
+
+First-time setup on this machine:
 
 ```bash
-# repo → runtime
-cp ~/src/IrredenEngine/.claude/commands/role-*.md ~/.claude/commands/
-cp ~/src/IrredenEngine/creations/game/.claude/commands/role-*.md ~/.claude/commands/
+cd ~/src/IrredenEngine
+scripts/fleet/install.sh
 ```
 
-(A later improvement would be a `sync-roles` script or git hook; for
-now, manual cp is fine.)
+If the installer warns that `~/bin` is not on PATH, add the line it
+prints to your shell startup file (`~/.zprofile` for zsh,
+`~/.bash_profile` for bash) and open a new terminal.
 
-### Step 5c — `~/bin/fleet-up`
-
-The `fleet-up` script does four things in order:
-
-1. Ensures all 7 worktrees exist (creates any that are missing).
-2. Resets each worktree to a fresh branch off `origin/master`,
-   skipping any that have uncommitted changes.
-3. Creates the tmux session with 7 tiled panes.
-4. In each pane, runs `claude --model <m> "/role-<role> dry-run"`
-   with the appropriate model and role.
-
-Source lives at `~/bin/fleet-up`. The current version handles all of
-the above; if you need to recreate it from scratch, the relevant
-shape is:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-ENGINE="$HOME/src/IrredenEngine"
-GAME="$ENGINE/creations/game"
-SESSION="fleet"
-MODE="${1:-dry-run}"
-
-# (1) ensure worktrees, (2) reset to fresh branches, (3) tmux session
-# with 7 tiled panes, each running:
-#     claude --model <m> "/role-<role> ${MODE}"; exec $SHELL
-```
-
-The trailing `exec $SHELL` keeps the pane alive with a usable shell
-if claude exits or errors out, instead of letting the pane vanish.
-
-Make sure `~/bin` is on PATH:
-
-```bash
-echo 'export PATH="$HOME/bin:$PATH"' >> ~/.zshrc   # or ~/.bashrc
-```
+Because `install.sh` uses symlinks, a subsequent `git pull` on the
+engine repo is enough to update both `fleet-up` and the role slash
+commands on every machine — you only need to re-run `install.sh` when
+a new role file is **added** to the repo (or an existing one deleted).
 
 ### Step 5d — daily ritual
 

--- a/scripts/fleet/README.md
+++ b/scripts/fleet/README.md
@@ -1,0 +1,50 @@
+# scripts/fleet/
+
+Launcher and per-machine installer for the Irreden Engine parallel-agent
+fleet workflow.
+
+## Files
+
+- **`fleet-up`** — brings the 7-pane tmux fleet online. Idempotent.
+  Creates any missing worktrees, resets each to a fresh branch off
+  `origin/master`, builds a `fleet` tmux session with one tiled
+  window, and auto-launches `claude` in each pane with the matching
+  role slash command. Default mode is `dry-run` (startup + stand-by);
+  pass `live` to skip dry-run and go straight to the normal loop.
+- **`install.sh`** — one-time setup per machine. Symlinks
+  `scripts/fleet/fleet-up` into `~/bin/fleet-up` and symlinks each
+  `.claude/commands/role-*.md` into `~/.claude/commands/`. Picks up
+  the game-architect role from `creations/game/` if that repo is
+  cloned. Warns (but does not edit) if `~/bin` is not on PATH.
+  Idempotent — re-run after every `git pull` that touches fleet tooling.
+
+Both files are portable across Linux (WSL/Ubuntu) and macOS. Neither
+requires sudo.
+
+## Quick start
+
+```bash
+cd ~/src/IrredenEngine
+scripts/fleet/install.sh
+# (follow the PATH warning if ~/bin isn't on PATH yet)
+fleet-up dry-run
+tmux attach -t fleet
+```
+
+## Updating the fleet across machines
+
+Because `install.sh` uses symlinks, editing `scripts/fleet/fleet-up`
+in the repo and committing it is enough — every machine that has run
+`install.sh` sees the new version on its next `git pull`. Same story
+for the role slash commands under `.claude/commands/role-*.md`.
+
+The only time you need to re-run `install.sh` is when a new file is
+added (or a file is deleted) — `git pull` alone doesn't create new
+symlinks or prune stale ones.
+
+## Full docs
+
+See [`docs/AGENT_FLEET_SETUP.md`](../../docs/AGENT_FLEET_SETUP.md) for
+the complete setup guide: worktree layout, role-to-model split,
+`~/.tmux.conf` template, daily ritual, dry-run walkthrough, permission
+allowlists, and troubleshooting.

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# fleet-up — bring the Irreden Engine + Game agent fleet online.
+#
+# Idempotent. Creates any missing worktrees, resets each to a fresh
+# branch off origin/master (skipping any that have uncommitted work),
+# then builds a single tmux session "fleet" with one window "agents"
+# containing 7 tiled panes — each launching `claude` with the right
+# model and the matching role slash command in dry-run mode.
+#
+# Source of truth: scripts/fleet/fleet-up in the engine repo.
+# Installed to ~/bin/fleet-up (as a symlink) by scripts/fleet/install.sh.
+#
+# Role slash commands live in ~/.claude/commands/role-*.md and are
+# the runtime source. The same files are checked into the engine and
+# game repos under .claude/commands/ for version control;
+# scripts/fleet/install.sh symlinks the repo copies into the runtime
+# location so a git pull updates both sides at once.
+
+set -euo pipefail
+
+ENGINE="$HOME/src/IrredenEngine"
+GAME="$ENGINE/creations/game"
+SESSION="fleet"
+
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "fleet-up: tmux not found. Install tmux (brew install tmux / apt install tmux) first." >&2
+    exit 1
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+    echo "fleet-up: claude CLI not found on PATH." >&2
+    exit 1
+fi
+
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "fleet session already exists — attach with: tmux attach -t $SESSION"
+    echo "(kill with \`tmux kill-session -t $SESSION\` first if you want a fresh layout)"
+    exit 0
+fi
+
+# ----------------------------------------------------------------------
+# Step 1: ensure all worktrees exist
+# ----------------------------------------------------------------------
+
+ensure_worktree() {
+    # $1 = repo root, $2 = worktree subpath relative to repo root,
+    # $3 = branch name to create or attach
+    local repo="$1"
+    local subpath="$2"
+    local branch="$3"
+    local wt="$repo/$subpath"
+
+    if [[ -d "$wt" ]]; then
+        return 0
+    fi
+    echo "fleet-up: creating worktree $wt (branch $branch)"
+    (cd "$repo" && git worktree add "$wt" -b "$branch" origin/master 2>&1 \
+        || git worktree add "$wt" "$branch")
+}
+
+(cd "$ENGINE" && git fetch origin --quiet) || {
+    echo "fleet-up: engine git fetch failed" >&2; exit 1; }
+
+ensure_worktree "$ENGINE" .claude/worktrees/opus-architect    fleet/opus-architect
+ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-1    fleet/sonnet-fleet-1
+ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-2    fleet/sonnet-fleet-2
+ensure_worktree "$ENGINE" .claude/worktrees/sonnet-reviewer   fleet/sonnet-reviewer
+ensure_worktree "$ENGINE" .claude/worktrees/opus-reviewer     fleet/opus-reviewer
+ensure_worktree "$ENGINE" .claude/worktrees/queue-manager     fleet/queue-manager
+
+if [[ -d "$GAME/.git" ]]; then
+    (cd "$GAME" && git fetch origin --quiet) || {
+        echo "fleet-up: game git fetch failed (continuing without game pane)" >&2; }
+    ensure_worktree "$GAME" .claude/worktrees/game-architect  fleet/game-architect
+else
+    echo "fleet-up: game repo not found at $GAME — skipping game pane"
+fi
+
+# ----------------------------------------------------------------------
+# Step 2: reset each worktree to a fresh branch off origin/master
+# ----------------------------------------------------------------------
+
+reset_worktree() {
+    # $1 = worktree path, $2 = scratch branch name to land on
+    local wt="$1"
+    local branch="$2"
+
+    if [[ ! -d "$wt" ]]; then
+        return 0
+    fi
+
+    # Refuse to clobber uncommitted work — the human can clean up first.
+    local dirty
+    dirty="$(cd "$wt" && git status --porcelain 2>/dev/null || echo SKIP)"
+    if [[ -n "$dirty" && "$dirty" != "SKIP" ]]; then
+        echo "fleet-up: $wt has uncommitted changes — leaving as-is."
+        echo "          (commit or stash and rerun fleet-up to reset.)"
+        return 0
+    fi
+
+    echo "fleet-up: resetting $wt -> $branch"
+    (cd "$wt" \
+        && git fetch origin --quiet \
+        && git checkout -B "$branch" origin/master >/dev/null 2>&1) || {
+        echo "fleet-up: failed to reset $wt — leaving as-is" >&2; }
+}
+
+reset_worktree "$ENGINE/.claude/worktrees/opus-architect"  claude/opus-arch-scratch
+reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-1"  claude/sonnet-1-scratch
+reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-2"  claude/sonnet-2-scratch
+reset_worktree "$ENGINE/.claude/worktrees/sonnet-reviewer" review-scratch-sonnet
+reset_worktree "$ENGINE/.claude/worktrees/opus-reviewer"   review-scratch-opus
+reset_worktree "$ENGINE/.claude/worktrees/queue-manager"   claude/queue-manager-scratch
+
+if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
+    reset_worktree "$GAME/.claude/worktrees/game-architect" claude/game-arch-scratch
+fi
+
+# ----------------------------------------------------------------------
+# Step 3: build the tmux session
+# ----------------------------------------------------------------------
+#
+# Each pane execs:
+#     claude --model <m> "/role-<role> <mode>"; exec $SHELL
+#
+# The trailing `exec $SHELL` keeps the pane alive with a usable shell
+# if claude exits or errors out, instead of letting the pane vanish.
+#
+# Default mode: dry-run. The agents do their startup actions and then
+# stand by for human instruction. Promote a pane to full operation by
+# typing in it: "you can stop dry-run mode and start working".
+
+MODE="${1:-dry-run}"
+
+launch_cmd() {
+    # $1 = model alias (opus|sonnet), $2 = role slug (without role- prefix)
+    local model="$1"
+    local role="$2"
+    printf 'claude --model %s "/role-%s %s"; exec $SHELL\n' \
+        "$model" "$role" "$MODE"
+}
+
+# Pane 1: opus-architect
+tmux new-session -d -s "$SESSION" -n agents \
+    -c "$ENGINE/.claude/worktrees/opus-architect" \
+    "$(launch_cmd opus opus-architect)"
+
+# Helper: split + tile
+split_pane() {
+    local cwd="$1"
+    local cmd="$2"
+    tmux split-window -t "$SESSION":agents -c "$cwd" "$cmd"
+    tmux select-layout -t "$SESSION":agents tiled >/dev/null
+}
+
+split_pane "$ENGINE/.claude/worktrees/sonnet-fleet-1" \
+    "$(launch_cmd sonnet sonnet-author)"
+split_pane "$ENGINE/.claude/worktrees/sonnet-fleet-2" \
+    "$(launch_cmd sonnet sonnet-author)"
+split_pane "$ENGINE/.claude/worktrees/sonnet-reviewer" \
+    "$(launch_cmd sonnet sonnet-reviewer)"
+split_pane "$ENGINE/.claude/worktrees/opus-reviewer" \
+    "$(launch_cmd opus opus-reviewer)"
+split_pane "$ENGINE/.claude/worktrees/queue-manager" \
+    "$(launch_cmd sonnet queue-manager)"
+
+if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
+    split_pane "$GAME/.claude/worktrees/game-architect" \
+        "$(launch_cmd opus game-architect)"
+fi
+
+tmux select-pane -t "$SESSION":agents.1
+
+cat <<EOF
+
+fleet session created with tiled panes — mode: ${MODE}.
+attach with:  tmux attach -t ${SESSION}
+
+panes (left-to-right, top-to-bottom in tiled layout):
+  1. opus-architect   (engine, opus,   stand-by)
+  2. sonnet-fleet-1   (engine, sonnet, author)
+  3. sonnet-fleet-2   (engine, sonnet, author)
+  4. sonnet-reviewer  (engine, sonnet, polling reviewer)
+  5. opus-reviewer    (engine, opus,   polling reviewer)
+  6. queue-manager    (engine, sonnet, task intake)
+  7. game-architect   (game,   opus,   stand-by)
+
+mode "dry-run" means each agent does its startup actions and then
+waits. promote a pane to full operation by typing in it:
+  "exit dry-run mode and begin your normal loop"
+
+other modes you can pass to fleet-up:
+  fleet-up dry-run   # default — startup + stand-by
+  fleet-up live      # full loop from the start (use after a clean dry run)
+EOF

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# scripts/fleet/install.sh — install fleet tooling on this machine.
+#
+# Idempotent. Creates ~/bin/fleet-up as a symlink to the versioned
+# script in this repo, and refreshes ~/.claude/commands/role-*.md as
+# symlinks into the versioned role files (engine + game if present).
+#
+# Run once per machine after cloning the engine repo. Re-run after
+# any git pull that touched scripts/fleet/ or .claude/commands/.
+#
+# Portable across Linux (WSL/Ubuntu) and macOS. Does not require sudo.
+# Does not edit shell startup files — if ~/bin is not on PATH, this
+# script prints the exact line to add for each common shell.
+
+set -euo pipefail
+
+# Locate the repo root from the script's own path — this works whether
+# install.sh is invoked directly, via a relative path, or via a symlink
+# from another directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# If we were invoked from inside a linked worktree, `.git` is a file
+# (pointing at the main clone's gitdir) rather than a directory. In
+# that case we want the symlinks to target the **main clone**, not the
+# worktree — worktree paths are ephemeral (fleet-up + start-next-task
+# reset them), so symlinking into them would dangle after the next
+# branch swap.
+#
+# Exception: during development of the fleet scripts themselves, the
+# main clone may not yet have the new files on master. If the main
+# clone's scripts/fleet/fleet-up is missing, fall back to the worktree
+# paths and print a warning. The user will need to re-run install.sh
+# from the main clone after the PR merges.
+if [[ -f "$REPO_ROOT/.git" ]]; then
+    MAIN_ROOT="$(git -C "$REPO_ROOT" worktree list --porcelain \
+        | awk '/^worktree /{print $2; exit}')"
+    if [[ -z "$MAIN_ROOT" || ! -d "$MAIN_ROOT" ]]; then
+        echo "install.sh: could not resolve main clone from worktree $REPO_ROOT" >&2
+        exit 1
+    fi
+    if [[ -x "$MAIN_ROOT/scripts/fleet/fleet-up" \
+        && -f "$MAIN_ROOT/.claude/commands/role-opus-architect.md" ]]; then
+        echo "note: invoked from linked worktree. redirecting symlink targets"
+        echo "      to main clone at $MAIN_ROOT."
+        REPO_ROOT="$MAIN_ROOT"
+        SCRIPT_DIR="$REPO_ROOT/scripts/fleet"
+    else
+        echo "warning: invoked from linked worktree, and main clone at"
+        echo "         $MAIN_ROOT is missing scripts/fleet/fleet-up or role"
+        echo "         files. Using worktree paths for now — re-run install.sh"
+        echo "         from the main clone after your PR merges so the"
+        echo "         symlinks point at stable files." >&2
+    fi
+fi
+
+if [[ ! -f "$REPO_ROOT/.claude/commands/role-opus-architect.md" ]]; then
+    echo "install.sh: expected engine role files under $REPO_ROOT/.claude/commands/" >&2
+    echo "            — is this actually the IrredenEngine repo?" >&2
+    exit 1
+fi
+
+FLEET_UP_SRC="$SCRIPT_DIR/fleet-up"
+FLEET_UP_DEST="$HOME/bin/fleet-up"
+
+if [[ ! -f "$FLEET_UP_SRC" ]]; then
+    echo "install.sh: $FLEET_UP_SRC does not exist — repo is incomplete" >&2
+    exit 1
+fi
+
+# Ensure the source is executable. Git normally preserves the +x bit,
+# but if someone unpacked a tarball or checked out with core.fileMode
+# off, fix it here.
+if [[ ! -x "$FLEET_UP_SRC" ]]; then
+    chmod +x "$FLEET_UP_SRC"
+fi
+
+# ----------------------------------------------------------------------
+# Step 1: symlink fleet-up into ~/bin
+# ----------------------------------------------------------------------
+
+mkdir -p "$HOME/bin"
+ln -sf "$FLEET_UP_SRC" "$FLEET_UP_DEST"
+echo "symlinked $FLEET_UP_DEST -> $FLEET_UP_SRC"
+
+# ----------------------------------------------------------------------
+# Step 2: symlink engine role slash commands into ~/.claude/commands
+# ----------------------------------------------------------------------
+
+mkdir -p "$HOME/.claude/commands"
+
+shopt -s nullglob
+ENGINE_ROLES=("$REPO_ROOT"/.claude/commands/role-*.md)
+shopt -u nullglob
+
+if [[ ${#ENGINE_ROLES[@]} -eq 0 ]]; then
+    echo "install.sh: no engine role files matched $REPO_ROOT/.claude/commands/role-*.md" >&2
+    exit 1
+fi
+
+for src in "${ENGINE_ROLES[@]}"; do
+    dest="$HOME/.claude/commands/$(basename "$src")"
+    ln -sf "$src" "$dest"
+    echo "symlinked $dest -> $src"
+done
+
+# ----------------------------------------------------------------------
+# Step 3: symlink game role slash command if the game repo is present
+# ----------------------------------------------------------------------
+
+GAME_ROLE="$REPO_ROOT/creations/game/.claude/commands/role-game-architect.md"
+if [[ -f "$GAME_ROLE" ]]; then
+    ln -sf "$GAME_ROLE" "$HOME/.claude/commands/role-game-architect.md"
+    echo "symlinked $HOME/.claude/commands/role-game-architect.md -> $GAME_ROLE"
+else
+    echo "note: game role file not found at $GAME_ROLE"
+    echo "      (clone jakildev/irreden into creations/game/ and re-run to pick it up.)"
+fi
+
+# ----------------------------------------------------------------------
+# Step 4: PATH sanity check
+# ----------------------------------------------------------------------
+
+case ":$PATH:" in
+    *":$HOME/bin:"*)
+        echo
+        echo "~/bin is on PATH — fleet-up should be runnable from a fresh shell."
+        ;;
+    *)
+        cat <<'EOF'
+
+WARNING: ~/bin is NOT on PATH in the current shell.
+
+Add this line to your shell startup file, then open a new terminal:
+
+    export PATH="$HOME/bin:$PATH"
+
+Which file depends on the shell:
+
+  zsh  (macOS default)    ~/.zprofile
+  bash (Linux default)    ~/.bash_profile  (and also source ~/.bashrc from it)
+  fish                    ~/.config/fish/config.fish — use: fish_add_path $HOME/bin
+
+Then run 'fleet-up dry-run' to bring the fleet up.
+EOF
+        ;;
+esac
+
+echo
+echo "install.sh: done."


### PR DESCRIPTION
## Summary
- Move the fleet launcher from unversioned `~/bin/fleet-up` into the engine repo at `scripts/fleet/fleet-up`, alongside `scripts/fleet/install.sh` that symlinks fleet-up + role slash commands into their runtime locations. Because install.sh uses **symlinks**, a `git pull` auto-updates everything on every machine — no more forgetting to cp after edits.
- The installer detects when invoked from a linked worktree and redirects symlink targets to the main clone (whose paths survive branch resets). Falls back to worktree paths during pre-merge dev with a clear warning.
- Updates `docs/AGENT_FLEET_SETUP.md` §5b (role-file sync is now install.sh, not manual cp) and §5c (describes the versioned installer instead of "write fleet-up by hand").

## Post-merge step (required once)
After merging, run from the main clone to convert the symlinks from worktree-pointing to main-clone-pointing:
```bash
cd ~/src/IrredenEngine
git pull --ff-only
scripts/fleet/install.sh
```
The same command on a second machine (WSL, another Mac, etc.) is the full first-time setup.

## Test plan
- [ ] `bash -n scripts/fleet/fleet-up && bash -n scripts/fleet/install.sh` — both pass syntax check
- [ ] `scripts/fleet/install.sh` from the worktree falls back with "warning: invoked from linked worktree" and creates working symlinks
- [ ] `scripts/fleet/install.sh` from the main clone (after merge + pull) redirects symlinks to stable main-clone paths
- [ ] `~/bin/fleet-up` resolves via symlink and `fleet-up --help` is runnable in a new terminal (requires `~/bin` on PATH)
- [ ] `~/.claude/commands/role-*.md` are symlinks into the repo (not copies), and `cat` on each resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)