### PR TITLE
T-063: fleet: design-escalation flow — bidirectional labels + plan re-sync + role docs

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -70,10 +70,16 @@ components, or entities.
 2. Read `TASKS.md` (use the Read tool, not `cat`) — review the current queue.
 3. `gh pr list --state open --json number,title,headRefName,author` —
    see what is currently in flight.
-4. Print a one-line summary: how many `[opus]` tasks are unblocked, how
+4. **List `fleet:design-blocked` PRs** (architect's lane — workers
+   escalate mid-task by adding this label):
+   `gh pr list --repo jakildev/IrredenEngine --state open --label "fleet:design-blocked" --json number,title,author --jq '.[] | "#\(.number) \(.title) (by \(.author.login))"'`
+   If non-empty, surface the list in the standing-by message so
+   the human can direct attention. See "Handling
+   `fleet:design-blocked` PRs" below for the response flow.
+5. Print a one-line summary: how many `[opus]` tasks are unblocked, how
    many open PRs are in flight, and which (if any) appear to be claiming
    core-engine work.
-5. Print `opus-arch standing by` (or `opus-arch standing by (dry-run)`
+6. Print `opus-arch standing by` (or `opus-arch standing by (dry-run)`
    if Mode above is `dry-run`).
 
 ## Loop behavior
@@ -225,6 +231,75 @@ conversation), use the same flow:
 
 If you disagree with the issue's direction, comment with your
 concerns but leave `fleet:needs-plan` on — let the human decide.
+
+## Handling `fleet:design-blocked` PRs
+
+The architect role is interactive (no autonomous loop), but workers
+can escalate mid-task by labeling their open PR with
+`fleet:design-blocked` and posting a `## NEEDS-DESIGN` comment.
+Those PRs sit there until you respond — the human will direct your
+attention to them, but you should also list them on startup so
+you know what's queued for you.
+
+On startup, list `fleet:design-blocked` PRs in the engine repo:
+
+```
+gh pr list --repo jakildev/IrredenEngine --state open --label "fleet:design-blocked" --json number,title,author --jq '.[] | "#\(.number) \(.title) (by \(.author.login))"'
+```
+
+If any exist, surface them in the standing-by message so the human
+can direct attention.
+
+When working a `fleet:design-blocked` PR:
+
+1. Read the PR body and the worker's `## NEEDS-DESIGN` comment(s)
+   carefully — the worker has done analysis you should leverage.
+   The escalation comment names the contradiction with the original
+   plan, the specific architectural question(s), and (sometimes)
+   suggested options.
+2. Decide on the architectural questions. You are not coding the
+   fix yourself; you are providing direction the worker will execute.
+3. **Update the canonical plan file at `~/.fleet/plans/issue-<N>.md`**
+   (where `<N>` is the issue number referenced in the PR body via
+   `Closes #<N>` — assumes the task was ingested from a backing
+   issue, which is the common case). Add a revision-history entry
+   at the bottom and update the scope / acceptance criteria
+   sections in place. The queue-manager re-syncs this file into
+   the repo at `.fleet/plans/T-<NNN>.md` on its next maintenance
+   pass, so the worker reads the updated plan when it picks the PR
+   back up. If the PR has no backing issue (rare — ad-hoc work
+   without a TASKS.md row), skip the plan-file update and put the
+   full direction inline in the PR comment in step 4.
+4. Post a PR comment with concrete decisions, re-scoped acceptance
+   criteria (if changed), and a pointer to the plan file:
+   ```
+   gh pr comment <N> --body "## Architect direction
+
+   <decisions, concretely — not vaguely>
+
+   <re-scoped acceptance criteria if the original ones changed>
+
+   The canonical plan at \`~/.fleet/plans/issue-<N>.md\` has been
+   updated; queue-manager will re-sync to
+   \`.fleet/plans/T-<NNN>.md\` on the next maintenance pass."
+   ```
+5. Swap labels — remove `fleet:design-blocked`, add
+   `fleet:design-unblocked`. The worker's next iteration picks
+   this up via its feedback-PR loop:
+   ```
+   gh pr edit <N> --remove-label "fleet:design-blocked" --add-label "fleet:design-unblocked"
+   ```
+6. (Optional) If the re-scope changes the semantics significantly,
+   update the PR title:
+   ```
+   gh pr edit <N> --title "<new title>"
+   ```
+
+Do NOT take ownership of the worker's branch. Do NOT push fixes
+yourself. The worker resumes execution; you provide direction only.
+The `fleet:wip` label stays on throughout — `design-blocked` and
+`design-unblocked` are state qualifiers on top of WIP, not transfers
+of ownership.
 
 ## Escalation rules (always)
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -218,9 +218,9 @@ Do the work, then exit cleanly:
    longer in your conversation context. From `repos.engine.prs[]`
    and `repos.game.prs[]`, pick PRs whose `labels` array contains
    any of `human:needs-fix`, `human:blocker`, `fleet:needs-fix`,
