### PR TITLE
T-113: Merger: cascade rebase on upstream force-push for stacked PRs

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -314,8 +314,7 @@ exit cleanly:
         — fleet merger
         ```
       - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
-      - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:needs-base-update"`
-      - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
+      - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:needs-base-update" --add-label "fleet:merger-cooldown"`
       - Log: `[YYYY-MM-DD HH:MM:SS] PR #<N> <headRefName>: cascade-rebase conflict onto #<base-pr-number>, labeled fleet:needs-base-update`
 
    d. **Reset to scratch.** Same as step 5f:

--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -143,17 +143,23 @@ exit cleanly:
    stacked-PR check need. (Cached equivalent of the previous
    `gh pr list --state open --json number,title,mergeable,labels,headRefName,baseRefName,updatedAt`.)
 
-2.5. **Reconcile `fleet:awaiting-base` labels.** Step 3's filter
-   skips PRs carrying `fleet:awaiting-base`, but the label is only
-   removed inside sub-case ii / iii of step 5a.5 — which doesn't
-   run if the PR was skipped. Without this reconciliation pass,
-   once the merger labels a stacked PR `fleet:awaiting-base`, it
-   keeps skipping forever even after the base PR merges (the label
-   never clears). This step closes the loop.
+2.5. **Reconcile `fleet:awaiting-base` / `fleet:needs-base-update`
+   labels.** Step 3's filter skips PRs carrying either label, but
+   they're only removed inside sub-case ii / iii of step 5a.5 —
+   which doesn't run if the PR was skipped. Without this
+   reconciliation pass, once the merger labels a stacked PR
+   `fleet:awaiting-base` (from step 5a.5 i — child CONFLICTING with
+   master) or `fleet:needs-base-update` (from step 2.6 — child
+   stale vs upstream tip and cascade-rebase failed), it keeps
+   skipping forever even after the base PR merges. This step
+   closes the loop for both labels — the merge / close transition
+   is the same regardless of which entry path set them.
 
    From `repos.engine.prs[]`, collect every PR whose `labels`
-   contains `fleet:awaiting-base`. For each such PR, look up its
-   base PR's state:
+   contains `fleet:awaiting-base` OR `fleet:needs-base-update`
+   (a PR may carry both; processing it once is sufficient — the
+   cleanup actions below remove both regardless). For each such
+   PR, look up its base PR's state:
 
    `gh pr list --repo <engine-repo> --search "head:<baseRefName>" --state all --json number,state --jq '.[] | "#\(.number) \(.state)"'`
 
@@ -165,20 +171,155 @@ exit cleanly:
    - **Base PR is MERGED** — run the same actions as step 5a.5
      sub-case ii (lines starting "Base PR is MERGED" below):
      re-target this PR to master, remove `fleet:awaiting-base`,
-     remove `fleet:stacked`, post the "base merged, re-targeted"
-     comment, add `fleet:stacked-rebase`, `fleet:changes-made`,
+     remove `fleet:stacked`, remove `fleet:needs-base-update` (a
+     stale-tip mark from step 2.6 is moot once the base lands),
+     post the "base merged, re-targeted" comment, add
+     `fleet:stacked-rebase`, `fleet:changes-made`,
      `fleet:merger-cooldown`. The PR's diff against master may
      differ from the previous review; reviewer re-evaluates next
      pass. Log: `... reconcile: base #<N> merged, re-targeted to master`.
 
    - **Base PR is CLOSED (not merged)** — run sub-case iii actions:
      post the "base closed without merging" comment, remove
-     `fleet:awaiting-base`, add `fleet:needs-info` and
+     `fleet:awaiting-base`, remove `fleet:needs-base-update` (the
+     orphaned-base hand-off via `fleet:needs-info` supersedes any
+     stale-tip mark), add `fleet:needs-info` and
      `fleet:merger-cooldown`. Log: `... reconcile: base #<N> closed (not merged), labeled fleet:needs-info`.
 
    PRs handled here count against the "2 candidates per iteration"
    cap in step 4 — re-targeting and label updates are write-heavy
    and we don't want to flood the API or the reviewer queue.
