### PR TITLE
build(linux): add missing standard headers for portability

### DIFF
--- a/engine/asset/src/ir_asset.cpp
+++ b/engine/asset/src/ir_asset.cpp
@@ -2,6 +2,7 @@
 #include <irreden/ir_profile.hpp>
 #include <irreden/ir_utility.hpp>
 
+#include <cstdio>
 #include <string>
 
 namespace IRAsset {

--- a/engine/input/src/input_manager.cpp
+++ b/engine/input/src/input_manager.cpp
@@ -3,6 +3,8 @@
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_window.hpp>
 
+#include <algorithm>
+
 #include <irreden/input/input_manager.hpp>
 #include <irreden/input/components/component_glfw_gamepad_state.hpp>
 #include <irreden/input/entities/entity_joystick.hpp>

--- a/engine/time/include/irreden/time/ir_time_types.hpp
+++ b/engine/time/include/irreden/time/ir_time_types.hpp
@@ -2,6 +2,7 @@
 #define IR_TIME_TYPES_H
 
 #include <chrono>
+#include <cstddef>
 #include <irreden/ir_constants.hpp>
 
 namespace IRTime {


### PR DESCRIPTION
## Summary
- `engine/asset/src/ir_asset.cpp`: add `<cstdio>` for `FILE`/`fopen`/`fread`/`fwrite`/`fclose`
- `engine/input/src/input_manager.cpp`: add `<algorithm>` for `std::fill`
- `engine/time/include/irreden/time/ir_time_types.hpp`: add `<cstddef>` for `size_t`

On Windows/MSYS2 these are pulled in transitively through system headers. On Linux with GCC the include graph is leaner — the C++ standard requires explicit inclusion of each of these headers for the symbols they define. These omissions are silent on Windows but will cause build failures on `linux-debug`.

Part of the **Linux build maturation: get `linux-debug` preset green end-to-end** umbrella task.

## Test plan
- [ ] `cmake --build build --target IrredenEngineTest -j$(nproc)` passes on WSL2 Ubuntu 24.04 with `linux-debug` preset
- [ ] `cmake --build build --target IRShapeDebug -j$(nproc)` passes

## Notes for reviewer
Build could not be verified on macOS (no `macos-debug` build tree configured on this host; rule prohibits running `cmake --preset`). These are header-only additions — they cannot regress existing code. All three are straightforward standard-library includes matching exactly the facilities used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)