### PR TITLE
T-087: Sprite rendering: C_Sprite / C_SpriteSheet components + design note

### DIFF
--- a/docs/design/sprites.md
+++ b/docs/design/sprites.md
@@ -1,0 +1,185 @@
+# 2D sprite rendering
+
+Companion design note for the sprite epic (#14). v1 specs the data
+model, pipeline placement, and depth semantics for a flat-2D sprite
+layer that renders alongside the trixel pipeline. Implementation lands
+across five child tasks (T-087 establishes the data model; the
+remaining four ship the loader, render pass, animation system, and
+demo); this note is the authoritative reference for the cross-task
+invariants.
+
+## TL;DR
+
+- Sprites are **screen-composite**, not trixel content.
+- They draw at the `FRAMEBUFFER_TO_SCREEN` pipeline stage via a sibling
+  system `SPRITES_TO_SCREEN` (child task 3), bypassing the entire
+  voxel → trixel → framebuffer machinery.
+- One iso-projected depth per sprite. Sort order between sprites is a
+  per-entity scalar, not a per-pixel depth-buffer problem.
+- Anchor defaults to `{0.5, 0.0}` — bottom-center.
+- v1 ships sprites composited above the main canvas and below the GUI
+  canvas; cross-canvas z-sort is explicitly Part 2.
+
+## Why screen-composite, not trixel content
+
+The trixel pipeline rasterizes a 3D voxel field through an isometric
+projection into a fixed-resolution canvas, then blits the canvas to the
+screen with camera pan/zoom. That is the right machinery for blocky
+voxel content but the wrong one for textured 2D quads:
+
+- A trixel canvas writes per-pixel `(color, distance, entityId)` triplets
+  via `imageAtomicMin` keyed by depth. A sprite has one depth for the
+  whole quad, so it would race per-pixel against itself.
+- Sprite sub-pixel filtering, alpha blending, and arbitrary sub-rect UV
+  sampling all require a fragment-shader path; the trixel canvas is a
+  compute-shader path.
+- Lighting, AO, and fog of war operate on the canvas. Sprites should
+  bypass all of those passes — their look is owned by the sprite's
+  texture, not by the lighting state of the world cell underneath.
+
+Drawing sprites alongside the canvas blit (the
+`FRAMEBUFFER_TO_SCREEN` pass that already textures a quad with the
+fully-composited canvas) keeps each system focused on one shape of
+content.
+
+## Pipeline placement
+
+The render pipeline (per `engine/render/CLAUDE.md`) ends with the canvas
+chain:
+
+```
+…  →  TRIXEL_TO_FRAMEBUFFER  →  FRAMEBUFFER_TO_SCREEN  →  end of frame
+```
+
+Sprites slot in as a sibling system at the same stage as
+`FRAMEBUFFER_TO_SCREEN`, drawing **after** the main canvas's blit and
+**before** the GUI canvas's blit:
+
+```
+… → main FRAMEBUFFER_TO_SCREEN
+  → SPRITES_TO_SCREEN              ← new system, one draw per frame
+  → gui FRAMEBUFFER_TO_SCREEN
+```
+
+Both passes write to the default framebuffer; the order is enforced by
+the prefab's pipeline registration in child task 3, not by any
+canvas-target indirection.
+
+## Component model
+
+```
+C_Sprite                  C_SpriteSheet (optional)         C_SpriteAnimation (optional)
+┌───────────────────┐    ┌───────────────────────────┐    ┌─────────────────────────┐
+│ textureHandle     │    │ textureHandle             │    │ animationIndex          │
+│ size              │    │ atlasSizePx               │    │ frameIndex / elapsed    │
+│ uvRect            │ ←  │ frames[]                  │  → │ loop mode / speed       │
+│ anchor            │    │ animations[]              │    │                         │
+│ tint              │    │   (NamedAnimation rows)   │    └─────────────────────────┘
+└───────────────────┘    │ findAnimationIndex(name)  │
+                         └───────────────────────────┘
+   per-instance              per-asset (one per sheet)         per-instance, optional
+```
+
+The runtime animation component stores `animationIndex` (resolved once
+via `findAnimationIndex` when the animation is set) and indexes
+`C_SpriteSheet.animations_[i]` per tick — string lookup never happens
+on the playback hot path.
+
+`C_Sprite` is the only component a static (non-animated) sprite needs.
+`C_SpriteSheet` lives on the same entity (or a separate "asset" entity
+referenced via a relation; child task 2 picks the layering) and owns
+the atlas's CPU-side metadata. `C_SpriteAnimation` (child task 4) is
+the runtime animation state; the animation system writes back into
+`C_Sprite.uvRect` each tick.
+
+### v1 depth model
+
+Each sprite uses `C_Position3D`. Depth = `pos3DtoDistance(pos)` —
+exactly what the trixel pipeline uses to sort voxels. Sort order is
+back-to-front; alpha blending requires it.
+
+### Anchor
+
+`C_Sprite.anchor_` is in local UV space:
+
+- `{0.5, 0.0}` — bottom-center (default; matches an iso character whose
+  feet are at the world position).
+- `{0.5, 0.5}` — center.
+- `{0.0, 0.0}` — top-left.
+
+Quad origin = `isoProject(C_Position3D.pos_) - anchor * size`.
+
+### Non-iso seam
+
+Future creations may render in a non-isometric projection (e.g. flat 2D
+side-scroller). The seam to that future is documented here so the v1
+implementation doesn't bake the iso projection in:
+
+- A future `C_Position2D` + `C_Depth` pair replaces `C_Position3D`. The
+  sprite system reads either pair and resolves to a `(screenX, screenY,
+  depth)` triple — same downstream sort-key shape, different inputs.
+- The animation system, atlas loader, and shader code are **invariant**
+  to the choice — they touch UVs, frames, and tints, not screen
+  position.
+
+v1 implements only the `C_Position3D + iso-projection` path. The seam
+is a one-function-per-projection swap, not a refactor.
+
+## Sort scope (v1)
+
+- Sort sprites against each other by iso depth. Strict back-to-front;
+  ties broken by entity id for determinism.
+- Do NOT sort sprites against canvas framebuffers. The main canvas
+  always draws below sprites; the GUI canvas always draws above.
+  Cross-layer sort is Part 2 and would require a different output
+  topology (a depth buffer shared across passes).
+
+## Drawing model (v1, child task 3)
+
+One instanced draw per frame:
+
+- CPU iterates `(C_Sprite, C_Position3D)`, computes iso depth, sorts
+  the entity-id array.
+- CPU builds a per-instance buffer in sort order, packing
+  `{ mat4 model, vec4 uvRect, uint textureSlot, vec4 tint }` per sprite.
+- GPU issues `drawArraysInstanced` against the shared `QuadVAOArrays`
+  (6-vert unit quad). A new `SpritesToScreenProgram` fragment shader
+  samples the bound atlas at `uvRect`.
+- v1 binds one atlas per draw call. Multi-sheet batching (texture
+  array, bindless) is a follow-up.
+
+GLSL and MSL shaders ship in lockstep per the `backend-parity` rule.
+
+## Lighting interaction
+
+Sprites bypass all lighting passes. They composite onto the framebuffer
+after the trixel pipeline has fully resolved lighting, so adding a
+sprite to a dimly-lit world does not darken the sprite. Creations that
+want a sprite to react to local lighting should pre-tint its texture or
+bake lighting into the sprite via `C_Sprite.tint_`.
+
+## What's explicitly out of scope (v1)
+
+- Sprite vs canvas z-sort (Part 2; needs shared depth buffer).
+- Atlas merging / bindless textures (one sheet per draw call is fine
+  for v1's instance counts).
+- Animation blending / crossfade (single active animation per
+  `C_SpriteAnimation`; switching is a hard cut).
+- Sprite-driven physics or collision (sprites are visual only;
+  hitboxes belong on a separate component).
+- Dynamic atlas repacking (atlases are loaded once, treated as
+  immutable).
+
+## Cross-task contract summary
+
+| Owner          | Owns                                              |
+|----------------|---------------------------------------------------|
+| Child 1 (T-087)| `C_Sprite`, `C_SpriteSheet` definitions, this note, Lua-binding stubs |
+| Child 2        | Sheet loader, asset format (PNG + sidecar), populating `C_SpriteSheet` |
+| Child 3        | `SPRITES_TO_SCREEN` system, GLSL+MSL shaders, instanced draw |
+| Child 4        | `C_SpriteAnimation` + animation system, named-animation playback API |
+| Child 5        | Lua bindings (full surface) + `sprite_demo` creation |
+
+Each child PR's diff stays local to its row above. Components from
+child 1 are a stable contract — don't quietly add fields in later
+children without revising this note.

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -23,6 +23,10 @@ the ECS surface.
 - `C_GeometricShape` — 2D overlay shape descriptor.
 - `C_FrameDataTrixelToFramebuffer` — per-frame UBO (MVP, hover coord,
   distance offset).
+- `C_Sprite` / `C_SpriteSheet` — 2D screen-composite sprite + atlas
+  metadata. Sprites bypass the trixel pipeline and draw at the
+  `FRAMEBUFFER_TO_SCREEN` stage. See [`docs/design/sprites.md`](../../../../docs/design/sprites.md)
+  for the full data model, depth semantics, and cross-task scope.
 
 ## Key systems (all RENDER pipeline)
 

--- a/engine/prefabs/irreden/render/components/component_sprite.hpp
+++ b/engine/prefabs/irreden/render/components/component_sprite.hpp
@@ -1,0 +1,56 @@
+#ifndef COMPONENT_SPRITE_H
+#define COMPONENT_SPRITE_H
+
+#include <irreden/ir_math.hpp>
+#include <irreden/render/ir_render_types.hpp>
+
+namespace IRComponents {
+
+/// Per-instance 2D sprite. A sprite is screen-composite content drawn at
+/// the FRAMEBUFFER_TO_SCREEN pipeline stage — it bypasses the trixel
+/// pipeline entirely. Pair with @c C_Position3D; the SPRITES_TO_SCREEN
+/// system iso-projects the position each frame to derive the screen
+/// position and the sort depth.
+///
+/// Anchor is in local UV space (`{0.5, 0.0}` = bottom-center). Quad
+/// origin = `isoProject(C_Position3D.pos_) - anchor_ * size_`.
+///
+/// @c uvRect_ is `(u0, v0, u1, v1)` in normalized [0, 1] texture coords.
+/// For a still sprite this is the whole texture; for an animated sprite
+/// driven by @c C_SpriteSheet + @c C_SpriteAnimation, it is rewritten
+/// each tick to the active frame's UV rect.
+struct C_Sprite {
+    IRRender::ResourceId textureHandle_ = 0;
+    IRMath::vec2 size_ = IRMath::vec2{0.0f, 0.0f};
+    IRMath::vec4 uvRect_ = IRMath::vec4{0.0f, 0.0f, 1.0f, 1.0f};
+    IRMath::vec2 anchor_ = IRMath::vec2{0.5f, 0.0f};
+    IRMath::Color tint_ = IRMath::IRColors::kWhite;
+
+    C_Sprite(
+        IRRender::ResourceId textureHandle,
+        IRMath::vec2 size,
+        IRMath::vec4 uvRect,
+        IRMath::vec2 anchor,
+        IRMath::Color tint
+    )
+        : textureHandle_{textureHandle}
+        , size_{size}
+        , uvRect_{uvRect}
+        , anchor_{anchor}
+        , tint_{tint} {}
+
+    C_Sprite(IRRender::ResourceId textureHandle, IRMath::vec2 size)
+        : C_Sprite{
+              textureHandle,
+              size,
+              IRMath::vec4{0.0f, 0.0f, 1.0f, 1.0f},
+              IRMath::vec2{0.5f, 0.0f},
+              IRMath::IRColors::kWhite
+          } {}
+
+    C_Sprite() = default;
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_SPRITE_H */

--- a/engine/prefabs/irreden/render/components/component_sprite_lua.hpp
+++ b/engine/prefabs/irreden/render/components/component_sprite_lua.hpp
@@ -1,0 +1,35 @@
+#ifndef COMPONENT_SPRITE_LUA_H
+#define COMPONENT_SPRITE_LUA_H
+
+#include <irreden/render/components/component_sprite.hpp>
+#include <irreden/script/lua_script.hpp>
+
+namespace IRScript {
+
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_Sprite> = true;
+
+template <> inline void bindLuaType<IRComponents::C_Sprite>(LuaScript &luaScript) {
+    using IRComponents::C_Sprite;
+
+    luaScript.registerType<
+        C_Sprite,
+        C_Sprite(IRRender::ResourceId, IRMath::vec2, IRMath::vec4, IRMath::vec2, IRMath::Color),
+        C_Sprite(IRRender::ResourceId, IRMath::vec2),
+        C_Sprite()>(
+        "C_Sprite",
+        "textureHandle",
+        &C_Sprite::textureHandle_,
+        "size",
+        &C_Sprite::size_,
+        "uvRect",
+        &C_Sprite::uvRect_,
+        "anchor",
+        &C_Sprite::anchor_,
+        "tint",
+        &C_Sprite::tint_
+    );
+}
+
+} // namespace IRScript
+
+#endif /* COMPONENT_SPRITE_LUA_H */

--- a/engine/prefabs/irreden/render/components/component_sprite_sheet.hpp
+++ b/engine/prefabs/irreden/render/components/component_sprite_sheet.hpp
@@ -1,0 +1,86 @@
+#ifndef COMPONENT_SPRITE_SHEET_H
+#define COMPONENT_SPRITE_SHEET_H
+
+#include <irreden/ir_math.hpp>
+#include <irreden/render/ir_render_types.hpp>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace IRComponents {
+
+/// One frame's slot in the sheet. @c uvRect_ is the normalized [0, 1]
+/// sub-rect of the atlas texture sampled while this frame is active.
+/// @c sizePx_ is the frame's pixel footprint — kept per-frame so sheets
+/// with non-uniform cell sizes (variable-width characters, packed atlases)
+/// can override the sprite's spawn size when the active frame changes.
+struct SpriteFrame {
+    IRMath::vec4 uvRect_ = IRMath::vec4{0.0f, 0.0f, 1.0f, 1.0f};
+    IRMath::ivec2 sizePx_ = IRMath::ivec2{0, 0};
+};
+
+/// A named sub-animation: a contiguous range of frames from
+/// @c C_SpriteSheet.frames_ played back at @c fps_ frames per second.
+/// FPS is a property of the animation, not the renderer, so playback
+/// rate is independent of render rate.
+///
+/// Loop mode (`ONCE`/`LOOP`/`PING_PONG`) is per-instance state on the
+/// runtime animation component — the same sub-animation can play looped
+/// on one entity and one-shot on another.
+struct SpriteAnimation {
+    int firstFrame_ = 0;
+    int frameCount_ = 0;
+    float fps_ = 0.0f;
+};
+
+/// Name → animation pair. Stored in a flat vector rather than a
+/// `std::unordered_map` so callers can resolve a name to a stable integer
+/// index once and dereference by index per-tick — avoiding string hashing
+/// and node-pointer chasing on the playback hot path. The loader assigns
+/// indices; @c findAnimationIndex performs the one-shot name resolution.
+struct NamedAnimation {
+    std::string name_;
+    SpriteAnimation animation_;
+};
+
+/// Sprite-sheet asset bound to a single atlas texture. @c frames_ is the
+/// dense, integer-indexed frame table. @c animations_ holds the named
+/// sub-animations as a flat vector; the runtime component resolves each
+/// name once via @c findAnimationIndex and caches the resulting index, so
+/// per-tick advance never touches a map.
+struct C_SpriteSheet {
+    IRRender::ResourceId textureHandle_ = 0;
+    IRMath::uvec2 atlasSizePx_ = IRMath::uvec2{0, 0};
+    std::vector<SpriteFrame> frames_{};
+    std::vector<NamedAnimation> animations_{};
+
+    C_SpriteSheet(
+        IRRender::ResourceId textureHandle,
+        IRMath::uvec2 atlasSizePx,
+        std::vector<SpriteFrame> frames,
+        std::vector<NamedAnimation> animations
+    )
+        : textureHandle_{textureHandle}
+        , atlasSizePx_{atlasSizePx}
+        , frames_{std::move(frames)}
+        , animations_{std::move(animations)} {}
+
+    C_SpriteSheet() = default;
+
+    /// Linear scan over @c animations_. Intended to be called once per
+    /// state change (e.g. when a creation calls `playAnimation("walk")`),
+    /// not per tick. Returns -1 if the name is not present.
+    int findAnimationIndex(std::string_view name) const {
+        for (int i = 0; i < static_cast<int>(animations_.size()); ++i) {
+            if (animations_[i].name_ == name) {
+                return i;
+            }
+        }
+        return -1;
+    }
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_SPRITE_SHEET_H */

--- a/engine/prefabs/irreden/render/components/component_sprite_sheet_lua.hpp
+++ b/engine/prefabs/irreden/render/components/component_sprite_sheet_lua.hpp
@@ -1,0 +1,29 @@
+#ifndef COMPONENT_SPRITE_SHEET_LUA_H
+#define COMPONENT_SPRITE_SHEET_LUA_H
+
+#include <irreden/render/components/component_sprite_sheet.hpp>
+#include <irreden/script/lua_script.hpp>
+
+namespace IRScript {
+
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_SpriteSheet> = true;
+
+template <> inline void bindLuaType<IRComponents::C_SpriteSheet>(LuaScript &luaScript) {
+    using IRComponents::C_SpriteSheet;
+
+    // The frame table and named-animation list are loader-populated and
+    // consumed by the animation runtime in C++; Lua drives playback via
+    // a prefab-scoped namespace API rather than poking the containers
+    // directly. Only the simple POD fields are reflected here.
+    luaScript.registerType<C_SpriteSheet, C_SpriteSheet()>(
+        "C_SpriteSheet",
+        "textureHandle",
+        &C_SpriteSheet::textureHandle_,
+        "atlasSizePx",
+        &C_SpriteSheet::atlasSizePx_
+    );
+}
+
+} // namespace IRScript
+
+#endif /* COMPONENT_SPRITE_SHEET_LUA_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(IrredenEngineTest
   render/light_volume_test.cpp
   render/sun_direction_test.cpp
   render/sun_lighting_test.cpp
+  render/sprite_components_test.cpp
   script/modifier_lua_test.cpp
   utility/ir_utility_test.cpp
 )

--- a/test/render/sprite_components_test.cpp
+++ b/test/render/sprite_components_test.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include <irreden/render/components/component_sprite.hpp>
+#include <irreden/render/components/component_sprite_sheet.hpp>
+
+namespace {
+
+TEST(SpriteComponents, SpriteDefaults) {
+    IRComponents::C_Sprite sprite{};
+    EXPECT_EQ(sprite.textureHandle_, 0u);
+    EXPECT_FLOAT_EQ(sprite.size_.x, 0.0f);
+    EXPECT_FLOAT_EQ(sprite.size_.y, 0.0f);
+    EXPECT_FLOAT_EQ(sprite.uvRect_.x, 0.0f);
+    EXPECT_FLOAT_EQ(sprite.uvRect_.y, 0.0f);
+    EXPECT_FLOAT_EQ(sprite.uvRect_.z, 1.0f);
+    EXPECT_FLOAT_EQ(sprite.uvRect_.w, 1.0f);
+    EXPECT_FLOAT_EQ(sprite.anchor_.x, 0.5f);
+    EXPECT_FLOAT_EQ(sprite.anchor_.y, 0.0f);
+    EXPECT_EQ(sprite.tint_.alpha_, 0xFFu);
+}
+
+TEST(SpriteComponents, SpriteTwoArgConstructorPicksAnchorDefault) {
+    IRComponents::C_Sprite sprite{42u, IRMath::vec2{32.0f, 48.0f}};
+    EXPECT_EQ(sprite.textureHandle_, 42u);
+    EXPECT_FLOAT_EQ(sprite.size_.x, 32.0f);
+    EXPECT_FLOAT_EQ(sprite.size_.y, 48.0f);
+    EXPECT_FLOAT_EQ(sprite.anchor_.x, 0.5f);
+    EXPECT_FLOAT_EQ(sprite.anchor_.y, 0.0f);
+}
+
+TEST(SpriteComponents, SpriteSheetDefaultsAndPopulate) {
+    IRComponents::C_SpriteSheet sheet{};
+    EXPECT_EQ(sheet.textureHandle_, 0u);
+    EXPECT_TRUE(sheet.frames_.empty());
+    EXPECT_TRUE(sheet.animations_.empty());
+
+    sheet.frames_.push_back(IRComponents::SpriteFrame{
+        IRMath::vec4{0.0f, 0.0f, 0.5f, 1.0f}, IRMath::ivec2{16, 32}});
+    sheet.animations_.push_back(IRComponents::NamedAnimation{
+        "walk_left", IRComponents::SpriteAnimation{0, 1, 12.0f}});
+
+    EXPECT_EQ(sheet.frames_.size(), 1u);
+    const int idx = sheet.findAnimationIndex("walk_left");
+    ASSERT_EQ(idx, 0);
+    EXPECT_EQ(sheet.animations_[idx].animation_.firstFrame_, 0);
+    EXPECT_EQ(sheet.animations_[idx].animation_.frameCount_, 1);
+    EXPECT_FLOAT_EQ(sheet.animations_[idx].animation_.fps_, 12.0f);
+    EXPECT_EQ(sheet.findAnimationIndex("missing"), -1);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Child 1 of 5 of the sprite epic (#14, #282). Defines the data model for
a flat-2D sprite layer that runs alongside the trixel pipeline, plus
the design note that locks down the cross-task invariants for the
remaining children.

- `C_Sprite` — per-instance state: `textureHandle_`, `size_`, `uvRect_`,
  `anchor_` (default `{0.5, 0.0}` = bottom-center), `tint_`.
- `C_SpriteSheet` — per-asset metadata: atlas handle + size, flat
  `SpriteFrame` table, flat `NamedAnimation` list, plus
  `findAnimationIndex(string_view)` for one-shot name resolution.
- Lua-binding stubs (POD-only reflection) so child 5 isn't blocked on
  `kHasLuaBinding<>` wiring.
- Design note at `docs/design/sprites.md`, cross-linked from
  `engine/prefabs/irreden/render/CLAUDE.md`.

### Key design points

- **Screen-composite, not trixel content.** Sprites composite at
  `FRAMEBUFFER_TO_SCREEN`, between the main canvas blit and the GUI
  canvas blit. They bypass voxel/trixel rasterization, AO, shadows,
  and lighting entirely.
- **One depth per sprite** (iso projection of `C_Position3D`), not a
  per-pixel depth-buffer problem.
- **Vector-backed `animations_`, not `unordered_map`.** The future
  runtime resolves a name to a stable integer index once via
  `findAnimationIndex` and dereferences by index per tick — string
  hashing never lands on the playback hot path.
- v1 sort scope: among sprites only. Cross-canvas z-sort is Part 2.

### Cross-task contract

| Owner | Owns |
|---|---|
| Child 1 (this PR) | `C_Sprite`, `C_SpriteSheet`, design note, Lua stubs |
| Child 2 | Atlas loader (PNG + sidecar), populates `C_SpriteSheet` |
| Child 3 | `SPRITES_TO_SCREEN` system, GLSL+MSL shaders |
| Child 4 | `C_SpriteAnimation` + animation system |
| Child 5 | Full Lua surface + `sprite_demo` creation |

## Test plan

- [x] `fleet-build --target IrredenEngineTest` clean on `macos-debug`
- [x] `fleet-build --target IRShapeDebug` clean on `macos-debug`
- [x] `IrredenEngineTest --gtest_filter=SpriteComponents*` 3/3 pass
- [ ] Linux/OpenGL build clean on `linux-debug` (pure C++ headers + a
      gtest, no shader changes — should be a no-op cross-host, but the
      cross-host smoke flow is render-system-only so no smoke labels here)

## Notes for reviewer

- No render pipeline / shader changes — just data definitions, design
  doc, and one gtest. `render-debug-loop` and screenshot capture not
  applicable (no visual effect).
- `findAnimationIndex` is the one Tier-b helper (per
  `engine/prefabs/CLAUDE.md` rules: reads only the component's own
  fields). It exists so child 4's runtime can keep its hot path
  free of string hashing — agreeing on the access pattern at child 1
  prevents a downstream rewrite.

Closes #282