### PR TITLE
feat: add simplify + optimize skills, wire into all author roles

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -88,14 +88,25 @@ When you do pick a task:
 4. Build the target you touched with `fleet-build --target <name>`.
    Run the relevant executable if one exists for the touched code:
    `fleet-run <executable-name>`
-5. Use the `commit-and-push` skill to open the PR. If the task has an
+5. **Polish before commit.** Run `optimize` then `simplify` on the
+   dirty working tree before invoking `commit-and-push`. This rule
+   applies to architects too — the architect's PRs touch core
+   engine code and need the same pre-commit polish as worker PRs.
+   - `optimize` — almost always applies (architect work is engine
+     core: render, ECS, math, audio, video). Profile, identify
+     hotspots, verify no regressions.
+   - `simplify` — every time, no exceptions.
+   When **addressing review feedback** (amending or pushing fixes),
+   re-run `simplify` (and `optimize` if the perf surface changed)
+   before pushing.
+6. Use the `commit-and-push` skill to open the PR. If the task has an
    `**Issue:** #N` field, include `Closes #N` in the PR body so the
    issue closes automatically when the PR merges.
-6. After the PR is open, release the claim and reset:
+7. After the PR is open, release the claim and reset:
    `fleet-claim release "<task ID>"`
    Then use the `start-next-task` skill to land on a fresh branch off
    `origin/master`.
-7. **Check for feedback labels on open PRs** before picking new work:
+8. **Check for feedback labels on open PRs** before picking new work:
    `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "fleet:needs-fix")) | "#\(.number) \(.title)"'`
    **Skip** PRs labeled `human:wip` — human is working on it directly.
    If any PR has `human:needs-fix` or `fleet:needs-fix`:

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -88,17 +88,20 @@ When you do pick a task:
 4. Build the target you touched with `fleet-build --target <name>`.
    Run the relevant executable if one exists for the touched code:
    `fleet-run <executable-name>`
-5. **Polish before commit.** Run `optimize` then `simplify` on the
-   dirty working tree before invoking `commit-and-push`. This rule
-   applies to architects too — the architect's PRs touch core
-   engine code and need the same pre-commit polish as worker PRs.
-   - `optimize` — almost always applies (architect work is engine
-     core: render, ECS, math, audio, video). Profile, identify
-     hotspots, verify no regressions.
-   - `simplify` — every time, no exceptions.
+5. **Optimize before commit.** Run the `optimize` skill before
+   invoking `commit-and-push`. This rule applies to architects too —
+   the architect's PRs touch core engine code (render, ECS, math,
+   audio, video) and almost always need a profiling pass. Skip only
+   for pure docs or mechanical refactors.
+
+   You don't need to invoke `simplify` separately — `commit-and-push`
+   runs it as part of its flow. Running `optimize` first matters
+   because optimize may add `IR_PROFILE_*` blocks and rationale
+   comments that simplify should leave alone.
+
    When **addressing review feedback** (amending or pushing fixes),
-   re-run `simplify` (and `optimize` if the perf surface changed)
-   before pushing.
+   re-run `optimize` (if the perf surface changed) before invoking
+   `commit-and-push` to push the fix.
 6. Use the `commit-and-push` skill to open the PR. If the task has an
    `**Issue:** #N` field, include `Closes #N` in the PR body so the
    issue closes automatically when the PR merges.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -247,13 +247,27 @@ Each invocation is one iteration — do the work, then exit cleanly:
    mid-task — the architect handles design conversations. Comment on
    your PR explaining the blocker and wait.
 
-9. **Finalize the PR.** Use `commit-and-push` to push work commits.
-   Remove the WIP label and release the claim:
-   `gh pr edit <N> --remove-label "fleet:wip"`
-   `fleet-claim release "<task ID>"`
-   Paste the PR URL.
+9. **Polish before commit.** Before invoking `commit-and-push`, run:
+   - **`optimize`** — `[opus]` work almost always touches perf-critical
+     code (engine/render, engine/system, engine/world, engine/audio,
+     engine/video, engine/math). Run optimize to profile the new code,
+     identify hotspots, and verify no regressions. Skip only for pure
+     docs or mechanical refactors that preserve hot-path structure.
+   - **`simplify`** — every time, no exceptions.
 
