### PR TITLE
feat: preserve human:approved label, add fleet:queued + fleet:in-progress

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -147,10 +147,13 @@ conversation), use the same flow:
    - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
    - Acceptance criteria
 3. Save the plan to `~/.fleet/plans/issue-<N>.md` using the Write tool.
-4. Remove `fleet:needs-plan` and add `human:approved`:
-   `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan" --add-label "human:approved"`
+4. Remove `fleet:needs-plan`. Do NOT touch `human:approved` —
+   it's still on the issue from when the human triaged it, and
+   removing it would erase the human's signal:
+   `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan"`
    The queue-manager will ingest it on its next maintenance pass
-   and rename the plan file to `T-NNN.md`.
+   (its search now matches once `fleet:needs-plan` is gone) and
+   rename the plan file to `T-NNN.md`.
 
 If you disagree with the issue's direction, comment with your
 concerns but leave `fleet:needs-plan` on — let the human decide.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -144,10 +144,15 @@ Each invocation is one iteration — do the work, then exit cleanly:
       <pitfalls the worker should watch for>
       ```
 
-   d. Swap labels: remove `fleet:needs-plan`, add `human:approved`:
-      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan" --add-label "human:approved"`
-      The queue-manager will ingest it on its next maintenance pass
-      and rename the plan file from `issue-N.md` to `T-NNN.md`.
+   d. Remove the `fleet:needs-plan` label. Do NOT touch
+      `human:approved` — it's still on the issue from when the
+      human triaged it, and removing it would erase the human's
+      original signal:
+      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan"`
+      The queue-manager's ingestion search (`label:human:approved
+      -label:fleet:queued -label:fleet:needs-plan -label:fleet:needs-info`)
+      now matches this issue on its next pass — it ingests the issue,
+      adds `fleet:queued`, and renames the plan file to `T-NNN.md`.
 
    If you disagree with the issue's direction, comment with your
    concerns but leave `fleet:needs-plan` on — let the human decide.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -213,9 +213,19 @@ You are the sole TASKS.md editor. Each maintenance pass:
     have already merged or closed.
 
 1. **Ingest triaged issues (engine repo):**
-   `gh issue list --repo <engine-repo> --label "human:approved" --state open --json number,title,body,comments,labels`
-   Only issues with the `human:approved` label are ingested — this
-   is the universal gate for both human-filed and agent-filed issues.
+   `gh issue list --repo <engine-repo> --search "is:open is:issue label:human:approved -label:fleet:queued -label:fleet:needs-plan -label:fleet:needs-info" --json number,title,body,comments,labels`
+
+   Only issues with `human:approved` (and not yet handled) are
+   ingested. The `human:approved` label is a **permanent** signal
+   from the human ("yes, work on this") and is never removed by the
+   fleet — state lives in the `fleet:*` labels:
+   - `fleet:queued` — already ingested into TASKS.md
+   - `fleet:needs-plan` — waiting on architect planning
+   - `fleet:needs-info` — waiting on human clarification
+   - `fleet:in-progress` — agent has opened a PR (set in step 4 below)
+
+   The search excludes issues that already have any of the first
+   three, so each issue is processed exactly once per state transition.
 
    For each matching issue, **read the full context** — title, body,
    AND all comments. Comments often contain clarifications, scope
@@ -273,35 +283,39 @@ You are the sole TASKS.md editor. Each maintenance pass:
       use the **Write tool** to create `.fleet/plans/T-<NNN>.md` from
       the comment content. The repo copy is the shared version —
       workers sync it alongside TASKS.md.
-   e. Remove the `human:approved` label (so the issue isn't
-      re-ingested):
-      `gh issue edit <N> --repo <engine-repo> --remove-label "human:approved"`
+   e. Add the `fleet:queued` label (the de-dupe signal — keeps
+      `human:approved` intact):
+      `gh issue edit <N> --repo <engine-repo> --add-label "fleet:queued"`
    f. Do **NOT** close the issue. It stays open until the author
       agent's PR merges via `Closes #N`.
 
    **If the issue needs a plan first** — the scope is large, the
    approach is unclear, or it needs architectural input:
