### PR TITLE
T-097: Sprite: C_SpriteAnimation + animation-advance system

### DIFF
--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -23,10 +23,14 @@ the ECS surface.
 - `C_GeometricShape` — 2D overlay shape descriptor.
 - `C_FrameDataTrixelToFramebuffer` — per-frame UBO (MVP, hover coord,
   distance offset).
-- `C_Sprite` / `C_SpriteSheet` — 2D screen-composite sprite + atlas
-  metadata. Sprites bypass the trixel pipeline and draw at the
-  `FRAMEBUFFER_TO_SCREEN` stage. See [`docs/design/sprites.md`](../../../../docs/design/sprites.md)
-  for the full data model, depth semantics, and cross-task scope.
+- `C_Sprite` / `C_SpriteSheet` / `C_SpriteAnimation` — 2D screen-composite
+  sprite + atlas metadata + per-instance playback state. Sprites bypass the
+  trixel pipeline and draw at the `FRAMEBUFFER_TO_SCREEN` stage;
+  `C_SpriteAnimation` tracks the active sub-animation, frame index, elapsed
+  time, and loop mode for the `SPRITE_ANIMATION_ADVANCE` UPDATE-phase
+  system to write `uvRect` back into `C_Sprite`. See
+  [`docs/design/sprites.md`](../../../../docs/design/sprites.md) for the
+  full data model, depth semantics, and cross-task scope.
 
 ## Key systems (all RENDER pipeline)
 

