### PR TITLE
math: fix exponentialEaseInOut boundary conditions for GLM 1.1.0

### DIFF
--- a/engine/math/include/irreden/math/easing_functions.hpp
+++ b/engine/math/include/irreden/math/easing_functions.hpp
@@ -71,7 +71,15 @@ const std::unordered_map<IREasingFunctions, GLMEasingFunction> kEasingFunctions 
     {kCircularEaseInOut, glm::circularEaseInOut<float>},
     {kExponentialEaseIn, glm::exponentialEaseIn<float>},
     {kExponentialEaseOut, glm::exponentialEaseOut<float>},
-    {kExponentialEaseInOut, glm::exponentialEaseInOut<float>},
+    // GLM 1.1.0 exponentialEaseInOut lacks boundary guards: at t=0 the formula
+    // evaluates to 0.5*2^(-10) ≈ 1/2048 instead of 0, and at t=1 it evaluates
+    // to 1-1/2048 instead of 1.  Wrap with explicit boundary clamps so the
+    // function satisfies f(0)=0 and f(1)=1 as expected by all callers.
+    {kExponentialEaseInOut, [](float t) -> float {
+        if (t == 0.0f) return 0.0f;
+        if (t == 1.0f) return 1.0f;
+        return glm::exponentialEaseInOut(t);
+    }},
     {kElasticEaseIn, glm::elasticEaseIn<float>},
     {kElasticEaseOut, glm::elasticEaseOut<float>},
     {kElasticEaseInOut, glm::elasticEaseInOut<float>},


### PR DESCRIPTION
## Summary
- `glm::exponentialEaseInOut` in GLM 1.1.0 removed the early-return boundary guards present in earlier versions, so at `t=0` the formula evaluates to `0.5*2^(-10) ≈ 1/2048` (not 0) and at `t=1` to `1-1/2048` (not 1).
- `EasingMapTest.AllFunctionsBoundaryConditions` was failing for enum value 21 (`kExponentialEaseInOut`) with a boundary drift of ~0.000488, far exceeding the 1e-5 tolerance.
- Fix: wrap the map entry in a lambda that short-circuits to exactly 0 and 1 at the boundary inputs. EaseIn and EaseOut variants still have guards in GLM 1.1.0 and are unaffected.

## Test plan
- [x] `IrredenEngineTest` — all 260 tests pass (was 259/260 before fix)
- [x] `IRShapeDebug` builds clean on macOS (no regressions)

## Notes for reviewer
Only `kExponentialEaseInOut` (enum value 21) is wrapped. Verified `kExponentialEaseIn` (19) and `kExponentialEaseOut` (20) still satisfy boundary conditions with GLM 1.1.0 directly. Lambda pattern is consistent with the existing `kBackEaseIn/Out/InOut` lambdas already in the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)