### PR TITLE
T-136: Systems: registerSystem<N> helper to retire Params + setSystemParams boilerplate

### DIFF
--- a/.claude/rules/cpp-systems.md
+++ b/.claude/rules/cpp-systems.md
@@ -5,11 +5,11 @@ paths:
   - "creations/**/system_*.{hpp,cpp}"
 ---
 
-# System state lives in SystemParams, never function-local static
+# System state lives on System<N> or in SystemParams, never function-local static
 
 Rule:
 
-> **Never** use function-local `static` for *mutable* or *system-owned* state inside a system tick or its `create()` function. Use `SystemParams` instead.
+> **Never** use function-local `static` for *mutable* or *system-owned* state inside a system tick or its `create()` function. Use the member-on-`System<N>` form (preferred) or the explicit `SystemParams` form.
 
 Allowed: `static constexpr`, `static const` for genuine compile-time constants. Those are program constants, not system state.
 
@@ -22,9 +22,38 @@ Function-local `static` for system state is broken on four axes:
 3. **Single-instance assumption** — all instances of `System<X>` share the same statics. Multi-instance use silently cross-talks.
 4. **Conflicts with the ECS philosophy** — "everything on an entity" is the design; statics are the back door.
 
-The performance argument doesn't hold either: `SystemParams` has the same per-tick access cost as `static`. Capture the params pointer once at `create()` time, pass it into lambdas by value — the pointer lookup happens once, not per tick.
+The performance argument doesn't hold either: both supported forms have the same per-tick access cost as `static`. The instance pointer is captured into the lambdas at `create()` time — the lookup happens once, not per tick.
 
-## Canonical SystemParams pattern
+## Preferred: member-on-`System<N>` via `registerSystem`
+
+State lives as fields on the `System<N>` specialization itself; hooks are named member functions:
+
+```cpp
+template <> struct System<MY_NAME> {
+    int counter_ = 0;             // params live as members
+
+    void beginTick() { counter_ = 0; }
+    void tick(C_Foo &foo) { counter_ += foo.x; }
+    void endTick() { /* flush counter_ */ }
+
+    static SystemId create() {
+        return registerSystem<MY_NAME, C_Foo>("MyName");
+    }
+};
+```
+
+`registerSystem<N, Components...>(name, relationParams = {})`:
+
+- `Components...` accepts the same `Exclude<...>` markers as `createSystem`.
+- `tick(...)` is required — three accepted signatures (per-component, per-entity-id, per-archetype batch); the helper picks the right one by member detection.
+- `beginTick()`, `endTick()`, `relationTick(RelComps&...)` are optional — wired only when defined on `System<N>`.
+- The instance is `std::make_unique<System<N>>()`, owned by the system entity's params slot, freed when the system is destroyed.
+
+Read the instance back via `getSystemParams<System<N>>(systemId)` (tests, diagnostics).
+
+## Explicit: `Params` + `setSystemParams` (escape hatch)
+
+The pre-`registerSystem` pattern. Same lifetime, same per-tick cost, more boilerplate. Reach for this when you need a custom params lifetime, multiple distinct params types per system, or you're maintaining an existing system already on this shape:
 
 ```cpp
 SystemId create() {
@@ -41,11 +70,9 @@ SystemId create() {
 }
 ```
 
-Notes:
+Notes (apply to both forms):
 
-- Allocate a `std::make_unique<MyParams>()`, capture its `.get()` pointer **before** the move.
-- The lambdas capture `p` by value. `p` outlives the lambdas because `setSystemParams` transfers ownership to the system entity.
-- The system entity owns the params; both are destroyed together when the system is destroyed.
+- The instance pointer is captured by value; it outlives the lambdas because the system entity owns the allocation.
 - **Don't store raw references to params across frames** — if the system is recreated (e.g. via reload), the pointer is invalid.
 
 ## Three valid TICK function signatures

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -53,6 +53,16 @@ must have its `NAME` added to the `SystemName` enum in
 system under `engine/prefabs/**/systems/` and the enum value doesn't exist,
 the specialization won't link. Add the enum value **first**.
 
