### PR TITLE
T-125: fleet — per-role concurrency cap config + dispatcher enforcement

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1873,6 +1873,82 @@ cmd_list_reservations() {
     fi
 }
 
+cmd_reservation_role() {
+    # Print the dispatcher role for a worktree's reservation, or empty
+    # if no reservation / task not found / Model unparseable. Maps the
+    # task's `Model:` field (sourced from the reservation's task_id)
+    # onto the dispatcher role tag:
+    #
+    #   Model: opus   → opus-worker
+    #   Model: sonnet → sonnet-author
+    #
+    # Used by fleet-dispatcher's per-role concurrency cap to count
+    # reserved-but-idle iterations alongside in-flight ones — a
+    # reservation represents paused work that will resume on the next
+    # tick and consume a slot.
+    #
+    # Searches engine TASKS.md first (origin/master), then game. A
+    # task_id slug is namespace-prefixed via the global --repo flag,
+    # but the reservation's task_id is stored without the prefix —
+    # checking both repos handles cross-repo reservations cheaply.
+    #
+    # Empty stdout + exit 0 = no answer (mirrors reservation-of's
+    # stdout-channel idiom — callers discriminate via `[[ -n ]]`).
+    local worktree="$1"
+    if [[ -z "$worktree" ]]; then
+        echo "usage: fleet-claim reservation-role <worktree>" >&2
+        return 2
+    fi
+    local task_id
+    task_id=$(reservation_task_id "$worktree")
+    [[ -n "$task_id" ]] || return 0
+
+    local engine_root="${FLEET_ENGINE_ROOT:-$HOME/src/IrredenEngine}"
+    local game_root="${FLEET_GAME_ROOT:-$engine_root/creations/game}"
+
+    local model=""
+    local repo
+    for repo in "$engine_root" "$game_root"; do
+        [[ -d "$repo/.git" || -f "$repo/.git" ]] || continue
+        local tasks_md
+        tasks_md=$(git -C "$repo" show "origin/master:TASKS.md" 2>/dev/null) || continue
+        model=$(FLEET_TASKS_MD="$tasks_md" python3 - "$task_id" <<'PYEOF'
+import sys, os, re
+task_id = sys.argv[1]
+content = os.environ.get('FLEET_TASKS_MD', '')
+current_id = None
+current_model = None
+for line in content.splitlines():
+    if re.match(r'^- \[.\] \*\*', line):
+        if current_id == task_id and current_model:
+            print(current_model)
+            sys.exit(0)
+        current_id = None
+        current_model = None
+        continue
+    m = re.match(r'^\s+- \*\*ID:\*\*\s*(.+)', line)
+    if m:
+        current_id = m.group(1).strip()
+        continue
+    m = re.match(r'^\s+- \*\*Model:\*\*\s*(.+)', line)
+    if m:
+        current_model = m.group(1).strip()
+        continue
+if current_id == task_id and current_model:
+    print(current_model)
+PYEOF
+)
+        [[ -n "$model" ]] && break
+    done
+
+    case "$model" in
+        opus*)   echo "opus-worker" ;;
+        sonnet*) echo "sonnet-author" ;;
+        *) ;;
+    esac
+    return 0
+}
+
 # --- main -----------------------------------------------------------------
 
 case "${1:-}" in
@@ -1991,6 +2067,13 @@ case "${1:-}" in
         ;;
     list-reservations)
         cmd_list_reservations
+        ;;
+    reservation-role)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim reservation-role <worktree>" >&2
+            exit 2
+        fi
+        cmd_reservation_role "$2"
         ;;
     molecule)
         sub="${2:-}"
@@ -2115,6 +2198,10 @@ reservation commands (worktree-pinning, distinct from claims):
   worktree-for-task <task-id>            print worktree pinned to a task, or empty.
                                          Same stdout-channel contract as reservation-of.
   list-reservations                      table of all active reservations with age.
+  reservation-role <worktree>            print dispatcher role tag for this worktree's
+                                         reservation (opus-worker / sonnet-author), or
+                                         empty if no reservation. Used by the dispatcher's
+                                         per-role concurrency cap.
 
   Reservation gate: cmd_claim and cmd_stack refuse to grant a task that is reserved
   for a different worktree than the requesting agent. cmd_release does NOT touch

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -61,10 +61,52 @@ STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
 TRIGGERS_DIR="$STATE_DIR/triggers"
 DISPATCH_DIR="$STATE_DIR/dispatch"
 RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
