### PR TITLE
fleet: skip feedback PRs whose branch is checked out elsewhere

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -222,7 +222,29 @@ Do the work, then exit cleanly:
       The cost of a fix-and-push iteration is tiny vs merging with known
       smells. Address every nit unless it's purely subjective preference.
 
-   For each flagged PR:
+   **Filter the candidate set: skip PRs whose branch is already
+   checked out in another worktree.** A PR's branch can only be in
+   one worktree at a time (git refuses to share). After a fleet
+   kill+restart, the worker that originally opened a PR still has
+   its branch checked out — that worker should address the
+   feedback, not you. Trying anyway just earns a `gh pr checkout`
+   failure (`branch is already used by worktree at ...`) after
+   you've already invested reasoning.
+
+   List other worktrees and their branches in one call:
+   `git -C ~/src/IrredenEngine worktree list --porcelain`
+
+   The output groups each worktree as 3 lines (`worktree <path>`,
+   `HEAD <sha>`, `branch refs/heads/<name>`). Build a set of
+   `<name>` values from worktrees whose path is NOT your own (i.e.,
+   skip the line group whose `worktree` matches `pwd`). For each
+   feedback PR in `repos.engine.prs[]`, match its `headRefName`
+   against that set; skip the PR if its head branch is in the set.
+   The same check applies to game-side PRs against
+   `git -C ~/src/IrredenEngine/creations/game worktree list
+   --porcelain`.
+
+   For each flagged PR (after the filter):
    a. Read **all** feedback (two separate commands):
       `gh pr view <N> --comments`
       `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // .original_line)] \(.body)"'`

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -241,8 +241,7 @@ Do the work, then exit cleanly:
    feedback PR in `repos.engine.prs[]`, match its `headRefName`
    against that set; skip the PR if its head branch is in the set.
    The same check applies to game-side PRs against
-   `git -C ~/src/IrredenEngine/creations/game worktree list
-   --porcelain`.
+   `git -C ~/src/IrredenEngine/creations/game worktree list --porcelain`.
 
    For each flagged PR (after the filter):
    a. Read **all** feedback (two separate commands):

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -146,7 +146,26 @@ Each iteration:
       The cost of a fix-and-push iteration is tiny vs merging with known
       smells. Address every nit unless it's purely subjective preference.
 
-   For each flagged PR:
+   **Filter the candidate set: skip PRs whose branch is already
+   checked out in another worktree.** A PR's branch can only be in
+   one worktree at a time (git refuses to share). After a fleet
+   kill+restart, the worker that originally opened a PR still has
+   its branch checked out — that worker should address the
+   feedback, not you. Trying anyway just earns a `gh pr checkout`
+   failure (`branch is already used by worktree at ...`) after
+   you've already invested reasoning.
+
+   List other worktrees and their branches in one call:
+   `git -C ~/src/IrredenEngine worktree list --porcelain`
+
+   The output groups each worktree as 3 lines (`worktree <path>`,
+   `HEAD <sha>`, `branch refs/heads/<name>`). Build a set of
+   `<name>` values from worktrees whose path is NOT your own (i.e.,
+   skip the line group whose `worktree` matches `pwd`). For each
+   feedback PR in `repos.engine.prs[]`, match its `headRefName`
+   against that set; skip the PR if its head branch is in the set.
+
+   For each flagged PR (after the filter):
    a. Read **all** feedback (two separate commands):
       `gh pr view <N> --comments`
       `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // .original_line)] \(.body)"'`


### PR DESCRIPTION
## Summary

After a fleet kill+restart, two workers can converge on the same
`fleet:needs-fix` PR — fleet-up wipes claims but worktrees persist,
so the worker that originally opened the PR still owns its branch.
The other worker tries `gh pr checkout <N>`, trips git's "branch
already used by worktree at ..." error, restores the label, and
moves on. Recovers correctly but wastes ~30s of agent reasoning.

This PR adds a pre-pickup filter: query `git worktree list
--porcelain`, skip PRs whose branch is checked out in another
worktree.

## Symptom (from your screenshot earlier)

opus-worker-2 saw `fleet:needs-fix` on PR #331, ran
`gh pr checkout 331`, hit:
```
fatal: 'claude/T-052-lua-bindings' is already used by worktree at
'/Users/.../opus-worker-1'
```
Agent's response: *"The branch is checked out in opus-worker-1's
worktree — they own this PR. I shouldn't step on their toes.
Restoring the label and moving to the next feedback PR."*

Right behavior, wrong timing — the realization should come
BEFORE the wasted reasoning, not after.

## The fix

A new "Filter the candidate set" paragraph added before the
`For each flagged PR:` loop in both author role docs. Single
`git worktree list --porcelain` call, build a set of branches
checked out in OTHER worktrees, filter the candidate PRs by
`headRefName`. PRs whose branch is in the set get skipped — the
worker that owns that worktree picks them up next iteration.

opus-worker version also covers the game-side worktree
(`creations/game/`); sonnet-author is engine-only.

## Recovery audit context

While diagnosing this I spot-checked the broader kill+restart
contract:

**State that survives kill+restart:** worktrees + dirty branches,
plan files, heartbeats, feedback files, logs, GitHub PR state,
architect session IDs.

**State intentionally wiped on fleet-up:** fleet-claim entries,
scout cache, trigger files, shutdown sentinel, tmux session.

**Common write-then-act sequences:** all recoverable. PR-create
+ label-set is one atomic gh call. Push + label-remove is
recoverable (next iteration re-reads, removes idempotently).
Queue-manager TASKS.md edits commit before push, so dirty state
only persists if killed pre-commit, and reset_worktree refuses
to clobber.

**The only race gap was the worker-converges-on-others-PR case**
this PR addresses.

Other improvements considered but **skipped**:

- PR-level fleet-claim lock — heavier; git's worktree
  exclusivity is sufficient and already enforced
- Self-owned-PR-first priority — separate concern; could
  follow up if cross-lane pickup becomes common
- Persistent PR-ownership state — not needed; the worktree
  itself is the persistent ownership record

## Files (2, +43/-2)

- `.claude/commands/role-opus-worker.md` — pre-pickup filter
  (engine + game worktree lists)
- `.claude/commands/role-sonnet-author.md` — pre-pickup filter
  (engine only)

## Test plan

- [x] Self-applied simplify (sections 7 + 9 from PR #330): no
      change-narration prose, no stale cross-refs, no redundant
      prose, no section drift
- [x] `git worktree list --porcelain` output format verified
      (stable porcelain form)
- [ ] Live: after next kill+restart with multiple workers
      holding open PRs, no \"branch already used by worktree\"
      errors in opus-worker / sonnet-author logs

## Notes for reviewer

- Same paragraph in both role docs — matches the existing
  duplication pattern (each role doc is independently
  self-contained). The earlier audit flagged cross-role
  duplication as a future refactor concern; not addressing here.
- The filter respects the existing `human:wip` skip rule and
  doesn't conflict with smoke-validation logic (smoke validation
  uses `gh pr checkout` separately and would benefit from the
  same filter — but that step already runs only on PRs labeled
  `fleet:needs-<host>-smoke + fleet:approved`, which by
  definition are post-merge-ready and already validated, so the
  worktree-clash race is much less likely there. Could add the
  filter there too in a follow-up if it ever bites.)
- The fix uses `git worktree list --porcelain` rather than
  `--json` because porcelain is the documented stable interface
  for scripts; `--json` is newer and we don't need its features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)