### PR TITLE
fleet-dispatcher: periodic re-arm for queue-manager + merger

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -71,6 +71,31 @@ SHUTDOWN_FLAG="$HOME/.fleet/shutdown-in-progress"
 # keeps pickup snappy without burning measurable CPU.
 POLL_INTERVAL_SECONDS="${FLEET_DISPATCHER_INTERVAL:-10}"
 
+# Periodic safety-net re-arm for queue-manager and merger. The
+# scout's queue-manager projection is insensitive to PR-merge events
+# (closing a fleet:queued issue doesn't move it INTO any of the
+# tracked lists; it just disappears), so when a wave of PRs merges
+# the chain stalls: queue-manager doesn't re-trigger → TASKS.md isn't
+# flipped from [~] → [x] → opus-worker projection doesn't change →
+# opus-worker doesn't re-fire. Workers sit idle despite there being
+# obvious follow-up work to do.
+#
+# Until project_queue_manager learns to track "closed fleet:queued
+# issues that haven't been flipped in TASKS.md yet" (the proper
+# fix), this periodic re-arm restores the babysit-era cadence for
+# the two meta-roles.
+#
+# queue-manager re-arms UNCONDITIONALLY (modulo in-flight / pending
+# checks) — its projection is insensitive to PR-merge events, so
+# an "empty" projection doesn't necessarily mean "no work". A no-op
+# iteration is ~30 s of claude time and the safe default.
+#
+# merger re-arms only when its projection has open PRs — its
+# projection is responsive to PR state changes, so the periodic
+# rearm just covers the corner case where a scout-fired trigger
+# was missed.
+PERIODIC_REARM_INTERVAL_SECONDS="${FLEET_DISPATCHER_REARM_INTERVAL:-300}"
+
 # Roles this dispatcher is responsible for. Architects are excluded
 # (kept on fleet-babysit). Aligned with the worker / reviewer /
 # queue-mgr / merger roles in fleet-up.
@@ -331,6 +356,78 @@ release_dispatcher_lock() {
     fi
 }
 
