### PR TITLE
simplify: broaden coverage (change-narration, magic numbers, doc checks)

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -217,6 +217,14 @@ per-entity `getComponent` inside system ticks, duplicated helpers, naming-
 convention slips, and other project-specific smells. It applies fixes
 directly.
 
+**Always run simplify, regardless of file types.** No "doc-only"
+or "small change" carve-out. The skill has a doc-side section
+(stale cross-references, change-narration prose, drifted examples,
+section drift) that earns its keep on markdown-heavy diffs too —
+exactly the failure mode that produced the wrong macOS smoke
+label on PR #319 (a stale cross-reference between the role doc
+and the actual host the author was on).
+
 After `simplify` finishes:
 
 - Re-run `git status` / `git diff --stat` to see the post-simplify state.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -254,8 +254,9 @@ auto-fix — these need human judgment on scope):
   in simplify (out of scope per "doesn't refactor across modules"
   below), but flag when you see it accumulating.
 - Stale instructions that contradict newer ones in the same
-  doc — e.g. step 5 says "use X", step 7 (added later) says "do
-  NOT use X". Reconcile inline if obvious; report otherwise.
+  doc — same smell as the main "Contradictions within a doc"
+  bullet, but in role/skill docs scope judgment belongs with the
+  human. Report; reconciling is outside simplify's scope here.
 
 ### 10. Format and verify
 

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -173,6 +173,13 @@ Remove:
 - Tautological comments where the code says exactly what the comment
   says — `/// Returns the value` on `int getValue() { return value_; }`.
   Same for `// Increment counter` on `++counter_;`.
+- Change-narration comments that describe what the diff modified
+  rather than what the code does — `// Refactored from std::vector
+  to std::array`, `// Now uses the deferred variant`, `// Updated
+  for the new API`, `// Removed old approach (was X, now Y)`.
+  These narrate the diff (which git already shows in the commit
+  history) and age into noise once the change is the new normal.
+  Delete; let the commit message carry the change story.
 - Stale `// TODO`/`// FIXME` markers on code you actually finished
   this session.
 - "Old code" markers next to deleted lines.
@@ -194,10 +201,66 @@ The engine's style preferences are simple and worth applying inline:
 - Don't add abstractions for hypothetical future requirements.
 - Don't validate scenarios that can't happen (defensive checks
   against impossible states); only validate at system boundaries.
+- Magic numbers that carry domain meaning — `if (count > 64)` where
+  64 is a GPU dispatch group size, `sleep(900)` where 900 is the
+  usage-limit cooldown, `if (depth > 4)` where 4 is the max
+  recursion. Extract to a named `constexpr` (or `const` in code that
+  can't be `constexpr`) at the appropriate scope (function-local,
+  file-local, or module-level). Throwaway numbers in tests, init
+  lists, axis vectors (`vec3(1.0f, 0.0f, 0.0f)`), or one-off math
+  are fine — only flag numbers where a name would clarify intent.
 
-### 9. Format and verify
+### 9. Doc-side checks (run when the diff includes any markdown)
 
