### PR TITLE
simplify: add grep checks for glm:: and static-in-tick

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -108,8 +108,8 @@ This pass catches what slipped through.
 
 **Check 1: `glm::` and `std::` math calls outside the allowlist.**
 
-Run a grep against the staged diff lines, scoped to C++ files outside
-the allowed surfaces. The Grep tool is allowlisted; use it directly:
+Run a grep against all in-scope C++ files (catches both new and existing
+violations). The Grep tool is allowlisted; use it directly:
 
 ```
 Grep tool with:
@@ -146,16 +146,22 @@ suggesting.)
 
 **Check 2: function-local `static` in system tick files.**
 
-Scan added lines (`+` lines from `git diff -U0`) in system files for
-`static` declarations that are NOT `static constexpr` or `static const`.
+Use Grep to scan system files for `static` declarations that are NOT
+`static constexpr` or `static const`, then cross-reference the hits
+against `git diff` added lines to confirm the match is newly introduced.
 
 ```
 Grep tool with:
-  pattern: '^\+\s*static\s+(?!constexpr|const\s+)'
+  pattern: '\bstatic\b(?!\s+constexpr)(?!\s+const\b)'
   glob:    '{engine/prefabs/irreden/**/system_*.{hpp,cpp},engine/system/**/*.{hpp,cpp},creations/**/system_*.{hpp,cpp}}'
   output_mode: 'content'
   -n: true
 ```
+
+Filter the Grep results to lines that also appear as `+` lines in
+`git diff --unified=0` for the same file — those are the newly added
+violations. Lines that exist on both sides (pre-existing code) belong
+to the live-deviation list and should only be noted, not re-flagged.
 
 For each hit, suggest the canonical `SystemParams` migration pattern:
 

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -98,6 +98,92 @@ Also flag (don't auto-fix):
 - `endTick` body that reads `ids[0]` or indexes `ids` without first
   guarding `ids.size() == 0`.
 
+### 2b. Math primitives + system-state smells (mechanically detectable)
+
+Two convention slips that are pure regex catches. Both are documented in
+[`.claude/rules/cpp-math.md`](../../rules/cpp-math.md) and
+[`.claude/rules/cpp-systems.md`](../../rules/cpp-systems.md) — those rules
+auto-load whenever an agent opens a C++ file, but agents still slip.
+This pass catches what slipped through.
+
+**Check 1: `glm::` and `std::` math calls outside the allowlist.**
+
+Run a grep against the staged diff lines, scoped to C++ files outside
+the allowed surfaces. The Grep tool is allowlisted; use it directly:
+
+```
+Grep tool with:
+  pattern: '\b(glm::|std::(sin|cos|tan|sqrt|abs|min|max|clamp|floor|ceil|round|pow|atan2|asin|acos))\b'
+  glob:    '**/*.{hpp,cpp,h,cc}'
+  output_mode: 'files_with_matches'
+```
+
+For each hit, manually exclude paths in the allowlist (do not flag):
+
+- `engine/math/**` — IRMath itself wraps these names internally.
+- `engine/render/include/irreden/render/backend/**` — backend interop
+  may pass raw glm types into graphics APIs.
+- `*.glsl` / `*.metal` files (the grep glob excludes these, but
+  double-check).
+
+For everything else, flag with the IRMath equivalent. Common substitutions:
+
+| Found | Suggest |
+|-------|---------|
+| `glm::vec3` / `glm::ivec3` / `glm::mat4` | `IRMath::vec3` / `IRMath::ivec3` / `IRMath::mat4` |
+| `glm::min` / `glm::max` / `glm::clamp` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
+| `glm::length` / `glm::normalize` / `glm::dot` | `IRMath::length` / `IRMath::normalize` / `IRMath::dot` |
+| `glm::sin` / `glm::cos` / `glm::sqrt` | `IRMath::sin` / `IRMath::cos` / `IRMath::sqrt` |
+| `glm::pi<float>()` / `glm::half_pi<float>()` / `glm::two_pi<float>()` | `IRMath::kPi` / `IRMath::kHalfPi` / `IRMath::kTwoPi` |
+| `std::min` / `std::max` / `std::clamp` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
+| `std::sin` / `std::cos` / `std::sqrt` / `std::abs` | `IRMath::sin` / `IRMath::cos` / `IRMath::sqrt` / `IRMath::abs` |
+
+If the IRMath wrapper does not exist yet, **don't auto-substitute** —
+flag with: "IRMath::<name> does not exist; add the wrapper to
+`engine/math/` first, then call it." (The `IRMath::kPi` / `kHalfPi` /
+`kTwoPi` constants in particular may not be merged yet — verify before
+suggesting.)
+
+**Check 2: function-local `static` in system tick files.**
+
+Scan added lines (`+` lines from `git diff -U0`) in system files for
+`static` declarations that are NOT `static constexpr` or `static const`.
+
+```
+Grep tool with:
+  pattern: '^\+\s*static\s+(?!constexpr|const\s+)'
+  glob:    '{engine/prefabs/irreden/**/system_*.{hpp,cpp},engine/system/**/*.{hpp,cpp},creations/**/system_*.{hpp,cpp}}'
+  output_mode: 'content'
+  -n: true
+```
+
+For each hit, suggest the canonical `SystemParams` migration pattern:
+
+> Replace `static <T> name;` with a `SystemParams` field. Capture the
+> params pointer once at `create()` time and pass into the lambdas by
+> value. See [`.claude/rules/cpp-systems.md`](../../rules/cpp-systems.md)
+> "Canonical SystemParams pattern" or
+> [`engine/system/CLAUDE.md`](../../../engine/system/CLAUDE.md) for the
+> canonical example.
+
+Live deviations already on the list (don't re-flag, but note in the
+report if touched):
+
+- `engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp:41-43`
+- `engine/prefabs/irreden/audio/systems/system_rhythmic_launch.hpp:29`
+- `engine/prefabs/irreden/update/systems/system_gravity.hpp:17`
+- `engine/prefabs/irreden/update/systems/system_animation_color.hpp:25-26`
+
+These are tracked in `.fleet/status/system-static-deviations.md` (or
+will be once it's introduced). Don't add new violations; do migrate
+when touching one of the deviation files for other reasons.
+
+**Check 3: `std::cout` / `printf` instead of the engine logger.**
+
+Already covered by section 6 (Reuse opportunities) — left here only as
+a cross-reference. The engine has `IRE_LOG_*` and `IR_LOG_*` macros;
+raw stdout/printf in non-debug code is a cleanup target.
+
 ### 3. Naming convention slips
 
 These are the rules from the top-level `CLAUDE.md`:


### PR DESCRIPTION
## Summary
- Adds a new section [2b. Math primitives + system-state smells](.claude/skills/simplify/SKILL.md) to the [`simplify`](.claude/skills/simplify/SKILL.md) skill.
- Two mechanically-detectable greps:
  1. `glm::*` / `std::sin/cos/sqrt/abs/min/max/clamp/etc.` outside `engine/math/`, `engine/render/include/irreden/render/backend/**`, and shader files.
  2. Function-local `static` (excluding `static constexpr`/`static const`) in system files under `engine/prefabs/**/system_*`, `engine/system/**`, and `creations/**/system_*`.
- Each check has a substitution table (what to replace the violation with) and references the deep-dive in `.claude/rules/cpp-{math,systems}.md`.

## Why

The `.claude/rules/` files (added in #471) auto-load when an agent opens a C++ file, so the rule is in context **at write time**. But agents still slip — they reach for `glm::clamp` because it's faster to type than checking for the wrapper. This pass catches what slipped through, **before the PR opens**.

Per the extension framework in the planning doc, this is the "high frequency + greppable → both rule (C/D) AND simplify (E)" pattern: the rule prevents the common case in context, simplify is the safety net.

## What this PR does NOT change

- Doesn't auto-fix anything. Both checks suggest the substitution but flag for human/agent review — there are legitimate edge cases (the IRMath constants `kPi`/`kHalfPi`/`kTwoPi` may not be merged yet; `static` in a free function inside a `.cpp` may be intentional).
- Doesn't introduce a hook. The user's earlier preference was post-hoc simplify-only enforcement, no write-time hook. That decision still stands.

## Live deviations noted

The simplify check explicitly knows about the four files on the SystemParams-deviation list (canvas-to-framebuffer, rhythmic-launch, gravity, animation-color) and avoids re-flagging them as churn. They're tracked centrally in `.fleet/status/system-static-deviations.md` (which is queue-manager-owned).

## Test plan
- [ ] Make a deliberate violation (`glm::clamp(v, 0, 1)` in a non-allowlisted file). Run `simplify`. Confirm it's flagged with the `IRMath::clamp` suggestion.
- [ ] Make a `static std::vector<int> cache;` inside a function in `engine/prefabs/irreden/audio/systems/system_test.hpp`. Run `simplify`. Confirm it's flagged with the SystemParams pattern suggestion.
- [ ] Run `simplify` on a clean diff in `engine/math/`. Confirm no false positives (the allowlist excludes `engine/math/**`).

## Notes for reviewer

Last of the three convention-codification PRs:
- #471 — `.claude/rules/cpp-{math,systems,ecs}.md` (in-context at write time)
- #472 — top-of-file Hard rules section in `engine/prefabs/CLAUDE.md` (high-salience reminder)
- This PR — `simplify` post-hoc enforcement (catches what slipped through)

After all three land, the framework is in place to catch a slipping convention at three different points in the workflow. Future conventions slot into the same A-F decision tree from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)