### PR TITLE
rules: add .claude/rules/ with path-scoped C++ conventions

### DIFF
--- a/.claude/rules/cpp-ecs.md
+++ b/.claude/rules/cpp-ecs.md
@@ -1,0 +1,100 @@
+---
+paths:
+  - "engine/**/*.{hpp,cpp,h,cc}"
+  - "creations/**/*.{hpp,cpp,h,cc}"
+---
+
+# ECS rules: getComponent in ticks, deferred entity ops, component method tiers
+
+## The ECS footgun: never call getComponent inside a per-entity tick
+
+> **Never** call `IREntity::getComponent` or `IREntity::getComponentOptional` on a system's *own* iterating entity inside its per-entity tick function.
+
+Each call is a hash-map lookup, a linear scan of the archetype, and another hash-map lookup. At scale, it dominates the frame.
+
+The fix is mechanical: **add the component to the system's template parameters**. The data is then accessed via contiguous archetype-column iteration — array index, not random lookup.
+
+Alternatives, in order of preference:
+
+1. Include the component in `createSystem<...>` template params.
+2. Cache the data in an existing component at creation time (e.g. store the canvas entity ID in `C_VoxelSetNew` during allocation rather than looking it up every frame).
+3. Use `beginTick` / `endTick` for once-per-frame lookups.
+4. Use `relationTick` for per-parent-group lookups — fires once per unique parent entity when using `CHILD_OF` or other relation queries.
+
+## Foreign-entity lookups: contact pairs, messages, target entities
+
+The "no getComponent in tick" rule is about entities the system iterates — adding to template params is the fix. For **dynamically-determined foreign entities** (the *other* entity in a contact pair, a target entity stored in a component, a parent looked up at runtime), getComponent is sometimes the only option, but the **established pattern is to batch the foreign entities as a vector** rather than calling `getComponent` per-pair inside the tick.
+
+The right shape for collision / message / event systems:
+
+- The event component (e.g. `C_ContactEvent`) carries a vector of all involved entities or a vector of contact pairs, batched by the producing system at frame boundary.
+- The consumer system iterates the **vector**, not individual events. The relevant component data is either pre-fetched into the event itself by the producer, or looked up once per batch in `beginTick`/`endTick`, not per-entity.
+
+This pattern is **not yet uniformly applied** in the codebase. Known violation:
+
+- `engine/prefabs/irreden/update/systems/system_spring_platform.hpp:54-55` — calls `getComponentOptional<C_Velocity3D>(contact.otherEntity_)` per contact inside the tick.
+
+When refactoring collision/message systems, drive toward the batched-vector pattern. New collision systems must use it from the start.
+
+## Deferred entity operations during tick
+
+`createEntity`, `setComponent`, `removeComponent`, and `removeEntity` called mid-iteration in a per-entity tick **silently invalidate component addresses** when they trigger an archetype change. The system that's iterating may skip or revisit entities, and any captured component reference becomes wild.
+
+Use the deferred variants (`IREntity::deferredCreate`, `deferredSetComponent`, etc.) and let `flushStructuralChanges` run at the end of the pipeline.
+
+## Component method tiers
+
+A component's methods fall into three categories. Anything outside (a) and (b), and not on the documented exceptions list, is a violation.
+
+**(a) Pure data.** Fields and a constructor that initializes them. Most components in `common/`, `input/`, and tag-style components.
+
+**(b) Self-only helpers (allowed).** Methods that read or write only the component's own fields (and stack-locals derived from them). Examples:
+
+- `C_PeriodicIdle::tick()` advances its own angle.
+- `C_CanvasFogOfWar::setCell()` writes its own grid.
+- `toGPUFormat()` converts own fields into a render struct.
+
+**(c) Cross-entity reaches (forbidden).** Methods that look up *another* entity through a stored `EntityId` field via `IREntity::getComponent`, `setComponent`, `createEntity`, `setParent`, or `getEntity`.
+
+These belong in **a system** (per-frame work) or one of:
+
+- **Entity builder** — `template <> struct IREntity::Prefab<NAME>` with a `create()` that wires up the entity bundle. Example: `engine/prefabs/irreden/render/entities/entity_trixel_canvas.hpp`.
+- **Prefab-scoped namespace** — a sibling `<feature>.hpp` exposing a `namespace IRPrefab::Foo` with free functions. The namespace owns the entity-lookup logic; callers don't carry the entity id. Example: `engine/prefabs/irreden/render/fog_of_war.hpp`. Use this when an API needs an ergonomic free-function shape and the caller is unlikely to hold the entity id.
+
+The split keeps component layout trivial (good for archetype iteration) and concentrates per-entity orchestration where it belongs.
+
+### Documented exceptions to (c)
+
+These patterns *look* like (c) but are accepted because the alternatives are worse:
+
+- **GPU / IO resource RAII.** A constructor that calls `IRRender::createResource<>` and a destructor that calls `destroyResource<>` is fine — the component IS the resource owner, and splitting allocation into a system makes the lifetime contract harder to enforce. Examples: `C_TriangleCanvasTextures`, `C_TrixelFramebuffer`, `C_CanvasFogOfWar`, `C_CanvasSunShadow`, `C_CanvasAOTexture`, `C_CanvasLightVolume`.
+- **`onDestroy()` IO cleanup.** A component that hooks the entity's destroy event to flush an external side effect (e.g. `C_MidiNote::onDestroy()` sending NOTE_OFF) is fine when the cleanup must be synchronized with entity death and a per-component hook is simpler than a "scan dying entities" system. Document the side effect in the domain `CLAUDE.md`.
+- **Constructor snapshots ambient state.** A constructor that reads `IRRender::getActiveCanvasEntity()` (or similar) to bind the component to the currently-active canvas is fine — no other entity is mutated, and the alternative is forcing every caller to thread the canvas id. Examples: `C_VoxelSetNew`, `C_ShapeDescriptor`.
+
+Anything outside (a)/(b) and not on the exceptions list above is a (c) violation and should be moved to a system, builder, or namespace.
+
+## Allocations in hot tick paths
+
+Allocating memory inside a per-entity tick (`new`, `std::vector::push_back`, `std::string` concatenation, `std::map::operator[]` insertion, `std::make_unique`) is a frame-time landmine. Reserve once at `beginTick`; reuse capacity across frames; clear without releasing.
+
+If the data structure size depends on input that varies per frame, the allocation belongs in `beginTick` (with a high-water-mark `reserve`) or in `SystemParams` (where it persists between frames and only grows).
+
+## Manager accessor calls inside ticks
+
+Calling `IREntity::*`, `IRRender::*`, `IRAudio::*` accessors **inline within a tick** is fine. The rule against "holding manager pointers across frames outside World's lifetime" is about *storing* a manager pointer or reference somewhere that outlives `World`. Inline calls into the manager that finish before the tick returns are not affected.
+
+## Naming
+
+| Context           | Convention                                         |
+|-------------------|----------------------------------------------------|
+| Private members   | `m_` prefix                                        |
+| Public members    | trailing `_`                                       |
+| Components        | `C_` prefix                                        |
+| Enum values       | `SCREAMING_SNAKE_CASE`                             |
+| Compute shaders   | `c_` prefix                                        |
+| Vertex shaders    | `v_` prefix                                        |
+| Fragment shaders  | `f_` prefix                                        |
+| Geometry shaders  | `g_` prefix                                        |
+| Header helpers    | nested `detail` namespace (not anonymous, not feature-named) |
+
+Prefer descriptive names over abbreviations (`viewCenterIso` not `vcIso`). Use a lowercase `detail` namespace for header-only helpers under the owning namespace (`IRSystem::detail`, `IRRender::detail`). Don't use anonymous namespaces in headers; keep them in `.cpp`.

