### PR TITLE
fleet: babysit survives API errors + auto-heartbeats + per-phase abort

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -111,6 +111,10 @@ shutdown_aware_sleep() {
         if [[ -f "$SHUTDOWN_FLAG" ]]; then
             return 1
         fi
+        # Re-touch heartbeat so the witness doesn't false-alarm STALE
+        # during a healthy between-iteration wait. Workers only —
+        # HEARTBEAT_FILE is empty for architects.
+        [[ -n "$HEARTBEAT_FILE" ]] && touch "$HEARTBEAT_FILE" 2>/dev/null || true
         # Sleep at most 5s at a time, but never longer than what's left.
         local remaining=$(( end - $(date +%s) ))
         local chunk=5
@@ -167,6 +171,52 @@ ARCHITECT_RESUME=0
 case "$ROLE" in
     *architect*) ARCHITECT_RESUME=1 ;;
 esac
+
+# Heartbeat file (workers/reviewers only — architects aren't witness-
+# tracked). The convention every role file uses is
+# `fleet-heartbeat <worktree-basename>`, which writes to
+# `~/.fleet/heartbeats/<worktree-basename>`. Babysit derives the same
+# name from `pwd` so it can re-touch the file during long sleeps and
+# during long agent iterations — without that, the witness sees a
+# heartbeat go stale during normal between-iteration sleeps (the
+# 1200s opus-worker LOOP_INTERVAL plus a 33-min iteration easily
+# blows past the 30m staleness threshold even when the fleet is
+# functioning correctly — observed in production 2026-04-22).
+HEARTBEAT_FILE=""
+if [[ "$ARCHITECT_RESUME" -eq 0 ]]; then
+    HEARTBEAT_FILE="$HOME/.fleet/heartbeats/$(basename "$(pwd)")"
+    mkdir -p "$(dirname "$HEARTBEAT_FILE")"
+fi
+
+# Background heartbeat-keeper — touches HEARTBEAT_FILE every 60s while
+# the agent (claude) is running. Caller starts it before each launch_*
+# call and stops it after the call returns, so the heartbeat stays
+# fresh even during agent iterations longer than the witness staleness
+# threshold (e.g. an opus refactor that takes 35 min of pure thinking
+# without hitting fleet-build / commit-and-push, the points where
+# role files explicitly re-heartbeat).
+#
+# Uses a global PID variable rather than returning the PID via stdout
+# capture (`hb_pid=$(start_heartbeat_keeper)`) — `$()` running a
+# function that backgrounds a subshell can hang waiting on the
+# subshell to close stdout, which doesn't reliably happen with
+# `( ... ) &` patterns on all bash versions. Side-effect global is
+# uglier but reliable.
+HB_KEEPER_PID=""
+start_heartbeat_keeper() {
+    [[ -z "$HEARTBEAT_FILE" ]] && return 0
+    while true; do touch "$HEARTBEAT_FILE" 2>/dev/null || true; sleep 60; done &
+    HB_KEEPER_PID=$!
+    # Disown the keeper so bash's job-control doesn't print
+    # `Terminated: 15` to stderr when we kill it later — that line
+    # would otherwise land in the pane scrollback every iteration.
+    disown "$HB_KEEPER_PID" 2>/dev/null || true
+}
+stop_heartbeat_keeper() {
+    [[ -z "$HB_KEEPER_PID" ]] && return 0
+    kill "$HB_KEEPER_PID" 2>/dev/null || true
+    HB_KEEPER_PID=""
+}
 
 # --- Stream-formatted claude wrapper ---------------------------------------
 #