-10. **Reset.** Use the `start-next-task` skill to land on a fresh
+   Order: `optimize` first if both apply (it may add `IR_PROFILE_*`
+   blocks and rationale comments that simplify should leave alone).
+   The same applies when **addressing review feedback** — after
+   editing in response to comments, re-run `simplify` (and `optimize`
+   if the perf surface changed) before pushing the fix.
+
+10. **Finalize the PR.** Use `commit-and-push` to push work commits.
+    Remove the WIP label and release the claim:
+    `gh pr edit <N> --remove-label "fleet:wip"`
+    `fleet-claim release "<task ID>"`
+    Paste the PR URL.
+
+11. **Reset.** Use the `start-next-task` skill to land on a fresh
     branch off `origin/master`. Exit cleanly. The `/loop` driver will
     re-invoke in 20 minutes.
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -247,19 +247,21 @@ Each invocation is one iteration — do the work, then exit cleanly:
    mid-task — the architect handles design conversations. Comment on
    your PR explaining the blocker and wait.
 
-9. **Polish before commit.** Before invoking `commit-and-push`, run:
-   - **`optimize`** — `[opus]` work almost always touches perf-critical
-     code (engine/render, engine/system, engine/world, engine/audio,
-     engine/video, engine/math). Run optimize to profile the new code,
-     identify hotspots, and verify no regressions. Skip only for pure
-     docs or mechanical refactors that preserve hot-path structure.
-   - **`simplify`** — every time, no exceptions.
+9. **Optimize before commit.** Run the `optimize` skill — `[opus]`
+   work almost always touches perf-critical code (engine/render,
+   engine/system, engine/world, engine/audio, engine/video,
+   engine/math). Optimize profiles the new code, identifies hotspots,
+   and verifies no regressions. Skip only for pure docs or mechanical
+   refactors that preserve hot-path structure.
 
-   Order: `optimize` first if both apply (it may add `IR_PROFILE_*`
-   blocks and rationale comments that simplify should leave alone).
+   You don't need to invoke `simplify` separately — `commit-and-push`
+   runs it as part of its flow. Running `optimize` first matters
+   because optimize may add `IR_PROFILE_*` blocks and rationale
+   comments that simplify should leave alone.
+
    The same applies when **addressing review feedback** — after
-   editing in response to comments, re-run `simplify` (and `optimize`
-   if the perf surface changed) before pushing the fix.
+   editing in response to comments, re-run `optimize` (if the perf
+   surface changed) before invoking `commit-and-push` to push the fix.
 
 10. **Finalize the PR.** Use `commit-and-push` to push work commits.
     Remove the WIP label and release the claim:

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -209,14 +209,30 @@ limit. Each loop iteration:
    ready. The queue-manager then adds it to TASKS.md. Move on to the
    next task.
 
-8. **Finalize the PR.** Use the `commit-and-push` skill to push your
+8. **Polish before commit.** Before invoking `commit-and-push`, run:
+   - **`optimize`** — but ONLY if the change touches a system tick,
+     a render pipeline stage, a shader, audio/video, math hot paths,
+     or anywhere on the per-frame critical path. Skip for pure docs,
+     tests, mechanical refactors, or build/CI changes.
+   - **`simplify`** — every time, no exceptions. Catches the smells
+     a reviewer would otherwise flag (per-entity getComponent,
+     naming slips, dead code, debug logs, tautological comments).
+
+   Order matters: `optimize` first if both apply (it may add
+   `IR_PROFILE_*` blocks and rationale comments that simplify
+   should leave alone). The same applies when **addressing review
+   feedback** — after editing in response to comments, re-run
+   `simplify` (and `optimize` if the perf surface changed) before
+   pushing the fix.
+
+9. **Finalize the PR.** Use the `commit-and-push` skill to push your
    work commits to the existing PR branch. Then remove the WIP label
    and release the claim:
    `gh pr edit <N> --remove-label "fleet:wip"`
    `fleet-claim release "<task ID, e.g. T-002>"`
    Paste the PR URL.
 
