### PR TITLE
role docs: drop stale loop/babysit cadence claims (transient model)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -89,7 +89,7 @@ the cooldown label prevents an immediate retry.
 ## Startup actions (do these immediately, in order)
 
 0. Print your role banner:
-   `[merger] Auto-rebases stale PRs and sort-merges TASKS.md conflicts. Loop: every 10m.`
+   `[merger] Auto-rebases stale PRs and sort-merges TASKS.md conflicts. Transient — re-fires when scout sees actionable PR state.`
 1. `pwd` — confirm you are in the `merger` worktree.
 2. **Discover engine repo slug** by Read'ing `~/.fleet/state/repos.json`
    (written once by `fleet-up` at startup). Use the `engine` field
@@ -576,9 +576,9 @@ exit cleanly:
    and silently strip from the saved summary (observed on
    opus-reviewer 2026-05-02). Write technical references in plain
    prose (`scale > 1` becomes `scale gt 1` or `the scale gate`).
-   Then print `[merger] Iteration complete. Next run in ~10m.`
-   Then exit cleanly. The `/loop` driver will re-invoke in 10
-   minutes.
+   Then print `[merger] Iteration complete. Will re-fire on next dispatcher trigger.`
+   Then exit cleanly. fleet-dispatcher re-fires this role when the
+   scout's projection sees new actionable PR state.
 
 If Mode above is `dry-run`: do startup actions only and stop at
 the `merger standing by (dry-run)` line. The PR list is not

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -97,7 +97,7 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
 ## Startup actions
 
 0. Print your role banner:
-   `[opus-reviewer] Final reviewer — Opus recheck on PRs touching core engine invariants or flagged by Sonnet. Loop: every 30m.`
+   `[opus-reviewer] Final reviewer — Opus recheck on PRs touching core engine invariants or flagged by Sonnet. Transient — re-fires when scout sees actionable PR state.`
 1. `pwd` — confirm you are in the `opus-reviewer` worktree.
 2. **Discover repo slugs** by Read'ing `~/.fleet/state/repos.json`
    (written once by `fleet-up` at startup). Use the `engine` field
@@ -321,9 +321,10 @@ iteration of polling, reviewing, and exiting cleanly:
    opus-reviewer 2026-05-02). Write technical references in plain
    prose (`scale > 1` becomes `scale gt 1` or `the scale gate`).
    Then print
-   `[opus-reviewer] Iteration complete. Next run in ~30m (fresh context).`
-   Then exit cleanly. `fleet-babysit` relaunches a fresh `claude` in
-   ~30 minutes — no carry-over from this iteration.
+   `[opus-reviewer] Iteration complete. Will re-fire on next dispatcher trigger.`
+   Then exit cleanly. fleet-dispatcher launches a fresh `claude` for
+   this role when the scout's projection sees new actionable PR
+   state — no carry-over between iterations.
 5. If you hit a usage-limit error: print the error and exit.
    `fleet-babysit` waits the limit-delay before relaunching.
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -125,7 +125,7 @@ fleet-claim --repo game claim "T-001" opus-worker-1
 ## Startup actions (do these immediately, in order)
 
 0. Print your role banner:
-   `[opus-worker] Plans fleet:needs-plan issues, executes [opus] tasks from engine + game TASKS.md. Loop: every 20m (fresh context).`
+   `[opus-worker] Plans fleet:needs-plan issues, executes [opus] tasks from engine + game TASKS.md. Transient — re-fires when scout sees actionable state (each iteration runs in fresh context).`
 1. `pwd` and confirm you are in an engine `opus-worker-*` worktree (not
    opus-architect, not a reviewer worktree). The directory basename
    (`opus-worker-1` or `opus-worker-2`) is your **agent name** — pass
@@ -708,7 +708,7 @@ Do the work, then exit cleanly:
    means the work would never get done. Pick it up.
 
    If no `Model: opus` tasks are available on either repo, print
-   `[opus-worker] No unblocked [opus] tasks (engine + game). Next run in ~20m.`
+   `[opus-worker] No unblocked [opus] tasks (engine + game). Will re-fire on next dispatcher trigger.`
    and exit cleanly. Do NOT invent work, self-assign documentation
    passes, or create tasks outside the queue.
 
