### PR TITLE
T-039: roles read shared scout cache instead of running gh/git directly

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -39,6 +39,33 @@ Common patterns and their correct alternatives:
   `.merger-body.md`), not to `/tmp`. The sandbox may block writes
   outside the project tree.
 
+## Shared fleet state cache
+
+The `fleet-state-scout` daemon (started by `fleet-up`) refreshes
+`~/.fleet/state/state.json` every ~60s with both repos' open PRs
+(including labels, mergeable state, base/head refs, and
+`updatedAt`). **This cache is the source of truth for list-y
+queries — do NOT bypass it for `gh pr list --state open` when the
+cache is fresh.** One Read tool call replaces what used to be two
+`gh pr list` invocations per iteration (cooldown sweep + main
+candidate fetch).
+
+Schema (slices this role uses):
+- `repos.engine.prs[]` — `number`, `title`, `headRefName`,
+  `baseRefName`, `labels` (sorted strings), `mergeable`, `isDraft`,
+  `updatedAt`. (Merger is engine-only; ignore `repos.game.prs[]`.)
+
+Per-item lookups (`gh pr view <N> --json mergeable` for UNKNOWN
+refresh, the per-PR conflict-resolution flow that needs `git fetch`,
+`git rebase`, `gh pr comment`, `gh pr edit`) stay inline — those
+pull or push live data the cache doesn't store. The cache covers
+list-shaped queries; live drill-in covers single-item drill-down.
+
+If `~/.fleet/state/state.json` is missing or its `generated_at` is
+more than ~5 minutes old, the scout daemon isn't running. Print
+`scout cache stale or missing — run fleet-up` and exit; do not
+silently fall back to direct `gh pr list` calls.
+
 ## What you do
 
 You poll open PRs on the **engine repo** every 10 minutes. For each
@@ -113,14 +140,17 @@ exit cleanly:
    than gating on `updatedAt`, which other agents' comments refresh)
    gives a single, predictable signal. Skip any PR that was already
    touched this iteration via the in-memory candidate list below.
-   `gh pr list --repo <engine-repo> --state open --label "fleet:merger-cooldown" --json number --jq '.[].number'`
-   For each number returned:
+   Read `~/.fleet/state/state.json`; from `repos.engine.prs[]`,
+   collect every PR whose `labels` contains `fleet:merger-cooldown`.
+   For each such PR number:
    `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:merger-cooldown"`
 
-2. Fetch the engine PR list. Include `baseRefName` so step a.5's
-   stacked-PR check can read it from memory instead of re-querying
-   per candidate:
-   `gh pr list --repo <engine-repo> --state open --json number,title,mergeable,labels,headRefName,baseRefName,updatedAt`
+2. Get the engine PR list from the cache you just loaded —
+   `repos.engine.prs[]` already includes `number`, `title`,
+   `mergeable`, `labels`, `headRefName`, `baseRefName`, and
+   `updatedAt`, which is everything step 3's filter and step a.5's
+   stacked-PR check need. (Cached equivalent of the previous
+   `gh pr list --state open --json number,title,mergeable,labels,headRefName,baseRefName,updatedAt`.)
 
 3. Filter to candidates. A PR is a candidate if:
    - `mergeable == "CONFLICTING"`, OR

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -35,6 +35,37 @@ Common patterns and their correct alternatives:
   write within the worktree (e.g. `.review-body.md`), not to `/tmp`.
   The sandbox may block writes outside the project tree.
 
