### PR TITLE
fleet: per-worktree builds, fleet-run, review --body-file

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -75,7 +75,8 @@ When you do pick a task:
 3. Flip the task to `[~]`, set Owner to `opus-architect`, and commit
    the edit in your first commit on the work branch.
 4. Build the target you touched with `fleet-build --target <name>`.
-   Run the relevant executable if one exists for the touched code.
+   Run the relevant executable if one exists for the touched code:
+   `fleet-run <executable-name>`
 5. Use the `commit-and-push` skill to open the PR. If the task has an
    `**Issue:** #N` field, include `Closes #N` in the PR body so the
    issue closes automatically when the PR merges.

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -88,13 +88,15 @@ than the Sonnet reviewer. Each iteration:
       not duplicate work Sonnet already did. Your review body should
       explicitly call out the Sonnet review by saying "Sonnet flagged
       X; on closer read I confirm/disagree because Y".
-   d. If the PR is sound, post the review with `--comment` and a
-      clear "Verdict: approve" line. If not, post `--comment` with
-      "Verdict: needs-fix" or "Verdict: blocker" and concrete fixes.
+   d. Post the review: write the review body to `/tmp/review-body.md`
+      using the **Write tool**, then:
+      `gh pr review <N> --comment --body-file /tmp/review-body.md`
+      For game PRs, add `--repo <game-repo>`.
+      **Never** use `--body "$(cat ...)"` or `--body "<text>"` — shell
+      escaping of backticks and special characters causes parse errors.
       Do **not** use `--approve` or `--request-changes` — all fleet
       agents share one GitHub account, and GitHub rejects formal
       review actions on your own PRs.
-      For game PRs, add `--repo <game-repo>` to all `gh` commands.
    e. **Set the PR label** to match your verdict (add `--repo
       <game-repo>` for game PRs). The label is the primary signal
       the human uses. Always remove stale labels first:

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -138,8 +138,11 @@ limit. Each loop iteration:
 
 5. **Build and run.**
    `fleet-build --target <name>`
-   If the touched code has an executable target, run it once. Untested
-   commits are the single biggest waste of reviewer-agent time.
+   If the touched code has an executable target, run it once:
+   `fleet-run <executable-name>`
+   **Never** use `cd <dir> && ./<exe>` — that triggers the compound-
+   command security gate. Untested commits are the single biggest
+   waste of reviewer-agent time.
 
 6. **Stop and escalate if the task is subtler than expected.** If the
    work touches:

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -91,7 +91,11 @@ usage limit. Each iteration:
       this engine worktree). Focus on code quality, style, and obvious
       bugs. For game-specific conventions, read the game CLAUDE.md at
       `~/src/IrredenEngine/creations/game/CLAUDE.md`.
-   d. Post the review: `gh pr review <N> --repo <game-repo> --comment --body "<review>"`
+   d. Post the review: write the review body to `/tmp/review-body.md`
+      using the **Write tool**, then:
+      `gh pr review <N> --repo <game-repo> --comment --body-file /tmp/review-body.md`
+      **Never** use `--body "$(cat ...)"` or `--body "<text>"` — shell
+      escaping of backticks and special characters causes parse errors.
    e. Set labels — always remove stale labels first:
       `gh pr edit <N> --repo <game-repo> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
       (swap the add-label name for `fleet:needs-fix` or `fleet:blocker` as appropriate).

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -191,10 +191,16 @@ compliance or raise an issue.
 
 ### 5. Write the review
 
-Post the review as a PR comment via `gh pr review`:
+Post the review as a PR comment via `gh pr review`. **Do NOT use
+`--body "$(cat <<'EOF'...)"` or any `$(...)` command substitution** —
+it triggers Claude Code's `command_substitution` security gate and
+causes parse errors when the body contains backticks or special
+characters. Instead, write the body to a temp file with the **Write
+tool**, then pass it with `--body-file`:
 
-```bash
-gh pr review <N> --comment --body "$(cat <<'EOF'
+1. Use the **Write tool** to write the review body to `/tmp/review-body.md`:
+
+```markdown
 ## Review — <title>
 
 **Verdict:** <approve | needs-fix | blocker>
@@ -216,8 +222,12 @@ gh pr review <N> --comment --body "$(cat <<'EOF'
 - [ ] <...>
 
 🤖 Reviewed by Claude Opus 4.6 (review-pr skill)
-EOF
-)"
+```
+
+2. Post the review:
+
+```bash
+gh pr review <N> --comment --body-file /tmp/review-body.md
 ```
 
 Rules for the review body:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,8 @@ runtime (`libgcc_s_seh-1.dll`, `libstdc++-6.dll`,
 `avutil-*`, `swscale-*`) are toolchain-supplied and live at
 `C:\msys64\mingw64\bin` — they are **not** copied next to the exe. The
 Windows DLL loader needs that directory on `PATH`. `fleet-run` handles