-   `fleet:has-nits`. (This is the cached equivalent of the previous
-   `gh pr list ... --jq 'select(.labels ...)'` chain — same filter,
-   no API call.)
+   `fleet:has-nits`, `fleet:design-unblocked`. (This is the cached
+   equivalent of the previous `gh pr list ... --jq 'select(.labels
+   ...)'` chain — same filter, no API call.)
 
    For game-side feedback work, **cd into the game opus-worker
    worktree** before any git/gh ops (same as step 4 for new tasks):
@@ -236,6 +236,11 @@ Do the work, then exit cleanly:
       improvements that should land before merge to keep code quality high.
       The cost of a fix-and-push iteration is tiny vs merging with known
       smells. Address every nit unless it's purely subjective preference.
+   4. `fleet:design-unblocked` — architect responded to a prior
+      mid-task escalation (`fleet:design-blocked` → resolved). The
+      canonical plan at `.fleet/plans/T-<NNN>.md` has been re-synced
+      by the queue-manager; address per the architect's PR comment
+      + updated plan, just like a normal feedback fix.
 
    **Filter the candidate set: skip PRs whose branch is already
    checked out in another worktree.** A PR's branch can only be in
@@ -265,6 +270,13 @@ Do the work, then exit cleanly:
 
       **For `fleet:has-nits`**: focus on the latest review's `### Nits`
       section. Address every nit unless it's purely subjective preference.
+
+      **For `fleet:design-unblocked`**: also re-read the canonical
+      plan file at `.fleet/plans/T-<NNN>.md` (the queue-manager has
+      re-synced it from `~/.fleet/plans/issue-<N>.md` after the
+      architect updated it). The latest architect comment is the
+      authoritative direction; the plan file is the long-form
+      version. If the two diverge, the comment wins for this PR.
 
    a2. **For `human:needs-fix` / `human:blocker` only — decide
        AMEND vs ESCALATE.** Two valid dispositions:
@@ -322,7 +334,7 @@ Do the work, then exit cleanly:
 
    b. **(AMEND path)** **Immediately remove the feedback label**
       to prevent another agent from also picking it up:
-      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:human-deferred"`
+      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:human-deferred" --remove-label "fleet:design-unblocked"`
 
       For `human:needs-fix` / `human:blocker` specifically, also
       mark the PR as in-progress and clear the prior approval so
@@ -331,9 +343,9 @@ Do the work, then exit cleanly:
       remove-when-absent with `--add-label` would abort the call):
       `gh pr edit <N> --add-label "fleet:human-amending"`
       `gh pr edit <N> --remove-label "fleet:approved"`
-      For `fleet:needs-fix` / `fleet:has-nits` only (no human
-      label): skip both — reviewer-flagged feedback doesn't
-      trigger the human-amending state.
+      For `fleet:needs-fix` / `fleet:has-nits` / `fleet:design-unblocked`
+      only (no human label): skip both — reviewer-flagged feedback
+      and architect direction don't trigger the human-amending state.
    c. Address every piece of feedback. Build with `fleet-build`.
    d. Push fixes using `commit-and-push`.
    e. Swap the in-progress label for the done label:
