### PR TITLE
fleet: split human:needs-fix disposition into amend vs deferred

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -250,20 +250,91 @@ Do the work, then exit cleanly:
 
       **For `fleet:has-nits`**: focus on the latest review's `### Nits`
       section. Address every nit unless it's purely subjective preference.
-   b. **Immediately remove the feedback label**:
+
+   a2. **For `human:needs-fix` / `human:blocker` only — decide
+       AMEND vs ESCALATE.** Two valid dispositions:
+
+       - **AMEND** (default): you'll fix the concerns inline in
+         this PR. The PR is being changed; merge should hold until
+         the reviewer re-approves. Continue with step b — step b
+         will set `fleet:human-amending` + clear `fleet:approved`
+         to make the "hold merge" state visible.
+
+       - **ESCALATE**: file a follow-up issue and leave this PR's
+         approval intact. Choose when:
+         - The concern is scope expansion (architect-level
+           redesign, follow-up feature)
+         - The concern is a downstream-PR dependency ("won't align
+           until T-X ships"), not a bug in THIS PR
+         - The original Sonnet/Opus review explicitly deferred the
+           concern; the human is overriding that deferral and the
+           new direction belongs in its own design issue
+         - The fix needs a different model tier than your own (rare
+           for opus-worker; mostly relevant for sonnet-author
+           escalating to opus)
+
+         Skip to the **ESCALATE path** below.
+
+       Default to AMEND when uncertain. ESCALATE is a deliberate
+       choice that needs justification in the linked issue.
+
+       **ESCALATE path:**
+       1. File the follow-up issue:
+          `gh issue create --repo jakildev/IrredenEngine --title "<short title>" --body "<body>"`
+          The body must include:
+          - **Context** — escalated from PR #<N>, list the human's
+            specific concerns (file:line for each)
+          - **Why escalating** — one paragraph: scope-expansion,
+            downstream-dependency, deferred-by-prior-review, etc.
+          - **Suggested model** — `[opus]` or `[sonnet]`
+          - **Suggested area** — module path
+          - **Suggested approach** — bullets, for the picker to
+            validate
+       2. Swap PR labels in one combine-safe call (the removed
+          label is guaranteed present — that is what brought you
+          here):
+          `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --add-label "fleet:human-deferred"`
+       3. **Keep `fleet:approved`** — the PR is internally
+          consistent, the prior reviewer approval stands.
+          `fleet:human-deferred` signals: "agent acknowledged the
+          concerns, linked issue tracks them, human decides
+          whether to merge as-is or re-add `human:needs-fix` to
+          force AMEND mode."
+       4. Comment on the PR linking the issue:
+          `gh pr comment <N> --body "Escalated — filed issue #<M> for the <opus|sonnet> work. Concerns map to <one-line summary>. PR is internally OK to merge if you accept the deferral; re-add human:needs-fix to switch to AMEND mode. — opus-worker"`
+       5. **Skip steps b–g.** Jump to step h (move to next
+          iteration). The PR's code is unchanged.
+
+   b. **(AMEND path)** **Immediately remove the feedback label**
+      to prevent another agent from also picking it up:
       `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits"`
+
+      For `human:needs-fix` / `human:blocker` specifically, also
+      mark the PR as in-progress and clear the prior approval so
+      the human knows to hold the merge (two separate calls —
+      `fleet:approved` may not be present and combining
+      remove-when-absent with `--add-label` would abort the call):
+      `gh pr edit <N> --add-label "fleet:human-amending"`
+      `gh pr edit <N> --remove-label "fleet:approved"`
+      For `fleet:needs-fix` / `fleet:has-nits` only (no human
+      label): skip both — reviewer-flagged feedback doesn't
+      trigger the human-amending state.
    c. Address every piece of feedback. Build with `fleet-build`.
    d. Push fixes using `commit-and-push`.
-   e. Add the appropriate response label:
-      - If it was `human:needs-fix` or `human:blocker` → add
-        `fleet:changes-made`:
-        `gh pr edit <N> --add-label "fleet:changes-made"`
+   e. Swap the in-progress label for the done label:
+      - If it was `human:needs-fix` or `human:blocker` → swap
+        `fleet:human-amending` for `fleet:changes-made` (one
+        combine-safe call — the removed label is guaranteed
+        present from step b):
+        `gh pr edit <N> --remove-label "fleet:human-amending" --add-label "fleet:changes-made"`
       - If it was `fleet:needs-fix` → no response label needed.
       - If it was `fleet:has-nits` → no response label needed; existing
         `fleet:approved` stays valid (cleanups don't invalidate approval).
       `gh pr comment <N> --body "Addressed feedback: <bullet list of what changed>"`
    f. Remove stale fleet review labels (`fleet:needs-fix`,
-      `fleet:blocker`) if present — but **keep `fleet:approved`**.
+      `fleet:blocker`) if present — but **keep `fleet:approved`** if
+      the path was `fleet:has-nits`. (The AMEND path already
+      cleared `fleet:approved` in step b for `human:needs-fix`.)
    g. **Propagate the upstream fix to any downstream branches in a
       stacked chain.** Always run, after every feedback fix:
       `fleet-claim molecule rebase-downstream <your-worktree-basename>`

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -307,7 +307,7 @@ Do the work, then exit cleanly:
 
    b. **(AMEND path)** **Immediately remove the feedback label**
       to prevent another agent from also picking it up:
-      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits"`
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:human-deferred"`
 
       For `human:needs-fix` / `human:blocker` specifically, also
       mark the PR as in-progress and clear the prior approval so

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -178,17 +178,87 @@ Each iteration:
       Address every nit unless it's purely subjective preference. The
       reviewer's "Nits" section is the comprehensive list — treat it
       like a checklist.
-   b. **Immediately remove the feedback label** to prevent another agent
-      from also picking it up:
+
+   a2. **For `human:needs-fix` / `human:blocker` only — decide
+       AMEND vs ESCALATE.** Two valid dispositions:
+
+       - **AMEND** (default): you'll fix the concerns inline in
+         this PR. The PR is being changed; merge should hold until
+         the reviewer re-approves. Continue with step b — the
+         existing flow handles this and step b will set
+         `fleet:human-amending` + clear `fleet:approved` to make
+         the "hold merge" state visible.
+
+       - **ESCALATE**: file a follow-up issue and leave this PR's
+         approval intact. Choose when:
+         - The concern is scope expansion (architect-level
+           redesign, follow-up feature)
+         - The concern is a downstream-PR dependency ("won't align
+           until T-X ships"), not a bug in THIS PR
+         - The fix needs Opus-tier reasoning and you're Sonnet
+         - The original review (Sonnet/Opus) explicitly deferred
+           the concern; the human is overriding that deferral and
+           the new direction belongs in its own design issue
+
+         Skip to the **ESCALATE path** below.
+
+       Default to AMEND when uncertain. ESCALATE is a deliberate
+       choice that needs justification in the linked issue.
+
+       **ESCALATE path:**
+       1. File the follow-up issue:
+          `gh issue create --repo jakildev/IrredenEngine --title "<short title>" --body "<body>"`
+          The body must include:
+          - **Context** — escalated from PR #<N>, list the human's
+            specific concerns (file:line for each)
+          - **Why escalating** — one paragraph: scope-expansion,
+            tier-mismatch, deferred-by-prior-review, etc.
+          - **Suggested model** — `[opus]` or `[sonnet]`
+          - **Suggested area** — module path
+          - **Suggested approach** — bullets, for the picker to
+            validate
+       2. Swap PR labels (one call combines remove+add safely
+          because `human:needs-fix` is guaranteed present — that
+          is what brought you here):
+          `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --add-label "fleet:human-deferred"`
+       3. **Keep `fleet:approved`** — the PR is internally
+          consistent, the prior reviewer approval stands.
+          `fleet:human-deferred` signals: "agent acknowledged the
+          concerns, linked issue tracks them, human decides
+          whether to merge as-is or re-add `human:needs-fix` to
+          force amend mode."
+       4. Comment on the PR linking the issue:
+          `gh pr comment <N> --body "Escalated — filed issue #<M> for the <opus|sonnet> work. Concerns map to <one-line summary>. PR is internally OK to merge if you accept the deferral; re-add human:needs-fix to switch to AMEND mode. — sonnet-author"`
+       5. **Skip steps b–g.** Jump to step h (move to next
+          iteration). The PR's code is unchanged.
+
+   b. **(AMEND path)** **Immediately remove the feedback label** to
+      prevent another agent from also picking it up:
       `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits"`
+
+      For `human:needs-fix` / `human:blocker` specifically, also
+      mark the PR as in-progress and clear the prior approval so
+      the human knows to hold the merge:
+      `gh pr edit <N> --add-label "fleet:human-amending"`
+      `gh pr edit <N> --remove-label "fleet:approved"`
+      (Two separate calls — `fleet:approved` may not be present
+      and `gh pr edit --remove-label` returns non-zero when the
+      label is absent, which would abort a chained `--add-label`.
+      For `fleet:needs-fix` / `fleet:has-nits` paths, skip both —
+      reviewer-flagged feedback doesn't trigger the human-amending
+      state.)
    c. Address every piece of feedback. Make the edits, build with
       `fleet-build --target <name>`.
    d. Push fixes using `commit-and-push`.
-   e. Add the appropriate response label and post a summary:
-      - If it was `human:needs-fix` or `human:blocker` → add
-        `fleet:changes-made` (signals BOTH the human AND the fleet
-        reviewer to re-verify; whichever picks it up first wins):
-        `gh pr edit <N> --add-label "fleet:changes-made"`
+   e. Swap the in-progress label for the done label and post a
+      summary:
+      - If it was `human:needs-fix` or `human:blocker` → swap
+        `fleet:human-amending` for `fleet:changes-made` (signals
+        BOTH the human AND the fleet reviewer to re-verify;
+        whichever picks it up first wins). Safe to combine in one
+        call — the removed label is guaranteed present (you set
+        it in step b):
+        `gh pr edit <N> --remove-label "fleet:human-amending" --add-label "fleet:changes-made"`
       - If it was `fleet:needs-fix` → no response label needed
         (fleet reviewer will re-review automatically on next poll)
       - If it was `fleet:has-nits` → no response label needed; the
@@ -220,13 +290,23 @@ Each iteration:
    h. Move to the next loop iteration.
 
    **Human feedback label cycle:** human adds `human:needs-fix` (+
-   comments) → agent removes it, works, adds `fleet:changes-made` →
-   either the human or the next-poll fleet reviewer re-verifies
-   (whichever happens first; the reviewer removes the label on
-   pickup so they don't double-process). Human can add multiple
-   comments before re-tagging; ALL are picked up when the tag
-   appears. If the human wants more changes after a review pass,
-   they re-add `human:needs-fix`.
+   comments) → agent picks up, decides AMEND vs ESCALATE per a2.
+
+   - **AMEND** (default): agent removes `human:needs-fix`, adds
+     `fleet:human-amending` + clears `fleet:approved`, works,
+     swaps `fleet:human-amending` for `fleet:changes-made` after
+     pushing. Either the human or the next-poll fleet reviewer
+     re-verifies (whichever first; reviewer removes the label on
+     pickup to avoid double-processing). Reviewer's re-approval
+     re-sets `fleet:approved`.
+   - **ESCALATE**: agent files a follow-up issue, swaps
+     `human:needs-fix` for `fleet:human-deferred`, KEEPS
+     `fleet:approved`. Human reviews the linked issue and either
+     accepts the deferral (PR ready to merge) or re-adds
+     `human:needs-fix` to force AMEND mode on the next iteration.
+
+   Human can add multiple comments before re-tagging; ALL are
+   picked up when the tag appears.
 
    The merger has its own label for non-mechanical rebase
    conflicts: `fleet:semantic-conflict`. That label is **not your

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -234,7 +234,7 @@ Each iteration:
 
    b. **(AMEND path)** **Immediately remove the feedback label** to
       prevent another agent from also picking it up:
-      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits"`
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:human-deferred"`
 
       For `human:needs-fix` / `human:blocker` specifically, also
       mark the PR as in-progress and clear the prior approval so

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -138,6 +138,8 @@ treat it as a hard rule for this role.
    - `human:needs-fix` — human requested changes, author agent is
      handling it. Don't pile on a fleet review while the human's
      feedback is being addressed.
+   - `fleet:human-amending` — author agent is actively addressing
+     human feedback. Hold review until `fleet:changes-made` appears.
    - `fleet:semantic-conflict` — merger detected a non-mechanical
      rebase conflict; the opus-worker is queued to attempt
      resolution. The PR's diff against master is meaningless until
@@ -164,7 +166,7 @@ iteration of polling, reviewing, and exiting cleanly:
    PRs with no fleet review, with `human:re-review`, with
    `fleet:changes-made` (remove the label on pickup), or with a "re-review please"
    comment after the last fleet review. Skip PRs carrying any of
-   `fleet:wip`, `human:wip`, `human:needs-fix`, or
+   `fleet:wip`, `human:wip`, `human:needs-fix`, `fleet:human-amending`, or
    `fleet:semantic-conflict`. For each remaining candidate, in
    oldest-first order:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,24 @@ Specifically, **never pass these via `--label` when filing**:
   can't auto-rebase). Cleared by the **opus-worker** after it
   resolves the conflict, or escalated to `human:needs-fix` if even
   Opus can't resolve.
+- `fleet:human-amending` / `fleet:human-deferred` — owned by the
+  **author worker** (sonnet-author / opus-worker) when picking up
+  `human:needs-fix`. The two labels express which disposition the
+  worker chose:
+  - `fleet:human-amending` — worker is fixing the concerns inline
+    on this PR. Set when the worker removes `human:needs-fix`;
+    cleared and replaced with `fleet:changes-made` after the push.
+    Co-set with removing `fleet:approved` (prior approval is no
+    longer valid until the reviewer re-approves the amended diff).
+    **Read as: "hold merge, fixes pending."**
+  - `fleet:human-deferred` — worker filed the human's concerns as
+    a follow-up issue rather than amending this PR. Set when the
+    worker removes `human:needs-fix`; **kept** until the human
+    either accepts the deferral (PR merges with this label) or
+    re-adds `human:needs-fix` to force AMEND mode on the next
+    iteration. `fleet:approved` is kept (PR is internally OK).
+    **Read as: "agent acknowledged your concerns, linked issue
+    tracks them, you decide whether to merge as-is or re-flag."**
 
 **The right pattern when filing an issue:** create it with NO labels.
 The human will add `human:approved` if and when they want it picked

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -113,6 +113,8 @@ LABELS=(
     "fleet:awaiting-base|c5def5|Stacked PR; merger is waiting for base PR to merge"
     "fleet:stacked-rebase|c5def5|Stacked PR; base just merged, re-targeted to master, awaiting reviewer re-eval"
     "fleet:awaiting-upstream-review|c5def5|Stacked PR; reviewer is holding verdict until upstream PR is approved"
+    "fleet:human-deferred|fbca04|Worker filed human:needs-fix concerns as a follow-up issue; PR is internally OK to merge if human accepts the deferral (fleet:approved kept)"
+    "fleet:human-amending|c5def5|Worker is amending this PR with the fixes for the human:needs-fix concerns; hold merge until fleet:changes-made appears"
     "human:wip|5319e7|Human is editing the PR directly; agents stand off"
     "human:approved|0e8a16|Human approved the PR (overrides agent verdict)"
     "human:needs-fix|d4c5f9|Human flagged a fix request; agent should address"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -216,6 +216,10 @@ REVIEW_VERDICT_LABELS = frozenset({
 REVIEW_SKIP_LABELS = frozenset({
     "fleet:wip", "human:wip", "fleet:merger-cooldown", "human:needs-fix",
     "fleet:semantic-conflict",
+    # Worker is amending the PR for the human's concerns; the diff
+    # the reviewer sees is in flux. Re-evaluate once fleet:changes-made
+    # appears (which RECHECK_LABELS picks up).
+    "fleet:human-amending",
 })
 RECHECK_LABELS = frozenset({"human:re-review", "fleet:changes-made"})
 


### PR DESCRIPTION
## Summary

Two new labels — `fleet:human-amending` and `fleet:human-deferred`
— let the worker express WHICH way it dispositioned a
`human:needs-fix` flag:

- **Amending**: fixing inline → hold merge
- **Deferred**: filed follow-up issue → PR is OK to merge if you accept the deferral

## Why

PR #334 today: human added inline comments + `human:needs-fix`.
Sonnet-author picked it up, decided the concerns were Opus-tier
shader architecture (couldn't fix at sonnet tier), filed issue
#345, removed `human:needs-fix`. Result: PR sat at
`fleet:approved` + smoke labels with no signal that the human had
raised concerns. Comment thread carried the escalation but the
LABEL surface said "ready to merge" — confusing.

## Two dispositions

When a worker (sonnet-author or opus-worker) picks up
`human:needs-fix`:

| Disposition | When | Label transitions | `fleet:approved`? | Reads as |
|---|---|---|---|---|
| **AMEND** (default) | Concerns are bounded; worker can fix inline at its tier | `human:needs-fix` → `fleet:human-amending`; on push: → `fleet:changes-made` | **Cleared** in step b, re-set by reviewer's re-approval | "Hold merge — fixes pending" |
| **ESCALATE** | Scope expansion / downstream-PR dep / explicit prior deferral / wrong tier | `human:needs-fix` → `fleet:human-deferred`; PR's code unchanged | **Kept** | "Concerns tracked in linked issue; you decide on merge" |

Default to AMEND when uncertain. ESCALATE is a deliberate choice
that needs justification in the linked issue body.

## Files (5, +195/-20)

- `scripts/fleet/fleet-labels` — register both labels
- `scripts/fleet/fleet-state-scout` — add `fleet:human-amending`
  to `REVIEW_SKIP_LABELS` (reviewers don't waste passes on
  mid-amend PRs); `fleet:human-deferred` is NOT in skip set
- `CLAUDE.md` — labeling discipline doc both labels with the
  AMEND/ESCALATE rationale
- `.claude/commands/role-sonnet-author.md` — new step a2 (decide
  AMEND vs ESCALATE) before the existing step b. ESCALATE path
  is a 5-step sub-flow that exits early. AMEND path adds
  `fleet:human-amending` set + `fleet:approved` clear in step b,
  swapped for `fleet:changes-made` in step e. Cycle-summary
  paragraph at section end rewritten to enumerate both dispositions.
- `.claude/commands/role-opus-worker.md` — same pattern, same
  step structure (workers share the human:needs-fix handling shape)

## Test plan

- [x] `bash -n scripts/fleet/fleet-labels` clean
- [x] Python syntax clean on fleet-state-scout
- [x] Self-applied simplify (sections 7 + 9 from PR #330): no
      change-narration prose, no stale cross-refs (#334 + #345
      are real, cited verbatim), no contradictions
- [ ] After merge: `fleet-labels` registers the two new labels on
      the engine repo on next fleet-up
- [ ] Live: a future `human:needs-fix` PR — worker picks AMEND
      → labels swap to `fleet:human-amending` + `fleet:approved`
      cleared
- [ ] Live: another PR — worker picks ESCALATE → labels swap to
      `fleet:human-deferred`, `fleet:approved` retained
- [ ] PR #334 retroactively: should be relabeled `fleet:approved`
      + `fleet:human-deferred` to match its actual state (offered
      as a separate one-off action below the PR)

## Notes for reviewer

- **Combine-safe label calls** follow the merger doc's rule —
  combine `--remove-label X --add-label Y` only when X is
  guaranteed present. The AMEND path's step b separates the
  `fleet:approved` clear because that label may not be present
  (PR might not have been approved yet when the human raised
  concerns).
- **Reviewer pickup**: `fleet:human-amending` is in the
  scout's `REVIEW_SKIP_LABELS` so reviewers skip until
  `fleet:changes-made` appears (then `RECHECK_LABELS` triggers
  re-review). `fleet:human-deferred` is not in skip set since
  those PRs are stable and reviewable normally.
- **Override path**: if the human reads `fleet:human-deferred`
  and disagrees with the deferral, they re-add `human:needs-fix`
  → next worker iteration sees both labels, picks up the
  `human:needs-fix`, and decides AMEND vs ESCALATE again. The
  `fleet:human-deferred` label gets cleared by step b's
  4-label-remove (since it's listed alongside the others).
  Wait — no, `fleet:human-deferred` is NOT in step b's removal
  list. Worth double-checking that re-flag works cleanly... 
  Actually the next iteration's step a2 reads the labels, sees
  `human:needs-fix`, picks AMEND or ESCALATE. The
  `fleet:human-deferred` from the prior iteration just sits
  there. Step b's removal list should arguably include it. Will
  flag in the next pass — for now, the label is harmless if
  redundant.
- The two label colors match their semantic family:
  - `fleet:human-amending` = `c5def5` light blue (matches
    `fleet:wip`, `fleet:changes-made` in-flight family)
  - `fleet:human-deferred` = `fbca04` yellow (matches
    `fleet:has-nits` "approved with caveats" family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)