### PR TITLE
fleet: add fleet:epic label + queue-manager auto-closes when children done

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -526,8 +526,11 @@ You are the sole TASKS.md editor. Each maintenance pass:
    markdown task list (`- [ ] #N` entries). When ALL referenced
    children are closed, close the epic.
 
-   For each repo (engine, then game if present), fetch open epics:
-   `gh issue list --repo <repo> --label "fleet:epic" --state open --json number,title`
+   For each repo (engine, then game if present), fetch open epics
+   (`--limit 100` matches the `fleet-labels` workaround for the
+   default 30-row cap; one or two epics today, but cheap to
+   future-proof):
+   `gh issue list --repo <repo> --label "fleet:epic" --state open --json number,title --limit 100`
 
    For each epic returned:
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -294,10 +294,18 @@ You are the sole TASKS.md editor. Each maintenance pass:
    `~/.fleet/state/state.json` if its contents are no longer in your
    conversation context. From `repos.engine.human_approved[]`
    (already filtered by the scout to exclude `fleet:queued`), drop
-   any entry whose `labels` include `fleet:needs-plan` or
-   `fleet:needs-info` — that matches the previous `gh issue list
-   ... --search "label:human:approved -label:fleet:queued
-   -label:fleet:needs-plan -label:fleet:needs-info"` query exactly.
+   any entry whose `labels` include `fleet:needs-plan`,
+   `fleet:needs-info`, or **`fleet:epic`** — that matches the
+   previous `gh issue list ... --search "label:human:approved
+   -label:fleet:queued -label:fleet:needs-plan -label:fleet:needs-info
+   -label:fleet:epic"` query exactly.
+
+   **`fleet:epic` excluded** because epics are meta-tracking
+   (parent issues bundling a set of children), not work items.
+   The CHILDREN go into TASKS.md via the normal flow when the
+   human approves them individually. The epic itself stays open
+   until step 7 (epic auto-close) determines all children are
+   resolved.
 
    The cache only stores list-shaped data (number, title, labels),
    so for each candidate fetch the body and comments per-item:
@@ -513,9 +521,61 @@ You are the sole TASKS.md editor. Each maintenance pass:
    issues arrives, some may reference blockers that weren't ingested
    yet. This pass resolves those once everything is in the queue.
 
-7. **Prune Done:** keep only the last 20 entries in each TASKS.md.
+7. **Auto-close completed epics (both repos).** An epic is an open
+   issue labeled `fleet:epic` whose body lists child issues as a
+   markdown task list (`- [ ] #N` entries). When ALL referenced
+   children are closed, close the epic.
 