@@ -345,6 +357,9 @@ Do the work, then exit cleanly:
       - If it was `fleet:needs-fix` → no response label needed.
       - If it was `fleet:has-nits` → no response label needed; existing
         `fleet:approved` stays valid (cleanups don't invalidate approval).
+      - If it was `fleet:design-unblocked` → no response label
+        needed; the PR re-enters the normal review flow once you
+        push (sonnet-reviewer will pick it up via `fleet:wip`).
       `gh pr comment <N> --body "Addressed feedback: <bullet list of what changed>"`
    f. Remove stale fleet review labels (`fleet:needs-fix`,
       `fleet:blocker`) if present — but **keep `fleet:approved`** if
@@ -863,9 +878,50 @@ Do the work, then exit cleanly:
      multiple modules in one PR
    - A build break looks structural
 
-   STOP. Surface the issue to the human. Do NOT try to redesign
-   mid-task — the architect handles design conversations. Comment on
-   your PR explaining the blocker and wait.
+   STOP. Do NOT try to redesign mid-task — the architect handles
+   design conversations.
+
+   **Design escalation via `fleet:design-blocked`.** When the
+   blocker is specifically architectural — the assigned task can't
+   proceed without a design call you don't have authority to make —
+   escalate via the label-driven flow (engine `CLAUDE.md`
+   "Design-escalation flow") so the architect can pick it up from
+   the trigger surface and the same worker (or any worker) can
+   resume cleanly:
+
+   a. **Commit and push whatever in-progress work you have on the
+      branch.** Even if half-done — the next worker iteration will
+      need it as the starting point when `fleet:design-unblocked`
+      appears. Use `commit-and-push` (the WIP PR already exists).
+   b. Post a `## NEEDS-DESIGN` escalation comment on the PR:
+      `gh pr comment <N> --body "## NEEDS-DESIGN
+
+      <what you've learned about the existing code / framework that
+      contradicts the original plan>
+
+      <the specific architectural question(s) you can't answer —
+      one per bullet>
+
+      <suggested options if you have a view; the architect picks,
+      you don't have to know the right answer>"`
+   c. Add the `fleet:design-blocked` label:
+      `gh pr edit <N> --add-label "fleet:design-blocked"`
+      Keep `fleet:wip` — design-blocked is a state qualifier on top
+      of WIP, not a transfer of ownership. Don't release the
+      `fleet-claim` lock — the open PR + the claim lock together
+      keep T-NNN reserved for resumption.
+   d. Reset the worktree via `start-next-task` so the branch is free
+      for the architect (or anyone else) to `gh pr checkout`. Then
+      pick a different unblocked TASKS.md task as your next
+      iteration's work — do NOT re-claim the same task. Once the
+      architect responds, the PR will be re-armed via
+      `fleet:design-unblocked` and any worker can pick it up via
+      step 1 priority 4 above.
+
+   For non-architectural escalations (scope grew, build break is
+   structural, public-API surface) where there's no design call to
+   route — comment on your PR explaining the blocker, leave the PR
+   in `fleet:wip`, and wait for the human directly.
 
 9. **Attach screenshots (when visual output changed).** Check whether
    the diff touches visual/render code:

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -542,6 +542,32 @@ You are the sole TASKS.md editor. Each maintenance pass:
    For each in-progress issue not referenced by any open PR:
    `gh issue edit <N> --repo <repo> --remove-label "fleet:in-progress"`
 
+5c. **Re-sync plan files for in-progress tasks.** The architect can
+   update `~/.fleet/plans/issue-<N>.md` after a task has already
+   been ingested (the design-escalation flow in
+   `role-opus-architect.md` does exactly this when responding to a
+   `fleet:design-blocked` PR). The original `.fleet/plans/T-<NNN>.md`
+   in the repo was copied at ingestion time (step 2.d) and is now
+   stale. Workers read the repo copy, so we need to re-copy when
+   the local file is newer.
+
+   For each `[~]` (in-progress) task in each TASKS.md whose entry
+   has `**Issue:** #N`:
+   - Local path: `~/.fleet/plans/issue-<N>.md`
+   - Repo path: `.fleet/plans/T-<NNN>.md` (engine repo) or
+     `creations/game/.fleet/plans/T-<NNN>.md` (game repo)
+   - If the local file exists AND its mtime is newer than the repo
+     file's mtime (or the repo file doesn't exist), re-copy:
+     `cp ~/.fleet/plans/issue-<N>.md <repo-path>`
+     Stage in the same maintenance commit as TASKS.md edits.
+   - If neither file exists, skip (no plan was ever written).
+
+   The re-copy is content-equivalent to the original ingest copy
+   (step 2.d) — same source, same destination. Workers see the
+   updated plan on their next iteration when they `git pull` (via
+   `git -C <repo> show origin/master:.fleet/plans/T-<NNN>.md` per
+   the role-opus-worker startup actions).
+
 6. **Resolve stale blocker references.** Scan all `## Open` entries in
    each TASKS.md. For any `Blocked by:` field that contains:
    - A free-text title that now matches an existing task → replace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,35 @@ If the agent is unsure which flow it's in, default to Cursor flow.
 Fleet roles (`.claude/commands/role-*.md`) override this default by
 being explicit about autonomous behavior.
 
+### Design-escalation flow
+
+When a worker discovers mid-task that the assigned task can't proceed
+without architectural input — the existing code/framework contradicts
+the original plan, or a design call is needed that the worker doesn't
+have authority to make — the fleet uses a label-driven cycle to route
+the question to the architect and resume cleanly:
+
+1. Worker posts `## NEEDS-DESIGN` comment on the open PR + adds
+   `fleet:design-blocked` (keeping `fleet:wip`) + commits whatever
+   in-progress work is on the branch + `start-next-task`s away to
+   pick a different unblocked task next iteration.
+2. Architect reads the comment, updates the canonical plan at
+   `~/.fleet/plans/issue-<N>.md`, posts a PR comment with concrete
+   decisions, swaps `fleet:design-blocked` → `fleet:design-unblocked`.
+3. Queue-manager re-syncs the updated plan into the repo at
+   `.fleet/plans/T-<NNN>.md` on its next maintenance pass.
+4. Worker (any worker — not necessarily the original one) sees the
+   `fleet:design-unblocked` PR via its feedback-PR loop on the next
+   iteration, reads the architect's comment + the updated plan,
+   addresses the direction, removes the label, pushes via
+   `commit-and-push`. PR re-enters normal review flow.
+
+Reviewer agents skip `fleet:design-blocked` PRs (they're in
+escalation limbo, not awaiting review). The full per-role procedure
+is in `role-opus-worker.md` (escalate + resume),
+`role-opus-architect.md` ("Handling `fleet:design-blocked` PRs"),
+and `role-queue-manager.md` (step 5c plan re-sync).
+
 ### Model split: Opus for core, Sonnet for the fleet
 
 The user has much more Sonnet budget than Opus budget. Spend each where it
