### PR TITLE
fleet: stop telling agents to write `cmd > /tmp/file` (always blocked)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -290,11 +290,15 @@ exit cleanly:
       (clean rebase, case i, case ii). Captures the post-rebase diff
       and compares it to the pre-capture from step b. Run
       `git diff origin/master` again — both pre and post snapshots
-      are now in your conversation context. Compare them: look for
-      lines beginning with `+` in the pre-capture that are absent
-      from the post-capture. Each such gap is a silently dropped
-      hunk. If any are found, do NOT push: restore the missing
-      lines and re-run this check before proceeding to the push.
+      are now in your conversation context. Compare them: for each
+      `+` line in the pre-capture, verify the same line content
+      appears somewhere in the post-capture. Scan for **content**,
+      not position — a hunk that moved to a different file offset
+      (or even a different file) is still intact and should not
+      trigger this check. Only a `+` line from pre that is missing
+      entirely from post is a silently dropped hunk. If any are
+      found, do NOT push: restore the missing lines and re-run this
+      check before proceeding to the push.
 
       (Same no-`>`-redirect rule as step b. Both diffs live in the
       conversation, not on disk.)

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -150,11 +150,22 @@ exit cleanly:
       `git fetch origin <headRefName>`
       `git checkout -B <headRefName> origin/<headRefName>`
 
-   **b. Rebase guard pre-capture.** Before rebasing, snapshot the current
-      diff so silently-dropped hunks can be detected afterward:
-      `git diff origin/master > /tmp/fleet-prerebase.diff`
-      (Git's 3-way merge can drop additions from non-conflicting regions
-      without any conflict marker; this capture enables a post-check.)
+   **b. Rebase guard pre-capture.** Before rebasing, snapshot the
+      current diff so silently-dropped hunks can be detected
+      afterward. Run `git diff origin/master` and keep the output
+      in your conversation context — you'll compare it to a
+      post-rebase snapshot in step e.
+
+      Do NOT redirect to `/tmp` or anywhere else with `>`. Claude
+      Code's Bash tool blocks shell redirects regardless of whether
+      the destination is in `additionalDirectories` (the gate is on
+      the `>` operation, not the path). Claude Code auto-persists
+      large outputs to a side file — for huge diffs you'll get a
+      `<persisted-output>` link the next iteration can Read.
+
+      (Git's 3-way merge can drop additions from non-conflicting
+      regions without any conflict marker; the pre/post comparison
+      below is what catches it.)
 
    **c. Try rebase.** `git rebase origin/master`
 
@@ -277,14 +288,16 @@ exit cleanly:
 
    **e. Post-rebase hunk check.** Runs on ALL paths that reach a push
       (clean rebase, case i, case ii). Captures the post-rebase diff
-      and compares it to the pre-capture from step b:
-      `git diff origin/master > /tmp/fleet-postrebase.diff`
-      Then use the **Read** tool to read both `/tmp/fleet-prerebase.diff`
-      and `/tmp/fleet-postrebase.diff`, and compare them. Look for
-      lines beginning with `< +` — additions present in the pre-capture
-      that are absent in the post-capture. Each such line is a silently
-      dropped hunk. If any are found, do NOT push: restore the missing
+      and compares it to the pre-capture from step b. Run
+      `git diff origin/master` again — both pre and post snapshots
+      are now in your conversation context. Compare them: look for
+      lines beginning with `+` in the pre-capture that are absent
+      from the post-capture. Each such gap is a silently dropped
+      hunk. If any are found, do NOT push: restore the missing
       lines and re-run this check before proceeding to the push.
