### PR TITLE
fleet: normalize scratch branch names to claude/<role>-scratch

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -30,8 +30,8 @@ conditions, allocator behavior, hot-path costs.
 
 1. `pwd` — confirm you are in the `opus-reviewer` worktree.
 2. Confirm you are on the throwaway branch
-   `review-scratch-opus`. If not:
-   `git fetch origin && git checkout -B review-scratch-opus origin/master`.
+   `claude/opus-reviewer-scratch`. If not:
+   `git fetch origin && git checkout -B claude/opus-reviewer-scratch origin/master`.
 3. `gh pr list --state open --json number,title,headRefName,reviews`
    — print the result.
 4. Identify the candidates: PRs where the latest review body contains

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -25,8 +25,8 @@ treat it as a hard rule for this role.
 1. `pwd` — confirm you are in the `sonnet-reviewer` worktree.
 2. Confirm you are on the throwaway branch:
    `git branch --show-current` should report something like
-   `review-scratch-sonnet`. If not, run
-   `git fetch origin && git checkout -B review-scratch-sonnet origin/master`.
+   `claude/sonnet-reviewer-scratch`. If not, run
+   `git fetch origin && git checkout -B claude/sonnet-reviewer-scratch origin/master`.
    `gh pr checkout` will rewrite this branch on each review.
 3. `gh pr list --state open --json number,title,headRefName,author,reviews`
    — print the result so we both see the current PR queue.

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -712,12 +712,12 @@ Before starting a reviewer session:
 
 ```bash
 cd ~/src/IrredenEngine/.claude/worktrees/sonnet-reviewer
-git checkout -B review-scratch origin/master
+git checkout -B claude/sonnet-reviewer-scratch origin/master
 ```
 
 Then inside the session you can `gh pr checkout 42`, review, post the
-comment, and `git checkout -B review-scratch origin/master` again for
-the next PR.
+comment, and `git checkout -B claude/sonnet-reviewer-scratch origin/master`
+again for the next PR.
 
 Don't commit or push from a reviewer worktree. The `review-pr` skill
 enforces this, but a human reviewer should know too.
@@ -1454,7 +1454,7 @@ logical boundary. That's the whole reason the skill exists.
   (`linux-debug` on WSL / `macos-debug` on macOS) and `IRShapeDebug`
   builds cleanly (or cross-platform-maturation tasks are filed for
   whatever doesn't). ✅
-- Reviewer worktrees parked on `review-scratch`. ✅
+- Reviewer worktrees parked on `claude/<role>-scratch`. ✅
 
 **Shared across hosts:**
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -108,8 +108,8 @@ reset_worktree() {
 reset_worktree "$ENGINE/.claude/worktrees/opus-architect"  claude/opus-arch-scratch
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-1"  claude/sonnet-1-scratch
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-2"  claude/sonnet-2-scratch
-reset_worktree "$ENGINE/.claude/worktrees/sonnet-reviewer" review-scratch-sonnet
-reset_worktree "$ENGINE/.claude/worktrees/opus-reviewer"   review-scratch-opus
+reset_worktree "$ENGINE/.claude/worktrees/sonnet-reviewer" claude/sonnet-reviewer-scratch
+reset_worktree "$ENGINE/.claude/worktrees/opus-reviewer"   claude/opus-reviewer-scratch
 reset_worktree "$ENGINE/.claude/worktrees/queue-manager"   claude/queue-manager-scratch
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then


### PR DESCRIPTION
## Summary
Reviewer worktrees used `review-scratch-sonnet` and `review-scratch-opus` while every other role used `claude/<role>-scratch`. No functional reason for the difference — normalize all seven to the consistent pattern so `git branch` output is predictable and the fleet documentation has one rule to remember.

**Before:**
```
claude/opus-arch-scratch        ✅
claude/sonnet-1-scratch         ✅
claude/sonnet-2-scratch         ✅
review-scratch-sonnet           ❌ different prefix
review-scratch-opus             ❌ different prefix
claude/queue-manager-scratch    ✅
claude/game-arch-scratch        ✅
```

**After:** all seven use `claude/<role>-scratch`.

## Files changed
- `scripts/fleet/fleet-up` — updated `reset_worktree` calls for both reviewer worktrees
- `.claude/commands/role-sonnet-reviewer.md` — updated startup branch-name reference
- `.claude/commands/role-opus-reviewer.md` — updated startup branch-name reference
- `docs/AGENT_FLEET_SETUP.md` — updated two references to the old names

## Test plan
- [ ] `fleet-up dry-run` resets `sonnet-reviewer` worktree to `claude/sonnet-reviewer-scratch`
- [ ] `fleet-up dry-run` resets `opus-reviewer` worktree to `claude/opus-reviewer-scratch`
- [ ] Reviewer role startup check (`git branch --show-current`) matches the branch name in the role file

🤖 Generated with [Claude Code](https://claude.com/claude-code)