### PR TITLE
fleet: commit-and-push post-rebase hunk-loss guard (T-031)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -159,17 +159,8 @@ exit cleanly:
    **d. Branch on the result:**
 
       **Clean rebase (exit 0).** No conflicts at all — the PR's
-      commits replayed without intervention.
-
-      **Post-rebase hunk check (run on ALL successful rebases before push):**
-      Capture the post-rebase state and diff against the pre-capture:
-      `git diff origin/master > /tmp/fleet-postrebase.diff`
-      Then use the **Read** tool to read both `/tmp/fleet-prerebase.diff`
-      and `/tmp/fleet-postrebase.diff`, and compare them. Look for
-      additions (`+` lines) present in the pre-capture that are absent in
-      the post-capture — these are silently dropped hunks. If any are
-      found, do NOT push: restore the missing lines, then re-run the
-      post-rebase check before pushing.
+      commits replayed without intervention. Proceed to **step e**
+      (post-rebase hunk check) before pushing.
       - `git push --force-with-lease`
       - Write `.merger-body.md` with:
         ```
@@ -208,6 +199,8 @@ exit cleanly:
            `git rebase --continue`
          - If `git rebase --continue` succeeds and the rebase
            completes (no further conflicts):
+           Proceed to **step e** (post-rebase hunk check) before
+           pushing.
            - `git push --force-with-lease`
            - Comment + cooldown label as in the clean-rebase case,
              with body noting "Merger: TASKS.md sort-merged
@@ -239,6 +232,8 @@ exit cleanly:
          - If every conflicted file passes the whitespace check:
            `git add <files>`
            `git rebase --continue`
+         - Proceed to **step e** (post-rebase hunk check) before
+           pushing.
          - Push, comment, cooldown label, log as above with body
            "Merger: whitespace-only conflicts auto-resolved by
            preferring master's formatting."
@@ -278,7 +273,18 @@ exit cleanly:
            `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
          - Log: `... semantic conflict, labeled human:needs-fix`
 
