### PR TITLE
T-060: modifier framework: wire MODIFIER_RESOLVE_EXEMPT via archetype exclude-tag filter

### DIFF
--- a/docs/design/modifiers.md
+++ b/docs/design/modifiers.md
@@ -354,11 +354,13 @@ its first real consumers arrive via downstream game logic.
 
 ### Framework gaps — follow-up issues
 
-Three gaps discovered during T-050 runtime development:
+Of the three gaps discovered during T-050 runtime development, two
+remain:
 
-- **#339** — Wire `MODIFIER_RESOLVE_EXEMPT` via archetype exclude-tag filter
-  (the exempt-resolver dispatch path is designed but not yet wired in
-  `registerResolverPipeline()`).
+- **#339** — Wire `MODIFIER_RESOLVE_EXEMPT` via archetype exclude-tag filter.
+  Resolved by T-060: `Exclude<...>` template parameter added to
+  `IRSystem::createSystem<>`, `MODIFIER_RESOLVE_EXEMPT` system shipped,
+  `MODIFIER_RESOLVE_GLOBAL` updated to skip `C_NoGlobalModifiers`.
 - **#340** — Pre-destroy hook for auto-sweep of source-attributed modifiers.
   T-050 implemented a manual sweep path; the pre-destroy hook that guarantees
   no stale modifiers survive `EntityId` reuse is still needed.

