### PR TITLE
docs: video module public header documentation

### DIFF
--- a/engine/video/include/irreden/ir_video.hpp
+++ b/engine/video/include/irreden/ir_video.hpp
@@ -7,20 +7,51 @@
 
 namespace IRVideo {
 
+/// @cond INTERNAL
 extern VideoManager *g_videoManager;
 VideoManager &getVideoManager();
+/// @endcond
 
+/// @{
+/// @name Recording control
+/// Start a new recording session with the supplied @p config. Creates or overwrites
+/// the output MP4. Returns @c false on FFmpeg initialisation failure; call
+/// @c getLastError() for details.
 bool startRecording(const VideoRecorderConfig &config);
+/// Flush the encoder pipeline and close the output file. Safe to call when not recording.
 void stopRecording();
-bool recordFrame(const std::uint8_t *rgbaData, int strideBytes);
-void configureScreenshotOutputDir(const std::string &outputDirPath);
-void requestScreenshot();
-void requestCanvasScreenshot();
+/// Convenience toggle: calls @c startRecording / @c stopRecording based on current state.
+/// Requires a previously configured @c VideoRecorderConfig (stored by @c VideoManager).
 void toggleRecording();
+/// @}
+
+/// Submit a raw RGBA8 frame to the encoder. Must be called once per render frame while
+/// recording is active. @p strideBytes is typically @c width * 4 for packed RGBA.
+/// Returns @c false on encode failure.
+bool recordFrame(const std::uint8_t *rgbaData, int strideBytes);
+
+/// @{
+/// @name Screenshot
+/// Set the directory where PNG screenshots are written. Defaults to the working directory.
+void configureScreenshotOutputDir(const std::string &outputDirPath);
+/// Queue a full-screen (composite) screenshot to be written on the next render frame.
+void requestScreenshot();
+/// Queue a screenshot of the voxel canvas only — no UI or overlay layers.
+void requestCanvasScreenshot();
+/// @}
+
+/// Notify the video manager that a fixed-update tick has elapsed. Call once per
+/// fixed-step update so the encoder can align audio/video timestamps correctly.
 void notifyFixedUpdate();
+
+/// @{
+/// @name Query
 bool isRecording();
+/// Total number of video frames submitted in the current recording session.
 std::uint64_t getFrameCount();
+/// Last error string set by FFmpeg.
 const std::string &getLastError();
+/// @}
 
 } // namespace IRVideo
 

--- a/engine/video/include/irreden/video/ir_video_types.hpp
+++ b/engine/video/include/irreden/video/ir_video_types.hpp
@@ -5,8 +5,12 @@ namespace IRVideo {
 
 class VideoManager;
 
+/// Byte width of a single row in an RGBA frame buffer passed to @c recordFrame /
+/// @c VideoRecorder::submitVideoFrame. Usually @c width * 4 for tightly-packed RGBA8.
 using VideoStrideBytes = int;
 
+/// Default capture frame rate used when no @c target_fps_ is specified in
+/// @c VideoRecorderConfig.
 constexpr int kDefaultCaptureFps = 60;
 
 } // namespace IRVideo

