### PR TITLE
render: GPU timer query infrastructure Part 1 (T-028)

### DIFF
--- a/.claude/skills/optimize/SKILL.md
+++ b/.claude/skills/optimize/SKILL.md
@@ -136,33 +136,56 @@ re-enable the profiler before re-running.
 
 ### 3. GPU profiling
 
-The engine **does not currently have GPU timer query infrastructure**
-in production. The OpenGL bindings (`engine/render/include/glad/glad.h`)
-expose `glQueryCounter` / `GL_TIMESTAMP`, but no engine code uses
-them. There is no per-pass timing API and no Lua-accessible breakdown.
+The engine has **per-pass GPU stage timing** wired into the render
+pipeline. Every major stage (`voxelCompact`, `voxelStage1`,
+`voxelStage2`, `shapeCompact`, `shapePass0`, `shapePass1`,
+`textToTrixel`, `computeVoxelAO`, `computeSunShadow`,
+`lightingToTrixel`, `trixelToTrixel`, `trixelToFb`, `entityCanvasToFb`,
+`fbToScreen`, `canvasClear`) brackets its GPU work with
+`device()->finish()` + `std::chrono::steady_clock` samples and writes
+the per-frame millisecond cost into `IRRender::gpuStageTiming()`.
 
-This is the work tracked in **jakildev/IrredenEngine#173** ("Skill:
-render performance optimization loop"). Until that lands, GPU
-profiling here is qualitative:
+Enable it by setting `gpu_stage_timing = true` in the creation's
+`.irconf` file, or flip it at runtime from Lua:
 
