### PR TITLE
T-093: input/render: hitbox projection under non-zero camera yaw

### DIFF
--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -192,26 +192,40 @@ constexpr vec2 rotate2D(const vec2 v, float angle) {
     return vec2(c * v.x - s * v.y, s * v.x + c * v.y);
 }
 
+/// Strongly-typed index for the four camera-yaw cardinal snap points.
+/// Mirrors the 0..3 range used by `rasterYawCardinalIndex` in
+/// `shaders/ir_iso_common.glsl`. CPU and GPU MUST agree on the same index for
+/// any picking ↔ raster handshake.
+enum class CardinalIndex : int {
+    k0 = 0,   ///< rasterYaw ≈ 0      (identity)
+    k90 = 1,  ///< rasterYaw ≈ π/2
+    k180 = 2, ///< rasterYaw ≈ π
+    k270 = 3, ///< rasterYaw ≈ 3π/2
+};
+
 /// CPU mirror of `rasterYawCardinalIndex` in `shaders/ir_iso_common.glsl`.
 /// `IRPrefab::Camera::computeYawSplit` snaps `rasterYaw` to a multiple of
 /// pi/2; the round() defends against bit-wise drift only. Negative inputs
 /// fold via `(q mod 4 + 4) mod 4` into [0, 3]. CPU and GPU MUST resolve
 /// the same cardinal index for any picking ↔ raster handshake.
