### PR TITLE
T-046: audit component-with-helper patterns; codify rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,15 @@ namespaces in headers; keep them in `.cpp`.
   `enum class TypeName : int { SCREAMING_SNAKE_CASE = 0, ... }` per the naming
   table. Strings are for human-readable text, file paths, and external interop —
   not for closed categorical sets that the framework dispatches on.
+- **Components hold data; systems do work.** A component method must read or
+  write only the component's own fields. Methods that look up *another* entity
+  via a stored `EntityId` (`IREntity::getComponent`, `setComponent`,
+  `createEntity`, `setParent`, `getEntity`) belong in a system, an entity
+  builder (`Prefab<>::create`), or a prefab-scoped `IRPrefab::Foo::` namespace
+  (Pattern B in `engine/prefabs/irreden/render/CLAUDE.md`). See
+  `engine/prefabs/CLAUDE.md` §"Component method rules" for the full
+  categorization and the documented exceptions (GPU resource RAII, `onDestroy`
+  IO cleanup).
 
 ---
 

--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -43,8 +43,8 @@ in that domain.
 ## Conventions
 
 - **Components** are plain data structs in `namespace IRComponents`, `C_`
-  prefix, public members with trailing `_`. No methods on components except
-  simple constructors and helpers.
+  prefix, public members with trailing `_`. Helper methods are constrained
+  by the categorization below.
 - **Systems** use `template <> struct IRSystem::System<SYSTEM_NAME>` with a
   static `create()` returning `SystemId`. The `SYSTEM_NAME` must exist in
   `engine/system/include/irreden/ir_system_types.hpp` (`SystemName` enum).
@@ -57,6 +57,64 @@ in that domain.
 - **Lua variants** (`*_lua.hpp`) specialize `kHasLuaBinding<T> = true` and
   implement `bindLuaType<T>(LuaScript&)`. They are only included when a
   creation's `lua_component_pack.hpp` lists them.
+
+## Component method rules
+
+Component methods fall into three tiers:
+
+**(a) Pure data.** Fields and a constructor that initializes them. Most
+components in `common/`, `input/`, and tag-style components fall here.
+
+**(b) Self-only helpers (allowed).** Methods that read or write only the
+component's own fields (and stack-locals derived from them). Examples:
+`C_PeriodicIdle::tick()` advances its own angle, `C_CanvasFogOfWar::setCell`
+writes its own grid, `toGPUFormat()` converts own fields into a render
+struct.
+
+**(c) Cross-entity reaches (forbidden).** Methods that look up *another*
+entity through a stored `EntityId` field — `IREntity::getComponent`,
+`setComponent`, `createEntity`, `setParent`, `getEntity`. These belong in
+a system (per-frame work) or one of:
+
+- **Entity builder** — `template <> struct IREntity::Prefab<NAME>` with a
+  `create()` that wires up the entity bundle. Example:
+  `engine/prefabs/irreden/render/entities/entity_trixel_canvas.hpp`.
+- **Prefab-scoped namespace** — a sibling `<feature>.hpp` exposing a
+  `namespace IRPrefab::Foo` with free functions. The namespace owns the
+  entity-lookup logic; callers don't carry the entity id. Example:
+  `engine/prefabs/irreden/render/fog_of_war.hpp`. Use this when an API
+  needs an ergonomic free-function shape and the caller is unlikely to
+  hold the entity id.
+
+The split keeps component layout trivial (good for archetype iteration)
+and concentrates per-entity orchestration where it belongs.
+
+### Documented exceptions
+
+These patterns *look* like (c) but are accepted because the alternatives
+are worse:
+
+- **GPU / IO resource RAII.** A constructor that calls
+  `IRRender::createResource<>` and a destructor that calls
+  `destroyResource<>` is fine — the component IS the resource owner, and
+  splitting allocation into a system makes the lifetime contract harder
+  to enforce. Examples: `C_TriangleCanvasTextures`, `C_TrixelFramebuffer`,
+  `C_CanvasFogOfWar`, `C_CanvasSunShadow`, `C_CanvasAOTexture`,
+  `C_CanvasLightVolume`.
+- **`onDestroy()` IO cleanup.** A component that hooks the entity's
+  destroy event to flush an external side effect (e.g.,
+  `C_MidiNote::onDestroy()` sending NOTE_OFF) is fine when the cleanup
+  must be synchronized with entity death and a per-component hook is
+  simpler than a "scan dying entities" system. Document the side effect
+  in the domain `CLAUDE.md`.
+- **Constructor snapshots ambient state.** A constructor that reads
+  `IRRender::getActiveCanvasEntity()` (or similar) to bind the component
+  to the currently-active canvas is fine — no other entity is mutated,
+  and the alternative is forcing every caller to thread the canvas id.
+  Examples: `C_VoxelSet`, `C_ShapeDescriptor`.
+
+Anything outside (a)/(b) and not on the exceptions list is a (c) violation
+and should be moved to a system, builder, or namespace.
 
 ## Anti-patterns
 

