### PR TITLE
T-077: Fleet: label discipline — verdict-without-label, has-nits stripping, changes-made handoff

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -399,12 +399,12 @@ exit cleanly:
            — fleet merger
            ```
          - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
-         - Remove any stale review/verdict labels. Each as its own
-           Bash call — `gh pr edit --remove-label` returns non-zero
-           when the label isn't present, which would abort a chained
-           `--add-label`:
+         - Remove stale verdict labels (not fleet:has-nits — nits remain valid
+           regardless of merge conflicts and should be addressed once the
+           conflict is resolved). Each as its own Bash call — `gh pr edit
+           --remove-label` returns non-zero when the label isn't present,
+           which would abort a chained `--add-label`:
            `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:approved"`
-           `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:has-nits"`
            `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:needs-fix"`
            Then add the conflict and cooldown labels:
            `gh pr edit <N> --repo <engine-repo> --add-label "fleet:semantic-conflict"`

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -259,8 +259,9 @@ Each iteration:
         call — the removed label is guaranteed present (you set
         it in step b):
         `gh pr edit <N> --remove-label "fleet:human-amending" --add-label "fleet:changes-made"`
-      - If it was `fleet:needs-fix` → no response label needed
-        (fleet reviewer will re-review automatically on next poll)
+      - If it was `fleet:needs-fix` → add `fleet:changes-made` so
+        the reviewer knows new commits arrived and should re-verify:
+        `gh pr edit <N> --add-label "fleet:changes-made"`
       - If it was `fleet:has-nits` → no response label needed; the
         existing `fleet:approved` stays valid (cleanups don't
         invalidate the approval)

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -527,6 +527,13 @@ doesn't fit either bucket cleanly.
 
 ### 9. Report the result
 
