### PR TITLE
fleet: cross-repo information isolation rule (engine public, game private)

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -101,6 +101,15 @@ Decide which repo the task belongs to:
   change), and a game-side task in the game queue with `Blocked by:`
   pointing at the engine task title or PR URL.
 
+  **Information isolation:** the engine task MUST be described in
+  pure engine terms — generic capabilities, no game-specific
+  motivation. Strip game task IDs, game PR URLs, game design
+  language, game feature names, and `creations/game/` paths from
+  the engine task entry, its title, its acceptance criteria, and
+  its notes. The engine repo is public; the game repo is private.
+  Only the game-side task may reference the engine. See engine
+  `CLAUDE.md` "Cross-repo information isolation" for the full rule.
+
 If you can't decide, ask the human.
 
 ### Step 2 — Categorize the model (`[opus]` vs `[sonnet]`)

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -113,9 +113,20 @@ of the following game-leakage tokens:
   "ant pheromone trails" or "fungus sporulation" instead of the
   underlying engine capability, rewrite in pure engine terms.
 
+Check for staged game-repo paths with a single git command using a
+pathspec filter — no pipe, no compound operator:
+
 ```bash
-git diff --cached --name-only | grep -E '^creations/game/' && echo "WARNING: engine PR includes creations/game/ paths"
+git diff --cached --name-only -- 'creations/game/'
 ```
+
+If the output is non-empty, the commit includes `creations/game/`
+paths and you must stop and warn the user. (If the output is empty,
+git prints nothing and you proceed.)
+
+For the PR body / commit message scan (looking for `jakildev/irreden`
+references or game task IDs), use the **Grep tool** on the draft text
+rather than a shell pipe.
 
 If any leakage is found, surface it to the user before committing.
 The fix is usually a 30-second rewrite of the commit message and PR

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -93,6 +93,35 @@ Skip the prompt if:
 - `docs/pr-screenshots/<branch>/` already contains screenshots from a prior
   run on this branch.
 
+**Then**, run the cross-repo information-isolation check (see engine
+`CLAUDE.md` "Cross-repo information isolation"). The engine repo is
+public; the game repo is private. Engine PRs MUST NOT leak game
+content. Scan the staged diff and the to-be-written PR body for any
+of the following game-leakage tokens:
+
+- `creations/game/` — engine PRs should never touch game files. If
+  the diff includes a path under `creations/game/`, this almost
+  certainly means the worker is in the wrong worktree (the engine
+  PR shouldn't be modifying the game tree). Stop and warn.
+- `jakildev/irreden` — the game repo slug. If a draft PR body or
+  commit message references it, scrub before continuing.
+- A `T-NNN` task ID that came from the game queue (cross-check
+  against `~/src/IrredenEngine/creations/game/TASKS.md` if present).
+  Engine PR bodies should reference engine task IDs only.
+- Game-specific feature names or design language. This one needs
+  human judgment — if the commit message you've drafted talks about
+  "ant pheromone trails" or "fungus sporulation" instead of the
+  underlying engine capability, rewrite in pure engine terms.
+
+```bash
+git diff --cached --name-only | grep -E '^creations/game/' && echo "WARNING: engine PR includes creations/game/ paths"
+```
+
+If any leakage is found, surface it to the user before committing.
+The fix is usually a 30-second rewrite of the commit message and PR
+body in engine-level terms; rarely is a code change actually needed
+(if it is, the worker is in the wrong repo entirely).
+
 **Then** invoke the `simplify` skill to review the dirty changes for reuse,
 quality, and efficiency issues specific to Irreden Engine:
 
@@ -245,6 +274,10 @@ if the user already asked for the next task).
 - ❌ Opening a PR without running `simplify` first.
 - ❌ Continuing to commit on the same feature branch after opening its PR
   unless the user explicitly asks for it — otherwise use `start-next-task`.
+- ❌ Leaking game references into an engine PR (file paths under
+  `creations/game/`, `jakildev/irreden`, game task IDs, game design
+  language). Engine repo is public; game repo is private. See engine
+  `CLAUDE.md` "Cross-repo information isolation".
 
 ## Recovery
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,6 +452,56 @@ is an additional hardcoded gate on top of that.
 
 ---
 
