### PR TITLE
test: add unit testing conventions and queue ECS/math test tasks

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -191,13 +191,37 @@ compliance or raise an issue.
 
 ### 5. Write the review
 
-Post the review as a PR comment via `gh pr review`:
+Post the review via `gh pr review`, using the review state that matches
+the verdict (`--approve`, `--request-changes`, or `--comment` for
+informational-only re-reviews). The body format is the same in all cases:
 
 ```bash
-gh pr review <N> --comment --body "$(cat <<'EOF'
+gh pr review <N> --approve --body "$(cat <<'EOF'
 ## Review — <title>
 
-**Verdict:** <approve | needs-fix | blocker>
+**Verdict:** approve
+
+### Nits
+- <path:line> — <nit>
+
+### Praise
+- <non-obvious good decision, if any>
+
+### Test plan the author should run before merge
+- [ ] <...>
+
+🤖 Reviewed by Claude Sonnet 4.6 (review-pr skill)
+EOF
+)"
+```
+
+For needs-fix / blocker verdicts, swap `--approve` for `--request-changes`:
+
+```bash
+gh pr review <N> --request-changes --body "$(cat <<'EOF'
+## Review — <title>
+
+**Verdict:** <needs-fix | blocker>
 
 ### Blockers
 - <path:line> — <issue> — <suggested fix>
@@ -215,7 +239,7 @@ gh pr review <N> --comment --body "$(cat <<'EOF'
 - [ ] <...>
 - [ ] <...>
 
-🤖 Reviewed by Claude Opus 4.6 (review-pr skill)
+🤖 Reviewed by Claude Sonnet 4.6 (review-pr skill)
 EOF
 )"
 ```
@@ -232,9 +256,16 @@ Rules for the review body:
   - **needs-fix** — one or more needs-fix items. No blockers.
   - **blocker** — at least one blocker. Merging would break master.
 
