### PR TITLE
T-059: Fleet docs: dormancy-verification rule for private creations

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -47,7 +47,7 @@ Read the top-level `CLAUDE.md` and `engine/CLAUDE.md` (and the relevant
 sub-module `CLAUDE.md`) before touching anything in the responsibility
 list above.
 
-## Dormancy verification across private creations
+## Dormancy verification across all creations, including private ones
 
 Before declaring any engine API "dead," "dormant," or "safe-to-delete,"
 you **must** verify there are no live consumers in ALL physical paths

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -47,6 +47,38 @@ Read the top-level `CLAUDE.md` and `engine/CLAUDE.md` (and the relevant
 sub-module `CLAUDE.md`) before touching anything in the responsibility
 list above.
 
+## Dormancy verification across private creations
+
+Before declaring any engine API "dead," "dormant," or "safe-to-delete,"
+you **must** verify there are no live consumers in ALL physical paths
+under `~/src/IrredenEngine/creations/`, including gitignored
+subdirectories.
+
+Private creations under `creations/<gitignored>/` are first-class
+consumers of engine APIs. A dormancy check that only greps committed
+code under `creations/demos/` is incomplete and risks propagating
+incorrect dormancy claims into the fleet.
+
+**The information-isolation rule does not restrict reading here.** That
+rule governs OUTPUT — what engine-side artifacts say publicly. It does
+not restrict INPUT — what engine-side agents may read when making
+engine-side decisions. Grepping a private creation to answer "does any
+code register `FOO_SYSTEM`?" is fine. Writing the creation's name or
+details in an engine PR body or commit message is not.
+
+**Dormancy check procedure:**
+
+1. Use the Grep tool with `path: ~/src/IrredenEngine/creations/` to
+   search across all subdirectories (committed and gitignored alike).
+2. If no consumers found: record "verified no consumers across all
+   `creations/`" in your PR or issue comment — without naming which
+   paths you searched.
+3. If live consumers found: record "verified live consumers exist" —
+   without naming which creation, what it does, or any
+   creation-specific context.
+
+The output stays in engine terms. The search covers everything on disk.
+
 ## Startup actions (do these immediately, in order)
 
 0. Print your role banner:

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -47,37 +47,20 @@ Read the top-level `CLAUDE.md` and `engine/CLAUDE.md` (and the relevant
 sub-module `CLAUDE.md`) before touching anything in the responsibility
 list above.
 
-## Dormancy verification across all creations, including private ones
+## Engine API removal rule
 
-Before declaring any engine API "dead," "dormant," or "safe-to-delete,"
-you **must** verify there are no live consumers in ALL physical paths
-under `~/src/IrredenEngine/creations/`, including gitignored
-subdirectories.
+**Never remove engine-defined systems, components, or entities.**
+External consumers of the engine may not have their code present in any
+`creations/` subdirectory — a local grep finding no consumers does not
+mean there are no consumers.
 
-Private creations under `creations/<gitignored>/` are first-class
-consumers of engine APIs. A dormancy check that only greps committed
-code under `creations/demos/` is incomplete and risks propagating
-incorrect dormancy claims into the fleet.
+When an engine API appears unused locally, the right action is to write
+a demo creation for it. Demos serve as living documentation and prevent
+the API from appearing dormant to future agents.
 
-**The information-isolation rule does not restrict reading here.** That
-rule governs OUTPUT — what engine-side artifacts say publicly. It does
-not restrict INPUT — what engine-side agents may read when making
-engine-side decisions. Grepping a private creation to answer "does any
-code register `FOO_SYSTEM`?" is fine. Writing the creation's name or
-details in an engine PR body or commit message is not.
-
-**Dormancy check procedure:**
-
-1. Use the Grep tool with `path: ~/src/IrredenEngine/creations/` to
-   search across all subdirectories (committed and gitignored alike).
-2. If no consumers found: record "verified no consumers across all
-   `creations/`" in your PR or issue comment — without naming which
-   paths you searched.
-3. If live consumers found: record "verified live consumers exist" —
-   without naming which creation, what it does, or any
-   creation-specific context.
-
-The output stays in engine terms. The search covers everything on disk.
+If an engine API is genuinely superseded and removal is being considered,
+escalate to the human. Do not unilaterally delete engine-level systems,
+components, or entities.
 
 ## Startup actions (do these immediately, in order)
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -91,6 +91,38 @@ Read the top-level `CLAUDE.md` and the sub-module `CLAUDE.md` for
 whatever directory the task touches before editing anything. For game
 tasks, also read `~/src/IrredenEngine/creations/game/CLAUDE.md`.
 
+## Dormancy verification across private creations
+
+Before declaring any engine API "dead," "dormant," or "safe-to-delete,"
+you **must** verify there are no live consumers in ALL physical paths
+under `~/src/IrredenEngine/creations/`, including gitignored
+subdirectories.
+
+Private creations under `creations/<gitignored>/` are first-class
+consumers of engine APIs. A dormancy check that only greps committed
+code under `creations/demos/` is incomplete and risks propagating
+incorrect dormancy claims into the fleet.
+
+**The information-isolation rule does not restrict reading here.** That
+rule governs OUTPUT — what engine-side artifacts say publicly. It does
+not restrict INPUT — what engine-side agents may read when making
+engine-side decisions. Grepping a private creation to answer "does any
+code register `FOO_SYSTEM`?" is fine. Writing the creation's name or
+details in an engine PR body or commit message is not.
+
+**Dormancy check procedure:**
+
+1. Use the Grep tool with `path: ~/src/IrredenEngine/creations/` to
+   search across all subdirectories (committed and gitignored alike).
+2. If no consumers found: record "verified no consumers across all
+   `creations/`" in your PR or issue comment — without naming which
+   paths you searched.
+3. If live consumers found: record "verified live consumers exist" —
+   without naming which creation, what it does, or any
+   creation-specific context.
+
+The output stays in engine terms. The search covers everything on disk.
+
 ## Cross-repo model
 
 Each opus-worker pane has TWO worktrees:

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -91,7 +91,7 @@ Read the top-level `CLAUDE.md` and the sub-module `CLAUDE.md` for
 whatever directory the task touches before editing anything. For game
 tasks, also read `~/src/IrredenEngine/creations/game/CLAUDE.md`.
 
