### PR TITLE
fleet: task IDs, fleet-build callout, and label-based feedback loop

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -65,15 +65,32 @@ When you do pick a task:
    title appears in an open PR's title or branch name. The open-PR list
    is the real claim signal — `TASKS.md` `[~]` flips on feature branches
    are not visible to other agents until merge.
-2. Flip the task to `[~]`, set Owner to `opus-architect`, and commit
+2. **Claim the task by its ID** (the `**ID:** T-NNN` field, not the
+   free-text title):
+   `fleet-claim claim "<task ID, e.g. T-003>" opus-architect`
+   Exit 0 = claimed, exit 1 = already taken (pick another).
+3. Flip the task to `[~]`, set Owner to `opus-architect`, and commit
    the edit in your first commit on the work branch.
-3. Build the target you touched with `fleet-build --target <name>`.
+4. Build the target you touched with `fleet-build --target <name>`.
    Run the relevant executable if one exists for the touched code.
-4. Use the `commit-and-push` skill to open the PR.
-5. After the PR is open, use the `start-next-task` skill to land on a
-   fresh branch off `origin/master`.
-6. Check whether your previously-opened PRs have new review comments —
-   address them before picking new work.
+5. Use the `commit-and-push` skill to open the PR.
+6. After the PR is open, release the claim and reset:
+   `fleet-claim release "<task ID>"`
+   Then use the `start-next-task` skill to land on a fresh branch off
+   `origin/master`.
+7. **Check for feedback labels on open PRs** before picking new work:
+   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "fleet:needs-fix")) | "#\(.number) \(.title)"'`
+   If any PR has `human:needs-fix` or `fleet:needs-fix`:
+   a. Read ALL comments:
+      `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // "general")] \(.body)"'`
+      `gh api repos/jakildev/IrredenEngine/pulls/<N>/reviews --jq '.[] | select(.body != "") | .body'`
+   b. Remove the feedback label immediately:
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "fleet:needs-fix"`
+   c. Address every piece of feedback. Build with `fleet-build`.
+   d. Push fixes using `commit-and-push`.
+   e. If it was `human:needs-fix`, add `fleet:changes-made`:
+      `gh pr edit <N> --add-label "fleet:changes-made"`
+      `gh pr comment <N> --body "Addressed feedback: <summary>"`
 
 If Mode above is `dry-run`: do **only** the startup actions. Do not pick
 a task. Wait for explicit human instruction.

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -47,8 +47,8 @@ conditions, allocator behavior, hot-path costs.
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git checkout -B claude/opus-reviewer-scratch origin/master`
 3. Fetch PR lists from both repos (each as a separate command):
-   `gh pr list --state open --json number,title,headRefName,reviews`
-   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,reviews`
+   `gh pr list --state open --json number,title,headRefName,reviews,labels`
+   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,reviews,labels`
    Print both results.
 4. Identify the candidates from both repos. A PR is a candidate if:
    - The latest Sonnet review body contains `Opus recheck required`, OR
@@ -56,8 +56,9 @@ conditions, allocator behavior, hot-path costs.
    - The author pushed fixes and commented "re-review please" after
      a previous Opus review (check comments after your last review).
 
-   Also re-review PRs where the human set `human:needs-fix`, the
-   author fixed and removed it, and the PR now needs a fresh pass.
+   **Skip** PRs labeled `fleet:wip`, `human:needs-fix`, or
+   `fleet:changes-made` — those are either in-progress or in the
+   human feedback loop, not ready for review.
 
 ## Loop behavior
 
@@ -65,8 +66,8 @@ Default: run continuously, but on a **longer interval (30 minutes)**
 than the Sonnet reviewer. Each iteration:
 
 1. Re-fetch PR lists from both repos (separate commands):
