### PR TITLE
fleet: post-audit cleanup — nine bugs across roles, skills, scripts

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -157,9 +157,16 @@ a task. Wait for explicit human instruction.
 ## Filing tasks
 
 When you identify work that needs doing — by you, a Sonnet agent, or
-anyone — file it as a GitHub issue with the `fleet:task` label:
+anyone — file it as a GitHub issue **with NO labels**:
 
-`gh issue create --repo jakildev/IrredenEngine --title "<short title>" --label "fleet:task" --body "<description>"`
+`gh issue create --repo jakildev/IrredenEngine --title "<short title>" --body "<description>"`
+
+Do NOT pre-apply `fleet:task`, `fleet:queued`, `fleet:needs-plan`, or
+any other state label. Per CLAUDE.md "Issue/PR labeling discipline":
+state labels are owned by specific roles (queue-manager, reviewers,
+the human). Author-side filing should add zero labels and let the
+human stamp `human:approved` when they want it picked up. The
+queue-manager adds the appropriate state labels post-triage.
 
 Include in the body:
 - **Area** (e.g. `engine/render`, `engine/math`, `docs`)

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -211,10 +211,14 @@ iteration of polling, reviewing, and exiting cleanly:
       not duplicate work Sonnet already did. Your review body should
       explicitly call out the Sonnet review by saying "Sonnet flagged
       X; on closer read I confirm/disagree because Y".
-   e. Post the review: write the review body to `/tmp/review-body.md`
-      using the **Write tool**, then:
-      `gh pr review <N> --comment --body-file /tmp/review-body.md`
+   e. Post the review: write the review body to `.review-body.md`
+      (worktree-local) using the **Write tool**, then:
+      `gh pr review <N> --comment --body-file .review-body.md`
       For game PRs, add `--repo <game-repo>`.
+      Do NOT write to `/tmp/...` — Claude Code's sandbox blocks Write
+      to paths outside the worktree even if `/tmp` is in
+      `additionalDirectories` (the gate is broader than path matching).
+      The `.review-body.md` filename is gitignored.
       **Never** use `--body "$(cat ...)"` or `--body "<text>"` — shell
       escaping of backticks and special characters causes parse errors.
       Do **not** use `--approve` or `--request-changes` — all fleet
@@ -222,11 +226,14 @@ iteration of polling, reviewing, and exiting cleanly:
       review actions on your own PRs.
    f. **Set the PR label** to match your verdict (add `--repo
       <game-repo>` for game PRs). The label is the primary signal
-      the human uses. Always remove stale labels first — the
-      remove list also clears `fleet:awaiting-upstream-review` so a
-      previously-gated stacked PR exits the gate cleanly when the
-      reviewer finally proceeds:
-      `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved"`
+      the human uses. Always remove stale labels first. Two labels
+      are also cleared here as part of the verdict:
+      - `fleet:awaiting-upstream-review` — a previously-gated stacked
+        PR exits the gate cleanly when the reviewer finally proceeds.
+      - `fleet:stacked-rebase` — set by merger when a stacked PR's
+        base just merged and got re-targeted to master; your re-eval
+        after the re-target is exactly what that label is waiting for.
+      `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved"`
       (swap the label name for needs-fix or blocker as appropriate).
       - Verdict approve, no Nits section → `fleet:approved` only
       - Verdict approve WITH a non-empty `### Nits` section → BOTH

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -51,10 +51,10 @@ Schema (slices this role uses):
   parsing keeps a per-item `gh pr view <N> --json body` inline.
 - `repos.{engine,game}.human_approved[]` — open issues with
   `human:approved` label, MINUS the ones the scout already filters
