### PR TITLE
T-001: add Linux CI build job to quality workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -60,7 +60,7 @@ jobs:
         run: cmake --preset linux-debug
 
       - name: Build tests
-        run: cmake --build --preset linux-tests
+        run: cmake --build --preset linux-tests --parallel
 
       - name: Run tests
         run: ctest --preset linux-default-tests

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,3 +38,32 @@ jobs:
 
       - name: Run tests
         run: ctest --preset windows-default-tests
+
+  linux-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gcc-13 g++-13 cmake ninja-build pkg-config \
+            libgl1-mesa-dev libglu1-mesa-dev xorg-dev \
+            libwayland-dev libxkbcommon-dev wayland-protocols \
+            libasound2-dev libpulse-dev libjack-jackd2-dev \
+            libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
+            libavdevice-dev libavfilter-dev
+
+      - name: Configure
+        run: cmake --preset linux-debug
+
+      - name: Build tests
+        run: cmake --build --preset linux-tests
+
+      - name: Run tests
+        run: ctest --preset linux-default-tests
+
+      - name: Build smoke target (IRShapeDebug)
+        run: cmake --build build --target IRShapeDebug -j $(nproc)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,7 +42,9 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5",
-        "IRREDEN_GRAPHICS_BACKEND": "OPENGL"
+        "IRREDEN_GRAPHICS_BACKEND": "OPENGL",
+        "CMAKE_C_COMPILER": "gcc-13",
+        "CMAKE_CXX_COMPILER": "g++-13"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Adds a `linux-build` job to `.github/workflows/quality.yml` running on `ubuntu-latest` (Ubuntu 24.04, GCC 13).
- Installs the system dependencies from `docs/AGENT_FLEET_SETUP.md §1a` (OpenGL/X11 headers, ALSA/Pulse/JACK for audio, FFmpeg, pkg-config).
- Configures with `cmake --preset linux-debug` (OpenGL backend), builds + runs `IrredenEngineTest` via the `linux-tests` preset and `linux-default-tests` CTest preset, then builds `IRShapeDebug` as a smoke target.

This gives the fleet a per-PR signal on whether the Linux/OpenGL path compiles. Any failures are the concrete items that T-001 Linux build maturation needs to address.

## Test plan
- [ ] CI job runs green (or its failures reveal specific Linux build errors to fix)
- [ ] Windows `quality-checks` job unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)