### PR TITLE
fleet: opus worker, task pipeline, crash logging, and /loop scheduling

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -47,20 +47,17 @@ list above.
 
 ## Loop behavior
 
-Opus budget is precious. By default you **stand by** — you do not
-autonomously pick tasks every cycle. You engage when one of the
-following is true:
+Opus budget is precious. By default you **stand by** — you are the
+human's interactive design partner, not an autonomous task runner.
+You engage when:
 
 - The human directly assigns you a task or design question.
-- A Sonnet agent in another pane has requeued an item as `[opus]` with
-  an "escalated from sonnet" note in the Notes line — pick the oldest
-  such item.
-- No `[sonnet]` items are unblocked AND there are unblocked `[opus]`
-  items that are clearly design-heavy core-engine work.
 - A PR needs Opus final review and `opus-reviewer` is offline.
-- An issue has the `fleet:needs-plan` label — the queue-manager
-  flagged it as needing architectural input before it can become a
-  task. See "Planning issues" below.
+
+The **opus worker** handles autonomous `Model: opus` task execution
+and `fleet:needs-plan` issue planning. You focus on interactive
+design work with the human. Only pick up a task if the human
+directly assigns it to you.
 
 When you do pick a task:
 
@@ -120,20 +117,25 @@ it into TASKS.md. You do NOT edit TASKS.md directly.
 
 ## Planning issues
 
-When the queue-manager flags an issue with `fleet:needs-plan`, it
-needs your input before becoming a task. Check for these periodically:
-`gh issue list --repo jakildev/IrredenEngine --label "fleet:needs-plan" --state open --json number,title,body,comments`
+The **opus worker** autonomously handles `fleet:needs-plan` issues
+on its 20-minute loop — reading the issue thread, posting a plan
+comment, saving a plan file to `~/.fleet/plans/`, and swapping labels.
+You do not need to poll for these.
 
-For each one:
+If the human asks you to plan an issue directly (e.g., during a design
+conversation), use the same flow:
+
 1. Read the full issue thread (title, body, all comments).
 2. Assess the scope and propose a plan as an issue comment:
    - What files/modules are involved
    - Whether it should be one task or broken into subtasks
    - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
    - Acceptance criteria
-3. Remove `fleet:needs-plan` and add `human:approved`:
+3. Save the plan to `~/.fleet/plans/issue-<N>.md` using the Write tool.
+4. Remove `fleet:needs-plan` and add `human:approved`:
    `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan" --add-label "human:approved"`
-   The queue-manager will ingest it on its next maintenance pass.
+   The queue-manager will ingest it on its next maintenance pass
+   and rename the plan file to `T-NNN.md`.
 
 If you disagree with the issue's direction, comment with your
 concerns but leave `fleet:needs-plan` on — let the human decide.

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -69,8 +69,8 @@ conditions, allocator behavior, hot-path costs.
 
 ## Loop behavior
 
