### PR TITLE
docs: add cursor-flow new-chat handling + stacking pattern

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -40,6 +40,10 @@ Do **not** invoke proactively — only when the user explicitly asks.
 
 ## Stack-aware mode
 
+This is the **fleet stack** path. The cursor-flow stacking variant
+lives in the next section ("Cursor stack mode"); they have separate
+detection signals and are mutually exclusive in practice.
+
 If the current task is part of an `fleet-claim stack` chain (i.e. the
 caller's worktree name has a stack claim under
 `~/.fleet/claims/_stack_<agent>/`), this skill opens **one PR per task,
@@ -92,6 +96,65 @@ back, the next stacked-PR iteration computes its own `--base` via
 When **the final task's PR is merged**, run
 `fleet-claim release-stack <agent>` to clean up both the per-task
 claims and the stack metadata.
+
+## Cursor stack mode
+
+This is the cursor-flow analog of the fleet stack mode above. It
+opens a single PR per slice but with `--base <previous-feature-
+branch>` instead of `--base master`, so the diffs stay isolated
+while the chain accumulates. No `fleet-claim` machinery, no task
+IDs, no `fleet:stacked` label. State lives entirely in the per-
+branch git config that `start-next-task` writes when the human
+cues stacking.
+
+Detect cursor stack mode after step 1 of the main flow, AFTER
+ruling out fleet stack mode:
+
+```bash
+git config --get branch.$(git branch --show-current).cursor-stack-base
+```
+
+- Output is empty / exit 1 → not cursor-stacked. Proceed with the
+  normal single-PR flow.
+- Output names a branch (e.g. `claude/render-glow-pulse`) → the
+  current branch is cursor-stacked on that branch. Note the value;
+  step 8 uses it as `--base` and writes a `Stacked on:` line to
+  the PR body.
+
+The deltas vs the normal single-PR flow:
+
+- **Step 8 PR base** is the recorded `cursor-stack-base` instead
+  of `master`. Pass it to `gh pr create` as `--base <base>`.
+- **PR body** includes a `Stacked on: <PR URL>` line. Look up the
+  parent PR URL once at PR-open time:
+  ```bash
+  parent_branch=$(git config --get branch.$(git branch --show-current).cursor-stack-base)
+  parent_pr_url=$(gh pr list --head "$parent_branch" --state all --json url -q '.[0].url' --limit 1)
+  ```
+  If the parent has no PR yet (e.g. the human hasn't run
+  `commit-and-push` on it — unusual but possible), use the branch
+  name instead: `Stacked on: <parent_branch>` and warn the user.
+- **Title** uses the normal cursor-flow shape (no `T-NNN:` prefix —
+  cursor flow doesn't use the queue).
+- **No labels** beyond what the normal flow adds. The
+  `fleet:stacked` label is fleet-only; cursor flow just relies on
+  `Stacked on:` in the PR body.
+
+After the PR opens, do NOT clear the `cursor-stack-base` config —
+leave it as a record of the chain. The config is local-only and
+doesn't need cleanup; the next `commit-and-push` on a
+non-stacked branch (no config set) takes the standard path
+automatically.
+
+When the parent PR merges, change this PR's base to `master` in the
+GitHub UI (or `gh pr edit <N> --base master`) — same step as in any
+manual stacked-PR workflow.
+
+**macOS sandbox note.** Cursor's Bash sandbox blocks `gh` keychain
+access and SSH `git push`. Always run `gh pr create`,
+`gh pr edit`, `gh pr list`, and `git push` with the `all`
+permission on macOS. Reads of `git config --get …` are not
+sandboxed.
 
 ## Flow
 
@@ -379,6 +442,48 @@ PRs are prerequisites. The `Full chain:` line helps them find the
 siblings if they want cross-context. The merger reads `baseRefName`
 directly for correctness decisions; `fleet:stacked` is a derived
 convenience label for human visibility and cheap filtering.
+
+**Cursor stack override:** when the current branch has a
+`cursor-stack-base` git config set (see "Cursor stack mode" section
+above), use that as the PR base instead of `master`. No `fleet-claim`
+calls and no `fleet:stacked` label — cursor stack mode is human-
+managed.
+
+```bash
+parent_branch=$(git config --get branch."$(git branch --show-current)".cursor-stack-base)
+if [[ -n "$parent_branch" ]]; then
+    parent_pr_url=$(gh pr list --head "$parent_branch" --state all \
+        --json url -q '.[0].url' --limit 1)
+    parent_pr_ref="${parent_pr_url:-$parent_branch (no PR yet)}"
+    gh pr create --base "$parent_branch" \
+        --title "<scope>: <title>" \
+        --body "$(cat <<EOF
+## Summary
+- <what this slice does>
+
+## Stack context
+Stacked on: $parent_pr_ref
+
+When the parent PR merges, change this PR's base to \`master\`
+(via the GitHub UI or \`gh pr edit <N> --base master\`).
+
+## Test plan
+- [ ] <slice-specific checks>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+fi
+```
+
+The `Stacked on:` line is the reviewer's signal that an earlier PR is
+a prerequisite. Cursor stack mode does not record a `Full chain:`
+line — chains are short and the link-walk via `Stacked on:` is
+sufficient.
+
+The `gh pr list --head` and `gh pr create` calls both need keychain
+access; on macOS Cursor's Bash sandbox, run them with `all`
+permissions.
 
 ### 8b. Tag the host the PR was authored on
 

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -3,12 +3,15 @@ name: start-next-task
 description: >-
   Reset the current worktree to a fresh feature branch for the next chunk of
   work. In the standard case that means branching off the latest
-  origin/master; if the worker has an active fleet-claim molecule (a stacked
-  task chain), the new branch instead bases on the just-opened PR's head ref
-  so the downstream task's diff stays isolated. Use after commit-and-push has
-  opened a PR and the user (or you) wants to move on to the next task, OR
-  whenever the user says "next task", "start next", "move on", or "pull master
-  and start fresh".
+  origin/master; if the worker has an active fleet-claim molecule (fleet
+  stack mode) or the human cued cursor-flow stacking, the new branch
+  instead bases on the just-opened PR's head ref so the downstream task's
+  diff stays isolated. Use after commit-and-push has opened a PR and the
+  user (or you) wants to move on to the next task, OR whenever the user
+  says "next task", "start next", "move on", "pull master and start
+  fresh", "I merged it", "back to master", "fresh start", "new task", or
+  cues stacking with "stack this", "next slice stacked", "keep stacking",
+  "stack the next on this PR".
 ---
 
 # start-next-task
@@ -18,32 +21,52 @@ Cleanly transitions a worktree from "this chunk is done, PR is open" to
 workflow — `commit-and-push` packages a slice; `start-next-task` prepares
 the worktree for the next slice.
 
-The skill operates in two modes selected by `fleet-claim molecule resume`
-(see step 4):
+The skill operates in three modes, selected in priority order at step 4:
 
-- **Standard mode** (no active molecule): branch off fresh `origin/master`.
-  This is the historical behavior and applies to single-task work.
-- **Stack mode** (active molecule with remaining tasks): branch off the
-  **old branch** — i.e. the head ref of the PR that `commit-and-push` just
-  opened. The downstream task's branch then contains the upstream commits
-  so the worker can keep building, while its PR's `--base <upstream>` (set
-  by `commit-and-push` at PR-open time) keeps the diff scoped to its own
-  changes.
+- **Fleet stack mode** (active `fleet-claim` molecule with remaining
+  tasks): branch off the **old branch** — i.e. the head ref of the PR
+  that `commit-and-push` just opened. The downstream task's branch then
+  contains the upstream commits so the worker can keep building, while
+  its PR's `--base <upstream>` (set by `commit-and-push` at PR-open
+  time) keeps the diff scoped to its own changes. Selected via
+  `fleet-claim molecule resume`.
+- **Cursor stack mode** (cursor flow only, driven by user cue): same
+  mechanic as fleet stack mode (branch off the old branch) but no
+  molecule machinery. Records the parent branch in
+  `branch.<new>.cursor-stack-base` git config so `commit-and-push`
+  picks it up later when opening the PR. Selected when the human
+  cues stacking ("stack this", "next slice stacked", "keep stacking",
+  "stack the next on this PR") and there is no active fleet molecule.
+- **Standard mode** (no fleet molecule and no stack cue): branch off
+  fresh `origin/master`. The historical behavior and the most common
+  case for both fleet single-task work and cursor flow's "I merged it,
+  start something new" pattern.
 
 ## When to invoke
 
 Trigger when the user says:
 
