### PR TITLE
test: delete empty orphaned test stubs

### DIFF
--- a/test/ecs/ir_entity_test.cpp
+++ b/test/ecs/ir_entity_test.cpp
@@ -1,4 +1,0 @@
-#include <gtest/gtest.h>
-#include <irreden/ir_entity.hpp>
-
-namespace {}


### PR DESCRIPTION
## Summary
- `test/ecs/ir_entity_test.cpp` contained only an empty `namespace {}` block — no tests.
- `test/system/system_manager_tests.cpp` was completely empty (0 bytes).
- Neither file was listed in `test/CMakeLists.txt`, so they were silently excluded from the build.

Deleting them removes the false signal that ECS and system-manager tests exist. The real ECS tests live in `test/ecs/entity_manager_test.cpp` which is wired in.

Flagged in the PR #107 review.

## Test plan
- [ ] `cmake --build build --target IrredenEngineTest` still compiles clean (no source removed from the build)
- [ ] No references to deleted files anywhere in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)