-   `gh pr list --state open --json number,title,headRefName,reviews`
-   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,reviews`
+   `gh pr list --state open --json number,title,headRefName,reviews,labels`
+   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,reviews,labels`
 2. For each candidate, in oldest-first order:
    a. Read the existing Sonnet review in full first
       (`gh pr view <N> --comments`, add `--repo jakildev/irreden` for

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -117,6 +117,7 @@ Use the exact template from `TASKS.md`:
 
 ```
 - [ ] **<short title>** — <one-line goal>
+  - **ID:** T-NNN
   - **Area:** <area>
   - **Model:** opus | sonnet
   - **Owner:** free
@@ -125,6 +126,11 @@ Use the exact template from `TASKS.md`:
   - **Notes:** <context, links, prior attempts>
   - **Links:** (empty until done)
 ```
+
+**Assigning task IDs:** scan the existing `## Open` and `## Done` sections
+for the highest `T-NNN` ID currently in use, then assign the next
+sequential number. IDs are never reused. The ID is the canonical claim
+key — agents pass it (not the free-text title) to `fleet-claim`.
 
 The **Acceptance** line is the most important. If the human's
 description is fuzzy, push back and ask for a concrete check before

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -48,10 +48,11 @@ whatever directory the task touches before editing anything.
 Default: run continuously until the human stops you or you hit a usage
 limit. Each loop iteration:
 
-1. **Check for feedback on PRs you previously opened.**
-   `gh pr list --state open --json number,title,labels`
-   Look for any of your PRs with `human:needs-fix`, `human:blocker`,
-   or `fleet:needs-fix` labels. Human feedback takes priority.
+1. **Check for feedback labels on open PRs.**
+   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
+
+   If any PR has `human:needs-fix`, `human:blocker`, or `fleet:needs-fix`,
+   address the **oldest** one first. Human feedback takes priority.
 
    For each flagged PR:
    a. Read **all** feedback (two separate commands):
@@ -60,13 +61,34 @@ limit. Each loop iteration:
       The first gets conversation-level comments. The second gets
       inline review comments on specific lines — this is where most
       human feedback lives. Address every comment, not just the first.
-   b. Address each issue raised. Build and test.
-   c. Push fixes with `commit-and-push`.
-   d. Remove the feedback label and request re-review:
-      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker"`
-      `gh pr comment <N> --body "Fixed — re-review please"`
-   e. If the PR also had `fleet:approved`, `fleet:needs-fix`, or `fleet:blocker`,
-      remove those too — the reviewer will re-review the updated PR.
+   b. **Immediately remove the feedback label** to prevent another agent
+      from also picking it up:
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix"`
+   c. Address every piece of feedback. Make the edits, build with
+      `fleet-build --target <name>`.
+   d. Push fixes using `commit-and-push`.
+   e. Add the appropriate response label and post a summary:
+      - If it was `human:needs-fix` or `human:blocker` → add
+        `fleet:changes-made` (signals human to re-review):
+        `gh pr edit <N> --add-label "fleet:changes-made"`
+      - If it was `fleet:needs-fix` → no response label needed
+        (fleet reviewer will re-review automatically on next poll)
+      `gh pr comment <N> --body "Addressed feedback: <bullet list of what changed>"`
+   f. If the PR also had `fleet:approved`, `fleet:needs-fix`, or
+      `fleet:blocker`, remove those too — the reviewer will re-review
+      the updated PR.
+   g. Move to the next loop iteration.
+
+   **Human feedback label cycle:** human adds `human:needs-fix` (+
+   comments) → agent removes it, works, adds `fleet:changes-made` →
+   human reviews again. Human can add multiple comments before
+   re-tagging; ALL are picked up when the tag appears. If the human
+   wants more changes, they remove `fleet:changes-made`, add
+   `human:needs-fix` again.
+
+   **Fleet feedback cycle:** fleet reviewer adds `fleet:needs-fix` →
+   author removes it, fixes, pushes → fleet reviewer sees the new
+   commits on next poll and re-reviews.
 
    Address all flagged PRs before picking new work.
 
@@ -83,8 +105,11 @@ limit. Each loop iteration:
    Do NOT edit `TASKS.md` — only the queue-manager touches it.
 
    First, acquire the local filesystem lock (atomic — prevents another
-   agent on this machine from picking the same task):
-   `fleet-claim claim "<exact task title from TASKS.md>" <your-worktree-name>`
+   agent on this machine from picking the same task). **Always pass the
+   task ID**, not the free-text title — IDs are short and unambiguous,
+   so two agents can never accidentally derive different claim slugs
+   for the same task:
+   `fleet-claim claim "<task ID, e.g. T-002>" <your-worktree-name>`
 
    - **Exit 0** — you own it. Proceed to open the PR.
    - **Exit 1** — already taken. Go back to step 2 and pick another.
@@ -125,7 +150,7 @@ limit. Each loop iteration:
    work commits to the existing PR branch. Then remove the WIP label
    and release the claim:
    `gh pr edit <N> --remove-label "fleet:wip"`
-   `fleet-claim release "<exact task title>"`
+   `fleet-claim release "<task ID, e.g. T-002>"`
    Paste the PR URL.
 
 8. **Reset.** Use the `start-next-task` skill to land on a fresh branch

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -44,15 +44,18 @@ treat it as a hard rule for this role.
    `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,author,reviews,labels`
    Print both results so we both see the current PR queues.
 4. Identify review candidates from both repos. A PR is a candidate if:
-   - It has **no fleet review yet** (no review from your GitHub user)
-     AND does not have the `fleet:wip` label, OR
+   - It has **no fleet review yet** (no review from your GitHub user), OR
    - It **previously had a fleet review** but the author pushed fixes
      and commented "re-review please" (check the comments array for
-     this text after your last review), OR
-   - It has a `human:needs-fix` label that was later removed (meaning
-     the author fixed the human's feedback) and needs a fresh pass.
+     this text after your last review).
 
-   Skip PRs labeled `fleet:wip` — those are work-in-progress claims.
+   **Skip** PRs with any of these labels:
+   - `fleet:wip` — work-in-progress claim, not ready for review.
+   - `human:needs-fix` — human requested changes, author agent is
+     handling it. Don't pile on a fleet review while the human's
+     feedback is being addressed.
+   - `fleet:changes-made` — agent addressed human feedback, waiting
+     for human re-review. Not your turn.
 
 ## Loop behavior
 
@@ -62,7 +65,10 @@ usage limit. Each iteration:
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
    `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,author,reviews,labels`
-2. For each unreviewed PR, in oldest-first order:
+2. Re-apply the same skip criteria from startup step 4: skip PRs that
+   already have a fleet review, or carry any of `fleet:wip`,
+   `human:needs-fix`, or `fleet:changes-made`. For each remaining
+   candidate, in oldest-first order:
 
    **Engine PRs** (default repo):
    a. Invoke the `review-pr` skill with the PR number.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ it in a dedicated PR, not to work around it.
   fixes. Work against `~/src/IrredenEngine`.
 - **Are you running on the Windows-native clone?** → use the Windows
   section below. The MSYS2 / Git mingw64 PATH saga applies to you.
-- **macOS?** → `cmake --preset macos-debug` + `cmake --build build`
+- **macOS?** → `cmake --preset macos-debug` + `fleet-build --target <name>`
   once deps are installed via homebrew. The details haven't been
   stress-tested recently — flag anything you hit as you go.
 
@@ -174,6 +174,15 @@ Canonical build command from the Bash tool:
 
 ```bash
 cmake --build build --target IRShapeDebug -j$(nproc)
+```
+
+**Fleet agents: use `fleet-build` instead.** The `$(nproc)` command
+substitution triggers Claude Code's `command_substitution` security
+gate, which blocks unattended operation with an interactive prompt.
+The `fleet-build` wrapper handles parallelism automatically:
+
+```bash
+fleet-build --target IRShapeDebug
 ```
 
 Swap `--target` for whichever executable or library you're working on

--- a/TASKS.md
+++ b/TASKS.md
@@ -54,11 +54,12 @@ defends against this in three layers:
    picks the next available task, and moves on. The work isn't lost; it
    just gets rescheduled.
 
-Don't try to engineer this away with file locking or external state. The
-PR-list cross-check plus GitHub's merge-conflict detection handles it
-cheaply. If collisions become frequent enough to be painful, the upgrade
-path is GitHub Issues as the queue with labels for claims — but only do
-that when the pain is real.
+The local `fleet-claim` script adds a fourth layer: agents call
+`fleet-claim claim "T-NNN" <agent>` using the task's **ID** (not the
+free-text title) before starting work. The short deterministic ID
+prevents the failure mode where two agents slugify different
+paraphrasings of the same title and both succeed. If `fleet-claim`
+returns exit 1 (already taken), skip to the next task.
 
 This file is the **engine-level** task queue. Private creations that live
 under `creations/` may define their own `TASKS.md` inside their own
@@ -70,6 +71,7 @@ them in the creation's own `TASKS.md`.
 
 ```
 - [ ] **<short title>** — <one-line goal>
+  - **ID:** T-NNN  (sequential, assigned by the queue-manager)
   - **Area:** engine/render | engine/entity | engine/prefabs/... | docs | build | creations/demos/... | ...
   - **Model:** opus | sonnet  (which model should run this)
   - **Owner:** free | <worktree-name>
@@ -78,6 +80,12 @@ them in the creation's own `TASKS.md`.
   - **Notes:** <context, links, prior attempts>
   - **Links:** (fill in PR URL when done)
 ```
+
+The **ID** is the canonical claim key. When calling `fleet-claim`, pass the
+task ID (e.g. `fleet-claim claim "T-003" sonnet-fleet-1`), **not** the
+free-text title. IDs are short and unambiguous — agents can't accidentally
+paraphrase them, which is the failure mode that free-text title slugification
+is vulnerable to.
 
 Status markers: `[ ]` open, `[~]` in progress, `[x]` done, `[!]` blocked/stuck.
 
@@ -138,6 +146,7 @@ Avoid:
   engine against the new `linux-debug` CMake preset inside WSL2 Ubuntu
   24.04. This is the umbrella epic — break it into smaller follow-up
   tasks as concrete issues are found.
