### PR TITLE
fleet: aggressive nit-fixing cycle, new fleet:has-nits label

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -127,18 +127,28 @@ When you do pick a task:
    "what's next?" — but the reset itself is non-negotiable, even in
    interactive mode.
 8. **Check for feedback labels on open PRs** before picking new work:
-   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "fleet:needs-fix")) | "#\(.number) \(.title)"'`
+   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "#\(.number) \(.title)"'`
    **Skip** PRs labeled `human:wip` — human is working on it directly.
-   If any PR has `human:needs-fix` or `fleet:needs-fix`:
+
+   **Priority order**: `human:needs-fix` > `fleet:needs-fix` > `fleet:has-nits`.
+   `fleet:has-nits` means the PR is approved but the reviewer flagged
+   optional improvements that should land before merge — address them.
+
+   If any PR has `human:needs-fix`, `fleet:needs-fix`, or `fleet:has-nits`:
    a. Read ALL comments:
       `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // "general")] \(.body)"'`
       `gh api repos/jakildev/IrredenEngine/pulls/<N>/reviews --jq '.[] | select(.body != "") | .body'`
+      For `fleet:has-nits`: focus on the latest review's `### Nits`
+      section.
    b. Remove the feedback label immediately:
-      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "fleet:needs-fix"`
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits"`
    c. Address every piece of feedback. Build with `fleet-build`.
    d. Push fixes using `commit-and-push`.
-   e. If it was `human:needs-fix`, add `fleet:changes-made`:
-      `gh pr edit <N> --add-label "fleet:changes-made"`
+   e. Response label:
+      - `human:needs-fix` → add `fleet:changes-made`:
+        `gh pr edit <N> --add-label "fleet:changes-made"`
+      - `fleet:needs-fix` / `fleet:has-nits` → no response label
+        needed; existing `fleet:approved` (if present) stays valid.
       `gh pr comment <N> --body "Addressed feedback: <summary>"`
 
 If Mode above is `dry-run`: do **only** the startup actions. Do not pick

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -131,19 +131,36 @@ Each invocation is one iteration — do the work, then exit cleanly:
    f. **Set the PR label** to match your verdict (add `--repo
       <game-repo>` for game PRs). The label is the primary signal
       the human uses. Always remove stale labels first:
-      `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
+      `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:approved"`
       (swap the label name for needs-fix or blocker as appropriate).
+      - Verdict approve, no Nits section → `fleet:approved` only
+      - Verdict approve WITH a non-empty `### Nits` section → BOTH
+        `fleet:approved` AND `fleet:has-nits` (the latter tells the
+        author worker to clean up the nits before the human merges)
+      - Verdict needs-fix → `fleet:needs-fix`
+      - Verdict blocker → `fleet:blocker`
 
-   **Nits vs real issues:**
-   - **Approve with nits.** If the only remaining findings are cosmetic
-     (naming style, comment wording, formatting), approve the PR and
-     list nits as suggestions under `### Nits (optional)`. Do NOT
-     block the PR for these — the human decides whether to address them.
-   - **Needs-fix** is for substantive issues only: correctness bugs,
+   **Nits vs real issues — the bright line:**
+   - **Approve with nits** is fine for genuinely-optional improvements
+     (naming, wording, formatting, optional asserts, follow-up
+     refactor opportunities). Add `fleet:has-nits` so the author
+     worker cleans them up before the human merges. The author now
+     treats `fleet:has-nits` as actionable, so put real nits in the
+     Nits section freely.
+   - **The contradiction "approve, but please fix X before merge" is
+     forbidden.** If a finding is described as "must resolve before
+     merge", "safe to merge once X is resolved", "the comment and code
+     must agree", or anything implying the merge depends on it — that
+     is by definition a `needs-fix`, not a Nit. Move it to the
+     Needs-fix section and drop the verdict to `needs-fix`.
+   - **Needs-fix** is for substantive issues: correctness bugs,
      invariant violations, lifetime/ownership mistakes, missing
-     synchronization, performance regressions, or unsafe API use.
-   - Opus budget is expensive. Don't spend it requesting a second
-     round-trip over a renamed variable. When in doubt, approve.
+     synchronization, performance regressions, unsafe API use, or any
+     nit that is actually a pre-merge requirement.
+   - Opus budget is expensive. Don't spend it requesting a full
+     re-review round over a renamed variable. When in doubt about a
+     borderline finding, prefer `fleet:has-nits` over `fleet:needs-fix`
+     — the author addresses nits aggressively now, no re-review needed.
 3. **Reset to scratch branch.** After reviewing all candidates (or if
    none existed), return to the scratch branch so no PR branch is left
    checked out — other agents may need to check out the same branch:

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -83,19 +83,27 @@ The `/loop` driver re-invokes this role every 20 minutes in live mode.
 Each invocation is one iteration — do the work, then exit cleanly:
 
 1. **Check for feedback labels on open PRs.**
