### PR TITLE
T-107: fleet-dispatcher: fix pane_is_running_claude for macOS version-string process names

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -230,7 +230,7 @@ dispatch_send_keys() {
 # Returns 0 if the pane is occupied (non-shell cmd), non-zero if idle at a shell.
 # Inverted allowlist: macOS tmux reports version strings (e.g. "2.1.132") instead
 # of "claude", so matching by name misses live panes and triggers premature cleanup.
-pane_is_running_claude() {
+pane_is_occupied() {
     local pane_id="$1"
     list_pane_state | awk -F'\t' -v target="$pane_id" '
         $1 == target {
@@ -289,7 +289,7 @@ cleanup_stale_dispatches() {
             rm -f "$file"
             continue
         fi
-        if pane_is_running_claude "$pane"; then
+        if pane_is_occupied "$pane"; then
             continue
         fi
         log "dispatch for $role on $pane completed (pane returned to shell)"

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -227,11 +227,19 @@ dispatch_send_keys() {
     fi
 }
 
-# Returns 0 if the pane is running claude, non-zero otherwise.
+# Returns 0 if the pane is occupied (non-shell cmd), non-zero if idle at a shell.
+# Inverted allowlist: macOS tmux reports version strings (e.g. "2.1.132") instead
+# of "claude", so matching by name misses live panes and triggers premature cleanup.
 pane_is_running_claude() {
     local pane_id="$1"
     list_pane_state | awk -F'\t' -v target="$pane_id" '
-        $1 == target { if ($3 == "claude" || $3 == "node") print "yes"; else print "no" }
+        $1 == target {
+            cmd = $3
+            if (cmd != "bash" && cmd != "zsh" && cmd != "sh" && cmd != "fish")
+                print "yes"
+            else
+                print "no"
+        }
     ' | grep -q "^yes$"
 }
 


### PR DESCRIPTION
## Summary
- `pane_is_running_claude` previously matched only `pane_current_command == "claude"` or `"node"`, missing macOS cases where tmux reports a version string (e.g. `"2.1.132"`) for the running claude process.
- Inverts the check to: pane is occupied if its command is **not** in the shell allowlist (`bash`/`zsh`/`sh`/`fish`), matching the same set already used by `find_idle_panes_for_role`.
- Prevents premature dispatch-record cleanup for live panes, fixing state-model drift where roles incorrectly appeared "free" mid-iteration.

## Test plan
- [ ] On macOS: start fleet, confirm `cleanup_stale_dispatches` no longer logs "dispatch completed" for panes visibly running claude
- [ ] On Linux: `pane_current_command` is reliably `"claude"` — inverted logic also handles this correctly (claude is not bash/zsh/sh/fish)

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)