### PR TITLE
fleet: issue triage, PR takeover, smart intake, and role cleanup

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -73,7 +73,9 @@ When you do pick a task:
    the edit in your first commit on the work branch.
 4. Build the target you touched with `fleet-build --target <name>`.
    Run the relevant executable if one exists for the touched code.
-5. Use the `commit-and-push` skill to open the PR.
+5. Use the `commit-and-push` skill to open the PR. If the task has an
+   `**Issue:** #N` field, include `Closes #N` in the PR body so the
+   issue closes automatically when the PR merges.
 6. After the PR is open, release the claim and reset:
    `fleet-claim release "<task ID>"`
    Then use the `start-next-task` skill to land on a fresh branch off
@@ -108,8 +110,9 @@ Include in the body:
 - **Acceptance criteria** (concrete check: build passes, test X works)
 - **Context** (why this matters, what you observed)
 
-The queue-manager will pick it up within 15 minutes, categorize it,
-and add it to TASKS.md. You do NOT edit TASKS.md directly.
+The issue will sit in the backlog until the **human triages and adds
+the `human:approved` label**. Only then does the queue-manager ingest
+it into TASKS.md. You do NOT edit TASKS.md directly.
 
 ## Escalation rules (always)
 

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -58,6 +58,9 @@ following is true:
 - No `[sonnet]` items are unblocked AND there are unblocked `[opus]`
   items that are clearly design-heavy core-engine work.
 - A PR needs Opus final review and `opus-reviewer` is offline.
+- An issue has the `fleet:needs-plan` label — the queue-manager
+  flagged it as needing architectural input before it can become a
+  task. See "Planning issues" below.
 
 When you do pick a task:
 
@@ -114,6 +117,26 @@ Include in the body:
 The issue will sit in the backlog until the **human triages and adds
 the `human:approved` label**. Only then does the queue-manager ingest
 it into TASKS.md. You do NOT edit TASKS.md directly.
+
+## Planning issues
+
+When the queue-manager flags an issue with `fleet:needs-plan`, it
+needs your input before becoming a task. Check for these periodically:
+`gh issue list --repo jakildev/IrredenEngine --label "fleet:needs-plan" --state open --json number,title,body,comments`
+
+For each one:
+1. Read the full issue thread (title, body, all comments).
+2. Assess the scope and propose a plan as an issue comment:
+   - What files/modules are involved
+   - Whether it should be one task or broken into subtasks
+   - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
+   - Acceptance criteria
+3. Remove `fleet:needs-plan` and add `human:approved`:
+   `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan" --add-label "human:approved"`
+   The queue-manager will ingest it on its next maintenance pass.
+
+If you disagree with the issue's direction, comment with your
+concerns but leave `fleet:needs-plan` on — let the human decide.
 
 ## Escalation rules (always)
 

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -82,6 +82,7 @@ When you do pick a task:
    `origin/master`.
 7. **Check for feedback labels on open PRs** before picking new work:
    `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "fleet:needs-fix")) | "#\(.number) \(.title)"'`
+   **Skip** PRs labeled `human:wip` — human is working on it directly.
    If any PR has `human:needs-fix` or `fleet:needs-fix`:
    a. Read ALL comments:
       `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // "general")] \(.body)"'`
@@ -133,10 +134,4 @@ Stop and surface to the human when:
 - Never run `cmake --preset` — only `cmake --build` against the
   already-configured tree.
 - Never touch the `.claude/worktrees/` layout.
-- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
-  commands in a single Bash invocation. Issue each command as its own
-  separate tool call (Bash or Read). Compound commands don't match the
-  allowlist and trigger interactive prompts that block unattended
-  operation. For git specifically, use `git -C <path>` instead of
-  `cd <path> && git`. For reading files, use the Read tool instead of
-  `cat`.
+- Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -56,9 +56,9 @@ conditions, allocator behavior, hot-path costs.
    - The author pushed fixes and commented "re-review please" after
      a previous Opus review (check comments after your last review).
 
-   **Skip** PRs labeled `fleet:wip`, `human:needs-fix`, or
-   `fleet:changes-made` — those are either in-progress or in the
-   human feedback loop, not ready for review.
+   **Skip** PRs labeled `fleet:wip`, `human:wip`, `human:needs-fix`,
+   or `fleet:changes-made` — those are either in-progress, human-owned,
+   or in the feedback loop.
 
 ## Loop behavior
 
