### PR TITLE
fleet: idle-aware --summary, label pre-creation, merger heartbeat doc

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -99,6 +99,12 @@ exit cleanly:
    10m budget for rebases / pushes). Re-write the heartbeat before any
    long-running git fetch / push / rebase loop so a slow conflict
    resolution doesn't trigger a false alert.
+   The single `>` redirect is **fine** — it's a single command, not a
+   compound chain. The "single-command Bash" rule above bans `&&`, `||`,
+   `;`, `|` between commands, not file redirects. Same goes for the audit
+   log: `echo "..." >> ~/.fleet/logs/merger-audit.log` is one command,
+   one file write — use it directly. Don't fall back to Read+Write for
+   either of these.
 
 1. **Clear all `fleet:merger-cooldown` labels.** The 10-minute loop
    interval is the cooldown — clearing at iteration start (rather

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -163,23 +163,26 @@ fi
 # The witness pane runs a bash daemon, not Claude; skip it.
 
 # Return 0 if the pane appears to be at an interactive prompt with no
-# active tool execution. Return 1 otherwise. Heuristic — captures the
-# last ~15 rows and looks for either "we're idle" or "we're busy" tells.
+# active tool execution. Return 1 otherwise.
+#
+# Heuristic: capture only the bottom ~5 rows. The prompt indicator `❯`
+# must appear in the bottom 3 of those rows AND no spinner / tool-UI
+# marker may appear anywhere in the captured rows. Restricting to the
+# bottom is essential — a pane that ran a tool a minute ago still has
+# ⏺/⎿ symbols up in scrollback, but if the prompt is at the bottom the
+# pane is ready for input. Searching the full scrollback would false-
+# positive busy and stall --summary for the entire idle-wait budget.
 pane_is_idle() {
     local pane_id="$1"
-    local capture
-    capture=$(tmux capture-pane -t "$pane_id" -p -S -15 2>/dev/null) || return 1
-    # Busy tells: thinking spinners, in-flight tool execution markers,
-    # any UI element that means "I'm not waiting for input right now".
-    # The exact glyphs Claude Code renders can shift between releases —
-    # this list is broad on purpose; false-positive busy means we just
-    # wait a bit longer (acceptable) vs false-positive idle which would
-    # send the prompt into garbage.
-    if printf '%s' "$capture" | grep -qE 'Caramelizing|Thinking|✻|✶|⏺|⎿|tool use|Allowed by|Permission required|Running…'; then
+    local tail
+    tail=$(tmux capture-pane -t "$pane_id" -p -S -5 2>/dev/null) || return 1
+    # Active-work tells in the visible bottom rows: spinners, in-flight
+    # tool UI, permission prompts. Any of these means "not ready".
+    if printf '%s' "$tail" | grep -qE 'Caramelizing|Thinking|✻|✶|⏺|⎿|tool use|Allowed by|Permission required|Running…'; then
         return 1
     fi
-    # Idle tells: prompt indicator on or near the last line.
-    if printf '%s' "$capture" | tail -3 | grep -q '❯'; then
+    # Idle tell: prompt indicator in the bottom 3 rows.
+    if printf '%s' "$tail" | tail -3 | grep -q '❯'; then
         return 0
     fi
     # Unknown state — assume busy.

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -170,19 +170,28 @@ fi
 # marker may appear anywhere in the captured rows. Restricting to the
 # bottom is essential — a pane that ran a tool a minute ago still has
 # ⏺/⎿ symbols up in scrollback, but if the prompt is at the bottom the
-# pane is ready for input. Searching the full scrollback would false-
+# pane is ready for input. Searching the full visible area would false-
 # positive busy and stall --summary for the entire idle-wait budget.
+#
+# Note on the tmux flags: we use plain `capture-pane -p` (visible only)
+# piped through `tail -5`. `capture-pane -p -S -5` does NOT capture
+# only 5 rows — it widens the capture by 5 rows of scrollback, leaving
+# the visible area's full pane_height intact. Verified empirically on
+# tmux 3.6a — what we want is the literal bottom 5 lines of output.
+# Regexes are tied to the English Claude Code TUI; if Claude Code ever
+# localizes, this list of spinner / tool tells will need updating.
 pane_is_idle() {
     local pane_id="$1"
-    local tail
-    tail=$(tmux capture-pane -t "$pane_id" -p -S -5 2>/dev/null) || return 1
+    local tail_text
+    tail_text=$(tmux capture-pane -t "$pane_id" -p 2>/dev/null | tail -5)
+    [[ -z "$tail_text" ]] && return 1
     # Active-work tells in the visible bottom rows: spinners, in-flight
     # tool UI, permission prompts. Any of these means "not ready".
-    if printf '%s' "$tail" | grep -qE 'Caramelizing|Thinking|✻|✶|⏺|⎿|tool use|Allowed by|Permission required|Running…'; then
+    if printf '%s' "$tail_text" | grep -qE 'Caramelizing|Thinking|✻|✶|⏺|⎿|tool use|Allowed by|Permission required|Running…'; then
         return 1
     fi
     # Idle tell: prompt indicator in the bottom 3 rows.
-    if printf '%s' "$tail" | tail -3 | grep -q '❯'; then
+    if printf '%s' "$tail_text" | tail -3 | grep -q '❯'; then
         return 0
     fi
     # Unknown state — assume busy.

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -18,6 +18,15 @@
 #                               before exiting; useful for "what snags did
 #                               we hit today" retros
 #
+# --summary timing knobs (env overrides):
+#   SUMMARY_IDLE_WAIT_SECONDS   max wait per pane to become idle  (default 1800)
+#   SUMMARY_WRITE_WAIT_SECONDS  max wait per pane for the file    (default 600)
+#   SUMMARY_IDLE_POLL_SECONDS   idle-check poll interval          (default 10)
+#   SUMMARY_WRITE_POLL_SECONDS  file-check poll interval          (default 5)
+# fleet-down processes panes sequentially: a busy pane stalls the rest
+# until idle or its idle deadline expires. Worst-case run time is roughly
+# (panes × (idle_wait + write_wait)).
+#
 # Note on --summary scope: workers run one task per fresh `claude`
 # process (see fleet-babysit), so an end-of-day worker summary covers
 # only the *current* iteration's task — not everything that pane has
@@ -50,10 +59,14 @@
 set -euo pipefail
 
 SESSION="fleet"
-GRACE_SECONDS=8           # how long to wait for panes to wind down after Ctrl-C
-WAIT_POLL_SECONDS=30      # how often to check for idle when --wait is set
-WAIT_MAX_SECONDS=1800     # cap --wait at 30 min (humans can re-run with --force)
-SUMMARY_WAIT_SECONDS=60   # how long to give panes to write their summaries
+GRACE_SECONDS=8                     # how long to wait for panes to wind down after Ctrl-C
+WAIT_POLL_SECONDS=30                # how often to check for idle when --wait is set
+WAIT_MAX_SECONDS=1800               # cap --wait at 30 min (humans can re-run with --force)
+# --- per-pane summary timings (override via env to tune for your fleet) ---
+SUMMARY_IDLE_WAIT_SECONDS=${SUMMARY_IDLE_WAIT_SECONDS:-1800}   # max wait for a busy pane to become idle (30m)
+SUMMARY_IDLE_POLL_SECONDS=${SUMMARY_IDLE_POLL_SECONDS:-10}     # poll interval while waiting for idle
+SUMMARY_WRITE_WAIT_SECONDS=${SUMMARY_WRITE_WAIT_SECONDS:-600}  # max wait per pane for the .md file to land (10m)
+SUMMARY_WRITE_POLL_SECONDS=${SUMMARY_WRITE_POLL_SECONDS:-5}    # poll interval while waiting for the file
 FORCE=0
 KEEP_CLAIMS=0
 WAIT_FOR_IDLE=0
@@ -66,7 +79,7 @@ for arg in "$@"; do
         --wait)         WAIT_FOR_IDLE=1 ;;
         --summary)      WANT_SUMMARY=1 ;;
         -h|--help)
