### PR TITLE
role docs: drop kill -TERM exit protocol (blocked by auto-mode)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -50,10 +50,13 @@ file, what stays direct — lives in
 ## Exit protocol
 
 You are a transient one-shot `claude --print` invocation. When
-your merge iteration finishes, `--print` exits and the pane
-returns to bash; `fleet-dispatcher` fires a fresh invocation
-when scout's next merge-candidate trigger arrives. Do NOT loop.
-If forced to exit explicitly: `bash -c 'kill -TERM $PPID'`.
+your merge iteration finishes, stop emitting tool calls and
+produce a final text response — `claude --print` then exits
+naturally, the pane returns to bash, and `fleet-dispatcher`
+fires a fresh invocation when scout's next merge-candidate
+trigger arrives. Do NOT loop. The auto-mode classifier blocks
+`bash -c 'kill -TERM $PPID'`, so the older explicit-kill path
+no longer applies — natural-exit on the final turn is correct.
 
 ## What you do
 

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -52,10 +52,13 @@ file, what stays direct — lives in
 ## Exit protocol
 
 You are a transient one-shot `claude --print` invocation. When
-your review iteration finishes, `--print` exits and the pane
-returns to bash; `fleet-dispatcher` fires a fresh invocation when
-scout's next flagged-PR trigger arrives. Do NOT loop. If forced
-to exit explicitly: `bash -c 'kill -TERM $PPID'`.
+your review iteration finishes, stop emitting tool calls and
+produce a final text response — `claude --print` then exits
+naturally, the pane returns to bash, and `fleet-dispatcher`
+fires a fresh invocation when scout's next flagged-PR trigger
+arrives. Do NOT loop. The auto-mode classifier blocks
+`bash -c 'kill -TERM $PPID'`, so the older explicit-kill path
+no longer applies — natural-exit on the final turn is correct.
 
 ## Role
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -49,17 +49,22 @@ file, what stays direct — lives in
 
 You are a transient one-shot `claude --print` invocation,
 dispatched into a tmux pane that's otherwise sitting at a bash
-prompt. When your iteration finishes, `--print` exits naturally
-and the pane returns to bash; `fleet-dispatcher` polls every 30 s
-and fires a fresh invocation when scout's next trigger arrives.
+prompt. When your iteration finishes, **stop emitting tool calls
+and produce a final text response** — `claude --print` then exits
+naturally, the pane returns to bash, and `fleet-dispatcher` fires
+a fresh invocation on scout's next trigger.
 
-Do NOT loop, do NOT call `fleet-babysit`. If you ever find
-yourself about to keep the process alive past iteration end,
-exit explicitly:
+Do NOT loop, do NOT call `fleet-babysit`, do NOT keep emitting
+tool calls hoping the iteration will be re-entered. The iteration
+is done when you stop producing turns.
 
