### PR TITLE
fleet: tighten sonnet loop intervals

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -168,7 +168,7 @@ half-finished and re-litigated in review.
 
 ### Step 6 — Maintenance scheduling
 
-The `/loop` driver re-invokes this role every 15 minutes in live
+The `/loop` driver re-invokes this role every 5 minutes in live
 mode. Each invocation runs the startup actions and a full maintenance
 pass, then exits cleanly. The `/loop` driver and `fleet-babysit`
 wrapper handle scheduling and crash recovery.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -67,7 +67,7 @@ treat it as a hard rule for this role.
 
 ## Loop behavior
 
-The `/loop` driver re-invokes this role every 10 minutes in live mode.
+The `/loop` driver re-invokes this role every 3 minutes in live mode.
 Each invocation is one iteration — do the work, then exit cleanly:
 
 1. Re-fetch PR lists from both repos (separate commands):
@@ -133,7 +133,7 @@ Each invocation is one iteration — do the work, then exit cleanly:
      Blocking PRs on style nits wastes more fleet time than the nit
      is worth.
 3. After the queue is drained, exit cleanly. The `/loop` driver
-   re-invokes this role in 10 minutes.
+   re-invokes this role in 3 minutes.
 4. If you hit a usage-limit error: print the error and exit. The
    `/loop` driver and `fleet-babysit` wrapper handle backoff.
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -316,7 +316,7 @@ label_pane_id "$TOP1" "sonnet-fleet-1 [sonnet]"
 # full window height at this point — 25% bottom, 75% top.
 tmux split-window -v -t "$TOP1" -p 25 \
     -c "$ENGINE/.claude/worktrees/sonnet-reviewer" \
-    "$(launch_cmd sonnet sonnet-reviewer 10m)"
+    "$(launch_cmd sonnet sonnet-reviewer 3m)"
 BOT1=$(active_pane_id)
 label_pane_id "$BOT1" "sonnet-reviewer [sonnet]"
 
@@ -328,7 +328,7 @@ label_pane_id "$BOT2" "opus-reviewer [opus]"
 
 tmux split-window -h -t "$BOT2" \
     -c "$ENGINE/.claude/worktrees/queue-manager" \
-    "$(launch_cmd sonnet queue-manager 15m)"
+    "$(launch_cmd sonnet queue-manager 5m)"
 BOT3=$(active_pane_id)
 label_pane_id "$BOT3" "queue-manager [sonnet]"
 
@@ -404,8 +404,8 @@ the session if claude exits (crash, usage limit, network drop).
   live    — auto-resumes on any exit (runs indefinitely)
 
 scheduling (live mode): polling roles use Claude's /loop for managed intervals:
-  sonnet-reviewer — /loop 10m    opus-reviewer — /loop 30m
-  opus-worker     — /loop 20m   queue-manager  — /loop 15m
+  sonnet-reviewer — /loop 3m     opus-reviewer — /loop 30m
+  opus-worker     — /loop 20m   queue-manager  — /loop 5m
   authors — continuous (no /loop)
   opus-architect — interactive (no /loop, human's design partner)
 


### PR DESCRIPTION
## Summary
- Sonnet reviewer: 10m → **3m**
- Queue-manager: 15m → **5m**
- Opus loops unchanged (20m worker, 30m reviewer)

## Why
Sonnet idle iterations are trivially cheap — read TASKS.md, check `gh pr list`, print "standing by", exit. Faster polling means:
- Issues get ingested into TASKS.md within 5 minutes of `human:approved`
- PRs get first-pass reviewed within 3 minutes of opening
- Human feedback labels get picked up faster

Opus loops stay at 20m/30m since those iterations actually burn budget.

## Test plan
- [ ] Next `fleet-up` launch uses new intervals
- [ ] Queue-manager ingests issue #156 within ~5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)