### PR TITLE
fleet: idempotent feedback-label clear via fleet-pr-clear-feedback-labels wrapper

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -357,7 +357,15 @@ Do the work, then exit cleanly:
 
       With checkout confirmed, **remove the feedback label** to
       prevent another agent from also picking it up:
-      `gh pr edit <N> --remove-label "human:needs-fix" --remove-label "human:blocker" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:human-deferred" --remove-label "fleet:design-unblocked"`
+      `fleet-pr-clear-feedback-labels <N>`
+
+      The wrapper is idempotent: it queries the live label set
+      first and only fires a `gh pr edit --remove-label` call per
+      label actually present. Plain `gh pr edit --remove-label X
+      --remove-label Y ...` is NOT atomic — it exits non-zero on
+      the first absent label, leaving every label removed BEFORE
+      the missing one already stripped. Observed on PR #637 on
+      2026-05-11 and 2026-05-12.
 
       For `human:needs-fix` / `human:blocker` specifically, also
       mark the PR as in-progress and clear the prior approval so

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -178,6 +178,10 @@ Parallel-agent fleet (tmux + Claude)
   witness [--once]               detect stale heartbeats (architects only)
   fleet-pr view|diff|comments <N> [--repo engine|game]
                                  read scout's per-PR cache + gh fallback
