### PR TITLE
T-156: Migrate trixel-canvas content systems to member-on-System<N>

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_fog_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_fog_to_trixel.hpp
@@ -40,15 +40,68 @@ constexpr int kFogToTrixelGroupSize = 16;
 // RGBA8 in a transient buffer because the GPU texture format is RGBA8
 // (Metal binding-layout sharing — see C_CanvasSunShadow rationale).
 template <> struct System<FOG_TO_TRIXEL> {
-    struct Params {
-        ShaderProgram *program_ = nullptr;
-        Buffer *voxelFrameDataBuf_ = nullptr;
-        // Reusable CPU staging buffer for the .r → RGBA8 expansion.
-        // Single shared scratch keeps per-frame uploads allocation-free
-        // regardless of how many fog canvases exist — system ticks are
-        // serial. value-init on resize zeros GBA bytes we never write.
-        std::vector<std::uint8_t> uploadScratch_;
-    };
+    ShaderProgram *program_ = nullptr;
+    Buffer *voxelFrameDataBuf_ = nullptr;
+    // Reusable CPU staging buffer for the .r → RGBA8 expansion.
+    // Single shared scratch keeps per-frame uploads allocation-free
+    // regardless of how many fog canvases exist — system ticks are
+    // serial. value-init on resize zeros GBA bytes we never write.
+    std::vector<std::uint8_t> uploadScratch_;
+
+    void tick(
+        const C_TriangleCanvasTextures &canvasTextures,
+        const C_TrixelCanvasRenderBehavior &behavior,
+        C_CanvasFogOfWar &fog
+    ) {
+        IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
+        if (!behavior.useCameraPositionIso_) {
+            return;
+        }
+
+        if (fog.dirty_) {
+            const std::size_t cellCount = fog.cpuBuffer_.size();
+            if (uploadScratch_.size() < cellCount * 4) {
+                uploadScratch_.resize(cellCount * 4);
+            }
+            // Only the .r channel ever changes; GBA stay at the
+            // zero-init from resize. Cuts per-dirty-frame stores
+            // 4×, ~256K → ~64K at 256² grid.
+            for (std::size_t i = 0; i < cellCount; ++i) {
+                uploadScratch_[i * 4] = fog.cpuBuffer_[i];
+            }
+            fog.getTexture()->subImage2D(
+                0,
+                0,
+                kFogOfWarSize,
+                kFogOfWarSize,
+                PixelDataFormat::RGBA,
+                PixelDataType::UNSIGNED_BYTE,
+                uploadScratch_.data()
+            );
+            fog.dirty_ = false;
+        }
+
+        canvasTextures.getTextureColors()
+            ->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
+        canvasTextures.getTextureDistances()
+            ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+        fog.getTexture()->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+        // FrameDataVoxelToTrixel carries frameCanvasOffset /
+        // trixelCanvasOffsetZ1 / voxelRenderOptions — needed for
+        // the iso pixel → world pos3D recovery in the shader.
+        // Each pass that consumes it re-binds explicitly because
+        // any intervening dispatch may have rebound binding 7.
+        voxelFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataVoxelToCanvas);
+
+        const int groupsX = IRMath::divCeil(canvasTextures.size_.x, kFogToTrixelGroupSize);
+        const int groupsY = IRMath::divCeil(canvasTextures.size_.y, kFogToTrixelGroupSize);
+        IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
+        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+    }
+
+    void beginTick() {
+        program_->use();
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
@@ -56,72 +109,14 @@ template <> struct System<FOG_TO_TRIXEL> {
             std::vector{ShaderStage{IRRender::kFileCompFogToTrixel, ShaderType::COMPUTE}}
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
+        SystemId systemId = registerSystem<
+            FOG_TO_TRIXEL,
+            C_TriangleCanvasTextures,
+            C_TrixelCanvasRenderBehavior,
+            C_CanvasFogOfWar>("FogToTrixel");
+        auto *p = getSystemParams<System<FOG_TO_TRIXEL>>(systemId);
         p->program_ = IRRender::getNamedResource<ShaderProgram>("FogToTrixelProgram");
         p->voxelFrameDataBuf_ = IRRender::getNamedResource<Buffer>("SingleVoxelFrameData");
-
-        SystemId systemId =
-            createSystem<C_TriangleCanvasTextures, C_TrixelCanvasRenderBehavior, C_CanvasFogOfWar>(
-                "FogToTrixel",
-                [p](const C_TriangleCanvasTextures &canvasTextures,
-                    const C_TrixelCanvasRenderBehavior &behavior,
-                    C_CanvasFogOfWar &fog) {
-                    IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
-                    if (!behavior.useCameraPositionIso_) {
-                        return;
-                    }
-
-                    if (fog.dirty_) {
-                        const std::size_t cellCount = fog.cpuBuffer_.size();
-                        if (p->uploadScratch_.size() < cellCount * 4) {
-                            p->uploadScratch_.resize(cellCount * 4);
-                        }
-                        // Only the .r channel ever changes; GBA stay at the
-                        // zero-init from resize. Cuts per-dirty-frame stores
-                        // 4×, ~256K → ~64K at 256² grid.
-                        for (std::size_t i = 0; i < cellCount; ++i) {
-                            p->uploadScratch_[i * 4] = fog.cpuBuffer_[i];
-                        }
-                        fog.getTexture()->subImage2D(
-                            0,
-                            0,
-                            kFogOfWarSize,
-                            kFogOfWarSize,
-                            PixelDataFormat::RGBA,
-                            PixelDataType::UNSIGNED_BYTE,
-                            p->uploadScratch_.data()
-                        );
-                        fog.dirty_ = false;
-                    }
-
-                    canvasTextures.getTextureColors()
-                        ->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
-                    canvasTextures.getTextureDistances()
-                        ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-                    fog.getTexture()
-                        ->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-                    // FrameDataVoxelToTrixel carries frameCanvasOffset /
-                    // trixelCanvasOffsetZ1 / voxelRenderOptions — needed for
-                    // the iso pixel → world pos3D recovery in the shader.
-                    // Each pass that consumes it re-binds explicitly because
-                    // any intervening dispatch may have rebound binding 7.
-                    p->voxelFrameDataBuf_->bindBase(
-                        BufferTarget::UNIFORM,
-                        kBufferIndex_FrameDataVoxelToCanvas
-                    );
-
-                    const int groupsX =
-                        IRMath::divCeil(canvasTextures.size_.x, kFogToTrixelGroupSize);
-                    const int groupsY =
-                        IRMath::divCeil(canvasTextures.size_.y, kFogToTrixelGroupSize);
-                    IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
-                    IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-                },
-                [p]() { p->program_->use(); }
-            );
-
-        setSystemParams(systemId, std::move(paramsOwner));
         IRRender::tagGpuStage(systemId, "fogToTrixel");
         return systemId;
     }

--- a/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
@@ -36,32 +36,229 @@ constexpr int kShapeTileSize = 8;
 template <> struct System<SHAPES_TO_TRIXEL> {
     using CanvasId = IREntity::EntityId;
 
-    struct Params {
-        ShaderProgram *shapesProgram_ = nullptr;
-        Buffer *shapeDescBuf_ = nullptr;
-        Buffer *shapesFrameDataBuf_ = nullptr;
-        Buffer *shapeTileDescBuf_ = nullptr;
-        GPUShapesFrameData frameData_{};
-        std::unordered_map<CanvasId, std::vector<GPUShapeDescriptor>> gpuShapesByCanvas_;
-        std::optional<IsoBounds2D> cullBounds_;
-        // Camera Z-yaw snapshotted at beginTick so the cull pass and the
-        // per-tile dispatch share byte-identical values even if a script
-        // mutates yaw mid-frame. visualYaw_ is split via computeYawSplit
-        // into rasterYaw_ (cardinal multiple of pi/2) + residualYaw_; the
-        // shapes shader rasterizes at rasterYaw_ so its output aligns with
-        // the voxel pool's cardinal-snap raster, and yawCos_/yawSin_ are
-        // the cos/sin of rasterYaw_ (always exact ±1 / 0). yawZero_ is
-        // the rasterYaw==0 fast path; it stays true for visualYaw inside
-        // (-pi/4, +pi/4) where rasterYaw rounds to 0. residualYaw_ is
-        // mirrored into the UBO for shaders downstream of this pass; the
-        // CPU side of this system does not consume it.
-        float visualYaw_ = 0.0f;
-        float rasterYaw_ = 0.0f;
-        float residualYaw_ = 0.0f;
-        float yawCos_ = 1.0f;
-        float yawSin_ = 0.0f;
-        bool yawZero_ = true;
-    };
+    ShaderProgram *shapesProgram_ = nullptr;
+    Buffer *shapeDescBuf_ = nullptr;
+    Buffer *shapesFrameDataBuf_ = nullptr;
+    Buffer *shapeTileDescBuf_ = nullptr;
+    GPUShapesFrameData frameData_{};
+    std::unordered_map<CanvasId, std::vector<GPUShapeDescriptor>> gpuShapesByCanvas_;
+    std::optional<IsoBounds2D> cullBounds_;
+    // Camera Z-yaw snapshotted at beginTick so the cull pass and the
+    // per-tile dispatch share byte-identical values even if a script
+    // mutates yaw mid-frame. visualYaw_ is split via computeYawSplit
+    // into rasterYaw_ (cardinal multiple of pi/2) + residualYaw_; the
+    // shapes shader rasterizes at rasterYaw_ so its output aligns with
+    // the voxel pool's cardinal-snap raster, and yawCos_/yawSin_ are
+    // the cos/sin of rasterYaw_ (always exact ±1 / 0). yawZero_ is
+    // the rasterYaw==0 fast path; it stays true for visualYaw inside
+    // (-pi/4, +pi/4) where rasterYaw rounds to 0. residualYaw_ is
+    // mirrored into the UBO for shaders downstream of this pass; the
+    // CPU side of this system does not consume it.
+    float visualYaw_ = 0.0f;
+    float rasterYaw_ = 0.0f;
+    float residualYaw_ = 0.0f;
+    float yawCos_ = 1.0f;
+    float yawSin_ = 0.0f;
+    bool yawZero_ = true;
+
+    void tick(
+        IREntity::EntityId entityId, const C_ShapeDescriptor &shape, const C_PositionGlobal3D &pos
+    ) {
+        if (cullBounds_.has_value()) {
+            vec3 viewPos = pos.pos_;
+            vec3 sizeForExtent = vec3(shape.params_);
+            if (!yawZero_) {
+                viewPos = vec3(
+                    yawCos_ * pos.pos_.x + yawSin_ * pos.pos_.y,
+                    -yawSin_ * pos.pos_.x + yawCos_ * pos.pos_.y,
+                    pos.pos_.z
+                );
+                const float absC = IRMath::abs(yawCos_);
+                const float absS = IRMath::abs(yawSin_);
+                sizeForExtent = vec3(
+                    sizeForExtent.x * absC + sizeForExtent.y * absS,
+                    sizeForExtent.x * absS + sizeForExtent.y * absC,
+                    sizeForExtent.z
+                );
+            }
+            vec2 shapeIsoPosition = IRMath::pos3DtoPos2DIso(viewPos);
+            vec2 shapeIsoHalfExtent = IRMath::shapeIsoHalfExtent(sizeForExtent);
+            if (shapeIsoPosition.x + shapeIsoHalfExtent.x < cullBounds_->min_.x ||
+                shapeIsoPosition.x - shapeIsoHalfExtent.x > cullBounds_->max_.x ||
+                shapeIsoPosition.y + shapeIsoHalfExtent.y < cullBounds_->min_.y ||
+                shapeIsoPosition.y - shapeIsoHalfExtent.y > cullBounds_->max_.y) {
+                return;
+            }
+        }
+
+        CanvasId canvas = shape.canvasEntity_;
+        if (canvas == IREntity::kNullEntity) {
+            canvas = IRRender::getActiveCanvasEntity();
+        }
+
+        auto &bucket = gpuShapesByCanvas_[canvas];
+        if (static_cast<int>(bucket.size()) >= kMaxShapeDescriptors) {
+            return;
+        }
+        GPUShapeDescriptor desc{};
+        desc.worldPosition = vec4(pos.pos_, 1.0f);
+        desc.params = shape.params_;
+        desc.shapeType = static_cast<std::uint32_t>(shape.shapeType_);
+        desc.color = shape.color_.toPackedRGBA();
+        desc.entityId = entityId;
+        desc.jointIndex = 0;
+        desc.flags = shape.flags_;
+        desc.lodLevel = shape.lodLevel_;
+        bucket.push_back(desc);
+    }
+
+    void beginTick() {
+        gpuShapesByCanvas_.clear();
+
+        // Snapshot camera yaw once for the whole tick so the cull
+        // pass and the per-tile dispatch share the same value, even
+        // if a script mutates yaw mid-frame. The shape SDF
+        // rasterizes at rasterYaw (cardinal-snap) so it lines up
+        // trixel-for-trixel with the voxel pool's cardinal-snap
+        // raster (T-055); the screen-space residual rotate pass
+        // (T-058) handles the leftover residualYaw on screen.
+        visualYaw_ = IRPrefab::Camera::getYaw();
+        const auto [rasterYaw, residualYaw] = IRPrefab::Camera::computeYawSplit(visualYaw_);
+        rasterYaw_ = rasterYaw;
+        residualYaw_ = residualYaw;
+        static constexpr float kCardinalCos[4] = {1.f, 0.f, -1.f, 0.f};
+        static constexpr float kCardinalSin[4] = {0.f, 1.f, 0.f, -1.f};
+        constexpr float kHalfPi = 1.5707963267948966f;
+        const int q = IRMath::round(rasterYaw / kHalfPi);
+        const int cardinalIdx = ((q % 4) + 4) % 4;
+        yawCos_ = kCardinalCos[cardinalIdx];
+        yawSin_ = kCardinalSin[cardinalIdx];
+        yawZero_ = (rasterYaw_ == 0.0f);
+
+        IREntity::EntityId mainCanvas = IRRender::getActiveCanvasEntity();
+        auto texOpt = IREntity::getComponentOptional<C_TriangleCanvasTextures>(mainCanvas);
+        if (texOpt.has_value()) {
+            IRRender::updateCullViewport(
+                IRRender::getCameraPosition2DIso(),
+                IRRender::getCameraZoom(),
+                texOpt.value()->size_
+            );
+            constexpr int kMargin = 4;
+            // Widen to the shadow-feeder AABB (visible ∪ swept along
+            // -sunDir by kSunShadowMaxDistance) so off-screen SDF
+            // casters still write distances into trixelDistances and
+            // feed BAKE_SUN_SHADOW_MAP. The same widened bounds are
+            // uploaded as cullIsoMin/Max in endTick so per-tile
+            // shaders never clip a shadow-feeder pixel. Sun-direction
+            // resolution is gated on the shadow flag so a disabled-
+            // shadow creation skips the C_LightSource archetype scan.
+            const bool shadowsEnabled = IRRender::getSunShadowsEnabled();
+            const vec3 sunDir =
+                shadowsEnabled ? IRPrefab::SunShadow::getFrameSunDirection() : vec3(0.0f);
+            const float sweepDistance =
+                shadowsEnabled ? IRPrefab::SunShadow::kSunShadowMaxDistance : 0.0f;
+            cullBounds_ = IRMath::shadowFeederIsoBounds(
+                IRRender::getCullViewport().isoViewport(kMargin),
+                sunDir,
+                sweepDistance
+            );
+        } else {
+            cullBounds_.reset();
+        }
+    }
+
+    void endTick() {
+        IREntity::EntityId mainCanvas = IRRender::getActiveCanvasEntity();
+        const float visualYaw = visualYaw_;
+        const float rasterYaw = rasterYaw_;
+        const float residualYaw = residualYaw_;
+
+        for (auto &[canvasId, gpuShapes] : gpuShapesByCanvas_) {
+            if (gpuShapes.empty()) {
+                continue;
+            }
+
+            auto texturesOpt = IREntity::getComponentOptional<C_TriangleCanvasTextures>(canvasId);
+            if (!texturesOpt.has_value()) {
+                continue;
+            }
+            auto &canvasTextures = *texturesOpt.value();
+
+            if (canvasId == mainCanvas) {
+                frameData_.cameraTrixelOffset = IRRender::getCameraPosition2DIso();
+            } else {
+                canvasTextures.clear();
+                vec3 entityPos = vec3(gpuShapes[0].worldPosition);
+                frameData_.cameraTrixelOffset = -pos3DtoPos2DIso(entityPos);
+            }
+            frameData_.trixelCanvasOffsetZ1 = IRMath::trixelOriginOffsetZ1(canvasTextures.size_);
+            frameData_.canvasSize = canvasTextures.size_;
+            frameData_.shapeCount = static_cast<int>(gpuShapes.size());
+            const auto renderMode = IRRender::getSubdivisionMode();
+            const int effectiveSub = IRRender::getVoxelRenderEffectiveSubdivisions();
+            frameData_.voxelRenderOptions = ivec2(static_cast<int>(renderMode), effectiveSub);
+            if (cullBounds_.has_value() && canvasId == mainCanvas) {
+                frameData_.cullIsoMin = ivec2(IRMath::floor(cullBounds_->min_));
+                frameData_.cullIsoMax = ivec2(IRMath::ceil(cullBounds_->max_));
+            } else {
+                frameData_.cullIsoMin = ivec2(-999999);
+                frameData_.cullIsoMax = ivec2(999999);
+            }
+            frameData_.visualYaw = visualYaw;
+            frameData_.rasterYaw = rasterYaw;
+            frameData_.residualYaw = residualYaw;
+
+            shapeDescBuf_
+                ->subData(0, gpuShapes.size() * sizeof(GPUShapeDescriptor), gpuShapes.data());
+
+            // Tile bounds are computed at rasterYaw — same rotation
+            // the shader uses to rasterize each shape — so the
+            // per-tile iso footprint matches the SDF surface that
+            // pixel ends up writing.
+            const int tileCount = buildAndUploadTileDescriptors(
+                gpuShapes,
+                shapeTileDescBuf_,
+                effectiveSub,
+                renderMode,
+                rasterYaw,
+                yawCos_,
+                yawSin_
+            );
+            if (tileCount == 0) {
+                continue;
+            }
+
+            shapesProgram_->use();
+            shapeDescBuf_->bindBase(BufferTarget::SHADER_STORAGE, kBufferIndex_ShapeDescriptors);
+            canvasTextures.getTextureDistances()
+                ->bindAsImage(1, TextureAccess::READ_WRITE, TextureFormat::R32I);
+
+            shapesFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_ShapesFrameData);
+
+            // Pass 0: depth via imageAtomicMin
+            frameData_.passIndex = 0;
+            shapesFrameDataBuf_->subData(0, sizeof(GPUShapesFrameData), &frameData_);
+
+            IRRender::device()->dispatchCompute(static_cast<std::uint32_t>(tileCount), 1, 1);
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+
+            // Pass 1: color + entity ID where depth matches
+            canvasTextures.getTextureColors()
+                ->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
+            canvasTextures.getTextureEntityIds()
+                ->bindAsImage(2, TextureAccess::WRITE_ONLY, TextureFormat::RG32UI);
+
+            frameData_.passIndex = 1;
+            shapesFrameDataBuf_->subData(0, sizeof(GPUShapesFrameData), &frameData_);
+
+            IRRender::device()->dispatchCompute(static_cast<std::uint32_t>(tileCount), 1, 1);
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+
+            auto &timing = IRRender::gpuStageTiming();
+            timing.visibleShapeCount_ = static_cast<std::uint32_t>(gpuShapes.size());
+            timing.shapeGroupsZ_ = 0;
+        }
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
@@ -109,229 +306,14 @@ template <> struct System<SHAPES_TO_TRIXEL> {
             kBufferIndex_ShapeTileDescriptors
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
+        SystemId systemId = registerSystem<SHAPES_TO_TRIXEL, C_ShapeDescriptor, C_PositionGlobal3D>(
+            "ShapesToTrixel"
+        );
+        auto *p = getSystemParams<System<SHAPES_TO_TRIXEL>>(systemId);
         p->shapesProgram_ = IRRender::getNamedResource<ShaderProgram>("ShapesToTrixelProgram");
         p->shapeDescBuf_ = IRRender::getNamedResource<Buffer>("ShapeDescriptorBuffer");
         p->shapesFrameDataBuf_ = IRRender::getNamedResource<Buffer>("ShapesFrameDataBuffer");
         p->shapeTileDescBuf_ = IRRender::getNamedResource<Buffer>("ShapeTileDescriptorBuffer");
-
-        SystemId systemId = createSystem<C_ShapeDescriptor, C_PositionGlobal3D>(
-            "ShapesToTrixel",
-            [p](IREntity::EntityId &entityId,
-                const C_ShapeDescriptor &shape,
-                const C_PositionGlobal3D &pos) {
-                if (p->cullBounds_.has_value()) {
-                    vec3 viewPos = pos.pos_;
-                    vec3 sizeForExtent = vec3(shape.params_);
-                    if (!p->yawZero_) {
-                        viewPos = vec3(
-                            p->yawCos_ * pos.pos_.x + p->yawSin_ * pos.pos_.y,
-                            -p->yawSin_ * pos.pos_.x + p->yawCos_ * pos.pos_.y,
-                            pos.pos_.z
-                        );
-                        const float absC = IRMath::abs(p->yawCos_);
-                        const float absS = IRMath::abs(p->yawSin_);
-                        sizeForExtent = vec3(
-                            sizeForExtent.x * absC + sizeForExtent.y * absS,
-                            sizeForExtent.x * absS + sizeForExtent.y * absC,
-                            sizeForExtent.z
-                        );
-                    }
-                    vec2 shapeIsoPosition = IRMath::pos3DtoPos2DIso(viewPos);
-                    vec2 shapeIsoHalfExtent = IRMath::shapeIsoHalfExtent(sizeForExtent);
-                    if (shapeIsoPosition.x + shapeIsoHalfExtent.x < p->cullBounds_->min_.x ||
-                        shapeIsoPosition.x - shapeIsoHalfExtent.x > p->cullBounds_->max_.x ||
-                        shapeIsoPosition.y + shapeIsoHalfExtent.y < p->cullBounds_->min_.y ||
-                        shapeIsoPosition.y - shapeIsoHalfExtent.y > p->cullBounds_->max_.y) {
-                        return;
-                    }
-                }
-
-                CanvasId canvas = shape.canvasEntity_;
-                if (canvas == IREntity::kNullEntity) {
-                    canvas = IRRender::getActiveCanvasEntity();
-                }
-
-                auto &bucket = p->gpuShapesByCanvas_[canvas];
-                if (static_cast<int>(bucket.size()) >= kMaxShapeDescriptors) {
-                    return;
-                }
-                GPUShapeDescriptor desc{};
-                desc.worldPosition = vec4(pos.pos_, 1.0f);
-                desc.params = shape.params_;
-                desc.shapeType = static_cast<std::uint32_t>(shape.shapeType_);
-                desc.color = shape.color_.toPackedRGBA();
-                desc.entityId = entityId;
-                desc.jointIndex = 0;
-                desc.flags = shape.flags_;
-                desc.lodLevel = shape.lodLevel_;
-                bucket.push_back(desc);
-            },
-            [p]() {
-                p->gpuShapesByCanvas_.clear();
-
-                // Snapshot camera yaw once for the whole tick so the cull
-                // pass and the per-tile dispatch share the same value, even
-                // if a script mutates yaw mid-frame. The shape SDF
-                // rasterizes at rasterYaw (cardinal-snap) so it lines up
-                // trixel-for-trixel with the voxel pool's cardinal-snap
-                // raster (T-055); the screen-space residual rotate pass
-                // (T-058) handles the leftover residualYaw on screen.
-                p->visualYaw_ = IRPrefab::Camera::getYaw();
-                const auto [rasterYaw, residualYaw] =
-                    IRPrefab::Camera::computeYawSplit(p->visualYaw_);
-                p->rasterYaw_ = rasterYaw;
-                p->residualYaw_ = residualYaw;
-                static constexpr float kCardinalCos[4] = {1.f, 0.f, -1.f, 0.f};
-                static constexpr float kCardinalSin[4] = {0.f, 1.f, 0.f, -1.f};
-                constexpr float kHalfPi = 1.5707963267948966f;
-                const int q = IRMath::round(rasterYaw / kHalfPi);
-                const int cardinalIdx = ((q % 4) + 4) % 4;
-                p->yawCos_ = kCardinalCos[cardinalIdx];
-                p->yawSin_ = kCardinalSin[cardinalIdx];
-                p->yawZero_ = (p->rasterYaw_ == 0.0f);
-
-                IREntity::EntityId mainCanvas = IRRender::getActiveCanvasEntity();
-                auto texOpt = IREntity::getComponentOptional<C_TriangleCanvasTextures>(mainCanvas);
-                if (texOpt.has_value()) {
-                    IRRender::updateCullViewport(
-                        IRRender::getCameraPosition2DIso(),
-                        IRRender::getCameraZoom(),
-                        texOpt.value()->size_
-                    );
-                    constexpr int kMargin = 4;
-                    // Widen to the shadow-feeder AABB (visible ∪ swept along
-                    // -sunDir by kSunShadowMaxDistance) so off-screen SDF
-                    // casters still write distances into trixelDistances and
-                    // feed BAKE_SUN_SHADOW_MAP. The same widened bounds are
-                    // uploaded as cullIsoMin/Max in endTick so per-tile
-                    // shaders never clip a shadow-feeder pixel. Sun-direction
-                    // resolution is gated on the shadow flag so a disabled-
-                    // shadow creation skips the C_LightSource archetype scan.
-                    const bool shadowsEnabled = IRRender::getSunShadowsEnabled();
-                    const vec3 sunDir =
-                        shadowsEnabled ? IRPrefab::SunShadow::getFrameSunDirection() : vec3(0.0f);
-                    const float sweepDistance =
-                        shadowsEnabled ? IRPrefab::SunShadow::kSunShadowMaxDistance : 0.0f;
-                    p->cullBounds_ = IRMath::shadowFeederIsoBounds(
-                        IRRender::getCullViewport().isoViewport(kMargin),
-                        sunDir,
-                        sweepDistance
-                    );
-                } else {
-                    p->cullBounds_.reset();
-                }
-            },
-            [p]() {
-                IREntity::EntityId mainCanvas = IRRender::getActiveCanvasEntity();
-                const float visualYaw = p->visualYaw_;
-                const float rasterYaw = p->rasterYaw_;
-                const float residualYaw = p->residualYaw_;
-
-                for (auto &[canvasId, gpuShapes] : p->gpuShapesByCanvas_) {
-                    if (gpuShapes.empty()) {
-                        continue;
-                    }
-
-                    auto texturesOpt =
-                        IREntity::getComponentOptional<C_TriangleCanvasTextures>(canvasId);
-                    if (!texturesOpt.has_value()) {
-                        continue;
-                    }
-                    auto &canvasTextures = *texturesOpt.value();
-
-                    if (canvasId == mainCanvas) {
-                        p->frameData_.cameraTrixelOffset = IRRender::getCameraPosition2DIso();
-                    } else {
-                        canvasTextures.clear();
-                        vec3 entityPos = vec3(gpuShapes[0].worldPosition);
-                        p->frameData_.cameraTrixelOffset = -pos3DtoPos2DIso(entityPos);
-                    }
-                    p->frameData_.trixelCanvasOffsetZ1 =
-                        IRMath::trixelOriginOffsetZ1(canvasTextures.size_);
-                    p->frameData_.canvasSize = canvasTextures.size_;
-                    p->frameData_.shapeCount = static_cast<int>(gpuShapes.size());
-                    const auto renderMode = IRRender::getSubdivisionMode();
-                    const int effectiveSub = IRRender::getVoxelRenderEffectiveSubdivisions();
-                    p->frameData_.voxelRenderOptions =
-                        ivec2(static_cast<int>(renderMode), effectiveSub);
-                    if (p->cullBounds_.has_value() && canvasId == mainCanvas) {
-                        p->frameData_.cullIsoMin = ivec2(IRMath::floor(p->cullBounds_->min_));
-                        p->frameData_.cullIsoMax = ivec2(IRMath::ceil(p->cullBounds_->max_));
-                    } else {
-                        p->frameData_.cullIsoMin = ivec2(-999999);
-                        p->frameData_.cullIsoMax = ivec2(999999);
-                    }
-                    p->frameData_.visualYaw = visualYaw;
-                    p->frameData_.rasterYaw = rasterYaw;
-                    p->frameData_.residualYaw = residualYaw;
-
-                    p->shapeDescBuf_->subData(
-                        0,
-                        gpuShapes.size() * sizeof(GPUShapeDescriptor),
-                        gpuShapes.data()
-                    );
-
-                    // Tile bounds are computed at rasterYaw — same rotation
-                    // the shader uses to rasterize each shape — so the
-                    // per-tile iso footprint matches the SDF surface that
-                    // pixel ends up writing.
-                    const int tileCount = buildAndUploadTileDescriptors(
-                        gpuShapes,
-                        p->shapeTileDescBuf_,
-                        effectiveSub,
-                        renderMode,
-                        rasterYaw,
-                        p->yawCos_,
-                        p->yawSin_
-                    );
-                    if (tileCount == 0) {
-                        continue;
-                    }
-
-                    p->shapesProgram_->use();
-                    p->shapeDescBuf_->bindBase(
-                        BufferTarget::SHADER_STORAGE,
-                        kBufferIndex_ShapeDescriptors
-                    );
-                    canvasTextures.getTextureDistances()
-                        ->bindAsImage(1, TextureAccess::READ_WRITE, TextureFormat::R32I);
-
-                    p->shapesFrameDataBuf_->bindBase(
-                        BufferTarget::UNIFORM,
-                        kBufferIndex_ShapesFrameData
-                    );
-
-                    // Pass 0: depth via imageAtomicMin
-                    p->frameData_.passIndex = 0;
-                    p->shapesFrameDataBuf_->subData(0, sizeof(GPUShapesFrameData), &p->frameData_);
-
-                    IRRender::device()
-                        ->dispatchCompute(static_cast<std::uint32_t>(tileCount), 1, 1);
-                    IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-                    // Pass 1: color + entity ID where depth matches
-                    canvasTextures.getTextureColors()
-                        ->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
-                    canvasTextures.getTextureEntityIds()
-                        ->bindAsImage(2, TextureAccess::WRITE_ONLY, TextureFormat::RG32UI);
-
-                    p->frameData_.passIndex = 1;
-                    p->shapesFrameDataBuf_->subData(0, sizeof(GPUShapesFrameData), &p->frameData_);
-
-                    IRRender::device()
-                        ->dispatchCompute(static_cast<std::uint32_t>(tileCount), 1, 1);
-                    IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-
-                    auto &timing = IRRender::gpuStageTiming();
-                    timing.visibleShapeCount_ = static_cast<std::uint32_t>(gpuShapes.size());
-                    timing.shapeGroupsZ_ = 0;
-                }
-            }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
         // Per-system bracket covers both pass 0 (depth) and pass 1 (color/id);
         // the formerly-separate shapePass0 slot stays at 0.0f for API stability.
         IRRender::tagGpuStage(systemId, "shapePass1");

--- a/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
@@ -35,7 +35,8 @@ inline std::vector<uint32_t> buildFontBuffer() {
     std::vector<uint32_t> buf(kFontBufferSize, 0);
     for (int ascii = 0; ascii < kFontTableEntries; ++ascii) {
         const IRRender::Glyph *g = IRRender::getGlyph(static_cast<char>(ascii));
-        if (!g) continue;
+        if (!g)
+            continue;
         for (int row = 0; row < kFontRowsPerGlyph; ++row) {
             buf[ascii * kFontRowsPerGlyph + row] = static_cast<uint32_t>((*g)[row]);
         }
@@ -43,12 +44,24 @@ inline std::vector<uint32_t> buildFontBuffer() {
     return buf;
 }
 
-inline int glyphWidth(int fontSize) { return IRRender::kGlyphWidth * fontSize; }
-inline int glyphHeight(int fontSize) { return IRRender::kGlyphHeight * fontSize; }
-inline int glyphStepX(int fontSize) { return IRRender::kGlyphStepX * fontSize; }
-inline int glyphStepY(int fontSize) { return IRRender::kGlyphStepY * fontSize; }
-inline int glyphSpacingX(int fontSize) { return IRRender::kGlyphSpacingX * fontSize; }
-inline int glyphSpacingY(int fontSize) { return IRRender::kGlyphSpacingY * fontSize; }
+inline int glyphWidth(int fontSize) {
+    return IRRender::kGlyphWidth * fontSize;
+}
+inline int glyphHeight(int fontSize) {
+    return IRRender::kGlyphHeight * fontSize;
+}
+inline int glyphStepX(int fontSize) {
+    return IRRender::kGlyphStepX * fontSize;
+}
+inline int glyphStepY(int fontSize) {
+    return IRRender::kGlyphStepY * fontSize;
+}
+inline int glyphSpacingX(int fontSize) {
+    return IRRender::kGlyphSpacingX * fontSize;
+}
+inline int glyphSpacingY(int fontSize) {
+    return IRRender::kGlyphSpacingY * fontSize;
+}
 
 inline int nextWordWidth(const std::string &text, size_t i, int fontSize) {
     int width = 0;
@@ -80,14 +93,17 @@ inline void expandTextToCommands(
     const int stepY = glyphStepY(fontSize);
     const int spacX = glyphSpacingX(fontSize);
     const int spacY = glyphSpacingY(fontSize);
-    const int effectiveWrap = (wrapWidth > 0)
-        ? aligned.x + wrapWidth
-        : (wrapWidth < 0 ? canvasSize.x : 0);
+    const int effectiveWrap =
+        (wrapWidth > 0) ? aligned.x + wrapWidth : (wrapWidth < 0 ? canvasSize.x : 0);
     uint32_t packed = color.toPackedRGBA();
 
     const size_t firstCmd = commands.size();
 
-    struct LineInfo { size_t firstIndex_; size_t count_; int width_; };
+    struct LineInfo {
+        size_t firstIndex_;
+        size_t count_;
+        int width_;
+    };
     std::vector<LineInfo> lines;
     lines.push_back({firstCmd, 0, 0});
 
@@ -144,20 +160,25 @@ inline void expandTextToCommands(
     if (lines.back().width_ > 0)
         lines.back().width_ -= spacX;
 
-    if (alignH == TextAlignH::LEFT && alignV == TextAlignV::TOP) return;
+    if (alignH == TextAlignH::LEFT && alignV == TextAlignV::TOP)
+        return;
 
     const int refW = (boxWidth > 0) ? boxWidth : canvasSize.x;
     const int refH = (boxHeight > 0) ? boxHeight : canvasSize.y;
     const int totalTextH = static_cast<int>(lines.size()) * stepY - spacY;
 
     int offsetY = 0;
-    if (alignV == TextAlignV::CENTER) offsetY = (refH - totalTextH) / 2;
-    else if (alignV == TextAlignV::BOTTOM) offsetY = refH - totalTextH;
+    if (alignV == TextAlignV::CENTER)
+        offsetY = (refH - totalTextH) / 2;
+    else if (alignV == TextAlignV::BOTTOM)
+        offsetY = refH - totalTextH;
 
     for (auto &line : lines) {
         int offsetX = 0;
-        if (alignH == TextAlignH::CENTER) offsetX = (refW - line.width_) / 2;
-        else if (alignH == TextAlignH::RIGHT) offsetX = refW - line.width_;
+        if (alignH == TextAlignH::CENTER)
+            offsetX = (refW - line.width_) / 2;
+        else if (alignH == TextAlignH::RIGHT)
+            offsetX = refW - line.width_;
 
         int roundedX = (offsetX / 2) * 2;
         int roundedY = (offsetY / 2) * 2;
@@ -166,28 +187,101 @@ inline void expandTextToCommands(
             auto &cmd = commands[line.firstIndex_ + j];
             int cx = static_cast<int>(cmd.positionPacked & 0xFFFF) + roundedX;
             int cy = static_cast<int>(cmd.positionPacked >> 16) + roundedY;
-            cmd.positionPacked = static_cast<uint32_t>(cx & 0xFFFF) |
-                                 (static_cast<uint32_t>(cy & 0xFFFF) << 16);
+            cmd.positionPacked =
+                static_cast<uint32_t>(cx & 0xFFFF) | (static_cast<uint32_t>(cy & 0xFFFF) << 16);
         }
     }
 }
 
 template <> struct System<TEXT_TO_TRIXEL> {
-    struct Params {
-        ShaderProgram *textProgram_ = nullptr;
-        Buffer *fontDataBuf_ = nullptr;
-        Buffer *glyphCmdBuf_ = nullptr;
-        std::vector<GlyphDrawCommand> drawCommands_;
-        std::string commandList_;
-        bool fontUploaded_ = false;
-    };
+    ShaderProgram *textProgram_ = nullptr;
+    Buffer *fontDataBuf_ = nullptr;
+    Buffer *glyphCmdBuf_ = nullptr;
+    std::vector<GlyphDrawCommand> drawCommands_;
+    std::string commandList_;
+    bool fontUploaded_ = false;
+
+    void tick(
+        const C_TextSegment &text,
+        const C_GuiPosition &guiPos,
+        const C_GuiElement &,
+        const C_TextStyle &style
+    ) {
+        EntityId guiCanvas = IRRender::getCanvas("gui");
+        auto &canvasTextures = IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
+
+        expandTextToCommands(
+            drawCommands_,
+            text.text_,
+            guiPos.pos_,
+            canvasTextures.size_,
+            style.color_,
+            style.wrapWidth_,
+            style.alignH_,
+            style.alignV_,
+            style.boxWidth_,
+            style.boxHeight_,
+            style.fontSize_
+        );
+    }
+
+    void beginTick() {
+        textProgram_->use();
+
+        if (!fontUploaded_) {
+            auto fontData = buildFontBuffer();
+            fontDataBuf_->subData(0, fontData.size() * sizeof(uint32_t), fontData.data());
+            fontUploaded_ = true;
+        }
+
+        EntityId guiCanvas = IRRender::getCanvas("gui");
+        auto &canvasTextures = IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
+        canvasTextures.clear();
+
+        drawCommands_.clear();
+
+        if (IRRender::isGuiVisible()) {
+            if (commandList_.empty()) {
+                commandList_ = IRCommand::buildCommandListText();
+            }
+            expandTextToCommands(
+                drawCommands_,
+                commandList_,
+                kGuiOverlayPadding,
+                canvasTextures.size_,
+                IRMath::IRColors::kWhite,
+                0
+            );
+        }
+    }
+
+    void endTick() {
+        if (drawCommands_.empty())
+            return;
+
+        int count = static_cast<int>(drawCommands_.size());
+        if (count > kMaxGlyphCommands) {
+            count = kMaxGlyphCommands;
+        }
+
+        glyphCmdBuf_->subData(0, count * sizeof(GlyphDrawCommand), drawCommands_.data());
+
+        EntityId guiCanvas = IRRender::getCanvas("gui");
+        auto &canvasTextures = IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
+        canvasTextures.getTextureColors()
+            ->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
+        canvasTextures.getTextureDistances()
+            ->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::R32I);
+
+        IRRender::device()->dispatchCompute(count, 1, 1);
+        // TODO: Look over all barriers and try and make the minimum necessary to speed up rendering
+        IRRender::device()->memoryBarrier(BarrierType::ALL);
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
             "TextToTrixelProgram",
-            std::vector{
-                ShaderStage{IRRender::kFileCompTextToTrixel, ShaderType::COMPUTE}
-            }
+            std::vector{ShaderStage{IRRender::kFileCompTextToTrixel, ShaderType::COMPUTE}}
         );
         IRRender::createNamedResource<Buffer>(
             "FontDataBuffer",
@@ -206,95 +300,14 @@ template <> struct System<TEXT_TO_TRIXEL> {
             kBufferIndex_GlyphDrawCommands
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
+        SystemId systemId =
+            registerSystem<TEXT_TO_TRIXEL, C_TextSegment, C_GuiPosition, C_GuiElement, C_TextStyle>(
+                "TextToTrixel"
+            );
+        auto *p = getSystemParams<System<TEXT_TO_TRIXEL>>(systemId);
         p->textProgram_ = IRRender::getNamedResource<ShaderProgram>("TextToTrixelProgram");
         p->fontDataBuf_ = IRRender::getNamedResource<Buffer>("FontDataBuffer");
         p->glyphCmdBuf_ = IRRender::getNamedResource<Buffer>("GlyphDrawCommandBuffer");
-
-        SystemId systemId = createSystem<C_TextSegment, C_GuiPosition, C_GuiElement, C_TextStyle>(
-            "TextToTrixel",
-            [p](const C_TextSegment &text,
-                const C_GuiPosition &guiPos,
-                const C_GuiElement &,
-                const C_TextStyle &style) {
-                EntityId guiCanvas = IRRender::getCanvas("gui");
-                auto &canvasTextures =
-                    IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
-
-                expandTextToCommands(
-                    p->drawCommands_,
-                    text.text_,
-                    guiPos.pos_,
-                    canvasTextures.size_,
-                    style.color_,
-                    style.wrapWidth_,
-                    style.alignH_,
-                    style.alignV_,
-                    style.boxWidth_,
-                    style.boxHeight_,
-                    style.fontSize_
-                );
-            },
-            [p]() {
-                p->textProgram_->use();
-
-                if (!p->fontUploaded_) {
-                    auto fontData = buildFontBuffer();
-                    p->fontDataBuf_->subData(
-                        0, fontData.size() * sizeof(uint32_t), fontData.data());
-                    p->fontUploaded_ = true;
-                }
-
-                EntityId guiCanvas = IRRender::getCanvas("gui");
-                auto &canvasTextures =
-                    IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
-                canvasTextures.clear();
-
-                p->drawCommands_.clear();
-
-                if (IRRender::isGuiVisible()) {
-                    if (p->commandList_.empty()) {
-                        p->commandList_ = IRCommand::buildCommandListText();
-                    }
-                    expandTextToCommands(
-                        p->drawCommands_,
-                        p->commandList_,
-                        kGuiOverlayPadding,
-                        canvasTextures.size_,
-                        IRMath::IRColors::kWhite,
-                        0
-                    );
-                }
-            },
-            [p]() {
-                if (p->drawCommands_.empty()) return;
-
-                int count = static_cast<int>(p->drawCommands_.size());
-                if (count > kMaxGlyphCommands) {
-                    count = kMaxGlyphCommands;
-                }
-
-                p->glyphCmdBuf_->subData(
-                    0, count * sizeof(GlyphDrawCommand), p->drawCommands_.data());
-
-                EntityId guiCanvas = IRRender::getCanvas("gui");
-                auto &canvasTextures =
-                    IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
-                canvasTextures.getTextureColors()->bindAsImage(
-                    0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8
-                );
-                canvasTextures.getTextureDistances()->bindAsImage(
-                    1, TextureAccess::WRITE_ONLY, TextureFormat::R32I
-                );
-
-                IRRender::device()->dispatchCompute(count, 1, 1);
-                // TODO: Look over all barriers and try and make the minimum necessary to speed up rendering
-                IRRender::device()->memoryBarrier(BarrierType::ALL);
-            }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
         IRRender::tagGpuStage(systemId, "textToTrixel");
         return systemId;
     }

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -101,24 +101,121 @@ inline void syncEntityIds(C_VoxelPool &pool, int liveCount, Buffer *entityIdBuf)
 }
 
 template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
-    struct Params {
-        ShaderProgram *compactProgram_ = nullptr;
-        ShaderProgram *stage1Program_ = nullptr;
-        Buffer *frameDataBuf_ = nullptr;
-        Buffer *voxelPosBuf_ = nullptr;
-        Buffer *voxelColorBuf_ = nullptr;
-        Buffer *voxelEntityIdBuf_ = nullptr;
-        Buffer *chunkVisBuf_ = nullptr;
-        Buffer *indirectBuf_ = nullptr;
-        FrameDataVoxelToCanvas frameData_{};
-        // Resolved once per frame in beginTick; read by the per-entity tick.
-        vec3 sunDir_{};
-        float sweepDistance_ = 0.0f;
-        // Log-throttle state — emit the render-mode log line only when
-        // mode or effective subdivisions change.
-        int previousRenderMode_ = -1;
-        int previousEffectiveSubdivisions_ = -1;
-    };
+    ShaderProgram *compactProgram_ = nullptr;
+    ShaderProgram *stage1Program_ = nullptr;
+    Buffer *frameDataBuf_ = nullptr;
+    Buffer *voxelPosBuf_ = nullptr;
+    Buffer *voxelColorBuf_ = nullptr;
+    Buffer *voxelEntityIdBuf_ = nullptr;
+    Buffer *chunkVisBuf_ = nullptr;
+    Buffer *indirectBuf_ = nullptr;
+    FrameDataVoxelToCanvas frameData_{};
+    // Resolved once per frame in beginTick; read by the per-entity tick.
+    vec3 sunDir_{};
+    float sweepDistance_ = 0.0f;
+    // Log-throttle state — emit the render-mode log line only when
+    // mode or effective subdivisions change.
+    int previousRenderMode_ = -1;
+    int previousEffectiveSubdivisions_ = -1;
+
+    void tick(
+        IREntity::EntityId entity,
+        C_VoxelPool &voxelPool,
+        C_TriangleCanvasTextures &triangleCanvasTextures
+    ) {
+        const int liveVoxelCount = voxelPool.getLiveVoxelCount();
+        if (liveVoxelCount == 0)
+            return;
+
+        IRRender::updateCullViewport(
+            IRRender::getCameraPosition2DIso(),
+            IRRender::getCameraZoom(),
+            triangleCanvasTextures.size_
+        );
+        const auto &cull = IRRender::getCullViewport();
+
+        buildVoxelFrameData(frameData_, triangleCanvasTextures, liveVoxelCount);
+
+        const int renderMode = frameData_.voxelRenderOptions_.x;
+        const int effectiveSub = frameData_.voxelRenderOptions_.y;
+        if (renderMode != previousRenderMode_ || effectiveSub != previousEffectiveSubdivisions_) {
+            const vec2 zoom = IRRender::getCameraZoom();
+            IRE_LOG_INFO(
+                "Voxel render mode={}, base_subdivisions={}, zoom_scale={}, "
+                "effective_subdivisions={}",
+                renderMode,
+                IRRender::getVoxelRenderSubdivisions(),
+                static_cast<int>(IRMath::round(IRMath::max(zoom.x, zoom.y))),
+                effectiveSub
+            );
+            previousRenderMode_ = renderMode;
+            previousEffectiveSubdivisions_ = effectiveSub;
+        }
+
+        clearCanvasAndDistances(entity, triangleCanvasTextures);
+
+        // Sun direction and sweep distance are resolved once per
+        // frame in beginTick (via IRPrefab::SunShadow::getFrameSunDirection)
+        // and cached in params, so no C_LightSource archetype scan
+        // runs per entity.
+        const float sweepDistance = sweepDistance_;
+
+        constexpr int kChunkMargin = 8;
+        const IsoBounds2D chunkVp =
+            IRMath::shadowFeederIsoBounds(cull.isoViewport(kChunkMargin), sunDir_, sweepDistance);
+        const auto &uploadMask = buildChunkVisibilityMask(voxelPool, chunkVp);
+        chunkVisBuf_->subData(0, uploadMask.size() * sizeof(std::uint32_t), uploadMask.data());
+
+        constexpr int kGpuMargin = 4;
+        const IsoBounds2D gpuVp =
+            IRMath::shadowFeederIsoBounds(cull.isoViewport(kGpuMargin), sunDir_, sweepDistance);
+        frameData_.cullIsoMin_ = ivec2(IRMath::floor(gpuVp.min_));
+        frameData_.cullIsoMax_ = ivec2(IRMath::ceil(gpuVp.max_));
+        frameDataBuf_->subData(0, sizeof(FrameDataVoxelToCanvas), &frameData_);
+
+        voxelPosBuf_->subData(
+            0,
+            liveVoxelCount * sizeof(C_PositionGlobal3D),
+            voxelPool.getPositionGlobals().data()
+        );
+        voxelColorBuf_->subData(0, liveVoxelCount * sizeof(C_Voxel), voxelPool.getColors().data());
+        syncEntityIds(voxelPool, liveVoxelCount, voxelEntityIdBuf_);
+
+        const VoxelIndirectDispatchParams zeroed{};
+        indirectBuf_->subData(0, sizeof(VoxelIndirectDispatchParams), &zeroed);
+
+        compactProgram_->use();
+        constexpr int kCompactLocalSize = 64;
+        const int compactGroups = IRMath::divCeil(liveVoxelCount, kCompactLocalSize);
+        const ivec2 compactGrid = voxelDispatchGridForCount(compactGroups);
+        IRRender::device()->dispatchCompute(compactGrid.x, compactGrid.y, 1);
+        IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+        IRRender::device()->memoryBarrier(BarrierType::COMMAND);
+
+        stage1Program_->use();
+        triangleCanvasTextures.getTextureDistances()
+            ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+        IRRender::device()->dispatchComputeIndirect(indirectBuf_, 0);
+        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+    }
+
+    void beginTick() {
+        // Resolve sun direction once per frame so the per-entity tick
+        // reads the cached value instead of scanning C_LightSource
+        // once per voxel-pool-canvas pair.
+        const bool shadowsEnabled = IRRender::getSunShadowsEnabled();
+        sunDir_ = shadowsEnabled ? IRPrefab::SunShadow::getFrameSunDirection() : vec3(0.0f);
+        sweepDistance_ = shadowsEnabled ? IRPrefab::SunShadow::kSunShadowMaxDistance : 0.0f;
+
+        IREntity::EntityId backgroundCanvas = IRRender::getCanvas("background");
+        auto background =
+            IREntity::getComponentOptional<C_TriangleCanvasBackground>(backgroundCanvas);
+        auto backgroundTextures =
+            IREntity::getComponentOptional<C_TriangleCanvasTextures>(backgroundCanvas);
+        if (background.has_value() && backgroundTextures.has_value()) {
+            (*background.value()).clearCanvasWithBackground(*backgroundTextures.value());
+        }
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
@@ -188,8 +285,11 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             kBufferIndex_IndirectDispatchParams
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
+        SystemId systemId =
+            registerSystem<VOXEL_TO_TRIXEL_STAGE_1, C_VoxelPool, C_TriangleCanvasTextures>(
+                "SingleVoxelToCanvasFirst"
+            );
+        auto *p = getSystemParams<System<VOXEL_TO_TRIXEL_STAGE_1>>(systemId);
         p->compactProgram_ = IRRender::getNamedResource<ShaderProgram>("VoxelCompactProgram");
         p->stage1Program_ = IRRender::getNamedResource<ShaderProgram>("SingleVoxelProgram1");
         p->frameDataBuf_ = IRRender::getNamedResource<Buffer>("SingleVoxelFrameData");
@@ -198,120 +298,6 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         p->voxelEntityIdBuf_ = IRRender::getNamedResource<Buffer>("VoxelEntityIdBuffer");
         p->chunkVisBuf_ = IRRender::getNamedResource<Buffer>("ChunkVisibilityBuffer");
         p->indirectBuf_ = IRRender::getNamedResource<Buffer>("IndirectDispatchParams");
-
-        SystemId systemId = createSystem<C_VoxelPool, C_TriangleCanvasTextures>(
-            "SingleVoxelToCanvasFirst",
-            [p](IREntity::EntityId &entity,
-                C_VoxelPool &voxelPool,
-                C_TriangleCanvasTextures &triangleCanvasTextures) {
-                const int liveVoxelCount = voxelPool.getLiveVoxelCount();
-                if (liveVoxelCount == 0)
-                    return;
-
-                IRRender::updateCullViewport(
-                    IRRender::getCameraPosition2DIso(),
-                    IRRender::getCameraZoom(),
-                    triangleCanvasTextures.size_
-                );
-                const auto &cull = IRRender::getCullViewport();
-
-                buildVoxelFrameData(p->frameData_, triangleCanvasTextures, liveVoxelCount);
-
-                const int renderMode = p->frameData_.voxelRenderOptions_.x;
-                const int effectiveSub = p->frameData_.voxelRenderOptions_.y;
-                if (renderMode != p->previousRenderMode_ ||
-                    effectiveSub != p->previousEffectiveSubdivisions_) {
-                    const vec2 zoom = IRRender::getCameraZoom();
-                    IRE_LOG_INFO(
-                        "Voxel render mode={}, base_subdivisions={}, zoom_scale={}, "
-                        "effective_subdivisions={}",
-                        renderMode,
-                        IRRender::getVoxelRenderSubdivisions(),
-                        static_cast<int>(IRMath::round(IRMath::max(zoom.x, zoom.y))),
-                        effectiveSub
-                    );
-                    p->previousRenderMode_ = renderMode;
-                    p->previousEffectiveSubdivisions_ = effectiveSub;
-                }
-
-                clearCanvasAndDistances(entity, triangleCanvasTextures);
-
-                // Sun direction and sweep distance are resolved once per
-                // frame in beginTick (via IRPrefab::SunShadow::getFrameSunDirection)
-                // and cached in params, so no C_LightSource archetype scan
-                // runs per entity.
-                const vec3 &sunDir = p->sunDir_;
-                const float sweepDistance = p->sweepDistance_;
-
-                constexpr int kChunkMargin = 8;
-                const IsoBounds2D chunkVp = IRMath::shadowFeederIsoBounds(
-                    cull.isoViewport(kChunkMargin),
-                    sunDir,
-                    sweepDistance
-                );
-                const auto &uploadMask = buildChunkVisibilityMask(voxelPool, chunkVp);
-                p->chunkVisBuf_
-                    ->subData(0, uploadMask.size() * sizeof(std::uint32_t), uploadMask.data());
-
-                constexpr int kGpuMargin = 4;
-                const IsoBounds2D gpuVp = IRMath::shadowFeederIsoBounds(
-                    cull.isoViewport(kGpuMargin),
-                    sunDir,
-                    sweepDistance
-                );
-                p->frameData_.cullIsoMin_ = ivec2(IRMath::floor(gpuVp.min_));
-                p->frameData_.cullIsoMax_ = ivec2(IRMath::ceil(gpuVp.max_));
-                p->frameDataBuf_->subData(0, sizeof(FrameDataVoxelToCanvas), &p->frameData_);
-
-                p->voxelPosBuf_->subData(
-                    0,
-                    liveVoxelCount * sizeof(C_PositionGlobal3D),
-                    voxelPool.getPositionGlobals().data()
-                );
-                p->voxelColorBuf_
-                    ->subData(0, liveVoxelCount * sizeof(C_Voxel), voxelPool.getColors().data());
-                syncEntityIds(voxelPool, liveVoxelCount, p->voxelEntityIdBuf_);
-
-                const VoxelIndirectDispatchParams zeroed{};
-                p->indirectBuf_->subData(0, sizeof(VoxelIndirectDispatchParams), &zeroed);
-
-                p->compactProgram_->use();
-                constexpr int kCompactLocalSize = 64;
-                const int compactGroups = IRMath::divCeil(liveVoxelCount, kCompactLocalSize);
-                const ivec2 compactGrid = voxelDispatchGridForCount(compactGroups);
-                IRRender::device()->dispatchCompute(compactGrid.x, compactGrid.y, 1);
-                IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-                IRRender::device()->memoryBarrier(BarrierType::COMMAND);
-
-                p->stage1Program_->use();
-                triangleCanvasTextures.getTextureDistances()
-                    ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-                IRRender::device()->dispatchComputeIndirect(p->indirectBuf_, 0);
-                IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-            },
-            [p]() {
-                // Resolve sun direction once per frame so the per-entity tick
-                // reads the cached value instead of scanning C_LightSource
-                // once per voxel-pool-canvas pair.
-                const bool shadowsEnabled = IRRender::getSunShadowsEnabled();
-                p->sunDir_ =
-                    shadowsEnabled ? IRPrefab::SunShadow::getFrameSunDirection() : vec3(0.0f);
-                p->sweepDistance_ =
-                    shadowsEnabled ? IRPrefab::SunShadow::kSunShadowMaxDistance : 0.0f;
-
-                IREntity::EntityId backgroundCanvas = IRRender::getCanvas("background");
-                auto background =
-                    IREntity::getComponentOptional<C_TriangleCanvasBackground>(backgroundCanvas);
-                auto backgroundTextures =
-                    IREntity::getComponentOptional<C_TriangleCanvasTextures>(backgroundCanvas);
-                if (background.has_value() && backgroundTextures.has_value()) {
-                    (*background.value()).clearCanvasWithBackground(*backgroundTextures.value());
-                }
-            },
-            []() {}
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
         // The observer-based timing brackets the entire system tick. The
         // formerly-separate canvasClear and voxelCompact sub-stages now
         // collapse into voxelStage1's measurement; their registry slots
@@ -322,10 +308,27 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
 };
 
 template <> struct System<VOXEL_TO_TRIXEL_STAGE_2> {
-    struct Params {
-        ShaderProgram *stage2Program_ = nullptr;
-        Buffer *indirectBuf_ = nullptr;
-    };
+    ShaderProgram *stage2Program_ = nullptr;
+    Buffer *indirectBuf_ = nullptr;
+
+    void tick(const C_VoxelPool &voxelPool, C_TriangleCanvasTextures &triangleCanvasTextures) {
+        if (voxelPool.getLiveVoxelCount() == 0)
+            return;
+
+        triangleCanvasTextures.getTextureColors()
+            ->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
+        triangleCanvasTextures.getTextureDistances()
+            ->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::R32I);
+        triangleCanvasTextures.getTextureEntityIds()
+            ->bindAsImage(2, TextureAccess::WRITE_ONLY, TextureFormat::RG32UI);
+
+        IRRender::device()->dispatchComputeIndirect(indirectBuf_, 0);
+        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+    }
+
+    void beginTick() {
+        stage2Program_->use();
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
@@ -333,31 +336,13 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_2> {
             std::vector{ShaderStage{IRRender::kFileCompVoxelToTrixelStage2, ShaderType::COMPUTE}}
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
+        SystemId systemId =
+            registerSystem<VOXEL_TO_TRIXEL_STAGE_2, C_VoxelPool, C_TriangleCanvasTextures>(
+                "SingleVoxelToCanvasSecond"
+            );
+        auto *p = getSystemParams<System<VOXEL_TO_TRIXEL_STAGE_2>>(systemId);
         p->stage2Program_ = IRRender::getNamedResource<ShaderProgram>("SingleVoxel2");
         p->indirectBuf_ = IRRender::getNamedResource<Buffer>("IndirectDispatchParams");
-
-        SystemId systemId = createSystem<C_VoxelPool, C_TriangleCanvasTextures>(
-            "SingleVoxelToCanvasSecond",
-            [p](const C_VoxelPool &voxelPool, C_TriangleCanvasTextures &triangleCanvasTextures) {
-                if (voxelPool.getLiveVoxelCount() == 0)
-                    return;
-
-                triangleCanvasTextures.getTextureColors()
-                    ->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
-                triangleCanvasTextures.getTextureDistances()
-                    ->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::R32I);
-                triangleCanvasTextures.getTextureEntityIds()
-                    ->bindAsImage(2, TextureAccess::WRITE_ONLY, TextureFormat::RG32UI);
-
-                IRRender::device()->dispatchComputeIndirect(p->indirectBuf_, 0);
-                IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-            },
-            [p]() { p->stage2Program_->use(); }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
         IRRender::tagGpuStage(systemId, "voxelStage2");
         return systemId;
     }


### PR DESCRIPTION
## Summary
- Migrates 5 systems across 4 files from explicit `Params + setSystemParams` to `member-on-System<N>` via `registerSystem` — PR 3 of the 5-PR plan from issue #580.
- Systems: `VOXEL_TO_TRIXEL_STAGE_1`, `VOXEL_TO_TRIXEL_STAGE_2`, `SHAPES_TO_TRIXEL`, `TEXT_TO_TRIXEL`, `FOG_TO_TRIXEL`.
- Each uses the GPU-resource two-step `create()` shape: `createNamedResource` calls, then `registerSystem`, then `getSystemParams` to populate cached pointers. Behavior and per-tick cost are identical to the original form.

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — 6/6 shots completed, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)