### PR TITLE
docs(script): /// comments for Lua binding/config headers

### DIFF
--- a/engine/script/include/irreden/script/ir_script_types.hpp
+++ b/engine/script/include/irreden/script/ir_script_types.hpp
@@ -4,6 +4,9 @@
 
 namespace IRScript {
 
+/// Discriminant tag for typed Lua configuration values (@ref LuaValue).
+/// `INTEGER` is an engine extension — Lua integers are a subtype of `number`;
+/// the engine exposes them as a distinct type for clarity.
 enum LuaType {
     NIL,
     BOOLEAN,
@@ -17,6 +20,8 @@ enum LuaType {
     TABLE
 };
 
+/// Thin wrapper around an `EntityId` for passing entities across the Lua/C++ boundary.
+/// sol2 registers this type so Lua scripts can receive and hold entity handles.
 struct LuaEntity {
     IREntity::EntityId entity;
 
@@ -27,9 +32,12 @@ struct LuaEntity {
         : entity{0} {}
 };
 
+/// Callable type that constructs a single component from entity-creation parameters.
 template <typename Component>
 using ComponentFunction = std::function<Component(IREntity::CreateEntityCallbackParams)>;
 
+/// Callable type that spawns a batch of entities given per-component factory functions.
+/// Limited to up to 12 component types (hardcoded in the batch-create binding).
 template <typename... Components>
 using EntityBatchFunction = std::function<std::vector<LuaEntity>(ComponentFunction<Components>...)>;
 

--- a/engine/script/include/irreden/script/lua_binding_traits.hpp
+++ b/engine/script/include/irreden/script/lua_binding_traits.hpp
@@ -3,7 +3,15 @@
 namespace IRScript {
 class LuaScript;
 
+/// Trait that gates whether a component type has a Lua binding.
+/// Defaults to `false`.  A sibling `component_<name>_lua.hpp` file
+/// specialises this to `true` and provides a `bindLuaType<T>` definition.
+/// Without that file, `LuaScript::registerTypeFromTraits<T>()` will fail to
+/// compile (static_assert) rather than fail at runtime.
 template <typename T> inline constexpr bool kHasLuaBinding = false;
 
+/// Registers the Lua usertype for @p T on @p script.
+/// Must be specialised by `component_<name>_lua.hpp` alongside the
+/// `kHasLuaBinding<T> = true` specialisation.
 template <typename T> void bindLuaType(LuaScript &);
 } // namespace IRScript

--- a/engine/script/include/irreden/script/lua_config.hpp
+++ b/engine/script/include/irreden/script/lua_config.hpp
@@ -7,6 +7,8 @@
 
 namespace IRScript {
 
+/// A single named entry in a `LuaConfig`: maps a Lua field name to a typed
+/// `ILuaValue` that owns the stored value and its default.
 struct LuaConfigEntry {
     std::string luaName;
     std::unique_ptr<ILuaValue> value;
@@ -16,15 +18,21 @@ struct LuaConfigEntry {
         , value(std::move(val)) {}
 };
 
+/// String-keyed collection of typed Lua configuration values.
+/// Populate with `addEntry()`, then call `parse(luaTable)` to populate all
+/// values from a `sol::table`; missing keys fall back to their defaults.
+/// Use `operator[]` to retrieve individual values after parsing.
 class LuaConfig {
   public:
     std::map<std::string, std::unique_ptr<ILuaValue>> entries;
 
+    /// Adds or replaces the entry for @p luaName with the given typed value.
     void addEntry(const std::string &luaName, std::unique_ptr<ILuaValue> value) {
         entries[luaName] = std::move(value);
     }
 
-    // Parse the Lua table
+    /// Parses all registered entries from @p luaTable, falling back to each
+    /// entry's default when a key is absent.
     void parse(sol::table luaTable) {
         for (auto &entry : entries) {
             sol::object luaValue = luaTable[entry.first];
@@ -36,6 +44,7 @@ class LuaConfig {
         }
     }
 
+    /// Returns a reference to the value for @p key.  Throws if the key is absent.
     ILuaValue &operator[](const std::string &key) {
         auto it = entries.find(key);
         if (it != entries.end()) {

--- a/engine/script/include/irreden/script/lua_value.hpp
+++ b/engine/script/include/irreden/script/lua_value.hpp
@@ -13,10 +13,16 @@
 
 namespace IRScript {
 
+/// Abstract base for a typed, resettable Lua configuration value.
+/// Concrete subtypes are `LuaValue<Type>` specialisations.  Each specialisation
+/// overrides the matching `get_*()` accessor; calling a mismatched accessor
+/// asserts and throws.
 struct ILuaValue {
     virtual ~ILuaValue() = default;
 
+    /// Reads the value from @p obj (a `sol::object`).  Asserts on type mismatch.
     virtual void parse(const sol::object &obj) = 0;
+    /// Resets the stored value to the default supplied at construction time.
     virtual void reset_to_default() = 0;
 
     virtual ILuaValue &operator[](const std::string &key) {
@@ -46,8 +52,10 @@ struct ILuaValue {
     }
 };
 
+/// Concrete typed Lua configuration value.  Specialised for each @ref LuaType.
 template <LuaType Type, typename EnumType = void> struct LuaValue;
 
+/// Boolean configuration value; `get_boolean()` returns the stored bool.
 template <> struct LuaValue<LuaType::BOOLEAN> : ILuaValue {
     bool value_;
     bool defaultValue_;
@@ -70,6 +78,7 @@ template <> struct LuaValue<LuaType::BOOLEAN> : ILuaValue {
     }
 };
 
+/// Floating-point (double) configuration value; `get_number()` returns the stored double.
 template <> struct LuaValue<IRScript::LuaType::NUMBER> : ILuaValue {
     double value_;
     double defaultValue_;
@@ -92,6 +101,8 @@ template <> struct LuaValue<IRScript::LuaType::NUMBER> : ILuaValue {
     }
 };
 
+/// Integer configuration value (engine-defined sub-type of Lua number).
+/// `get_integer()` returns the stored `int`.
 template <> struct LuaValue<LuaType::INTEGER> : ILuaValue {
     int value_;
     int defaultValue_;
@@ -114,6 +125,7 @@ template <> struct LuaValue<LuaType::INTEGER> : ILuaValue {
     }
 };
 
+/// String configuration value; `get_string()` returns the stored `std::string`.
 template <> struct LuaValue<LuaType::STRING> : ILuaValue {
     std::string value_;
     std::string defaultValue_;
@@ -136,6 +148,9 @@ template <> struct LuaValue<LuaType::STRING> : ILuaValue {
     }
 };
 
+/// Enum configuration value.  Accepts either an integer or a string from Lua;
+/// strings are mapped to the enum via a caller-supplied `stringToEnum_` function.
+/// `get_enum_value()` returns the typed enum; `get_enum()` returns it as `int`.
 template <typename EnumType> struct LuaValue<LuaType::ENUM, EnumType> : ILuaValue {
     using EnumMappingFunction = std::function<EnumType(const std::string &)>;
 
@@ -171,6 +186,10 @@ template <typename EnumType> struct LuaValue<LuaType::ENUM, EnumType> : ILuaValu
     }
 };
 
+/// Nested-table configuration value.  Stores a string-keyed map of child
+/// `ILuaValue` entries; `operator[]` retrieves children by key.
+/// On `parse()`, each child parses its own sub-field from the Lua table,
+/// falling back to its default if the key is absent.
 template <> struct LuaValue<LuaType::TABLE> : ILuaValue {
     std::map<std::string, std::unique_ptr<ILuaValue>> value_;
 


### PR DESCRIPTION
## Summary

- `lua_binding_traits.hpp`: `///` on `kHasLuaBinding<T>` (defaults false, notes the `static_assert` compile-time enforcement) and `bindLuaType<T>()`.
- `ir_script_types.hpp`: `///` on `LuaType` enum (notes `INTEGER` is an engine extension), `LuaEntity` struct, `ComponentFunction`, `EntityBatchFunction` (notes 12-component batch limit).
- `lua_value.hpp`: `///` on `ILuaValue` abstract base (type-erased parse/reset protocol); `LuaValue<>` template; all six specialisations — `BOOLEAN`, `NUMBER`, `INTEGER`, `STRING`, `ENUM` (notes the `stringToEnum_` function requirement), `TABLE` (notes child-map structure and fallback-to-default on missing keys).
- `lua_config.hpp`: `///` on `LuaConfigEntry`, `LuaConfig`, `addEntry()`, `parse()`, `operator[]`.

Continues the documentation pass series (PRs #135, #136, #138–#142).

**Pre-existing failure:** `EasingMapTest.AllFunctionsBoundaryConditions` fails on master — fix is in PR #132.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` builds clean
- [x] 259/260 tests pass; 1 pre-existing failure unrelated to this change