### PR TITLE
T-108: docs: replace stale fleet-babysit references in transient role docs

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -401,7 +401,7 @@ exit cleanly:
       - Add cooldown label so we don't re-attempt next iteration:
         `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
       - Append a log line to `~/.fleet/logs/merger-audit.log`
-        (separate from `merger.log`, which `fleet-babysit` rotates):
+        (separate from `merger.log`):
         `[YYYY-MM-DD HH:MM:SS] PR #<N> <headRefName>: clean rebase, force-pushed`
 
       **Conflict (non-zero exit).** Identify which files are
@@ -590,8 +590,8 @@ If Mode above is `review-only`: behave as `live`. Auto-rebasing
 mechanical conflicts helps close out PRs, which IS the point of
 review-only mode.
 
-If you hit a usage-limit error: print the error and exit. The
-`/loop` driver and `fleet-babysit` wrapper handle backoff.
+If you hit a usage-limit error: print the error and exit.
+`fleet-dispatcher` does NOT implement usage-limit back-off; flag the limit in your iteration summary so the human can intervene.
 
 ## End-of-iteration feedback
 
@@ -625,9 +625,8 @@ iterations write nothing).
 - **Always log every action** to `~/.fleet/logs/merger-audit.log`
   AND comment on the PR. Two-channel audit: the log is the merger's
   internal trail; the comment is the human-visible trail. The
-  audit log is separate from `~/.fleet/logs/merger.log` (which
-  `fleet-babysit` rotates by `tail -1000`) to keep the audit trail
-  intact across babysit restarts.
+  audit log is separate from `~/.fleet/logs/merger.log` (tail-rotated)
+  to keep the audit trail intact.
 - **Process at most 2 PRs per iteration.** Auto-pushes retrigger
   CI; flooding the queue is worse than slow turnover.
 - **One conflict class per push.** If a rebase needs both TASKS.md
@@ -674,8 +673,7 @@ Every action lands in TWO places:
 
 1. `~/.fleet/logs/merger-audit.log` — append-only audit trail.
    One line per action with timestamp, PR number, branch, action,
-   outcome. Kept separate from `merger.log` (which `fleet-babysit`
-   tail-rotates) so the audit history survives babysit restarts.
+   outcome. Kept separate from `merger.log` (tail-rotated) so the audit history is preserved.
 2. The PR comment thread — human-visible. Always end with
    `— fleet merger` so a human (or another agent) scanning the
    thread can identify merger comments without parsing the

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -155,8 +155,8 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
 
 ## Loop behavior
 
-`fleet-babysit` relaunches this role every ~30 minutes in live mode
-with a **fresh `claude` process and an empty conversation** — no
+`fleet-dispatcher` launches a fresh `claude` for this role when scout
+sees new actionable PR state, with an empty conversation — no
 context carries over from prior reviews. Each invocation is one
 iteration of polling, reviewing, and exiting cleanly:
 
@@ -326,7 +326,7 @@ iteration of polling, reviewing, and exiting cleanly:
    this role when the scout's projection sees new actionable PR
    state — no carry-over between iterations.
 5. If you hit a usage-limit error: print the error and exit.
-   `fleet-babysit` waits the limit-delay before relaunching.
+   `fleet-dispatcher` does NOT implement usage-limit back-off; flag the limit in your iteration summary so the human can intervene.
 
 If Mode above is `dry-run`: review exactly **one** flagged PR
 end-to-end, then stop and wait for human instruction. Do not loop.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -177,8 +177,8 @@ fleet-claim --repo game claim "T-001" opus-worker-1
 ## Loop behavior
 
 Each invocation of this role is **one task iteration in a fresh
-`claude` process** — `fleet-babysit` relaunches you every ~20 minutes
-in live mode (or sooner if you exit faster), with an empty
+`claude` process** — `fleet-dispatcher` launches a fresh `claude` when scout sees
+new actionable state, with an empty
 conversation each time. Don't try to "remember" anything from the
 prior iteration; everything you need lives in TASKS.md, the open-PR
 list, plan files under `~/.fleet/plans/`, and the role file you're
@@ -1041,10 +1041,10 @@ Do the work, then exit cleanly:
 ## Mode behavior
 
 The Mode argument at the top of this file is one of `dry-run`, `live`,