+## System-owned state lives on `System<N>` itself
+
+Prefer the **member-on-`System<N>`** form for system-owned state — declare
+the params as fields on the `System<N>` specialization, hooks (`tick`,
+`beginTick`, `endTick`, `relationTick`) as named member functions, and
+register via `IRSystem::registerSystem<N, Components...>("Name")`. The
+explicit `Params` + `setSystemParams` form remains supported as an escape
+hatch. See [`engine/system/CLAUDE.md`](system/CLAUDE.md) "Per-system
+parameters" for both shapes and the migration story.
+
 ## `createEntity` always adds position components
 
 `IREntity::createEntity(...)` implicitly adds `C_PositionGlobal3D` and

--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -19,11 +19,14 @@ when you open any C++ file. The capsules here are reminders.
   Use `IRMath::vec3` not `glm::vec3`, `IRMath::clamp` not `std::clamp`,
   `IRMath::kPi` not `glm::pi<float>()`. Need a primitive that isn't
   there? Add the wrapper to `engine/math/` first, then call it.
-- **System state lives in `SystemParams`.** Never function-local
-  `static` for mutable or system-owned state — `static constexpr` /
-  `static const` for genuine compile-time constants is fine. Capture
-  the `SystemParams` pointer once in `create()`, pass into lambdas by
-  value (same per-tick cost). The full canonical pattern lives in
+- **System state lives on `System<N>` or in `SystemParams`.** Never
+  function-local `static` for mutable or system-owned state —
+  `static constexpr` / `static const` for genuine compile-time
+  constants is fine. Prefer the **member-on-`System<N>`** form via
+  `IRSystem::registerSystem<N, Cs...>(name)` (params as fields,
+  hooks as named member functions); the explicit `Params` +
+  `setSystemParams` form remains supported as an escape hatch.
+  Both forms have the same per-tick cost. Full pattern in
   [`engine/system/CLAUDE.md`](../system/CLAUDE.md) and
   [`.claude/rules/cpp-systems.md`](../../.claude/rules/cpp-systems.md).
 - **No per-entity `getComponent` inside a system tick.** Add the
@@ -155,7 +158,9 @@ and should be moved to a system, builder, or namespace.
 - ❌ Cross-domain includes inside a prefab header (e.g. `voxel/` component
   including `audio/` component). Prefabs are grouped by domain on purpose;
   cross-domain composition belongs in a creation.
-- ❌ Function-local `static` for system-owned state. Use `SystemParams`
-  instead — same per-tick cost, correct lifetime, multi-instance safe.
-  See `engine/system/CLAUDE.md` "Don't use function-local `static` for
-  system state" for the rule, rationale, and canonical pattern.
+- ❌ Function-local `static` for system-owned state. Use the
+  member-on-`System<N>` form via `registerSystem` (preferred) or the
+  explicit `Params` + `setSystemParams` form — both have the same
+  per-tick cost, correct lifetime, and are multi-instance safe.
+  See `engine/system/CLAUDE.md` "Per-system parameters" for the
+  rule, rationale, and canonical patterns.

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -95,37 +95,76 @@ Go to (3) for bulk-processing opportunities (SIMD, sort, partition).
 
 ## Per-system parameters
 
-If a system needs persistent state beyond components (e.g. a GPU buffer
-handle, an accumulator), allocate a `SystemParams` subclass. Call
-`setSystemParams` **after** `createSystem` — the system entity must exist
-first. See the canonical example in the section below.
+When a system needs persistent state beyond components (a GPU buffer
+handle, an accumulator, a snapshot taken at `beginTick` and read by the
+per-entity tick), there are two ways to attach it. Both have the same
+runtime lifetime — params owned by the system entity, freed when the
+system is destroyed — and the same per-tick cost (one pointer capture,
+no per-frame lookup).
+
+### Preferred: member-on-`System<N>` via `registerSystem`
+
+The system's state lives as **member fields on the `System<N>`
+specialization itself**, with `tick` / `beginTick` / `endTick` /
+`relationTick` as named member functions. `registerSystem<N, Cs...>`
+allocates the `System<N>` instance, captures its pointer into the
+per-tick lambdas, and hands ownership to the system entity's params
+slot. No nested `Params` struct, no `setSystemParams` call.
 
 ```cpp
-// After createSystem returns systemId:
-auto& params = getSystemParams<MyParams>(systemId);
+template <> struct System<HITBOX_MOUSE_TEST_GUI> {
+    // Member variables = params. No nested Params struct.
+    vec2 mouseGuiTrixel_ = vec2(0.0f);
+
+    // Per-entity tick — normal member function, no lambda, no captures.
+    void tick(C_HitBox2DGui &hitbox, const C_GuiPosition &guiPos) {
+        const vec2 lo = vec2(guiPos.pos_);
+        const vec2 hi = vec2(guiPos.pos_ + hitbox.size_);
+        hitbox.hovered_ =
+            mouseGuiTrixel_.x >= lo.x && mouseGuiTrixel_.x < hi.x &&
+            mouseGuiTrixel_.y >= lo.y && mouseGuiTrixel_.y < hi.y;
+    }
+
+    void beginTick() {
+        // ... compute frame-scoped state ...
+        mouseGuiTrixel_ = mouseFb / fbRes * guiSize;
+    }
+
+    static SystemId create() {
+        return registerSystem<HITBOX_MOUSE_TEST_GUI,
+                              C_HitBox2DGui,
+                              C_GuiPosition>("HitBoxMouseTestGui");
+    }
+};
 ```
 
