### PR TITLE
build(linux): add missing <algorithm> to prefab headers using std::sort

### DIFF
--- a/engine/prefabs/irreden/audio/components/component_midi_sequence.hpp
+++ b/engine/prefabs/irreden/audio/components/component_midi_sequence.hpp
@@ -10,6 +10,7 @@
 #include <irreden/common/components/component_tags_all.hpp>
 #include <irreden/audio/components/component_midi_message.hpp>
 
+#include <algorithm>
 #include <optional>
 
 using namespace IRMath;

--- a/engine/prefabs/irreden/update/components/component_periodic_idle.hpp
+++ b/engine/prefabs/irreden/update/components/component_periodic_idle.hpp
@@ -2,6 +2,8 @@
 #define COMPONENT_PERIODIC_IDLE_H
 
 #include <irreden/ir_math.hpp>
+
+#include <algorithm>
 #include <cmath>
 
 using namespace IRMath;


### PR DESCRIPTION
## Summary
- `engine/prefabs/irreden/update/components/component_periodic_idle.hpp`: add `<algorithm>` — `sortSequence()` calls `std::sort`, `mapAngleToStageTValue()` calls `std::max`/`std::min`
- `engine/prefabs/irreden/audio/components/component_midi_sequence.hpp`: add `<algorithm>` — `sortSequence()` calls `std::sort`

Both headers rely on `ir_math.hpp` → GLM. GLM does **not** pull in `<algorithm>`, so `std::sort` is unavailable through any transitive path. On Windows/MSYS2 this is hidden by the wider system header pull-in; on Linux with GCC these are clean build failures.

Part of the **Linux build maturation: get `linux-debug` preset green end-to-end** umbrella task.

## Test plan
- [ ] `cmake --build build --target IrredenEngineTest -j$(nproc)` on WSL2 Ubuntu 24.04 with `linux-debug` preset
- [ ] `cmake --build build --target IRShapeDebug -j$(nproc)` on WSL2 Ubuntu 24.04

## Notes for reviewer
These are header additions only; no logic changes. Build not verified on macOS (build tree not configured on this host; rule prohibits `cmake --preset`). The standard requires explicit `<algorithm>` for `std::sort`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)