-8. **Push changes (if any).**
+   For each repo (engine, then game if present), fetch open epics:
+   `gh issue list --repo <repo> --label "fleet:epic" --state open --json number,title`
+
+   For each epic returned:
+
+   a. Fetch the LIVE body (not from the cache — bodies aren't
+      cached, and re-reading on every pass is what catches "new
+      children added after work began" automatically):
+      `gh issue view <epic-N> --repo <repo> --json body`
+
+   b. Parse the body for markdown task list entries pointing at
+      issue or PR numbers. Pattern: lines matching the regex
+      `^\s*-\s*\[[ xX~]\]\s*#(\d+)\b`. Both `- [ ]` (open) and
+      `- [x]` (manually checked) count — we trust the actual issue
+      state, not the checkbox. Collect the set of all referenced
+      numbers.
+
+   c. **Skip if no children found.** An epic with an empty checklist
+      is either still being scoped or uses a different format we
+      don't auto-close. Don't guess.
+
+   d. For each referenced number, check its state with the GitHub
+      API (works uniformly for issues AND PRs — GitHub treats PRs
+      as a kind of issue):
+      `gh api repos/<repo>/issues/<N> --jq '.state'`
+      Returns `open` or `closed`. If `gh api` returns 404, the
+      number doesn't exist (typo, transferred, deleted) — treat
+      as closed (don't block the epic on a phantom child).
+
+   e. **If ALL children are closed, close the epic.** Comment with
+      a one-line summary listing the children. Combine the comment
+      and close in a single call (gh supports `--comment` on
+      `gh issue close`):
+      `gh issue close <epic-N> --repo <repo> --comment "Auto-closing: all <N> child issues are closed (#A, #B, #C, ...). — queue-manager"`
+
+   f. **If ANY child is still open, leave the epic alone.** No
+      label change, no comment. The next maintenance pass re-reads
+      the body and re-checks. This is what handles the "new child
+      added after work began" case: if the human edits the epic
+      body to add `- [ ] #500` after #A/#B/#C have closed, the next
+      pass sees four references and waits for #500 too.
+
+   The epic itself never goes into TASKS.md (step 2 already
+   excludes `fleet:epic`). The CHILDREN go through the normal
+   ingestion flow when the human approves them individually with
+   `human:approved`.
+
+8. **Prune Done:** keep only the last 20 entries in each TASKS.md.
+
+9. **Push changes (if any).**
    **Order matters:** stage and commit FIRST, then fetch and rebase.
    `git rebase` refuses to run with unstaged changes ("You have
    unstaged changes") AND with staged-but-uncommitted changes ("Your
@@ -548,10 +608,10 @@ You are the sole TASKS.md editor. Each maintenance pass:
    warning is informational — the push still succeeded if you don't
    see "rejected" or "failed". Don't try to "fix" it by opening a PR.
 
-9. Print the maintenance summary, queue summary, and next-run timing:
-   `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned`
-   `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
-   `[queue-manager] Iteration complete. Next run in ~5m.`
+10. Print the maintenance summary, queue summary, and next-run timing:
+    `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned, W epics closed`
+    `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
+    `[queue-manager] Iteration complete. Next run in ~5m.`
 
 ## Hard rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -528,6 +528,17 @@ Specifically, **never pass these via `--label` when filing**:
 
 - `human:approved` — owned by the **human**. The human's "yes, work on
   this" gate. Queue-manager keys ingestion off it.
+- `fleet:epic` — owned by the **human**. Marks an issue as a parent
+  that bundles multiple child issues (listed as a markdown task list
+  `- [ ] #N` in the body). Queue-manager:
+  (1) skips epics from TASKS.md ingestion (they're meta, not work),
+  (2) auto-closes the epic on its 5-min maintenance pass once ALL
+      referenced children are closed,
+  (3) re-reads the body LIVE each pass — so adding a new `- [ ] #M`
+      after the original children close keeps the epic open until
+      #M also closes ("done done").
+  The CHILDREN go through the normal `human:approved` ingestion
+  flow individually; the epic itself is just visible bookkeeping.
 - `fleet:queued` / `fleet:task` — owned by the **queue-manager**, set
   AFTER it ingests an issue into `TASKS.md`. Adding it at filing time
   excludes the issue from queue-manager's triage search and strands

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -92,6 +92,7 @@ fi
 
 LABELS=(
     "fleet:task|0366d6|Task tracked in TASKS.md"
+    "fleet:epic|cc317c|Parent issue tracking a set of child issues; queue-manager auto-closes when all children close"
     "fleet:queued|c5def5|Queued for ingestion into TASKS.md"
     "fleet:needs-info|fbca04|Needs more info from the author before triage"
     "fleet:needs-plan|fbca04|Needs an architect plan before a worker can pick it up"


### PR DESCRIPTION
## Summary

Adds a first-class `fleet:epic` label so parent issues bundling
multiple sub-issues stand out in the queue, and grows the
queue-manager to auto-close epics on its 5-min maintenance pass once
ALL children are closed. Re-reads the epic body LIVE each pass so
late-added children block the close ("done done").

## Why

The fleet had multi-task efforts in production (sprite rendering
#14, modifier framework #302, etc.) but no machinery to track
completion. The human had to manually scan child issues and
remember to close the parent. Easy to miss; epics linger open even
after every shipped child got merged.

## Design

**Naming + visibility:** `fleet:epic`, magenta `cc317c` (no other
fleet/human label uses that hue, so epics pop in the GitHub issue
list). Owner = the human (humans file epics; agents don't auto-detect
them).

**Source of truth for children:** the epic's body markdown task list,
e.g.:
```
## Sub-tasks
- [ ] #283 sprite sheet asset format + loader
- [ ] #284 SPRITES_TO_SCREEN pass with instanced draw + iso z-sort
- [ ] #285 C_SpriteAnimation + animation advance system
- [ ] #286 Lua bindings + sprite_demo creation
```
Easy for humans to maintain (it's just markdown); queue-manager
parses on each pass.

**Skipped from TASKS.md ingestion** — epics are meta-tracking, not
work. The CHILDREN go through the normal `human:approved` flow
individually and end up in TASKS.md. The epic itself stays at the
GitHub-issue layer.

**Auto-close flow** (new step 7 in queue-manager maintenance):
1. `gh issue list --label fleet:epic --state open` (both repos)
2. For each epic, fetch the LIVE body
3. Parse `^\s*-\s*\[[ xX~]\]\s*#(\d+)` matches; collect child set
4. Skip if no children found (placeholder epic)
5. For each child, `gh api repos/.../issues/<N> --jq '.state'`
   - Works uniformly for issues AND PRs (REST API treats PRs as
     issues internally)
   - 404 (deleted/transferred) → treat as closed, don't block
6. If ALL closed → `gh issue close <epic-N> --comment '...'` in
   one call
7. If ANY open → leave it alone, re-check next pass

**The \"done done\" guarantee:** the body is fetched LIVE each pass,
NOT from cache. So if a human edits the epic body to add
`- [ ] #500` AFTER the original #A/#B/#C have closed, the next
maintenance pass sees four references and waits for #500 too.
This is exactly what the user asked for — \"catch if new issues
were added after work has began, so we only close when it is done
done.\"

## Files

- `scripts/fleet/fleet-labels` — register the new label
- `.claude/commands/role-queue-manager.md`:
  - Step 2 (engine ingestion) excludes `fleet:epic` from the
    TASKS.md ingestion search
  - NEW step 7: auto-close completed epics (~50 lines)
  - Renumber prune/push/summary 7/8/9 → 8/9/10
  - Maintenance summary line gains a \"W epics closed\" counter
- `CLAUDE.md` \"Issue/PR labeling discipline\" — document the
  label as human-owned with the (1) skip-ingestion / (2)
  auto-close / (3) re-read-live-each-pass semantics

## Test plan

- [x] `bash -n scripts/fleet/fleet-labels` clean
- [x] Step renumbering: cross-reference at line 307 (\"step 7 (epic
      auto-close)\") matches the new step number
- [x] No other cross-references to old numbered steps in the doc
- [ ] After merge: run `fleet-labels` once on engine + game repos
      to register the new label (idempotent — only creates
      missing labels)
- [ ] Live: file an epic with `fleet:epic` and a body listing 2
      children. Close children one at a time. After the last
      close, next queue-manager iteration auto-closes the epic
      with a comment listing the children
- [ ] Live: file an epic with 3 children. Close 2. Then edit the
      body to add a 4th `- [ ] #N`. Close the 3rd. Verify the
      epic stays open until the 4th also closes (\"done done\"
      check)
- [ ] Live: edge case — epic with `- [ ] #DELETED` entry. The 404
      gets treated as closed, doesn't block

## Notes for reviewer

- The `gh api repos/.../issues/<N>` path is the right one for
  uniform handling. `gh issue view <N>` chokes on PR numbers; `gh
  pr view <N>` chokes on issue numbers. The REST `issues` endpoint
  returns both because GitHub stores PRs as a kind of issue
  internally. One call shape, both kinds.
- Body re-fetching is per-pass-per-epic, so the GitHub API impact
  is small in practice (handfuls of epics, every 5 min). If we
  ever have hundreds of epics this would be worth caching, but
  that's premature optimization today.
- I considered tracking epics in scout's cache for cross-role
  visibility, but only queue-manager uses them — keeping the
  fetch inline keeps the cache lean and makes the dependency
  obvious from the role doc.
- Closed-without-merge children count as closed (we trust the
  human's close action; if they didn't want it tracked-as-done
  they wouldn't have closed it). If a child is reopened later,
  the next pass sees it open again and the epic becomes
  not-yet-closeable. The auto-close-comment was already posted
  though; reopening the child won't reopen the epic
  automatically. That's acceptable — the human can reopen the
  epic manually if they really want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)