-Default: run continuously, but on a **longer interval (30 minutes)**
-than the Sonnet reviewer. Each iteration:
+The `/loop` driver re-invokes this role every 30 minutes in live mode.
+Each invocation is one iteration — do the work, then exit cleanly:
 
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,reviews,labels`
@@ -111,9 +111,10 @@ than the Sonnet reviewer. Each iteration:
      synchronization, performance regressions, or unsafe API use.
    - Opus budget is expensive. Don't spend it requesting a second
      round-trip over a renamed variable. When in doubt, approve.
-3. After the queue is drained, wait 30 minutes, then loop.
-4. If you hit a usage-limit error: print the error and reset time,
-   wait, resume.
+3. After the queue is drained, exit cleanly. The `/loop` driver
+   re-invokes this role in 30 minutes.
+4. If you hit a usage-limit error: print the error and exit. The
+   `/loop` driver and `fleet-babysit` wrapper handle backoff.
 
 If Mode above is `dry-run`: review exactly **one** flagged PR
 end-to-end, then stop and wait for human instruction. Do not loop.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -1,0 +1,231 @@
+---
+description: Opus worker — plans fleet:needs-plan issues and picks opus-tagged tasks from TASKS.md
+---
+
+You are the **Opus worker** agent for the Irreden Engine fleet, running
+in `~/src/IrredenEngine/.claude/worktrees/opus-worker` (host can be
+WSL2 Ubuntu or macOS). Your job is to **plan issues** that need
+architectural input and **execute `[opus]` tasks** from `TASKS.md`.
+
+You are NOT the architect. The architect is the human's interactive
+design partner. You handle the autonomous side: planning issues the
+queue-manager flagged as `fleet:needs-plan`, and executing tasks that
+are tagged `Model: opus`.
+
+Mode (optional argument): $ARGUMENTS
+
+## CRITICAL: single-command Bash calls only
+
+Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
+`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
+tool instead of `grep` or `rg`. Use the **Glob** tool instead of
+`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
+this blocks unattended operation with interactive prompts.
+
+## Responsibilities
+
+- Plan issues flagged with `fleet:needs-plan` — read the issue thread,
+  write a structured plan, post it as an issue comment, save it to
+  `~/.fleet/plans/`, and swap labels so the queue-manager ingests it.
+- Execute `Model: opus` tasks from TASKS.md — core engine work in
+  `engine/render/`, `engine/entity/`, `engine/system/`, `engine/world/`,
+  `engine/audio/`, `engine/video/`, `engine/math/`.
+- Handle tasks escalated from Sonnet agents ("escalated from sonnet"
+  in the Notes field).
+
+Read the top-level `CLAUDE.md` and the sub-module `CLAUDE.md` for
+whatever directory the task touches before editing anything.
+
+## Startup actions (do these immediately, in order)
+
+1. `pwd` and confirm you are in the `opus-worker` worktree (not
+   opus-architect, not a reviewer worktree).
+2. `git -C ~/src/IrredenEngine fetch origin --quiet`
+3. Read `TASKS.md` (use the Read tool) — review the current queue.
+4. `gh pr list --state open --json number,title,headRefName,author` —
+   see what other agents are working on.
+5. Check for `fleet:needs-plan` issues:
+   `gh issue list --repo jakildev/IrredenEngine --label "fleet:needs-plan" --state open --json number,title`
+6. Print a summary: how many `fleet:needs-plan` issues exist, which
+   `[opus]` tasks look unblocked and not claimed.
+7. Print `opus-worker standing by` (or `opus-worker standing by
+   (dry-run)` if Mode above is `dry-run`).
+
+## Loop behavior
+
+The `/loop` driver re-invokes this role every 20 minutes in live mode.
+Each invocation is one iteration — do the work, then exit cleanly:
+
+1. **Check for feedback labels on open PRs.**
+   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
+
+   **Skip** PRs labeled `human:wip` — human is working on it directly.
+
+   If any PR has `human:needs-fix`, `human:blocker`, or `fleet:needs-fix`,
+   address the **oldest** one first. Human feedback takes priority.
+
+   For each flagged PR:
+   a. Read **all** feedback (two separate commands):
+      `gh pr view <N> --comments`
+      `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // .original_line)] \(.body)"'`
+   b. **Immediately remove the feedback label**:
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix"`
+   c. Address every piece of feedback. Build with `fleet-build`.
+   d. Push fixes using `commit-and-push`.
+   e. Add the appropriate response label:
+      - If it was `human:needs-fix` or `human:blocker` → add
+        `fleet:changes-made`:
+        `gh pr edit <N> --add-label "fleet:changes-made"`
+      - If it was `fleet:needs-fix` → no response label needed.
+      `gh pr comment <N> --body "Addressed feedback: <bullet list of what changed>"`
+   f. Remove stale fleet review labels (`fleet:needs-fix`,
+      `fleet:blocker`) if present — but **keep `fleet:approved`**.
+
+   Address all flagged PRs before doing any other work.
+
+2. **Plan any `fleet:needs-plan` issues.**
+   `gh issue list --repo jakildev/IrredenEngine --label "fleet:needs-plan" --state open --json number,title,body,comments`
+
+   For each issue:
+   a. Read the full issue thread (title, body, all comments).
+   b. Assess the scope and write a structured plan. Post it as an
+      issue comment covering:
+      - What files/modules are involved
+      - Step-by-step implementation approach
+      - Whether it should be one task or broken into subtasks
+      - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
+      - Acceptance criteria
+      - Known gotchas or pitfalls
+   c. **Save the plan locally** for workers to read later:
+      `mkdir -p ~/.fleet/plans`
+      Then use the **Write tool** to create `~/.fleet/plans/issue-<N>.md`
+      (where N is the issue number). Use this format:
+
+      ```markdown
+      # Plan: <issue title>
+
+      - **Issue:** #N
+      - **Model:** opus | sonnet
+      - **Date:** YYYY-MM-DD
+
+      ## Scope
+      <what this task achieves>
+
+      ## Approach
+      <step-by-step: which files, what order, key decisions>
+
+      ## Affected files
+      - `path/to/file.hpp` — <what changes>
+
+      ## Acceptance criteria
+      <concrete checks>
+
+      ## Gotchas
+      <pitfalls the worker should watch for>
+      ```
+
+   d. Swap labels: remove `fleet:needs-plan`, add `human:approved`:
+      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan" --add-label "human:approved"`
+      The queue-manager will ingest it on its next maintenance pass
+      and rename the plan file from `issue-N.md` to `T-NNN.md`.
+
+   If you disagree with the issue's direction, comment with your
+   concerns but leave `fleet:needs-plan` on — let the human decide.
+
+   Also check the game repo for `fleet:needs-plan` issues:
+   `gh issue list --repo jakildev/irreden --label "fleet:needs-plan" --state open --json number,title,body,comments`
+   Same planning flow, but use `--repo jakildev/irreden` for label edits.
+
+3. **Pick the next task.** Read `TASKS.md` (use the Read tool) and find
+   the first `[ ]` item in `## Open` with `Model: opus` whose:
+   - **Owner** is `free` (or your worktree name)
+   - **Blocked by** is empty (or only references already-merged work)
+   - **Title is NOT referenced in any open PR's title or branch name**
+     (cross-check with the `gh pr list` output)
+
+   If no `Model: opus` tasks are available, exit cleanly. The `/loop`
+   driver will re-invoke in 20 minutes.
+
+   Print the task and explain why you picked it.
+
+4. **Claim the task, then open a PR with `fleet:wip`.**
+   Do NOT edit `TASKS.md` — only the queue-manager touches it.
+
+   Acquire the local filesystem lock. **Always pass the task ID**:
+   `fleet-claim claim "<task ID, e.g. T-003>" opus-worker`
+
+   - **Exit 0** — you own it. Proceed.
+   - **Exit 1** — already taken. Go back to step 3 and pick another.
+
+   Then create the branch, commit, and open a `fleet:wip` PR:
+   `git checkout -b claude/<area>-<topic>`
+   `git commit --allow-empty -m "claim: <task title>"`
+
+   Check the task's **Issue:** field. If it has a `#N` reference,
+   include `Closes #N` in the PR body:
+   `gh pr create --title "<task title>" --body "Claiming task. Work in progress.\n\nCloses #N" --label "fleet:wip"`
+   If there is no issue (`(none)`), omit the `Closes` line.
+
+   Reference the task title in the PR title so the queue-manager can
+   match it.
+
+5. **Read the plan file (if it exists).** Check
+   `~/.fleet/plans/<task-ID>.md` (e.g. `~/.fleet/plans/T-003.md`).
+   If it exists, read it with the Read tool — it contains the
+   implementation approach, affected files, and gotchas. Use it to
+   guide your work. If `T-NNN.md` doesn't exist but the task has an
+   `Issue: #N` field, also check `~/.fleet/plans/issue-<N>.md` — the
+   plan may not have been renamed yet by the queue-manager. If no
+   plan file exists at either path, proceed with the task description
+   from TASKS.md and read the issue thread for additional context:
+   `gh issue view <N> --repo jakildev/IrredenEngine`
+
+6. **Work it.** Read every `CLAUDE.md` on the path to the file(s) you
+   touch first. Follow naming conventions, the no-`getComponent`-in-tick
+   rule, early returns, `unique_ptr` over `shared_ptr`, and the rest of
+   the engine style guide.
+
+7. **Build and run.**
+   `fleet-build --target <name>`
+   Run the relevant executable with `fleet-run <name>` if one exists.
+   Untested commits are the single biggest waste of reviewer-agent time.
+
+8. **Stop and escalate if the task scope grows.** If:
+   - The scope grows beyond one PR's worth of work
+   - A design decision needs product or architectural input
+   - You're about to touch the public `ir_*.hpp` surface across
+     multiple modules in one PR
+   - A build break looks structural
+
+   STOP. Surface the issue to the human. Do NOT try to redesign
+   mid-task — the architect handles design conversations. Comment on
+   your PR explaining the blocker and wait.
+
+9. **Finalize the PR.** Use `commit-and-push` to push work commits.
+   Remove the WIP label and release the claim:
+   `gh pr edit <N> --remove-label "fleet:wip"`
+   `fleet-claim release "<task ID>"`
+   Paste the PR URL.
+
+10. **Reset.** Use the `start-next-task` skill to land on a fresh
+    branch off `origin/master`. Exit cleanly. The `/loop` driver will
+    re-invoke in 20 minutes.
+
+If Mode above is `dry-run`: do startup actions only. Do not plan or
+pick a task. Wait for human instruction.
+
+If you hit a usage-limit error: print the error and exit. The `/loop`
+driver and `fleet-babysit` wrapper handle backoff.
+
+## Hard rules
+
+- Never `git push origin master`. Never `--force`. Never call
+  `gh pr merge`. The human merges.
+- Never run `cmake --preset` — only `cmake --build` against the
+  already-configured tree.
+- Never touch the `.claude/worktrees/` layout.
+- Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
+  `xcode-select` — those are human-initiated.
+- Never write plan files during task execution. Plan files are written
+  only during the planning step (step 2) for `fleet:needs-plan` issues.
+- Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -222,10 +222,14 @@ You are the sole TASKS.md editor. Each maintenance pass:
    b. Append a properly formatted entry to `## Open` in `TASKS.md`.
       Include `**Issue:** #N` in the entry. Synthesize acceptance
       criteria from the full issue thread, not just the title.
