### PR TITLE
fleet: fix queue-manager game-repo compound commands

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -24,12 +24,14 @@ merges.
 1. `pwd` — confirm you are in the `queue-manager` worktree.
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
 3. Read `TASKS.md` (use the Read tool, not `cat`) — read the engine queue.
-4. If `~/src/IrredenEngine/creations/game/.git` exists:
+4. Check for the game repo — run `ls ~/src/IrredenEngine/creations/game/.git`
+   (just `ls`, no `&&` or `||` fallback). If it succeeds (file exists),
+   run these as separate tool calls:
    `git -C ~/src/IrredenEngine/creations/game fetch origin --quiet`
-   Then read `~/src/IrredenEngine/creations/game/TASKS.md` (Read tool)
-   — read the game queue too.
-5. `gh pr list --state open --json number,title,headRefName` for both
-   repos — see what is in flight.
+   Read `~/src/IrredenEngine/creations/game/TASKS.md` (Read tool)
+   If the `ls` fails (file not found), skip — no game repo on this machine.
+5. `gh pr list --state open --json number,title,headRefName` — engine PRs.
+   If game repo exists, also run `gh -C ~/src/IrredenEngine/creations/game pr list --state open --json number,title,headRefName` separately.
 6. Print `queue-manager standing by — paste a task description and I will
    categorize and file it`.
 


### PR DESCRIPTION
## Summary
- Queue-manager startup step 4 was constructing `ls ... && echo ... || echo ...` and `cd ... && git remote -v` despite the compound-command ban
- Spelled out the exact non-compound approach: plain `ls` to check existence, separate tool calls for fetch and Read
- Companion local change: added `Glob(*)` and `Grep(*)` to `~/.claude/settings.json` allowlist — sonnet-author search tools were prompting

## Test plan
- [ ] `fleet-up dry-run` — all 7 panes complete startup without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)