### PR TITLE
fleet: tighten daemon poll intervals (scout 60→30s, dispatcher 30→10s)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -62,7 +62,14 @@ PID_FILE="$STATE_DIR/dispatcher.pid"
 LOCK_DIR="$STATE_DIR/dispatcher.lock.d"
 SHUTDOWN_FLAG="$HOME/.fleet/shutdown-in-progress"
 
-POLL_INTERVAL_SECONDS="${FLEET_DISPATCHER_INTERVAL:-30}"
+# Default poll cadence. Workers are transient — each iteration is a
+# one-shot `claude --print` spawned into an idle pane when a trigger
+# file appears, then the pane returns to bash. The dispatcher's
+# interval is the second half of "external state change → worker
+# fires" latency (the scout's interval is the first half). Local-only
+# work (no network), so a tight cadence is essentially free; 10 s
+# keeps pickup snappy without burning measurable CPU.
+POLL_INTERVAL_SECONDS="${FLEET_DISPATCHER_INTERVAL:-10}"
 
 # Roles this dispatcher is responsible for. Architects are excluded
 # (kept on fleet-babysit). Aligned with the worker / reviewer /

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -53,7 +53,17 @@ REPO_KEY_TO_SLUG = {
     "game": "jakildev/irreden",
 }
 
-POLL_SECONDS_DEFAULT = 60
+# Default poll cadence. Workers are transient now (each iteration is a
+# fresh `claude --print` process spawned by fleet-dispatcher when the
+# scout writes a per-role trigger). The scout's interval is therefore
+# the dominant component of "external state changed → worker fires"
+# latency; under the babysit model workers held context between ticks
+# and could self-pace, but here a 60 s interval was producing ~90 s
+# pickup latency and visibly idle panes. 30 s halves the latency and
+# stays well under GitHub's 5000-req/hr authenticated rate limit even
+# with the per-tick fan-out (the throttled max_workers=2 fetcher caps
+# burst).
+POLL_SECONDS_DEFAULT = 30
 GH_TIMEOUT_SECONDS = 30
 
 # Cap concurrent gh calls and stagger their submission to avoid GitHub's

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -907,7 +907,7 @@ def main():
     parser.add_argument("--once", action="store_true",
                         help="run one tick and exit (for testing)")
     parser.add_argument("--interval", type=int, default=POLL_SECONDS_DEFAULT,
-                        help="poll interval in seconds (default 60)")
+                        help="poll interval in seconds (default 30)")
     args = parser.parse_args()
 
     STATE_DIR.mkdir(parents=True, exist_ok=True)

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -404,7 +404,7 @@ fi
 # Step 3d: launch fleet-state-scout daemon
 # ----------------------------------------------------------------------
 #
-# Polls GitHub + git every 60s and writes `~/.fleet/state/state.json`
+# Polls GitHub + git every 30s and writes `~/.fleet/state/state.json`
 # plus per-role trigger files under `~/.fleet/state/triggers/`. Roles
 # (sonnet-author, opus-worker, sonnet-reviewer, opus-reviewer,
 # queue-manager, merger) read state.json instead of running their own
@@ -460,7 +460,7 @@ fi
 # Step 3f: launch fleet-dispatcher daemon
 # ----------------------------------------------------------------------
 #
-# Polls every 30 s, watches ~/.fleet/state/triggers/<role>, dispatches
+# Polls every 10 s, watches ~/.fleet/state/triggers/<role>, dispatches
 # transient `claude --print ... | fleet-claude-stream` invocations
 # into idle worker / reviewer / queue-mgr / merger panes via
 # `tmux send-keys`. Architects keep fleet-babysit (interactive


### PR DESCRIPTION
## Summary

With workers transient (each iteration a one-shot `claude --print` spawned by the dispatcher), end-to-end latency from "external state changed" → "worker iteration fires" is now `scout_interval + dispatcher_interval`. With the previous 60s + 30s defaults, panes sat idle ~90s between iterations even when there was visible work to pick up — observed today across opus-worker-1, sonnet-author, sonnet-reviewer, opus-reviewer.

Cut scout to **30s** and dispatcher to **10s**. New worst-case pickup is **40s**.

## Cost

| Daemon | Old | New | Notes |
|---|---|---|---|
| `fleet-state-scout` | 60s | 30s | Each tick: 4 `gh` calls + a few `git`. Doubles to ~480/hr; well under GitHub's 5000/hr authenticated limit. The throttled `max_workers=2` fetcher already caps per-tick burst, so the secondary rate limit isn't a concern. |
| `fleet-dispatcher` | 30s | 10s | Local-only (tmux + filesystem). 3x polls, but each tick is a few syscalls. Effectively free. |

## Overrides preserved

- Scout: `fleet-state-scout --interval 60` (or whatever)
- Dispatcher: `FLEET_DISPATCHER_INTERVAL=30 fleet-up live`

## Test plan

- [x] `bash -n scripts/fleet/{fleet-up,fleet-dispatcher}` and `python3 -c 'import ast; ast.parse(...)'` for scout pass
- [ ] Next `fleet-up live`: dispatcher.log shows polls every ~10s; state-scout.log shows ticks every ~30s
- [ ] Iteration-to-iteration latency observably tighter (≤ 40s for the trigger → dispatch path)

## Notes for reviewer

The two stale comments in `fleet-up` ("Polls GitHub + git every 60s" / "Polls every 30 s") are also updated to match. No callers pass explicit intervals, so the default change is the actual behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)