### PR TITLE
docs(math): /// comments for easing, color-sort, and physics helpers

### DIFF
--- a/engine/math/include/irreden/math/color.hpp
+++ b/engine/math/include/irreden/math/color.hpp
@@ -8,6 +8,7 @@
 
 namespace IRMath {
 
+/// Returns @p colors sorted by HSV hue, ascending (red → yellow → green → … → red).
 inline std::vector<Color> sortByHue(std::vector<Color> colors) {
     std::sort(colors.begin(), colors.end(), [](const Color &a, const Color &b) {
         vec3 ha = glm::hsvColor(vec3(a.red_ / 255.0f, a.green_ / 255.0f, a.blue_ / 255.0f));
@@ -17,6 +18,7 @@ inline std::vector<Color> sortByHue(std::vector<Color> colors) {
     return colors;
 }
 
+/// Returns @p colors sorted by HSV saturation, ascending (grey → vivid).
 inline std::vector<Color> sortBySaturation(std::vector<Color> colors) {
     std::sort(colors.begin(), colors.end(), [](const Color &a, const Color &b) {
         vec3 ha = glm::hsvColor(vec3(a.red_ / 255.0f, a.green_ / 255.0f, a.blue_ / 255.0f));
@@ -26,6 +28,7 @@ inline std::vector<Color> sortBySaturation(std::vector<Color> colors) {
     return colors;
 }
 
+/// Returns @p colors sorted by HSV value (brightness), ascending (dark → bright).
 inline std::vector<Color> sortByValue(std::vector<Color> colors) {
     std::sort(colors.begin(), colors.end(), [](const Color &a, const Color &b) {
         vec3 ha = glm::hsvColor(vec3(a.red_ / 255.0f, a.green_ / 255.0f, a.blue_ / 255.0f));
@@ -35,6 +38,8 @@ inline std::vector<Color> sortByValue(std::vector<Color> colors) {
     return colors;
 }
 
+/// Returns @p colors sorted by perceptual luminance, ascending (dark → bright).
+/// Luminance formula: `0.299r + 0.587g + 0.114b` (BT.601 luma coefficients).
 inline std::vector<Color> sortByLuminance(std::vector<Color> colors) {
     std::sort(colors.begin(), colors.end(), [](const Color &a, const Color &b) {
         float la = 0.299f * a.red_ + 0.587f * a.green_ + 0.114f * a.blue_;

--- a/engine/math/include/irreden/math/easing_functions.hpp
+++ b/engine/math/include/irreden/math/easing_functions.hpp
@@ -9,6 +9,10 @@
 
 namespace IRMath {
 
+/// Identifies an easing curve backed by `glm/gtx/easing.hpp`.
+/// Not every GLM easing overload is exposed — some variants (e.g. back-ease
+/// overshoot parameters) are pre-configured with engine defaults in
+/// @ref kEasingFunctions.
 enum IREasingFunctions {
     kLinearInterpolation,
     kQuadraticEaseIn,
@@ -43,12 +47,14 @@ enum IREasingFunctions {
     kBounceEaseInOut
 };
 
+/// Callable type for a single-argument easing function: `float f(float t)`
+/// where `t ∈ [0, 1]` and the return value is typically in [0, 1] (some
+/// curves like elastic and back overshoot this range).
 using GLMEasingFunction = std::function<float(const float &)>;
-// using GLMEasingFunction = float (*)(float);
 
-// const std::unordered_map<IREasingFunctions, GLMEasingFunction> kEasingFunctions = {
-//     {kLinearInterpolation, glm::linearInterpolation<float>}
-// };
+/// Dispatch table mapping each @ref IREasingFunctions variant to its
+/// GLM-backed implementation.  Back-ease variants use engine-default
+/// overshoot factors rather than raw GLM defaults.
 const std::unordered_map<IREasingFunctions, GLMEasingFunction> kEasingFunctions = {
     {kLinearInterpolation, glm::linearInterpolation<float>},
     {kQuadraticEaseIn, glm::quadraticEaseIn<float>},

--- a/engine/math/include/irreden/math/physics.hpp
+++ b/engine/math/include/irreden/math/physics.hpp
@@ -5,30 +5,37 @@
 
 namespace IRMath {
 
-// Upward impulse speed for a symmetric ballistic arc reaching height h
-// under constant gravity g.
+/// Upward impulse speed (in units/s) required for a symmetric ballistic arc
+/// reaching @p height under constant gravity @p gravity.
+/// Formula: `sqrt(2 * g * h)`.
 inline float impulseForHeight(float gravity, float height) {
     return std::sqrt(2.0f * gravity * height);
 }
 
-// Total flight time (up + down) for a symmetric arc under gravity g
-// reaching height h.
+/// Total flight time (up + down) for a symmetric arc under constant gravity
+/// @p gravity reaching @p height.
+/// Formula: `2 * sqrt(2h / g)`.
 inline float flightTimeForHeight(float gravity, float height) {
     return 2.0f * std::sqrt(2.0f * height / gravity);
 }
 
-// Height reached by a given impulse speed under gravity g.
+/// Peak height reached by an object launched at @p impulseSpeed under
+/// constant gravity @p gravity.
+/// Formula: `v² / (2g)`.
 constexpr float heightForImpulse(float gravity, float impulseSpeed) {
     return (impulseSpeed * impulseSpeed) / (2.0f * gravity);
 }
 
-// Max position displacement in a single frame at a given velocity.
+/// Maximum position displacement in one frame: `velocity * dt`.
+/// Used as the reference distance for tunneling checks.
 constexpr float maxFrameDisplacement(float velocity, float dt) {
     return velocity * dt;
 }
 
-// Whether the combined collider thickness is sufficient to prevent
-// tunneling at the given max velocity and timestep.
+/// Returns `true` when the combined thickness of two colliders is large
+/// enough that a body moving at @p maxVelocity cannot pass through both in
+/// a single timestep @p dt.
+/// Check: `maxVelocity * dt < colliderThicknessA + colliderThicknessB`.
 constexpr bool isTunnelingSafe(
     float maxVelocity,
     float dt,


### PR DESCRIPTION
## Summary

- `easing_functions.hpp`: `///` on `IREasingFunctions` enum (notes it is not 1:1 with GLM), `GLMEasingFunction` type alias, and `kEasingFunctions` dispatch table (notes pre-configured overshoot for back-ease variants).
- `color.hpp`: `///` on all four sort functions with sort direction and formula references (BT.601 luma for `sortByLuminance`).
- `physics.hpp`: promoted `//` block comments to `///` and added closed-form formulas for impulse, flight time, peak height, max displacement, and tunneling check.

Continues the documentation pass series from PRs #135, #136, and #138.

**Pre-existing failure:** `EasingMapTest.AllFunctionsBoundaryConditions` fails on master before any changes in this PR — unrelated `exponentialEaseInOut` boundary-guard issue; fix is in PR #132.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` builds clean
- [x] `./IrredenEngineTest` — 259/260 pass; 1 pre-existing failure unrelated to this change