-   c. Remove the `human:approved` label (so the issue isn't
+   c. If `~/.fleet/plans/issue-<N>.md` exists (the opus worker or
+      architect wrote a plan for this issue), rename it to match the
+      assigned task ID:
+      `mv ~/.fleet/plans/issue-<N>.md ~/.fleet/plans/T-<NNN>.md`
+   d. Remove the `human:approved` label (so the issue isn't
       re-ingested):
       `gh issue edit <N> --repo <engine-repo> --remove-label "human:approved"`
-   d. Do **NOT** close the issue. It stays open until the author
+   e. Do **NOT** close the issue. It stays open until the author
       agent's PR merges via `Closes #N`.
 
    **If the issue needs a plan first** — the scope is large, the
@@ -261,6 +265,9 @@ You are the sole TASKS.md editor. Each maintenance pass:
    For each recently merged PR whose title or branch matches an
    `[~]` or `[ ]` task in the **matching repo's** TASKS.md: flip to
    `[x]`, add the PR URL to **Links**, move to `## Done — last 20`.
+   If `~/.fleet/plans/<task-ID>.md` exists for the completed task,
+   delete it — the plan has served its purpose:
+   `rm -f ~/.fleet/plans/<task-ID>.md`
 
 4. **Sync open PRs → In-progress (both repos):**
    Engine:

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -166,27 +166,23 @@ half-finished and re-litigated in review.
    PR FIRST so the game task can reference its title in `Blocked by`,
    then file the game task.
 
-### Step 6 — Wait for triggers
+### Step 6 — Maintenance scheduling
 
-After the startup actions (and one initial maintenance pass), **wait
-for input**. You will receive two kinds of messages:
+The `/loop` driver re-invokes this role every 15 minutes in live
+mode. Each invocation runs the startup actions and a full maintenance
+pass, then exits cleanly. The `/loop` driver and `fleet-babysit`
+wrapper handle scheduling and crash recovery.
 
-- **"run maintenance"** — sent automatically every 15 minutes by the
-  fleet timer in tmux. Run the full maintenance pass below, print a
-  one-line summary of what changed, then wait again.
-- **Human-typed task descriptions** — any other input. Process it
-  through Steps 1–5 above (categorize, format, file to TASKS.md),
-  then wait again.
+Between `/loop` fires, the human can still type task descriptions
+into this pane. Process those through Steps 1–5 above (categorize,
+format, file to TASKS.md).
 
-You do NOT need to sleep, poll, or self-loop. The timer handles
-scheduling. Just respond to each message as it arrives.
-
-If you hit a usage-limit error: print the error and reset time,
-wait, resume when the next trigger arrives.
+If you hit a usage-limit error: print the error and exit. The
+`/loop` driver and `fleet-babysit` handle backoff.
 
 If Mode above is `dry-run`: do exactly one maintenance pass, then
-stop and wait for human instruction. Do not respond to timer
-triggers.
+stop and wait for human instruction. `/loop` is not active in
+dry-run mode.
 
 ### Maintenance pass
 
@@ -194,6 +190,13 @@ You are the sole TASKS.md editor. Each maintenance pass:
 
 0. **Clean stale claims:**
    `fleet-claim cleanup --repo <engine-repo> --repo <game-repo>`
+
+0b. **Release timed-out claims:**
+    `fleet-claim check-stale 7200`
+    Claims older than 2 hours with no corresponding PR are likely
+    orphaned (agent crashed without releasing). This supplements
+    the `cleanup` step above, which only catches claims whose PRs
+    have already merged or closed.
 
 1. **Ingest triaged issues (engine repo):**
    `gh issue list --repo <engine-repo> --label "human:approved" --state open --json number,title,body,comments,labels`

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -131,17 +131,28 @@ limit. Each loop iteration:
    Reference the task title in the PR title so the queue-manager can
    match it.
 
-4. **Work it.** Read every `CLAUDE.md` on the path to the file(s) you
+4. **Read the plan file (if it exists).** Check
+   `~/.fleet/plans/<task-ID>.md` (e.g. `~/.fleet/plans/T-003.md`).
+   If it exists, read it with the Read tool — it contains the
+   implementation approach, affected files, and gotchas. Use it to
+   guide your work. If `T-NNN.md` doesn't exist but the task has an
+   `Issue: #N` field, also check `~/.fleet/plans/issue-<N>.md` — the
+   plan may not have been renamed yet by the queue-manager. If no
+   plan file exists at either path, proceed with the task description
+   from TASKS.md and read the issue thread for additional context:
+   `gh issue view <N> --repo jakildev/IrredenEngine`
+
+5. **Work it.** Read every `CLAUDE.md` on the path to the file(s) you
    touch first. Follow naming conventions, the no-`getComponent`-in-tick
    rule, early returns, `unique_ptr` over `shared_ptr`, and the rest of
    the engine style guide.
 
-5. **Build and run.**
+6. **Build and run.**
    `fleet-build --target <name>`
    If the touched code has an executable target, run it once. Untested
    commits are the single biggest waste of reviewer-agent time.
 
-6. **Stop and escalate if the task is subtler than expected.** If the
+7. **Stop and escalate if the task is subtler than expected.** If the
    work touches:
    - Core ECS types (`engine/entity/`)
    - Render pipeline state, GPU buffer lifetime, shader compilation
@@ -157,18 +168,18 @@ limit. Each loop iteration:
    ready. The queue-manager then adds it to TASKS.md. Move on to the
    next task.
 
-7. **Finalize the PR.** Use the `commit-and-push` skill to push your
+8. **Finalize the PR.** Use the `commit-and-push` skill to push your
    work commits to the existing PR branch. Then remove the WIP label
    and release the claim:
    `gh pr edit <N> --remove-label "fleet:wip"`
    `fleet-claim release "<task ID, e.g. T-002>"`
    Paste the PR URL.
 
-8. **Reset.** Use the `start-next-task` skill to land on a fresh branch
+9. **Reset.** Use the `start-next-task` skill to land on a fresh branch
    off `origin/master`. Loop back to step 1.
 
 If Mode above is `dry-run`: do exactly **one** task end-to-end (steps
-1-7), print the PR URL, then stop and wait for human instruction. Do
+1-8), print the PR URL, then stop and wait for human instruction. Do
 not loop.
 
 ## Usage-limit handling

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -67,8 +67,8 @@ treat it as a hard rule for this role.
 
 ## Loop behavior
 
