### PR TITLE
scripts/fleet: add debugger launcher

### DIFF
--- a/scripts/fleet/README.md
+++ b/scripts/fleet/README.md
@@ -45,12 +45,17 @@ fleet workflow.
   under `creations/` and `test/` by default, or `--plan` for CMake
   demo/test target names from `cmake --build --target help`. Use
   `fleet-run --targets --plain` for one name per line (e.g. pipe to `fzf`).
+- **`fleet-debug`** — builds a target through `fleet-build`, finds the
+  resulting executable under `build/`, changes to its runtime directory,
+  and launches it under `lldb` or `gdb`. Use `--batch` for non-interactive
+  crash triage that runs once and prints all thread backtraces.
 - **`fleet-help`** — prints an index of all `fleet-*` tools (build, run,
   tmux fleet, claims, …) and how to install them; `fleet-help <cmd>`
   forwards to `--help` when the tool supports it (or a short summary).
 - **`completions/fleet-run.bash`** — bash tab completion for `fleet-run`
   (built exe names when the word does not start with `-`) and
-  `fleet-build` (CMake demo names after `--target`). `install.sh`
+  `fleet-build` (CMake demo names after `--target`) plus `fleet-debug`.
+  `install.sh`
   symlinks it into `${XDG_DATA_HOME:-~/.local/share}/bash-completion/completions/`
   for bash-completion / Homebrew `bash-completion@2`.
 - **`completions/irreden-fleet.zsh`** — zsh entry: ensures `compinit` (if

--- a/scripts/fleet/completions/fleet-run.bash
+++ b/scripts/fleet/completions/fleet-run.bash
@@ -1,4 +1,4 @@
-# Bash programmable completion for fleet-run and fleet-build.
+# Bash programmable completion for fleet-run, fleet-build, and fleet-debug.
 # Bash 3.2+ (macOS default). Uses compgen, not mapfile.
 #
 # fleet-run: words not starting with "-" complete built executable basenames
@@ -9,7 +9,7 @@
 # (same as "fleet-run-targets --plan --plain").
 #
 # install.sh symlinks this file into:
-#   ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/{fleet-run,fleet-build}
+#   ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/{fleet-run,fleet-build,fleet-debug}
 # Requires bash-completion to load ~/.local/share/bash-completion/completions/*
 # (many distros and Homebrew bash-completion@2 do). Otherwise: source this file.
 #
@@ -54,6 +54,13 @@ _irreden_fleet_plan_words() {
     cmd="$(_irreden_fleet_run_targets_cmd)"
     [[ -n "$cmd" ]] || return 0
     "$cmd" --plan --plain 2>/dev/null
+}
+
+_irreden_fleet_debug_words() {
+    {
+        _irreden_fleet_built_words
+        _irreden_fleet_plan_words
+    } | LC_ALL=C sort -u
 }
 
 _irreden_fleet_run_targets_mode() {
@@ -141,5 +148,49 @@ _irreden_fleet_build_complete() {
     return 1
 }
 
+_irreden_fleet_debug_first_target_slot() {
+    local i a skip=0
+    for ((i = 1; i < COMP_CWORD; i++)); do
+        a="${COMP_WORDS[i]}"
+        [[ -z "$a" ]] && continue
+        if ((skip)); then
+            skip=0
+            continue
+        fi
+        if [[ "$a" == -- ]]; then
+            return 1
+        fi
+        case "$a" in
+            --build-dir | --debugger) skip=1 ;;
+            --batch | --no-build) ;;
+            -*) ;;
+            *) return 1 ;;
+        esac
+    done
+    return 0
+}
+
+_irreden_fleet_debug_complete() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD - 1]}"
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help --batch --no-build --build-dir --debugger" -- "$cur"))
+        return 0
+    fi
+
+    case "$prev" in
+        --build-dir | --debugger) return 1 ;;
+    esac
+
+    if _irreden_fleet_debug_first_target_slot; then
+        COMPREPLY=($(compgen -W "$(_irreden_fleet_debug_words | tr '\n' ' ')" -- "$cur"))
+        return 0
+    fi
+
+    return 1
+}
+
 complete -F _irreden_fleet_run_complete fleet-run
 complete -F _irreden_fleet_build_complete fleet-build
