### PR TITLE
fleet: add review-only mode for closing out PRs without expanding queue

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -444,6 +444,10 @@ fetched (consistent with startup, which deliberately skips that
 work) and no candidates are printed. Do not check out any branch,
 do not rebase, do not push.
 
+If Mode above is `review-only`: behave as `live`. Auto-rebasing
+mechanical conflicts helps close out PRs, which IS the point of
+review-only mode.
+
 If you hit a usage-limit error: print the error and exit. The
 `/loop` driver and `fleet-babysit` wrapper handle backoff.
 

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -154,6 +154,11 @@ When you do pick a task:
 If Mode above is `dry-run`: do **only** the startup actions. Do not pick
 a task. Wait for explicit human instruction.
 
+If Mode above is `review-only`: behave as `live` for this role. The
+architect is interactive and never autonomously claims tasks, so
+`review-only` (which gates worker / queue-manager autonomous pickup)
+has no special behavior here.
+
 ## Filing tasks
 
 When you identify work that needs doing — by you, a Sonnet agent, or

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -315,6 +315,9 @@ iteration of polling, reviewing, and exiting cleanly:
 If Mode above is `dry-run`: review exactly **one** flagged PR
 end-to-end, then stop and wait for human instruction. Do not loop.
 
+If Mode above is `review-only`: behave as `live`. Reviewing IS the
+point of review-only mode — keep reviewing PRs as normal.
+
 ## When to escalate to the human (do not approve)
 
 - The PR's design implies a follow-up architectural decision.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -842,8 +842,41 @@ Do the work, then exit cleanly:
     in ~20 minutes — the new process lands cwd back in the engine
     worktree, so the next iteration starts from a clean slate.
 