--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -111,7 +111,7 @@ are worse:
   `IRRender::getActiveCanvasEntity()` (or similar) to bind the component
   to the currently-active canvas is fine — no other entity is mutated,
   and the alternative is forcing every caller to thread the canvas id.
-  Examples: `C_VoxelSet`, `C_ShapeDescriptor`.
+  Examples: `C_VoxelSetNew`, `C_ShapeDescriptor`.
 
 Anything outside (a)/(b) and not on the exceptions list is a (c) violation
 and should be moved to a system, builder, or namespace.

--- a/engine/prefabs/irreden/render/components/component_entity_canvas.hpp
+++ b/engine/prefabs/irreden/render/components/component_entity_canvas.hpp
@@ -3,11 +3,6 @@
 
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_entity.hpp>
-#include <irreden/ir_render.hpp>
-
-#include <irreden/render/components/component_triangle_canvas_textures.hpp>
-#include <irreden/common/components/component_size_triangles.hpp>
-#include <irreden/voxel/components/component_voxel_pool.hpp>
 
 using namespace IRMath;
 
@@ -15,44 +10,13 @@ namespace IRComponents {
 
 struct C_EntityCanvas {
     IREntity::EntityId canvasEntity_ = IREntity::kNullEntity;
-    ivec2 canvasSize_;
+    ivec2 canvasSize_{0};
     bool visible_ = true;
 
-    C_EntityCanvas() : canvasSize_{0} {}
+    C_EntityCanvas() = default;
 
-    C_EntityCanvas(ivec2 canvasSize)
-        : canvasSize_{canvasSize} {
-        canvasEntity_ = IREntity::createEntity(
-            C_SizeTriangles{canvasSize},
-            C_TriangleCanvasTextures{canvasSize}
-        );
-        IREntity::EntityId mainFb = IREntity::getEntity("mainFramebuffer");
-        if (mainFb != IREntity::kNullEntity) {
-            IREntity::setParent(canvasEntity_, mainFb);
-        }
-    }
-
-    void addVoxelPool(ivec3 poolSize) {
-        if (canvasEntity_ != IREntity::kNullEntity) {
-            IREntity::setComponent(canvasEntity_, C_VoxelPool{poolSize});
-        }
-    }
-
-    void resize(ivec2 newSize) {
-        canvasSize_ = newSize;
-        if (canvasEntity_ != IREntity::kNullEntity) {
-            IREntity::setComponent(canvasEntity_, C_SizeTriangles{newSize});
-            IREntity::setComponent(canvasEntity_, C_TriangleCanvasTextures{newSize});
-        }
-    }
-
-    C_TriangleCanvasTextures &getTextures() {
-        return IREntity::getComponent<C_TriangleCanvasTextures>(canvasEntity_);
-    }
-
-    const C_TriangleCanvasTextures &getTextures() const {
-        return IREntity::getComponent<C_TriangleCanvasTextures>(canvasEntity_);
-    }
+    C_EntityCanvas(IREntity::EntityId canvasEntity, ivec2 canvasSize, bool visible = true)
+        : canvasEntity_{canvasEntity}, canvasSize_{canvasSize}, visible_{visible} {}
 };
 
 } // namespace IRComponents

