### PR TITLE
fix: three fleet hygiene bugs from observed production failures

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -116,10 +116,16 @@ When you do pick a task:
 6. Use the `commit-and-push` skill to open the PR. If the task has an
    `**Issue:** #N` field, include `Closes #N` in the PR body so the
    issue closes automatically when the PR merges.
-7. After the PR is open, release the claim and reset:
+7. **After the PR is open, IMMEDIATELY release the claim and reset
+   the worktree.** Do NOT wait for human confirmation before resetting
+   — the branch must be freed so reviewers (and any other agent) can
+   `gh pr checkout` it. Holding the branch checked out blocks the
+   review pipeline.
    `fleet-claim release "<task ID>"`
    Then use the `start-next-task` skill to land on a fresh branch off
-   `origin/master`.
+   `origin/master`. AFTER the reset is complete, you may ask the human
+   "what's next?" — but the reset itself is non-negotiable, even in
+   interactive mode.
 8. **Check for feedback labels on open PRs** before picking new work:
    `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "fleet:needs-fix")) | "#\(.number) \(.title)"'`
    **Skip** PRs labeled `human:wip` — human is working on it directly.
@@ -202,4 +208,14 @@ Stop and surface to the human when:
 - Never run `cmake --preset` — only `cmake --build` against the
   already-configured tree.
 - Never touch the `.claude/worktrees/` layout.
