### PR TITLE
fleet: broaden hard rule to ban all && compounds

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -28,7 +28,7 @@ list above.
 ## Startup actions (do these immediately, in order)
 
 1. `git -C ~/src/IrredenEngine fetch origin --quiet`
-2. `cat TASKS.md` — review the current queue.
+2. Read `TASKS.md` (use the Read tool, not `cat`) — review the current queue.
 3. `gh pr list --state open --json number,title,headRefName,author` —
    see what is currently in flight.
 4. Print a one-line summary: how many `[opus]` tasks are unblocked, how
@@ -90,8 +90,10 @@ Stop and surface to the human when:
 - Never run `cmake --preset` — only `cmake --build` against the
   already-configured tree.
 - Never touch the `.claude/worktrees/` layout.
-- Never use `&&` to chain commands in a single Bash invocation. Issue
-  each command as its own separate Bash tool call. Compound commands
-  don't match the allowlist and trigger interactive prompts that block
-  unattended operation. For git specifically, use `git -C <path>`
-  instead of `cd <path> && git`.
+- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
+  commands in a single Bash invocation. Issue each command as its own
+  separate tool call (Bash or Read). Compound commands don't match the
+  allowlist and trigger interactive prompts that block unattended
+  operation. For git specifically, use `git -C <path>` instead of
+  `cd <path> && git`. For reading files, use the Read tool instead of
+  `cat`.

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -90,6 +90,8 @@ Stop and surface to the human when:
 - Never run `cmake --preset` — only `cmake --build` against the
   already-configured tree.
 - Never touch the `.claude/worktrees/` layout.
-- Never use `cd <path> && git ...` — use `git -C <path> ...` instead.
-  Compound `cd`+git commands trigger a Claude Code security prompt on
-  every invocation and block unattended operation.
+- Never use `&&` to chain commands in a single Bash invocation. Issue
+  each command as its own separate Bash tool call. Compound commands
+  don't match the allowlist and trigger interactive prompts that block
+  unattended operation. For git specifically, use `git -C <path>`
+  instead of `cd <path> && git`.

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -83,8 +83,10 @@ end-to-end, then stop and wait for human instruction. Do not loop.
 - Do NOT take on first-pass reviews that Sonnet has not yet touched
   (unless `sonnet-reviewer` is offline AND the PR has been open more
   than 1 hour). The model split exists to conserve Opus budget.
-- Never use `&&` to chain commands in a single Bash invocation. Issue
-  each command as its own separate Bash tool call. Compound commands
-  don't match the allowlist and trigger interactive prompts that block
-  unattended operation. For git specifically, use `git -C <path>`
-  instead of `cd <path> && git`.
+- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
+  commands in a single Bash invocation. Issue each command as its own
+  separate tool call (Bash or Read). Compound commands don't match the
+  allowlist and trigger interactive prompts that block unattended
+  operation. For git specifically, use `git -C <path>` instead of
+  `cd <path> && git`. For reading files, use the Read tool instead of
+  `cat`.

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -83,6 +83,8 @@ end-to-end, then stop and wait for human instruction. Do not loop.
 - Do NOT take on first-pass reviews that Sonnet has not yet touched
   (unless `sonnet-reviewer` is offline AND the PR has been open more
   than 1 hour). The model split exists to conserve Opus budget.
-- Never use `cd <path> && git ...` — use `git -C <path> ...` instead.
-  Compound `cd`+git commands trigger a Claude Code security prompt on
-  every invocation and block unattended operation.
+- Never use `&&` to chain commands in a single Bash invocation. Issue
+  each command as its own separate Bash tool call. Compound commands
+  don't match the allowlist and trigger interactive prompts that block
+  unattended operation. For git specifically, use `git -C <path>`
+  instead of `cd <path> && git`.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -23,11 +23,10 @@ merges.
 
 1. `pwd` — confirm you are in the `queue-manager` worktree.
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. `cat TASKS.md` — read the engine queue.
-4. If `~/src/IrredenEngine/creations/game/.git` exists, run these two
-   commands separately (do NOT combine with `cd ... &&`):
+3. Read `TASKS.md` (use the Read tool, not `cat`) — read the engine queue.
+4. If `~/src/IrredenEngine/creations/game/.git` exists:
    `git -C ~/src/IrredenEngine/creations/game fetch origin --quiet`
-   `cat ~/src/IrredenEngine/creations/game/TASKS.md`
+   Then read `~/src/IrredenEngine/creations/game/TASKS.md` (Read tool)
    — read the game queue too.
 5. `gh pr list --state open --json number,title,headRefName` for both
    repos — see what is in flight.
@@ -144,8 +143,10 @@ stop and wait for human instruction.
 - Queue-only PRs are explicitly allowed by `TASKS.md` as queue
   maintenance — you do not need to bundle a task add with actual
   work.
-- Never use `&&` to chain commands in a single Bash invocation. Issue
-  each command as its own separate Bash tool call. Compound commands
-  don't match the allowlist and trigger interactive prompts that block
-  unattended operation. For git specifically, use `git -C <path>`
-  instead of `cd <path> && git`.
+- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
+  commands in a single Bash invocation. Issue each command as its own
+  separate tool call (Bash or Read). Compound commands don't match the
+  allowlist and trigger interactive prompts that block unattended
+  operation. For git specifically, use `git -C <path>` instead of
+  `cd <path> && git`. For reading files, use the Read tool instead of
+  `cat`.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -144,6 +144,8 @@ stop and wait for human instruction.
 - Queue-only PRs are explicitly allowed by `TASKS.md` as queue
   maintenance — you do not need to bundle a task add with actual
   work.
