### PR TITLE
T-109: Lua-driven ECS: field index + index-style accessors for zero-string hot path

### DIFF
--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -104,6 +104,29 @@ IREntity.removeLuaComponent(entity, C_Hp)
   Reading or writing a field is a typed vector index — never a per-frame
   `sol::table` lookup.
 
+### Two-tier accessor contract
+
+**Table-style** (`addLuaComponent(overrides)`, `getLuaComponent`) — friendly
+setup/debug surface. `getLuaComponent` allocates a Lua table per call and does
+string-keyed field lookups. Fine for one-shot calls and inspection; not for
+per-tick hot paths.
+
+**Index-style** (`getLuaField`, `setLuaField`) — zero-string hot-path surface.
+Resolve `field.index` once at script load and pass the integer per tick. No
+string lookup, no table allocation:
+
+```lua
+local C_Hp = IRComponent.register("Hp", { current = 100 })
+local currentIdx = C_Hp.fields.current.index  -- resolve once
+
+-- inside per-tick system body:
+local v = IREntity.getLuaField(entity, C_Hp, currentIdx)
+IREntity.setLuaField(entity, C_Hp, currentIdx, v + 1)
+```
+
+Both accessors bounds-check `fieldIndex` and raise a Lua error on
+out-of-range. Use index-style inside any per-tick Lua system body.
+
 The full design is in [`docs/design/lua-driven-ecs.md`](../../docs/design/lua-driven-ecs.md).
 
 ## Lua-defined systems (`IRSystem.registerSystem`)

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -381,6 +381,7 @@ void LuaScript::bindLuaDrivenEcs() {
             fieldEntry["name"] = schema[i].name_;
             fieldEntry["type"] = std::string{toString(schema[i].type_)};
             fieldEntry["bindingId"] = static_cast<lua_Integer>(fieldIds[i]);
+            fieldEntry["index"] = static_cast<lua_Integer>(i);
             fieldsTable[schema[i].name_] = fieldEntry;
         }
         handle["fields"] = fieldsTable;
