### PR TITLE
fleet: fix compound-command permission prompts

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -12,10 +12,24 @@ Mode (optional argument): $ARGUMENTS
 ## CRITICAL: single-command Bash calls only
 
 Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
-`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
-tool instead of `grep` or `rg`. Use the **Glob** tool instead of
-`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
-this blocks unattended operation with interactive prompts.
+`;`, or `|`. Never append `2>/dev/null`. Use the **Read** tool instead
+of `cat`. Use the **Grep** tool instead of `grep` or `rg`. Use the
+**Glob** tool instead of `find`. Use `git -C <path>` instead of
+`cd <path> && git`. Violating this blocks unattended operation with
+interactive prompts.
+
+Common patterns and their correct alternatives:
+
+- **Check if a file exists:** Use the **Read** tool — it returns an
+  error if the file doesn't exist, which is fine. Do NOT use
+  `ls <file> 2>/dev/null || echo "missing"`.
+- **Check if a directory exists:** `ls <dir>` alone (no `||`, no
+  `2>/dev/null`). If it fails, the error message tells you.
+- **Read a file that might not exist:** Use the **Read** tool. A "file
+  not found" error is a normal signal, not something to suppress.
+- **Run a command and fall back:** Issue the command alone. Read the
+  exit status / error. Issue the fallback as a separate Bash call if
+  needed.
 
 ## Responsibilities
 

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -13,10 +13,27 @@ Mode (optional argument): $ARGUMENTS
 ## CRITICAL: single-command Bash calls only
 
 Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
-`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
-tool instead of `grep` or `rg`. Use the **Glob** tool instead of
-`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
-this blocks unattended operation with interactive prompts.
+`;`, or `|`. Never append `2>/dev/null`. Use the **Read** tool instead
+of `cat`. Use the **Grep** tool instead of `grep` or `rg`. Use the
+**Glob** tool instead of `find`. Use `git -C <path>` instead of
+`cd <path> && git`. Violating this blocks unattended operation with
+interactive prompts.
+
+Common patterns and their correct alternatives:
+
+- **Check if a file exists:** Use the **Read** tool — it returns an
+  error if the file doesn't exist, which is fine. Do NOT use
+  `ls <file> 2>/dev/null || echo "missing"`.
+- **Check if a directory exists:** `ls <dir>` alone (no `||`, no
+  `2>/dev/null`). If it fails, the error message tells you.
+- **Read a file that might not exist:** Use the **Read** tool. A "file
+  not found" error is a normal signal, not something to suppress.
+- **Run a command and fall back:** Issue the command alone. Read the
+  exit status / error. Issue the fallback as a separate Bash call if
+  needed.
+- **Write a temp file for `--body-file`:** Use the **Write** tool to
+  write within the worktree (e.g. `.review-body.md`), not to `/tmp`.
+  The sandbox may block writes outside the project tree.
 
 ## Role
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -17,10 +17,24 @@ Mode (optional argument): $ARGUMENTS
 ## CRITICAL: single-command Bash calls only
 
 Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
-`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
-tool instead of `grep` or `rg`. Use the **Glob** tool instead of
-`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
-this blocks unattended operation with interactive prompts.
+`;`, or `|`. Never append `2>/dev/null`. Use the **Read** tool instead
+of `cat`. Use the **Grep** tool instead of `grep` or `rg`. Use the
+**Glob** tool instead of `find`. Use `git -C <path>` instead of
+`cd <path> && git`. Violating this blocks unattended operation with
+interactive prompts.
+
+Common patterns and their correct alternatives:
+
+- **Check if a file exists:** Use the **Read** tool — it returns an
+  error if the file doesn't exist, which is fine. Do NOT use
+  `ls <file> 2>/dev/null || echo "missing"`.
+- **Check if a directory exists:** `ls <dir>` alone (no `||`, no
+  `2>/dev/null`). If it fails, the error message tells you.
+- **Read a file that might not exist:** Use the **Read** tool. A "file
+  not found" error is a normal signal, not something to suppress.
+- **Run a command and fall back:** Issue the command alone. Read the
+  exit status / error. Issue the fallback as a separate Bash call if
+  needed.
 
 ## Responsibilities
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -11,10 +11,24 @@ Mode (optional argument): $ARGUMENTS
 ## CRITICAL: single-command Bash calls only
 
 Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
-`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
-tool instead of `grep` or `rg`. Use the **Glob** tool instead of
-`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
-this blocks unattended operation with interactive prompts.
+`;`, or `|`. Never append `2>/dev/null`. Use the **Read** tool instead
+of `cat`. Use the **Grep** tool instead of `grep` or `rg`. Use the
+**Glob** tool instead of `find`. Use `git -C <path>` instead of
+`cd <path> && git`. Violating this blocks unattended operation with
+interactive prompts.
+
+Common patterns and their correct alternatives:
+
+- **Check if a file exists:** Use the **Read** tool — it returns an
+  error if the file doesn't exist, which is fine. Do NOT use
+  `ls <file> 2>/dev/null || echo "missing"`.
+- **Check if a directory exists:** `ls <dir>` alone (no `||`, no
+  `2>/dev/null`). If it fails, the error message tells you.
+- **Read a file that might not exist:** Use the **Read** tool. A "file
+  not found" error is a normal signal, not something to suppress.
+- **Run a command and fall back:** Issue the command alone. Read the
+  exit status / error. Issue the fallback as a separate Bash call if
+  needed.
 
 ## Role
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -12,10 +12,24 @@ Mode (optional argument): $ARGUMENTS
 ## CRITICAL: single-command Bash calls only
 
 Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
