### PR TITLE
Fleet: 5-hour-window usage gate — defer dispatch above 80% utilization

### DIFF
--- a/scripts/fleet/fleet-claude-stream
+++ b/scripts/fleet/fleet-claude-stream
@@ -29,7 +29,11 @@
 # Installed to ~/bin/fleet-claude-stream by scripts/fleet/install.sh.
 
 import json
+import os
+import pathlib
 import sys
+import tempfile
+import time
 
 # ANSI: dim/colors gracefully no-op in non-tty (we still keep them — tmux
 # panes always have a tty, and a plain `tee` of the pipe will show the
@@ -40,6 +44,15 @@ BLUE, CYAN = "\033[34m", "\033[36m"
 
 INPUT_PREVIEW_LEN = 100   # truncate tool inputs to this many chars
 RESULT_PREVIEW_LEN = 200  # truncate tool results to this many chars
+
+# Where rate_limit_event observations are latched for the dispatcher's
+# usage gate. One file per rateLimitType (e.g. five_hour, output_tokens),
+# overwritten with the latest observation. fleet-dispatcher reads these
+# at the top of dispatch_role and defers when any utilization is past
+# FLEET_DISPATCHER_USAGE_GATE (default 0.80).
+USAGE_DIR = pathlib.Path(
+    os.environ.get("FLEET_STATE_DIR", str(pathlib.Path.home() / ".fleet" / "state"))
+) / "usage"
 
 
 def emit(s):
@@ -115,6 +128,44 @@ def handle_result(event):
         emit(f"{RED}{event['result']}{RESET}\n")
 
 
+def latch_usage_observation(rl_type, info):
+    """Write the latest rate_limit_info to ~/.fleet/state/usage/<type>.json.
+
+    fleet-dispatcher reads these files to gate dispatch when any
+    utilization is past FLEET_DISPATCHER_USAGE_GATE. Each rateLimitType
+    gets its own file (overwritten); stale observations age out via the
+    `observed_at` timestamp the dispatcher checks.
+
+    Best-effort: any IO error is swallowed so a state-dir mishap can't
+    take down the live render of the pane.
+    """
+    if not isinstance(rl_type, str) or not rl_type:
+        return
+    safe_type = "".join(c if c.isalnum() or c in "_-" else "_" for c in rl_type)
+    if not safe_type:
+        return
+    payload = {
+        "rateLimitType": rl_type,
+        "utilization": info.get("utilization"),
+        "resetsAt": info.get("resetsAt"),
+        "observed_at": int(time.time()),
+    }
+    try:
+        USAGE_DIR.mkdir(parents=True, exist_ok=True)
+        target = USAGE_DIR / f"{safe_type}.json"
+        with tempfile.NamedTemporaryFile(
+            "w", dir=USAGE_DIR, prefix=f".{safe_type}.", suffix=".tmp", delete=False
+        ) as tmp:
+            json.dump(payload, tmp)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_path = pathlib.Path(tmp.name)
+        os.replace(tmp_path, target)
+    except OSError:
+        # State-dir not writable, etc. Don't crash the stream renderer.
+        return
+
+
 # Known-benign claude stderr warnings — claude prints these AFTER the
 # result event has already been received and exits 0. Without
 # annotation they read as fatal errors in the pane scrollback even
@@ -160,6 +211,7 @@ def main():
             util = info.get("utilization", 0)
             rl_type = info.get("rateLimitType", "?")
             emit(f"\n{YELLOW}[rate-limit {rl_type} util={util:.0%}]{RESET}\n")
+            latch_usage_observation(rl_type, info)
         elif t == "stream_event":
             handle_stream_event(event)
         elif t == "assistant":

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -61,6 +61,7 @@ STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
 TRIGGERS_DIR="$STATE_DIR/triggers"
 DISPATCH_DIR="$STATE_DIR/dispatch"
 RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
+USAGE_DIR="$STATE_DIR/usage"
 RESERVATIONS_DIR="${FLEET_RESERVATIONS_DIR:-$HOME/.fleet/reservations}"
 LOG_FILE="$HOME/.fleet/logs/dispatcher.log"
 PID_FILE="$STATE_DIR/dispatcher.pid"
