### PR TITLE
fleet: fix review-pr skill to use --body-file instead of --body

### DIFF
--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -91,7 +91,11 @@ usage limit. Each iteration:
       this engine worktree). Focus on code quality, style, and obvious
       bugs. For game-specific conventions, read the game CLAUDE.md at
       `~/src/IrredenEngine/creations/game/CLAUDE.md`.
-   d. Post the review: `gh pr review <N> --repo <game-repo> --comment --body "<review>"`
+   d. Post the review: write the review body to `/tmp/review-body.md`
+      using the **Write tool**, then:
+      `gh pr review <N> --repo <game-repo> --comment --body-file /tmp/review-body.md`
+      **Never** use `--body "$(cat ...)"` or `--body "<text>"` — shell
+      escaping of backticks and special characters causes parse errors.
    e. Set labels — always remove stale labels first:
       `gh pr edit <N> --repo <game-repo> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
       (swap the add-label name for `fleet:needs-fix` or `fleet:blocker` as appropriate).

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -191,10 +191,16 @@ compliance or raise an issue.
 
 ### 5. Write the review
 
-Post the review as a PR comment via `gh pr review`:
+Post the review as a PR comment via `gh pr review`. **Do NOT use
+`--body "$(cat <<'EOF'...)"` or any `$(...)` command substitution** —
+it triggers Claude Code's `command_substitution` security gate and
+causes parse errors when the body contains backticks or special
+characters. Instead, write the body to a temp file with the **Write
+tool**, then pass it with `--body-file`:
 
-```bash
-gh pr review <N> --comment --body "$(cat <<'EOF'
+1. Use the **Write tool** to write the review body to `/tmp/review-body.md`:
+
+```markdown
 ## Review — <title>
 
 **Verdict:** <approve | needs-fix | blocker>
@@ -216,8 +222,12 @@ gh pr review <N> --comment --body "$(cat <<'EOF'
 - [ ] <...>
 
 🤖 Reviewed by Claude Opus 4.6 (review-pr skill)
-EOF
-)"
+```
+
+2. Post the review:
+
+```bash
+gh pr review <N> --comment --body-file /tmp/review-body.md
 ```
 
 Rules for the review body:


### PR DESCRIPTION
## Summary

- `review-pr` SKILL.md and `role-sonnet-reviewer.md`: replace the `gh pr review --body "$(cat <<'EOF'...)"` pattern with a two-step approach — write the review body to `/tmp/review-body.md` via the **Write tool**, then run `gh pr review --body-file /tmp/review-body.md`.

**Why:** `--body "$(cat ...)"` triggers Claude Code's `command_substitution` security gate, blocking unattended operation. It also fails silently when the review body contains backticks, `$`, or other characters that shell-expand in double quotes.

## Test plan

- [x] Reviewed the diff — logic unchanged, only the body-passing mechanism
- [x] Pattern is consistent with the `commit-and-push` skill which already uses heredoc-to-variable