### PR TITLE
fleet: workers get fresh context per task iteration (+ recover lost PR #205)

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -91,8 +91,10 @@ conditions, allocator behavior, hot-path costs.
 
 ## Loop behavior
 
-The `/loop` driver re-invokes this role every 30 minutes in live mode.
-Each invocation is one iteration — do the work, then exit cleanly:
+`fleet-babysit` relaunches this role every ~30 minutes in live mode
+with a **fresh `claude` process and an empty conversation** — no
+context carries over from prior reviews. Each invocation is one
+iteration of polling, reviewing, and exiting cleanly:
 
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,reviews,labels`
@@ -168,11 +170,11 @@ Each invocation is one iteration — do the work, then exit cleanly:
    This prevents "branch already checked out in worktree" errors when
    a worker agent tries to check out a PR branch you just reviewed.
 4. After the reset, print
-   `[opus-reviewer] Iteration complete. Next run in ~30m.`
-   Then exit cleanly. The `/loop` driver re-invokes this role in 30
-   minutes.
-5. If you hit a usage-limit error: print the error and exit. The
-   `/loop` driver and `fleet-babysit` wrapper handle backoff.
+   `[opus-reviewer] Iteration complete. Next run in ~30m (fresh context).`
+   Then exit cleanly. `fleet-babysit` relaunches a fresh `claude` in
+   ~30 minutes — no carry-over from this iteration.
+5. If you hit a usage-limit error: print the error and exit.
+   `fleet-babysit` waits the limit-delay before relaunching.
 
 If Mode above is `dry-run`: review exactly **one** flagged PR
 end-to-end, then stop and wait for human instruction. Do not loop.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -86,8 +86,15 @@ whatever directory the task touches before editing anything.
 
 ## Loop behavior
 
-The `/loop` driver re-invokes this role every 20 minutes in live mode.
-Each invocation is one iteration — do the work, then exit cleanly:
+Each invocation of this role is **one task iteration in a fresh
+`claude` process** — `fleet-babysit` relaunches you every ~20 minutes
+in live mode (or sooner if you exit faster), with an empty
+conversation each time. Don't try to "remember" anything from the
+prior iteration; everything you need lives in TASKS.md, the open-PR
+list, plan files under `~/.fleet/plans/`, and the role file you're
+reading right now.
+
+Do the work, then exit cleanly:
 
 1. **Check for feedback labels on open PRs.**
    `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
@@ -360,14 +367,15 @@ Each invocation is one iteration — do the work, then exit cleanly:
 
 11. **Reset.** Use the `start-next-task` skill to land on a fresh
     branch off `origin/master`. Print
-    `[opus-worker] Iteration complete. Next run in ~20m.`
-    Then exit cleanly. The `/loop` driver will re-invoke in 20 minutes.
+    `[opus-worker] Iteration complete. Next run in ~20m (fresh context).`
+    Then exit cleanly. `fleet-babysit` will relaunch a fresh `claude`
+    in ~20 minutes — no carry-over from this task.
 
 If Mode above is `dry-run`: do startup actions only. Do not plan or
 pick a task. Wait for human instruction.
 
-If you hit a usage-limit error: print the error and exit. The `/loop`
-driver and `fleet-babysit` wrapper handle backoff.
+If you hit a usage-limit error: print the error and exit. `fleet-babysit`
+detects exit code 2 and waits the limit-delay before relaunching.
 
 ## Hard rules
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -184,21 +184,24 @@ half-finished and re-litigated in review.
 
 ### Step 6 — Maintenance scheduling
 
-The `/loop` driver re-invokes this role every 5 minutes in live
-mode. Each invocation runs the startup actions and a full maintenance
-pass, then exits cleanly. The `/loop` driver and `fleet-babysit`
-wrapper handle scheduling and crash recovery.
+`fleet-babysit` relaunches this role every ~5 minutes in live mode
+with a **fresh `claude` process and an empty conversation**. Each
+invocation runs the startup actions and a full maintenance pass, then
+exits cleanly. `fleet-babysit` handles scheduling and crash recovery
+between fresh launches.
 
-Between `/loop` fires, the human can still type task descriptions
-into this pane. Process those through Steps 1–5 above (categorize,
+Between maintenance passes, the human can still type task descriptions
+into this pane (the conversation is live until the agent exits at the
+end of the pass). Process those through Steps 1–5 above (categorize,
 format, file to TASKS.md).
 
-If you hit a usage-limit error: print the error and exit. The
-`/loop` driver and `fleet-babysit` handle backoff.
+If you hit a usage-limit error: print the error and exit.
+`fleet-babysit` waits the limit-delay before relaunching with a fresh
+context.
 
 If Mode above is `dry-run`: do exactly one maintenance pass, then
-stop and wait for human instruction. `/loop` is not active in
-dry-run mode.
+stop and wait for human instruction. `fleet-babysit` does not
+auto-relaunch in dry-run mode.
 
 ### Maintenance pass
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -73,8 +73,15 @@ whatever directory the task touches before editing anything.
 
 ## Loop behavior
 
-Default: run continuously until the human stops you or you hit a usage
-limit. Each loop iteration:
+Each invocation of this role is **one task iteration**. After the
+iteration completes (or after determining there's no work to do), exit
+cleanly. `fleet-babysit` then relaunches you with a **fresh `claude`
+process and an empty conversation**, so the next task starts with no
+context carried over from the prior task. This keeps each task's
+reasoning focused on its own files instead of accumulating noise from
+earlier work.
+
+Each iteration:
 
 1. **Check for feedback labels on open PRs.**
    `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
@@ -309,8 +316,12 @@ limit. Each loop iteration:
    `fleet-claim release "<task ID, e.g. T-002>"`
    Paste the PR URL.
 
-10. **Reset.** Use the `start-next-task` skill to land on a fresh branch
-   off `origin/master`. Loop back to step 1.
+10. **Reset and exit cleanly.** Use the `start-next-task` skill to land
+   on a fresh branch off `origin/master`. Print
+   `[sonnet-author] Iteration complete. Exiting; babysit will relaunch with fresh context.`
+   Then exit cleanly (do NOT loop back to step 1 inside this same
+   `claude` session — `fleet-babysit` handles the relaunch with a
+   clean conversation).
 
 If Mode above is `dry-run`: do exactly **one** task end-to-end (steps
 1-9), print the PR URL, then stop and wait for human instruction. Do

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -92,8 +92,10 @@ treat it as a hard rule for this role.
 
 ## Loop behavior
 
-The `/loop` driver re-invokes this role every 3 minutes in live mode.
-Each invocation is one iteration — do the work, then exit cleanly:
+`fleet-babysit` relaunches this role every ~3 minutes in live mode
+with a **fresh `claude` process and an empty conversation** — no
+context carries over from the prior iteration. Each invocation is one
+iteration of polling, reviewing, and exiting cleanly:
 
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
@@ -207,11 +209,11 @@ Each invocation is one iteration — do the work, then exit cleanly:
    This prevents "branch already checked out in worktree" errors when
    a worker agent tries to check out a PR branch you just reviewed.
 4. After the reset, print
-   `[sonnet-reviewer] Iteration complete. Next run in ~3m.`
-   Then exit cleanly. The `/loop` driver re-invokes this role in 3
-   minutes.
-5. If you hit a usage-limit error: print the error and exit. The
-   `/loop` driver and `fleet-babysit` wrapper handle backoff.
+   `[sonnet-reviewer] Iteration complete. Next run in ~3m (fresh context).`
+   Then exit cleanly. `fleet-babysit` relaunches a fresh `claude` in
+   ~3 minutes — no carry-over from this iteration.
+5. If you hit a usage-limit error: print the error and exit.
+   `fleet-babysit` waits the limit-delay before relaunching.
 
 If Mode above is `dry-run`: review exactly **one** PR end-to-end
 (complete one iteration of step 2 with one PR), then stop and wait

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -82,15 +82,61 @@ rotate_log() {
 
 log "starting ($MODEL effort=$EFFORT) mode=$MODE loop=${LOOP_INTERVAL:-none} in $(pwd)"
 
+# --- Cross-restart session resume (architects only) ------------------------
+#
+# Architects (opus-architect, game-architect) are the human's interactive
+# design partners — their conversation context is the most valuable
+# state in the fleet. Other roles (workers, reviewers, queue-manager)
+# are loop-based and benefit from a fresh start each iteration.
+#
+# To preserve architect context across `fleet-down` -> `fleet-up`
+# cycles, we save a stable session UUID per architect role to
+# ~/.fleet/sessions/<role>.session-id. On first launch, generate the
+# UUID and pass --session-id; on subsequent launches, use --resume
+# instead of re-firing the role slash command.
+#
+# fleet-down does NOT delete these files — that's how resume survives
+# restarts. To reset an architect's context (start fresh next time),
+# delete ~/.fleet/sessions/<role>.session-id manually.
+
+SESSIONS_DIR="$HOME/.fleet/sessions"
+mkdir -p "$SESSIONS_DIR"
+SESSION_FILE="$SESSIONS_DIR/$ROLE.session-id"
+
+# Architects qualify for cross-restart resume; everyone else gets a
+# fresh session each fleet-up.
+ARCHITECT_RESUME=0
+case "$ROLE" in
+    *architect*) ARCHITECT_RESUME=1 ;;
+esac
+
 # --- First run: send the role slash command --------------------------------
 # If a loop interval is set and mode is live, wrap the role invocation in
 # /loop so Claude's runtime handles the scheduling (replaces sleep-based
 # polling and external tmux timers).
-if [[ -n "$LOOP_INTERVAL" && "$MODE" == "live" ]]; then
+
+if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
+    SESSION_ID=$(cat "$SESSION_FILE")
+    log "resuming architect session $SESSION_ID (preserved across fleet restart)"
+    claude --model "$MODEL" --effort "$EFFORT" --resume "$SESSION_ID" \
+        "fleet just restarted. resume our previous conversation; you don't need to re-run your startup banner. tell me what you were last working on so we can continue."
+elif [[ -n "$LOOP_INTERVAL" && "$MODE" == "live" ]]; then
     log "using /loop $LOOP_INTERVAL for scheduling"
     claude --model "$MODEL" --effort "$EFFORT" "/loop $LOOP_INTERVAL /role-$ROLE"
 else
-    claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
+    if [[ "$ARCHITECT_RESUME" -eq 1 ]]; then
+        # Generate and persist a stable session ID so subsequent
+        # fleet-ups can resume this conversation. Persist BEFORE
+        # launching claude — if claude crashes during startup, we
+        # still want the next fleet-up to try resuming.
+        SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())')
+        echo "$SESSION_ID" > "$SESSION_FILE"
+        log "starting architect session $SESSION_ID (saved to $SESSION_FILE)"
+        claude --model "$MODEL" --effort "$EFFORT" --session-id "$SESSION_ID" \
+            "/role-$ROLE $MODE"
+    else
+        claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
+    fi
 fi
 last_exit=$?
 
@@ -135,6 +181,14 @@ while true; do
     esac
 
     log "resuming session (attempt $attempt)..."
-    claude --model "$MODEL" --effort "$EFFORT" --continue "resume your work from where you left off"
+    if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
+        # Resume the specific persisted session (not "most recent in
+        # cwd"), so a stray manual claude run in this cwd can't
+        # accidentally hijack the architect's session.
+        claude --model "$MODEL" --effort "$EFFORT" --resume "$(cat "$SESSION_FILE")" \
+            "resume your work from where you left off"
+    else
+        claude --model "$MODEL" --effort "$EFFORT" --continue "resume your work from where you left off"
+    fi
     last_exit=$?
 done

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -2,21 +2,32 @@
 # fleet-babysit — auto-resume wrapper for fleet Claude Code agents.
 #
 # Runs claude interactively with a role slash command, then auto-resumes
-# the session if claude exits (usage limit, crash, network drop, etc.).
-# Works identically for engine and game worktrees — the cwd determines
-# which repo/session context claude uses.
+# on exit. Two distinct lifecycles:
+#
+#   Workers (sonnet-author, opus-worker, sonnet-reviewer, opus-reviewer,
+#   queue-manager): each task iteration is a *fresh* claude invocation,
+#   so context doesn't accumulate across tasks. After clean exit (task
+#   done), babysit waits the LOOP_INTERVAL (or CLEAN_DELAY if no
+#   interval) and then relaunches with the role slash command — no
+#   --continue, no --resume. Mid-task crashes still use --continue so
+#   partial work isn't lost.
+#
+#   Architects (opus-architect, game-architect): one long conversation,
+#   preserved across crashes AND across fleet-down/fleet-up cycles via
+#   ~/.fleet/sessions/<role>.session-id. Always --resume on relaunch
+#   so the human's interactive design conversation never resets.
 #
 # Usage:
 #   fleet-babysit <model> <role> [mode] [loop-interval]
 #
 # Examples:
 #   fleet-babysit sonnet sonnet-author dry-run
-#   fleet-babysit sonnet sonnet-author live          # continuous, no /loop
-#   fleet-babysit sonnet sonnet-reviewer live 10m    # /loop every 10 min
-#   fleet-babysit opus  opus-reviewer live 30m       # /loop every 30 min
-#   fleet-babysit sonnet queue-manager live 15m      # /loop every 15 min
-#   fleet-babysit opus  opus-architect live           # on-demand, no /loop
-#   fleet-babysit opus  game-architect live           # game worktree cwd
+#   fleet-babysit sonnet sonnet-author live          # fresh per task, no interval
+#   fleet-babysit sonnet sonnet-reviewer live 3m     # fresh per task, 3m between
+#   fleet-babysit opus  opus-reviewer live 30m       # fresh per task, 30m between
+#   fleet-babysit sonnet queue-manager live 5m       # fresh per task, 5m between
+#   fleet-babysit opus  opus-architect live          # interactive, no interval, --resume
+#   fleet-babysit opus  game-architect live          # game worktree cwd, --resume
 #
 # Behavior by mode:
 #   dry-run  — start the agent, auto-resume on crash, but do NOT
@@ -24,9 +35,6 @@
 #              when to promote to live.
 #   live     — auto-resume on any exit. Keeps the agent running
 #              indefinitely until the fleet session is killed.
-#
-# On resume, sends "resume your work from where you left off" so the
-# agent auto-continues without human intervention.
 #
 # Source of truth: scripts/fleet/fleet-babysit in the engine repo.
 # Installed to ~/bin/fleet-babysit by scripts/fleet/install.sh.
@@ -55,8 +63,23 @@ EFFORT="${FLEET_EFFORT:-$EFFORT}"
 # Timing
 CRASH_DELAY=30        # seconds to wait after non-zero exit (crash)
 LIMIT_DELAY=900       # seconds to wait on suspected usage limit (exit 2)
-CLEAN_DELAY=60        # seconds to wait after clean exit
+CLEAN_DELAY=60        # seconds to wait after clean exit (no LOOP_INTERVAL)
 MAX_ATTEMPTS=200      # safety valve — prevents infinite loops on hard failures
+
+# Convert a Claude-style interval ("20m", "3m", "1h", "30s") into seconds.
+# This replaces what /loop used to do internally, so that babysit can
+# enforce the between-iteration delay at the *process* level (each
+# iteration is a fresh `claude` invocation with cleared context).
+parse_interval_seconds() {
+    local s="$1"
+    [[ -z "$s" ]] && { echo 0; return; }
+    case "$s" in
+        *s) echo "${s%s}" ;;
+        *m) echo $(( ${s%m} * 60 )) ;;
+        *h) echo $(( ${s%h} * 3600 )) ;;
+        *)  echo "$s" ;;  # bare number = seconds
+    esac
+}
 
 # Logging
 LOG_DIR="${FLEET_LOG_DIR:-$HOME/.fleet/logs}"
@@ -110,21 +133,33 @@ case "$ROLE" in
     *architect*) ARCHITECT_RESUME=1 ;;
 esac
 
-# --- First run: send the role slash command --------------------------------
-# If a loop interval is set and mode is live, wrap the role invocation in
-# /loop so Claude's runtime handles the scheduling (replaces sleep-based
-# polling and external tmux timers).
+# --- Launch helpers --------------------------------------------------------
+#
+# Two distinct lifecycles:
+#
+#   Architects (opus-architect, game-architect) — one long conversation,
+#     preserved across crashes AND across fleet-down/fleet-up cycles via
+#     a persisted session-id. Always use --resume on relaunch so the
+#     interactive design conversation never resets.
+#
+#   Workers (everyone else: sonnet-author, opus-worker, sonnet-reviewer,
+#     opus-reviewer, queue-manager) — one fresh `claude` invocation per
+#     task iteration. Between tasks, we relaunch with the role slash
+#     command (no --continue, no --resume), so the new task starts with
+#     a clean conversation. This stops a context built up over hours of
+#     prior task work from leaking into the next task's reasoning.
+#
+#     Mid-task crashes are still handled via --continue so partial work
+#     doesn't get lost — the LOOP_INTERVAL gating is the "ok, *task is
+#     done*, start fresh" signal, not "agent is unhealthy, retry".
 
-if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
-    SESSION_ID=$(cat "$SESSION_FILE")
-    log "resuming architect session $SESSION_ID (preserved across fleet restart)"
-    claude --model "$MODEL" --effort "$EFFORT" --resume "$SESSION_ID" \
-        "fleet just restarted. resume our previous conversation; you don't need to re-run your startup banner. tell me what you were last working on so we can continue."
-elif [[ -n "$LOOP_INTERVAL" && "$MODE" == "live" ]]; then
-    log "using /loop $LOOP_INTERVAL for scheduling"
-    claude --model "$MODEL" --effort "$EFFORT" "/loop $LOOP_INTERVAL /role-$ROLE"
-else
-    if [[ "$ARCHITECT_RESUME" -eq 1 ]]; then
+launch_architect_first() {
+    if [[ -f "$SESSION_FILE" ]]; then
+        SESSION_ID=$(cat "$SESSION_FILE")
+        log "resuming architect session $SESSION_ID (preserved across fleet restart)"
+        claude --model "$MODEL" --effort "$EFFORT" --resume "$SESSION_ID" \
+            "fleet just restarted. resume our previous conversation; you don't need to re-run your startup banner. tell me what you were last working on so we can continue."
+    else
         # Generate and persist a stable session ID so subsequent
         # fleet-ups can resume this conversation. Persist BEFORE
         # launching claude — if claude crashes during startup, we
@@ -134,9 +169,34 @@ else
         log "starting architect session $SESSION_ID (saved to $SESSION_FILE)"
         claude --model "$MODEL" --effort "$EFFORT" --session-id "$SESSION_ID" \
             "/role-$ROLE $MODE"
-    else
-        claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
     fi
+}
+
+launch_worker_fresh() {
+    # No --continue, no --resume — fresh conversation for each task
+    # iteration. Used both on first launch and between task iterations.
+    claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
+}
+
+resume_mid_task() {
+    # Mid-task crash recovery. Architects always --resume their persisted
+    # session. Workers --continue the most recent session in this cwd
+    # (that's whatever crashed mid-task — we want to pick up where it
+    # left off so partial work isn't lost).
+    if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
+        claude --model "$MODEL" --effort "$EFFORT" --resume "$(cat "$SESSION_FILE")" \
+            "resume your work from where you left off"
+    else
+        claude --model "$MODEL" --effort "$EFFORT" --continue "resume your work from where you left off"
+    fi
+}
+
+# --- First run -------------------------------------------------------------
+
+if [[ "$ARCHITECT_RESUME" -eq 1 ]]; then
+    launch_architect_first
+else
+    launch_worker_fresh
 fi
 last_exit=$?
 
@@ -160,35 +220,37 @@ while true; do
         break
     fi
 
-    # Pick a wait time based on exit code
     case $last_exit in
         0)
-            log "exit_code=0 attempt=$attempt (clean)"
-            log "resuming in ${CLEAN_DELAY}s..."
-            sleep "$CLEAN_DELAY"
+            # Clean exit = task complete. Workers get a between-task
+            # delay (LOOP_INTERVAL if set, else CLEAN_DELAY) and then
+            # relaunch *fresh* — the new task gets a clean conversation.
+            # Architects re-resume their preserved session immediately.
+            if [[ "$ARCHITECT_RESUME" -eq 1 ]]; then
+                log "architect clean exit (attempt $attempt) — re-resuming preserved session in ${CLEAN_DELAY}s..."
+                sleep "$CLEAN_DELAY"
+                launch_architect_first
+            else
+                between_task_delay=$(parse_interval_seconds "${LOOP_INTERVAL:-${CLEAN_DELAY}s}")
+                log "worker clean exit (attempt $attempt) — fresh launch in ${between_task_delay}s (clears context for next task)"
+                sleep "$between_task_delay"
+                launch_worker_fresh
+            fi
             ;;
         2)
             # Exit code 2 often indicates usage limit
-            log "exit_code=2 attempt=$attempt (suspected usage limit)"
-            log "waiting ${LIMIT_DELAY}s..."
+            log "exit_code=2 attempt=$attempt (suspected usage limit), waiting ${LIMIT_DELAY}s..."
             sleep "$LIMIT_DELAY"
+            log "resuming session (attempt $attempt)..."
+            resume_mid_task
             ;;
         *)
-            log "exit_code=$last_exit attempt=$attempt (crash)"
-            log "resuming in ${CRASH_DELAY}s..."
+            # Crash mid-task. --continue (workers) / --resume (architects)
+            # so partial work isn't lost.
+            log "exit_code=$last_exit attempt=$attempt (crash), resuming mid-task in ${CRASH_DELAY}s..."
             sleep "$CRASH_DELAY"
+            resume_mid_task
             ;;
     esac
-
-    log "resuming session (attempt $attempt)..."
-    if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
-        # Resume the specific persisted session (not "most recent in
-        # cwd"), so a stray manual claude run in this cwd can't
-        # accidentally hijack the architect's session.
-        claude --model "$MODEL" --effort "$EFFORT" --resume "$(cat "$SESSION_FILE")" \
-            "resume your work from where you left off"
-    else
-        claude --model "$MODEL" --effort "$EFFORT" --continue "resume your work from where you left off"
-    fi
     last_exit=$?
 done

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -66,7 +66,7 @@ for arg in "$@"; do
         --wait)         WAIT_FOR_IDLE=1 ;;
         --summary)      WANT_SUMMARY=1 ;;
         -h|--help)
-            sed -n '2,40p' "$0"
+            sed -n '2,50p' "$0"
             exit 0
             ;;
         *) echo "fleet-down: unknown argument '$arg'" >&2; exit 2 ;;
@@ -109,7 +109,6 @@ count_active_claims() {
         echo 0
         return
     fi
-    # Each non-empty, non-header line is one active claim.
     echo "$out" | grep -v "^$" | wc -l | tr -d ' '
 }
 

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -10,6 +10,19 @@
 #   fleet-down                  graceful: send Ctrl-C + "exit", wait, kill
 #   fleet-down --force          immediate: kill the session, no grace
 #   fleet-down --keep-claims    don't wipe ~/.fleet/claims (default: wipe)
+#   fleet-down --wait           wait for active fleet-claim locks to drain
+#                               before shutting down (poll every 30s, cap
+#                               at WAIT_MAX_SECONDS)
+#   fleet-down --summary        ask each pane to write a session summary
+#                               to ~/.fleet/summaries/<timestamp>/<role>.md
+#                               before exiting; useful for "what snags did
+#                               we hit today" retros
+#
+# Architect session resume (preserved across down/up cycles): each
+# architect role's session ID is saved in ~/.fleet/sessions/. fleet-down
+# does NOT delete those files, so the next fleet-up can resume the
+# architect conversations. Delete ~/.fleet/sessions/<role>.session-id
+# manually to force a fresh architect session next time.
 #
 # Why not just `tmux kill-session`?
 #   - Each pane runs `fleet-babysit`, which itself runs `claude`. A bare
@@ -29,16 +42,23 @@
 set -euo pipefail
 
 SESSION="fleet"
-GRACE_SECONDS=8       # how long to wait for panes to wind down after Ctrl-C
+GRACE_SECONDS=8           # how long to wait for panes to wind down after Ctrl-C
+WAIT_POLL_SECONDS=30      # how often to check for idle when --wait is set
+WAIT_MAX_SECONDS=1800     # cap --wait at 30 min (humans can re-run with --force)
+SUMMARY_WAIT_SECONDS=60   # how long to give panes to write their summaries
 FORCE=0
 KEEP_CLAIMS=0
+WAIT_FOR_IDLE=0
+WANT_SUMMARY=0
 
 for arg in "$@"; do
     case "$arg" in
         --force)        FORCE=1 ;;
         --keep-claims)  KEEP_CLAIMS=1 ;;
+        --wait)         WAIT_FOR_IDLE=1 ;;
+        --summary)      WANT_SUMMARY=1 ;;
         -h|--help)
-            sed -n '2,30p' "$0"
+            sed -n '2,40p' "$0"
             exit 0
             ;;
         *) echo "fleet-down: unknown argument '$arg'" >&2; exit 2 ;;
@@ -53,6 +73,92 @@ fi
 if ! tmux has-session -t "$SESSION" 2>/dev/null; then
     echo "fleet-down: no '$SESSION' tmux session is running. Nothing to do."
     exit 0
+fi
+
+# ----------------------------------------------------------------------
+# Step 0a: --wait — block until active fleet-claim locks drain
+# ----------------------------------------------------------------------
+#
+# An active claim means a worker is mid-task (mid-build, mid-edit,
+# mid-PR-create). If we kill it, the local commits and partial work
+# are lost (work is on the worktree's filesystem; only what's pushed
+# survives). Waiting for the worker to release its claim — which
+# happens after `commit-and-push` succeeds and the WIP label is
+# removed — gives in-flight work a chance to land cleanly.
+#
+# We poll fleet-claim list (filtering out _stack_* metadata dirs).
+# When the count drops to zero, all workers are between tasks and
+# safe to shut down.
+
+count_active_claims() {
+    if ! command -v fleet-claim >/dev/null 2>&1; then
+        echo 0
+        return
+    fi
+    local out
+    out=$(fleet-claim list 2>/dev/null || true)
+    if echo "$out" | grep -q "no active claims"; then
+        echo 0
+        return
+    fi
+    # Each non-empty, non-header line is one active claim.
+    echo "$out" | grep -v "^$" | wc -l | tr -d ' '
+}
+
+if [[ "$WAIT_FOR_IDLE" -eq 1 ]]; then
+    deadline=$(( $(date +%s) + WAIT_MAX_SECONDS ))
+    echo "fleet-down --wait: waiting for active claims to drain (max ${WAIT_MAX_SECONDS}s, polling every ${WAIT_POLL_SECONDS}s)"
+    while [[ $(date +%s) -lt $deadline ]]; do
+        n=$(count_active_claims)
+        if [[ "$n" -eq 0 ]]; then
+            echo "fleet-down --wait: all claims released. Proceeding."
+            break
+        fi
+        echo "fleet-down --wait: $n active claim(s); rechecking in ${WAIT_POLL_SECONDS}s..."
+        sleep "$WAIT_POLL_SECONDS"
+    done
+    if [[ $(date +%s) -ge $deadline ]]; then
+        n=$(count_active_claims)
+        echo "fleet-down --wait: deadline reached with $n claim(s) still held. Proceeding to graceful shutdown anyway."
+    fi
+fi
+
+# ----------------------------------------------------------------------
+# Step 0b: --summary — request per-pane session summaries
+# ----------------------------------------------------------------------
+#
+# Send a Write-tool prompt to each pane asking it to record what it
+# worked on, what snags it hit, and what could improve. We collect
+# these in ~/.fleet/summaries/<timestamp>/<role>.md so the human can
+# review them after the fleet is down.
+#
+# The summaries are best-effort — if an agent is mid-iteration and
+# can't acknowledge in time, we skip it and proceed. SUMMARY_WAIT_SECONDS
+# bounds the total wait.
+
+SUMMARY_DIR=""
+if [[ "$WANT_SUMMARY" -eq 1 ]]; then
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    SUMMARY_DIR="$HOME/.fleet/summaries/$timestamp"
+    mkdir -p "$SUMMARY_DIR"
+    echo "fleet-down --summary: requesting per-pane summaries to $SUMMARY_DIR/"
+
+    while IFS= read -r pane_id; do
+        # Read the pane's @role label (set by fleet-up); fall back to
+        # the pane index if @role isn't set.
+        role=$(tmux show-options -t "$pane_id" -p -v @role 2>/dev/null | awk '{print $1}')
+        [[ -z "$role" ]] && role="pane-${pane_id#%}"
+        summary_file="$SUMMARY_DIR/$role.md"
+        prompt="Before exiting: use the Write tool to save a short session summary to $summary_file. Cover (1) what tasks/PRs you worked on this session, (2) any snags, surprises, or ergonomics issues that the human might want to fix in the fleet tooling, (3) anything left blocked or waiting. Keep under 500 words. Markdown headings welcome. Then continue your normal exit flow."
+        tmux send-keys -t "$pane_id" "$prompt" Enter
+    done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
+
+    echo "fleet-down --summary: waiting up to ${SUMMARY_WAIT_SECONDS}s for panes to write..."
+    sleep "$SUMMARY_WAIT_SECONDS"
+
+    # Report what landed.
+    written=$(find "$SUMMARY_DIR" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+    echo "fleet-down --summary: $written summary file(s) written to $SUMMARY_DIR/"
 fi
 
 # ----------------------------------------------------------------------
@@ -122,4 +228,11 @@ else
 fi
 
 echo
+if [[ -n "$SUMMARY_DIR" ]]; then
+    echo "fleet-down: session summaries in $SUMMARY_DIR/"
+fi
+if [[ -d "$HOME/.fleet/sessions" ]] && find "$HOME/.fleet/sessions" -maxdepth 1 -name '*.session-id' | grep -q .; then
+    echo "fleet-down: architect session IDs preserved in ~/.fleet/sessions/."
+    echo "            next fleet-up will resume those conversations automatically."
+fi
 echo "fleet-down: done. Bring the fleet back up with:  fleet-up live"

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -18,6 +18,14 @@
 #                               before exiting; useful for "what snags did
 #                               we hit today" retros
 #
+# Note on --summary scope: workers run one task per fresh `claude`
+# process (see fleet-babysit), so an end-of-day worker summary covers
+# only the *current* iteration's task — not everything that pane has
+# done since fleet-up. Architects retain full session context across
+# their day and can write a true session summary. For per-task
+# worker history, scrape ~/.fleet/logs/<role>.log (babysit logs every
+# launch + exit) or each PR's own commit + comment trail.
+#
 # Architect session resume (preserved across down/up cycles): each
 # architect role's session ID is saved in ~/.fleet/sessions/. fleet-down
 # does NOT delete those files, so the next fleet-up can resume the
@@ -149,7 +157,7 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
         role=$(tmux show-options -t "$pane_id" -p -v @role 2>/dev/null | awk '{print $1}')
         [[ -z "$role" ]] && role="pane-${pane_id#%}"
         summary_file="$SUMMARY_DIR/$role.md"
-        prompt="Before exiting: use the Write tool to save a short session summary to $summary_file. Cover (1) what tasks/PRs you worked on this session, (2) any snags, surprises, or ergonomics issues that the human might want to fix in the fleet tooling, (3) anything left blocked or waiting. Keep under 500 words. Markdown headings welcome. Then continue your normal exit flow."
+        prompt="Before exiting: use the Write tool to save a short summary to $summary_file. Cover what's in your *current* conversation context — for workers (sonnet-author, opus-worker, sonnet-reviewer, opus-reviewer, queue-manager) that's just the current iteration's task; for architects it's the full session. Include: (1) what tasks/PRs are in your context, (2) any snags, surprises, or ergonomics issues worth fixing in the fleet tooling, (3) anything blocked or waiting. Keep under 500 words. Markdown headings welcome. Then continue your normal exit flow."
         tmux send-keys -t "$pane_id" "$prompt" Enter
     done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -466,7 +466,15 @@ other modes you can pass to fleet-up:
 
 graceful shutdown:
   fleet-down                     # graceful: send "exit", wait, kill, clear claims
+  fleet-down --wait              # wait for active claims to drain first
+  fleet-down --summary           # ask each pane to write a session summary
   fleet-down --force             # immediate: just kill the tmux session
+
+architect session resume:
+  ~/.fleet/sessions/<role>.session-id is preserved across fleet-down/up
+  cycles. opus-architect and game-architect will resume their previous
+  conversation on the next fleet-up. To force a fresh architect session
+  next time, delete the corresponding .session-id file.
 EOF
 
 # In live mode, attach to the tmux session so the user lands in the

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -451,11 +451,14 @@ the session if claude exits (crash, usage limit, network drop).
   dry-run — auto-resumes on crash, stops on clean exit
   live    — auto-resumes on any exit (runs indefinitely)
 
-scheduling (live mode): polling roles use Claude's /loop for managed intervals:
-  sonnet-reviewer — /loop 3m     opus-reviewer — /loop 30m
-  opus-worker-1/2 — /loop 20m    queue-manager — /loop 5m
-  sonnet-fleet-1  — continuous (no /loop)
-  opus-architect, game-architect — interactive (no /loop, human's design partners)
+scheduling (live mode): each worker iteration is a fresh \`claude\` process
+  (no context carry-over between tasks). babysit relaunches per role's
+  configured interval:
+  sonnet-reviewer — every ~3m     opus-reviewer — every ~30m
+  opus-worker-1/2 — every ~20m    queue-manager — every ~5m
+  sonnet-fleet-1  — back-to-back (60s pause between iterations)
+  opus-architect, game-architect — interactive, persistent session
+                                   (--resume across crashes + fleet-down/up)
 
 logs: crash diagnostics written to ~/.fleet/logs/<role>.log
 


### PR DESCRIPTION
## Summary
Per the user's ask: workers now clear context between task iterations so each new task starts with a fresh `claude` conversation, not hours of accumulated noise from prior tasks.

Also recovers the architect session resume + `fleet-down --wait` + `fleet-down --summary` content that PR #205 was supposed to land. PR #205 squash-merged into its base branch (`claude/fleet-orchestration-basics`) at 20:33Z, but PR #204 had already squash-merged that base into master at 20:29Z — the base was deleted out from under it, so #205's changes never reached master. This PR re-applies them on top of current master (cherry-picked commit) and then layers the new fresh-context behavior on top.

## Two commits

**1. Cherry-pick of PR #205 content** (architect session resume + fleet-down --wait/--summary). Identical to what was reviewed and approved on #205.

**2. Worker fresh-context behavior** (the new ask).
- `fleet-babysit` no longer wraps role launches in `/loop $LOOP_INTERVAL /role-X`. /loop kept the conversation alive across iterations within one session — the opposite of what we now want.
- On clean exit (task complete) in live mode:
  - **Architects** → re-resume the persisted session (unchanged — context is the value).
  - **Workers** → wait `LOOP_INTERVAL` (or `CLEAN_DELAY` if no interval) and relaunch with `claude /role-X $MODE`. **No `--continue`, no `--resume`, no `/loop`. Fresh conversation.**
- On crash (non-zero exit):
  - **Architects** → `--resume` the persisted session.
  - **Workers** → `--continue` the most recent session (mid-task crash recovery preserves work-in-progress; only clean exit triggers fresh launch).
- New helper `parse_interval_seconds()` converts `20m` / `3m` / `1h` / `30s` → seconds, since babysit now handles the between-iteration sleep itself.
- Refactored launch logic into named helpers: `launch_architect_first`, `launch_worker_fresh`, `resume_mid_task`.

Role files updated (sonnet-author, opus-worker, sonnet-reviewer, opus-reviewer, queue-manager): the "Loop behavior" section now explicitly tells the agent each invocation is a fresh process, that `fleet-babysit` (not `/loop`) handles the relaunch interval, and that they shouldn't try to "remember" anything from a prior iteration. The "next run in ~Nm" log lines now say `(fresh context)` so it's visible in the babysit log when an iteration started clean.

`sonnet-author` step 10 changed from "Loop back to step 1" (internal loop) to "Exit cleanly; babysit will relaunch with fresh context" (process-level loop).

## Trade-off acknowledged

The user noted: "Might make it harder for the summarize at the end but is probably worth it." Confirmed: with workers cleared between tasks, `fleet-down --summary` collects only the *current* iteration's task per worker pane, not the day's full history. Architects retain full context and write a true session summary. For per-task worker history, the babysit log (`~/.fleet/logs/<role>.log`) records every launch + exit, and each PR's commit + comment trail covers what was actually done.

The summary prompt in `fleet-down --summary` was updated to explicitly note this scope difference per role type.

## Files
- `scripts/fleet/fleet-babysit` — major refactor (+180 lines): launch helpers, fresh-launch logic, interval parsing
- `scripts/fleet/fleet-down` — recovers PR #205's --wait + --summary; updated summary prompt to note worker scope
- `scripts/fleet/fleet-up` — recovers PR #205's help-text additions (architect resume note); scheduling block describes fresh-launch model
- `.claude/commands/role-{sonnet-author,opus-worker,sonnet-reviewer,opus-reviewer,queue-manager}.md` — Loop behavior + tail "next run" log updated

## Test plan
- [ ] After both this and PR #221 (game-architect mirror, follow-up) merge, restart the fleet
- [ ] Worker pane: complete one task → exit → babysit logs `clean exit ... fresh launch in 1200s (clears context for next task)` (for opus-worker with 20m interval) → relaunches at the interval with `/role-X live` (verifiable via `~/.fleet/logs/opus-worker-1.log`)
- [ ] Architect pane: not affected — still uses `--resume` on every relaunch (whether clean exit or crash)
- [ ] Mid-task crash on a worker: babysit logs `crash, resuming mid-task` and uses `--continue` (preserves work)
- [ ] `fleet-down --summary` after a few iterations: each worker's `~/.fleet/summaries/<ts>/<role>.md` covers only the most recent task
- [ ] First-ever fleet-up after this PR: `~/.fleet/sessions/opus-architect.session-id` is created (recovers PR #205 behavior)
- [ ] Subsequent `fleet-up` (after `fleet-down`): architect logs `resuming architect session <uuid>` (preserved) — also recovers PR #205

## Notes for reviewer
- The cherry-pick of PR #205's content was clean (no merge conflicts). The diff against master matches what was on the original PR plus the new fresh-context layer.
- Did **NOT** test by running fleet-down/fleet-up — would have killed the user's live session. All scripts pass `bash -n`.
- Companion change for game-architect role coming as a separate PR on `jakildev/irreden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)