### PR TITLE
agents: expose role-* slash commands as subagents via symlinks

### DIFF
--- a/.claude/agents/role-merger.md
+++ b/.claude/agents/role-merger.md
@@ -1,0 +1,1 @@
+../commands/role-merger.md

--- a/.claude/agents/role-opus-architect.md
+++ b/.claude/agents/role-opus-architect.md
@@ -1,0 +1,1 @@
+../commands/role-opus-architect.md

--- a/.claude/agents/role-opus-reviewer.md
+++ b/.claude/agents/role-opus-reviewer.md
@@ -1,0 +1,1 @@
+../commands/role-opus-reviewer.md

--- a/.claude/agents/role-opus-worker.md
+++ b/.claude/agents/role-opus-worker.md
@@ -1,0 +1,1 @@
+../commands/role-opus-worker.md

--- a/.claude/agents/role-queue-manager.md
+++ b/.claude/agents/role-queue-manager.md
@@ -1,0 +1,1 @@
+../commands/role-queue-manager.md

--- a/.claude/agents/role-sonnet-author.md
+++ b/.claude/agents/role-sonnet-author.md
@@ -1,0 +1,1 @@
+../commands/role-sonnet-author.md

--- a/.claude/agents/role-sonnet-reviewer.md
+++ b/.claude/agents/role-sonnet-reviewer.md
@@ -1,0 +1,1 @@
+../commands/role-sonnet-reviewer.md

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -1,4 +1,5 @@
 ---
+name: role-merger
 description: Merger orchestrator — auto-resolves mechanical PR conflicts, labels semantic ones for the human
 ---
 

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -1,4 +1,5 @@
 ---
+name: role-opus-architect
 description: Opus architect — engine core design and heavy ECS/render work
 ---
 

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -1,4 +1,5 @@
 ---
+name: role-opus-reviewer
 description: Opus final reviewer — Opus recheck pass on PRs flagged by Sonnet
 ---
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -1,4 +1,5 @@
 ---
+name: role-opus-worker
 description: Opus worker — plans fleet:needs-plan issues and picks opus-tagged tasks from TASKS.md
 ---
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -1,4 +1,5 @@
 ---
+name: role-queue-manager
 description: Queue manager — categorize, tag, and file new tasks into TASKS.md via PR
 ---
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -1,4 +1,5 @@
 ---
+name: role-sonnet-author
 description: Sonnet author — picks bounded tasks from TASKS.md and opens PRs
 ---
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -1,4 +1,5 @@
 ---
+name: role-sonnet-reviewer
 description: Sonnet first-pass PR reviewer — polls open PRs and posts structured reviews
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ creations/*
 !creations/demos/
 !creations/demos/**
 
-# claude code: share skills + roles + path-scoped rules, ignore worktrees and local session state
+# claude code: share skills + roles + path-scoped rules + worker subagents, ignore worktrees and local session state
 .claude/*
 !.claude/skills/
 !.claude/skills/**
@@ -46,3 +46,5 @@ creations/*
 !.claude/commands/**
 !.claude/rules/
 !.claude/rules/**
+!.claude/agents/
+!.claude/agents/**


### PR DESCRIPTION
## Summary
- Adds `.claude/agents/role-*.md` symlinks that point at the canonical [`.claude/commands/role-*.md`](.claude/commands/) files. Each role is now invokable two ways:
  - `/role-opus-worker live` (slash command — what the fleet uses)
  - `claude --agent role-opus-worker` (subagent — main session takes on that role's system prompt)
- Adds the required `name:` field to each role file's frontmatter (unique identifier required for subagent loading; ignored by the slash command parser).
- Updates `.gitignore` to allowlist `.claude/agents/` alongside skills/, commands/, rules/.

## Strictly additive

- **Fleet-dispatcher invocation path is untouched.** `scripts/fleet/fleet-dispatcher`, `fleet-up`, and `fleet-claude-stream` keep using `/role-X` slash commands. No fleet script changes.
- **Single source of truth.** Symlinks mean any edit to a `.claude/commands/role-*.md` file is reflected in `.claude/agents/` automatically. No content duplication.
- **No tools:/model: restrictions** on the subagent forms — they inherit the parent's tools and model. Per-role restrictions are a deliberate punt; that's a future enhancement once the user has weighed in on which roles get which tool allowlist.

## Why bother

- Per Anthropic's published architecture, "subagent" is the right word for what the fleet roles ARE: a configured AI assistant with a system prompt, optional tool restrictions, optional model assignment, optional memory directory. Slash commands are user-typed shortcuts; subagents are the canonical mechanism for personas.
- `claude --agent role-X` gives a cleaner human invocation path for ad-hoc *"be the merger for a sec"* interactive use.
- Future enhancements (per-role tool restrictions, per-role model, preloaded skills, persistent memory, frontmatter hooks) become available the moment they're useful, without further structural rework. The frontmatter is already a valid subagent shape.

## What this PR does NOT do

- **Does not migrate fleet-dispatcher to use `claude --agent`.** That's a stage-2 PR. Once you validate this stage works (try `claude --agent role-merger` interactively, confirm it loads the merger system prompt), I can update the fleet scripts to drop the slash-command path entirely. Until then both paths coexist.
- **Does not assign `tools:` / `model:` per role.** Each role would get a different decision (reviewer probably no Edit; merger probably no PR commits; architect probably Opus model; sonnet roles probably Sonnet model). Wants user input on the matrix.
- **Does not add `memory:` / `hooks:` / `skills:` frontmatter.** Nice-to-haves, not required.

## Symlink portability note

Git tracks the entries as mode 120000 (symlink). Runs cleanly on macOS and Linux. Windows users running Claude Code from the WSL clone (which is the fleet's primary host per `docs/agents/BUILD.md`) are also fine — WSL handles symlinks natively. If a Windows-native Claude Code session ever needs to load these as subagents, the symlinks may not resolve and we'd want to switch to a different mechanism (e.g. duplicate content with a "kept in sync via CI" check). Flag if that comes up.

## Test plan
- [ ] `claude agents` lists all 7 role-* subagents.
- [ ] `claude --agent role-merger` opens a session whose system prompt header shows the merger persona.
- [ ] `/role-merger live` from a regular Claude session still works (the slash command path is unchanged).
- [ ] Editing `.claude/commands/role-merger.md` and reloading via `claude --agent role-merger` shows the edit (symlink resolves correctly).

## Stage-2 follow-up

After this lands and is validated, the next PR would:

1. Update `scripts/fleet/fleet-dispatcher` (line 206) to emit `claude --model %q --effort %q --print --agent role-%s "live"` instead of `claude --model %q --effort %q --print "/role-%s live"`.
2. Update `scripts/fleet/fleet-up` (line 530) similarly.
3. Either keep `.claude/commands/role-*.md` as canonical (and drop the slash command invocation from fleet) or convert the symlinks to point the other direction (`commands/` → `agents/`).
4. Add `tools:` and `model:` to each role file with the per-role matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)