### PR TITLE
fleet: per-model effort levels, auto permission mode, architect-centric layout

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -38,6 +38,18 @@ ROLE="${2:?usage: fleet-babysit <model> <role> [mode] [loop-interval]}"
 MODE="${3:-dry-run}"
 LOOP_INTERVAL="${4:-}"
 
+# Effort level — derived from model. Opus agents get max thinking
+# budget (architects + workers do the hard reasoning). Sonnet agents
+# get high (good output without burning the budget on tasks where
+# diminishing returns kick in).
+case "$MODEL" in
+    opus|claude-opus*) EFFORT="max" ;;
+    sonnet|claude-sonnet*) EFFORT="high" ;;
+    *) EFFORT="high" ;;
+esac
+# Allow override from env if needed (e.g. a debugging session)
+EFFORT="${FLEET_EFFORT:-$EFFORT}"
+
 # Timing
 CRASH_DELAY=30        # seconds to wait after non-zero exit (crash)
 LIMIT_DELAY=900       # seconds to wait on suspected usage limit (exit 2)
@@ -66,7 +78,7 @@ rotate_log() {
     fi
 }
 
-log "starting ($MODEL) mode=$MODE loop=${LOOP_INTERVAL:-none} in $(pwd)"
+log "starting ($MODEL effort=$EFFORT) mode=$MODE loop=${LOOP_INTERVAL:-none} in $(pwd)"
 
 # --- First run: send the role slash command --------------------------------
 # If a loop interval is set and mode is live, wrap the role invocation in
@@ -74,9 +86,9 @@ log "starting ($MODEL) mode=$MODE loop=${LOOP_INTERVAL:-none} in $(pwd)"
 # polling and external tmux timers).
 if [[ -n "$LOOP_INTERVAL" && "$MODE" == "live" ]]; then
     log "using /loop $LOOP_INTERVAL for scheduling"
-    claude --model "$MODEL" "/loop $LOOP_INTERVAL /role-$ROLE"
+    claude --model "$MODEL" --effort "$EFFORT" "/loop $LOOP_INTERVAL /role-$ROLE"
 else
-    claude --model "$MODEL" "/role-$ROLE $MODE"
+    claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
 fi
 last_exit=$?
 
@@ -121,6 +133,6 @@ while true; do
     esac
 
     log "resuming session (attempt $attempt)..."
-    claude --model "$MODEL" --continue "resume your work from where you left off"
+    claude --model "$MODEL" --effort "$EFFORT" --continue "resume your work from where you left off"
     last_exit=$?
 done

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -47,7 +47,9 @@ case "$MODEL" in
     sonnet|claude-sonnet*) EFFORT="high" ;;
     *) EFFORT="high" ;;
 esac
-# Allow override from env if needed (e.g. a debugging session)
+# Global override from env if set. Note: FLEET_EFFORT applies to
+# every pane in the fleet — fleet-up does not thread env per-pane.
+# To change one pane's effort, edit the case statement above.
 EFFORT="${FLEET_EFFORT:-$EFFORT}"
 
 # Timing

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -4,8 +4,9 @@
 # Idempotent. Creates any missing worktrees, resets each to a fresh
 # branch off origin/master (skipping any that have uncommitted work),
 # then builds a single tmux session "fleet" with one window "agents"
-# containing 7 tiled panes — each launching `claude` with the right
-# model and the matching role slash command in dry-run mode.
+# containing up to 9 tiled panes (7 engine + 2 game if the game repo
+# is present) — each launching `claude` with the right model and the
+# matching role slash command in dry-run mode.
 #
 # Source of truth: scripts/fleet/fleet-up in the engine repo.
 # Installed to ~/bin/fleet-up (as a symlink) by scripts/fleet/install.sh.
@@ -256,10 +257,12 @@ mkdir -p "$HOME/.fleet/plans"
 # Step 4: build the tmux session
 # ----------------------------------------------------------------------
 #
-# Layout: single window with three rows.
-#   top    — sonnet-fleet-1, sonnet-fleet-2, game-sonnet  (authors)
-#   middle — opus-architect, opus-worker, game-architect  (architects + worker)
-#   bottom — sonnet-reviewer, opus-reviewer, queue-manager (ops)
+# Layout: single window with three rows (see detailed comment block
+# below the launch_cmd helper — that's the canonical description).
+# Summary:
+#   top    (~32%, 4 panes) — autonomous workers
+#   middle (~40%, 2 panes) — interactive architects (biggest)
+#   bottom (~28%, 3 panes) — ops
 #
 # Cycle windows: Ctrl-b n / Ctrl-b p, or Ctrl-b <number>.
 #
@@ -408,7 +411,9 @@ layout (single window, three rows):
 effort levels:
   opus agents (architects, opus-worker, opus-reviewer) — max
   sonnet agents (workers, reviewer, queue-manager) — high
