### PR TITLE
T-074: Fleet docs: add silent-correctness rule coverage to review-pr + simplify (Tier 1)

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -173,6 +173,18 @@ compliance or raise an issue.
   `engine/system/include/irreden/ir_system_types.hpp`.
 - ❌ New component that isn't `C_`-prefixed, or whose public members don't
   have a trailing `_`.
+- ❌ `functionBeginTick` / `functionEndTick` declared with `Archetype&` or
+  any component parameter — they must be `void()`. The per-entity tick is
+  where entity data arrives; `begin`/`endTick` receive no entity args.
+- ❌ `endTick` reads `ids[0]` or indexes `ids` without a `ids.size() == 0`
+  guard — `begin`/`endTick` fire even when the archetype is empty.
+- ❌ system reads `C_Position3D` for visual placement instead of
+  `C_PositionGlobal3D + C_PositionOffset3D` — rendered position is always
+  Global + Offset (see `engine/CLAUDE.md`).
+- ❌ component method calls `IREntity::getComponent` / `setComponent` /
+  `createEntity` / `setParent` on a *different* entity (tier-c violation per
+  `engine/prefabs/CLAUDE.md`). Confirm the method appears on the documented
+  exceptions list before allowing.
 
 **Ownership / lifetime**
 - ❌ `shared_ptr` where `unique_ptr` would do.
@@ -181,13 +193,42 @@ compliance or raise an issue.
   archetype changes invalidate addresses.
 - ❌ Capturing `this` or references to World managers in lambdas that outlive
   the World (e.g. lua callbacks registered before World teardown).
+- ❌ Stored `g_*Manager` pointer or reference in any object whose lifetime
+  can outlive `World` (background threads, sol2 callback closures, long-lived
+  caches) — see `engine/world/CLAUDE.md` and `engine/CLAUDE.md`.
 
 **Render pipeline**
-- ❌ CPU frame-data struct out of sync with its GLSL `layout(std140)` counter-
-  part.
+- ❌ CPU frame-data struct out of sync with its GLSL `layout(std140)`
+  counterpart. `vec3` members pad to 16 bytes; array elements stride to 16
+  bytes; members crossing a 16-byte boundary need `alignas(16)`. If either
+  the C++ struct (in `engine/render/include/irreden/render/`) or its shader
+  `uniform` block changed, cross-reference both sides.
+- ❌ shader references `binding = N` but the C++ `kBufferIndex_*` constant
+  was not updated — the mismatch is silent (wrong uniforms, no error).
+  Confirm every bind-point index agrees on both sides.
 - ❌ New shader file not following the `c_` / `v_` / `f_` / `g_` prefix.
 - ❌ Canvas allocation before the canvas entity exists.
 - ❌ Compute dispatch size doesn't match `voxelDispatchGridForCount()`.
