### PR TITLE
build: fix CI quality.yml preset names to match CMakePresets.json

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,16 +25,16 @@ jobs:
           version: "18"
 
       - name: Configure
-        run: cmake --preset default
+        run: cmake --preset windows-debug
 
       - name: Format check
-        run: cmake --build --preset format-check
+        run: cmake --build --preset windows-format-check
 
       - name: Lint
-        run: cmake --build --preset lint
+        run: cmake --build --preset windows-lint
 
       - name: Build tests
-        run: cmake --build --preset tests
+        run: cmake --build --preset windows-tests
 
       - name: Run tests
-        run: ctest --preset default-tests
+        run: ctest --preset windows-default-tests


### PR DESCRIPTION
## Summary
- All five `cmake`/`ctest` invocations in the quality workflow referenced non-existent preset names (`default`, `format-check`, `lint`, `tests`, `default-tests`).
- `CMakePresets.json` uses platform-prefixed names throughout; since the workflow runs on `windows-latest`, the correct names are `windows-debug`, `windows-format-check`, `windows-lint`, `windows-tests`, `windows-default-tests`.
- Without this fix the CI fails at the configure step with "no preset named 'default' found" and every subsequent step is unreachable.

## Test plan
- [x] Verified all five preset names against `CMakePresets.json` — each replacement resolves to a real entry
- [ ] CI green on this PR (will confirm once GitHub Actions runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)