### PR TITLE
fleet: author host suppresses its own cross-host smoke label

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -246,17 +246,25 @@ iteration of polling, reviewing, and exiting cleanly:
    label is set, check whether the PR's diff touches any render path:
    `engine/render/`, `engine/prefabs/irreden/render/`, any `*.glsl`,
    any `*.metal`, or any file under `engine/render/src/shaders/`. Use
-   `gh pr diff <N> --name-only` to read the changed paths. If any path
-   matches, add BOTH smoke labels so both hosts pick the PR up for
-   validation:
-   `gh pr edit <N> --add-label "fleet:needs-linux-smoke" --add-label "fleet:needs-macos-smoke"`
+   `gh pr diff <N> --name-only` to read the changed paths. If any
+   path matches, add the smoke label for the host the author was NOT
+   on (`commit-and-push` stamps `fleet:authored-on-<host>` at PR
+   create-time; the author already smoke-tested their own host per
+   the workflow):
+
+   - PR has `fleet:authored-on-linux` → add `fleet:needs-macos-smoke`
+   - PR has `fleet:authored-on-macos` → add `fleet:needs-linux-smoke`
+   - Neither (Windows-native author, or pre-fix PR) → add both
+
+   `gh pr edit <N> --add-label "fleet:needs-<other-host>-smoke"`
+
    Each host's author agents poll for the label matching their host,
    run a clean-checkout build + `IRShapeDebug` smoke, and remove the
-   label on success. The PR cannot be safely merged until both labels
-   are gone. Skip for game-repo PRs and non-render engine PRs — the
-   labels narrow the "did this port build on the other backend"
-   question, not general CI. If Sonnet already added the labels on
-   first pass, no action needed.
+   label on success. The PR cannot be safely merged until the
+   outstanding label is gone. Skip for game-repo PRs and non-render
+   engine PRs — the labels narrow the "did this port build on the
+   other backend" question, not general CI. If Sonnet already added
+   the labels on first pass, no action needed.
 
    **Nits vs real issues — the bright line:**
    - **Approve with nits** is fine for genuinely-optional improvements

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -289,17 +289,24 @@ iteration of polling, reviewing, and exiting cleanly:
    `engine/render/`, `engine/prefabs/irreden/render/`, any `*.glsl`,
    any `*.metal`, or any file under `engine/render/src/shaders/`. Use
    `gh pr diff <N> --name-only` to read the changed paths. If any path
-   matches, add BOTH smoke labels so both hosts pick the PR up for
-   validation:
-   `gh pr edit <N> --add-label "fleet:needs-linux-smoke" --add-label "fleet:needs-macos-smoke"`
+   matches, add the smoke label for the host the author was NOT on
+   (the author already smoke-tested their own host per the workflow,
+   so tagging it again is redundant):
+
+   - PR has `fleet:authored-on-linux` → add `fleet:needs-macos-smoke`
+   - PR has `fleet:authored-on-macos` → add `fleet:needs-linux-smoke`
+   - Neither (Windows-native author, or pre-fix PR) → add both
+
+   `gh pr edit <N> --add-label "fleet:needs-<other-host>-smoke"`
+
    Each host's author agents (opus-worker, sonnet-author) poll for the
    label matching their host, run a clean-checkout build + `IRShapeDebug`
    smoke, and remove the label on success. The PR cannot be safely
-   merged until both labels are gone. Skip this step for game-repo PRs
-   — cross-host smoke applies to engine backends only. Skip for
-   non-render engine PRs (tooling, docs, non-render modules) — the
-   labels exist to narrow the "did this port build on the other
-   backend" question, not as general CI.
+   merged until the outstanding label is gone. Skip this step entirely
+   for game-repo PRs — cross-host smoke applies to engine backends
+   only. Skip for non-render engine PRs (tooling, docs, non-render
+   modules) — the labels exist to narrow the "did this port build on
+   the other backend" question, not as general CI.
 
    **Nits vs real issues — the bright line:**
    - **Approve with nits** is fine for genuinely-optional cosmetic

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -372,6 +372,46 @@ siblings if they want cross-context. The merger reads `baseRefName`
 directly for correctness decisions; `fleet:stacked` is a derived
 convenience label for human visibility and cheap filtering.
 