@@ -429,6 +430,47 @@ void LuaScript::bindLuaDrivenEcs() {
     m_lua["IREntity"]["hasLuaComponent"] = [](IRScript::LuaEntity entity, sol::table componentDef) {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
         return IREntity::getEntityManager().hasComponent(entity.entity, componentId);
+    };
+
+    m_lua["IREntity"]["getLuaField"] = [this](
+                                           IRScript::LuaEntity entity,
+                                           sol::table componentDef,
+                                           int fieldIndex
+                                       ) -> sol::object {
+        const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
+        auto &em = IREntity::getEntityManager();
+        auto [data, row] = em.getComponentDataAndRow(entity.entity, componentId);
+        if (!data)
+            return sol::make_object(m_lua, sol::lua_nil);
+        auto *typed = static_cast<IComponentDataLuaTyped *>(data);
+        const int schemaSize = static_cast<int>(typed->schema().size());
+        if (fieldIndex < 0 || fieldIndex >= schemaSize)
+            throw sol::error(
+                "getLuaField: fieldIndex " + std::to_string(fieldIndex) + " out of range [0, " +
+                std::to_string(schemaSize) + ")"
+            );
+        return typed->readFieldAt(row, fieldIndex, m_lua);
+    };
+
+    m_lua["IREntity"]["setLuaField"] = [this](
+                                           IRScript::LuaEntity entity,
+                                           sol::table componentDef,
+                                           int fieldIndex,
+                                           sol::object value
+                                       ) {
+        const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
+        auto &em = IREntity::getEntityManager();
+        auto [data, row] = em.getComponentDataAndRow(entity.entity, componentId);
+        if (!data)
+            return;
+        auto *typed = static_cast<IComponentDataLuaTyped *>(data);
+        const int schemaSize = static_cast<int>(typed->schema().size());
+        if (fieldIndex < 0 || fieldIndex >= schemaSize)
+            throw sol::error(
+                "setLuaField: fieldIndex " + std::to_string(fieldIndex) + " out of range [0, " +
+                std::to_string(schemaSize) + ")"
+            );
+        typed->writeFieldAt(row, fieldIndex, value);
     };
 
     bindLuaDrivenSystems();

--- a/test/script/lua_component_register_test.cpp
+++ b/test/script/lua_component_register_test.cpp
@@ -306,4 +306,144 @@ TEST_F(LuaComponentTest, RemoveLuaComponentDropsFromArchetype) {
     EXPECT_FALSE(m_entity_manager.hasComponent(e, componentId));
 }
 
+// ---- Field index + index-style accessors -----------------------------------
+
+TEST_F(LuaComponentTest, FieldHandleExposesIndex) {
+    auto &lua = m_lua.lua();
+    // field.index must be a non-negative integer, distinct across all fields.
+    auto result = lua.safe_script(
+        "local C = IRComponent.register('IdxComp', { hp = 100, mp = 50, name = 'hero' })\n"
+        "return C.fields.hp.index, C.fields.mp.index, C.fields.name.index"
+    );
+    ASSERT_TRUE(result.valid());
+    auto [hpIdx, mpIdx, nameIdx] =
+        result.get<std::tuple<lua_Integer, lua_Integer, lua_Integer>>();
+    EXPECT_GE(hpIdx, 0);
+    EXPECT_GE(mpIdx, 0);
+    EXPECT_GE(nameIdx, 0);
+    EXPECT_NE(hpIdx, mpIdx);
+    EXPECT_NE(hpIdx, nameIdx);
+    EXPECT_NE(mpIdx, nameIdx);
+}
+
+TEST_F(LuaComponentTest, FieldIndexMatchesFindFieldIndex) {
+    auto &lua = m_lua.lua();
+    // The index in the Lua handle must equal findFieldIndex's result for the same name.
+    ASSERT_TRUE(lua.safe_script(
+                        "C_Score = IRComponent.register('Score', { value = 0 })\n"
+                        "scoreIdx = C_Score.fields.value.index"
+                    )
+                    .valid());
+    const IREntity::ComponentId cid = m_entity_manager.getComponentTypeByName("Score");
+    IREntity::EntityId e = IREntity::createEntity();
+    m_entity_manager.addComponentDynamic(e, cid);
+
+    auto [data, row] = m_entity_manager.getComponentDataAndRow(e, cid);
+    ASSERT_NE(data, nullptr);
+    auto *typed = static_cast<IRScript::IComponentDataLuaTyped *>(data);
+    const int cppIdx = typed->findFieldIndex("value");
+    ASSERT_GE(cppIdx, 0);
+
+    auto idxResult = lua.safe_script("return scoreIdx");
+    ASSERT_TRUE(idxResult.valid());
+    EXPECT_EQ(idxResult.get<lua_Integer>(), static_cast<lua_Integer>(cppIdx));
+}
+
+TEST_F(LuaComponentTest, IndexStyleSetGetRoundTrip) {
+    // Verify readFieldAt / writeFieldAt work correctly at the C++ level using
+    // the index exposed via the Lua handle — the same index getLuaField /
+    // setLuaField will use at runtime.
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script(
+                        "C_Energy = IRComponent.register('Energy', { level = 0 })\n"
+                        "energyIdx = C_Energy.fields.level.index"
+                    )
+                    .valid());
+    const IREntity::ComponentId cid = m_entity_manager.getComponentTypeByName("Energy");
+    IREntity::EntityId e = IREntity::createEntity();
+    m_entity_manager.addComponentDynamic(e, cid);
+
+    auto [data, row] = m_entity_manager.getComponentDataAndRow(e, cid);
+    ASSERT_NE(data, nullptr);
+    auto *typed = static_cast<IRScript::IComponentDataLuaTyped *>(data);
+
+    auto idxResult = lua.safe_script("return energyIdx");
+    ASSERT_TRUE(idxResult.valid());
+    const int fieldIdx = static_cast<int>(idxResult.get<lua_Integer>());
+
+    typed->writeFieldAt(row, fieldIdx, sol::make_object(lua, 42));
+    sol::object readBack = typed->readFieldAt(row, fieldIdx, lua);
+    ASSERT_TRUE(readBack.is<int>());
+    EXPECT_EQ(readBack.as<int>(), 42);
+}
+
+TEST_F(LuaComponentTest, IndexStyleLuaSetGet) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script(
+                        "C_Mana = IRComponent.register('Mana', { current = 100, max = 200 })"
+                    )
+                    .valid());
+    const IREntity::ComponentId cid = m_entity_manager.getComponentTypeByName("Mana");
+    IREntity::EntityId e = IREntity::createEntity();
+    m_entity_manager.addComponentDynamic(e, cid);
+
+    // Register a C++ helper so Lua can get a typed entity handle.
+    lua["_makeHandle"] = [e]() -> IRScript::LuaEntity { return IRScript::LuaEntity{e}; };
+    auto result = lua.safe_script(
+        "local ent = _makeHandle()\n"
+        "local idx = C_Mana.fields.current.index\n"
+        "IREntity.setLuaField(ent, C_Mana, idx, 77)\n"
+        "return IREntity.getLuaField(ent, C_Mana, idx)"
+    );
+    ASSERT_TRUE(result.valid());
+    EXPECT_EQ(result.get<int>(), 77);
+}
+
+TEST_F(LuaComponentTest, IndexStyleTableStyleAccessorsUnchanged) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script(
+                        "C_Shield = IRComponent.register('Shield', { hp = 50 })"
+                    )
+                    .valid());
+    const IREntity::ComponentId cid = m_entity_manager.getComponentTypeByName("Shield");
+    IREntity::EntityId e = IREntity::createEntity();
+    m_entity_manager.addComponentDynamic(e, cid);
+
+    lua["_makeHandle"] = [e]() -> IRScript::LuaEntity { return IRScript::LuaEntity{e}; };
+    auto result = lua.safe_script(
+        "return IREntity.getLuaComponent(_makeHandle(), C_Shield).hp"
+    );
+    ASSERT_TRUE(result.valid());
+    EXPECT_EQ(result.get<int>(), 50);
+}
+
+TEST_F(LuaComponentTest, IndexStyleOutOfRangeRaisesLuaError) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script(
+                        "C_Tag = IRComponent.register('Tag', { label = 'x' })"
+                    )
+                    .valid());
+    const IREntity::ComponentId cid = m_entity_manager.getComponentTypeByName("Tag");
+    IREntity::EntityId e = IREntity::createEntity();
+    m_entity_manager.addComponentDynamic(e, cid);
+
+    lua["_makeHandle"] = [e]() -> IRScript::LuaEntity { return IRScript::LuaEntity{e}; };
+
+    auto getResult = lua.safe_script(
+        "IREntity.getLuaField(_makeHandle(), C_Tag, 999)",
+        sol::script_pass_on_error
+    );
+    EXPECT_FALSE(getResult.valid());
+    sol::error getErr = getResult;
+    EXPECT_NE(std::string(getErr.what()).find("999"), std::string::npos);
+
+    auto setResult = lua.safe_script(
+        "IREntity.setLuaField(_makeHandle(), C_Tag, 999, 'oops')",
+        sol::script_pass_on_error
+    );
+    EXPECT_FALSE(setResult.valid());
+    sol::error setErr = setResult;
+    EXPECT_NE(std::string(setErr.what()).find("999"), std::string::npos);
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
- `IRComponent.register` now includes `field.index` in each field handle alongside `name`, `type`, and `bindingId`
- Added `IREntity.getLuaField(entity, componentDef, fieldIndex)` — reads a field by pre-resolved integer index; no string scan, no table allocation
- Added `IREntity.setLuaField(entity, componentDef, fieldIndex, value)` — writes a field by index; both accessors bounds-check and raise a Lua error on out-of-range
- `engine/script/CLAUDE.md` documents the two-tier accessor contract with a usage example

## Why
Per-tick Lua systems using `getLuaComponent` pay a Lua table allocation + N string-keyed lookups per entity per frame. Index-style accessors let scripts resolve field indices once at load time and use integers per tick — the hot path is then a direct `readFieldAt`/`writeFieldAt` vector index.

## Test plan
- [x] `IrredenEngineTest` — 20 tests pass, including 6 new T-109 tests:
  - `FieldHandleExposesIndex` — indices are non-negative and distinct across fields
  - `FieldIndexMatchesFindFieldIndex` — Lua `field.index` equals `findFieldIndex` result
  - `IndexStyleSetGetRoundTrip` — `writeFieldAt`/`readFieldAt` round-trip at the cached index
  - `IndexStyleLuaSetGet` — `setLuaField`/`getLuaField` from Lua via entity handle
  - `IndexStyleTableStyleAccessorsUnchanged` — `getLuaComponent` still works
  - `IndexStyleOutOfRangeRaisesLuaError` — error message includes offending index

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)