--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - "engine/**/*.{hpp,cpp,h,cc}"
+  - "creations/**/*.{hpp,cpp,h,cc}"
+---
+
+# Math primitives go through IRMath, never glm:: or std::
+
+Rule, with zero exceptions outside `engine/math/`:
+
+> **Never** call `glm::*`, `std::sin`, `std::cos`, `std::tan`, `std::sqrt`, `std::abs`, `std::min`, `std::max`, `std::clamp`, `std::floor`, `std::ceil`, `std::round`, `std::pow`, `std::atan2`, `std::asin`, or `std::acos` from C++ files outside `engine/math/`.
+
+The wrapper layer in [`engine/math/include/irreden/`](../../engine/math/include/irreden/) owns everything. Two reasons:
+
+1. **One place to swap implementations.** If we ever switch from glm to a faster custom path (or add a SIMD variant), it changes in `engine/math/` and every caller picks it up.
+2. **One place to encode CPU↔GPU consistency.** `IRMath::roundHalfUp` mirrors the GLSL/Metal `roundHalfUp` so half-integer positions classify the same on both sides. `glm::round` does not. Without the wrapper layer, this kind of consistency rule has to be re-asserted at every call site.
+
+## What to use instead
+
+| Don't write | Write |
+|-------------|-------|
+| `glm::vec3` / `glm::ivec3` / `glm::mat4` | `IRMath::vec3` / `IRMath::ivec3` / `IRMath::mat4` |
+| `glm::min(a, b)` / `glm::max(a, b)` | `IRMath::min(a, b)` / `IRMath::max(a, b)` |
+| `glm::clamp(v, lo, hi)` | `IRMath::clamp(v, lo, hi)` |
+| `glm::length(v)` / `glm::normalize(v)` / `glm::dot(a, b)` | `IRMath::length(v)` / `IRMath::normalize(v)` / `IRMath::dot(a, b)` |
+| `glm::sin(x)` / `glm::cos(x)` / `glm::sqrt(x)` | `IRMath::sin(x)` / `IRMath::cos(x)` / `IRMath::sqrt(x)` |
+| `glm::pi<float>()` / `glm::half_pi<float>()` / `glm::two_pi<float>()` | `IRMath::kPi` / `IRMath::kHalfPi` / `IRMath::kTwoPi` |
+| `std::min(a, b)` / `std::max(a, b)` / `std::clamp(...)` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
+| `std::sin(x)` / `std::cos(x)` / `std::abs(x)` | `IRMath::sin(x)` / `IRMath::cos(x)` / `IRMath::abs(x)` |
+
+## Iso projection: never inline the equations
+
+```
+iso.x = -x + y
+iso.y = -x - y + 2z
+distance = x + y + z
+```
+
+Always call the named helpers — never inline these equations in system code:
+
+- `IRMath::pos3DtoPos2DIso(pos3D)` — projection
+- `IRMath::pos3DtoPos2DScreen(pos3D)` — projection scaled + sign-flipped for screen coords (backend-aware)
+- `IRMath::pos3DtoDistance(pos3D)` — depth scalar
+- `IRMath::isoDepthShift(pos, d)` — shift depth without affecting 2D projection
+
+One place to fix a coordinate-system bug.
+
+## When the wrapper doesn't exist yet
+
+If you need a primitive `IRMath` doesn't expose, **add the wrapper to `engine/math/` first**, then call it. Don't reach for `glm::` "just for now" — that's the path that produced the 164 violations this rule exists to clean up.
+
+The math library may itself wrap `glm::*` / `std::*` internally — that is the **only** place those names should appear.
+
+## Allowlist (do NOT flag these)
+
+- Anything in `engine/math/**` itself.
+- The graphics-backend interop layer at `engine/render/include/irreden/render/backend/**` — when wiring an actual `glm` value into a `glDrawElements`-shaped API, raw glm types are the surface.
+- Shader source: `*.glsl`, `*.metal`. These have their own native math; the rule is about C++ files.
+
+## Live deviations (queue-manager-owned)
+
+The current list of files still calling `glm::*` outside the allowlist lives in `.fleet/status/glm-deviations.md` (or will, once it's introduced — track via a follow-up task). Don't add new violations; do migrate when you're already touching one of the deviation files.

--- a/.claude/rules/cpp-systems.md
+++ b/.claude/rules/cpp-systems.md
@@ -1,0 +1,92 @@
+---
+paths:
+  - "engine/prefabs/**/system_*.{hpp,cpp}"
+  - "engine/system/**"
+  - "creations/**/system_*.{hpp,cpp}"
+---
+
+# System state lives in SystemParams, never function-local static
+
+Rule:
+
+> **Never** use function-local `static` for *mutable* or *system-owned* state inside a system tick or its `create()` function. Use `SystemParams` instead.
+
+Allowed: `static constexpr`, `static const` for genuine compile-time constants. Those are program constants, not system state.
+
+## Why this matters
+
+Function-local `static` for system state is broken on four axes:
+
+1. **Hidden state** — not visible to ECS inspectors, system-walking tools, or anyone reading the prefab catalog.
+2. **Lifetime mismatch** — persists for program lifetime, doesn't free when the system entity is destroyed. Every reload leaks.
+3. **Single-instance assumption** — all instances of `System<X>` share the same statics. Multi-instance use silently cross-talks.
+4. **Conflicts with the ECS philosophy** — "everything on an entity" is the design; statics are the back door.
+
+The performance argument doesn't hold either: `SystemParams` has the same per-tick access cost as `static`. Capture the params pointer once at `create()` time, pass it into lambdas by value — the pointer lookup happens once, not per tick.
+
+## Canonical SystemParams pattern
+
+```cpp
+SystemId create() {
+    auto paramsOwner = std::make_unique<MyParams>();
+    auto* p = paramsOwner.get();    // capture raw ptr before move
+    SystemId myId = createSystem<...>(
+        "Name",
+        [p](C_Foo& foo) { p->bar += foo.x; },
+        [p]()           { p->bar = 0.0f; },
+        [p]()           { /* end-of-tick using p */ }
+    );
+    setSystemParams(myId, std::move(paramsOwner));
+    return myId;
+}
+```
+
+Notes:
+
+- Allocate a `std::make_unique<MyParams>()`, capture its `.get()` pointer **before** the move.
+- The lambdas capture `p` by value. `p` outlives the lambdas because `setSystemParams` transfers ownership to the system entity.
+- The system entity owns the params; both are destroyed together when the system is destroyed.
+- **Don't store raw references to params across frames** — if the system is recreated (e.g. via reload), the pointer is invalid.
+
+## Three valid TICK function signatures
+
+`createSystem<Components...>` detects the signature at compile time via `std::is_invocable_v<>`:
+
+```cpp
+// 1. Per-component (most common — pick this by default)
+createSystem<C_Velocity3D, C_VelocityDrag>(
+    "VelocityDrag",
+    [](C_Velocity3D& velocity, C_VelocityDrag& drag) {
+        // deltaTime(UPDATE) is the tick's dt
+    });
+
+// 2. Per-entity-id (when the system truly needs the entity id)
+createSystem<C_NavAgent, C_MoveOrder>(
+    "GridPathfind",
+    [](EntityId id, C_NavAgent& agent, C_MoveOrder& order) { ... });
+
+// 3. Per-archetype / batch (bulk-processing, SIMD, sort, partition)
+createSystem<C_NavAgent>(
+    "GridBake",
+    [](const Archetype& arch,
+       std::vector<EntityId>& ids,
+       std::vector<C_NavAgent>& agents) { ... });
+```
+
+## beginTick / endTick contract
+
+- `functionBeginTick` fires **once per pipeline execution** before any per-entity ticks. **Signature: `void()`.** No `Archetype&`, no component params. Good for frame-scoped setup.
+- `functionEndTick` fires once after all per-entity ticks. **Same `void()` signature.** Good for teardown, GPU upload, swap.
+- **Begin/End tick runs even if zero entities match.** Check `ids.size()` yourself if you care.
+- `functionRelationTick` fires per-parent when using `RelationParams<...>`. Takes an `EntityRecord` so you can walk the relation.
+
+## Live deviations
+
+Files that still use function-local `static` for system-owned state are tracked in `.fleet/status/system-static-deviations.md` (queue-manager-owned). Don't add new violations; migrate when you're already touching one of the listed files. **Active known violations as of this rule landing:**
+
+- `engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp:41-43` — `getInstances()` returns a function-local static `std::vector<CanvasInstance>&`.
+- `engine/prefabs/irreden/audio/systems/system_rhythmic_launch.hpp:29` — static unordered_map for platform cache.
+- `engine/prefabs/irreden/update/systems/system_gravity.hpp:17` — static singleton instance.
+- `engine/prefabs/irreden/update/systems/system_animation_color.hpp:25-26` — two static animation clip caches.
+
+Each should be migrated to `SystemParams`. Refactor when touching the file for other reasons; don't delay other work to migrate aggressively.

--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,11 @@ creations/*
 !creations/demos/
 !creations/demos/**
 
-# claude code: share skills + role slash commands, ignore worktrees and local session state
+# claude code: share skills + roles + path-scoped rules, ignore worktrees and local session state
 .claude/*
 !.claude/skills/
 !.claude/skills/**
 !.claude/commands/
 !.claude/commands/**
+!.claude/rules/
+!.claude/rules/**


### PR DESCRIPTION
## Summary
- Adds [`.claude/rules/`](.claude/rules/) with three path-scoped rule files using Anthropic's `paths:` frontmatter mechanism. Each rule loads ONLY when Claude reads files matching the glob, so non-C++ edits don't pay context for them.
- Updates `.gitignore` to allowlist `.claude/rules/` alongside `skills/` and `commands/`.
- Codifies the four convention conflict decisions just made by the user.

## Files added

- [`cpp-math.md`](.claude/rules/cpp-math.md) (62 lines, paths: `engine/**/*.{hpp,cpp,h,cc}`, `creations/**/*.{hpp,cpp,h,cc}`) — IRMath rule with strict scope. Includes the alias table, isometric projection helpers, "add the wrapper first" workflow, and allowlist.
- [`cpp-systems.md`](.claude/rules/cpp-systems.md) (92 lines, paths: `engine/prefabs/**/system_*.{hpp,cpp}`, `engine/system/**`, `creations/**/system_*.{hpp,cpp}`) — SystemParams rule, canonical pattern, three valid tick signatures, beginTick/endTick contract, **live deviations list** (4 known files).
- [`cpp-ecs.md`](.claude/rules/cpp-ecs.md) (100 lines, paths: `engine/**/*.{hpp,cpp,h,cc}`, `creations/**/*.{hpp,cpp,h,cc}`) — ECS footgun (no per-entity getComponent in tick), **foreign-entity batched-vector pattern** for collisions/messages, deferred entity ops, component method tiers (a/b/c) with documented exceptions, allocations in hot paths, naming.

## Conflict decisions encoded

- **#1 (canvas static)**: `system_entity_canvas_to_framebuffer.hpp:41-43` listed in `cpp-systems.md` as a live deviation pending migration. **No grandfather, no carve-out.**
- **#2+#3 (glm:: scope)**: **Strict rule**. The doc now expects `IRMath::kPi`/`kHalfPi`/`kTwoPi` constants — these need to land in `engine/math/` as a follow-up before the violations can be migrated cleanly. Rule remains absolute: never `glm::*` or `std::sin/cos/sqrt/abs/min/max/clamp` outside `engine/math/`.
- **#4 (foreign getComponent)**: Rule clarified. Per-entity getComponent on the system's *own* iterating entity is forbidden (template params is the fix). Per-entity getComponent on a *dynamically-determined foreign entity* (contact pairs, messages) is allowed BUT the established pattern is to batch as a vector. `system_spring_platform.hpp:54-55` listed as a known violation.

## Why path-scoped rules?

Per Anthropic's published guidance, rules with `paths:` frontmatter only load when Claude reads matching files. Two practical wins:

1. **Zero context cost for non-C++ work.** A doc edit, Lua script, or Markdown PR doesn't pay for the C++ convention rules.
2. **Rule fires close to where violations happen.** Every `.hpp`/`.cpp` open auto-loads the relevant rule, so the model sees the IRMath/SystemParams/ECS reminder right next to the code being edited. No reliance on the agent remembering to read CLAUDE-BASELINE.

## Test plan
- [ ] Open a `.hpp` file in `engine/prefabs/irreden/render/`. Confirm via `/memory` that all three `cpp-*.md` rules are loaded.
- [ ] Open a `.lua` file or this PR's body in markdown. Confirm `cpp-*.md` rules are NOT loaded.
- [ ] Skim `cpp-systems.md` deviations list — 4 files explicitly named: canvas-to-framebuffer, rhythmic-launch, gravity, animation-color.

## Notes for reviewer

This is the first of three PRs that codify the convention conflict decisions. Follow-ups in the queue:
- **PR 7** — add convention capsules to `engine/prefabs/CLAUDE.md` and the four highest-violation domain CLAUDE.md files (prefabs/render, prefabs/update, prefabs/voxel, prefabs/audio).
- **PR 8** — add `glm::` and static-in-tick grep checks to the `simplify` skill.

The IRMath constants (`kPi`, `kHalfPi`, `kTwoPi`) are referenced by the rule but don't yet exist in `engine/math/`. Adding them is a separate small follow-up issue I'll file. Until then, the violations in `render/camera.hpp` and `component_camera_yaw.hpp` should NOT be migrated — wait for the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)