### PR TITLE
T-158: Migrate final composite + sprites cluster to member-on-System<N>

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp
+++ b/engine/prefabs/irreden/render/systems/system_framebuffer_to_screen.hpp
@@ -24,12 +24,36 @@ using namespace IRMath;
 namespace IRSystem {
 
 template <> struct System<FRAMEBUFFER_TO_SCREEN> {
-    struct Params {
-        Buffer *frameDataBuf_ = nullptr;
-        ShaderProgram *program_ = nullptr;
-        VAO *quadVao_ = nullptr;
-        FrameDataFramebuffer frameData_{};
-    };
+    Buffer *frameDataBuf_ = nullptr;
+    ShaderProgram *program_ = nullptr;
+    VAO *quadVao_ = nullptr;
+    FrameDataFramebuffer frameData_{};
+
+    void tick(
+        const C_TrixelCanvasFramebuffer &framebuffer,
+        const C_Position3D &cameraPosition,
+        const C_Name &name
+    ) {
+        framebuffer.bindTextures(0, 1);
+        frameData_.mvpMatrix =
+            calcProjectionMatrix() * calcModelMatrix(
+                                         framebuffer.getResolution(),
+                                         framebuffer.getResolutionPlusBuffer(),
+                                         cameraPosition.pos_,
+                                         IRRender::getCameraPosition2DIso(),
+                                         name.name_
+                                     );
+        frameDataBuf_->subData(0, sizeof(FrameDataFramebuffer), &frameData_);
+        IRRender::device()->setPolygonMode(PolygonMode::FILL);
+        IRRender::device()->drawArrays(DrawMode::TRIANGLES, 0, 6);
+    }
+
+    void beginTick() {
+        bindDefaultFramebuffer();
+        clearDefaultFramebuffer();
+        program_->use();
+        quadVao_->bind();
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
@@ -48,41 +72,16 @@ template <> struct System<FRAMEBUFFER_TO_SCREEN> {
             kBufferIndex_FramebufferFrameDataUniform
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
-        p->frameDataBuf_ = IRRender::getNamedResource<Buffer>("FramebufferToScreenFrameData");
-        p->program_ = IRRender::getNamedResource<ShaderProgram>("FramebufferToScreenProgram");
-        p->quadVao_ = IRRender::getNamedResource<VAO>("QuadVAOArrays");
-
-        SystemId systemId = createSystem<C_TrixelCanvasFramebuffer, C_Position3D, C_Name>(
-            "FramebufferToScreen",
-            [p](const C_TrixelCanvasFramebuffer &framebuffer,
-                const C_Position3D &cameraPosition,
-                const C_Name &name) {
-                framebuffer.bindTextures(0, 1);
-                p->frameData_.mvpMatrix =
-                    calcProjectionMatrix() * calcModelMatrix(
-                                                 framebuffer.getResolution(),
-                                                 framebuffer.getResolutionPlusBuffer(),
-                                                 cameraPosition.pos_,
-                                                 IRRender::getCameraPosition2DIso(),
-                                                 name.name_
-                                             );
-                p->frameDataBuf_->subData(0, sizeof(FrameDataFramebuffer), &p->frameData_);
-                IRRender::device()->setPolygonMode(PolygonMode::FILL);
-                IRRender::device()->drawArrays(DrawMode::TRIANGLES, 0, 6);
-            },
-            [p]() {
-                bindDefaultFramebuffer();
-                clearDefaultFramebuffer();
-                p->program_->use();
-                p->quadVao_->bind();
-            }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
-        IRRender::tagGpuStage(systemId, "fbToScreen");
-        return systemId;
+        SystemId id = registerSystem<FRAMEBUFFER_TO_SCREEN,
+                                     C_TrixelCanvasFramebuffer,
+                                     C_Position3D,
+                                     C_Name>("FramebufferToScreen");
+        auto *sys = getSystemParams<System<FRAMEBUFFER_TO_SCREEN>>(id);
+        sys->frameDataBuf_ = IRRender::getNamedResource<Buffer>("FramebufferToScreenFrameData");
+        sys->program_ = IRRender::getNamedResource<ShaderProgram>("FramebufferToScreenProgram");
+        sys->quadVao_ = IRRender::getNamedResource<VAO>("QuadVAOArrays");
+        IRRender::tagGpuStage(id, "fbToScreen");
+        return id;
     }
 
   private:
@@ -98,11 +97,10 @@ template <> struct System<FRAMEBUFFER_TO_SCREEN> {
         // also known as screen center
         float xOffset = IRRender::getViewport().x / 2.0f;
         float yOffset = IRRender::getViewport().y / 2.0f;
-        vec2 offset = vec2(xOffset, yOffset) +
-                      isoDeltaToScreenDelta(
-                          pos3DtoPos2DIso(cameraPosition),
-                          IRRender::getTriangleStepSizeScreen()
-                      );
+        vec2 offset = vec2(xOffset, yOffset) + isoDeltaToScreenDelta(
+                                                   pos3DtoPos2DIso(cameraPosition),
+                                                   IRRender::getTriangleStepSizeScreen()
+                                               );
 
         mat4 model = mat4(1.0f);
 

--- a/engine/prefabs/irreden/render/systems/system_screen_residual_rotate.hpp
+++ b/engine/prefabs/irreden/render/systems/system_screen_residual_rotate.hpp
@@ -26,12 +26,37 @@ namespace IRSystem {
 /// (passthrough branch in the fragment shader bypasses the bilinear blend),
 /// rotated bilinear sample otherwise.
 template <> struct System<SCREEN_SPACE_RESIDUAL_ROTATE> {
-    struct Params {
-        Buffer *frameDataBuf_ = nullptr;
-        ShaderProgram *program_ = nullptr;
-        VAO *quadVao_ = nullptr;
-        FrameDataScreenResidualRotate frameData_{};
-    };
+    Buffer *frameDataBuf_ = nullptr;
+    ShaderProgram *program_ = nullptr;
+    VAO *quadVao_ = nullptr;
+    FrameDataScreenResidualRotate frameData_{};
+
+    void tick(
+        const C_TrixelCanvasFramebuffer &framebuffer,
+        const C_Position3D &cameraPosition,
+        const C_Name &name
+    ) {
+        framebuffer.bindTextures(0, 1);
+        frameData_.mvpMatrix =
+            calcProjectionMatrix() * calcModelMatrix(
+                                         framebuffer.getResolution(),
+                                         framebuffer.getResolutionPlusBuffer(),
+                                         cameraPosition.pos_,
+                                         IRRender::getCameraPosition2DIso(),
+                                         name.name_
+                                     );
+        frameData_.residualYaw = IRPrefab::Camera::getResidualYaw();
+        frameDataBuf_->subData(0, sizeof(FrameDataScreenResidualRotate), &frameData_);
+        IRRender::device()->setPolygonMode(PolygonMode::FILL);
+        IRRender::device()->drawArrays(DrawMode::TRIANGLES, 0, 6);
+    }
+
+    void beginTick() {
+        bindDefaultFramebuffer();
+        clearDefaultFramebuffer();
+        program_->use();
+        quadVao_->bind();
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
@@ -50,42 +75,18 @@ template <> struct System<SCREEN_SPACE_RESIDUAL_ROTATE> {
             kBufferIndex_FrameDataScreenResidualRotate
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
-        p->frameDataBuf_ = IRRender::getNamedResource<Buffer>("ScreenSpaceResidualRotateFrameData");
-        p->program_ = IRRender::getNamedResource<ShaderProgram>("ScreenSpaceResidualRotateProgram");
-        p->quadVao_ = IRRender::getNamedResource<VAO>("QuadVAOArrays");
-
-        SystemId systemId = createSystem<C_TrixelCanvasFramebuffer, C_Position3D, C_Name>(
-            "ScreenSpaceResidualRotate",
-            [p](const C_TrixelCanvasFramebuffer &framebuffer,
-                const C_Position3D &cameraPosition,
-                const C_Name &name) {
-                framebuffer.bindTextures(0, 1);
-                p->frameData_.mvpMatrix =
-                    calcProjectionMatrix() * calcModelMatrix(
-                                                 framebuffer.getResolution(),
-                                                 framebuffer.getResolutionPlusBuffer(),
-                                                 cameraPosition.pos_,
-                                                 IRRender::getCameraPosition2DIso(),
-                                                 name.name_
-                                             );
-                p->frameData_.residualYaw = IRPrefab::Camera::getResidualYaw();
-                p->frameDataBuf_->subData(0, sizeof(FrameDataScreenResidualRotate), &p->frameData_);
-                IRRender::device()->setPolygonMode(PolygonMode::FILL);
-                IRRender::device()->drawArrays(DrawMode::TRIANGLES, 0, 6);
-            },
-            [p]() {
-                bindDefaultFramebuffer();
-                clearDefaultFramebuffer();
-                p->program_->use();
-                p->quadVao_->bind();
-            }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
-        IRRender::tagGpuStage(systemId, "screenSpaceResidualRotate");
-        return systemId;
+        SystemId id = registerSystem<SCREEN_SPACE_RESIDUAL_ROTATE,
+                                     C_TrixelCanvasFramebuffer,
+                                     C_Position3D,
+                                     C_Name>("ScreenSpaceResidualRotate");
+        auto *sys = getSystemParams<System<SCREEN_SPACE_RESIDUAL_ROTATE>>(id);
+        sys->frameDataBuf_ =
+            IRRender::getNamedResource<Buffer>("ScreenSpaceResidualRotateFrameData");
+        sys->program_ =
+            IRRender::getNamedResource<ShaderProgram>("ScreenSpaceResidualRotateProgram");
+        sys->quadVao_ = IRRender::getNamedResource<VAO>("QuadVAOArrays");
+        IRRender::tagGpuStage(id, "screenSpaceResidualRotate");
+        return id;
     }
 
   private:

--- a/engine/prefabs/irreden/render/systems/system_sprites_to_screen.hpp
+++ b/engine/prefabs/irreden/render/systems/system_sprites_to_screen.hpp
@@ -48,17 +48,85 @@ template <> struct System<SPRITE_TO_SCREEN> {
         std::size_t count_;
     };
 
-    struct Params {
-        IRRender::Buffer *frameDataBuf_ = nullptr;
-        IRRender::Buffer *instancesBuf_ = nullptr;
-        IRRender::ShaderProgram *program_ = nullptr;
-        IRRender::VAO *quadVao_ = nullptr;
-        bool overflowWarned_ = false;
-        IRRender::FrameDataSpritesToScreen frameData_{};
-        std::vector<IRRender::SpriteRenderEntry> entries_;
-        std::vector<IRRender::GpuSpriteInstance> gpuScratch_;
-        std::vector<Group> groups_;
-    };
+    IRRender::Buffer *frameDataBuf_ = nullptr;
+    IRRender::Buffer *instancesBuf_ = nullptr;
+    IRRender::ShaderProgram *program_ = nullptr;
+    IRRender::VAO *quadVao_ = nullptr;
+    bool overflowWarned_ = false;
+    IRRender::FrameDataSpritesToScreen frameData_{};
+    std::vector<IRRender::SpriteRenderEntry> entries_;
+    std::vector<IRRender::GpuSpriteInstance> gpuScratch_;
+    std::vector<Group> groups_;
+
+    void tick(
+        const IRComponents::C_Sprite &sprite,
+        const IRComponents::C_PositionGlobal3D &global,
+        const IRComponents::C_PositionOffset3D &offset
+    ) {
+        if (sprite.textureHandle_ == 0) {
+            return;
+        }
+        if (entries_.size() >= kMaxSprites) {
+            if (!overflowWarned_) {
+                IR_LOG_WARN(
+                    "SpritesToScreen: sprite count exceeded kMaxSprites={} — extras "
+                    "dropped this frame",
+                    kMaxSprites
+                );
+                overflowWarned_ = true;
+            }
+            return;
+        }
+        const vec3 worldPos = global.pos_ + offset.pos_;
+        IRRender::SpriteRenderEntry entry{};
+        entry.textureHandle_ = sprite.textureHandle_;
+        entry.isoDepth_ = static_cast<int>(pos3DtoDistance(worldPos));
+        entry.size_ = sprite.size_;
+        entry.uvRect_ = sprite.uvRect_;
+        entry.tintRgba_ = vec4(
+            static_cast<float>(sprite.tint_.red_) / 255.0f,
+            static_cast<float>(sprite.tint_.green_) / 255.0f,
+            static_cast<float>(sprite.tint_.blue_) / 255.0f,
+            static_cast<float>(sprite.tint_.alpha_) / 255.0f
+        );
+        entry.screenPos_ = computeScreenAnchor(worldPos) - sprite.anchor_ * sprite.size_;
+        entries_.push_back(entry);
+    }
+
+    void beginTick() {
+        entries_.clear();
+        groups_.clear();
+    }
+
+    void endTick() {
+        if (entries_.empty()) {
+            return;
+        }
+        std::sort(entries_.begin(), entries_.end(), entryLess);
+        groups_ = buildGroups(entries_);
+        uploadFrameData();
+        bindPipeline();
+        for (const Group &g : groups_) {
+            auto *atlas = IRRender::getResource<IRRender::Texture2D>(g.textureHandle_);
+            if (atlas == nullptr) {
+                continue;
+            }
+            packGroupToScratch(g);
+            instancesBuf_->subData(
+                0,
+                gpuScratch_.size() * sizeof(IRRender::GpuSpriteInstance),
+                gpuScratch_.data()
+            );
+            atlas->bind(0);
+            IRRender::device()->drawArraysInstanced(
+                IRRender::DrawMode::TRIANGLES,
+                0,
+                6,
+                static_cast<int>(g.count_)
+            );
+        }
+        unbindPipeline();
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<IRRender::ShaderProgram>(
@@ -91,61 +159,21 @@ template <> struct System<SPRITE_TO_SCREEN> {
             IRRender::kBufferIndex_SpritesInstances
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
-        p->frameDataBuf_ = IRRender::getNamedResource<IRRender::Buffer>("SpritesToScreenFrameData");
-        p->instancesBuf_ = IRRender::getNamedResource<IRRender::Buffer>("SpritesToScreenInstances");
-        p->program_ = IRRender::getNamedResource<IRRender::ShaderProgram>("SpritesToScreenProgram");
-        p->quadVao_ = IRRender::getNamedResource<IRRender::VAO>("QuadVAOArrays");
-        p->entries_.reserve(256);
-        p->gpuScratch_.reserve(256);
-
-        SystemId systemId = createSystem<
-            IRComponents::C_Sprite,
-            IRComponents::C_PositionGlobal3D,
-            IRComponents::C_PositionOffset3D>(
-            "SpritesToScreen",
-            [p](const IRComponents::C_Sprite &sprite,
-                const IRComponents::C_PositionGlobal3D &global,
-                const IRComponents::C_PositionOffset3D &offset) {
-                if (sprite.textureHandle_ == 0) {
-                    return;
-                }
-                if (p->entries_.size() >= kMaxSprites) {
-                    if (!p->overflowWarned_) {
-                        IR_LOG_WARN(
-                            "SpritesToScreen: sprite count exceeded kMaxSprites={} — extras "
-                            "dropped this frame",
-                            kMaxSprites
-                        );
-                        p->overflowWarned_ = true;
-                    }
-                    return;
-                }
-                const vec3 worldPos = global.pos_ + offset.pos_;
-                IRRender::SpriteRenderEntry entry{};
-                entry.textureHandle_ = sprite.textureHandle_;
-                entry.isoDepth_ = static_cast<int>(pos3DtoDistance(worldPos));
-                entry.size_ = sprite.size_;
-                entry.uvRect_ = sprite.uvRect_;
-                entry.tintRgba_ = vec4(
-                    static_cast<float>(sprite.tint_.red_) / 255.0f,
-                    static_cast<float>(sprite.tint_.green_) / 255.0f,
-                    static_cast<float>(sprite.tint_.blue_) / 255.0f,
-                    static_cast<float>(sprite.tint_.alpha_) / 255.0f
-                );
-                entry.screenPos_ = computeScreenAnchor(worldPos) - sprite.anchor_ * sprite.size_;
-                p->entries_.push_back(entry);
-            },
-            [p]() {
-                p->entries_.clear();
-                p->groups_.clear();
-            },
-            [p]() { endTick(*p); }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
-        return systemId;
+        SystemId id = registerSystem<SPRITE_TO_SCREEN,
+                                     IRComponents::C_Sprite,
+                                     IRComponents::C_PositionGlobal3D,
+                                     IRComponents::C_PositionOffset3D>("SpritesToScreen");
+        auto *sys = getSystemParams<System<SPRITE_TO_SCREEN>>(id);
+        sys->frameDataBuf_ =
+            IRRender::getNamedResource<IRRender::Buffer>("SpritesToScreenFrameData");
+        sys->instancesBuf_ =
+            IRRender::getNamedResource<IRRender::Buffer>("SpritesToScreenInstances");
+        sys->program_ =
+            IRRender::getNamedResource<IRRender::ShaderProgram>("SpritesToScreenProgram");
+        sys->quadVao_ = IRRender::getNamedResource<IRRender::VAO>("QuadVAOArrays");
+        sys->entries_.reserve(256);
+        sys->gpuScratch_.reserve(256);
+        return id;
     }
 
     /// Stable build-order rule used by the sort: equal-handle sprites
@@ -193,50 +221,20 @@ template <> struct System<SPRITE_TO_SCREEN> {
         return viewport * 0.5f + isoDelta * stepSize * screenSign;
     }
 
-    static void endTick(Params &p) {
-        if (p.entries_.empty()) {
-            return;
-        }
-        std::sort(p.entries_.begin(), p.entries_.end(), entryLess);
-        p.groups_ = buildGroups(p.entries_);
-        uploadFrameData(p);
-        bindPipeline(p);
-        for (const Group &g : p.groups_) {
-            auto *atlas = IRRender::getResource<IRRender::Texture2D>(g.textureHandle_);
-            if (atlas == nullptr) {
-                continue;
-            }
-            packGroupToScratch(p, g);
-            p.instancesBuf_->subData(
-                0,
-                p.gpuScratch_.size() * sizeof(IRRender::GpuSpriteInstance),
-                p.gpuScratch_.data()
-            );
-            atlas->bind(0);
-            IRRender::device()->drawArraysInstanced(
-                IRRender::DrawMode::TRIANGLES,
-                0,
-                6,
-                static_cast<int>(g.count_)
-            );
-        }
-        unbindPipeline();
-    }
-
-    static void packGroupToScratch(Params &p, const Group &g) {
-        p.gpuScratch_.resize(g.count_);
+    void packGroupToScratch(const Group &g) {
+        gpuScratch_.resize(g.count_);
         for (std::size_t i = 0; i < g.count_; ++i) {
-            const IRRender::SpriteRenderEntry &e = p.entries_[g.firstEntry_ + i];
-            p.gpuScratch_[i].screenPosSize_ =
+            const IRRender::SpriteRenderEntry &e = entries_[g.firstEntry_ + i];
+            gpuScratch_[i].screenPosSize_ =
                 vec4(e.screenPos_.x, e.screenPos_.y, e.size_.x, e.size_.y);
-            p.gpuScratch_[i].uvRect_ = e.uvRect_;
-            p.gpuScratch_[i].tintRgba_ = e.tintRgba_;
+            gpuScratch_[i].uvRect_ = e.uvRect_;
+            gpuScratch_[i].tintRgba_ = e.tintRgba_;
         }
     }
 
-    static void uploadFrameData(Params &p) {
+    void uploadFrameData() {
         const ivec2 viewport = IRRender::getViewport();
-        p.frameData_.projection_ = IRMath::ortho(
+        frameData_.projection_ = IRMath::ortho(
             0.0f,
             static_cast<float>(viewport.x),
             0.0f,
@@ -244,12 +242,12 @@ template <> struct System<SPRITE_TO_SCREEN> {
             -1.0f,
             100.0f
         );
-        p.frameDataBuf_->subData(0, sizeof(IRRender::FrameDataSpritesToScreen), &p.frameData_);
+        frameDataBuf_->subData(0, sizeof(IRRender::FrameDataSpritesToScreen), &frameData_);
     }
 
-    static void bindPipeline(Params &p) {
-        p.program_->use();
-        p.quadVao_->bind();
+    void bindPipeline() {
+        program_->use();
+        quadVao_->bind();
         IRRender::device()->setDepthTest(false);
         IRRender::device()->setDepthWrite(false);
         IRRender::device()->enableBlending();

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
@@ -26,12 +26,94 @@ using namespace IRMath;
 namespace IRSystem {
 
 template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
-    struct Params {
-        Buffer *frameDataBuf_ = nullptr;
-        Buffer *hoveredIdBuf_ = nullptr;
-        ShaderProgram *program_ = nullptr;
-        VAO *quadVao_ = nullptr;
-    };
+    Buffer *frameDataBuf_ = nullptr;
+    Buffer *hoveredIdBuf_ = nullptr;
+    ShaderProgram *program_ = nullptr;
+    VAO *quadVao_ = nullptr;
+
+    void tick(
+        IREntity::EntityId entity,
+        const C_TriangleCanvasTextures &triangleCanvasTextures,
+        const C_Name &
+    ) {
+        auto &framebuffer =
+            IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
+        auto &frameData =
+            IREntity::getComponent<C_FrameDataTrixelToFramebuffer>("mainFramebuffer");
+        vec2 framebufferResolution = vec2(framebuffer.getResolutionPlusBuffer());
+        const int effectiveSubdivisions = IRRender::getVoxelRenderEffectiveSubdivisions();
+        const IRRender::SubdivisionMode renderMode = IRRender::getSubdivisionMode();
+        auto renderBehavior =
+            IREntity::getComponentOptional<C_TrixelCanvasRenderBehavior>(entity);
+        const C_TrixelCanvasRenderBehavior behavior = renderBehavior.has_value()
+                                                          ? (*renderBehavior.value())
+                                                          : C_TrixelCanvasRenderBehavior{};
+        auto zoomLevel = IREntity::getComponentOptional<C_ZoomLevel>(entity);
+        const vec2 baseCanvasZoom =
+            behavior.useCameraZoom_
+                ? IRRender::getCameraZoom()
+                : (zoomLevel.has_value() ? (*zoomLevel.value()).zoom_ : vec2(1.0f));
+
+        frameData.frameData_.canvasZoomLevel_ = baseCanvasZoom;
+        if (behavior.applyRenderSubdivisions_ &&
+            renderMode != IRRender::SubdivisionMode::NONE) {
+            frameData.frameData_.canvasZoomLevel_ /= vec2(effectiveSubdivisions);
+        }
+
+        frameData.frameData_.cameraTrixelOffset_ = behavior.useCameraPositionIso_
+                                                       ? IRRender::getCameraPosition2DIso()
+                                                       : vec2(0.0f);
+        frameData.frameData_.cameraTrixelOffset_ +=
+            vec2(behavior.parityOffsetIsoX_, behavior.parityOffsetIsoY_);
+        if (behavior.applyRenderSubdivisions_ &&
+            renderMode != IRRender::SubdivisionMode::NONE) {
+            frameData.frameData_.cameraTrixelOffset_ *= vec2(effectiveSubdivisions);
+        }
+        frameData.frameData_.textureOffset_ = vec2(0);
+        frameData.frameData_.distanceOffset_ = 0;
+        frameData.frameData_.mpMatrix_ = calcProjectionMatrix(framebufferResolution) *
+                                         calcModelMatrix(
+                                             framebufferResolution,
+                                             frameData.frameData_.cameraTrixelOffset_,
+                                             frameData.frameData_.canvasZoomLevel_
+                                         );
+
+        if (!behavior.mouseHoverEnabled_) {
+            frameData.frameData_.mouseHoveredTriangleIndex_ = vec2(-1000000.0f);
+            frameData.frameData_.effectiveSubdivisionsForHover_ = vec2(1.0f);
+            frameData.frameData_.showHoverHighlight_ = 0.0f;
+        } else {
+            const ivec2 hoverSubdiv = IRRender::mouseTrixelPositionWorld();
+            const float subdiv = static_cast<float>(effectiveSubdivisions);
+            frameData.frameData_.mouseHoveredTriangleIndex_ =
+                vec2(hoverSubdiv) / vec2(subdiv);
+            frameData.frameData_.effectiveSubdivisionsForHover_ = vec2(subdiv, 0.0f);
+            frameData.frameData_.showHoverHighlight_ =
+                (IRRender::isHoveredTrixelVisible() ? 1.0f : 0.0f);
+        }
+
+        frameData.updateFrameData(frameDataBuf_);
+
+        triangleCanvasTextures.bind(0, 1, 2);
+        IRRender::device()->setPolygonMode(PolygonMode::FILL);
+        IRRender::device()->drawElements(
+            DrawMode::TRIANGLES,
+            IRShapes2D::kQuadIndicesLength,
+            IndexType::UNSIGNED_SHORT
+        );
+        IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
+    }
+
+    void beginTick() {
+        HoveredEntityIdLayout resetData;
+        hoveredIdBuf_->subData(0, sizeof(resetData), &resetData);
+        program_->use();
+        quadVao_->bind();
+        auto &framebuffer =
+            IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
+        framebuffer.bindFramebuffer();
+        framebuffer.clear();
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
@@ -54,107 +136,24 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
             "HoveredEntityIdBuffer",
             &initData,
             sizeof(initData),
-            BUFFER_STORAGE_DYNAMIC | BUFFER_STORAGE_MAP_READ |
-                BUFFER_STORAGE_MAP_PERSISTENT | BUFFER_STORAGE_MAP_COHERENT,
+            BUFFER_STORAGE_DYNAMIC | BUFFER_STORAGE_MAP_READ | BUFFER_STORAGE_MAP_PERSISTENT |
+                BUFFER_STORAGE_MAP_COHERENT,
             BufferTarget::SHADER_STORAGE,
             kBufferIndex_HoveredEntityId
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
-        p->frameDataBuf_ = IRRender::getNamedResource<Buffer>("TrixelToFramebufferFrameData");
-        p->hoveredIdBuf_ = IRRender::getNamedResource<Buffer>("HoveredEntityIdBuffer");
-        p->program_ = IRRender::getNamedResource<ShaderProgram>("CanvasToFramebufferProgram");
-        p->quadVao_ = IRRender::getNamedResource<VAO>("QuadVAO");
-
-        SystemId systemId = createSystem<C_TriangleCanvasTextures, C_Name>(
-            "CanvasToFramebuffer",
-            [p](IREntity::EntityId &entity,
-                const C_TriangleCanvasTextures &triangleCanvasTextures,
-                const C_Name &) {
-                auto &framebuffer =
-                    IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
-                auto &frameData =
-                    IREntity::getComponent<C_FrameDataTrixelToFramebuffer>("mainFramebuffer");
-                vec2 framebufferResolution = vec2(framebuffer.getResolutionPlusBuffer());
-                const int effectiveSubdivisions = IRRender::getVoxelRenderEffectiveSubdivisions();
-                const IRRender::SubdivisionMode renderMode = IRRender::getSubdivisionMode();
-                auto renderBehavior =
-                    IREntity::getComponentOptional<C_TrixelCanvasRenderBehavior>(entity);
-                const C_TrixelCanvasRenderBehavior behavior =
-                    renderBehavior.has_value() ? (*renderBehavior.value())
-                                               : C_TrixelCanvasRenderBehavior{};
-                auto zoomLevel = IREntity::getComponentOptional<C_ZoomLevel>(entity);
-                const vec2 baseCanvasZoom = behavior.useCameraZoom_
-                                                ? IRRender::getCameraZoom()
-                                                : (zoomLevel.has_value() ? (*zoomLevel.value()).zoom_
-                                                                         : vec2(1.0f));
-
-                frameData.frameData_.canvasZoomLevel_ = baseCanvasZoom;
-                if (behavior.applyRenderSubdivisions_ &&
-                    renderMode != IRRender::SubdivisionMode::NONE) {
-                    frameData.frameData_.canvasZoomLevel_ /= vec2(effectiveSubdivisions);
-                }
-
-                frameData.frameData_.cameraTrixelOffset_ =
-                    behavior.useCameraPositionIso_ ? IRRender::getCameraPosition2DIso()
-                                                   : vec2(0.0f);
-                frameData.frameData_.cameraTrixelOffset_ +=
-                    vec2(behavior.parityOffsetIsoX_, behavior.parityOffsetIsoY_);
-                if (behavior.applyRenderSubdivisions_ &&
-                    renderMode != IRRender::SubdivisionMode::NONE) {
-                    frameData.frameData_.cameraTrixelOffset_ *= vec2(effectiveSubdivisions);
-                }
-                frameData.frameData_.textureOffset_ = vec2(0);
-                frameData.frameData_.distanceOffset_ = 0;
-                frameData.frameData_.mpMatrix_ = calcProjectionMatrix(framebufferResolution) *
-                                                 calcModelMatrix(
-                                                     framebufferResolution,
-                                                     frameData.frameData_.cameraTrixelOffset_,
-                                                     frameData.frameData_.canvasZoomLevel_
-                                                 );
-
-                if (!behavior.mouseHoverEnabled_) {
-                    frameData.frameData_.mouseHoveredTriangleIndex_ = vec2(-1000000.0f);
-                    frameData.frameData_.effectiveSubdivisionsForHover_ = vec2(1.0f);
-                    frameData.frameData_.showHoverHighlight_ = 0.0f;
-                }
-                else {
-                    const ivec2 hoverSubdiv = IRRender::mouseTrixelPositionWorld();
-                    const float subdiv = static_cast<float>(effectiveSubdivisions);
-                    frameData.frameData_.mouseHoveredTriangleIndex_ =
-                        vec2(hoverSubdiv) / vec2(subdiv);
-                    frameData.frameData_.effectiveSubdivisionsForHover_ = vec2(subdiv, 0.0f);
-                    frameData.frameData_.showHoverHighlight_ =
-                        (IRRender::isHoveredTrixelVisible() ? 1.0f : 0.0f);
-                }
-
-                frameData.updateFrameData(p->frameDataBuf_);
-
-                triangleCanvasTextures.bind(0, 1, 2);
-                IRRender::device()->setPolygonMode(PolygonMode::FILL);
-                IRRender::device()->drawElements(
-                    DrawMode::TRIANGLES,
-                    IRShapes2D::kQuadIndicesLength,
-                    IndexType::UNSIGNED_SHORT
-                );
-                IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
-            },
-            [p]() {
-                HoveredEntityIdLayout resetData;
-                p->hoveredIdBuf_->subData(0, sizeof(resetData), &resetData);
-                p->program_->use();
-                p->quadVao_->bind();
-                auto &framebuffer =
-                    IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
-                framebuffer.bindFramebuffer();
-                framebuffer.clear();
-            }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
-        IRRender::tagGpuStage(systemId, "trixelToFb");
-        return systemId;
+        SystemId id = registerSystem<TRIXEL_TO_FRAMEBUFFER,
+                                     C_TriangleCanvasTextures,
+                                     C_Name>("CanvasToFramebuffer");
+        auto *sys = getSystemParams<System<TRIXEL_TO_FRAMEBUFFER>>(id);
+        sys->frameDataBuf_ =
+            IRRender::getNamedResource<Buffer>("TrixelToFramebufferFrameData");
+        sys->hoveredIdBuf_ = IRRender::getNamedResource<Buffer>("HoveredEntityIdBuffer");
+        sys->program_ =
+            IRRender::getNamedResource<ShaderProgram>("CanvasToFramebufferProgram");
+        sys->quadVao_ = IRRender::getNamedResource<VAO>("QuadVAO");
+        IRRender::tagGpuStage(id, "trixelToFb");
+        return id;
     }
 
     static mat4 calcProjectionMatrix(const vec2 &resolution) {
@@ -178,7 +177,6 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
         model = scale(model, vec3(resolution.x * zoomLevel.x, resolution.y * zoomLevel.y, 1.0f));
         return model;
     }
-
 };
 
 } // namespace IRSystem


### PR DESCRIPTION
## Summary
- Migrates four final-composite render pipeline systems from explicit `Params` + `setSystemParams` + lambda-capture to the preferred `registerSystem` member-on-`System<N>` form.
- **TRIXEL_TO_FRAMEBUFFER**: entity-id tick form preserved; `Buffer`/`ShaderProgram`/`VAO` fields lifted from nested `Params` to direct `System<N>` members, initialized via `getSystemParams` after `registerSystem` returns.
- **FRAMEBUFFER_TO_SCREEN**: per-component tick; same field lift pattern; `frameData_` member default-initializes correctly.
- **SCREEN_SPACE_RESIDUAL_ROTATE**: same structure as `FRAMEBUFFER_TO_SCREEN`; residualYaw field on `frameData_` preserved.
- **SPRITE_TO_SCREEN**: `endTick`, `packGroupToScratch`, `uploadFrameData`, `bindPipeline` converted from static `Params&` helpers to member functions; `entryLess`, `buildGroups`, `computeScreenAnchor`, `unbindPipeline` remain static (no instance state). Vector reserves moved to `create()` via `getSystemParams`.

All logic is preserved 1:1. This is the final PR in the migration chain started in #580.

## Test plan
- [x] `fleet-build --target IRShapeDebug` — builds clean
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — all 6 shots captured, no errors, render pipeline intact
- [ ] Linux/OpenGL cross-host smoke (pending `fleet:needs-linux-smoke`)

## Notes for reviewer
Pre-existing `getComponentOptional<C_TrixelCanvasRenderBehavior>(entity)` and `getComponentOptional<C_ZoomLevel>(entity)` in `TRIXEL_TO_FRAMEBUFFER::tick()` are preserved as-is — optional per-entity lookups that can't be moved to template params without changing which entities match. Not introduced by this PR.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)