### PR TITLE
fleet: add fleet-down + auto-attach for fleet-up live

### DIFF
--- a/scripts/fleet/README.md
+++ b/scripts/fleet/README.md
@@ -5,20 +5,26 @@ fleet workflow.
 
 ## Files
 
-- **`fleet-up`** — brings the 7-pane tmux fleet online. Idempotent.
+- **`fleet-up`** — brings the 8-pane tmux fleet online. Idempotent.
   Creates any missing worktrees, resets each to a fresh branch off
   `origin/master`, builds a `fleet` tmux session with one tiled
   window, and auto-launches `claude` in each pane with the matching
   role slash command. Default mode is `dry-run` (startup + stand-by);
-  pass `live` to skip dry-run and go straight to the normal loop.
-- **`install.sh`** — one-time setup per machine. Symlinks
-  `scripts/fleet/fleet-up` into `~/bin/fleet-up` and symlinks each
+  `fleet-up live` skips dry-run, goes straight to the normal loop, and
+  auto-attaches the tmux session. Pass `--no-attach` to opt out of
+  the attach (CI / headless runs).
+- **`fleet-down`** — graceful shutdown of the fleet. Sends Ctrl-C +
+  "exit" to each pane, waits a short grace period, then kills the
+  tmux session and clears stale fleet-claim locks. `--force` skips
+  the graceful step; `--keep-claims` preserves `~/.fleet/claims`.
+- **`install.sh`** — one-time setup per machine. Symlinks every
+  `scripts/fleet/fleet-*` script into `~/bin/` and symlinks each
   `.claude/commands/role-*.md` into `~/.claude/commands/`. Picks up
   the game-architect role from `creations/game/` if that repo is
   cloned. Warns (but does not edit) if `~/bin` is not on PATH.
   Idempotent — re-run after every `git pull` that touches fleet tooling.
 
-Both files are portable across Linux (WSL/Ubuntu) and macOS. Neither
+All files are portable across Linux (WSL/Ubuntu) and macOS. None
 requires sudo.
 
 ## Quick start
@@ -27,8 +33,12 @@ requires sudo.
 cd ~/src/IrredenEngine
 scripts/fleet/install.sh
 # (follow the PATH warning if ~/bin isn't on PATH yet)