@@ -225,16 +275,38 @@ stream_claude() {
     # error out (`--include-partial-messages` requires `--print`),
     # which is the right failure mode — better than silently entering
     # interactive limbo like the pre-PR-#257 bug.
+    #
+    # `2>&1` merges claude's stderr into the same pipe as stdout so the
+    # formatter sees both. Without this, claude's post-result warnings
+    # (e.g. "API Error: Stream idle timeout - partial response received"
+    # printed during HTTP-client cleanup AFTER the result event was
+    # already received) bypass the formatter and land in the pane raw,
+    # reading like a fatal error even though claude actually exited 0.
+    # The formatter recognizes a small allowlist of these and annotates
+    # them as `⚠ [claude-warn]` instead of leaving them as raw red text.
     if [[ -n "$STREAM_FORMATTER" ]]; then
         claude --model "$MODEL" --effort "$EFFORT" \
             --output-format stream-json --include-partial-messages --verbose \
-            "$@" | "$STREAM_FORMATTER"
+            "$@" 2>&1 | "$STREAM_FORMATTER"
     else
         # Fallback: plain claude with whatever the caller passed.
         # `--print` from the caller stays put, so worker exit semantics
         # are unchanged; only the live-pane visibility regresses.
         claude --model "$MODEL" --effort "$EFFORT" "$@"
     fi
+}
+
+# Wrap a launch_*/resume_* call with a backgrounded heartbeat-keeper
+# that touches HEARTBEAT_FILE every 60s while claude runs. Returns the
+# wrapped call's exit code without tripping `set -e` (the `|| rc=$?`
+# pattern). Architects skip the keeper (HEARTBEAT_FILE is empty for
+# them; start_heartbeat_keeper is a no-op).
+run_with_heartbeat() {
+    start_heartbeat_keeper
+    local rc=0
+    "$@" || rc=$?
+    stop_heartbeat_keeper
+    return "$rc"
 }
 
 # --- Launch helpers --------------------------------------------------------
@@ -317,13 +389,21 @@ resume_mid_task() {
 }
 
 # --- First run -------------------------------------------------------------
+#
+# `|| last_exit=$?` is a `set -e` defuse: if the launch helper returns
+# non-zero (claude exited with an error code — observed in production
+# with "API Error: Stream idle timeout"), we want to capture the exit
+# code and let the resume loop dispatch on it, NOT have `set -e` kill
+# babysit before the loop ever runs. Without this, the pane would just
+# drop to bash and never relaunch — there's no log entry, no graceful
+# crash branch, just a silently dead pane until the next fleet-up.
 
+last_exit=0
 if [[ "$ARCHITECT_RESUME" -eq 1 ]]; then
-    launch_architect_first
+    run_with_heartbeat launch_architect_first || last_exit=$?
 else
-    launch_worker_fresh
+    run_with_heartbeat launch_worker_fresh || last_exit=$?
 fi
-last_exit=$?
 
 # --- Resume loop -----------------------------------------------------------
 while true; do
@@ -354,7 +434,18 @@ while true; do
         break
     fi
 
-    case $last_exit in
+    # Snapshot the previous attempt's exit code, then reset last_exit
+    # so the `|| last_exit=$?` captures below only see this attempt's
+    # exit. The `|| last_exit=$?` pattern itself defuses `set -e` —
+    # if claude exits non-zero (API timeout, network blip, etc.) and
+    # the launch helper returns that code, set -e would otherwise kill
+    # babysit silently, dropping the pane to bash with no log entry
+    # and no relaunch. Observed in production after Anthropic API
+    # stream-idle-timeout errors.
+    prev_exit="$last_exit"
+    last_exit=0
+
+    case $prev_exit in
         0)
             # Clean exit = task complete. Workers get a between-task
             # delay (LOOP_INTERVAL if set, else CLEAN_DELAY) and then
@@ -366,7 +457,7 @@ while true; do
                     log "shutdown signaled during between-iteration wait — exiting"
                     break
                 fi
-                launch_architect_first
+                run_with_heartbeat launch_architect_first || last_exit=$?
             else
                 between_task_delay=$(parse_interval_seconds "${LOOP_INTERVAL:-${CLEAN_DELAY}s}")
                 log "worker clean exit (attempt $attempt) — fresh launch in ${between_task_delay}s (clears context for next task)"
@@ -374,7 +465,7 @@ while true; do
                     log "shutdown signaled during between-iteration wait — exiting"
                     break
                 fi
-                launch_worker_fresh
+                run_with_heartbeat launch_worker_fresh || last_exit=$?
             fi
             ;;
         2)
@@ -385,18 +476,17 @@ while true; do
                 break
             fi
             log "resuming session (attempt $attempt)..."
-            resume_mid_task
+            run_with_heartbeat resume_mid_task || last_exit=$?
             ;;
         *)
             # Crash mid-task. --continue (workers) / --resume (architects)
             # so partial work isn't lost.
