### PR TITLE
T-033: engine/render CLAUDE.md install layering principle between render and prefabs

### DIFF
--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -53,9 +53,10 @@ fog.setState(worldX, worldY, kFogStateVisible);
 
 **Pattern B — prefab-scoped free-function namespace.** A header in this
 directory (e.g. `fog_of_war.hpp`) exposes a namespace such as `IRPrefab::Fog::`
-that internally performs the entity-lookup logic. Keeps an ergonomic
-free-function shape without putting the feature into `IRRender::` or adding
-fields to `RenderManager`.
+(declared in the feature's own header; name it anything that doesn't collide
+with `IRRender::`) that internally performs the entity-lookup logic. Keeps an
+ergonomic free-function shape without putting the feature into `IRRender::` or
+adding fields to `RenderManager`.
 
 ```cpp
 // Header exposes a namespace; callers do not need to hold the entity.

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -36,6 +36,42 @@ the ECS surface.
 
 See `engine/render/CLAUDE.md` for the full pipeline diagram.
 
+## Exposing system public API from the prefab layer
+
+Feature systems in this directory may need a public API surface so creations
+and Lua bindings can drive their behavior. Two patterns:
+
+**Pattern A — direct component access.** Caller grabs the relevant entity via
+an ECS query and reads or writes the component directly. Best when the API
+surface is small and callers already hold the entity id.
+
+```cpp
+// Caller holds the canvas entity and writes the fog component directly.
+auto &fog = IREntity::getComponent<C_CanvasFogOfWar>(canvasEntity);
+fog.setState(worldX, worldY, kFogStateVisible);
+```
+
+**Pattern B — prefab-scoped free-function namespace.** A header in this
+directory (e.g. `fog_of_war.hpp`) exposes a namespace such as `IRPrefab::Fog::`
+that internally performs the entity-lookup logic. Keeps an ergonomic
+free-function shape without putting the feature into `IRRender::` or adding
+fields to `RenderManager`.
+
+```cpp
+// Header exposes a namespace; callers do not need to hold the entity.
+namespace IRPrefab::Fog {
+    void setCell(int worldX, int worldY, std::uint8_t state);
+    void revealRadius(int cx, int cy, int radius);
+    void clear();
+}
+```
+
+**What not to do.** Do not add a feature setter/getter to `IRRender::` or a
+backing field to `RenderManager`. See `engine/render/CLAUDE.md`
+§"What belongs in engine/render/ vs engine/prefabs/irreden/render/" for the
+full principle, the rule of thumb, and the list of existing violations being
+cleaned up.
+
 ## Gotchas
 
 - **Canvas texture lifetime.** The 3 GPU textures owned by

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -155,6 +155,8 @@ relocated in the T-034 / T-035 / T-036 refactor stack:
 | Debug overlay | `IRRender::setDebugOverlay` / `getDebugOverlay` | T-035 (PR #235) |
 | Fog-of-war | `IRRender::setFogCell` / `getFogCell` / `revealRadius` / `clearFogOfWar` | T-034 (PR #238) |
 
+When a tracking task's PR merges, remove the corresponding row from this table.
+
 ## Verifying render changes
 
 Rendering bugs rarely show up in the type checker or the test suite. Any

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -119,6 +119,42 @@ header when you add or rename a shader.
 `RenderDevice` interfaces. `RenderManager` holds one via `unique_ptr`.
 Platform selection is compile-time (`IR_GRAPHICS_OPENGL` / `_METAL`).
 
+## What belongs in engine/render/ vs engine/prefabs/irreden/render/
+
+`engine/render/` is a graphics primitive library. It owns what the pipeline
+itself needs regardless of which features a creation enables:
+
+- Device abstraction and context (`RenderManager`, `RenderImpl`, `RenderDevice`).
+- GPU resource CRUD (`RenderingResourceManager`).
+- Pipeline execution (frame loop, canvas dispatch, framebuffer flip).
+- Camera, viewport, subdivision mode — the pipeline reads these every frame.
+- Voxel pool allocation (the pool is a device-level concept).
+
+Feature state — anything a creation opts into — belongs in
+`engine/prefabs/irreden/render/`. If the renderer can ship without the feature
+(fog-of-war is optional per-creation; debug overlay is dev-only), that feature
+does not belong in `engine/render/`.
+
+**Rule of thumb.** If you are about to add a field to `RenderManager`, ask:
+is this a per-feature concern? If so, it belongs on a component owned by the
+feature's system, exposed from a prefab-scoped surface. `RenderManager` should
+not grow fields for features that individual creations may not use.
+
+For the two viable patterns for exposing feature API from the prefab layer, see
+`engine/prefabs/irreden/render/CLAUDE.md` §"Exposing system public API from
+the prefab layer".
+
+### Current deviations
+
+Three features landed before this principle was established. Each will be
+relocated in the T-034 / T-035 / T-036 refactor stack:
+
+| Feature | Current (wrong) surface | Tracking task |
+|---|---|---|
+| Sun lighting | `IRRender::setSunDirection` / `getSunDirection` | T-036 (PR #210) |
+| Debug overlay | `IRRender::setDebugOverlay` / `getDebugOverlay` | T-035 (PR #235) |
+| Fog-of-war | `IRRender::setFogCell` / `getFogCell` / `revealRadius` / `clearFogOfWar` | T-034 (PR #238) |
+
 ## Verifying render changes
 
 Rendering bugs rarely show up in the type checker or the test suite. Any


### PR DESCRIPTION
## Summary
- Adds \"What belongs in engine/render/ vs engine/prefabs/irreden/render/\" section to `engine/render/CLAUDE.md` with the layering principle, rule of thumb, and a \"Current deviations\" table for T-034/T-035/T-036.
- Adds \"Exposing system public API from the prefab layer\" to `engine/prefabs/irreden/render/CLAUDE.md` with Pattern A (direct component access) and Pattern B (prefab-scoped namespace) code sketches.
- Sections cross-reference each other.
- Doc-only PR — no build change.

## Test plan
- [ ] Both sections present and cross-referencing correctly
- [ ] Current deviations table lists all three violations with tracking task column
- [ ] Pattern A and Pattern B code sketches are present and syntactically correct
- [ ] Build clean (doc-only change, no compile needed)

Closes #266 (doc portion — refactor tasks T-034/T-035/T-036 follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)