@@ -531,6 +560,18 @@ Specifically, **never pass these via `--label` when filing**:
     iteration. `fleet:approved` is kept (PR is internally OK).
     **Read as: "agent acknowledged your concerns, linked issue
     tracks them, you decide whether to merge as-is or re-flag."**
+- `fleet:design-blocked` / `fleet:design-unblocked` — paired
+  state qualifiers for the mid-task design-escalation cycle (see
+  "Design-escalation flow" above). `design-blocked` is set by the
+  **worker** when it escalates and cleared by the **architect** when
+  responding (replaced by `design-unblocked`). `design-unblocked`
+  is then cleared by the **worker** when it picks the PR back up.
+  Coexist with `fleet:wip` — they're qualifiers, not transfers of
+  ownership. Distinct from `fleet:needs-fix` because the worker
+  isn't fixing a defect, they're following architectural direction
+  (which may include "no code change, just doc update"). Reviewer
+  agents skip `fleet:design-blocked` PRs (the scout's
+  `REVIEW_SKIP_LABELS` excludes them).
 
 **The right pattern when filing an issue:** create it with NO labels.
 The human will add `human:approved` if and when they want it picked

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -105,6 +105,8 @@ LABELS=(
     "fleet:blocker|800010|Reviewer agent flagged a blocker; do not merge"
     "fleet:semantic-conflict|d73a4a|Merger hit non-mechanical conflict; opus-worker resolves or escalates"
     "fleet:merger-cooldown|bfdadc|Merger touched this PR; skip until next iteration"
+    "fleet:design-blocked|fbca04|Worker escalated for architectural input mid-task; architect should respond"
+    "fleet:design-unblocked|c5def5|Architect responded; worker resumes per the architect comment + updated plan file"
     "fleet:needs-linux-smoke|c5def5|Engine render PR awaiting Linux/OpenGL cross-host smoke validation"
     "fleet:needs-macos-smoke|c5def5|Engine render PR awaiting macOS/Metal cross-host smoke validation"
     "fleet:authored-on-linux|ededed|PR was opened from a Linux/WSL host; reviewer skips fleet:needs-linux-smoke"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -210,12 +210,17 @@ def stable_hash(obj):
 FEEDBACK_LABELS = frozenset({
     "human:needs-fix", "human:blocker", "fleet:needs-fix", "fleet:has-nits",
 })
+# Worker-only resume signal — a PR the worker escalated for architectural
+# input that the architect has now answered. Surfaced in project_opus_worker
+# (and only there) so the worker iteration picks it up like any other
+# feedback PR; reviewers and authors do not act on it.
+DESIGN_RESUME_LABELS = frozenset({"fleet:design-unblocked"})
 REVIEW_VERDICT_LABELS = frozenset({
     "fleet:approved", "fleet:needs-fix", "fleet:blocker", "fleet:has-nits",
 })
 REVIEW_SKIP_LABELS = frozenset({
     "fleet:wip", "human:wip", "fleet:merger-cooldown", "human:needs-fix",
-    "fleet:semantic-conflict",
+    "fleet:semantic-conflict", "fleet:design-blocked",
     # Worker is amending the PR for the human's concerns; the diff
     # the reviewer sees is in flux. Re-evaluate once fleet:changes-made
     # appears (which RECHECK_LABELS picks up).
@@ -261,7 +266,7 @@ def project_opus_worker(state):
             labels = set(pr["labels"])
             if "human:wip" in labels:
                 continue
-            if labels & FEEDBACK_LABELS:
+            if labels & (FEEDBACK_LABELS | DESIGN_RESUME_LABELS):
                 items.append({"kind": "pr", "repo": repo, "pr": pr["number"],
                               "labels": pr["labels"]})
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))


### PR DESCRIPTION
## Summary
- Install `fleet:design-blocked` / `fleet:design-unblocked` GitHub labels.
- Update worker, architect, and queue-manager role docs for the mid-task escalation cycle (escalate → architect responds → resume).
- Add cross-references in engine `CLAUDE.md` so the labels fit alongside the rest of the `fleet:*` vocabulary.

Claiming task. Work in progress.

Closes #342