### PR TITLE
profile: add agent-readable profiling infrastructure

### DIFF
--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -55,6 +55,8 @@ int g_settleCounter = 0;
 bool g_screenshotPending = false;
 bool g_autoMode = false;
 bool g_depthColor = false;
+int g_autoProfileFrames = 0;  // 0 = disabled
+int g_autoProfileCount = 0;
 
 } // namespace
 
@@ -74,6 +76,15 @@ int main(int argc, char **argv) {
                     ++i;
                 }
             }
+        } else if (std::strcmp(argv[i], "--auto-profile") == 0) {
+            g_autoProfileFrames = 300;  // default
+            if (i + 1 < argc) {
+                int frames = std::atoi(argv[i + 1]);
+                if (frames > 0) {
+                    g_autoProfileFrames = frames;
+                    ++i;
+                }
+            }
         } else if (std::strcmp(argv[i], "--depth-color") == 0) {
             g_depthColor = true;
         }
@@ -81,6 +92,9 @@ int main(int argc, char **argv) {
 
     IR_LOG_INFO("Starting creation: shape_debug");
     IREngine::init(argv[0]);
+    if (g_autoProfileFrames > 0) {
+        IREngine::enableFrameTiming(true);
+    }
     initSystems();
     initCommands();
     initEntities();
@@ -107,6 +121,22 @@ void initSystems() {
         IRSystem::createSystem<IRSystem::TRIXEL_TO_FRAMEBUFFER>(),
         IRSystem::createSystem<IRSystem::FRAMEBUFFER_TO_SCREEN>(),
     };
+
+    if (g_autoProfileFrames > 0) {
+        IRSystem::SystemId autoProfileId = IRSystem::createSystem<C_VoxelSetNew>(
+            "AutoProfile",
+            [](C_VoxelSetNew &) {},
+            []() {
+                ++g_autoProfileCount;
+                if (g_autoProfileCount >= g_autoProfileFrames) {
+                    IR_LOG_INFO("Auto-profile: {} frames collected, exiting",
+                                g_autoProfileFrames);
+                    IRWindow::closeWindow();
+                }
+            }
+        );
+        renderPipeline.push_back(autoProfileId);
+    }
 
     if (g_autoMode) {
         IRSystem::SystemId autoScreenshotId = IRSystem::createSystem<C_VoxelSetNew>(

--- a/engine/include/irreden/ir_engine.hpp
+++ b/engine/include/irreden/ir_engine.hpp
@@ -53,6 +53,10 @@ inline void runScript(const char *scriptFileName) {
     g_world->runScript(resolveScriptPath(scriptFileName).c_str());
 }
 
+inline void enableFrameTiming(bool enabled) {
+    getWorld().enableFrameTiming(enabled);
+}
+
 inline void gameLoop() {
     getWorld().gameLoop();
 }

--- a/engine/profile/CMakeLists.txt
+++ b/engine/profile/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(IrredenEngineProfile STATIC
     src/cpu_profiler.cpp
     src/logger_spd.cpp
     src/ir_profile.cpp
+    src/profile_report.cpp
 )
 
 option(

--- a/engine/profile/include/irreden/profile/profile_report.hpp
+++ b/engine/profile/include/irreden/profile/profile_report.hpp
@@ -1,5 +1,5 @@
-#ifndef PROFILE_REPORT_H
-#define PROFILE_REPORT_H
+#ifndef IR_PROFILE_REPORT_H
+#define IR_PROFILE_REPORT_H
 
 #include <cstdint>
 #include <string>
@@ -44,4 +44,4 @@ void writeProfileReport(const ProfileReport &report, const char *outputPath);
 
 } // namespace IRProfile
 
-#endif /* PROFILE_REPORT_H */
+#endif /* IR_PROFILE_REPORT_H */

--- a/engine/profile/include/irreden/profile/profile_report.hpp
+++ b/engine/profile/include/irreden/profile/profile_report.hpp
@@ -1,0 +1,47 @@
+#ifndef PROFILE_REPORT_H
+#define PROFILE_REPORT_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace IRProfile {
+
+/// Per-system timing entry for agent-readable profile reports.
+struct SystemTimingEntry {
+    std::string name_;
+    std::string pipeline_;  // "INPUT", "UPDATE", "RENDER"
+    uint64_t totalNs_ = 0;
+    uint64_t minNs_ = UINT64_MAX;
+    uint64_t maxNs_ = 0;
+    uint32_t callCount_ = 0;
+    uint64_t totalEntityCount_ = 0;
+};
+
+/// Per-GPU-stage timing entry.
+struct GpuStageEntry {
+    std::string name_;
+    float totalMs_ = 0.0f;
+    float maxMs_ = 0.0f;
+    uint32_t sampleCount_ = 0;
+};
+
+/// Aggregated data for a profile report, populated by World at shutdown.
+struct ProfileReport {
+    std::vector<float> frameTimesMs_;
+    uint32_t totalFrames_ = 0;
+    uint32_t totalUpdateTicks_ = 0;
+    uint32_t maxUpdateTicksPerFrame_ = 0;
+    uint64_t entityCount_ = 0;
+    uint32_t archetypeCount_ = 0;
+    std::vector<SystemTimingEntry> systemTimings_;
+    std::vector<GpuStageEntry> gpuStages_;
+};
+
+/// Write a plain-text profile report to the given file path.
+/// Creates parent directories if they don't exist.
+void writeProfileReport(const ProfileReport &report, const char *outputPath);
+
+} // namespace IRProfile
+
+#endif /* PROFILE_REPORT_H */

--- a/engine/profile/src/profile_report.cpp
+++ b/engine/profile/src/profile_report.cpp
@@ -1,0 +1,137 @@
+#include <irreden/profile/profile_report.hpp>
+#include <irreden/ir_profile.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <numeric>
+
+namespace IRProfile {
+
+namespace {
+
+struct Percentiles {
+    float p50_ = 0.0f;
+    float p95_ = 0.0f;
+    float p99_ = 0.0f;
+    float avg_ = 0.0f;
+    float min_ = 0.0f;
+    float max_ = 0.0f;
+};
+
+Percentiles computePercentiles(std::vector<float> values) {
+    Percentiles p;
+    if (values.empty()) return p;
+
+    std::sort(values.begin(), values.end());
+    float sum = std::accumulate(values.begin(), values.end(), 0.0f);
+    size_t n = values.size();
+
+    p.avg_ = sum / static_cast<float>(n);
+    p.min_ = values.front();
+    p.max_ = values.back();
+    p.p50_ = values[n * 50 / 100];
+    p.p95_ = values[std::min(n * 95 / 100, n - 1)];
+    p.p99_ = values[std::min(n * 99 / 100, n - 1)];
+    return p;
+}
+
+const char *kPipelineOrder[] = {"INPUT", "UPDATE", "RENDER"};
+
+int pipelineRank(const std::string &pipeline) {
+    for (int i = 0; i < 3; ++i) {
+        if (pipeline == kPipelineOrder[i]) return i;
+    }
+    return 99;
+}
+
+} // namespace
+
+void writeProfileReport(const ProfileReport &report, const char *outputPath) {
+    std::filesystem::path outPath(outputPath);
+    std::filesystem::create_directories(outPath.parent_path());
+
+    FILE *f = std::fopen(outputPath, "w");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open profile report output: {}", outputPath);
+        return;
+    }
+
+    // --- Header ---
+    std::fprintf(f, "=== PROFILE REPORT (%u frames) ===\n", report.totalFrames_);
+
+    // --- Frame timing ---
+    if (!report.frameTimesMs_.empty()) {
+        Percentiles fp = computePercentiles(report.frameTimesMs_);
+        std::fprintf(f, "Frame time:   avg=%.2fms   p50=%.2fms   p95=%.2fms   p99=%.2fms   "
+                        "min=%.2fms   max=%.2fms\n",
+                     fp.avg_, fp.p50_, fp.p95_, fp.p99_, fp.min_, fp.max_);
+    }
+
+    float avgUpdateTicks = report.totalFrames_ > 0
+        ? static_cast<float>(report.totalUpdateTicks_) / static_cast<float>(report.totalFrames_)
+        : 0.0f;
+    std::fprintf(f, "Update ticks: avg=%.1f/frame  max=%u\n",
+                 avgUpdateTicks, report.maxUpdateTicksPerFrame_);
+    std::fprintf(f, "Entity count: %llu (%u archetypes)\n",
+                 static_cast<unsigned long long>(report.entityCount_),
+                 report.archetypeCount_);
+    std::fprintf(f, "\n");
+
+    // --- Per-system timing ---
+    if (!report.systemTimings_.empty()) {
+        // Sort by pipeline order, then by total time descending within each pipeline.
+        std::vector<const SystemTimingEntry *> sorted;
+        sorted.reserve(report.systemTimings_.size());
+        for (auto &e : report.systemTimings_) {
+            sorted.push_back(&e);
+        }
+        std::sort(sorted.begin(), sorted.end(),
+                  [](const SystemTimingEntry *a, const SystemTimingEntry *b) {
+                      int ra = pipelineRank(a->pipeline_);
+                      int rb = pipelineRank(b->pipeline_);
+                      if (ra != rb) return ra < rb;
+                      return a->totalNs_ > b->totalNs_;
+                  });
+
+        std::fprintf(f, "--- Per-system timing (by pipeline, then total descending) ---\n");
+        std::fprintf(f, "%-8s %-36s %10s %9s %9s %9s %7s %10s\n",
+                     "Pipeline", "System", "Total(ms)", "Avg(ms)", "Min(ms)", "Max(ms)",
+                     "Calls", "Entities");
+
+        for (auto *entry : sorted) {
+            if (entry->callCount_ == 0) continue;
+            double totalMs = static_cast<double>(entry->totalNs_) / 1e6;
+            double avgMs = totalMs / static_cast<double>(entry->callCount_);
+            double minMs = static_cast<double>(entry->minNs_) / 1e6;
+            double maxMs = static_cast<double>(entry->maxNs_) / 1e6;
+
+            std::fprintf(f, "%-8s %-36s %10.2f %9.3f %9.3f %9.3f %7u %10llu\n",
+                         entry->pipeline_.c_str(),
+                         entry->name_.c_str(),
+                         totalMs, avgMs, minMs, maxMs,
+                         entry->callCount_,
+                         static_cast<unsigned long long>(entry->totalEntityCount_));
+        }
+        std::fprintf(f, "\n");
+    }
+
+    // --- GPU stage timing ---
+    if (!report.gpuStages_.empty()) {
+        std::fprintf(f, "--- GPU stage timing ---\n");
+        std::fprintf(f, "%-36s %9s %9s\n", "Stage", "Avg(ms)", "Max(ms)");
+
+        for (auto &stage : report.gpuStages_) {
+            if (stage.sampleCount_ == 0) continue;
+            float avgMs = stage.totalMs_ / static_cast<float>(stage.sampleCount_);
+            std::fprintf(f, "%-36s %9.3f %9.3f\n",
+                         stage.name_.c_str(), avgMs, stage.maxMs_);
+        }
+        std::fprintf(f, "\n");
+    }
+
+    std::fprintf(f, "=== END REPORT ===\n");
+    std::fclose(f);
+}
+
+} // namespace IRProfile

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -57,6 +57,10 @@ template <typename Params> Params *getSystemParams(SystemId system) {
 void registerPipeline(IRTime::Events systemType, std::list<SystemId> pipeline);
 void executePipeline(IRTime::Events event);
 
+inline void setTimingEnabled(bool enabled) { getSystemManager().setTimingEnabled(enabled); }
+inline bool isTimingEnabled() { return getSystemManager().isTimingEnabled(); }
+inline void resetTimingStats() { getSystemManager().resetTimingStats(); }
+
 } // namespace IRSystem
 
 #endif /* IR_SYSTEM_H */

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -11,6 +11,7 @@
 #include <irreden/system/components/component_system_event.hpp>
 #include <irreden/system/components/component_system_relation.hpp>
 
+#include <chrono>
 #include <vector>
 #include <unordered_map>
 #include <memory>
@@ -36,6 +37,15 @@ template <typename Params> class ISystemParamsImpl : public ISystemParams {
 class SystemManager {
   public:
     using ErasedParamsPtr = std::unique_ptr<ISystemParams>;
+
+    /// Per-system timing accumulator, populated when timing is enabled.
+    struct TimingAccum {
+        uint64_t totalNs_ = 0;
+        uint64_t minNs_ = UINT64_MAX;
+        uint64_t maxNs_ = 0;
+        uint32_t callCount_ = 0;
+        uint64_t totalEntityCount_ = 0;
+    };
 
     SystemManager();
     ~SystemManager();
@@ -66,6 +76,7 @@ class SystemManager {
 
         m_relations.emplace_back(C_SystemRelation{extraParams.relation_});
         m_systemParams.emplace_back(nullptr);
+        m_timingAccum.emplace_back();
         return newSystemId;
     }
 
@@ -86,6 +97,17 @@ class SystemManager {
     void executePipeline(IRTime::Events event);
     void executeSystem(SystemId system);
 
+    void setTimingEnabled(bool enabled) { m_timingEnabled = enabled; }
+    bool isTimingEnabled() const { return m_timingEnabled; }
+    void resetTimingStats();
+
+    const std::string &getSystemName(SystemId id) const { return m_systemNames[id].name_; }
+    SystemId getSystemCount() const { return m_nextSystemId; }
+    const TimingAccum &getTimingAccum(SystemId id) const { return m_timingAccum[id]; }
+    const std::unordered_map<IRTime::Events, std::list<SystemId>> &getPipelines() const {
+        return m_systemPipelinesNew;
+    }
+
   private:
     SystemId m_nextSystemId = 0;
     std::vector<C_Name> m_systemNames;
@@ -98,6 +120,9 @@ class SystemManager {
     std::unordered_map<SystemName, SystemId> m_engineSystemIds;
 
     std::unordered_map<IRTime::Events, std::list<SystemId>> m_systemPipelinesNew;
+
+    bool m_timingEnabled = false;
+    std::vector<TimingAccum> m_timingAccum;
 
     // Begin tick functions happen once per system before tick function(s)
     template <typename FunctionBeginTick>

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -3,6 +3,8 @@
 
 #include <irreden/common/components/component_name.hpp>
 
+#include <chrono>
+
 namespace IRSystem {
 
 SystemManager::SystemManager()
@@ -14,6 +16,12 @@ SystemManager::SystemManager()
 SystemManager::~SystemManager() {
     if (g_systemManager == this) {
         g_systemManager = nullptr;
+    }
+}
+
+void SystemManager::resetTimingStats() {
+    for (auto &acc : m_timingAccum) {
+        acc = TimingAccum{};
     }
 }
 
@@ -32,6 +40,13 @@ void SystemManager::executePipeline(IRTime::Events event) {
 
 void SystemManager::executeSystem(SystemId system) {
     IR_PROFILE_BLOCK(m_systemNames[system].name_.c_str(), IR_PROFILER_COLOR_SYSTEMS);
+
+    using Clock = std::chrono::steady_clock;
+    Clock::time_point t0;
+    if (m_timingEnabled) {
+        t0 = Clock::now();
+    }
+
     m_beginTicks[system].functionBeginTick_();
     std::vector<ArchetypeNode *> nodes;
     if (m_relations[system].relation_ == Relation::NONE) {
@@ -43,12 +58,31 @@ void SystemManager::executeSystem(SystemId system) {
             m_ticks[system].archetype_
         );
     }
+
+    uint64_t entityCount = 0;
     EntityId previousRelatedEntity = kNullEntity;
     for (auto node : nodes) {
+        if (m_timingEnabled) {
+            entityCount += static_cast<uint64_t>(node->length_);
+        }
         previousRelatedEntity = handleRelationTick(node, system, previousRelatedEntity);
         m_ticks[system].functionTick_(node);
     }
     m_endTicks[system].functionEndTick_();
+
+    if (m_timingEnabled) {
+        auto elapsed = Clock::now() - t0;
+        uint64_t ns = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count()
+        );
+        auto &acc = m_timingAccum[system];
+        acc.totalNs_ += ns;
+        if (ns < acc.minNs_) acc.minNs_ = ns;
+        if (ns > acc.maxNs_) acc.maxNs_ = ns;
+        acc.callCount_++;
+        acc.totalEntityCount_ += entityCount;
+    }
+
     IREntity::flushStructuralChanges();
 }
 

--- a/engine/world/include/irreden/world.hpp
+++ b/engine/world/include/irreden/world.hpp
@@ -30,6 +30,7 @@ class World {
     void gameLoop();
     void setupLuaBindings(const std::vector<LuaBindingRegistration> &bindings);
     void runScript(const char *fileName);
+    void enableFrameTiming(bool enabled);
 
     // void setPlayer(const IREntity::EntityId& player);
     // void setCameraPosition3D(const vec3& position);
@@ -49,6 +50,12 @@ class World {
     bool m_waitForFirstUpdateInput = false;
     bool m_startRecordingOnFirstInput = false;
     bool m_hasHandledFirstInput = false;
+
+    // Agent-readable profiling: frame timing accumulation
+    bool m_frameTimingEnabled = false;
+    std::vector<float> m_frameTimesMs;
+    uint32_t m_frameTotalUpdateTicks = 0;
+    uint32_t m_frameMaxUpdateTicksPerFrame = 0;
     // adding to world for user should just be attaching things to world ecs
     // entity! I have tried this before btw but wasnt ready
     // EntityHandle m_worldEngine;
@@ -65,6 +72,7 @@ class World {
     void start();
     void end();
     void render();
+    void buildAndWriteProfileReport();
 };
 
 } // namespace IREngine

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -219,8 +219,8 @@ void World::buildAndWriteProfileReport() {
     if (!m_frameTimingEnabled) return;
 
     IRProfile::ProfileReport report;
-    report.frameTimesMs_ = std::move(m_frameTimesMs);
     report.totalFrames_ = static_cast<uint32_t>(m_frameTimesMs.size());
+    report.frameTimesMs_ = std::move(m_frameTimesMs);
     report.totalUpdateTicks_ = m_frameTotalUpdateTicks;
     report.maxUpdateTicksPerFrame_ = m_frameMaxUpdateTicksPerFrame;
     report.entityCount_ = IREntity::getLiveEntityCount();

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -1,11 +1,15 @@
 #include <irreden/ir_profile.hpp>
 #include <irreden/ir_render.hpp>
 #include <irreden/ir_system.hpp>
+#include <irreden/ir_entity.hpp>
 #include <irreden/ir_input.hpp>
 #include <irreden/ir_audio.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/profile/profile_report.hpp>
 
 #include <irreden/world.hpp>
+
+#include <chrono>
 
 namespace IREngine {
 
@@ -91,6 +95,7 @@ void World::runScript(const char *fileName) {
 }
 
 void World::gameLoop() {
+    using Clock = std::chrono::steady_clock;
     try {
         start();
         if (m_waitForFirstUpdateInput) {
@@ -100,6 +105,12 @@ void World::gameLoop() {
         while (!m_IRGLFWWindow.shouldClose()) {
             m_timeManager.beginMainLoop();
 
+            Clock::time_point frameStart;
+            if (m_frameTimingEnabled) {
+                frameStart = Clock::now();
+            }
+
+            uint32_t updateTicksThisFrame = 0;
             while (m_timeManager.shouldUpdate()) {
                 m_IRGLFWWindow.pollEvents();
                 input();
@@ -118,8 +129,19 @@ void World::gameLoop() {
                 }
 
                 update();
+                ++updateTicksThisFrame;
             }
             render();
+
+            if (m_frameTimingEnabled) {
+                auto elapsed = Clock::now() - frameStart;
+                float ms = std::chrono::duration<float, std::milli>(elapsed).count();
+                m_frameTimesMs.push_back(ms);
+                m_frameTotalUpdateTicks += updateTicksThisFrame;
+                if (updateTicksThisFrame > m_frameMaxUpdateTicksPerFrame) {
+                    m_frameMaxUpdateTicksPerFrame = updateTicksThisFrame;
+                }
+            }
         }
     } catch (...) {
         IRE_LOG_ERROR("Unhandled exception in game loop, running cleanup");
@@ -145,6 +167,7 @@ void World::start() {
 }
 
 void World::end() {
+    buildAndWriteProfileReport();
     m_videoManager.shutdown();
     // Ensure component onDestroy hooks run while managers are still valid
     // (e.g. MIDI cleanup that sends NOTE_OFF on shutdown).
@@ -178,6 +201,84 @@ void World::render() {
     m_renderer.presentFrame();
 
     m_timeManager.endEvent<IRTime::RENDER>();
+}
+
+void World::enableFrameTiming(bool enabled) {
+    m_frameTimingEnabled = enabled;
+    m_systemManager.setTimingEnabled(enabled);
+    if (enabled) {
+        m_frameTimesMs.clear();
+        m_frameTimesMs.reserve(1024);
+        m_frameTotalUpdateTicks = 0;
+        m_frameMaxUpdateTicksPerFrame = 0;
+        m_systemManager.resetTimingStats();
+    }
+}
+
+void World::buildAndWriteProfileReport() {
+    if (!m_frameTimingEnabled) return;
+
+    IRProfile::ProfileReport report;
+    report.frameTimesMs_ = std::move(m_frameTimesMs);
+    report.totalFrames_ = static_cast<uint32_t>(m_frameTimesMs.size());
+    report.totalUpdateTicks_ = m_frameTotalUpdateTicks;
+    report.maxUpdateTicksPerFrame_ = m_frameMaxUpdateTicksPerFrame;
+    report.entityCount_ = IREntity::getLiveEntityCount();
+    report.archetypeCount_ = static_cast<uint32_t>(m_entityManager.getArchetypeNodes().size());
+
+    // Collect per-system timing, grouped by pipeline
+    auto pipelineName = [](IRTime::Events e) -> const char * {
+        switch (e) {
+            case IRTime::Events::INPUT:  return "INPUT";
+            case IRTime::Events::UPDATE: return "UPDATE";
+            case IRTime::Events::RENDER: return "RENDER";
+            default: return "OTHER";
+        }
+    };
+
+    const auto &pipelines = m_systemManager.getPipelines();
+    for (auto &[event, systemList] : pipelines) {
+        for (auto systemId : systemList) {
+            const auto &acc = m_systemManager.getTimingAccum(systemId);
+            if (acc.callCount_ == 0) continue;
+            IRProfile::SystemTimingEntry entry;
+            entry.name_ = m_systemManager.getSystemName(systemId);
+            entry.pipeline_ = pipelineName(event);
+            entry.totalNs_ = acc.totalNs_;
+            entry.minNs_ = acc.minNs_;
+            entry.maxNs_ = acc.maxNs_;
+            entry.callCount_ = acc.callCount_;
+            entry.totalEntityCount_ = acc.totalEntityCount_;
+            report.systemTimings_.push_back(std::move(entry));
+        }
+    }
+
+    // Collect GPU stage timing if enabled
+    auto &gpu = IRRender::gpuStageTiming();
+    if (gpu.enabled_ && report.totalFrames_ > 0) {
+        auto addGpuStage = [&](const char *name, float perFrameMs) {
+            IRProfile::GpuStageEntry stage;
+            stage.name_ = name;
+            stage.totalMs_ = perFrameMs * static_cast<float>(report.totalFrames_);
+            stage.maxMs_ = perFrameMs;  // Only per-frame snapshot available
+            stage.sampleCount_ = report.totalFrames_;
+            report.gpuStages_.push_back(std::move(stage));
+        };
+        addGpuStage("canvas_clear", gpu.canvasClearMs_);
+        addGpuStage("voxel_compact", gpu.voxelCompactMs_);
+        addGpuStage("voxel_stage_1", gpu.voxelStage1Ms_);
+        addGpuStage("voxel_stage_2", gpu.voxelStage2Ms_);
+        addGpuStage("shape_compact", gpu.shapeCompactMs_);
+        addGpuStage("shape_pass_0", gpu.shapePass0Ms_);
+        addGpuStage("shape_pass_1", gpu.shapePass1Ms_);
+        addGpuStage("trixel_to_framebuffer", gpu.trixelToFbMs_);
+        addGpuStage("entity_canvas_to_framebuffer", gpu.entityCanvasToFbMs_);
+        addGpuStage("framebuffer_to_screen", gpu.fbToScreenMs_);
+    }
+
+    IRProfile::writeProfileReport(report, "save_files/profile_report.txt");
+    IRE_LOG_INFO("Profile report written to save_files/profile_report.txt ({} frames)",
+                 report.totalFrames_);
 }
 
 } // namespace IREngine


### PR DESCRIPTION
## Summary
- Adds per-system `std::chrono` timing to `SystemManager::executeSystem()` — zero cost when disabled, nanosecond-resolution min/max/avg/total + entity counts when enabled.
- `World` accumulates frame wall-clock times and update tick counts; `buildAndWriteProfileReport()` writes a plain-text report at shutdown.
- New `ProfileReport` data structs and `writeProfileReport()` in `engine/profile/` — outputs frame percentiles (p50/p95/p99), per-system table sorted by pipeline then total time, GPU stage timing, entity/archetype counts.
- `shape_debug` gains `--auto-profile <N>` (default 300 frames) — enables timing, runs N frames, exits cleanly so agents can `cat save_files/profile_report.txt`.

## Context
This is PR 1 of a series building toward a `/perf-loop` skill that lets agents iterate on performance the way `/render-debug-loop` iterates on visuals. Future PRs will add a dedicated benchmark creation with entity scaling, and the skill definition itself.

## Build verification
All changed translation units compile cleanly on macOS-debug. Full link is blocked by the pre-existing spdlog/fmt v10 incompatibility in the video module (unrelated to this PR).

## Test plan
- [ ] `IRShapeDebug --auto-profile 100` runs 100 frames and exits
- [ ] `cat save_files/profile_report.txt` shows frame percentiles, per-system table, GPU stages
- [ ] Running without `--auto-profile` behaves identically to before (timing disabled by default)
- [ ] Verify zero overhead: profiling disabled path has no `Clock::now()` calls

## Files changed
- `engine/profile/include/irreden/profile/profile_report.hpp` — new: report data structs
- `engine/profile/src/profile_report.cpp` — new: report writer
- `engine/profile/CMakeLists.txt` — add profile_report.cpp
- `engine/system/include/irreden/system/system_manager.hpp` — TimingAccum, timing API
- `engine/system/src/system_manager.cpp` — chrono instrumentation in executeSystem
- `engine/system/include/irreden/ir_system.hpp` — timing facade functions
- `engine/world/include/irreden/world.hpp` — frame timing members
- `engine/world/src/world.cpp` — frame accumulation, report assembly
- `engine/include/irreden/ir_engine.hpp` — enableFrameTiming facade
- `creations/demos/shape_debug/main.cpp` — --auto-profile flag + AutoProfile system

🤖 Generated with [Claude Code](https://claude.com/claude-code)