### PR TITLE
T-085: fleet: set fleet:changes-made atomically in DEFER handoff + fleet:human-deferred reviewer skip

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -158,12 +158,16 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
      `submittedAt`).
 
    **Skip** PRs labeled `fleet:wip`, `human:wip`, `human:needs-fix`,
+   `fleet:human-amending`, `fleet:human-deferred`,
    `fleet:semantic-conflict`, or `fleet:fork-of-other-pr` — those are
-   either in-progress, human-owned, queued for conflict resolution
-   (diff against master is meaningless until the rebase lands), or
-   forked from another open PR (diff includes inherited commits that
-   don't belong to this PR's scope — skip until the human runs
-   `rebase --onto` and clears this label).
+   either in-progress, human-owned, under active author fixes
+   (`fleet:human-amending`), in DEFER mode where the human decides
+   to merge as-is or re-flag (`fleet:human-deferred` — do NOT
+   re-apply `fleet:needs-fix` for deferred concerns), queued for
+   conflict resolution (diff against master is meaningless until the
+   rebase lands), or forked from another open PR (diff includes
+   inherited commits that don't belong to this PR's scope — skip
+   until the human runs `rebase --onto` and clears this label).
 
 ## Loop behavior
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -314,10 +314,11 @@ Do the work, then exit cleanly:
           - **Suggested area** — module path
           - **Suggested approach** — bullets, for the picker to
             validate
-       2. Swap PR labels in one combine-safe call (the removed
-          label is guaranteed present — that is what brought you
-          here):
-          `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --add-label "fleet:human-deferred"`
+       2. Swap PR labels atomically — `fleet:changes-made` MUST be
+          added in the same call as `human:needs-fix` is removed to
+          prevent a labeless window the reviewer could mistake for a
+          missing verdict and re-apply `fleet:needs-fix` into:
+          `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --add-label "fleet:human-deferred" --add-label "fleet:changes-made"`
        3. **Keep `fleet:approved`** — the PR is internally
           consistent, the prior reviewer approval stands.
           `fleet:human-deferred` signals: "agent acknowledged the

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -216,10 +216,11 @@ Each iteration:
           - **Suggested area** — module path
           - **Suggested approach** — bullets, for the picker to
             validate
-       2. Swap PR labels (one call combines remove+add safely
-          because `human:needs-fix` is guaranteed present — that
-          is what brought you here):
-          `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --add-label "fleet:human-deferred"`
+       2. Swap PR labels atomically — `fleet:changes-made` MUST be
+          added in the same call as `human:needs-fix` is removed to
+          prevent a labeless window the reviewer could mistake for a
+          missing verdict and re-apply `fleet:needs-fix` into:
+          `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --add-label "fleet:human-deferred" --add-label "fleet:changes-made"`
        3. **Keep `fleet:approved`** — the PR is internally
           consistent, the prior reviewer approval stands.
           `fleet:human-deferred` signals: "agent acknowledged the
@@ -299,9 +300,9 @@ Each iteration:
      re-verifies (whichever first; reviewer removes the label on
      pickup to avoid double-processing). Reviewer's re-approval
      re-sets `fleet:approved`.
-   - **ESCALATE**: agent files a follow-up issue, swaps
-     `human:needs-fix` for `fleet:human-deferred`, KEEPS
-     `fleet:approved`. Human reviews the linked issue and either
+   - **ESCALATE**: agent files a follow-up issue, atomically swaps
+     `human:needs-fix` for `fleet:human-deferred` + `fleet:changes-made`,
+     KEEPS `fleet:approved`. Human reviews the linked issue and either
      accepts the deferral (PR ready to merge) or re-adds
      `human:needs-fix` to force AMEND mode on the next iteration.
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -140,6 +140,10 @@ treat it as a hard rule for this role.
      feedback is being addressed.
    - `fleet:human-amending` — author agent is actively addressing
      human feedback. Hold review until `fleet:changes-made` appears.
+   - `fleet:human-deferred` — author chose DEFER mode: acknowledged
+     concerns, filed a follow-up issue, and the human decides to
+     merge as-is or re-add `human:needs-fix` to force inline fixes.
+     Do NOT re-apply `fleet:needs-fix` for deferred concerns.
    - `fleet:semantic-conflict` — merger detected a non-mechanical
      rebase conflict; the opus-worker is queued to attempt
      resolution. The PR's diff against master is meaningless until
