### PR TITLE
queue: sync task state — asset extension task in-progress, flag race

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -133,12 +133,12 @@ Avoid:
 
 <!-- Add tasks below this line. -->
 
-- [ ] **Fix `engine/asset` extension mismatch: `.txl` vs `.irtxl`** —
+- [~] **Fix `engine/asset` extension mismatch: `.txl` vs `.irtxl`** —
   `saveTrixelTextureData` writes files with `.txl` but `loadTrixelTextureData`
   opens files expecting `.irtxl`. Standardize both on `.txl`.
   - **Area:** engine/asset
   - **Model:** sonnet
-  - **Owner:** free
+  - **Owner:** asset-extension-fix (PR #96), asset-txl-fix-v2 (PR #97) — RACE: two agents claimed this task; human should close one before merging
   - **Blocked by:** (none)
   - **Acceptance:** both `saveTrixelTextureData` and `loadTrixelTextureData`
     use `.txl`; CMake build passes (`linux-debug` or `macos-debug`);
@@ -295,7 +295,9 @@ Avoid:
 
 <!-- Tasks currently being worked on. Mirror of [~] items above. -->
 
-(none yet)
+- [~] **Fix `engine/asset` extension mismatch: `.txl` vs `.irtxl`** — PR #96
+  (claude/asset-extension-fix) and PR #97 (claude/asset-txl-fix-v2) both open;
+  race condition — human should close one before merging the other.
 
 ---
 


### PR DESCRIPTION
## Summary
- Flips the `Fix engine/asset extension mismatch` task from `[ ]` to `[~]`
- Two open PRs (#96 and #97) are both addressing this task — a two-agent race collision
- Owner field and In-progress mirror now document the race so the human knows to close one before merging

## Notes for reviewer
This is a queue-maintenance-only PR. No code changes.

Race situation:
- PR #96 `claude/asset-extension-fix` — first claim
- PR #97 `claude/asset-txl-fix-v2` — second claim (v2 implies it was filed after seeing the first)

Human action needed: review both PRs, pick the better one, close the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)