-Default: run continuously until the human stops you or you hit a
-usage limit. Each iteration:
+The `/loop` driver re-invokes this role every 10 minutes in live mode.
+Each invocation is one iteration — do the work, then exit cleanly:
 
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
@@ -128,9 +128,10 @@ usage limit. Each iteration:
    - When in doubt, approve. The human can always request a follow-up.
      Blocking PRs on style nits wastes more fleet time than the nit
      is worth.
-3. After the queue is drained, wait 10 minutes, then loop.
-4. If you hit a usage-limit error: print the error and reset time,
-   wait, resume.
+3. After the queue is drained, exit cleanly. The `/loop` driver
+   re-invokes this role in 10 minutes.
+4. If you hit a usage-limit error: print the error and exit. The
+   `/loop` driver and `fleet-babysit` wrapper handle backoff.
 
 If Mode above is `dry-run`: review exactly **one** PR end-to-end
 (complete one iteration of step 2 with one PR), then stop and wait

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -727,69 +727,39 @@ enforces this, but a human reviewer should know too.
 The whole point of a fleet is that author and reviewer agents can have
 a back-and-forth while you're AFK. That requires the reviewer agent to
 keep checking for new PRs on its own, not wait for you to type "review
-PR 42" each time. Here are three ways to run it, from simplest to most
-robust. Pick one per reviewer window.
+PR 42" each time.
 
-**Option A — session-prompt loop (simplest, what the dry run uses).**
-Launch the reviewer window's Claude Code session with a prompt that
-tells the agent it is a persistent reviewer and to poll on an interval.
-Something like:
-
-```text
-You are a persistent PR reviewer for the Irreden Engine fleet. Your job
-is to review open PRs on github.com/jakildev/IrredenEngine that have
-not yet been reviewed by this fleet.
-
-Every 10 minutes:
-
-1. Run `gh pr list --state open --json number,title,headRefName,reviews`
-   and filter for PRs where `reviews` does not already contain a review
-   authored by this reviewer (check the author login — yours is
-   `<github username>`).
-2. For each unreviewed PR, invoke the `review-pr` skill with that PR
-   number. The skill will `gh pr checkout`, read the diff in context,
-   write a structured review, and post it.
-3. After reviewing everything new, wait 10 minutes and check again.
-4. If you hit a usage-limit error, print the error, wait until the
-   stated reset time, and resume.
-5. Keep doing this until I return and stop you. Do not open new PRs,
-   do not commit from this worktree, do not merge anything.
-
-Start by listing what's currently open so I know what you see.
-```
-
-The `review-pr` skill's trigger phrases already cover the loop case
-(`"review any new PRs"` / `"review the PR queue"`), so the agent will
-naturally engage it from inside this loop without a magic phrase.
-
-Drawbacks: dies when the tmux window dies, dies when Claude Code
-hits an unrecoverable error, dies when you `C-c` out. Fine for "I'm
-stepping away for a few hours," not great for "I'm asleep for eight
-hours."
-
-**Option B — `loop` skill on top of option A.** The built-in `loop`
-skill (`/loop 10m <prompt-or-slash-command>`) re-runs a prompt on an
-interval inside the same session. You can use it to schedule a short
-poll prompt every N minutes instead of having the agent manage its own
-sleep:
+**Primary approach — `/loop` via `fleet-babysit` (what the fleet uses).**
+`fleet-up` launches each reviewer with `fleet-babysit` and a loop
+interval. In live mode, `fleet-babysit` wraps the role invocation in
+Claude's built-in `/loop` skill:
 
 ```text
-/loop 10m Run `gh pr list --state open --json number,title,reviews` and
-invoke the `review-pr` skill on any PR that hasn't been reviewed by
-this fleet yet. Report what you did.
+# What fleet-babysit runs under the hood:
+claude --model sonnet "/loop 10m /role-sonnet-reviewer"
+claude --model opus  "/loop 30m /role-opus-reviewer"
 ```
 