@@ -1032,10 +1032,11 @@ Do the work, then exit cleanly:
     Then use the `start-next-task` skill to land on a fresh
     branch off `origin/master` in the **current cwd's repo** (engine
     if you didn't cd; game if you did). Print
-    `[opus-worker] Iteration complete. Next run in ~20m (fresh context).`
-    Then exit cleanly. `fleet-babysit` will relaunch a fresh `claude`
-    in ~20 minutes — the new process lands cwd back in the engine
-    worktree, so the next iteration starts from a clean slate.
+    `[opus-worker] Iteration complete. Will re-fire on next dispatcher trigger.`
+    Then exit cleanly. fleet-dispatcher launches a fresh `claude` for
+    this role when the scout's projection sees new actionable state —
+    the new process lands cwd back in the engine worktree, so the
+    next iteration starts from a clean slate.
 
 ## Mode behavior
 
@@ -1071,10 +1072,14 @@ or `review-only` (passed by `fleet-babysit` from `fleet-up`'s mode arg).
   step 1c finds no semantic conflicts, and step 3's molecule resume
   returns empty, print
   `[opus-worker] review-only: nothing to address this iteration.`
-  and exit. fleet-babysit will relaunch you on the normal cadence.
+  and exit. fleet-dispatcher will re-fire when scout sees new
+  actionable state.
 
-If you hit a usage-limit error: print the error and exit. `fleet-babysit`
-detects exit code 2 and waits the limit-delay before relaunching.
+If you hit a usage-limit error: print the error and exit. The pane
+returns to shell; fleet-dispatcher's next tick clears the dispatch
+record. The dispatcher does not implement usage-limit back-off, so
+the next scout-trigger will re-fire and may hit the same limit —
+flag the limit in your iteration summary so the human can adjust.
 
 ## End-of-iteration feedback
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -71,7 +71,7 @@ Run each step as its own **single** tool call. Never combine with
 use `cat` — use the Read tool for files.
 
 0. Print your role banner:
-   `[queue-manager] Task intake — ingests approved issues into TASKS.md, syncs PR state, maintains the queue. Loop: every 5m. You can also type task descriptions here between loop fires.`
+   `[queue-manager] Task intake — ingests approved issues into TASKS.md, syncs PR state, maintains the queue. Transient — re-fires when scout sees new human:approved issues. You can also type task descriptions at the zsh prompt between iterations.`
 1. `pwd`
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
 3. **Discover repo slugs** by Read'ing `~/.fleet/state/repos.json`
@@ -769,7 +769,7 @@ You are the sole TASKS.md editor. Each maintenance pass:
     references in plain prose.
     `Maintenance: X issues ingested, Y tasks flipped, Z claims cleaned, W epics closed`
     `Queue: X open (Y opus, Z sonnet) · N in-progress · M done`
-    `[queue-manager] Iteration complete. Next run in ~5m.`
+    `[queue-manager] Iteration complete. Will re-fire on next dispatcher trigger.`
 
 ## End-of-iteration feedback
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -702,10 +702,11 @@ Each iteration:
 
    Then use the `start-next-task` skill to land on a fresh branch off
    `origin/master`. Print
-   `[sonnet-author] Iteration complete. Exiting; babysit will relaunch with fresh context.`
+   `[sonnet-author] Iteration complete. Will re-fire on next dispatcher trigger.`
    Then exit cleanly (do NOT loop back to step 1 inside this same
-   `claude` session — `fleet-babysit` handles the relaunch with a
-   clean conversation).
+   `claude` session — fleet-dispatcher launches a fresh `claude` for
+   each iteration when scout sees new actionable state, so each run
+   has clean conversation context).
 
 ## Mode behavior
 
