### PR TITLE
T-119: Fleet: usage-limit back-off for fleet-dispatcher transient workers

### DIFF
--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -23,7 +23,10 @@ PANE_KEY="${1:?fleet-dispatch-wrap: missing pane_key}"
 MODEL="${2:?fleet-dispatch-wrap: missing model}"
 EFFORT="${3:?fleet-dispatch-wrap: missing effort}"
 ROLE="${4:?fleet-dispatch-wrap: missing role}"
-RATE_LIMIT_DIR="$HOME/.fleet/state/rate-limit"
+# Track fleet-dispatcher's STATE_DIR via the same env-var override so a
+# config change in one place propagates to both scripts.
+STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
+RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
 
 claude --model "$MODEL" --effort "$EFFORT" --print \
     --output-format stream-json --include-partial-messages --verbose \

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# fleet-dispatch-wrap — run one transient-role claude iteration and record
+# rate-limit exits for fleet-dispatcher's per-pane cooldown (issue #520).
+#
+# Called by fleet-dispatcher via tmux send-keys. Arguments:
+#   $1  pane_key  e.g. "pane-3"
+#   $2  model     e.g. "sonnet" or "claude-opus-4-7"
+#   $3  effort    e.g. "high" or "xhigh"
+#   $4  role      e.g. "sonnet-author"
+#
+# On usage-limit exit (exit code 2), writes a Unix-epoch timestamp to
+# ~/.fleet/state/rate-limit/<pane_key>.ts. fleet-dispatcher checks that
+# file before dispatching a new iteration and skips the pane for
+# FLEET_DISPATCHER_LIMIT_DELAY seconds (default: 900).
+#
+# PIPESTATUS[0] captures claude's exit code even though its stdout is
+# piped to fleet-claude-stream — the pipe exit status would be
+# fleet-claude-stream's code, not claude's.
+
+set -uo pipefail
+
+PANE_KEY="${1:?fleet-dispatch-wrap: missing pane_key}"
+MODEL="${2:?fleet-dispatch-wrap: missing model}"
+EFFORT="${3:?fleet-dispatch-wrap: missing effort}"
+ROLE="${4:?fleet-dispatch-wrap: missing role}"
+RATE_LIMIT_DIR="$HOME/.fleet/state/rate-limit"
+
+claude --model "$MODEL" --effort "$EFFORT" --print \
+    --output-format stream-json --include-partial-messages --verbose \
+    "/role-$ROLE live" | fleet-claude-stream
+
+rc="${PIPESTATUS[0]}"
+if [[ "$rc" == "2" ]]; then
+    mkdir -p "$RATE_LIMIT_DIR"
+    date +%s > "$RATE_LIMIT_DIR/$PANE_KEY.ts"
+fi

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -60,10 +60,16 @@ FLEET_SESSION="${FLEET_SESSION:-fleet}"
 STATE_DIR="$HOME/.fleet/state"
 TRIGGERS_DIR="$STATE_DIR/triggers"
 DISPATCH_DIR="$STATE_DIR/dispatch"
+RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
 LOG_FILE="$HOME/.fleet/logs/dispatcher.log"
 PID_FILE="$STATE_DIR/dispatcher.pid"
 LOCK_DIR="$STATE_DIR/dispatcher.lock.d"
 SHUTDOWN_FLAG="$HOME/.fleet/shutdown-in-progress"
+
+# Seconds to back off after a pane exits with code 2 (suspected usage limit).
+# Mirrors fleet-babysit's LIMIT_DELAY. Per-pane: if one of two opus-worker
+# panes hits a limit, the other keeps running.
+LIMIT_DELAY="${FLEET_DISPATCHER_LIMIT_DELAY:-900}"
 
 # Default poll cadence. Workers are transient — each iteration is a
 # one-shot `claude --print` spawned into an idle pane when a trigger
@@ -142,6 +148,11 @@ declare -A ROLE_EFFORT=(
     ["queue-manager"]="high"
     ["merger"]="xhigh"
 )
+
+# Tracks which panes have already had their cooldown logged this cycle so
+# the "in rate-limit cooldown" message fires once per pane per cooldown
+# window, not every 10-second tick. Keyed by pane_key (e.g. "pane-3").
+declare -A RATE_LIMIT_COOLDOWN_LOGGED=()
 
 # --- Logging ---------------------------------------------------------------
 #
@@ -297,23 +308,45 @@ cleanup_stale_dispatches() {
     done
 }
 
