### PR TITLE
docs: upgrade physics.hpp comments to /// with formula derivations

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -289,6 +289,19 @@ Avoid:
     profiler build flag.
   - **Links:**
 
+- [~] **Doc pass: add doc comments to `physics.hpp`** — upgrade the five `//`
+  comments in `engine/math/include/irreden/math/physics.hpp` to `///` and
+  expand with formula derivations and units.
+  - **Area:** engine/math
+  - **Model:** sonnet
+  - **Owner:** sonnet-fleet-2
+  - **Blocked by:** (none)
+  - **Acceptance:** all five public declarations have `///` doc comments with
+    formula notes; build passes.
+  - **Notes:** formulas are v=√(2gh), t=2√(2h/g), h=v²/(2g). isTunnelingSafe
+    uses maxFrameDisplacement as the tunneling threshold.
+  - **Links:**
+
 - [~] **Unit tests for iso-projection and math helpers in ir_math.hpp** —
   add `test/math/ir_math_test.cpp` covering the untested `constexpr`/`inline`
   helpers that `physics_test.cpp` does not exercise.

--- a/engine/math/include/irreden/math/physics.hpp
+++ b/engine/math/include/irreden/math/physics.hpp
@@ -5,30 +5,38 @@
 
 namespace IRMath {
 
-// Upward impulse speed for a symmetric ballistic arc reaching height h
-// under constant gravity g.
+/// Upward impulse speed needed to reach `height` under constant `gravity`.
+/// Derived from energy conservation: v = √(2·g·h).
+/// Both `gravity` and `height` must be non-negative; negative inputs produce NaN.
 inline float impulseForHeight(float gravity, float height) {
     return std::sqrt(2.0f * gravity * height);
 }
 
-// Total flight time (up + down) for a symmetric arc under gravity g
-// reaching height h.
+/// Total flight time (up + down) for a symmetric arc reaching `height` under
+/// constant `gravity`. Derived from t = 2·√(2h/g).
+/// The arc is symmetric: time to peak equals time back to the launch height.
 inline float flightTimeForHeight(float gravity, float height) {
     return 2.0f * std::sqrt(2.0f * height / gravity);
 }
 
-// Height reached by a given impulse speed under gravity g.
+/// Maximum height reached by a projectile launched at `impulseSpeed` under
+/// constant `gravity`. Derived from h = v² / (2g).
 constexpr float heightForImpulse(float gravity, float impulseSpeed) {
     return (impulseSpeed * impulseSpeed) / (2.0f * gravity);
 }
 
-// Max position displacement in a single frame at a given velocity.
+/// Maximum position displacement in one frame at `velocity` with timestep `dt`.
+/// Used as the tunneling threshold: if an object can move more than the
+/// combined collider thickness in one frame it may skip through geometry.
 constexpr float maxFrameDisplacement(float velocity, float dt) {
     return velocity * dt;
 }
 
-// Whether the combined collider thickness is sufficient to prevent
-// tunneling at the given max velocity and timestep.
+/// Returns true if the combined collider thickness is large enough to prevent
+/// tunneling at the given max velocity and timestep.
+/// Safe when: maxFrameDisplacement(maxVelocity, dt) < colliderA + colliderB.
+/// If this returns false, reduce `dt`, reduce `maxVelocity`, or thicken the
+/// colliders to restore safety.
 constexpr bool isTunnelingSafe(
     float maxVelocity,
     float dt,


### PR DESCRIPTION
## Summary
- `engine/math/include/irreden/math/physics.hpp`: upgraded all five `//` block comments to `///` doc comments
- Added kinematic formula derivations: `v=√(2gh)`, `t=2√(2h/g)`, `h=v²/(2g)`
- Documents the `maxFrameDisplacement`↔`isTunnelingSafe` relationship
- Notes that negative inputs to the sqrt-based helpers produce NaN
- `TASKS.md`: adds and claims this physics doc-pass task

## Test plan
- [ ] Build passes — no code changed, only comment syntax and content
- [ ] All five public declarations have `///` comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)