### PR TITLE
tools: img_diff cli for highlighting render-baseline pixel drift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(BuildCreation VERSION 0.1.0)
 option(IRREDEN_BUILD_CREATIONS "Build engine-owned creations" ${PROJECT_IS_TOP_LEVEL})
 option(IRREDEN_BUILD_TESTS "Build engine test targets" ${PROJECT_IS_TOP_LEVEL})
 option(IRREDEN_BUILD_QUALITY_TARGETS "Build engine quality targets" ${PROJECT_IS_TOP_LEVEL})
+option(IRREDEN_BUILD_TOOLS "Build standalone tools (img_diff, etc.)" ${PROJECT_IS_TOP_LEVEL})
 set(
     IRREDEN_USER_PROJECTS
     ""
@@ -89,6 +90,10 @@ endif()
 
 if(IRREDEN_BUILD_TESTS)
     add_subdirectory(${PROJECT_SOURCE_DIR}/test)
+endif()
+
+if(IRREDEN_BUILD_TOOLS)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/tools/img_diff)
 endif()
 
 if(IRREDEN_BUILD_QUALITY_TARGETS)

--- a/tools/img_diff/CMakeLists.txt
+++ b/tools/img_diff/CMakeLists.txt
@@ -3,7 +3,8 @@ include(FetchContent)
 # stb is already declared by engine/render/CMakeLists.txt; the second
 # FetchContent_Declare with the same name is a no-op (CMake reuses the cache).
 # Declared here too so img_diff can build standalone if a future configure
