### PR TITLE
docs: update §10 macOS FFmpeg note to reflect keg-only path fix

### DIFF
--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -924,10 +924,19 @@ Common first-time issues you might hit:
   versions of most but not all shaders. When a demo links against a
   missing shader, that's a `backend-parity` skill job. Keep a list
   and run the skill after the build is otherwise green.
-- **FFmpeg framework paths** — `brew install ffmpeg` puts libs under
-  `/opt/homebrew/` (Apple Silicon) or `/usr/local/` (Intel). CMake's
-  `pkg_check_modules(FFMPEG ...)` picks them up via `pkg-config`, but
-  if it can't, `export PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig:$PKG_CONFIG_PATH"`.
+- **FFmpeg / fmt header shadowing** — `brew install ffmpeg` installs
+  headers under `/opt/homebrew/include/` (Apple Silicon), which also
+  contains Homebrew's own `fmt`. Earlier versions of the engine put
+  this broad prefix first in the hint list, causing Homebrew `fmt 12.x`
+  to shadow the FetchContent-fetched `fmt 10.1.1` that spdlog depends
+  on, and failing compilation with "no template named
+  `basic_format_string` in namespace `fmt`". Fixed in the engine:
+  `engine/video/CMakeLists.txt` now prefers the keg-only path
+  `/opt/homebrew/opt/ffmpeg/include` (FFmpeg-only headers) first.
+  Detection is automatic; no `PKG_CONFIG_PATH` export needed. If
+  detection still fails, set `IRREDEN_FFMPEG_ROOT=/opt/homebrew/opt/ffmpeg`
+  (Apple Silicon) or `IRREDEN_FFMPEG_ROOT=/usr/local/opt/ffmpeg` (Intel)
+  as a CMake cache variable.
 - **Apple Silicon vs Intel** — the Metal backend should work on
   both, but if you're on an older Intel Mac and hit Metal 3-only
   features, flag it. The engine targets Metal 3+.


### PR DESCRIPTION
## Summary
- The §10 macOS troubleshooting note in `docs/AGENT_FLEET_SETUP.md` suggested exporting `PKG_CONFIG_PATH` manually to fix FFmpeg detection.
- The actual issue was the hint list ordering: `/opt/homebrew/include` (broad prefix) came before the keg-only `/opt/homebrew/opt/ffmpeg/include`, pulling in Homebrew `fmt 12.x` which shadowed the FetchContent `fmt 10.1.1` that spdlog needs. This caused a `basic_format_string` compile error in all video module TUs.
- That root cause was fixed in PR #128. This PR updates the docs to describe the real issue, note the fix, and replace the `PKG_CONFIG_PATH` workaround with `IRREDEN_FFMPEG_ROOT` as the correct fallback.

## Test plan
- [x] Docs-only change — no build impact

## Notes for reviewer
Companion to PR #128 (`build: fix macOS FFmpeg include path to avoid shadowing FetchContent fmt`). Safe to merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)