### PR TITLE
fleet: merger reconciles fleet:awaiting-base before the candidate filter

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -152,6 +152,43 @@ exit cleanly:
    stacked-PR check need. (Cached equivalent of the previous
    `gh pr list --state open --json number,title,mergeable,labels,headRefName,baseRefName,updatedAt`.)
 
+2.5. **Reconcile `fleet:awaiting-base` labels.** Step 3's filter
+   skips PRs carrying `fleet:awaiting-base`, but the label is only
+   removed inside sub-case ii / iii of step 5a.5 — which doesn't
+   run if the PR was skipped. Without this reconciliation pass,
+   once the merger labels a stacked PR `fleet:awaiting-base`, it
+   keeps skipping forever even after the base PR merges (the label
+   never clears). This step closes the loop.
+
+   From `repos.engine.prs[]`, collect every PR whose `labels`
+   contains `fleet:awaiting-base`. For each such PR, look up its
+   base PR's state:
+
+   `gh pr list --repo <engine-repo> --search "head:<baseRefName>" --state all --json number,state --jq '.[] | "#\(.number) \(.state)"'`
+
+   Three outcomes:
+
+   - **Base PR is OPEN** — leave the label in place; nothing to do.
+     The base hasn't landed yet.
+
+   - **Base PR is MERGED** — run the same actions as step 5a.5
+     sub-case ii (lines starting "Base PR is MERGED" below):
+     re-target this PR to master, remove `fleet:awaiting-base`,
+     remove `fleet:stacked`, post the "base merged, re-targeted"
+     comment, add `fleet:stacked-rebase`, `fleet:changes-made`,
+     `fleet:merger-cooldown`. The PR's diff against master may
+     differ from the previous review; reviewer re-evaluates next
+     pass. Log: `... reconcile: base #<N> merged, re-targeted to master`.
+
+   - **Base PR is CLOSED (not merged)** — run sub-case iii actions:
+     post the "base closed without merging" comment, remove
+     `fleet:awaiting-base`, add `fleet:needs-info` and
+     `fleet:merger-cooldown`. Log: `... reconcile: base #<N> closed (not merged), labeled fleet:needs-info`.
+
+   PRs handled here count against the "2 candidates per iteration"
+   cap in step 4 — re-targeting and label updates are write-heavy
+   and we don't want to flood the API or the reviewer queue.
+
 3. Filter to candidates. A PR is a candidate if:
    - `mergeable == "CONFLICTING"`, OR
    - `mergeable == "UNKNOWN"` AND the PR was updated > 5 minutes ago
@@ -165,7 +202,7 @@ exit cleanly:
    - `human:needs-fix` — human owes a fix; don't loop on it
    - `human:blocker` — same
    - `human:re-review` — reviewer concern; not the merger's lane
-   - `fleet:awaiting-base` — stacked PR waiting on its base to merge; skip until base merges/closes and sub-case ii/iii removes this label
+   - `fleet:awaiting-base` — stacked PR waiting on its base to merge. Step 2.5 runs first and clears this label whenever the base has merged or closed; if the label survives into step 3 it means the base is still OPEN, so skip.
    - `fleet:semantic-conflict` — already handed off to opus-worker; the
      label IS the durable cooldown and only opus-worker (or the human,
      via `human:needs-fix` escalation) clears it. Re-running rebase


### PR DESCRIPTION
## Summary

Closes a self-perpetuating-label bug in the merger lifecycle: once the merger labels a stacked PR `fleet:awaiting-base`, the label never clears even after the base PR merges, because step 3's candidate filter skips on the label and step 5a.5's sub-case ii (which would clear it) never runs.

Adds **step 2.5** between cache-load and candidate-filter: iterate every PR with `fleet:awaiting-base`, look up the base PR via `gh pr list --search head:<baseRefName>`, and run the existing sub-case ii / iii actions (re-target, swap labels, post comment) when the base is MERGED or CLOSED. PRs whose base is still OPEN keep the label.

## Why

Concrete case from production today:
- #449's base = `claude/render-light-volume-gpu` (head of #448).
- #448 merged at 2026-05-06T19:03:06Z.
- #449 last touched at 19:17:31Z (the merger's "stacked on open #448" comment), then nothing.
- Same shape on #450 (stacked behind #449).

Both sat with `fleet:awaiting-base` indefinitely after the base merged. Multiple merger iterations skipped them in step 3 with no path back into the lifecycle.

The role-doc comment at line 168 (pre-PR) said *"skip until base merges/closes and sub-case ii/iii removes this label"*, which described intent but the code path didn't deliver it: skipping in step 3 prevents the sub-case from ever running.

## Diff

One file, +38/-1 in `.claude/commands/role-merger.md`:
- New step 2.5 with three branches (OPEN / MERGED / CLOSED).
- Updated step 3's `fleet:awaiting-base` skip note to reflect the new contract: the label only survives into step 3 when the base is still OPEN.

## Test plan

- [ ] Manual: on next merger iteration after this lands, #449's base should be detected as MERGED, #449 gets re-targeted to master, `fleet:awaiting-base` removed, `fleet:stacked-rebase` + `fleet:changes-made` + `fleet:merger-cooldown` added. Same for #450 once #449 merges.
- [ ] Edge case: a PR whose `baseRefName` doesn't resolve to any PR (e.g. base branch was force-deleted directly) should hit the `gh pr list --search head:...` returning empty — log + leave label, don't crash. (Step 2.5's three outcomes don't currently cover this; if it shows up in practice we can add a fourth "base PR not found" branch.)
- [ ] Step 2.5 PRs count against step 4's 2-per-iteration cap so reconciliation doesn't flood.

## Notes for reviewer

- I considered the alternative fix (remove `fleet:awaiting-base` from step 3's skip list, let it fall through to step 5a.5 every iteration) but rejected it: sub-case i would then re-post the "waiting on base" comment every loop, spamming the PR. Would need an additional gate. Step 2.5 keeps the skip + adds the missing reconciliation path, which is a smaller change.
- Step 2.5 inlines the actions (rather than referencing sub-case ii / iii). The agent reads top-to-bottom; jumping to a sub-case mid-loop is awkward. Mild duplication for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)