### PR TITLE
docs: add cursor flow + polish-checkpoint skill

### DIFF
--- a/.claude/skills/polish-checkpoint/SKILL.md
+++ b/.claude/skills/polish-checkpoint/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: polish-checkpoint
+description: >-
+  Run a mid-session quality checkpoint without committing. Mirrors the
+  pre-commit phase of `commit-and-push` (simplify the dirty tree,
+  format, verify the build for the touched target) but stops before
+  any git operations — no staging, no commit, no push, no PR. Use
+  when the user says "checkpoint", "polish for now", "verify what I
+  have", "clean up but don't commit", "self-review without shipping",
+  "polish + verify", or otherwise wants confidence that the working
+  tree is clean and the build is green before continuing to iterate.
+  Designed for the Cursor / human-in-the-loop flow where intermediate
+  quality passes happen often but PRs open rarely. When the user is
+  ready to PR, they invoke `commit-and-push` as usual; running both
+  back-to-back is fine because `simplify` is idempotent.
+---
+
+# polish-checkpoint
+
+A mid-session quality pass for the Cursor flow. Same pre-commit
+checks as `commit-and-push`, minus everything past the simplify
+step. Lets the human iterate with confidence that the working tree
+is clean and the build is green, without locking the work into a PR.
+
+## Why this exists
+
+The fleet workflow bundles polish + commit + push + PR open into one
+end-to-end skill (`commit-and-push`). That fits an autonomous worker
+shipping a finished slice, but it doesn't fit an interactive Cursor
+session where the human wants intermediate confidence checks while
+still iterating. The Cursor flow needs a way to say "clean the diff
+and verify the build, but don't commit yet" — that's what this skill
+is. When the human is genuinely ready to PR, `commit-and-push` runs
+the same pre-commit checks again (idempotent) and then does the git
+work.
+
+## When to invoke
+
+Trigger when the user says:
+
+- "checkpoint" / "polish for now" / "let's checkpoint"
+- "verify what I have" / "is the working tree clean?"
+- "clean up but don't commit" / "self-review without shipping"
+- "run simplify and the build" / "polish + verify"
+
+Do **not** auto-invoke. Always wait for an explicit cue. This is the
+Cursor-flow analog of `simplify` plus a build verify; it's not a
+save-on-edit hook.
+
+This skill is **not** a substitute for `commit-and-push`. When the
+user is ready to open a PR, they'll say "commit", "ship it", "open a
+PR", or similar, and `commit-and-push` runs the same checks plus the
+actual git work. Running this skill and then `commit-and-push`
+back-to-back is fine — `simplify` is idempotent and a clean working
+tree just means the commit-and-push pre-checks find nothing to do.
+
+## Preconditions
+
+1. **The working tree must have something to polish.** If `git
+   status` is clean and there are no unpushed commits, report
+   "nothing to check" and exit.
+2. **Either branch is fine.** Cursor flow defaults to working off
+   `master` with a dirty tree (the auto-branch happens at commit
+   time); a feature branch also works. Don't switch branches as
+   part of this skill.
+
+## Flow
+
+### 1. Gather state
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git status
+git diff --stat && git diff
+```
+
+Group touched files by module (`engine/render/`, `engine/system/`,
+`engine/prefabs/irreden/`, `creations/<name>/`, etc.). Read the most
+specific `CLAUDE.md` for any module the diff touches before
+inspecting it — module-specific rules override the engine baseline.
+
+### 2. Run `simplify`
+
+```
+Skill: simplify
+```
+
+`simplify` reads the same diff and applies inline fixes for the usual
+Irreden-Engine smells: per-entity `getComponent` inside system tick
+functions, naming-convention slips (`m_` on public, missing `C_`
+prefix on a new component), debug `std::cout` lines left from
+troubleshooting, tautological doc comments, change-narration
+comments, allocation in hot loops, etc. It auto-fixes the safe ones
+and reports anything that needs human judgment.
+
+After `simplify` finishes, re-check `git status` so you know the
+post-simplify state. If `simplify` reverted everything (rare — only
+happens when the only diffs were ones it cleaned up entirely),
+report "working tree is clean after simplify" and stop.
+
+### 3. Format
+
+Run the formatter so the diff shape stays consistent across the
+session:
+
+```bash
+fleet-build --target format
+```
+
+If `format` rewrote files, those edits are part of the polish — keep
+them. Re-check `git status` afterwards so the report below reflects
+the post-format state.
+
+### 4. Verify the build (code diffs only)
+
+If the diff is purely docs/markdown (no `.cpp`, `.hpp`, `.glsl`,
+`.metal`, `CMakeLists.txt`, etc.), skip this step.
+
+Otherwise build the target most directly affected by the diff:
+
+```bash
+fleet-build --target <touched-target>
+```
+
+Choosing the target:
+
+- A creation diff — build that creation's executable target
+  (`IRShapeDebug`, `IRCreationDefault`, `IRGame`, etc.).
+- An engine module diff — build a creation that exercises it
+  (default: `IRShapeDebug` for render/math/system; the most
+  representative demo otherwise) plus `IrredenEngineTest` if the
+  diff touches `engine/`.
+- A pure prefab-header diff — build any creation that includes that
+  prefab (header-only prefabs only compile when included by a
+  creation).
+
+Don't try to build everything — the all-targets build is
+`commit-and-push`'s job at the moment of shipping. Polish-checkpoint
+is a fast confidence check.
+
+If the build broke, **stop and report** with the error. Do not try
+to silently "fix" the break in this pass — that's editing scope and
+risks turning a checkpoint into a debugging detour. Surface the
+error and let the human decide whether to fix it next or roll back.
+
+### 5. Report
+
+Compact summary so the user knows where they stand:
+
+```
+polish-checkpoint:
+  branch: <branch-name>  (<N> file(s) dirty, <M> hunk(s))
+  simplify: applied <X> auto-fix(es), reported <Y> finding(s)
+  format:   <N> file(s) reformatted   (or: clean)
+  build:    <target>   clean           (or: broken — see below)
+```
+
+If `simplify` reported findings that need human judgment, list them
+inline beneath the summary so they're easy to act on:
+
+```
+  reported findings:
+    - engine/prefabs/irreden/render/systems/IRSGlow.hpp:42 —
+      conditional getComponent<C_Color> in tick; not auto-fixable
+      because the conditional path may not always have C_Color.
+```
+
+If the build broke, surface the error message immediately after the
+summary and stop — no follow-up action.
+
+If everything is clean, end with a one-liner so the user knows the
+state:
+
+> Working tree is polished and the build is green. Keep iterating,
+> or invoke `commit-and-push` when ready to PR.
+
+## What this skill does NOT do
+
+- **No git operations.** No `git add`, no `git commit`, no `git
+  push`, no `gh pr create`. Read-only on history; only edits the
+  working tree (via `simplify` and `format`).
+- **No branch switching.** Don't invoke `start-next-task`, don't
+  create a feature branch, don't pull master. The user is iterating
+  on the current state.
+- **No tests.** Like `simplify`, this skill doesn't run the test
+  suite. The user runs tests separately when they want them.
+- **No fix-the-build.** If the build is broken, stop and report.
+  Diagnosing a build break is a separate task.
+- **No proactive invocation.** Always wait for an explicit cue.
+
+## Anti-patterns
+
+- ❌ Running this skill autonomously after every edit. It's a
+  user-invoked checkpoint, not a save-on-edit hook.
+- ❌ Following polish-checkpoint with `commit-and-push` unless the
+  user explicitly asks. The whole point is the human controls when
+  to PR.
+- ❌ Skipping the build step on code diffs to save time. The
+  checkpoint is not real if the build doesn't actually pass.
+- ❌ Editing files outside the dirty diff to "improve" them. Stay
+  scoped to what the session has already changed.
+- ❌ Switching branches mid-skill. The user's current branch state
+  is intentional; respect it.
+- ❌ Using this skill in fleet flow. Fleet workers run
+  `commit-and-push` end-to-end; intermediate checkpoints are an
+  interactive-session concept.
+
+## Recovery
+
+If `simplify` makes a change the user didn't want, they can revert
+with `git checkout -- <path>` since polish-checkpoint never commits.
+
+If `format` rewrites a file in a way the user disagrees with (rare —
+the formatter is configured project-wide), the same revert works,
+but the underlying clang-format config is probably what wants
+adjusting. Flag it for follow-up; don't fight the formatter inline.
+
+If the build was green before the session and broke during this
+checkpoint, the most useful next step is usually to bisect the
+session's edits (most recent first) rather than dig into the
+compiler error directly. Mention that to the user before they
+start chasing the error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,59 @@ This repo runs a parallel-agent workflow. The rules:
 See `TASKS.md` for the current queue and `.claude/skills/` for the exact
 commit/PR/review flows.
 
+### Cursor flow (human-in-the-loop)
+
+The rules above describe the fleet workflow. When working with the
+human directly in the Cursor IDE — an interactive chat session, not
+an autonomous role — the same correctness rules apply (no commits to
+`master`, no force-pushes, PRs only via `commit-and-push`) but the
+**timing is different**: the human drives when to commit, not the
+agent.
+
+In Cursor flow:
+
+- **Iterate freely.** Edit files, build, run, refine. Do not propose
+  committing after every change. The human will say when a slice is
+  ready.
+- **Quality skills are on-demand.** `simplify`, `polish-checkpoint`,
+  `optimize`, `attach-screenshots`, `render-debug-loop` may be
+  invoked whenever the human asks. Don't auto-invoke them
+  mid-iteration.
+- **Never auto-invoke `commit-and-push` or `start-next-task`.** Wait
+  for an explicit "ship it" / "commit this" / "open a PR" / "ready
+  for review" cue. The fleet's rules 2 and 3 describe what happens
+  *when* those cues arrive — they don't license proactive
+  invocation.
+- **`TASKS.md` is fleet-only.** The Cursor session is not bound to
+  the shared queue; the human decides what to work on.
+
+**Branching.** You do not need to manually create a feature branch
+before starting Cursor work. `commit-and-push` step 2 detects when
+HEAD is `master` and creates `claude/<area>-<topic>` for you before
+staging; the dirty working tree carries over via `git checkout -b`.
+The only things to keep in mind:
+
+- **No local commits on `master` during a session.** Dirty changes
+  are fine (they migrate to the new branch); committed history on
+  local `master` is not (it would have to be moved off, which is
+  error-prone). The "Never commit to master directly" rule above
+  applies in Cursor flow too.
+- **Watch for stale local master.** If a session runs for a while on
+  a local `master` that's behind `origin/master`, the auto-created
+  branch will be based on stale code. Mention this at commit time so
+  the human can decide whether to rebase the new branch onto current
+  `origin/master` before pushing.
+
+If you want to start a Cursor session with a known-fresh base, invoke
+`start-next-task` at the top — it fetches `origin/master` and
+branches off it cleanly. Otherwise, working dirty on `master` and
+letting `commit-and-push` branch you at the end is the lowest-friction
+default.
+
+If the agent is unsure which flow it's in, default to Cursor flow.
+Fleet roles (`.claude/commands/role-*.md`) override this default by
+being explicit about autonomous behavior.
+
 ### Model split: Opus for core, Sonnet for the fleet
 
 The user has much more Sonnet budget than Opus budget. Spend each where it


### PR DESCRIPTION
## Summary
- Adds a "Cursor flow (human-in-the-loop)" subsection to top-level `CLAUDE.md` distinguishing the new interactive workflow from the existing fleet workflow. Same correctness rules; different timing — the human drives commit cadence, quality skills are on-demand, and `commit-and-push` / `start-next-task` are never auto-invoked.
- Documents that working dirty on `master` is the cursor-flow default — `commit-and-push` step 2 auto-branches off `master` before staging, so manual branching isn't required. Calls out the two real caveats: no local commits on `master`, watch for stale local master.
- Adds a new `polish-checkpoint` skill — the cursor-flow analog of the pre-commit phase of `commit-and-push`. Runs `simplify`, formats, verifies the build for the touched target, and stops. No git operations. Idempotent with `commit-and-push`, so running both back-to-back when the human is ready to ship is fine.

## Why
The two-workflow distinction was implicit before. Fleet workers run `commit-and-push` end-to-end without human gating; Cursor sessions need different timing or the agent ends up proposing commits mid-iteration. Making it explicit in `CLAUDE.md` plus naming the mid-session checkpoint pattern as a skill closes the gap without changing any fleet-side behavior.

## Test plan
- [ ] Read the new "Cursor flow" subsection top-to-bottom; confirm it scopes existing rule #6 (TASKS.md) cleanly rather than contradicting it.
- [ ] Read `polish-checkpoint/SKILL.md`; confirm the flow stops before any git operation and that the build-verify step is correctly gated on "code diffs only".
- [ ] In a future Cursor session, say "checkpoint" or "polish for now" and confirm the skill is discovered and invoked correctly.

## Notes for reviewer
- Doc-only diff. No `engine/` or shader changes; screenshot prompt skipped.
- The frontmatter `description` for `polish-checkpoint` is intentionally long so the skill is discoverable from many phrasings of the cue ("checkpoint", "polish for now", "verify what I have", etc.) — same pattern as `simplify`.
- The "What this skill does NOT do" and "Anti-patterns" sections overlap somewhat; they serve different purposes (scope vs. don'ts) and the same split exists in `commit-and-push`. Consolidating is a separate cleanup if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)