### PR TITLE
fleet: review-pr verifies previously-flagged hunks on re-review (T-030)

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -386,9 +386,13 @@ comments:
       don't require tracking.) Do NOT silently re-flag an item without first
       checking whether it was fixed.
 
-3. **Read the new commits only.** `git log origin/master..HEAD --oneline`, then
-   diff only the commits that arrived after the prior review timestamp. Avoid
-   re-examining already-reviewed code — focus the checklist on what changed.
+3. **Read the new commits only.** `git log origin/master..HEAD --oneline` lists
+   all commits on the PR branch since it diverged from master. Scope to the
+   subset that arrived **after the prior review's timestamp** — the prior review
+   comment's `created_at` (visible in the `gh pr view --comments` output from
+   step 2a) is the cutoff. Commits older than that were already reviewed; commits
+   newer than that are the delta to inspect. Avoid re-examining already-reviewed
+   code — focus the checklist on what changed.
 
 4. **Run the full fresh-eyes checklist** (Step 4 of the main flow) against the
    new commits. Carry forward any "Still open" or "Location changed" items from

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -340,12 +340,66 @@ Reply with a compact summary to the calling session:
 If the user says "re-review PR 42" after the author-agent has addressed
 comments:
 
-1. Check out the updated PR branch (`gh pr checkout <N>` again — it pulls).
-2. Read only the **new** commits (`git log origin/master..HEAD` then diff
-   the range since your last review).
-3. Verify each blocker/needs-fix from your previous review was actually
-   addressed. Cite the old review and the new resolution.
-4. Post a follow-up comment with the updated verdict.
+1. **Check out the updated branch.** `gh pr checkout <N>` again — it pulls
+   the latest commits onto the already-checked-out branch.
+
+2. **Verify previously-flagged items first — before running the checklist.**
+   This is the most important step. Skipping it causes false-positive re-flags.
+
+   a. Fetch the prior review body (run both commands in parallel — first gets
+      conversation-level comments, second gets inline review comments):
+      ```
+      gh pr view <N> --comments
+      gh api repos/jakildev/IrredenEngine/pulls/<N>/comments \
+          --jq '.[] | "[\(.path):\(.line // .original_line)] \(.body)"'
+      ```
+      Identify the review comment that was posted by this fleet (look for
+      the `## Review —` header and `🤖 Reviewed by` footer).
+
+   b. Extract every `<path>:<line>` or `<path>` reference from the
+      **Blockers**, **Needs-fix**, and **Nits** sections of that prior review.
+      Inline comments from the second command are also flagged items — treat
+      them the same way.
+
+   c. Get the HEAD commit SHA for attribution:
+      ```
+      git rev-parse --short HEAD
+      ```
+
+   d. For each flagged item, read the relevant portion of the file at HEAD
+      using the **Read tool** with `offset` near the flagged line. Determine:
+      - **Fixed** — the issue described in the prior review is no longer present
+        at that location (and not obviously moved elsewhere).
+      - **Still open** — the issue is still present at that location.
+      - **Location changed** — the line moved; the issue exists at a new path/line.
+
+   e. Write a **Prior-review resolution** section that will open the new review
+      body. Format:
+      ```
+      ### Prior-review resolution
+      - ✅ `path:line` — <prior issue summary> — verified fixed at <SHA>
+      - ❌ `path:line` — <prior issue summary> — still present; re-flagged below
+      - ↗ `old_path:old_line` — <prior issue summary> — moved to `new_path:new_line`; re-flagged below
+      ```
+      Every **Blocker**, **Needs-fix**, and **Nit** item from the prior review
+      must appear in one of these three states. (Praise and test-plan items
+      don't require tracking.) Do NOT silently re-flag an item without first
+      checking whether it was fixed.
+
+3. **Read the new commits only.** `git log origin/master..HEAD --oneline`, then
+   diff only the commits that arrived after the prior review timestamp. Avoid
+   re-examining already-reviewed code — focus the checklist on what changed.
+
+4. **Run the full fresh-eyes checklist** (Step 4 of the main flow) against the
+   new commits. Carry forward any "Still open" or "Location changed" items from
+   step 2e. Do **not** re-raise items already confirmed fixed in the resolution
+   table.
+
+5. **Post the review.** Open the review body with the Prior-review resolution
+   table (step 2e), then present any new findings and any carried-forward open
+   items. If all prior items are fixed and no new issues appear, the verdict is
+   approve. Follow the same body format and label steps as the main flow
+   (steps 5, 5b, 6).
 
 ## Escalation footer
 


### PR DESCRIPTION
## Summary
- Re-reviewers were running the full checklist without first verifying
  whether previously-flagged items were actually fixed, causing false-positive
  re-flags (observed: reviewer claimed a nit was still present when the fix
  commit had already removed it).
- Expands the `Re-review` section of `review-pr/SKILL.md` with an explicit
  prior-hunk verification step: fetch prior review + inline comments in parallel,
  extract every Blocker/Needs-fix/Nit file:line reference, read each at HEAD,
  build a ✅/❌/↗ resolution table, then run the full checklist only on new
  commits.

## Test plan
- [ ] Re-review flow reads prior review body and inline comments before checklist
- [ ] Resolution table appears at the top of new review body
- [ ] Already-fixed items show "verified fixed at \<SHA\>" and are not re-flagged
- [ ] Full checklist still runs against new commits

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)