### PR TITLE
fleet-babysit: --print for worker launches so iterations actually exit

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -175,19 +175,33 @@ launch_architect_first() {
 launch_worker_fresh() {
     # No --continue, no --resume — fresh conversation for each task
     # iteration. Used both on first launch and between task iterations.
-    claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
+    #
+    # `--print` is CRITICAL here. Without it, `claude "prompt"` starts
+    # INTERACTIVE mode and never exits — the agent finishes its work,
+    # emits a "standing by" message, then sits at the prompt forever
+    # waiting for more user input. Babysit only relaunches on process
+    # exit, so no-exit = no-relaunch = agent goes stale. Observed in
+    # production with sonnet-fleet-1 / sonnet-reviewer running once
+    # then stuck forever.
+    #
+    # `--print` means one-shot: run the prompt (including all tool use
+    # within it), emit the response, exit 0. That's exactly the
+    # "one iteration = one claude process" model the babysit header
+    # comment describes. Tool use still works under --print; the only
+    # difference is no interactive prompt after the response completes.
+    claude --model "$MODEL" --effort "$EFFORT" --print "/role-$ROLE $MODE"
 }
 
 resume_mid_task() {
     # Mid-task crash recovery. Architects always --resume their persisted
-    # session. Workers --continue the most recent session in this cwd
-    # (that's whatever crashed mid-task — we want to pick up where it
-    # left off so partial work isn't lost).
+    # session (interactive — they need the human's next input).
+    # Workers --continue + --print the most recent session in this cwd
+    # (one-shot — resume, finish what was interrupted, exit).
     if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
         claude --model "$MODEL" --effort "$EFFORT" --resume "$(cat "$SESSION_FILE")" \
             "resume your work from where you left off"
     else
-        claude --model "$MODEL" --effort "$EFFORT" --continue "resume your work from where you left off"
+        claude --model "$MODEL" --effort "$EFFORT" --print --continue "resume your work from where you left off"
     fi
 }
 


### PR DESCRIPTION
## Root cause of "sonnet agents go stale and don't get reinvoked"

`fleet-babysit` launches workers with `claude --model X "/role-..."` — which defaults to INTERACTIVE mode. The agent runs the role slash command, does its work, emits "standing by, babysit will re-invoke", and then sits at the prompt forever waiting for more user input. Babysit only relaunches on **process exit**. No exit → no relaunch → agent stale.

Direct quote from `claude --help`:

> "Claude Code - starts an interactive session by default, use -p/--print for non-interactive output"

## Evidence from production

sonnet-fleet-1 started at 10:06:57, touched its heartbeat at 10:09 (end of first iteration), and did not write another heartbeat for 14+ minutes. Log confirms: no "worker clean exit" event. Process was still running, just idle at the prompt.

`worker clean exit` counts across all logs (over the log's lifetime):

| Agent | Count | Expected (3m loop = 20/hr × 24h) |
|---|---|---|
| opus-worker | 4 | ~72/day |
| sonnet-author | 2 | ~72/day |
| sonnet-reviewer | 2 | **~480/day** on a 3m loop |
| queue-manager | 2 | ~288/day |
| merger | 0 | ~144/day |
| opus-reviewer | 2 | ~48/day |

Clean exits were only happening when the human Ctrl-C'd a pane or during `fleet-down` — not from agent self-completion.

## The fix

Add `--print` to `launch_worker_fresh` and to the worker branch of `resume_mid_task`:

```diff
- claude --model "$MODEL" --effort "$EFFORT" "/role-$ROLE $MODE"
+ claude --model "$MODEL" --effort "$EFFORT" --print "/role-$ROLE $MODE"
```

With `--print`, claude runs the prompt (including all tool use during it), emits the response, exits 0. That's exactly the one-iteration-per-process model the babysit header comment describes — but the existing implementation wasn't asking for it.

Tool use still works under `--print`; the only difference is no interactive prompt after the response completes.

Architects unchanged — they remain interactive because they need to continue the human conversation across turns.

## Expected effect after merge + fleet restart

- Each worker iteration produces exactly one `starting` line and one `worker clean exit` line in `~/.fleet/logs/<role>.log`
- Heartbeat mtimes bump every LOOP_INTERVAL
- Witness staleness alerts only fire when an agent actually hangs (real problem), not when it's done-and-waiting (false positive)

## Test plan

- [ ] Merge
- [ ] `fleet-down --force && fleet-up live`
- [ ] Wait one full loop interval (5m for sonnet-author, 3m for sonnet-reviewer)
- [ ] Confirm `~/.fleet/logs/sonnet-author.log` shows a `worker clean exit` line within the first iteration
- [ ] Confirm the heartbeat file's mtime advances on each iteration
- [ ] Witness log shows no STALE entries for agents that are actually running

## Risk

- **If --print behaves differently from what I read:** the agent crashes or can't use tools. I don't THINK this is the case — the claude CLI docs suggest --print just changes the "wait for next user input" behavior, not tool capability. But worth confirming on the first launched pane.
- **If architects accidentally get --print:** they'd one-shot and never continue the conversation. Guarded by the `ARCHITECT_RESUME` check.

## Stack

This is on top of #256 (fleet-claim UX). No conflict between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)