### PR TITLE
fleet: add fleet:semantic-conflict label + opus-worker resolution lane

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -391,11 +391,13 @@ exit cleanly:
            — fleet merger
            ```
          - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
-         - Remove `fleet:approved` if it's set. Issue this as its
-           own Bash call — `gh pr edit --remove-label` returns
-           non-zero when the label isn't present, which would abort
-           a chained `--add-label`:
+         - Remove any stale review/verdict labels. Each as its own
+           Bash call — `gh pr edit --remove-label` returns non-zero
+           when the label isn't present, which would abort a chained
+           `--add-label`:
            `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:approved"`
+           `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:has-nits"`
+           `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:needs-fix"`
            Then add the conflict and cooldown labels:
            `gh pr edit <N> --repo <engine-repo> --add-label "fleet:semantic-conflict"`
            `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -363,25 +363,30 @@ exit cleanly:
 
       **iii. Anything else (semantic conflict).**
          - `git rebase --abort`
-         - Build a description of the conflict for the human. Cap
-           the file list at 5; if more files conflict, append
-           `… and N more` so the comment stays readable. For each
-           listed file, run `git log -1 --format="%h %s" origin/master -- <file>`
-           to identify what touched it on master, and
+         - Build a description of the conflict. Cap the file list at
+           5; if more files conflict, append `… and N more` so the
+           comment stays readable. For each listed file, run
+           `git log -1 --format="%h %s" origin/master -- <file>` to
+           identify what touched it on master, and
            `git log -1 --format="%h %s" -- <file>` for the PR side.
            Write to `.merger-body.md`:
            ```
-           Merger: cannot auto-resolve. The PR conflicts with
-           current master in ways that require human judgement.
+           Merger: cannot auto-resolve mechanically. The PR has
+           semantic conflicts with current master that need
+           judgement-level resolution.
 
            Conflicted files:
            - `<file1>` — master: `<sha> <subj>`; PR: `<sha> <subj>`
            - `<file2>` — ...
 
-           Please rebase locally and resolve, or coordinate with the
-           author of the conflicting master change. The
-           `fleet:approved` label has been removed if it was set —
-           the PR no longer represents a reviewed state.
+           Labeled `fleet:semantic-conflict` — an opus-worker will
+           attempt resolution on its next iteration (rebase,
+           manually resolve, build, push). If the opus-worker also
+           can't resolve (truly ambiguous, design decision needed),
+           it will escalate to `human:needs-fix`.
+
+           The `fleet:approved` label has been removed if it was set
+           — the PR no longer represents a reviewed state.
 
            — fleet merger
            ```
@@ -391,10 +396,10 @@ exit cleanly:
            non-zero when the label isn't present, which would abort
            a chained `--add-label`:
            `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:approved"`
-           Then add the human-fix and cooldown labels:
-           `gh pr edit <N> --repo <engine-repo> --add-label "human:needs-fix"`
+           Then add the conflict and cooldown labels:
+           `gh pr edit <N> --repo <engine-repo> --add-label "fleet:semantic-conflict"`
            `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
-         - Log: `... semantic conflict, labeled human:needs-fix`
+         - Log: `... semantic conflict, labeled fleet:semantic-conflict`
 
    **e. Post-rebase hunk check.** Runs on ALL paths that reach a push
       (clean rebase, case i, case ii). Captures the post-rebase diff

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -131,8 +131,11 @@ conditions, allocator behavior, hot-path costs.
      `gh pr view <N> --comments` after your last review's
      `submittedAt`).
 
-   **Skip** PRs labeled `fleet:wip`, `human:wip`, or `human:needs-fix`
-   — those are either in-progress or human-owned.
+   **Skip** PRs labeled `fleet:wip`, `human:wip`, `human:needs-fix`,
+   or `fleet:semantic-conflict` — those are either in-progress,
+   human-owned, or queued for the opus-worker's conflict-resolution
+   lane (the diff against master is meaningless until the rebase
+   lands).
 
 ## Loop behavior
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -327,6 +327,9 @@ Do the work, then exit cleanly:
 
     Game repo is intentionally out of scope for v1: the merger is
     engine-only, so no game PR ever gets the label.
+    All `--repo` flags in this step use `jakildev/IrredenEngine`
+    (`<engine-repo>` in the merger-role convention — same slug, not
+    auto-derived here since this step is always engine-only).
 
     If the filtered list is empty, skip to step 2. Otherwise pick
     the oldest (smallest `number`) and:
@@ -376,6 +379,11 @@ Do the work, then exit cleanly:
        this PR matched the filter):
        `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:semantic-conflict" --add-label "fleet:changes-made"`
        `gh pr comment <N> --repo jakildev/IrredenEngine --body "Resolved semantic conflict: <one-line summary of what you reconciled>. Build clean. Reviewer please re-evaluate the rebased diff. — opus-worker"`
