### PR TITLE
T-066: render/system: centralize GPU stage probes via SystemManager TickObserver

### DIFF
--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -56,6 +56,23 @@ struct GpuStageInfo {
     float budgetShare_;
 };
 
+// Authoritative mapping name → field → budget. `gpu_stage_timing_observer`
+// resolves a system's tag against this table; pass the same name to
+// `IRRender::tagGpuStage(system, "<name>")` and the observer fills the
+// matching `GpuStageTiming::*Ms_` field at end-of-tick.
+//
+// Per-system mapping post-T-066 (one observer fire per `SystemId`):
+//   `voxelStage1`  ← VOXEL_TO_TRIXEL_STAGE_1 (covers former canvasClear +
+//                    voxelCompact + voxelStage1 sub-stages)
+//   `voxelStage2`  ← VOXEL_TO_TRIXEL_STAGE_2
+//   `shapePass1`   ← SHAPES_TO_TRIXEL (covers former shapePass0 + shapePass1)
+//   The remaining 8 names map 1:1 to single-stage systems.
+//
+// Three rows have no current writer: `canvasClear`, `voxelCompact`,
+// `shapePass0` (folded into the per-system measurement above), and
+// `shapeCompact` (no system has ever written it; reserved for a
+// future shape-compaction pass). They stay in the registry to keep
+// the Lua API and perf overlay stable; their reported value is 0.0f.
 inline const std::array<GpuStageInfo, 15> &gpuStageRegistry() {
     static const std::array<GpuStageInfo, 15> registry{{
         {"canvasClear",       &GpuStageTiming::canvasClearMs_,      0.05f},

--- a/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
@@ -1,0 +1,84 @@
+#ifndef GPU_STAGE_TIMING_OBSERVER_H
+#define GPU_STAGE_TIMING_OBSERVER_H
+
+#include <irreden/ir_system.hpp>
+#include <irreden/render/render_device.hpp>
+#include <irreden/render/gpu_stage_timing.hpp>
+
+#include <memory>
+#include <string_view>
+#include <unordered_map>
+
+namespace IRRender {
+
+// Observer that brackets every system tick with GPU `device()->finish()`
+// samples and writes the elapsed time into a `GpuStageTiming` field for
+// systems that have been tagged via `tagGpuStage`. Centralizes what used
+// to be 14 inlined `if (timing.enabled_) { device()->finish(); ... }`
+// blocks scattered across `engine/prefabs/irreden/render/systems/*.hpp`.
+//
+// Untagged systems pay nothing: the `m_stages.find(system)` returns end
+// and both fires return immediately. When `gpuStageTiming().enabled_` is
+// false (the default), even tagged systems pay only one bool check per
+// fire.
+class GpuStageTimingObserver : public IRSystem::TickObserver {
+  public:
+    void tagStage(IRSystem::SystemId system, const GpuStageInfo &info) {
+        m_stages[system] = &info;
+    }
+
+    void onBeforeTick(IRSystem::SystemId system) override {
+        if (!gpuStageTiming().enabled_) return;
+        auto it = m_stages.find(system);
+        if (it == m_stages.end()) return;
+        IRRender::device()->finish();
+        m_t0 = SteadyClock::now();
+    }
+
+    void onAfterTick(IRSystem::SystemId system) override {
+        if (!gpuStageTiming().enabled_) return;
+        auto it = m_stages.find(system);
+        if (it == m_stages.end()) return;
+        IRRender::device()->finish();
+        gpuStageTiming().*(it->second->field_) = elapsedMs(m_t0, SteadyClock::now());
+    }
+
+  private:
+    std::unordered_map<IRSystem::SystemId, const GpuStageInfo *> m_stages;
+    TimePoint m_t0;
+};
+
+namespace detail {
+
+// Lazy install: the first `tagGpuStage` call creates the observer,
+// transfers ownership to SystemManager via `registerTickObserver`, and
+// caches a raw pointer for subsequent tagging. The observer lives as
+// long as the SystemManager (program-bound; see engine/world/CLAUDE.md).
+inline GpuStageTimingObserver *installAndGetObserver() {
+    static GpuStageTimingObserver *cached = []() {
+        auto owner = std::make_unique<GpuStageTimingObserver>();
+        GpuStageTimingObserver *raw = owner.get();
+        IRSystem::registerTickObserver(std::move(owner));
+        return raw;
+    }();
+    return cached;
+}
+
+} // namespace detail
+
+// Tag a system with a stage name from `gpuStageRegistry()`. The registry
+// is the single source of truth for the field pointer + budget share;
+// callers pass only the name. An unknown name is a silent no-op so a
+// future stage rename can't crash the engine at startup.
+inline void tagGpuStage(IRSystem::SystemId system, std::string_view stageName) {
+    for (const auto &info : gpuStageRegistry()) {
+        if (info.name_ == stageName) {
+            detail::installAndGetObserver()->tagStage(system, info);
+            return;
+        }
+    }
+}
+
+} // namespace IRRender
+
+#endif /* GPU_STAGE_TIMING_OBSERVER_H */

--- a/engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp
@@ -26,6 +26,7 @@
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/render/cull_viewport_state.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 #include <irreden/render/systems/system_build_occupancy_grid.hpp>
 #include <irreden/common/components/component_position_global_3d.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
@@ -265,13 +266,6 @@ template <> struct System<COMPUTE_SUN_SHADOW> {
                 }
                 p->frameData_.shapeCasterCount_ = static_cast<int>(shapeCasters.size());
 
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint t0;
-                if (timing.enabled_) {
-                    IRRender::device()->finish();
-                    t0 = IRRender::SteadyClock::now();
-                }
-
                 canvasTextures.getTextureDistances()
                     ->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
                 shadow.getTexture()
@@ -312,15 +306,6 @@ template <> struct System<COMPUTE_SUN_SHADOW> {
                     IRMath::divCeil(canvasTextures.size_.y, kComputeSunShadowGroupSize);
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-                // Assumes a single matching canvas per frame. Switch to `+=`
-                // with a `beginTick` reset if the filter ever matches
-                // multiple entities — otherwise later entities overwrite.
-                if (timing.enabled_) {
-                    IRRender::device()->finish();
-                    timing.computeSunShadowMs_ =
-                        IRRender::elapsedMs(t0, IRRender::SteadyClock::now());
-                }
             },
             [p]() {
                 p->program_->use();
@@ -342,6 +327,7 @@ template <> struct System<COMPUTE_SUN_SHADOW> {
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        IRRender::tagGpuStage(systemId, "computeSunShadow");
         return systemId;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
@@ -20,6 +20,7 @@
 #include <irreden/render/components/component_canvas_ao_texture.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 
 #include <cstddef>
 
@@ -72,10 +73,6 @@ template <> struct System<COMPUTE_VOXEL_AO> {
                 if (!behavior.useCameraPositionIso_) return;
                 IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
 
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint t0;
-                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
-
                 canvasTextures.getTextureDistances()->bindAsImage(
                     0, TextureAccess::READ_ONLY, TextureFormat::R32I
                 );
@@ -98,11 +95,6 @@ template <> struct System<COMPUTE_VOXEL_AO> {
                 );
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-                // Assumes a single matching canvas per frame. Switch to `+=`
-                // with a `beginTick` reset if the filter ever matches
-                // multiple entities — otherwise later entities overwrite.
-                if (timing.enabled_) { IRRender::device()->finish(); timing.computeVoxelAoMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             [p]() {
                 p->program_->use();
@@ -128,6 +120,7 @@ template <> struct System<COMPUTE_VOXEL_AO> {
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        IRRender::tagGpuStage(systemId, "computeVoxelAO");
         return systemId;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
@@ -10,6 +10,7 @@
 #include <irreden/render/components/component_entity_canvas.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 #include <irreden/render/components/component_trixel_framebuffer.hpp>
 #include <irreden/render/components/component_frame_data_trixel_to_framebuffer.hpp>
 #include <irreden/common/components/component_position_global_3d.hpp>
@@ -43,7 +44,7 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
     }
 
     static SystemId create() {
-        return createSystem<C_EntityCanvas, C_PositionGlobal3D, C_PositionOffset3D>(
+        SystemId s = createSystem<C_EntityCanvas, C_PositionGlobal3D, C_PositionOffset3D>(
             "EntityCanvasToFramebuffer",
             [](IREntity::EntityId entityId,
                const C_EntityCanvas &entityCanvas,
@@ -124,18 +125,10 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
             },
             []() {
                 getInstances().clear();
-                IRRender::gpuStageTiming().entityCanvasToFbMs_ = 0.0f;
             },
             []() {
                 auto &allInstances = getInstances();
                 if (allInstances.empty()) return;
-
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint drawStart;
-                if (timing.enabled_) {
-                    IRRender::device()->finish();
-                    drawStart = IRRender::SteadyClock::now();
-                }
 
                 auto &framebuffer =
                     IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
@@ -160,14 +153,10 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
                 }
 
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-
-                if (timing.enabled_) {
-                    IRRender::device()->finish();
-                    timing.entityCanvasToFbMs_ = IRRender::elapsedMs(
-                        drawStart, IRRender::SteadyClock::now());
-                }
             }
         );
+        IRRender::tagGpuStage(s, "entityCanvasToFb");
+        return s;
     }
 
     static mat4 calcProjectionMatrix(const vec2 &resolution) {

--- a/engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp
+++ b/engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp
@@ -10,6 +10,7 @@
 #include <irreden/render/components/component_camera_position_2d_iso.hpp>
 #include <irreden/render/components/component_texture_scroll.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 
 #include <vector>
 
@@ -58,10 +59,6 @@ template <> struct System<FRAMEBUFFER_TO_SCREEN> {
             [p](const C_TrixelCanvasFramebuffer &framebuffer,
                 const C_Position3D &cameraPosition,
                 const C_Name &name) {
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint t0;
-                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
-
                 framebuffer.bindTextures(0, 1);
                 p->frameData_.mvpMatrix =
                     calcProjectionMatrix() * calcModelMatrix(
@@ -74,11 +71,8 @@ template <> struct System<FRAMEBUFFER_TO_SCREEN> {
                 p->frameDataBuf_->subData(0, sizeof(FrameDataFramebuffer), &p->frameData_);
                 IRRender::device()->setPolygonMode(PolygonMode::FILL);
                 IRRender::device()->drawArrays(DrawMode::TRIANGLES, 0, 6);
-
-                if (timing.enabled_) { IRRender::device()->finish(); timing.fbToScreenMs_ += IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             [p]() {
-                IRRender::gpuStageTiming().fbToScreenMs_ = 0.0f;
                 bindDefaultFramebuffer();
                 clearDefaultFramebuffer();
                 p->program_->use();
@@ -87,6 +81,7 @@ template <> struct System<FRAMEBUFFER_TO_SCREEN> {
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        IRRender::tagGpuStage(systemId, "fbToScreen");
         return systemId;
     }
 

--- a/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
@@ -14,6 +14,7 @@
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -161,13 +162,6 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
                     return;
                 }
 
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint t0;
-                if (timing.enabled_) {
-                    IRRender::device()->finish();
-                    t0 = IRRender::SteadyClock::now();
-                }
-
                 canvasTextures.getTextureColors()
                     ->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
                 canvasTextures.getTextureDistances()
@@ -199,15 +193,6 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
                     IRMath::divCeil(canvasTextures.size_.y, kLightingToTrixelGroupSize);
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-                // Assumes a single matching canvas per frame. Switch to `+=`
-                // with a `beginTick` reset if the filter ever matches
-                // multiple entities — otherwise later entities overwrite.
-                if (timing.enabled_) {
-                    IRRender::device()->finish();
-                    timing.lightingToTrixelMs_ =
-                        IRRender::elapsedMs(t0, IRRender::SteadyClock::now());
-                }
             },
             [p]() {
                 p->program_->use();
@@ -221,6 +206,7 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        IRRender::tagGpuStage(systemId, "lightingToTrixel");
         return systemId;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
@@ -14,6 +14,7 @@
 #include <irreden/render/camera.hpp>
 
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 
 #include <cstring>
 #include <optional>
@@ -180,7 +181,6 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                 }
             },
             [p]() {
-                auto &timing = IRRender::gpuStageTiming();
                 IREntity::EntityId mainCanvas = IRRender::getActiveCanvasEntity();
                 const float visualYaw = p->visualYaw_;
 
@@ -257,28 +257,11 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                     p->shapesFrameDataBuf_->subData(
                         0, sizeof(GPUShapesFrameData), &p->frameData_);
 
-                    IRRender::TimePoint pass0Start;
-                    if (timing.enabled_) {
-                        IRRender::device()->finish();
-                        pass0Start = IRRender::SteadyClock::now();
-                    }
-
                     IRRender::device()
                         ->dispatchCompute(static_cast<std::uint32_t>(tileCount), 1, 1);
                     IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
-                    if (timing.enabled_) {
-                        IRRender::device()->finish();
-                        timing.shapePass0Ms_ =
-                            IRRender::elapsedMs(pass0Start, IRRender::SteadyClock::now());
-                    }
-
                     // Pass 1: color + entity ID where depth matches
-                    IRRender::TimePoint pass1Start;
-                    if (timing.enabled_) {
-                        pass1Start = IRRender::SteadyClock::now();
-                    }
-
                     canvasTextures.getTextureColors()
                         ->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
                     canvasTextures.getTextureEntityIds()
@@ -292,18 +275,17 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                         ->dispatchCompute(static_cast<std::uint32_t>(tileCount), 1, 1);
                     IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
-                    if (timing.enabled_) {
-                        IRRender::device()->finish();
-                        timing.shapePass1Ms_ =
-                            IRRender::elapsedMs(pass1Start, IRRender::SteadyClock::now());
-                        timing.visibleShapeCount_ = static_cast<std::uint32_t>(gpuShapes.size());
-                        timing.shapeGroupsZ_ = 0;
-                    }
+                    auto &timing = IRRender::gpuStageTiming();
+                    timing.visibleShapeCount_ = static_cast<std::uint32_t>(gpuShapes.size());
+                    timing.shapeGroupsZ_ = 0;
                 }
             }
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        // Per-system bracket covers both pass 0 (depth) and pass 1 (color/id);
+        // the formerly-separate shapePass0 slot stays at 0.0f for API stability.
+        IRRender::tagGpuStage(systemId, "shapePass1");
         return systemId;
     }
 

--- a/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
@@ -15,6 +15,7 @@
 #include <irreden/render/components/component_text_style.hpp>
 #include <irreden/common/components/component_tags_all.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 
 #include <vector>
 
@@ -267,17 +268,12 @@ template <> struct System<TEXT_TO_TRIXEL> {
                 }
             },
             [p]() {
-                auto &timing = IRRender::gpuStageTiming();
-                timing.textToTrixelMs_ = 0.0f;
                 if (p->drawCommands_.empty()) return;
 
                 int count = static_cast<int>(p->drawCommands_.size());
                 if (count > kMaxGlyphCommands) {
                     count = kMaxGlyphCommands;
                 }
-
-                IRRender::TimePoint t0;
-                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
 
                 p->glyphCmdBuf_->subData(
                     0, count * sizeof(GlyphDrawCommand), p->drawCommands_.data());
@@ -295,12 +291,11 @@ template <> struct System<TEXT_TO_TRIXEL> {
                 IRRender::device()->dispatchCompute(count, 1, 1);
                 // TODO: Look over all barriers and try and make the minimum necessary to speed up rendering
                 IRRender::device()->memoryBarrier(BarrierType::ALL);
-
-                if (timing.enabled_) { IRRender::device()->finish(); timing.textToTrixelMs_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             }
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        IRRender::tagGpuStage(systemId, "textToTrixel");
         return systemId;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
@@ -15,6 +15,7 @@
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/common/components/component_name.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 
 using namespace IRComponents;
 using namespace IRRender;
@@ -71,10 +72,6 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
             [p](IREntity::EntityId &entity,
                 const C_TriangleCanvasTextures &triangleCanvasTextures,
                 const C_Name &) {
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint drawStart;
-                if (timing.enabled_) { IRRender::device()->finish(); drawStart = IRRender::SteadyClock::now(); }
-
                 auto &framebuffer =
                     IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
                 auto &frameData =
@@ -142,11 +139,8 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
                     IndexType::UNSIGNED_SHORT
                 );
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-
-                if (timing.enabled_) { IRRender::device()->finish(); timing.trixelToFbMs_ += IRRender::elapsedMs(drawStart, IRRender::SteadyClock::now()); }
             },
             [p]() {
-                IRRender::gpuStageTiming().trixelToFbMs_ = 0.0f;
                 struct { uvec2 entityId{0u, 0u}; float depth{1.0f}; float _pad{0.0f}; } resetData;
                 p->hoveredIdBuf_->subData(0, sizeof(resetData), &resetData);
                 p->program_->use();
@@ -159,6 +153,7 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        IRRender::tagGpuStage(systemId, "trixelToFb");
         return systemId;
     }
 

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp
@@ -8,6 +8,7 @@
 
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 
 using namespace IRComponents;
 using namespace IRRender;
@@ -49,10 +50,6 @@ template <> struct System<TRIXEL_TO_TRIXEL> {
             "CanvasToFramebuffer",
             [p](const C_TriangleCanvasTextures &trixelTextures,
                 const C_Position2DIso &position2DIso) {
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint t0;
-                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
-
                 trixelTextures.bind(2, 3);
                 p->frameData_.trixelTextureOffsetZ1_ =
                     IRMath::trixelOriginOffsetZ1(trixelTextures.size_);
@@ -62,11 +59,8 @@ template <> struct System<TRIXEL_TO_TRIXEL> {
                 const int groupsY = IRMath::divCeil(trixelTextures.size_.y, kTrixelToTrixelGroupSize);
                 IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-                if (timing.enabled_) { IRRender::device()->finish(); timing.trixelToTrixelMs_ += IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             [p]() {
-                IRRender::gpuStageTiming().trixelToTrixelMs_ = 0.0f;
                 p->program_->use();
                 vec2 camIso = IRRender::getCameraPosition2DIso();
                 p->frameData_.cameraTrixelOffset_ = ivec2(
@@ -86,6 +80,7 @@ template <> struct System<TRIXEL_TO_TRIXEL> {
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        IRRender::tagGpuStage(systemId, "trixelToTrixel");
         return systemId;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -20,6 +20,7 @@
 #include <irreden/render/camera.hpp>
 
 #include <irreden/render/gpu_stage_timing.hpp>
+#include <irreden/render/gpu_stage_timing_observer.hpp>
 
 #include <cstdint>
 #include <vector>
@@ -222,9 +223,6 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             [p](IREntity::EntityId &entity,
                 C_VoxelPool &voxelPool,
                 C_TriangleCanvasTextures &triangleCanvasTextures) {
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint t0, t1;
-
                 const int liveVoxelCount = voxelPool.getLiveVoxelCount();
                 if (liveVoxelCount == 0) return;
 
@@ -256,9 +254,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
                     p->previousEffectiveSubdivisions_ = effectiveSub;
                 }
 
-                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
                 clearCanvasAndDistances(entity, triangleCanvasTextures);
-                if (timing.enabled_) { IRRender::device()->finish(); t1 = IRRender::SteadyClock::now(); timing.canvasClearMs_ = IRRender::elapsedMs(t0, t1); }
 
                 ivec2 cullOffsetZ1 = IRMath::trixelOriginOffsetZ1(cull.canvasSize_);
                 const auto &uploadMask = buildChunkVisibilityMask(
@@ -288,9 +284,6 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
                 );
                 syncEntityIds(voxelPool, liveVoxelCount, p->voxelEntityIdBuf_);
 
-                // --- GPU visibility compaction ---
-                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
-
                 const VoxelIndirectDispatchParams zeroed{};
                 p->indirectBuf_->subData(0, sizeof(VoxelIndirectDispatchParams), &zeroed);
 
@@ -302,19 +295,12 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
                 IRRender::device()->memoryBarrier(BarrierType::COMMAND);
 
-                if (timing.enabled_) { IRRender::device()->finish(); t1 = IRRender::SteadyClock::now(); timing.voxelCompactMs_ = IRRender::elapsedMs(t0, t1); }
-
-                // --- Stage 1: indirect dispatch from compacted visible set ---
-                if (timing.enabled_) { t0 = IRRender::SteadyClock::now(); }
-
                 p->stage1Program_->use();
                 triangleCanvasTextures.getTextureDistances()->bindAsImage(
                     1, TextureAccess::READ_ONLY, TextureFormat::R32I
                 );
                 IRRender::device()->dispatchComputeIndirect(p->indirectBuf_, 0);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-                if (timing.enabled_) { IRRender::device()->finish(); t1 = IRRender::SteadyClock::now(); timing.voxelStage1Ms_ = IRRender::elapsedMs(t0, t1); }
             },
             []() {
                 IREntity::EntityId backgroundCanvas = IRRender::getCanvas("background");
@@ -330,6 +316,11 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        // The observer-based timing brackets the entire system tick. The
+        // formerly-separate canvasClear and voxelCompact sub-stages now
+        // collapse into voxelStage1's measurement; their registry slots
+        // remain at 0.0f for API-compatibility.
+        IRRender::tagGpuStage(systemId, "voxelStage1");
         return systemId;
     }
 };
@@ -358,10 +349,6 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_2> {
             [p](const C_VoxelPool &voxelPool, C_TriangleCanvasTextures &triangleCanvasTextures) {
                 if (voxelPool.getLiveVoxelCount() == 0) return;
 
-                auto &timing = IRRender::gpuStageTiming();
-                IRRender::TimePoint t0;
-                if (timing.enabled_) { IRRender::device()->finish(); t0 = IRRender::SteadyClock::now(); }
-
                 triangleCanvasTextures.getTextureColors()->bindAsImage(
                     0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8
                 );
@@ -374,13 +361,12 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_2> {
 
                 IRRender::device()->dispatchComputeIndirect(p->indirectBuf_, 0);
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-                if (timing.enabled_) { IRRender::device()->finish(); timing.voxelStage2Ms_ = IRRender::elapsedMs(t0, IRRender::SteadyClock::now()); }
             },
             [p]() { p->stage2Program_->use(); }
         );
 
         setSystemParams(systemId, std::move(paramsOwner));
+        IRRender::tagGpuStage(systemId, "voxelStage2");
         return systemId;
     }
 };

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -98,6 +98,13 @@ inline void setTimingEnabled(bool enabled) { getSystemManager().setTimingEnabled
 inline bool isTimingEnabled() { return getSystemManager().isTimingEnabled(); }
 inline void resetTimingStats() { getSystemManager().resetTimingStats(); }
 
+inline TickObserverId registerTickObserver(std::unique_ptr<TickObserver> observer) {
+    return getSystemManager().registerTickObserver(std::move(observer));
+}
+inline void unregisterTickObserver(TickObserverId id) {
+    getSystemManager().unregisterTickObserver(id);
+}
+
 } // namespace IRSystem
 
 #endif /* IR_SYSTEM_H */

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -34,6 +34,22 @@ template <typename Params> class ISystemParamsImpl : public ISystemParams {
     std::unique_ptr<Params> params_;
 };
 
+/// Observer hook fired before and after every system tick. Used by the
+/// render layer to bracket GPU-stage timing samples around per-system work
+/// without inlining `device()->finish()` blocks into every tick lambda.
+/// Generic on purpose: trace capture or per-system telemetry can plug in
+/// using the same hook without touching SystemManager again.
+class TickObserver {
+  public:
+    virtual ~TickObserver() = default;
+    virtual void onBeforeTick(SystemId system) = 0;
+    virtual void onAfterTick(SystemId system) = 0;
+};
+
+struct TickObserverId {
+    std::uint32_t value_;
+};
+
 class SystemManager {
   public:
     using ErasedParamsPtr = std::unique_ptr<ISystemParams>;
@@ -105,6 +121,13 @@ class SystemManager {
     bool isTimingEnabled() const { return m_timingEnabled; }
     void resetTimingStats();
 
+    /// Take ownership of an observer; fires `onBeforeTick`/`onAfterTick`
+    /// around every `executeSystem` call. Returns an id usable with
+    /// `unregisterTickObserver`. If `m_observers` is empty the dispatch
+    /// is a single bool check, so unregistered systems pay nothing.
+    TickObserverId registerTickObserver(std::unique_ptr<TickObserver> observer);
+    void unregisterTickObserver(TickObserverId id);
+
     const std::string &getSystemName(SystemId id) const { return m_systemNames[id].name_; }
     SystemId getSystemCount() const { return m_nextSystemId; }
     const TimingAccum &getTimingAccum(SystemId id) const { return m_timingAccum[id]; }
@@ -127,6 +150,9 @@ class SystemManager {
 
     bool m_timingEnabled = false;
     std::vector<TimingAccum> m_timingAccum;
+
+    std::uint32_t m_nextObserverId = 1;
+    std::vector<std::pair<TickObserverId, std::unique_ptr<TickObserver>>> m_observers;
 
     // Begin tick functions happen once per system before tick function(s)
     template <typename FunctionBeginTick>

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -25,6 +25,21 @@ void SystemManager::resetTimingStats() {
     }
 }
 
+TickObserverId SystemManager::registerTickObserver(std::unique_ptr<TickObserver> observer) {
+    TickObserverId id{m_nextObserverId++};
+    m_observers.emplace_back(id, std::move(observer));
+    return id;
+}
+
+void SystemManager::unregisterTickObserver(TickObserverId id) {
+    for (auto it = m_observers.begin(); it != m_observers.end(); ++it) {
+        if (it->first.value_ == id.value_) {
+            m_observers.erase(it);
+            return;
+        }
+    }
+}
+
 void SystemManager::registerPipeline(IRTime::Events event, std::list<SystemId> pipeline) {
     m_systemPipelinesNew[event] = pipeline;
 }
@@ -40,6 +55,13 @@ void SystemManager::executePipeline(IRTime::Events event) {
 
 void SystemManager::executeSystem(SystemId system) {
     IR_PROFILE_BLOCK(m_systemNames[system].name_.c_str(), IR_PROFILER_COLOR_SYSTEMS);
+
+    // Observer fires bracket the entire system execution. They sit outside
+    // the CPU timing window so a GPU observer's `device()->finish()` doesn't
+    // get billed against m_timingAccum (CPU vs GPU stay orthogonal).
+    for (auto &entry : m_observers) {
+        entry.second->onBeforeTick(system);
+    }
 
     using Clock = std::chrono::steady_clock;
     Clock::time_point t0;
@@ -85,6 +107,10 @@ void SystemManager::executeSystem(SystemId system) {
         if (ns > acc.maxNs_) acc.maxNs_ = ns;
         acc.callCount_++;
         acc.totalEntityCount_ += entityCount;
+    }
+
+    for (auto &entry : m_observers) {
+        entry.second->onAfterTick(system);
     }
 
     IREntity::flushStructuralChanges();


### PR DESCRIPTION
## Summary
- Replace 14 inlined `device()->finish()` GPU-timing probes scattered across 11 render system tick lambdas with a generic `IRSystem::TickObserver` hook + `GpuStageTimingObserver` that plugs into it.
- Render systems now end `create()` with `IRRender::tagGpuStage(s, "<name>")`. The registry in `gpu_stage_timing.hpp` is the single source of truth for the `field_` pointer and `budgetShare_`.
- Fixes the multi-canvas overwrite bug for COMPUTE_SUN_SHADOW / COMPUTE_VOXEL_AO / LIGHTING_TO_TRIXEL (`=` per-entity write previously dropped to last canvas).
- Removes the `+=` accumulator + `beginTick` zero-reset ceremony from trixelToTrixel / trixelToFb / fbToScreen.

## Trade-off — multi-stage system collapse
`VOXEL_TO_TRIXEL_STAGE_1` and `SHAPES_TO_TRIXEL` each used to write multiple sub-stage timings (canvasClear/voxelCompact/voxelStage1 and shapePass0/shapePass1). After T-066 each system reports one per-system measurement. The previously sub-staged registry slots (`canvasClear`, `voxelCompact`, `shapePass0`) read `0.0f` to keep the 15-row API surface stable; documented in `gpu_stage_timing.hpp`. `shapeCompact` continues to read 0.0f as it always did.

The Opus-recheck question for review: is "same 15 rows, same field semantics" satisfied by keeping the registry intact with collapsed slots reading 0, or should multi-stage systems be split into multiple `SystemId`s to preserve sub-stage observability? I went with the smaller change; happy to split if review prefers.

## Layering
- `TickObserver` lives in `engine/system/` and stays graphics-agnostic.
- `GpuStageTimingObserver` lives in `engine/prefabs/irreden/render/` and owns the GPU-side bracket.
- Observer fires sit OUTSIDE the CPU timing window in `executeSystem`, so a GPU `finish()` doesn't get billed against `m_timingAccum`.
- Lazy install: first `tagGpuStage` call creates the observer and registers it with `SystemManager` via `registerTickObserver`. The observer lives as long as the manager.

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean on macos-debug
- [x] `fleet-build --target IrredenEngineTest` clean; 367/367 tests pass
- [x] `IRShapeDebug --auto-screenshot 10` produces 6 byte-identical screenshots vs origin/master baseline (`cmp` silent on all 6)
- [ ] Linux smoke (cross-host) — needs `fleet:needs-linux-smoke`
- [ ] Multi-canvas creation (manually constructed if no existing demo has it) confirms COMPUTE_SUN_SHADOW etc. now sum across entities — deferred; the observer's per-system bracket is the architecturally correct fix and existing single-canvas demos remain unchanged

## Notes for reviewer
- Hot-path overhead: range-for over an empty `m_observers` vector is one branch. Once the observer is installed (always, after engine init), it's one virtual call per system tick. With ~50–100 systems × ~100Hz that's ~10k virtual calls/sec — negligible.
- `unordered_map<SystemId, const GpuStageInfo*>::find` per system per tick happens only when `gpuStageTiming().enabled_` is true. Untagged systems hit a fast-fail before any GPU work. Vector-indexed-by-SystemId would be a micro-optimization; not in this PR.
- `IRRender::tagGpuStage(s, std::string_view)` is a silent no-op for unknown names — chosen over assertion so a future stage rename can't crash engine startup.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)