### PR TITLE
fleet: rewrite role docs to call fleet-pr / fleet-issue wrappers

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -50,12 +50,19 @@ Schema (slices this role uses):
 - `repos.engine.tasks.{open,in_progress,done}[]` — `status`, `title`,
   `summary`, `id`, `model`, `owner`, `area`, `blocked_by`, `issue`.
 
-Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`,
-`gh api repos/.../pulls/<N>/comments`,
-`gh api repos/.../pulls/<N>/reviews`) stay inline — those pull live
-data the cache doesn't store. The cache covers list-shaped queries;
-live drill-in covers single-item drill-down. Writes (`gh pr edit`,
-`gh pr comment`, `gh issue create`, `gh issue edit`) stay direct.
+Per-item drill-ins go through the `fleet-pr` and `fleet-issue`
+wrappers, which read scout's per-PR / per-issue cache and fall
+back to live `gh` on cache miss:
+
+- `fleet-pr view <N>` — full PR detail (body + comments + reviews +
+  inline review threads).
+- `fleet-pr diff <N>` — raw diff text.
+- `fleet-pr comments <N>` — flat timeline of comments + review
+  summaries + inline comments. Use this when addressing feedback.
+- `fleet-issue view <N>` — issue body + comments + labels + state.
+
+Writes (`gh pr edit`, `gh pr comment`, `gh issue create`,
+`gh issue edit`) stay direct — the wrappers are read-only.
 
 If `~/.fleet/state/state.json` is missing or its `generated_at` is
 more than ~5 minutes old, the scout daemon isn't running. Print
@@ -205,8 +212,9 @@ When you do pick a task:
 
    If any PR has `human:needs-fix`, `fleet:needs-fix`, or `fleet:has-nits`:
    a. Read ALL comments:
-      `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // "general")] \(.body)"'`
-      `gh api repos/jakildev/IrredenEngine/pulls/<N>/reviews --jq '.[] | select(.body != "") | .body'`
+      `fleet-pr comments <N>`
+      (combines the timeline, review summaries, and inline comments
+      that used to require three separate `gh api` calls.)
       For `fleet:has-nits`: focus on the latest review's `### Nits`
       section.
    b. Remove the feedback label immediately:

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -63,12 +63,21 @@ Schema (slices this role uses):
   `…[truncated]…` separator (the verdict line typically lives in the
   tail), so the recheck signal still reaches the cache for typical
   reviews; if a finding requires the full body for context, fetch
-  it with `gh pr view <N> --comments`.
+  it with `fleet-pr view <N>`.
 
-Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`)
-stay inline — those pull live data the cache doesn't store (issue
-comment timeline, file diffs). The cache covers list-shaped queries;
-live drill-in covers single-item drill-down.
+Per-item drill-ins go through the `fleet-pr` and `fleet-issue`
+wrappers, which read scout's per-PR / per-issue cache and fall back
+to live `gh` on cache miss:
+
+- `fleet-pr view <N>` — full PR detail (body + comments + reviews +
+  inline review threads).
+- `fleet-pr diff <N>` — raw diff text. Used on every PR you review.
+- `fleet-pr comments <N>` — flat timeline; convenient when you only
+  need to skim the conversation without the body.
+- `fleet-issue view <N>` — issue body + comments.
+
+Writes (`gh pr review`, `gh pr comment`, `gh pr edit`) stay direct
+— the wrappers are read-only.
 
 If `~/.fleet/state/state.json` is missing or its `generated_at` is
 more than ~5 minutes old, the scout daemon isn't running. Print
@@ -144,7 +153,7 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
    - Its latest review (sort `reviews[]` by `submittedAt`) has a
      `body` containing `Opus recheck required`, OR
    - The PR touches core engine/game invariants (need to read its
-     diff via `gh pr diff <N>` per-item), OR
+     diff via `fleet-pr diff <N>` per-item), OR
    - Its `labels` contains `human:re-review` (human made changes and
      requested re-review — remove the label when you pick it up:
      `gh pr edit <N> --remove-label "human:re-review"`), OR
@@ -156,7 +165,7 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
      fixups, OR
    - The author pushed fixes and commented "re-review please" after
      a previous Opus review (per-item — check comments via
-     `gh pr view <N> --comments` after your last review's
+     `fleet-pr comments <N>` after your last review's
      `submittedAt`).
 
    **Skip** PRs labeled `fleet:wip`, `human:wip`, `human:needs-fix`,
@@ -190,8 +199,8 @@ iteration of polling, reviewing, and exiting cleanly:
    `repos.game.prs[]`.
 2. For each candidate, in oldest-first order:
    a. Read the existing Sonnet review in full first
-      (`gh pr view <N> --comments`, add `--repo <game-repo>` for
-      game PRs). Note what Sonnet flagged.
+      (`fleet-pr comments <N>`; add `--repo game` for game PRs).
+      Note what Sonnet flagged.
    b. **Stack awareness — gate on upstream status, then note context.**
       A stacked PR's `baseRefName` IS its upstream PR's `headRefName`.
       The candidate PR's own metadata already lives in the cache
@@ -237,12 +246,12 @@ iteration of polling, reviewing, and exiting cleanly:
            `gh pr comment <N> --body "Stack issue: upstream PR for base \`<baseRefName>\` was not found or was closed without merging. Surfacing to the human — this PR likely needs to be re-targeted or closed."`
            Do NOT add a verdict label.
 
-      `gh pr diff <N>` always scopes to this PR's own diff — do not
-      re-review the parent.
+      `fleet-pr diff <N>` always scopes to this PR's own diff — do
+      not re-review the parent.
    c. **Engine PRs:** Invoke the `review-pr` skill on the PR.
-      **Game PRs:** Read the diff with `gh pr diff <N> --repo
-      <game-repo>` and review manually (you cannot check out game
-      PRs into this engine worktree). For game conventions, read
+      **Game PRs:** Read the diff with `fleet-pr diff <N> --repo game`
+      and review manually (you cannot check out game PRs into this
+      engine worktree). For game conventions, read
       `~/src/IrredenEngine/creations/game/CLAUDE.md`.
    d. Focus your review on the items Sonnet could not confirm — do
       not duplicate work Sonnet already did. Your review body should

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -270,7 +270,7 @@ Do the work, then exit cleanly:
    repo's list; skip the PR if its head branch is in the set.
 
    For each flagged PR (after the filter):
-   a. Read **all** feedback (two separate commands):
+   a. Read **all** feedback (one wrapper call):
       `fleet-pr comments <N>`
       (covers the timeline, review summaries, and inline comments
       in one call.)

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -61,11 +61,20 @@ Schema (slices this role uses):
   `title`, `summary`, `id`, `model`, `owner`, `area`, `blocked_by`,
   `issue`.
 
-Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`,
-`gh issue view <N>`, `gh api repos/.../comments`) stay inline — those
-pull live data the cache doesn't store (PR bodies, comments, diffs).
-The cache covers list-shaped queries; live drill-in covers
-single-item drill-down.
+Per-item drill-ins go through the `fleet-pr` and `fleet-issue`
+wrappers, which read scout's per-PR / per-issue cache and fall back
+to live `gh` on cache miss:
+
+- `fleet-pr view <N>` — full PR detail.
+- `fleet-pr diff <N>` — raw diff text.
+- `fleet-pr comments <N>` — flat timeline of comments + review
+  summaries + inline comments. Use this when addressing feedback.
+- `fleet-issue view <N>` — issue body + comments + labels + state.
+  Use this when planning a `fleet:needs-plan` issue.
+
+Writes (`gh pr edit`, `gh pr comment`, `gh pr create`,
+`gh issue edit`, `gh issue create`) stay direct — the wrappers are
+read-only.
 
 If `~/.fleet/state/state.json` is missing or its `generated_at` is
 more than ~5 minutes old, the scout daemon isn't running. Print a
@@ -262,8 +271,9 @@ Do the work, then exit cleanly:
 
    For each flagged PR (after the filter):
    a. Read **all** feedback (two separate commands):
