### PR TITLE
T-138: fleet-claim: atomic master-side TASKS.md lock

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -33,6 +33,34 @@ This repo runs a parallel-agent workflow. The rules:
 See `TASKS.md` for the current queue and `.claude/skills/` for the exact
 commit/PR/review flows.
 
+### How `fleet-claim` enforces single-claim atomicity
+
+Picking a task is two-step: a local FS lock (per-host atomic via
+`mkdir(2)` under `~/.fleet/claims/<slug>/`) and a master-side TASKS.md
+push that flips `[ ] → [~]` and writes `Owner:` on `origin/master`.
+The master push is pure git plumbing (`hash-object` + `mktree` +
+`commit-tree` + `push`) — no working-tree mutation in the agent's
+worktree. Together they catch:
+
+- **Same-host races** — the FS lock wins atomically; the loser never
+  reaches the master push.
+- **Cross-host races** — both win their FS lock; their master pushes
+  race, and the loser's `git push` returns non-fast-forward. After
+  re-fetching, the loser sees `[~]` set by the winner and aborts with
+  exit 1 ("race lost on master push"), rolling back its FS claim.
+
+Once the worker opens its PR, `fleet-tasks-render` re-derives Owner
+from the PR's `headRefName`. In the no-PR window between
+`fleet-claim claim` and `gh pr create` the renderer preserves `[~]`
+by reading the FS claim directly — so a queue-tick that fires in
+that gap does not clobber the master-push. When `check-stale` prunes
+an abandoned claim the next renderer run reverts `[~]` to `[ ]`
+naturally.
+
+`FLEET_CLAIM_NO_MASTER_LOCK=1` skips the master push entirely
+(used by tests and bootstrap-without-network flows). Cross-host
+race resolution degrades to FS-lock-only when set.
+
 ### Cursor flow (human-in-the-loop)
 
 The rules above describe the fleet workflow. When working with the

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -46,6 +46,34 @@ RESERVATIONS_DIR="${FLEET_RESERVATIONS_DIR:-$HOME/.fleet/reservations}"
 FLEET_ENGINE_ROOT="${FLEET_ENGINE_ROOT:-$HOME/src/IrredenEngine}"
 FLEET_GITHUB_REPO="${FLEET_GITHUB_REPO:-jakildev/IrredenEngine}"
 
+# --- master-side TASKS.md lock (T-138) ------------------------------------
+#
+# Beyond the local FS lock, claim/stack push a one-line TASKS.md update to
+# `origin/master` so a polling worker on any host (or a worker that sees
+# only origin/master/TASKS.md) can no longer mistake a claimed task for
+# free. The push uses pure git plumbing (hash-object + mktree +
+# commit-tree + push) — no working-tree mutation in the agent's worktree.
+#
+# Race resolution:
+#   - Two same-host workers race on the FS mkdir lock first; the loser
+#     never reaches master_lock_task.
+#   - Two cross-host workers (or workers whose FS claim layouts diverge)
+#     each win their FS lock; their master pushes race. One push lands
+#     fast-forward; the other detects non-FF, refetches, sees [~] already
+#     set, and aborts with "race lost on master push" — its FS claim is
+#     rolled back.
+#
+# Stranded [~] recovery:
+#   fleet-tasks-render preserves [~] when an active FS claim exists, so
+#   queue-tick won't immediately revert. When `fleet-claim check-stale`
+#   removes a stale FS claim, the next queue-tick re-derives without the
+#   FS-claim signal and reverts [~] → [ ]. No new metadata in TASKS.md.
+#
+# Opt-out:
+#   Set FLEET_CLAIM_NO_MASTER_LOCK=1 to skip the master push. Used by
+#   tests and any bootstrap scenario where origin is unreachable.
+#   `cmd_claim` falls back to FS-lock-only behavior with a stderr note.
+
 # --- claim sidecar layout --------------------------------------------------
 #
 # Each claim is the directory $CLAIMS_DIR/<slug>/ (atomic mkdir-as-lock).
@@ -356,6 +384,308 @@ sys.exit(0)
 PYEOF
 }
 
