### PR TITLE
feat: stack PR commit format and per-task review structure

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -99,16 +99,25 @@ Each invocation is one iteration — do the work, then exit cleanly:
    a. Read the existing Sonnet review in full first
       (`gh pr view <N> --comments`, add `--repo <game-repo>` for
       game PRs). Note what Sonnet flagged.
-   b. **Engine PRs:** Invoke the `review-pr` skill on the PR.
+   b. **Detect stack PRs.** Check the commit list:
+      `gh pr view <N> --json commits --jq '.commits[].messageHeadline'`
+      If multiple commit subjects start with `T-NNN: ` prefixes
+      (different task IDs), this is a stack PR. The Sonnet review
+      should already have per-task `## T-NNN` sections — your
+      Opus pass should mirror that structure, reviewing each
+      task's commits independently for the deeper invariants
+      (ECS, lifetime, GPU buffers) that Opus focuses on.
+   c. **Engine PRs:** Invoke the `review-pr` skill on the PR.
       **Game PRs:** Read the diff with `gh pr diff <N> --repo
       <game-repo>` and review manually (you cannot check out game
       PRs into this engine worktree). For game conventions, read
       `~/src/IrredenEngine/creations/game/CLAUDE.md`.
-   c. Focus your review on the items Sonnet could not confirm — do
+   d. Focus your review on the items Sonnet could not confirm — do
       not duplicate work Sonnet already did. Your review body should
       explicitly call out the Sonnet review by saying "Sonnet flagged
-      X; on closer read I confirm/disagree because Y".
-   d. Post the review: write the review body to `/tmp/review-body.md`
+      X; on closer read I confirm/disagree because Y". For stack
+      PRs, do this per-task under matching `## T-NNN` headings.
+   e. Post the review: write the review body to `/tmp/review-body.md`
       using the **Write tool**, then:
       `gh pr review <N> --comment --body-file /tmp/review-body.md`
       For game PRs, add `--repo <game-repo>`.
@@ -117,7 +126,7 @@ Each invocation is one iteration — do the work, then exit cleanly:
       Do **not** use `--approve` or `--request-changes` — all fleet
       agents share one GitHub account, and GitHub rejects formal
       review actions on your own PRs.