--- a/engine/entity/include/irreden/entity/archetype_graph.hpp
+++ b/engine/entity/include/irreden/entity/archetype_graph.hpp
@@ -41,14 +41,34 @@ class ArchetypeGraph {
         std::vector<ArchetypeNode *> nodes;
         nodes.reserve(m_nodes.size());
         for (auto &node : m_nodes) {
-            if (node->length_ > 0 && std::includes(
-                                         node->type_.begin(),
-                                         node->type_.end(),
-                                         includeComponents.begin(),
-                                         includeComponents.end()
-                                     )) {
-                nodes.push_back(node.get());
+            if (node->length_ <= 0) continue;
+            if (!std::includes(
+                    node->type_.begin(),
+                    node->type_.end(),
+                    includeComponents.begin(),
+                    includeComponents.end()
+                )) continue;
+            // Reject any node that contains a component the caller asked
+            // to exclude. Both sets are sorted (std::set), so an empty
+            // intersection is what we want — std::set_intersection isn't
+            // needed; a one-pass disjointness check is sufficient.
+            if (!excludeComponents.empty()) {
+                auto itNode = node->type_.begin();
+                auto itExc = excludeComponents.begin();
+                bool intersects = false;
+                while (itNode != node->type_.end() && itExc != excludeComponents.end()) {
+                    if (*itNode < *itExc) {
+                        ++itNode;
+                    } else if (*itExc < *itNode) {
+                        ++itExc;
+                    } else {
+                        intersects = true;
+                        break;
+                    }
+                }
+                if (intersects) continue;
             }
+            nodes.push_back(node.get());
         }
         return nodes;
     }

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -56,8 +56,8 @@ Runtime entry points (all `inline`, header-only):
   paths give the same answer for the same input.
 - `registerResolverPipeline()` — call once at creation init. Creates
   the singleton globals entity (named `"modifierGlobals"`) and
-  registers the four resolver systems in canonical order. Returns
-  the four `SystemId`s in pipeline order so the caller splices them
+  registers the five resolver systems in canonical order. Returns
+  the `SystemId`s in pipeline order so the caller splices them
   into its `IRTime::UPDATE` pipeline.
 - `globalsEntity()` — returns the singleton globals entity created by
   `registerResolverPipeline()`. Intended for tests and diagnostics;
@@ -99,16 +99,10 @@ Key invariants the design rests on:
 
 ### Open follow-ups (runtime gaps)
 
-The current runtime ships four of the five resolver systems plus the
-manual-call sweep API. Two design-mandated paths are deferred:
+The current runtime ships all five resolver systems plus the
+manual-call sweep API. One design-mandated path is deferred, plus a
+prefab-layer gap:
 
-- **`MODIFIER_RESOLVE_EXEMPT` archetype-routed exemption.** The
-  design routes entities tagged `C_NoGlobalModifiers` to a sibling
-  resolver that skips globals. `engine/system/` does not yet expose
-  an exclude-tag filter mechanism — `addSystemTag<T>` is include-
-  only. Until an `addSystemExcludeTag<T>` (or equivalent) lands,
-  exempt-tagged entities still receive globals. The `SystemName`
-  enum slot is reserved.
 - **Auto-sweep on entity destruction.** The design contract is for
   `removeModifiersFromSource(entityId)` to fire inside
   `EntityManager::destroyEntity` *before* `returnEntityToPool`, so
@@ -128,8 +122,8 @@ manual-call sweep API. Two design-mandated paths are deferred:
   explicitly. The `ticksRemaining` parameter is reserved for this future
   system.
 
-The first two gaps need engine-level additions; the lambda decay gap is
-prefab-layer work. File a follow-up task before relying on any of them.
+The pre-destroy hook is engine-level work; the lambda decay gap is
+prefab-layer. File a follow-up task before relying on either.
 
 ## Commands
 

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -61,8 +61,8 @@ Runtime entry points (all `inline`, header-only):
   paths give the same answer for the same input.
 - `registerResolverPipeline()` — call once at creation init. Creates
   the singleton globals entity (named `"modifierGlobals"`) and
-  registers the four resolver systems in canonical order. Returns
-  the four `SystemId`s in pipeline order so the caller splices them
+  registers the five resolver systems in canonical order. Returns
+  the `SystemId`s in pipeline order so the caller splices them
   into its `IRTime::UPDATE` pipeline.
 - `globalsEntity()` — returns the singleton globals entity created by
   `registerResolverPipeline()`. Intended for tests and diagnostics;
@@ -104,17 +104,9 @@ Key invariants the design rests on:
 
 ### Open follow-ups (runtime gaps)
 
-The current runtime ships four of the five resolver systems, the
-manual-call sweep API, and the pre-destroy hook auto-sweep. One
-design-mandated resolver path and one decay gap remain deferred:
-
-- **`MODIFIER_RESOLVE_EXEMPT` archetype-routed exemption.** The
-  design routes entities tagged `C_NoGlobalModifiers` to a sibling
-  resolver that skips globals. `engine/system/` does not yet expose
-  an exclude-tag filter mechanism — `addSystemTag<T>` is include-
-  only. Until an `addSystemExcludeTag<T>` (or equivalent) lands,
-  exempt-tagged entities still receive globals. The `SystemName`
-  enum slot is reserved. Tracked in #339 / T-060.
+The current runtime ships all five resolver systems, the manual-call
+sweep API, and the pre-destroy hook auto-sweep. One decay gap remains
+deferred:
 
 - **Lambda modifier auto-expire (`pushLambda` `ticksRemaining` gap).**
   `pushLambda` accepts a `ticksRemaining` parameter and stores it in
@@ -125,8 +117,8 @@ design-mandated resolver path and one decay gap remain deferred:
   explicitly. The `ticksRemaining` parameter is reserved for this future
   system. Tracked in #341 / T-062.
 
-The exempt resolver gap needs an engine-level addition; the lambda decay
-gap is prefab-layer work. File a follow-up task before relying on either.
+The lambda decay gap is prefab-layer work. File a follow-up task before
+relying on it.
 
 The pre-destroy hook used for auto-sweep is a generic
 `EntityManager::registerPreDestroyHook` mechanism (see

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -22,6 +22,7 @@
 #include <irreden/common/modifier_field_registry.hpp>
 #include <irreden/common/systems/system_global_modifier_decay.hpp>
 #include <irreden/common/systems/system_modifier_decay.hpp>
+#include <irreden/common/systems/system_modifier_resolve_exempt.hpp>
 #include <irreden/common/systems/system_modifier_resolve_global.hpp>
 #include <irreden/common/systems/system_modifier_resolve_lambda.hpp>
 
@@ -153,17 +154,20 @@ inline float applyToField(
     return detail::composeForField(baseValue, field, globals, entityMods);
 }
 
-// Wires up the singleton globals entity and registers the four resolver
+// Wires up the singleton globals entity and registers the five resolver
 // systems in the canonical order. Must be called once at creation init,
 // before any system that depends on resolved fields.
 //
 // Pipeline ordering chosen by the caller's registerPipeline(); this
 // function returns the SystemIds in resolver order so the caller can
-// splice them in.
+// splice them in. The two RESOLVE_GLOBAL/RESOLVE_EXEMPT systems
+// archetype-route on C_NoGlobalModifiers so each entity hits exactly
+// one (no per-entity branching).
 struct ResolverPipelineSystems {
     IRSystem::SystemId modifierDecay_;
     IRSystem::SystemId globalModifierDecay_;
     IRSystem::SystemId modifierResolveGlobal_;
+    IRSystem::SystemId modifierResolveExempt_;
     IRSystem::SystemId modifierResolveLambda_;
 };
 
@@ -182,6 +186,7 @@ inline ResolverPipelineSystems registerResolverPipeline() {
         IRSystem::createSystem<IRSystem::MODIFIER_DECAY>(),
         IRSystem::createSystem<IRSystem::GLOBAL_MODIFIER_DECAY>(),
         IRSystem::createSystem<IRSystem::MODIFIER_RESOLVE_GLOBAL>(),
+        IRSystem::createSystem<IRSystem::MODIFIER_RESOLVE_EXEMPT>(),
         IRSystem::createSystem<IRSystem::MODIFIER_RESOLVE_LAMBDA>(),
     };
 }

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -22,6 +22,7 @@
 #include <irreden/common/modifier_field_registry.hpp>
 #include <irreden/common/systems/system_global_modifier_decay.hpp>
 #include <irreden/common/systems/system_modifier_decay.hpp>
+#include <irreden/common/systems/system_modifier_resolve_exempt.hpp>
 #include <irreden/common/systems/system_modifier_resolve_global.hpp>
 #include <irreden/common/systems/system_modifier_resolve_lambda.hpp>
 
@@ -156,17 +157,20 @@ inline float applyToField(
     return detail::composeForField(baseValue, field, globals, entityMods);
 }
 
-// Wires up the singleton globals entity and registers the four resolver
+// Wires up the singleton globals entity and registers the five resolver
 // systems in the canonical order. Must be called once at creation init,
 // before any system that depends on resolved fields.
 //
 // Pipeline ordering chosen by the caller's registerPipeline(); this
 // function returns the SystemIds in resolver order so the caller can
-// splice them in.
+// splice them in. The two RESOLVE_GLOBAL/RESOLVE_EXEMPT systems
+// archetype-route on C_NoGlobalModifiers so each entity hits exactly
+// one (no per-entity branching).
 struct ResolverPipelineSystems {
     IRSystem::SystemId modifierDecay_;
     IRSystem::SystemId globalModifierDecay_;
     IRSystem::SystemId modifierResolveGlobal_;
+    IRSystem::SystemId modifierResolveExempt_;
     IRSystem::SystemId modifierResolveLambda_;
 };
 
@@ -194,6 +198,7 @@ inline ResolverPipelineSystems registerResolverPipeline() {
         IRSystem::createSystem<IRSystem::MODIFIER_DECAY>(),
         IRSystem::createSystem<IRSystem::GLOBAL_MODIFIER_DECAY>(),
         IRSystem::createSystem<IRSystem::MODIFIER_RESOLVE_GLOBAL>(),
+        IRSystem::createSystem<IRSystem::MODIFIER_RESOLVE_EXEMPT>(),
         IRSystem::createSystem<IRSystem::MODIFIER_RESOLVE_LAMBDA>(),
     };
 }

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
@@ -1,0 +1,44 @@
+#ifndef SYSTEM_MODIFIER_RESOLVE_EXEMPT_H
+#define SYSTEM_MODIFIER_RESOLVE_EXEMPT_H
+
+// Sibling of MODIFIER_RESOLVE_GLOBAL for entities tagged
+// C_NoGlobalModifiers. Composes only the entity's own C_Modifiers
+// (skipping the global vector) into C_ResolvedFields.
+//
+// Dispatch is archetype-routed: this system's include archetype
+// requires C_NoGlobalModifiers, while MODIFIER_RESOLVE_GLOBAL excludes
+// the same tag. Together they partition the C_Modifiers + C_ResolvedFields
+// population without a per-entity branch.
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+
+#include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/common/modifier_compose.hpp>
+
+namespace IRSystem {
+
+template <> struct System<MODIFIER_RESOLVE_EXEMPT> {
+    static SystemId create() {
+        return createSystem<
+            IRComponents::C_Modifiers,
+            IRComponents::C_ResolvedFields,
+            IRComponents::C_NoGlobalModifiers
+        >(
+            "ModifierResolveExempt",
+            [](IRComponents::C_Modifiers &m,
+               IRComponents::C_ResolvedFields &resolved,
+               IRComponents::C_NoGlobalModifiers &) {
+                for (auto &rf : resolved.fields_) {
+                    rf.value_ = IRPrefab::Modifier::detail::composeForField(
+                        rf.value_, rf.field_, m.modifiers_
+                    );
+                }
+            }
+        );
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_MODIFIER_RESOLVE_EXEMPT_H */

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
@@ -28,7 +28,7 @@ template <> struct System<MODIFIER_RESOLVE_EXEMPT> {
             "ModifierResolveExempt",
             [](IRComponents::C_Modifiers &m,
                IRComponents::C_ResolvedFields &resolved,
-               IRComponents::C_NoGlobalModifiers &) {
+               [[maybe_unused]] IRComponents::C_NoGlobalModifiers &) {
                 for (auto &rf : resolved.fields_) {
                     rf.value_ = IRPrefab::Modifier::detail::composeForField(
                         rf.value_, rf.field_, m.modifiers_

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
@@ -15,11 +15,9 @@
 // current base value before this system runs; the resolver mutates
 // value_ in place.
 //
-// NOTE — exempt path (C_NoGlobalModifiers) is not yet wired. A separate
-// MODIFIER_RESOLVE_EXEMPT system would require an exclude-tag filter
-// mechanism in engine/system. Until that lands, exempt entities still
-// receive globals; tag them with absorbing-no-op globals or push through
-// a custom path.
+// Entities tagged with C_NoGlobalModifiers are routed away by the
+// archetype filter (Exclude<C_NoGlobalModifiers>) so they fall through
+// to MODIFIER_RESOLVE_EXEMPT instead — no per-entity branching here.
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_system.hpp>
@@ -51,7 +49,8 @@ template <> struct System<MODIFIER_RESOLVE_GLOBAL> {
     static SystemId create() {
         return createSystem<
             IRComponents::C_Modifiers,
-            IRComponents::C_ResolvedFields
+            IRComponents::C_ResolvedFields,
+            Exclude<IRComponents::C_NoGlobalModifiers>
         >(
             "ModifierResolveGlobal",
             [](IRComponents::C_Modifiers &m,

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -10,7 +10,33 @@ namespace IRSystem {
 extern SystemManager *g_systemManager;
 SystemManager &getSystemManager();
 
-// Create a new system
+namespace detail {
+
+// Re-expand a TypeList<Cs...> back into the include-pack of
+// SystemManager::createSystem so the matched archetype + dispatch only
+// see the real components (not Exclude<...> placeholders).
+template <typename L> struct CallCreateSystem;
+template <typename... Cs>
+struct CallCreateSystem<TypeList<Cs...>> {
+    template <typename... Args>
+    static SystemId run(SystemManager &mgr, Args &&...args) {
+        return mgr.template createSystem<Cs...>(std::forward<Args>(args)...);
+    }
+};
+
+template <typename L> struct ArchetypeFromList;
+template <typename... Cs>
+struct ArchetypeFromList<TypeList<Cs...>> {
+    static IREntity::Archetype value() { return IREntity::getArchetype<Cs...>(); }
+};
+
+} // namespace detail
+
+// Create a new system. `TickComponents...` may include zero or more
+// `Exclude<Tags...>` markers; these are partitioned out at compile time
+// and used to build an exclude archetype that the matcher rejects nodes
+// against (so tagged entities skip this system without per-entity
+// branching). See ir_system_types.hpp for the Exclude<> declaration.
 template <
     typename... TickComponents,
     typename... TickRelationComponents,
@@ -26,13 +52,18 @@ constexpr SystemId createSystem(
     RelationParams<TickRelationComponents...> extraParams = {},
     FunctionRelationTick functionRelationTick = nullptr
 ) {
-    return getSystemManager().createSystem<TickComponents...>(
-        name,
-        functionTick,
-        functionBeginTick,
-        functionEndTick,
+    using Partition = detail::PartitionExcludes<TickComponents...>;
+    auto excludeArchetype =
+        detail::ArchetypeFromList<typename Partition::Excluded>::value();
+    return detail::CallCreateSystem<typename Partition::Included>::run(
+        getSystemManager(),
+        std::move(name),
+        std::move(functionTick),
+        std::move(functionBeginTick),
+        std::move(functionEndTick),
         extraParams,
-        functionRelationTick
+        std::move(functionRelationTick),
+        std::move(excludeArchetype)
     );
 }
 
@@ -44,6 +75,12 @@ template <SystemName type, typename... Args> SystemId createSystem(Args &&...arg
 // TODO: Make extra param as well
 template <typename ComponentTag> void addSystemTag(SystemId system) {
     getSystemManager().addSystemTag<ComponentTag>(system);
+}
+
+// Mirror of addSystemTag<> for the exclude archetype. After this call,
+// the matcher rejects any node whose type contains the tag.
+template <typename ComponentTag> void addSystemExcludeTag(SystemId system) {
+    getSystemManager().addSystemExcludeTag<ComponentTag>(system);
 }
 
 template <typename Params> void setSystemParams(SystemId system, std::unique_ptr<Params> params) {

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -61,7 +61,7 @@ constexpr SystemId createSystem(
         std::move(functionTick),
         std::move(functionBeginTick),
         std::move(functionEndTick),
-        extraParams,
+        std::move(extraParams),
         std::move(functionRelationTick),
         std::move(excludeArchetype)
     );

--- a/engine/system/include/irreden/system/components/component_system_event.hpp
+++ b/engine/system/include/irreden/system/components/component_system_event.hpp
@@ -25,13 +25,16 @@ template <> struct C_SystemEvent<IRSystem::BEGIN_TICK> {
 template <> struct C_SystemEvent<IRSystem::TICK> {
     std::function<void(IREntity::ArchetypeNode *)> functionTick_;
     IREntity::Archetype archetype_;
+    IREntity::Archetype excludeArchetype_;
 
     C_SystemEvent(
         const std::function<void(IREntity::ArchetypeNode *)> &tickFunctions,
-        const IREntity::Archetype &archetype
+        const IREntity::Archetype &archetype,
+        const IREntity::Archetype &excludeArchetype = {}
     )
         : functionTick_(tickFunctions)
-        , archetype_(archetype) {}
+        , archetype_(archetype)
+        , excludeArchetype_(excludeArchetype) {}
 
     C_SystemEvent()
         : functionTick_() {}

--- a/engine/system/include/irreden/system/components/component_system_event.hpp
+++ b/engine/system/include/irreden/system/components/component_system_event.hpp
@@ -29,12 +29,12 @@ template <> struct C_SystemEvent<IRSystem::TICK> {
 
     C_SystemEvent(
         const std::function<void(IREntity::ArchetypeNode *)> &tickFunctions,
-        const IREntity::Archetype &archetype,
-        const IREntity::Archetype &excludeArchetype = {}
+        IREntity::Archetype archetype,
+        IREntity::Archetype excludeArchetype = {}
     )
         : functionTick_(tickFunctions)
-        , archetype_(archetype)
-        , excludeArchetype_(excludeArchetype) {}
+        , archetype_(std::move(archetype))
+        , excludeArchetype_(std::move(excludeArchetype)) {}
 
     C_SystemEvent()
         : functionTick_() {}

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -71,10 +71,9 @@ enum SystemName {
     SPRING_COLOR,
 
     // Modifier framework — runs at end of UPDATE, before RENDER reads
-    // C_ResolvedFields. Order: decay both vectors, then resolve, then
-    // lambda escape hatch. The MODIFIER_RESOLVE_EXEMPT slot is reserved
-    // for the C_NoGlobalModifiers archetype-routing path (deferred —
-    // requires an exclude-tag mechanism in engine/system).
+    // C_ResolvedFields. Order: decay both vectors, then resolve
+    // (global / exempt partitioned by C_NoGlobalModifiers via the
+    // Exclude<> archetype filter), then lambda escape hatch.
     MODIFIER_DECAY,
     GLOBAL_MODIFIER_DECAY,
     MODIFIER_RESOLVE_GLOBAL,
@@ -115,6 +114,63 @@ template <typename... RelationComponents> struct RelationParams {
     RelationParams(Relation relation = Relation::NONE)
         : relation_(relation) {}
 };
+
+/// Mark archetype components that a system should EXCLUDE from its match,
+/// not include. Use as a template parameter to `createSystem<...>`:
+///
+///     createSystem<
+///         C_Modifiers,
+///         C_ResolvedFields,
+///         Exclude<C_NoGlobalModifiers>
+///     >("ModifierResolveGlobal", [](C_Modifiers&, C_ResolvedFields&) { ... });
+///
+/// The wrapper partitions the pack into includes / excludes at compile
+/// time, so dispatch only iterates the include components and the
+/// archetype matcher rejects nodes whose type intersects the exclude set
+/// (no per-entity branching).
+template <typename... Tags> struct Exclude {};
+
+namespace detail {
+
+template <typename...> struct TypeList {};
+
+template <typename T> struct ExtractFromExclude {
+    using Included = TypeList<T>;
+    using Excluded = TypeList<>;
+};
+template <typename... Tags> struct ExtractFromExclude<Exclude<Tags...>> {
+    using Included = TypeList<>;
+    using Excluded = TypeList<Tags...>;
+};
+
+template <typename A, typename B> struct ConcatTypeList;
+template <typename... A, typename... B>
+struct ConcatTypeList<TypeList<A...>, TypeList<B...>> {
+    using Type = TypeList<A..., B...>;
+};
+
+template <typename Acc, typename... Pack> struct PartitionImpl;
+
+template <typename Inc, typename Exc>
+struct PartitionImpl<TypeList<Inc, Exc>> {
+    using Included = Inc;
+    using Excluded = Exc;
+};
+
+template <typename Inc, typename Exc, typename Head, typename... Tail>
+struct PartitionImpl<TypeList<Inc, Exc>, Head, Tail...> {
+    using Extract = ExtractFromExclude<Head>;
+    using NextInc = typename ConcatTypeList<Inc, typename Extract::Included>::Type;
+    using NextExc = typename ConcatTypeList<Exc, typename Extract::Excluded>::Type;
+    using Rec = PartitionImpl<TypeList<NextInc, NextExc>, Tail...>;
+    using Included = typename Rec::Included;
+    using Excluded = typename Rec::Excluded;
+};
+
+template <typename... Pack>
+using PartitionExcludes = PartitionImpl<TypeList<TypeList<>, TypeList<>>, Pack...>;
+
+} // namespace detail
 // // Deduction guide
 // template <typename... RelationComponents>
 // RelationParams(Relation, void (*)(const RelationComponents&...)) ->

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -63,14 +63,14 @@ class SystemManager {
         FunctionBeginTick functionBeginTick = nullptr,
         FunctionEndTick functionEndTick = nullptr,
         RelationParams<RelationComponents...> extraParams = {},
-        FunctionRelationTick functionRelationTick = nullptr
-
+        FunctionRelationTick functionRelationTick = nullptr,
+        Archetype excludeArchetype = {}
     ) {
         m_systemNames.emplace_back(C_Name{name});
         SystemId newSystemId = m_nextSystemId++;
 
         insertBeginTickFunction(functionBeginTick);
-        insertTickFunction<Components...>(functionTick, extraParams);
+        insertTickFunction<Components...>(functionTick, extraParams, std::move(excludeArchetype));
         insertEndTickFunction(functionEndTick);
         insertRelationTickFunction<RelationComponents...>(functionRelationTick);
 
@@ -82,6 +82,10 @@ class SystemManager {
 
     template <typename Tag> void addSystemTag(SystemId system) {
         m_ticks[system].archetype_.insert(IREntity::getComponentType<Tag>());
+    }
+
+    template <typename Tag> void addSystemExcludeTag(SystemId system) {
+        m_ticks[system].excludeArchetype_.insert(IREntity::getComponentType<Tag>());
     }
 
     template <typename Params> void setSystemParams(SystemId system, std::unique_ptr<Params> params) {
@@ -140,7 +144,9 @@ class SystemManager {
     // matching the archetype. This can happen a variery of ways
     template <typename... Components, typename... RelationComponents, typename FunctionTick>
     void insertTickFunction(
-        FunctionTick functionTick, RelationParams<RelationComponents...> extraParams
+        FunctionTick functionTick,
+        RelationParams<RelationComponents...> extraParams,
+        Archetype excludeArchetype
     ) {
         m_ticks.emplace_back(
             C_SystemEvent<TICK>{
@@ -210,7 +216,8 @@ class SystemManager {
                         static_assert(false, "Unsupported tick function signature.");
                     }
                 },
-                getArchetype<Components...>()
+                getArchetype<Components...>(),
+                std::move(excludeArchetype)
             }
         );
     }

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -50,12 +50,16 @@ void SystemManager::executeSystem(SystemId system) {
     m_beginTicks[system].functionBeginTick_();
     std::vector<ArchetypeNode *> nodes;
     if (m_relations[system].relation_ == Relation::NONE) {
-        nodes = IREntity::queryArchetypeNodesSimple(m_ticks[system].archetype_);
+        nodes = IREntity::queryArchetypeNodesSimple(
+            m_ticks[system].archetype_,
+            m_ticks[system].excludeArchetype_
+        );
     }
     if (m_relations[system].relation_ == Relation::CHILD_OF) {
         nodes = IREntity::queryArchetypeNodesRelational(
             m_relations[system].relation_,
-            m_ticks[system].archetype_
+            m_ticks[system].archetype_,
+            m_ticks[system].excludeArchetype_
         );
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(IrredenEngineTest
   ecs/entity_manager_test.cpp
   ecs/modifier_runtime_test.cpp
   ecs/modifier_types_test.cpp
+  ecs/system_exclude_test.cpp
   math/physics_test.cpp
   math/ir_math_test.cpp
   math/ir_math_viewport_helpers_test.cpp

--- a/test/ecs/system_exclude_test.cpp
+++ b/test/ecs/system_exclude_test.cpp
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+#include <irreden/entity/archetype_graph.hpp>
+#include <irreden/entity/entity_manager.hpp>
+
+namespace {
+
+// Plain data + tag types — kept local to this TU so they don't pollute
+// the engine's component registry across test files.
+struct Counter {
+    int n_ = 0;
+};
+struct ExcludeTag {};
+
+// ---- Low-level: ArchetypeGraph honors excludeComponents ------------------
+
+class ArchetypeGraphExcludeTest : public testing::Test {
+  protected:
+    IREntity::EntityManager m_entity_manager;
+};
+
+TEST_F(ArchetypeGraphExcludeTest, EmptyExcludeMatchesAllIncluded) {
+    IREntity::createEntity(Counter{1});
+    IREntity::createEntity(Counter{2}, ExcludeTag{});
+
+    auto include = IREntity::getArchetype<Counter>();
+    auto nodes = IREntity::queryArchetypeNodesSimple(include);
+
+    int total = 0;
+    for (auto *node : nodes) total += node->length_;
+    EXPECT_EQ(total, 2);
+}
+
+TEST_F(ArchetypeGraphExcludeTest, NonEmptyExcludeRejectsTaggedNodes) {
+    IREntity::createEntity(Counter{1});
+    IREntity::createEntity(Counter{2}, ExcludeTag{});
+
+    auto include = IREntity::getArchetype<Counter>();
+    auto exclude = IREntity::getArchetype<ExcludeTag>();
+    auto nodes = IREntity::queryArchetypeNodesSimple(include, exclude);
+
+    int total = 0;
+    for (auto *node : nodes) total += node->length_;
+    EXPECT_EQ(total, 1);
+}
+
+TEST_F(ArchetypeGraphExcludeTest, ExcludeOnNonTaggedNodesIsNoOp) {
+    IREntity::createEntity(Counter{1});
+    IREntity::createEntity(Counter{2});
+
+    auto include = IREntity::getArchetype<Counter>();
+    auto exclude = IREntity::getArchetype<ExcludeTag>();
+    auto nodes = IREntity::queryArchetypeNodesSimple(include, exclude);
+
+    int total = 0;
+    for (auto *node : nodes) total += node->length_;
+    EXPECT_EQ(total, 2);
+}
+
+// ---- High-level: Exclude<> in createSystem<> dispatches via archetype ----
+
+class SystemExcludeTest : public testing::Test {
+  protected:
+    SystemExcludeTest()
+        : m_entity_manager{}
+        , m_system_manager{} {}
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(SystemExcludeTest, ExcludeTemplateParamSkipsTaggedEntities) {
+    auto idA = IREntity::createEntity(Counter{0});             // not tagged
+    auto idB = IREntity::createEntity(Counter{0}, ExcludeTag{}); // tagged
+
+    auto sysId = IRSystem::createSystem<Counter, IRSystem::Exclude<ExcludeTag>>(
+        "IncrementUntagged",
+        [](Counter &c) { c.n_++; }
+    );
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_EQ(IREntity::getComponent<Counter>(idA).n_, 1) << "untagged entity should run";
+    EXPECT_EQ(IREntity::getComponent<Counter>(idB).n_, 0) << "tagged entity should be excluded";
+}
+
+TEST_F(SystemExcludeTest, NoExcludeTemplateParamMatchesAll) {
+    auto idA = IREntity::createEntity(Counter{0});
+    auto idB = IREntity::createEntity(Counter{0}, ExcludeTag{});
+
+    auto sysId = IRSystem::createSystem<Counter>(
+        "IncrementAll",
+        [](Counter &c) { c.n_++; }
+    );
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_EQ(IREntity::getComponent<Counter>(idA).n_, 1);
+    EXPECT_EQ(IREntity::getComponent<Counter>(idB).n_, 1);
+}
+
+TEST_F(SystemExcludeTest, ExcludeAndIncludePartitionTaggedPopulation) {
+    auto idA = IREntity::createEntity(Counter{0});
+    auto idB = IREntity::createEntity(Counter{0}, ExcludeTag{});
+
+    auto sysExempt = IRSystem::createSystem<Counter, IRSystem::Exclude<ExcludeTag>>(
+        "IncrementUntagged",
+        [](Counter &c) { c.n_ += 1; }
+    );
+    auto sysTagged = IRSystem::createSystem<Counter, ExcludeTag>(
+        "IncrementTaggedTenfold",
+        [](Counter &c, ExcludeTag &) { c.n_ += 10; }
+    );
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysExempt, sysTagged});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_EQ(IREntity::getComponent<Counter>(idA).n_, 1)  << "untagged path only";
+    EXPECT_EQ(IREntity::getComponent<Counter>(idB).n_, 10) << "tagged path only";
+}
+
+TEST_F(SystemExcludeTest, AddSystemExcludeTagMatchesExcludeTemplateParam) {
+    auto idA = IREntity::createEntity(Counter{0});
+    auto idB = IREntity::createEntity(Counter{0}, ExcludeTag{});
+
+    auto sysId = IRSystem::createSystem<Counter>(
+        "IncrementUntaggedRuntime",
+        [](Counter &c) { c.n_++; }
+    );
+    IRSystem::addSystemExcludeTag<ExcludeTag>(sysId);
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_EQ(IREntity::getComponent<Counter>(idA).n_, 1);
+    EXPECT_EQ(IREntity::getComponent<Counter>(idB).n_, 0);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Adds `Exclude<Tags...>` template parameter to `IRSystem::createSystem<>`. The wrapper partitions the pack at compile time (`detail::PartitionExcludes`) so dispatch only iterates real components and the matcher rejects nodes whose type intersects the exclude set — no per-entity branch.
- Fixes `ArchetypeGraph::queryArchetypeNodesSimple`: it has accepted an `excludeComponents` parameter since inception but never honored it. Now does a one-pass set-disjointness walk, gated on `.empty()` so the no-exclude hot path adds one branch.
- Ships `MODIFIER_RESOLVE_EXEMPT` and updates `MODIFIER_RESOLVE_GLOBAL` to add `Exclude<C_NoGlobalModifiers>`. Tagged entities are now routed to the exempt resolver via archetype filter, exactly the design's archetype-routing invariant.
- Mirror `addSystemTag<T>` with `addSystemExcludeTag<T>` for runtime mutation.

## API at the call site
```cpp
createSystem<
    C_Modifiers,
    C_ResolvedFields,
    Exclude<C_NoGlobalModifiers>
>("ModifierResolveGlobal", [](C_Modifiers&, C_ResolvedFields&) { ... });
```

## Test plan
- [x] `IrredenEngineTest --gtest_filter='*Exclude*'` — 7/7 pass (3 archetype-graph filter cases, 4 SystemManager-level dispatch cases including `addSystemExcludeTag` parity with the template form)
- [x] Full `IrredenEngineTest` — 340/340 pass
- [x] `IRShapeDebug` builds clean (production code path: any creation call that uses `createSystem` without `Exclude<>` is unaffected — the partition helper degenerates to the existing include-only flow)

## Notes for reviewer
- `engine/system/include/irreden/system/ir_system_types.hpp` — new `Exclude<>` + `detail::PartitionExcludes` typelist fold.
- `engine/system/include/irreden/ir_system.hpp` — wrapper partitions and forwards.
- `engine/entity/include/irreden/entity/archetype_graph.hpp` lines 41–72 — set-disjointness walk. Comment explains why `std::set_intersection` would be a perf regression.
- `engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp` (new) — mirrors the global resolver but uses the single-vector `composeForField` overload (no globals to layer). Matches `C_NoGlobalModifiers` as a real include component.

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)