### PR TITLE
fleet: persistent pane labels and fix game repo name

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -28,12 +28,10 @@ use `cat` — use the Read tool for files.
 1. `pwd`
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
 3. Read tool → `TASKS.md`
-4. `ls ~/src/IrredenEngine/creations/game/.git`
-   - If it succeeds → step 4a, 4b, 4c (each a separate tool call):
-     4a. `git -C ~/src/IrredenEngine/creations/game fetch origin --quiet`
-     4b. Read tool → `~/src/IrredenEngine/creations/game/TASKS.md`
-     4c. `gh pr list --repo jakildev/IrredenEngine-game --state open --json number,title,headRefName`
-   - If it fails (not found) → skip 4a–4c.
+4. Read tool → `~/src/IrredenEngine/creations/game/TASKS.md`
+   - If the Read succeeds (file exists) → also run step 4a (separate tool call):
+     4a. `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName`
+   - If the Read fails (file not found) → skip 4a. No game repo on this machine.
 5. `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName`
 6. Print `queue-manager standing by — paste a task description and I will
    categorize and file it`.

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -180,8 +180,15 @@ tmux new-session -d -s "$SESSION" -n agents \
     -c "$ENGINE/.claude/worktrees/opus-architect" \
     "$(launch_cmd opus opus-architect)"
 
-# Helper: split, tile, and label
+# Helper: split, tile, and label using a custom tmux variable @role
+# that Claude Code cannot override (unlike pane_title which programs
+# can set via terminal escape sequences).
 PANE_INDEX=1
+label_pane() {
+    local idx="$1"
+    local label="$2"
+    tmux set-option -t "$SESSION":agents.$idx -p @role "$label"
+}
 split_pane() {
     local cwd="$1"
     local cmd="$2"
@@ -189,15 +196,11 @@ split_pane() {
     tmux split-window -t "$SESSION":agents -c "$cwd" "$cmd"
     tmux select-layout -t "$SESSION":agents tiled >/dev/null
     PANE_INDEX=$((PANE_INDEX + 1))
-    tmux select-pane -t "$SESSION":agents.$PANE_INDEX -T "$label"
+    label_pane "$PANE_INDEX" "$label"
 }
 
-# Prevent Claude Code from overwriting pane titles with "· Claude Code"
-tmux set-option -t "$SESSION" allow-rename off
-tmux set-option -t "$SESSION" automatic-rename off
-
 # Label pane 1
-tmux select-pane -t "$SESSION":agents.1 -T "opus-architect [opus]"
+label_pane 1 "opus-architect [opus]"
 
 split_pane "$ENGINE/.claude/worktrees/sonnet-fleet-1" \
     "$(launch_cmd sonnet sonnet-author)" "sonnet-fleet-1 [sonnet]"
@@ -215,9 +218,9 @@ if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
         "$(launch_cmd opus game-architect)" "game-architect [opus]"
 fi
 
-# Enable pane border labels
+# Enable pane border labels using @role (immune to program overrides)
 tmux set-option -t "$SESSION" pane-border-status top
-tmux set-option -t "$SESSION" pane-border-format " #{pane_index}: #{pane_title} "
+tmux set-option -t "$SESSION" pane-border-format " #{pane_index}: #{@role} "
 
 tmux select-pane -t "$SESSION":agents.1
 


### PR DESCRIPTION
## Summary
- **Pane labels**: Claude Code overrides `pane_title` via escape sequences, so labels disappeared after launch. Switched to a custom tmux per-pane variable `@role` (set via `set-option -p`) which programs cannot override. Border format now reads `#{@role}`.
- **Queue-manager game repo**: was referencing `jakildev/IrredenEngine-game` but the actual game remote is `jakildev/irreden`. Simplified step 4 to use Read tool to probe for `game/TASKS.md` instead of `ls .git` + separate fetch.

## Test plan
- [ ] `fleet-up dry-run` — pane borders show role names that persist after Claude Code starts
- [ ] Queue-manager pane 6 completes startup without game repo errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)