### PR TITLE
docs(render): render module public header documentation

### DIFF
--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -14,33 +14,55 @@
 
 namespace IRRender {
 
+/// @cond INTERNAL
 extern RenderingResourceManager *g_renderingResourceManager;
 RenderingResourceManager &getRenderingResourceManager();
 
 extern RenderManager *g_renderManager;
 RenderManager &getRenderManager();
+/// @endcond
 
+/// @{
+/// @name GPU resource management
+/// Type-safe CRUD for GPU resources (shaders, textures, buffers, VAOs, …) managed
+/// by the @c RenderingResourceManager pool. Resources are indexed by @c ResourceId
+/// and type (@c typeid<T>); named resources support lookup by string key.
+
+/// Allocate a new @c T resource. Returns @c {id, ptr} where @c ptr is valid until
+/// @c destroyResource<T>(id) is called.
 template <typename T, typename... Args> std::pair<ResourceId, T *> createResource(Args &&...args) {
     return getRenderingResourceManager().create<T>(std::forward<Args>(args)...);
 }
 
+/// Allocate a @c T resource and register it under @p name for later lookup via
+/// @c getNamedResource<T>.
 template <typename T, typename... Args>
 std::pair<ResourceId, T *> createNamedResource(const std::string &name, Args &&...args) {
     return getRenderingResourceManager().createNamed<T>(name, std::forward<Args>(args)...);
 }
 
+/// Destroy the resource identified by @p resource and return its id to the free list.
 template <typename T> void destroyResource(ResourceId resource) {
     getRenderingResourceManager().destroy<T>(resource);
 }
 
+/// Return a raw (non-owning) pointer to the resource. Null if @p resource is invalid.
 template <typename T> T *getResource(ResourceId resource) {
     return getRenderingResourceManager().get<T>(resource);
 }
 
+/// Look up a previously-named resource. Returns null if @p resourceName is not registered.
 template <typename T> T *getNamedResource(std::string resourceName) {
     return getRenderingResourceManager().getNamed<T>(resourceName);
 }
+/// @}
 
+/// @{
+/// @name Voxel pool
+/// Allocate / release contiguous spans of voxel component arrays from the named canvas
+/// pool. All four spans are co-indexed — element [i] of each span belongs to voxel i.
+/// @param size        Number of voxels to allocate.
+/// @param canvasName  Canvas pool to allocate from (default @c "main").
 inline std::tuple<
     std::span<C_Position3D>,
     std::span<C_PositionOffset3D>,
@@ -50,6 +72,7 @@ allocateVoxels(unsigned int size, std::string canvasName = "main") {
     return getRenderManager().allocateVoxels(size, canvasName);
 }
 
+/// Release voxel spans previously returned by @c allocateVoxels back to the pool.
 inline void deallocateVoxels(
     std::span<C_Position3D> positions,
     std::span<C_PositionOffset3D> positionOffsets,
@@ -60,11 +83,22 @@ inline void deallocateVoxels(
     getRenderManager()
         .deallocateVoxels(positions, positionOffsets, positionGlobals, voxels, canvasName);
 }
+/// @}
 
+/// @{
+/// @name Canvas management
+/// Each canvas is an ECS entity that owns three GPU textures (color RGBA8,
+/// distance R32I, entity-id RG32UI) and is rendered in registration order.
+/// Do not destroy a canvas entity mid-frame — see @c engine/render/CLAUDE.md.
+
+/// Return the entity id of the canvas registered under @p canvasName.
 inline IREntity::EntityId getCanvas(std::string canvasName) {
     return getRenderManager().getCanvas(canvasName);
 }
 
+/// Create a new canvas entity with a voxel pool of @p voxelPoolSize voxels and a
+/// trixel texture of @p trixelSize pixels. Optionally bind it to an existing
+/// @p framebuffer entity.
 inline IREntity::EntityId createCanvas(
     std::string name,
     ivec3 voxelPoolSize,
@@ -78,6 +112,8 @@ inline bool hasCanvas(const std::string &name) {
     return getRenderManager().hasCanvas(name);
 }
 
+/// Set the canvas that receives input from @c setActiveCanvas-aware systems
+/// (e.g. the paint/draw tools in editor mode).
 inline void setActiveCanvas(const std::string &name) {
     getRenderManager().setActiveCanvas(name);
 }
@@ -85,44 +121,93 @@ inline void setActiveCanvas(const std::string &name) {
 inline IREntity::EntityId getActiveCanvasEntity() {
     return getRenderManager().getActiveCanvasEntity();
 }
+/// @}
 
+/// @{
+/// @name Camera and viewport queries
+/// Camera position and zoom are read by the voxel→trixel shaders every frame.
+/// Viewport and scale-factor queries are needed when mapping pixel coordinates
+/// to world space.
+
+/// Camera position in isometric 2-D canvas space (trixel units).
 vec2 getCameraPosition2DIso();
+/// Current zoom factor as a 2-D scale (x and y may differ for anisotropic zoom).
 vec2 getCameraZoom();
+/// Size of one trixel in screen pixels at the current zoom level.
 vec2 getTriangleStepSizeScreen();
+/// Render viewport dimensions in pixels.
 ivec2 getViewport();
+/// Ratio of output framebuffer pixels to screen pixels (HiDPI scale factor).
 ivec2 getOutputScaleFactor();
+/// Copy a rectangular region from the default framebuffer into @p rgbaData (RGBA8).
+/// Returns @c false on GL error. Used by the screenshot system.
 bool readDefaultFramebuffer(int x, int y, int width, int height, void *rgbaData);
+/// Mouse position in the output view (after upscaling), in pixels.
 vec2 getMousePositionOutputView();
+/// Logical game resolution before any output upscaling.
 vec2 getGameResolution();
+/// Main canvas size in trixels.
 vec2 getMainCanvasSizeTrixels();
-// Mouse position in iso coordinates as it appears on the screen
-vec2 mousePosition2DIsoScreenRender();
-// Mouse position in iso coordinates as it appears in the world
-// (so with camera offset)
-vec2 mousePosition2DIsoWorldRender();
-vec2 mousePosition2DIsoUpdate();
-ivec2 mouseTrixelPositionWorld();
-IREntity::EntityId getEntityIdAtMouseTrixel();
+/// @}
 
+/// @{
+/// @name Mouse position (iso space)
+/// Multiple iso-space mouse position variants are maintained because the render
+/// and update pipelines run at different rates and the camera offset matters.
+
+/// Mouse position in iso canvas coordinates **as seen on screen** — no camera offset.
+/// Use this to align UI overlays to the render output.
+vec2 mousePosition2DIsoScreenRender();
+/// Mouse position in iso canvas coordinates **in world space** — camera offset applied.
+/// Use this for world-space entity placement or selection.
+vec2 mousePosition2DIsoWorldRender();
+/// Mouse position in iso world space sampled during the UPDATE pipeline tick.
+/// Use this inside update systems; it may lag the render-pipeline variants by one frame.
+vec2 mousePosition2DIsoUpdate();
+/// Integer trixel coordinate of the mouse in world space.
+ivec2 mouseTrixelPositionWorld();
+/// Entity id of the voxel under the mouse cursor, read from the entity-id GPU texture.
+/// @note This reads a persistent-mapped GPU buffer — values become valid only after the
+///       GPU pipeline has completed the previous frame's @c FRAMEBUFFER_TO_SCREEN pass.
+IREntity::EntityId getEntityIdAtMouseTrixel();
+/// @}
+
+/// @{
+/// @name Camera setters
 void setCameraZoom(float zoom);
 void setCameraPosition2DIso(vec2 pos);
+/// @}
+
+/// @{
+/// @name Voxel render mode
+/// @see VoxelRenderMode for SNAPPED vs SMOOTH trade-offs.
+/// @see getVoxelRenderEffectiveSubdivisions for the value actually used by shaders.
 void setVoxelRenderMode(VoxelRenderMode mode);
 VoxelRenderMode getVoxelRenderMode();
+/// Set the subdivision count for @c SMOOTH mode. Higher values = smoother panning,
+/// more GPU work. Also multiplied by zoom in the compute pass.
 void setVoxelRenderSubdivisions(int subdivisions);
 int getVoxelRenderSubdivisions();
+/// The actual subdivisions value sent to the shader: @c subdivisions × zoom factor.
 int getVoxelRenderEffectiveSubdivisions();
 void zoomMainBackgroundPatternIn();
 void zoomMainBackgroundPatternOut();
+/// @}
 
+/// @{
+/// @name GUI state
 void setGuiVisible(bool visible);
 void toggleGuiVisible();
 bool isGuiVisible();
-
+/// Scale the GUI canvas. Changing this resizes the GUI canvas entity — do not change
+/// mid-frame without understanding the coordinate-mapping consequences.
 void setGuiScale(int scale);
 int getGuiScale();
-
+/// Enable / disable the trixel hover highlight (visual ring around the trixel under
+/// the cursor). Entity-id detection continues regardless of this flag.
 void setHoveredTrixelVisible(bool visible);
 bool isHoveredTrixelVisible();
+/// @}
 
 } // namespace IRRender
 

--- a/engine/render/include/irreden/render/ir_render_enums.hpp
+++ b/engine/render/include/irreden/render/ir_render_enums.hpp
@@ -5,18 +5,27 @@
 
 namespace IRRender {
 
+/// @{
+/// @name Texture enums
+
+/// Dimensionality of a GPU texture object.
 enum class TextureKind : std::uint8_t {
-    TEXTURE_2D,
-    TEXTURE_3D,
-    TEXTURE_2D_ARRAY
+    TEXTURE_2D,       ///< Standard 2-D texture (most canvas textures).
+    TEXTURE_3D,       ///< Volume texture (3-D voxel maps).
+    TEXTURE_2D_ARRAY  ///< Array of 2-D layers (e.g. sprite sheets).
 };
 
+/// Image-unit access qualifier for compute-shader image bindings.
 enum class TextureAccess : std::uint8_t {
-    READ_ONLY,
-    WRITE_ONLY,
-    READ_WRITE
+    READ_ONLY,   ///< @c readonly image (GLSL) / @c texture_access::read (MSL).
+    WRITE_ONLY,  ///< @c writeonly image.
+    READ_WRITE   ///< @c image (default, both read and write).
 };
 
+/// Internal texture format. Matches the GLSL/MSL image format qualifier.
+/// - @c R32I — canvas distance texture; written via @c imageAtomicMin.
+/// - @c RG32UI — entity-id texture; stores (low, high) 32-bit halves.
+/// - @c DEPTH24_STENCIL8 — framebuffer depth+stencil attachment.
 enum class TextureFormat : std::uint8_t {
     RGBA8,
     RGBA32F,
@@ -25,12 +34,14 @@ enum class TextureFormat : std::uint8_t {
     DEPTH24_STENCIL8
 };
 
+/// CPU-side pixel format for @c glReadPixels / texture upload.
 enum class PixelDataFormat : std::uint8_t {
     RGBA,
     RED_INTEGER,
     RG_INTEGER
 };
 
+/// CPU-side pixel data type for @c glReadPixels / texture upload.
 enum class PixelDataType : std::uint8_t {
     UNSIGNED_BYTE,
     INT32,
@@ -38,17 +49,25 @@ enum class PixelDataType : std::uint8_t {
     FLOAT32
 };
 
+/// Texture wrap mode for UV coordinates outside [0, 1].
 enum class TextureWrap : std::uint8_t {
     REPEAT,
     CLAMP_TO_EDGE,
     MIRRORED_REPEAT
 };
 
+/// Texture sampling filter.
 enum class TextureFilter : std::uint8_t {
-    NEAREST,
-    LINEAR
+    NEAREST,  ///< Pixel-art / no interpolation.
+    LINEAR    ///< Bilinear interpolation.
 };
 
+/// @}
+
+/// @{
+/// @name Buffer enums
+
+/// GPU buffer binding target.
 enum class BufferTarget : std::uint8_t {
     VERTEX,
     INDEX,
@@ -57,19 +76,29 @@ enum class BufferTarget : std::uint8_t {
     PIXEL_PACK
 };
 
+/// Bit-combinable storage flags for persistent-mapped GPU buffers.
+/// Combine with @c |: e.g. @c BUFFER_STORAGE_MAP_READ | @c BUFFER_STORAGE_MAP_PERSISTENT.
+/// @note @c MAP_PERSISTENT + @c MAP_COHERENT is used by @c HoveredEntityIdBuffer —
+///       read it only after the GPU fence signals or you get last-frame garbage.
 enum BufferStorageFlag : std::uint32_t {
-    BUFFER_STORAGE_NONE = 0,
-    BUFFER_STORAGE_DYNAMIC = 1u << 0,
-    BUFFER_STORAGE_MAP_READ = 1u << 1,
-    BUFFER_STORAGE_MAP_WRITE = 1u << 2,
+    BUFFER_STORAGE_NONE        = 0,
+    BUFFER_STORAGE_DYNAMIC     = 1u << 0,
+    BUFFER_STORAGE_MAP_READ    = 1u << 1,
+    BUFFER_STORAGE_MAP_WRITE   = 1u << 2,
     BUFFER_STORAGE_MAP_PERSISTENT = 1u << 3,
-    BUFFER_STORAGE_MAP_COHERENT = 1u << 4
+    BUFFER_STORAGE_MAP_COHERENT   = 1u << 4
 };
 
 inline constexpr std::uint32_t operator|(BufferStorageFlag lhs, BufferStorageFlag rhs) {
     return static_cast<std::uint32_t>(lhs) | static_cast<std::uint32_t>(rhs);
 }
 
+/// @}
+
+/// @{
+/// @name Shader / draw enums
+
+/// Stage type passed to @c Shader construction.
 enum class ShaderType : std::uint8_t {
     VERTEX,
     FRAGMENT,
@@ -77,6 +106,8 @@ enum class ShaderType : std::uint8_t {
     GEOMETRY
 };
 
+/// Memory-barrier scope after a compute dispatch. @c ALL is safe but coarse;
+/// prefer a narrower scope when possible to avoid unnecessary GPU pipeline flushes.
 enum class BarrierType : std::uint8_t {
     ALL,
     SHADER_STORAGE,
@@ -84,24 +115,30 @@ enum class BarrierType : std::uint8_t {
     COMMAND
 };
 
+/// Polygon rasterization mode. @c LINE / @c POINT are useful for wireframe debugging.
 enum class PolygonMode : std::uint8_t {
     FILL,
     LINE,
     POINT
 };
 
+/// Primitive topology for a draw call.
 enum class DrawMode : std::uint8_t {
     TRIANGLES,
     LINES
 };
 
+/// Index buffer element size. Only @c UNSIGNED_SHORT (uint16) is used.
 enum class IndexType : std::uint8_t {
     UNSIGNED_SHORT
 };
 
+/// Vertex attribute element type.
 enum class VertexAttributeDataType : std::uint8_t {
     FLOAT32
 };
+
+/// @}
 
 } // namespace IRRender
 

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -9,14 +9,22 @@
 using namespace IRMath;
 
 namespace IRRender {
+
+/// Opaque handle returned by @c createResource<T>() / @c createNamedResource<T>().
+/// Pass to @c getResource<T>() / @c destroyResource<T>().
 typedef uint32_t ResourceId;
+
+/// Internal type discriminant used by @c RenderingResourceManager; not used by callers.
 typedef uint32_t ResourceType;
 
+/// Single trixel (triangle-pixel) value written by the voxel→trixel compute shaders.
 struct TrixelData {
     vec4 color_;
     int distance_;
 };
 
+/// UBO uploaded once at init time. Contains the distance sentinel values used
+/// in both GLSL and Metal shaders to detect "empty" trixels.
 struct GlobalConstantsGLSL {
     int kMinTriangleDistance = IRConstants::kTrixelDistanceMinDistance;
     int kMaxTriangleDistance = IRConstants::kTrixelDistanceMaxDistance;
@@ -74,7 +82,14 @@ struct GlyphDrawCommand {
     uint32_t styleFlags = 0;
 };
 
+/// How the output canvas is scaled to fill the window.
 enum class FitMode { FIT, STRETCH, UNKNOWN };
+
+/// Controls sub-voxel positioning in the voxel→trixel compute pass.
+/// - @c SNAPPED — voxels snap to the nearest trixel grid cell. Fast, pixel-perfect.
+/// - @c SMOOTH  — sub-trixel offsets are applied using @c subdivisions × zoom.
+///   Produces smoother camera panning but costs more GPU time. Changing mode or
+///   subdivisions mid-frame stalls the pipeline.
 enum class VoxelRenderMode { SNAPPED = 0, SMOOTH = 1 };
 enum class LodLevel : std::uint32_t {
     LOD_0 = 0,
@@ -97,6 +112,8 @@ struct GPUUpdateParams {
     int _padding[3] = {};
 };
 
+/// SDF primitive type dispatched to the shapes→trixel compute shader.
+/// Each value corresponds to a branch in the shader's SDF evaluation function.
 enum class ShapeType : std::uint32_t {
     BOX = 0,
     SPHERE = 1,
@@ -105,25 +122,26 @@ enum class ShapeType : std::uint32_t {
     CURVED_PANEL = 4,
     WEDGE = 5,
     TAPERED_BOX = 6,
-    CUSTOM_SDF = 7,
+    CUSTOM_SDF = 7,  ///< User-supplied SDF; requires a matching shader specialization.
     CONE = 8,
     TORUS = 9
 };
 
+/// Bit-combinable rendering flags stored in @c GPUShapeDescriptor::flags.
+/// Combine with @c |.
 enum ShapeFlags : std::uint32_t {
-    SHAPE_FLAG_NONE = 0,
-    SHAPE_FLAG_HOLLOW = 1u << 0,
-    SHAPE_FLAG_MIRROR_X = 1u << 1,
-    SHAPE_FLAG_MIRROR_Y = 1u << 2,
-    SHAPE_FLAG_VISIBLE = 1u << 3,
-    // Forward-looking: when joints are wired, snap rotation to nearest
-    // 90-degree increments in iso-adjusted coordinates. Not yet implemented.
+    SHAPE_FLAG_NONE       = 0,
+    SHAPE_FLAG_HOLLOW     = 1u << 0,  ///< Render only the shell; skip interior voxels.
+    SHAPE_FLAG_MIRROR_X   = 1u << 1,
+    SHAPE_FLAG_MIRROR_Y   = 1u << 2,
+    SHAPE_FLAG_VISIBLE    = 1u << 3,
+    /// Forward-looking: snap joint rotation to nearest 90° in iso-adjusted space.
+    /// Not yet implemented.
     SHAPE_FLAG_DISCRETE_ROTATION = 1u << 4,
-    SHAPE_FLAG_CHECKERBOARD = 1u << 5,
-    // Color each voxel by its LOCAL iso-depth along the camera's forward axis,
-    // normalized to [0,1] over the shape's own depth extent.  Useful for
-    // visually distinguishing individual shapes regardless of their position
-    // in the scene (compared to absolute world-depth colouring).
+    SHAPE_FLAG_CHECKERBOARD      = 1u << 5,
+    /// Color each voxel by its LOCAL iso-depth along the camera's forward axis,
+    /// normalized to [0, 1] over the shape's own depth extent. Useful for
+    /// visually distinguishing individual shapes regardless of world position.
     SHAPE_FLAG_DEPTH_COLOR = 1u << 6,
 };
 
@@ -165,6 +183,12 @@ struct GPUShapesFrameData {
     ivec2 cullIsoMax;
 };
 
+/// @{
+/// @name GPU buffer binding points
+/// **CRITICAL:** These indices are hard-coded in both C++ and GLSL/MSL shaders.
+/// A mismatch between C++ and the shader is **silent** — no error, just wrong
+/// uniforms / garbage data. When adding or renaming a buffer, update the
+/// corresponding @c binding or @c [[buffer(N)]] annotation in the shader as well.
 constexpr std::uint32_t kBufferIndex_FrameDataUniform = 0;
 constexpr std::uint32_t kBufferIndex_GlobalConstantsGLSL = 1;
 constexpr std::uint32_t kBufferIndex_FramebufferFrameDataUniform = 2;
@@ -191,6 +215,7 @@ constexpr std::uint32_t kBufferIndex_ChunkVisibility = 24;
 constexpr std::uint32_t kBufferIndex_CompactedVoxelIndices = 25;
 constexpr std::uint32_t kBufferIndex_IndirectDispatchParams = 26;
 constexpr std::uint32_t kBufferIndex_ShapeTileDescriptors = 30;
+/// @}
 
 // One entry per dispatched tile in the batched shapes→trixel pass.
 // shapeIndex picks the ShapeDescriptor; tileIsoOrigin is the iso-space


### PR DESCRIPTION
Documentation pass for the render module public facade headers. No logic changes. Deliberately scoped to the three public-facing headers only — render internals (`render_manager.hpp`, `rendering_rm.hpp`, GPU buffer/shader/VAO implementation files) are Opus territory per CLAUDE.md.

## Changes

**`engine/render/include/irreden/render/ir_render_enums.hpp`**
- GPU texture enums (`TextureKind`, `TextureAccess`, `TextureFormat`, `PixelDataFormat`, `PixelDataType`, `TextureWrap`, `TextureFilter`) grouped under `@{`/`@}` with GLSL/MSL format notes
- Buffer enums (`BufferTarget`, `BufferStorageFlag`) with persistent-mapped buffer caveat (`HoveredEntityIdBuffer` read-after-GPU-write note)
- Shader/draw enums (`ShaderType`, `BarrierType`, `PolygonMode`, `DrawMode`, `IndexType`, `VertexAttributeDataType`)

**`engine/render/include/irreden/render/ir_render_types.hpp`**
- `ResourceId` / `ResourceType`: purpose documented
- `VoxelRenderMode`: SNAPPED (fast, pixel-perfect) vs SMOOTH (sub-trixel, costs GPU) trade-off note
- `ShapeType`: SDF primitive dispatch note
- `ShapeFlags`: bit-flag descriptions including `DEPTH_COLOR` explanation
- Buffer bind-point constants grouped under `@{`/`@}` with **CRITICAL** warning: indices are hard-coded in both C++ and GLSL/MSL — a mismatch is silent (wrong uniforms, no error)

**`engine/render/include/irreden/ir_render.hpp`**
- Resource CRUD templates (`createResource`, `createNamedResource`, `destroyResource`, `getResource`, `getNamedResource`) with `ResourceId` lifetime note
- Voxel pool (`allocateVoxels`, `deallocateVoxels`) with co-indexed spans explanation
- Canvas management group: `createCanvas`, `getCanvas`, `hasCanvas`, `setActiveCanvas`, mid-frame destroy warning
- Camera/viewport group: `getCameraPosition2DIso`, `getCameraZoom`, `getViewport`, `getOutputScaleFactor`, `readDefaultFramebuffer`
- Mouse iso-space variants: three `mousePosition2DIsо*` functions distinguished by screen vs world vs update-pipeline; `getEntityIdAtMouseTrixel` with GPU fence note
- Voxel render mode group with `getVoxelRenderEffectiveSubdivisions` explanation
- GUI state group with `setGuiScale` coordinate-mapping warning

## Tests

259 tests pass (excluding pre-existing `EasingMapTest.AllFunctionsBoundaryConditions` failure on master — fix in PR #132, fleet:approved, not yet merged).
