### PR TITLE
fleet: restructure to 8 panes (2× opus-worker, 1× sonnet, drop game-sonnet)

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -2,10 +2,15 @@
 description: Opus worker — plans fleet:needs-plan issues and picks opus-tagged tasks from TASKS.md
 ---
 
-You are the **Opus worker** agent for the Irreden Engine fleet, running
-in `~/src/IrredenEngine/.claude/worktrees/opus-worker` (host can be
-WSL2 Ubuntu or macOS). Your job is to **plan issues** that need
+You are an **Opus worker** agent for the Irreden Engine fleet, running
+in one of `~/src/IrredenEngine/.claude/worktrees/opus-worker-*` (host
+can be WSL2 Ubuntu or macOS). Your job is to **plan issues** that need
 architectural input and **execute `[opus]` tasks** from `TASKS.md`.
+
+The fleet runs **two opus-worker panes** in parallel — they cooperate
+via `fleet-claim` (atomic locks) and open-PR cross-checks. Your job is
+identical to the other opus-worker; the lock fabric prevents you from
+double-claiming the same task.
 
 You are NOT the architect. The architect is the human's interactive
 design partner. You handle the autonomous side: planning issues the
@@ -54,8 +59,10 @@ whatever directory the task touches before editing anything.
 
 0. Print your role banner:
    `[opus-worker] Plans fleet:needs-plan issues, executes [opus] tasks from TASKS.md. Loop: every 20m.`
-1. `pwd` and confirm you are in the `opus-worker` worktree (not
-   opus-architect, not a reviewer worktree).
+1. `pwd` and confirm you are in an `opus-worker-*` worktree (not
+   opus-architect, not a reviewer worktree). The directory basename
+   (`opus-worker-1` or `opus-worker-2`) is your **agent name** — pass
+   it as the `<agent>` argument to `fleet-claim claim`.
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
 3. **Read the latest TASKS.md from origin/master without staging it.**
    The working copy may be stale if the worktree is on a feature
@@ -200,8 +207,10 @@ Each invocation is one iteration — do the work, then exit cleanly:
 4. **Claim the task, then open a PR with `fleet:wip`.**
    Do NOT edit `TASKS.md` — only the queue-manager touches it.
 
-   Acquire the local filesystem lock. **Always pass the task ID**:
-   `fleet-claim claim "<task ID, e.g. T-003>" opus-worker`
+   Acquire the local filesystem lock. **Always pass the task ID**,
+   and pass your worktree basename (`opus-worker-1` or `opus-worker-2`)
+   as the agent name so it's visible in `fleet-claim list`:
+   `fleet-claim claim "<task ID, e.g. T-003>" <your-worktree-name>`
 
    - **Exit 0** — you own it. Proceed.
    - **Exit 1 (already taken)** — go back to step 3, pick another.
@@ -212,13 +221,13 @@ Each invocation is one iteration — do the work, then exit cleanly:
    **Stack claiming for dependency chains:** If you find a sequence of
    unblocked tasks that form a dependency chain (e.g. T-005 blocks
    T-007 blocks T-009), you can claim them atomically:
-   `fleet-claim stack "T-005 T-007 T-009" opus-worker`
+   `fleet-claim stack "T-005 T-007 T-009" <your-worktree-name>`
 
    Stack claim is all-or-nothing — if any task is already claimed or
    has unresolved external blockers, all are rolled back. Within the
    stack, earlier tasks satisfy later tasks' `Blocked by:` fields.
    Work the stack sequentially on a **single branch**, one commit per
-   task, then `fleet-claim release-stack opus-worker`.
+   task, then `fleet-claim release-stack <your-worktree-name>`.
 
    Use stack claiming when:
    - Two tasks are tightly coupled (e.g. foundation + first consumer)

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -353,14 +353,15 @@ A reasonable starting setup with the model split in mind:
 | Worktree            | Repo   | Model  | Role                                                |
 |---------------------|--------|--------|-----------------------------------------------------|
 | `opus-architect`    | engine | Opus   | Core engine work, ECS/render/audio. Stand-by.       |
+| `opus-worker-1`     | engine | Opus   | Plans `fleet:needs-plan` issues, executes `[opus]` tasks |
+| `opus-worker-2`     | engine | Opus   | Second opus-worker pane — parallel planning/execution    |
 | `sonnet-fleet-1`    | engine | Sonnet | TASKS.md `[sonnet]` items, tests, docs              |
