### PR TITLE
fleet: fix bash 3 compat in write_worktree_settings

### DIFF
--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -181,21 +181,20 @@ except: pass
         "Bash(dirname:*)"
     )
 
-    # Deduplicate: baseline + existing
-    local -A seen
+    # Deduplicate: baseline + existing (bash 3-compatible — no -A arrays)
     local -a all_allows=()
-    for entry in "${baseline_allows[@]}"; do
-        if [[ -z "${seen[$entry]:-}" ]]; then
-            seen[$entry]=1
-            all_allows+=("$entry")
-        fi
-    done
+    # Baseline has no internal duplicates; add all of it first.
+    all_allows=("${baseline_allows[@]}")
+    # For each existing entry, only add if not already in baseline.
     if [[ -n "$existing_allows" ]]; then
         while IFS= read -r entry; do
-            if [[ -n "$entry" && -z "${seen[$entry]:-}" ]]; then
-                seen[$entry]=1
-                all_allows+=("$entry")
-            fi
+            [[ -z "$entry" ]] && continue
+            local found=0
+            local b
+            for b in "${all_allows[@]}"; do
+                if [[ "$b" == "$entry" ]]; then found=1; break; fi
+            done
+            [[ $found -eq 0 ]] && all_allows+=("$entry")
         done <<< "$existing_allows"
     fi
 


### PR DESCRIPTION
## Summary
- `fleet-up` was crashing with `local: -A: invalid option` on macOS because `write_worktree_settings()` used `local -A seen` (associative array), which requires bash 4+. macOS ships bash 3.2.
- Fix: replace the associative array dedup with a simple indexed array loop. The baseline list is ~24 entries so the O(n²) scan is negligible.

## Test plan
- [ ] Run `fleet-up` on macOS — should complete without `local: -A` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)