### PR TITLE
fleet: prevent idle agents from inventing work outside the queue

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -143,8 +143,10 @@ Each invocation is one iteration — do the work, then exit cleanly:
    - **Title is NOT referenced in any open PR's title or branch name**
      (cross-check with the `gh pr list` output)
 
-   If no `Model: opus` tasks are available, exit cleanly. The `/loop`
-   driver will re-invoke in 20 minutes.
+   If no `Model: opus` tasks are available, print
+   `no unblocked [opus] tasks — standing by` and exit cleanly. Do NOT
+   invent work, self-assign documentation passes, or create tasks
+   outside the queue. The `/loop` driver will re-invoke in 20 minutes.
 
    Print the task and explain why you picked it.
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -103,6 +103,12 @@ limit. Each loop iteration:
    - **Title is NOT referenced in any open PR's title or branch name**
      (cross-check with the `gh pr list` output)
 
+   **If no matching task exists, exit cleanly.** Print
+   `no unblocked [sonnet] tasks — standing by` and stop. Do NOT
+   invent work, self-assign documentation passes, or create tasks
+   outside the queue. The `/loop` driver or `fleet-babysit` will
+   re-invoke you later when new tasks may have appeared.
+
    Print the task and explain why you picked it.
 
 3. **Claim the task, then open a PR with `fleet:wip`.**


### PR DESCRIPTION
## Summary
- Sonnet authors with an empty `[sonnet]` task queue were self-assigning `///` doc comment passes across every engine header — 13 PRs in a single day, all bypassing human triage via TASKS.md
- Both `role-sonnet-author.md` and `role-opus-worker.md` now have an explicit guardrail: if no matching tasks exist, print a standing-by message and exit cleanly
- Hard prohibition: "Do NOT invent work, self-assign documentation passes, or create tasks outside the queue"

## Test plan
- [ ] With an empty `[sonnet]` queue, a sonnet author should print `no unblocked [sonnet] tasks — standing by` and exit
- [ ] With an empty `[opus]` queue, the opus worker should print `no unblocked [opus] tasks — standing by` and exit
- [ ] Neither agent should open PRs for work not in TASKS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)