### PR TITLE
fleet: worker-side stacked-PR mechanism (T-020 Part 1)

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -383,8 +383,10 @@ Do the work, then exit cleanly:
    Stack claim is all-or-nothing — if any task is already claimed or
    has unresolved external blockers, all are rolled back. Within the
    stack, earlier tasks satisfy later tasks' `Blocked by:` fields.
-   Work the stack sequentially on a **single branch**, one commit per
-   task, then `fleet-claim release-stack <your-worktree-name>`.
+   Work the stack **sequentially, one PR per task**, with each PR's
+   base set to the previous task's branch (true stacked PRs). Release
+   the chain with `fleet-claim release-stack <your-worktree-name>`
+   after the last PR merges.
 
    **`stack` also writes a molecule file** (`~/.fleet/molecules/<your-
    worktree-name>.yml`) so a crash mid-stack won't strand the
@@ -400,47 +402,65 @@ Do the work, then exit cleanly:
    - The merge → unblock → re-pick latency would waste more budget
      than keeping the context
 
-   **Stack PR commit format (REQUIRED):** Each commit subject MUST
-   start with the task ID prefix `T-NNN: `:
+   **Stacked PR flow (REQUIRED):** each task in the chain gets its
+   own branch and its own PR, with each PR's `--base` pointing at the
+   previous task's branch. GitHub treats these as "stacked PRs":
+   reviewers approve each one independently, and when an earlier PR
+   merges, the next PR's base auto-rebases to master.
 
-   ```
-   T-005: <short description>
-   T-007: <short description>
-   T-009: <short description>
-   ```
+   For the current task in the stack (first `(pending)` row in
+   `fleet-claim stack-pr-state <your-worktree-name>`):
 
-   This is the load-bearing anchor that lets reviewers segment the
-   PR into per-task review passes. **Never edit the subject line
-   when amending a stack commit** — only touch the body. `git commit
-   --amend --no-edit` (to add staged files) and body-only amends are
-   safe; `--amend -m "..."` rewrites the subject and breaks reviewer
-   detection for that task. Commit SHAs change on any amend, which is
-   why we use the subject prefix as the anchor instead.
+   1. **Compute the base branch** for this PR:
+      `base=$(fleet-claim stack-base <your-worktree-name> <task-id>)`
+      — returns `master` for the first task, or the previous task's
+      branch (e.g. `claude/T-005-occupancy`) for subsequent tasks.
+   2. **Branch off that base:**
+      `git fetch origin "$base"`
+      `git checkout -b claude/<task-id>-<short-topic> "origin/$base"`
+      (e.g. `claude/T-005-occupancy`, `claude/T-007-lighting-seeds`).
+   3. Do the task's work in that branch. Commit as normal — no
+      special commit-subject prefix is required anymore; one task per
+      branch means the branch name IS the per-task anchor.
+   4. Open the PR with `--base "$base"` and record it in the stack:
+      `gh pr create --base "$base" --title "T-<NNN>: <title>" --body "..." --label "fleet:wip"`
+      `fleet-claim stack-set-pr <your-worktree-name> <task-id> "$(git branch --show-current)" "<pr-url>"`
 
-   **Stack PR description format:** When opening a stack PR, write
-   the body with one section per task and tell reviewers to segment:
+   **Stacked PR title + body format:** start the PR title with the
+   task ID so reviewers can tell which task in the chain this PR
+   covers. The body includes a `Stacked on:` line pointing at the
+   previous PR (or `master` for the first) so reviewers see the
+   stack context immediately.
 
    ```markdown
-   This PR implements a chain of dependent tasks. Reviewers: please
-   review each task's commit(s) independently — verdict is one
-   overall approval, but findings should be grouped per task.
+   ## Summary
+   - <what this task does>
 
-   ## T-005 — <task title>
-   What this implements, key files touched, what to focus on.
-   Commits prefixed `T-005:` belong to this task.
+   ## Stack context
+   Stacked on: <previous PR URL, or "master" for the first>
+   Full chain: T-005 → T-007 → T-009
 
-   ## T-007 — <task title>
-   ...
+   ## Test plan
+   - [ ] <task-specific checks>
 
-   Closes #N1
-   Closes #N2
-   Closes #N3
+   Closes #<issue-N>
    ```
 
