### PR TITLE
fleet: don't count idle-pane reservations against dispatcher cap

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -608,17 +608,60 @@ usage_gate_open() {
 
 # Print the count of unique active worktrees for a role. "Active" =
 # (in-flight dispatch record for this role) ∪ (reservation whose task's
-# Model maps to this role). Dedup keys on worktree-basename, which is
-# shared between dispatch records (via the pane's pane_current_path) and
-# reservations (whose filename IS the worktree basename).
+# Model maps to this role AND whose matching pane is currently busy).
+# Dedup keys on worktree-basename, which is shared between dispatch
+# records (via the pane's pane_current_path) and reservations (whose
+# filename IS the worktree basename).
+#
+# A reservation on an idle pane is NOT counted. That case is the
+# resume-after-crash signal that role docs (see role-sonnet-author.md
+# step 0.5) consume on the next iteration — counting it would pin the
+# cap and prevent the resume from ever dispatching, which is the exact
+# stuck-fleet failure mode this guards against. The matching pane's
+# busy state is the disambiguator: a busy pane means an iteration is
+# live (the normal dispatch+reservation pairing); an idle pane means
+# the prior iteration crashed and the reservation is queued for the
+# next dispatch to consume.
 #
 # When tmux isn't running (shouldn't happen for a live dispatcher, but
 # the standalone --count-active CLI invokes this without a session),
 # dispatch records key on pane id instead — same dedup contract still
-# holds across two dispatch records for the same pane.
+# holds across two dispatch records for the same pane. Reservations in
+# that mode fall back to the legacy "always count" behavior since we
+# can't probe pane state; the tests that exercise --count-active
+# without tmux depend on this fallback.
 count_active_for_role() {
     local role="$1"
     declare -A seen=()
+
+    # Build worktree → busy map for panes tagged with this role. Used
+    # by the reservation pass below to skip idle-pane reservations.
+    declare -A worktree_busy=()
+    local have_tmux=0
+    if session_exists; then
+        have_tmux=1
+        local pane_id pane_role pane_cmd wt_path wt_name
+        while IFS=$'\t' read -r pane_id pane_role pane_cmd; do
+            [[ "$pane_role" == "$role" ]] || continue
+            wt_path=$(tmux display-message -t "$pane_id" -p '#{pane_current_path}' 2>/dev/null || true)
+            [[ -n "$wt_path" ]] || continue
+            wt_name=$(basename "$wt_path")
+            case "$pane_cmd" in
+                bash|zsh|sh|fish)
+                    # Shell allowlist matches find_idle_panes_for_role's
+                    # idle detection — but a fleet-dispatch-wrap child
+                    # still means the pane is mid-iteration even though
+                    # tmux reports the parent shell's name.
+                    if pane_has_running_wrapper "$pane_id"; then
+                        worktree_busy["$wt_name"]=1
+                    fi
+                    ;;
+                *)
+                    worktree_busy["$wt_name"]=1
+                    ;;
+            esac
+        done < <(list_pane_state)
+    fi
 
     if [[ -d "$DISPATCH_DIR" ]]; then
         local f r p wt_path wt_name
