### PR TITLE
fleet: rm -f body file before Write to avoid stale-Read error

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -43,6 +43,9 @@ Common patterns and their correct alternatives:
   Read in this session, which is the normal case when a previous
   iteration left the body file behind. The `rm` removes the
   staleness; the fresh Write goes through.
+- **Delete a temp body file before writing:** `rm -f .merger-body.md`.
+  This is safe and single-command — `-f` silences "no such file" so
+  first-iteration runs proceed without error.
 
 ## Shared fleet state cache
 

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -37,7 +37,12 @@ Common patterns and their correct alternatives:
 - **Write a body file for `gh pr comment --body-file`:** Use the
   **Write** tool to write within the worktree (e.g.
   `.merger-body.md`), not to `/tmp`. The sandbox may block writes
-  outside the project tree.
+  outside the project tree. **First** run `rm -f .merger-body.md`
+  so the Write tool doesn't refuse with "File has not been read
+  yet" — that error fires when an existing file at the path wasn't
+  Read in this session, which is the normal case when a previous
+  iteration left the body file behind. The `rm` removes the
+  staleness; the fresh Write goes through.
 
 ## Shared fleet state cache
 

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -39,6 +39,10 @@ Common patterns and their correct alternatives:
   file at the path wasn't Read in this session, which is the normal
   case when a previous iteration left the body file behind. The
   `rm` removes the staleness; the fresh Write goes through.
+- **Delete a temp body file before writing:** `rm -f .review-body.md`
+  (or `.merger-body.md`). This is safe and single-command — `-f`
+  silences "no such file" so first-iteration runs proceed without
+  error.
 
 ## Shared fleet state cache
 

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -33,7 +33,12 @@ Common patterns and their correct alternatives:
   needed.
 - **Write a temp file for `--body-file`:** Use the **Write** tool to
   write within the worktree (e.g. `.review-body.md`), not to `/tmp`.
-  The sandbox may block writes outside the project tree.
+  The sandbox may block writes outside the project tree. **First**
+  run `rm -f .review-body.md` so the Write tool doesn't refuse with
+  "File has not been read yet" — that error fires when an existing
+  file at the path wasn't Read in this session, which is the normal
+  case when a previous iteration left the body file behind. The
+  `rm` removes the staleness; the fresh Write goes through.
 
 ## Shared fleet state cache
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -32,7 +32,12 @@ Common patterns and their correct alternatives:
   needed.
 - **Write a temp file for `--body-file`:** Use the **Write** tool to
   write within the worktree (e.g. `.review-body.md`), not to `/tmp`.
-  The sandbox may block writes outside the project tree.
+  The sandbox may block writes outside the project tree. **First**
+  run `rm -f .review-body.md` so the Write tool doesn't refuse with
+  "File has not been read yet" — that error fires when an existing
+  file at the path wasn't Read in this session, which is the normal
+  case when a previous iteration left the body file behind. The
+  `rm` removes the staleness; the fresh Write goes through.
 
 ## Shared fleet state cache
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -38,6 +38,10 @@ Common patterns and their correct alternatives:
   file at the path wasn't Read in this session, which is the normal
   case when a previous iteration left the body file behind. The
   `rm` removes the staleness; the fresh Write goes through.
+- **Delete a temp body file before writing:** `rm -f .review-body.md`
+  (or `.merger-body.md`). This is safe and single-command — `-f`
+  silences "no such file" so first-iteration runs proceed without
+  error.
 
 ## Shared fleet state cache
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -232,9 +232,14 @@ causes parse errors when the body contains backticks or special
 characters. Instead, write the body to a temp file with the **Write
 tool**, then pass it with `--body-file`:
 
-1. Use the **Write tool** to write the review body to `.review-body.md`
-   in the worktree root (NOT `/tmp/` — the sandbox may block writes
-   outside the project tree). This file is gitignored:
+1. **First** run `rm -f .review-body.md` so the Write tool doesn't
+   refuse with "File has not been read yet" — that error fires when
+   an existing file at the path wasn't Read in this session, which
+   is the normal case when a previous review iteration left the
+   body file behind. Then use the **Write tool** to write the review
+   body to `.review-body.md` in the worktree root (NOT `/tmp/` —
+   the sandbox may block writes outside the project tree). This
+   file is gitignored:
 
 ```markdown
 ## Review — <title>


### PR DESCRIPTION
## Summary

Reviewers and merger Write a `--body-file` once per iteration. The
previous iteration's file is still on disk, and the Write tool's
safety check refuses with `File has not been read yet`. Fix: `rm -f`
the body file first.

## Symptom

From your screenshot earlier today on a sonnet-reviewer iteration:
```
Write({"file_path":"/.../sonnet-reviewer/.review-body.md"…})
<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>
```
Followed by `ls` confirming `.review-body.md 5408 Apr 25 18:20`
existed from a prior review. The agent went into a Read+retry sequence
that wasted tokens before the actual `gh pr review --body-file` call.

## Why this happens

The Write tool's safety check is a guard against accidental overwrites
— it requires a deliberate Read of any existing file at the path
before clobbering. For these temp body files, we don't care about
preserving the previous iteration's content, so the safety check is
just friction.

## Fix

One bullet added to the "Common patterns" section of each role doc
(merger, opus-reviewer, sonnet-reviewer) and the canonical step in
`review-pr` SKILL.md: **first `rm -f .review-body.md`** (or
`.merger-body.md`), then Write. With no existing file at the path,
the Write goes through cleanly on the first attempt.

Putting it in "Common patterns" rather than at each Write site means
it applies to all Write-body-file sites in the doc — the merger has
4 (one per conflict-class branch); reviewers each have 1.

## Files (4, +26/-6)

- `.claude/commands/role-opus-reviewer.md` — bullet update
- `.claude/commands/role-sonnet-reviewer.md` — bullet update
- `.claude/commands/role-merger.md` — bullet update (`.merger-body.md`)
- `.claude/skills/review-pr/SKILL.md` — step 1 of the body-write block

## Test plan

- [ ] Live: next reviewer iteration on a worktree with a leftover
      `.review-body.md` writes the new body without the stale-Read
      error
- [ ] Same for merger on a `.merger-body.md`

## Notes for reviewer

- Doc-only change. No code touched. Effective at each agent's next
  iteration when the role doc re-reads.
- I considered adding the `rm` to fleet-babysit's per-iteration
  startup (so it runs unconditionally regardless of role doc), but
  putting it in the role doc keeps the rationale visible to the
  agent reading it (the why is documented inline, not hidden in
  babysit). Easier to evolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)