### PR TITLE
T-160: TEXT_TO_TRIXEL — hoist gui canvas lookup out of per-entity tick

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
@@ -201,20 +201,22 @@ template <> struct System<TEXT_TO_TRIXEL> {
     std::string commandList_;
     bool fontUploaded_ = false;
 
+    // Cached once per frame in beginTick; the gui canvas entity is permanent so
+    // the pointer remains valid through endTick without re-resolving.
+    EntityId guiCanvas_ = IREntity::kNullEntity;
+    C_TriangleCanvasTextures *canvasTextures_ = nullptr;
+
     void tick(
         const C_TextSegment &text,
         const C_GuiPosition &guiPos,
         const C_GuiElement &,
         const C_TextStyle &style
     ) {
-        EntityId guiCanvas = IRRender::getCanvas("gui");
-        auto &canvasTextures = IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
-
         expandTextToCommands(
             drawCommands_,
             text.text_,
             guiPos.pos_,
-            canvasTextures.size_,
+            canvasTextures_->size_,
             style.color_,
             style.wrapWidth_,
             style.alignH_,
@@ -234,9 +236,9 @@ template <> struct System<TEXT_TO_TRIXEL> {
             fontUploaded_ = true;
         }
 
-        EntityId guiCanvas = IRRender::getCanvas("gui");
-        auto &canvasTextures = IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
-        canvasTextures.clear();
+        guiCanvas_ = IRRender::getCanvas("gui");
+        canvasTextures_ = &IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas_);
+        canvasTextures_->clear();
 
         drawCommands_.clear();
 
@@ -248,7 +250,7 @@ template <> struct System<TEXT_TO_TRIXEL> {
                 drawCommands_,
                 commandList_,
                 kGuiOverlayPadding,
-                canvasTextures.size_,
+                canvasTextures_->size_,
                 IRMath::IRColors::kWhite,
                 0
             );
@@ -266,11 +268,9 @@ template <> struct System<TEXT_TO_TRIXEL> {
 
         glyphCmdBuf_->subData(0, count * sizeof(GlyphDrawCommand), drawCommands_.data());
 
-        EntityId guiCanvas = IRRender::getCanvas("gui");
-        auto &canvasTextures = IREntity::getComponent<C_TriangleCanvasTextures>(guiCanvas);
-        canvasTextures.getTextureColors()
+        canvasTextures_->getTextureColors()
             ->bindAsImage(0, TextureAccess::WRITE_ONLY, TextureFormat::RGBA8);
-        canvasTextures.getTextureDistances()
+        canvasTextures_->getTextureDistances()
             ->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::R32I);
 
         IRRender::device()->dispatchCompute(count, 1, 1);


### PR DESCRIPTION
## Summary
- Hoist `IRRender::getCanvas("gui")` + `IREntity::getComponent<C_TriangleCanvasTextures>` out of `System<TEXT_TO_TRIXEL>::tick()` into `beginTick()`
- Cache result as `guiCanvas_` (EntityId) and `canvasTextures_` (raw pointer) on the system struct
- `tick()` now uses `canvasTextures_->size_` directly; `endTick()` uses the same cached pointer for texture binds — eliminating three redundant per-frame foreign-entity lookups
- No behavior change

## Test plan
- [x] `IRUIWidgetsDemo` builds clean (text-bearing creation that registers TEXT_TO_TRIXEL)
- [x] `fleet-run --timeout 15 IRUIWidgetsDemo` — 15s no crash
- [ ] `fleet-build --target IRShapeDebug` clean on linux-debug (acceptance criterion 3)

## Notes for reviewer
- Raw pointer `canvasTextures_` is safe across hooks: the gui canvas entity is permanent (created at engine init, never destroyed), so no archetype change can invalidate the pointer within a frame.
- `beginTick` `getComponent` call is once-per-frame (not per entity) — consistent with WIDGET_INPUT and other systems that resolve the gui canvas in `beginTick`.
- Pre-existing `getComponent` in `endTick` also consolidated; no new `getComponent` calls added.

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