-  (`fleet:task`, `fleet:queued`). Each entry has `number`, `title`,
-  `labels` — to match the queue-manager's full ingest search,
-  additionally filter out entries whose `labels` include
-  `fleet:needs-plan` or `fleet:needs-info`.
+  (`fleet:queued`). Each entry has `number`, `title`, `labels` — to
+  match the queue-manager's full ingest search, additionally filter
+  out entries whose `labels` include `fleet:needs-plan` or
+  `fleet:needs-info`.
 - `repos.{engine,game}.needs_plan[]` — open issues with
   `fleet:needs-plan` label. `number`, `title`, `labels`.
 - `repos.{engine,game}.tasks.{open,in_progress,done}[]` — `status`,
@@ -287,12 +287,11 @@ You are the sole TASKS.md editor. Each maintenance pass:
 2. **Ingest triaged issues (engine repo).** Re-Read
    `~/.fleet/state/state.json` if its contents are no longer in your
    conversation context. From `repos.engine.human_approved[]`
-   (already filtered by the scout to exclude `fleet:queued` and
-   `fleet:task`), drop any entry whose `labels` include
-   `fleet:needs-plan` or `fleet:needs-info` — that matches the
-   previous `gh issue list ... --search "label:human:approved
-   -label:fleet:queued -label:fleet:needs-plan
-   -label:fleet:needs-info"` query exactly.
+   (already filtered by the scout to exclude `fleet:queued`), drop
+   any entry whose `labels` include `fleet:needs-plan` or
+   `fleet:needs-info` — that matches the previous `gh issue list
+   ... --search "label:human:approved -label:fleet:queued
+   -label:fleet:needs-plan -label:fleet:needs-info"` query exactly.
 
    The cache only stores list-shaped data (number, title, labels),
    so for each candidate fetch the body and comments per-item:

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -80,7 +80,11 @@ whatever directory the task touches before editing anything.
 0. Print your role banner:
    `[sonnet-author] Picks bounded [sonnet] tasks from TASKS.md, works them end-to-end, opens PRs. Runs continuously.`
 1. `pwd` and confirm you are in a sonnet-fleet worktree (not the main
-   clone, not a reviewer worktree).
+   clone, not a reviewer worktree). The directory basename
+   (`sonnet-fleet-1` today, but parameterized so a future
+   `sonnet-fleet-2` works without a doc rewrite) is your **agent
+   name** — substitute it everywhere this file says
+   `<your-worktree-basename>` (heartbeat name, scratch branch suffix).
 2. `git -C ~/src/IrredenEngine fetch origin --quiet` — pulls refs
    for later `git checkout`/`git rebase`; the cache snapshots TASKS.md
    and PR metadata but doesn't fetch refs.
@@ -114,13 +118,15 @@ earlier work.
 Each iteration:
 
 0. **Write heartbeat** — signal to the witness monitor that this agent is alive:
-   `fleet-heartbeat sonnet-fleet-1`
-   (Wrapper script around `touch ~/.fleet/heartbeats/<role>`. Using
-   the helper instead of a direct `touch` avoids the `~`-expansion
-   path-scope prompt that fires on the raw form.)
-   Also re-run `fleet-heartbeat sonnet-fleet-1` before long-running
-   steps (fleet-build, fleet-run, commit-and-push) to prevent false
-   staleness alerts during builds or PR actions.
+   `fleet-heartbeat <your-worktree-basename>`
+   (e.g. `fleet-heartbeat sonnet-fleet-1` — substitute the basename
+   from your `pwd` at startup. Wrapper script around
+   `touch ~/.fleet/heartbeats/<role>`. Using the helper instead of a
+   direct `touch` avoids the `~`-expansion path-scope prompt that
+   fires on the raw form.)
+   Also re-run `fleet-heartbeat <your-worktree-basename>` before
+   long-running steps (fleet-build, fleet-run, commit-and-push) to
+   prevent false staleness alerts during builds or PR actions.
 
 1. **Check for feedback labels on open PRs.** Re-Read
    `~/.fleet/state/state.json` if its contents are no longer in your
@@ -216,8 +222,9 @@ Each iteration:
     The filter keeps only PRs that are approved, not flagged for
     fixes, and not claimed by the human. If the list is empty, skip
     to step 2. Otherwise, pick the oldest (smallest number), then:
