### PR TITLE
T-078: fleet: worktree contention — extend branch-lock filter, abort merger rebase, doc path prefix

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -179,6 +179,22 @@ exit cleanly:
    CONFLICTING list already has ≥2 candidates, defer all UNKNOWN
    refreshes to the next iteration.
 
+3.5. **Drop candidates whose head branch is held by another worktree.**
+   A branch can only be checked out in one worktree at a time. If an
+   opus-worker is mid-resolution of `fleet:semantic-conflict` on
+   `claude/T-NNN-foo`, step 5a's `git checkout -B claude/T-NNN-foo`
+   will fail with "branch is already used by worktree at …" and the
+   merger has no useful work it can do on that PR this iteration.
+
+   List the busy branches once (any path inside the engine clone
+   resolves to the same worktree set):
+   `fleet-worktree-busy-branches`
+
+   For each candidate from step 3, drop it if its `headRefName`
+   appears in that list. The dropped candidate stays in flight under
+   whichever worktree holds it; retry on the next iteration. Log:
+   `… N candidates dropped (branch held by another worktree)`.
+
 4. **Process at most 2 candidates per iteration.** Auto-resolution
    pushes a force-with-lease, which retriggers CI and reviewers.
    Don't flood. Pick the oldest two (lowest PR number).
@@ -371,6 +387,13 @@ exit cleanly:
 
       **iii. Anything else (semantic conflict).**
          - `git rebase --abort`
+         - **Immediately switch back to scratch** so the PR's branch is
+           released even if the steps below crash or hit a usage limit
+           before step f runs. Otherwise the next agent that tries to
+           `gh pr checkout` this branch hits "branch is already used by
+           worktree at .../merger" and the conflict-resolution lane is
+           unreachable until the merger reboots:
+           `git switch claude/merger-scratch`
          - Build a description of the conflict. Cap the file list at
            5; if more files conflict, append `… and N more` so the
            comment stays readable. For each listed file, run

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -399,7 +399,10 @@ exit cleanly:
            comment stays readable. For each listed file, run
            `git log -1 --format="%h %s" origin/master -- <file>` to
            identify what touched it on master, and
