### PR TITLE
fleet: use python3 for settings.local.json generation to fix JSON escaping

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -133,21 +133,6 @@ Avoid:
 
 <!-- Add tasks below this line. -->
 
-- [~] **Docs: doc pass on `ir_math_types.hpp` and `color_palettes.hpp`** —
-  add `///` to every public declaration in both files; remove dead commented-
-  out code (the `kFaceCameraRotations` stub in `ir_math_types.hpp` and the
-  commented-out alternative color values in `color_palettes.hpp`).
-  - **Area:** engine/math
-  - **Model:** sonnet
-  - **Owner:** sonnet-fleet-2
-  - **Blocked by:** (none)
-  - **Acceptance:** every public enum, struct, field, and constant in both
-    files has a `///` doc comment; no `//`-commented-out dead code remains;
-    all existing `///` comments from prior passes are preserved.
-  - **Notes:** skip `kInvisable` typo rename — that affects a prefab header
-    in a different module and belongs in its own PR.
-  - **Links:**
-
 - [ ] **Fix `engine/asset` extension mismatch: `.txl` vs `.irtxl`** —
   `saveTrixelTextureData` writes files with `.txl` but `loadTrixelTextureData`
   opens files expecting `.irtxl`. Standardize both on `.txl`.
@@ -317,6 +302,21 @@ Avoid:
 ## Done — last 20
 
 <!-- Completed tasks, newest first. Prune older entries beyond 20. -->