@@ -170,7 +174,7 @@ iteration of polling, reviewing, and exiting cleanly:
    `fleet:changes-made` (remove the label on pickup), or with a "re-review please"
    comment after the last fleet review. Skip PRs carrying any of
    `fleet:wip`, `human:wip`, `human:needs-fix`, `fleet:human-amending`,
-   `fleet:semantic-conflict`, or `fleet:fork-of-other-pr`. For each remaining candidate, in
+   `fleet:human-deferred`, `fleet:semantic-conflict`, or `fleet:fork-of-other-pr`. For each remaining candidate, in
    oldest-first order:
 
    **Engine PRs** (default repo): Invoke the `review-pr` skill with

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -172,10 +172,16 @@ iteration of polling, reviewing, and exiting cleanly:
 2. Re-apply the same candidate criteria from startup step 5: pick up
    PRs with no fleet review, with `human:re-review`, with
    `fleet:changes-made` (remove the label on pickup), or with a "re-review please"
-   comment after the last fleet review. Skip PRs carrying any of
-   `fleet:wip`, `human:wip`, `human:needs-fix`, `fleet:human-amending`,
-   `fleet:human-deferred`, `fleet:semantic-conflict`, or `fleet:fork-of-other-pr`. For each remaining candidate, in
-   oldest-first order:
+   comment after the last fleet review. Skip PRs carrying any of:
+   - `fleet:wip` — not ready for review
+   - `human:wip` — human is working on it
+   - `human:needs-fix` — human feedback is being addressed
+   - `fleet:human-amending` — author actively addressing human feedback
+   - `fleet:human-deferred` — DEFER mode; human decides to merge or re-flag
+   - `fleet:semantic-conflict` — merger conflict pending resolution
+   - `fleet:fork-of-other-pr` — inherited commits; skip until `rebase --onto`
+
+   For each remaining candidate, in oldest-first order:
 
    **Engine PRs** (default repo): Invoke the `review-pr` skill with
    the PR number. Every engine PR today is single-task — one task, one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,11 +573,16 @@ Specifically, **never pass these via `--label` when filing**:
     longer valid until the reviewer re-approves the amended diff).
     **Read as: "hold merge, fixes pending."**
   - `fleet:human-deferred` — worker filed the human's concerns as
-    a follow-up issue rather than amending this PR. Set when the
-    worker removes `human:needs-fix`; **kept** until the human
-    either accepts the deferral (PR merges with this label) or
-    re-adds `human:needs-fix` to force AMEND mode on the next
+    a follow-up issue rather than amending this PR. Set atomically
+    with `fleet:changes-made` when the worker removes `human:needs-fix`
+    (both in one `gh pr edit` call to prevent a labeless gap where
+    the reviewer could re-apply `fleet:needs-fix`). **Kept** until
+    the human either accepts the deferral (PR merges with this label)
+    or re-adds `human:needs-fix` to force AMEND mode on the next
     iteration. `fleet:approved` is kept (PR is internally OK).
+    **Reviewer agents skip PRs with this label** — the human is the
+    decision-maker; do NOT re-apply `fleet:needs-fix` for deferred
+    concerns.
     **Read as: "agent acknowledged your concerns, linked issue
     tracks them, you decide whether to merge as-is or re-flag."**
 - `fleet:design-blocked` / `fleet:design-unblocked` — paired


### PR DESCRIPTION
## Summary
- In the DEFER/ESCALATE option-B handoff, `fleet:changes-made` is now set in the same `gh pr edit` call as `human:needs-fix` is removed — eliminating the labeless window where a reviewer could re-apply `fleet:needs-fix` (root cause of the race observed on PR #394, T-069).
- `fleet:human-deferred` added to reviewer skip lists in both `role-opus-reviewer.md` and `role-sonnet-reviewer.md` — a PR in DEFER mode is "human decides" state; reviewer agents should not re-flag deferred concerns.
- `fleet:human-amending` added to `role-opus-reviewer.md` skip list (was missing; `role-sonnet-reviewer.md` already had it).
- `CLAUDE.md` label discipline entry for `fleet:human-deferred` updated to document the atomic pairing and reviewer-skip behavior.

## Test plan
- [ ] DEFER path in role-sonnet-author and role-opus-worker: the `gh pr edit` command includes both `--add-label "fleet:human-deferred"` and `--add-label "fleet:changes-made"` in a single call
- [ ] role-opus-reviewer.md skip list includes `fleet:human-amending` and `fleet:human-deferred`
- [ ] role-sonnet-reviewer.md skip list (startup step 5 AND loop step 2) both include `fleet:human-deferred`
- [ ] CLAUDE.md fleet:human-deferred entry mentions atomic pairing and reviewer skip

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)