### PR TITLE
fleet: architect session resume + fleet-down --wait/--summary

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -82,15 +82,61 @@ rotate_log() {
 
 log "starting ($MODEL effort=$EFFORT) mode=$MODE loop=${LOOP_INTERVAL:-none} in $(pwd)"
 
+# --- Cross-restart session resume (architects only) ------------------------
+#
+# Architects (opus-architect, game-architect) are the human's interactive
+# design partners — their conversation context is the most valuable
+# state in the fleet. Other roles (workers, reviewers, queue-manager)
+# are loop-based and benefit from a fresh start each iteration.
+#
+# To preserve architect context across `fleet-down` -> `fleet-up`
+# cycles, we save a stable session UUID per architect role to
+# ~/.fleet/sessions/<role>.session-id. On first launch, generate the
+# UUID and pass --session-id; on subsequent launches, use --resume
+# instead of re-firing the role slash command.
+#
+# fleet-down does NOT delete these files — that's how resume survives
+# restarts. To reset an architect's context (start fresh next time),
+# delete ~/.fleet/sessions/<role>.session-id manually.
+
+SESSIONS_DIR="$HOME/.fleet/sessions"
+mkdir -p "$SESSIONS_DIR"
+SESSION_FILE="$SESSIONS_DIR/$ROLE.session-id"
+
+# Architects qualify for cross-restart resume; everyone else gets a
+# fresh session each fleet-up.
+ARCHITECT_RESUME=0
+case "$ROLE" in
+    *architect*) ARCHITECT_RESUME=1 ;;
+esac
+
 # --- First run: send the role slash command --------------------------------
 # If a loop interval is set and mode is live, wrap the role invocation in
 # /loop so Claude's runtime handles the scheduling (replaces sleep-based
 # polling and external tmux timers).
-if [[ -n "$LOOP_INTERVAL" && "$MODE" == "live" ]]; then
+
+if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
+    SESSION_ID=$(cat "$SESSION_FILE")
+    log "resuming architect session $SESSION_ID (preserved across fleet restart)"
+    claude --model "$MODEL" --effort "$EFFORT" --resume "$SESSION_ID" \
+        "fleet just restarted. resume our previous conversation; you don't need to re-run your startup banner. tell me what you were last working on so we can continue."
+elif [[ -n "$LOOP_INTERVAL" && "$MODE" == "live" ]]; then
     log "using /loop $LOOP_INTERVAL for scheduling"
     claude --model "$MODEL" --effort "$EFFORT" "/loop $LOOP_INTERVAL /role-$ROLE"
 else
-    claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
+    if [[ "$ARCHITECT_RESUME" -eq 1 ]]; then
+        # Generate and persist a stable session ID so subsequent
+        # fleet-ups can resume this conversation. Persist BEFORE
+        # launching claude — if claude crashes during startup, we
+        # still want the next fleet-up to try resuming.
+        SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())')
+        echo "$SESSION_ID" > "$SESSION_FILE"
+        log "starting architect session $SESSION_ID (saved to $SESSION_FILE)"
+        claude --model "$MODEL" --effort "$EFFORT" --session-id "$SESSION_ID" \
+            "/role-$ROLE $MODE"
+    else
+        claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
+    fi
 fi
 last_exit=$?
 
@@ -135,6 +181,14 @@ while true; do
     esac
 
     log "resuming session (attempt $attempt)..."
-    claude --model "$MODEL" --effort "$EFFORT" --continue "resume your work from where you left off"
+    if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
+        # Resume the specific persisted session (not "most recent in
+        # cwd"), so a stray manual claude run in this cwd can't
+        # accidentally hijack the architect's session.
+        claude --model "$MODEL" --effort "$EFFORT" --resume "$(cat "$SESSION_FILE")" \
+            "resume your work from where you left off"
+    else
+        claude --model "$MODEL" --effort "$EFFORT" --continue "resume your work from where you left off"
+    fi
     last_exit=$?
 done

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -10,6 +10,19 @@
 #   fleet-down                  graceful: send Ctrl-C + "exit", wait, kill
 #   fleet-down --force          immediate: kill the session, no grace
 #   fleet-down --keep-claims    don't wipe ~/.fleet/claims (default: wipe)
