### PR TITLE
T-082: fleet: factor CLAUDE.md status-prose into .fleet/status/

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -1107,6 +1107,10 @@ human can tell which opus-worker observed what. See top-level
   Read only the file matching your task ID. Authority for "who works
   on what" lives in TASKS.md `Owner:` and `fleet-claim` locks; nothing
   else.
+- **`.fleet/status/*.md` is queue-manager-owned bookkeeping**, like
+  `TASKS.md`. Read when a CLAUDE.md pointer directs you to one;
+  never include them in a feature PR's diff. Canonical explanation
+  in `.fleet/status/README.md`.
 - **Edit/Write paths must stay inside your worktree.** The parent
   clone at `/Users/evinjkill/src/IrredenEngine/` (no `.claude/worktrees/`
   in the path) and your worktree at

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -516,6 +516,19 @@ You are the sole TASKS.md editor. Each maintenance pass:
    `rm -f ~/.fleet/plans/<task-ID>.md`
    `rm -f .fleet/plans/<task-ID>.md`
 
+   **Also scan `.fleet/status/*.md`** (engine repo) for references to
+   the merged PR or its task ID and update accordingly. Use the Grep
+   tool across `.fleet/status/` for the merged task's `T-NNN`, the PR
+   number `#<N>`, and the PR URL `pull/<N>`. For per-row references
+   (e.g., a table row in `render-api-relocations.md` listing the task)
+   delete the row. For whole-file references (e.g., the "Migration
+   tracked in T-NNN" framing in `system-static-deviations.md`) the
+   file's premise may dissolve when its tracking task ships — if the
+   remaining content is a stub, delete the file and remove its entry
+   from `.fleet/status/README.md`. Stage `.fleet/status/` edits in the
+   same maintenance commit as the TASKS.md flip; the bookkeeping
+   exception (Hard rules) covers them.
+
 5. **Sync open PRs → In-progress (both repos).** Use the cached
    `repos.engine.prs[]` and `repos.game.prs[]` for the open PR
    list — the title-to-task match below uses `title` and

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -699,10 +699,17 @@ iterations write nothing).
   other agent should edit TASKS.md. If you see a PR that includes
   TASKS.md changes from an author agent, flag it in your review or
   comment — the author should remove those changes.
+- You are also the **sole `.fleet/status/*.md` editor** — same rule
+  shape as TASKS.md. Update these files when a PR referenced from
+  one merges, either by appending to the next maintenance commit
+  (covered by the bookkeeping exception below) or via a regular
+  `queue: status update` PR through `commit-and-push`. Canonical
+  explanation in `.fleet/status/README.md`.
 - Never `gh pr merge` — the human merges.
 - **Bookkeeping exception:** you MAY push directly to master in
   **both** repos (engine and game) when the commit touches **only**
-  `TASKS.md` and/or `.fleet/plans/*.md`. These are bookkeeping files,
-  not code. Never push any other file to master in either repo.
+  `TASKS.md`, `.fleet/plans/*.md`, and/or `.fleet/status/*.md`.
+  These are bookkeeping files, not code. Never push any other file
+  to master in either repo.
 - Never `git push --force`.
 - Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -766,6 +766,10 @@ the human can tell which sonnet pane observed what. See top-level
   finish the flow. Don't invoke `simplify` standalone — let
   `commit-and-push` invoke it for you, so the commit step is
   guaranteed to follow.
+- **`.fleet/status/*.md` is queue-manager-owned bookkeeping**, like
+  `TASKS.md`. Read when a CLAUDE.md pointer directs you to one;
+  never include them in a feature PR's diff. Canonical explanation
+  in `.fleet/status/README.md`.
 - **Edit/Write paths must stay inside your worktree.** The parent
   clone at `/Users/evinjkill/src/IrredenEngine/` (no `.claude/worktrees/`
   in the path) and your worktree at

