### PR TITLE
T-042: start-next-task stack-aware reset

### DIFF
--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -94,11 +94,11 @@ Never rely on a stale local `master` ref. Always fetch before branching.
 
 If the current task is part of a `fleet-claim stack` chain, the next branch
 must build on the just-opened PR's head ref — not `origin/master` — so the
-downstream task's diff shows only its own changes. Probe the molecule:
+downstream task's diff shows only its own changes. Probe the molecule (agents already know their own worktree name — it is passed
+in their role instructions, the same way `fleet-heartbeat <name>` is called):
 
 ```bash
-agent=$(basename "$(git rev-parse --show-toplevel)")
-fleet-claim molecule resume "$agent"
+fleet-claim molecule resume <your-worktree-name>
 ```
 
 Interpret the output (the helper always exits 0; discriminate via stdout):

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -1,21 +1,34 @@
 ---
 name: start-next-task
 description: >-
-  Reset the current worktree to a fresh feature branch off the latest
-  origin/master so the agent can start the next chunk of work without
-  contaminating the previous PR branch. Use after commit-and-push has opened a
-  PR and the user (or you) wants to move on to the next task, OR whenever the
-  user says "next task", "start next", "move on", or "pull master and start
-  fresh". This is the "rebase-off-master-after-opening-a-pr" step of the
-  parallel-agent workflow.
+  Reset the current worktree to a fresh feature branch for the next chunk of
+  work. In the standard case that means branching off the latest
+  origin/master; if the worker has an active fleet-claim molecule (a stacked
+  task chain), the new branch instead bases on the just-opened PR's head ref
+  so the downstream task's diff stays isolated. Use after commit-and-push has
+  opened a PR and the user (or you) wants to move on to the next task, OR
+  whenever the user says "next task", "start next", "move on", or "pull master
+  and start fresh".
 ---
 
 # start-next-task
 
 Cleanly transitions a worktree from "this chunk is done, PR is open" to
-"ready for the next chunk of work on fresh master". This is the other half
-of the new PR workflow — `commit-and-push` packages a slice; `start-next-task`
-prepares the worktree for the next slice.
+"ready for the next chunk of work". This is the other half of the new PR
+workflow — `commit-and-push` packages a slice; `start-next-task` prepares
+the worktree for the next slice.
+
+The skill operates in two modes selected by `fleet-claim molecule resume`
+(see step 4):
+
+- **Standard mode** (no active molecule): branch off fresh `origin/master`.
+  This is the historical behavior and applies to single-task work.
+- **Stack mode** (active molecule with remaining tasks): branch off the
+  **old branch** — i.e. the head ref of the PR that `commit-and-push` just
+  opened. The downstream task's branch then contains the upstream commits
+  so the worker can keep building, while its PR's `--base <upstream>` (set
+  by `commit-and-push` at PR-open time) keeps the diff scoped to its own
+  changes.
 
 ## When to invoke
 
@@ -50,8 +63,9 @@ push" and stops, don't also run `start-next-task` — wait for them to ask.
 git rev-parse --abbrev-ref HEAD
 ```
 
-Remember this — you'll reference it in the report at the end, and the user
-may want to check that the PR is still tracking it.
+Remember this — you'll reference it in the report at the end, the user may
+want to check that the PR is still tracking it, and stack mode (step 4)
+uses it as the new branch's base.
 
 ### 2. Confirm the old branch's PR is pushed and open
 
@@ -76,20 +90,59 @@ git fetch origin master
 
 Never rely on a stale local `master` ref. Always fetch before branching.
 
-### 4. Derive a new branch name
+### 4. Detect active molecule (stack-aware mode)
 
-Ask the user what the next task is if they haven't already told you. Derive
-a short, kebab-case branch name from the task, prefixed `claude/<area>-`:
+If the current task is part of a `fleet-claim stack` chain, the next branch
+must build on the just-opened PR's head ref — not `origin/master` — so the
+downstream task's diff shows only its own changes. Probe the molecule:
+
+```bash
+agent=$(basename "$(git rev-parse --show-toplevel)")
+fleet-claim molecule resume "$agent"
+```
+
+Interpret the output (the helper always exits 0; discriminate via stdout):
+
+- **stdout names a `T-NNN`** — there is an active stack with remaining
+  tasks. The returned ID is the **next** task in the chain (resume marks
+  the first pending task as `in-progress` as a side effect).
+  - **Sanity-check:** if the returned ID matches the old branch's task
+    prefix (e.g. old branch `claude/T-005-foo` and resume returned
+    `T-005`), the worker forgot to run `fleet-claim molecule advance
+    <agent> T-005 done pr=<URL> commit=<SHA>` after `commit-and-push`.
+    Stop and tell the user to advance the molecule before retrying — do
+    not proceed, or you will branch back onto the same task.
+  - Otherwise the new branch is `claude/<returned-T-NNN>-<short-topic>`
+    based on the **old branch** (the just-opened PR's head ref). Set
+    `BASE=<old-branch-name>` and remember `<returned-T-NNN>` for step 5.
+- **stdout is empty** — no molecule, or the molecule is fully done.
+  Standard flow. Set `BASE=origin/master` and proceed as before.
+
+If `molecule resume` exits non-zero (malformed YAML, etc.), stop and
+surface the stderr message — that is a real fault, not a "no work" signal.
+
+### 5. Derive a new branch name
+
+In **stack mode** (step 4 returned a `T-NNN`): the new branch is
+`claude/<T-NNN>-<short-topic>`. Pull the topic from the task title in
+`TASKS.md` if obvious (read it via `git show origin/master:TASKS.md` —
+do NOT `git checkout origin/master -- TASKS.md`, which would stage it
+and break the next `git checkout -b`). If the user already named the
+next slice in conversation, prefer that; otherwise `<short-topic>` can
+be a brief paraphrase of the title.
+
+In **standard mode** (step 4 returned empty): ask the user what the
+next task is if they haven't already told you. Derive a short,
+kebab-case branch name from the task, prefixed `claude/<area>-`:
 
 - `claude/game-ant-pheromones`
 - `claude/engine-velocity-drag-refactor`
 - `claude/render-lod-threshold-tuning`
 
-If the user already gave you a task and a name is obvious, just use it. Do
-not pick a name with a random suffix — permanent worktrees work best with
-human-readable, topic-named branches.
+Either way: do not pick a name with a random suffix — permanent worktrees
+work best with human-readable, topic-named branches.
 
-### 5. Discard any staged or working-tree changes from the old branch
+### 6. Discard any staged or working-tree changes from the old branch
 
 Before switching, ensure the working tree is fully clean — even of files
 that look like a no-op (e.g. `TASKS.md` that was checked out from
@@ -106,28 +159,34 @@ If it didn't, these clear any leftover staged changes that would otherwise
 fail the next `git checkout -b` with "your local changes would be
 overwritten by checkout."
 
-### 6. Check out the new branch off fresh origin/master
+### 7. Check out the new branch off the right base
 
 ```bash
