### PR TITLE
fleet: stop label-list pagination noise + ignore agent scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ Thumbs.db
 
 # fleet agent temp files
 .review-body.md
+.review-body-*.md
+.pr-body.md
+.merger-body.md
+__pycache__/
 
 # creations: keep demos + top-level CLAUDE.md, ignore other folders
 creations/*

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -110,10 +110,20 @@ LABELS=(
     "human:re-review|5319e7|Human pushed changes; reviewer agent should re-review"
 )
 
+# `gh label list` defaults to --limit 30. The engine repo already has
+# more than 30 labels (10 fleet/human + 10 IR* component + ~10 stock +
+# growing), and the game repo will too once it ages. Without an
+# explicit limit, labels past the alphabetical cutoff are invisible
+# to this script — it tries to create them, gh rejects with "already
+# exists", and the recheck (also paginated) still doesn't see them,
+# so they get logged as "failed to create" on every fleet-up. 1000 is
+# well above any plausible label count.
+LABEL_LIST_LIMIT=1000
+
 ensure_label_for_repo() {
     local repo="$1"
     local existing
-    if ! existing=$(gh label list --repo "$repo" --json name --jq '.[].name' 2>&1); then
+    if ! existing=$(gh label list --repo "$repo" --limit "$LABEL_LIST_LIMIT" --json name --jq '.[].name' 2>&1); then
         echo "fleet-labels: failed to list labels on $repo: $existing" >&2
         return 1
     fi
@@ -139,7 +149,7 @@ ensure_label_for_repo() {
         else
             # Label may have been created by a parallel run between our list
             # and create — re-check rather than treating as failure.
-            if gh label list --repo "$repo" --json name --jq '.[].name' | grep -qx "$name"; then
+            if gh label list --repo "$repo" --limit "$LABEL_LIST_LIMIT" --json name --jq '.[].name' | grep -qx "$name"; then
                 existed=$((existed + 1))
             else
                 echo "  failed to create: $name" >&2


### PR DESCRIPTION
## Summary

Two small fleet-up hygiene fixes that surfaced bringing the fleet back
up after a forced shutdown — the worktrees had filled with agent
scratch files and `fleet-labels` was logging seven false "failed to
create" lines on every run.

- **fleet-labels: `--limit 1000` on `gh label list`.** The default
  page size is 30. The engine repo has 39 labels and growing, so the
  alphabetically-late ones were invisible to the script. It would try
  to recreate them, gh rejected with "already exists", the recheck
  (also paginated) still missed them, and they got logged as failures.
  Steady-state output is now silent.
- **.gitignore: cover the actual agent scratch filenames.** The
  existing pattern only matched `.review-body.md` singular, but the
  reviewer writes per-PR `.review-body-NNN.md`, the merger writes
  `.merger-body.md`, and `commit-and-push` writes `.pr-body.md`. Also
  adds `__pycache__/` since one pane left Python bytecode behind.
  These had piled up across six worktrees and blocked
  `fleet-up`'s reset because it refuses to clobber dirty trees.

## Test plan

- [x] `fleet-labels --repo jakildev/IrredenEngine` — output goes from
      7 spurious "failed to create" lines to silent
      "0 created, 17 already existed".
- [x] `git status` in stoic-kapitsa with `.review-body-test.md`,
      `.pr-body.md`, `.merger-body.md` present — all ignored.
- [ ] Next `fleet-up live` → no spurious label noise + no dirty
      worktrees on subsequent restarts.

## Notes for reviewer

- `LABEL_LIST_LIMIT=1000` is a sentinel ("well above any plausible
  count"), not a derived value. Reviewer Agent 2 explicitly considered
  whether to derive it from `${#LABELS[@]} * 10` and concluded that
  would couple the *fleet-managed* set to the *repo's total* label
  count, which is wrong.
- The 8-line comment is proportional to the surprise of seeing
  `--limit 1000` in a script that only manages 17 labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)