### PR TITLE
test(common): 11 unit tests for IRPlatform::conventionsFor and predicates

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(IrredenEngineTest
   audio/music_theory_test.cpp
+  common/ir_platform_test.cpp
   ecs/entity_manager_test.cpp
   math/physics_test.cpp
   math/ir_math_test.cpp

--- a/test/common/ir_platform_test.cpp
+++ b/test/common/ir_platform_test.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+#include <irreden/ir_platform.hpp>
+
+namespace {
+
+using namespace IRPlatform;
+
+// ─────────────────────────────────────────────
+// conventionsFor — pure constexpr, no GPU needed
+// ─────────────────────────────────────────────
+
+TEST(ConventionsForTest, OpenGLHasNegativeYDirection) {
+    constexpr GraphicsConventions c = conventionsFor(GraphicsBackend::OPENGL);
+    EXPECT_FLOAT_EQ(c.screenYDirection_, -1.0f);
+}
+
+TEST(ConventionsForTest, OpenGLFlipsMouseY) {
+    constexpr GraphicsConventions c = conventionsFor(GraphicsBackend::OPENGL);
+    EXPECT_TRUE(c.flipMouseY_);
+}
+
+TEST(ConventionsForTest, OpenGLUsesSymmetricNDCDepth) {
+    // OpenGL clip-space depth is [-1, 1], so ndcDepthZeroToOne_ is false.
+    constexpr GraphicsConventions c = conventionsFor(GraphicsBackend::OPENGL);
+    EXPECT_FALSE(c.ndcDepthZeroToOne_);
+}
+
+TEST(ConventionsForTest, MetalHasPositiveYDirection) {
+    constexpr GraphicsConventions c = conventionsFor(GraphicsBackend::METAL);
+    EXPECT_FLOAT_EQ(c.screenYDirection_, 1.0f);
+}
+
+TEST(ConventionsForTest, MetalDoesNotFlipMouseY) {
+    constexpr GraphicsConventions c = conventionsFor(GraphicsBackend::METAL);
+    EXPECT_FALSE(c.flipMouseY_);
+}
+
+TEST(ConventionsForTest, MetalUsesZeroToOneNDCDepth) {
+    // Metal clip-space depth is [0, 1].
+    constexpr GraphicsConventions c = conventionsFor(GraphicsBackend::METAL);
+    EXPECT_TRUE(c.ndcDepthZeroToOne_);
+}
+
+TEST(ConventionsForTest, VulkanMatchesMetal) {
+    // Vulkan shares Metal's clip conventions (positive Y, [0,1] depth).
+    constexpr GraphicsConventions vk = conventionsFor(GraphicsBackend::VULKAN);
+    constexpr GraphicsConventions mt = conventionsFor(GraphicsBackend::METAL);
+    EXPECT_FLOAT_EQ(vk.screenYDirection_, mt.screenYDirection_);
+    EXPECT_EQ(vk.flipMouseY_, mt.flipMouseY_);
+    EXPECT_EQ(vk.ndcDepthZeroToOne_, mt.ndcDepthZeroToOne_);
+}
+
+TEST(ConventionsForTest, OpenGLAndMetalHaveOppositeYDirection) {
+    constexpr float ogl = conventionsFor(GraphicsBackend::OPENGL).screenYDirection_;
+    constexpr float mtl = conventionsFor(GraphicsBackend::METAL).screenYDirection_;
+    EXPECT_FLOAT_EQ(ogl, -mtl);
+}
+
+// ─────────────────────────────────────────────
+// Platform predicate constants — compile-time consistency
+// ─────────────────────────────────────────────
+
+TEST(PlatformPredicatesTest, ExactlyOneOSIsTrue) {
+    int count = 0;
+    if (kIsLinux)   ++count;
+    if (kIsMacOS)   ++count;
+    if (kIsWindows) ++count;
+    EXPECT_EQ(count, 1) << "exactly one OS predicate must be true";
+}
+
+TEST(PlatformPredicatesTest, KGfxMatchesCurrentBackend) {
+    // kGfx must equal what conventionsFor(kGraphicsBackend) returns.
+    const GraphicsConventions expected = conventionsFor(kGraphicsBackend);
+    EXPECT_FLOAT_EQ(kGfx.screenYDirection_, expected.screenYDirection_);
+    EXPECT_EQ(kGfx.flipMouseY_, expected.flipMouseY_);
+    EXPECT_EQ(kGfx.ndcDepthZeroToOne_, expected.ndcDepthZeroToOne_);
+}
+
+TEST(PlatformPredicatesTest, KIsOpenGLConsistentWithBackend) {
+    EXPECT_EQ(kIsOpenGL, kGraphicsBackend == GraphicsBackend::OPENGL);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Adds `test/common/ir_platform_test.cpp` with 11 `constexpr`-driven tests for `ir_platform.hpp`.

**`ConventionsForTest` (8 tests):**
- `OpenGLHasNegativeYDirection` / `OpenGLFlipsMouseY` / `OpenGLUsesSymmetricNDCDepth` — verifies all three OpenGL conventions
- `MetalHasPositiveYDirection` / `MetalDoesNotFlipMouseY` / `MetalUsesZeroToOneNDCDepth` — verifies all three Metal conventions
- `VulkanMatchesMetal` — Vulkan and Metal share the same clip/mouse conventions
- `OpenGLAndMetalHaveOppositeYDirection` — sign-inversion invariant

**`PlatformPredicatesTest` (3 tests):**
- `ExactlyOneOSIsTrue` — `kIsLinux`, `kIsMacOS`, `kIsWindows` form a partition
- `KGfxMatchesCurrentBackend` — `kGfx == conventionsFor(kGraphicsBackend)` self-consistency
- `KIsOpenGLConsistentWithBackend` — `kIsOpenGL` agrees with `kGraphicsBackend` comparison

All tests use `constexpr` values — no GPU or window required.

**Pre-existing failure:** `EasingMapTest.AllFunctionsBoundaryConditions` fails on master — fix is in PR #132.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` builds clean
- [x] `./IrredenEngineTest --gtest_filter="ConventionsForTest.*:PlatformPredicatesTest.*"` — 11/11 pass