### PR TITLE
queue: add task — macOS FFmpeg: fix CMake/pkg-config wiring on macos-debug

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -159,6 +159,15 @@ Avoid:
     first-time issues.
   - **Links:**
 
+- [ ] **macOS FFmpeg: fix CMake/pkg-config wiring on `macos-debug`** — get FFmpeg headers and libs found and linked correctly on macOS so `engine/video/` compiles and links on the `macos-debug` preset.
+  - **Area:** build, engine/video
+  - **Model:** sonnet
+  - **Owner:** free
+  - **Blocked by:** (none)
+  - **Acceptance:** `cmake --preset macos-debug && cmake --build build --target IRShapeDebug` completes with zero FFmpeg-related include or linker errors; `avcodec`, `avformat`, `avutil`, and `swscale` all appear in the final link line.
+  - **Notes:** Known macOS first-time issue per `docs/AGENT_FLEET_SETUP.md` §10 — Homebrew FFmpeg pkg-config path differs from Linux (`/opt/homebrew/lib/pkgconfig` on Apple Silicon, `/usr/local/lib/pkgconfig` on Intel). If the fix requires changes to `engine/video/` source beyond CMake, escalate to `[opus]`.
+  - **Links:**
+
 - [ ] **macOS/Metal build maturation: get `macos-debug` preset green end-to-end** —
   mirror of the Linux-maturation task, on the Mac side. Umbrella epic
   for fixing every compile/link/runtime issue in the Metal backend


### PR DESCRIPTION
## Summary
- Adds a concrete, actionable sub-task for the known Homebrew FFmpeg discovery problem on `macos-debug`
- Scoped to CMake/pkg-config wiring only; escalates to `[opus]` if `engine/video/` source needs changes
- Acceptance: clean build with all four FFmpeg libs appearing in the final link line

## Test plan
- [ ] PR merges cleanly (TASKS.md only, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)