### PR TITLE
T-043: reviewer upstream approval gating for stacked PRs

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -155,16 +155,45 @@ iteration of polling, reviewing, and exiting cleanly:
    a. Read the existing Sonnet review in full first
       (`gh pr view <N> --comments`, add `--repo <game-repo>` for
       game PRs). Note what Sonnet flagged.
-   b. **Check whether the PR is stacked.** Every fleet PR today is
-      single-task, but stacked PRs (chains of dependent tasks) base off
-      a parent PR's branch rather than `master`. Detect with:
-      `gh pr view <N> --json baseRefName,body --jq '"\(.baseRefName)\n---\n\(.body)"'`
-      If the base is not `master` or the body carries a `Stacked on:`
-      line, this PR depends on the parent landing first. Review only
-      this PR's own diff (as always — `gh pr diff <N>` scopes to it).
-      Do not re-review the parent; it has its own PR, its own Sonnet
-      first pass, and possibly its own Opus pass. Note the stack
-      context in your review body.
+   b. **Stack awareness — gate on upstream status, then note context.**
+      A stacked PR's `baseRefName` IS its upstream PR's `headRefName`.
+      The candidate PR's own metadata already lives in the cache
+      loaded at step 1 of the iteration; read from there first and
+      fall back to live `gh` only when the cache misses.
+
+      1. **Detect stacking.** From the cached candidate PR, check
+         `baseRefName`. If it equals `"master"`, this is a standalone
+         PR — skip to step c with a normal review.
+
+      2. **Look up the upstream PR.** Search the same cache
+         (`repos.<repo>.prs[]`) for an entry whose `headRefName`
+         matches the candidate's `baseRefName`. A hit gives you the
+         upstream's `number` and `labels` for free. A miss means the
+         upstream is merged or closed; fall through to one live call:
+         `gh pr list --head "<baseRefName>" --state all --json number,state,mergedAt --jq '.[0]'`
+         (add `--repo <game-repo>` for game PRs).
+
+      3. **Decide based on upstream status:**
+         - **Upstream MERGED, or upstream OPEN with `fleet:approved`
+           or `human:approved`** — proceed to step c. Note the stack
+           context in the review body: "Stacked on #<U>; approval
+           assumes #<U> lands first."
+         - **Upstream OPEN without an approval label** (its `labels`
+           contains neither `fleet:approved` nor `human:approved`) —
+           gate this PR. Do NOT post a verdict:
+           - If the candidate's own `labels` already contains
+             `fleet:awaiting-upstream-review`, silently move on.
+           - Otherwise:
+             `gh pr edit <N> --add-label "fleet:awaiting-upstream-review"`
+             `gh pr comment <N> --body "Holding review: upstream PR #<U> is not yet approved. This stacked PR will be re-evaluated once the upstream lands an approval label."`
+             For game PRs add `--repo <game-repo>` to both.
+         - **Upstream not found, OR closed-not-merged** — the stack
+           is broken. Surface to the human:
+           `gh pr comment <N> --body "Stack issue: upstream PR for base \`<baseRefName>\` was not found or was closed without merging. Surfacing to the human — this PR likely needs to be re-targeted or closed."`
+           Do NOT add a verdict label.
+
+      `gh pr diff <N>` always scopes to this PR's own diff — do not
+      re-review the parent.
    c. **Engine PRs:** Invoke the `review-pr` skill on the PR.
       **Game PRs:** Read the diff with `gh pr diff <N> --repo
       <game-repo>` and review manually (you cannot check out game
@@ -185,8 +214,11 @@ iteration of polling, reviewing, and exiting cleanly:
       review actions on your own PRs.
    f. **Set the PR label** to match your verdict (add `--repo
       <game-repo>` for game PRs). The label is the primary signal
-      the human uses. Always remove stale labels first:
-      `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:approved"`
+      the human uses. Always remove stale labels first — the
+      remove list also clears `fleet:awaiting-upstream-review` so a
+      previously-gated stacked PR exits the gate cleanly when the
+      reviewer finally proceeds:
+      `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved"`
       (swap the label name for needs-fix or blocker as appropriate).
       - Verdict approve, no Nits section → `fleet:approved` only
       - Verdict approve WITH a non-empty `### Nits` section → BOTH

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -173,22 +173,30 @@ iteration of polling, reviewing, and exiting cleanly:
          `gh pr list --head "<baseRefName>" --state all --json number,state,mergedAt --jq '.[0]'`
          (add `--repo <game-repo>` for game PRs).
 
-      3. **Decide based on upstream status:**
+      3. **Already gated — check before deciding.** If the candidate's
+         own `labels` already contains `fleet:awaiting-upstream-review`:
+         - Re-check upstream status using the same cache-then-live-
+           fallback logic from step 2 above.
+         - If upstream is now approved or merged — remove the gate label
+           (`gh pr edit <N> --remove-label "fleet:awaiting-upstream-review"`)
+           and proceed to step c.
+         - Otherwise (still open-without-approval, OR now broken) —
+           silently skip. Do NOT post any additional comment.
+
+      4. **Decide based on upstream status** (gate label not present):
          - **Upstream MERGED, or upstream OPEN with `fleet:approved`
            or `human:approved`** — proceed to step c. Note the stack
            context in the review body: "Stacked on #<U>; approval
            assumes #<U> lands first."
          - **Upstream OPEN without an approval label** (its `labels`
            contains neither `fleet:approved` nor `human:approved`) —
-           gate this PR. Do NOT post a verdict:
-           - If the candidate's own `labels` already contains
-             `fleet:awaiting-upstream-review`, silently move on.
-           - Otherwise:
-             `gh pr edit <N> --add-label "fleet:awaiting-upstream-review"`
-             `gh pr comment <N> --body "Holding review: upstream PR #<U> is not yet approved. This stacked PR will be re-evaluated once the upstream lands an approval label."`
-             For game PRs add `--repo <game-repo>` to both.
+           add the gate label and post a hold-comment once:
+           `gh pr edit <N> --add-label "fleet:awaiting-upstream-review"`
+           `gh pr comment <N> --body "Holding review: upstream PR #<U> is not yet approved. This stacked PR will be re-evaluated once the upstream lands an approval label."`
+           For game PRs add `--repo <game-repo>` to both.
+           Do NOT post a verdict.
          - **Upstream not found, OR closed-not-merged** — the stack
-           is broken. Surface to the human:
+           is broken. Surface to the human once:
            `gh pr comment <N> --body "Stack issue: upstream PR for base \`<baseRefName>\` was not found or was closed without merging. Surfacing to the human — this PR likely needs to be re-targeted or closed."`
            Do NOT add a verdict label.
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -179,22 +179,30 @@ iteration of polling, reviewing, and exiting cleanly:
       `gh pr list --head "<baseRefName>" --state all --json number,state,mergedAt --jq '.[0]'`
       (add `--repo <game-repo>` for game PRs).
 
-   3. **Decide based on upstream status:**
+   3. **Already gated — check before deciding.** If the candidate's
+      own `labels` already contains `fleet:awaiting-upstream-review`:
+      - Re-check upstream status using the same cache-then-live-
+        fallback logic from step 2 above.
+      - If upstream is now approved or merged — remove the gate label
+        (`gh pr edit <N> --remove-label "fleet:awaiting-upstream-review"`)
+        and proceed to the review.
+      - Otherwise (still open-without-approval, OR now broken) —
+        silently skip. Do NOT post any additional comment.
+
+   4. **Decide based on upstream status** (gate label not present):
       - **Upstream MERGED, or upstream OPEN with `fleet:approved`
         or `human:approved`** — proceed with review. Note the stack
         context in the review body: "Stacked on #<U>; approval
         assumes #<U> lands first."
       - **Upstream OPEN without an approval label** (its `labels`
         contains neither `fleet:approved` nor `human:approved`) —
-        gate this PR. Do NOT post a verdict:
-        - If the candidate's own `labels` already contains
-          `fleet:awaiting-upstream-review`, silently move on.
-        - Otherwise:
-          `gh pr edit <N> --add-label "fleet:awaiting-upstream-review"`
-          `gh pr comment <N> --body "Holding review: upstream PR #<U> is not yet approved. This stacked PR will be re-evaluated once the upstream lands an approval label."`
-          For game PRs add `--repo <game-repo>` to both.
+        add the gate label and post a hold-comment once:
+        `gh pr edit <N> --add-label "fleet:awaiting-upstream-review"`
+        `gh pr comment <N> --body "Holding review: upstream PR #<U> is not yet approved. This stacked PR will be re-evaluated once the upstream lands an approval label."`
+        For game PRs add `--repo <game-repo>` to both.
+        Do NOT post a verdict.
       - **Upstream not found, OR closed-not-merged** — the stack is
-        broken. Surface to the human:
+        broken. Surface to the human once:
         `gh pr comment <N> --body "Stack issue: upstream PR for base \`<baseRefName>\` was not found or was closed without merging. Surfacing to the human — this PR likely needs to be re-targeted or closed."`
         Do NOT add a verdict label.
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -161,16 +161,45 @@ iteration of polling, reviewing, and exiting cleanly:
    task's branch instead of `master`; each one gets its own independent
    review and label.
 
-   **Stack awareness:** before invoking the skill, check whether this
-   PR is stacked on a parent PR (it will be if its base branch is not
-   `master` or its body carries a `Stacked on:` line):
-   `gh pr view <N> --json baseRefName,body --jq '"\(.baseRefName)\n---\n\(.body)"'`
-   If it is stacked, review only this PR's own diff (`gh pr diff <N>`
-   already scopes to it — don't pull in the parent's changes) and note
-   the stack context in your review body: "Stacked on #<parent>;
-   approval assumes #<parent> lands first." Do not re-review the
-   parent — it has its own PR and its own review. The `review-pr`
-   skill handles this as part of its normal flow.
+   **Stack awareness — gate on upstream status, then note context.**
+   A stacked PR's `baseRefName` IS its upstream PR's `headRefName`.
+   The candidate PR's own metadata already lives in the cache loaded
+   at the start of the iteration; read from there first and fall
+   back to live `gh` only when the cache misses.
+
+   1. **Detect stacking.** From the cached candidate PR, check
+      `baseRefName`. If it equals `"master"`, this is a standalone
+      PR — skip to the engine/game branch below and review normally.
+
+   2. **Look up the upstream PR.** Search the same cache
+      (`repos.<repo>.prs[]`) for an entry whose `headRefName`
+      matches the candidate's `baseRefName`. A hit gives you the
+      upstream's `number` and `labels` for free. A miss means the
+      upstream is merged or closed; fall through to one live call:
+      `gh pr list --head "<baseRefName>" --state all --json number,state,mergedAt --jq '.[0]'`
+      (add `--repo <game-repo>` for game PRs).
+
+   3. **Decide based on upstream status:**
+      - **Upstream MERGED, or upstream OPEN with `fleet:approved`
+        or `human:approved`** — proceed with review. Note the stack
+        context in the review body: "Stacked on #<U>; approval
+        assumes #<U> lands first."
+      - **Upstream OPEN without an approval label** (its `labels`
+        contains neither `fleet:approved` nor `human:approved`) —
+        gate this PR. Do NOT post a verdict:
+        - If the candidate's own `labels` already contains
+          `fleet:awaiting-upstream-review`, silently move on.
+        - Otherwise:
+          `gh pr edit <N> --add-label "fleet:awaiting-upstream-review"`
+          `gh pr comment <N> --body "Holding review: upstream PR #<U> is not yet approved. This stacked PR will be re-evaluated once the upstream lands an approval label."`
+          For game PRs add `--repo <game-repo>` to both.
+      - **Upstream not found, OR closed-not-merged** — the stack is
+        broken. Surface to the human:
+        `gh pr comment <N> --body "Stack issue: upstream PR for base \`<baseRefName>\` was not found or was closed without merging. Surfacing to the human — this PR likely needs to be re-targeted or closed."`
+        Do NOT add a verdict label.
+
+   `gh pr diff <N>` always scopes to this PR's own diff — do not
+   re-review the parent.
 
    **Game PRs** (`<game-repo>`):
    a. Read the diff: `gh pr diff <N> --repo <game-repo>`