-   a. Add the `fleet:needs-plan` label:
-      `gh issue edit <N> --repo <engine-repo> --remove-label "human:approved" --add-label "fleet:needs-plan"`
+   a. Add the `fleet:needs-plan` label (keeps `human:approved`):
+      `gh issue edit <N> --repo <engine-repo> --add-label "fleet:needs-plan"`
    b. Comment explaining what's missing and that the architect
       should weigh in before this becomes a task:
       `gh issue comment <N> --repo <engine-repo> --body "Needs planning: <what's unclear>. Tagging for architect review."`
-   c. Do NOT add it to TASKS.md yet. The human or architect will
-      refine the issue, then the human re-adds `human:approved`.
+   c. Do NOT add it to TASKS.md yet. The opus-worker (planner) picks
+      up `fleet:needs-plan` issues, posts a plan, and removes the
+      label. On the next maintenance pass, the queue-manager's
+      ingestion search picks the issue up again (no longer excluded
+      by `-label:fleet:needs-plan`) and ingests it as `fleet:queued`.
 
    **If the issue is too vague** — not enough info to even plan:
-   a. Add the `fleet:needs-info` label:
-      `gh issue edit <N> --repo <engine-repo> --remove-label "human:approved" --add-label "fleet:needs-info"`
+   a. Add the `fleet:needs-info` label (keeps `human:approved`):
+      `gh issue edit <N> --repo <engine-repo> --add-label "fleet:needs-info"`
    b. Comment with specific questions:
       `gh issue comment <N> --repo <engine-repo> --body "Need more info before scheduling: <specific questions>"`
    c. Do NOT add it to TASKS.md.
 
 2. **Ingest triaged issues (game repo):**
-   `gh issue list --repo <game-repo> --label "human:approved" --state open --json number,title,body,comments,labels`
+   `gh issue list --repo <game-repo> --search "is:open is:issue label:human:approved -label:fleet:queued -label:fleet:needs-plan -label:fleet:needs-info" --json number,title,body,comments,labels`
    Same full-context assessment as above. Apply the same ready /
    needs-plan / needs-info logic, using `--repo <game-repo>`
    on all `gh` commands. Append to the **game** TASKS.md at
-   `~/src/IrredenEngine/creations/game/TASKS.md`.
+   `~/src/IrredenEngine/creations/game/TASKS.md`. The
+   `human:approved` label is preserved on game-repo issues too.
 
 3. **Sync merged PRs → Done (both repos):**
    Engine:
@@ -319,12 +333,28 @@ You are the sole TASKS.md editor. Each maintenance pass:
 
 4. **Sync open PRs → In-progress (both repos):**
    Engine:
-   `gh pr list --repo <engine-repo> --state open --json number,title,headRefName`
+   `gh pr list --repo <engine-repo> --state open --json number,title,headRefName,body`
    Game:
