### PR TITLE
docs: fix stale names and inaccurate descriptions across four CLAUDE.md files

### DIFF
--- a/engine/common/CLAUDE.md
+++ b/engine/common/CLAUDE.md
@@ -16,7 +16,7 @@ There is no `ir_common.hpp` umbrella — include the specific header.
 
 ## `ir_constants.hpp` highlights
 
-- `IRConstants::kTargetFps = 60` — main loop fixed-step rate.
+- `IRConstants::kFPS = 60` — main loop fixed-step rate.
 - `IRConstants::kChunkSize = 32` — voxel chunk edge (32×32×32).
 - `IRConstants::kTrixelDistanceMaxDistance` — sentinel distance used to
   clear the trixel depth texture. Read by GLSL as the "nothing here" depth.
@@ -28,8 +28,8 @@ systems.
 
 ## `ir_platform.hpp` highlights
 
-- `IRPlatform::kIsOpenGL`, `kIsMetal`, `kIsVulkan` (compile-time bools).
-- `IRPlatform::kIsWindows`, `kIsMac`, `kIsLinux`.
+- `IRPlatform::kIsOpenGL` (compile-time bool; no `kIsMetal`/`kIsVulkan` bools — check `kGraphicsBackend` directly for those backends).
+- `IRPlatform::kIsWindows`, `kIsMacOS`, `kIsLinux`.
 - `IRPlatform::kGfx` — a struct of conventions that differ by backend:
   NDC Y direction, depth range convention (0..1 vs -1..1), mouse Y flip.
   Use this instead of `#ifdef`ing backends in call sites.

--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -51,22 +51,24 @@ so there's one place to fix a coordinate-system bug.
 
 ## Layout helpers
 
-Entity-positioning helpers that return `std::vector<vec3>` or similar:
+Entity-positioning helpers — each returns a single `vec3` for one `index`.
+Call in a loop from `0` to `count - 1` to place a group of entities:
 
-- `layoutGridCentered(count, spacing, plane)` — grid of N positions on a
-  `PlaneIso`.
-- `layoutZigZagCentered(...)` — zig-zag variant.
-- `layoutCircle(count, radius, plane)` — ring.
-- `layoutHelix(count, radius, pitch, axis)` — vertical spiral.
-- `layoutPathTangentArcs(...)` — along a parametric path with tangent-
-  aligned rotation.
+- `layoutGridCentered(index, count, columns, spacingPrimary, spacingSecondary, plane, depth)` — rectangular grid.
+- `layoutZigZagCentered(index, count, itemsPerZag, spacingPrimary, spacingSecondary, plane, depth)` — zig-zag variant.
+- `layoutZigZagPath(index, count, itemsPerSegment, spacingPrimary, spacingSecondary, plane, depth)` — zig-zag along a path.
+- `layoutCircle(index, count, radius, startAngleRad, plane, depth)` — ring.
+- `layoutSquareSpiral(index, spacing, plane, depth)` — outward square spiral.
+- `layoutHelix(index, count, radius, turns, heightSpan, axis)` — vertical spiral; `turns` is full rotations, `heightSpan` is total rise.
+- `layoutPathTangentArcs(index, count, radius, blocksPerArc, zStep, axis, startAngleRad, invert)` — along a parametric arc path.
 
-All take a `PlaneIso` selector. Double-check the plane axis — `XY` vs `YZ`
-is the #1 bug source.
+Helpers that take `PlaneIso` (most of them): double-check the plane axis —
+`XY` vs `YZ` is the #1 bug source.
 
 ## Color
 
-- `hsvToRgb` / `rgbToHsv` — convert between Color and ColorHSV.
+- `colorToColorHSV(Color) → ColorHSV` / `colorHSVToColor(ColorHSV) → Color` — convert between `Color` (u8 RGBA) and `ColorHSV` (float HSV).
+- `hsvToRgb(vec3 hsv) → vec3` — raw float HSV → RGB (no `Color` wrapping).
 - `lerpColor(a, b, t)` / `lerpHSV(a, b, t)` — interpolation.
 - `applyHSVOffset(base, hsvDelta)` — shift hue/saturation/value on a
   packed RGBA color.