-9. **Reset.** Use the `start-next-task` skill to land on a fresh branch
+10. **Reset.** Use the `start-next-task` skill to land on a fresh branch
    off `origin/master`. Loop back to step 1.
 
 If Mode above is `dry-run`: do exactly **one** task end-to-end (steps

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -209,21 +209,21 @@ limit. Each loop iteration:
    ready. The queue-manager then adds it to TASKS.md. Move on to the
    next task.
 
-8. **Polish before commit.** Before invoking `commit-and-push`, run:
-   - **`optimize`** — but ONLY if the change touches a system tick,
-     a render pipeline stage, a shader, audio/video, math hot paths,
-     or anywhere on the per-frame critical path. Skip for pure docs,
-     tests, mechanical refactors, or build/CI changes.
-   - **`simplify`** — every time, no exceptions. Catches the smells
-     a reviewer would otherwise flag (per-entity getComponent,
-     naming slips, dead code, debug logs, tautological comments).
+8. **Optimize before commit (when relevant).** Run the `optimize`
+   skill ONLY if the change touches a system tick, a render pipeline
+   stage, a shader, audio/video, math hot paths, or anywhere on the
+   per-frame critical path. Skip for pure docs, tests, mechanical
+   refactors, or build/CI changes.
 
-   Order matters: `optimize` first if both apply (it may add
-   `IR_PROFILE_*` blocks and rationale comments that simplify
-   should leave alone). The same applies when **addressing review
-   feedback** — after editing in response to comments, re-run
-   `simplify` (and `optimize` if the perf surface changed) before
-   pushing the fix.
+   You don't need to invoke `simplify` here — `commit-and-push`
+   runs it as part of its flow. Running `optimize` first matters
+   because optimize may add `IR_PROFILE_*` blocks and rationale
+   comments that simplify should leave alone; commit-and-push's
+   simplify pass then polishes everything together.
+
+   The same applies when **addressing review feedback** — after
+   editing in response to comments, re-run `optimize` (if the perf
+   surface changed) before invoking `commit-and-push` to push the fix.
 
 9. **Finalize the PR.** Use the `commit-and-push` skill to push your
    work commits to the existing PR branch. Then remove the WIP label
@@ -236,7 +236,7 @@ limit. Each loop iteration:
    off `origin/master`. Loop back to step 1.
 
 If Mode above is `dry-run`: do exactly **one** task end-to-end (steps
-1-8), print the PR URL, then stop and wait for human instruction. Do
+1-9), print the PR URL, then stop and wait for human instruction. Do
 not loop.
 
 ## Usage-limit handling