-git checkout -B claude/<new-area>-<new-topic> origin/master
+git checkout -B <new-branch> "$BASE"
 ```
 
-`-B` (uppercase) creates the branch if it doesn't exist AND resets it
-to the named commit if it does. Lowercase `-b` errors out with "branch
-already exists" — surprisingly common because the worktree's previous
-scratch branches accumulate over many iterations. With `-B`, we don't
-care; the branch always lands on a clean `origin/master` regardless of
-its prior state.
+`$BASE` was set in step 4: `origin/master` for the standard flow,
+`<old-branch-name>` for stack mode. `-B` (uppercase) creates the branch
+if it doesn't exist AND resets it to the named commit if it does.
+Lowercase `-b` errors out with "branch already exists" — surprisingly
+common because the worktree's previous scratch branches accumulate over
+many iterations. With `-B`, the branch always lands on the requested
+base regardless of its prior state.
 
-This creates the new branch starting from the tip of `origin/master`, not
-from wherever your previous branch was. Critical: without `origin/master`,
-you'd branch off your old PR branch and carry its commits forward.
+In **standard mode**, this starts the new branch from the tip of
+`origin/master`. Critical: without `origin/master`, you'd branch off
+your old PR branch and carry its commits forward.
 
-**Do NOT** `git rebase origin/master` on the old branch and keep working on
-it. That would mix old PR commits with new work, which pollutes the old PR
-when you push. Always start a new branch.
+In **stack mode**, this is intentional — the downstream task is meant to
+contain the upstream commits so the worker can keep building. The
+downstream PR's `--base` (set later by `commit-and-push`) is the upstream
+branch, so the diff still shows only the downstream changes.
 
-### 7. Sanity-check the state
+**Do NOT** `git rebase origin/master` on the old branch and keep working
+on it. That would mix old PR commits with new work, which pollutes the
+old PR when you push. Always start a new branch.
+
+### 8. Sanity-check the state
 
 ```bash
 git status