-   When **amending** a stack commit (e.g. addressing review feedback
-   for one task), keep the `T-NNN: ` subject prefix intact — only
-   amend the body. If you need to add a follow-up commit for one
-   task, use the same prefix: `T-005: address review feedback`.
+   The `commit-and-push` skill's "Stack-aware mode" section walks
+   through the branch + PR creation; let it drive — it already knows
+   to call `stack-base` and `stack-set-pr`.
+
+   **When an earlier PR in the stack merges:** GitHub auto-rebases
+   the next PR's base to master. Pull the latest master into the
+   next branch before continuing work on it:
+   `git fetch origin master && git rebase origin/master`
+   Force-push with `--force-with-lease` (never `--force`). The
+   reviewer's approval on the unchanged commits carries over unless
+   a conflict actually modified them.
+
+   **Addressing review feedback on a stacked PR:** commit the fix on
+   the same branch, push, and comment as usual. No cross-task
+   side-effects.
 
    For single tasks, use the normal claim flow:
    `git checkout -b claude/<area>-<topic>`

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -453,7 +453,8 @@ Do the work, then exit cleanly:
    **When an earlier PR in the stack merges:** GitHub auto-rebases
    the next PR's base to master. Pull the latest master into the
    next branch before continuing work on it:
-   `git fetch origin master && git rebase origin/master`
+   `git fetch origin master`
+   `git rebase origin/master`
    Force-push with `--force-with-lease` (never `--force`). The
    reviewer's approval on the unchanged commits carries over unless
    a conflict actually modified them.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -332,18 +332,20 @@ You are the sole TASKS.md editor. Each maintenance pass:
    `gh pr list --repo <game-repo> --state merged --json number,title,mergedAt,commits --jq '.[] | select(.mergedAt > "YYYY-MM-DDT00:00:00Z")'`
    (use yesterday's date to catch recent merges)
 
-   **For each merged PR**, find which TASKS.md tasks it completes:
-   - **Single-task PR (most common):** match the PR title or branch
-     name against `[~]` or `[ ]` task entries.
-   - **Stack PR (multi-task chain):** extract the task IDs from the
-     merged PR's commit subjects. The canonical query (extracts every
-     `T-NNN` referenced as a commit subject prefix, deduplicated):
+   **For each merged PR**, find which TASKS.md task it completes:
+   - **Single-task PR (the norm):** match the PR title (`T-NNN: ...`
+     prefix) or branch name (`claude/T-NNN-...`) against a `[~]` or
+     `[ ]` task entry. Every PR today is single-task — stacked PR
+     chains produce N individual PRs, each covering exactly one task,
+     that merge independently as GitHub rebases their bases forward.
+   - **Legacy multi-task PR (pre-stacked-PRs):** older merged PRs may
+     bundle multiple tasks in one PR via `T-NNN: ` commit subject
+     prefixes. Fallback query:
      ```
      gh pr view <N> --repo <repo> --json commits \
        --jq '[.commits[].messageHeadline | capture("^(?<id>T-[0-9]+):") | .id] | unique'
      ```
-     Each unique task ID is one completed task. A stack PR can complete
-     2+ tasks in one merge — flip ALL of them.
+     Each unique task ID there is one completed task — flip ALL.
 
    For every task completed by the merge: flip to `[x]`, add the PR
    URL to **Links**, move to `## Done — last 20`. Clean up plan

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -301,7 +301,8 @@ Each iteration:
    **When an earlier PR in the stack merges:** GitHub auto-rebases
    the next PR's base to master. Pull the latest master into the
    next branch before continuing work on it:
-   `git fetch origin master && git rebase origin/master`
+   `git fetch origin master`
+   `git rebase origin/master`
    Force-push with `--force-with-lease` (never `--force`). The
    reviewer's approval on the unchanged commits carries over unless
    a conflict actually modified them.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -233,9 +233,15 @@ Each iteration:
    independent): If you find two tightly coupled `[sonnet]` tasks in
    a dependency chain, you can claim them atomically:
    `fleet-claim stack "T-002 T-004" <your-worktree-name>`
