### PR TITLE
docs: add /// doc comments to ir_platform.hpp

### DIFF
--- a/engine/common/include/irreden/ir_platform.hpp
+++ b/engine/common/include/irreden/ir_platform.hpp
@@ -5,18 +5,26 @@
 
 namespace IRPlatform {
 
+/// Graphics backend compiled into this binary.
 enum class GraphicsBackend {
     OPENGL,
     METAL,
     VULKAN
 };
 
+/// Operating system detected at compile time.
 enum class OperatingSystem {
     LINUX,
     MACOS,
     WINDOWS
 };
 
+/// Compile-time graphics backend, selected by the CMake-injected
+/// IR_GRAPHICS_METAL / IR_GRAPHICS_VULKAN / (default) preprocessor macro.
+/// Branch on this to differ behaviour across backends.  For a quick
+/// boolean test, @see kIsOpenGL — but note that no corresponding
+/// kIsMetal or kIsVulkan bools exist; check kGraphicsBackend directly
+/// for those backends.
 #if defined(IR_GRAPHICS_METAL)
 inline constexpr GraphicsBackend kGraphicsBackend = GraphicsBackend::METAL;
 #elif defined(IR_GRAPHICS_VULKAN)
@@ -25,6 +33,7 @@ inline constexpr GraphicsBackend kGraphicsBackend = GraphicsBackend::VULKAN;
 inline constexpr GraphicsBackend kGraphicsBackend = GraphicsBackend::OPENGL;
 #endif
 
+/// Compile-time operating system, detected from standard predefined macros.
 #if defined(__APPLE__)
 inline constexpr OperatingSystem kOperatingSystem = OperatingSystem::MACOS;
 #elif defined(_WIN32)
@@ -33,21 +42,37 @@ inline constexpr OperatingSystem kOperatingSystem = OperatingSystem::WINDOWS;
 inline constexpr OperatingSystem kOperatingSystem = OperatingSystem::LINUX;
 #endif
 
+/// True when the OpenGL backend is active.  No equivalent bools exist for
+/// Metal or Vulkan — branch on kGraphicsBackend directly for those cases.
 inline constexpr bool kIsOpenGL = kGraphicsBackend == GraphicsBackend::OPENGL;
 
+/// True when running on Linux.
 inline constexpr bool kIsLinux = kOperatingSystem == OperatingSystem::LINUX;
+/// True when running on macOS.
 inline constexpr bool kIsMacOS = kOperatingSystem == OperatingSystem::MACOS;
+/// True when running on Windows.
 inline constexpr bool kIsWindows = kOperatingSystem == OperatingSystem::WINDOWS;
 
+/// Per-backend rendering conventions bundled into a single struct so call
+/// sites can read kGfx.field instead of scattering #ifdefs everywhere.
+/// All fields are constexpr and branches on them compile away.
 struct GraphicsConventions {
-    // Net screen-vs-iso Y direction after backend-specific clip/texture transforms.
+    /// Net screen-vs-iso Y direction after backend-specific clip/texture
+    /// transforms.  OpenGL: -1 (Y grows down in screen space after flip);
+    /// Metal/Vulkan: +1.
     float screenYDirection_;
-    // GLFW reports mouse Y top-down; flip when the backend expects bottom-up screen space.
+    /// Whether to invert the GLFW mouse Y coordinate before use.  GLFW
+    /// reports Y top-down; OpenGL expects bottom-up screen space, so this
+    /// is true for OpenGL and false for Metal/Vulkan.
     bool flipMouseY_;
-    // GLM orthographic helper choice: true uses [0, 1], false uses [-1, 1].
+    /// Whether the GLM orthographic projection uses a [0, 1] depth range
+    /// (Metal/Vulkan) or [-1, 1] (OpenGL).
     bool ndcDepthZeroToOne_;
 };
 
+/// Returns the GraphicsConventions appropriate for the given backend.
+/// Used only to initialise kGfx at compile time — prefer kGfx at all
+/// call sites.
 constexpr GraphicsConventions conventionsFor(GraphicsBackend backend) {
     switch (backend) {
         case GraphicsBackend::OPENGL:
@@ -61,7 +86,14 @@ constexpr GraphicsConventions conventionsFor(GraphicsBackend backend) {
     return GraphicsConventions{-1.0f, true, false};
 }
 
+/// The active backend's rendering conventions.  This is the primary accessor
+/// for per-backend differences — use kGfx.screenYDirection_, kGfx.flipMouseY_,
+/// and kGfx.ndcDepthZeroToOne_ instead of #ifdefs.  All fields are constexpr;
+/// branching on them is optimised away per build.
 inline constexpr GraphicsConventions kGfx = conventionsFor(kGraphicsBackend);
+
+/// Screen-space sign vector for the isometric Y axis.  Multiply iso-space
+/// Y displacements by this before submitting to the renderer.
 inline constexpr IRMath::vec2 kIsoToScreenSign{1.0f, kGfx.screenYDirection_};
 
 } // namespace IRPlatform


### PR DESCRIPTION
## Summary

- All public declarations in `IRPlatform` were undocumented; this pass adds `///` comments to every one: the two enums, six compile-time constants, the `GraphicsConventions` struct and its three fields, `conventionsFor()`, `kGfx`, and `kIsoToScreenSign`.
- Folds the existing inline `//` comments on `GraphicsConventions` fields into proper `///` doc comments.
- Documents the key gotcha from `common/CLAUDE.md`: no `kIsMetal` or `kIsVulkan` bools exist — callers needing those must branch on `kGraphicsBackend` directly.
- No values or logic changed — doc-only edit.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` — build clean on `macos-debug`
- [x] 259/260 tests pass — 1 pre-existing failure: `EasingMapTest.AllFunctionsBoundaryConditions` (tracked in PR #132, unrelated)

## Notes

Companion to PR #135 (`ir_constants.hpp` doc pass). Both files in `engine/common/include/irreden/` are now fully documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)