### PR TITLE
fleet: game repo review coverage + single-command bash rule

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -67,8 +67,7 @@ When you do pick a task:
    are not visible to other agents until merge.
 2. Flip the task to `[~]`, set Owner to `opus-architect`, and commit
    the edit in your first commit on the work branch.
-3. Build the target you touched with
-   `cmake --build build --target <name> -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)`.
+3. Build the target you touched with `fleet-build --target <name>`.
    Run the relevant executable if one exists for the touched code.
 4. Use the `commit-and-push` skill to open the PR.
 5. After the PR is open, use the `start-next-task` skill to land on a

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -9,6 +9,14 @@ Your role is **design and heavy core-engine work**, not rapid task picking.
 
 Mode (optional argument): $ARGUMENTS
 
+## CRITICAL: single-command Bash calls only
+
+Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
+`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
+tool instead of `grep` or `rg`. Use the **Glob** tool instead of
+`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
+this blocks unattended operation with interactive prompts.
+
 ## Responsibilities
 
 - Core engine architecture: ECS design, ownership and lifetime rules,

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -10,9 +10,18 @@ human merges.
 
 Mode (optional argument): $ARGUMENTS
 
+## CRITICAL: single-command Bash calls only
+
+Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
+`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
+tool instead of `grep` or `rg`. Use the **Glob** tool instead of
+`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
+this blocks unattended operation with interactive prompts.
+
 ## Role
 
-You poll open PRs and act on the ones that:
+You poll open PRs on **both repos** — `jakildev/IrredenEngine` (engine)
+and `jakildev/irreden` (game) — and act on the ones that:
 - Have a Sonnet first-pass review whose body ends with
   `Opus recheck required: ...`, or
 - Touch core engine invariants regardless of Sonnet's verdict
@@ -20,6 +29,9 @@ You poll open PRs and act on the ones that:
   `engine/world/`, `engine/audio/`, `engine/video/`, non-trivial
   `engine/math/`, public `ir_*.hpp` surface, lifetime/ownership,
   concurrency).
+- For game repo PRs: touch game-side ECS extensions, perf-critical
+  gameplay loops, cross-repo integration points, or persistence/save
+  format code.
 
 You read the Sonnet review first to understand what was already
 checked, then focus your pass on what Sonnet could not confirm:
@@ -34,21 +46,31 @@ conditions, allocator behavior, hot-path costs.
    separately (do NOT wrap in `cd ... &&`):
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git checkout -B claude/opus-reviewer-scratch origin/master`
-3. `gh pr list --state open --json number,title,headRefName,reviews`
-   — print the result.
-4. Identify the candidates: PRs where the latest review body contains
-   `Opus recheck required` OR PRs touching core engine invariants.
+3. Fetch PR lists from both repos (each as a separate command):
+   `gh pr list --state open --json number,title,headRefName,reviews`
+   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,reviews`
+   Print both results.
+4. Identify the candidates from both repos: PRs where the latest
+   review body contains `Opus recheck required` OR PRs touching
+   core engine/game invariants.
 
 ## Loop behavior
 
 Default: run continuously, but on a **longer interval (30 minutes)**
 than the Sonnet reviewer. Each iteration:
 
