### PR TITLE
T-092: Render: final occupancy-grid teardown — comment cleanup

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_build_light_occlusion_grid.hpp
+++ b/engine/prefabs/irreden/render/systems/system_build_light_occlusion_grid.hpp
@@ -17,18 +17,14 @@
 // pre-#359 SDF-LOS behavior the GPU port lost. AO does not read either
 // bitfield (it migrated to screen-space neighbour sampling in T-091).
 //
-// T-126: bitfield storage moved into `SystemParams` and the SSBO was
-// renamed from `OccupancyGrid` to `LightOcclusionGrid` to reflect the
-// post-T-091 consumer set; the `C_OccupancyGrid` component opt-in is
-// gone. The system selects the main rendering canvas via
+// The system selects the main rendering canvas via
 // `<C_VoxelPool, C_TrixelCanvasRenderBehavior>` and the
 // `useCameraPositionIso_` flag — same gate `COMPUTE_LIGHT_VOLUME` uses.
+// Bitfield storage lives in `SystemParams` (no per-canvas component opt-in).
 //
 // Phased-out producer: this system + the LightOcclusionGrid SSBO it
 // feeds are scheduled for full removal in T-09Y once light-volume LOS
-// moves off the world-space bitfield. T-126 detached the producer from
-// per-canvas component storage so T-092 can delete `C_OccupancyGrid`
-// without touching shader bindings.
+// moves off the world-space bitfield.
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -222,9 +218,7 @@ template <> struct System<BUILD_LIGHT_OCCLUSION_GRID> {
         Buffer *ssbo_ = nullptr;
         LightOcclusionGridHeader header_{};
         /// CPU mirror of the voxel-existence bitfield, allocated once
-        /// at `create()` and reused every frame. T-126: replaces the
-        /// per-canvas `C_OccupancyGrid::bitfield()` storage so the SSBO
-        /// producer no longer requires the component opt-in.
+        /// at `create()` and reused every frame.
         std::vector<std::uint32_t> voxelBitfield_{};
         /// CPU mirror of the light-blocker bitfield. Allocated once at
         /// `create()` and reused every frame.

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -61,7 +61,7 @@ named lookup. Holds shaders, buffers, textures, VAOs, etc.
 │    BAKE_SUN_SHADOW_MAP                                           │
 │      • c_clear_sun_shadow_map.glsl + c_bake_sun_shadow_map.glsl  │
 │      • atomicMin-projects iso pixels into a sun-aligned depth    │
-│        map at slot 28 (aliases the occupancy grid; rebind)       │
+│        map at slot 28 (kBufferIndex_LightOcclusionGrid alias)    │
 │    COMPUTE_SUN_SHADOW                                            │
 │      • c_compute_sun_shadow.glsl → single-texel lookup against   │
 │        the baked sun depth map → per-pixel shadow brightness     │

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -331,10 +331,8 @@ constexpr std::uint32_t kBufferIndex_ChunkVisibility = 24;
 constexpr std::uint32_t kBufferIndex_CompactedVoxelIndices = 25;
 constexpr std::uint32_t kBufferIndex_IndirectDispatchParams = 26;
 constexpr std::uint32_t kBufferIndex_FrameDataLightingToTrixel = 27;
-// T-126 renamed this slot from `kBufferIndex_OccupancyGrid` to reflect
-// the post-T-091 consumer set: the SSBO at slot 28 now feeds only the
-// light-volume propagate shader (voxel-existence + SDF-blocker bits),
-// not AO or sun-shadow.
+// Slot 28: feeds only the light-volume propagate shader (voxel-existence
+// + SDF-blocker bits). Neither AO nor sun-shadow reads this SSBO.
 constexpr std::uint32_t kBufferIndex_LightOcclusionGrid = 28;
 constexpr std::uint32_t kBufferIndex_FrameDataSun = 29;
 constexpr std::uint32_t kBufferIndex_ShapeTileDescriptors = 30;

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -332,7 +332,8 @@ constexpr std::uint32_t kBufferIndex_CompactedVoxelIndices = 25;
 constexpr std::uint32_t kBufferIndex_IndirectDispatchParams = 26;
 constexpr std::uint32_t kBufferIndex_FrameDataLightingToTrixel = 27;
 // Slot 28: feeds only the light-volume propagate shader (voxel-existence
-// + SDF-blocker bits). Neither AO nor sun-shadow reads this SSBO.
+// + SDF-blocker bits). Neither AO nor sun-shadow reads this bitfield SSBO
+// (see `kBufferIndex_SunShadowDepthMap` below for the slot-28 alias).
 constexpr std::uint32_t kBufferIndex_LightOcclusionGrid = 28;
 constexpr std::uint32_t kBufferIndex_FrameDataSun = 29;
 constexpr std::uint32_t kBufferIndex_ShapeTileDescriptors = 30;


### PR DESCRIPTION
## Summary

T-126 did the heavy lifting for T-092: renamed the system/SSBO from
`OccupancyGrid` → `LightOcclusionGrid`, deleted `C_OccupancyGrid`,
migrated bitfield storage to `SystemParams`. This PR removes the three
stale `C_OccupancyGrid` comment fragments T-126 left as breadcrumbs,
converts the T-126 history note in `ir_render_types.hpp` into a stable
description of the slot's current role, and updates the CLAUDE.md
pipeline diagram to name the correct constant.

## Changes

- **`system_build_light_occlusion_grid.hpp`**: strip 3 comment fragments
  that referenced the now-deleted `C_OccupancyGrid` component (lines 20–31
  reduced from 12 lines to 8; doc comment for `voxelBitfield_` simplified).
- **`ir_render_types.hpp`**: replace the T-126 changelog comment above
  `kBufferIndex_LightOcclusionGrid = 28` with a one-liner describing what
  the slot feeds today.
- **`engine/render/CLAUDE.md`**: update pipeline-diagram entry for slot 28
  from `"aliases the occupancy grid; rebind"` to
  `"kBufferIndex_LightOcclusionGrid alias"`.

## Acceptance criteria

All four from issue #429:

1. ✅ `grep -rn 'C_OccupancyGrid|OccupancyGrid|kBufferIndex_OccupancyGrid|BUILD_OCCUPANCY_GRID|occupancyGetBit' engine/ creations/ test/` → **zero hits**
2. ✅ No lighting code deleted; purely comment/doc cleanup — visual parity is trivially preserved.
3. ✅ `fleet-build --target IrredenEngineTest` + `fleet-run IrredenEngineTest` — 432/432 pass on macOS.
4. ✅ CLAUDE.md updated: occupancy-grid slot-alias framing corrected.

## Test plan

- [x] Acceptance grep returns zero hits (verified)
- [x] `fleet-build --target IrredenEngineTest` + 432/432 tests pass
- [x] No source file deletions — build is trivially clean

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)