### PR TITLE
macOS FFmpeg: fix CMake/pkg-config wiring on macos-debug

### DIFF
--- a/engine/video/CMakeLists.txt
+++ b/engine/video/CMakeLists.txt
@@ -99,9 +99,8 @@ if(IRREDEN_VIDEO_ENABLE_FFMPEG)
                 break()
             endif()
         endforeach()
-        # When the root was auto-detected (not user-supplied), clear any stale
-        # cached find_path/find_library results so they re-discover from the
-        # new root on this configure run.
+        # root was just set by the loop above; only unset cache if we actually
+        # found one (user-supplied IRREDEN_FFMPEG_ROOT skips this block entirely).
         if(IRREDEN_FFMPEG_ROOT)
             unset(IRREDEN_FFMPEG_INCLUDE_DIR CACHE)
             foreach(_lib IN LISTS _ffmpeg_components)

--- a/engine/video/CMakeLists.txt
+++ b/engine/video/CMakeLists.txt
@@ -69,11 +69,14 @@ set(
 
 set(IRREDEN_FFMPEG_ROOT_HINTS "")
 if(IR_isDarwin)
+    # Prefer the keg-only paths first: they contain only FFmpeg headers and
+    # avoid shadowing other FetchContent deps (e.g. fmt) that live under the
+    # generic /opt/homebrew/include alongside Homebrew's own fmt package.
     list(APPEND IRREDEN_FFMPEG_ROOT_HINTS
-        /opt/homebrew
         /opt/homebrew/opt/ffmpeg
-        /usr/local
+        /opt/homebrew
         /usr/local/opt/ffmpeg
+        /usr/local
     )
 endif()
 if(IR_isLinux)
@@ -96,6 +99,16 @@ if(IRREDEN_VIDEO_ENABLE_FFMPEG)
                 break()
             endif()
         endforeach()
+        # When the root was auto-detected (not user-supplied), clear any stale
+        # cached find_path/find_library results so they re-discover from the
+        # new root on this configure run.
+        if(IRREDEN_FFMPEG_ROOT)
+            unset(IRREDEN_FFMPEG_INCLUDE_DIR CACHE)
+            foreach(_lib IN LISTS _ffmpeg_components)
+                string(TOUPPER "${_lib}" _lib_upper)
+                unset(IRREDEN_FFMPEG_${_lib_upper}_LIBRARY CACHE)
+            endforeach()
+        endif()
     endif()
 
     if(IRREDEN_FFMPEG_ROOT)
@@ -105,6 +118,7 @@ if(IRREDEN_VIDEO_ENABLE_FFMPEG)
             HINTS
             ${IRREDEN_FFMPEG_ROOT}/include
             ${IRREDEN_FFMPEG_ROOT}
+            NO_DEFAULT_PATH
         )
 
         foreach(_ffmpeg_lib IN LISTS _ffmpeg_components)
@@ -115,6 +129,7 @@ if(IRREDEN_VIDEO_ENABLE_FFMPEG)
                 HINTS
                 ${IRREDEN_FFMPEG_ROOT}/lib
                 ${IRREDEN_FFMPEG_ROOT}
+                NO_DEFAULT_PATH
             )
             if(IRREDEN_FFMPEG_${_ffmpeg_lib_upper}_LIBRARY)
                 list(APPEND IRREDEN_VIDEO_FFMPEG_LIBS ${IRREDEN_FFMPEG_${_ffmpeg_lib_upper}_LIBRARY})


### PR DESCRIPTION
## Summary
- The macOS FFmpeg auto-detection hint list put `/opt/homebrew` before the keg-only `/opt/homebrew/opt/ffmpeg`. The broad prefix brings in Homebrew's system `fmt 12.1.0` headers, which shadowed the FetchContent-fetched `fmt 10.1.1` that spdlog uses — breaking compilation in every TU that included spdlog through the profile module (`fmt::basic_format_string` was removed in fmt 11+).
- Fix: reorder hints so the keg-only path (FFmpeg-only headers) is checked first.
- Also: `unset()` stale `find_path`/`find_library` cache entries when auto-detecting so existing builds pick up the corrected root immediately without needing a cache wipe.
- Also: add `NO_DEFAULT_PATH` to `find_path`/`find_library` to constrain searches to the hinted root only.

## Test plan
- [x] `cmake --build build --target IRShapeDebug` builds clean on macOS (Apple Silicon, Homebrew FFmpeg 8.1, fmt 12.1.0 installed)
- [x] `IrredenEngineVideo: FFmpeg enabled from /opt/homebrew/opt/ffmpeg` appears in cmake output
- [x] All four libs (`avcodec`, `avformat`, `avutil`, `swscale`) appear in CMakeCache at the keg-only path

## Notes for reviewer
The root cause: `engine/profile/CMakeLists.txt` configures spdlog with `SPDLOG_FMT_EXTERNAL` (so spdlog includes `<fmt/core.h>`), but with `/opt/homebrew/include` first in the include path the compiler finds Homebrew fmt 12.1.0 which removed `fmt::basic_format_string`. Keg-only path `/opt/homebrew/opt/ffmpeg/include` has no `fmt/` subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)