-`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
-tool instead of `grep` or `rg`. Use the **Glob** tool instead of
-`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
-this blocks unattended operation with interactive prompts.
+`;`, or `|`. Never append `2>/dev/null`. Use the **Read** tool instead
+of `cat`. Use the **Grep** tool instead of `grep` or `rg`. Use the
+**Glob** tool instead of `find`. Use `git -C <path>` instead of
+`cd <path> && git`. Violating this blocks unattended operation with
+interactive prompts.
+
+Common patterns and their correct alternatives:
+
+- **Check if a file exists:** Use the **Read** tool — it returns an
+  error if the file doesn't exist, which is fine. Do NOT use
+  `ls <file> 2>/dev/null || echo "missing"`.
+- **Check if a directory exists:** `ls <dir>` alone (no `||`, no
+  `2>/dev/null`). If it fails, the error message tells you.
+- **Read a file that might not exist:** Use the **Read** tool. A "file
+  not found" error is a normal signal, not something to suppress.
+- **Run a command and fall back:** Issue the command alone. Read the
+  exit status / error. Issue the fallback as a separate Bash call if
+  needed.
 
 ## Responsibilities
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -12,10 +12,27 @@ Mode (optional argument): $ARGUMENTS
 ## CRITICAL: single-command Bash calls only
 
 Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
-`;`, or `|`. Use the **Read** tool instead of `cat`. Use the **Grep**
-tool instead of `grep` or `rg`. Use the **Glob** tool instead of
-`find`. Use `git -C <path>` instead of `cd <path> && git`. Violating
-this blocks unattended operation with interactive prompts.
+`;`, or `|`. Never append `2>/dev/null`. Use the **Read** tool instead
+of `cat`. Use the **Grep** tool instead of `grep` or `rg`. Use the
+**Glob** tool instead of `find`. Use `git -C <path>` instead of
+`cd <path> && git`. Violating this blocks unattended operation with
+interactive prompts.
+
+Common patterns and their correct alternatives:
+
+- **Check if a file exists:** Use the **Read** tool — it returns an
+  error if the file doesn't exist, which is fine. Do NOT use
+  `ls <file> 2>/dev/null || echo "missing"`.
+- **Check if a directory exists:** `ls <dir>` alone (no `||`, no
+  `2>/dev/null`). If it fails, the error message tells you.
+- **Read a file that might not exist:** Use the **Read** tool. A "file
+  not found" error is a normal signal, not something to suppress.
+- **Run a command and fall back:** Issue the command alone. Read the
+  exit status / error. Issue the fallback as a separate Bash call if
+  needed.
+- **Write a temp file for `--body-file`:** Use the **Write** tool to
+  write within the worktree (e.g. `.review-body.md`), not to `/tmp`.
+  The sandbox may block writes outside the project tree.
 
 ## Role
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -198,7 +198,9 @@ causes parse errors when the body contains backticks or special
 characters. Instead, write the body to a temp file with the **Write
 tool**, then pass it with `--body-file`:
 
-1. Use the **Write tool** to write the review body to `/tmp/review-body.md`:
+1. Use the **Write tool** to write the review body to `.review-body.md`
+   in the worktree root (NOT `/tmp/` — the sandbox may block writes
+   outside the project tree). This file is gitignored:
 
 ```markdown
 ## Review — <title>
@@ -227,7 +229,7 @@ tool**, then pass it with `--body-file`:
 2. Post the review:
 
 ```bash
-gh pr review <N> --comment --body-file /tmp/review-body.md
+gh pr review <N> --comment --body-file .review-body.md
 ```
 
 Rules for the review body:

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Thumbs.db
 .vs/
 *.vcxproj.user
 
+# fleet agent temp files
+.review-body.md
+
 # creations: keep demos + top-level CLAUDE.md, ignore other folders
 creations/*
 !creations/CLAUDE.md


### PR DESCRIPTION
## Summary
- Expanded the CRITICAL single-command section in all 6 role files with explicit alternatives for common patterns that agents were improvising as compound commands (`ls ... 2>/dev/null || echo`, etc.)
- Changed review-pr skill temp file from `/tmp/review-body.md` to `.review-body.md` (within worktree) — the sandbox may block writes outside the project tree
- Added `.review-body.md` to `.gitignore`

## Problem
Agents were hitting interactive "Do you want to proceed?" prompts during unattended operation because they improvised compound Bash commands to check file/directory existence. The CRITICAL section banned `||` and `2>/dev/null` but didn't show what to do instead.

## Test plan
- [ ] Restart fleet agents — verify no `||` or `2>/dev/null` prompts appear
- [ ] Sonnet reviewer writes review body to `.review-body.md` successfully
- [ ] `.review-body.md` does not appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)