@@ -207,18 +236,22 @@ iteration of polling, reviewing, and exiting cleanly:
    Always remove stale verdict labels before adding the new one. For
    game PRs, add `--repo <game-repo>` to the gh pr edit call.
 
+   Each verdict command also removes `fleet:awaiting-upstream-review`
+   so a previously-gated stacked PR exits the gate cleanly when the
+   reviewer finally proceeds.
+
    ```
    # Verdict approve, no Nits section:
-   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:approved"
+   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved"
 
    # Verdict approve WITH a non-empty `### Nits` section (also set fleet:has-nits):
-   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved" --add-label "fleet:has-nits"
+   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved" --add-label "fleet:has-nits"
 
    # Verdict needs-fix:
-   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"
+   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:needs-fix"
 
    # Verdict blocker:
-   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --add-label "fleet:blocker"
+   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:blocker"
 
    # Re-review of a previously fleet:has-nits PR that's now clean:
    #   removes the has-nits flag while keeping fleet:approved

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -325,20 +325,22 @@ you need to be sure).
 a PR should have exactly one verdict label (`fleet:approved` /
 `fleet:needs-fix` / `fleet:blocker`) at any time. The
 `fleet:has-nits` label is orthogonal — it can ride on top of
-`fleet:approved`.
+`fleet:approved`. The remove list also clears
+`fleet:awaiting-upstream-review` so a previously-gated stacked PR
+exits the gate cleanly when the reviewer finally proceeds.
 
 ```bash
 # For approve, no nits in body:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:approved"
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved"
 
 # For approve WITH a non-empty Nits section in the body:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --add-label "fleet:approved" --add-label "fleet:has-nits"
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved" --add-label "fleet:has-nits"
 
 # For needs-fix (nits roll into the fix work; no separate label):
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:needs-fix"
 
 # For blocker:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --add-label "fleet:blocker"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:blocker"
 ```
 
 The verdict label is the **primary signal** the human uses to decide

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -108,6 +108,7 @@ LABELS=(
     "fleet:stacked|c5def5|PR's base is a feature branch (stacked PR)"
     "fleet:awaiting-base|c5def5|Stacked PR; merger is waiting for base PR to merge"
     "fleet:stacked-rebase|c5def5|Stacked PR; base just merged, re-targeted to master, awaiting reviewer re-eval"
+    "fleet:awaiting-upstream-review|c5def5|Stacked PR; reviewer is holding verdict until upstream PR is approved"
     "human:wip|5319e7|Human is editing the PR directly; agents stand off"
     "human:approved|0e8a16|Human approved the PR (overrides agent verdict)"
     "human:needs-fix|d4c5f9|Human flagged a fix request; agent should address"


### PR DESCRIPTION
## Summary
- Adds `fleet:awaiting-upstream-review` label to the catalog.
- Both reviewer roles (sonnet + opus) and the `review-pr` skill now gate stacked-PR review on upstream approval: cache-first lookup of the upstream by `headRefName`, with one live `gh pr list --state all` fallback only when the cache misses.
- Verdict-label commands clear the gate label as part of the normal `--remove-label` set so a previously-gated PR exits the gate cleanly the first time it lands a verdict.

## Behavior
- **Upstream MERGED, or OPEN with `fleet:approved` / `human:approved`** → proceed with review; note the stack context in the body.
- **Upstream OPEN without an approval label** → gate: add `fleet:awaiting-upstream-review`, post a hold-comment once, skip the verdict. Subsequent iterations silently skip while the gate persists.
- **Upstream not found, OR closed-not-merged** → broken stack; surface to the human and skip.

## Test plan
- [ ] Once `fleet-up` re-runs `fleet-labels`, the `fleet:awaiting-upstream-review` label exists on engine + game repos.
- [ ] Open a stacked PR while its upstream has `fleet:needs-fix`: reviewer adds `fleet:awaiting-upstream-review` and posts the hold-comment, no verdict label set.
- [ ] Re-approve the upstream: next reviewer pass on the downstream proceeds normally; verdict-label command removes `fleet:awaiting-upstream-review` and adds `fleet:approved`.
- [ ] Standalone PR (base=`master`): no gating, normal review flow.

## Notes for reviewer
- T-043 is part of the issue #289 5-task stacked-PR vision stack. This is the third task; T-041/T-042 already merged. T-044 / T-045 follow.
- `scripts/fleet/fleet-labels --dry-run` confirms the new label entry parses (22 existed, 1 would be created).
- The gating logic is intentionally duplicated across both reviewer role files, mirroring the existing pattern (the `review-pr` skill also carries its own copy of the verdict-label commands).

Part of #289 (T-043 only; T-044/T-045 will land in follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)