### PR TITLE
docs: add doc comments to ir_platform.hpp, color.hpp, easing_functions.hpp

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -271,11 +271,11 @@ Avoid:
     profiler build flag.
   - **Links:**
 
-- [ ] **Example: unit tests for engine/math/physics.hpp** — exhaustive
+- [x] **Example: unit tests for engine/math/physics.hpp** — exhaustive
   tests for ballistic helpers.
   - **Area:** engine/math
   - **Model:** sonnet
-  - **Owner:** free
+  - **Owner:** sonnet-fleet-2
   - **Blocked by:** (none — unit tests don't care which platform builds them)
   - **Acceptance:** new test binary builds, tests cover all four physics
     helpers (`impulseForHeight`, `flightTimeForHeight`, `heightForImpulse`,
@@ -284,6 +284,38 @@ Avoid:
     `engine/math/CLAUDE.md` under "Physics". If a test uncovers a real bug
     in the helpers, stop and requeue as `[opus]` with a bug report rather
     than fixing inline.
+  - **Links:** https://github.com/jakildev/IrredenEngine/pull/79
+
+- [~] **Doc pass: add doc comments to `ir_platform.hpp`, `color.hpp`, and `easing_functions.hpp`** —
+  document the platform-detection scheme, graphics-convention struct, HSV
+  color sorting helpers, and easing function map so contributors don't have
+  to grep call sites to understand the non-obvious values.
+  - **Area:** engine/common, engine/math
+  - **Model:** sonnet
+  - **Owner:** sonnet-fleet-2
+  - **Blocked by:** (none)
+  - **Acceptance:** every public declaration in the three files has a `///`
+    doc comment; no APIs renamed or removed; build passes.
+  - **Notes:** key non-obvious items — `screenYDirection_` sign convention
+    (OpenGL Y-up vs Metal/Vulkan Y-down), `backEaseIn/Out/InOut` hardcoded
+    overshoot params, `kIsoToScreenSign` derivation.
+  - **Links:**
+
+- [ ] **Perf: cache HSV in color sort helpers** — `sortByHue`, `sortBySaturation`,
+  and `sortByValue` in `engine/math/include/irreden/math/color.hpp` each call
+  `glm::hsvColor` twice per comparison (once for `a`, once for `b`), resulting
+  in O(n log n) redundant HSV conversions. Pre-compute HSV for each element
+  before calling `std::sort`.
+  - **Area:** engine/math
+  - **Model:** sonnet
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** each of the three HSV sort functions converts each Color to
+    HSV exactly once (O(n) total); `sortByLuminance` is unchanged; build passes.
+  - **Notes:** uncovered by simplify review on the doc-pass PR. Fix is a
+    standard Schwartzian-transform pattern: build a `vector<pair<float,Color>>`
+    sorted on the cached channel, then strip the key. Only worthwhile if these
+    functions are ever called on palettes larger than ~50 colors.
   - **Links:**
 
 ---

--- a/engine/common/include/irreden/ir_platform.hpp
+++ b/engine/common/include/irreden/ir_platform.hpp
@@ -5,18 +5,25 @@
 
 namespace IRPlatform {
 
+/// Identifies which GPU graphics API the engine is compiled against.
+/// Selected at build time via the `IR_GRAPHICS_METAL` or `IR_GRAPHICS_VULKAN`
+/// preprocessor defines; defaults to OpenGL when neither is defined.
 enum class GraphicsBackend {
     OPENGL,
     METAL,
     VULKAN
 };
 
+/// Identifies the host operating system at compile time.
+/// Derived from standard predefined macros (`__APPLE__`, `_WIN32`);
+/// defaults to Linux when neither is defined.
 enum class OperatingSystem {
     LINUX,
     MACOS,
     WINDOWS
 };
 
+/// Compile-time graphics backend selected for this build.
 #if defined(IR_GRAPHICS_METAL)
 inline constexpr GraphicsBackend kGraphicsBackend = GraphicsBackend::METAL;
 #elif defined(IR_GRAPHICS_VULKAN)
@@ -25,6 +32,7 @@ inline constexpr GraphicsBackend kGraphicsBackend = GraphicsBackend::VULKAN;
 inline constexpr GraphicsBackend kGraphicsBackend = GraphicsBackend::OPENGL;
 #endif
 
+/// Compile-time operating system selected for this build.
 #if defined(__APPLE__)
 inline constexpr OperatingSystem kOperatingSystem = OperatingSystem::MACOS;
 #elif defined(_WIN32)
@@ -33,21 +41,33 @@ inline constexpr OperatingSystem kOperatingSystem = OperatingSystem::WINDOWS;
 inline constexpr OperatingSystem kOperatingSystem = OperatingSystem::LINUX;
 #endif
 
+/// True when the active backend is OpenGL.
 inline constexpr bool kIsOpenGL = kGraphicsBackend == GraphicsBackend::OPENGL;
 
+/// True when building for Linux (WSL or native).
 inline constexpr bool kIsLinux = kOperatingSystem == OperatingSystem::LINUX;
+/// True when building for macOS.
 inline constexpr bool kIsMacOS = kOperatingSystem == OperatingSystem::MACOS;
+/// True when building for Windows (MSYS2 / native).
 inline constexpr bool kIsWindows = kOperatingSystem == OperatingSystem::WINDOWS;
 
+/// Per-backend coordinate-convention constants used to reconcile differences
+/// between OpenGL and Metal/Vulkan clip-space and screen-space orientations.
 struct GraphicsConventions {
-    // Net screen-vs-iso Y direction after backend-specific clip/texture transforms.
+    /// Sign applied to the iso-space Y axis when converting to screen space.
+    /// OpenGL clip-space is Y-up, so iso +Y must flip to -1 to go down the
+    /// screen. Metal and Vulkan are Y-down, so no flip is needed (+1).
     float screenYDirection_;
-    // GLFW reports mouse Y top-down; flip when the backend expects bottom-up screen space.
+    /// Whether to negate GLFW's top-down mouse Y before use.
+    /// OpenGL expects bottom-up screen coordinates, so the mouse Y must be
+    /// flipped. Metal/Vulkan are already top-down, matching GLFW directly.
     bool flipMouseY_;
-    // GLM orthographic helper choice: true uses [0, 1], false uses [-1, 1].
+    /// Which GLM orthographic depth range to use: true → [0, 1] (Metal/Vulkan
+    /// NDC convention), false → [-1, 1] (OpenGL NDC convention).
     bool ndcDepthZeroToOne_;
 };
 
+/// Returns the GraphicsConventions for a given backend.
 constexpr GraphicsConventions conventionsFor(GraphicsBackend backend) {
     switch (backend) {
         case GraphicsBackend::OPENGL:
@@ -61,7 +81,14 @@ constexpr GraphicsConventions conventionsFor(GraphicsBackend backend) {
     return GraphicsConventions{-1.0f, true, false};
 }
 
+/// Compile-time graphics conventions for the active backend.
+/// Use `kGfx.screenYDirection_` etc. instead of querying the backend enum
+/// directly — it centralises all backend-specific sign logic here.
 inline constexpr GraphicsConventions kGfx = conventionsFor(kGraphicsBackend);
+
+/// Per-component sign vector for converting an iso-space (x, y) vector to
+/// screen space. X is always +1 (iso and screen X agree); Y uses
+/// `kGfx.screenYDirection_` to account for the Y-axis flip on OpenGL.
 inline constexpr IRMath::vec2 kIsoToScreenSign{1.0f, kGfx.screenYDirection_};
 
 } // namespace IRPlatform

--- a/engine/math/include/irreden/math/color.hpp
+++ b/engine/math/include/irreden/math/color.hpp
@@ -8,6 +8,9 @@
 
 namespace IRMath {
 
+/// Returns `colors` sorted ascending by HSV hue (0°–360°).
+/// Converts each Color from RGB to HSV via `glm::hsvColor` and compares the
+/// H channel (vec3.x). Takes by value so the caller's vector is not mutated.
 inline std::vector<Color> sortByHue(std::vector<Color> colors) {
     std::sort(colors.begin(), colors.end(), [](const Color &a, const Color &b) {
         vec3 ha = glm::hsvColor(vec3(a.red_ / 255.0f, a.green_ / 255.0f, a.blue_ / 255.0f));
@@ -17,6 +20,8 @@ inline std::vector<Color> sortByHue(std::vector<Color> colors) {
     return colors;
 }
 
+/// Returns `colors` sorted ascending by HSV saturation (0–1).
+/// Converts each Color from RGB to HSV and compares the S channel (vec3.y).
 inline std::vector<Color> sortBySaturation(std::vector<Color> colors) {
     std::sort(colors.begin(), colors.end(), [](const Color &a, const Color &b) {
         vec3 ha = glm::hsvColor(vec3(a.red_ / 255.0f, a.green_ / 255.0f, a.blue_ / 255.0f));
@@ -26,6 +31,8 @@ inline std::vector<Color> sortBySaturation(std::vector<Color> colors) {
     return colors;
 }
 
+/// Returns `colors` sorted ascending by HSV value (brightness, 0–1).
+/// Converts each Color from RGB to HSV and compares the V channel (vec3.z).
 inline std::vector<Color> sortByValue(std::vector<Color> colors) {
     std::sort(colors.begin(), colors.end(), [](const Color &a, const Color &b) {
         vec3 ha = glm::hsvColor(vec3(a.red_ / 255.0f, a.green_ / 255.0f, a.blue_ / 255.0f));
@@ -35,6 +42,9 @@ inline std::vector<Color> sortByValue(std::vector<Color> colors) {
     return colors;
 }
 
+/// Returns `colors` sorted ascending by perceptual luminance.
+/// Uses the Rec. 601 luma formula: Y = 0.299R + 0.587G + 0.114B, where R/G/B
+/// are raw uint8_t byte values (not normalized). Darker colors sort first.
 inline std::vector<Color> sortByLuminance(std::vector<Color> colors) {
     std::sort(colors.begin(), colors.end(), [](const Color &a, const Color &b) {
         float la = 0.299f * a.red_ + 0.587f * a.green_ + 0.114f * a.blue_;

--- a/engine/math/include/irreden/math/easing_functions.hpp
+++ b/engine/math/include/irreden/math/easing_functions.hpp
@@ -1,4 +1,4 @@
-// Easing function implementations come from the GLM library
+// Easing function implementations come from glm/gtx/easing.hpp
 
 #ifndef EASING_FUNCTIONS_H
 #define EASING_FUNCTIONS_H
@@ -9,6 +9,9 @@
 
 namespace IRMath {
 
+/// Enumeration of all available easing curves.
+/// Use as a key into `kEasingFunctions` to retrieve a callable that maps a
+/// normalized time `t ∈ [0, 1]` to an eased output value.
 enum IREasingFunctions {
     kLinearInterpolation,
     kQuadraticEaseIn,
@@ -43,12 +46,19 @@ enum IREasingFunctions {
     kBounceEaseInOut
 };
 
+/// Callable type for a GLM easing function: maps normalized `t ∈ [0, 1]` to
+/// an eased output. Stored as `std::function` so lambdas (e.g. back-ease with
+/// a captured overshoot parameter) can be held alongside raw function pointers.
 using GLMEasingFunction = std::function<float(const float &)>;
-// using GLMEasingFunction = float (*)(float);
 
-// const std::unordered_map<IREasingFunctions, GLMEasingFunction> kEasingFunctions = {
-//     {kLinearInterpolation, glm::linearInterpolation<float>}
-// };
+/// Maps every `IREasingFunctions` variant to its GLM implementation.
+/// Look up an easing function by key and call it with a normalized `t` value.
+///
+/// Note: the three back-ease variants use non-default overshoot parameters:
+/// `backEaseIn(t, 0.0)` — no overshoot on the approach;
+/// `backEaseOut(t, 6.0)` — exaggerated overshoot on the release;
+/// `backEaseInOut(t, 0.5)` — mild overshoot in both directions.
+/// These were tuned for the engine's animation feel; change with care.
 const std::unordered_map<IREasingFunctions, GLMEasingFunction> kEasingFunctions = {
     {kLinearInterpolation, glm::linearInterpolation<float>},
     {kQuadraticEaseIn, glm::quadraticEaseIn<float>},


### PR DESCRIPTION
## Summary
- `ir_platform.hpp`: documented all public enums, constants, struct fields, and `conventionsFor` — focus on the non-obvious `GraphicsConventions` sign values and `kIsoToScreenSign` derivation
- `color.hpp`: documented all four HSV/luminance sort helpers, including the by-value semantics and the Rec. 601 luma formula
- `easing_functions.hpp`: documented the enum, `GLMEasingFunction` type alias, and `kEasingFunctions` map; noted the tuned back-ease overshoot params; removed dead commented-out code
- `TASKS.md`: marks the physics-test example task `[x]` (completed by PR #79); queues a follow-up `[sonnet]` task for the pre-existing double-HSV-conversion in the three HSV sort lambdas

## Test plan
- [ ] Build passes — no APIs renamed or removed, pure doc addition
- [ ] Every public declaration in the three files has a `///` comment

## Notes for reviewer
The `kIsMacOS` comment previously said "(Metal backend)" — removed that conflation; macOS could theoretically build with a different backend. The `IREasingFunctions` enum comment previously cited `glm/gtx/easing.hpp` as an implementation detail — moved that reference to the file-level comment near the `#include` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)