-            log "exit_code=$last_exit attempt=$attempt (crash), resuming mid-task in ${CRASH_DELAY}s..."
+            log "exit_code=$prev_exit attempt=$attempt (crash), resuming mid-task in ${CRASH_DELAY}s..."
             if ! shutdown_aware_sleep "$CRASH_DELAY"; then
                 log "shutdown signaled during crash recovery wait — exiting"
                 break
             fi
-            resume_mid_task
+            run_with_heartbeat resume_mid_task || last_exit=$?
             ;;
     esac
-    last_exit=$?
 done

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -111,9 +111,7 @@ shutdown_aware_sleep() {
         if [[ -f "$SHUTDOWN_FLAG" ]]; then
             return 1
         fi
-        # Re-touch heartbeat so the witness doesn't false-alarm STALE
-        # during a healthy between-iteration wait. Workers only —
-        # HEARTBEAT_FILE is empty for architects.
+        # Keep heartbeat fresh during between-iteration wait.
         [[ -n "$HEARTBEAT_FILE" ]] && touch "$HEARTBEAT_FILE" 2>/dev/null || true
         # Sleep at most 5s at a time, but never longer than what's left.
         local remaining=$(( end - $(date +%s) ))

--- a/scripts/fleet/fleet-claude-stream
+++ b/scripts/fleet/fleet-claude-stream
@@ -122,6 +122,7 @@ def handle_result(event):
 # up with exact wording. Add new prefixes here as they show up.
 BENIGN_WARNING_PREFIXES = (
     "API Error: Stream idle timeout",
+    # These appear post-result during HTTP-client cleanup; annotating rather than suppressing.
     "API Error: Connection error",
     "API Error: Request timed out",
 )

--- a/scripts/fleet/fleet-claude-stream
+++ b/scripts/fleet/fleet-claude-stream
@@ -115,6 +115,18 @@ def handle_result(event):
         emit(f"{RED}{event['result']}{RESET}\n")
 
 
+# Known-benign claude stderr warnings — claude prints these AFTER the
+# result event has already been received and exits 0. Without
+# annotation they read as fatal errors in the pane scrollback even
+# though the agent succeeded. Match by prefix so we don't have to keep
+# up with exact wording. Add new prefixes here as they show up.
+BENIGN_WARNING_PREFIXES = (
+    "API Error: Stream idle timeout",
+    "API Error: Connection error",
+    "API Error: Request timed out",
+)
+
+
 def main():
     for line in sys.stdin:
         line = line.strip()
@@ -123,9 +135,15 @@ def main():
         try:
             event = json.loads(line)
         except json.JSONDecodeError:
-            # Pass through anything that isn't JSON (e.g. claude wrapper
-            # warnings). Better to over-show than swallow useful errors.
-            emit(line + "\n")
+            # Non-JSON line — typically claude's stderr (we route it
+            # into this same pipe via `2>&1` so the formatter sees both
+            # streams in temporal order). Annotate known post-result
+            # warnings as warnings, pass through everything else
+            # untouched so we don't accidentally hide a real error.
+            if any(line.startswith(p) for p in BENIGN_WARNING_PREFIXES):
+                emit(f"{YELLOW}⚠ [claude-warn] {line}{RESET}\n")
+            else:
+                emit(line + "\n")
             continue
 
         t = event.get("type")

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -135,25 +135,56 @@ echo "$$ $(date '+%Y-%m-%dT%H:%M:%S%z')" > "$SHUTDOWN_FLAG"
 trap 'rm -f "$SHUTDOWN_FLAG"' EXIT
 
 # ----------------------------------------------------------------------
-# Ctrl-C trap: continue to graceful shutdown instead of bailing
+# Ctrl-C trap: per-phase abort, doesn't cascade
 # ----------------------------------------------------------------------
 #
 # Without this trap, hitting Ctrl-C during --wait or --summary would
 # kill fleet-down outright (bash propagates SIGINT under `set -e`).
 # The user then has to run `fleet-down --force` separately to actually
-# bring the fleet down — which observed in production after the user
-# Ctrl-C'd a stuck --summary pass.
+# bring the fleet down — observed in production.
 #
-# With the trap: Ctrl-C sets a flag, the long-running loops below
-# notice the flag and break out of their wait, and the rest of
-# fleet-down (graceful shutdown + kill-session + claim-clear) runs
-# normally. One Ctrl-C and the whole shutdown completes.
-USER_ABORTED=0
+# Per-phase semantics matter: a Ctrl-C during --wait should skip
+# *only* the wait, then run --summary normally (the user explicitly
+# asked for --summary). Earlier behavior used a single USER_ABORTED
+# flag that cascaded — Ctrl-C during a stuck --wait left every pane
+# in the --summary loop printing "skipped — fleet-down aborted by
+# user" and produced 0/9 summaries. To skip multiple phases the user
+# Ctrl-Cs once per phase.
+#
+# Implementation: trap sets ABORTED_<phase> for whatever phase is
+# active, based on CURRENT_PHASE. Each loop checks only its own
+# phase's flag, so a Ctrl-C during one phase doesn't pre-cancel the
+# next.
+ABORTED_WAIT=0
+ABORTED_SUMMARY=0
+ABORTED_GRACE=0
+CURRENT_PHASE="init"
 on_sigint() {
-    USER_ABORTED=1
-    echo
-    echo "fleet-down: Ctrl-C received — skipping remaining wait/summary work"
-    echo "            and proceeding to graceful shutdown."
+    case "$CURRENT_PHASE" in
+        wait)
+            ABORTED_WAIT=1
+            echo
+            echo "fleet-down: Ctrl-C — skipping remaining --wait, proceeding to --summary."
+            ;;
+        summary)
+            ABORTED_SUMMARY=1
+            echo
+            echo "fleet-down: Ctrl-C — skipping remaining --summary, proceeding to graceful shutdown."
+            ;;
+        grace)
+            ABORTED_GRACE=1
+            echo
+            echo "fleet-down: Ctrl-C — skipping graceful pause, killing tmux session now."
+            ;;
+        *)
+            # Pre-phase or post-everything Ctrl-C: just abort all.
+            ABORTED_WAIT=1
+            ABORTED_SUMMARY=1
+            ABORTED_GRACE=1
+            echo
+            echo "fleet-down: Ctrl-C — aborting current operation."
+            ;;
+    esac
 }
 trap on_sigint INT TERM
 
