### PR TITLE
macOS/Metal build maturation (T-003)

### DIFF
--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -337,10 +337,38 @@ metalCurrentDepthPixelFormat(),
     }
 
     void drawElementsInstanced(DrawMode drawMode, int count, IndexType indexType, int instanceCount) override {
-        // Metal instanced draw - stub for now, not yet wired for entity canvas instancing.
-        for (int i = 0; i < instanceCount; ++i) {
-            drawElements(drawMode, count, indexType);
+        auto *pipeline = activeMetalPipeline();
+        const auto &layout = activeMetalVertexLayout();
+        if (pipeline == nullptr || pipeline->isComputePipeline() || layout.indexBuffer_ == nullptr) {
+            return;
         }
+
+        auto *encoder = createRenderEncoder();
+        if (encoder == nullptr) {
+            return;
+        }
+
+        auto *pipelineState = pipeline->getRenderPipelineState(
+            metalCurrentColorPixelFormat(),
+            metalCurrentDepthPixelFormat(),
+            layout.vertexDescriptor_
+        );
+        IR_ASSERT(pipelineState != nullptr, "Failed to get Metal render pipeline state");
+        encoder->setRenderPipelineState(pipelineState);
+        if (metalCurrentDepthTexture() != nullptr) {
+            encoder->setDepthStencilState(currentMetalDepthStencilState());
+        }
+        bindRenderResources(encoder);
+        encoder->setVertexBuffer(layout.vertexBuffer_, 0, 0);
+        encoder->drawIndexedPrimitives(
+            toMetalPrimitiveType(drawMode),
+            static_cast<NS::UInteger>(count),
+            toMetalIndexType(indexType),
+            layout.indexBuffer_,
+            0,
+            static_cast<NS::UInteger>(instanceCount)
+        );
+        encoder->endEncoding();
     }
 
     void copyImageSubData(

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -337,6 +337,9 @@ metalCurrentDepthPixelFormat(),
     }
 
     void drawElementsInstanced(DrawMode drawMode, int count, IndexType indexType, int instanceCount) override {
+        if (instanceCount <= 0) {
+            return;
+        }
         auto *pipeline = activeMetalPipeline();
         const auto &layout = activeMetalVertexLayout();
         if (pipeline == nullptr || pipeline->isComputePipeline() || layout.indexBuffer_ == nullptr) {


### PR DESCRIPTION
## Summary
- Implement proper Metal `drawIndexedPrimitives` with `instanceCount` in `drawElementsInstanced`, replacing the loop-based stub that created N render encoders per call
- Verified the full `macos-debug` preset end-to-end on Apple M4 Max (macOS)

## Verification results (T-003 acceptance criteria)

| Check | Result |
|-------|--------|
| `IRShapeDebug` builds | Pass — zero engine-code errors |
| `IRCreationDefault` builds | Pass |
| `IrredenEngineTest` builds | Pass |
| 271 unit tests | All pass |
| `IRShapeDebug` launches on Metal | Pass — renders shapes, accepts input, exits cleanly |
| Metal device detected | Apple M4 Max |
| All pipeline shaders present | All 12 .metal files exist |
| Retina scaling | Handled via `backingScaleFactor` |

## Remaining items (not blockers for T-003)
- `copyImageSubData` stub is a no-op — method is not called by any pipeline code
- Visual rendering parity with OpenGL backend requires human comparison
- Metal shader precompilation skipped (Command Line Tools only, no full Xcode) — runtime compilation works fine

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean
- [x] `fleet-build --target IRCreationDefault` — clean
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] `fleet-run IrredenEngineTest --gtest_brief=1` — 271/271 pass
- [x] `fleet-run IRShapeDebug` — launches, renders, exits code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)