### PR TITLE
fleet: bootstrap-trigger queue-manager + merger on actionable state

### DIFF
--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -457,6 +457,61 @@ else
 fi
 
 # ----------------------------------------------------------------------
+# Step 3e2: bootstrap-trigger queue-manager / merger on actionable state
+# ----------------------------------------------------------------------
+#
+# Workers are transient now — each iteration is a one-shot `claude`
+# spawned by the dispatcher when the scout writes a per-role trigger,
+# and triggers fire only on projection-content deltas. Edge case:
+# if a previous iteration was killed mid-run (fleet-down during
+# queue-manager's ingestion, dispatcher crash mid-merge, etc.) the
+# inputs that drove that trigger are still in the projection on the
+# next boot — but the scout sees identical content, decides "no
+# change", emits no trigger, and the work never resumes.
+#
+# Surgical bootstrap: for the two idempotent meta-roles (queue-manager,
+# merger), if their projection has actionable content right now, seed a
+# trigger so the dispatcher picks them up in its first tick. A no-op
+# iteration is cheap and self-correcting; the cost of a false-positive
+# bootstrap is one short claude invocation, while the cost of a missed
+# resume is a permanently stuck queue or merge backlog.
+#
+# Author/reviewer roles intentionally NOT bootstrapped — those should
+# fire only when real new work appears in the projection delta. A
+# spurious sonnet-author dispatch on every boot would burn cycles.
+if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY' || true
+import json
+import pathlib
+
+proj_dir = pathlib.Path("~/.fleet/state/projections").expanduser()
+trig_dir = pathlib.Path("~/.fleet/state/triggers").expanduser()
+trig_dir.mkdir(parents=True, exist_ok=True)
+
+def queue_manager_actionable(p):
+    return bool(p.get("human_approved")) or bool(p.get("needs_plan"))
+
+def merger_actionable(p):
+    return bool(p.get("prs"))
+
+for role, predicate in [
+    ("queue-manager", queue_manager_actionable),
+    ("merger", merger_actionable),
+]:
+    proj = proj_dir / f"{role}.json"
+    if not proj.is_file():
+        continue
+    try:
+        data = json.loads(proj.read_text())
+    except (OSError, json.JSONDecodeError):
+        continue
+    if predicate(data):
+        (trig_dir / role).touch()
+        print(f"fleet-up: bootstrap-triggered {role} (projection has actionable content)")
+PY
+fi
+
+# ----------------------------------------------------------------------
 # Step 3f: launch fleet-dispatcher daemon
 # ----------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary

Fix a stuck-state class of bug introduced by the transient-worker model: **interrupted iterations don't resume on the next boot if their inputs are stable.**

The scout emits triggers only on projection-content deltas. If a worker iteration is killed mid-run (e.g. `fleet-down` during queue-manager's ingestion, dispatcher crash mid-merge), the inputs that drove the trigger are still in the projection on the next boot — but the scout sees identical content, decides "no change", emits no trigger, and the work never resumes.

## Repro from today

```
16:19:27  Issues #283–286 get human:approved
16:22:39  Scout triggers queue-manager (issues=4)
16:23:34  Dispatcher dispatches queue-manager
16:23:49  fleet-down — both scout and dispatcher get SIGTERM
          Queue-manager iteration killed ~15s in, never wrote summary
16:24:51  fleet-up restart
          Scout: "no triggers (all projections unchanged)"
          ↑ same 4 issues still in human_approved, fleet:queued never got applied,
            projection content identical → no trigger → ingestion never resumes
```

Issues #283–286 were stranded out of TASKS.md until manually unstuck.

## Fix

Surgical bootstrap-trigger pass in fleet-up between scout-ready and dispatcher launch. For the two idempotent meta-roles, seed a trigger if their projection has actionable content right now:

- **queue-manager** — trigger if `human_approved` or `needs_plan` non-empty
- **merger** — trigger if `prs` non-empty (any candidate to consider)

Author/reviewer roles intentionally excluded — those should fire only on real new-work deltas; a spurious `sonnet-author` dispatch on every boot would burn cycles. The two meta-roles are idempotent — worst case is one cheap no-op iteration if they would have been triggered shortly anyway.

## Test plan

- [x] `bash -n scripts/fleet/fleet-up` passes
- [x] Inline python dry-run against current `~/.fleet/state/projections/` correctly identifies both queue-manager and merger as having actionable content (live state has 4 unmerged candidate PRs and 4 ungingested approved issues)
- [ ] Next `fleet-up live`: log shows `fleet-up: bootstrap-triggered queue-manager (projection has actionable content)` and `bootstrap-triggered merger (...)` in the startup output
- [ ] Dispatcher's first tick dispatches both roles (≤30s, ≤10s if PR #484 lands)
- [ ] When projections are empty (no actionable work), no bootstrap triggers fire (verified by predicate logic — bool() of empty list is False)

## Notes for reviewer

- The python check is wrapped in `if command -v python3` and `|| true` — fleet-up's `set -euo pipefail` won't be tripped by a missing python3 or a malformed projection.
- The bootstrap is best-effort. If a projection file is missing or malformed, that role just doesn't get bootstrapped this boot. The dispatcher will still operate normally on real triggers.
- Step number in fleet-up: inserted as "Step 3e2" (between 3e — scout ready — and 3f — dispatcher launch). Could renumber later; preserved continuity for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)