### PR TITLE
fleet: stagger pane launches in fleet-up + wait for first state.json

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -31,6 +31,37 @@ Common patterns and their correct alternatives:
   exit status / error. Issue the fallback as a separate Bash call if
   needed.
 
+## Shared fleet state cache
+
+The `fleet-state-scout` daemon (started by `fleet-up`) refreshes
+`~/.fleet/state/state.json` every ~60s with both repos' open PRs and
+parsed `TASKS.md` rows. **This cache is the source of truth for
+list-y queries — do NOT bypass it for `gh pr list` or
+`git show origin/master:TASKS.md` when the cache is fresh.** One Read
+tool call covers four list-shaped queries this role uses: open PRs,
+`fleet:design-blocked` filter, feedback-label filter, and the
+`TASKS.md` task table.
+
+Schema (slices this role uses):
+- `repos.engine.prs[]` — `number`, `title`, `headRefName`,
+  `baseRefName`, `author` (login string), `labels` (sorted strings),
+  `mergeable`, `isDraft`. Filter locally for `fleet:design-blocked`,
+  `human:needs-fix`, `fleet:needs-fix`, `fleet:has-nits`.
+- `repos.engine.tasks.{open,in_progress,done}[]` — `status`, `title`,
+  `summary`, `id`, `model`, `owner`, `area`, `blocked_by`, `issue`.
+
+Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`,
+`gh api repos/.../pulls/<N>/comments`,
+`gh api repos/.../pulls/<N>/reviews`) stay inline — those pull live
+data the cache doesn't store. The cache covers list-shaped queries;
+live drill-in covers single-item drill-down. Writes (`gh pr edit`,
+`gh pr comment`, `gh issue create`, `gh issue edit`) stay direct.
+
+If `~/.fleet/state/state.json` is missing or its `generated_at` is
+more than ~5 minutes old, the scout daemon isn't running. Print
+`scout cache stale or missing — run fleet-up` and exit; do not
+silently fall back to direct `gh`/`git` calls.
+
 ## Responsibilities
 
 - Core engine architecture: ECS design, ownership and lifetime rules,
@@ -67,18 +98,29 @@ components, or entities.
 0. Print your role banner:
    `[opus-architect] Interactive design partner — core engine architecture, ECS design, render pipeline decisions. On-demand (no loop).`
 1. `git -C ~/src/IrredenEngine fetch origin --quiet`
-2. Read `TASKS.md` (use the Read tool, not `cat`) — review the current queue.
-3. `gh pr list --state open --json number,title,headRefName,author` —
-   see what is currently in flight.
-4. **List `fleet:design-blocked` PRs** (architect's lane — workers
-   escalate mid-task by adding this label):
-   `gh pr list --repo jakildev/IrredenEngine --state open --label "fleet:design-blocked" --json number,title,author --jq '.[] | "#\(.number) \(.title) (by \(.author.login))"'`
-   If non-empty, surface the list in the standing-by message so
-   the human can direct attention. See "Handling
-   `fleet:design-blocked` PRs" below for the response flow.
-5. Print a one-line summary: how many `[opus]` tasks are unblocked, how
-   many open PRs are in flight, and which (if any) appear to be claiming
-   core-engine work.
+2. **Read the shared fleet state cache** with the Read tool:
+   `~/.fleet/state/state.json`. Covers open PRs, the
+   `fleet:design-blocked` filter, the feedback-label filter, and
+   the parsed `TASKS.md` rows in one call.
+
+   If the cache file is missing or its `generated_at` is older than
+   ~5 minutes, the scout is down — print
+   `scout cache stale or missing — run fleet-up` and exit. Do not
+   fall back to direct `gh`/`git` calls.
+3. (Optional) Read `TASKS.md` directly for editorial review —
+   parsed rows are already in `repos.engine.tasks` from step 2.
+4. **Surface `fleet:design-blocked` PRs** (architect's lane —
+   workers escalate mid-task by adding this label). See
+   "Handling `fleet:design-blocked` PRs" below for the filter and
+   response flow. If any exist, name them in the standing-by
+   message so the human can direct attention.
+5. Print a one-line summary: how many `[opus]` tasks in
+   `repos.engine.tasks.open[]` are unblocked, how many entries in
+   `repos.engine.prs[]` are in flight, and which (if any) appear
+   to be claiming core-engine work (heuristic: title or
+   `headRefName` mentions `engine/render`, `engine/entity`,
+   `engine/system`, `engine/world`, `engine/audio`, `engine/video`,
+   `engine/math`).
 6. Print `opus-arch standing by` (or `opus-arch standing by (dry-run)`
    if Mode above is `dry-run`).
 
@@ -107,10 +149,13 @@ opus-worker will (correctly) pick it up.
 
 When you do pick a task:
 
-1. **Cross-check `gh pr list --state open` first.** Skip any task whose
-   title appears in an open PR's title or branch name. The open-PR list
-   is the real claim signal — `TASKS.md` `[~]` flips on feature branches
-   are not visible to other agents until merge.
+1. **Cross-check open PRs from the cache first.** Re-Read
+   `~/.fleet/state/state.json` if its contents are no longer in
+   your conversation context. Skip any task whose title appears in
+   `repos.engine.prs[].title` or `repos.engine.prs[].headRefName`.
+   The open-PR list is the real claim signal — `TASKS.md` `[~]`
+   flips on feature branches are not visible to other agents until
+   merge.
 2. **Claim the task by its ID** (the `**ID:** T-NNN` field, not the
    free-text title):
    `fleet-claim claim "<task ID, e.g. T-003>" opus-architect`
@@ -147,8 +192,11 @@ When you do pick a task:
    `origin/master`. AFTER the reset is complete, you may ask the human
    "what's next?" — but the reset itself is non-negotiable, even in
    interactive mode.
-8. **Check for feedback labels on open PRs** before picking new work:
-   `gh pr list --state open --json number,title,labels --jq '.[] | select(.labels | map(.name) | any(. == "human:needs-fix" or . == "fleet:needs-fix" or . == "fleet:has-nits")) | "#\(.number) \(.title)"'`
+8. **Check for feedback labels on open PRs** before picking new work.
+   Re-Read `~/.fleet/state/state.json` if its contents are no
+   longer in your conversation context. From
+   `repos.engine.prs[]`, pick PRs whose `labels` array contains
+   any of `human:needs-fix`, `fleet:needs-fix`, `fleet:has-nits`.
    **Skip** PRs labeled `human:wip` — human is working on it directly.
 
    **Priority order**: `human:needs-fix` > `fleet:needs-fix` > `fleet:has-nits`.
@@ -257,14 +305,11 @@ Those PRs sit there until you respond — the human will direct your
 attention to them, but you should also list them on startup so
 you know what's queued for you.
 
-On startup, list `fleet:design-blocked` PRs in the engine repo:
-
-```
-gh pr list --repo jakildev/IrredenEngine --state open --label "fleet:design-blocked" --json number,title,author --jq '.[] | "#\(.number) \(.title) (by \(.author.login))"'
-```
-
-If any exist, surface them in the standing-by message so the human
-can direct attention.
+On startup (step 4), surface `fleet:design-blocked` PRs from the
+cache: filter `repos.engine.prs[]` for entries whose `labels` array
+contains `fleet:design-blocked` and format
+`#{number} {title} (by {author})`. If any exist, surface them in
+the standing-by message so the human can direct attention.
 
 When working a `fleet:design-blocked` PR:
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -43,6 +43,16 @@ SHUTDOWN_FLAG = Path.home() / ".fleet" / "shutdown-in-progress"
 POLL_SECONDS_DEFAULT = 60
 GH_TIMEOUT_SECONDS = 30
 
