### PR TITLE
fleet: lower opus EFFORT from max to xhigh

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -61,12 +61,14 @@ ROLE="${2:?usage: fleet-babysit <model> <role> [mode] [loop-interval]}"
 MODE="${3:-dry-run}"
 LOOP_INTERVAL="${4:-}"
 
-# Effort level — derived from model. Opus agents get max thinking
-# budget (architects + workers do the hard reasoning). Sonnet agents
-# get high (good output without burning the budget on tasks where
+# Effort level — derived from model. Opus agents get xhigh (one notch
+# below `max`); architects, opus-workers, opus-reviewer, and merger
+# all do the hard reasoning, but `max` was burning budget faster than
+# the marginal quality justified on routine fleet iterations. Sonnet
+# agents get high (good output without burning budget on tasks where
 # diminishing returns kick in).
 case "$MODEL" in
-    opus|claude-opus*) EFFORT="max" ;;
+    opus|claude-opus*) EFFORT="xhigh" ;;
     sonnet|claude-sonnet*) EFFORT="high" ;;
     *) EFFORT="high" ;;
 esac

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -621,7 +621,7 @@ layout (two windows):
     bottom — witness        terminal (\$HOME, free-form shell)
 
 effort levels:
-  opus agents (architects, opus-workers, opus-reviewer, merger) — max
+  opus agents (architects, opus-workers, opus-reviewer, merger) — xhigh
   sonnet agents (sonnet-fleet-1/2, sonnet-reviewer, queue-manager) — high
   override globally by exporting FLEET_EFFORT=<level> before fleet-up.
   (to change one pane, edit fleet-babysit's case statement — fleet-up


### PR DESCRIPTION
## Summary
- `EFFORT` for all opus panes (opus-architect, game-architect, opus-worker-1/2, opus-reviewer, merger) drops from `max` → `xhigh`.
- Sonnet panes (sonnet-fleet-1/2, sonnet-reviewer, queue-manager) stay at `high`.
- `max` was over-spending Opus budget on routine fleet iterations relative to the marginal quality gain. `xhigh` is one notch below — same reasoning shape on hard core-engine reviews, lower cost on the long tail.

## Test plan
- [ ] After next `fleet-up`, opus panes log `starting (claude-opus-4-7 effort=xhigh) ...` instead of `effort=max` (visible in `~/.fleet/logs/<role>.log` headers)
- [ ] `FLEET_EFFORT=max fleet-up` still works as a one-shot override
- [ ] Sonnet panes remain at `high` (no regression on the sonnet side)

## Notes for reviewer
Two-file mechanical change:
- `scripts/fleet/fleet-babysit:68-77` — case-statement constant + comment update
- `scripts/fleet/fleet-up:623` — help-text line keeps the docs in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)