### PR TITLE
fleet: fleet-down stops dispatcher; witness only watches architects

### DIFF
--- a/scripts/fleet/fleet-down
+++ b/scripts/fleet/fleet-down
@@ -156,6 +156,24 @@ if [[ -f "$SCOUT_PID_FILE" ]]; then
 fi
 
 # ----------------------------------------------------------------------
+# Stop fleet-dispatcher daemon (started by fleet-up after #273 cutover)
+# ----------------------------------------------------------------------
+#
+# Same pattern as scout: the dispatcher polls the shutdown sentinel
+# every second and exits on its own; the explicit SIGTERM here is
+# belt-and-suspenders for wedged / missed-poll cases.
+
+DISPATCHER_PID_FILE="$HOME/.fleet/state/dispatcher.pid"
+if [[ -f "$DISPATCHER_PID_FILE" ]]; then
+    dispatcher_pid=$(cat "$DISPATCHER_PID_FILE" 2>/dev/null || true)
+    if [[ -n "$dispatcher_pid" ]] && kill -0 "$dispatcher_pid" 2>/dev/null; then
+        echo "fleet-down: stopping fleet-dispatcher (pid $dispatcher_pid)"
+        kill -TERM "$dispatcher_pid" 2>/dev/null || true
+    fi
+    rm -f "$DISPATCHER_PID_FILE"
+fi
+
+# ----------------------------------------------------------------------
 # Ctrl-C trap: per-phase abort, doesn't cascade
 # ----------------------------------------------------------------------
 #

--- a/scripts/fleet/witness
+++ b/scripts/fleet/witness
@@ -36,18 +36,20 @@ for arg in "$@"; do
     esac
 done
 
-# Per-role staleness thresholds in seconds.
-# = loop interval + overrun budget (build/API/usage-limit wait).
+# Per-role staleness thresholds in seconds. Only architects are
+# monitored — non-architect panes run under fleet-dispatcher (#273)
+# and may sit idle for arbitrarily long when no triggers fire. The
+# dispatcher's cleanup_stale_dispatches loop is the canonical
+# aliveness check for those panes; witness alerts on workers would
+# be false positives every quiet period.
+#
+# Architects use --resume sessions, may sit at "standing by" between
+# human prompts. The 2 h threshold is generous enough for typical
+# desk-time gaps without missing a genuine wedge.
 threshold_for_agent() {
     case "$1" in
-        sonnet-fleet-1)  echo 300  ;;   # 5m  — continuous loop, back-to-back
-        sonnet-reviewer) echo 360  ;;   # 6m  — 3m loop + 3m budget
-        queue-manager)   echo 600  ;;   # 10m — 5m loop + 5m budget
-        opus-worker-1)   echo 1800 ;;   # 30m — 20m loop + 10m budget
-        opus-worker-2)   echo 1800 ;;   # 30m
-        opus-reviewer)   echo 2700 ;;   # 45m — 30m loop + 15m budget
-        merger)          echo 1200 ;;   # 20m — 10m loop + 10m budget
-        *)               echo 0    ;;   # unknown — not monitored
+        opus-architect|game-architect)  echo 7200 ;;  # 2 h
+        *)                              echo 0    ;;  # not monitored
     esac
 }
 


### PR DESCRIPTION
## Summary

- **E.4+E.5 of the fleet GitHub-interaction overhaul plan** (stacked on #463). Final PR of the [#273](https://github.com/jakildev/IrredenEngine/issues/273) cutover.
- **fleet-down**: extends the existing scout-shutdown block to also SIGTERM `fleet-dispatcher`'s PID. Same pattern as the scout teardown.
- **witness**: drops worker / reviewer / queue-mgr / merger from its per-role thresholds — under the dispatcher those panes may sit at a bash prompt for arbitrarily long, and heartbeat-staleness alerts during quiet periods would lose signal. Architects keep monitoring with a generous 2 h threshold.

## Why

After E.2+E.3 (#463), worker panes idle at a bash prompt and only run claude when scout fires a trigger that the dispatcher routes. Three implications cleaned up here:

1. fleet-down didn't know about the dispatcher daemon → the daemon survived `fleet-down` until its `flock` was released by the next `fleet-up` (one-tick race window). Now it's signaled cleanly.
2. witness watched workers' heartbeats. After cutover, a quiet weekend with no triggers means workers don't iterate, heartbeats don't update, witness alerts every 60 s. Removing workers from witness's role list eliminates the false positives. The dispatcher's own `cleanup_stale_dispatches` is the canonical "is this pane alive?" check now.
3. Architects keep both heartbeats and witness because they're interactive --resume sessions — different lifecycle, different aliveness story.

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/463 (E.2+E.3 — fleet-up cutover to dispatcher)

When the parent PR merges, change this PR's base to `master`.

## What's NOT included

- **Removing `fleet-heartbeat <name>` lines from worker role docs.** They're harmless cheap overhead under the dispatcher (witness ignores those names); dropping them is a follow-up PR if the noise becomes a problem.
- **Retiring `fleet-babysit` entirely.** Architects still use it. The script stays installed.

## Test plan

- [ ] `bash -n scripts/fleet/fleet-down && bash -n scripts/fleet/witness` — done locally.
- [ ] After this lands + #463 lands: `fleet-down` sends SIGTERM to the dispatcher PID; `~/.fleet/state/dispatcher.pid` is removed; `fleet-down --force` works without leaving an orphan dispatcher.
- [ ] `witness --once` after a quiet hour: no STALE alerts for sonnet-fleet-1, sonnet-reviewer, opus-worker-1, opus-worker-2, opus-reviewer, queue-manager, merger. Architects (opus-architect / game-architect) still tracked with the 2 h threshold.
- [ ] Architect heartbeat at >2 h triggers a STALE alert.
- [ ] Worker heartbeat freshness has zero effect on witness output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)