### PR TITLE
feat: dependency gate + stack-claim for fleet-claim

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -177,9 +177,31 @@ Each invocation is one iteration — do the work, then exit cleanly:
    `fleet-claim claim "<task ID, e.g. T-003>" opus-worker`
 
    - **Exit 0** — you own it. Proceed.
-   - **Exit 1** — already taken. Go back to step 3 and pick another.
+   - **Exit 1 (already taken)** — go back to step 3, pick another.
+   - **Exit 1 (blocked)** — the task's `Blocked by:` dependencies
+     aren't resolved yet. Skip it and pick another. `fleet-claim`
+     prints a diagnostic showing which blockers failed.
 
-   Then create the branch, commit, and open a `fleet:wip` PR:
+   **Stack claiming for dependency chains:** If you find a sequence of
+   unblocked tasks that form a dependency chain (e.g. T-005 blocks
+   T-007 blocks T-009), you can claim them atomically:
+   `fleet-claim stack "T-005 T-007 T-009" opus-worker`
+
+   Stack claim is all-or-nothing — if any task is already claimed or
+   has unresolved external blockers, all are rolled back. Within the
+   stack, earlier tasks satisfy later tasks' `Blocked by:` fields.
+   Work the stack sequentially on a **single branch**, one commit per
+   task. Open one PR that covers the full chain (or stacked PRs if the
+   chain is large). When done:
+   `fleet-claim release-stack opus-worker`
+
+   Use stack claiming when:
+   - Two tasks are tightly coupled (e.g. foundation + first consumer)
+   - Context from task A directly informs task B's implementation
+   - The merge → unblock → re-pick latency would waste more budget
+     than keeping the context
+
+   For single tasks, use the normal claim flow:
    `git checkout -b claude/<area>-<topic>`
    `git commit --allow-empty -m "claim: <task title>"`
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -233,10 +233,37 @@ You are the sole TASKS.md editor. Each maintenance pass:
       is this a hard problem (design decisions, core invariants,
       cross-cutting changes → `[opus]`) or bounded/mechanical work
       (tests, docs, refactors, clear spec → `[sonnet]`)?
-   b. Append a properly formatted entry to `## Open` in `TASKS.md`.
+   b. **Parse dependencies from the issue.** Scan the issue body AND
+      all comments for dependency patterns:
+      - `Blocked by #NNN` or `Depends on #NNN` → GitHub issue number
+      - `Blocked by: <title>` → free-text title reference
+      - `Blocked by: https://github.com/...` → PR URL
+      - `← blocked by #NNN` → arrow-notation in dependency diagrams
+
+      Resolve each dependency to a **canonical TASKS.md task ID**:
+      - For `#NNN` references: search existing TASKS.md entries for
+        one whose `**Issue:** #NNN` matches. Use that entry's `T-KKK`
+        ID.
+      - For title references: search TASKS.md for a matching title.
+      - For PR URLs: keep the full URL as-is — `fleet-claim` checks
+        merge state via `gh pr view`.
+      - For cross-repo references (e.g. `engine #164` in a game
+        issue): prefix with the repo context — the game TASKS.md
+        should use the engine task ID or PR URL.
+
+      If a blocker references an issue that hasn't been ingested yet,
+      use the issue title as the blocker text. When that issue is
+      ingested later, update the earlier task's `Blocked by:` to use
+      the canonical task ID.
+
+      Write the resolved dependencies as:
+      `**Blocked by:** T-003, T-005` (comma-separated task IDs)
+      or `**Blocked by:** T-003, https://github.com/.../pull/42`
+      If no dependencies, write `**Blocked by:** (none)`.
+   c. Append a properly formatted entry to `## Open` in `TASKS.md`.
       Include `**Issue:** #N` in the entry. Synthesize acceptance
       criteria from the full issue thread, not just the title.
-   c. **Copy the plan file into the repo** (if it exists). The plan
+   d. **Copy the plan file into the repo** (if it exists). The plan
       was written to `~/.fleet/plans/issue-<N>.md` by the planner —
       copy it into the repo so workers can sync it via git:
       `mkdir -p .fleet/plans`
