### PR TITLE
T-112: Worker role docs: stackable-blocked fallback pickup tier

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -898,6 +898,9 @@ Do the work, then exit cleanly:
 
    For a stackable-on claim (base is a feature branch), open with
    `--base <upstream-branch>` and add `fleet:stacked`:
+   First look up the upstream PR URL:
+   `gh pr view <stackable_blocker_pr.number> --json url --jq .url`
+   Then open the PR:
    `gh pr create --base <upstream-branch> --title "T-<NNN>: <title>" --body "Stacked on: <upstream PR URL>\n\nWork in progress." --label "fleet:wip" --label "fleet:stacked"`
 
    Reference the task title in the PR title so the queue-manager can

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -727,8 +727,26 @@ Do the work, then exit cleanly:
    "reserved for game-architect" in any file other than `fleet-claim`
    means the work would never get done. Pick it up.
 
-   If no `Model: opus` tasks are available on either repo, print
-   `[opus-worker] No unblocked [opus] tasks (engine + game). Will re-fire on next dispatcher trigger.`
+   **If no unblocked tasks are available on either repo, try the
+   fallback tier.**
+
+   **Fallback: stackable-blocked tasks (engine only, v1).** Look in
+   `repos.engine.tasks.open[]` for entries where `owner == "free"` (or
+   your worktree name), `model` contains `opus`, AND the entry has a
+   `stackable_blocker_pr` field. Only single-blocker tasks have this
+   field — the scout does not set it for tasks with multiple `Blocked by:`
+   entries (Q3 decision: multi-blocker not eligible in v1). Skip game-side
+   tasks — game stackable pickup is deferred to v2; engine only in
+   this tier. Pick the oldest eligible engine task by task ID.
+
+   If a stackable-blocked task is found, claim it with `--stackable-on`:
+   `fleet-claim claim "<task-id>" <your-worktree-name> --stackable-on <stackable_blocker_pr.number>`
+   where `<stackable_blocker_pr.number>` is the PR number from the scout's
+   `stackable_blocker_pr` object (the fleet-claim script accepts a number
+   or full URL). See step 4 for the branching flow.
+
+   **If neither tier yields a task, exit cleanly.** Print
+   `[opus-worker] No unblocked or stackable-blocked [opus] tasks (engine + game). Will re-fire on next dispatcher trigger.`
    and exit cleanly. Do NOT invent work, self-assign documentation
    passes, or create tasks outside the queue.
 
@@ -860,7 +878,16 @@ Do the work, then exit cleanly:
    the same branch, push, and comment as usual. No cross-task
    side-effects.
 
-   For single tasks, use the normal claim flow:
+   For single tasks (including stackable-blocked claims), determine
+   the base branch before checking out:
+   `fleet-claim claim-base "<task-id>"`
+   - Returns `master` — branch off `origin/master` normally.
+   - Returns a feature branch (e.g. `claude/T-NNN-…`) — this is a
+     stackable-on claim; fetch and branch off that upstream branch:
+     `git fetch origin <upstream-branch>`
+     `git checkout -b claude/<task-id>-<short-topic> origin/<upstream-branch>`
+
+   For a normal claim (base is `master`):
    `git checkout -b claude/<area>-<topic>`
    `git commit --allow-empty -m "claim: <task title>"`
 
@@ -868,6 +895,10 @@ Do the work, then exit cleanly:
    include `Closes #N` in the PR body:
    `gh pr create --title "<task title>" --body "Claiming task. Work in progress.\n\nCloses #N" --label "fleet:wip"`
    If there is no issue (`(none)`), omit the `Closes` line.
+
+   For a stackable-on claim (base is a feature branch), open with
+   `--base <upstream-branch>` and add `fleet:stacked`:
+   `gh pr create --base <upstream-branch> --title "T-<NNN>: <title>" --body "Stacked on: <upstream PR URL>\n\nWork in progress." --label "fleet:wip" --label "fleet:stacked"`
 
    Reference the task title in the PR title so the queue-manager can
    match it.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -468,8 +468,25 @@ Each iteration:
    `[sonnet]` agent shouldn't pick `[opus]` tasks anyway). Otherwise
    the task is yours to claim.
 
-   **If no matching task exists, exit cleanly.** Print
-   `[sonnet-author] No unblocked [sonnet] tasks — standing by. Babysit will re-invoke.`
+   **If no matching unblocked task exists, try the fallback tier.**
+
+   **Fallback: stackable-blocked tasks (engine only, v1).** Look in
+   `repos.engine.tasks.open[]` for entries where `owner == "free"` (or
+   your worktree name), `model` contains `sonnet`, AND the entry has a
+   `stackable_blocker_pr` field. Only single-blocker tasks have this
+   field — the scout does not set it for tasks with multiple `Blocked by:`
+   entries (Q3 decision: multi-blocker not eligible in v1). Skip game-side
+   tasks — game stackable pickup is deferred to v2; check
+   `repo == "engine"` only. Pick the oldest eligible task by task ID.
+
+   If a stackable-blocked task is found, claim it with `--stackable-on`:
+   `fleet-claim claim "<task-id>" <your-worktree-name> --stackable-on <stackable_blocker_pr.number>`
+   where `<stackable_blocker_pr.number>` is the PR number from the scout's
+   `stackable_blocker_pr` object (the fleet-claim script accepts a number
+   or full URL). See step 3 for the branching flow.
+
+   **If neither tier yields a task, exit cleanly.** Print
+   `[sonnet-author] No unblocked or stackable-blocked [sonnet] tasks — standing by. Babysit will re-invoke.`
    and stop. Do NOT invent work, self-assign documentation passes,
    or create tasks outside the queue.
 
