### PR TITLE
fleet: shutdown sentinel stops babysit from relaunching during fleet-down

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -86,6 +86,41 @@ LOG_DIR="${FLEET_LOG_DIR:-$HOME/.fleet/logs}"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/$ROLE.log"
 
+# Shutdown sentinel — fleet-down creates this file at the start of its
+# wait/summary phase to signal that no agent should be relaunched.
+# Without it, an agent that exits cleanly DURING fleet-down (worker
+# finishing its iteration, architect responding to the summary prompt
+# and exiting) gets immediately relaunched into a fresh claude — which
+# then gets killed mid-startup when tmux kill-session lands. Wasteful,
+# confusing in scrollback, and observed in production.
+#
+# With the sentinel: any sleep-then-relaunch in the loop below polls
+# for the file and bails out immediately if it appears. The pane's
+# bash shell then sees the buffered "exit" command from fleet-down's
+# graceful shutdown, exits, and kill-session has nothing to do.
+SHUTDOWN_FLAG="${FLEET_SHUTDOWN_FLAG:-$HOME/.fleet/shutdown-in-progress}"
+
+# Sleep that exits early if the shutdown sentinel appears. Returns 0 if
+# the full duration elapsed (relaunch as planned), 1 if shutdown was
+# signaled (caller should break out of the loop). Polls every 5s, so
+# worst-case observed-shutdown-to-pane-exit latency is ~5s.
+shutdown_aware_sleep() {
+    local seconds="$1"
+    local end=$(( $(date +%s) + seconds ))
+    while [[ $(date +%s) -lt $end ]]; do
+        if [[ -f "$SHUTDOWN_FLAG" ]]; then
+            return 1
+        fi
+        # Sleep at most 5s at a time, but never longer than what's left.
+        local remaining=$(( end - $(date +%s) ))
+        local chunk=5
+        [[ "$remaining" -lt "$chunk" ]] && chunk="$remaining"
+        [[ "$chunk" -lt 1 ]] && chunk=1
+        sleep "$chunk" || true
+    done
+    return 0
+}
+
 attempt=0
 
 log() {
@@ -310,6 +345,15 @@ while true; do
         break
     fi
 
+    # Shutdown signaled while claude was running (fleet-down created the
+    # sentinel). Don't even enter the sleep — exit straight away so the
+    # pane's bash can pick up the buffered `exit` from fleet-down's
+    # graceful shutdown.
+    if [[ -f "$SHUTDOWN_FLAG" ]]; then
+        log "shutdown sentinel detected — exiting babysit loop without relaunching"
+        break
+    fi
+
     case $last_exit in
         0)
             # Clean exit = task complete. Workers get a between-task
@@ -318,19 +362,28 @@ while true; do
             # Architects re-resume their preserved session immediately.
             if [[ "$ARCHITECT_RESUME" -eq 1 ]]; then
                 log "architect clean exit (attempt $attempt) — re-resuming preserved session in ${CLEAN_DELAY}s..."
-                sleep "$CLEAN_DELAY"
+                if ! shutdown_aware_sleep "$CLEAN_DELAY"; then
+                    log "shutdown signaled during between-iteration wait — exiting"
+                    break
+                fi
                 launch_architect_first
             else
                 between_task_delay=$(parse_interval_seconds "${LOOP_INTERVAL:-${CLEAN_DELAY}s}")
                 log "worker clean exit (attempt $attempt) — fresh launch in ${between_task_delay}s (clears context for next task)"
-                sleep "$between_task_delay"
+                if ! shutdown_aware_sleep "$between_task_delay"; then
+                    log "shutdown signaled during between-iteration wait — exiting"
+                    break
+                fi
                 launch_worker_fresh
             fi
             ;;
         2)
             # Exit code 2 often indicates usage limit
             log "exit_code=2 attempt=$attempt (suspected usage limit), waiting ${LIMIT_DELAY}s..."
-            sleep "$LIMIT_DELAY"
+            if ! shutdown_aware_sleep "$LIMIT_DELAY"; then
+                log "shutdown signaled during limit wait — exiting"
+                break
+            fi
             log "resuming session (attempt $attempt)..."
             resume_mid_task
             ;;
@@ -338,7 +391,10 @@ while true; do
             # Crash mid-task. --continue (workers) / --resume (architects)
             # so partial work isn't lost.
             log "exit_code=$last_exit attempt=$attempt (crash), resuming mid-task in ${CRASH_DELAY}s..."