@@ -133,10 +133,4 @@ end-to-end, then stop and wait for human instruction. Do not loop.
 - Do NOT take on first-pass reviews that Sonnet has not yet touched
   (unless `sonnet-reviewer` is offline AND the PR has been open more
   than 1 hour). The model split exists to conserve Opus budget.
-- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
-  commands in a single Bash invocation. Issue each command as its own
-  separate tool call (Bash or Read). Compound commands don't match the
-  allowlist and trigger interactive prompts that block unattended
-  operation. For git specifically, use `git -C <path>` instead of
-  `cd <path> && git`. For reading files, use the Read tool instead of
-  `cat`.
+- Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -95,9 +95,11 @@ Per the top-level engine `CLAUDE.md` "Model split":
   changes, gameplay work where mistakes are cheap to catch, bounded
   shader tweaks with a written spec.
 
-When in doubt, tag `[opus]` and let the human downgrade. Over-tagging
-to Opus burns budget; under-tagging to Sonnet causes a Sonnet agent
-to escalate mid-task, which wastes more.
+**Issue author's tag takes precedence.** If the issue body explicitly
+says `[opus]` or `[sonnet]`, use that — the filer knows the work best.
+Otherwise, when in doubt, tag `[opus]` and let the human downgrade.
+Over-tagging to Opus burns budget; under-tagging to Sonnet causes a
+Sonnet agent to escalate mid-task, which wastes more.
 
 ### Step 3 — Pick the area
 
@@ -184,27 +186,57 @@ You are the sole TASKS.md editor. Each maintenance pass:
    `fleet-claim cleanup --repo jakildev/IrredenEngine --repo jakildev/irreden`
 
 1. **Ingest triaged issues (engine repo):**
-   `gh issue list --repo jakildev/IrredenEngine --label "human:approved" --state open --json number,title,body`
+   `gh issue list --repo jakildev/IrredenEngine --label "human:approved" --state open --json number,title,body,comments,labels`
    Only issues with the `human:approved` label are ingested — this
    is the universal gate for both human-filed and agent-filed issues.