+
+- [x] **Docs: doc pass on `ir_math_types.hpp` and `color_palettes.hpp`** —
+  add `///` to every public declaration in both files; remove dead commented-
+  out code (the `kFaceCameraRotations` stub in `ir_math_types.hpp` and the
+  commented-out alternative color values in `color_palettes.hpp`).
+  - **Area:** engine/math
+  - **Model:** sonnet
+  - **Owner:** sonnet-fleet-2
+  - **Blocked by:** (none)
+  - **Acceptance:** every public enum, struct, field, and constant in both
+    files has a `///` doc comment; no `//`-commented-out dead code remains;
+    all existing `///` comments from prior passes are preserved.
+  - **Notes:** skip `kInvisable` typo rename — that affects a prefab header
+    in a different module and belongs in its own PR.
+  - **Links:** https://github.com/jakildev/IrredenEngine/pull/90
 
 - [x] **Unit tests for iso-projection and math helpers in ir_math.hpp** —
   add `test/math/ir_math_test.cpp` covering the untested `constexpr`/`inline`

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -137,91 +137,76 @@ write_worktree_settings() {
     [[ -d "$wt" ]] || return 0
     mkdir -p "$settings_dir"
 
-    # Merge: preserve any user-granted "allow" entries from previous
-    # sessions, then ensure our baseline entries are present.
-    local existing_allows=""
-    if [[ -f "$settings_file" ]] && command -v python3 >/dev/null 2>&1; then
-        existing_allows="$(python3 -c "
-import json, sys
-try:
-    d = json.load(open('$settings_file'))
-    for a in d.get('permissions',{}).get('allow',[]):
-        print(a)
-except: pass
-" 2>/dev/null)"
-    fi
-
+    # Use python3 to merge baseline allows with any user-granted entries from
+    # previous sessions and write properly-escaped JSON. Bash string concat
+    # cannot safely embed arbitrary allow-rule strings (they may contain
+    # quotes, backslashes, parens) into a JSON file. python3's json.dumps
+    # handles all escaping correctly.
+    #
     # Baseline allows that every fleet agent needs (beyond the user-level
     # ~/.claude/settings.json entries). These cover tools the agents use
     # during freeform work that aren't in the user-level allowlist.
-    local -a baseline_allows=(
-        "Bash(grep:*)"
-        "Bash(find:*)"
-        "Bash(head:*)"
-        "Bash(tail:*)"
-        "Bash(wc:*)"
-        "Bash(diff:*)"
-        "Bash(mkdir:*)"
-        "Bash(cp:*)"
-        "Bash(mv:*)"
-        "Bash(chmod:*)"
-        "Bash(sort:*)"
-        "Bash(uniq:*)"
-        "Bash(tr:*)"
-        "Bash(cut:*)"
-        "Bash(sed:*)"
-        "Bash(awk:*)"
-        "Bash(xargs:*)"
-        "Bash(tee:*)"
-        "Bash(python3:*)"
-        "Bash(file:*)"
-        "Bash(stat:*)"
-        "Bash(realpath:*)"
-        "Bash(basename:*)"
-        "Bash(dirname:*)"
-    )
+    python3 - "$settings_file" "$repo_root" <<'PYEOF'
+import json, sys, os
 
-    # Deduplicate: baseline + existing (bash 3-compatible — no -A arrays)
-    local -a all_allows=()
-    # Baseline has no internal duplicates; add all of it first.
-    all_allows=("${baseline_allows[@]}")
-    # For each existing entry, only add if not already in baseline.
-    if [[ -n "$existing_allows" ]]; then
-        while IFS= read -r entry; do
-            [[ -z "$entry" ]] && continue
-            local found=0
-            local b
-            for b in "${all_allows[@]}"; do
-                if [[ "$b" == "$entry" ]]; then found=1; break; fi
-            done
-            [[ $found -eq 0 ]] && all_allows+=("$entry")
-        done <<< "$existing_allows"
-    fi
+settings_file = sys.argv[1]
+repo_root     = sys.argv[2]
 
-    # Build the JSON allow array
-    local allow_json=""
-    local first=1
-    for entry in "${all_allows[@]}"; do
-        if [[ $first -eq 1 ]]; then
-            allow_json="\"$entry\""
-            first=0
-        else
-            allow_json="$allow_json, \"$entry\""
-        fi
-    done
+baseline = [
+    "Bash(grep:*)",
+    "Bash(find:*)",
+    "Bash(head:*)",
+    "Bash(tail:*)",
+    "Bash(wc:*)",
+    "Bash(diff:*)",
+    "Bash(mkdir:*)",
+    "Bash(cp:*)",
+    "Bash(mv:*)",
+    "Bash(chmod:*)",
+    "Bash(sort:*)",
+    "Bash(uniq:*)",
+    "Bash(tr:*)",
+    "Bash(cut:*)",
+    "Bash(sed:*)",
+    "Bash(awk:*)",
+    "Bash(xargs:*)",
+    "Bash(tee:*)",
+    "Bash(python3:*)",
+    "Bash(file:*)",
+    "Bash(stat:*)",
+    "Bash(realpath:*)",
+    "Bash(basename:*)",
+    "Bash(dirname:*)",
+]
 
-    cat > "$settings_file" <<SETTINGS
-{
-  "permissions": {
-    "additionalDirectories": [
-      "$repo_root"
-    ],
-    "allow": [
-      $allow_json
-    ]
-  }
+# Preserve any user-granted "always allow" entries from previous sessions,
+# but skip ones that look like specific inline python3 -c commands — those
+# are session-specific one-liners that shouldn't outlive a session, and
+# they corrupt JSON when bash tries to re-embed them as string literals.
+# The catch-all "Bash(python3:*)" baseline entry covers all python3 use.
+existing_extra = []
+if os.path.isfile(settings_file):
+    try:
+        d = json.load(open(settings_file))
+        for a in d.get("permissions", {}).get("allow", []):
+            if a not in baseline and 'python3 -c' not in a:
+                existing_extra.append(a)
+    except Exception:
+        pass  # malformed file — start fresh with baseline only
+
+all_allows = baseline + existing_extra
+
+out = {
+    "permissions": {
+        "additionalDirectories": [repo_root],
+        "allow": all_allows,
+    }
 }
-SETTINGS
+
+with open(settings_file, "w") as f:
+    json.dump(out, f, indent=2)
+    f.write("\n")
+PYEOF
 }
 
 for wt in opus-architect sonnet-fleet-1 sonnet-fleet-2 sonnet-reviewer opus-reviewer queue-manager; do


### PR DESCRIPTION
## Summary

- `write_worktree_settings()` was using bash string concatenation to build the `allow` array in `settings.local.json`. Any allow rule containing embedded double quotes (e.g. user-granted `always allow` entries for inline `python3 -c '...'` commands) would be written verbatim as an unescaped JSON string, producing a malformed file.
- Claude Code rejected the malformed files with a **Settings Error: Invalid or malformed JSON** dialog on startup for `sonnet-fleet-1` and `sonnet-fleet-2`.
- Replaced the bash heredoc + string-concat approach with a `python3` heredoc that uses `json.dumps()` for all serialisation — handles any character in an allow rule, including quotes and backslashes.
- Also skips session-specific `python3 -c ...` entries during the merge step (they're covered by the catch-all `Bash(python3:*)` baseline and are the primary source of corruption). Falls back to baseline-only when the existing file can't be parsed.

## Test plan
- [ ] Kill the fleet session: `tmux kill-session -t fleet`
- [ ] Run `fleet-up dry-run` — should complete with no errors
- [ ] Check that all worktree `.claude/settings.local.json` files are valid JSON
- [ ] Attach to the fleet session — no Settings Error dialogs should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)