### PR TITLE
queue: drop obsolete T-067 + close stranded human:approved issues

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -165,19 +165,6 @@ Avoid:
   - **Links:**
 
 
-- [ ] **Metal: sync FrameDataVoxelToTrixel struct and C++ feeder with GLSL yaw fields** — add `visualYaw`, `rasterYaw`, `residualYaw`, `_yawPadding` to the Metal struct in `ir_iso_common.metal` and to the C++ `FrameDataVoxelToCanvas` struct in `ir_render_types.hpp`
-  - **ID:** T-067
-  - **Area:** engine/render, shaders/metal
-  - **Model:** opus
-  - **Owner:** free
-  - **Blocked by:** (none)
-  - **Acceptance:** (1) four yaw fields added to Metal `FrameDataVoxelToTrixel` in `ir_iso_common.metal` matching std140 layout; (2) four fields added to C++ `FrameDataVoxelToCanvas` in `ir_render_types.hpp`; populated each frame from camera-state component; (3) `c_voxel_visibility_compact.metal`, `c_voxel_to_trixel_stage_1.metal`, `c_voxel_to_trixel_stage_2.metal`, `c_lighting_to_trixel.metal` all compile clean; (4) `fleet-build --target IRShapeDebug` (or any voxel-pipeline creation) clean on `macos-debug`; GLSL pipeline still renders correctly with initialized yaw values
-  - **Issue:** #337
-  - **Notes:** Metal shaders crash at runtime referencing `frameData.rasterYaw` which doesn't exist in the Metal struct. The C++ struct is also missing the four fields (GLSL has been reading garbage/zero-padding). Default value when no rotation is happening is 0 for all three yaws — forward-compatible. macOS/Metal only crash; WSL/Linux (OpenGL) is unaffected.
-  - **Links:**
-
-
-
 - [ ] **Render: screen-space sun shadow map — delete occupancy grid + analytic caster paths** — remove `BUILD_OCCUPANCY_GRID`, `C_OccupancyGrid`, `SunShadowShapeCasterBuffer`, `analyticShapeShadowHit`, and in-shader SDF helpers after T-070 establishes the screen-space path
   - **ID:** T-071
   - **Area:** engine/render, engine/prefabs/irreden/render, shaders/glsl, shaders/metal


### PR DESCRIPTION
## Summary

Cleanup pass to align TASKS.md with the live state of GitHub issues
after auditing the queue against `human:approved` issues.

- **Drop T-067 from TASKS.md.** Linked issue #337 closed 2026-05-01;
  opus-worker-1 has flagged it as bogus across multiple iterations
  (visible in `~/.fleet/summaries/20260502-191228/opus-worker-2.md`
  and `…-190409/queue-manager.md`). PR #420 was opened against it
  earlier today and closed without merge.

## Out-of-band cleanup (done outside this PR)

- Closed issue #386 (work shipped as T-079 → PR #398, but the
  human-filed issue was never linked back / closed).
- Stripped stale `fleet:queued` from issues #341 and #307 — both
  carried the label but had no corresponding entry in TASKS.md, so
  queue-manager's `human:approved AND NOT fleet:queued` intake
  filter was silently skipping them. Removing the label puts them
  back in the ingest queue.

T-057 self-healed in the queue-manager's 19:39 maintenance pass
after PR #418 was closed without merging.

## Test plan

- [x] `git diff` shows only T-067 block removed; surrounding tasks intact.
- [ ] Queue-manager next pass (≤5 min after merge) sees #341 and #307 as
      ingest candidates again and either ingests them or labels
      `fleet:needs-plan` / `fleet:needs-info`.
- [ ] No worker pane picks up T-067 on the next iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)