### PR TITLE
T-122: Fleet: role docs startup reservation check

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -200,6 +200,24 @@ Do the work, then exit cleanly:
    doesn't false-alarm during long builds or PR flows (threshold is
    30 minutes per iteration).
 
+0.5. **Check for a worktree reservation.** See whether a prior iteration
+   reserved this worktree for an interrupted task:
+   `fleet-claim reservation-of <your-worktree-basename>`
+
+   - **Empty output** — no reservation; proceed normally (step 1 onward).
+   - **Non-empty output (a task ID, e.g. `T-NNN`)** — this worktree is
+     reserved for an in-flight task from a previous interrupted iteration.
+     Read the reserved branch and check it out:
+     `branch=$(jq -r .branch ~/.fleet/reservations/<your-worktree-basename>.json)`
+     `git checkout "$branch"`
+     (No-op if the branch is already checked out.) Run steps 1, 1b, and
+     2 normally — feedback, smoke, and `fleet:needs-plan` planning are
+     still your responsibility. **At step 3**, skip task pickup: the
+     reserved task IS your task. Record the reserved task ID, skip steps
+     3–4 (pickup and claim — already done), and jump directly to step 5
+     (read the plan file) with the reserved task ID. The PR from the
+     previous iteration is still open; do NOT open a new one.
+
 1. **Check for feedback labels on open PRs across both repos.**
    Re-Read `~/.fleet/state/state.json` if its contents are no
    longer in your conversation context. From `repos.engine.prs[]`
@@ -1029,6 +1047,10 @@ Do the work, then exit cleanly:
     and silently strip from the saved summary. Write technical
     references in plain prose.
 
+    Before invoking `start-next-task`, release the worktree reservation
+    so the next iteration sees this worktree as free:
+    `fleet-claim release-worktree <your-worktree-basename>`
+
     Then use the `start-next-task` skill to land on a fresh
     branch off `origin/master` in the **current cwd's repo** (engine
     if you didn't cd; game if you did). Print
