### PR TITLE
fleet: stream live worker output through readable formatter

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -133,6 +133,75 @@ case "$ROLE" in
     *architect*) ARCHITECT_RESUME=1 ;;
 esac
 
+# --- Stream-formatted claude wrapper ---------------------------------------
+#
+# Workers run claude with `--print` so each iteration exits cleanly
+# (PR #257). The downside: `--print` with the default text output
+# buffers EVERYTHING and only emits at the very end — the pane looks
+# dead the whole time the agent is thinking, reading files, calling
+# tools, etc. Humans watching the fleet can't tell "agent is working"
+# from "agent is wedged" until the final dump lands.
+#
+# Fix: pair `--print` with `--output-format stream-json
+# --include-partial-messages --verbose`, then pipe through
+# fleet-claude-stream which renders the JSON event stream as readable
+# terminal text. `set -o pipefail` (set at the top of this script)
+# preserves claude's exit code through the pipe so the babysit
+# `last_exit` dispatch still works.
+#
+# Resolve fleet-claude-stream from PATH (post-install.sh) or fall back
+# to a sibling next to this script (pre-install.sh, or a worktree
+# running an unreleased version). If neither is present, fall through
+# to plain text output — the live-pane visibility regresses but the
+# fleet still functions.
+#
+# We can't use `readlink -f` for the sibling lookup: BSD readlink on
+# macOS doesn't support `-f`, so it would silently return the
+# unresolved symlink path (e.g. ~/bin/fleet-babysit) and dirname would
+# point at ~/bin, not the real scripts/fleet/. Walk the symlink chain
+# manually — same pattern as fleet-labels' resolve_symlink_chain.
+__resolve_real_path() {
+    local path="$1"
+    while [[ -L "$path" ]]; do
+        local target
+        target=$(readlink "$path")
+        if [[ "$target" = /* ]]; then
+            path="$target"
+        else
+            path="$(cd "$(dirname "$path")" && pwd)/$target"
+        fi
+    done
+    echo "$path"
+}
+__BABYSIT_DIR="$(dirname "$(__resolve_real_path "${BASH_SOURCE[0]}")")"
+
+if command -v fleet-claude-stream >/dev/null 2>&1; then
+    STREAM_FORMATTER="fleet-claude-stream"
+elif [[ -x "$__BABYSIT_DIR/fleet-claude-stream" ]]; then
+    STREAM_FORMATTER="$__BABYSIT_DIR/fleet-claude-stream"
+else
+    STREAM_FORMATTER=""
+fi
+
+stream_claude() {
+    # Both callers pass --print themselves (workers must one-shot exit
+    # so babysit can relaunch — see launch_worker_fresh comment block).
+    # If a future caller forgets --print, the formatter branch will
+    # error out (`--include-partial-messages` requires `--print`),
+    # which is the right failure mode — better than silently entering
+    # interactive limbo like the pre-PR-#257 bug.
+    if [[ -n "$STREAM_FORMATTER" ]]; then
+        claude --model "$MODEL" --effort "$EFFORT" \
+            --output-format stream-json --include-partial-messages --verbose \
+            "$@" | "$STREAM_FORMATTER"
+    else
+        # Fallback: plain claude with whatever the caller passed.
+        # `--print` from the caller stays put, so worker exit semantics
+        # are unchanged; only the live-pane visibility regresses.
+        claude --model "$MODEL" --effort "$EFFORT" "$@"
+    fi
+}
+
 # --- Launch helpers --------------------------------------------------------
 #
 # Two distinct lifecycles:
@@ -189,7 +258,14 @@ launch_worker_fresh() {
     # "one iteration = one claude process" model the babysit header
     # comment describes. Tool use still works under --print; the only
     # difference is no interactive prompt after the response completes.
-    claude --model "$MODEL" --effort "$EFFORT" --print "/role-$ROLE $MODE"
+    #
+    # The downside of `--print` alone is that text output is buffered
+    # to the very end — the pane looks dead the whole time the agent
+    # is thinking, calling tools, etc. We pipe through fleet-claude-stream
+    # to render the live event stream as readable text. `set -o pipefail`
+    # at the top of this script preserves claude's exit code through
+    # the pipe, so the babysit `last_exit` dispatch still works.
+    stream_claude --print "/role-$ROLE $MODE"
 }
 
 resume_mid_task() {
@@ -201,7 +277,7 @@ resume_mid_task() {
         claude --model "$MODEL" --effort "$EFFORT" --resume "$(cat "$SESSION_FILE")" \
             "resume your work from where you left off"
     else
-        claude --model "$MODEL" --effort "$EFFORT" --print --continue "resume your work from where you left off"
+        stream_claude --print --continue "resume your work from where you left off"
     fi
 }
 

--- a/scripts/fleet/fleet-claude-stream
+++ b/scripts/fleet/fleet-claude-stream
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# fleet-claude-stream — render `claude --print --output-format stream-json
+# --include-partial-messages --verbose` into readable terminal text for
+# tmux panes.
+#
+# Why this exists:
+#   Workers run with `--print` so each task iteration is a fresh,
+#   one-shot `claude` process that exits when done (PR #257). But
+#   `--print` with the default text output buffers EVERYTHING and
+#   only emits at the very end — the pane looks dead the whole time
+#   the agent is thinking, reading files, calling tools, etc. Humans
+#   watching the fleet can't tell "agent is working" from "agent is
+#   wedged" until the final dump lands several minutes later.
+#
+#   `stream-json` gives us live events but is a wall of JSON lines,
+#   useless for human eyeballs. This formatter sits between them and
+#   renders only what's actually informative: the model's text deltas
+#   inline, tool calls with truncated args, tool results with truncated
+#   previews, and a one-line cost/duration summary at the end.
+#
+# Usage (in fleet-babysit):
+#   claude --print --output-format stream-json \
+#          --include-partial-messages --verbose ... | fleet-claude-stream
+#
+# `set -o pipefail` in the caller preserves claude's exit code through
+# the pipe so babysit's last_exit-driven relaunch logic still works.
+#
+# Source of truth: scripts/fleet/fleet-claude-stream in the engine repo.
+# Installed to ~/bin/fleet-claude-stream by scripts/fleet/install.sh.
+
+import json
+import sys
+
+# ANSI: dim/colors gracefully no-op in non-tty (we still keep them — tmux
+# panes always have a tty, and a plain `tee` of the pipe will show the
+# escape codes raw, which is acceptable since this is a tmux-pane tool).
+DIM, RESET = "\033[2m", "\033[0m"
+RED, GREEN, YELLOW = "\033[31m", "\033[32m", "\033[33m"
+BLUE, CYAN = "\033[34m", "\033[36m"
+
+INPUT_PREVIEW_LEN = 100   # truncate tool inputs to this many chars
+RESULT_PREVIEW_LEN = 200  # truncate tool results to this many chars
+
+
+def emit(s):
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+
+def short(value, n):
+    """Stringify and truncate a value for inline display."""
+    if isinstance(value, (dict, list)):
+        s = json.dumps(value, separators=(",", ":"))
+    else:
+        s = str(value)
+    s = s.replace("\n", "\\n")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def handle_assistant(event):
+    """Tool calls (text blocks are already streamed via deltas)."""
+    msg = event.get("message", {})
+    for block in msg.get("content", []):
+        if block.get("type") == "tool_use":
+            name = block.get("name", "?")
+            inp = short(block.get("input", {}), INPUT_PREVIEW_LEN)
+            emit(f"\n{BLUE}▸ {name}({inp}){RESET}\n")
+
+
+def handle_user(event):
+    """Tool results from the previous turn (between assistant turns)."""
+    msg = event.get("message", {})
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if block.get("type") == "tool_result":
+            inner = block.get("content")
+            if isinstance(inner, list):
+                # Anthropic returns tool_result.content as a list of blocks
+                text = "".join(b.get("text", "") for b in inner if isinstance(b, dict))
+            elif isinstance(inner, str):
+                text = inner
+            else:
+                text = ""
+            preview = short(text, RESULT_PREVIEW_LEN) if text else "(no output)"
+            color = RED if block.get("is_error") else DIM
+            emit(f"{color}  ⎿ {preview}{RESET}\n")
+
+
+def handle_stream_event(event):
+    """Inline text/thinking deltas (the live-typing visibility)."""
+    evt = event.get("event", {})
+    et = evt.get("type")
+    if et == "content_block_delta":
+        delta = evt.get("delta", {})
+        dt = delta.get("type")
+        if dt == "text_delta":
+            emit(delta.get("text", ""))
+        elif dt == "thinking_delta":
+            # Render thinking as dimmed inline text so it visually folds
+            # into the response stream rather than dominating the pane.
+            emit(f"{DIM}{delta.get('thinking', '')}{RESET}")
+
+
+def handle_result(event):
+    cost = event.get("total_cost_usd", 0) or 0
+    dur_s = (event.get("duration_ms", 0) or 0) / 1000
+    turns = event.get("num_turns", 0)
+    is_err = event.get("is_error", False)
+    subtype = event.get("subtype", "?")
+    color = RED if is_err else GREEN
+    emit(f"\n{color}[done {subtype} turns={turns} ${cost:.4f} {dur_s:.1f}s]{RESET}\n")
+    if is_err and event.get("result"):
+        emit(f"{RED}{event['result']}{RESET}\n")
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Pass through anything that isn't JSON (e.g. claude wrapper
+            # warnings). Better to over-show than swallow useful errors.
+            emit(line + "\n")
+            continue
+
+        t = event.get("type")
+        if t == "system":
+            sub = event.get("subtype")
+            if sub == "init":
+                model = event.get("model", "?")
+                cwd = event.get("cwd", "?").rsplit("/", 1)[-1]
+                sess = (event.get("session_id") or "?")[:8]
+                emit(f"{DIM}[claude {model} sess={sess} cwd={cwd}]{RESET}\n")
+        elif t == "rate_limit_event":
+            info = event.get("rate_limit_info", {})
+            util = info.get("utilization", 0)
+            rl_type = info.get("rateLimitType", "?")
+            emit(f"\n{YELLOW}[rate-limit {rl_type} util={util:.0%}]{RESET}\n")
+        elif t == "stream_event":
+            handle_stream_event(event)
+        elif t == "assistant":
+            handle_assistant(event)
+        elif t == "user":
+            handle_user(event)
+        elif t == "result":
+            handle_result(event)
+        # else: silently drop status pings, message envelopes, etc.
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (BrokenPipeError, KeyboardInterrupt):
+        # Pane closed or ctrl-c'd mid-stream. Exit cleanly so the upstream
+        # claude process's exit code is what `set -o pipefail` reports.
+        sys.exit(0)

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -76,6 +76,8 @@ FLEET_LABELS_SRC="$SCRIPT_DIR/fleet-labels"
 FLEET_LABELS_DEST="$HOME/bin/fleet-labels"
 FLEET_HEARTBEAT_SRC="$SCRIPT_DIR/fleet-heartbeat"
 FLEET_HEARTBEAT_DEST="$HOME/bin/fleet-heartbeat"
+FLEET_STREAM_SRC="$SCRIPT_DIR/fleet-claude-stream"
+FLEET_STREAM_DEST="$HOME/bin/fleet-claude-stream"
 WITNESS_SRC="$SCRIPT_DIR/witness"
 WITNESS_DEST="$HOME/bin/witness"
 
@@ -87,7 +89,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -134,6 +136,11 @@ fi
 if [[ -f "$FLEET_HEARTBEAT_SRC" ]]; then
     ln -sf "$FLEET_HEARTBEAT_SRC" "$FLEET_HEARTBEAT_DEST"
     echo "symlinked $FLEET_HEARTBEAT_DEST -> $FLEET_HEARTBEAT_SRC"
+fi
+
+if [[ -f "$FLEET_STREAM_SRC" ]]; then
+    ln -sf "$FLEET_STREAM_SRC" "$FLEET_STREAM_DEST"
+    echo "symlinked $FLEET_STREAM_DEST -> $FLEET_STREAM_SRC"
 fi
 
 if [[ -f "$WITNESS_SRC" ]]; then


### PR DESCRIPTION
## Summary

PR #257 added `--print` to worker claude invocations so each task
iteration is a clean one-shot process — fixing the no-exit/no-relaunch
staleness on sonnet panes. Side effect: `--print` text output buffers
to the very end. Panes look dead while the agent works, until a
several-minutes-late dump lands. This restores live visibility while
keeping clean-exit semantics.

- **`scripts/fleet/fleet-claude-stream` (new).** Python 3 formatter
  for Claude Code's stream-json event stream. Renders text deltas
  inline, tool uses as `▸ Name(args)`, tool results as truncated
  `⎿ preview`, rate-limit warnings, plus a one-line cost/duration
  summary at the end. ANSI-coloured for tmux.
- **`fleet-babysit` adds `stream_claude` helper** that pipes claude's
  stream-json output through the formatter. `set -o pipefail`
  preserves claude's exit code through the pipe, so the
  `last_exit`-driven relaunch dispatch is unchanged.
- **Symlink resolution** uses a manual chain-walking loop rather than
  `readlink -f` (BSD readlink on macOS doesn't support `-f`). Same
  pattern fleet-labels uses for the same reason.
- **Graceful fallback** to plain `claude --print` if the formatter
  isn't found — visibility regresses but the fleet keeps working.
- **install.sh wires fleet-claude-stream into the symlink loop** so
  PATH-based lookup works after the next install.sh run.

Architects unchanged — they stay interactive, no `--print`, no
streaming wrapper.

## Test plan

- [x] `python3 fleet-claude-stream` with synthetic event stream → text
      deltas / tool uses / tool results / final summary all render.
- [x] `set -o pipefail; (echo … ; exit 42) | fleet-claude-stream;
      echo $?` → exits 42, formatter doesn't swallow upstream code.
- [x] Real `claude --output-format stream-json … | fleet-claude-stream`
      → live deltas appear during tool use, not just at end.
- [x] `bash -n` clean on both fleet-babysit and install.sh.
- [x] Symlink-walk loop verified on macOS — resolves
      `~/bin/fleet-babysit` → `…/scripts/fleet/fleet-babysit` correctly.
- [ ] Next `fleet-up live` → worker panes show streaming output during
      iterations (was silent under PR #257).

## Notes for reviewer

- The defensive comment in `stream_claude` notes that callers must pass
  `--print` themselves; future caller forgetting it gets an explicit
  error from claude (`--include-partial-messages requires --print`)
  rather than silent interactive limbo.
- Formatter truncation: `INPUT_PREVIEW_LEN=100` for tool-use args,
  `RESULT_PREVIEW_LEN=200` for tool-result content. Tuned for one-line
  pane density.
- Reuse review (Agent 1) suggested extracting `__resolve_real_path`
  into a shared `fleet-common.sh` since fleet-labels has the same
  loop. Deferred — premature with only 2 callers; revisit if a 3rd
  shows up.
- Efficiency review (Agent 3) flagged a nit on `json.dumps()` in
  `short()` for huge tool inputs. Bounded in practice (tool inputs
  are file paths, search patterns, short args), so deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)