### PR TITLE
fleet: clear pane input before dispatching to defuse stray keystrokes

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -263,7 +263,16 @@ dispatch_role() {
     cmd=$(build_dispatch_command "$role")
 
     log "dispatching $role -> $pane_id"
-    if ! tmux send-keys -t "$pane_id" "$cmd" C-m; then
+    # C-c aborts any partial input the human may have typed into the
+    # idle pane (including multi-line continuations); C-u then clears
+    # the input line for good measure. Without this the typed-but-
+    # uncommitted prefix concatenates with our dispatch command —
+    # observed: stray "Ca" turned the next dispatch into
+    # "Caclaude --model …" / "zsh: command not found: Caclaude".
+    # Safe at a shell prompt — find_idle_pane_for_role only picks
+    # panes whose pane_current_command is bash/zsh/sh/fish, so C-c
+    # acts on the input loop, not a running command.
+    if ! tmux send-keys -t "$pane_id" C-c C-u "$cmd" C-m; then
         # send-keys failed (pane vanished, tmux server died). Leave the
         # trigger in place so the next tick retries — don't orphan the
         # work by consuming the trigger before the dispatch landed.


### PR DESCRIPTION
## Summary

If the human types anything into an idle worker pane (intentionally during debugging, or accidentally by clicking through it), the typed-but-uncommitted prefix sits in the shell's input buffer. The next \`tmux send-keys\` from the dispatcher appends the dispatch command to that prefix → garbled command → iteration lost.

Observed today in sonnet-fleet-1:

\`\`\`
~/src/IrredenEngine/.claude/worktrees/sonnet-fleet-1/ Caclaude --model sonnet --effort high --print --output-format stream-json --include-partial-messages --verbose \"/role-sonnet-author live\" | fleet-claude-stream
zsh: command not found: Caclaude
\`\`\`

A stray \"Ca\" prefix nuked one full sonnet-author iteration.

## Fix

Prepend \`C-c\` (abort partial input, handles multi-line continuations too) and \`C-u\` (clear the input line) to the send-keys sequence:

\`\`\`bash
tmux send-keys -t \"\$pane_id\" C-c C-u \"\$cmd\" C-m
\`\`\`

Safe at a shell prompt — \`find_idle_pane_for_role\` only picks panes whose \`pane_current_command\` is bash/zsh/sh/fish, so C-c acts on the input loop, not a running command.

## Why both keys

- **C-c alone:** handles multi-line continuations (e.g. unclosed quote) which C-u can't unwind.
- **C-u alone:** silent (no \`^C\` echoed in scrollback) but doesn't unwind continuations.
- **Both:** belt-and-suspenders. The second is a no-op if the first already cleared the buffer.

## Test plan

- [x] \`bash -n scripts/fleet/fleet-dispatcher\` passes
- [ ] Type random characters into an idle worker pane; next dispatch fires the clean command, not the concatenated garbage
- [ ] Idle pane with no stray input still dispatches normally (no visible effect from the C-c/C-u — at an empty prompt both are no-ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)