+RESERVATIONS_DIR="${FLEET_RESERVATIONS_DIR:-$HOME/.fleet/reservations}"
 LOG_FILE="$HOME/.fleet/logs/dispatcher.log"
 PID_FILE="$STATE_DIR/dispatcher.pid"
 LOCK_DIR="$STATE_DIR/dispatcher.lock.d"
 SHUTDOWN_FLAG="$HOME/.fleet/shutdown-in-progress"
+
+# --- Per-role concurrency cap config ---------------------------------------
+#
+# Soft cap on simultaneous iterations per role. Counts unique active
+# worktrees: in-flight (dispatch record present) ∪ reserved (reservation
+# whose task's Model maps to this role). Dedup by worktree avoids the
+# auto-reserve double-count where a normally-running pane has both a
+# dispatch record and a reservation for the same task.
+#
+# Override priority: env var > ~/.fleet/fleet-up.conf > built-in default.
+# Default values match each role's current pane count, so no role hits the
+# cap under normal flow — the cap only fires when reservations from a
+# crashed iteration would push the total over.
+FLEET_CONF="${FLEET_CONF:-$HOME/.fleet/fleet-up.conf}"
+# Capture env-set values before sourcing the conf, so a `FLEET_CONCURRENCY_X`
+# in the caller's environment still wins over a value set inside conf.
+_env_opus_worker="${FLEET_CONCURRENCY_OPUS_WORKER:-}"
+_env_sonnet_author="${FLEET_CONCURRENCY_SONNET_AUTHOR:-}"
+_env_sonnet_reviewer="${FLEET_CONCURRENCY_SONNET_REVIEWER:-}"
+_env_opus_reviewer="${FLEET_CONCURRENCY_OPUS_REVIEWER:-}"
+_env_queue_manager="${FLEET_CONCURRENCY_QUEUE_MANAGER:-}"
+_env_merger="${FLEET_CONCURRENCY_MERGER:-}"
+if [[ -f "$FLEET_CONF" ]]; then
+    # shellcheck disable=SC1090
+    source "$FLEET_CONF"
+fi
+declare -A ROLE_CONCURRENCY=(
+    ["opus-worker"]="${_env_opus_worker:-${FLEET_CONCURRENCY_OPUS_WORKER:-2}}"
+    ["sonnet-author"]="${_env_sonnet_author:-${FLEET_CONCURRENCY_SONNET_AUTHOR:-2}}"
+    ["sonnet-reviewer"]="${_env_sonnet_reviewer:-${FLEET_CONCURRENCY_SONNET_REVIEWER:-1}}"
+    ["opus-reviewer"]="${_env_opus_reviewer:-${FLEET_CONCURRENCY_OPUS_REVIEWER:-1}}"
+    ["queue-manager"]="${_env_queue_manager:-${FLEET_CONCURRENCY_QUEUE_MANAGER:-1}}"
+    ["merger"]="${_env_merger:-${FLEET_CONCURRENCY_MERGER:-1}}"
+)
+unset _env_opus_worker _env_sonnet_author _env_sonnet_reviewer \
+      _env_opus_reviewer _env_queue_manager _env_merger
+
+# Tracks per-role "deferred-by-cap" log throttling so the at-cap message
+# doesn't spam every 10s tick while the cap is held. Cleared whenever a
+# role drops back below cap.
+declare -A CAP_DEFER_LOGGED=()
 
 # Seconds to back off after a pane exits with code 2 (suspected usage limit).
 # Mirrors fleet-babysit's LIMIT_DELAY. Per-pane: if one of two opus-worker
@@ -332,6 +374,58 @@ pane_in_rate_limit_cooldown() {
     return 1
 }
 
