### PR TITLE
T-041: reconcile commit-and-push stack-aware overview with override

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -71,8 +71,15 @@ The deltas versus the single-PR flow:
   ```bash
   fleet-claim stack-set-pr <agent> <task-id> <branch> <pr-url>
   ```
-- **PR body** includes a "Stacked on: <prev PR URL>" line for all but
-  the first PR and names the whole chain so reviewers see the context.
+- **PR body** includes a `## Stack context` block with a `Stacked on:`
+  line (the previous PR URL, or `master` for the first task in the
+  chain) and a `Full chain:` line listing the task IDs the molecule
+  covers. Reviewers use this to navigate sibling PRs without leaving
+  the diff.
+- **Labels** include `fleet:stacked` whenever `--base != master` (i.e.
+  every PR in the chain except the first). The merger reads
+  `baseRefName` directly for routing decisions; the label is a derived
+  convenience for human visibility and cheap GitHub-side filtering.
 - **Title** starts with `T-NNN: ` so the queue-manager's per-task
   matching works and reviewers can tell which task in the chain this
   PR belongs to.


### PR DESCRIPTION
## Summary
- The "Stack-aware mode" overview in `commit-and-push/SKILL.md` was
  out of sync with the recipe in step 8 (added by T-037, PR #290): the
  PR-body bullet said "Stacked on: <prev PR URL> for all but the first
  PR" while the recipe writes the line for every PR with `master` as
  the value for the first, and the deltas list never mentioned the
  `fleet:stacked` label that the recipe applies when `--base !=
  master`.
- Update the upper section's bullets so they mirror the recipe and add
  a Labels delta covering the `fleet:stacked` behavior alongside the
  existing branch/base/body/title deltas. The lower override is
  unchanged; this PR only completes T-041's "complete stack-aware
  mode" docs polish on top of T-037.

## Stack context
This PR opens against `master` because T-041 is the bootstrapping task
in the T-041..T-045 stacked-PR-vision chain — the stack-aware code it
documents already exists, so the documentation update itself does not
need to ride that pipeline.

## Test plan
- [ ] A reader of `Stack-aware mode` who never reads step 8 can
  predict the recipe's behavior (base, body, label) from the bullets
  alone.
- [ ] No-molecule case still produces `--base master` and no
  `fleet:stacked` label (recipe unchanged).

Refs #289 (T-041 of T-041..T-045; the parent issue stays open until
T-042..T-045 land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)