--- a/engine/video/include/irreden/video/video_recorder.hpp
+++ b/engine/video/include/irreden/video/video_recorder.hpp
@@ -7,41 +7,107 @@
 
 namespace IRVideo {
 
+/// Configuration for a single recording session. Pass to @c VideoRecorder::start or
+/// @c IRVideo::startRecording. All fields have sane defaults; at minimum set
+/// @c width_, @c height_, and @c source_width_, @c source_height_ for the output.
 struct VideoRecorderConfig {
+    /// Output file path (MP4 container). Created or overwritten on @c start.
     std::string output_file_path_ = "capture.mp4";
+    /// Output frame dimensions after any scaling applied by the FFmpeg pipeline.
     int width_ = 0;
     int height_ = 0;
+    /// Source frame dimensions as supplied to @c submitVideoFrame. The pipeline
+    /// scales source → (width_, height_) if they differ.
     int source_width_ = 0;
     int source_height_ = 0;
+    /// Target output frame rate. Frames submitted faster than this are dropped;
+    /// slower submission causes the output to run short.
     int target_fps_ = 60;
+    /// Video bitrate in bits/s (default 8 Mbps — good for 1080p gameplay at 60 fps).
     int video_bitrate_ = 8'000'000;
+
+    /// @{
+    /// @name Audio capture settings
+    /// When @c capture_audio_input_ is true, the engine opens @c audio_input_device_name_
+    /// via RtAudio and feeds interleaved float samples into the recording. Call
+    /// @c IRAudio::startAudioInputCapture and wire its callback to
+    /// @c VideoRecorder::submitAudioInputSamples so audio is routed to the encoder.
     bool capture_audio_input_ = false;
+    /// RtAudio device name to open for capture. Must match the name returned by
+    /// @c IRAudio::startAudioInputCapture's device enumeration.
     std::string audio_input_device_name_ = "";
     int audio_sample_rate_ = 48'000;
     int audio_channels_ = 2;
+    /// Audio bitrate in bits/s. Ignored when @c audio_lossless_ is true.
     int audio_bitrate_ = 320'000;
+    /// Use a lossless audio codec (e.g. FLAC) instead of AAC.
     bool audio_lossless_ = false;
+    /// Mux the captured audio into the MP4 container alongside the video stream.
     bool audio_mux_enabled_ = true;
+    /// Also write a sidecar @c .wav file next to @c output_file_path_. Useful for
+    /// post-processing audio independently of the video.
     bool audio_wav_enabled_ = true;
+    /// Manual A/V sync correction in milliseconds. Positive values delay audio
+    /// relative to video; negative values advance it.
     double audio_sync_offset_ms_ = 0.0;
+    /// @}
 };
 
+/// FFmpeg-backed video encoder. Wraps the full encode pipeline: RGBA → libx264/libx265
+/// video, optional AAC/FLAC audio, muxed into an MP4 container.
+///
+/// Typical frame-submission loop:
+/// @code
+///   auto buf = recorder.acquireFrameBuffer(width * height * 4);
+///   // fill buf with RGBA pixels ...
+///   recorder.submitVideoFrame(std::move(buf));
+/// @endcode
 class VideoRecorder {
   public:
     VideoRecorder();
     ~VideoRecorder();
 
+    /// @{
+    /// @name Recording control
+    /// @param config  Fully-populated @c VideoRecorderConfig; width/height must be non-zero.
+    /// @return @c true on success; @c false if FFmpeg initialisation failed — call
+    ///         @c getLastError() for the diagnostic string.
     bool start(const VideoRecorderConfig &config);
+    /// Flush the encoder, close the output file, and reset internal state. Safe to call
+    /// even when not recording (no-op).
     void stop();
+    /// @}
 
+    /// @{
+    /// @name Frame submission
+    /// Submit a raw RGBA8 frame. Both overloads are non-blocking on the calling thread —
+    /// encoding happens on an internal FFmpeg thread.
+    /// @param rgbaData    Pointer to RGBA pixel data; must remain valid until the call returns.
+    /// @param strideBytes Byte width of one row (typically @c width * 4).
+    /// @return @c false if encoding failed; check @c getLastError().
     bool submitVideoFrame(const std::uint8_t *rgbaData, int strideBytes);
+    /// Move-in variant — takes ownership of the buffer, avoiding a copy. Prefer this
+    /// with @c acquireFrameBuffer for zero-copy submission.
     bool submitVideoFrame(std::vector<std::uint8_t> &&frameData);
+    /// Feed interleaved float PCM samples from an RtAudio callback into the audio encoder.
+    /// Call this from the @c AudioInputCallback to keep A/V in sync.
+    /// @param interleavedSamples  Interleaved float samples (left, right, left, …).
+    /// @param frameCount          Number of sample frames (total samples / channels).
+    /// @param streamTime          RtAudio stream timestamp in seconds.
     bool submitAudioInputSamples(const float *interleavedSamples, int frameCount, double streamTime);
+    /// Acquire a pooled RGBA frame buffer of at least @p minCapacity bytes. Reusing the
+    /// returned buffer across frames avoids repeated heap allocations.
     std::vector<std::uint8_t> acquireFrameBuffer(std::size_t minCapacity);
+    /// @}
 
+    /// @{
+    /// @name Query
     [[nodiscard]] bool isRecording() const;
+    /// Total number of video frames submitted since the last @c start call.
     [[nodiscard]] std::uint64_t getVideoFrameCount() const;
+    /// Last error string set by FFmpeg on a failed @c start or @c submitVideoFrame.
     [[nodiscard]] const std::string &getLastError() const;
+    /// @}
 
   private:
     bool m_isRecording = false;


### PR DESCRIPTION
Documentation pass for the video module public headers. No logic changes.

## Changes

**`engine/video/include/irreden/video/ir_video_types.hpp`**
- `VideoStrideBytes`: note it's row byte width (typically `width * 4` for RGBA8)
- `kDefaultCaptureFps`: describe its role as default when config omits `target_fps_`

**`engine/video/include/irreden/video/video_recorder.hpp`**
- `VideoRecorderConfig`: document every field — output path, dimensions (source vs output), FPS, video bitrate, audio capture group (device name, sample rate, channels, bitrate, lossless, mux/wav flags, sync offset)
- `VideoRecorder`: class-level overview of FFmpeg pipeline; methods grouped via `@{`/`@}` into record-control, frame-submission, and query; move-in `submitVideoFrame` variant noted as zero-copy path via `acquireFrameBuffer`; `submitAudioInputSamples` cross-referenced to RtAudio callback wiring

**`engine/video/include/irreden/ir_video.hpp`**
- `g_videoManager`/`getVideoManager()`: marked `@cond INTERNAL`
- Recording-control group: `startRecording`, `stopRecording`, `toggleRecording`
- `recordFrame`: note RGBA8 + strideBytes contract
- Screenshot group: `configureScreenshotOutputDir`, `requestScreenshot`, `requestCanvasScreenshot`
- `notifyFixedUpdate`: explain role in A/V timestamp alignment
- Query group: `isRecording`, `getFrameCount`, `getLastError`

## Tests

259 tests pass (excluding pre-existing `EasingMapTest.AllFunctionsBoundaryConditions` failure on master — fix in PR #132, fleet:approved, not yet merged).