-| `sonnet-fleet-2`    | engine | Sonnet | TASKS.md `[sonnet]` items, tests, docs              |
 | `sonnet-reviewer`   | engine | Sonnet | First-pass PR review (polling loop)                 |
 | `opus-reviewer`     | engine | Opus   | Final review on flagged PRs (polling loop)          |
 | `queue-manager`     | engine | Sonnet | Task intake — categorizes and files new tasks       |
 | `game-architect`    | game   | Opus   | Game-side architect / stand-by, cross-repo aware    |
 
-The first six live in `~/src/IrredenEngine/.claude/worktrees/`. The
+The first seven live in `~/src/IrredenEngine/.claude/worktrees/`. The
 last (`game-architect`) lives inside the game repo at
 `~/src/IrredenEngine/creations/game/.claude/worktrees/game-architect`,
 because the game is its own git repo with its own PR namespace.
@@ -385,8 +386,9 @@ cd ~/src/IrredenEngine
 git fetch origin master
 
 git worktree add -b fleet/opus-architect  .claude/worktrees/opus-architect  origin/master
+git worktree add -b fleet/opus-worker-1   .claude/worktrees/opus-worker-1   origin/master
+git worktree add -b fleet/opus-worker-2   .claude/worktrees/opus-worker-2   origin/master
 git worktree add -b fleet/sonnet-fleet-1  .claude/worktrees/sonnet-fleet-1  origin/master
-git worktree add -b fleet/sonnet-fleet-2  .claude/worktrees/sonnet-fleet-2  origin/master
 git worktree add -b fleet/sonnet-reviewer .claude/worktrees/sonnet-reviewer origin/master
 git worktree add -b fleet/opus-reviewer   .claude/worktrees/opus-reviewer   origin/master
 git worktree add -b fleet/queue-manager   .claude/worktrees/queue-manager   origin/master