+#   fleet-down --wait           wait for active fleet-claim locks to drain
+#                               before shutting down (poll every 30s, cap
+#                               at WAIT_MAX_SECONDS)
+#   fleet-down --summary        ask each pane to write a session summary
+#                               to ~/.fleet/summaries/<timestamp>/<role>.md
+#                               before exiting; useful for "what snags did
+#                               we hit today" retros
+#
+# Architect session resume (preserved across down/up cycles): each
+# architect role's session ID is saved in ~/.fleet/sessions/. fleet-down
+# does NOT delete those files, so the next fleet-up can resume the
+# architect conversations. Delete ~/.fleet/sessions/<role>.session-id
+# manually to force a fresh architect session next time.
 #
 # Why not just `tmux kill-session`?
 #   - Each pane runs `fleet-babysit`, which itself runs `claude`. A bare
@@ -29,16 +42,23 @@
 set -euo pipefail
 
 SESSION="fleet"
-GRACE_SECONDS=8       # how long to wait for panes to wind down after Ctrl-C
+GRACE_SECONDS=8           # how long to wait for panes to wind down after Ctrl-C
+WAIT_POLL_SECONDS=30      # how often to check for idle when --wait is set
+WAIT_MAX_SECONDS=1800     # cap --wait at 30 min (humans can re-run with --force)
+SUMMARY_WAIT_SECONDS=60   # how long to give panes to write their summaries
 FORCE=0
 KEEP_CLAIMS=0
+WAIT_FOR_IDLE=0
+WANT_SUMMARY=0
 
 for arg in "$@"; do
     case "$arg" in
         --force)        FORCE=1 ;;
         --keep-claims)  KEEP_CLAIMS=1 ;;
+        --wait)         WAIT_FOR_IDLE=1 ;;
+        --summary)      WANT_SUMMARY=1 ;;
         -h|--help)
-            sed -n '2,30p' "$0"
+            sed -n '2,40p' "$0"
             exit 0
             ;;
         *) echo "fleet-down: unknown argument '$arg'" >&2; exit 2 ;;
@@ -53,6 +73,92 @@ fi
 if ! tmux has-session -t "$SESSION" 2>/dev/null; then
     echo "fleet-down: no '$SESSION' tmux session is running. Nothing to do."
     exit 0