-  override per-agent with FLEET_EFFORT=<level> in the agent's env.
+  override globally by exporting FLEET_EFFORT=<level> before fleet-up.
+  (to change one pane, edit fleet-babysit's case statement — fleet-up
+  does not thread env per-pane.)
 
 permission mode: auto (model decides when to ask vs proceed)
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -212,6 +212,7 @@ out = {
     "permissions": {
         "additionalDirectories": [repo_root],
         "allow": all_allows,
+        "defaultMode": "auto",
     }
 }
 
@@ -290,9 +291,16 @@ launch_cmd() {
 }
 
 # Single window, three rows:
-#   Top    (~45% height): sonnet authors + game-sonnet  — biggest panes
-#   Middle (~30% height): architects                    — medium panes
-#   Bottom (~25% height): reviewers + queue-manager     — small panes
+#   Top    (~32% height): autonomous workers (4 panes)  — small workspace
+#                         sonnet-fleet-1, sonnet-fleet-2, opus-worker, [game-sonnet]
+#   Middle (~40% height): architects (2 wide panes)     — interactive design
+#                         opus-architect, [game-architect] — biggest, most-used
+#   Bottom (~28% height): ops (3 panes)                 — small status panes
+#                         sonnet-reviewer, opus-reviewer, queue-manager
+#
+# The architect row is widest+tallest because it's where the human
+# spends interactive time. Workers and ops are autonomous loops you
+# only glance at.
 #
 # Navigate without a prefix key: Option+arrow (see ~/.tmux.conf).
 # Ctrl-a o = cycle next pane, Ctrl-a ; = jump to last-used pane.
@@ -311,17 +319,16 @@ active_pane_id() {
     tmux display-message -t "$SESSION:fleet" -p "#{pane_id}"
 }
 
-# --- Row 1: authors (starts full-screen; will become top ~45%) ----------
+# --- Row 1: workers (starts full-screen, ends as top ~32%) -------------
 tmux new-session -d -s "$SESSION" -n fleet \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-1" \
     "$(launch_cmd "$SONNET_MODEL" sonnet-author)"
 TOP1=$(active_pane_id)
 label_pane_id "$TOP1" "sonnet-fleet-1 [sonnet]"
 
-# --- Row 3 (bottom, ~25%): reviewers + queue-manager -------------------
-# Split off the bottom strip first. The percentage is relative to the
-# full window height at this point — 25% bottom, 75% top.
-tmux split-window -v -t "$TOP1" -p 25 \
+# --- Row 3 (bottom, ~28%): ops -----------------------------------------
+# Split off the bottom strip first.
+tmux split-window -v -t "$TOP1" -p 28 \
     -c "$ENGINE/.claude/worktrees/sonnet-reviewer" \
     "$(launch_cmd "$SONNET_MODEL" sonnet-reviewer 3m)"
 BOT1=$(active_pane_id)
@@ -339,52 +346,54 @@ tmux split-window -h -t "$BOT2" \
 BOT3=$(active_pane_id)
 label_pane_id "$BOT3" "queue-manager [sonnet]"
 
-# --- Row 2 (middle, ~30%): architects + opus-worker --------------------
-# Split off the middle row from TOP1. TOP1 is currently 75% of the
-# window. Splitting 40% off the bottom of that gives:
-#   TOP1 = 75% * 60% = ~45% of window  (authors)
-#   MID1 = 75% * 40% = ~30% of window  (architects + opus-worker)
-tmux split-window -v -t "$TOP1" -p 40 \
+# --- Row 2 (middle, ~40%): architects ---------------------------------
+# Split off the middle row from TOP1. TOP1 is currently 72% of window
+# (after bottom 28%). Splitting 56% off the bottom of TOP1 gives:
+#   TOP1 = 72% * 44% = ~32% of window  (workers)
+#   MID  = 72% * 56% = ~40% of window  (architects — taller)
+tmux split-window -v -t "$TOP1" -p 56 \
     -c "$ENGINE/.claude/worktrees/opus-architect" \
     "$(launch_cmd "$OPUS_MODEL" opus-architect)"
 MID1=$(active_pane_id)
 label_pane_id "$MID1" "opus-architect [opus 4.7]"
 
-tmux split-window -h -t "$MID1" \
-    -c "$ENGINE/.claude/worktrees/opus-worker" \
-    "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)"
-MID2=$(active_pane_id)
-label_pane_id "$MID2" "opus-worker [opus 4.7]"
-
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
-    tmux split-window -h -t "$MID2" \
+    tmux split-window -h -t "$MID1" \
         -c "$GAME/.claude/worktrees/game-architect" \
         "$(launch_cmd "$OPUS_MODEL" game-architect)"
-    MID3=$(active_pane_id)
-    label_pane_id "$MID3" "game-architect [opus 4.7]"
+    MID2=$(active_pane_id)
+    label_pane_id "$MID2" "game-architect [opus 4.7]"
 fi
 
-# --- Expand Row 1 (top) with remaining authors -------------------------
+# --- Expand Row 1 (top) with remaining workers -------------------------
+# Top row layout: 4 autonomous workers
+#   sonnet-fleet-1, sonnet-fleet-2, opus-worker, [game-sonnet]
 tmux split-window -h -t "$TOP1" \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-2" \
     "$(launch_cmd "$SONNET_MODEL" sonnet-author)"
 TOP2=$(active_pane_id)
 label_pane_id "$TOP2" "sonnet-fleet-2 [sonnet]"
 
