### PR TITLE
fleet: align reviewer docs with stacked-PR flow (T-020 Part 2)

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -112,14 +112,16 @@ iteration of polling, reviewing, and exiting cleanly:
    a. Read the existing Sonnet review in full first
       (`gh pr view <N> --comments`, add `--repo <game-repo>` for
       game PRs). Note what Sonnet flagged.
-   b. **Detect stack PRs.** Check the commit list:
-      `gh pr view <N> --json commits --jq '.commits[].messageHeadline'`
-      If multiple commit subjects start with `T-NNN: ` prefixes
-      (different task IDs), this is a stack PR. The Sonnet review
-      should already have per-task `## T-NNN` sections — your
-      Opus pass should mirror that structure, reviewing each
-      task's commits independently for the deeper invariants
-      (ECS, lifetime, GPU buffers) that Opus focuses on.
+   b. **Check whether the PR is stacked.** Every fleet PR today is
+      single-task, but stacked PRs (chains of dependent tasks) base off
+      a parent PR's branch rather than `master`. Detect with:
+      `gh pr view <N> --json baseRefName,body --jq '"\(.baseRefName)\n---\n\(.body)"'`
+      If the base is not `master` or the body carries a `Stacked on:`
+      line, this PR depends on the parent landing first. Review only
+      this PR's own diff (as always — `gh pr diff <N>` scopes to it).
+      Do not re-review the parent; it has its own PR, its own Sonnet
+      first pass, and possibly its own Opus pass. Note the stack
+      context in your review body.
    c. **Engine PRs:** Invoke the `review-pr` skill on the PR.
       **Game PRs:** Read the diff with `gh pr diff <N> --repo
       <game-repo>` and review manually (you cannot check out game
@@ -128,8 +130,7 @@ iteration of polling, reviewing, and exiting cleanly:
    d. Focus your review on the items Sonnet could not confirm — do
       not duplicate work Sonnet already did. Your review body should
       explicitly call out the Sonnet review by saying "Sonnet flagged
-      X; on closer read I confirm/disagree because Y". For stack
-      PRs, do this per-task under matching `## T-NNN` headings.
+      X; on closer read I confirm/disagree because Y".
    e. Post the review: write the review body to `/tmp/review-body.md`
       using the **Write tool**, then:
       `gh pr review <N> --comment --body-file /tmp/review-body.md`

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -264,11 +264,13 @@ Do the work, then exit cleanly:
      normal pickup flow below and jump straight to step 6 ("Work it",
      the implementation step) to begin working it.
      If the task's PR is already open, `fleet-claim stack-pr-state
-     <your-worktree-name>` (add `--repo game` for game-side molecules)
-     shows its URL and branch. Check out the task's branch and
-     continue committing normally — one task per branch means the
-     branch itself is the per-task anchor, so no special
-     commit-subject prefix is required.
+     <your-worktree-name>` (use `fleet-claim --repo game
+     stack-pr-state <your-worktree-name>` for game-side molecules —
+     `--repo` is a global flag parsed before the subcommand) shows
+     its URL and branch. Check out the task's branch and continue
+     committing normally — one task per branch means the branch
+     itself is the per-task anchor, so no special commit-subject
+     prefix is required.
 
      **Resume vs restart judgment.** Read the worktree's git status:
      - If there is no work-in-progress on the branch matching that

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -263,10 +263,12 @@ Do the work, then exit cleanly:
      a crash). It is now (or remains) marked `in-progress`. Skip the
      normal pickup flow below and jump straight to step 6 ("Work it",
      the implementation step) to begin working it.
