### PR TITLE
docs(command): /// comments for ir_command_types.hpp and ir_command.hpp

### DIFF
--- a/engine/command/include/irreden/command/ir_command_types.hpp
+++ b/engine/command/include/irreden/command/ir_command_types.hpp
@@ -5,8 +5,12 @@
 
 namespace IRCommand {
 
+/// Opaque handle returned by `createCommand`; identifies a registered binding.
 using CommandId = std::uint32_t;
 
+/// All engine-level command identifiers.
+/// Every prefab command must have an entry here **before** implementing the
+/// `Command<NAME>` specialisation — missing entries cause linker errors.
 enum CommandNames {
     NULL_COMMAND,
     EXAMPLE,
@@ -47,8 +51,12 @@ enum CommandNames {
 
 };
 
+/// Type-tag struct; specialised per command to provide a `create()` factory
+/// that returns the `std::function<void()>` for that command.
 template <CommandNames command> struct Command;
 
+/// Internal binding category used by `CommandManager` to route events to the
+/// right registry (button, MIDI note, or MIDI CC).
 enum CommandTypes { IR_COMMAND_NULL, COMMAND_BUTTON, COMMAND_MIDI_NOTE, COMMAND_MIDI_CC };
 
 } // namespace IRCommand

--- a/engine/command/include/irreden/ir_command.hpp
+++ b/engine/command/include/irreden/ir_command.hpp
@@ -10,9 +10,14 @@
 
 namespace IRCommand {
 
+/// Global pointer to the active `CommandManager`; managed by the engine runtime.
+/// Prefer @ref getCommandManager() for safe access.
 extern CommandManager *g_commandManager;
+/// Returns a reference to the active `CommandManager`. Asserts if not initialised.
 CommandManager &getCommandManager();
 
+/// Returns a short human-readable label for @p name (e.g. "ZOOM IN").
+/// Used by the debug overlay and `buildCommandListText()`.
 inline std::string commandNameToString(CommandNames name) {
     switch (name) {
     case ZOOM_IN:                   return "ZOOM IN";
@@ -44,6 +49,8 @@ inline std::string commandNameToString(CommandNames name) {
     }
 }
 
+/// Returns a short display name for a @ref IRInput::KeyMouseButtons value
+/// (e.g. "A", "ENTER", "MOUSE L"). Used in the debug help overlay.
 inline std::string keyButtonToString(int button) {
     using namespace IRInput;
     switch (button) {
@@ -115,6 +122,8 @@ inline std::string keyButtonToString(int button) {
     }
 }
 
+/// Formats an @ref IRInput::KeyModifierMask as a prefix string (e.g. "SHIFT+CTRL+").
+/// Empty string if no modifiers are set.
 inline std::string modifierString(IRInput::KeyModifierMask mods) {
     std::string result;
     if (mods & IRInput::kModifierShift) result += "SHIFT+";
@@ -123,6 +132,9 @@ inline std::string modifierString(IRInput::KeyModifierMask mods) {
     return result;
 }
 
+/// Builds a multi-line human-readable list of all registered `PRESSED` commands
+/// with their modifier + key bindings. Used by the in-game debug help overlay.
+/// Only `PRESSED`-status bindings appear; `HELD`/`RELEASED` bindings are excluded.
 inline std::string buildCommandListText() {
     const auto &regs = getCommandManager().getCommandRegistrations();
     std::string text = "COMMANDS\n";
@@ -136,6 +148,14 @@ inline std::string buildCommandListText() {
     return text;
 }
 
+/// Registers an ad-hoc command from a callable (lambda or functor).
+/// @param inputType    Device class (KEY_MOUSE / GAMEPAD / MIDI_NOTE / MIDI_CC).
+/// @param triggerStatus Button state that fires the command (PRESSED, HELD, …).
+/// @param button       Raw button/key/note identifier.
+/// @param command      The callable to invoke on trigger; `void()` signature.
+/// @param requiredModifiers Modifier bits that must be active (KEY_MOUSE only).
+/// @param blockedModifiers  Modifier bits that must be inactive (KEY_MOUSE only).
+/// @return A `CommandId` handle for the binding.
 template <typename Function>
 int createCommand(
     IRInput::InputTypes inputType,
@@ -155,6 +175,9 @@ int createCommand(
     );
 }
 
+/// Registers a named engine command using its `Command<NAME>::create()` factory.
+/// The enum value doubles as the identifier; the display name is derived from
+/// @ref commandNameToString and appears in the debug help overlay.
 template <CommandNames commandName>
 CommandId createCommand(
     IRInput::InputTypes inputType,


### PR DESCRIPTION
## Summary

- `ir_command_types.hpp`: `///` on `CommandId` type alias; `CommandNames` enum (notes the linker-error footgun: must add enum entry before implementing `Command<NAME>`); `Command<>` template struct; `CommandTypes` enum.
- `ir_command.hpp`: `///` on `g_commandManager`, `getCommandManager`, `commandNameToString`, `keyButtonToString`, `modifierString`, `buildCommandListText` (notes `HELD`/`RELEASED` bindings are excluded from the overlay); `@param`/`@return` docs on both `createCommand` overloads.

Continues the documentation pass series (PRs #135, #136, #138, #139, #140).

**Pre-existing failure:** `EasingMapTest.AllFunctionsBoundaryConditions` fails on master before any changes in this PR — fix is in PR #132.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` builds clean; command module TUs recompiled
- [x] 259/260 tests pass; 1 pre-existing failure unrelated to this change