### PR TITLE
T-049: modifier framework: design doc + audit + framework declarations

### DIFF
--- a/docs/design/modifiers.md
+++ b/docs/design/modifiers.md
@@ -1,0 +1,377 @@
+# Modifier framework
+
+Engine-level mechanism that lets any component field be modulated by a
+vector of structured `(transform, parameter)` pairs. The pattern
+generalizes the existing `C_Position3D` + `C_PositionOffset3D` →
+`C_PositionGlobal3D` pipeline so other features (velocity drag,
+buff/debuff stacks, color modulation, etc.) can hand off the
+"compose base + N modifications → effective value" math to a shared
+resolver.
+
+This document specifies the framework's public contract and the
+locked design choices behind it. The runtime that backs these
+contracts (registry, resolver systems, source-destruction sweep)
+ships in the follow-up task — see [Decomposition](#decomposition).
+
+## Table of contents
+
+- [Vocabulary](#vocabulary)
+- [Locked design choices](#locked-design-choices)
+- [Data shapes](#data-shapes)
+- [Resolver pipeline](#resolver-pipeline)
+- [Public API surface](#public-api-surface)
+- [Existing-pattern audit](#existing-pattern-audit)
+- [Decomposition](#decomposition)
+
+## Vocabulary
+
+- **Field** — a logical scalar value an entity owns, identified by a
+  dense `FieldBindingId` (e.g. *velocity X drag scale*, *color V
+  channel*, *position Z offset*). The framework is agnostic to where
+  the field's base value lives — it only operates on the
+  `(field, base) → effective` transformation.
+- **Modifier** — a request to transform one field's value by one
+  amount (`ADD 0.25`, `MULTIPLY 0.8`, `CLAMP_MIN 0.0`, …). Carries a
+  source attribution and an optional decay tick counter.
+- **Source** — the entity that pushed the modifier. When the source
+  is destroyed, every modifier it pushed is swept away.
+- **Resolver** — the pipeline stage that consumes the modifier vector,
+  produces a per-field effective value, and writes it to the output
+  cache (`C_ResolvedFields`) or directly returns it via the
+  `applyToField` query API.
+
+## Locked design choices
+
+The design picks below were settled during the planning rounds for
+issue #302 and are NOT open for re-litigation in implementation tasks
+(children 2-5). If during implementation a choice looks wrong,
+**escalate** rather than silently re-deciding — see
+[Notes for implementers](#notes-for-implementers).
+
+### Hybrid transform shape (Path C)
+
+`TransformKind` is a small structured enum (`ADD`, `MULTIPLY`, `SET`,
+`CLAMP_MIN`, `CLAMP_MAX`, `OVERRIDE`). The lambda escape hatch is a
+**sibling component** (`C_LambdaModifiers`) so the structured
+modifier stays trivially-copyable and dense-cache-friendly.
+
+**Why:** the long-tail "I need a sine-decayed source-aware modifier"
+case exists, but it is rare. Forcing a `std::function` into the dense
+modifier path penalizes every entity in the cache to support a
+minority pattern. The split keeps the hot path tight while leaving
+the escape hatch one component-add away.
+
+### Eager composition, no dirty flag
+
+The resolver runs every UPDATE tick over a dense archetype iteration.
+Recompute is `O(modifiers per entity)`; for typical entities (~5
+modifiers) that's < 1 cache line of work per entity.
+
+**Why:** dirty-flag accounting costs branch + flag-store on every
+modifier push and decay, and saves work only when modifier vectors
+are mostly stable across frames. Profiling other ECS engines that
+attempted dirty-flag modifier pipelines showed branch cost dominating
+the savings. The ECS storage is designed for dense iteration; lean
+into it.
+
+### Vector-on-component storage
+
+`C_Modifiers` carries `std::vector<Modifier>` directly. One
+allocation per entity, all modifiers contiguous, trivially-copyable
+element type.
+
+**Why:** entity-per-modifier (one entity per modifier with `EntityId
+target_`) is cleaner conceptually but pays an entity creation +
+archetype lookup per push, and forces the resolver to do an
+N×M relation walk instead of a dense column iteration. Vector-on-
+component is the cheaper end of the cost curve for v1. Modifier-as-
+entity remains a reasonable v2 path for cases that genuinely need it
+(modifier with its own physics / particle effect / lifetime), but it
+doesn't earn its complexity for the common case.
+
+### `EntityId` source attribution (not strings, not handles)
+
+Each modifier carries `EntityId source_`. The source's identity is
+the entity itself.
+
+**Why:** engine-native, dense, no hash map, no string interning.
+Human-readable names come for free via the source entity's `C_Name`
+component. Source-tied lifetime falls out naturally — when the source
+dies, sweep modifiers where `source_ == destroyedId`. No separate
+"modifier handle" type needed; you can either remember the source
+yourself or call `removeBySource(sourceId)`.
+
+### `ticksRemaining_` decay only
+
+Built-in lifetime is just an `int32_t` tick counter and a one-time
+sweep of expired modifiers (`ticksRemaining_ <= 0` after decrement).
+`-1` is the sentinel for "no decay".
+
+**Why:** non-linear / curved / source-driven decay is **not the
+modifier's problem**. The source entity's tick function adjusts its
+modifier's `param_` directly via the source attribution, or
+destroys-and-replaces. Trying to bake every decay shape into the
+modifier struct turns it into a small interpreter; we already have a
+better interpreter — the host language and the source entity's tick
+function.
+
+### Singleton globals + archetype-routed exemption
+
+A singleton entity carries `C_GlobalModifiers`. Per-entity opt-out is
+a `C_NoGlobalModifiers` empty tag. Resolver dispatch is via
+**archetype routing**: register the global-resolving system with a
+filter that excludes archetypes containing `C_NoGlobalModifiers`, and
+register a sibling exempt-resolving system that includes the tag.
+Both are dense iterations; neither branches on the tag at runtime.
+
+**Why:** "all entities feel the global slow except boss enemies" is
+the canonical case. Putting the exemption check inside the resolver
+tick body adds a branch to every entity-tick to support a small
+minority. Archetype routing solves the same problem in the type
+system: the entities are already in different archetypes, so use the
+ECS's native dispatch instead of branching.
+
+### Vector ordering — push-order, OVERRIDE wins last
+
+The resolver applies modifiers in the order they appear in the
+vector. `OVERRIDE` short-circuits to the most recent OVERRIDE's
+`param_` and ignores everything after it.
+
+**Why:** the user-facing semantics most callers expect ("the last
+buff I pushed wins") map to push-order without any sort. `OVERRIDE`
+is the explicit "this beats whatever came before" knob; the
+implementation looks for the latest OVERRIDE in one pass, then
+applies the prefix-of-the-vector before that override (so it can
+still be clamped by a later CLAMP_MIN/MAX).
+
+## Data shapes
+
+```cpp
+namespace IRComponents {
+
+using FieldBindingId = std::uint16_t;        // dense registry index
+constexpr FieldBindingId kInvalidFieldId = 0;  // 0 is reserved
+
+enum class TransformKind : std::uint8_t {
+    ADD,
+    MULTIPLY,
+    SET,
+    CLAMP_MIN,
+    CLAMP_MAX,
+    OVERRIDE,
+};
+
+struct Modifier {
+    FieldBindingId       field_;          // 2 B — what is being modified
+    TransformKind        kind_;           // 1 B
+                                          // 1 B compiler-inserted pad
+    float                param_;          // 4 B — amount / multiplier / set / bound
+    IREntity::EntityId   source_;         // 8 B — who pushed this
+    std::int32_t         ticksRemaining_; // 4 B — -1 = no decay; ≤ 0 = expired
+                                          // 4 B tail pad (alignof 8)
+};
+// Trivially-copyable. sizeof == 24 B, alignof == 8 (locked by unit test).
+
+struct LambdaModifier {
+    FieldBindingId              field_;
+    std::function<float(float)> fn_;             // base → effective
+    IREntity::EntityId          source_;
+    std::int32_t                ticksRemaining_;
+};
+// NOT trivially-copyable. Lives in a sibling component on purpose.
+
+struct ResolvedField {
+    FieldBindingId field_;
+    float          value_;
+};
+
+struct C_Modifiers        { std::vector<Modifier>       modifiers_; };
+struct C_GlobalModifiers  { std::vector<Modifier>       modifiers_; };  // singleton
+struct C_NoGlobalModifiers {};                                          // empty tag
+struct C_LambdaModifiers  { std::vector<LambdaModifier> modifiers_; };
+struct C_ResolvedFields   { std::vector<ResolvedField>  fields_; };
+}
+```
+
+`Modifier` is 24 B (not the 16 B figure floated during planning); the
+8-byte `EntityId` source dominates the alignment, so the struct ends up
+two-per-cache-line — which was the property that mattered. A future
+v2 packing experiment could pull `source_` down to a 32-bit raw entity
+id (low 32 bits of `EntityId`; the high bits are flag metadata) and
+collapse the struct to 16 B / three-per-cache-line; out of scope for
+v1 since the runtime should drive that representation choice.
+
+## Resolver pipeline
+
+Once per pipeline execution, end of UPDATE phase, before RENDER reads:
+
+```
+ModifierDecay              decrement ticksRemaining_, drop expired
+GlobalModifierDecay        same on the singleton
+ModifierResolveGlobal      non-exempt entities (archetype filter)
+ModifierResolveExempt      exempt entities (with C_NoGlobalModifiers)
+ModifierResolveLambda      lambda escape hatch, both archetypes
+→ RENDER reads C_ResolvedFields directly
+```
+
+Five systems, all dense archetype iterations, no per-entity hash
+lookups in any tick body. Resolver dispatch is archetype-routed:
+`ModifierResolveGlobal` is registered with an *exclude*
+`C_NoGlobalModifiers` filter; `ModifierResolveExempt` with an
+*include* filter. Both are dense; neither branches on the tag.
+
+### Resolver evaluation order (per entity, per field)
+
+1. Start with the field's `base` value (read from the field's owning
+   component — provided to the framework via the field-binding
+   registry).
+2. Look back through the entity's modifier vector for the **latest**
+   `OVERRIDE` for this field. If found, replace `base` with that
+   override's `param_` and discard every modifier earlier than it.
+3. Apply `ADD` / `MULTIPLY` / `SET` modifiers in push-order (newer
+   wins for `SET`).
+4. Apply `CLAMP_MIN` / `CLAMP_MAX` (always after the algebra so they
+   bound the result).
+5. Write the result to `C_ResolvedFields` (or return it from
+   `applyToField`).
+
+`SET` is distinct from `OVERRIDE` in that `SET` participates in
+later clamps; `OVERRIDE` short-circuits the prefix.
+
+## Public API surface
+
+The framework's free-function API ships in child 2 alongside the
+runtime. The shape (locked here so child 3 can plan around it):
+
+```cpp
+namespace IRPrefab::Modifier {
+
+// Field registry (called at init by feature owners).
+IRComponents::FieldBindingId registerField(const char* name);
+const char* fieldName(IRComponents::FieldBindingId id);
+std::size_t fieldCount();
+
+// Push.
+void push(IREntity::EntityId target,
+          IRComponents::FieldBindingId field,
+          IRComponents::TransformKind kind,
+          float param,
+          IREntity::EntityId source,
+          std::int32_t ticksRemaining = -1);
+
+void pushGlobal(IRComponents::FieldBindingId field,
+                IRComponents::TransformKind kind,
+                float param,
+                IREntity::EntityId source,
+                std::int32_t ticksRemaining = -1);
+
+void pushLambda(IREntity::EntityId target,
+                IRComponents::FieldBindingId field,
+                std::function<float(float)> fn,
+                IREntity::EntityId source,
+                std::int32_t ticksRemaining = -1);
+
+// Remove.
+void removeBySource(IREntity::EntityId source);
+
+// Direct query (skips the C_ResolvedFields cache).
+float applyToField(IREntity::EntityId target,
+                   IRComponents::FieldBindingId field,
+                   float baseValue);
+
+// Pipeline registration (called once at init).
+void registerResolverPipeline();
+}
+```
+
+Lua mirrors this (child 4): `ir.modifier.registerField`,
+`ir.modifier.push`, `ir.modifier.pushGlobal`, `ir.modifier.pushLambda`,
+`ir.modifier.removeBySource`, `ir.modifier.applyToField`. The
+`TransformKind` enum is exposed as
+`ir.modifier.ADD/MULTIPLY/SET/CLAMP_MIN/CLAMP_MAX/OVERRIDE`.
+
+## Existing-pattern audit
+
+The engine already hand-rolls the "base + modulation → effective"
+shape in several places. The framework's first internal consumers are
+the v1 migration targets; later candidates are folded in once the
+framework has baked.
+
+### v1 migration targets (this epic)
+
+- **Position pattern** — `C_Position3D` + `C_PositionOffset3D` →
+  `C_PositionGlobal3D`. The canonical worked example. Drivers:
+  `engine/prefabs/irreden/update/systems/system_apply_position_offset.hpp`
+  and `system_update_positions_global.hpp`. Migration: register a
+  `position.x/y/z` field triplet, push offsets as
+  `ADD` modifiers from whichever system owns the offset (idle drift,
+  bumps, knock-back, hover), let the resolver write
+  `C_PositionGlobal3D`. Follow-up: `apply_position_offset.hpp` and
+  `update_positions_global.hpp` collapse into the resolver.
+
+- **Velocity drag** — `C_VelocityDrag` modulates `C_Velocity3D`.
+  Driver: `engine/prefabs/irreden/update/systems/system_velocity_drag.hpp`.
+  Mostly a `MULTIPLY` transform on three velocity components, with a
+  hover-blend phase that's better expressed as a lambda or a
+  switch-on-state in the source's tick function. Migration: register
+  `velocity.x/y/z` fields, push the drag scale as `MULTIPLY`
+  modifiers, push the hover envelope as a `LambdaModifier`. The
+  current `system_velocity_drag.hpp` collapses into a *modifier
+  source* (something that pushes/refreshes the modifier each tick)
+  rather than a velocity-mutating system.
+
+### Follow-up candidates (post-epic)
+
+These fit the modifier shape but are out of scope for the v1 epic.
+Each gets its own follow-up task once the framework has baked.
+
+- **Animation color** — `C_AnimColorState` + `system_animation_color.hpp`.
+  HSV blending over a curve. Lambda territory (the curve isn't a
+  scalar transform).
+- **Spring color** — `system_spring_color.hpp`. Physics-driven color
+  modulation. Lambda territory; the spring state is already a
+  per-field accumulator that maps cleanly onto a `LambdaModifier`.
+- **Spawn / trigger glow** — time-bounded brightness modulation on
+  voxel sets. Clean `MULTIPLY` + decay. Probably the smallest
+  follow-up.
+- **Texture scroll** — UV offset modulation on materials. Less
+  obviously a modifier (it's input to UV computation, not a
+  target value), so it may stay as-is.
+
+## Decomposition
+
+The epic decomposes into five sequenced child tasks. Stack order:
+
+```
+1 ─► 2 ─► 3 / 4 (parallel) ─► 5
+```
+
+| Child | Title                                                 | Model    |
+|-------|-------------------------------------------------------|----------|
+| 1     | Design doc + audit + framework declarations           | `[opus]` |
+| 2     | Core runtime (registry, resolver systems, sweep)      | `[opus]` |
+| 3     | Migrate position + velocity-drag patterns             | `[opus]` |
+| 4     | Lua bindings                                          | `[sonnet]` |
+| 5     | `modifier_demo` creation (visual showcase)            | `[sonnet]` |
+
+Children 3 and 4 may run in parallel after child 2 lands. Child 5
+needs all four predecessors.
+
+## Notes for implementers
+
+- The locked design choices above are the source of truth. If during
+  writing the runtime, a child task finds a flaw in any choice,
+  **escalate** to the architect — don't silently re-decide.
+- The `Modifier` struct must stay trivially-copyable. If a refinement
+  requires a `std::function` or `std::string` inline, that's a smell
+  — push it to a sibling component.
+- Framework public API lives in `IRPrefab::Modifier::` per the
+  layering principle in `engine/prefabs/irreden/render/CLAUDE.md`
+  ("Exposing system public API from the prefab layer"), NOT in
+  `IRRender::` or any engine-library-level namespace.
+- `FieldBindingId` is a registry-backed dense integer. The registry
+  itself ships in child 2. This task only declares the type alias and
+  documents what the registry will look like.
+- `kInvalidFieldId == 0` is reserved so that an unset binding id is
+  cheaply detectable and so that `0` is never a valid registered
+  field. Registration starts at id `1`.

--- a/docs/design/modifiers.md
+++ b/docs/design/modifiers.md
@@ -101,6 +101,16 @@ dies, sweep modifiers where `source_ == destroyedId`. No separate
 "modifier handle" type needed; you can either remember the source
 yourself or call `removeBySource(sourceId)`.
 
+### Source attribution lifetime contract
+
+The source-destruction sweep MUST run inside `EntityManager::destroyEntity`
+before `returnEntityToPool` fires — implemented as a pre-destroy hook the
+framework registers at `registerResolverPipeline()` init time. Deferred
+sweep is unsafe: `EntityId` has no generation counter, so after
+`returnEntityToPool` the same id can be issued to an unrelated entity, and a
+delayed `removeBySource(oldId)` would silently strip that new entity's
+modifiers. T-050 wires this by registering the sweep as a pre-destroy hook.
+
 ### `ticksRemaining_` decay only
 
 Built-in lifetime is just an `int32_t` tick counter and a one-time
@@ -228,6 +238,9 @@ lookups in any tick body. Resolver dispatch is archetype-routed:
 2. Look back through the entity's modifier vector for the **latest**
    `OVERRIDE` for this field. If found, replace `base` with that
    override's `param_` and discard every modifier earlier than it.
+   `OVERRIDE` discards prior `CLAMP_MIN`/`CLAMP_MAX` as well as prior
+   `ADD`/`MULTIPLY`/`SET`. To clamp an `OVERRIDE` result, push the clamp
+   *after* the `OVERRIDE`.
 3. Apply `ADD` / `MULTIPLY` / `SET` modifiers in push-order (newer
    wins for `SET`).
 4. Apply `CLAMP_MIN` / `CLAMP_MAX` (always after the algebra so they
@@ -283,6 +296,14 @@ float applyToField(IREntity::EntityId target,
 void registerResolverPipeline();
 }
 ```
+
+`registerField` stores the pointer, not a copy — `name` must have
+static-storage lifetime (use a string literal). `applyToField` and the
+resolver pipeline share a single per-field evaluator; T-050 should verify
+equivalence with a property test so the two read paths never silently
+disagree. `C_ResolvedFields` lookup by `FieldBindingId` is linear over
+`std::vector` — fine for v1 (~5 fields per entity), but T-050 should pick a
+lookup strategy explicitly and note it in the runtime PR.
 
 Lua mirrors this (child 4): `ir.modifier.registerField`,
 `ir.modifier.push`, `ir.modifier.pushGlobal`, `ir.modifier.pushLambda`,
@@ -375,3 +396,7 @@ needs all four predecessors.
 - `kInvalidFieldId == 0` is reserved so that an unset binding id is
   cheaply detectable and so that `0` is never a valid registered
   field. Registration starts at id `1`.
+- `push()` should defensively reject any modifier where `field_ ==
+  kInvalidFieldId` — a default-constructed `Modifier{}` produces this
+  state (`kind_ == ADD`, `field_ == 0`). Fail fast rather than silently
+  adding an invalid modifier to the vector.

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -34,10 +34,10 @@ mechanism: any feature that wants a stack of additive / multiplicative
 `C_Modifiers` vector. The resolver pipeline composes them once per
 UPDATE tick and writes the result to `C_ResolvedFields`.
 
-Child task 1 of issue #302 ships only the **types** and the **design
-contract**. The runtime (`FieldBindingId` registry, the five resolver
-systems, source-destruction sweep, `applyToField` query) ships in
-child 2.
+The framework ships in two phases: type declarations (component types,
+`Modifier` struct, static asserts) and the runtime (`FieldBindingId`
+registry, the five resolver systems, source-destruction sweep,
+`applyToField` query) in a follow-up.
 
 Full design — locked choices, rationale, audit, public-API surface,
 and decomposition — is in `docs/design/modifiers.md`. Read that

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -14,11 +14,51 @@ in `update/`.
 - `C_Name` — debug/display string.
 - `C_Player` — tag for player-controlled entities.
 - `C_Selected` — tag for UI selection.
+- `C_Modifiers` / `C_GlobalModifiers` / `C_NoGlobalModifiers` /
+  `C_LambdaModifiers` / `C_ResolvedFields` — generic modifier
+  framework. See [Modifier framework](#modifier-framework) below.
 
 ## Systems
 
 None. Position math is read-only in `common/` — write paths live in
 `update/systems/` (velocity, physics, animation).
+
+## Modifier framework
+
+`component_modifiers.hpp` declares the generic
+`base + N modifications → effective` framework that generalizes the
+position-offset / velocity-drag pattern. It is an engine-level
+mechanism: any feature that wants a stack of additive / multiplicative
+/ clamp / override modulations on a scalar field can register a
+`FieldBindingId` and push `Modifier` records onto the entity's
+`C_Modifiers` vector. The resolver pipeline composes them once per
+UPDATE tick and writes the result to `C_ResolvedFields`.
+
+Child task 1 of issue #302 ships only the **types** and the **design
+contract**. The runtime (`FieldBindingId` registry, the five resolver
+systems, source-destruction sweep, `applyToField` query) ships in
+child 2.
+
+Full design — locked choices, rationale, audit, public-API surface,
+and decomposition — is in `docs/design/modifiers.md`. Read that
+before adding to the framework or migrating an existing
+`base + offset` pattern onto it.
+
+Key invariants the design rests on:
+
+- `Modifier` stays **trivially-copyable**. Anything needing inline
+  `std::function` or `std::string` belongs in `C_LambdaModifiers`,
+  not `C_Modifiers`.
+- Public API lives in the `IRPrefab::Modifier::` namespace per the
+  prefab-layer principle in `engine/prefabs/irreden/render/CLAUDE.md`,
+  NOT in `IRRender::` or any engine-library-level namespace.
+- Globals + exemption are dispatched via **archetype routing**
+  (separate include / exclude resolver systems on
+  `C_NoGlobalModifiers`), never via per-entity branching inside a
+  tick body.
+- Decay is built-in only as `ticksRemaining_` (an `int32_t` counter
+  with `-1` as the sentinel for "no decay"). Curved / source-driven
+  decay is the source entity's job, not the modifier struct's.
 
 ## Commands
 

--- a/engine/prefabs/irreden/common/components/component_modifiers.hpp
+++ b/engine/prefabs/irreden/common/components/component_modifiers.hpp
@@ -30,7 +30,8 @@ enum class TransformKind : std::uint8_t {
 /// enforces trivial-copyability; anything that needs `std::function`
 /// or `std::string` belongs in `LambdaModifier`. `ticksRemaining_ == -1`
 /// is the sentinel for "no decay"; the decay system drops the modifier
-/// once the counter reaches 0.
+/// once the counter reaches 0. See `docs/design/modifiers.md` §Data shapes
+/// for per-field semantics.
 struct Modifier {
     FieldBindingId       field_;
     TransformKind        kind_;

--- a/engine/prefabs/irreden/common/components/component_modifiers.hpp
+++ b/engine/prefabs/irreden/common/components/component_modifiers.hpp
@@ -1,0 +1,84 @@
+#ifndef COMPONENT_MODIFIERS_H
+#define COMPONENT_MODIFIERS_H
+
+// Generic modifier framework — data declarations.
+// See docs/design/modifiers.md for the locked design choices, the
+// resolver-pipeline contract, and the existing-pattern audit.
+
+#include <irreden/entity/ir_entity_types.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <type_traits>
+#include <vector>
+
+namespace IRComponents {
+
+using FieldBindingId = std::uint16_t;
+inline constexpr FieldBindingId kInvalidFieldId = 0;
+
+enum class TransformKind : std::uint8_t {
+    ADD,
+    MULTIPLY,
+    SET,
+    CLAMP_MIN,
+    CLAMP_MAX,
+    OVERRIDE,
+};
+
+/// Dense modulation request on one field. The `static_assert` below
+/// enforces trivial-copyability; anything that needs `std::function`
+/// or `std::string` belongs in `LambdaModifier`. `ticksRemaining_ == -1`
+/// is the sentinel for "no decay"; the decay system drops the modifier
+/// once the counter reaches 0.
+struct Modifier {
+    FieldBindingId       field_;
+    TransformKind        kind_;
+    float                param_;
+    IREntity::EntityId   source_;
+    std::int32_t         ticksRemaining_;
+};
+
+static_assert(
+    std::is_trivially_copyable_v<Modifier>,
+    "Modifier must remain trivially-copyable; anything needing "
+    "std::function/std::string belongs in LambdaModifier."
+);
+
+struct LambdaModifier {
+    FieldBindingId              field_;
+    std::function<float(float)> fn_;
+    IREntity::EntityId          source_;
+    std::int32_t                ticksRemaining_;
+};
+
+struct ResolvedField {
+    FieldBindingId field_;
+    float          value_;
+};
+
+struct C_Modifiers {
+    std::vector<Modifier> modifiers_;
+};
+
+struct C_GlobalModifiers {
+    std::vector<Modifier> modifiers_;
+};
+
+/// Empty tag opting an entity out of `C_GlobalModifiers`. The
+/// resolver's global vs exempt dispatch is **archetype-routed** — two
+/// resolver systems with include / exclude filters on this tag —
+/// never a runtime branch inside a tick body.
+struct C_NoGlobalModifiers {};
+
+struct C_LambdaModifiers {
+    std::vector<LambdaModifier> modifiers_;
+};
+
+struct C_ResolvedFields {
+    std::vector<ResolvedField> fields_;
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_MODIFIERS_H */

--- a/engine/prefabs/irreden/common/components/component_modifiers_lua.hpp
+++ b/engine/prefabs/irreden/common/components/component_modifiers_lua.hpp
@@ -1,0 +1,111 @@
+#ifndef COMPONENT_MODIFIERS_LUA_H
+#define COMPONENT_MODIFIERS_LUA_H
+
+// Reflection-only Lua bindings for the modifier framework. Exposes
+// the value types and the TransformKind enum; the `ir.modifier.*`
+// behavior API ships separately. See docs/design/modifiers.md.
+
+#include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/script/lua_script.hpp>
+
+namespace IRScript {
+
+template <> inline constexpr bool kHasLuaBinding<IRComponents::Modifier> = true;
+template <> inline constexpr bool kHasLuaBinding<IRComponents::LambdaModifier> = true;
+template <> inline constexpr bool kHasLuaBinding<IRComponents::ResolvedField> = true;
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_Modifiers> = true;
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_GlobalModifiers> = true;
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_NoGlobalModifiers> = true;
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_LambdaModifiers> = true;
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_ResolvedFields> = true;
+
+template <> inline void bindLuaType<IRComponents::Modifier>(LuaScript &luaScript) {
+    using IRComponents::Modifier;
+    using IRComponents::TransformKind;
+
+    luaScript.registerEnum<TransformKind>(
+        "TransformKind",
+        {
+            {"ADD",       TransformKind::ADD},
+            {"MULTIPLY",  TransformKind::MULTIPLY},
+            {"SET",       TransformKind::SET},
+            {"CLAMP_MIN", TransformKind::CLAMP_MIN},
+            {"CLAMP_MAX", TransformKind::CLAMP_MAX},
+            {"OVERRIDE",  TransformKind::OVERRIDE},
+        }
+    );
+
+    luaScript.registerType<Modifier, Modifier()>(
+        "Modifier",
+        "field",          &Modifier::field_,
+        "kind",            &Modifier::kind_,
+        "param",           &Modifier::param_,
+        "source",          &Modifier::source_,
+        "ticksRemaining",  &Modifier::ticksRemaining_
+    );
+}
+
+template <> inline void bindLuaType<IRComponents::LambdaModifier>(LuaScript &luaScript) {
+    using IRComponents::LambdaModifier;
+
+    // fn_ deliberately not exposed — lambda push goes through the
+    // dedicated API surface in child 4 (`ir.modifier.pushLambda`).
+    luaScript.registerType<LambdaModifier, LambdaModifier()>(
+        "LambdaModifier",
+        "field",           &LambdaModifier::field_,
+        "source",          &LambdaModifier::source_,
+        "ticksRemaining",  &LambdaModifier::ticksRemaining_
+    );
+}
+
+template <> inline void bindLuaType<IRComponents::ResolvedField>(LuaScript &luaScript) {
+    using IRComponents::ResolvedField;
+    luaScript.registerType<ResolvedField, ResolvedField()>(
+        "ResolvedField",
+        "field", &ResolvedField::field_,
+        "value", &ResolvedField::value_
+    );
+}
+
+template <> inline void bindLuaType<IRComponents::C_Modifiers>(LuaScript &luaScript) {
+    using IRComponents::C_Modifiers;
+    luaScript.registerType<C_Modifiers, C_Modifiers()>(
+        "C_Modifiers",
+        "modifiers", &C_Modifiers::modifiers_
+    );
+}
+
+template <> inline void bindLuaType<IRComponents::C_GlobalModifiers>(LuaScript &luaScript) {
+    using IRComponents::C_GlobalModifiers;
+    luaScript.registerType<C_GlobalModifiers, C_GlobalModifiers()>(
+        "C_GlobalModifiers",
+        "modifiers", &C_GlobalModifiers::modifiers_
+    );
+}
+
+template <> inline void bindLuaType<IRComponents::C_NoGlobalModifiers>(LuaScript &luaScript) {
+    using IRComponents::C_NoGlobalModifiers;
+    luaScript.registerType<C_NoGlobalModifiers, C_NoGlobalModifiers()>(
+        "C_NoGlobalModifiers"
+    );
+}
+
+template <> inline void bindLuaType<IRComponents::C_LambdaModifiers>(LuaScript &luaScript) {
+    using IRComponents::C_LambdaModifiers;
+    luaScript.registerType<C_LambdaModifiers, C_LambdaModifiers()>(
+        "C_LambdaModifiers",
+        "modifiers", &C_LambdaModifiers::modifiers_
+    );
+}
+
+template <> inline void bindLuaType<IRComponents::C_ResolvedFields>(LuaScript &luaScript) {
+    using IRComponents::C_ResolvedFields;
+    luaScript.registerType<C_ResolvedFields, C_ResolvedFields()>(
+        "C_ResolvedFields",
+        "fields", &C_ResolvedFields::fields_
+    );
+}
+
+} // namespace IRScript
+
+#endif /* COMPONENT_MODIFIERS_LUA_H */

--- a/engine/prefabs/irreden/common/components/component_modifiers_lua.hpp
+++ b/engine/prefabs/irreden/common/components/component_modifiers_lua.hpp
@@ -19,6 +19,10 @@ template <> inline constexpr bool kHasLuaBinding<IRComponents::C_NoGlobalModifie
 template <> inline constexpr bool kHasLuaBinding<IRComponents::C_LambdaModifiers> = true;
 template <> inline constexpr bool kHasLuaBinding<IRComponents::C_ResolvedFields> = true;
 
+// TransformKind is registered here as a side effect. Bind Modifier before
+// C_Modifiers / C_GlobalModifiers if scripts inspect the kind_ field on a
+// modifier entry; to remove the ordering dependency, factor TransformKind
+// registration into its own bindLuaType specialization.
 template <> inline void bindLuaType<IRComponents::Modifier>(LuaScript &luaScript) {
     using IRComponents::Modifier;
     using IRComponents::TransformKind;
@@ -49,7 +53,7 @@ template <> inline void bindLuaType<IRComponents::LambdaModifier>(LuaScript &lua
     using IRComponents::LambdaModifier;
 
     // fn_ deliberately not exposed — lambda push goes through the
-    // dedicated API surface in child 4 (`ir.modifier.pushLambda`).
+    // dedicated behavior API surface (`ir.modifier.pushLambda`).
     luaScript.registerType<LambdaModifier, LambdaModifier()>(
         "LambdaModifier",
         "field",           &LambdaModifier::field_,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(IrredenEngineTest
   audio/music_theory_test.cpp
   common/ir_platform_test.cpp
   ecs/entity_manager_test.cpp
+  ecs/modifier_types_test.cpp
   math/physics_test.cpp
   math/ir_math_test.cpp
   math/ir_math_viewport_helpers_test.cpp

--- a/test/ecs/modifier_types_test.cpp
+++ b/test/ecs/modifier_types_test.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+
+#include <irreden/common/components/component_modifiers.hpp>
+
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+using IRComponents::FieldBindingId;
+using IRComponents::kInvalidFieldId;
+using IRComponents::TransformKind;
+using IRComponents::Modifier;
+using IRComponents::LambdaModifier;
+using IRComponents::ResolvedField;
+using IRComponents::C_Modifiers;
+using IRComponents::C_GlobalModifiers;
+using IRComponents::C_NoGlobalModifiers;
+using IRComponents::C_LambdaModifiers;
+using IRComponents::C_ResolvedFields;
+
+TEST(ModifierTypes, ModifierIsTriviallyCopyable) {
+    static_assert(std::is_trivially_copyable_v<Modifier>);
+    SUCCEED();
+}
+
+TEST(ModifierTypes, ModifierLayoutLocked) {
+    static_assert(sizeof(Modifier) == 24);
+    static_assert(alignof(Modifier) == 8);
+    SUCCEED();
+}
+
+TEST(ModifierTypes, FieldBindingSentinelIsZero) {
+    static_assert(kInvalidFieldId == FieldBindingId{0});
+    SUCCEED();
+}
+
+TEST(ModifierTypes, TransformKindSize) {
+    static_assert(sizeof(TransformKind) == 1);
+    SUCCEED();
+}
+
+TEST(ModifierTypes, ComponentsDefaultConstructEmpty) {
+    C_Modifiers per_entity{};
+    C_GlobalModifiers global{};
+    C_NoGlobalModifiers tag{};
+    C_LambdaModifiers lambdas{};
+    C_ResolvedFields resolved{};
+
+    EXPECT_TRUE(per_entity.modifiers_.empty());
+    EXPECT_TRUE(global.modifiers_.empty());
+    EXPECT_TRUE(lambdas.modifiers_.empty());
+    EXPECT_TRUE(resolved.fields_.empty());
+    (void)tag;
+}
+
+TEST(ModifierTypes, ModifierPushAndRead) {
+    C_Modifiers c{};
+    c.modifiers_.push_back(Modifier{
+        FieldBindingId{1},
+        TransformKind::ADD,
+        0.5f,
+        IREntity::EntityId{42},
+        std::int32_t{-1},
+    });
+
+    ASSERT_EQ(c.modifiers_.size(), std::size_t{1});
+    EXPECT_EQ(c.modifiers_[0].field_, FieldBindingId{1});
+    EXPECT_EQ(c.modifiers_[0].kind_, TransformKind::ADD);
+    EXPECT_FLOAT_EQ(c.modifiers_[0].param_, 0.5f);
+    EXPECT_EQ(c.modifiers_[0].source_, IREntity::EntityId{42});
+    EXPECT_EQ(c.modifiers_[0].ticksRemaining_, std::int32_t{-1});
+}
+
+TEST(ModifierTypes, LambdaModifierStoresFunction) {
+    C_LambdaModifiers c{};
+    c.modifiers_.push_back(LambdaModifier{
+        FieldBindingId{2},
+        [](float base) { return base * 2.0f; },
+        IREntity::EntityId{7},
+        std::int32_t{60},
+    });
+
+    ASSERT_EQ(c.modifiers_.size(), std::size_t{1});
+    EXPECT_FLOAT_EQ(c.modifiers_[0].fn_(3.0f), 6.0f);
+    EXPECT_EQ(c.modifiers_[0].source_, IREntity::EntityId{7});
+    EXPECT_EQ(c.modifiers_[0].ticksRemaining_, std::int32_t{60});
+}
+
+TEST(ModifierTypes, ResolvedFieldsLookup) {
+    C_ResolvedFields c{};
+    c.fields_.push_back(ResolvedField{FieldBindingId{1}, 1.5f});
+    c.fields_.push_back(ResolvedField{FieldBindingId{2}, 2.5f});
+
+    EXPECT_EQ(c.fields_.size(), std::size_t{2});
+    EXPECT_FLOAT_EQ(c.fields_[1].value_, 2.5f);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
Foundation task for the modifier framework epic (#302). Ships the
locked design contract, the data-shape declarations, and a
reflection-only Lua surface — no runtime yet. The runtime registry,
five resolver systems, source-destruction sweep, and the
`applyToField` query ship in **T-050** (child 2).

This is the data-vocabulary half of the framework: the next
implementation task can lean on `Modifier`, `C_Modifiers`,
`TransformKind`, etc. without re-litigating the shape, and the Lua
binding task (**T-052**) can wire its `ir.modifier.*` API on top of
the already-bound types.

### What's in the diff

- **`docs/design/modifiers.md`** — locked design picks (hybrid
  transforms, eager composition, vector-on-component storage,
  `EntityId` source attribution, ticks-only built-in decay,
  archetype-routed globals exemption, push-order with `OVERRIDE`
  short-circuit), the resolver pipeline shape, the
  `IRPrefab::Modifier::` public-API surface, and the existing-pattern
  audit (v1 migration targets: position-offset and velocity-drag;
  post-epic follow-up candidates: animation color, spring color,
  spawn/trigger glow, texture scroll).
- **`engine/prefabs/irreden/common/components/component_modifiers.hpp`**
  — `FieldBindingId` (with `kInvalidFieldId = 0` sentinel),
  `TransformKind` enum, `Modifier` (24 B trivially-copyable, layout
  locked by `static_assert` + unit test), `LambdaModifier` (escape
  hatch with `std::function`), the four `C_*` component types plus
  the `C_NoGlobalModifiers` tag, and `ResolvedField`.
- **`engine/prefabs/irreden/common/components/component_modifiers_lua.hpp`**
  — reflection-only sol2 bindings: the data types and the
  `TransformKind` enum exposed to Lua so the API task isn't blocked
  on type plumbing.
- **`engine/prefabs/irreden/common/CLAUDE.md`** — pointer to the
  design doc + the load-bearing invariants future readers must keep
  intact (trivially-copyable `Modifier`, archetype-routed globals
  exemption, `IRPrefab::Modifier::` namespace placement, ticks-only
  built-in decay).
- **`test/ecs/modifier_types_test.cpp`** — gtest smoke covering
  trivial-copyability, the locked layout (`sizeof == 24`,
  `alignof == 8`), the field-id sentinel, default-construct, and
  basic push/read for both the structured and the lambda paths.

### Acceptance (from the issue)

- [x] Design doc checked into the repo and cross-linked from
  `engine/prefabs/irreden/common/CLAUDE.md`.
- [x] All declared types compile and are exercised by the smoke test
  (the engine ECS auto-registers component types lazily on first use,
  so there is no manual component enum to update — see
  `engine/entity/CLAUDE.md`).
- [x] Lua-binding stub committed.
- [x] `fleet-build --target IRShapeDebug` clean on `macos-debug`.

### Test plan

- [x] `fleet-build --target IRShapeDebug` clean (macOS / Metal).
- [x] `fleet-build --target IrredenEngineTest` clean.
- [x] `fleet-run IrredenEngineTest --gtest_filter=ModifierTypes*` —
  all 8 new tests pass.
- [x] `fleet-run IrredenEngineTest` — full 279-test suite passes.

### Notes for reviewer

- Layout is locked at 24 B by the unit test; an accidental field
  reorder or a new field will break the test, which is the intended
  guard.
- `LambdaModifier` deliberately lives in a sibling component
  (`C_LambdaModifiers`) so the dense `C_Modifiers` path stays
  trivially-copyable.
- `kHasLuaBinding<C_NoGlobalModifiers> = true` matches the existing
  empty-tag-with-Lua-binding precedent at
  `engine/prefabs/irreden/common/components/component_selected_lua.hpp`.
- The `IRPrefab::Modifier::` API surface is documented in the design
  doc but **not** declared in this PR — child 2 owns it alongside the
  runtime, so the surface and its implementation move together.

Closes #303