### PR TITLE
T-095: Sprite: sprite-sheet asset format + loader

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -1,19 +1,25 @@
-# engine/asset/ — trixel texture I/O
+# engine/asset/ — trixel texture + sprite-sheet I/O
 
-Tiny module. The only thing it does today is save and load trixel textures
-(a `(size, colors[], distances[])` tuple) to disk as a raw binary format.
+Tiny module. Today it covers two file formats:
 
-`IRAsset::` exposes two free functions:
+- **Trixel textures** — raw binary `(size, colors[], distances[])` blobs
+  with extension `.txl`.
+- **Sprite-sheet sidecars** — plain-text metadata for PNG atlases with
+  extension `.irsprite`. The PNG itself is loaded by `engine/render/`'s
+  `ImageData`; this module owns only the sidecar.
 
-- `saveTrixelTextureData(name, path, size, colors, distances)` —
-  writes a binary file.
-- `loadTrixelTextureData(name, path, size, colors, distances)` —
-  reads one.
+`IRAsset::` exposes:
 
-The `name` is embedded in the file header; the `path` is the output
-directory.
+- `saveTrixelTextureData(name, path, size, colors, distances)` /
+  `loadTrixelTextureData(...)` — trixel binary round-trip.
+- `saveSpriteSheetMeta(name, path, meta)` /
+  `loadSpriteSheetMeta(name, path)` — sidecar text round-trip.
 
-## Format
+The `name` is embedded in the trixel file header; the `path` is the
+output directory. For sprite sheets, `name` is the basename shared
+by the `.png` atlas and its `.irsprite` sidecar.
+
+## Trixel format
 
 Raw binary, no versioning:
 