-The params are owned by the system entity and freed when the system is
-destroyed. **Do not store raw references to params across frames** — if the
-system is recreated (e.g. via reload), the pointer is invalid.
+`registerSystem<N, Components...>(name, relationParams = {})`:
 
-### Don't use function-local `static` for system state
+- `Components...` may include `Exclude<...>` markers, same as
+  `createSystem`.
+- `tick(...)` is required. Three accepted signatures, mirroring
+  `createSystem`'s three TICK forms (per-component, per-entity-id,
+  per-archetype batch). The helper picks the right one by member
+  detection.
+- `beginTick()`, `endTick()` are optional; presence is detected via
+  concept and they're wired only when defined.
+- `relationTick(RelComps&...)` is optional; pair it with a
+  `RelationParams<RelComps...>` argument so the helper can match
+  the member's signature.
+- The instance is `std::make_unique<System<N>>()` — held in the
+  same `m_systemParams` slot the explicit pattern uses, freed
+  identically when the system is destroyed.
 
-Function-local `static` for system-owned state is an anti-pattern.
-Use `SystemParams` instead.
+`getSystemParams<System<N>>(systemId)` returns the instance pointer
+when you need to reach into the system from outside (tests,
+diagnostics).
 
-**Why it's wrong:**
-- Hidden state — not visible to ECS inspectors or system-walking tools.
-- Lifetime mismatch — persists for program lifetime, doesn't free when the
-  system entity is destroyed.
-- Single-instance assumption — all instances of `System<X>` share the same
-  statics; future multi-instance use silently cross-talks.
-- Conflicts with the ECS "everything on an entity" philosophy.
+### Explicit: `Params` + `setSystemParams` (escape hatch)
 
-**Why the perf argument doesn't hold:** the canonical `SystemParams` pattern
-has the same per-tick access cost as `static`. Capture the pointer once at
-`create()` time and pass into lambdas by value — the pointer lookup happens
-once, not per tick.
+The pre-`registerSystem` pattern. Allocate a separate `Params` struct,
+build the per-tick lambdas with a captured raw pointer, hand the
+allocation to the system entity via `setSystemParams` **after**
+`createSystem` returns:
 
 ```cpp
 SystemId create() {
@@ -141,6 +180,46 @@ SystemId create() {
     return myId;
 }
 ```
+
+Same lifetime, same per-tick cost, more boilerplate. Reach for this
+form when:
+
+- The params type needs a custom lifetime (allocated elsewhere,
+  re-seated by an external owner, etc.).
+- A single system juggles multiple distinct params types and you want
+  them as separate allocations.
+- You're maintaining an existing system already on this pattern and
+  the migration isn't worth the diff right now.
+
+Both forms coexist; new systems should default to `registerSystem`.
+
+```cpp
+// Either path: read the params back from outside the tick.
+auto* params = getSystemParams<MyParams>(systemId);            // explicit
+auto* sys    = getSystemParams<System<MY_NAME>>(systemId);     // member-on-System<N>
+```
+
+**Don't store raw references to params across frames** — if the
+system is recreated (e.g. via reload), the pointer is invalid.
+
+### Don't use function-local `static` for system state
+
+Function-local `static` for system-owned state is an anti-pattern.
+Use one of the two patterns above instead.
+
+**Why it's wrong:**
+- Hidden state — not visible to ECS inspectors or system-walking tools.
+- Lifetime mismatch — persists for program lifetime, doesn't free when the
+  system entity is destroyed.
+- Single-instance assumption — all instances of `System<X>` share the same
+  statics; future multi-instance use silently cross-talks.
+- Conflicts with the ECS "everything on an entity" philosophy.
+
+**Why the perf argument doesn't hold:** both supported patterns
+(`registerSystem` member-on-`System<N>` and the explicit `Params`
+form) have the same per-tick access cost as `static`. The pointer is
+captured by value into the lambdas at `create()` time — the lookup
+happens once, not per tick.
 
 **Exception:** truly invariant data — `constexpr` integer constants,
 named-resource pointers fetched once at engine init that never change — is

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -72,6 +72,142 @@ template <SystemName type, typename... Args> SystemId createSystem(Args &&...arg
     return System<type>::create(args...);
 }
 