+       Also clear the merger's cooldown label if still present — prevents
+       one unnecessary iteration delay before the PR can be re-evaluated
+       (the merger clears it anyway on next tick, but this makes it
+       watertight when the opus-worker resolves before the merger fires):
+       `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:merger-cooldown"`
        Then jump to step k (reset).
     j. **Resolution failed (escalation).** When to escalate:
        - The two sides did substantively different things and you

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -308,6 +308,102 @@ Do the work, then exit cleanly:
     are handled across successive iterations so task pickup isn't
     starved by back-to-back smoke runs.
 
+1c. **Resolve one `fleet:semantic-conflict` PR per iteration
+    (engine only).** The merger sets this label when mechanical
+    rebase fails (label semantics: see CLAUDE.md "Issue/PR labeling
+    discipline"). That's your lane.
+
+    From the cached `repos.engine.prs[]`, pick PRs whose `labels`
+    array contains `fleet:semantic-conflict` AND contains NONE of
+    `fleet:wip`, `human:wip`, `human:needs-fix`, `human:blocker`,
+    `fleet:awaiting-base`, `fleet:awaiting-upstream-review`. The
+    `awaiting-*` exclusions matter because those PRs aren't yet
+    rebaseable against master.
+
+    **Stack-aware filter.** If a candidate's `baseRefName != master`
+    (stacked PR), look up the base PR in the cached `prs[]` by its
+    `headRefName`. If the base PR also has `fleet:semantic-conflict`,
+    SKIP this candidate — resolve the base first.
+
+    Game repo is intentionally out of scope for v1: the merger is
+    engine-only, so no game PR ever gets the label.
+
+    If the filtered list is empty, skip to step 2. Otherwise pick
+    the oldest (smallest `number`) and:
+
+    a. Re-touch heartbeat — rebases + reads can take minutes:
+       `fleet-heartbeat <your-worktree-basename>`
+    b. Read the merger's most recent comment — it lists the
+       conflicted files and the master/PR shas that touched each,
+       so you don't need to re-discover them:
+       `gh pr view <N> --repo jakildev/IrredenEngine --comments`
+       Look for the comment ending in `— fleet merger`.
+    c. Check out the PR (this also fetches the head branch):
+       `gh pr checkout <N> --repo jakildev/IrredenEngine`
+    d. Identify the rebase target. For most PRs `baseRefName` is
+       `master`; for stacked PRs it's the upstream branch. Use
+       whichever the PR is actually based on, NOT always master:
+       `git fetch origin <baseRefName>`
+       `git rebase origin/<baseRefName>`
+    e. For each conflicted file (`git diff --name-only --diff-filter=U`):
+       - **Read the full file** (not just the conflict block) so you
+         understand the surrounding code.
+       - Step b's comment already names the relevant master/PR
+         shas. Pull bodies for context where needed:
+         `git log -1 --format="%h %s%n%n%b" <sha> -- <file>`
+       - Resolve manually with the Edit tool. The principle: preserve
+         BOTH sides' intent unless they're genuinely incompatible.
+       - `git add <file>`
+    f. Continue the rebase: `git rebase --continue`. If new conflicts
+       surface in subsequent commits, repeat step e for each.
+    g. **Build before pushing.** Safety net for resolutions that
+       compile-broke without a textual conflict marker (the most
+       common Opus failure mode):
+       `fleet-build --target IRShapeDebug`
+       If the build fails AND the failure is in code that this PR
+       touched, fix it inline and rebuild. If the failure is in
+       unrelated code, your resolution introduced a regression —
+       jump to step j (escalate).
+    h. Push:
+       `git push --force-with-lease`
+       If the lease check fails (someone pushed in parallel), add
+       `fleet:merger-cooldown` so the next iteration doesn't
+       re-attempt immediately, then jump to step k (reset):
+       `gh pr edit <N> --repo jakildev/IrredenEngine --add-label "fleet:merger-cooldown"`
+    i. **Resolution succeeded.** Swap labels and comment in one
+       `gh pr edit` call (safe to combine remove+add here because
+       `fleet:semantic-conflict` is guaranteed present — that's how
+       this PR matched the filter):
+       `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:semantic-conflict" --add-label "fleet:changes-made"`
+       `gh pr comment <N> --repo jakildev/IrredenEngine --body "Resolved semantic conflict: <one-line summary of what you reconciled>. Build clean. Reviewer please re-evaluate the rebased diff. — opus-worker"`
+       Then jump to step k (reset).
+    j. **Resolution failed (escalation).** When to escalate:
+       - The two sides did substantively different things and you
+         can't tell from the code which intent should win (master
+         rewrote a function, PR also rewrote it, neither is a
+         superset).
+       - The conflict requires a product/architecture decision (e.g.
+         master removed an API the PR depends on — should the PR
+         migrate or be reverted?).
+       - You resolved the markers but the build fails in code the
+         PR didn't touch — your resolution introduced a regression
+         you can't fix from the PR's intent alone.
+
+       Abort and hand off to the human (same combine-safe rationale
+       as step i):
+       `git rebase --abort`
+       `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:semantic-conflict" --add-label "human:needs-fix"`
+       `gh pr comment <N> --repo jakildev/IrredenEngine --body "Opus pass on semantic conflict could not resolve: <one paragraph of why — what the two sides did, what the ambiguity is>. Handing off to human. — opus-worker"`
+    k. Reset to scratch (runs at the end of every step 1c branch —
+       success, lease-fail, or escalation — so the next iteration
+       starts clean and reviewers aren't blocked from `gh pr
+       checkout`ing this branch):
+       `git checkout -B claude/<your-worktree-basename>-scratch origin/master`
+
+    Conflicts are slow work (read both sides, judge intent, build,
+    push) and force-push retriggers CI — keep this step bounded to
+    one PR per iteration.
+
 2. **Plan any `fleet:needs-plan` issues on either repo.** The
    cached `repos.engine.needs_plan[]` and `repos.game.needs_plan[]`
    arrays hold the open needs-plan issues. Pick the oldest

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -209,11 +209,13 @@ Each iteration:
    appears. If the human wants more changes after a review pass,
    they re-add `human:needs-fix`.
 
-   The merger uses the same path: when it labels a PR
-   `human:needs-fix` for an unresolvable conflict, an opus-worker
-   that picks up the conflict resolution should follow this same
-   cycle (remove `human:needs-fix`, fix, add `fleet:changes-made`).
-   The fleet reviewer will re-verify the resolution.
+   The merger has its own label for non-mechanical rebase
+   conflicts: `fleet:semantic-conflict`. That label is **not your
+   lane** — it's owned by the opus-worker (which has the budget +
+   the rebase + manual conflict resolution flow in its role doc).
+   You skip PRs with this label entirely. If the opus-worker also
+   can't resolve, IT escalates to `human:needs-fix`, which you DO
+   pick up via the normal cycle above.
 
    **Fleet feedback cycle:** fleet reviewer adds `fleet:needs-fix` →
    author removes it, fixes, pushes → fleet reviewer sees the new

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -129,6 +129,10 @@ treat it as a hard rule for this role.
    - `human:needs-fix` — human requested changes, author agent is
      handling it. Don't pile on a fleet review while the human's
      feedback is being addressed.
+   - `fleet:semantic-conflict` — merger detected a non-mechanical
+     rebase conflict; the opus-worker is queued to attempt
+     resolution. The PR's diff against master is meaningless until
+     the rebase lands, so reviewing now wastes a pass.
 
 ## Loop behavior
 
@@ -151,8 +155,9 @@ iteration of polling, reviewing, and exiting cleanly:
    PRs with no fleet review, with `human:re-review`, with
    `fleet:changes-made` (remove the label on pickup), or with a "re-review please"
    comment after the last fleet review. Skip PRs carrying any of
-   `fleet:wip`, `human:wip`, or `human:needs-fix`. For each remaining
-   candidate, in oldest-first order:
+   `fleet:wip`, `human:wip`, `human:needs-fix`, or
+   `fleet:semantic-conflict`. For each remaining candidate, in
+   oldest-first order:
 
    **Engine PRs** (default repo): Invoke the `review-pr` skill with
    the PR number. Every engine PR today is single-task — one task, one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,6 +541,10 @@ Specifically, **never pass these via `--label` when filing**:
   during a normal `commit-and-push` flow). Don't add to issues.
 - `fleet:in-progress` / `fleet:merger-cooldown` /
   `fleet:changes-made` — owned by the worker / merger pipeline.
+- `fleet:semantic-conflict` — owned by the **merger** (sets when it
+  can't auto-rebase). Cleared by the **opus-worker** after it
+  resolves the conflict, or escalated to `human:needs-fix` if even
+  Opus can't resolve.
 
 **The right pattern when filing an issue:** create it with NO labels.
 The human will add `human:approved` if and when they want it picked

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -102,6 +102,7 @@ LABELS=(
     "fleet:has-nits|fbca04|Approved but author should clean up nits before merge"
     "fleet:needs-fix|d73a4a|Reviewer agent flagged correctness/quality issues"
     "fleet:blocker|800010|Reviewer agent flagged a blocker; do not merge"
+    "fleet:semantic-conflict|d73a4a|Merger detected non-mechanical conflict; opus-worker will attempt resolution before escalating to human"
     "fleet:merger-cooldown|bfdadc|Merger touched this PR; skip until next iteration"
     "fleet:needs-linux-smoke|c5def5|Engine render PR awaiting Linux/OpenGL cross-host smoke validation"
     "fleet:needs-macos-smoke|c5def5|Engine render PR awaiting macOS/Metal cross-host smoke validation"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -215,6 +215,7 @@ REVIEW_VERDICT_LABELS = frozenset({
 })
 REVIEW_SKIP_LABELS = frozenset({
     "fleet:wip", "human:wip", "fleet:merger-cooldown", "human:needs-fix",
+    "fleet:semantic-conflict",
 })
 RECHECK_LABELS = frozenset({"human:re-review", "fleet:changes-made"})
 


### PR DESCRIPTION
## Summary

When the merger can't auto-rebase a PR, it now labels it
`fleet:semantic-conflict` (instead of `human:needs-fix`), and the
opus-worker grows a step 1c that attempts manual resolution before
escalating to the human. Distinct verdict label = distinct routing
+ visible-at-a-glance distinction between code-review feedback and
merge conflicts.

## Why

Previously, both code-review feedback (\"this function is leaky\")
and unresolvable merge conflicts (\"I tried to rebase your PR onto
master and it conflicted in 3 files\") landed under the same label:
`human:needs-fix`. Two problems:

1. **Visibility** — the human couldn't tell at a glance which PRs
   were waiting on code-review fixes vs merge conflicts. Different
   work modes (read comments + edit + push vs. checkout + rebase +
   resolve markers + force-push), same signal.
2. **Routing** — merge-conflict resolution is exactly the kind of
   work an Opus agent can attempt. Routing all conflicts directly
   to the human was wasting the budget split. Author agents picking
   up `human:needs-fix` would try to address \"feedback\" but the
   PR has none — the conflict is between branches, not in comments.

## What

The escalation chain is now:

```
merger detects semantic conflict
  → labels fleet:semantic-conflict + fleet:merger-cooldown,
    removes fleet:approved, comments with conflicted-files list
  → opus-worker step 1c picks it up next iteration (1/iter, same
    throttle as smoke validation)
      → checkout, rebase against PR's actual baseRefName
        (master OR upstream branch for stacked PRs),
        read both sides, resolve manually, build, push,
        swap to fleet:changes-made
      → reviewer re-evaluates the rebased diff
  OR if Opus also can't resolve (genuinely ambiguous, design
  decision needed, or build broke unrelated code):
      → escalate to human:needs-fix, comment with the why,
        author/architect handles it via existing path
