### PR TITLE
T-105: fleet-scout: fire queue-manager trigger on PR-merge events

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -22,11 +22,13 @@ prompts.
 Read your pre-filtered slice at
 `~/.fleet/state/projections/queue-manager.json` — `needs_plan`
 (open issues awaiting plans), `human_approved` (issues ready to
-ingest, with `fleet:queued` already filtered out), and
-`tasks_done` (TASKS.md done section). ~5 KB vs. ~32 KB for full
-`state.json`. Fall back to `state.json` for cross-role data
-(e.g. open PRs to scan for `Closes #N` references — the slice
-doesn't carry full PR records).
+ingest, with `fleet:queued` already filtered out),
+`tasks_done` (TASKS.md done section), and `needs_flip`
+(in-progress tasks whose linked `fleet:queued` issue closed after
+a PR merged, but TASKS.md hasn't been flipped to `[x]` yet).
+~5 KB vs. ~32 KB for full `state.json`. Fall back to `state.json`
+for cross-role data (e.g. open PRs to scan for `Closes #N`
+references — the slice doesn't carry full PR records).
 
 The cached `tasks` data reflects `origin/master`. The
 queue-manager's own in-progress edits sit in the working tree

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -75,7 +75,7 @@ just the items that role works on:
 | opus-worker | `tasks_open` (filtered to `[opus]` tasks, both repos), `needs_plan`, `feedback_prs` |
 | sonnet-reviewer | `candidate_prs` (review-skip filter applied) |
 | opus-reviewer | `flagged_prs` (`fleet:has-nits` / `fleet:needs-fix`) |
-| queue-manager | `needs_plan`, `human_approved`, `tasks_done` |
+| queue-manager | `needs_plan`, `human_approved`, `tasks_done`, `needs_flip` (in-progress tasks whose linked issue closed) |
 | merger | `prs` (engine, approved or non-MERGEABLE only) |
 
 **Read the projection first.** It's ~5 KB vs. ~32 KB for full

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -179,6 +179,29 @@ def fetch_human_approved(repo):
     return fetch_issues_by_label(repo, "human:approved", _ALREADY_QUEUED_LABELS)
 
 
+def fetch_closed_fleet_queued(repo, limit=20):
+    # Closed fleet:queued issues whose TASKS.md [~] entry hasn't been flipped
+    # to [x] yet. --limit caps API cost; recently-closed issues are returned
+    # first by default so the 20-item window covers any realistic merge wave.
+    out = run_capture([
+        "gh", "issue", "list", "--repo", repo,
+        "--label", "fleet:queued", "--state", "closed",
+        "--limit", str(limit),
+        "--json", "number,title,labels,updatedAt",
+    ])
+    if out is None:
+        return []
+    try:
+        issues = json.loads(out)
+    except json.JSONDecodeError as e:
+        log(f"gh issue list {repo} --label fleet:queued --state closed: bad JSON: {e}")
+        return []
+    for issue in issues:
+        issue["labels"] = sorted(lbl["name"] for lbl in issue.get("labels", []))
+    issues.sort(key=lambda issue: issue.get("number", 0))
+    return issues
+
+
 TASK_HEADER_RE = re.compile(r"^- \[([ ~x!])\] \*\*(.+?)\*\*\s*(?:—\s*(.*))?$")
 TASK_FIELD_RE = re.compile(r"^\s+- \*\*([^:]+?):\*\*\s*(.+?)\s*$")
 SECTION_RE = re.compile(r"^##\s+(.+?)\s*$")
@@ -614,6 +637,21 @@ def project_opus_reviewer(state):
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
+def _needs_flip_entries(repo_state):
+    # Yield (task_id, issue_num) for [~] tasks whose linked fleet:queued issue
+    # closed (PR merged) but TASKS.md hasn't been flipped to [x] yet.
+    closed_queued_nums = {
+        i["number"] for i in repo_state.get("closed_fleet_queued", [])
+    }
+    for task in repo_state.get("tasks", {}).get("open", []):
+        if task.get("status") != "~":
+            continue
+        issue_ref = task.get("issue") or ""
+        m = re.match(r"#(\d+)", issue_ref)
+        if m and int(m.group(1)) in closed_queued_nums:
+            yield task.get("id") or task.get("title"), int(m.group(1))
+
+
 def project_queue_manager(state):
     items = []
     for repo, repo_state in state["repos"].items():
@@ -626,6 +664,9 @@ def project_queue_manager(state):
         for task in repo_state.get("tasks", {}).get("done", []):
             items.append({"kind": "done", "repo": repo,
                           "id": task.get("id") or task.get("title")})
+        for task_id, issue_num in _needs_flip_entries(repo_state):
+            items.append({"kind": "needs_flip", "repo": repo,
+                          "task_id": task_id, "issue": issue_num})
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
@@ -745,7 +786,7 @@ def slice_opus_reviewer(state):
 
 
 def slice_queue_manager(state):
-    out = {"needs_plan": [], "human_approved": [], "tasks_done": []}
+    out = {"needs_plan": [], "human_approved": [], "tasks_done": [], "needs_flip": []}
     for repo_key, repo_state in state["repos"].items():
         for issue in repo_state.get("needs_plan", []):
             out["needs_plan"].append(_slice_issue_with_repo(repo_key, issue))
@@ -753,6 +794,10 @@ def slice_queue_manager(state):
             out["human_approved"].append(_slice_issue_with_repo(repo_key, issue))
         for task in repo_state.get("tasks", {}).get("done", []):
             out["tasks_done"].append(_slice_task_with_repo(repo_key, task))
+        for task_id, issue_num in _needs_flip_entries(repo_state):
+            out["needs_flip"].append(
+                {"repo": repo_key, "task_id": task_id, "issue": issue_num}
+            )
     return out
 
 
@@ -814,6 +859,7 @@ def collect_state():
             ("engine", "prs", lambda: fetch_prs("jakildev/IrredenEngine")),
             ("engine", "needs_plan", lambda: fetch_needs_plan("jakildev/IrredenEngine")),
             ("engine", "human_approved", lambda: fetch_human_approved("jakildev/IrredenEngine")),
+            ("engine", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/IrredenEngine")),
             ("engine", "tasks", lambda: fetch_tasks(ENGINE)),
         ]
     if "game" in repos:
@@ -821,6 +867,7 @@ def collect_state():
             ("game", "prs", lambda: fetch_prs("jakildev/irreden")),
             ("game", "needs_plan", lambda: fetch_needs_plan("jakildev/irreden")),
             ("game", "human_approved", lambda: fetch_human_approved("jakildev/irreden")),
+            ("game", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/irreden")),
             ("game", "tasks", lambda: fetch_tasks(GAME)),
         ]
 


### PR DESCRIPTION
## Summary
- Scout now fetches recently-closed `fleet:queued` issues (up to 20, most-recent first) as `closed_fleet_queued` per repo.
- New `_needs_flip_entries` helper cross-references those issue numbers against TASKS.md `[~]` tasks by their `Issue:` field.
- Any match emits a `needs_flip` item into `project_queue_manager` and `slice_queue_manager`, changing the projection hash and firing the trigger immediately after a PR merges.
- Updates `FLEET-CACHE.md` and `role-queue-manager.md` to document the new `needs_flip` slice key.

## Problem solved
`project_queue_manager` had no signal for the PR-merge → issue-close transition. When a PR merged and closed its linked `fleet:queued` issue, the projection content was unchanged → no trigger → queue-manager never ran → TASKS.md `[~]` entries stayed stale until the periodic re-arm in #499 fired (burning ~$36/day on no-op iterations on quiet fleets).

## Test plan
- [ ] `python3 -m py_compile scripts/fleet/fleet-state-scout` — syntax clean
- [ ] After a PR merges and closes its linked `fleet:queued` issue: scout fires the `queue-manager` trigger within one 30 s tick
- [ ] Quiet fleet (no PRs merging): `needs_flip` stays empty; no spurious queue-manager triggers
- [ ] `projections/queue-manager.json` includes `needs_flip` field

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)