-   e. **Set the PR label** to match your verdict (add `--repo
+   f. **Set the PR label** to match your verdict (add `--repo
       <game-repo>` for game PRs). The label is the primary signal
       the human uses. Always remove stale labels first:
       `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -230,9 +230,12 @@ Each invocation is one iteration — do the work, then exit cleanly:
    ```
 
    This is the load-bearing anchor that lets reviewers segment the
-   PR into per-task review passes. The subject prefix is stable
-   across `git commit --amend` (you amend the body, not the subject)
-   and across rebases — unlike commit SHAs which change on amend.
+   PR into per-task review passes. **Never edit the subject line
+   when amending a stack commit** — only touch the body. `git commit
+   --amend --no-edit` (to add staged files) and body-only amends are
+   safe; `--amend -m "..."` rewrites the subject and breaks reviewer
+   detection for that task. Commit SHAs change on any amend, which is
+   why we use the subject prefix as the anchor instead.
 
    **Stack PR description format:** When opening a stack PR, write
    the body with one section per task and tell reviewers to segment:

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -212,15 +212,52 @@ Each invocation is one iteration — do the work, then exit cleanly:
    has unresolved external blockers, all are rolled back. Within the
    stack, earlier tasks satisfy later tasks' `Blocked by:` fields.
    Work the stack sequentially on a **single branch**, one commit per
-   task. Open one PR that covers the full chain (or stacked PRs if the
-   chain is large). When done:
-   `fleet-claim release-stack opus-worker`
+   task, then `fleet-claim release-stack opus-worker`.
 
    Use stack claiming when:
    - Two tasks are tightly coupled (e.g. foundation + first consumer)
    - Context from task A directly informs task B's implementation
    - The merge → unblock → re-pick latency would waste more budget
      than keeping the context
+
+   **Stack PR commit format (REQUIRED):** Each commit subject MUST
+   start with the task ID prefix `T-NNN: `:
+
+   ```
+   T-005: <short description>
+   T-007: <short description>
+   T-009: <short description>
+   ```
+
+   This is the load-bearing anchor that lets reviewers segment the
+   PR into per-task review passes. The subject prefix is stable
+   across `git commit --amend` (you amend the body, not the subject)
+   and across rebases — unlike commit SHAs which change on amend.
+
+   **Stack PR description format:** When opening a stack PR, write
+   the body with one section per task and tell reviewers to segment:
+
+   ```markdown
+   This PR implements a chain of dependent tasks. Reviewers: please
+   review each task's commit(s) independently — verdict is one
+   overall approval, but findings should be grouped per task.
+
+   ## T-005 — <task title>
+   What this implements, key files touched, what to focus on.
+   Commits prefixed `T-005:` belong to this task.
+
+   ## T-007 — <task title>
+   ...
+
+   Closes #N1
+   Closes #N2
+   Closes #N3
+   ```
+
+   When **amending** a stack commit (e.g. addressing review feedback
+   for one task), keep the `T-NNN: ` subject prefix intact — only
+   amend the body. If you need to add a follow-up commit for one
+   task, use the same prefix: `T-005: address review feedback`.
 
    For single tasks, use the normal claim flow:
    `git checkout -b claude/<area>-<topic>`

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -319,15 +319,22 @@ You are the sole TASKS.md editor. Each maintenance pass:
 
 3. **Sync merged PRs → Done (both repos):**
    Engine:
-   `gh pr list --repo <engine-repo> --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
+   `gh pr list --repo <engine-repo> --state merged --json number,title,mergedAt,commits --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
    Game:
-   `gh pr list --repo <game-repo> --state merged --json number,title,mergedAt --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
+   `gh pr list --repo <game-repo> --state merged --json number,title,mergedAt,commits --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
    (use yesterday's date to catch recent merges)
-   For each recently merged PR whose title or branch matches an
-   `[~]` or `[ ]` task in the **matching repo's** TASKS.md: flip to
-   `[x]`, add the PR URL to **Links**, move to `## Done — last 20`.
-   Clean up plan files for the completed task (both local staging
-   and repo copy):
+
+   **For each merged PR**, find which TASKS.md tasks it completes:
+   - **Single-task PR (most common):** match the PR title or branch
+     name against `[~]` or `[ ]` task entries.
+   - **Stack PR (multi-task chain):** scan the merged PR's commit
+     subjects for `T-NNN: ` prefixes. Each unique task ID prefix
+     marks one completed task. A stack PR can complete 2+ tasks in
+     one merge — flip ALL of them.
+
+   For every task completed by the merge: flip to `[x]`, add the PR
+   URL to **Links**, move to `## Done — last 20`. Clean up plan
+   files for each completed task (both local staging and repo copy):
    `rm -f ~/.fleet/plans/<task-ID>.md`
    `rm -f .fleet/plans/<task-ID>.md`
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -327,10 +327,15 @@ You are the sole TASKS.md editor. Each maintenance pass:
    **For each merged PR**, find which TASKS.md tasks it completes:
    - **Single-task PR (most common):** match the PR title or branch
      name against `[~]` or `[ ]` task entries.
-   - **Stack PR (multi-task chain):** scan the merged PR's commit
-     subjects for `T-NNN: ` prefixes. Each unique task ID prefix
-     marks one completed task. A stack PR can complete 2+ tasks in
-     one merge — flip ALL of them.
+   - **Stack PR (multi-task chain):** extract the task IDs from the
+     merged PR's commit subjects. The canonical query (extracts every
+     `T-NNN` referenced as a commit subject prefix, deduplicated):
+     ```
+     gh pr view <N> --repo <repo> --json commits \
+       --jq '[.commits[].messageHeadline | capture("^(?<id>T-[0-9]+):") | .id] | unique'
+     ```
+     Each unique task ID is one completed task. A stack PR can complete
+     2+ tasks in one merge — flip ALL of them.
 
    For every task completed by the merge: flip to `[x]`, add the PR
    URL to **Links**, move to `## Done — last 20`. Clean up plan

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -162,9 +162,47 @@ limit. Each loop iteration:
    independent): If you find two tightly coupled `[sonnet]` tasks in
    a dependency chain, you can claim them atomically:
    `fleet-claim stack "T-002 T-004" <your-worktree-name>`