+## Shared fleet state cache
+
+The `fleet-state-scout` daemon (started by `fleet-up`) refreshes
+`~/.fleet/state/state.json` every ~60s with both repos' open PRs
+(including their reviews and labels). **This cache is the source of
+truth for list-y queries — do NOT bypass it for `gh pr list` when
+the cache is fresh.** One Read tool call replaces what used to be
+two `gh pr list` invocations per iteration.
+
+Schema (slices this role uses):
+- `repos.{engine,game}.prs[]` — `number`, `title`, `headRefName`,
+  `baseRefName`, `author` (login string), `labels` (sorted strings),
+  `mergeable`, `isDraft`, `reviews[]` (each with `author` login,
+  `body`, `state`, `submittedAt`). The `body` of the latest Sonnet
+  review is what tells you whether `Opus recheck required` is in
+  play. Bodies longer than 2 KB are stored as head + tail with an
+  `…[truncated]…` separator (the verdict line typically lives in the
+  tail), so the recheck signal still reaches the cache for typical
+  reviews; if a finding requires the full body for context, fetch
+  it with `gh pr view <N> --comments`.
+
+Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`)
+stay inline — those pull live data the cache doesn't store (issue
+comment timeline, file diffs). The cache covers list-shaped queries;
+live drill-in covers single-item drill-down.
+
+If `~/.fleet/state/state.json` is missing or its `generated_at` is
+more than ~5 minutes old, the scout daemon isn't running. Print
+`scout cache stale or missing — run fleet-up` and exit; do not
+silently fall back to direct `gh pr list` calls.
+
 ## Role
 
 You poll open PRs on **both repos** — the engine repo and the game
@@ -72,24 +103,33 @@ conditions, allocator behavior, hot-path costs.
    separately (do NOT wrap in `cd ... &&`):
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git checkout -B claude/opus-reviewer-scratch origin/master`
-4. Fetch PR lists from both repos (each as a separate command):
-   `gh pr list --state open --json number,title,headRefName,reviews,labels`
-   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,reviews,labels`
-   Print both results.
+4. **Read the shared fleet state cache** with the Read tool:
+   `~/.fleet/state/state.json`. One Read replaces the two `gh pr
+   list --json reviews,labels,...` calls that used to live here —
+   open PRs across both repos (with their reviews and labels) live
+   at `repos.engine.prs[]` and `repos.game.prs[]`.
+
+   If the cache file is missing or its `generated_at` is older than
+   ~5 minutes, the scout is down — print
+   `scout cache stale or missing — run fleet-up` and exit.
 5. Identify the candidates from both repos. A PR is a candidate if:
-   - The latest Sonnet review body contains `Opus recheck required`, OR
-   - The PR touches core engine/game invariants, OR
-   - The PR has the `human:re-review` label (human made changes and
+   - Its latest review (sort `reviews[]` by `submittedAt`) has a
+     `body` containing `Opus recheck required`, OR
+   - The PR touches core engine/game invariants (need to read its
+     diff via `gh pr diff <N>` per-item), OR
+   - Its `labels` contains `human:re-review` (human made changes and
      requested re-review — remove the label when you pick it up:
      `gh pr edit <N> --remove-label "human:re-review"`), OR
-   - The PR has the `fleet:changes-made` label AND it touches core
-     engine/game invariants (remove the label on pickup:
+   - Its `labels` contains `fleet:changes-made` AND the PR touches
+     core engine/game invariants (remove the label on pickup:
      `gh pr edit <N> --remove-label "fleet:changes-made"`). For
      non-core PRs, leave `fleet:changes-made` for sonnet-reviewer to
      handle — Opus budget is expensive, don't burn it on docs/tooling
      fixups, OR
    - The author pushed fixes and commented "re-review please" after
-     a previous Opus review (check comments after your last review).
+     a previous Opus review (per-item — check comments via
+     `gh pr view <N> --comments` after your last review's
+     `submittedAt`).
 
    **Skip** PRs labeled `fleet:wip`, `human:wip`, or `human:needs-fix`
    — those are either in-progress or human-owned.
@@ -107,9 +147,10 @@ iteration of polling, reviewing, and exiting cleanly:
    the helper instead of a direct `touch` avoids the `~`-expansion
    path-scope prompt that fires on the raw form.)
 
-1. Re-fetch PR lists from both repos (separate commands):
-   `gh pr list --state open --json number,title,headRefName,reviews,labels`
-   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,reviews,labels`
+1. Re-Read `~/.fleet/state/state.json` if its contents are no
+   longer in your conversation context — both repos' open PRs (with
+   labels and reviews) live at `repos.engine.prs[]` and
+   `repos.game.prs[]`.
 2. For each candidate, in oldest-first order:
    a. Read the existing Sonnet review in full first
       (`gh pr view <N> --comments`, add `--repo <game-repo>` for

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -41,6 +41,39 @@ Common patterns and their correct alternatives:
   exit status / error. Issue the fallback as a separate Bash call if
   needed.
 
+## Shared fleet state cache
+
+The `fleet-state-scout` daemon (started by `fleet-up`) refreshes
+`~/.fleet/state/state.json` every ~60s with both repos' open PRs,
+`fleet:needs-plan` issues, and parsed `TASKS.md` rows. **This cache
+is the source of truth for list-y queries — do NOT bypass it for
+`gh pr list`, `gh issue list --label fleet:needs-plan`, or
+`git show origin/master:TASKS.md` when the cache is fresh.** One Read
+tool call replaces what used to be three to six `gh`/`git` invocations
+at startup.
+
+Schema (slices this role uses):
+- `repos.{engine,game}.prs[]` — `number`, `title`, `headRefName`,
+  `baseRefName`, `author` (login string), `labels` (sorted strings),
+  `mergeable`, `isDraft`.
+- `repos.{engine,game}.needs_plan[]` — `number`, `title`, `labels`.
+- `repos.{engine,game}.tasks.{open,in_progress,done}[]` — `status`,
+  `title`, `summary`, `id`, `model`, `owner`, `area`, `blocked_by`,
+  `issue`.
+
+Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`,
+`gh issue view <N>`, `gh api repos/.../comments`) stay inline — those
+pull live data the cache doesn't store (PR bodies, comments, diffs).
+The cache covers list-shaped queries; live drill-in covers
+single-item drill-down.
+
+If `~/.fleet/state/state.json` is missing or its `generated_at` is
+more than ~5 minutes old, the scout daemon isn't running. Print a
+diagnostic (`scout cache stale or missing — run fleet-up`) and exit;
+do not silently fall back to direct `gh`/`git` calls — that defeats
+the budget split, hides the outage, and races with whichever role
+the human is debugging.
+
 ## Responsibilities
 
 - Plan issues flagged with `fleet:needs-plan` on **either repo** — read
@@ -95,43 +128,48 @@ fleet-claim --repo game claim "T-001" opus-worker-1
    opus-architect, not a reviewer worktree). The directory basename
    (`opus-worker-1` or `opus-worker-2`) is your **agent name** — pass
    it as the `<agent>` argument to `fleet-claim claim`.
-2. Fetch both repos (separate calls):
+2. Fetch both repos so per-task `git checkout`/`git rebase` and
+   `gh pr checkout` work later (the cache gives you a parsed
+   snapshot but does not pull refs):
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git -C ~/src/IrredenEngine/creations/game fetch origin --quiet`
    If the game fetch fails because `creations/game/` isn't present,
    the game repo is not set up on this host. Skip all game-queue
-   steps below (3–6 game variants, step 1's game PR check) and
-   proceed with engine tasks only — do not abort the iteration.
-3. **Read the latest TASKS.md from origin/master without staging.**
-   Use `git show` to dump the current master versions directly to
-   stdout — does NOT touch the working tree or index, so it won't
-   break later branch checkouts. Two repos, two Bash calls:
-   `git -C ~/src/IrredenEngine show origin/master:TASKS.md`
-   `git -C ~/src/IrredenEngine/creations/game show origin/master:TASKS.md`
-   The Bash tool returns the full content as its output (and
-   auto-persists to a `.claude/projects/.../`-side file if the
-   output is large — automatic, you don't have to manage it).
+   steps below (game-side feedback, game-side needs-plan, game task
+   pickup) and proceed with engine tasks only — do not abort the
+   iteration.
+3. **Read the shared fleet state cache** with the Read tool:
+   `~/.fleet/state/state.json`. One Read replaces what used to be
+   six `gh` / `git` calls here:
+   - both repos' open PR lists
+     (`repos.{engine,game}.prs[]`)
+   - both repos' `fleet:needs-plan` issue lists
+     (`repos.{engine,game}.needs_plan[]`)
+   - both repos' `TASKS.md` parsed into open / in-progress / done
+     (`repos.{engine,game}.tasks.{open,in_progress,done}[]`)
 
-   Do NOT redirect to `/tmp` or anywhere else with `>`. Claude
-   Code's Bash tool blocks shell redirects regardless of whether
-   the destination is in `additionalDirectories` (the gate is on
-   the `>` operation, not the path). Stick with stdout-only.
+   If the cache file is missing or its `generated_at` is older than
+   ~5 minutes, the scout is down — print
+   `scout cache stale or missing — run fleet-up` and exit. Do not
+   fall back to direct `gh`/`git` calls; see "Shared fleet state
+   cache" above.
 
-   For plan files, list them with `git -C <repo> ls-tree -r origin/master --name-only -- .fleet/plans/`
-   then `git -C <repo> show origin/master:.fleet/plans/<file>` for any
-   you need to read. Do NOT use `git checkout origin/master -- ...` —
-   it stages the files and breaks later `git checkout -b`.
-4. Review both queues from the `git show` output you just captured
-   for the engine and game `TASKS.md`.
-5. Open-PR cross-check on both repos:
-   `gh pr list --repo jakildev/IrredenEngine --state open --json number,title,headRefName,author`
-   `gh pr list --repo jakildev/irreden       --state open --json number,title,headRefName,author`
-6. Check for `fleet:needs-plan` issues on both repos:
-   `gh issue list --repo jakildev/IrredenEngine --label "fleet:needs-plan" --state open --json number,title`
-   `gh issue list --repo jakildev/irreden       --label "fleet:needs-plan" --state open --json number,title`
-7. Print a one-line summary: count of `fleet:needs-plan` issues across
-   both repos, count of unblocked unclaimed `[opus]` tasks per repo.
-8. Print `opus-worker standing by` (or `opus-worker standing by
+   For plan files (still on disk, not in cache), list with
+   `git -C <repo> ls-tree -r origin/master --name-only -- .fleet/plans/`
+   and read individual entries with
+   `git -C <repo> show origin/master:.fleet/plans/<file>`.
+   Do NOT use `git checkout origin/master -- ...` — it stages the
+   files and breaks later `git checkout -b`.
+4. Review both queues from the `tasks.open[]` arrays you just
+   loaded; cross-check the `prs[]` arrays for what is already
+   in flight under another agent (the live "is this task already
+   being worked" signal).
+5. Print a one-line summary: count of `fleet:needs-plan` entries
+   across both repos, count of unblocked unclaimed `[opus]` tasks
+   per repo (filter `tasks.open[]` where `model` contains `opus`,
+   `owner == "free"`, and `blocked_by` resolves to merged work or
+   `(none)`).
+6. Print `opus-worker standing by` (or `opus-worker standing by
    (dry-run)` if Mode above is `dry-run`).
 
 ## Loop behavior
@@ -161,10 +199,13 @@ Do the work, then exit cleanly:
    30 minutes per iteration).
 
 1. **Check for feedback labels on open PRs across both repos.**
-   ```
-   gh pr list --repo jakildev/IrredenEngine --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "engine #\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'
-   gh pr list --repo jakildev/irreden       --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "game #\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'
-   ```
+   Re-Read `~/.fleet/state/state.json` if its contents are no
+   longer in your conversation context. From `repos.engine.prs[]`
+   and `repos.game.prs[]`, pick PRs whose `labels` array contains
+   any of `human:needs-fix`, `human:blocker`, `fleet:needs-fix`,
+   `fleet:has-nits`. (This is the cached equivalent of the previous
+   `gh pr list ... --jq 'select(.labels ...)'` chain — same filter,
+   no API call.)
 
    For game-side feedback work, **cd into the game opus-worker
    worktree** before any git/gh ops (same as step 4 for new tasks):
@@ -212,9 +253,13 @@ Do the work, then exit cleanly:
     - `Linux` → host key `linux`, poll `fleet:needs-linux-smoke`
     - `Darwin` → host key `macos`, poll `fleet:needs-macos-smoke`
 
-    ```
-    gh pr list --repo jakildev/IrredenEngine --state open --label "fleet:needs-<host>-smoke" --json number,title,headRefName,labels --jq '.[] | select(.labels | map(.name) | any(. == "fleet:approved")) | select(.labels | map(.name) | all(. != "fleet:needs-fix" and . != "fleet:blocker" and . != "human:wip" and . != "fleet:wip" and . != "fleet:merger-cooldown" and . != "human:needs-fix")) | "#\(.number) \(.title) (\(.headRefName))"'
-    ```
+    From the cached `repos.engine.prs[]`, pick PRs whose `labels`
+    array contains BOTH `fleet:needs-<host>-smoke` AND
+    `fleet:approved`, and contains NONE of `fleet:needs-fix`,
+    `fleet:blocker`, `human:wip`, `fleet:wip`,
+    `fleet:merger-cooldown`, `human:needs-fix`. (Cached equivalent
+    of the previous `gh pr list --label fleet:needs-<host>-smoke
+    ... --jq` chain — same filter, no API call.)
 
     The filter keeps only PRs that are approved, not flagged for
     fixes, and not claimed by the human. If the list is empty, skip
@@ -248,11 +293,16 @@ Do the work, then exit cleanly:
     are handled across successive iterations so task pickup isn't
     starved by back-to-back smoke runs.
 
-2. **Plan any `fleet:needs-plan` issues on either repo.**
-   `gh issue list --repo jakildev/IrredenEngine --label "fleet:needs-plan" --state open --json number,title,body,comments`
-   `gh issue list --repo jakildev/irreden       --label "fleet:needs-plan" --state open --json number,title,body,comments`
+2. **Plan any `fleet:needs-plan` issues on either repo.** The
+   cached `repos.engine.needs_plan[]` and `repos.game.needs_plan[]`
+   arrays hold the open needs-plan issues. Pick the oldest
+   unprocessed entry (smallest `number`) across both repos.
 
-   Process the oldest first across both repos. For each issue:
+   The cache only stores list-shaped data — for per-issue body and
+   comments, pull live (per-item lookup, stays inline):
+   `gh issue view <N> --repo <repo> --comments`
+
+   For each issue:
    a. Read the full issue thread (title, body, all comments).
    b. Assess the scope and write a structured plan. Post it as an
       issue comment covering:
@@ -376,14 +426,15 @@ Do the work, then exit cleanly:
      below.
 
    **Normal pickup (no active molecule)** — pick from either queue.
-   Re-run the two `git show origin/master:TASKS.md` Bash calls from
-   step 3 if their output isn't still in your context. Find the
-   first `[ ]` item in `## Open` with `Model: opus` whose:
+   Re-Read `~/.fleet/state/state.json` if its contents are no longer
+   in your conversation context. From `repos.{engine,game}.tasks.open[]`,
+   find the first row with `status == " "` (open) and `model`
+   containing `opus` whose:
    - **Owner** is `free` (or your worktree name)
    - **Blocked by** is empty (or only references already-merged work)
    - **Title is NOT referenced in any open PR's title or branch name**
-     in **the same repo** (cross-check with the per-repo `gh pr list`
-     output from step 5)
+     in **the same repo** (cross-check against the same repo's
+     `prs[]` array from the cache)
 
    **Priority:** prefer engine tasks over game tasks when both are
    available — engine work is the core dependency surface. But if

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -30,6 +30,50 @@ Common patterns and their correct alternatives:
   exit status / error. Issue the fallback as a separate Bash call if
   needed.
 
+## Shared fleet state cache
+
+The `fleet-state-scout` daemon (started by `fleet-up`) refreshes
+`~/.fleet/state/state.json` every ~60s with both repos' open PRs,
+ingestion-pending `human:approved` issues (filtered to exclude
+already-queued ones), `fleet:needs-plan` issues, and parsed
+`TASKS.md` rows. **This cache is the source of truth for list-y
+queries — do NOT bypass it for `gh pr list --state open`,
+`gh issue list --label human:approved`, or `gh issue list --label
+fleet:needs-plan` when the cache is fresh.** One Read tool call
+replaces what used to be six or more `gh` invocations per
+maintenance pass.
+
+Schema (slices this role uses):
+- `repos.{engine,game}.prs[]` — `number`, `title`, `headRefName`,
+  `baseRefName`, `author` (login string), `labels` (sorted strings),
+  `mergeable`, `isDraft`, `reviews[]`. **No `body`** — the cache
+  doesn't store PR bodies, so any check that needs `Closes #N`
+  parsing keeps a per-item `gh pr view <N> --json body` inline.
+- `repos.{engine,game}.human_approved[]` — open issues with
+  `human:approved` label, MINUS the ones the scout already filters
+  (`fleet:task`, `fleet:queued`). Each entry has `number`, `title`,
+  `labels` — to match the queue-manager's full ingest search,
+  additionally filter out entries whose `labels` include
+  `fleet:needs-plan` or `fleet:needs-info`.
+- `repos.{engine,game}.needs_plan[]` — open issues with
+  `fleet:needs-plan` label. `number`, `title`, `labels`.
+- `repos.{engine,game}.tasks.{open,in_progress,done}[]` — `status`,
+  `title`, `summary`, `id`, `model`, `owner`, `area`, `blocked_by`,
+  `issue`. **Reflects origin/master** — the queue-manager's own
+  in-progress edits sit only in the working tree until pushed, so
+  the working-tree TASKS.md is still what you Edit/Read for
+  maintenance.
+
+Per-item lookups (`gh pr view <N> --json body`,
+`gh issue view <N> --comments`, `gh pr list --state merged ...`)
+stay inline — those pull live data the cache doesn't store (PR
+bodies, comment timelines, merged PRs).
+
+If `~/.fleet/state/state.json` is missing or its `generated_at` is
+more than ~5 minutes old, the scout daemon isn't running. Print
+`scout cache stale or missing — run fleet-up` and exit; do not
+silently fall back to direct `gh`/`git` calls.
+
 ## Role
 
 You are the **task intake** for the fleet. The human (or an idle agent)
@@ -58,17 +102,25 @@ use `cat` — use the Read tool for files.
    Game: determined in step 5 below (probe the game directory).
    All `<engine-repo>` and `<game-repo>` placeholders below refer
    to these discovered slugs.
-4. Read tool → `TASKS.md`
+4. Read tool → `TASKS.md` (working-tree copy in this worktree —
+   the queue-manager edits this file in place, so always Read the
+   working tree, not the cache).
 5. Read tool → `~/src/IrredenEngine/creations/game/TASKS.md`
    - If the Read succeeds (file exists), the game repo is present.
-     Run these two commands (separate tool calls):
-     5a. `git -C ~/src/IrredenEngine/creations/game remote get-url origin`
-         Parse `owner/repo` from the URL (strip protocol, `.git`
-         suffix). This is `<game-repo>`.
-     5b. `gh pr list --repo <game-repo> --state open --json number,title,headRefName`
-   - If the Read fails (file not found) → skip 5a–5b. No game repo.
-     All game-repo steps below are skipped.
-6. `gh pr list --repo <engine-repo> --state open --json number,title,headRefName`
+     Then derive `<game-repo>`:
+     `git -C ~/src/IrredenEngine/creations/game remote get-url origin`
+     Parse `owner/repo` from the URL (strip protocol, `.git` suffix).
+   - If the Read fails (file not found) → no game repo. All
+     game-repo steps below are skipped.
+6. **Read the shared fleet state cache** with the Read tool:
+   `~/.fleet/state/state.json`. One Read replaces what used to be
+   two `gh pr list --state open` calls (one per repo) here. Both
+   repos' open PRs live at `repos.engine.prs[]` and
+   `repos.game.prs[]`.
+
+   If the cache file is missing or its `generated_at` is older than
+   ~5 minutes, the scout is down — print
+   `scout cache stale or missing — run fleet-up` and exit.
 7. Print a **one-line queue summary** followed by the standing-by message.
    Format: `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
    Count from both engine and game TASKS.md (if present). Then print:
@@ -232,8 +284,19 @@ You are the sole TASKS.md editor. Each maintenance pass:
     the `cleanup` step above, which only catches claims whose PRs
     have already merged or closed.
 
-2. **Ingest triaged issues (engine repo):**
-   `gh issue list --repo <engine-repo> --search "is:open is:issue label:human:approved -label:fleet:queued -label:fleet:needs-plan -label:fleet:needs-info" --json number,title,body,comments,labels`
+2. **Ingest triaged issues (engine repo).** Re-Read
+   `~/.fleet/state/state.json` if its contents are no longer in your
+   conversation context. From `repos.engine.human_approved[]`
+   (already filtered by the scout to exclude `fleet:queued` and
+   `fleet:task`), drop any entry whose `labels` include
+   `fleet:needs-plan` or `fleet:needs-info` — that matches the
+   previous `gh issue list ... --search "label:human:approved
+   -label:fleet:queued -label:fleet:needs-plan
+   -label:fleet:needs-info"` query exactly.
+
+   The cache only stores list-shaped data (number, title, labels),
+   so for each candidate fetch the body and comments per-item:
+   `gh issue view <N> --repo <engine-repo> --json body,comments,labels`
 
    Only issues with `human:approved` (and not yet handled) are
    ingested. The `human:approved` label is a **permanent** signal
@@ -329,11 +392,10 @@ You are the sole TASKS.md editor. Each maintenance pass:
       `gh issue comment <N> --repo <engine-repo> --body "Need more info before scheduling: <specific questions>"`
    c. Do NOT add it to TASKS.md.
 
-3. **Ingest triaged issues (game repo):**
-   `gh issue list --repo <game-repo> --search "is:open is:issue label:human:approved -label:fleet:queued -label:fleet:needs-plan -label:fleet:needs-info" --json number,title,body,comments,labels`
-   Same full-context assessment as above. Apply the same ready /
-   needs-plan / needs-info logic, using `--repo <game-repo>`
-   on all `gh` commands. Append to the **game** TASKS.md at
+3. **Ingest triaged issues (game repo).** Same flow as step 2, but
+   sourced from `repos.game.human_approved[]` and using `--repo
+   <game-repo>` on the per-item `gh issue view`. Append to the
+   **game** TASKS.md at
    `~/src/IrredenEngine/creations/game/TASKS.md`. The
    `human:approved` label is preserved on game-repo issues too.
 
@@ -365,11 +427,12 @@ You are the sole TASKS.md editor. Each maintenance pass:
    `rm -f ~/.fleet/plans/<task-ID>.md`
    `rm -f .fleet/plans/<task-ID>.md`
 
-5. **Sync open PRs → In-progress (both repos):**
-   Engine:
-   `gh pr list --repo <engine-repo> --state open --json number,title,headRefName,body`
-   Game:
-   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,body`
+5. **Sync open PRs → In-progress (both repos).** Use the cached
+   `repos.engine.prs[]` and `repos.game.prs[]` for the open PR
+   list — the title-to-task match below uses `title` and
+   `headRefName`, both of which are in the cache. (No PR body is
+   needed here; step 5b is the only stage that parses `Closes #N`
+   from PR bodies, and stays inline.)
    For each open PR whose title matches a `[ ]` task in the matching
    repo's TASKS.md:
    a. Flip the task to `[~]`, set Owner to the PR author's worktree name.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -31,6 +31,35 @@ Common patterns and their correct alternatives:
   exit status / error. Issue the fallback as a separate Bash call if
   needed.
 
+## Shared fleet state cache
+
+The `fleet-state-scout` daemon (started by `fleet-up`) refreshes
+`~/.fleet/state/state.json` every ~60s with both repos' open PRs and
+parsed `TASKS.md` rows. **This cache is the source of truth for
+list-y queries — do NOT bypass it for `gh pr list` or
+`git show origin/master:TASKS.md` when the cache is fresh.** One Read
+tool call replaces what used to be two `gh`/`git` invocations at
+startup.
+
+Schema (slices this role uses):
+- `repos.engine.prs[]` — `number`, `title`, `headRefName`,
+  `baseRefName`, `author` (login string), `labels` (sorted strings),
+  `mergeable`, `isDraft`. (Sonnet author works only the engine queue
+  — `repos.game` is loaded by the cache too but this role ignores
+  it.)
+- `repos.engine.tasks.{open,in_progress,done}[]` — `status`, `title`,
+  `summary`, `id`, `model`, `owner`, `area`, `blocked_by`, `issue`.
+
+Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`,
+`gh api repos/.../comments`) stay inline — those pull live data the
+cache doesn't store. The cache covers list-shaped queries; live
+drill-in covers single-item drill-down.
+
+If `~/.fleet/state/state.json` is missing or its `generated_at` is
+more than ~5 minutes old, the scout daemon isn't running. Print
+`scout cache stale or missing — run fleet-up` and exit; do not
+silently fall back to direct `gh`/`git` calls.
+
 ## Responsibilities
 
 - Test generation against a clear spec.
@@ -52,31 +81,25 @@ whatever directory the task touches before editing anything.
    `[sonnet-author] Picks bounded [sonnet] tasks from TASKS.md, works them end-to-end, opens PRs. Runs continuously.`
 1. `pwd` and confirm you are in a sonnet-fleet worktree (not the main
    clone, not a reviewer worktree).
-2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. **Read the latest TASKS.md from origin/master without staging it.**
-   The working copy may be stale if the worktree is on a feature
-   branch. Use `git show` to dump the current master version
-   directly to stdout:
-   `git show origin/master:TASKS.md`
-   The Bash tool returns the full content as its output (and
-   auto-persists to a `.claude/projects/.../`-side file if the
-   output is large — the persistence is automatic, you don't have
-   to manage it). This does NOT touch the working tree or index,
-   so it won't break later branch checkouts.
+2. `git -C ~/src/IrredenEngine fetch origin --quiet` — pulls refs
+   for later `git checkout`/`git rebase`; the cache snapshots TASKS.md
+   and PR metadata but doesn't fetch refs.
+3. **Read the shared fleet state cache** with the Read tool:
+   `~/.fleet/state/state.json`. One Read replaces what used to be
+   two calls here:
+   - `git show origin/master:TASKS.md` →
+     `repos.engine.tasks.{open,in_progress,done}[]`
+   - `gh pr list --state open ...` → `repos.engine.prs[]`
 
-   Do NOT redirect to `/tmp` or anywhere else with `>`. Claude
-   Code's Bash tool blocks shell redirects regardless of whether
-   the destination is in `additionalDirectories` (the gate is on
-   the `>` operation, not the path). Stick with stdout-only.
-
-   Do NOT use `git checkout origin/master -- TASKS.md` either.
-   That stages the file. When `start-next-task` later tries
-   `git checkout -b new-branch origin/master` it errors with
-   "your local changes would be overwritten by checkout."
-4. `gh pr list --state open --json number,title,headRefName,author` —
-   see what other agents are working on.
-5. Print a one-line summary: which `[sonnet]` items look unblocked and
-   not currently claimed in any open PR.
+   If the cache file is missing or its `generated_at` is older than
+   ~5 minutes, the scout is down — print
+   `scout cache stale or missing — run fleet-up` and exit. Do not
+   fall back to direct `gh`/`git` calls.
+4. Print a one-line summary: which `[sonnet]` items in
+   `tasks.open[]` look unblocked (`owner == "free"`, `blocked_by`
+   resolves to `(none)` or merged work) and not currently claimed
+   in any open PR (cross-check against `prs[].title` and
+   `prs[].headRefName`).
 
 ## Loop behavior
 
@@ -99,8 +122,13 @@ Each iteration:
    steps (fleet-build, fleet-run, commit-and-push) to prevent false
    staleness alerts during builds or PR actions.
 
-1. **Check for feedback labels on open PRs.**
-   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "human:blocker" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'`
+1. **Check for feedback labels on open PRs.** Re-Read
+   `~/.fleet/state/state.json` if its contents are no longer in your
+   conversation context. From `repos.engine.prs[]`, pick PRs whose
+   `labels` array contains any of `human:needs-fix`,
+   `human:blocker`, `fleet:needs-fix`, `fleet:has-nits`. (Cached
+   equivalent of the previous `gh pr list ... --jq 'select(.labels
+   ...)'` chain — same filter, no API call.)
 
    **Skip** PRs labeled `human:wip` — human is working on it directly.
 
@@ -177,9 +205,13 @@ Each iteration:
     - `Linux` → host key `linux`, poll `fleet:needs-linux-smoke`
     - `Darwin` → host key `macos`, poll `fleet:needs-macos-smoke`
 
-    ```
-    gh pr list --repo jakildev/IrredenEngine --state open --label "fleet:needs-<host>-smoke" --json number,title,headRefName,labels --jq '.[] | select(.labels | map(.name) | any(. == "fleet:approved")) | select(.labels | map(.name) | all(. != "fleet:needs-fix" and . != "fleet:blocker" and . != "human:wip" and . != "fleet:wip" and . != "fleet:merger-cooldown" and . != "human:needs-fix")) | "#\(.number) \(.title) (\(.headRefName))"'
-    ```
+    From the cached `repos.engine.prs[]`, pick PRs whose `labels`
+    array contains BOTH `fleet:needs-<host>-smoke` AND
+    `fleet:approved`, and contains NONE of `fleet:needs-fix`,
+    `fleet:blocker`, `human:wip`, `fleet:wip`,
+    `fleet:merger-cooldown`, `human:needs-fix`. (Cached equivalent
+    of the previous `gh pr list --label fleet:needs-<host>-smoke
+    ... --jq` chain — same filter, no API call.)
 
     The filter keeps only PRs that are approved, not flagged for
     fixes, and not claimed by the human. If the list is empty, skip
@@ -263,13 +295,15 @@ Each iteration:
      there's nothing to archive, so it's safe in any batch). Then
      proceed with the normal pickup flow.
 
-   **Normal pickup (no active molecule):** Read `TASKS.md` (use the
-   Read tool) and find the first `[ ]` `[sonnet]`-tagged item in
-   `## Open` whose:
+   **Normal pickup (no active molecule):** Re-Read
+   `~/.fleet/state/state.json` if its contents are no longer in your
+   conversation context. From `repos.engine.tasks.open[]`, find the
+   first row with `status == " "` (open) and `model` containing
+   `sonnet` whose:
    - **Owner** is `free` (or your worktree name)
    - **Blocked by** is empty (or only references already-merged work)
    - **Title is NOT referenced in any open PR's title or branch name**
-     (cross-check with the `gh pr list` output)
+     (cross-check against `repos.engine.prs[]` from the cache)
 
    **Deterministic pickup — only these signals count:**
    - The task's `Owner:` field in TASKS.md

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -34,6 +34,31 @@ Common patterns and their correct alternatives:
   write within the worktree (e.g. `.review-body.md`), not to `/tmp`.
   The sandbox may block writes outside the project tree.
 
+## Shared fleet state cache
+
+The `fleet-state-scout` daemon (started by `fleet-up`) refreshes
+`~/.fleet/state/state.json` every ~60s with both repos' open PRs
+(including their reviews and labels). **This cache is the source of
+truth for list-y queries — do NOT bypass it for `gh pr list` when
+the cache is fresh.** One Read tool call replaces what used to be
+two `gh pr list` invocations per iteration.
+
+Schema (slices this role uses):
+- `repos.{engine,game}.prs[]` — `number`, `title`, `headRefName`,
+  `baseRefName`, `author` (login string), `labels` (sorted strings),
+  `mergeable`, `isDraft`, `reviews[]` (each with `author` login,
+  `body`, `state`, `submittedAt`).
+
+Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`,
+`gh api repos/.../comments`) stay inline — those pull live data the
+cache doesn't store (issue comment timeline). The cache covers
+list-shaped queries; live drill-in covers single-item drill-down.
+
+If `~/.fleet/state/state.json` is missing or its `generated_at` is
+more than ~5 minutes old, the scout daemon isn't running. Print
+`scout cache stale or missing — run fleet-up` and exit; do not
+silently fall back to direct `gh pr list` calls.
+
 ## Role
 
 You poll open PRs on **both repos** — the engine repo and the game
@@ -65,20 +90,28 @@ treat it as a hard rule for this role.
    `git -C ~/src/IrredenEngine fetch origin --quiet`
    `git checkout -B claude/sonnet-reviewer-scratch origin/master`
    `gh pr checkout` will rewrite this branch on each review.
-4. Fetch PR lists from both repos (each as a separate command):
-   `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
-   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,author,reviews,labels`
-   Print both results so we both see the current PR queues.
+4. **Read the shared fleet state cache** with the Read tool:
+   `~/.fleet/state/state.json`. One Read replaces the two `gh pr
+   list --json reviews,labels,...` calls that used to live here —
+   open PRs across both repos (with their reviews and labels) live
+   at `repos.engine.prs[]` and `repos.game.prs[]`.
+
+   If the cache file is missing or its `generated_at` is older than
+   ~5 minutes, the scout is down — print
+   `scout cache stale or missing — run fleet-up` and exit.
 5. Identify review candidates from both repos. A PR is a candidate if:
-   - It has **no fleet review yet** (no review from your GitHub user), OR
-   - It has the `human:re-review` label (human made changes and
+   - It has **no fleet review yet** — none of its `reviews[].author`
+     entries match the fleet's GitHub login, OR
+   - Its `labels` contains `human:re-review` (human made changes and
      explicitly requested re-review via the `request-re-review` skill), OR
-   - It has the `fleet:changes-made` label (author addressed feedback;
-     either the human or the fleet should re-verify — whichever gets
-     to it first), OR
+   - Its `labels` contains `fleet:changes-made` (author addressed
+     feedback; either the human or the fleet should re-verify —
+     whichever gets to it first), OR
    - It **previously had a fleet review** but the author pushed fixes
-     and commented "re-review please" (check the comments array for
-     this text after your last review).
+     and commented "re-review please" — for this last one, do a per-PR
+     `gh pr view <N> --comments` only when the other criteria didn't
+     already match (the comment timeline is per-item drill-in, not in
+     the cache).
 
    When picking up a `human:re-review` or `fleet:changes-made` PR,
    **immediately remove the label that triggered pickup** so another
@@ -110,9 +143,10 @@ iteration of polling, reviewing, and exiting cleanly:
    the helper instead of a direct `touch` avoids the `~`-expansion
    path-scope prompt that fires on the raw form.)
 
-1. Re-fetch PR lists from both repos (separate commands):
-   `gh pr list --state open --json number,title,headRefName,author,reviews,labels`
-   `gh pr list --repo <game-repo> --state open --json number,title,headRefName,author,reviews,labels`
+1. Re-Read `~/.fleet/state/state.json` if its contents are no
+   longer in your conversation context — both repos' open PRs (with
+   labels and reviews) live at `repos.engine.prs[]` and
+   `repos.game.prs[]`.
 2. Re-apply the same candidate criteria from startup step 5: pick up
    PRs with no fleet review, with `human:re-review`, with
    `fleet:changes-made` (remove the label on pickup), or with a "re-review please"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -8,10 +8,10 @@ normalized result atomically to ~/.fleet/state/state.json, and
 emits a per-role trigger file under ~/.fleet/state/triggers/
 whenever a role's projected view of the data has changed.
 
-This is purely additive infrastructure — no role files consume the
-cache yet (that's T-039) and fleet-babysit isn't trigger-aware yet
-(that's T-040). The only thing T-038 ships is the daemon itself
-plus the fleet-up / fleet-down / install.sh wiring.
+Role files now consume this cache (T-039). fleet-babysit is not yet
+trigger-aware (that's T-040) — roles read the cache on their normal
+polling interval until that lands. The daemon itself was shipped in
+T-038 (fleet-up / fleet-down / install.sh wiring).
 
 Source of truth: scripts/fleet/fleet-state-scout in the engine repo.
 Installed to ~/bin/fleet-state-scout by scripts/fleet/install.sh.

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -66,11 +66,27 @@ def run_capture(cmd, cwd=None):
     return proc.stdout
 
 
+REVIEW_BODY_HEAD = 1024
+REVIEW_BODY_TAIL = 1024
+
+
+def _truncate_review_body(body):
+    # Reviewer roles only need enough of the body to filter on phrases like
+    # "Opus recheck required" (typically near the end) and skim the gist
+    # (typically at the start). Storing full bodies bloats state.json since
+    # every role re-reads the cache each iteration; cap at head + tail with
+    # an ellipsis between when oversized.
+    if not body or len(body) <= REVIEW_BODY_HEAD + REVIEW_BODY_TAIL:
+        return body
+    return body[:REVIEW_BODY_HEAD] + "\n…[truncated]…\n" + body[-REVIEW_BODY_TAIL:]
+
+
 def fetch_prs(repo):
     out = run_capture([
         "gh", "pr", "list", "--repo", repo, "--state", "open",
         "--json",
-        "number,title,headRefName,baseRefName,author,labels,mergeable,isDraft",
+        "number,title,headRefName,baseRefName,author,labels,mergeable,"
+        "isDraft,reviews,updatedAt",
     ])
     if out is None:
         return []
@@ -82,6 +98,15 @@ def fetch_prs(repo):
     for pr in prs:
         pr["labels"] = sorted(label["name"] for label in pr.get("labels", []))
         pr["author"] = pr.get("author", {}).get("login", "")
+        pr["reviews"] = [
+            {
+                "author": rev.get("author", {}).get("login", ""),
+                "body": _truncate_review_body(rev.get("body", "")),
+                "state": rev.get("state", ""),
+                "submittedAt": rev.get("submittedAt", ""),
+            }
+            for rev in pr.get("reviews", [])
+        ]
     # gh's PR ordering is not stable run-to-run; sort by number so the
     # projection hash stays quiescent when nothing has actually changed.
     prs.sort(key=lambda pr: pr.get("number", 0))


### PR DESCRIPTION
## Summary
- Six fleet role files (`role-opus-worker.md`, `role-sonnet-author.md`, `role-sonnet-reviewer.md`, `role-opus-reviewer.md`, `role-queue-manager.md`, `role-merger.md`) now read `~/.fleet/state/state.json` for list-y state (open PRs, `fleet:needs-plan` issues, `human:approved` issues, parsed `TASKS.md`) instead of running their own `gh pr list` / `gh issue list` / `git show origin/master:TASKS.md` per iteration.
- `fleet-state-scout` extended to capture `reviews[]` (so reviewer roles can filter on review author/body/state) and `updatedAt` (so the merger's UNKNOWN-state refresh rule can run from cache). Review bodies are capped at 1 KB head + 1 KB tail to prevent a single oversized review from bloating the shared cache.
- Per-item drill-in (`gh pr view <N> --comments`, `gh pr diff <N>`, `gh issue view <N>`, `gh pr list --state merged`) stays inline — the cache only stores list-shaped data.
- Architect role files unchanged per task scope.

Each role file gains a "Shared fleet state cache" preamble describing the schema slice it consumes and a staleness fallback: if `state.json` is missing or `generated_at` is >5 minutes old, the role exits with `scout cache stale or missing — run fleet-up` rather than silently falling back to direct `gh`/`git` calls.

## Test plan
- [ ] `fleet-state-scout --once` produces `state.json` with `reviews[]` and `updatedAt` populated on each PR (verified locally — cache is 43 KB with 2 PRs across two repos and 24 KB of review bodies).
- [ ] One iteration of each affected role under the new instructions surfaces the same set of work items it would have via direct `gh pr list` / `gh issue list` / `git show TASKS.md` (smoke check — verified for opus-worker locally; reviewers/merger/queue-manager need a live fleet pass to confirm).
- [ ] Projector hashes stay quiescent across consecutive scout ticks when nothing has changed (verified — `no triggers (all projections unchanged)` on the second `--once`).
- [ ] Long review body (>2 KB) gets cached as `head…[truncated]…tail` rather than full content.

## Notes for reviewer
- The "Shared fleet state cache" preamble is duplicated across the six role files (with role-specific schema slices). Slash-command files don't support `include`, and the runtime loads each role as a single document, so consolidating into a partial isn't an option without changing the harness. Each role's schema-slice section is the part that genuinely differs.
- Alternative considered: pushing the label-filter logic from role prompts into named projections in `state.json` (e.g. `derived.feedback_prs[]`). Out of scope for T-039 — the projector functions already compute these slices internally for trigger hashing, so a follow-up could expose them. Filed as a possible follow-up rather than included here.
- Body-truncation cap (`REVIEW_BODY_HEAD = REVIEW_BODY_TAIL = 1024`) is a heuristic. Verdict lines like "Opus recheck required" typically live at the tail; the head preserves the gist. If a verdict line happens to land in the truncated middle of a >2 KB review, opus-reviewer can still drill in via `gh pr view <N> --comments` for the full text.

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)