### PR TITLE
fleet: opus-workers cross-poll game queue + per-pane game worktrees + fleet-claim --repo namespace

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -98,6 +98,10 @@ fleet-claim --repo game claim "T-001" opus-worker-1
 2. Fetch both repos (separate calls):
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git -C ~/src/IrredenEngine/creations/game fetch origin --quiet`
+   If the game fetch fails because `creations/game/` isn't present,
+   the game repo is not set up on this host. Skip all game-queue
+   steps below (3–6 game variants, step 1's game PR check) and
+   proceed with engine tasks only — do not abort the iteration.
 3. **Read the latest TASKS.md from origin/master without staging.**
    Use `git show` to write current master versions to temp files — does
    NOT touch the working tree or index, so it won't break later branch

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -43,45 +43,82 @@ Common patterns and their correct alternatives:
 
 ## Responsibilities
 
-- Plan issues flagged with `fleet:needs-plan` — read the issue thread,
-  write a structured plan, post it as an issue comment, save it to
-  `~/.fleet/plans/`, and swap labels so the queue-manager ingests it.
-- Execute `Model: opus` tasks from TASKS.md — core engine work in
-  `engine/render/`, `engine/entity/`, `engine/system/`, `engine/world/`,
-  `engine/audio/`, `engine/video/`, `engine/math/`.
+- Plan issues flagged with `fleet:needs-plan` on **either repo** — read
+  the issue thread, write a structured plan, post it as an issue comment,
+  save it to `~/.fleet/plans/`, and swap labels so the queue-manager
+  ingests it.
+- Execute `Model: opus` tasks from **either** the engine `TASKS.md` or
+  the game `TASKS.md`. There is no separate game-side opus-worker; you
+  cover both queues. (game-architect is interactive only and does not
+  autonomously claim tasks.)
 - Handle tasks escalated from Sonnet agents ("escalated from sonnet"
   in the Notes field).
 
 Read the top-level `CLAUDE.md` and the sub-module `CLAUDE.md` for
-whatever directory the task touches before editing anything.
+whatever directory the task touches before editing anything. For game
+tasks, also read `~/src/IrredenEngine/creations/game/CLAUDE.md`.
+
+## Cross-repo model
+
+Each opus-worker pane has TWO worktrees:
+
+- **Engine worktree** (pane cwd at launch):
+  `~/src/IrredenEngine/.claude/worktrees/opus-worker-<N>`
+- **Game worktree** (cd here for game tasks):
+  `~/src/IrredenEngine/creations/game/.claude/worktrees/opus-worker-<N>`
+
+When you pick a task, **decide first which repo it's in** based on which
+TASKS.md it came from. For game tasks, `cd` into the game worktree
+**before** any git/gh operations. The Bash tool's cwd persists across
+calls, so one `cd` at the start of step 4 covers everything until the
+next iteration's fresh launch (which lands you back in the engine
+worktree).
+
+For commands that don't honor cwd (most `gh issue ...` and `gh api ...`
+calls), explicitly add `--repo jakildev/irreden` for game-side ops.
+
+`fleet-claim` needs the `--repo game` namespace flag for game tasks so
+the slug doesn't collide with engine T-NNN of the same number:
+
+```
+# engine task
+fleet-claim claim "T-001" opus-worker-1
+# game task — note the --repo game BEFORE the subcommand
+fleet-claim --repo game claim "T-001" opus-worker-1
+```
 
 ## Startup actions (do these immediately, in order)
 
 0. Print your role banner:
-   `[opus-worker] Plans fleet:needs-plan issues, executes [opus] tasks from TASKS.md. Loop: every 20m.`
-1. `pwd` and confirm you are in an `opus-worker-*` worktree (not
+   `[opus-worker] Plans fleet:needs-plan issues, executes [opus] tasks from engine + game TASKS.md. Loop: every 20m (fresh context).`
+1. `pwd` and confirm you are in an engine `opus-worker-*` worktree (not
    opus-architect, not a reviewer worktree). The directory basename
    (`opus-worker-1` or `opus-worker-2`) is your **agent name** — pass
    it as the `<agent>` argument to `fleet-claim claim`.
-2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. **Read the latest TASKS.md from origin/master without staging it.**
-   The working copy may be stale if the worktree is on a feature
-   branch. Use `git show` to write current master versions to temp
-   files — this does NOT touch the working tree or index, so it
-   won't break later branch checkouts:
-   `git show origin/master:TASKS.md > /tmp/tasks-master.md`
-   For plan files, list them with `git ls-tree -r origin/master --name-only -- .fleet/plans/`
-   then `git show origin/master:.fleet/plans/<file>` for any you
-   need to read. Do NOT use `git checkout origin/master -- ...` —
+2. Fetch both repos (separate calls):
+   `git -C ~/src/IrredenEngine fetch origin --quiet`
+   `git -C ~/src/IrredenEngine/creations/game fetch origin --quiet`
+3. **Read the latest TASKS.md from origin/master without staging.**
+   Use `git show` to write current master versions to temp files — does
+   NOT touch the working tree or index, so it won't break later branch
+   checkouts. Two repos, two temp files:
+   `git -C ~/src/IrredenEngine show origin/master:TASKS.md > /tmp/tasks-engine.md`
+   `git -C ~/src/IrredenEngine/creations/game show origin/master:TASKS.md > /tmp/tasks-game.md`
+   For plan files, list them with `git -C <repo> ls-tree -r origin/master --name-only -- .fleet/plans/`
+   then `git -C <repo> show origin/master:.fleet/plans/<file>` for any
+   you need to read. Do NOT use `git checkout origin/master -- ...` —
    it stages the files and breaks later `git checkout -b`.
-4. Read `/tmp/tasks-master.md` (use the Read tool) — review the current queue.
-4. `gh pr list --state open --json number,title,headRefName,author` —
-   see what other agents are working on.
-5. Check for `fleet:needs-plan` issues:
+4. Read `/tmp/tasks-engine.md` and `/tmp/tasks-game.md` (Read tool) —
+   review both queues.
+5. Open-PR cross-check on both repos:
+   `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName,author`
+   `gh pr list --repo jakildev/irreden       --state open --json number,title,headRefName,author`
+6. Check for `fleet:needs-plan` issues on both repos:
    `gh issue list --repo jakildev/IrredenEngine --label "fleet:needs-plan" --state open --json number,title`
-6. Print a summary: how many `fleet:needs-plan` issues exist, which
-   `[opus]` tasks look unblocked and not claimed.
-7. Print `opus-worker standing by` (or `opus-worker standing by
+   `gh issue list --repo jakildev/irreden       --label "fleet:needs-plan" --state open --json number,title`
+7. Print a one-line summary: count of `fleet:needs-plan` issues across
+   both repos, count of unblocked unclaimed `[opus]` tasks per repo.
+8. Print `opus-worker standing by` (or `opus-worker standing by
    (dry-run)` if Mode above is `dry-run`).
 
 ## Loop behavior