--- a/engine/prefabs/irreden/render/components/component_entity_canvas_lua.hpp
+++ b/engine/prefabs/irreden/render/components/component_entity_canvas_lua.hpp
@@ -9,19 +9,14 @@ template <> inline constexpr bool kHasLuaBinding<IRComponents::C_EntityCanvas> =
 
 template <> inline void bindLuaType<IRComponents::C_EntityCanvas>(LuaScript &luaScript) {
     using IRComponents::C_EntityCanvas;
-    using IRMath::ivec2;
-    using IRMath::ivec3;
-    luaScript.registerType<
-        C_EntityCanvas,
-        C_EntityCanvas(ivec2),
-        C_EntityCanvas()>(
+    luaScript.registerType<C_EntityCanvas, C_EntityCanvas()>(
         "C_EntityCanvas",
         "canvasSize",
         &C_EntityCanvas::canvasSize_,
         "visible",
         &C_EntityCanvas::visible_,
-        "addVoxelPool",
-        &C_EntityCanvas::addVoxelPool
+        "canvasEntity",
+        &C_EntityCanvas::canvasEntity_
     );
 }
 } // namespace IRScript

--- a/engine/prefabs/irreden/render/components/component_entity_canvas_lua.hpp
+++ b/engine/prefabs/irreden/render/components/component_entity_canvas_lua.hpp
@@ -9,6 +9,7 @@ template <> inline constexpr bool kHasLuaBinding<IRComponents::C_EntityCanvas> =
 
 template <> inline void bindLuaType<IRComponents::C_EntityCanvas>(LuaScript &luaScript) {
     using IRComponents::C_EntityCanvas;
+    // Default ctor only — to create a live canvas-backed entity call IRPrefab::EntityCanvas::create() from C++; no Lua factory binding exists.
     luaScript.registerType<C_EntityCanvas, C_EntityCanvas()>(
         "C_EntityCanvas",
         "canvasSize",

--- a/engine/prefabs/irreden/render/entity_canvas.hpp
+++ b/engine/prefabs/irreden/render/entity_canvas.hpp
@@ -1,0 +1,63 @@
+#ifndef IR_PREFAB_ENTITY_CANVAS_H
+#define IR_PREFAB_ENTITY_CANVAS_H
+
+// Prefab-scoped helpers for C_EntityCanvas. The component itself is plain
+// data (an EntityId pointing at a child canvas entity, plus size/visible
+// fields); cross-entity orchestration — spawning the child, parenting it
+// to mainFramebuffer, swapping its textures on resize — lives here so
+// the component layout stays trivial and archetype-iteration friendly.
+//
+// `create` delegates to Prefab<PrefabTypes::kTrixelCanvas> so the canvas-
+// entity bundle (textures + size + name) and parent-to-mainFramebuffer
+// behavior stays defined in one place. If a creation needs a voxel-pool-
+// backed canvas, prefer Prefab<PrefabTypes::kVoxelPoolCanvas>::create
+// directly — `addVoxelPool` here is a post-hoc archetype migration that
+// triggers a node move.
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <irreden/render/components/component_entity_canvas.hpp>
+#include <irreden/render/components/component_triangle_canvas_textures.hpp>
+#include <irreden/render/entities/entity_trixel_canvas.hpp>
+#include <irreden/common/components/component_size_triangles.hpp>
+#include <irreden/voxel/components/component_voxel_pool.hpp>
+
+#include <string>
+
+namespace IRPrefab::EntityCanvas {
+
+/// Spawn a child canvas entity (textures + size + name) parented to
+/// `mainFramebuffer`, and return a `C_EntityCanvas` that wraps it. Add
+/// the returned component to the parent entity that should host the
+/// sub-canvas. The name lets debug tooling and entity-by-name lookup
+/// find the child later.
+inline IRComponents::C_EntityCanvas create(std::string canvasName, IRMath::ivec2 canvasSize) {
+    IREntity::EntityId canvas =
+        IREntity::Prefab<IREntity::PrefabTypes::kTrixelCanvas>::create(canvasName, canvasSize);
+    return IRComponents::C_EntityCanvas{canvas, canvasSize};
+}
+
+/// Attach a `C_VoxelPool` to the child canvas entity, upgrading it for
+/// voxel-pool consumers. No-op if the canvas isn't initialized.
+inline void addVoxelPool(
+    const IRComponents::C_EntityCanvas &entityCanvas, IRMath::ivec3 poolSize
+) {
+    if (entityCanvas.canvasEntity_ == IREntity::kNullEntity) return;
+    IREntity::setComponent(entityCanvas.canvasEntity_, IRComponents::C_VoxelPool{poolSize});
+}
+
+/// Resize the child canvas's textures and update the wrapper's cached
+/// size. No-op if the canvas isn't initialized.
+inline void resize(IRComponents::C_EntityCanvas &entityCanvas, IRMath::ivec2 newSize) {
+    entityCanvas.canvasSize_ = newSize;
+    if (entityCanvas.canvasEntity_ == IREntity::kNullEntity) return;
+    IREntity::setComponent(entityCanvas.canvasEntity_, IRComponents::C_SizeTriangles{newSize});
+    IREntity::setComponent(
+        entityCanvas.canvasEntity_, IRComponents::C_TriangleCanvasTextures{newSize}
+    );
+}
+
+} // namespace IRPrefab::EntityCanvas
+
+#endif /* IR_PREFAB_ENTITY_CANVAS_H */


### PR DESCRIPTION
## Summary
- Audited every `engine/prefabs/**/components/component_*.hpp` for cross-entity reaches; found exactly one violation (`C_EntityCanvas`).
- Refactored `C_EntityCanvas` to plain data; moved ctor/`addVoxelPool`/`resize` into `IRPrefab::EntityCanvas::` free functions (Pattern B). New `create()` delegates to `Prefab<kTrixelCanvas>::create` so the canvas-entity bundle and parent-to-mainFramebuffer logic lives in one place.
- Deleted dead `getTextures()` (no callers; system already uses `getComponentOptional` directly).
- Codified the rule: top-level `CLAUDE.md` Style bullet + full \"Component method rules\" section in `engine/prefabs/CLAUDE.md` covering the (a)/(b)/(c) categorization and the three documented exceptions (GPU resource RAII, `onDestroy` IO cleanup, ctor snapshots of ambient state).

## Audit findings

(c) violations — refactored: `C_EntityCanvas`.

Documented exceptions (left as-is, called out in the new doc): GPU resource RAII (`C_TriangleCanvasTextures`, `C_TrixelFramebuffer`, `C_CanvasFogOfWar`, `C_CanvasSunShadow`, `C_CanvasAOTexture`, `C_CanvasLightVolume`), `C_MidiNote::onDestroy()` (note-off on death), `C_VoxelSet`/`C_ShapeDescriptor` ctors snapshotting active canvas.

Everything else is (a) pure data or (b) self-only helpers.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] `fleet-run IrredenEngineTest` — 271/271 pass
- [x] `fleet-build --target IRShapeDebug` — clean
- [x] `fleet-run --timeout 5 IRShapeDebug` — engine boots, render pipeline initializes, no crash

No visual change (no demo creates `C_EntityCanvas` today; it has only one consumer system that wasn't touched).

Closes #294