+  - **ID:** T-001
   - **Area:** engine/* (anywhere the Linux path breaks)
   - **Model:** opus (for anything touching core-engine invariants) /
     sonnet (for mechanical port fixes like missing `#include`, case-
@@ -160,6 +169,7 @@ Avoid:
   - **Links:**
 
 - [~] **macOS FFmpeg: fix CMake/pkg-config wiring on `macos-debug`** — get FFmpeg headers and libs found and linked correctly on macOS so `engine/video/` compiles and links on the `macos-debug` preset.
+  - **ID:** T-002
   - **Area:** build, engine/video
   - **Model:** sonnet
   - **Owner:** build-macos-ffmpeg-pkgconfig-2
@@ -173,6 +183,7 @@ Avoid:
   for fixing every compile/link/runtime issue in the Metal backend
   as the fleet surfaces them. Must be run from a macOS host (Apple
   Silicon or Intel) — the Metal backend can't be cross-compiled.
+  - **ID:** T-003
   - **Area:** engine/render/src/metal, engine/render/src/shaders/metal,
     anywhere the Metal path breaks
   - **Model:** opus (backend/render work is Opus territory)
@@ -195,6 +206,7 @@ Avoid:
   the GLSL compute for writing 2D shape SDFs into trixel canvases has
   no Metal counterpart. Invoke the `backend-parity` skill on a macOS
   host and port it.
+  - **ID:** T-004
   - **Area:** engine/render/src/shaders/metal
   - **Model:** opus
   - **Owner:** free
@@ -213,6 +225,7 @@ Avoid:
 - [ ] **Metal parity: port `c_update_voxel_positions.glsl` to MSL** —
   GPU-side voxel-position update compute with no Metal counterpart.
   Same skill flow as above.
+  - **ID:** T-005
   - **Area:** engine/render/src/shaders/metal
   - **Model:** opus
   - **Owner:** free
@@ -230,6 +243,7 @@ Avoid:
 - [ ] **Metal parity: port `c_voxel_visibility_compact.glsl` to MSL** —
   the voxel-visibility compaction pass (reduces visible-voxel indices
   into a dense buffer) has no Metal counterpart. Same skill flow.
+  - **ID:** T-006
   - **Area:** engine/render/src/shaders/metal
   - **Model:** opus
   - **Owner:** free
@@ -252,6 +266,7 @@ Avoid:
   of the "example" tasks below — the goal is to exercise the skill's
   flow and catch any workflow bugs before running it on real
   production gaps.
+  - **ID:** T-007
   - **Area:** tooling
   - **Model:** opus
   - **Owner:** free
@@ -267,6 +282,7 @@ Avoid:
 
 - [ ] **Example: benchmark IRShapeDebug at zoom 4** — measure per-system
   timing and file a report.
+  - **ID:** T-008
   - **Area:** engine/profile
   - **Model:** opus
   - **Owner:** free


### PR DESCRIPTION
## Summary

- **Task IDs** (`T-NNN`) added to every TASKS.md entry. `fleet-claim` now takes the ID, not the free-text title — prevents the slug-divergence race that caused two agents to both claim the macOS FFmpeg task.
- **`fleet-build` callout** in CLAUDE.md build sections so fleet agents don't copy the raw `$(nproc)` command that triggers the `command_substitution` security gate.
- **Label-based feedback loop** for human ↔ agent PR review handoff: `human:needs-fix` → agent works → `fleet:changes-made` → human re-reviews. Author agents also handle `fleet:needs-fix` from fleet reviewers.
- **Gap fixes** found during end-to-end audit: opus-reviewer now fetches `labels` in PR list, game-architect has a feedback loop, sonnet-reviewer loop restates skip criteria.

## Files changed

- `CLAUDE.md` — fleet-build note in build section
- `TASKS.md` — task IDs, claim-by-ID docs
- `.claude/commands/role-sonnet-author.md` — feedback loop, task ID claiming
- `.claude/commands/role-opus-architect.md` — feedback loop, task ID claiming
- `.claude/commands/role-sonnet-reviewer.md` — expanded skip list
- `.claude/commands/role-opus-reviewer.md` — labels field, skip list
- `.claude/commands/role-queue-manager.md` — task ID template

## Test plan

- [ ] `fleet-up dry-run` — all agents start, read updated role commands, print correct startup summaries
- [ ] Sonnet author sees `human:needs-fix` on a test PR and addresses it
- [ ] `fleet-claim claim "T-001" test-agent` succeeds; `fleet-claim claim "T-001" other-agent` returns exit 1
- [ ] Reviewers skip PRs with `fleet:wip`, `human:needs-fix`, `fleet:changes-made`

🤖 Generated with [Claude Code](https://claude.com/claude-code)