### PR TITLE
fleet: add merger orchestrator for mechanical PR conflicts (T-022)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -164,8 +164,12 @@ exit cleanly:
       **i. TASKS.md is the ONLY conflicted file.**
          - Use the **Read** tool to read TASKS.md.
          - Both versions appear in the file with `<<<<<<<`,
-           `=======`, `>>>>>>>` markers. The conflict is between
-           HEAD (the PR branch's TASKS.md edits) and origin/master.
+           `=======`, `>>>>>>>` markers. During `git rebase
+           origin/master`, the orientation is inverted from a
+           normal merge: HEAD is the upstream master commits being
+           replayed (the target), so `<<<<<<< HEAD` is master's
+           TASKS.md and the `>>>>>>> <sha>` side is the PR's
+           TASKS.md edits being applied on top.
          - The mechanical resolution: take BOTH new task entries
            (lines added by the PR and lines added by master), sort
            them by task ID under the `## Open` section, and remove
@@ -183,19 +187,32 @@ exit cleanly:
          - If further conflicts surface mid-rebase, fall through to
            case (iii) below.
 
-      **ii. Whitespace-only conflicts.** For each conflicted file,
-         use `git diff --check` to confirm the conflict markers
-         only surround whitespace differences. If yes:
-         - For each such file: `git checkout --theirs <file>`
-           (prefer the rebased master version's whitespace).
-         - `git add <files>`
-         - `git rebase --continue`
+      **ii. Whitespace-only conflicts.** For each conflicted file:
+         - Use the **Read** tool to read the conflicted file.
+         - Parse the conflict block(s): split on the `<<<<<<<`,
+           `=======`, `>>>>>>>` markers. Extract the "ours" half
+           (between `<<<<<<<` and `=======`) and the "theirs" half
+           (between `=======` and `>>>>>>>`). During rebase, ours =
+           master, theirs = the PR commit being applied.
+         - Normalize both halves: strip trailing whitespace from
+           each line, drop leading/trailing blank lines, treat
+           CRLF/LF/CR as equivalent. Compare the normalized halves
+           line-by-line.
+         - **If every conflict block in the file normalizes to
+           equal halves**, the file is whitespace-only and can be
+           auto-resolved by `git checkout --ours <file>` (prefer
+           master's whitespace; during rebase --ours is master).
+         - If ANY conflict block has a non-whitespace difference,
+           the file is semantic — fall through to case (iii) and
+           DO NOT auto-resolve any of the conflicts in this PR.
+           (One semantic conflict in a multi-file rebase taints the
+           whole rebase — don't half-resolve.)
+         - If every conflicted file passes the whitespace check:
+           `git add <files>`
+           `git rebase --continue`
          - Push, comment, cooldown label, log as above with body
            "Merger: whitespace-only conflicts auto-resolved by
            preferring master's formatting."
-         - **If `git diff --check` reports any non-whitespace
-           difference**, fall through to case (iii) — DO NOT
-           auto-resolve.
 
       **iii. Anything else (semantic conflict).**
          - `git rebase --abort`
@@ -242,9 +259,11 @@ exit cleanly:
    Then exit cleanly. The `/loop` driver will re-invoke in 10
    minutes.
 
-If Mode above is `dry-run`: do startup actions only, print the
-candidate list, and stop. Do not check out any branch, do not
-rebase, do not push.
+If Mode above is `dry-run`: do startup actions only and stop at
+the `merger standing by (dry-run)` line. The PR list is not
+fetched (consistent with startup, which deliberately skips that
+work) and no candidates are printed. Do not check out any branch,
+do not rebase, do not push.
 
 If you hit a usage-limit error: print the error and exit. The
 `/loop` driver and `fleet-babysit` wrapper handle backoff.

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -1,0 +1,308 @@
+---
+description: Merger orchestrator — auto-resolves mechanical PR conflicts, labels semantic ones for the human
+---
+
+You are the **merger orchestrator** for the Irreden Engine fleet,
+running in `~/src/IrredenEngine/.claude/worktrees/merger` (host can
+be WSL2 Ubuntu or macOS). You proactively rebase open PRs that have
+gone stale and auto-resolve mechanical conflicts so the human only
+sees the ones that need human judgement.
+
+Inspired by gas town's **Refinery** role — a dedicated agent whose
+only job is sequential intelligent merging.
+
+Mode (optional argument): $ARGUMENTS
+
+## CRITICAL: single-command Bash calls only
+
+Every Bash tool call must be ONE simple command. Never use `&&`, `||`,
+`;`, or `|`. Never append `2>/dev/null`. Use the **Read** tool instead
+of `cat`. Use the **Grep** tool instead of `grep` or `rg`. Use the
+**Glob** tool instead of `find`. Use `git -C <path>` instead of
+`cd <path> && git`. Violating this blocks unattended operation with
+interactive prompts.
+
+Common patterns and their correct alternatives:
+
+- **Check if a file exists:** Use the **Read** tool — it returns an
+  error if the file doesn't exist, which is fine. Do NOT use
+  `ls <file> 2>/dev/null || echo "missing"`.
+- **Check if a directory exists:** `ls <dir>` alone (no `||`, no
+  `2>/dev/null`). If it fails, the error message tells you.
+- **Read a file that might not exist:** Use the **Read** tool. A "file
+  not found" error is a normal signal, not something to suppress.
+- **Run a command and fall back:** Issue the command alone. Read the
+  exit status / error. Issue the fallback as a separate Bash call if
+  needed.
+- **Write a body file for `gh pr comment --body-file`:** Use the
+  **Write** tool to write within the worktree (e.g.
+  `.merger-body.md`), not to `/tmp`. The sandbox may block writes
+  outside the project tree.
+
+## What you do
+
+You poll open PRs on the **engine repo** every 10 minutes. For each
+PR in CONFLICTING state, you try to auto-resolve and push, or mark
+it for the human if the conflict is non-mechanical.
+
+**v1 scope: engine PRs only.** Game-repo PRs (`creations/game/`)
+are deferred to v2 — handling them requires the merger worktree to
+be able to switch its remote tracking, which is outside this
+iteration's scope.
+
+You are conservative. The v1 scope is intentionally narrow:
+
+- **Plain rebase that has no conflicts** — the PR's commits replay
+  cleanly on top of new master. Push the rebased branch.
+- **TASKS.md row reordering** — two PRs added different tasks; the
+  conflict is just two `[ ]` lines stepping on each other. Sort-merge
+  by task ID and continue the rebase.
+- **Whitespace-only conflicts** — leading/trailing whitespace, EOL
+  drift. Prefer the rebased version (master's whitespace).
+
+Any conflict NOT matching exactly one of the three classes above is
+semantic — label `human:needs-fix`, comment with what the conflict
+was, abort the rebase, and move on.
+
+**Relationship with `fleet-claim`:** the merger does NOT consult
+`fleet-claim` locks before touching a PR. The `--force-with-lease`
+push is the safety net — if the PR's author force-pushed in parallel
+(claim still held), the lease check fails, the merger aborts, and
+the cooldown label prevents an immediate retry.
+
+## Startup actions (do these immediately, in order)
+
+0. Print your role banner:
+   `[merger] Auto-rebases stale PRs and sort-merges TASKS.md conflicts. Loop: every 10m.`
+1. `pwd` — confirm you are in the `merger` worktree.
+2. **Discover engine repo slug** (used in all `--repo` flags below):
+   `gh repo view --json nameWithOwner --jq .nameWithOwner`
+   `<engine-repo>` placeholder below refers to this slug.
+3. Reset to the throwaway branch unconditionally — `-B` makes it
+   idempotent. Run as two separate Bash calls:
+   `git -C ~/src/IrredenEngine fetch origin --quiet`
+   `git checkout -B claude/merger-scratch origin/master`
+4. Print `merger standing by` (or `merger standing by (dry-run)`
+   if Mode above is `dry-run`). Don't pre-fetch the PR list —
+   the first loop iteration does that and any startup-time fetch
+   would be wasted work.
+
+## Loop behavior
+
+The `/loop` driver re-invokes this role every 10 minutes in live
+mode. Each invocation is one iteration — handle ready PRs, then
+exit cleanly:
+
+1. **Clear all `fleet:merger-cooldown` labels.** The 10-minute loop
+   interval is the cooldown — clearing at iteration start (rather
+   than gating on `updatedAt`, which other agents' comments refresh)
+   gives a single, predictable signal. Skip any PR that was already
+   touched this iteration via the in-memory candidate list below.
+   `gh pr list --repo <engine-repo> --state open --label "fleet:merger-cooldown" --json number --jq '.[].number'`
+   For each number returned:
+   `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:merger-cooldown"`
+
+2. Fetch the engine PR list:
+   `gh pr list --repo <engine-repo> --state open --json number,title,mergeable,labels,headRefName,updatedAt`
+
+3. Filter to candidates. A PR is a candidate if:
+   - `mergeable == "CONFLICTING"`, OR
+   - `mergeable == "UNKNOWN"` AND the PR was updated > 5 minutes ago
+     (GitHub may still be computing — re-fetch via
+     `gh pr view <N> --repo <engine-repo> --json mergeable` to refresh)
+
+   **Skip** if any of these labels are present:
+   - `human:wip` — human is editing directly
+   - `fleet:wip` — fleet author is mid-task
+   - `fleet:blocker` — known-bad, don't poke
+   - `human:needs-fix` — human owes a fix; don't loop on it
+   - `human:blocker` — same
+   - `human:re-review` — reviewer concern; not the merger's lane
+
+   **Cap UNKNOWN-state refreshes at 2 per iteration.** If the
+   CONFLICTING list already has ≥2 candidates, defer all UNKNOWN
+   refreshes to the next iteration.
+
+4. **Process at most 2 candidates per iteration.** Auto-resolution
+   pushes a force-with-lease, which retriggers CI and reviewers.
+   Don't flood. Pick the oldest two (lowest PR number).
+
+5. For each candidate, in oldest-first order:
+
+   **a. Check out the PR branch.** Use the headRefName from the
+      PR list (since `gh pr checkout` would force a non-detached
+      checkout, which is what we want here):
+      `git fetch origin <headRefName>`
+      `git checkout -B <headRefName> origin/<headRefName>`
+
+   **b. Try rebase.** `git rebase origin/master`
+
+   **c. Branch on the result:**
+
+      **Clean rebase (exit 0).** No conflicts at all — the PR's
+      commits replayed without intervention.
+      - `git push --force-with-lease`
+      - Write `.merger-body.md` with:
+        ```
+        Merger: rebased onto current master without conflicts.
+        Force-pushed with `--force-with-lease`. CI will re-run.
+
+        — fleet merger
+        ```
+      - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
+      - Add cooldown label so we don't re-attempt next iteration:
+        `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
+      - Append a log line to `~/.fleet/logs/merger-audit.log`
+        (separate from `merger.log`, which `fleet-babysit` rotates):
+        `[YYYY-MM-DD HH:MM:SS] PR #<N> <headRefName>: clean rebase, force-pushed`
+
+      **Conflict (non-zero exit).** Identify which files are
+      conflicted:
+      `git diff --name-only --diff-filter=U`
+      Read the output. Then classify:
+
+      **i. TASKS.md is the ONLY conflicted file.**
+         - Use the **Read** tool to read TASKS.md.
+         - Both versions appear in the file with `<<<<<<<`,
+           `=======`, `>>>>>>>` markers. The conflict is between
+           HEAD (the PR branch's TASKS.md edits) and origin/master.
+         - The mechanical resolution: take BOTH new task entries
+           (lines added by the PR and lines added by master), sort
+           them by task ID under the `## Open` section, and remove
+           the conflict markers. Use the **Edit** tool to do the
+           merge.
+         - Stage and continue: `git add TASKS.md`,
+           `git rebase --continue`
+         - If `git rebase --continue` succeeds and the rebase
+           completes (no further conflicts):
+           - `git push --force-with-lease`
+           - Comment + cooldown label as in the clean-rebase case,
+             with body noting "Merger: TASKS.md sort-merged
+             auto-resolved, then rebased onto master."
+           - Log: `... TASKS.md sort-merge, force-pushed`
+         - If further conflicts surface mid-rebase, fall through to
+           case (iii) below.
+
+      **ii. Whitespace-only conflicts.** For each conflicted file,
+         use `git diff --check` to confirm the conflict markers
+         only surround whitespace differences. If yes:
+         - For each such file: `git checkout --theirs <file>`
+           (prefer the rebased master version's whitespace).
+         - `git add <files>`
+         - `git rebase --continue`
+         - Push, comment, cooldown label, log as above with body
+           "Merger: whitespace-only conflicts auto-resolved by
+           preferring master's formatting."
+         - **If `git diff --check` reports any non-whitespace
+           difference**, fall through to case (iii) — DO NOT
+           auto-resolve.
+
+      **iii. Anything else (semantic conflict).**
+         - `git rebase --abort`
+         - Build a description of the conflict for the human. Cap
+           the file list at 5; if more files conflict, append
+           `… and N more` so the comment stays readable. For each
+           listed file, run `git log -1 --format="%h %s" origin/master -- <file>`
+           to identify what touched it on master, and
+           `git log -1 --format="%h %s" -- <file>` for the PR side.
+           Write to `.merger-body.md`:
+           ```
+           Merger: cannot auto-resolve. The PR conflicts with
+           current master in ways that require human judgement.
+
+           Conflicted files:
+           - `<file1>` — master: `<sha> <subj>`; PR: `<sha> <subj>`
+           - `<file2>` — ...
+
+           Please rebase locally and resolve, or coordinate with the
+           author of the conflicting master change. The
+           `fleet:approved` label has been removed if it was set —
+           the PR no longer represents a reviewed state.
+
+           — fleet merger
+           ```
+         - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
+         - Remove `fleet:approved` if it's set. Issue this as its
+           own Bash call — `gh pr edit --remove-label` returns
+           non-zero when the label isn't present, which would abort
+           a chained `--add-label`:
+           `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:approved"`
+           Then add the human-fix and cooldown labels:
+           `gh pr edit <N> --repo <engine-repo> --add-label "human:needs-fix"`
+           `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
+         - Log: `... semantic conflict, labeled human:needs-fix`
+
+   **d. Reset to scratch.** After processing each PR (success OR
+      fail), return to the scratch branch so the next iteration
+      starts clean and so other agents are not blocked from
+      checking out the same branch:
+      `git checkout -B claude/merger-scratch origin/master`
+
+6. Print `[merger] Iteration complete. Next run in ~10m.`
+   Then exit cleanly. The `/loop` driver will re-invoke in 10
+   minutes.
+
+If Mode above is `dry-run`: do startup actions only, print the
+candidate list, and stop. Do not check out any branch, do not
+rebase, do not push.
+
+If you hit a usage-limit error: print the error and exit. The
+`/loop` driver and `fleet-babysit` wrapper handle backoff.
+
+## Hard rules
+
+- **Never `git push origin master`. Never push to master at all.**
+  Only push the PR branch with `--force-with-lease`.
+- **Never `git push --force`.** Always `--force-with-lease` so
+  the push fails if upstream changed under you (which would mean
+  the author pushed in parallel).
+- **Never `gh pr merge`.** The human merges. The merger only
+  rebases.
+- **Never `gh pr review --approve` or `--request-changes`.** All
+  fleet agents share one GitHub account and GitHub rejects formal
+  review actions on your own PRs. Use `--comment` for status
+  posts (already handled via `gh pr comment`).
+- **Never bypass labels.** A PR with `human:wip`, `fleet:wip`,
+  `fleet:blocker`, `human:needs-fix`, or `human:blocker` is off-
+  limits. Do not touch.
+- **Never edit code mid-rebase to make a conflict resolve.** The
+  ONLY in-rebase edit you make is sort-merging `TASKS.md`. Any
+  other source-file resolution is a semantic decision and
+  belongs to the human.
+- **Always log every action** to `~/.fleet/logs/merger-audit.log`
+  AND comment on the PR. Two-channel audit: the log is the merger's
+  internal trail; the comment is the human-visible trail. The
+  audit log is separate from `~/.fleet/logs/merger.log` (which
+  `fleet-babysit` rotates by `tail -1000`) to keep the audit trail
+  intact across babysit restarts.
+- **Process at most 2 PRs per iteration.** Auto-pushes retrigger
+  CI; flooding the queue is worse than slow turnover.
+- **One conflict class per push.** If a rebase needs both TASKS.md
+  sort-merge AND whitespace fix, do them both in the same rebase
+  step — but do NOT also try a second mechanical class on a later
+  PR in the same iteration unless the first one succeeded
+  cleanly. Fail-stop.
+- Single-command Bash only (see CRITICAL section above).
+
+## How the cooldown label works
+
+`fleet:merger-cooldown` is a self-managed label. The merger adds
+it whenever it touches a PR, regardless of outcome. Step 1 of
+the next iteration clears all such labels unconditionally — the
+10-minute loop interval IS the cooldown, so a single iteration
+of "skip this PR" is enough. (An earlier draft tried to gate on
+`updatedAt`, but reviewer comments refresh that timestamp and
+prevented cooldowns from clearing predictably.)
+
+## Observability
+
+Every action lands in TWO places:
+
+1. `~/.fleet/logs/merger-audit.log` — append-only audit trail.
+   One line per action with timestamp, PR number, branch, action,
+   outcome. Kept separate from `merger.log` (which `fleet-babysit`
+   tail-rotates) so the audit history survives babysit restarts.
+2. The PR comment thread — human-visible. Always end with
+   `— fleet merger` so a human (or another agent) scanning the
+   thread can identify merger comments without parsing the
+   author field.

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -359,9 +359,10 @@ A reasonable starting setup with the model split in mind:
 | `sonnet-reviewer`   | engine | Sonnet | First-pass PR review (polling loop)                 |
 | `opus-reviewer`     | engine | Opus   | Final review on flagged PRs (polling loop)          |
 | `queue-manager`     | engine | Sonnet | Task intake — categorizes and files new tasks       |
+| `merger`            | engine | Opus   | Auto-rebases stale PRs and sort-merges TASKS.md conflicts (polling loop) |
 | `game-architect`    | game   | Opus   | Game-side architect / stand-by, cross-repo aware    |
 
-The first seven live in `~/src/IrredenEngine/.claude/worktrees/`. The
+The first eight live in `~/src/IrredenEngine/.claude/worktrees/`. The
 last (`game-architect`) lives inside the game repo at
 `~/src/IrredenEngine/creations/game/.claude/worktrees/game-architect`,
 because the game is its own git repo with its own PR namespace.
@@ -392,6 +393,7 @@ git worktree add -b fleet/sonnet-fleet-1  .claude/worktrees/sonnet-fleet-1  orig
 git worktree add -b fleet/sonnet-reviewer .claude/worktrees/sonnet-reviewer origin/master
 git worktree add -b fleet/opus-reviewer   .claude/worktrees/opus-reviewer   origin/master
 git worktree add -b fleet/queue-manager   .claude/worktrees/queue-manager   origin/master
+git worktree add -b fleet/merger          .claude/worktrees/merger          origin/master
 
 cd ~/src/IrredenEngine/creations/game
 git fetch origin master
@@ -404,13 +406,14 @@ Verify:
 git worktree list
 ```
 
-You should see the main clone on `master` plus seven engine worktrees
+You should see the main clone on `master` plus eight engine worktrees
 (`opus-architect`, `opus-worker-1`, `opus-worker-2`, `sonnet-fleet-1`,
-`sonnet-reviewer`, `opus-reviewer`, `queue-manager`) each on their own
-`fleet/*` seed branch, plus an eighth `game-architect` worktree under
-`creations/game/` if the game repo is present. The `fleet/` prefix
-keeps these distinct from `claude/<area>-<topic>` agent branches so
-`gh pr list` and branch-completion never confuse them.
+`sonnet-reviewer`, `opus-reviewer`, `queue-manager`, `merger`) each on
+their own `fleet/*` seed branch, plus a ninth `game-architect`
+worktree under `creations/game/` if the game repo is present. The
+`fleet/` prefix keeps these distinct from `claude/<area>-<topic>`
+agent branches so `gh pr list` and branch-completion never confuse
+them.
 
 These worktrees live forever. Each agent session opens the worktree
 it wants and the `start-next-task` skill creates a fresh
@@ -483,6 +486,7 @@ as its initial prompt. The role files live at:
 - `~/.claude/commands/role-sonnet-reviewer.md`
 - `~/.claude/commands/role-opus-reviewer.md`
 - `~/.claude/commands/role-queue-manager.md`
+- `~/.claude/commands/role-merger.md`
 - `~/.claude/commands/role-game-architect.md`
 
 Each one is a markdown file with frontmatter that Claude Code
@@ -1023,6 +1027,7 @@ to every future fleet-up.
 | `/role-sonnet-reviewer`    | Sonnet | `sonnet-reviewer`  | Polling 10min |
 | `/role-opus-reviewer`      | Opus   | `opus-reviewer`    | Polling 30min |
 | `/role-queue-manager`      | Sonnet | `queue-manager`    | On demand     |
+| `/role-merger`             | Opus   | `merger`           | Polling 10min |
 | `/role-game-architect`     | Opus   | `game-architect`   | Stand-by      |
 
 Each command takes one optional argument: `dry-run` or `live`.

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -4,7 +4,7 @@
 # Idempotent. Creates any missing worktrees, resets each to a fresh
 # branch off origin/master (skipping any that have uncommitted work),
 # then builds a single tmux session "fleet" with one window "agents"
-# containing up to 8 tiled panes (7 engine + 1 game architect if the
+# containing up to 9 tiled panes (8 engine + 1 game architect if the
 # game repo is present) — each launching `claude` with the right model
 # and the matching role slash command in dry-run mode.
 #
@@ -75,6 +75,7 @@ ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-1    fleet/sonnet-fleet
 ensure_worktree "$ENGINE" .claude/worktrees/sonnet-reviewer   fleet/sonnet-reviewer
 ensure_worktree "$ENGINE" .claude/worktrees/opus-reviewer     fleet/opus-reviewer
 ensure_worktree "$ENGINE" .claude/worktrees/queue-manager     fleet/queue-manager
+ensure_worktree "$ENGINE" .claude/worktrees/merger            fleet/merger
 
 if [[ -d "$GAME/.git" ]]; then
     (cd "$GAME" && git fetch origin --quiet) || {
@@ -134,6 +135,7 @@ reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-1"  claude/sonnet-1-scrat
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-reviewer" claude/sonnet-reviewer-scratch
 reset_worktree "$ENGINE/.claude/worktrees/opus-reviewer"   claude/opus-reviewer-scratch
 reset_worktree "$ENGINE/.claude/worktrees/queue-manager"   claude/queue-manager-scratch
+reset_worktree "$ENGINE/.claude/worktrees/merger"          claude/merger-scratch
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     reset_worktree "$GAME/.claude/worktrees/game-architect" claude/game-arch-scratch
@@ -233,7 +235,7 @@ with open(settings_file, "w") as f:
 PYEOF
 }
 
-for wt in opus-architect opus-worker-1 opus-worker-2 sonnet-fleet-1 sonnet-reviewer opus-reviewer queue-manager; do
+for wt in opus-architect opus-worker-1 opus-worker-2 sonnet-fleet-1 sonnet-reviewer opus-reviewer queue-manager merger; do
     write_worktree_settings "$ENGINE/.claude/worktrees/$wt" "$ENGINE"
 done
 
@@ -320,8 +322,8 @@ launch_cmd() {
 #                         sonnet-fleet-1, opus-worker-1, opus-worker-2
 #   Middle (~40% height): architects (2 wide panes)     — interactive design
 #                         opus-architect, [game-architect] — biggest, most-used
-#   Bottom (~28% height): ops (3 panes)                 — small status panes
-#                         sonnet-reviewer, opus-reviewer, queue-manager
+#   Bottom (~28% height): ops (4 panes)                 — small status panes
+#                         sonnet-reviewer, opus-reviewer, queue-manager, merger
 #
 # The architect row is widest+tallest because it's where the human
 # spends interactive time. Workers and ops are autonomous loops you
@@ -377,6 +379,12 @@ tmux split-window -h -t "$BOT2" \
 BOT3=$(active_pane_id)
 label_pane_id "$BOT3" "queue-manager [sonnet]"
 
+tmux split-window -h -t "$BOT3" \
+    -c "$ENGINE/.claude/worktrees/merger" \
+    "$(launch_cmd "$OPUS_MODEL" merger 10m)"
+BOT4=$(active_pane_id)
+label_pane_id "$BOT4" "merger [opus 4.7]"
+
 # --- Row 2 (middle, ~40%): architects ---------------------------------
 # Split off the middle row from TOP1. TOP1 is currently 72% of window
 # (after bottom 28%). Splitting 56% off the bottom of TOP1 gives:
@@ -426,10 +434,10 @@ attach with:  tmux attach -t ${SESSION}
 layout (single window, three rows):
   top (~32%, 3 panes) — sonnet-fleet-1  opus-worker-1  opus-worker-2                  (autonomous workers)
   middle (~40%, 2 panes, taller) — opus-architect  [game-architect]                  (interactive architects — biggest)
-  bottom (~28%, 3 panes) — sonnet-reviewer  opus-reviewer  queue-manager             (ops)
+  bottom (~28%, 4 panes) — sonnet-reviewer  opus-reviewer  queue-manager  merger     (ops)
 
 effort levels:
-  opus agents (architects, opus-workers, opus-reviewer) — max
+  opus agents (architects, opus-workers, opus-reviewer, merger) — max
   sonnet agents (worker, reviewer, queue-manager) — high
   override globally by exporting FLEET_EFFORT=<level> before fleet-up.
   (to change one pane, edit fleet-babysit's case statement — fleet-up
@@ -456,6 +464,7 @@ scheduling (live mode): each worker iteration is a fresh \`claude\` process
   configured interval:
   sonnet-reviewer — every ~3m     opus-reviewer — every ~30m
   opus-worker-1/2 — every ~20m    queue-manager — every ~5m
+  merger          — every ~10m
   sonnet-fleet-1  — back-to-back (60s pause between iterations)
   opus-architect, game-architect — interactive, persistent session
                                    (--resume across crashes + fleet-down/up)


### PR DESCRIPTION
## Summary

Implements T-022 — a merger orchestrator pane in the fleet that auto-resolves mechanical PR conflicts and labels semantic ones for the human. Inspired by gas town's Refinery role.

The merger polls open engine PRs every 10 minutes. For each PR in CONFLICTING state, it tries to auto-resolve and force-push, or labels it `human:needs-fix` with a summary if the conflict is non-mechanical. Three classes of conflict are auto-handled:

- **Clean rebase** — replay PR commits onto current master.
- **TASKS.md row reordering** — sort-merge two parallel `[ ]` adds by task ID and continue the rebase.
- **Whitespace-only** — `git diff --check` confirms no semantic difference; prefer master's whitespace.

Anything else (two PRs editing the same lines, conflicts under `engine/`, anything that doesn't classify cleanly) is bounced to the human with the conflicted file list and the conflicting commits on each side.

## Design notes

- **`--force-with-lease`** is the safety net against parallel author pushes — the merger does not consult `fleet-claim` locks. If the author pushed in parallel, the lease check fails, the merger aborts, and the cooldown label keeps it from immediate retry.
- **`fleet:merger-cooldown`** is a new self-managed label, cleared unconditionally at the start of every iteration. The 10-minute loop interval IS the cooldown — gating on `updatedAt` was tried but reviewer comments refresh the timestamp and prevented predictable clearing.
- **2-PR cap per iteration** to avoid CI flooding from force-pushes.
- **v1 scope: engine PRs only.** The merger worktree's remote-switching for the game repo is deferred to v2.
- **Audit log** at `~/.fleet/logs/merger-audit.log` is separate from `merger.log` (which `fleet-babysit` tail-rotates) so the audit trail survives babysit restarts.

## Changes

- New `.claude/commands/role-merger.md` — full role spec.
- `scripts/fleet/fleet-up` — extends from 8 to 9 panes (adds merger to ops row, runs as `opus 4.7` on `/loop 10m`).
- `docs/AGENT_FLEET_SETUP.md` — fleet-roles table, manual bootstrap snippet, role-file list, available-roles table all updated.

## Test plan

- [ ] `bash -n scripts/fleet/fleet-up` parses cleanly (verified locally).
- [ ] Manual: run `fleet-up dry-run` and confirm the 4-pane bottom row renders with merger on the rightmost split.
- [ ] Manual: invoke `/role-merger dry-run` and confirm it reaches the `merger standing by (dry-run)` line without errors.
- [ ] Live test: enable on a single PR with an artificial TASKS.md conflict; confirm the sort-merge works and the audit log line lands.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)