### PR TITLE
fleet: stop merger spinning on its own label toggles (~$2-3/hr idle burn fix)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -814,37 +814,36 @@ release_dispatcher_lock() {
 }
 
 rearm_periodic_meta_triggers() {
-    # Periodic safety net for merger. The PRIMARY trigger path is scout's
-    # hash-diff detection — when merger's projection changes, scout writes
-    # ~/.fleet/state/triggers/merger and the dispatcher picks it up the
-    # next tick. This function is the BACKUP path for cases the primary
-    # chain misses (e.g. a scout tick was skipped or the trigger file was
-    # swept on fleet-up).
+    # Scout-watchdog safety net only. With merger's projection now
+    # tightened (only durable signals, not the merger's own toggled
+    # labels), the scout-driven trigger path is sufficient — the
+    # merger only fires when actionable state actually changes.
     #
-    # queue-manager is no longer in this function: maintenance (derived-
-    # field rendering) is now handled by fleet-queue-tick, spawned directly
-    # by fleet-state-scout on projection change. No LLM dispatch needed.
+    # The earlier `maybe_arm("merger", merger_actionable)` periodic
+    # re-arm fired every 5 min whenever any approved/blocked PR
+    # existed in the projection, even when the merger had nothing
+    # to do (e.g. PR has fleet:approved + fleet:needs-linux-smoke
+    # awaiting smoke validation — not the merger's job). Burning
+    # ~$0.30 per iteration × 12/hour was the dominant idle-fleet
+    # token cost. Dropped.
     #
-    # merger: actionable-projection predicate. Its projection IS
-    # responsive (PRs appear/disappear on merge), so we only re-arm
-    # when the natural trigger chain might be lagging.
+    # queue-manager (bookkeeping) is handled by fleet-queue-tick,
+    # spawned directly by fleet-state-scout on projection change.
+    # Queue-manager (ingestion) fires on its own scout-driven
+    # trigger when human:approved-not-yet-queued issues appear.
+    #
+    # If scout itself dies, every role's projection-diff machinery
+    # stops. Re-fire merger as a one-shot so a scout crash doesn't
+    # strand the merge queue indefinitely.
     python3 - <<'PY' || true
-import json
 import pathlib
 import time
 
 STATE = pathlib.Path("~/.fleet/state").expanduser()
-PROJ = STATE / "projections"
 TRIG = STATE / "triggers"
-DISP = STATE / "dispatch"
 STATE_FILE = STATE / "state.json"
 TRIG.mkdir(parents=True, exist_ok=True)
 
-# Scout writes state.json every ~30s. If it hasn't been touched in this
-# many seconds, treat scout as unhealthy and wake queue-manager so a
-# scout crash doesn't strand the queue indefinitely. The dispatcher's
-# rearm interval is the upper bound on detection latency anyway, so a
-# generous threshold here costs nothing.
 SCOUT_STALENESS_SECONDS = 120
 
 
@@ -858,48 +857,15 @@ def scout_unhealthy():
     return age > SCOUT_STALENESS_SECONDS
 
 
-def merger_actionable(p):
-    return bool(p.get("prs"))
-
-
-def role_in_flight(role):
-    if not DISP.is_dir():
-        return False
-    for f in DISP.glob("*.json"):
-        try:
-            data = json.loads(f.read_text())
-        except (OSError, json.JSONDecodeError):
-            continue
-        if data.get("role") == role:
-            return True
-    return False
-
-
-def maybe_arm(role, predicate=None, reason="actionable projection"):
-    if predicate is not None:
-        proj = PROJ / f"{role}.json"
-        if not proj.is_file():
-            return
-        try:
-            data = json.loads(proj.read_text())
-        except (OSError, json.JSONDecodeError):
-            return
-        if not predicate(data):
-            return
-    trig_file = TRIG / role
-    if trig_file.exists():
-        # Already armed (scout, prior rearm, fleet-up bootstrap).
-        return
-    if role_in_flight(role):
-        # Iteration already running for this role.
-        return
-    trig_file.touch()
-    print(f"periodic re-arm: {role} ({reason}, no in-flight)")
-
-
-# queue-manager is no longer LLM-dispatched; fleet-queue-tick handles
-# maintenance directly. Only merger needs the periodic safety-net re-arm.
-maybe_arm("merger", merger_actionable)
+if scout_unhealthy():
+    # One-shot watchdog: write merger trigger if scout is dead. The
+    # next scout tick (when scout recovers) will re-establish the
+    # normal projection-diff cadence and this fallback won't fire
+    # again until staleness recurs.
+    trig = TRIG / "merger"
+    if not trig.exists():
+        trig.touch()
+        print("scout-watchdog: re-arming merger (state.json stale)")
 PY
 }
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -760,17 +760,62 @@ def project_queue_manager(state):
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
+def _merger_action_signal(labels, mergeable, base_ref):
+    """Canonical signal for whether the merger has actionable work on a PR.
+
+    Returns one of:
+        "merge-ready"      — fleet:approved + MERGEABLE + base==master + no skip
+        "needs-resolve"    — approved but CONFLICTING / UNSTABLE / BEHIND
+        "stacked-pending"  — approved and base != master (or fleet:stacked)
+        None               — merger has no action right now (skip)
+
+    The signal is computed from durable labels and `mergeable` only.
+    Transient self-set labels the merger toggles on its own iterations
+    (`fleet:merger-cooldown`, `fleet:awaiting-base`,
+    `fleet:needs-base-update`, `fleet:stacked-rebase`,
+    `fleet:changes-made`, `fleet:semantic-conflict`) are intentionally
+    NOT inputs — including them turned the projection hash into a
+    self-trigger loop: the merger fired, toggled its cooldown,
+    re-fired itself on the next scout tick. Observed live 2026-05-09
+    burning ~$2/10min on idle state.
+
+    `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` are also
+    skip signals — the merger isn't the agent that resolves those;
+    a smoke-runner clears them. Including them as merger candidates
+    just makes the merger fire repeatedly to find nothing to do.
+    """
+    skip = labels & {
+        "fleet:wip", "human:wip", "fleet:blocker",
+        "fleet:fork-of-other-pr", "fleet:design-blocked",
+        "fleet:needs-info", "fleet:needs-linux-smoke",
+        "fleet:needs-macos-smoke",
+    }
+    if skip:
+        return None
+    approved = "fleet:approved" in labels
+    if mergeable in ("CONFLICTING", "UNSTABLE", "BEHIND") and approved:
+        return "needs-resolve"
+    if approved and mergeable == "MERGEABLE" and base_ref == "master":
+        return "merge-ready"
+    if approved and (base_ref != "master" or "fleet:stacked" in labels):
+        return "stacked-pending"
+    return None
+
+
 def project_merger(state):