-      `gh pr view <N> --comments`
-      `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // .original_line)] \(.body)"'`
+      `fleet-pr comments <N>`
+      (covers the timeline, review summaries, and inline comments
+      in one call.)
 
       **For `fleet:has-nits`**: focus on the latest review's `### Nits`
       section. Address every nit unless it's purely subjective preference.
@@ -480,7 +490,7 @@ Do the work, then exit cleanly:
     b. Read the merger's most recent comment — it lists the
        conflicted files and the master/PR shas that touched each,
        so you don't need to re-discover them:
-       `gh pr view <N> --repo jakildev/IrredenEngine --comments`
+       `fleet-pr comments <N>` (engine; for game PRs add `--repo game`).
        Look for the comment ending in `— fleet merger`.
     c. Check out the PR (this also fetches the head branch):
        `gh pr checkout <N> --repo jakildev/IrredenEngine`
@@ -560,7 +570,7 @@ Do the work, then exit cleanly:
 
    The cache only stores list-shaped data — for per-issue body and
    comments, pull live (per-item lookup, stays inline):
-   `gh issue view <N> --repo <repo> --comments`
+   `fleet-issue view <N>` (engine; for game issues add `--repo game`).
 
    For each issue:
    a. Read the full issue thread (title, body, all comments).

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -64,10 +64,18 @@ Schema (slices this role uses):
   the working-tree TASKS.md is still what you Edit/Read for
   maintenance.
 
-Per-item lookups (`gh pr view <N> --json body`,
-`gh issue view <N> --comments`, `gh pr list --state merged ...`)
-stay inline — those pull live data the cache doesn't store (PR
-bodies, comment timelines, merged PRs).
+Per-item drill-ins go through the `fleet-pr` and `fleet-issue`
+wrappers, which read scout's per-PR / per-issue cache and fall back
+to live `gh` on cache miss:
+
+- `fleet-pr view <N>` — PR body + comments + reviews + inline
+  threads. Use this for the `Closes #N` parsing.
+- `fleet-issue view <N>` — issue body + comments + labels + state.
+  Use this when ingesting a `human:approved` issue.
+
+Queries the wrappers don't cover stay direct: `gh pr list --state
+merged`, `gh api repos/.../issues/<N>/timeline`, label edits, and
+all writes (`gh pr edit`, `gh issue edit`).
 
 If `~/.fleet/state/state.json` is missing or its `generated_at` is
 more than ~5 minutes old, the scout daemon isn't running. Print
@@ -374,10 +382,12 @@ You are the sole TASKS.md editor. Each maintenance pass:
     pays the same pickup tax (observed: T-067 hit 4×, T-089 hit 2× by
     different opus-workers). For each `[ ]` or `[~]` task whose
     `**Issue:** #N` is a number, fetch the most recent few comments:
-    `gh issue view <N> --repo <repo> --json comments --jq '.comments[-5:]'`
-    Look for a comment body matching the release pattern — case-insensitive
-    substrings like `releasing the t-`, `already shipped`, `work shipped under pr #`,
-    `duplicate of pr #`, `already complete` — that names a specific PR
+    `fleet-issue view <N>` (engine; for game issues add `--repo game`).
+    Scan the comment timeline in the output; the most recent comments
+    are at the end. Look for a comment body matching the release pattern
+    — case-insensitive substrings like `releasing the t-`, `already shipped`,
+    `work shipped under pr #`, `duplicate of pr #`, `already complete` — that
+    names a specific PR
     number. Verify that PR's state with `gh pr view <PR-N> --repo <repo>
     --json state,mergedAt`. If state is `MERGED`:
     a. Flip the TASKS.md row to `[x]` (use Edit; same rules as step 5

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -50,10 +50,18 @@ Schema (slices this role uses):
 - `repos.engine.tasks.{open,in_progress,done}[]` — `status`, `title`,
   `summary`, `id`, `model`, `owner`, `area`, `blocked_by`, `issue`.
 
-Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`,
-`gh api repos/.../comments`) stay inline — those pull live data the
-cache doesn't store. The cache covers list-shaped queries; live
-drill-in covers single-item drill-down.
+Per-item drill-ins go through the `fleet-pr` and `fleet-issue`
+wrappers, which read scout's per-PR / per-issue cache and fall back
+to live `gh` on cache miss:
+
+- `fleet-pr view <N>` — full PR detail.
+- `fleet-pr diff <N>` — raw diff text.
+- `fleet-pr comments <N>` — flat timeline of comments + review
+  summaries + inline comments. Use this when addressing feedback.
+- `fleet-issue view <N>` — issue body + comments + labels + state.
+
+Writes (`gh pr edit`, `gh pr comment`, `gh pr create`) stay direct
+— the wrappers are read-only.
 
 If `~/.fleet/state/state.json` is missing or its `generated_at` is
 more than ~5 minutes old, the scout daemon isn't running. Print