-     The PR for the stack is also already open — find it via the
-     branch name on `gh pr list` and continue committing to it
-     (use the `T-NNN: ` commit-subject prefix described in the stack
-     PR section).
+     If the task's PR is already open, `fleet-claim stack-pr-state
+     <your-worktree-name>` (add `--repo game` for game-side molecules)
+     shows its URL and branch. Check out the task's branch and
+     continue committing normally — one task per branch means the
+     branch itself is the per-task anchor, so no special
+     commit-subject prefix is required.
 
      **Resume vs restart judgment.** Read the worktree's git status:
      - If there is no work-in-progress on the branch matching that

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -173,9 +173,11 @@ Each iteration:
      crash). It is now (or remains) marked `in-progress`. Skip the
      normal pickup flow and jump straight to step 4 ("Read the plan
      file"), then continue to step 5 ("Work it") to begin working it.
-     The stack PR is already open — find it via the branch name on
-     `gh pr list` and continue committing to it (use the `T-NNN: `
-     commit-subject prefix from the stack PR section).
+     If the task's PR is already open, `fleet-claim stack-pr-state
+     <your-worktree-name>` shows its URL and branch. Check out the
+     task's branch and continue committing normally — one task per
+     branch means the branch itself is the per-task anchor, so no
+     special commit-subject prefix is required.
 
      **Resume vs restart judgment.** Read the worktree's git status:
      - No work-in-progress on the branch matching that task ID →

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -118,42 +118,23 @@ iteration of polling, reviewing, and exiting cleanly:
    `fleet:wip`, `human:wip`, or `human:needs-fix`. For each remaining
    candidate, in oldest-first order:
 
-   **Engine PRs** (default repo):
-   a. **Detect stack PRs first.** A stack PR has multiple commits
-      whose subjects are prefixed with `T-NNN: ` (one prefix per
-      task in the chain). Check with:
-      `gh pr view <N> --json commits --jq '.commits[].messageHeadline'`
-      If you see two or more `T-NNN:` prefixes, this is a stack PR
-      and you MUST review each task's commits independently — the
-      worker chained dependent tasks into one PR for context
-      efficiency, but the review pass is still per-task.
+   **Engine PRs** (default repo): Invoke the `review-pr` skill with
+   the PR number. Every engine PR today is single-task — one task, one
+   branch, one PR. Stacked PRs (chains of dependent tasks) are just a
+   sequence of single-task PRs whose `--base` points at the previous
+   task's branch instead of `master`; each one gets its own independent
+   review and label.
 
-      For a stack PR:
-      - List task IDs from the prefixes (e.g. `T-005`, `T-007`).
-      - For each task, find its commits:
-        `gh pr view <N> --json commits --jq '.commits[] | select(.messageHeadline | startswith("T-005:")) | .oid'`
-      - Review only that task's diff. Two paths:
-        - **Quick:** `gh pr diff <N>` for the whole PR — then
-          mentally segment by task (commits and the PR description's
-          `## T-NNN` sections guide you).
-        - **Precise (for non-trivial stacks, or when tasks touch
-          overlapping files):** check out the PR, then for each task
-          find the task-tip commit — the last commit whose subject
-          starts with that task's prefix:
-          `gh pr view <N> --json commits --jq '.commits[] | select(.messageHeadline | startswith("T-005:")) | .oid' | tail -1`
-          Then diff that slice:
-          `git diff <previous-task-tip>...<this-task-tip>`
-          (For the first task in the stack, use `origin/master` as
-          the previous tip.)
-      - Write per-task findings in the review body under
-        `## T-NNN` headings. Verdict is one overall approval (the
-        whole PR merges as a unit), but the per-task structure
-        gives the author and the human a clear view of what's
-        clean vs what needs fixing per task.
-
-   b. **Single-task PR (most common):** Invoke the `review-pr`
-      skill with the PR number. The skill checks out the PR, reads
-      the diff in context, writes a structured review, and posts it.
+   **Stack awareness:** before invoking the skill, check whether this
+   PR is stacked on a parent PR (it will be if its base branch is not
+   `master` or its body carries a `Stacked on:` line):
+   `gh pr view <N> --json baseRefName,body --jq '"\(.baseRefName)\n---\n\(.body)"'`
+   If it is stacked, review only this PR's own diff (`gh pr diff <N>`
+   already scopes to it — don't pull in the parent's changes) and note
+   the stack context in your review body: "Stacked on #<parent>;
+   approval assumes #<parent> lands first." Do not re-review the
+   parent — it has its own PR and its own review. The `review-pr`
+   skill handles this as part of its normal flow.
 
    **Game PRs** (`<game-repo>`):
    a. Read the diff: `gh pr diff <N> --repo <game-repo>`

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -90,6 +90,40 @@ gh pr list --state open --limit 5
 
 Pick the top result, confirm the title with the user if there's ambiguity.
 
+### 1b. Check whether the PR is stacked
+
+Every fleet PR today is single-task. When workers claim a dependency
+chain via `fleet-claim stack`, they produce a sequence of single-task
+PRs where each one's `--base` points at the previous task's branch
+instead of `master` — GitHub calls these "stacked PRs". The review
+pass is still per-PR; you don't re-review the parent PR as part of
+reviewing its child.
+
+Detect stacking from the metadata already fetched in step 1:
+
+- **Base branch** (`baseRefName`) is not `master` → stacked on the PR
+  whose head is that branch.
+- **Body** contains a `Stacked on:` line → confirms it, and the line
+  gives you the parent PR URL for the review-body callout.
+
+If stacked:
+
+- Review **only this PR's own diff**. `gh pr diff <N>` already scopes
+  to the changes this PR introduces on top of its base branch — it
+  does NOT include the parent's changes. Trust that output; don't
+  manually expand the range.
+- Note the stack context in the review body, e.g. "Stacked on
+  #<parent>; approval assumes #<parent> lands first." Reviewers
+  (and the human merger) use that line to sequence merges.
+- Do **not** read, cite, or re-verify the parent PR's diff. It has
+  its own independent review and label. Cross-contamination between
+  stacked PRs' reviews is the main failure mode to avoid.
+- Verdict and label are set for this PR alone, the same way as a
+  non-stacked PR.
+
+If the base is `master` and there's no `Stacked on:` line, this is a
+standalone PR — proceed with the rest of the flow as normal.
+
 ### 2. Check out the PR branch locally (read-only)
 
 ```bash


### PR DESCRIPTION
## Summary
- Reviewer-side alignment for the stacked-PR flow. PR #242 delivered the worker-side mechanism (one PR per task, chained via `--base`); this PR updates the reviewer roles and `review-pr` skill so they stop describing the superseded multi-commit-single-PR concept.
- **`role-sonnet-reviewer.md`** and **`role-opus-reviewer.md`** now detect stacking from the PR's `baseRefName` / body (`Stacked on:` line) instead of scanning commit subjects for multiple `T-NNN:` prefixes. Stacked PRs are reviewed independently per PR — each gets its own verdict and label.
- **`role-sonnet-author.md`** and **`role-opus-worker.md`** drop the resume-time reference to a per-task commit-subject prefix. With one branch per task, the branch itself is the per-task anchor; commits need no special prefix.
- **`review-pr/SKILL.md`** gains a new \"1b. Check whether the PR is stacked\" section covering detection + what not to do (don't re-review the parent, don't expand the diff range, verdict and label are per-PR).

## Test plan
- [ ] Next sonnet-reviewer iteration picks up an open PR and follows the new flow (no attempts to scan for multi-`T-NNN:` commit subjects)
- [ ] An opus-worker resuming a molecule no longer looks for a \"stack PR section\" that no longer exists
- [ ] `review-pr` skill invocations correctly handle a stacked PR (note stack context, don't re-review parent)

## Notes
T-020 Part 1 (#242) landed the worker-side mechanism. This is Part 2 — docs-only, no behaviour changes to the tools themselves.

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)