+    """Hash-input projection: contains only stable signals so the merger
+    doesn't self-trigger on its own label toggles. Slicer (slice_merger)
+    still emits the full PR record for the role to consume."""
     items = []
     for repo, repo_state in state["repos"].items():
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
-            mergeable = pr.get("mergeable")
-            approved = "fleet:approved" in labels
-            blocked = mergeable not in (None, "", "MERGEABLE", "UNKNOWN")
-            if approved or blocked:
-                items.append({"repo": repo, "pr": pr["number"],
-                              "mergeable": mergeable, "labels": pr["labels"]})
+            signal = _merger_action_signal(
+                labels, pr.get("mergeable"), pr.get("baseRefName", "master")
+            )
+            if signal is None:
+                continue
+            items.append({"repo": repo, "pr": pr["number"], "signal": signal})
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -1,0 +1,169 @@
+"""Tests for project_merger() in fleet-state-scout.
+
+The merger's hash-input projection MUST be stable across the merger's
+own self-toggled labels (fleet:merger-cooldown, fleet:awaiting-base,
+fleet:needs-base-update, etc.). Without this invariant, the merger
+self-triggers on every iteration: it toggles its cooldown label, scout
+sees the projection hash flip, scout fires the merger again, repeat.
+
+Observed live 2026-05-09: ~$0.30/iteration × 12/hour idle-fleet burn.
+
+This harness locks in the behavior:
+  - Same durable state -> same hash, regardless of cooldown labels.
+  - Action-relevant transitions (approved becomes mergeable, conflict
+    arises) DO change the hash.
+  - Skip-labels (wip, blocker, needs-linux-smoke, etc.) drop a PR
+    from the projection entirely so the merger isn't woken to find
+    nothing to do.
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+project_merger = _mod.project_merger
+stable_hash = _mod.stable_hash
+
+
+def _state(prs):
+    return {"repos": {"engine": {"prs": prs}}}
+
+
+def _pr(num, *, labels=None, mergeable="MERGEABLE", base="master",
+        head="claude/feat", author="bot"):
+    return {
+        "number": num,
+        "title": f"T-{num}: feat",
+        "headRefName": head,
+        "baseRefName": base,
+        "labels": sorted(labels or []),
+        "mergeable": mergeable,
+        "author": author,
+    }
+
+
+def _hash(state):
+    return stable_hash(project_merger(state))
+
+
+class StableAcrossSelfToggledLabels(unittest.TestCase):
+    """The core invariant: merger-toggled labels must NOT change the hash."""
+
+    def test_cooldown_label_does_not_flip_hash(self):
+        before = _state([_pr(101, labels=["fleet:approved"])])
+        after = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:merger-cooldown",
+        ])])
+        self.assertEqual(_hash(before), _hash(after),
+                         "cooldown toggle must not re-trigger merger")
+
+    def test_awaiting_base_label_does_not_flip_hash(self):
+        before = _state([_pr(101, labels=["fleet:approved"], base="claude/parent")])
+        after = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:awaiting-base",
+        ], base="claude/parent")])
+        self.assertEqual(_hash(before), _hash(after))
+
+    def test_stacked_rebase_label_does_not_flip_hash(self):
+        before = _state([_pr(101, labels=["fleet:approved"])])
+        after = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:stacked-rebase",
+            "fleet:changes-made",
+        ])])
+        self.assertEqual(_hash(before), _hash(after))
+
+    def test_semantic_conflict_label_does_not_flip_hash(self):
+        before = _state([_pr(101, labels=["fleet:approved"],
+                             mergeable="CONFLICTING")])
+        after = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:semantic-conflict",
+        ], mergeable="CONFLICTING")])
+        self.assertEqual(_hash(before), _hash(after))
+
+
+class ActionableTransitionsFlipHash(unittest.TestCase):
+    """Real state changes must still trigger the merger."""
+
+    def test_approval_appears_flips_hash(self):
+        before = _state([_pr(101, labels=[])])
+        after = _state([_pr(101, labels=["fleet:approved"])])
+        self.assertNotEqual(_hash(before), _hash(after))
+
+    def test_mergeable_to_conflicting_flips_hash(self):
+        before = _state([_pr(101, labels=["fleet:approved"], mergeable="MERGEABLE")])
+        after = _state([_pr(101, labels=["fleet:approved"], mergeable="CONFLICTING")])
+        self.assertNotEqual(_hash(before), _hash(after))
+
+    def test_new_approved_pr_flips_hash(self):
+        before = _state([])
+        after = _state([_pr(101, labels=["fleet:approved"])])
+        self.assertNotEqual(_hash(before), _hash(after))
+
+
+class SkipLabelsRemovedFromProjection(unittest.TestCase):
+    """Skip labels exclude a PR entirely so the merger isn't woken
+    to find nothing to do."""
+
+    def test_needs_linux_smoke_dropped(self):
+        # PR with fleet:approved + fleet:needs-linux-smoke is a smoke-runner's
+        # job, not the merger's. Should NOT appear in the projection.
+        empty = _state([])
+        with_smoke = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:needs-linux-smoke",
+        ])])
+        self.assertEqual(_hash(empty), _hash(with_smoke),
+                         "needs-linux-smoke PRs should be invisible to merger")
+
+    def test_needs_macos_smoke_dropped(self):
+        empty = _state([])
+        with_smoke = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:needs-macos-smoke",
+        ])])
+        self.assertEqual(_hash(empty), _hash(with_smoke))
+
+    def test_wip_dropped(self):
+        empty = _state([])
+        with_wip = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:wip",
+        ])])
+        self.assertEqual(_hash(empty), _hash(with_wip))
+
+    def test_blocker_dropped(self):
+        empty = _state([])
+        with_blocker = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:blocker",
+        ])])
+        self.assertEqual(_hash(empty), _hash(with_blocker))
+
+
+class SignalSemantics(unittest.TestCase):
+    """Verify the action signal categorization matches the role doc."""
+
+    def test_approved_mergeable_master_is_merge_ready(self):
+        items = project_merger(_state([_pr(101, labels=["fleet:approved"])]))
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["signal"], "merge-ready")
+
+    def test_approved_conflicting_is_needs_resolve(self):
+        items = project_merger(_state([_pr(101, labels=["fleet:approved"],
+                                            mergeable="CONFLICTING")]))
+        self.assertEqual(items[0]["signal"], "needs-resolve")
+
+    def test_approved_stacked_is_stacked_pending(self):
+        items = project_merger(_state([_pr(101, labels=[
+            "fleet:approved", "fleet:stacked",
+        ], base="claude/parent")]))
+        self.assertEqual(items[0]["signal"], "stacked-pending")
+
+    def test_unapproved_is_dropped(self):
+        items = project_merger(_state([_pr(101, labels=[])]))
+        self.assertEqual(items, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two coupled defects were burning ~$2-3/hour of opus credit on an idle fleet:

1. **Self-triggering loop:** `project_merger` captured the full PR labels array in its hash. The merger sets/clears its own labels every iteration (`fleet:merger-cooldown`, `fleet:awaiting-base`, `fleet:stacked-rebase`, `fleet:changes-made`, `fleet:semantic-conflict`, `fleet:needs-base-update`). Each toggle flipped the projection hash → scout fired the merger → merger toggled labels → repeat.
2. **Periodic re-arm fired every 5 min** if the projection had any approved-or-blocked PR — including PRs that carry `fleet:approved + fleet:needs-linux-smoke` (which are NOT the merger's job; the smoke runner clears those).

Observed live 2026-05-09 17:48-17:59 UTC: 6 merger iterations in 10 minutes, all returning "0 candidates". Per-iteration cost ~$0.30 → ~$2/hour idle, scaled to all-day operation.

## Fix

### A. Tightened `project_merger` hash input (`scripts/fleet/fleet-state-scout`)

New `_merger_action_signal(labels, mergeable, base_ref)` returns one of:
- `merge-ready` — `fleet:approved` + `MERGEABLE` + `base==master`, no skip labels
- `needs-resolve` — approved but `CONFLICTING` / `UNSTABLE` / `BEHIND`
- `stacked-pending` — approved + base != master (or `fleet:stacked`)
- `None` — drop from projection entirely

Computed from durable labels and `mergeable` only. Transient self-set labels (cooldown, awaiting-base, stacked-rebase, changes-made, semantic-conflict, needs-base-update) are intentionally NOT inputs.

Skip labels (`wip`, `human:wip`, `blocker`, `fork-of-other-pr`, `design-blocked`, `needs-info`, `needs-linux-smoke`, `needs-macos-smoke`) drop the PR from the projection so the merger isn't woken to find nothing to do.

`project_merger` now emits `[{repo, pr, signal}]` instead of `[{repo, pr, mergeable, labels[]}]`. Hash is stable across the merger's own toggles.

### B. Drop merger periodic re-arm (`scripts/fleet/fleet-dispatcher`)

`rearm_periodic_meta_triggers` no longer fires merger every 5 min on the actionable-projection predicate. Replaced with a **scout-watchdog one-shot** that fires merger only when `state.json` mtime is older than 120s (= scout is dead).

The tightened projection makes the scout-driven trigger path sufficient for happy-path operation. The watchdog covers the failure case where scout itself dies.

## Test plan

New `scripts/fleet/tests/test_merger_projection.py` — **15 cases / 15 PASS**:

| Class | Cases |
|---|---|
| `StableAcrossSelfToggledLabels` | cooldown, awaiting-base, stacked-rebase, semantic-conflict toggles → hash unchanged |
| `ActionableTransitionsFlipHash` | approval-appears, mergeable→conflicting, new-approved-PR → hash flips |
| `SkipLabelsRemovedFromProjection` | needs-linux-smoke, needs-macos-smoke, wip, blocker → PR dropped from projection |
| `SignalSemantics` | merge-ready, needs-resolve, stacked-pending, dropped-when-unapproved |

Regression checks (all pass):
- `test_queue_manager_projection.py` — 6 PASS
- `test_tasks_render.py` — 13 PASS
- `test_enrich_stackable_blocker_prs.py` — 12 PASS
- `test_dispatcher_concurrency_cap.sh` — 13 PASS
- `test_dispatcher_usage_gate.sh` — 13 PASS
- `bash -n fleet-dispatcher` clean
- `ast.parse fleet-state-scout` clean

## Acceptance

- After merge: `grep "periodic re-arm: merger" ~/.fleet/logs/dispatcher.log` returns 0 over a stable hour. The new `scout-watchdog: re-arming merger (state.json stale)` line only fires when scout actually dies.
- After merge: `grep "dispatching merger" ~/.fleet/logs/dispatcher.log | uniq -c` shows merger fires only on real PR-state transitions (label edits that change `fleet:approved` / `mergeable`), not on the merger's own iteration toggles.
- Idle-fleet token burn for the merger drops from ~$2-3/hour to ~$0/hour (only fires when actually merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)