### PR TITLE
prefabs: promote IRMath/SystemParams/ECS rules into Hard rules section

### DIFF
--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -5,6 +5,33 @@ domain under `engine/prefabs/irreden/`. Everything here is compiled by whoever
 includes it — there is no prefab .cpp. Keep headers lean; heavy logic belongs
 in `engine/<module>/src/`.
 
+## Hard rules (read before editing)
+
+Two redlines that get violated most often when adding prefab systems and
+components. The full reasoning, allowlists, and canonical patterns live in
+[`.claude/rules/cpp-math.md`](../../.claude/rules/cpp-math.md),
+[`.claude/rules/cpp-systems.md`](../../.claude/rules/cpp-systems.md), and
+[`.claude/rules/cpp-ecs.md`](../../.claude/rules/cpp-ecs.md) — those auto-load
+when you open any C++ file. The capsules here are reminders.
+
+- **Math primitives go through IRMath.** Never `glm::*` or
+  `std::sin/cos/sqrt/abs/min/max/clamp` outside `engine/math/`.
+  Use `IRMath::vec3` not `glm::vec3`, `IRMath::clamp` not `std::clamp`,
+  `IRMath::kPi` not `glm::pi<float>()`. Need a primitive that isn't
+  there? Add the wrapper to `engine/math/` first, then call it.
+- **System state lives in `SystemParams`.** Never function-local
+  `static` for mutable or system-owned state — `static constexpr` /
+  `static const` for genuine compile-time constants is fine. Capture
+  the `SystemParams` pointer once in `create()`, pass into lambdas by
+  value (same per-tick cost). The full canonical pattern lives in
+  [`engine/system/CLAUDE.md`](../system/CLAUDE.md) and
+  [`.claude/rules/cpp-systems.md`](../../.claude/rules/cpp-systems.md).
+- **No per-entity `getComponent` inside a system tick.** Add the
+  component to the system's template parameters instead. Foreign-entity
+  lookups for collisions/messages should batch the entities as a vector
+  rather than per-call inside the tick — see
+  [`.claude/rules/cpp-ecs.md`](../../.claude/rules/cpp-ecs.md).
+
 ## Layout
 
 ```

--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -7,7 +7,7 @@ in `engine/<module>/src/`.
 
 ## Hard rules (read before editing)
 
-Two redlines that get violated most often when adding prefab systems and
+Three rules that get violated most often when adding prefab systems and
 components. The full reasoning, allowlists, and canonical patterns live in
 [`.claude/rules/cpp-math.md`](../../.claude/rules/cpp-math.md),
 [`.claude/rules/cpp-systems.md`](../../.claude/rules/cpp-systems.md), and


### PR DESCRIPTION
## Summary
- Adds a top-of-file "Hard rules" section to [`engine/prefabs/CLAUDE.md`](engine/prefabs/CLAUDE.md) (line 9, right after the intro).
- Three short capsules covering the most-violated rules: IRMath usage, SystemParams over function-local static, and the ECS getComponent footgun.
- Each capsule links to the full deep-dive in `.claude/rules/cpp-{math,systems,ecs}.md` (added in #471) and to the canonical patterns in `engine/system/CLAUDE.md`.

## Why

`engine/prefabs/CLAUDE.md` auto-loads whenever Claude opens any file under `engine/prefabs/` — that's the single highest-leverage doc location for prefab-author agents. Previously the rules were either:

- **At the bottom of the same file** (line 131+, in the Anti-patterns list) — most agents don't scroll that far.
- **In CLAUDE-BASELINE** — referenced but not auto-loaded; many agents miss it.

Surfacing them at the top puts the redlines in the agent's first ~30 lines of prefab context.

## What's NOT being added

- Per-domain capsules in `engine/prefabs/irreden/{render,update,voxel,audio}/CLAUDE.md` — skipped because Claude Code auto-loads the full ancestor chain (so the umbrella `engine/prefabs/CLAUDE.md` already loads when an agent edits a file under any domain). Adding duplicate capsules per domain would just be busywork.
- The existing Anti-patterns list at the bottom — left intact as the thorough catalog. The top capsule is the high-salience reminder; the bottom is the lookup.

## Stacking

This PR depends on #471 (`.claude/rules/cpp-*.md`) for the link targets to resolve. If they don't merge in order, the links to `.claude/rules/` will resolve only after #471 lands. The PR-7 capsule is still useful standalone (it includes the rule text itself, not just a pointer).

## Test plan
- [ ] Open any file under `engine/prefabs/irreden/`. Confirm via `/memory` that `engine/prefabs/CLAUDE.md` is in the loaded context with the new Hard rules section visible at the top.
- [ ] After #471 lands, click through the `.claude/rules/cpp-*.md` references — they resolve.

## Notes for reviewer

Part of the agent docs overhaul plan at `~/.claude/plans/i-think-we-really-merry-hejlsberg.md`. Last of the three convention-codification PRs (along with #471 for `.claude/rules/` and an upcoming PR for `simplify` grep checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)