### PR TITLE
docs(window): /// comments for ir_window.hpp and ir_glfw_window.hpp

### DIFF
--- a/engine/window/include/irreden/ir_window.hpp
+++ b/engine/window/include/irreden/ir_window.hpp
@@ -3,12 +3,21 @@
 
 namespace IRWindow {
 
+/// Global pointer to the active GLFW window; managed by the engine runtime.
+/// Prefer @ref getWindow() for safe access.
 extern IRGLFWWindow *g_irglfwWindow;
+/// Returns a reference to the active window. Asserts if not initialised.
 IRGLFWWindow &getWindow();
 
+/// Signals the window to close on the next `World::gameLoop()` iteration.
 void closeWindow();
+/// Writes the current window size in logical pixels to @p size.
+/// Use @ref getFramebufferSize when you need the actual render target dimensions.
 void getWindowSize(IRMath::ivec2 &size);
+/// Writes the framebuffer dimensions in physical pixels to @p size.
+/// Under HiDPI / scaling this is larger than the logical window size.
 void getFramebufferSize(IRMath::ivec2 &size);
+/// Writes the raw GLFW cursor position in window-space pixels to @p pos.
 void getCursorPosition(IRMath::dvec2 &pos);
 
 } // namespace IRWindow

--- a/engine/window/include/irreden/window/ir_glfw_window.hpp
+++ b/engine/window/include/irreden/window/ir_glfw_window.hpp
@@ -16,6 +16,7 @@ using namespace IRMath;
 
 namespace IRWindow {
 
+/// Describes a connected GLFW joystick / gamepad device.
 struct IRGLFWJoystickInfo {
     int joystickId_;
     std::string joystickName_;
@@ -27,10 +28,12 @@ struct IRGLFWJoystickInfo {
         , isGamepad_{isGamepad} {}
 };
 
+/// GLFW window hints for Metal / Vulkan backends (no GL context).
 inline constexpr std::pair<int, int> kNoApiWindowHints[] = {
     {GLFW_CLIENT_API, GLFW_NO_API},
 };
 
+/// GLFW window hints for OpenGL 4.6 core profile with double-buffering.
 inline constexpr std::pair<int, int> kOpenGLWindowHints[] = {
     {GLFW_CONTEXT_VERSION_MAJOR, 4},
     {GLFW_CONTEXT_VERSION_MINOR, 6},
@@ -39,10 +42,12 @@ inline constexpr std::pair<int, int> kOpenGLWindowHints[] = {
 };
 
 // These checks gate GLFW/OpenGL setup, not shared renderer conventions.
+/// Number of GLFW hints active for the current backend.
 inline constexpr int kNumWindowHints = IRPlatform::kIsOpenGL
     ? static_cast<int>(sizeof(kOpenGLWindowHints) / sizeof(kOpenGLWindowHints[0]))
     : static_cast<int>(sizeof(kNoApiWindowHints) / sizeof(kNoApiWindowHints[0]));
 
+/// Returns the GLFW hint at @p index for the current backend.
 inline const std::pair<int, int> &getWindowHint(int index) {
     if constexpr (IRPlatform::kIsOpenGL) {
         return kOpenGLWindowHints[index];
@@ -51,44 +56,68 @@ inline const std::pair<int, int> &getWindowHint(int index) {
     }
 }
 
+/// Owns the GLFW window, the GL context (OpenGL builds), fullscreen state,
+/// and the per-frame event queues that `InputManager` drains each frame.
 class IRGLFWWindow {
   public:
     IRGLFWWindow(ivec2 initWindowSize, bool fullscreen, int monitorIndex, std::string monitorName);
     ~IRGLFWWindow();
 
+    /// Logical window size in screen coordinates (may differ from framebuffer under HiDPI).
     void getWindowSize(int &width, int &height);
+    /// Physical framebuffer size in pixels — use this for viewport and render-target sizing.
     void getFramebufferSize(int &width, int &height);
+    /// Raw GLFW cursor position in window-space pixels.
     void getCursorPosition(double &posX, double &posY);
+    /// Raw GLFW key status (`GLFW_PRESS`, `GLFW_RELEASE`, `GLFW_REPEAT`).
     int getKeyStatus(int key);
+    /// Raw GLFW mouse-button status.
     int getMouseButtonStatus(int button);
+    /// Full GLFW gamepad state snapshot for @p gamepad (axes + buttons).
     GLFWgamepadstate getGamepadState(int gamepad);
 
+    /// Returns `GLFW_TRUE` if @p joystick is connected.
     int joystickPresent(int joystick);
+    /// Human-readable name of the connected joystick.
     std::string getJoystickName(int joystick);
+    /// Returns `true` if @p joystick has a known gamepad mapping.
     bool joystickIsGamepad(int joystick);
 
+    /// Returns non-zero if GLFW has flagged the window for closing.
     int shouldClose();
+    /// Flags the window for closing on the next `gameLoop()` iteration.
     void setShouldClose();
     void setWindowMonitor();
     void setWindowUserPointer(void *pointer);
+    /// Returns the raw `GLFWwindow*` for operations not wrapped by this class.
     GLFWwindow *getRawWindow() const;
 
+    /// Swaps front/back buffers; called by `World::gameLoop()` after each render frame.
     void swapBuffers();
+    /// Pumps the GLFW event queue; must be called once per frame.
     void pollEvents();
 
+    /// @name GLFW callback registration (called during engine init)
+    /// @{
     void setCallbackError(GLFWerrorfun callbackFunction);
     void setCallbackFramebufferSize(GLFWframebuffersizefun callbackFunction);
     void setCallbackKey(GLFWkeyfun callbackFunction);
     void setCallbackMouseButton(GLFWmousebuttonfun callbackFunction);
     void setCallbackScroll(GLFWscrollfun callbackFunction);
     void setWindowIcon(const GLFWimage *image) const;
+    /// @}
 
+    /// @name Event-queue enqueue helpers (called by GLFW callbacks)
+    /// @{
     void addKeyPressedToProcess(int key);
     void addKeyReleasedToProcess(int key);
     void addMouseButtonPressedToProcess(int button);
     void addMouseButtonReleasedToProcess(int button);
     void addScrollToProcess(double xoffset, double yoffset);
+    /// @}
 
+    /// @name Event-queue drain accessors (called by InputManager each frame)
+    /// @{
     inline std::queue<int> &getKeysPressedToProcess() {
         return m_keysPressedToProcess;
     }
@@ -104,6 +133,7 @@ class IRGLFWWindow {
     inline std::queue<std::pair<double, double>> &getScrollsToProcess() {
         return m_scrollsToProcess;
     }
+    /// @}
 
   private:
     GLFWwindow *m_window;
@@ -119,9 +149,13 @@ class IRGLFWWindow {
     std::queue<std::pair<double, double>> m_scrollsToProcess;
 };
 
+/// GLFW error callback — logs the error message.
 void irglfwCallback_error(int error, const char *msg);
+/// GLFW key callback — enqueues key press/release events via `g_irglfwWindow`.
 void irglfwCallback_key(GLFWwindow *window, int key, int scancode, int action, int mods);
+/// GLFW mouse-button callback — enqueues button press/release events.
 void irglfwCallback_mouseButton(GLFWwindow *window, int button, int action, int mods);
+/// GLFW scroll callback — enqueues scroll delta events.
 void irglfwCallback_scroll(GLFWwindow *window, double xoffset, double yoffset);
 
 } // namespace IRWindow


### PR DESCRIPTION
## Summary

- `ir_window.hpp`: `///` on `g_irglfwWindow`, `getWindow`, `closeWindow`, `getWindowSize` (notes logical vs. framebuffer size distinction), `getFramebufferSize` (notes HiDPI caveat), `getCursorPosition`.
- `ir_glfw_window.hpp`: `///` on `IRGLFWJoystickInfo`; window-hint constant arrays and `getWindowHint`; class-level doc on `IRGLFWWindow` (owns window, GL context, event queues); public methods grouped into three `@{`/`@}` Doxygen groups (callback registration, event-enqueue helpers, event-drain accessors); four module-scope GLFW callback functions.

Continues the documentation pass series (PRs #135, #136, #138–#141).

**Pre-existing failure:** `EasingMapTest.AllFunctionsBoundaryConditions` fails on master before any changes in this PR — fix is in PR #132.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` builds clean; window/render TUs recompiled
- [x] 259/260 tests pass; 1 pre-existing failure unrelated to this change