@@ -629,7 +672,7 @@ count_active_for_role() {
             p=$(sed -n 's/.*"pane":"\([^"]*\)".*/\1/p' "$f" | head -n 1)
             [[ -n "$p" ]] || continue
             wt_path=""
-            if session_exists; then
+            if (( have_tmux )); then
                 wt_path=$(tmux display-message -t "$p" -p '#{pane_current_path}' 2>/dev/null || true)
             fi
             if [[ -n "$wt_path" ]]; then
@@ -647,7 +690,19 @@ count_active_for_role() {
             [[ -e "$rfile" ]] || continue
             wt_name=$(basename "$rfile" .json)
             rrole=$(fleet-claim reservation-role "$wt_name" 2>/dev/null || true)
-            if [[ "$rrole" == "$role" ]]; then
+            [[ "$rrole" == "$role" ]] || continue
+            # With tmux available, only count the reservation when its
+            # worktree's pane is actually busy. An idle pane with a
+            # leftover reservation is the resume-after-crash case and
+            # must not pin the cap. Without tmux (CLI invocation
+            # outside a live fleet), fall back to the legacy "always
+            # count" behavior so test harnesses that don't stub tmux
+            # keep matching the documented contract.
+            if (( have_tmux )); then
+                if [[ -n "${worktree_busy[$wt_name]+x}" ]]; then
+                    seen["$wt_name"]=1
+                fi
+            else
                 seen["$wt_name"]=1
             fi
         done

--- a/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
+++ b/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
@@ -6,6 +6,8 @@
 #   - count with only in-flight (dispatch records)
 #   - count with only reserved (reservations whose task maps to role)
 #   - dedup when a worktree has both a dispatch record and a reservation
+#   - reservation on an idle pane does NOT count (resume-after-crash)
+#   - reservation on a busy pane DOES count (live iteration)
 #   - cap defaults (preserve current behavior at 2 for multi-pane roles)
 #   - env var override
 #   - conf file override
@@ -55,6 +57,11 @@ export FLEET_STATE_DIR="$TMPROOT/state"
 export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
 export FLEET_CLAIMS_DIR="$TMPROOT/claims"
 export FLEET_CONF="$TMPROOT/fleet-up.conf"
+# Point at a guaranteed non-existent tmux session so `session_exists`
+# returns false in tests that don't install a tmux stub — otherwise a
+# real fleet running on the dev machine would bleed pane state into
+# these tests and skew the busy-pane reservation count.
+export FLEET_SESSION="fleet-test-$$"
 
 mkdir -p "$FLEET_STATE_DIR/dispatch" "$FLEET_RESERVATIONS_DIR" "$FLEET_CLAIMS_DIR"
 
@@ -120,30 +127,44 @@ assert_eq "$n" "2" "opus-worker count is 2 (1 in-flight + 1 reserved on differen
 # --- Test 4: dedup when same worktree has both ------------------------------
 echo "T4: add second in-flight whose worktree matches the reservation"
 # pane-5's dispatch record — without tmux, fallback identity is pane-5
-# (cannot match the reservation key opus-worker-2). To exercise dedup,
-# stub tmux so display-message returns the worktree path.
+# (cannot match the reservation key opus-worker-2). To exercise dedup
+# AND the new busy-pane-counts-reservation semantics, stub tmux for
+# has-session, list-panes (so worktree-busy population works), and
+# display-message (so dispatch records resolve to worktree names).
 mkdir -p "$TMPROOT/bin-tmux"
 cat >"$TMPROOT/bin-tmux/tmux" <<'TMUXEOF'
 #!/usr/bin/env bash
-# Test stub: respond to `tmux has-session` (success) and
-# `tmux display-message -t <pane> -p <fmt>` (returns canned path per pane).
 sub="$1"; shift
 case "$sub" in
     has-session) exit 0 ;;
+    list-panes)
+        # Tab-separated: pane_id, fleet-role, pane_current_command.
+        # Both panes report `claude` (busy) so the reservation on
+        # opus-worker-2 is counted via the live-iteration path, then
+        # dedups with pane %5's dispatch record.
+        printf '%%3\topus-worker\tclaude\n%%5\topus-worker\tclaude\n'
+        exit 0
+        ;;
     display-message)
-        pane=""
+        pane=""; fmt=""
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 -t) pane="$2"; shift 2 ;;
-                -p) shift 2 ;;
+                -p) fmt="$2"; shift 2 ;;
                 *)  shift ;;
             esac
         done
-        case "$pane" in
-            "%3") echo "/fake/worktrees/opus-worker-1" ;;
-            "%5") echo "/fake/worktrees/opus-worker-2" ;;
-            *)    echo "/fake/worktrees/unknown" ;;
-        esac
+        if [[ "$fmt" == *pane_current_path* ]]; then
+            case "$pane" in
+                "%3") echo "/fake/worktrees/opus-worker-1" ;;
+                "%5") echo "/fake/worktrees/opus-worker-2" ;;
+                *)    echo "/fake/worktrees/unknown" ;;
+            esac
+        elif [[ "$fmt" == *pane_pid* ]]; then
+            # Irrelevant for the busy case (cmd!=shell short-circuits
+            # the wrapper-child probe), but emit something plausible.
+            echo "99000"
+        fi
         exit 0
         ;;
     *) exit 0 ;;
