### PR TITLE
fleet: reviewers MUST set verdict label after every review (PR #230 fix)

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -201,6 +201,13 @@ end-to-end, then stop and wait for human instruction. Do not loop.
   actions on your own PRs. Always use `--comment` with a clear verdict.
 - Never commit, push, or open PRs from this worktree.
 - Never `git push --force`.
+- **Never post a review without setting the verdict label.** A review
+  without a `fleet:approved` / `fleet:needs-fix` / `fleet:blocker`
+  label is invisible to the human's merge queue. After every
+  `gh pr review --comment ...`, your VERY NEXT bash call MUST be
+  `gh pr edit <N> ... --add-label "fleet:..."`. Describing the label
+  change in the review body does NOT set the label — only the gh
+  command does. Verify with `gh pr view <N> --json labels` if unsure.
 - Do NOT take on first-pass reviews that Sonnet has not yet touched
   (unless `sonnet-reviewer` is offline AND the PR has been open more
   than 1 hour). The model split exists to conserve Opus budget.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -158,11 +158,8 @@ iteration of polling, reviewing, and exiting cleanly:
       `gh pr review <N> --repo <game-repo> --comment --body-file /tmp/review-body.md`
       **Never** use `--body "$(cat ...)"` or `--body "<text>"` — shell
       escaping of backticks and special characters causes parse errors.
-   e. Set labels — always remove stale labels first:
-      `gh pr edit <N> --repo <game-repo> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved"`
-      (swap the add-label name for `fleet:needs-fix` or `fleet:blocker` as appropriate).
 
-   For all PRs, the review body MUST end with one of these explicit lines:
+   **For all PRs (engine and game): the review body MUST end with one of:**
       - `Opus recheck not required.`
       - `Opus recheck required: <reason>` — use this if the PR touches
         any of: `engine/render/`, `engine/entity/`, `engine/system/`,
@@ -171,19 +168,46 @@ iteration of polling, reviewing, and exiting cleanly:
         modules, lifetime/ownership decisions, or concurrency. Also
         flag for Opus recheck if you're uncertain — better to escalate
         than to approve something subtle by mistake.
-   d. **Set the PR label** to match your verdict (add `--repo
-      <game-repo>` for game PRs). The label is the primary signal
-      the human uses. Always remove stale labels first:
-      `gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"`
-      (swap the label name for approved or blocker as appropriate).
-      - Verdict approve, no Nits section → `fleet:approved`
-      - Verdict approve WITH a non-empty `### Nits` section → BOTH
-        `fleet:approved` AND `fleet:has-nits` (the latter tells the
-        author worker to address the nits before the human merges)
-      - Verdict approve + "Opus recheck required" → **do not label**.
-        Leave it unlabeled; Opus will set the final label.
-      - Verdict needs-fix → `fleet:needs-fix`
-      - Verdict blocker → `fleet:blocker`
+
+   **For all PRs: set the verdict label IMMEDIATELY after posting the
+   review.** This is the single most-skipped step in the loop, and it's
+   the primary signal the human uses to decide what to merge — a review
+   without a label is invisible to the human's merge queue. Your VERY
+   NEXT bash call after `gh pr review` MUST be `gh pr edit ... --add-label`.
+   Do not move on to the next PR or exit the iteration without confirming
+   the label is set (`gh pr view <N> --json labels --jq '.labels[].name'`
+   after the edit, if you want to be sure).
+
+   Always remove stale verdict labels before adding the new one. For
+   game PRs, add `--repo <game-repo>` to the gh pr edit call.
+
+   ```
+   # Verdict approve, no Nits section:
+   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:approved"
+
+   # Verdict approve WITH a non-empty `### Nits` section (also set fleet:has-nits):
+   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved" --add-label "fleet:has-nits"
+
+   # Verdict needs-fix:
+   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"
+
+   # Verdict blocker:
+   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --add-label "fleet:blocker"
+
+   # Re-review of a previously fleet:has-nits PR that's now clean:
+   #   removes the has-nits flag while keeping fleet:approved
+   gh pr edit <N> --remove-label "fleet:has-nits"
+   ```
+
+   Special case: **Verdict approve + "Opus recheck required"** → do NOT
+   set any verdict label. Leave it unlabeled; opus-reviewer will set
+   the final label on its next pass. (You still set `fleet:has-nits`
+   here if there are nits, even without a verdict label.)
+
+   The `review-pr` skill (invoked for engine single-task PRs) writes
+   its own label per the same rules — but if you find a PR you reviewed
+   without a label after the skill returns, run the gh pr edit yourself
+   immediately. Don't assume the skill did it.
 
    **Nits vs real issues — the bright line:**
    - **Approve with nits** is fine for genuinely-optional cosmetic
@@ -243,4 +267,15 @@ for human instruction. Do not loop.
   actions on your own PRs. Always use `--comment` with a clear
   verdict line (`Verdict: approve`, `Verdict: needs-fix`, etc.).
 - Never `git push --force` (you have no reason to push at all).
+- **Never post a review without setting the verdict label.** A review
+  comment without a `fleet:approved` / `fleet:needs-fix` /
+  `fleet:blocker` label is invisible to the human's merge queue —
+  the human filters PRs by label, not by review body. After every
+  `gh pr review --comment ...`, your VERY NEXT bash call MUST be
+  `gh pr edit <N> ... --add-label "fleet:..."`. This is the
+  most-skipped step in the loop; it has been observed in production
+  on PR #230 (re-review approve, no label set, PR sat invisible).
+  If you described the label change in the review body but didn't
+  run the gh command, the label is NOT set — describing isn't
+  doing. Verify with `gh pr view <N> --json labels`.
 - Single-command Bash only (see CRITICAL section above).

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -273,12 +273,25 @@ merge. Merging is always the user's call.
 
 ### 5b. Set the PR label to match the verdict
 
-After posting the review comment, set the label so the human can see
-at a glance which PRs are ready. **Always remove stale verdict labels
-before adding the new one** — a PR should have exactly one verdict
-label (`fleet:approved` / `fleet:needs-fix` / `fleet:blocker`) at any
-time. The `fleet:has-nits` label is orthogonal — it can ride on top
-of `fleet:approved`.
+**This step is non-negotiable.** A review without a verdict label is
+invisible to the human's merge queue — they filter PRs by label, not
+by review body. Posting a review and then exiting without setting the
+label leaves the PR in limbo (observed in production on PR #230, where
+both first-pass and re-review approved but the agent only described
+the label in the body and never ran the gh command — PR sat unlabeled
+for hours).
+
+Your VERY NEXT bash call after `gh pr review --comment ...` MUST be
+the `gh pr edit ... --add-label` below. Don't move on to the next PR
+or invoke any other skill until you've confirmed the label is set
+(verify with `gh pr view <N> --json labels --jq '.labels[].name'` if
+you need to be sure).
+
+**Always remove stale verdict labels before adding the new one** —
+a PR should have exactly one verdict label (`fleet:approved` /
+`fleet:needs-fix` / `fleet:blocker`) at any time. The
+`fleet:has-nits` label is orthogonal — it can ride on top of
+`fleet:approved`.
 
 ```bash
 # For approve, no nits in body:


### PR DESCRIPTION
## Why

PR #230 sat unlabeled for hours despite TWO approve verdicts (first-pass + re-review). The sonnet-reviewer described the label change in prose ("Removing fleet:has-nits", "Verdict: approve") but never actually ran `gh pr edit ... --add-label`. A review without a label is invisible to the human's merge queue — they filter by label, not by review body.

I added `fleet:approved` to PR #230 manually. This PR fixes the underlying role bug so it doesn't recur.

## Three problems compounded

**1. `role-sonnet-reviewer.md` was structurally broken.**
The engine PR flow ("invoke `review-pr` skill") had NO follow-up label step. The label block existed in two places:
- `e.` inside the Game PRs subsection — game-repo-specific, no `fleet:has-nits` handling.
- `d.` orphaned after the Opus-recheck note — the complete one with all verdict cases.

For an engine PR going through `review-pr`, the agent could read "invoke review-pr skill" and just exit without ever encountering the label step. The `e.`/`d.` numbering was also out of sequence (Game PRs already had `d.` and `e.`), making the orphan look like a continuation rather than a top-level rule.

**2. Wording was passive throughout.**
"Set the PR label..." reads as documentation, not an instruction the agent must execute. With the new fresh-context-per-iteration model (PR #221), there's no muscle memory carrying over from prior loop runs to remind the agent.

**3. The `review-pr` skill describes labels at section 5b but doesn't force the order.**
Agent posts the review at step 5, drifts off into "Report back" (step 6), forgets 5b ever happened.

## Files

- `.claude/commands/role-sonnet-reviewer.md` — eliminated duplicate label blocks; replaced with one shared "After posting any review: set verdict label IMMEDIATELY" section that applies to both engine and game flows. Added re-review case for clearing `fleet:has-nits` while keeping `fleet:approved` (what PR #230's re-review needed but didn't execute). New hard rule at the bottom citing PR #230.
- `.claude/commands/role-opus-reviewer.md` — same hard rule mirrored. Its loop was already clean (single a..f with f. = label step) but the hard rule is cheap insurance.
- `.claude/skills/review-pr/SKILL.md` — rewrote 5b intro from descriptive to imperative: "Your VERY NEXT bash call after `gh pr review` MUST be `gh pr edit --add-label`." Cited PR #230 as production example.

## Test plan

- [ ] After merge + fleet restart: sonnet-reviewer reviews a fresh PR. Confirm `gh pr view <N> --json labels` shows the verdict label immediately after the review comment lands.
- [ ] Re-review of a `fleet:has-nits` PR (after author addressed): sonnet-reviewer removes `fleet:has-nits` while keeping `fleet:approved`.
- [ ] opus-reviewer's existing flow still works (no behavior change there, just an extra hard rule).
- [ ] An engine PR going through `review-pr` skill ends up labeled — either by the skill itself, or (if skill misses) by the calling reviewer's belt-and-suspenders check.

## Notes for reviewer

- The PR #230 label was set manually (`gh pr edit 230 --add-label "fleet:approved"`) before this PR was opened. The bug fix is forward-looking; the PR itself is now visible in the merge queue.
- Did not change the underlying gh command set — same labels, same flag patterns, same verdict→label mapping. Pure docs/instructions strengthening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)