+### 8b. Tag the host the PR was authored on
+
+After `gh pr create` succeeds, stamp a `fleet:authored-on-<host>`
+label so the reviewer knows which backend the author already
+implicitly smoke-tested. Per the engine `CLAUDE.md` "Verifying
+render changes" section, render-PR authors are expected to build
+and run the demo on their host before opening — so authoring on a
+host is reasonable evidence that host's smoke is at least
+baseline-validated.
+
+This is the **author's host fact**, not a state label. Reviewers
+read it to skip the matching `fleet:needs-<host>-smoke` label so
+the author's host doesn't get tagged for redundant validation.
+The OTHER host's smoke label (if needed per the diff) still gets
+added — backend drift between OpenGL and Metal is the whole point
+of cross-host validation.
+
+```bash
+host_kernel=$(uname -s)
+case "$host_kernel" in
+    Linux)  host_label="fleet:authored-on-linux" ;;
+    Darwin) host_label="fleet:authored-on-macos" ;;
+    *)      host_label="" ;;  # unknown host (Windows native, etc.) — skip
+esac
+if [[ -n "$host_label" ]]; then
+    gh pr edit <N> --add-label "$host_label"
+fi
+```
+
+This applies to **all** PRs (engine and game, render-touching or
+not). The label is cheap and consistent — having it always present
+makes the reviewer's logic simple ("subtract author host from smoke
+labels"). Game PRs don't currently get smoke labels, so the host
+label is just informational there; that's fine.
+
+If the host kernel is neither `Linux` nor `Darwin` (Windows
+native via MSYS2, etc.), skip the label — the cross-host smoke
+flow is OpenGL-on-Linux vs Metal-on-macOS, and a Windows author
+doesn't fit either bucket cleanly.
+
 ### 9. Report the result
 
 Reply with a compact summary:

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -369,7 +369,7 @@ After setting the verdict label in 5b, check the diff's file paths:
 gh pr diff <N> --name-only
 ```
 
-If any path matches **any** of these, add both smoke labels:
+If any path matches **any** of these, the PR needs cross-host smoke:
 
 - `engine/render/`
 - `engine/prefabs/irreden/render/`
@@ -377,8 +377,28 @@ If any path matches **any** of these, add both smoke labels:
 - any `*.glsl` file
 - any `*.metal` file
 
+**Subtract the author's host before tagging.** `commit-and-push`
+stamps `fleet:authored-on-linux` or `fleet:authored-on-macos` at
+PR-create time based on the author's `uname -s`. Per the engine
+`CLAUDE.md` "Verifying render changes" section, render-PR authors
+build + run the demo on their host before opening, so authoring
+on a host is reasonable evidence its smoke is baseline-validated.
+Only the OTHER host actually needs cross-host validation.
+
+Read the candidate's labels (already in the cache as
+`repos.engine.prs[].labels`) and add only the smoke label for the
+host the author was NOT on:
+
+| Author label present | Add smoke label |
+|---|---|
+| `fleet:authored-on-linux` | `fleet:needs-macos-smoke` only |
+| `fleet:authored-on-macos` | `fleet:needs-linux-smoke` only |
+| Neither (Windows-native author, or pre-fix PR) | Both labels |
+
 ```bash
-gh pr edit <N> --add-label "fleet:needs-linux-smoke" --add-label "fleet:needs-macos-smoke"
+# Determine which host(s) need smoke (one Bash call per add — keep
+# them separate so each is independently safe and idempotent):
+gh pr edit <N> --add-label "fleet:needs-<other-host>-smoke"
 ```
 
 Each host's author agents (opus-worker, sonnet-author) poll for the

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -396,9 +396,16 @@ host the author was NOT on:
 | Neither (Windows-native author, or pre-fix PR) | Both labels |
 
 ```bash