-            sed -n '2,50p' "$0"
+            sed -n '2,57p' "$0"
             exit 0
             ;;
         *) echo "fleet-down: unknown argument '$arg'" >&2; exit 2 ;;
@@ -134,14 +147,56 @@ fi
 # Step 0b: --summary — request per-pane session summaries
 # ----------------------------------------------------------------------
 #
-# Send a Write-tool prompt to each pane asking it to record what it
-# worked on, what snags it hit, and what could improve. We collect
-# these in ~/.fleet/summaries/<timestamp>/<role>.md so the human can
-# review them after the fleet is down.
+# For each pane:
+#   1. Wait for the pane to become idle (no spinner / tool execution
+#      visible). A busy pane will swallow the prompt into its scrollback
+#      or worse, treat it as terminal noise. Cap at SUMMARY_IDLE_WAIT_SECONDS.
+#   2. Send the prompt text first, sleep briefly, THEN send Enter as a
+#      separate keystroke. tmux's bracketed-paste handling can otherwise
+#      consume the trailing Enter as part of the paste, leaving the text
+#      in the input field unsubmitted (the human had to manually press
+#      Enter on every pane in past runs — this fixes that).
+#   3. Wait for the .md file to actually appear before moving to the
+#      next pane. Opus agents need real time to think — 60s default was
+#      too short.
 #
