### PR TITLE
engine/asset: fix .txl/.irtxl extension mismatch and add fopen guards

### DIFF
--- a/engine/asset/src/ir_asset.cpp
+++ b/engine/asset/src/ir_asset.cpp
@@ -15,6 +15,10 @@ void saveTrixelTextureData(
 ) {
     const std::string filename = IRUtility::joinPath(path, name, ".txl");
     FILE *f = fopen(filename.c_str(), "wb");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for writing: {}", filename);
+        return;
+    }
     fwrite(&size, sizeof(size), 1, f);
     fwrite(colors.data(), sizeof(colors.at(0)), size.x * size.y, f);
     fwrite(distances.data(), sizeof(distances.at(0)), size.x * size.y, f);
@@ -29,8 +33,12 @@ void loadTrixelTextureData(
     std::vector<Color> &colors,
     std::vector<Distance> &distances
 ) {
-    const std::string filename = IRUtility::joinPath(path, name, ".irtxl");
+    const std::string filename = IRUtility::joinPath(path, name, ".txl");
     FILE *f = fopen(filename.c_str(), "rb");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for reading: {}", filename);
+        return;
+    }
     fread(&size, sizeof(size), 1, f);
     colors.resize(size.x * size.y);
     distances.resize(size.x * size.y);


### PR DESCRIPTION
## Summary
- `loadTrixelTextureData` was opening files with `.irtxl` while `saveTrixelTextureData` wrote `.txl`, making every round-trip silently fail. Both now use `.txl`.
- Added `IRE_LOG_ERROR` early-return guards after both `fopen` calls — previously any I/O failure would crash via NULL dereference on the `FILE*` operations that followed.

## Test plan
- [ ] Build `linux-debug` or `macos-debug` — single-file change, should be clean
- [ ] `saveTrixelTextureData` followed by `loadTrixelTextureData` with the same `name`/`path` round-trips a canvas without corruption
- [ ] Confirm no `.irtxl` files exist in the repo (none do — `git grep .irtxl` returns empty)

## Notes
No `.irtxl` files existed in the repo, so no backward-compat concern. The macOS build tree was not configured on this host; the change is a string literal swap + error guards, verifiable by code inspection.

Supersedes PR #96 (same fix, this branch was already claimed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)