### PR TITLE
fleet: prevent Claude Code from overwriting pane titles

### DIFF
--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -192,6 +192,10 @@ split_pane() {
     tmux select-pane -t "$SESSION":agents.$PANE_INDEX -T "$label"
 }
 
+# Prevent Claude Code from overwriting pane titles with "· Claude Code"
+tmux set-option -t "$SESSION" allow-rename off
+tmux set-option -t "$SESSION" automatic-rename off
+
 # Label pane 1
 tmux select-pane -t "$SESSION":agents.1 -T "opus-architect [opus]"
 


### PR DESCRIPTION
## Summary
- PR #75 added pane labels but Claude Code overrides terminal titles with "· Claude Code" on launch, stomping them
- Fix: `allow-rename off` and `automatic-rename off` on the tmux session before labeling, so programs can't override

## Test plan
- [ ] `fleet-up dry-run` — each pane border shows role name like `1: opus-architect [opus]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)