@@ -574,8 +591,16 @@ Each iteration:
    reviewer's approval on the unchanged commits carries over unless
    a conflict actually modified them.
 
-   **For single-task claims**, create the branch, commit, and open a
-   `fleet:wip` PR normally:
+   **For single-task claims** (including stackable-blocked claims),
+   determine the base before branching:
+   `fleet-claim claim-base "<task-id>"`
+   - Returns `master` — branch off `origin/master` normally.
+   - Returns a feature branch (e.g. `claude/T-NNN-…`) — this is a
+     stackable-on claim; fetch and branch off that upstream branch:
+     `git fetch origin <upstream-branch>`
+     `git checkout -b claude/<task-id>-<short-topic> origin/<upstream-branch>`
+
+   For a normal claim (base is `master`):
    `git checkout -b claude/<area>-<topic>`
    `git commit --allow-empty -m "claim: <task title>"`
 
@@ -584,6 +609,10 @@ Each iteration:
    automatically when the PR merges:
    `gh pr create --title "<task title>" --body "Claiming task. Work in progress.\n\nCloses #N" --label "fleet:wip"`
    If there is no issue (`(none)`), omit the `Closes` line.
+
+   For a stackable-on claim (base is a feature branch), open with
+   `--base <upstream-branch>` and add `fleet:stacked`:
+   `gh pr create --base <upstream-branch> --title "T-<NNN>: <title>" --body "Stacked on: <upstream PR URL>\n\nWork in progress." --label "fleet:wip" --label "fleet:stacked"`
 
    Reference the task title in the PR title so the queue-manager can
    match it.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -486,7 +486,7 @@ Each iteration:
    or full URL). See step 3 for the branching flow.
 
    **If neither tier yields a task, exit cleanly.** Print
-   `[sonnet-author] No unblocked or stackable-blocked [sonnet] tasks — standing by. Babysit will re-invoke.`
+   `[sonnet-author] No unblocked or stackable-blocked [sonnet] tasks — standing by. Will re-fire on next dispatcher trigger.`
    and stop. Do NOT invent work, self-assign documentation passes,
    or create tasks outside the queue.
 
@@ -612,6 +612,9 @@ Each iteration:
 
    For a stackable-on claim (base is a feature branch), open with
    `--base <upstream-branch>` and add `fleet:stacked`:
+   First look up the upstream PR URL:
+   `gh pr view <stackable_blocker_pr.number> --json url --jq .url`
+   Then open the PR:
    `gh pr create --base <upstream-branch> --title "T-<NNN>: <title>" --body "Stacked on: <upstream PR URL>\n\nWork in progress." --label "fleet:wip" --label "fleet:stacked"`
 
    Reference the task title in the PR title so the queue-manager can


### PR DESCRIPTION
## Summary
- `role-sonnet-author.md` and `role-opus-worker.md` step 3/Normal pickup: add two-tier task pickup with stackable-blocked fallback when no unblocked tasks exist
- Fallback tier picks the oldest engine task with `stackable_blocker_pr` set (scout pre-computes this field for single-blocker tasks with exactly one open PR on the blocker branch)
- Multi-blocker tasks excluded from fallback (Q3 decision: scout only sets the field for single-`T-NNN` blockers)
- Engine-only guard in v1; game stackable pickup deferred to v2
- Claim uses `fleet-claim claim --stackable-on <number>` to bypass the blocker gate
- PR opening reads `fleet-claim claim-base` to determine whether to branch off master or the blocker's feature branch; adds `--base` + `fleet:stacked` for the stackable case

## Test plan
- [ ] Iteration with zero unblocked tasks but a task with `stackable_blocker_pr` set → falls through to fallback tier and picks the task
- [ ] `fleet-claim claim <id> <agent> --stackable-on <n>` exits 0 and writes the sidecar `.meta` file
- [ ] `fleet-claim claim-base <id>` returns the upstream branch name (or `master` if blocker merged in the gap)
- [ ] Task with `Blocked by: T-A, T-B` has no `stackable_blocker_pr` field in scout output (multi-blocker excluded)
- [ ] Game-side tasks with `stackable_blocker_pr` not picked up by engine workers in v1

PR 3 of 6 for issue #501. Depends on T-110 (fleet-claim stackable-on, #525) and T-111 (scout stackable_blocker_pr, #536), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)