-           `git log -1 --format="%h %s" -- <file>` for the PR side.
+           `git log -1 --format="%h %s" origin/<headRefName> -- <file>`
+           for the PR side. The `origin/<headRefName>` ref is required
+           because `git switch claude/merger-scratch` left HEAD on
+           master — a bare `git log -- <file>` would log master twice.
            Write to `.merger-body.md`:
            ```
            Merger: cannot auto-resolve mechanically. The PR has

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -251,17 +251,14 @@ Do the work, then exit cleanly:
    failure (`branch is already used by worktree at ...`) after
    you've already invested reasoning.
 
-   List other worktrees and their branches in one call:
-   `git -C ~/src/IrredenEngine worktree list --porcelain`
+   List the busy branches in each repo with the shared helper. It
+   reads `git worktree list --porcelain` and emits one branch name
+   per line, excluding the caller's own worktree:
+   `fleet-worktree-busy-branches --repo ~/src/IrredenEngine`
+   `fleet-worktree-busy-branches --repo ~/src/IrredenEngine/creations/game`
 
-   The output groups each worktree as 3 lines (`worktree <path>`,
-   `HEAD <sha>`, `branch refs/heads/<name>`). Build a set of
-   `<name>` values from worktrees whose path is NOT your own (i.e.,
-   skip the line group whose `worktree` matches `pwd`). For each
-   feedback PR in `repos.engine.prs[]`, match its `headRefName`
-   against that set; skip the PR if its head branch is in the set.
-   The same check applies to game-side PRs against
-   `git -C ~/src/IrredenEngine/creations/game worktree list --porcelain`.
+   For each feedback PR, match its `headRefName` against the relevant
+   repo's list; skip the PR if its head branch is in the set.
 
    For each flagged PR (after the filter):
    a. Read **all** feedback (two separate commands):
@@ -446,6 +443,15 @@ Do the work, then exit cleanly:
     (stacked PR), look up the base PR in the cached `prs[]` by its
     `headRefName`. If the base PR also has `fleet:semantic-conflict`,
     SKIP this candidate — resolve the base first.
+
+    **Branch-lock filter.** `gh pr checkout <N>` fails with "branch is
+    already used by worktree at …" when another agent (typically the
+    merger mid-rebase, or another opus-worker that also picked up the
+    PR) already has the branch checked out. List the busy branches
+    once and drop any candidate whose `headRefName` appears there:
+    `fleet-worktree-busy-branches`
+    Mirrors the same filter used by the feedback PR pickup loop in
+    step 1 (PR #336) and the merger's step 3.5.
 
     Game repo is intentionally out of scope for v1: the merger is
     engine-only, so no game PR ever gets the label.
@@ -1060,4 +1066,16 @@ human can tell which opus-worker observed what. See top-level
   Read only the file matching your task ID. Authority for "who works
   on what" lives in TASKS.md `Owner:` and `fleet-claim` locks; nothing
   else.
+- **Edit/Write paths must stay inside your worktree.** The parent
+  clone at `/Users/evinjkill/src/IrredenEngine/` (no `.claude/worktrees/`
+  in the path) and your worktree at
+  `.../.claude/worktrees/<your-basename>/` both contain the same tree
+  shape, so an Edit aimed at the parent's absolute path will succeed
+  silently — but your build runs against the worktree, so the edit
+  appears to "do nothing" while quietly orphaning changes in the
+  parent clone (potentially clobbering another agent's work). Prefer
+  relative paths from your worktree's cwd. If you must use an
+  absolute path, it MUST start with
+  `/Users/evinjkill/src/IrredenEngine/.claude/worktrees/<your-basename>/`.
+  Re-confirm with `pwd` if unsure.
 - Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -155,15 +155,14 @@ Each iteration:
    failure (`branch is already used by worktree at ...`) after
    you've already invested reasoning.
 
-   List other worktrees and their branches in one call:
-   `git -C ~/src/IrredenEngine worktree list --porcelain`
+   List the busy branches with the shared helper. It reads
+   `git worktree list --porcelain` and emits one branch name per
+   line, excluding the caller's own worktree:
+   `fleet-worktree-busy-branches`
 
-   The output groups each worktree as 3 lines (`worktree <path>`,
-   `HEAD <sha>`, `branch refs/heads/<name>`). Build a set of
-   `<name>` values from worktrees whose path is NOT your own (i.e.,
-   skip the line group whose `worktree` matches `pwd`). For each
-   feedback PR in `repos.engine.prs[]`, match its `headRefName`
-   against that set; skip the PR if its head branch is in the set.
+   For each feedback PR in `repos.engine.prs[]`, match its
+   `headRefName` against the helper's output; skip the PR if its
+   head branch is in the set.
 
    For each flagged PR (after the filter):
    a. Read **all** feedback (two separate commands):
@@ -724,4 +723,16 @@ the human can tell which sonnet pane observed what. See top-level
   finish the flow. Don't invoke `simplify` standalone — let
   `commit-and-push` invoke it for you, so the commit step is
   guaranteed to follow.
+- **Edit/Write paths must stay inside your worktree.** The parent
+  clone at `/Users/evinjkill/src/IrredenEngine/` (no `.claude/worktrees/`
+  in the path) and your worktree at
+  `.../.claude/worktrees/<your-basename>/` both contain the same tree
+  shape, so an Edit aimed at the parent's absolute path will succeed
+  silently — but your build runs against the worktree, so the edit
+  appears to "do nothing" while quietly orphaning changes in the
+  parent clone (potentially clobbering another agent's work). Prefer
+  relative paths from your worktree's cwd. If you must use an
+  absolute path, it MUST start with
+  `/Users/evinjkill/src/IrredenEngine/.claude/worktrees/<your-basename>/`.
+  Re-confirm with `pwd` if unsure.
 - Single-command Bash only (see CRITICAL section above).

--- a/scripts/fleet/fleet-worktree-busy-branches
+++ b/scripts/fleet/fleet-worktree-busy-branches
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# fleet-worktree-busy-branches — list branches held by other worktrees.
+#
+# A branch can only be checked out in one worktree at a time; git refuses
+# `gh pr checkout`, `git checkout -B`, etc. with "branch is already used
+# by worktree at ..." otherwise. Multiple fleet roles need to know
+# "is this PR's branch held elsewhere?" before trying to take it:
+#
+#   - sonnet-author / opus-worker feedback PR pickup (PR #336 lifted this
+#     out of an inline awk loop into a role-doc note; agents kept burning
+#     reasoning before hitting the gh pr checkout failure).
+#   - merger candidate selection (when an opus-worker is mid-resolution
+#     of fleet:semantic-conflict, the merger trying the same branch
+#     always fails).
+#   - opus-worker step 1c semantic-conflict resolution.
+#
+# Outputs one branch name per line on stdout (no `refs/heads/` prefix),
+# suitable for `grep -F -x` filtering.
+#
+# Usage:
+#   fleet-worktree-busy-branches [--exclude <path>] [--repo <path>]
+#
+# Options:
+#   --exclude <path>   Worktree path to exclude (the caller's own worktree).
+#                      Default: $PWD (the cwd's worktree).
+#   --repo <path>      Repo root to query. Default: $PWD's git toplevel.
+#
+# Source of truth: scripts/fleet/fleet-worktree-busy-branches in the engine
+# repo. Installed to ~/bin/ by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+exclude_path=""
+repo_path=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --exclude)
+            exclude_path="$2"
+            shift 2
+            ;;
+        --repo)
+            repo_path="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "fleet-worktree-busy-branches: unknown arg '$1'" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$repo_path" ]]; then
+    repo_path="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -z "$repo_path" ]]; then
+        echo "fleet-worktree-busy-branches: not in a git repo and no --repo given" >&2
+        exit 2
+    fi
+fi
+
+if [[ -z "$exclude_path" ]]; then
+    exclude_path="$PWD"
+fi
+
+# Resolve both paths so the comparison is symlink-safe and trailing-slash-
+# safe. `realpath -m` doesn't fail on missing tail components, but we expect
+# both to exist; pwd -P would also work but is awk-unfriendly.
+exclude_real="$(cd "$exclude_path" 2>/dev/null && pwd -P || echo "$exclude_path")"
+
+git -C "$repo_path" worktree list --porcelain | awk -v exclude="$exclude_real" '
+    /^worktree / {
+        wt = $2
+        next
+    }
+    /^branch refs\/heads\// {
+        if (wt != exclude) {
+            sub(/^branch refs\/heads\//, "", $0)
+            print
+        }
+    }
+'

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -82,6 +82,8 @@ FLEET_SCOUT_SRC="$SCRIPT_DIR/fleet-state-scout"
 FLEET_SCOUT_DEST="$HOME/bin/fleet-state-scout"
 FLEET_FEEDBACK_SRC="$SCRIPT_DIR/fleet-feedback"
 FLEET_FEEDBACK_DEST="$HOME/bin/fleet-feedback"
+FLEET_BUSY_SRC="$SCRIPT_DIR/fleet-worktree-busy-branches"
+FLEET_BUSY_DEST="$HOME/bin/fleet-worktree-busy-branches"
 WITNESS_SRC="$SCRIPT_DIR/witness"
 WITNESS_DEST="$HOME/bin/witness"
 
@@ -93,7 +95,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -155,6 +157,11 @@ fi
 if [[ -f "$FLEET_FEEDBACK_SRC" ]]; then
     ln -sf "$FLEET_FEEDBACK_SRC" "$FLEET_FEEDBACK_DEST"
     echo "symlinked $FLEET_FEEDBACK_DEST -> $FLEET_FEEDBACK_SRC"
+fi
+
+if [[ -f "$FLEET_BUSY_SRC" ]]; then
+    ln -sf "$FLEET_BUSY_SRC" "$FLEET_BUSY_DEST"
+    echo "symlinked $FLEET_BUSY_DEST -> $FLEET_BUSY_SRC"
 fi
 
 if [[ -f "$WITNESS_SRC" ]]; then


### PR DESCRIPTION
## Summary

Three recurring worktree-contention bugs from `~/.fleet/feedback/{merger,opus-worker-1,opus-worker-2,sonnet-author}.md` (2026-04-29 → 2026-04-30), all per issue #385:

**B1 — merger leaves rebase state on give-up path.** `role-merger.md` case (iii) now does `git rebase --abort && git switch claude/merger-scratch` immediately, before the comment/label edits. The old flow relied on step f to switch back; a crash or usage-limit exit between abort and step f left the worktree on the PR's branch and blocked `gh pr checkout` for the next agent (observed on PR #333).

**B2 — branch-lock filter only at one site.** Lifted PR #336's inline awk parse into `scripts/fleet/fleet-worktree-busy-branches`. Applied at:
- `role-merger.md` step 3.5 (new — drop candidates whose head branch is held)
- `role-opus-worker.md` step 1c (semantic-conflict resolution)
- `role-opus-worker.md` step 1 + `role-sonnet-author.md` step 1 (feedback-PR pickup, replacing the old inline parser)

`scripts/fleet/install.sh` symlinks the new helper into `~/bin/`.

**B3 — Edit/Write to parent-clone absolute paths.** Added a Hard rule to `role-opus-worker.md` and `role-sonnet-author.md`: absolute paths in Edit/Write must start with `.../IrredenEngine/.claude/worktrees/<your-basename>/`, not the parent clone. Doc-only fix per the alternative listed in the issue; no settings.json hook (avoids global behavior change for all agents).

Out of scope: a `PreToolUse:Edit|Write` hook to enforce B3 (issue listed it as the more-intrusive option). The doc rule covers the observed failure mode without adding harness behavior.

## Test plan

- [x] `fleet-worktree-busy-branches` correctly excludes caller's worktree (verified locally; output matches `git worktree list --porcelain` minus self).
- [x] `--help`, `--exclude <path>`, `--repo <path>` flags all work.
- [x] `install.sh` symlinks the new helper alongside the existing fleet helpers (re-running the existing chmod loop handles +x).
- [ ] Reviewer: verify merger case (iii) abort+switch is at the right point in the flow (before comment/label edits, not after).
- [ ] Reviewer: confirm `role-opus-worker.md` step 1's `--repo` paths point at engine and game correctly (helper auto-detects when called without `--repo`, but step 1 walks both repos so explicit `--repo` is correct there).

Closes #385