-```
-bash -c 'kill -TERM $PPID'
-```
+Older role-doc revisions suggested `bash -c 'kill -TERM $PPID'`
+to terminate immediately. The auto-mode classifier now blocks
+that command (it reads as "agent attempting to terminate its
+controlling session"), so the explicit-kill path no longer
+applies. Ending your turn cleanly without further tool calls is
+the correct exit; the natural-exit pause is at most a few
+seconds and doesn't change anything load-bearing.
 
 ## Responsibilities
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -38,20 +38,22 @@ file, what stays direct — lives in
 
 You are a transient one-shot `claude --print` invocation,
 dispatched into a tmux pane that's otherwise sitting at a bash
-prompt. When your iteration finishes, `--print` exits naturally
-and the pane returns to bash; `fleet-dispatcher` polls every 30 s
-and fires a fresh invocation when scout's next trigger arrives.
+prompt. When your iteration finishes, **stop emitting tool calls
+and produce a final text response** — `claude --print` then exits
+naturally, the pane returns to bash, and `fleet-dispatcher` fires
+a fresh invocation when scout's next trigger arrives.
 
-Do NOT loop, do NOT call `fleet-babysit`. If you ever find
-yourself about to keep the process alive past iteration end (an
-unhandled error, an unexpected prompt), exit explicitly:
+Do NOT loop, do NOT call `fleet-babysit`, do NOT keep emitting
+tool calls hoping the iteration will be re-entered. The iteration
+is done when you stop producing turns.
 
-```
-bash -c 'kill -TERM $PPID'
-```
-
-That kills the claude parent PID, returns the pane to bash, and
-lets the dispatcher dispatch the next iteration.
+Older role-doc revisions suggested `bash -c 'kill -TERM $PPID'`
+to terminate immediately. The auto-mode classifier now blocks
+that command (it reads as "agent attempting to terminate its
+controlling session"), so the explicit-kill path no longer
+applies. Ending your turn cleanly without further tool calls is
+the correct exit; the natural-exit pause is at most a few
+seconds and doesn't change anything load-bearing.
 
 ## Responsibilities
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -46,10 +46,13 @@ file, what stays direct — lives in
 ## Exit protocol
 
 You are a transient one-shot `claude --print` invocation. When
-your review iteration finishes, `--print` exits and the pane
-returns to bash; `fleet-dispatcher` fires a fresh invocation when
-scout's next candidate trigger arrives. Do NOT loop. If forced
-to exit explicitly: `bash -c 'kill -TERM $PPID'`.
+your review iteration finishes, stop emitting tool calls and
+produce a final text response — `claude --print` then exits
+naturally, the pane returns to bash, and `fleet-dispatcher`
+fires a fresh invocation when scout's next candidate trigger
+arrives. Do NOT loop. The auto-mode classifier blocks
+`bash -c 'kill -TERM $PPID'`, so the older explicit-kill path
+no longer applies — natural-exit on the final turn is correct.
 
 ## Role
 


### PR DESCRIPTION
## Summary

Five transient-role docs (opus-worker, sonnet-author, opus-reviewer, sonnet-reviewer, merger) instructed agents to run `bash -c 'kill -TERM $PPID'` as the explicit exit signal. Recent auto-mode classifier changes block this — it reads as "agent attempting to terminate its controlling session" — so the role-doc-prescribed exit fails with a permission error.

Replace with explicit guidance to end the turn cleanly without further tool calls. `claude --print` exits naturally when the LLM stops emitting turns. Takes a few seconds longer than the kill but is otherwise load-bearing-equivalent.

## Observed live

Worker pane scrollback (2026-05-09 ~10:50 PT):

```
▸ Bash({"command":"bash -c 'kill -TERM $PPID'", "description":"Exit cleanly per protocol"})
  ⎿ Permission for this action was denied by the Claude Code auto mode classifier.
    Reason: Killing the parent process via SIGTERM is an attempt to terminate/interfere
    with the agent's controlling session…

The exit-protocol kill was blocked by auto-mode. Per role doc, this is a transient
`claude --print` invocation — when I stop responding, the process exits naturally
and the dispatcher re-fires on the next scout trigger. Ending iteration here.
[done success turns=16 $1.0635 131.5s]
```

The worker correctly figured out the workaround on its own — but every iteration that hits this path burns one extra agent turn just to write the "Ending iteration here" reasoning. Updating the role docs makes the natural-exit path canonical and removes the dead-end command.

## Files changed

- `.claude/commands/role-opus-worker.md`
- `.claude/commands/role-sonnet-author.md`
- `.claude/commands/role-opus-reviewer.md`
- `.claude/commands/role-sonnet-reviewer.md`
- `.claude/commands/role-merger.md`

5 files, +53/-37. Each replaces the explicit-kill block with: "stop emitting tool calls and produce a final text response — `claude --print` then exits naturally."

The kill string is preserved verbatim in the new prose (as a "this used to work, doesn't anymore, here's why" note) so an agent that recalls the older guidance from training data finds the explanation immediately rather than re-deriving the workaround.

## Test plan

- [x] `grep "kill -TERM" .claude/commands/*.md` — no remaining instructions to RUN the command; only references that explain it's deprecated.
- [ ] Live verification post-merge: confirm a regular worker iteration ends without the permission-denied detour. (Will be visible the moment any pane finishes a real iteration.)

## Self-approve

Doc-only change across five role files, no behavior depends on the removed instruction beyond pane exit speed. Carrying `fleet:approved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)