### PR TITLE
fleet: cut over worker panes to fleet-dispatcher (#273 step 2)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -46,6 +46,14 @@ Full cache protocol — staleness rules, layout of every cache
 file, what stays direct — lives in
 [docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
 
+## Exit protocol
+
+You are a transient one-shot `claude --print` invocation. When
+your merge iteration finishes, `--print` exits and the pane
+returns to bash; `fleet-dispatcher` fires a fresh invocation
+when scout's next merge-candidate trigger arrives. Do NOT loop.
+If forced to exit explicitly: `bash -c 'kill -TERM $PPID'`.
+
 ## What you do
 
 You poll open PRs on the **engine repo** every 10 minutes. For each

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -48,6 +48,14 @@ Full cache protocol — staleness rules, layout of every cache
 file, what stays direct — lives in
 [docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
 
+## Exit protocol
+
+You are a transient one-shot `claude --print` invocation. When
+your review iteration finishes, `--print` exits and the pane
+returns to bash; `fleet-dispatcher` fires a fresh invocation when
+scout's next flagged-PR trigger arrives. Do NOT loop. If forced
+to exit explicitly: `bash -c 'kill -TERM $PPID'`.
+
 ## Role
 
 You poll open PRs on **both repos** — the engine repo and the game

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -44,6 +44,22 @@ Full cache protocol — staleness rules, layout of every cache
 file, what stays direct — lives in
 [docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
 
+## Exit protocol
+
+You are a transient one-shot `claude --print` invocation,
+dispatched into a tmux pane that's otherwise sitting at a bash
+prompt. When your iteration finishes, `--print` exits naturally
+and the pane returns to bash; `fleet-dispatcher` polls every 30 s
+and fires a fresh invocation when scout's next trigger arrives.
+
+Do NOT loop, do NOT call `fleet-babysit`. If you ever find
+yourself about to keep the process alive past iteration end,
+exit explicitly:
+
+```
+bash -c 'kill -TERM $PPID'
+```
+
 ## Responsibilities
 
 - Plan issues flagged with `fleet:needs-plan` on **either repo** — read

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -42,6 +42,14 @@ Full cache protocol — staleness rules, layout of every cache
 file, what stays direct — lives in
 [docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
 
+## Exit protocol
+
+You are a transient one-shot `claude --print` invocation. When
+your maintenance iteration finishes, `--print` exits and the
+pane returns to bash; `fleet-dispatcher` fires a fresh invocation
+when scout's next ingestion trigger arrives. Do NOT loop. If
+forced to exit explicitly: `bash -c 'kill -TERM $PPID'`.
+
 ## Role
 
 You are the **task intake** for the fleet. The human (or an idle agent)

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -33,6 +33,25 @@ Full cache protocol — staleness rules, layout of every cache
 file, what stays direct — lives in
 [docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
 
+## Exit protocol
+
+You are a transient one-shot `claude --print` invocation,
+dispatched into a tmux pane that's otherwise sitting at a bash
+prompt. When your iteration finishes, `--print` exits naturally
+and the pane returns to bash; `fleet-dispatcher` polls every 30 s
+and fires a fresh invocation when scout's next trigger arrives.
+
+Do NOT loop, do NOT call `fleet-babysit`. If you ever find
+yourself about to keep the process alive past iteration end (an
+unhandled error, an unexpected prompt), exit explicitly:
+
+```
+bash -c 'kill -TERM $PPID'
+```
+
+That kills the claude parent PID, returns the pane to bash, and
+lets the dispatcher dispatch the next iteration.
+
 ## Responsibilities
 
 - Test generation against a clear spec.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -42,6 +42,14 @@ Full cache protocol — staleness rules, layout of every cache
 file, what stays direct — lives in
 [docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
 
+## Exit protocol
+
+You are a transient one-shot `claude --print` invocation. When
+your review iteration finishes, `--print` exits and the pane
+returns to bash; `fleet-dispatcher` fires a fresh invocation when
+scout's next candidate trigger arrives. Do NOT loop. If forced
+to exit explicitly: `bash -c 'kill -TERM $PPID'`.
+
 ## Role
 
 You poll open PRs on **both repos** — the engine repo and the game

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -435,6 +435,44 @@ else
 fi
 
 # ----------------------------------------------------------------------
+# Step 3f: launch fleet-dispatcher daemon
+# ----------------------------------------------------------------------
+#
+# Polls every 30 s, watches ~/.fleet/state/triggers/<role>, dispatches
+# transient `claude --print ... | fleet-claude-stream` invocations
+# into idle worker / reviewer / queue-mgr / merger panes via
+# `tmux send-keys`. Architects keep fleet-babysit (interactive
+# --resume sessions), so they're not in the dispatcher's role list.
+#
+# Backgrounded with nohup, PID written to dispatcher.pid for
+# fleet-down to terminate cleanly. The dispatcher itself uses
+# `flock -n` on dispatcher.lock as a second-layer guard.
+dispatcher_cmd=""
+if command -v fleet-dispatcher >/dev/null 2>&1; then
+    dispatcher_cmd="fleet-dispatcher"
+elif [[ -x "$ENGINE/scripts/fleet/fleet-dispatcher" ]]; then
+    dispatcher_cmd="$ENGINE/scripts/fleet/fleet-dispatcher"
+fi
+if [[ -z "$dispatcher_cmd" ]]; then
+    echo "fleet-up: fleet-dispatcher not found — workers will fall back to fleet-babysit lifecycle"
+else
+    dispatcher_pid_file="$HOME/.fleet/state/dispatcher.pid"
+    if [[ -f "$dispatcher_pid_file" ]]; then
+        old_pid=$(cat "$dispatcher_pid_file" 2>/dev/null || true)
+        if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
+            kill -TERM "$old_pid" 2>/dev/null || true
+            sleep 1
+        fi
+        rm -f "$dispatcher_pid_file"
+    fi
+    mkdir -p "$HOME/.fleet/state" "$HOME/.fleet/logs"
+    dispatcher_log="$HOME/.fleet/logs/dispatcher.log"
+    nohup "$dispatcher_cmd" >>"$dispatcher_log" 2>&1 &
+    disown
+    echo "fleet-up: launched fleet-dispatcher (pid $!, log $dispatcher_log)"
+fi
+
+# ----------------------------------------------------------------------
 # Step 3e: write the repo-discovery cache
 # ----------------------------------------------------------------------
 #
@@ -585,6 +623,20 @@ label_pane_id() {
     tmux set-option -t "$1" -p @role "$2"
 }
 
+# Tag a pane with its dispatcher role slug. The dispatcher matches
+# panes via this tag (separate from the human-readable @role label).
+# Architects don't get tagged — they stay on fleet-babysit and the
+# dispatcher's role list excludes them.
+set_fleet_role() {
+    tmux set-option -t "$1" -p @fleet-role "$2"
+}
+
+# Command for a non-architect pane that's been migrated to the
+# dispatcher model: just an interactive shell. The dispatcher will
+# `tmux send-keys` a `claude --print ... | fleet-claude-stream` line
+# in when it sees a trigger for this role's pane.
+TRANSIENT_PANE_CMD='exec $SHELL -i'
+
 # --- Window 1: "fleet" — 3 rows × 3 columns ---------------------------
 #
 # Build top-down: create initial pane (will become top-left), split
@@ -594,9 +646,10 @@ label_pane_id() {
 
 tmux new-session -d -s "$SESSION" -n fleet \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-1" \
-    "$(launch_cmd "$SONNET_MODEL" sonnet-author)"
+    "$TRANSIENT_PANE_CMD"
 TOP_LEFT=$(tmux display-message -t "$SESSION:fleet" -p "#{pane_id}")
 label_pane_id "$TOP_LEFT" "sonnet-fleet-1 [sonnet]"
+set_fleet_role "$TOP_LEFT" "sonnet-author"
 pane_stagger
 
 # Split bottom 2/3 off — that becomes the middle row's leftmost pane.
@@ -609,8 +662,9 @@ pane_stagger
 # Split bottom 1/2 of the middle off — that becomes bottom row leftmost.
 BOT_LEFT=$(tmux split-window -v -t "$MID_LEFT" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-1" \
-    "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)")
+    "$TRANSIENT_PANE_CMD")
 label_pane_id "$BOT_LEFT" "opus-worker-1 [opus 4.7]"
+set_fleet_role "$BOT_LEFT" "opus-worker"
 pane_stagger
 
 # Top row: split TOP_LEFT horizontally to add sonnet-fleet-2 and
@@ -619,14 +673,16 @@ pane_stagger
 # left, giving three equal columns.
 TOP_MID=$(tmux split-window -h -t "$TOP_LEFT" -p 67 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-2" \
-    "$(launch_cmd "$SONNET_MODEL" sonnet-author)")
+    "$TRANSIENT_PANE_CMD")
 label_pane_id "$TOP_MID" "sonnet-fleet-2 [sonnet]"
+set_fleet_role "$TOP_MID" "sonnet-author"
 pane_stagger
 
 TOP_RIGHT=$(tmux split-window -h -t "$TOP_MID" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/sonnet-reviewer" \
-    "$(launch_cmd "$SONNET_MODEL" sonnet-reviewer 3m)")
+    "$TRANSIENT_PANE_CMD")
 label_pane_id "$TOP_RIGHT" "sonnet-reviewer [sonnet]"
+set_fleet_role "$TOP_RIGHT" "sonnet-reviewer"
 pane_stagger
 
 # Middle row: split MID_LEFT horizontally for game-architect (only if
@@ -645,14 +701,16 @@ fi
 # equal columns.
 BOT_MID=$(tmux split-window -h -t "$BOT_LEFT" -p 67 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-2" \
-    "$(launch_cmd "$OPUS_MODEL" opus-worker 20m)")
+    "$TRANSIENT_PANE_CMD")
 label_pane_id "$BOT_MID" "opus-worker-2 [opus 4.7]"
+set_fleet_role "$BOT_MID" "opus-worker"
 pane_stagger
 
 BOT_RIGHT=$(tmux split-window -h -t "$BOT_MID" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
-    "FLEET_MIN_BACKOFF=$OPUS_MIN_BACKOFF $(launch_cmd "$OPUS_MODEL" opus-reviewer 30m)")
+    "$TRANSIENT_PANE_CMD")
 label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.7]"
+set_fleet_role "$BOT_RIGHT" "opus-reviewer"
 pane_stagger
 
 # --- Window 2: "ops" — 2x2 grid ---------------------------------------
@@ -668,14 +726,16 @@ pane_stagger
 # at fleet-index + 1 regardless of base-index.
 OPS_TL=$(tmux new-window -a -t "$SESSION:fleet" -n ops -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/queue-manager" \
-    "$(launch_cmd "$SONNET_MODEL" queue-manager 5m)")
+    "$TRANSIENT_PANE_CMD")
 label_pane_id "$OPS_TL" "queue-manager [sonnet]"
+set_fleet_role "$OPS_TL" "queue-manager"
 pane_stagger
 
 OPS_TR=$(tmux split-window -h -t "$OPS_TL" -p 50 -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/merger" \
-    "$(launch_cmd "$OPUS_MODEL" merger 10m)")
+    "$TRANSIENT_PANE_CMD")
 label_pane_id "$OPS_TR" "merger [opus 4.7]"
+set_fleet_role "$OPS_TR" "merger"
 
 OPS_BL=$(tmux split-window -v -t "$OPS_TL" -p 50 -P -F "#{pane_id}" \
     -c "$HOME/.fleet" \


### PR DESCRIPTION
## Summary

- **E.2+E.3 of the fleet GitHub-interaction overhaul plan** (stacked on #462). This is the [#273](https://github.com/jakildev/IrredenEngine/issues/273) cutover — the moment where worker / reviewer / queue-mgr / merger panes flip from `fleet-babysit` to the central `fleet-dispatcher` model.
- After this PR, idle worker panes sit at a `bash` prompt. The dispatcher polls every 30 s and `tmux send-keys` a transient `claude --print "/role-<role> live" | fleet-claude-stream` command into a free pane when scout fires a trigger.

## What changed

### `scripts/fleet/fleet-up`

1. **Step 3f (new):** spawn `fleet-dispatcher` as a background daemon (mirrors the scout launch in step 3d, with the same shutdown-PID-file dance).
2. **Helpers:** new `set_fleet_role <pane-id> <role-slug>` that sets the `@fleet-role` tmux option (separate from the human-readable `@role` label). New `TRANSIENT_PANE_CMD='exec $SHELL -i'` for non-architect panes.
3. **Pane spawning:** every non-architect pane now uses `TRANSIENT_PANE_CMD` instead of `launch_cmd "$MODEL" <role>`, and gets a `set_fleet_role <pane> <role-slug>` after `label_pane_id`. Architect panes are unchanged — they still run `fleet-babysit --resume` and don't get `@fleet-role` tagged.

### Role docs

Each of `role-sonnet-author.md`, `role-opus-worker.md`, `role-sonnet-reviewer.md`, `role-opus-reviewer.md`, `role-queue-manager.md`, `role-merger.md` gains an "Exit protocol" section that explains the transient model: `--print` exits naturally, the dispatcher fires the next iteration, force-exit with `bash -c 'kill -TERM $PPID'` if claude is about to overstay.

Architect docs are unchanged.

## Why this isn't disruptive

- **`fleet-claude-stream` preserved.** Every dispatched invocation still pipes through it, so pane text streaming during work looks identical to today. Only the *idle* pane visual changes — bash prompt instead of `fleet-babysit`'s `[babysit ...]` log lines.
- **Shutdown sentinel preserved.** The dispatcher (from #462) listens on the same `~/.fleet/shutdown-in-progress` flag fleet-down already uses, so fleet-down terminates it cleanly — no extra plumbing in this PR.
- **Easy revert.** If anything misfires, `git revert` on the single fleet-up commit flips panes back to `fleet-babysit`; `fleet-dispatcher` remains installed but unused.

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/462 (E.1 — fleet-dispatcher script)

When the parent PR merges, change this PR's base to the next parent or to `master`.

## Carve-outs

- **Architects** (opus-architect, game-architect): keep `fleet-babysit --resume`. Long-lived interactive sessions don't fit transient dispatch.
- **Witness pane**: keeps the `witness` daemon command — not a claude pane.
- **Terminal pane**: keeps `exec $SHELL` — human's free-form shell, no `@fleet-role` tag (not a dispatch target).
- **`fleet-heartbeat` + `witness` for workers**: still wired up. Workers no longer strictly need them under the dispatcher (the dispatcher knows pane state via `pane_current_command`), but tearing them out is the next PR (E.4+E.5).

## Test plan

- [ ] `bash -n scripts/fleet/fleet-up` parses clean. (Done locally.)
- [ ] After this lands: `fleet-down && fleet-up live --no-attach` brings up the session. `tmux list-panes -t fleet -F '#{@fleet-role}: #{pane_current_command}'` shows worker panes at `bash`, dispatcher visible in process list, scout still running.
- [ ] Scout fires a trigger (e.g. by opening a fresh PR labeled `human:needs-fix`). Within 30 s, the matching role's pane shows `tmux send-keys` activity and `claude --print` runs through `fleet-claude-stream` exactly as before.
- [ ] Iteration completes; pane returns to `bash`; `~/.fleet/state/dispatch/<role>.json` is cleared by `cleanup_stale_dispatches` on the next dispatcher tick.
- [ ] Architect panes still run `fleet-babysit` (visible in their pane log).
- [ ] `fleet-down`: shutdown sentinel fires; dispatcher logs "shutdown sentinel detected; exiting"; tmux kill-session lands cleanly.

## Risk + rollback

This is the highest-risk PR of the overhaul. Recommend leaving the fleet on it for a full active day before merging the cleanup PR (E.4+E.5). If problems show up:

1. `git revert <this PR's commit>` on the fleet-up file flips panes back to fleet-babysit.
2. `fleet-dispatcher` remains installed but harmless (it just sees no `@fleet-role`-tagged panes and dispatches nothing).
3. The dispatcher process can be killed via `kill $(cat ~/.fleet/state/dispatcher.pid)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)