### PR TITLE
fleet: stop prompting on heartbeat / tmp / GIT_EDITOR + use -B for scratch

### DIFF
--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -109,8 +109,15 @@ overwritten by checkout."
 ### 6. Check out the new branch off fresh origin/master
 
 ```bash
-git checkout -b claude/<new-area>-<new-topic> origin/master
+git checkout -B claude/<new-area>-<new-topic> origin/master
 ```
+
+`-B` (uppercase) creates the branch if it doesn't exist AND resets it
+to the named commit if it does. Lowercase `-b` errors out with "branch
+already exists" — surprisingly common because the worktree's previous
+scratch branches accumulate over many iterations. With `-B`, we don't
+care; the branch always lands on a clean `origin/master` regardless of
+its prior state.
 
 This creates the new branch starting from the tip of `origin/master`, not
 from wherever your previous branch was. Critical: without `origin/master`,

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -214,6 +214,11 @@ baseline = [
     "Bash(fleet-claim:*)",
     "Bash(fleet-build:*)",
     "Bash(fleet-run:*)",
+    # Env-var-prefixed git for non-interactive rebase. `Bash(git:*)`
+    # in the user-level allowlist matches commands STARTING with `git`,
+    # so a `GIT_EDITOR=true git ...` prefix doesn't match. Add an
+    # explicit entry so `git rebase --continue` works without a prompt.
+    "Bash(GIT_EDITOR=true git:*)",
 ]
 
 # Preserve any user-granted "always allow" entries from previous sessions,
@@ -233,9 +238,21 @@ if os.path.isfile(settings_file):
 
 all_allows = baseline + existing_extra
 
+# additionalDirectories scopes file-system access. The worktree path
+# is automatic; we add:
+#   - repo_root: the main clone, so the agent can read engine/ build/
+#     etc. from inside a worktree without triggering path-scope
+#     prompts on every cross-reference.
+#   - ~/.fleet/: heartbeats, plans, claims, logs, sessions, summaries,
+#     molecules, alerts. Every fleet role writes into one of these
+#     subdirs; without this entry every heartbeat write prompts.
+#   - /tmp/: fleet-claim test patterns, mktemp scratch dirs, generic
+#     scratch usage. Already partially allowlisted via Bash entries
+#     for mktemp/rm; adding the directory closes the path-scope side.
+home = os.path.expanduser("~")
 out = {
     "permissions": {
-        "additionalDirectories": [repo_root],
+        "additionalDirectories": [repo_root, f"{home}/.fleet", "/tmp"],
         "allow": all_allows,
         "defaultMode": "auto",
     }


### PR DESCRIPTION
## Summary

Three friction points caught from a sonnet-fleet-1 screenshot mid-rebase. All three were prompting agents during normal-path operations — every one of them blocks unattended fleet runs.

### 1. Heartbeat (and other `~/.fleet/`) writes prompt every iteration

Every fleet role's step 0 is `date -u +... > ~/.fleet/heartbeats/<role>`. The per-worktree settings.local.json template only put `repo_root` in `additionalDirectories`, so any write under `~/.fleet/` triggered a path-scope approval prompt. Same problem hits:

- `~/.fleet/plans/` (opus-worker plan files)
- `~/.fleet/claims/` (fleet-claim locks)
- `~/.fleet/logs/` (fleet-babysit + merger audit logs)
- `~/.fleet/sessions/` (architect session-id resume)
- `~/.fleet/summaries/` (fleet-down --summary outputs)
- `~/.fleet/molecules/` (PR #230 stack-claim metadata)
- `~/.fleet/alerts/` (witness staleness alerts)
- `/tmp/fleet-claim-test.*` (fleet-claim test scratch — partially fixed in PR #243 via Bash allowlist; this finishes the path-scope side)

**Fix:** extend `additionalDirectories` to `[repo_root, ~/.fleet, /tmp]`.

### 2. `GIT_EDITOR=true git ...` not allowlisted

The merger and post-rebase flows use `GIT_EDITOR=true git rebase --continue` to prevent the editor opening on a non-interactive continue. The user-level allowlist `Bash(git:*)` matches commands STARTING with `git`, so the env-var prefix doesn't match.

**Fix:** add baseline entry `Bash(GIT_EDITOR=true git:*)`.

### 3. `git checkout -b` blocks on existing scratch branch

Screenshot showed the agent doing this dance after `commit-and-push`:

```
git checkout -b claude/sonnet-1-scratch origin/master    -> fatal: branch exists
git checkout -b claude/sonnet-1-fresh   origin/master    -> fatal: branch exists
git checkout -b claude/sonnet-fleet-1-next origin/master -> succeeded (random name)
```

Worktrees accumulate stale scratch branches across iterations, so the collision is the norm, not the exception. `start-next-task` should use `-B` (create-or-reset). Lossless because the prior scratch branch is, by design, throwaway.

**Fix:** swap `-b` → `-B` in `start-next-task` step 6.

`commit-and-push` deliberately keeps `-b` — its branch names are session-unique topic branches, so a collision IS a real signal that the worker should pick a different name.

## Test plan

- [ ] After merge, run `fleet-up live`. Settings get rewritten on every pass.
- [ ] Inspect `~/src/IrredenEngine/.claude/worktrees/sonnet-fleet-1/.claude/settings.local.json`; confirm `additionalDirectories` includes `~/.fleet` and `/tmp` and the new `Bash(GIT_EDITOR=true git:*)` entry.
- [ ] Watch a sonnet-fleet-1 iteration; confirm no prompts on heartbeat write or rebase --continue.
- [ ] Trigger `start-next-task` after a commit-and-push; confirm it lands on a fresh scratch branch without "fatal: branch exists" detours.

## Notes for reviewer

- Two-file diff: `scripts/fleet/fleet-up` (settings template) + `.claude/skills/start-next-task/SKILL.md` (`-b` → `-B`).
- `additionalDirectories` widening is intentionally three known fleet-owned paths, not a blanket allow. `/tmp` is broad but standard and the alternative (per-suffix entries) doesn't compose with `additionalDirectories` (no globs).
- `simplify` skipped — config + doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)