-After applying fixes, run the formatter and rebuild:
+Code-only diffs can skip. Mixed and doc-heavy diffs run these too.
+Markdown sources to check: `.md` files anywhere, `docs/**`, role
+docs under `.claude/commands/`, skill docs under `.claude/skills/`,
+top-level `CLAUDE.md` and module-level `CLAUDE.md` files.
+
+- **Stale cross-references.** A file path, label name, role name,
+  task ID, PR number, or skill name cited in the prose now refers
+  to something that no longer exists or means something different.
+  Common triggers: a renamed file, a removed label, a role that
+  got merged into another, a TASKS.md task ID that already shipped.
+  Grep the cited identifiers against the current tree and fix what
+  drifted.
+- **Examples that drifted from the current API.** A doc shows a
+  code snippet using `IRRender::makeCanvas()` but the API is now
+  `IRRender::createCanvas()`. Same for shell snippets that use
+  removed scripts or outdated flags.
+- **Change-narration prose** (markdown analog of the code rule):
+  paragraphs that describe what *was changed* in the current PR
+  rather than what the doc covers — "Updated this section to
+  reflect the new flow", "Removed the old explanation of X". The
+  commit message is the place for change history; doc bodies
+  describe the current state.
+- **Redundant prose.** A paragraph that re-says the previous
+  paragraph in different words. Pick the clearer one, drop the
+  other. Same for two bullet items that say the same thing with
+  different framing.
+- **Section drift.** A section header promises one thing but the
+  body covers something else (heading "Common patterns" but body
+  is a single example, or heading "Examples" with no examples).
+  Either rename the heading or refocus the body.
+- **Contradictions within a doc.** Step 3 says X, step 7 (added
+  later in a different change) says NOT X. Reconcile or report.
+
+For role docs and skill docs specifically, also report (don't
+auto-fix — these need human judgment on scope):
+
+- Cross-doc duplication that's grown unmanageable. The earlier
+  fleet audit flagged 3-7× duplication of "Common patterns" /
+  "single-command Bash" blocks across role docs. Don't refactor
+  in simplify (out of scope per "doesn't refactor across modules"
+  below), but flag when you see it accumulating.
+- Stale instructions that contradict newer ones in the same
+  doc — e.g. step 5 says "use X", step 7 (added later) says "do
+  NOT use X". Reconcile inline if obvious; report otherwise.
+
+### 10. Format and verify
+
+After applying fixes, run the formatter and rebuild (code diffs
+only; doc-only diffs can skip the build):
 
 ```bash
 fleet-build --target format
@@ -209,7 +272,7 @@ keep them. If the build broke, **revert your simplify changes** (or
 fix the break before continuing) — never push a simplify pass that
 broke the build.
 
-### 10. Report
+### 11. Report
 
 Print a compact summary so the author knows what changed and what
 needs their attention:


### PR DESCRIPTION
## Summary

Three new things in `simplify` to make it earn its keep on every
PR, plus a `commit-and-push` clarification that simplify always
runs (no doc-only carve-out).

## What's new

**simplify section 7** (dead code, comments) — added bullet for
**change-narration comments**: comments that describe what the
diff modified (`// Refactored from X to Y`, `// Now uses the
deferred variant`) rather than what the code does. These narrate
the diff and age into noise; commit message carries the change
story instead.

**simplify section 8** (style) — added bullet for **magic numbers
with domain meaning**: `if (count > 64)` where 64 is a GPU
dispatch group size, `sleep(900)` where 900 is the usage-limit
cooldown. Throwaway numbers (axis vectors, init lists, test
scaffolding) stay fine — only flag names where naming would
clarify intent.

**simplify section 9** (NEW: doc-side checks) — entirely new
section. Runs when the diff includes any markdown. Catches:

- Stale cross-references (file paths, label names, role names,
  task IDs that drifted)
- Examples drifted from the current API
- Change-narration prose (markdown analog of the code rule)
- Redundant prose / bullet duplication
- Section drift (heading promises X, body covers Y)
- Contradictions within a single doc
- Cross-doc duplication accumulating across role/skill docs (report-only)

This is the section that would have caught PR #319's wrong
macOS smoke label (a stale cross-reference in the role doc).

**commit-and-push** — paragraph tightening "always run simplify,
regardless of file types. No doc-only carve-out." Cites PR #319
as the cost of skipping.

## Files (2, +76/-5)

- `.claude/skills/simplify/SKILL.md` — three additions, renumbered
  existing sections 9 and 10 to 10 and 11
- `.claude/skills/commit-and-push/SKILL.md` — always-run paragraph

## Test plan

- [x] Self-applied simplify section 9 to this PR's own diff: no
      stale cross-refs, no drifted examples, no change-narration
      prose, no redundant prose, headings match content, no
      contradictions. Clean per the rules it adds.
- [x] Section renumbering is local: no other cross-references to
      `section N` by number elsewhere in the file
- [ ] Live: next code+doc PR runs simplify and the new bullets +
      section catch anything (or honestly say "nothing to flag")
- [ ] Live: a doc-only PR (next role-doc tweak) runs simplify and
      gets useful output from section 9 instead of "code-only
      diff, skipping"

## Notes for reviewer

- This is a meta-PR: simplify is being asked to better catch the
  things that simplify already exists to catch, when applied to
  doc PRs. Straight extension, no logic change to existing rules.
- The commit-and-push clarification is also a behavior commitment
  on my end: today's session had several doc-heavy PRs (#323,
  #324, #326, #328, #329) where I skipped simplify. Won't
  happen going forward — the doc-side rules in section 9 mean
  it's worth running every time.
- The two existing bullets in section 7 (\"tautological comments\"
  and \"stale TODOs\") were preserved verbatim. The new
  change-narration bullet sits between them as the natural
  category.
- Magic numbers section deliberately carves out throwaway numbers
  (axis vectors, init lists, tests) so the rule doesn't generate
  noise from `vec3(1.0, 0.0, 0.0)` or `EXPECT_EQ(x, 5)`.
- Cross-doc duplication is report-only because resolving it
  needs design judgment (factor into shared file? leave for
  explicitness?). Out of scope for a pre-commit pass per
  simplify's own \"doesn't refactor across modules\" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)