### PR TITLE
T-142: macOS — fix IRShapeDebug crash in UPDATE_VOXEL_SET_CHILDREN

### DIFF
--- a/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
@@ -209,6 +209,7 @@ struct C_VoxelPool {
         m_entityIdsDirty = false;
     }
 
+    [[deprecated("Capture VoxelPoolAllocation::startIndex_ at allocateVoxels call time instead — see engine/render/CLAUDE.md")]]
     const C_PositionGlobal3D *getPositionGlobalsBasePtr() const {
         return m_voxelPositionsGlobal.data();
     }

--- a/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
@@ -3,6 +3,7 @@
 
 #include <irreden/ir_math.hpp>
 #include <irreden/render/ir_render_types.hpp>
+#include <irreden/render/voxel_pool_allocation.hpp>
 
 #include <irreden/common/components/component_position_3d.hpp>
 #include <irreden/common/components/component_position_offset_3d.hpp>
@@ -73,12 +74,7 @@ struct C_VoxelPool {
 
     // EntityId addVoxel
 
-    std::tuple<
-        std::span<C_Position3D>,
-        std::span<C_PositionOffset3D>,
-        std::span<C_PositionGlobal3D>,
-        std::span<C_Voxel>>
-    allocateVoxels(unsigned int size) {
+    IRRender::VoxelPoolAllocation allocateVoxels(unsigned int size) {
         auto freeSpan = findFreeSpan(size);
         if (freeSpan.has_value()) {
             size_t startIndex = freeSpan->first;
@@ -88,49 +84,51 @@ struct C_VoxelPool {
                 m_freeSpanLookup.erase(size);
             }
             m_chunkBoundsDirty = true;
-            return std::make_tuple(
+            return IRRender::VoxelPoolAllocation{
+                startIndex,
                 std::span<C_Position3D>{m_voxelPositions.data() + startIndex, size},
                 std::span<C_PositionOffset3D>{m_voxelPositionsOffset.data() + startIndex, size},
                 std::span<C_PositionGlobal3D>{m_voxelPositionsGlobal.data() + startIndex, size},
                 std::span<C_Voxel>{m_voxelColors.data() + startIndex, size}
-            );
+            };
         }
 
         if (m_voxelPoolIndex + size <= m_voxelPoolSize) {
-            int startIndex = m_voxelPoolIndex;
+            size_t startIndex = static_cast<size_t>(m_voxelPoolIndex);
             m_voxelPoolIndex += size;
             m_chunkBoundsDirty = true;
             IRE_LOG_DEBUG("Allocated voxels from {} to {}", startIndex, m_voxelPoolIndex - 1);
-            return std::make_tuple(
+            return IRRender::VoxelPoolAllocation{
+                startIndex,
                 std::span<C_Position3D>{m_voxelPositions.data() + startIndex, size},
                 std::span<C_PositionOffset3D>{m_voxelPositionsOffset.data() + startIndex, size},
                 std::span<C_PositionGlobal3D>{m_voxelPositionsGlobal.data() + startIndex, size},
                 std::span<C_Voxel>{m_voxelColors.data() + startIndex, size}
-            );
+            };
         }
 
         IR_ASSERT(false, "Ran out of voxels");
 
-        return std::make_tuple(
+        return IRRender::VoxelPoolAllocation{
+            0,
             std::span<C_Position3D>{},
             std::span<C_PositionOffset3D>{},
             std::span<C_PositionGlobal3D>{},
             std::span<C_Voxel>{}
-        );
+        };
     }
 
-    void deallocateVoxels(
-        std::span<C_Position3D> positions,
-        std::span<C_PositionOffset3D> positionOffsets,
-        std::span<C_PositionGlobal3D> positionGlobals,
-        std::span<C_Voxel> colors
-    ) {
-        for (size_t i = 0; i < colors.size(); i++) {
-            C_Voxel &voxel = colors[i];
-            voxel.color_ = Color{0, 0, 0, 0};
+    void deallocateVoxels(size_t startIndex, size_t size) {
+        IR_ASSERT(
+            startIndex + size <= static_cast<size_t>(m_voxelPoolSize),
+            "deallocateVoxels out of bounds: startIndex={}, size={}, poolSize={}",
+            startIndex,
+            size,
+            m_voxelPoolSize
+        );
+        for (size_t i = 0; i < size; i++) {
+            m_voxelColors[startIndex + i].color_ = Color{0, 0, 0, 0};
         }
-        size_t startIndex = positions.data() - m_voxelPositions.data();
-        size_t size = positions.size();
 
         std::fill(
             m_voxelEntities.begin() + startIndex,
@@ -184,6 +182,13 @@ struct C_VoxelPool {
     }
 
     void setEntityIdForRange(size_t startIdx, size_t count, EntityId entityId) {
+        IR_ASSERT(
+            startIdx + count <= m_voxelEntities.size(),
+            "setEntityIdForRange out of bounds: startIdx={}, count={}, poolSize={}",
+            startIdx,
+            count,
+            m_voxelEntities.size()
+        );
         std::fill(
             m_voxelEntities.begin() + startIdx,
             m_voxelEntities.begin() + startIdx + count,
@@ -217,14 +222,17 @@ struct C_VoxelPool {
     }
 
     void rebuildChunkBounds() {
-        if (!m_chunkBoundsDirty) return;
+        if (!m_chunkBoundsDirty)
+            return;
 
         int chunkCount = getChunkCount();
         m_chunkBounds.resize(chunkCount);
-        for (auto &cb : m_chunkBounds) cb.reset();
+        for (auto &cb : m_chunkBounds)
+            cb.reset();
 
         for (int i = 0; i < m_voxelPoolIndex; ++i) {
-            if (m_voxelColors[i].color_.alpha_ == 0) continue;
+            if (m_voxelColors[i].color_.alpha_ == 0)
+                continue;
             int chunk = i / IRRender::kVoxelChunkSize;
             vec2 isoPos = IRMath::pos3DtoPos2DIso(m_voxelPositionsGlobal[i].pos_);
             m_chunkBounds[chunk].expand(isoPos);

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -31,6 +31,12 @@ struct C_VoxelSetNew {
     vec3 lastParentPosition_ = vec3(0.0f);
     bool hasLastParentPosition_ = false;
 
+    // Index into the canvas voxel pool's underlying arrays. Captured at
+    // allocation time so consumers never recompute it from a pointer-diff
+    // against a separately-cached @c C_VoxelPool* (a stale cached pool
+    // pointer made the diff resolve to a wild index).
+    size_t voxelStartIdx_ = 0;
+
     // local voxel position
     std::span<C_Position3D> positions_;
 
@@ -50,11 +56,12 @@ struct C_VoxelSetNew {
         , size_{size} {
         const int requestedVoxels = size.x * size.y * size.z;
         canvasEntity_ = IRRender::getActiveCanvasEntity();
-        auto voxels = IRRender::allocateVoxels(requestedVoxels);
-        positions_ = std::get<0>(voxels);
-        positionOffsets_ = std::get<1>(voxels);
-        globalPositions_ = std::get<2>(voxels);
-        voxels_ = std::get<3>(voxels);
+        auto allocation = IRRender::allocateVoxels(requestedVoxels);
+        voxelStartIdx_ = allocation.startIndex_;
+        positions_ = allocation.positions_;
+        positionOffsets_ = allocation.positionOffsets_;
+        globalPositions_ = allocation.positionGlobals_;
+        voxels_ = allocation.voxels_;
 
         // Keep runtime-safe bounds even if allocation returns an unexpected span size.
         numVoxels_ = static_cast<int>(IRMath::min(
@@ -76,8 +83,8 @@ struct C_VoxelSetNew {
         }
 
         vec3 offset = centerAroundOrigin
-            ? vec3(-(size.x - 1) * 0.5f, -(size.y - 1) * 0.5f, -(size.z - 1) * 0.5f)
-            : vec3(0.0f);
+                          ? vec3(-(size.x - 1) * 0.5f, -(size.y - 1) * 0.5f, -(size.z - 1) * 0.5f)
+                          : vec3(0.0f);
         for (int x = 0; x < size.x; x++) {
             for (int y = 0; y < size.y; y++) {
                 for (int z = 0; z < size.z; z++) {
@@ -104,7 +111,7 @@ struct C_VoxelSetNew {
     // voxels, just in case the constructor might be called in more than
     // one place?
     void onDestroy() {
-        IRRender::deallocateVoxels(positions_, positionOffsets_, globalPositions_, voxels_);
+        IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(numVoxels_));
         IRE_LOG_DEBUG("Deallocated {} voxels", numVoxels_);
     }
 

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -111,6 +111,10 @@ struct C_VoxelSetNew {
     // voxels, just in case the constructor might be called in more than
     // one place?
     void onDestroy() {
+        // numVoxels_ equals requestedVoxels on all non-error paths (the
+        // constructor min-span guard fires IR_ASSERT before returning a
+        // mismatched allocation), so deallocateVoxels releases exactly
+        // what allocateVoxels reserved.
         IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(numVoxels_));
         IRE_LOG_DEBUG("Deallocated {} voxels", numVoxels_);
     }

--- a/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
@@ -8,47 +8,37 @@
 #include <irreden/common/components/component_player.hpp>
 #include <irreden/ir_render.hpp>
 
-#include <unordered_map>
-
 using namespace IRComponents;
 using namespace IRMath;
 
 namespace IRSystem {
 template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
     static SystemId create() {
-        // Cached per-canvas pool pointers. Only a handful of canvases exist,
-        // so this map stays tiny and lookups are negligible.
-        // TODO: replace with relation-based archetype grouping (RENDERS_ON)
-        // so the pool is resolved once per archetype node, not per entity.
-        static std::unordered_map<IREntity::EntityId, C_VoxelPool *> poolCache;
-
         return createSystem<C_VoxelSetNew, C_PositionGlobal3D>(
             "UpdateVoxelSetChildren",
             [](IREntity::EntityId &entityId,
                C_VoxelSetNew &voxelSet,
                C_PositionGlobal3D &position) {
-                IREntity::EntityId canvas = voxelSet.canvasEntity_;
-                if (canvas == IREntity::kNullEntity) {
-                    canvas = IRRender::getActiveCanvasEntity();
-                }
-
-                auto it = poolCache.find(canvas);
-                if (it == poolCache.end()) {
-                    it = poolCache.emplace(
-                        canvas, &IREntity::getComponent<C_VoxelPool>(canvas)
-                    ).first;
-                }
-                C_VoxelPool *pool = it->second;
-
                 voxelSet.updateAsChild(position.pos_);
 
                 if (voxelSet.ownerEntityId_ == IREntity::kNullEntity &&
-                    entityId != IREntity::kNullEntity &&
-                    voxelSet.numVoxels_ > 0) {
+                    entityId != IREntity::kNullEntity && voxelSet.numVoxels_ > 0) {
                     voxelSet.ownerEntityId_ = entityId;
-                    size_t startIdx = voxelSet.globalPositions_.data() -
-                                      pool->getPositionGlobalsBasePtr();
-                    pool->setEntityIdForRange(startIdx, voxelSet.numVoxels_, entityId);
+                    // The pool pointer is fetched fresh per call rather than
+                    // cached: a canvas archetype mutation invalidates any
+                    // cached @c C_VoxelPool* and a subsequent pointer-diff
+                    // against `voxelSet.globalPositions_.data()` then yields
+                    // a wild index. The gate above keeps this getComponent a
+                    // one-shot per voxel-set lifetime.
+                    IREntity::EntityId canvas = voxelSet.canvasEntity_;
+                    if (canvas == IREntity::kNullEntity) {
+                        canvas = IRRender::getActiveCanvasEntity();
+                    }
+                    IREntity::getComponent<C_VoxelPool>(canvas).setEntityIdForRange(
+                        voxelSet.voxelStartIdx_,
+                        static_cast<size_t>(voxelSet.numVoxels_),
+                        entityId
+                    );
                 }
             }
         );

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -16,7 +16,10 @@ Key exposed surface:
 - Resource CRUD: `createResource<T>()`, `getResource<T>()`,
   `destroyResource<T>()`, plus `createNamed<T>(name, ...)` and
   `getNamedResource<T>(name)`.
-- Voxel pool: `allocateVoxels(count)`, `deallocateVoxels(span)`.
+- Voxel pool: `allocateVoxels(count)` returns a `VoxelPoolAllocation`
+  (`startIndex_` + the four co-indexed spans); `deallocateVoxels(startIndex,
+  size)` releases the span. The start index is the source of truth — never
+  recompute it from `positions.data() - basePtr`.
 - Canvases: `createCanvas(name, size, ...)`, `getCanvas(name)`,
   `setActiveCanvas(name)`.
 - Camera and viewport: `getCameraPosition2DIso()`, `getCameraZoom()`,

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -60,28 +60,22 @@ template <typename T> T *getNamedResource(std::string resourceName) {
 /// @{
 /// @name Voxel pool
 /// Allocate / release contiguous spans of voxel component arrays from the named canvas
-/// pool. All four spans are co-indexed — element [i] of each span belongs to voxel i.
+/// pool. The four spans returned by @c allocateVoxels are co-indexed — element [i] of
+/// each span belongs to voxel i — and @c VoxelPoolAllocation::startIndex_ is the offset
+/// of those spans inside the pool's underlying voxel arrays. Pass that index back to
+/// @c deallocateVoxels (and to @c C_VoxelPool::setEntityIdForRange); never recompute it
+/// from `positions.data() - basePtr` against a separately-cached @c C_VoxelPool*, since
+/// a canvas archetype mutation can leave such a cache pointing at a different pool.
 /// @param size        Number of voxels to allocate.
 /// @param canvasName  Canvas pool to allocate from (default @c "main").
-inline std::tuple<
-    std::span<C_Position3D>,
-    std::span<C_PositionOffset3D>,
-    std::span<C_PositionGlobal3D>,
-    std::span<C_Voxel>>
-allocateVoxels(unsigned int size, std::string canvasName = "main") {
+inline VoxelPoolAllocation allocateVoxels(unsigned int size, std::string canvasName = "main") {
     return getRenderManager().allocateVoxels(size, canvasName);
 }
 
-/// Release voxel spans previously returned by @c allocateVoxels back to the pool.
-inline void deallocateVoxels(
-    std::span<C_Position3D> positions,
-    std::span<C_PositionOffset3D> positionOffsets,
-    std::span<C_PositionGlobal3D> positionGlobals,
-    std::span<C_Voxel> voxels,
-    std::string canvasName = "main"
-) {
-    getRenderManager()
-        .deallocateVoxels(positions, positionOffsets, positionGlobals, voxels, canvasName);
+/// Release a previously-allocated voxel span back to the pool. Pass the start index
+/// returned by @c allocateVoxels and the same size used to allocate.
+inline void deallocateVoxels(size_t startIndex, size_t size, std::string canvasName = "main") {
+    getRenderManager().deallocateVoxels(startIndex, size, canvasName);
 }
 /// @}
 

--- a/engine/render/include/irreden/render/render_manager.hpp
+++ b/engine/render/include/irreden/render/render_manager.hpp
@@ -7,15 +7,14 @@
 #include <irreden/render/ir_render_types.hpp>
 #include <irreden/render/buffer.hpp>
 #include <irreden/render/renderer_impl.hpp>
+#include <irreden/render/voxel_pool_allocation.hpp>
 
 #include <irreden/common/components/component_position_3d.hpp>
 #include <irreden/common/components/component_position_offset_3d.hpp>
 #include <irreden/common/components/component_position_global_3d.hpp>
 #include <irreden/voxel/components/component_voxel.hpp>
 
-#include <tuple>
 #include <string>
-#include <span>
 
 using namespace IRComponents;
 using namespace IREntity;
@@ -86,20 +85,9 @@ class RenderManager {
     void presentFrame();
     void printRenderInfo();
 
-    std::tuple<
-        std::span<C_Position3D>,
-        std::span<C_PositionOffset3D>,
-        std::span<C_PositionGlobal3D>,
-        std::span<C_Voxel>>
-    allocateVoxels(unsigned int size, std::string canvasName = "main");
+    VoxelPoolAllocation allocateVoxels(unsigned int size, std::string canvasName = "main");
 
-    void deallocateVoxels(
-        std::span<C_Position3D> positions,
-        std::span<C_PositionOffset3D> positionsOffset,
-        std::span<C_PositionGlobal3D> positionsGlobal,
-        std::span<C_Voxel> voxels,
-        std::string canvasName = "main"
-    );
+    void deallocateVoxels(size_t startIndex, size_t size, std::string canvasName = "main");
 
     EntityId createCanvas(
         std::string name, ivec3 voxelPoolSize, ivec2 trixelSize, EntityId framebuffer = EntityId{}

--- a/engine/render/include/irreden/render/voxel_pool_allocation.hpp
+++ b/engine/render/include/irreden/render/voxel_pool_allocation.hpp
@@ -20,7 +20,7 @@ namespace IRRender {
 // pointer-diff produces an out-of-bounds index that on macOS walks off into
 // unmapped VM space.
 struct VoxelPoolAllocation {
-    size_t startIndex_;
+    size_t startIndex_ = 0;
     std::span<IRComponents::C_Position3D> positions_;
     std::span<IRComponents::C_PositionOffset3D> positionOffsets_;
     std::span<IRComponents::C_PositionGlobal3D> positionGlobals_;

--- a/engine/render/include/irreden/render/voxel_pool_allocation.hpp
+++ b/engine/render/include/irreden/render/voxel_pool_allocation.hpp
@@ -1,0 +1,34 @@
+#ifndef IRREDEN_RENDER_VOXEL_POOL_ALLOCATION_H
+#define IRREDEN_RENDER_VOXEL_POOL_ALLOCATION_H
+
+#include <irreden/common/components/component_position_3d.hpp>
+#include <irreden/common/components/component_position_offset_3d.hpp>
+#include <irreden/common/components/component_position_global_3d.hpp>
+#include <irreden/voxel/components/component_voxel.hpp>
+
+#include <cstddef>
+#include <span>
+
+namespace IRRender {
+
+// Result of @c IRRender::allocateVoxels (and @c RenderManager::allocateVoxels /
+// @c C_VoxelPool::allocateVoxels). @c startIndex_ is the source of truth for
+// where the spans live inside the pool's voxel arrays — consumers must not
+// recompute it from `positions.data() - basePtr`. The caller's cached basePtr
+// can refer to a different pool's allocation (e.g. when an EntityId-keyed
+// pool-pointer cache survives a canvas-archetype mutation), so the
+// pointer-diff produces an out-of-bounds index that on macOS walks off into
+// unmapped VM space.
+struct VoxelPoolAllocation {
+    size_t startIndex_;
+    std::span<IRComponents::C_Position3D> positions_;
+    std::span<IRComponents::C_PositionOffset3D> positionOffsets_;
+    std::span<IRComponents::C_PositionGlobal3D> positionGlobals_;
+    // C_Voxel lives at global scope (not in IRComponents) — see
+    // engine/prefabs/irreden/voxel/components/component_voxel.hpp.
+    std::span<C_Voxel> voxels_;
+};
+
+} // namespace IRRender
+
+#endif /* IRREDEN_RENDER_VOXEL_POOL_ALLOCATION_H */

--- a/engine/render/src/render_manager.cpp
+++ b/engine/render/src/render_manager.cpp
@@ -193,12 +193,7 @@ void RenderManager::presentFrame() {
     IRRender::device()->present();
 }
 
-std::tuple<
-    std::span<C_Position3D>,
-    std::span<C_PositionOffset3D>,
-    std::span<C_PositionGlobal3D>,
-    std::span<C_Voxel>>
-RenderManager::allocateVoxels(unsigned int numVoxels, std::string canvasName) {
+VoxelPoolAllocation RenderManager::allocateVoxels(unsigned int numVoxels, std::string canvasName) {
     auto it = m_canvasMap.find(canvasName);
     IR_ASSERT(it != m_canvasMap.end(), "Canvas not found: {}", canvasName);
     auto poolOpt = IREntity::getComponentOptional<C_VoxelPool>(it->second);
@@ -296,13 +291,7 @@ void RenderManager::zoomMainBackgroundPatternOut() {
     (*zoomLevel.value()).zoomOut();
 }
 
-void RenderManager::deallocateVoxels(
-    std::span<C_Position3D> positions,
-    std::span<C_PositionOffset3D> positionOffsets,
-    std::span<C_PositionGlobal3D> positionGlobals,
-    std::span<C_Voxel> voxels,
-    std::string canvasName
-) {
+void RenderManager::deallocateVoxels(size_t startIndex, size_t size, std::string canvasName) {
     auto it = m_canvasMap.find(canvasName);
     if (it == m_canvasMap.end()) {
         return;
@@ -314,7 +303,7 @@ void RenderManager::deallocateVoxels(
     if (!poolOpt.has_value()) {
         return;
     }
-    (*poolOpt.value()).deallocateVoxels(positions, positionOffsets, positionGlobals, voxels);
+    (*poolOpt.value()).deallocateVoxels(startIndex, size);
 }
 
 EntityId RenderManager::getCanvas(std::string canvasName) {


### PR DESCRIPTION
## Summary
- Eliminates the wild pointer-diff in `C_VoxelPool::setEntityIdForRange` that produces SIGBUS / KERN_PROTECTION_FAILURE on macOS during `IRShapeDebug` init.
- Replaces the static `unordered_map<EntityId, C_VoxelPool*>` cache + `data() - basePtr` math in `system_update_voxel_set_children` with an explicit `voxelStartIdx_` captured at allocation time.
- Adds bounds assertions in `setEntityIdForRange` and `deallocateVoxels` so a future regression of this bug class fails at the call site instead of corrupting memory.

## Root cause
The system stored raw `C_VoxelPool*` pointers in a function-local `static unordered_map`, populated lazily on first lookup. Once the canvas entity's archetype mutated (component added/removed, or the column reallocated as more canvases shared it), the cached pointer pointed into a different allocation. The subsequent `globalPositions_.data() - pool->getPositionGlobalsBasePtr()` then subtracted pointers from unrelated allocations — undefined behavior that on macOS resolved to a multi-GB index walking off into unmapped VM space. Linux's allocator happened to mask the bad index by leaving nearby pages mapped, which is why this only fired on macOS.

## API change
The new `VoxelPoolAllocation` struct (in `engine/render/include/irreden/render/voxel_pool_allocation.hpp`) carries `startIndex_` plus the four co-indexed spans through `C_VoxelPool::allocateVoxels` → `RenderManager::allocateVoxels` → `IRRender::allocateVoxels`. `deallocateVoxels` switches to `(startIndex, size)` for symmetry and to eliminate the same pointer-diff hazard from the dealloc path. The single consumer is `C_VoxelSetNew`, which now stashes `voxelStartIdx_` for both the entity-id range write and `onDestroy`.

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean on macOS
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` runs to completion (6/6 screenshots captured, exit code 0)
- [x] Visual output identical to master — change is pure data-flow refactor, no shader / render algorithm change
- [ ] Linux smoke verification (cross-host)

## Notes for reviewer
- No visual change expected — the entity-id values written into the pool are unchanged, only the index plumbing differs. Skipping `attach-screenshots` per skill rules ("mechanical refactor with no visual effect").
- `getPositionGlobalsBasePtr()` is now unused but kept on the public surface (per engine-API removal rule). External consumers that were using it for the same pointer-diff pattern are vulnerable to the same bug; the right migration is to capture `VoxelPoolAllocation::startIndex_` at allocation time.
- Pre-existing build break in `IrredenEngineTest` on macOS (T-106 codegen test asserting `float` on what the codegen tool emits as `int32`) — unrelated, surfaces during `fleet-build --target IrredenEngineTest` on master too. Not addressed here.

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)