+complete -F _irreden_fleet_debug_complete fleet-debug

--- a/scripts/fleet/completions/irreden-fleet.zsh
+++ b/scripts/fleet/completions/irreden-fleet.zsh
@@ -1,4 +1,4 @@
-# Zsh: fleet-run / fleet-build tab completion via bashcompinit + fleet-run.bash
+# Zsh: fleet-run / fleet-build / fleet-debug completion via bashcompinit + fleet-run.bash
 #
 # Install: scripts/fleet/install.sh symlinks this file and fleet-run.bash into
 #   ~/.zsh/completions/ and idempotently appends a marked source line to

--- a/scripts/fleet/fleet-debug
+++ b/scripts/fleet/fleet-debug
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# fleet-debug — build and debug a target from its runtime directory.
+#
+# Mirrors fleet-run's cwd behavior so data/, shaders/, and scripts/ resolve
+# beside the executable, then launches the process under lldb or gdb.
+#
+# Usage:
+#   fleet-debug IRShapeDebug
+#   fleet-debug --batch IRLightingCombined
+#   fleet-debug --no-build --debugger lldb IRShapeDebug -- --auto-screenshot
+#
+# Source of truth: scripts/fleet/fleet-debug in the engine repo.
+# Installed to ~/bin/fleet-debug (as a symlink) by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+BUILD_DIR=""
+DEBUGGER=""
+SHOULD_BUILD=true
+BATCH=false
+
+usage() {
+    cat <<'USAGE'
+usage: fleet-debug [options] <target-or-executable> [--] [program-args...]
+
+Builds <target-or-executable> with the current worktree's debug build tree,
+finds the built executable under build/, cd's beside it, and starts a debugger
+from that runtime directory.
+
+Options
+  --batch             Non-interactive crash triage: run immediately, then print
+                      all thread backtraces before exiting.
+  --no-build          Do not run fleet-build first. Useful if the binary is
+                      already built and you only want to re-run under debugger.
+  --build-dir <dir>   CMake build directory. Default resolution matches
+                      fleet-build / fleet-run:
+                        1. this flag
+                        2. $IRREDEN_BUILD_DIR
+                        3. git worktree root + /build
+                        4. $HOME/src/IrredenEngine/build
+  --debugger <name>   Debugger executable to use. Default:
+                        macOS: lldb, then gdb
+                        other: gdb, then lldb
+  --help | -h         Show this text.
+
+Examples
+  fleet-debug IRShapeDebug
+  fleet-debug --batch IRLightingCombined
+  fleet-debug --no-build --debugger lldb IRShapeDebug -- --auto-screenshot
+
+Notes
+  The repo's fleet presets are already debug builds (CMAKE_BUILD_TYPE=Debug).
+  This command builds via fleet-build unless --no-build is passed.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --batch)
+            BATCH=true
+            shift
+            ;;
+        --no-build)
+            SHOULD_BUILD=false
+            shift
+            ;;
+        --build-dir)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "fleet-debug: --build-dir requires a directory path" >&2
+                exit 2
+            fi
+            BUILD_DIR="$2"
+            shift 2
+            ;;
+        --debugger)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "fleet-debug: --debugger requires a command name" >&2
+                exit 2
+            fi
+            DEBUGGER="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "fleet-debug: unknown option '$1' (try fleet-debug --help)" >&2
+            exit 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: fleet-debug [--batch] [--no-build] [--build-dir <dir>] <target-or-executable> [--] [program-args...]" >&2
+    echo "       fleet-debug --help" >&2
+    exit 2
+fi
+
+TARGET_NAME="$1"
+shift
+if [[ "${1:-}" == "--" ]]; then
+    shift
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/src/IrredenEngine")
+BUILD_DIR="${BUILD_DIR:-${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}}"
+
+if $SHOULD_BUILD; then
+    FLEET_BUILD="$SCRIPT_DIR/fleet-build"
+    if [[ ! -x "$FLEET_BUILD" ]]; then
+        if command -v fleet-build >/dev/null 2>&1; then
+            FLEET_BUILD="$(command -v fleet-build)"
+        else
+            echo "fleet-debug: could not find fleet-build next to this script or on PATH" >&2
+            exit 1
+        fi
+    fi
+    echo "fleet-debug: building target $TARGET_NAME"
+    IRREDEN_BUILD_DIR="$BUILD_DIR" "$FLEET_BUILD" --target "$TARGET_NAME"
+fi
+
+if [[ ! -d "$BUILD_DIR" ]]; then
+    echo "fleet-debug: build directory $BUILD_DIR does not exist." >&2
+    echo "             run 'fleet-build --target $TARGET_NAME' first, or omit --no-build." >&2
+    exit 1
+fi
+
+resolve_debugger() {
+    if [[ -n "$DEBUGGER" ]]; then
+        if command -v "$DEBUGGER" >/dev/null 2>&1; then
+            command -v "$DEBUGGER"
+            return 0
+        fi
+        echo "fleet-debug: debugger '$DEBUGGER' was not found on PATH" >&2
+        return 1
+    fi
+
+    case "$(uname -s)" in
+        Darwin)
+            command -v lldb >/dev/null 2>&1 && { command -v lldb; return 0; }
+            command -v gdb >/dev/null 2>&1 && { command -v gdb; return 0; }
+            ;;
+        *)
+            command -v gdb >/dev/null 2>&1 && { command -v gdb; return 0; }
+            command -v lldb >/dev/null 2>&1 && { command -v lldb; return 0; }
+            ;;
+    esac
+
+    echo "fleet-debug: no debugger found (install lldb or gdb, or pass --debugger <cmd>)" >&2
+    return 1
+}
+
+find_executable() {
+    local name=$1
+    local candidate
+
+    while IFS= read -r candidate; do
+        printf '%s\n' "$candidate"
+        return 0
+    done < <(find "$BUILD_DIR" -name "$name" -type f -perm -u=x 2>/dev/null)
+
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            while IFS= read -r candidate; do
+                printf '%s\n' "$candidate"
+                return 0
+            done < <(find "$BUILD_DIR" -name "${name}.exe" -type f 2>/dev/null)
+            ;;
+    esac
+
+    return 1
+}
+
+EXE_PATH=$(find_executable "$TARGET_NAME" || true)
+if [[ -z "$EXE_PATH" ]]; then
+    echo "fleet-debug: could not find executable '$TARGET_NAME' in $BUILD_DIR" >&2
+    echo "             build it first: fleet-build --target $TARGET_NAME" >&2
+    echo "             list targets:    fleet-run --targets --plan" >&2
+    exit 1
+fi
+
+DEBUGGER_PATH=$(resolve_debugger)
+DEBUGGER_NAME=$(basename "$DEBUGGER_PATH")
+EXE_DIR=$(dirname "$EXE_PATH")
+EXE_BASE=$(basename "$EXE_PATH")
+
+echo "fleet-debug: $DEBUGGER_NAME $EXE_PATH $*"
+cd "$EXE_DIR"
+
+case "$DEBUGGER_NAME" in
+    lldb|lldb-*)
+        if $BATCH; then
+            exec "$DEBUGGER_PATH" --batch -o run -o "thread backtrace all" -- "./$EXE_BASE" "$@"
+        fi
+        exec "$DEBUGGER_PATH" -- "./$EXE_BASE" "$@"
+        ;;
+    gdb|gdb-*)
+        if $BATCH; then
+            exec "$DEBUGGER_PATH" -q -ex run -ex "thread apply all bt" -ex quit --args "./$EXE_BASE" "$@"
+        fi
+        exec "$DEBUGGER_PATH" --args "./$EXE_BASE" "$@"
+        ;;
+    *)
+        if $BATCH; then
+            echo "fleet-debug: --batch only knows lldb and gdb command syntax (got $DEBUGGER_NAME)" >&2
+            exit 2
+        fi
+        exec "$DEBUGGER_PATH" "./$EXE_BASE" "$@"
+        ;;
+esac

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -45,6 +45,9 @@ Or (curated demo names):
   fleet-run --targets --plan
 EOF
             ;;
