### PR TITLE
fleet: label lifecycle fix, dual-repo sync, and generic repo slugs

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -20,8 +20,8 @@ this blocks unattended operation with interactive prompts.
 
 ## Role
 
-You poll open PRs on **both repos** — `jakildev/IrredenEngine` (engine)
-and `jakildev/irreden` (game) — and act on the ones that:
+You poll open PRs on **both repos** — the engine repo and the game
+repo at `creations/game/` (if present) — and act on the ones that:
 - Have a Sonnet first-pass review whose body ends with
   `Opus recheck required: ...`, or
 - Touch core engine invariants regardless of Sonnet's verdict
@@ -41,14 +41,21 @@ conditions, allocator behavior, hot-path costs.
 ## Startup actions
 
 1. `pwd` — confirm you are in the `opus-reviewer` worktree.
-2. Confirm you are on the throwaway branch
+2. **Discover repo slugs** (used in all `--repo` flags below):
+   Engine: `gh repo view --json nameWithOwner --jq .nameWithOwner`
+   Game: `git -C ~/src/IrredenEngine/creations/game remote get-url origin`
+   Parse `owner/repo` from the URL (strip protocol, `.git` suffix).
+   If the game directory doesn't exist, skip all game-repo steps.
+   All `<engine-repo>` and `<game-repo>` placeholders below refer
+   to these discovered slugs.
+3. Confirm you are on the throwaway branch
    `claude/opus-reviewer-scratch`. If not, run these two commands
    separately (do NOT wrap in `cd ... &&`):
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git checkout -B claude/opus-reviewer-scratch origin/master`
-3. Fetch PR lists from both repos (each as a separate command):
+4. Fetch PR lists from both repos (each as a separate command):
    `gh pr list --state open --json number,title,headRefName,reviews,labels`
-   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,reviews,labels`
+   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,reviews,labels`
    Print both results.
 4. Identify the candidates from both repos. A PR is a candidate if:
    - The latest Sonnet review body contains `Opus recheck required`, OR
@@ -67,14 +74,14 @@ than the Sonnet reviewer. Each iteration:
 
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,reviews,labels`
-   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,reviews,labels`
+   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,reviews,labels`
 2. For each candidate, in oldest-first order:
    a. Read the existing Sonnet review in full first
