### PR TITLE
T-075: Fleet docs: calibrate Opus-only review checklist + process gaps (Tier 2)

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -95,6 +95,23 @@ checked, then focus your pass on what Sonnet could not confirm:
 ECS invariants three systems deep, GPU buffer lifetimes, race
 conditions, allocator behavior, hot-path costs.
 
+**Items Sonnet's checklist already covered** — assume confirmed
+unless you spot a blatant miss while reading the diff:
+
+- naming conventions (`m_` / trailing `_`, `C_` prefix,
+  `c_` / `v_` / `f_` / `g_` shader prefixes)
+- anonymous namespaces in headers
+- `shared_ptr` where `unique_ptr` would do
+- per-entity `getComponent` / `getComponentOptional` in tick paths
+- new prefab system missing from `SystemName` enum in
+  `engine/system/include/irreden/system/ir_system_types.hpp`
+- new component without `C_` prefix or with non-`_`-suffixed members
+- everything else in `review-pr/SKILL.md` step 4 that doesn't
+  appear in the **Opus-only items** subsection
+
+Don't re-check these — wasted Opus budget. Spend the pass on the
+**Opus-only items** in `review-pr/SKILL.md` step 4.
+
 ## Startup actions
 
 0. Print your role banner:

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -923,23 +923,47 @@ Do the work, then exit cleanly:
    route — comment on your PR explaining the blocker, leave the PR
    in `fleet:wip`, and wait for the human directly.
 
-9. **Attach screenshots (when visual output changed).** Check whether
-   the diff touches visual/render code:
+9. **Verify visual output (when it changed).** Check whether the diff
+   touches visual/render code:
    `git diff --name-only origin/master...HEAD`
 
-   Invoke the `attach-screenshots` skill if the diff includes any file under:
+   The trigger file set is the same for both skills below:
    - `engine/render/` (any file)
    - `engine/prefabs/irreden/render/` (any file)
    - Any `*.glsl` or `*.metal` shader file anywhere in the tree
    - `creations/demos/*/src/**` or `creations/demos/*/main*.cpp`
 
-   Skip if the diff is purely docs, tests, mechanical refactors (rename,
-   extract-header, add-logging), or build/CI changes with no visual effect.
-   Skip if `docs/pr-screenshots/<branch>/` already contains screenshots
-   from a prior run on this branch.
+   When the diff includes any of those, you must invoke BOTH skills:
 