-1. Re-fetch the PR list.
+1. Re-fetch PR lists from both repos (separate commands):
+   `gh pr list --state open --json number,title,headRefName,reviews`
+   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,reviews`
 2. For each candidate, in oldest-first order:
    a. Read the existing Sonnet review in full first
-      (`gh pr view <N> --comments`). Note what Sonnet flagged.
-   b. Invoke the `review-pr` skill on the PR.
+      (`gh pr view <N> --comments`, add `--repo jakildev/irreden` for
+      game PRs). Note what Sonnet flagged.
+   b. **Engine PRs:** Invoke the `review-pr` skill on the PR.
+      **Game PRs:** Read the diff with `gh pr diff <N> --repo
+      jakildev/irreden` and review manually (you cannot check out game
+      PRs into this engine worktree). For game conventions, read
+      `~/src/IrredenEngine/creations/game/CLAUDE.md`.
    c. Focus your review on the items Sonnet could not confirm — do
       not duplicate work Sonnet already did. Your review body should
       explicitly call out the Sonnet review by saying "Sonnet flagged
@@ -59,8 +81,10 @@ than the Sonnet reviewer. Each iteration:
       Do **not** use `--approve` or `--request-changes` — all fleet
       agents share one GitHub account, and GitHub rejects formal
       review actions on your own PRs.
-   e. **Set the PR label** to match your verdict. The label is the
-      primary signal the human uses. Always remove stale labels first:
+      For game PRs, add `--repo jakildev/irreden` to all `gh` commands.
+   e. **Set the PR label** to match your verdict (add `--repo
+      jakildev/irreden` for game PRs). The label is the primary signal
+      the human uses. Always remove stale labels first:
       `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
       (swap the label name for needs-fix or blocker as appropriate).
 3. After the queue is drained, wait 30 minutes, then loop.

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -87,6 +87,17 @@ than the Sonnet reviewer. Each iteration:
       the human uses. Always remove stale labels first:
       `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
       (swap the label name for needs-fix or blocker as appropriate).
+
+   **Nits vs real issues:**
+   - **Approve with nits.** If the only remaining findings are cosmetic
+     (naming style, comment wording, formatting), approve the PR and
+     list nits as suggestions under `### Nits (optional)`. Do NOT
+     block the PR for these — the human decides whether to address them.
+   - **Needs-fix** is for substantive issues only: correctness bugs,
+     invariant violations, lifetime/ownership mistakes, missing
+     synchronization, performance regressions, or unsafe API use.
+   - Opus budget is expensive. Don't spend it requesting a second
+     round-trip over a renamed variable. When in doubt, approve.
 3. After the queue is drained, wait 30 minutes, then loop.
 4. If you hit a usage-limit error: print the error and reset time,
    wait, resume.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -43,7 +43,10 @@ use `cat` — use the Read tool for files.
      4a. `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName`
    - If the Read fails (file not found) → skip 4a. No game repo on this machine.
 5. `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName`
-6. Print `queue-manager standing by — paste a task description and I will
+6. Print a **one-line queue summary** followed by the standing-by message.
+   Format: `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
+   Count from both engine and game TASKS.md (if present). Then print:
+   `queue-manager standing by — paste a task description and I will
    categorize and file it`.
 
 ## Loop behavior
@@ -206,8 +209,9 @@ You are the sole TASKS.md editor. Each maintenance pass:
    - `git push origin HEAD:master`
    If push rejected, `git pull --rebase origin master` then retry.
 
-7. Print a one-line summary: how many issues ingested, tasks flipped,
-   claims cleaned.
+7. Print the maintenance summary AND the queue summary on two lines:
+   `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned`
+   `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
 
 ## Hard rules
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -8,6 +8,14 @@ WSL2 Ubuntu or macOS).
 
 Mode (optional argument): $ARGUMENTS
 
+## CRITICAL: single-command Bash calls only
+
+Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
+`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
+tool instead of `grep` or `rg`. Use the **Glob** tool instead of
+`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
+this blocks unattended operation with interactive prompts.
+
 ## Role
 
 You are the **task intake** for the fleet. The human (or an idle agent)

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -9,6 +9,14 @@ tasks from `TASKS.md`, work them end-to-end, and open PRs.
 
 Mode (optional argument): $ARGUMENTS
 
+## CRITICAL: single-command Bash calls only
+
+Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
+`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
+tool instead of `grep` or `rg`. Use the **Glob** tool instead of
+`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
+this blocks unattended operation with interactive prompts.
+
 ## Responsibilities
 
 - Test generation against a clear spec.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -87,7 +87,7 @@ limit. Each loop iteration:
    the engine style guide.
 
 5. **Build and run.**
-   `cmake --build build --target <name> -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)`.
+   `fleet-build --target <name>`
    If the touched code has an executable target, run it once. Untested
    commits are the single biggest waste of reviewer-agent time.
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -9,12 +9,21 @@ WSL2 Ubuntu or macOS).
 
 Mode (optional argument): $ARGUMENTS
 
+## CRITICAL: single-command Bash calls only
+
+Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
+`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
+tool instead of `grep` or `rg`. Use the **Glob** tool instead of
+`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
+this blocks unattended operation with interactive prompts.
+
 ## Role
 
-You poll open PRs on `github.com/jakildev/IrredenEngine`, run the
-`review-pr` skill on any that have not been reviewed by this fleet
-yet, and post a structured first-pass review. You also flag PRs that
-need an Opus final pass.
+You poll open PRs on **both repos** — `github.com/jakildev/IrredenEngine`
+(engine) and `github.com/jakildev/irreden` (game) — run the `review-pr`
+skill on any that have not been reviewed by this fleet yet, and post a
+structured first-pass review. You also flag PRs that need an Opus final
+pass.
 
 You are NOT an author. You never commit, push, or open PRs from this
 worktree. The `review-pr` skill documents this as an anti-pattern;
@@ -30,25 +39,43 @@ treat it as a hard rule for this role.
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git checkout -B claude/sonnet-reviewer-scratch origin/master`
    `gh pr checkout` will rewrite this branch on each review.