-or `review-only` (passed by `fleet-babysit` from `fleet-up`'s mode arg).
+or `review-only` (passed by `fleet-dispatcher` from `fleet-up`'s mode arg).
 
 - **`live`** (full operation): each iteration runs steps 0–12 above,
-  then exits. fleet-babysit relaunches every ~20m with fresh context.
+  then exits. fleet-dispatcher launches a fresh claude when scout sees actionable state.
 
 - **`dry-run`** (default): do startup actions only. Do not plan or
   pick a task. Wait for human instruction.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -227,11 +227,11 @@ half-finished and re-litigated in review.
 
 ### Step 6 — Maintenance scheduling
 
-`fleet-babysit` relaunches this role every ~5 minutes in live mode
-with a **fresh `claude` process and an empty conversation**. Each
+`fleet-dispatcher` launches a fresh `claude` for this role when scout
+sees new actionable state, with an empty conversation. Each
 invocation runs the startup actions and a full maintenance pass, then
-exits cleanly. `fleet-babysit` handles scheduling and crash recovery
-between fresh launches.
+exits cleanly. The pane returns to shell on crash or clean exit so
+the next dispatch lands on a fresh claude.
 
 Between maintenance passes, the human can still type task descriptions
 into this pane (the conversation is live until the agent exits at the
@@ -239,21 +239,18 @@ end of the pass). Process those through Steps 1–5 above (categorize,
 format, file to TASKS.md).
 
 If you hit a usage-limit error: print the error and exit.
-`fleet-babysit` waits the limit-delay before relaunching with a fresh
-context.
+`fleet-dispatcher` does NOT implement usage-limit back-off; flag the limit in your iteration summary so the human can intervene.
 
 ### Mode behavior
 
 The Mode argument at the top of this file is one of `dry-run`, `live`,
-or `review-only` (passed by `fleet-babysit` from `fleet-up`'s mode arg).
+or `review-only` (passed by `fleet-dispatcher` from `fleet-up`'s mode arg).
 
 - **`live`** (full operation): each iteration runs a full maintenance
-  pass (steps 0–10 below), then exits. fleet-babysit relaunches every
-  ~5m with fresh context.
+  pass (steps 0–10 below), then exits. fleet-dispatcher launches a fresh claude when scout sees actionable state.
 
 - **`dry-run`** (default): do exactly one maintenance pass, then stop
-  and wait for human instruction. `fleet-babysit` does not auto-relaunch
-  in dry-run mode.
+  and wait for human instruction. `fleet-dispatcher` does not fire again in dry-run mode.
 
 - **`review-only`** (close-out mode): conserves credit by closing out
   in-flight work without expanding the queue. Each iteration runs:

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -99,8 +99,8 @@ whatever directory the task touches before editing anything.
 
 Each invocation of this role is **one task iteration**. After the
 iteration completes (or after determining there's no work to do), exit
-cleanly. `fleet-babysit` then relaunches you with a **fresh `claude`
-process and an empty conversation**, so the next task starts with no
+cleanly. `fleet-dispatcher` then launches a fresh `claude`
+process with an empty conversation, so the next task starts with no
 context carried over from the prior task. This keeps each task's
 reasoning focused on its own files instead of accumulating noise from
 earlier work.
@@ -711,10 +711,10 @@ Each iteration:
 ## Mode behavior
 
 The Mode argument at the top of this file is one of `dry-run`, `live`,
-or `review-only` (passed by `fleet-babysit` from `fleet-up`'s mode arg).
+or `review-only` (passed by `fleet-dispatcher` from `fleet-up`'s mode arg).
 
 - **`live`** (full operation): each iteration runs steps 0–11 above,
-  then exits. fleet-babysit relaunches with fresh context.
+  then exits. fleet-dispatcher launches a fresh claude when scout sees actionable state.
 
 - **`dry-run`** (default): do exactly **one** task end-to-end (steps
   1–11), print the PR URL, then stop and wait for human instruction.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -138,8 +138,8 @@ treat it as a hard rule for this role.
 
 ## Loop behavior
 
-`fleet-babysit` relaunches this role every ~3 minutes in live mode
-with a **fresh `claude` process and an empty conversation** — no
+`fleet-dispatcher` launches a fresh `claude` for this role when scout
+sees new actionable PR state, with an empty conversation — no
 context carries over from the prior iteration. Each invocation is one
 iteration of polling, reviewing, and exiting cleanly:
 
@@ -360,7 +360,7 @@ iteration of polling, reviewing, and exiting cleanly:
    this role when the scout's projection sees new actionable PR
    state — no carry-over between iterations.
 5. If you hit a usage-limit error: print the error and exit.
-   `fleet-babysit` waits the limit-delay before relaunching.
+   `fleet-dispatcher` does NOT implement usage-limit back-off; flag the limit in your iteration summary so the human can intervene.
 
 If Mode above is `dry-run`: review exactly **one** PR end-to-end
 (complete one iteration of step 2 with one PR), then stop and wait


### PR DESCRIPTION
## Summary
- Sweep 6 transient-role docs replacing all surviving `fleet-babysit` references with the accurate `fleet-dispatcher` mechanism description.
- Usage-limit back-off sections aligned to the opus-worker pattern from PR #497: "fleet-dispatcher does NOT implement back-off; flag in iteration summary so the human can intervene."
- Log-rotation parentheticals in `role-merger.md` simplified to "tail-rotated" to remove the fleet-babysit ownership claim without asserting a specific mechanism.
- Architect-role docs (`role-opus-architect.md`, `role-game-architect.md`) untouched — those panes use `--resume` and are correctly babysat.

Files changed: `role-merger.md`, `role-opus-reviewer.md`, `role-opus-worker.md`, `role-queue-manager.md`, `role-sonnet-author.md`, `role-sonnet-reviewer.md`

## Test plan
- [ ] No remaining `fleet-babysit` references in the 6 modified files (except the intentional "Do NOT call fleet-babysit" warning lines at opus-worker:56 and sonnet-author:45)
- [ ] Architect docs unchanged

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)