### PR TITLE
simplify: add code-to-doc drift check so CLAUDE.md stays current

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -9,9 +9,10 @@ description: >-
   commit-and-push before the commit message is drafted. The skill
   finds per-entity getComponent in tick functions, allocation in hot
   loops, ECS naming convention slips, opportunities to reuse existing
-  helpers, dead code, debug logs left behind, and tautological
-  comments — applying safe fixes inline and reporting anything that
-  needs human judgment. Saves a review-fix-rereview round-trip.
+  helpers, dead code, debug logs left behind, tautological comments,
+  and stale or drifting CLAUDE.md / role / skill docs — applying safe
+  fixes inline and reporting anything that needs human judgment.
+  Saves a review-fix-rereview round-trip.
 ---
 
 # simplify
@@ -328,9 +329,22 @@ The engine's style preferences are simple and worth applying inline:
   lists, axis vectors (`vec3(1.0f, 0.0f, 0.0f)`), or one-off math
   are fine — only flag numbers where a name would clarify intent.
 
-### 9. Doc-side checks (run when the diff includes any markdown)
+### 9. Doc-side checks (always run)
 
-Code-only diffs can skip. Mixed and doc-heavy diffs run these too.
+Doc upkeep is part of the reviewer-facing bar, in both directions:
+
+- **9a — Doc → code drift.** When the diff includes markdown,
+  check the doc still describes reality (existing API examples,
+  cited file paths, internal consistency).
+- **9b — Code → doc drift.** When the diff includes non-doc files,
+  check whether the nearest `CLAUDE.md` (or relevant role / skill
+  doc) should be updated to reflect a new or removed pattern.
+
+Run whichever sub-checks apply. Pure formatter-only diffs can skip
+both.
+
+#### 9a. Doc → code drift (when the diff includes markdown)
+
 Markdown sources to check: `.md` files anywhere, `docs/**`, role
 docs under `.claude/commands/`, skill docs under `.claude/skills/`,
 top-level `CLAUDE.md` and module-level `CLAUDE.md` files.
@@ -375,6 +389,68 @@ auto-fix — these need human judgment on scope):
   doc — same smell as the main "Contradictions within a doc"
   bullet, but in role/skill docs scope judgment belongs with the
   human. Report; reconciling is outside simplify's scope here.
+
+#### 9b. Code → doc drift (when the diff includes non-doc files)
+
+For each non-doc file in the diff, walk up the directory tree to
+locate the nearest `CLAUDE.md`. De-dupe so each `CLAUDE.md` is
+considered once. For each one, ask whether the current change
+introduces something the doc would reasonably want to mention, or
+invalidates something it currently asserts. The intent is to keep
+each module's `CLAUDE.md` representative of the current state — not
+to grow them with every change.
+
+Flag (don't auto-edit — the "doc-worthy?" call belongs to the
+author):
+
+- **New pattern, file, or convention.** The diff adds a system,
+  component, prefab, shader, helper namespace, debug toggle, build
+  preset, label, role, skill, or any other piece of vocabulary the
+  doc establishes. If the doc enumerates the category (e.g.
+  `engine/render/CLAUDE.md` describes the pipeline stages, or a
+  module `CLAUDE.md` lists "common patterns"), the new entry
+  belongs in the list — or the list needs to stop claiming to be
+  exhaustive.
+- **Removed or renamed thing the doc cites.** The diff deletes or
+  renames a symbol, file, helper, label, or skill that the doc
+  body references by name. Grep the doc for the old name; if it
+  appears, the doc lies now.
+- **Documented counts or lists drifted.** The doc says "we have N
+  X" or enumerates by name; the diff changed the count or the
+  membership. Numbered claims rot the fastest.
+- **A new convention the doc should warn about.** The diff adds a
+  rule or constraint that future contributors will trip over
+  without docs (e.g., "this struct must stay 16-byte aligned",
+  "this enum is the registration mechanism", "this header is
+  generated"). If a reviewer would reasonably ask "where is this
+  documented?", surface the gap.
+- **A convention the doc warned about that no longer applies.**
+  The diff removes the constraint; the warning in the doc is now
+  noise.
+
+Skip 9b when:
+
+- The diff only changes function bodies — no new symbol, no
+  removed symbol, no new file, no new build target.
+- The touched directory has no relevant `CLAUDE.md` upstream
+  (test fixture, generated artifact, third-party vendor tree).
+- The change is purely a typo, formatting, or comment edit.
+
+Report format — one line per `CLAUDE.md` that may need attention,
+with the specific gap and a one-line suggestion. Don't speculate
+about wording; let the author decide whether and how to update.
+Example:
+
+```
+  reported 1 doc-drift finding:
+    - engine/render/CLAUDE.md — pipeline-stages list doesn't
+      mention the new SSAO compute stage added in
+      engine/prefabs/irreden/render/systems/system_ssao.hpp.
+      Worth a one-line addition under "Pipeline stages"?
+```
+
+A clean 9b pass is a finding of "no doc drift" and produces no
+output — silence is success.
 
 ### 10. Format and verify
 


### PR DESCRIPTION
## Summary
- Section 9 of `simplify` used to skip on code-only diffs, so PRs that introduced new systems, shaders, or conventions never got a nudge to update the nearest `CLAUDE.md`. Docs drifted between the markdown-touching PRs that did exercise section 9.
- Split into **9a (doc → code drift)** — existing rules, gated on markdown in the diff — and **9b (code → doc drift)** — new, gated on non-doc files in the diff.
- 9b walks up to the nearest `CLAUDE.md` per touched file and flags new patterns/files/conventions the doc would reasonably mention, removed/renamed things the doc cites, drifted counts/lists, new constraints worth warning about, and stale warnings whose constraint is gone. Report-only — "doc-worthy?" judgment stays with the author.
- Skip rules cover function-body-only edits, dirs without an upstream `CLAUDE.md`, and pure formatting/typo changes so the check doesn't spam silence-worthy diffs.
- Because `commit-and-push` and `polish-checkpoint` both invoke `simplify`, this nudge fires on every commit and mid-session checkpoint without needing a separate hook.

## Test plan
- [ ] Next PR that adds a new system / shader / prefab — confirm `simplify` surfaces a 9b finding pointing at the nearest `CLAUDE.md`
- [ ] Function-body-only diff — confirm 9b stays silent (skip rule fires)
- [ ] Markdown-touching diff — confirm 9a still runs as before

## Notes for reviewer
- Frontmatter description gains "stale or drifting CLAUDE.md / role / skill docs" so the skill triggers on doc-upkeep intent.
- The 9b output format is silence-on-clean by design; "no doc drift" is a non-finding, not a printed line.
- This is the lighter-weight option (1 of 3) discussed before implementing — extends the existing skill rather than adding a new `claude-md-audit` skill or a `settings.json` hook. If 9b proves expensive or noisy in practice, splitting it into a `simplify-check-docs` worker subagent (alongside the existing `simplify-check-{ecs,math,naming}` ones) is the obvious next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)