-            sleep "$CRASH_DELAY"
+            if ! shutdown_aware_sleep "$CRASH_DELAY"; then
+                log "shutdown signaled during crash recovery wait — exiting"
+                break
+            fi
             resume_mid_task
             ;;
     esac

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -115,7 +115,7 @@ shutdown_aware_sleep() {
         local remaining=$(( end - $(date +%s) ))
         local chunk=5
         [[ "$remaining" -lt "$chunk" ]] && chunk="$remaining"
-        [[ "$chunk" -lt 1 ]] && chunk=1
+        [[ "$chunk" -lt 1 ]] && chunk=1  # Minimum 1s to avoid zero-sleep busyloop on sub-second remaining time.
         sleep "$chunk" || true
     done
     return 0

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -105,6 +105,36 @@ if ! tmux has-session -t "$SESSION" 2>/dev/null; then
 fi
 
 # ----------------------------------------------------------------------
+# Shutdown sentinel — tell babysit loops to stop relaunching
+# ----------------------------------------------------------------------
+#
+# Every pane runs `fleet-babysit`, which has a relaunch loop: when
+# claude exits (clean or crash), babysit logs and sleeps then
+# relaunches. Without this sentinel, fleet-down's --wait/--summary
+# phase races against that relaunch cycle — agents that exited a few
+# seconds before fleet-down ran will have their LOOP_INTERVAL sleep
+# expire mid-shutdown, launching a fresh claude that then gets killed
+# mid-startup by kill-session. Wasteful (cost), confusing in
+# scrollback ("started up again, then got cut off"), and the partial
+# claude can leave orphaned `gh pr checkout` worktree adds, half-
+# initialized session caches, etc.
+#
+# Fix: create a sentinel file BEFORE --wait/--summary. babysit's loop
+# polls for it before each relaunch and exits cleanly when it
+# appears. By the time we reach kill-session, every babysit has
+# already exited and the panes are sitting at their bash prompts
+# waiting on the buffered `exit`.
+#
+# Cleanup happens via trap on EXIT — even if the script crashes or
+# the user double-Ctrl-Cs, the next fleet-up won't see a stale
+# sentinel that would prevent agents from ever launching. fleet-up
+# also clears it defensively at startup (belt-and-suspenders).
+SHUTDOWN_FLAG="${FLEET_SHUTDOWN_FLAG:-$HOME/.fleet/shutdown-in-progress}"
+mkdir -p "$(dirname "$SHUTDOWN_FLAG")"
+echo "$$ $(date '+%Y-%m-%dT%H:%M:%S%z')" > "$SHUTDOWN_FLAG"
+trap 'rm -f "$SHUTDOWN_FLAG"' EXIT
+
+# ----------------------------------------------------------------------
 # Ctrl-C trap: continue to graceful shutdown instead of bailing
 # ----------------------------------------------------------------------
 #

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -326,6 +326,15 @@ mkdir -p "$HOME/.fleet/plans"
 mkdir -p "$HOME/.fleet/heartbeats"
 mkdir -p "$HOME/.fleet/alerts"
 
+# Clear any stale shutdown sentinel left behind by a crashed fleet-down
+# (or one that was kill -9'd). fleet-down normally cleans this up via
+# its EXIT trap, but if the process died abnormally the file persists,
+# and every babysit launched below would see it and exit immediately
+# without ever running an iteration. Clearing here is belt-and-
+# suspenders against that "fleet appears up but no agent ever runs"
+# failure mode.
+rm -f "${FLEET_SHUTDOWN_FLAG:-$HOME/.fleet/shutdown-in-progress}"
+
 # ----------------------------------------------------------------------
 # Step 3c: ensure GitHub labels referenced by agents exist
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Observed running `fleet-down --wait --summary` on a real shutdown:
agents that exited a few seconds before fleet-down was issued had
their babysit `sleep <interval>` timer expire mid-shutdown, launching
a fresh claude that then got killed mid-startup when kill-session
landed. Wasted iterations (cost), confusing scrollback ("started up
again, then got cut off"), and the partial claude could leave
orphaned `gh pr checkout` worktree adds, half-initialized session
caches, etc.

This adds a sentinel-file mechanism so babysit stops relaunching as
soon as fleet-down begins, while still letting in-flight claude
iterations finish naturally.

- **fleet-down** creates `~/.fleet/shutdown-in-progress` (env-
  overridable via `FLEET_SHUTDOWN_FLAG`) at the start of the script,
  before --wait. Cleans up via `trap EXIT`.
- **fleet-babysit** gains `shutdown_aware_sleep` that polls the
  sentinel every 5s. All four sleeps in the resume loop use it, and
  the loop also checks the flag at the top of each iteration to
  catch the case where claude was still running when fleet-down ran.
- **fleet-up** does a defensive `rm -f` of the sentinel at startup
  against the kill-9'd-fleet-down case.

Worst-case latency from "fleet-down starts" to "babysit exits its
sleep" is ~5s (one poll cycle). The pane's bash then picks up the
buffered `exit` from fleet-down's graceful shutdown, exits cleanly,
and kill-session has nothing to do for that pane.

## Test plan

- [x] Isolated bash test of `shutdown_aware_sleep`:
  - 3s sleep without sentinel → returns 0 in 3s ✓
  - Sentinel appears at 2s of a 30s sleep → bails after ~5s ✓
  - Pre-existing sentinel + 60s sleep → returns 1 immediately ✓
- [x] EXIT trap test: flag created, trap removes it on script exit ✓
- [x] `bash -n` clean on all three scripts.
- [ ] Real `fleet-up live` followed by `fleet-down --wait --summary`:
  - Babysit logs show `shutdown sentinel detected` or `shutdown
    signaled during ... wait` for each pane.
  - No new "fresh launch in Ns" log entries during the shutdown
    window.
  - Architects still write summaries (claude is still running so the
    sentinel doesn't kick in until they exit cleanly post-summary).
- [ ] `fleet-up live` after a successful shutdown — sentinel cleanup
  via EXIT trap means it's already gone, defensive `rm -f` is a no-op.

## Notes for reviewer

- 5s poll interval is a tradeoff: lower = faster shutdown response,
  higher = less file-stat churn. 5s matches babysit's existing
  granularity and gives <5% latency overhead on the smallest sleep
  (60s CLEAN_DELAY).
- The two traps in fleet-down (`on_sigint INT TERM` for graceful
  abort, `EXIT` for sentinel cleanup) are independent and don't
  interact — bash supports separate handlers per signal class.
- The `if ! shutdown_aware_sleep ...; then break; fi` pattern looks
  verbose, but each branch already had distinct delay constants and
  follow-up log messages, so trying to factor it would actually add
  parameters and obscure the per-branch intent. Inline reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)