-   `gh pr list --repo <game-repo> --state open --json number,title,headRefName`
+   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,body`
    For each open PR whose title matches a `[ ]` task in the matching
-   repo's TASKS.md: flip to `[~]`, set Owner to the PR author's
-   worktree name.
+   repo's TASKS.md:
+   a. Flip the task to `[~]`, set Owner to the PR author's worktree name.
+   b. **Tag the linked issue as in-progress.** If the task entry has
+      `**Issue:** #N` (or the PR body has `Closes #N`), add the
+      `fleet:in-progress` label to that issue (idempotent — re-adding
+      is a no-op):
+      `gh issue edit <N> --repo <repo> --add-label "fleet:in-progress"`
+
+4b. **Clean up stale `fleet:in-progress` labels.** For each issue
+   currently labeled `fleet:in-progress` (both repos), check whether
+   any open PR still references it via `Closes #N` (or via the matching
+   TASKS.md entry's PR link). If no open PR matches, the PR closed
+   without merging or was abandoned — remove the label so the issue
+   shows as queued-and-available again:
+   `gh issue list --repo <repo> --label "fleet:in-progress" --state open --json number,body`
+   `gh pr list --repo <repo> --state open --json number,body`
+   For each in-progress issue not referenced by any open PR:
+   `gh issue edit <N> --repo <repo> --remove-label "fleet:in-progress"`
 
 5. **Resolve stale blocker references.** Scan all `## Open` entries in
    each TASKS.md. For any `Blocked by:` field that contains:
@@ -368,6 +398,11 @@ You are the sole TASKS.md editor. Each maintenance pass:
 ## Hard rules
 
 - Never claim or work tasks. You only file and maintain them.
+- **Never remove `human:approved`.** It is a permanent signal from
+  the human and is what humans use to find what they've approved.
+  Use `fleet:queued` / `fleet:needs-plan` / `fleet:needs-info` /
+  `fleet:in-progress` for state. Older tooling that removed
+  `human:approved` was wrong; the new model preserves it.
 - You are the **sole TASKS.md editor** across the entire fleet. No
   other agent should edit TASKS.md. If you see a PR that includes
   TASKS.md changes from an author agent, flag it in your review or


### PR DESCRIPTION
## Summary
You're right that removing `human:approved` on ingestion was wrong — it strips the human's signal of "yes, work on this." This PR introduces a separation between **signal** (the human's approval) and **state** (where in the fleet pipeline the issue is).

**New label model:**

| Label | Meaning | Set by | Removed by |
|-------|---------|--------|------------|
| `human:approved` | Permanent human signal — "yes, work on this" | Human | **Never** (by fleet) |
| `fleet:queued` | Ingested into TASKS.md | Queue-manager | (issue closes when PR merges) |
| `fleet:in-progress` | An agent has opened a PR | Queue-manager | Queue-manager (when no open PR matches) |
| `fleet:needs-plan` | Waiting on architect planning | Queue-manager | Planner agent after posting plan |
| `fleet:needs-info` | Waiting on human clarification | Queue-manager | Human after answering |

**The ingestion filter** uses GitHub search negation:
```
is:open is:issue label:human:approved -label:fleet:queued -label:fleet:needs-plan -label:fleet:needs-info
```

This means each issue is processed exactly once per state transition, without ever stripping the approval signal.

## Lifecycle example

1. Human files issue, triages, adds `human:approved`
2. Queue-manager picks it up: adds `fleet:queued`. Now has both labels.
3. Sonnet author claims, opens PR with `Closes #N`
4. Queue-manager next pass: adds `fleet:in-progress` to issue. Now has all three.
5. PR merges → `Closes #N` closes the issue → labels become moot

If the PR closes without merging, queue-manager step 4b removes `fleet:in-progress` so the issue is back to `human:approved + fleet:queued` (queued and available for another worker).

## Files changed
- `role-queue-manager.md` — new ingestion filter, new step 4b for stale `fleet:in-progress` cleanup, new hard rule "never remove human:approved"
- `role-opus-worker.md` — planner step now only removes `fleet:needs-plan`, doesn't re-add `human:approved`
- `role-opus-architect.md` — same planner change

## Side artifacts (already done, not in this PR)
- Labels created on both repos:
  - `fleet:queued` (BFD4F2 — soft blue)
  - `fleet:in-progress` (1D76DB — bright blue)

## Test plan
- [ ] After merge, file a test issue with `human:approved`
- [ ] Verify queue-manager ingests it, adds `fleet:queued`, keeps `human:approved`
- [ ] Have an agent claim and open a PR
- [ ] Verify queue-manager adds `fleet:in-progress` on its next pass
- [ ] Verify the issue retains `human:approved` throughout
- [ ] Close the PR without merging, verify queue-manager removes `fleet:in-progress`
- [ ] File a vague issue, mark `human:approved`, verify queue-manager adds `fleet:needs-plan` (keeps `human:approved`)
- [ ] Have opus-worker plan it, verify only `fleet:needs-plan` is removed (not `human:approved`)
- [ ] Verify queue-manager picks it up on the next pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)