### PR TITLE
T-073: ECS: support non-default-constructible component types in EntityManager::setComponent

### DIFF
--- a/engine/entity/include/irreden/entity/entity_manager.hpp
+++ b/engine/entity/include/irreden/entity/entity_manager.hpp
@@ -131,18 +131,32 @@ class EntityManager {
         return m_pureComponentTypes[typeName];
     }
 
-    // Set component should return an ComponentId
-    // The ComponentId can be looked up to figure out what component it belongs to
-    // Therefore, it can be looked up in memory
+    // Insert (or overwrite) a component on an entity. Does NOT require the
+    // component to be default-constructible: the new-archetype path moves
+    // the entity, then push_backs the caller's value directly into the
+    // new column. Lets components like C_CanvasAOTexture `= delete` their
+    // default ctor and force a size-bearing ctor at the call site.
     template <typename Component>
     Component &setComponent(EntityId entity, const Component &component) {
         IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
-        Component &c = getInsertComponent<Component>(entity);
+        EntityRecord &record = getRecord(entity);
+        ComponentId componentType = getComponentType<Component>();
+
+        if (!record.archetypeNode->type_.contains(componentType)) {
+            return insertNewComponent<Component>(record, component);
+        }
+
+        IComponentDataImpl<Component> *data =
+            castComponentDataPointer<Component>(
+                record.archetypeNode->components_[componentType].get()
+            );
+        Component &c = data->dataVector[record.row];
         c = component;
         return c;
     }
 
