### PR TITLE
docs: fix getMousePosition API description in engine/input/CLAUDE.md

### DIFF
--- a/engine/input/CLAUDE.md
+++ b/engine/input/CLAUDE.md
@@ -11,9 +11,10 @@ functions:
 
 - `getInputManager()`.
 - `checkKeyMouseButton(button, status)` — is this button in this state?
-- `checkKeyMouseModifiers(mods)` — Shift/Ctrl/Alt.
-- `getMousePosition(event)` — cursor position as of a specific pipeline
-  event.
+- `checkKeyMouseModifiers(requiredMods, blockedMods)` — Shift/Ctrl/Alt mask check.
+- `getMousePosition()` — cursor position in iso/world space for the current
+  pipeline event's snapshot.
+- `getMousePositionScreen()` — cursor position in screen (pixel) space.
 - Per-button press/release frame counters.
 
 ## `InputManager`
@@ -24,9 +25,9 @@ Owns:
   `C_KeyMouseButton` holding the current `ButtonStatuses`.
 - A vector of gamepad entities (`C_GlfwGamepad`, `C_GlfwJoystick`).
 - Scroll deltas, mouse position cache, press/release accumulators.
-- One `EventInputState` per pipeline event (INPUT, UPDATE, RENDER), so
-  `getMousePosition(UPDATE)` returns the cursor as it was at the UPDATE
-  tick's snapshot.
+- One `EventInputState` per pipeline event (INPUT, UPDATE, RENDER). Each
+  state holds its own `mousePosition_` snapshot; `getMousePosition()` returns
+  the snapshot for whichever event is currently advancing.
 
 ### Button state machine
 


### PR DESCRIPTION
## Summary
- Fixes two public API inaccuracies in `engine/input/CLAUDE.md` verified against `engine/input/include/irreden/ir_input.hpp`

## Changes

### Entry point
- `getMousePosition(event)` → `getMousePosition()`. The `event` overload does not exist. The no-arg form automatically returns the current pipeline event's position snapshot.
- Added missing `getMousePositionScreen()` — returns cursor in screen pixel space (was not documented at all).
- `checkKeyMouseModifiers(mods)` → `checkKeyMouseModifiers(requiredMods, blockedMods)` — shows the two-param signature (second param has a default).

### `InputManager` section
- Removed the example `getMousePosition(UPDATE)` call which references a non-existent overload. Replaced with an accurate description of the internal mechanism: `EventInputState` holds per-event `mousePosition_` snapshots; the no-arg `getMousePosition()` reads whichever event is currently advancing.

## Notes for reviewer
All changes are verified against `ir_input.hpp` and `input_manager.hpp`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)