-3. `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
-   — print the result so we both see the current PR queue.
-4. List the PRs that have **no review yet from this fleet** (filter
-   out PRs whose `reviews` array contains a review by your GitHub
-   user) **and do not have the `fleet:wip` label**. PRs labeled
-   `fleet:wip` are work-in-progress claims — skip them until the
-   author removes the label. These are your candidates.
+3. Fetch PR lists from both repos (each as a separate command):
+   `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
+   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,author,reviews,labels`
+   Print both results so we both see the current PR queues.
+4. List the PRs (from both repos) that have **no review yet from this
+   fleet** (filter out PRs whose `reviews` array contains a review by
+   your GitHub user) **and do not have the `fleet:wip` label**. PRs
+   labeled `fleet:wip` are work-in-progress claims — skip them until
+   the author removes the label. These are your candidates.
 
 ## Loop behavior
 
 Default: run continuously until the human stops you or you hit a
 usage limit. Each iteration:
 
-1. Re-fetch the PR list with `gh pr list ...`.
+1. Re-fetch PR lists from both repos (separate commands):
+   `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
+   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,author,reviews,labels`
 2. For each unreviewed PR, in oldest-first order:
+
+   **Engine PRs** (default repo):
    a. Invoke the `review-pr` skill with the PR number.
    b. The skill checks out the PR, reads the diff in context, writes
       a structured review, and posts it.
-   c. The review body MUST end with one of these explicit lines:
+
+   **Game PRs** (`jakildev/irreden`):
+   a. Read the diff: `gh pr diff <N> --repo jakildev/irreden`
+   b. Read PR details: `gh pr view <N> --repo jakildev/irreden`
+   c. Review the diff manually (you cannot check out game PRs into
+      this engine worktree). Focus on code quality, style, and obvious
+      bugs. For game-specific conventions, read the game CLAUDE.md at
+      `~/src/IrredenEngine/creations/game/CLAUDE.md`.
+   d. Post the review: `gh pr comment <N> --repo jakildev/irreden --body "<review>"`
+   e. Set labels: `gh pr edit <N> --repo jakildev/irreden --add-label "fleet:approved"`
+      (or `fleet:needs-fix` / `fleet:blocker`).
+
+   For all PRs, the review body MUST end with one of these explicit lines:
       - `Opus recheck not required.`
       - `Opus recheck required: <reason>` — use this if the PR touches
         any of: `engine/render/`, `engine/entity/`, `engine/system/`,
@@ -57,8 +84,9 @@ usage limit. Each iteration:
         modules, lifetime/ownership decisions, or concurrency. Also
         flag for Opus recheck if you're uncertain — better to escalate
         than to approve something subtle by mistake.
-   d. **Set the PR label** to match your verdict. The label is the
-      primary signal the human uses. Always remove stale labels first:
+   d. **Set the PR label** to match your verdict (add `--repo
+      jakildev/irreden` for game PRs). The label is the primary signal
+      the human uses. Always remove stale labels first:
       `gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --add-label "fleet:needs-fix"`
       (swap the label name for approved or blocker as appropriate).
       - Verdict approve + "Opus recheck not required" → `fleet:approved`

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -71,9 +71,10 @@ usage limit. Each iteration:
       this engine worktree). Focus on code quality, style, and obvious
       bugs. For game-specific conventions, read the game CLAUDE.md at
       `~/src/IrredenEngine/creations/game/CLAUDE.md`.
-   d. Post the review: `gh pr comment <N> --repo jakildev/irreden --body "<review>"`
-   e. Set labels: `gh pr edit <N> --repo jakildev/irreden --add-label "fleet:approved"`
-      (or `fleet:needs-fix` / `fleet:blocker`).
+   d. Post the review: `gh pr review <N> --repo jakildev/irreden --comment --body "<review>"`
+   e. Set labels — always remove stale labels first:
+      `gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
+      (swap the add-label name for `fleet:needs-fix` or `fleet:blocker` as appropriate).
 
    For all PRs, the review body MUST end with one of these explicit lines:
       - `Opus recheck not required.`

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -94,6 +94,19 @@ usage limit. Each iteration:
         Leave it unlabeled; Opus will set the final label.
       - Verdict needs-fix → `fleet:needs-fix`
       - Verdict blocker → `fleet:blocker`