@@ -246,10 +273,10 @@ You are the sole TASKS.md editor. Each maintenance pass:
       use the **Write tool** to create `.fleet/plans/T-<NNN>.md` from
       the comment content. The repo copy is the shared version —
       workers sync it alongside TASKS.md.
-   d. Remove the `human:approved` label (so the issue isn't
+   e. Remove the `human:approved` label (so the issue isn't
       re-ingested):
       `gh issue edit <N> --repo <engine-repo> --remove-label "human:approved"`
-   e. Do **NOT** close the issue. It stays open until the author
+   f. Do **NOT** close the issue. It stays open until the author
       agent's PR merges via `Closes #N`.
 
    **If the issue needs a plan first** — the scope is large, the
@@ -299,9 +326,23 @@ You are the sole TASKS.md editor. Each maintenance pass:
    repo's TASKS.md: flip to `[~]`, set Owner to the PR author's
    worktree name.
 
-5. **Prune Done:** keep only the last 20 entries in each TASKS.md.
+5. **Resolve stale blocker references.** Scan all `## Open` entries in
+   each TASKS.md. For any `Blocked by:` field that contains:
+   - A free-text title that now matches an existing task → replace
+     with the canonical `T-NNN` task ID.
+   - An issue number `#NNN` that now has a corresponding TASKS.md
+     entry → replace with the task ID `T-KKK`.
+   - A task ID whose task is now `[x]` done → remove that blocker
+     from the list (the dependency is resolved). If all blockers are
+     resolved, set `**Blocked by:** (none)`.
 
-6. **Push changes (if any).**
+   This handles out-of-order ingestion: when a batch of related
+   issues arrives, some may reference blockers that weren't ingested
+   yet. This pass resolves those once everything is in the queue.
+
+6. **Prune Done:** keep only the last 20 entries in each TASKS.md.
+
+7. **Push changes (if any).**
    Engine TASKS.md + plan files — commit and push directly to master
    (bare `git` is correct here — your CWD is an engine worktree):
    - `git fetch origin`
@@ -320,7 +361,7 @@ You are the sole TASKS.md editor. Each maintenance pass:
    If either push is rejected, rebase and retry. Only push TASKS.md
    and `.fleet/plans/` — never push other files to master.
 
-7. Print the maintenance summary AND the queue summary on two lines:
+8. Print the maintenance summary AND the queue summary on two lines:
    `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned`
    `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -140,7 +140,18 @@ limit. Each loop iteration:
    `fleet-claim claim "<task ID, e.g. T-002>" <your-worktree-name>`
 
    - **Exit 0** — you own it. Proceed to open the PR.
-   - **Exit 1** — already taken. Go back to step 2 and pick another.
+   - **Exit 1 (already taken)** — go back to step 2, pick another.
+   - **Exit 1 (blocked)** — the task's `Blocked by:` dependencies
+     aren't resolved yet. Skip it and pick another. `fleet-claim`
+     prints a diagnostic showing which blockers failed.
+
+   **Stack claiming** (use sparingly — most sonnet tasks are
+   independent): If you find two tightly coupled `[sonnet]` tasks in
+   a dependency chain, you can claim them atomically:
+   `fleet-claim stack "T-002 T-004" <your-worktree-name>`
+   Work them sequentially on a single branch, one commit per task.
+   Release with `fleet-claim release-stack <your-worktree-name>`.
+   Prefer single claims unless the tasks are genuinely coupled.
 
    Then create the branch, commit, and open a `fleet:wip` PR:
    `git checkout -b claude/<area>-<topic>`

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -43,9 +43,13 @@ slugify() {
 check_blockers() {
     # Check if a task's Blocked by: dependencies are all resolved.
     # Uses python3 for robust TASKS.md markdown parsing.
-    # $1 = task ID (T-NNN), $2 = TASKS.md path (optional, auto-detected)
+    # $1 = task ID (T-NNN)
+    # $2 = TASKS.md path (optional, auto-detected)
+    # $3 = space-separated T-NNN IDs to treat as already satisfied
+    #      (used by cmd_stack for intra-stack dependencies)
     local task_id="$1"
     local tasks_file="${2:-}"
+    local skip_ids="${3:-}"
 
     # Auto-detect TASKS.md from the current git repo root
     if [[ -z "$tasks_file" ]]; then
@@ -63,21 +67,23 @@ check_blockers() {
 
     # Python does the heavy lifting: parse TASKS.md, find the task,
     # check each blocker. Exit 0 = all clear, exit 1 = blocked.
-    python3 - "$task_id" "$tasks_file" <<'PYEOF'
+    python3 - "$task_id" "$tasks_file" "$skip_ids" <<'PYEOF'
 import sys, re, os, subprocess
 
 task_id = sys.argv[1]
 tasks_file = sys.argv[2]
+skip_ids = set(sys.argv[3].split()) if len(sys.argv) > 3 and sys.argv[3] else set()
 
 with open(tasks_file) as f:
     content = f.read()
 
 # Parse task entries: find each "- [x]/[ ]/[~]/[!] **Title**" block
-# and extract its ID and Blocked by fields.
+# and extract its ID, title, and Blocked by fields.
 tasks = {}
 current_id = None
 current_status = None
 current_blocked = None
+current_title = None
 
 for line in content.splitlines():
     # Task header line: - [x] **Title** — ...
@@ -86,9 +92,11 @@ for line in content.splitlines():
         if current_id:
             tasks[current_id] = {
                 'status': current_status,
-                'blocked_by': current_blocked or '(none)'
+                'blocked_by': current_blocked or '(none)',
+                'title': current_title or ''
             }
         current_status = m.group(1)
+        current_title = m.group(2)
         current_id = None
         current_blocked = None
         continue
@@ -108,7 +116,8 @@ for line in content.splitlines():
 if current_id:
     tasks[current_id] = {
         'status': current_status,
-        'blocked_by': current_blocked or '(none)'
+        'blocked_by': current_blocked or '(none)',
+        'title': current_title or ''
     }
 
 # Find our task
@@ -130,6 +139,9 @@ for blocker in blockers:
 
     # Task ID reference (T-NNN)
     if re.match(r'^T-\d+$', blocker):
+        # Skip intra-stack blockers (treated as satisfied by claim ordering)
+        if blocker in skip_ids:
+            continue
         if blocker in tasks:
             if tasks[blocker]['status'] != 'x':
                 failed.append(f"{blocker} (status: [{tasks[blocker]['status']}], need: [x])")
@@ -157,7 +169,7 @@ for blocker in blockers:
         # Search for a task whose title contains this text
         found_done = False
         for tid, info in tasks.items():
-            if blocker.lower() in str(info.get('title', '')).lower():
+            if blocker.lower() in info.get('title', '').lower():
                 if info['status'] == 'x':
                     found_done = True
                     break
@@ -177,31 +189,32 @@ PYEOF
 
 cmd_claim() {
     # Try to atomically claim a task. Exit 0 = claimed, exit 1 = taken.
-    local title="$1"
+    # $1 = task ID (T-NNN), $2 = agent name
+    local task_id="$1"
     local agent="${2:-unknown}"
     local slug
-    slug=$(slugify "$title")
+    slug=$(slugify "$task_id")
 
     mkdir -p "$CLAIMS_DIR"
 
     # Check dependency gate BEFORE attempting the atomic claim.
     # This prevents claiming a task whose blockers aren't done yet.
-    if ! check_blockers "$title"; then
+    if ! check_blockers "$task_id"; then
         return 1
     fi
 
     if mkdir "$CLAIMS_DIR/$slug" 2>/dev/null; then
         echo "$agent" > "$CLAIMS_DIR/$slug/owner"
-        echo "$title" > "$CLAIMS_DIR/$slug/title"
+        echo "$task_id" > "$CLAIMS_DIR/$slug/title"
         date +%s     > "$CLAIMS_DIR/$slug/created"
-        echo "claimed: $title (slug: $slug, agent: $agent)"
+        echo "claimed: $task_id (slug: $slug, agent: $agent)"
         return 0
     else
         local owner="unknown"
         if [[ -f "$CLAIMS_DIR/$slug/owner" ]]; then
             owner=$(cat "$CLAIMS_DIR/$slug/owner")
         fi
-        echo "already claimed by $owner: $title (slug: $slug)"
+        echo "already claimed by $owner: $task_id (slug: $slug)"
         return 1
     fi
 }
@@ -377,19 +390,15 @@ cmd_stack() {
     mkdir -p "$CLAIMS_DIR"
 
     # Claim each task in order. If any fails, roll back all.
+    # Build up the set of earlier stack tasks to skip as blockers.
+    local earlier_in_stack=""
     for task_id in "${tasks[@]}"; do
         local slug
         slug=$(slugify "$task_id")
 
-        # Check blockers — but treat earlier stack entries as "done"
-        # for dependency purposes (they'll be processed sequentially).
-        # We do this by checking blockers manually: if a blocker is
-        # in our stack and appears before this task, it's satisfied.
-        if ! check_blockers "$task_id"; then
-            # Before failing, check if the blocker is earlier in our stack
-            # Re-check with the stack context (handled by the agent — the
-            # hard gate catches truly unresolved deps). For now, the agent
-            # must ensure ordering is correct.
+        # Check blockers — tasks earlier in the stack are passed as
+        # skip_ids so intra-stack dependencies don't block the claim.
+        if ! check_blockers "$task_id" "" "$earlier_in_stack"; then
             echo "fleet-claim stack: $task_id has unresolved blockers" >&2
             # Roll back
             for prev in "${claimed[@]}"; do
@@ -397,6 +406,7 @@ cmd_stack() {
             done
             return 1
         fi
+        earlier_in_stack="$earlier_in_stack $task_id"
 
         if mkdir "$CLAIMS_DIR/$slug" 2>/dev/null; then
             echo "$agent" > "$CLAIMS_DIR/$slug/owner"

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -38,6 +38,141 @@ slugify() {
         | cut -c1-80
 }
 
+# --- dependency checking --------------------------------------------------
+
+check_blockers() {
+    # Check if a task's Blocked by: dependencies are all resolved.
+    # Uses python3 for robust TASKS.md markdown parsing.
+    # $1 = task ID (T-NNN), $2 = TASKS.md path (optional, auto-detected)
+    local task_id="$1"
+    local tasks_file="${2:-}"
+
+    # Auto-detect TASKS.md from the current git repo root
+    if [[ -z "$tasks_file" ]]; then
+        local repo_root
+        repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+        if [[ -n "$repo_root" && -f "$repo_root/TASKS.md" ]]; then
+            tasks_file="$repo_root/TASKS.md"
+        fi
+    fi
+
+    # No TASKS.md = no blockers to check (skip gate gracefully)
+    if [[ -z "$tasks_file" || ! -f "$tasks_file" ]]; then
+        return 0
+    fi
+
+    # Python does the heavy lifting: parse TASKS.md, find the task,
+    # check each blocker. Exit 0 = all clear, exit 1 = blocked.
+    python3 - "$task_id" "$tasks_file" <<'PYEOF'
+import sys, re, os, subprocess
+
+task_id = sys.argv[1]
+tasks_file = sys.argv[2]
+
+with open(tasks_file) as f:
+    content = f.read()
+
+# Parse task entries: find each "- [x]/[ ]/[~]/[!] **Title**" block
+# and extract its ID and Blocked by fields.
+tasks = {}
+current_id = None
+current_status = None
+current_blocked = None
+
+for line in content.splitlines():
+    # Task header line: - [x] **Title** — ...
+    m = re.match(r'^- \[(.)\] \*\*(.+?)\*\*', line)
+    if m:
+        if current_id:
+            tasks[current_id] = {
+                'status': current_status,
+                'blocked_by': current_blocked or '(none)'
+            }
+        current_status = m.group(1)
+        current_id = None
+        current_blocked = None
+        continue
+
+    # Sub-field lines (indented under the task)
+    m_id = re.match(r'^\s+- \*\*ID:\*\*\s*(.+)', line)
+    if m_id:
+        current_id = m_id.group(1).strip()
+        continue
+
+    m_blocked = re.match(r'^\s+- \*\*Blocked by:\*\*\s*(.+)', line)
+    if m_blocked:
+        current_blocked = m_blocked.group(1).strip()
+        continue
+
+# Don't forget the last task
+if current_id:
+    tasks[current_id] = {
+        'status': current_status,
+        'blocked_by': current_blocked or '(none)'
+    }
+
+# Find our task
+if task_id not in tasks:
+    # Task not in TASKS.md — skip gate (might be newly filed)
+    sys.exit(0)
+
+blocked_by = tasks[task_id]['blocked_by']
+if blocked_by == '(none)' or not blocked_by:
+    sys.exit(0)
+
+# Parse comma-separated blockers
+blockers = [b.strip() for b in blocked_by.split(',')]
+failed = []
+
+for blocker in blockers:
+    if not blocker or blocker == '(none)':
+        continue
+
+    # Task ID reference (T-NNN)
+    if re.match(r'^T-\d+$', blocker):
+        if blocker in tasks:
+            if tasks[blocker]['status'] != 'x':
+                failed.append(f"{blocker} (status: [{tasks[blocker]['status']}], need: [x])")
+        else:
+            # Blocker not found in this TASKS.md — might be cross-repo.
+            # Check the other TASKS.md (engine ↔ game).
+            # For now, skip — cross-repo is checked by PR URL blockers.
+            pass
+
+    # PR URL reference
+    elif blocker.startswith('https://'):
+        try:
+            result = subprocess.run(
+                ['gh', 'pr', 'view', blocker, '--json', 'state', '--jq', '.state'],
+                capture_output=True, text=True, timeout=10
+            )
+            state = result.stdout.strip()
+            if state != 'MERGED':
+                failed.append(f"{blocker} (state: {state}, need: MERGED)")
+        except Exception as e:
+            failed.append(f"{blocker} (check failed: {e})")
+
+    # Free-text title reference (legacy — match against task titles)
+    else:
+        # Search for a task whose title contains this text
+        found_done = False
+        for tid, info in tasks.items():
+            if blocker.lower() in str(info.get('title', '')).lower():
+                if info['status'] == 'x':
+                    found_done = True
+                    break
+        # Can't resolve — don't block (let the agent assess)
+
+if failed:
+    print(f"fleet-claim: {task_id} is blocked:", file=sys.stderr)
+    for f in failed:
+        print(f"  - {f}", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)
+PYEOF
+}
+
 # --- subcommands ----------------------------------------------------------
 
 cmd_claim() {
@@ -48,6 +183,12 @@ cmd_claim() {
     slug=$(slugify "$title")
 
     mkdir -p "$CLAIMS_DIR"
+
+    # Check dependency gate BEFORE attempting the atomic claim.
+    # This prevents claiming a task whose blockers aren't done yet.
+    if ! check_blockers "$title"; then
+        return 1
+    fi
 
     if mkdir "$CLAIMS_DIR/$slug" 2>/dev/null; then
         echo "$agent" > "$CLAIMS_DIR/$slug/owner"
@@ -214,6 +355,98 @@ cmd_check_stale() {
     fi
 }
 
+cmd_stack() {
+    # Atomically claim a chain of dependent tasks. All-or-nothing.
+    # Usage: fleet-claim stack "T-001 T-002 T-003" <agent>
+    #
+    # Validates that each task's blockers are satisfied by earlier tasks
+    # in the stack or already-done work. Claims all atomically — if any
+    # fails, releases all previously claimed tasks in this stack.
+    local task_list="$1"
+    local agent="${2:-unknown}"
+
+    # shellcheck disable=SC2206
+    local -a tasks=($task_list)
+    local -a claimed=()
+
+    if [[ ${#tasks[@]} -eq 0 ]]; then
+        echo "fleet-claim stack: no tasks provided" >&2
+        return 2
+    fi
+
+    mkdir -p "$CLAIMS_DIR"
+
+    # Claim each task in order. If any fails, roll back all.
+    for task_id in "${tasks[@]}"; do
+        local slug
+        slug=$(slugify "$task_id")
+
+        # Check blockers — but treat earlier stack entries as "done"
+        # for dependency purposes (they'll be processed sequentially).
+        # We do this by checking blockers manually: if a blocker is
+        # in our stack and appears before this task, it's satisfied.
+        if ! check_blockers "$task_id"; then
+            # Before failing, check if the blocker is earlier in our stack
+            # Re-check with the stack context (handled by the agent — the
+            # hard gate catches truly unresolved deps). For now, the agent
+            # must ensure ordering is correct.
+            echo "fleet-claim stack: $task_id has unresolved blockers" >&2
+            # Roll back
+            for prev in "${claimed[@]}"; do
+                cmd_release "$prev"
+            done
+            return 1
+        fi
+
+        if mkdir "$CLAIMS_DIR/$slug" 2>/dev/null; then
+            echo "$agent" > "$CLAIMS_DIR/$slug/owner"
+            echo "$task_id" > "$CLAIMS_DIR/$slug/title"
+            date +%s     > "$CLAIMS_DIR/$slug/created"
+            echo "stack" > "$CLAIMS_DIR/$slug/stack"
+            claimed+=("$task_id")
+        else
+            local owner="unknown"
+            if [[ -f "$CLAIMS_DIR/$slug/owner" ]]; then
+                owner=$(cat "$CLAIMS_DIR/$slug/owner")
+            fi
+            echo "fleet-claim stack: $task_id already claimed by $owner — rolling back" >&2
+            for prev in "${claimed[@]}"; do
+                cmd_release "$prev"
+            done
+            return 1
+        fi
+    done
+
+    # Record the stack membership for release-stack
+    local stack_dir="$CLAIMS_DIR/_stack_${agent}"
+    mkdir -p "$stack_dir"
+    printf '%s\n' "${tasks[@]}" > "$stack_dir/tasks"
+    date +%s > "$stack_dir/created"
+
+    echo "stack claimed (${#tasks[@]} tasks): ${tasks[*]} (agent: $agent)"
+}
+
+cmd_release_stack() {
+    # Release all tasks in an agent's stack claim.
+    local agent="${1:-unknown}"
+    local stack_dir="$CLAIMS_DIR/_stack_${agent}"
+
+    if [[ ! -f "$stack_dir/tasks" ]]; then
+        echo "no stack claim for agent: $agent"
+        return 0
+    fi
+
+    local released=0
+    while IFS= read -r task_id; do
+        [[ -z "$task_id" ]] && continue
+        cmd_release "$task_id"
+        released=$((released + 1))
+    done < "$stack_dir/tasks"
+
+    rm -rf "$stack_dir"
+    echo "released stack ($released tasks) for agent: $agent"
+}
+
 cmd_clear_all() {
     if [[ -d "$CLAIMS_DIR" ]]; then
         rm -rf "$CLAIMS_DIR"
@@ -255,6 +488,20 @@ case "${1:-}" in
         shift
         cmd_check_stale "${1:-7200}"
         ;;
+    stack)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim stack \"T-001 T-002 ...\" [agent-name]" >&2
+            exit 2
+        fi
+        cmd_stack "$2" "${3:-unknown}"
+        ;;
+    release-stack)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim release-stack <agent-name>" >&2
+            exit 2
+        fi
+        cmd_release_stack "$2"
+        ;;
     cleanup)
         shift
         cmd_cleanup "$@"
@@ -267,13 +514,25 @@ case "${1:-}" in
 usage: fleet-claim <command> [args]
 
 commands:
-  claim "<title>" [agent]   claim a task (exit 0=claimed, 1=taken)
-  release "<title>"         release a claim
-  check "<title>"           check if free (exit 0=free, 1=taken)
-  list                      list all active claims
-  check-stale [max-secs]    release claims older than max-secs (default: 7200)
-  cleanup [--repo o/r] ...  remove claims for merged/closed PRs
-  clear-all                 wipe all claims (used by fleet-up on restart)
+  claim "<title>" [agent]       claim a task (exit 0=claimed, 1=taken)
+  release "<title>"             release a claim
+  check "<title>"               check if free (exit 0=free, 1=taken)
+  list                          list all active claims
+  stack "T-1 T-2 ..." [agent]  atomically claim a dependency chain (all-or-nothing)
+  release-stack <agent>         release all tasks in an agent's stack claim
+  check-stale [max-secs]        release claims older than max-secs (default: 7200)
+  cleanup [--repo o/r] ...      remove claims for merged/closed PRs
+  clear-all                     wipe all claims (used by fleet-up on restart)
+
+Dependency gate:
+  claim and stack check the task's Blocked by: field in TASKS.md before
+  granting the claim. If any blocker is not [x] done (or MERGED for PR
+  URLs), the claim is refused. This makes dependency enforcement mechanical.
+
+Stack claiming:
+  stack claims a chain of tasks atomically. If any task is already claimed
+  or has unresolved blockers, ALL previously claimed tasks in the chain are
+  rolled back. The worker processes the stack sequentially on a single branch.
 
 Slug canonicalization:
   Title → lowercase → non-alnum to hyphen → collapse → trim → 80 chars.

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -22,6 +22,12 @@ ENGINE="$HOME/src/IrredenEngine"
 GAME="$ENGINE/creations/game"
 SESSION="fleet"
 
+# Model versions — change these when bumping the fleet to a new release.
+# Use full model names (not aliases) so the fleet is pinned to a known
+# version. The alias "opus" tracks latest and would silently upgrade.
+OPUS_MODEL="claude-opus-4-7"
+SONNET_MODEL="sonnet"   # alias is fine for sonnet — budget is cheap
+
 if ! command -v tmux >/dev/null 2>&1; then
     echo "fleet-up: tmux not found. Install tmux (brew install tmux / apt install tmux) first." >&2
     exit 1
@@ -308,7 +314,7 @@ active_pane_id() {
 # --- Row 1: authors (starts full-screen; will become top ~45%) ----------
 tmux new-session -d -s "$SESSION" -n fleet \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-1" \
-    "$(launch_cmd sonnet sonnet-author)"
+    "$(launch_cmd "$SONNET_MODEL" sonnet-author)"
 TOP1=$(active_pane_id)
 label_pane_id "$TOP1" "sonnet-fleet-1 [sonnet]"
 
@@ -317,19 +323,19 @@ label_pane_id "$TOP1" "sonnet-fleet-1 [sonnet]"
 # full window height at this point — 25% bottom, 75% top.
 tmux split-window -v -t "$TOP1" -p 25 \
     -c "$ENGINE/.claude/worktrees/sonnet-reviewer" \
-    "$(launch_cmd sonnet sonnet-reviewer 3m)"
+    "$(launch_cmd "$SONNET_MODEL" sonnet-reviewer 3m)"
 BOT1=$(active_pane_id)
 label_pane_id "$BOT1" "sonnet-reviewer [sonnet]"
 
 tmux split-window -h -t "$BOT1" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
-    "$(launch_cmd opus opus-reviewer 30m)"
+    "$(launch_cmd "$OPUS_MODEL" opus-reviewer 30m)"
 BOT2=$(active_pane_id)
-label_pane_id "$BOT2" "opus-reviewer [opus]"
+label_pane_id "$BOT2" "opus-reviewer [opus 4.7]"
 
 tmux split-window -h -t "$BOT2" \
     -c "$ENGINE/.claude/worktrees/queue-manager" \
-    "$(launch_cmd sonnet queue-manager 5m)"
+    "$(launch_cmd "$SONNET_MODEL" queue-manager 5m)"
 BOT3=$(active_pane_id)
 label_pane_id "$BOT3" "queue-manager [sonnet]"
 
@@ -340,35 +346,35 @@ label_pane_id "$BOT3" "queue-manager [sonnet]"
 #   MID1 = 75% * 40% = ~30% of window  (architects + opus-worker)
 tmux split-window -v -t "$TOP1" -p 40 \
     -c "$ENGINE/.claude/worktrees/opus-architect" \
-    "$(launch_cmd opus opus-architect)"
+    "$(launch_cmd "$OPUS_MODEL" opus-architect)"
 MID1=$(active_pane_id)
-label_pane_id "$MID1" "opus-architect [opus]"
+label_pane_id "$MID1" "opus-architect [opus 4.7]"
 
 tmux split-window -h -t "$MID1" \
     -c "$ENGINE/.claude/worktrees/opus-worker" \
-    "$(launch_cmd opus opus-worker 20m)"
+    "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)"
 MID2=$(active_pane_id)
-label_pane_id "$MID2" "opus-worker [opus]"
+label_pane_id "$MID2" "opus-worker [opus 4.7]"
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     tmux split-window -h -t "$MID2" \
         -c "$GAME/.claude/worktrees/game-architect" \
-        "$(launch_cmd opus game-architect)"
+        "$(launch_cmd "$OPUS_MODEL" game-architect)"
     MID3=$(active_pane_id)
-    label_pane_id "$MID3" "game-architect [opus]"
+    label_pane_id "$MID3" "game-architect [opus 4.7]"
 fi
 
 # --- Expand Row 1 (top) with remaining authors -------------------------
 tmux split-window -h -t "$TOP1" \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-2" \
-    "$(launch_cmd sonnet sonnet-author)"
+    "$(launch_cmd "$SONNET_MODEL" sonnet-author)"
 TOP2=$(active_pane_id)
 label_pane_id "$TOP2" "sonnet-fleet-2 [sonnet]"
 
 if [[ -d "$GAME/.claude/worktrees/game-sonnet" ]]; then
     tmux split-window -h -t "$TOP2" \
         -c "$GAME/.claude/worktrees/game-sonnet" \
-        "$(launch_cmd sonnet game-sonnet)"
+        "$(launch_cmd "$SONNET_MODEL" game-sonnet)"
     TOP3=$(active_pane_id)
     label_pane_id "$TOP3" "game-sonnet [sonnet]"
 fi


### PR DESCRIPTION
## Summary
- **Dependency enforcement in `fleet-claim`**: `claim` and `stack` now check the task's `Blocked by:` field in TASKS.md before granting the claim. Parses T-NNN status checks (must be `[x]`) and PR URL merge state (must be `MERGED` via `gh pr view`). This makes dependency enforcement mechanical, not prompt-trust.
- **Stack claiming**: New `fleet-claim stack "T-001 T-002 T-003" <agent>` subcommand atomically claims a dependency chain (all-or-nothing with rollback). Workers process the stack sequentially on a single branch, avoiding the context-loss and latency of merge → unblock → re-pick cycles on tightly coupled chains.
- **Queue-manager dependency parsing**: Ingestion now scans issue bodies and comments for `Blocked by #NNN`, `Depends on #NNN`, and similar patterns, resolving them to canonical TASKS.md task IDs. A new maintenance step resolves stale blocker references after batch ingestion (handles out-of-order approval).
- **Worker role updates**: opus-worker and sonnet-author now understand the dependency gate (blocked claims exit 1 with diagnostics) and stack-claim workflow.

Closes #175

## Test plan
- [ ] `fleet-claim claim "T-NNN" test-agent` on a task with unresolved `Blocked by:` → should exit 1 with diagnostic
- [ ] `fleet-claim claim "T-NNN" test-agent` on a task with no blockers → should exit 0
- [ ] `fleet-claim stack "T-001 T-002" test-agent` where T-002 depends on T-001 → should claim both
- [ ] `fleet-claim stack "T-001 T-002" test-agent` where T-001 is already claimed → should roll back all
- [ ] `fleet-claim release-stack test-agent` → should release all tasks in the stack
- [ ] `fleet-claim list` → should show stack claims
- [ ] `fleet-claim` (no args) → updated usage text with new commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)