-    template <typename Component> void insertDefaultComponent(EntityRecord &record) {
+    template <typename Component>
+    Component &insertNewComponent(EntityRecord &record, const Component &component) {
         ComponentId componentType = getComponentType<Component>();
         ArchetypeNode *fromNode = record.archetypeNode;
         Archetype type = fromNode->type_;
@@ -151,16 +165,17 @@ class EntityManager {
 
         moveEntityByArchetype(record, fromNode->type_, fromNode, toNode);
 
-        int insertedIndex =
-            insertComponent<Component>(toNode->components_[componentType].get(), Component{});
+        IComponentDataImpl<Component> *data =
+            castComponentDataPointer<Component>(toNode->components_[componentType].get());
+        data->dataVector.push_back(component);
 
         IR_ASSERT(
-            insertedIndex == toNode->length_ - 1,
-            "Component inserted at unexpected location."
+            static_cast<int>(data->dataVector.size()) == toNode->length_,
+            "Component column out of sync with archetype node row count."
         );
 
         IRE_LOG_DEBUG(
-            "Added default component type={} to entity={}: \n\
+            "Added component type={} to entity={}: \n\
                 \tnew row={}\n\
                 \tnew type={}",
             componentType,
@@ -168,25 +183,11 @@ class EntityManager {
             record.row,
             makeComponentStringInternal(type).c_str()
         );
-    }
-
-    EntityId setRelation(Relation relation, EntityId entity, EntityId relatedEntity);
-
-    template <typename Component> Component &getInsertComponent(EntityId entity) {
-        IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
-        EntityRecord &record = getRecord(entity);
-        ComponentId componentType = getComponentType<Component>();
-        Archetype archetype = record.archetypeNode->type_;
-
-        if (std::find(archetype.begin(), archetype.end(), componentType) == archetype.end()) {
-            insertDefaultComponent<Component>(record);
-        }
-        ArchetypeNode *node = record.archetypeNode;
-        IComponentDataImpl<Component> *data =
-            castComponentDataPointer<Component>(node->components_[componentType].get());
 
         return data->dataVector[record.row];
     }
+
+    EntityId setRelation(Relation relation, EntityId entity, EntityId relatedEntity);
 
     template <typename... Components>
     void setComponents(EntityId entity, const Components &...components) {
@@ -384,13 +385,6 @@ class EntityManager {
     int emplaceComponent(IComponentData *dest, Args &&...args) {
         IComponentDataImpl<Component> *d = castComponentDataPointer<Component>(dest);
         d->dataVector.emplace_back(std::forward<Args>(args)...);
-        int index = d->size() - 1;
-        return index;
-    }
-
-    template <typename Component> int insertComponent(IComponentData *dest, Component component) {
-        IComponentDataImpl<Component> *d = castComponentDataPointer<Component>(dest);
-        d->dataVector.push_back(component);
         int index = d->size() - 1;
         return index;
     }

--- a/engine/entity/include/irreden/entity/entity_manager.hpp
+++ b/engine/entity/include/irreden/entity/entity_manager.hpp
@@ -171,7 +171,8 @@ class EntityManager {
 
         IR_ASSERT(
             static_cast<int>(data->dataVector.size()) == toNode->length_,
-            "Component column out of sync with archetype node row count."
+            "Component column out of sync with archetype node row count "
+            "after push_back into new archetype column."
         );
 
         IRE_LOG_DEBUG(

--- a/engine/prefabs/irreden/render/components/component_canvas_ao_texture.hpp
+++ b/engine/prefabs/irreden/render/components/component_canvas_ao_texture.hpp
@@ -29,20 +29,13 @@ struct C_CanvasAOTexture {
               TextureFilter::NEAREST
           )} {}
 
-    // Required by EntityManager::setComponent, which default-constructs the
-    // destination slot before assigning the concrete sized component.
-    C_CanvasAOTexture() = default;
+    C_CanvasAOTexture() = delete;
 
     void onDestroy() {
         IRRender::destroyResource<Texture2D>(textureAO_.first);
     }
 
     const Texture2D *getTexture() const {
-        IR_ASSERT(
-            textureAO_.second != nullptr,
-            "C_CanvasAOTexture::getTexture() called on default-constructed "
-            "instance — must be constructed with a size."
-        );
         return textureAO_.second;
     }
 };

--- a/engine/prefabs/irreden/render/components/component_canvas_sun_shadow.hpp
+++ b/engine/prefabs/irreden/render/components/component_canvas_sun_shadow.hpp
@@ -31,20 +31,13 @@ struct C_CanvasSunShadow {
               TextureFilter::NEAREST
           )} {}
 
-    // Required by EntityManager::setComponent, which default-constructs the
-    // destination slot before assigning the concrete sized component.
-    C_CanvasSunShadow() = default;
+    C_CanvasSunShadow() = delete;
 
     void onDestroy() {
         IRRender::destroyResource<Texture2D>(textureShadow_.first);
     }
 
     const Texture2D *getTexture() const {
-        IR_ASSERT(
-            textureShadow_.second != nullptr,
-            "C_CanvasSunShadow::getTexture() called on default-constructed "
-            "instance — must be constructed with a size."
-        );
         return textureShadow_.second;
     }
 };

--- a/test/ecs/entity_manager_test.cpp
+++ b/test/ecs/entity_manager_test.cpp
@@ -1,6 +1,25 @@
 #include <gtest/gtest.h>
 #include <irreden/ir_entity.hpp>
 
+#include <irreden/render/components/component_canvas_ao_texture.hpp>
+#include <irreden/render/components/component_canvas_sun_shadow.hpp>
+
+#include <type_traits>
+
+// Issue #367: these canvas components must require an explicit size at
+// construction. Default-construction must be a compile error so a missing
+// size shows up at the call site rather than as a runtime null-texture.
+static_assert(
+    !std::is_default_constructible_v<IRComponents::C_CanvasAOTexture>,
+    "C_CanvasAOTexture must remain non-default-constructible — "
+    "size argument is required."
+);
+static_assert(
+    !std::is_default_constructible_v<IRComponents::C_CanvasSunShadow>,
+    "C_CanvasSunShadow must remain non-default-constructible — "
+    "size argument is required."
+);
+
 namespace {
 struct TestMarker {
 };
@@ -13,6 +32,14 @@ struct TestPayload {
 
     TestPayload() = default;
     explicit TestPayload(int value)
+        : value_{value} {}
+};
+
+struct TestNonDefaultConstructible {
+    int value_;
+
+    TestNonDefaultConstructible() = delete;
+    explicit TestNonDefaultConstructible(int value)
         : value_{value} {}
 };
 
@@ -155,5 +182,27 @@ TEST_F(IREntityTest, UnregisterPreDestroyHookStopsFiring) {
     auto entityB = IREntity::createEntity(TestMarker{});
     m_entity_manager.destroyEntity(entityB);
     EXPECT_EQ(fireCount, 1);
+}
+
+// setComponent must construct the new archetype slot directly from the
+// caller's value rather than default-construct + assign — components like
+// C_CanvasAOTexture rely on this so they can `= delete` their default ctor.
+TEST_F(IREntityTest, SetComponentSupportsNonDefaultConstructibleType) {
+    static_assert(
+        !std::is_default_constructible_v<TestNonDefaultConstructible>,
+        "Test component must remain non-default-constructible to be a "
+        "meaningful regression guard."
+    );
+
+    auto entity = IREntity::createEntity(TestMarker{});
+
+    IREntity::setComponent(entity, TestNonDefaultConstructible{7});
+
+    auto opt = IREntity::getComponentOptional<TestNonDefaultConstructible>(entity);
+    ASSERT_TRUE(opt.has_value());
+    EXPECT_EQ((*opt)->value_, 7);
+
+    IREntity::setComponent(entity, TestNonDefaultConstructible{42});
+    EXPECT_EQ(IREntity::getComponent<TestNonDefaultConstructible>(entity).value_, 42);
 }
 } // namespace


### PR DESCRIPTION
## Summary

`EntityManager::setComponent` previously default-constructed the new archetype slot then copy-assigned the caller's value. Every component type had to expose a default ctor — even GPU-texture-owning ones where the default-constructed state is meaningless. `C_CanvasAOTexture` and `C_CanvasSunShadow` documented this with `= default;` plus a runtime `IR_ASSERT` in `getTexture()` guarding the null-texture path.

This PR refactors the dispatch so `setComponent` push-backs the caller's value directly when the entity is moving to a new archetype, then deletes the default ctors on the two canvas components.

## Changes

**`engine/entity/include/irreden/entity/entity_manager.hpp`**
- `setComponent` now dispatches on whether the component already exists on the entity.
  - Existing slot: copy-assign over the slot (unchanged).
  - New slot: move the entity, then `push_back` the caller's value into the new column. No default construct.
- Collapsed `getInsertComponent` + `insertDefaultComponent` into a single `insertNewComponent(record, component)`.
- Membership check uses `Archetype::contains(componentType)` (O(log N) on the underlying `std::set`) instead of `std::find` (O(N)) with a redundant set copy.
- Removed the now-unused `insertComponent` private helper.

**`engine/prefabs/irreden/render/components/component_canvas_ao_texture.hpp`**, **`component_canvas_sun_shadow.hpp`**
- Default ctor: `= default` → `= delete`. Size-mismatch is now a compile error at the call site.
- Removed the now-unreachable runtime `IR_ASSERT` in `getTexture()`.

**`test/ecs/entity_manager_test.cpp`**
- New runtime test `SetComponentSupportsNonDefaultConstructibleType` guards the dispatch behavior.
- File-scope `static_assert`s lock the canvas components' contracts (compile-time regression guards per issue #367 acceptance criteria).

## Acceptance criteria (issue #367)

- [x] `C_CanvasAOTexture` / `C_CanvasSunShadow` have deleted default constructors.
- [x] Existing creation code that passes a size at construction continues to compile (`IRShapeDebug`, `IRLightingCombined` build clean).
- [x] A test that tries to default-construct one fails at compile time (file-scope `static_assert` in `entity_manager_test.cpp`).

## Test plan

- [x] `fleet-build --target IrredenEngineTest` clean
- [x] `fleet-build --target IRShapeDebug` clean
- [x] `fleet-build --target IRLightingCombined` clean
- [x] `IrredenEngineTest --gtest_brief=1` — 367/367 pass on macOS
- [ ] `fleet:needs-linux-smoke` — engine/entity changes affect the entire ECS hot path; cross-host validation recommended

## Notes for reviewer

- `C_CanvasFogOfWar` and `C_CanvasLightVolume` (sibling canvas components) still have default ctors that allocate textures + a now-dead `IR_ASSERT` in `getTexture()`. They're out of scope here — the issue tracks only AO and SunShadow — but a follow-up could apply the same `= delete` + drop-assert pattern.
- `setComponentDeferred` is unchanged; it already captures by value before queuing, so the new dispatch picks up automatically.

Closes #367