+## Cross-repo information isolation (applies everywhere, all agents)
+
+**The engine repo (`jakildev/IrredenEngine`) is public. The game repo
+(`jakildev/irreden`) is private.** Information flows one way only:
+
+- **Game-side artifacts MAY reference engine.** The engine is public,
+  so a game PR description, commit message, issue, review comment,
+  or `TASKS.md` blocker can freely cite engine PRs/issues/files. Game
+  agents already do this when filing engine issues for cross-repo
+  dependencies.
+- **Engine-side artifacts MUST NOT reference game.** Anything the
+  engine repo publishes — PR titles, PR descriptions, commit
+  messages, review comments, `TASKS.md` entries, GitHub issue bodies
+  filed on the engine — is world-readable. Leaking the game's task
+  IDs, feature names, design language, file paths, or repo slug
+  exposes private game work.
+
+**Concretely, when filing or writing anything that lands in the
+engine repo, never include:**
+
+- Game task IDs (`game T-005`, or unqualified `T-NNN` IDs that came
+  from the game queue).
+- Game PR or issue URLs (`jakildev/irreden#41`, etc.).
+- The game repo slug `jakildev/irreden`.
+- File paths under `creations/game/` (or any other gitignored
+  creation that lives in its own repo — `creations/<name>/`).
+- Game-specific design language, feature names, mechanics, or
+  systems by their game-side names. Talk in engine-level terms only:
+  "the prefab system needs a relation cache" rather than "the ant
+  pheromone trails need a relation cache for diffusion".
+
+**Cross-repo dependencies — the right pattern:**
+
+1. The work that lands in the engine PR is described in **pure
+   engine terms** — generic capabilities, no game-specific
+   motivation. The engine task in `TASKS.md` is self-contained.
+2. The game-side PR's description / TASKS.md entry references the
+   engine task by ID or PR URL as a `Blocked by:` dependency.
+
+This is the existing convention for `Blocked by:` (see queue-manager
+role, "Cross-repo work" section). The information-isolation rule
+generalizes that direction: engine talks engine, game talks both.
+
+**`commit-and-push` checks for this** before opening an engine PR
+— it greps the staged diff and the PR body for game-leakage tokens
+and warns. Treat the warning as blocking unless the leakage is
+intentional and the user explicitly approves.
+
+---
+
 ## Project layout (pointers to deeper CLAUDE.md files)
 
 ```


### PR DESCRIPTION
## Summary

You raised this concern: when filing tickets/PRs/comments on the engine repo, agents should know not to leak game references. The engine repo is **public**; the game repo is **private**. There was no canonical rule preventing engine artifacts from referencing game ones — one careless reference and private game design lands in a public Google search result.

The existing convention partially handled this (queue-manager's "Cross-repo work" pattern says game tasks reference engine via `Blocked by`, not the reverse). But that wasn't generalized: nothing prevented a game-related motivation from sneaking into an engine PR title or commit message.

## Three pieces

### 1. Engine `CLAUDE.md` — new top-level "Cross-repo information isolation" section

States the rule explicitly:

- **Game-side artifacts MAY reference engine** (engine is public, anything referenced is already world-readable).
- **Engine-side artifacts MUST NOT reference game.** Enumerated leakage tokens to scrub:
  - Game task IDs
  - Game PR/issue URLs (`jakildev/irreden#N`)
  - Game repo slug `jakildev/irreden`
  - File paths under `creations/game/`
  - Game-specific design language and feature names

And points at the correct cross-repo pattern: engine task = self-contained in pure engine terms; game task = references engine via `Blocked by`.

### 2. `role-queue-manager.md` — "Information isolation" paragraph

The queue-manager is the primary cross-repo entry point — every game-driven engine ticket passes through it. New paragraph in the "Cross-repo work" clause cites the canonical rule and enumerates what to scrub from engine task entries.

### 3. `commit-and-push` skill — leakage scan step

New pre-commit step (between the screenshot check and `simplify`) that:

- Greps the staged diff for `creations/game/` paths and warns. (Engine PRs should never touch game files; if they do, the worker is in the wrong worktree.)
- Notes other tokens (`jakildev/irreden`, game task IDs, game feature language) that need manual scrubbing of the to-be-written commit message and PR body.

Plus an anti-pattern entry pointing at the rule.

## Why no centralized "file-cross-repo-issue" skill (yet)

You suggested a skill if one didn't exist. I'd argue the rule itself ("don't leak") is more about content judgment than mechanism — a skill would have to either (a) be a thin wrapper that documents the rule (which is what the doc already does) or (b) actively scrub content (which requires NLP-grade judgment to catch design-language leakage). The doc + the `commit-and-push` warning hits the practical sweet spot.

If we observe the rule getting violated despite docs, the next step is a stronger gate — e.g. a pre-commit hook that hard-blocks if `creations/game/` appears in the diff. Easy to add later.

## Out-of-scope

- **Game-side CLAUDE.md** — it tells game agents how to file engine issues (`creations/game/CLAUDE.md` lines 91-92, "what the game needs"). That language deserves a scrubbing reminder too. Lives in the private game repo, so a separate PR there.
- **Reviewer roles** — leakage in review comments is already covered by the global CLAUDE.md rule that every reviewer reads. If we see violations, add a reviewer-side note then.

## Test plan

- [ ] Confirm engine `CLAUDE.md` renders the new section cleanly
- [ ] Next time `commit-and-push` runs, verify the worker references the new isolation step
- [ ] Manual smoke: stage a fake `creations/game/foo.txt` and run the grep — should warn

## Notes for reviewer

- Doc-only change. `simplify` skipped (prose).
- The `commit-and-push` grep snippet is intentionally simple (one `grep -E`); not trying to be a comprehensive scanner.
- The rule does NOT block — it warns and asks the worker to confirm. Bypass-pushing rare cases (e.g. queue-manager TASKS.md referencing a public game repo for an open-source creation) shouldn't get blocked by a hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)