--- a/engine/profile/CLAUDE.md
+++ b/engine/profile/CLAUDE.md
@@ -6,7 +6,7 @@ builds.
 
 ## Entry point
 
-`engine/profile/ir_profile.hpp` — macros and free-function wrappers. No
+`engine/profile/include/irreden/ir_profile.hpp` — macros and free-function wrappers. No
 class to instantiate on the caller side; the underlying `LoggerSpd` and
 `CPUProfiler` are singletons.
 
@@ -33,9 +33,9 @@ strings work. In `IR_RELEASE` mode every log macro is an empty statement
 IR_ASSERT(cond, "formatted message %d", value);
 ```
 
-On failure: logs a critical GL error via the engine logger and throws
-`std::runtime_error`. In `IR_RELEASE` it's still evaluated (the
-assertion is not eliminated) but no log is emitted.
+On failure: logs via the GL API logger at `critical` severity and throws
+`std::runtime_error`. In `IR_RELEASE` the macro expands to nothing —
+the condition is **not evaluated** at all, not merely silenced.
 
 ## Profiling macros
 
@@ -54,11 +54,13 @@ creation's startup if you want profiling off by default.
 
 ```
 engine/profile/
-├── ir_profile.hpp             — public macros
-├── ir_profile.tpp             — template impls for log macros
-└── profile/
-    ├── logger_spd.hpp         — spdlog singleton (engine/gl/game sinks)
-    └── cpu_profiler.hpp       — easy_profiler singleton
+└── include/irreden/
+    ├── ir_profile.hpp             — public macros
+    └── profile/
+        ├── ir_profile.tpp         — template impls for log macros
+        ├── ir_profile_types.hpp   — shared type helpers
+        ├── logger_spd.hpp         — spdlog singleton (engine/gl/game sinks)
+        └── cpu_profiler.hpp       — easy_profiler singleton
 ```
 
 ## Gotchas

--- a/engine/time/CLAUDE.md
+++ b/engine/time/CLAUDE.md
@@ -11,7 +11,7 @@ functions:
 
 - `getTimeManager()`.
 - `shouldUpdate()` — true when the UPDATE accumulator has buffered at
-  least one frame period (1/kTargetFps).
+  least one frame period (1/kFPS).
 - `deltaTime(Events event)` — actual wall-clock dt for this event's last
   tick.
 - `renderFps()`, `updateFps()` — 1-second rolling averages.
@@ -79,7 +79,7 @@ engine/time/
 ## Gotchas
 
 - **`deltaTime(UPDATE)` is wall-clock, not fixed.** It's the actual time
-  the last UPDATE tick took, not `1.0 / kTargetFps`. Good for physics
+  the last UPDATE tick took, not `1.0 / kFPS`. Good for physics
   damping and decay, but **do not** use it to advance simulation state
   you expect to be deterministic — that's why the fixed-step loop exists.
 - **Lag can cascade.** If one frame takes 50 ms, the next loop iteration


### PR DESCRIPTION
## Summary
- `engine/common/CLAUDE.md`: `kTargetFps` → `kFPS`, `kIsMac` → `kIsMacOS`, clarify that only `kIsOpenGL` bool exists (no `kIsMetal`/`kIsVulkan` — check `kGraphicsBackend` enum directly).
- `engine/math/CLAUDE.md`: layout helpers return a single `vec3` per index call (not `std::vector`); all signatures expanded to match actual declarations; add missing `layoutZigZagPath` and `layoutSquareSpiral`; fix color API — `rgbToHsv` does not exist; correct functions are `colorToColorHSV`/`colorHSVToColor` and `hsvToRgb(vec3)`.
- `engine/profile/CLAUDE.md`: fix entry point path; `IR_ASSERT` in `IR_RELEASE` expands to nothing (condition **not evaluated**), not "still evaluated but silent"; fix internal layout tree to match actual directory structure.
- `engine/time/CLAUDE.md`: `kTargetFps` → `kFPS` in two places.

## Test plan
- [ ] Doc-only change. Spot-check each corrected symbol against the actual header.

## Notes for reviewer
All corrections verified against actual headers in the worktree. May conflict trivially with PR #116 on `engine/common/CLAUDE.md` (same fix) — keep whichever merges second, they're identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)