@@ -105,8 +142,16 @@ Do the work, then exit cleanly:
    Also write before fleet-build and before commit-and-push so the witness
    doesn't false-alarm during long builds (threshold is 30 minutes per iteration).
 
-1. **Check for feedback labels on open PRs.**
-   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
+1. **Check for feedback labels on open PRs across both repos.**
+   ```
+   gh pr list --repo jakildev/IrredenEngine --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "engine #\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'
+   gh pr list --repo jakildev/irreden       --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "game #\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'
+   ```
+
+   For game-side feedback work, **cd into the game opus-worker
+   worktree** before any git/gh ops (same as step 4 for new tasks):
+   `cd ~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-name>`
+   And add `--repo jakildev/irreden` to gh label edits below.
 
    **Skip** PRs labeled `human:wip` — human is working on it directly.
 
@@ -142,10 +187,11 @@ Do the work, then exit cleanly:
 
    Address all flagged PRs before doing any other work.
 
-2. **Plan any `fleet:needs-plan` issues.**
+2. **Plan any `fleet:needs-plan` issues on either repo.**
    `gh issue list --repo jakildev/IrredenEngine --label "fleet:needs-plan" --state open --json number,title,body,comments`
+   `gh issue list --repo jakildev/irreden       --label "fleet:needs-plan" --state open --json number,title,body,comments`
 
