### PR TITLE
fleet: fleet:changes-made now triggers reviewer re-review (was: stuck)

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -82,12 +82,17 @@ conditions, allocator behavior, hot-path costs.
    - The PR has the `human:re-review` label (human made changes and
      requested re-review — remove the label when you pick it up:
      `gh pr edit <N> --remove-label "human:re-review"`), OR
+   - The PR has the `fleet:changes-made` label AND it touches core
+     engine/game invariants (remove the label on pickup:
+     `gh pr edit <N> --remove-label "fleet:changes-made"`). For
+     non-core PRs, leave `fleet:changes-made` for sonnet-reviewer to
+     handle — Opus budget is expensive, don't burn it on docs/tooling
+     fixups, OR
    - The author pushed fixes and commented "re-review please" after
      a previous Opus review (check comments after your last review).
 
-   **Skip** PRs labeled `fleet:wip`, `human:wip`, `human:needs-fix`,
-   or `fleet:changes-made` — those are either in-progress, human-owned,
-   or in the feedback loop.
+   **Skip** PRs labeled `fleet:wip`, `human:wip`, or `human:needs-fix`
+   — those are either in-progress or human-owned.
 
 ## Loop behavior
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -122,7 +122,8 @@ Each iteration:
    d. Push fixes using `commit-and-push`.
    e. Add the appropriate response label and post a summary:
       - If it was `human:needs-fix` or `human:blocker` → add
-        `fleet:changes-made` (signals human to re-review):
+        `fleet:changes-made` (signals BOTH the human AND the fleet
+        reviewer to re-verify; whichever picks it up first wins):
         `gh pr edit <N> --add-label "fleet:changes-made"`
       - If it was `fleet:needs-fix` → no response label needed
         (fleet reviewer will re-review automatically on next poll)
@@ -139,10 +140,18 @@ Each iteration:
 
    **Human feedback label cycle:** human adds `human:needs-fix` (+
    comments) → agent removes it, works, adds `fleet:changes-made` →
