### PR TITLE
docs: fix incorrect INT32_MAX sentinel claim in render CLAUDE.md

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -138,7 +138,11 @@ engine/render/
   `kBufferIndex_FrameDataVoxelToCanvas = 7` appear in both C++ and GLSL. A
   mismatch is silent — wrong uniforms, no error.
 - **Distance texture clear.** Cleared to `kTrixelDistanceMaxDistance`
-  (INT32_MAX sentinel). If a clear is skipped, stale depth causes flicker.
+  (65535, **not** INT32_MAX). Voxels and shapes both write smaller values
+  via `imageAtomicMin`; the clear value acts as the "nothing here" background.
+  The shape SDF helpers use a separate `kInvalidDepth = 0x7FFFFFFF` (INT32_MAX)
+  constant to signal "ray missed" and skip writing — don't confuse the two.
+  If a clear is skipped, stale depth causes flicker.
 - **Persistent mapped buffers.** `HoveredEntityIdBuffer` is
   `PERSISTENT | COHERENT`. Reading it too early (before GPU write) returns
   garbage from the previous frame.


### PR DESCRIPTION
## Summary
- The gotcha note for "Distance texture clear" in `engine/render/CLAUDE.md` incorrectly stated `kTrixelDistanceMaxDistance` is "INT32_MAX" — it is actually 65535.
- Added clarifying text explaining `kInvalidDepth = 0x7FFFFFFF` (INT32_MAX) is a *separate* constant used by shape SDF helpers in `c_shapes_to_trixel.glsl` to signal a ray miss; those code paths skip `imageAtomicMin` entirely.

## Why it matters
Conflating the two sentinel values makes it harder to reason about depth competition in the trixel pipeline. A dev reading the gotcha section expecting INT32_MAX and seeing 65535 in the source would be confused.

## Test plan
- [ ] Doc-only change — no build required
- [ ] Verify values against `engine/common/include/irreden/ir_constants.hpp` (`kTrixelDistanceMaxDistance = 65535`) and `engine/render/src/shaders/ir_constants.glsl` (`kInvalidDepth = 0x7FFFFFFF`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)