+
+2.6. **Cascade rebase stacked children whose upstream tip moved.**
+   Step 2.5 reconciles `fleet:awaiting-base` PRs when their base
+   PR merges or closes; this step handles the orthogonal case
+   where the base PR is still OPEN but its head ref was force-
+   pushed (typically because the upstream author addressed
+   reviewer feedback). Without this pass, the child PR's branch
+   stays anchored to the upstream's old tip — even after the base
+   merges, the re-target to master in step 2.5 ii leaves the
+   inherited-but-now-orphan upstream commits in the child's
+   history, which the reviewer then sees as a giant unrelated diff.
+
+   From `repos.engine.prs[]`, collect every PR where:
+   - `baseRefName != "master"` (stacked PR), AND
+   - `labels` contains NONE of `fleet:wip`, `human:wip`,
+     `fleet:blocker`, `human:needs-fix`, `human:blocker`,
+     `human:re-review`, `fleet:semantic-conflict`,
+     `fleet:fork-of-other-pr`, `fleet:needs-base-update`,
+     `fleet:needs-info`, `fleet:merger-cooldown`.
+
+   `fleet:awaiting-base` is intentionally NOT in this skip list —
+   those PRs are exactly the population whose upstream tip we
+   want to keep tracking. (`fleet:stacked` is also fine here; it
+   marks the same population from a different angle.)
+
+   For each candidate, look up the base PR's state — same query as
+   step 2.5 and step 5a.5:
+
+   `gh pr list --repo <engine-repo> --search "head:<baseRefName>" --state all --json number,state --jq '.[] | "#\(.number) \(.state)"'`
+
+   If state is not OPEN, skip — step 2.5 owns the merged/closed
+   transitions. If OPEN, fetch both refs (separate Bash calls,
+   single-command rule):
+
+   `git fetch origin <baseRefName>`
+   `git fetch origin <headRefName>`
+
+   Then check whether the upstream tip is reachable from the
+   child's tip:
+
+   `git merge-base --is-ancestor origin/<baseRefName> origin/<headRefName>`
+
+   - **Exit 0** — upstream tip is an ancestor of child tip; child
+     is up-to-date with upstream. No rebase needed; skip.
+   - **Exit 1** — upstream tip has moved beyond what the child
+     knows about; the child needs cascade-rebasing. (Same
+     `--is-ancestor` non-zero-as-expected pattern as step 5a.6 —
+     do not treat as a script error.)
+
+   Drop any "tip moved" candidate whose `headRefName` appears in
+   `fleet-worktree-busy-branches` (same rule as step 3.5; another
+   worktree owns the branch and `git checkout` would fail).
+
+   **Cap:** PRs handled here count against the "2 candidates per
+   iteration" cap shared with step 2.5 and step 4. If the
+   running total of {2.5 transitions + 2.6 rebases + step 4
+   rebases} would exceed 2, defer the remaining 2.6 candidates
+   to the next iteration. Pick oldest (lowest PR number) first.
+
+   For each "tip moved" candidate within the cap:
+
+   a. **Check out the child:**
+      `git checkout -B <headRefName> origin/<headRefName>`
+
+   b. **Try rebase onto the new upstream tip:**
+      `git rebase origin/<baseRefName>`
+
+   c. **Branch on the result.** Note: this step does NOT attempt
+      mechanical sub-resolutions (TASKS.md sort-merge, whitespace).
+      The conflict surface is "child commits vs. updated upstream
+      tip", and the right resolver is whoever owns the child PR
+      or the upstream author — not the merger. Either it replays
+      cleanly or it gets handed off.
+
+      **Clean rebase (exit 0).** The child's commits replayed
+      onto the new upstream tip without intervention.
+      - `git push --force-with-lease`
+      - Run `rm -f .merger-body.md`, then write `.merger-body.md`
+        with the **Write** tool:
+        ```
+        Merger: cascade-rebased onto updated base PR
+        #<base-pr-number>. Its head ref `<baseRefName>` was force-
+        pushed since this PR was last rebased; the child commits
+        replayed cleanly onto the new upstream tip. Force-pushed
+        with `--force-with-lease`. CI will re-run.
+
+        — fleet merger
+        ```
+      - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
+      - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
+      - Append to `~/.fleet/logs/merger-audit.log`:
+        `[YYYY-MM-DD HH:MM:SS] PR #<N> <headRefName>: cascade-rebase clean onto #<base-pr-number>, force-pushed`
+
+      **Conflict (non-zero exit).** The new upstream tip is not
+      compatible with the child's commits. Hand off:
+      - `git rebase --abort`
+      - **Switch back to scratch immediately** (same release-the-
+        branch rule as step 5d.iii):
+        `git switch claude/merger-scratch`
+      - Run `rm -f .merger-body.md`, then write `.merger-body.md`
+        with the **Write** tool:
+        ```
+        Merger: cannot cascade-rebase onto updated base PR
+        #<base-pr-number>. Its head ref `<baseRefName>` was force-
+        pushed and the new tip conflicts with this PR's own
+        commits.
+
+        Resolution: the author of this PR (or the upstream author)
+        rebases manually onto the new upstream tip:
+
+          git fetch origin
+          git rebase origin/<baseRefName>
+          # resolve conflicts, then:
+          git push --force-with-lease
+
+        Labeled `fleet:needs-base-update` — the merger and the
+        cascade-rebase pass skip this PR until the label clears.
+        It clears automatically when the upstream merges (step
+        2.5 re-targets to master and removes the label) or
+        closes; otherwise the human or an opus-worker clears it
+        after a manual rebase.
+
+        — fleet merger
+        ```
+      - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
+      - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:needs-base-update"`
+      - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
+      - Log: `[YYYY-MM-DD HH:MM:SS] PR #<N> <headRefName>: cascade-rebase conflict onto #<base-pr-number>, labeled fleet:needs-base-update`
+
+   d. **Reset to scratch.** Same as step 5f:
+      `git checkout -B claude/merger-scratch origin/master`
 
 3. Filter to candidates. A PR is a candidate if:
    - `mergeable == "CONFLICTING"`, OR