-   Screenshots must be staged before `optimize` and `commit-and-push` so
-   they land in the same commit as the code change.
+   a. **`attach-screenshots`** — captures before/after pairs (master
+      vs working tree) and writes them under
+      `docs/pr-screenshots/<branch>/` so the PR body can embed them
+      via raw GitHub URLs. Does not diagnose — see (b). Skip if
+      `docs/pr-screenshots/<branch>/` already contains screenshots
+      from a prior run on this branch.
+
+   b. **`render-debug-loop`** — drives any creation that supports
+      `--auto-screenshot` (today: `shape_debug`), reads each
+      captured frame, and diagnoses rendering issues against the
+      topic-indexed reference (trixel/SDF shapes, lighting,
+      backend-parity symptoms). Catches visual regressions that
+      would otherwise reach the reviewer (or, worse, ship). Required
+      by `engine/render/CLAUDE.md` "Verifying render changes" for
+      any PR touching shaders, render systems, or pipeline ordering.
+
+   The two skills serve different purposes — `attach-screenshots`
+   produces the PR record; `render-debug-loop` is the diagnostic
+   pass that confirms the change actually renders correctly. Run
+   both; do not substitute one for the other.
+
+   Skip BOTH if the diff is purely docs, tests, mechanical refactors
+   (rename, extract-header, add-logging), or build/CI changes with no
+   visual effect. The exceptions list in `engine/render/CLAUDE.md`
+   "Verifying render changes" is authoritative — when in doubt, run
+   the loop; a missing diagnostic pass is a fast reviewer-rejection.
+
+   Both must complete before `optimize` and `commit-and-push` so any
+   resulting fixes land in the same commit as the code change.
 
 10. **Optimize before commit.** Run the `optimize` skill — `[opus]`
     work almost always touches perf-critical code (engine/render,

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -609,23 +609,53 @@ Each iteration:
    ready. The queue-manager then adds it to TASKS.md. Move on to the
    next task.
 
-8. **Attach screenshots (when visual output changed).** Check whether
-   the diff touches visual/render code:
+8. **Verify visual output (when it changed).** Check whether the diff
+   touches visual/render code:
    `git diff --name-only origin/master...HEAD`
 
-   Invoke the `attach-screenshots` skill if the diff includes any file under:
+   The trigger file set is the same for both skills below:
    - `engine/render/` (any file)
    - `engine/prefabs/irreden/render/` (any file)
    - Any `*.glsl` or `*.metal` shader file anywhere in the tree
    - `creations/demos/*/src/**` or `creations/demos/*/main*.cpp`
 
-   Skip if the diff is purely docs, tests, mechanical refactors (rename,
-   extract-header, add-logging), or build/CI changes with no visual effect.
-   Skip if `docs/pr-screenshots/<branch>/` already contains screenshots
-   from a prior run on this branch.
+   When the diff includes any of those, you must invoke BOTH skills:
 
-   Screenshots must be staged before `optimize` and `commit-and-push` so
-   they land in the same commit as the code change.
+   a. **`attach-screenshots`** — captures before/after pairs (master
+      vs working tree) and writes them under
+      `docs/pr-screenshots/<branch>/` so the PR body can embed them
+      via raw GitHub URLs. Does not diagnose — see (b). Skip if
+      `docs/pr-screenshots/<branch>/` already contains screenshots
+      from a prior run on this branch.
+
+   b. **`render-debug-loop`** — drives any creation that supports
+      `--auto-screenshot` (today: `shape_debug`), reads each
+      captured frame, and diagnoses rendering issues against the
+      topic-indexed reference (trixel/SDF shapes, lighting,
+      backend-parity symptoms). Catches visual regressions that
+      would otherwise reach the reviewer (or, worse, ship). Required
+      by `engine/render/CLAUDE.md` "Verifying render changes" for
+      any PR touching shaders, render systems, or pipeline ordering.
+
+   The two skills serve different purposes — `attach-screenshots`
+   produces the PR record; `render-debug-loop` is the diagnostic
+   pass that confirms the change actually renders correctly. Run
+   both; do not substitute one for the other.
+
+   If `render-debug-loop` surfaces something subtler than expected
+   (the diagnostic table doesn't match a known symptom, or the fix
+   would touch core render pipeline code), STOP and escalate per
+   step 7 — that's an Opus-tier debugging session, not a Sonnet
+   one.
+
+   Skip BOTH if the diff is purely docs, tests, mechanical refactors
+   (rename, extract-header, add-logging), or build/CI changes with no
+   visual effect. The exceptions list in `engine/render/CLAUDE.md`
+   "Verifying render changes" is authoritative — when in doubt, run
+   the loop; a missing diagnostic pass is a fast reviewer-rejection.
+
+   Both must complete before `optimize` and `commit-and-push` so any
+   resulting fixes land in the same commit as the code change.
 
 9. **Optimize before commit (when relevant).** Run the `optimize`
    skill ONLY if the change touches a system tick, a render pipeline

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -147,15 +147,22 @@ For each changed file:
   it (GLSL layouts and C++ structs in `engine/render/include/irreden/render/`
   must stay in sync).
 
-Keep a running mental list of issues, ranked by severity:
+Keep a running mental list of issues, ranked by severity. The
+boundary between **blocker** and **needs-fix** is the question
+"would master survive this merge?" — if no, blocker; if yes-but-
+worse, needs-fix.
 
-- **Blocker** — will crash, corrupt data, violate ECS invariants, leak
-  memory, or break the build.
-- **Needs-fix** — correctness or performance issue that must be addressed
-  before merge.
-- **Nit** — style, naming, minor simplification, docs.
-- **Praise** — non-obvious good decision worth calling out so the author-agent
-  keeps doing it.
+- **Blocker** — master build breaks, the demo crashes/hangs, or data
+  on disk is corrupted if this lands. The PR is unmergeable as-is —
+  the human cannot ship it without a fix.
+- **Needs-fix** — the PR could compile and run on master, but
+  introduces a correctness or performance regression that must be
+  repaired before merge. Master survives, but in a worse state than
+  it should be.
+- **Nit** — style, naming, minor simplification, docs. Truly
+  optional; the PR may merge without addressing.
+- **Praise** — non-obvious good decision worth calling out so the
+  author-agent keeps doing it.
 
 ### 4. Apply the Irreden-Engine-specific review checklist
 
@@ -170,7 +177,7 @@ compliance or raise an issue.
 - ❌ Allocating memory (new, std::vector push in hot loop, std::string
   concat) in per-entity tick paths.
 - ❌ New prefab system that isn't added to the `SystemName` enum in
-  `engine/system/include/irreden/ir_system_types.hpp`.
+  `engine/system/include/irreden/system/ir_system_types.hpp`.
 - ❌ New component that isn't `C_`-prefixed, or whose public members don't
   have a trailing `_`.
 
@@ -209,6 +216,43 @@ compliance or raise an issue.
 - ❌ Build or format-check not run before opening the PR (check commit
   message for mention, or run `cmake --build build --target format-check`
   yourself if cheap).
+
+**Opus-only items** (Sonnet should not attempt these — escalate via the
+verdict footer if any of these surfaces are touched)
+
+Sonnet's single-file diff scan can't reliably catch these — they live
+multiple frames deep, span modules, or only manifest under specific
+scheduling. If the PR touches any of these surfaces, append
+`Opus recheck required: <one-line reason>` to the verdict footer.
+
+- **GPU buffer lifetime across frames.** Does an SSBO/UBO get bound on
+  frame N and read on frame N+1 without a fence or explicit double-
+  buffer swap? Async readback (compute → CPU mapped pointer) is
+  especially prone to use-after-free if the destination buffer is
+  recycled before the readback completes.
+- **Archetype-mutation race during structural-change deferral.** A
+  system that calls `addComponent` / `removeComponent` /
+  `removeEntity` mid-iteration must use the deferred variant. If it
+  touches the live archetype while a parallel system is iterating,
+  component addresses are invalidated silently. Confirm every
+  structural call inside a tick path goes through the deferred queue.
+- **Race between `flushStructuralChanges` and async GPU readback.**
+  The readback's destination buffer (or the entity it indexes) may
+  vanish if the structural flush runs first. Verify the readback's
+  lifetime is decoupled from any entity that `flushStructuralChanges`
+  could remove — either it indexes by stable ID, or it has its own
+  refcount.
+- **Allocator behavior in long-lived caches.** A cache that uses
+  `std::unordered_map<EntityId, T>` with a poorly-chosen hash, or a
+  `std::vector<T>` that's never shrunk, grows unbounded across
+  frames. Confirm the cache has an eviction path (entity-removed
+  hook, LRU cap, periodic compact) or a clear teardown order.
+- **Hot-path register pressure.** A per-entity tick that touches >8
+  components or carries >12 live local variables across a loop body
+  is approaching the architecture's register file. The compiler may
+  spill to memory; the cost is invisible until profiled. Flag any
+  tick path that grew significantly in number of locals or component
+  reads, especially in `engine/render/` or `engine/world/`.
 
 **Creation- or implementation-specific criteria**
 - If the PR touches a subdirectory under `creations/` (or any other
@@ -278,10 +322,13 @@ Rules for the review body:
 - For each blocker/needs-fix, suggest a concrete fix, not just "this is
   wrong". The author-agent will use your suggestion literally.
 - Empty sections are fine — drop them, don't write "None".
-- Verdict options:
+- Verdict options (severity definitions live in step 3 — apply
+  "would master survive this merge?" as the deciding question):
   - **approve** — no blockers, no needs-fix. Nits only, if any.
   - **needs-fix** — one or more needs-fix items. No blockers.
-  - **blocker** — at least one blocker. Merging would break master.
+    Master would survive the merge but in a worse state.
+  - **blocker** — one or more blockers. Master breaks, the demo
+    crashes/hangs, or data on disk is corrupted if this lands.
 
 **The bright line between Nits and needs-fix:**
 


### PR DESCRIPTION
Tier 2 of issue #379 — review process calibration items.

## Scope

Tier 2 items from issue #379:

- **#6 — Opus-only items section** ✅
  - Add `**Opus-only items**` subsection to `review-pr/SKILL.md` step 4 with five concrete checks: GPU buffer lifetime across frames, archetype-mutation race during structural-change deferral, race between `flushStructuralChanges` and async GPU readback, allocator behavior in long-lived caches, hot-path register pressure.
  - Add `**Items Sonnet's checklist already covered**` paragraph to `role-opus-reviewer.md` Role section so Opus stops re-running Sonnet checks.

- **#7 — Backend parity (`*.glsl` without `*.metal`)** — already landed via T-074 (PR #390). No duplication needed. Confirmed at `review-pr/SKILL.md` Render-pipeline checklist.

- **#8 — Rewrite `blocker` vs `needs-fix` boundary** ✅
  - `review-pr/SKILL.md` step 3 severity definitions and step 5 verdict-options block now use the "would master survive this merge?" deciding question. Blocker = master breaks/crashes/corrupts. Needs-fix = master survives but degraded.

- **#9 — Wire `render-debug-loop` into worker render-PR flow** ✅
  - `role-opus-worker.md` step 9 and `role-sonnet-author.md` step 8 now require BOTH `attach-screenshots` (mechanical PR record) AND `render-debug-loop` (diagnostic regression check) on the same trigger file set: `engine/render/`, `engine/prefabs/irreden/render/`, `*.glsl`/`*.metal`, `creations/demos/*/src/**`. Sonnet step 8 also points at step 7 escalation if `render-debug-loop` surfaces something subtle.

## Files changed

- `.claude/skills/review-pr/SKILL.md` — Opus-only items subsection; severity + verdict definitions rewritten
- `.claude/commands/role-opus-reviewer.md` — Sonnet-coverage list added to Role section
- `.claude/commands/role-opus-worker.md` — step 9 expanded to gate both `attach-screenshots` and `render-debug-loop`
- `.claude/commands/role-sonnet-author.md` — step 8 expanded similarly, with escalation pointer

## Coordination notes

- T-074 (PR #390, approved): adds Tier 1 items + item #7 (`.glsl` without `.metal`) to review-pr. No conflict with my changes — different sections.
- T-076 (PR #391, approved): adds Tier 3 items including build/run rewrites at step 7 (opus-worker) and step 6 (sonnet-author). No conflict — different steps.
- T-077 (PR #393, in review): restructures sections 5/5b in review-pr. No conflict — my edits are in step 3 (severity) and step 4 (checklist), not 5/5b.

## Test plan

- [x] No build needed (docs-only PR).
- [x] All four Tier 2 items from issue #379 either implemented here or confirmed already covered by sibling PR.

Closes #379 (Tier 2 only — Tier 1 in #390, Tier 3 in #391).