```

**Stack-aware:** the resolver looks up the candidate's
`baseRefName` in the cached `prs[]` and skips children whose base
is also conflicted (resolve base first). Stacked PRs whose base
merged + got re-targeted to master (`fleet:stacked-rebase`) just
rebase against master normally — no special path needed.

## Files (8)

| File | Why |
|---|---|
| `scripts/fleet/fleet-labels` | Register the new label (red, same family as `fleet:needs-fix`) |
| `scripts/fleet/fleet-state-scout` | Add to `REVIEW_SKIP_LABELS` so reviewer projections skip mid-conflict PRs |
| `.claude/commands/role-merger.md` | Replace `human:needs-fix` with `fleet:semantic-conflict` in the case-iii verdict; updated comment body to mention the opus-worker handoff |
| `.claude/commands/role-opus-worker.md` | New step 1c (~96 lines) between existing 1b (smoke) and 2 (planning) |
| `.claude/commands/role-sonnet-reviewer.md` + `role-opus-reviewer.md` | Skip the new label in their PR pickup |
| `.claude/commands/role-sonnet-author.md` | Existing conflict-resolution note (left over from when conflicts were lumped under `human:needs-fix`) updated to point at the new opus-worker lane |
| `CLAUDE.md` \"Issue/PR labeling discipline\" | New label added to the merger-owned list |

## Test plan

- [x] `bash -n scripts/fleet/fleet-labels` clean
- [x] `python3 -c \"import scripts.fleet.fleet_state_scout\"` (or equivalent ast.parse) — `REVIEW_SKIP_LABELS` frozenset addition is syntactically valid
- [x] `simplify` pass: trimmed step 1c by 7 lines (deduped 3x reset-to-scratch into a footer step, combined safe `--remove-label X --add-label Y` calls, removed redundant prose)
- [ ] Live: trigger a real semantic conflict (modify a function on master, modify the same function differently on a feature branch, push, wait for merger)
- [ ] Live: confirm merger labels `fleet:semantic-conflict` (not `human:needs-fix`)
- [ ] Live: confirm opus-worker step 1c picks it up next iteration and either resolves or escalates with explanation
- [ ] Live: confirm reviewer panes skip the PR while it's labeled `fleet:semantic-conflict`

## Notes for reviewer

- `fleet-labels` runs `gh label create` only on labels that don't
  yet exist (idempotent), so the new label gets created on the
  next `fleet-up` automatically. Existing PRs labeled
  `human:needs-fix` for old merger conflicts stay as they are —
  the human handles them; we don't retroactively re-label.
- Step 1c is intentionally the same shape as step 1b (smoke
  validation): one PR per iteration, heartbeat-touch first, scratch
  reset at the end. The simplify pass made the structural symmetry
  explicit by extracting the reset into step k.
- The `--remove-label X --add-label Y` combinations in steps 1i and
  1j are safe to combine (the merger doc warns about combining when
  the removed label might not be present — but in step 1c, the
  removed label `fleet:semantic-conflict` is GUARANTEED present
  because that's how the candidate matched the filter). The doc
  notes this explicitly.
- The merger is engine-only in v1, so this entire flow is engine-only.
  Game support comes when the merger does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)