### PR TITLE
fleet: GitHub issue-driven task intake + maintenance timer

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -71,6 +71,22 @@ When you do pick a task:
 If Mode above is `dry-run`: do **only** the startup actions. Do not pick
 a task. Wait for explicit human instruction.
 
+## Filing tasks
+
+When you identify work that needs doing — by you, a Sonnet agent, or
+anyone — file it as a GitHub issue with the `fleet:task` label:
+
+`gh issue create --repo jakildev/IrredenEngine --title "<short title>" --label "fleet:task" --body "<description>"`
+
+Include in the body:
+- **Area** (e.g. `engine/render`, `engine/math`, `docs`)
+- **Suggested model** (`[opus]` or `[sonnet]`)
+- **Acceptance criteria** (concrete check: build passes, test X works)
+- **Context** (why this matters, what you observed)
+
+The queue-manager will pick it up within 15 minutes, categorize it,
+and add it to TASKS.md. You do NOT edit TASKS.md directly.
+
 ## Escalation rules (always)
 
 Stop and surface to the human when:

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -131,57 +131,75 @@ half-finished and re-litigated in review.
    PR FIRST so the game task can reference its title in `Blocked by`,
    then file the game task.
 
-### Step 6 — Loop
+### Step 6 — Wait for triggers
 
-Run continuously on a **15-minute polling interval**. Each iteration:
+After the startup actions (and one initial maintenance pass), **wait
+for input**. You will receive two kinds of messages:
 
-1. Run a **maintenance pass** (see below) — sync TASKS.md with
-   merged/open PRs, prune Done, commit if anything changed.
-2. Check if the human has typed a new task description. If so,
-   process it through Steps 1–5 above.
-3. Wait 15 minutes, then loop.
+- **"run maintenance"** — sent automatically every 15 minutes by the
+  fleet timer in tmux. Run the full maintenance pass below, print a
+  one-line summary of what changed, then wait again.
+- **Human-typed task descriptions** — any other input. Process it
+  through Steps 1–5 above (categorize, format, file to TASKS.md),
+  then wait again.
+
+You do NOT need to sleep, poll, or self-loop. The timer handles
+scheduling. Just respond to each message as it arrives.
 
 If you hit a usage-limit error: print the error and reset time,
-wait, resume.
+wait, resume when the next trigger arrives.
 
-If Mode above is `dry-run`: do exactly one maintenance pass, file
-one task if the human provides one, then stop and wait for
-instruction. Do not loop.
+If Mode above is `dry-run`: do exactly one maintenance pass, then
+stop and wait for human instruction. Do not respond to timer
+triggers.
 
-### Maintenance (run each loop iteration)
+### Maintenance pass
 
-You are the sole TASKS.md editor. On each loop:
+You are the sole TASKS.md editor. Each maintenance pass:
 
 0. **Clean stale claims:**
    `fleet-claim cleanup --repo jakildev/IrredenEngine --repo jakildev/irreden`
-   This removes filesystem claims whose task title matches a merged or
-   closed PR. Harmless if no claims exist.
-1. `gh pr list --repo jakildev/IrredenEngine --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
+
+1. **Ingest `fleet:task` issues (engine repo):**
+   `gh issue list --repo jakildev/IrredenEngine --label "fleet:task" --state open --json number,title,body`
+   For each open issue:
+   - Read the title and body as a task description.
+   - Categorize it (model tag, area) per Steps 2–3 above.
+   - Append a properly formatted entry to `## Open` in `TASKS.md`.
+   - Close the issue with a comment:
+     `gh issue close <N> --repo jakildev/IrredenEngine --comment "Filed in TASKS.md"`
+
+2. **Ingest `fleet:task` issues (game repo):**
+   `gh issue list --repo jakildev/irreden --label "fleet:task" --state open --json number,title,body`
+   Same flow as above, but append to the game repo's `TASKS.md`.
+   Close the issue:
+   `gh issue close <N> --repo jakildev/irreden --comment "Filed in TASKS.md"`
+
+3. **Sync merged PRs → Done:**
+   `gh pr list --repo jakildev/IrredenEngine --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
    (use yesterday's date to catch recent merges)
-2. Read `TASKS.md`.
-3. For each recently merged PR, check if its title or branch name
-   matches an `[~]` (in-progress) or `[ ]` (open) task:
-   - If matched: flip to `[x]`, add the PR URL to **Links**, move to
-     `## Done — last 20`.
-4. For each open PR (`gh pr list --state open`), check if its title
-   matches a `[ ]` (open) task:
-   - If matched and the task is still `[ ]`: flip to `[~]`, set Owner
-     to the PR author's worktree name.
-5. **Prune Done:** keep only the last 20 entries in `## Done — last 20`.
-   Delete older ones — git history is the archive.
-6. If any changes were made: commit TASKS.md only (no other files)
-   and push directly to master. You are the sole TASKS.md editor, so
-   this is safe and avoids creating PRs the human has to merge for
-   pure bookkeeping. Steps:
+   Read `TASKS.md`. For each recently merged PR whose title or branch
+   matches an `[~]` or `[ ]` task: flip to `[x]`, add the PR URL to
+   **Links**, move to `## Done — last 20`.
+
+4. **Sync open PRs → In-progress:**
+   `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName`
+   For each open PR whose title matches a `[ ]` task: flip to `[~]`,
+   set Owner to the PR author's worktree name.
+
+5. **Prune Done:** keep only the last 20 entries. Delete older ones.
+
+6. **Push changes (if any).** Commit TASKS.md only and push directly
+   to master:
    - `git fetch origin`
-   - `git rebase origin/master`  (land on top of latest master)
+   - `git rebase origin/master`
    - `git add TASKS.md`
