### PR TITLE
fleet: increase babysit usage-limit wait to 15 minutes

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -35,7 +35,7 @@ MODE="${3:-dry-run}"
 
 # Timing
 CRASH_DELAY=30        # seconds to wait after non-zero exit (crash)
-LIMIT_DELAY=300       # seconds to wait on suspected usage limit (exit 2)
+LIMIT_DELAY=900       # seconds to wait on suspected usage limit (exit 2)
 CLEAN_DELAY=60        # seconds to wait after clean exit
 MAX_ATTEMPTS=200      # safety valve — prevents infinite loops on hard failures
 


### PR DESCRIPTION
## Summary
- Increases `LIMIT_DELAY` in `fleet-babysit` from 300s (5 min) to 900s (15 min)
- Usage limits typically need longer to reset; 5 minutes was causing unnecessary retry churn

## Test plan
- [ ] Verify fleet-babysit waits 15 minutes on exit code 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)