+namespace detail {
+
+// Member-on-System<N> hook detection. Each concept is satisfied when
+// the System<N> specialization declares the named member function with
+// a matching signature. Concepts are defined here so registerSystem<>
+// can dispatch to no-op fallbacks when an optional hook is absent.
+template <typename T>
+concept HasBeginTickMember = requires(T &t) { t.beginTick(); };
+
+template <typename T>
+concept HasEndTickMember = requires(T &t) { t.endTick(); };
+
+template <typename T, typename... RelComps>
+concept HasRelationTickMember = requires(T &t, RelComps &...rs) { t.relationTick(rs...); };
+
+template <typename T, typename L> struct MakeMemberTickFn;
+
+// Build a tick lambda that forwards to the matching `tick(...)` member
+// on the System<N> instance. Three signatures are supported, mirroring
+// `createSystem`'s three TICK forms:
+//   1. tick(Cs&...)                                  — per-component
+//   2. tick(EntityId, Cs&...)                        — per-entity-id
+//   3. tick(const Archetype&, std::vector<EntityId>&,
+//          std::vector<Cs>&...)                      — per-archetype batch
+template <typename T, typename... Cs> struct MakeMemberTickFn<T, TypeList<Cs...>> {
+    static auto build(T *p) {
+        if constexpr (requires(T &s, Cs &...cs) { s.tick(cs...); }) {
+            return [p](Cs &...cs) { p->tick(cs...); };
+        } else if constexpr (requires(T &s, EntityId id, Cs &...cs) { s.tick(id, cs...); }) {
+            return [p](EntityId id, Cs &...cs) { p->tick(id, cs...); };
+        } else if constexpr (
+            requires(
+                T &s,
+                const Archetype &a,
+                std::vector<EntityId> &ids,
+                std::vector<Cs> &...cols
+            ) { s.tick(a, ids, cols...); }
+        ) {
+            return [p](const Archetype &a, std::vector<EntityId> &ids, std::vector<Cs> &...cols) {
+                p->tick(a, ids, cols...);
+            };
+        } else {
+            static_assert(
+                false,
+                "registerSystem<N, Cs...>: System<N> must declare a tick(...) "
+                "member matching one of the three valid signatures: "
+                "tick(Cs&...), tick(EntityId, Cs&...), or "
+                "tick(const Archetype&, std::vector<EntityId>&, std::vector<Cs>&...)."
+            );
+        }
+    }
+};
+
+template <typename T> auto makeMemberBeginTickFn(T *p) {
+    if constexpr (HasBeginTickMember<T>) {
+        return [p]() { p->beginTick(); };
+    } else {
+        return nullptr;
+    }
+}
+
+template <typename T> auto makeMemberEndTickFn(T *p) {
+    if constexpr (HasEndTickMember<T>) {
+        return [p]() { p->endTick(); };
+    } else {
+        return nullptr;
+    }
+}
+
+template <typename T, typename... RelComps> auto makeMemberRelationTickFn(T *p) {
+    if constexpr (HasRelationTickMember<T, RelComps...>) {
+        return [p](RelComps &...rs) { p->relationTick(rs...); };
+    } else {
+        return nullptr;
+    }
+}
+
+} // namespace detail
+
+// Register a system whose state lives as **member fields on the
+// `System<N>` specialization itself**, with `tick` / `beginTick` /
+// `endTick` / `relationTick` as named member functions instead of the
+// explicit `Params` + lambda-capture + `setSystemParams` boilerplate.
+//
+// The lifetime contract is identical to `setSystemParams`: a single
+// `std::make_unique<System<N>>()` instance is allocated here, owned by
+// the system entity's parameters slot, and freed when the system is
+// destroyed. The instance pointer is captured by value into the
+// per-tick lambdas — same one-pointer-lookup-per-frame cost as the
+// canonical Params pattern.
+//
+// Usage:
+//
+//     template <> struct System<MY_NAME> {
+//         vec2 cachedMouse_ = vec2(0.0f);   // params live as members
+//
+//         void beginTick() { cachedMouse_ = IRRender::getMouse(); }
+//         void tick(C_HitBox &h, const C_Pos &p) {
+//             h.hovered_ = aabbContains(p.pos_, cachedMouse_);
+//         }
+//
+//         static SystemId create() {
+//             return registerSystem<MY_NAME, C_HitBox, C_Pos>("MyName");
+//         }
+//     };
+//
+// The `Components...` pack supports the same `Exclude<...>` markers as
+// `createSystem` (partitioned at compile time). `RelationParams<...>`
+// is forwarded the same way; the helper detects a `relationTick`
+// member with a signature matching the relation components.
+template <SystemName N, typename... Components, typename... RelationComponents>
+SystemId
+registerSystem(std::string name, RelationParams<RelationComponents...> relationParams = {}) {
+    using SystemT = System<N>;
+    using IncludedList = typename detail::PartitionExcludes<Components...>::Included;
+
+    auto instance = std::make_unique<SystemT>();
+    SystemT *p = instance.get();
+
+    auto tickFn = detail::MakeMemberTickFn<SystemT, IncludedList>::build(p);
+    auto beginFn = detail::makeMemberBeginTickFn<SystemT>(p);
+    auto endFn = detail::makeMemberEndTickFn<SystemT>(p);
+    auto relationFn = detail::makeMemberRelationTickFn<SystemT, RelationComponents...>(p);
+
+    SystemId id = createSystem<Components...>(
+        std::move(name),
+        std::move(tickFn),
+        std::move(beginFn),
+        std::move(endFn),
+        std::move(relationParams),
+        std::move(relationFn)
+    );
+    setSystemParams(id, std::move(instance));
+    return id;
+}
+
 // Free-function wrapper around `SystemManager::createSystemDynamic`. Used by
 // the Lua-driven path where component types are known only at runtime; the
 // caller passes resolved archetype sets (lists of `ComponentId`) and a body

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -112,7 +112,12 @@ enum SystemName {
     CAMERA_MOUSE_PAN,
     DEBUG_CULLING_MINIMAP,
     PERF_STATS_OVERLAY,
-    ENTITY_CANVAS_TO_FRAMEBUFFER
+    ENTITY_CANVAS_TO_FRAMEBUFFER,
+
+    // Reserved for tests of the registerSystem<> member-on-System<N>
+    // helper. Do not use from a creation or prefab system.
+    TEST_REGISTER_SYSTEM_A,
+    TEST_REGISTER_SYSTEM_B
 };
 
 template <typename... RelationComponents> struct RelationParams {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(IrredenEngineTest
   script/lua_pipeline_register_test.cpp
   script/lua_system_register_test.cpp
   script/modifier_lua_test.cpp
+  system/register_system_test.cpp
   utility/ir_utility_test.cpp
 )
 

--- a/test/system/register_system_test.cpp
+++ b/test/system/register_system_test.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+#include <irreden/entity/entity_manager.hpp>
+
+namespace {
+
+struct ValueA {
+    int n_ = 0;
+};
+struct ValueB {
+    int m_ = 0;
+};
+
+} // namespace
+
+namespace IRSystem {
+
+// Specialization with all four hooks (tick, beginTick, endTick) plus a
+// member field (`scaleFromBegin_`) that beginTick writes and tick reads.
+// The member-field shape is the helper's whole point — verify it
+// persists across ticks within a frame and is reset frame-to-frame as
+// beginTick re-seeds it.
+template <> struct System<TEST_REGISTER_SYSTEM_A> {
+    int scaleFromBegin_ = 0;
+    int beginCount_ = 0;
+    int endCount_ = 0;
+    int tickCount_ = 0;
+
+    void beginTick() {
+        beginCount_++;
+        scaleFromBegin_ = beginCount_ * 10;
+    }
+
+    void tick(ValueA &v) {
+        tickCount_++;
+        v.n_ += scaleFromBegin_;
+    }
+
+    void endTick() {
+        endCount_++;
+    }
+
+    static SystemId create() {
+        return registerSystem<TEST_REGISTER_SYSTEM_A, ValueA>("RegisterSystemTestA");
+    }
+};
+
+// Second specialization to exercise per-instance state separation —
+// the same SystemName cannot be registered twice (the params slot is
+// per SystemId), but two distinct System<NAME>s should each own their
+// own params instance with no cross-talk.
+template <> struct System<TEST_REGISTER_SYSTEM_B> {
+    int hits_ = 0;
+
+    void tick(ValueB &v) {
+        hits_++;
+        v.m_ += 1;
+    }
+
+    static SystemId create() {
+        return registerSystem<TEST_REGISTER_SYSTEM_B, ValueB>("RegisterSystemTestB");
+    }
+};
+
+} // namespace IRSystem
+
+namespace {
+
+class RegisterSystemTest : public testing::Test {
+  protected:
+    RegisterSystemTest()
+        : m_entity_manager{}
+        , m_system_manager{} {}
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(RegisterSystemTest, MemberTickFiresPerEntity) {
+    auto idA = IREntity::createEntity(ValueA{0});
+    auto idB = IREntity::createEntity(ValueA{0});
+
+    auto sysId = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    // beginTick set scaleFromBegin_ = 10; tick added 10 to each ValueA.
+    EXPECT_EQ(IREntity::getComponent<ValueA>(idA).n_, 10);
+    EXPECT_EQ(IREntity::getComponent<ValueA>(idB).n_, 10);
+}
+
+TEST_F(RegisterSystemTest, MemberFieldsPersistAcrossTicks) {
+    auto idA = IREntity::createEntity(ValueA{0});
+
+    auto sysId = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // begin=1, scale=10, +10
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // begin=2, scale=20, +20
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // begin=3, scale=30, +30
+
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::TEST_REGISTER_SYSTEM_A>>(sysId);
+    ASSERT_NE(params, nullptr);
+    EXPECT_EQ(params->beginCount_, 3) << "beginTick fired once per pipeline execution";
+    EXPECT_EQ(params->endCount_, 3) << "endTick fired once per pipeline execution";
+    EXPECT_EQ(params->tickCount_, 3) << "per-entity tick fired once per execution per entity";
+
+    // beginCount_ accumulated 1+2+3=6 in the field; scaleFromBegin_ = 10*beginCount_ each tick.
+    // ValueA.n_ accumulated 10 + 20 + 30 = 60.
+    EXPECT_EQ(IREntity::getComponent<ValueA>(idA).n_, 60);
+}
+
+TEST_F(RegisterSystemTest, BeginAndEndFireWithZeroEntities) {
+    auto sysId = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::TEST_REGISTER_SYSTEM_A>>(sysId);
+    ASSERT_NE(params, nullptr);
+    EXPECT_EQ(params->beginCount_, 1);
+    EXPECT_EQ(params->endCount_, 1);
+    EXPECT_EQ(params->tickCount_, 0);
+}
+
+TEST_F(RegisterSystemTest, DistinctSystemsHaveIndependentParams) {
+    IREntity::createEntity(ValueA{0});
+    IREntity::createEntity(ValueB{0});
+
+    auto sysA = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
+    auto sysB = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_B>();
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysA, sysB});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    auto *paramsA =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::TEST_REGISTER_SYSTEM_A>>(sysA);
+    auto *paramsB =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::TEST_REGISTER_SYSTEM_B>>(sysB);
+    ASSERT_NE(paramsA, nullptr);
+    ASSERT_NE(paramsB, nullptr);
+    EXPECT_EQ(paramsA->beginCount_, 2);
+    EXPECT_EQ(paramsB->hits_, 2);
+}
+
+TEST_F(RegisterSystemTest, ParamsAccessibleAfterCreate) {
+    auto sysId = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
+    auto *params =
+        m_system_manager.getSystemParams<IRSystem::System<IRSystem::TEST_REGISTER_SYSTEM_A>>(sysId);
+    ASSERT_NE(params, nullptr) << "registerSystem must populate the params slot";
+    EXPECT_EQ(params->beginCount_, 0);
+    EXPECT_EQ(params->scaleFromBegin_, 0);
+}
+
+} // namespace

