### PR TITLE
fix: allow edits in worktrees and prevent reviewer branch collisions

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -130,9 +130,15 @@ Each invocation is one iteration — do the work, then exit cleanly:
      synchronization, performance regressions, or unsafe API use.
    - Opus budget is expensive. Don't spend it requesting a second
      round-trip over a renamed variable. When in doubt, approve.
-3. After the queue is drained, exit cleanly. The `/loop` driver
-   re-invokes this role in 30 minutes.
-4. If you hit a usage-limit error: print the error and exit. The
+3. **Reset to scratch branch.** After reviewing all candidates (or if
+   none existed), return to the scratch branch so no PR branch is left
+   checked out — other agents may need to check out the same branch:
+   `git checkout -B claude/opus-reviewer-scratch origin/master`
+   This prevents "branch already checked out in worktree" errors when
+   a worker agent tries to check out a PR branch you just reviewed.
+4. After the reset, exit cleanly. The `/loop` driver re-invokes this
+   role in 30 minutes.
+5. If you hit a usage-limit error: print the error and exit. The
    `/loop` driver and `fleet-babysit` wrapper handle backoff.
 
 If Mode above is `dry-run`: review exactly **one** flagged PR

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -149,9 +149,15 @@ Each invocation is one iteration — do the work, then exit cleanly:
    - When in doubt, approve. The human can always request a follow-up.
      Blocking PRs on style nits wastes more fleet time than the nit
      is worth.
-3. After the queue is drained, exit cleanly. The `/loop` driver
-   re-invokes this role in 3 minutes.
-4. If you hit a usage-limit error: print the error and exit. The
+3. **Reset to scratch branch.** After reviewing all candidates (or if
+   none existed), return to the scratch branch so no PR branch is left
+   checked out — other agents may need to check out the same branch:
+   `git checkout -B claude/sonnet-reviewer-scratch origin/master`
+   This prevents "branch already checked out in worktree" errors when
+   a worker agent tries to check out a PR branch you just reviewed.
+4. After the reset, exit cleanly. The `/loop` driver re-invokes this
+   role in 3 minutes.
+5. If you hit a usage-limit error: print the error and exit. The
    `/loop` driver and `fleet-babysit` wrapper handle backoff.
 
 If Mode above is `dry-run`: review exactly **one** PR end-to-end

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -155,6 +155,7 @@ settings_file = sys.argv[1]
 repo_root     = sys.argv[2]
 
 baseline = [
+    "Edit(*)",
     "Bash(grep:*)",
     "Bash(find:*)",
     "Bash(head:*)",


### PR DESCRIPTION
## Summary
- Adds `Edit(*)` to the baseline allow list in `fleet-up`'s `write_worktree_settings()` so agents don't get interactive edit prompts on project files
- Adds a scratch-branch reset step at the end of both reviewer loops (`sonnet-reviewer` and `opus-reviewer`) so they don't leave PR branches checked out — this was causing "branch already checked out in worktree" errors when workers tried to check out the same branch

## Test plan
- [ ] After `fleet-up`, check a worktree's `.claude/settings.local.json` — confirm `Edit(*)` is in the allow list
- [ ] Sonnet reviewer finishes reviewing a PR → confirm it resets to `claude/sonnet-reviewer-scratch`
- [ ] Opus worker tries to check out a branch that was just reviewed → no collision error

🤖 Generated with [Claude Code](https://claude.com/claude-code)