### PR TITLE
docs: fix stale symbol names and failure semantics in CLAUDE.md files

### DIFF
--- a/engine/common/CLAUDE.md
+++ b/engine/common/CLAUDE.md
@@ -16,7 +16,7 @@ There is no `ir_common.hpp` umbrella — include the specific header.
 
 ## `ir_constants.hpp` highlights
 
-- `IRConstants::kTargetFps = 60` — main loop fixed-step rate.
+- `IRConstants::kFPS = 60` — main loop fixed-step rate.
 - `IRConstants::kChunkSize = 32` — voxel chunk edge (32×32×32).
 - `IRConstants::kTrixelDistanceMaxDistance` — sentinel distance used to
   clear the trixel depth texture. Read by GLSL as the "nothing here" depth.
@@ -28,8 +28,8 @@ systems.
 
 ## `ir_platform.hpp` highlights
 
-- `IRPlatform::kIsOpenGL`, `kIsMetal`, `kIsVulkan` (compile-time bools).
-- `IRPlatform::kIsWindows`, `kIsMac`, `kIsLinux`.
+- `IRPlatform::kIsOpenGL` (compile-time bool; no `kIsMetal`/`kIsVulkan` bools — check `kGraphicsBackend` directly for those backends).
+- `IRPlatform::kIsWindows`, `kIsMacOS`, `kIsLinux`.
 - `IRPlatform::kGfx` — a struct of conventions that differ by backend:
   NDC Y direction, depth range convention (0..1 vs -1..1), mouse Y flip.
   Use this instead of `#ifdef`ing backends in call sites.

--- a/engine/utility/CLAUDE.md
+++ b/engine/utility/CLAUDE.md
@@ -12,7 +12,8 @@ functions for reading files and composing paths. Used by `asset/`,
 ## What's here
 
 - `IRUtility::readFileAsString(filepath)` — load a text file into a
-  `std::string`. No encoding normalization. Throws on failure.
+  `std::string`. No encoding normalization. On failure: logs fatal +
+  asserts in debug builds; returns `{}` silently in release.
 - `IRUtility::joinPath(dir, filename, ext)` — concatenate a directory,
   filename, and extension. Handles separator insertion.
 - `IRUtility::pathWithExtension(path, ext)` — replace or append an
@@ -33,8 +34,11 @@ engine/utility/
 
 ## Gotchas
 
-- **`readFileAsString` throws.** Catch it where you care; don't let the
-  exception cross a callback boundary.
+- **`readFileAsString` failure is build-mode dependent.** In debug builds
+  it calls `IRE_LOG_FATAL` + `IR_ASSERT(false)`, which throws
+  `std::runtime_error` via `engAssert`. In release both macros are
+  no-ops and the function returns `{}` silently. Don't depend on the
+  exception in production paths.
 - **Separator handling is C++-string-based.** It assumes forward slashes
   work on Windows (they do, mostly). If a path eventually reaches a Win32
   API that insists on backslashes, normalize at the call site.


### PR DESCRIPTION
## Summary
- `engine/common/CLAUDE.md`: corrected `kTargetFps` → `kFPS`, `kIsMac` → `kIsMacOS`, and clarified that only `kIsOpenGL` bool exists (no `kIsMetal`/`kIsVulkan` — check `kGraphicsBackend` enum directly).
- `engine/utility/CLAUDE.md`: replaced misleading "Throws on failure" with accurate build-mode-dependent semantics for `readFileAsString`.

## Test plan
- [ ] Doc-only change; no code touched. Spot-check both files match the actual implementation.

## Notes for reviewer
- `kFPS` and `kIsMacOS` verified against `engine/common/include/irreden/ir_constants.hpp` and `ir_platform.hpp`.
- `readFileAsString` failure behavior verified against `engine/utility/utility/file_utils.hpp` — `IRE_LOG_FATAL` + `IR_ASSERT(false)` in debug, silent `{}` return in release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)