### PR TITLE
fleet: rewrite queue-manager startup as verbatim commands

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -21,17 +21,20 @@ merges.
 
 ## Startup actions
 
-1. `pwd` — confirm you are in the `queue-manager` worktree.
+Run each step as its own **single** tool call. Never combine with
+`&&`, `||`, `;`, or `|`. Never use `cd` before `git` or `gh`. Never
+use `cat` — use the Read tool for files.
+
+1. `pwd`
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. Read `TASKS.md` (use the Read tool, not `cat`) — read the engine queue.
-4. Check for the game repo — run `ls ~/src/IrredenEngine/creations/game/.git`
-   (just `ls`, no `&&` or `||` fallback). If it succeeds (file exists),
-   run these as separate tool calls:
-   `git -C ~/src/IrredenEngine/creations/game fetch origin --quiet`
-   Read `~/src/IrredenEngine/creations/game/TASKS.md` (Read tool)
-   If the `ls` fails (file not found), skip — no game repo on this machine.
-5. `gh pr list --state open --json number,title,headRefName` — engine PRs.
-   If game repo exists, also run `gh -C ~/src/IrredenEngine/creations/game pr list --state open --json number,title,headRefName` separately.
+3. Read tool → `TASKS.md`
+4. `ls ~/src/IrredenEngine/creations/game/.git`
+   - If it succeeds → step 4a, 4b, 4c (each a separate tool call):
+     4a. `git -C ~/src/IrredenEngine/creations/game fetch origin --quiet`
+     4b. Read tool → `~/src/IrredenEngine/creations/game/TASKS.md`
+     4c. `gh pr list --repo jakildev/IrredenEngine-game --state open --json number,title,headRefName`
+   - If it fails (not found) → skip 4a–4c.
+5. `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName`
 6. Print `queue-manager standing by — paste a task description and I will
    categorize and file it`.
 


### PR DESCRIPTION
## Summary
- Queue-manager agent kept constructing compound commands (`cd && gh`, `cat || echo`) despite the hard rule — prose-style instructions gave too much room to improvise
- Rewrote startup as a strict numbered list where every step is a verbatim tool call
- Added `--repo jakildev/IrredenEngine` flag to `gh pr list` so no `cd` is needed
- Header reminder at top of startup section reinforcing the no-compound rule

## Companion local change (not in PR)
Added `Edit(*)`, `Write(*)`, `Bash(test:*)` to `~/.claude/settings.json` allowlist — sonnet authors were prompting on first TASKS.md edit to claim tasks

## Test plan
- [ ] `fleet-up dry-run` — queue-manager completes startup without compounds or prompts
- [ ] Sonnet authors edit TASKS.md without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)