@@ -187,10 +218,11 @@ count_active_claims() {
 }
 
 if [[ "$WAIT_FOR_IDLE" -eq 1 ]]; then
+    CURRENT_PHASE="wait"
     deadline=$(( $(date +%s) + WAIT_MAX_SECONDS ))
     echo "fleet-down --wait: waiting for active claims to drain (max ${WAIT_MAX_SECONDS}s, polling every ${WAIT_POLL_SECONDS}s)"
-    echo "                   (Ctrl-C to skip the wait and proceed to shutdown)"
-    while [[ $(date +%s) -lt $deadline && "$USER_ABORTED" -eq 0 ]]; do
+    echo "                   (Ctrl-C to skip the wait and proceed to --summary / shutdown)"
+    while [[ $(date +%s) -lt $deadline && "$ABORTED_WAIT" -eq 0 ]]; do
         n=$(count_active_claims)
         if [[ "$n" -eq 0 ]]; then
             echo "fleet-down --wait: all claims released. Proceeding."
@@ -206,13 +238,14 @@ if [[ "$WAIT_FOR_IDLE" -eq 1 ]]; then
         fi
         # `|| true` defends against `set -e` when sleep is interrupted by
         # SIGINT — without it, bash sees sleep's 130 exit and kills the
-        # script before the next loop iteration can check USER_ABORTED.
+        # script before the next loop iteration can check ABORTED_WAIT.
         sleep "$WAIT_POLL_SECONDS" || true
     done
-    if [[ "$USER_ABORTED" -eq 0 && $(date +%s) -ge $deadline ]]; then
+    if [[ "$ABORTED_WAIT" -eq 0 && $(date +%s) -ge $deadline ]]; then
         n=$(count_active_claims)
-        echo "fleet-down --wait: deadline reached with $n claim(s) still held. Proceeding to graceful shutdown anyway."
+        echo "fleet-down --wait: deadline reached with $n claim(s) still held. Proceeding to --summary / shutdown anyway."
     fi
+    CURRENT_PHASE="post-wait"
 fi
 
 # ----------------------------------------------------------------------
@@ -330,6 +363,7 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
         SUMMARY_ROLES+=("$role")
     done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
 