-constexpr int rasterYawCardinalIndex(float rasterYaw) {
+constexpr CardinalIndex rasterYawCardinalIndex(float rasterYaw) {
     constexpr float kHalfPi = 1.5707963267948966f;
     const int q = static_cast<int>(glm::round(rasterYaw / kHalfPi));
-    return ((q % 4) + 4) % 4;
+    return static_cast<CardinalIndex>(((q % 4) + 4) % 4);
 }
 
 /// CPU mirror of `rotateCardinalZ` in `shaders/ir_iso_common.glsl`.
-/// World→view = R_z(-rasterYaw) for cardinal index in [0, 3]. The voxel
+/// World→view = R_z(-rasterYaw) for the given cardinal snap. The voxel
 /// rasterizer applies this to world positions before iso projection, so
 /// any screen↔world picking inverse must compose its inverse on the
 /// recovered 3D position.
-constexpr ivec3 rotateCardinalZ(const ivec3 v, int cardinalIndex) {
-    if (cardinalIndex == 1) return ivec3( v.y, -v.x, v.z);
-    if (cardinalIndex == 2) return ivec3(-v.x, -v.y, v.z);
-    if (cardinalIndex == 3) return ivec3(-v.y,  v.x, v.z);
+constexpr ivec3 rotateCardinalZ(const ivec3 v, CardinalIndex cardinalIndex) {
+    if (cardinalIndex == CardinalIndex::k90)
+        return ivec3(v.y, -v.x, v.z);
+    if (cardinalIndex == CardinalIndex::k180)
+        return ivec3(-v.x, -v.y, v.z);
+    if (cardinalIndex == CardinalIndex::k270)
+        return ivec3(-v.y, v.x, v.z);
     return v;
 }
 
@@ -219,28 +233,37 @@ constexpr ivec3 rotateCardinalZ(const ivec3 v, int cardinalIndex) {
 /// positions (e.g. `C_PositionGlobal3D + C_PositionOffset3D`) into the
 /// rasterYaw-rotated canvas frame. Same R_z(-rasterYaw) sign convention
 /// as the integer overload.
-constexpr vec3 rotateCardinalZ(const vec3 v, int cardinalIndex) {
-    if (cardinalIndex == 1) return vec3( v.y, -v.x, v.z);
-    if (cardinalIndex == 2) return vec3(-v.x, -v.y, v.z);
-    if (cardinalIndex == 3) return vec3(-v.y,  v.x, v.z);
+constexpr vec3 rotateCardinalZ(const vec3 v, CardinalIndex cardinalIndex) {
+    if (cardinalIndex == CardinalIndex::k90)
+        return vec3(v.y, -v.x, v.z);
+    if (cardinalIndex == CardinalIndex::k180)
+        return vec3(-v.x, -v.y, v.z);
+    if (cardinalIndex == CardinalIndex::k270)
+        return vec3(-v.y, v.x, v.z);
     return v;
 }
 
 /// CPU mirror of `rotateCardinalZInv` in `shaders/ir_iso_common.glsl`.
 /// View→world = R_z(+rasterYaw). Use after `isoPixelToPos3D` to lift a
 /// reconstructed 3D position back to true world coordinates.
-constexpr vec3 rotateCardinalZInv(const vec3 v, int cardinalIndex) {
-    if (cardinalIndex == 1) return vec3(-v.y,  v.x, v.z);
-    if (cardinalIndex == 2) return vec3(-v.x, -v.y, v.z);
-    if (cardinalIndex == 3) return vec3( v.y, -v.x, v.z);
+constexpr vec3 rotateCardinalZInv(const vec3 v, CardinalIndex cardinalIndex) {
+    if (cardinalIndex == CardinalIndex::k90)
+        return vec3(-v.y, v.x, v.z);
+    if (cardinalIndex == CardinalIndex::k180)
+        return vec3(-v.x, -v.y, v.z);
+    if (cardinalIndex == CardinalIndex::k270)
+        return vec3(v.y, -v.x, v.z);
     return v;
 }
 
 /// Integer view→world variant matching GLSL `rotateCardinalZInvI`.
-constexpr ivec3 rotateCardinalZInvI(const ivec3 v, int cardinalIndex) {
-    if (cardinalIndex == 1) return ivec3(-v.y,  v.x, v.z);
-    if (cardinalIndex == 2) return ivec3(-v.x, -v.y, v.z);
-    if (cardinalIndex == 3) return ivec3( v.y, -v.x, v.z);
+constexpr ivec3 rotateCardinalZInvI(const ivec3 v, CardinalIndex cardinalIndex) {
+    if (cardinalIndex == CardinalIndex::k90)
+        return ivec3(-v.y, v.x, v.z);
+    if (cardinalIndex == CardinalIndex::k180)
+        return ivec3(-v.x, -v.y, v.z);
+    if (cardinalIndex == CardinalIndex::k270)
+        return ivec3(v.y, -v.x, v.z);
     return v;
 }
 

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -215,6 +215,17 @@ constexpr ivec3 rotateCardinalZ(const ivec3 v, int cardinalIndex) {
     return v;
 }
 
+/// @overload Float variant for forward-projecting non-integer world
+/// positions (e.g. `C_PositionGlobal3D + C_PositionOffset3D`) into the
+/// rasterYaw-rotated canvas frame. Same R_z(-rasterYaw) sign convention
+/// as the integer overload.
+constexpr vec3 rotateCardinalZ(const vec3 v, int cardinalIndex) {
+    if (cardinalIndex == 1) return vec3( v.y, -v.x, v.z);
+    if (cardinalIndex == 2) return vec3(-v.x, -v.y, v.z);
+    if (cardinalIndex == 3) return vec3(-v.y,  v.x, v.z);
+    return v;
+}
+
 /// CPU mirror of `rotateCardinalZInv` in `shaders/ir_iso_common.glsl`.
 /// View→world = R_z(+rasterYaw). Use after `isoPixelToPos3D` to lift a
 /// reconstructed 3D position back to true world coordinates.

--- a/engine/prefabs/irreden/input/systems/system_hitbox_mouse_test.hpp
+++ b/engine/prefabs/irreden/input/systems/system_hitbox_mouse_test.hpp
@@ -5,31 +5,53 @@
 #include <irreden/ir_render.hpp>
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_entity.hpp>
+#include <irreden/ir_platform.hpp>
 
 #include <irreden/input/components/component_hitbox_2d.hpp>
 #include <irreden/common/components/component_position_global_3d.hpp>
 #include <irreden/common/components/component_position_offset_3d.hpp>
 #include <irreden/render/components/component_trixel_framebuffer.hpp>
+#include <irreden/render/camera.hpp>
+
+#include <cmath>
 
 using namespace IRComponents;
 using namespace IRMath;
 
 namespace IRSystem {
 
+// Mirrors `kIdentityYawEpsilon` in `f_screen_residual_rotate.glsl`. Below
+// this magnitude the screen composite passes the canvas through pixel-
+// identical, so the picking-side inverse must skip its rotation too or a
+// yaw=0 hover would shift by sub-pixel rounding.
+inline constexpr float kHitboxIdentityYawEpsilon = 1e-6f;
+
 template <> struct System<HITBOX_MOUSE_TEST> {
     static SystemId create() {
-        static vec2 s_mouseOutput;
+        // `s_mouseCanvas` holds the cursor in the trixel-canvas-pixel
+        // frame (pre-residual-composite); the per-entity tick compares
+        // against entity centers in that same frame, so the inverse
+        // rotation happens once at beforeTick rather than per entity.
+        static vec2 s_mouseCanvas;
         static vec2 s_cameraIso;
         static vec2 s_cameraZoom;
         static vec2 s_fbResHalf;
+        static int s_cardinalIndex;
 
         return createSystem<C_HitBox2D, C_PositionGlobal3D, C_PositionOffset3D>(
             "HitBoxMouseTest",
             [](C_HitBox2D &hitbox,
                const C_PositionGlobal3D &globalPos,
                const C_PositionOffset3D &offsetPos) {
-                vec3 pos3D = globalPos.pos_ + offsetPos.pos_;
-                vec2 entityIso = IRMath::pos3DtoPos2DIso(pos3D);
+                // Apply the cardinal-snap world->view rotation that the
+                // voxel rasterizer applies on the GPU side; without this,
+                // the entity's projected center stays at its yaw=0 location
+                // while the rendered output spins under the camera, and
+                // hover misses the rendered position.
+                vec3 viewPos = IRMath::rotateCardinalZ(
+                    globalPos.pos_ + offsetPos.pos_, s_cardinalIndex
+                );
+                vec2 entityIso = IRMath::pos3DtoPos2DIso(viewPos);
                 vec2 relativeIso = entityIso - s_cameraIso;
                 vec2 screenOffset = IRMath::pos2DIsoToPos2DGameResolution(
                     relativeIso, s_cameraZoom
@@ -40,17 +62,36 @@ template <> struct System<HITBOX_MOUSE_TEST> {
                 );
 
                 hitbox.hovered_ =
-                    abs(s_mouseOutput.x - entityCenter.x) <= hitbox.halfExtent_.x &&
-                    abs(s_mouseOutput.y - entityCenter.y) <= hitbox.halfExtent_.y;
+                    abs(s_mouseCanvas.x - entityCenter.x) <= hitbox.halfExtent_.x &&
+                    abs(s_mouseCanvas.y - entityCenter.y) <= hitbox.halfExtent_.y;
             },
             []() {
-                s_mouseOutput = IRRender::getMousePositionOutputView();
                 s_cameraIso = IRRender::getCameraPosition2DIso();
                 s_cameraZoom = IRRender::getCameraZoom();
                 auto &framebuffer =
                     IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
-                vec2 fbRes = vec2(framebuffer.getResolutionPlusBuffer());
-                s_fbResHalf = fbRes * 0.5f;
+                s_fbResHalf = vec2(framebuffer.getResolutionPlusBuffer()) * 0.5f;
+
+                const auto [rasterYaw, residualYaw] =
+                    IRPrefab::Camera::getYawSplit();
+                s_cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
+
+                // Inverse-rotate the mouse out of the post-composite
+                // framebuffer-pixel frame into the canvas-pixel frame the
+                // forward projection above lands in. Sign matches the
+                // shader (`cos(-residualYaw)`) on the backend whose pixel
+                // Y axis aligns with framebuffer-texture Y; flips on
+                // OpenGL where the output framebuffer Y is inverted.
+                const vec2 mouseFb = IRRender::getMousePositionOutputView();
+                if (std::abs(residualYaw) < kHitboxIdentityYawEpsilon) {
+                    s_mouseCanvas = mouseFb;
+                } else {
+                    const float effectiveAngle =
+                        -residualYaw * IRPlatform::kGfx.screenYDirection_;
+                    s_mouseCanvas =
+                        IRMath::rotate2D(mouseFb - s_fbResHalf, effectiveAngle) +
+                        s_fbResHalf;
+                }
             }
         );
     }

--- a/engine/prefabs/irreden/input/systems/system_hitbox_mouse_test.hpp
+++ b/engine/prefabs/irreden/input/systems/system_hitbox_mouse_test.hpp
@@ -36,7 +36,7 @@ template <> struct System<HITBOX_MOUSE_TEST> {
         static vec2 s_cameraIso;
         static vec2 s_cameraZoom;
         static vec2 s_fbResHalf;
-        static int s_cardinalIndex;
+        static IRMath::CardinalIndex s_cardinalIndex;
 
         return createSystem<C_HitBox2D, C_PositionGlobal3D, C_PositionOffset3D>(
             "HitBoxMouseTest",
@@ -48,22 +48,17 @@ template <> struct System<HITBOX_MOUSE_TEST> {
                 // the entity's projected center stays at its yaw=0 location
                 // while the rendered output spins under the camera, and
                 // hover misses the rendered position.
-                vec3 viewPos = IRMath::rotateCardinalZ(
-                    globalPos.pos_ + offsetPos.pos_, s_cardinalIndex
-                );
+                vec3 viewPos =
+                    IRMath::rotateCardinalZ(globalPos.pos_ + offsetPos.pos_, s_cardinalIndex);
                 vec2 entityIso = IRMath::pos3DtoPos2DIso(viewPos);
                 vec2 relativeIso = entityIso - s_cameraIso;
-                vec2 screenOffset = IRMath::pos2DIsoToPos2DGameResolution(
-                    relativeIso, s_cameraZoom
-                );
-                vec2 entityCenter = vec2(
-                    s_fbResHalf.x + screenOffset.x,
-                    s_fbResHalf.y - screenOffset.y
-                );
+                vec2 screenOffset =
+                    IRMath::pos2DIsoToPos2DGameResolution(relativeIso, s_cameraZoom);
+                vec2 entityCenter =
+                    vec2(s_fbResHalf.x + screenOffset.x, s_fbResHalf.y - screenOffset.y);
 
-                hitbox.hovered_ =
-                    abs(s_mouseCanvas.x - entityCenter.x) <= hitbox.halfExtent_.x &&
-                    abs(s_mouseCanvas.y - entityCenter.y) <= hitbox.halfExtent_.y;
+                hitbox.hovered_ = abs(s_mouseCanvas.x - entityCenter.x) <= hitbox.halfExtent_.x &&
+                                  abs(s_mouseCanvas.y - entityCenter.y) <= hitbox.halfExtent_.y;
             },
             []() {
                 s_cameraIso = IRRender::getCameraPosition2DIso();
@@ -72,8 +67,7 @@ template <> struct System<HITBOX_MOUSE_TEST> {
                     IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
                 s_fbResHalf = vec2(framebuffer.getResolutionPlusBuffer()) * 0.5f;
 
-                const auto [rasterYaw, residualYaw] =
-                    IRPrefab::Camera::getYawSplit();
+                const auto [rasterYaw, residualYaw] = IRPrefab::Camera::getYawSplit();
                 s_cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
 
                 // Inverse-rotate the mouse out of the post-composite
@@ -86,11 +80,9 @@ template <> struct System<HITBOX_MOUSE_TEST> {
                 if (std::abs(residualYaw) < kHitboxIdentityYawEpsilon) {
                     s_mouseCanvas = mouseFb;
                 } else {
-                    const float effectiveAngle =
-                        -residualYaw * IRPlatform::kGfx.screenYDirection_;
+                    const float effectiveAngle = -residualYaw * IRPlatform::kGfx.screenYDirection_;
                     s_mouseCanvas =
-                        IRMath::rotate2D(mouseFb - s_fbResHalf, effectiveAngle) +
-                        s_fbResHalf;
+                        IRMath::rotate2D(mouseFb - s_fbResHalf, effectiveAngle) + s_fbResHalf;
                 }
             }
         );

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -196,7 +196,7 @@ ivec2 mouseTrixelPositionWorld();
 /// canvas frame and take its iso depth:
 /// @code
 ///   const ivec3 worldRef = ... ;  // e.g. entity world position
-///   const int idx = IRMath::rasterYawCardinalIndex(
+///   const IRMath::CardinalIndex idx = IRMath::rasterYawCardinalIndex(
 ///       IRPrefab::Camera::getRasterYaw());
 ///   const float canvasIsoDepth = static_cast<float>(
 ///       IRMath::pos3DtoDistance(IRMath::rotateCardinalZ(worldRef, idx)));

--- a/test/math/ir_math_test.cpp
+++ b/test/math/ir_math_test.cpp
@@ -727,4 +727,272 @@ TEST(PickingInverseTest, RoundTripsAcrossAllCardinals) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// rotateCardinalZ vec3 overload — float world positions cardinally
+// rotated into the rasterYaw-rotated canvas frame, paralleling the
+// ivec3 overload's R_z(-rasterYaw) sign convention.
+// ---------------------------------------------------------------------------
+
+TEST(RotateCardinalZVec3Test, MatchesIntegerOverloadOnIntegerValuedFloats) {
+    const IRMath::vec3 worlds[] = {
+        IRMath::vec3(0.0f, 0.0f, 0.0f),
+        IRMath::vec3(3.0f, 5.0f, 0.0f),
+        IRMath::vec3(-2.0f, 1.0f, 4.0f),
+        IRMath::vec3(7.0f, -3.0f, 2.0f),
+    };
+    for (int idx = 0; idx < 4; ++idx) {
+        for (const auto &w : worlds) {
+            const IRMath::vec3 rFloat = IRMath::rotateCardinalZ(w, idx);
+            const IRMath::ivec3 rInt = IRMath::rotateCardinalZ(
+                IRMath::ivec3(static_cast<int>(w.x), static_cast<int>(w.y),
+                              static_cast<int>(w.z)),
+                idx);
+            EXPECT_NEAR(rFloat.x, static_cast<float>(rInt.x), kTolerance);
+            EXPECT_NEAR(rFloat.y, static_cast<float>(rInt.y), kTolerance);
+            EXPECT_NEAR(rFloat.z, static_cast<float>(rInt.z), kTolerance);
+        }
+    }
+}
+
+TEST(RotateCardinalZVec3Test, PreservesFractionalCoords) {
+    // The float overload exists for non-integer world positions (entity
+    // global+offset). For cardinalIndex=1 (rasterYaw=π/2 → world→view
+    // = R_z(-π/2)): (x, y, z) → (y, -x, z). Verify exact preservation
+    // of fractional values, not just sign behavior.
+    const IRMath::vec3 v(2.5f, -3.75f, 1.125f);
+    const IRMath::vec3 r = IRMath::rotateCardinalZ(v, 1);
+    EXPECT_FLOAT_EQ(r.x, -3.75f);
+    EXPECT_FLOAT_EQ(r.y, -2.5f);
+    EXPECT_FLOAT_EQ(r.z, 1.125f);
+}
+
+TEST(RotateCardinalZVec3Test, InverseRoundTripPerCardinal) {
+    const IRMath::vec3 v(1.5f, -2.25f, 0.75f);
+    for (int idx = 0; idx < 4; ++idx) {
+        const IRMath::vec3 forward = IRMath::rotateCardinalZ(v, idx);
+        const IRMath::vec3 back = IRMath::rotateCardinalZInv(forward, idx);
+        EXPECT_NEAR(back.x, v.x, kTolerance) << "idx=" << idx;
+        EXPECT_NEAR(back.y, v.y, kTolerance) << "idx=" << idx;
+        EXPECT_NEAR(back.z, v.z, kTolerance) << "idx=" << idx;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hitbox forward-projection chain — proves the math used by
+// HITBOX_MOUSE_TEST under non-zero camera yaw is self-consistent.
+//
+// The system applies: viewPos = R_z(-rasterYaw)·world; then iso project;
+// then offset by camera; then scale to game resolution; then place at
+// fbResHalf with Y-flip. The cursor is inverse-residual-rotated from
+// framebuffer-pixel space into this same canvas-pixel frame.
+//
+// A hover should fire iff the inverse-rotated mouse falls within the
+// hitbox half-extent of the forward-projected entity center. The tests
+// below synthesize known mouse + camera-yaw combinations and assert
+// the predicted hover state matches what the system would compute.
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+// Mirror of the per-entity tick body in
+// `engine/prefabs/irreden/input/systems/system_hitbox_mouse_test.hpp`.
+// Returns the canvas-pixel position the entity projects to under the
+// captured camera state.
+inline IRMath::vec2 forwardProjectEntity(IRMath::vec3 worldPos,
+                                          int cardinalIndex,
+                                          IRMath::vec2 cameraIso,
+                                          IRMath::vec2 cameraZoom,
+                                          IRMath::vec2 fbResHalf) {
+    const IRMath::vec3 viewPos = IRMath::rotateCardinalZ(worldPos, cardinalIndex);
+    const IRMath::vec2 entityIso = IRMath::pos3DtoPos2DIso(viewPos);
+    const IRMath::vec2 relativeIso = entityIso - cameraIso;
+    const IRMath::vec2 screenOffset =
+        IRMath::pos2DIsoToPos2DGameResolution(relativeIso, cameraZoom);
+    return IRMath::vec2(fbResHalf.x + screenOffset.x,
+                        fbResHalf.y - screenOffset.y);
+}
+
+// Build a synthetic mouse position by forward-rotating an entity's
+// canvas-pixel center through the residual composite (the inverse of
+// the system's beforeTick lifting). Round-tripping through the
+// system's inverse must recover the same canvas pixel; that is the
+// load-bearing property a yaw-correct hitbox must satisfy.
+inline IRMath::vec2 forwardResidualOnCanvasPixel(IRMath::vec2 canvasPixel,
+                                                  float residualYaw,
+                                                  float effectiveSign,
+                                                  IRMath::vec2 fbResHalf) {
+    const float forwardAngle = residualYaw * effectiveSign;
+    return IRMath::rotate2D(canvasPixel - fbResHalf, forwardAngle) + fbResHalf;
+}
+
+inline IRMath::vec2 inverseResidualOnFramebufferPixel(IRMath::vec2 mouseFb,
+                                                      float residualYaw,
+                                                      float effectiveSign,
+                                                      IRMath::vec2 fbResHalf) {
+    const float effectiveAngle = -residualYaw * effectiveSign;
+    return IRMath::rotate2D(mouseFb - fbResHalf, effectiveAngle) + fbResHalf;
+}
+
+} // namespace detail
+
+TEST(HitboxProjectionTest, ResidualRotationRoundTripsAtNonCardinalYaws) {
+    // Two non-cardinal residual yaws bracket the [-π/4, π/4] range:
+    // π/8 (mid-positive) and the -π/4 boundary that visualYaw=π/4
+    // produces (rasterYaw snaps to π/2 by std::round half-away-from-zero,
+    // residualYaw = -π/4).
+    constexpr float halfPi = glm::half_pi<float>();
+    const float residualYaws[] = {halfPi / 4.0f,
+                                  -halfPi / 2.0f};
+    const IRMath::vec2 fbResHalf(640.0f, 360.0f);
+    const IRMath::vec2 canvasPixels[] = {
+        IRMath::vec2(640.0f, 360.0f),  // center — invariant under any rotation
+        IRMath::vec2(700.0f, 400.0f),
+        IRMath::vec2(540.0f, 280.0f),
+    };
+    // Both screenYDirection signs (+1 Metal/Vulkan, -1 OpenGL) so the test
+    // catches a regression on whichever backend isn't compiled in.
+    const float effectiveSigns[] = {1.0f, -1.0f};
+    for (float residualYaw : residualYaws) {
+        for (float sign : effectiveSigns) {
+            for (const auto &canvasPixel : canvasPixels) {
+                const IRMath::vec2 mouseFb =
+                    detail::forwardResidualOnCanvasPixel(
+                        canvasPixel, residualYaw, sign, fbResHalf);
+                const IRMath::vec2 recovered =
+                    detail::inverseResidualOnFramebufferPixel(
+                        mouseFb, residualYaw, sign, fbResHalf);
+                EXPECT_NEAR(recovered.x, canvasPixel.x, 1e-3f)
+                    << "residualYaw=" << residualYaw << " sign=" << sign;
+                EXPECT_NEAR(recovered.y, canvasPixel.y, 1e-3f)
+                    << "residualYaw=" << residualYaw << " sign=" << sign;
+            }
+        }
+    }
+}
+
+TEST(HitboxProjectionTest, HoverFiresAtCardinalYawOnEntityUnderCursor) {
+    // visualYaw = π/2 (pure cardinal): rasterYaw = π/2, residualYaw = 0.
+    // Entity at world (3, 0, 0) rotates world→view to (0, -3, 0), iso
+    // projects to (-3, 3) ... actually iso(0,-3,0) = (0-3+0, 0+3+0) = (-3,3).
+    // We synthesize a cursor exactly at the projected center and
+    // expect the hitbox half-extent to flip hovered_ on.
+    const IRMath::vec3 entityWorld(3.0f, 0.0f, 0.0f);
+    const float rasterYaw = glm::half_pi<float>();
+    const int cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
+    const IRMath::vec2 cameraIso(0.0f, 0.0f);
+    const IRMath::vec2 cameraZoom(1.0f, 1.0f);
+    const IRMath::vec2 fbResHalf(640.0f, 360.0f);
+
+    const IRMath::vec2 entityCenter =
+        detail::forwardProjectEntity(
+            entityWorld, cardinalIndex, cameraIso, cameraZoom, fbResHalf);
+
+    // The cursor lands exactly on the projected center; with any
+    // positive halfExtent the hitbox should match.
+    const IRMath::vec2 cursorCanvas = entityCenter;
+    const IRMath::vec2 halfExtent(8.0f, 8.0f);
+    const bool hovered =
+        std::abs(cursorCanvas.x - entityCenter.x) <= halfExtent.x &&
+        std::abs(cursorCanvas.y - entityCenter.y) <= halfExtent.y;
+    EXPECT_TRUE(hovered);
+
+    // Without the cardinal rotation the projected center would land at
+    // a different canvas pixel — verify the test is not vacuous. For
+    // entity (3,0,0): iso.x = -x+y stays at -3 across both rotations
+    // (-3+0 == 0+(-3)), but iso.y flips sign, so y differs.
+    const IRMath::vec2 yawZeroCenter =
+        detail::forwardProjectEntity(
+            entityWorld, /*cardinalIndex=*/0, cameraIso, cameraZoom, fbResHalf);
+    EXPECT_NE(entityCenter.y, yawZeroCenter.y);
+}
+
+TEST(HitboxProjectionTest, HoverFiresUnderNonCardinalYaw) {
+    // Two non-cardinal visualYaw values from the acceptance spec:
+    // π/8 (rasterYaw=0, residualYaw=π/8) and π/2 + π/16
+    // (rasterYaw=π/2, residualYaw=π/16). Pick a cursor exactly at the
+    // forward-projected post-residual framebuffer location and verify
+    // the system's inverse-then-compare logic flips hovered_ on.
+    constexpr float halfPi = glm::half_pi<float>();
+    struct Case {
+        float visualYaw_;
+        IRMath::vec3 entityWorld_;
+    };
+    const Case cases[] = {
+        {halfPi / 4.0f,                   IRMath::vec3(2.0f, 1.0f, 0.0f)},
+        {halfPi + halfPi / 8.0f,           IRMath::vec3(3.0f, -2.0f, 1.0f)},
+    };
+    const IRMath::vec2 cameraIso(0.0f, 0.0f);
+    const IRMath::vec2 cameraZoom(1.0f, 1.0f);
+    const IRMath::vec2 fbResHalf(640.0f, 360.0f);
+    const IRMath::vec2 halfExtent(6.0f, 6.0f);
+
+    for (float effectiveSign : {1.0f, -1.0f}) {
+        for (const auto &c : cases) {
+            const float rasterYaw =
+                glm::round(c.visualYaw_ / halfPi) * halfPi;
+            const float residualYaw = c.visualYaw_ - rasterYaw;
+            const int cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
+
+            // Project entity to its canvas-pixel center.
+            const IRMath::vec2 entityCenter =
+                detail::forwardProjectEntity(
+                    c.entityWorld_, cardinalIndex, cameraIso, cameraZoom,
+                    fbResHalf);
+            // Forward-rotate that canvas pixel through the residual
+            // composite to compute where the user must click on the
+            // framebuffer for the hitbox to be "under" the cursor.
+            const IRMath::vec2 mouseFb =
+                detail::forwardResidualOnCanvasPixel(
+                    entityCenter, residualYaw, effectiveSign, fbResHalf);
+            // Inverse-rotate the cursor as the system's beforeTick does.
+            const IRMath::vec2 mouseCanvas =
+                detail::inverseResidualOnFramebufferPixel(
+                    mouseFb, residualYaw, effectiveSign, fbResHalf);
+            const bool hovered =
+                std::abs(mouseCanvas.x - entityCenter.x) <= halfExtent.x &&
+                std::abs(mouseCanvas.y - entityCenter.y) <= halfExtent.y;
+            EXPECT_TRUE(hovered)
+                << "visualYaw=" << c.visualYaw_ << " sign=" << effectiveSign;
+        }
+    }
+}
+
+TEST(HitboxProjectionTest, HoverDoesNotFireOutsideHalfExtentUnderYaw) {
+    // Mouse outside the hitbox half-extent in canvas-pixel space must
+    // not flip hovered_ even after the inverse-residual rotation. Tests
+    // that the inverse helper isn't accidentally widening the hit area
+    // (e.g. via wrong sign on screenYDirection).
+    constexpr float halfPi = glm::half_pi<float>();
+    const float visualYaw = halfPi / 4.0f;  // residualYaw = π/8, raster=0
+    const float rasterYaw = glm::round(visualYaw / halfPi) * halfPi;
+    const float residualYaw = visualYaw - rasterYaw;
+    const int cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
+    const IRMath::vec2 cameraIso(0.0f, 0.0f);
+    const IRMath::vec2 cameraZoom(1.0f, 1.0f);
+    const IRMath::vec2 fbResHalf(640.0f, 360.0f);
+    const IRMath::vec3 entityWorld(2.0f, 1.0f, 0.0f);
+    const IRMath::vec2 halfExtent(4.0f, 4.0f);
+
+    const IRMath::vec2 entityCenter =
+        detail::forwardProjectEntity(
+            entityWorld, cardinalIndex, cameraIso, cameraZoom, fbResHalf);
+
+    // Place the cursor at a canvas pixel 20 units away — well outside
+    // the half-extent. Forward-rotate it to fb-space, inverse-rotate
+    // it back, and verify the comparison still falls outside.
+    const IRMath::vec2 farCanvas = entityCenter + IRMath::vec2(20.0f, 20.0f);
+    for (float effectiveSign : {1.0f, -1.0f}) {
+        const IRMath::vec2 mouseFb =
+            detail::forwardResidualOnCanvasPixel(
+                farCanvas, residualYaw, effectiveSign, fbResHalf);
+        const IRMath::vec2 mouseCanvas =
+            detail::inverseResidualOnFramebufferPixel(
+                mouseFb, residualYaw, effectiveSign, fbResHalf);
+        const bool hovered =
+            std::abs(mouseCanvas.x - entityCenter.x) <= halfExtent.x &&
+            std::abs(mouseCanvas.y - entityCenter.y) <= halfExtent.y;
+        EXPECT_FALSE(hovered) << "sign=" << effectiveSign;
+    }
+}
+
 } // namespace

--- a/test/math/ir_math_test.cpp
+++ b/test/math/ir_math_test.cpp
@@ -2,9 +2,27 @@
 #include <irreden/ir_math.hpp>
 
 #include <glm/gtc/constants.hpp>
+#include <ostream>
 
 // Tests for the pure/constexpr helpers in ir_math.hpp.
 // Platform-dependent helpers (pos3DtoPos2DScreen, ortho) are excluded.
+
+// GTest diagnostic support for CardinalIndex.
+namespace IRMath {
+inline std::ostream &operator<<(std::ostream &os, CardinalIndex c) {
+    switch (c) {
+    case CardinalIndex::k0:
+        return os << "k0";
+    case CardinalIndex::k90:
+        return os << "k90";
+    case CardinalIndex::k180:
+        return os << "k180";
+    case CardinalIndex::k270:
+        return os << "k270";
+    }
+    return os << "CardinalIndex(" << static_cast<int>(c) << ")";
+}
+} // namespace IRMath
 
 namespace {
 
@@ -542,8 +560,8 @@ TEST(EntityIsoBoundsTest, UnitVoxelAtOrigin) {
     auto b = IRMath::entityIsoBounds(IRMath::vec3(0.0f), IRMath::ivec3(1, 1, 1));
     EXPECT_NEAR(b.min_.x, -1.0f, kTolerance);
     EXPECT_NEAR(b.min_.y, -2.0f, kTolerance);
-    EXPECT_NEAR(b.max_.x,  1.0f, kTolerance);
-    EXPECT_NEAR(b.max_.y,  2.0f, kTolerance);
+    EXPECT_NEAR(b.max_.x, 1.0f, kTolerance);
+    EXPECT_NEAR(b.max_.y, 2.0f, kTolerance);
 }
 
 TEST(EntityIsoBoundsTest, OriginProjectedInBounds) {
@@ -562,11 +580,12 @@ TEST(EntityIsoBoundsTest, BoundsEncloseAllCorners) {
     for (int dx = 0; dx <= 1; ++dx) {
         for (int dy = 0; dy <= 1; ++dy) {
             for (int dz = 0; dz <= 1; ++dz) {
-                IRMath::vec3 corner = worldPos + IRMath::vec3(dx * size.x, dy * size.y, dz * size.z);
+                IRMath::vec3 corner =
+                    worldPos + IRMath::vec3(dx * size.x, dy * size.y, dz * size.z);
                 auto iso = IRMath::pos3DtoPos2DIso(corner);
                 EXPECT_TRUE(b.contains(iso))
-                    << "corner (" << dx << "," << dy << "," << dz << ") iso=("
-                    << iso.x << "," << iso.y << ") not in bounds";
+                    << "corner (" << dx << "," << dy << "," << dz << ") iso=(" << iso.x << ","
+                    << iso.y << ") not in bounds";
             }
         }
     }
@@ -619,22 +638,22 @@ TEST(Rotate2DTest, ForwardThenInverseIsIdentity) {
 // ---------------------------------------------------------------------------
 
 TEST(RasterYawCardinalIndexTest, ZeroIsIndexZero) {
-    EXPECT_EQ(IRMath::rasterYawCardinalIndex(0.0f), 0);
+    EXPECT_EQ(IRMath::rasterYawCardinalIndex(0.0f), IRMath::CardinalIndex::k0);
 }
 
 TEST(RasterYawCardinalIndexTest, ExactCardinals) {
     constexpr float halfPi = glm::half_pi<float>();
-    EXPECT_EQ(IRMath::rasterYawCardinalIndex(halfPi),       1);
-    EXPECT_EQ(IRMath::rasterYawCardinalIndex(2.0f * halfPi), 2);
-    EXPECT_EQ(IRMath::rasterYawCardinalIndex(3.0f * halfPi), 3);
-    EXPECT_EQ(IRMath::rasterYawCardinalIndex(4.0f * halfPi), 0);
+    EXPECT_EQ(IRMath::rasterYawCardinalIndex(halfPi), IRMath::CardinalIndex::k90);
+    EXPECT_EQ(IRMath::rasterYawCardinalIndex(2.0f * halfPi), IRMath::CardinalIndex::k180);
+    EXPECT_EQ(IRMath::rasterYawCardinalIndex(3.0f * halfPi), IRMath::CardinalIndex::k270);
+    EXPECT_EQ(IRMath::rasterYawCardinalIndex(4.0f * halfPi), IRMath::CardinalIndex::k0);
 }
 
 TEST(RasterYawCardinalIndexTest, NegativeFoldsIntoRange) {
     constexpr float halfPi = glm::half_pi<float>();
-    EXPECT_EQ(IRMath::rasterYawCardinalIndex(-halfPi),       3);
-    EXPECT_EQ(IRMath::rasterYawCardinalIndex(-2.0f * halfPi), 2);
-    EXPECT_EQ(IRMath::rasterYawCardinalIndex(-3.0f * halfPi), 1);
+    EXPECT_EQ(IRMath::rasterYawCardinalIndex(-halfPi), IRMath::CardinalIndex::k270);
+    EXPECT_EQ(IRMath::rasterYawCardinalIndex(-2.0f * halfPi), IRMath::CardinalIndex::k180);
+    EXPECT_EQ(IRMath::rasterYawCardinalIndex(-3.0f * halfPi), IRMath::CardinalIndex::k90);
 }
 
 // ---------------------------------------------------------------------------
@@ -644,24 +663,24 @@ TEST(RasterYawCardinalIndexTest, NegativeFoldsIntoRange) {
 
 TEST(RotateCardinalZTest, IdentityCardinalIsNoOp) {
     IRMath::ivec3 v(3, -2, 5);
-    auto r = IRMath::rotateCardinalZ(v, 0);
+    auto r = IRMath::rotateCardinalZ(v, IRMath::CardinalIndex::k0);
     EXPECT_EQ(r.x, v.x);
     EXPECT_EQ(r.y, v.y);
     EXPECT_EQ(r.z, v.z);
 }
 
 TEST(RotateCardinalZTest, MatchesGLSLPlusXMappings) {
-    // World +X (rasterYaw=π/2 → cardinalIndex=1) → view -Y, per the GLSL
+    // World +X (rasterYaw=π/2 → CardinalIndex::k90) → view -Y, per the GLSL
     // convention documented in ir_iso_common.glsl: world→view = R_z(-rasterYaw).
-    auto r = IRMath::rotateCardinalZ(IRMath::ivec3(1, 0, 0), 1);
+    auto r = IRMath::rotateCardinalZ(IRMath::ivec3(1, 0, 0), IRMath::CardinalIndex::k90);
     EXPECT_EQ(r.x, 0);
     EXPECT_EQ(r.y, -1);
     EXPECT_EQ(r.z, 0);
 }
 
 TEST(RotateCardinalZTest, HalfTurnNegatesXY) {
-    // rasterYaw=π → cardinalIndex=2, world→view negates X and Y.
-    auto r = IRMath::rotateCardinalZ(IRMath::ivec3(3, -4, 7), 2);
+    // rasterYaw=π → CardinalIndex::k180, world→view negates X and Y.
+    auto r = IRMath::rotateCardinalZ(IRMath::ivec3(3, -4, 7), IRMath::CardinalIndex::k180);
     EXPECT_EQ(r.x, -3);
     EXPECT_EQ(r.y, 4);
     EXPECT_EQ(r.z, 7);
@@ -679,16 +698,19 @@ TEST(RotateCardinalZTest, InverseRoundTripsAllCardinals) {
         IRMath::vec3(2.5f, -3.5f, 1.25f),
         IRMath::vec3(-7.0f, 11.0f, -2.0f),
     };
-    for (int idx = 0; idx < 4; ++idx) {
+    for (int raw = 0; raw < 4; ++raw) {
+        const auto idx = static_cast<IRMath::CardinalIndex>(raw);
         for (const auto &w : worlds) {
-            const IRMath::ivec3 wInt(static_cast<int>(w.x), static_cast<int>(w.y),
-                                     static_cast<int>(w.z));
+            const IRMath::ivec3 wInt(
+                static_cast<int>(w.x),
+                static_cast<int>(w.y),
+                static_cast<int>(w.z)
+            );
             const IRMath::ivec3 rotated = IRMath::rotateCardinalZ(wInt, idx);
-            const IRMath::vec3 back =
-                IRMath::rotateCardinalZInv(IRMath::vec3(rotated), idx);
-            EXPECT_NEAR(back.x, static_cast<float>(wInt.x), kTolerance) << "idx=" << idx;
-            EXPECT_NEAR(back.y, static_cast<float>(wInt.y), kTolerance) << "idx=" << idx;
-            EXPECT_NEAR(back.z, static_cast<float>(wInt.z), kTolerance) << "idx=" << idx;
+            const IRMath::vec3 back = IRMath::rotateCardinalZInv(IRMath::vec3(rotated), idx);
+            EXPECT_NEAR(back.x, static_cast<float>(wInt.x), kTolerance) << "raw=" << raw;
+            EXPECT_NEAR(back.y, static_cast<float>(wInt.y), kTolerance) << "raw=" << raw;
+            EXPECT_NEAR(back.z, static_cast<float>(wInt.z), kTolerance) << "raw=" << raw;
         }
     }
 }
@@ -710,7 +732,7 @@ TEST(PickingInverseTest, RoundTripsAcrossAllCardinals) {
         IRMath::ivec3(7, -3, 2),
     };
     for (float rasterYaw : rasterYaws) {
-        const int cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
+        const IRMath::CardinalIndex cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
         for (const auto &w : worlds) {
             const IRMath::ivec3 wRotated = IRMath::rotateCardinalZ(w, cardinalIndex);
             const IRMath::ivec2 canvasIso = IRMath::pos3DtoPos2DIso(wRotated);
@@ -740,13 +762,14 @@ TEST(RotateCardinalZVec3Test, MatchesIntegerOverloadOnIntegerValuedFloats) {
         IRMath::vec3(-2.0f, 1.0f, 4.0f),
         IRMath::vec3(7.0f, -3.0f, 2.0f),
     };
-    for (int idx = 0; idx < 4; ++idx) {
+    for (int raw = 0; raw < 4; ++raw) {
+        const auto idx = static_cast<IRMath::CardinalIndex>(raw);
         for (const auto &w : worlds) {
             const IRMath::vec3 rFloat = IRMath::rotateCardinalZ(w, idx);
             const IRMath::ivec3 rInt = IRMath::rotateCardinalZ(
-                IRMath::ivec3(static_cast<int>(w.x), static_cast<int>(w.y),
-                              static_cast<int>(w.z)),
-                idx);
+                IRMath::ivec3(static_cast<int>(w.x), static_cast<int>(w.y), static_cast<int>(w.z)),
+                idx
+            );
             EXPECT_NEAR(rFloat.x, static_cast<float>(rInt.x), kTolerance);
             EXPECT_NEAR(rFloat.y, static_cast<float>(rInt.y), kTolerance);
             EXPECT_NEAR(rFloat.z, static_cast<float>(rInt.z), kTolerance);
@@ -760,7 +783,7 @@ TEST(RotateCardinalZVec3Test, PreservesFractionalCoords) {
     // = R_z(-π/2)): (x, y, z) → (y, -x, z). Verify exact preservation
     // of fractional values, not just sign behavior.
     const IRMath::vec3 v(2.5f, -3.75f, 1.125f);
-    const IRMath::vec3 r = IRMath::rotateCardinalZ(v, 1);
+    const IRMath::vec3 r = IRMath::rotateCardinalZ(v, IRMath::CardinalIndex::k90);
     EXPECT_FLOAT_EQ(r.x, -3.75f);
     EXPECT_FLOAT_EQ(r.y, -2.5f);
     EXPECT_FLOAT_EQ(r.z, 1.125f);
@@ -768,7 +791,8 @@ TEST(RotateCardinalZVec3Test, PreservesFractionalCoords) {
 
 TEST(RotateCardinalZVec3Test, InverseRoundTripPerCardinal) {
     const IRMath::vec3 v(1.5f, -2.25f, 0.75f);
-    for (int idx = 0; idx < 4; ++idx) {
+    for (int raw = 0; raw < 4; ++raw) {
+        const auto idx = static_cast<IRMath::CardinalIndex>(raw);
         const IRMath::vec3 forward = IRMath::rotateCardinalZ(v, idx);
         const IRMath::vec3 back = IRMath::rotateCardinalZInv(forward, idx);
         EXPECT_NEAR(back.x, v.x, kTolerance) << "idx=" << idx;
@@ -798,18 +822,19 @@ namespace detail {
 // `engine/prefabs/irreden/input/systems/system_hitbox_mouse_test.hpp`.
 // Returns the canvas-pixel position the entity projects to under the
 // captured camera state.
-inline IRMath::vec2 forwardProjectEntity(IRMath::vec3 worldPos,
-                                          int cardinalIndex,
-                                          IRMath::vec2 cameraIso,
-                                          IRMath::vec2 cameraZoom,
-                                          IRMath::vec2 fbResHalf) {
+inline IRMath::vec2 forwardProjectEntity(
+    IRMath::vec3 worldPos,
+    IRMath::CardinalIndex cardinalIndex,
+    IRMath::vec2 cameraIso,
+    IRMath::vec2 cameraZoom,
+    IRMath::vec2 fbResHalf
+) {
     const IRMath::vec3 viewPos = IRMath::rotateCardinalZ(worldPos, cardinalIndex);
     const IRMath::vec2 entityIso = IRMath::pos3DtoPos2DIso(viewPos);
     const IRMath::vec2 relativeIso = entityIso - cameraIso;
     const IRMath::vec2 screenOffset =
         IRMath::pos2DIsoToPos2DGameResolution(relativeIso, cameraZoom);
-    return IRMath::vec2(fbResHalf.x + screenOffset.x,
-                        fbResHalf.y - screenOffset.y);
+    return IRMath::vec2(fbResHalf.x + screenOffset.x, fbResHalf.y - screenOffset.y);
 }
 
 // Build a synthetic mouse position by forward-rotating an entity's
@@ -817,18 +842,16 @@ inline IRMath::vec2 forwardProjectEntity(IRMath::vec3 worldPos,
 // the system's beforeTick lifting). Round-tripping through the
 // system's inverse must recover the same canvas pixel; that is the
 // load-bearing property a yaw-correct hitbox must satisfy.
-inline IRMath::vec2 forwardResidualOnCanvasPixel(IRMath::vec2 canvasPixel,
-                                                  float residualYaw,
-                                                  float effectiveSign,
-                                                  IRMath::vec2 fbResHalf) {
+inline IRMath::vec2 forwardResidualOnCanvasPixel(
+    IRMath::vec2 canvasPixel, float residualYaw, float effectiveSign, IRMath::vec2 fbResHalf
+) {
     const float forwardAngle = residualYaw * effectiveSign;
     return IRMath::rotate2D(canvasPixel - fbResHalf, forwardAngle) + fbResHalf;
 }
 
-inline IRMath::vec2 inverseResidualOnFramebufferPixel(IRMath::vec2 mouseFb,
-                                                      float residualYaw,
-                                                      float effectiveSign,
-                                                      IRMath::vec2 fbResHalf) {
+inline IRMath::vec2 inverseResidualOnFramebufferPixel(
+    IRMath::vec2 mouseFb, float residualYaw, float effectiveSign, IRMath::vec2 fbResHalf
+) {
     const float effectiveAngle = -residualYaw * effectiveSign;
     return IRMath::rotate2D(mouseFb - fbResHalf, effectiveAngle) + fbResHalf;
 }
@@ -841,11 +864,10 @@ TEST(HitboxProjectionTest, ResidualRotationRoundTripsAtNonCardinalYaws) {
     // produces (rasterYaw snaps to π/2 by std::round half-away-from-zero,
     // residualYaw = -π/4).
     constexpr float halfPi = glm::half_pi<float>();
-    const float residualYaws[] = {halfPi / 4.0f,
-                                  -halfPi / 2.0f};
+    const float residualYaws[] = {halfPi / 4.0f, -halfPi / 2.0f};
     const IRMath::vec2 fbResHalf(640.0f, 360.0f);
     const IRMath::vec2 canvasPixels[] = {
-        IRMath::vec2(640.0f, 360.0f),  // center — invariant under any rotation
+        IRMath::vec2(640.0f, 360.0f), // center — invariant under any rotation
         IRMath::vec2(700.0f, 400.0f),
         IRMath::vec2(540.0f, 280.0f),
     };
@@ -856,11 +878,13 @@ TEST(HitboxProjectionTest, ResidualRotationRoundTripsAtNonCardinalYaws) {
         for (float sign : effectiveSigns) {
             for (const auto &canvasPixel : canvasPixels) {
                 const IRMath::vec2 mouseFb =
-                    detail::forwardResidualOnCanvasPixel(
-                        canvasPixel, residualYaw, sign, fbResHalf);
-                const IRMath::vec2 recovered =
-                    detail::inverseResidualOnFramebufferPixel(
-                        mouseFb, residualYaw, sign, fbResHalf);
+                    detail::forwardResidualOnCanvasPixel(canvasPixel, residualYaw, sign, fbResHalf);
+                const IRMath::vec2 recovered = detail::inverseResidualOnFramebufferPixel(
+                    mouseFb,
+                    residualYaw,
+                    sign,
+                    fbResHalf
+                );
                 EXPECT_NEAR(recovered.x, canvasPixel.x, 1e-3f)
                     << "residualYaw=" << residualYaw << " sign=" << sign;
                 EXPECT_NEAR(recovered.y, canvasPixel.y, 1e-3f)
@@ -878,31 +902,33 @@ TEST(HitboxProjectionTest, HoverFiresAtCardinalYawOnEntityUnderCursor) {
     // expect the hitbox half-extent to flip hovered_ on.
     const IRMath::vec3 entityWorld(3.0f, 0.0f, 0.0f);
     const float rasterYaw = glm::half_pi<float>();
-    const int cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
+    const IRMath::CardinalIndex cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
     const IRMath::vec2 cameraIso(0.0f, 0.0f);
     const IRMath::vec2 cameraZoom(1.0f, 1.0f);
     const IRMath::vec2 fbResHalf(640.0f, 360.0f);
 
     const IRMath::vec2 entityCenter =
-        detail::forwardProjectEntity(
-            entityWorld, cardinalIndex, cameraIso, cameraZoom, fbResHalf);
+        detail::forwardProjectEntity(entityWorld, cardinalIndex, cameraIso, cameraZoom, fbResHalf);
 
     // The cursor lands exactly on the projected center; with any
     // positive halfExtent the hitbox should match.
     const IRMath::vec2 cursorCanvas = entityCenter;
     const IRMath::vec2 halfExtent(8.0f, 8.0f);
-    const bool hovered =
-        std::abs(cursorCanvas.x - entityCenter.x) <= halfExtent.x &&
-        std::abs(cursorCanvas.y - entityCenter.y) <= halfExtent.y;
+    const bool hovered = std::abs(cursorCanvas.x - entityCenter.x) <= halfExtent.x &&
+                         std::abs(cursorCanvas.y - entityCenter.y) <= halfExtent.y;
     EXPECT_TRUE(hovered);
 
     // Without the cardinal rotation the projected center would land at
     // a different canvas pixel — verify the test is not vacuous. For
     // entity (3,0,0): iso.x = -x+y stays at -3 across both rotations
     // (-3+0 == 0+(-3)), but iso.y flips sign, so y differs.
-    const IRMath::vec2 yawZeroCenter =
-        detail::forwardProjectEntity(
-            entityWorld, /*cardinalIndex=*/0, cameraIso, cameraZoom, fbResHalf);
+    const IRMath::vec2 yawZeroCenter = detail::forwardProjectEntity(
+        entityWorld,
+        IRMath::CardinalIndex::k0,
+        cameraIso,
+        cameraZoom,
+        fbResHalf
+    );
     EXPECT_NE(entityCenter.y, yawZeroCenter.y);
 }
 
@@ -918,8 +944,8 @@ TEST(HitboxProjectionTest, HoverFiresUnderNonCardinalYaw) {
         IRMath::vec3 entityWorld_;
     };
     const Case cases[] = {
-        {halfPi / 4.0f,                   IRMath::vec3(2.0f, 1.0f, 0.0f)},
-        {halfPi + halfPi / 8.0f,           IRMath::vec3(3.0f, -2.0f, 1.0f)},
+        {halfPi / 4.0f, IRMath::vec3(2.0f, 1.0f, 0.0f)},
+        {halfPi + halfPi / 8.0f, IRMath::vec3(3.0f, -2.0f, 1.0f)},
     };
     const IRMath::vec2 cameraIso(0.0f, 0.0f);
     const IRMath::vec2 cameraZoom(1.0f, 1.0f);
@@ -928,31 +954,37 @@ TEST(HitboxProjectionTest, HoverFiresUnderNonCardinalYaw) {
 
     for (float effectiveSign : {1.0f, -1.0f}) {
         for (const auto &c : cases) {
-            const float rasterYaw =
-                glm::round(c.visualYaw_ / halfPi) * halfPi;
+            const float rasterYaw = glm::round(c.visualYaw_ / halfPi) * halfPi;
             const float residualYaw = c.visualYaw_ - rasterYaw;
-            const int cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
+            const IRMath::CardinalIndex cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
 
             // Project entity to its canvas-pixel center.
-            const IRMath::vec2 entityCenter =
-                detail::forwardProjectEntity(
-                    c.entityWorld_, cardinalIndex, cameraIso, cameraZoom,
-                    fbResHalf);
+            const IRMath::vec2 entityCenter = detail::forwardProjectEntity(
+                c.entityWorld_,
+                cardinalIndex,
+                cameraIso,
+                cameraZoom,
+                fbResHalf
+            );
             // Forward-rotate that canvas pixel through the residual
             // composite to compute where the user must click on the
             // framebuffer for the hitbox to be "under" the cursor.
-            const IRMath::vec2 mouseFb =
-                detail::forwardResidualOnCanvasPixel(
-                    entityCenter, residualYaw, effectiveSign, fbResHalf);
+            const IRMath::vec2 mouseFb = detail::forwardResidualOnCanvasPixel(
+                entityCenter,
+                residualYaw,
+                effectiveSign,
+                fbResHalf
+            );
             // Inverse-rotate the cursor as the system's beforeTick does.
-            const IRMath::vec2 mouseCanvas =
-                detail::inverseResidualOnFramebufferPixel(
-                    mouseFb, residualYaw, effectiveSign, fbResHalf);
-            const bool hovered =
-                std::abs(mouseCanvas.x - entityCenter.x) <= halfExtent.x &&
-                std::abs(mouseCanvas.y - entityCenter.y) <= halfExtent.y;
-            EXPECT_TRUE(hovered)
-                << "visualYaw=" << c.visualYaw_ << " sign=" << effectiveSign;
+            const IRMath::vec2 mouseCanvas = detail::inverseResidualOnFramebufferPixel(
+                mouseFb,
+                residualYaw,
+                effectiveSign,
+                fbResHalf
+            );
+            const bool hovered = std::abs(mouseCanvas.x - entityCenter.x) <= halfExtent.x &&
+                                 std::abs(mouseCanvas.y - entityCenter.y) <= halfExtent.y;
+            EXPECT_TRUE(hovered) << "visualYaw=" << c.visualYaw_ << " sign=" << effectiveSign;
         }
     }
 }
@@ -963,10 +995,10 @@ TEST(HitboxProjectionTest, HoverDoesNotFireOutsideHalfExtentUnderYaw) {
     // that the inverse helper isn't accidentally widening the hit area
     // (e.g. via wrong sign on screenYDirection).
     constexpr float halfPi = glm::half_pi<float>();
-    const float visualYaw = halfPi / 4.0f;  // residualYaw = π/8, raster=0
+    const float visualYaw = halfPi / 4.0f; // residualYaw = π/8, raster=0
     const float rasterYaw = glm::round(visualYaw / halfPi) * halfPi;
     const float residualYaw = visualYaw - rasterYaw;
-    const int cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
+    const IRMath::CardinalIndex cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
     const IRMath::vec2 cameraIso(0.0f, 0.0f);
     const IRMath::vec2 cameraZoom(1.0f, 1.0f);
     const IRMath::vec2 fbResHalf(640.0f, 360.0f);
@@ -974,8 +1006,7 @@ TEST(HitboxProjectionTest, HoverDoesNotFireOutsideHalfExtentUnderYaw) {
     const IRMath::vec2 halfExtent(4.0f, 4.0f);
 
     const IRMath::vec2 entityCenter =
-        detail::forwardProjectEntity(
-            entityWorld, cardinalIndex, cameraIso, cameraZoom, fbResHalf);
+        detail::forwardProjectEntity(entityWorld, cardinalIndex, cameraIso, cameraZoom, fbResHalf);
 
     // Place the cursor at a canvas pixel 20 units away — well outside
     // the half-extent. Forward-rotate it to fb-space, inverse-rotate
@@ -983,14 +1014,15 @@ TEST(HitboxProjectionTest, HoverDoesNotFireOutsideHalfExtentUnderYaw) {
     const IRMath::vec2 farCanvas = entityCenter + IRMath::vec2(20.0f, 20.0f);
     for (float effectiveSign : {1.0f, -1.0f}) {
         const IRMath::vec2 mouseFb =
-            detail::forwardResidualOnCanvasPixel(
-                farCanvas, residualYaw, effectiveSign, fbResHalf);
-        const IRMath::vec2 mouseCanvas =
-            detail::inverseResidualOnFramebufferPixel(
-                mouseFb, residualYaw, effectiveSign, fbResHalf);
-        const bool hovered =
-            std::abs(mouseCanvas.x - entityCenter.x) <= halfExtent.x &&
-            std::abs(mouseCanvas.y - entityCenter.y) <= halfExtent.y;
+            detail::forwardResidualOnCanvasPixel(farCanvas, residualYaw, effectiveSign, fbResHalf);
+        const IRMath::vec2 mouseCanvas = detail::inverseResidualOnFramebufferPixel(
+            mouseFb,
+            residualYaw,
+            effectiveSign,
+            fbResHalf
+        );
+        const bool hovered = std::abs(mouseCanvas.x - entityCenter.x) <= halfExtent.x &&
+                             std::abs(mouseCanvas.y - entityCenter.y) <= halfExtent.y;
         EXPECT_FALSE(hovered) << "sign=" << effectiveSign;
     }
 }


### PR DESCRIPTION
## Summary
- Wire rasterYaw cardinal rotation + residualYaw inverse-rotate into `HITBOX_MOUSE_TEST` so `C_HitBox2D`-driven hover tracks rendered entity centers at any `visualYaw`.
- Add `vec3 rotateCardinalZ(vec3, int)` overload next to T-057's ivec3 variant (entity world positions are vec3; the integer helper would truncate).
- Tests cover: vec3 overload semantics, residual round-trip across both `screenYDirection` signs, and the full hitbox projection chain at `visualYaw ∈ {π/2, π/4, π/2+π/16}`.

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/424 (T-057 — picking inverse + cardinal helpers)

The `vec3 rotateCardinalZ` overload, `inverseResidualYawOnFramebufferPixel` semantics, `rasterYawCardinalIndex`, and the picking inverse machinery this PR depends on are part of T-057. When PR #424 merges, GitHub auto-rebases this PR's base to `master`.

## Test plan
- [ ] `fleet-build --target IrredenEngineTest` clean
- [ ] `fleet-run IrredenEngineTest` — 394+7 tests pass (4 new HitboxProjectionTest cases, 3 new RotateCardinalZVec3Test cases)
- [ ] `fleet-build --target IRShapeDebug` clean (linux-debug + macos-debug)
- [ ] Interactive: spawn an entity with `C_HitBox2D + C_PositionGlobal3D` in any creation that exercises hitbox-driven hover; rotate the camera to any non-cardinal `visualYaw`; mouse over the entity — `onHovered` callback fires correctly. Without this fix, hover missed.

## Notes for reviewer
- The system continues to use function-local `static` for tick-scoped state. This file is **not** in `.fleet/status/system-static-deviations.md` (the migration list there is render-only), so the pattern is preserved consistently with the rest of `engine/prefabs/irreden/input/systems/`.
- The inverse-residual-rotate logic in `beforeTick` reproduces ~10 lines from `engine/render/src/ir_render.cpp`'s anonymous-namespace `inverseResidualYawOnFramebufferPixel`. Promoting that helper to public surface in a follow-up would let HITBOX_MOUSE_TEST reuse it; left as-is to keep this PR's diff scoped and to avoid widening T-057's API surface mid-review.
- The vec3 overload of `rotateCardinalZ` lives immediately after the ivec3 variant T-057 added. The duplication mirrors the existing `sumVecComponents` / `pos3DtoPos2DIso` overload pattern in `ir_math.hpp` (plain overloads, not templates).
- No render shaders, render systems, or pipeline ordering changed — render-debug-loop / attach-screenshots not required per `engine/render/CLAUDE.md` "Verifying render changes" exception list.

Closes #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)