### PR TITLE
T-081: review-pr: detect oversized churn on CONFLICTING PRs + forked-from-other-PR signal

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -174,6 +174,7 @@ exit cleanly:
    - `human:blocker` — same
    - `human:re-review` — reviewer concern; not the merger's lane
    - `fleet:awaiting-base` — stacked PR waiting on its base to merge; skip until base merges/closes and sub-case ii/iii removes this label
+   - `fleet:fork-of-other-pr` — PR's branch forked from another open PR; skip until the human clears this label after the upstream PR merges
 
    **Cap UNKNOWN-state refreshes at 2 per iteration.** If the
    CONFLICTING list already has ≥2 candidates, defer all UNKNOWN
@@ -267,6 +268,53 @@ exit cleanly:
       are derived-state convenience labels for human visibility. Author
       roles add `fleet:stacked` at PR creation; the merger maintains
       `fleet:awaiting-base` / `fleet:stacked-rebase` as above.
+
+   **a.6. Fork-of-other-PR check.** Before rebasing, detect whether this
+      PR's branch was forked from another open PR — even if `baseRefName`
+      shows `master`. A forked PR's diff carries inherited commits from
+      the other PR; rebasing onto master replays those commits and causes
+      massive conflicts that look semantic but are really a topology problem
+      (the commits already land on master via the upstream PR).
+
+      From the cached PR list (step 2), collect all other open PRs'
+      `headRefName`s (exclude the current candidate's own `headRefName`).
+      Run a single batch fetch to update all remote refs at once:
+      `git fetch origin`
+      Then for each other PR's `headRefName`:
+      `git merge-base --is-ancestor origin/<other-headRefName> HEAD`
+
+      `git merge-base --is-ancestor` exits 0 if the other PR's tip is an
+      ancestor of this PR's HEAD (fork confirmed), exits 1 otherwise.
+      Each fetch + check is a separate Bash call (single-command rule).
+
+      If any check exits 0 for an "upstream PR" (`<upstream-N>`):
+      - Write `.merger-body.md` with:
+        ```
+        Merger: this PR's branch was forked from open PR #<upstream-N>
+        (`<upstream-headRefName>`). Its diff carries inherited commits
+        from that PR and cannot be cleanly rebased onto master until
+        #<upstream-N> merges.
+
+        Resolution after #<upstream-N> merges:
+          git fetch origin
+          git rebase --onto origin/master <upstream-tip-sha> <this-headRefName>
+          git push --force-with-lease
+
+        This drops #<upstream-N>'s inherited commits and leaves only
+        this PR's own changes on top of master.
+
+        Labeled `fleet:fork-of-other-pr` — the merger and opus-worker
+        skip this PR in their conflict-resolution sweeps.
+
+        — fleet merger
+        ```
+      - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
+      - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:fork-of-other-pr"`
+      - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
+      - Log: `... forked from #<upstream-N> <upstream-headRefName>, labeled fleet:fork-of-other-pr`
+      - Jump to step f (reset to scratch); do NOT proceed to step b.
+
+      If all checks return non-zero (no fork detected), continue to step b.
 
    **b. Rebase guard pre-capture.** Before rebasing, snapshot the
       current diff so silently-dropped hunks can be detected

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -285,9 +285,15 @@ exit cleanly:
 
       `git merge-base --is-ancestor` exits 0 if the other PR's tip is an
       ancestor of this PR's HEAD (fork confirmed), exits 1 otherwise.
+      (Exit 1 is the expected "not an ancestor" result; do not treat it
+      as a script error — the Bash tool reports non-zero exits but this
+      check intentionally returns 1 for the common "no fork" case.)
       Each fetch + check is a separate Bash call (single-command rule).
 
       If any check exits 0 for an "upstream PR" (`<upstream-N>`):
+      - Resolve the upstream tip SHA (needed for the rebase recipe below):
+        `git rev-parse origin/<upstream-headRefName>`
+        Store this output as `<upstream-tip-sha>`.
       - Write `.merger-body.md` with:
         ```
         Merger: this PR's branch was forked from open PR #<upstream-N>

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -141,10 +141,12 @@ conditions, allocator behavior, hot-path costs.
      `submittedAt`).
 
    **Skip** PRs labeled `fleet:wip`, `human:wip`, `human:needs-fix`,
-   or `fleet:semantic-conflict` — those are either in-progress,
-   human-owned, or queued for the opus-worker's conflict-resolution
-   lane (the diff against master is meaningless until the rebase
-   lands).
+   `fleet:semantic-conflict`, or `fleet:fork-of-other-pr` — those are
+   either in-progress, human-owned, queued for conflict resolution
+   (diff against master is meaningless until the rebase lands), or
+   forked from another open PR (diff includes inherited commits that
+   don't belong to this PR's scope — skip until the human runs
+   `rebase --onto` and clears this label).
 
 ## Loop behavior
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -438,9 +438,9 @@ Do the work, then exit cleanly:
     From the cached `repos.engine.prs[]`, pick PRs whose `labels`
     array contains `fleet:semantic-conflict` AND contains NONE of
     `fleet:wip`, `human:wip`, `human:needs-fix`, `human:blocker`,
-    `fleet:awaiting-base`, `fleet:awaiting-upstream-review`. The
-    `awaiting-*` exclusions matter because those PRs aren't yet
-    rebaseable against master.
+    `fleet:awaiting-base`, `fleet:awaiting-upstream-review`,
+    `fleet:fork-of-other-pr`. The `awaiting-*` and `fork-*` exclusions
+    matter because those PRs aren't yet rebaseable against master.
 
     **Stack-aware filter.** If a candidate's `baseRefName != master`
     (stacked PR), look up the base PR in the cached `prs[]` by its

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -144,6 +144,9 @@ treat it as a hard rule for this role.
      rebase conflict; the opus-worker is queued to attempt
      resolution. The PR's diff against master is meaningless until
      the rebase lands, so reviewing now wastes a pass.
+   - `fleet:fork-of-other-pr` — PR branch forked from another open
+     PR; diff includes inherited commits — skip until the human runs
+     `rebase --onto` and clears this label.
 
 ## Loop behavior
 
@@ -166,8 +169,8 @@ iteration of polling, reviewing, and exiting cleanly:
    PRs with no fleet review, with `human:re-review`, with
    `fleet:changes-made` (remove the label on pickup), or with a "re-review please"
    comment after the last fleet review. Skip PRs carrying any of
-   `fleet:wip`, `human:wip`, `human:needs-fix`, `fleet:human-amending`, or
-   `fleet:semantic-conflict`. For each remaining candidate, in
+   `fleet:wip`, `human:wip`, `human:needs-fix`, `fleet:human-amending`,
+   `fleet:semantic-conflict`, or `fleet:fork-of-other-pr`. For each remaining candidate, in
    oldest-first order:
 
    **Engine PRs** (default repo): Invoke the `review-pr` skill with

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -154,8 +154,9 @@ Apply two checks to the stat output:
    (e.g. `system_compute_light_volume.hpp` appearing in a PR scoped to
    12 other system files).
 2. **Out-of-scope file** — any file that appears in the stat output but
-   is neither described in the PR body nor a mechanical side-effect of
-   the PR's claimed scope (e.g. `TASKS.md`, `.fleet/plans/`, docs).
+   is neither described in the PR body nor a known mechanical side-effect
+   of the PR's claimed scope (e.g. a `CMakeLists.txt` accompanying a new
+   source file — not `TASKS.md`, `.fleet/plans/` drift, or unrelated docs).
    Flag as **Needs-fix**: author must acknowledge the file in the PR
    body or rebase to drop the accidental hunk.
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -78,7 +78,7 @@ the top-level `CLAUDE.md` for the full model split.
 ### 1. Resolve the PR and pull its metadata
 
 ```bash
-gh pr view <N> --json number,title,body,headRefName,baseRefName,author,files,additions,deletions,commits
+gh pr view <N> --json number,title,body,headRefName,baseRefName,author,files,additions,deletions,commits,mergeable
 gh pr diff <N>
 ```
 
@@ -128,6 +128,42 @@ If stacked:
 
 If the base is `master` and there's no `Stacked on:` line, this is a
 standalone PR — proceed with the rest of the flow as normal.
+
+### 1c. Churn audit when `mergeable == CONFLICTING`
+
+A PR in `CONFLICTING` state has a stale branch relative to `master`.
+A stale branch can silently carry reverted hunks — content that landed
+on `master` after the PR branch was cut but isn't reflected in the PR
+body because the author never rebased. `gh pr diff --stat` makes the
+actual scope visible before any code-path review.
+
+**When `mergeable` is `CONFLICTING`**, run:
+
+```bash
+gh pr diff <N> --stat
+```
+
+Apply two checks to the stat output:
+
+1. **Oversized churn** — any file with ≥100 added + deleted lines that
+   the PR body does not explicitly mention. Flag as **Needs-fix** (escalate
+   to **Blocker** if the churn includes deleted functions or files that
+   would break the build): the PR may be silently reverting work that
+   landed on master after the branch was cut. Classic pattern: a file
+   with 200+ line deletions in a PR that never claimed to touch it
+   (e.g. `system_compute_light_volume.hpp` appearing in a PR scoped to
+   12 other system files).
+2. **Out-of-scope file** — any file that appears in the stat output but
+   is neither described in the PR body nor a mechanical side-effect of
+   the PR's claimed scope (e.g. `TASKS.md`, `.fleet/plans/`, docs).
+   Flag as **Needs-fix**: author must acknowledge the file in the PR
+   body or rebase to drop the accidental hunk.
+
+If neither check fires, note in the review body:
+> "CONFLICTING state checked — `gh pr diff --stat` shows no out-of-scope
+> files or oversized churn."
+
+If `mergeable` is anything other than `CONFLICTING`, skip this step.
 
 ### 2. Check out the PR branch locally (read-only)
 
@@ -198,14 +234,9 @@ compliance or raise an issue.
   archetype changes invalidate addresses.
 - ❌ Capturing `this` or references to World managers in lambdas that outlive
   the World (e.g. lua callbacks registered before World teardown).
-<<<<<<< claude/T-076-worker-doc-tweaks
-- ❌ Stored `g_*Manager` pointer or reference in any object whose lifetime can
-  outlive `World` (e.g. `std::thread` tasks, sol2 callback closures).
-=======
 - ❌ Stored `g_*Manager` pointer or reference in any object whose lifetime
   can outlive `World` (background threads, sol2 callback closures, long-lived
   caches) — see `engine/world/CLAUDE.md` and `engine/CLAUDE.md`.
->>>>>>> master
 
 **Render pipeline**
 - ❌ CPU frame-data struct out of sync with its GLSL `layout(std140)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,6 +542,14 @@ Specifically, **never pass these via `--label` when filing**:
   can't auto-rebase). Cleared by the **opus-worker** after it
   resolves the conflict, or escalated to `human:needs-fix` if even
   Opus can't resolve.
+- `fleet:fork-of-other-pr` — owned by the **merger** (sets when it
+  detects this PR's branch was forked from another open PR's branch
+  rather than from master, meaning the diff carries inherited commits
+  from that PR). Signals: wait for the other PR to merge, then use
+  `rebase --onto` to drop the inherited commits. The merger skips
+  these in its CONFLICTING sweep; opus-worker excludes them from its
+  `fleet:semantic-conflict` step. Cleared by the **human** after the
+  upstream PR merges.
 - `fleet:human-amending` / `fleet:human-deferred` — owned by the
   **author worker** (sonnet-author / opus-worker) when picking up
   `human:needs-fix`. The two labels express which disposition the


### PR DESCRIPTION
## Summary
- `review-pr/SKILL.md`: adds step 1c — when `mergeable == CONFLICTING`, run `gh pr diff --stat` and flag files with ≥100-line unexplained churn or files outside the PR's claimed scope as Needs-fix (escalate to Blocker if build-breaking). Adds `mergeable` to step-1 JSON fetch. Resolves inherited conflict marker using the master version.
- `role-merger.md`: adds step a.6 — after the stacked-PR check, batch-fetches remote refs then runs `git merge-base --is-ancestor` for each other open PR's head to detect forks. On detection: posts comment with `rebase --onto` resolution recipe, applies `fleet:fork-of-other-pr` + `fleet:merger-cooldown`, skips to step f. Label added to step 3 skip list for future iterations.
- `role-opus-worker.md`: adds `fleet:fork-of-other-pr` to the step-1c `fleet:semantic-conflict` exclusion list.
- `CLAUDE.md`: documents `fleet:fork-of-other-pr` ownership and lifecycle.

## Test plan
- [ ] Review step 1c text: does the Needs-fix/escalate-to-Blocker distinction match the real T-065 incident?
- [ ] Review step a.6 ordering: `git fetch origin` batch before loop, then per-PR `merge-base --is-ancestor`
- [ ] Verify `fleet:fork-of-other-pr` appears in: merger step 3 skip list, merger step a.6 actions, opus-worker step 1c exclusion, CLAUDE.md label docs

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)