### PR TITLE
fleet-dispatcher: detect fleet-dispatch-wrap as occupying the pane

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -282,6 +282,27 @@ list_pane_state() {
 # iterations. The previous singular form picked the first idle pane
 # and dropped the rest, which silently single-flighted multi-pane
 # roles.
+# Returns 0 (true) when a fleet-dispatch-wrap is currently running as a
+# direct child of the pane's shell. Used to disambiguate tmux's
+# pane_current_command, which reports "bash" while fleet-dispatch-wrap
+# (a `#!/usr/bin/env bash` script) runs its `claude | fleet-claude-stream`
+# pipeline — the wrapper's bash interpreter is the process-group leader,
+# so tmux's foreground-pgroup-name lookup returns "bash" rather than
+# "claude" or "python3". Without this check the dispatcher's idle-detection
+# treats a mid-iteration pane as idle: cleanup_stale_dispatches deletes
+# the dispatch record at the next 10s tick, and the next periodic re-arm
+# (default 5 min) fires C-c+new-dispatch into the live pipeline, killing
+# the iteration mid-edit. Observed for queue-manager: ~5 min of analysis
+# + edits would consistently get C-c'd before reaching the commit step,
+# leaving TASKS.md dirty and the master state stale across iterations.
+pane_has_running_wrapper() {
+    local pane_id="$1"
+    local pane_pid
+    pane_pid=$(tmux display-message -t "$pane_id" -p '#{pane_pid}' 2>/dev/null || true)
+    [[ -n "$pane_pid" ]] || return 1
+    pgrep -P "$pane_pid" -f fleet-dispatch-wrap >/dev/null 2>&1
+}
+
 find_idle_panes_for_role() {
     local role="$1"
     list_pane_state | while IFS=$'\t' read -r pane_id pane_role pane_cmd; do
@@ -290,6 +311,13 @@ find_idle_panes_for_role() {
         fi
         case "$pane_cmd" in
             bash|zsh|sh|fish)
+                # tmux reports "bash" while fleet-dispatch-wrap is running.
+                # Skip the pane when the wrapper is alive — the iteration
+                # is in progress even though the foreground command name
+                # is in the shell allowlist.
+                if pane_has_running_wrapper "$pane_id"; then
+                    continue
+                fi
                 printf '%s\n' "$pane_id"
                 ;;
         esac
@@ -308,12 +336,16 @@ dispatch_send_keys() {
     fi
 }
 
-# Returns 0 if the pane is occupied (non-shell cmd), non-zero if idle at a shell.
-# Inverted allowlist: macOS tmux reports version strings (e.g. "2.1.132") instead
-# of "claude", so matching by name misses live panes and triggers premature cleanup.
+# Returns 0 if the pane is occupied (non-shell cmd OR fleet-dispatch-wrap
+# alive as direct child of the pane shell), non-zero if truly idle.
+# Inverted allowlist: macOS tmux reports version strings (e.g. "2.1.132")
+# instead of "claude", so matching by name misses live panes and triggers
+# premature cleanup. The wrapper-process check covers the orthogonal case
+# where pane_current_command IS one of the allowlisted shells but a
+# fleet-dispatch-wrap iteration is mid-flight underneath it.
 pane_is_occupied() {
     local pane_id="$1"
-    list_pane_state | awk -F'\t' -v target="$pane_id" '
+    if list_pane_state | awk -F'\t' -v target="$pane_id" '
         $1 == target {
             cmd = $3
             if (cmd != "bash" && cmd != "zsh" && cmd != "sh" && cmd != "fish")
@@ -321,7 +353,10 @@ pane_is_occupied() {
             else
                 print "no"
         }
-    ' | grep -q "^yes$"
+    ' | grep -q "^yes$"; then
+        return 0
+    fi
+    pane_has_running_wrapper "$pane_id"
 }
 
 # --- Dispatch state --------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix idle-detection so the dispatcher doesn't kill its own long-running iterations every 5 minutes.

## Bug

`fleet-dispatch-wrap` is a `#!/usr/bin/env bash` script. When it runs the `claude | fleet-claude-stream` pipeline, the wrapper's own bash interpreter is the pipeline's process-group leader. So **tmux's `pane_current_command` reports `bash`** (or `zsh`/`sh`/`fish`) — even though claude and fleet-claude-stream are very much alive underneath it.

The dispatcher's idle-detection (`find_idle_panes_for_role`, `pane_is_occupied`) treats those four shell names as idle. So:

1. T=0s: dispatcher dispatches into pane, writes dispatch record
2. T=10s: `cleanup_stale_dispatches` runs, sees `pane_cmd=bash`, logs "dispatch ... completed (pane returned to shell)", deletes the dispatch record
3. T=300s (next periodic re-arm): finds pane "idle", fires `C-c` + a new dispatch into the still-running pipeline, killing the iteration mid-output

## Symptom (observed live)

queue-manager iterations consistently got C-c'd before reaching the `git add / git commit / git push` step. TASKS.md edits piled up uncommitted in the queue-manager worktree; the next iteration re-did the same edits, got killed at the same point, the queue never advanced. Visible in scrollback as `^Cfleet-dispatch-wrap pane-N ...` interrupting mid-edit.

Process tree at the time of misdetection:

```
9181 zsh                                 (pane shell)
└─ 22606 bash fleet-dispatch-wrap ...   ← tmux reports this as "bash"
   ├─ 22607 claude --print ...
   └─ 22608 python3 fleet-claude-stream
```

## Fix

Add `pane_has_running_wrapper(pane_id)` which uses `pgrep -P <pane_pid> -f fleet-dispatch-wrap` to check whether the wrapper is alive as a direct child of the pane's shell. Both `find_idle_panes_for_role` and `pane_is_occupied` consult it; a pane is never treated as idle while the wrapper is alive, even when `pane_current_command` is a shell name.

`pgrep -P` is direct-children-only; the wrapper IS a direct child of the pane shell (the pipeline children are grandchildren but share the wrapper's pgid, so the wrapper is what we look for).

## Test plan

- [x] `bash -n` clean
- [x] `scripts/fleet/tests/test_dispatcher_concurrency_cap.sh` — 13/13 PASS (no regression)
- [x] `scripts/fleet/tests/test_dispatcher_usage_gate.sh` — 8/8 PASS (no regression)
- [x] Manual repro — confirmed live via `ps` that fleet-dispatch-wrap runs as a direct child of the pane shell while tmux reports `pane_current_command=bash`
- [ ] After merge: `fleet-down && fleet-up`, then watch for queue-manager iterations to complete and commit (no "^C" interruptions visible in scrollback; `git status` in queue-manager worktree returns clean after maintenance pass)

## Impact

This is the "queue manager just spinning, no work happening" symptom from this evening. It's been latent since fleet-dispatch-wrap was introduced (T-119, PR #526) — visible only for long iterations that exceed the 5-minute periodic-rearm cadence (queue-manager + opus-worker analysis-heavy iterations). Short iterations (10–60s) finish before the next rearm and didn't trip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)