+- **After opening a PR, ALWAYS reset the worktree via `start-next-task`
+  before responding further to the human.** Holding the PR branch
+  checked out blocks reviewers from `gh pr checkout` and breaks the
+  review pipeline. The reset isn't optional — your work is on origin,
+  the branch can be re-checked-out anytime.
+- **Never leave dirty edits uncommitted at the end of an iteration.**
+  If you made any changes to the working tree — manual edits, edits
+  that simplify applied, fixes from optimize, anything — you MUST
+  follow with `commit-and-push` to land them. Don't invoke `simplify`
+  standalone — let `commit-and-push` invoke it for you.
 - Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -57,13 +57,17 @@ whatever directory the task touches before editing anything.
 1. `pwd` and confirm you are in the `opus-worker` worktree (not
    opus-architect, not a reviewer worktree).
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. Sync TASKS.md and plan files from origin/master (the working copy
-   may be stale if the worktree is on a feature branch or a
-   queue-manager push landed since last fetch):
-   `git checkout origin/master -- TASKS.md`
-   `git checkout origin/master -- .fleet/plans/` (ignore errors if
-   the directory doesn't exist on master yet)
-4. Read `TASKS.md` (use the Read tool) — review the current queue.
+3. **Read the latest TASKS.md from origin/master without staging it.**
+   The working copy may be stale if the worktree is on a feature
+   branch. Use `git show` to write current master versions to temp
+   files — this does NOT touch the working tree or index, so it
+   won't break later branch checkouts:
+   `git show origin/master:TASKS.md > /tmp/tasks-master.md`
+   For plan files, list them with `git ls-tree -r origin/master --name-only -- .fleet/plans/`
+   then `git show origin/master:.fleet/plans/<file>` for any you
+   need to read. Do NOT use `git checkout origin/master -- ...` —
+   it stages the files and breaks later `git checkout -b`.
+4. Read `/tmp/tasks-master.md` (use the Read tool) — review the current queue.
 4. `gh pr list --state open --json number,title,headRefName,author` —
    see what other agents are working on.
 5. Check for `fleet:needs-plan` issues:
@@ -317,6 +321,13 @@ driver and `fleet-babysit` wrapper handle backoff.
   `xcode-select` — those are human-initiated.
 - Never write plan files during task execution. Plan files are written
   only during the planning step (step 2) for `fleet:needs-plan` issues.
+- **Never leave dirty edits uncommitted at the end of an iteration.**
+  If you made any changes to the working tree — manual edits, edits
+  that simplify applied, fixes from optimize, anything — you MUST
+  follow with `commit-and-push` to land them. The next iteration's
+  branch switch will discard them. Don't invoke `simplify` standalone
+  — let `commit-and-push` invoke it for you, so the commit step is
+  guaranteed to follow.
 - **`~/.fleet/plans/` and `.fleet/plans/` are for task plans only.**
   The only valid filenames are `T-NNN.md` (canonical) and
   `issue-N.md` (pre-rename, awaiting queue-manager ingestion).

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -53,11 +53,19 @@ whatever directory the task touches before editing anything.
 1. `pwd` and confirm you are in a sonnet-fleet worktree (not the main
    clone, not a reviewer worktree).
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. Sync TASKS.md from origin/master (the working copy may be stale
-   if the worktree is on a feature branch or a queue-manager push
-   landed since last fetch):
-   `git checkout origin/master -- TASKS.md`
-4. Read `TASKS.md` (use the Read tool, not `cat`) — review the current queue.
+3. **Read the latest TASKS.md from origin/master without staging it.**
+   The working copy may be stale if the worktree is on a feature
+   branch. Use `git show` to write the current master version to a
+   temp file — this does NOT touch the working tree or index, so it
+   won't break later branch checkouts:
+   `git show origin/master:TASKS.md > /tmp/tasks-master.md`
+   Then read `/tmp/tasks-master.md` with the Read tool.
+
+   Do NOT use `git checkout origin/master -- TASKS.md` here. That
+   stages the file. When `start-next-task` later tries
+   `git checkout -b new-branch origin/master` it errors with
+   "your local changes would be overwritten by checkout."
+4. Read `/tmp/tasks-master.md` (use the Read tool, not `cat`) — review the current queue.
 4. `gh pr list --state open --json number,title,headRefName,author` —
    see what other agents are working on.
 5. Print a one-line summary: which `[sonnet]` items look unblocked and
@@ -272,4 +280,13 @@ budget split. Just wait.
 - Never touch the `.claude/worktrees/` layout.
 - Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
   `xcode-select` — those are human-initiated.
+- **Never leave dirty edits uncommitted at the end of an iteration.**
+  If you made any changes to the working tree — manual edits, edits
+  that simplify applied, fixes from optimize, anything — you MUST
+  follow with `commit-and-push` to land them. The next iteration's
+  branch switch will discard them. If `simplify` ran and reported
+  fixes applied but you didn't proceed to commit, that's the bug:
+  finish the flow. Don't invoke `simplify` standalone — let
+  `commit-and-push` invoke it for you, so the commit step is
+  guaranteed to follow.
 - Single-command Bash only (see CRITICAL section above).

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -89,7 +89,24 @@ If the user already gave you a task and a name is obvious, just use it. Do
 not pick a name with a random suffix — permanent worktrees work best with
 human-readable, topic-named branches.
 
-### 5. Check out the new branch off fresh origin/master
+### 5. Discard any staged or working-tree changes from the old branch
+
+Before switching, ensure the working tree is fully clean — even of files
+that look like a no-op (e.g. `TASKS.md` that was checked out from
+`origin/master` to read the latest queue while you were on the feature
+branch — that staging blocks the next branch checkout):
+
+```bash
+git restore --staged .
+git checkout -- .
+```
+
+If `git status` reported clean in the preconditions, these are no-ops.
+If it didn't, these clear any leftover staged changes that would otherwise
+fail the next `git checkout -b` with "your local changes would be
+overwritten by checkout."
+
+### 6. Check out the new branch off fresh origin/master
 
 ```bash
 git checkout -b claude/<new-area>-<new-topic> origin/master
@@ -103,7 +120,7 @@ you'd branch off your old PR branch and carry its commits forward.
 it. That would mix old PR commits with new work, which pollutes the old PR
 when you push. Always start a new branch.
 
-### 6. Sanity-check the state
+### 7. Sanity-check the state
 
 ```bash
 git status
@@ -115,7 +132,7 @@ git log --oneline -5
   commit, not one of your previous PR's commits. If it's still showing old
   PR commits, the checkout went wrong — stop and investigate.
 
-### 7. Read the relevant CLAUDE.md for the new task area
+### 8. Read the relevant CLAUDE.md for the new task area
 
 Before starting the next task, read the most specific `CLAUDE.md` for the
 directory you're about to work in. For example:
@@ -130,7 +147,7 @@ This primes your context with the module's conventions and gotchas before
 you start editing. If the subdirectory has a dedicated workflow that
 differs from the engine baseline, honor the subdirectory's rules.
 
-### 8. Report
+### 9. Report
 
 Reply with a compact summary:
 


### PR DESCRIPTION
## Summary

Three bugs caught from a live fleet run today.

### Bug 1: Architect blocking reviewer checkout
- opus-architect created PR #190, then waited for human \"what next?\" before running \`start-next-task\`
- sonnet-reviewer's \`gh pr checkout 190\` failed: \`'claude/render-debug-loop-genericize' is already used by worktree at /opus-architect/\`
- Reviewer fell back to reading files from architect's worktree (works but fragile — sees local edits, not PR state)

**Fix:** role-opus-architect step 7 + new hard rule. Reset the worktree IMMEDIATELY after PR creation, before responding to human. Ask \"what's next?\" AFTER the reset, not before. Same fix in role-game-architect (game PR follows).

### Bug 2: Worker ran simplify but didn't commit the fixes
- sonnet-fleet-2 invoked \`simplify\` standalone
- simplify modified \`component_light_source.hpp\` (constructor default, doc cleanup)
- worker considered itself done — fixes never committed
- next iteration's branch switch would have discarded them; PR #187 wouldn't have had them
- Confirmed by user prompting the worker; it correctly admitted \"my instructions aren't wrong — I just need to continue the commit-and-push flow\" and then did it

**Fix:** new hard rule in all author/worker roles. Never leave dirty edits uncommitted; never invoke simplify standalone (let commit-and-push invoke it so the commit step is guaranteed to follow).

### Bug 3: TASKS.md sync staged the file and broke branch switching
- Role startup said \`git checkout origin/master -- TASKS.md\` to read latest queue
- This STAGES the file (writes to index)
- Worker later runs start-next-task → \`git checkout -b new-branch origin/master\` errors: \"your local changes to the following files would be overwritten by checkout: TASKS.md\"
- Worker had to manually \`git restore --staged TASKS.md\` to recover (visible in screenshot 2)

**Fix:** change TASKS.md sync to \`git show origin/master:TASKS.md > /tmp/tasks-master.md\` — doesn't touch index. Plus belt-and-suspenders \`git restore --staged .\` step in start-next-task as defensive cleanup for any other staged-file paths.

## Files
- \`.claude/skills/start-next-task/SKILL.md\` — new defensive cleanup step (5)
- \`.claude/commands/role-sonnet-author.md\` — TASKS.md sync via git show, no-dirty hard rule
- \`.claude/commands/role-opus-worker.md\` — same + plan files via git show
- \`.claude/commands/role-opus-architect.md\` — auto-reset rule + no-dirty hard rule

## Test plan
- [ ] After merge, an opus-architect that finishes a task runs \`start-next-task\` automatically (no human \"go\" needed) — branch is freed for reviewers
- [ ] A sonnet-author worker reading TASKS.md uses \`git show\` not \`git checkout\` — no staged file after read
- [ ] After running simplify (via commit-and-push), the worker always commits and pushes; never leaves dirty edits
- [ ] start-next-task with a stale staged TASKS.md from a previous bad-pattern run still succeeds (defensive restore step kicks in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)