@@ -166,8 +174,9 @@ Each iteration:
 
    For each flagged PR (after the filter):
    a. Read **all** feedback (two separate commands):
-      `gh pr view <N> --comments`
-      `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments --jq '.[] | "[\(.path):\(.line // .original_line)] \(.body)"'`
+      `fleet-pr comments <N>`
+      (covers the timeline, review summaries, and inline comments
+      in one call.)
       The first gets conversation-level comments. The second gets
       inline review comments on specific lines — this is where most
       human feedback lives. Address every comment, not just the first.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -173,13 +173,12 @@ Each iteration:
    head branch is in the set.
 
    For each flagged PR (after the filter):
-   a. Read **all** feedback (two separate commands):
+   a. Read **all** feedback:
       `fleet-pr comments <N>`
       (covers the timeline, review summaries, and inline comments
       in one call.)
-      The first gets conversation-level comments. The second gets
-      inline review comments on specific lines — this is where most
-      human feedback lives. Address every comment, not just the first.
+      Address every comment — conversation-level, review summaries,
+      and inline line-level comments are all in the output.
 
       **For `fleet:has-nits`** (PR was approved, reviewer flagged
       improvements): focus on the latest review's `### Nits` section.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -58,10 +58,17 @@ Schema (slices this role uses):
   `mergeable`, `isDraft`, `reviews[]` (each with `author` login,
   `body`, `state`, `submittedAt`).
 
-Per-item lookups (`gh pr view <N> --comments`, `gh pr diff <N>`,
-`gh api repos/.../comments`) stay inline — those pull live data the
-cache doesn't store (issue comment timeline). The cache covers
-list-shaped queries; live drill-in covers single-item drill-down.
+Per-item drill-ins go through the `fleet-pr` and `fleet-issue`
+wrappers, which read scout's per-PR / per-issue cache and fall back
+to live `gh` on cache miss:
+
+- `fleet-pr view <N>` — full PR detail.
+- `fleet-pr diff <N>` — raw diff text. Used on every PR you review.
+- `fleet-pr comments <N>` — flat timeline; convenient when you only
+  need to skim the conversation without the body.
+
+Writes (`gh pr review`, `gh pr comment`, `gh pr edit`) stay direct
+— the wrappers are read-only.
 
 If `~/.fleet/state/state.json` is missing or its `generated_at` is
 more than ~5 minutes old, the scout daemon isn't running. Print
@@ -120,9 +127,8 @@ treat it as a hard rule for this role.
      whichever gets to it first), OR
    - It **previously had a fleet review** but the author pushed fixes
      and commented "re-review please" — for this last one, do a per-PR
-     `gh pr view <N> --comments` only when the other criteria didn't
-     already match (the comment timeline is per-item drill-in, not in
-     the cache).
+     `fleet-pr comments <N>` only when the other criteria didn't
+     already match.
 
    When picking up a `human:re-review` or `fleet:changes-made` PR,
    **immediately remove the label that triggered pickup** so another
@@ -237,12 +243,12 @@ iteration of polling, reviewing, and exiting cleanly:
         `gh pr comment <N> --body "Stack issue: upstream PR for base \`<baseRefName>\` was not found or was closed without merging. Surfacing to the human — this PR likely needs to be re-targeted or closed."`
         Do NOT add a verdict label.
 
-   `gh pr diff <N>` always scopes to this PR's own diff — do not
+   `fleet-pr diff <N>` always scopes to this PR's own diff — do not
    re-review the parent.
 
    **Game PRs** (`<game-repo>`):
