### PR TITLE
fleet: add fleet-claim to worktree settings allowlist

### DIFF
--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -177,6 +177,7 @@ baseline = [
     "Bash(realpath:*)",
     "Bash(basename:*)",
     "Bash(dirname:*)",
+    "Bash(fleet-claim:*)",
 ]
 
 # Preserve any user-granted "always allow" entries from previous sessions,


### PR DESCRIPTION
## Summary

- Adds `Bash(fleet-claim:*)` to the baseline allow list in `write_worktree_settings()` so agents can run `fleet-claim` without an interactive approval prompt.
- Without this, the queue-manager's `fleet-claim cleanup` and author agents' `fleet-claim claim/release` commands trigger the "This command requires approval" dialog, blocking unattended operation.

## Test plan
- [ ] Merge, kill fleet, run `fleet-up dry-run`
- [ ] Verify queue-manager runs `fleet-claim cleanup` without a permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)