@@ -202,6 +343,11 @@ exit cleanly:
      Durable human-handoff signal; only the human clears it by
      re-targeting or closing.
    - `fleet:fork-of-other-pr` — PR's branch forked from another open PR; skip until the human clears this label after the upstream PR merges
+   - `fleet:needs-base-update` — set in step 2.6 when a stacked child's
+     upstream tip moved and the cascade-rebase conflicted. Durable
+     handoff to the author / opus-worker; cleared automatically when
+     the base merges (step 2.5 ii) or closes (step 2.5 iii), or
+     manually after a successful rebase onto the new upstream tip.
 
    **Cap UNKNOWN-state refreshes at 2 per iteration.** If the
    CONFLICTING list already has ≥2 candidates, defer all UNKNOWN
@@ -275,6 +421,7 @@ exit cleanly:
          - `gh pr edit <N> --repo <engine-repo> --base master`
          - `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:awaiting-base"`
          - `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:stacked"`
+         - `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:needs-base-update"`
          - Write `.merger-body.md` with:
            ```
            Merger: base PR #<base-pr-number> merged. Re-targeted this PR from
@@ -304,13 +451,16 @@ exit cleanly:
            ```
          - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
          - `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:awaiting-base"`
+         - `gh pr edit <N> --repo <engine-repo> --remove-label "fleet:needs-base-update"`
          - `gh pr edit <N> --repo <engine-repo> --add-label "fleet:needs-info" --add-label "fleet:merger-cooldown"`
          - Log: `... base #<base-pr-number> closed (not merged), labeled fleet:needs-info`
 