+        fleet-debug)
+            bash "$path" --help
+            ;;
         fleet-up)
             cat <<'EOF'
 fleet-up — multi-pane tmux fleet + optional scout daemon.
@@ -144,6 +147,10 @@ Engine build / run (everyday dev)
       cmake --build wrapper; auto -j; auto-configures <worktree>/build
       on first run. Same build directory as fleet-run.
 
+  fleet-debug [--batch] <target-or-exe> [-- program-args...]
+      Builds with fleet-build, cd's beside data/shaders/scripts, then starts
+      lldb/gdb. Use --batch to run once and print all thread backtraces.
+
   fleet-run [--build-dir <dir>] [--timeout N] <exe-name> [args...]
       Finds the built binary under build/, cd's beside data/shaders/scripts.
 
@@ -152,6 +159,7 @@ Engine build / run (everyday dev)
 
   Per-tool:  fleet-help fleet-run
               fleet-help fleet-build
+              fleet-help fleet-debug
 
   Tab completion: see scripts/fleet/README.md (Files › completions).
 

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -100,6 +100,8 @@ FLEET_CLAIM_SRC="$SCRIPT_DIR/fleet-claim"
 FLEET_CLAIM_DEST="$HOME/bin/fleet-claim"
 FLEET_BUILD_SRC="$SCRIPT_DIR/fleet-build"
 FLEET_BUILD_DEST="$HOME/bin/fleet-build"