+
+      (Same no-`>`-redirect rule as step b. Both diffs live in the
+      conversation, not on disk.)
 
    **f. Reset to scratch.** After processing each PR (success OR
       fail), return to the scratch branch so the next iteration

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -103,17 +103,26 @@ fleet-claim --repo game claim "T-001" opus-worker-1
    steps below (3–6 game variants, step 1's game PR check) and
    proceed with engine tasks only — do not abort the iteration.
 3. **Read the latest TASKS.md from origin/master without staging.**
-   Use `git show` to write current master versions to temp files — does
-   NOT touch the working tree or index, so it won't break later branch
-   checkouts. Two repos, two temp files:
-   `git -C ~/src/IrredenEngine show origin/master:TASKS.md > /tmp/tasks-engine.md`
-   `git -C ~/src/IrredenEngine/creations/game show origin/master:TASKS.md > /tmp/tasks-game.md`
+   Use `git show` to dump the current master versions directly to
+   stdout — does NOT touch the working tree or index, so it won't
+   break later branch checkouts. Two repos, two Bash calls:
+   `git -C ~/src/IrredenEngine show origin/master:TASKS.md`
+   `git -C ~/src/IrredenEngine/creations/game show origin/master:TASKS.md`
+   The Bash tool returns the full content as its output (and
+   auto-persists to a `.claude/projects/.../`-side file if the
+   output is large — automatic, you don't have to manage it).
+
+   Do NOT redirect to `/tmp` or anywhere else with `>`. Claude
+   Code's Bash tool blocks shell redirects regardless of whether
+   the destination is in `additionalDirectories` (the gate is on
+   the `>` operation, not the path). Stick with stdout-only.
+
    For plan files, list them with `git -C <repo> ls-tree -r origin/master --name-only -- .fleet/plans/`
    then `git -C <repo> show origin/master:.fleet/plans/<file>` for any
    you need to read. Do NOT use `git checkout origin/master -- ...` —
    it stages the files and breaks later `git checkout -b`.
-4. Read `/tmp/tasks-engine.md` and `/tmp/tasks-game.md` (Read tool) —
-   review both queues.
+4. Review both queues from the `git show` output you just captured
+   for the engine and game `TASKS.md`.
 5. Open-PR cross-check on both repos:
    `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName,author`
    `gh pr list --repo jakildev/irreden       --state open --json number,title,headRefName,author`
@@ -367,8 +376,9 @@ Do the work, then exit cleanly:
      below.
 
    **Normal pickup (no active molecule)** — pick from either queue.
-   Look at both `/tmp/tasks-engine.md` and `/tmp/tasks-game.md`. Find
-   the first `[ ]` item in `## Open` with `Model: opus` whose:
+   Re-run the two `git show origin/master:TASKS.md` Bash calls from
+   step 3 if their output isn't still in your context. Find the
+   first `[ ]` item in `## Open` with `Model: opus` whose:
    - **Owner** is `free` (or your worktree name)
    - **Blocked by** is empty (or only references already-merged work)
    - **Title is NOT referenced in any open PR's title or branch name**

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -55,17 +55,24 @@ whatever directory the task touches before editing anything.
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
 3. **Read the latest TASKS.md from origin/master without staging it.**
    The working copy may be stale if the worktree is on a feature
-   branch. Use `git show` to write the current master version to a
-   temp file — this does NOT touch the working tree or index, so it
-   won't break later branch checkouts:
-   `git show origin/master:TASKS.md > /tmp/tasks-master.md`
-   Then read `/tmp/tasks-master.md` with the Read tool.
+   branch. Use `git show` to dump the current master version
+   directly to stdout:
+   `git show origin/master:TASKS.md`
+   The Bash tool returns the full content as its output (and
+   auto-persists to a `.claude/projects/.../`-side file if the
+   output is large — the persistence is automatic, you don't have
+   to manage it). This does NOT touch the working tree or index,
+   so it won't break later branch checkouts.
 
-   Do NOT use `git checkout origin/master -- TASKS.md` here. That
-   stages the file. When `start-next-task` later tries
+   Do NOT redirect to `/tmp` or anywhere else with `>`. Claude
+   Code's Bash tool blocks shell redirects regardless of whether
+   the destination is in `additionalDirectories` (the gate is on
+   the `>` operation, not the path). Stick with stdout-only.
+
+   Do NOT use `git checkout origin/master -- TASKS.md` either.
+   That stages the file. When `start-next-task` later tries
    `git checkout -b new-branch origin/master` it errors with
    "your local changes would be overwritten by checkout."
-4. Read `/tmp/tasks-master.md` (use the Read tool, not `cat`) — review the current queue.
 4. `gh pr list --state open --json number,title,headRefName,author` —
    see what other agents are working on.
 5. Print a one-line summary: which `[sonnet]` items look unblocked and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,6 +428,15 @@ Read/Glob/Grep tools instead of Bash when possible.
 - **No `cat file || echo fallback`** — use the Read tool for files.
 - **No `cmd1 | cmd2`** — run `cmd1`, read the output, then run `cmd2`
   if needed.
+- **No `cmd > /tmp/file`** (or any other path) — Claude Code's Bash
+  tool blocks shell `>` redirects regardless of whether the
+  destination is in `additionalDirectories`. The gate is on the
+  redirect operation itself, not the path. Run the command alone;
+  the Bash tool returns stdout in its output (and auto-persists
+  large outputs to a side file you can Read on the next iteration
+  via the `<persisted-output>` link). If you need a file on disk,
+  use the **Write** tool with the captured content — that's a
+  different mechanism and does honor `additionalDirectories`.
 - **No `sed -n 'N,Mp' file`** — use the Read tool with `offset` and
   `limit` parameters instead. `sed` triggers its own security gate.
 - **Use `git -C`** for any git operation on a repo other than the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,10 +428,11 @@ Read/Glob/Grep tools instead of Bash when possible.
 - **No `cat file || echo fallback`** — use the Read tool for files.
 - **No `cmd1 | cmd2`** — run `cmd1`, read the output, then run `cmd2`
   if needed.
-- **No `cmd > /tmp/file`** (or any other path) — Claude Code's Bash
-  tool blocks shell `>` redirects regardless of whether the
-  destination is in `additionalDirectories`. The gate is on the
-  redirect operation itself, not the path. Run the command alone;
+- **No `cmd > file`** (the `>` overwrite redirect operator, to any
+  path) — Claude Code's Bash tool blocks shell `>` redirects
+  regardless of destination. The gate is on the redirect operator
+  itself, not the path. (The `>>` append form used for audit logs
+  is distinct and may be fine in specific documented cases.) Run the command alone;
   the Bash tool returns stdout in its output (and auto-persists
   large outputs to a side file you can Read on the next iteration
   via the `<persisted-output>` link). If you need a file on disk,


### PR DESCRIPTION
## Summary

Observed in production every worker iteration: sonnet-author and
opus-worker startup attempts `git show origin/master:TASKS.md > /tmp/tasks-master.md`
because that's what the role docs tell them to do. Claude Code's
Bash tool blocks ALL shell `>` redirects regardless of whether the
destination is in `additionalDirectories`. The gate is on the
redirect operation, not the path.

PR #268 added `/private/tmp` to `additionalDirectories` thinking it
would resolve the path-resolution issue, but the agent in tonight's
screenshot still hit the same block — and explicitly noticed the
contradiction: "Wait, the allowed directories include /private/tmp
explicitly. But the system says /private/tmp was blocked."

Cost per fresh iteration: ~6 wasted tool calls + thinking tokens to
derive the workaround (run `git show` without redirect, read stdout).
Every iteration re-derives it because the role doc still says to
redirect.

This PR replaces the redirect-then-Read pattern with run-and-read-
stdout in the three role docs that use it, plus a forward-reference
in `CLAUDE.md`'s Bash rules block so future agents pre-empt the
pattern.

- **`role-sonnet-author.md`** step 3: `git show ... > /tmp/...` →
  Read becomes just `git show origin/master:TASKS.md` and consume
  stdout. Comment notes Claude Code's auto-persists-large-output
  side file.
- **`role-opus-worker.md`** step 3: same fix, both repos. Step 4 in
  the normal-pickup branch updated to re-run the `git show` calls
  if needed.
- **`role-merger.md`** rebase guard: `git diff origin/master > /tmp/...`
  becomes `git diff origin/master` with both pre and post snapshots
  living in conversation context. Hunk-drop comparison still works.
- **`CLAUDE.md`** Bash rules: add `cmd > /tmp/file` to the no-go
  list alongside no-`|`, no-`cd && git`, no-`sed -n`.

## Test plan

- [x] Grep confirms no remaining `> /tmp` patterns in any role doc
      (other than the new "Do NOT" warnings).
- [ ] Next `fleet-up live` → first sonnet-author / opus-worker
      iteration runs `git show origin/master:TASKS.md` without
      redirect on first try (no path-block backtrack).
- [ ] First merger iteration that has a real PR to rebase: pre/post
      diff comparison happens in context without any `/tmp` writes.

## Notes for reviewer

- The merger change is the trickiest because the diffs can be large.
  Claude Code auto-persists large stdout to a side file under
  `~/.claude/projects/.../` and the next iteration can Read that
  via the `<persisted-output>` link. So the comparison still
  scales — it just lives in conversation/persisted-output instead of
  agent-managed `/tmp` files.
- PR #268 (`/private/tmp` in additionalDirectories) is now
  technically dead-code for this use case. Could be reverted in a
  follow-up, but it's harmless and might still help for other
  path-checked operations (e.g. Write tool to `/tmp` paths). Leave
  for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)