-      `fleet:stacked`, `fleet:awaiting-base`, and `fleet:stacked-rebase`
-      are derived-state convenience labels for human visibility. Author
-      roles add `fleet:stacked` at PR creation; the merger maintains
-      `fleet:awaiting-base` / `fleet:stacked-rebase` as above.
+      `fleet:stacked`, `fleet:awaiting-base`, `fleet:stacked-rebase`,
+      and `fleet:needs-base-update` are derived-state convenience
+      labels for human visibility. Author roles add `fleet:stacked`
+      at PR creation; the merger maintains `fleet:awaiting-base` /
+      `fleet:stacked-rebase` as above and `fleet:needs-base-update`
+      via step 2.6.
 
    **a.6. Fork-of-other-PR check.** Before rebasing, detect whether this
       PR's branch was forked from another open PR — even if `baseRefName`
@@ -641,14 +791,16 @@ iterations write nothing).
 The merger has TWO tiers of "don't touch this PR again":
 
 1. **Durable handoff labels** — `fleet:semantic-conflict`,
-   `fleet:awaiting-base`, `fleet:needs-info`. Once the merger
-   sets one of these, the PR is no longer the merger's
-   responsibility. Only the role that owns the next step
-   (opus-worker for semantic-conflict; the merger itself for
-   awaiting-base when the base merges/closes; the human for
-   needs-info) removes the label. These are in step 3's skip
-   list, so the merger never re-runs rebase on a PR in this
-   state — no comment spam.
+   `fleet:awaiting-base`, `fleet:needs-info`,
+   `fleet:needs-base-update`. Once the merger sets one of these,
+   the PR is no longer the merger's responsibility. Only the role
+   that owns the next step (opus-worker for semantic-conflict; the
+   merger itself for awaiting-base when the base merges/closes
+   and for needs-base-update on the same transition; the human or
+   author for needs-base-update via manual rebase; the human for
+   needs-info) removes the label. These are in step 3's skip list,
+   so the merger never re-runs rebase on a PR in this state — no
+   comment spam.
 
 2. **`fleet:merger-cooldown`** — short-lived, self-managed.
    The merger adds it after a *non-durable* outcome (clean

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -327,6 +327,17 @@ Specifically, **never pass these via `--label` when filing**:
   these in its CONFLICTING sweep; opus-worker excludes them from its
   `fleet:semantic-conflict` step. Cleared by the **human** after the
   upstream PR merges.
+- `fleet:needs-base-update` — owned by the **merger** (sets in step 2.6
+  when a stacked child PR's upstream tip was force-pushed and the
+  cascade-rebase onto the new tip conflicts with the child's own
+  commits). The child's branch is anchored to the upstream's old tip;
+  without manual reconciliation it cannot inherit the upstream's
+  updated state. The merger and the cascade-rebase pass skip these.
+  Cleared automatically when the base merges (step 2.5 ii's re-target
+  to master removes it) or closes (step 2.5 iii). Otherwise the
+  **author** rebases manually onto the new upstream tip and removes
+  the label, or an **opus-worker** drives the resolution similar to
+  `fleet:semantic-conflict`.
 - `fleet:human-amending` / `fleet:human-deferred` — owned by the
   **author worker** (sonnet-author / opus-worker) when picking up
   `human:needs-fix`. The two labels express which disposition the

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -113,6 +113,7 @@ LABELS=(
     "fleet:authored-on-macos|ededed|PR was opened from a macOS host; reviewer skips fleet:needs-macos-smoke"
     "fleet:stacked|c5def5|PR's base is a feature branch (stacked PR)"
     "fleet:awaiting-base|c5def5|Stacked PR; merger is waiting for base PR to merge"
+    "fleet:needs-base-update|fbca04|Stacked child PR; upstream force-pushed and cascade-rebase conflicted; author rebases manually"
     "fleet:stacked-rebase|c5def5|Stacked PR; base just merged, re-targeted to master, awaiting reviewer re-eval"
     "fleet:awaiting-upstream-review|c5def5|Stacked PR; reviewer is holding verdict until upstream PR is approved"
     "fleet:human-deferred|fbca04|Worker filed human:needs-fix concerns as a follow-up issue; PR is internally OK to merge if human accepts the deferral (fleet:approved kept)"


### PR DESCRIPTION
## Summary
- Adds merger step 2.6: cascade-rebase a stacked child PR onto its base PR's new tip when the base was force-pushed (e.g. for review feedback). Clean rebases push via `--force-with-lease`; conflicts get `fleet:needs-base-update` for author/opus-worker handoff.
- Expands step 2.5 to reconcile both `fleet:awaiting-base` and `fleet:needs-base-update` so the durability loop closes regardless of which entry path set the label.
- Step 5a.5 ii / iii also drop `fleet:needs-base-update` on the base merge/close transition.
- Documents `fleet:needs-base-update` in `docs/agents/FLEET.md`'s label registry AND registers it in `scripts/fleet/fleet-labels` so a fresh `fleet-up` on a clean repo creates it automatically.

## Why this matters
A stacked child PR whose upstream is still OPEN but force-pushed is invisible to the existing flow:
- step 5a.5 i only fires when the child is CONFLICTING with master, which doesn't have to happen even when the upstream tip moved
- step 2.5 only handles base-merge / base-close transitions
- without 2.6, the child stays anchored to a tip the upstream rewrote; when the upstream eventually merges, step 2.5 ii re-targets to master, leaving orphan upstream commits in the child's history that read as a giant unrelated diff.

## Acceptance criteria
- (1) merger loop detects `fleet:stacked` PRs with open base PR whose tip SHA moved — step 2.6 filter + `git merge-base --is-ancestor` check
- (2) clean rebase -> `git push --force-with-lease`, prior approval labels preserved — only `fleet:merger-cooldown` added
- (3) conflict -> `git rebase --abort`, `fleet:needs-base-update` label added, conflict comment posted
- (4) fleet-labels updated with `fleet:needs-base-update` registration — second commit in this PR
- (5) blocker's author never touches child branch — merger does it from its own worktree
- (6) avoids re-processing already-rebased children — done via the ancestor check (clean rebases make the new upstream tip an ancestor, so the next iteration short-circuits) plus the durable `fleet:needs-base-update` label for the conflict path. The original plan called for sidecar SHA tracking; the ancestor check is equivalent and simpler.

## Test plan
- [ ] Verify role-merger.md renders correctly (no broken cross-references to step numbers).
- [ ] Verify `fleet:needs-base-update` is registered: `scripts/fleet/fleet-labels --dry-run --repo jakildev/IrredenEngine` — entry should appear in the catalog (already present on the repo from out-of-band creation, so no "would create" line).
- [ ] Smoke-trace step 2.6 on a synthetic two-PR stack: open child, force-push upstream, confirm next merger iteration cascade-rebases.
- [ ] Confirm step 2.5 filter still picks up `fleet:awaiting-base`-only PRs after the OR expansion.

## Notes for reviewer
- 2.6's filter intentionally **does not** exclude `fleet:awaiting-base` — those PRs are exactly the population whose upstream tip we want to keep tracking.
- The 2-PRs-per-iteration cap is shared across steps 2.5, 2.6, and step 4 to avoid CI flooding.
- Follow-up gap (out of T-113 scope): worker step 1 priority list does NOT include `fleet:needs-base-update`. Per the T-110 plan Q2 decision, the child's original author should pick it up "via the existing feedback loop". A small follow-up to `role-opus-worker.md` and `role-sonnet-author.md` should add the label to the priority list — likely belongs in T-112 (worker role docs PR) or a tiny `[sonnet]` task.
- No code changes to engine/render/etc.; pure docs/role + label-registry edits.

Closes T-113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)