### PR TITLE
fleet/queue-manager: fix maintenance-push order — commit before rebase

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -393,23 +393,37 @@ You are the sole TASKS.md editor. Each maintenance pass:
 7. **Prune Done:** keep only the last 20 entries in each TASKS.md.
 
 8. **Push changes (if any).**
-   Engine TASKS.md + plan files — commit and push directly to master
-   (bare `git` is correct here — your CWD is an engine worktree):
-   - `git fetch origin`
-   - `git rebase origin/master`
+   **Order matters:** stage and commit FIRST, then fetch and rebase.
+   `git rebase` refuses to run with unstaged changes ("You have
+   unstaged changes") AND with staged-but-uncommitted changes ("Your
+   index contains uncommitted changes"). The maintenance pass always
+   leaves dirty TASKS.md edits in the worktree, so rebase before
+   commit always errors out.
+
+   Engine TASKS.md + plan files — commit then rebase then push (bare
+   `git` is correct here — your CWD is an engine worktree):
    - `git add TASKS.md`
    - `git add .fleet/plans/`
    - `git commit -m "queue: maintenance sync"`
+   - `git fetch origin`
+   - `git rebase origin/master`
    - `git push origin HEAD:master`
-   Game TASKS.md + plan files — separate commit and push:
-   - `git -C ~/src/IrredenEngine/creations/game fetch origin`
-   - `git -C ~/src/IrredenEngine/creations/game rebase origin/master`
+   Game TASKS.md + plan files — same order, same dirs:
    - `git -C ~/src/IrredenEngine/creations/game add TASKS.md`
    - `git -C ~/src/IrredenEngine/creations/game add .fleet/plans/`
    - `git -C ~/src/IrredenEngine/creations/game commit -m "queue: maintenance sync"`
+   - `git -C ~/src/IrredenEngine/creations/game fetch origin`
+   - `git -C ~/src/IrredenEngine/creations/game rebase origin/master`
    - `git -C ~/src/IrredenEngine/creations/game push origin HEAD:master`
-   If either push is rejected, rebase and retry. Only push TASKS.md
-   and `.fleet/plans/` — never push other files to master.
+   If either push is rejected (race with another commit hitting master
+   in the same window), re-fetch + re-rebase + re-push. Only push
+   TASKS.md and `.fleet/plans/` — never push other files to master.
+
+   **Expect a "Bypassed rule violations" warning on each push.** The
+   engine repo has branch protection requiring PRs for master, but
+   this account has admin bypass for these bookkeeping files. The
+   warning is informational — the push still succeeded if you don't
+   see "rejected" or "failed". Don't try to "fix" it by opening a PR.
 
 9. Print the maintenance summary, queue summary, and next-run timing:
    `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned`


### PR DESCRIPTION
## Summary

Real friction caught from a screenshot of the queue-manager pane:

```
Bash(git rebase origin/master)
Error: Exit code 1
error: cannot rebase: You have unstaged changes.
error: Please commit or stash them.

Bash(git add TASKS.md)

Bash(git rebase origin/master)
Error: Exit code 1
error: cannot rebase: Your index contains uncommitted changes.
error: Please commit or stash them.

Bash(git commit -m "queue: maintenance sync — T-026 done (PR #233)")

Bash(git rebase origin/master)
Current branch claude/queue-manager-scratch is up to date.

Bash(git push origin HEAD:master)
```

The role doc told the agent to:

```
fetch → rebase → add → commit → push
```

But step 8 always runs after step 6 has edited TASKS.md, so the worktree always has dirty changes when it gets to "rebase". `git rebase` refuses to run with unstaged changes ("You have unstaged changes") AND with staged-but-uncommitted changes ("Your index contains uncommitted changes"). So the documented sequence guaranteed two errors per cycle.

The queue-manager flagged this in its own session summary yesterday too:

> Stash-rebase pattern required for both repos. The queue-manager worktree branch and the game repo main clone both needed `stash → rebase → stash-pop → commit → push` rather than a clean `rebase → add → commit → push`. Happened because edits were made before rebasing.

## The fix

Invert the order — commit FIRST, then fetch+rebase the local commit on top of master, then push:

```
add → commit → fetch → rebase → push
```

Same set of operations, no errors. Race-on-push handling is unchanged.

Also documents the **"Bypassed rule violations" warning** users see on each push: it's expected (this account has admin bypass for the TASKS.md/plans bookkeeping exception against the master PR rule), not something to "fix" by opening a PR.

## Test plan

- [ ] Next queue-manager iteration runs without the two-error dance.
- [ ] No regression on race-on-push handling — if another commit lands on master while the queue-manager is mid-cycle, the re-fetch + re-rebase + re-push retry still works.
- [ ] Game-repo path mirrors the engine-repo path — same fix applied to both blocks.

## Notes for reviewer

- Doc-only change in `.claude/commands/role-queue-manager.md` step 8.
- The added paragraph about "Bypassed rule violations" is informational — preempts the next agent from getting confused by the warning and trying to open a PR.
- `simplify` skipped — prose-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)