+tmux split-window -h -t "$TOP2" \
+    -c "$ENGINE/.claude/worktrees/opus-worker" \
+    "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)"
+TOP3=$(active_pane_id)
+label_pane_id "$TOP3" "opus-worker [opus 4.7]"
+
 if [[ -d "$GAME/.claude/worktrees/game-sonnet" ]]; then
-    tmux split-window -h -t "$TOP2" \
+    tmux split-window -h -t "$TOP3" \
         -c "$GAME/.claude/worktrees/game-sonnet" \
         "$(launch_cmd "$SONNET_MODEL" game-sonnet)"
-    TOP3=$(active_pane_id)
-    label_pane_id "$TOP3" "game-sonnet [sonnet]"
+    TOP4=$(active_pane_id)
+    label_pane_id "$TOP4" "game-sonnet [sonnet]"
 fi
 
 # Enable pane border labels using @role (immune to program overrides)
 tmux set-option -t "$SESSION" pane-border-status top
 tmux set-option -t "$SESSION" pane-border-format " #{pane_index}: #{@role} "
 
-# Focus sonnet-fleet-1 on attach
-tmux select-pane -t "$TOP1"
+# Focus opus-architect on attach (the human's main interactive pane)
+tmux select-pane -t "$MID1"
 
 cat <<EOF
 
@@ -392,9 +401,16 @@ fleet session created — mode: ${MODE}.
 attach with:  tmux attach -t ${SESSION}
 
 layout (single window, three rows):
-  top (big)    — sonnet-fleet-1  sonnet-fleet-2  [game-sonnet]   (authors)
-  middle (med) — opus-architect  opus-worker  [game-architect]   (architects + worker)
-  bottom (sm)  — sonnet-reviewer  opus-reviewer  queue-manager   (ops)
+  top (~32%, 4 panes) — sonnet-fleet-1  sonnet-fleet-2  opus-worker  [game-sonnet]   (autonomous workers)
+  middle (~40%, 2 panes, taller) — opus-architect  [game-architect]                  (interactive architects — biggest)
+  bottom (~28%, 3 panes) — sonnet-reviewer  opus-reviewer  queue-manager             (ops)
+
+effort levels:
+  opus agents (architects, opus-worker, opus-reviewer) — max
+  sonnet agents (workers, reviewer, queue-manager) — high
+  override per-agent with FLEET_EFFORT=<level> in the agent's env.
+
+permission mode: auto (model decides when to ask vs proceed)
 
 navigation (no prefix needed):
   Option+Up/Down/Left/Right — move to pane in that direction


### PR DESCRIPTION
## Summary

Three coordinated changes to optimize the fleet for interactive architect work + autonomous worker throughput.

### 1. Per-model effort levels (`fleet-babysit`)
| Model | Effort | Why |
|---|---|---|
| Opus (architects, opus-worker, opus-reviewer) | `max` | Hard reasoning, Opus recheck, ECS invariants, render decisions — burn the thinking budget |
| Sonnet (workers, reviewer, queue-manager) | `high` | Good output without diminishing returns on bounded work |

Override per-agent via `FLEET_EFFORT=<level>` in env (for debugging sessions).

### 2. Auto permission mode (`fleet-up` settings)
`permissions.defaultMode` flipped from `acceptEdits` → `auto`. Model decides when to ask vs proceed, instead of blanket-accepting all edits. Safer for autonomous loops without sacrificing throughput.

### 3. Architect-centric layout (`fleet-up` tmux)

**Before:**
```
TOP    (~45%, 3 panes): sonnet-fleet-1, sonnet-fleet-2, [game-sonnet]
MIDDLE (~30%, 3 panes): opus-architect, opus-worker, [game-architect]
BOTTOM (~25%, 3 panes): sonnet-reviewer, opus-reviewer, queue-manager
```

**After:**
```
TOP    (~32%, 4 panes): sonnet-fleet-1, sonnet-fleet-2, opus-worker, [game-sonnet]   (autonomous)
MIDDLE (~40%, 2 panes): opus-architect, [game-architect]                              (interactive — biggest)
BOTTOM (~28%, 3 panes): sonnet-reviewer, opus-reviewer, queue-manager                 (ops)
```

- Architect row is now **taller** (40% vs 30%) AND each pane is **wider** (50% width vs 33%) — they're where the human spends interactive time
- `opus-worker` moved from middle → top row (it's autonomous, not interactive — belongs with workers)
- Default selected pane on attach is now `opus-architect` (was `sonnet-fleet-1`)

## Test plan
- [ ] Run `fleet-up dry-run` — verify the layout has 4-2-3 rows with architects in middle
- [ ] Verify each pane shows `effort=max` (opus) or `effort=high` (sonnet) in the babysit log line
- [ ] Verify `~/.claude/projects/.../settings.local.json` has `defaultMode: \"auto\"` after `fleet-up`
- [ ] Tmux attaches to `opus-architect` pane by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)