-   a. Read the diff: `gh pr diff <N> --repo <game-repo>`
-   b. Read PR details: `gh pr view <N> --repo <game-repo>`
+   a. Read the diff: `fleet-pr diff <N> --repo game`
+   b. Read PR details: `fleet-pr view <N> --repo game`
    c. Review the diff manually (you cannot check out game PRs into
       this engine worktree). Focus on code quality, style, and obvious
       bugs. For game-specific conventions, read the game CLAUDE.md at


### PR DESCRIPTION
## Summary

- **B.4 of the fleet GitHub-interaction overhaul plan** (stacked on #458).
- Mechanical rewrite of 6 role docs: replaces inline `gh pr view --comments` / `gh pr diff` / `gh api .../pulls/<N>/comments` / `gh api .../pulls/<N>/reviews` / `gh issue view --comments` with `fleet-pr` and `fleet-issue` wrapper calls.
- Cache-protocol section in each affected role doc updated to list the wrappers as the canonical drill-in path.

## Coverage

| Role doc | Updates |
|---|---|
| role-opus-architect.md | feedback-PR comments fetch + cache-protocol prose |
| role-opus-reviewer.md | Sonnet-review read, diff read, recheck-comment read, game-PR diff read, cache-protocol prose |
| role-opus-worker.md | feedback-PR comments fetch, planning issue view, comments per re-review, cache-protocol prose |
| role-queue-manager.md | release-comment scan via `fleet-issue view` (last 5 comments are at the end of the timeline), cache-protocol prose |
| role-sonnet-author.md | feedback-PR comments fetch, cache-protocol prose |
| role-sonnet-reviewer.md | recheck-comment read, diff read, game-PR view + diff, cache-protocol prose |

Merger is unchanged — its only per-PR drill-in is `gh pr view <N> --json mergeable` (UNKNOWN refresh), which the wrapper doesn't cover and which is fine to leave direct.

## Why

This is the consumer side of #457 (per-PR/issue cache layer) + #458 (`fleet-pr` and `fleet-issue` wrappers). With this PR, agents stop firing live `gh pr view --comments`, `gh pr diff`, etc. on every iteration — the data already lives in `~/.fleet/state/prs/<repo>/<N>.json` and `~/.fleet/state/diffs/<repo>/<N>-<sha>.diff`.

For reviewers, this is the biggest token-spend cut of the overhaul: every PR review previously fired `gh pr diff <N>` (often 10–500 KB per PR) live as a child process; now those bytes come from the on-disk cache via a single Read.

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/458 (B.3 — fleet-pr / fleet-issue wrappers)

When the parent PR merges, change this PR's base to the next parent or to `master`.

## Carve-outs (kept as direct gh calls)

- `gh pr diff <N> --name-only` — reviewer-side scan for render-touching diffs to set cross-host smoke labels. The wrapper doesn't replicate `--name-only`; the agent could grep the cached diff but `gh pr diff --name-only` is simpler.
- `gh pr list --state merged --json ...` — list-shaped, not currently in scout's cache (only open PRs are cached today).
- `gh api repos/.../issues/<N>/timeline` — label-strip event timeline; not cached.
- All writes: `gh pr edit`, `gh pr comment`, `gh pr create`, `gh pr review`, `gh issue edit`, `gh issue create`. Wrappers are read-only by design.

## Test plan

- [ ] `grep -nE 'gh pr view.*--comments|gh pr diff <N>$|gh api repos/.*pulls/.*comments|gh api repos/.*pulls/.*reviews|gh issue view.*--comments|gh issue view.*--json comments' .claude/commands/role-*.md` returns only the two `gh pr diff <N> --name-only` mentions. (Done locally.)
- [ ] After this lands, run sonnet-reviewer once on a PR that previously took N gh calls. Pane log shows `fleet-pr: cache miss for engine#<N>; falling back to gh` only on cache misses — populated PRs show no fallback line.
- [ ] Cache-protocol section in each role doc lists the wrappers (visible in the rendered markdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)