-   Work them sequentially on a single branch, one commit per task,
-   then release with `fleet-claim release-stack <your-worktree-name>`.
-   Prefer single claims unless the tasks are genuinely coupled.
+
+   Stack claim is all-or-nothing — if any task is already claimed or
+   has unresolved external blockers, all are rolled back. Within the
+   stack, earlier tasks satisfy later tasks' `Blocked by:` fields.
+   Work the stack **sequentially, one PR per task**, with each PR's
+   base set to the previous task's branch (true stacked PRs). Release
+   the chain with `fleet-claim release-stack <your-worktree-name>`
+   after the last PR merges. Prefer single claims unless the tasks
+   are genuinely coupled.
 
    **`stack` also writes a molecule file** (`~/.fleet/molecules/<your-
    worktree-name>.yml`) so a crash mid-stack won't strand the
@@ -244,48 +250,64 @@ Each iteration:
    `fleet-claim molecule advance` so the molecule reflects reality;
    `release-stack` archives the molecule when you're done.
 
-   **Stack PR commit format (REQUIRED):** When working a stack, each
-   commit subject MUST start with the task ID prefix `T-NNN: `:
+   **Stacked PR flow (REQUIRED):** each task in the chain gets its
+   own branch and its own PR, with each PR's `--base` pointing at the
+   previous task's branch. GitHub treats these as "stacked PRs":
+   reviewers approve each one independently, and when an earlier PR
+   merges, the next PR's base auto-rebases to master.
 
-   ```
-   T-002: <short description of T-002 work>
-   T-004: <short description of T-004 work>
-   ```
+   For the current task in the stack (first `(pending)` row in
+   `fleet-claim stack-pr-state <your-worktree-name>`):
 
-   This is the load-bearing anchor that lets reviewers segment the
-   PR into per-task review passes. **Never edit the subject line
-   when amending a stack commit** — only touch the body. `git commit
-   --amend --no-edit` (to add staged files) and body-only amends are
-   safe; `--amend -m "..."` rewrites the subject and breaks reviewer
-   detection for that task. Commit SHAs change on any amend, which is
-   why we use the subject prefix as the anchor instead.
+   1. **Compute the base branch** for this PR:
+      `base=$(fleet-claim stack-base <your-worktree-name> <task-id>)`
+      — returns `master` for the first task, or the previous task's
+      branch (e.g. `claude/T-002-lua-bindings`) for subsequent tasks.
+   2. **Branch off that base:**
+      `git fetch origin "$base"`
+      `git checkout -b claude/<task-id>-<short-topic> "origin/$base"`
+      (e.g. `claude/T-002-lua-bindings`, `claude/T-004-lua-tests`).
+   3. Do the task's work in that branch. Commit as normal — no
+      special commit-subject prefix is required anymore; one task per
+      branch means the branch name IS the per-task anchor.
+   4. Open the PR with `--base "$base"` and record it in the stack:
+      `gh pr create --base "$base" --title "T-<NNN>: <title>" --body "..." --label "fleet:wip"`
+      `fleet-claim stack-set-pr <your-worktree-name> <task-id> "$(git branch --show-current)" "<pr-url>"`
 
-   **Stack PR description format:** When opening a stack PR, write
-   the body with one section per task:
+   **Stacked PR title + body format:** start the PR title with the
+   task ID so reviewers can tell which task in the chain this PR
+   covers. The body includes a `Stacked on:` line pointing at the
+   previous PR (or `master` for the first) so reviewers see the
+   stack context immediately.
 
    ```markdown
-   This PR implements a chain of dependent tasks. Reviewers: please
-   review each task's commit(s) independently — verdict is one
-   overall approval, but findings should be grouped per task.
+   ## Summary
+   - <what this task does>
 
-   ## T-002 — <task title>
-   What this implements, key files touched, what to focus on.
-   Commits prefixed `T-002:` belong to this task.
+   ## Stack context
+   Stacked on: <previous PR URL, or "master" for the first>
+   Full chain: T-002 → T-004
 
-   ## T-004 — <task title>
-   What this implements, key files touched, what to focus on.
-   Commits prefixed `T-004:` belong to this task.
+   ## Test plan
+   - [ ] <task-specific checks>
 
-   Closes #N1
-   Closes #N2
+   Closes #<issue-N>
    ```
 
