### PR TITLE
T-154: Migrate hitbox GUI system to member-on-System<N>

### DIFF
--- a/engine/prefabs/irreden/input/systems/system_hitbox_mouse_test_gui.hpp
+++ b/engine/prefabs/irreden/input/systems/system_hitbox_mouse_test_gui.hpp
@@ -26,67 +26,60 @@ namespace IRSystem {
 inline constexpr float kHitboxGuiIdentityYawEpsilon = 1e-6f;
 
 template <> struct System<HITBOX_MOUSE_TEST_GUI> {
-    struct Params {
-        // Mouse position projected into GUI-canvas-trixel coordinates;
-        // computed once per frame in beginTick, read by every per-entity
-        // hitbox check.
-        vec2 mouseGuiTrixel_ = vec2(0.0f);
-    };
+    // Mouse position projected into GUI-canvas-trixel coordinates;
+    // computed once per frame in beginTick, read by every per-entity
+    // hitbox check.
+    vec2 mouseGuiTrixel_ = vec2(0.0f);
+
+    void tick(C_HitBox2DGui &hitbox, const C_GuiPosition &guiPos) {
+        const vec2 lo = vec2(guiPos.pos_);
+        const vec2 hi = vec2(guiPos.pos_ + hitbox.size_);
+        hitbox.hovered_ = mouseGuiTrixel_.x >= lo.x && mouseGuiTrixel_.x < hi.x &&
+                          mouseGuiTrixel_.y >= lo.y && mouseGuiTrixel_.y < hi.y;
+    }
+
+    void beginTick() {
+        // beginTick lookups assume the "gui" canvas and
+        // "mainFramebuffer" entities already exist. Standard render
+        // setup creates both before INPUT pipelines run, so a creation
+        // that registers HITBOX_MOUSE_TEST_GUI in an INPUT pipeline
+        // gets them for free. A creation registering this system
+        // before its render pipeline has constructed the GUI canvas
+        // would assert here on the first frame.
+        EntityId guiCanvas = IRRender::getCanvas("gui");
+        auto &canvasTextures = IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
+        auto &framebuffer =
+            IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
+
+        const vec2 fbRes = vec2(framebuffer.getResolutionPlusBuffer());
+        const vec2 guiSize = vec2(canvasTextures.size_);
+
+        // The GUI canvas composites into the same framebuffer that
+        // SCREEN_SPACE_RESIDUAL_ROTATE later spins, so its
+        // rendered position rotates too. Inverse the residual yaw
+        // around the framebuffer center on the same backend-aware
+        // axis convention as `system_hitbox_mouse_test`.
+        const float residualYaw = IRPrefab::Camera::getResidualYaw();
+        vec2 mouseFb = IRRender::getMousePositionOutputView();
+        if (IRMath::abs(residualYaw) >= kHitboxGuiIdentityYawEpsilon) {
+            const vec2 fbCenter = fbRes * 0.5f;
+            const float effectiveAngle = -residualYaw * IRPlatform::kGfx.screenYDirection_;
+            mouseFb = IRMath::rotate2D(mouseFb - fbCenter, effectiveAngle) + fbCenter;
+        }
+
+        // The GUI canvas texture (size = mainCanvasSize / guiScale)
+        // is composited onto a quad covering the entire framebuffer:
+        // its `C_TrixelCanvasRenderBehavior` disables camera-pos /
+        // zoom / subdivision hookups, so `system_trixel_to_framebuffer`
+        // builds an identity-translation + framebuffer-scale model
+        // matrix. One framebuffer pixel therefore maps linearly onto
+        // `guiSize / fbRes` GUI trixels.
+        mouseGuiTrixel_ = mouseFb / fbRes * guiSize;
+    }
 
     static SystemId create() {
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
-
-        SystemId systemId = createSystem<C_HitBox2DGui, C_GuiPosition>(
-            "HitBoxMouseTestGui",
-            [p](C_HitBox2DGui &hitbox, const C_GuiPosition &guiPos) {
-                const vec2 lo = vec2(guiPos.pos_);
-                const vec2 hi = vec2(guiPos.pos_ + hitbox.size_);
-                hitbox.hovered_ = p->mouseGuiTrixel_.x >= lo.x && p->mouseGuiTrixel_.x < hi.x &&
-                                  p->mouseGuiTrixel_.y >= lo.y && p->mouseGuiTrixel_.y < hi.y;
-            },
-            [p]() {
-                // beginTick lookups assume the "gui" canvas and
-                // "mainFramebuffer" entities already exist. Standard render
-                // setup creates both before INPUT pipelines run, so a creation
-                // that registers HITBOX_MOUSE_TEST_GUI in an INPUT pipeline
-                // gets them for free. A creation registering this system
-                // before its render pipeline has constructed the GUI canvas
-                // would assert here on the first frame.
-                EntityId guiCanvas = IRRender::getCanvas("gui");
-                auto &canvasTextures = IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
-                auto &framebuffer =
-                    IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
-
-                const vec2 fbRes = vec2(framebuffer.getResolutionPlusBuffer());
-                const vec2 guiSize = vec2(canvasTextures.size_);
-
-                // The GUI canvas composites into the same framebuffer that
-                // SCREEN_SPACE_RESIDUAL_ROTATE later spins, so its
-                // rendered position rotates too. Inverse the residual yaw
-                // around the framebuffer center on the same backend-aware
-                // axis convention as `system_hitbox_mouse_test`.
-                const float residualYaw = IRPrefab::Camera::getResidualYaw();
-                vec2 mouseFb = IRRender::getMousePositionOutputView();
-                if (IRMath::abs(residualYaw) >= kHitboxGuiIdentityYawEpsilon) {
-                    const vec2 fbCenter = fbRes * 0.5f;
-                    const float effectiveAngle = -residualYaw * IRPlatform::kGfx.screenYDirection_;
-                    mouseFb = IRMath::rotate2D(mouseFb - fbCenter, effectiveAngle) + fbCenter;
-                }
-
-                // The GUI canvas texture (size = mainCanvasSize / guiScale)
-                // is composited onto a quad covering the entire framebuffer:
-                // its `C_TrixelCanvasRenderBehavior` disables camera-pos /
-                // zoom / subdivision hookups, so `system_trixel_to_framebuffer`
-                // builds an identity-translation + framebuffer-scale model
-                // matrix. One framebuffer pixel therefore maps linearly onto
-                // `guiSize / fbRes` GUI trixels.
-                p->mouseGuiTrixel_ = mouseFb / fbRes * guiSize;
-            }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
-        return systemId;
+        return registerSystem<HITBOX_MOUSE_TEST_GUI, C_HitBox2DGui, C_GuiPosition>(
+            "HitBoxMouseTestGui");
     }
 };
 


### PR DESCRIPTION
## Summary
- Migrate `system_hitbox_mouse_test_gui.hpp` from explicit `Params + setSystemParams` to member-on-`System<N>` via `registerSystem`
- `mouseGuiTrixel_` moves from nested `Params` struct to direct member field on `System<HITBOX_MOUSE_TEST_GUI>`
- `tick` and `beginTick` become named member functions; `create()` becomes a one-liner
- Canonical example PR for the five-PR migration chain from issue #580
- Pure mechanical 1:1 refactor — behavior, lifetime, and per-tick cost unchanged

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean build
- [x] `fleet-build --target IrredenEngineTest` — 486/486 pass
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — clean run, 6 screenshots captured

Part of the 5-PR chain from issue #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)