+
+   **Nits vs real issues:**
+   - **Approve with nits.** If the only findings are cosmetic (naming
+     style, comment wording, import order, minor formatting), approve
+     the PR and list the nits as suggestions in the review body under
+     a `### Nits (optional)` heading. Do NOT block the PR for these.
+   - **Needs-fix** is for substantive issues only: bugs, logic errors,
+     missing error handling at system boundaries, convention violations
+     that would confuse future readers, performance regressions, or
+     missing tests for non-trivial logic.
+   - When in doubt, approve. The human can always request a follow-up.
+     Blocking PRs on style nits wastes more fleet time than the nit
+     is worth.
 3. After the queue is drained, wait 10 minutes, then loop.
 4. If you hit a usage-limit error: print the error and reset time,
    wait, resume.

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# fleet-babysit — auto-resume wrapper for fleet Claude Code agents.
+#
+# Runs claude interactively with a role slash command, then auto-resumes
+# the session if claude exits (usage limit, crash, network drop, etc.).
+# Works identically for engine and game worktrees — the cwd determines
+# which repo/session context claude uses.
+#
+# Usage:
+#   fleet-babysit <model> <role> [mode]
+#
+# Examples:
+#   fleet-babysit sonnet sonnet-author dry-run
+#   fleet-babysit opus  opus-architect live
+#   fleet-babysit sonnet game-sonnet live    # game worktree cwd
+#
+# Behavior by mode:
+#   dry-run  — start the agent, auto-resume on crash, but do NOT
+#              auto-resume on clean exit (exit 0). The human decides
+#              when to promote to live.
+#   live     — auto-resume on any exit. Keeps the agent running
+#              indefinitely until the fleet session is killed.
+#
+# On resume, sends "resume your work from where you left off" so the
+# agent auto-continues without human intervention.
+#
+# Source of truth: scripts/fleet/fleet-babysit in the engine repo.
+# Installed to ~/bin/fleet-babysit by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+MODEL="${1:?usage: fleet-babysit <model> <role> [mode]}"
+ROLE="${2:?usage: fleet-babysit <model> <role> [mode]}"
+MODE="${3:-dry-run}"
+
+# Timing
+CRASH_DELAY=30        # seconds to wait after non-zero exit (crash)
+LIMIT_DELAY=300       # seconds to wait on suspected usage limit (exit 2)
+CLEAN_DELAY=60        # seconds to wait after clean exit
+MAX_ATTEMPTS=200      # safety valve — prevents infinite loops on hard failures
+
+attempt=0
+
+log() { echo "[babysit $(date +%H:%M:%S)] $ROLE: $*"; }
+
+log "starting ($MODEL) mode=$MODE in $(pwd)"
+
+# --- First run: send the role slash command --------------------------------
+claude --model "$MODEL" "/role-$ROLE $MODE"
+last_exit=$?
+
+# --- Resume loop -----------------------------------------------------------
+while true; do
+    attempt=$((attempt + 1))
+
+    if [[ $attempt -ge $MAX_ATTEMPTS ]]; then
+        log "safety limit reached ($MAX_ATTEMPTS attempts). stopping."
+        break
+    fi
+
+    # In dry-run mode, don't auto-resume on clean exit — the agent
+    # completed its one-shot task and the human should review.
+    if [[ "$MODE" == "dry-run" && $last_exit -eq 0 ]]; then
+        log "clean exit in dry-run mode. standing by (type 'claude --continue' to resume manually)."
+        break
+    fi
+
+    # Pick a wait time based on exit code
+    case $last_exit in
+        0)
+            log "exited cleanly. resuming in ${CLEAN_DELAY}s..."
+            sleep "$CLEAN_DELAY"
+            ;;
+        2)
+            # Exit code 2 often indicates usage limit
+            log "possible usage limit (exit 2). waiting ${LIMIT_DELAY}s..."
+            sleep "$LIMIT_DELAY"
+            ;;
+        *)
+            log "exited with code $last_exit. resuming in ${CRASH_DELAY}s..."
+            sleep "$CRASH_DELAY"
+            ;;
+    esac
+
+    log "resuming session (attempt $attempt)..."
+    claude --model "$MODEL" --continue "resume your work from where you left off"
+    last_exit=$?
+done