-# ever excludes the engine subdir.
+# ever excludes the engine subdir. GIT_TAG master intentionally matches
+# engine/render/CMakeLists.txt — both track the same floating ref.
 FetchContent_Declare(
     stbimage
     GIT_REPOSITORY https://github.com/nothings/stb/

--- a/tools/img_diff/CMakeLists.txt
+++ b/tools/img_diff/CMakeLists.txt
@@ -1,0 +1,15 @@
+include(FetchContent)
+
+# stb is already declared by engine/render/CMakeLists.txt; the second
+# FetchContent_Declare with the same name is a no-op (CMake reuses the cache).
+# Declared here too so img_diff can build standalone if a future configure
+# ever excludes the engine subdir.
+FetchContent_Declare(
+    stbimage
+    GIT_REPOSITORY https://github.com/nothings/stb/
+    GIT_TAG master
+)
+FetchContent_MakeAvailable(stbimage)
+
+add_executable(img_diff main.cpp)
+target_include_directories(img_diff PRIVATE ${stbimage_SOURCE_DIR})

--- a/tools/img_diff/README.md
+++ b/tools/img_diff/README.md
@@ -1,0 +1,81 @@
+# img_diff
+
+Tiny standalone CLI that highlights per-pixel drift between two PNGs.
+
+```
+img_diff <baseline.png> <current.png> <out_diff.png> [--threshold N] [--ignore-alpha]
+```
+
+## Output PNG
+
+| Pixel state | What gets written |
+|---|---|
+| Drifted (any channel `> threshold`) | Solid red `(255, 0, 0, 255)` |
+| Unchanged | Baseline pixel desaturated to ~30% luminance |
+
+Drift pops red against quiet visible context, so a single drifted pixel
+in a 1280×720 frame is impossible to miss. The desaturated baseline
+keeps spatial reference (you can see *where* the drift sits relative to
+geometry) without competing with the red highlights.
+
+## Why it exists
+
+Render-debug agents and human reviewers both lose subtle 1-pixel
+regressions (cube-edge zigzag, single-pixel parity drift) when looking
+at full-frame screenshots. A red-on-grey diff PNG turns "compare these
+two images pixel by pixel" into "which pixels are red".
+
+Companion to `scripts/render-compare.py`, which reports aggregate
+metrics (PSNR, max delta, match%) and a brightness-delta diff PNG. Use
+`render-compare.py` for pass/fail gates and `img_diff` for "show me
+the drift".
+
+## Build
+
+The tool builds whenever `IRREDEN_BUILD_TOOLS` is on (default for the
+top-level engine build):
+
+```
+cmake --preset macos-debug      # or linux-debug / windows-debug
+cmake --build build --target img_diff
+```
+
+Binary lands at `build/tools/img_diff/img_diff`.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Zero drift — current matches baseline within `--threshold` |
+| 1 | Drift detected — diff PNG written |
+| 2 | Argument or I/O error |
+
+## Options
+
+- `--threshold N` — per-channel delta tolerance, default `0`. A pixel
+  drifts when its largest channel delta is **strictly greater** than
+  the threshold.
+- `--ignore-alpha` — compare RGB only; useful when alpha is constant
+  but renders differently across PNG encoders.
+
+## Examples
+
+```
+# zero drift
+img_diff a.png a.png /tmp/diff.png
+# img_diff: total=921600 drift=0 (0.0000%) max_delta=0 threshold=0 -> /tmp/diff.png
+
+# show drift between baseline and current shot
+img_diff baselines/zoom4_origin.png current/zoom4_origin.png /tmp/zoom4_diff.png
+
+# tolerate small shading differences (tone-mapper jitter, etc.)
+img_diff baseline.png current.png /tmp/diff.png --threshold 4
+```
+
+## Related
+
+- `scripts/render-compare.py` — aggregate metrics + brightness-delta diff
+- `.claude/skills/render-debug-loop/SKILL.md` — agent workflow that
+  consumes `img_diff` output
+- `.claude/skills/attach-screenshots/SKILL.md` — captures the before/
+  after pairs that `img_diff` operates on

--- a/tools/img_diff/main.cpp
+++ b/tools/img_diff/main.cpp
@@ -1,0 +1,229 @@
+// img_diff: highlight per-pixel drift between two PNGs.
+//
+// Spec: GitHub issue #435. Standalone tool with no engine dependencies — used
+// by `render-debug-loop`, the `attach-screenshots` skill, and human reviewers
+// to make pixel-level baseline drift impossible to miss.
+//
+// Output PNG layout:
+//   * Drifted pixel  → solid red (255, 0, 0, 255)
+//   * Unchanged      → baseline pixel desaturated to ~30% luminance, so the
+//                      drift pops against quiet visible context (rather than
+//                      a flat black field).
+//
+// A pixel "drifts" when ANY channel differs from the baseline by strictly
+// more than `--threshold` (default 0). Alpha is included by default; pass
+// `--ignore-alpha` to compare RGB only.
+
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace {
+
+constexpr int kExitMatch = 0;
+constexpr int kExitDrift = 1;
+constexpr int kExitArgError = 2;
+
+constexpr float kContextLuminanceScale = 0.3f;
+
+struct Args {
+    std::string baselinePath_;
+    std::string currentPath_;
+    std::string outputPath_;
+    int threshold_ = 0;
+    bool ignoreAlpha_ = false;
+};
+
+void printUsage(const char *exe) {
+    std::fprintf(
+        stderr,
+        "Usage: %s <baseline.png> <current.png> <out_diff.png> "
+        "[--threshold N] [--ignore-alpha]\n"
+        "\n"
+        "Highlights pixels that drift between baseline and current. Drifted\n"
+        "pixels are written red; unchanged pixels are written as a desaturated\n"
+        "30%%-luminance copy of the baseline so context stays visible.\n"
+        "\n"
+        "Options:\n"
+        "  --threshold N    Per-channel delta tolerance (default: 0).\n"
+        "  --ignore-alpha   Compare RGB only; ignore the alpha channel.\n"
+        "\n"
+        "Exit code: 0 on zero drift, 1 on any drift, 2 on argument / IO error.\n",
+        exe
+    );
+}
+
+bool parseArgs(int argc, char **argv, Args &out) {
+    int positional = 0;
+    for (int i = 1; i < argc; ++i) {
+        const char *a = argv[i];
+        if (std::strcmp(a, "--threshold") == 0) {
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "img_diff: --threshold requires an argument\n");
+                return false;
+            }
+            out.threshold_ = std::atoi(argv[++i]);
+            if (out.threshold_ < 0) {
+                std::fprintf(stderr, "img_diff: --threshold must be >= 0\n");
+                return false;
+            }
+        } else if (std::strcmp(a, "--ignore-alpha") == 0) {
+            out.ignoreAlpha_ = true;
+        } else if (std::strcmp(a, "-h") == 0 || std::strcmp(a, "--help") == 0) {
+            return false;
+        } else if (a[0] == '-') {
+            std::fprintf(stderr, "img_diff: unknown option '%s'\n", a);
+            return false;
+        } else {
+            switch (positional++) {
+            case 0: out.baselinePath_ = a; break;
+            case 1: out.currentPath_ = a; break;
+            case 2: out.outputPath_ = a; break;
+            default:
+                std::fprintf(stderr, "img_diff: unexpected argument '%s'\n", a);
+                return false;
+            }
+        }
+    }
+    if (positional != 3) {
+        std::fprintf(stderr, "img_diff: expected 3 positional arguments, got %d\n", positional);
+        return false;
+    }
+    return true;
+}
+
+struct Image {
+    unsigned char *data_ = nullptr;
+    int width_ = 0;
+    int height_ = 0;
+
+    ~Image() {
+        if (data_ != nullptr) {
+            stbi_image_free(data_);
+        }
+    }
+};
+
+bool loadRgba(const std::string &path, Image &out) {
+    int channels = 0;
+    out.data_ = stbi_load(path.c_str(), &out.width_, &out.height_, &channels, 4);
+    if (out.data_ == nullptr) {
+        std::fprintf(
+            stderr,
+            "img_diff: failed to load '%s': %s\n",
+            path.c_str(),
+            stbi_failure_reason()
+        );
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    Args args;
+    if (!parseArgs(argc, argv, args)) {
+        printUsage(argv[0]);
+        return kExitArgError;
+    }
+
+    Image baseline;
+    Image current;
+    if (!loadRgba(args.baselinePath_, baseline) || !loadRgba(args.currentPath_, current)) {
+        return kExitArgError;
+    }
+
+    if (baseline.width_ != current.width_ || baseline.height_ != current.height_) {
+        std::fprintf(
+            stderr,
+            "img_diff: dimension mismatch: baseline=%dx%d, current=%dx%d\n",
+            baseline.width_, baseline.height_, current.width_, current.height_
+        );
+        return kExitArgError;
+    }
+
+    const int width = baseline.width_;
+    const int height = baseline.height_;
+    const int totalPixels = width * height;
+    const int threshold = args.threshold_;
+    const int channelsCompared = args.ignoreAlpha_ ? 3 : 4;
+
+    auto *out = static_cast<unsigned char *>(std::malloc(static_cast<size_t>(totalPixels) * 4));
+    if (out == nullptr) {
+        std::fprintf(stderr, "img_diff: out of memory\n");
+        return kExitArgError;
+    }
+
+    std::int64_t driftPixels = 0;
+    int maxDelta = 0;
+
+    for (int i = 0; i < totalPixels; ++i) {
+        const int byteOffset = i * 4;
+        int pixelMaxDelta = 0;
+        for (int c = 0; c < channelsCompared; ++c) {
+            const int b = baseline.data_[byteOffset + c];
+            const int v = current.data_[byteOffset + c];
+            const int d = (v >= b) ? (v - b) : (b - v);
+            if (d > pixelMaxDelta) {
+                pixelMaxDelta = d;
+            }
+        }
+        if (pixelMaxDelta > maxDelta) {
+            maxDelta = pixelMaxDelta;
+        }
+
+        const bool drifted = pixelMaxDelta > threshold;
+        if (drifted) {
+            ++driftPixels;
+            out[byteOffset + 0] = 255;
+            out[byteOffset + 1] = 0;
+            out[byteOffset + 2] = 0;
+            out[byteOffset + 3] = 255;
+        } else {
+            for (int c = 0; c < 3; ++c) {
+                const int b = baseline.data_[byteOffset + c];
+                const int dim = static_cast<int>(static_cast<float>(b) * kContextLuminanceScale);
+                out[byteOffset + c] = static_cast<unsigned char>(dim);
+            }
+            out[byteOffset + 3] = 255;
+        }
+    }
+
+    const int writeOk = stbi_write_png(
+        args.outputPath_.c_str(),
+        width,
+        height,
+        4,
+        out,
+        width * 4
+    );
+    std::free(out);
+    if (writeOk == 0) {
+        std::fprintf(stderr, "img_diff: failed to write '%s'\n", args.outputPath_.c_str());
+        return kExitArgError;
+    }
+
+    const double driftPct = totalPixels == 0
+        ? 0.0
+        : (100.0 * static_cast<double>(driftPixels) / static_cast<double>(totalPixels));
+
+    std::printf(
+        "img_diff: total=%d drift=%lld (%.4f%%) max_delta=%d threshold=%d -> %s\n",
+        totalPixels,
+        static_cast<long long>(driftPixels),
+        driftPct,
+        maxDelta,
+        threshold,
+        args.outputPath_.c_str()
+    );
+
+    return driftPixels == 0 ? kExitMatch : kExitDrift;
+}

--- a/tools/img_diff/main.cpp
+++ b/tools/img_diff/main.cpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 
 namespace {
@@ -69,15 +70,18 @@ bool parseArgs(int argc, char **argv, Args &out) {
                 std::fprintf(stderr, "img_diff: --threshold requires an argument\n");
                 return false;
             }
-            out.threshold_ = std::atoi(argv[++i]);
+            try {
+                out.threshold_ = std::stoi(argv[++i]);
+            } catch (const std::exception &) {
+                std::fprintf(stderr, "img_diff: --threshold requires a numeric argument\n");
+                return false;
+            }
             if (out.threshold_ < 0) {
                 std::fprintf(stderr, "img_diff: --threshold must be >= 0\n");
                 return false;
             }
         } else if (std::strcmp(a, "--ignore-alpha") == 0) {
             out.ignoreAlpha_ = true;
-        } else if (std::strcmp(a, "-h") == 0 || std::strcmp(a, "--help") == 0) {
-            return false;
         } else if (a[0] == '-') {
             std::fprintf(stderr, "img_diff: unknown option '%s'\n", a);
             return false;
@@ -129,6 +133,12 @@ bool loadRgba(const std::string &path, Image &out) {
 } // namespace
 
 int main(int argc, char **argv) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
+            printUsage(argv[0]);
+            return 0;
+        }
+    }
     Args args;
     if (!parseArgs(argc, argv, args)) {
         printUsage(argv[0]);


### PR DESCRIPTION
## Summary

Closes #435. Tiny standalone CLI under `tools/img_diff/` that highlights per-pixel drift between two PNGs.

## Output PNG

| Pixel state | What gets written |
|---|---|
| Drifted (any channel `> threshold`) | Solid red `(255, 0, 0, 255)` |
| Unchanged | Baseline pixel desaturated to ~30% luminance |

Drift pops red against quiet visible context. The desaturated baseline keeps spatial reference (you can see *where* the drift sits relative to geometry) without competing with the red highlights.

## Why it's useful

Render-debug agents and human reviewers both lose subtle 1-pixel regressions (cube-edge zigzag, single-pixel parity drift) when looking at full-frame screenshots — exactly the failure mode that motivated #432–#435. A red-on-grey diff PNG turns "compare these two images pixel by pixel" into "which pixels are red".

Companion to `scripts/render-compare.py`, which reports aggregate metrics (PSNR, max delta, match%) and a brightness-delta diff PNG. The Python tool answers _"how much drift?"_; this one answers _"where is it?"_.

## Acceptance (from #435)

- [x] `tools/img_diff/` builds via the same preset machinery as the rest of the repo (`IRREDEN_BUILD_TOOLS` option, ON by default for top-level).
- [x] Exit code semantics match the spec: 0 = match, 1 = drift, 2 = arg/IO error.
- [x] Summary line prints to stdout.
- [x] `img_diff a.png a.png` exits 0 with 0 drift (verified with `metal_zoom4_offset_3_5.png` self-diff: `total=3686400 drift=0 (0.0000%) max_delta=0`).
- [x] `img_diff a.png b.png` exits 1 and writes a diff PNG (verified with cross-image: `drift=940264 max_delta=255`, exit 1).

## Test plan

- [x] `cmake --build build --target img_diff` clean on macos-debug
- [x] Self-diff exits 0
- [x] Different-image diff exits 1 with drift count > 0
- [x] No-args invocation exits 2 with usage message
- [ ] Linux smoke (build + self-diff) — defer to reviewer / linux smoke pass

## Notes for reviewer

- The FetchContent declaration in `tools/img_diff/CMakeLists.txt` duplicates the engine's stb declaration on purpose — CMake's FetchContent dedupes by name, and having it locally means `img_diff` builds even in configurations where the engine subdir is excluded (future use case).
- The `--threshold` semantics are *strictly greater* (any channel delta `> threshold` drifts). `--threshold 0` (default) flags any non-byte-identical pixel. `--threshold 4` is a useful loose match for tone-mapper jitter or compression artefacts.
- Follow-up: #434 will update `render-debug-loop` SKILL.md and `engine/render/CLAUDE.md` to point at this tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)