### PR TITLE
docs: don't pre-apply state labels when filing issues/PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,6 +512,41 @@ intentional and the user explicitly approves.
 
 ---
 
+## Issue/PR labeling discipline (applies everywhere, all agents)
+
+When filing a GitHub issue (`gh issue create`) or PR (`gh pr create`)
+on either repo, **do not pre-apply state labels**. Every fleet label
+has an owner that's allowed to set it; agents filing new artifacts
+are not in that owner set.
+
+Specifically, **never pass these via `--label` when filing**:
+
+- `human:approved` — owned by the **human**. The human's "yes, work on
+  this" gate. Queue-manager keys ingestion off it.
+- `fleet:queued` / `fleet:task` — owned by the **queue-manager**, set
+  AFTER it ingests an issue into `TASKS.md`. Adding it at filing time
+  excludes the issue from queue-manager's triage search and strands
+  it (observed on issues #270-#273, #287).
+- `fleet:approved` / `fleet:needs-fix` / `fleet:has-nits` /
+  `fleet:blocker` — owned by the **reviewer agents** as PR verdicts.
+- `fleet:wip` — owned by the **author agent** (set at PR creation
+  during a normal `commit-and-push` flow). Don't add to issues.
+- `fleet:in-progress` / `fleet:merger-cooldown` /
+  `fleet:changes-made` — owned by the worker / merger pipeline.
+
+**The right pattern when filing an issue:** create it with NO labels.
+The human will add `human:approved` if and when they want it picked
+up. The queue-manager will add `fleet:queued` (or `fleet:needs-plan`
+/ `fleet:needs-info`) on the next triage pass after that.
+
+**Exception:** if you're operating in a role's own lane (e.g. you
+ARE the queue-manager and you've just ingested an issue, or you ARE
+a reviewer and you've just verdict'd a PR), then setting your role's
+labels is correct. The rule above is about ad-hoc issue/PR filing
+from human conversations.
+
+---
+
 ## Project layout (pointers to deeper CLAUDE.md files)
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -529,6 +529,9 @@ Specifically, **never pass these via `--label` when filing**:
   it (observed on issues #270-#273, #287).
 - `fleet:approved` / `fleet:needs-fix` / `fleet:has-nits` /
   `fleet:blocker` — owned by the **reviewer agents** as PR verdicts.
+- `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` — owned by the
+  **reviewer agents**, added after the verdict to request a cross-host
+  build + run validation.
 - `fleet:wip` — owned by the **author agent** (set at PR creation
   during a normal `commit-and-push` flow). Don't add to issues.
 - `fleet:in-progress` / `fleet:merger-cooldown` /


### PR DESCRIPTION
## Summary

Add a CLAUDE.md rule on issue/PR labeling discipline. Agents filing
artifacts via `gh issue create` / `gh pr create` from human
conversations should NOT pass state labels via `--label`. Each fleet
label has a designated owner role; pre-applying from outside that
owner's flow corrupts the state machine.

Most concretely: pre-applying `fleet:queued` at filing time excludes
the issue from queue-manager's triage search (which uses
`-label:fleet:queued` to skip already-ingested items) and strands
the issue. Observed on issues #270-#273 and #287 — all had to be
manually unstuck.

The new rule:

> When filing a GitHub issue or PR, **do not pre-apply state labels**.
> Create with NO labels. The human adds `human:approved` if/when they
> want it picked up. The queue-manager will add `fleet:queued` (or
> `fleet:needs-plan` / `fleet:needs-info`) on the next triage pass.

Includes the carve-out for in-role label management (a queue-manager
ingesting, a reviewer verdict-labeling, etc., are still correct to
set their own role's labels).

## Test plan

- [x] Rule lives in `CLAUDE.md` between "Cross-repo information
      isolation" and "Project layout" — both similar workflow-rule
      sections.
- [ ] Next time a Claude session in this repo files an issue from a
      conversation, no `--label` flag is passed; the issue lands
      with zero labels and the human applies `human:approved`
      themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)