### PR TITLE
fleet: always fetch issue/PR comments in workers and reviewers

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -921,8 +921,12 @@ Do the work, then exit cleanly:
    If your task ID is `T-010`, you read `T-010.md` — that's it.
    Anything else in `~/.fleet/plans/` is not yours and not authoritative
    (stale prose, drafts, abandoned files). If none of those three
-   files exist, read the issue thread for the plan comment:
-   `gh issue view <N> --repo jakildev/IrredenEngine`
+   files exist, read the **full issue thread** (body + every comment —
+   the plan is often posted as a comment, and the human may have left
+   scope refinements there too) via the same wrapper used in step 2:
+   `fleet-issue view <N>` (engine; for game issues add `--repo game`).
+   Do **not** fall back to bare `gh issue view <N>` — it omits comments
+   by default and silently drops the plan.
 
 6. **Work it.** Read every `CLAUDE.md` on the path to the file(s) you
    touch first. Follow naming conventions, the no-`getComponent`-in-tick

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -629,8 +629,12 @@ Each iteration:
    If any exists, read it with the Read tool — it contains the
    implementation approach, affected files, and gotchas. Use it to
    guide your work. If no plan file exists at any path, read the
-   issue thread for the plan comment:
-   `gh issue view <N> --repo jakildev/IrredenEngine`
+   **full issue thread** (body + every comment — the plan is often
+   posted as a comment, and the human may have left scope refinements
+   there too) via the cache-aware wrapper:
+   `fleet-issue view <N>` (engine; for game issues add `--repo game`).
+   Do **not** fall back to bare `gh issue view <N>` — it omits comments
+   by default and silently drops the plan.
 
 5. **Work it.** Read every `CLAUDE.md` on the path to the file(s) you
    touch first. Follow naming conventions, the no-`getComponent`-in-tick

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -77,10 +77,22 @@ it as a first pass, and focus on what Sonnet could not confirm. See
 
 ### 1. Resolve the PR and pull its metadata
 
+Read author/human PR comments before walking the diff — they're how
+authors flag deliberate scope ("I deferred X to a follow-up") and how
+humans pre-flag concerns ("watch out for Y on macOS"). Missing them
+leads to reviews that re-raise points the author already addressed in
+conversation.
+
 ```bash
-gh pr view <N> --json number,title,body,headRefName,baseRefName,author,files,additions,deletions,commits,mergeable
+gh pr view <N> --json number,title,body,headRefName,baseRefName,author,files,additions,deletions,commits,mergeable,comments,reviews
+gh api repos/jakildev/IrredenEngine/pulls/<N>/comments
 gh pr diff <N>
 ```
+
+The first command returns issue-level comments (`comments`) and review
+summaries (`reviews`). The second returns inline code-review comments
+(line-attached) — `gh pr view --json` does not include these. Together
+the two commands cover every kind of PR conversation.
 
 If the user said "latest" / "most recent":
 


### PR DESCRIPTION
## Summary

Three workflow fallback paths were calling bare `gh issue view <N>` / `gh pr view <N> --json ...` without `--comments`. If the fallback fired (no plan file present; first-pass review on a PR with prior author or human commentary), the worker or reviewer silently saw only the body and dropped every comment.

Fix:

- `role-opus-worker.md` step 5 plan-file fallback → `fleet-issue view <N>` (already used in step 2 of the same role; wrapper always surfaces body + comments and falls back to `gh issue view --comments` on cache miss).
- `role-sonnet-author.md` step 4 plan-file fallback → same replacement.
- `review-pr/SKILL.md` step 1 first-pass metadata fetch → extend `--json` with `comments,reviews` and add `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments` for inline review comments (the same incantation `procedures/re-review.md` already uses).

## What the investigation found

The system mostly does the right thing — most surfaces already pull comments correctly:

| Surface | Command | Reads comments? |
|---|---|---|
| `queue-manager` ingesting `human:approved` issue | `gh issue view --json body,comments,labels` | ✅ |
| `opus-worker` planning a `fleet:needs-plan` issue (step 2) | `fleet-issue view <N>` | ✅ |
| Scout cache (`fleet-state-scout`) | `gh issue view --json …,comments,…` | ✅ |
| `fleet-issue` cache-miss fallback | `gh issue view --comments` | ✅ |
| Re-review (`procedures/re-review.md`) | `gh pr view --comments` + `gh api …/pulls/N/comments` | ✅ |
| Sonnet/Opus reviewer first pass via `fleet-pr comments <N>` | cached | ✅ |

The three gaps fixed here all had the same shape: a *fallback* path that calls bare `gh` without `--comments`. They are the only such call sites that are supposed to read full thread context.

## What triggered this

An `opus-worker` left a scope-concern comment on issue #209 (T-139, GPU particle system) that read as if it had ignored the owner's comment. Investigation showed the worker did read the comment (the scout cache + queue-manager ingestion paths already fetch comments correctly), but uncovered three genuinely broken fallback paths that would silently drop comments if reached. This PR fixes those.

## Test plan

- [x] `fleet-issue view 209` on cache miss → falls back to `gh issue view --comments` → prints body + owner comment ✓
- [x] `gh pr view 615 --json ...,comments,reviews` → returns `{comments: 1, reviews: 2, ...}` ✓
- [x] `gh api repos/jakildev/IrredenEngine/pulls/615/comments` → returns inline-comments array (`0` for #615 specifically, endpoint works) ✓
- [ ] Reviewer reads PR body, confirms the three changes match the diff exactly
- [ ] No build needed — pure doc/role/skill edits

## Out of scope

- The T-139 / issue #209 scope discussion itself (stays an architect conversation).
- Cross-repo isolation rework (engine workers genuinely can't see game-repo content — that's deliberate).
- Migrating every `gh pr view`/`gh issue view` in the repo to wrappers. Only the **fallback** call sites are changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)