-# Determine which host(s) need smoke (one Bash call per add — keep
-# them separate so each is independently safe and idempotent):
-gh pr edit <N> --add-label "fleet:needs-<other-host>-smoke"
+# Linux author  → one call:
+gh pr edit <N> --add-label "fleet:needs-macos-smoke"
+
+# macOS author  → one call:
+gh pr edit <N> --add-label "fleet:needs-linux-smoke"
+
+# Neither (Windows-native or pre-fix PR) → two calls, one per label
+# (keep them separate so each is independently safe and idempotent):
+gh pr edit <N> --add-label "fleet:needs-linux-smoke"
+gh pr edit <N> --add-label "fleet:needs-macos-smoke"
 ```
 
 Each host's author agents (opus-worker, sonnet-author) poll for the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,6 +539,13 @@ Specifically, **never pass these via `--label` when filing**:
   build + run validation.
 - `fleet:wip` — owned by the **author agent** (set at PR creation
   during a normal `commit-and-push` flow). Don't add to issues.
+- `fleet:authored-on-linux` / `fleet:authored-on-macos` — owned by
+  the **author's `commit-and-push`** (set at PR creation based on
+  `uname -s`). Records which host the PR was opened from so the
+  reviewer's cross-host smoke step subtracts the author's host
+  (no point asking for a smoke label on the host that just built
+  and ran the demo). Permanent label — it's a fact about the PR,
+  not a state. Don't add to issues.
 - `fleet:in-progress` / `fleet:merger-cooldown` /
   `fleet:changes-made` — owned by the worker / merger pipeline.
 

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -105,6 +105,8 @@ LABELS=(
     "fleet:merger-cooldown|bfdadc|Merger touched this PR; skip until next iteration"
     "fleet:needs-linux-smoke|c5def5|Engine render PR awaiting Linux/OpenGL cross-host smoke validation"
     "fleet:needs-macos-smoke|c5def5|Engine render PR awaiting macOS/Metal cross-host smoke validation"
+    "fleet:authored-on-linux|ededed|PR was opened from a Linux/WSL host; reviewer skips fleet:needs-linux-smoke"
+    "fleet:authored-on-macos|ededed|PR was opened from a macOS host; reviewer skips fleet:needs-macos-smoke"
     "fleet:stacked|c5def5|PR's base is a feature branch (stacked PR)"
     "fleet:awaiting-base|c5def5|Stacked PR; merger is waiting for base PR to merge"
     "fleet:stacked-rebase|c5def5|Stacked PR; base just merged, re-targeted to master, awaiting reviewer re-eval"


### PR DESCRIPTION
## Summary

`commit-and-push` now stamps `fleet:authored-on-<host>` at PR-create
time based on `uname -s`. The reviewer's cross-host smoke step
reads it and adds only the OTHER host's smoke label. Result: PRs
authored on macOS no longer carry a redundant
`fleet:needs-macos-smoke` (and vice versa for Linux).

## Why

Surfaced on PR #319 — the author opened from macOS with a clean
`IRShapeDebug` smoke in the test plan, but the reviewer
unconditionally added BOTH smoke labels because it had no signal
about the author's host. The macOS label was provably redundant.

Prior to this fix the PR sat with two outstanding smoke labels.
Each host's author-loop would eventually clear its own, but until
both cleared the merge was held. With the fix: only the lagging
host's label is ever set, so the merge gate is exactly as tight as
it needs to be and not tighter.

## What

- **`commit-and-push` step 8b** (new): after `gh pr create`,
  derive host from `uname -s` (`Linux` → `linux`, `Darwin` →
  `macos`, anything else → skip), and add
  `fleet:authored-on-<host>`. Applied to ALL PRs unconditionally
  — cheap, consistent, simplifies reviewer logic. Game PRs and
  non-render engine PRs don't get smoke labels anyway, so the
  host label is just informational there.

- **`review-pr` SKILL.md step 5c** (modified): when adding smoke
  labels, route based on the author label:
  - `fleet:authored-on-linux` → add `fleet:needs-macos-smoke` only
  - `fleet:authored-on-macos` → add `fleet:needs-linux-smoke` only
  - Neither (Windows author or pre-fix PR) → add both (current behavior)

- **`role-sonnet-reviewer.md` + `role-opus-reviewer.md`**: same
  routing table inline so reviewer agents reading the role doc
  match the skill's behavior.

- **`scripts/fleet/fleet-labels`**: register the two new labels
  with a gray color (`ededed`) to visually distinguish them as
  informational facts vs state labels (which are blue/green/red).

- **`CLAUDE.md` \"Issue/PR labeling discipline\"**: new labels
  added to the author-owned set with the suppression rationale.

## What this does NOT change

Per direction in conversation: the broad render-path filter
(`engine/render/`, `engine/prefabs/irreden/render/`, shaders) is
**not** tightened. Component data shapes feed render systems, so
changes to them legitimately warrant smoke validation when a
cross-host backend exists. The bug was the host-suppression
logic, not the path-filter scope.

## Test plan

- [x] `bash -n scripts/fleet/fleet-labels` clean
- [x] `uname -s` on macOS returns `Darwin`, on Linux returns
      `Linux` — case statement maps both correctly
- [ ] Live: next render PR opened from macOS via `commit-and-push`
      gets `fleet:authored-on-macos` at create time
- [ ] Live: next reviewer pass sees the label and adds only
      `fleet:needs-linux-smoke`
- [ ] Live: a PR opened from Linux gets the mirror treatment
- [ ] Live: a PR opened from Windows-native (uname -s = something
      other than Linux/Darwin) gets neither host label, reviewer
      adds both smoke labels (graceful fallback)
- [ ] After merge: run `fleet-labels` once on engine + game repos
      to register the two new labels (idempotent — only creates
      missing ones)

## Notes for reviewer

- The label name uses `authored-on-<host>` (a fact about WHERE)
  rather than `smoked-on-<host>` (a claim about WHAT was done).
  More honest about what we know — `commit-and-push` knows the
  host from `uname -s` but doesn't independently verify the
  author actually ran smoke. The workflow expects them to have
  (per CLAUDE.md \"Verifying render changes\"), so authoring on a
  host is treated as proxy evidence for that host's smoke being
  baseline-validated.
- Graceful for Windows-native authors: case statement falls
  through to no-op, reviewer falls back to add-both. No
  regression vs current behavior.
- The label is added unconditionally (not gated on whether the
  diff touches render). Two reasons:
  - Reviewer logic stays simple (\"subtract author host from
    whatever smoke labels you'd add\")
  - The label is also useful informational metadata for the human
    reviewing the PR queue (\"oh, this one was authored on
    macOS\")
- PR #319 had the redundant `fleet:needs-macos-smoke` stripped
  out-of-band before this PR opened. Future macOS-authored render
  PRs won't get tagged that way once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)