### PR TITLE
T-080: Fleet: orchestration calibration — babysit cooldown, fleet-claim git-aware, stale-status auto-flip

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -568,6 +568,32 @@ You are the sole TASKS.md editor. Each maintenance pass:
    `git -C <repo> show origin/master:.fleet/plans/T-<NNN>.md` per
    the role-opus-worker startup actions).
 
+5d. **Auto-flip stale `[~]` tasks whose branch merged to master.**
+   Step 4 flips tasks by matching merged PR titles/branches. A gap
+   exists when the PR was merged but the title match failed (e.g.
+   title drift, task-ID prefix missing, multi-task legacy PRs) — the
+   task stays `[~]` indefinitely until a human fixes it.
+
+   For each `[~]` (in-progress) task in each TASKS.md whose `Owner:`
+   field contains a branch name (starts with `claude/`):
+   a. Check whether the branch tip is an ancestor of `origin/master`:
+      `git -C <repo> fetch origin --quiet`
+      `git -C <repo> merge-base --is-ancestor origin/<branch> origin/master`
+      Exit 0 = branch is merged; exit non-zero = branch still open or
+      unknown.
+   b. If merged (exit 0) AND the task has no PR URL in its `**Links:**`
+      field yet, find the merged PR:
+      `gh pr list --repo <repo> --state merged --head <branch> --json number,url --jq '.[0].url'`
+   c. If merged: flip the task to `[x]`, add the PR URL (if found)
+      to **Links:**, move to `## Done — last 20`, and delete plan
+      files (same cleanup as step 4).
+
+   Skip tasks whose `Owner:` is `free` or does not start with
+   `claude/` — there's no branch to check.
+
+   Run this pass BEFORE step 6 so the blocker-resolution pass
+   sees up-to-date `[x]` status for freshly-flipped tasks.
+
 6. **Resolve stale blocker references.** Scan all `## Open` entries in
    each TASKS.md. For any `Blocked by:` field that contains:
    - A free-text title that now matches an existing task → replace

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -99,6 +99,13 @@ MAX_ATTEMPTS=200      # safety valve — prevents infinite loops on hard failure
 # Set via env to override.
 LONG_BACKOFF_SECONDS="${FLEET_LONG_BACKOFF:-1800}"
 
+# Suppress trigger wakes until this many seconds have elapsed since the iteration
+# started. Prevents the scout's own trigger (fired ~60s after state change) from
+# immediately relaunching an agent that just exited cleanly. Set to 0 (default)
+# to preserve trigger-driven immediacy; fleet-up sets FLEET_MIN_BACKOFF=1800 for
+# opus-reviewer to enforce the 30-min budget window.
+MIN_BACKOFF_SECONDS="${FLEET_MIN_BACKOFF:-0}"
+
 # Convert a Claude-style interval ("20m", "3m", "1h", "30s") into seconds.
 # This replaces what /loop used to do internally, so that babysit can
 # enforce the between-iteration delay at the *process* level (each
