### PR TITLE
fleet: filesystem-based task claiming to prevent duplicate work

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -152,6 +152,10 @@ instruction. Do not loop.
 
 You are the sole TASKS.md editor. On each loop:
 
+0. **Clean stale claims:**
+   `fleet-claim cleanup --repo jakildev/IrredenEngine --repo jakildev/irreden`
+   This removes filesystem claims whose task title matches a merged or
+   closed PR. Harmless if no claims exist.
 1. `gh pr list --repo jakildev/IrredenEngine --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
    (use yesterday's date to catch recent merges)
 2. Read `TASKS.md`.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -55,16 +55,23 @@ limit. Each loop iteration:
 
    Print the task and explain why you picked it.
 
-3. **Claim the task by opening a PR with `fleet:wip` immediately.**
+3. **Claim the task, then open a PR with `fleet:wip`.**
    Do NOT edit `TASKS.md` — only the queue-manager touches it.
-   Create a branch whose name includes the task area (e.g.
-   `claude/doc-pass-ir-math`), make one empty commit
-   (`git commit --allow-empty -m "claim: <task title>"`), push the
-   branch, and open a PR with the WIP label:
+
+   First, acquire the local filesystem lock (atomic — prevents another
+   agent on this machine from picking the same task):
+   `fleet-claim claim "<exact task title from TASKS.md>" <your-worktree-name>`
+
+   - **Exit 0** — you own it. Proceed to open the PR.
+   - **Exit 1** — already taken. Go back to step 2 and pick another.
+
+   Then create the branch, commit, and open a `fleet:wip` PR:
+   `git checkout -b claude/<area>-<topic>`
+   `git commit --allow-empty -m "claim: <task title>"`
    `gh pr create --title "<task title>" --body "Claiming task. Work in progress." --label "fleet:wip"`
-   This makes the claim visible to other agents within seconds via
-   `gh pr list`. Reference the task title in the PR title so the
-   queue-manager can match it.
+
+   Reference the task title in the PR title so the queue-manager can
+   match it.
 
 4. **Work it.** Read every `CLAUDE.md` on the path to the file(s) you
    touch first. Follow naming conventions, the no-`getComponent`-in-tick
@@ -90,8 +97,10 @@ limit. Each loop iteration:
    on to the next task.
 
 7. **Finalize the PR.** Use the `commit-and-push` skill to push your
-   work commits to the existing PR branch. Then remove the WIP label:
+   work commits to the existing PR branch. Then remove the WIP label
+   and release the claim:
    `gh pr edit <N> --remove-label "fleet:wip"`
+   `fleet-claim release "<exact task title>"`
    Paste the PR URL.
 
 8. **Reset.** Use the `start-next-task` skill to land on a fresh branch

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# fleet-claim — filesystem-based task claiming for the agent fleet.
+#
+# Uses atomic mkdir(2) to prevent two agents from picking the same task.
+# All agents on the same machine share ~/.fleet/claims/. Each claim is a
+# directory named after the canonicalized task title (the "slug"); the
+# directory contains metadata files (owner, title, timestamp).
+#
+# Slug canonicalization: lowercase, non-alphanumeric → hyphen, collapse
+# runs, trim edges, truncate to 80 chars. Deterministic — every agent
+# derives the same slug from the same TASKS.md title.
+#
+# Installed to ~/bin/fleet-claim by scripts/fleet/install.sh.
+#
+# Usage:
+#   fleet-claim claim "<task title>" <agent-name>
+#   fleet-claim release "<task title>"
+#   fleet-claim check "<task title>"
+#   fleet-claim list
+#   fleet-claim cleanup [--repo <owner/repo>] ...
+#   fleet-claim clear-all
+
+set -euo pipefail
+
+CLAIMS_DIR="${FLEET_CLAIMS_DIR:-$HOME/.fleet/claims}"
+
+# --- slug canonicalization ------------------------------------------------
+
+slugify() {
+    # Lowercase → replace non-alnum with hyphen → collapse runs → trim
+    # edges → truncate. Pure POSIX tools, no bash 4+ features.
+    echo "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' \
+        | sed 's/--*/-/g' \
+        | sed 's/^-//' \
+        | sed 's/-$//' \
+        | cut -c1-80
+}
+
+# --- subcommands ----------------------------------------------------------
+
+cmd_claim() {
+    # Try to atomically claim a task. Exit 0 = claimed, exit 1 = taken.
+    local title="$1"
+    local agent="${2:-unknown}"
+    local slug
+    slug=$(slugify "$title")
+
+    mkdir -p "$CLAIMS_DIR"
+
+    if mkdir "$CLAIMS_DIR/$slug" 2>/dev/null; then
+        echo "$agent" > "$CLAIMS_DIR/$slug/owner"
+        echo "$title" > "$CLAIMS_DIR/$slug/title"
+        date +%s     > "$CLAIMS_DIR/$slug/created"
+        echo "claimed: $title (slug: $slug, agent: $agent)"
+        return 0
+    else
+        local owner="unknown"
+        if [[ -f "$CLAIMS_DIR/$slug/owner" ]]; then
+            owner=$(cat "$CLAIMS_DIR/$slug/owner")
+        fi
+        echo "already claimed by $owner: $title (slug: $slug)"
+        return 1
+    fi
+}
+
+cmd_release() {
+    local title="$1"
+    local slug
+    slug=$(slugify "$title")
+
+    if [[ -d "$CLAIMS_DIR/$slug" ]]; then
+        rm -rf "$CLAIMS_DIR/$slug"
+        echo "released: $title (slug: $slug)"
+    else
+        echo "not claimed: $title (slug: $slug)"
+    fi
+}
+
+cmd_check() {
+    # Exit 0 = free, exit 1 = claimed.
+    local title="$1"
+    local slug
+    slug=$(slugify "$title")
+
+    if [[ -d "$CLAIMS_DIR/$slug" ]]; then
+        local owner="unknown"
+        if [[ -f "$CLAIMS_DIR/$slug/owner" ]]; then
+            owner=$(cat "$CLAIMS_DIR/$slug/owner")
+        fi
+        echo "claimed by $owner (slug: $slug)"
+        return 1
+    else
+        echo "free (slug: $slug)"
+        return 0
+    fi
+}
+
+cmd_list() {
+    mkdir -p "$CLAIMS_DIR"
+    local found=0
+
+    for dir in "$CLAIMS_DIR"/*/; do
+        # Guard against the glob not matching (no claims).
+        [[ -d "$dir" ]] || continue
+        found=1
+        local slug
+        slug=$(basename "$dir")
+        local owner="unknown"
+        local title="$slug"
+        if [[ -f "$dir/owner" ]]; then owner=$(cat "$dir/owner"); fi
+        if [[ -f "$dir/title" ]]; then title=$(cat "$dir/title"); fi
+        printf "  %-20s  %s\n" "$owner" "$title"
+    done
+
+    if [[ $found -eq 0 ]]; then
+        echo "no active claims"
+    fi
+}
+
+cmd_cleanup() {
+    # Remove claims whose task title matches a merged or closed PR title.
+    # Accepts zero or more --repo flags; defaults to jakildev/IrredenEngine.
+    mkdir -p "$CLAIMS_DIR"
+
+    local -a repos=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --repo) repos+=("$2"); shift 2 ;;
+            *)      shift ;;
+        esac
+    done
+    if [[ ${#repos[@]} -eq 0 ]]; then
+        repos=("jakildev/IrredenEngine")
+    fi
+
+    # Collect slugified titles of all merged + closed PRs from each repo.
+    local -a done_slugs=()
+    for repo in "${repos[@]}"; do
+        local titles
+        titles=$(gh pr list --repo "$repo" --state merged \
+            --json title --jq '.[].title' 2>/dev/null || true)
+        while IFS= read -r t; do
+            [[ -z "$t" ]] && continue
+            done_slugs+=("$(slugify "$t")")
+        done <<< "$titles"
+
+        titles=$(gh pr list --repo "$repo" --state closed \
+            --json title --jq '.[].title' 2>/dev/null || true)
+        while IFS= read -r t; do
+            [[ -z "$t" ]] && continue
+            done_slugs+=("$(slugify "$t")")
+        done <<< "$titles"
+    done
+
+    local cleaned=0
+    for dir in "$CLAIMS_DIR"/*/; do
+        [[ -d "$dir" ]] || continue
+        local slug
+        slug=$(basename "$dir")
+        for ds in "${done_slugs[@]}"; do
+            if [[ "$slug" == "$ds" ]]; then
+                local title="$slug"
+                if [[ -f "$dir/title" ]]; then title=$(cat "$dir/title"); fi
+                rm -rf "$dir"
+                echo "cleaned: $title (merged/closed)"
+                cleaned=$((cleaned + 1))
+                break
+            fi
+        done
+    done
+
+    if [[ $cleaned -eq 0 ]]; then
+        echo "no stale claims found"
+    else
+        echo "cleaned $cleaned stale claim(s)"
+    fi
+}
+
+cmd_clear_all() {
+    if [[ -d "$CLAIMS_DIR" ]]; then
+        rm -rf "$CLAIMS_DIR"
+        mkdir -p "$CLAIMS_DIR"
+        echo "all claims cleared"
+    else
+        echo "no claims directory"
+    fi
+}
+
+# --- main -----------------------------------------------------------------
+
+case "${1:-}" in
+    claim)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim claim \"<title>\" [agent-name]" >&2
+            exit 2
+        fi
+        cmd_claim "$2" "${3:-unknown}"
+        ;;
+    release)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim release \"<title>\"" >&2
+            exit 2
+        fi
+        cmd_release "$2"
+        ;;
+    check)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim check \"<title>\"" >&2
+            exit 2
+        fi
+        cmd_check "$2"
+        ;;
+    list)
+        cmd_list
+        ;;
+    cleanup)
+        shift
+        cmd_cleanup "$@"
+        ;;
+    clear-all)
+        cmd_clear_all
+        ;;
+    *)
+        cat <<'USAGE'
+usage: fleet-claim <command> [args]
+
+commands:
+  claim "<title>" [agent]   claim a task (exit 0=claimed, 1=taken)
+  release "<title>"         release a claim
+  check "<title>"           check if free (exit 0=free, 1=taken)
+  list                      list all active claims
+  cleanup [--repo o/r] ...  remove claims for merged/closed PRs
+  clear-all                 wipe all claims (used by fleet-up on restart)
+
+Slug canonicalization:
+  Title → lowercase → non-alnum to hyphen → collapse → trim → 80 chars.
+  All agents derive the same slug from the same TASKS.md title.
+USAGE
+        exit 2
+        ;;
+esac

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -221,6 +221,22 @@ if [[ -d "$GAME/.claude/worktrees/game-sonnet" ]]; then
 fi
 
 # ----------------------------------------------------------------------
+# Step 3b: clear stale task claims
+# ----------------------------------------------------------------------
+#
+# fleet-up resets every worktree to a fresh branch, so any claims from
+# a previous fleet session are stale. Wipe them so agents start clean.
+
+if command -v fleet-claim >/dev/null 2>&1; then
+    fleet-claim clear-all
+elif [[ -x "$ENGINE/scripts/fleet/fleet-claim" ]]; then
+    "$ENGINE/scripts/fleet/fleet-claim" clear-all
+else
+    echo "fleet-up: fleet-claim not found — skipping claims cleanup"
+    echo "          (run scripts/fleet/install.sh to install it)"
+fi
+
+# ----------------------------------------------------------------------
 # Step 4: build the tmux session
 # ----------------------------------------------------------------------
 #

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -62,26 +62,35 @@ fi
 
 FLEET_UP_SRC="$SCRIPT_DIR/fleet-up"
 FLEET_UP_DEST="$HOME/bin/fleet-up"
+FLEET_CLAIM_SRC="$SCRIPT_DIR/fleet-claim"
+FLEET_CLAIM_DEST="$HOME/bin/fleet-claim"
 
 if [[ ! -f "$FLEET_UP_SRC" ]]; then
     echo "install.sh: $FLEET_UP_SRC does not exist — repo is incomplete" >&2
     exit 1
 fi
 
-# Ensure the source is executable. Git normally preserves the +x bit,
+# Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-if [[ ! -x "$FLEET_UP_SRC" ]]; then
-    chmod +x "$FLEET_UP_SRC"
-fi
+for src in "$FLEET_UP_SRC" "$FLEET_CLAIM_SRC"; do
+    if [[ -f "$src" && ! -x "$src" ]]; then
+        chmod +x "$src"
+    fi
+done
 
 # ----------------------------------------------------------------------
-# Step 1: symlink fleet-up into ~/bin
+# Step 1: symlink fleet scripts into ~/bin
 # ----------------------------------------------------------------------
 
 mkdir -p "$HOME/bin"
 ln -sf "$FLEET_UP_SRC" "$FLEET_UP_DEST"
 echo "symlinked $FLEET_UP_DEST -> $FLEET_UP_SRC"
+
+if [[ -f "$FLEET_CLAIM_SRC" ]]; then
+    ln -sf "$FLEET_CLAIM_SRC" "$FLEET_CLAIM_DEST"
+    echo "symlinked $FLEET_CLAIM_DEST -> $FLEET_CLAIM_SRC"
+fi
 
 # ----------------------------------------------------------------------
 # Step 2: symlink engine role slash commands into ~/.claude/commands


### PR DESCRIPTION
## Summary

- Two sonnet agents picked the same task simultaneously (#96 and #97 both fix the same asset extension mismatch). The `fleet:wip` PR mechanism can't prevent this — both agents read the PR list before either has pushed.
- New `fleet-claim` script uses atomic `mkdir(2)` on `~/.fleet/claims/<slug>/` as a lock. First agent wins; second gets `EEXIST` and picks another task. Zero network latency, no race window.
- Slug canonicalization is deterministic (lowercase → non-alnum to hyphen → collapse → trim → 80 chars), so every agent derives the same slug from the same TASKS.md title.
- `fleet-up` clears all claims on startup (worktrees are reset, previous claims are stale).
- Queue-manager runs `fleet-claim cleanup` each maintenance loop to remove claims for merged/closed PRs.

### Files changed (engine repo)
- **NEW** `scripts/fleet/fleet-claim` — claim/release/check/list/cleanup/clear-all
- `scripts/fleet/install.sh` — symlink fleet-claim to ~/bin/
- `scripts/fleet/fleet-up` — clear claims on startup
- `.claude/commands/role-sonnet-author.md` — use fleet-claim before fleet:wip PR
- `.claude/commands/role-queue-manager.md` — run fleet-claim cleanup in maintenance

### Game repo (separate commit needed)
- `creations/game/.claude/commands/role-game-sonnet.md` — updated locally, needs commit to `jakildev/irreden`

## Test plan
- [ ] Run `scripts/fleet/install.sh` to install fleet-claim symlink
- [ ] `fleet-claim claim "test task" agent-1` → exit 0, "claimed"
- [ ] `fleet-claim claim "test task" agent-2` → exit 1, "already claimed by agent-1"
- [ ] `fleet-claim list` → shows "agent-1  test task"
- [ ] `fleet-claim release "test task"` → "released"
- [ ] `fleet-claim clear-all` → "all claims cleared"
- [ ] Kill fleet, run `fleet-up dry-run` — should print "all claims cleared" during startup
- [ ] Verify no two agents open PRs for the same task

🤖 Generated with [Claude Code](https://claude.com/claude-code)