### PR TITLE
T-114: Reviewer: cross-author stacked-PR awareness

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -245,14 +245,16 @@ iteration of polling, reviewing, and exiting cleanly:
       review actions on your own PRs.
    f. **Set the PR label** to match your verdict (add `--repo
       <game-repo>` for game PRs). The label is the primary signal
-      the human uses. Always remove stale labels first. Two labels
+      the human uses. Always remove stale labels first. Three labels
       are also cleared here as part of the verdict:
       - `fleet:awaiting-upstream-review` — a previously-gated stacked
         PR exits the gate cleanly when the reviewer finally proceeds.
       - `fleet:stacked-rebase` — set by merger when a stacked PR's
         base just merged and got re-targeted to master; your re-eval
         after the re-target is exactly what that label is waiting for.
-      `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved"`
+      - `fleet:needs-base-update` — stacked PR whose upstream has since
+        been re-approved or merged; cleared on any verdict re-evaluation.
+      `gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved"`
       (swap the label name for needs-fix or blocker as appropriate).
       - Verdict approve, no Nits section → `fleet:approved` only
       - Verdict approve WITH a non-empty `### Nits` section → BOTH

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -211,9 +211,9 @@ iteration of polling, reviewing, and exiting cleanly:
         the child diff only — upstream is approved separately."
         When upstream is merged: "Stacked on #<U> (now merged).
         Reviewing standalone diff." Derive `<U>` from the upstream
-        PR number, `<agent>` from the upstream `headRefName`
-        worktree slug (e.g. `sonnet-fleet-1`), and `T-X` from
-        the task ID in the branch name.
+        PR number, `<agent>` from the upstream PR's `author` field
+        (or "N/A" if indeterminate), and `T-X` from the task ID
+        in the branch name.
       - **Upstream OPEN without an approval label** (its `labels`
         contains neither `fleet:approved` nor `human:approved`) —
         add the gate label and post a hold-comment once:

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -204,9 +204,16 @@ iteration of polling, reviewing, and exiting cleanly:
 
    4. **Decide based on upstream status** (gate label not present):
       - **Upstream MERGED, or upstream OPEN with `fleet:approved`
-        or `human:approved`** — proceed with review. Note the stack
-        context in the review body: "Stacked on #<U>; approval
-        assumes #<U> lands first."
+        or `human:approved`** — proceed with review. Prepend the
+        verdict body with a stacked-PR context note. When upstream
+        is still open (has `fleet:approved` or `human:approved`):
+        "Stacked on #<U> (cross-author: <agent> on T-X). Reviewing
+        the child diff only — upstream is approved separately."
+        When upstream is merged: "Stacked on #<U> (now merged).
+        Reviewing standalone diff." Derive `<U>` from the upstream
+        PR number, `<agent>` from the upstream `headRefName`
+        worktree slug (e.g. `sonnet-fleet-1`), and `T-X` from
+        the task ID in the branch name.
       - **Upstream OPEN without an approval label** (its `labels`
         contains neither `fleet:approved` nor `human:approved`) —
         add the gate label and post a hold-comment once:
@@ -265,22 +272,25 @@ iteration of polling, reviewing, and exiting cleanly:
 
    Each verdict command also removes `fleet:awaiting-upstream-review`
    (so a previously-gated stacked PR exits the gate when the reviewer
-   finally proceeds) AND `fleet:stacked-rebase` (set by merger when a
+   finally proceeds), `fleet:stacked-rebase` (set by merger when a
    stacked PR's base just merged and got re-targeted to master — the
-   reviewer's re-eval is what that label is waiting for).
+   reviewer's re-eval is what that label is waiting for), and
+   `fleet:needs-base-update` (set by merger when a stacked child PR
+   conflicted on rebase and needed manual resolution — cleared by the
+   next review verdict once the author has resolved and pushed).
 
    ```
    # Verdict approve, no Nits section:
-   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved"
+   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved"
 
    # Verdict approve WITH a non-empty `### Nits` section (also set fleet:has-nits):
-   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved" --add-label "fleet:has-nits"
+   gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved" --add-label "fleet:has-nits"
 
    # Verdict needs-fix:
-   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:needs-fix"
+   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:needs-fix"
 
    # Verdict blocker:
-   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:blocker"
+   gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:blocker"
 
    # Re-review of a previously fleet:has-nits PR that's now clean:
    #   removes the has-nits flag while keeping fleet:approved

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -427,22 +427,23 @@ calls. Always remove stale verdict labels before adding the new one — a PR
 should have exactly one verdict label (`fleet:approved` / `fleet:needs-fix`
 / `fleet:blocker`) at any time. `fleet:has-nits` is orthogonal — it rides
 on top of `fleet:approved`. The remove list also clears
-`fleet:awaiting-upstream-review` (previously-gated stacked PR exits cleanly)
-and `fleet:stacked-rebase` (re-eval after a stacked-PR retarget completes
-the label's intent).
+`fleet:awaiting-upstream-review` (previously-gated stacked PR exits cleanly),
+`fleet:stacked-rebase` (re-eval after a stacked-PR retarget completes
+the label's intent), and `fleet:needs-base-update` (stacked PR whose
+upstream has since been re-approved or merged).
 
 ```bash
 # For approve, no nits in body:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved"
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved"
 
 # For approve WITH a non-empty Nits section in the body:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:approved" --add-label "fleet:has-nits"
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved" --add-label "fleet:has-nits"
 
 # For needs-fix (nits roll into the fix work; no separate label):
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:needs-fix"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:needs-fix"
 
 # For blocker:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --add-label "fleet:blocker"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:blocker"
 ```
 
 The verdict label is the **primary signal** the human uses to decide


### PR DESCRIPTION
## Summary
- When reviewing a `fleet:stacked` PR whose upstream is approved (open) or merged, the reviewer now prepends the verdict body with a cross-author topology note: `Stacked on #<U> (cross-author: <agent> on T-X). Reviewing the child diff only — upstream is approved separately.` This makes the stacking visible to the human merger without manual PR spelunking.
- All four verdict-clear label commands now include `--remove-label "fleet:needs-base-update"` so a child PR that the merger marked stale (conflicted rebase) exits that state on the next review verdict after the author pushes the rebase fix.

## Changes
- `.claude/commands/role-sonnet-reviewer.md`: step 4 bullet 1 updated with specific note format and derivation instructions; verdict-clear explanatory text and all four verdict commands updated with `fleet:needs-base-update`.

## Test plan
- [ ] Step 4 bullet 1 describes the note format with `Stacked on #<U> (cross-author: <agent> on T-X)` for open-upstream case and `Stacked on #<U> (now merged)` for merged-upstream case
- [ ] All four verdict commands include `--remove-label "fleet:needs-base-update"`
- [ ] `fleet:awaiting-upstream-review` gate logic (steps 3 and 4 bullets 2-3) unchanged
- [ ] Non-stacked PRs (baseRefName == master) unaffected

PR 5 of 6 for #501 (cross-author scheduler stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)