### PR TITLE
Fix engine/asset extension mismatch: .txl vs .irtxl

### DIFF
--- a/engine/asset/src/ir_asset.cpp
+++ b/engine/asset/src/ir_asset.cpp
@@ -6,6 +6,10 @@
 
 namespace IRAsset {
 
+namespace {
+constexpr const char* kTrixelExtension = ".txl";
+}
+
 void saveTrixelTextureData(
     const std::string &name,
     const std::string &path,
@@ -13,8 +17,12 @@ void saveTrixelTextureData(
     const std::vector<Color> &colors,
     const std::vector<Distance> &distances
 ) {
-    const std::string filename = IRUtility::joinPath(path, name, ".txl");
+    const std::string filename = IRUtility::joinPath(path, name, kTrixelExtension);
     FILE *f = fopen(filename.c_str(), "wb");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for writing: {}", filename);
+        return;
+    }
     fwrite(&size, sizeof(size), 1, f);
     fwrite(colors.data(), sizeof(colors.at(0)), size.x * size.y, f);
     fwrite(distances.data(), sizeof(distances.at(0)), size.x * size.y, f);
@@ -29,8 +37,12 @@ void loadTrixelTextureData(
     std::vector<Color> &colors,
     std::vector<Distance> &distances
 ) {
-    const std::string filename = IRUtility::joinPath(path, name, ".irtxl");
+    const std::string filename = IRUtility::joinPath(path, name, kTrixelExtension);
     FILE *f = fopen(filename.c_str(), "rb");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for reading: {}", filename);
+        return;
+    }
     fread(&size, sizeof(size), 1, f);
     colors.resize(size.x * size.y);
     distances.resize(size.x * size.y);


### PR DESCRIPTION
## Summary
- `loadTrixelTextureData` was opening files with `.irtxl` while `saveTrixelTextureData` wrote `.txl`, making every round-trip silently fail. Both now use a shared `kTrixelExtension` constant so the extension can't drift again.
- Added early-return `IRE_LOG_ERROR` guards after each `fopen` call — previously any I/O failure would crash via NULL dereference on the `FILE*` operations that followed.

## Test plan
- [ ] Build `linux-debug` or `macos-debug` — single-file change, should be clean
- [ ] `saveTrixelTextureData` followed by `loadTrixelTextureData` with the same `name`/`path` round-trips a canvas without corruption
- [ ] Confirm no `.irtxl` files exist in the repo (none do — `git grep .irtxl` returns empty)

## Notes for reviewer
No `.irtxl` files existed in the repo, so no backward-compat concern. The macOS build tree wasn't configured on this host (covered by the separate macOS maturation task); the change is a string literal + error guard, verifiable by code inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)