### PR TITLE
skills: refresh render-debug-loop lighting diagnosis to match landed state

### DIFF
--- a/.claude/skills/render-debug-loop/diagnosis/lighting.md
+++ b/.claude/skills/render-debug-loop/diagnosis/lighting.md
@@ -1,24 +1,25 @@
-# Diagnosis: Lighting (T-011 onward)
+# Diagnosis: Lighting
 
-The lighting stack is being built out in phases — the `LIGHTING_TO_TRIXEL` pipeline stage has landed (T-011, PR #185); AO (T-012), directional shadows (T-013), flood-fill propagation (T-014), LUT palette (T-015), and fog of war (T-016) are the incoming phases. See `engine/render/CLAUDE.md` for pipeline position.
+The lighting stack is mostly built out. The `LIGHTING_TO_TRIXEL` pipeline stage (T-011, PR #185) is the integration point; AO (T-012, PR #197), directional sun shadows (T-013/T-070), flood-fill colored light propagation (T-014, PR #232), LUT palette shading (T-015, PR #198), and fog of war (T-016, PR #238) all run through it. The light volume itself was rewritten on the GPU in PR #448. Outstanding refactors: T-091 migrates AO off `OccupancyGridBuffer` to sample neighbour pixels in `trixelDistances`, and T-094 camera-anchors the GPU light volume so fidelity holds past the static window. See `engine/render/CLAUDE.md` for pipeline position.
 
-Populate this section as phases land. For now, the evaluation pattern:
+## Evaluation pattern
 
 1. Capture a **baseline** screenshot set with lighting disabled (no `C_LightSource` in scene, or set `frameData.lightingEnabled_ = 0` in `system_lighting_to_trixel.hpp` — that's the CPU short-circuit that skips the per-canvas dispatch).
 2. Capture the same shots with lighting enabled.
 3. Diff: lighting-on frames should modulate voxel and shape canvas pixels; **GUI-canvas pixels must be untouched** (T-011 invariant).
 
-## Symptom lookup (to be expanded)
+## Symptom lookup
 
 | Symptom | Likely location |
 |---------|----------------|
 | Lighting pass modulates GUI text/panels | `LIGHTING_TO_TRIXEL` not respecting GUI-canvas bypass |
 | No visible lighting effect | Lighting textures unbound, or `isoPixelToPos3D` returning wrong world coords |
-| AO missing at voxel junctions (T-012) | `computeAO` neighbor-sampling indices against the 3D occupancy grid |
-| Shadow direction wrong (T-013) | Sun-direction uniform vs. shadow-map sweep axis mismatch |
-| Torch doesn't light neighbors (T-014) | BFS frontier not seeding emissive voxels, or occupancy grid missing analytic shapes |
-| Cel-shade bands smeared (T-015) | LUT sampler filter mode (GL_LINEAR instead of GL_NEAREST) |
-| Fog of war reveals through walls (T-016) | LOS ray casting not consulting columnar span lists |
+| AO missing or wrong at voxel junctions | `c_compute_voxel_ao.{glsl,metal}` neighbour sampling — `OccupancyGridBuffer` indexing today; `trixelDistances` face-tangent taps once T-091 lands |
+| Shadow direction wrong | Sun-direction uniform vs. shadow-map sweep axis mismatch in `c_bake_sun_shadow_map` / `c_compute_sun_shadow` |
+| Torch doesn't light neighbours | Light-volume seed pass not seeding emissive voxels, or analytic shapes missing from occupancy |
+| Cel-shade bands smeared | LUT sampler filter mode (`GL_LINEAR` instead of `GL_NEAREST`) |
+| Fog of war reveals through walls | LOS ray casting in `c_fog_to_trixel` not consulting columnar span lists |
+| Lighting fidelity drifts past static window | Missing camera-anchor on GPU light volume (T-094) — `worldOrigin_` not subtracted before volume sample |
 
 ## Baseline-diff screenshots
 


### PR DESCRIPTION
## Summary

Follow-up nit from PR #470 (which merged before the nit could land in-place). The reviewer flagged that `diagnosis/lighting.md` inherited language from the original SKILL.md framing T-012 through T-016 as "incoming phases" — but those phases all landed long ago (PRs #197, #198, #210, #232, #238) and the GPU light volume rewrite landed in PR #448. The two outstanding refactors today are T-091 (AO via `trixelDistances`, drops `OccupancyGridBuffer`) and T-094 (camera-anchor GPU light volume so fidelity holds past the static window).

This PR refreshes:
- the intro paragraph to reflect what's actually shipped vs. in flight
- the symptom table to point at current shader file names (`c_compute_voxel_ao`, `c_bake_sun_shadow_map`, `c_compute_sun_shadow`, `c_fog_to_trixel`) instead of legacy phase task IDs
- adds a row for the camera-anchor fidelity drift symptom (T-094)

Pure docs change — no engine code touched, no behavior change.

## Test plan
- [ ] PR numbers cited resolve to real merged PRs (verified locally: #185, #197, #198, #210, #232, #238, #448)
- [ ] Shader file names cited exist in `engine/render/src/shaders/` (verified)
- [ ] T-091 and T-094 are open issues (#428 and #360, both confirmed open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)