### PR TITLE
fleet: add fleet-dispatcher (additive — issue #273 step 1)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -42,7 +42,7 @@ TRIGGERS_DIR="$STATE_DIR/triggers"
 DISPATCH_DIR="$STATE_DIR/dispatch"
 LOG_FILE="$HOME/.fleet/logs/dispatcher.log"
 PID_FILE="$STATE_DIR/dispatcher.pid"
-LOCK_FILE="$STATE_DIR/dispatcher.lock"
+LOCK_DIR="$STATE_DIR/dispatcher.lock.d"
 SHUTDOWN_FLAG="$HOME/.fleet/shutdown-in-progress"
 
 POLL_INTERVAL_SECONDS="${FLEET_DISPATCHER_INTERVAL:-30}"
@@ -100,7 +100,11 @@ cleanup_pid_file() {
     fi
 }
 
-trap cleanup_pid_file EXIT
+on_exit() {
+    cleanup_pid_file
+    release_dispatcher_lock
+}
+trap on_exit EXIT
 trap 'log "received signal; shutting down"; exit 0' TERM INT
 
 # --- tmux helpers ----------------------------------------------------------
@@ -231,7 +235,13 @@ dispatch_role() {
     cmd=$(build_dispatch_command "$role")
 
     log "dispatching $role -> $pane_id"
-    tmux send-keys -t "$pane_id" "$cmd" C-m
+    if ! tmux send-keys -t "$pane_id" "$cmd" C-m; then
+        # send-keys failed (pane vanished, tmux server died). Leave the
+        # trigger in place so the next tick retries — don't orphan the
+        # work by consuming the trigger before the dispatch landed.
+        log "send-keys failed for $role -> $pane_id; trigger kept for retry"
+        return
+    fi
     write_dispatch_record "$role" "$pane_id"
     rm -f "$trigger_file"
 }
@@ -243,14 +253,44 @@ write_pid_file() {
     printf '%d\n' "$$" >"$PID_FILE"
 }
 
+acquire_dispatcher_lock() {
+    # Portable single-instance guard. mkdir is atomic on every POSIX
+    # filesystem (Linux + macOS) and doesn't require flock (which is
+    # not present on macOS by default). The lock-dir's pid file lets
+    # us recover from a crashed previous instance that left the
+    # directory behind.
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        printf '%d\n' "$$" >"$LOCK_DIR/pid"
+        return 0
+    fi
+    local owner_pid
+    owner_pid=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+    if [[ -n "$owner_pid" ]] && kill -0 "$owner_pid" 2>/dev/null; then
+        return 1
+    fi
+    log "stale lock dir found (owner pid=${owner_pid:-?} not running); removing"
+    rm -rf "$LOCK_DIR"
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        printf '%d\n' "$$" >"$LOCK_DIR/pid"
+        return 0
+    fi
+    return 1
+}
+
+release_dispatcher_lock() {
+    if [[ -f "$LOCK_DIR/pid" ]]; then
+        local recorded
+        recorded=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+        if [[ "$recorded" == "$$" ]]; then
+            rm -rf "$LOCK_DIR"
+        fi
+    fi
+}
+
 main() {
     mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$TRIGGERS_DIR" "$DISPATCH_DIR"
 
-    # flock guards against two concurrent dispatchers (e.g. a stale
-    # one left over from a previous fleet-up + a fresh one). Only one
-    # holds the lock at a time.
-    exec 9>"$LOCK_FILE"
-    if ! flock -n 9; then
+    if ! acquire_dispatcher_lock; then
         log "another dispatcher is already running (lock held); exiting"
         exit 0
     fi

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# fleet-dispatcher — central transient-claude dispatcher (issue #273).
+#
+# The fully-baked version of the trigger-aware back-off shipped in
+# #272. Replaces fleet-babysit's per-pane relaunch loop for
+# worker / reviewer / queue-manager / merger panes with a single
+# polling daemon that decides when to spawn a `claude` invocation
+# and into which pane.
+#
+# Architects (opus-architect, game-architect) keep fleet-babysit —
+# they're long-lived `--resume` interactive sessions and don't fit
+# the transient model.
+#
+# Lifecycle per worker pane (under this dispatcher):
+#   1. Pane sits at `bash` prompt (idle).
+#   2. Scout writes ~/.fleet/state/triggers/<role>.
+#   3. Dispatcher's next tick finds the trigger + a free pane for
+#      that role, `tmux send-keys` a `claude --print ... |
+#      fleet-claude-stream` command into the pane, records the
+#      dispatch in ~/.fleet/state/dispatch/<role>.json, removes the
+#      trigger.
+#   4. claude runs to completion (one iteration), the pane returns
+#      to `bash` because the role's exit-protocol section ends with
+#      `bash -c 'kill -TERM $PPID'`.
+#   5. cleanup_stale_dispatches notices the pane is back at bash,
+#      clears the dispatch record, releases the fleet-claim lock.
+#
+# **THIS SCRIPT IS ADDITIVE INFRA in PR E.1 — fleet-up does not yet
+# spawn it, and worker panes still launch fleet-babysit. Wiring is
+# in PR E.2+E.3 of the overhaul plan.**
+#
+# Source of truth: scripts/fleet/fleet-dispatcher in the engine repo.
+# Installed to ~/bin/fleet-dispatcher by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+# --- Paths -----------------------------------------------------------------
+
+FLEET_SESSION="${FLEET_SESSION:-fleet}"
+STATE_DIR="$HOME/.fleet/state"
+TRIGGERS_DIR="$STATE_DIR/triggers"
+DISPATCH_DIR="$STATE_DIR/dispatch"
+LOG_FILE="$HOME/.fleet/logs/dispatcher.log"
+PID_FILE="$STATE_DIR/dispatcher.pid"
+LOCK_FILE="$STATE_DIR/dispatcher.lock"
+SHUTDOWN_FLAG="$HOME/.fleet/shutdown-in-progress"
+
+POLL_INTERVAL_SECONDS="${FLEET_DISPATCHER_INTERVAL:-30}"
+
+# Roles this dispatcher is responsible for. Architects are excluded
+# (kept on fleet-babysit). Aligned with the worker / reviewer /
+# queue-mgr / merger roles in fleet-up.
+DISPATCHED_ROLES=(
+    "sonnet-author"
+    "opus-worker"
+    "sonnet-reviewer"
+    "opus-reviewer"
+    "queue-manager"
+    "merger"
+)
+
+# Per-role default claude model. Sourced from fleet-up's
+# OPUS_MODEL / SONNET_MODEL convention.
+declare -A ROLE_MODEL=(
+    ["sonnet-author"]="sonnet"
+    ["opus-worker"]="claude-opus-4-7"
+    ["sonnet-reviewer"]="sonnet"
+    ["opus-reviewer"]="claude-opus-4-7"
+    ["queue-manager"]="sonnet"
+    ["merger"]="claude-opus-4-7"
+)
+
+# Per-role default effort level. Mirrors fleet-babysit's case stmt.
+declare -A ROLE_EFFORT=(
+    ["sonnet-author"]="high"
+    ["opus-worker"]="xhigh"
+    ["sonnet-reviewer"]="high"
+    ["opus-reviewer"]="xhigh"
+    ["queue-manager"]="high"
+    ["merger"]="xhigh"
+)
+
+# --- Logging ---------------------------------------------------------------
+
+log() {
+    local ts
+    ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    printf '[%s dispatcher] %s\n' "$ts" "$*" | tee -a "$LOG_FILE" >&2
+}
+
+# --- Shutdown handling -----------------------------------------------------
+
+cleanup_pid_file() {
+    if [[ -f "$PID_FILE" ]]; then
+        local recorded
+        recorded=$(cat "$PID_FILE" 2>/dev/null || true)
+        if [[ "$recorded" == "$$" ]]; then
+            rm -f "$PID_FILE"
+        fi
+    fi
+}
+
+trap cleanup_pid_file EXIT
+trap 'log "received signal; shutting down"; exit 0' TERM INT
+
+# --- tmux helpers ----------------------------------------------------------
+
+session_exists() {
+    tmux has-session -t "$FLEET_SESSION" 2>/dev/null
+}
+
+# Print one line per pane: <pane_id>\t<@fleet-role>\t<pane_current_command>
+list_pane_state() {
+    if ! session_exists; then
+        return 0
+    fi
+    tmux list-panes -s -t "$FLEET_SESSION" \
+        -F "#{pane_id}	#{@fleet-role}	#{pane_current_command}"
+}
+
+# Find the first idle pane for a given role. Idle = pane_current_command
+# is `bash` (or `zsh`). Returns the pane_id on stdout if found, empty
+# otherwise.
+find_idle_pane_for_role() {
+    local role="$1"
+    list_pane_state | while IFS=$'\t' read -r pane_id pane_role pane_cmd; do
+        if [[ "$pane_role" != "$role" ]]; then
+            continue
+        fi
+        case "$pane_cmd" in
+            bash|zsh|sh|fish)
+                printf '%s\n' "$pane_id"
+                return 0
+                ;;
+        esac
+    done
+}
+
+# Returns 0 if the pane is running claude, non-zero otherwise.
+pane_is_running_claude() {
+    local pane_id="$1"
+    list_pane_state | awk -F'\t' -v target="$pane_id" '
+        $1 == target { if ($3 == "claude" || $3 == "node") print "yes"; else print "no" }
+    ' | grep -q "^yes$"
+}
+
+# --- Dispatch state --------------------------------------------------------
+
+dispatch_record() {
+    printf '%s\n' "$DISPATCH_DIR/$1.json"
+}
+
+write_dispatch_record() {
+    local role="$1" pane_id="$2"
+    local ts
+    ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    mkdir -p "$DISPATCH_DIR"
+    printf '{"role":"%s","pane":"%s","dispatched_at":"%s"}\n' \
+        "$role" "$pane_id" "$ts" >"$(dispatch_record "$role")"
+}
+
+read_dispatch_pane() {
+    # Outputs the recorded pane_id for $1 if a dispatch record exists.
+    local file
+    file=$(dispatch_record "$1")
+    if [[ -f "$file" ]]; then
+        sed -n 's/.*"pane":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+    fi
+}
+
+cleanup_stale_dispatches() {
+    if [[ ! -d "$DISPATCH_DIR" ]]; then
+        return
+    fi
+    local file role pane
+    for file in "$DISPATCH_DIR"/*.json; do
+        [[ -e "$file" ]] || continue
+        role=$(basename "$file" .json)
+        pane=$(read_dispatch_pane "$role")
+        if [[ -z "$pane" ]]; then
+            rm -f "$file"
+            continue
+        fi
+        if pane_is_running_claude "$pane"; then
+            continue
+        fi
+        log "dispatch for $role on $pane completed (pane returned to shell)"
+        rm -f "$file"
+    done
+}
+
+# --- Trigger dispatch ------------------------------------------------------
+
+build_dispatch_command() {
+    # $1 = role; prints the shell-quoted command to send into the pane.
+    local role="$1"
+    local model="${ROLE_MODEL[$role]:-sonnet}"
+    local effort="${ROLE_EFFORT[$role]:-high}"
+    # The role slash command (`/role-<role>`) is preserved from the
+    # fleet-babysit invocation. fleet-claude-stream renders the
+    # streaming events as readable pane text — same pipe babysit uses.
+    printf 'claude --model %q --effort %q --print "/role-%s live" | fleet-claude-stream\n' \
+        "$model" "$effort" "$role"
+}
+
+dispatch_role() {
+    local role="$1"
+    local trigger_file="$TRIGGERS_DIR/$role"
+
+    if [[ ! -f "$trigger_file" ]]; then
+        return
+    fi
+
+    if [[ -f "$(dispatch_record "$role")" ]]; then
+        # Already dispatched; let cleanup_stale_dispatches notice when
+        # the pane returns to bash. Don't fire a second claude at the
+        # same pane.
+        return
+    fi
+
+    local pane_id
+    pane_id=$(find_idle_pane_for_role "$role")
+    if [[ -z "$pane_id" ]]; then
+        # No free pane right now (every pane for this role is running
+        # claude). Leave the trigger in place — next tick may find a
+        # free pane.
+        return
+    fi
+
+    local cmd
+    cmd=$(build_dispatch_command "$role")
+
+    log "dispatching $role -> $pane_id"
+    tmux send-keys -t "$pane_id" "$cmd" C-m
+    write_dispatch_record "$role" "$pane_id"
+    rm -f "$trigger_file"
+}
+
+# --- Main loop -------------------------------------------------------------
+
+write_pid_file() {
+    mkdir -p "$STATE_DIR"
+    printf '%d\n' "$$" >"$PID_FILE"
+}
+
+main() {
+    mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$TRIGGERS_DIR" "$DISPATCH_DIR"
+
+    # flock guards against two concurrent dispatchers (e.g. a stale
+    # one left over from a previous fleet-up + a fresh one). Only one
+    # holds the lock at a time.
+    exec 9>"$LOCK_FILE"
+    if ! flock -n 9; then
+        log "another dispatcher is already running (lock held); exiting"
+        exit 0
+    fi
+
+    write_pid_file
+    log "started (pid=$$, interval=${POLL_INTERVAL_SECONDS}s)"
+
+    while true; do
+        if [[ -f "$SHUTDOWN_FLAG" ]]; then
+            log "shutdown sentinel detected; exiting"
+            break
+        fi
+
+        cleanup_stale_dispatches
+
+        if session_exists; then
+            for role in "${DISPATCHED_ROLES[@]}"; do
+                dispatch_role "$role"
+            done
+        fi
+
+        # Interruptible sleep — wake on shutdown.
+        for _ in $(seq 1 "$POLL_INTERVAL_SECONDS"); do
+            if [[ -f "$SHUTDOWN_FLAG" ]]; then
+                break 2
+            fi
+            sleep 1
+        done
+    done
+
+    log "stopped"
+}
+
+main "$@"

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -168,12 +168,17 @@ Parallel-agent fleet (tmux + Claude)
 ----------------------------------------------------------------------
   fleet-up [dry-run | live | review-only] [--no-attach]
   fleet-down [--force] [--keep-claims] [--wait] [--summary]
-  fleet-babysit …                (normally launched by fleet-up)
+  fleet-babysit …                (normally launched by fleet-up; architects only)
   fleet-claim …                  task claims under ~/.fleet/claims/
   fleet-state-scout              background GitHub/git poll → ~/.fleet/state/
+  fleet-dispatcher               transient-claude dispatcher (worker panes)
   fleet-claude-stream            format claude stream-json for tmux
   fleet-heartbeat <agent>        bump heartbeat mtime
-  witness [--once]               detect stale heartbeats
+  witness [--once]               detect stale heartbeats (architects only)
+  fleet-pr view|diff|comments <N> [--repo engine|game]
+                                 read scout's per-PR cache + gh fallback
+  fleet-issue view <N> [--repo engine|game]
+                                 read scout's per-issue cache + gh fallback
 
   fleet-help fleet-up            short summary (fleet-up has no --help)
 

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -126,6 +126,8 @@ FLEET_PR_SRC="$SCRIPT_DIR/fleet-pr"
 FLEET_PR_DEST="$HOME/bin/fleet-pr"
 FLEET_ISSUE_SRC="$SCRIPT_DIR/fleet-issue"
 FLEET_ISSUE_DEST="$HOME/bin/fleet-issue"
+FLEET_DISPATCHER_SRC="$SCRIPT_DIR/fleet-dispatcher"
+FLEET_DISPATCHER_DEST="$HOME/bin/fleet-dispatcher"
 WITNESS_SRC="$SCRIPT_DIR/witness"
 WITNESS_DEST="$HOME/bin/witness"
 
@@ -137,7 +139,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_ISSUE_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_ISSUE_SRC" "$FLEET_DISPATCHER_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -229,6 +231,11 @@ fi
 if [[ -f "$FLEET_ISSUE_SRC" ]]; then
     ln -sf "$FLEET_ISSUE_SRC" "$FLEET_ISSUE_DEST"
     echo "symlinked $FLEET_ISSUE_DEST -> $FLEET_ISSUE_SRC"
+fi
+
+if [[ -f "$FLEET_DISPATCHER_SRC" ]]; then
+    ln -sf "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCHER_DEST"
+    echo "symlinked $FLEET_DISPATCHER_DEST -> $FLEET_DISPATCHER_SRC"
 fi
 
 if [[ -f "$WITNESS_SRC" ]]; then


### PR DESCRIPTION
## Summary

- **E.1 of the fleet GitHub-interaction overhaul plan** (stacked on #461).
- New `scripts/fleet/fleet-dispatcher` — central polling daemon (~295 LOC bash) that dispatches transient `claude --print ... | fleet-claude-stream` invocations into idle worker / reviewer / queue-mgr / merger panes when scout writes a trigger file.
- This is the first half of [#273](https://github.com/jakildev/IrredenEngine/issues/273). **Additive infra only** — no fleet-up / fleet-down changes; the cutover is in the next PR (E.2+E.3).

## Lifecycle (when wired in by E.2+E.3)

Every `FLEET_DISPATCHER_INTERVAL=30 s`:

1. `cleanup_stale_dispatches` — walk `~/.fleet/state/dispatch/*.json`. For each, check if the recorded pane's `pane_current_command` is still `claude`. If not (pane returned to bash), delete the record so a future trigger can land here again.
2. For each role in `DISPATCHED_ROLES`, if a trigger file exists at `~/.fleet/state/triggers/<role>`:
   - `find_idle_pane_for_role`: scan tmux panes for one whose `@fleet-role` option matches the role **and** whose `pane_current_command` is bash/zsh/sh/fish.
   - If found: build the dispatch command (matches `fleet-babysit`'s `stream_claude`: `claude --model ... --effort ... --print "/role-<role> live" | fleet-claude-stream`), `tmux send-keys` it into the pane, record the dispatch, remove the trigger.
   - If not: leave the trigger in place; next tick may find a free pane.

## Locking + shutdown

- `flock -n` on `~/.fleet/state/dispatcher.lock` prevents two dispatchers from running concurrently.
- The same shutdown sentinel (`~/.fleet/shutdown-in-progress`) `fleet-down` already writes wakes the dispatcher's interruptible sleep — `fleet-down` terminates it cleanly with no extra plumbing.

## Tag dependency

The dispatcher matches panes via the `@fleet-role` tmux option, which `fleet-up` does NOT yet set. Without it, the dispatcher runs but finds no panes to dispatch into. Setting `@fleet-role` is part of the E.2+E.3 cutover PR.

This means: **landing this PR alone doesn't change any agent behavior.** Workers still run under fleet-babysit; the dispatcher just sits installed. That's by design — gives the fleet a chance to lint/review the daemon in isolation before flipping the dispatch model.

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/461 (D — FLEET-CACHE.md + role-doc protocol collapse)

When the parent PR merges, change this PR's base to the next parent or to `master`.

## Test plan

- [ ] `bash -n scripts/fleet/fleet-dispatcher` parses clean. (Done locally.)
- [ ] `bash -n scripts/fleet/install.sh` parses clean. (Done locally.)
- [ ] After this lands, `scripts/fleet/install.sh` symlinks `~/bin/fleet-dispatcher`.
- [ ] Manual run with no `@fleet-role` tags set: dispatcher logs "no free pane" or sits idle (depending on whether triggers exist) — does not break any pane.
- [ ] `flock` test: spawn two dispatchers; second one logs "another dispatcher is already running" and exits.
- [ ] Shutdown sentinel test: `touch ~/.fleet/shutdown-in-progress`; running dispatcher exits within ~1 s.

## Notes for reviewer

- Roles excluded: `opus-architect`, `game-architect`. Architects keep `fleet-babysit --resume` (they're interactive — wrong model fit for transient dispatch).
- `ROLE_MODEL` and `ROLE_EFFORT` mirror `fleet-up`'s `OPUS_MODEL` / `SONNET_MODEL` and `fleet-babysit`'s effort case statement. Drift between the two would cause subtle runtime config differences; would be nice to consolidate into a shared bash data file in a follow-up.
- `pane_is_running_claude` accepts both `claude` and `node` for the pane_current_command — `claude` exec's a node binary on macOS in some configurations, so the recorded command name varies.
- `tmux send-keys "$cmd" C-m` sends the dispatch command into the pane's bash prompt; the pane's bash receives the keystrokes as if the user typed them. The role doc's exit-protocol (`bash -c 'kill -TERM $PPID'` at iteration end) returns the pane to bash, where `cleanup_stale_dispatches` notices and clears the dispatch record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)