### PR TITLE
T-157: Migrate lighting + debug cluster to member-on-System<N>

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_debug_culling_minimap.hpp
+++ b/engine/prefabs/irreden/render/systems/system_debug_culling_minimap.hpp
@@ -50,11 +50,16 @@ struct MinimapLayout {
     float width_;
     float height_;
 
-    vec2 center() const { return origin_ + vec2(width_, height_) * 0.5f; }
-    IsoBounds2D screenBounds() const { return {origin_, origin_ + vec2(width_, height_)}; }
+    vec2 center() const {
+        return origin_ + vec2(width_, height_) * 0.5f;
+    }
+    IsoBounds2D screenBounds() const {
+        return {origin_, origin_ + vec2(width_, height_)};
+    }
 };
 
-inline MinimapLayout computeLayout(ivec2 viewport, float screenWidthFraction, float aspectRatio, float padding) {
+inline MinimapLayout
+computeLayout(ivec2 viewport, float screenWidthFraction, float aspectRatio, float padding) {
     float width = viewport.x * screenWidthFraction;
     float height = width / aspectRatio;
     vec2 origin = vec2((viewport.x - width) * 0.5f, padding);
@@ -66,30 +71,31 @@ struct EntityRecord {
     bool isVisible_;
 };
 
+struct PendingEntity {
+    IREntity::EntityId entityId_;
+    vec2 isoPosition_;
+};
+
 inline float computeAutoFitExtent(
-    const std::vector<EntityRecord> &entityRecords,
-    vec2 viewCenterIso,
-    vec2 cullExtent
+    const std::vector<EntityRecord> &entityRecords, vec2 viewCenterIso, vec2 cullExtent
 ) {
     float autoExtent = IRMath::max(cullExtent.x, cullExtent.y) * 0.5f;
     for (const auto &record : entityRecords) {
-        vec2 distanceFromCenter = glm::abs(record.isoPosition_ - viewCenterIso);
-        autoExtent = IRMath::max(autoExtent, IRMath::max(distanceFromCenter.x, distanceFromCenter.y));
+        vec2 distanceFromCenter = IRMath::abs(record.isoPosition_ - viewCenterIso);
+        autoExtent =
+            IRMath::max(autoExtent, IRMath::max(distanceFromCenter.x, distanceFromCenter.y));
     }
     return autoExtent * 1.2f;
 }
 
-inline vec2 isoToMinimapScreen(vec2 isoPosition, vec2 viewCenterIso, float scale, vec2 minimapCenter) {
+inline vec2
+isoToMinimapScreen(vec2 isoPosition, vec2 viewCenterIso, float scale, vec2 minimapCenter) {
     vec2 relativeOffset = (isoPosition - viewCenterIso) * scale;
     return minimapCenter + vec2(relativeOffset.x, -relativeOffset.y);
 }
 
 inline void drawViewportOutline(
-    IsoBounds2D isoViewport,
-    vec2 viewCenterIso,
-    float scale,
-    vec2 minimapCenter,
-    vec4 borderColor
+    IsoBounds2D isoViewport, vec2 viewCenterIso, float scale, vec2 minimapCenter, vec4 borderColor
 ) {
     vec2 mappedMin = isoToMinimapScreen(isoViewport.min_, viewCenterIso, scale, minimapCenter);
     vec2 mappedMax = isoToMinimapScreen(isoViewport.max_, viewCenterIso, scale, minimapCenter);
@@ -109,7 +115,8 @@ inline void drawEntityDots(
     const vec4 kCulledColor(1.0f, 0.0f, 0.0f, 0.7f);
 
     for (const auto &record : entityRecords) {
-        vec2 dotPosition = isoToMinimapScreen(record.isoPosition_, viewCenterIso, scale, minimapCenter);
+        vec2 dotPosition =
+            isoToMinimapScreen(record.isoPosition_, viewCenterIso, scale, minimapCenter);
         if (!minimapScreenBounds.contains(dotPosition)) {
             continue;
         }
@@ -127,121 +134,136 @@ inline void drawFrozenIndicator(vec2 minimapOrigin, float minimapWidth, float mi
 } // namespace detail
 
 template <> struct System<DEBUG_CULLING_MINIMAP> {
+    // Layout configuration — settable via create(Params).
+    float screenWidthFraction_ = 0.15f;
+    float aspectRatio_ = 12.0f / 7.0f;
+    float padding_ = 10.0f;
+
+    // Per-frame scratch buffers (reused across ticks).
+    std::vector<detail::EntityRecord> entityRecords_;
+    IRRender::IsoSpatialHash spatialHash_{32};
+    std::vector<detail::PendingEntity> pendingEntities_;
+
+    // External config type for the two-argument create() overload.
     struct Params {
         float screenWidthFraction_ = 0.15f;
         float aspectRatio_ = 12.0f / 7.0f;
         float padding_ = 10.0f;
     };
 
-    static SystemId create() { return create(Params{}); }
+    void tick(
+        IREntity::EntityId entityId,
+        const C_ShapeDescriptor &shape,
+        const C_PositionGlobal3D &position
+    ) {
+        vec2 isoPosition = IRMath::pos3DtoPos2DIso(position.pos_);
+        vec2 isoHalfExtent = IRMath::shapeIsoHalfExtent(vec3(shape.params_));
 
-    static SystemId create(const Params &initialParams) {
-        auto paramsOwner = std::make_unique<Params>(initialParams);
-        Params *params = paramsOwner.get();
+        spatialHash_.insert(entityId, isoPosition - isoHalfExtent, isoPosition + isoHalfExtent);
+        pendingEntities_.push_back({entityId, isoPosition});
+    }
 
-        static std::vector<detail::EntityRecord> entityRecords;
+    void beginTick() {
+        spatialHash_.clear();
+        pendingEntities_.clear();
+    }
 
-        static IRRender::IsoSpatialHash spatialHash(32);
+    void endTick() {
+        const auto &cullState = IRRender::getCullViewport();
+        bool isCullingFrozen = cullState.frozen_;
+        vec2 liveCameraIso = IRRender::getCameraPosition2DIso();
+        vec2 liveCameraZoom = IRRender::getCameraZoom();
+        ivec2 viewportSize = IRRender::getViewport();
 
-        struct PendingEntity {
-            IREntity::EntityId entityId_;
-            vec2 isoPosition_;
-        };
-        static std::vector<PendingEntity> pendingEntities;
+        auto cullViewport = cullState.isoViewport();
+        auto visibleEntityIds = spatialHash_.query(cullViewport.min_, cullViewport.max_);
 
-        SystemId systemId = createSystem<C_ShapeDescriptor, C_PositionGlobal3D>(
-            "DebugCullingMinimap",
-            [](IREntity::EntityId &entityId,
-               const C_ShapeDescriptor &shape,
-               const C_PositionGlobal3D &position) {
-                vec2 isoPosition = IRMath::pos3DtoPos2DIso(position.pos_);
-                vec2 isoHalfExtent = IRMath::shapeIsoHalfExtent(vec3(shape.params_));
+        entityRecords_.clear();
+        for (const auto &pending : pendingEntities_) {
+            bool isVisible =
+                std::find(visibleEntityIds.begin(), visibleEntityIds.end(), pending.entityId_) !=
+                visibleEntityIds.end();
+            entityRecords_.push_back({pending.isoPosition_, isVisible});
+        }
 
-                spatialHash.insert(entityId, isoPosition - isoHalfExtent, isoPosition + isoHalfExtent);
-                pendingEntities.push_back({entityId, isoPosition});
-            },
-            []() {
-                spatialHash.clear();
-                pendingEntities.clear();
-            },
-            [params]() {
-                const auto &cullState = IRRender::getCullViewport();
-                bool isCullingFrozen = cullState.frozen_;
-                vec2 liveCameraIso = IRRender::getCameraPosition2DIso();
-                vec2 liveCameraZoom = IRRender::getCameraZoom();
-                ivec2 viewportSize = IRRender::getViewport();
+        auto layout =
+            detail::computeLayout(viewportSize, screenWidthFraction_, aspectRatio_, padding_);
 
-                auto cullViewport = cullState.isoViewport();
-                auto visibleEntityIds = spatialHash.query(cullViewport.min_, cullViewport.max_);
-
-                entityRecords.clear();
-                for (const auto &pending : pendingEntities) {
-                    bool isVisible =
-                        std::find(visibleEntityIds.begin(), visibleEntityIds.end(), pending.entityId_)
-                        != visibleEntityIds.end();
-                    entityRecords.push_back({pending.isoPosition_, isVisible});
-                }
-
-                auto layout = detail::computeLayout(
-                    viewportSize, params->screenWidthFraction_,
-                    params->aspectRatio_, params->padding_
-                );
-
-                IRDebug::drawRectScreen(
-                    layout.origin_,
-                    layout.origin_ + vec2(layout.width_, layout.height_),
-                    vec4(0.0f, 0.0f, 0.0f, 0.4f),
-                    vec4(0.5f, 0.5f, 0.5f, 0.8f)
-                );
-
-                vec2 viewCenterIso = cullViewport.center();
-                vec2 cullExtent = cullViewport.extent();
-
-                float autoFitExtent = detail::computeAutoFitExtent(
-                    entityRecords, viewCenterIso, cullExtent
-                );
-
-                float isoToMinimapScale = layout.width_ / (autoFitExtent * 2.0f);
-                vec2 minimapCenter = layout.center();
-
-                detail::drawViewportOutline(
-                    cullViewport, viewCenterIso, isoToMinimapScale,
-                    minimapCenter, vec4(1.0f, 1.0f, 1.0f, 0.9f)
-                );
-
-                if (isCullingFrozen) {
-                    ivec2 liveCanvasSize = ivec2(0);
-                    {
-                        IREntity::EntityId mainCanvasEntity = IRRender::getActiveCanvasEntity();
-                        auto texturesOptional =
-                            IREntity::getComponentOptional<C_TriangleCanvasTextures>(mainCanvasEntity);
-                        if (texturesOptional.has_value()) {
-                            liveCanvasSize = texturesOptional.value()->size_;
-                        }
-                    }
-                    auto liveViewport = IRMath::visibleIsoViewport(
-                        liveCameraIso,
-                        IRMath::trixelOriginOffsetZ1(liveCanvasSize),
-                        liveCanvasSize, liveCameraZoom
-                    );
-                    detail::drawViewportOutline(
-                        liveViewport, viewCenterIso, isoToMinimapScale,
-                        minimapCenter, vec4(0.2f, 0.8f, 1.0f, 0.7f)
-                    );
-                }
-
-                detail::drawEntityDots(
-                    entityRecords, viewCenterIso, isoToMinimapScale,
-                    minimapCenter, layout.screenBounds()
-                );
-
-                if (isCullingFrozen) {
-                    detail::drawFrozenIndicator(layout.origin_, layout.width_, layout.height_);
-                }
-            }
+        IRDebug::drawRectScreen(
+            layout.origin_,
+            layout.origin_ + vec2(layout.width_, layout.height_),
+            vec4(0.0f, 0.0f, 0.0f, 0.4f),
+            vec4(0.5f, 0.5f, 0.5f, 0.8f)
         );
 
-        setSystemParams(systemId, std::move(paramsOwner));
+        vec2 viewCenterIso = cullViewport.center();
+        vec2 cullExtent = cullViewport.extent();
+
+        float autoFitExtent =
+            detail::computeAutoFitExtent(entityRecords_, viewCenterIso, cullExtent);
+
+        float isoToMinimapScale = layout.width_ / (autoFitExtent * 2.0f);
+        vec2 minimapCenter = layout.center();
+
+        detail::drawViewportOutline(
+            cullViewport,
+            viewCenterIso,
+            isoToMinimapScale,
+            minimapCenter,
+            vec4(1.0f, 1.0f, 1.0f, 0.9f)
+        );
+
+        if (isCullingFrozen) {
+            ivec2 liveCanvasSize = ivec2(0);
+            {
+                IREntity::EntityId mainCanvasEntity = IRRender::getActiveCanvasEntity();
+                auto texturesOptional =
+                    IREntity::getComponentOptional<C_TriangleCanvasTextures>(mainCanvasEntity);
+                if (texturesOptional.has_value()) {
+                    liveCanvasSize = texturesOptional.value()->size_;
+                }
+            }
+            auto liveViewport = IRMath::visibleIsoViewport(
+                liveCameraIso,
+                IRMath::trixelOriginOffsetZ1(liveCanvasSize),
+                liveCanvasSize,
+                liveCameraZoom
+            );
+            detail::drawViewportOutline(
+                liveViewport,
+                viewCenterIso,
+                isoToMinimapScale,
+                minimapCenter,
+                vec4(0.2f, 0.8f, 1.0f, 0.7f)
+            );
+        }
+
+        detail::drawEntityDots(
+            entityRecords_,
+            viewCenterIso,
+            isoToMinimapScale,
+            minimapCenter,
+            layout.screenBounds()
+        );
+
+        if (isCullingFrozen) {
+            detail::drawFrozenIndicator(layout.origin_, layout.width_, layout.height_);
+        }
+    }
+
+    static SystemId create() {
+        return create(Params{});
+    }
+
+    static SystemId create(const Params &initialParams) {
+        SystemId systemId =
+            registerSystem<DEBUG_CULLING_MINIMAP, C_ShapeDescriptor, C_PositionGlobal3D>(
+                "DebugCullingMinimap"
+            );
+        auto *p = getSystemParams<System<DEBUG_CULLING_MINIMAP>>(systemId);
+        p->screenWidthFraction_ = initialParams.screenWidthFraction_;
+        p->aspectRatio_ = initialParams.aspectRatio_;
+        p->padding_ = initialParams.padding_;
         return systemId;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp
@@ -59,23 +59,69 @@ struct FrameDataLightingToTrixel {
 // `C_TrixelCanvasRenderBehavior::useCameraPositionIso_ == false` early-
 // return in the tick.
 template <> struct System<LIGHTING_TO_TRIXEL> {
-    struct Params {
-        ShaderProgram *program_ = nullptr;
-        Buffer *frameDataBuf_ = nullptr;
-        // Reuse the voxel pipeline's per-frame UBO so we can recover the
-        // world voxel position of each pixel via the same iso math the AO
-        // pass uses. Created by VOXEL_TO_TRIXEL_STAGE_1; this system runs
-        // later in the pipeline so the buffer is always populated.
-        Buffer *voxelFrameDataBuf_ = nullptr;
-        Buffer *sunFrameDataBuf_ = nullptr;
-        // Phase 1c (#360): camera-anchored light-volume params UBO. Owned
-        // + uploaded by COMPUTE_LIGHT_VOLUME; the lighting pass needs to
-        // know the volume's world origin to map a pixel's world voxel
-        // back into the volume texel.
-        Buffer *lightVolumeParamsBuf_ = nullptr;
-        Texture2D *paletteLUT_ = nullptr;
-        FrameDataLightingToTrixel frameData_{};
-    };
+    ShaderProgram *program_ = nullptr;
+    Buffer *frameDataBuf_ = nullptr;
+    // Reuse the voxel pipeline's per-frame UBO so we can recover the
+    // world voxel position of each pixel via the same iso math the AO
+    // pass uses. Created by VOXEL_TO_TRIXEL_STAGE_1; this system runs
+    // later in the pipeline so the buffer is always populated.
+    Buffer *voxelFrameDataBuf_ = nullptr;
+    Buffer *sunFrameDataBuf_ = nullptr;
+    // Phase 1c (#360): camera-anchored light-volume params UBO. Owned
+    // + uploaded by COMPUTE_LIGHT_VOLUME; the lighting pass needs to
+    // know the volume's world origin to map a pixel's world voxel
+    // back into the volume texel.
+    Buffer *lightVolumeParamsBuf_ = nullptr;
+    Texture2D *paletteLUT_ = nullptr;
+    FrameDataLightingToTrixel frameData_{};
+
+    void tick(
+        const C_TriangleCanvasTextures &canvasTextures,
+        const C_TrixelCanvasRenderBehavior &behavior,
+        const C_CanvasAOTexture &ao,
+        const C_CanvasSunShadow &shadow,
+        const C_CanvasLightVolume &lightVolume
+    ) {
+        if (!behavior.useCameraPositionIso_) {
+            return;
+        }
+
+        canvasTextures.getTextureColors()
+            ->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
+        canvasTextures.getTextureDistances()
+            ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
+        ao.getTexture()->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+        // Texture/image unit layout (must match GLSL + MSL):
+        //   3: paletteLUT (sampler2D)
+        //   4: canvasSunShadow (image2D, R/O)
+        //   5: lightVolume (sampler3D)
+        // Metal flattens the sampler and image namespaces into a
+        // shared setTexture slot space, so all three slots must be
+        // unique across both kinds.
+        paletteLUT_->bind(3);
+        shadow.getTexture()->bindAsImage(4, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
+        // `getReadTexture()` returns whichever ping-pong texture
+        // the GPU light-volume producer last wrote to, so this
+        // sampler always sees the latest dilation result.
+        lightVolume.getReadTexture()->bind(5);
+        frameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataLightingToTrixel);
+        voxelFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataVoxelToCanvas);
+        sunFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataSun);
+        lightVolumeParamsBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_LightVolumeParams);
+
+        const int groupsX = IRMath::divCeil(canvasTextures.size_.x, kLightingToTrixelGroupSize);
+        const int groupsY = IRMath::divCeil(canvasTextures.size_.y, kLightingToTrixelGroupSize);
+        IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
+        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+    }
+
+    void beginTick() {
+        program_->use();
+        frameData_.lightingEnabled_ = 1;
+        frameData_.lightVolumeEnabled_ = 1;
+        frameData_.debugOverlayMode_ = static_cast<int>(IRRender::getDebugOverlay());
+        frameDataBuf_->subData(0, sizeof(FrameDataLightingToTrixel), &frameData_);
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
@@ -109,17 +155,6 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
             TextureFilter::LINEAR
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
-        p->program_ = IRRender::getNamedResource<ShaderProgram>("LightingToTrixelProgram");
-        p->frameDataBuf_ = IRRender::getNamedResource<Buffer>("LightingToTrixelFrameData");
-        p->voxelFrameDataBuf_ = IRRender::getNamedResource<Buffer>("SingleVoxelFrameData");
-        p->sunFrameDataBuf_ = IRRender::getNamedResource<Buffer>("ComputeSunShadowFrameData");
-        // LightVolumeParamsBuffer is created by COMPUTE_LIGHT_VOLUME,
-        // which is registered ahead of LIGHTING_TO_TRIXEL in the render
-        // pipeline; safe to look up at init time.
-        p->lightVolumeParamsBuf_ = IRRender::getNamedResource<Buffer>("LightVolumeParamsBuffer");
-        p->paletteLUT_ = IRRender::getNamedResource<Texture2D>("PaletteLUT_Nearest");
         // Upload default LUT: cool-shadow (x=0) → full-white (x=255) gradient.
         // Same data for both filter variants; the difference is sampling mode.
         {
@@ -134,15 +169,16 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
                     data[idx + 3] = 255u;
                 }
             }
-            p->paletteLUT_->subImage2D(
-                0,
-                0,
-                256,
-                16,
-                PixelDataFormat::RGBA,
-                PixelDataType::UNSIGNED_BYTE,
-                data.data()
-            );
+            IRRender::getNamedResource<Texture2D>("PaletteLUT_Nearest")
+                ->subImage2D(
+                    0,
+                    0,
+                    256,
+                    16,
+                    PixelDataFormat::RGBA,
+                    PixelDataType::UNSIGNED_BYTE,
+                    data.data()
+                );
             IRRender::getNamedResource<Texture2D>("PaletteLUT_Linear")
                 ->subImage2D(
                     0,
@@ -155,71 +191,23 @@ template <> struct System<LIGHTING_TO_TRIXEL> {
                 );
         }
 
-        SystemId systemId = createSystem<
+        SystemId systemId = registerSystem<
+            LIGHTING_TO_TRIXEL,
             C_TriangleCanvasTextures,
             C_TrixelCanvasRenderBehavior,
             C_CanvasAOTexture,
             C_CanvasSunShadow,
-            C_CanvasLightVolume>(
-            "LightingToTrixel",
-            [p](const C_TriangleCanvasTextures &canvasTextures,
-                const C_TrixelCanvasRenderBehavior &behavior,
-                const C_CanvasAOTexture &ao,
-                const C_CanvasSunShadow &shadow,
-                const C_CanvasLightVolume &lightVolume) {
-                if (!behavior.useCameraPositionIso_) {
-                    return;
-                }
-
-                canvasTextures.getTextureColors()
-                    ->bindAsImage(0, TextureAccess::READ_WRITE, TextureFormat::RGBA8);
-                canvasTextures.getTextureDistances()
-                    ->bindAsImage(1, TextureAccess::READ_ONLY, TextureFormat::R32I);
-                ao.getTexture()->bindAsImage(2, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-                // Texture/image unit layout (must match GLSL + MSL):
-                //   3: paletteLUT (sampler2D)
-                //   4: canvasSunShadow (image2D, R/O)
-                //   5: lightVolume (sampler3D)
-                // Metal flattens the sampler and image namespaces into a
-                // shared setTexture slot space, so all three slots must be
-                // unique across both kinds.
-                p->paletteLUT_->bind(3);
-                shadow.getTexture()->bindAsImage(4, TextureAccess::READ_ONLY, TextureFormat::RGBA8);
-                // `getReadTexture()` returns whichever ping-pong texture
-                // the GPU light-volume producer last wrote to, so this
-                // sampler always sees the latest dilation result.
-                lightVolume.getReadTexture()->bind(5);
-                p->frameDataBuf_->bindBase(
-                    BufferTarget::UNIFORM,
-                    kBufferIndex_FrameDataLightingToTrixel
-                );
-                p->voxelFrameDataBuf_->bindBase(
-                    BufferTarget::UNIFORM,
-                    kBufferIndex_FrameDataVoxelToCanvas
-                );
-                p->sunFrameDataBuf_->bindBase(BufferTarget::UNIFORM, kBufferIndex_FrameDataSun);
-                p->lightVolumeParamsBuf_->bindBase(
-                    BufferTarget::UNIFORM,
-                    kBufferIndex_LightVolumeParams
-                );
-
-                const int groupsX =
-                    IRMath::divCeil(canvasTextures.size_.x, kLightingToTrixelGroupSize);
-                const int groupsY =
-                    IRMath::divCeil(canvasTextures.size_.y, kLightingToTrixelGroupSize);
-                IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
-                IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-            },
-            [p]() {
-                p->program_->use();
-                p->frameData_.lightingEnabled_ = 1;
-                p->frameData_.lightVolumeEnabled_ = 1;
-                p->frameData_.debugOverlayMode_ = static_cast<int>(IRRender::getDebugOverlay());
-                p->frameDataBuf_->subData(0, sizeof(FrameDataLightingToTrixel), &p->frameData_);
-            }
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
+            C_CanvasLightVolume>("LightingToTrixel");
+        auto *p = getSystemParams<System<LIGHTING_TO_TRIXEL>>(systemId);
+        p->program_ = IRRender::getNamedResource<ShaderProgram>("LightingToTrixelProgram");
+        p->frameDataBuf_ = IRRender::getNamedResource<Buffer>("LightingToTrixelFrameData");
+        p->voxelFrameDataBuf_ = IRRender::getNamedResource<Buffer>("SingleVoxelFrameData");
+        p->sunFrameDataBuf_ = IRRender::getNamedResource<Buffer>("ComputeSunShadowFrameData");
+        // LightVolumeParamsBuffer is created by COMPUTE_LIGHT_VOLUME,
+        // which is registered ahead of LIGHTING_TO_TRIXEL in the render
+        // pipeline; safe to look up at init time.
+        p->lightVolumeParamsBuf_ = IRRender::getNamedResource<Buffer>("LightVolumeParamsBuffer");
+        p->paletteLUT_ = IRRender::getNamedResource<Texture2D>("PaletteLUT_Nearest");
         IRRender::tagGpuStage(systemId, "lightingToTrixel");
         return systemId;
     }

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_trixel.hpp
@@ -6,6 +6,7 @@
 #include <irreden/ir_constants.hpp>
 #include <irreden/ir_math.hpp>
 
+#include <irreden/common/components/component_position_2d_iso.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/gpu_stage_timing_observer.hpp>
@@ -19,18 +20,42 @@ namespace IRSystem {
 constexpr int kTrixelToTrixelGroupSize = 16; // must match local_size in c_trixel_to_trixel.glsl
 
 template <> struct System<TRIXEL_TO_TRIXEL> {
-    struct Params {
-        ShaderProgram *program_ = nullptr;
-        Buffer *frameDataBuf_ = nullptr;
-        FrameDataTrixelToTrixel frameData_{};
-    };
+    ShaderProgram *program_ = nullptr;
+    Buffer *frameDataBuf_ = nullptr;
+    FrameDataTrixelToTrixel frameData_{};
+
+    void
+    tick(const C_TriangleCanvasTextures &trixelTextures, const C_Position2DIso &position2DIso) {
+        trixelTextures.bind(2, 3);
+        frameData_.trixelTextureOffsetZ1_ = IRMath::trixelOriginOffsetZ1(trixelTextures.size_);
+        frameData_.texturePos2DIso_ = position2DIso.pos_;
+        frameDataBuf_->subData(0, sizeof(FrameDataTrixelToTrixel), &frameData_);
+        const int groupsX = IRMath::divCeil(trixelTextures.size_.x, kTrixelToTrixelGroupSize);
+        const int groupsY = IRMath::divCeil(trixelTextures.size_.y, kTrixelToTrixelGroupSize);
+        IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
+        IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+    }
+
+    void beginTick() {
+        program_->use();
+        vec2 camIso = IRRender::getCameraPosition2DIso();
+        frameData_.cameraTrixelOffset_ = ivec2(
+            static_cast<int>(IRMath::floor(camIso.x)),
+            static_cast<int>(IRMath::floor(camIso.y))
+        );
+    }
+
+    // TODO: Add position here and bind camera position to
+    // main trixel canvas.
+    void relationTick(const C_TriangleCanvasTextures &parentTexture) {
+        parentTexture.bind(0, 1);
+        frameData_.trixelCanvasOffsetZ1_ = IRMath::trixelOriginOffsetZ1(parentTexture.size_);
+    }
 
     static SystemId create() {
         IRRender::createNamedResource<ShaderProgram>(
             "TrixelToTrixelProgram",
-            std::vector{
-                ShaderStage{IRRender::kFileCompTrixelToTrixel, ShaderType::COMPUTE}
-            }
+            std::vector{ShaderStage{IRRender::kFileCompTrixelToTrixel, ShaderType::COMPUTE}}
         );
         IRRender::createNamedResource<Buffer>(
             "TrixelToTrixelFrameData",
@@ -41,45 +66,14 @@ template <> struct System<TRIXEL_TO_TRIXEL> {
             kBufferIndex_FrameDataTrixelToTrixel
         );
 
-        auto paramsOwner = std::make_unique<Params>();
-        Params *p = paramsOwner.get();
+        SystemId systemId =
+            registerSystem<TRIXEL_TO_TRIXEL, C_TriangleCanvasTextures, C_Position2DIso>(
+                "CanvasToFramebuffer",
+                RelationParams<C_TriangleCanvasTextures>{Relation::CHILD_OF}
+            );
+        auto *p = getSystemParams<System<TRIXEL_TO_TRIXEL>>(systemId);
         p->program_ = IRRender::getNamedResource<ShaderProgram>("TrixelToTrixelProgram");
         p->frameDataBuf_ = IRRender::getNamedResource<Buffer>("TrixelToTrixelFrameData");
-
-        SystemId systemId = createSystem<C_TriangleCanvasTextures, C_Position2DIso>(
-            "CanvasToFramebuffer",
-            [p](const C_TriangleCanvasTextures &trixelTextures,
-                const C_Position2DIso &position2DIso) {
-                trixelTextures.bind(2, 3);
-                p->frameData_.trixelTextureOffsetZ1_ =
-                    IRMath::trixelOriginOffsetZ1(trixelTextures.size_);
-                p->frameData_.texturePos2DIso_ = position2DIso.pos_;
-                p->frameDataBuf_->subData(0, sizeof(FrameDataTrixelToTrixel), &p->frameData_);
-                const int groupsX = IRMath::divCeil(trixelTextures.size_.x, kTrixelToTrixelGroupSize);
-                const int groupsY = IRMath::divCeil(trixelTextures.size_.y, kTrixelToTrixelGroupSize);
-                IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
-                IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
-            },
-            [p]() {
-                p->program_->use();
-                vec2 camIso = IRRender::getCameraPosition2DIso();
-                p->frameData_.cameraTrixelOffset_ = ivec2(
-                    static_cast<int>(IRMath::floor(camIso.x)),
-                    static_cast<int>(IRMath::floor(camIso.y))
-                );
-            },
-            nullptr,
-            // TODO: Add position here and bind camera position to
-            // main trixel canvas.
-            RelationParams<C_TriangleCanvasTextures>{Relation::CHILD_OF},
-            [p](const C_TriangleCanvasTextures &parentTexture) {
-                parentTexture.bind(0, 1);
-                p->frameData_.trixelCanvasOffsetZ1_ = IRMath::trixelOriginOffsetZ1(parentTexture.size_);
-            }
-
-        );
-
-        setSystemParams(systemId, std::move(paramsOwner));
         IRRender::tagGpuStage(systemId, "trixelToTrixel");
         return systemId;
     }


### PR DESCRIPTION
## Summary

- Migrates `LIGHTING_TO_TRIXEL`, `TRIXEL_TO_TRIXEL`, and `DEBUG_CULLING_MINIMAP` from explicit `Params + setSystemParams + lambda` to `registerSystem<N, Cs...>` with member fields and named member functions.
- `TRIXEL_TO_TRIXEL` relation tick (`CHILD_OF` canvas hierarchy) forwarded via `registerSystem`'s second argument; named `relationTick` member wired automatically.
- `DEBUG_CULLING_MINIMAP` moves three function-local statics (`entityRecords`, `spatialHash`, `pendingEntities`) to member fields; `PendingEntity` type promoted to `detail` namespace. Two `create()` overloads preserved for API compatibility.
- Fixes pre-existing `glm::abs` → `IRMath::abs` in `detail::computeAutoFitExtent`.

## Test plan

- [x] `fleet-build --target IRShapeDebug` — clean
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — 6/6 shots clean, lighting/AO/shadows correct, no regressions vs. T-155 baseline

## Notes for reviewer

`DEBUG_CULLING_MINIMAP` previously relied on function-local `static` for shared per-frame state across three lambdas — a live deviation in `system-static-deviations.md`. This PR resolves that deviation as a side effect of the migration; no behavioral change.

Closes part of #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)