### PR TITLE
T-151: Editor F-0.7 — JSON sidecar format for .txl

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -1,12 +1,15 @@
-# engine/asset/ — trixel texture + sprite-sheet I/O
+# engine/asset/ — trixel texture, sprite-sheet, and txl-sidecar I/O
 
-Tiny module. Today it covers two file formats:
+Tiny module. Today it covers three file formats:
 
 - **Trixel textures** — raw binary `(size, colors[], distances[])` blobs
   with extension `.txl`.
 - **Sprite-sheet sidecars** — plain-text metadata for PNG atlases with
   extension `.irsprite`. The PNG itself is loaded by `engine/render/`'s
   `ImageData`; this module owns only the sidecar.
+- **Trixel JSON sidecars** — JSON metadata stored alongside a `.txl` as
+  `<name>.txl.json`; holds bind-points, component-pack blobs, and
+  material-registry references.
 
 ## What this module is and isn't
 
@@ -47,6 +50,8 @@ snapshot (issue #199). It walks the archetype graph, so it lives in
   `loadTrixelTextureData(...)` — trixel binary round-trip.
 - `saveSpriteSheetMeta(name, path, meta)` /
   `loadSpriteSheetMeta(name, path)` — sidecar text round-trip.
+- `saveTxlSidecar(name, path, sidecar)` /
+  `loadTxlSidecar(name, path)` — `.txl.json` sidecar JSON round-trip.
 - `saveShapeGroup(path, span<ShapeRecord>)` / `loadShapeGroup(path)` —
   `.vxs` SHAPES-mode SDF primitive composition round-trip. See
   `voxel_set_format.hpp` for record layout and the
@@ -67,6 +72,42 @@ ivec2 size
 ```
 
 No checksum, no magic bytes, no compression. Treat the file as volatile.
+
+## Trixel JSON sidecar format (`.txl.json`)
+
+Written/read by `saveTxlSidecar` / `loadTxlSidecar`. Stored as
+`<name>.txl.json` next to the binary `<name>.txl`. The file is omitted when
+the sidecar is empty; a missing file loads as all-defaults with no log.
+
+```json
+{
+  "bind_points": [
+    {
+      "name": "root",
+      "bone_id": 0,
+      "offset": [0.0, 0.0, 0.0],
+      "rotation": [1.0, 0.0, 0.0, 0.0]
+    }
+  ],
+  "component_pack": {},
+  "material_refs": [
+    { "name": "wood", "material_id": 1 }
+  ]
+}
+```
+
+Field notes:
+
+- **`bind_points`** — named attachment points used by the game's animation /
+  IK system. `rotation` is `[qw, qx, qy, qz]` stored in `vec4.x .y .z .w`.
+- **`component_pack`** — opaque JSON object; the engine stores it verbatim as
+  a `std::string`. The game-side component registry interprets the
+  per-component key → value entries at entity spawn time.
+- **`material_refs`** — maps human-readable names to `material_id` bytes from
+  the per-voxel metadata field added in `.txl` v2 (T-146 / F-0.6). The
+  identity map (empty array) is the default when no material info was authored.
+
+The `.txl.json` sidecar complements the binary `.txl` v2 spec from F-0.6.
 
 ## Sprite-sheet sidecar format
 

--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -76,8 +76,8 @@ No checksum, no magic bytes, no compression. Treat the file as volatile.
 ## Trixel JSON sidecar format (`.txl.json`)
 
 Written/read by `saveTxlSidecar` / `loadTxlSidecar`. Stored as
-`<name>.txl.json` next to the binary `<name>.txl`. The file is omitted when
-the sidecar is empty; a missing file loads as all-defaults with no log.
+`<name>.txl.json` next to the binary `<name>.txl`. Saving an empty sidecar
+removes any pre-existing file; a missing file loads as all-defaults with no log.
 
 ```json
 {

--- a/engine/asset/CMakeLists.txt
+++ b/engine/asset/CMakeLists.txt
@@ -13,12 +13,25 @@ target_compile_options(
     -O3
 )
 
+# nlohmann/json — header-only, used privately for .txl.json sidecar I/O
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+    GIT_SHALLOW TRUE
+)
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+set(JSON_Install OFF CACHE INTERNAL "")
+FetchContent_MakeAvailable(nlohmann_json)
+
 target_link_libraries(
     IrredenEngineAsset
     PUBLIC
     IrredenEngineMath
     IrredenEngineProfile
     IrredenEngineUtility
+    PRIVATE
+    nlohmann_json::nlohmann_json
 )
 
 target_include_directories(

--- a/engine/asset/include/irreden/ir_asset.hpp
+++ b/engine/asset/include/irreden/ir_asset.hpp
@@ -81,6 +81,54 @@ void saveSpriteSheetMeta(
 /// Returns a default-constructed SpriteSheetMeta if the file cannot be opened.
 SpriteSheetMeta loadSpriteSheetMeta(const std::string &name, const std::string &path);
 
+// ---- Trixel sidecar (.txl.json) ----
+
+/// A named attachment point on the voxel model.
+/// `rotation_` stores `{qw, qx, qy, qz}` in `.x .y .z .w` order.
+struct BindPoint {
+    std::string name_;
+    int boneId_ = 0;
+    vec3 offset_ = vec3{0.0f, 0.0f, 0.0f};
+    vec4 rotation_ = vec4{1.0f, 0.0f, 0.0f, 0.0f};
+};
+
+/// Maps a human-readable material name to the `material_id` byte from the
+/// per-voxel metadata field (added in .txl v2 by T-146 / F-0.6).
+struct MaterialRef {
+    std::string name_;
+    uint8_t materialId_ = 0;
+};
+
+/// JSON sidecar metadata stored alongside a `.txl` binary file.
+///
+/// Persisted as `<name>.txl.json` next to `<name>.txl`.  The file is omitted
+/// on save when the sidecar is empty — callers should treat a missing sidecar
+/// as all-defaults (empty bind-point list, empty component-pack, identity
+/// material map).
+///
+/// `componentPackJson_` is an opaque JSON object string that the engine
+/// stores verbatim; the game-side component registry interprets the per-
+/// component key→value entries at entity spawn time.
+struct TxlSidecar {
+    std::vector<BindPoint> bindPoints_;
+    std::string componentPackJson_;
+    std::vector<MaterialRef> materialRefs_;
+
+    bool empty() const {
+        return bindPoints_.empty() && componentPackJson_.empty() && materialRefs_.empty();
+    }
+};
+
+/// Writes a `.txl.json` sidecar to `path`/`name`.txl.json.
+/// Does nothing (no file created) if `sidecar.empty()`.
+void saveTxlSidecar(const std::string &name, const std::string &path, const TxlSidecar &sidecar);
+
+/// Reads a `.txl.json` sidecar from `path`/`name`.txl.json.
+/// Returns a default-constructed TxlSidecar (all empty) if the file is absent
+/// or cannot be opened — caller treats missing sidecar as all-defaults, no
+/// log message emitted for the missing-file case.
+TxlSidecar loadTxlSidecar(const std::string &name, const std::string &path);
+
 }; // namespace IRAsset
 
 #endif /* IR_ASSET_H */

--- a/engine/asset/include/irreden/ir_asset.hpp
+++ b/engine/asset/include/irreden/ir_asset.hpp
@@ -89,7 +89,7 @@ struct BindPoint {
     std::string name_;
     int boneId_ = 0;
     vec3 offset_ = vec3{0.0f, 0.0f, 0.0f};
-    vec4 rotation_ = vec4{1.0f, 0.0f, 0.0f, 0.0f};
+    vec4 rotation_ = vec4{1.0f, 0.0f, 0.0f, 0.0f}; // {qw, qx, qy, qz} in .x .y .z .w
 };
 
 /// Maps a human-readable material name to the `material_id` byte from the
@@ -101,14 +101,16 @@ struct MaterialRef {
 
 /// JSON sidecar metadata stored alongside a `.txl` binary file.
 ///
-/// Persisted as `<name>.txl.json` next to `<name>.txl`.  The file is omitted
-/// on save when the sidecar is empty — callers should treat a missing sidecar
-/// as all-defaults (empty bind-point list, empty component-pack, identity
-/// material map).
+/// Persisted as `<name>.txl.json` next to `<name>.txl`.  Saving an empty
+/// sidecar removes any pre-existing file; callers should treat a missing
+/// sidecar as all-defaults (empty bind-point list, empty component-pack,
+/// identity material map).
 ///
 /// `componentPackJson_` is an opaque JSON object string that the engine
 /// stores verbatim; the game-side component registry interprets the per-
-/// component key→value entries at entity spawn time.
+/// component key→value entries at entity spawn time. Round-trip through
+/// `saveTxlSidecar`/`loadTxlSidecar` preserves structure but not byte
+/// order — do not hash the string for change detection.
 struct TxlSidecar {
     std::vector<BindPoint> bindPoints_;
     std::string componentPackJson_;
@@ -120,7 +122,8 @@ struct TxlSidecar {
 };
 
 /// Writes a `.txl.json` sidecar to `path`/`name`.txl.json.
-/// Does nothing (no file created) if `sidecar.empty()`.
+/// If `sidecar.empty()`, removes any pre-existing sidecar file and returns
+/// without creating a new one.
 void saveTxlSidecar(const std::string &name, const std::string &path, const TxlSidecar &sidecar);
 
 /// Reads a `.txl.json` sidecar from `path`/`name`.txl.json.

--- a/engine/asset/src/ir_asset.cpp
+++ b/engine/asset/src/ir_asset.cpp
@@ -2,13 +2,17 @@
 #include <irreden/ir_profile.hpp>
 #include <irreden/ir_utility.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include <cstdio>
+#include <fstream>
 #include <string>
 
 namespace IRAsset {
 
 namespace {
 constexpr const char *kTrixelExtension = ".txl";
+constexpr const char *kTxlSidecarExtension = ".txl.json";
 constexpr const char *kIRSpriteExtension = ".irsprite";
 } // namespace
 
@@ -123,6 +127,108 @@ SpriteSheetMeta loadSpriteSheetMeta(const std::string &name, const std::string &
     fclose(f);
     IRE_LOG_INFO("Loaded sprite sheet meta from {}", filename);
     return meta;
+}
+
+void saveTxlSidecar(const std::string &name, const std::string &path, const TxlSidecar &sidecar) {
+    if (sidecar.empty())
+        return;
+
+    nlohmann::json j;
+
+    nlohmann::json bpArray = nlohmann::json::array();
+    for (const auto &bp : sidecar.bindPoints_) {
+        bpArray.push_back(
+            {{"name", bp.name_},
+             {"bone_id", bp.boneId_},
+             {"offset", {bp.offset_.x, bp.offset_.y, bp.offset_.z}},
+             {"rotation", {bp.rotation_.x, bp.rotation_.y, bp.rotation_.z, bp.rotation_.w}}}
+        );
+    }
+    j["bind_points"] = std::move(bpArray);
+
+    if (!sidecar.componentPackJson_.empty()) {
+        try {
+            j["component_pack"] = nlohmann::json::parse(sidecar.componentPackJson_);
+        } catch (const nlohmann::json::parse_error &e) {
+            IRE_LOG_ERROR("saveTxlSidecar: invalid componentPackJson for '{}': {}", name, e.what());
+            j["component_pack"] = nlohmann::json::object();
+        }
+    }
+
+    nlohmann::json refArray = nlohmann::json::array();
+    for (const auto &ref : sidecar.materialRefs_) {
+        refArray.push_back(
+            {{"name", ref.name_}, {"material_id", static_cast<int>(ref.materialId_)}}
+        );
+    }
+    j["material_refs"] = std::move(refArray);
+
+    const std::string filename = IRUtility::joinPath(path, name, kTxlSidecarExtension);
+    std::ofstream f(filename);
+    if (!f) {
+        IRE_LOG_ERROR("Failed to open file for writing: {}", filename);
+        return;
+    }
+    f << j.dump(2);
+    IRE_LOG_INFO("Saved trixel sidecar to {}", filename);
+}
+
+TxlSidecar loadTxlSidecar(const std::string &name, const std::string &path) {
+    const std::string filename = IRUtility::joinPath(path, name, kTxlSidecarExtension);
+    std::ifstream f(filename);
+    if (!f)
+        return {};
+
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(f);
+    } catch (const nlohmann::json::parse_error &e) {
+        IRE_LOG_ERROR("loadTxlSidecar: JSON parse error for '{}': {}", filename, e.what());
+        return {};
+    }
+
+    TxlSidecar sidecar;
+
+    if (j.contains("bind_points") && j["bind_points"].is_array()) {
+        for (const auto &bp : j["bind_points"]) {
+            BindPoint entry;
+            entry.name_ = bp.value("name", "");
+            entry.boneId_ = bp.value("bone_id", 0);
+            if (bp.contains("offset") && bp["offset"].is_array() && bp["offset"].size() == 3) {
+                entry.offset_ = vec3{
+                    bp["offset"][0].get<float>(),
+                    bp["offset"][1].get<float>(),
+                    bp["offset"][2].get<float>()
+                };
+            }
+            if (bp.contains("rotation") && bp["rotation"].is_array() &&
+                bp["rotation"].size() == 4) {
+                entry.rotation_ = vec4{
+                    bp["rotation"][0].get<float>(),
+                    bp["rotation"][1].get<float>(),
+                    bp["rotation"][2].get<float>(),
+                    bp["rotation"][3].get<float>()
+                };
+            }
+            sidecar.bindPoints_.push_back(std::move(entry));
+        }
+    }
+
+    if (j.contains("component_pack") && j["component_pack"].is_object()) {
+        sidecar.componentPackJson_ = j["component_pack"].dump();
+    }
+
+    if (j.contains("material_refs") && j["material_refs"].is_array()) {
+        for (const auto &ref : j["material_refs"]) {
+            MaterialRef entry;
+            entry.name_ = ref.value("name", "");
+            entry.materialId_ = static_cast<uint8_t>(ref.value("material_id", 0));
+            sidecar.materialRefs_.push_back(std::move(entry));
+        }
+    }
+
+    IRE_LOG_INFO("Loaded trixel sidecar from {}", filename);
+    return sidecar;
 }
 
 } // namespace IRAsset

--- a/engine/asset/src/ir_asset.cpp
+++ b/engine/asset/src/ir_asset.cpp
@@ -130,8 +130,11 @@ SpriteSheetMeta loadSpriteSheetMeta(const std::string &name, const std::string &
 }
 
 void saveTxlSidecar(const std::string &name, const std::string &path, const TxlSidecar &sidecar) {
-    if (sidecar.empty())
+    const std::string filename = IRUtility::joinPath(path, name, kTxlSidecarExtension);
+    if (sidecar.empty()) {
+        std::remove(filename.c_str());
         return;
+    }
 
     nlohmann::json j;
 
@@ -163,7 +166,6 @@ void saveTxlSidecar(const std::string &name, const std::string &path, const TxlS
     }
     j["material_refs"] = std::move(refArray);
 
-    const std::string filename = IRUtility::joinPath(path, name, kTxlSidecarExtension);
     std::ofstream f(filename);
     if (!f) {
         IRE_LOG_ERROR("Failed to open file for writing: {}", filename);
@@ -189,42 +191,54 @@ TxlSidecar loadTxlSidecar(const std::string &name, const std::string &path) {
 
     TxlSidecar sidecar;
 
-    if (j.contains("bind_points") && j["bind_points"].is_array()) {
-        for (const auto &bp : j["bind_points"]) {
-            BindPoint entry;
-            entry.name_ = bp.value("name", "");
-            entry.boneId_ = bp.value("bone_id", 0);
-            if (bp.contains("offset") && bp["offset"].is_array() && bp["offset"].size() == 3) {
-                entry.offset_ = vec3{
-                    bp["offset"][0].get<float>(),
-                    bp["offset"][1].get<float>(),
-                    bp["offset"][2].get<float>()
-                };
+    try {
+        if (j.contains("bind_points") && j["bind_points"].is_array()) {
+            for (const auto &bp : j["bind_points"]) {
+                BindPoint entry;
+                entry.name_ = bp.value("name", "");
+                entry.boneId_ = bp.value("bone_id", 0);
+                if (bp.contains("offset") && bp["offset"].is_array() && bp["offset"].size() == 3) {
+                    entry.offset_ = vec3{
+                        bp["offset"][0].get<float>(),
+                        bp["offset"][1].get<float>(),
+                        bp["offset"][2].get<float>()
+                    };
+                }
+                if (bp.contains("rotation") && bp["rotation"].is_array() &&
+                    bp["rotation"].size() == 4) {
+                    entry.rotation_ = vec4{
+                        bp["rotation"][0].get<float>(),
+                        bp["rotation"][1].get<float>(),
+                        bp["rotation"][2].get<float>(),
+                        bp["rotation"][3].get<float>()
+                    };
+                }
+                sidecar.bindPoints_.push_back(std::move(entry));
             }
-            if (bp.contains("rotation") && bp["rotation"].is_array() &&
-                bp["rotation"].size() == 4) {
-                entry.rotation_ = vec4{
-                    bp["rotation"][0].get<float>(),
-                    bp["rotation"][1].get<float>(),
-                    bp["rotation"][2].get<float>(),
-                    bp["rotation"][3].get<float>()
-                };
+        }
+
+        if (j.contains("component_pack") && j["component_pack"].is_object()) {
+            sidecar.componentPackJson_ = j["component_pack"].dump();
+        }
+
+        if (j.contains("material_refs") && j["material_refs"].is_array()) {
+            for (const auto &ref : j["material_refs"]) {
+                MaterialRef entry;
+                entry.name_ = ref.value("name", "");
+                const int id = ref.value("material_id", 0);
+                IR_ASSERT(
+                    id >= 0 && id <= 255,
+                    "material_id {} out of uint8_t range in '{}'",
+                    id,
+                    filename
+                );
+                entry.materialId_ = static_cast<uint8_t>(id);
+                sidecar.materialRefs_.push_back(std::move(entry));
             }
-            sidecar.bindPoints_.push_back(std::move(entry));
         }
-    }
-
-    if (j.contains("component_pack") && j["component_pack"].is_object()) {
-        sidecar.componentPackJson_ = j["component_pack"].dump();
-    }
-
-    if (j.contains("material_refs") && j["material_refs"].is_array()) {
-        for (const auto &ref : j["material_refs"]) {
-            MaterialRef entry;
-            entry.name_ = ref.value("name", "");
-            entry.materialId_ = static_cast<uint8_t>(ref.value("material_id", 0));
-            sidecar.materialRefs_.push_back(std::move(entry));
-        }
+    } catch (const nlohmann::json::exception &e) {
+        IRE_LOG_ERROR("loadTxlSidecar: type error in '{}': {}", filename, e.what());
+        return {};
     }
 
     IRE_LOG_INFO("Loaded trixel sidecar from {}", filename);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 add_executable(IrredenEngineTest
   asset/binary_io_test.cpp
   asset/sprite_sheet_test.cpp
+  asset/txl_sidecar_test.cpp
   asset/voxel_set_shapes_test.cpp
   audio/music_theory_test.cpp
   common/ir_platform_test.cpp

--- a/test/asset/txl_sidecar_test.cpp
+++ b/test/asset/txl_sidecar_test.cpp
@@ -119,4 +119,31 @@ TEST(TxlSidecar, EmptySidecarNotWritten) {
         fclose(f);
 }
 
+TEST(TxlSidecar, ClearedSidecarRemovesFile) {
+    const std::string name = "ir_test_txl_sidecar_cleared";
+    const std::string path = kTmpDir + "/" + name + ".txl.json";
+
+    IRAsset::TxlSidecar sidecar;
+    IRAsset::BindPoint bp;
+    bp.name_ = "root";
+    bp.boneId_ = 0;
+    sidecar.bindPoints_.push_back(bp);
+    IRAsset::saveTxlSidecar(name, kTmpDir, sidecar);
+
+    FILE *f = fopen(path.c_str(), "r");
+    ASSERT_NE(f, nullptr) << "sidecar should exist after saving with bind-points";
+    if (f)
+        fclose(f);
+
+    IRAsset::saveTxlSidecar(name, kTmpDir, IRAsset::TxlSidecar{});
+
+    FILE *f2 = fopen(path.c_str(), "r");
+    EXPECT_EQ(f2, nullptr) << "empty sidecar save should remove pre-existing file";
+    if (f2)
+        fclose(f2);
+
+    const IRAsset::TxlSidecar loaded = IRAsset::loadTxlSidecar(name, kTmpDir);
+    EXPECT_TRUE(loaded.empty());
+}
+
 } // namespace

--- a/test/asset/txl_sidecar_test.cpp
+++ b/test/asset/txl_sidecar_test.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_asset.hpp>
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+const std::string kTmpDir = "/tmp";
+
+TEST(TxlSidecar, RoundTripBindPoints) {
+    const std::string name = "ir_test_txl_sidecar_rt";
+
+    IRAsset::TxlSidecar sidecar;
+    IRAsset::BindPoint bp0;
+    bp0.name_ = "root";
+    bp0.boneId_ = 0;
+    bp0.offset_ = vec3{1.0f, 2.0f, 3.0f};
+    bp0.rotation_ = vec4{1.0f, 0.0f, 0.0f, 0.0f};
+    sidecar.bindPoints_.push_back(bp0);
+
+    IRAsset::BindPoint bp1;
+    bp1.name_ = "hand_left";
+    bp1.boneId_ = 5;
+    bp1.offset_ = vec3{-0.5f, 1.2f, 0.0f};
+    bp1.rotation_ = vec4{0.7071f, 0.7071f, 0.0f, 0.0f};
+    sidecar.bindPoints_.push_back(bp1);
+
+    IRAsset::saveTxlSidecar(name, kTmpDir, sidecar);
+
+    const IRAsset::TxlSidecar loaded = IRAsset::loadTxlSidecar(name, kTmpDir);
+
+    ASSERT_EQ(loaded.bindPoints_.size(), 2u);
+
+    EXPECT_EQ(loaded.bindPoints_[0].name_, "root");
+    EXPECT_EQ(loaded.bindPoints_[0].boneId_, 0);
+    EXPECT_FLOAT_EQ(loaded.bindPoints_[0].offset_.x, 1.0f);
+    EXPECT_FLOAT_EQ(loaded.bindPoints_[0].offset_.y, 2.0f);
+    EXPECT_FLOAT_EQ(loaded.bindPoints_[0].offset_.z, 3.0f);
+    EXPECT_FLOAT_EQ(loaded.bindPoints_[0].rotation_.x, 1.0f);
+    EXPECT_FLOAT_EQ(loaded.bindPoints_[0].rotation_.y, 0.0f);
+    EXPECT_FLOAT_EQ(loaded.bindPoints_[0].rotation_.z, 0.0f);
+    EXPECT_FLOAT_EQ(loaded.bindPoints_[0].rotation_.w, 0.0f);
+
+    EXPECT_EQ(loaded.bindPoints_[1].name_, "hand_left");
+    EXPECT_EQ(loaded.bindPoints_[1].boneId_, 5);
+    EXPECT_NEAR(loaded.bindPoints_[1].offset_.x, -0.5f, 1e-5f);
+    EXPECT_NEAR(loaded.bindPoints_[1].offset_.y, 1.2f, 1e-5f);
+    EXPECT_NEAR(loaded.bindPoints_[1].rotation_.x, 0.7071f, 1e-4f);
+    EXPECT_NEAR(loaded.bindPoints_[1].rotation_.y, 0.7071f, 1e-4f);
+
+    EXPECT_TRUE(loaded.componentPackJson_.empty());
+    EXPECT_TRUE(loaded.materialRefs_.empty());
+
+    std::remove((kTmpDir + "/" + name + ".txl.json").c_str());
+}
+
+TEST(TxlSidecar, RoundTripMaterialRefs) {
+    const std::string name = "ir_test_txl_sidecar_matref";
+
+    IRAsset::TxlSidecar sidecar;
+    sidecar.materialRefs_.push_back({"wood", 1});
+    sidecar.materialRefs_.push_back({"stone", 7});
+    sidecar.materialRefs_.push_back({"metal", 255});
+
+    IRAsset::saveTxlSidecar(name, kTmpDir, sidecar);
+    const IRAsset::TxlSidecar loaded = IRAsset::loadTxlSidecar(name, kTmpDir);
+
+    ASSERT_EQ(loaded.materialRefs_.size(), 3u);
+    EXPECT_EQ(loaded.materialRefs_[0].name_, "wood");
+    EXPECT_EQ(loaded.materialRefs_[0].materialId_, 1u);
+    EXPECT_EQ(loaded.materialRefs_[1].name_, "stone");
+    EXPECT_EQ(loaded.materialRefs_[1].materialId_, 7u);
+    EXPECT_EQ(loaded.materialRefs_[2].name_, "metal");
+    EXPECT_EQ(loaded.materialRefs_[2].materialId_, 255u);
+
+    std::remove((kTmpDir + "/" + name + ".txl.json").c_str());
+}
+
+TEST(TxlSidecar, RoundTripComponentPackJson) {
+    const std::string name = "ir_test_txl_sidecar_comppack";
+
+    IRAsset::TxlSidecar sidecar;
+    sidecar.componentPackJson_ = R"({"Health":{"max":100},"Speed":{"base":5.0}})";
+
+    IRAsset::saveTxlSidecar(name, kTmpDir, sidecar);
+    const IRAsset::TxlSidecar loaded = IRAsset::loadTxlSidecar(name, kTmpDir);
+
+    EXPECT_FALSE(loaded.componentPackJson_.empty());
+    EXPECT_NE(loaded.componentPackJson_.find("Health"), std::string::npos);
+    EXPECT_NE(loaded.componentPackJson_.find("Speed"), std::string::npos);
+
+    std::remove((kTmpDir + "/" + name + ".txl.json").c_str());
+}
+
+TEST(TxlSidecar, MissingFileReturnsEmptyDefault) {
+    const IRAsset::TxlSidecar loaded =
+        IRAsset::loadTxlSidecar("ir_test_nonexistent_sidecar", kTmpDir);
+
+    EXPECT_TRUE(loaded.empty());
+    EXPECT_TRUE(loaded.bindPoints_.empty());
+    EXPECT_TRUE(loaded.componentPackJson_.empty());
+    EXPECT_TRUE(loaded.materialRefs_.empty());
+}
+
+TEST(TxlSidecar, EmptySidecarNotWritten) {
+    const std::string name = "ir_test_txl_sidecar_empty";
+    const std::string path = kTmpDir + "/" + name + ".txl.json";
+
+    std::remove(path.c_str());
+
+    IRAsset::TxlSidecar sidecar;
+    IRAsset::saveTxlSidecar(name, kTmpDir, sidecar);
+
+    FILE *f = fopen(path.c_str(), "r");
+    EXPECT_EQ(f, nullptr) << "empty sidecar should not create a file";
+    if (f)
+        fclose(f);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Add `.txl.json` sidecar written alongside every `.txl` save (omitted when empty)
- Loader reads sidecar if present; missing sidecar = empty bind-points, empty component-pack, identity material map (silent)
- Round-trip test: write bind-points → reload → exact match

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/635
Full chain: T-146 → T-151

## Test plan
- [ ] `IRVoxelEditor` (or unit test) writes `.txl.json` alongside `.txl` save with bind-points populated
- [ ] Missing sidecar loads silently (no log, empty defaults)
- [ ] Round-trip: bind-points survive save + reload unchanged
- [ ] Schema documented alongside `.txl` v2 spec

Closes #626