-   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
+   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
 
    **Skip** PRs labeled `human:wip` — human is working on it directly.
 
-   If any PR has `human:needs-fix`, `human:blocker`, or `fleet:needs-fix`,
-   address the **oldest** one first. Human feedback takes priority.
+   **Priority order** (address one PR per iteration, oldest within each tier):
+   1. `human:needs-fix` / `human:blocker` — human review feedback, top priority
+   2. `fleet:needs-fix` — fleet review wants concrete fixes before merge
+   3. `fleet:has-nits` — PR is approved, but the reviewer flagged optional
+      improvements that should land before merge to keep code quality high.
+      The cost of a fix-and-push iteration is tiny vs merging with known
+      smells. Address every nit unless it's purely subjective preference.
 
    For each flagged PR:
    a. Read **all** feedback (two separate commands):
       `gh pr view <N> --comments`
       `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // .original_line)] \(.body)"'`
+
+      **For `fleet:has-nits`**: focus on the latest review's `### Nits`
+      section. Address every nit unless it's purely subjective preference.
    b. **Immediately remove the feedback label**:
-      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix"`
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits"`
    c. Address every piece of feedback. Build with `fleet-build`.
    d. Push fixes using `commit-and-push`.
    e. Add the appropriate response label:
@@ -103,6 +111,8 @@ Each invocation is one iteration — do the work, then exit cleanly:
         `fleet:changes-made`:
         `gh pr edit <N> --add-label "fleet:changes-made"`
       - If it was `fleet:needs-fix` → no response label needed.