+# --- master-side TASKS.md push helpers ------------------------------------
+
+master_lock_task() {
+    # Push a TASKS.md status update to origin/master via pure git plumbing.
+    # $1 = action ("lock" → flip [ ] → [~]; "unlock" → flip [~] → [ ])
+    # $2 = task ID (T-NNN)
+    # $3 = owner string ("opus-worker-1", "free", etc.)
+    #
+    # Exit codes:
+    #   0 — push succeeded (or no-op: row already in target state)
+    #   1 — race lost (TASKS.md shows the task in a state that means
+    #       another agent already claimed/released it)
+    #   2 — task not found in TASKS.md, or origin unreachable, or
+    #       protected push was rejected for a non-race reason
+    #
+    # Skipped entirely when FLEET_CLAIM_NO_MASTER_LOCK=1 — exits 0 with
+    # a stderr note. Tests and bootstrap-without-network use this.
+    local action="$1"
+    local task_id="$2"
+    local owner="$3"
+
+    if [[ "${FLEET_CLAIM_NO_MASTER_LOCK:-0}" == "1" ]]; then
+        echo "fleet-claim: master-lock skipped (FLEET_CLAIM_NO_MASTER_LOCK=1)" >&2
+        return 0
+    fi
+
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [[ -z "$repo_root" || ! -f "$repo_root/TASKS.md" ]]; then
+        echo "fleet-claim: master-lock requires a git repo with TASKS.md (cwd: $(pwd))" >&2
+        return 2
+    fi
+
+    FLEET_REPO_ROOT="$repo_root" \
+    FLEET_LOCK_ACTION="$action" \
+    FLEET_LOCK_TASK_ID="$task_id" \
+    FLEET_LOCK_OWNER="$owner" \
+    python3 <<'PYEOF'
+import os, re, subprocess, sys
+
+repo = os.environ['FLEET_REPO_ROOT']
+action = os.environ['FLEET_LOCK_ACTION']
+task_id = os.environ['FLEET_LOCK_TASK_ID']
+owner = os.environ['FLEET_LOCK_OWNER']
+
+
+def run(args, **kw):
+    return subprocess.run(args, capture_output=True, text=True, **kw)
+
+
+def git(*args, check=False, **kw):
+    return run(['git', '-C', repo, *args], check=check, **kw)
+
+
+def fetch_master():
+    # Soft-fail when origin isn't configured or unreachable: the local
+    # FS lock alone is still a real lock for same-host races, so we
+    # warn and skip the master push rather than blocking the claim.
+    # Cross-host race resolution degrades silently in that env.
+    r = git('fetch', 'origin', 'master', '--quiet')
+    if r.returncode != 0:
+        sys.stderr.write(
+            "fleet-claim: master-lock skipped — fetch origin master failed "
+            f"(repo: {repo}). FS-lock-only mode.\n"
+        )
+        sys.exit(0)
+
+
+# Apply the [ ]/[~] flip + Owner update for $task_id. Returns
+# (new_content, decision) where decision is one of:
+#   'edited'    — row was modified, push needed
+#   'noop'      — row already in target state AND owned by $owner
+#                 (idempotent re-lock / same-agent re-unlock)
+#   'race-lost' — row state implies another agent already owns it
+#                 (or the task is done) — caller must roll back
+def edit_tasks_md(content, action, task_id, owner):
+    target_status = '~' if action == 'lock' else ' '
+    expect_status = ' ' if action == 'lock' else '~'
+
+    lines = content.splitlines(keepends=True)
+    out = []
+    found = False
+    decision = None
+
+    header_re = re.compile(r'^- \[([ ~x!])\] \*\*([^*]+)\*\*(.*)$')
+    field_re = re.compile(r'^(\s+)- \*\*([^:]+):\*\*\s*(.*?)\s*$')
+
+    n = len(lines)
+    i = 0
+    while i < n:
+        line = lines[i]
+        m = header_re.match(line.rstrip('\n'))
+        if not m:
+            out.append(line)
+            i += 1
+            continue
+
+        # Read the whole block (header + field lines until next header
+        # or section break).
+        status = m.group(1)
+        j = i + 1
+        block = [line]
+        block_id_local = None
+        block_owner = None
+        field_indices = {}
+        while j < n:
+            nxt = lines[j]
+            if header_re.match(nxt.rstrip('\n')):
+                break
+            if nxt.startswith('## '):
+                break
+            fm = field_re.match(nxt.rstrip('\n'))
+            if fm:
+                key = fm.group(2).strip().lower()
+                field_indices[key] = len(block)
+                if key == 'id':
+                    block_id_local = fm.group(3).strip()
+                if key == 'owner':
+                    block_owner = fm.group(3).strip()
+            block.append(nxt)
+            j += 1
+
+        if block_id_local == task_id:
+            found = True
+            if status == target_status:
+                # Already in the target state. Whether that's a benign
+                # noop or a race-lost depends on Owner:
+                #   lock:   target=[~]. If Owner is us → noop (idempotent
+                #           re-lock). If Owner is someone else → race-lost.
+                #   unlock: target=[ ]. Already free; treat as noop
+                #           regardless of Owner (someone else may have
+                #           released first; nothing to do).
+                if action == 'lock':
+                    if (block_owner or 'free') == owner:
+                        decision = 'noop'
+                    else:
+                        decision = 'race-lost'
+                else:
+                    decision = 'noop'
+            elif status != expect_status:
+                # Wrong starting state — task may be [x] (done) or in some
+                # other terminal state. Don't try to overwrite.
+                decision = 'race-lost'
+            elif action == 'unlock' and (block_owner or 'free') != owner and owner != 'free':
+                # Sanity check: we're trying to release someone else's
+                # lock. Refuse — leave the row alone. (The free-target
+                # branch above already handles "owner==free" correctly.)
+                decision = 'race-lost'
+            else:
+                decision = 'edited'
+                new_header = re.sub(
+                    r'^(- \[)[ ~x!](\])',
+                    lambda mm: mm.group(1) + target_status + mm.group(2),
+                    block[0],
+                    count=1,
+                )
+                block[0] = new_header
+                if 'owner' in field_indices:
+                    idx = field_indices['owner']
+                    block[idx] = re.sub(
+                        r'^(\s+- \*\*Owner:\*\*\s*).*$',
+                        lambda mm: mm.group(1) + owner,
+                        block[idx].rstrip('\n'),
+                        count=1,
+                    ) + '\n'
+            out.extend(block)
+            i = j
+            continue
+
+        out.extend(block)
+        i = j
+
+    if not found:
+        return None, 'not-found'
+
+    return ''.join(out), decision
+
+
+fetch_master()
+
+for attempt in range(1, 4):
+    cur_master = git('rev-parse', 'origin/master').stdout.strip()
+    if not cur_master:
+        sys.stderr.write("fleet-claim: could not resolve origin/master\n")
+        sys.exit(2)
+
+    show = git('show', f'{cur_master}:TASKS.md')
+    if show.returncode != 0:
+        sys.stderr.write(f"fleet-claim: read TASKS.md from origin/master: {show.stderr}")
+        sys.exit(2)
+    content = show.stdout
+
+    new_content, decision = edit_tasks_md(content, action, task_id, owner)
+
+    if decision == 'not-found':
+        sys.stderr.write(f"fleet-claim: {task_id} not found in master/TASKS.md\n")
+        sys.exit(2)
+
+    if decision == 'noop':
+        sys.exit(0)
+
+    if decision == 'race-lost':
+        sys.stderr.write(
+            f"fleet-claim: {task_id} on master is not in expected state "
+            f"({'[ ]' if action == 'lock' else '[~]'}) — race lost\n"
+        )
+        sys.exit(1)
+
+    # Hash the new TASKS.md as a blob.
+    hp = subprocess.run(
+        ['git', '-C', repo, 'hash-object', '-w', '--stdin'],
+        input=new_content, capture_output=True, text=True,
+    )
+    if hp.returncode != 0:
+        sys.stderr.write(f"fleet-claim: hash-object failed: {hp.stderr}")
+        sys.exit(2)
+    new_blob = hp.stdout.strip()
+
+    # Read the master tree top-level entries; replace TASKS.md's blob.
+    ls = git('ls-tree', cur_master)
+    if ls.returncode != 0:
+        sys.stderr.write(f"fleet-claim: ls-tree failed: {ls.stderr}")
+        sys.exit(2)
+    new_tree_lines = []
+    seen_tasks_md = False
+    for line in ls.stdout.splitlines():
+        m = re.match(r'^(\S+) (\S+) (\S+)\t(.+)$', line)
+        if not m:
+            continue
+        mode, otype, sha, name = m.group(1), m.group(2), m.group(3), m.group(4)
+        if name == 'TASKS.md':
+            new_tree_lines.append(f'{mode} {otype} {new_blob}\t{name}')
+            seen_tasks_md = True
+        else:
+            new_tree_lines.append(line)
+    if not seen_tasks_md:
+        sys.stderr.write("fleet-claim: TASKS.md not found in origin/master tree\n")
+        sys.exit(2)
+
+    mt = subprocess.run(
+        ['git', '-C', repo, 'mktree'],
+        input='\n'.join(new_tree_lines) + '\n',
+        capture_output=True, text=True,
+    )
+    if mt.returncode != 0:
+        sys.stderr.write(f"fleet-claim: mktree failed: {mt.stderr}")
+        sys.exit(2)
+    new_tree = mt.stdout.strip()
+
+    msg_verb = 'claim' if action == 'lock' else 'release'
+    commit_msg = f"queue: {msg_verb} {task_id} ({owner})"
+
+    env = os.environ.copy()
+    # Use the user's git identity for the commit; fall back to a fleet
+    # identity if not configured (CI / fresh test env).
+    cfg_email = git('config', 'user.email').stdout.strip()
+    cfg_name = git('config', 'user.name').stdout.strip()
+    env.setdefault('GIT_AUTHOR_NAME', cfg_name or 'fleet-claim')
+    env.setdefault('GIT_AUTHOR_EMAIL', cfg_email or 'fleet-claim@local')
+    env.setdefault('GIT_COMMITTER_NAME', cfg_name or 'fleet-claim')
+    env.setdefault('GIT_COMMITTER_EMAIL', cfg_email or 'fleet-claim@local')
+
+    ct = subprocess.run(
+        ['git', '-C', repo, 'commit-tree', new_tree, '-p', cur_master, '-m', commit_msg],
+        capture_output=True, text=True, env=env,
+    )
+    if ct.returncode != 0:
+        sys.stderr.write(f"fleet-claim: commit-tree failed: {ct.stderr}")
+        sys.exit(2)
+    new_commit = ct.stdout.strip()
+
+    push = subprocess.run(
+        ['git', '-C', repo, 'push', 'origin', f'{new_commit}:refs/heads/master'],
+        capture_output=True, text=True,
+    )
+    if push.returncode == 0:
+        # Update local origin/master ref so subsequent reads see our push.
+        # Skip silently if the update-ref fails — the remote is the source
+        # of truth either way and the next fetch will catch up.
+        subprocess.run(
+            ['git', '-C', repo, 'update-ref', 'refs/remotes/origin/master', new_commit],
+            capture_output=True,
+        )
+        sys.exit(0)
+
+    err = (push.stderr or push.stdout).lower()
+    if ('non-fast-forward' in err or 'fetch first' in err
+            or 'rejected' in err and 'fetch' in err):
+        # Refetch and retry — another push won the race; we re-read and
+        # check whether the row is already in our target state.
+        fetch_master()
+        continue
+
+    sys.stderr.write(f"fleet-claim: push origin master failed: {push.stderr}")
+    sys.exit(2)
+
+# Out of retries. Treat as race lost — the row may now be [~] or [x].
+sys.stderr.write(f"fleet-claim: {task_id} master-lock retries exhausted; race lost\n")
+sys.exit(1)
+PYEOF
+}
+
 # --- subcommands ----------------------------------------------------------
 
 cmd_claim() {
@@ -468,6 +798,24 @@ cmd_claim() {
         echo "$agent" > "$CLAIMS_DIR/$slug/owner"
         echo "$task_id" > "$CLAIMS_DIR/$slug/title"
         date +%s     > "$CLAIMS_DIR/$slug/created"
+
+        # Master-side TASKS.md push (T-138). Cross-host race resolution:
+        # if another agent already pushed [~] for this task while we were
+        # acquiring the FS lock, master_lock_task returns 1 — we roll
+        # back the FS claim so it doesn't shadow the real owner. Soft
+        # failures (origin unreachable, malformed TASKS.md) abort with
+        # the same rollback; the task should be re-attempted on the
+        # next iteration once origin is reachable again.
+        local lock_rc=0
+        master_lock_task lock "$task_id" "$agent" || lock_rc=$?
+        if [[ $lock_rc -ne 0 ]]; then
+            __remove_claim "$slug"
+            if [[ $lock_rc -eq 1 ]]; then
+                echo "fleet-claim claim: $task_id master-lock race lost — another agent already claimed on origin/master" >&2
+            fi
+            return 1
+        fi
+
         if [[ -n "$stackable_branch" ]]; then
             echo "stackable_base_branch=$stackable_branch" > "$CLAIMS_DIR/${slug}.meta"
             echo "claimed: $task_id (slug: $slug, agent: $agent, base: $stackable_branch)"
@@ -646,6 +994,120 @@ if not url or not head:
     sys.exit(0)
 print(f"{url}\t{head}\t{author}\t{number}")
 PYEOF
+}
+
+cmd_reclaim() {
+    # Manual recovery for a stranded `[~]` row whose Owner branch no
+    # longer exists on the remote (the worker died between the master
+    # push and the feature-branch push). Resets master to `[ ]`+free
+    # and drops any matching local FS claim. Called by humans /
+    # cleanup tools; auto-recovery via check-stale + the FS-claim
+    # signal in fleet-tasks-render handles the typical case.
+    #
+    # Usage: fleet-claim reclaim <task-id>
+    # Exit 0 — reclaimed (or row was already [ ]/[x]; nothing to do)
+    # Exit 1 — Owner branch IS reachable; refusing to clobber an
+    #          actively-held lock.
+    # Exit 2 — origin unreachable, malformed TASKS.md, etc.
+    local task_id="$1"
+    if [[ -z "$task_id" ]]; then
+        echo "usage: fleet-claim reclaim <task-id>" >&2
+        return 2
+    fi
+
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [[ -z "$repo_root" || ! -f "$repo_root/TASKS.md" ]]; then
+        echo "fleet-claim reclaim: requires a git repo with TASKS.md" >&2
+        return 2
+    fi
+
+    if ! git -C "$repo_root" fetch origin master --quiet; then
+        echo "fleet-claim reclaim: fetch origin master failed" >&2
+        return 2
+    fi
+
+    # Read row state + Owner branch from master. The helper reads
+    # FLEET_RECLAIM_TASKS_MD from the env to avoid a broken-pipe
+    # interaction with `git show | python3` under `set -e + pipefail`
+    # (python's early sys.exit() closes the pipe; git's SIGPIPE then
+    # propagates to a non-zero command-substitution status).
+    local tasks_md_content
+    if ! tasks_md_content=$(git -C "$repo_root" show "origin/master:TASKS.md" 2>/dev/null); then
+        echo "fleet-claim reclaim: read TASKS.md from origin/master failed" >&2
+        return 2
+    fi
+    local owner_branch
+    owner_branch=$(FLEET_RECLAIM_TASKS_MD="$tasks_md_content" python3 - "$task_id" <<'PYEOF'
+import os, re, sys
+task_id = sys.argv[1]
+content = os.environ.get('FLEET_RECLAIM_TASKS_MD', '')
+block_status = None
+block_id = None
+block_owner = None
+header_re = re.compile(r'^- \[([ ~x!])\] \*\*([^*]+)\*\*')
+field_re = re.compile(r'^\s+- \*\*([^:]+):\*\*\s*(.*?)\s*$')
+for line in content.splitlines():
+    m = header_re.match(line)
+    if m:
+        if block_id == task_id:
+            print(f"{block_status}\t{block_owner or 'free'}")
+            sys.exit(0)
+        block_status = m.group(1)
+        block_id = None
+        block_owner = None
+        continue
+    fm = field_re.match(line)
+    if fm:
+        key = fm.group(1).strip().lower()
+        if key == 'id':
+            block_id = fm.group(2).strip()
+        elif key == 'owner':
+            block_owner = fm.group(2).strip()
+if block_id == task_id:
+    print(f"{block_status}\t{block_owner or 'free'}")
+PYEOF
+    )
+
+    if [[ -z "$owner_branch" ]]; then
+        echo "fleet-claim reclaim: $task_id not found in master/TASKS.md" >&2
+        return 2
+    fi
+
+    local status="${owner_branch%%	*}"
+    local owner="${owner_branch#*	}"
+
+    if [[ "$status" != "~" ]]; then
+        echo "fleet-claim reclaim: $task_id is not in [~] state (status: [$status]) — nothing to reclaim"
+        return 0
+    fi
+
+    # If the Owner field looks like a branch name (claude/T-NNN-…),
+    # check whether the branch actually exists on origin. If yes,
+    # someone is actively holding the lock — refuse to clobber.
+    # If the Owner is just a worktree name (opus-worker-1) or "free",
+    # the worker died before the PR opened, so reclaim is safe.
+    if [[ "$owner" == claude/* ]]; then
+        if git -C "$repo_root" ls-remote --exit-code origin "refs/heads/$owner" >/dev/null 2>&1; then
+            echo "fleet-claim reclaim: $task_id Owner branch '$owner' still exists on origin — refusing to clobber" >&2
+            return 1
+        fi
+    fi
+
+    # Push [~]+owner → [ ]+free. Use master_lock_task with action=unlock,
+    # passing the current owner so the in-helper sanity check accepts
+    # the transition (we own this revert because no live branch claims it).
+    local rc=0
+    master_lock_task unlock "$task_id" "$owner" || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "fleet-claim reclaim: master push failed (rc=$rc)" >&2
+        return $rc
+    fi
+
+    # Drop any matching local FS claim. cmd_release is idempotent.
+    cmd_release "$task_id" >/dev/null 2>&1 || true
+
+    echo "reclaimed: $task_id (was [~]+$owner on master)"
 }
 
 cmd_release() {
@@ -954,8 +1416,11 @@ cmd_stack() {
         # skip_ids so intra-stack dependencies don't block the claim.
         if ! check_blockers "$task_id" "" "$earlier_in_stack"; then
             echo "fleet-claim stack: $task_id has unresolved blockers" >&2
-            # Roll back
+            # Roll back FS claims AND any master-side [~] pushes for the
+            # tasks earlier in this stack — leaving them on master would
+            # let the next iteration see the chain as half-claimed.
             for prev in "${claimed[@]}"; do
+                master_lock_task unlock "$prev" "free" >/dev/null 2>&1 || true
                 cmd_release "$prev"
             done
             return 1
@@ -969,6 +1434,7 @@ cmd_stack() {
         if [[ -n "$reserved_worktree" && "$reserved_worktree" != "$agent" ]]; then
             echo "fleet-claim stack: $task_id is reserved for $reserved_worktree (refusing claim by $agent) — rolling back" >&2
             for prev in "${claimed[@]}"; do
+                master_lock_task unlock "$prev" "free" >/dev/null 2>&1 || true
                 cmd_release "$prev"
             done
             return 1
@@ -979,6 +1445,25 @@ cmd_stack() {
             echo "$task_id" > "$CLAIMS_DIR/$slug/title"
             date +%s     > "$CLAIMS_DIR/$slug/created"
             echo "stack" > "$CLAIMS_DIR/$slug/stack"
+
+            # Master-side TASKS.md push (T-138). Same rollback discipline
+            # as cmd_claim: lose the master race → release THIS slug AND
+            # all earlier stack entries (FS + master) so the chain ends
+            # in a clean state.
+            local lock_rc=0
+            master_lock_task lock "$task_id" "$agent" || lock_rc=$?
+            if [[ $lock_rc -ne 0 ]]; then
+                __remove_claim "$slug"
+                if [[ $lock_rc -eq 1 ]]; then
+                    echo "fleet-claim stack: $task_id master-lock race lost — rolling back" >&2
+                fi
+                for prev in "${claimed[@]}"; do
+                    master_lock_task unlock "$prev" "free" >/dev/null 2>&1 || true
+                    cmd_release "$prev"
+                done
+                return 1
+            fi
+
             claimed+=("$task_id")
         else
             local owner="unknown"
@@ -987,6 +1472,7 @@ cmd_stack() {
             fi
             echo "fleet-claim stack: $task_id already claimed by $owner — rolling back" >&2
             for prev in "${claimed[@]}"; do
+                master_lock_task unlock "$prev" "free" >/dev/null 2>&1 || true
                 cmd_release "$prev"
             done
             return 1
@@ -2124,6 +2610,13 @@ case "${1:-}" in
         fi
         cmd_release "$2"
         ;;
+    reclaim)
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-claim reclaim <task-id>" >&2
+            exit 2
+        fi
+        cmd_reclaim "$2"
+        ;;
     check)
         if [[ -z "${2:-}" ]]; then
             echo "usage: fleet-claim check \"<title>\"" >&2
@@ -2284,6 +2777,13 @@ global options (must come BEFORE the subcommand):
                                 Engine and game share T-NNN IDs; this keeps
                                 their lock dirs distinct. Omit for engine.
 
+environment:
+  FLEET_CLAIM_NO_MASTER_LOCK=1  skip the master-side TASKS.md push that
+                                claim/stack normally do (T-138). Used by
+                                tests and bootstrap scenarios where origin
+                                is unreachable. Cross-host race resolution
+                                degrades to FS-lock-only when set.
+
 commands:
   claim "<title>" [agent] [--stackable-on <pr-url>]
                                 claim a task (exit 0=claimed, 1=taken).
@@ -2310,6 +2810,14 @@ commands:
                                 etc.) — callers treat as a hint.
   release "<title>"             release a claim (also clears the
                                 --stackable-on .meta sidecar).
+  reclaim <task-id>             manually unstick a [~] row whose Owner
+                                branch no longer exists on origin (the
+                                worker died between master push and PR
+                                open). Pushes [~] → [ ]+free. Refuses
+                                if the Owner branch IS on origin
+                                (someone holds the lock). check-stale
+                                + the FS-claim signal handle the
+                                typical case automatically.
   check "<title>"               check if free (exit 0=free, 1=taken)
   list                          list all active claims
   stack "T-1 T-2 ..." [agent]  atomically claim a dependency chain (all-or-nothing)
@@ -2381,6 +2889,20 @@ Dependency gate:
   URLs), the claim is refused. The cwd's git repo determines which
   TASKS.md is consulted — `cd` into the right worktree before claiming
   cross-repo tasks.
+
+Master-side TASKS.md lock (T-138):
+  After acquiring the local FS lock, claim/stack push a one-line
+  TASKS.md update to origin/master via pure git plumbing
+  (hash-object + mktree + commit-tree + push). The row is flipped from
+  [ ] to [~] and Owner is set to the agent name. This closes the
+  cross-host race window where a polling worker on another machine
+  reads origin/master/TASKS.md and sees a claimed task as still free.
+  Race semantics: a non-fast-forward push (someone else's claim landed
+  first) triggers a fetch + retry; if the row is now [~] from another
+  agent the FS lock is rolled back and the claim returns 1 ("race
+  lost on master push"). fleet-tasks-render preserves [~] in the
+  no-PR window via the same FS claim signal — when check-stale
+  prunes an abandoned claim the next render naturally reverts [~].
 
 Stack claiming:
   stack claims a chain of tasks atomically. If any task is already claimed

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1095,10 +1095,11 @@ PYEOF
     fi
 
     # Push [~]+owner → [ ]+free. Use master_lock_task with action=unlock,
-    # passing the current owner so the in-helper sanity check accepts
-    # the transition (we own this revert because no live branch claims it).
+    # passing "free" so the Owner field is reset correctly. The sanity
+    # check's `owner != 'free'` clause is also bypassed by "free", so
+    # this is both correct and accepted by the helper.
     local rc=0
-    master_lock_task unlock "$task_id" "$owner" || rc=$?
+    master_lock_task unlock "$task_id" "free" || rc=$?
     if [[ $rc -ne 0 ]]; then
         echo "fleet-claim reclaim: master push failed (rc=$rc)" >&2
         return $rc

--- a/scripts/fleet/fleet-tasks-render
+++ b/scripts/fleet/fleet-tasks-render
@@ -354,10 +354,75 @@ def pick_pr(prs: list[dict]) -> Optional[dict]:
     return None
 
 
-def derive_status(task_id: str, by_id: dict[str, list[dict]]) -> tuple[str, str, Optional[dict]]:
+def load_fs_claims(repo_key: str) -> set[str]:
+    """Return the set of task IDs that have an active fleet-claim FS lock.
+
+    Filters by the slug's namespace prefix so engine renders ignore game
+    claims and vice-versa. Engine slugs lack a prefix; game slugs are
+    `game-...`. The directory is read defensively — a malformed or
+    missing entry contributes nothing rather than aborting the render.
+
+    Used by `derive_status` to preserve [~] in the no-PR window between
+    `fleet-claim claim` (T-138 master-push) and the worker's first
+    `gh pr create`. Without this, the next queue-tick after the master
+    push would clobber [~] back to [ ] before the worker had a chance
+    to open the PR — the very race T-138 is meant to close.
+    """
+    claims_dir = pathlib.Path(
+        os.environ.get(
+            "FLEET_CLAIMS_DIR",
+            str(pathlib.Path.home() / ".fleet" / "claims"),
+        )
+    )
+    if not claims_dir.is_dir():
+        return set()
+    out: set[str] = set()
+    for entry in sorted(claims_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        slug = entry.name
+        # Stack metadata (`_stack_<agent>/`) is bookkeeping, not a claim.
+        if slug.startswith("_stack_"):
+            continue
+        if repo_key == "engine" and slug.startswith("game-"):
+            continue
+        if repo_key == "game" and not slug.startswith("game-"):
+            continue
+        title_file = entry / "title"
+        if not title_file.is_file():
+            continue
+        try:
+            tid = title_file.read_text().strip()
+        except OSError:
+            continue
+        if TASK_ID_RE.match(tid):
+            out.add(tid)
+    return out
+
+
+def derive_status(
+    task_id: str,
+    by_id: dict[str, list[dict]],
+    fs_claims: Optional[set[str]] = None,
+    existing_status: Optional[str] = None,
+    existing_owner: Optional[str] = None,
+) -> tuple[str, str, Optional[dict]]:
     """Return (status_marker, owner_string, pr_or_None) for a task id."""
     pr = pick_pr(by_id.get(task_id, []))
     if pr is None:
+        # No PR found. Normally this means the task is open ([ ]/free).
+        # T-138 exception: if fleet-claim has just written [~] to master
+        # but the worker hasn't opened the PR yet, the FS claim is the
+        # only signal that the task is in-flight. Preserve [~] in that
+        # narrow window so this render doesn't overwrite the master-push
+        # we just made. `cmd_check_stale` later prunes abandoned FS
+        # claims; the next render after that reverts naturally to [ ].
+        if (
+            fs_claims
+            and task_id in fs_claims
+            and existing_status == "~"
+        ):
+            return "~", existing_owner or "free", None
         return " ", "free", None
     if pr.get("mergedAt") and pr.get("baseRefName") == "master":
         return "x", "free", pr  # owner irrelevant for merged
@@ -517,6 +582,10 @@ def render(
         if m:
             status_by_id.setdefault(m.group(1), "x")
 
+    # FS claims (T-138): preserves [~] in the no-PR window after
+    # fleet-claim's master-push and before the worker's PR is opened.
+    fs_claims = load_fs_claims(repo_key)
+
     # First pass: derive status for each task. Detect newly-merged
     # tasks so we can move them to Done.
     block_decisions: list[tuple[TaskBlock, str, str, Optional[dict]]] = []
@@ -525,7 +594,12 @@ def render(
         if tid is None:
             block_decisions.append((block, block.status, block.get_field("owner") or "free", None))
             continue
-        marker, owner, pr = derive_status(tid, by_id)
+        existing_owner = block.get_field("owner")
+        marker, owner, pr = derive_status(
+            tid, by_id, fs_claims=fs_claims,
+            existing_status=block.status,
+            existing_owner=existing_owner,
+        )
         status_by_id[tid] = marker
         block_decisions.append((block, marker, owner, pr))
 

--- a/scripts/fleet/tests/test_fleet_claim_master_lock.sh
+++ b/scripts/fleet/tests/test_fleet_claim_master_lock.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim's T-138 master-side TASKS.md lock.
+#
+# Covers:
+#   - master_lock_task pushes [~] + Owner to origin/master
+#   - concurrent claims: exactly one wins, the other rolls back FS lock
+#   - FLEET_CLAIM_NO_MASTER_LOCK=1 skips the master push
+#   - cmd_release does NOT re-push master (release is queue-tick's job)
+#   - cmd_stack atomicity: one bad task rolls back master pushes too
+#
+# Each test uses a fresh temp dir as a bare git "origin" + a working
+# clone. The agent's cwd is the working clone. fleet-claim's
+# `git rev-parse --show-toplevel` resolves to that clone, which is what
+# the master_lock_task helper uses for the push.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        wanted substring: $needle"
+        echo "        actual:           $haystack"
+    fi
+}
+
+# Build a bare origin + working clone with a TASKS.md containing two
+# free tasks. Reset between tests via `setup_fixture`.
+TMPROOT=$(mktemp -d)
+ORIGIN_BARE="$TMPROOT/origin.git"
+WORK="$TMPROOT/work"
+
+setup_fixture() {
+    rm -rf "$ORIGIN_BARE" "$WORK"
+    git init --bare --quiet "$ORIGIN_BARE"
+
+    local seed="$TMPROOT/seed"
+    rm -rf "$seed"
+    git init --quiet -b master "$seed"
+    (
+        cd "$seed"
+        git config user.email "test@test"
+        git config user.name "test"
+        git config commit.gpgsign false
+        cat >TASKS.md <<'TASKSEOF'
+# TASKS
+
+## Open
+
+- [ ] **Task A** — first task
+  - **ID:** T-901
+  - **Model:** opus
+  - **Owner:** free
+  - **Blocked by:** (none)
+
+- [ ] **Task B** — second task
+  - **ID:** T-902
+  - **Model:** opus
+  - **Owner:** free
+  - **Blocked by:** (none)
+TASKSEOF
+        git add TASKS.md
+        git commit --quiet --no-gpg-sign -m "init"
+        git remote add origin "$ORIGIN_BARE"
+        git push --quiet origin master
+    )
+
+    git clone --quiet "$ORIGIN_BARE" "$WORK"
+    git -C "$WORK" config user.email "test@test"
+    git -C "$WORK" config user.name "test"
+    git -C "$WORK" config commit.gpgsign false
+
+    # Per-test claim/reservation state.
+    rm -rf "$TMPROOT/claims" "$TMPROOT/reservations" "$TMPROOT/molecules"
+    mkdir -p "$TMPROOT/claims" "$TMPROOT/reservations" "$TMPROOT/molecules"
+}
+
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_MOLECULES_DIR="$TMPROOT/molecules"
+
+# Read TASKS.md from the bare origin's tip — what observers would see
+# after the master push. Avoids any working-tree-state confusion.
+read_origin_tasks_md() {
+    git -C "$ORIGIN_BARE" show "master:TASKS.md"
+}
+
+# --- Test 1: claim pushes [~]+Owner to origin/master ----------------------
+echo "T1: claim updates origin/master TASKS.md with [~] + Owner"
+setup_fixture
+(
+    cd "$WORK"
+    "$FLEET_CLAIM" claim "T-901" agent-A >/dev/null
+)
+master_md=$(read_origin_tasks_md)
+assert_contains "$master_md" "- [~] **Task A**" "T-901 status flipped to [~] on master"
+assert_contains "$master_md" "**Owner:** agent-A" "Owner field shows agent-A on master"
+assert_contains "$master_md" "- [ ] **Task B**" "Task B unaffected (still [ ])"
+# T-902's Owner stays "free"
+assert_contains "$master_md" "  - **Owner:** free" "Task B's Owner remains free"
+
+# --- Test 2: concurrent claims — exactly one wins -------------------------
+echo "T2: concurrent claims race — exactly one succeeds"
+setup_fixture
+# Two clones racing the same task. Each clone has its own claims dir
+# (mimics two different hosts / fleet roots), so the FS-lock alone
+# wouldn't catch them — only the master-push race resolution does.
+WORK_A="$TMPROOT/work-a"
+WORK_B="$TMPROOT/work-b"
+git clone --quiet "$ORIGIN_BARE" "$WORK_A"
+git clone --quiet "$ORIGIN_BARE" "$WORK_B"
+git -C "$WORK_A" config user.email "a@test"; git -C "$WORK_A" config user.name "a"
+git -C "$WORK_A" config commit.gpgsign false
+git -C "$WORK_B" config user.email "b@test"; git -C "$WORK_B" config user.name "b"
+git -C "$WORK_B" config commit.gpgsign false
+mkdir -p "$TMPROOT/claims-a" "$TMPROOT/claims-b" \
+         "$TMPROOT/resv-a" "$TMPROOT/resv-b"
+
+# Spawn both in background.
+(
+    cd "$WORK_A"
+    FLEET_CLAIMS_DIR="$TMPROOT/claims-a" \
+    FLEET_RESERVATIONS_DIR="$TMPROOT/resv-a" \
+    "$FLEET_CLAIM" claim "T-901" agent-A
+) >"$TMPROOT/out-a" 2>"$TMPROOT/err-a" &
+PID_A=$!
+(
+    cd "$WORK_B"
+    FLEET_CLAIMS_DIR="$TMPROOT/claims-b" \
+    FLEET_RESERVATIONS_DIR="$TMPROOT/resv-b" \
+    "$FLEET_CLAIM" claim "T-901" agent-B
+) >"$TMPROOT/out-b" 2>"$TMPROOT/err-b" &
+PID_B=$!
+
+set +e
+wait $PID_A; rc_a=$?
+wait $PID_B; rc_b=$?
+set -e
+
+# Exactly one should succeed (rc=0), the other should fail (rc=1).
+winners=$(( (rc_a == 0 ? 1 : 0) + (rc_b == 0 ? 1 : 0) ))
+assert_eq "$winners" "1" "exactly one of two concurrent claims wins"
+losers=$(( (rc_a == 1 ? 1 : 0) + (rc_b == 1 ? 1 : 0) ))
+assert_eq "$losers" "1" "exactly one of two concurrent claims loses with rc=1"
+
+# Master-side TASKS.md shows [~] with the winner's agent name.
+master_md=$(read_origin_tasks_md)
+assert_contains "$master_md" "- [~] **Task A**" "winner's [~] visible on master"
+if [[ $rc_a -eq 0 ]]; then
+    assert_contains "$master_md" "**Owner:** agent-A" "winner is agent-A; Owner reflects it"
+    # Loser (B) must NOT have an FS claim — the helper rolled it back.
+    if [[ -d "$TMPROOT/claims-b/t-901" ]]; then
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: loser (agent-B) FS claim was not rolled back"
+    else
+        PASS=$((PASS + 1))
+        echo "  ok: loser (agent-B) FS claim rolled back"
+    fi
+else
+    assert_contains "$master_md" "**Owner:** agent-B" "winner is agent-B; Owner reflects it"
+    if [[ -d "$TMPROOT/claims-a/t-901" ]]; then
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: loser (agent-A) FS claim was not rolled back"
+    else
+        PASS=$((PASS + 1))
+        echo "  ok: loser (agent-A) FS claim rolled back"
+    fi
+fi
+
+# --- Test 3: FLEET_CLAIM_NO_MASTER_LOCK=1 skips master push ---------------
+echo "T3: env var skips master push (legacy mode)"
+setup_fixture
+(
+    cd "$WORK"
+    FLEET_CLAIM_NO_MASTER_LOCK=1 \
+        "$FLEET_CLAIM" claim "T-902" agent-X >/dev/null
+)
+master_md=$(read_origin_tasks_md)
+# Task B should be untouched on master — only the FS claim was taken.
+assert_contains "$master_md" "- [ ] **Task B**" "T-902 master row unchanged with NO_MASTER_LOCK=1"
+if [[ -d "$TMPROOT/claims/t-902" ]]; then
+    PASS=$((PASS + 1))
+    echo "  ok: FS claim was taken (FS-lock-only fallback works)"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: FS claim missing — fallback didn't take the lock"
+fi
+
+# --- Test 4: re-claim by a different agent (with separate reservation dir)
+# returns race-lost via the master-lock path (not the reservation gate).
+echo "T4: re-claim of an already-[~] task fails cleanly via master-lock"
+setup_fixture
+(
+    cd "$WORK"
+    "$FLEET_CLAIM" claim "T-901" agent-A >/dev/null
+)
+# Another agent on its own FS-claims-dir AND its own reservations dir
+# (mimics a different host) tries to claim the same task. The
+# reservation gate doesn't see agent-A's binding, so the FS lock
+# succeeds — only master_lock_task can catch the race.
+mkdir -p "$TMPROOT/claims-2" "$TMPROOT/resv-2"
+set +e
+(
+    cd "$WORK"
+    FLEET_CLAIMS_DIR="$TMPROOT/claims-2" \
+    FLEET_RESERVATIONS_DIR="$TMPROOT/resv-2" \
+        "$FLEET_CLAIM" claim "T-901" agent-2 >"$TMPROOT/out-rc" 2>"$TMPROOT/err-rc"
+)
+rc=$?
+set -e
+assert_eq "$rc" "1" "second-agent re-claim returns 1 (race lost)"
+err_text=$(cat "$TMPROOT/err-rc")
+assert_contains "$err_text" "race lost" "stderr mentions race lost"
+# Master-side TASKS.md still owned by agent-A.
+master_md=$(read_origin_tasks_md)
+assert_contains "$master_md" "**Owner:** agent-A" "master Owner is still agent-A after losing race"
+# Loser's FS claim was rolled back.
+if [[ -d "$TMPROOT/claims-2/t-901" ]]; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: agent-2's FS claim was not rolled back"
+else
+    PASS=$((PASS + 1))
+    echo "  ok: agent-2's FS claim rolled back"
+fi
+
+# --- Test 5: stack claim — atomic master push + rollback on race-lost -----
+echo "T5: stack claim pushes [~] for each task atomically"
+setup_fixture
+(
+    cd "$WORK"
+    "$FLEET_CLAIM" stack "T-901 T-902" stack-agent >/dev/null
+)
+master_md=$(read_origin_tasks_md)
+assert_contains "$master_md" "- [~] **Task A**" "stack: T-901 flipped to [~]"
+assert_contains "$master_md" "- [~] **Task B**" "stack: T-902 flipped to [~]"
+
+# Now race-lose on a stack: pre-claim T-902 from a separate FS, then try
+# to stack-claim [T-901, T-902]. The T-902 race should fail and roll
+# back T-901's master push.
+setup_fixture
+mkdir -p "$TMPROOT/claims-pre"
+(
+    cd "$WORK"
+    FLEET_CLAIMS_DIR="$TMPROOT/claims-pre" \
+        "$FLEET_CLAIM" claim "T-902" pre-agent >/dev/null
+)
+set +e
+(
+    cd "$WORK"
+    "$FLEET_CLAIM" stack "T-901 T-902" stack-agent >"$TMPROOT/out-stk" 2>"$TMPROOT/err-stk"
+)
+rc=$?
+set -e
+assert_eq "$rc" "1" "stack claim fails when T-902 is already locked elsewhere"
+master_md=$(read_origin_tasks_md)
+# T-902 should be [~] (pre-agent's lock); T-901 should be back to [ ]
+# because the stack rolled back its T-901 push.
+assert_contains "$master_md" "- [~] **Task B**" "T-902 still [~] from pre-agent"
+assert_contains "$master_md" "- [ ] **Task A**" "T-901 rolled back to [ ] on master"
+
+# --- Test 6: reclaim resets a stranded [~] row to [ ]+free ----------------
+echo "T6: reclaim a stranded [~] row whose Owner branch is gone"
+setup_fixture
+(
+    cd "$WORK"
+    "$FLEET_CLAIM" claim "T-901" agent-A >/dev/null
+)
+master_md=$(read_origin_tasks_md)
+assert_contains "$master_md" "- [~] **Task A**" "T-901 starts as [~] (set by claim)"
+
+# Owner is "agent-A" — looks like a worktree name, not a branch (no
+# claude/* prefix). reclaim should accept (no branch to check).
+(
+    cd "$WORK"
+    "$FLEET_CLAIM" reclaim "T-901" >/dev/null 2>"$TMPROOT/err-rc6"
+)
+master_md=$(read_origin_tasks_md)
+assert_contains "$master_md" "- [ ] **Task A**" "T-901 reclaimed to [ ]"
+# Match the indented Owner field (avoid catching done-section "Owner:" form)
+if [[ "$master_md" == *"  - **Owner:** free"* ]]; then
+    PASS=$((PASS + 1))
+    echo "  ok: Owner reset to free after reclaim"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: Owner not reset to free"
+fi
+
+# --- Test 7: reclaim refuses to clobber when Owner branch is live ---------
+echo "T7: reclaim refuses when Owner branch exists on origin"
+setup_fixture
+# Inject a [~]+claude/T-901-foo state on master, then push the
+# claude/T-901-foo branch as if a worker held it.
+(
+    cd "$WORK"
+    git checkout -b claude/T-901-foo --quiet
+    git push --quiet origin claude/T-901-foo
+    git checkout master --quiet
+    # Edit Task A's row only — first occurrence of "Task A" header and
+    # the matching Owner line. Use python (sed -i differs on macOS).
+    python3 - <<'PYE'
+import re, pathlib
+p = pathlib.Path("TASKS.md")
+text = p.read_text()
+# Flip header
+text = text.replace("- [ ] **Task A**", "- [~] **Task A**", 1)
+# Flip Owner — first "  - **Owner:** free" only.
+text = text.replace("  - **Owner:** free", "  - **Owner:** claude/T-901-foo", 1)
+p.write_text(text)
+PYE
+    git add TASKS.md && git commit --quiet --no-gpg-sign -m "manual"
+    git push --quiet origin master
+)
+set +e
+(
+    cd "$WORK"
+    "$FLEET_CLAIM" reclaim "T-901" >/dev/null 2>"$TMPROOT/err-rc7"
+)
+rc=$?
+set -e
+assert_eq "$rc" "1" "reclaim refuses with rc=1"
+err_text=$(cat "$TMPROOT/err-rc7")
+assert_contains "$err_text" "still exists on origin" "stderr explains the refusal"
+master_md=$(read_origin_tasks_md)
+assert_contains "$master_md" "- [~] **Task A**" "T-901 still [~] after refused reclaim"
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+if (( FAIL > 0 )); then
+    exit 1
+fi

--- a/scripts/fleet/tests/test_tasks_render.py
+++ b/scripts/fleet/tests/test_tasks_render.py
@@ -144,6 +144,78 @@ class StatusDerivation(unittest.TestCase):
             self.assertIn("- [x] **T-200**", out)
             self.assertIn("PR: https://github.com/jakildev/IrredenEngine/pull/200", out)
 
+    def test_fs_claim_preserves_in_progress_marker_with_no_pr(self):
+        # T-138: fleet-claim flips master/TASKS.md [ ] → [~] before the
+        # worker opens its PR. derive_status with no PR would normally
+        # revert to [ ], clobbering the master push. The FS claim is the
+        # signal to preserve [~] until the PR appears (or check-stale
+        # prunes the abandoned claim).
+        with tempfile.TemporaryDirectory() as td:
+            state = _state_file(td)
+            claims_dir = pathlib.Path(td) / "claims"
+            (claims_dir / "t-200").mkdir(parents=True)
+            (claims_dir / "t-200" / "title").write_text("T-200")
+            (claims_dir / "t-200" / "owner").write_text("opus-worker-1")
+            import os
+            old = os.environ.pop("FLEET_CLAIMS_DIR", None)
+            os.environ["FLEET_CLAIMS_DIR"] = str(claims_dir)
+            try:
+                text = _basic_tasks_md(open_status="~", owner="opus-worker-1")
+                out = render(text, state_file=state, repo_key="engine")
+            finally:
+                if old is None:
+                    os.environ.pop("FLEET_CLAIMS_DIR", None)
+                else:
+                    os.environ["FLEET_CLAIMS_DIR"] = old
+            self.assertIn("- [~] **Some Engine Feature**", out)
+            self.assertIn("**Owner:** opus-worker-1", out)
+
+    def test_no_fs_claim_reverts_in_progress_marker_with_no_pr(self):
+        # Mirror of the test above without the FS claim — confirms the
+        # FS-claim signal is what preserves [~]. With no PR and no FS
+        # claim, the row reverts to [ ] (the historical behavior).
+        with tempfile.TemporaryDirectory() as td:
+            state = _state_file(td)
+            claims_dir = pathlib.Path(td) / "empty-claims"
+            claims_dir.mkdir(parents=True)
+            import os
+            old = os.environ.pop("FLEET_CLAIMS_DIR", None)
+            os.environ["FLEET_CLAIMS_DIR"] = str(claims_dir)
+            try:
+                text = _basic_tasks_md(open_status="~", owner="opus-worker-1")
+                out = render(text, state_file=state, repo_key="engine")
+            finally:
+                if old is None:
+                    os.environ.pop("FLEET_CLAIMS_DIR", None)
+                else:
+                    os.environ["FLEET_CLAIMS_DIR"] = old
+            self.assertIn("- [ ] **Some Engine Feature**", out)
+            self.assertIn("**Owner:** free", out)
+
+    def test_game_slug_namespace_isolation(self):
+        # An engine render must ignore game-namespaced FS claims (slug
+        # `game-...`) so cross-repo claims don't bleed across renders.
+        with tempfile.TemporaryDirectory() as td:
+            state = _state_file(td)
+            claims_dir = pathlib.Path(td) / "claims"
+            (claims_dir / "game-t-200").mkdir(parents=True)
+            (claims_dir / "game-t-200" / "title").write_text("T-200")
+            (claims_dir / "game-t-200" / "owner").write_text("opus-worker-1")
+            import os
+            old = os.environ.pop("FLEET_CLAIMS_DIR", None)
+            os.environ["FLEET_CLAIMS_DIR"] = str(claims_dir)
+            try:
+                text = _basic_tasks_md(open_status="~", owner="opus-worker-1")
+                # Engine render: game-T-200 claim must not preserve [~]
+                # for this engine task with the same task ID.
+                out = render(text, state_file=state, repo_key="engine")
+            finally:
+                if old is None:
+                    os.environ.pop("FLEET_CLAIMS_DIR", None)
+                else:
+                    os.environ["FLEET_CLAIMS_DIR"] = old
+            self.assertIn("- [ ] **Some Engine Feature**", out)
+
     def test_stranded_merge_keeps_task_in_progress(self):
         # PR #543 regression: mergedAt is set but base != master, so
         # the commit isn't reachable from origin/master. Don't move

--- a/scripts/fleet/tests/test_tasks_render.py
+++ b/scripts/fleet/tests/test_tasks_render.py
@@ -20,6 +20,7 @@ Issue, Stack, etc.). This harness covers:
 import importlib.machinery
 import importlib.util
 import json
+import os
 import pathlib
 import tempfile
 import unittest
@@ -156,7 +157,6 @@ class StatusDerivation(unittest.TestCase):
             (claims_dir / "t-200").mkdir(parents=True)
             (claims_dir / "t-200" / "title").write_text("T-200")
             (claims_dir / "t-200" / "owner").write_text("opus-worker-1")
-            import os
             old = os.environ.pop("FLEET_CLAIMS_DIR", None)
             os.environ["FLEET_CLAIMS_DIR"] = str(claims_dir)
             try:
@@ -178,7 +178,6 @@ class StatusDerivation(unittest.TestCase):
             state = _state_file(td)
             claims_dir = pathlib.Path(td) / "empty-claims"
             claims_dir.mkdir(parents=True)
-            import os
             old = os.environ.pop("FLEET_CLAIMS_DIR", None)
             os.environ["FLEET_CLAIMS_DIR"] = str(claims_dir)
             try:
@@ -201,7 +200,6 @@ class StatusDerivation(unittest.TestCase):
             (claims_dir / "game-t-200").mkdir(parents=True)
             (claims_dir / "game-t-200" / "title").write_text("T-200")
             (claims_dir / "game-t-200" / "owner").write_text("opus-worker-1")
-            import os
             old = os.environ.pop("FLEET_CLAIMS_DIR", None)
             os.environ["FLEET_CLAIMS_DIR"] = str(claims_dir)
             try:


### PR DESCRIPTION
## Summary

`fleet-claim claim` / `stack` now push a one-line `TASKS.md` update to
`origin/master` as part of the claim handshake (`[ ] → [~]` + `Owner:`).
The push uses pure git plumbing (`hash-object` + `mktree` + `commit-tree` +
`push`) — no working-tree mutation in the agent's worktree.

This closes the cross-host claim race that produced the T-130 double-claim
incident: a worker polling `origin/master/TASKS.md` after another worker
already claimed locally would see `[ ]+free` until the next `queue-tick`
maintenance sync (1–2h later). After this change the master row reflects
the claim within one push round-trip.

`fleet-tasks-render` reads `~/.fleet/claims/` as a secondary signal so a
`queue-tick` firing in the no-PR window between `fleet-claim claim` and
the worker's first `gh pr create` does not revert `[~]` back to `[ ]`.
`cmd_check_stale` auto-recovers stranded rows; `fleet-claim reclaim
<task-id>` is a manual override.

`FLEET_CLAIM_NO_MASTER_LOCK=1` opts out (tests / bootstrap-without-network).

## Race resolution

- **Same-host** — FS `mkdir(2)` wins atomically; loser never reaches the
  master push.
- **Cross-host** — both win their FS lock; their master pushes race. The
  loser's `git push` returns non-fast-forward, refetches, sees `[~]` set
  by the winner, and aborts with `race lost on master push` while
  rolling back its FS claim.

## Test plan

- [x] `scripts/fleet/tests/test_fleet_claim_master_lock.sh` — 26
      asserts covering acceptance #1 (concurrent claims, exactly one
      wins), acceptance #2 (master visibility within seconds),
      `reclaim` semantics, stack rollback, env-var bypass.
- [x] `scripts/fleet/tests/test_tasks_render.py` — three new asserts
      covering FS-claim preservation (engine/game namespace isolation
      included).
- [x] Existing `test_dispatcher_concurrency_cap.sh`,
      `test_dispatcher_usage_gate.sh`, `test_tasks_render.py` (16
      tests), `test_enrich_stackable_blocker_prs.py`,
      `test_merger_projection.py`, `test_queue_manager_projection.py`
      all pass — no regressions.
- [x] End-to-end smoke: `fleet-claim claim "T-138" opus-worker-1`
      pushed `[~]+claude/T-138-fleet-claim-master-lock` to engine
      master/TASKS.md (visible in the queue-tick re-derivation that
      followed); `fleet-claim list-reservations` shows the binding;
      `fleet-claim help` lists the new `reclaim` subcommand and the
      `FLEET_CLAIM_NO_MASTER_LOCK` env var.

## Acceptance (from #583)

1. ✅ Two concurrent `fleet-claim T-X` invocations: exactly one
   succeeds, the other exits `1` with `race lost` and rolls back its
   FS claim. Covered by T2 + T4 in `test_fleet_claim_master_lock.sh`.
2. ✅ After a successful claim, master `TASKS.md` shows `[~]` + `Owner`
   within seconds (single push round-trip, ~1–2s in practice).
   Covered by T1 + T2.
3. ✅ `fleet-claim reclaim T-X` resets `[~]` → `[ ]` if the Owner
   branch doesn't exist on the remote, and refuses to clobber when
   it does. Covered by T6 + T7.

## Notes for reviewer

- The master push uses GitHub's existing direct-push channel
  (precedent: `fleet-queue-tick` already pushes `queue: maintenance
  sync` directly to `master`). No new permissions needed.
- `derive_status` now takes optional `fs_claims`, `existing_status`,
  `existing_owner` keyword args. Default-None preserves the old
  return behavior — the FS-claim preservation only kicks in when the
  caller passes those (which `render()` does after my patch).
- `cmd_stack`'s rollback paths (blocker check failure, reservation
  conflict, FS-lock conflict, master-lock race-lost) all run
  `master_lock_task unlock` before `cmd_release` so a half-claimed
  stack never strands `[~]` rows on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)