-Still dies with the session, but the loop driver is tighter than an
-agent running its own `while` logic and is easier to pause (`/loop
-stop`) when you come back.
+Each `/loop` fire re-invokes the full role — the agent fetches PR
+lists, reviews candidates, and exits cleanly. The `/loop` driver
+handles the interval between fires. `fleet-babysit` handles crash
+recovery and rate-limit backoff around the outer session.
 
-**Option C — `scheduled-tasks` / `schedule` skill (most robust).** For
+Benefits over the old self-managed sleep and tmux-timer approaches:
+- Consistent scheduling across all polling agents
+- Claude-runtime-managed intervals (survives session compaction)
+- Built-in rate-limit awareness
+- Easy to pause (`/loop stop`) when you come back
+
+The queue-manager uses the same pattern at a 15-minute interval.
+
+**Alternative — `scheduled-tasks` / `schedule` skill (most robust).** For
 "keep running even if every tmux session is dead and my laptop slept,"
 create a scheduled remote trigger that fires every 15 minutes and
-re-runs a small review-new-PRs prompt. Unlike options A and B, this
-runs independently of any running Claude Code window — it spawns a
-fresh Claude run on each fire. Downside: each fire has no memory of
-the previous fire, so the agent has to re-derive "what have I already
+re-runs a small review-new-PRs prompt. Unlike `/loop`, this runs
+independently of any running Claude Code window — it spawns a fresh
+Claude run on each fire. Downside: each fire has no memory of the
+previous fire, so the agent has to re-derive "what have I already
 reviewed" from the GitHub state every time (cheap, but not free).
 
 Use the `schedule` skill to create it:
@@ -802,8 +772,8 @@ and for every PR that does not yet have a review authored by
 exit."
 ```
 
-Layer this on top of option A or B if you want redundancy: the tmux
-reviewer window handles the common case with low latency; the
+Layer this on top of the `/loop` approach if you want redundancy: the
+tmux reviewer window handles the common case with low latency; the
 scheduled task is the safety net that catches everything if the tmux
 window dies.
 
@@ -813,21 +783,20 @@ The Opus/Sonnet model split (see root `CLAUDE.md`) wants most first-
 pass reviews to be Sonnet and only have Opus look at core-engine PRs
 or Sonnet-escalated ones. In the reviewer-loop pattern that means:
 
-- `sonnet-rev` window polls every 10 minutes, reviews **every** open
+- `sonnet-reviewer` uses `/loop 10m`, reviews **every** open
   unreviewed PR at Sonnet cost, and writes a verdict. If the PR
   touches `engine/render/`, `engine/entity/`, `engine/system/`,
   `engine/world/`, `engine/audio/`, `engine/video/`, or
   `engine/math/`, or the Sonnet verdict ends with an Opus-escalation
   line, the review body explicitly says "please Opus-recheck."
-- `opus-rev` window polls on a **longer** interval (e.g. 30 minutes)
-  and filters for PRs whose latest Sonnet review asked for an Opus
-  recheck. It reads the Sonnet review first, then focuses on what
-  Sonnet couldn't confirm — concurrency, lifetime, ECS invariants
-  three systems deep.
+- `opus-reviewer` uses `/loop 30m` and filters for PRs whose latest
+  Sonnet review asked for an Opus recheck. It reads the Sonnet review
+  first, then focuses on what Sonnet couldn't confirm — concurrency,
+  lifetime, ECS invariants three systems deep.
 
 This keeps most reviews on Sonnet (cheap) while guaranteeing core
 invariants still get an Opus pass. When Opus budget is tight, you
-can safely disable the `opus-rev` loop for a while — the
+can safely disable the `opus-reviewer` loop for a while — the
 escalation notes accumulate in the PR comments and you can come back
 and drain them manually or by enabling the loop again.
 
@@ -1421,18 +1390,20 @@ If a window keeps hitting the cap even after the stated reset time:
 
 ### When a window dies entirely
 
-If a tmux window's Claude process exits hard (not just stalls on a
-usage error):
+Each agent is wrapped in `fleet-babysit`, which auto-resumes the
+session on crash, usage limit, or clean exit. Crash diagnostics are
+logged to `~/.fleet/logs/<role>.log`. If an agent hits the 200-attempt
+safety limit, an alert file is written to `~/.fleet/logs/<role>.alert`.
 
-1. Check the JSONL transcript at
+If you need to investigate a crash manually:
+
+1. Check `~/.fleet/logs/<role>.log` for exit codes and timestamps.
+2. Check the JSONL transcript at
    `~/.claude/projects/<slug>/<session>.jsonl` — it should still be
    there.
-2. Start a new `claude` in the same worktree, pass `--resume <session-id>`,
+3. Start a new `claude` in the same worktree, pass `--resume <session-id>`,
    and you land back in the same conversation with the same context
    window.
-3. If the session-id is lost, `claude` in that worktree with no flags
-   still picks up the latest session for that project in most Claude
-   Code versions.
 
 No work is ever lost as long as `commit-and-push` was run at the last
 logical boundary. That's the whole reason the skill exists.

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -7,12 +7,16 @@
 # which repo/session context claude uses.
 #
 # Usage:
-#   fleet-babysit <model> <role> [mode]
+#   fleet-babysit <model> <role> [mode] [loop-interval]
 #
 # Examples:
 #   fleet-babysit sonnet sonnet-author dry-run
-#   fleet-babysit opus  opus-architect live
-#   fleet-babysit sonnet game-sonnet live    # game worktree cwd
+#   fleet-babysit sonnet sonnet-author live          # continuous, no /loop
+#   fleet-babysit sonnet sonnet-reviewer live 10m    # /loop every 10 min
+#   fleet-babysit opus  opus-reviewer live 30m       # /loop every 30 min
+#   fleet-babysit sonnet queue-manager live 15m      # /loop every 15 min
+#   fleet-babysit opus  opus-architect live           # on-demand, no /loop
+#   fleet-babysit sonnet game-sonnet live             # game worktree cwd
 #
 # Behavior by mode:
 #   dry-run  — start the agent, auto-resume on crash, but do NOT
@@ -29,9 +33,10 @@
 
 set -euo pipefail
 
-MODEL="${1:?usage: fleet-babysit <model> <role> [mode]}"
-ROLE="${2:?usage: fleet-babysit <model> <role> [mode]}"
+MODEL="${1:?usage: fleet-babysit <model> <role> [mode] [loop-interval]}"
+ROLE="${2:?usage: fleet-babysit <model> <role> [mode] [loop-interval]}"
 MODE="${3:-dry-run}"
+LOOP_INTERVAL="${4:-}"
 
 # Timing
 CRASH_DELAY=30        # seconds to wait after non-zero exit (crash)
@@ -39,22 +44,52 @@ LIMIT_DELAY=900       # seconds to wait on suspected usage limit (exit 2)
 CLEAN_DELAY=60        # seconds to wait after clean exit
 MAX_ATTEMPTS=200      # safety valve — prevents infinite loops on hard failures
 
+# Logging
+LOG_DIR="${FLEET_LOG_DIR:-$HOME/.fleet/logs}"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$ROLE.log"
+
 attempt=0
 
-log() { echo "[babysit $(date +%H:%M:%S)] $ROLE: $*"; }
+log() {
+    local msg="[babysit $(date '+%Y-%m-%d %H:%M:%S')] $ROLE: $*"
+    echo "$msg"
+    echo "$msg" >> "$LOG_FILE"
+}
 
-log "starting ($MODEL) mode=$MODE in $(pwd)"
+# Rotate log if it grows too large (keep last 1000 lines at 5000)
+rotate_log() {
+    if [[ -f "$LOG_FILE" ]] && [[ $(wc -l < "$LOG_FILE") -gt 5000 ]]; then
+        tail -1000 "$LOG_FILE" > "$LOG_FILE.tmp"
+        mv "$LOG_FILE.tmp" "$LOG_FILE"
+        log "log rotated (kept last 1000 lines)"
+    fi
+}
+
+log "starting ($MODEL) mode=$MODE loop=${LOOP_INTERVAL:-none} in $(pwd)"
 
 # --- First run: send the role slash command --------------------------------
-claude --model "$MODEL" "/role-$ROLE $MODE"
+# If a loop interval is set and mode is live, wrap the role invocation in
+# /loop so Claude's runtime handles the scheduling (replaces sleep-based
+# polling and external tmux timers).
+if [[ -n "$LOOP_INTERVAL" && "$MODE" == "live" ]]; then
+    log "using /loop $LOOP_INTERVAL for scheduling"
+    claude --model "$MODEL" "/loop $LOOP_INTERVAL /role-$ROLE"
+else
+    claude --model "$MODEL" "/role-$ROLE $MODE"
+fi
 last_exit=$?
 
 # --- Resume loop -----------------------------------------------------------
 while true; do
     attempt=$((attempt + 1))
 
+    rotate_log
+
     if [[ $attempt -ge $MAX_ATTEMPTS ]]; then
-        log "safety limit reached ($MAX_ATTEMPTS attempts). stopping."
+        log "ALERT: safety limit reached ($MAX_ATTEMPTS attempts). stopping."
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $ROLE hit $MAX_ATTEMPTS attempts. Manual intervention needed." \
+            > "$LOG_DIR/$ROLE.alert"
         break
     fi
 
@@ -68,16 +103,19 @@ while true; do
     # Pick a wait time based on exit code
     case $last_exit in
         0)
-            log "exited cleanly. resuming in ${CLEAN_DELAY}s..."
+            log "exit_code=0 attempt=$attempt (clean)"
+            log "resuming in ${CLEAN_DELAY}s..."
             sleep "$CLEAN_DELAY"
             ;;
         2)
             # Exit code 2 often indicates usage limit
-            log "possible usage limit (exit 2). waiting ${LIMIT_DELAY}s..."
+            log "exit_code=2 attempt=$attempt (suspected usage limit)"
+            log "waiting ${LIMIT_DELAY}s..."
             sleep "$LIMIT_DELAY"
             ;;
         *)
-            log "exited with code $last_exit. resuming in ${CRASH_DELAY}s..."
+            log "exit_code=$last_exit attempt=$attempt (crash)"
+            log "resuming in ${CRASH_DELAY}s..."
             sleep "$CRASH_DELAY"
             ;;
     esac

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -178,6 +178,42 @@ cmd_cleanup() {
     fi
 }
 
+cmd_check_stale() {
+    # Release claims older than max_age seconds (default: 7200 = 2 hours).
+    local max_age="${1:-7200}"
+    local now
+    now=$(date +%s)
+    local stale=0
+
+    mkdir -p "$CLAIMS_DIR"
+
+    for dir in "$CLAIMS_DIR"/*/; do
+        [[ -d "$dir" ]] || continue
+        local created=0
+        if [[ -f "$dir/created" ]]; then
+            created=$(cat "$dir/created")
+        fi
+        local age=$(( now - created ))
+        if [[ $age -ge $max_age ]]; then
+            local slug
+            slug=$(basename "$dir")
+            local owner="unknown"
+            local title="$slug"
+            if [[ -f "$dir/owner" ]]; then owner=$(cat "$dir/owner"); fi
+            if [[ -f "$dir/title" ]]; then title=$(cat "$dir/title"); fi
+            echo "stale ($((age / 60))m old): $title (owner: $owner)"
+            rm -rf "$dir"
+            stale=$((stale + 1))
+        fi
+    done
+
+    if [[ $stale -eq 0 ]]; then
+        echo "no stale claims"
+    else
+        echo "released $stale stale claim(s)"
+    fi
+}
+
 cmd_clear_all() {
     if [[ -d "$CLAIMS_DIR" ]]; then
         rm -rf "$CLAIMS_DIR"
@@ -215,6 +251,10 @@ case "${1:-}" in
     list)
         cmd_list
         ;;
+    check-stale)
+        shift
+        cmd_check_stale "${1:-7200}"
+        ;;
     cleanup)
         shift
         cmd_cleanup "$@"
@@ -231,6 +271,7 @@ commands:
   release "<title>"         release a claim
   check "<title>"           check if free (exit 0=free, 1=taken)
   list                      list all active claims
+  check-stale [max-secs]    release claims older than max-secs (default: 7200)
   cleanup [--repo o/r] ...  remove claims for merged/closed PRs
   clear-all                 wipe all claims (used by fleet-up on restart)
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -264,10 +264,17 @@ MODE="${1:-dry-run}"
 
 launch_cmd() {
     # $1 = model alias (opus|sonnet), $2 = role slug (without role- prefix)
+    # $3 = loop interval (optional — for polling roles like reviewers/queue-mgr)
     local model="$1"
     local role="$2"
-    printf 'fleet-babysit %s %s %s; exec $SHELL\n' \
-        "$model" "$role" "$MODE"
+    local loop="${3:-}"
+    if [[ -n "$loop" ]]; then
+        printf 'fleet-babysit %s %s %s %s; exec $SHELL\n' \
+            "$model" "$role" "$MODE" "$loop"
+    else
+        printf 'fleet-babysit %s %s %s; exec $SHELL\n' \
+            "$model" "$role" "$MODE"
+    fi
 }
 
 # Single window, three rows:
@@ -304,19 +311,19 @@ label_pane_id "$TOP1" "sonnet-fleet-1 [sonnet]"
 # full window height at this point — 25% bottom, 75% top.
 tmux split-window -v -t "$TOP1" -p 25 \
     -c "$ENGINE/.claude/worktrees/sonnet-reviewer" \
-    "$(launch_cmd sonnet sonnet-reviewer)"
+    "$(launch_cmd sonnet sonnet-reviewer 10m)"
 BOT1=$(active_pane_id)
 label_pane_id "$BOT1" "sonnet-reviewer [sonnet]"
 
 tmux split-window -h -t "$BOT1" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
-    "$(launch_cmd opus opus-reviewer)"
+    "$(launch_cmd opus opus-reviewer 30m)"
 BOT2=$(active_pane_id)
 label_pane_id "$BOT2" "opus-reviewer [opus]"
 
 tmux split-window -h -t "$BOT2" \
     -c "$ENGINE/.claude/worktrees/queue-manager" \
-    "$(launch_cmd sonnet queue-manager)"
+    "$(launch_cmd sonnet queue-manager 15m)"
 BOT3=$(active_pane_id)
 label_pane_id "$BOT3" "queue-manager [sonnet]"
 
@@ -361,30 +368,6 @@ tmux set-option -t "$SESSION" pane-border-format " #{pane_index}: #{@role} "
 # Focus sonnet-fleet-1 on attach
 tmux select-pane -t "$TOP1"
 
-# ----------------------------------------------------------------------
-# Step 5: start the queue-manager maintenance timer
-# ----------------------------------------------------------------------
-#
-# Claude Code agents can't self-loop — they process input, respond,
-# then wait. This background loop sends "run maintenance" to the
-# queue-manager pane every 15 minutes, triggering the maintenance pass.
-# The loop exits automatically when the tmux session is killed.
-#
-# In dry-run mode, skip the timer (queue-manager does one pass and
-# stops; the human triggers subsequent runs manually).
-
-if [[ "$MODE" != "dry-run" ]]; then
-    (
-        sleep 120  # let agents finish startup before first trigger
-        while tmux has-session -t "$SESSION" 2>/dev/null; do
-            tmux send-keys -t "$BOT3" "run maintenance" Enter 2>/dev/null || true
-            sleep 900  # 15 minutes
-        done
-    ) &
-    TIMER_PID=$!
-    echo "fleet-up: maintenance timer started (PID $TIMER_PID, every 15 min)"
-fi
-
 cat <<EOF
 
 fleet session created — mode: ${MODE}.
@@ -408,6 +391,12 @@ babysit: each agent is wrapped in fleet-babysit, which auto-resumes
 the session if claude exits (crash, usage limit, network drop).
   dry-run — auto-resumes on crash, stops on clean exit
   live    — auto-resumes on any exit (runs indefinitely)
+
+scheduling (live mode): polling roles use Claude's /loop for managed intervals:
+  sonnet-reviewer — /loop 10m    opus-reviewer — /loop 30m
+  queue-manager   — /loop 15m    authors — continuous (no /loop)
+
+logs: crash diagnostics written to ~/.fleet/logs/<role>.log
 
 other modes you can pass to fleet-up:
   fleet-up dry-run   # default — startup + stand-by

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -62,6 +62,7 @@ ensure_worktree() {
     echo "fleet-up: engine git fetch failed" >&2; exit 1; }
 
 ensure_worktree "$ENGINE" .claude/worktrees/opus-architect    fleet/opus-architect
+ensure_worktree "$ENGINE" .claude/worktrees/opus-worker       fleet/opus-worker
 ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-1    fleet/sonnet-fleet-1
 ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-2    fleet/sonnet-fleet-2
 ensure_worktree "$ENGINE" .claude/worktrees/sonnet-reviewer   fleet/sonnet-reviewer
@@ -107,6 +108,7 @@ reset_worktree() {
 }
 
 reset_worktree "$ENGINE/.claude/worktrees/opus-architect"  claude/opus-arch-scratch
+reset_worktree "$ENGINE/.claude/worktrees/opus-worker"     claude/opus-worker-scratch
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-1"  claude/sonnet-1-scratch
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-2"  claude/sonnet-2-scratch
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-reviewer" claude/sonnet-reviewer-scratch
@@ -211,7 +213,7 @@ with open(settings_file, "w") as f:
 PYEOF
 }
 
-for wt in opus-architect sonnet-fleet-1 sonnet-fleet-2 sonnet-reviewer opus-reviewer queue-manager; do
+for wt in opus-architect opus-worker sonnet-fleet-1 sonnet-fleet-2 sonnet-reviewer opus-reviewer queue-manager; do
     write_worktree_settings "$ENGINE/.claude/worktrees/$wt" "$ENGINE"
 done
 
@@ -238,15 +240,17 @@ else
     echo "          (run scripts/fleet/install.sh to install it)"
 fi
 
+# Ensure the plans directory exists for opus-worker and architect to write to.
+mkdir -p "$HOME/.fleet/plans"
+
 # ----------------------------------------------------------------------
 # Step 4: build the tmux session
 # ----------------------------------------------------------------------
 #
-# Layout: 4 named windows instead of one mega-window.
-#   1:authors  — sonnet-fleet-1, sonnet-fleet-2, game-sonnet
-#   2:review   — sonnet-reviewer, opus-reviewer
-#   3:arch     — opus-architect, game-architect
-#   4:ops      — queue-manager
+# Layout: single window with three rows.
+#   top    — sonnet-fleet-1, sonnet-fleet-2, game-sonnet  (authors)
+#   middle — opus-architect, opus-worker, game-architect  (architects + worker)
+#   bottom — sonnet-reviewer, opus-reviewer, queue-manager (ops)
 #
 # Cycle windows: Ctrl-b n / Ctrl-b p, or Ctrl-b <number>.
 #
@@ -327,23 +331,29 @@ tmux split-window -h -t "$BOT2" \
 BOT3=$(active_pane_id)
 label_pane_id "$BOT3" "queue-manager [sonnet]"
 
-# --- Row 2 (middle, ~30%): architects ----------------------------------
+# --- Row 2 (middle, ~30%): architects + opus-worker --------------------
 # Split off the middle row from TOP1. TOP1 is currently 75% of the
 # window. Splitting 40% off the bottom of that gives:
 #   TOP1 = 75% * 60% = ~45% of window  (authors)
-#   MID1 = 75% * 40% = ~30% of window  (architects)
+#   MID1 = 75% * 40% = ~30% of window  (architects + opus-worker)
 tmux split-window -v -t "$TOP1" -p 40 \
     -c "$ENGINE/.claude/worktrees/opus-architect" \
     "$(launch_cmd opus opus-architect)"
 MID1=$(active_pane_id)
 label_pane_id "$MID1" "opus-architect [opus]"
 
+tmux split-window -h -t "$MID1" \
+    -c "$ENGINE/.claude/worktrees/opus-worker" \
+    "$(launch_cmd opus opus-worker 20m)"
+MID2=$(active_pane_id)
+label_pane_id "$MID2" "opus-worker [opus]"
+
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
-    tmux split-window -h -t "$MID1" \
+    tmux split-window -h -t "$MID2" \
         -c "$GAME/.claude/worktrees/game-architect" \
         "$(launch_cmd opus game-architect)"
-    MID2=$(active_pane_id)
-    label_pane_id "$MID2" "game-architect [opus]"
+    MID3=$(active_pane_id)
+    label_pane_id "$MID3" "game-architect [opus]"
 fi
 
 # --- Expand Row 1 (top) with remaining authors -------------------------
@@ -375,7 +385,7 @@ attach with:  tmux attach -t ${SESSION}
 
 layout (single window, three rows):
   top (big)    — sonnet-fleet-1  sonnet-fleet-2  [game-sonnet]   (authors)
-  middle (med) — opus-architect  [game-architect]                (architects)
+  middle (med) — opus-architect  opus-worker  [game-architect]   (architects + worker)
   bottom (sm)  — sonnet-reviewer  opus-reviewer  queue-manager   (ops)
 
 navigation (no prefix needed):
@@ -394,7 +404,9 @@ the session if claude exits (crash, usage limit, network drop).
 
 scheduling (live mode): polling roles use Claude's /loop for managed intervals:
   sonnet-reviewer — /loop 10m    opus-reviewer — /loop 30m
-  queue-manager   — /loop 15m    authors — continuous (no /loop)
+  opus-worker     — /loop 20m   queue-manager  — /loop 15m
+  authors — continuous (no /loop)
+  opus-architect — interactive (no /loop, human's design partner)
 
 logs: crash diagnostics written to ~/.fleet/logs/<role>.log
 


### PR DESCRIPTION
## Summary
Two commits covering the fleet refactor:

**Commit 1: crash logging, claim timeouts, /loop scheduling**
- `fleet-babysit`: crash logging with rotation, alert files on max retries
- `fleet-claim`: `check-stale` subcommand for releasing orphaned claims (>2hr)
- All polling roles (reviewers, queue-manager) now use Claude's `/loop` for scheduling instead of sleep-based polling or tmux timers
- Removed the tmux maintenance timer (Step 5) from fleet-up

**Commit 2: opus worker + task pipeline with plan files**
- New `role-opus-worker.md`: runs on `/loop 20m`, autonomously plans `fleet:needs-plan` issues and executes `Model: opus` tasks
- Architect stays interactive (no /loop) — the human's design partner
- Workers (sonnet + opus) read plan files from `~/.fleet/plans/` before starting work, with `issue-N.md` fallback for rename race
- Queue manager renames plan files during ingestion (`issue-N.md` → `T-NNN.md`) and deletes them on task completion
- `fleet-up`: adds opus-worker worktree, tmux pane in middle row, creates plans directory

## Test plan
- [ ] `fleet-up dry-run` — opus-worker pane appears in middle row alongside opus-architect
- [ ] All role files load without errors when invoked via `/role-*`
- [ ] Plan file lifecycle: opus-worker creates `issue-N.md`, queue-manager renames to `T-NNN.md`, workers read it, queue-manager deletes on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)