### PR TITLE
fleet: add --timeout to fleet-run so agents auto-close windows

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -189,7 +189,10 @@ Each invocation is one iteration — do the work, then exit cleanly:
 
 7. **Build and run.**
    `fleet-build --target <name>`
-   Run the relevant executable with `fleet-run <name>` if one exists.
+   Run the relevant executable with a timeout so the window auto-closes:
+   `fleet-run --timeout 5 <name>`
+   **Always use `--timeout`** for GUI executables — without it the
+   window stays open and steals focus from the human.
    Untested commits are the single biggest waste of reviewer-agent time.
 
 8. **Stop and escalate if the task scope grows.** If:

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -155,11 +155,15 @@ limit. Each loop iteration:
 
 6. **Build and run.**
    `fleet-build --target <name>`
-   If the touched code has an executable target, run it once:
-   `fleet-run <executable-name>`
-   **Never** use `cd <dir> && ./<exe>` — that triggers the compound-
-   command security gate. Untested commits are the single biggest
-   waste of reviewer-agent time.
+   If the touched code has an executable target, run it once with a
+   timeout so the window auto-closes:
+   `fleet-run --timeout 5 <executable-name>`
+   **Always use `--timeout`** for GUI executables — without it the
+   window stays open and steals focus from the human. Use `--timeout`
+   for test executables too (they exit on their own, but the timeout
+   is a safety net). **Never** use `cd <dir> && ./<exe>` — that
+   triggers the compound-command security gate. Untested commits are
+   the single biggest waste of reviewer-agent time.
 
 7. **Stop and escalate if the task is subtler than expected.** If the
    work touches:

--- a/scripts/fleet/fleet-run
+++ b/scripts/fleet/fleet-run
@@ -10,7 +10,11 @@
 # Usage:
 #   fleet-run IrredenEngineTest --gtest_brief=1
 #   fleet-run IRShapeDebug
+#   fleet-run --timeout 5 IRShapeDebug       # auto-kill after 5 seconds
 #   fleet-run --build-dir /path/to/build IrredenEngineTest
+#
+# Fleet agents should always use --timeout for GUI executables to avoid
+# leaving windows open and stealing focus from the human.
 #
 # Source of truth: scripts/fleet/fleet-run in the engine repo.
 # Installed to ~/bin/fleet-run (as a symlink) by scripts/fleet/install.sh.
@@ -18,18 +22,25 @@
 set -euo pipefail
 
 BUILD_DIR=""
+TIMEOUT=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        --timeout|-t) TIMEOUT="$2"; shift 2 ;;
         --help|-h)
             cat <<'USAGE'
-usage: fleet-run [--build-dir <dir>] <executable-name> [args...]
+usage: fleet-run [options] <executable-name> [args...]
 
 Finds <executable-name> in the build tree, cd's into its directory,
 and runs it. Sibling data/shaders/scripts directories are on CWD.
 
 Options:
   --build-dir <dir>   Override the build directory (default: auto-detect)
+  --timeout <secs>    Auto-kill after N seconds (for fleet verification).
+                      Exit 0 if the process survived the timeout (healthy).
+                      Exit 1 if the process crashed before the timeout.
+                      Fleet agents should use this for GUI executables to
+                      avoid leaving windows open and stealing focus.
 
 Build directory resolution (in order):
   1. --build-dir flag
