### PR TITLE
fleet: retain bootstrap trigger during boot fan-out window

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -214,6 +214,15 @@ PERIODIC_REARM_INTERVAL_SECONDS="${FLEET_DISPATCHER_REARM_INTERVAL:-300}"
 # (consume-on-success) are unchanged. 60s is generous — the race
 # typically resolves in 1–2 ticks (10–20s after start).
 BOOT_FANOUT_WINDOW_SECONDS="${FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS:-60}"
+# Validate-and-clamp: a non-numeric override (operator typo,
+# trailing-suffix like "9999s") would otherwise emit arithmetic errors
+# every tick or, under `set -u`, kill the daemon outright. Fall back
+# to the default and log a one-shot warning instead.
+if ! [[ "$BOOT_FANOUT_WINDOW_SECONDS" =~ ^[0-9]+$ ]]; then
+    printf '[%s dispatcher] BOOT_FANOUT_WINDOW_SECONDS=%q is not a non-negative integer; falling back to 60\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$BOOT_FANOUT_WINDOW_SECONDS" >&2
+    BOOT_FANOUT_WINDOW_SECONDS=60
+fi
 
 # Roles this dispatcher is responsible for. Architects are excluded
 # (kept on fleet-babysit). Aligned with the worker / reviewer /
@@ -853,7 +862,8 @@ dispatch_role() {
         local active
         active=$(count_active_for_role "$role")
         if should_retain_trigger_for_fanout_race "$role" "$active"; then
-            log "$role: dispatched $dispatched, active=$active < cap=${ROLE_CONCURRENCY[$role]} within boot fan-out window (${SECONDS}s < ${BOOT_FANOUT_WINDOW_SECONDS}s); keeping trigger for late-tag race"
+            local cap="${ROLE_CONCURRENCY[$role]:-0}"
+            log "$role: dispatched $dispatched, active=$active < cap=$cap within boot fan-out window (${SECONDS}s < ${BOOT_FANOUT_WINDOW_SECONDS}s); keeping trigger for late-tag race"
             return
         fi
         # Steady state (or boot window with cap saturated): at least
@@ -1084,6 +1094,10 @@ case "${1:-}" in
         # boot window is "in" by default unless the override drops it.
         if [[ -z "${2:-}" || -z "${3:-}" ]]; then
             echo "usage: fleet-dispatcher --retain-trigger-check <role> <active-count>" >&2
+            exit 2
+        fi
+        if ! [[ "$3" =~ ^[0-9]+$ ]]; then
+            echo "fleet-dispatcher --retain-trigger-check: <active-count> must be a non-negative integer (got: $3)" >&2
             exit 2
         fi
         if should_retain_trigger_for_fanout_race "$2" "$3"; then

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -195,6 +195,26 @@ fi
 # (fleet-queue-tick, spawned by fleet-state-scout on projection change).
 PERIODIC_REARM_INTERVAL_SECONDS="${FLEET_DISPATCHER_REARM_INTERVAL:-300}"
 
+# Boot fan-out window. During the first N seconds after dispatcher start,
+# `dispatch_role` keeps the per-role trigger in place after a successful
+# dispatch when the post-dispatch active count is still below cap. This
+# guards against a race that surfaces at `fleet-up`: tmux applies the
+# `@fleet-role` tags to panes asynchronously, so the dispatcher's first
+# tick can see only a subset of role-tagged panes (e.g. one of two
+# sonnet-author panes). With the existing single-shot trigger semantic
+# that subset gets dispatched, the bootstrap trigger is consumed, and
+# the late-tagged panes sit idle until scout notices a projection
+# delta — which can take an arbitrarily long time when the same task
+# set was already actionable before the boot. Keeping the trigger for
+# the boot window gives subsequent ticks a chance to dispatch into the
+# missed panes; the dispatch records written here prevent
+# double-dispatch into the already-running panes.
+#
+# Scoped to the boot window so steady-state trigger semantics
+# (consume-on-success) are unchanged. 60s is generous — the race
+# typically resolves in 1–2 ticks (10–20s after start).
+BOOT_FANOUT_WINDOW_SECONDS="${FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS:-60}"
+
 # Roles this dispatcher is responsible for. Architects are excluded
 # (kept on fleet-babysit). Aligned with the worker / reviewer /
 # queue-mgr / merger roles in fleet-up.
@@ -821,7 +841,24 @@ dispatch_role() {
     done <<< "$idle_panes"
 
     if (( dispatched > 0 )); then
-        # At least one pane took the work; consume the trigger.
+        # Boot fan-out guard. If the role's post-dispatch active count
+        # is still below cap AND we're within the boot fan-out window,
+        # keep the trigger so the next tick can catch a pane whose
+        # `@fleet-role` tag landed late (the fleet-up tmux setup race).
+        # Dispatch records already written on this tick prevent
+        # double-dispatch into the panes we just fired. After the
+        # window, fall through to the legacy consume-on-success
+        # semantics so steady-state iterations don't loop just because
+        # of cap headroom.
+        local active
+        active=$(count_active_for_role "$role")
+        if should_retain_trigger_for_fanout_race "$role" "$active"; then
+            log "$role: dispatched $dispatched, active=$active < cap=${ROLE_CONCURRENCY[$role]} within boot fan-out window (${SECONDS}s < ${BOOT_FANOUT_WINDOW_SECONDS}s); keeping trigger for late-tag race"
+            return
+        fi
+        # Steady state (or boot window with cap saturated): at least
+        # one pane took the work and headroom is filled, consume the
+        # trigger.
         rm -f "$trigger_file"
     else
         # Every idle pane already had a record (still settling in
@@ -829,6 +866,25 @@ dispatch_role() {
         # the trigger for the next tick.
         log "no fresh dispatch for $role; trigger kept for retry"
     fi
+}
+
+# Decide whether to retain a per-role trigger after a successful
+# dispatch tick to catch the fleet-up tmux-tag race. Returns 0
+# (retain) if all of: cap is configured (>0), the dispatcher is still
+# inside its boot fan-out window, and the post-dispatch active count
+# is below cap. Returns 1 (consume) otherwise — including any time
+# `BOOT_FANOUT_WINDOW_SECONDS=0` is set, which tests use to simulate
+# the post-window steady state.
+#
+# Extracted so the dispatcher's concurrency tests can drive the
+# decision without spinning up the full main loop.
+should_retain_trigger_for_fanout_race() {
+    local role="$1" active="$2"
+    local cap="${ROLE_CONCURRENCY[$role]:-0}"
+    if (( cap > 0 && SECONDS < BOOT_FANOUT_WINDOW_SECONDS && active < cap )); then
+        return 0
+    fi
+    return 1
 }
 
 # --- Main loop -------------------------------------------------------------
@@ -1017,6 +1073,24 @@ case "${1:-}" in
         # Used by operators to inspect the 5-hour-window state without
         # tailing the dispatcher log.
         usage_gate_status
+        exit 0
+        ;;
+    --retain-trigger-check)
+        # Test/debug: print `retain` or `consume` for this role given a
+        # post-dispatch active count. Honors BOOT_FANOUT_WINDOW_SECONDS
+        # (env override), so tests set it to 0 to simulate the
+        # post-window steady state or to a large value to simulate the
+        # boot window. SECONDS in a fresh CLI invocation is ~0, so the
+        # boot window is "in" by default unless the override drops it.
+        if [[ -z "${2:-}" || -z "${3:-}" ]]; then
+            echo "usage: fleet-dispatcher --retain-trigger-check <role> <active-count>" >&2
+            exit 2
+        fi
+        if should_retain_trigger_for_fanout_race "$2" "$3"; then
+            echo "retain"
+        else
+            echo "consume"
+        fi
         exit 0
         ;;
 esac

--- a/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
+++ b/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
@@ -354,6 +354,25 @@ out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
     "$DISPATCHER" --retain-trigger-check opus-worker 0)
 assert_eq "$out" "consume" "cap=0 short-circuits the retention check"
 
