### PR TITLE
docs(time,profile): /// comments for time types, ir_time, and ir_profile

### DIFF
--- a/engine/profile/include/irreden/ir_profile.hpp
+++ b/engine/profile/include/irreden/ir_profile.hpp
@@ -11,7 +11,9 @@
 
 namespace IRProfile {
 
-// Profiler colors (ARGB)
+/// @name Profiler block colours (ARGB hex) for easy_profiler blocks.
+/// Pass one of these to `IR_PROFILE_FUNCTION` / `IR_PROFILE_BLOCK`.
+/// @{
 #define IR_PROFILER_COLOR_UPDATE 0xff0000ff
 #define IR_PROFILER_COLOR_RENDER 0xffff0000
 #define IR_PROFILER_COLOR_AUDIO 0xff00ffff
@@ -22,7 +24,10 @@ namespace IRProfile {
 #define IR_PROFILER_COLOR_END_EXECUTE 0xff00ff00
 #define IR_PROFILER_COLOR_INPUT 0xff4444ff
 #define IR_PROFILER_COLOR_VIDEO 0xffff8800
+/// @}
 
+/// Implementation backing `IR_ASSERT`.  On failure, logs at critical severity
+/// and throws `std::runtime_error`.  Compiled to a no-op in `IR_RELEASE` builds.
 template <typename... Args>
 inline void engAssert(
     bool condition,
@@ -34,28 +39,39 @@ inline void engAssert(
     Args &&...args
 );
 
+/// Returns `true` if the spdlog logging system is currently active.
 bool isLoggingEnabled();
+/// Flushes and tears down the spdlog sinks.  Call during engine shutdown.
 void shutdownLogging();
 
-// Game logging commands
+/// @name Game/client logger (use `IR_LOG_*` macros instead of calling directly)
+/// Routes to the game logger sink.  Do **not** call from `engine/` code.
+/// @{
 template <typename... Args> inline void logTrace(const char *format, Args &&...args);
 template <typename... Args> inline void logDebug(const char *format, Args &&...args);
 template <typename... Args> inline void logInfo(const char *format, Args &&...args);
 template <typename... Args> inline void logWarn(const char *format, Args &&...args);
 template <typename... Args> inline void logError(const char *format, Args &&...args);
 template <typename... Args> inline void logFatal(const char *format, Args &&...args);
+/// @}
 
-// Engine logging commands
+/// @name Engine logger (use `IRE_LOG_*` macros instead of calling directly)
+/// Routes to the engine logger sink.  Use from `engine/` code only.
+/// @{
 template <typename... Args> inline void engLogTrace(const char *format, Args &&...args);
 template <typename... Args> inline void engLogDebug(const char *format, Args &&...args);
 template <typename... Args> inline void engLogInfo(const char *format, Args &&...args);
 template <typename... Args> inline void engLogWarn(const char *format, Args &&...args);
 template <typename... Args> inline void engLogError(const char *format, Args &&...args);
 template <typename... Args> inline void engLogFatal(const char *format, Args &&...args);
+/// @}
 
-// GL logging commands
+/// @name GL debug logger (use `IRE_GL_LOG_*` macros instead of calling directly)
+/// Routes to the GL debug logger sink; driven by OpenGL debug callbacks.
+/// @{
 template <typename... Args> inline void glLogDebug(const char *format, Args &&...args);
 template <typename... Args> inline void glLogFatal(const char *format, Args &&...args);
+/// @}
 
 } // namespace IRProfile
 
@@ -65,29 +81,45 @@ template <typename... Args> inline void glLogFatal(const char *format, Args &&..
 // strip asserts, profiling, and logging from release builds.
 #ifndef IR_RELEASE
 
+/// Asserts @p x; on failure logs at critical and throws `std::runtime_error`.
+/// Expands to nothing in `IR_RELEASE`.  **Do not** put side-effectful calls
+/// in the condition or message — they are not evaluated in release.
 #define IR_ASSERT(x, en, ...)                                                                      \
     IRProfile::engAssert(x, __FILE__, __FUNCTION__, __LINE__, #x, en, ##__VA_ARGS__)
-#define IR_PROFILE_FUNCTION(color) EASY_FUNCTION(color)
-#define IR_PROFILE_BLOCK(name, color) EASY_BLOCK(name, color)
-#define IR_PROFILE_END_BLOCK EASY_END_BLOCK
-#define IR_PROFILE_MAIN_THREAD EASY_MAIN_THREAD
 
+/// @name CPU profiling macros (easy_profiler wrappers, no-ops in IR_RELEASE)
+/// @{
+#define IR_PROFILE_FUNCTION(color) EASY_FUNCTION(color)  ///< Block named by `__FUNCTION__`.
+#define IR_PROFILE_BLOCK(name, color) EASY_BLOCK(name, color)  ///< Block with explicit name.
+#define IR_PROFILE_END_BLOCK EASY_END_BLOCK  ///< Closes the innermost open block.
+#define IR_PROFILE_MAIN_THREAD EASY_MAIN_THREAD  ///< Marks the calling thread as the main thread.
+/// @}
+
+/// @name Game/client log macros — route to the game logger sink (use in creation code)
+/// @{
 #define IR_LOG_TRACE(...) IRProfile::logTrace(__VA_ARGS__)
 #define IR_LOG_DEBUG(...) IRProfile::logDebug(__VA_ARGS__)
 #define IR_LOG_INFO(...) IRProfile::logInfo(__VA_ARGS__)
 #define IR_LOG_WARN(...) IRProfile::logWarn(__VA_ARGS__)
 #define IR_LOG_ERROR(...) IRProfile::logError(__VA_ARGS__)
 #define IR_LOG_FATAL(...) IRProfile::logFatal(__VA_ARGS__)
+/// @}
 
+/// @name Engine log macros — route to the engine logger sink (use in engine/ code)
+/// @{
 #define IRE_LOG_TRACE(...) IRProfile::engLogTrace(__VA_ARGS__)
 #define IRE_LOG_DEBUG(...) IRProfile::engLogDebug(__VA_ARGS__)
 #define IRE_LOG_INFO(...) IRProfile::engLogInfo(__VA_ARGS__)
 #define IRE_LOG_WARN(...) IRProfile::engLogWarn(__VA_ARGS__)
 #define IRE_LOG_ERROR(...) IRProfile::engLogError(__VA_ARGS__)
 #define IRE_LOG_FATAL(...) IRProfile::engLogFatal(__VA_ARGS__)
+/// @}
 
+/// @name GL debug log macros — route to the GL debug logger sink
+/// @{
 #define IRE_GL_LOG_DEBUG(...) IRProfile::glLogDebug(__VA_ARGS__)
 #define IRE_GL_LOG_FATAL(...) IRProfile::glLogFatal(__VA_ARGS__)
+/// @}
 
 #else
 

--- a/engine/time/include/irreden/ir_time.hpp
+++ b/engine/time/include/irreden/ir_time.hpp
@@ -5,16 +5,31 @@
 
 namespace IRTime {
 
+/// Global pointer to the active `TimeManager`; managed by the engine runtime.
+/// Prefer @ref getTimeManager() for safe access.
 extern TimeManager *g_timeManager;
+/// Returns a reference to the active `TimeManager`. Asserts if not initialised.
 TimeManager &getTimeManager();
 
+/// Returns the actual wall-clock dt (seconds) for the last tick of @p eventType.
+/// Note: this is wall-clock time, **not** a fixed step — do not use it to advance
+/// deterministic simulation state.  For that, use the fixed-step accumulator pattern
+/// (see `shouldUpdate()`).
 double deltaTime(Events eventType);
+/// Returns `true` when the UPDATE accumulator has buffered at least one frame period
+/// (1 / @ref IRConstants::kFPS).  Call in a `while` loop to drain catch-up ticks.
 bool shouldUpdate();
 
+/// 1-second rolling average of RENDER ticks per second.
 double renderFps();
+/// Average RENDER frame time in milliseconds over the last second.
 double renderFrameTimeMs();
+/// 1-second rolling average of UPDATE ticks per second.
 double updateFps();
+/// Number of RENDER frames dropped since last @ref resetDroppedFrames call.
+/// A frame is "dropped" when RENDER is ≥ 2 frame periods behind schedule.
 unsigned int droppedFrames();
+/// Resets the dropped-frame counter to zero.
 void resetDroppedFrames();
 } // namespace IRTime
 

--- a/engine/time/include/irreden/time/ir_time_types.hpp
+++ b/engine/time/include/irreden/time/ir_time_types.hpp
@@ -8,23 +8,38 @@
 namespace IRTime {
 class TimeManager;
 
+/// Monotonic clock used for all engine timekeeping.
 using Clock = std::chrono::steady_clock;
+/// A point-in-time on the @ref Clock.
 using TimePoint = std::chrono::time_point<Clock>;
+/// Integer nanosecond duration (for accumulator arithmetic).
 using NanoDuration = std::chrono::duration<int64_t, std::nano>;
+/// Floating-point millisecond duration (for display / logging).
 using MilliDuration = std::chrono::duration<double, std::milli>;
+/// Floating-point seconds duration (for dt values).
 using SecondsDuration = std::chrono::duration<double>;
 using NanoSeconds = std::chrono::nanoseconds;
 using MilliSeconds = std::chrono::milliseconds;
 using Seconds = std::chrono::seconds;
+/// Compile-time duration type representing one frame at @p fps frames per second.
 template <intmax_t fps> using FramePeriod = std::chrono::duration<double, std::ratio<1, fps>>;
+/// Duration of one frame at the engine's target frame rate (@ref IRConstants::kFPS).
 constexpr FramePeriod<IRConstants::kFPS> kFPSFramePeriod{1};
+/// Same as @ref kFPSFramePeriod in integer nanoseconds (for accumulator comparisons).
 constexpr NanoDuration kFPSNanoDuration = std::chrono::duration_cast<NanoDuration>(kFPSFramePeriod);
 
+/// Rolling history depth used by each `EventProfiler` (frames).
 const unsigned int kProfileHistoryBufferSize = 100;
+/// Capacity of the FPS rolling window inside `EventProfiler` (frames).
 constexpr size_t kFpsWindowCapacity = 1024;
 
+/// Pipeline event tags — used as template parameters to
+/// `TimeManager::beginEvent<E>()` / `endEvent<E>()` and as arguments to
+/// `deltaTime(E)`.  @ref UPDATE drives the fixed-step accumulator.
 enum Events { UPDATE, RENDER, INPUT, START, END };
 
+/// Per-event timing profiler; tracks accumulator, rolling history, FPS window,
+/// and dropped-frame counter.  Instantiated inside `TimeManager`.
 template <Events eventType> class EventProfiler;
 } // namespace IRTime
 


### PR DESCRIPTION
## Summary

**`engine/time`**
- `ir_time_types.hpp`: `///` on all type aliases (`Clock`, `TimePoint`, duration types), `FramePeriod<fps>` template, `kFPSFramePeriod`/`kFPSNanoDuration`, rolling-window size constants, `Events` enum (notes use as template parameter), `EventProfiler<E>` forward declaration.
- `ir_time.hpp`: `///` on `g_timeManager`, `getTimeManager`, `deltaTime` (critical note: wall-clock, not fixed-step), `shouldUpdate` (notes while-loop pattern for catch-up ticks), `renderFps`, `renderFrameTimeMs`, `updateFps`, `droppedFrames`, `resetDroppedFrames`.

**`engine/profile`**
- `ir_profile.hpp`: profiler colour macros grouped under `@{`/`@}`; `engAssert` (notes it logs + throws and is a no-op in `IR_RELEASE` — don't put side effects in args); `isLoggingEnabled`/`shutdownLogging`; logger functions grouped by sink (game/engine/GL) with routing notes; all macro sets (`IR_ASSERT`, `IR_PROFILE_*`, `IR_LOG_*`, `IRE_LOG_*`, `IRE_GL_LOG_*`) grouped under `@{`/`@}`.

Continues the documentation pass series (PRs #135, #136, #138–#144).

**Pre-existing failure:** `EasingMapTest.AllFunctionsBoundaryConditions` fails on master — fix is in PR #132.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` builds clean
- [x] 270/271 tests pass; 1 pre-existing failure unrelated to this change