-   For each issue:
+   Process the oldest first across both repos. For each issue:
    a. Read the full issue thread (title, body, all comments).
    b. Assess the scope and write a structured plan. Post it as an
       issue comment covering:
@@ -186,8 +232,11 @@ Do the work, then exit cleanly:
    d. Remove the `fleet:needs-plan` label. Do NOT touch
       `human:approved` — it's still on the issue from when the
       human triaged it, and removing it would erase the human's
-      original signal:
-      `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan"`
+      original signal. Use the issue's repo:
+      `gh issue edit <N> --repo <owner/repo> --remove-label "fleet:needs-plan"`
+      (where `<owner/repo>` is `jakildev/IrredenEngine` for engine
+      issues or `jakildev/irreden` for game issues — the repo where
+      the issue lives, not your worktree's repo).
       The queue-manager's ingestion search (`label:human:approved
       -label:fleet:queued -label:fleet:needs-plan -label:fleet:needs-info`)
       now matches this issue on its next pass — it ingests the issue,
@@ -195,10 +244,6 @@ Do the work, then exit cleanly:
 
    If you disagree with the issue's direction, comment with your
    concerns but leave `fleet:needs-plan` on — let the human decide.
-
-   Also check the game repo for `fleet:needs-plan` issues:
-   `gh issue list --repo jakildev/irreden --label "fleet:needs-plan" --state open --json number,title,body,comments`
-   Same planning flow, but use `--repo jakildev/irreden` for label edits.
 
 3. **Resume an active molecule first, then pick the next task.**
 
@@ -238,52 +283,87 @@ Do the work, then exit cleanly:
      `failed` instead of `done` and surface the failure to the human
      before continuing.
 
+     **Cross-repo molecules:** if the in-flight molecule's tasks live
+     in the game repo (the molecule was claimed with `--repo game`),
+     all `fleet-claim molecule advance/complete` calls must include
+     `--repo game` too. Cd into the game opus-worker worktree before
+     resuming so commit-and-push targets the right repo (see step 4
+     for the cd path).
+
    - **Exit 1** — the molecule has no remaining work (every task is
      `done` or `failed`). Archive it and release the stack-claim:
      `fleet-claim molecule complete <your-worktree-name>`
-     Then proceed with the normal pickup flow.
+     (add `--repo game` for game-side molecules.) Then proceed with
+     the normal pickup flow.
 
    - **Exit 2** — no molecule for this agent. Proceed with the normal
      pickup flow below.
 
-   **Normal pickup (no active molecule):** Read `TASKS.md` (use the
-   Read tool) and find the first `[ ]` item in `## Open` with `Model:
-   opus` whose:
+   **Normal pickup (no active molecule)** — pick from either queue.
+   Look at both `/tmp/tasks-engine.md` and `/tmp/tasks-game.md`. Find
+   the first `[ ]` item in `## Open` with `Model: opus` whose:
    - **Owner** is `free` (or your worktree name)
    - **Blocked by** is empty (or only references already-merged work)
    - **Title is NOT referenced in any open PR's title or branch name**
-     (cross-check with the `gh pr list` output)
+     in **the same repo** (cross-check with the per-repo `gh pr list`
+     output from step 5)
+
+   **Priority:** prefer engine tasks over game tasks when both are
+   available — engine work is the core dependency surface. But if
+   there are no unblocked engine `[opus]` tasks and the game has one,
+   take the game task; don't sit idle waiting for engine work.
 
    **Deterministic pickup — only these signals count:**
    - The task's `Owner:` field in TASKS.md
    - The task's `Blocked by:` field in TASKS.md
-   - Open PR titles/branches (the live in-flight signal)
-   - `fleet-claim`'s lock state (atomic claims)
+   - Open PR titles/branches in the task's repo (the live in-flight
+     signal)
+   - `fleet-claim`'s lock state (atomic claims, with `--repo game`
+     namespacing for game tasks)
 
    Do NOT defer to free-form "directives", "recommendations", "fleet
    notes", or any prose hint suggesting another agent should handle
    the task. If a task is genuinely reserved for another agent, that
    agent must hold the `fleet-claim` lock — period. A directive file
    sitting in `~/.fleet/plans/` is NOT a reservation; it's stale
