### PR TITLE
build: add .gitattributes for cross-platform EOL normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,68 @@
+# Normalize all text files to LF on commit and checkout.
+# This prevents CRLF line endings from entering the repository from Windows
+# contributors and ensures Linux/WSL builds see clean LF-only source.
+
+# Catch-all: auto-detect text, normalize to LF.
+* text=auto eol=lf
+
+# ── C / C++ ──────────────────────────────────────────────────────────────────
+*.c     text eol=lf
+*.h     text eol=lf
+*.cpp   text eol=lf
+*.hpp   text eol=lf
+*.inl   text eol=lf
+
+# ── Shaders ──────────────────────────────────────────────────────────────────
+*.glsl  text eol=lf
+*.vert  text eol=lf
+*.frag  text eol=lf
+*.geom  text eol=lf
+*.comp  text eol=lf
+*.tesc  text eol=lf
+*.tese  text eol=lf
+*.metal text eol=lf
+
+# ── Scripting / config ────────────────────────────────────────────────────────
+*.lua   text eol=lf
+*.json  text eol=lf
+*.toml  text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.sh    text eol=lf
+*.md    text eol=lf
+*.txt   text eol=lf
+*.py    text eol=lf
+
+# ── CMake ────────────────────────────────────────────────────────────────────
+CMakeLists.txt  text eol=lf
+*.cmake         text eol=lf
+
+# ── Windows-specific scripts — keep CRLF so cmd/PowerShell parse them correctly
+*.ps1  text eol=crlf
+*.bat  text eol=crlf
+*.cmd  text eol=crlf
+
+# ── Binary files — never modify ───────────────────────────────────────────────
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.bmp       binary
+*.ico       binary
+*.ttf       binary
+*.otf       binary
+*.woff      binary
+*.woff2     binary
+*.pdf       binary
+*.zip       binary
+*.tar       binary
+*.gz        binary
+*.7z        binary
+*.dll       binary
+*.so        binary
+*.dylib     binary
+*.a         binary
+*.lib       binary
+*.exe       binary
+*.metallib  binary
+*.air       binary


### PR DESCRIPTION
## Summary

- Adds `.gitattributes` to the repo root so git normalizes all text files to LF on commit and checkout across all platforms
- Prevents `\r\n` line endings from contaminating C++, GLSL, Metal shader, Lua, CMake, and config files when contributors check out on Windows
- `.ps1` / `.bat` / `.cmd` scripts keep CRLF since PowerShell and cmd.exe require it
- Binary assets (images, compiled libs, `.metallib`, `.air`) are marked binary to suppress diff noise and prevent corruption

Addresses the **EOL drift** risk documented in `docs/AGENT_FLEET_SETUP.md §10` as a known first-time Linux/WSL build issue. Part of the **Linux build maturation** umbrella task.

## Test plan

- [ ] `git check-attr eol -- engine/render/src/shader.cpp` → `lf`
- [ ] `git check-attr eol -- open_profiler.ps1` → `crlf`
- [ ] `git check-attr -a -- engine/render/data/*.png` → shows `binary`
- [ ] On a WSL clone: `git config core.autocrlf` output irrelevant — `.gitattributes` forces LF regardless
- [ ] After merging, existing contributors on Windows should re-normalize: `git add --renormalize .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)