@@ -158,22 +165,32 @@ consume_trigger_if_present() {
 #   2 = trigger file appeared mid-sleep (caller should consume + relaunch)
 #
 # Pass the trigger path as $2 to enable trigger watching; omit to keep
-# the legacy shutdown-only behavior. Polls every 5s.
+# the legacy shutdown-only behavior. Pass min_floor as $3 to suppress
+# trigger wakes until at least that many seconds have elapsed — prevents
+# the agent's own actions from immediately waking it via the scout
+# (see FLEET_MIN_BACKOFF / MIN_BACKOFF_SECONDS). Polls every 5s.
 interruptible_sleep() {
     local seconds="$1"
     local trigger_path="${2:-}"
-    local end=$(( $(date +%s) + seconds ))
-    while [[ $(date +%s) -lt $end ]]; do
+    local min_floor="${3:-0}"
+    local started_at
+    started_at=$(date +%s)
+    local end=$(( started_at + seconds ))
+    local now
+    while now=$(date +%s); [[ $now -lt $end ]]; do
         if [[ -f "$SHUTDOWN_FLAG" ]]; then
             return 1
         fi
         if [[ -n "$trigger_path" && -f "$trigger_path" ]]; then
-            return 2
+            local elapsed=$(( now - started_at ))
+            if [[ $elapsed -ge $min_floor ]]; then
+                return 2
+            fi
         fi
         # Keep heartbeat fresh during between-iteration wait.
         [[ -n "$HEARTBEAT_FILE" ]] && touch "$HEARTBEAT_FILE" 2>/dev/null || true
         # Sleep at most 5s at a time, but never longer than what's left.
-        local remaining=$(( end - $(date +%s) ))
+        local remaining=$(( end - now ))
         local chunk=5
         [[ "$remaining" -lt "$chunk" ]] && chunk="$remaining"
         [[ "$chunk" -lt 1 ]] && chunk=1  # Minimum 1s to avoid zero-sleep busyloop on sub-second remaining time.
@@ -526,7 +543,7 @@ while true; do
                     log "worker clean exit (attempt $attempt) — bootstrap relaunch in ${sleep_dur}s (no trigger consumed yet)"
                 fi
                 rc=0
-                interruptible_sleep "$sleep_dur" "$TRIGGER_FILE" || rc=$?
+                interruptible_sleep "$sleep_dur" "$TRIGGER_FILE" "$MIN_BACKOFF_SECONDS" || rc=$?
                 case $rc in
                     1)
                         log "shutdown signaled during between-iteration wait — exiting"

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -121,12 +121,13 @@ with open(tasks_file) as f:
     content = f.read()
 
 # Parse task entries: find each "- [x]/[ ]/[~]/[!] **Title**" block
-# and extract its ID, title, and Blocked by fields.
+# and extract its ID, title, Blocked by, and Owner fields.
 tasks = {}
 current_id = None
 current_status = None
 current_blocked = None
 current_title = None
+current_owner = None
 
 for line in content.splitlines():
     # Task header line: - [x] **Title** — ...
@@ -136,12 +137,14 @@ for line in content.splitlines():
             tasks[current_id] = {
                 'status': current_status,
                 'blocked_by': current_blocked or '(none)',
-                'title': current_title or ''
+                'title': current_title or '',
+                'owner': current_owner or 'free',
             }
         current_status = m.group(1)
         current_title = m.group(2)
         current_id = None
         current_blocked = None
+        current_owner = None
         continue
 
     # Sub-field lines (indented under the task)
@@ -155,12 +158,18 @@ for line in content.splitlines():
         current_blocked = m_blocked.group(1).strip()
         continue
 
+    m_owner = re.match(r'^\s+- \*\*Owner:\*\*\s*(.+)', line)
+    if m_owner:
+        current_owner = m_owner.group(1).strip()
+        continue
+
 # Don't forget the last task
 if current_id:
     tasks[current_id] = {
         'status': current_status,
         'blocked_by': current_blocked or '(none)',
-        'title': current_title or ''
+        'title': current_title or '',
+        'owner': current_owner or 'free',
     }
 
 # Find our task
@@ -187,7 +196,24 @@ for blocker in blockers:
             continue
         if blocker in tasks:
             if tasks[blocker]['status'] != 'x':
-                failed.append(f"{blocker} (status: [{tasks[blocker]['status']}], need: [x])")
+                # TASKS.md says not done, but the branch may already be merged
+                # into origin/master (queue-manager hasn't run its flip yet).
+                # git merge-base --is-ancestor catches this gap.
+                branch = tasks[blocker].get('owner', 'free')
+                resolved_via_git = False
+                if branch and branch not in ('free', '(none)', ''):
+                    try:
+                        r = subprocess.run(
+                            ['git', 'merge-base', '--is-ancestor',
+                             f'origin/{branch}', 'origin/master'],
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                            timeout=10
+                        )
+                        resolved_via_git = (r.returncode == 0)
+                    except (subprocess.SubprocessError, OSError):
+                        pass
+                if not resolved_via_git:
+                    failed.append(f"{blocker} (status: [{tasks[blocker]['status']}], need: [x])")
         else:
             # Blocker not found in this TASKS.md — might be cross-repo.
             # Check the other TASKS.md (engine ↔ game).

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -203,6 +203,9 @@ for blocker in blockers:
                 resolved_via_git = False
                 if branch and branch not in ('free', '(none)', ''):
                     try:
+                        # No `git fetch origin` here intentionally: stale refs
+                        # produce false-negatives (claim fails until next fetch),
+                        # never false-positives (unmerged branch treated as done).
                         r = subprocess.run(
                             ['git', 'merge-base', '--is-ancestor',
                              f'origin/{branch}', 'origin/master'],

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -28,6 +28,10 @@ SESSION="fleet"
 OPUS_MODEL="claude-opus-4-7"
 SONNET_MODEL="sonnet"   # alias is fine for sonnet — budget is cheap
 
+# Minimum seconds between opus-reviewer relaunches (cooldown floor).
+# fleet-babysit reads this via FLEET_MIN_BACKOFF; keep the two in sync.
+OPUS_MIN_BACKOFF=1800
+
 if ! command -v tmux >/dev/null 2>&1; then
     echo "fleet-up: tmux not found. Install tmux (brew install tmux / apt install tmux) first." >&2
     exit 1
@@ -559,7 +563,7 @@ label_pane_id "$BOT_MID" "opus-worker-2 [opus 4.7]"
 
 BOT_RIGHT=$(tmux split-window -h -t "$BOT_MID" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
-    "FLEET_MIN_BACKOFF=1800 $(launch_cmd "$OPUS_MODEL" opus-reviewer 30m)")
+    "FLEET_MIN_BACKOFF=$OPUS_MIN_BACKOFF $(launch_cmd "$OPUS_MODEL" opus-reviewer 30m)")
 label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.7]"
 
 # --- Window 2: "ops" — 2x2 grid ---------------------------------------

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -559,7 +559,7 @@ label_pane_id "$BOT_MID" "opus-worker-2 [opus 4.7]"
 
 BOT_RIGHT=$(tmux split-window -h -t "$BOT_MID" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
-    "$(launch_cmd "$OPUS_MODEL" opus-reviewer 30m)")
+    "FLEET_MIN_BACKOFF=1800 $(launch_cmd "$OPUS_MODEL" opus-reviewer 30m)")
 label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.7]"
 
 # --- Window 2: "ops" — 2x2 grid ---------------------------------------


