### PR TITLE
engine/video: promote --auto-screenshot into reusable helper (T-027)

### DIFF
--- a/.claude/skills/render-debug-loop/SKILL.md
+++ b/.claude/skills/render-debug-loop/SKILL.md
@@ -36,24 +36,25 @@ directory before launching, so the demo picks up its sibling `data/`,
 
 ### Demo requirement: `--auto-screenshot`
 
-This skill drives a demo that implements the `--auto-screenshot` flag. A
-conforming demo:
+This skill drives a demo that opts into the reusable auto-screenshot
+helper in `engine/video/`. Conforming demos do three things in `main.cpp`:
 
-1. Parses `--auto-screenshot [warmup-frames]` in `main()`.
-2. Defines a shot table (zoom, camera offset, optional render mode) and
-   cycles through it one shot per screenshot, with settle frames between
-   shots.
-3. Calls `IRVideo::requestScreenshot()` to capture each shot.
-4. Closes the window after the last shot.
+1. Call `IRVideo::parseAutoScreenshotArgv(argc, argv, &warmupFrames)` to
+   detect the flag and read its optional warmup-frames count.
+2. Declare an `IRVideo::AutoScreenshotShot` table (zoom + iso camera
+   position + label per shot).
+3. When `warmupFrames > 0`, append `IRVideo::createAutoScreenshotSystem(
+   cfg)`'s returned `SystemId` to the RENDER pipeline list before
+   `registerPipeline` fires.
 