-   human reviews again. Human can add multiple comments before
-   re-tagging; ALL are picked up when the tag appears. If the human
-   wants more changes, they remove `fleet:changes-made`, add
-   `human:needs-fix` again.
+   either the human or the next-poll fleet reviewer re-verifies
+   (whichever happens first; the reviewer removes the label on
+   pickup so they don't double-process). Human can add multiple
+   comments before re-tagging; ALL are picked up when the tag
+   appears. If the human wants more changes after a review pass,
+   they re-add `human:needs-fix`.
+
+   The merger uses the same path: when it labels a PR
+   `human:needs-fix` for an unresolvable conflict, an opus-worker
+   that picks up the conflict resolution should follow this same
+   cycle (remove `human:needs-fix`, fix, add `fleet:changes-made`).
+   The fleet reviewer will re-verify the resolution.
 
    **Fleet feedback cycle:** fleet reviewer adds `fleet:needs-fix` →
    author removes it, fixes, pushes → fleet reviewer sees the new

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -73,13 +73,18 @@ treat it as a hard rule for this role.
    - It has **no fleet review yet** (no review from your GitHub user), OR
    - It has the `human:re-review` label (human made changes and
      explicitly requested re-review via the `request-re-review` skill), OR
+   - It has the `fleet:changes-made` label (author addressed feedback;
+     either the human or the fleet should re-verify — whichever gets
+     to it first), OR
    - It **previously had a fleet review** but the author pushed fixes
      and commented "re-review please" (check the comments array for
      this text after your last review).
 
-   When picking up a `human:re-review` PR, **immediately remove the
-   label** so another reviewer doesn't also grab it:
+   When picking up a `human:re-review` or `fleet:changes-made` PR,
+   **immediately remove the label** so another reviewer doesn't also
+   grab it (run as separate calls):
    `gh pr edit <N> --remove-label "human:re-review"`
+   `gh pr edit <N> --remove-label "fleet:changes-made"`
 
    **Skip** PRs with any of these labels:
    - `fleet:wip` — work-in-progress claim, not ready for review.
@@ -87,8 +92,6 @@ treat it as a hard rule for this role.
    - `human:needs-fix` — human requested changes, author agent is
      handling it. Don't pile on a fleet review while the human's
      feedback is being addressed.
-   - `fleet:changes-made` — agent addressed human feedback, waiting
-     for human re-review. Not your turn.
 
 ## Loop behavior
 
@@ -103,10 +106,11 @@ iteration of polling, reviewing, and exiting cleanly:
 1. Re-fetch PR lists from both repos (separate commands):
    `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
    `gh pr list --repo <game-repo> --state open --json number,title,headRefName,author,reviews,labels`
-2. Re-apply the same skip criteria from startup step 5: skip PRs that
-   already have a fleet review, or carry any of `fleet:wip`,
-   `human:wip`, `human:needs-fix`, or `fleet:changes-made`. For each
-   remaining
+2. Re-apply the same candidate criteria from startup step 5: pick up
+   PRs with no fleet review, with `human:re-review`, with
+   `fleet:changes-made` (remove the label on pickup), or with a "re-review please"
+   comment after the last fleet review. Skip PRs carrying any of
+   `fleet:wip`, `human:wip`, or `human:needs-fix`. For each remaining
    candidate, in oldest-first order:
 
    **Engine PRs** (default repo):

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -81,10 +81,14 @@ treat it as a hard rule for this role.
      this text after your last review).
 
    When picking up a `human:re-review` or `fleet:changes-made` PR,
-   **immediately remove the label** so another reviewer doesn't also
-   grab it (run as separate calls):
-   `gh pr edit <N> --remove-label "human:re-review"`
-   `gh pr edit <N> --remove-label "fleet:changes-made"`
+   **immediately remove the label that triggered pickup** so another
+   reviewer doesn't also grab it. Run only the command matching the
+   label you picked up on — removing the other is a no-op on GitHub's
+   side but reads as unclear intent. If the PR has *both* labels
+   (rare — possible if a human re-requested review and the author
+   separately pushed fixes), remove both:
+   `gh pr edit <N> --remove-label "human:re-review"`  (if picked up via `human:re-review`)
+   `gh pr edit <N> --remove-label "fleet:changes-made"`  (if picked up via `fleet:changes-made`)
 
    **Skip** PRs with any of these labels:
    - `fleet:wip` — work-in-progress claim, not ready for review.


### PR DESCRIPTION
## Summary

PR #235 surfaced a real workflow bug. Trace:

1. Sonnet first pass + Opus recheck reviewed the original commit (04-20).
2. Merger flagged it `human:needs-fix` for unresolvable conflicts (PR #232 + PR #234 landed during).
3. Author rebased, removed `human:needs-fix`, added `fleet:changes-made` per the documented author flow (~1m later, 04-21).
4. **Both reviewers explicitly skip `fleet:changes-made`** — `role-sonnet-reviewer.md:90`: "agent addressed human feedback, waiting for human re-review. Not your turn."
5. PR sits forever unless the human notices and re-reviews manually.

## Root cause

The `fleet:changes-made` skip rule made sense when the dance was purely human↔author. With the merger now setting `human:needs-fix` autonomously (for conflicts the author then resolves), the fleet reviewer is excluded from a loop it should clearly be part of — the author's fix is exactly the kind of mechanical change a fresh-context reviewer can verify cheaply.

## Fix

Change the semantic of `fleet:changes-made` from **"human re-reviews next"** to **"either human OR fleet re-reviews next, whichever gets to it first"**.

- `role-sonnet-reviewer.md`: move `fleet:changes-made` from skip-list to candidate-trigger list. Reviewer removes the label on pickup (matching the existing `human:re-review` pattern).
- `role-opus-reviewer.md`: same move, but Opus only picks it up if the PR touches **core engine/game invariants**. Non-core fixups stay with sonnet — Opus budget is expensive.
- `role-sonnet-author.md`: clarify the new semantic in the response-label description and the human-feedback-cycle paragraph. Also document that the merger's `human:needs-fix` follows the same cycle (opus-worker resolves the conflict, adds `fleet:changes-made`, fleet reviewer verifies).

## In-flight cleanup

PR #235 manually unstuck before this PR lands: `human:re-review` added, `fleet:changes-made` removed. It will be picked up under the OLD logic too.

## Test plan

- [ ] Bring fleet up after merge: `fleet-up live`
- [ ] Confirm sonnet-reviewer iteration logs show `fleet:changes-made` PRs being picked up (not skipped)
- [ ] On a test PR: add `fleet:changes-made` label, push a commit, verify reviewer picks it up within ~3 min and removes the label
- [ ] On a core engine PR: verify Opus picks it up if it has `fleet:changes-made` AND touches `engine/render/`/`engine/entity/`/etc.
- [ ] Verify Opus does NOT pick up a docs-only PR with `fleet:changes-made` (sonnet handles it)

## Notes for reviewer

- Doc-only changes across 3 role files. No script logic touched.
- The `human:re-review` label still works as a parallel pathway — humans can use `request-re-review` skill to explicitly trigger.
- The "re-review please" comment-trigger remains; this PR adds a SECOND, label-based trigger so workflow doesn't depend on a magic phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)