@@ -112,6 +113,33 @@ declare -A CAP_DEFER_LOGGED=()
 # Mirrors fleet-babysit's LIMIT_DELAY. Per-pane: if one of two opus-worker
 # panes hits a limit, the other keeps running.
 LIMIT_DELAY="${FLEET_DISPATCHER_LIMIT_DELAY:-900}"
+
+# --- 5-hour-window usage gate ---------------------------------------------
+#
+# Soft, fleet-wide pre-emption: when any rate_limit_event observation
+# reports utilization >= USAGE_GATE_THRESHOLD, defer ALL fresh
+# dispatches until the window resets or utilization drops. In-flight
+# iterations finish normally; their next trigger waits.
+#
+# Observations are written by fleet-claude-stream (one file per
+# rateLimitType under $USAGE_DIR), so the gate piggybacks on every
+# transient worker's stream — no separate poller needed.
+#
+# Conservative against staleness: an observation older than
+# USAGE_STALE_SECONDS (default 1h) or whose resetsAt is in the past
+# is ignored, so the gate doesn't latch closed forever after a single
+# high-watermark reading.
+#
+# Sibling to LIMIT_DELAY's per-pane post-mortem cooldown: that fires
+# AFTER a pane hits the wall and exits with code 2; this fires BEFORE
+# the wall to spread the remaining budget across in-flight work.
+USAGE_GATE_THRESHOLD="${FLEET_DISPATCHER_USAGE_GATE:-0.80}"
+USAGE_STALE_SECONDS="${FLEET_DISPATCHER_USAGE_STALE_SECONDS:-3600}"
+
+# Track whether the gate was logged-as-closed last tick so the
+# "deferring all dispatches" message fires once per closed-window,
+# not every 10s.
+USAGE_GATE_CLOSED_LOGGED=""
 
 # Default poll cadence. Workers are transient — each iteration is a
 # one-shot `claude --print` spawned into an idle pane when a trigger
@@ -372,6 +400,115 @@ pane_in_rate_limit_cooldown() {
     rm -f "$ts_file"
     unset "RATE_LIMIT_COOLDOWN_LOGGED[$pane_key]"
     return 1
+}
+
+# --- Usage gate ------------------------------------------------------------
+
+# Print the gate state on stdout: "open" or "closed:<reason>".
+#
+# Reads ~/.fleet/state/usage/*.json files (latched by fleet-claude-stream
+# on every rate_limit_event), picks the worst observation that is both
+# fresh (observed within USAGE_STALE_SECONDS) and not yet reset
+# (resetsAt in the future), and reports closed iff utilization
+# >= USAGE_GATE_THRESHOLD.
+#
+# Inlined python3 so we get JSON parsing + ISO-8601 timestamp math
+# without adding a shell dep. Same pattern rearm_periodic_meta_triggers
+# uses below.
+usage_gate_status() {
+    local threshold="$USAGE_GATE_THRESHOLD"
+    local stale="$USAGE_STALE_SECONDS"
+    local usage_dir="$USAGE_DIR"
+    USAGE_DIR="$usage_dir" \
+    USAGE_GATE_THRESHOLD="$threshold" \
+    USAGE_STALE_SECONDS="$stale" \
+    python3 - <<'PY'
+import json
+import os
+import pathlib
+import sys
+import time
+from datetime import datetime, timezone
+
+usage_dir = pathlib.Path(os.environ["USAGE_DIR"])
+threshold = float(os.environ.get("USAGE_GATE_THRESHOLD", "0.80"))
+stale_s = int(os.environ.get("USAGE_STALE_SECONDS", "3600"))
+
+if not usage_dir.is_dir():
+    print("open")
+    sys.exit(0)
+
+now = int(time.time())
+worst_util = -1.0
+worst_type = None
+worst_resets = None
+
+for path in sorted(usage_dir.glob("*.json")):
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        continue
+    util = data.get("utilization")
+    if not isinstance(util, (int, float)):
+        continue
+    observed_at = data.get("observed_at")
+    if isinstance(observed_at, (int, float)) and now - int(observed_at) > stale_s:
+        continue
+    resets_at = data.get("resetsAt")
+    if isinstance(resets_at, str):
+        try:
+            # API returns ISO-8601 with Z suffix; datetime.fromisoformat
+            # accepts +00:00 but not Z until 3.11 — sub it.
+            dt = datetime.fromisoformat(resets_at.replace("Z", "+00:00"))
+            if dt.timestamp() <= now:
+                continue
+        except ValueError:
+            pass
+    util_f = float(util)
+    # Utilization comes back in [0,1]. Be defensive against a future
+    # API that sends a percent in [0,100] (the chat-formatter prints
+    # it as a percent, but the value itself is a fraction today).
+    if util_f > 1.5:
+        util_f = util_f / 100.0
+    if util_f > worst_util:
+        worst_util = util_f
+        worst_type = data.get("rateLimitType", path.stem)
+        worst_resets = resets_at if isinstance(resets_at, str) else None
+
+if worst_util < 0:
+    print("open")
+    sys.exit(0)
+
+if worst_util >= threshold:
+    pct = int(round(worst_util * 100))
+    thr_pct = int(round(threshold * 100))
+    resets_part = f" resets={worst_resets}" if worst_resets else ""
+    print(f"closed:{worst_type} util={pct}% (>= {thr_pct}%){resets_part}")
+else:
+    pct = int(round(worst_util * 100))
+    print(f"open:{worst_type} util={pct}%")
+PY
+}
+
+# Returns 0 (true) when the gate is open and dispatching may proceed.
+# Side effect: emits a one-shot log entry on transitions (open->closed
+# and closed->open) using USAGE_GATE_CLOSED_LOGGED to suppress
+# repeat-on-every-tick spam.
+usage_gate_open() {
+    local status
+    status=$(usage_gate_status)
+    if [[ "$status" == closed:* ]]; then
+        if [[ -z "$USAGE_GATE_CLOSED_LOGGED" ]]; then
+            log "usage gate ${status}; deferring all dispatches"
+            USAGE_GATE_CLOSED_LOGGED=1
+        fi
+        return 1
+    fi
+    if [[ -n "$USAGE_GATE_CLOSED_LOGGED" ]]; then
+        log "usage gate re-opened (${status}); resuming dispatch"
+        USAGE_GATE_CLOSED_LOGGED=""
+    fi
+    return 0
 }
 
 # --- Per-role active-iteration count ---------------------------------------
