### PR TITLE
fleet-babysit: disable auto-memory for architects

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -75,6 +75,20 @@ esac
 # To change one pane's effort, edit the case statement above.
 EFFORT="${FLEET_EFFORT:-$EFFORT}"
 
+# Architects boot with auto-memory disabled. The project-wide
+# MEMORY.md auto-injects past-session notes into every Claude Code
+# session — useful continuity for autonomous workers/reviewers, but
+# noise for the architects' interactive design conversations, where
+# stale notes from unrelated prior sessions bias the discussion
+# before the human types anything. Persistent design memory belongs
+# on the issue thread, not in a project-wide file. Glob matches the
+# `*architect*` convention used by ARCHITECT_RESUME below.
+case "$ROLE" in
+    *architect*)
+        export CLAUDE_CODE_DISABLE_AUTO_MEMORY="${CLAUDE_CODE_DISABLE_AUTO_MEMORY:-1}"
+        ;;
+esac
+
 # Timing
 CRASH_DELAY=30        # seconds to wait after non-zero exit (crash)
 LIMIT_DELAY=900       # seconds to wait on suspected usage limit (exit 2)


### PR DESCRIPTION
## Summary

Architect panes (`opus-architect`, `game-architect`) now boot with
`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` so the project-wide auto-memory
file (`~/.claude/projects/<project>/memory/MEMORY.md`) is neither
read nor written for those sessions. Workers, reviewers,
queue-manager, and merger keep auto-memory enabled.

## Why

Auto-memory is two different things in two different roles:

- **Autonomous panes** (sonnet-author, opus-worker, reviewers,
  queue-manager, merger) — each iteration is a fresh `claude`
  process. Auto-memory keeps them learning the fleet's quirks
  across runs (existing notes cover `fleet-build`, `fleet-claim`
  semantics, human-review label handoffs, doc-comment quality bar).
  Net positive.
- **Interactive panes** (the two architects) — the human's design
  partner. The conversation should start from a clean slate so the
  human's first message frames the discussion. Loading a digest of
  unrelated prior sessions biases the conversation before the human
  has typed anything. Persistent architectural decisions belong on
  the issue thread, where they're scoped to one design question and
  visible to workers/reviewers cross-checking the rationale.

## What

One `case` block in `scripts/fleet/fleet-babysit`, just after the
`EFFORT` setup (which is a similar role-vs-model classification).
Uses the `*architect*` glob convention already established 140 lines
down (`ARCHITECT_RESUME` block) so future architect roles are
auto-included. Override is preserved — pre-set
`CLAUDE_CODE_DISABLE_AUTO_MEMORY` in the environment to opt one pane
back in (e.g. for debugging).

## Test plan

- [x] `bash -n scripts/fleet/fleet-babysit` — clean.
- [ ] Next `fleet-up` cycle: opus-architect and game-architect panes
      start without the `# userMemory` system reminder block in
      their first message. Workers/reviewers still load it.
- [ ] Architect's `MEMORY.md` writes (e.g. via `consolidate-memory`
      skill) no-op silently when run from an architect pane.
- [ ] Existing memory file at
      `~/.claude/projects/-Users-evinjkill-src-IrredenEngine/memory/`
      remains untouched by architect activity going forward (workers
      can still mutate it).

## Notes for reviewer

- Live propagation: `~/bin/fleet-babysit` symlinks to the engine
  repo's copy. Once this merges and the user pulls master in the
  main clone, the next `fleet-up` brings up the architects with no
  auto-memory. Currently-running architect sessions keep their
  memory for the rest of their lifetime — they restart with the
  next fleet bounce.
- The `${CLAUDE_CODE_DISABLE_AUTO_MEMORY:-1}` form preserves any
  external override (e.g. `CLAUDE_CODE_DISABLE_AUTO_MEMORY=0
  fleet-up`). Functionally same as `EFFORT="${FLEET_EFFORT:-$EFFORT}"`
  on line 76 above.
- Glob `*architect*` chosen over explicit `opus-architect|game-architect`
  to match the existing classifier at line 239. A hypothetical future
  `render-architect` pane gets the same treatment automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)