-      (`gh pr view <N> --comments`, add `--repo jakildev/irreden` for
+      (`gh pr view <N> --comments`, add `--repo <game-repo>` for
       game PRs). Note what Sonnet flagged.
    b. **Engine PRs:** Invoke the `review-pr` skill on the PR.
       **Game PRs:** Read the diff with `gh pr diff <N> --repo
-      jakildev/irreden` and review manually (you cannot check out game
+      <game-repo>` and review manually (you cannot check out game
       PRs into this engine worktree). For game conventions, read
       `~/src/IrredenEngine/creations/game/CLAUDE.md`.
    c. Focus your review on the items Sonnet could not confirm — do
@@ -87,9 +94,9 @@ than the Sonnet reviewer. Each iteration:
       Do **not** use `--approve` or `--request-changes` — all fleet
       agents share one GitHub account, and GitHub rejects formal
       review actions on your own PRs.
-      For game PRs, add `--repo jakildev/irreden` to all `gh` commands.
+      For game PRs, add `--repo <game-repo>` to all `gh` commands.
    e. **Set the PR label** to match your verdict (add `--repo
-      jakildev/irreden` for game PRs). The label is the primary signal
+      <game-repo>` for game PRs). The label is the primary signal
       the human uses. Always remove stale labels first:
       `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
       (swap the label name for needs-fix or blocker as appropriate).

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -57,7 +57,7 @@ conditions, allocator behavior, hot-path costs.
    `gh pr list --state open --json number,title,headRefName,reviews,labels`
    `gh pr list --repo <game-repo> --state open --json number,title,headRefName,reviews,labels`
    Print both results.
-4. Identify the candidates from both repos. A PR is a candidate if:
+5. Identify the candidates from both repos. A PR is a candidate if:
    - The latest Sonnet review body contains `Opus recheck required`, OR
    - The PR touches core engine/game invariants, OR
    - The author pushed fixes and commented "re-review please" after

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -236,30 +236,45 @@ You are the sole TASKS.md editor. Each maintenance pass:
    `gh issue list --repo jakildev/irreden --label "human:approved" --state open --json number,title,body,comments,labels`
    Same full-context assessment as above. Apply the same ready /
    needs-plan / needs-info logic, using `--repo jakildev/irreden`
-   on all `gh` commands.
+   on all `gh` commands. Append to the **game** TASKS.md at
+   `~/src/IrredenEngine/creations/game/TASKS.md`.
 
-3. **Sync merged PRs → Done:**
+3. **Sync merged PRs → Done (both repos):**
+   Engine:
    `gh pr list --repo jakildev/IrredenEngine --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
+   Game:
+   `gh pr list --repo jakildev/irreden --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
    (use yesterday's date to catch recent merges)
-   Read `TASKS.md`. For each recently merged PR whose title or branch
-   matches an `[~]` or `[ ]` task: flip to `[x]`, add the PR URL to
-   **Links**, move to `## Done — last 20`.
+   For each recently merged PR whose title or branch matches an
+   `[~]` or `[ ]` task in the **matching repo's** TASKS.md: flip to
+   `[x]`, add the PR URL to **Links**, move to `## Done — last 20`.
 
-4. **Sync open PRs → In-progress:**
+4. **Sync open PRs → In-progress (both repos):**
+   Engine:
    `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName`
-   For each open PR whose title matches a `[ ]` task: flip to `[~]`,
-   set Owner to the PR author's worktree name.
+   Game:
+   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName`
+   For each open PR whose title matches a `[ ]` task in the matching
+   repo's TASKS.md: flip to `[~]`, set Owner to the PR author's
+   worktree name.
 
-5. **Prune Done:** keep only the last 20 entries. Delete older ones.
+5. **Prune Done:** keep only the last 20 entries in each TASKS.md.
 
-6. **Push changes (if any).** Commit TASKS.md only and push directly
-   to master:
-   - `git fetch origin`
-   - `git rebase origin/master`
-   - `git add TASKS.md`
-   - `git commit -m "queue: maintenance sync"`
-   - `git push origin HEAD:master`
-   If push rejected, `git pull --rebase origin master` then retry.
+6. **Push changes (if any).**
+   Engine TASKS.md — commit and push directly to master:
+   - `git -C ~/src/IrredenEngine fetch origin`
+   - `git -C ~/src/IrredenEngine rebase origin/master`
+   - `git -C ~/src/IrredenEngine add TASKS.md`
+   - `git -C ~/src/IrredenEngine commit -m "queue: maintenance sync"`
+   - `git -C ~/src/IrredenEngine push origin HEAD:master`
+   Game TASKS.md — separate commit and push to game repo master:
+   - `git -C ~/src/IrredenEngine/creations/game fetch origin`
+   - `git -C ~/src/IrredenEngine/creations/game rebase origin/master`
+   - `git -C ~/src/IrredenEngine/creations/game add TASKS.md`
+   - `git -C ~/src/IrredenEngine/creations/game commit -m "queue: maintenance sync"`
+   - `git -C ~/src/IrredenEngine/creations/game push origin HEAD:master`
+   If either push is rejected, rebase and retry. Only push TASKS.md
+   — never push other files to master.
 
 7. Print the maintenance summary AND the queue summary on two lines:
    `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned`
@@ -273,9 +288,10 @@ You are the sole TASKS.md editor. Each maintenance pass:
   TASKS.md changes from an author agent, flag it in your review or
   comment — the author should remove those changes.
 - Never `gh pr merge` — the human merges.
-- **TASKS.md exception:** you MAY `git push origin HEAD:master` when
-  the commit touches **only** TASKS.md. This is the sole exception to
-  the no-direct-push rule — TASKS.md is bookkeeping, not code, and
-  you are its sole editor. Never push any other file to master.
+- **TASKS.md exception:** you MAY push directly to master in **both**
+  repos (engine and game) when the commit touches **only** TASKS.md.
+  This is the sole exception to the no-direct-push rule — TASKS.md is
+  bookkeeping, not code, and you are its sole editor. Never push any
+  other file to master in either repo.
 - Never `git push --force`.
 - Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -39,20 +39,21 @@ use `cat` — use the Read tool for files.
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
 3. **Discover repo slugs** (used in all `--repo` flags below):
    Engine: `gh repo view --json nameWithOwner --jq .nameWithOwner`
-   Game: Read `~/src/IrredenEngine/creations/game/TASKS.md` (next step).
-   If the game TASKS.md exists, run:
-   `git -C ~/src/IrredenEngine/creations/game remote get-url origin`
-   Parse `owner/repo` from the URL (strip protocol, `.git` suffix).
-   If the game repo doesn't exist, skip all game-repo steps below.
+   Game: determined in step 5 below (probe the game directory).
    All `<engine-repo>` and `<game-repo>` placeholders below refer
    to these discovered slugs.
 4. Read tool → `TASKS.md`
 5. Read tool → `~/src/IrredenEngine/creations/game/TASKS.md`
-   - If the Read succeeds (file exists) → also run step 5a:
-     5a. `gh pr list --repo <game-repo> --state open --json number,title,headRefName`
-   - If the Read fails (file not found) → skip 5a. No game repo.
+   - If the Read succeeds (file exists), the game repo is present.
+     Run these two commands (separate tool calls):
+     5a. `git -C ~/src/IrredenEngine/creations/game remote get-url origin`
+         Parse `owner/repo` from the URL (strip protocol, `.git`
+         suffix). This is `<game-repo>`.
+     5b. `gh pr list --repo <game-repo> --state open --json number,title,headRefName`
+   - If the Read fails (file not found) → skip 5a–5b. No game repo.
+     All game-repo steps below are skipped.
 6. `gh pr list --repo <engine-repo> --state open --json number,title,headRefName`
-6. Print a **one-line queue summary** followed by the standing-by message.
+7. Print a **one-line queue summary** followed by the standing-by message.
    Format: `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
    Count from both engine and game TASKS.md (if present). Then print:
    `queue-manager standing by — paste a task description and I will
@@ -270,12 +271,13 @@ You are the sole TASKS.md editor. Each maintenance pass:
 5. **Prune Done:** keep only the last 20 entries in each TASKS.md.
 
 6. **Push changes (if any).**
-   Engine TASKS.md — commit and push directly to master:
-   - `git -C ~/src/IrredenEngine fetch origin`
-   - `git -C ~/src/IrredenEngine rebase origin/master`
-   - `git -C ~/src/IrredenEngine add TASKS.md`
-   - `git -C ~/src/IrredenEngine commit -m "queue: maintenance sync"`
-   - `git -C ~/src/IrredenEngine push origin HEAD:master`
+   Engine TASKS.md — commit and push directly to master (bare `git`
+   is correct here — your CWD is an engine worktree):
+   - `git fetch origin`
+   - `git rebase origin/master`
+   - `git add TASKS.md`
+   - `git commit -m "queue: maintenance sync"`
+   - `git push origin HEAD:master`
    Game TASKS.md — separate commit and push to game repo master:
    - `git -C ~/src/IrredenEngine/creations/game fetch origin`
    - `git -C ~/src/IrredenEngine/creations/game rebase origin/master`

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -37,12 +37,21 @@ use `cat` — use the Read tool for files.
 
 1. `pwd`
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. Read tool → `TASKS.md`
-4. Read tool → `~/src/IrredenEngine/creations/game/TASKS.md`
-   - If the Read succeeds (file exists) → also run step 4a (separate tool call):
-     4a. `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName`
-   - If the Read fails (file not found) → skip 4a. No game repo on this machine.
-5. `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName`
+3. **Discover repo slugs** (used in all `--repo` flags below):
+   Engine: `gh repo view --json nameWithOwner --jq .nameWithOwner`
+   Game: Read `~/src/IrredenEngine/creations/game/TASKS.md` (next step).
+   If the game TASKS.md exists, run:
+   `git -C ~/src/IrredenEngine/creations/game remote get-url origin`
+   Parse `owner/repo` from the URL (strip protocol, `.git` suffix).
+   If the game repo doesn't exist, skip all game-repo steps below.
+   All `<engine-repo>` and `<game-repo>` placeholders below refer
+   to these discovered slugs.
+4. Read tool → `TASKS.md`
+5. Read tool → `~/src/IrredenEngine/creations/game/TASKS.md`
+   - If the Read succeeds (file exists) → also run step 5a:
+     5a. `gh pr list --repo <game-repo> --state open --json number,title,headRefName`
+   - If the Read fails (file not found) → skip 5a. No game repo.
+6. `gh pr list --repo <engine-repo> --state open --json number,title,headRefName`
 6. Print a **one-line queue summary** followed by the standing-by message.
    Format: `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
    Count from both engine and game TASKS.md (if present). Then print:
@@ -183,10 +192,10 @@ triggers.
 You are the sole TASKS.md editor. Each maintenance pass:
 
 0. **Clean stale claims:**
-   `fleet-claim cleanup --repo jakildev/IrredenEngine --repo jakildev/irreden`
+   `fleet-claim cleanup --repo <engine-repo> --repo <game-repo>`
 
 1. **Ingest triaged issues (engine repo):**
-   `gh issue list --repo jakildev/IrredenEngine --label "human:approved" --state open --json number,title,body,comments,labels`
+   `gh issue list --repo <engine-repo> --label "human:approved" --state open --json number,title,body,comments,labels`
    Only issues with the `human:approved` label are ingested — this
    is the universal gate for both human-filed and agent-filed issues.
 
@@ -211,39 +220,39 @@ You are the sole TASKS.md editor. Each maintenance pass:
       criteria from the full issue thread, not just the title.
    c. Remove the `human:approved` label (so the issue isn't
       re-ingested):
-      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "human:approved"`
+      `gh issue edit <N> --repo <engine-repo> --remove-label "human:approved"`
    d. Do **NOT** close the issue. It stays open until the author
       agent's PR merges via `Closes #N`.
 
    **If the issue needs a plan first** — the scope is large, the
    approach is unclear, or it needs architectural input:
    a. Add the `fleet:needs-plan` label:
-      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "human:approved" --add-label "fleet:needs-plan"`
+      `gh issue edit <N> --repo <engine-repo> --remove-label "human:approved" --add-label "fleet:needs-plan"`
    b. Comment explaining what's missing and that the architect
       should weigh in before this becomes a task:
-      `gh issue comment <N> --repo jakildev/IrredenEngine --body "Needs planning: <what's unclear>. Tagging for architect review."`
+      `gh issue comment <N> --repo <engine-repo> --body "Needs planning: <what's unclear>. Tagging for architect review."`
    c. Do NOT add it to TASKS.md yet. The human or architect will
       refine the issue, then the human re-adds `human:approved`.
 
    **If the issue is too vague** — not enough info to even plan:
    a. Add the `fleet:needs-info` label:
-      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "human:approved" --add-label "fleet:needs-info"`
+      `gh issue edit <N> --repo <engine-repo> --remove-label "human:approved" --add-label "fleet:needs-info"`
    b. Comment with specific questions:
-      `gh issue comment <N> --repo jakildev/IrredenEngine --body "Need more info before scheduling: <specific questions>"`
+      `gh issue comment <N> --repo <engine-repo> --body "Need more info before scheduling: <specific questions>"`
    c. Do NOT add it to TASKS.md.
 
 2. **Ingest triaged issues (game repo):**
-   `gh issue list --repo jakildev/irreden --label "human:approved" --state open --json number,title,body,comments,labels`
+   `gh issue list --repo <game-repo> --label "human:approved" --state open --json number,title,body,comments,labels`
    Same full-context assessment as above. Apply the same ready /
-   needs-plan / needs-info logic, using `--repo jakildev/irreden`
+   needs-plan / needs-info logic, using `--repo <game-repo>`
    on all `gh` commands. Append to the **game** TASKS.md at
    `~/src/IrredenEngine/creations/game/TASKS.md`.
 
 3. **Sync merged PRs → Done (both repos):**
    Engine:
-   `gh pr list --repo jakildev/IrredenEngine --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
+   `gh pr list --repo <engine-repo> --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
    Game:
-   `gh pr list --repo jakildev/irreden --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
+   `gh pr list --repo <game-repo> --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
    (use yesterday's date to catch recent merges)
    For each recently merged PR whose title or branch matches an
    `[~]` or `[ ]` task in the **matching repo's** TASKS.md: flip to
@@ -251,9 +260,9 @@ You are the sole TASKS.md editor. Each maintenance pass:
 
 4. **Sync open PRs → In-progress (both repos):**
    Engine:
-   `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName`
+   `gh pr list --repo <engine-repo> --state open --json number,title,headRefName`
    Game:
-   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName`
+   `gh pr list --repo <game-repo> --state open --json number,title,headRefName`
    For each open PR whose title matches a `[ ]` task in the matching
    repo's TASKS.md: flip to `[~]`, set Owner to the PR author's
    worktree name.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -76,9 +76,11 @@ limit. Each loop iteration:
       - If it was `fleet:needs-fix` → no response label needed
         (fleet reviewer will re-review automatically on next poll)
       `gh pr comment <N> --body "Addressed feedback: <bullet list of what changed>"`
-   f. If the PR also had `fleet:approved`, `fleet:needs-fix`, or
-      `fleet:blocker`, remove those too — the reviewer will re-review
-      the updated PR.
+   f. Remove stale fleet review labels (`fleet:needs-fix`,
+      `fleet:blocker`) if present — but **keep `fleet:approved`**.
+      The fleet's approval is still valid; human tweaks don't
+      invalidate it. The reviewer will re-review only if the stale
+      labels triggered it.
    g. Move to the next loop iteration.
 
    **Human feedback label cycle:** human adds `human:needs-fix` (+

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -19,8 +19,8 @@ this blocks unattended operation with interactive prompts.
 
 ## Role
 
-You poll open PRs on **both repos** — `github.com/jakildev/IrredenEngine`
-(engine) and `github.com/jakildev/irreden` (game) — run the `review-pr`
+You poll open PRs on **both repos** — the engine repo and the game
+repo at `creations/game/` (if present) — run the `review-pr`
 skill on any that have not been reviewed by this fleet yet, and post a
 structured first-pass review. You also flag PRs that need an Opus final
 pass.
@@ -32,18 +32,25 @@ treat it as a hard rule for this role.
 ## Startup actions
 
 1. `pwd` — confirm you are in the `sonnet-reviewer` worktree.
-2. Confirm you are on the throwaway branch:
+2. **Discover repo slugs** (used in all `--repo` flags below):
+   Engine: `gh repo view --json nameWithOwner --jq .nameWithOwner`
+   Game: `git -C ~/src/IrredenEngine/creations/game remote get-url origin`
+   Parse `owner/repo` from the URL (strip protocol, `.git` suffix).
+   If the game directory doesn't exist, skip all game-repo steps.
+   All `<engine-repo>` and `<game-repo>` placeholders below refer
+   to these discovered slugs.
+4. Confirm you are on the throwaway branch:
    `git branch --show-current` should report something like
    `claude/sonnet-reviewer-scratch`. If not, run these two commands
    separately (do NOT wrap in `cd ... &&`):
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git checkout -B claude/sonnet-reviewer-scratch origin/master`
    `gh pr checkout` will rewrite this branch on each review.
-3. Fetch PR lists from both repos (each as a separate command):
+5. Fetch PR lists from both repos (each as a separate command):
    `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
-   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,author,reviews,labels`
+   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,author,reviews,labels`
    Print both results so we both see the current PR queues.
-4. Identify review candidates from both repos. A PR is a candidate if:
+6. Identify review candidates from both repos. A PR is a candidate if:
    - It has **no fleet review yet** (no review from your GitHub user), OR
    - It **previously had a fleet review** but the author pushed fixes
      and commented "re-review please" (check the comments array for
@@ -65,7 +72,7 @@ usage limit. Each iteration:
 
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
-   `gh pr list --repo jakildev/irreden --state open --json number,title,headRefName,author,reviews,labels`
+   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,author,reviews,labels`
 2. Re-apply the same skip criteria from startup step 4: skip PRs that
    already have a fleet review, or carry any of `fleet:wip`,
    `human:needs-fix`, or `fleet:changes-made`. For each remaining
@@ -76,16 +83,16 @@ usage limit. Each iteration:
    b. The skill checks out the PR, reads the diff in context, writes
       a structured review, and posts it.
 
-   **Game PRs** (`jakildev/irreden`):
-   a. Read the diff: `gh pr diff <N> --repo jakildev/irreden`
-   b. Read PR details: `gh pr view <N> --repo jakildev/irreden`
+   **Game PRs** (`<game-repo>`):
+   a. Read the diff: `gh pr diff <N> --repo <game-repo>`
+   b. Read PR details: `gh pr view <N> --repo <game-repo>`
    c. Review the diff manually (you cannot check out game PRs into
       this engine worktree). Focus on code quality, style, and obvious
       bugs. For game-specific conventions, read the game CLAUDE.md at
       `~/src/IrredenEngine/creations/game/CLAUDE.md`.
-   d. Post the review: `gh pr review <N> --repo jakildev/irreden --comment --body "<review>"`
+   d. Post the review: `gh pr review <N> --repo <game-repo> --comment --body "<review>"`
    e. Set labels — always remove stale labels first:
-      `gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
+      `gh pr edit <N> --repo <game-repo> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
       (swap the add-label name for `fleet:needs-fix` or `fleet:blocker` as appropriate).
 
    For all PRs, the review body MUST end with one of these explicit lines:
@@ -98,7 +105,7 @@ usage limit. Each iteration:
         flag for Opus recheck if you're uncertain — better to escalate
         than to approve something subtle by mistake.
    d. **Set the PR label** to match your verdict (add `--repo
-      jakildev/irreden` for game PRs). The label is the primary signal
+      <game-repo>` for game PRs). The label is the primary signal
       the human uses. Always remove stale labels first:
       `gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --add-label "fleet:needs-fix"`
       (swap the label name for approved or blocker as appropriate).

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -39,18 +39,18 @@ treat it as a hard rule for this role.
    If the game directory doesn't exist, skip all game-repo steps.
    All `<engine-repo>` and `<game-repo>` placeholders below refer
    to these discovered slugs.
-4. Confirm you are on the throwaway branch:
+3. Confirm you are on the throwaway branch:
    `git branch --show-current` should report something like
    `claude/sonnet-reviewer-scratch`. If not, run these two commands
    separately (do NOT wrap in `cd ... &&`):
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git checkout -B claude/sonnet-reviewer-scratch origin/master`
    `gh pr checkout` will rewrite this branch on each review.
-5. Fetch PR lists from both repos (each as a separate command):
+4. Fetch PR lists from both repos (each as a separate command):
    `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
    `gh pr list --repo <game-repo> --state open --json number,title,headRefName,author,reviews,labels`
    Print both results so we both see the current PR queues.
-6. Identify review candidates from both repos. A PR is a candidate if:
+5. Identify review candidates from both repos. A PR is a candidate if:
    - It has **no fleet review yet** (no review from your GitHub user), OR
    - It **previously had a fleet review** but the author pushed fixes
      and commented "re-review please" (check the comments array for
@@ -73,9 +73,10 @@ usage limit. Each iteration:
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
    `gh pr list --repo <game-repo> --state open --json number,title,headRefName,author,reviews,labels`
-2. Re-apply the same skip criteria from startup step 4: skip PRs that
+2. Re-apply the same skip criteria from startup step 5: skip PRs that
    already have a fleet review, or carry any of `fleet:wip`,
-   `human:needs-fix`, or `fleet:changes-made`. For each remaining
+   `human:wip`, `human:needs-fix`, or `fleet:changes-made`. For each
+   remaining
    candidate, in oldest-first order:
 
    **Engine PRs** (default repo):


### PR DESCRIPTION
## Summary
Three fleet workflow fixes:

**1. Keep `fleet:approved` when addressing human feedback**
- Stop removing `fleet:approved` when author agents address `human:needs-fix`
- Only remove stale review labels (`fleet:needs-fix`, `fleet:blocker`)

**2. Queue-manager: sync both repos during maintenance**
- Steps 3-4 (PR sync) and step 6 (push) now cover both engine and game repos
- Hard rules updated: TASKS.md direct-push exception covers both repos

**3. Decouple game repo slug from engine role files**
- Queue-manager, sonnet-reviewer, and opus-reviewer previously hardcoded
  `jakildev/irreden` — now each discovers the game repo at startup via
  `git remote get-url origin` in `creations/game/`
- Uses `<engine-repo>` and `<game-repo>` placeholders throughout
- Engine fleet is now generic: any game repo at `creations/game/` works

## Test plan
- [ ] Grep engine `.claude/commands/` for `jakildev/irreden` — should find zero matches
- [ ] Read queue-manager startup step 3 — confirms repo discovery logic
- [ ] Read sonnet-reviewer startup step 2 — confirms repo discovery logic
- [ ] Confirm role-sonnet-author step 1f keeps `fleet:approved`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>