-## Dormancy verification across private creations
+## Dormancy verification across all creations, including private ones
 
 Before declaring any engine API "dead," "dormant," or "safe-to-delete,"
 you **must** verify there are no live consumers in ALL physical paths

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -91,37 +91,20 @@ Read the top-level `CLAUDE.md` and the sub-module `CLAUDE.md` for
 whatever directory the task touches before editing anything. For game
 tasks, also read `~/src/IrredenEngine/creations/game/CLAUDE.md`.
 
-## Dormancy verification across all creations, including private ones
+## Engine API removal rule
 
-Before declaring any engine API "dead," "dormant," or "safe-to-delete,"
-you **must** verify there are no live consumers in ALL physical paths
-under `~/src/IrredenEngine/creations/`, including gitignored
-subdirectories.
+**Never remove engine-defined systems, components, or entities.**
+External consumers of the engine may not have their code present in any
+`creations/` subdirectory — a local grep finding no consumers does not
+mean there are no consumers.
 
-Private creations under `creations/<gitignored>/` are first-class
-consumers of engine APIs. A dormancy check that only greps committed
-code under `creations/demos/` is incomplete and risks propagating
-incorrect dormancy claims into the fleet.
+When an engine API appears unused locally, the right action is to write
+a demo creation for it. Demos serve as living documentation and prevent
+the API from appearing dormant to future agents.
 
-**The information-isolation rule does not restrict reading here.** That
-rule governs OUTPUT — what engine-side artifacts say publicly. It does
-not restrict INPUT — what engine-side agents may read when making
-engine-side decisions. Grepping a private creation to answer "does any
-code register `FOO_SYSTEM`?" is fine. Writing the creation's name or
-details in an engine PR body or commit message is not.
-
-**Dormancy check procedure:**
-
-1. Use the Grep tool with `path: ~/src/IrredenEngine/creations/` to
-   search across all subdirectories (committed and gitignored alike).
-2. If no consumers found: record "verified no consumers across all
-   `creations/`" in your PR or issue comment — without naming which
-   paths you searched.
-3. If live consumers found: record "verified live consumers exist" —
-   without naming which creation, what it does, or any
-   creation-specific context.
-
-The output stays in engine terms. The search covers everything on disk.
+If an engine API is genuinely superseded and removal is being considered,
+escalate to the human. Do not unilaterally delete engine-level systems,
+components, or entities.
 
 ## Cross-repo model
 

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -211,3 +211,11 @@ A creation in its own private repo may participate in this rule by
 treating its own repo as the private side and the engine repo as
 the public side. A creation that does not participate in the engine
 fleet at all may opt out of this section.
+
+**Engine API dormancy checks:** The isolation rule governs what engine
+artifacts SAY, not what engine agents may READ. Before declaring any
+engine API dormant or safe-to-delete, agents must search ALL
+`creations/` subdirectories on disk — including gitignored ones. The
+dormancy-check procedure and output format are documented in the
+"Dormancy verification across private creations" section of
+`role-opus-architect.md` and `role-opus-worker.md`.

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -212,10 +212,12 @@ treating its own repo as the private side and the engine repo as
 the public side. A creation that does not participate in the engine
 fleet at all may opt out of this section.
 
-**Engine API dormancy checks:** The isolation rule governs what engine
-artifacts SAY, not what engine agents may READ. Before declaring any
-engine API dormant or safe-to-delete, agents must search ALL
-`creations/` subdirectories on disk — including gitignored ones. The
-dormancy-check procedure and output format are documented in the
-"Dormancy verification across private creations" section of
-`role-opus-architect.md` and `role-opus-worker.md`.
+**Engine API removal rule:** Systems, components, and entities defined
+in the engine must never be removed. External consumers of the engine
+may not have their code present in any `creations/` subdirectory — a
+local grep that finds no consumers does not mean there are no consumers.
+When an engine API appears unused locally, the right action is to write
+a demo creation for it, not to remove it. Removal requires an explicit
+human decision. See the "Engine API removal rule" section of
+`role-opus-architect.md` and `role-opus-worker.md` for the full
+guidance.


### PR DESCRIPTION
## Summary

- Add **"Dormancy verification across private creations"** section to `role-opus-architect.md` and `role-opus-worker.md`: before declaring any engine API dead/dormant/safe-to-delete, agents must grep ALL `creations/` subdirectories on disk (including gitignored ones).
- The information-isolation rule governs OUTPUT (what engine artifacts say publicly) — it does NOT restrict agents from READING private creations to verify engine-side facts.
- Add cross-reference paragraph to `docs/agents/CLAUDE-BASELINE.md` at the end of "Cross-repo information isolation" pointing to the new sections.

## Motivation

Surfaced in PR #332 review: an opus-worker grepped only `creations/demos/` and declared an engine system dormant. A private creation under `creations/<gitignored>/` was a live consumer. The wrong finding propagated into an architectural "delete this" recommendation that the human caught.

## Test plan

- [x] Docs-only change — no build required
- [x] Each role doc has exactly one "Dormancy verification" section
- [x] No private creation names appear in the diff

Closes #338