-# The summaries are best-effort — if an agent is mid-iteration and
-# can't acknowledge in time, we skip it and proceed. SUMMARY_WAIT_SECONDS
-# bounds the total wait.
+# The witness pane runs a bash daemon, not Claude; skip it.
+
+# Return 0 if the pane appears to be at an interactive prompt with no
+# active tool execution. Return 1 otherwise. Heuristic — captures the
+# last ~15 rows and looks for either "we're idle" or "we're busy" tells.
+pane_is_idle() {
+    local pane_id="$1"
+    local capture
+    capture=$(tmux capture-pane -t "$pane_id" -p -S -15 2>/dev/null) || return 1
+    # Busy tells: thinking spinners, in-flight tool execution markers,
+    # any UI element that means "I'm not waiting for input right now".
+    # The exact glyphs Claude Code renders can shift between releases —
+    # this list is broad on purpose; false-positive busy means we just
+    # wait a bit longer (acceptable) vs false-positive idle which would
+    # send the prompt into garbage.
+    if printf '%s' "$capture" | grep -qE 'Caramelizing|Thinking|✻|✶|⏺|⎿|tool use|Allowed by|Permission required|Running…'; then
+        return 1
+    fi
+    # Idle tells: prompt indicator on or near the last line.
+    if printf '%s' "$capture" | tail -3 | grep -q '❯'; then
+        return 0
+    fi
+    # Unknown state — assume busy.
+    return 1
+}
+
+# Send a multi-line prompt into a pane and submit it. Splits the text
+# send and the Enter into separate calls because Claude Code's TUI
+# treats long pastes (via tmux's bracketed-paste mode) as block inserts
+# that swallow the trailing Enter.
+send_prompt_to_pane() {
+    local pane_id="$1"
+    local text="$2"
+    tmux send-keys -t "$pane_id" -- "$text"
+    sleep 0.5
+    tmux send-keys -t "$pane_id" Enter
+}
 
 SUMMARY_DIR=""
 if [[ "$WANT_SUMMARY" -eq 1 ]]; then
@@ -149,27 +204,70 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
     SUMMARY_DIR="$HOME/.fleet/summaries/$timestamp"
     mkdir -p "$SUMMARY_DIR"
     echo "fleet-down --summary: requesting per-pane summaries to $SUMMARY_DIR/"
+    echo "  (per-pane budget: idle wait ${SUMMARY_IDLE_WAIT_SECONDS}s, write wait ${SUMMARY_WRITE_WAIT_SECONDS}s)"
 
+    # Build a worklist first so we know how many panes to expect.
+    declare -a SUMMARY_PANES=()
+    declare -a SUMMARY_ROLES=()
     while IFS= read -r pane_id; do
-        # Read the pane's @role label (set by fleet-up); fall back to
-        # the pane index if @role isn't set.
         role=$(tmux show-options -t "$pane_id" -p -v @role 2>/dev/null | awk '{print $1}')
         [[ -z "$role" ]] && role="pane-${pane_id#%}"
-        # witness is a bash daemon, not Claude — can't write a summary.
         if [[ "$role" == "witness" ]]; then
             continue
         fi
-        summary_file="$SUMMARY_DIR/$role.md"
-        prompt="Before exiting: use the Write tool to save a short summary to $summary_file. Cover what's in your *current* conversation context — looping agents (sonnet-author, opus-worker-*, sonnet-reviewer, opus-reviewer, queue-manager, merger) cover just the current iteration's task / PRs; architects (opus-architect, game-architect) cover the full session. Include: (1) what tasks/PRs are in your context, (2) any snags, surprises, or ergonomics issues worth fixing in the fleet tooling, (3) anything blocked or waiting. Keep under 500 words. Markdown headings welcome. Then continue your normal exit flow."
-        tmux send-keys -t "$pane_id" "$prompt" Enter
+        SUMMARY_PANES+=("$pane_id")
+        SUMMARY_ROLES+=("$role")
     done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
 