-   **d. Reset to scratch.** After processing each PR (success OR
+   **e. Post-rebase hunk check.** Runs on ALL paths that reach a push
+      (clean rebase, case i, case ii). Captures the post-rebase diff
+      and compares it to the pre-capture from step b:
+      `git diff origin/master > /tmp/fleet-postrebase.diff`
+      Then use the **Read** tool to read both `/tmp/fleet-prerebase.diff`
+      and `/tmp/fleet-postrebase.diff`, and compare them. Look for
+      lines beginning with `< +` — additions present in the pre-capture
+      that are absent in the post-capture. Each such line is a silently
+      dropped hunk. If any are found, do NOT push: restore the missing
+      lines and re-run this check before proceeding to the push.
+
+   **f. Reset to scratch.** After processing each PR (success OR
       fail), return to the scratch branch so the next iteration
       starts clean and so other agents are not blocked from
       checking out the same branch:

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -148,12 +148,28 @@ exit cleanly:
       `git fetch origin <headRefName>`
       `git checkout -B <headRefName> origin/<headRefName>`
 
-   **b. Try rebase.** `git rebase origin/master`
+   **b. Rebase guard pre-capture.** Before rebasing, snapshot the current
+      diff so silently-dropped hunks can be detected afterward:
+      `git diff origin/master > /tmp/fleet-prerebase.diff`
+      (Git's 3-way merge can drop additions from non-conflicting regions
+      without any conflict marker; this capture enables a post-check.)
 
-   **c. Branch on the result:**
+   **c. Try rebase.** `git rebase origin/master`
+
+   **d. Branch on the result:**
 
       **Clean rebase (exit 0).** No conflicts at all — the PR's
       commits replayed without intervention.
+
+      **Post-rebase hunk check (run on ALL successful rebases before push):**
+      Capture the post-rebase state and diff against the pre-capture:
+      `git diff origin/master > /tmp/fleet-postrebase.diff`
+      Then use the **Read** tool to read both `/tmp/fleet-prerebase.diff`
+      and `/tmp/fleet-postrebase.diff`, and compare them. Look for
+      additions (`+` lines) present in the pre-capture that are absent in
+      the post-capture — these are silently dropped hunks. If any are
+      found, do NOT push: restore the missing lines, then re-run the
+      post-rebase check before pushing.
       - `git push --force-with-lease`
       - Write `.merger-body.md` with:
         ```

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -129,9 +129,16 @@ If you're on `master`:
 
 If you're already on a feature branch, just use it. Do not rename mid-session.
 
-### 3. Check for visual changes and run `simplify`
+### 3. Pre-commit checks and `simplify`
 
-**First**, check whether the diff touches visual/render files:
+**First**, run the **Rebase guard** check (see section below): use the
+**Read** tool on `/tmp/fleet-prerebase.diff`. If the file exists, a
+pre-capture was taken before a recent rebase — run the post-capture and
+comparison as described in the Rebase guard section. If missing, check
+`git reflog --since=2.hours.ago` for a recent rebase entry; if found,
+warn and inspect manually before proceeding.
+
+**Second**, check whether the diff touches visual/render files:
 
 ```bash
 git diff --name-only origin/master...HEAD
@@ -363,6 +370,45 @@ Reply with a compact summary:
 `start-next-task` skill handles resetting the worktree to a fresh branch off
 master for the next chunk — tell the user to invoke it (or invoke it yourself
 if the user already asked for the next task).
+
+## Rebase guard
+
+**Before rebasing this PR branch onto origin/master**, always capture the
+current diff first. Git's 3-way merge can silently drop hunks from non-
+conflicting regions of a file when a different region of the same file has
+a conflict — no conflict markers, no warning in the rebase output.
+
+### Pre-capture (do this BEFORE `git rebase origin/master`)
+
+```bash
+git diff origin/master > /tmp/fleet-prerebase.diff
+```
+
+### Rebase and resolve conflicts
+
+Run `git rebase origin/master`. Resolve any conflict markers normally.
+
+### Post-capture and comparison
+
+```bash
+git diff origin/master > /tmp/fleet-postrebase.diff
+diff /tmp/fleet-prerebase.diff /tmp/fleet-postrebase.diff
+```
+
+Scan the `diff` output for lines beginning with `< +` — additions that were
+present in the pre-rebase state but are absent after. Each is a dropped hunk
+that must be manually re-applied before committing.
+
+If every line of `diff` output is a metadata change (index hashes, commit
+SHAs, `@@` hunk header offset shifts), no content was lost.
+
+### If the pre-capture was skipped
+
+1. Run `git reflog --since=2.hours.ago` to confirm a rebase happened.
+2. Compare `git diff origin/master` against the branch's last pushed state:
+   `git diff origin/<branch-name>` shows what changed since the last push.
+3. Look for missing code blocks based on the PR's commit messages and
+   description. Re-apply any that are absent.
 
 ## Anti-patterns
 


### PR DESCRIPTION
## Summary

- Git's 3-way merge can silently drop additions from non-conflicting file regions during rebase — no conflict markers, no warning.
- Adds a pre/post-rebase diff guard: capture `git diff origin/master` before rebasing, compare to a post-rebase capture, and scan for `< +` lines (dropped additions).
- `role-merger.md`: new step b (pre-capture), plus post-rebase hunk check in the clean-rebase path before any `--force-with-lease` push.
- `commit-and-push/SKILL.md`: step 3 gains a brief rebase-guard callout; full protocol in new `## Rebase guard` section.

## Test plan

- [ ] Simulate a rebase that drops a hunk: pre-capture matches post-capture discrepancy, agent catches it
- [ ] Clean rebase with no dropped hunks: `diff` shows no `< +` lines, proceed normally
- [ ] Missing pre-capture (no rebase in session): reflog check, warn only if rebase entry found

Closes #T-031

🤖 Generated with [Claude Code](https://claude.com/claude-code)
