### PR TITLE
fleet: stream claude JSON events from dispatcher invocations

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -223,10 +223,15 @@ build_dispatch_command() {
     local role="$1"
     local model="${ROLE_MODEL[$role]:-sonnet}"
     local effort="${ROLE_EFFORT[$role]:-high}"
-    # The role slash command (`/role-<role>`) is preserved from the
-    # fleet-babysit invocation. fleet-claude-stream renders the
-    # streaming events as readable pane text — same pipe babysit uses.
-    printf 'claude --model %q --effort %q --print "/role-%s live" | fleet-claude-stream\n' \
+    # `--print` makes each iteration a one-shot process that exits on
+    # completion (PR #257). `--output-format stream-json
+    # --include-partial-messages --verbose` is what makes claude emit
+    # the live JSON event stream that fleet-claude-stream renders as
+    # readable pane text — without those three flags claude buffers in
+    # plain-text mode and only flushes at exit, so the pane looks dead
+    # the whole iteration and the formatter sees no init / tool / delta
+    # events to render. Mirrors fleet-babysit's stream_claude().
+    printf 'claude --model %q --effort %q --print --output-format stream-json --include-partial-messages --verbose "/role-%s live" | fleet-claude-stream\n' \
         "$model" "$effort" "$role"
 }
 


### PR DESCRIPTION
## Summary

The dispatcher's `build_dispatch_command()` emits a claude pipeline that's
missing `--output-format stream-json --include-partial-messages --verbose`.
Without those, claude runs in default plain-text `--print` mode and buffers
everything until exit; `fleet-claude-stream`'s parser sees no JSON events
and renders nothing.

## Symptoms

- Worker panes appear dead during the entire iteration.
- No `[claude <model> sess=<id> cwd=<dir>]` init line in the pane.
- No tool-call indicators, no progressive text deltas.
- Output only appears when claude exits and prints the final response in one chunk (which fleet-claude-stream then passes through as raw text).
- `dispatcher.log` shows clean dispatch + completion entries — the streaming-flags omission is invisible above the pane layer.

## Fix

Add the three flags to the printf that constructs the per-pane invocation. Mirrors `fleet-babysit`'s `stream_claude()` (the reference impl that PR #463's dispatcher rewrite replaced — the original had the flags at line 365, the rewrite dropped them).

Before:

```
claude --model sonnet --effort high --print "/role-sonnet-author live" | fleet-claude-stream
```

After:

```
claude --model sonnet --effort high --print --output-format stream-json --include-partial-messages --verbose "/role-sonnet-author live" | fleet-claude-stream
```

## Test plan

- [x] `bash -n scripts/fleet/fleet-dispatcher` passes
- [x] `build_dispatch_command sonnet-author` emits the same shape as `fleet-babysit`'s `stream_claude()`
- [ ] Next `fleet-up live`: panes show the `[claude … sess=… cwd=…]` init line and progressive text/tool indicators during each iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)