-this automatically on Windows.
+the working-directory requirement, but you still need
+`C:\msys64\mingw64\bin` on PATH for the MinGW runtime DLLs.
 
 Each creation typically defines an `IR<Name>Run` custom target that
 builds + launches with the correct working directory (on both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,12 @@ it in a dedicated PR, not to work around it.
 
 In all three cases:
 
-- The build tree is configured against the **main clone**, not against
-  `.claude/worktrees/...` subdirectories. Agents inside a worktree
-  must edit files at the main clone path for the change to reach the
-  build. Markdown, skill files, and docs can be edited in-worktree
-  freely.
+- **Each worktree has its own build tree.** `fleet-build` auto-detects
+  the worktree root (`git rev-parse --show-toplevel`) and uses
+  `<worktree>/build/`. If the build hasn't been configured yet,
+  `fleet-build` runs `cmake --preset` automatically. Agents edit
+  files in their own worktree and build there — no need to touch the
+  main clone.
 - `CMAKE_CXX_STANDARD` is **23**; your compiler must support it.
   (gcc ≥ 13 on Linux/WSL, gcc ≥ 13 via MSYS2 on Windows.)
 
@@ -273,18 +274,25 @@ single biggest waste of reviewer-agent time.
 
 ## Running an executable
 
+**Fleet agents: use `fleet-run` instead of `cd <dir> && ./<exe>`.**
+The `cd && command` pattern triggers Claude Code's compound-command
+security gate and blocks unattended operation. `fleet-run` finds the
+executable in the build tree, cd's into its directory (so sibling
+`data/`, `shaders/`, `scripts/` are on its CWD), and runs it:
+
+```bash
+fleet-run IRShapeDebug
+fleet-run IrredenEngineTest --gtest_brief=1
+```
+
+`fleet-run` auto-detects the build directory using the same logic as
+`fleet-build` (worktree root → `<root>/build`).
+
 ### On Linux / WSL (fleet)
 
 No runtime-DLL drama. Binaries are ELF files; deps resolve through the
 normal dynamic linker using `rpath` (CMake sets this automatically for
-targets in `build/`). Run the exe from its own build directory so its
-sibling `data/`, `shaders/`, and `scripts/` are on its working
-directory:
-
-```bash
-cd ~/src/IrredenEngine/build/creations/demos/shape_debug
-./IRShapeDebug
-```
+targets in `build/`).
 
 WSLg routes GLFW/OpenGL windows to the Windows host automatically on
 Windows 11 and recent Windows 10 — no X server setup required. Audio
@@ -302,18 +310,8 @@ runtime (`libgcc_s_seh-1.dll`, `libstdc++-6.dll`,
 `libwinpthread-1.dll`) and FFmpeg DLLs (`avcodec-*`, `avformat-*`,
 `avutil-*`, `swscale-*`) are toolchain-supplied and live at
 `C:\msys64\mingw64\bin` — they are **not** copied next to the exe. The