--- a/scripts/fleet/fleet-build
+++ b/scripts/fleet/fleet-build
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# fleet-build — cmake --build wrapper with auto-parallelism.
+#
+# Removes the need for agents to embed $(nproc) or $(sysctl -n hw.ncpu)
+# in their Bash calls, which triggers Claude Code's command_substitution
+# security gate and blocks unattended operation.
+#
+# Usage:
+#   fleet-build --target IRShapeDebug
+#   fleet-build --target IRCreationDefault
+#   fleet-build --target IrredenEngineTest -- -j4   # override parallelism
+#
+# All arguments are forwarded to `cmake --build`. If no -j flag is
+# provided, one is injected automatically using the detected CPU count.
+#
+# Source of truth: scripts/fleet/fleet-build in the engine repo.
+# Installed to ~/bin/fleet-build (as a symlink) by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+BUILD_DIR="${IRREDEN_BUILD_DIR:-$HOME/src/IrredenEngine/build}"
+
+# Auto-detect CPU count if no -j flag was passed.
+has_j_flag=false
+for arg in "$@"; do
+    case "$arg" in
+        -j*|--parallel*) has_j_flag=true ;;
+    esac
+done
+
+if $has_j_flag; then
+    exec cmake --build "$BUILD_DIR" "$@"
+else
+    if command -v nproc >/dev/null 2>&1; then
+        JOBS=$(nproc)
+    elif command -v sysctl >/dev/null 2>&1; then
+        JOBS=$(sysctl -n hw.ncpu)
+    else
+        JOBS=4
+    fi
+    exec cmake --build "$BUILD_DIR" -j"$JOBS" "$@"
+fi

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -266,7 +266,7 @@ launch_cmd() {
     # $1 = model alias (opus|sonnet), $2 = role slug (without role- prefix)
     local model="$1"
     local role="$2"
-    printf 'claude --model %s "/role-%s %s"; exec $SHELL\n' \
+    printf 'fleet-babysit %s %s %s; exec $SHELL\n' \
         "$model" "$role" "$MODE"
 }
 
@@ -404,7 +404,12 @@ mode "dry-run" means each agent does its startup actions and then
 waits. promote a pane to full operation by typing in it:
   "exit dry-run mode and begin your normal loop"
 