-   Work them sequentially on a single branch, one commit per task.
-   Release with `fleet-claim release-stack <your-worktree-name>`.
+   Work them sequentially on a single branch, one commit per task,
+   then release with `fleet-claim release-stack <your-worktree-name>`.
    Prefer single claims unless the tasks are genuinely coupled.
+
+   **Stack PR commit format (REQUIRED):** When working a stack, each
+   commit subject MUST start with the task ID prefix `T-NNN: `:
+
+   ```
+   T-002: <short description of T-002 work>
+   T-004: <short description of T-004 work>
+   ```
+
+   This is the load-bearing anchor that lets reviewers segment the
+   PR into per-task review passes. The subject prefix is stable
+   across `git commit --amend` (you amend the body, not the subject)
+   and across rebases — unlike commit SHAs which change on amend.
+
+   **Stack PR description format:** When opening a stack PR, write
+   the body with one section per task:
+
+   ```markdown
+   This PR implements a chain of dependent tasks. Reviewers: please
+   review each task's commit(s) independently — verdict is one
+   overall approval, but findings should be grouped per task.
+
+   ## T-002 — <task title>
+   What this implements, key files touched, what to focus on.
+   Commits prefixed `T-002:` belong to this task.
+
+   ## T-004 — <task title>
+   What this implements, key files touched, what to focus on.
+   Commits prefixed `T-004:` belong to this task.
+
+   Closes #N1
+   Closes #N2
+   ```
+
+   When **amending** a stack commit (e.g. addressing review feedback
+   for one task), keep the `T-NNN: ` subject prefix intact — only
+   amend the body. If you need to add a follow-up commit for one
+   task, use the same prefix: `T-002: address review feedback`.
 
    Then create the branch, commit, and open a `fleet:wip` PR:
    `git checkout -b claude/<area>-<topic>`

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -175,9 +175,12 @@ limit. Each loop iteration:
    ```
 
    This is the load-bearing anchor that lets reviewers segment the
-   PR into per-task review passes. The subject prefix is stable
-   across `git commit --amend` (you amend the body, not the subject)
-   and across rebases — unlike commit SHAs which change on amend.
+   PR into per-task review passes. **Never edit the subject line
+   when amending a stack commit** — only touch the body. `git commit
+   --amend --no-edit` (to add staged files) and body-only amends are
+   safe; `--amend -m "..."` rewrites the subject and breaks reviewer
+   detection for that task. Commit SHAs change on any amend, which is
+   why we use the subject prefix as the anchor instead.
 
    **Stack PR description format:** When opening a stack PR, write
    the body with one section per task:

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -103,9 +103,34 @@ Each invocation is one iteration — do the work, then exit cleanly:
    candidate, in oldest-first order:
 
    **Engine PRs** (default repo):
-   a. Invoke the `review-pr` skill with the PR number.
-   b. The skill checks out the PR, reads the diff in context, writes
-      a structured review, and posts it.
+   a. **Detect stack PRs first.** A stack PR has multiple commits
+      whose subjects are prefixed with `T-NNN: ` (one prefix per
+      task in the chain). Check with:
+      `gh pr view <N> --json commits --jq '.commits[].messageHeadline'`
+      If you see two or more `T-NNN:` prefixes, this is a stack PR
+      and you MUST review each task's commits independently — the
+      worker chained dependent tasks into one PR for context
+      efficiency, but the review pass is still per-task.
+
+      For a stack PR:
+      - List task IDs from the prefixes (e.g. `T-005`, `T-007`).
+      - For each task, find its commits:
+        `gh pr view <N> --json commits --jq '.commits[] | select(.messageHeadline | startswith("T-005:")) | .oid'`
+      - Review only that task's diff:
+        `gh pr diff <N>` for the whole PR — then mentally segment
+        by task (commits and the PR description's `## T-NNN`
+        sections guide you), OR check out the PR and use
+        `git diff <previous-task-tip>...<this-task-tip>` for the
+        per-task slice.
+      - Write per-task findings in the review body under
+        `## T-NNN` headings. Verdict is one overall approval (the
+        whole PR merges as a unit), but the per-task structure
+        gives the author and the human a clear view of what's
+        clean vs what needs fixing per task.
+
+   b. **Single-task PR (most common):** Invoke the `review-pr`
+      skill with the PR number. The skill checks out the PR, reads
+      the diff in context, writes a structured review, and posts it.
 
    **Game PRs** (`<game-repo>`):
    a. Read the diff: `gh pr diff <N> --repo <game-repo>`

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -116,12 +116,19 @@ Each invocation is one iteration — do the work, then exit cleanly:
       - List task IDs from the prefixes (e.g. `T-005`, `T-007`).
       - For each task, find its commits:
         `gh pr view <N> --json commits --jq '.commits[] | select(.messageHeadline | startswith("T-005:")) | .oid'`