@@ -135,11 +194,17 @@ git log --oneline -5
 ```
 
 - `git status`: should be `nothing to commit, working tree clean`.
-- `git log --oneline -5`: the top commit should now be the latest `master`
-  commit, not one of your previous PR's commits. If it's still showing old
-  PR commits, the checkout went wrong — stop and investigate.
+- **Standard mode:** `git log --oneline -5` top commit should be the
+  latest `master` commit, not one of your previous PR's commits.
+- **Stack mode:** the top commit should be the just-opened PR's tip
+  (i.e. the last commit on the old branch). The new branch's
+  merge-base with `origin/master` is whatever the old branch branched
+  from — not the old branch's tip. That's expected.
 
-### 8. Read the relevant CLAUDE.md for the new task area
+If the top commit is wrong for the mode you're in, the checkout went
+wrong — stop and investigate.
+
+### 9. Read the relevant CLAUDE.md for the new task area
 
 Before starting the next task, read the most specific `CLAUDE.md` for the
 directory you're about to work in. For example:
@@ -154,25 +219,39 @@ This primes your context with the module's conventions and gotchas before
 you start editing. If the subdirectory has a dedicated workflow that
 differs from the engine baseline, honor the subdirectory's rules.
 
-### 9. Report
+### 10. Report
 
 Reply with a compact summary:
 
 - Old branch name + its PR URL (from step 2).
-- New branch name + confirmation it's based on fresh `origin/master`.
+- New branch name + the base it's tracking. In standard mode that's
+  fresh `origin/master`; in stack mode call out the upstream branch
+  explicitly so the reviewer-and-merger pipeline isn't surprised when
+  `commit-and-push` later sets `--base <upstream>`.
 - The CLAUDE.md files you just read to prime context.
 - One sentence: "Ready for <next task>. Go ahead."
 
 ## Anti-patterns
 
 - ❌ Switching branches with a dirty working tree. Always clean first.
-- ❌ Branching off your previous PR branch instead of `origin/master`. This
-  stacks work and pollutes the old PR.
-- ❌ Running `git rebase origin/master` on the old branch to "catch it up",
-  then reusing it. Rebasing the same branch for new unrelated work is how
-  PR histories become unreadable.
+- ❌ Branching off your previous PR branch in **standard mode** (no active
+  molecule). That stacks unrelated work and pollutes the old PR. Stack
+  mode (step 4 returned a `T-NNN`) is the only case where the old branch
+  is the correct base.
+- ❌ Branching off `origin/master` in **stack mode**. The downstream
+  task's diff would then include the upstream changes too, defeating
+  the whole point of stacked PRs (one task = one isolated diff).
+- ❌ Skipping `fleet-claim molecule advance` after `commit-and-push` and
+  going straight to `start-next-task`. `molecule resume` would return
+  the just-completed task as still in-progress, branching you onto the
+  same thing you just shipped. The stack-mode sanity-check in step 4
+  catches this — heed it.
+- ❌ Running `git rebase origin/master` on the old branch to "catch it
+  up", then reusing it. Rebasing the same branch for new unrelated work
+  is how PR histories become unreadable.
 - ❌ Deleting the old local branch. Leave it alone — if the reviewer asks
-  for changes, you'll need to check it out again.
+  for changes, you'll need to check it out again. Stack mode REQUIRES
+  the old branch as the new branch's base.
 - ❌ Starting the next task without reading the target area's CLAUDE.md.
   That's where the module-specific invariants live.
 - ❌ Invoking this skill when no PR was actually opened (i.e. after a

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -162,11 +162,12 @@ overwritten by checkout."
 ### 7. Check out the new branch off the right base
 
 ```bash
-git checkout -B <new-branch> "$BASE"
+git checkout -B <new-branch> origin/master      # standard mode
+git checkout -B <new-branch> <old-branch-name>  # stack mode
 ```
 
-`$BASE` was set in step 4: `origin/master` for the standard flow,
-`<old-branch-name>` for stack mode. `-B` (uppercase) creates the branch
+The base is `origin/master` for the standard flow, `<old-branch-name>` for
+stack mode (see step 4). `-B` (uppercase) creates the branch
 if it doesn't exist AND resets it to the named commit if it does.
 Lowercase `-b` errors out with "branch already exists" — surprisingly
 common because the worktree's previous scratch branches accumulate over


### PR DESCRIPTION
## Summary

- `start-next-task` now probes `fleet-claim molecule resume <agent>` before resetting.
- Stack mode (resume returns `T-NNN`): new branch bases on the just-opened PR's head ref, so the downstream task's diff stays scoped to its own changes when `commit-and-push` later sets `--base <upstream>`.
- Standard mode (resume returns empty): unchanged — branch off fresh `origin/master`.
- Sanity check refuses to proceed when resume returns the same task ID as the old branch's prefix (caller forgot `molecule advance ... done`); that scenario would silently re-branch onto the just-shipped task.
- Anti-patterns and report step grew per-mode guidance so the standard flow still reads cleanly and stack mode reads as intentional.

Acceptance from `.fleet/plans/T-042.md`: after opening the PR for the first task in a 2-task stack, `start-next-task` lands on a branch whose merge-base with the just-opened PR's head ref is that head ref's tip; after exhausting the stack, `molecule resume` returns empty and the skill resets to `origin/master` as today.

## Stack context

Part 2 of 5 in the stacked-PR vision (issue #289). T-041 (commit-and-push stack-aware mode) merged in #292; this is the start-next-task counterpart so a worker can chain through the molecule without manual base-branch fix-ups.

Standalone PR — does NOT chain off another open PR. T-043 will land next on top of `origin/master` once this merges (queue-manager will reflect the unblocking).

## Test plan

- [ ] Single-task flow (no molecule): `start-next-task` still branches off `origin/master`. (Verified mentally: the `BASE=origin/master` path is unchanged.)
- [ ] 2-task stack: after opening PR for task A and running `molecule advance ... done`, `start-next-task` returns task B's ID, branches off `claude/T-A-...`, and `git log -1` shows task A's tip as HEAD.
- [ ] Forgot-to-advance guard: if `molecule resume` returns the same ID as the old branch's prefix, the skill stops and tells the caller to advance the molecule first.
- [ ] After exhausting the stack, `molecule resume` returns empty, the skill falls through to standard mode, and the next iteration's reset reaches `origin/master`.

Refs #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)