### PR TITLE
fleet: witness coverage for merger + fleet-down summary cleanup

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -93,6 +93,13 @@ The `/loop` driver re-invokes this role every 10 minutes in live
 mode. Each invocation is one iteration — handle ready PRs, then
 exit cleanly:
 
+0. **Write heartbeat** — signal to the witness monitor that this agent is alive:
+   `date -u +%Y-%m-%dT%H:%M:%SZ > ~/.fleet/heartbeats/merger`
+   Witness's staleness threshold for `merger` is 20 minutes (10m loop +
+   10m budget for rebases / pushes). Re-write the heartbeat before any
+   long-running git fetch / push / rebase loop so a slow conflict
+   resolution doesn't trigger a false alert.
+
 1. **Clear all `fleet:merger-cooldown` labels.** The 10-minute loop
    interval is the cooldown — clearing at iteration start (rather
    than gating on `updatedAt`, which other agents' comments refresh)

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -155,8 +155,12 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
         # the pane index if @role isn't set.
         role=$(tmux show-options -t "$pane_id" -p -v @role 2>/dev/null | awk '{print $1}')
         [[ -z "$role" ]] && role="pane-${pane_id#%}"
+        # witness is a bash daemon, not Claude — can't write a summary.
+        if [[ "$role" == "witness" ]]; then
+            continue
+        fi
         summary_file="$SUMMARY_DIR/$role.md"
-        prompt="Before exiting: use the Write tool to save a short summary to $summary_file. Cover what's in your *current* conversation context — for workers (sonnet-author, opus-worker, sonnet-reviewer, opus-reviewer, queue-manager) that's just the current iteration's task; for architects it's the full session. Include: (1) what tasks/PRs are in your context, (2) any snags, surprises, or ergonomics issues worth fixing in the fleet tooling, (3) anything blocked or waiting. Keep under 500 words. Markdown headings welcome. Then continue your normal exit flow."
+        prompt="Before exiting: use the Write tool to save a short summary to $summary_file. Cover what's in your *current* conversation context — looping agents (sonnet-author, opus-worker-*, sonnet-reviewer, opus-reviewer, queue-manager, merger) cover just the current iteration's task / PRs; architects (opus-architect, game-architect) cover the full session. Include: (1) what tasks/PRs are in your context, (2) any snags, surprises, or ergonomics issues worth fixing in the fleet tooling, (3) anything blocked or waiting. Keep under 500 words. Markdown headings welcome. Then continue your normal exit flow."
         tmux send-keys -t "$pane_id" "$prompt" Enter
     done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
 

--- a/scripts/fleet/witness
+++ b/scripts/fleet/witness
@@ -46,6 +46,7 @@ threshold_for_agent() {
         opus-worker-1)   echo 1800 ;;   # 30m — 20m loop + 10m budget
         opus-worker-2)   echo 1800 ;;   # 30m
         opus-reviewer)   echo 2700 ;;   # 45m — 30m loop + 15m budget
+        merger)          echo 1200 ;;   # 20m — 10m loop + 10m budget
         *)               echo 0    ;;   # unknown — not monitored
     esac
 }


### PR DESCRIPTION
## Summary

The witness daemon (PR #229) and the merger orchestrator (PR #224) landed close together but never wired into each other. Two holes surfaced in an audit:

1. **`scripts/fleet/witness`** — `threshold_for_agent()` had no entry for `merger`. Even if the merger had been writing a heartbeat, witness would have silently skipped it (the `*) echo 0` fallback means "not monitored").
2. **`.claude/commands/role-merger.md`** — never wrote a heartbeat at all. So even after fix #1, witness still couldn't see it.

Together: a hung merger (mid-rebase, mid-push) was invisible. Both fixed here.

Also picks up a related cleanup in `scripts/fleet/fleet-down`:

3. The `--summary` prompt listed `(sonnet-author, opus-worker, sonnet-reviewer, opus-reviewer, queue-manager)` as "workers" and forgot `merger` entirely (it's also a looping ops agent that should write per-iteration summaries). Reframed as "looping agents" vs "architects" so future-added looping roles slot in cleanly.
4. The summary loop sent the prompt to **every** pane — including witness, which is a bash daemon, not Claude. It would dump the prompt into the shell as un-executable text. Skipped explicitly.

## Test plan

- [ ] Bring fleet up: `fleet-up live`
- [ ] Confirm `~/.fleet/heartbeats/merger` appears within ~10 min (first merger iteration writes it)
- [ ] Tail `~/.fleet/witness.log` and confirm it lists merger in the tracked-agent count
- [ ] Run `fleet-down --summary`; confirm 8 summary files (no `witness.md`) land in `~/.fleet/summaries/<ts>/`

## Notes for reviewer

- Heartbeat phrasing in `role-merger.md` mirrors the existing pattern in `role-sonnet-reviewer.md:100-101` and the other 4 looping roles.
- Threshold of 1200s = 10m loop interval + 10m budget for rebases / pushes. Matches the pattern of other roles (loop interval + per-iteration overrun budget).
- No attempt to factor heartbeat-writing into a shared helper — every other role inlines `date -u +... > ~/.fleet/heartbeats/<name>` and that's the established convention. Not worth a separate refactor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)