### PR TITLE
docs: add doc comments to ir_constants.hpp

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -271,6 +271,21 @@ Avoid:
     profiler build flag.
   - **Links:**
 
+- [~] **Doc pass: add doc comments to `ir_constants.hpp`** — explain the
+  non-obvious engine-wide constants (chunk size, voxel pool limits, distance
+  sentinel range, extra pixel buffer) so new contributors don't have to
+  grep call sites to understand their purpose.
+  - **Area:** engine/common
+  - **Model:** sonnet
+  - **Owner:** sonnet-fleet-2
+  - **Blocked by:** (none)
+  - **Acceptance:** every constant in `engine/common/include/irreden/ir_constants.hpp`
+    has a `///` doc comment; no constants renamed or removed; build passes.
+  - **Notes:** mechanical doc pass. Source of truth for semantic meaning is
+    `engine/render/src/render_manager.cpp` (pixel buffer, voxel pool) and
+    `engine/prefabs/irreden/render/` (distance sentinels).
+  - **Links:**
+
 - [ ] **Example: unit tests for engine/math/physics.hpp** — exhaustive
   tests for ballistic helpers.
   - **Area:** engine/math

--- a/engine/common/include/irreden/ir_constants.hpp
+++ b/engine/common/include/irreden/ir_constants.hpp
@@ -7,34 +7,70 @@ using namespace IRMath;
 
 namespace IRConstants {
 
+/// Target frame rate for the fixed-step update loop.
 constexpr int kFPS = 60;
 
+/// Extra canvas dimensions (in iso pixels) added beyond the game resolution.
+/// Prevents visible seams at canvas edges when the camera is offset by a
+/// fractional amount — the trixel-to-framebuffer blit can shift by up to
+/// this amount without uncovering empty canvas.
 constexpr ivec2 kSizeExtraPixelBuffer = uvec2(4, 2);
 
+/// Size of a standard voxel chunk (width × depth × height, in voxels).
 constexpr uvec3 kChunkSize = uvec3{32, 32, 32};
+
+/// Iso-space canvas size (in triangles) that covers one full chunk at 1:1 zoom.
+/// Derived from kChunkSize via the isometric projection.
 constexpr uvec2 kChunkTriangleCanvasSize = IRMath::size3DtoSize2DIso(kChunkSize);
+
+/// Minimum zoom level for the trixel canvas (1 iso-pixel = 1 screen pixel).
 constexpr vec2 kTrixelCanvasZoomMin = vec2{1.0f, 1.0f};
+
+/// Maximum zoom level for the trixel canvas (1 iso-pixel = 64 screen pixels).
 constexpr vec2 kTrixelCanvasZoomMax = vec2{64.0f, 64.0f};
 
+/// Reserved: intended voxel-pool bounding box for a player entity.
+/// Currently unused — kept as a reference size for future player-specific pools.
 constexpr ivec3 kVoxelPoolPlayerSize = ivec3{16, 16, 16};
+
+/// Iso-space canvas size for a player voxel pool (derived from kVoxelPoolPlayerSize).
+/// Currently unused.
 constexpr ivec2 kTrixelCanvasPlayerSize = IRMath::size3DtoSize2DIso(kVoxelPoolPlayerSize);
 
+/// World-space origin for entities placed at ground level within a chunk.
+/// Z is the maximum layer (kChunkSize.z - 1) because the walkable surface
+/// is the topmost voxel layer of the chunk — higher Z is visually higher.
 constexpr ivec3 kChunkGroundOrigin = ivec3{0, 0, kChunkSize.z - 1};
 
+/// Minimum corner of the valid world-space AABB for entity positions.
 constexpr vec3 kWorldBoundMin = vec3{0, 0, 0};
+
+/// Maximum corner of the valid world-space AABB for entity positions.
+/// Leaves a 1-voxel border on X/Y and a 2-voxel border on Z to keep entities
+/// inside visible canvas area.
 constexpr vec3 kWorldBoundMax = vec3(kChunkSize) - vec3(1, 1, 2);
 
+/// Sentinel value used to clear / mark "empty" in the trixel distance buffer.
+/// Anything ≤ this is treated as background (behind every real voxel).
 constexpr Distance kTrixelDistanceMinDistance = -65535;
+
+/// Maximum depth value stored in the trixel distance buffer.
+/// Used as the initial clear value and as a far-plane sentinel in shaders.
 constexpr Distance kTrixelDistanceMaxDistance = 65535;
 
-// TODO: Dynamic based on current GPU
+/// Maximum voxel pool AABB per entity allocation.
+/// TODO: derive this dynamically from GPU memory stats at init time.
 constexpr ivec3 kVoxelPoolMaxAllocationSize = ivec3{64, 64, 64};
+
+/// Total voxel count in one max-size entity allocation.
 constexpr int kVoxelPoolMaxAllocationSizeTotal =
     kVoxelPoolMaxAllocationSize.x * kVoxelPoolMaxAllocationSize.y * kVoxelPoolMaxAllocationSize.z;
 
+/// Total size of the GPU voxel pool (all single-voxel entity slots combined).
+/// TODO: initialise based on GPU stats; make multiple pools if needed.
 constexpr ivec3 kVoxelPoolSize = ivec3{64, 64, 64};
-// TODO: initalize buffer based on GPU stats, and make multiple to
-// make up the difference
+
+/// Total number of single-voxel slots in the GPU pool.
 constexpr int kMaxSingleVoxels = IRMath::multVecComponents(IRConstants::kVoxelPoolSize);
 
 } // namespace IRConstants


### PR DESCRIPTION
## Summary
- Added `///` doc comments to every constant in `engine/common/include/irreden/ir_constants.hpp`
- Comments explain purpose and non-obvious semantics (extra pixel buffer, distance sentinels, ground-level Z convention, unused reserved constants)

## Test plan
- [ ] Build passes (no constants renamed or removed — pure doc addition)
- [ ] Each constant has a `///` comment explaining its purpose and, where relevant, its derivation or non-obvious semantics

## Notes for reviewer
Key non-obvious semantics captured:
- `kSizeExtraPixelBuffer`: prevents seams at canvas edges when camera has fractional offsets
- `kChunkGroundOrigin`: Z is max layer because higher Z = visually higher in the isometric projection (walkable surface is topmost layer)
- `kTrixelDistanceMinDistance/MaxDistance`: sentinels for clear value and background detection — anything ≤ min is treated as background
- `kVoxelPoolPlayerSize` / `kTrixelCanvasPlayerSize`: explicitly marked as reserved/currently unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)