-    a. Re-touch heartbeat (`fleet-heartbeat sonnet-fleet-1`) — the
-       build can take minutes and you don't want the witness to alarm.
+    a. Re-touch heartbeat (`fleet-heartbeat <your-worktree-basename>`)
+       — the build can take minutes and you don't want the witness to
+       alarm.
     b. Check out the PR: `gh pr checkout <N> --repo jakildev/IrredenEngine`
     c. Build the demo smoke target: `fleet-build --target IRShapeDebug`.
        If the PR breaks that build, the smoke has failed — jump to
@@ -237,7 +244,9 @@ Each iteration:
        `gh pr comment <N> --repo jakildev/IrredenEngine --body "Cross-host smoke FAILED on <host>: <one-line symptom>. Details: <attach log excerpt>"`
        `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:approved" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"`
     g. Reset to scratch branch before continuing:
-       `git checkout -B claude/sonnet-fleet-1-scratch origin/master`
+       `git checkout -B claude/<your-worktree-basename>-scratch origin/master`
+       (e.g. `claude/sonnet-fleet-1-scratch` for the sonnet-fleet-1
+       worktree.)
 
     Validate ONE PR per iteration. Multiple outstanding render PRs
     are handled across successive iterations so task pickup isn't
@@ -473,9 +482,10 @@ Each iteration:
    - The public `ir_*.hpp` surface across multiple modules
    - Lifetime/ownership decisions
 
-   STOP. File a GitHub issue for the opus work and note the escalation
+   STOP. File a GitHub issue for the opus work (no labels — see
+   CLAUDE.md "Issue/PR labeling discipline") and note the escalation
    on your PR:
-   `gh issue create --repo jakildev/IrredenEngine --title "<what needs opus attention>" --label "fleet:task" --body "Escalated from sonnet. Area: ... Suggested model: [opus]. Context: ..."`
+   `gh issue create --repo jakildev/IrredenEngine --title "<what needs opus attention>" --body "Escalated from sonnet. Area: ... Suggested model: [opus]. Context: ..."`
    Then comment on your PR: "escalated — filed issue #N for opus".
    The human will triage the issue and add `human:approved` when
    ready. The queue-manager then adds it to TASKS.md. Move on to the

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -216,9 +216,11 @@ iteration of polling, reviewing, and exiting cleanly:
       this engine worktree). Focus on code quality, style, and obvious
       bugs. For game-specific conventions, read the game CLAUDE.md at
       `~/src/IrredenEngine/creations/game/CLAUDE.md`.
-   d. Post the review: write the review body to `/tmp/review-body.md`
-      using the **Write tool**, then:
-      `gh pr review <N> --repo <game-repo> --comment --body-file /tmp/review-body.md`
+   d. Post the review: write the review body to `.review-body.md`
+      (worktree-local) using the **Write tool**, then:
+      `gh pr review <N> --repo <game-repo> --comment --body-file .review-body.md`
+      Do NOT write to `/tmp/...` — Claude Code's sandbox blocks Write
+      to paths outside the worktree. `.review-body.md` is gitignored.
       **Never** use `--body "$(cat ...)"` or `--body "<text>"` — shell
       escaping of backticks and special characters causes parse errors.
 
@@ -242,24 +244,30 @@ iteration of polling, reviewing, and exiting cleanly:
    after the edit, if you want to be sure).
 
    Always remove stale verdict labels before adding the new one. For
-   game PRs, add `--repo <game-repo>` to the gh pr edit call.
+   game PRs, add `--repo <game-repo>` to the gh pr edit call. Each
+   verdict also clears `fleet:stacked-rebase` (set by the merger
+   when a stacked PR's base just merged and got re-targeted to
+   master) — your re-eval after the re-target IS the action that
+   label is waiting for, regardless of which verdict you reach.
 
    Each verdict command also removes `fleet:awaiting-upstream-review`
