### PR TITLE
docs(asset,audio): /// comments for ir_asset, ir_audio_types, ir_audio

### DIFF
--- a/engine/asset/include/irreden/ir_asset.hpp
+++ b/engine/asset/include/irreden/ir_asset.hpp
@@ -9,8 +9,16 @@ using namespace IRMath;
 
 namespace IRAsset {
 
+/// Asset file type discriminant.
+/// Note: only `kTrixelImage` has corresponding I/O routines today.
+/// `kSpriteImage` and `kVoxelImage` are aspirational stubs with no
+/// load/save implementation yet.
 enum FileTypes { kSpriteImage, kTrixelImage, kVoxelImage };
 
+/// Writes trixel texture data to a raw binary file at @p path / @p name.txt.
+/// The name is embedded in the file header; @p path is the output directory.
+/// Format: `ivec2 size | size.x*size.y Color entries | size.x*size.y Distance entries`.
+/// No checksum or magic bytes — treat files as volatile.
 void saveTrixelTextureData(
     const std::string &name,
     const std::string &path,
@@ -19,6 +27,9 @@ void saveTrixelTextureData(
     const std::vector<Distance> &distances
 );
 
+/// Reads trixel texture data from a raw binary file previously written by
+/// @ref saveTrixelTextureData.  `fread` return values are unchecked — a
+/// truncated file loads as garbage with no error.
 void loadTrixelTextureData(
     const std::string &name,
     const std::string &path,

--- a/engine/audio/include/irreden/audio/ir_audio_types.hpp
+++ b/engine/audio/include/irreden/audio/ir_audio_types.hpp
@@ -9,14 +9,23 @@ namespace IRAudio {
 
 class AudioManager;
 
+/// MIDI channel number (0-based; channel 1 = value 0).
 using MidiChannel = unsigned char;
+/// Raw MIDI status byte (high nibble = message type, low nibble = channel).
 using MidiStatus = unsigned char;
+/// MIDI CC (control-change) value byte.
 using CCData = unsigned char;
+/// MIDI CC (control-change) message number byte.
 using CCMessage = unsigned char;
 
+/// Sentinel value returned by @ref checkCCMessage when no CC was received this frame.
 constexpr CCData kCCFalse = 0xFF;
+/// Default RtAudio input buffer size in frames (samples per callback invocation).
 constexpr unsigned int kAudioInputDefaultBufferFrames = 1024;
 
+/// Indices into the hardcoded MIDI-input device list.
+/// Pass to `openPortMidiIn(MidiInInterfaces)` to open by index, or use
+/// @ref kMidiInInterfaceNames to open by substring match.
 enum MidiInInterfaces {
     MIDI_IN_UMC,
     MIDI_IN_FOCUSRITE,
@@ -25,6 +34,7 @@ enum MidiInInterfaces {
     NUM_MIDI_IN_INTERFACES
 };
 
+/// Indices into the hardcoded MIDI-output device list.
 enum MidiOutInterfaces {
     MIDI_OUT_UMC,
     MIDI_OUT_FOCUSRITE,
@@ -33,16 +43,22 @@ enum MidiOutInterfaces {
     NUM_MIDI_OUT_INTERFACES
 };
 
+/// Casts a @ref MidiInInterfaces value to its array index.
 constexpr std::size_t midiInInterfaceIndex(MidiInInterfaces midiInInterface) {
     return static_cast<std::size_t>(midiInInterface);
 }
 
+/// Casts a @ref MidiOutInterfaces value to its array index.
 constexpr std::size_t midiOutInterfaceIndex(MidiOutInterfaces midiOutInterface) {
     return static_cast<std::size_t>(midiOutInterface);
 }
 
+/// Discriminant for whether a MIDI device handle is input or output.
 enum MidiDeviceType { MIDI_DEVICE_TYPE_IN, MIDI_DEVICE_TYPE_OUT };
 
+/// Named MIDI channel aliases (0-indexed: `kMidiChannel1` = 0).
+/// `kMidiChannelAll` = 16 is a convention used by the engine to mean
+/// "broadcast to all channels".
 enum MidiChannels {
     kMidiChannel1 = 0,
     kMidiChannel2 = 1,
@@ -64,6 +80,8 @@ enum MidiChannels {
 
 };
 
+/// @name Hardcoded MIDI device port name substrings (used for substring-match port opening)
+/// @{
 const char *const kMidiInInterfaceName_UMC = "UMC1820 MIDI In";
 const char *const kMidiInInterfaceName_FOCUSRITE = "Focusrite USB MIDI";
 const char *const kMidiInInterfaceName_MPK = "MPKmini2";
@@ -73,8 +91,9 @@ const char *const kMidiOutInterfaceName_UMC = "UMC1820 MIDI Out";
 const char *const kMidiOutInterfaceName_FOCUSRITE = "Focusrite USB MIDI";
 const char *const kMidiOutInterfaceName_MPK = "MPKmini2";
 const char *const kMidiOutInterfaceName_OP1 = "OP-1 Midi Device";
+/// @}
 
-// map midi in interface to name
+/// Maps @ref MidiInInterfaces index to its device name substring.
 inline const std::array<const char *, NUM_MIDI_IN_INTERFACES> kMidiInInterfaceNames = {
     kMidiInInterfaceName_UMC,
     kMidiInInterfaceName_FOCUSRITE,
@@ -82,7 +101,7 @@ inline const std::array<const char *, NUM_MIDI_IN_INTERFACES> kMidiInInterfaceNa
     kMidiInInterfaceName_OP1
 };
 
-// map midi out interface to name
+/// Maps @ref MidiOutInterfaces index to its device name substring.
 inline const std::array<const char *, NUM_MIDI_OUT_INTERFACES> kMidiOutInterfaceNames = {
     kMidiOutInterfaceName_UMC,
     kMidiOutInterfaceName_FOCUSRITE,
@@ -90,23 +109,31 @@ inline const std::array<const char *, NUM_MIDI_OUT_INTERFACES> kMidiOutInterface
     kMidiOutInterfaceName_OP1
 };
 
+/// High-nibble mask for the status byte (message type bits).
 const unsigned char kMidiMessageBits_STATUS = 0xF0;
+/// Low-nibble mask for the status byte (channel bits).
 const unsigned char kMidiMessageBits_CHANNEL = 0x0F;
 
+/// Strips the message-type bits from a combined status byte, leaving only the channel.
 constexpr MidiChannel normalizeMidiChannel(MidiChannel channel) {
     return static_cast<MidiChannel>(channel & kMidiMessageBits_CHANNEL);
 }
 
+/// Strips the channel bits from a combined status byte, leaving only the message type.
 constexpr MidiStatus normalizeMidiStatus(MidiStatus status) {
     return static_cast<MidiStatus>(status & kMidiMessageBits_STATUS);
 }
 
+/// Combines a message-type status nibble and a channel nibble into a single status byte.
 constexpr MidiStatus buildMidiStatus(MidiStatus status, MidiChannel channel) {
     return static_cast<MidiStatus>(normalizeMidiStatus(status) | normalizeMidiChannel(channel));
 }
 
+/// Total number of MIDI channels per device (standard MIDI: 16).
 constexpr MidiChannel kNumMidiChannels = 16;
 
+/// @name MIDI message-type status bytes (high nibble of the status byte)
+/// @{
 constexpr MidiStatus kMidiStatus_NOTE_OFF = 0x80;
 constexpr MidiStatus kMidiStatus_NOTE_ON = 0x90;
 constexpr MidiStatus kMidiStatus_POLYPHONIC_KEY_PRESSURE = 0xA0;
@@ -114,7 +141,10 @@ constexpr MidiStatus kMidiStatus_CONTROL_CHANGE = 0xB0;
 constexpr MidiStatus kMidiStatus_PROGRAM_CHANGE = 0xC0;
 constexpr MidiStatus kMidiStatus_CHANNEL_PRESSURE = 0xD0;
 constexpr MidiStatus kMidiStatus_PITCH_BEND = 0xE0;
+/// @}
 
+/// MIDI note numbers for the 88-key piano range (A0=21 … C8=108).
+/// Values follow the General MIDI standard (middle C = C4 = 60).
 enum IRMidiNote {
     NOTE_A0 = 21,
     NOTE_A0_SHARP = 22,
@@ -206,7 +236,9 @@ enum IRMidiNote {
     NOTE_C8 = 108
 };
 
+/// MIDI CC 120 — silences all sounding notes immediately (no release).
 constexpr unsigned char kMidiCC_ALL_SOUND_OFF = 120;
+/// MIDI CC 123 — releases all held notes (allows natural release/decay).
 constexpr unsigned char kMidiCC_ALL_NOTES_OFF = 123;
 
 } // namespace IRAudio

--- a/engine/audio/include/irreden/ir_audio.hpp
+++ b/engine/audio/include/irreden/ir_audio.hpp
@@ -13,32 +13,56 @@
 namespace IRAudio {
 
 class AudioManager;
+/// Global pointer to the active `AudioManager`; managed by the engine runtime.
+/// Prefer @ref getAudioManager() for safe access.
 extern AudioManager *g_audioManager;
+/// Returns a reference to the active `AudioManager`. Asserts if not initialised.
 AudioManager &getAudioManager();
+
+/// RtAudio input callback type: `void(samples, frameCount, streamTime, overflow)`.
+/// Invoked on the RtAudio thread — **do not** access ECS or Lua state from inside it.
 using AudioInputCallback = std::function<void(const float *, int, double, bool)>;
 
+/// Returns the active `IAudioCaptureSource` (used by `VideoManager` for recording).
 IAudioCaptureSource &getAudioCaptureSource();
 
+/// Opens a MIDI input port by hardcoded interface index.
 int openPortMidiIn(MidiInInterfaces midiInInterface);
+/// Opens the first MIDI input port whose name contains @p deviceName (substring match).
 int openPortMidiIn(const std::string &deviceName);
+/// Opens a MIDI output port by hardcoded interface index.
 int openPortMidiOut(MidiOutInterfaces midiOutInterface);
+/// Opens the first MIDI output port whose name contains @p midiOutInterface (substring match).
 int openPortMidiOut(const std::string &midiOutInterface);
+/// Sends a raw MIDI message (fire-and-forget via `RtMidiOut`).
 void sendMidiMessage(const std::vector<unsigned char> &message);
 
+/// Returns the CC value for @p ccMessage on @p device received this frame,
+/// or @ref kCCFalse if no CC message arrived.
 CCData checkCCMessage(int device, CCMessage ccMessage);
+/// Returns the list of note-on messages received on @p device this frame.
+/// The list is cleared on the next `MidiIn::tick()` — read during INPUT/UPDATE only.
 const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOnThisFrame(int device);
+/// Returns the list of note-off messages received on @p device this frame.
 const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOffThisFrame(int device);
 
+/// @name Low-level MIDI message insertion (used by prefab systems)
+/// @{
 void insertNoteOffMessage(MidiChannel channel, const IRComponents::C_MidiMessage &message);
 void insertNoteOnMessage(MidiChannel channel, const IRComponents::C_MidiMessage &message);
 void insertCCMessage(MidiChannel channel, const IRComponents::C_MidiMessage &message);
+/// @}
 
+/// Opens and starts an RtAudio input capture stream.
+/// @p callback is invoked on the RtAudio thread — copy data out before returning.
+/// Returns `false` if the device could not be opened.
 bool startAudioInputCapture(
     const std::string &deviceName,
     int sampleRate,
     int channels,
     AudioInputCallback callback
 );
+/// Stops the active RtAudio input stream.  Always call before `AudioManager` teardown.
 void stopAudioInputCapture();
 
 } // namespace IRAudio


### PR DESCRIPTION
## Summary

**`engine/asset`**
- `ir_asset.hpp`: `///` on `FileTypes` enum (notes `kSpriteImage`/`kVoxelImage` are aspirational stubs with no I/O), `saveTrixelTextureData` (raw binary format), `loadTrixelTextureData` (notes unchecked `fread` return values).

**`engine/audio`**
- `ir_audio_types.hpp`: `///` on all type aliases, constants, enums, and helpers — MIDI channel/status type aliases, sentinel constants, `MidiInInterfaces`/`MidiOutInterfaces` enums + index helpers, `MidiDeviceType`, `MidiChannels` (notes 0-indexed + `kMidiChannelAll`=16), device name strings and arrays, MIDI bitmask constants, `normalizeMidi*`/`buildMidiStatus` helpers, `kNumMidiChannels`, MIDI status byte constants (grouped), `IRMidiNote` 88-key enum, CC sentinels.
- `ir_audio.hpp`: `///` on `g_audioManager`, `getAudioManager`, `AudioInputCallback` (notes RtAudio thread caveat), `getAudioCaptureSource`, four MIDI port open overloads, `sendMidiMessage`, `checkCCMessage`, `getMidiNotesOn/OffThisFrame` (per-frame-wipe note), insert helpers (grouped), `startAudioInputCapture`/`stopAudioInputCapture`.

Continues the documentation pass series (PRs #135, #136, #138–#146).

**Pre-existing failure:** `EasingMapTest.AllFunctionsBoundaryConditions` fails on master — fix is in PR #132.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` builds clean
- [x] Audio/asset TUs recompiled without warnings