### PR TITLE
fleet: add startup banners and post-loop timing

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -49,6 +49,8 @@ list above.
 
 ## Startup actions (do these immediately, in order)
 
+0. Print your role banner:
+   `[opus-architect] Interactive design partner — core engine architecture, ECS design, render pipeline decisions. On-demand (no loop).`
 1. `git -C ~/src/IrredenEngine fetch origin --quiet`
 2. Read `TASKS.md` (use the Read tool, not `cat`) — review the current queue.
 3. `gh pr list --state open --json number,title,headRefName,author` —

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -57,6 +57,8 @@ conditions, allocator behavior, hot-path costs.
 
 ## Startup actions
 
+0. Print your role banner:
+   `[opus-reviewer] Final reviewer — Opus recheck on PRs touching core engine invariants or flagged by Sonnet. Loop: every 30m.`
 1. `pwd` — confirm you are in the `opus-reviewer` worktree.
 2. **Discover repo slugs** (used in all `--repo` flags below):
    Engine: `gh repo view --json nameWithOwner --jq .nameWithOwner`
@@ -139,8 +141,10 @@ Each invocation is one iteration — do the work, then exit cleanly:
    `git checkout -B claude/opus-reviewer-scratch origin/master`
    This prevents "branch already checked out in worktree" errors when
    a worker agent tries to check out a PR branch you just reviewed.
-4. After the reset, exit cleanly. The `/loop` driver re-invokes this
-   role in 30 minutes.
+4. After the reset, print
+   `[opus-reviewer] Iteration complete. Next run in ~30m.`
+   Then exit cleanly. The `/loop` driver re-invokes this role in 30
+   minutes.
 5. If you hit a usage-limit error: print the error and exit. The
    `/loop` driver and `fleet-babysit` wrapper handle backoff.
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -52,6 +52,8 @@ whatever directory the task touches before editing anything.
 
 ## Startup actions (do these immediately, in order)
 
+0. Print your role banner:
+   `[opus-worker] Plans fleet:needs-plan issues, executes [opus] tasks from TASKS.md. Loop: every 20m.`
 1. `pwd` and confirm you are in the `opus-worker` worktree (not
    opus-architect, not a reviewer worktree).
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
@@ -185,9 +187,9 @@ Each invocation is one iteration — do the work, then exit cleanly:
    get done. Pick it up.
 
    If no `Model: opus` tasks are available, print
-   `no unblocked [opus] tasks — standing by` and exit cleanly. Do NOT
-   invent work, self-assign documentation passes, or create tasks
-   outside the queue. The `/loop` driver will re-invoke in 20 minutes.
+   `[opus-worker] No unblocked [opus] tasks — standing by. Next run in ~20m.`
+   and exit cleanly. Do NOT invent work, self-assign documentation
+   passes, or create tasks outside the queue.
 
    Print the task and explain why you picked it.
 
@@ -294,8 +296,9 @@ Each invocation is one iteration — do the work, then exit cleanly:
     Paste the PR URL.
 
 11. **Reset.** Use the `start-next-task` skill to land on a fresh
-    branch off `origin/master`. Exit cleanly. The `/loop` driver will
-    re-invoke in 20 minutes.
+    branch off `origin/master`. Print
+    `[opus-worker] Iteration complete. Next run in ~20m.`
+    Then exit cleanly. The `/loop` driver will re-invoke in 20 minutes.
 
 If Mode above is `dry-run`: do startup actions only. Do not plan or
 pick a task. Wait for human instruction.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -49,6 +49,8 @@ Run each step as its own **single** tool call. Never combine with
 `&&`, `||`, `;`, or `|`. Never use `cd` before `git` or `gh`. Never
 use `cat` — use the Read tool for files.
 
+0. Print your role banner:
+   `[queue-manager] Task intake — ingests approved issues into TASKS.md, syncs PR state, maintains the queue. Loop: every 5m. You can also type task descriptions here between loop fires.`
 1. `pwd`
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
 3. **Discover repo slugs** (used in all `--repo` flags below):
@@ -391,9 +393,10 @@ You are the sole TASKS.md editor. Each maintenance pass:
    If either push is rejected, rebase and retry. Only push TASKS.md
    and `.fleet/plans/` — never push other files to master.
 
-8. Print the maintenance summary AND the queue summary on two lines:
+8. Print the maintenance summary, queue summary, and next-run timing:
    `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned`
    `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
+   `[queue-manager] Iteration complete. Next run in ~5m.`
 
 ## Hard rules
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -48,6 +48,8 @@ whatever directory the task touches before editing anything.
 
 ## Startup actions (do these immediately, in order)
 
+0. Print your role banner:
+   `[sonnet-author] Picks bounded [sonnet] tasks from TASKS.md, works them end-to-end, opens PRs. Runs continuously.`
 1. `pwd` and confirm you are in a sonnet-fleet worktree (not the main
    clone, not a reviewer worktree).
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
@@ -135,10 +137,9 @@ limit. Each loop iteration:
    the task is yours to claim.
 
    **If no matching task exists, exit cleanly.** Print
-   `no unblocked [sonnet] tasks — standing by` and stop. Do NOT
-   invent work, self-assign documentation passes, or create tasks
-   outside the queue. The `/loop` driver or `fleet-babysit` will
-   re-invoke you later when new tasks may have appeared.
+   `[sonnet-author] No unblocked [sonnet] tasks — standing by. Babysit will re-invoke.`
+   and stop. Do NOT invent work, self-assign documentation passes,
+   or create tasks outside the queue.
 
    Print the task and explain why you picked it.
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -48,6 +48,8 @@ treat it as a hard rule for this role.
 
 ## Startup actions
 
+0. Print your role banner:
+   `[sonnet-reviewer] First-pass PR reviewer — polls for unreviewed PRs, posts structured reviews, flags Opus escalations. Loop: every 3m.`
 1. `pwd` — confirm you are in the `sonnet-reviewer` worktree.
 2. **Discover repo slugs** (used in all `--repo` flags below):
    Engine: `gh repo view --json nameWithOwner --jq .nameWithOwner`
@@ -161,8 +163,10 @@ Each invocation is one iteration — do the work, then exit cleanly:
    `git checkout -B claude/sonnet-reviewer-scratch origin/master`
    This prevents "branch already checked out in worktree" errors when
    a worker agent tries to check out a PR branch you just reviewed.
-4. After the reset, exit cleanly. The `/loop` driver re-invokes this
-   role in 3 minutes.
+4. After the reset, print
+   `[sonnet-reviewer] Iteration complete. Next run in ~3m.`
+   Then exit cleanly. The `/loop` driver re-invokes this role in 3
+   minutes.
 5. If you hit a usage-limit error: print the error and exit. The
    `/loop` driver and `fleet-babysit` wrapper handle backoff.
 


### PR DESCRIPTION
## Summary
- All 6 roles print a startup banner: `[role-name] What I do. Loop: every Xm.`
- Looped roles print next-run timing after each iteration: `[role-name] Iteration complete. Next run in ~Xm.`
- Idle-exit messages also show timing so the human knows when to expect the next check

## Examples
Startup:
```
[queue-manager] Task intake — ingests approved issues into TASKS.md, syncs PR state, maintains the queue. Loop: every 5m. You can also type task descriptions here between loop fires.
```
End of iteration:
```
[queue-manager] Iteration complete. Next run in ~5m.
```

## Test plan
- [ ] Restart fleet — each pane shows its role banner on startup
- [ ] After a loop iteration completes, timing message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)