### PR TITLE
docs: fix stale filenames and descriptions in math and command CLAUDE.md

### DIFF
--- a/engine/command/CLAUDE.md
+++ b/engine/command/CLAUDE.md
@@ -67,7 +67,7 @@ engine/command/
 │   └── command/
 │       ├── ir_command_types.hpp  — CommandNames enum, InputTypes
 │       ├── command_manager.hpp
-│       └── command_struct.hpp    — CommandStruct<T>
+│       └── command.hpp           — CommandStruct<T> specializations
 └── src/
     ├── ir_command.cpp
     └── command_manager.cpp

--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -71,7 +71,7 @@ is the #1 bug source.
 - `applyHSVOffset(base, hsvDelta)` — shift hue/saturation/value on a
   packed RGBA color.
 - `IRColors::kBlack/kWhite/kRed/...` — canned constants.
-- `color_palettes.hpp` — load palette files from the asset path.
+- `color_palettes.hpp` — compile-time palette arrays (no file I/O).
 - `color.hpp` — sorting (`sortByHue`).
 
 ## Physics
@@ -115,10 +115,10 @@ engine/math/
 │       ├── ir_math_types.hpp      — GLM aliases, Color, enums
 │       ├── easing_functions.hpp   — IREasingFunctions + GLM wrappers
 │       ├── color.hpp              — sorting, hue utilities
-│       ├── color_palettes.hpp     — palette file loading
+│       ├── color_palettes.hpp     — compile-time palette arrays
 │       ├── physics.hpp            — ballistic helpers
-│       ├── bezier_curves.hpp      — interpolation helpers
-│       └── percolation.hpp        — procedural/noise helpers
+│       ├── bezier_curves.hpp      — stub (not yet implemented)
+│       └── percolation.hpp        — stub (not yet implemented)
 └── src/
     └── ir_math.cpp                — non-inlined impls
 ```


### PR DESCRIPTION
## Summary
- Fixes three inaccurate descriptions in `engine/math/CLAUDE.md`
- Fixes one wrong filename in `engine/command/CLAUDE.md`

## Changes

### `engine/math/CLAUDE.md`
- `color_palettes.hpp` described as "palette file loading" → `compile-time palette arrays (no file I/O)`. The header contains only inline `std::vector<Color>` constants; there is no file I/O.
- `bezier_curves.hpp` described as "interpolation helpers" → `stub (not yet implemented)`. The file contains only a TODO comment and an empty `namespace IRMath {}`.
- `percolation.hpp` described as "procedural/noise helpers" → `stub (not yet implemented)`. Same — two TODO comments, no code.

### `engine/command/CLAUDE.md`
- Internal layout listed `command_struct.hpp` → actual file is `command.hpp`. Verified via `engine/command/include/irreden/command/`.

## Notes for reviewer
`engine/math/CLAUDE.md` overlaps with PR #117 (which rewrites the Layout helpers and Color sections). The `color_palettes.hpp` fix in the Color section touches a line that PR #117 keeps unchanged, so a conflict is possible. If both PRs merge, the fix for this line should be preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)