### PR TITLE
build: scope clang-format to changed files via new format-changed target

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -472,14 +472,18 @@ After applying fixes, run the formatter and rebuild (code diffs
 only; doc-only diffs can skip the build):
 
 ```bash
-fleet-build --target format
+fleet-build --target format-changed
 fleet-build --target <touched-target>
 ```
 
-If `format` rewrote anything, those changes are part of the polish —
-keep them. If the build broke, **revert your simplify changes** (or
-fix the break before continuing) — never push a simplify pass that
-broke the build.
+`format-changed` scopes clang-format to files changed on the
+current branch (committed vs upstream + working tree). The bare
+`format` target is whole-tree and will pull every drift in the
+repo into your PR — use it only on intentional cleanup PRs, never
+mid-iteration. If `format-changed` rewrote anything, those changes
+are part of the polish — keep them. If the build broke, **revert
+your simplify changes** (or fix the break before continuing) —
+never push a simplify pass that broke the build.
 
 ### 11. Report
 

--- a/cmake/ir_quality_tools.cmake
+++ b/cmake/ir_quality_tools.cmake
@@ -101,6 +101,20 @@ function(irreden_add_quality_targets)
             COMMENT "Checking source formatting with clang-format"
             VERBATIM
         )
+
+        # Diff-scoped formatter: only rewrites files changed on the
+        # current branch (committed vs upstream + working tree).
+        # Safe to invoke mid-iteration; the bare `format` target is
+        # whole-tree and should only run on intentional cleanup PRs.
+        add_custom_target(format-changed
+            COMMAND ${CMAKE_COMMAND}
+                -DCLANG_FORMAT_BIN="${IRREDEN_CLANG_FORMAT_BIN}"
+                -DQUALITY_FILE_LIST="${irreden_quality_file_list}"
+                -DPROJECT_ROOT="${PROJECT_SOURCE_DIR}"
+                -P "${PROJECT_SOURCE_DIR}/cmake/run_clang_format_changed.cmake"
+            COMMENT "Formatting branch-changed source files with clang-format"
+            VERBATIM
+        )
     else()
         message(STATUS "clang-format not found; format targets will print install guidance.")
         add_custom_target(format
@@ -111,6 +125,13 @@ function(irreden_add_quality_targets)
         )
 
         add_custom_target(format-check
+            COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --red
+                "clang-format not found. Install LLVM/clang tools and ensure clang-format is on PATH."
+            COMMAND ${CMAKE_COMMAND} -E false
+            VERBATIM
+        )
+
+        add_custom_target(format-changed
             COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --red
                 "clang-format not found. Install LLVM/clang tools and ensure clang-format is on PATH."
             COMMAND ${CMAKE_COMMAND} -E false

--- a/cmake/run_clang_format_changed.cmake
+++ b/cmake/run_clang_format_changed.cmake
@@ -1,0 +1,123 @@
+if(NOT DEFINED CLANG_FORMAT_BIN OR CLANG_FORMAT_BIN STREQUAL "")
+    message(FATAL_ERROR "CLANG_FORMAT_BIN is required.")
+endif()
+string(REPLACE "\"" "" CLANG_FORMAT_BIN "${CLANG_FORMAT_BIN}")
+
+if(NOT DEFINED QUALITY_FILE_LIST OR QUALITY_FILE_LIST STREQUAL "")
+    message(FATAL_ERROR "QUALITY_FILE_LIST is required.")
+endif()
+string(REPLACE "\"" "" QUALITY_FILE_LIST "${QUALITY_FILE_LIST}")
+
+if(NOT DEFINED PROJECT_ROOT OR PROJECT_ROOT STREQUAL "")
+    message(FATAL_ERROR "PROJECT_ROOT is required.")
+endif()
+string(REPLACE "\"" "" PROJECT_ROOT "${PROJECT_ROOT}")
+
+include("${QUALITY_FILE_LIST}")
+if(NOT DEFINED QUALITY_FILES OR QUALITY_FILES STREQUAL "")
+    message(FATAL_ERROR "QUALITY_FILES is empty. No files to process.")
+endif()
+
+# Build the set of files changed on the current branch — committed
+# vs the upstream tracking branch (typically origin/master) plus
+# anything dirty in the working tree. Matches the worker's intuition:
+# "format the files my PR touches", not the engine-wide reformat
+# that the bare `format` target produces.
+
+# Pick a useful base for the committed-diff range:
+#   - upstream tracking branch if one is set (the common case for an
+#     agent-owned worktree branched off origin/master);
+#   - fall back to origin/master.
+execute_process(
+    COMMAND git -C "${PROJECT_ROOT}" rev-parse --abbrev-ref "@{upstream}"
+    OUTPUT_VARIABLE _upstream
+    RESULT_VARIABLE _upstream_rc
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(_upstream_rc EQUAL 0 AND NOT _upstream STREQUAL "")
+    set(_diff_base "${_upstream}")
+else()
+    set(_diff_base "origin/master")
+endif()
+
+function(_collect_git_diff range out_var)
+    # `range` is a CMake list (semicolon-separated tokens) passed
+    # whole into the git command line.
+    execute_process(
+        COMMAND git -C "${PROJECT_ROOT}" diff --name-only ${range}
+        OUTPUT_VARIABLE _out
+        RESULT_VARIABLE _rc
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT _rc EQUAL 0 OR _out STREQUAL "")
+        set(${out_var} "" PARENT_SCOPE)
+        return()
+    endif()
+    string(REPLACE "\n" ";" _list "${_out}")
+    set(${out_var} "${_list}" PARENT_SCOPE)
+endfunction()
+
+set(_changed_files "")
+_collect_git_diff("${_diff_base}...HEAD" _committed)
+list(APPEND _changed_files ${_committed})
+# `git diff --name-only HEAD` covers both staged and unstaged
+# working-tree edits in a single call.
+_collect_git_diff("HEAD" _working)
+list(APPEND _changed_files ${_working})
+
+if(NOT _changed_files)
+    message(STATUS "clang-format (changed): no diff vs ${_diff_base}; nothing to format.")
+    return()
+endif()
+
+list(REMOVE_DUPLICATES _changed_files)
+
+# Intersect against the project's quality file list so generated,
+# vendored, and out-of-tree files stay excluded — same filter the
+# bare `format` target applies via irreden_collect_quality_files.
+set(_targets "")
+foreach(_rel IN LISTS _changed_files)
+    if(NOT _rel STREQUAL "")
+        set(_abs "${PROJECT_ROOT}/${_rel}")
+        if(EXISTS "${_abs}")
+            list(FIND QUALITY_FILES "${_abs}" _idx)
+            if(NOT _idx EQUAL -1)
+                list(APPEND _targets "${_abs}")
+            endif()
+        endif()
+    endif()
+endforeach()
+
+if(NOT _targets)
+    message(STATUS "clang-format (changed): diff vs ${_diff_base} touches no formattable sources.")
+    return()
+endif()
+
+set(_failed "")
+set(_count 0)
+foreach(_file IN LISTS _targets)
+    math(EXPR _count "${_count} + 1")
+    execute_process(
+        COMMAND "${CLANG_FORMAT_BIN}" -i --style=file "${_file}"
+        RESULT_VARIABLE _rc
+        ERROR_VARIABLE _err
+    )
+    if(NOT _rc EQUAL 0)
+        list(APPEND _failed "${_file}")
+        if(NOT _err STREQUAL "")
+            message(STATUS "${_err}")
+        endif()
+    endif()
+endforeach()
+
+message(STATUS "clang-format (changed) formatted ${_count} file(s) vs ${_diff_base}.")
+
+if(_failed)
+    list(JOIN _failed "\n  - " _failed_joined)
+    message(FATAL_ERROR
+        "clang-format failed for file(s):\n"
+        "  - ${_failed_joined}"
+    )
+endif()

--- a/cmake/run_clang_format_changed.cmake
+++ b/cmake/run_clang_format_changed.cmake
@@ -42,8 +42,10 @@ else()
 endif()
 
 function(_collect_git_diff range out_var)
-    # `range` is a CMake list (semicolon-separated tokens) passed
-    # whole into the git command line.
+    # `range` is passed as a CMake unquoted variable below; any
+    # semicolons in it expand into separate git arguments. Current
+    # call sites pass a single-string git range ("base...HEAD" or
+    # "HEAD"), but multi-token ranges would also work.
     execute_process(
         COMMAND git -C "${PROJECT_ROOT}" diff --name-only ${range}
         OUTPUT_VARIABLE _out

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -90,10 +90,16 @@ issues and how to attack them are documented in
 Utility targets (Linux):
 
 ```bash
-cmake --build build --target format        # auto-format
-cmake --build build --target format-check  # check only
-cmake --build build --target lint          # clang-tidy
+cmake --build build --target format          # auto-format (whole tree)
+cmake --build build --target format-changed  # auto-format current-branch diff only
+cmake --build build --target format-check    # check only
+cmake --build build --target lint            # clang-tidy
 ```
+
+`format-changed` is what you want mid-iteration: it only touches files
+your branch has modified (committed vs `@{upstream}` plus working
+tree). The bare `format` target rewrites every formattable file in the
+repo and should only run on intentional cleanup PRs.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `format-changed`, a diff-scoped clang-format target alongside the existing whole-tree `format`.
- Switches the simplify skill to `format-changed` so worker iterations no longer pull engine-wide formatter drift into their PRs.
- Updates `docs/agents/BUILD.md` to document the two-target split.

## Why

Fleet feedback this week recorded two workers hitting the same trap:

- **opus-worker-1 (2026-05-12 03:11):** simplify's `fleet-build --target format` step rewrote 157 unrelated files on an 11-file T-162 iteration. Required a `git stash` / selective `git checkout stash@{0} --` dance to keep the PR scoped.
- **opus-worker-2 (2026-05-12 03:50):** same target rewrote 494 files on a 1-file PR #629 nit cleanup. Worked around by `git restore .`-ing the formatter sweeps after staging the one edited file.

A less-cautious agent would silently land the engine-wide reformat. The simplify skill explicitly says "If `format` rewrote anything, those changes are part of the polish — keep them" which silently assumes diff-scoping that doesn't exist.

## Approach

- New `cmake/run_clang_format_changed.cmake` collects `git diff --name-only @{upstream}...HEAD` (falling back to `origin/master` when no upstream is set) plus `git diff --name-only HEAD` (working tree edits), intersects with the existing quality file list (so generated / vendored stay excluded), and runs clang-format on that set.
- Empty diff is a silent no-op rather than an error — common case for the doc-only diffs that simplify also gets called on.
- The bare `format` target is unchanged and stays as the explicit whole-tree option for intentional cleanup PRs.

## Test plan

- [ ] `fleet-build --target format-changed` on a worktree with a small staged + unstaged change touches only the diff files; `git status` stays scoped.
- [ ] `fleet-build --target format-changed` on a clean tree exits 0 with the "no diff" message.
- [ ] `fleet-build --target format` still rewrites everything (no behavior change).
- [ ] End-to-end via simplify: make a tiny edit, run simplify, confirm the polish step doesn't pull in unrelated reformatting.

Smoke-tested locally with `cmake -P run_clang_format_changed.cmake` against a stubbed quality list — both the "1 file matches" and "0 files match" paths emit the expected status lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)