### PR TITLE
fix: sync TASKS.md from origin/master on agent startup

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -41,7 +41,11 @@ whatever directory the task touches before editing anything.
 1. `pwd` and confirm you are in the `opus-worker` worktree (not
    opus-architect, not a reviewer worktree).
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. Read `TASKS.md` (use the Read tool) — review the current queue.
+3. Sync TASKS.md from origin/master (the working copy may be stale
+   if the worktree is on a feature branch or a queue-manager push
+   landed since last fetch):
+   `git checkout origin/master -- TASKS.md`
+4. Read `TASKS.md` (use the Read tool) — review the current queue.
 4. `gh pr list --state open --json number,title,headRefName,author` —
    see what other agents are working on.
 5. Check for `fleet:needs-plan` issues:

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -37,7 +37,11 @@ whatever directory the task touches before editing anything.
 1. `pwd` and confirm you are in a sonnet-fleet worktree (not the main
    clone, not a reviewer worktree).
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. Read `TASKS.md` (use the Read tool, not `cat`) — review the current queue.
+3. Sync TASKS.md from origin/master (the working copy may be stale
+   if the worktree is on a feature branch or a queue-manager push
+   landed since last fetch):
+   `git checkout origin/master -- TASKS.md`
+4. Read `TASKS.md` (use the Read tool, not `cat`) — review the current queue.
 4. `gh pr list --state open --json number,title,headRefName,author` —
    see what other agents are working on.
 5. Print a one-line summary: which `[sonnet]` items look unblocked and


### PR DESCRIPTION
## Summary
- Adds `git checkout origin/master -- TASKS.md` step to opus-worker and sonnet-author startup actions, between fetch and read
- Fixes a bug where workers on feature branches missed newly-added tasks because `git fetch` updates remote refs but not the working copy

**Companion PR:** game repo PR for game-architect plan flow fix (jakildev/irreden)

## Test plan
- [ ] Start opus-worker on a feature branch → confirm it sees tasks added by queue-manager since the branch diverged
- [ ] Start sonnet-author on a feature branch → same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)