-   For each matching issue:
-   - Read the title and body as a task description.
-   - Categorize it (model tag, area) per Steps 2–3 above.
-   - Append a properly formatted entry to `## Open` in `TASKS.md`.
-     Include `**Issue:** #N` in the entry so author agents can link
-     their PR back to this issue.
-   - Remove the `human:approved` label (so the issue isn't re-ingested):
-     `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "human:approved"`
-   - Do **NOT** close the issue. It stays open until the author agent's
-     PR merges — the PR body will contain `Closes #N` which lets
-     GitHub close the issue automatically on merge.
+
+   For each matching issue, **read the full context** — title, body,
+   AND all comments. Comments often contain clarifications, scope
+   refinements, or design decisions that the body alone misses.
+
+   **Assess readiness** before ingesting. The issue must have:
+   - A clear, bounded scope (one PR's worth of work)
+   - Enough detail to derive acceptance criteria
+   - No open questions that would block an author mid-task
+
+   **If the issue is ready** — ingest it:
+   a. Categorize it (model tag, area) per Steps 2–3 above.
+      If the issue body explicitly says `[opus]` or `[sonnet]`, that
+      takes precedence over your own assessment. Otherwise, assess:
+      is this a hard problem (design decisions, core invariants,
+      cross-cutting changes → `[opus]`) or bounded/mechanical work
+      (tests, docs, refactors, clear spec → `[sonnet]`)?
+   b. Append a properly formatted entry to `## Open` in `TASKS.md`.
+      Include `**Issue:** #N` in the entry. Synthesize acceptance
+      criteria from the full issue thread, not just the title.
+   c. Remove the `human:approved` label (so the issue isn't
+      re-ingested):
+      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "human:approved"`
+   d. Do **NOT** close the issue. It stays open until the author
+      agent's PR merges via `Closes #N`.
+
+   **If the issue needs a plan first** — the scope is large, the
+   approach is unclear, or it needs architectural input:
+   a. Add the `fleet:needs-plan` label:
+      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "human:approved" --add-label "fleet:needs-plan"`
+   b. Comment explaining what's missing and that the architect
+      should weigh in before this becomes a task:
+      `gh issue comment <N> --repo jakildev/IrredenEngine --body "Needs planning: <what's unclear>. Tagging for architect review."`
+   c. Do NOT add it to TASKS.md yet. The human or architect will
+      refine the issue, then the human re-adds `human:approved`.
+
+   **If the issue is too vague** — not enough info to even plan:
+   a. Add the `fleet:needs-info` label:
+      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "human:approved" --add-label "fleet:needs-info"`
+   b. Comment with specific questions:
+      `gh issue comment <N> --repo jakildev/IrredenEngine --body "Need more info before scheduling: <specific questions>"`
+   c. Do NOT add it to TASKS.md.
 
 2. **Ingest triaged issues (game repo):**
-   `gh issue list --repo jakildev/irreden --label "human:approved" --state open --json number,title,body`
-   Same flow as above, but append to the game repo's `TASKS.md`.
-   Remove `human:approved`:
-   `gh issue edit <N> --repo jakildev/irreden --remove-label "human:approved"`
-   Do NOT close the issue — the PR will close it on merge.
+   `gh issue list --repo jakildev/irreden --label "human:approved" --state open --json number,title,body,comments,labels`
+   Same full-context assessment as above. Apply the same ready /
+   needs-plan / needs-info logic, using `--repo jakildev/irreden`
+   on all `gh` commands.
 
 3. **Sync merged PRs → Done:**
    `gh pr list --repo jakildev/IrredenEngine --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -184,10 +184,10 @@ You are the sole TASKS.md editor. Each maintenance pass:
    `fleet-claim cleanup --repo jakildev/IrredenEngine --repo jakildev/irreden`
 
 1. **Ingest triaged issues (engine repo):**
-   `gh issue list --repo jakildev/IrredenEngine --label "fleet:task" --label "human:approved" --state open --json number,title,body`
-   Only issues with **both** `fleet:task` AND `human:approved` are
-   ingested — the human must triage agent-filed issues before they
-   enter the queue. For each matching issue:
+   `gh issue list --repo jakildev/IrredenEngine --label "human:approved" --state open --json number,title,body`
+   Only issues with the `human:approved` label are ingested — this
+   is the universal gate for both human-filed and agent-filed issues.
+   For each matching issue:
    - Read the title and body as a task description.
    - Categorize it (model tag, area) per Steps 2–3 above.
    - Append a properly formatted entry to `## Open` in `TASKS.md`.
@@ -200,7 +200,7 @@ You are the sole TASKS.md editor. Each maintenance pass:
      GitHub close the issue automatically on merge.
 
 2. **Ingest triaged issues (game repo):**
-   `gh issue list --repo jakildev/irreden --label "fleet:task" --label "human:approved" --state open --json number,title,body`
+   `gh issue list --repo jakildev/irreden --label "human:approved" --state open --json number,title,body`
    Same flow as above, but append to the game repo's `TASKS.md`.
    Remove `human:approved`:
    `gh issue edit <N> --repo jakildev/irreden --remove-label "human:approved"`
@@ -246,10 +246,4 @@ You are the sole TASKS.md editor. Each maintenance pass:
   the no-direct-push rule — TASKS.md is bookkeeping, not code, and
   you are its sole editor. Never push any other file to master.
 - Never `git push --force`.
-- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
-  commands in a single Bash invocation. Issue each command as its own
-  separate tool call (Bash or Read). Compound commands don't match the
-  allowlist and trigger interactive prompts that block unattended
-  operation. For git specifically, use `git -C <path>` instead of
-  `cd <path> && git`. For reading files, use the Read tool instead of
-  `cat`.
+- Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -123,6 +123,7 @@ Use the exact template from `TASKS.md`:
   - **Owner:** free
   - **Blocked by:** (none) | <title or PR URL>
   - **Acceptance:** <concrete check: build passes, test X passes, screenshot looks like Y>
+  - **Issue:** (none) | #N
   - **Notes:** <context, links, prior attempts>
   - **Links:** (empty until done)
 ```
@@ -131,6 +132,11 @@ Use the exact template from `TASKS.md`:
 for the highest `T-NNN` ID currently in use, then assign the next
 sequential number. IDs are never reused. The ID is the canonical claim
 key — agents pass it (not the free-text title) to `fleet-claim`.
+
+**Issue field:** if the task was ingested from a GitHub issue, set
+`**Issue:** #N` (the issue number). Author agents use this to include
+`Closes #N` in their PR body, so the issue closes automatically when
+the PR merges. For human-pasted tasks with no issue, set `(none)`.
 
 The **Acceptance** line is the most important. If the human's
 description is fuzzy, push back and ask for a concrete check before
@@ -177,20 +183,28 @@ You are the sole TASKS.md editor. Each maintenance pass:
 0. **Clean stale claims:**
    `fleet-claim cleanup --repo jakildev/IrredenEngine --repo jakildev/irreden`
 
-1. **Ingest `fleet:task` issues (engine repo):**
-   `gh issue list --repo jakildev/IrredenEngine --label "fleet:task" --state open --json number,title,body`
-   For each open issue:
+1. **Ingest triaged issues (engine repo):**
+   `gh issue list --repo jakildev/IrredenEngine --label "fleet:task" --label "human:approved" --state open --json number,title,body`
+   Only issues with **both** `fleet:task` AND `human:approved` are
+   ingested — the human must triage agent-filed issues before they
+   enter the queue. For each matching issue:
    - Read the title and body as a task description.
    - Categorize it (model tag, area) per Steps 2–3 above.
    - Append a properly formatted entry to `## Open` in `TASKS.md`.
-   - Close the issue with a comment:
-     `gh issue close <N> --repo jakildev/IrredenEngine --comment "Filed in TASKS.md"`
+     Include `**Issue:** #N` in the entry so author agents can link
+     their PR back to this issue.
+   - Remove the `human:approved` label (so the issue isn't re-ingested):
+     `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "human:approved"`
+   - Do **NOT** close the issue. It stays open until the author agent's
+     PR merges — the PR body will contain `Closes #N` which lets
+     GitHub close the issue automatically on merge.
 
-2. **Ingest `fleet:task` issues (game repo):**
-   `gh issue list --repo jakildev/irreden --label "fleet:task" --state open --json number,title,body`
+2. **Ingest triaged issues (game repo):**
+   `gh issue list --repo jakildev/irreden --label "fleet:task" --label "human:approved" --state open --json number,title,body`
    Same flow as above, but append to the game repo's `TASKS.md`.
-   Close the issue:
-   `gh issue close <N> --repo jakildev/irreden --comment "Filed in TASKS.md"`
+   Remove `human:approved`:
+   `gh issue edit <N> --repo jakildev/irreden --remove-label "human:approved"`
+   Do NOT close the issue — the PR will close it on merge.
 
 3. **Sync merged PRs → Done:**
    `gh pr list --repo jakildev/IrredenEngine --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -117,7 +117,12 @@ limit. Each loop iteration:
    Then create the branch, commit, and open a `fleet:wip` PR:
    `git checkout -b claude/<area>-<topic>`
    `git commit --allow-empty -m "claim: <task title>"`
-   `gh pr create --title "<task title>" --body "Claiming task. Work in progress." --label "fleet:wip"`
+
+   Check the task's **Issue:** field. If it has a `#N` reference,
+   include `Closes #N` in the PR body so the issue closes
+   automatically when the PR merges:
+   `gh pr create --title "<task title>" --body "Claiming task. Work in progress.\n\nCloses #N" --label "fleet:wip"`
+   If there is no issue (`(none)`), omit the `Closes` line.
 
    Reference the task title in the PR title so the queue-manager can
    match it.
@@ -144,7 +149,9 @@ limit. Each loop iteration:
    on your PR:
    `gh issue create --repo jakildev/IrredenEngine --title "<what needs opus attention>" --label "fleet:task" --body "Escalated from sonnet. Area: ... Suggested model: [opus]. Context: ..."`
    Then comment on your PR: "escalated — filed issue #N for opus".
-   The queue-manager will add it to TASKS.md. Move on to the next task.
+   The human will triage the issue and add `human:approved` when
+   ready. The queue-manager then adds it to TASKS.md. Move on to the
+   next task.
 
 7. **Finalize the PR.** Use the `commit-and-push` skill to push your
    work commits to the existing PR branch. Then remove the WIP label

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -51,6 +51,8 @@ limit. Each loop iteration:
 1. **Check for feedback labels on open PRs.**
    `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
 
+   **Skip** PRs labeled `human:wip` — human is working on it directly.
+
    If any PR has `human:needs-fix`, `human:blocker`, or `fleet:needs-fix`,
    address the **oldest** one first. Human feedback takes priority.
 
@@ -186,10 +188,4 @@ budget split. Just wait.
 - Never touch the `.claude/worktrees/` layout.
 - Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
   `xcode-select` — those are human-initiated.
-- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
-  commands in a single Bash invocation. Issue each command as its own
-  separate tool call (Bash or Read). Compound commands don't match the
-  allowlist and trigger interactive prompts that block unattended
-  operation. For git specifically, use `git -C <path>` instead of
-  `cd <path> && git`. For reading files, use the Read tool instead of
-  `cat`.
+- Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -51,6 +51,7 @@ treat it as a hard rule for this role.
 
    **Skip** PRs with any of these labels:
    - `fleet:wip` — work-in-progress claim, not ready for review.
+   - `human:wip` — human is working on this PR. Hands off.
    - `human:needs-fix` — human requested changes, author agent is
      handling it. Don't pile on a fleet review while the human's
      feedback is being addressed.
@@ -148,10 +149,4 @@ for human instruction. Do not loop.
   actions on your own PRs. Always use `--comment` with a clear
   verdict line (`Verdict: approve`, `Verdict: needs-fix`, etc.).
 - Never `git push --force` (you have no reason to push at all).
-- Never use shell compound operators (`&&`, `||`, `;`, `|`) to chain
-  commands in a single Bash invocation. Issue each command as its own
-  separate tool call (Bash or Read). Compound commands don't match the
-  allowlist and trigger interactive prompts that block unattended
-  operation. For git specifically, use `git -C <path>` instead of
-  `cd <path> && git`. For reading files, use the Read tool instead of
-  `cat`.
+- Single-command Bash only (see CRITICAL section above).

--- a/TASKS.md
+++ b/TASKS.md
@@ -77,6 +77,7 @@ them in the creation's own `TASKS.md`.
   - **Owner:** free | <worktree-name>
   - **Blocked by:** (none) | <title of blocking task>
   - **Acceptance:** <concrete check: build passes, test X passes, PR merged, screenshot Y looks like Z>
+  - **Issue:** (none) | #N  (GitHub issue number, if task originated from an issue)
   - **Notes:** <context, links, prior attempts>
   - **Links:** (fill in PR URL when done)
 ```


### PR DESCRIPTION
## Summary

- **human:approved as universal issue gate** — queue-manager ingests any issue with this label (human-filed or agent-filed). No longer requires `fleet:task` too. Issues are your single backlog.
- **human:wip PR takeover** — add this label to any PR and all agents back off (no reviews, no feedback fixes). Remove when done.
- **Smart issue intake** — queue-manager reads title + body + all comments before ingesting. Three outcomes:
  - **Ready** → ingests into TASKS.md with `Issue: #N`
  - **Needs plan** (`fleet:needs-plan`) → routes to architect for planning
  - **Needs info** (`fleet:needs-info`) → rejects with specific questions
- **Issue author's model tag takes precedence** — if the issue says `[opus]` or `[sonnet]`, the queue-manager uses that.
- **Architect planning flow** — architects watch for `fleet:needs-plan` issues, comment with a plan, then swap to `human:approved`.
- **Issue ↔ PR linkage** — task template has `Issue: #N` field, author agents include `Closes #N` in PR body. Issues auto-close on merge.
- **Boilerplate trim** — removed ~60 lines of duplicated shell-compound-operator warnings across all role files.

## Test plan
- [ ] Merge and run `fleet-up dry-run`
- [ ] File a test issue, add `human:approved`, verify queue-manager ingests it on maintenance pass
- [ ] File a vague issue, add `human:approved`, verify queue-manager rejects with `fleet:needs-info`
- [ ] Add `human:wip` to a PR, verify reviewers skip it
- [ ] Verify `commit-and-push` still runs `simplify` (it does — built into the skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)