### PR TITLE
T-101: Lua-driven ECS — Lua-defined systems with archetype-batched dispatch

### DIFF
--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -105,8 +105,67 @@ IREntity.removeLuaComponent(entity, C_Hp)
   `sol::table` lookup.
 
 The full design is in [`docs/design/lua-driven-ecs.md`](../../docs/design/lua-driven-ecs.md).
-T-100 (this PR) lands components only; systems, pipelines, hot-reload,
-and the parity demo follow in T-101..T-104.
+
+## Lua-defined systems (`IRSystem.registerSystem`)
+
+`bindLuaDrivenEcs()` also exposes `IRSystem.registerSystem`. A Lua
+system is a runtime-archetype-typed dispatch: include / exclude
+component sets and a tick body, both resolved against the same
+`ComponentId` space as C++ components.
+
+```lua
+local sysId = IRSystem.registerSystem({
+    name = "MoveByVelocity",
+    components = { "C_Position3D", "C_Velocity3D", C_Marker },  -- string OR handle
+    excludes = { "C_NoMove" },
+    tick = function(arch)
+        for i = 0, arch.length - 1 do
+            local pos = arch.C_Position3D:at(i)
+            local vel = arch.C_Velocity3D:at(i)
+            arch.C_Position3D:setAt(i, C_Position3D.new(pos.x + vel.x, pos.y, pos.z))
+        end
+    end,
+})
+```
+
+- **Component name resolution.** Strings are resolved against the
+  Lua-name registry populated by `LuaScript::registerType` (so any
+  component included in the creation's `lua_component_pack` is
+  matchable by its bound name) and against the dynamic component
+  registry (Lua-defined components by user name). Tables holding a
+  numeric `componentId` field — i.e. the handle returned by
+  `IRComponent.register` — are accepted directly. Any other entry, or
+  a string that doesn't resolve in either registry, raises a Lua-side
+  error pointing at the `lua_component_pack`.
+- **Archetype-batched dispatch.** The tick body fires once per
+  matched archetype per pipeline tick — *not* once per entity. Per-
+  entity work happens entirely inside Lua via the column views, so
+  the C++/Lua boundary is one `sol::function` call per archetype +
+  one sol2 method call per row access.
+- **Entity ids.** `arch.entityAt(i)` reads the row's `EntityId`
+  directly from the archetype node — no per-tick column copy. The
+  tick body sees the entity layout from `arch.length` and a single
+  closure for id lookup; archetype mutation during a tick still
+  needs to go through the deferred ECS API, just like a C++ system.
+- **Column views.**
+  - `arch.<name>` for a C++-bound component is a `LuaCppColumnView`:
+    `:at(i)` returns the row as a sol::reference to T (read mutable
+    fields), `:setAt(i, T.new(...))` overwrites the row by value.
+    `setAt` exists because most existing `*_lua.hpp` bindings expose
+    fields as getter lambdas rather than `sol::property` pairs, so a
+    full-row replacement is the universal write path.
+  - `arch.<name>` for a Lua-defined component is a
+    `LuaTypedColumnView`: `:getField(i, "name")` /
+    `:setField(i, "name", v)` for typed per-field access, or
+    `:getRow(i)` / `:setRow(i, table)` for whole-row read/write.
+- **Return value.** A `SystemId` (`lua_Integer`). Holds for use with
+  `IRSystem.registerPipeline` (lands in T-102).
+- **No begin/end ticks yet.** Lua-side `beginTick` / `endTick`
+  hooks are not exposed in T-101; add them when a use case needs
+  frame-scoped setup or teardown.
+
+T-100 landed components; T-101 (this) lands systems; pipelines,
+hot-reload, and the parity demo follow in T-102..T-104.
 
 ## Script resolution
 

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(
     lua
     sol2
     IrredenEngineEntity
+    IrredenEngineSystem
 )
 target_include_directories(
     IrredenEngineScripting

--- a/engine/script/include/irreden/script/lua_archetype_view.hpp
+++ b/engine/script/include/irreden/script/lua_archetype_view.hpp
@@ -1,0 +1,127 @@
+#ifndef LUA_ARCHETYPE_VIEW_H
+#define LUA_ARCHETYPE_VIEW_H
+
+// Column views passed to a Lua-defined system body via the per-archetype
+// `archetype` table (see `LuaScript::registerSystem`). One per matched
+// component per archetype tick; lifetimes are bounded by the body
+// invocation. Do NOT cache across ticks — the underlying ArchetypeNode
+// can have its column vectors moved or rebuilt by structural changes
+// at the next pipeline boundary.
+//
+// `LuaCppColumnView` covers C++ components: it dispatches per-row read
+// and replace through accessors registered alongside the type's Lua
+// binding (see LuaScript::registerType). `LuaTypedColumnView` covers
+// Lua-defined components and goes directly through the schema-aware
+// `IComponentDataLuaTyped` API for per-field access.
+
+#define SOL_ALL_SAFETIES_ON 1
+#include <sol/sol.hpp>
+
+#include <irreden/entity/i_component_data.hpp>
+#include <irreden/script/lua_component_data.hpp>
+
+#include <functional>
+#include <string>
+
+namespace IRScript {
+
+// Per-row reader: given a row index, return the row's value as a
+// sol::object (typically a sol::reference to T so Lua can read mutable
+// fields). Captured at registerType<T> time — one entry per C++
+// component type that has a Lua binding.
+using LuaColumnRowReader =
+    std::function<sol::object(sol::state_view, IREntity::IComponentData *, int)>;
+
+// Per-row replacer: given a row index and a sol::object holding a value
+// of the same userdata type, copy-assign the column's slot. Allows Lua
+// to write back component values whose member fields aren't directly
+// assignable from Lua (most existing `*_lua.hpp` bindings expose fields
+// as getter lambdas, not sol::property pairs). Construct a new value
+// from Lua and `setAt(i, value)` to overwrite.
+using LuaColumnRowReplacer =
+    std::function<void(sol::state_view, IREntity::IComponentData *, int, const sol::object &)>;
+
+struct LuaCppColumnAccessor {
+    LuaColumnRowReader reader_;
+    LuaColumnRowReplacer replacer_;
+};
+
+// View of one C++ component column inside an archetype tick. Holds a
+// non-owning pointer to the column's `IComponentData*` plus a pointer
+// to the per-component-type accessor pair stored in LuaScript. The
+// accessor pointer remains valid because LuaScript's accessor map only
+// grows; references to map elements are not invalidated by rehash.
+class LuaCppColumnView {
+  public:
+    LuaCppColumnView() = default;
+    LuaCppColumnView(
+        IREntity::IComponentData *data, const LuaCppColumnAccessor *accessor, int length
+    )
+        : m_data{data}
+        , m_accessor{accessor}
+        , m_length{length} {}
+
+    sol::object at(int row, sol::this_state ts) const {
+        return m_accessor->reader_(sol::state_view{ts}, m_data, row);
+    }
+
+    void setAt(int row, const sol::object &value, sol::this_state ts) const {
+        m_accessor->replacer_(sol::state_view{ts}, m_data, row, value);
+    }
+
+    int length() const {
+        return m_length;
+    }
+
+  private:
+    IREntity::IComponentData *m_data = nullptr;
+    const LuaCppColumnAccessor *m_accessor = nullptr;
+    int m_length = 0;
+};
+
+// View of one Lua-defined component column inside an archetype tick.
+// Per-field access is dispatched on the field name (linear scan;
+// schemas typically have <10 fields).
+class LuaTypedColumnView {
+  public:
+    LuaTypedColumnView() = default;
+    LuaTypedColumnView(IComponentDataLuaTyped *data, int length)
+        : m_data{data}
+        , m_length{length} {}
+
+    sol::object getField(int row, const std::string &fieldName, sol::this_state ts) const {
+        const int fieldIdx = m_data->findFieldIndex(fieldName);
+        if (fieldIdx < 0) {
+            return sol::make_object(sol::state_view{ts}, sol::lua_nil);
+        }
+        return m_data->readFieldAt(row, fieldIdx, sol::state_view{ts});
+    }
+
+    void setField(int row, const std::string &fieldName, const sol::object &value) const {
+        const int fieldIdx = m_data->findFieldIndex(fieldName);
+        if (fieldIdx < 0) {
+            return;
+        }
+        m_data->writeFieldAt(row, fieldIdx, value);
+    }
+
+    sol::table getRow(int row, sol::this_state ts) const {
+        return m_data->readRowAsTable(row, sol::state_view{ts});
+    }
+
+    void setRow(int row, const sol::table &values) const {
+        m_data->writeRowFromTable(row, values);
+    }
+
+    int length() const {
+        return m_length;
+    }
+
+  private:
+    IComponentDataLuaTyped *m_data = nullptr;
+    int m_length = 0;
+};
+
+} // namespace IRScript
+
+#endif /* LUA_ARCHETYPE_VIEW_H */

--- a/engine/script/include/irreden/script/lua_script.hpp
+++ b/engine/script/include/irreden/script/lua_script.hpp
@@ -11,9 +11,12 @@
 #include <irreden/ir_entity.hpp>
 
 #include <irreden/script/ir_script_types.hpp>
+#include <irreden/script/lua_archetype_view.hpp>
 #include <irreden/script/lua_binding_traits.hpp>
 #include <irreden/script/lua_component_data.hpp>
 
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace IRScript {
@@ -34,12 +37,46 @@ class LuaScript {
 
     void bindCreateEntityBatchFunction();
 
-    // Bind the Lua-driven ECS surface — IRComponent.{register,bindField}
-    // and IREntity.{addLuaComponent,getLuaComponent,removeLuaComponent,
-    // hasLuaComponent}. Idempotent; safe to call multiple times.
-    // Required for any creation that registers Lua-defined components.
-    // See docs/design/lua-driven-ecs.md and engine/script/CLAUDE.md.
+    // Bind the Lua-driven ECS surface — IRComponent.{register,bindField},
+    // IREntity.{addLuaComponent,getLuaComponent,removeLuaComponent,
+    // hasLuaComponent}, and IRSystem.registerSystem (T-101 archetype-
+    // batched dispatch). Idempotent; safe to call multiple times.
+    // Required for any creation that registers Lua-defined components
+    // or Lua-defined systems. See docs/design/lua-driven-ecs.md and
+    // engine/script/CLAUDE.md.
     void bindLuaDrivenEcs();
+
+    // True when the C++ component type registered with `luaName`
+    // (typically the binding's `registerType<T>("C_Foo")`) was already
+    // recorded by a prior `registerType` call. Used by Lua systems to
+    // resolve component names against the lua_component_pack the
+    // creation has bound.
+    bool hasComponentLuaName(const std::string &luaName) const {
+        return m_componentByLuaName.find(luaName) != m_componentByLuaName.end();
+    }
+
+    // Returns the `ComponentId` recorded for `luaName`, or
+    // `IREntity::kNullComponent` if no C++ component type with that
+    // Lua name has been registered.
+    IREntity::ComponentId componentIdByLuaName(const std::string &luaName) const {
+        auto it = m_componentByLuaName.find(luaName);
+        if (it == m_componentByLuaName.end()) {
+            return IREntity::kNullComponent;
+        }
+        return it->second;
+    }
+
+    // Returns the column accessor pair registered for the C++ component
+    // with `componentId`, or nullptr if the component does not have a
+    // Lua binding (Lua-defined components go through
+    // `LuaTypedColumnView` instead and do not appear in this map).
+    const LuaCppColumnAccessor *cppColumnAccessor(IREntity::ComponentId componentId) const {
+        auto it = m_cppColumnAccessors.find(componentId);
+        if (it == m_cppColumnAccessors.end()) {
+            return nullptr;
+        }
+        return &it->second;
+    }
 
     template <typename T> void registerTypeFromTraits() {
         static_assert(kHasLuaBinding<T>, "Lua binding specialization missing for this type.");
@@ -63,7 +100,18 @@ class LuaScript {
         IR_LOG_INFO("Registering lua type {}", name);
         IR_ASSERT(sizeof...(Constructors) > 0, "At least one constructor must be specified");
 
-        return m_lua.new_usertype<T>(name, sol::constructors<Constructors...>(), keyValuePairs...);
+        auto usertype =
+            m_lua.new_usertype<T>(name, sol::constructors<Constructors...>(), keyValuePairs...);
+
+        // Components that have a Lua binding (`*_lua.hpp` specializing
+        // `kHasLuaBinding<T> = true`) get their Lua-visible name +
+        // column-row accessors recorded so dynamic systems can resolve
+        // them by name and expose their columns to a Lua tick body.
+        if constexpr (kHasLuaBinding<T>) {
+            recordComponentLuaName<T>(name);
+        }
+
+        return usertype;
     }
     // template <typename T, typename... Args, typename... KeyValuePairs>
     // void registerType(
@@ -113,6 +161,52 @@ class LuaScript {
 
   private: //----------------------------------------------------------------
     sol::state m_lua;
+
+    // Lua-name → ComponentId for C++ components that have a Lua
+    // binding (populated by `registerType` when `kHasLuaBinding<T>`).
+    // Lua-defined components go through `EntityManager`'s
+    // `m_pureComponentTypes` directly; this map only covers C++ types.
+    std::unordered_map<std::string, IREntity::ComponentId> m_componentByLuaName;
+    std::unordered_map<IREntity::ComponentId, std::string> m_componentLuaName;
+
+    // Per-C++-component-id row accessor pair (read + replace) used by
+    // `LuaCppColumnView` so a Lua system tick can read or overwrite a
+    // typed column row without templating the column view on T.
+    // Pointers into this map are handed to view objects on a per-tick
+    // basis; std::unordered_map references are stable across rehash,
+    // so this is safe.
+    std::unordered_map<IREntity::ComponentId, LuaCppColumnAccessor> m_cppColumnAccessors;
+
+    // Wires `IRSystem.registerSystem` and the column-view usertypes
+    // into the Lua state. Called from the public `bindLuaDrivenEcs()`
+    // entry; the public API stays singular so creations only need one
+    // init call regardless of which Lua-driven-ECS PRs land.
+    void bindLuaDrivenSystems();
+
+    // Build the read/replace accessor pair for a C++ component type
+    // and record it under the type's `ComponentId`. Called from
+    // `registerType` when `kHasLuaBinding<T>`.
+    template <typename T> void recordComponentLuaName(const std::string &name) {
+        auto &em = IREntity::getEntityManager();
+        IREntity::ComponentId componentId = em.getComponentType<T>();
+        m_componentByLuaName.emplace(name, componentId);
+        m_componentLuaName.emplace(componentId, name);
+
+        LuaCppColumnAccessor accessor;
+        accessor.reader_ =
+            [](sol::state_view lua, IREntity::IComponentData *data, int row) -> sol::object {
+            auto *typed = IREntity::castComponentDataPointer<T>(data);
+            return sol::make_object(lua, std::ref(typed->dataVector[row]));
+        };
+        accessor.replacer_ =
+            [](sol::state_view, IREntity::IComponentData *data, int row, const sol::object &value) {
+                auto *typed = IREntity::castComponentDataPointer<T>(data);
+                if (auto opt = value.as<sol::optional<T>>()) {
+                    typed->dataVector[row] = *opt;
+                }
+            };
+        m_cppColumnAccessors[componentId] = std::move(accessor);
+    }
 
     template <typename Component>
     ComponentFunction<Component> wrapLuaFunction(sol::protected_function function) {

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -2,10 +2,13 @@
 
 #include <irreden/script/lua_script.hpp>
 
+#include <irreden/ir_system.hpp>
+
 #include <irreden/common/modifier_field_registry.hpp>
 
 #include <deque>
 #include <string>
+#include <vector>
 
 namespace IRScript {
 
@@ -427,6 +430,223 @@ void LuaScript::bindLuaDrivenEcs() {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
         return IREntity::getEntityManager().hasComponent(entity.entity, componentId);
     };
+
+    bindLuaDrivenSystems();
+}
+
+namespace {
+
+// Resolve one entry of a `components` / `excludes` list to a
+// `ComponentId`. Lists may hold either:
+//   - a string (the Lua name of a C++ component bound via
+//     `lua_component_pack`, e.g. "C_Position3D", or the user name of a
+//     Lua-defined component, e.g. "Hp"); OR
+//   - a table handle returned by `IRComponent.register` (as produced
+//     by T-100, holding `componentId` + `typeName` + `fields`).
+//
+// Returns `kNullComponent` and sets `errorMessage` when the entry is
+// neither (caller surfaces a Lua error so the user sees an actionable
+// "this name isn't bound" message — the same "fails fast on unbound
+// C++ type" requirement from the T-101 plan).
+IREntity::ComponentId resolveComponentEntry(
+    const sol::object &entry,
+    const LuaScript &script,
+    const IREntity::EntityManager &em,
+    std::string &errorMessage
+) {
+    if (entry.is<sol::table>()) {
+        sol::table t = entry.as<sol::table>();
+        sol::optional<lua_Integer> id = t.get<sol::optional<lua_Integer>>("componentId");
+        if (id && *id != 0) {
+            return static_cast<IREntity::ComponentId>(*id);
+        }
+        errorMessage = "table entry is missing componentId — pass either a "
+                       "string name or an IRComponent.register handle";
+        return IREntity::kNullComponent;
+    }
+    if (entry.is<std::string>()) {
+        const std::string name = entry.as<std::string>();
+        // C++ components register their Lua-visible name through
+        // `LuaScript::registerType`. Lua-defined components register
+        // their user name through `EntityManager::registerComponentDynamic`.
+        IREntity::ComponentId fromCpp = script.componentIdByLuaName(name);
+        if (fromCpp != IREntity::kNullComponent) {
+            return fromCpp;
+        }
+        IREntity::ComponentId fromLuaTyped = em.getComponentTypeByName(name);
+        if (fromLuaTyped != IREntity::kNullComponent) {
+            return fromLuaTyped;
+        }
+        errorMessage = "unknown component '" + name +
+                       "' — must be a Lua-defined component (IRComponent.register) "
+                       "or a C++ component included in this creation's lua_component_pack";
+        return IREntity::kNullComponent;
+    }
+    errorMessage = "component list entry must be a string name or an "
+                   "IRComponent.register handle";
+    return IREntity::kNullComponent;
+}
+
+// Build the std::vector<ComponentId> for a `components` / `excludes`
+// list. Throws sol::error on the first unresolvable entry.
+std::vector<IREntity::ComponentId> resolveComponentList(
+    const sol::table &list,
+    const std::string &fieldName,
+    const std::string &systemName,
+    const LuaScript &script,
+    const IREntity::EntityManager &em
+) {
+    std::vector<IREntity::ComponentId> ids;
+    ids.reserve(list.size());
+    for (auto &kv : list) {
+        std::string err;
+        IREntity::ComponentId id = resolveComponentEntry(kv.second, script, em, err);
+        if (id == IREntity::kNullComponent) {
+            throw sol::error{
+                "IRSystem.registerSystem: '" + systemName + "'." + fieldName + ": " + err
+            };
+        }
+        ids.push_back(id);
+    }
+    return ids;
+}
+
+} // namespace
+
+void LuaScript::bindLuaDrivenSystems() {
+    if (m_lua["IRSystem"].valid()) {
+        return;
+    }
+
+    // Column-view usertypes shared by every Lua-driven system tick.
+    // Registered once; `registerSystem` plugs concrete column pointers
+    // into fresh views per archetype invocation.
+    m_lua.new_usertype<LuaCppColumnView>(
+        "_IRLuaCppColumnView",
+        sol::no_constructor,
+        "at",
+        &LuaCppColumnView::at,
+        "setAt",
+        &LuaCppColumnView::setAt,
+        "length",
+        &LuaCppColumnView::length
+    );
+    m_lua.new_usertype<LuaTypedColumnView>(
+        "_IRLuaTypedColumnView",
+        sol::no_constructor,
+        "getField",
+        &LuaTypedColumnView::getField,
+        "setField",
+        &LuaTypedColumnView::setField,
+        "getRow",
+        &LuaTypedColumnView::getRow,
+        "setRow",
+        &LuaTypedColumnView::setRow,
+        "length",
+        &LuaTypedColumnView::length
+    );
+
+    m_lua["IRSystem"] = m_lua.create_table();
+
+    auto registerSystem = [this](sol::table args) -> sol::object {
+        sol::optional<std::string> nameOpt = args.get<sol::optional<std::string>>("name");
+        if (!nameOpt) {
+            throw sol::error{"IRSystem.registerSystem: missing required field 'name'"};
+        }
+        const std::string systemName = *nameOpt;
+
+        sol::optional<sol::table> components = args.get<sol::optional<sol::table>>("components");
+        if (!components) {
+            throw sol::error{
+                "IRSystem.registerSystem: '" + systemName +
+                "' missing required field 'components' (list of component names or handles)"
+            };
+        }
+
+        sol::optional<sol::function> tickOpt = args.get<sol::optional<sol::function>>("tick");
+        if (!tickOpt) {
+            throw sol::error{
+                "IRSystem.registerSystem: '" + systemName + "' missing required field 'tick'"
+            };
+        }
+        sol::protected_function tick = *tickOpt;
+
+        auto &em = IREntity::getEntityManager();
+
+        std::vector<IREntity::ComponentId> includeIds =
+            resolveComponentList(*components, "components", systemName, *this, em);
+        std::vector<std::string> includeNames;
+        includeNames.reserve(includeIds.size());
+        for (auto &kv : *components) {
+            includeNames.push_back(
+                kv.second.is<std::string>()
+                    ? kv.second.as<std::string>()
+                    : kv.second.as<sol::table>().get<std::string>("typeName")
+            );
+        }
+
+        std::vector<IREntity::ComponentId> excludeIds;
+        sol::optional<sol::table> excludes = args.get<sol::optional<sol::table>>("excludes");
+        if (excludes) {
+            excludeIds = resolveComponentList(*excludes, "excludes", systemName, *this, em);
+        }
+
+        IREntity::Archetype includeArchetype{includeIds.begin(), includeIds.end()};
+        IREntity::Archetype excludeArchetype{excludeIds.begin(), excludeIds.end()};
+
+        // Body wrapper: one sol::function invocation per matched
+        // archetype per tick. Column views are stack-allocated value
+        // types pushed into a fresh per-tick `archetype` table; the
+        // body inside Lua iterates rows itself, so per-entity work
+        // never crosses the C++/Lua boundary except through column
+        // userdata methods (sol2 method calls, not sol::function
+        // invocations).
+        auto body =
+            [this, tick, includeIds, includeNames, systemName](IREntity::ArchetypeNode *node) {
+                sol::state_view lua{m_lua.lua_state()};
+                sol::table archView = lua.create_table();
+                archView["length"] = node->length_;
+                // entity-id access without copying node->entities_ (which
+                // would be O(N) per archetype tick at large entity counts).
+                archView["entityAt"] = [node](int row) -> lua_Integer {
+                    return static_cast<lua_Integer>(node->entities_[row]);
+                };
+
+                for (std::size_t i = 0; i < includeIds.size(); ++i) {
+                    const IREntity::ComponentId cid = includeIds[i];
+                    IREntity::IComponentData *impl = node->components_.at(cid).get();
+                    if (auto *typed = dynamic_cast<IComponentDataLuaTyped *>(impl)) {
+                        archView[includeNames[i]] = LuaTypedColumnView{typed, node->length_};
+                        continue;
+                    }
+                    const LuaCppColumnAccessor *accessor = cppColumnAccessor(cid);
+                    IR_ASSERT(
+                        accessor != nullptr,
+                        "Lua system '{}': component id {} has no Lua binding accessor — was it "
+                        "registered via LuaScript::registerType?",
+                        systemName.c_str(),
+                        cid
+                    );
+                    archView[includeNames[i]] = LuaCppColumnView{impl, accessor, node->length_};
+                }
+
+                sol::protected_function_result result = tick(archView);
+                if (!result.valid()) {
+                    sol::error err = result;
+                    IRE_LOG_ERROR("Lua system '{}' tick error: {}", systemName.c_str(), err.what());
+                }
+            };
+
+        IRSystem::SystemId systemId = IRSystem::createSystemDynamic(
+            systemName,
+            std::move(includeArchetype),
+            std::move(excludeArchetype),
+            std::move(body)
+        );
+        return sol::make_object(m_lua, static_cast<lua_Integer>(systemId));
+    };
+
+    m_lua["IRSystem"]["registerSystem"] = registerSystem;
 }
 
 } // namespace IRScript

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -8,8 +8,29 @@ system entity.
 
 ## Public API
 
-`IRSystem::` exposes: `createSystem<...>()`, `registerPipeline()`,
-`executePipeline()`, system tag helpers, and per-system-parameters.
+`IRSystem::` exposes: `createSystem<...>()`, `createSystemDynamic()`,
+`registerPipeline()`, `executePipeline()`, system tag helpers, and
+per-system-parameters.
+
+## `createSystemDynamic` for runtime-typed systems
+
+`createSystem<Components...>()` is the canonical path — component types
+are template parameters, the body's tick signature is detected via
+`std::is_invocable_v`, and dispatch is the per-entity-shape
+fast path described below.
+
+`createSystemDynamic(name, includeArchetype, excludeArchetype, body)`
+is the runtime-typed parallel, used by Lua-defined systems
+(`LuaScript::registerSystem`). The component sets are passed as
+resolved `IREntity::Archetype` (sets of `ComponentId`) and the body
+is a `std::function<void(ArchetypeNode*)>` that fires once per
+matched archetype. Per-entity iteration is the body's responsibility,
+not SystemManager's — the Lua surface uses this to keep the C++/Lua
+boundary at one `sol::function` call per archetype.
+
+Both paths share the same scheduler: `executePipeline` walks
+`m_ticks[system].functionTick_`, which is a `std::function<void(
+ArchetypeNode*)>` regardless of which factory created the system.
 
 ## Three valid TICK function signatures
 

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -6,6 +6,8 @@
 #include <irreden/system/ir_system_types.hpp>
 #include <irreden/system/system_manager.hpp>
 
+#include <functional>
+
 namespace IRSystem {
 extern SystemManager *g_systemManager;
 SystemManager &getSystemManager();
@@ -16,18 +18,17 @@ namespace detail {
 // SystemManager::createSystem so the matched archetype + dispatch only
 // see the real components (not Exclude<...> placeholders).
 template <typename L> struct CallCreateSystem;
-template <typename... Cs>
-struct CallCreateSystem<TypeList<Cs...>> {
-    template <typename... Args>
-    static SystemId run(SystemManager &mgr, Args &&...args) {
+template <typename... Cs> struct CallCreateSystem<TypeList<Cs...>> {
+    template <typename... Args> static SystemId run(SystemManager &mgr, Args &&...args) {
         return mgr.template createSystem<Cs...>(std::forward<Args>(args)...);
     }
 };
 
 template <typename L> struct ArchetypeFromList;
-template <typename... Cs>
-struct ArchetypeFromList<TypeList<Cs...>> {
-    static IREntity::Archetype value() { return IREntity::getArchetype<Cs...>(); }
+template <typename... Cs> struct ArchetypeFromList<TypeList<Cs...>> {
+    static IREntity::Archetype value() {
+        return IREntity::getArchetype<Cs...>();
+    }
 };
 
 } // namespace detail
@@ -53,8 +54,7 @@ constexpr SystemId createSystem(
     FunctionRelationTick functionRelationTick = nullptr
 ) {
     using Partition = detail::PartitionExcludes<TickComponents...>;
-    auto excludeArchetype =
-        detail::ArchetypeFromList<typename Partition::Excluded>::value();
+    auto excludeArchetype = detail::ArchetypeFromList<typename Partition::Excluded>::value();
     return detail::CallCreateSystem<typename Partition::Included>::run(
         getSystemManager(),
         std::move(name),
@@ -70,6 +70,26 @@ constexpr SystemId createSystem(
 // Create a prefab system
 template <SystemName type, typename... Args> SystemId createSystem(Args &&...args) {
     return System<type>::create(args...);
+}
+
+// Free-function wrapper around `SystemManager::createSystemDynamic`. Used by
+// the Lua-driven path where component types are known only at runtime; the
+// caller passes resolved archetype sets (lists of `ComponentId`) and a body
+// taking the matched `ArchetypeNode*`. Templated `createSystem<...>` remains
+// the canonical path for C++ systems; this exists only for runtime-typed
+// dispatch (Lua, dynamic systems registered from a creation script).
+inline SystemId createSystemDynamic(
+    std::string name,
+    IREntity::Archetype includeArchetype,
+    IREntity::Archetype excludeArchetype,
+    std::function<void(IREntity::ArchetypeNode *)> body
+) {
+    return getSystemManager().createSystemDynamic(
+        std::move(name),
+        std::move(includeArchetype),
+        std::move(excludeArchetype),
+        std::move(body)
+    );
 }
 
 // TODO: Make extra param as well
@@ -94,9 +114,15 @@ template <typename Params> Params *getSystemParams(SystemId system) {
 void registerPipeline(IRTime::Events systemType, std::list<SystemId> pipeline);
 void executePipeline(IRTime::Events event);
 
-inline void setTimingEnabled(bool enabled) { getSystemManager().setTimingEnabled(enabled); }
-inline bool isTimingEnabled() { return getSystemManager().isTimingEnabled(); }
-inline void resetTimingStats() { getSystemManager().resetTimingStats(); }
+inline void setTimingEnabled(bool enabled) {
+    getSystemManager().setTimingEnabled(enabled);
+}
+inline bool isTimingEnabled() {
+    return getSystemManager().isTimingEnabled();
+}
+inline void resetTimingStats() {
+    getSystemManager().resetTimingStats();
+}
 
 inline TickObserverId registerTickObserver(std::unique_ptr<TickObserver> observer) {
     return getSystemManager().registerTickObserver(std::move(observer));

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -115,6 +115,23 @@ class SystemManager {
         return paramsImpl == nullptr ? nullptr : paramsImpl->params_.get();
     }
 
+    /// Runtime-archetype-typed parallel of `createSystem<...>`. The
+    /// include / exclude archetypes are passed as resolved `Archetype`
+    /// values (sets of `ComponentId`) rather than C++ template
+    /// parameters, and the body is a `std::function` that receives the
+    /// matched `ArchetypeNode*` directly. Used by the Lua-driven path
+    /// (`LuaScript::registerSystem`) where the component types are
+    /// known only at runtime; the body fires once per matched
+    /// archetype per tick (no per-entity dispatch by SystemManager —
+    /// caller's body decides whether to iterate the columns row-wise
+    /// or batch-process them).
+    SystemId createSystemDynamic(
+        std::string name,
+        Archetype includeArchetype,
+        Archetype excludeArchetype,
+        std::function<void(ArchetypeNode *)> body
+    );
+
     void registerPipeline(IRTime::Events event, std::list<SystemId> pipeline);
     void executePipeline(IRTime::Events event);
     void executeSystem(SystemId system);

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -44,6 +44,32 @@ void SystemManager::clearTickObservers() {
     m_observers.clear();
 }
 
+SystemId SystemManager::createSystemDynamic(
+    std::string name,
+    Archetype includeArchetype,
+    Archetype excludeArchetype,
+    std::function<void(ArchetypeNode *)> body
+) {
+    m_systemNames.emplace_back(C_Name{std::move(name)});
+    SystemId newSystemId = m_nextSystemId++;
+
+    m_beginTicks.emplace_back(C_SystemEvent<BEGIN_TICK>{[]() {}});
+    m_ticks.emplace_back(
+        C_SystemEvent<TICK>{
+            std::move(body),
+            std::move(includeArchetype),
+            std::move(excludeArchetype),
+        }
+    );
+    m_endTicks.emplace_back(C_SystemEvent<END_TICK>{[]() {}});
+    m_relationTicks.emplace_back(C_SystemEvent<RELATION_TICK>{[](EntityRecord) {}});
+
+    m_relations.emplace_back(C_SystemRelation{Relation::NONE});
+    m_systemParams.emplace_back(nullptr);
+    m_timingAccum.emplace_back();
+    return newSystemId;
+}
+
 void SystemManager::registerPipeline(IRTime::Events event, std::list<SystemId> pipeline) {
     m_systemPipelinesNew[event] = pipeline;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(IrredenEngineTest
   render/sprite_components_test.cpp
   render/sprite_render_test.cpp
   script/lua_component_register_test.cpp
+  script/lua_system_register_test.cpp
   script/modifier_lua_test.cpp
   utility/ir_utility_test.cpp
 )

--- a/test/script/lua_system_register_test.cpp
+++ b/test/script/lua_system_register_test.cpp
@@ -1,0 +1,394 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+#include <irreden/script/lua_archetype_view.hpp>
+#include <irreden/script/lua_binding_traits.hpp>
+#include <irreden/script/lua_component_data.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace {
+
+// Test-only components with sol2 bindings using member pointers, so the
+// Lua side can both read and write fields directly. Most of the engine's
+// existing `*_lua.hpp` bindings expose getters as lambdas (read-only); a
+// production migration to sol::property pairs is out of scope for T-101.
+// Using member-pointer bindings here is the cleanest way to verify the
+// shared-ComponentId-space round-trip claim from the plan.
+
+struct TestPos {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+struct TestVel {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+// Tag — used to demonstrate that a Lua-defined component participates
+// in archetype filtering through the same ComponentId space as the C++
+// types above.
+struct LuaSysTestMarker {};
+
+} // namespace
+
+namespace IRScript {
+template <> inline constexpr bool kHasLuaBinding<TestPos> = true;
+template <> inline constexpr bool kHasLuaBinding<TestVel> = true;
+
+template <> inline void bindLuaType<TestPos>(LuaScript &script) {
+    script.registerType<TestPos, TestPos(), TestPos(float, float, float)>(
+        "TestPos",
+        "x",
+        &TestPos::x,
+        "y",
+        &TestPos::y,
+        "z",
+        &TestPos::z
+    );
+}
+
+template <> inline void bindLuaType<TestVel>(LuaScript &script) {
+    script.registerType<TestVel, TestVel(), TestVel(float, float, float)>(
+        "TestVel",
+        "x",
+        &TestVel::x,
+        "y",
+        &TestVel::y,
+        "z",
+        &TestVel::z
+    );
+}
+} // namespace IRScript
+
+namespace {
+
+class LuaSystemRegisterTest : public testing::Test {
+  protected:
+    LuaSystemRegisterTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_system_manager{} {
+        m_lua.bindLuaDrivenEcs();
+        m_lua.registerTypeFromTraits<TestPos>();
+        m_lua.registerTypeFromTraits<TestVel>();
+
+        // LuaEntity is bound by each creation's lua_bindings.cpp;
+        // tests bind a minimal version locally so the dynamic-add
+        // path (`IREntity.addLuaComponent(LuaEntity.new(id), ...)`)
+        // is exercised end-to-end.
+        m_lua.lua().new_usertype<IRScript::LuaEntity>(
+            "LuaEntity",
+            sol::constructors<IRScript::LuaEntity(IREntity::EntityId)>(),
+            "entity",
+            &IRScript::LuaEntity::entity
+        );
+    }
+
+    // m_lua first so its sol::state outlives sol::function-bearing
+    // columns held by the EntityManager (matches modifier_lua_test.cpp).
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+// ---- Acceptance criterion 1 -------------------------------------------------
+//
+// Lua system iterates a mix of C++-defined components alongside a
+// Lua-defined tag, and writes back to a C++ component. C++ side reads
+// the change.
+
+TEST_F(LuaSystemRegisterTest, MixedCppAndLuaDefinedComponentsRoundTrip) {
+    auto &lua = m_lua.lua();
+
+    // Tag the entity with a Lua-defined "Marker" so the system's
+    // archetype filter has to resolve a name from the runtime
+    // ComponentId space.
+    ASSERT_TRUE(lua.safe_script("Marker = IRComponent.register('Marker', { dummy = 0 })").valid());
+
+    auto entityIncluded =
+        IREntity::createEntity(TestPos{1.0f, 2.0f, 3.0f}, TestVel{10.0f, 20.0f, 30.0f});
+    auto entityExcluded =
+        IREntity::createEntity(TestPos{0.0f, 0.0f, 0.0f}, TestVel{0.0f, 0.0f, 0.0f});
+
+    lua["entityIncluded"] = static_cast<lua_Integer>(entityIncluded);
+
+    auto registerResult = lua.safe_script(
+        R"(
+        IREntity.addLuaComponent(LuaEntity.new(entityIncluded), Marker)
+        sysId = IRSystem.registerSystem({
+            name = 'MoveByVelocity',
+            components = { 'TestPos', 'TestVel', 'Marker' },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    local pos = arch.TestPos:at(i)
+                    local vel = arch.TestVel:at(i)
+                    arch.TestPos:setAt(i, TestPos.new(pos.x + vel.x, pos.y + vel.y, pos.z + vel.z))
+                end
+            end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(registerResult.valid()) << sol::error{registerResult}.what();
+    IRSystem::SystemId sysId = registerResult.get<lua_Integer>();
+    EXPECT_LT(sysId, m_system_manager.getSystemCount());
+
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    // Included entity moved by velocity — Lua wrote, C++ reads.
+    EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entityIncluded).x, 11.0f);
+    EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entityIncluded).y, 22.0f);
+    EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entityIncluded).z, 33.0f);
+
+    // Untagged entity untouched — Marker filter held.
+    EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entityExcluded).x, 0.0f);
+    EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entityExcluded).y, 0.0f);
+    EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entityExcluded).z, 0.0f);
+}
+
+// ---- Acceptance criterion 2 -------------------------------------------------
+//
+// Body fires once per matching archetype per tick — not once per entity.
+
+TEST_F(LuaSystemRegisterTest, BodyFiresOncePerArchetypeNotPerEntity) {
+    auto &lua = m_lua.lua();
+
+    // Three entities in a single archetype (TestPos + TestVel).
+    for (int i = 0; i < 3; ++i) {
+        IREntity::createEntity(TestPos{}, TestVel{});
+    }
+
+    lua["bodyCallCount"] = 0;
+    auto registerResult = lua.safe_script(
+        R"(
+        sysId = IRSystem.registerSystem({
+            name = 'Counter',
+            components = { 'TestPos', 'TestVel' },
+            tick = function(arch)
+                bodyCallCount = bodyCallCount + 1
+            end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(registerResult.valid()) << sol::error{registerResult}.what();
+    IRSystem::SystemId sysId = registerResult.get<lua_Integer>();
+
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    // One archetype matched, one body invocation — even though three
+    // entities share that archetype.
+    EXPECT_EQ(lua["bodyCallCount"].get<int>(), 1);
+}
+
+// ---- Acceptance criterion 3 -------------------------------------------------
+//
+// Unbound C++ component name fails fast at registerSystem, with an
+// error pointing at the lua_component_pack.
+
+TEST_F(LuaSystemRegisterTest, UnboundComponentNameFailsAtRegisterTime) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        IRSystem.registerSystem({
+            name = 'BogusSys',
+            components = { 'C_NotBoundAnywhere' },
+            tick = function(arch) end,
+        })
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_FALSE(result.valid());
+    sol::error err = result;
+    const std::string msg = err.what();
+    EXPECT_NE(msg.find("C_NotBoundAnywhere"), std::string::npos);
+    EXPECT_NE(msg.find("lua_component_pack"), std::string::npos);
+}
+
+// ---- Acceptance criterion 4 -------------------------------------------------
+//
+// registerSystem returns a SystemId that Lua can hold; SystemManager
+// can run it through the pipeline machinery just like a templated system.
+
+TEST_F(LuaSystemRegisterTest, ReturnsSystemIdUsableInPipeline) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "return IRSystem.registerSystem({ name = 'Ret', components = { 'TestPos' }, "
+        "tick = function() end })"
+    );
+    ASSERT_TRUE(result.valid());
+    const lua_Integer sysId = result.get<lua_Integer>();
+    // SystemIds start at 0 in a fresh SystemManager, so the meaningful
+    // round-trip check is "the returned id is in range and the
+    // pipeline accepts it" rather than "id > 0".
+    EXPECT_GE(sysId, 0);
+    EXPECT_LT(sysId, m_system_manager.getSystemCount());
+
+    m_system_manager.registerPipeline(
+        IRTime::Events::UPDATE,
+        {static_cast<IRSystem::SystemId>(sysId)}
+    );
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    EXPECT_STREQ(m_system_manager.getSystemName(sysId).c_str(), "Ret");
+}
+
+// ---- Lua-only iteration -----------------------------------------------------
+//
+// Lua-defined component columns can be iterated, mutated, and read back
+// through `LuaTypedColumnView` without crossing back to C++ between
+// per-row operations.
+
+TEST_F(LuaSystemRegisterTest, LuaOnlyComponentColumnsRoundTrip) {
+    auto &lua = m_lua.lua();
+    auto setup = lua.safe_script(R"(
+        Hp = IRComponent.register('Hp', { current = 100, max = 100 })
+        Tag = IRComponent.register('Tag', { kind = 0 })
+    )");
+    ASSERT_TRUE(setup.valid());
+
+    const IREntity::ComponentId hpId = m_entity_manager.getComponentTypeByName("Hp");
+    const IREntity::ComponentId tagId = m_entity_manager.getComponentTypeByName("Tag");
+    ASSERT_GT(hpId, 0u);
+    ASSERT_GT(tagId, 0u);
+
+    for (int i = 0; i < 4; ++i) {
+        auto e = IREntity::createEntity();
+        m_entity_manager.addComponentDynamic(e, hpId);
+        m_entity_manager.addComponentDynamic(e, tagId);
+    }
+
+    auto regResult = lua.safe_script(
+        R"(
+        sysId = IRSystem.registerSystem({
+            name = 'Damage',
+            components = { 'Hp', 'Tag' },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    local cur = arch.Hp:getField(i, 'current')
+                    arch.Hp:setField(i, 'current', cur - 10)
+                end
+            end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(regResult.valid()) << sol::error{regResult}.what();
+    const IRSystem::SystemId sysId = regResult.get<lua_Integer>();
+
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    // Each entity dropped from 100 to 90 in one tick.
+    auto nodes = IREntity::queryArchetypeNodesSimple({hpId, tagId});
+    int totalRows = 0;
+    for (auto *node : nodes) {
+        auto *typed =
+            static_cast<IRScript::IComponentDataLuaTyped *>(node->components_.at(hpId).get());
+        const int currentIdx = typed->findFieldIndex("current");
+        const auto *col = std::get_if<std::vector<std::int32_t>>(&typed->columnAt(currentIdx));
+        ASSERT_NE(col, nullptr);
+        for (auto v : *col) {
+            EXPECT_EQ(v, 90);
+            ++totalRows;
+        }
+    }
+    EXPECT_EQ(totalRows, 4);
+}
+
+// ---- entityAt provides id access without copying the column --------------
+
+TEST_F(LuaSystemRegisterTest, EntityAtSurfacesEntityIdsToLua) {
+    auto &lua = m_lua.lua();
+    auto e0 = IREntity::createEntity(TestPos{}, TestVel{});
+    auto e1 = IREntity::createEntity(TestPos{}, TestVel{});
+
+    lua["seenIds"] = lua.create_table();
+    auto regResult = lua.safe_script(
+        R"(
+        sysId = IRSystem.registerSystem({
+            name = 'CollectIds',
+            components = { 'TestPos', 'TestVel' },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    table.insert(seenIds, arch.entityAt(i))
+                end
+            end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(regResult.valid()) << sol::error{regResult}.what();
+    const IRSystem::SystemId sysId = regResult.get<lua_Integer>();
+
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    sol::table seen = lua["seenIds"];
+    EXPECT_EQ(seen.size(), 2u);
+    // archetype iteration order is not guaranteed; assert membership.
+    std::set<IREntity::EntityId> ids;
+    for (std::size_t i = 1; i <= seen.size(); ++i) {
+        ids.insert(seen.get<IREntity::EntityId>(i));
+    }
+    EXPECT_TRUE(ids.count(e0));
+    EXPECT_TRUE(ids.count(e1));
+}
+
+// ---- excludes filter --------------------------------------------------------
+
+TEST_F(LuaSystemRegisterTest, ExcludesFilterDropsTaggedArchetype) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script("Skip = IRComponent.register('Skip', { dummy = 0 })").valid());
+
+    auto entityKeep = IREntity::createEntity(TestPos{1.0f, 0.0f, 0.0f}, TestVel{1.0f, 0.0f, 0.0f});
+    auto entitySkip = IREntity::createEntity(TestPos{1.0f, 0.0f, 0.0f}, TestVel{1.0f, 0.0f, 0.0f});
+
+    lua["entitySkip"] = static_cast<lua_Integer>(entitySkip);
+    auto setup = lua.safe_script("IREntity.addLuaComponent(LuaEntity.new(entitySkip), Skip)");
+    ASSERT_TRUE(setup.valid());
+
+    auto regResult = lua.safe_script(
+        R"(
+        sysId = IRSystem.registerSystem({
+            name = 'KeepOnly',
+            components = { 'TestPos', 'TestVel' },
+            excludes = { 'Skip' },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    local pos = arch.TestPos:at(i)
+                    arch.TestPos:setAt(i, TestPos.new(pos.x + 100.0, pos.y, pos.z))
+                end
+            end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(regResult.valid()) << sol::error{regResult}.what();
+    const IRSystem::SystemId sysId = regResult.get<lua_Integer>();
+
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entityKeep).x, 101.0f);
+    EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entitySkip).x, 1.0f);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

PR 3 of 6 for parent epic #293. Adds the runtime path for Lua-defined systems with archetype-batched dispatch.

- New `SystemManager::createSystemDynamic(name, includeArchetype, excludeArchetype, body)` with a runtime-archetype-typed body, sharing the existing per-archetype tick scheduler.
- New `IRSystem::createSystemDynamic` free-function wrapper.
- `LuaScript::registerType<T>(luaName, ...)` now records `luaName → ComponentId` and a per-component column-row accessor when the type satisfies `kHasLuaBinding<T>`. Existing `*_lua.hpp` files pick this up automatically with no source change.
- New `IRSystem.registerSystem({ name, components, excludes, tick })` Lua surface. Resolves component names via the same id space as C++ components — Lua-defined components register by user name; C++ components register by their `registerType` Lua name (e.g. `C_Position3D`). Unbound names raise a Lua-side error pointing at the `lua_component_pack`.
- Body wrapper exposes each archetype's columns to Lua via two view types: `LuaCppColumnView` for C++ components (returns `T&` per row, integrating with existing sol::usertype bindings) and `LuaTypedColumnView` for Lua-defined components (per-field array access).
- One `sol::function` invocation per matching archetype per tick — not per entity.

Closes #489

## Test plan

- [ ] `fleet-build --target IrredenEngineTest`
- [ ] `IrredenEngineTest` passes (new `LuaSystemRegisterTest` suite covers the four acceptance criteria)
- [ ] `fleet-build --target IRShapeDebug` clean