-   so a previously-gated stacked PR exits the gate cleanly when the
-   reviewer finally proceeds.
+   (so a previously-gated stacked PR exits the gate when the reviewer
+   finally proceeds) AND `fleet:stacked-rebase` (set by merger when a
+   stacked PR's base just merged and got re-targeted to master — the
+   reviewer's re-eval is what that label is waiting for).
 
    ```
    # Verdict approve, no Nits section:
-   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved"
+   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved"
 
    # Verdict approve WITH a non-empty `### Nits` section (also set fleet:has-nits):
-   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved" --add-label "fleet:has-nits"
+   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved" --add-label "fleet:has-nits"
 
    # Verdict needs-fix:
-   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:needs-fix"
+   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:needs-fix"
 
    # Verdict blocker:
-   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:blocker"
+   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:blocker"
 
    # Re-review of a previously fleet:has-nits PR that's now clean:
    #   removes the has-nits flag while keeping fleet:approved

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -138,12 +138,12 @@ If you're already on a feature branch, just use it. Do not rename mid-session.
 
 ### 3. Pre-commit checks and `simplify`
 
-**First**, run the **Rebase guard** check (see section below): use the
-**Read** tool on `/tmp/fleet-prerebase.diff`. If the file exists, a
-pre-capture was taken before a recent rebase — run the post-capture and
-comparison as described in the Rebase guard section. If missing, check
-`git reflog --since=2.hours.ago` for a recent rebase entry; if found,
-warn and inspect manually before proceeding.
+**First**, run the **Rebase guard** check (see section below): if you
+saved a pre-capture earlier in this conversation (a `git diff
+origin/master` snapshot before rebasing), compare it now against a
+fresh `git diff origin/master`. If you don't have that snapshot in
+context, check `git reflog --since=2.hours.ago` for a recent rebase
+entry; if found, warn and inspect manually before proceeding.
 
 **Second**, check whether the diff touches visual/render files:
 
@@ -389,16 +389,22 @@ if the user already asked for the next task).
 
 ## Rebase guard
 
-**Before rebasing this PR branch onto origin/master**, always capture the
-current diff first. Git's 3-way merge can silently drop hunks from non-
-conflicting regions of a file when a different region of the same file has
-a conflict — no conflict markers, no warning in the rebase output.
+**Before rebasing this PR branch onto origin/master**, always capture
+the current diff first. Git's 3-way merge can silently drop hunks
+from non-conflicting regions of a file when a different region of the
+same file has a conflict — no conflict markers, no warning in the
+rebase output.
+
+Do NOT use `>` redirects to `/tmp/` (or any path) — Claude Code's Bash
+tool blocks shell redirects regardless of destination. Both snapshots
+live in your conversation context as Bash output; large diffs auto-
+persist to a `<persisted-output>` link the next iteration can Read.
+(Same rule that role-merger.md uses for its rebase guard.)
 
 ### Pre-capture (do this BEFORE `git rebase origin/master`)
 
-```bash
-git diff origin/master > /tmp/fleet-prerebase.diff
-```
+Run `git diff origin/master` and keep the output in your conversation
+context — you'll compare it to the post-rebase snapshot below.
 
 ### Rebase and resolve conflicts
 
@@ -406,17 +412,14 @@ Run `git rebase origin/master`. Resolve any conflict markers normally.
 
 ### Post-capture and comparison
 
-```bash
-git diff origin/master > /tmp/fleet-postrebase.diff
-diff /tmp/fleet-prerebase.diff /tmp/fleet-postrebase.diff
-```
+Run `git diff origin/master` again. Compare to the pre-capture above:
+look for lines beginning with `+` in the pre-capture that are absent
+from the post-capture. Each such gap is a silently dropped hunk that
+must be manually re-applied before committing.
 
-Scan the `diff` output for lines beginning with `< +` — additions that were
-present in the pre-rebase state but are absent after. Each is a dropped hunk
-that must be manually re-applied before committing.
-
-If every line of `diff` output is a metadata change (index hashes, commit
-SHAs, `@@` hunk header offset shifts), no content was lost.
+For huge diffs that don't fit cleanly in context, both snapshots get
+auto-persisted by Claude Code; Read the persisted-output files to
+diff them with the Read tool's `offset`/`limit`.
 
 ### If the pre-capture was skipped
 