-Windows DLL loader needs that directory on `PATH`.
-
-From the Bash tool:
-
-```bash
-cd "C:/Users/evinj/VSCODE_PROJECTS/repos/IrredenEngine/build/creations/demos/shape_debug" && \
-PATH="/c/msys64/mingw64/bin:$PATH" cmd.exe /c "set PATH=C:\\msys64\\mingw64\\bin;%PATH% && .\IRShapeDebug.exe"
-```
-
-The double `PATH` set is intentional. Run from the exe's own directory
-— that's where its sibling DLLs and `data/`, `shaders/`, `scripts/`
-live.
+Windows DLL loader needs that directory on `PATH`. `fleet-run` handles
+this automatically on Windows.
 
 Each creation typically defines an `IR<Name>Run` custom target that
 builds + launches with the correct working directory (on both

--- a/scripts/fleet/fleet-build
+++ b/scripts/fleet/fleet-build
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-# fleet-build — cmake --build wrapper with auto-parallelism.
+# fleet-build — cmake --build wrapper with auto-parallelism and worktree detection.
 #
 # Removes the need for agents to embed $(nproc) or $(sysctl -n hw.ncpu)
 # in their Bash calls, which triggers Claude Code's command_substitution
 # security gate and blocks unattended operation.
+#
+# Auto-detects the current git worktree root and uses <root>/build as
+# the build directory. Each worktree gets its own build tree — no more
+# conflicts between parallel agents. If the build tree hasn't been
+# configured yet, fleet-build runs cmake --preset automatically.
 #
 # Usage:
 #   fleet-build --target IRShapeDebug
@@ -18,9 +23,29 @@
 
 set -euo pipefail
 
-BUILD_DIR="${IRREDEN_BUILD_DIR:-$HOME/src/IrredenEngine/build}"
+# --- Build directory resolution ---
+# Priority: $IRREDEN_BUILD_DIR > <worktree-root>/build > ~/src/IrredenEngine/build
+WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/src/IrredenEngine")
+BUILD_DIR="${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}"
 
-# Auto-detect CPU count if no -j flag was passed.
+# --- Auto-configure if the build tree doesn't exist yet ---
+if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+    case "$(uname -s)" in
+        Darwin)          PRESET="macos-debug" ;;
+        Linux)           PRESET="linux-debug" ;;
+        MINGW*|MSYS*|CYGWIN*) PRESET="windows-debug" ;;
+        *)
+            echo "fleet-build: unsupported platform $(uname -s)" >&2
+            exit 1
+            ;;
+    esac
+    echo "fleet-build: no build tree at $BUILD_DIR"
+    echo "fleet-build: configuring with preset '$PRESET'..."
+    cmake --preset "$PRESET" -S "$WORKTREE_ROOT"
+    echo "fleet-build: configure done."
+fi
+
+# --- Auto-detect CPU count if no -j flag was passed ---
 has_j_flag=false
 for arg in "$@"; do
     case "$arg" in

--- a/scripts/fleet/fleet-run
+++ b/scripts/fleet/fleet-run
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# fleet-run — find and run a built executable from its own directory.
+#
+# Avoids the `cd <dir> && ./<exe>` pattern that triggers Claude Code's
+# compound-command security gate and blocks unattended operation.
+#
+# The executable runs from its own directory so sibling data/, shaders/,
+# and scripts/ directories are on its CWD (required by most creations).
+#
+# Usage:
+#   fleet-run IrredenEngineTest --gtest_brief=1
+#   fleet-run IRShapeDebug
+#   fleet-run --build-dir /path/to/build IrredenEngineTest
+#
+# Source of truth: scripts/fleet/fleet-run in the engine repo.
+# Installed to ~/bin/fleet-run (as a symlink) by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+BUILD_DIR=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        --help|-h)
+            cat <<'USAGE'
+usage: fleet-run [--build-dir <dir>] <executable-name> [args...]
+
+Finds <executable-name> in the build tree, cd's into its directory,
+and runs it. Sibling data/shaders/scripts directories are on CWD.
+
+Options:
+  --build-dir <dir>   Override the build directory (default: auto-detect)
+
+Build directory resolution (in order):
+  1. --build-dir flag
+  2. $IRREDEN_BUILD_DIR environment variable
+  3. <git-worktree-root>/build
+  4. ~/src/IrredenEngine/build (fallback)
+USAGE
+            exit 0
+            ;;
+        --) shift; break ;;
+        -*) echo "fleet-run: unknown option $1" >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: fleet-run [--build-dir <dir>] <executable-name> [args...]" >&2
+    exit 2
+fi
+
+EXE_NAME="$1"
+shift
+
+# Default build dir: same auto-detection logic as fleet-build.
+if [[ -z "$BUILD_DIR" ]]; then
+    WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/src/IrredenEngine")
+    BUILD_DIR="${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}"
+fi
+
+if [[ ! -d "$BUILD_DIR" ]]; then
+    echo "fleet-run: build directory $BUILD_DIR does not exist." >&2
+    echo "           run 'fleet-build --target $EXE_NAME' first." >&2
+    exit 1
+fi
+
+# Find the executable in the build tree.
+EXE_PATH=$(find "$BUILD_DIR" -name "$EXE_NAME" -type f -perm +111 2>/dev/null | head -1)
+
+if [[ -z "$EXE_PATH" ]]; then
+    echo "fleet-run: could not find executable '$EXE_NAME' in $BUILD_DIR" >&2
+    echo "           build it first: fleet-build --target $EXE_NAME" >&2
+    exit 1
+fi
+
+EXE_DIR=$(dirname "$EXE_PATH")
+
+echo "fleet-run: $EXE_PATH $*"
+cd "$EXE_DIR"
+exec "./$EXE_NAME" "$@"

