### PR TITLE
fleet-up: anchor ops window after fleet; shorten semantic-conflict label desc

### DIFF
--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -103,7 +103,7 @@ LABELS=(
     "fleet:has-nits|fbca04|Approved but author should clean up nits before merge"
     "fleet:needs-fix|d73a4a|Reviewer agent flagged correctness/quality issues"
     "fleet:blocker|800010|Reviewer agent flagged a blocker; do not merge"
-    "fleet:semantic-conflict|d73a4a|Merger detected non-mechanical conflict; opus-worker will attempt resolution before escalating to human"
+    "fleet:semantic-conflict|d73a4a|Merger hit non-mechanical conflict; opus-worker resolves or escalates"
     "fleet:merger-cooldown|bfdadc|Merger touched this PR; skip until next iteration"
     "fleet:needs-linux-smoke|c5def5|Engine render PR awaiting Linux/OpenGL cross-host smoke validation"
     "fleet:needs-macos-smoke|c5def5|Engine render PR awaiting macOS/Metal cross-host smoke validation"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -564,7 +564,13 @@ label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.7]"
 # queue-manager (top-left), merger (top-right),
 # witness (bottom-left), terminal (bottom-right, $HOME, free-form shell).
 
-OPS_TL=$(tmux new-window -t "$SESSION" -n ops -P -F "#{pane_id}" \
+# Anchor explicitly after the fleet window with `-a -t fleet`. Without
+# the anchor, `new-window -t "$SESSION"` picks the lowest unused index
+# starting at base-index — which collides on tmux configs with
+# `base-index 1` (fleet itself sits at 1, and `-t "$SESSION"` retries
+# 1 instead of advancing to 2). `-a -t fleet:fleet` always lands ops
+# at fleet-index + 1 regardless of base-index.
+OPS_TL=$(tmux new-window -a -t "$SESSION:fleet" -n ops -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/queue-manager" \
     "$(launch_cmd "$SONNET_MODEL" queue-manager 5m)")
 label_pane_id "$OPS_TL" "queue-manager [sonnet]"


### PR DESCRIPTION
## Summary

Two startup blockers observed on macOS during a fresh `fleet-up live`:

1. **tmux ops window collision.** `tmux new-window -t \"\$SESSION\"`
   (no anchor) failed with `create window failed: index 1 in use`
   when the user's tmux config has \`base-index 1\`. The fleet
   window itself sits at index 1, and the auto-pick logic somehow
   retries 1 instead of advancing. Fixed by anchoring explicitly
   with \`-a -t fleet:fleet\` so ops always lands at fleet-index + 1
   regardless of base-index.

2. **\`fleet:semantic-conflict\` label create failed silently.**
   GitHub's label-description limit is 100 chars; the previous
   description was 103. \`gh label create\` rejected it, the script
   re-checked and didn't find it, and logged \`failed to create\`
   on every fleet-up. Shortened the description to 69 chars while
   preserving the workflow narrative.

Both bugs were silent before — the tmux error only printed if you
scrolled the launch output, and the label create swallowed its
stderr via \`>/dev/null 2>&1\`.

## Test plan

- [ ] \`fleet-down --force\` then \`fleet-up live\` on a host with
      \`base-index 1\` succeeds — ops window lands at index 2.
- [ ] \`fleet-up live\` on a host with default \`base-index 0\` still
      works — ops window lands at index 1.
- [ ] \`fleet-labels\` reports \`27 created\` (or matching count) on
      a fresh repo, no \`failed to create\` entries.
- [ ] \`bash -n scripts/fleet/fleet-up\` and
      \`bash -n scripts/fleet/fleet-labels\` both pass.

## Notes for reviewer

- The \`-a\` flag means \"insert after target window.\" Combined with
  \`-t fleet:fleet\` (anchored to the fleet window by name, not
  index), this makes the new ops window always land at fleet's
  index + 1. Correct under any \`base-index\` value.
- The new description (\`Merger hit non-mechanical conflict;
  opus-worker resolves or escalates\`) preserves the merger →
  opus-worker → escalation workflow; just drops the more verbose
  \"will attempt resolution before escalating to human\" phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)