+fi
+
+# ----------------------------------------------------------------------
+# Step 0a: --wait — block until active fleet-claim locks drain
+# ----------------------------------------------------------------------
+#
+# An active claim means a worker is mid-task (mid-build, mid-edit,
+# mid-PR-create). If we kill it, the local commits and partial work
+# are lost (work is on the worktree's filesystem; only what's pushed
+# survives). Waiting for the worker to release its claim — which
+# happens after `commit-and-push` succeeds and the WIP label is
+# removed — gives in-flight work a chance to land cleanly.
+#
+# We poll fleet-claim list (filtering out _stack_* metadata dirs).
+# When the count drops to zero, all workers are between tasks and
+# safe to shut down.
+
+count_active_claims() {
+    if ! command -v fleet-claim >/dev/null 2>&1; then
+        echo 0
+        return
+    fi
+    local out
+    out=$(fleet-claim list 2>/dev/null || true)
+    if echo "$out" | grep -q "no active claims"; then
+        echo 0
+        return
+    fi
+    # Each non-empty, non-header line is one active claim.
+    echo "$out" | grep -v "^$" | wc -l | tr -d ' '
+}
+
+if [[ "$WAIT_FOR_IDLE" -eq 1 ]]; then
+    deadline=$(( $(date +%s) + WAIT_MAX_SECONDS ))
+    echo "fleet-down --wait: waiting for active claims to drain (max ${WAIT_MAX_SECONDS}s, polling every ${WAIT_POLL_SECONDS}s)"
+    while [[ $(date +%s) -lt $deadline ]]; do
+        n=$(count_active_claims)
+        if [[ "$n" -eq 0 ]]; then
+            echo "fleet-down --wait: all claims released. Proceeding."
+            break
+        fi
+        echo "fleet-down --wait: $n active claim(s); rechecking in ${WAIT_POLL_SECONDS}s..."
+        sleep "$WAIT_POLL_SECONDS"
+    done
+    if [[ $(date +%s) -ge $deadline ]]; then
+        n=$(count_active_claims)
+        echo "fleet-down --wait: deadline reached with $n claim(s) still held. Proceeding to graceful shutdown anyway."
+    fi
+fi
+
+# ----------------------------------------------------------------------
+# Step 0b: --summary — request per-pane session summaries
+# ----------------------------------------------------------------------
+#
+# Send a Write-tool prompt to each pane asking it to record what it
+# worked on, what snags it hit, and what could improve. We collect
+# these in ~/.fleet/summaries/<timestamp>/<role>.md so the human can
+# review them after the fleet is down.
+#
+# The summaries are best-effort — if an agent is mid-iteration and
+# can't acknowledge in time, we skip it and proceed. SUMMARY_WAIT_SECONDS
+# bounds the total wait.
+
+SUMMARY_DIR=""
+if [[ "$WANT_SUMMARY" -eq 1 ]]; then
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    SUMMARY_DIR="$HOME/.fleet/summaries/$timestamp"
+    mkdir -p "$SUMMARY_DIR"
+    echo "fleet-down --summary: requesting per-pane summaries to $SUMMARY_DIR/"
+
+    while IFS= read -r pane_id; do
+        # Read the pane's @role label (set by fleet-up); fall back to
+        # the pane index if @role isn't set.
+        role=$(tmux show-options -t "$pane_id" -p -v @role 2>/dev/null | awk '{print $1}')
+        [[ -z "$role" ]] && role="pane-${pane_id#%}"
+        summary_file="$SUMMARY_DIR/$role.md"
+        prompt="Before exiting: use the Write tool to save a short session summary to $summary_file. Cover (1) what tasks/PRs you worked on this session, (2) any snags, surprises, or ergonomics issues that the human might want to fix in the fleet tooling, (3) anything left blocked or waiting. Keep under 500 words. Markdown headings welcome. Then continue your normal exit flow."
+        tmux send-keys -t "$pane_id" "$prompt" Enter
+    done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
+
+    echo "fleet-down --summary: waiting up to ${SUMMARY_WAIT_SECONDS}s for panes to write..."
+    sleep "$SUMMARY_WAIT_SECONDS"
+
+    # Report what landed.
+    written=$(find "$SUMMARY_DIR" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+    echo "fleet-down --summary: $written summary file(s) written to $SUMMARY_DIR/"
 fi
 
 # ----------------------------------------------------------------------
@@ -122,4 +228,11 @@ else
 fi
 
 echo
+if [[ -n "$SUMMARY_DIR" ]]; then
+    echo "fleet-down: session summaries in $SUMMARY_DIR/"
+fi
+if [[ -d "$HOME/.fleet/sessions" ]] && find "$HOME/.fleet/sessions" -maxdepth 1 -name '*.session-id' | grep -q .; then
+    echo "fleet-down: architect session IDs preserved in ~/.fleet/sessions/."
+    echo "            next fleet-up will resume those conversations automatically."
+fi
 echo "fleet-down: done. Bring the fleet back up with:  fleet-up live"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -461,7 +461,15 @@ other modes you can pass to fleet-up:
 
 graceful shutdown:
   fleet-down                     # graceful: send "exit", wait, kill, clear claims
+  fleet-down --wait              # wait for active claims to drain first
+  fleet-down --summary           # ask each pane to write a session summary
   fleet-down --force             # immediate: just kill the tmux session
+
+architect session resume:
+  ~/.fleet/sessions/<role>.session-id is preserved across fleet-down/up
+  cycles. opus-architect and game-architect will resume their previous
+  conversation on the next fleet-up. To force a fresh architect session
+  next time, delete the corresponding .session-id file.
 EOF
 
 # In live mode, attach to the tmux session so the user lands in the


### PR DESCRIPTION
## Summary
Stack PR on top of #204. Adds three orchestration features:

**1. Architect session resume across `fleet-down`/`fleet-up` cycles.**
- `fleet-babysit` persists per-architect session UUIDs to `~/.fleet/sessions/<role>.session-id`.
- First launch: generates UUID, passes `--session-id` to claude.
- Subsequent launches: uses `--resume <uuid>` instead of re-firing the role slash command, so the architect picks up the prior conversation.
- Workers/reviewers/queue-manager excluded — they're loop-driven and benefit from a fresh start.
- `fleet-down` does NOT delete `~/.fleet/sessions/`, so resume survives restarts. Delete a `.session-id` file manually to force a fresh architect session next time.
- The in-fleet resume loop also switches to `--resume <uuid>` for architects (was `--continue`), preventing a stray manual `claude` run in the same cwd from accidentally hijacking the architect's session.

**2. `fleet-down --wait`**
- Polls `fleet-claim list` every 30s; proceeds only once all worker locks have drained.
- Capped at 30 minutes; falls through after that (human can override with `--force`).
- Motivation: a worker mid-task has local commits that haven't pushed yet. Killing loses that work. `--wait` lets the worker finish `commit-and-push` and release the claim before shutdown.

**3. `fleet-down --summary`**
- Sends a `Write` prompt to each pane asking it to record what it worked on, what snags it hit, and what could improve.
- Collects summaries in `~/.fleet/summaries/<timestamp>/<role>.md`.
- Best-effort: agents mid-iteration may not acknowledge in time; their summary file just won't exist.
- Useful for end-of-day retros: "what slowed the fleet down today?"

## Stacked on #204
This branch is **stacked on `claude/fleet-orchestration-basics`** (PR #204). The PR target is that branch (not `master`) so the diff shows only the PR C-specific changes. **Merge #204 first**, then this PR's base will auto-retarget to `master` and it will be mergeable.

If you'd rather review them as one PR, close this one and tell me — I can fold both commits into a single PR.

## Files
- `scripts/fleet/fleet-babysit` — `~/.fleet/sessions/<role>.session-id` lifecycle, architect-only resume logic for both first launch and the in-fleet resume loop
- `scripts/fleet/fleet-down` — `--wait` (poll fleet-claim list), `--summary` (per-pane Write prompt + collect), final-message updates
- `scripts/fleet/fleet-up` — help text mentions new fleet-down flags + architect session resume

## Test plan
- [ ] `fleet-up live` — first launch: each architect pane logs `starting architect session <uuid> (saved to ...)` and `~/.fleet/sessions/opus-architect.session-id` and `~/.fleet/sessions/game-architect.session-id` exist
- [ ] `fleet-down` then `fleet-up live` — each architect pane logs `resuming architect session <uuid> (preserved across fleet restart)` and the architect picks up its prior conversation
- [ ] `rm ~/.fleet/sessions/opus-architect.session-id; fleet-up live` — opus-architect starts a brand new session, generates a new UUID; game-architect still resumes
- [ ] `fleet-down --wait` while a worker is mid-task — fleet-down polls every 30s and only proceeds after the worker releases its claim. Hit Ctrl-C in fleet-down to abort the wait if needed.
- [ ] `fleet-down --summary` — each pane writes (or attempts to write) `~/.fleet/summaries/<timestamp>/<role>.md`. Final fleet-down output reports the count.
- [ ] `fleet-down --wait --summary` — both flags compose; --wait runs first, then --summary, then graceful kill.
- [ ] An architect pane that crashes mid-conversation can be `--continue`'d manually (the session-id file is the source of truth, not "most recent in cwd").

## Notes for reviewer
- Did NOT actually run `fleet-down` against the live fleet (would have killed the user's session). Only `bash -n` syntax-checked.
- The resume prompt for architects is a single line: "fleet just restarted. resume our previous conversation; ... tell me what you were last working on". Tune if it feels off in practice.
- `~/.fleet/summaries/` directory layout has one timestamp dir per fleet-down call. Old summaries accumulate — no auto-pruning. If this becomes noisy, add `find ~/.fleet/summaries -mtime +30 -delete` to fleet-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)