-   prose. The opus-architect runs interactively (no `/loop`) and
-   does not autonomously claim tasks, so "reserved for opus-architect"
-   in any file other than `fleet-claim` means the work would never
-   get done. Pick it up.
+   prose. The architects run interactively (no `/loop`) and do not
+   autonomously claim tasks, so "reserved for opus-architect" or
+   "reserved for game-architect" in any file other than `fleet-claim`
+   means the work would never get done. Pick it up.
 
-   If no `Model: opus` tasks are available, print
-   `[opus-worker] No unblocked [opus] tasks — standing by. Next run in ~20m.`
+   If no `Model: opus` tasks are available on either repo, print
+   `[opus-worker] No unblocked [opus] tasks (engine + game). Next run in ~20m.`
    and exit cleanly. Do NOT invent work, self-assign documentation
    passes, or create tasks outside the queue.
 
-   Print the task and explain why you picked it.
+   Print the task and explain why you picked it. **State which repo
+   the task is from** — you'll need this for step 4.
 
-4. **Claim the task, then open a PR with `fleet:wip`.**
+4. **Switch to the right worktree, claim, open a `fleet:wip` PR.**
    Do NOT edit `TASKS.md` — only the queue-manager touches it.
 
-   Acquire the local filesystem lock. **Always pass the task ID**,
+   **For a game task: cd into the game opus-worker worktree FIRST.**
+   This makes commit-and-push, gh pr create, and `fleet-claim`'s
+   dependency check all pick up the right repo automatically:
+   `cd ~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-name>`
+   (e.g. `cd ~/src/IrredenEngine/creations/game/.claude/worktrees/opus-worker-1`).
+   For an engine task, stay in your engine worktree (no cd needed).
+
+   Then acquire the local filesystem lock. **Always pass the task ID**,
    and pass your worktree basename (`opus-worker-1` or `opus-worker-2`)
    as the agent name so it's visible in `fleet-claim list`:
-   `fleet-claim claim "<task ID, e.g. T-003>" <your-worktree-name>`
+
+   ```
+   # engine task
+   fleet-claim claim "<task ID, e.g. T-003>" <your-worktree-name>
+
+   # game task — note --repo game BEFORE the subcommand
+   fleet-claim --repo game claim "<task ID, e.g. T-002>" <your-worktree-name>
+   ```
+
+   The `--repo game` namespace prefixes the slug with `game-` so it
+   doesn't collide with engine tasks of the same T-NNN. Mirror it in
+   `release` / `release-stack` calls later.
 
    - **Exit 0** — you own it. Proceed.
    - **Exit 1 (already taken)** — go back to step 3, pick another.
@@ -441,17 +521,32 @@ Do the work, then exit cleanly:
     editing in response to comments, re-run `optimize` (if the perf
     surface changed) before invoking `commit-and-push` to push the fix.
 
