### PR TITLE
fleet: feedback-driven role-doc hygiene (TOCTOU, label re-stamp, claim-release, audit checklist)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -550,6 +550,12 @@ exit cleanly:
 
 6. Write a per-iteration summary, then print completion:
    `fleet-iteration-summary merger "<PRs processed, outcomes, snags — under 100 words.>"`
+   **Do NOT use backticks in the summary text.** Your bash shell
+   evaluates backticks within double-quoted args as command
+   substitution — `` `something` `` will be run as a command, fail,
+   and silently strip from the saved summary (observed on
+   opus-reviewer 2026-05-02). Write technical references in plain
+   prose (`scale > 1` becomes `scale gt 1` or `the scale gate`).
    Then print `[merger] Iteration complete. Next run in ~10m.`
    Then exit cleanly. The `/loop` driver will re-invoke in 10
    minutes.

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -220,6 +220,22 @@ conversation), use the same flow:
    - Whether it should be one task or broken into subtasks
    - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
    - Acceptance criteria
+   - **Cross-system audit (when planning a deletion or migration of
+     a shared resource — component, SSBO, GPU buffer, system,
+     coordinate convention, etc.).** List every consumer of the
+     resource being changed and a per-consumer migration plan.
+     Audit by grep on the type/symbol name and on slot/binding
+     numbers (some consumers reference resources by index, not
+     name). Without this section the worker discovers gaps mid-task
+     and escalates: T-071's design doc planned `BUILD_OCCUPANCY_GRID`
+     deletion based on the sun-shadow consumer alone, missing AO
+     (`c_compute_voxel_ao.glsl` slot 28) and light-volume
+     (`detail::hasLineOfSight`) which both also depend on it. T-072
+     then expected the grid to still exist as a GPU resource T-071
+     was deleting. Sign-convention drift between parallel PRs
+     (T-055 vs T-056 on `visualYaw`→world rotation) is the same
+     class of bug — name the convention and the consumers that
+     must agree on it.
 3. Save the plan to `~/.fleet/plans/issue-<N>.md` using the Write tool.
 4. Remove `fleet:needs-plan`. Do NOT touch `human:approved` —
    it's still on the issue from when the human triaged it, and

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -330,6 +330,12 @@ iteration of polling, reviewing, and exiting cleanly:
    a worker agent tries to check out a PR branch you just reviewed.
 4. After the reset, write a per-iteration summary:
    `fleet-iteration-summary opus-reviewer "<PR numbers reviewed, verdicts, snags — under 100 words.>"`
+   **Do NOT use backticks in the summary text.** Your bash shell
+   evaluates backticks within double-quoted args as command
+   substitution — `` `something` `` will be run as a command, fail,
+   and silently strip from the saved summary (observed on
+   opus-reviewer 2026-05-02). Write technical references in plain
+   prose (`scale > 1` becomes `scale gt 1` or `the scale gate`).
    Then print
    `[opus-reviewer] Iteration complete. Next run in ~30m (fresh context).`
    Then exit cleanly. `fleet-babysit` relaunches a fresh `claude` in
@@ -378,6 +384,24 @@ iterations write nothing).
   `gh pr edit <N> ... --add-label "fleet:..."`. Describing the label
   change in the review body does NOT set the label — only the gh
   command does. Verify with `gh pr view <N> --json labels` if unsure.
+- **Never re-apply a verdict label without posting a new review in
+  the same iteration.** A PR with a prior Opus needs-fix verdict in
+  history but no current label is NOT automatically a label-fixup
+  candidate — the label may have been legitimately cleared by the
+  author's `commit-and-push` after a fix push, by an ESCALATE
+  handoff (swap of `fleet:needs-fix` for `fleet:changes-made`), or
+  by a worker mid-claim. Before re-stamping a "missing" verdict
+  label, do one live check for ANY of: (a) a new commit since your
+  last review's `submittedAt`, (b) a new author comment, (c) a
+  recent `fleet:needs-fix` / `fleet:approved` UNLABELED event, (d)
+  presence of `fleet:changes-made`. If any are present, the prior
+  verdict was author-acknowledged — treat the PR as a re-review
+  candidate and post a fresh review (which sets the label as part
+  of its own flow) rather than re-stamping the stale verdict.
+  `gh pr view <N> --json labels` alone does not show label-strip
+  events; use `gh api repos/jakildev/IrredenEngine/issues/<N>/timeline`
+  to see UNLABELED events. Observed bogus re-stamps: PRs #347,
+  #348, #394.
 - Do NOT take on first-pass reviews that Sonnet has not yet touched
   (unless `sonnet-reviewer` is offline AND the PR has been open more
   than 1 hour). The model split exists to conserve Opus budget.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -330,8 +330,20 @@ Do the work, then exit cleanly:
        5. **Skip steps b–g.** Jump to step h (move to next
           iteration). The PR's code is unchanged.
 