--- a/.claude/skills/optimize/SKILL.md
+++ b/.claude/skills/optimize/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: optimize
+description: >-
+  Profile and improve performance for newly written or modified
+  performance-critical code in the Irreden Engine. Use whenever the
+  current change touches a system tick function, a render pipeline
+  stage, a shader, audio/video processing, math hot paths, or
+  anywhere on the per-frame critical path. Also use when the user
+  says "optimize", "profile", "this is slow", "find the hotspot",
+  "check perf", "benchmark this", or "why is this frame slow".
+  Should run BEFORE simplify when the change is performance-relevant
+  — optimize may add profile blocks or comments that simplify would
+  otherwise consider extraneous. Reports CPU profiler findings and,
+  where GPU profiling infrastructure exists, GPU timer query results.
+  Files an issue if the necessary profiling infrastructure is
+  missing.
+---
+
+# optimize
+
+A performance pass on freshly written or modified hot-path code.
+Decides what kind of profiling matters (CPU, GPU, or both), runs it,
+identifies hotspots, and applies engine-specific optimizations.
+
+## Why this exists
+
+The engine has hard real-time goals: 60 FPS on the target platform,
+deterministic frame pacing for the iso voxel pipeline. New code that
+adds even 0.5 ms to the per-frame budget compounds — by the time five
+features have each shipped a "small" regression, the frame budget is
+gone.
+
+Catching regressions in the author's worktree, before review, is much
+cheaper than discovering them in a perf bisect three weeks later.
+This skill is that catch.
+
+It runs **before** simplify when relevant, because simplify might
+strip the `IR_PROFILE_BLOCK` calls or the explanatory comments that
+optimize added during instrumentation.
+
+## When this is the right skill (vs. simplify alone)
+
+Run optimize when the diff touches:
+
+- **System tick functions** — anything in `engine/system/`,
+  `engine/prefabs/irreden/.../systems/`, or per-entity loops in
+  creations.
+- **Render pipeline stages** — `engine/render/`, shader files
+  (`engine/render/src/shaders/`), GPU buffer lifetimes, dispatch
+  sizes.
+- **Audio / video processing** — `engine/audio/`, `engine/video/`,
+  ffmpeg paths, MIDI handling.
+- **Math hot paths** — `engine/math/` functions called from per-entity
+  loops or per-pixel shader code.
+- **New game systems** — anything in `creations/<name>/src/` that
+  runs per-frame or per-entity.
+- **Anything the author suspects is slow** — even if it's not in the
+  list above, if the user says "this feels slow", profile it.
+
+Skip optimize when the diff is:
+
+- Tests, docs, or config changes.
+- Build / CI / tooling changes.
+- One-shot setup or teardown code that doesn't run per frame.
+- Pure refactors that preserve hot-path structure.
+
+If you're unsure, ask. Profiling time is cheap; pushing a hot-path
+regression is expensive.
+
+## Flow
+
+### 1. Identify the hot path
+
+```bash
+git diff --stat
+git diff
+```
+
+For each touched file, ask:
+- Does this run per-frame?
+- Does this run per-entity inside a system tick?
+- Does this run per-pixel inside a shader?
+- Does this run per-sample in audio?
+
+If yes to any, that file is a candidate for profiling. Group
+candidates by **CPU-bound** (system ticks, math) and **GPU-bound**
+(shaders, dispatch sizes, frame buffer ops). Some changes are both.
+
+### 2. CPU profiling
+
+The engine has CPU profiling via `engine/profile/` — easy_profiler
+under the hood, exposed through the `IR_PROFILE_*` macros in
+`engine/profile/include/irreden/ir_profile.hpp`. Read
+`engine/profile/CLAUDE.md` for the full surface.
+
+**Instrument the hot path:**
+
+```cpp
+void IRSGlowPulse::tickEntity(C_GlowPulse& glow, C_Color& color) {
+    IR_PROFILE_FUNCTION(0xff00ff00);  // green = render-system family
+    // ... existing logic
+}
+```
+
+Wrap the **entry point** of the new code (system tick function,
+pipeline stage, audio callback). For inner sub-blocks worth
+isolating, use `IR_PROFILE_BLOCK("name", color)` / `IR_PROFILE_END_BLOCK`.
+
+Color convention (ARGB hex): pick consistently with neighboring
+blocks — read other systems in the same module to match. The colors
+are the only way to find your block in the easy_profiler timeline.
+
+**Run with profiling enabled:**
+
+```bash
+fleet-build --target <executable>
+fleet-run --timeout 15 <executable>
+```
+
+`CPUProfiler::setEnabled(true)` is the runtime gate — check the
+creation's startup to confirm it's on, or temporarily enable in the
+demo's main.
+
+The profiler dumps a `.prof` file when the executable exits. Open it
+with the `profiler_gui` tool from easy_profiler (the human runs this
+— you can't render the GUI from here). Ask the human for the
+hotspot read.
+
+If `IR_PROFILE_*` macros are no-ops (release build) or disabled at
+runtime, the run produces no data — switch the build to debug or
+re-enable the profiler before re-running.
+
+### 3. GPU profiling
+
+The engine **does not currently have GPU timer query infrastructure**
+in production. The OpenGL bindings (`engine/render/include/glad/glad.h`)
+expose `glQueryCounter` / `GL_TIMESTAMP`, but no engine code uses
+them. There is no per-pass timing API and no Lua-accessible breakdown.
+
+This is the work tracked in **jakildev/IrredenEngine#173** ("Skill:
+render performance optimization loop"). Until that lands, GPU
+profiling here is qualitative:
+
+- **Use RenderDoc** for a single-frame capture if the human can run
+  it (RenderDoc is GUI; you can't drive it from here). Tell the
+  human what to look at — which pass, which draw call, which compute
+  dispatch.
+- **Use shader-side counters** as a proxy: a debug uniform
+  incremented per work-group, read back via SSBO, gives a coarse
+  cost estimate. Useful for "is the new compute pass even running"
+  but not for ms-level timing.
+- **Compare frame time before/after** with the engine's existing
+  frame counter (`IRTime` / wherever `getDeltaTime()` lives) — log
+  the average delta over 300 frames before the change and after.
+  Coarse but real.
+
+**If the change touches a render pipeline stage and the impact isn't
+obvious from inspection alone**, comment on the PR that
+`jakildev/IrredenEngine#173` is required to validate the perf cost,
+and surface the missing infrastructure to the human. Don't merge
+hot-path GPU work blind.
+
+### 4. Engine-specific optimizations to check
+
+For **CPU hotspots** in system ticks:
+
+- Per-entity `getComponent<C_Foo>()` → add `C_Foo` to the system's
+  template parameters so it's iterated as a dense column. (See
+  `engine/system/CLAUDE.md` for tick-function signature patterns.)
+  This is the single biggest engine-wide perf win and `simplify`
+  also flags it — but optimize is the place to actually verify the
+  measured ms improvement after fixing.
+- Allocation in per-entity paths → hoist to component construction
+  or pre-size + reuse a member buffer.
+- `std::map` / `std::unordered_map` lookups in the inner loop →
+  replace with a flat array indexed by entity ID, or move the
+  lookup outside the loop.
+- Virtual dispatch in the inner loop → if the type is known at
+  compile time, devirtualize via templates.
+
+For **GPU hotspots**:
+
+- Hand-rolled compute dispatch sizes → use
+  `voxelDispatchGridForCount()`. Wrong dispatch sizes either waste
+  workgroups (overestimate) or miss work (underestimate).
+- Compute shader workgroup-size mismatch with the dispatched size —
+  read the shader's `layout(local_size_x = ...)` and confirm the CPU
+  side's dispatch math accounts for it.
+- Excessive uniform block updates per frame → batch into one update.
+- Texture-format mismatch causing implicit conversions in the
+  fragment shader.
+- Read-back via `glReadPixels` or `glGetBufferSubData` synchronously
+  — kills the frame, force a fence + multi-frame ringbuffer instead.
+
+For **shader hot paths**:
+
+- Repeated math sequences across multiple shaders that should be in
+  a shared `.glsl` include (e.g. `ir_iso_common.glsl` for iso
+  projection math).
+- Per-pixel work that could be per-vertex — move it.
+- Branchy conditionals on a uniform value → consider a permutation.
+
+### 5. Measure, don't guess
+
+For each change you make based on profiling, **re-run the same
+benchmark** and confirm the improvement. A "fix" that doesn't move
+the needle isn't an optimization — revert it and look elsewhere.
+Pre/post numbers belong in the PR body so the reviewer doesn't have
+to re-profile.
+
+If pre/post measurement isn't possible (e.g. GPU pass without timer
+queries), say so explicitly in the PR — never claim "this is faster"
+without numbers.
+
+### 6. Report
+
+Print a compact summary:
+
+```
+optimize: <N> hot-path file(s) profiled
+  CPU hotspots:
+    - <path:line> — <function> — <ms before> → <ms after> (<change>)
+    - ...
+  GPU hotspots:
+    - <pass name> — <observation> — <action taken or blocker>
+  applied <X> optimization(s)
+  reported <Y> finding(s) needing more measurement
+  baselines: <link to docs/perf-reports/ entry, if added>
+```
+
+If the touched code didn't actually need optimization (after
+profiling, no hotspot), say so — the value here is the confidence,
+not the changes.
+
+## Coordinating with simplify
+
+Run optimize **first** when the change is performance-relevant.
+Optimize may:
+- Add `IR_PROFILE_*` blocks at hot-path entry points
+- Add explanatory comments documenting non-obvious perf trade-offs
+  (e.g. "// pre-sized to avoid realloc in tick — see PR #N")
+- Restructure a tick function for better cache behavior
+
+Simplify, run after, will respect those additions because:
+- `IR_PROFILE_*` macros are part of the engine's profiling story,
+  not "debug logs"
+- Comments that explain a perf rationale are kept (they explain a
+  non-obvious why)
+
+If you're working on a non-perf-critical change (docs, tests,
+mechanical refactor), skip optimize and run simplify directly.
+
+## What this skill does NOT do
+
+- **Doesn't replace human profiling judgment.** A 0.1 ms regression
+  in a cold path may be fine; a 0.1 ms regression on the per-entity
+  hot path at 50K entities is 5 ms/frame. Surface the data, let the
+  human decide.
+- **Doesn't optimize without measuring.** Speculative optimization
+  is worth less than the readability it costs. Always measure.
+- **Doesn't push.** Edits the working tree only.
+- **Doesn't run RenderDoc or other GUI profilers.** Hand off the
+  capture instructions and ask the human to run it.
+
+## Example
+
+User: "I added a new lighting pass — optimize it before I push"
+
+```
+optimize: 3 files profiled (engine/render/, shaders/glsl/)
+
+CPU hotspots: none. The new pass is GPU-bound.
+
+GPU profiling: limited — engine has no timer-query infrastructure
+(see #173). Frame-time A/B with 300-frame averages:
+  - before: 14.2 ms ± 0.3
+  - after:  16.8 ms ± 0.4
+  - delta:  +2.6 ms (16% over budget at 60fps)
+
+Hotspot suspect (RenderDoc capture needed, asked human to run):
+  c_lighting_apply.glsl — likely the per-pixel 3x3x3 sample loop.
+  Reading the occupancy grid 27 times per pixel.
+
+Optimization applied:
+  - Switched to a 2D shadow texture lookup once per pixel instead
+    of per-sample, then modulated by the precomputed AO texture.
+  - Re-measured: 14.5 ms ± 0.3 (+0.3 ms over original — acceptable).
+
+Reported for human:
+  - GPU timer queries needed before next render PR (issue #173).
+
+ready for simplify pass.
+```

