### PR TITLE
T-134: C_SpriteSheet: onDestroy GPU texture cleanup

### DIFF
--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -28,7 +28,9 @@ the ECS surface.
   trixel pipeline and draw at the `FRAMEBUFFER_TO_SCREEN` stage;
   `C_SpriteAnimation` tracks the active sub-animation, frame index, elapsed
   time, and loop mode for the `SPRITE_ANIMATION_ADVANCE` UPDATE-phase
-  system to write `uvRect` back into `C_Sprite`. See
+  system to write `uvRect` back into `C_Sprite`. `C_SpriteSheet` owns the
+  atlas GPU texture handle — **freed in `onDestroy()`**; callers must not
+  call `destroyResource` manually. See
   [`docs/design/sprites.md`](../../../../docs/design/sprites.md) for the
   full data model, depth semantics, and cross-task scope.
 

--- a/engine/prefabs/irreden/render/components/component_sprite_sheet.hpp
+++ b/engine/prefabs/irreden/render/components/component_sprite_sheet.hpp
@@ -2,7 +2,8 @@
 #define COMPONENT_SPRITE_SHEET_H
 
 #include <irreden/ir_math.hpp>
-#include <irreden/render/ir_render_types.hpp>
+#include <irreden/ir_render.hpp>
+#include <irreden/render/texture.hpp>
 
 #include <string>
 #include <string_view>
@@ -67,6 +68,12 @@ struct C_SpriteSheet {
         , animations_{std::move(animations)} {}
 
     C_SpriteSheet() = default;
+
+    void onDestroy() {
+        if (textureHandle_ != 0) {
+            IRRender::destroyResource<IRRender::Texture2D>(textureHandle_);
+        }
+    }
 
     /// Linear scan over @c animations_. Intended to be called once per
     /// state change (e.g. when a creation calls `playAnimation("walk")`),

--- a/engine/prefabs/irreden/render/entities/entity_sprite_sheet.hpp
+++ b/engine/prefabs/irreden/render/entities/entity_sprite_sheet.hpp
@@ -65,9 +65,8 @@ buildFrameTable(IRMath::uvec2 atlasSizePx, const IRAsset::SpriteSheetMeta &meta)
 ///   - @p name .irsprite — sidecar metadata (see @c IRAsset::loadSpriteSheetMeta).
 ///
 /// The returned component owns a GPU Texture2D identified by
-/// @c sheet.textureHandle_.  The caller is responsible for releasing it via
-/// @c IRRender::destroyResource<IRRender::Texture2D>(sheet.textureHandle_)
-/// when the sheet is no longer needed.
+/// @c sheet.textureHandle_.  The texture is freed automatically when the
+/// entity that holds the component is destroyed (@c C_SpriteSheet::onDestroy).
 inline IRComponents::C_SpriteSheet
 loadSpriteSheet(const std::string &name, const std::string &path) {
     IRAsset::SpriteSheetMeta meta = IRAsset::loadSpriteSheetMeta(name, path);


### PR DESCRIPTION
## Summary
- Added `onDestroy()` to `C_SpriteSheet` that calls `IRRender::destroyResource<Texture2D>(textureHandle_)` when the entity is destroyed.
- Guards against the default-constructed (zero-handle) case to avoid an invalid destroy call.
- Updated `loadSpriteSheet()` doc in `entity_sprite_sheet.hpp` — callers no longer need to release manually.
- Matches the pattern on `C_TriangleCanvasTextures`, `C_TrixelFramebuffer`, and `C_CanvasFogOfWar`.

## Test plan
- [x] `fleet-build --target IRShapeDebug` succeeds (macOS Metal backend)
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` completes cleanly (6/6 screenshots captured, zero crashes)

## Notes for reviewer
The change only affects entity destruction — no render pipeline, no shader, no visual output change. Screenshots omitted per the "mechanical refactor with provably no render path effect" exception in `engine/render/CLAUDE.md`.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)