@@ -733,7 +734,8 @@ or `review-only` (passed by `fleet-babysit` from `fleet-up`'s mode arg).
   If step 1 finds no flagged PRs and step 1b finds no smoke-pending
   PRs, print
   `[sonnet-author] review-only: nothing to address this iteration.`
-  and exit. fleet-babysit will relaunch you on the normal cadence.
+  and exit. fleet-dispatcher will re-fire when scout sees new
+  actionable state.
 
 ## Usage-limit handling
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -66,7 +66,7 @@ treat it as a hard rule for this role.
 ## Startup actions
 
 0. Print your role banner:
-   `[sonnet-reviewer] First-pass PR reviewer — polls for unreviewed PRs, posts structured reviews, flags Opus escalations. Loop: every 3m.`
+   `[sonnet-reviewer] First-pass PR reviewer — polls for unreviewed PRs, posts structured reviews, flags Opus escalations. Transient — re-fires when scout sees actionable PR state.`
 1. `pwd` — confirm you are in the `sonnet-reviewer` worktree.
 2. **Discover repo slugs** by Read'ing `~/.fleet/state/repos.json`
    (written once by `fleet-up` at startup). Use the `engine` field
@@ -355,9 +355,10 @@ iteration of polling, reviewing, and exiting cleanly:
    and silently strip from the saved summary. Write technical
    references in plain prose.
    Then print
-   `[sonnet-reviewer] Iteration complete. Next run in ~3m (fresh context).`
-   Then exit cleanly. `fleet-babysit` relaunches a fresh `claude` in
-   ~3 minutes — no carry-over from this iteration.
+   `[sonnet-reviewer] Iteration complete. Will re-fire on next dispatcher trigger.`
+   Then exit cleanly. fleet-dispatcher launches a fresh `claude` for
+   this role when the scout's projection sees new actionable PR
+   state — no carry-over between iterations.
 5. If you hit a usage-limit error: print the error and exit.
    `fleet-babysit` waits the limit-delay before relaunching.
 


### PR DESCRIPTION
## Summary

Workers are transient (PR #463) — each iteration is a one-shot \`claude --print\` spawned by fleet-dispatcher when the scout sees new actionable state. There's no fixed cadence. Yet role docs still print babysit-era language at iteration start/end:

\`\`\`
[opus-reviewer] Final reviewer — ... Loop: every 30m.
[opus-reviewer] Iteration complete. Next run in ~30m (fresh context).
\`\`\`

Misleading. Actual re-fire latency is "whenever scout sees a projection delta" — could be 30s when state's moving, hours during quiet stretches. The "~30m" claim suggested a guaranteed cadence that does not exist. Observed in opus-reviewer pane: \"Iteration complete. Next run in ~30m\" → next run fired ~3 minutes later when a PR landed. Confusing for the human reading the pane.

## Replacements

For each of the 6 transient roles (merger, queue-manager, sonnet-author, sonnet-reviewer, opus-worker, opus-reviewer):

| Old | New |
|---|---|
| \`Loop: every Nm.\` (banner) | \`Transient — re-fires when scout sees actionable state.\` |
| \`Next run in ~Nm (fresh context)\` (exit) | \`Will re-fire on next dispatcher trigger.\` |
| \`fleet-babysit relaunches with fresh context\` | \`fleet-dispatcher launches a fresh claude when scout sees new actionable state — no carry-over\` |
| \`fleet-babysit will relaunch you on the normal cadence\` (review-only / no-work exits) | \`fleet-dispatcher will re-fire when scout sees new actionable state\` |

Plus updated the opus-worker usage-limit note to reflect that the dispatcher does NOT implement back-off (the pane just returns to shell on exit; next trigger re-fires and may hit the same limit).

## What's NOT in this PR

The deeper operational sections (log rotation, ~Nm relaunch comments inside mode docs, "fleet-babysit handles scheduling and crash recovery" notes) still mention fleet-babysit. Those are docs the role reads about its environment — stale but not printed to the human each iteration. A follow-up doc sweep can clean them up; this PR is scoped to the user-visible per-iteration text.

Architects (opus-architect, game-architect) genuinely still use fleet-babysit (interactive --resume sessions don't fit the transient model), so references to fleet-babysit in their context remain correct.

## Test plan

- [x] All 14 \`Loop: every Nm\` / \`Next run in ~Nm\` references in role docs are gone (\`grep -E "Loop: every|Next run in" .claude/commands/role-*.md\` returns empty)
- [ ] Next iteration of each role prints the new banner/exit text — verify by attaching to the pane after PR lands and observing one full iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)