-If Mode above is `dry-run`: do startup actions only. Do not plan or
-pick a task. Wait for human instruction.
+## Mode behavior
+
+The Mode argument at the top of this file is one of `dry-run`, `live`,
+or `review-only` (passed by `fleet-babysit` from `fleet-up`'s mode arg).
+
+- **`live`** (full operation): each iteration runs steps 0–12 above,
+  then exits. fleet-babysit relaunches every ~20m with fresh context.
+
+- **`dry-run`** (default): do startup actions only. Do not plan or
+  pick a task. Wait for human instruction.
+
+- **`review-only`** (close-out mode): conserves credit by closing out
+  in-flight work without expanding the queue. Each iteration runs:
+  - Step 0 (heartbeat)
+  - Step 1 (address feedback labels on open PRs, both repos)
+  - Step 1b (cross-host smoke validation on approved render PRs)
+  - Step 1c (resolve `fleet:semantic-conflict` PRs)
+  - Step 3 **molecule-resume only** — call
+    `fleet-claim molecule resume <your-worktree-name>`. If stdout
+    returns a `T-NNN`, that's an in-flight stack you started earlier;
+    continue with steps 4–12 to finish that task (in-flight work IS
+    in scope). If stdout is empty, **exit cleanly** — do NOT fall
+    through to "Normal pickup".
+
+  **Skip entirely** in review-only mode:
+  - Step 2 (planning `fleet:needs-plan` issues) — planning expands
+    the queue; the architect can plan manually if needed.
+  - Step 3's "Normal pickup (no active molecule)" branch — that's
+    what brings new tasks into in-flight state.
+
+  If step 1 finds no flagged PRs, step 1b finds no smoke-pending PRs,
+  step 1c finds no semantic conflicts, and step 3's molecule resume
+  returns empty, print
+  `[opus-worker] review-only: nothing to address this iteration.`
+  and exit. fleet-babysit will relaunch you on the normal cadence.
 
 If you hit a usage-limit error: print the error and exit. `fleet-babysit`
 detects exit code 2 and waits the limit-delay before relaunching.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -266,9 +266,44 @@ If you hit a usage-limit error: print the error and exit.
 `fleet-babysit` waits the limit-delay before relaunching with a fresh
 context.
 
-If Mode above is `dry-run`: do exactly one maintenance pass, then
-stop and wait for human instruction. `fleet-babysit` does not
-auto-relaunch in dry-run mode.
+### Mode behavior
+
+The Mode argument at the top of this file is one of `dry-run`, `live`,
+or `review-only` (passed by `fleet-babysit` from `fleet-up`'s mode arg).
+
+- **`live`** (full operation): each iteration runs a full maintenance
+  pass (steps 0–10 below), then exits. fleet-babysit relaunches every
+  ~5m with fresh context.
+
+- **`dry-run`** (default): do exactly one maintenance pass, then stop
+  and wait for human instruction. `fleet-babysit` does not auto-relaunch
+  in dry-run mode.
+
+- **`review-only`** (close-out mode): conserves credit by closing out
+  in-flight work without expanding the queue. Each iteration runs:
+  - Step 0 (heartbeat)
+  - Step 1 (clean stale claims)
+  - Step 1b (release timed-out claims)
+  - Step 4 (sync merged PRs → Done)
+  - Step 5 (sync open PRs → In-progress)
+  - Step 5b (clean stale `fleet:in-progress` labels)
+  - Step 6 (resolve stale blocker references)
+  - Step 7 (auto-close completed epics)
+  - Step 8 (prune Done)
+  - Step 9 (push changes)
+  - Step 10 (print summary)
+
+  **Skip entirely** in review-only mode:
+  - Step 2 (ingest engine `human:approved` issues into TASKS.md) —
+    ingestion expands the queue.
+  - Step 3 (ingest game `human:approved` issues into TASKS.md) — same.
+
+  Human-pasted task descriptions in this pane are still processed
+  normally (the ingestion skip applies to autonomous polling only —
+  if the human explicitly hands you a task between iterations, file
+  it). The autonomous skip prevents the maintenance loop from
+  silently pulling new issues into the queue while the user is
+  trying to close out existing work.
 
 ### Maintenance pass
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -577,9 +577,33 @@ Each iteration:
    `claude` session — `fleet-babysit` handles the relaunch with a
    clean conversation).
 
-If Mode above is `dry-run`: do exactly **one** task end-to-end (steps
-1-11), print the PR URL, then stop and wait for human instruction. Do
-not loop.
+## Mode behavior
+
+The Mode argument at the top of this file is one of `dry-run`, `live`,
+or `review-only` (passed by `fleet-babysit` from `fleet-up`'s mode arg).
+
+- **`live`** (full operation): each iteration runs steps 0–11 above,
+  then exits. fleet-babysit relaunches with fresh context.
+
+- **`dry-run`** (default): do exactly **one** task end-to-end (steps
+  1–11), print the PR URL, then stop and wait for human instruction.
+  Do not loop.
+
+- **`review-only`** (close-out mode): conserves credit by closing out
+  in-flight work without expanding the queue. Each iteration runs:
+  - Step 0 (heartbeat)
+  - Step 1 (address feedback labels on open PRs)
+  - Step 1b (cross-host smoke validation on approved render PRs)
+
+  Then **exit cleanly** — skip step 2 and beyond. Do **not** pick up
+  any new task from TASKS.md. The smoke and feedback steps still help
+  close out PRs the fleet already opened; new claims would expand the
+  queue, which is exactly what review-only mode is meant to prevent.
+
+  If step 1 finds no flagged PRs and step 1b finds no smoke-pending
+  PRs, print
+  `[sonnet-author] review-only: nothing to address this iteration.`
+  and exit. fleet-babysit will relaunch you on the normal cadence.
 
 ## Usage-limit handling
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -359,6 +359,9 @@ If Mode above is `dry-run`: review exactly **one** PR end-to-end
 (complete one iteration of step 2 with one PR), then stop and wait
 for human instruction. Do not loop.
 
+If Mode above is `review-only`: behave as `live`. Reviewing IS the
+point of review-only mode — keep reviewing PRs as normal.
+
 ## Escalation
 
 - A PR that looks structurally broken (wrong file edited, force-pushed

--- a/scripts/fleet/README.md
+++ b/scripts/fleet/README.md
@@ -11,8 +11,14 @@ fleet workflow.
   window, and auto-launches `claude` in each pane with the matching
   role slash command. Default mode is `dry-run` (startup + stand-by);
   `fleet-up live` skips dry-run, goes straight to the normal loop, and
-  auto-attaches the tmux session. Pass `--no-attach` to opt out of
-  the attach (CI / headless runs).
+  auto-attaches the tmux session. `fleet-up review-only` runs the
+  loop but tells worker / queue-manager roles to skip new task
+  pickup and new issue ingestion — reviewers, mergers, smoke
+  validators, semantic-conflict resolvers, feedback handlers, and
+  in-flight molecule continuation all still run, so it's the right
+  mode for closing out open PRs without expanding the queue (e.g.
+  conserving credits before a session boundary). Pass `--no-attach`
+  to opt out of the attach (CI / headless runs).
 - **`fleet-down`** — graceful shutdown of the fleet. Sends Ctrl-C +
   "exit" to each pane, waits a short grace period, then kills the
   tmux session and clears stale fleet-claim locks. `--force` skips

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -427,16 +427,19 @@ fi
 #
 # Argument parsing:
 #   fleet-up [mode] [--no-attach]
-#     mode = dry-run | live (default: dry-run)
+#     mode = dry-run | live | review-only (default: dry-run)
 #     --no-attach: skip the auto-attach (live mode only). Useful for
 #                  headless runs / CI / tests that just need the panes
 #                  spawned but don't want to attach.
+#
+# See the heredoc below ("mode review-only ...") for the user-facing
+# description of each mode.
 
 MODE="dry-run"
 ATTACH_LIVE=1   # in live mode, attach to the tmux session at the end
 for arg in "$@"; do
     case "$arg" in
-        dry-run|live) MODE="$arg" ;;
+        dry-run|live|review-only) MODE="$arg" ;;
         --no-attach)  ATTACH_LIVE=0 ;;
         *) echo "fleet-up: unknown argument '$arg'" >&2; exit 2 ;;
     esac
