### PR TITLE
docs: add CLAUDE.md to asset/demo/wip prefab dirs; fix C_Alarm ctor

### DIFF
--- a/engine/prefabs/irreden/asset/CLAUDE.md
+++ b/engine/prefabs/irreden/asset/CLAUDE.md
@@ -1,0 +1,32 @@
+# engine/prefabs/irreden/asset/ — asset I/O commands
+
+Prefab commands for saving and loading engine assets at runtime.
+
+## Commands
+
+- `commands/command_save_main_canvas_trixels.hpp` — `Command<SAVE_MAIN_CANVAS_TRIXELS>`.
+  Grabs `C_TriangleCanvasTextures` off the entity named `"main"` via
+  `IRRender::getCanvas("main")` and calls `saveToFile("main_canvas")`, writing
+  `main_canvas.txl` to the current working directory.
+
+  The `SAVE_MAIN_CANVAS_TRIXELS` enum entry lives in
+  `engine/command/include/irreden/command/ir_command_types.hpp`.
+
+## Typical usage
+
+```cpp
+#include <irreden/asset/commands/command_save_main_canvas_trixels.hpp>
+IRCommand::Command<SAVE_MAIN_CANVAS_TRIXELS>::create();
+```
+
+Bind to an input key via `IRCommand::bindCommand<SAVE_MAIN_CANVAS_TRIXELS>(...)`
+if you want interactive save-on-keypress.
+
+## Gotchas
+
+- **Canvas must be named `"main"`.** `IRRender::getCanvas("main")` panics if no
+  canvas with that name exists. If your creation uses a differently-named canvas,
+  copy the command and substitute the name.
+- **Output path is cwd-relative.** The file is written to wherever the exe's
+  working directory is. Use the `IR<Name>Run` CMake target (which sets
+  `WORKING_DIRECTORY` correctly) to avoid writing files to unexpected places.

--- a/engine/prefabs/irreden/demo/CLAUDE.md
+++ b/engine/prefabs/irreden/demo/CLAUDE.md
@@ -1,0 +1,26 @@
+# engine/prefabs/irreden/demo/ — example/template prefabs
+
+Minimal example prefabs used in documentation, tests, and as copy-paste
+templates when adding a new component or entity type. **Do not include
+these in production creations.**
+
+## Contents
+
+- `components/component_example.hpp` — `C_Example`. A single
+  `std::string exampleSentence_` member. Used only as a template to
+  show the `C_` component struct layout.
+- `entities/entity_example.hpp` — `Prefab<PrefabTypes::kExample>`.
+  Creates an entity with `C_Example{}`. Shows the `template<> struct
+  Prefab<T>` pattern and how to call `entity.set(...)`.
+
+## Rules
+
+- **Don't copy from `demo/` into real code.** The `C_Example` component
+  and `kExample` prefab exist solely as readable references. Real
+  components belong under the domain that owns them (`common/`,
+  `update/`, `voxel/`, etc.).
+- **Don't add logic here.** If an example needs more than a trivial
+  struct, it has grown beyond this directory's purpose. Put it in the
+  right domain directory instead.
+- **No production includes.** Nothing outside `demo/` should `#include`
+  from `demo/`. These headers are not part of any umbrella `ir_*.hpp`.

--- a/engine/prefabs/irreden/wip/CLAUDE.md
+++ b/engine/prefabs/irreden/wip/CLAUDE.md
@@ -1,0 +1,25 @@
+# engine/prefabs/irreden/wip/ — experimental, not production-ready
+
+Prefabs that are mid-design and not yet safe to include from production
+code. Nothing under `wip/` is referenced by any umbrella `ir_*.hpp`
+header.
+
+## Contents
+
+- `components/component_alarm.hpp` — `C_Alarm`. A single `int alarmTime_`
+  countdown member. Placeholder for a "fire once after N ticks" mechanism.
+  Not yet integrated with any system.
+
+## Rules
+
+- **Nothing in `wip/` should be included from engine or creation code.**
+  These files exist as design sketches. If you find a `#include` pointing
+  here outside of `wip/` itself, remove it.
+- **Graduating a component out of `wip/`.** When a component is ready:
+  1. Move it to the correct domain directory (`common/`, `update/`, etc.).
+  2. Add a system or other consumer in the same PR.
+  3. Add the file to the appropriate umbrella `ir_*.hpp`.
+  4. Delete it from `wip/`.
+- **Files here must still compile.** The `lint` and `format-check` CMake
+  targets scan everything under `engine/` including `wip/`. Keep
+  `wip/` files syntactically valid even if the design is incomplete.

--- a/engine/prefabs/irreden/wip/components/component_alarm.hpp
+++ b/engine/prefabs/irreden/wip/components/component_alarm.hpp
@@ -1,10 +1,6 @@
 #ifndef COMPONENT_ALARM_H
 #define COMPONENT_ALARM_H
 
-#include <irreden/ir_math.hpp>
-
-using namespace IRMath;
-
 namespace IRComponents {
 
 struct C_Alarm {
@@ -13,9 +9,8 @@ struct C_Alarm {
     C_Alarm(int alarmTime)
         : alarmTime_(alarmTime) {}
 
-    // Default
     C_Alarm()
-        : {}
+        : alarmTime_(0) {}
 };
 
 } // namespace IRComponents


### PR DESCRIPTION
## Summary
- Added `CLAUDE.md` to the three `engine/prefabs/irreden/` subdirectories
  (`asset/`, `demo/`, `wip/`) that were missing them — these are now the
  only ones with documentation for agents running `start-next-task`.
- Fixed broken default constructor in `engine/prefabs/irreden/wip/
  components/component_alarm.hpp`: `C_Alarm() : {}` is invalid C++;
  replaced with `C_Alarm() : alarmTime_(0) {}`.
- Removed unused `#include <irreden/ir_math.hpp>` and file-scope
  `using namespace IRMath;` from the same file.

## Test plan
- [ ] No compilation required — `component_alarm.hpp` is not included
  anywhere. Verify `engine/prefabs/irreden/wip/` is still excluded from
  all umbrella `ir_*.hpp` headers.
- [ ] CLAUDE.md content is accurate: `SAVE_MAIN_CANVAS_TRIXELS` exists in
  `ir_command_types.hpp`, `C_Example`/`Prefab<kExample>` exist in demo/.
- [ ] `wip/CLAUDE.md` correctly describes the graduation process (move to
  domain dir, add system, add to umbrella, delete from wip/).

## Notes for reviewer
The `C_Alarm` naming triggers a clang-tidy `readability-identifier-naming`
warning (ClassCase: CamelCase vs the `C_` prefix convention). This is a
pre-existing project-wide issue affecting every `C_*` component — not
introduced here and not scoped to this PR to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)