--- a/.fleet/status/README.md
+++ b/.fleet/status/README.md
@@ -1,0 +1,53 @@
+# `.fleet/status/` — queue-manager-owned status roll-ups
+
+Roll-up prose that tracks rapidly-changing project state across the
+fleet (in-flight migrations, deferred follow-ups, API relocations).
+Stored here rather than inline in CLAUDE.md sections so feature PRs
+that touch the relevant module's CLAUDE.md don't conflict on the
+roll-up paragraph.
+
+## Ownership
+
+These files follow the same bookkeeping pattern as `TASKS.md` and
+`.fleet/plans/`:
+
+- **Queue-manager** is the sole editor. Maintenance pass updates
+  the contents as underlying state changes (PRs merge, task status
+  flips, architect-gated decisions resolve).
+- **Author / reviewer / worker / merger agents do not edit these
+  files in feature PRs.** Read them when a CLAUDE.md pointer
+  directs you to one; never include them in a feature PR's diff.
+- **Cursor / human-in-the-loop edits** are fine — the human is the
+  source of truth and may update any of these directly.
+
+The bookkeeping carve-out in `role-queue-manager.md` "Hard rules"
+covers `.fleet/status/*.md` so the queue-manager can push status
+updates straight to master alongside `TASKS.md` and
+`.fleet/plans/*.md` without going through PR review.
+
+## Files
+
+- `modifier-runtime-gaps.md` — modifier framework follow-ups
+  (architect-gated runtime escape hatches, perf optimizations not
+  yet justified by profile data).
+- `render-api-relocations.md` — features still on the `IRRender::`
+  surface that should move to feature-specific prefab namespaces.
+- `system-static-deviations.md` — render system headers that still
+  use `function-local static` for system state instead of the
+  canonical `SystemParams` pattern.
+
+## Adding a new status file
+
+When a "list of in-flight items" pattern would otherwise grow inline
+in some CLAUDE.md, add a new file here instead. Pick a kebab-case
+filename keyed by area + topic. Reference it from the relevant
+CLAUDE.md with the canonical pointer shape:
+
+```
+See `.fleet/status/<file>.md` (queue-manager-owned; feature PRs do
+not edit) for <one-line summary of what it tracks>.
+```
+
+The pointer line itself is rate-stable: the file name doesn't
+change, only the file's contents do, so feature PRs touching the
+same module's CLAUDE.md don't collide on the pointer.

--- a/.fleet/status/modifier-runtime-gaps.md
+++ b/.fleet/status/modifier-runtime-gaps.md
@@ -1,0 +1,28 @@
+# Modifier framework — runtime gaps
+
+Open follow-ups in the modifier framework's runtime.
+
+The current runtime ships all six resolver systems, the manual-call
+sweep API, and the pre-destroy hook auto-sweep. One prefab-layer
+escape-hatch remains gated on architect review:
+
+- **Stateful lambdas.** `LambdaModifier::fn_` is `std::function<float(float)>`
+  — pure base→effective. Patterns that need per-modifier mutable state
+  (velocity-drag's hover/blend, glow's hold/fade phases, anything with
+  an elapsed-time accumulator) cannot be expressed today. The architect-
+  preferred path is the "companion component" shape (entity ID threaded
+  into the lambda; state lives in a sibling component on the source).
+  Design proposal in `docs/design/modifier_stateful_lambdas.md`; needs
+  architect lock-in before implementation.
+
+The stateful-lambda gap is prefab-layer work but has cross-cutting
+implications (lambda signature change, new "companion component"
+convention) and is gated on architect review.
+
+The pre-destroy hook used for auto-sweep is a generic
+`EntityManager::registerPreDestroyHook` mechanism (see
+`engine/entity/CLAUDE.md`). Iterating all entities with `C_Modifiers`
+on every destruction is O(N) per destroy; for high-churn workloads a
+reverse-index (which targets carry modifiers from source X) would
+make sweeps O(K) in the per-source modifier count instead. Defer the
+index until a profile shows the linear sweep matters.