-- "next task" / "start next" / "what's next" (when a PR has just been opened)
-- "move on" / "move to the next item"
-- "pull master and start fresh"
-- "rebase off master"
-- Immediately after `commit-and-push` completes, if the user indicated they
-  want to keep working (e.g. "commit this and then start on the pathfinding
-  refactor").
+- **Fresh-start cues** (→ standard mode):
+  - "next task" / "start next" / "what's next" (when a PR has just
+    been opened)
+  - "move on" / "move to the next item"
+  - "pull master and start fresh" / "rebase off master"
+  - "I merged it" / "merged, let's keep going" / "back to master"
+  - "fresh start" / "new task"
+- **Stack cues** (→ cursor stack mode, when not in fleet stack mode):
+  - "stack this" / "next slice, stacked" / "keep stacking"
+  - "stack the next on this PR"
+  - "build on the last PR" / "PR-stacked next slice"
+- Immediately after `commit-and-push` completes, if the user indicated
+  they want to keep working (e.g. "commit this and then start on the
+  pathfinding refactor", or "ship it and keep going stacked").
 
-Do **not** invoke proactively without a cue. If the user says "commit and
-push" and stops, don't also run `start-next-task` — wait for them to ask.
+Do **not** invoke proactively without a cue. If the user says "commit
+and push" and stops, don't also run `start-next-task` — wait for them
+to ask. The one cursor-flow exception is documented in the top-level
+`CLAUDE.md`: when a new chat lands on a feature branch with an
+already-merged PR and the user asks for new work, surface the state
+and ask whether to invoke `start-next-task` first.
 
 ## Preconditions
 
@@ -90,12 +113,18 @@ git fetch origin master
 
 Never rely on a stale local `master` ref. Always fetch before branching.
 
-### 4. Detect active molecule (stack-aware mode)
+### 4. Detect mode
 
-If the current task is part of a `fleet-claim stack` chain, the next branch
-must build on the just-opened PR's head ref — not `origin/master` — so the
-downstream task's diff shows only its own changes. Probe the molecule (agents already know their own worktree name — it is passed
-in their role instructions, the same way `fleet-heartbeat <name>` is called):
+Three modes, checked in priority order. The first one that matches wins.
+
+#### 4a. Fleet stack mode
+
+If the current task is part of a `fleet-claim stack` chain, the next
+branch must build on the just-opened PR's head ref — not
+`origin/master` — so the downstream task's diff shows only its own
+changes. Probe the molecule (agents already know their own worktree
+name — it is passed in their role instructions, the same way
+`fleet-heartbeat <name>` is called):
 
 ```bash
 fleet-claim molecule resume <your-worktree-name>
@@ -114,16 +143,49 @@ Interpret the output (the helper always exits 0; discriminate via stdout):
     not proceed, or you will branch back onto the same task.
   - Otherwise the new branch is `claude/<returned-T-NNN>-<short-topic>`
     based on the **old branch** (the just-opened PR's head ref). Set
-    `BASE=<old-branch-name>` and remember `<returned-T-NNN>` for step 5.
-- **stdout is empty** — no molecule, or the molecule is fully done.
-  Standard flow. Set `BASE=origin/master` and proceed as before.
+    `MODE=fleet-stack`, `BASE=<old-branch-name>`, and remember
+    `<returned-T-NNN>` for step 5.
+- **stdout is empty** — no fleet molecule. Continue to 4b.
 
 If `molecule resume` exits non-zero (malformed YAML, etc.), stop and
 surface the stderr message — that is a real fault, not a "no work" signal.
 
+In a cursor-flow session there is no fleet-claim machinery; this probe
+will return empty unless the user has set up fleet machinery on the
+side. That's the expected case for cursor flow.
+
+#### 4b. Cursor stack mode
+
+If 4a returned empty AND the user's cue contained a stacking phrase
+("stack this", "next slice stacked", "keep stacking", "stack the next
+on this PR", "build on the last PR"), this is **cursor stack mode**.
+
+Set `MODE=cursor-stack`, `BASE=<old-branch-name>` (the branch you
+recorded in step 1). Note the old branch name — step 7b writes it to
+git config on the new branch.
+
+If 4a returned empty AND the cue is fresh-start ("next task", "I
+merged it", "back to master", etc.), continue to 4c.
+
+If the cue is ambiguous (just "next slice" / "next" with no stacking
+or fresh-start hint) AND the **old branch has its own
+`cursor-stack-base` set** (i.e. the old branch is itself the middle
+of a stack), stop and ask the user:
+
+> You're on a stacked branch (`<old-branch>` → base
+> `<existing-stack-base>`). Should the next slice continue the stack
+> (branch off `<old-branch>`), or branch off `master`?
+
+Don't guess. Stack continuation has different review semantics than a
+fresh slice and the human should pick.
+
+#### 4c. Standard mode
+
+Default. `MODE=standard`, `BASE=origin/master`. Proceed.
+
 ### 5. Derive a new branch name
 
-In **stack mode** (step 4 returned a `T-NNN`): the new branch is
+In **fleet stack mode** (4a returned a `T-NNN`): the new branch is
 `claude/<T-NNN>-<short-topic>`. Pull the topic from the task title in
 `TASKS.md` if obvious (read it via `git show origin/master:TASKS.md` —
 do NOT `git checkout origin/master -- TASKS.md`, which would stage it
@@ -131,9 +193,18 @@ and break the next `git checkout -b`). If the user already named the
 next slice in conversation, prefer that; otherwise `<short-topic>` can
 be a brief paraphrase of the title.
 
-In **standard mode** (step 4 returned empty): ask the user what the
-next task is if they haven't already told you. Derive a short,
-kebab-case branch name from the task, prefixed `claude/<area>-`:
+In **cursor stack mode** (4b): the new branch is
+`claude/<area>-<topic>`, no `T-NNN` prefix (cursor flow doesn't use
+the queue). Derive from the conversation: the user usually names the
+next slice when they cue stacking. If they didn't, ask. Examples:
+
+- `claude/render-glow-pulse-tuning` (stacked on
+  `claude/render-glow-pulse`)
+- `claude/game-pheromone-decay` (stacked on `claude/game-pheromones`)
+
+In **standard mode** (4c): ask the user what the next task is if they
+haven't already told you. Derive a short, kebab-case branch name from
+the task, prefixed `claude/<area>-`:
 
 - `claude/game-ant-pheromones`
 - `claude/engine-velocity-drag-refactor`
@@ -163,11 +234,11 @@ overwritten by checkout."
 
 ```bash
 git checkout -B <new-branch> origin/master      # standard mode
-git checkout -B <new-branch> <old-branch-name>  # stack mode
+git checkout -B <new-branch> <old-branch-name>  # fleet-stack or cursor-stack
 ```
 
-The base is `origin/master` for the standard flow, `<old-branch-name>` for
-stack mode (see step 4). `-B` (uppercase) creates the branch
+The base is `origin/master` for the standard flow, `<old-branch-name>`
+for either stack mode (see step 4). `-B` (uppercase) creates the branch
 if it doesn't exist AND resets it to the named commit if it does.
 Lowercase `-b` errors out with "branch already exists" — surprisingly
 common because the worktree's previous scratch branches accumulate over
@@ -178,14 +249,45 @@ In **standard mode**, this starts the new branch from the tip of
 `origin/master`. Critical: without `origin/master`, you'd branch off
 your old PR branch and carry its commits forward.
 
-In **stack mode**, this is intentional — the downstream task is meant to
-contain the upstream commits so the worker can keep building. The
-downstream PR's `--base` (set later by `commit-and-push`) is the upstream
-branch, so the diff still shows only the downstream changes.
+In **fleet stack mode** and **cursor stack mode**, this is intentional —
+the downstream slice is meant to contain the upstream commits so the
+human (or worker) can keep building. The downstream PR's `--base` (set
+later by `commit-and-push`) is the upstream branch, so the diff still
+shows only the downstream changes.
+
+**macOS sandbox note.** `git checkout -B` writes `.git/config` to set up
+branch tracking. On macOS Cursor's Bash sandbox, `.git/config` writes
+need the `all` permission — without it the checkout *appears* to
+succeed but the tracking config is missing, leaving the new branch
+without an upstream. Always run this checkout with sandbox bypass on
+macOS.
 
 **Do NOT** `git rebase origin/master` on the old branch and keep working
 on it. That would mix old PR commits with new work, which pollutes the
 old PR when you push. Always start a new branch.
+
+### 7b. Record cursor-stack-base (cursor stack mode only)
+
+In **cursor stack mode** only, persist the parent branch name as
+git config on the new branch so `commit-and-push` can find it later
+when opening the PR:
+
+```bash
+git config branch.<new-branch>.cursor-stack-base <old-branch-name>
+```
+
+This config write is also `.git/config` — same `all` permissions
+requirement on macOS as step 7.
+
+The config is per-branch and survives chat boundaries: if the human
+opens a new chat tomorrow already on `<new-branch>`, `commit-and-push`
+reads the config from `branch.<new-branch>.cursor-stack-base` and
+opens the PR with the correct `--base`. No "resume stack" cue is
+needed across chats.
+
+Skip this step in fleet stack mode (the chain lives in
+`fleet-claim` state, not git config) and in standard mode (no
+parent to record).
 
 ### 8. Sanity-check the state
 
@@ -197,10 +299,20 @@ git log --oneline -5
 - `git status`: should be `nothing to commit, working tree clean`.
 - **Standard mode:** `git log --oneline -5` top commit should be the
   latest `master` commit, not one of your previous PR's commits.
-- **Stack mode:** the top commit should be the just-opened PR's tip
-  (i.e. the last commit on the old branch). The new branch's
+- **Fleet/cursor stack mode:** the top commit should be the just-opened
+  PR's tip (i.e. the last commit on the old branch). The new branch's
   merge-base with `origin/master` is whatever the old branch branched
   from — not the old branch's tip. That's expected.
+
+In cursor stack mode, also confirm the config write took:
+
+```bash
+git config --get branch.<new-branch>.cursor-stack-base
+```
+
+It should print `<old-branch-name>`. If it's empty, the write was
+sandboxed (see step 7b's macOS note) — re-run with `all` permissions
+before continuing.
 
 If the top commit is wrong for the mode you're in, the checkout went
 wrong — stop and investigate.
@@ -224,37 +336,51 @@ differs from the engine baseline, honor the subdirectory's rules.
 
 Reply with a compact summary:
 
+- **Mode** you ended up in (standard / fleet-stack / cursor-stack).
 - Old branch name + its PR URL (from step 2).
 - New branch name + the base it's tracking. In standard mode that's
-  fresh `origin/master`; in stack mode call out the upstream branch
-  explicitly so the reviewer-and-merger pipeline isn't surprised when
-  `commit-and-push` later sets `--base <upstream>`.
+  fresh `origin/master`; in either stack mode call out the upstream
+  branch explicitly so the reviewer-and-merger pipeline (or the human
+  in cursor flow) isn't surprised when `commit-and-push` later sets
+  `--base <upstream>`.
+- In cursor stack mode: confirm `branch.<new>.cursor-stack-base` was
+  recorded.
 - The CLAUDE.md files you just read to prime context.
 - One sentence: "Ready for <next task>. Go ahead."
 
 ## Anti-patterns
 
 - ❌ Switching branches with a dirty working tree. Always clean first.
-- ❌ Branching off your previous PR branch in **standard mode** (no active
-  molecule). That stacks unrelated work and pollutes the old PR. Stack
-  mode (step 4 returned a `T-NNN`) is the only case where the old branch
-  is the correct base.
-- ❌ Branching off `origin/master` in **stack mode**. The downstream
-  task's diff would then include the upstream changes too, defeating
-  the whole point of stacked PRs (one task = one isolated diff).
-- ❌ Skipping `fleet-claim molecule advance` after `commit-and-push` and
-  going straight to `start-next-task`. `molecule resume` would return
-  the just-completed task as still in-progress, branching you onto the
-  same thing you just shipped. The stack-mode sanity-check in step 4
-  catches this — heed it.
-- ❌ Running `git rebase origin/master` on the old branch to "catch it
-  up", then reusing it. Rebasing the same branch for new unrelated work
-  is how PR histories become unreadable.
-- ❌ Deleting the old local branch. Leave it alone — if the reviewer asks
-  for changes, you'll need to check it out again. Stack mode REQUIRES
-  the old branch as the new branch's base.
-- ❌ Starting the next task without reading the target area's CLAUDE.md.
-  That's where the module-specific invariants live.
+- ❌ Branching off your previous PR branch in **standard mode** (no
+  active molecule and no stack cue). That stacks unrelated work and
+  pollutes the old PR. Either stack mode (4a returned a `T-NNN`, or
+  the human cued stacking) is the only case where the old branch is
+  the correct base.
+- ❌ Branching off `origin/master` in **either stack mode**. The
+  downstream slice's diff would then include the upstream changes
+  too, defeating the whole point of stacked PRs (one slice = one
+  isolated diff).
+- ❌ Skipping `fleet-claim molecule advance` after `commit-and-push`
+  and going straight to `start-next-task`. `molecule resume` would
+  return the just-completed task as still in-progress, branching you
+  onto the same thing you just shipped. The stack-mode sanity-check
+  in step 4a catches this — heed it.
+- ❌ Writing `cursor-stack-base` git config in fleet stack mode or
+  standard mode. The config is the cursor-flow stack signal; setting
+  it elsewhere confuses `commit-and-push`.
+- ❌ Auto-detecting cursor stack mode from "old branch happens to be
+  a feature branch" without a user cue. The cue is the only signal.
+  Without it, the human's intent is ambiguous (they may want a fresh
+  slice off master), and step 4b's "ask, don't guess" rule applies
+  for cursor flow.
+- ❌ Running `git rebase origin/master` on the old branch to "catch
+  it up", then reusing it. Rebasing the same branch for new unrelated
+  work is how PR histories become unreadable.
+- ❌ Deleting the old local branch. Leave it alone — if the reviewer
+  asks for changes, you'll need to check it out again. Both stack
+  modes REQUIRE the old branch as the new branch's base.
+- ❌ Starting the next task without reading the target area's
+  CLAUDE.md. That's where the module-specific invariants live.
 - ❌ Invoking this skill when no PR was actually opened (i.e. after a
   `commit-and-push` failure). Check step 2.
 
@@ -267,3 +393,14 @@ work (somehow step 1's clean check missed it):
 2. Stash or commit the dirty work on the old branch.
 3. Push and update the PR.
 4. `git checkout <new-branch>` to return.
+
+If you set up cursor stack mode and later realize the new slice should
+not actually be stacked (e.g. you decide to base it on master after
+all):
+
+1. Clear the config: `git config --unset
+   branch.<new-branch>.cursor-stack-base` (needs `all` permissions on
+   macOS).
+2. Rebase the new branch onto master:
+   `git rebase --onto origin/master <old-branch> <new-branch>`.
+3. Continue work. `commit-and-push` will now open the PR vs `master`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,9 @@ In Cursor flow:
   invoked whenever the human asks. Don't auto-invoke them
   mid-iteration.
 - **Never auto-invoke `commit-and-push` or `start-next-task`.** Wait
-  for an explicit "ship it" / "commit this" / "open a PR" / "ready
-  for review" cue. The fleet's rules 2 and 3 describe what happens
-  *when* those cues arrive — they don't license proactive
-  invocation.
+  for an explicit cue (see the cue table below). The fleet's rules
+  2 and 3 describe what happens *when* those cues arrive — they
+  don't license proactive invocation.
 - **`TASKS.md` is fleet-only.** The Cursor session is not bound to
   the shared queue; the human decides what to work on.
 
@@ -82,24 +81,100 @@ In Cursor flow:
 before starting Cursor work. `commit-and-push` step 2 detects when
 HEAD is `master` and creates `claude/<area>-<topic>` for you before
 staging; the dirty working tree carries over via `git checkout -b`.
-The only things to keep in mind:
+
+The cursor-flow cues that drive branching:
+
+- **"commit"** / **"commit and push"** / **"open a PR"** / **"ship
+  it"** / **"ready for review"** → `commit-and-push` runs end-to-end.
+  If on `master`, it auto-branches first.
+- **"I merged it"** / **"back to master"** / **"fresh start"** /
+  **"new task"** / **"next task"** → `start-next-task` runs. Fetches
+  `origin/master`, branches off it cleanly, primes context for the
+  new area.
+- **"stack this"** / **"next slice, stacked"** / **"keep stacking"** /
+  **"stack the next on this PR"** → the next `start-next-task` (or
+  `commit-and-push`, depending on which side of the chain you're on)
+  runs in **cursor stack mode**. See "Stacking in cursor flow" below.
+
+Two things to watch when working dirty on `master`:
 
 - **No local commits on `master` during a session.** Dirty changes
   are fine (they migrate to the new branch); committed history on
-  local `master` is not (it would have to be moved off, which is
-  error-prone). The "Never commit to master directly" rule above
-  applies in Cursor flow too.
+  local `master` is not. The "Never commit to master directly" rule
+  above applies in Cursor flow too.
 - **Watch for stale local master.** If a session runs for a while on
   a local `master` that's behind `origin/master`, the auto-created
   branch will be based on stale code. Mention this at commit time so
   the human can decide whether to rebase the new branch onto current
   `origin/master` before pushing.
 
-If you want to start a Cursor session with a known-fresh base, invoke
-`start-next-task` at the top — it fetches `origin/master` and
-branches off it cleanly. Otherwise, working dirty on `master` and
-letting `commit-and-push` branch you at the end is the lowest-friction
-default.
+**New chats.** Each Cursor chat starts with fresh context. The agent
+should briefly check `git rev-parse --abbrev-ref HEAD` early in the
+first turn that touches code, so it knows the branch state. Do not
+propose any branching action unless the human cues for it. The one
+exception: **if the human asks for new work and HEAD is a feature
+branch whose PR is already merged**, surface this and ask whether to
+run `start-next-task` first — continuing on a stale merged branch
+produces a confusing PR later.
+
+If a new chat lands on a feature branch with an **open PR**, assume
+the human is continuing that PR (e.g. addressing review feedback).
+Don't suggest branching.
+
+If a new chat lands on `master`, just work — the auto-branch happens
+at commit time. This is the lowest-friction default and the most
+common shape.
+
+**Stacking in cursor flow.** Use this when you want to ship slice
+A's PR and immediately start slice B that depends on A — before A
+is merged — with B's diff scoped to its own changes only.
+
+Cursor stacking is a lighter-weight pattern than fleet's
+`fleet-claim stack` mode: no molecules, no task IDs, no worktree
+claims, no `fleet:stacked` label. State is per-branch git config,
+so it survives across chat boundaries automatically.
+
+Mechanics:
+
+1. Ship slice A normally: "commit and push" → PR A vs `master`.
+2. Start B stacked: "next slice, stacked" → `start-next-task`
+   branches off the **current branch** (A's head) instead of
+   `origin/master`, and writes
+   `branch.<new>.cursor-stack-base = <A's branch>` to git config.
+3. Iterate on B, then "commit and push" → `commit-and-push` reads
+   the `cursor-stack-base` config; if set, opens the PR with
+   `--base <A's branch>` and adds `Stacked on: <PR A URL>` to the
+   PR body.
+4. Repeat for C, D, …
+
+Stacks usually live in one Cursor chat (ship A → start B → ship B
+→ start C, all in one context), but they can span chats. The git
+config is per-branch and persists, so a fresh chat that lands on
+`claude/slice-c` finds its `cursor-stack-base` automatically and
+`commit-and-push` does the right thing.
+
+When PR A merges, change PR B's base to `master` in the GitHub UI
+(or `gh pr edit B --base master`) — same step as in any stacked-PR
+workflow. The `cursor-stack-base` config is local-only; nothing
+upstream needs cleanup.
+
+If a chat lands on a branch that already has `cursor-stack-base`
+set and the human cues a non-specific "next slice" without saying
+"stacked" or "fresh start", **ask** whether to continue the stack
+or branch off master. Don't guess.
+
+**macOS sandbox note.** Cursor's Bash sandbox on macOS blocks
+writes to `.git/config`, `gh` keychain access, and SSH `git push`.
+Any `git config <branch>.<key> <value>` write, `git push`, `gh pr
+create`, or `gh pr edit` invoked from a cursor-flow skill needs to
+run with the `all` permission. Reads (`git config --get …`) are
+not sandboxed and run normally.
+
+If you want to start a Cursor session with a known-fresh base,
+invoke `start-next-task` at the top — it fetches `origin/master`
+and branches off it cleanly. Otherwise, working dirty on `master`
+and letting `commit-and-push` branch you at the end is the
+lowest-friction default.
 
 If the agent is unsure which flow it's in, default to Cursor flow.
 Fleet roles (`.claude/commands/role-*.md`) override this default by


### PR DESCRIPTION
## Summary

- Document **new-chat behavior** for cursor flow: brief `git rev-parse --abbrev-ref HEAD` check on the first code-touching turn; surface a "your branch's PR was already merged" warning **only** when the human asks for new work and HEAD is a stale merged feature branch. Working dirty on `master` and continuing on an open-PR branch are both no-op defaults.
- Add a **cursor-flow stacking pattern** as a lighter-weight peer to fleet's `fleet-claim stack` mode. Per-branch git config (`branch.<new>.cursor-stack-base = <parent>`) records the parent branch; `commit-and-push` reads it and opens the PR with `--base <parent>` plus a `Stacked on: <PR URL>` line. State is local-only and persists across chat boundaries automatically.
- Refactor `start-next-task` to detect three modes (fleet stack, cursor stack, standard) in priority order at step 4, derive the branch-name shape per mode at step 5, and write `cursor-stack-base` in a new step 7b when in cursor stack mode.
- Add a peer "Cursor stack mode" section to `commit-and-push` and a step-8 PR-base override that reads the config.
- Document the **macOS sandbox quirk**: `.git/config` writes, `gh` keychain access, and SSH `git push` all need `required_permissions: ["all"]` from inside Cursor's Bash sandbox; reads (`git config --get …`) run unrestricted.
- Map cursor-flow cues to skills in `CLAUDE.md` so the agent knows when each cue triggers `commit-and-push`, `start-next-task`, or cursor stack mode (and never proactively).

## Test plan

- [ ] Read-through: cue table in `CLAUDE.md` covers commit, start-next, and stack triggers.
- [ ] `start-next-task` step 4a/4b/4c logic matches the priority-order intent (fleet > cursor stack > standard).
- [ ] `commit-and-push` step 8 reads `cursor-stack-base` and falls back to `master` when unset.
- [ ] Anti-patterns and recovery sections in `start-next-task` cover both "wrote config in wrong mode" and "want to un-stack" cases.
- [ ] No fleet machinery (molecules, claims, `TASKS.md`) leaks into the cursor-stack path.
- [ ] macOS sandbox notes are co-located with each skill step that needs `all` permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)