-   When **amending** a stack commit (e.g. addressing review feedback
-   for one task), keep the `T-NNN: ` subject prefix intact — only
-   amend the body. If you need to add a follow-up commit for one
-   task, use the same prefix: `T-002: address review feedback`.
+   The `commit-and-push` skill's "Stack-aware mode" section walks
+   through the branch + PR creation; let it drive — it already knows
+   to call `stack-base` and `stack-set-pr`.
 
-   Then create the branch, commit, and open a `fleet:wip` PR:
+   **When an earlier PR in the stack merges:** GitHub auto-rebases
+   the next PR's base to master. Pull the latest master into the
+   next branch before continuing work on it:
+   `git fetch origin master && git rebase origin/master`
+   Force-push with `--force-with-lease` (never `--force`). The
+   reviewer's approval on the unchanged commits carries over unless
+   a conflict actually modified them.
+
+   **For single-task claims**, create the branch, commit, and open a
+   `fleet:wip` PR normally:
    `git checkout -b claude/<area>-<topic>`
    `git commit --allow-empty -m "claim: <task title>"`
 

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -38,6 +38,54 @@ Do **not** invoke proactively — only when the user explicitly asks.
 3. **The working tree must have something to commit.** If `git status` is
    clean, tell the user and stop.
 
+## Stack-aware mode
+
+If the current task is part of an `fleet-claim stack` chain (i.e. the
+caller's worktree name has a stack claim under
+`~/.fleet/claims/_stack_<agent>/`), this skill opens **one PR per task,
+chained by `--base`** instead of a single PR with multiple commits.
+
+Detect stack mode at the start of the flow:
+
+```bash
+fleet-claim stack-pr-state <your-worktree-name>
+```
+
+- Output `no stack claim for agent: <name>` → not stacked, proceed with
+  the normal single-PR flow below.
+- Output with `task`/`branch`/`pr` columns → stacked. The row whose PR
+  column is `(pending)` and whose earlier rows (if any) are all filled
+  is the current task. Note its `<task-id>`; you will need it in steps
+  2 and 8.
+
+The deltas versus the single-PR flow:
+
+- **Step 2 branch name** is `claude/<task-id>-<short-topic>` (e.g.
+  `claude/T-005-occupancy-grid`). The task ID prefix lets the
+  queue-manager, reviewers, and `stack-base` resolve the chain.
+- **Step 8 PR base** is `fleet-claim stack-base <agent> <task-id>`
+  instead of `master`. For the first task this still returns `master`;
+  for subsequent tasks it returns the previous task's branch.
+- **After `gh pr create`** record the PR in the stack so the next task
+  can chain off it:
+  ```bash
+  fleet-claim stack-set-pr <agent> <task-id> <branch> <pr-url>
+  ```
+- **PR body** includes a "Stacked on: <prev PR URL>" line for all but
+  the first PR and names the whole chain so reviewers see the context.
+- **Title** starts with `T-NNN: ` so the queue-manager's per-task
+  matching works and reviewers can tell which task in the chain this
+  PR belongs to.
+
+After the PR opens, do NOT start the next task in the same branch.
+Invoke `start-next-task` the same way as single-PR work; when it comes
+back, the next stacked-PR iteration computes its own `--base` via
+`stack-base` and branches off that (not `origin/master`).
+
+When **the final task's PR is merged**, run
+`fleet-claim release-stack <agent>` to clean up both the per-task
+claims and the stack metadata.
+
 ## Flow
 
 ### 1. Gather state (parallel)
@@ -67,6 +115,16 @@ If you're on `master`:
 - Create the branch **before** staging so the commits land there:
   ```bash
   git checkout -b claude/<area>-<topic>
+  ```
+- **In stack-aware mode** (see section above): use
+  `claude/<task-id>-<short-topic>` instead, and branch off the base
+  returned by `fleet-claim stack-base <agent> <task-id>` (which is
+  `master` for the first task in the chain, or the previous task's
+  branch for subsequent tasks):
+  ```bash
+  base=$(fleet-claim stack-base <agent> <task-id>)
+  git fetch origin "$base"
+  git checkout -b claude/<task-id>-<short-topic> "origin/$base"
   ```
 
 If you're already on a feature branch, just use it. Do not rename mid-session.
@@ -192,8 +250,8 @@ plain `git push` works.
 
 ### 8. Open the PR
 