--- a/.claude/skills/optimize/SKILL.md
+++ b/.claude/skills/optimize/SKILL.md
@@ -97,7 +97,7 @@ under the hood, exposed through the `IR_PROFILE_*` macros in
 
 ```cpp
 void IRSGlowPulse::tickEntity(C_GlowPulse& glow, C_Color& color) {
-    IR_PROFILE_FUNCTION(0xff00ff00);  // green = render-system family
+    IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
     // ... existing logic
 }
 ```
@@ -106,9 +106,13 @@ Wrap the **entry point** of the new code (system tick function,
 pipeline stage, audio callback). For inner sub-blocks worth
 isolating, use `IR_PROFILE_BLOCK("name", color)` / `IR_PROFILE_END_BLOCK`.
 
-Color convention (ARGB hex): pick consistently with neighboring
-blocks — read other systems in the same module to match. The colors
-are the only way to find your block in the easy_profiler timeline.
+Use the named `IR_PROFILER_COLOR_*` constants from
+`engine/profile/include/irreden/ir_profile.hpp` (`_RENDER`,
+`_ENTITY_OPS`, `_COMMANDS`, etc.). Every existing call site uses
+the named constants — raw ARGB hex literals are an anti-pattern.
+Pick the constant that matches the module of the system you're
+instrumenting; the colors group related blocks visually in the
+easy_profiler timeline.
 
 **Run with profiling enabled:**
 

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: simplify
+description: >-
+  Polish the dirty working tree before committing — catch Irreden-Engine
+  smells that a reviewer would otherwise flag. Use whenever you're
+  about to commit, after addressing review feedback, after amending a
+  commit, or whenever the user says "simplify", "clean up", "polish",
+  "self-review", or "review my changes". Also auto-invoked by
+  commit-and-push before the commit message is drafted. The skill
+  finds per-entity getComponent in tick functions, allocation in hot
+  loops, ECS naming convention slips, opportunities to reuse existing
+  helpers, dead code, debug logs left behind, and tautological
+  comments — applying safe fixes inline and reporting anything that
+  needs human judgment. Saves a review-fix-rereview round-trip.
+---
+
+# simplify
+
+A pre-commit cleanup pass on the dirty working tree. Reads what
+changed, applies the fixes that don't need judgment, and reports
+the rest.
+
+## Why this exists
+
+The reviewer agent flags the same handful of issues over and over:
+per-entity `getComponent` inside a system tick, naming-convention
+slips, debug `std::cout` lines that didn't get removed, comments
+that say `/// Returns x` on `int getX() { return x_; }`. Each
+flagged issue costs a round-trip — reviewer comments, author
+addresses, reviewer re-reviews. If the author's worktree catches
+these before the PR opens, the reviewer's only finding is the
+genuinely subtle stuff.
+
+This skill is that filter. It's not a substitute for review — it's a
+first pass that gets the cheap stuff out of the way so the reviewer
+can focus on what matters.
+
+## Flow
+
+### 1. Read what changed
+
+```bash
+git diff --stat
+git diff
+```
+
+If both are empty, also check unpushed commits:
+
+```bash
+git diff @{upstream}..HEAD
+```
+
+If everything is empty, report "nothing to simplify" and exit.
+
+Group the touched files by module — `engine/render/`,
+`engine/system/`, `engine/prefabs/irreden/`, `creations/`, etc. The
+relevant `CLAUDE.md` files in those directories define module-specific
+rules that override the defaults below; read them before touching
+anything in their scope.
+
+### 2. ECS smells (the biggest performance footgun)
+
+Per-entity `getComponent<C_Foo>()` or `getComponentOptional<C_Foo>()`
+inside a system's per-entity tick is a hash-map lookup, an archetype
+scan, and another hash-map lookup — at scale it dominates the frame.
+The fix is mechanical: add the component to the system's template
+parameters so it iterates the dense column.
+
+**Apply the fix when** the call is unconditional and the component is
+small. Add the type to the system's `createSystem<...>` template
+params (or the equivalent template signature) and replace the
+`getComponent` call with the iteration variable.
+
+**Report instead of fixing when** the call is conditional, when the
+component might not exist on every entity in the archetype, or when
+the system signature is shared with other tick functions you can't
+see in the diff. Note `engine/system/CLAUDE.md` has the full
+tick-function-signature story.
+
+Also flag (don't auto-fix):
+- `createEntity` / `removeComponent` mid-iteration without the
+  deferred variant — race-prone, deferred is the right answer.
+- Allocation in per-entity tick paths (`new`, `vector::push_back` on
+  a hot vector, `string` concat, `map::operator[]` insertion).
+- A new prefab system that isn't added to `SystemName` in
+  `engine/system/include/irreden/ir_system_types.hpp` (the system
+  name enum is the registration mechanism).
+
+### 3. Naming convention slips
+
+These are the rules from the top-level `CLAUDE.md`:
+
+| Context           | Convention            |
+|-------------------|-----------------------|
+| Private members   | `m_` prefix           |
+| Public members    | trailing `_`          |
+| Components        | `C_` prefix           |
+| Compute shaders   | `c_` prefix           |
+| Vertex shaders    | `v_` prefix           |
+| Fragment shaders  | `f_` prefix           |
+| Geometry shaders  | `g_` prefix           |
+
+Backwards usage (`m_` on public, trailing `_` on private) is the
+single most common slip — fix it inline. Same for missing `C_` on a
+new component class, missing shader prefixes, anonymous namespaces in
+headers (use a nested `detail` namespace instead), or feature-named
+helper namespaces (`MinimapDetail` instead of plain `detail`).
+
+Abbreviations in new identifiers (`vcIso` instead of `viewCenterIso`)
+are worth flagging as a nit unless context makes them unambiguous.
+
+### 4. Ownership and lifetime
+
+- `shared_ptr` where `unique_ptr` would do — fix when the lifetime is
+  obviously a tree, report otherwise.
+- Raw owning pointers — raw pointer = non-owning, always.
+- Storing references or pointers to ECS component storage across
+  ticks — archetype changes invalidate addresses. The fix is to
+  cache the entity ID and re-fetch.
+- Lambdas that capture `this` or World-manager references and outlive
+  the World (e.g. lua callbacks registered before World teardown) —
+  flag for human review.
+
+### 5. Render pipeline
+
+For files in `engine/render/` or shaders, check that the CPU
+frame-data struct in `engine/render/include/irreden/render/` is in
+sync with its GLSL `layout(std140)` counterpart — an out-of-sync pair
+silently corrupts uniform blocks. Cross-reference the two if either
+side changed.
+
+Also check:
+- Canvas allocation before the canvas entity exists (race in init).
+- Hand-rolled compute dispatch sizes — should use
+  `voxelDispatchGridForCount()` rather than computing `(n+63)/64`
+  manually.
+- 3D-world-coord values being mixed with iso-2D-coord values without
+  going through `IRMath::pos3DtoPos2DIso` or a named helper. The two
+  spaces are not interchangeable.
+
+### 6. Reuse opportunities (the highest-leverage check)
+
+For every new function or block of logic, search for similar code
+that already exists. The signal is strong enough to justify a
+`Grep` round even if you think the code is novel:
+
+- Same name → likely a duplicate
+- Same call sequence (3+ identical lines, possibly with different
+  variable names) → extract a shared helper
+- Same math sequence in shaders → check `engine/math/` (CPU) or
+  shader includes like `ir_iso_common.glsl` (GPU). If the helper
+  exists, use it; if it doesn't but the sequence appears 3+ times,
+  propose extracting one.
+- Raw `std::cout` / `printf` for diagnostic output → use the
+  `IRE_LOG_*` (engine) or `IR_LOG_*` (game) macros from
+  `engine/profile/include/irreden/ir_profile.hpp`. They route to the
+  right sink and compile to no-ops in release.
+
+Prefer existing helpers over inline duplication, even if the
+duplication is shorter.
+
+### 7. Dead code, debug logs, extraneous comments
+
+Remove:
+- Unused functions, unused includes, unreachable branches.
+- Commented-out code blocks (even ones from this session).
+- Debug-level logging added during development that isn't part of the
+  task spec — `std::cout << "DEBUG: ..."`, `printf("here\n")`,
+  `IRE_LOG_DEBUG("step 3")` left over from troubleshooting. If the
+  logging has rare-path or error-context value, downgrade to the
+  right severity (`IRE_LOG_WARN` / `IRE_LOG_ERROR`) instead of
+  removing.
+- Tautological comments where the code says exactly what the comment
+  says — `/// Returns the value` on `int getValue() { return value_; }`.
+  Same for `// Increment counter` on `++counter_;`.
+- Stale `// TODO`/`// FIXME` markers on code you actually finished
+  this session.
+- "Old code" markers next to deleted lines.
+
+Keep:
+- Comments that explain non-obvious **why** — rationale, gotchas,
+  cross-references to docs/papers/prior-art decisions.
+- Doc comments on public surface where the function name alone
+  doesn't capture the contract (preconditions, side effects, ranges).
+
+### 8. Style
+
+The engine's style preferences are simple and worth applying inline:
+
+- Early return over nested logic — refactor when nesting is 2+ levels
+  and the condition is a guard rather than a real branch.
+- No `try`/`catch` for control flow at internal boundaries; the
+  engine doesn't use exceptions internally.
+- Don't add abstractions for hypothetical future requirements.
+- Don't validate scenarios that can't happen (defensive checks
+  against impossible states); only validate at system boundaries.
+
+### 9. Format and verify
+
+After applying fixes, run the formatter and rebuild:
+
+```bash
+fleet-build --target format
+fleet-build --target <touched-target>
+```
+
+If `format` rewrote anything, those changes are part of the polish —
+keep them. If the build broke, **revert your simplify changes** (or
+fix the break before continuing) — never push a simplify pass that
+broke the build.
+
+### 10. Report
+
+Print a compact summary so the author knows what changed and what
+needs their attention:
+
+```
+simplify: <N> file(s), <M> hunk(s)
+  applied <X> auto-fix(es):
+    - <path:line> — <one-line description>
+  reported <Y> finding(s) for review:
+    - <path:line> — <issue> — <suggested fix>
+```
+
+Empty sections — drop them rather than writing "None".
+
+If everything was either fixed in place or reverted, report a clean
+working tree and let `commit-and-push` proceed.
+
+## What this skill does NOT do
+
+- **Doesn't run tests.** The author runs tests separately via
+  `fleet-run` or `ctest`.
+- **Doesn't refactor across modules.** Out of scope for a pre-commit
+  pass. If a fix would touch unrelated files, report instead of
+  applying.
+- **Doesn't redesign.** If the code is structurally wrong, surface it
+  and let the author decide. Don't silently rewrite a system.
+- **Doesn't push.** Read-only on history; only edits the working tree.
+- **Doesn't bundle unrelated cleanup.** Drift in files the current PR
+  doesn't touch — report it (or file an issue), don't sneak it into
+  the dirty diff.
+
+## Example
+
+User says "simplify before I commit". The diff touches a new render
+system and a creation demo.
+
+```
+simplify: 4 files, 11 hunks
+  applied 3 auto-fixes:
+    - engine/prefabs/irreden/render/systems/IRSGlowPulse.hpp:34
+      moved getComponent<C_Color> out of tick, added C_Color to
+      system template
+    - engine/render/src/RenderManager.cpp:128 — removed
+      `std::cout << "made canvas " << id` debug log
+    - engine/render/include/irreden/render/IRCanvas.hpp:18 —
+      removed tautological `/// Returns the canvas ID` doc comment
+  reported 1 finding for review:
+    - creations/demos/IRDemoFoo/src/main.cpp:55 — `shared_ptr<Foo>`
+      where `unique_ptr` would do, but the demo passes the pointer
+      to a lua callback — may be intentional sharing. Confirm
+      before changing.
+  build: clean
+```
+
+The author commits via `commit-and-push` knowing the diff is
+already polished. If the reported finding matters, the author
+addresses it; otherwise, ship.


### PR DESCRIPTION
## Summary
- New `simplify` skill at `.claude/skills/simplify/SKILL.md` — fills the gap that `commit-and-push` has been calling for. Engine-specific pre-commit polish: catches per-entity getComponent in tick functions, allocation in hot loops, ECS naming convention slips, dead code, debug logs, tautological comments, and finds reuse opportunities. Saves a review-fix-rereview round-trip per PR.
- New `optimize` skill at `.claude/skills/optimize/SKILL.md` — profiles and improves perf for hot-path code (system ticks, render, audio/video, math hot paths). Runs BEFORE simplify when relevant. CPU profiling via easy_profiler / IR_PROFILE_* macros; GPU profiling is qualitative until #173 lands.
- Wired into all engine author roles: `role-sonnet-author`, `role-opus-worker`, and `role-opus-architect` (architects too — they touch core engine code and need pre-commit polish too).
- Both skills auto-invoke after addressing review feedback before pushing fixes.

Skill descriptions follow Anthropic skill-creator best practices: explicit triggers, theory-of-mind WHY explanations, lean instructions, real Input/Output examples.

## Issue #173 update (already applied)
Updated title and body of the existing render-perf issue to reflect the broader scope: Part 1 = `[opus]` GPU timer query infrastructure + Lua API, Part 2 = `[sonnet]` benchmark harness + `render-perf` skill that the optimize skill will delegate to once it lands.

## Game-side companion
Mirror PR for game roles: jakildev/irreden#26 (will create once this lands).

## Test plan
- [ ] After merge, run `/simplify` in any worktree on a dirty diff — verify it catches a deliberate `getComponent` in a tick function and removes a deliberate `std::cout` debug log
- [ ] Run `/optimize` before `/simplify` on a render-touching change — verify optimize doesn't fight simplify (no rationale comments removed)
- [ ] Verify a sonnet-author or opus-worker /loop iteration on a perf-touching task runs both skills before commit-and-push
- [ ] Verify the architect's interactive task flow includes the polish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)