+- ❌ new `*.glsl` added without a matching `*.metal` counterpart (if parity
+  is intentionally deferred, the PR body must acknowledge it and reference a
+  follow-up task).
+
+**Lighting** (if the diff touches `system_*ao*`, `system_*shadow*`,
+`system_*flood*`, `system_*fog*`, `system_build_occupancy_grid*`, or any
+`c_compute_*shadow*.glsl` / `.metal`)
+- Check 1 (grid coverage): `system_build_occupancy_grid.hpp` iterates the
+  full voxel pool — it does **not** include `cull_viewport_state.hpp` and
+  does not call `visibleIsoViewport`. Off-screen geometry participates in
+  lighting by design.
+- Check 2 (shadow-ring extent): if chunk streaming is involved, the
+  resident-chunk set extends past the view frustum by
+  `maxCasterHeight × cot(sunAltitude)` in the sun-projection direction.
+- Check 3 (light-seed expansion): the flood-fill seed gather does not filter
+  by `visibleIsoViewport` without expanding by `C_LightSource::radius_`.
+  Off-screen light sources within radius must still seed on-screen tiles.
+- Check 4 (AO/shadow guard band): when chunk streaming is active, the
+  resident chunk set includes a 1-chunk guard band in all six directions for
+  correct AO neighbor-voxel sampling.
 
 **Math / coordinates**
 - ❌ Mixing 3D world coords with iso 2D coords without going through

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -85,6 +85,18 @@ Also flag (don't auto-fix):
 - A new prefab system that isn't added to `SystemName` in
   `engine/system/include/irreden/ir_system_types.hpp` (the system
   name enum is the registration mechanism).
+- `C_Position3D` read in a render-related system for visual placement
+  instead of `C_PositionGlobal3D + C_PositionOffset3D` — rendered
+  position is always Global + Offset. Flag; confirm the component is
+  intentional.
+- A component method that calls `IREntity::getComponent` /
+  `setComponent` / `createEntity` / `setParent` on a *different*
+  entity (tier-c violation per `engine/prefabs/CLAUDE.md`). Flag
+  unless the method is on the documented exceptions list.
+- `functionBeginTick` / `functionEndTick` declared with `Archetype&`
+  or any component parameter — they must be `void()`.
+- `endTick` body that reads `ids[0]` or indexes `ids` without first
+  guarding `ids.size() == 0`.
 
 ### 3. Naming convention slips
 
@@ -127,7 +139,11 @@ For files in `engine/render/` or shaders, check that the CPU
 frame-data struct in `engine/render/include/irreden/render/` is in
 sync with its GLSL `layout(std140)` counterpart — an out-of-sync pair
 silently corrupts uniform blocks. Cross-reference the two if either
-side changed.
+side changed. When checking: `vec3` members pad to 16 bytes, array
+elements stride to 16 bytes, members crossing a 16-byte boundary need
+`alignas(16)`. Also verify that every `binding = N` in the shader
+matches the C++ `kBufferIndex_*` constant — a bind-point mismatch is
+silent.
 
 Also check:
 - Canvas allocation before the canvas entity exists (race in init).
@@ -137,6 +153,16 @@ Also check:
 - 3D-world-coord values being mixed with iso-2D-coord values without
   going through `IRMath::pos3DtoPos2DIso` or a named helper. The two
   spaces are not interchangeable.
+
+If the diff touches `system_*ao*`, `system_*shadow*`, `system_*flood*`,
+`system_*fog*`, `system_build_occupancy_grid*`, or any
+`c_compute_*shadow*.glsl` / `.metal`, also flag:
+- Grid-build code that includes `cull_viewport_state.hpp` or calls
+  `visibleIsoViewport` — the occupancy grid must cover the full voxel
+  pool, not the render-culled subset.
+- Flood-fill seed gather filtered by `visibleIsoViewport` without
+  expanding by `C_LightSource::radius_` — off-screen sources must
+  still seed on-screen tiles.
 
 ### 6. Reuse opportunities (the highest-leverage check)
 


### PR DESCRIPTION
## Summary
- Add 5 Tier-1 silent-correctness checks to `review-pr/SKILL.md` and `simplify/SKILL.md` (issue #379, Tier 1)
- ECS: `beginTick`/`endTick` must be `void()` (no `Archetype&` arg); `endTick` must guard `ids.size()==0`; visual systems must use `C_PositionGlobal3D+Offset` not `C_Position3D`; component methods must not reach across entities (tier-c)
- Ownership: stored `g_*Manager` pointer in objects outliving `World`
- Render: full std140 alignment rules; binding-point index sync; new glsl-without-metal parity check; Lighting subsection with the four invariants from `engine/render/CLAUDE.md`

## Test plan
- [ ] Read both modified skill files and confirm all five Tier-1 items from issue #379 are present
- [ ] Confirm review-pr Lighting subsection matches the four checks in `engine/render/CLAUDE.md:238-293`
- [ ] Confirm simplify mirrors the ECS and render items as "also flag" entries
- [ ] No build required (docs-only)

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)