+  fleet-pr-clear-feedback-labels <N> [--repo …] [--labels …]
+                                 idempotently strip feedback labels from a PR
+                                 (skips absent labels; one --remove-label per
+                                 present label so partial failure can't strand)
   fleet-issue view <N> [--repo engine|game]
                                  read scout's per-issue cache + gh fallback
 

--- a/scripts/fleet/fleet-pr-clear-feedback-labels
+++ b/scripts/fleet/fleet-pr-clear-feedback-labels
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# fleet-pr-clear-feedback-labels — idempotently strip a known set of
+# feedback labels from a PR.
+#
+# Why this exists:
+#   `gh pr edit <N> --remove-label A --remove-label B ...` is NOT
+#   atomic. gh processes removals left-to-right and exits non-zero
+#   on the first absent label, leaving every label removed BEFORE
+#   the missing one already stripped. The role files combine the
+#   canonical AMEND-path label clear into one such call and have
+#   burned multiple worker iterations on PRs with a mixed-presence
+#   feedback label set (observed on PR #637 — opus-worker-2 at
+#   2026-05-11 20:05 and opus-worker-1 at 2026-05-12 03:11).
+#
+# This wrapper queries the live label set first and only fires a
+# remove-label call for labels actually present, one per call so a
+# single failure doesn't strand the others. The default label list
+# is the worker AMEND set; override with --labels for other callers.
+#
+# Usage:
+#   fleet-pr-clear-feedback-labels <N> [--repo <slug>] [--labels <csv>]
+#
+# Options:
+#   --repo <slug>     Target repo (e.g. jakildev/IrredenEngine). Default:
+#                     the current git remote.
+#   --labels <csv>    Comma-separated label set to clear. Default:
+#                     the worker AMEND set.
+#
+# Exit status:
+#   0  every label in --labels that was present has been removed
+#   1  one or more removals failed (PR labels may be partially cleared)
+#   2  usage error
+#
+# Source of truth: scripts/fleet/fleet-pr-clear-feedback-labels in the
+# engine repo. Installed to ~/bin/ by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+DEFAULT_LABELS="human:needs-fix,human:blocker,fleet:needs-fix,fleet:has-nits,fleet:human-deferred,fleet:design-unblocked"
+
+pr_number=""
+repo_slug=""
+labels_csv="$DEFAULT_LABELS"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            repo_slug="$2"
+            shift 2
+            ;;
+        --labels)
+            labels_csv="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,35p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "fleet-pr-clear-feedback-labels: unknown option '$1'" >&2
+            exit 2
+            ;;
+        *)
+            if [[ -z "$pr_number" ]]; then
+                pr_number="$1"
+            else
+                echo "fleet-pr-clear-feedback-labels: unexpected arg '$1'" >&2
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$pr_number" ]]; then
+    echo "fleet-pr-clear-feedback-labels: PR number required" >&2
+    echo "usage: fleet-pr-clear-feedback-labels <N> [--repo <slug>] [--labels <csv>]" >&2
+    exit 2
+fi
+
+repo_args=()
+if [[ -n "$repo_slug" ]]; then
+    repo_args=(--repo "$repo_slug")
+fi
+
+# Read live labels in one call so the set is consistent against the
+# moment we decide what to remove.
+if ! live_labels=$(gh pr view "$pr_number" "${repo_args[@]}" --json labels --jq '.labels[].name' 2>&1); then
+    echo "fleet-pr-clear-feedback-labels: gh pr view failed:" >&2
+    echo "$live_labels" >&2
+    exit 1
+fi
+
+# Convert the CSV target set into a newline-delimited list for grep.
+target_labels=$(echo "$labels_csv" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$')
+
+removed=()
+failed=()
+for label in $target_labels; do
+    if printf '%s\n' "$live_labels" | grep -Fxq -- "$label"; then
+        if gh pr edit "$pr_number" "${repo_args[@]}" --remove-label "$label" >/dev/null 2>&1; then
+            removed+=("$label")
+        else
+            failed+=("$label")
+        fi
+    fi
+done
+
+if [[ ${#removed[@]} -gt 0 ]]; then
+    echo "fleet-pr-clear-feedback-labels: removed ${#removed[@]} label(s) from PR #$pr_number: ${removed[*]}"
+fi
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "fleet-pr-clear-feedback-labels: failed to remove ${#failed[@]} label(s) from PR #$pr_number: ${failed[*]}" >&2
+    exit 1
+fi
+
+if [[ ${#removed[@]} -eq 0 ]]; then
+    echo "fleet-pr-clear-feedback-labels: no feedback labels present on PR #$pr_number; nothing to do."
+fi

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -126,6 +126,8 @@ FLEET_BUSY_SRC="$SCRIPT_DIR/fleet-worktree-busy-branches"
 FLEET_BUSY_DEST="$HOME/bin/fleet-worktree-busy-branches"
 FLEET_PR_SRC="$SCRIPT_DIR/fleet-pr"
 FLEET_PR_DEST="$HOME/bin/fleet-pr"
+FLEET_PR_CLEAR_SRC="$SCRIPT_DIR/fleet-pr-clear-feedback-labels"
+FLEET_PR_CLEAR_DEST="$HOME/bin/fleet-pr-clear-feedback-labels"
 FLEET_ISSUE_SRC="$SCRIPT_DIR/fleet-issue"
 FLEET_ISSUE_DEST="$HOME/bin/fleet-issue"
 FLEET_DISPATCHER_SRC="$SCRIPT_DIR/fleet-dispatcher"
@@ -151,7 +153,7 @@ fi
 # Ensure the sources are executable. Git normally preserves the +x bit,
 # but if someone unpacked a tarball or checked out with core.fileMode
 # off, fix it here.
-for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_COMMON_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_ISSUE_SRC" "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCH_WRAP_SRC" "$FLEET_GATE_STATUS_SRC" "$FLEET_TASKS_RENDER_SRC" "$FLEET_QUEUE_TICK_SRC" "$FLEET_QUEUE_INGEST_SRC" "$WITNESS_SRC"; do
+for src in "$FLEET_UP_SRC" "$FLEET_DOWN_SRC" "$FLEET_CLAIM_SRC" "$FLEET_COMMON_SRC" "$FLEET_BUILD_SRC" "$FLEET_DEBUG_SRC" "$FLEET_RUN_SRC" "$FLEET_RUN_TARGETS_SRC" "$FLEET_HELP_SRC" "$FLEET_BABYSIT_SRC" "$FLEET_LABELS_SRC" "$FLEET_HEARTBEAT_SRC" "$FLEET_STREAM_SRC" "$FLEET_SCOUT_SRC" "$FLEET_FEEDBACK_SRC" "$FLEET_BUSY_SRC" "$FLEET_PR_SRC" "$FLEET_PR_CLEAR_SRC" "$FLEET_ISSUE_SRC" "$FLEET_DISPATCHER_SRC" "$FLEET_DISPATCH_WRAP_SRC" "$FLEET_GATE_STATUS_SRC" "$FLEET_TASKS_RENDER_SRC" "$FLEET_QUEUE_TICK_SRC" "$FLEET_QUEUE_INGEST_SRC" "$WITNESS_SRC"; do
     if [[ -f "$src" && ! -x "$src" ]]; then
         chmod +x "$src"
     fi
@@ -243,6 +245,11 @@ fi
 if [[ -f "$FLEET_PR_SRC" ]]; then
     ln -sf "$FLEET_PR_SRC" "$FLEET_PR_DEST"
     echo "symlinked $FLEET_PR_DEST -> $FLEET_PR_SRC"
+fi
+
+if [[ -f "$FLEET_PR_CLEAR_SRC" ]]; then
+    ln -sf "$FLEET_PR_CLEAR_SRC" "$FLEET_PR_CLEAR_DEST"
+    echo "symlinked $FLEET_PR_CLEAR_DEST -> $FLEET_PR_CLEAR_SRC"
 fi
 
 if [[ -f "$FLEET_ISSUE_SRC" ]]; then


### PR DESCRIPTION
## Summary

- Adds `scripts/fleet/fleet-pr-clear-feedback-labels`, a small bash wrapper that idempotently strips a configurable set of feedback labels from a PR — querying live labels first, then firing one independent `gh pr edit --remove-label` per label actually present.
- Switches `role-opus-worker.md` step 1.b (the AMEND-path label clear) from a combined `gh pr edit --remove-label A --remove-label B ...` call to the wrapper.
- Registers the script in `scripts/fleet/install.sh` and the `fleet-help` index.

## Why

Fleet feedback recorded two workers hitting the same trap on PR #637 within seven hours:

- **opus-worker-2 (2026-05-11 20:05):** the combined remove-label call exited non-zero on `fleet:human-deferred` (absent), but `fleet:has-nits` had already been stripped before that point. Had to manually re-add it.
- **opus-worker-1 (2026-05-12 03:11):** same shape from the other side. Logged that gh processes `--remove-label` flags left-to-right and commits each removal as it goes, exiting partway when one isn't found — so a "failed" call still mutated state.

The combined call is the role doc's prescribed pattern precisely because the broad clear handles the mixed-presence cases it's designed for. The fragility of "remove every possibly-present label" is silent: a less-cautious agent wouldn't notice the half-applied state and would move on with the PR's labels permanently wrong.

## Approach

The wrapper reads the live label set in one `gh pr view --json labels` call so the decision is consistent against the moment we decide what to remove. Then for each label in `--labels` that's also on the PR, it fires `gh pr edit <N> --remove-label <L>` individually. A single failure logs to stderr and continues — partial apply now means partial success rather than a stranded mid-operation state.

Default `--labels` is the worker AMEND set; `--labels <csv>` lets the merger and reviewer roles reuse the same primitive when they need similar broad clears.

## Test plan

- [x] `fleet-pr-clear-feedback-labels --help` prints the usage block.
- [x] `fleet-pr-clear-feedback-labels 653` on a PR with no feedback labels exits 0 with the "nothing to do" message.
- [ ] On a PR with only `fleet:has-nits`, the wrapper removes that label, ignores the absent five, exits 0.
- [ ] On a real AMEND-path iteration (next worker pickup of a `fleet:has-nits` PR), the wrapper completes cleanly where the combined call would have errored.
- [ ] `bash scripts/fleet/install.sh` (re-run) symlinks the new script into `~/bin/`.

## Notes for reviewer

- The wrapper deliberately uses `printf '%s\n' ... | grep -Fxq` for the "is this label present" check rather than parameter expansion, so labels with special characters (currently none, but defensive) work.
- The `gh pr view ... --json labels` call is a single round-trip; per-label `gh pr edit --remove-label` calls are sequential. For the typical AMEND case (1 label present out of 6 possible), this is one read + one write — same cost as the broken combined call, just without the partial-apply blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)