### PR TITLE
docs(input): /// comments for ir_input_types.hpp and ir_input.hpp

### DIFF
--- a/engine/input/include/irreden/input/ir_input_types.hpp
+++ b/engine/input/include/irreden/input/ir_input_types.hpp
@@ -9,23 +9,39 @@
 #include <cstdint>
 
 namespace IRInput {
+/// Physical device categories that can produce input events.
 enum InputDevices { kKeyboard, kGamepad, kMouse, kMidi };
 
+/// Per-button state machine tracked by `InputManager`.
+/// Transitions each pipeline event via `advanceInputState(event)`:
+/// ```
+/// NOT_HELD → (press)                → PRESSED
+/// PRESSED  → (held next frame)      → HELD
+/// HELD     → (release)              → RELEASED
+/// RELEASED → (idle next frame)      → NOT_HELD
+/// PRESSED  → (release in same frame)→ PRESSED_AND_RELEASED
+/// ```
 enum ButtonStatuses { NOT_HELD, PRESSED, HELD, RELEASED, PRESSED_AND_RELEASED };
 
+/// Categories of input source used when registering commands.
 enum InputTypes { KEY_MOUSE, GAMEPAD, MIDI_NOTE, MIDI_CC };
 
+/// Bitmask type for Shift/Ctrl/Alt modifier state.
 using KeyModifierMask = uint8_t;
+/// No modifiers held.
 constexpr KeyModifierMask kModifierNone = 0;
+/// Shift is held.
 constexpr KeyModifierMask kModifierShift = 1 << 0;
+/// Control is held.
 constexpr KeyModifierMask kModifierControl = 1 << 1;
+/// Alt is held.
 constexpr KeyModifierMask kModifierAlt = 1 << 2;
 
+/// MIDI output event types (note-on / note-off) for MIDI-out commands.
 enum OutputTypes { kMidiOutNotePressed, kMidiOutNoteReleased };
 
-// Key mouse buttons would be another good place to use
-// entity parent child relationships. Each key can be an
-// entity, and could have a parent keyboard controller, etc...
+/// Unified keyboard + mouse button identifiers.
+/// Mapped from GLFW key/button codes via @ref kMapGLFWtoIRKeyMouseButtons.
 enum KeyMouseButtons {
     kNullButton = 0,
     kKeyButtonMinus,
@@ -157,6 +173,9 @@ enum KeyMouseButtons {
     kNumKeyMouseButtons
 };
 
+/// Gamepad button identifiers (Xbox-style layout).
+/// Mapped from GLFW gamepad button codes via @ref kGLFWtoGamepadButtons.
+/// Only gamepad 0 is polled; multi-gamepad support requires engine changes.
 enum GamepadButtons {
     kGamepadButtonA,
     kGamepadButtonB,
@@ -177,6 +196,8 @@ enum GamepadButtons {
     kNumGamepadButtons
 };
 
+/// Gamepad analogue axis identifiers (left/right stick + triggers).
+/// Mapped from GLFW gamepad axis codes via @ref kGLFWtoGamepadAxes.
 enum GamepadAxes {
     kGamepadAxisLeftX,
     kGamepadAxisLeftY,
@@ -188,6 +209,8 @@ enum GamepadAxes {
     kNumGamepadAxes
 };
 
+/// Translates raw GLFW key/mouse-button codes to engine @ref KeyMouseButtons values.
+/// Used by the GLFW key and mouse-button callbacks inside `InputManager`.
 const std::unordered_map<int, KeyMouseButtons> kMapGLFWtoIRKeyMouseButtons = {
     // Key
     {GLFW_KEY_UNKNOWN, kNullButton},
@@ -319,6 +342,7 @@ const std::unordered_map<int, KeyMouseButtons> kMapGLFWtoIRKeyMouseButtons = {
     {GLFW_MOUSE_BUTTON_MIDDLE, kMouseButtonMiddle}
 };
 
+/// Translates raw GLFW gamepad button indices to engine @ref GamepadButtons values.
 const std::unordered_map<int, GamepadButtons> kGLFWtoGamepadButtons = {
     {GLFW_GAMEPAD_BUTTON_A, kGamepadButtonA},
     {GLFW_GAMEPAD_BUTTON_B, kGamepadButtonB},
@@ -337,6 +361,7 @@ const std::unordered_map<int, GamepadButtons> kGLFWtoGamepadButtons = {
     {GLFW_GAMEPAD_BUTTON_DPAD_LEFT, kGamepadButtonDPadLeft}
 };
 
+/// Translates raw GLFW gamepad axis indices to engine @ref GamepadAxes values.
 const std::unordered_map<int, GamepadAxes> kGLFWtoGamepadAxes = {
     {GLFW_GAMEPAD_AXIS_LEFT_X, kGamepadAxisLeftX},
     {GLFW_GAMEPAD_AXIS_LEFT_Y, kGamepadAxisLeftY},

--- a/engine/input/include/irreden/ir_input.hpp
+++ b/engine/input/include/irreden/ir_input.hpp
@@ -8,21 +8,32 @@
 
 namespace IRInput {
 
+/// Global pointer to the active `InputManager`; managed by the engine runtime.
+/// Prefer @ref getInputManager() for safe access.
 extern InputManager *g_inputManager;
+/// Returns a reference to the active `InputManager`. Asserts if not initialised.
 InputManager &getInputManager();
 
+/// Returns `true` if @p button is currently in @p buttonStatus this frame.
+/// Queries the snapshot for the current pipeline event (INPUT / UPDATE / RENDER).
 bool checkKeyMouseButton(KeyMouseButtons button, ButtonStatuses buttonStatus);
+/// Returns `true` when all bits in @p requiredModifiers are set and none of the
+/// bits in @p blockedModifiers are set in the current modifier state.
 bool checkKeyMouseModifiers(
     KeyModifierMask requiredModifiers, KeyModifierMask blockedModifiers = kModifierNone
 );
 
+/// Cursor position in iso/world space for the current pipeline event's snapshot.
 IRMath::vec2 getMousePosition();
+/// Cursor position in screen (pixel) space for the current pipeline event's snapshot.
 IRMath::vec2 getMousePositionScreen();
 
-// Internal use for key mouse input system
+/// @name Internal input counters (used by input systems, not for general use)
+/// @{
 int getNumButtonPressesThisFrame(KeyMouseButtons button);
 int getNumButtonReleasesThisFrame(KeyMouseButtons button);
 bool hasAnyButtonPressedThisFrame();
+/// @}
 } // namespace IRInput
 
 #endif /* IR_INPUT_H */


### PR DESCRIPTION
## Summary

- `ir_input_types.hpp`: `///` on all public declarations — `InputDevices`, `ButtonStatuses` (includes full state-machine diagram from `CLAUDE.md`), `InputTypes`, `KeyModifierMask` type alias + three bitmask constants, `OutputTypes`; enum-level group docs on `KeyMouseButtons`, `GamepadButtons`, `GamepadAxes`; comments on the three GLFW-to-engine mapping tables.
- `ir_input.hpp`: `///` on `g_inputManager`, `getInputManager`, `checkKeyMouseButton`, `checkKeyMouseModifiers`, `getMousePosition`, `getMousePositionScreen`; grouped internal counter helpers under a `@{`/`@}` Doxygen group.

Continues the documentation pass series (PRs #135, #136, #138, #139).

**Pre-existing failure:** `EasingMapTest.AllFunctionsBoundaryConditions` fails on master before any changes in this PR — fix is in PR #132.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` builds clean
- [x] All TUs that include `ir_input_types.hpp` recompiled without warnings