@@ -156,11 +177,96 @@ cat >"$FLEET_STATE_DIR/dispatch/pane-5.json" <<'JSON'
 {"role":"opus-worker","pane":"%5","dispatched_at":"2026-05-08T00:00:00Z"}
 JSON
 
-# With tmux stub: pane %3 → opus-worker-1, pane %5 → opus-worker-2.
-# Reservation is on opus-worker-2 → dedup with pane %5's record.
-# Total unique = 2 (opus-worker-1, opus-worker-2).
+# With tmux stub: pane %3 → opus-worker-1, pane %5 → opus-worker-2,
+# both busy. Reservation is on opus-worker-2 → dedup with pane %5's
+# record. Total unique = 2 (opus-worker-1, opus-worker-2).
 PATH="$TMPROOT/bin-tmux:$PATH" n=$("$DISPATCHER" --count-active opus-worker)
 assert_eq "$n" "2" "opus-worker count dedups same-worktree dispatch+reservation"
+
+# --- Test 4b: reservation on IDLE pane (resume case) does NOT count --------
+echo "T4b: reservation on idle pane does NOT count (resume case)"
+# Clean slate: drop dispatch records and the prior reservation; reserve
+# T-901 for opus-worker-2 again.
+rm -f "$FLEET_STATE_DIR"/dispatch/*.json
+"$FLEET_CLAIM" release-worktree opus-worker-2 >/dev/null 2>&1 || true
+"$FLEET_CLAIM" reserve T-901 opus-worker-2 claude/T-901-something >/dev/null
+
+mkdir -p "$TMPROOT/bin-tmux-idle"
+cat >"$TMPROOT/bin-tmux-idle/tmux" <<'TMUXEOF'
+#!/usr/bin/env bash
+sub="$1"; shift
+case "$sub" in
+    has-session) exit 0 ;;
+    list-panes)
+        # Pane reports `zsh` (idle shell) and no fleet-dispatch-wrap
+        # child (pgrep on the fake pid will find nothing). The new
+        # count_active_for_role semantics: reservation skipped.
+        printf '%%5\topus-worker\tzsh\n'
+        exit 0
+        ;;
+    display-message)
+        pane=""; fmt=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -t) pane="$2"; shift 2 ;;
+                -p) fmt="$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ "$fmt" == *pane_current_path* ]]; then
+            echo "/fake/worktrees/opus-worker-2"
+        elif [[ "$fmt" == *pane_pid* ]]; then
+            # Fake pid that pgrep will not match → wrapper-child probe
+            # returns "not running" → pane is genuinely idle.
+            echo "999999"
+        fi
+        exit 0
+        ;;
+    *) exit 0 ;;
+esac
+TMUXEOF
+chmod +x "$TMPROOT/bin-tmux-idle/tmux"
+
+n=$(PATH="$TMPROOT/bin-tmux-idle:$PATH" "$DISPATCHER" --count-active opus-worker)
+assert_eq "$n" "0" "reservation on idle pane is the resume signal — does not pin the cap"
+
+# --- Test 4c: reservation on BUSY pane DOES count --------------------------
+echo "T4c: reservation on busy pane DOES count (live iteration)"
+mkdir -p "$TMPROOT/bin-tmux-busy"
+cat >"$TMPROOT/bin-tmux-busy/tmux" <<'TMUXEOF'
+#!/usr/bin/env bash
+sub="$1"; shift
+case "$sub" in
+    has-session) exit 0 ;;
+    list-panes)
+        # pane_current_command=claude → outside the shell allowlist
+        # → considered busy without needing the wrapper-child probe.
+        printf '%%5\topus-worker\tclaude\n'
+        exit 0
+        ;;
+    display-message)
+        pane=""; fmt=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -t) pane="$2"; shift 2 ;;
+                -p) fmt="$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ "$fmt" == *pane_current_path* ]]; then
+            echo "/fake/worktrees/opus-worker-2"
+        elif [[ "$fmt" == *pane_pid* ]]; then
+            echo "999998"
+        fi
+        exit 0
+        ;;
+    *) exit 0 ;;
+esac
+TMUXEOF
+chmod +x "$TMPROOT/bin-tmux-busy/tmux"
+
+n=$(PATH="$TMPROOT/bin-tmux-busy:$PATH" "$DISPATCHER" --count-active opus-worker)
+assert_eq "$n" "1" "reservation on busy pane counts (live iteration)"
 
 # --- Test 5: cap defaults --------------------------------------------------
 echo "T5: cap defaults (no conf, no env)"

--- a/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
+++ b/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
@@ -198,9 +198,10 @@ sub="$1"; shift
 case "$sub" in
     has-session) exit 0 ;;
     list-panes)
-        # Pane reports `zsh` (idle shell) and no fleet-dispatch-wrap
-        # child (pgrep on the fake pid will find nothing). The new
-        # count_active_for_role semantics: reservation skipped.
+        # Pane reports `zsh` (idle shell). The pgrep stub alongside
+        # this tmux stub forces the wrapper-child probe to "not
+        # running" → the new count_active_for_role semantics skip
+        # the reservation as a queued resume signal.
         printf '%%5\topus-worker\tzsh\n'
         exit 0
         ;;
@@ -216,9 +217,7 @@ case "$sub" in
         if [[ "$fmt" == *pane_current_path* ]]; then
             echo "/fake/worktrees/opus-worker-2"
         elif [[ "$fmt" == *pane_pid* ]]; then
-            # Fake pid that pgrep will not match → wrapper-child probe
-            # returns "not running" → pane is genuinely idle.
-            echo "999999"
+            echo "1"
         fi
         exit 0
         ;;
@@ -226,6 +225,18 @@ case "$sub" in
 esac
 TMUXEOF
 chmod +x "$TMPROOT/bin-tmux-idle/tmux"
+
+# Stub `pgrep` alongside the tmux stub so the wrapper-child probe is
+# decoupled from the host's process table. Without this the test would
+# rely on no real process matching `pgrep -P <fake-pid> -f
+# fleet-dispatch-wrap`, which is true in practice on the fleet box but
+# brittle in principle on a Linux host with a high kernel.pid_max.
+cat >"$TMPROOT/bin-tmux-idle/pgrep" <<'PGREPEOF'
+#!/usr/bin/env bash
+# No match for the wrapper-child probe → pane reads as idle.
+exit 1
+PGREPEOF
+chmod +x "$TMPROOT/bin-tmux-idle/pgrep"
 
 n=$(PATH="$TMPROOT/bin-tmux-idle:$PATH" "$DISPATCHER" --count-active opus-worker)
 assert_eq "$n" "0" "reservation on idle pane is the resume signal — does not pin the cap"


### PR DESCRIPTION
## Summary

- `count_active_for_role` was counting every role-matched reservation against the per-role concurrency cap, even when the worktree's pane was sitting idle at a shell prompt. After a `fleet-down` (or sleep that timed out an iteration), the leftover reservations would permanently pin the cap and no resume could dispatch — the trigger sat queued, the panes sat idle, the dispatcher logged `at concurrency cap` every tick.
- The reservation IS the resume signal: [`role-sonnet-author.md`](.claude/commands/role-sonnet-author.md) step 0.5 reads it on the next iteration to resume the prior branch. So the fix is to count a reservation only when its worktree's matching pane is *busy* — either running a non-shell command, or running a `fleet-dispatch-wrap` child under a shell. An idle pane's leftover reservation is queued work for the next dispatch to consume, not an active iteration eating budget.
- Falls back to the legacy "always count" path when tmux isn't available (e.g. the `--count-active` CLI invocation outside a live fleet) so existing test harnesses still match the documented contract.

## Test plan

- [x] `bash scripts/fleet/tests/test_dispatcher_concurrency_cap.sh` — **15/15 pass** (3 added: T4 strengthened with `list-panes` stub; T4b verifies idle-pane reservation → 0; T4c verifies busy-pane reservation → 1).
- [x] `bash scripts/fleet/tests/test_dispatcher_usage_gate.sh` — 13/13 pass.
- [x] `bash scripts/fleet/tests/test_fleet_claim_master_lock.sh` — 26/26 pass.
- [x] `bash scripts/fleet/tests/test_fleet_claim_model_gate.sh` — 8/8 pass.
- Tests now point `FLEET_SESSION` at a per-pid fake name so a real fleet tmux session on the dev machine can't bleed pane state into the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)