### PR TITLE
build: sync bootstrap_linux.sh with §1a apt package list

### DIFF
--- a/scripts/bootstrap_linux.sh
+++ b/scripts/bootstrap_linux.sh
@@ -59,11 +59,13 @@ ${SUDO} apt-get install -y \
     clang-format \
     clang-tidy
 
-# If gcc-13 is not the default g++ (possible on Ubuntu 22.04), register it.
-if command -v g++-13 >/dev/null 2>&1 && ! g++ --version 2>&1 | grep -q "gcc-13\|13\."; then
+# Ensure gcc-13 is registered as a default-priority alternative for g++ and gcc.
+# Ubuntu 24.04 ships gcc-13 as the system default via build-essential, but on
+# 22.04 (or when multiple versions coexist) this pins the C++23-capable toolchain.
+if command -v g++-13 >/dev/null 2>&1; then
     ${SUDO} update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
     ${SUDO} update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
-    echo "[ok] Registered gcc-13 / g++-13 as default via update-alternatives"
+    echo "[ok] Registered gcc-13 / g++-13 as priority-100 alternative for g++/gcc"
 fi
 
 # Qt5 is optional and only used by the easy_profiler GUI. Install on a

--- a/scripts/bootstrap_linux.sh
+++ b/scripts/bootstrap_linux.sh
@@ -7,8 +7,8 @@
 #
 # The engine itself is built from source via CMake + FetchContent, so the
 # only things we install here are:
-#   - a C/C++ toolchain + cmake + ninja + pkg-config
-#   - OpenGL, X11 extensions, and libxkbcommon for GLFW
+#   - gcc-13 / g++-13 for C++23 support (cmake + ninja + pkg-config)
+#   - OpenGL, X11 extensions, libxkbcommon, and wayland-protocols for GLFW
 #   - ALSA + PulseAudio + JACK for RtAudio / RtMidi (all three are enabled
 #     by rtaudio/rtmidi autodetection whenever their dev headers are present)
 #   - FFmpeg dev libraries for IrredenEngineVideo
@@ -33,7 +33,7 @@ fi
 ${SUDO} apt-get update
 
 ${SUDO} apt-get install -y \
-    build-essential \
+    build-essential gcc-13 g++-13 \
     cmake \
     ninja-build \
     pkg-config \
@@ -48,6 +48,7 @@ ${SUDO} apt-get install -y \
     libxext-dev \
     libxkbcommon-dev \
     libwayland-dev \
+    wayland-protocols \
     libasound2-dev \
     libpulse-dev \
     libjack-jackd2-dev \
@@ -57,6 +58,13 @@ ${SUDO} apt-get install -y \
     libswscale-dev \
     clang-format \
     clang-tidy
+
+# If gcc-13 is not the default g++ (possible on Ubuntu 22.04), register it.
+if command -v g++-13 >/dev/null 2>&1 && ! g++ --version 2>&1 | grep -q "gcc-13\|13\."; then
+    ${SUDO} update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+    ${SUDO} update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
+    echo "[ok] Registered gcc-13 / g++-13 as default via update-alternatives"
+fi
 
 # Qt5 is optional and only used by the easy_profiler GUI. Install on a
 # best-effort basis so a missing package on newer Ubuntu (which renamed
@@ -77,12 +85,13 @@ verify_tool() {
 echo
 echo "Verifying toolchain..."
 verify_tool "cmake available" cmake --version
-verify_tool "g++ available" g++ --version
+verify_tool "g++ available (C++23)" g++-13 --version
 verify_tool "pkg-config finds libavcodec" pkg-config --exists libavcodec
 verify_tool "pkg-config finds alsa" pkg-config --exists alsa
 verify_tool "pkg-config finds libpulse-simple" pkg-config --exists libpulse-simple
 verify_tool "pkg-config finds jack" pkg-config --exists jack
 verify_tool "pkg-config finds gl" pkg-config --exists gl
+verify_tool "pkg-config finds wayland-protocols" pkg-config --exists wayland-protocols
 verify_tool "clang-format available" clang-format --version
 verify_tool "clang-tidy available" clang-tidy --version
 


### PR DESCRIPTION
## Summary

Mechanical fix for T-001 (Linux build maturation) — closes two gaps between `scripts/bootstrap_linux.sh` and the authoritative apt list in `docs/AGENT_FLEET_SETUP.md §1a`:

- **Add `wayland-protocols`** — GLFW 3.3.10 needs the Wayland protocol XML definitions (`wayland-scanner` reads them) to build its Wayland backend at cmake configure time. Without this package, GLFW silently falls back to X11-only, and on some distros the configure step warns or fails. `libwayland-dev` alone isn't enough.
- **Add `gcc-13 g++-13` explicitly** — the engine requires C++23 (`CMAKE_CXX_STANDARD 23`). Ubuntu 24.04 ships gcc-13 via `build-essential`, but spelling it out is defensive for non-24.04 users and matches §1a. A post-install `update-alternatives --install` block registers gcc-13 as the priority-100 alternative for `g++`/`gcc` so cmake finds the right compiler automatically.
- **Update comment header** to name the new deps (wayland-protocols, gcc-13).
- **Verify `g++-13` explicitly** in the post-install check (instead of `g++` which could resolve to an older compiler), and add a `wayland-protocols` pkg-config check to the verification pass.

## Test plan

- [ ] On a fresh Ubuntu 24.04 WSL2 instance, run `scripts/bootstrap_linux.sh` — should complete without errors and print `[ok]` for all verifications including `wayland-protocols`
- [ ] Run `cmake --preset linux-debug` — GLFW Wayland backend should configure without missing-protocol warnings
- [ ] `fleet-build --target IRShapeDebug` builds successfully

*Note: linux-debug build verification requires a WSL2/Linux host. This PR is the mechanical bootstrap fix; runtime verification is tracked under T-001.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)