+# Cap concurrent gh calls and stagger their submission to avoid GitHub's
+# secondary rate limit on private repos. The first tick used to fire all
+# 8 fetches in parallel against a cold token, which on private-repo
+# accounts is enough to trip the per-IP burst limit. With max_workers=2
+# and a 250 ms inter-submit gap the first tick takes ~2 s longer but
+# starts cleanly; pane startup already waits for state.json so the
+# extra latency is invisible to consumers.
+FETCH_MAX_WORKERS = 2
+FETCH_SUBMIT_GAP_SECONDS = 0.25
+
 TERMINATE = threading.Event()
 
 
@@ -385,9 +395,12 @@ def collect_state():
             ("game", "tasks", lambda: fetch_tasks(GAME)),
         ]
 
-    with ThreadPoolExecutor(max_workers=8) as ex:
-        futures = {ex.submit(fn): (repo_key, field)
-                   for (repo_key, field, fn) in fetch_specs}
+    with ThreadPoolExecutor(max_workers=FETCH_MAX_WORKERS) as ex:
+        futures = {}
+        for i, (repo_key, field, fn) in enumerate(fetch_specs):
+            if i > 0:
+                time.sleep(FETCH_SUBMIT_GAP_SECONDS)
+            futures[ex.submit(fn)] = (repo_key, field)
         for fut in as_completed(futures):
             repo_key, field = futures[fut]
             try:

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -32,6 +32,12 @@ SONNET_MODEL="sonnet"   # alias is fine for sonnet — budget is cheap
 # fleet-babysit reads this via FLEET_MIN_BACKOFF; keep the two in sync.
 OPUS_MIN_BACKOFF=1800
 
