### PR TITLE
fleet: macOS /private/tmp + molecule-resume parallel-batch safety

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -261,7 +261,11 @@ Do the work, then exit cleanly:
 
    `fleet-claim molecule resume <your-worktree-name>`
 
-   - **Exit 0** — a task ID was printed. That task is already part of
+   This command always exits 0 (so it's safe to include in a parallel
+   tool batch with `git fetch`, `gh pr list`, etc.). Discriminate via
+   stdout:
+
+   - **Stdout has a `T-NNN` task ID** — that task is already part of
      a stack you started earlier (possibly in a previous process before
      a crash). It is now (or remains) marked `in-progress`. Skip the
      normal pickup flow below and jump straight to step 6 ("Work it",
@@ -303,19 +307,21 @@ Do the work, then exit cleanly:
      resuming so commit-and-push targets the right repo (see step 4
      for the cd path).
 
-   - **Exit 1** — nothing to resume. Two sub-cases collapse to this
-     exit code because they're handled the same way:
-     - No molecule exists for this agent (the common case — you
-       didn't leave a stack claim open last iteration).
-     - A molecule exists but every task is already `done` or
-       `failed`. If you see the latter, also run
-       `fleet-claim molecule complete <your-worktree-name>` (use
-       `fleet-claim --repo game molecule complete
-       <your-worktree-name>` for game-side — `--repo` is a global
-       flag parsed before the subcommand) to archive it. For the
-       former, you can tell by looking at whether stdout had the
-       "no molecule" message.
-     Either way, proceed with the normal pickup flow below.
+   - **Stdout is empty** — nothing to resume. Either no molecule
+     exists for this agent (overwhelming common case — you didn't
+     leave a stack claim open last iteration), or a molecule exists
+     but every task is already `done` or `failed`. The stderr message
+     tells you which: `"no molecule for agent: ..."` for the former,
+     or `"molecule fully complete (no remaining tasks)"` for the
+     latter. If the latter, also run
+     `fleet-claim molecule complete <your-worktree-name>` (use
+     `fleet-claim --repo game molecule complete <your-worktree-name>`
+     for game-side — `--repo` is a global flag parsed before the
+     subcommand) to archive it. The complete command is itself
+     idempotent (exits 0 with a stderr note if there's nothing to
+     archive), so calling it speculatively after every empty resume
+     is also safe. Either way, proceed with the normal pickup flow
+     below.
 
    **Normal pickup (no active molecule)** — pick from either queue.
    Look at both `/tmp/tasks-engine.md` and `/tmp/tasks-game.md`. Find

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -170,7 +170,11 @@ Each iteration:
 
    `fleet-claim molecule resume <your-worktree-name>`
 
-   - **Exit 0** — a task ID was printed. That task is part of a stack
+   This command always exits 0 (so it's safe to include in a parallel
+   tool batch with `git fetch`, `gh pr list`, etc.). Discriminate via
+   stdout:
+
+   - **Stdout has a `T-NNN` task ID** — that task is part of a stack
      you started earlier (possibly in a previous process before a
      crash). It is now (or remains) marked `in-progress`. Skip the
      normal pickup flow and jump straight to step 4 ("Read the plan
@@ -194,11 +198,13 @@ Each iteration:
      `fleet-claim molecule advance <your-worktree-name> <task-id> done pr=<PR-URL> commit=<sha>`
      If you can't complete a task, use `failed` and surface to human.
 
-   - **Exit 1** — molecule has no remaining work. Archive it:
-     `fleet-claim molecule complete <your-worktree-name>`
-     Then proceed with the normal pickup flow.
-
-   - **Exit 2** — no molecule for this agent. Proceed normally.
+   - **Stdout is empty** — no work to resume. Either there's no
+     molecule for this agent (overwhelming common case) or the
+     molecule is fully done. Optionally call
+     `fleet-claim molecule complete <your-worktree-name>` to archive
+     a finished molecule (idempotent — exits 0 with a stderr note if
+     there's nothing to archive, so it's safe in any batch). Then
+     proceed with the normal pickup flow.
 
    **Normal pickup (no active molecule):** Read `TASKS.md` (use the
    Read tool) and find the first `[ ]` `[sonnet]`-tagged item in

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -917,7 +917,8 @@ if action == 'advance':
 if action == 'resume':
     # Find the first task that is in-progress (resume in place) or
     # the first pending (start it). Print the task ID on stdout.
-    # Exit 0 if a task was returned, exit 1 if molecule is fully done.
+    # Always exits 0 — see cmd_molecule_resume in the bash wrapper for
+    # the contract rationale (stdout-as-task-id, empty=no-work).
     in_prog = next((t for t in tasks if t.get('state') == 'in-progress'), None)
     if in_prog is not None:
         print(in_prog['id'])
@@ -929,9 +930,10 @@ if action == 'resume':
         emit(path, meta, tasks, notes)
         print(pending['id'])
         sys.exit(0)
-    # Nothing left to do — every task is done or failed.
-    print("", end='')
-    sys.exit(1)
+    # Nothing left to do — every task is done or failed. Empty stdout
+    # signals "no work to resume"; the human-visible note goes to stderr.
+    print("molecule fully complete (no remaining tasks)", file=sys.stderr)
+    sys.exit(0)
 
 print(f"unknown action: {action}", file=sys.stderr)
 sys.exit(2)
@@ -993,29 +995,33 @@ cmd_molecule_show() {
 }
 
 cmd_molecule_resume() {
-    # Mark the next pending task as in-progress and print its ID.
-    # Exit 0 if a task was returned (worker should pick it up).
-    # Exit 1 if there is nothing to resume — either no molecule exists
-    # at all, or the molecule has no remaining work. In both cases the
-    # worker should just move on to normal task pickup; "no molecule"
-    # is the overwhelming common case for opus-worker startup and is
-    # NOT an error.
-    # Exit 2 is reserved for usage errors (bad args, etc.).
+    # Print the next task ID to resume on stdout, or print nothing if
+    # there's no work. Always exits 0 unless the molecule yaml itself
+    # is malformed (in which case molecule_python prints to stderr and
+    # exits 2 — that bubbles up here and is a real error worth seeing).
+    #
+    # Contract for callers (agents reading role docs, shell scripts):
+    #   stdout=T-NNN, exit 0    → resume that task
+    #   stdout="",     exit 0    → no molecule, or molecule fully done; move on
+    #   exit non-zero            → real error (malformed yaml, etc.)
+    #
+    # History: previously returned exit 1 for the "no molecule" + "all
+    # done" cases to let shell `if` chains discriminate. Switched to
+    # the empty-stdout idiom because Claude Code's parallel tool batch
+    # cancels subsequent tools in the same message when ANY tool exits
+    # non-zero — agents calling this in a startup batch alongside
+    # `git fetch`, `gh pr list`, etc. were getting their parallel
+    # batches cancelled mid-startup. The informational "no molecule"
+    # message moved to stderr so it stays visible to humans without
+    # corrupting the stdout-as-task-id channel.
     local agent="$1"
     local file
     file=$(molecule_file "$agent")
     if [[ ! -f "$file" ]]; then
-        # Print to stdout (informational), not stderr (error). Keep the
-        # message so a human running it interactively still sees the
-        # signal, but don't make it look like a failure.
-        echo "no molecule for agent: $agent (nothing to resume)"
-        return 1
-    fi
-    if molecule_python resume "$file"; then
+        echo "no molecule for agent: $agent (nothing to resume)" >&2
         return 0
-    else
-        return 1
     fi
+    molecule_python resume "$file"
 }
 
 cmd_molecule_advance() {
@@ -1038,12 +1044,18 @@ cmd_molecule_complete() {
     # Archive the molecule and release the stack claim. Use this when
     # every task in the molecule is done and the worker has nothing
     # left to resume.
+    #
+    # Idempotent: if there's no molecule for this agent, exit 0 with a
+    # stderr note rather than failing. Same parallel-tool-batch
+    # rationale as cmd_molecule_resume — agents calling this in a
+    # cleanup batch alongside other tools shouldn't have the whole
+    # batch cancelled because there happened to be no molecule.
     local agent="$1"
     local file
     file=$(molecule_file "$agent")
     if [[ ! -f "$file" ]]; then
-        echo "no molecule for agent: $agent" >&2
-        return 1
+        echo "no molecule for agent: $agent (nothing to archive)" >&2
+        return 0
     fi
     # molecule complete = release-stack; archives the molecule as a
     # side-effect. This function exists as a transparent alias so the
@@ -1208,9 +1220,11 @@ molecule commands (crash-recovery state for stack claims):
   molecule list                          show all active molecules + per-task state
   molecule show <agent>                  print one molecule yaml verbatim
   molecule resume <agent>                mark next pending → in-progress, print task ID
-                                         exit 0 = task ID printed, 1 = nothing to resume
-                                         (no molecule OR molecule already done — just move
-                                         on to normal TASKS.md pickup)
+                                         stdout=T-NNN → resume that task; stdout="" → no
+                                         work to resume (no molecule, or molecule fully
+                                         done) → fall through to normal TASKS.md pickup.
+                                         Always exits 0 unless the molecule yaml is
+                                         malformed; safe to call in a parallel tool batch.
   molecule advance <agent> <task-id> <new-state> [pr=URL] [commit=SHA]
                                          transition one task's state. New state is one of
                                          pending|in-progress|done|failed.

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -259,10 +259,21 @@ all_allows = baseline + existing_extra
 #   - /tmp/: fleet-claim test patterns, mktemp scratch dirs, generic
 #     scratch usage. Already partially allowlisted via Bash entries
 #     for mktemp/rm; adding the directory closes the path-scope side.
+#   - /private/tmp/: macOS canonical form of /tmp (it's a symlink to
+#     /private/tmp). Shell redirects like `cmd > /tmp/foo` and bash
+#     `mktemp` invocations get path-resolved by the kernel before
+#     Claude Code sees them, so the permission check sees the
+#     canonical /private/tmp/... and rejects unless that path is
+#     also in the allowlist. Observed in production: workers' attempts
+#     to redirect `git show > /tmp/tasks-master.md` were blocked with
+#     "may only write to files in the allowed working directories"
+#     even though /tmp was listed. Adding both forms is the simplest
+#     cross-platform fix (Linux ignores the /private/tmp entry since
+#     no such path exists there).
 home = os.path.expanduser("~")
 out = {
     "permissions": {
-        "additionalDirectories": [repo_root, f"{home}/.fleet", "/tmp"],
+        "additionalDirectories": [repo_root, f"{home}/.fleet", "/tmp", "/private/tmp"],
         "allow": all_allows,
         "defaultMode": "auto",
     }


### PR DESCRIPTION
## Summary

Two issues observed in worker scrollback after the post-#264 fleet-up
on macOS — surfaced because the new streaming formatter makes the
underlying agent struggle visible in panes.

- **macOS `/tmp` writes blocked.** `/tmp` is a symlink to
  `/private/tmp` on macOS. Shell redirects (`cmd > /tmp/foo`) get
  path-resolved by the kernel to `/private/tmp/foo` before the
  permission check sees them, so adding `/tmp` to
  `additionalDirectories` isn't enough. Add `/private/tmp` alongside.
  Linux ignores it (no such path) so cross-platform behavior is
  preserved.
- **`fleet-claim molecule resume` exit 1 cancels parallel tool batches.**
  The "no molecule to resume" case (overwhelming-common at worker
  startup) returned exit 1. Claude Code cancels the rest of a parallel
  tool batch when any one tool exits non-zero, so an agent calling
  resume alongside `Read(TASKS.md)` had the Read cancelled with
  `<tool_use_error>Cancelled: parallel tool call</tool_use_error>`,
  wasting a turn. Switched to empty-stdout idiom: always exit 0,
  signal "no work" via empty stdout, route the informational message
  to stderr. Also made `molecule complete` idempotent (exit 0 with
  stderr note when no molecule), so it's also batch-safe.

Updated role-sonnet-author.md and role-opus-worker.md to describe the
new contract. The old "Exit 2 — no molecule" branch in sonnet-author
was already inaccurate (the code never returned exit 2; it always
returned exit 1 for both no-molecule and molecule-done).

## Test plan

- [x] `fleet-claim molecule resume nonexistent-agent` → exit 0,
      stdout empty, stderr `"no molecule for agent: nonexistent-agent
      (nothing to resume)"`.
- [x] `fleet-claim molecule complete nonexistent-agent` → exit 0,
      stdout empty, stderr `"no molecule for agent: nonexistent-agent
      (nothing to archive)"`.
- [x] `bash -n` clean on fleet-up and fleet-claim.
- [ ] Next `fleet-up live` on macOS → workers can write `/tmp/foo`
      via shell redirects without permission errors.
- [ ] Worker startup scrollback no longer shows `Cancelled: parallel
      tool call Bash(fleet-claim molecule resume ...)` followed by
      cancelled Reads.

## Notes for reviewer

- The new contract is documented in the script's header (line 27,
  `fleet-claim list [--with-age]` style), in the inline help block
  (`molecule resume <agent>` lines), and in the function comments.
- `fleet-up` change is a single-line list extension + 13-line comment
  explaining the macOS symlink reasoning. The comment is detailed
  because future agents touching path-scope settings will otherwise
  re-introduce this exact bug.
- Real callers of `molecule resume` (the role docs themselves) were
  updated in lockstep so the documented contract matches the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)