@@ -402,10 +404,10 @@ Verify:
 git worktree list
 ```
 
-You should see the main clone on `master` plus six engine worktrees
-(`opus-architect`, `sonnet-fleet-1`, `sonnet-fleet-2`, `sonnet-reviewer`,
-`opus-reviewer`, `queue-manager`) each on their own `fleet/*` seed
-branch, plus a seventh `game-architect` worktree under
+You should see the main clone on `master` plus seven engine worktrees
+(`opus-architect`, `opus-worker-1`, `opus-worker-2`, `sonnet-fleet-1`,
+`sonnet-reviewer`, `opus-reviewer`, `queue-manager`) each on their own
+`fleet/*` seed branch, plus an eighth `game-architect` worktree under
 `creations/game/` if the game repo is present. The `fleet/` prefix
 keeps these distinct from `claude/<area>-<topic>` agent branches so
 `gh pr list` and branch-completion never confuse them.
@@ -1258,8 +1260,8 @@ This validates the agent has read the game `CLAUDE.md` correctly.
 - Did the `[~]` → `[x]` move land in the merged commit, and did the
   Done list pick it up?
 - Did `gh pr list` show the claim quickly enough that
-  `sonnet-fleet-2` would not have picked the same task?
-  (Test: while sonnet-fleet-1 is mid-task, switch to sonnet-fleet-2
+  `opus-worker-2` would not have picked the same task?
+  (Test: while opus-worker-1 is mid-task, switch to opus-worker-2
   and ask it to "list candidate tasks." It should NOT include the
   in-flight task.)
 - Did the build go cleanly with

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -16,7 +16,7 @@
 #   fleet-babysit opus  opus-reviewer live 30m       # /loop every 30 min
 #   fleet-babysit sonnet queue-manager live 15m      # /loop every 15 min
 #   fleet-babysit opus  opus-architect live           # on-demand, no /loop
-#   fleet-babysit sonnet game-sonnet live             # game worktree cwd
+#   fleet-babysit opus  game-architect live           # game worktree cwd
 #
 # Behavior by mode:
 #   dry-run  — start the agent, auto-resume on crash, but do NOT

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -4,9 +4,9 @@
 # Idempotent. Creates any missing worktrees, resets each to a fresh
 # branch off origin/master (skipping any that have uncommitted work),
 # then builds a single tmux session "fleet" with one window "agents"
-# containing up to 9 tiled panes (7 engine + 2 game if the game repo
-# is present) — each launching `claude` with the right model and the
-# matching role slash command in dry-run mode.
+# containing up to 8 tiled panes (7 engine + 1 game architect if the
+# game repo is present) — each launching `claude` with the right model
+# and the matching role slash command in dry-run mode.
 #
 # Source of truth: scripts/fleet/fleet-up in the engine repo.
 # Installed to ~/bin/fleet-up (as a symlink) by scripts/fleet/install.sh.
@@ -69,9 +69,9 @@ ensure_worktree() {
     echo "fleet-up: engine git fetch failed" >&2; exit 1; }
 
 ensure_worktree "$ENGINE" .claude/worktrees/opus-architect    fleet/opus-architect
-ensure_worktree "$ENGINE" .claude/worktrees/opus-worker       fleet/opus-worker
+ensure_worktree "$ENGINE" .claude/worktrees/opus-worker-1     fleet/opus-worker-1
+ensure_worktree "$ENGINE" .claude/worktrees/opus-worker-2     fleet/opus-worker-2
 ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-1    fleet/sonnet-fleet-1
-ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-2    fleet/sonnet-fleet-2
 ensure_worktree "$ENGINE" .claude/worktrees/sonnet-reviewer   fleet/sonnet-reviewer
 ensure_worktree "$ENGINE" .claude/worktrees/opus-reviewer     fleet/opus-reviewer
 ensure_worktree "$ENGINE" .claude/worktrees/queue-manager     fleet/queue-manager
@@ -80,10 +80,23 @@ if [[ -d "$GAME/.git" ]]; then
     (cd "$GAME" && git fetch origin --quiet) || {
         echo "fleet-up: game git fetch failed (continuing without game panes)" >&2; }
     ensure_worktree "$GAME" .claude/worktrees/game-architect  fleet/game-architect
-    ensure_worktree "$GAME" .claude/worktrees/game-sonnet     fleet/game-sonnet
 else
     echo "fleet-up: game repo not found at $GAME — skipping game panes"
 fi
+
+# Warn about legacy worktrees from the pre-restructure layout.
+# We don't auto-remove them (they may have uncommitted work) — just
+# point the human at them.
+warn_legacy_worktree() {
+    local wt="$1"
+    if [[ -d "$wt" ]]; then
+        echo "fleet-up: legacy worktree at $wt is no longer used."
+        echo "          remove with: git worktree remove $wt (after committing/stashing any work)"
+    fi
+}
+warn_legacy_worktree "$ENGINE/.claude/worktrees/opus-worker"
+warn_legacy_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-2"
+warn_legacy_worktree "$GAME/.claude/worktrees/game-sonnet"
 
 # ----------------------------------------------------------------------
 # Step 2: reset each worktree to a fresh branch off origin/master
@@ -115,18 +128,15 @@ reset_worktree() {
 }
 
 reset_worktree "$ENGINE/.claude/worktrees/opus-architect"  claude/opus-arch-scratch
-reset_worktree "$ENGINE/.claude/worktrees/opus-worker"     claude/opus-worker-scratch
+reset_worktree "$ENGINE/.claude/worktrees/opus-worker-1"   claude/opus-worker-1-scratch
+reset_worktree "$ENGINE/.claude/worktrees/opus-worker-2"   claude/opus-worker-2-scratch
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-1"  claude/sonnet-1-scratch
-reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-2"  claude/sonnet-2-scratch
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-reviewer" claude/sonnet-reviewer-scratch
 reset_worktree "$ENGINE/.claude/worktrees/opus-reviewer"   claude/opus-reviewer-scratch
 reset_worktree "$ENGINE/.claude/worktrees/queue-manager"   claude/queue-manager-scratch
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     reset_worktree "$GAME/.claude/worktrees/game-architect" claude/game-arch-scratch
-fi
-if [[ -d "$GAME/.claude/worktrees/game-sonnet" ]]; then
-    reset_worktree "$GAME/.claude/worktrees/game-sonnet" claude/game-sonnet-scratch
 fi
 
 # ----------------------------------------------------------------------
@@ -223,15 +233,12 @@ with open(settings_file, "w") as f:
 PYEOF
 }
 
-for wt in opus-architect opus-worker sonnet-fleet-1 sonnet-fleet-2 sonnet-reviewer opus-reviewer queue-manager; do
+for wt in opus-architect opus-worker-1 opus-worker-2 sonnet-fleet-1 sonnet-reviewer opus-reviewer queue-manager; do
     write_worktree_settings "$ENGINE/.claude/worktrees/$wt" "$ENGINE"
 done
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     write_worktree_settings "$GAME/.claude/worktrees/game-architect" "$GAME"
-fi
-if [[ -d "$GAME/.claude/worktrees/game-sonnet" ]]; then
-    write_worktree_settings "$GAME/.claude/worktrees/game-sonnet" "$GAME"
 fi
 
 # ----------------------------------------------------------------------
@@ -294,8 +301,8 @@ launch_cmd() {
 }
 
 # Single window, three rows:
-#   Top    (~32% height): autonomous workers (4 panes)  — small workspace
-#                         sonnet-fleet-1, sonnet-fleet-2, opus-worker, [game-sonnet]
+#   Top    (~32% height): autonomous workers (3 panes)  — small workspace
+#                         sonnet-fleet-1, opus-worker-1, opus-worker-2
 #   Middle (~40% height): architects (2 wide panes)     — interactive design
 #                         opus-architect, [game-architect] — biggest, most-used
 #   Bottom (~28% height): ops (3 panes)                 — small status panes
@@ -304,6 +311,12 @@ launch_cmd() {
 # The architect row is widest+tallest because it's where the human
 # spends interactive time. Workers and ops are autonomous loops you
 # only glance at.
+#
+# Worker mix: 2× opus-worker, 1× sonnet-fleet. Most engine work is
+# core/perf-sensitive (rendering, ECS, audio/video, math) which needs
+# Opus reasoning; one Sonnet pane covers tests, docs, and mechanical
+# refactors. The two opus-workers can plan + execute in parallel,
+# halving the planning queue latency.
 #
 # Navigate without a prefix key: Option+arrow (see ~/.tmux.conf).
 # Ctrl-a o = cycle next pane, Ctrl-a ; = jump to last-used pane.
@@ -369,27 +382,19 @@ if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
 fi
 
 # --- Expand Row 1 (top) with remaining workers -------------------------
-# Top row layout: 4 autonomous workers
-#   sonnet-fleet-1, sonnet-fleet-2, opus-worker, [game-sonnet]
+# Top row layout: 3 autonomous workers
+#   sonnet-fleet-1, opus-worker-1, opus-worker-2
 tmux split-window -h -t "$TOP1" \
-    -c "$ENGINE/.claude/worktrees/sonnet-fleet-2" \
-    "$(launch_cmd "$SONNET_MODEL" sonnet-author)"
+    -c "$ENGINE/.claude/worktrees/opus-worker-1" \
+    "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)"
 TOP2=$(active_pane_id)
-label_pane_id "$TOP2" "sonnet-fleet-2 [sonnet]"
+label_pane_id "$TOP2" "opus-worker-1 [opus 4.7]"
 
 tmux split-window -h -t "$TOP2" \
-    -c "$ENGINE/.claude/worktrees/opus-worker" \
+    -c "$ENGINE/.claude/worktrees/opus-worker-2" \
     "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)"
 TOP3=$(active_pane_id)
-label_pane_id "$TOP3" "opus-worker [opus 4.7]"
-
-if [[ -d "$GAME/.claude/worktrees/game-sonnet" ]]; then
-    tmux split-window -h -t "$TOP3" \
-        -c "$GAME/.claude/worktrees/game-sonnet" \
-        "$(launch_cmd "$SONNET_MODEL" game-sonnet)"
-    TOP4=$(active_pane_id)
-    label_pane_id "$TOP4" "game-sonnet [sonnet]"
-fi
+label_pane_id "$TOP3" "opus-worker-2 [opus 4.7]"
 
 # Enable pane border labels using @role (immune to program overrides)
 tmux set-option -t "$SESSION" pane-border-status top
@@ -404,13 +409,13 @@ fleet session created — mode: ${MODE}.
 attach with:  tmux attach -t ${SESSION}
 
 layout (single window, three rows):
-  top (~32%, 4 panes) — sonnet-fleet-1  sonnet-fleet-2  opus-worker  [game-sonnet]   (autonomous workers)
+  top (~32%, 3 panes) — sonnet-fleet-1  opus-worker-1  opus-worker-2                  (autonomous workers)
   middle (~40%, 2 panes, taller) — opus-architect  [game-architect]                  (interactive architects — biggest)
   bottom (~28%, 3 panes) — sonnet-reviewer  opus-reviewer  queue-manager             (ops)
 
 effort levels:
-  opus agents (architects, opus-worker, opus-reviewer) — max
-  sonnet agents (workers, reviewer, queue-manager) — high
+  opus agents (architects, opus-workers, opus-reviewer) — max
+  sonnet agents (worker, reviewer, queue-manager) — high
   override globally by exporting FLEET_EFFORT=<level> before fleet-up.
   (to change one pane, edit fleet-babysit's case statement — fleet-up
   does not thread env per-pane.)
@@ -433,9 +438,9 @@ the session if claude exits (crash, usage limit, network drop).
 
 scheduling (live mode): polling roles use Claude's /loop for managed intervals:
   sonnet-reviewer — /loop 3m     opus-reviewer — /loop 30m
-  opus-worker     — /loop 20m   queue-manager  — /loop 5m
-  authors — continuous (no /loop)
-  opus-architect — interactive (no /loop, human's design partner)
+  opus-worker-1/2 — /loop 20m    queue-manager — /loop 5m
+  sonnet-fleet-1  — continuous (no /loop)
+  opus-architect, game-architect — interactive (no /loop, human's design partners)
 
 logs: crash diagnostics written to ~/.fleet/logs/<role>.log
 


### PR DESCRIPTION
## Summary
- **Drop** `sonnet-fleet-2` and `game-sonnet` panes; **add** `opus-worker-2`.
- Final layout: 3 workers (sonnet-fleet-1 + opus-worker-1 + opus-worker-2), 2 architects (opus-architect + game-architect), 3 ops (sonnet-reviewer + opus-reviewer + queue-manager) = **8 panes**.
- Most engine work is core/perf-sensitive (rendering, ECS, audio/video, math); doubling Opus workers ~halves planning queue latency. One Sonnet pane keeps tests/docs/mechanical refactors moving.
- Game-architect (Opus, interactive) handles game-side work on demand. Cognitive separation preserved at the architect level (separate worktree, own role file). The autonomous game queue is intentionally empty until a worker pane is reintroduced.

## Files
- `scripts/fleet/fleet-up` — worktree creation/reset/settings + tmux layout updated; legacy-worktree warnings printed for removed worktrees (no auto-removal — could lose uncommitted work)
- `.claude/commands/role-opus-worker.md` — describe parallel pane setup, instruct agent to use its directory basename (`opus-worker-1` / `opus-worker-2`) as fleet-claim agent name
- `scripts/fleet/fleet-babysit` — example comment updated
- `docs/AGENT_FLEET_SETUP.md` — worktree table, manual-bootstrap commands, verification text

## Test plan
- [ ] `fleet-up dry-run` brings up exactly 8 panes (3 top, 2 middle, 3 bottom) on a machine with the game repo present
- [ ] Without the game repo, brings up 7 panes (no game-architect pane)
- [ ] Re-running `fleet-up` after the previous fleet has been killed prints legacy warnings for any leftover `opus-worker` / `sonnet-fleet-2` / `game-sonnet` worktrees, but does not error
- [ ] Both opus-worker panes can plan and execute tasks in parallel without claiming the same task (atomic `fleet-claim` lock)
- [ ] Opus-worker agent prints its worktree basename when claiming (e.g. `claimed: T-020 (slug: t-020, agent: opus-worker-1)`)

## Notes for reviewer
- The two opus-worker tmux panes share the same `/role-opus-worker` slash command; the agent identifies its pane via `pwd` basename. Cooperation is purely through `fleet-claim` atomic mkdir locks + open-PR cross-checks.
- `TASKS.md` still has `Owner: sonnet-fleet-2` on a couple of T-NNN entries from earlier ingestion. Those are stale attribution hints, not load-bearing — pickup is by `fleet-claim` lock + open-PR scan, not the Owner field. Queue-manager will refresh them on its next maintenance pass. **Not included in this PR** to avoid TASKS.md merge conflicts with parallel author PRs (per CLAUDE.md rule: only queue-manager edits TASKS.md).
- Companion change in the game repo (delete `creations/game/.claude/commands/role-game-sonnet.md`) coming as a separate PR on `jakildev/irreden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)