-- **Use RenderDoc** for a single-frame capture if the human can run
-  it (RenderDoc is GUI; you can't drive it from here). Tell the
-  human what to look at — which pass, which draw call, which compute
-  dispatch.
-- **Use shader-side counters** as a proxy: a debug uniform
-  incremented per work-group, read back via SSBO, gives a coarse
-  cost estimate. Useful for "is the new compute pass even running"
-  but not for ms-level timing.
-- **Compare frame time before/after** with the engine's existing
-  frame counter (`IRTime` / wherever `getDeltaTime()` lives) — log
-  the average delta over 300 frames before the change and after.
-  Coarse but real.
+```lua
+ir.render.setGpuTimingEnabled(true)
+-- ... let the scene render for a few frames ...
+local budget = ir.render.getFrameTimeBudgetMs()   -- 16.667
+for _, row in ipairs(ir.render.getPassTimings()) do
+    print(row.name, row.ms, row.budgetMs, row.overBudget)
+end
+```
 
-**If the change touches a render pipeline stage and the impact isn't
-obvious from inspection alone**, comment on the PR that
-`jakildev/IrredenEngine#173` is required to validate the perf cost,
-and surface the missing infrastructure to the human. Don't merge
-hot-path GPU work blind.
+`getPassTimings()` returns an ordered list of
+`{name, ms, budgetMs, budgetShare, overBudget}` rows; a row whose
+`overBudget` is true has exceeded its allocated slice of the 16.67 ms
+frame budget. `getPassTiming(name)` fetches a single pass by name.
+
+When the flag is on, the end-of-run profile report
+(`save_files/profile_report.txt`) also includes the per-stage sum so
+pre/post A/B comparisons can be read from disk.
+
+Real async `GL_TIMESTAMP` / Metal counter-sample queries are not wired
+yet — the current path uses `glFinish()`-style stalls, which measure
+GPU cost accurately but at a small per-frame throughput cost. Default
+is **off**; leave it off in release runs. Turn it on while optimizing,
+then turn it off.
+
+Complementary tools when you need a finer single-frame view:
+
+- **RenderDoc / Xcode GPU capture** for a single-frame breakdown if
+  the human can run it (GUI tools; you can't drive them from here).
+  Tell the human which pass to focus on based on
+  `getPassTimings()` hot rows.
+- **Shader-side counters** as a proxy: a debug uniform incremented
+  per work-group, read back via SSBO, gives coarse "is this pass even
+  running" data.
+
+**Do not merge hot-path GPU work blind** — if a render PR's
+`getPassTimings()` output shows a pass over its budget share, either
+fix the regression or surface it explicitly in the PR body with
+before/after numbers.
 
 ### 4. Engine-specific optimizations to check
 
@@ -275,23 +298,21 @@ optimize: 3 files profiled (engine/render/, shaders/glsl/)
 
 CPU hotspots: none. The new pass is GPU-bound.
 
-GPU profiling: limited — engine has no timer-query infrastructure
-(see #173). Frame-time A/B with 300-frame averages:
-  - before: 14.2 ms ± 0.3
-  - after:  16.8 ms ± 0.4
-  - delta:  +2.6 ms (16% over budget at 60fps)
+GPU profiling: `ir.render.setGpuTimingEnabled(true)` + 300-frame
+averages from `ir.render.getPassTimings()`:
+  - lightingToTrixel:    0.4 ms → 3.0 ms  (budget 1.7 ms — OVER)
+  - trixelToFb:          2.1 ms → 2.1 ms  (budget 2.5 ms — ok)
+  - fbToScreen:          0.3 ms → 0.3 ms  (budget 0.8 ms — ok)
+  - total frame:        14.2 ms → 16.8 ms (+2.6 ms, 16% over budget)
 
-Hotspot suspect (RenderDoc capture needed, asked human to run):
-  c_lighting_apply.glsl — likely the per-pixel 3x3x3 sample loop.
-  Reading the occupancy grid 27 times per pixel.
+Hotspot confirmed: lightingToTrixel jumped 2.6 ms on its own —
+matches the per-pixel 3x3x3 sample loop I added.
 
 Optimization applied:
   - Switched to a 2D shadow texture lookup once per pixel instead
     of per-sample, then modulated by the precomputed AO texture.
-  - Re-measured: 14.5 ms ± 0.3 (+0.3 ms over original — acceptable).
-
-Reported for human:
-  - GPU timer queries needed before next render PR (issue #173).
+  - Re-measured lightingToTrixel: 0.7 ms (within budget).
+  - Total frame: 14.5 ms ± 0.3 (+0.3 ms over original — acceptable).
 
 ready for simplify pass.
 ```

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -28,6 +28,9 @@ struct GpuStageTiming {
     float fbToScreenMs_        = 0.0f;
     std::uint32_t visibleShapeCount_ = 0;
     std::uint32_t shapeGroupsZ_ = 0;
+    // Only flipped between frames by Lua on the main thread (Lua runs in
+    // INPUT/UPDATE, never RENDER). Stable across the RENDER pipeline, so
+    // probes can read `enabled_` twice and rely on both values matching.
     bool enabled_ = false;
 };
 

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -1,22 +1,31 @@
 #ifndef GPU_STAGE_TIMING_H
 #define GPU_STAGE_TIMING_H
 
+#include <array>
 #include <chrono>
 #include <cstdint>
+#include <string_view>
 
 namespace IRRender {
 
+inline constexpr float kFrameTimeBudgetMs = 1000.0f / 60.0f;
+
 struct GpuStageTiming {
-    float canvasClearMs_ = 0.0f;
-    float voxelCompactMs_ = 0.0f;
-    float voxelStage1Ms_ = 0.0f;
-    float voxelStage2Ms_ = 0.0f;
-    float shapeCompactMs_ = 0.0f;
-    float shapePass0Ms_ = 0.0f;
-    float shapePass1Ms_ = 0.0f;
-    float trixelToFbMs_ = 0.0f;
-    float entityCanvasToFbMs_ = 0.0f;
-    float fbToScreenMs_ = 0.0f;
+    float canvasClearMs_       = 0.0f;
+    float voxelCompactMs_      = 0.0f;
+    float voxelStage1Ms_       = 0.0f;
+    float voxelStage2Ms_       = 0.0f;
+    float shapeCompactMs_      = 0.0f;
+    float shapePass0Ms_        = 0.0f;
+    float shapePass1Ms_        = 0.0f;
+    float textToTrixelMs_      = 0.0f;
+    float computeVoxelAoMs_    = 0.0f;
+    float computeSunShadowMs_  = 0.0f;
+    float lightingToTrixelMs_  = 0.0f;
+    float trixelToTrixelMs_    = 0.0f;
+    float trixelToFbMs_        = 0.0f;
+    float entityCanvasToFbMs_  = 0.0f;
+    float fbToScreenMs_        = 0.0f;
     std::uint32_t visibleShapeCount_ = 0;
     std::uint32_t shapeGroupsZ_ = 0;
     bool enabled_ = false;
@@ -32,6 +41,41 @@ using TimePoint = SteadyClock::time_point;
 
 inline float elapsedMs(TimePoint start, TimePoint end) {
     return std::chrono::duration<float, std::milli>(end - start).count();
+}
+
+// `budgetShare_` values do not sum to 1.0 — they are per-pass soft
+// budgets reflecting the relative weight of each pass at current
+// scales. A pass exceeding its share is flagged as over-budget; the
+// absolute 16.67 ms frame limit is a separate top-line check.
+struct GpuStageInfo {
+    std::string_view name_;
+    float GpuStageTiming::* field_;
+    float budgetShare_;
+};
+
+inline const std::array<GpuStageInfo, 15> &gpuStageRegistry() {
+    static const std::array<GpuStageInfo, 15> registry{{
+        {"canvasClear",       &GpuStageTiming::canvasClearMs_,      0.05f},
+        {"voxelCompact",      &GpuStageTiming::voxelCompactMs_,     0.10f},
+        {"voxelStage1",       &GpuStageTiming::voxelStage1Ms_,      0.20f},
+        {"voxelStage2",       &GpuStageTiming::voxelStage2Ms_,      0.15f},
+        {"shapeCompact",      &GpuStageTiming::shapeCompactMs_,     0.05f},
+        {"shapePass0",        &GpuStageTiming::shapePass0Ms_,       0.10f},
+        {"shapePass1",        &GpuStageTiming::shapePass1Ms_,       0.10f},
+        {"textToTrixel",      &GpuStageTiming::textToTrixelMs_,     0.05f},
+        {"computeVoxelAO",    &GpuStageTiming::computeVoxelAoMs_,   0.10f},
+        {"computeSunShadow",  &GpuStageTiming::computeSunShadowMs_, 0.10f},
+        {"lightingToTrixel",  &GpuStageTiming::lightingToTrixelMs_, 0.10f},
+        {"trixelToTrixel",    &GpuStageTiming::trixelToTrixelMs_,   0.05f},
+        {"trixelToFb",        &GpuStageTiming::trixelToFbMs_,       0.15f},
+        {"entityCanvasToFb",  &GpuStageTiming::entityCanvasToFbMs_, 0.05f},
+        {"fbToScreen",        &GpuStageTiming::fbToScreenMs_,       0.05f},
+    }};
+    return registry;
+}
+
+inline float budgetMsFor(const GpuStageInfo &info) {
+    return kFrameTimeBudgetMs * info.budgetShare_;
 }
 
 } // namespace IRRender

--- a/engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp
@@ -108,6 +108,9 @@ template <> struct System<COMPUTE_SUN_SHADOW> {
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
+                // Assumes a single matching canvas per frame. Switch to `+=`
+                // with a `beginTick` reset if the filter ever matches
+                // multiple entities — otherwise later entities overwrite.
                 if (timing.enabled_) { IRRender::device()->finish(); timing.computeSunShadowMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             []() {

--- a/engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp
@@ -21,6 +21,7 @@
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/components/component_canvas_sun_shadow.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -78,6 +79,10 @@ template <> struct System<COMPUTE_SUN_SHADOW> {
                 if (!behavior.useCameraPositionIso_) return;
                 IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
 
+                auto &timing = IRRender::gpuStageTiming();
+                IRRender::TimePoint t0;
+                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
+
                 canvasTextures.getTextureDistances()->bindAsImage(
                     0, TextureAccess::READ_ONLY, TextureFormat::R32I
                 );
@@ -102,6 +107,8 @@ template <> struct System<COMPUTE_SUN_SHADOW> {
                 );
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+
+                if (timing.enabled_) { IRRender::device()->finish(); timing.computeSunShadowMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             []() {
                 s_program->use();

--- a/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
@@ -19,6 +19,7 @@
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/components/component_canvas_ao_texture.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -59,6 +60,10 @@ template <> struct System<COMPUTE_VOXEL_AO> {
                 if (!behavior.useCameraPositionIso_) return;
                 IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
 
+                auto &timing = IRRender::gpuStageTiming();
+                IRRender::TimePoint t0;
+                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
+
                 canvasTextures.getTextureDistances()->bindAsImage(
                     0, TextureAccess::READ_ONLY, TextureFormat::R32I
                 );
@@ -80,6 +85,8 @@ template <> struct System<COMPUTE_VOXEL_AO> {
                 );
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+
+                if (timing.enabled_) { IRRender::device()->finish(); timing.computeVoxelAoMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             []() { s_program->use(); }
         );

--- a/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
@@ -86,6 +86,9 @@ template <> struct System<COMPUTE_VOXEL_AO> {
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
+                // Assumes a single matching canvas per frame. Switch to `+=`
+                // with a `beginTick` reset if the filter ever matches
+                // multiple entities — otherwise later entities overwrite.
                 if (timing.enabled_) { IRRender::device()->finish(); timing.computeVoxelAoMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             []() { s_program->use(); }

--- a/engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp
+++ b/engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp
@@ -9,6 +9,7 @@
 #include <irreden/render/components/component_trixel_framebuffer.hpp>
 #include <irreden/render/components/component_camera_position_2d_iso.hpp>
 #include <irreden/render/components/component_texture_scroll.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
 
 #include <vector>
 
@@ -51,6 +52,10 @@ template <> struct System<FRAMEBUFFER_TO_SCREEN> {
             [](const C_TrixelCanvasFramebuffer &framebuffer,
                const C_Position3D &cameraPosition,
                const C_Name &name) {
+                auto &timing = IRRender::gpuStageTiming();
+                IRRender::TimePoint t0;
+                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
+
                 framebuffer.bindTextures(0, 1);
                 frameData.mvpMatrix =
                     calcProjectionMatrix() * calcModelMatrix(
@@ -63,8 +68,11 @@ template <> struct System<FRAMEBUFFER_TO_SCREEN> {
                 s_frameDataBuf->subData(0, sizeof(FrameDataFramebuffer), &frameData);
                 IRRender::device()->setPolygonMode(PolygonMode::FILL);
                 IRRender::device()->drawArrays(DrawMode::TRIANGLES, 0, 6);
+
+                if (timing.enabled_) { IRRender::device()->finish(); timing.fbToScreenMs_ += IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             []() {
+                IRRender::gpuStageTiming().fbToScreenMs_ = 0.0f;
                 bindDefaultFramebuffer();
                 clearDefaultFramebuffer();
                 s_program->use();

--- a/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
@@ -178,6 +178,9 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
+                // Assumes a single matching canvas per frame. Switch to `+=`
+                // with a `beginTick` reset if the filter ever matches
+                // multiple entities — otherwise later entities overwrite.
                 if (timing.enabled_) { IRRender::device()->finish(); timing.lightingToTrixelMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             []() {

--- a/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
@@ -13,6 +13,7 @@
 #include <irreden/render/components/component_canvas_sun_shadow.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -136,6 +137,10 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
                     return;
                 }
 
+                auto &timing = IRRender::gpuStageTiming();
+                IRRender::TimePoint t0;
+                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
+
                 canvasTextures.getTextureColors()->bindAsImage(
                     0, TextureAccess::READ_WRITE, TextureFormat::RGBA8
                 );
@@ -172,6 +177,8 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
                 );
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+
+                if (timing.enabled_) { IRRender::device()->finish(); timing.lightingToTrixelMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             []() {
                 s_program->use();

--- a/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
@@ -14,6 +14,7 @@
 #include <irreden/render/components/component_gui_position.hpp>
 #include <irreden/render/components/component_text_style.hpp>
 #include <irreden/common/components/component_tags_all.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
 
 #include <vector>
 
@@ -259,12 +260,17 @@ expandTextToCommands(
                 }
             },
             []() {
+                auto &timing = IRRender::gpuStageTiming();
+                timing.textToTrixelMs_ = 0.0f;
                 if (drawCommands.empty()) return;
 
                 int count = static_cast<int>(drawCommands.size());
                 if (count > kMaxGlyphCommands) {
                     count = kMaxGlyphCommands;
                 }
+
+                IRRender::TimePoint t0;
+                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
 
                 IRRender::getNamedResource<Buffer>("GlyphDrawCommandBuffer")
                     ->subData(0, count * sizeof(GlyphDrawCommand), drawCommands.data());
@@ -282,6 +288,8 @@ expandTextToCommands(
                 IRRender::device()->dispatchCompute(count, 1, 1);
                 // TODO: Look over all barriers and try and make the minimum necessary to speed up rendering
                 IRRender::device()->memoryBarrier(BarrierType::ALL);
+
+                if (timing.enabled_) { IRRender::device()->finish(); timing.textToTrixelMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             }
         );
     }

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp
@@ -7,6 +7,7 @@
 #include <irreden/ir_math.hpp>
 
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
 
 using namespace IRComponents;
 using namespace IRRender;
@@ -43,6 +44,10 @@ template <> struct System<TRIXEL_TO_TRIXEL> {
             "CanvasToFramebuffer",
             [](const C_TriangleCanvasTextures &trixelTextures,
                const C_Position2DIso &position2DIso) {
+                auto &timing = IRRender::gpuStageTiming();
+                IRRender::TimePoint t0;
+                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
+
                 trixelTextures.bind(2, 3);
                 frameData.trixelTextureOffsetZ1_ =
                     IRMath::trixelOriginOffsetZ1(trixelTextures.size_);
@@ -52,8 +57,11 @@ template <> struct System<TRIXEL_TO_TRIXEL> {
                 const int groupsY = IRMath::divCeil(trixelTextures.size_.y, kTrixelToTrixelGroupSize);
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+
+                if (timing.enabled_) { IRRender::device()->finish(); timing.trixelToTrixelMs_ += IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             []() {
+                IRRender::gpuStageTiming().trixelToTrixelMs_ = 0.0f;
                 s_program->use();
                 vec2 camIso = IRRender::getCameraPosition2DIso();
                 frameData.cameraTrixelOffset_ = ivec2(

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -121,6 +121,9 @@ void World::setupLuaBindings(const std::vector<LuaBindingRegistration> &bindings
         }
         return out;
     };
+    // Unknown names return 0.0f — indistinguishable from a pass that
+    // legitimately took 0ms. Callers that need to detect typos should
+    // enumerate names via `getPassTimings` first. 15 stages, linear is fine.
     render["getPassTiming"] = [](std::string_view name) {
         const auto &registry = IRRender::gpuStageRegistry();
         const auto &timing = IRRender::gpuStageTiming();
@@ -304,6 +307,11 @@ void World::buildAndWriteProfileReport() {
             const float perFrameMs = gpu.*info.field_;
             IRProfile::GpuStageEntry stage;
             stage.name_ = std::string(info.name_);
+            // totalMs_ is an approximation: the GpuStageTiming struct only
+            // keeps the last frame's sample, not a running sum across all
+            // frames. Multiplying by totalFrames_ estimates total GPU cost
+            // assuming steady-state — good enough for a summary report,
+            // not a true accumulator. Same snapshot is used for maxMs_.
             stage.totalMs_ = perFrameMs * static_cast<float>(report.totalFrames_);
             stage.maxMs_ = perFrameMs;
             stage.sampleCount_ = report.totalFrames_;

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -85,6 +85,51 @@ World::~World() {
 }
 
 void World::setupLuaBindings(const std::vector<LuaBindingRegistration> &bindings) {
+    sol::state &lua = m_lua.lua();
+    sol::table ir = lua["ir"].valid()
+        ? lua["ir"].get<sol::table>()
+        : lua.create_named_table("ir");
+    sol::table render = ir["render"].valid()
+        ? ir["render"].get<sol::table>()
+        : lua.create_table();
+    ir["render"] = render;
+
+    render["getFrameTimeBudgetMs"] = []() {
+        return IRRender::kFrameTimeBudgetMs;
+    };
+    render["isGpuTimingEnabled"] = []() {
+        return IRRender::gpuStageTiming().enabled_;
+    };
+    render["setGpuTimingEnabled"] = [](bool enabled) {
+        IRRender::gpuStageTiming().enabled_ = enabled;
+    };
+    render["getPassTimings"] = [&lua]() {
+        sol::table out = lua.create_table();
+        const auto &registry = IRRender::gpuStageRegistry();
+        const auto &timing = IRRender::gpuStageTiming();
+        int index = 1;
+        for (const auto &info : registry) {
+            sol::table row = lua.create_table();
+            row["name"]       = info.name_;
+            const float ms    = timing.*info.field_;
+            const float budget = IRRender::budgetMsFor(info);
+            row["ms"]         = ms;
+            row["budgetMs"]   = budget;
+            row["budgetShare"] = info.budgetShare_;
+            row["overBudget"] = ms > budget;
+            out[index++] = row;
+        }
+        return out;
+    };
+    render["getPassTiming"] = [](std::string_view name) {
+        const auto &registry = IRRender::gpuStageRegistry();
+        const auto &timing = IRRender::gpuStageTiming();
+        for (const auto &info : registry) {
+            if (info.name_ == name) return timing.*info.field_;
+        }
+        return 0.0f;
+    };
+
     for (const auto &bind : bindings) {
         bind(m_lua);
     }
@@ -253,27 +298,17 @@ void World::buildAndWriteProfileReport() {
         }
     }
 
-    // Collect GPU stage timing if enabled
     auto &gpu = IRRender::gpuStageTiming();
     if (gpu.enabled_ && report.totalFrames_ > 0) {
-        auto addGpuStage = [&](const char *name, float perFrameMs) {
+        for (const auto &info : IRRender::gpuStageRegistry()) {
+            const float perFrameMs = gpu.*info.field_;
             IRProfile::GpuStageEntry stage;
-            stage.name_ = name;
+            stage.name_ = std::string(info.name_);
             stage.totalMs_ = perFrameMs * static_cast<float>(report.totalFrames_);
-            stage.maxMs_ = perFrameMs;  // Only per-frame snapshot available
+            stage.maxMs_ = perFrameMs;
             stage.sampleCount_ = report.totalFrames_;
             report.gpuStages_.push_back(std::move(stage));
-        };
-        addGpuStage("canvas_clear", gpu.canvasClearMs_);
-        addGpuStage("voxel_compact", gpu.voxelCompactMs_);
-        addGpuStage("voxel_stage_1", gpu.voxelStage1Ms_);
-        addGpuStage("voxel_stage_2", gpu.voxelStage2Ms_);
-        addGpuStage("shape_compact", gpu.shapeCompactMs_);
-        addGpuStage("shape_pass_0", gpu.shapePass0Ms_);
-        addGpuStage("shape_pass_1", gpu.shapePass1Ms_);
-        addGpuStage("trixel_to_framebuffer", gpu.trixelToFbMs_);
-        addGpuStage("entity_canvas_to_framebuffer", gpu.entityCanvasToFbMs_);
-        addGpuStage("framebuffer_to_screen", gpu.fbToScreenMs_);
+        }
     }
 
     IRProfile::writeProfileReport(report, "save_files/profile_report.txt");


### PR DESCRIPTION
## Summary
- Add per-pass GPU stage timing infrastructure for all 15 render pipeline stages
- Expose pass timings to Lua via `ir.render.getPassTimings()` / `getPassTiming()` / `getFrameTimeBudgetMs()` / `setGpuTimingEnabled()` / `isGpuTimingEnabled()`
- Per-pass soft budgets reflect the relative weight of each pass as a fraction of the 16.67 ms frame target; passes over their share are flagged via `overBudget`
- End-of-run profile report's GPU section now iterates the same registry (single source of truth) — fixes prior hand-rolled list that only reported 10 of 15 stages
- Probes are gated on `timing.enabled_` (default off via the `gpu_stage_timing` config key) so release runs pay only a load-and-branch

## Scope
Part 1 of GPU timer query infrastructure. Uses `device()->finish()` + `std::chrono::steady_clock` samples, matching the existing pattern from earlier work. Real async `GL_TIMESTAMP` / Metal counter-sample queries will come in a later Part.

Newly instrumented passes: `computeSunShadow`, `computeVoxelAO`, `textToTrixel`, `lightingToTrixel`, `trixelToTrixel`, `fbToScreen`.

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean (macOS/Metal)
- [x] `fleet-run --timeout 8 IRShapeDebug` runs without crashing, no visual changes (probes off by default)
- [ ] Reviewer: enable `gpu_stage_timing = true` in a config and verify Lua `ir.render.getPassTimings()` returns 15 rows with sensible ms / budget values
- [ ] Reviewer: confirm profile report's GPU stage section now lists all 15 stages (not 10)

## Notes for reviewer
- Bindings live inline in `World::setupLuaBindings` rather than via the `LuaBindingRegistration` callback pattern — this avoids adding `IrredenEngineScript` to render's CMake deps (cross-module coupling). Factoring into `World::registerEngineRenderLuaBindings` is an optional follow-up if you'd prefer the helper shape.
- `gpu_stage_timing.hpp` uses pointer-to-member (`float GpuStageTiming::*`) to let the registry describe both name and destination field without macros.
- `optimize` skill (section 3 + worked example) updated to point at the new Lua API as the primary workflow.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)