### PR TITLE
fleet-claim: molecule resume exit 1 on 'no molecule', help subcommand works

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -302,10 +302,12 @@ Do the work, then exit cleanly:
        didn't leave a stack claim open last iteration).
      - A molecule exists but every task is already `done` or
        `failed`. If you see the latter, also run
-       `fleet-claim molecule complete <your-worktree-name>` (add
-       `--repo game` for game-side) to archive it. For the former,
-       you can tell by looking at whether stdout had the "no
-       molecule" message.
+       `fleet-claim molecule complete <your-worktree-name>` (use
+       `fleet-claim --repo game molecule complete
+       <your-worktree-name>` for game-side — `--repo` is a global
+       flag parsed before the subcommand) to archive it. For the
+       former, you can tell by looking at whether stdout had the
+       "no molecule" message.
      Either way, proceed with the normal pickup flow below.
 
    **Normal pickup (no active molecule)** — pick from either queue.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -296,14 +296,17 @@ Do the work, then exit cleanly:
      resuming so commit-and-push targets the right repo (see step 4
      for the cd path).
 
-   - **Exit 1** — the molecule has no remaining work (every task is
-     `done` or `failed`). Archive it and release the stack-claim:
-     `fleet-claim molecule complete <your-worktree-name>`
-     (add `--repo game` for game-side molecules.) Then proceed with
-     the normal pickup flow.
-
-   - **Exit 2** — no molecule for this agent. Proceed with the normal
-     pickup flow below.
+   - **Exit 1** — nothing to resume. Two sub-cases collapse to this
+     exit code because they're handled the same way:
+     - No molecule exists for this agent (the common case — you
+       didn't leave a stack claim open last iteration).
+     - A molecule exists but every task is already `done` or
+       `failed`. If you see the latter, also run
+       `fleet-claim molecule complete <your-worktree-name>` (add
+       `--repo game` for game-side) to archive it. For the former,
+       you can tell by looking at whether stdout had the "no
+       molecule" message.
+     Either way, proceed with the normal pickup flow below.
 
    **Normal pickup (no active molecule)** — pick from either queue.
    Look at both `/tmp/tasks-engine.md` and `/tmp/tasks-game.md`. Find

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -955,14 +955,21 @@ cmd_molecule_show() {
 cmd_molecule_resume() {
     # Mark the next pending task as in-progress and print its ID.
     # Exit 0 if a task was returned (worker should pick it up).
-    # Exit 1 if molecule has no remaining work — worker should run
-    # `fleet-claim molecule complete <agent>` to archive it.
+    # Exit 1 if there is nothing to resume — either no molecule exists
+    # at all, or the molecule has no remaining work. In both cases the
+    # worker should just move on to normal task pickup; "no molecule"
+    # is the overwhelming common case for opus-worker startup and is
+    # NOT an error.
+    # Exit 2 is reserved for usage errors (bad args, etc.).
     local agent="$1"
     local file
     file=$(molecule_file "$agent")
     if [[ ! -f "$file" ]]; then
-        echo "no molecule for agent: $agent" >&2
-        return 2
+        # Print to stdout (informational), not stderr (error). Keep the
+        # message so a human running it interactively still sees the
+        # signal, but don't make it look like a failure.
+        echo "no molecule for agent: $agent (nothing to resume)"
+        return 1
     fi
     if molecule_python resume "$file"; then
         return 0
@@ -1123,7 +1130,11 @@ case "${1:-}" in
                 ;;
         esac
         ;;
-    *)
+    help|--help|-h|"")
+        # Explicit help / no-subcommand case: print usage and exit 0.
+        # Exit 0 is important — agents tend to run `fleet-claim help`
+        # expecting docs, and a non-zero exit reads as a failure.
+        # The real "unknown command" case falls through to `*)` below.
         cat <<'USAGE'
 usage: fleet-claim [--repo <ns>] <command> [args]
 
@@ -1157,8 +1168,9 @@ molecule commands (crash-recovery state for stack claims):
   molecule list                          show all active molecules + per-task state
   molecule show <agent>                  print one molecule yaml verbatim
   molecule resume <agent>                mark next pending → in-progress, print task ID
-                                         exit 0 = task ID printed, 1 = molecule fully done,
-                                         2 = no molecule for this agent
+                                         exit 0 = task ID printed, 1 = nothing to resume
+                                         (no molecule OR molecule already done — just move
+                                         on to normal TASKS.md pickup)
   molecule advance <agent> <task-id> <new-state> [pr=URL] [commit=SHA]
                                          transition one task's state. New state is one of
                                          pending|in-progress|done|failed.
@@ -1193,6 +1205,11 @@ Examples:
                                                            #  prefixed slugs
                                                            #  visible in list)
 USAGE
+        exit 0
+        ;;
+    *)
+        echo "fleet-claim: unknown command '$1'" >&2
+        echo "run 'fleet-claim help' for usage." >&2
         exit 2
         ;;
 esac


### PR DESCRIPTION
## Summary

Two UX issues observed in an opus-worker iteration screenshot:

### 1. `fleet-claim molecule resume <agent>` exited 2 when no molecule exists

Exit 2 is idiomatic "usage error" — bad signal for what's actually the common case. Most opus-worker startups don't have an active molecule. Agents see "Error: Exit code 2" and treat it as a failure, even though the role doc says exit 2 means "proceed normally".

**Fix:** collapse "no molecule" AND "molecule already done" into exit 1 ("nothing to resume"). Both cases mean the same thing to the worker — move on to normal pickup. Exit 2 reserved for actual usage errors. Kept the informational message but routed to stdout (not stderr) so the Bash tool doesn't flag it red.

Updated `role-opus-worker.md` to reflect the collapsed semantics.

### 2. `fleet-claim help` errored out

Agents naturally type `help` looking for docs. The dispatcher only matched `-h`/`--help`/no-arg. `help` fell through to `*)` which printed usage AND exited 2.

**Fix:** explicit `help|--help|-h|""` case that prints usage with exit 0. `*)` now handles unknown commands with a targeted "unknown command 'X'" message + exit 2.

## Verified

```
fleet-claim help             → exit 0 ✓
fleet-claim --help           → exit 0 ✓
fleet-claim                  → exit 0 ✓
fleet-claim not-a-command    → exit 2 ✓ (with targeted error)
fleet-claim molecule resume nobody
  → stdout: "no molecule for agent: nobody (nothing to resume)"
  → exit 1 ✓
```

## Test plan

- [ ] Merge; watch an opus-worker iteration. `fleet-claim molecule resume opus-worker-X` should not show as "Error: Exit code 2" in the agent's Bash output anymore.
- [ ] Confirm the worker proceeds straight to normal TASKS.md pickup after the resume check.

## Out of scope (separate PR coming)

The bigger issue observed in the same investigation: **workers don't cleanly exit after iterations because `claude "prompt"` starts interactive mode by default**. The sonnet-fleet-1 agent printed "standing by, babysit will re-invoke" but never exited. Fix is `--print` flag in `fleet-babysit`'s worker launch. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)