-fleet-up dry-run
-tmux attach -t fleet
+fleet-up dry-run                # dry run — confirms panes spawn cleanly
+# ...inspect, then promote each pane manually, or:
+fleet-down                      # shut down before going live
+fleet-up live                   # full loop, auto-attaches
+# Ctrl-a d to detach without killing the fleet.
+fleet-down                      # graceful shutdown when done for the day.
 ```
 
 ## Updating the fleet across machines

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# fleet-down — bring the Irreden Engine + Game agent fleet down.
+#
+# Counterpart to fleet-up. Sends an "exit" cue to each pane, waits a
+# short grace period for in-flight work to drain, kills the tmux
+# session, and clears stale fleet-claim locks so the next fleet-up
+# starts from a clean slate.
+#
+# Usage:
+#   fleet-down                  graceful: send Ctrl-C + "exit", wait, kill
+#   fleet-down --force          immediate: kill the session, no grace
+#   fleet-down --keep-claims    don't wipe ~/.fleet/claims (default: wipe)
+#
+# Why not just `tmux kill-session`?
+#   - Each pane runs `fleet-babysit`, which itself runs `claude`. A bare
+#     SIGTERM aborts whatever the agent was doing mid-step (mid-build,
+#     mid-edit, mid-PR-create) without giving it a chance to push
+#     uncommitted work or release its claim. Graceful shutdown sends
+#     Ctrl-C + "exit" first so the agent can wind down its current
+#     loop iteration before the session dies.
+#   - Stale claims persist in ~/.fleet/claims after a hard kill, which
+#     blocks the next fleet from picking up the same tasks. Wipe by
+#     default (the next fleet-up does this anyway, but doing it here
+#     too makes the system "clean" between runs).
+#
+# Source of truth: scripts/fleet/fleet-down in the engine repo.
+# Installed to ~/bin/fleet-down by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+SESSION="fleet"
+GRACE_SECONDS=8       # how long to wait for panes to wind down after Ctrl-C
+FORCE=0
+KEEP_CLAIMS=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --force)        FORCE=1 ;;
+        --keep-claims)  KEEP_CLAIMS=1 ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *) echo "fleet-down: unknown argument '$arg'" >&2; exit 2 ;;
+    esac
+done
+
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "fleet-down: tmux not found." >&2
+    exit 1
+fi
+
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "fleet-down: no '$SESSION' tmux session is running. Nothing to do."
+    exit 0
+fi
+
+# ----------------------------------------------------------------------
+# Step 1: graceful shutdown (unless --force)
+# ----------------------------------------------------------------------
+#
+# Send Ctrl-C to interrupt whatever each pane is doing right now,
+# then send "exit" + Enter to take the surrounding shell down so
+# fleet-babysit's resume loop also dies cleanly. tmux kill-session
+# afterwards is the safety net.
+
+if [[ "$FORCE" -eq 0 ]]; then
+    pane_count=$(tmux list-panes -t "$SESSION" -F '#{pane_id}' | wc -l | tr -d ' ')
+    echo "fleet-down: sending graceful shutdown to $pane_count pane(s)..."
+
+    # Ctrl-C every pane to interrupt the current claude/babysit operation.
+    while IFS= read -r pane_id; do
+        tmux send-keys -t "$pane_id" C-c
+    done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
+
+    # Brief pause so signal handlers in claude/babysit have time to
+    # tear down (release any in-flight write file handles, finalize
+    # the current stream-json line, etc.).
+    sleep 2
+
+    # Send "exit" + Enter so the surrounding shell terminates and
+    # fleet-babysit doesn't auto-resume.
+    while IFS= read -r pane_id; do
+        tmux send-keys -t "$pane_id" "exit" Enter
+    done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
+
+    echo "fleet-down: waiting ${GRACE_SECONDS}s for panes to wind down..."
+    sleep "$GRACE_SECONDS"
+else
+    echo "fleet-down: --force — skipping graceful shutdown."
+fi
+
+# ----------------------------------------------------------------------
+# Step 2: kill the tmux session
+# ----------------------------------------------------------------------
+
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+    tmux kill-session -t "$SESSION"
+    echo "fleet-down: killed tmux session '$SESSION'."
+else
+    echo "fleet-down: tmux session '$SESSION' already gone (graceful exit completed)."
+fi
+
+# ----------------------------------------------------------------------
+# Step 3: clear stale claims (unless --keep-claims)
+# ----------------------------------------------------------------------
+#
+# Even after a graceful shutdown, agents that were mid-task won't have
+# released their fleet-claim locks. Wipe them so the next fleet-up
+# starts clean. (fleet-up itself also does this in step 3b, so this
+# is belt-and-suspenders, but keeping the system "clean between runs"
+# is a useful invariant for the human eyeballing ~/.fleet/claims.)
+
+if [[ "$KEEP_CLAIMS" -eq 0 ]]; then
+    if command -v fleet-claim >/dev/null 2>&1; then
+        fleet-claim clear-all
+    else
+        echo "fleet-down: fleet-claim not found — skipping claim cleanup"
+    fi
+else
+    echo "fleet-down: --keep-claims — leaving ~/.fleet/claims intact."
+fi
+
+echo
+echo "fleet-down: done. Bring the fleet back up with:  fleet-up live"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -275,8 +275,23 @@ mkdir -p "$HOME/.fleet/plans"
 # Default mode: dry-run. The agents do their startup actions and then
 # stand by for human instruction. Promote a pane to full operation by
 # typing in it: "you can stop dry-run mode and start working".
+#
+# Argument parsing:
+#   fleet-up [mode] [--no-attach]
+#     mode = dry-run | live (default: dry-run)
+#     --no-attach: skip the auto-attach (live mode only). Useful for
+#                  headless runs / CI / tests that just need the panes
+#                  spawned but don't want to attach.
 
-MODE="${1:-dry-run}"
+MODE="dry-run"
+ATTACH_LIVE=1   # in live mode, attach to the tmux session at the end
+for arg in "$@"; do
+    case "$arg" in
+        dry-run|live) MODE="$arg" ;;
+        --no-attach)  ATTACH_LIVE=0 ;;
+        *) echo "fleet-up: unknown argument '$arg'" >&2; exit 2 ;;
+    esac
+done
 
 launch_cmd() {
     # $1 = model alias (opus|sonnet), $2 = role slug (without role- prefix)
@@ -440,6 +455,21 @@ scheduling (live mode): polling roles use Claude's /loop for managed intervals:
 logs: crash diagnostics written to ~/.fleet/logs/<role>.log
 
 other modes you can pass to fleet-up:
-  fleet-up dry-run   # default — startup + stand-by
-  fleet-up live      # full loop from the start (use after a clean dry run)
+  fleet-up dry-run               # default — startup + stand-by, no auto-attach
+  fleet-up live                  # full loop from the start, auto-attaches tmux
+  fleet-up live --no-attach      # full loop, leave detached (CI / headless)
+
+graceful shutdown:
+  fleet-down                     # graceful: send "exit", wait, kill, clear claims
+  fleet-down --force             # immediate: just kill the tmux session
 EOF
+
+# In live mode, attach to the tmux session so the user lands in the
+# fleet without a separate `tmux attach`. dry-run mode leaves the
+# session detached so the user can confirm panes spawned cleanly
+# before opting in.
+if [[ "$MODE" == "live" && "$ATTACH_LIVE" -eq 1 ]]; then
+    echo
+    echo "fleet-up: attaching to tmux session 'fleet' (Ctrl-a d to detach)..."
+    exec tmux attach-session -t "$SESSION"
+fi

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -62,6 +62,8 @@ fi
 
 FLEET_UP_SRC="$SCRIPT_DIR/fleet-up"
 FLEET_UP_DEST="$HOME/bin/fleet-up"
+FLEET_DOWN_SRC="$SCRIPT_DIR/fleet-down"
+FLEET_DOWN_DEST="$HOME/bin/fleet-down"
 FLEET_CLAIM_SRC="$SCRIPT_DIR/fleet-claim"
 FLEET_CLAIM_DEST="$HOME/bin/fleet-claim"
 FLEET_BUILD_SRC="$SCRIPT_DIR/fleet-build"
@@ -79,7 +81,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -92,6 +94,11 @@ done
 mkdir -p "$HOME/bin"
 ln -sf "$FLEET_UP_SRC" "$FLEET_UP_DEST"
 echo "symlinked $FLEET_UP_DEST -> $FLEET_UP_SRC"
+
+if [[ -f "$FLEET_DOWN_SRC" ]]; then
+    ln -sf "$FLEET_DOWN_SRC" "$FLEET_DOWN_DEST"
+    echo "symlinked $FLEET_DOWN_DEST -> $FLEET_DOWN_SRC"
+fi
 
 if [[ -f "$FLEET_CLAIM_SRC" ]]; then
     ln -sf "$FLEET_CLAIM_SRC" "$FLEET_CLAIM_DEST"


### PR DESCRIPTION
## Summary
Two small ergonomics on top of the fleet orchestration:

**1. `fleet-up live` auto-attaches the tmux session.**
Single command takes you from "no fleet" to "attached to live panes". Dry-run mode keeps the old detached behavior so you can confirm panes spawned cleanly before committing. New `--no-attach` flag opts out for headless / CI use.

**2. New `fleet-down` command for graceful shutdown.**
```
fleet-down                # Ctrl-C every pane, send "exit", wait, kill session, wipe claims
fleet-down --force        # skip the graceful step
fleet-down --keep-claims  # don't wipe ~/.fleet/claims
```

## Why graceful?
Each pane runs `fleet-babysit` → `claude`. A bare `tmux kill-session` aborts agents mid-edit / mid-PR without giving them a chance to finalize. Sending Ctrl-C + "exit" first lets babysit's resume loop terminate cleanly, then the session kill is a safety net.

Stale `fleet-claim` locks are wiped by default — agents killed mid-task don't release their own locks, and leaving them blocks the next fleet from picking up the same tasks. (`fleet-up` step 3b already does this on startup, but doing it on shutdown too keeps `~/.fleet/claims` clean between runs.)

## Files
- `scripts/fleet/fleet-up` — argument parsing extended to accept `--no-attach`; `exec tmux attach-session` at the end when `MODE=live` and `--no-attach` not set
- `scripts/fleet/fleet-down` — new script (graceful shutdown)
- `scripts/fleet/install.sh` — symlinks `fleet-down` into `~/bin/`
- `scripts/fleet/README.md` — updated quick-start with `fleet-up live` / `fleet-down` flow

## Test plan
- [ ] `fleet-up dry-run` works exactly as before — startup, no auto-attach, exits cleanly
- [ ] `fleet-up live` brings up panes, then auto-attaches (Ctrl-a d to detach)
- [ ] `fleet-up live --no-attach` brings up live, leaves detached (verifiable via `tmux ls`)
- [ ] `fleet-down` (no args, with a fleet running) sends Ctrl-C to all panes, waits ~10s, kills session, wipes `~/.fleet/claims`
- [ ] `fleet-down --force` immediately kills without waiting
- [ ] `fleet-down --keep-claims` leaves `~/.fleet/claims` intact
- [ ] `fleet-down` (no fleet running) prints "no fleet session, nothing to do" and exits 0
- [ ] After `install.sh`, `which fleet-down` finds it on PATH
- [ ] `fleet-up live` followed immediately by Ctrl-a d, then `fleet-down`, then `fleet-up live` works (idempotent cycle)

## Notes for reviewer
- Ran `bash -n` on all three scripts — no syntax errors. Did NOT run `fleet-down` against the live fleet (would have killed user's session).
- `GRACE_SECONDS=8` is conservative; bump to 12-15 if real testing shows agents need more time to wind down. On the upper bound, fleet-down's total wall time should still be well under a minute.
- Architect session resume + `fleet-down --wait` + `fleet-down --summary` are coming as a separate PR (more involved, want this one to land first as the foundation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)