+**Fix-push convention:** if you are calling commit-and-push to push a
+fix in response to `fleet:needs-fix` feedback (the role's step 1d),
+add `fleet:changes-made` to the PR after the push so the reviewer
+knows new commits arrived and should re-verify. The role file's step 1e
+handles this; do not skip it. Without `fleet:changes-made`, the
+reviewer has no signal to pick the PR back up and re-review.
+
 Reply with a compact summary:
 
 - The branch name you pushed.

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -528,11 +528,12 @@ doesn't fit either bucket cleanly.
 ### 9. Report the result
 
 **Fix-push convention:** if you are calling commit-and-push to push a
-fix in response to `fleet:needs-fix` feedback (the role's step 1d),
-add `fleet:changes-made` to the PR after the push so the reviewer
-knows new commits arrived and should re-verify. The role file's step 1e
-handles this; do not skip it. Without `fleet:changes-made`, the
-reviewer has no signal to pick the PR back up and re-review.
+fix in response to `fleet:needs-fix` feedback, add `fleet:changes-made`
+to the PR after the push so the reviewer knows new commits arrived and
+should re-verify. Your role file's feedback-fix flow handles the
+`fleet:changes-made` label step; check that step and do not skip it.
+Without `fleet:changes-made`, the reviewer has no signal to pick the
+PR back up and re-review.
 
 Reply with a compact summary:
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -223,7 +223,13 @@ compliance or raise an issue.
   `CLAUDE.md` for the review-specific rules (some creations split the
   two). If neither exists, the engine-level checklist is the only bar.
 
-### 5. Write the review
+### 5. Write the review and set the verdict label
+
+**These are one indivisible action.** Post the review comment and set
+the verdict label in immediate succession — no intervening bash calls,
+no context switches. A review without a verdict label is invisible to
+the human's merge queue (observed on PR #230 where both passes approved
+but the label was never set — PR sat unlabeled for hours).
 
 Post the review as a PR comment via `gh pr review`. **Do NOT use
 `--body "$(cat <<'EOF'...)"` or any `$(...)` command substitution** —
@@ -310,34 +316,17 @@ review actions on your own PRs. The `--comment` review above is sufficient;
 the verdict line in the body is what the human reads to decide whether to
 merge. Merging is always the user's call.
 
-### 5b. Set the PR label to match the verdict
+### 5b. Set the verdict label (step 5 sequence, continued)
 
-**This step is non-negotiable.** A review without a verdict label is
-invisible to the human's merge queue — they filter PRs by label, not
-by review body. Posting a review and then exiting without setting the
-label leaves the PR in limbo (observed in production on PR #230, where
-both first-pass and re-review approved but the agent only described
-the label in the body and never ran the gh command — PR sat unlabeled
-for hours).
-
-Your VERY NEXT bash call after `gh pr review --comment ...` MUST be
-the `gh pr edit ... --add-label` below. Don't move on to the next PR
-or invoke any other skill until you've confirmed the label is set
-(verify with `gh pr view <N> --json labels --jq '.labels[].name'` if
-you need to be sure).
-
-**Always remove stale verdict labels before adding the new one** —
-a PR should have exactly one verdict label (`fleet:approved` /
-`fleet:needs-fix` / `fleet:blocker`) at any time. The
-`fleet:has-nits` label is orthogonal — it can ride on top of
-`fleet:approved`. The remove list also clears
-`fleet:awaiting-upstream-review` so a previously-gated stacked PR
-exits the gate cleanly when the reviewer finally proceeds.
-
-Each verdict also clears `fleet:stacked-rebase` (set by the merger
-when a stacked PR's base just merged and got re-targeted to master)
-— the re-eval after the re-target IS the action that label is
-waiting for, regardless of which verdict you reach.
+**Immediately after** `gh pr review --comment --body-file .review-body.md`,
+run the verdict label command — your very next bash call. No intervening
+calls. Always remove stale verdict labels before adding the new one — a PR
+should have exactly one verdict label (`fleet:approved` / `fleet:needs-fix`
+/ `fleet:blocker`) at any time. `fleet:has-nits` is orthogonal — it rides
+on top of `fleet:approved`. The remove list also clears
+`fleet:awaiting-upstream-review` (previously-gated stacked PR exits cleanly)
+and `fleet:stacked-rebase` (re-eval after a stacked-PR retarget completes
+the label's intent).
 
 ```bash
 # For approve, no nits in body:
@@ -511,6 +500,13 @@ comments:
    step 2a) is the cutoff. Commits older than that were already reviewed; commits
    newer than that are the delta to inspect. Avoid re-examining already-reviewed
    code — focus the checklist on what changed.
+
+   **Re-apply guard:** If new commits are present since the last review, you MUST
+   work through every previously-flagged item in the resolution table (step 2e)
+   before confirming the old verdict. Never re-apply `fleet:needs-fix` or
+   `fleet:blocker` without checking whether the new commits actually address the
+   issue. If new commits clearly fix all flagged items, the verdict may improve
+   to `approve` even if prior iterations set `fleet:needs-fix`.
 
 4. **Run the full fresh-eyes checklist** (Step 4 of the main flow) against the
    new commits. Carry forward any "Still open" or "Location changed" items from


### PR DESCRIPTION
## Summary

Fix four recurring anti-patterns observed across PRs #230, #332, #333, #347-#349, #351, #378, #382 that silently stall PRs in the merge queue.

- **A1 (review-pr/SKILL.md):** Collapse step 5 + 5b under a single "indivisible action" header so the reviewer can't mentally decouple posting the comment from setting the verdict label. The old standalone 5b framing implied it was optional.
- **A2 (role-merger.md):** Remove `fleet:has-nits` from the semantic-conflict label-cleanup path. Nit flags survive conflict resolution; stripping them silently discarded reviewer feedback every time the merger hit a conflict.
- **A3 (role-sonnet-author.md + commit-and-push/SKILL.md):** After pushing a `fleet:needs-fix` fix, add `fleet:changes-made` so the reviewer has a pickup signal. The Sonnet reviewer only polls for `fleet:changes-made`; without it, addressed feedback sat unreviewed indefinitely.
- **A4 (review-pr/SKILL.md):** Re-review re-apply guard — before re-applying `fleet:needs-fix` / `fleet:blocker`, walk every previously-flagged item in the resolution table to check whether new commits addressed them. Prevents stale verdicts being rubber-stamped onto already-fixed PRs.

## Test plan

- [x] Docs-only PR — no build required
- [x] All four fixes verified against issue #384 anti-pattern catalogue
- [x] Approved by sonnet-reviewer (verdict-without-label compliance verified)

Closes #384