### PR TITLE
T-047: Engine CLAUDE.md style: add prefer enums over strings rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,6 +380,11 @@ namespaces in headers; keep them in `.cpp`.
   future requirements.
 - Don't add error handling, fallbacks, or validation for scenarios that can't
   happen. Trust internal code. Only validate at system boundaries.
+- **Prefer `enum class` over strings for typed categorical fields.** Closed-set
+  fields (e.g., light type, text alignment, system name) are
+  `enum class TypeName : int { SCREAMING_SNAKE_CASE = 0, ... }` per the naming
+  table. Strings are for human-readable text, file paths, and external interop —
+  not for closed categorical sets that the framework dispatches on.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds one bullet to the Style section in the root `CLAUDE.md` directing authors to use `enum class` for typed categorical fields.
- Clarifies when strings ARE appropriate (human-readable text, file paths, external interop) vs. when enums are required (closed categorical sets the framework dispatches on).
- References the existing naming table for `SCREAMING_SNAKE_CASE` and `: int` base conventions.

## Why
The Style section had naming conventions for enum values but no rule about _when_ to use enums. Downstream component authors defaulted to `std::string` for categorical fields because the convention wasn't stated. This closes the gap.

## Test plan
- [x] Doc-only change — no build required
- [x] Wording reviewed against existing Style bullets for tone/length consistency
- [x] Confirmed no existing enum/string guidance elsewhere in any CLAUDE.md

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)