### PR TITLE
T-064: engine/system docs: document 'no function-local static for system state' rule

### DIFF
--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -128,3 +128,7 @@ and should be moved to a system, builder, or namespace.
 - ❌ Cross-domain includes inside a prefab header (e.g. `voxel/` component
   including `audio/` component). Prefabs are grouped by domain on purpose;
   cross-domain composition belongs in a creation.
+- ❌ Function-local `static` for system-owned state. Use `SystemParams`
+  instead — same per-tick cost, correct lifetime, multi-instance safe.
+  See `engine/system/CLAUDE.md` "Don't use function-local `static` for
+  system state" for the rule, rationale, and canonical pattern.

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -66,6 +66,57 @@ The params are owned by the system entity and freed when the system is
 destroyed. **Do not store raw references to params across frames** — if the
 system is recreated (e.g. via reload), the pointer is invalid.
 
+### Don't use function-local `static` for system state
+
+Function-local `static` for system-owned state is an anti-pattern.
+Use `SystemParams` instead.
+
+**Why it's wrong:**
+- Hidden state — not visible to ECS inspectors or system-walking tools.
+- Lifetime mismatch — persists for program lifetime, doesn't free when the
+  system entity is destroyed.
+- Single-instance assumption — all instances of `System<X>` share the same
+  statics; future multi-instance use silently cross-talks.
+- Conflicts with the ECS "everything on an entity" philosophy.
+
+**Why the perf argument doesn't hold:** the canonical `SystemParams` pattern
+has the same per-tick access cost as `static`. Capture the pointer once at
+`create()` time and pass into lambdas by value — the pointer lookup happens
+once, not per tick.
+
+```cpp
+SystemId create() {
+    SystemId myId = ...;
+    setSystemParams(myId, std::make_unique<MyParams>());
+    auto* p = getSystemParams<MyParams>(myId);   // once, at create
+    return createSystem<...>(
+        "Name",
+        [p](C_Foo& foo) { p->bar += foo.x; },
+        [p]()           { p->bar = 0.0f; },
+        [p]()           { /* end-of-tick using p */ }
+    );
+}
+```
+
+**Exception:** truly invariant data — `constexpr` integer constants,
+named-resource pointers fetched once at engine init that never change — is
+fine as `static`. Those are program constants, not system state. The rule
+applies to *mutable* or *system-owned* state.
+
+**Current deviations** (migration tracked in T-065):
+- `engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_build_occupancy_grid.hpp`
+- `engine/prefabs/irreden/render/systems/system_fog_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp`
+- `engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp`
+- `engine/prefabs/irreden/render/systems/system_sprites_to_screen.hpp`
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp`
+- `engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp`
+
 ## Pipelines
 
 ```cpp

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -55,10 +55,12 @@ Go to (3) for bulk-processing opportunities (SIMD, sort, partition).
 ## Per-system parameters
 
 If a system needs persistent state beyond components (e.g. a GPU buffer
-handle, an accumulator), allocate a `SystemParams` subclass and attach:
+handle, an accumulator), allocate a `SystemParams` subclass. Call
+`setSystemParams` **after** `createSystem` — the system entity must exist
+first. See the canonical example in the section below.
 
 ```cpp
-setSystemParams(systemId, std::make_unique<MyParams>(...));
+// After createSystem returns systemId:
 auto& params = getSystemParams<MyParams>(systemId);
 ```
 

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -86,15 +86,16 @@ once, not per tick.
 
 ```cpp
 SystemId create() {
-    SystemId myId = ...;
-    setSystemParams(myId, std::make_unique<MyParams>());
-    auto* p = getSystemParams<MyParams>(myId);   // once, at create
-    return createSystem<...>(
+    auto paramsOwner = std::make_unique<MyParams>();
+    auto* p = paramsOwner.get();    // capture raw ptr before move
+    SystemId myId = createSystem<...>(
         "Name",
         [p](C_Foo& foo) { p->bar += foo.x; },
         [p]()           { p->bar = 0.0f; },
         [p]()           { /* end-of-tick using p */ }
     );
+    setSystemParams(myId, std::move(paramsOwner));
+    return myId;
 }
 ```
 


### PR DESCRIPTION
## Summary

- Added **"Don't use function-local `static` for system state"** subsection to `engine/system/CLAUDE.md` with: rule, 4-point rationale (hidden state, lifetime mismatch, single-instance assumption, ECS philosophy violation), perf-argument rebuttal, canonical `SystemParams` capture pattern, exception for truly invariant data, and the 12-file deviation list.
- Fixed `setSystemParams`/`createSystem` ordering in the intro example (must call `setSystemParams` after `createSystem` returns the system entity).
- Added cross-reference bullet to `engine/prefabs/CLAUDE.md`.
- `creations/CLAUDE.md` inherits from engine baseline — no change required.

## Test plan

- [x] Docs-only change — build not required
- [x] Rule, rationale, canonical shape, exception, and 12-file deviation list all present in `engine/system/CLAUDE.md`
- [x] Cross-reference in `engine/prefabs/CLAUDE.md` points to the new subsection
- [x] `creations/CLAUDE.md` confirmed to inherit the rule via engine baseline reference

Closes #343