### PR TITLE
fleet: add fleet-pr and fleet-issue wrappers over scout cache

### DIFF
--- a/scripts/fleet/fleet-issue
+++ b/scripts/fleet/fleet-issue
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""fleet-issue — read scout's per-issue cache, fall back to gh on cache miss.
+
+Subcommand:
+  view <N>      full issue body + comments + labels + state
+
+Repo selection:
+  --repo {engine,game}  default: engine
+
+The scout caches issues that hit `needs_plan` or `human_approved` in
+state.json. Other issues (closed, unlabeled) are not in the cache by
+design — the cache miss path covers those by exec'ing `gh issue view`
+directly.
+
+Source of truth: scripts/fleet/fleet-issue in the engine repo.
+Installed to ~/bin/fleet-issue by scripts/fleet/install.sh.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".fleet" / "state"
+ISSUES_DIR = STATE_DIR / "issues"
+REPOS_CACHE = STATE_DIR / "repos.json"
+
+DEFAULT_SLUGS = {
+    "engine": "jakildev/IrredenEngine",
+    "game": "jakildev/irreden",
+}
+
+
+def repo_slug(repo_key):
+    try:
+        repos = json.loads(REPOS_CACHE.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return DEFAULT_SLUGS.get(repo_key)
+    return repos.get(repo_key) or DEFAULT_SLUGS.get(repo_key)
+
+
+def warn(msg):
+    print(f"fleet-issue: {msg}", file=sys.stderr)
+
+
+def cmd_view(args):
+    path = ISSUES_DIR / args.repo / f"{args.issue_number}.json"
+    detail = None
+    try:
+        detail = json.loads(path.read_text())
+    except FileNotFoundError:
+        warn(f"cache miss for {args.repo}#{args.issue_number}; falling back to gh")
+    except json.JSONDecodeError as e:
+        warn(f"cache file {path} is corrupt: {e}; falling back to gh")
+
+    if detail is None:
+        slug = repo_slug(args.repo)
+        if slug is None:
+            warn(f"unknown repo key: {args.repo}")
+            return 2
+        return subprocess.run([
+            "gh", "issue", "view", str(args.issue_number),
+            "--repo", slug, "--comments",
+        ]).returncode
+
+    print(f"# Issue #{detail['number']}: {detail.get('title', '')}")
+    labels = detail.get("labels", [])
+    if labels:
+        print(f"labels: {', '.join(labels)}")
+    print(f"state: {detail.get('state', '?')}")
+    print()
+    if detail.get("body"):
+        print(detail["body"])
+        print()
+    for c in detail.get("comments", []):
+        author = (c.get("author") or {}).get("login", "?")
+        print(f"\n## {author} at {c.get('createdAt', '')}")
+        print(c.get("body", ""))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read scout's per-issue cache.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sp = sub.add_parser("view")
+    sp.add_argument("issue_number", type=int)
+    sp.add_argument(
+        "--repo", default="engine", choices=["engine", "game"],
+        help="Which cached repo to read (default: engine).",
+    )
+    args = parser.parse_args()
+    sys.exit(cmd_view(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fleet/fleet-pr
+++ b/scripts/fleet/fleet-pr
@@ -76,9 +76,7 @@ def cmd_view(args):
             "gh", "pr", "view", str(args.pr_number), "--comments",
         ])
 
-    print(f"# PR #{detail['number']}")
-    if detail.get("title"):
-        print(f"# {detail['title']}")
+    print(f"# PR #{detail['number']}: {detail.get('title', '')}")
     print()
     if detail.get("body"):
         print(detail["body"])

--- a/scripts/fleet/fleet-pr
+++ b/scripts/fleet/fleet-pr
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""fleet-pr — read scout's per-PR cache, fall back to gh on cache miss.
+
+Subcommands:
+  view <N>      full PR detail (body + comments + reviews + inline review threads)
+  diff <N>      raw diff text
+  comments <N>  flat timeline of conversation + review-summary + inline comments
+
+Repo selection:
+  --repo {engine,game}  default: engine
+
+Cache miss policy: prints a single `fleet-pr: cache miss for <repo>#<N>;
+falling back to gh` line to stderr, then exec's the equivalent live `gh`
+call. Agents that prefer to know about cache misses can grep stderr;
+silent agents see normal stdout regardless.
+
+Source of truth: scripts/fleet/fleet-pr in the engine repo.
+Installed to ~/bin/fleet-pr by scripts/fleet/install.sh.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+STATE_DIR = Path.home() / ".fleet" / "state"
+PRS_DIR = STATE_DIR / "prs"
+DIFFS_DIR = STATE_DIR / "diffs"
+REPOS_CACHE = STATE_DIR / "repos.json"
+
+# Hardcoded fallback if repos.json is missing. Keep in sync with
+# fleet-state-scout's REPO_KEY_TO_SLUG.
+DEFAULT_SLUGS = {
+    "engine": "jakildev/IrredenEngine",
+    "game": "jakildev/irreden",
+}
+
+
+def repo_slug(repo_key):
+    try:
+        repos = json.loads(REPOS_CACHE.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return DEFAULT_SLUGS.get(repo_key)
+    return repos.get(repo_key) or DEFAULT_SLUGS.get(repo_key)
+
+
+def warn(msg):
+    print(f"fleet-pr: {msg}", file=sys.stderr)
+
+
+def read_cached_pr(repo_key, pr_number):
+    path = PRS_DIR / repo_key / f"{pr_number}.json"
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as e:
+        warn(f"cache file {path} is corrupt: {e}")
+        return None
+
+
+def fallback_gh(args, gh_cmd):
+    slug = repo_slug(args.repo)
+    if slug is None:
+        warn(f"unknown repo key: {args.repo}")
+        return 2
+    return subprocess.run(gh_cmd + ["--repo", slug]).returncode
+
+
+def cmd_view(args):
+    detail = read_cached_pr(args.repo, args.pr_number)
+    if detail is None:
+        warn(f"cache miss for {args.repo}#{args.pr_number}; falling back to gh")
+        return fallback_gh(args, [
+            "gh", "pr", "view", str(args.pr_number), "--comments",
+        ])
+
+    print(f"# PR #{detail['number']}")
+    if detail.get("title"):
+        print(f"# {detail['title']}")
+    print()
+    if detail.get("body"):
+        print(detail["body"])
+        print()
+
+    comments = detail.get("comments", [])
+    if comments:
+        print("## Comments")
+        for c in comments:
+            author = (c.get("author") or {}).get("login", "?")
+            print(f"\n### {author} at {c.get('createdAt', '')}")
+            print(c.get("body", ""))
+
+    reviews = detail.get("reviews", [])
+    if reviews:
+        print("\n## Reviews")
+        for r in reviews:
+            author = (r.get("author") or {}).get("login", "?")
+            state = r.get("state", "")
+            print(f"\n### {author} ({state}) at {r.get('submittedAt', '')}")
+            if r.get("body"):
+                print(r["body"])
+
+    inline = detail.get("inlineComments", [])
+    if inline:
+        print("\n## Inline review comments")
+        for ic in inline:
+            path = ic.get("path", "?")
+            line = ic.get("line") or ic.get("original_line") or "?"
+            user = (ic.get("user") or {}).get("login", "?")
+            body = ic.get("body", "")
+            print(f"\n[{path}:{line}] {user}")
+            print(body)
+
+    return 0
+
+
+def cmd_diff(args):
+    diff_dir = DIFFS_DIR / args.repo
+    if diff_dir.exists():
+        # GC keeps only the current head's diff per PR, but pick newest by
+        # mtime as a safety net in case GC is mid-tick.
+        candidates = sorted(
+            diff_dir.glob(f"{args.pr_number}-*.diff"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if candidates:
+            sys.stdout.write(candidates[0].read_text())
+            return 0
+
+    warn(f"diff cache miss for {args.repo}#{args.pr_number}; falling back to gh")
+    return fallback_gh(args, ["gh", "pr", "diff", str(args.pr_number)])
+
+
+def cmd_comments(args):
+    detail = read_cached_pr(args.repo, args.pr_number)
+    if detail is None:
+        warn(f"cache miss for {args.repo}#{args.pr_number}; falling back to gh")
+        return fallback_gh(args, [
+            "gh", "pr", "view", str(args.pr_number), "--comments",
+        ])
+
+    any_output = False
+    for c in detail.get("comments", []):
+        author = (c.get("author") or {}).get("login", "?")
+        body = (c.get("body") or "").rstrip()
+        print(f"[comment {c.get('createdAt', '')}] {author}: {body}")
+        any_output = True
+    for r in detail.get("reviews", []):
+        body = (r.get("body") or "").rstrip()
+        if not body:
+            continue
+        author = (r.get("author") or {}).get("login", "?")
+        state = r.get("state", "")
+        print(f"[review {r.get('submittedAt', '')} {state}] {author}: {body}")
+        any_output = True
+    for ic in detail.get("inlineComments", []):
+        path = ic.get("path", "?")
+        line = ic.get("line") or ic.get("original_line") or "?"
+        user = (ic.get("user") or {}).get("login", "?")
+        body = (ic.get("body") or "").rstrip()
+        print(f"[{path}:{line}] {user}: {body}")
+        any_output = True
+
+    if not any_output:
+        warn(f"no comments yet on {args.repo}#{args.pr_number}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read scout's per-PR cache.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    for name, fn in [("view", cmd_view), ("diff", cmd_diff), ("comments", cmd_comments)]:
+        sp = sub.add_parser(name)
+        sp.add_argument("pr_number", type=int)
+        sp.add_argument(
+            "--repo", default="engine", choices=["engine", "game"],
+            help="Which cached repo to read (default: engine).",
+        )
+        sp.set_defaults(handler=fn)
+    args = parser.parse_args()
+    sys.exit(args.handler(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -122,6 +122,10 @@ FLEET_FEEDBACK_SRC="$SCRIPT_DIR/fleet-feedback"
 FLEET_FEEDBACK_DEST="$HOME/bin/fleet-feedback"
 FLEET_BUSY_SRC="$SCRIPT_DIR/fleet-worktree-busy-branches"
 FLEET_BUSY_DEST="$HOME/bin/fleet-worktree-busy-branches"
+FLEET_PR_SRC="$SCRIPT_DIR/fleet-pr"
+FLEET_PR_DEST="$HOME/bin/fleet-pr"
+FLEET_ISSUE_SRC="$SCRIPT_DIR/fleet-issue"
+FLEET_ISSUE_DEST="$HOME/bin/fleet-issue"
 WITNESS_SRC="$SCRIPT_DIR/witness"
 WITNESS_DEST="$HOME/bin/witness"
 
@@ -133,7 +137,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_ISSUE_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -215,6 +219,16 @@ fi
 if [[ -f "$FLEET_BUSY_SRC" ]]; then
     ln -sf "$FLEET_BUSY_SRC" "$FLEET_BUSY_DEST"
     echo "symlinked $FLEET_BUSY_DEST -> $FLEET_BUSY_SRC"
+fi
+
+if [[ -f "$FLEET_PR_SRC" ]]; then
+    ln -sf "$FLEET_PR_SRC" "$FLEET_PR_DEST"
+    echo "symlinked $FLEET_PR_DEST -> $FLEET_PR_SRC"
+fi
+
+if [[ -f "$FLEET_ISSUE_SRC" ]]; then
+    ln -sf "$FLEET_ISSUE_SRC" "$FLEET_ISSUE_DEST"
+    echo "symlinked $FLEET_ISSUE_DEST -> $FLEET_ISSUE_SRC"
 fi
 
 if [[ -f "$WITNESS_SRC" ]]; then


### PR DESCRIPTION
## Summary

- **B.3 of the fleet GitHub-interaction overhaul plan** (stacked on #457).
- Two thin Python CLIs that read scout's per-PR / per-issue caches and fall back to live `gh` on cache miss.
- `scripts/fleet/install.sh` symlinks them into `~/bin/` alongside the existing fleet-* tools.

## Wrappers

```
fleet-pr view <N> [--repo engine|game]
fleet-pr diff <N> [--repo engine|game]
fleet-pr comments <N> [--repo engine|game]
fleet-issue view <N> [--repo engine|game]
```

`fleet-pr view` prints PR body + conversation comments + review summaries + inline review threads.
`fleet-pr diff` prints raw diff text (latest cached SHA per PR).
`fleet-pr comments` prints a flat timeline (`[comment ...]` / `[review ...]` / `[path:line]` lines) — exactly what the address-feedback flow wants.
`fleet-issue view` prints issue body + comments + labels + state.

## Why

This is the read-side of the per-PR / per-issue cache from #457. Without these, agents would still need bespoke `python3 -c 'json.load(...)'` to read the cache files — defeating the point of the cache. The wrappers also mean the role docs only need to know `fleet-pr` / `fleet-issue`, not the cache layout.

The next PR (B.4) does the mechanical rewrite of role docs to call these wrappers (and removes the inline `gh pr view --comments` / `gh pr diff` / `gh api .../comments` / `gh api .../reviews` / `gh issue view --comments` calls).

## Cache miss policy

Loud stderr / silent stdout: cache miss prints a single
`fleet-pr: cache miss for engine#123; falling back to gh` line to stderr,
then exec's the equivalent live `gh` call. Stdout is whatever the caller asked for. Agents that want to log misses can grep stderr; agents that don't, just see stdout.

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/457 (B.1+B.2 — per-PR + per-issue cache layer)

When the parent PR merges, change this PR's base to the next parent or to `master`.

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("scripts/fleet/fleet-pr").read())'` and same for `fleet-issue` — done locally, parses clean.
- [ ] `bash -n scripts/fleet/install.sh` — done locally, lints clean.
- [ ] After this and #457 land, run `scripts/fleet/install.sh` once: `~/bin/fleet-pr` and `~/bin/fleet-issue` appear as symlinks.
- [ ] `fleet-pr view 999999` (non-existent PR) — prints cache-miss warning to stderr, exec's gh, exits non-zero. (Verified locally: `rc=1`, stderr `cache miss for engine#999999; falling back to gh`, then GraphQL error.)
- [ ] `fleet-pr view 453` (this PR's parent stack) before scout caches it — falls back to gh and shows the PR review thread. (Verified locally on PR #453.)
- [ ] After the next scout tick caches an open PR, `fleet-pr view <that PR>` prints the cached body without firing gh.

## Notes for reviewer

- Repo slugs come from `~/.fleet/state/repos.json` (A.4 / #456). If repos.json is missing, both wrappers fall back to a hardcoded `{engine: "jakildev/IrredenEngine", game: "jakildev/irreden"}` map. The hardcoded map duplicates `REPO_KEY_TO_SLUG` from `fleet-state-scout` — kept in sync manually for now; both files would need updating if a third repo is ever added.
- Output format for `fleet-pr view` is a markdown-ish layout (`# PR #N`, `## Comments`, etc.) optimized for agent consumption. `gh pr view --comments` produces a slightly different layout; the cache-miss fallback path inherits gh's format (acceptable — fallback is rare).
- `fleet-pr comments` flat-timeline format (`[comment <ts>] <author>: <body>`) matches the format used in role-doc snippets like `gh api .../pulls/<N>/comments --jq '.[] | "[\(.path):\(.line)] \(.body)"'`. Designed to drop into existing prose without rewriting the agent-consumption side.
- Both scripts use stdlib only (no `jq`, no third-party deps) so the install footprint matches `fleet-state-scout`.
- argparse is configured so `--repo` works after the subcommand (`fleet-pr view <N> --repo game`); placing it before the subcommand would require the `fleet-pr --repo game view <N>` form which is less ergonomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)