### PR TITLE
feat: add request-re-review skill and human:re-review label

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -77,6 +77,9 @@ conditions, allocator behavior, hot-path costs.
 5. Identify the candidates from both repos. A PR is a candidate if:
    - The latest Sonnet review body contains `Opus recheck required`, OR
    - The PR touches core engine/game invariants, OR
+   - The PR has the `human:re-review` label (human made changes and
+     requested re-review — remove the label when you pick it up:
+     `gh pr edit <N> --remove-label "human:re-review"`), OR
    - The author pushed fixes and commented "re-review please" after
      a previous Opus review (check comments after your last review).
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -69,9 +69,15 @@ treat it as a hard rule for this role.
    Print both results so we both see the current PR queues.
 5. Identify review candidates from both repos. A PR is a candidate if:
    - It has **no fleet review yet** (no review from your GitHub user), OR
+   - It has the `human:re-review` label (human made changes and
+     explicitly requested re-review via the `request-re-review` skill), OR
    - It **previously had a fleet review** but the author pushed fixes
      and commented "re-review please" (check the comments array for
      this text after your last review).
+
+   When picking up a `human:re-review` PR, **immediately remove the
+   label** so another reviewer doesn't also grab it:
+   `gh pr edit <N> --remove-label "human:re-review"`
 
    **Skip** PRs with any of these labels:
    - `fleet:wip` — work-in-progress claim, not ready for review.

--- a/.claude/skills/request-re-review/SKILL.md
+++ b/.claude/skills/request-re-review/SKILL.md
@@ -1,0 +1,104 @@
+# request-re-review
+
+Push changes on the current PR branch and request a fleet re-review.
+
+## When to invoke
+
+Trigger when the user says:
+
+- "request re-review" / "re-review this PR"
+- "push and re-review" / "push for re-review"
+- "I'm done with this PR, have the fleet re-review"
+- "update PR and get it reviewed again"
+- Any phrase implying: I've made changes to an approved/reviewed PR
+  and want the fleet reviewers to look at it again.
+
+Also useful when the user has checked out a PR branch in any pane
+(architect, worker, etc.), made manual edits with an agent, and wants
+the review pipeline to pick it back up.
+
+## Preconditions
+
+1. You are on a PR branch (not a scratch branch, not master).
+2. There is an open PR for this branch.
+3. `gh` is authenticated.
+
+## Flow
+
+### 1. Identify the current PR
+
+```bash
+git branch --show-current
+```
+
+Find the open PR for this branch:
+```bash
+gh pr list --state open --head <branch-name> --json number,title,labels
+```
+
+If no PR is found, tell the user and stop.
+
+### 2. Commit and push any uncommitted changes
+
+Check for uncommitted work:
+```bash
+git status --porcelain
+```
+
+If there are changes:
+- Stage all modified/added files: `git add -A`
+- Commit with a descriptive message:
+  `git commit -m "changes from human review session"`
+- Push: `git push`
+
+If there are no uncommitted changes but there ARE unpushed commits,
+push them.
+
+If everything is already clean and pushed, that's fine — proceed to
+relabel.
+
+### 3. Swap labels to request re-review
+
+Remove stale fleet verdict labels and add the re-review request:
+```bash
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "human:re-review"
+```
+
+### 4. Post a comment
+
+```bash
+gh pr comment <N> --body "Human made changes — re-review requested."
+```
+
+### 5. Release the branch
+
+Determine the correct scratch branch name based on your worktree:
+- If in an engine worktree named `<name>`: `claude/<name>-scratch`
+  (e.g., `opus-architect` → `claude/opus-arch-scratch`)
+- If unsure, use a generic: `claude/scratch`
+
+Reset to the scratch branch:
+```bash
+git checkout -B claude/<name>-scratch origin/master
+```
+
+This frees the PR branch so reviewers (or other agents) can check
+it out.
+
+### 6. Report back
+
+Print:
+```
+Re-review requested for PR #<N> (<title>).
+- Label: human:re-review added, fleet:approved removed
+- Branch released — reviewers can check it out
+- Next reviewer pass will pick it up
+```
+
+## Anti-patterns
+
+- ❌ Leaving the PR branch checked out after requesting re-review.
+  The whole point is to release it for reviewers.
+- ❌ Using this on a PR that's still `fleet:wip` — that PR isn't
+  ready for review at all. Tell the user to finalize first.
+- ❌ Force-pushing. Never `--force`.


### PR DESCRIPTION
## Summary
- New `/request-re-review` skill: commits+pushes changes on current PR branch, removes `fleet:approved`, adds `human:re-review`, posts a comment, resets to scratch branch (releases the PR branch for reviewers)
- Sonnet reviewer now checks for `human:re-review` label as a review trigger (removes it immediately to prevent double-pickup)
- Opus reviewer same

**Use case:** You're in an architect/worker pane, checked out a PR, made manual edits with the agent. Run `/request-re-review` and the fleet picks it up on the next reviewer pass.

**Label lifecycle:** human edits PR → `/request-re-review` adds `human:re-review` → reviewer removes it, reviews fresh, sets new verdict label

## Test plan
- [ ] Check out an approved PR, make an edit, run `/request-re-review` → changes pushed, `fleet:approved` removed, `human:re-review` added, branch released
- [ ] Sonnet reviewer next pass sees `human:re-review` → removes it, reviews the PR, posts verdict
- [ ] PR branch is free for reviewer checkout (no "branch already checked out" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)