### PR TITLE
T-052: Modifier framework: Lua bindings

### DIFF
--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -59,7 +59,7 @@ inline void push(
     std::int32_t ticksRemaining = -1
 ) {
     if (field == IRComponents::kInvalidFieldId) return;
-    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target);
+    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
     if (!c) return;
     c->modifiers_.push_back(IRComponents::Modifier{
         field, kind, param, source, ticksRemaining
@@ -76,7 +76,7 @@ inline void pushGlobal(
     if (field == IRComponents::kInvalidFieldId) return;
     auto entity = detail::globalsEntityId();
     if (entity == IREntity::kNullEntity) return;
-    auto *c = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity);
+    auto *c = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
     if (!c) return;
     c->modifiers_.push_back(IRComponents::Modifier{
         field, kind, param, source, ticksRemaining
@@ -94,7 +94,7 @@ inline void pushLambda(
     std::int32_t ticksRemaining = -1
 ) {
     if (field == IRComponents::kInvalidFieldId) return;
-    auto *c = IREntity::getComponentOptional<IRComponents::C_LambdaModifiers>(target);
+    auto *c = IREntity::getComponentOptional<IRComponents::C_LambdaModifiers>(target).value_or(nullptr);
     if (!c) return;
     c->modifiers_.push_back(IRComponents::LambdaModifier{
         field, std::move(fn), source, ticksRemaining
@@ -139,13 +139,13 @@ inline float applyToField(
     IRComponents::FieldBindingId field,
     float baseValue
 ) {
-    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target);
+    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
     const auto &entityMods = c ? c->modifiers_ : detail::emptyModifiers();
 
     const std::vector<IRComponents::Modifier> *globalsPtr = nullptr;
     auto entity = detail::globalsEntityId();
     if (entity != IREntity::kNullEntity) {
-        auto *g = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity);
+        auto *g = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
         if (g) globalsPtr = &g->modifiers_;
     }
     const auto &globals = globalsPtr ? *globalsPtr : detail::emptyModifiers();

--- a/engine/prefabs/irreden/common/modifier_lua.hpp
+++ b/engine/prefabs/irreden/common/modifier_lua.hpp
@@ -15,6 +15,9 @@
 #include <irreden/common/modifier.hpp>
 #include <irreden/script/lua_script.hpp>
 
+#include <string>
+#include <unordered_set>
+
 namespace IRScript {
 
 inline void bindModifierNamespace(LuaScript &luaScript) {
@@ -33,7 +36,9 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
     modTbl["OVERRIDE"]  = static_cast<int>(IRComponents::TransformKind::OVERRIDE);
 
     modTbl["registerField"] = [](const char *name) -> int {
-        return static_cast<int>(IRPrefab::Modifier::registerField(name));
+        static std::unordered_set<std::string> s_luaNames;
+        const char *interned = s_luaNames.emplace(name).first->c_str();
+        return static_cast<int>(IRPrefab::Modifier::registerField(interned));
     };
 
     struct PushOpts {

--- a/engine/prefabs/irreden/common/modifier_lua.hpp
+++ b/engine/prefabs/irreden/common/modifier_lua.hpp
@@ -72,6 +72,8 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
     // fn: Lua function(base: float) -> float.
     // ticks is reserved for a future lambda-decay system; lambda modifiers
     // never auto-expire regardless of the value passed. Use removeBySource to clean up.
+    // LIFETIME: the captured sol::function calls lua_unref on destruction; LuaScript
+    // must outlive any EntityManager that holds entities with C_LambdaModifiers entries.
     modTbl["pushLambda"] = [](IREntity::EntityId target, sol::table opts) {
         auto field = static_cast<IRComponents::FieldBindingId>(opts.get<int>("field"));
         sol::function fn = opts["fn"];

--- a/engine/prefabs/irreden/common/modifier_lua.hpp
+++ b/engine/prefabs/irreden/common/modifier_lua.hpp
@@ -1,0 +1,100 @@
+#ifndef MODIFIER_LUA_H
+#define MODIFIER_LUA_H
+
+// Behavior-API Lua bindings for the modifier framework.
+// Exposes IRPrefab::Modifier:: free functions as the ir.modifier.* Lua namespace.
+// Component/type bindings live separately in component_modifiers_lua.hpp.
+//
+// Call bindModifierNamespace(luaScript) during creation init, e.g. from the
+// creation's lua_bindings.cpp, after the sol2 state is open.
+//
+// Entity IDs cross the Lua/C++ boundary as raw integers (IREntity::EntityId,
+// which is uint64). Scripts with LuaEntity objects from createEntity calls
+// should pass the .entity field: ir.modifier.push(entity.entity, { ... }).
+
+#include <irreden/common/modifier.hpp>
+#include <irreden/script/lua_script.hpp>
+
+namespace IRScript {
+
+inline void bindModifierNamespace(LuaScript &luaScript) {
+    auto &lua = luaScript.lua();
+
+    if (!lua["ir"].valid()) {
+        lua["ir"] = lua.create_table();
+    }
+    auto modTbl = lua.create_table();
+
+    modTbl["ADD"]       = static_cast<int>(IRComponents::TransformKind::ADD);
+    modTbl["MULTIPLY"]  = static_cast<int>(IRComponents::TransformKind::MULTIPLY);
+    modTbl["SET"]       = static_cast<int>(IRComponents::TransformKind::SET);
+    modTbl["CLAMP_MIN"] = static_cast<int>(IRComponents::TransformKind::CLAMP_MIN);
+    modTbl["CLAMP_MAX"] = static_cast<int>(IRComponents::TransformKind::CLAMP_MAX);
+    modTbl["OVERRIDE"]  = static_cast<int>(IRComponents::TransformKind::OVERRIDE);
+
+    modTbl["registerField"] = [](const char *name) -> int {
+        return static_cast<int>(IRPrefab::Modifier::registerField(name));
+    };
+
+    struct PushOpts {
+        IRComponents::FieldBindingId field_;
+        IRComponents::TransformKind  kind_;
+        float                        param_;
+        IREntity::EntityId           source_;
+        std::int32_t                 ticks_;
+    };
+    auto parseOpts = [](sol::table t) -> PushOpts {
+        return {
+            static_cast<IRComponents::FieldBindingId>(t.get<int>("field")),
+            static_cast<IRComponents::TransformKind>(
+                t.get_or("kind", static_cast<int>(IRComponents::TransformKind::ADD))),
+            t.get_or("param", 0.0f),
+            t.get_or<IREntity::EntityId>("source", IREntity::kNullEntity),
+            t.get_or("ticks", -1)
+        };
+    };
+
+    modTbl["push"] = [parseOpts](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOpts(opts);
+        IRPrefab::Modifier::push(target, o.field_, o.kind_, o.param_, o.source_, o.ticks_);
+    };
+
+    modTbl["pushGlobal"] = [parseOpts](sol::table opts) {
+        auto o = parseOpts(opts);
+        IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
+    };
+
+    // fn: Lua function(base: float) -> float.
+    // ticks is reserved for a future lambda-decay system; lambda modifiers
+    // never auto-expire regardless of the value passed. Use removeBySource to clean up.
+    modTbl["pushLambda"] = [](IREntity::EntityId target, sol::table opts) {
+        auto field = static_cast<IRComponents::FieldBindingId>(opts.get<int>("field"));
+        sol::function fn = opts["fn"];
+        if (!fn.valid()) return;
+        auto source = opts.get_or<IREntity::EntityId>("source", IREntity::kNullEntity);
+        int32_t ticks = opts.get_or("ticks", -1);
+        IRPrefab::Modifier::pushLambda(
+            target, field,
+            [fn](float base) -> float { return fn.call<float>(base); },
+            source, ticks
+        );
+    };
+
+    modTbl["removeBySource"] = [](IREntity::EntityId source) {
+        IRPrefab::Modifier::removeBySource(source);
+    };
+
+    modTbl["applyToField"] = [](IREntity::EntityId target, int field, float base) -> float {
+        return IRPrefab::Modifier::applyToField(
+            target,
+            static_cast<IRComponents::FieldBindingId>(field),
+            base
+        );
+    };
+
+    lua["ir"]["modifier"] = modTbl;
+}
+
+} // namespace IRScript
+
+#endif /* MODIFIER_LUA_H */

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
@@ -76,7 +76,7 @@ template <> struct System<MODIFIER_RESOLVE_GLOBAL> {
                     cachedPtr = nullptr;
                     return;
                 }
-                auto *gm = IREntity::getComponentOptional<C_GlobalModifiers>(entity);
+                auto *gm = IREntity::getComponentOptional<C_GlobalModifiers>(entity).value_or(nullptr);
                 cachedPtr = gm ? &gm->modifiers_ : nullptr;
             }
         );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(IrredenEngineTest
   math/ir_math_random_misc_test.cpp
   math/ir_math_trixel_index_test.cpp
   render/camera_yaw_test.cpp
+  script/modifier_lua_test.cpp
   utility/ir_utility_test.cpp
 )
 

--- a/test/script/modifier_lua_test.cpp
+++ b/test/script/modifier_lua_test.cpp
@@ -127,7 +127,7 @@ TEST_F(ModifierLuaApplyTest, ClampMinModifierApplied) {
         })
     )");
     float result = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 5.0f);
-    EXPECT_GE(result, 20.0f);
+    EXPECT_FLOAT_EQ(result, 20.0f);
 }
 
 TEST_F(ModifierLuaApplyTest, ClampMaxModifierApplied) {
@@ -140,7 +140,7 @@ TEST_F(ModifierLuaApplyTest, ClampMaxModifierApplied) {
         })
     )");
     float result = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 100.0f);
-    EXPECT_LE(result, 8.0f);
+    EXPECT_FLOAT_EQ(result, 8.0f);
 }
 
 TEST_F(ModifierLuaApplyTest, OverrideModifierApplied) {
@@ -217,6 +217,46 @@ TEST_F(ModifierLuaApplyTest, PushLambdaApplied) {
     EXPECT_EQ(lmPtr->modifiers_[0].field_, m_field_id);
     EXPECT_EQ(lmPtr->modifiers_[0].source_, lambdaEntity);
     EXPECT_FLOAT_EQ(lmPtr->modifiers_[0].fn_(5.0f), 10.0f);
+}
+
+// ---- pushGlobal -------------------------------------------------------------
+
+// Fixture: sets up a standalone globals entity and wires it into the detail
+// singleton directly, avoiding registerResolverPipeline() which also creates
+// systems and requires SystemManager.
+class ModifierLuaGlobalTest : public ModifierLuaTest {
+  protected:
+    ModifierLuaGlobalTest() {
+        m_field_id = IRPrefab::Modifier::registerField("lua.global.smoke");
+        m_globals_entity = IREntity::createEntity(IRComponents::C_GlobalModifiers{});
+        IRPrefab::Modifier::detail::globalsEntityId() = m_globals_entity;
+        m_lua.lua()["testField"] = static_cast<lua_Integer>(m_field_id);
+    }
+
+    ~ModifierLuaGlobalTest() {
+        IRPrefab::Modifier::detail::globalsEntityId() = IREntity::kNullEntity;
+    }
+
+    IRComponents::FieldBindingId m_field_id = 0;
+    IREntity::EntityId m_globals_entity = IREntity::kNullEntity;
+};
+
+TEST_F(ModifierLuaGlobalTest, PushGlobalAddsModifierToGlobalsEntity) {
+    m_lua.lua().script(R"(
+        ir.modifier.pushGlobal({
+            field  = testField,
+            kind   = ir.modifier.ADD,
+            param  = 5.0,
+            source = 0,
+        })
+    )");
+    auto *g = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(m_globals_entity)
+                  .value_or(nullptr);
+    ASSERT_NE(g, nullptr);
+    ASSERT_EQ(g->modifiers_.size(), 1u);
+    EXPECT_EQ(g->modifiers_[0].field_, m_field_id);
+    EXPECT_FLOAT_EQ(g->modifiers_[0].param_, 5.0f);
+    EXPECT_EQ(g->modifiers_[0].kind_, IRComponents::TransformKind::ADD);
 }
 
 } // namespace

--- a/test/script/modifier_lua_test.cpp
+++ b/test/script/modifier_lua_test.cpp
@@ -1,0 +1,222 @@
+#include <gtest/gtest.h>
+
+#include <irreden/common/modifier_lua.hpp>
+#include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/script/lua_script.hpp>
+
+namespace {
+
+using IRComponents::C_Modifiers;
+using IRComponents::C_LambdaModifiers;
+using IRComponents::FieldBindingId;
+using IRComponents::TransformKind;
+using IREntity::EntityId;
+
+// Fixture: owns an EntityManager (sets the global g_entityManager) and a
+// LuaScript with the modifier namespace pre-bound.
+class ModifierLuaTest : public testing::Test {
+  protected:
+    ModifierLuaTest()
+        : m_lua{}
+        , m_entity_manager{} {
+        IRScript::bindModifierNamespace(m_lua);
+    }
+
+    // m_lua must be declared first so it is destroyed last: sol::function
+    // references inside LambdaModifier::fn_ call lua_unref during EntityManager
+    // cleanup, which requires the lua_State to still be open.
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+};
+
+// ---- Enum surface -----------------------------------------------------------
+
+TEST_F(ModifierLuaTest, EnumValuesMatchCpp) {
+    auto &lua = m_lua.lua();
+    EXPECT_EQ(lua.script("return ir.modifier.ADD").get<int>(),
+              static_cast<int>(TransformKind::ADD));
+    EXPECT_EQ(lua.script("return ir.modifier.MULTIPLY").get<int>(),
+              static_cast<int>(TransformKind::MULTIPLY));
+    EXPECT_EQ(lua.script("return ir.modifier.SET").get<int>(),
+              static_cast<int>(TransformKind::SET));
+    EXPECT_EQ(lua.script("return ir.modifier.CLAMP_MIN").get<int>(),
+              static_cast<int>(TransformKind::CLAMP_MIN));
+    EXPECT_EQ(lua.script("return ir.modifier.CLAMP_MAX").get<int>(),
+              static_cast<int>(TransformKind::CLAMP_MAX));
+    EXPECT_EQ(lua.script("return ir.modifier.OVERRIDE").get<int>(),
+              static_cast<int>(TransformKind::OVERRIDE));
+}
+
+// ---- registerField ----------------------------------------------------------
+
+TEST_F(ModifierLuaTest, RegisterFieldReturnsNonzeroId) {
+    auto &lua = m_lua.lua();
+    int id = lua.script("return ir.modifier.registerField('lua.test.speed')").get<int>();
+    EXPECT_GT(id, 0);
+}
+
+TEST_F(ModifierLuaTest, RegisterFieldIdsAreUnique) {
+    auto &lua = m_lua.lua();
+    int idA = lua.script("return ir.modifier.registerField('lua.test.uniq.a')").get<int>();
+    int idB = lua.script("return ir.modifier.registerField('lua.test.uniq.b')").get<int>();
+    EXPECT_NE(idA, idB);
+}
+
+// ---- push / applyToField per TransformKind ----------------------------------
+
+class ModifierLuaApplyTest : public ModifierLuaTest {
+  protected:
+    ModifierLuaApplyTest() {
+        m_field_id = IRPrefab::Modifier::registerField("lua.apply.test");
+        m_entity = IREntity::createEntity(C_Modifiers{});
+        m_lua.lua()["testEntity"] = static_cast<lua_Integer>(m_entity);
+        m_lua.lua()["testField"]  = static_cast<lua_Integer>(m_field_id);
+    }
+
+    FieldBindingId m_field_id = 0;
+    EntityId m_entity = 0;
+};
+
+TEST_F(ModifierLuaApplyTest, AddModifierApplied) {
+    m_lua.lua().script(R"(
+        ir.modifier.push(testEntity, {
+            field  = testField,
+            kind   = ir.modifier.ADD,
+            param  = 5.0,
+            source = testEntity,
+        })
+    )");
+    float result = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 10.0f);
+    EXPECT_FLOAT_EQ(result, 15.0f);
+}
+
+TEST_F(ModifierLuaApplyTest, MultiplyModifierApplied) {
+    m_lua.lua().script(R"(
+        ir.modifier.push(testEntity, {
+            field  = testField,
+            kind   = ir.modifier.MULTIPLY,
+            param  = 3.0,
+            source = testEntity,
+        })
+    )");
+    float result = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 4.0f);
+    EXPECT_FLOAT_EQ(result, 12.0f);
+}
+
+TEST_F(ModifierLuaApplyTest, SetModifierApplied) {
+    m_lua.lua().script(R"(
+        ir.modifier.push(testEntity, {
+            field  = testField,
+            kind   = ir.modifier.SET,
+            param  = 99.0,
+            source = testEntity,
+        })
+    )");
+    float result = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 1.0f);
+    EXPECT_FLOAT_EQ(result, 99.0f);
+}
+
+TEST_F(ModifierLuaApplyTest, ClampMinModifierApplied) {
+    m_lua.lua().script(R"(
+        ir.modifier.push(testEntity, {
+            field  = testField,
+            kind   = ir.modifier.CLAMP_MIN,
+            param  = 20.0,
+            source = testEntity,
+        })
+    )");
+    float result = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 5.0f);
+    EXPECT_GE(result, 20.0f);
+}
+
+TEST_F(ModifierLuaApplyTest, ClampMaxModifierApplied) {
+    m_lua.lua().script(R"(
+        ir.modifier.push(testEntity, {
+            field  = testField,
+            kind   = ir.modifier.CLAMP_MAX,
+            param  = 8.0,
+            source = testEntity,
+        })
+    )");
+    float result = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 100.0f);
+    EXPECT_LE(result, 8.0f);
+}
+
+TEST_F(ModifierLuaApplyTest, OverrideModifierApplied) {
+    m_lua.lua().script(R"(
+        ir.modifier.push(testEntity, {
+            field  = testField,
+            kind   = ir.modifier.OVERRIDE,
+            param  = 42.0,
+            source = testEntity,
+        })
+    )");
+    float result = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 1.0f);
+    EXPECT_FLOAT_EQ(result, 42.0f);
+}
+
+// ---- applyToField from Lua --------------------------------------------------
+
+TEST_F(ModifierLuaApplyTest, ApplyToFieldReturnedFromLua) {
+    auto &lua = m_lua.lua();
+    lua.script(R"(
+        ir.modifier.push(testEntity, {
+            field  = testField,
+            kind   = ir.modifier.ADD,
+            param  = 7.0,
+            source = testEntity,
+        })
+    )");
+    float result = lua.script("return ir.modifier.applyToField(testEntity, testField, 3.0)")
+                       .get<float>();
+    EXPECT_FLOAT_EQ(result, 10.0f);
+}
+
+// ---- removeBySource ---------------------------------------------------------
+
+TEST_F(ModifierLuaApplyTest, RemoveBySourceClearsModifiers) {
+    auto &lua = m_lua.lua();
+    lua.script(R"(
+        ir.modifier.push(testEntity, {
+            field  = testField,
+            kind   = ir.modifier.ADD,
+            param  = 100.0,
+            source = testEntity,
+        })
+    )");
+    float before = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 0.0f);
+    EXPECT_FLOAT_EQ(before, 100.0f);
+
+    lua.script("ir.modifier.removeBySource(testEntity)");
+
+    float after = IRPrefab::Modifier::applyToField(m_entity, m_field_id, 0.0f);
+    EXPECT_FLOAT_EQ(after, 0.0f);
+}
+
+// ---- pushLambda -------------------------------------------------------------
+
+TEST_F(ModifierLuaApplyTest, PushLambdaApplied) {
+    auto &lua = m_lua.lua();
+    // Create a fresh entity with both modifier component types.
+    EntityId lambdaEntity = IREntity::createEntity(C_Modifiers{}, C_LambdaModifiers{});
+    lua["lambdaEntity"] = static_cast<lua_Integer>(lambdaEntity);
+
+    lua.script(R"(
+        ir.modifier.pushLambda(lambdaEntity, {
+            field  = testField,
+            fn     = function(base) return base * 2.0 end,
+            source = lambdaEntity,
+        })
+    )");
+    // Lambda modifiers feed C_ResolvedFields through the resolver pipeline,
+    // not applyToField. Verify the lambda was stored and is callable.
+    auto *lmPtr = IREntity::getComponentOptional<C_LambdaModifiers>(lambdaEntity).value_or(nullptr);
+    ASSERT_NE(lmPtr, nullptr);
+    ASSERT_EQ(lmPtr->modifiers_.size(), 1u);
+    EXPECT_EQ(lmPtr->modifiers_[0].field_, m_field_id);
+    EXPECT_EQ(lmPtr->modifiers_[0].source_, lambdaEntity);
+    EXPECT_FLOAT_EQ(lmPtr->modifiers_[0].fn_(5.0f), 10.0f);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Adds `engine/prefabs/irreden/common/modifier_lua.hpp` exposing the modifier framework's behavior API to Lua via the `ir.modifier.*` namespace
- TransformKind enum constants (ADD, MULTIPLY, SET, CLAMP_MIN, CLAMP_MAX, OVERRIDE) available as `ir.modifier.ADD` etc.
- Full API surface: `registerField`, `push`, `pushGlobal`, `pushLambda`, `removeBySource`, `applyToField`
- Fixes five `getComponentOptional` call sites to use `.value_or(nullptr)` (correct for `optional<T*>` return type)
- Adds `test/script/modifier_lua_test.cpp` with 12 Google Tests (all 6 TransformKind paths, registerField, removeBySource, pushLambda)

## Test plan
- [x] All 12 `ModifierLua*` tests pass (`fleet-run IrredenEngineTest --gtest_filter=ModifierLua*`)
- [x] `fleet-build --target IrredenEngineTest` clean

## Usage (Lua side)
```lua
-- In creation lua_bindings.cpp:
IRScript::bindModifierNamespace(luaScript);

-- In a Lua script:
local speedField = ir.modifier.registerField("my.speed")
ir.modifier.push(entity.entity, {
    field  = speedField,
    kind   = ir.modifier.MULTIPLY,
    param  = 1.5,
    source = entity.entity,
})
local effective = ir.modifier.applyToField(entity.entity, speedField, baseSpeed)
```

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)