-    echo "fleet-down --summary: waiting up to ${SUMMARY_WAIT_SECONDS}s for panes to write..."
-    sleep "$SUMMARY_WAIT_SECONDS"
+    total_panes=${#SUMMARY_PANES[@]}
+    pane_idx=0
+    for pane_id in "${SUMMARY_PANES[@]}"; do
+        role="${SUMMARY_ROLES[$pane_idx]}"
+        pane_idx=$((pane_idx + 1))
+        summary_file="$SUMMARY_DIR/$role.md"
+        echo "[$pane_idx/$total_panes] $role:"
 
-    # Report what landed.
+        # 1. Wait for idle.
+        idle_deadline=$(( $(date +%s) + SUMMARY_IDLE_WAIT_SECONDS ))
+        first_busy_report=1
+        while [[ $(date +%s) -lt $idle_deadline ]]; do
+            if pane_is_idle "$pane_id"; then
+                break
+            fi
+            if [[ "$first_busy_report" -eq 1 ]]; then
+                echo "  pane is busy — waiting up to ${SUMMARY_IDLE_WAIT_SECONDS}s for idle..."
+                first_busy_report=0
+            fi
+            sleep "$SUMMARY_IDLE_POLL_SECONDS"
+        done
+        if ! pane_is_idle "$pane_id"; then
+            echo "  pane still busy at deadline — sending prompt anyway (may not land cleanly)"
+        fi
+
+        # 2. Send the prompt.
+        prompt="Before exiting: use the Write tool to save a short summary to $summary_file. Cover what's in your *current* conversation context — looping agents (sonnet-author, opus-worker-*, sonnet-reviewer, opus-reviewer, queue-manager, merger) cover just the current iteration's task / PRs; architects (opus-architect, game-architect) cover the full session. Include: (1) what tasks/PRs are in your context, (2) any snags, surprises, or ergonomics issues worth fixing in the fleet tooling, (3) anything blocked or waiting. Keep under 500 words. Markdown headings welcome. Then continue your normal exit flow."
+        send_prompt_to_pane "$pane_id" "$prompt"
+
+        # 3. Wait for the file to appear.
+        write_deadline=$(( $(date +%s) + SUMMARY_WRITE_WAIT_SECONDS ))
+        wrote=0
+        while [[ $(date +%s) -lt $write_deadline ]]; do
+            if [[ -f "$summary_file" ]]; then
+                wrote=1
+                break
+            fi
+            sleep "$SUMMARY_WRITE_POLL_SECONDS"
+        done
+        if [[ "$wrote" -eq 1 ]]; then
+            echo "  ✓ $(basename "$summary_file") landed ($(wc -c < "$summary_file" | tr -d ' ') bytes)"
+        else
+            echo "  ✗ $(basename "$summary_file") did not appear within ${SUMMARY_WRITE_WAIT_SECONDS}s"
+        fi
+    done
+
     written=$(find "$SUMMARY_DIR" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-    echo "fleet-down --summary: $written summary file(s) written to $SUMMARY_DIR/"
+    echo
+    echo "fleet-down --summary: $written/$total_panes summary file(s) written to $SUMMARY_DIR/"
 fi
 
 # ----------------------------------------------------------------------

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -183,7 +183,11 @@ fi
 pane_is_idle() {
     local pane_id="$1"
     local tail_text
-    tail_text=$(tmux capture-pane -t "$pane_id" -p 2>/dev/null | tail -5)
+    # `|| true` defends `set -euo pipefail` against the rare case where
+    # `pane_is_idle` is invoked outside an `if`/`||`/`&&` context — the
+    # tmux capture failing then would otherwise abort the whole script.
+    # Empty tail_text below already routes to "busy" (the safe default).
+    tail_text=$(tmux capture-pane -t "$pane_id" -p 2>/dev/null | tail -5) || true
     [[ -z "$tail_text" ]] && return 1
     # Active-work tells in the visible bottom rows: spinners, in-flight
     # tool UI, permission prompts. Any of these means "not ready".

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -26,20 +26,33 @@ set -euo pipefail
 DRY_RUN=0
 TARGET_REPO=""
 
-for arg in "$@"; do
-    case "$arg" in
-        --dry-run) DRY_RUN=1 ;;
-        --repo)    : ;;  # consumed below
-        --repo=*)  TARGET_REPO="${arg#--repo=}" ;;
+# Use a while-loop so `--repo <ns>` consumes its value with `shift 2`
+# rather than relying on the value falling through to the wildcard
+# branch on the next iteration (which would silently swallow a real
+# flag if you typed `--repo --dry-run`).
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --repo)
+            # Reject if next arg is missing OR looks like another flag.
+            if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+                echo "fleet-labels: --repo requires a value (e.g. owner/repo)" >&2
+                exit 2
+            fi
+            TARGET_REPO="$2"
+            shift 2
+            ;;
+        --repo=*) TARGET_REPO="${1#--repo=}"; shift ;;
         -h|--help)
             sed -n '2,22p' "$0"
             exit 0
             ;;
         *)