-**Reference implementation:** `creations/demos/shape_debug/main.cpp`. Look
-at `ShotConfig`, `g_shots[]`, and the `AutoScreenshot` system for the
-pattern. If your target demo does not yet support `--auto-screenshot`, you
-have three options: (a) add it to that demo following the shape_debug
-pattern; (b) use `shape_debug` if it exercises the code path you care
-about; (c) wait on the auto-screenshot engine helper (GitHub issue
-tracked under the `fleet:task` label — search for "auto-screenshot
-helper" if promoting shot config into a reusable system).
+The helper handles warmup, settle frames, zoom / camera application,
+the screenshot request, and window close after the last shot.
+
+**Reference implementations:** `creations/demos/shape_debug/main.cpp` and
+`creations/demos/metal_clear_test/main.cpp` — both wire up the helper in
+under a dozen lines. If your target demo does not yet opt in, either
+(a) add the six-line wire-up shown there, or (b) use `shape_debug` if
+it exercises the code path you care about.
 
 ## Loop Steps
 

--- a/creations/demos/metal_clear_test/main.cpp
+++ b/creations/demos/metal_clear_test/main.cpp
@@ -1,12 +1,26 @@
 #include <irreden/ir_engine.hpp>
+#include <irreden/ir_video.hpp>
 #include <irreden/ir_window.hpp>
 
 #include <irreden/input/systems/system_input_key_mouse.hpp>
 #include <irreden/input/commands/command_close_window.hpp>
 #include <irreden/render/systems/system_framebuffer_to_screen.hpp>
 
+namespace {
+
+constexpr IRVideo::AutoScreenshotShot kShots[] = {
+    {1.0f, vec2(0, 0),  "metal_clear_zoom1"},
+    {2.0f, vec2(0, 0),  "metal_clear_zoom2"},
+    {4.0f, vec2(4, 4),  "metal_clear_zoom4_offset"},
+};
+
+} // namespace
+
 int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: metal_clear_test");
+
+    int autoWarmupFrames = 0;
+    IRVideo::parseAutoScreenshotArgv(argc, argv, &autoWarmupFrames);
 
     IREngine::init(argv[0], "config.lua");
 
@@ -14,10 +28,21 @@ int main(int argc, char **argv) {
         IRTime::Events::INPUT,
         {IRSystem::createSystem<IRSystem::INPUT_KEY_MOUSE>()}
     );
-    IRSystem::registerPipeline(
-        IRTime::Events::RENDER,
-        {IRSystem::createSystem<IRSystem::FRAMEBUFFER_TO_SCREEN>()}
-    );
+
+    std::list<IRSystem::SystemId> renderPipeline = {
+        IRSystem::createSystem<IRSystem::FRAMEBUFFER_TO_SCREEN>(),
+    };
+
+    if (autoWarmupFrames > 0) {
+        IRVideo::AutoScreenshotConfig cfg{};
+        cfg.warmupFrames_ = autoWarmupFrames;
+        cfg.settleFrames_ = 3;
+        cfg.shots_ = kShots;
+        cfg.numShots_ = sizeof(kShots) / sizeof(kShots[0]);
+        renderPipeline.push_back(IRVideo::createAutoScreenshotSystem(cfg));
+    }
+
+    IRSystem::registerPipeline(IRTime::Events::RENDER, renderPipeline);
 
     IRCommand::createCommand<IRCommand::CLOSE_WINDOW>(
         InputTypes::KEY_MOUSE,

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -36,31 +36,16 @@
 
 namespace {
 
-struct ShotConfig {
-    float zoom_;
-    vec2 cameraIso_;
-    const char *label_;
+constexpr IRVideo::AutoScreenshotShot kShots[] = {
+    {1.0f, vec2(0, 0), "zoom1_origin"},
+    {2.0f, vec2(0, 0), "zoom2_origin"},
+    {4.0f, vec2(0, 0), "zoom4_origin"},
+    {1.0f, vec2(1, 0), "zoom1_odd_offset"},
+    {8.0f, vec2(0, 0), "zoom8_origin"},
+    {4.0f, vec2(3, 5), "zoom4_offset_3_5"},
 };
 
-// Each entry gets its own screenshot.  The settle frame lets the render
-// pipeline absorb zoom/camera changes before capture.
-constexpr int kSettleFrames = 3;
-
-ShotConfig g_shots[] = {
-    {1.0f, vec2(0, 0),   "zoom1_origin"},
-    {2.0f, vec2(0, 0),   "zoom2_origin"},
-    {4.0f, vec2(0, 0),   "zoom4_origin"},
-    {1.0f, vec2(1, 0),   "zoom1_odd_offset"},
-    {8.0f, vec2(0, 0),   "zoom8_origin"},
-    {4.0f, vec2(3, 5),   "zoom4_offset_3_5"},
-};
-constexpr int kNumShots = sizeof(g_shots) / sizeof(g_shots[0]);
-
-int g_initialWarmup = -1;
-int g_currentShot = 0;
-int g_settleCounter = 0;
-bool g_screenshotPending = false;
-bool g_autoMode = false;
+int g_autoWarmupFrames = 0;  // 0 = --auto-screenshot not requested
 bool g_depthColor = false;
 int g_autoProfileFrames = 0;  // 0 = disabled
 int g_autoProfileCount = 0;
@@ -73,18 +58,9 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
+    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
     for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--auto-screenshot") == 0) {
-            g_autoMode = true;
-            g_initialWarmup = 10;
-            if (i + 1 < argc) {
-                int frames = std::atoi(argv[i + 1]);
-                if (frames > 0) {
-                    g_initialWarmup = frames;
-                    ++i;
-                }
-            }
-        } else if (std::strcmp(argv[i], "--auto-profile") == 0) {
+        if (std::strcmp(argv[i], "--auto-profile") == 0) {
             g_autoProfileFrames = 300;  // default
             if (i + 1 < argc) {
                 int frames = std::atoi(argv[i + 1]);
@@ -164,53 +140,13 @@ void initSystems() {
         renderPipeline.push_back(autoProfileId);
     }
 
-    if (g_autoMode) {
-        IRSystem::SystemId autoScreenshotId = IRSystem::createSystem<C_VoxelSetNew>(
-            "AutoScreenshot",
-            [](C_VoxelSetNew &) {},
-            []() {
-                if (g_initialWarmup > 0) {
-                    --g_initialWarmup;
-                    return;
-                }
-
-                if (g_currentShot >= kNumShots) {
-                    IRWindow::closeWindow();
-                    return;
-                }
-
-                if (g_settleCounter == 0) {
-                    auto &shot = g_shots[g_currentShot];
-                    IR_LOG_INFO(
-                        "Shot {}/{}: {} (zoom={}, cam=({},{}))",
-                        g_currentShot + 1, kNumShots, shot.label_,
-                        shot.zoom_, shot.cameraIso_.x, shot.cameraIso_.y
-                    );
-                    IRRender::setCameraZoom(shot.zoom_);
-                    IRRender::setCameraPosition2DIso(shot.cameraIso_);
-                    g_settleCounter = kSettleFrames;
-                    g_screenshotPending = false;
-                    return;
-                }
-
-                if (g_settleCounter > 1) {
-                    --g_settleCounter;
-                    return;
-                }
-
-                // settleCounter == 1: capture this frame, then advance
-                if (!g_screenshotPending) {
-                    IRVideo::requestScreenshot();
-                    g_screenshotPending = true;
-                    return;
-                }
-
-                g_settleCounter = 0;
-                g_screenshotPending = false;
-                ++g_currentShot;
-            }
-        );
-        renderPipeline.push_back(autoScreenshotId);
+    if (g_autoWarmupFrames > 0) {
+        IRVideo::AutoScreenshotConfig cfg{};
+        cfg.warmupFrames_ = g_autoWarmupFrames;
+        cfg.settleFrames_ = 3;
+        cfg.shots_ = kShots;
+        cfg.numShots_ = sizeof(kShots) / sizeof(kShots[0]);
+        renderPipeline.push_back(IRVideo::createAutoScreenshotSystem(cfg));
     }
 
     IRSystem::registerPipeline(IRTime::Events::RENDER, renderPipeline);

--- a/engine/video/CLAUDE.md
+++ b/engine/video/CLAUDE.md
@@ -57,6 +57,27 @@ On Windows, the FFmpeg DLLs (`avcodec-*.dll`, `avformat-*.dll`,
 be on `PATH` when the executable runs. See the top-level CLAUDE.md for
 the PATH-fix wrapper.
 
+## Auto-screenshot helper
+
+`engine/video/include/irreden/video/auto_screenshot.hpp` — declarative
+shot-cycling helper that any creation can opt into with a shot table
+plus five lines of wire-up. Used by the `render-debug-loop` and
+`render-verify` skills.
+
+- `AutoScreenshotShot` — one shot: zoom, camera-iso position, label.
+- `AutoScreenshotConfig` — warmup/settle frame counts and a
+  caller-owned `const AutoScreenshotShot *` table.
+- `parseAutoScreenshotArgv` — CLI parser for
+  `--auto-screenshot [frames]`.
+- `createAutoScreenshotSystem` — RENDER-pipeline system that cycles
+  through shots, triggers one screenshot per shot, and calls
+  `IRWindow::closeWindow()` when done.
+
+Reference callers: `creations/demos/shape_debug/main.cpp` and
+`creations/demos/metal_clear_test/main.cpp`. The shot table must outlive
+the game loop — `constexpr AutoScreenshotShot kShots[]` at file scope
+is the idiomatic shape.
+
 ## Commands and components (prefabs/irreden/video)
 
 - `command_take_screenshot` → `requestScreenshot()`.

--- a/engine/video/CMakeLists.txt
+++ b/engine/video/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(VIDEO_CORE_SRC
+    src/auto_screenshot.cpp
     src/ir_video.cpp
     src/video_manager.cpp
     src/video_recorder.cpp

--- a/engine/video/include/irreden/ir_video.hpp
+++ b/engine/video/include/irreden/ir_video.hpp
@@ -1,6 +1,7 @@
 #ifndef IR_VIDEO_H
 #define IR_VIDEO_H
 
+#include <irreden/video/auto_screenshot.hpp>
 #include <irreden/video/ir_video_types.hpp>
 #include <irreden/video/video_recorder.hpp>
 #include <string>

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -1,0 +1,48 @@
+#ifndef IR_VIDEO_AUTO_SCREENSHOT_H
+#define IR_VIDEO_AUTO_SCREENSHOT_H
+
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_constants.hpp>
+#include <irreden/system/ir_system_types.hpp>
+
+namespace IRVideo {
+
+/// One entry in an auto-screenshot shot list. The cycling system applies
+/// @c zoom_ and @c cameraIso_ via @c IRRender before capture, waits the
+/// configured settle frames, then triggers a composite screenshot.
+///
+/// @c label_ is printed to the log around each capture — it does not affect
+/// the on-disk filename (@c IRVideo uses a running counter for that).
+struct AutoScreenshotShot {
+    float zoom_ = 1.0f;
+    vec2 cameraIso_ = vec2(0.0f);
+    const char *label_ = "shot";
+};
+
+/// Declarative config for @c createAutoScreenshotSystem. @c shots_ /
+/// @c numShots_ point at a shot table owned by the caller — it must outlive
+/// the game loop.
+struct AutoScreenshotConfig {
+    int warmupFrames_ = 10;
+    int settleFrames_ = 3;
+    const AutoScreenshotShot *shots_ = nullptr;
+    int numShots_ = 0;
+};
+
+/// Parse @c --auto-screenshot<space>[frames] from argv. Returns @c true if
+/// the flag is present. When present and followed by a positive integer,
+/// @c *warmupFramesOut is set to that value; otherwise the default of 10 is
+/// written. @c warmupFramesOut may be @c nullptr.
+bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut);
+
+/// Create a system that cycles through @c config.shots_ — one screenshot per
+/// shot with @c settleFrames_ between shots — then calls
+/// @c IRWindow::closeWindow(). The caller must append the returned @c SystemId
+/// to the RENDER pipeline before @c registerPipeline fires.
+///
+/// Requires @c IREngine::init() has run (so the system manager is live).
+IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config);
+
+} // namespace IRVideo
+
+#endif /* IR_VIDEO_AUTO_SCREENSHOT_H */

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -33,6 +33,12 @@ struct AutoScreenshotConfig {
 /// the flag is present. When present and followed by a positive integer,
 /// @c *warmupFramesOut is set to that value; otherwise the default of 10 is
 /// written. @c warmupFramesOut may be @c nullptr.
+///
+/// This helper peeks at the token after @c --auto-screenshot but does not
+/// tell the caller whether it consumed one or two argv slots. Callers with
+/// subsequent argv loops must be aware that a bare positive integer may
+/// appear at the slot immediately after @c --auto-screenshot — if their
+/// own loop could interpret that token, skip past it explicitly.
 bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut);
 
 /// Create a system that cycles through @c config.shots_ — one screenshot per

--- a/engine/video/src/auto_screenshot.cpp
+++ b/engine/video/src/auto_screenshot.cpp
@@ -1,0 +1,98 @@
+#include <irreden/video/auto_screenshot.hpp>
+
+#include <irreden/ir_profile.hpp>
+#include <irreden/ir_render.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_video.hpp>
+#include <irreden/ir_window.hpp>
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+
+namespace IRVideo {
+
+namespace {
+
+// Private anchor: never attached to any entity, so the per-entity tick
+// runs zero times. engine/system/CLAUDE.md guarantees endTick fires even
+// when zero entities match — we only care about endTick here.
+struct C_AutoScreenshotAnchor {};
+
+struct CyclingState {
+    AutoScreenshotConfig config_;
+    int warmupRemaining_ = 0;
+    int currentShot_ = 0;
+    int settleCounter_ = 0;
+    bool screenshotPending_ = false;
+};
+
+} // namespace
+
+bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--auto-screenshot") != 0) continue;
+        int warmup = 10;
+        if (i + 1 < argc) {
+            int parsed = std::atoi(argv[i + 1]);
+            if (parsed > 0) warmup = parsed;
+        }
+        if (warmupFramesOut != nullptr) *warmupFramesOut = warmup;
+        return true;
+    }
+    return false;
+}
+
+IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config) {
+    auto state = std::make_shared<CyclingState>();
+    state->config_ = config;
+    state->warmupRemaining_ = config.warmupFrames_;
+
+    return IRSystem::createSystem<C_AutoScreenshotAnchor>(
+        "AutoScreenshot",
+        [](C_AutoScreenshotAnchor &) {},
+        nullptr,
+        [state]() {
+            if (state->warmupRemaining_ > 0) {
+                --state->warmupRemaining_;
+                return;
+            }
+
+            if (state->currentShot_ >= state->config_.numShots_) {
+                IRWindow::closeWindow();
+                return;
+            }
+
+            if (state->settleCounter_ == 0) {
+                const auto &shot = state->config_.shots_[state->currentShot_];
+                IR_LOG_INFO(
+                    "AutoScreenshot {}/{}: {} (zoom={}, cam=({},{}))",
+                    state->currentShot_ + 1, state->config_.numShots_,
+                    shot.label_, shot.zoom_, shot.cameraIso_.x, shot.cameraIso_.y
+                );
+                IRRender::setCameraZoom(shot.zoom_);
+                IRRender::setCameraPosition2DIso(shot.cameraIso_);
+                state->settleCounter_ = state->config_.settleFrames_;
+                state->screenshotPending_ = false;
+                return;
+            }
+
+            if (state->settleCounter_ > 1) {
+                --state->settleCounter_;
+                return;
+            }
+
+            if (!state->screenshotPending_) {
+                IRVideo::requestScreenshot();
+                state->screenshotPending_ = true;
+                return;
+            }
+
+            state->settleCounter_ = 0;
+            state->screenshotPending_ = false;
+            ++state->currentShot_;
+        }
+    );
+}
+
+} // namespace IRVideo


### PR DESCRIPTION
## Summary

Promotes the `--auto-screenshot` cycling machinery (previously ~60 lines
of globals + state machine inside `creations/demos/shape_debug/main.cpp`)
into a reusable helper under `engine/video/`. Other creations can now
opt in by declaring a shot table and calling
`IRVideo::createAutoScreenshotSystem(cfg)`.

Closes #189

## What changed

**New API (declarative):**
- `engine/video/include/irreden/video/auto_screenshot.hpp`
  - `struct AutoScreenshotShot { float zoom_; vec2 cameraIso_; const char *label_; }`
  - `struct AutoScreenshotConfig { int warmupFrames_; int settleFrames_; const AutoScreenshotShot *shots_; int numShots_; }`
  - `bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupOut)` — flag + optional warmup count.
  - `IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig&)` — caller appends the returned id to its RENDER pipeline list before `registerPipeline`.

**Helper internals:**
- A private `C_AutoScreenshotAnchor` marker component (anonymous namespace in the `.cpp`) that no entity ever carries — per-entity tick is a zero-iteration no-op; the whole state machine runs in `endTick`, which fires regardless per engine/system/CLAUDE.md.

**Callers:**
- `creations/demos/shape_debug/main.cpp` — old inline cycling collapses to a shot table + 5-line opt-in.
- `creations/demos/metal_clear_test/main.cpp` — wires up the helper as a second reference implementation (proves reuse in a demo with zero voxel sets).

**Docs:**
- `.claude/skills/render-debug-loop/SKILL.md` updated to cite the new helper with both demos as references.

## Test plan

- [x] `fleet-build --target IRShapeDebug` — clean (engine/video/src/auto_screenshot.cpp.o built).
- [x] `fleet-build --target IRMetalClearTest` — clean.
- [x] `fleet-run --timeout 15 IRShapeDebug --auto-screenshot 10` — all 6 shots captured with correct zoom/cam; window closes cleanly after last shot.
- [x] `fleet-run --timeout 10 IRMetalClearTest --auto-screenshot 10` — all 3 shots captured; window closes cleanly.
- [ ] Reviewer: confirm the new helper API covers the feature surface that was inline in shape_debug.

## Notes for reviewer

- The marker-component trick deserves a glance — it uses the
  zero-cardinality invariant to make the cycling system a true
  once-per-frame loop without a dedicated "no entity" createSystem
  overload.
- The shot table is declared with `constexpr` + `const AutoScreenshotShot *` raw pointer — the helper's doc notes the table must outlive the game loop, which is trivially true for a `constexpr` at file scope.
- `SystemName` enum is unchanged — the helper uses the string-name `createSystem<Components...>` overload, not the prefab `System<NAME>::create()` pattern that requires an enum slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)