### PR TITLE
metal: implement finish() for accurate GPU stage timing (T-007)

### DIFF
--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -476,12 +476,20 @@ setMetalDepthWriteEnabled(enabled);
     }
 
     void finish() override {
-        // The Metal render impl already commits-and-waits each frame at
-        // present(), so finish() is only used by GPU stage timing. Spinning
-        // up a no-op command buffer here would force a flush, but stage
-        // timing is OFF by default and the per-command-buffer cost is
-        // dominated by the present-time wait. Leaving as a no-op until we
-        // need precise per-stage timings on Metal.
+        // Block until prior GPU work completes, then start a fresh command
+        // buffer for subsequent encoders. Mirrors OpenGL glFinish(). The
+        // fresh-buffer step is required because Metal encoders cannot
+        // record into a committed buffer; without it, the next dispatch
+        // or draw silently no-ops. Same pattern as readDefaultFramebuffer()
+        // above.
+        auto *commandBuffer = metalCommandBuffer();
+        if (commandBuffer == nullptr) {
+            return;
+        }
+        commandBuffer->commit();
+        commandBuffer->waitUntilCompleted();
+        releaseDeferredMetalBuffers();
+        setMetalCommandBuffer(metalCommandQueue()->commandBuffer());
     }
 };
 


### PR DESCRIPTION
## Summary

Metal's `finish()` was a no-op stub, which silently broke the GPU stage timing infrastructure from PR #237 on the Metal backend. Every Metal stage reported near-zero ms because the chrono samples captured only CPU-side encoding time — actual GPU work stayed queued in a single un-synchronized command buffer.

This PR mirrors the `commit / waitUntilCompleted / fresh-buffer` pattern already used by `readDefaultFramebuffer()` in the same file, so Metal `finish()` now honors OpenGL `glFinish()`'s blocking-sync contract.

## Parity reference

- **Leading backend:** OpenGL — `engine/render/src/opengl/opengl_render_impl.cpp:134-136` (one-liner `glFinish()`).
- **Precedent in Metal backend:** `engine/render/src/metal/metal_render_impl.cpp:215-228` (`readDefaultFramebuffer` uses the same commit/wait/fresh-buffer idiom for the mid-frame screenshot flush).
- **Parity gap surfaced by:** PR #237 (T-028) introducing `IRRender::gpuStageTiming().finish()` call sites at stage boundaries.

## Test plan

- [x] `fleet-build --target IRShapeDebug` — clean build, hygiene canary observed (real `Building CXX object … metal_render_impl.cpp.o` line).
- [x] `fleet-run IRShapeDebug --timeout 5` — init completed, no crashes, full ECS/render bring-up logs.
- [ ] **Reviewer on macOS:** set `gpu_stage_timing = true` in a creation config and confirm the perf-stats overlay reports nonzero per-stage ms instead of the pre-fix near-zero values.

## Notes

- The fresh-buffer step is mandatory — Metal encoders cannot record into a committed buffer; without it, the first dispatch/draw after `finish()` silently no-ops. `readDefaultFramebuffer()` learned this the hard way; the comment in the new code points at that precedent.
- Per the backend-parity skill, this is a one-feature-per-PR port. `copyImageSubData` remains a Metal stub but it isn't called from live code; flagging separately rather than bundling.
- Closes T-007.