### PR TITLE
ci: auto re-review on push to fleet-approved PRs

### DIFF
--- a/.github/workflows/auto-rereview.yml
+++ b/.github/workflows/auto-rereview.yml
@@ -1,0 +1,40 @@
+name: Auto re-review on push to approved PR
+
+# Fires when commits are pushed to a PR that already has fleet:approved.
+# Swaps the label to human:re-review so the fleet reviewers pick it up
+# again on their next poll. This means the human can edit an approved
+# PR and just `git push` — no skill invocation needed.
+#
+# Why filter on fleet:approved only (not all fleet verdict labels):
+#   - During fleet:needs-fix, the author agent is addressing feedback
+#     and pushing fixes via commit-and-push. Auto-swapping there would
+#     fight the fleet:changes-made label the author sets.
+#   - During fleet:wip, the author is actively working. No verdict yet.
+#   - fleet:approved is the only state where a human-pushed change
+#     unambiguously means "I edited after fleet was done — please look
+#     again."
+
+on:
+  pull_request:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write   # gh pr edit --add-label uses the issues label API
+
+jobs:
+  swap-approval-label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'fleet:approved')
+    steps:
+      - name: Swap fleet:approved → human:re-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR" --repo "$REPO" \
+            --remove-label "fleet:approved" \
+            --add-label "human:re-review"
+          gh pr comment "$PR" --repo "$REPO" \
+            --body "New commits pushed after fleet approval. Re-tagging \`human:re-review\` so the fleet picks it up again."


### PR DESCRIPTION
## Summary
- New GitHub Actions workflow `.github/workflows/auto-rereview.yml` fires on `pull_request` synchronize events (any commit push)
- If PR has `fleet:approved` label → removes it, adds `human:re-review`, posts comment
- Fleet reviewers already poll for `human:re-review` (added in #176) and will pick up the change automatically

**The flow:**
1. PR gets `fleet:approved` from a fleet reviewer
2. Human edits the PR (manual tweaks, polish, whatever)
3. Human runs `git push`
4. Workflow fires → label swaps → comment posted
5. Sonnet/Opus reviewer's next poll sees `human:re-review` and re-reviews

No skill invocation needed. The `/request-re-review` skill from #176 is still useful for the case where the human is editing in an agent pane and wants the workflow without a manual push (the skill handles commit + push + label swap in one shot), but for the common case of pushing from anywhere, this workflow handles it server-side.

**Why filter on fleet:approved only:**
- During `fleet:needs-fix`, the author agent is addressing feedback and pushing fixes — auto-swapping would fight the `fleet:changes-made` label they set themselves.
- During `fleet:wip`, no verdict has been issued yet.
- `fleet:approved` is the only state where a human-pushed change unambiguously means "I edited after fleet was done."

**Side artifacts (not in this PR — already done):**
- `human:re-review` label created on both `jakildev/IrredenEngine` and `jakildev/irreden`
- Game repo will need the same workflow added separately (it doesn't have `.github/workflows/` yet)

## Test plan
- [ ] Approve a test PR (add `fleet:approved` label manually)
- [ ] Push a trivial commit to its branch
- [ ] Verify Actions tab shows the workflow ran
- [ ] Verify `fleet:approved` was removed and `human:re-review` was added
- [ ] Verify comment was posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)