### PR TITLE
fleet: dedupe fleet-dispatcher log lines

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -98,11 +98,17 @@ declare -A ROLE_EFFORT=(
 )
 
 # --- Logging ---------------------------------------------------------------
+#
+# Writes to stderr only. fleet-up nohups the dispatcher with
+# `>>"$dispatcher_log" 2>&1`, so the redirect is the sole file
+# writer — `tee -a "$LOG_FILE"` here would double every line. When
+# the dispatcher is run manually for debugging, stderr lands on the
+# operator's tty as expected.
 
 log() {
     local ts
     ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-    printf '[%s dispatcher] %s\n' "$ts" "$*" | tee -a "$LOG_FILE" >&2
+    printf '[%s dispatcher] %s\n' "$ts" "$*" >&2
 }
 
 # --- Shutdown handling -----------------------------------------------------


### PR DESCRIPTION
## Summary

Every line in `~/.fleet/logs/dispatcher.log` was being written twice. The dispatcher's `log()` function pipes printf through `tee -a "$LOG_FILE" >&2`, but `fleet-up` launches the dispatcher under `nohup ... >>"$dispatcher_log" 2>&1`, so:

- `tee -a` writes one copy directly to the log file.
- `tee`'s stdout (redirected to stderr by `>&2`) lands in fleet-up's `2>&1` capture, which appends a second copy to the same file.

Drop the tee; let fleet-up's redirect be the sole writer.

## Repro

Observed on a clean fleet-up after PR #473 landed:

```
[2026-05-07T06:37:08Z dispatcher] started (pid=75700, interval=30s)
[2026-05-07T06:37:08Z dispatcher] started (pid=75700, interval=30s)
[2026-05-07T06:37:38Z dispatcher] dispatching sonnet-author -> %0
[2026-05-07T06:37:38Z dispatcher] dispatching sonnet-author -> %0
...
```

Same PID, same timestamp — single process double-writing.

## Test plan

- [x] `bash -n scripts/fleet/fleet-dispatcher` passes
- [ ] Next `fleet-up live`: each event appears once in `dispatcher.log`
- [ ] Standalone run (`fleet-dispatcher`) still emits log output on stderr

## Notes for reviewer

The `LOG_FILE` variable is intentionally kept (definition + the `mkdir -p "$(dirname "$LOG_FILE")"` in `init_state()`) so a standalone run still creates the log directory. The variable is now referenced only by that mkdir and the explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)