-11. **Finalize the PR.** Use `commit-and-push` to push work commits.
-    Remove the WIP label and release the claim:
-    `gh pr edit <N> --remove-label "fleet:wip"`
-    `fleet-claim release "<task ID>"`
+11. **Finalize the PR.** Use `commit-and-push` to push work commits
+    (commit-and-push uses cwd's git repo automatically — for game
+    tasks, you cd'd in step 4, so it targets the right repo).
+    Remove the WIP label and release the claim. **For game tasks,
+    add `--repo jakildev/irreden` to gh and `--repo game` to
+    fleet-claim release** so the right PR + the right slug are
+    targeted:
+
+    ```
+    # engine task
+    gh pr edit <N> --remove-label "fleet:wip"
+    fleet-claim release "<task ID>"
+
+    # game task
+    gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:wip"
+    fleet-claim --repo game release "<task ID>"
+    ```
     Paste the PR URL.
 
 12. **Reset.** Use the `start-next-task` skill to land on a fresh
-    branch off `origin/master`. Print
+    branch off `origin/master` in the **current cwd's repo** (engine
+    if you didn't cd; game if you did). Print
     `[opus-worker] Iteration complete. Next run in ~20m (fresh context).`
     Then exit cleanly. `fleet-babysit` will relaunch a fresh `claude`
-    in ~20 minutes — no carry-over from this task.
+    in ~20 minutes — the new process lands cwd back in the engine
+    worktree, so the next iteration starts from a clean slate.
 
 If Mode above is `dry-run`: do startup actions only. Do not plan or
 pick a task. Wait for human instruction.

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -30,18 +30,49 @@ set -euo pipefail
 CLAIMS_DIR="${FLEET_CLAIMS_DIR:-$HOME/.fleet/claims}"
 MOLECULES_DIR="${FLEET_MOLECULES_DIR:-$HOME/.fleet/molecules}"
 
+# --- global --repo <namespace> ---------------------------------------------
+#
+# Engine and game both use T-NNN task IDs that overlap (engine T-001 and
+# game T-001 are different tasks). To keep their fleet-claim slugs distinct,
+# game-side claims pass `--repo game` BEFORE the subcommand:
+#
+#   fleet-claim claim "T-002" opus-worker-1                # engine: slug=t-002
+#   fleet-claim --repo game claim "T-002" opus-worker-1    # game: slug=game-t-002
+#   fleet-claim --repo game release "T-002"                # release with same prefix
+#
+# This is parsed BEFORE the subcommand so it doesn't collide with cleanup's
+# own `--repo <owner/repo>` flag (cleanup parses --repo args after its own
+# subcommand name, so they're scoped to that subcommand).
+
+REPO_NS=""
+while [[ $# -gt 0 && "$1" == --* ]]; do
+    case "$1" in
+        --repo)    REPO_NS="$2"; shift 2 ;;
+        --repo=*)  REPO_NS="${1#--repo=}"; shift ;;
+        *)         break ;;
+    esac
+done
+
 # --- slug canonicalization ------------------------------------------------
 
 slugify() {
     # Lowercase → replace non-alnum with hyphen → collapse runs → trim
     # edges → truncate. Pure POSIX tools, no bash 4+ features.
-    echo "$1" \
+    # Prepends the global REPO_NS prefix (set by --repo above) so that
+    # game and engine tasks with the same T-NNN don't collide.
+    local base
+    base=$(echo "$1" \
         | tr '[:upper:]' '[:lower:]' \
         | sed 's/[^a-z0-9]/-/g' \
         | sed 's/--*/-/g' \
         | sed 's/^-//' \
         | sed 's/-$//' \
-        | cut -c1-80
+        | cut -c1-80)
+    if [[ -n "$REPO_NS" ]]; then
+        echo "${REPO_NS}-${base}"
+    else
+        echo "$base"
+    fi
 }
 
 # --- dependency checking --------------------------------------------------
@@ -940,7 +971,12 @@ case "${1:-}" in
         ;;
     *)
         cat <<'USAGE'
-usage: fleet-claim <command> [args]
+usage: fleet-claim [--repo <ns>] <command> [args]
+
+global options (must come BEFORE the subcommand):
+  --repo <ns>                   namespace prefix for the slug (e.g. "game").
+                                Engine and game share T-NNN IDs; this keeps
+                                their lock dirs distinct. Omit for engine.
 
 commands:
   claim "<title>" [agent]       claim a task (exit 0=claimed, 1=taken)
@@ -950,7 +986,11 @@ commands:
   stack "T-1 T-2 ..." [agent]  atomically claim a dependency chain (all-or-nothing)
   release-stack <agent>         release all tasks in an agent's stack claim
   check-stale [max-secs]        release claims older than max-secs (default: 7200)
-  cleanup [--repo o/r] ...      remove claims for merged/closed PRs
+  cleanup [--repo o/r] ...      remove claims for merged/closed PRs.
+                                NOTE: cleanup's --repo takes a full owner/repo
+                                path (e.g. "jakildev/IrredenEngine"); it lives
+                                AFTER the subcommand and is unrelated to the
+                                global --repo namespace flag above.
   clear-all                     wipe all claims (used by fleet-up on restart)
 
 molecule commands (crash-recovery state for stack claims):
@@ -967,7 +1007,9 @@ molecule commands (crash-recovery state for stack claims):
 Dependency gate:
   claim and stack check the task's Blocked by: field in TASKS.md before
   granting the claim. If any blocker is not [x] done (or MERGED for PR
-  URLs), the claim is refused. This makes dependency enforcement mechanical.
+  URLs), the claim is refused. The cwd's git repo determines which
+  TASKS.md is consulted — `cd` into the right worktree before claiming
+  cross-repo tasks.
 
 Stack claiming:
   stack claims a chain of tasks atomically. If any task is already claimed