--- a/.fleet/status/render-api-relocations.md
+++ b/.fleet/status/render-api-relocations.md
@@ -1,0 +1,14 @@
+# Render API relocations — feature surfaces still on `IRRender::`
+
+Features still on the `IRRender::` namespace that should move to
+feature-scoped prefab namespaces, per the rule in
+`engine/render/CLAUDE.md` "What belongs in `engine/render/` vs
+`engine/prefabs/irreden/render/`".
+
+| Feature | Current (wrong) surface | Tracking task |
+|---|---|---|
+| Sun lighting | `IRRender::setSunDirection` / `getSunDirection` | T-036 (PR #210) |
+| Debug overlay | `IRRender::setDebugOverlay` / `getDebugOverlay` | T-035 (PR #235) |
+
+When a tracking task's PR merges, the queue-manager removes the
+corresponding row on its next maintenance pass.

--- a/.fleet/status/system-static-deviations.md
+++ b/.fleet/status/system-static-deviations.md
@@ -1,0 +1,19 @@
+# System: function-local `static` deviations
+
+Render system headers that still use `function-local static` for
+mutable system state instead of the canonical `SystemParams` pattern,
+per the rule in `engine/system/CLAUDE.md` "Don't use function-local
+`static` for system state". Migration tracked in T-065.
+
+- `engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_build_occupancy_grid.hpp`
+- `engine/prefabs/irreden/render/systems/system_fog_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp`
+- `engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp`
+- `engine/prefabs/irreden/render/systems/system_sprites_to_screen.hpp`
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp`
+- `engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp`
+- `engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ This repo runs a parallel-agent workflow. The rules:
    from there rather than inventing work. **Only the queue-manager agent
    edits `TASKS.md`** — author agents must never include TASKS.md changes
    in their feature PRs (this causes merge conflicts across all parallel
-   PRs). Reference the task title in your PR description instead.
+   PRs). Reference the task title in your PR description instead. The
+   same single-editor rule applies to `.fleet/status/*.md`; see
+   `.fleet/status/README.md`.
 
 See `TASKS.md` for the current queue and `.claude/skills/` for the exact
 commit/PR/review flows.

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -104,30 +104,9 @@ Key invariants the design rests on:
 
 ### Open follow-ups (runtime gaps)
 
-The current runtime ships all six resolver systems, the manual-call
-sweep API, and the pre-destroy hook auto-sweep. One prefab-layer
-escape-hatch remains gated on architect review:
-
-- **Stateful lambdas.** `LambdaModifier::fn_` is `std::function<float(float)>`
-  — pure base→effective. Patterns that need per-modifier mutable state
-  (velocity-drag's hover/blend, glow's hold/fade phases, anything with
-  an elapsed-time accumulator) cannot be expressed today. The architect-
-  preferred path is the "companion component" shape (entity ID threaded
-  into the lambda; state lives in a sibling component on the source).
-  Design proposal in `docs/design/modifier_stateful_lambdas.md`; needs
-  architect lock-in before implementation.
-
-The stateful-lambda gap is prefab-layer work but has cross-cutting
-implications (lambda signature change, new "companion component"
-convention) and is gated on architect review.
-
-The pre-destroy hook used for auto-sweep is a generic
-`EntityManager::registerPreDestroyHook` mechanism (see
-`engine/entity/CLAUDE.md`). Iterating all entities with `C_Modifiers`
-on every destruction is O(N) per destroy; for high-churn workloads a
-reverse-index (which targets carry modifiers from source X) would
-make sweeps O(K) in the per-source modifier count instead. Defer the
-index until a profile shows the linear sweep matters.
+See `.fleet/status/modifier-runtime-gaps.md` (queue-manager-owned;
+feature PRs do not edit) for the current list of pending modifier
+runtime work and architect-gated decisions.
 
 ## Commands
 

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -146,14 +146,9 @@ the prefab layer".
 
 ### Current deviations
 
-Two features still need relocating in the T-035 / T-036 refactor stack:
-
-| Feature | Current (wrong) surface | Tracking task |
-|---|---|---|
-| Sun lighting | `IRRender::setSunDirection` / `getSunDirection` | T-036 (PR #210) |
-| Debug overlay | `IRRender::setDebugOverlay` / `getDebugOverlay` | T-035 (PR #235) |
-
-When a tracking task's PR merges, remove the corresponding row from this table.
+See `.fleet/status/render-api-relocations.md` (queue-manager-owned;
+feature PRs do not edit) for in-flight relocations of feature-specific
+API off `IRRender::` and onto feature-scoped prefab namespaces.
 
 ## Verifying render changes
 

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -106,19 +106,9 @@ named-resource pointers fetched once at engine init that never change — is
 fine as `static`. Those are program constants, not system state. The rule
 applies to *mutable* or *system-owned* state.
 
-**Current deviations** (migration tracked in T-065):
-- `engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp`
-- `engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp`
-- `engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp`
-- `engine/prefabs/irreden/render/systems/system_build_occupancy_grid.hpp`
-- `engine/prefabs/irreden/render/systems/system_fog_to_trixel.hpp`
-- `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp`
-- `engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp`
-- `engine/prefabs/irreden/render/systems/system_compute_sun_shadow.hpp`
-- `engine/prefabs/irreden/render/systems/system_sprites_to_screen.hpp`
-- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp`
-- `engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp`
-- `engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp`
+See `.fleet/status/system-static-deviations.md` (queue-manager-owned;
+feature PRs do not edit) for the current list of files still using
+function-local `static` for system state.
 
 ## Pipelines
 


### PR DESCRIPTION
## Summary

- Three CLAUDE.md sections were rapidly-changing roll-ups; parallel feature PRs that rewrote them collided on rebase (observed: T-061/T-060/T-062 on `engine/prefabs/irreden/common/CLAUDE.md` "Open follow-ups (runtime gaps)").
- Factor the three known instances out into queue-manager-owned files under `.fleet/status/`. Replace each CLAUDE.md section with a rate-stable one-line pointer.
- Same bookkeeping pattern as `TASKS.md` and `.fleet/plans/`: queue-manager is the sole editor; feature PRs read these files when a CLAUDE.md pointer directs to one but never include diffs against them.

## Files factored out

| Source CLAUDE.md section | Moved to |
|---|---|
| `engine/prefabs/irreden/common/CLAUDE.md` "Open follow-ups (runtime gaps)" | `.fleet/status/modifier-runtime-gaps.md` |
| `engine/render/CLAUDE.md` "Current deviations" | `.fleet/status/render-api-relocations.md` |
| `engine/system/CLAUDE.md` "Current deviations" (function-local static list) | `.fleet/status/system-static-deviations.md` |

## Role-doc updates

- `role-queue-manager.md` — extends sole-editor responsibility and the bookkeeping push exception (direct-push-to-master scope) to `.fleet/status/*.md` alongside the existing `TASKS.md` and `.fleet/plans/*.md`.
- `role-opus-worker.md`, `role-sonnet-author.md` — hard rule that workers do not edit `.fleet/status/*.md` in feature PRs.
- `CLAUDE.md` (project root, rule 6) — extends the TASKS.md single-editor rule to `.fleet/status/*.md` by reference.

## Acceptance check (issue #389)

- [x] (1) status prose factored out of CLAUDE.md sections that feature PRs touch into queue-manager-owned files (option 1 from the issue).
- [x] (2) worker docs updated — workers don't edit `.fleet/status/` in feature PRs (option 1's stronger form of "restate only changed lines").
- [x] (3) chosen path documented — `.fleet/status/README.md` and project-root `CLAUDE.md` rule 6.

## Test plan

- [x] `fleet-build --target IRShapeDebug` clean (docs-only diff but ran a sanity build on macOS — links cleanly).
- [ ] Reviewer: confirm the three pointer lines in CLAUDE.md still leave each section's surrounding paragraphs coherent (i.e. no orphaned "When a tracking task's PR merges, remove the corresponding row" prose).
- [ ] Reviewer: spot-check that the new role rules don't contradict existing ownership — workers' "never edit `.fleet/status/`" is parallel to the existing "never edit TASKS.md" rule, not a new constraint class.

## Notes for reviewer

- One follow-up worth filing: the queue-manager doesn't yet auto-prune `.fleet/status/render-api-relocations.md` rows when a tracked PR merges (the file references PR #210 and #235 by number). Maintenance pass step in `role-queue-manager.md` could be extended to scan for `PR #N` markers and prune; deferred for v1.
- A second follow-up: programmatic enforcement (e.g. `commit-and-push` aborts when a feature PR's diff includes `.fleet/status/*.md`) would be belt+suspenders. Skipped here to keep the diff scoped to the factor-out itself.

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)