### PR TITLE
fleet: sweep stale triggers in fleet-up before scout starts

### DIFF
--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -347,6 +347,28 @@ mkdir -p "$HOME/.fleet/alerts"
 # failure mode.
 rm -f "${FLEET_SHUTDOWN_FLAG:-$HOME/.fleet/shutdown-in-progress}"
 
+# Sweep stale trigger files from prior fleet sessions. The scout
+# writes ~/.fleet/state/triggers/<role> when it sees new work; the
+# dispatcher consumes them. If the dispatcher crashed or fleet-down
+# was forced, triggers can be left behind, and the next fleet's
+# dispatcher would treat them as fresh work the new scout never
+# asked for (observed: dispatched sonnet-author + opus-worker on
+# fleet-up despite the fresh scout only triggering sonnet-reviewer).
+# Sweep before the scout starts (Step 3d) so any triggers it writes
+# in its first tick are preserved.
+triggers_dir="$HOME/.fleet/state/triggers"
+if [[ -d "$triggers_dir" ]]; then
+    swept=0
+    for trigger in "$triggers_dir"/*; do
+        [[ -e "$trigger" ]] || continue
+        rm -f "$trigger"
+        swept=$((swept + 1))
+    done
+    if (( swept > 0 )); then
+        echo "fleet-up: swept $swept stale trigger(s) from prior session"
+    fi
+fi
+
 # ----------------------------------------------------------------------
 # Step 3c: ensure GitHub labels referenced by agents exist
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

If the dispatcher crashed or `fleet-down` was forced, files in `~/.fleet/state/triggers/` can be left behind. The next fleet's dispatcher consumes them and fires iterations the new scout never asked for.

Observed on a recent `fleet-up` after PR #473 landed:

- New scout triggered: `sonnet-reviewer, merger`, then `merger`, then `queue-manager, merger`.
- New dispatcher dispatched: `sonnet-author`, `opus-worker`, `sonnet-reviewer`, `opus-reviewer`, `queue-manager`, `merger`.
- The first three dispatches were stale triggers from earlier failed fleet-up runs (where the dispatcher crashed before consuming them).

## Fix

Sweep `~/.fleet/state/triggers/*` in fleet-up's Step 3b boot-hygiene block, alongside the existing stale-shutdown-sentinel clear. Runs **before** Step 3d launches the scout, so any triggers the scout writes in its first tick are preserved.

## Test plan

- [x] `bash -n scripts/fleet/fleet-up` passes
- [ ] Next `fleet-up live` after a forced `fleet-down`: dispatch log matches scout trigger log (no phantom roles dispatched)
- [ ] When triggers dir is empty: no \"swept N stale trigger(s)\" line printed (current observed behavior preserved)

## Notes for reviewer

Counterpoint considered: dispatch records (`~/.fleet/state/dispatch/*.json`) might also be stale after a crash. They aren't swept because `cleanup_stale_dispatches()` already self-heals them on the dispatcher's next tick (line 192 in fleet-dispatcher) — it sees the recorded pane is back at shell and removes the record. Triggers don't self-heal because the dispatcher consumes any trigger it sees, regardless of when it was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)