### PR TITLE
T-162: engine/entity: ECS singleton-component infrastructure

### DIFF
--- a/engine/entity/CLAUDE.md
+++ b/engine/entity/CLAUDE.md
@@ -120,6 +120,85 @@ to remember a manual cleanup step before `destroyEntity`. Per-component
 cleanup belongs in the component's `onDestroy()` member, not in a hook
 — see `engine/prefabs/CLAUDE.md` "Documented exceptions".
 
+## Singleton components
+
+A "singleton component" is a component for which exactly one record
+exists per world — framework-level globals, per-world settings, scratch
+state. The canonical example is the modifier framework's
+`C_GlobalModifiers` (one `"modifierGlobals"` entity per world); the
+sim-clock substrate (#200) and future per-world game-rules holders will
+adopt the same shape.
+
+`IREntity::singleton<T>()` is the public API for this pattern. Lazy-init
+on first call (creates an entity with default-constructed `T` and caches
+the id by `ComponentId`); subsequent calls return the same reference at
+the cost of one hash-map lookup. Singleton entities are normal ECS
+entities and participate in archetype iteration — a `forEachComponent<T>`
+that matches `T` will see the singleton row.
+
+```cpp
+// Typed C++ entry points (engine/entity/include/irreden/ir_entity.hpp):
+template <typename C> IREntity::EntityId singletonEntity();        // lazy-create
+template <typename C> IREntity::EntityId singletonEntityOrNull();  // no-create
+template <typename C> C& singleton();                              // lazy-create + ref
+template <typename C> C* singletonOrNull();                        // no-create + ptr
+```
+
+Lua: `IREntity.singleton(componentDef) -> LuaEntity`. Works for
+codegen'd-as-C++ components and runtime-registered Lua-defined
+components — both share the same `ComponentId` space and the same
+cache. Pass the returned `LuaEntity` to the standard
+`IREntity.getLuaComponent` / `IREntity.setLuaField` accessors.
+
+```lua
+local C_GameRules = IRComponent.register("GameRules", { score = 0 })
+local entity = IREntity.singleton(C_GameRules)         -- lazy-creates first time
+IREntity.setLuaField(entity, C_GameRules, scoreIdx, 1) -- normal field accessor
+```
+
+### Conventions
+
+- **Default-constructible.** The typed `singleton<T>()` path calls
+  `createEntity(T{})`. If `T` cannot be default-constructed, expose a
+  feature-specific factory wrapping `singletonEntity<T>` so callers can
+  seed the row with explicit values.
+- **Lazy validation.** The cache is keyed by `ComponentId` and validated
+  against `entityExists` on every lookup. If a singleton entity is
+  destroyed externally (manual `destroyEntity` call, end-of-world
+  `destroyAllEntities` reset), the next access lazy-recreates (typed
+  path) or returns `kNullEntity` / `nullptr` (or-null path).
+- **`destroyAllEntities` resets the cache.** Tests that tear down and
+  rebuild the world between cases get a fresh singleton on the first
+  post-reset access.
+- **Naming is optional.** The API does NOT auto-name the entity; callers
+  who want diagnostic visibility can `setName(singletonEntity<T>(),
+  "myThing")`. The modifier framework names its globals
+  `"modifierGlobals"` for the existing tooling that scans by name.
+- **Use the API for what it's for.** Singleton-shaped *components* — yes.
+  Things that should live on a manager (graphics device handles,
+  RenderManager fields) — no; manager fields are still the right
+  shape for device-level state. Rule of thumb: if the data is naturally
+  an ECS column (composable, iterable, save/load-friendly), use a
+  singleton component; if it's a pointer to an external resource that
+  the manager already owns, leave it on the manager.
+
+### Archetype implications
+
+A singleton entity is a normal entity in the archetype graph. Adding or
+removing components on it moves it between archetype nodes the same way
+any other entity does. Iteration order across nodes is implementation-
+defined, so don't assume the singleton appears first or last in a
+`forEachComponent` walk — query by `singletonEntity<T>()` when you need
+the specific row.
+
+### Save/load implications
+
+Per-component save/load (#199) treats singleton entities like any other:
+the entity id round-trips and the cache rebuilds on first access against
+the loaded entity. Workers retrofitting #199 into the singleton API should
+verify the cache invalidates on load (typically a `destroyAllEntities`
+precedes the load, which already clears the cache).
+
 ## Position components are automatic
 
 `createEntity(...)` always adds `C_PositionGlobal3D` and

--- a/engine/entity/include/irreden/entity/entity_manager.hpp
+++ b/engine/entity/include/irreden/entity/entity_manager.hpp
@@ -371,6 +371,41 @@ class EntityManager {
     PreDestroyHookId registerPreDestroyHook(PreDestroyHook hook);
     void unregisterPreDestroyHook(PreDestroyHookId id);
 
+    /// Singleton-component support. One entity per component type, cached
+    /// by `ComponentId`. The cache is lazily validated: if the cached
+    /// entity has been destroyed (e.g. by `destroyAllEntities`), the next
+    /// lookup discards the stale entry and either lazy-creates (typed
+    /// path) or returns `kNullEntity` (or-null path).
+    ///
+    /// Typed C++ entry point: `singleton<T>()` (templated). Uses
+    /// `createEntity(T{})` so `T` must be default-constructible.
+    template <typename Component> EntityId getOrCreateSingleton() {
+        IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
+        const ComponentId componentType = getComponentType<Component>();
+        auto it = m_singletonEntityByComponent.find(componentType);
+        if (it != m_singletonEntityByComponent.end() && entityExists(it->second)) {
+            return it->second;
+        }
+        if (it != m_singletonEntityByComponent.end()) {
+            m_singletonEntityByComponent.erase(it);
+        }
+        EntityId entity = createEntity(Component{});
+        m_singletonEntityByComponent[componentType] = entity;
+        return entity;
+    }
+
+    /// Untyped entry point used by Lua-defined components — the component
+    /// is attached via the dynamic-add path so this works uniformly for
+    /// both `registerComponent<T>` and `registerComponentDynamic` types.
+    /// For typed C++ components, prefer `getOrCreateSingleton<T>()`.
+    EntityId getOrCreateSingletonByComponentId(ComponentId componentType);
+
+    /// No-create variant. Returns the cached singleton entity for this
+    /// component type if previously created (and still alive), else
+    /// `kNullEntity`. Useful for query sites that should not implicitly
+    /// instantiate the singleton when called before initial setup.
+    EntityId getSingletonByComponentIdOrNull(ComponentId componentType);
+
   private:
     std::queue<EntityId> m_entityPool;
     std::unordered_map<EntityId, EntityRecord> m_entityIndex;
@@ -388,6 +423,11 @@ class EntityManager {
     std::vector<PreDestroyHookEntry> m_preDestroyHooks;
     PreDestroyHookId m_nextPreDestroyHookId{1};
     bool m_preDestroyHookIterating{false};
+    // Singleton-component cache. Key is `ComponentId`, value is the entity
+    // owning that component. Stale entries (entity destroyed externally)
+    // are evicted lazily via the `entityExists` check on lookup. Cleared
+    // unconditionally by `destroyAllEntities`.
+    std::unordered_map<ComponentId, EntityId> m_singletonEntityByComponent;
 
     EntityId allocateEntity();
     void addNewEntityToBaseNode(EntityId entity);

--- a/engine/entity/include/irreden/ir_entity.hpp
+++ b/engine/entity/include/irreden/ir_entity.hpp
@@ -61,8 +61,9 @@ std::vector<ArchetypeNode *> queryArchetypeNodesRelational(
     const Archetype &excludeComponents = Archetype{}
 );
 
-inline std::vector<EntityId>
-collectEntitiesSimple(const Archetype &includeComponents, const Archetype &excludeComponents = Archetype{}) {
+inline std::vector<EntityId> collectEntitiesSimple(
+    const Archetype &includeComponents, const Archetype &excludeComponents = Archetype{}
+) {
     std::vector<EntityId> entities;
     auto nodes = queryArchetypeNodesSimple(includeComponents, excludeComponents);
     for (auto *node : nodes) {
@@ -76,8 +77,9 @@ collectEntitiesSimple(const Archetype &includeComponents, const Archetype &exclu
 }
 
 template <typename Component>
-inline void
-removeComponentsSimple(const Archetype &includeComponents, const Archetype &excludeComponents = Archetype{}) {
+inline void removeComponentsSimple(
+    const Archetype &includeComponents, const Archetype &excludeComponents = Archetype{}
+) {
     auto entities = collectEntitiesSimple(includeComponents, excludeComponents);
     for (auto entity : entities) {
         getEntityManager().removeComponent<Component>(entity);
@@ -116,11 +118,13 @@ template <typename Component, typename Function> void forEachComponent(Function 
             for (int i = 0; i < node->length_; ++i) {
                 function(entities[i], components[i]);
             }
-        } else if constexpr (std::is_invocable_v<
-                                 Function,
-                                 const Archetype &,
-                                 std::vector<EntityId> &,
-                                 std::vector<Component> &>) {
+        } else if constexpr (
+            std::is_invocable_v<
+                Function,
+                const Archetype &,
+                std::vector<EntityId> &,
+                std::vector<Component> &>
+        ) {
             function(node->type_, node->entities_, components);
         } else {
             IR_ASSERT(
@@ -260,12 +264,50 @@ template <typename Component> void removeComponentDeferred(EntityId entity) {
     getEntityManager().removeComponentDeferred<Component>(entity);
 }
 
-template <typename Component> void setComponentDeferred(EntityId entity, const Component &component) {
+template <typename Component>
+void setComponentDeferred(EntityId entity, const Component &component) {
     getEntityManager().setComponentDeferred<Component>(entity, component);
 }
 
 inline void flushStructuralChanges() {
     getEntityManager().flushStructuralChanges();
+}
+
+/// Singleton-component API. One entity per component type, lazily created
+/// on first access and cached by `ComponentId`. The cache survives entity
+/// destruction lazily — calls after `destroyAllEntities` re-create on
+/// demand.
+///
+/// Use for "global game state" components where exactly one record exists
+/// per world: framework-level globals (the modifier framework's
+/// `C_GlobalModifiers`), per-world settings, scratch containers. Do NOT
+/// use as a back door for "things that should be on the manager"; if the
+/// data is graphics-device-level state, it belongs on the manager.
+///
+/// Singleton entities are normal ECS entities and participate in
+/// archetype iteration. A `forEachComponent<T>` that matches `T` will see
+/// the singleton row.
+template <typename Component> EntityId singletonEntity() {
+    return getEntityManager().template getOrCreateSingleton<Component>();
+}
+
+template <typename Component> EntityId singletonEntityOrNull() {
+    return getEntityManager().getSingletonByComponentIdOrNull(
+        getEntityManager().template getComponentType<Component>()
+    );
+}
+
+template <typename Component> Component &singleton() {
+    return getComponent<Component>(singletonEntity<Component>());
+}
+
+template <typename Component> Component *singletonOrNull() {
+    EntityId entity = singletonEntityOrNull<Component>();
+    if (entity == kNullEntity) {
+        return nullptr;
+    }
+    auto opt = getComponentOptional<Component>(entity);
+    return opt.has_value() ? *opt : nullptr;
 }
 
 } // namespace IREntity

--- a/engine/entity/src/entity_manager.cpp
+++ b/engine/entity/src/entity_manager.cpp
@@ -253,6 +253,36 @@ void EntityManager::destroyAllEntities() {
             destroyEntity(entity);
         }
     }
+
+    m_singletonEntityByComponent.clear();
+}
+
+EntityId EntityManager::getOrCreateSingletonByComponentId(ComponentId componentType) {
+    IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
+    auto it = m_singletonEntityByComponent.find(componentType);
+    if (it != m_singletonEntityByComponent.end() && entityExists(it->second)) {
+        return it->second;
+    }
+    if (it != m_singletonEntityByComponent.end()) {
+        m_singletonEntityByComponent.erase(it);
+    }
+    EntityId entity = createEntity();
+    addComponentDynamic(entity, componentType);
+    m_singletonEntityByComponent[componentType] = entity;
+    return entity;
+}
+
+EntityId EntityManager::getSingletonByComponentIdOrNull(ComponentId componentType) {
+    IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
+    auto it = m_singletonEntityByComponent.find(componentType);
+    if (it == m_singletonEntityByComponent.end()) {
+        return kNullEntity;
+    }
+    if (!entityExists(it->second)) {
+        m_singletonEntityByComponent.erase(it);
+        return kNullEntity;
+    }
+    return it->second;
 }
 
 EntityRecord &EntityManager::getRecord(EntityId entity) {

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -60,12 +60,12 @@ inline void push(
     IREntity::EntityId source,
     std::int32_t ticksRemaining = -1
 ) {
-    if (field == IRComponents::kInvalidFieldId) return;
+    if (field == IRComponents::kInvalidFieldId)
+        return;
     auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
-    if (!c) return;
-    c->modifiers_.push_back(IRComponents::Modifier{
-        field, kind, param, source, ticksRemaining
-    });
+    if (!c)
+        return;
+    c->modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, ticksRemaining});
 }
 
 inline void pushGlobal(
@@ -75,14 +75,16 @@ inline void pushGlobal(
     IREntity::EntityId source,
     std::int32_t ticksRemaining = -1
 ) {
-    if (field == IRComponents::kInvalidFieldId) return;
+    if (field == IRComponents::kInvalidFieldId)
+        return;
     auto entity = detail::globalsEntityId();
-    if (entity == IREntity::kNullEntity) return;
-    auto *c = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
-    if (!c) return;
-    c->modifiers_.push_back(IRComponents::Modifier{
-        field, kind, param, source, ticksRemaining
-    });
+    if (entity == IREntity::kNullEntity)
+        return;
+    auto *c =
+        IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
+    if (!c)
+        return;
+    c->modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, ticksRemaining});
 }
 
 // `ticksRemaining` is honored by `LAMBDA_MODIFIER_DECAY`, registered alongside
@@ -97,12 +99,15 @@ inline void pushLambda(
     IREntity::EntityId source,
     std::int32_t ticksRemaining = -1
 ) {
-    if (field == IRComponents::kInvalidFieldId) return;
-    auto *c = IREntity::getComponentOptional<IRComponents::C_LambdaModifiers>(target).value_or(nullptr);
-    if (!c) return;
-    c->modifiers_.push_back(IRComponents::LambdaModifier{
-        field, std::move(fn), source, ticksRemaining
-    });
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    auto *c =
+        IREntity::getComponentOptional<IRComponents::C_LambdaModifiers>(target).value_or(nullptr);
+    if (!c)
+        return;
+    c->modifiers_.push_back(
+        IRComponents::LambdaModifier{field, std::move(fn), source, ticksRemaining}
+    );
 }
 
 // Sweep both per-entity and global modifier vectors, removing any whose
@@ -125,9 +130,9 @@ inline void removeBySource(IREntity::EntityId source) {
         );
     };
 
-    IREntity::forEachComponent<IRComponents::C_Modifiers>(
-        [&](IRComponents::C_Modifiers &c) { stripVec(c.modifiers_); }
-    );
+    IREntity::forEachComponent<IRComponents::C_Modifiers>([&](IRComponents::C_Modifiers &c) {
+        stripVec(c.modifiers_);
+    });
     IREntity::forEachComponent<IRComponents::C_GlobalModifiers>(
         [&](IRComponents::C_GlobalModifiers &c) { stripVec(c.modifiers_); }
     );
@@ -141,19 +146,19 @@ inline void removeBySource(IREntity::EntityId source) {
 // without touching C_ResolvedFields. The resolver pipeline and
 // applyToField share `composeForField`, so the two read paths give
 // the same answer for the same input.
-inline float applyToField(
-    IREntity::EntityId target,
-    IRComponents::FieldBindingId field,
-    float baseValue
-) {
+inline float
+applyToField(IREntity::EntityId target, IRComponents::FieldBindingId field, float baseValue) {
     auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
     const auto &entityMods = c ? c->modifiers_ : detail::emptyModifiers();
 
     const std::vector<IRComponents::Modifier> *globalsPtr = nullptr;
     auto entity = detail::globalsEntityId();
     if (entity != IREntity::kNullEntity) {
-        auto *g = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
-        if (g) globalsPtr = &g->modifiers_;
+        auto *g = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(
+            nullptr
+        );
+        if (g)
+            globalsPtr = &g->modifiers_;
     }
     const auto &globals = globalsPtr ? *globalsPtr : detail::emptyModifiers();
 
@@ -180,24 +185,26 @@ struct ResolverPipelineSystems {
 
 inline ResolverPipelineSystems registerResolverPipeline() {
     static bool registered = false;
-    IR_ASSERT(!registered, "registerResolverPipeline called more than once — duplicate decay/resolve systems would double-apply per tick");
+    IR_ASSERT(
+        !registered,
+        "registerResolverPipeline called more than once — duplicate decay/resolve systems would "
+        "double-apply per tick"
+    );
     registered = true;
-    auto &globalsEntity = detail::globalsEntityId();
-    if (globalsEntity == IREntity::kNullEntity) {
-        globalsEntity = IREntity::createEntity(
-            IRComponents::C_GlobalModifiers{}
-        );
-        IREntity::setName(globalsEntity, "modifierGlobals");
-    }
+    // Name the singleton globals entity so tooling that scans named
+    // entities (and `globalsEntity()` below) can find it by lookup
+    // rather than by re-resolving the singleton.
+    auto globalsEntity = IREntity::singletonEntity<IRComponents::C_GlobalModifiers>();
+    IREntity::setName(globalsEntity, "modifierGlobals");
     // Auto-sweep source-attributed modifiers when their source entity is
     // destroyed. Without this, a target outliving its source keeps the
     // dead source's modifiers applied indefinitely; recycled EntityIds
     // would then inherit them on a future allocation. Linear sweep is
     // acceptable for v1 — see CLAUDE.md "Open follow-ups" for the
     // reverse-index option if churn becomes a profile hotspot.
-    (void)IREntity::getEntityManager().registerPreDestroyHook(
-        [](IREntity::EntityId destroyed) { removeBySource(destroyed); }
-    );
+    (void)IREntity::getEntityManager().registerPreDestroyHook([](IREntity::EntityId destroyed) {
+        removeBySource(destroyed);
+    });
     return ResolverPipelineSystems{
         IRSystem::createSystem<IRSystem::MODIFIER_DECAY>(),
         IRSystem::createSystem<IRSystem::GLOBAL_MODIFIER_DECAY>(),

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
@@ -36,9 +36,15 @@ inline const std::vector<IRComponents::Modifier> *&currentGlobalModifiersPtr() {
     return p;
 }
 
-inline IREntity::EntityId &globalsEntityId() {
-    static IREntity::EntityId id = IREntity::kNullEntity;
-    return id;
+// No-create accessor for the singleton globals entity. Returns
+// `kNullEntity` if `registerResolverPipeline` has not yet wired up
+// the singleton, so `beginTick` below can no-op cleanly when the
+// modifier framework is registered later in init order than this
+// system's first tick. Use `IREntity::singletonEntity<C_GlobalModifiers>`
+// directly when you intend to lazy-create.
+inline IREntity::EntityId globalsEntityId() {
+    using IRComponents::C_GlobalModifiers;
+    return IREntity::singletonEntityOrNull<C_GlobalModifiers>();
 }
 
 } // namespace IRPrefab::Modifier::detail
@@ -50,32 +56,32 @@ template <> struct System<MODIFIER_RESOLVE_GLOBAL> {
         return createSystem<
             IRComponents::C_Modifiers,
             IRComponents::C_ResolvedFields,
-            Exclude<IRComponents::C_NoGlobalModifiers>
-        >(
+            Exclude<IRComponents::C_NoGlobalModifiers>>(
             "ModifierResolveGlobal",
-            [](IRComponents::C_Modifiers &m,
-               IRComponents::C_ResolvedFields &resolved) {
-                const auto *globalsPtr =
-                    IRPrefab::Modifier::detail::currentGlobalModifiersPtr();
-                const auto &globals = globalsPtr ? *globalsPtr
-                                                 : IRPrefab::Modifier::detail::emptyModifiers();
+            [](IRComponents::C_Modifiers &m, IRComponents::C_ResolvedFields &resolved) {
+                const auto *globalsPtr = IRPrefab::Modifier::detail::currentGlobalModifiersPtr();
+                const auto &globals =
+                    globalsPtr ? *globalsPtr : IRPrefab::Modifier::detail::emptyModifiers();
                 for (auto &rf : resolved.fields_) {
                     rf.value_ = IRPrefab::Modifier::detail::composeForField(
-                        rf.value_, rf.field_, globals, m.modifiers_
+                        rf.value_,
+                        rf.field_,
+                        globals,
+                        m.modifiers_
                     );
                 }
             },
             // beginTick: cache the singleton's modifier vector pointer.
             []() {
                 using IRComponents::C_GlobalModifiers;
-                auto &cachedPtr =
-                    IRPrefab::Modifier::detail::currentGlobalModifiersPtr();
+                auto &cachedPtr = IRPrefab::Modifier::detail::currentGlobalModifiersPtr();
                 auto entity = IRPrefab::Modifier::detail::globalsEntityId();
                 if (entity == IREntity::kNullEntity) {
                     cachedPtr = nullptr;
                     return;
                 }
-                auto *gm = IREntity::getComponentOptional<C_GlobalModifiers>(entity).value_or(nullptr);
+                auto *gm =
+                    IREntity::getComponentOptional<C_GlobalModifiers>(entity).value_or(nullptr);
                 cachedPtr = gm ? &gm->modifiers_ : nullptr;
             }
         );

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -131,6 +131,11 @@ local entity = IREntity.create_some_entity()
 IREntity.addLuaComponent(entity, C_Hp, { current = 50 })  -- optional overrides
 local hp = IREntity.getLuaComponent(entity, C_Hp)         -- table snapshot
 IREntity.removeLuaComponent(entity, C_Hp)
+
+-- Singleton-component access (one entity per component type, lazily
+-- created and cached by ComponentId; see engine/entity/CLAUDE.md):
+local rules = IREntity.singleton(C_Hp)                    -- LuaEntity
+IREntity.setLuaField(rules, C_Hp, C_Hp.fields.current.index, 100)
 ```
 
 - **Type inference:** integer literal → `int32`; float literal → `float`;

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -473,6 +473,20 @@ void LuaScript::bindLuaDrivenEcs() {
         return IREntity::getEntityManager().hasComponent(entity.entity, componentId);
     };
 
+    // ECS singleton-component lookup. One entity per component type,
+    // lazily created on first call and cached by `ComponentId`. Returns
+    // a `LuaEntity` so callers can chain into the standard
+    // `getLuaComponent` / `setLuaField` accessors. Works for both
+    // codegen'd-as-C++ components and runtime-registered Lua-defined
+    // components — both paths share the same `ComponentId` space and the
+    // same singleton cache on `EntityManager`.
+    m_lua["IREntity"]["singleton"] = [](sol::table componentDef) -> IRScript::LuaEntity {
+        const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
+        return IRScript::LuaEntity{
+            IREntity::getEntityManager().getOrCreateSingletonByComponentId(componentId)
+        };
+    };
+
     m_lua["IREntity"]["getLuaField"] =
         [this](IRScript::LuaEntity entity, sol::table componentDef, int fieldIndex) -> sol::object {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");

--- a/test/ecs/entity_manager_test.cpp
+++ b/test/ecs/entity_manager_test.cpp
@@ -21,11 +21,9 @@ static_assert(
 );
 
 namespace {
-struct TestMarker {
-};
+struct TestMarker {};
 
-struct TestRemovable {
-};
+struct TestRemovable {};
 
 struct TestPayload {
     int value_ = 0;
@@ -128,16 +126,13 @@ TEST_F(IREntityTest, PreDestroyHookFiresWithEntityIdBeforeDestruction) {
     IREntity::EntityId entity = IREntity::createEntity(TestMarker{});
     IREntity::EntityId observed = IREntity::kNullEntity;
     bool componentVisibleInHook = false;
-    auto id = m_entity_manager.registerPreDestroyHook(
-        [&, entity](IREntity::EntityId destroyed) {
-            observed = destroyed;
-            // The entity must still be queryable at hook time — that's
-            // the whole point of "pre-destroy", as opposed to post-.
-            componentVisibleInHook =
-                IREntity::getComponentOptional<TestMarker>(destroyed).has_value();
-            EXPECT_EQ(destroyed, entity);
-        }
-    );
+    auto id = m_entity_manager.registerPreDestroyHook([&, entity](IREntity::EntityId destroyed) {
+        observed = destroyed;
+        // The entity must still be queryable at hook time — that's
+        // the whole point of "pre-destroy", as opposed to post-.
+        componentVisibleInHook = IREntity::getComponentOptional<TestMarker>(destroyed).has_value();
+        EXPECT_EQ(destroyed, entity);
+    });
     EXPECT_NE(id, IREntity::kInvalidPreDestroyHookId);
 
     m_entity_manager.destroyEntity(entity);
@@ -148,15 +143,9 @@ TEST_F(IREntityTest, PreDestroyHookFiresWithEntityIdBeforeDestruction) {
 
 TEST_F(IREntityTest, PreDestroyHooksFireInRegistrationOrder) {
     std::vector<int> order;
-    m_entity_manager.registerPreDestroyHook(
-        [&](IREntity::EntityId) { order.push_back(1); }
-    );
-    m_entity_manager.registerPreDestroyHook(
-        [&](IREntity::EntityId) { order.push_back(2); }
-    );
-    m_entity_manager.registerPreDestroyHook(
-        [&](IREntity::EntityId) { order.push_back(3); }
-    );
+    m_entity_manager.registerPreDestroyHook([&](IREntity::EntityId) { order.push_back(1); });
+    m_entity_manager.registerPreDestroyHook([&](IREntity::EntityId) { order.push_back(2); });
+    m_entity_manager.registerPreDestroyHook([&](IREntity::EntityId) { order.push_back(3); });
 
     auto entity = IREntity::createEntity(TestMarker{});
     m_entity_manager.destroyEntity(entity);
@@ -169,9 +158,7 @@ TEST_F(IREntityTest, PreDestroyHooksFireInRegistrationOrder) {
 
 TEST_F(IREntityTest, UnregisterPreDestroyHookStopsFiring) {
     int fireCount = 0;
-    auto id = m_entity_manager.registerPreDestroyHook(
-        [&](IREntity::EntityId) { ++fireCount; }
-    );
+    auto id = m_entity_manager.registerPreDestroyHook([&](IREntity::EntityId) { ++fireCount; });
 
     auto entityA = IREntity::createEntity(TestMarker{});
     m_entity_manager.destroyEntity(entityA);
@@ -182,6 +169,55 @@ TEST_F(IREntityTest, UnregisterPreDestroyHookStopsFiring) {
     auto entityB = IREntity::createEntity(TestMarker{});
     m_entity_manager.destroyEntity(entityB);
     EXPECT_EQ(fireCount, 1);
+}
+
+// Singleton-component API (T-162): one entity per component type, lazily
+// created on first access, cached by ComponentId in EntityManager.
+struct TestSingleton {
+    int counter_ = 0;
+};
+
+TEST_F(IREntityTest, SingletonReturnsSameReferenceAcrossCalls) {
+    auto &a = IREntity::singleton<TestSingleton>();
+    auto &b = IREntity::singleton<TestSingleton>();
+    EXPECT_EQ(&a, &b);
+}
+
+TEST_F(IREntityTest, SingletonEntityIsCachedById) {
+    auto entityA = IREntity::singletonEntity<TestSingleton>();
+    auto entityB = IREntity::singletonEntity<TestSingleton>();
+    EXPECT_NE(entityA, IREntity::kNullEntity);
+    EXPECT_EQ(entityA, entityB);
+}
+
+TEST_F(IREntityTest, SingletonMutationPersistsAcrossCalls) {
+    IREntity::singleton<TestSingleton>().counter_ = 42;
+    EXPECT_EQ(IREntity::singleton<TestSingleton>().counter_, 42);
+    IREntity::singleton<TestSingleton>().counter_++;
+    EXPECT_EQ(IREntity::singleton<TestSingleton>().counter_, 43);
+}
+
+TEST_F(IREntityTest, SingletonOrNullReturnsNullBeforeFirstCreate) {
+    EXPECT_EQ(IREntity::singletonOrNull<TestSingleton>(), nullptr);
+    EXPECT_EQ(IREntity::singletonEntityOrNull<TestSingleton>(), IREntity::kNullEntity);
+}
+
+TEST_F(IREntityTest, SingletonOrNullReturnsValidAfterCreate) {
+    IREntity::singleton<TestSingleton>().counter_ = 7;
+    auto *ptr = IREntity::singletonOrNull<TestSingleton>();
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->counter_, 7);
+}
+
+TEST_F(IREntityTest, SingletonLazyRecreateAfterExternalDestroy) {
+    auto firstEntity = IREntity::singletonEntity<TestSingleton>();
+    IREntity::singleton<TestSingleton>().counter_ = 99;
+    m_entity_manager.destroyEntity(firstEntity);
+
+    // Next access lazy-recreates with a default-constructed component.
+    auto secondEntity = IREntity::singletonEntity<TestSingleton>();
+    EXPECT_NE(secondEntity, firstEntity);
+    EXPECT_EQ(IREntity::singleton<TestSingleton>().counter_, 0);
 }
 
 // setComponent must construct the new archetype slot directly from the

--- a/test/script/lua_component_register_test.cpp
+++ b/test/script/lua_component_register_test.cpp
@@ -461,4 +461,49 @@ TEST_F(LuaComponentTest, IndexStyleOutOfRangeRaisesLuaError) {
     EXPECT_NE(std::string(setErr.what()).find("999"), std::string::npos);
 }
 
+// ---- Singleton (T-162) -----------------------------------------------------
+
+// `LuaEntity` is opaque to Lua under `bindLuaDrivenEcs()` alone (no
+// usertype registration). The behavior we care about is "subsequent
+// calls land on the same entity", which is observable via field-state
+// persistence: write through the first handle, read through a second,
+// and a properly cached singleton returns the written value.
+TEST_F(LuaComponentTest, SingletonCachesAcrossCalls) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "local C = IRComponent.register('GameRules', { score = 0, level = 1 })\n"
+        "local a = IREntity.singleton(C)\n"
+        "IREntity.setLuaField(a, C, C.fields.score.index, 42)\n"
+        "IREntity.setLuaField(a, C, C.fields.level.index, 7)\n"
+        // Re-fetch the singleton; mutations must persist on a second call.
+        "local b = IREntity.singleton(C)\n"
+        "return IREntity.getLuaField(b, C, C.fields.score.index), "
+        "       IREntity.getLuaField(b, C, C.fields.level.index)"
+    );
+    ASSERT_TRUE(result.valid());
+    auto [score, level] = result.get<std::tuple<lua_Integer, lua_Integer>>();
+    EXPECT_EQ(score, 42);
+    EXPECT_EQ(level, 7);
+}
+
+TEST_F(LuaComponentTest, SingletonInteropsWithCppApi) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script(
+                       "C_Counter = IRComponent.register('Counter', { value = 0 })\n"
+                       "IREntity.setLuaField(IREntity.singleton(C_Counter), C_Counter, "
+                       "                     C_Counter.fields.value.index, 17)"
+    )
+                    .valid());
+
+    // C++ side reaches the same singleton via the typeName lookup.
+    const IREntity::ComponentId cid = m_entity_manager.getComponentTypeByName("Counter");
+    ASSERT_NE(cid, IREntity::kNullComponent);
+    const IREntity::EntityId cppEntity = m_entity_manager.getOrCreateSingletonByComponentId(cid);
+    auto [data, row] = m_entity_manager.getComponentDataAndRow(cppEntity, cid);
+    ASSERT_NE(data, nullptr);
+    auto *typed = static_cast<IRScript::IComponentDataLuaTyped *>(data);
+    sol::object value = typed->readFieldAt(row, 0, lua);
+    EXPECT_EQ(value.as<lua_Integer>(), 17);
+}
+
 } // namespace

--- a/test/script/modifier_lua_test.cpp
+++ b/test/script/modifier_lua_test.cpp
@@ -7,8 +7,8 @@
 
 namespace {
 
-using IRComponents::C_Modifiers;
 using IRComponents::C_LambdaModifiers;
+using IRComponents::C_Modifiers;
 using IRComponents::FieldBindingId;
 using IRComponents::TransformKind;
 using IREntity::EntityId;
@@ -34,18 +34,30 @@ class ModifierLuaTest : public testing::Test {
 
 TEST_F(ModifierLuaTest, EnumValuesMatchCpp) {
     auto &lua = m_lua.lua();
-    EXPECT_EQ(lua.script("return ir.modifier.ADD").get<int>(),
-              static_cast<int>(TransformKind::ADD));
-    EXPECT_EQ(lua.script("return ir.modifier.MULTIPLY").get<int>(),
-              static_cast<int>(TransformKind::MULTIPLY));
-    EXPECT_EQ(lua.script("return ir.modifier.SET").get<int>(),
-              static_cast<int>(TransformKind::SET));
-    EXPECT_EQ(lua.script("return ir.modifier.CLAMP_MIN").get<int>(),
-              static_cast<int>(TransformKind::CLAMP_MIN));
-    EXPECT_EQ(lua.script("return ir.modifier.CLAMP_MAX").get<int>(),
-              static_cast<int>(TransformKind::CLAMP_MAX));
-    EXPECT_EQ(lua.script("return ir.modifier.OVERRIDE").get<int>(),
-              static_cast<int>(TransformKind::OVERRIDE));
+    EXPECT_EQ(
+        lua.script("return ir.modifier.ADD").get<int>(),
+        static_cast<int>(TransformKind::ADD)
+    );
+    EXPECT_EQ(
+        lua.script("return ir.modifier.MULTIPLY").get<int>(),
+        static_cast<int>(TransformKind::MULTIPLY)
+    );
+    EXPECT_EQ(
+        lua.script("return ir.modifier.SET").get<int>(),
+        static_cast<int>(TransformKind::SET)
+    );
+    EXPECT_EQ(
+        lua.script("return ir.modifier.CLAMP_MIN").get<int>(),
+        static_cast<int>(TransformKind::CLAMP_MIN)
+    );
+    EXPECT_EQ(
+        lua.script("return ir.modifier.CLAMP_MAX").get<int>(),
+        static_cast<int>(TransformKind::CLAMP_MAX)
+    );
+    EXPECT_EQ(
+        lua.script("return ir.modifier.OVERRIDE").get<int>(),
+        static_cast<int>(TransformKind::OVERRIDE)
+    );
 }
 
 // ---- registerField ----------------------------------------------------------
@@ -71,7 +83,7 @@ class ModifierLuaApplyTest : public ModifierLuaTest {
         m_field_id = IRPrefab::Modifier::registerField("lua.apply.test");
         m_entity = IREntity::createEntity(C_Modifiers{});
         m_lua.lua()["testEntity"] = static_cast<lua_Integer>(m_entity);
-        m_lua.lua()["testField"]  = static_cast<lua_Integer>(m_field_id);
+        m_lua.lua()["testField"] = static_cast<lua_Integer>(m_field_id);
     }
 
     FieldBindingId m_field_id = 0;
@@ -168,8 +180,8 @@ TEST_F(ModifierLuaApplyTest, ApplyToFieldReturnedFromLua) {
             source = testEntity,
         })
     )");
-    float result = lua.script("return ir.modifier.applyToField(testEntity, testField, 3.0)")
-                       .get<float>();
+    float result =
+        lua.script("return ir.modifier.applyToField(testEntity, testField, 3.0)").get<float>();
     EXPECT_FLOAT_EQ(result, 10.0f);
 }
 
@@ -221,20 +233,16 @@ TEST_F(ModifierLuaApplyTest, PushLambdaApplied) {
 
 // ---- pushGlobal -------------------------------------------------------------
 
-// Fixture: sets up a standalone globals entity and wires it into the detail
-// singleton directly, avoiding registerResolverPipeline() which also creates
-// systems and requires SystemManager.
+// Fixture: lazy-creates the globals entity via the singleton API,
+// avoiding registerResolverPipeline() which also creates systems and
+// requires SystemManager. The EntityManager fixture goes out of scope
+// at end-of-test, taking the singleton cache with it.
 class ModifierLuaGlobalTest : public ModifierLuaTest {
   protected:
     ModifierLuaGlobalTest() {
         m_field_id = IRPrefab::Modifier::registerField("lua.global.smoke");
-        m_globals_entity = IREntity::createEntity(IRComponents::C_GlobalModifiers{});
-        IRPrefab::Modifier::detail::globalsEntityId() = m_globals_entity;
+        m_globals_entity = IREntity::singletonEntity<IRComponents::C_GlobalModifiers>();
         m_lua.lua()["testField"] = static_cast<lua_Integer>(m_field_id);
-    }
-
-    ~ModifierLuaGlobalTest() {
-        IRPrefab::Modifier::detail::globalsEntityId() = IREntity::kNullEntity;
     }
 
     IRComponents::FieldBindingId m_field_id = 0;


### PR DESCRIPTION
## Summary

Generalize the modifier framework's hand-rolled lazy-init singleton pattern (`detail::globalsEntityId()` in `engine/prefabs/irreden/common/modifier.hpp`) into a public `IREntity::singleton<T>()` API and retrofit `C_GlobalModifiers` to validate the design.

Work in progress.

Closes #646