+      - If it was `fleet:has-nits` → no response label needed; existing
+        `fleet:approved` stays valid (cleanups don't invalidate approval).
       `gh pr comment <N> --body "Addressed feedback: <bullet list of what changed>"`
    f. Remove stale fleet review labels (`fleet:needs-fix`,
       `fleet:blocker`) if present — but **keep `fleet:approved`**.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -77,12 +77,17 @@ Default: run continuously until the human stops you or you hit a usage
 limit. Each loop iteration:
 
 1. **Check for feedback labels on open PRs.**
-   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
+   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
 
    **Skip** PRs labeled `human:wip` — human is working on it directly.
 
-   If any PR has `human:needs-fix`, `human:blocker`, or `fleet:needs-fix`,
-   address the **oldest** one first. Human feedback takes priority.
+   **Priority order** (address one PR per iteration, oldest within each tier):
+   1. `human:needs-fix` / `human:blocker` — human review feedback, top priority
+   2. `fleet:needs-fix` — fleet review wants concrete fixes before merge
+   3. `fleet:has-nits` — PR is approved, but the reviewer flagged optional
+      improvements that should land before merge to keep code quality high.
+      The cost of a fix-and-push iteration is tiny vs merging with known
+      smells. Address every nit unless it's purely subjective preference.
 
    For each flagged PR:
    a. Read **all** feedback (two separate commands):
@@ -91,9 +96,15 @@ limit. Each loop iteration:
       The first gets conversation-level comments. The second gets
       inline review comments on specific lines — this is where most
       human feedback lives. Address every comment, not just the first.
+
+      **For `fleet:has-nits`** (PR was approved, reviewer flagged
+      improvements): focus on the latest review's `### Nits` section.
+      Address every nit unless it's purely subjective preference. The
+      reviewer's "Nits" section is the comprehensive list — treat it
+      like a checklist.
    b. **Immediately remove the feedback label** to prevent another agent
       from also picking it up:
-      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix"`
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits"`
    c. Address every piece of feedback. Make the edits, build with
       `fleet-build --target <name>`.
    d. Push fixes using `commit-and-push`.
@@ -103,12 +114,15 @@ limit. Each loop iteration:
         `gh pr edit <N> --add-label "fleet:changes-made"`
       - If it was `fleet:needs-fix` → no response label needed
         (fleet reviewer will re-review automatically on next poll)
+      - If it was `fleet:has-nits` → no response label needed; the
+        existing `fleet:approved` stays valid (cleanups don't
+        invalidate the approval)
       `gh pr comment <N> --body "Addressed feedback: <bullet list of what changed>"`
    f. Remove stale fleet review labels (`fleet:needs-fix`,
       `fleet:blocker`) if present — but **keep `fleet:approved`**.
-      The fleet's approval is still valid; human tweaks don't
-      invalidate it. The reviewer will re-review only if the stale
-      labels triggered it.
+      The fleet's approval is still valid; human tweaks and nit
+      cleanups don't invalidate it. The reviewer will re-review only
+      if the stale labels triggered it.
    g. Move to the next loop iteration.
 
    **Human feedback label cycle:** human adds `human:needs-fix` (+

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -169,26 +169,37 @@ Each invocation is one iteration — do the work, then exit cleanly:
    d. **Set the PR label** to match your verdict (add `--repo
       <game-repo>` for game PRs). The label is the primary signal
       the human uses. Always remove stale labels first:
-      `gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --add-label "fleet:needs-fix"`
+      `gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"`
       (swap the label name for approved or blocker as appropriate).
-      - Verdict approve + "Opus recheck not required" → `fleet:approved`
+      - Verdict approve, no Nits section → `fleet:approved`
+      - Verdict approve WITH a non-empty `### Nits` section → BOTH
+        `fleet:approved` AND `fleet:has-nits` (the latter tells the
+        author worker to address the nits before the human merges)
       - Verdict approve + "Opus recheck required" → **do not label**.
         Leave it unlabeled; Opus will set the final label.
       - Verdict needs-fix → `fleet:needs-fix`
       - Verdict blocker → `fleet:blocker`
 
-   **Nits vs real issues:**
-   - **Approve with nits.** If the only findings are cosmetic (naming
-     style, comment wording, import order, minor formatting), approve
-     the PR and list the nits as suggestions in the review body under
-     a `### Nits (optional)` heading. Do NOT block the PR for these.
-   - **Needs-fix** is for substantive issues only: bugs, logic errors,
+   **Nits vs real issues — the bright line:**
+   - **Approve with nits** is fine for genuinely-optional cosmetic
+     items (naming style, comment wording, import order, minor
+     formatting). Add `fleet:has-nits` so the author cleans them up
+     before the human merges.
+   - **The contradiction "approve, but please fix X before merge" is
+     forbidden.** If a finding is described as "must resolve before
+     merge", "pre-merge ask", "the comment and code must agree", or
+     anything implying the merge depends on it — that is by definition
+     a `needs-fix`, not a Nit. Move it to the Needs-fix section and
+     drop the verdict to `needs-fix`.
+   - **Needs-fix** is for substantive issues: bugs, logic errors,
      missing error handling at system boundaries, convention violations
-     that would confuse future readers, performance regressions, or
-     missing tests for non-trivial logic.
-   - When in doubt, approve. The human can always request a follow-up.
-     Blocking PRs on style nits wastes more fleet time than the nit
-     is worth.
+     that would confuse future readers, performance regressions,
+     missing tests for non-trivial logic, or any nit that is actually
+     a pre-merge requirement.
+   - When in doubt about a finding being a real issue, prefer
+     `fleet:has-nits` over `fleet:needs-fix` — the author worker now
+     addresses nits aggressively, so genuinely-borderline items still
+     get cleaned up without the round-trip cost of a full re-review.
 3. **Reset to scratch branch.** After reviewing all candidates (or if
    none existed), return to the scratch branch so no PR branch is left
    checked out — other agents may need to check out the same branch:

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -244,6 +244,27 @@ Rules for the review body:
   - **needs-fix** — one or more needs-fix items. No blockers.
   - **blocker** — at least one blocker. Merging would break master.
 
+**The bright line between Nits and needs-fix:**
+
+A "Nit" is a **truly optional** improvement the author may skip without
+hurting the merge. Anything you describe with phrases like "must resolve
+before merge", "pre-merge ask", "the comment and code must agree",
+"safe to merge once X is resolved", or "needs to be reconciled" is
+**by definition NOT a Nit** — it is a **needs-fix** item. Move it. The
+verdict drops to `needs-fix`.
+
+The contradiction "approve, but please fix X before merge" is forbidden.
+If X must be fixed before merge, the verdict is needs-fix; if it doesn't,
+say so and stop putting it in the body. The author and the human both
+read the verdict label as the primary signal — equivocating in the body
+defeats the workflow.
+
+**Nits are still encouraged** — author-agents now scan approved PRs for
+any "Nits" section and address every item before considering the PR
+landed (see the role files). So put real nits in the Nits section
+freely; they will get acted on. The bar isn't "is this nit worth
+mentioning?" — it's "is this nit a merge blocker or not?"
+
 **Do not use `gh pr review --approve` or `--request-changes`.** All fleet
 agents share the same GitHub account, and GitHub's API rejects formal
 review actions on your own PRs. The `--comment` review above is sufficient;
@@ -253,23 +274,31 @@ merge. Merging is always the user's call.
 ### 5b. Set the PR label to match the verdict
 
 After posting the review comment, set the label so the human can see
-at a glance which PRs are ready. **Always remove stale labels before
-adding the new one** — a PR should have exactly one fleet label at a
-time.
+at a glance which PRs are ready. **Always remove stale verdict labels
+before adding the new one** — a PR should have exactly one verdict
+label (`fleet:approved` / `fleet:needs-fix` / `fleet:blocker`) at any
+time. The `fleet:has-nits` label is orthogonal — it can ride on top
+of `fleet:approved`.
 
 ```bash
-# For approve:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"
+# For approve, no nits in body:
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:approved"
 
-# For needs-fix:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --add-label "fleet:needs-fix"
+# For approve WITH a non-empty Nits section in the body:
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved" --add-label "fleet:has-nits"
+
+# For needs-fix (nits roll into the fix work; no separate label):
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"
 
 # For blocker:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --add-label "fleet:blocker"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --add-label "fleet:blocker"
 ```
 
-This label is the **primary signal** the human uses to decide what to
-merge. The comment body has the details; the label has the verdict.
+The verdict label is the **primary signal** the human uses to decide
+what to merge. The comment body has the details. The `fleet:has-nits`
+label tells the author "you've been approved, and there are nits to
+clean up before this lands" — author roles poll for it and address
+the nits without losing the approval.
 
 ### 6. Report back
 


### PR DESCRIPTION
## Why
PR #197 is the motivating example: both Sonnet and Opus reviewers said "approve" but the Opus review explicitly added "Safe to merge once the AO-formula ambiguity (#1 above) is resolved." The PR sits as `fleet:approved` with a known unaddressed comment-vs-code mismatch. The author worker doesn't iterate because the loop only triggers on `fleet:needs-fix` / `human:needs-fix`.

The user's ask: "make the review and iteration cycle a bit more aggressive as far as fixing nits and other comments, even though it is safe to merge."

## Two changes

**1. New label: `fleet:has-nits`**
Reviewers add it (in addition to `fleet:approved`) when an approved PR's review body has a non-empty Nits section. Author workers poll for it and address the nits before the human merges, without losing the approval.

**2. Stricter Nits/needs-fix bright line**
"Approve, but please fix X before merge" is forbidden — it contradicts the verdict label which is the human's primary signal. If a finding is a pre-merge requirement (phrases like "must resolve before merge", "safe to merge once X is resolved", "the comment and code must agree"), the verdict drops to `needs-fix`. Truly optional improvements stay as Nits and ride on top of `fleet:has-nits`.

## Files
- `.claude/skills/review-pr/SKILL.md` — bright line for Nit vs needs-fix; updated label-setting examples
- `.claude/commands/role-sonnet-reviewer.md`, `role-opus-reviewer.md` — set `fleet:has-nits` on approve-with-nits; "when in doubt, prefer `fleet:has-nits` over `fleet:needs-fix`"
- `.claude/commands/role-sonnet-author.md`, `role-opus-worker.md`, `role-opus-architect.md` — loop step 1 also triggers on `fleet:has-nits`; priority order documented; approval stays valid after nit cleanups

## Companion change in game repo
The `role-game-architect.md` mirror is coming as a separate PR on `jakildev/irreden`.

## Labels
Created `fleet:has-nits` (yellow #FBCA04) on both `jakildev/IrredenEngine` and `jakildev/irreden`.

## Test plan
- [ ] After a Sonnet review approves a PR with a non-empty Nits section, both `fleet:approved` and `fleet:has-nits` end up on the PR
- [ ] An author worker on its next loop iteration picks the `fleet:has-nits` PR (after `human:needs-fix`/`fleet:needs-fix` if any), addresses the nits, removes `fleet:has-nits`, leaves `fleet:approved`, posts an "Addressed feedback: ..." comment
- [ ] Reviewer who finds a "must resolve before merge" item now drops verdict to `needs-fix` (not approve) — verify by reading any new review against the bright-line rule
- [ ] Auto-rereview workflow still fires when commits land on a `fleet:approved` PR (worker pushes nit fixes → human re-reviews — that's correct behavior)

## Notes for reviewer
- Did NOT touch `auto-rereview.yml` — when the worker pushes nit fixes, the workflow correctly flips `fleet:approved` to `human:re-review`. The human IS the merger and should look at any post-approval push.
- I'll re-label PR #197 with `fleet:needs-fix` separately to trigger the existing flow under the running fleet — the new workflow won't be live until this PR merges and the fleet restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)