+# --- Test 14: numeric guard on --retain-trigger-check active arg -----------
+echo "T14: non-numeric active arg → usage error, no daemon crash"
+if FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
+    "$DISPATCHER" --retain-trigger-check opus-worker notanumber >/dev/null 2>&1; then
+    rc=0
+else
+    rc=$?
+fi
+assert_eq "$rc" "2" "non-numeric active arg exits with rc=2 (usage error)"
+
+# --- Test 15: non-numeric BOOT_FANOUT_WINDOW_SECONDS clamps to default -----
+echo "T15: non-numeric BOOT_FANOUT_WINDOW_SECONDS clamps to 60s default"
+# Default-window (60s) + fresh CLI invocation (SECONDS≈0) + active<cap → retain.
+# If the validate-and-clamp at startup fails, the bash arithmetic would either
+# emit a stderr error (silent flip to consume) or trip set -u (rc=1).
+out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS="9999s" \
+    "$DISPATCHER" --retain-trigger-check opus-worker 1 2>/dev/null)
+assert_eq "$out" "retain" "non-numeric env override clamps to 60s → in-window retain"
+
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"
 if (( FAIL > 0 )); then

--- a/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
+++ b/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
@@ -315,6 +315,45 @@ echo "T8: env var has higher priority than conf"
 cap=$(FLEET_CONCURRENCY_OPUS_WORKER=7 "$DISPATCHER" --print-cap opus-worker)
 assert_eq "$cap" "7" "env var beats conf file"
 