-   b. **(AMEND path)** **Immediately remove the feedback label**
-      to prevent another agent from also picking it up:
+   b. **(AMEND path)** **First, claim the branch by checking out the
+      PR.** `fleet-worktree-busy-branches` is a fast-path filter; git
+      is the source of truth and can change between the helper call
+      and the checkout (observed TOCTOU on PRs #402, #406, #425). Do
+      this BEFORE removing any label so a stale-busy-branch list
+      cannot leave the PR in a labeless state:
+      `gh pr checkout <N> --repo jakildev/IrredenEngine`
+      If checkout fails with `branch is already used by worktree at
+      ...`, **do NOT remove the feedback label**. Skip this PR and
+      move to the next iteration — the label stays on the PR so the
+      agent that does own the worktree can pick it up.
+
+      With checkout confirmed, **remove the feedback label** to
+      prevent another agent from also picking it up:
       `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:human-deferred" --remove-label "fleet:design-unblocked"`
 
       For `human:needs-fix` / `human:blocker` specifically, also
@@ -1023,6 +1035,11 @@ Do the work, then exit cleanly:
 
 12. **Reset.** Before resetting, write a per-iteration summary:
     `fleet-iteration-summary <your-worktree-basename> "T-NNN: <task title>. PR: #<N>. <Snags if any — under 100 words.>"`
+    **Do NOT use backticks in the summary text.** Your bash shell
+    evaluates backticks within double-quoted args as command
+    substitution — `` `something` `` will be run as a command, fail,
+    and silently strip from the saved summary. Write technical
+    references in plain prose.
 
     Then use the `start-next-task` skill to land on a fresh
     branch off `origin/master` in the **current cwd's repo** (engine

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -366,6 +366,33 @@ You are the sole TASKS.md editor. Each maintenance pass:
        Record the pruned task ID and closed issue number in the
        iteration summary.
 
+    **Check C — claim-release comment naming a merged PR (work shipped
+    elsewhere).** Workers occasionally pick up a task, discover the
+    engineering work already shipped under a different task ID, and
+    leave a release comment on the linked issue rather than opening a
+    new PR. Without this check, the row stays open forever (the issue
+    is still OPEN, so Check B doesn't fire) and every subsequent worker
+    pays the same pickup tax (observed: T-067 hit 4×, T-089 hit 2× by
+    different opus-workers). For each `[ ]` or `[~]` task whose
+    `**Issue:** #N` is a number, fetch the most recent few comments:
+    `gh issue view <N> --repo <repo> --json comments --jq '.comments[-5:]'`
+    Look for a comment body matching the release pattern — case-insensitive
+    substrings like `releasing the t-`, `already shipped`, `work shipped under pr #`,
+    `duplicate of pr #`, `already complete` — that names a specific PR
+    number. Verify that PR's state with `gh pr view <PR-N> --repo <repo>
+    --json state,mergedAt`. If state is `MERGED`:
+    a. Flip the TASKS.md row to `[x]` (use Edit; same rules as step 5
+       below for the done-row format).
+    b. Delete plan files: `rm -f ~/.fleet/plans/<task-ID>.md` and
+       `rm -f .fleet/plans/<task-ID>.md` (use the worktree-relative
+       form for the latter).
+    c. Comment on the issue requesting human-close (only if no such
+       comment is already present after the release comment):
+       `gh issue comment <N> --repo <repo> --body "Queue-manager: marked T-NNN done in TASKS.md (work shipped under PR #<PR-N>). Suggest closing this issue."`
+       This is intentionally non-destructive — workers don't close
+       issues, the human does.
+    Record each flipped task in the iteration summary.
+
     This step runs in **review-only mode** as well — it repairs
     existing state without expanding the queue.
 
@@ -757,6 +784,11 @@ You are the sole TASKS.md editor. Each maintenance pass:
 
 10. Write a per-iteration summary, then print the maintenance summary:
     `fleet-iteration-summary queue-manager "<X issues ingested, Y tasks flipped, Z claims cleaned. Snags if any. Under 100 words.>"`
+    **Do NOT use backticks in the summary text.** Your bash shell
+    evaluates backticks within double-quoted args as command
+    substitution — `` `something` `` will be run as a command, fail,
+    and silently strip from the saved summary. Write technical
+    references in plain prose.
     `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned, W epics closed`
     `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
     `[queue-manager] Iteration complete. Next run in ~5m.`

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -232,7 +232,19 @@ Each iteration:
        5. **Skip steps b–g.** Jump to step h (move to next
           iteration). The PR's code is unchanged.
 
-   b. **(AMEND path)** **Immediately remove the feedback label** to
+   b. **(AMEND path)** **First, claim the branch by checking out the
+      PR.** `fleet-worktree-busy-branches` is a fast-path filter; git
+      is the source of truth and can change between the helper call
+      and the checkout (observed TOCTOU on PRs #402, #406, #425). Do
+      this BEFORE removing any label so a stale-busy-branch list
+      cannot leave the PR in a labeless state:
+      `gh pr checkout <N> --repo jakildev/IrredenEngine`
+      If checkout fails with `branch is already used by worktree at
+      ...`, **do NOT remove the feedback label**. Skip this PR and
+      move to the next iteration — the label stays on the PR so the
+      agent that does own the worktree can pick it up.
+
+      With checkout confirmed, **remove the feedback label** to
       prevent another agent from also picking it up:
       `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:human-deferred"`
 
@@ -692,6 +704,11 @@ Each iteration:
    summary so `fleet-down --summary` has coverage even if the pane is
    between iterations at shutdown:
    `fleet-iteration-summary <your-worktree-basename> "T-NNN: <task title>. PR: #<N>. <Snags if any — under 100 words.>"`
+   **Do NOT use backticks in the summary text.** Your bash shell
+   evaluates backticks within double-quoted args as command
+   substitution — `` `something` `` will be run as a command, fail,
+   and silently strip from the saved summary. Write technical
+   references in plain prose.
 
    Then use the `start-next-task` skill to land on a fresh branch off
    `origin/master`. Print

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -365,6 +365,11 @@ iteration of polling, reviewing, and exiting cleanly:
    a worker agent tries to check out a PR branch you just reviewed.
 4. After the reset, write a per-iteration summary:
    `fleet-iteration-summary sonnet-reviewer "<PR numbers reviewed, verdicts, snags — under 100 words.>"`
+   **Do NOT use backticks in the summary text.** Your bash shell
+   evaluates backticks within double-quoted args as command
+   substitution — `` `something` `` will be run as a command, fail,
+   and silently strip from the saved summary. Write technical
+   references in plain prose.
    Then print
    `[sonnet-reviewer] Iteration complete. Next run in ~3m (fresh context).`
    Then exit cleanly. `fleet-babysit` relaunches a fresh `claude` in
@@ -420,4 +425,16 @@ iterations write nothing).
   If you described the label change in the review body but didn't
   run the gh command, the label is NOT set — describing isn't
   doing. Verify with `gh pr view <N> --json labels`.
+- **Never re-apply a verdict label without posting a new review in
+  the same iteration.** If a PR you previously verdicted is now
+  missing its verdict label, that is NOT a label-fixup trigger —
+  the label may have been legitimately cleared by the author's
+  `commit-and-push` after a fix push, by an ESCALATE handoff (which
+  swaps `fleet:needs-fix` for `fleet:changes-made`), or by a worker
+  mid-claim on a `fleet:has-nits` PR. Heuristically re-stamping a
+  stale verdict overwrites those transitions and produces
+  invisible-needs-fix states (observed: PRs #347, #348, #394, plus
+  the 65s `fleet:has-nits` re-stamp race on #402). If you decide to
+  re-review, post a new review and set the label as part of THAT
+  review's flow. Otherwise leave the label alone.
 - Single-command Bash only (see CRITICAL section above).


### PR DESCRIPTION
## Summary

Bundle of role-doc fixes derived from the last week of fleet feedback across all eight roles. Each item closes a recurring failure mode that has been observed in production at least twice.

### Changes

| Role doc | Change |
|---|---|
| `role-sonnet-author.md`, `role-opus-worker.md` | TOCTOU guard: `gh pr checkout` runs **before** the `--remove-label` call. If checkout fails (branch held by another worktree), the feedback label is left in place. |
| `role-sonnet-reviewer.md`, `role-opus-reviewer.md` | New hard rule: never re-apply a verdict label without posting a new review in the same iteration. Opus-reviewer gets the cache-vs-live race-guard checklist (commit/comment/UNLABELED-event/`fleet:changes-made`) before treating a missing verdict label as a fixup target. |
| `role-queue-manager.md` | Bidirectional consistency pass gets **Check C**: scan recent comments on each open task's linked issue for a "Releasing the T-NNN claim; work shipped under PR #M" pattern. When the named PR is MERGED, auto-flip the row to `[x]` and post a follow-up comment requesting human-close. |
| `role-opus-architect.md` | Planning-issues checklist gets a **Cross-system audit** bullet: when planning deletion or migration of a shared resource, list every consumer with a per-consumer migration plan. |
| All six roles that invoke `fleet-iteration-summary` | Backtick-escape warning: bash evaluates backticks within double-quoted args as command substitution, silently stripping technical references from the saved summary. |

### Failure modes this closes

- **Worktree-list → label-remove → checkout TOCTOU** — observed on PRs #402, #406, #425.
- **Reviewer re-stamps verdict labels without re-reviewing** — observed on PRs #347, #348, #394, plus 65s `fleet:has-nits` race on #402.
- **Stale TASKS.md rows when work shipped under a different ID** — observed on T-067 (4× opus-worker iterations) and T-089 (2× iterations).
- **Cross-system consumer audit gap in design docs** — T-071 missed AO + light-volume consumers of the occupancy grid; T-055/T-056 shipped opposite `visualYaw` sign conventions.
- **fleet-iteration-summary backtick eval** — opus-reviewer 2026-05-02 lost technical specifics from a summary because `\`scale > 1\`` got executed and stripped.

### Out of scope (filed separately)

The remaining items from the feedback survey need script changes or investigation rather than role-doc edits:

- **fleet-babysit post-review label-audit cron** (the 8+ occurrence reviewer-label-gap; T-077 merged a doc-side fix that didn't fully stick).
- **Worktree-misroute pre-Edit hook** (T-078 verification — recurred on T-066 with a real 3-way conflict on recovery).
- **Scout daemon heartbeat / auto-relaunch** (silent 4.5h outage 2026-05-01).
- **`.claude/commands/` and `.claude/skills/` Edit-tool block** (T-079 follow-up — workaround `python3 /tmp/foo.py` still required).
- **Merger leaves rebase state in worktree on give-up path**.

## Test plan

- [ ] Author worker (sonnet-author / opus-worker) on a `fleet:has-nits` PR whose branch is held in another worktree: `gh pr checkout` fails, label stays on the PR, agent skips cleanly.
- [ ] Reviewer (sonnet-reviewer / opus-reviewer) sees a PR with a prior needs-fix verdict but no current label and a `fleet:changes-made` label: posts a fresh review (which sets the label), does NOT re-stamp the stale verdict.
- [ ] Queue-manager bidirectional pass detects "Releasing the T-NNN claim; work shipped under PR #M" comment on an open task's issue, validates PR #M is MERGED, flips row to `[x]`, comments on the issue.
- [ ] Architect planning a `fleet:needs-plan` issue that proposes a shared-resource deletion includes a Cross-system audit section in the plan comment.
- [ ] None of the six `fleet-iteration-summary` invocations across role docs go without the backtick warning sentence.

## Notes for reviewer

Pure doc PR, no code surface. Each change is surgical (single insert into an existing section); no restructuring of the role flows themselves. PR/issue/T-NNN references in the doc text are sourced from `~/.fleet/feedback/` entries dated 2026-04-30 → 2026-05-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)