+FLEET_DEBUG_SRC="$SCRIPT_DIR/fleet-debug"
+FLEET_DEBUG_DEST="$HOME/bin/fleet-debug"
 FLEET_RUN_SRC="$SCRIPT_DIR/fleet-run"
 FLEET_RUN_DEST="$HOME/bin/fleet-run"
 FLEET_RUN_TARGETS_SRC="$SCRIPT_DIR/fleet-run-targets"
@@ -131,7 +133,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -158,6 +160,11 @@ fi
 if [[ -f "$FLEET_BUILD_SRC" ]]; then
     ln -sf "$FLEET_BUILD_SRC" "$FLEET_BUILD_DEST"
     echo "symlinked $FLEET_BUILD_DEST -> $FLEET_BUILD_SRC"
+fi
+
+if [[ -f "$FLEET_DEBUG_SRC" ]]; then
+    ln -sf "$FLEET_DEBUG_SRC" "$FLEET_DEBUG_DEST"
+    echo "symlinked $FLEET_DEBUG_DEST -> $FLEET_DEBUG_SRC"
 fi
 
 if [[ -f "$FLEET_RUN_SRC" ]]; then
@@ -224,7 +231,8 @@ if [[ -f "$FLEET_COMP_SRC" ]]; then
     mkdir -p "$BASH_COMP_DIR"
     ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-run"
     ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-build"
-    echo "symlinked bash completion -> $BASH_COMP_DIR/fleet-run (+ fleet-build)"
+    ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-debug"
+    echo "symlinked bash completion -> $BASH_COMP_DIR/fleet-run (+ fleet-build, fleet-debug)"
 fi
 
 # Zsh: bash-completion dirs are not read by zsh; irreden-fleet.zsh uses
@@ -356,7 +364,7 @@ esac
 
 if [[ -f "$FLEET_COMP_SRC" ]]; then
     echo
-    echo "Bash tab-completion for fleet-run / fleet-build (built targets and"
+    echo "Bash tab-completion for fleet-run / fleet-build / fleet-debug (built targets and"
     echo "  fleet-build --target names) installs under:"
     echo "    $BASH_COMP_DIR"
     echo "  Open a new bash login shell (or: source your bash-completion init)"


### PR DESCRIPTION
## Summary
- Add `fleet-debug`, a debugger wrapper that builds through `fleet-build`, runs from the executable runtime directory, and launches `lldb` or `gdb`.
- Support `--batch` crash triage for one-shot runs that print all thread backtraces.
- Wire the new helper into installer symlinks, `fleet-help`, README docs, and shell completions.

## Test plan
- [x] `bash -n scripts/fleet/fleet-debug`
- [x] `bash -n scripts/fleet/install.sh`
- [x] `bash -n scripts/fleet/fleet-help`
- [x] `bash -n scripts/fleet/completions/fleet-run.bash`
- [x] `scripts/fleet/fleet-debug --help`
- [x] `scripts/fleet/fleet-help fleet-debug`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)