@@ -634,10 +637,18 @@ mode "dry-run" means each agent does its startup actions and then
 waits. promote a pane to full operation by typing in it:
   "exit dry-run mode and begin your normal loop"
 
+mode "review-only" keeps the loop running but the role docs skip
+new-task pickup and new-issue ingestion. Reviewers review, mergers
+merge, smoke runs, feedback gets addressed, in-flight molecules
+finish — but no NEW work enters the queue. Use this to close out
+open PRs without expanding the queue (e.g. before a session
+boundary or to conserve credits).
+
 babysit: each agent is wrapped in fleet-babysit, which auto-resumes
 the session if claude exits (crash, usage limit, network drop).
-  dry-run — auto-resumes on crash, stops on clean exit
-  live    — auto-resumes on any exit (runs indefinitely)
+  dry-run     — auto-resumes on crash, stops on clean exit
+  live        — auto-resumes on any exit (runs indefinitely)
+  review-only — same as live; the role docs gate new-work pickup
 
 scheduling (live mode): each worker iteration is a fresh \`claude\` process
   (no context carry-over between tasks). babysit relaunches per role's
@@ -655,6 +666,7 @@ other modes you can pass to fleet-up:
   fleet-up dry-run               # default — startup + stand-by, no auto-attach
   fleet-up live                  # full loop from the start, auto-attaches tmux
   fleet-up live --no-attach      # full loop, leave detached (CI / headless)
+  fleet-up review-only           # close-out mode — no new work, finish in-flight
 
 graceful shutdown:
   fleet-down                     # graceful: send "exit", wait, kill, clear claims
@@ -669,11 +681,11 @@ architect session resume:
   next time, delete the corresponding .session-id file.
 EOF
 
-# In live mode, attach to the tmux session so the user lands in the
-# fleet without a separate `tmux attach`. dry-run mode leaves the
+# In live or review-only mode, attach to tmux so the user lands in
+# the fleet without a separate `tmux attach`. dry-run leaves the
 # session detached so the user can confirm panes spawned cleanly
 # before opting in.
-if [[ "$MODE" == "live" && "$ATTACH_LIVE" -eq 1 ]]; then
+if [[ ( "$MODE" == "live" || "$MODE" == "review-only" ) && "$ATTACH_LIVE" -eq 1 ]]; then
     echo
     echo "fleet-up: attaching to tmux session 'fleet' (Ctrl-a d to detach)..."
     exec tmux attach-session -t "$SESSION"


### PR DESCRIPTION
## Summary

A third `fleet-up` mode alongside `dry-run` and `live`. Use it when you
want to close out the open PR queue near a session boundary or when
conserving credits — without the fleet pulling in fresh work that
won't finish before time runs out.

## Behavior

`fleet-babysit` treats `review-only` as `live` (auto-resume on any
exit). The role docs interpret the mode and gate new-work pickup:

| Role | Review-only behavior |
|------|---------------------|
| sonnet-author | Steps 0 (heartbeat), 1 (feedback), 1b (smoke); skip step 2+ (task pickup) |
| opus-worker | Steps 0, 1, 1b (smoke), 1c (semantic-conflict), 3 molecule-resume only; skip step 2 (planning) and normal pickup |
| queue-manager | Steps 0, 1, 1b, 4–10 (claim cleanup, PR-state sync, epic close, TASKS.md push); skip steps 2/3 (ingestion) |
| reviewers (sonnet + opus) | Behave as `live` — reviewing IS the point |
| merger | Behaves as `live` — auto-rebasing closes out PRs |
| architects (opus + game) | Behave as `live` — interactive, never autonomously claim |

If a worker / queue-manager iteration finds nothing to do, it prints
`<role>: review-only: nothing to address this iteration.` and exits.
fleet-babysit relaunches on the normal cadence.

## Files

- `scripts/fleet/fleet-up` — `review-only` added to MODE arg case;
  auto-attach extended; help text + heredoc updated.
- `scripts/fleet/README.md` — documents the new mode.
- `.claude/commands/role-{sonnet-author,opus-worker,queue-manager}.md`
  — full \"Mode behavior\" section listing which steps to run vs skip.
- `.claude/commands/role-{opus-architect,sonnet-reviewer,opus-reviewer,merger}.md`
  — one-line \"behaves as live for this role\" note so the mode falls
  through cleanly.

## Test plan

- [ ] `fleet-up review-only` accepts the mode arg and auto-attaches
- [ ] `fleet-up bogus-mode` still errors out (unknown argument)
- [ ] `bash -n scripts/fleet/fleet-up` passes
- [ ] sonnet-author iteration with no flagged PRs and no smoke-pending
      PRs prints the \"nothing to address\" line and exits
- [ ] opus-worker iteration: same behavior, plus molecule-resume returns
      empty → exits without touching TASKS.md
- [ ] queue-manager iteration: claim cleanup + PR sync run, ingestion
      steps 2/3 skipped (no new TASKS.md entries even if a fresh
      `human:approved` issue exists)

## Notes for reviewer

- The bash condition at `fleet-up:694` uses parens to group the
  `||` — `&&` binds tighter, so without parens `--no-attach` would
  be silently ignored when `MODE=live`. Keep the parens.
- The `### Mode behavior` heading in `role-queue-manager.md` is h3
  (not h2 like the other two role docs) on purpose — its sibling
  `### Maintenance pass` is h3 too, both under the `## Loop behavior`
  umbrella. Promoting to h2 would orphan `### Maintenance pass`.
- No fleet-babysit changes needed: `MODE != \"dry-run\"` falls through
  to the live auto-resume branch, which is exactly what we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)