+    CURRENT_PHASE="summary"
     total_panes=${#SUMMARY_PANES[@]}
     pane_idx=0
     for pane_id in "${SUMMARY_PANES[@]}"; do
@@ -338,10 +372,13 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
         summary_file="$SUMMARY_DIR/$role.md"
         echo "[$pane_idx/$total_panes] $role:"
 
-        # User Ctrl-C'd — bail out of the loop, print what we got, then
+        # User Ctrl-C'd during --summary — bail out of the loop, then
         # let the rest of fleet-down (graceful shutdown + claim clear) run.
-        if [[ "$USER_ABORTED" -eq 1 ]]; then
-            echo "  skipped — fleet-down aborted by user"
+        # ABORTED_SUMMARY is per-phase: a Ctrl-C during --wait does NOT
+        # set this flag, so summary still runs normally if the user
+        # only wanted to skip the wait.
+        if [[ "$ABORTED_SUMMARY" -eq 1 ]]; then
+            echo "  skipped — --summary aborted by user"
             continue
         fi
 
@@ -380,7 +417,7 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
         # 1. Wait for idle.
         idle_deadline=$(( $(date +%s) + SUMMARY_IDLE_WAIT_SECONDS ))
         first_busy_report=1
-        while [[ $(date +%s) -lt $idle_deadline && "$USER_ABORTED" -eq 0 ]]; do
+        while [[ $(date +%s) -lt $idle_deadline && "$ABORTED_SUMMARY" -eq 0 ]]; do
             if pane_is_idle "$pane_id"; then
                 break
             fi
@@ -390,7 +427,7 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
             fi
             sleep "$SUMMARY_IDLE_POLL_SECONDS" || true
         done
-        if [[ "$USER_ABORTED" -eq 1 ]]; then
+        if [[ "$ABORTED_SUMMARY" -eq 1 ]]; then
             echo "  aborted while waiting for idle"
             continue
         fi
@@ -405,7 +442,7 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
         # 3. Wait for the file to appear.
         write_deadline=$(( $(date +%s) + SUMMARY_WRITE_WAIT_SECONDS ))
         wrote=0
-        while [[ $(date +%s) -lt $write_deadline && "$USER_ABORTED" -eq 0 ]]; do
+        while [[ $(date +%s) -lt $write_deadline && "$ABORTED_SUMMARY" -eq 0 ]]; do
             if [[ -f "$summary_file" ]]; then
                 wrote=1
                 break
@@ -414,7 +451,7 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
         done
         if [[ "$wrote" -eq 1 ]]; then
             echo "  ✓ $(basename "$summary_file") landed ($(wc -c < "$summary_file" | tr -d ' ') bytes)"
-        elif [[ "$USER_ABORTED" -eq 1 ]]; then
+        elif [[ "$ABORTED_SUMMARY" -eq 1 ]]; then
             echo "  aborted while waiting for $(basename "$summary_file")"
         else
             echo "  ✗ $(basename "$summary_file") did not appear within ${SUMMARY_WRITE_WAIT_SECONDS}s"
@@ -424,6 +461,7 @@ if [[ "$WANT_SUMMARY" -eq 1 ]]; then
     written=$(find "$SUMMARY_DIR" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
     echo
     echo "fleet-down --summary: $written/$total_panes summary file(s) written to $SUMMARY_DIR/"
+    CURRENT_PHASE="post-summary"
 fi
 
 # ----------------------------------------------------------------------
@@ -455,12 +493,14 @@ if [[ "$FORCE" -eq 0 ]]; then
         tmux send-keys -t "$pane_id" "exit" Enter
     done < <(tmux list-panes -t "$SESSION" -F '#{pane_id}')
 
-    if [[ "$USER_ABORTED" -eq 1 ]]; then
+    CURRENT_PHASE="grace"
+    if [[ "$ABORTED_GRACE" -eq 1 ]]; then
         echo "fleet-down: skipping ${GRACE_SECONDS}s grace pause (user aborted)."
     else
-        echo "fleet-down: waiting ${GRACE_SECONDS}s for panes to wind down..."
+        echo "fleet-down: waiting ${GRACE_SECONDS}s for panes to wind down... (Ctrl-C to skip)"
         sleep "$GRACE_SECONDS" || true
     fi
+    CURRENT_PHASE="post-grace"
 else
     echo "fleet-down: --force — skipping graceful shutdown."
 fi


### PR DESCRIPTION
## Summary

Four fixes for issues observed running the post-#264-#269 fleet on
macOS overnight:

- **babysit silently dies when claude exits non-zero.** Anthropic's
  `claude --output-format stream-json` sometimes prints `API Error:
  Stream idle timeout - partial response received` to stderr DURING
  HTTP-client cleanup AFTER the result event. Agent succeeded but
  claude exits non-zero. Babysit's case-statement called launch
  helpers as simple commands; under `set -e`, any non-zero return
  killed babysit before it could log/sleep/relaunch. Pane dropped
  to bash, no entry, no recovery — observed on opus-worker-2 and
  sonnet-reviewer panes that exited and never came back. Fix: `||
  last_exit=$?` defuse around each launch call.
- **Witness STALE warnings during normal long iterations.** Opus
  iterations frequently run 30+ min; threshold is 30 min; the
  1200s LOOP_INTERVAL sleep that follows compounds the gap. Fix:
  backgrounded heartbeat-keeper touches HEARTBEAT_FILE every 60s
  while claude runs, plus shutdown_aware_sleep also touches it
  every poll. Architects skipped (no heartbeat file). Disowned to
  avoid `Terminated: 15` job-control noise in scrollback.
- **claude stderr warnings rendered as raw red error text.** Same
  "API Error" message — agent succeeded but the warning landed in
  the pane unformatted, reading as fatal. Fix: route claude stderr
  through formatter (`2>&1` in stream_claude); fleet-claude-stream
  recognizes a small allowlist of known-benign warnings and
  annotates as `⚠ [claude-warn]` in yellow. Real errors still pass
  through unchanged.
- **fleet-down Ctrl-C during --wait cascaded into --summary.** PR
  #265 used a single USER_ABORTED flag both phases checked. User
  Ctrl-C'd a stuck --wait → got 0/9 summaries even though they
  explicitly asked for --summary. Fix: per-phase `ABORTED_WAIT` /
  `ABORTED_SUMMARY` / `ABORTED_GRACE` flags, with `CURRENT_PHASE`
  driving which one the trap sets. To skip multiple phases the
  user Ctrl-Cs once per phase.

## Test plan

- [x] `bash -n` clean on babysit + fleet-down; `python3 compile`
      clean on fleet-claude-stream.
- [x] Isolated bash test: heartbeat-keeper updates file, exits
      cleanly when killed, leaves no orphans.
- [x] Isolated bash test: `|| last_exit=$?` captures non-zero
      exits without tripping set -e (3 iterations: 0, 0, 5 — all
      captured).
- [x] Formatter test: synthetic `API Error: Stream idle timeout`
      stderr line gets the yellow `⚠ [claude-warn]` prefix; other
      stderr passes through unchanged; JSON events still render.
- [ ] Real `fleet-up live` with an iteration that hits the API
      timeout: babysit logs the exit + relaunches normally instead
      of silently dying.
- [ ] Witness pane shows no false-positive STALE warnings during
      normal long opus-worker iterations.
- [ ] `fleet-down --wait --summary` with Ctrl-C during the wait:
      summary phase actually runs (not all-skipped), summaries land.

## Notes for reviewer

- The four fixes are technically independent but bundled because
  they all came out of the same overnight production run and share
  the babysit lifecycle code path. Splitting into four PRs would
  cause merge conflicts on babysit. They've been wired so each can
  be reviewed in isolation against the diff.
- Heartbeat-keeper uses a global `HB_KEEPER_PID` var rather than
  returning the PID via stdout (`hb_pid=$(start_heartbeat_keeper)`)
  — `$()` capturing a backgrounded subshell can hang waiting on
  the subshell to close stdout. Side-effect global is uglier but
  reliable across bash versions.
- Per-phase abort design: `CURRENT_PHASE` is what makes the trap
  aware of which phase fired the Ctrl-C. Doc updated in the trap
  comment block to explain the rationale.
- The `BENIGN_WARNING_PREFIXES` list is intentionally small. New
  prefixes get added as they show up in production; we deliberately
  don't try to enumerate every possible claude warning, since
  unrecognized warnings still pass through (just without
  annotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)