### PR TITLE
fleet: allow mktemp + narrow rm -rf for fleet-owned /tmp dirs

### DIFF
--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -214,6 +214,14 @@ baseline = [
     "Bash(fleet-claim:*)",
     "Bash(fleet-build:*)",
     "Bash(fleet-run:*)",
+    # Temp-dir lifecycle for agents that need isolated scratch space
+    # (e.g. testing fleet-claim with FLEET_CLAIMS_DIR=/tmp/fleet-...).
+    # The `rm -rf` pattern is intentionally narrowed to the `/tmp/fleet-`
+    # prefix — covers `mktemp -d -t fleet-...` outputs without giving
+    # blanket rm rights. Convention: fleet-owned temp dirs MUST live
+    # under `/tmp/fleet-<purpose>.<suffix>` so this allowlist works.
+    "Bash(mktemp:*)",
+    "Bash(rm -rf /tmp/fleet-:*)",
 ]
 
 # Preserve any user-granted "always allow" entries from previous sessions,


### PR DESCRIPTION
## Summary

Caught from a screenshot: an agent testing `fleet-claim` in an isolated `FLEET_CLAIMS_DIR=/tmp/fleet-claim-test.hAWWQC` completed all its tests, then couldn't clean up:

```
Bash(rm -rf /tmp/fleet-claim-test.hAWWQC)
Error: Permission to use Bash with command rm -rf /tmp/fleet-claim-test.hAWWQC has been denied.
```

The auto-permission classifier denies all `rm -rf` of arbitrary paths (correctly — `rm -rf $HOME` would be very bad). But it also denies the legitimate fleet-test cleanup pattern.

## The fix

Add two narrow entries to the per-worktree allowlist baseline in `fleet-up`:

- `Bash(mktemp:*)` — agents can create isolated temp dirs
- `Bash(rm -rf /tmp/fleet-:*)` — agents can clean them up, but **only** for paths under `/tmp/fleet-`. Not blanket rm rights.

Convention going forward: fleet-owned temp dirs MUST live under `/tmp/fleet-<purpose>.<suffix>`. Created via:

```bash
mktemp -d -t fleet-claim-test  # → /tmp/fleet-claim-test.X1Y2Z3
```

Documented in the settings-template comment so future tests follow the pattern.

## Risk envelope

- `Bash(rm -rf /tmp/fleet-:*)` is prefix-matching, so `rm -rf /tmp/fleet-foo /etc/passwd` would technically be allowed by the pattern. The fleet agents are trusted (this is their own machine, no remote attackers), so the realistic risk is fat-fingering, not malice. The narrow `/tmp/fleet-` prefix prevents blast-radius worse than "delete one fleet-owned temp dir + accidentally a sibling /tmp path".
- For comparison, the alternative blanket `Bash(rm:*)` would allow `rm -rf /` outright. This is much narrower.
- The user can tighten further any time by replacing the prefix with a wrapper script (`fleet-rm-tmp` that validates the arg before rm).

## Test plan

- [ ] Re-run `fleet-up live` — settings are rewritten on every pass, existing worktrees pick up the new entries
- [ ] Inspect `~/src/IrredenEngine/.claude/worktrees/opus-worker-1/.claude/settings.local.json`; confirm both new entries appear
- [ ] In a worktree pane, run `mktemp -d -t fleet-test` then `rm -rf /tmp/fleet-test.<suffix>`; both should run without prompts

## Notes for reviewer

- One-line addition + one-line allowlist entry + comment block in `scripts/fleet/fleet-up`. No other files touched.
- `simplify` skipped — bash settings template change, no logic to simplify.
- Other auto-deny patterns probably exist (the fleet hits them as workers do new things). This PR just addresses the one that surfaced today; future ones can ride on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)