--- a/.claude/skills/request-re-review/SKILL.md
+++ b/.claude/skills/request-re-review/SKILL.md
@@ -1,3 +1,13 @@
+---
+description: >-
+  Push changes on the current PR branch and request a fleet re-review.
+  Use when the user says "request re-review", "push and re-review",
+  "push for re-review", "I'm done with this PR have the fleet
+  re-review", or "update PR and get it reviewed again". Also useful
+  when the user has manually edited a PR branch in any pane and wants
+  the fleet review pipeline to pick it back up.
+---
+
 # request-re-review
 
 Push changes on the current PR branch and request a fleet re-review.
@@ -46,7 +56,10 @@ git status --porcelain
 ```
 
 If there are changes:
-- Stage all modified/added files: `git add -A`
+- Stage specific files by path (e.g. `git add engine/.../foo.cpp`).
+  Do NOT use `git add -A` or `git add .` — risks staging secrets,
+  build artifacts, or unrelated stray edits in the worktree.
+  `commit-and-push` enforces the same rule; this skill follows it.
 - Commit with a descriptive message:
   `git commit -m "changes from human review session"`
 - Push: `git push`

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -329,18 +329,23 @@ a PR should have exactly one verdict label (`fleet:approved` /
 `fleet:awaiting-upstream-review` so a previously-gated stacked PR
 exits the gate cleanly when the reviewer finally proceeds.
 
+Each verdict also clears `fleet:stacked-rebase` (set by the merger
+when a stacked PR's base just merged and got re-targeted to master)
+— the re-eval after the re-target IS the action that label is
+waiting for, regardless of which verdict you reach.
+
 ```bash
 # For approve, no nits in body:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved"
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved"
 
 # For approve WITH a non-empty Nits section in the body:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:approved" --add-label "fleet:has-nits"
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved" --add-label "fleet:has-nits"
 
 # For needs-fix (nits roll into the fix work; no separate label):
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:needs-fix"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:needs-fix"
 
 # For blocker:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --add-label "fleet:blocker"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:blocker"
 ```
 
 The verdict label is the **primary signal** the human uses to decide

--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -220,7 +220,15 @@ trap on_sigint INT TERM
 # happens after `commit-and-push` succeeds and the WIP label is
 # removed — gives in-flight work a chance to land cleanly.
 #
-# We poll fleet-claim list (filtering out _stack_* metadata dirs).
+# We poll fleet-claim list and filter out `_stack_*` metadata dirs
+# (created by `fleet-claim stack` to track which tasks are part of a
+# given stack — they're internal markers, not in-flight work). Without
+# this filter --wait would never see "all claims released" while a
+# stack metadata dir still exists, even after every member task has
+# released its own claim. fleet-claim's `cmd_list` itself doesn't
+# filter — that would be a behavior change for other callers — so we
+# filter here at the consumption site.
+#
 # When the count drops to zero, all workers are between tasks and
 # safe to shut down.
 
@@ -235,7 +243,7 @@ count_active_claims() {
         echo 0
         return
     fi
-    echo "$out" | grep -v "^$" | wc -l | tr -d ' '
+    echo "$out" | grep -v "^$" | grep -v "_stack_" | wc -l | tr -d ' '
 }
 
 if [[ "$WAIT_FOR_IDLE" -eq 1 ]]; then

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -113,7 +113,7 @@ def fetch_prs(repo):
     return prs
 
 
-_ALREADY_QUEUED_LABELS = frozenset({"fleet:task", "fleet:queued"})
+_ALREADY_QUEUED_LABELS = frozenset({"fleet:queued"})
 
 
 def fetch_issues_by_label(repo, filter_label, exclude_labels=None):

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -371,10 +371,14 @@ fi
 # ----------------------------------------------------------------------
 #
 # Polls GitHub + git every 60s and writes `~/.fleet/state/state.json`
-# plus per-role trigger files under `~/.fleet/state/triggers/`. Pure
-# additive infra — no role currently consumes the cache (T-039
-# follow-up). Backgrounded with nohup, PID written to scout.pid for
-# fleet-down to terminate cleanly.
+# plus per-role trigger files under `~/.fleet/state/triggers/`. Roles
+# (sonnet-author, opus-worker, sonnet-reviewer, opus-reviewer,
+# queue-manager, merger) read state.json instead of running their own
+# `gh pr list` / `git show` calls — see each role's "Shared fleet
+# state cache" section. The trigger files are emitted but not yet
+# consumed by babysit (the trigger-aware back-off planned by #272 is
+# still pending). Backgrounded with nohup, PID written to scout.pid
+# for fleet-down to terminate cleanly.
 scout_cmd=""
 if command -v fleet-state-scout >/dev/null 2>&1; then
     scout_cmd="fleet-state-scout"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -375,9 +375,9 @@ fi
 # (sonnet-author, opus-worker, sonnet-reviewer, opus-reviewer,
 # queue-manager, merger) read state.json instead of running their own
 # `gh pr list` / `git show` calls — see each role's "Shared fleet
-# state cache" section. The trigger files are emitted but not yet
-# consumed by babysit (the trigger-aware back-off planned by #272 is
-# still pending). Backgrounded with nohup, PID written to scout.pid
+# state cache" section. The trigger files are emitted and consumed by
+# babysit — trigger-aware back-off is live (T-040 / PR #300).
+# Backgrounded with nohup, PID written to scout.pid
 # for fleet-down to terminate cleanly.
 scout_cmd=""
 if command -v fleet-state-scout >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Comprehensive sanity-check pass over all landed fleet code — scripts,
role docs, skills, CLAUDE.md, and label cross-references. Four parallel
audit agents combed the surface area; this PR fixes the nine concrete
issues that surfaced. The rest is healthy.

| # | Severity | What | Where |
|---|---|---|---|
| 1 | blocker | Reviewers writing review body to `/tmp` (sandbox blocks) | role-opus-reviewer.md, role-sonnet-reviewer.md |
| 2 | blocker | Authors pre-applying `fleet:task` (CLAUDE.md forbids) | role-opus-architect.md, role-sonnet-author.md |
| 3 | blocker | Rebase guard `git diff > /tmp/...` redirect (banned by PR #281) | commit-and-push SKILL.md |
| 4 | needs-fix | Skill registry shows `request-re-review: request-re-review` (no description) | request-re-review SKILL.md (missing YAML frontmatter) |
| 5 | needs-fix | `git add -A` in skill (commit-and-push explicitly bans it) | request-re-review SKILL.md |
| 6 | needs-fix | `fleet:stacked-rebase` set by merger but never cleared by anyone | role-sonnet-reviewer.md, role-opus-reviewer.md, review-pr SKILL.md |
| 7 | needs-fix | `_stack_*` claim metadata leaks into `fleet-down --wait` count | fleet-down |
| 8 | nit | `fleet-up` scout-launch comment claims T-039 still pending; T-039 has shipped | fleet-up |
| 9 | blocker | scout's de-dupe filter strands every issue with `fleet:task` (8 in production) | fleet-state-scout |

Bonus: parameterized four hardcodes of `sonnet-fleet-1` in
`role-sonnet-author.md` to `<your-worktree-basename>`, matching the
opus-worker pattern (heartbeat name, scratch-branch suffix).

### Item #9 — scout strand bug, found while debugging an unrelated symptom

After the audit landed locally, a check of the GitHub Issues tab showed
8 issues with `human:approved + fleet:task` that had never made it into
TASKS.md (#294, #298, #299, #303, #304, #305, #306, #307). Root cause:
the scout's `_ALREADY_QUEUED_LABELS = frozenset({\"fleet:task\",
\"fleet:queued\"})` filter (`fleet-state-scout:116`) treated
`fleet:task` as a \"already-queued, skip\" signal — but only
`fleet:queued` is the canonical post-ingestion marker that
queue-manager actually adds (role-queue-manager.md:369-371).
`fleet:task` only ends up on issues when an agent pre-applied it at
filing time, which audit item #2 just fixed in the role docs. So once
an issue had `fleet:task` on it (historically, or via the buggy role
docs), the scout silently filtered it out forever even though the human
had explicitly approved it. Fix is one line plus two stale doc
references in `role-queue-manager.md`. The 8 stranded issues had their
stale `fleet:task` labels removed manually so the scout will surface
them on its next sweep.

## Test plan

- [x] `bash -n` clean on `fleet-down`, `fleet-up`
- [x] `python3 compile` clean on `fleet-state-scout`, `fleet-claude-stream`
- [x] `fleet-claim list --with-age` works; bad flag rejected
- [x] `fleet-labels --dry-run` works
- [x] `_stack_*` filter end-to-end: synthetic claim + 2-task stack
      went from raw count 5 → filtered count 4 (the missing 1 is the
      `_stack_test-stack` metadata dir)
- [x] `request-re-review` skill registry now shows the new
      description (verified live via available-skills list)
- [x] 8 stranded issues had `fleet:task` removed manually so the scout
      can surface them on next sweep
- [ ] Real `fleet-up live` next session: reviewer panes write
      `.review-body.md` (worktree-local), no /tmp blocks
- [ ] Author panes file new issues with no labels
- [ ] Stacked-PR cascade through merger: child PR's `fleet:stacked-rebase`
      gets cleared on next reviewer pass
- [ ] Next queue-manager sweep ingests the 8 unstranded issues into TASKS.md

## Out-of-scope (deferred to future PRs)

The audit also surfaced these, which warrant their own scope rather
than getting bundled in:

- **Cross-role duplication.** Big refactor — \"single-command Bash
  calls\" / \"Common patterns\" / heartbeat / smoke-validate /
  molecule-resume blocks duplicated 3-7× across role docs. Needs
  design pass on whether to factor into CLAUDE.md, a shared include,
  or leave as-is for explicitness.
- **`backend-parity/SKILL.md` Bash-rule violations.** Multiple
  sections use `cd && cmd`, `>/dev/null`, `<( ... )`, `$(nproc)`.
  Multi-section rewrite; own scope.
- **Date-stamped backstory comments** (\"observed in production
  2026-04-22\") accumulate across scripts. Cosmetic.
- **`role-game-architect.md`** (in game repo, not engine) has the
  same `--label \"fleet:task\"` pattern that needs fixing — will land
  in a game-side PR.

## Notes for reviewer

- This PR was rebased onto current master to resolve conflicts that
  surfaced after PR #300 (T-040 trigger-aware back-off) and PR #301
  (T-043 reviewer upstream gating) merged. Both touched the same
  reviewer label-clear chains in `role-sonnet-reviewer.md`,
  `role-opus-reviewer.md`, and `review-pr SKILL.md` that audit item
  #6 also touches. Resolution: keep BOTH `--remove-label` entries
  (`fleet:awaiting-upstream-review` from #301 + `fleet:stacked-rebase`
  from this PR) in all four verdict chains. Combined the explanatory
  comments accordingly.
- All nine fixes touch isolated lines; no cross-cutting refactors.
  Each can be reverted independently if any is wrong.
- The `_stack_*` filter lives at the consumption site
  (`fleet-down`'s `count_active_claims`) rather than in
  `fleet-claim`'s `cmd_list` — that's intentional. Changing
  `cmd_list` semantics would surprise other callers (humans
  inspecting the queue, future scripts that DO want to see metadata
  dirs).
- The `fleet:stacked-rebase` clearer is added to ALL four verdict
  branches (approve / approve+nits / needs-fix / blocker), since
  the reviewer's re-eval after the re-target is what the label is
  waiting for, regardless of which verdict they reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)