### PR DESCRIPTION
## Summary
- **D2**: `fleet-babysit` + `fleet-up` enforce a 30-min minimum backoff for the opus-reviewer. Added `MIN_BACKOFF_SECONDS` and `min_floor` param to `interruptible_sleep()` so scout triggers during the budget window can't cause premature relaunches. `fleet-up` passes `FLEET_MIN_BACKOFF=1800` for the opus-reviewer pane.
- **D3**: `fleet-claim` blocker check now uses `git merge-base --is-ancestor` as a fallback when TASKS.md shows a blocker as `[~]`. Parses the `Owner:` field to get the branch name and resolves merged branches even before the queue-manager's next maintenance pass flips the status.
- **D4**: `role-queue-manager.md` gains step 5d instructing the queue-manager to auto-flip stale `[~]` tasks whose `Owner:` branch has merged to master. Runs before step 6 so blocker-resolution sees fresh `[x]` statuses.

## Test plan
- [ ] `fleet-babysit`: confirm opus-reviewer with `FLEET_MIN_BACKOFF=1800` ignores scout triggers for 30 min after clean exit
- [ ] `fleet-claim claim T-NNN`: with a blocker whose TASKS.md status is `[~]` but whose branch is merged, claim should succeed
- [ ] `fleet-claim claim T-NNN`: with a blocker whose branch is NOT merged and status is `[~]`, claim should still fail with clear error
- [ ] `role-queue-manager.md` step 5d: verify instruction text is correctly positioned before step 6

## Notes for reviewer
- `interruptible_sleep` now caches `date +%s` once per poll iteration (used for end check, elapsed, and remaining) to avoid triple-syscall per 5s tick.
- Exception handler in the `merge-base` subprocess call narrowed from `except Exception` to `except (subprocess.SubprocessError, OSError)` to avoid silencing non-git errors.

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)