-If the verdict is **approve**, also use `gh pr review <N> --approve` (in
-addition to the comment). Do **not** approve and then merge — merging is the
-user's call.
+Use the matching `gh pr review` state so GitHub's PR list shows the
+verdict at a glance:
+
+- **approve** → post the body with `gh pr review <N> --approve --body "..."`
+  (green checkmark in the PR list).
+- **needs-fix** or **blocker** → post the body with
+  `gh pr review <N> --request-changes --body "..."` (red "Changes
+  requested" badge in the PR list).
+
+Do **not** approve and then merge — merging is the user's call.
 
 ### 6. Report back
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -192,10 +192,23 @@ compliance or raise an issue.
 ### 5. Write the review
 
 Post the review via `gh pr review`, using the review state that matches
-the verdict (`--approve`, `--request-changes`, or `--comment` for
-informational-only re-reviews). The body format is the same in all cases:
+the verdict. The body format is the same in all cases — only the
+`gh pr review` flag changes.
+
+**Important — two-tier approve gate:** only **Opus** reviewers may use
+`--approve`. Sonnet first-pass reviewers use `--comment` for approve
+verdicts (the Sonnet review is informational; the Opus pass or the
+human is what actually gates merge). Both tiers use `--request-changes`
+for needs-fix / blocker verdicts.
+
+| Verdict | Sonnet first-pass | Opus final review |
+|---------|-------------------|-------------------|
+| approve | `--comment` | `--approve` |
+| needs-fix | `--request-changes` | `--request-changes` |
+| blocker | `--request-changes` | `--request-changes` |
 
 ```bash
+# Opus approve example (Sonnet: swap --approve for --comment)
 gh pr review <N> --approve --body "$(cat <<'EOF'
 ## Review — <title>
 
@@ -210,12 +223,12 @@ gh pr review <N> --approve --body "$(cat <<'EOF'
 ### Test plan the author should run before merge
 - [ ] <...>
 
-🤖 Reviewed by Claude Sonnet 4.6 (review-pr skill)
+🤖 Reviewed by <your model name> (review-pr skill)
 EOF
 )"
 ```
 
-For needs-fix / blocker verdicts, swap `--approve` for `--request-changes`:
+For needs-fix / blocker verdicts (both tiers use `--request-changes`):
 
 ```bash
 gh pr review <N> --request-changes --body "$(cat <<'EOF'
@@ -239,10 +252,13 @@ gh pr review <N> --request-changes --body "$(cat <<'EOF'
 - [ ] <...>
 - [ ] <...>
 
-🤖 Reviewed by Claude Sonnet 4.6 (review-pr skill)
+🤖 Reviewed by <your model name> (review-pr skill)
 EOF
 )"
 ```
+
+Replace `<your model name>` with the actual model you are running as
+(e.g. `Claude Sonnet 4.6` or `Claude Opus 4.6`).
 
 Rules for the review body:
 
@@ -256,16 +272,8 @@ Rules for the review body:
   - **needs-fix** — one or more needs-fix items. No blockers.
   - **blocker** — at least one blocker. Merging would break master.
 
-Use the matching `gh pr review` state so GitHub's PR list shows the
-verdict at a glance:
-
-- **approve** → post the body with `gh pr review <N> --approve --body "..."`
-  (green checkmark in the PR list).
-- **needs-fix** or **blocker** → post the body with
-  `gh pr review <N> --request-changes --body "..."` (red "Changes
-  requested" badge in the PR list).
-
-Do **not** approve and then merge — merging is the user's call.
+See the table above for which `gh pr review` flag to use per tier and
+verdict. Do **not** approve and then merge — merging is the user's call.
 
 ### 6. Report back
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -288,22 +288,24 @@ Avoid:
 
 - [ ] **Unit tests: expand EntityManager coverage** — add tests for
   the EntityManager operations not yet covered by
-  `test/ecs/entity_manager_test.cpp`.
-  - **Area:** test/ecs
+  `entity_manager_test.cpp`.
+  - **Area:** test/entity
   - **Model:** sonnet
   - **Owner:** free
   - **Blocked by:** (none)
-  - **Acceptance:** `test/ecs/entity_manager_test.cpp` covers: entity
+  - **Acceptance:** `test/entity/entity_manager_test.cpp` covers: entity
     create/destroy lifecycle, entity pool recycling, named entities
     (`setName`/`getEntityByName`), `destroyAllEntities`, entity flags
     (`setFlags`, `markEntityForDeletion`, `destroyMarkedEntities`),
     and archetype migration when components are added/removed via
     `setComponent`/`removeComponentById`. All tests pass.
-  - **Notes:** follow the conventions in `test/CLAUDE.md`. The existing
-    file already has a `IREntityTest` fixture that constructs an
-    `EntityManager` — extend it. The constructor sets `g_entityManager`,
-    so both member-instance and free-function calls work. Existing tests
-    cover deferred removal and simple removal — focus on the gaps. If a
+  - **Notes:** follow the conventions in `test/CLAUDE.md`. First, move
+    the existing file from `test/ecs/entity_manager_test.cpp` to
+    `test/entity/entity_manager_test.cpp` and update the source path
+    in `test/CMakeLists.txt`. Then extend the existing `IREntityTest`
+    fixture. The constructor sets `g_entityManager`, so both
+    member-instance and free-function calls work. Existing tests cover
+    deferred removal and simple removal — focus on the gaps. If a
     test uncovers a real bug, stop and requeue as `[opus]`.
   - **Links:**
 
@@ -407,7 +409,7 @@ Avoid:
   - **Notes:** these are pure functions with no global state — use
     plain `TEST()`, no fixture needed. `kTolerance` for float
     comparisons. The `ir_math.cpp` iso-math tests are being handled
-    on a separate branch (`claude/math-iso-tests`) — do not duplicate
+    on a separate PR (jakildev/IrredenEngine#79) — do not duplicate
     that work. Focus only on the header-only helpers listed above.
     Follow `test/CLAUDE.md` conventions.
   - **Links:**

--- a/TASKS.md
+++ b/TASKS.md
@@ -286,6 +286,132 @@ Avoid:
     than fixing inline.
   - **Links:**
 
+- [ ] **Unit tests: expand EntityManager coverage** — add tests for
+  the EntityManager operations not yet covered by
+  `test/ecs/entity_manager_test.cpp`.
+  - **Area:** test/ecs
+  - **Model:** sonnet
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** `test/ecs/entity_manager_test.cpp` covers: entity
+    create/destroy lifecycle, entity pool recycling, named entities
+    (`setName`/`getEntityByName`), `destroyAllEntities`, entity flags
+    (`setFlags`, `markEntityForDeletion`, `destroyMarkedEntities`),
+    and archetype migration when components are added/removed via
+    `setComponent`/`removeComponentById`. All tests pass.
+  - **Notes:** follow the conventions in `test/CLAUDE.md`. The existing
+    file already has a `IREntityTest` fixture that constructs an
+    `EntityManager` — extend it. The constructor sets `g_entityManager`,
+    so both member-instance and free-function calls work. Existing tests
+    cover deferred removal and simple removal — focus on the gaps. If a
+    test uncovers a real bug, stop and requeue as `[opus]`.
+  - **Links:**
+
+- [ ] **Unit tests: archetype and archetype_node** — test archetype
+  creation, component string formatting, and ArchetypeNode construction
+  and child-of relation lookup.
+  - **Area:** test/entity
+  - **Model:** sonnet
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** new file `test/entity/archetype_test.cpp` added to
+    `test/CMakeLists.txt`, covers: `makeComponentStringInternal`
+    formatting, `ArchetypeNode` construction with pure components,
+    `getChildOfRelation` returning `kNullRelation` when no child-of
+    relation is present. All tests pass.
+  - **Notes:** `archetype.cpp` is small (just string formatting) and
+    `archetype_node.cpp` is small (constructor + one query). Combine
+    into one test file. Use an `EntityManager` fixture since
+    `ArchetypeNode` construction calls `isPureComponent` and
+    `createComponentData` which need the global entity manager. Follow
+    `test/CLAUDE.md` conventions.
+  - **Links:**
+
+- [ ] **Unit tests: ArchetypeGraph** — test graph construction, node
+  lookup/creation, edge wiring, and the BFS relation sort.
+  - **Area:** test/entity
+  - **Model:** opus
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** new file `test/entity/archetype_graph_test.cpp`
+    added to `test/CMakeLists.txt`, covers: base node exists after
+    construction, `findArchetypeNode` returns nullptr for unknown type,
+    `findCreateArchetypeNode` creates and wires add/remove edges,
+    repeated `findCreateArchetypeNode` returns the same node,
+    `sortArchetypeNodesByRelationChildOf` orders parents before
+    children. All tests pass.
+  - **Notes:** this is `[opus]` because the graph traversal logic,
+    edge wiring, and BFS sort are subtle — a Sonnet agent could
+    miss edge cases around shared intermediate nodes or the
+    unused-but-present `createArchetypeNodeWithArchetype` /
+    `connectNodeToBase` / `createNodeChainToBase` functions. Need an
+    `EntityManager` fixture for the global state. Follow
+    `test/CLAUDE.md` conventions.
+  - **Links:**
+
+- [ ] **Unit tests: ir_entity free-function API** — test the global
+  facade functions in `engine/entity/src/ir_entity.cpp`.
+  - **Area:** test/entity
+  - **Model:** sonnet
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** new file `test/entity/ir_entity_test.cpp` added to
+    `test/CMakeLists.txt`, covers: `createEntity`, `destroyEntity`,
+    `destroyAllEntities`, `makeComponentString`, `setParent` /
+    `getParentEntityFromArchetype` relation wiring, `setName` /
+    `getEntity` named-entity round-trip. All tests pass.
+  - **Notes:** these are thin wrappers over `EntityManager` — the
+    tests verify the global wiring works, not the underlying logic
+    (that's covered by the EntityManager tests). Keep tests focused
+    on "does the facade route correctly." The old stub
+    `ir_entity_test.cpp` was deleted in the test-conventions PR —
+    create a fresh file. Follow `test/CLAUDE.md` conventions.
+  - **Links:**
+
+- [ ] **Unit tests: SystemManager** — test system registration,
+  pipeline execution order, and relation tick dispatch.
+  - **Area:** test/system
+  - **Model:** opus
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** new file `test/system/system_manager_test.cpp`
+    added to `test/CMakeLists.txt`, covers: `registerPipeline` stores
+    the pipeline, `executePipeline` calls systems in order and flushes
+    structural changes, `handleRelationTick` fires once per unique
+    related entity. All tests pass.
+  - **Notes:** this is `[opus]` because the tick dispatch, relation
+    tick deduplication, and interaction with `flushStructuralChanges`
+    are subtle. The fixture needs both `EntityManager` and
+    `SystemManager` initialized (both set their global pointers in
+    their constructors). Creating test systems requires the
+    `createSystem<>` template machinery — read
+    `engine/system/CLAUDE.md` before writing tests. Follow
+    `test/CLAUDE.md` conventions.
+  - **Links:**
+
+- [ ] **Unit tests: math headers (easing, color, bezier)** — test
+  pure-function math helpers in the header-only math utilities.
+  - **Area:** test/math
+  - **Model:** sonnet
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** new file(s) under `test/math/` added to
+    `test/CMakeLists.txt`, covering: easing functions
+    (`engine/math/include/irreden/math/easing_functions.hpp`) —
+    boundary values (t=0 returns 0, t=1 returns 1), monotonicity for
+    a sampling of t values; color helpers
+    (`engine/math/include/irreden/math/color.hpp`) — round-trip
+    conversions if any, boundary values; bezier curves
+    (`engine/math/include/irreden/math/bezier_curves.hpp`) — endpoint
+    interpolation (t=0 returns start, t=1 returns end). All tests pass.
+  - **Notes:** these are pure functions with no global state — use
+    plain `TEST()`, no fixture needed. `kTolerance` for float
+    comparisons. The `ir_math.cpp` iso-math tests are being handled
+    on a separate branch (`claude/math-iso-tests`) — do not duplicate
+    that work. Focus only on the header-only helpers listed above.
+    Follow `test/CLAUDE.md` conventions.
+  - **Links:**
+
 ---
 
 ## In progress

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -1,0 +1,200 @@
+# Unit Tests
+
+GoogleTest-based test suite for the Irreden Engine. All tests live in
+the centralized `test/` tree (not co-located with source) and compile
+into a single `IrredenEngineTest` binary that links against the full
+`IrredenEngine` static library.
+
+---
+
+## Why centralized, not co-located
+
+The engine modules are tightly coupled static libraries — ECS tests
+need entity + math + profile wired up together, system tests need the
+full archetype runtime, etc. A per-module test binary would duplicate
+all that linkage. The centralized tree gives us one binary, one
+FetchContent pull of gtest, and a directory structure that mirrors the
+engine modules for discoverability.
+
+---
+
+## Directory layout
+
+Mirror the engine module path under `test/`:
+
+```
+test/
+  CMakeLists.txt          # single IrredenEngineTest target
+  CLAUDE.md               # this file
+  entity/                 # tests for engine/entity/
+    entity_manager_test.cpp
+    archetype_test.cpp
+    archetype_graph_test.cpp
+    archetype_node_test.cpp
+  math/                   # tests for engine/math/
+    physics_test.cpp
+    ir_math_test.cpp
+  system/                 # tests for engine/system/
+    system_manager_test.cpp
+  render/                 # tests for engine/render/
+  world/                  # tests for engine/world/
+  ...
+```
+
+Create the subdirectory when adding the first test file for a module.
+
+---
+
+## File naming
+
+- One test file per source file: `<source_basename>_test.cpp`
+- Example: `engine/entity/src/archetype_graph.cpp` is tested by
+  `test/entity/archetype_graph_test.cpp`
+- For header-only code (e.g. prefabs), name the test after the header:
+  `test/prefabs/c_position_test.cpp` for a component header
+
+---
+
+## Registration
+
+Every new `_test.cpp` **must** be added to the `add_executable` source
+list in `test/CMakeLists.txt`. `gtest_discover_tests()` handles CTest
+registration automatically — no manual `add_test()` calls needed.
+
+---
+
+## Test naming
+
+| Element             | Convention                          | Example                                          |
+|---------------------|-------------------------------------|--------------------------------------------------|
+| Test suite (fixture)| `PascalCase`, module prefix allowed | `EntityManagerTest`, `ArchetypeGraphTest`         |
+| Test suite (plain)  | `PascalCase`                        | `PhysicsTest`, `IsoMathTest`                      |
+| Test name           | `PascalCase`, descriptive verb      | `CreateEntityReturnsNonNull`                      |
+| Fixture class       | Same as test suite name             | `class EntityManagerTest : public testing::Test`  |
+
+Use `TEST_F` (fixture) when tests share setup — typically anything that
+needs ECS runtime state (entity manager, archetypes). Use plain `TEST`
+for pure functions (math helpers, coordinate transforms).
+
+---
+
+## Test components and helpers
+
+Test-only component types use the `Test` prefix — `TestMarker`,
+`TestPayload`, `TestRemovable`. Do **not** use the engine's `C_` prefix
+for test components (they aren't real components registered in the
+engine).
+
+Keep test helpers (custom matchers, shared fixtures) in a `test/support/`
+directory if they're used by more than one test file. For single-file
+helpers, define them in an anonymous namespace at the top of the file.
+
+---
+
+## Floating-point comparisons
+
+Use `EXPECT_NEAR(actual, expected, tolerance)` with a file-scoped
+tolerance constant:
+
+```cpp
+namespace {
+constexpr float kTolerance = 1e-5f;
+} // namespace
+```
+
+Do not use `EXPECT_FLOAT_EQ` — it uses ULP-based comparison that can
+be surprising for computed values.
+
+---
+
+## Assertion guidelines
+
+- `EXPECT_*` for checks that should continue on failure (most cases)
+- `ASSERT_*` only when the test cannot meaningfully continue after
+  failure (e.g. a pointer is null and the next line dereferences it)
+- Prefer the most specific assertion: `EXPECT_EQ` over `EXPECT_TRUE(a == b)`,
+  `EXPECT_NEAR` over manual tolerance checks
+
+---
+
+## Structure within a test file
+
+```cpp
+#include <gtest/gtest.h>
+#include <irreden/the_header_under_test.hpp>
+
+namespace {
+
+// Test-only types (if needed)
+struct TestMarker {};
+
+// Tolerance constants (if needed)
+constexpr float kTolerance = 1e-5f;
+
+// Fixture (if needed)
+class FooTest : public testing::Test {
+  protected:
+    FooTest() : m_thing{} {}
+    SomeType m_thing;
+};
+
+// Tests — group by function/behavior, most basic first
+TEST_F(FooTest, BasicOperation) { ... }
+TEST_F(FooTest, EdgeCase) { ... }
+TEST_F(FooTest, ErrorCondition) { ... }
+
+} // namespace
+```
+
+Wrap everything in an anonymous namespace. This prevents ODR collisions
+between test files that define identically-named helpers.
+
+---
+
+## Building and running
+
+```bash
+# Build
+cmake --build build --target IrredenEngineTest -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+
+# Run all tests
+ctest --test-dir build --output-on-failure
+
+# Run tests matching a pattern
+ctest --test-dir build --tests-regex "EntityManager"
+
+# Run the binary directly (verbose gtest output)
+./build/IrredenEngineTest --gtest_filter="EntityManagerTest.*"
+```
+
+---
+
+## GoogleTest version
+
+Pinned to a release tag in `test/CMakeLists.txt` (not `main`). Update
+the tag deliberately, not by accident. If you need a newer gtest
+feature, update the `GIT_TAG` and note the reason in the commit message.
+
+---
+
+## What to test (guidance for task authors)
+
+**Good targets for unit tests:**
+- Pure functions (math helpers, coordinate transforms, physics formulas)
+- Entity manager operations (create, destroy, component add/remove/get,
+  archetype migration)
+- Archetype graph traversal and matching
+- System creation and tick dispatch (with mock components)
+- Deferred structural changes (the flush/apply cycle)
+- World/chunk management
+
+**Not good targets for unit tests (use integration/visual tests):**
+- Render pipeline output (requires GPU context)
+- Audio playback
+- Window/input handling (requires OS event loop)
+- Shader compilation (requires graphics backend)
+
+When a test uncovers a real bug in the code under test, **stop and
+requeue as `[opus]`** with a bug report rather than fixing the bug
+inline in a test PR. Test PRs should test existing behavior, not
+change it.

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -43,6 +43,10 @@ test/
 
 Create the subdirectory when adding the first test file for a module.
 
+**Migration note:** `entity_manager_test.cpp` currently lives at
+`test/ecs/` (legacy path). The first entity-test task should move it to
+`test/entity/` and update `test/CMakeLists.txt` accordingly.
+
 ---
 
 ## File naming

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(IrredenEngineTest
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        main
+    GIT_TAG        v1.15.2
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)

--- a/test/ecs/ir_entity_test.cpp
+++ b/test/ecs/ir_entity_test.cpp
@@ -1,4 +1,0 @@
-#include <gtest/gtest.h>
-#include <irreden/ir_entity.hpp>
-
-namespace {}


### PR DESCRIPTION
## Summary
- Add `test/CLAUDE.md` documenting the engine's unit testing conventions: centralized test tree layout, file/suite/fixture naming, assertion guidelines, float tolerance patterns, and what-to-test guidance.
- Pin googletest to `v1.15.2` (was tracking `main`).
- Delete two dead stub files (`test/ecs/ir_entity_test.cpp`, `test/system/system_manager_tests.cpp`).
- Queue 6 new unit-test tasks in `TASKS.md` for the fleet: EntityManager expansion, archetype/archetype_node, ArchetypeGraph (opus), ir_entity facade, SystemManager (opus), math headers (easing/color/bezier).

## Test plan
- [ ] Verify `test/CLAUDE.md` conventions are clear and complete
- [ ] Verify gtest `v1.15.2` tag resolves on next `cmake --preset` configure
- [ ] Confirm deleted stubs were not referenced in `test/CMakeLists.txt` (they weren't)
- [ ] Review TASKS.md entries for correct model tagging and acceptance criteria

## Notes for reviewer
This is a docs/config/queue PR — no application code changed. Once merged, Sonnet agents can immediately start picking up the queued test tasks. The two `[opus]` tasks (ArchetypeGraph, SystemManager) are flagged because their test subjects involve subtle graph traversal and tick-dispatch logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)