### PR TITLE
render: restore metal ao coefficient parity with glsl

### DIFF
--- a/engine/render/src/shaders/metal/c_compute_voxel_ao.metal
+++ b/engine/render/src/shaders/metal/c_compute_voxel_ao.metal
@@ -82,6 +82,9 @@ kernel void c_compute_voxel_ao(
     if (occupancyGetBit(occupancyBits, baseOut.x + t2.x, baseOut.y + t2.y, baseOut.z + t2.z)) occl++;
     if (occupancyGetBit(occupancyBits, baseOut.x - t2.x, baseOut.y - t2.y, baseOut.z - t2.z)) occl++;
 
-    float ao = 1.0 - float(occl) * 0.15;
+    // Each filled edge-neighbor darkens by 10%; all four caps at 60%
+    // brightness keeps crease darkening visually subtle. Must stay in
+    // lockstep with the 0.10 coefficient in c_compute_voxel_ao.glsl.
+    float ao = 1.0 - float(occl) * 0.10;
     canvasAO.write(float4(ao, 0.0, 0.0, 0.0), uint2(pixel));
 }


### PR DESCRIPTION
## Summary
- PR #197's squash-merge dropped the Metal half of the `0.15 → 0.10` coefficient change the Opus reviewer asked for pre-merge. Master shipped with the two backends disagreeing: GLSL produces a 60% brightness floor at full occlusion, Metal still produces 40%.
- This PR makes Metal match GLSL.

## Context

The original PR #197 commit `5a169a9` touched both shaders:

```
engine/render/src/shaders/c_compute_voxel_ao.glsl              |  9 ++++++---
engine/render/src/shaders/metal/c_compute_voxel_ao.metal       |  3 +++
```

…but when PR #197 squash-merged as `8ff5ac9`, the Metal hunk kept the new sister-shader comment and lost the coefficient change. Easiest to just re-apply it on master.

## Changes
- `engine/render/src/shaders/metal/c_compute_voxel_ao.metal`: coefficient `0.15 → 0.10` so `occl=4` yields `1.0 - 4*0.10 = 0.60`.
- Added the inline darkening comment that GLSL already has, plus an explicit "must stay in lockstep with the 0.10 coefficient in c_compute_voxel_ao.glsl" callout. Hopefully that reduces the odds of a future squash-merge desync.

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean
- [x] `fleet-run IRShapeDebug --auto-screenshot 30` on macOS / Metal: `ComputeVoxelAOProgram` compiled at runtime, 6 screenshots saved
- [ ] Linux/OpenGL baseline unchanged (GLSL coefficient was already `0.10` — no-op on that path)
- [ ] Next AO tuning PR that touches this line hits both backends

## Notes for reviewer
This is a one-line functional fix + three comment lines. No new behavior, just closing a parity gap that landed by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)