-Use `gh pr create`. Target is always `master`. Pass the body via HEREDOC so
-the Markdown renders correctly:
+Use `gh pr create`. For the single-PR flow, target is `master`. Pass the
+body via HEREDOC so the Markdown renders correctly:
 
 ```bash
 gh pr create --base master --title "render: match cpu/gpu iso culling bounds" --body "$(cat <<'EOF'
@@ -216,6 +274,40 @@ EOF
 
 Title should match the commit title when the PR is a single commit. For
 multi-commit PRs, use a broader title that covers the series.
+
+**Stack-aware override:** when the current task is part of a
+`fleet-claim stack`, compute the base via `stack-base` and record the
+resulting PR via `stack-set-pr`:
+
+```bash
+base=$(fleet-claim stack-base <agent> <task-id>)
+pr_url=$(gh pr create --base "$base" \
+    --title "T-<NNN>: <short title>" \
+    --body "$(cat <<'EOF'
+## Summary
+- <what this task does>
+
+## Stack context
+This PR is part of a stack. Reviewers: review this PR on its own; the
+chain is coordinated in the PR body's "Stacked on" line.
+
+Stacked on: <previous PR URL, or "master" for the first PR>
+Full chain: T-<A>, T-<B>, T-<C>
+
+## Test plan
+- [ ] <task-specific checks>
+
+Closes #<issue-N>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" --label "fleet:wip")
+fleet-claim stack-set-pr <agent> <task-id> "$(git branch --show-current)" "$pr_url"
+```
+
+The `Stacked on:` line is the reviewer's primary signal that earlier
+PRs are prerequisites. The `Full chain:` line helps them find the
+siblings if they want cross-context.
 
 ### 9. Report the result
 

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -19,6 +19,11 @@
 #   fleet-claim list
 #   fleet-claim cleanup [--repo <owner/repo>] ...
 #   fleet-claim clear-all
+#   fleet-claim stack "T-1 T-2 ..." <agent>
+#   fleet-claim release-stack <agent>
+#   fleet-claim stack-base <agent> <task-id>
+#   fleet-claim stack-set-pr <agent> <task-id> <branch> <pr-url>
+#   fleet-claim stack-pr-state <agent>
 #   fleet-claim molecule list
 #   fleet-claim molecule show <agent>
 #   fleet-claim molecule resume <agent>
@@ -506,6 +511,134 @@ cmd_release_stack() {
     echo "released stack ($released tasks) for agent: $agent"
 }
 
+# --- stacked-PR chain state ------------------------------------------------
+#
+# True stacked PRs need each task in a chain to open its own PR whose --base
+# is the previous task's branch. The per-task branch + PR URL is recorded
+# inside the existing _stack_<agent>/ directory so the next task in the
+# chain can resolve its base.
+#
+# Storage layout inside $CLAIMS_DIR/_stack_<agent>/:
+#   tasks                       task list written by cmd_stack (unchanged)
+#   created                     timestamp written by cmd_stack (unchanged)
+#   <task-id>.branch            branch name once that task's PR is opened
+#   <task-id>.pr                PR URL once that task's PR is opened
+#
+# Lifecycle:
+#   stack                    → writes tasks + created; branch/pr files empty
+#   stack-base <agent> <id>  → returns base for <id> (master or previous
+#                              task's branch)
+#   stack-set-pr             → writes <id>.branch and <id>.pr (called by
+#                              commit-and-push after gh pr create)
+#   stack-pr-state           → prints task / branch / pr table
+#   release-stack            → rm -rf the whole stack dir (cleans up
+#                              branch/pr files too)
+
+cmd_stack_base() {
+    # Return the base branch for a task's PR inside an agent's stack.
+    # First task in the chain  → "master"
+    # Any subsequent task      → previous task's branch (from stack-set-pr)
+    #
+    # Usage: fleet-claim stack-base <agent> <task-id>
+    # Exit 0: branch written to stdout.
+    # Exit 1: no stack for agent, task not in stack, or previous task's
+    #         branch has not been recorded yet (caller must open the
+    #         previous task's PR before asking for this one's base).
+    local agent="$1"
+    local task_id="$2"
+    local stack_dir="$CLAIMS_DIR/_stack_${agent}"
+
+    if [[ ! -f "$stack_dir/tasks" ]]; then
+        echo "fleet-claim stack-base: no stack claim for agent: $agent" >&2
+        return 1
+    fi
+
+    local prev=""
+    local found=0
+    while IFS= read -r t; do
+        [[ -z "$t" ]] && continue
+        if [[ "$t" == "$task_id" ]]; then
+            found=1
+            break
+        fi
+        prev="$t"
+    done < "$stack_dir/tasks"
+
+    if [[ $found -eq 0 ]]; then
+        echo "fleet-claim stack-base: $task_id not in agent $agent's stack" >&2
+        return 1
+    fi
+
+    if [[ -z "$prev" ]]; then
+        echo "master"
+        return 0
+    fi
+
+    local prev_branch_file="$stack_dir/${prev}.branch"
+    if [[ ! -f "$prev_branch_file" ]]; then
+        echo "fleet-claim stack-base: previous task $prev has no branch recorded; open its PR (stack-set-pr) first" >&2
+        return 1
+    fi
+    cat "$prev_branch_file"
+}
+
+cmd_stack_set_pr() {
+    # Record the branch + PR URL for a task in an agent's stack.
+    # Subsequent stack-base lookups resolve the chain via these files.
+    #
+    # Usage: fleet-claim stack-set-pr <agent> <task-id> <branch> <pr-url>
+    local agent="$1"
+    local task_id="$2"
+    local branch="$3"
+    local pr_url="$4"
+    local stack_dir="$CLAIMS_DIR/_stack_${agent}"
+
+    if [[ ! -f "$stack_dir/tasks" ]]; then
+        echo "fleet-claim stack-set-pr: no stack claim for agent: $agent" >&2
+        return 1
+    fi
+
+    if ! grep -Fxq "$task_id" "$stack_dir/tasks"; then
+        echo "fleet-claim stack-set-pr: $task_id not in agent $agent's stack" >&2
+        return 1
+    fi
+
+    echo "$branch" > "$stack_dir/${task_id}.branch"
+    echo "$pr_url" > "$stack_dir/${task_id}.pr"
+    echo "recorded: $task_id → branch=$branch pr=$pr_url"
+}
+
+cmd_stack_pr_state() {
+    # Print the stack's per-task PR state (task / branch / pr), one row
+    # each. Tasks with no branch or PR yet show (pending).
+    #
+    # Usage: fleet-claim stack-pr-state <agent>
+    # Always exits 0 so `set -euo pipefail` callers can detect the
+    # no-stack case via the output string ("no stack claim for …")
+    # without wrapping the call in `|| true`.
+    local agent="$1"
+    local stack_dir="$CLAIMS_DIR/_stack_${agent}"
+
+    if [[ ! -f "$stack_dir/tasks" ]]; then
+        echo "no stack claim for agent: $agent"
+        return 0
+    fi
+
+    printf '%-10s %-50s %s\n' "task" "branch" "pr"
+    while IFS= read -r t; do
+        [[ -z "$t" ]] && continue
+        local branch="(pending)"
+        local pr="(pending)"
+        if [[ -f "$stack_dir/${t}.branch" ]]; then
+            branch=$(cat "$stack_dir/${t}.branch")
+        fi
+        if [[ -f "$stack_dir/${t}.pr" ]]; then
+            pr=$(cat "$stack_dir/${t}.pr")
+        fi
+        printf '%-10s %-50s %s\n' "$t" "$branch" "$pr"
+    done < "$stack_dir/tasks"
+}
+
 cmd_clear_all() {
     # Wipe all claims (used by fleet-up on restart) but PRESERVE the
     # molecule directory — molecules are crash-recovery state and must
@@ -916,6 +1049,27 @@ case "${1:-}" in
         fi
         cmd_release_stack "$2"
         ;;
+    stack-base)
+        if [[ -z "${3:-}" ]]; then
+            echo "usage: fleet-claim stack-base <agent-name> <task-id>" >&2
+            exit 2
+        fi
+        cmd_stack_base "$2" "$3"
+        ;;
+    stack-set-pr)
+        if [[ -z "${5:-}" ]]; then
+            echo "usage: fleet-claim stack-set-pr <agent-name> <task-id> <branch> <pr-url>" >&2
+            exit 2
+        fi
+        cmd_stack_set_pr "$2" "$3" "$4" "$5"
+        ;;
+    stack-pr-state)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim stack-pr-state <agent-name>" >&2
+            exit 2
+        fi
+        cmd_stack_pr_state "$2"
+        ;;
     cleanup)
         shift
         cmd_cleanup "$@"
@@ -985,6 +1139,12 @@ commands:
   list                          list all active claims
   stack "T-1 T-2 ..." [agent]  atomically claim a dependency chain (all-or-nothing)
   release-stack <agent>         release all tasks in an agent's stack claim
+  stack-base <agent> <task-id>  print base branch for this task's PR (master
+                                for the first task, previous task's branch
+                                for subsequent tasks)
+  stack-set-pr <agent> <task-id> <branch> <pr-url>
+                                record branch+PR for a stacked task
+  stack-pr-state <agent>        print task/branch/pr table for agent's stack
   check-stale [max-secs]        release claims older than max-secs (default: 7200)
   cleanup [--repo o/r] ...      remove claims for merged/closed PRs.
                                 NOTE: cleanup's --repo takes a full owner/repo


### PR DESCRIPTION
## Summary

Migrate from one-PR-multi-commit stacks to true stacked PRs: each task in an `fleet-claim stack` chain now gets its own branch + PR, with each PR's `--base` pointing at the previous task's branch.

**New `fleet-claim` subcommands** (the worker-side primitive):

- `stack-base <agent> <task-id>` — resolve a task's PR base. `master` for the first task in the chain, previous task's branch for subsequent ones. Errors cleanly if the previous task hasn't opened its PR yet.
- `stack-set-pr <agent> <task-id> <branch> <pr-url>` — record a task's branch + PR once the PR is opened, so the next task can chain off it.
- `stack-pr-state <agent>` — print a `task / branch / pr` table for the agent's stack. Exits 0 on the no-stack path (matching `list` / `molecule list`) so `set -euo pipefail` callers don't need `|| true`.

Per-task sidecar files live inside the existing `_stack_<agent>/` dir, so `release-stack`'s `rm -rf` continues to clean them up — no new cleanup path.

**Doc updates** so the mechanism is reachable end-to-end:

- `commit-and-push` skill — new "Stack-aware mode" section: detect via `stack-pr-state`, branch off `stack-base`, record via `stack-set-pr`.
- `role-opus-worker` + `role-sonnet-author` — replace one-PR-multi-commit flow with per-task PR flow. PR titles start with `T-NNN: `; body has a `Stacked on:` line.
- `role-queue-manager` — single-task PRs are the norm now; the multi-task commit-subject-prefix matcher is kept as a legacy fallback for pre-migration merged PRs.

## Scope

This is **Part 1** of issue #183. Closes acceptance criteria 1-2 and partially 3.

**Part 2 stays open on #183**:
- Criterion 3 full coverage (queue-manager cascade behavior: when an earlier PR in a chain merges, validate the next PR's base auto-rebases cleanly)
- Criteria 4-5 (end-to-end validation of a 3-task stack flowing through author → reviewer → merge)

## Test plan

- [x] `fleet-claim` still syntax-checks (`bash -n`)
- [x] `stack-pr-state nonexistent-agent` exits 0 with `no stack claim for agent: ...` message
- [x] `stack-base nonexistent-agent T-001` exits 1 with `no stack claim for agent: ...` on stderr
- [ ] Reviewer pass on the subcommand contracts — look for edge cases in the base-resolution walk (task not in list, previous task's `.branch` file missing, etc.)
- [ ] Reviewer pass on the doc updates — are the role / skill walkthroughs internally consistent about who calls what when?

## Notes for reviewer

The deliberate cuts from the quality pass:

- Inlined `stack_task_in_list` into its single caller; `grep -Fxq` is clearer as a one-liner.
- Removed two narration comments that restated what the file-level comment block already documents.
- Did NOT trim the stacked-PR sections in role-opus-worker.md / role-sonnet-author.md — each role file should stay self-contained so an agent reading its role doesn't have to cross-chase into SKILL.md mid-task.

Files to focus on:

- `scripts/fleet/fleet-claim` — the three new cmd_* functions at lines ~540-640 and their dispatcher cases / USAGE entries.
- `.claude/skills/commit-and-push/SKILL.md` — the "Stack-aware mode" section and the new "Stack-aware override" block in step 8.
- `.claude/commands/role-*.md` — sanity-check the new per-task PR flow against the skill so they agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)