+# --- Test 9: boot fan-out trigger retention --------------------------------
+#
+# When a successful dispatch leaves the role under cap and the dispatcher
+# is still inside its boot fan-out window, the trigger must be retained
+# (so the next tick can dispatch into a pane whose @fleet-role tag landed
+# late at fleet-up). Outside the window, the legacy consume-on-success
+# behavior applies regardless of cap headroom.
+# Clear the conf override so opus-worker is back at default cap=2 for T9+.
+rm -f "$FLEET_CONF"
+
+echo "T9: boot fan-out — active < cap inside window → retain"
+out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
+    "$DISPATCHER" --retain-trigger-check opus-worker 1)
+assert_eq "$out" "retain" "active=1 < cap=2 inside window → retain"
+
+echo "T10: boot fan-out — active == cap inside window → consume"
+out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
+    "$DISPATCHER" --retain-trigger-check opus-worker 2)
+assert_eq "$out" "consume" "active=2 == cap=2 inside window → consume"
+
+echo "T11: boot fan-out — window expired → consume even if under cap"
+out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=0 \
+    "$DISPATCHER" --retain-trigger-check opus-worker 1)
+assert_eq "$out" "consume" "active=1 < cap=2 but window expired → consume"
+
+echo "T12: boot fan-out — single-pane role saturated → consume"
+# Merger has cap=1; in the real dispatch flow, a successful dispatch
+# means the merger pane just got a dispatch record so active==cap, which
+# is the only realistic post-dispatch state for cap=1 roles.
+out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
+    "$DISPATCHER" --retain-trigger-check merger 1)
+assert_eq "$out" "consume" "merger cap=1 with active=1 → consume (cap saturated)"
+
+echo "T13: boot fan-out — cap=0 (unconfigured role) → consume"
+out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
+    FLEET_CONCURRENCY_OPUS_WORKER=0 \
+    "$DISPATCHER" --retain-trigger-check opus-worker 0)
+assert_eq "$out" "consume" "cap=0 short-circuits the retention check"
+
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"
 if (( FAIL > 0 )); then


### PR DESCRIPTION
## Summary

- At `fleet-up`, the dispatcher's first tick can race with tmux's asynchronous `@fleet-role` tag application. Only a subset of role-tagged panes are visible to `find_idle_panes_for_role` on that tick, the bootstrap trigger gets consumed by the partial dispatch, and the late-tagged panes sit idle until scout notices a projection-content delta — which can take an arbitrarily long time when the task set is unchanged across the boot.
- Observed live on 2026-05-12 after merging [#656](https://github.com/jakildev/IrredenEngine/pull/656): 2 sonnet-author panes + 2 opus-worker panes available, but the dispatcher only fired into `%0` and `%2`. `%3` and `%6` stayed idle for ~5 minutes until a manual `touch ~/.fleet/state/triggers/<role>` re-armed them.
- Fix: in `dispatch_role`, retain the trigger after a successful dispatch when (a) we're still inside the boot fan-out window and (b) the role's post-dispatch active count is below cap. Existing dispatch records prevent double-dispatch into the panes that just fired, so the next tick can cleanly catch any pane whose tag landed late. Outside the window, legacy consume-on-success semantics apply.

Scoped via `SECONDS` (bash builtin, seconds since dispatcher start) and `BOOT_FANOUT_WINDOW_SECONDS` env override (default 60s; race typically resolves in 1–2 ticks at 10s each).

Decision logic extracted into `should_retain_trigger_for_fanout_race` and exposed via a new `--retain-trigger-check <role> <active>` CLI subcommand so the tests can drive it without spinning up the main loop.

## Test plan

- [x] `bash scripts/fleet/tests/test_dispatcher_concurrency_cap.sh` — **20/20 pass** (5 new: T9 retain inside window; T10 cap-saturated consume; T11 window-expired consume; T12 single-pane saturated consume; T13 cap=0 short-circuit consume).
- [x] `bash scripts/fleet/tests/test_dispatcher_usage_gate.sh` — 13/13 pass.
- [x] `bash scripts/fleet/tests/test_fleet_claim_master_lock.sh` — 26/26 pass.
- [x] `bash scripts/fleet/tests/test_fleet_claim_model_gate.sh` — 8/8 pass.
- [x] `bash scripts/fleet/tests/test_fleet_up_conf_bootstrap.sh` — 5/5 pass.
- [ ] Live verification (next `fleet-up`): all role panes get dispatched on the first or second tick, no manual trigger touch required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)