+rearm_periodic_meta_triggers() {
+    # Write fresh queue-manager / merger triggers when due. Skips if a
+    # trigger is already pending or an iteration is already in flight.
+    #
+    # queue-manager fires UNCONDITIONALLY every cycle (modulo in-flight
+    # / pending checks): its projection is insensitive to PR-merge
+    # events (closing a fleet:queued issue removes it from
+    # human_approved without triggering a delta), so an "empty"
+    # projection does NOT mean "nothing to do" — there may be merged
+    # PRs whose [~] tasks haven't been flipped to [x] yet. The role
+    # itself does the consistency reconciliation; a no-op iteration is
+    # ~30s of claude time and the safe default.
+    #
+    # merger keeps an actionable predicate: its projection IS
+    # responsive (PRs appear/disappear on merge), so we only need to
+    # rearm when the natural trigger chain might be lagging.
+    python3 - <<'PY' || true
+import json
+import pathlib
+
+STATE = pathlib.Path("~/.fleet/state").expanduser()
+PROJ = STATE / "projections"
+TRIG = STATE / "triggers"
+DISP = STATE / "dispatch"
+TRIG.mkdir(parents=True, exist_ok=True)
+
+
+def merger_actionable(p):
+    return bool(p.get("prs"))
+
+
+def role_in_flight(role):
+    if not DISP.is_dir():
+        return False
+    for f in DISP.glob("*.json"):
+        try:
+            data = json.loads(f.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("role") == role:
+            return True
+    return False
+
+
+def maybe_arm(role, predicate=None):
+    if predicate is not None:
+        proj = PROJ / f"{role}.json"
+        if not proj.is_file():
+            return
+        try:
+            data = json.loads(proj.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        if not predicate(data):
+            return
+    trig_file = TRIG / role
+    if trig_file.exists():
+        # Already armed (scout, prior rearm, fleet-up bootstrap).
+        return
+    if role_in_flight(role):
+        # Iteration already running for this role.
+        return
+    trig_file.touch()
+    note = "actionable projection" if predicate is not None else "unconditional cadence"
+    print(f"periodic re-arm: {role} ({note}, no in-flight)")
+
+
+maybe_arm("queue-manager")  # unconditional
+maybe_arm("merger", merger_actionable)
+PY
+}
+
 main() {
     mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$TRIGGERS_DIR" "$DISPATCH_DIR"
 
@@ -340,7 +437,17 @@ main() {
     fi
 
     write_pid_file
-    log "started (pid=$$, interval=${POLL_INTERVAL_SECONDS}s)"
+    log "started (pid=$$, interval=${POLL_INTERVAL_SECONDS}s, rearm=${PERIODIC_REARM_INTERVAL_SECONDS}s)"
+
+    # Periodic re-arm runs every Nth tick where N covers
+    # PERIODIC_REARM_INTERVAL_SECONDS. Pre-compute and clamp to >=1
+    # in case someone sets a poll interval longer than the rearm
+    # window (would otherwise produce a div-by-zero in the modulo).
+    local rearm_ticks=$((PERIODIC_REARM_INTERVAL_SECONDS / POLL_INTERVAL_SECONDS))
+    if (( rearm_ticks < 1 )); then
+        rearm_ticks=1
+    fi
+    local tick_count=0
 
     while true; do
         if [[ -f "$SHUTDOWN_FLAG" ]]; then
@@ -350,11 +457,20 @@ main() {
 
         cleanup_stale_dispatches
 
+        # Periodic safety net for chain-broken meta-roles (queue-manager,
+        # merger). Runs first so any rearm-written triggers are picked
+        # up by the normal dispatch_role pass on the same tick.
+        if (( tick_count % rearm_ticks == 0 )); then
+            rearm_periodic_meta_triggers
+        fi
+
         if session_exists; then
             for role in "${DISPATCHED_ROLES[@]}"; do
                 dispatch_role "$role"
             done
         fi
+
+        tick_count=$((tick_count + 1))
 
         # Interruptible sleep — wake on shutdown.
         for _ in $(seq 1 "$POLL_INTERVAL_SECONDS"); do


### PR DESCRIPTION
## Summary

Workers were sitting idle for hours despite obvious actionable work in the queue, because the queue-manager projection is **insensitive to PR-merge events**, breaking the trigger chain at the meta-role layer.

### The chain break

\`\`\`
PR merges → linked fleet:queued issue closes
          → issue drops out of \`human_approved\` (already excluded since it has fleet:queued)
          → does NOT move into \`needs_plan\`
          → TASKS.md \`tasks.done\` doesn't change (queue-manager hasn't run yet)
          → queue-manager projection content UNCHANGED
          → scout sees no delta, no trigger fires
          → queue-manager never runs to flip [~] → [x]
          → opus-worker projection (which reads TASKS.md tasks_open) doesn't change
          → no opus-worker trigger
          → workers idle, despite [x] flips being trivially overdue
\`\`\`

Observed today: queue-manager last ran at **17:57Z**; T-095/T-097/T-099 PRs merged **hours later** but TASKS.md still shows them as \`[~]\`. Both opus-worker panes were idle while T-096 and T-100 (blocked on the un-flipped tasks) sat un-claimable.

### Fix

Add a periodic safety-net re-arm in the dispatcher's main loop. Every \`PERIODIC_REARM_INTERVAL_SECONDS\` (default 300, env-overridable via \`FLEET_DISPATCHER_REARM_INTERVAL\`):

- **queue-manager** fires **unconditionally** (modulo no-trigger-pending + no-iteration-in-flight checks). Its projection lies; "empty" doesn't mean "nothing to do". A no-op iteration is ~30s of claude time, cheap.
- **merger** keeps an actionable predicate (\`prs\` non-empty). Its projection IS responsive to PR state, so this is just a safety net for missed scout triggers.

This restores the babysit-era "every 5m" cadence for the two meta-roles, but only as a safety net — the trigger-driven path still works for events the projections DO catch.

### What this does NOT change

- Author/reviewer roles (opus-worker, sonnet-author, opus-reviewer, sonnet-reviewer) still rely entirely on scout deltas. Their projections are responsive to TASKS.md / PR state, so they don't need the periodic safety net. Once queue-manager runs and updates TASKS.md, they fire naturally on the next scout tick.
- Existing trigger semantics (scout writes triggers on projection delta; dispatcher consumes) are unchanged. The periodic rearm is purely additive.

### Proper fix (follow-up)

Update \`project_queue_manager\` in fleet-state-scout to include "closed fleet:queued issues that haven't been flipped in TASKS.md yet" as actionable signal. Then PR-merge → projection delta → trigger fires naturally, and this periodic crutch becomes unnecessary. Filing as a follow-up.

### Test plan

- [x] \`bash -n scripts/fleet/fleet-dispatcher\` passes
- [x] Inline-Python dry-run against current fleet state shows \`queue-manager: would_arm=True\` (correct — system is in the chain-broken state) and \`merger: would_arm=True\` (correct — has open PRs)
- [ ] After fleet restart with this change: dispatcher.log shows \`periodic re-arm: queue-manager (unconditional cadence, no in-flight)\` once per 5min, queue-manager runs and flips stale [~] entries, opus-worker fires naturally on the resulting projection delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)