@@ -24,6 +30,25 @@ ivec2 size
 ```
 
 No checksum, no magic bytes, no compression. Treat the file as volatile.
+
+## Sprite-sheet sidecar format
+
+Plain text, line-oriented, order-independent. See `ir_asset.hpp` for the
+full `SpriteSheetMeta` / `SpriteAnimationDesc` field set. Atlas pixel
+dimensions are NOT stored — they are read from the PNG at load time.
+
+```
+# comment line (ignored)
+cellWidth  <pixels>
+cellHeight <pixels>
+margin     <pixels>   (optional, default 0)
+padding    <pixels>   (optional, default 0)
+anim <name> <firstFrame> <frameCount> <fps>
+```
+
+Animation names must not contain whitespace (the loader scans with
+`%127s` and would silently truncate); `saveSpriteSheetMeta` asserts on
+this at write time.
 
 ## Typical usage
 
@@ -43,6 +68,7 @@ import/export. Runtime gameplay code generally does not touch this module.
 - **Not a general asset pipeline.** Don't add shader hot-reload, audio
   decoding, or model loading here without a design pass — the file name
   suggests an abstraction that doesn't exist yet.
-- **Only trixel data.** The `FileTypes` enum in `ir_asset.hpp` has
-  `kSpriteImage` and `kVoxelImage` values but no corresponding load/save
-  routines — they're aspirational stubs only.
+- **Voxel image stub.** The `FileTypes` enum in `ir_asset.hpp` has a
+  `kVoxelImage` value with no corresponding load/save routine — still an
+  aspirational stub. (`kSpriteImage` is paired with the `.irsprite`
+  sidecar routines above.)

--- a/engine/asset/include/irreden/ir_asset.hpp
+++ b/engine/asset/include/irreden/ir_asset.hpp
@@ -11,9 +11,10 @@ using namespace IRMath;
 namespace IRAsset {
 
 /// Asset file type discriminant.
-/// Note: only `kTrixelImage` has corresponding I/O routines today.
-/// `kSpriteImage` and `kVoxelImage` are aspirational stubs with no
-/// load/save implementation yet.
+/// `kTrixelImage` has `saveTrixelTextureData` / `loadTrixelTextureData`.
+/// `kSpriteImage` has `saveSpriteSheetMeta` / `loadSpriteSheetMeta` for
+/// the `.irsprite` sidecar (the paired PNG is handled by render-module
+/// `ImageData`). `kVoxelImage` is an aspirational stub with no I/O yet.
 enum FileTypes { kSpriteImage, kTrixelImage, kVoxelImage };
 
 /// Writes trixel texture data to a raw binary file at @p path / @p name.txt.
@@ -60,6 +61,10 @@ struct SpriteAnimationDesc {
 ///   margin     <pixels>   (optional outer border, default 0)
 ///   padding    <pixels>   (optional inter-cell gap, default 0)
 ///   anim <name> <firstFrame> <frameCount> <fps>
+///
+/// Animation names must not contain whitespace — the loader scans them
+/// with `%127s`, which stops at the first space/tab and would silently
+/// truncate. `saveSpriteSheetMeta` asserts this at write time.
 struct SpriteSheetMeta {
     uvec2 cellSizePx_ = uvec2{0, 0};
     int margin_ = 0;
@@ -69,17 +74,12 @@ struct SpriteSheetMeta {
 
 /// Writes sprite-sheet sidecar metadata to @p path / @p name .irsprite.
 void saveSpriteSheetMeta(
-    const std::string &name,
-    const std::string &path,
-    const SpriteSheetMeta &meta
+    const std::string &name, const std::string &path, const SpriteSheetMeta &meta
 );
 
 /// Reads sprite-sheet sidecar metadata from @p path / @p name .irsprite.
 /// Returns a default-constructed SpriteSheetMeta if the file cannot be opened.
-SpriteSheetMeta loadSpriteSheetMeta(
-    const std::string &name,
-    const std::string &path
-);
+SpriteSheetMeta loadSpriteSheetMeta(const std::string &name, const std::string &path);
 
 }; // namespace IRAsset
 

--- a/engine/asset/include/irreden/ir_asset.hpp
+++ b/engine/asset/include/irreden/ir_asset.hpp
@@ -4,6 +4,7 @@
 #include <irreden/ir_math.hpp>
 
 #include <string>
+#include <vector>
 
 using namespace IRMath;
 
@@ -37,6 +38,49 @@ void loadTrixelTextureData(
     std::vector<Color> &colors,
     std::vector<Distance> &distances
 );
+
+// ---- Sprite-sheet sidecar ----
+
+/// Per-animation descriptor in a .irsprite sidecar file.
+struct SpriteAnimationDesc {
+    std::string name_;
+    int firstFrame_ = 0;
+    int frameCount_ = 0;
+    float fps_ = 0.0f;
+};
+
+/// Sidecar metadata for a PNG atlas sprite sheet.
+/// Atlas pixel dimensions are NOT stored here — they are read from the PNG
+/// at load time and used to compute normalized frame UV rects.
+///
+/// .irsprite plain-text format (lines, order-independent):
+///   # comment line (ignored)
+///   cellWidth  <pixels>
+///   cellHeight <pixels>
+///   margin     <pixels>   (optional outer border, default 0)
+///   padding    <pixels>   (optional inter-cell gap, default 0)
+///   anim <name> <firstFrame> <frameCount> <fps>
+struct SpriteSheetMeta {
+    uvec2 cellSizePx_ = uvec2{0, 0};
+    int margin_ = 0;
+    int padding_ = 0;
+    std::vector<SpriteAnimationDesc> animations_;
+};
+
+/// Writes sprite-sheet sidecar metadata to @p path / @p name .irsprite.
+void saveSpriteSheetMeta(
+    const std::string &name,
+    const std::string &path,
+    const SpriteSheetMeta &meta
+);
+
+/// Reads sprite-sheet sidecar metadata from @p path / @p name .irsprite.
+/// Returns a default-constructed SpriteSheetMeta if the file cannot be opened.
+SpriteSheetMeta loadSpriteSheetMeta(
+    const std::string &name,
+    const std::string &path
+);
+
 }; // namespace IRAsset
 
 #endif /* IR_ASSET_H */

--- a/engine/asset/src/ir_asset.cpp
+++ b/engine/asset/src/ir_asset.cpp
@@ -8,9 +8,9 @@
 namespace IRAsset {
 
 namespace {
-constexpr const char* kTrixelExtension = ".txl";
-constexpr const char* kIRSpriteExtension = ".irsprite";
-}
+constexpr const char *kTrixelExtension = ".txl";
+constexpr const char *kIRSpriteExtension = ".irsprite";
+} // namespace
 
 void saveTrixelTextureData(
     const std::string &name,
@@ -55,9 +55,7 @@ void loadTrixelTextureData(
 }
 
 void saveSpriteSheetMeta(
-    const std::string &name,
-    const std::string &path,
-    const SpriteSheetMeta &meta
+    const std::string &name, const std::string &path, const SpriteSheetMeta &meta
 ) {
     const std::string filename = IRUtility::joinPath(path, name, kIRSpriteExtension);
     FILE *f = fopen(filename.c_str(), "w");
@@ -70,17 +68,20 @@ void saveSpriteSheetMeta(
     fprintf(f, "margin %d\n", meta.margin_);
     fprintf(f, "padding %d\n", meta.padding_);
     for (const auto &a : meta.animations_) {
-        fprintf(f, "anim %s %d %d %g\n",
-                a.name_.c_str(), a.firstFrame_, a.frameCount_, a.fps_);
+        // Loader scans names with `%127s`, which truncates at the first
+        // space/tab. Catch it at write time rather than load time.
+        IR_ASSERT(
+            a.name_.find_first_of(" \t\r\n") == std::string::npos,
+            "sprite-sheet animation name '{}' contains whitespace",
+            a.name_
+        );
+        fprintf(f, "anim %s %d %d %g\n", a.name_.c_str(), a.firstFrame_, a.frameCount_, a.fps_);
     }
     fclose(f);
     IRE_LOG_INFO("Saved sprite sheet meta to {}", filename);
 }
 
-SpriteSheetMeta loadSpriteSheetMeta(
-    const std::string &name,
-    const std::string &path
-) {
+SpriteSheetMeta loadSpriteSheetMeta(const std::string &name, const std::string &path) {
     const std::string filename = IRUtility::joinPath(path, name, kIRSpriteExtension);
     FILE *f = fopen(filename.c_str(), "r");
     if (!f) {
@@ -90,9 +91,11 @@ SpriteSheetMeta loadSpriteSheetMeta(
     SpriteSheetMeta meta{};
     char line[256];
     while (fgets(line, static_cast<int>(sizeof(line)), f)) {
-        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r') continue;
+        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r')
+            continue;
         char key[64];
-        if (sscanf(line, "%63s", key) != 1) continue;
+        if (sscanf(line, "%63s", key) != 1)
+            continue;
         if (strcmp(key, "cellWidth") == 0) {
             sscanf(line, "cellWidth %u", &meta.cellSizePx_.x);
         } else if (strcmp(key, "cellHeight") == 0) {
@@ -104,8 +107,14 @@ SpriteSheetMeta loadSpriteSheetMeta(
         } else if (strcmp(key, "anim") == 0) {
             SpriteAnimationDesc anim{};
             char animName[128];
-            if (sscanf(line, "anim %127s %d %d %f",
-                       animName, &anim.firstFrame_, &anim.frameCount_, &anim.fps_) == 4) {
+            if (sscanf(
+                    line,
+                    "anim %127s %d %d %f",
+                    animName,
+                    &anim.firstFrame_,
+                    &anim.frameCount_,
+                    &anim.fps_
+                ) == 4) {
                 anim.name_ = animName;
                 meta.animations_.push_back(std::move(anim));
             }

--- a/engine/asset/src/ir_asset.cpp
+++ b/engine/asset/src/ir_asset.cpp
@@ -9,6 +9,7 @@ namespace IRAsset {
 
 namespace {
 constexpr const char* kTrixelExtension = ".txl";
+constexpr const char* kIRSpriteExtension = ".irsprite";
 }
 
 void saveTrixelTextureData(
@@ -51,6 +52,68 @@ void loadTrixelTextureData(
     fread(distances.data(), sizeof(distances.at(0)), size.x * size.y, f);
     fclose(f);
     IRE_LOG_INFO("Loaded trixel data from {}", filename);
+}
+
+void saveSpriteSheetMeta(
+    const std::string &name,
+    const std::string &path,
+    const SpriteSheetMeta &meta
+) {
+    const std::string filename = IRUtility::joinPath(path, name, kIRSpriteExtension);
+    FILE *f = fopen(filename.c_str(), "w");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for writing: {}", filename);
+        return;
+    }
+    fprintf(f, "cellWidth %u\n", meta.cellSizePx_.x);
+    fprintf(f, "cellHeight %u\n", meta.cellSizePx_.y);
+    fprintf(f, "margin %d\n", meta.margin_);
+    fprintf(f, "padding %d\n", meta.padding_);
+    for (const auto &a : meta.animations_) {
+        fprintf(f, "anim %s %d %d %g\n",
+                a.name_.c_str(), a.firstFrame_, a.frameCount_, a.fps_);
+    }
+    fclose(f);
+    IRE_LOG_INFO("Saved sprite sheet meta to {}", filename);
+}
+
+SpriteSheetMeta loadSpriteSheetMeta(
+    const std::string &name,
+    const std::string &path
+) {
+    const std::string filename = IRUtility::joinPath(path, name, kIRSpriteExtension);
+    FILE *f = fopen(filename.c_str(), "r");
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for reading: {}", filename);
+        return {};
+    }
+    SpriteSheetMeta meta{};
+    char line[256];
+    while (fgets(line, static_cast<int>(sizeof(line)), f)) {
+        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r') continue;
+        char key[64];
+        if (sscanf(line, "%63s", key) != 1) continue;
+        if (strcmp(key, "cellWidth") == 0) {
+            sscanf(line, "cellWidth %u", &meta.cellSizePx_.x);
+        } else if (strcmp(key, "cellHeight") == 0) {
+            sscanf(line, "cellHeight %u", &meta.cellSizePx_.y);
+        } else if (strcmp(key, "margin") == 0) {
+            sscanf(line, "margin %d", &meta.margin_);
+        } else if (strcmp(key, "padding") == 0) {
+            sscanf(line, "padding %d", &meta.padding_);
+        } else if (strcmp(key, "anim") == 0) {
+            SpriteAnimationDesc anim{};
+            char animName[128];
+            if (sscanf(line, "anim %127s %d %d %f",
+                       animName, &anim.firstFrame_, &anim.frameCount_, &anim.fps_) == 4) {
+                anim.name_ = animName;
+                meta.animations_.push_back(std::move(anim));
+            }
+        }
+    }
+    fclose(f);
+    IRE_LOG_INFO("Loaded sprite sheet meta from {}", filename);
+    return meta;
 }
 
 } // namespace IRAsset

--- a/engine/prefabs/irreden/render/entities/entity_sprite_sheet.hpp
+++ b/engine/prefabs/irreden/render/entities/entity_sprite_sheet.hpp
@@ -2,6 +2,7 @@
 #define ENTITY_SPRITE_SHEET_H
 
 #include <irreden/ir_render.hpp>
+#include <irreden/ir_utility.hpp>
 #include <irreden/render/texture.hpp>
 #include <irreden/ir_asset.hpp>
 #include <irreden/render/components/component_sprite_sheet.hpp>
@@ -24,28 +25,26 @@ namespace IRSprite {
 /// Padding convention: @p meta.padding_ is the gap BETWEEN cells, not after
 /// the last cell in each row/column (Aseprite / Texture Packer default).
 /// Number of columns = (atlasW - 2*margin + padding) / (cellW + padding).
-inline std::vector<IRComponents::SpriteFrame> buildFrameTable(
-    IRMath::uvec2 atlasSizePx,
-    const IRAsset::SpriteSheetMeta &meta
-) {
-    if (meta.cellSizePx_.x == 0 || meta.cellSizePx_.y == 0
-            || atlasSizePx.x == 0 || atlasSizePx.y == 0) {
+inline std::vector<IRComponents::SpriteFrame>
+buildFrameTable(IRMath::uvec2 atlasSizePx, const IRAsset::SpriteSheetMeta &meta) {
+    if (meta.cellSizePx_.x == 0 || meta.cellSizePx_.y == 0 || atlasSizePx.x == 0 ||
+        atlasSizePx.y == 0) {
         return {};
     }
     const int cellW = static_cast<int>(meta.cellSizePx_.x);
     const int cellH = static_cast<int>(meta.cellSizePx_.y);
-    const int aw    = static_cast<int>(atlasSizePx.x);
-    const int ah    = static_cast<int>(atlasSizePx.y);
-    const int cols  = (aw - 2 * meta.margin_ + meta.padding_) / (cellW + meta.padding_);
-    const int rows  = (ah - 2 * meta.margin_ + meta.padding_) / (cellH + meta.padding_);
+    const int aw = static_cast<int>(atlasSizePx.x);
+    const int ah = static_cast<int>(atlasSizePx.y);
+    const int cols = (aw - 2 * meta.margin_ + meta.padding_) / (cellW + meta.padding_);
+    const int rows = (ah - 2 * meta.margin_ + meta.padding_) / (cellH + meta.padding_);
     if (cols <= 0 || rows <= 0) {
         return {};
     }
 
     const float faw = static_cast<float>(aw);
     const float fah = static_cast<float>(ah);
-    const float uw  = static_cast<float>(cellW) / faw;
-    const float uh  = static_cast<float>(cellH) / fah;
+    const float uw = static_cast<float>(cellW) / faw;
+    const float uh = static_cast<float>(cellH) / fah;
 
     std::vector<IRComponents::SpriteFrame> frames;
     frames.reserve(static_cast<std::size_t>(cols * rows));
@@ -53,10 +52,7 @@ inline std::vector<IRComponents::SpriteFrame> buildFrameTable(
         for (int col = 0; col < cols; ++col) {
             const float u = static_cast<float>(meta.margin_ + col * (cellW + meta.padding_)) / faw;
             const float v = static_cast<float>(meta.margin_ + row * (cellH + meta.padding_)) / fah;
-            frames.push_back({
-                IRMath::vec4{u, v, u + uw, v + uh},
-                IRMath::ivec2{cellW, cellH}
-            });
+            frames.push_back({IRMath::vec4{u, v, u + uw, v + uh}, IRMath::ivec2{cellW, cellH}});
         }
     }
     return frames;
@@ -72,14 +68,15 @@ inline std::vector<IRComponents::SpriteFrame> buildFrameTable(
 /// @c sheet.textureHandle_.  The caller is responsible for releasing it via
 /// @c IRRender::destroyResource<IRRender::Texture2D>(sheet.textureHandle_)
 /// when the sheet is no longer needed.
-inline IRComponents::C_SpriteSheet loadSpriteSheet(
-    const std::string &name,
-    const std::string &path
-) {
+inline IRComponents::C_SpriteSheet
+loadSpriteSheet(const std::string &name, const std::string &path) {
     IRAsset::SpriteSheetMeta meta = IRAsset::loadSpriteSheetMeta(name, path);
 
-    const std::string pngPath = path + "/" + name + ".png";
+    const std::string pngPath = IRUtility::joinPath(path, name, ".png");
     IRRender::ImageData img{pngPath.c_str()};
+    if (!img.data_) {
+        return {};
+    }
     const IRMath::uvec2 atlasSizePx{
         static_cast<unsigned int>(img.width_),
         static_cast<unsigned int>(img.height_)
@@ -94,7 +91,10 @@ inline IRComponents::C_SpriteSheet loadSpriteSheet(
         IRRender::TextureFilter::NEAREST
     );
     tex->subImage2D(
-        0, 0, img.width_, img.height_,
+        0,
+        0,
+        img.width_,
+        img.height_,
         IRRender::PixelDataFormat::RGBA,
         IRRender::PixelDataType::UNSIGNED_BYTE,
         img.data_
@@ -105,14 +105,16 @@ inline IRComponents::C_SpriteSheet loadSpriteSheet(
     std::vector<IRComponents::NamedAnimation> animations;
     animations.reserve(meta.animations_.size());
     for (const auto &a : meta.animations_) {
-        animations.push_back({
-            a.name_,
-            IRComponents::SpriteAnimation{a.firstFrame_, a.frameCount_, a.fps_}
-        });
+        animations.push_back(
+            {a.name_, IRComponents::SpriteAnimation{a.firstFrame_, a.frameCount_, a.fps_}}
+        );
     }
 
     return IRComponents::C_SpriteSheet{
-        texHandle, atlasSizePx, std::move(frames), std::move(animations)
+        texHandle,
+        atlasSizePx,
+        std::move(frames),
+        std::move(animations)
     };
 }
 

--- a/engine/prefabs/irreden/render/entities/entity_sprite_sheet.hpp
+++ b/engine/prefabs/irreden/render/entities/entity_sprite_sheet.hpp
@@ -1,0 +1,121 @@
+#ifndef ENTITY_SPRITE_SHEET_H
+#define ENTITY_SPRITE_SHEET_H
+
+#include <irreden/ir_render.hpp>
+#include <irreden/render/texture.hpp>
+#include <irreden/ir_asset.hpp>
+#include <irreden/render/components/component_sprite_sheet.hpp>
+
+#include <string>
+#include <vector>
+
+/// @namespace IRSprite
+/// Free functions for building and loading sprite-sheet data.
+/// These live outside @c IRRender:: / @c IRAsset:: to keep each module
+/// focused: @c IRAsset handles file I/O, @c IRRender owns GPU resources,
+/// and @c IRSprite wires them together at the prefab layer.
+namespace IRSprite {
+
+/// Compute the frame UV-rect table from atlas pixel dimensions and sidecar
+/// metadata.  Frames are enumerated row-major, left-to-right inside each row,
+/// top-to-bottom across rows.  Returns an empty vector for degenerate inputs
+/// (zero cell or atlas dimension).
+///
+/// Padding convention: @p meta.padding_ is the gap BETWEEN cells, not after
+/// the last cell in each row/column (Aseprite / Texture Packer default).
+/// Number of columns = (atlasW - 2*margin + padding) / (cellW + padding).
+inline std::vector<IRComponents::SpriteFrame> buildFrameTable(
+    IRMath::uvec2 atlasSizePx,
+    const IRAsset::SpriteSheetMeta &meta
+) {
+    if (meta.cellSizePx_.x == 0 || meta.cellSizePx_.y == 0
+            || atlasSizePx.x == 0 || atlasSizePx.y == 0) {
+        return {};
+    }
+    const int cellW = static_cast<int>(meta.cellSizePx_.x);
+    const int cellH = static_cast<int>(meta.cellSizePx_.y);
+    const int aw    = static_cast<int>(atlasSizePx.x);
+    const int ah    = static_cast<int>(atlasSizePx.y);
+    const int cols  = (aw - 2 * meta.margin_ + meta.padding_) / (cellW + meta.padding_);
+    const int rows  = (ah - 2 * meta.margin_ + meta.padding_) / (cellH + meta.padding_);
+    if (cols <= 0 || rows <= 0) {
+        return {};
+    }
+
+    const float faw = static_cast<float>(aw);
+    const float fah = static_cast<float>(ah);
+    const float uw  = static_cast<float>(cellW) / faw;
+    const float uh  = static_cast<float>(cellH) / fah;
+
+    std::vector<IRComponents::SpriteFrame> frames;
+    frames.reserve(static_cast<std::size_t>(cols * rows));
+    for (int row = 0; row < rows; ++row) {
+        for (int col = 0; col < cols; ++col) {
+            const float u = static_cast<float>(meta.margin_ + col * (cellW + meta.padding_)) / faw;
+            const float v = static_cast<float>(meta.margin_ + row * (cellH + meta.padding_)) / fah;
+            frames.push_back({
+                IRMath::vec4{u, v, u + uw, v + uh},
+                IRMath::ivec2{cellW, cellH}
+            });
+        }
+    }
+    return frames;
+}
+
+/// Load a sprite sheet from disk and return a populated @c C_SpriteSheet.
+///
+/// Expects two files in @p path:
+///   - @p name .png   — RGBA atlas image (loaded via stb_image).
+///   - @p name .irsprite — sidecar metadata (see @c IRAsset::loadSpriteSheetMeta).
+///
+/// The returned component owns a GPU Texture2D identified by
+/// @c sheet.textureHandle_.  The caller is responsible for releasing it via
+/// @c IRRender::destroyResource<IRRender::Texture2D>(sheet.textureHandle_)
+/// when the sheet is no longer needed.
+inline IRComponents::C_SpriteSheet loadSpriteSheet(
+    const std::string &name,
+    const std::string &path
+) {
+    IRAsset::SpriteSheetMeta meta = IRAsset::loadSpriteSheetMeta(name, path);
+
+    const std::string pngPath = path + "/" + name + ".png";
+    IRRender::ImageData img{pngPath.c_str()};
+    const IRMath::uvec2 atlasSizePx{
+        static_cast<unsigned int>(img.width_),
+        static_cast<unsigned int>(img.height_)
+    };
+
+    auto [texHandle, tex] = IRRender::createResource<IRRender::Texture2D>(
+        IRRender::TextureKind::TEXTURE_2D,
+        static_cast<unsigned int>(img.width_),
+        static_cast<unsigned int>(img.height_),
+        IRRender::TextureFormat::RGBA8,
+        IRRender::TextureWrap::CLAMP_TO_EDGE,
+        IRRender::TextureFilter::NEAREST
+    );
+    tex->subImage2D(
+        0, 0, img.width_, img.height_,
+        IRRender::PixelDataFormat::RGBA,
+        IRRender::PixelDataType::UNSIGNED_BYTE,
+        img.data_
+    );
+
+    auto frames = buildFrameTable(atlasSizePx, meta);
+
+    std::vector<IRComponents::NamedAnimation> animations;
+    animations.reserve(meta.animations_.size());
+    for (const auto &a : meta.animations_) {
+        animations.push_back({
+            a.name_,
+            IRComponents::SpriteAnimation{a.firstFrame_, a.frameCount_, a.fps_}
+        });
+    }
+
+    return IRComponents::C_SpriteSheet{
+        texHandle, atlasSizePx, std::move(frames), std::move(animations)
+    };
+}
+
+} // namespace IRSprite
+
+#endif /* ENTITY_SPRITE_SHEET_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ include(GoogleTest)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(IrredenEngineTest
+  asset/sprite_sheet_test.cpp
   audio/music_theory_test.cpp
   common/ir_platform_test.cpp
   ecs/entity_manager_test.cpp

--- a/test/asset/sprite_sheet_test.cpp
+++ b/test/asset/sprite_sheet_test.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_asset.hpp>
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+// All sidecar files are written to /tmp so no test fixtures or setup is needed.
+const std::string kTmpDir = "/tmp";
+
+TEST(SpriteSheetMeta, RoundTrip) {
+    const std::string name = "ir_test_sprite_sheet_rt";
+
+    IRAsset::SpriteSheetMeta meta{};
+    meta.cellSizePx_ = uvec2{32, 48};
+    meta.margin_     = 1;
+    meta.padding_    = 2;
+    meta.animations_ = {
+        {"idle",       0, 4,  8.0f},
+        {"walk_left",  4, 6, 12.0f},
+        {"walk_right", 10, 6, 12.0f},
+    };
+
+    IRAsset::saveSpriteSheetMeta(name, kTmpDir, meta);
+
+    const IRAsset::SpriteSheetMeta loaded = IRAsset::loadSpriteSheetMeta(name, kTmpDir);
+
+    EXPECT_EQ(loaded.cellSizePx_.x, 32u);
+    EXPECT_EQ(loaded.cellSizePx_.y, 48u);
+    EXPECT_EQ(loaded.margin_,       1);
+    EXPECT_EQ(loaded.padding_,      2);
+    ASSERT_EQ(loaded.animations_.size(), 3u);
+
+    EXPECT_EQ(loaded.animations_[0].name_,       "idle");
+    EXPECT_EQ(loaded.animations_[0].firstFrame_,  0);
+    EXPECT_EQ(loaded.animations_[0].frameCount_,  4);
+    EXPECT_FLOAT_EQ(loaded.animations_[0].fps_,  8.0f);
+
+    EXPECT_EQ(loaded.animations_[1].name_,       "walk_left");
+    EXPECT_EQ(loaded.animations_[1].firstFrame_,  4);
+    EXPECT_EQ(loaded.animations_[1].frameCount_,  6);
+    EXPECT_FLOAT_EQ(loaded.animations_[1].fps_,  12.0f);
+
+    EXPECT_EQ(loaded.animations_[2].name_,       "walk_right");
+    EXPECT_EQ(loaded.animations_[2].firstFrame_,  10);
+    EXPECT_EQ(loaded.animations_[2].frameCount_,  6);
+    EXPECT_FLOAT_EQ(loaded.animations_[2].fps_,  12.0f);
+
+    std::remove((kTmpDir + "/" + name + ".irsprite").c_str());
+}
+
+TEST(SpriteSheetMeta, OptionalFieldsDefaultToZero) {
+    const std::string name = "ir_test_sprite_sheet_defaults";
+    const std::string path = kTmpDir + "/" + name + ".irsprite";
+
+    FILE *f = fopen(path.c_str(), "w");
+    ASSERT_NE(f, nullptr) << "Could not write test sidecar to /tmp";
+    fprintf(f, "cellWidth 16\ncellHeight 24\n");
+    fclose(f);
+
+    const IRAsset::SpriteSheetMeta loaded = IRAsset::loadSpriteSheetMeta(name, kTmpDir);
+
+    EXPECT_EQ(loaded.cellSizePx_.x, 16u);
+    EXPECT_EQ(loaded.cellSizePx_.y, 24u);
+    EXPECT_EQ(loaded.margin_,       0);
+    EXPECT_EQ(loaded.padding_,      0);
+    EXPECT_TRUE(loaded.animations_.empty());
+
+    std::remove(path.c_str());
+}
+
+TEST(SpriteSheetMeta, CommentLinesIgnored) {
+    const std::string name = "ir_test_sprite_sheet_comments";
+    const std::string path = kTmpDir + "/" + name + ".irsprite";
+
+    FILE *f = fopen(path.c_str(), "w");
+    ASSERT_NE(f, nullptr);
+    fprintf(f, "# IRSprite sheet metadata\n");
+    fprintf(f, "cellWidth 64\n");
+    fprintf(f, "# another comment\n");
+    fprintf(f, "cellHeight 64\n");
+    fprintf(f, "anim run 0 8 24.0\n");
+    fclose(f);
+
+    const IRAsset::SpriteSheetMeta loaded = IRAsset::loadSpriteSheetMeta(name, kTmpDir);
+
+    EXPECT_EQ(loaded.cellSizePx_.x, 64u);
+    EXPECT_EQ(loaded.cellSizePx_.y, 64u);
+    ASSERT_EQ(loaded.animations_.size(), 1u);
+    EXPECT_EQ(loaded.animations_[0].name_, "run");
+    EXPECT_EQ(loaded.animations_[0].frameCount_, 8);
+    EXPECT_FLOAT_EQ(loaded.animations_[0].fps_, 24.0f);
+
+    std::remove(path.c_str());
+}
+
+TEST(SpriteSheetMeta, MissingFileReturnsDefault) {
+    const IRAsset::SpriteSheetMeta loaded =
+        IRAsset::loadSpriteSheetMeta("ir_test_nonexistent_sheet", kTmpDir);
+
+    EXPECT_EQ(loaded.cellSizePx_.x, 0u);
+    EXPECT_EQ(loaded.cellSizePx_.y, 0u);
+    EXPECT_TRUE(loaded.animations_.empty());
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Adds `.irsprite` plain-text sidecar format for PNG atlas sprite sheets (cell size, margin, padding, named animations).
- `IRAsset::saveSpriteSheetMeta` / `loadSpriteSheetMeta` in `engine/asset/` handle the file I/O (no GPU dependency).
- `IRSprite::loadSpriteSheet` in `engine/prefabs/irreden/render/entities/entity_sprite_sheet.hpp` wires the parsed metadata to a GPU `Texture2D` and returns a populated `C_SpriteSheet` ready to attach to an entity.
- `IRSprite::buildFrameTable` is exposed separately for callers that already have an atlas size and want to build the frame table without touching the GPU.
- Four round-trip tests in `test/asset/sprite_sheet_test.cpp` cover save/load, optional-field defaults, comment-line skipping, and missing-file handling.

## Format detail
The `.irsprite` sidecar uses the Aseprite/TexturePacker padding convention — padding is the gap between cells, not after the last cell. Atlas pixel dimensions are intentionally omitted (read from the PNG at load time).

## Test plan
- [x] `fleet-run IrredenEngineTest --gtest_filter=SpriteSheetMeta*` — 4/4 pass
- [x] `fleet-run IrredenEngineTest` — 393/393 pass (no regressions)
- [x] `fleet-build --target IRShapeDebug` — clean

## Notes for reviewer
`entity_sprite_sheet.hpp` is a new header in `engine/prefabs/irreden/render/entities/` — header-only, no new `SystemName` enum entry needed (no ECS system). The GPU texture lifetime is the caller's responsibility (documented at the function signature). `IRSprite::buildFrameTable` guards against negative `cols`/`rows` from bad sidecar data (over-large margin).

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)