@@ -980,7 +1022,16 @@ Stack claiming:
 
 Slug canonicalization:
   Title → lowercase → non-alnum to hyphen → collapse → trim → 80 chars.
-  All agents derive the same slug from the same TASKS.md title.
+  Optionally prefixed with "<ns>-" via the global --repo flag.
+
+Examples:
+  fleet-claim claim "T-001" opus-worker-1                  # engine claim
+  fleet-claim --repo game claim "T-002" opus-worker-1      # game claim
+  fleet-claim --repo game release "T-002"                  # release game claim
+  fleet-claim list                                         # show all claims
+                                                           # (engine + game,
+                                                           #  prefixed slugs
+                                                           #  visible in list)
 USAGE
         exit 2
         ;;

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -81,6 +81,12 @@ if [[ -d "$GAME/.git" ]]; then
     (cd "$GAME" && git fetch origin --quiet) || {
         echo "fleet-up: game git fetch failed (continuing without game panes)" >&2; }
     ensure_worktree "$GAME" .claude/worktrees/game-architect  fleet/game-architect
+    # Engine opus-workers also pick up game-side `Model: opus` tasks.
+    # Each opus-worker pane has its own game worktree so it can `cd` over
+    # for game tasks and use commit-and-push there cleanly. The pane's
+    # cwd at launch is the engine worktree; the agent cd's per task.
+    ensure_worktree "$GAME" .claude/worktrees/opus-worker-1   fleet/game-opus-worker-1
+    ensure_worktree "$GAME" .claude/worktrees/opus-worker-2   fleet/game-opus-worker-2
 else
     echo "fleet-up: game repo not found at $GAME — skipping game panes"
 fi
@@ -139,6 +145,12 @@ reset_worktree "$ENGINE/.claude/worktrees/merger"          claude/merger-scratch
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     reset_worktree "$GAME/.claude/worktrees/game-architect" claude/game-arch-scratch
+fi
+if [[ -d "$GAME/.claude/worktrees/opus-worker-1" ]]; then
+    reset_worktree "$GAME/.claude/worktrees/opus-worker-1" claude/game-opus-worker-1-scratch
+fi
+if [[ -d "$GAME/.claude/worktrees/opus-worker-2" ]]; then
+    reset_worktree "$GAME/.claude/worktrees/opus-worker-2" claude/game-opus-worker-2-scratch
 fi
 
 # ----------------------------------------------------------------------
@@ -241,6 +253,16 @@ done
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     write_worktree_settings "$GAME/.claude/worktrees/game-architect" "$GAME"
+fi
+# Game-side opus-worker worktrees (used by engine opus-worker panes when
+# they cd over for game tasks). Allow access to BOTH the game tree (the
+# worktree's own scope) and the engine tree (so engine helper scripts +
+# CLAUDE.md are reachable from a game cd).
+if [[ -d "$GAME/.claude/worktrees/opus-worker-1" ]]; then
+    write_worktree_settings "$GAME/.claude/worktrees/opus-worker-1" "$ENGINE"
+fi
+if [[ -d "$GAME/.claude/worktrees/opus-worker-2" ]]; then
+    write_worktree_settings "$GAME/.claude/worktrees/opus-worker-2" "$ENGINE"
 fi
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Why

Diagnosed live: opus-worker-2 saw game-repo task T-002 via `gh issue view 18` but couldn't execute it because:

1. The pane's only worktree is the engine one — no game-side worktree to cd into for branch / build / `commit-and-push` / `gh pr create`.
2. Game-architect is interactive (no `/loop`) and only engages when the human assigns a task, so the autonomous-pickup gap left after PR #203 (which dropped game-sonnet) had no fallback.
3. **Engine T-001 and game T-001 share the same `fleet-claim` slug** (`t-001`), so even if a worker tried both queues, claiming game T-001 would spuriously look like an engine T-001 conflict (or vice versa).