-      - Review only that task's diff:
-        `gh pr diff <N>` for the whole PR — then mentally segment
-        by task (commits and the PR description's `## T-NNN`
-        sections guide you), OR check out the PR and use
-        `git diff <previous-task-tip>...<this-task-tip>` for the
-        per-task slice.
+      - Review only that task's diff. Two paths:
+        - **Quick:** `gh pr diff <N>` for the whole PR — then
+          mentally segment by task (commits and the PR description's
+          `## T-NNN` sections guide you).
+        - **Precise (for non-trivial stacks, or when tasks touch
+          overlapping files):** check out the PR, then for each task
+          find the task-tip commit — the last commit whose subject
+          starts with that task's prefix:
+          `gh pr view <N> --json commits --jq '.commits[] | select(.messageHeadline | startswith("T-005:")) | .oid' | tail -1`
+          Then diff that slice:
+          `git diff <previous-task-tip>...<this-task-tip>`
+          (For the first task in the stack, use `origin/master` as
+          the previous tip.)
       - Write per-task findings in the review body under
         `## T-NNN` headings. Verdict is one overall approval (the
         whole PR merges as a unit), but the per-task structure


### PR DESCRIPTION
## Summary
Implements per-task structure for stack PRs (multiple dependent tasks chained into one PR via `fleet-claim stack`) so reviewers can segment review work and the queue-manager correctly flips all completed tasks.

**Commit format (REQUIRED for stack PRs):** Each commit subject MUST start with `T-NNN: <description>`. The subject prefix is the load-bearing anchor — stable across `git commit --amend` (workers amend bodies, not subjects) and across rebases. Commit SHAs would change on amend; we don't use them.

**PR description format:** One `## T-NNN — <title>` section per task plus instructions telling reviewers to segment.

**Reviewer flow:**
1. Detect stack via `gh pr view --json commits` looking for multiple distinct `T-NNN:` prefixes
2. Review each task's commits independently
3. Write per-task findings under matching `## T-NNN` headings
4. Single overall verdict (PR merges as a unit), but per-task structure tells the author and human exactly which tasks need attention

**Queue-manager:** \"Sync merged PRs → done\" step now scans commit subjects for `T-NNN:` prefixes, so a stack PR can correctly flip 2+ tasks to done in one merge.

## Files
- `role-sonnet-author.md` — stack section + commit/PR-body format
- `role-opus-worker.md` — same
- `role-sonnet-reviewer.md` — stack PR detection + per-task review pass
- `role-opus-reviewer.md` — same, plus per-task references in Sonnet comparison
- `role-queue-manager.md` — multi-task completion logic

## Out of scope
- `role-game-sonnet.md` doesn't currently document `fleet-claim stack` (separate gap from earlier PRs). If we add stack support there, we'll add the same format requirements then.
- True stacked PRs (each task = its own PR with `--base <previous>`) — see follow-up issue (filed next).

## Test plan
- [ ] After merge, an opus-worker that picks up a 2-task stack writes commits with `T-NNN:` subject prefixes
- [ ] PR body has `## T-NNN — title` sections for each task
- [ ] Sonnet reviewer detects the stack via commit subjects and writes per-task review sections
- [ ] After merge of a stack PR, queue-manager's next maintenance pass flips all completed tasks (not just one)
- [ ] Amending a stack commit body keeps the subject prefix intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)