+# How long to wait for fleet-state-scout's first tick to write
+# state.json before giving up and launching panes anyway. With the
+# throttled fan-out (FETCH_MAX_WORKERS=2 + 250 ms gap) the first
+# tick lands in ~5-10 s; 30 s gives ample headroom for slow networks.
+SCOUT_STARTUP_TIMEOUT_SECONDS=30
+
 if ! command -v tmux >/dev/null 2>&1; then
     echo "fleet-up: tmux not found. Install tmux (brew install tmux / apt install tmux) first." >&2
     exit 1
@@ -410,6 +416,22 @@ else
     nohup "$scout_cmd" >>"$scout_log" 2>&1 &
     disown
     echo "fleet-up: launched fleet-state-scout (pid $!, log $scout_log)"
+
+    # Wait for scout's first tick so panes find a populated state.json
+    # on startup. Without this wait, every pane's "scout cache stale
+    # or missing" diagnostic fires until the first tick lands.
+    state_json="$HOME/.fleet/state/state.json"
+    echo "fleet-up: waiting for first state.json..."
+    for _ in $(seq 1 "$SCOUT_STARTUP_TIMEOUT_SECONDS"); do
+        if [[ -f "$state_json" ]]; then
+            echo "fleet-up: state.json ready"
+            break
+        fi
+        sleep 1
+    done
+    if [[ ! -f "$state_json" ]]; then
+        echo "fleet-up: warning: state.json not present after ${SCOUT_STARTUP_TIMEOUT_SECONDS} s — panes will surface the staleness diagnostic"
+    fi
 fi
 
 # ----------------------------------------------------------------------
@@ -450,6 +472,18 @@ for arg in "$@"; do
         *) echo "fleet-up: unknown argument '$arg'" >&2; exit 2 ;;
     esac
 done