The agent itself wrote a [handoff file](file:///tmp/game-t-002-handoff-from-opus-worker-2.md) documenting all three causes correctly.

## Fix

Give each opus-worker pane a sibling game worktree, teach the role to cross-poll, and namespace fleet-claim by repo.

### `scripts/fleet/fleet-claim`
- New global `--repo <ns>` flag, parsed **before** the subcommand. Prefixes the slug with `<ns>-`:
  ```
  fleet-claim claim "T-001" engine-worker             # slug t-001
  fleet-claim --repo game claim "T-001" game-worker   # slug game-t-001
  ```
- Doesn't conflict with cleanup's existing subcommand-scoped `--repo` (which takes a full owner/repo path) — cleanup's parser sits inside `cmd_cleanup` and doesn't see the global flag.
- `check_blockers` still gets the bare task ID (no prefix) — it looks up `T-NNN` literally in the cwd-detected `TASKS.md`, which is correct because the agent is cd'd into the right repo's worktree by the time it claims.
- Tested locally: engine + game claims for same `T-001` coexist; double-claim with same `--repo` correctly fails.

### `scripts/fleet/fleet-up`
- Creates `~/src/IrredenEngine/creations/game/.claude/worktrees/opus-worker-{1,2}` on the game side (sibling to game-architect).
- Reset + settings.local.json for both. Settings allow the engine root as `additionalDirectories` so cd'd-in agents can still read engine helper scripts and CLAUDE.md.
- Branch names: `fleet/game-opus-worker-{1,2}` (distinct from `fleet/opus-worker-{1,2}` on the engine side).

### `.claude/commands/role-opus-worker.md`
- New "Cross-repo model" section: each pane has TWO worktrees (engine cwd at launch, game one at the parallel path). cd into the game worktree for game tasks before any git/gh ops; use `--repo jakildev/irreden` for cwd-blind gh calls; use `fleet-claim --repo game claim` for game tasks.
- Startup polls BOTH engine + game `TASKS.md` and PR lists.
- Task pickup considers both queues; engine takes priority when both have unblocked work, but the worker takes a game task rather than sit idle.
- Step 4 (claim/branch/PR) updated with cd-first instructions and side-by-side engine vs game examples for fleet-claim and gh.
- Step 10 (finalize) shows both label-removal forms (with/without `--repo jakildev/irreden`) and `--repo game release` for game claims.
- Step 11 (reset) notes that babysit's fresh-context relaunch lands cwd back in the engine worktree, so the next iteration starts clean.
- Loop step 1 (feedback) polls both repos; cd into the game worktree if addressing game-side feedback.
- Removed the duplicate "Also check the game repo" tail of the planning step (now native to step 2's both-repos call).

## Companion change

`creations/game/.claude/commands/role-game-architect.md` — clarify that game-architect is not the autonomous executor for routine `Model: opus` game work (engine opus-workers cover that); add `--repo game` to its own fleet-claim usage. Coming as a separate game-repo PR.

## Test plan

- [ ] After both PRs merge + fleet restart: `~/src/IrredenEngine/creations/game/.claude/worktrees/opus-worker-{1,2}` exist
- [ ] An opus-worker iteration picks up game T-002 (or any unblocked game `[opus]` task), cd's into the game worktree, claims `--repo game`, opens a game-repo PR
- [ ] `fleet-claim list` shows both `engine` and `game` namespaces clearly (slugs prefixed `game-*` for game claims)
- [ ] If both engine and game have unblocked `[opus]` tasks, the engine one is picked first
- [ ] If only the game queue has unblocked work, the worker takes it instead of idling
- [ ] Subsequent iteration (fresh launch via fleet-babysit) lands cwd back in the engine worktree

## Notes for reviewer

- The user explicitly asked: "Do we need them to also make their own worktrees, or something else." Yes to both — worktrees AND the cross-poll guidance, plus the fleet-claim namespace fix that the agent didn't flag but turns out to be a latent collision risk.
- Did NOT modify `commit-and-push` or `start-next-task` skills — they already use cwd's git repo, so cd-first works automatically.
- Sonnet-author is engine-only for now. The current game queue is all `Model: opus`, so no immediate need. If a `[sonnet]` game task appears, file a follow-up to extend sonnet-author the same way.
- The legacy `game-sonnet` worktree warning (added in PR #203) still fires if someone has it lying around; harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)