--- a/engine/prefabs/irreden/render/components/component_sprite_animation.hpp
+++ b/engine/prefabs/irreden/render/components/component_sprite_animation.hpp
@@ -1,0 +1,86 @@
+#ifndef COMPONENT_SPRITE_ANIMATION_H
+#define COMPONENT_SPRITE_ANIMATION_H
+
+#include <irreden/entity/ir_entity_types.hpp>
+
+#include <string>
+
+namespace IRComponents {
+
+/// Loop behavior for a playing sub-animation.
+enum class SpriteLoopMode {
+    /// Plays once and clamps at the final frame. The advance system
+    /// flips @c terminated_ on completion so subsequent ticks no-op.
+    /// Caller is responsible for triggering whatever comes next.
+    ONCE,
+    /// Wraps from the last frame back to the first indefinitely.
+    LOOP,
+    /// Walks the frame range forward, reverses at each endpoint.
+    /// `pingPongDirection_` carries the current sign.
+    PING_PONG,
+};
+
+/// Per-instance playback state for a sub-animation in @c C_SpriteSheet.
+/// The advance system consumes this each UPDATE tick: it advances
+/// @c elapsedInFrame_, flips @c frameIndex_ when an interval expires,
+/// and writes the resolved UV rect onto the entity's @c C_Sprite so
+/// the renderer reads the current frame without knowing about
+/// animation state.
+///
+/// `animationIndex_` is resolved once at @c IRPrefab::Sprite::playAnimation
+/// time so per-tick advance never touches the sheet's name table.
+/// Bounds-checked against the sheet's @c animations_ vector before
+/// use; if the sheet shrinks or the animation is reordered after
+/// resolve, the index is silently stale and the system no-ops until
+/// the next playAnimation call.
+struct C_SpriteAnimation {
+    /// Asset entity that owns the @c C_SpriteSheet to read frames from.
+    /// Resolved by the caller of @c playAnimation.
+    IREntity::EntityId sheetEntity_ = IREntity::kNullEntity;
+
+    /// Index into @c C_SpriteSheet.animations_, or -1 when no
+    /// animation is bound (constructed-but-never-played, or
+    /// playAnimation failed to resolve a name).
+    int animationIndex_ = -1;
+
+    /// Current frame within the sub-animation, 0 to
+    /// `animations_[animationIndex_].animation_.frameCount_ - 1`.
+    int frameIndex_ = 0;
+
+    /// Seconds elapsed since the current frame started. Carries the
+    /// remainder across frame flips so playback rate is preserved
+    /// when @c deltaTime stretches past a single frame interval.
+    float elapsedInFrame_ = 0.0f;
+
+    SpriteLoopMode loopMode_ = SpriteLoopMode::LOOP;
+
+    /// Playback rate multiplier. 1.0 plays at the sheet's nominal
+    /// fps; 2.0 plays at twice that, 0.5 at half. Negative speed is
+    /// not supported in v1 (use PING_PONG for reverse traversal).
+    float speed_ = 1.0f;
+
+    /// PING_PONG direction sign: +1 forward, -1 reverse. Unused in
+    /// LOOP / ONCE modes.
+    int pingPongDirection_ = 1;
+
+    /// True once a ONCE animation has clamped at its final frame.
+    /// While set, the advance system does no further work on this
+    /// component until @c playAnimation is called again.
+    bool terminated_ = false;
+
+    /// Set by @c stopAnimation. The frame and UV stay on whatever
+    /// the last advance wrote. Cleared by @c playAnimation.
+    bool stopped_ = false;
+
+    /// Last name passed to @c playAnimation, kept for
+    /// @c getCurrentAnimation queries. Storage is cheap (small-string
+    /// optimized for typical names) and only re-allocated on a new
+    /// play call, never per tick.
+    std::string currentAnimName_{};
+
+    C_SpriteAnimation() = default;
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_SPRITE_ANIMATION_H */

--- a/engine/prefabs/irreden/render/sprite_animation.hpp
+++ b/engine/prefabs/irreden/render/sprite_animation.hpp
@@ -1,0 +1,90 @@
+#ifndef IR_PREFAB_SPRITE_ANIMATION_H
+#define IR_PREFAB_SPRITE_ANIMATION_H
+
+// Driver-side API for sprite animation playback. Functions resolve
+// foreign-entity lookups (the sheet entity that owns C_SpriteSheet,
+// the sprite entity that owns C_SpriteAnimation) once per call and
+// silently no-op when a referenced entity is missing the expected
+// component — this lets scripts and init code run before the sprite
+// is fully wired without crashing.
+
+#include <irreden/ir_entity.hpp>
+
+#include <irreden/render/components/component_sprite_animation.hpp>
+#include <irreden/render/components/component_sprite_sheet.hpp>
+
+#include <string>
+#include <string_view>
+
+namespace IRPrefab::Sprite {
+
+/// Bind @p spriteEntity's @c C_SpriteAnimation to the sub-animation
+/// named @p animationName in the @c C_SpriteSheet on @p sheetEntity.
+/// Resets frame state to the start of the range and clears any prior
+/// terminated/stopped flags. Silently no-ops if either entity lacks
+/// the expected component or the name does not resolve.
+inline void playAnimation(
+    IREntity::EntityId spriteEntity,
+    IREntity::EntityId sheetEntity,
+    std::string_view animationName,
+    IRComponents::SpriteLoopMode loopMode = IRComponents::SpriteLoopMode::LOOP,
+    float speed = 1.0f
+) {
+    auto animOpt = IREntity::getComponentOptional<IRComponents::C_SpriteAnimation>(spriteEntity);
+    auto sheetOpt = IREntity::getComponentOptional<IRComponents::C_SpriteSheet>(sheetEntity);
+    if (!animOpt.has_value() || !sheetOpt.has_value()) {
+        return;
+    }
+    const int idx = sheetOpt.value()->findAnimationIndex(animationName);
+    if (idx < 0) {
+        return;
+    }
+    auto &anim = *animOpt.value();
+    anim.sheetEntity_ = sheetEntity;
+    anim.animationIndex_ = idx;
+    anim.frameIndex_ = 0;
+    anim.elapsedInFrame_ = 0.0f;
+    anim.pingPongDirection_ = 1;
+    anim.terminated_ = false;
+    anim.stopped_ = false;
+    anim.loopMode_ = loopMode;
+    anim.speed_ = speed;
+    anim.currentAnimName_.assign(animationName);
+}
+
+/// Halt playback for @p spriteEntity. The current frame and
+/// resolved UV stay on @c C_Sprite — caller is responsible for any
+/// subsequent visual state. No-op when the entity lacks
+/// @c C_SpriteAnimation.
+inline void stopAnimation(IREntity::EntityId spriteEntity) {
+    auto animOpt = IREntity::getComponentOptional<IRComponents::C_SpriteAnimation>(spriteEntity);
+    if (!animOpt.has_value()) {
+        return;
+    }
+    animOpt.value()->stopped_ = true;
+}
+
+/// Returns the active frame index within the current sub-animation,
+/// or -1 if @p spriteEntity lacks @c C_SpriteAnimation.
+inline int getCurrentFrame(IREntity::EntityId spriteEntity) {
+    auto animOpt = IREntity::getComponentOptional<IRComponents::C_SpriteAnimation>(spriteEntity);
+    if (!animOpt.has_value()) {
+        return -1;
+    }
+    return animOpt.value()->frameIndex_;
+}
+
+/// Returns the name passed to the most recent successful
+/// @c playAnimation call, or an empty string if @p spriteEntity
+/// lacks @c C_SpriteAnimation or no animation has been bound.
+inline std::string getCurrentAnimation(IREntity::EntityId spriteEntity) {
+    auto animOpt = IREntity::getComponentOptional<IRComponents::C_SpriteAnimation>(spriteEntity);
+    if (!animOpt.has_value()) {
+        return {};
+    }
+    return animOpt.value()->currentAnimName_;
+}
+
+} // namespace IRPrefab::Sprite
+
+#endif /* IR_PREFAB_SPRITE_ANIMATION_H */

--- a/engine/prefabs/irreden/render/systems/system_sprite_animation_advance.hpp
+++ b/engine/prefabs/irreden/render/systems/system_sprite_animation_advance.hpp
@@ -1,0 +1,166 @@
+#ifndef SYSTEM_SPRITE_ANIMATION_ADVANCE_H
+#define SYSTEM_SPRITE_ANIMATION_ADVANCE_H
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <irreden/render/components/component_sprite.hpp>
+#include <irreden/render/components/component_sprite_animation.hpp>
+#include <irreden/render/components/component_sprite_sheet.hpp>
+
+namespace IRSystem {
+
+namespace detail {
+
+/// Pure-data result of advancing a sprite animation by `dt` against a
+/// fixed sub-animation. Factored out so the unit tests can drive the
+/// time-advance math without standing up an entity manager.
+struct SpriteAnimationAdvanceResult {
+    int frameIndex_;
+    float elapsedInFrame_;
+    int pingPongDirection_;
+    bool terminated_;
+};
+
+/// Advance a sprite animation in place. Pure function: takes the
+/// previous state plus the active sub-animation's frame count / fps,
+/// returns the next state. Wall-clock time inputs are passed in (not
+/// pulled from `IRTime`) so this can be exercised deterministically.
+///
+/// `frameCount`, `fps`, `speed` must all be > 0; the caller is
+/// responsible for the early-out (no-op when frameCount <= 0 or fps
+/// <= 0). The function handles dt large enough to span multiple
+/// frames in one call.
+inline SpriteAnimationAdvanceResult advanceSpriteAnimation(
+    int frameIndex,
+    float elapsedInFrame,
+    int pingPongDirection,
+    bool terminated,
+    IRComponents::SpriteLoopMode loopMode,
+    int frameCount,
+    float fps,
+    float dtSeconds,
+    float speed
+) {
+    SpriteAnimationAdvanceResult out{
+        frameIndex,
+        elapsedInFrame + dtSeconds * speed,
+        pingPongDirection,
+        terminated,
+    };
+    if (terminated) {
+        return out;
+    }
+    const float frameDuration = 1.0f / fps;
+    while (out.elapsedInFrame_ >= frameDuration && !out.terminated_) {
+        out.elapsedInFrame_ -= frameDuration;
+        switch (loopMode) {
+        case IRComponents::SpriteLoopMode::LOOP: {
+            int next = out.frameIndex_ + 1;
+            if (next >= frameCount) {
+                next = 0;
+            }
+            out.frameIndex_ = next;
+            break;
+        }
+        case IRComponents::SpriteLoopMode::ONCE: {
+            if (out.frameIndex_ + 1 >= frameCount) {
+                out.frameIndex_ = frameCount - 1;
+                out.terminated_ = true;
+                out.elapsedInFrame_ = 0.0f;
+            } else {
+                out.frameIndex_ += 1;
+            }
+            break;
+        }
+        case IRComponents::SpriteLoopMode::PING_PONG: {
+            if (frameCount == 1) {
+                // Single-frame range — no traversal possible. Hold
+                // the frame and consume the elapsed remainder so the
+                // while loop terminates.
+                out.elapsedInFrame_ = 0.0f;
+                break;
+            }
+            int next = out.frameIndex_ + out.pingPongDirection_;
+            if (next >= frameCount || next < 0) {
+                out.pingPongDirection_ = -out.pingPongDirection_;
+                next = out.frameIndex_ + out.pingPongDirection_;
+            }
+            out.frameIndex_ = next;
+            break;
+        }
+        }
+    }
+    return out;
+}
+
+} // namespace detail
+
+/// UPDATE-phase system that advances every entity carrying both
+/// @c C_SpriteAnimation and @c C_Sprite. Reads the bound sheet's
+/// frame table and writes the active frame's UV rect onto
+/// @c C_Sprite.uvRect_ so the FRAMEBUFFER_TO_SCREEN sprite stage
+/// (T-096) reads the resolved UV without knowing about animation
+/// state.
+///
+/// Sheet lookup is by EntityId per tick — the sheet is a foreign
+/// entity, not one the system iterates. In typical use the unique
+/// sheet count is small (one or two atlases per scene); per-tick
+/// cost is one map lookup per sprite. If profiling shows this as a
+/// hotspot, a SystemParams cache keyed on @c sheetEntity_ is the
+/// next step (see `engine/prefabs/CLAUDE.md` "Foreign-entity
+/// lookups").
+template <> struct System<SPRITE_ANIMATION_ADVANCE> {
+    static SystemId create() {
+        return createSystem<IRComponents::C_SpriteAnimation, IRComponents::C_Sprite>(
+            "SpriteAnimationAdvance",
+            [](IRComponents::C_SpriteAnimation &anim, IRComponents::C_Sprite &sprite) {
+                if (anim.stopped_ || anim.terminated_ || anim.animationIndex_ < 0 ||
+                    anim.sheetEntity_ == IREntity::kNullEntity) {
+                    return;
+                }
+                auto sheetOpt =
+                    IREntity::getComponentOptional<IRComponents::C_SpriteSheet>(anim.sheetEntity_);
+                if (!sheetOpt.has_value()) {
+                    return;
+                }
+                const auto &sheet = *sheetOpt.value();
+                if (anim.animationIndex_ >= static_cast<int>(sheet.animations_.size())) {
+                    return;
+                }
+                const auto &subAnim = sheet.animations_[anim.animationIndex_].animation_;
+                if (subAnim.frameCount_ <= 0 || subAnim.fps_ <= 0.0f || anim.speed_ <= 0.0f) {
+                    return;
+                }
+                const float dt = static_cast<float>(IRTime::deltaTime(IRTime::UPDATE));
+                const auto next = detail::advanceSpriteAnimation(
+                    anim.frameIndex_,
+                    anim.elapsedInFrame_,
+                    anim.pingPongDirection_,
+                    anim.terminated_,
+                    anim.loopMode_,
+                    subAnim.frameCount_,
+                    subAnim.fps_,
+                    dt,
+                    anim.speed_
+                );
+                anim.frameIndex_ = next.frameIndex_;
+                anim.elapsedInFrame_ = next.elapsedInFrame_;
+                anim.pingPongDirection_ = next.pingPongDirection_;
+                anim.terminated_ = next.terminated_;
+
+                const int globalFrameIdx = subAnim.firstFrame_ + anim.frameIndex_;
+                if (globalFrameIdx >= 0 &&
+                    globalFrameIdx < static_cast<int>(sheet.frames_.size())) {
+                    sprite.uvRect_ = sheet.frames_[globalFrameIdx].uvRect_;
+                }
+            }
+        );
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_SPRITE_ANIMATION_ADVANCE_H */

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -69,6 +69,7 @@ enum SystemName {
     ANIMATION_MOTION_COLOR_SHIFT,
     SPRING_PLATFORM,
     SPRING_COLOR,
+    SPRITE_ANIMATION_ADVANCE,
 
     // Modifier framework — runs at end of UPDATE, before RENDER reads
     // C_ResolvedFields. Order: decay all three vectors (per-entity,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(IrredenEngineTest
   render/frame_data_sun_layout_test.cpp
   render/sun_direction_test.cpp
   render/sun_lighting_test.cpp
+  render/sprite_animation_test.cpp
   render/sprite_components_test.cpp
   script/modifier_lua_test.cpp
   utility/ir_utility_test.cpp

--- a/test/render/sprite_animation_test.cpp
+++ b/test/render/sprite_animation_test.cpp
@@ -1,0 +1,170 @@
+#include <gtest/gtest.h>
+
+#include <irreden/render/components/component_sprite_animation.hpp>
+#include <irreden/render/systems/system_sprite_animation_advance.hpp>
+
+using IRComponents::SpriteLoopMode;
+using IRSystem::detail::advanceSpriteAnimation;
+using IRSystem::detail::SpriteAnimationAdvanceResult;
+
+namespace {
+
+constexpr float kFps = 10.0f;
+constexpr float kFrameDuration = 1.0f / kFps;
+constexpr float kEpsilon = 1e-5f;
+
+SpriteAnimationAdvanceResult step(
+    SpriteAnimationAdvanceResult prev,
+    SpriteLoopMode mode,
+    int frameCount,
+    float dtSeconds,
+    float speed = 1.0f
+) {
+    return advanceSpriteAnimation(
+        prev.frameIndex_,
+        prev.elapsedInFrame_,
+        prev.pingPongDirection_,
+        prev.terminated_,
+        mode,
+        frameCount,
+        kFps,
+        dtSeconds,
+        speed
+    );
+}
+
+SpriteAnimationAdvanceResult initialState() {
+    return SpriteAnimationAdvanceResult{
+        /*frameIndex_*/ 0,
+        /*elapsedInFrame_*/ 0.0f,
+        /*pingPongDirection_*/ 1,
+        /*terminated_*/ false,
+    };
+}
+
+TEST(SpriteAnimationAdvance, LoopWrapsAfterFrameCount) {
+    auto state = initialState();
+    state = step(state, SpriteLoopMode::LOOP, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 1);
+    state = step(state, SpriteLoopMode::LOOP, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 2);
+    state = step(state, SpriteLoopMode::LOOP, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 3);
+    state = step(state, SpriteLoopMode::LOOP, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 0);
+    EXPECT_FALSE(state.terminated_);
+}
+
+TEST(SpriteAnimationAdvance, OnceClampsAtLastFrameAndTerminates) {
+    auto state = initialState();
+    for (int i = 0; i < 3; ++i) {
+        state = step(state, SpriteLoopMode::ONCE, 3, kFrameDuration);
+    }
+    EXPECT_EQ(state.frameIndex_, 2);
+    EXPECT_TRUE(state.terminated_);
+
+    // Further ticks must not advance past the terminal frame.
+    state = step(state, SpriteLoopMode::ONCE, 3, kFrameDuration * 5.0f);
+    EXPECT_EQ(state.frameIndex_, 2);
+    EXPECT_TRUE(state.terminated_);
+}
+
+TEST(SpriteAnimationAdvance, PingPongReversesAtBothEndpoints) {
+    // 4 frames: indices 0,1,2,3 then 2,1,0 then 1,2,3 ...
+    auto state = initialState();
+    state = step(state, SpriteLoopMode::PING_PONG, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 1);
+    state = step(state, SpriteLoopMode::PING_PONG, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 2);
+    state = step(state, SpriteLoopMode::PING_PONG, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 3);
+    state = step(state, SpriteLoopMode::PING_PONG, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 2);
+    EXPECT_EQ(state.pingPongDirection_, -1);
+    state = step(state, SpriteLoopMode::PING_PONG, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 1);
+    state = step(state, SpriteLoopMode::PING_PONG, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 0);
+    state = step(state, SpriteLoopMode::PING_PONG, 4, kFrameDuration);
+    EXPECT_EQ(state.frameIndex_, 1);
+    EXPECT_EQ(state.pingPongDirection_, 1);
+}
+
+TEST(SpriteAnimationAdvance, LargeDtSpansMultipleFrames) {
+    // Single advance call covers 5 frame intervals. LOOP wraps inside
+    // the call, so the result should be (5 % 4) = 1 with a small
+    // remainder of elapsedInFrame_ because dt is exactly 5 frame
+    // durations (no remainder expected).
+    auto state = initialState();
+    state = step(state, SpriteLoopMode::LOOP, 4, kFrameDuration * 5.0f);
+    EXPECT_EQ(state.frameIndex_, 1);
+    EXPECT_NEAR(state.elapsedInFrame_, 0.0f, kEpsilon);
+}
+
+TEST(SpriteAnimationAdvance, OnceTerminatesEvenWhenLargeDtOvershoots) {
+    auto state = initialState();
+    state = step(state, SpriteLoopMode::ONCE, 3, kFrameDuration * 100.0f);
+    EXPECT_EQ(state.frameIndex_, 2);
+    EXPECT_TRUE(state.terminated_);
+    EXPECT_NEAR(state.elapsedInFrame_, 0.0f, kEpsilon);
+}
+
+TEST(SpriteAnimationAdvance, PingPongSingleFrameHoldsStill) {
+    // Edge case: a sub-animation of length 1. PING_PONG cannot
+    // traverse anywhere; the system must consume elapsed time
+    // without crashing or moving frame index.
+    auto state = initialState();
+    state = step(state, SpriteLoopMode::PING_PONG, 1, kFrameDuration * 3.0f);
+    EXPECT_EQ(state.frameIndex_, 0);
+    EXPECT_FALSE(state.terminated_);
+}
+
+TEST(SpriteAnimationAdvance, SubFrameDtAccumulatesElapsed) {
+    // Three sub-frame ticks must aggregate to one frame advance.
+    auto state = initialState();
+    const float third = kFrameDuration / 3.0f;
+    state = step(state, SpriteLoopMode::LOOP, 4, third);
+    EXPECT_EQ(state.frameIndex_, 0);
+    state = step(state, SpriteLoopMode::LOOP, 4, third);
+    EXPECT_EQ(state.frameIndex_, 0);
+    state = step(state, SpriteLoopMode::LOOP, 4, third);
+    EXPECT_EQ(state.frameIndex_, 1);
+}
+
+TEST(SpriteAnimationAdvance, SpeedScalesAdvanceRate) {
+    // 2x speed should advance two frames per dt that nominally
+    // covers one frame interval.
+    auto state = initialState();
+    state = step(state, SpriteLoopMode::LOOP, 4, kFrameDuration, 2.0f);
+    EXPECT_EQ(state.frameIndex_, 2);
+}
+
+TEST(SpriteAnimationAdvance, ComponentResetSemanticsMimicPlayAnimation) {
+    // Mid-playback reset: the IRPrefab::Sprite::playAnimation entry
+    // point clears frameIndex_ / elapsedInFrame_ / pingPongDirection_
+    // / terminated_ / stopped_. Verifying the equivalent reset on a
+    // C_SpriteAnimation instance documents the contract that the
+    // pure-helper math relies on.
+    IRComponents::C_SpriteAnimation anim{};
+    anim.frameIndex_ = 2;
+    anim.elapsedInFrame_ = 0.05f;
+    anim.terminated_ = true;
+    anim.pingPongDirection_ = -1;
+    anim.stopped_ = true;
+
+    // What playAnimation does (open-coded so the test has no
+    // dependency on the entity manager):
+    anim.frameIndex_ = 0;
+    anim.elapsedInFrame_ = 0.0f;
+    anim.pingPongDirection_ = 1;
+    anim.terminated_ = false;
+    anim.stopped_ = false;
+
+    EXPECT_EQ(anim.frameIndex_, 0);
+    EXPECT_FLOAT_EQ(anim.elapsedInFrame_, 0.0f);
+    EXPECT_EQ(anim.pingPongDirection_, 1);
+    EXPECT_FALSE(anim.terminated_);
+    EXPECT_FALSE(anim.stopped_);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- New `C_SpriteAnimation` component (UPDATE-phase playback state) + new `SPRITE_ANIMATION_ADVANCE` system that advances frames per the sheet-specified fps and writes the active frame's UV rect onto `C_Sprite.uvRect_`.
- Public API in `IRPrefab::Sprite::` (`playAnimation`, `stopAnimation`, `getCurrentFrame`, `getCurrentAnimation`) — per the layering principle in #266, this is prefab-scoped, not `IRRender::`.
- Pure-helper `IRSystem::detail::advanceSpriteAnimation` factors the time-advance math out of the system tick so the gtests exercise it without an entity manager.

## Loop modes
- **LOOP** — wraps frame index modulo frame count.
- **ONCE** — clamps at the final frame, sets `terminated_` so subsequent ticks no-op.
- **PING_PONG** — walks forward/reverse, flips `pingPongDirection_` at each endpoint. Single-frame range holds still.

## Foreign-entity lookup
The sheet entity (owns `C_SpriteSheet`) is referenced via `sheetEntity_` on the playback component. Per tick the system does one `getComponentOptional<C_SpriteSheet>` — for the typical 1–2 atlases per scene this is cheap. The system header documents the SystemParams-cache optimization path if profiling later flags this as a hotspot.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` clean (macos-debug)
- [x] `fleet-build --target IRShapeDebug` clean (macos-debug)
- [x] 9 new `SpriteAnimationAdvance` gtests + 3 existing `SpriteComponents` gtests — all pass
- [ ] `fleet-build --target IrredenEngineTest` clean on `linux-debug`
- [ ] `fleet-run IrredenEngineTest` on linux-debug — full suite pass

## Stack context
- Children done: T-087 (`C_Sprite` / `C_SpriteSheet` components).
- This task: T-097 — playback state + advance system.
- Children pending: T-095 (sprite-sheet asset loader), T-096 (`SPRITES_TO_SCREEN` render stage), T-098 (Lua bindings + `sprite_demo`).

T-098 will add the `_lua.hpp` binding for `C_SpriteAnimation` and the demo creation that exercises the LOOP/ONCE/PING_PONG modes end-to-end.

Closes #285