-            if [[ -z "$TARGET_REPO" && "$arg" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-                TARGET_REPO="$arg"
+            if [[ -z "$TARGET_REPO" && "$1" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+                TARGET_REPO="$1"
+                shift
             else
-                echo "fleet-labels: unknown argument '$arg'" >&2
+                echo "fleet-labels: unknown argument '$1'" >&2
                 exit 2
             fi
             ;;
@@ -133,23 +146,61 @@ ensure_label_for_repo() {
 # Determine which repos to sync
 # ----------------------------------------------------------------------
 
+# Resolve a symlink chain manually. `readlink -f` works on Linux
+# (coreutils) but not on macOS BSD readlink, and `realpath` isn't on
+# every old distro. The loop below works on every POSIX shell — it's
+# what we need because fleet-up calls this script via the
+# `~/bin/fleet-labels` symlink, and `cd "$(dirname "${BASH_SOURCE[0]}")"`
+# returns the symlink's parent (e.g. `~/bin`) rather than the real
+# script's location (e.g. `~/src/.../scripts/fleet`).
+resolve_symlink_chain() {
+    local path="$1"
+    while [[ -L "$path" ]]; do
+        local target
+        target=$(readlink "$path")
+        if [[ "$target" = /* ]]; then
+            path="$target"
+        else
+            path="$(cd "$(dirname "$path")" && pwd)/$target"
+        fi
+    done
+    echo "$path"
+}
+
+# Parse `owner/repo` from a git remote URL. Handles both SSH
+# (git@github.com:owner/repo[.git]) and HTTPS
+# (https://github.com/owner/repo[.git]) forms via bash parameter
+# expansion — no sed dependency.
+slug_from_remote() {
+    local url="$1"
+    local slug="${url#*github.com[:/]}"
+    slug="${slug%.git}"
+    echo "$slug"
+}
+
 REPOS=()
 if [[ -n "$TARGET_REPO" ]]; then
     REPOS=("$TARGET_REPO")
 else
-    # Engine repo: discover from the script's own location
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # Engine repo: discover from the script's own location, after
+    # following any symlink chain (production invocation is always
+    # via the ~/bin/fleet-labels symlink installed by install.sh).
+    SCRIPT_PATH=$(resolve_symlink_chain "${BASH_SOURCE[0]}")
+    SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
     ENGINE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-    if engine_slug=$(gh -R "$ENGINE_ROOT" repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null); then
-        REPOS+=("$engine_slug")
+    # `gh -R <path>` is NOT valid for `gh repo view` (only `gh pr` /
+    # `gh issue` accept it). Parse `origin` from git instead — works
+    # against any directory and doesn't require gh to know about it.
+    if engine_url=$(git -C "$ENGINE_ROOT" remote get-url origin 2>/dev/null); then
+        REPOS+=("$(slug_from_remote "$engine_url")")
     else
-        echo "fleet-labels: could not resolve engine repo slug from $ENGINE_ROOT" >&2
+        echo "fleet-labels: could not resolve engine repo from $ENGINE_ROOT" >&2
     fi
     # Game repo: optional
     GAME_ROOT="$ENGINE_ROOT/creations/game"
     if [[ -d "$GAME_ROOT/.git" ]] || [[ -f "$GAME_ROOT/.git" ]]; then
-        if game_slug=$(gh -R "$GAME_ROOT" repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null); then
-            REPOS+=("$game_slug")
+        if game_url=$(git -C "$GAME_ROOT" remote get-url origin 2>/dev/null); then
+            REPOS+=("$(slug_from_remote "$game_url")")
         fi
     fi
 fi

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -42,7 +42,14 @@ while [[ $# -gt 0 ]]; do
             TARGET_REPO="$2"
             shift 2
             ;;
-        --repo=*) TARGET_REPO="${1#--repo=}"; shift ;;
+        --repo=*)
+            TARGET_REPO="${1#--repo=}"
+            if [[ -z "$TARGET_REPO" ]]; then
+                echo "fleet-labels: --repo= requires a value (e.g. --repo=owner/repo)" >&2
+                exit 2
+            fi
+            shift
+            ;;
         -h|--help)
             sed -n '2,22p' "$0"
             exit 0

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# fleet-labels — ensure every fleet/human label the agents reference
+# exists on a target GitHub repo. Idempotent: missing labels get
+# created; existing labels are left alone (color/description not
+# overwritten, so humans can re-skin).
+#
+# Why this exists:
+#   The merger surfaced this in a session summary — its first attempt
+#   to add `fleet:merger-cooldown` failed because the label didn't
+#   exist on the engine repo, and it had to side-trip into
+#   `gh label create`. New labels added by future fleet PRs would hit
+#   the same gap. Rather than each agent trying to lazily create its
+#   own labels mid-loop, we sync them up-front.
+#
+# Usage:
+#   fleet-labels                  sync engine + game (auto-detected)
+#   fleet-labels --repo <ns>      sync only the named repo
+#                                 (e.g. --repo jakildev/IrredenEngine)
+#   fleet-labels --dry-run        print what would be created, don't act
+#
+# Source of truth: scripts/fleet/fleet-labels in the engine repo.
+# Installed to ~/bin/fleet-labels by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+DRY_RUN=0
+TARGET_REPO=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --repo)    : ;;  # consumed below
+        --repo=*)  TARGET_REPO="${arg#--repo=}" ;;
+        -h|--help)
+            sed -n '2,22p' "$0"
+            exit 0
+            ;;
+        *)
+            if [[ -z "$TARGET_REPO" && "$arg" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+                TARGET_REPO="$arg"
+            else
+                echo "fleet-labels: unknown argument '$arg'" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "fleet-labels: gh not found." >&2
+    exit 1
+fi
+
+# ----------------------------------------------------------------------
+# The label catalog
+# ----------------------------------------------------------------------
+#
+# Format: "name|color|description"
+# Color is a 6-char hex without leading #. Description is one-line,
+# wraps gracefully in GitHub's UI.
+#
+# When you add a label here:
+#   1. Make sure it's actually used by a role/skill (grep first).
+#   2. Pick a color that matches its semantic class:
+#      - fleet:* (blueish 0e8a16/1d76db) — process state
+#      - fleet:approved (green 0e8a16) — positive verdict
+#      - fleet:needs-fix / blocker (red d73a4a / 800010) — negative verdict
+#      - fleet:has-nits (yellow fbca04) — approved-with-followups
+#      - fleet:wip / changes-made (light blue c5def5) — in-flight
+#      - fleet:merger-cooldown (gray bfdadc) — fleet-internal back-pressure
+#      - human:* (purple 5319e7 / d4c5f9) — handoff to the human
+
+LABELS=(
+    "fleet:task|0366d6|Task tracked in TASKS.md"
+    "fleet:queued|c5def5|Queued for ingestion into TASKS.md"
+    "fleet:needs-info|fbca04|Needs more info from the author before triage"
+    "fleet:needs-plan|fbca04|Needs an architect plan before a worker can pick it up"
+    "fleet:in-progress|c5def5|A fleet worker has claimed this task"
+    "fleet:wip|c5def5|Fleet worker is mid-task on the corresponding PR"
+    "fleet:changes-made|c5def5|Worker addressed feedback; awaiting re-review"
+    "fleet:approved|0e8a16|Reviewer agent approved; safe for human merge"
+    "fleet:has-nits|fbca04|Approved but author should clean up nits before merge"
+    "fleet:needs-fix|d73a4a|Reviewer agent flagged correctness/quality issues"
+    "fleet:blocker|800010|Reviewer agent flagged a blocker; do not merge"
+    "fleet:merger-cooldown|bfdadc|Merger touched this PR; skip until next iteration"
+    "human:wip|5319e7|Human is editing the PR directly; agents stand off"
+    "human:approved|0e8a16|Human approved the PR (overrides agent verdict)"
+    "human:needs-fix|d4c5f9|Human flagged a fix request; agent should address"
+    "human:blocker|d4c5f9|Human flagged a blocker; do not merge"
+    "human:re-review|5319e7|Human pushed changes; reviewer agent should re-review"
+)
+
+ensure_label_for_repo() {
+    local repo="$1"
+    local existing
+    if ! existing=$(gh label list --repo "$repo" --json name --jq '.[].name' 2>&1); then
+        echo "fleet-labels: failed to list labels on $repo: $existing" >&2
+        return 1
+    fi
+    local created=0
+    local existed=0
+    for entry in "${LABELS[@]}"; do
+        local name="${entry%%|*}"
+        local rest="${entry#*|}"
+        local color="${rest%%|*}"
+        local desc="${rest#*|}"
+        if echo "$existing" | grep -qx "$name"; then
+            existed=$((existed + 1))
+            continue
+        fi
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+            echo "  would create: $name (#$color) — $desc"
+            created=$((created + 1))
+            continue
+        fi
+        if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" >/dev/null 2>&1; then
+            echo "  created: $name (#$color)"
+            created=$((created + 1))
+        else
+            # Label may have been created by a parallel run between our list
+            # and create — re-check rather than treating as failure.
+            if gh label list --repo "$repo" --json name --jq '.[].name' | grep -qx "$name"; then
+                existed=$((existed + 1))
+            else
+                echo "  failed to create: $name" >&2
+            fi
+        fi
+    done
+    echo "fleet-labels: $repo — $created created, $existed already existed"
+}
+
+# ----------------------------------------------------------------------
+# Determine which repos to sync
+# ----------------------------------------------------------------------
+
+REPOS=()
+if [[ -n "$TARGET_REPO" ]]; then
+    REPOS=("$TARGET_REPO")
+else
+    # Engine repo: discover from the script's own location
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    ENGINE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    if engine_slug=$(gh -R "$ENGINE_ROOT" repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null); then
+        REPOS+=("$engine_slug")
+    else
+        echo "fleet-labels: could not resolve engine repo slug from $ENGINE_ROOT" >&2
+    fi
+    # Game repo: optional
+    GAME_ROOT="$ENGINE_ROOT/creations/game"
+    if [[ -d "$GAME_ROOT/.git" ]] || [[ -f "$GAME_ROOT/.git" ]]; then
+        if game_slug=$(gh -R "$GAME_ROOT" repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null); then
+            REPOS+=("$game_slug")
+        fi
+    fi
+fi
+
+if [[ ${#REPOS[@]} -eq 0 ]]; then
+    echo "fleet-labels: no repos to sync." >&2
+    exit 1
+fi
+
+echo "fleet-labels: syncing ${#LABELS[@]} labels across ${#REPOS[@]} repo(s)..."
+[[ "$DRY_RUN" -eq 1 ]] && echo "  (dry run — no changes will be made)"
+echo
+
+for repo in "${REPOS[@]}"; do
+    echo "→ $repo"
+    ensure_label_for_repo "$repo"
+    echo
+done
+
+echo "fleet-labels: done."

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -300,18 +300,23 @@ mkdir -p "$HOME/.fleet/alerts"
 # Best-effort: if `gh` isn't authenticated, or the user is offline,
 # skip with a warning rather than failing the entire fleet-up.
 
+# Resolve which fleet-labels command we'll use (PATH first, repo
+# fallback for fleets brought up before install.sh has run).
+labels_cmd=""
 if command -v fleet-labels >/dev/null 2>&1; then
-    if gh auth status >/dev/null 2>&1; then
-        fleet-labels || echo "fleet-up: fleet-labels exited non-zero — continuing anyway"
-    else
-        echo "fleet-up: gh not authenticated — skipping label sync"
-        echo "          (run 'gh auth login' then 'fleet-labels' to backfill)"
-    fi
+    labels_cmd="fleet-labels"
 elif [[ -x "$ENGINE/scripts/fleet/fleet-labels" ]]; then
-    "$ENGINE/scripts/fleet/fleet-labels" || true
-else
+    labels_cmd="$ENGINE/scripts/fleet/fleet-labels"
+fi
+
+if [[ -z "$labels_cmd" ]]; then
     echo "fleet-up: fleet-labels not found — skipping label sync"
     echo "          (run scripts/fleet/install.sh to install it)"
+elif ! gh auth status >/dev/null 2>&1; then
+    echo "fleet-up: gh not authenticated — skipping label sync"
+    echo "          (run 'gh auth login' then '$labels_cmd' to backfill)"
+else
+    "$labels_cmd" || echo "fleet-up: fleet-labels exited non-zero — continuing anyway"
 fi
 
 # ----------------------------------------------------------------------

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -289,6 +289,32 @@ mkdir -p "$HOME/.fleet/heartbeats"
 mkdir -p "$HOME/.fleet/alerts"
 
 # ----------------------------------------------------------------------
+# Step 3c: ensure GitHub labels referenced by agents exist
+# ----------------------------------------------------------------------
+#
+# The merger surfaced this in a session summary: its first attempt to
+# add `fleet:merger-cooldown` failed because the label didn't exist on
+# the engine repo, and it had to side-trip into `gh label create` mid-
+# loop. Pre-create here so no agent ever has to lazily create labels.
+#
+# Best-effort: if `gh` isn't authenticated, or the user is offline,
+# skip with a warning rather than failing the entire fleet-up.
+
+if command -v fleet-labels >/dev/null 2>&1; then
+    if gh auth status >/dev/null 2>&1; then
+        fleet-labels || echo "fleet-up: fleet-labels exited non-zero — continuing anyway"
+    else
+        echo "fleet-up: gh not authenticated — skipping label sync"
+        echo "          (run 'gh auth login' then 'fleet-labels' to backfill)"
+    fi
+elif [[ -x "$ENGINE/scripts/fleet/fleet-labels" ]]; then
+    "$ENGINE/scripts/fleet/fleet-labels" || true
+else
+    echo "fleet-up: fleet-labels not found — skipping label sync"
+    echo "          (run scripts/fleet/install.sh to install it)"
+fi
+
+# ----------------------------------------------------------------------
 # Step 4: build the tmux session
 # ----------------------------------------------------------------------
 #

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -72,6 +72,8 @@ FLEET_RUN_SRC="$SCRIPT_DIR/fleet-run"
 FLEET_RUN_DEST="$HOME/bin/fleet-run"
 FLEET_BABYSIT_SRC="$SCRIPT_DIR/fleet-babysit"
 FLEET_BABYSIT_DEST="$HOME/bin/fleet-babysit"
+FLEET_LABELS_SRC="$SCRIPT_DIR/fleet-labels"
+FLEET_LABELS_DEST="$HOME/bin/fleet-labels"
 WITNESS_SRC="$SCRIPT_DIR/witness"
 WITNESS_DEST="$HOME/bin/witness"
 
@@ -83,7 +85,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -120,6 +122,11 @@ fi
 if [[ -f "$FLEET_BABYSIT_SRC" ]]; then
     ln -sf "$FLEET_BABYSIT_SRC" "$FLEET_BABYSIT_DEST"
     echo "symlinked $FLEET_BABYSIT_DEST -> $FLEET_BABYSIT_SRC"
+fi
+
+if [[ -f "$FLEET_LABELS_SRC" ]]; then
+    ln -sf "$FLEET_LABELS_SRC" "$FLEET_LABELS_DEST"
+    echo "symlinked $FLEET_LABELS_DEST -> $FLEET_LABELS_SRC"
 fi
 
 if [[ -f "$WITNESS_SRC" ]]; then


### PR DESCRIPTION
## Summary

Three sets of friction surfaced by the last `fleet-down --summary` run on 2026-04-20 — fixed in one PR because they're all "next fleet startup will hit this".

### 1. `fleet-down --summary` rewrite

Three failure modes from the previous run:

- **Trailing `Enter` was swallowed by Claude Code's bracketed-paste handling.** The text landed in the input field but never submitted — the human had to manually press Enter on every pane.
- **60s `SUMMARY_WAIT_SECONDS` was too short for opus agents.** Several panes wrote nothing.
- **Prompts went out without checking pane state.** A busy pane absorbed the keys into a tool-execution display or scrollback.

New behavior, per pane, sequentially:

1. Wait for the pane to look idle (no spinner / tool execution visible via `tmux capture-pane` heuristic). Cap at `SUMMARY_IDLE_WAIT_SECONDS` (default **30 min**).
2. Send the prompt text, sleep 0.5s, then send `Enter` as a *separate* keystroke event. This bypasses the bracketed-paste swallow.
3. Wait for the `.md` file to actually appear on disk before moving to the next pane. Cap at `SUMMARY_WRITE_WAIT_SECONDS` (default **10 min**).

All four timing knobs (idle wait/poll, write wait/poll) are env-overridable. Per-pane progress is now logged with ✓/✗ marks.

### 2. New `scripts/fleet/fleet-labels` script

The merger's first iteration failed because `fleet:merger-cooldown` didn't exist on the engine repo. An audit found the engine repo was missing **7 labels** role files reference: `queued`, `needs-info`, `needs-plan`, `in-progress`, `has-nits`, `merger-cooldown`, and `human:re-review`.

`fleet-labels` syncs all 17 known labels to engine + game (auto-discovered). Idempotent — existing labels are not overwritten so humans can re-skin colors. Wired into `fleet-up` step 3c so every startup gets a clean label baseline before any pane launches. Also runnable standalone with `--dry-run`, `--repo <ns>`.

### 3. `role-merger.md` heartbeat clarification

The merger summary said `date > file` was blocked by the single-command-Bash rule and worked around it via Read+Write. It isn't — `>` and `>>` are file redirects, not compound operators. Updated step 0 to say so explicitly, and to greenlight `echo "..." >> ~/.fleet/logs/merger-audit.log` for the audit log.

## Findings deliberately NOT in this PR

These came out of the same session summaries but need separate scoping (some are design questions, some are bigger refactors):

- **Branch checkout coordination across worktrees.** Both opus-workers reported "branch already checked out elsewhere" races. Needs a coordination story (claim-aware checkout, or worktree dispatcher).
- **Self-modification gate too strict for role-file PRs.** Opus-worker-1 couldn't address review nits on a PR that itself modifies the role file. Needs Claude Code settings work.
- **Stale `fleet:has-nits` after self-fix.** Process gap when human fixes nits without clearing the label. Needs a workflow refinement.
- **Centralized gh / status daemon.** User flagged this as a direction. Substantial architecture; should be its own task with a design doc.
- **`start-next-task` should clean `.review-body.md`.** Minor; standalone PR.

Happy to file any of these as TASKS.md items if you want.

## Test plan

- [ ] `fleet-labels --dry-run --repo jakildev/IrredenEngine` lists the 7 missing labels (verified locally — see PR description).
- [ ] `fleet-labels` (no args) creates them on engine + game.
- [ ] `fleet-up dry-run` runs the new step 3c without erroring.
- [ ] Bring fleet up, kick off a busy worker, then `fleet-down --summary`. Confirm:
  - [ ] Per-pane progress logs appear (`[N/M] role:`)
  - [ ] Busy pane correctly waits for idle
  - [ ] Prompt actually submits (no manual Enter needed)
  - [ ] Summary `.md` files appear before moving to next pane
- [ ] Override `SUMMARY_IDLE_WAIT_SECONDS=60 fleet-down --summary` to test the env knobs.

## Notes for reviewer

- `pane_is_idle` heuristic (`fleet-down:178`) intentionally errs on the side of "looks busy" — false-positive busy just means we wait longer; false-positive idle would send the prompt into garbage.
- `send_prompt_to_pane` (`fleet-down:193`) is split into two `send-keys` calls because that's the whole fix for the Enter-not-submitting bug. Inlining would obscure the intent.
- `LABELS` array in `fleet-labels` is intentionally inline — labels rarely change, and a separate config file would just add deployment friction.
- `fleet-up`'s new step 3c is best-effort: if `gh` isn't authenticated, it warns and continues so an offline developer can still bring the fleet up locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)