+
+# Sleep between each agent-pane launch so 8+ panes don't simultaneously
+# fire `git fetch` + the first `claude` invocation on a cold session.
+# Without the stagger, the burst overlaps with the scout's first tick
+# and trips GitHub's secondary rate limit on private repos.
+# Override with FLEET_PANE_STAGGER_SECONDS=0 for tests / local dev.
+FLEET_PANE_STAGGER_SECONDS="${FLEET_PANE_STAGGER_SECONDS:-5}"
+pane_stagger() {
+    if (( FLEET_PANE_STAGGER_SECONDS > 0 )); then
+        sleep "$FLEET_PANE_STAGGER_SECONDS"
+    fi
+}
 
 launch_cmd() {
     # $1 = model alias (opus|sonnet), $2 = role slug (without role- prefix)
@@ -518,18 +552,21 @@ tmux new-session -d -s "$SESSION" -n fleet \
     "$(launch_cmd "$SONNET_MODEL" sonnet-author)"
 TOP_LEFT=$(tmux display-message -t "$SESSION:fleet" -p "#{pane_id}")
 label_pane_id "$TOP_LEFT" "sonnet-fleet-1 [sonnet]"
+pane_stagger
 
 # Split bottom 2/3 off — that becomes the middle row's leftmost pane.
 MID_LEFT=$(tmux split-window -v -t "$TOP_LEFT" -p 67 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-architect" \
     "$(launch_cmd "$OPUS_MODEL" opus-architect)")
 label_pane_id "$MID_LEFT" "opus-architect [opus 4.7]"
+pane_stagger
 
 # Split bottom 1/2 of the middle off — that becomes bottom row leftmost.
 BOT_LEFT=$(tmux split-window -v -t "$MID_LEFT" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-1" \
     "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)")
 label_pane_id "$BOT_LEFT" "opus-worker-1 [opus 4.7]"
+pane_stagger
 
 # Top row: split TOP_LEFT horizontally to add sonnet-fleet-2 and
 # sonnet-reviewer. -p 67 leaves 33% for the new pane (right 2/3
@@ -539,11 +576,13 @@ TOP_MID=$(tmux split-window -h -t "$TOP_LEFT" -p 67 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-2" \
     "$(launch_cmd "$SONNET_MODEL" sonnet-author)")
 label_pane_id "$TOP_MID" "sonnet-fleet-2 [sonnet]"
+pane_stagger
 
 TOP_RIGHT=$(tmux split-window -h -t "$TOP_MID" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/sonnet-reviewer" \
     "$(launch_cmd "$SONNET_MODEL" sonnet-reviewer 3m)")
 label_pane_id "$TOP_RIGHT" "sonnet-reviewer [sonnet]"
+pane_stagger
 
 # Middle row: split MID_LEFT horizontally for game-architect (only if
 # the game worktree exists). 50/50 split since architects coexist as
@@ -553,6 +592,7 @@ if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
         -c "$GAME/.claude/worktrees/game-architect" \
         "$(launch_cmd "$OPUS_MODEL" game-architect)")
     label_pane_id "$MID_RIGHT" "game-architect [opus 4.7]"
+    pane_stagger
 fi
 
 # Bottom row: split BOT_LEFT horizontally for opus-worker-2 and
@@ -562,11 +602,13 @@ BOT_MID=$(tmux split-window -h -t "$BOT_LEFT" -p 67 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-2" \
     "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)")
 label_pane_id "$BOT_MID" "opus-worker-2 [opus 4.7]"
+pane_stagger
 
 BOT_RIGHT=$(tmux split-window -h -t "$BOT_MID" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
     "FLEET_MIN_BACKOFF=$OPUS_MIN_BACKOFF $(launch_cmd "$OPUS_MODEL" opus-reviewer 30m)")
 label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.7]"
+pane_stagger
 
 # --- Window 2: "ops" — 2x2 grid ---------------------------------------
 #
@@ -583,6 +625,7 @@ OPS_TL=$(tmux new-window -a -t "$SESSION:fleet" -n ops -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/queue-manager" \
     "$(launch_cmd "$SONNET_MODEL" queue-manager 5m)")
 label_pane_id "$OPS_TL" "queue-manager [sonnet]"
+pane_stagger
 
 OPS_TR=$(tmux split-window -h -t "$OPS_TL" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/merger" \


### PR DESCRIPTION
## Summary

- **A.3 of the fleet GitHub-interaction overhaul plan** (stacked on #454).
- Adds two cold-start safety nets to `fleet-up`:
  1. Polls for `~/.fleet/state/state.json` to appear after scout launch (up to `SCOUT_STARTUP_TIMEOUT_SECONDS=30`), so panes find a populated cache on first read.
  2. Introduces `FLEET_PANE_STAGGER_SECONDS` (default 5) + a `pane_stagger` helper invoked between each claude-running pane spawn.

## Why

Without these, `fleet-up` fires 8-10 simultaneous `git fetch` + initial `claude` invocations the moment the tmux panes split, while scout is still on its first tick. The combined burst is the primary cause of GitHub's secondary rate limit firing during fleet startup on private repos.

With A.2 (scout throttle) + A.3 (pane stagger):
- Scout's first tick takes ~5-10 s with FETCH_MAX_WORKERS=2.
- fleet-up waits for state.json before launching the first pane.
- Then 9 stagger gaps × 5 s = 45 s of staggered claude pane spawns.
- Witness and terminal panes are non-claude and left un-staggered (no rate-limit risk).

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/454 (A.2 — scout fan-out throttle)

When the parent PR merges, change this PR's base to the next parent or to `master` (via the GitHub UI or `gh pr edit <N> --base ...`).

## Test plan

- [ ] `bash -n scripts/fleet/fleet-up` parses clean. (Done locally.)
- [ ] `fleet-down && fleet-up live --no-attach` brings up the session without secondary-rate-limit errors in any pane log.
- [ ] `tmux list-panes -F '#{@role}'` after fleet-up settles shows all 12 panes labeled correctly.
- [ ] `FLEET_PANE_STAGGER_SECONDS=0 fleet-up live --no-attach` skips the stagger (useful for tests).
- [ ] If the scout daemon is missing (uninstalled), the wait loop is skipped (the `else` branch around the scout launch — confirmed in diff).

## Notes for reviewer

- `pane_stagger` is invoked **between** pane launches (n-1 calls for n panes). Merger is the last claude pane in the ops window; no stagger is added after it because witness and terminal don't run `claude` and don't carry rate-limit risk.
- `FLEET_PANE_STAGGER_SECONDS` follows the existing `FLEET_LONG_BACKOFF` / `FLEET_MIN_BACKOFF` env-override pattern in `fleet-babysit`.
- `SCOUT_STARTUP_TIMEOUT_SECONDS=30` is a hardcoded module constant, matching `OPUS_MIN_BACKOFF`.
- Total added cold-start latency: ~30-75 s (5-10 s state.json wait + 45 s pane stagger). Unattended-launch cost only — once the fleet is running, no impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)