+# --- Rate-limit cooldown ---------------------------------------------------
+
+# Returns 0 (true) if the pane is still within its usage-limit cooldown
+# window; returns 1 (false) if the pane is free to dispatch.
+# As a side effect, removes the marker file when the cooldown expires and
+# clears the "already logged" flag so the next cooldown produces a fresh log.
+pane_in_rate_limit_cooldown() {
+    local pane_key="$1"
+    local ts_file="$RATE_LIMIT_DIR/$pane_key.ts"
+    if [[ ! -f "$ts_file" ]]; then
+        return 1
+    fi
+    local ts now elapsed
+    ts=$(cat "$ts_file" 2>/dev/null || printf '0')
+    now=$(date +%s)
+    elapsed=$(( now - ts ))
+    if (( elapsed < LIMIT_DELAY )); then
+        return 0
+    fi
+    rm -f "$ts_file"
+    unset 'RATE_LIMIT_COOLDOWN_LOGGED[$pane_key]'
+    return 1
+}
+
 # --- Trigger dispatch ------------------------------------------------------
 
 build_dispatch_command() {
-    # $1 = role; prints the shell-quoted command to send into the pane.
-    local role="$1"
+    # $1 = role, $2 = pane_id (e.g. "%3")
+    # Prints the shell-quoted command to send into the pane.
+    # Delegates to fleet-dispatch-wrap so the pane can capture claude's
+    # exit code and record rate-limit exits — the pipe to fleet-claude-stream
+    # would otherwise swallow claude's exit code (PIPESTATUS is only available
+    # in the pane's shell, not in the dispatcher). See fleet-dispatch-wrap.
+    local role="$1" pane_id="$2"
+    local pane_key
+    pane_key=$(pane_id_to_key "$pane_id")
     local model="${ROLE_MODEL[$role]:-sonnet}"
     local effort="${ROLE_EFFORT[$role]:-high}"
-    # `--print` makes each iteration a one-shot process that exits on
-    # completion (PR #257). `--output-format stream-json
-    # --include-partial-messages --verbose` is what makes claude emit
-    # the live JSON event stream that fleet-claude-stream renders as
-    # readable pane text — without those three flags claude buffers in
-    # plain-text mode and only flushes at exit, so the pane looks dead
-    # the whole iteration and the formatter sees no init / tool / delta
-    # events to render. Mirrors fleet-babysit's stream_claude().
-    printf 'claude --model %q --effort %q --print --output-format stream-json --include-partial-messages --verbose "/role-%s live" | fleet-claude-stream\n' \
-        "$model" "$effort" "$role"
+    printf 'fleet-dispatch-wrap %q %q %q %q\n' "$pane_key" "$model" "$effort" "$role"
 }
 
 dispatch_role() {
@@ -346,9 +379,6 @@ dispatch_role() {
         return
     fi
 
-    local cmd
-    cmd=$(build_dispatch_command "$role")
-
     local dispatched=0
     while IFS= read -r pane_id; do
         [[ -n "$pane_id" ]] || continue
@@ -359,6 +389,21 @@ dispatch_role() {
         if [[ -f "$(dispatch_record "$pane_id")" ]]; then
             continue
         fi
+        # Skip panes that hit a usage-limit recently. The per-pane
+        # rate-limit marker is written by fleet-dispatch-wrap when claude
+        # exits with code 2. Log the skip once per cooldown window to
+        # avoid repeating the message on every 10-second tick.
+        local pane_key
+        pane_key=$(pane_id_to_key "$pane_id")
+        if pane_in_rate_limit_cooldown "$pane_key"; then
+            if [[ -z "${RATE_LIMIT_COOLDOWN_LOGGED[$pane_key]+x}" ]]; then
+                log "pane $pane_id ($role) in usage-limit cooldown (${LIMIT_DELAY}s); trigger kept"
+                RATE_LIMIT_COOLDOWN_LOGGED["$pane_key"]=1
+            fi
+            continue
+        fi
+        local cmd
+        cmd=$(build_dispatch_command "$role" "$pane_id")
         log "dispatching $role -> $pane_id"
         # C-c aborts any partial input the human may have typed into
         # the idle pane (including multi-line continuations); C-u then
@@ -505,7 +550,7 @@ PY
 }
 
 main() {
-    mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$TRIGGERS_DIR" "$DISPATCH_DIR"
+    mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$TRIGGERS_DIR" "$DISPATCH_DIR" "$RATE_LIMIT_DIR"
 
     if ! acquire_dispatcher_lock; then
         log "another dispatcher is already running (lock held); exiting"

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -57,7 +57,7 @@ set -euo pipefail
 # --- Paths -----------------------------------------------------------------
 
 FLEET_SESSION="${FLEET_SESSION:-fleet}"
-STATE_DIR="$HOME/.fleet/state"
+STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
 TRIGGERS_DIR="$STATE_DIR/triggers"
 DISPATCH_DIR="$STATE_DIR/dispatch"
 RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
@@ -335,15 +335,13 @@ pane_in_rate_limit_cooldown() {
 # --- Trigger dispatch ------------------------------------------------------
 
 build_dispatch_command() {
-    # $1 = role, $2 = pane_id (e.g. "%3")
+    # $1 = role, $2 = pane_key (e.g. "pane-3")
     # Prints the shell-quoted command to send into the pane.
     # Delegates to fleet-dispatch-wrap so the pane can capture claude's
     # exit code and record rate-limit exits — the pipe to fleet-claude-stream
     # would otherwise swallow claude's exit code (PIPESTATUS is only available
     # in the pane's shell, not in the dispatcher). See fleet-dispatch-wrap.
-    local role="$1" pane_id="$2"
-    local pane_key
-    pane_key=$(pane_id_to_key "$pane_id")
+    local role="$1" pane_key="$2"
     local model="${ROLE_MODEL[$role]:-sonnet}"
     local effort="${ROLE_EFFORT[$role]:-high}"
     printf 'fleet-dispatch-wrap %q %q %q %q\n' "$pane_key" "$model" "$effort" "$role"
@@ -403,7 +401,7 @@ dispatch_role() {
             continue
         fi
         local cmd
-        cmd=$(build_dispatch_command "$role" "$pane_id")
+        cmd=$(build_dispatch_command "$role" "$pane_key")
         log "dispatching $role -> $pane_id"
         # C-c aborts any partial input the human may have typed into
         # the idle pane (including multi-line continuations); C-u then

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -128,6 +128,8 @@ FLEET_ISSUE_SRC="$SCRIPT_DIR/fleet-issue"
 FLEET_ISSUE_DEST="$HOME/bin/fleet-issue"
 FLEET_DISPATCHER_SRC="$SCRIPT_DIR/fleet-dispatcher"
 FLEET_DISPATCHER_DEST="$HOME/bin/fleet-dispatcher"
+FLEET_DISPATCH_WRAP_SRC="$SCRIPT_DIR/fleet-dispatch-wrap"
+FLEET_DISPATCH_WRAP_DEST="$HOME/bin/fleet-dispatch-wrap"
 WITNESS_SRC="$SCRIPT_DIR/witness"
 WITNESS_DEST="$HOME/bin/witness"
 
@@ -139,7 +141,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_ISSUE_SRC" "$FLEET_DISPATCHER_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_ISSUE_SRC" "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCH_WRAP_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -236,6 +238,11 @@ fi
 if [[ -f "$FLEET_DISPATCHER_SRC" ]]; then
     ln -sf "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCHER_DEST"
     echo "symlinked $FLEET_DISPATCHER_DEST -> $FLEET_DISPATCHER_SRC"
+fi
+
+if [[ -f "$FLEET_DISPATCH_WRAP_SRC" ]]; then
+    ln -sf "$FLEET_DISPATCH_WRAP_SRC" "$FLEET_DISPATCH_WRAP_DEST"
+    echo "symlinked $FLEET_DISPATCH_WRAP_DEST -> $FLEET_DISPATCH_WRAP_SRC"
 fi
 
 if [[ -f "$WITNESS_SRC" ]]; then


### PR DESCRIPTION
## Summary
- Adds `fleet-dispatch-wrap`, a new script that wraps the `claude` pipeline call and records usage-limit exits (exit code 2) as a per-pane timestamp marker at `~/.fleet/state/rate-limit/<pane-key>.ts`.
- Adds `pane_in_rate_limit_cooldown()` to `fleet-dispatcher` that checks the marker and skips dispatch for `FLEET_DISPATCHER_LIMIT_DELAY` seconds (default 900, matching `fleet-babysit`'s `LIMIT_DELAY`).
- Cooldown log message fires once per pane per cooldown window, not every 10-second tick.
- Per-pane scoping preserves parallelism: if one of two opus-worker panes hits a limit, the other keeps running.
- Wires `fleet-dispatch-wrap` into `install.sh` symlink and chmod passes.

## Why fleet-dispatch-wrap rather than inline
The dispatcher sends commands to tmux panes via `send-keys` (fire-and-forget). The pane's shell runs `claude | fleet-claude-stream`; the pipe swallows claude's exit code from the dispatcher's perspective. `PIPESTATUS` is only available in the pane's shell. A separate wrapper script captures it there and writes the marker file, keeping the dispatcher's logic clean.

## Test plan
- [ ] `bash -n scripts/fleet/fleet-dispatcher` passes (syntax check)
- [ ] `bash -n scripts/fleet/fleet-dispatch-wrap` passes (syntax check)
- [ ] `install.sh` dry-run shows `fleet-dispatch-wrap` in the symlink list
- [ ] After a simulated rate-limit exit (write a timestamp to `~/.fleet/state/rate-limit/pane-N.ts`), dispatcher skips that pane for 900 s and logs one "in usage-limit cooldown" message
- [ ] After 900 s elapse, the pane resumes normal dispatch

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)