### PR TITLE
fleet: allowlist scout-cache + iteration-summary wrappers

### DIFF
--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -228,6 +228,20 @@ baseline = [
     "Bash(fleet-run-targets:*)",
     "Bash(fleet-help:*)",
     "Bash(fleet-heartbeat:*)",
+    # Scout-cache wrappers (PR #458) and post-iteration helpers. Without
+    # these every iteration that calls fleet-issue / fleet-pr /
+    # fleet-iteration-summary stalls at a permission prompt that no human
+    # is around to answer; observed: queue-manager iteration paused for
+    # ~25 minutes on `fleet-issue view 428`. fleet-worktree-busy-branches
+    # is the fast-path filter sonnet-author / opus-worker run on every
+    # task-pickup pass. fleet-labels is the GitHub-label sync wrapper
+    # invoked by fleet-up itself but also occasionally by roles for
+    # ad-hoc relabel passes.
+    "Bash(fleet-issue:*)",
+    "Bash(fleet-pr:*)",
+    "Bash(fleet-iteration-summary:*)",
+    "Bash(fleet-worktree-busy-branches:*)",
+    "Bash(fleet-labels:*)",
     # Env-var-prefixed git for non-interactive rebase. `Bash(git:*)`
     # in the user-level allowlist matches commands STARTING with `git`,
     # so a `GIT_EDITOR=true git ...` prefix doesn't match. Add an


### PR DESCRIPTION
## Summary

The baseline allowlist that fleet-up writes into each worktree's `.claude/settings.local.json` covers `fleet-claim`, `fleet-build`, `fleet-run`, `fleet-heartbeat`, etc. — but **not** the wrappers PR #458 added (`fleet-issue`, `fleet-pr`) or the helpers every role uses after each iteration (`fleet-iteration-summary`, `fleet-worktree-busy-branches`, `fleet-labels`). Result: every worker iteration that calls one of these stalls on a permission prompt that no human is around to answer.

## Symptoms observed today

Queue-manager iteration sat for ~25 minutes on `fleet-issue view 428 — This command requires approval`, which cascaded:

1. **Dispatcher main loop frozen inside `tmux send-keys`.** The send-keys writes the dispatch command into the pane's input buffer and waits for it to drain. The buffer didn't drain because the pane's claude was sitting on the approval gate.
2. **All six trigger files piled up unconsumed** while the dispatcher was stuck.
3. Iteration eventually fell back to `gh issue view ...` (already in allowlist) and ingested the four sprite issues anyway — but only after the human killed the stuck send-keys.

The allowlist gap was silent because:
- Each role's iteration "completed" from the dispatcher's POV (it logged `dispatch ... completed`).
- The pane scrollback shows the approval prompt but no human watches every pane.
- Roles fall back to `gh ...` direct calls when the wrapper is denied — work mostly happens but slower and with random stalls.

## Fix

Add the missing entries to the baseline:

```python
"Bash(fleet-issue:*)",
"Bash(fleet-pr:*)",
"Bash(fleet-iteration-summary:*)",
"Bash(fleet-worktree-busy-branches:*)",
"Bash(fleet-labels:*)",
```

Roles that don't use a given wrapper ignore the entry — allow rules are permissive, extras don't change behavior.

## Live patch (out of band, already applied to running fleet)

Ran a one-shot Python script against all 10 active worker worktrees (engine + game) to add the same 5 entries to their existing `settings.local.json` files. The next iteration of each pane reads the updated file at claude startup, so no fleet-down/up was needed. The PR change makes this permanent on the next reset.

## Test plan

- [x] `bash -n scripts/fleet/fleet-up` passes
- [x] All 10 active worker worktrees patched live; queue-manager's next iteration calls `fleet-iteration-summary` without hitting an approval prompt (verified after live patch — current iteration is no longer stalling)
- [ ] Next `fleet-down` / `fleet-up` cycle: fresh worktree settings.local.json files include all five new entries

## Related

- PR #458 added `fleet-issue` / `fleet-pr` wrappers; the role docs were updated to use them in PR #459, but the allowlist update never landed.
- Dispatcher blocking inside `tmux send-keys` when the pane is stuck on a prompt is a separate vulnerability — could be hardened with a send-keys timeout. Not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)