@@ -1052,6 +1074,7 @@ or `review-only` (passed by `fleet-dispatcher` from `fleet-up`'s mode arg).
 - **`review-only`** (close-out mode): conserves credit by closing out
   in-flight work without expanding the queue. Each iteration runs:
   - Step 0 (heartbeat)
+  - Step 0.5 (reservation check — checkout reserved branch if found)
   - Step 1 (address feedback labels on open PRs, both repos)
   - Step 1b (cross-host smoke validation on approved render PRs)
   - Step 1c (resolve `fleet:semantic-conflict` PRs)

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -208,8 +208,10 @@ Do the work, then exit cleanly:
    - **Non-empty output (a task ID, e.g. `T-NNN`)** — this worktree is
      reserved for an in-flight task from a previous interrupted iteration.
      Read the reserved branch and check it out:
-     `branch=$(jq -r .branch ~/.fleet/reservations/<your-worktree-basename>.json)`
-     `git checkout "$branch"`
+     Use the **Read tool** to read
+     `~/.fleet/reservations/<your-worktree-basename>.json`
+     and extract the `branch` field from the JSON. Then:
+     `git checkout <branch>`
      (No-op if the branch is already checked out.) Run steps 1, 1b, and
      2 normally — feedback, smoke, and `fleet:needs-plan` planning are
      still your responsibility. **At step 3**, skip task pickup: the

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -126,8 +126,10 @@ Each iteration:
    - **Non-empty output (a task ID, e.g. `T-NNN`)** — this worktree is
      reserved for an in-flight task from a previous interrupted iteration.
      Read the reserved branch and check it out:
-     `branch=$(jq -r .branch ~/.fleet/reservations/<your-worktree-basename>.json)`
-     `git checkout "$branch"`
+     Use the **Read tool** to read
+     `~/.fleet/reservations/<your-worktree-basename>.json`
+     and extract the `branch` field from the JSON. Then:
+     `git checkout <branch>`
      (No-op if the branch is already checked out.) Run steps 1 and 1b
      normally — feedback and smoke are still your responsibility. **At
      step 2**, skip molecule resume and task pickup entirely: the
@@ -745,7 +747,11 @@ or `review-only` (passed by `fleet-dispatcher` from `fleet-up`'s mode arg).
 - **`review-only`** (close-out mode): conserves credit by closing out
   in-flight work without expanding the queue. Each iteration runs:
   - Step 0 (heartbeat)
-  - Step 0.5 (reservation check — checkout reserved branch if found)
+  - Step 0.5 (reservation check — checkout reserved branch if found;
+    in review-only mode, check out the reserved branch so step 1
+    feedback applies to the right PR, but do NOT jump to step 4 —
+    exit after step 1b as normal; the reservation persists until the
+    next live-mode iteration resumes the task)
   - Step 1 (address feedback labels on open PRs)
   - Step 1b (cross-host smoke validation on approved render PRs)
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -118,6 +118,24 @@ Each iteration:
    long-running steps (fleet-build, fleet-run, commit-and-push) to
    prevent false staleness alerts during builds or PR actions.
 
+0.5. **Check for a worktree reservation.** See whether a prior iteration
+   reserved this worktree for an interrupted task:
+   `fleet-claim reservation-of <your-worktree-basename>`
+
+   - **Empty output** — no reservation; proceed normally (step 1 onward).
+   - **Non-empty output (a task ID, e.g. `T-NNN`)** — this worktree is
+     reserved for an in-flight task from a previous interrupted iteration.
+     Read the reserved branch and check it out:
+     `branch=$(jq -r .branch ~/.fleet/reservations/<your-worktree-basename>.json)`
+     `git checkout "$branch"`
+     (No-op if the branch is already checked out.) Run steps 1 and 1b
+     normally — feedback and smoke are still your responsibility. **At
+     step 2**, skip molecule resume and task pickup entirely: the
+     reserved task IS your task. Record the reserved task ID, skip steps
+     2–3 (pickup and claim — already done), and jump directly to step 4
+     (read the plan file) with the reserved task ID. The PR from the
+     previous iteration is still open; do NOT open a new one.
+
 1. **Check for feedback labels on open PRs.** Re-Read
    `~/.fleet/state/state.json` if its contents are no longer in your
    conversation context. From `repos.engine.prs[]`, pick PRs whose
@@ -700,6 +718,10 @@ Each iteration:
    and silently strip from the saved summary. Write technical
    references in plain prose.
 
+   Before invoking `start-next-task`, release the worktree reservation
+   so the next iteration sees this worktree as free:
+   `fleet-claim release-worktree <your-worktree-basename>`
+
    Then use the `start-next-task` skill to land on a fresh branch off
    `origin/master`. Print
    `[sonnet-author] Iteration complete. Will re-fire on next dispatcher trigger.`
@@ -723,6 +745,7 @@ or `review-only` (passed by `fleet-dispatcher` from `fleet-up`'s mode arg).
 - **`review-only`** (close-out mode): conserves credit by closing out
   in-flight work without expanding the queue. Each iteration runs:
   - Step 0 (heartbeat)
+  - Step 0.5 (reservation check — checkout reserved branch if found)
   - Step 1 (address feedback labels on open PRs)
   - Step 1b (cross-host smoke validation on approved render PRs)
 


### PR DESCRIPTION
## Summary

- Adds step 0.5 to `role-sonnet-author.md` and `role-opus-worker.md`: check `fleet-claim reservation-of <worktree>` after heartbeat
- If a reservation is found from a prior interrupted iteration: checkout the reserved branch, run feedback/smoke steps normally, skip task-pickup steps, jump to the plan-file step with the reserved task
- Reset step in both roles now calls `fleet-claim release-worktree <worktree>` before `start-next-task` so the worktree returns to the free pool
- `review-only` mode step lists updated to include step 0.5

## Stack context

PR 3 of 6 for issue #521 (worktree-as-reservation epic). Full plan in `.fleet/plans/T-120.md`.

**Important:** References `fleet-claim reservation-of` and `fleet-claim release-worktree` which are added by T-120 (PR 1 of 6). This PR should **not merge until T-120 is installed** — before T-120 ships, these commands exit non-zero and running agents would fail step 0.5.

## Test plan

- [ ] After T-120 installs: dry-run a sonnet-author iteration with a stale reservation in place — verify it exits without double-claiming
- [ ] After T-120 installs: full iteration with reservation → checkout reserved branch → work → release-worktree → start-next-task; verify reservation is gone after start-next-task
- [ ] Agents without reservations (the common case) see empty output and proceed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)