### PR TITLE
fleet: add agent-to-human feedback channel + fleet-feedback aggregator

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -439,6 +439,15 @@ do not rebase, do not push.
 If you hit a usage-limit error: print the error and exit. The
 `/loop` driver and `fleet-babysit` wrapper handle backoff.
 
+## End-of-iteration feedback
+
+If you noticed something this iteration that the human should know
+about — a fleet bug, missing permission, surprising state, or
+suggestion for the fleet itself — append a structured entry to
+`~/.fleet/feedback/merger.md`. See top-level `CLAUDE.md` "Fleet
+feedback channel" for the format and the bar (high — most
+iterations write nothing).
+
 ## Hard rules
 
 - **Never `git push origin master`. Never push to master at all.**

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -218,6 +218,15 @@ Stop and surface to the human when:
 - You hit a usage-limit error — print the error, the stated reset
   time, and wait. Do not retry blindly.
 
+## End-of-iteration feedback
+
+If during a session you noticed something the human should know
+about — a fleet bug, missing permission, surprising state, or
+suggestion for the fleet itself — append a structured entry to
+`~/.fleet/feedback/opus-architect.md`. See top-level `CLAUDE.md`
+"Fleet feedback channel" for the format and the bar (high — write
+only when there's a real signal worth surfacing).
+
 ## Hard rules
 
 - Never `git push origin master`. Never `--force`. Never call

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -317,6 +317,15 @@ end-to-end, then stop and wait for human instruction. Do not loop.
 - The PR force-pushed over master or bypassed hooks — hard-reject and
   surface to human.
 
+## End-of-iteration feedback
+
+If you noticed something this iteration that the human should know
+about — a fleet bug, missing permission, surprising state, or
+suggestion for the fleet itself — append a structured entry to
+`~/.fleet/feedback/opus-reviewer.md`. See top-level `CLAUDE.md`
+"Fleet feedback channel" for the format and the bar (high — most
+iterations write nothing).
+
 ## Hard rules
 
 - Never `gh pr merge` — the human merges.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -827,6 +827,17 @@ pick a task. Wait for human instruction.
 If you hit a usage-limit error: print the error and exit. `fleet-babysit`
 detects exit code 2 and waits the limit-delay before relaunching.
 
+## End-of-iteration feedback
+
+If you noticed something this iteration that the human should know
+about — a fleet bug, missing permission, surprising state, or
+suggestion for the fleet itself — append a structured entry to
+`~/.fleet/feedback/<your-worktree-basename>.md` (e.g.
+`~/.fleet/feedback/opus-worker-1.md`). Per-worktree filename so the
+human can tell which opus-worker observed what. See top-level
+`CLAUDE.md` "Fleet feedback channel" for the format and the bar
+(high — most iterations write nothing).
+
 ## Hard rules
 
 - Never `git push origin master`. Never `--force`. Never call

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -616,6 +616,15 @@ You are the sole TASKS.md editor. Each maintenance pass:
     `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
     `[queue-manager] Iteration complete. Next run in ~5m.`
 
+## End-of-iteration feedback
+
+If you noticed something this iteration that the human should know
+about — a fleet bug, missing permission, surprising state, or
+suggestion for the fleet itself — append a structured entry to
+`~/.fleet/feedback/queue-manager.md`. See top-level `CLAUDE.md`
+"Fleet feedback channel" for the format and the bar (high — most
+iterations write nothing).
+
 ## Hard rules
 
 - Never claim or work tasks. You only file and maintain them.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -572,6 +572,17 @@ If you hit a usage-limit error:
 Do NOT switch to `/model opus` to keep working — that defeats the
 budget split. Just wait.
 
+## End-of-iteration feedback
+
+If you noticed something this iteration that the human should know
+about — a fleet bug, missing permission, surprising state, or
+suggestion for the fleet itself — append a structured entry to
+`~/.fleet/feedback/<your-worktree-basename>.md` (e.g.
+`~/.fleet/feedback/sonnet-fleet-1.md`). Per-worktree filename so
+the human can tell which sonnet pane observed what. See top-level
+`CLAUDE.md` "Fleet feedback channel" for the format and the bar
+(high — most iterations write nothing).
+
 ## Hard rules
 
 - Never `git push origin master`. Never `--force`. Never call

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -362,6 +362,15 @@ for human instruction. Do not loop.
   bypasses hooks (`--no-verify`): hard-reject with a "needs revert"
   comment and flag for Opus recheck.
 
+## End-of-iteration feedback
+
+If you noticed something this iteration that the human should know
+about — a fleet bug, missing permission, surprising state, or
+suggestion for the fleet itself — append a structured entry to
+`~/.fleet/feedback/sonnet-reviewer.md`. See top-level `CLAUDE.md`
+"Fleet feedback channel" for the format and the bar (high — most
+iterations write nothing).
+
 ## Hard rules
 
 - Never commit, push, or open PRs from this worktree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,6 +399,62 @@ from human conversations.
 
 ---
 
+## Fleet feedback channel (applies everywhere, all roles)
+
+Each fleet iteration runs in a fresh `claude` process, so the
+agent's per-iteration observations evaporate when the process
+exits. To keep useful signals from getting lost, every role appends
+to a per-role markdown file at `~/.fleet/feedback/<role>.md` when
+it notices something the human should know about. The human reads
+the digest with `fleet-feedback` (default: last 24h, all roles)
+in interactive sessions and addresses items by editing the fleet
+directly. The channel is **one-way** — there's no return path; the
+human's response is whatever fleet edit they make.
+
+**The bar for writing an entry:** "would a future fleet-up benefit
+from the human knowing this?" Examples worth recording:
+
+- A fleet bug or surprising state (permission denial that should
+  have worked; cache stale because daemon wasn't restarted; tool
+  not on PATH).
+- A missing tool, missing permission, or confusing role-doc
+  instruction that cost you time this iteration.
+- A pattern you noticed across multiple iterations (e.g., "tasks
+  with this shape keep getting stuck at step X").
+- A concrete fleet-improvement suggestion you'd file as an issue
+  if the threshold were lower.
+
+**Skip routine completion notes.** "I did task T-NNN, no issues"
+goes in logs (which already capture everything). The feedback
+channel is for things the human should consider acting on. Most
+iterations write nothing — that's correct.
+
+**Format:**
+
+```
+## YYYY-MM-DD HH:MM
+<one-line headline (action-oriented if possible)>
+
+<optional 1-3 lines of context: what you tried, what surprised you,
+what you'd suggest>
+```
+
+The timestamp is parsed by `fleet-feedback` for `--since` filtering
+— use 24-hour `HH:MM`, optionally with seconds. Append (don't
+overwrite) the file. The directory `~/.fleet/feedback/` is created
+on first use; just `mkdir -p` it before appending.
+
+**Aggregator commands:**
+
+- `fleet-feedback` — last 24h, all roles, chronological
+- `fleet-feedback --since 1h` (or `30m`, `2d`, `7d`)
+- `fleet-feedback --role merger` — filter to one role
+- `fleet-feedback --headlines` — one-liners only
+- `fleet-feedback --clear` — archive all entries to
+  `~/.fleet/feedback/.archive/<timestamp>/` and start fresh
+
+---
+
 ## Project layout (pointers to deeper CLAUDE.md files)
 
 ```

--- a/scripts/fleet/fleet-feedback
+++ b/scripts/fleet/fleet-feedback
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""fleet-feedback — read structured agent-to-human feedback files.
+
+Each role appends entries to ~/.fleet/feedback/<role>.md when it
+notices something the human should know about (fleet bugs, missing
+permissions, surprising state, suggestions). This script reads
+those files, filters by recency, and prints a digest.
+
+The channel is one-way: agents write, humans read in interactive
+sessions. There's no return path; humans address feedback by
+editing the fleet (role docs, scripts, settings) directly.
+
+Usage:
+  fleet-feedback                     # last 24h, all roles, chronological
+  fleet-feedback --since 1h          # last 1 hour
+  fleet-feedback --since 7d          # last 7 days
+  fleet-feedback --role merger       # filter to one role
+  fleet-feedback --headlines         # first line of each entry only
+  fleet-feedback --clear             # archive all feedback files
+
+Entry format (in ~/.fleet/feedback/<role>.md):
+  ## YYYY-MM-DD HH:MM
+  <one-line headline>
+
+  <optional 1-3 lines of context>
+
+Source of truth: scripts/fleet/fleet-feedback in the engine repo.
+Installed to ~/bin/fleet-feedback by scripts/fleet/install.sh.
+"""
+
+import argparse
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+FEEDBACK_DIR = Path.home() / ".fleet" / "feedback"
+ARCHIVE_DIR = FEEDBACK_DIR / ".archive"
+
+# `## YYYY-MM-DD HH:MM` (24h time, optional seconds, optional TZ suffix
+# we ignore). The agent writes this when it appends an entry — see
+# CLAUDE.md "Fleet feedback channel" for the format.
+HEADER_RE = re.compile(
+    r"^## (\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?)(?:\s+\S+)?\s*$"
+)
+
+
+@dataclass
+class Entry:
+    role: str
+    timestamp: datetime
+    headline: str
+    body: str  # may be empty
+
+
+def parse_duration(s: str) -> timedelta:
+    """Parse `1h`, `30m`, `2d`, `45s` into a timedelta."""
+    if not s or not s[:-1].isdigit():
+        raise ValueError(f"bad duration: {s!r} (use e.g. 1h, 30m, 2d)")
+    n = int(s[:-1])
+    unit = s[-1]
+    if unit == "s":
+        return timedelta(seconds=n)
+    if unit == "m":
+        return timedelta(minutes=n)
+    if unit == "h":
+        return timedelta(hours=n)
+    if unit == "d":
+        return timedelta(days=n)
+    raise ValueError(f"unknown duration unit: {unit!r} (use s/m/h/d)")
+
+
+def parse_role_file(path: Path) -> list[Entry]:
+    """Read one role's feedback file, split into entries.
+
+    Tolerates malformed timestamps (skips the entry, prints a warning).
+    Body lines are everything between this header and the next
+    header (or EOF), with surrounding blank lines stripped.
+    """
+    role = path.stem
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+
+    entries: list[Entry] = []
+    cur_ts: datetime | None = None
+    cur_body: list[str] = []
+
+    def flush() -> None:
+        if cur_ts is None:
+            return
+        # First non-blank line of body is the headline; rest is context.
+        non_blank_idx = next(
+            (i for i, ln in enumerate(cur_body) if ln.strip()), None
+        )
+        if non_blank_idx is None:
+            headline = "(no headline)"
+            body = ""
+        else:
+            headline = cur_body[non_blank_idx].strip()
+            rest = cur_body[non_blank_idx + 1 :]
+            body = "\n".join(rest).strip()
+        entries.append(Entry(role=role, timestamp=cur_ts, headline=headline, body=body))
+
+    for line in lines:
+        match = HEADER_RE.match(line)
+        if match:
+            flush()
+            cur_body = []
+            ts_str = match.group(1).replace("T", " ")
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+                try:
+                    cur_ts = datetime.strptime(ts_str, fmt)
+                    break
+                except ValueError:
+                    continue
+            else:
+                print(
+                    f"fleet-feedback: skipping bad timestamp {ts_str!r} in {path.name}",
+                    file=sys.stderr,
+                )
+                cur_ts = None
+        else:
+            cur_body.append(line)
+    flush()
+
+    return entries
+
+
+def collect_entries(role_filter: str | None) -> list[Entry]:
+    if not FEEDBACK_DIR.is_dir():
+        return []
+    entries: list[Entry] = []
+    for path in sorted(FEEDBACK_DIR.glob("*.md")):
+        # Skip files in the .archive subdir (glob doesn't recurse, but
+        # be explicit in case the user drops a file at the top level).
+        if path.parent != FEEDBACK_DIR:
+            continue
+        if role_filter and path.stem != role_filter:
+            continue
+        entries.extend(parse_role_file(path))
+    return entries
+
+
+def cmd_clear() -> int:
+    if not FEEDBACK_DIR.is_dir():
+        print("fleet-feedback: nothing to clear (no feedback dir).")
+        return 0
+    files = sorted(p for p in FEEDBACK_DIR.glob("*.md") if p.parent == FEEDBACK_DIR)
+    if not files:
+        print("fleet-feedback: nothing to clear (no feedback files).")
+        return 0
+    stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    dest = ARCHIVE_DIR / stamp
+    dest.mkdir(parents=True, exist_ok=True)
+    for path in files:
+        shutil.move(str(path), str(dest / path.name))
+    print(f"fleet-feedback: archived {len(files)} file(s) to {dest}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read agent-to-human feedback files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("Usage:")[1].rstrip() if __doc__ else None,
+    )
+    parser.add_argument(
+        "--since", default="24h",
+        help="Filter to entries newer than this (e.g. 1h, 30m, 7d). Default: 24h.",
+    )
+    parser.add_argument(
+        "--role", default=None,
+        help="Filter to one role (e.g. merger, sonnet-author).",
+    )
+    parser.add_argument(
+        "--headlines", action="store_true",
+        help="Print only the headline line of each entry.",
+    )
+    parser.add_argument(
+        "--clear", action="store_true",
+        help="Archive all feedback files to ~/.fleet/feedback/.archive/<timestamp>/.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.clear:
+        return cmd_clear()
+
+    try:
+        cutoff = datetime.now() - parse_duration(args.since)
+    except ValueError as e:
+        print(f"fleet-feedback: {e}", file=sys.stderr)
+        return 2
+
+    entries = [e for e in collect_entries(args.role) if e.timestamp >= cutoff]
+    if not entries:
+        suffix = f" for role {args.role!r}" if args.role else ""
+        print(f"fleet-feedback: no entries in the last {args.since}{suffix}.")
+        return 0
+
+    # Chronological, oldest first — newest at the bottom is what you
+    # want when you're scrolling for "what happened recently."
+    entries.sort(key=lambda e: e.timestamp)
+
+    for entry in entries:
+        ts = entry.timestamp.strftime("%Y-%m-%d %H:%M")
+        print(f"[{ts}] [{entry.role}] {entry.headline}")
+        if not args.headlines and entry.body:
+            for line in entry.body.splitlines():
+                print(f"    {line}")
+            print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/fleet/fleet-feedback
+++ b/scripts/fleet/fleet-feedback
@@ -172,7 +172,7 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--role", default=None,
-        help="Filter to one role (e.g. merger, sonnet-author).",
+        help="Filter to one role (e.g. merger, sonnet-author). For multi-instance roles use the full per-worktree name (e.g. sonnet-author-1, opus-worker-2).",
     )
     parser.add_argument(
         "--headlines", action="store_true",
@@ -180,7 +180,7 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--clear", action="store_true",
-        help="Archive all feedback files to ~/.fleet/feedback/.archive/<timestamp>/.",
+        help="Archive ALL feedback files to ~/.fleet/feedback/.archive/<timestamp>/. Ignores --role; clears all agents.",
     )
     args = parser.parse_args(argv)
 

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -80,6 +80,8 @@ FLEET_STREAM_SRC="$SCRIPT_DIR/fleet-claude-stream"
 FLEET_STREAM_DEST="$HOME/bin/fleet-claude-stream"
 FLEET_SCOUT_SRC="$SCRIPT_DIR/fleet-state-scout"
 FLEET_SCOUT_DEST="$HOME/bin/fleet-state-scout"
+FLEET_FEEDBACK_SRC="$SCRIPT_DIR/fleet-feedback"
+FLEET_FEEDBACK_DEST="$HOME/bin/fleet-feedback"
 WITNESS_SRC="$SCRIPT_DIR/witness"
 WITNESS_DEST="$HOME/bin/witness"
 
@@ -91,7 +93,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -148,6 +150,11 @@ fi
 if [[ -f "$FLEET_SCOUT_SRC" ]]; then
     ln -sf "$FLEET_SCOUT_SRC" "$FLEET_SCOUT_DEST"
     echo "symlinked $FLEET_SCOUT_DEST -> $FLEET_SCOUT_SRC"
+fi
+
+if [[ -f "$FLEET_FEEDBACK_SRC" ]]; then
+    ln -sf "$FLEET_FEEDBACK_SRC" "$FLEET_FEEDBACK_DEST"
+    echo "symlinked $FLEET_FEEDBACK_DEST -> $FLEET_FEEDBACK_SRC"
 fi
 
 if [[ -f "$WITNESS_SRC" ]]; then


### PR DESCRIPTION
## Summary

Adds `~/.fleet/feedback/<role>.md` as a structured agent-to-human
feedback channel, plus a `fleet-feedback` aggregator. Each role
appends entries when it notices something the human should know
about (fleet bugs, missing permissions, surprising state,
suggestions); the human reads digests in interactive sessions and
addresses items by editing the fleet directly.

## Why

Each fleet iteration runs in a fresh `claude` process, so its
observations evaporate when the process exits. Existing channels:
- `~/.fleet/logs/<role>.log` — captures everything but is
  unstructured; useless for skimming "what's worth acting on."
- Auto-memory (`MEMORY.md`) — agent-to-future-self for patterns to
  remember next iteration. Wrong audience.
- Merger audit log — structured but only the merger writes to it.

No structured agent-to-human channel exists. This PR adds one.

## Design choices

- **Always-on, no flag.** Bar is high enough that most iterations
  skip writing — opt-in is unnecessary complexity. Cost is zero per
  iteration unless something noteworthy happened.
- **One-way only** (per user direction): agents write, human reads
  and acts. No bidirectional plumbing means no conflict resolution
  between agent re-reads and human edits.
- **Convention in CLAUDE.md, pointer in each role doc.** CLAUDE.md
  is auto-loaded into every session, so the bar/format definition
  is single-sourced. Each role doc gets a 7-line pointer rather
  than 60 lines of duplicated content.
- **Per-worktree filename for multi-instance roles** (opus-workers,
  sonnet-fleet panes): `opus-worker-1.md` vs `opus-worker-2.md`.
  Matches existing `fleet-heartbeat` / `fleet-claim` convention.

## Files (10, +348 / -1)

| File | Change |
|---|---|
| `scripts/fleet/fleet-feedback` | NEW ~200-line Python aggregator (stdlib only) |
| `scripts/fleet/install.sh` | Symlink fleet-feedback into ~/bin |
| `CLAUDE.md` | New top-level "Fleet feedback channel" section (~50 lines) — bar, format, aggregator commands |
| `.claude/commands/role-merger.md` + 6 other role docs | 7-line pointer to CLAUDE.md before "Hard rules" section, each with the matching `<role>.md` filename baked in |

## Aggregator commands

```
fleet-feedback                  # last 24h, all roles, chronological
fleet-feedback --since 1h       # 1h, 30m, 2d, 7d
fleet-feedback --role merger    # filter to one role
fleet-feedback --headlines      # one-liners only
fleet-feedback --clear          # archive all entries to .archive/<timestamp>/
```

## Test plan

- [x] `python3 ast.parse` clean on fleet-feedback
- [x] `fleet-feedback --help` prints usage
- [x] `bash -n scripts/fleet/install.sh` clean
- [x] Smoke test: synthetic entry written to
      `~/.fleet/feedback/_smoke-test.md` round-trips through full,
      headlines, since-filter, and clear
- [ ] After merge: `install.sh` symlinks fleet-feedback into ~/bin
- [ ] After merge: next fleet-up iteration of each role picks up
      the new "End-of-iteration feedback" section
- [ ] Live: a real fleet bug surfaces, agent appends to
      `~/.fleet/feedback/<role>.md`, `fleet-feedback` shows it in
      digest

## Notes for reviewer

- The aggregator is intentionally tolerant: malformed timestamps
  skip with a warning rather than crashing; missing dir is a
  no-op; bodies are optional. Failure modes shouldn't block the
  human's read.
- `--clear` archives to `.archive/<YYYY-MM-DD-HHMMSS>/` rather
  than deleting. The archive is your audit trail of past feedback;
  if you wonder "did we ever notice X before?" `ls .archive/`
  has the answer.
- Per-role file convention means a future role can adopt the
  channel by adding `~/.fleet/feedback/<their-role>.md` writes
  without coordinating with this script — the aggregator globs
  the dir.
- Two efficiency-conscious choices to call out:
  1. Bodies parsed only when `--headlines` is NOT set
  2. Glob excludes the `.archive/` subdir so accumulated history
     doesn't slow down the digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)