### PR TITLE
T-083: render/metal: fix getEntityIdAtMouseTrixel stale-pointer UAF

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
@@ -49,7 +49,7 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
             BufferTarget::UNIFORM,
             kBufferIndex_FrameDataUniformIsoTriangles
         );
-        struct { uvec2 entityId{0u, 0u}; float depth{1.0f}; float _pad{0.0f}; } initData;
+        HoveredEntityIdLayout initData;
         IRRender::createNamedResource<Buffer>(
             "HoveredEntityIdBuffer",
             &initData,
@@ -141,7 +141,7 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
             },
             [p]() {
-                struct { uvec2 entityId{0u, 0u}; float depth{1.0f}; float _pad{0.0f}; } resetData;
+                HoveredEntityIdLayout resetData;
                 p->hoveredIdBuf_->subData(0, sizeof(resetData), &resetData);
                 p->program_->use();
                 p->quadVao_->bind();

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -51,6 +51,17 @@ struct FrameDataScreenResidualRotate {
     float _pad0 = 0.0f;
 };
 
+/// CPU mirror of the @c HoveredEntityIdBuffer SSBO layout (binding 14).
+/// The fragment shader writes the hovered entity id + depth here every frame;
+/// @c IRRender::getEntityIdAtMouseTrixel reads it back via persistent map.
+/// The binary layout must stay byte-identical to the GLSL/MSL @c std430 block
+/// declared in @c f_trixel_to_framebuffer.glsl and @c trixel_to_framebuffer.metal.
+struct HoveredEntityIdLayout {
+    uvec2 entityId_{0u, 0u};
+    float depth_{1.0f};
+    float _pad_{0.0f};
+};
+
 struct FrameDataTrixelToFramebuffer {
     mat4 mpMatrix_;
     vec2 canvasZoomLevel_;

--- a/engine/render/src/ir_render.cpp
+++ b/engine/render/src/ir_render.cpp
@@ -97,29 +97,22 @@ ivec2 mouseTrixelPositionWorld() {
 }
 
 IREntity::EntityId getEntityIdAtMouseTrixel() {
-    static void *s_mappedPtr = nullptr;
-
     auto *buf = IRRender::getNamedResource<Buffer>("HoveredEntityIdBuffer");
     if (!buf)
         return IREntity::kNullEntity;
 
-    if (!s_mappedPtr) {
-        struct HoveredLayout {
-            uvec2 entityId;
-            float depth;
-            float _pad;
-        };
-        s_mappedPtr = buf->mapRange(
-            0,
-            sizeof(HoveredLayout),
-            BUFFER_STORAGE_MAP_READ | BUFFER_STORAGE_MAP_PERSISTENT | BUFFER_STORAGE_MAP_COHERENT
-        );
-    }
-    if (!s_mappedPtr)
+    // Re-fetch every frame: on Metal, subData orphans the MTL::Buffer (see
+    // metal_buffer.cpp), so any cached pointer is a use-after-free.
+    void *mappedPtr = buf->mapRange(
+        0,
+        sizeof(HoveredEntityIdLayout),
+        BUFFER_STORAGE_MAP_READ | BUFFER_STORAGE_MAP_PERSISTENT | BUFFER_STORAGE_MAP_COHERENT
+    );
+    if (!mappedPtr)
         return IREntity::kNullEntity;
 
     uvec2 packed;
-    std::memcpy(&packed, s_mappedPtr, sizeof(uvec2));
+    std::memcpy(&packed, mappedPtr, sizeof(uvec2));
 
     return static_cast<IREntity::EntityId>(packed.x) |
            (static_cast<IREntity::EntityId>(packed.y) << 32);

--- a/engine/render/src/ir_render.cpp
+++ b/engine/render/src/ir_render.cpp
@@ -101,8 +101,9 @@ IREntity::EntityId getEntityIdAtMouseTrixel() {
     if (!buf)
         return IREntity::kNullEntity;
 
-    // Re-fetch every frame: on Metal, subData orphans the MTL::Buffer (see
-    // metal_buffer.cpp), so any cached pointer is a use-after-free.
+    // Re-fetch every frame: on Metal, subData orphans the MTL::Buffer on
+    // write (metal_buffer.cpp:58–79); a statically-cached pointer from
+    // mapRange would be stale by the next frame.
     void *mappedPtr = buf->mapRange(
         0,
         sizeof(HoveredEntityIdLayout),

--- a/engine/render/src/opengl/opengl_buffer.cpp
+++ b/engine/render/src/opengl/opengl_buffer.cpp
@@ -69,20 +69,39 @@ class OpenGLBufferImpl final : public BufferImpl {
     void *mapRange(
         std::ptrdiff_t offset, std::size_t length, std::uint32_t accessFlags
     ) override {
-        return ENG_API->glMapNamedBufferRange(
+        // Idempotent for the same range: glMapNamedBufferRange returns
+        // INVALID_OPERATION on an already-mapped buffer.
+        if (m_mappedPtr != nullptr && m_mappedOffset == offset && m_mappedLength == length) {
+            return m_mappedPtr;
+        }
+        if (m_mappedPtr != nullptr) {
+            ENG_API->glUnmapNamedBuffer(m_handle);
+            m_mappedPtr = nullptr;
+        }
+        m_mappedPtr = ENG_API->glMapNamedBufferRange(
             m_handle,
             static_cast<GLintptr>(offset),
             static_cast<GLsizeiptr>(length),
             toGLBufferStorageFlags(accessFlags)
         );
+        m_mappedOffset = offset;
+        m_mappedLength = length;
+        return m_mappedPtr;
     }
 
     void unmap() override {
+        if (m_mappedPtr == nullptr) {
+            return;
+        }
         ENG_API->glUnmapNamedBuffer(m_handle);
+        m_mappedPtr = nullptr;
     }
 
   private:
     GLuint m_handle = 0;
+    void *m_mappedPtr = nullptr;
+    std::ptrdiff_t m_mappedOffset = 0;
+    std::size_t m_mappedLength = 0;
 };
 
 std::unique_ptr<BufferImpl> createBufferImpl(const void *data, std::size_t size, std::uint32_t flags) {

--- a/engine/render/src/opengl/opengl_buffer.cpp
+++ b/engine/render/src/opengl/opengl_buffer.cpp
@@ -71,6 +71,7 @@ class OpenGLBufferImpl final : public BufferImpl {
     ) override {
         // Idempotent for the same range: glMapNamedBufferRange returns
         // INVALID_OPERATION on an already-mapped buffer.
+        // Cache key omits accessFlags — callers on the same range must use consistent flags.
         if (m_mappedPtr != nullptr && m_mappedOffset == offset && m_mappedLength == length) {
             return m_mappedPtr;
         }

--- a/engine/render/src/shaders/metal/trixel_to_framebuffer.metal
+++ b/engine/render/src/shaders/metal/trixel_to_framebuffer.metal
@@ -24,8 +24,8 @@ struct FrameDataIsoTriangles {
 // SSBO populated by the fragment shader when the mouse hovers over a
 // non-transparent trixel that wins the depth test. CPU side is
 // `HoveredEntityIdBuffer` (slot 14, kBufferIndex_HoveredEntityId);
-// readback layout matches the C++ `HoveredLayout` in
-// `getEntityIdAtMouseTrixel()` and the GLSL std430 buffer in
+// readback layout matches the C++ `HoveredEntityIdLayout` in
+// `ir_render_types.hpp` and the GLSL std430 buffer in
 // `f_trixel_to_framebuffer.glsl`.
 struct HoveredEntityIdBuffer {
     uint2 hoveredEntityId;


### PR DESCRIPTION
## Summary

Fixes a use-after-free in the Metal hover-readback path that PR #394
(T-069) newly exposed.

`getEntityIdAtMouseTrixel` cached the persistent-mapped pointer to
`HoveredEntityIdBuffer` on first call. `MetalBufferImpl::subData`
orphans the underlying `MTL::Buffer` every frame (creates a new
allocation, copies content with the write applied, deferred-releases
the old one). Starting on frame 2, the cached pointer was inside the
freed buffer while GPU writes landed in the new one — CPU hover reads
pulled from the wrong (released) memory.

The bug was silent before T-069 because the Metal fragment shader
didn't yet write to the SSBO. Reading zeros from the freed buffer
happened to match `kNullEntity`, so hover detection appeared dead
rather than corrupted.

## Fix (Option A from issue #403)

- **`engine/render/src/ir_render.cpp`** — Drop the static cache; call
  `Buffer::mapRange` every frame. On Metal this is just
  `m_buffer->contents() + offset`, so the per-frame call is one
  pointer arithmetic op.

- **`engine/render/src/opengl/opengl_buffer.cpp`** — `mapRange` now
  caches the persistent map internally so repeated calls with the same
  range return the cached pointer (per OpenGL spec, calling
  `glMapNamedBufferRange` on an already-mapped buffer is
  `INVALID_OPERATION`). Behavior on GL is identical to the original
  static-cache code path; this just moves the caching where each
  backend can implement it correctly.

- **`engine/render/include/irreden/render/ir_render_types.hpp`** —
  Extract a named `HoveredEntityIdLayout` for the SSBO mirror struct.
  Three sites (init in `system_trixel_to_framebuffer.hpp`, per-frame
  reset, and CPU readback in `ir_render.cpp`) used to declare anonymous
  copies of the same binary layout; now they share one type.

## Test plan

- [x] `fleet-build --target IRShapeDebug` clean on `macos-debug`
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` runs cleanly (all 6
      shots captured, no crash)
- [ ] Manual: `fleet-run IRShapeDebug` + hover cursor over a voxel/SDF
      shape for ~5s confirms `[HoverDetect] eid=...` logs fire (one
      every 600 ticks per `system_entity_hover_detect.hpp:127-128`)
- [ ] Cross-host: Linux/OpenGL smoke (the `OpenGLBufferImpl::mapRange`
      change is the only GL-side delta — same-range repeat call is now
      idempotent rather than a per-frame `glMapNamedBufferRange`)

## Notes for reviewer

The OpenGL backend change is a behavior change to the `mapRange`
abstraction: same range repeat calls now return the cached pointer
instead of re-mapping. Per OpenGL spec, re-mapping a persistent-mapped
buffer is `INVALID_OPERATION`, so no correct caller could rely on
fresh-map-each-call. The other `mapRange` caller
(`system_update_voxel_positions_gpu.hpp`) maps once at init via a
static — unaffected.

Closes #403