-- Never use `cd <path> && git ...` — use `git -C <path> ...` instead.
-  Compound `cd`+git commands trigger a Claude Code security prompt on
-  every invocation and block unattended operation.
+- Never use `&&` to chain commands in a single Bash invocation. Issue
+  each command as its own separate Bash tool call. Compound commands
+  don't match the allowlist and trigger interactive prompts that block
+  unattended operation. For git specifically, use `git -C <path>`
+  instead of `cd <path> && git`.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -111,6 +111,8 @@ budget split. Just wait.
 - Never touch the `.claude/worktrees/` layout.
 - Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
   `xcode-select` — those are human-initiated.
-- Never use `cd <path> && git ...` — use `git -C <path> ...` instead.
-  Compound `cd`+git commands trigger a Claude Code security prompt on
-  every invocation and block unattended operation.
+- Never use `&&` to chain commands in a single Bash invocation. Issue
+  each command as its own separate Bash tool call. Compound commands
+  don't match the allowlist and trigger interactive prompts that block
+  unattended operation. For git specifically, use `git -C <path>`
+  instead of `cd <path> && git`.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -29,7 +29,7 @@ whatever directory the task touches before editing anything.
 1. `pwd` and confirm you are in a sonnet-fleet worktree (not the main
    clone, not a reviewer worktree).
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. `cat TASKS.md` — review the current queue.
+3. Read `TASKS.md` (use the Read tool, not `cat`) — review the current queue.
 4. `gh pr list --state open --json number,title,headRefName,author` —
    see what other agents are working on.
 5. Print a one-line summary: which `[sonnet]` items look unblocked and
@@ -111,8 +111,10 @@ budget split. Just wait.
 - Never touch the `.claude/worktrees/` layout.
 - Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
   `xcode-select` — those are human-initiated.
-- Never use `&&` to chain commands in a single Bash invocation. Issue
-  each command as its own separate Bash tool call. Compound commands
-  don't match the allowlist and trigger interactive prompts that block
-  unattended operation. For git specifically, use `git -C <path>`
-  instead of `cd <path> && git`.
+- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
+  commands in a single Bash invocation. Issue each command as its own
+  separate tool call (Bash or Read). Compound commands don't match the
+  allowlist and trigger interactive prompts that block unattended
+  operation. For git specifically, use `git -C <path>` instead of
+  `cd <path> && git`. For reading files, use the Read tool instead of
+  `cat`.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -83,6 +83,8 @@ for human instruction. Do not loop.
   `--request-changes` or `--comment`. The Opus reviewer is the only
   agent allowed to approve.
 - Never `git push --force` (you have no reason to push at all).
-- Never use `cd <path> && git ...` — use `git -C <path> ...` instead.
-  Compound `cd`+git commands trigger a Claude Code security prompt on
-  every invocation and block unattended operation.
+- Never use `&&` to chain commands in a single Bash invocation. Issue
+  each command as its own separate Bash tool call. Compound commands
+  don't match the allowlist and trigger interactive prompts that block
+  unattended operation. For git specifically, use `git -C <path>`
+  instead of `cd <path> && git`.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -83,8 +83,10 @@ for human instruction. Do not loop.
   `--request-changes` or `--comment`. The Opus reviewer is the only
   agent allowed to approve.
 - Never `git push --force` (you have no reason to push at all).
-- Never use `&&` to chain commands in a single Bash invocation. Issue
-  each command as its own separate Bash tool call. Compound commands
-  don't match the allowlist and trigger interactive prompts that block
-  unattended operation. For git specifically, use `git -C <path>`
-  instead of `cd <path> && git`.
+- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
+  commands in a single Bash invocation. Issue each command as its own
+  separate tool call (Bash or Read). Compound commands don't match the
+  allowlist and trigger interactive prompts that block unattended
+  operation. For git specifically, use `git -C <path>` instead of
+  `cd <path> && git`. For reading files, use the Read tool instead of
+  `cat`.


### PR DESCRIPTION
## Summary
- PR #70 banned `cd <path> && git` specifically, but agents were still constructing their own `&&` chains (`pwd && echo "---" && git -C ...`, `cd ... && gh pr list`)
- These compound commands don't match any single-command allowlist pattern — `Bash(git:*)` only matches commands that *start* with `git`
- Broadened the hard rule in all 5 role prompts: never use `&&` in a single Bash invocation at all; issue each command as its own separate Bash tool call

## Companion local change (not in this PR)
Simplified `~/.claude/settings.json` allowlist: replaced 20 fine-grained `Bash(git fetch:*)` / `Bash(gh pr view:*)` entries with blanket `Bash(git:*)` and `Bash(gh:*)`. The old fine-grained patterns broke when `-C` appeared between `git` and the subcommand. Deny list still blocks dangerous operations.

## Test plan
- [ ] `fleet-up dry-run` — all 7 panes start without any permission prompts
- [ ] Verify agents issue separate Bash calls instead of `&&` chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)