### PR TITLE
voxel: drop dead getLocalPosition + redundant voxels_.size() bound

### DIFF
--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -182,10 +182,6 @@ struct C_VoxelSetNew {
         }
     }
 
-    vec3 getLocalPosition(int index) {
-        return positions_[index].pos_ + positionOffsets_[index].pos_;
-    }
-
     // TODO each individual voxel should be treated like this
     // and a set should only contain local positions...
     //
@@ -215,10 +211,7 @@ struct C_VoxelSetNew {
             poolOffsets.size() > voxelStartIdx_ ? poolOffsets.size() - voxelStartIdx_ : 0u;
         const int safeCount = IRMath::min(
             numVoxels_,
-            static_cast<int>(IRMath::min(
-                IRMath::min(availPositions, availOffsets),
-                IRMath::min(static_cast<size_t>(voxels_.size()), writableTail)
-            ))
+            static_cast<int>(IRMath::min(IRMath::min(availPositions, availOffsets), writableTail))
         );
         for (int i = 0; i < safeCount; i++) {
             poolGlobalsOut[voxelStartIdx_ + i].pos_ = poolPositions[voxelStartIdx_ + i].pos_ +


### PR DESCRIPTION
## Summary

Two trivial nits flagged by the sonnet-reviewer on PR #629 that landed in parallel with the merge — re-filed as a follow-up.

- `component_voxel_set.hpp:185-187` — removed `getLocalPosition()`. The function read `positions_[i].pos_ + positionOffsets_[i].pos_`, both of which are spans documented as dangling after a between-frame canvas archetype migration (the same hazard the rest of #629 was eliminating in `updateAsChild`). `Grep getLocalPosition` confirms no callers anywhere in the engine.
- `component_voxel_set.hpp:220` — removed `static_cast<size_t>(voxels_.size())` from the inner `IRMath::min`. `numVoxels_` is set by the constructor min-span guard to that same value at allocation time, so the outer `IRMath::min(numVoxels_, …)` already bounds by it. One fewer line of redundant defensive math.

## Test plan

- [x] `fleet-build --target IRShapeDebug` — clean on macOS/Metal
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — all 6 shots captured, no visual regression
- [ ] `fleet:needs-linux-smoke` if reviewers want cross-host confirmation; the change is pure dead-code removal so should be backend-agnostic.

## Why a separate PR

The merger merged #629 while I was pushing the cleanup commit — my push landed on the closed branch and never reached master. Re-filed here as a tiny follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)