--- a/test/system/register_system_test.cpp
+++ b/test/system/register_system_test.cpp
@@ -7,10 +7,10 @@
 
 namespace {
 
-struct ValueA {
+struct C_ValueA {
     int n_ = 0;
 };
-struct ValueB {
+struct C_ValueB {
     int m_ = 0;
 };
 
@@ -34,7 +34,7 @@ template <> struct System<TEST_REGISTER_SYSTEM_A> {
         scaleFromBegin_ = beginCount_ * 10;
     }
 
-    void tick(ValueA &v) {
+    void tick(C_ValueA &v) {
         tickCount_++;
         v.n_ += scaleFromBegin_;
     }
@@ -44,24 +44,23 @@ template <> struct System<TEST_REGISTER_SYSTEM_A> {
     }
 
     static SystemId create() {
-        return registerSystem<TEST_REGISTER_SYSTEM_A, ValueA>("RegisterSystemTestA");
+        return registerSystem<TEST_REGISTER_SYSTEM_A, C_ValueA>("RegisterSystemTestA");
     }
 };
 
 // Second specialization to exercise per-instance state separation —
-// the same SystemName cannot be registered twice (the params slot is
-// per SystemId), but two distinct System<NAME>s should each own their
-// own params instance with no cross-talk.
+// two distinct System<N> specializations own independent params instances
+// with no cross-talk between different SystemName types.
 template <> struct System<TEST_REGISTER_SYSTEM_B> {
     int hits_ = 0;
 
-    void tick(ValueB &v) {
+    void tick(C_ValueB &v) {
         hits_++;
         v.m_ += 1;
     }
 
     static SystemId create() {
-        return registerSystem<TEST_REGISTER_SYSTEM_B, ValueB>("RegisterSystemTestB");
+        return registerSystem<TEST_REGISTER_SYSTEM_B, C_ValueB>("RegisterSystemTestB");
     }
 };
 
@@ -80,20 +79,20 @@ class RegisterSystemTest : public testing::Test {
 };
 
 TEST_F(RegisterSystemTest, MemberTickFiresPerEntity) {
-    auto idA = IREntity::createEntity(ValueA{0});
-    auto idB = IREntity::createEntity(ValueA{0});
+    auto idA = IREntity::createEntity(C_ValueA{0});
+    auto idB = IREntity::createEntity(C_ValueA{0});
 
     auto sysId = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
     m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
     m_system_manager.executePipeline(IRTime::Events::UPDATE);
 
-    // beginTick set scaleFromBegin_ = 10; tick added 10 to each ValueA.
-    EXPECT_EQ(IREntity::getComponent<ValueA>(idA).n_, 10);
-    EXPECT_EQ(IREntity::getComponent<ValueA>(idB).n_, 10);
+    // beginTick set scaleFromBegin_ = 10; tick added 10 to each C_ValueA.
+    EXPECT_EQ(IREntity::getComponent<C_ValueA>(idA).n_, 10);
+    EXPECT_EQ(IREntity::getComponent<C_ValueA>(idB).n_, 10);
 }
 
 TEST_F(RegisterSystemTest, MemberFieldsPersistAcrossTicks) {
-    auto idA = IREntity::createEntity(ValueA{0});
+    auto idA = IREntity::createEntity(C_ValueA{0});
 
     auto sysId = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
     m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
@@ -109,9 +108,8 @@ TEST_F(RegisterSystemTest, MemberFieldsPersistAcrossTicks) {
     EXPECT_EQ(params->endCount_, 3) << "endTick fired once per pipeline execution";
     EXPECT_EQ(params->tickCount_, 3) << "per-entity tick fired once per execution per entity";
 
-    // beginCount_ accumulated 1+2+3=6 in the field; scaleFromBegin_ = 10*beginCount_ each tick.
-    // ValueA.n_ accumulated 10 + 20 + 30 = 60.
-    EXPECT_EQ(IREntity::getComponent<ValueA>(idA).n_, 60);
+    // scaleFromBegin_ was 10, 20, 30 on executions 1-3; C_ValueA.n_ accumulated 10+20+30=60.
+    EXPECT_EQ(IREntity::getComponent<C_ValueA>(idA).n_, 60);
 }
 
 TEST_F(RegisterSystemTest, BeginAndEndFireWithZeroEntities) {
@@ -128,8 +126,8 @@ TEST_F(RegisterSystemTest, BeginAndEndFireWithZeroEntities) {
 }
 
 TEST_F(RegisterSystemTest, DistinctSystemsHaveIndependentParams) {
-    IREntity::createEntity(ValueA{0});
-    IREntity::createEntity(ValueB{0});
+    IREntity::createEntity(C_ValueA{0});
+    IREntity::createEntity(C_ValueB{0});
 
     auto sysA = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_A>();
     auto sysB = IRSystem::createSystem<IRSystem::TEST_REGISTER_SYSTEM_B>();


### PR DESCRIPTION
## Summary

Adds `IRSystem::registerSystem<SystemName, Components...>(name, relationParams = {})` to `engine/system/include/irreden/ir_system.hpp`, allowing system-owned state to live as **member fields on the `System<NAME>` specialization** itself, with `tick`/`beginTick`/`endTick`/`relationTick` as named member functions instead of explicit `Params` + lambda captures + `setSystemParams` boilerplate.

This is **PR 1 of #580**: helper + docs + test. Per-system migrations from the explicit pattern to the member-on-`System<N>` shape follow as separate small PRs.

## What lands

- `engine/system/include/irreden/ir_system.hpp` — `registerSystem<N, Cs...>` + `IRSystem::detail::HasBeginTickMember` / `HasEndTickMember` / `HasRelationTickMember` / `MakeMemberTickFn` for compile-time hook detection. `Components...` accepts the same `Exclude<...>` markers as `createSystem`. Three accepted tick signatures (per-component, per-entity-id, per-archetype batch) are detected automatically; missing required tick = `static_assert`. Optional hooks (`beginTick`/`endTick`/`relationTick`) are wired only when defined.
- `engine/system/include/irreden/system/ir_system_types.hpp` — `TEST_REGISTER_SYSTEM_A` / `TEST_REGISTER_SYSTEM_B` enum values reserved for the test specializations (so the test can call `registerSystem<TEST_REGISTER_SYSTEM_A, ...>` against a real `System<N>` specialization).
- `test/system/register_system_test.cpp` (new) — 5 cases:
  - `MemberTickFiresPerEntity` — verifies the per-component tick form drives the right entities
  - `MemberFieldsPersistAcrossTicks` — member field state persists across ticks AND `beginTick`/`endTick` fire once per pipeline execution
  - `BeginAndEndFireWithZeroEntities` — empty-archetype contract preserved
  - `DistinctSystemsHaveIndependentParams` — two `System<N>`s have separate instances, no cross-talk
  - `ParamsAccessibleAfterCreate` — `getSystemParams<System<N>>(id)` returns the instance pointer for diagnostic / test reach-in
- `engine/system/CLAUDE.md` — "Per-system parameters" rewritten with two forms: preferred (member-on-`System<N>` via `registerSystem`) and explicit escape hatch (`Params` + `setSystemParams`). Same lifetime, same per-tick cost; new systems default to the helper.
- `engine/CLAUDE.md` — adds a "System-owned state lives on `System<N>` itself" section pointing at `engine/system/CLAUDE.md`.
- `engine/prefabs/CLAUDE.md` — both the Hard rules summary and the Anti-patterns entry now mention both forms.
- `.claude/rules/cpp-systems.md` — auto-loaded rule for system files updated to lead with the member-on-`System<N>` form.

## Why now (not deferred)

The explicit `Params + setSystemParams` pattern was the right escape from function-local `static`, but every consumer pays five lines of boilerplate to work around the constructor-order constraint. The longer the explicit pattern is the documented canonical form, the more new systems ship in that shape and the bigger the eventual rewrite. Landing the helper first keeps the migration tractable; the migration PRs are pure 1:1 refactors with no behavior change.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` clean (Linux/WSL2 path identical; built locally on macOS for this PR)
- [x] `fleet-build --target IRShapeDebug` clean (sanity: helper doesn't perturb existing TUs even though no system uses it yet)
- [x] `IrredenEngineTest` runs clean — 465/465 tests pass; new `RegisterSystemTest` 5/5 green
- [ ] Linux smoke (cross-host) — header-only template helper, no shader or backend touch, but flagged via `fleet:needs-linux-smoke` if the reviewer wants confirmation

## Notes for reviewer

- The helper is header-only template metaprogramming; runtime behavior of every existing system is unchanged (no callsite touched). The migration impact lives in PR 2+.
- `static_assert(false, "...")` in the discarded if-constexpr branch follows the existing pattern in `engine/system/include/irreden/system/system_manager.hpp:284`.
- Acceptance criterion 6 ("no frame-time regression on `IRShapeDebug`") is N/A for PR 1 — no migrations means no perf surface to compare. Will verify on the first migration PR.
- Acceptance criterion 4 (deviations file rename) is also N/A for PR 1 — there are no holdouts to track until migrations begin. Queue-manager-owned anyway.

Closes (none directly — issue #580 stays open across PRs 1..N).

🤖 Generated with [Claude Code](https://claude.com/claude-code)