### PR TITLE
engine/asset: fix .txl/.irtxl extension mismatch and add fopen guards

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -271,6 +271,19 @@ Avoid:
     profiler build flag.
   - **Links:**
 
+- [~] **Fix `engine/asset` extension mismatch: `.txl` vs `.irtxl`** —
+  `saveTrixelTextureData` writes `.txl` but `loadTrixelTextureData` opens `.irtxl`.
+  Standardize both on `.txl` and add null-check guards around fopen results.
+  - **Area:** engine/asset
+  - **Model:** sonnet
+  - **Owner:** sonnet-fleet-2
+  - **Blocked by:** (none)
+  - **Acceptance:** both functions use `.txl`; both `fopen` results are null-checked
+    with `IRE_LOG_ERROR` and early return; build passes.
+  - **Notes:** bug is in `engine/asset/src/ir_asset.cpp` line 32. No `.irtxl` files
+    exist in the repo; no backward-compat concern.
+  - **Links:**
+
 - [ ] **Example: unit tests for engine/math/physics.hpp** — exhaustive
   tests for ballistic helpers.
   - **Area:** engine/math

--- a/engine/asset/src/ir_asset.cpp
+++ b/engine/asset/src/ir_asset.cpp
@@ -15,6 +15,10 @@ void saveTrixelTextureData(
 ) {
     const std::string filename = IRUtility::joinPath(path, name, ".txl");
     FILE *f = fopen(filename.c_str(), "wb");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for writing: {}", filename);
+        return;
+    }
     fwrite(&size, sizeof(size), 1, f);
     fwrite(colors.data(), sizeof(colors.at(0)), size.x * size.y, f);
     fwrite(distances.data(), sizeof(distances.at(0)), size.x * size.y, f);
@@ -29,8 +33,12 @@ void loadTrixelTextureData(
     std::vector<Color> &colors,
     std::vector<Distance> &distances
 ) {
-    const std::string filename = IRUtility::joinPath(path, name, ".irtxl");
+    const std::string filename = IRUtility::joinPath(path, name, ".txl");
     FILE *f = fopen(filename.c_str(), "rb");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for reading: {}", filename);
+        return;
+    }
     fread(&size, sizeof(size), 1, f);
     colors.resize(size.x * size.y);
     distances.resize(size.x * size.y);


### PR DESCRIPTION
## Summary
- `loadTrixelTextureData` was using `.irtxl` as the file extension while `saveTrixelTextureData` wrote `.txl`, making every save→load round-trip silently fail (file not found)
- Standardized both functions on `.txl` — no `.irtxl` files exist in the repo
- Added `if (!f)` null-check guards after both `fopen` calls; previously a failed open caused a NULL dereference crash with no diagnostic

## Test plan
- [ ] A creation that calls `saveTrixelTextureData` then `loadTrixelTextureData` round-trips a canvas without corruption
- [ ] Passing a bad path to either function logs `IRE_LOG_ERROR` and returns cleanly instead of crashing
- [ ] Build passes on any configured preset (`linux-debug` or `macos-debug`)

## Notes for reviewer
The partial-read case (truncated file, fread returns fewer bytes than expected) is a pre-existing gap and out of scope for this fix. That would require changing the function signature to return a status — tracked in `engine/asset/CLAUDE.md` as a known gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)