### PR TITLE
queue: correct T-130 owner branch after duplicate-claim cleanup

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -181,7 +181,7 @@ Avoid:
   - **ID:** T-130
   - **Area:** engine/prefabs/irreden/input
   - **Model:** opus
-  - **Owner:** claude/T-130-hover-gui-source
+  - **Owner:** claude/T-130-gui-hitbox-source
   - **Blocked by:** (none)
   - **Acceptance:** (1) demos with voxel-only hover (no C_HitBox2DGui entities) unchanged; (2) C_HitBox2DGui + SYSTEM_ENTITY_HOVER_DETECT priority ordering (GUI > world > trixel) documented in engine/prefabs/irreden/input/CLAUDE.md; (3) HITBOX_MOUSE_TEST_GUI added to SystemName enum in engine/system/include/irreden/system/ir_system_types.hpp; (4) pipeline order: HITBOX_MOUSE_TEST, HITBOX_MOUSE_TEST_GUI, ENTITY_HOVER_DETECT; (5) fleet-build clean on linux-debug
   - **Issue:** #354


### PR DESCRIPTION
## Summary

Point the T-130 `**Owner:**` field at the canonical branch (`claude/T-130-gui-hitbox-source`, PR #575) instead of the closed-as-duplicate branch (`claude/T-130-hover-gui-source`, PR #579, now deleted).

## Context

Two workers claimed T-130 within 44 minutes of each other due to a fleet-claim race:

- 11:46 PDT — sonnet-author claims (branch `claude/T-130-gui-hitbox-source`, opens PR #575)
- 12:30 PDT — opus-worker claims (branch `claude/T-130-hover-gui-source`, opens PR #579)

Both `claim:` commits live on their feature branches; neither updated `master/TASKS.md`. T-130 is also tagged `**Model:** opus` but the gate is policy, not enforced — sonnet-author claimed an opus task. Process fixes filed separately to harden `fleet-claim`.

PR #579 closed as duplicate; PR #575 wins the tie (ships 4 unit tests, claimed first, more reviewer iteration).

## Test plan

- [x] One-line edit; no code touched
- [ ] Queue-manager's next maintenance sync flips T-130 to done after #575 merges, against the corrected Owner branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)