@@ -660,7 +797,7 @@ PY
 }
 
 main() {
-    mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$TRIGGERS_DIR" "$DISPATCH_DIR" "$RATE_LIMIT_DIR"
+    mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$TRIGGERS_DIR" "$DISPATCH_DIR" "$RATE_LIMIT_DIR" "$USAGE_DIR"
 
     if ! acquire_dispatcher_lock; then
         log "another dispatcher is already running (lock held); exiting"
@@ -698,7 +835,11 @@ main() {
             rearm_periodic_meta_triggers
         fi
 
-        if session_exists; then
+        # Fleet-wide usage gate. Closed → skip the dispatch_role pass
+        # entirely; triggers stay in place for next tick. The
+        # rearm_periodic_meta_triggers above still runs so the trigger
+        # set stays accurate for when the gate re-opens.
+        if session_exists && usage_gate_open; then
             for role in "${DISPATCHED_ROLES[@]}"; do
                 dispatch_role "$role"
             done
@@ -737,6 +878,13 @@ case "${1:-}" in
             exit 2
         fi
         echo "${ROLE_CONCURRENCY[$2]:-0}"
+        exit 0
+        ;;
+    --gate-status)
+        # Print the live usage gate status (open / closed) and exit.
+        # Used by operators to inspect the 5-hour-window state without
+        # tailing the dispatcher log.
+        usage_gate_status
         exit 0
         ;;
 esac

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -29,3 +29,24 @@
 # FLEET_CONCURRENCY_OPUS_REVIEWER=1
 # FLEET_CONCURRENCY_QUEUE_MANAGER=1
 # FLEET_CONCURRENCY_MERGER=1
+
+# --- 5-hour-window usage gate -----------------------------------------------
+#
+# Soft, fleet-wide pre-emption: when any rate_limit_event observation
+# (latched by fleet-claude-stream into ~/.fleet/state/usage/<type>.json)
+# reports utilization >= the threshold, the dispatcher defers ALL fresh
+# dispatches until the window resets or utilization drops back below.
+# In-flight iterations finish normally; their next trigger waits.
+#
+# The threshold is a fraction in [0, 1]; default 0.80 reserves the last
+# 20% of the 5-hour budget for already-running work.
+# Stale window: observations older than this many seconds are ignored,
+# so the gate doesn't latch closed forever based on a single high
+# watermark. Default 1h.
+#
+# Sibling to FLEET_DISPATCHER_LIMIT_DELAY (per-pane post-mortem cooldown
+# after a usage_limit exit). Use --gate-status on fleet-dispatcher to
+# inspect the live state.
+
+# FLEET_DISPATCHER_USAGE_GATE=0.80
+# FLEET_DISPATCHER_USAGE_STALE_SECONDS=3600

--- a/scripts/fleet/tests/test_dispatcher_usage_gate.sh
+++ b/scripts/fleet/tests/test_dispatcher_usage_gate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Tests for fleet-dispatcher's 5-hour-window usage gate.
+#
+# Covers:
+#   - empty usage dir => gate open
+#   - utilization >= threshold + fresh + future reset => gate closed
+#   - threshold override via env var (FLEET_DISPATCHER_USAGE_GATE)
+#   - stale observation (older than USAGE_STALE_SECONDS) => ignored
+#   - resetsAt in the past => observation ignored
+#   - utilization < threshold => gate open with util reported
+#   - worst-of across multiple types when only one is over threshold
+#   - defensive percent path (utilization > 1.5 treated as percent)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+
+if [[ ! -x "$DISPATCHER" ]]; then
+    echo "test setup: fleet-dispatcher not found at $DISPATCHER" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_starts_with() {
+    local actual="$1" prefix="$2" msg="$3"
+    if [[ "$actual" == "$prefix"* ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected prefix: $prefix"
+        echo "        actual:          $actual"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_STATE_DIR="$TMPROOT/state"
+mkdir -p "$FLEET_STATE_DIR/usage"
+
+NOW=$(date +%s)
+# Future ISO-8601 timestamp; portable across BSD/GNU date.
+RESETS=$(python3 -c "import datetime,time; print(datetime.datetime.fromtimestamp(time.time()+3600,tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+
+echo "T1: empty usage dir => open"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open" "empty state reports open"
+
+echo "T2: utilization 0.85, fresh, future reset => closed"
+printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$NOW" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:five_hour util=85%" "85% trips default 80% threshold"
+
+echo "T3: same fixture, threshold 0.99 => open"
+out=$(FLEET_DISPATCHER_USAGE_GATE=0.99 "$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open:five_hour util=85%" "raised threshold opens gate"
+
+echo "T4: stale observation (2h old) => open"
+printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$((NOW - 7200))" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open" "stale observation ignored"
+
+echo "T5: resetsAt in the past => open"
+printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"2020-01-01T00:00:00Z","observed_at":%s}\n' "$NOW" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open" "expired window ignored"
+
+echo "T6: utilization 0.50 => open with util reported"
+printf '{"rateLimitType":"five_hour","utilization":0.50,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$NOW" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open:five_hour util=50%" "below-threshold reports util"
+
+echo "T7: worst-of across two types (one over)"
+printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$NOW" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+printf '{"rateLimitType":"output_tokens","utilization":0.30,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$NOW" \
+    > "$FLEET_STATE_DIR/usage/output_tokens.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:five_hour util=85%" "worst observation wins"
+rm -f "$FLEET_STATE_DIR/usage/output_tokens.json"
+
+echo "T8: defensive percent path (raw 85, not 0.85) => closed"
+printf '{"rateLimitType":"five_hour","utilization":85,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$NOW" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:five_hour util=85%" "percent value treated as percent"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds a soft, fleet-wide rate-limit pre-emption: when any `rate_limit_event` observation reports utilization past a configurable threshold (default **80%**), `fleet-dispatcher` defers ALL fresh dispatches until the window resets or utilization drops. In-flight iterations finish normally; their next trigger waits.

Sibling to T-119's per-pane post-mortem cooldown — that fires AFTER a pane hits the wall and exits with code 2; this fires BEFORE the wall to spread the remaining 5h budget across already-running work.

## Why

Today's only pre-emption is post-mortem (`fleet-dispatch-wrap` writes `~/.fleet/state/rate-limit/<pane>.ts` after a `usage_limit` exit; the dispatcher then sleeps that pane for `LIMIT_DELAY`). By the time it fires, the 5h budget is already exhausted, and any concurrent panes are about to hit the same wall on their next iteration. The user wanted a cooperative 80% gate so the fleet stops spending budget on new work and lets in-flight iterations finish cleanly.

## How it works

- **`fleet-claude-stream`** already parses `rate_limit_event` from claude's stream-json output (`fleet-claude-stream:158-162`). It now ALSO writes the latest observation to `~/.fleet/state/usage/<rateLimitType>.json` (atomic temp-file-then-rename to avoid torn reads). Every transient worker contributes its own observation as a side effect of running — no separate poller.
- **`fleet-dispatcher`** gains a `usage_gate_open()` check at the top of the main loop. The gate considers an observation only if its `observed_at` is within `FLEET_DISPATCHER_USAGE_STALE_SECONDS` (default 1h) AND its `resetsAt` is in the future. Closes if any qualifying observation is >= `FLEET_DISPATCHER_USAGE_GATE` (default 0.80). Logged once per closed-window via `USAGE_GATE_CLOSED_LOGGED` — no per-tick spam. Triggers stay in place during a closed window, so the next tick after the gate re-opens fires normally.
- **`fleet-dispatcher --gate-status`** prints the live state for operator inspection without tailing the log:
  ```
  $ fleet-dispatcher --gate-status
  closed:five_hour util=91% (>= 80%) resets=2026-05-09T01:00:00Z
  ```

## Stale-observation handling

If `claude` hasn't run in an hour, observations age out via the `observed_at` check, so the gate doesn't latch closed forever based on a single high watermark from earlier in the day.

## Defensive percent-vs-fraction path

The current API returns `utilization` as a fraction in `[0,1]`. The python implementation has a `if util > 1.5: util /= 100` guard so that if Anthropic ever returns a percent in `[0,100]` the gate still trips correctly. Tested in T8 of the harness.

## Files

- `scripts/fleet/fleet-claude-stream` — `latch_usage_observation()` writer (~40 lines)
- `scripts/fleet/fleet-dispatcher` — `usage_gate_status` / `usage_gate_open` helpers, main-loop hook, `--gate-status` CLI entry, `USAGE_DIR` mkdir on startup (~110 lines)
- `scripts/fleet/fleet-up.conf.sample` — document `FLEET_DISPATCHER_USAGE_GATE` and `FLEET_DISPATCHER_USAGE_STALE_SECONDS`
- `scripts/fleet/tests/test_dispatcher_usage_gate.sh` — 8-case bash harness

## Test plan

- [x] `scripts/fleet/tests/test_dispatcher_usage_gate.sh` — 8 PASS / 0 FAIL
  - empty state → open
  - 0.85 fresh + future reset → closed
  - same fixture + threshold 0.99 → open
  - stale observation (2h old) → ignored (open)
  - resetsAt in past → ignored (open)
  - 0.50 → open with util reported
  - worst-of across two types when only one is over threshold
  - defensive percent path (raw 85, not 0.85) → closed
- [x] `scripts/fleet/tests/test_dispatcher_concurrency_cap.sh` — 13 PASS / 0 FAIL (no regression)
- [x] `bash -n scripts/fleet/fleet-dispatcher` — clean
- [x] `python3 -c "import ast; ast.parse(open(...))"` — clean on `fleet-claude-stream`
- [x] End-to-end: piped a synthetic `rate_limit_event` JSON through `fleet-claude-stream`, confirmed the latched JSON file matches expected shape, then ran `fleet-dispatcher --gate-status` and got the expected `closed:five_hour util=91% (>= 80%) resets=...` line.
- [ ] Live test: confirm gate trips when actual fleet utilization passes 80% (requires hitting the wall in production).

## Stacking

This PR is **stacked on PR #548** (T-125 concurrency cap) since both touch `fleet-dispatcher`'s `dispatch_role` / main loop. Merge order:

1. PR #548 (T-125 concurrency cap)
2. This PR

Once #548 merges, GitHub will auto-retarget this PR's base to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)