--- a/scripts/fleet/fleet-run
+++ b/scripts/fleet/fleet-run
@@ -66,7 +66,7 @@ if [[ ! -d "$BUILD_DIR" ]]; then
 fi
 
 # Find the executable in the build tree.
-EXE_PATH=$(find "$BUILD_DIR" -name "$EXE_NAME" -type f -perm +111 2>/dev/null | head -1)
+EXE_PATH=$(find "$BUILD_DIR" -name "$EXE_NAME" -type f -perm -u=x 2>/dev/null | head -1)
 
 if [[ -z "$EXE_PATH" ]]; then
     echo "fleet-run: could not find executable '$EXE_NAME' in $BUILD_DIR" >&2

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -179,6 +179,7 @@ baseline = [
     "Bash(dirname:*)",
     "Bash(fleet-claim:*)",
     "Bash(fleet-build:*)",
+    "Bash(fleet-run:*)",
 ]
 
 # Preserve any user-granted "always allow" entries from previous sessions,

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -66,6 +66,8 @@ FLEET_CLAIM_SRC="$SCRIPT_DIR/fleet-claim"
 FLEET_CLAIM_DEST="$HOME/bin/fleet-claim"
 FLEET_BUILD_SRC="$SCRIPT_DIR/fleet-build"
 FLEET_BUILD_DEST="$HOME/bin/fleet-build"
+FLEET_RUN_SRC="$SCRIPT_DIR/fleet-run"
+FLEET_RUN_DEST="$HOME/bin/fleet-run"
 FLEET_BABYSIT_SRC="$SCRIPT_DIR/fleet-babysit"
 FLEET_BABYSIT_DEST="$HOME/bin/fleet-babysit"
 
@@ -77,7 +79,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_BABYSIT_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -99,6 +101,11 @@ fi
 if [[ -f "$FLEET_BUILD_SRC" ]]; then
     ln -sf "$FLEET_BUILD_SRC" "$FLEET_BUILD_DEST"
     echo "symlinked $FLEET_BUILD_DEST -> $FLEET_BUILD_SRC"
+fi
+
+if [[ -f "$FLEET_RUN_SRC" ]]; then
+    ln -sf "$FLEET_RUN_SRC" "$FLEET_RUN_DEST"
+    echo "symlinked $FLEET_RUN_DEST -> $FLEET_RUN_SRC"
 fi
 
 if [[ -f "$FLEET_BABYSIT_SRC" ]]; then


### PR DESCRIPTION
## Summary
- **fleet-run** (new script): finds and runs built executables from their own directory, replacing the `cd <dir> && ./<exe>` pattern that triggers Claude Code's compound-command security gate
- **fleet-build** updated: auto-detects git worktree root, uses `<worktree>/build` instead of hardcoded `~/src/IrredenEngine/build`. Auto-configures with `cmake --preset` if the build tree doesn't exist yet. Each worktree gets its own build — no more conflicts between parallel agents
- **review-pr skill + reviewer roles**: write review body to `/tmp/review-body.md` via Write tool, then pass `--body-file` instead of `--body "$(cat <<'EOF'...)"`. Fixes parse errors when review body contains backticks or special characters
- **install.sh / fleet-up**: install fleet-run symlink, add `Bash(fleet-run:*)` to worktree permission baseline
- **CLAUDE.md**: documents per-worktree builds and fleet-run usage, removes stale "edit at main clone" instruction
- **Role files**: sonnet-author and opus-architect reference fleet-run for running executables

## Test plan
- [ ] Run `scripts/fleet/install.sh` — verify fleet-run symlink appears in ~/bin
- [ ] From a worktree with no build/, run `fleet-build --target IrredenEngineTest` — verify it auto-configures
- [ ] Run `fleet-run IrredenEngineTest --gtest_brief=1` — verify it finds and runs the test binary
- [ ] Verify sonnet-reviewer can post a review containing backticks without parse errors

Generated with [Claude Code](https://claude.com/claude-code)