-other modes:
-  fleet-up dry-run   # default
-  fleet-up live      # full loop from the start (timer sends maintenance triggers)
+babysit: each agent is wrapped in fleet-babysit, which auto-resumes
+the session if claude exits (crash, usage limit, network drop).
+  dry-run — auto-resumes on crash, stops on clean exit
+  live    — auto-resumes on any exit (runs indefinitely)
+
+other modes you can pass to fleet-up:
+  fleet-up dry-run   # default — startup + stand-by
+  fleet-up live      # full loop from the start (use after a clean dry run)
 EOF

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -178,6 +178,7 @@ baseline = [
     "Bash(basename:*)",
     "Bash(dirname:*)",
     "Bash(fleet-claim:*)",
+    "Bash(fleet-build:*)",
 ]
 
 # Preserve any user-granted "always allow" entries from previous sessions,

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -66,6 +66,8 @@ FLEET_CLAIM_SRC="$SCRIPT_DIR/fleet-claim"
 FLEET_CLAIM_DEST="$HOME/bin/fleet-claim"
 FLEET_BUILD_SRC="$SCRIPT_DIR/fleet-build"
 FLEET_BUILD_DEST="$HOME/bin/fleet-build"
+FLEET_BABYSIT_SRC="$SCRIPT_DIR/fleet-babysit"
+FLEET_BABYSIT_DEST="$HOME/bin/fleet-babysit"
 
 if [[ ! -f "$FLEET_UP_SRC" ]]; then
     echo "install.sh: $FLEET_UP_SRC does not exist — repo is incomplete" >&2
@@ -75,7 +77,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_BABYSIT_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -97,6 +99,11 @@ fi
 if [[ -f "$FLEET_BUILD_SRC" ]]; then
     ln -sf "$FLEET_BUILD_SRC" "$FLEET_BUILD_DEST"
     echo "symlinked $FLEET_BUILD_DEST -> $FLEET_BUILD_SRC"
+fi
+
+if [[ -f "$FLEET_BABYSIT_SRC" ]]; then
+    ln -sf "$FLEET_BABYSIT_SRC" "$FLEET_BABYSIT_DEST"
+    echo "symlinked $FLEET_BABYSIT_DEST -> $FLEET_BABYSIT_SRC"
 fi
 
 # ----------------------------------------------------------------------

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -64,6 +64,8 @@ FLEET_UP_SRC="$SCRIPT_DIR/fleet-up"
 FLEET_UP_DEST="$HOME/bin/fleet-up"
 FLEET_CLAIM_SRC="$SCRIPT_DIR/fleet-claim"
 FLEET_CLAIM_DEST="$HOME/bin/fleet-claim"
+FLEET_BUILD_SRC="$SCRIPT_DIR/fleet-build"
+FLEET_BUILD_DEST="$HOME/bin/fleet-build"
 
 if [[ ! -f "$FLEET_UP_SRC" ]]; then
     echo "install.sh: $FLEET_UP_SRC does not exist — repo is incomplete" >&2
@@ -73,7 +75,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_CLAIM_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -90,6 +92,11 @@ echo "symlinked $FLEET_UP_DEST -> $FLEET_UP_SRC"
 if [[ -f "$FLEET_CLAIM_SRC" ]]; then
     ln -sf "$FLEET_CLAIM_SRC" "$FLEET_CLAIM_DEST"
     echo "symlinked $FLEET_CLAIM_DEST -> $FLEET_CLAIM_SRC"
+fi
+
+if [[ -f "$FLEET_BUILD_SRC" ]]; then
+    ln -sf "$FLEET_BUILD_SRC" "$FLEET_BUILD_DEST"
+    echo "symlinked $FLEET_BUILD_DEST -> $FLEET_BUILD_SRC"
 fi
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reviewers (sonnet-reviewer + opus-reviewer) now poll both `jakildev/IrredenEngine` AND `jakildev/irreden` (game repo) for open PRs
- Game PRs are reviewed via `gh pr diff` since they can't be checked out into engine worktrees
- Added prominent `## CRITICAL: single-command Bash calls only` section at the top of every role file to reduce compound command violations
- Created `fleet:wip`, `fleet:approved`, `fleet:needs-fix`, `fleet:blocker` labels on the game repo
- Updated `~/.tmux.conf` with macOS fallback keybindings (M-b/M-f) for Option+Left/Right pane navigation

## Test plan
- [ ] Verify `fleet-up dry-run` launches without errors
- [ ] Verify Option+Left/Right navigates panes on macOS
- [ ] Verify reviewers pick up game repo PRs in their startup actions
- [ ] Verify agents no longer use compound bash commands (or at least less frequently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)