### PR TITLE
queue: add task for engine/asset file extension mismatch fix

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -133,6 +133,24 @@ Avoid:
 
 <!-- Add tasks below this line. -->
 
+- [ ] **Fix `engine/asset` extension mismatch: `.txl` vs `.irtxl`** —
+  `saveTrixelTextureData` writes files with `.txl` but `loadTrixelTextureData`
+  opens files expecting `.irtxl`. Standardize both on `.txl`.
+  - **Area:** engine/asset
+  - **Model:** sonnet
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** both `saveTrixelTextureData` and `loadTrixelTextureData`
+    use `.txl`; CMake build passes (`linux-debug` or `macos-debug`);
+    `C_TriangleCanvasTextures::saveToFile` followed by `loadFromFile` round-
+    trips a canvas without corruption.
+  - **Notes:** Bug in `engine/asset/src/ir_asset.cpp` line 32 — change
+    `.irtxl` → `.txl`. No `.irtxl` files exist in the repo so there is no
+    backward-compat concern. While editing, add `if (!f) { IRE_LOG_ERROR(...); return; }`
+    guards around both `fopen` calls — the current code crashes on any I/O
+    failure. Single-file change, one PR.
+  - **Links:**
+
 - [ ] **Linux build maturation: get `linux-debug` preset green end-to-end** —
   fix every compile/link/runtime issue encountered when building the
   engine against the new `linux-debug` CMake preset inside WSL2 Ubuntu


### PR DESCRIPTION
## Summary
- Adds a bounded `[sonnet]` task to `TASKS.md` for the confirmed bug in `engine/asset/src/ir_asset.cpp` where `saveTrixelTextureData` writes `.txl` but `loadTrixelTextureData` reads `.irtxl`.
- Task includes concrete acceptance criteria, exact fix location (line 32), and calls out the missing `fopen` null-check guards.

## Why this task was queued rather than fixed inline
Running on macOS with no configured build tree; the hard fleet rule prohibits `cmake --preset`. The fix itself is one-line but requires a build to verify the round-trip. A WSL-fleet agent can pick it up with a build tree already in place.

## Test plan
- [ ] No code changed — queue maintenance PR only; verify task entry follows the TASKS.md template

🤖 Generated with [Claude Code](https://claude.com/claude-code)