-   - `git commit -m "queue: sync task state from merged PRs"`
+   - `git commit -m "queue: maintenance sync"`
    - `git push origin HEAD:master`
-   Use `HEAD:master` (refspec form) — this pushes the current HEAD to
-   the remote's master branch. If the push is rejected, rebase again:
-   - `git pull --rebase origin master`
-   - `git push origin HEAD:master`
+   If push rejected, `git pull --rebase origin master` then retry.
+
+7. Print a one-line summary: how many issues ingested, tasks flipped,
+   claims cleaned.
 
 ## Hard rules
 
@@ -196,12 +214,6 @@ You are the sole TASKS.md editor. On each loop:
   the no-direct-push rule — TASKS.md is bookkeeping, not code, and
   you are its sole editor. Never push any other file to master.
 - Never `git push --force`.
-- New-task PRs (Step 5) still go through `commit-and-push` so the
-  human sees the task description in a PR. Maintenance syncs (Step 6
-  in Maintenance) push directly.
-- Queue-only PRs are explicitly allowed by `TASKS.md` as queue
-  maintenance — you do not need to bundle a task add with actual
-  work.
 - Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
   commands in a single Bash invocation. Issue each command as its own
   separate tool call (Bash or Read). Compound commands don't match the

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -91,10 +91,11 @@ limit. Each loop iteration:
    - The public `ir_*.hpp` surface across multiple modules
    - Lifetime/ownership decisions
 
-   STOP. Post a comment on your PR (or open a stub PR if none exists)
-   noting the escalation: "escalated — touches X invariant, deferring
-   to opus architect". The queue-manager will update TASKS.md. Move
-   on to the next task.
+   STOP. File a GitHub issue for the opus work and note the escalation
+   on your PR:
+   `gh issue create --repo jakildev/IrredenEngine --title "<what needs opus attention>" --label "fleet:task" --body "Escalated from sonnet. Area: ... Suggested model: [opus]. Context: ..."`
+   Then comment on your PR: "escalated — filed issue #N for opus".
+   The queue-manager will add it to TASKS.md. Move on to the next task.
 
 7. **Finalize the PR.** Use the `commit-and-push` skill to push your
    work commits to the existing PR branch. Then remove the WIP label

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -360,6 +360,30 @@ tmux set-option -t "$SESSION" pane-border-format " #{pane_index}: #{@role} "
 # Focus sonnet-fleet-1 on attach
 tmux select-pane -t "$TOP1"
 
+# ----------------------------------------------------------------------
+# Step 5: start the queue-manager maintenance timer
+# ----------------------------------------------------------------------
+#
+# Claude Code agents can't self-loop — they process input, respond,
+# then wait. This background loop sends "run maintenance" to the
+# queue-manager pane every 15 minutes, triggering the maintenance pass.
+# The loop exits automatically when the tmux session is killed.
+#
+# In dry-run mode, skip the timer (queue-manager does one pass and
+# stops; the human triggers subsequent runs manually).
+
+if [[ "$MODE" != "dry-run" ]]; then
+    (
+        sleep 120  # let agents finish startup before first trigger
+        while tmux has-session -t "$SESSION" 2>/dev/null; do
+            tmux send-keys -t "$BOT3" "run maintenance" Enter 2>/dev/null || true
+            sleep 900  # 15 minutes
+        done
+    ) &
+    TIMER_PID=$!
+    echo "fleet-up: maintenance timer started (PID $TIMER_PID, every 15 min)"
+fi
+
 cat <<EOF
 
 fleet session created — mode: ${MODE}.
@@ -381,5 +405,5 @@ waits. promote a pane to full operation by typing in it:
 
 other modes:
   fleet-up dry-run   # default
-  fleet-up live      # full loop from the start
+  fleet-up live      # full loop from the start (timer sends maintenance triggers)
 EOF


### PR DESCRIPTION
## Summary

Two problems fixed:

1. **Task filing was bottlenecked on humans.** Only way to add tasks was to paste descriptions into the queue-manager pane. Now any agent can `gh issue create --label "fleet:task"` and the queue-manager ingests it automatically.

2. **Queue-manager couldn't actually poll.** Claude Code agents can't sleep or self-trigger — the "wait 15 minutes, then loop" instruction just made it stop after one pass. Now `fleet-up` spawns a background timer that sends `"run maintenance"` to the queue-manager pane every 15 minutes via `tmux send-keys`. The timer only runs in `live` mode (not `dry-run`).

### New task flow
```
Architect/Author identifies work
        │
        ▼
gh issue create --label "fleet:task"
        │
        ▼  (within 15 min)
Queue-manager ingests issue → TASKS.md entry
        │
        ▼
gh issue close with "Filed in TASKS.md"
```

### Files changed
- **role-queue-manager.md** — trigger-driven instead of self-loop; ingests `fleet:task` issues from both repos
- **role-opus-architect.md** — new "Filing tasks" section
- **role-sonnet-author.md** — escalation files GitHub issue instead of just PR comment
- **fleet-up** — background timer (PID printed on startup, auto-exits when session killed)

### Game repo (separate commit needed)
- `role-game-architect.md` and `role-game-sonnet.md` also updated locally

### Labels created
- `fleet:task` label created on both `jakildev/IrredenEngine` and `jakildev/irreden`

## Test plan
- [ ] Merge, run `fleet-up live`
- [ ] Create a test issue: `gh issue create --repo jakildev/IrredenEngine --title "Test task" --label "fleet:task" --body "Test"`
- [ ] Wait for maintenance trigger (or type "run maintenance" in queue-manager pane)
- [ ] Verify issue was ingested into TASKS.md and closed
- [ ] Verify timer PID is printed on startup and sends triggers every 15 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)