@@ -46,7 +57,7 @@ USAGE
 done
 
 if [[ $# -eq 0 ]]; then
-    echo "usage: fleet-run [--build-dir <dir>] <executable-name> [args...]" >&2
+    echo "usage: fleet-run [--build-dir <dir>] [--timeout <secs>] <executable-name> [args...]" >&2
     exit 2
 fi
 
@@ -76,6 +87,40 @@ fi
 
 EXE_DIR=$(dirname "$EXE_PATH")
 
-echo "fleet-run: $EXE_PATH $*"
+# --- No timeout: interactive mode, exec replaces this process --------------
+if [[ -z "$TIMEOUT" ]]; then
+    echo "fleet-run: $EXE_PATH $*"
+    cd "$EXE_DIR"
+    exec "./$EXE_NAME" "$@"
+fi
+
+# --- Timeout mode: launch, wait, kill, report ------------------------------
+echo "fleet-run: $EXE_PATH $* (timeout: ${TIMEOUT}s)"
 cd "$EXE_DIR"
-exec "./$EXE_NAME" "$@"
+"./$EXE_NAME" "$@" &
+PID=$!
+
+# Wait for either the timeout or the process to exit early (crash).
+elapsed=0
+while [[ $elapsed -lt $TIMEOUT ]]; do
+    if ! kill -0 "$PID" 2>/dev/null; then
+        # Process exited before timeout — check if it crashed.
+        wait "$PID" 2>/dev/null
+        exit_code=$?
+        if [[ $exit_code -eq 0 ]]; then
+            echo "fleet-run: $EXE_NAME exited cleanly after ${elapsed}s"
+            exit 0
+        else
+            echo "fleet-run: $EXE_NAME crashed after ${elapsed}s (exit code $exit_code)"
+            exit 1
+        fi
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+done
+
+# Process survived the timeout — it's healthy. Kill it.
+kill "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null || true
+echo "fleet-run: $EXE_NAME ran for ${TIMEOUT}s without crashing — killed"
+exit 0

--- a/scripts/fleet/fleet-run
+++ b/scripts/fleet/fleet-run
@@ -36,7 +36,7 @@ and runs it. Sibling data/shaders/scripts directories are on CWD.
 
 Options:
   --build-dir <dir>   Override the build directory (default: auto-detect)
-  --timeout <secs>    Auto-kill after N seconds (for fleet verification).
+  --timeout|-t <secs> Auto-kill after N seconds (for fleet verification).
                       Exit 0 if the process survived the timeout (healthy).
                       Exit 1 if the process crashed before the timeout.
                       Fleet agents should use this for GUI executables to
@@ -58,6 +58,11 @@ done
 
 if [[ $# -eq 0 ]]; then
     echo "usage: fleet-run [--build-dir <dir>] [--timeout <secs>] <executable-name> [args...]" >&2
+    exit 2
+fi
+
+if [[ -n "$TIMEOUT" ]] && ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || [[ "$TIMEOUT" == "0" ]]; then
+    echo "fleet-run: --timeout must be a positive integer, got '$TIMEOUT'" >&2
     exit 2
 fi
 
@@ -105,8 +110,8 @@ elapsed=0
 while [[ $elapsed -lt $TIMEOUT ]]; do
     if ! kill -0 "$PID" 2>/dev/null; then
         # Process exited before timeout — check if it crashed.
-        wait "$PID" 2>/dev/null
-        exit_code=$?
+        exit_code=0
+        wait "$PID" 2>/dev/null || exit_code=$?
         if [[ $exit_code -eq 0 ]]; then
             echo "fleet-run: $EXE_NAME exited cleanly after ${elapsed}s"
             exit 0


### PR DESCRIPTION
## Summary
- `fleet-run` now accepts `--timeout <secs>` — launches the process in the background, polls for early crash, and auto-kills after the timeout
- Exit 0 = process survived the timeout (healthy), exit 1 = process crashed before timeout
- Without `--timeout`, behavior is unchanged (`exec` replaces the shell for interactive use)
- Both worker role files (`role-sonnet-author.md`, `role-opus-worker.md`) updated to use `fleet-run --timeout 5` for all GUI executables

**Problem:** agents were running `fleet-run IRShapeDebug` which `exec`'d into the process — the window stayed open indefinitely, stole focus from the human, and the agent had no way to close it.

## Test plan
- [ ] `fleet-run --timeout 3 IRShapeDebug` — window appears, auto-closes after 3s, exit 0
- [ ] `fleet-run --timeout 3 IrredenEngineTest` — tests run, exit reflects test result
- [ ] `fleet-run IRShapeDebug` (no timeout) — behaves as before, interactive mode
- [ ] `fleet-run --timeout 1 nonexistent-binary` — reports "not found", exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)