+# --- Per-role active-iteration count ---------------------------------------
+
+# Print the count of unique active worktrees for a role. "Active" =
+# (in-flight dispatch record for this role) ∪ (reservation whose task's
+# Model maps to this role). Dedup keys on worktree-basename, which is
+# shared between dispatch records (via the pane's pane_current_path) and
+# reservations (whose filename IS the worktree basename).
+#
+# When tmux isn't running (shouldn't happen for a live dispatcher, but
+# the standalone --count-active CLI invokes this without a session),
+# dispatch records key on pane id instead — same dedup contract still
+# holds across two dispatch records for the same pane.
+count_active_for_role() {
+    local role="$1"
+    declare -A seen=()
+
+    if [[ -d "$DISPATCH_DIR" ]]; then
+        local f r p wt_path wt_name
+        for f in "$DISPATCH_DIR"/*.json; do
+            [[ -e "$f" ]] || continue
+            r=$(sed -n 's/.*"role":"\([^"]*\)".*/\1/p' "$f" | head -n 1)
+            [[ "$r" == "$role" ]] || continue
+            p=$(sed -n 's/.*"pane":"\([^"]*\)".*/\1/p' "$f" | head -n 1)
+            [[ -n "$p" ]] || continue
+            wt_path=""
+            if session_exists; then
+                wt_path=$(tmux display-message -t "$p" -p '#{pane_current_path}' 2>/dev/null || true)
+            fi
+            if [[ -n "$wt_path" ]]; then
+                wt_name=$(basename "$wt_path")
+                seen["$wt_name"]=1
+            else
+                seen["pane-${p#%}"]=1
+            fi
+        done
+    fi
+
+    if [[ -d "$RESERVATIONS_DIR" ]]; then
+        local rfile wt_name rrole
+        for rfile in "$RESERVATIONS_DIR"/*.json; do
+            [[ -e "$rfile" ]] || continue
+            wt_name=$(basename "$rfile" .json)
+            rrole=$(fleet-claim reservation-role "$wt_name" 2>/dev/null || true)
+            if [[ "$rrole" == "$role" ]]; then
+                seen["$wt_name"]=1
+            fi
+        done
+    fi
+
+    echo "${#seen[@]}"
+}
+
 # --- Trigger dispatch ------------------------------------------------------
 
 build_dispatch_command() {
@@ -353,6 +447,24 @@ dispatch_role() {
 
     if [[ ! -f "$trigger_file" ]]; then
         return
+    fi
+
+    # Per-role concurrency cap. Defer if (in-flight + reserved) already at
+    # cap. Trigger stays in place so the next tick can re-evaluate once an
+    # iteration finishes or a reservation releases. Logged once per cap-held
+    # window to avoid spamming.
+    local cap="${ROLE_CONCURRENCY[$role]:-0}"
+    if (( cap > 0 )); then
+        local active
+        active=$(count_active_for_role "$role")
+        if (( active >= cap )); then
+            if [[ -z "${CAP_DEFER_LOGGED[$role]+x}" ]]; then
+                log "$role at concurrency cap ($active >= $cap); deferring trigger"
+                CAP_DEFER_LOGGED["$role"]=1
+            fi
+            return
+        fi
+        unset 'CAP_DEFER_LOGGED[$role]'
     fi
 
     # Fan out across every idle pane for this role, skipping any that
@@ -605,5 +717,28 @@ main() {
 
     log "stopped"
 }
+
+# Operator/test entry points — exit before main() so the daemon never starts.
+case "${1:-}" in
+    --count-active)
+        # Print active count for a role (in-flight ∪ reserved, deduped by
+        # worktree). Used by tests and for operator inspection.
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-dispatcher --count-active <role>" >&2
+            exit 2
+        fi
+        count_active_for_role "$2"
+        exit 0
+        ;;
+    --print-cap)
+        # Print configured cap for a role.
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-dispatcher --print-cap <role>" >&2
+            exit 2
+        fi
+        echo "${ROLE_CONCURRENCY[$2]:-0}"
+        exit 0
+        ;;
+esac
 
 main "$@"

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -370,7 +370,7 @@ pane_in_rate_limit_cooldown() {
         return 0
     fi
     rm -f "$ts_file"
-    unset 'RATE_LIMIT_COOLDOWN_LOGGED[$pane_key]'
+    unset "RATE_LIMIT_COOLDOWN_LOGGED[$pane_key]"
     return 1
 }
 
@@ -464,7 +464,7 @@ dispatch_role() {
             fi
             return
         fi
-        unset 'CAP_DEFER_LOGGED[$role]'
+        unset "CAP_DEFER_LOGGED[$role]"
     fi
 
     # Fan out across every idle pane for this role, skipping any that

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -38,6 +38,58 @@ OPUS_MIN_BACKOFF=1800
 # tick lands in ~5-10 s; 30 s gives ample headroom for slow networks.
 SCOUT_STARTUP_TIMEOUT_SECONDS=30
 
+# --- Per-role concurrency cap config schema -------------------------------
+#
+# The dispatcher (fleet-dispatcher) enforces a soft cap on simultaneous
+# iterations per role. Counts unique active worktrees: in-flight (pane
+# mid-claude-print) ∪ reserved (worktree pinned to a paused task).
+#
+# Defaults match each role's current pane count, so no role hits the
+# cap under normal operation. The cap only fires when reservations from
+# crashed iterations would push the total over (e.g. a reserved-but-idle
+# pane resumes on the next tick — its slot is counted up front so a
+# fresh dispatch to a free pane doesn't push the role above its budget).
+#
+# Override priority (highest first):
+#   1. Env var: FLEET_CONCURRENCY_<ROLE_UPPERCASE> (e.g. FLEET_CONCURRENCY_OPUS_WORKER=3)
+#   2. ~/.fleet/fleet-up.conf (bash-sourceable; same variable names)
+#   3. Built-in default (defined in fleet-dispatcher)
+#
+# Sample conf (write to ~/.fleet/fleet-up.conf):
+#   FLEET_CONCURRENCY_OPUS_WORKER=2
+#   FLEET_CONCURRENCY_SONNET_AUTHOR=2
+#   FLEET_CONCURRENCY_SONNET_REVIEWER=1
+#   FLEET_CONCURRENCY_OPUS_REVIEWER=1
+#   FLEET_CONCURRENCY_QUEUE_MANAGER=1
+#   FLEET_CONCURRENCY_MERGER=1
+#
+# fleet-up sources the same conf so `fleet-up --help` and the startup
+# banner reflect the active values, and so any future fleet-up logic
+# that wants to provision based on caps can read them directly.
+FLEET_CONF="${FLEET_CONF:-$HOME/.fleet/fleet-up.conf}"
+# Capture env-set values before sourcing the conf so caller env still wins.
+_env_opus_worker="${FLEET_CONCURRENCY_OPUS_WORKER:-}"
+_env_sonnet_author="${FLEET_CONCURRENCY_SONNET_AUTHOR:-}"
+_env_sonnet_reviewer="${FLEET_CONCURRENCY_SONNET_REVIEWER:-}"
+_env_opus_reviewer="${FLEET_CONCURRENCY_OPUS_REVIEWER:-}"
+_env_queue_manager="${FLEET_CONCURRENCY_QUEUE_MANAGER:-}"
+_env_merger="${FLEET_CONCURRENCY_MERGER:-}"
+if [[ -f "$FLEET_CONF" ]]; then
+    # shellcheck disable=SC1090
+    source "$FLEET_CONF"
+fi
+FLEET_CONCURRENCY_OPUS_WORKER="${_env_opus_worker:-${FLEET_CONCURRENCY_OPUS_WORKER:-2}}"
+FLEET_CONCURRENCY_SONNET_AUTHOR="${_env_sonnet_author:-${FLEET_CONCURRENCY_SONNET_AUTHOR:-2}}"
+FLEET_CONCURRENCY_SONNET_REVIEWER="${_env_sonnet_reviewer:-${FLEET_CONCURRENCY_SONNET_REVIEWER:-1}}"
+FLEET_CONCURRENCY_OPUS_REVIEWER="${_env_opus_reviewer:-${FLEET_CONCURRENCY_OPUS_REVIEWER:-1}}"
+FLEET_CONCURRENCY_QUEUE_MANAGER="${_env_queue_manager:-${FLEET_CONCURRENCY_QUEUE_MANAGER:-1}}"
+FLEET_CONCURRENCY_MERGER="${_env_merger:-${FLEET_CONCURRENCY_MERGER:-1}}"
+unset _env_opus_worker _env_sonnet_author _env_sonnet_reviewer \
+      _env_opus_reviewer _env_queue_manager _env_merger
+export FLEET_CONCURRENCY_OPUS_WORKER FLEET_CONCURRENCY_SONNET_AUTHOR
+export FLEET_CONCURRENCY_SONNET_REVIEWER FLEET_CONCURRENCY_OPUS_REVIEWER
+export FLEET_CONCURRENCY_QUEUE_MANAGER FLEET_CONCURRENCY_MERGER
+
 if ! command -v tmux >/dev/null 2>&1; then
     echo "fleet-up: tmux not found. Install tmux (brew install tmux / apt install tmux) first." >&2
     exit 1

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -1,0 +1,31 @@
+# fleet-up.conf — fleet runtime configuration overrides.
+#
+# Copy to ~/.fleet/fleet-up.conf and edit values to tune. fleet-up and
+# fleet-dispatcher both source this file at startup; fleet-dispatcher
+# re-reads on next launch (kill+restart the dispatcher to pick up new
+# values mid-session).
+#
+# Bash-sourceable. Comments start with `#`. Values without quotes work
+# for integers; quote any value containing spaces.
+
+# --- Per-role concurrency caps ----------------------------------------------
+#
+# Soft cap on simultaneous iterations per role. The dispatcher counts
+# (in-flight + reserved) unique worktrees and defers fresh dispatches when
+# the role hits its cap. Reservations count because a paused iteration will
+# resume on the next tick and consume a slot — counting them up front
+# prevents the role from briefly exceeding its budget when a reserved-idle
+# pane wakes up alongside a normal dispatch to a free pane.
+#
+# Defaults match each role's current pane count under stock fleet-up
+# layout (2x opus-worker, 2x sonnet-author, 1 each of the rest), so under
+# default values no role hits its cap during normal operation. Tune up to
+# allow more parallelism (requires adding panes); tune down to throttle a
+# role that's burning too much credit budget.
+
+# FLEET_CONCURRENCY_OPUS_WORKER=2
+# FLEET_CONCURRENCY_SONNET_AUTHOR=2
+# FLEET_CONCURRENCY_SONNET_REVIEWER=1
+# FLEET_CONCURRENCY_OPUS_REVIEWER=1
+# FLEET_CONCURRENCY_QUEUE_MANAGER=1
+# FLEET_CONCURRENCY_MERGER=1

--- a/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
+++ b/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Tests for fleet-dispatcher's per-role concurrency cap.
+#
+# Covers:
+#   - count_active_for_role with no reservations + no dispatch records
+#   - count with only in-flight (dispatch records)
+#   - count with only reserved (reservations whose task maps to role)
+#   - dedup when a worktree has both a dispatch record and a reservation
+#   - cap defaults (preserve current behavior at 2 for multi-pane roles)
+#   - env var override
+#   - conf file override
+#   - conf override beat by env var
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$DISPATCHER" ]]; then
+    echo "test setup: fleet-dispatcher not found at $DISPATCHER" >&2
+    exit 1
+fi
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+# Build a sandbox: temp dirs for state + reservations, a fake TASKS.md
+# in a fake git repo so reservation-role can resolve task → Model.
+TMPROOT=$(mktemp -d)
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_CONF="$TMPROOT/fleet-up.conf"
+
+mkdir -p "$FLEET_STATE_DIR/dispatch" "$FLEET_RESERVATIONS_DIR" "$FLEET_CLAIMS_DIR"
+
+FAKE_REPO="$TMPROOT/repo"
+mkdir -p "$FAKE_REPO"
+(
+    cd "$FAKE_REPO"
+    git init --quiet -b master
+    git config user.email "test@test"
+    git config user.name "test"
+    cat >TASKS.md <<'TASKSEOF'
+# TASKS
+
+## Open
+
+- [ ] **Task A — opus** — first opus task
+  - **ID:** T-901
+  - **Model:** opus
+  - **Owner:** free
+  - **Blocked by:** (none)
+
+- [ ] **Task B — sonnet** — first sonnet task
+  - **ID:** T-902
+  - **Model:** sonnet
+  - **Owner:** free
+  - **Blocked by:** (none)
+TASKSEOF
+    git add TASKS.md
+    git commit --quiet -m "init" --no-gpg-sign
+    # Set origin/master (reservation-role reads via `git show origin/master:TASKS.md`)
+    git update-ref refs/remotes/origin/master HEAD
+)
+export FLEET_ENGINE_ROOT="$FAKE_REPO"
+export FLEET_GAME_ROOT="$FAKE_REPO/no-game-here"
+
+# Make our fake fleet-claim discoverable on PATH so the dispatcher's
+# subshell call resolves to it (with the test env vars).
+mkdir -p "$TMPROOT/bin"
+ln -s "$FLEET_CLAIM" "$TMPROOT/bin/fleet-claim"
+export PATH="$TMPROOT/bin:$PATH"
+
+# --- Test 1: no records, no reservations -----------------------------------
+echo "T1: empty state — count is 0"
+n=$("$DISPATCHER" --count-active opus-worker)
+assert_eq "$n" "0" "opus-worker count is 0 with empty state"
+
+# --- Test 2: in-flight only ------------------------------------------------
+echo "T2: one in-flight dispatch record for opus-worker"
+cat >"$FLEET_STATE_DIR/dispatch/pane-3.json" <<'JSON'
+{"role":"opus-worker","pane":"%3","dispatched_at":"2026-05-08T00:00:00Z"}
+JSON
+n=$("$DISPATCHER" --count-active opus-worker)
+assert_eq "$n" "1" "opus-worker count is 1 with one in-flight"
+n=$("$DISPATCHER" --count-active sonnet-author)
+assert_eq "$n" "0" "sonnet-author count is 0 (in-flight is opus-worker)"
+
+# --- Test 3: reservation only ----------------------------------------------
+echo "T3: a reservation for an opus task on a different worktree"
+"$FLEET_CLAIM" reserve T-901 opus-worker-2 claude/T-901-something >/dev/null
+n=$("$DISPATCHER" --count-active opus-worker)
+assert_eq "$n" "2" "opus-worker count is 2 (1 in-flight + 1 reserved on different worktree)"
+
+# --- Test 4: dedup when same worktree has both ------------------------------
+echo "T4: add second in-flight whose worktree matches the reservation"
+# pane-5's dispatch record — without tmux, fallback identity is pane-5
+# (cannot match the reservation key opus-worker-2). To exercise dedup,
+# stub tmux so display-message returns the worktree path.
+mkdir -p "$TMPROOT/bin-tmux"
+cat >"$TMPROOT/bin-tmux/tmux" <<'TMUXEOF'
+#!/usr/bin/env bash
+# Test stub: respond to `tmux has-session` (success) and
+# `tmux display-message -t <pane> -p <fmt>` (returns canned path per pane).
+sub="$1"; shift
+case "$sub" in
+    has-session) exit 0 ;;
+    display-message)
+        pane=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -t) pane="$2"; shift 2 ;;
+                -p) shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        case "$pane" in
+            "%3") echo "/fake/worktrees/opus-worker-1" ;;
+            "%5") echo "/fake/worktrees/opus-worker-2" ;;
+            *)    echo "/fake/worktrees/unknown" ;;
+        esac
+        exit 0
+        ;;
+    *) exit 0 ;;
+esac
+TMUXEOF
+chmod +x "$TMPROOT/bin-tmux/tmux"
+
+# Add a second dispatch record on pane %5 (opus-worker-2)
+cat >"$FLEET_STATE_DIR/dispatch/pane-5.json" <<'JSON'
+{"role":"opus-worker","pane":"%5","dispatched_at":"2026-05-08T00:00:00Z"}
+JSON
+
+# With tmux stub: pane %3 → opus-worker-1, pane %5 → opus-worker-2.
+# Reservation is on opus-worker-2 → dedup with pane %5's record.
+# Total unique = 2 (opus-worker-1, opus-worker-2).
+PATH="$TMPROOT/bin-tmux:$PATH" n=$("$DISPATCHER" --count-active opus-worker)
+assert_eq "$n" "2" "opus-worker count dedups same-worktree dispatch+reservation"
+
+# --- Test 5: cap defaults --------------------------------------------------
+echo "T5: cap defaults (no conf, no env)"
+unset FLEET_CONCURRENCY_OPUS_WORKER FLEET_CONCURRENCY_SONNET_AUTHOR \
+      FLEET_CONCURRENCY_SONNET_REVIEWER FLEET_CONCURRENCY_OPUS_REVIEWER \
+      FLEET_CONCURRENCY_QUEUE_MANAGER FLEET_CONCURRENCY_MERGER
+rm -f "$FLEET_CONF"
+cap=$("$DISPATCHER" --print-cap opus-worker)
+assert_eq "$cap" "2" "default cap for opus-worker is 2"
+cap=$("$DISPATCHER" --print-cap sonnet-author)
+assert_eq "$cap" "2" "default cap for sonnet-author is 2"
+cap=$("$DISPATCHER" --print-cap merger)
+assert_eq "$cap" "1" "default cap for merger is 1"
+
+# --- Test 6: env var override ---------------------------------------------
+echo "T6: env var overrides default"
+cap=$(FLEET_CONCURRENCY_OPUS_WORKER=5 "$DISPATCHER" --print-cap opus-worker)
+assert_eq "$cap" "5" "env var overrides default cap"
+
+# --- Test 7: conf file override --------------------------------------------
+echo "T7: conf file overrides default"
+cat >"$FLEET_CONF" <<'CONFEOF'
+FLEET_CONCURRENCY_OPUS_WORKER=4
+FLEET_CONCURRENCY_MERGER=3
+CONFEOF
+cap=$("$DISPATCHER" --print-cap opus-worker)
+assert_eq "$cap" "4" "conf file sets opus-worker cap to 4"
+cap=$("$DISPATCHER" --print-cap merger)
+assert_eq "$cap" "3" "conf file sets merger cap to 3"
+cap=$("$DISPATCHER" --print-cap sonnet-author)
+assert_eq "$cap" "2" "untouched roles keep their default"
+
+# --- Test 8: env var beats conf --------------------------------------------
+echo "T8: env var has higher priority than conf"
+cap=$(FLEET_CONCURRENCY_OPUS_WORKER=7 "$DISPATCHER" --print-cap opus-worker)
+assert_eq "$cap" "7" "env var beats conf file"
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+if (( FAIL > 0 )); then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- `~/.fleet/fleet-up.conf` per-role concurrency knobs; `fleet-up` and
  `fleet-dispatcher` source it on startup. Defaults match current pane
  counts so behavior is unchanged out of the box.
- `fleet-dispatcher` enforces the cap inside `dispatch_role`: defers
  the trigger when `(in-flight ∪ reserved)` for the role hits the
  configured cap, deduped by worktree basename to avoid the auto-reserve
  double-count.
- `fleet-claim reservation-role <wt>` maps a reservation's `task_id` →
  `Model:` → dispatcher role tag (`opus` → `opus-worker`,
  `sonnet` → `sonnet-author`). Searches engine TASKS.md first, falls
  back to game.
- `fleet-dispatcher --count-active <role>` and `--print-cap <role>`
  are operator/test entry points that compute the same numbers the
  daemon uses without starting the loop.
- Bash integration test under `scripts/fleet/tests/` exercises 13
  cases (empty, in-flight only, reserved only, dedup, defaults,
  env override, conf override, env-beats-conf).
- Sample conf at `scripts/fleet/fleet-up.conf.sample` documents the
  six knobs.

## Acceptance vs. task spec

1. ✅ `fleet-up.conf` gains per-role concurrency config (opus-worker=2,
   sonnet-author=2; the queue's "sonnet-fleet" entry was the
   pre-rename worktree-prefix name — current dispatcher role is
   `sonnet-author`).
2. ✅ Dispatcher defers when in-flight + reserved for role >= cap.
3. ✅ With concurrency=2, third concurrent opus-worker iteration is
   deferred even with free worktrees (cap fires before pane fan-out).
4. ✅ Env-overridable: `FLEET_CONCURRENCY_<ROLE>=N` beats both conf
   and built-in default.
5. ✅ Per-pane parallelism preserved for roles under cap — fan-out
   logic unchanged when cap-check passes.
6. ✅ Default values preserve current behavior (each role's default
   matches its current pane count).

## Why dedup matters

`fleet-claim claim` auto-reserves on success — so during normal
operation, a claiming pane has BOTH a dispatch record AND a
reservation pointing at the same task. Naively summing `in-flight +
reserved` would count it twice and force the cap to be ≥ 2× the
intended number. Deduping by worktree basename gives the natural
reading: "how many unique panes are doing work for this role". Tested
explicitly in T4 of the harness.

## Test plan

- [x] `bash -n` clean on `fleet-up`, `fleet-dispatcher`, `fleet-claim`
- [x] `tests/test_dispatcher_concurrency_cap.sh` — 13 PASS / 0 FAIL
- [x] Existing `tests/test_enrich_stackable_blocker_prs.py` still PASS
- [x] `fleet-claim reservation-role` smoke against real engine TASKS.md
      (T-118 → `opus-worker`)
- [ ] Live dispatcher pickup of new conf on next `fleet-up` boot
      (kill-restart needed for env-source refresh)

## Out of scope

- Wiring caps into the periodic re-arm path (`maybe_arm` already
  short-circuits on `role_in_flight`; reservation counting there is
  follow-up work if cap pressure becomes visible there too).
- T-NNN-2 (reservation-aware pane selection — preferring reserved
  pane over free for routing). Cap enforcement is orthogonal: it
  runs before pane selection. T-NNN-2 lives in its own PR.

Part of #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)