### PR TITLE
fleet: re-exec fleet-dispatcher under bash >= 4

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -32,6 +32,23 @@
 # Source of truth: scripts/fleet/fleet-dispatcher in the engine repo.
 # Installed to ~/bin/fleet-dispatcher by scripts/fleet/install.sh.
 
+# Re-exec under bash >= 4 if the resolved interpreter is older. macOS
+# ships /bin/bash 3.2 (last GPLv2 release); env-resolved `bash` lands
+# there when no Homebrew bash is installed. This script uses bash 4
+# associative arrays (declare -A), which 3.2 silently mis-parses under
+# `set -u` as `<key>: unbound variable`. Fail loudly with an actionable
+# message instead.
+if (( BASH_VERSINFO[0] < 4 )); then
+    for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        if [[ -x "$_candidate" ]] && "$_candidate" -c '(( BASH_VERSINFO[0] >= 4 ))' 2>/dev/null; then
+            exec "$_candidate" "$0" "$@"
+        fi
+    done
+    echo "fleet-dispatcher: requires bash >= 4 (found ${BASH_VERSION})." >&2
+    echo "  Install a newer bash, e.g.: brew install bash" >&2
+    exit 1
+fi
+
 set -euo pipefail
 
 # --- Paths -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- macOS \`/bin/bash\` is 3.2 (last GPLv2 release). \`fleet-dispatcher\`'s shebang \`#!/usr/bin/env bash\` resolves to it when no Homebrew bash is installed; under \`set -u\` 3.2 mis-parses \`declare -A\` array literals as \`<key>: unbound variable\` and the dispatcher crashes on its first scout trigger.
- Result on a fresh macOS \`fleet-up\`: only the architects (started directly by \`fleet-babysit\`) run. Every worker/reviewer/queue-manager/merger pane sits idle at \`zsh\` because the dispatcher exited before launching any \`claude\` invocation.
- Add a tiny version guard at the top of the script: re-exec under \`/opt/homebrew/bin/bash\` or \`/usr/local/bin/bash\` if the resolved interpreter is < 4; otherwise print an actionable \`brew install bash\` hint and exit 1. No-op on Linux/WSL.

## Repro

\`\`\`
$ /bin/bash -c 'set -u; declare -A foo=(["a"]="b")'
/bin/bash: a: unbound variable
\`\`\`

Observed log (\`~/.fleet/logs/dispatcher.log\`, single line):

\`\`\`
/Users/.../bin/fleet-dispatcher: line 64: sonnet: unbound variable
\`\`\`

\`fleet-state-scout\` fires triggers normally; only the dispatcher half of the loop is broken.

## Test plan

- [x] On bash 3.2: \`/bin/bash scripts/fleet/fleet-dispatcher\` prints \`requires bash >= 4 ... brew install bash\` and exits 1
- [x] \`/bin/bash -n scripts/fleet/fleet-dispatcher\` (syntax check) passes
- [ ] On a Linux/WSL host with bash 5.x: \`fleet-up live\` → dispatcher launches workers normally (no behavior change)
- [ ] On macOS with \`brew install bash\`: \`fleet-up live\` → dispatcher re-execs under Homebrew bash and the worker panes start firing

## Notes for reviewer

Narrow scope: 17 lines added before \`set -euo pipefail\`. The body of the script is unchanged — re-exec keeps the bash 4 syntax that's already there rather than rewriting the two associative arrays as case statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)