### PR TITLE
engine/asset: add binary I/O + chunk-table + name-table + JSON sidecar primitives (T-166)

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -30,8 +30,10 @@ existing trixel-texture and sprite-sheet I/O:
 The binary-I/O primitives (`BinaryWriter`/`Reader`, chunk-table header
 helpers, name-table encoding, JSON sidecar emitter) used by every new
 format also live here so consumers have one place to look. All formats
-obey the seven "Save format extensibility rules" documented in the
-editor-epic design doc.
+obey the seven [Save format extensibility rules](#save-format-extensibility-rules)
+below — the same list lives in `docs/design/entity-editor-epic.md` as
+the design-doc home of the rules; this module's contract is to provide
+the primitives that make those rules cheap to follow.
 
 The one save/load surface that does **not** live here is the ECS world
 snapshot (issue #199). It walks the archetype graph, so it lives in
@@ -86,6 +88,120 @@ this at write time.
 Creations call this during tool runs (e.g. the `shape_debug` demo dumps
 generated trixel shapes to disk for later loading) and during
 import/export. Runtime gameplay code generally does not touch this module.
+
+## Binary-I/O primitives (shared across all new formats)
+
+The headers under `engine/asset/include/irreden/asset/` provide the
+read/write building blocks every new asset format uses. Existing
+formats (`.txl`, `.irsprite`) predate the contract; new formats must
+use these.
+
+### `binary_io.hpp` — `BinaryWriter` / `BinaryReader`
+
+Abstract sinks/sources with two backends each:
+
+- `FileBinaryWriter` / `FileBinaryReader` — wraps a `FILE*` in `wb`/`rb`
+  mode.
+- `MemoryBinaryWriter` / `MemoryBinaryReader` — backed by a
+  `std::vector<uint8_t>` (writer) or a borrowed byte span (reader).
+
+All primitives are little-endian, fixed-width:
+
+- `writeU8/U16/U32/U64`, signed `writeI*`, and matching `read*` returning
+  `Result<T>`.
+- `writeF32/F64` / `readF32/F64` — IEEE 754 bit pattern, host-byte-order
+  agnostic.
+- `writeVarUInt(u64)` / `readVarUInt()` — ULEB128 (Protocol Buffers
+  style). 1 byte for values < 128, up to 10 bytes for `u64`.
+- `writeString(string_view)` / `readString()` — UTF-8 with a varuint
+  byte-length prefix.
+
+Reads return `Result<T>` with a `BinaryStatus status_` and the typed
+`value_`. Check `r.ok()` before consuming `r.value_`. Truncated files,
+malformed varints, and length-prefixed strings that exceed the
+remaining buffer all surface as recoverable errors with file path +
+byte offset in the diagnostic.
+
+### `chunk_header.hpp` — file header + chunk table
+
+Every binary asset format starts with the 12-byte header
+
+```
+char magic[4];
+uint32 version;
+uint32 chunkCount;
+```
+
+followed by `chunkCount` entries of `{ char tag[4]; uint64 offset;
+uint64 size; }` (20 bytes each), then the chunk bodies. Use
+`writeChunked(writer, magic, version, span<ChunkPayload>)` on save —
+it computes offsets and writes header + table + bodies in one pass.
+On load, `readChunks(reader, expectedMagic, maxKnownVersion)` returns
+a `std::vector<LoadedChunk>` (every chunk's bytes copied into memory)
+plus the header. Unknown chunks come through with their raw bytes
+intact so loaders silently skip them (**Extensibility Rule #1** — no
+version bump needed when a future writer adds a new chunk).
+
+### `name_table.hpp` — enum name-table chunk
+
+`writeNameTable(w, span<NameTableEntry>)` and `readNameTable(r)`
+serialize `(uint32 id, string name)` pairs into a chunk body.
+`NameTable` is the in-memory lookup helper (`idByName(name)` and
+`nameById(id)`) consumers use to translate disk-side ids to the
+current build's enum values. **Extensibility Rule #2**: prefer
+`name → current enum` lookup, fall back to id only when the name
+table is absent, so a save written by a future build with a new
+`ShapeType` value loads on an older build as "unknown shape, skipped"
+— not "corrupt file."
+
+### `json_sidecar.hpp` — write-only JSON emitter
+
+`JsonSidecarWriter` builds a pretty-printed JSON document via
+`beginObject` / `endObject` / `beginArray` / `endArray` /
+`key(string_view)` / `value*` calls. No third-party dep. **Read side
+is intentionally not implemented** — sidecars are regenerated from the
+binary on every save (**Extensibility Rule #6**). Extending the binary
+side never forces a sidecar schema migration; the emitter just learns
+the new field.
+
+## Save format extensibility rules
+
+Every binary asset format the engine ships (`.vxs`, `.rig`, the ECS
+world snapshot in `engine/world/`, any future format) obeys the seven
+rules below. They're the constitution for the binary-I/O primitives
+in this module and every consumer of them; the long-form rationale and
+worked examples live in `docs/design/entity-editor-epic.md`. The summary:
+
+1. **Chunk-table forward compatibility.** Loaders silently skip
+   unknown chunk tags. Writers append new chunks without bumping the
+   file version. Order in the chunk table is not load-bearing.
+2. **Enums travel by name + id.** Anywhere a registered enum is
+   stored (`ShapeType`, `ComponentId`, `RelationType`, `MaterialId`,
+   bind-point semantic role), write both the numeric id and a
+   string-name table. On load, prefer name → current enum lookup; fall
+   back to id only when the name table is absent.
+3. **Per-component / per-record additive-only versioning.** Each
+   component (in the world snapshot) and each record type (per-voxel
+   record, joint, bind-point, shape primitive) carries a `uint16`
+   version alongside its blob. Field additions append + bump the
+   version; the load migration defaults the appended fields. Removals
+   and renames require an explicit migration function keyed by
+   `(typeId, oldVersion)`. **No silent structural changes.**
+4. **Relations as first-class data, not hard-coded.** The relation
+   chunk stores `(relationTypeId, entityA, entityB)` triples with the
+   name table at the chunk head — adding `OWNS`, `ATTACHED_TO`,
+   `EQUIPPED_BY` is a one-line enum extension.
+5. **Unknown is recoverable, never fatal.** Bad magic, truncated
+   file, version newer than the loader knows about → clear diagnostic
+   with file path + offset, return an empty/default value, never
+   crash. Test fixtures: corrupt-magic, truncated-mid-chunk,
+   version-too-new, unknown-chunk-tag, unknown-enum-value.
+6. **JSON sidecar is regenerated from the binary, never the source
+   of truth.** Emit on save, ignore on load.
+7. **Save/load surface is documented in one place per format.** Each
+   asset format gets a header block in its `.hpp` describing the
+   chunk table, current chunks, version history, and the migration
+   registry.
 
 ## Gotchas
 

--- a/engine/asset/CMakeLists.txt
+++ b/engine/asset/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_library(IrredenEngineAsset STATIC
     src/ir_asset.cpp
+    src/binary_io.cpp
+    src/chunk_header.cpp
+    src/name_table.cpp
+    src/json_sidecar.cpp
 )
 
 target_compile_options(

--- a/engine/asset/include/irreden/asset/binary_io.hpp
+++ b/engine/asset/include/irreden/asset/binary_io.hpp
@@ -1,0 +1,300 @@
+#ifndef IR_ASSET_BINARY_IO_H
+#define IR_ASSET_BINARY_IO_H
+
+/// Little-endian, fixed-width binary I/O primitives shared by every
+/// asset format in `engine/asset/` and the ECS world snapshot in
+/// `engine/world/`. Two backends — file and in-memory — implement the
+/// same abstract `BinaryWriter` / `BinaryReader` interface so callers
+/// can write the same chunk-building code against either.
+///
+/// All integer primitives are stored little-endian regardless of host
+/// byte order. Floats are stored as their IEEE 754 bit pattern in the
+/// same width as the host (assumes IEEE 754, which is universal on
+/// platforms the engine supports).
+///
+/// Reads return `Result<T>` so a truncated file, bad magic, or malformed
+/// varint is recoverable — never a crash. The 7 Save Format Extensibility
+/// Rules in `docs/design/entity-editor-epic.md` mandate this contract.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace IRAsset {
+
+/// Error codes returned by binary reads. `Ok` means success; anything
+/// else is recoverable (no crash) and carries a diagnostic message.
+enum class BinaryIOError {
+    Ok = 0,
+    OpenFailed,       ///< fopen failed
+    Truncated,        ///< read past end-of-file / end-of-buffer
+    BadMagic,         ///< asset header magic mismatch
+    VersionTooNew,    ///< asset header version above the loader's max
+    InvalidVarUInt,   ///< varint had no terminating byte / overflowed u64
+    InvalidString,    ///< string length prefix exceeded available bytes
+    ChunkOutOfBounds, ///< chunk-table entry points outside the file
+    WriteFailed,      ///< fwrite returned fewer bytes than requested
+};
+
+/// Status payload returned by void-typed binary operations.
+struct BinaryStatus {
+    BinaryIOError code_ = BinaryIOError::Ok;
+    std::string message_;
+
+    bool ok() const {
+        return code_ == BinaryIOError::Ok;
+    }
+    explicit operator bool() const {
+        return ok();
+    }
+
+    static BinaryStatus success() {
+        return {};
+    }
+    static BinaryStatus error(BinaryIOError c, std::string msg) {
+        return {c, std::move(msg)};
+    }
+};
+
+/// Generic result wrapper for binary reads. `value_` is default-constructed
+/// when `status_.ok()` is false; check `ok()` before consuming it.
+template <typename T> struct Result {
+    BinaryStatus status_;
+    T value_{};
+
+    bool ok() const {
+        return status_.ok();
+    }
+    explicit operator bool() const {
+        return ok();
+    }
+
+    static Result success(T v) {
+        Result r;
+        r.value_ = std::move(v);
+        return r;
+    }
+    static Result error(BinaryIOError c, std::string msg) {
+        Result r;
+        r.status_ = BinaryStatus::error(c, std::move(msg));
+        return r;
+    }
+};
+
+// ---- Writer ------------------------------------------------------------
+
+/// Abstract sink for byte-level writes. File and memory backends below.
+/// Concrete primitives (`writeU8`, `writeVarUInt`, ...) are implemented
+/// in terms of `writeBytes` so a subclass only has to override the raw
+/// byte sink + position tracking.
+class BinaryWriter {
+  public:
+    virtual ~BinaryWriter() = default;
+
+    /// Append @p size bytes from @p data. Sets the writer's failure flag
+    /// on any backend error; subsequent calls become no-ops once failed.
+    virtual void writeBytes(const void *data, std::size_t size) = 0;
+
+    /// Current write position in bytes from the start.
+    virtual std::uint64_t tell() const = 0;
+
+    /// Seek to @p pos. Caller guarantees @p pos lies within the
+    /// already-written prefix (for back-patching chunk tables).
+    virtual void seek(std::uint64_t pos) = 0;
+
+    /// Returns true after a previous backend write failed.
+    bool failed() const {
+        return m_failed;
+    }
+
+    /// Diagnostic for the first failure encountered.
+    const std::string &failureMessage() const {
+        return m_failureMessage;
+    }
+
+    void writeU8(std::uint8_t v);
+    void writeU16(std::uint16_t v);
+    void writeU32(std::uint32_t v);
+    void writeU64(std::uint64_t v);
+    void writeI8(std::int8_t v);
+    void writeI16(std::int16_t v);
+    void writeI32(std::int32_t v);
+    void writeI64(std::int64_t v);
+    void writeF32(float v);
+    void writeF64(double v);
+
+    /// ULEB128 varint (Protocol Buffers style). 1 byte for values < 128,
+    /// up to 10 bytes for u64. Use for counts/IDs where small values are
+    /// common.
+    void writeVarUInt(std::uint64_t v);
+
+    /// Length-prefixed UTF-8 string. Prefix is a varint byte-count.
+    void writeString(std::string_view s);
+
+  protected:
+    void setFailed(std::string msg) {
+        if (!m_failed) {
+            m_failed = true;
+            m_failureMessage = std::move(msg);
+        }
+    }
+
+  private:
+    bool m_failed = false;
+    std::string m_failureMessage;
+};
+
+/// File-backed writer. Wraps a `FILE*` opened in binary mode.
+class FileBinaryWriter final : public BinaryWriter {
+  public:
+    /// Opens @p path for binary write (truncates). Check `ok()` after
+    /// construction — false means the file could not be opened and all
+    /// subsequent writes are no-ops.
+    explicit FileBinaryWriter(const std::string &path);
+    ~FileBinaryWriter() override;
+
+    FileBinaryWriter(const FileBinaryWriter &) = delete;
+    FileBinaryWriter &operator=(const FileBinaryWriter &) = delete;
+
+    bool ok() const {
+        return m_file != nullptr && !failed();
+    }
+
+    void writeBytes(const void *data, std::size_t size) override;
+    std::uint64_t tell() const override;
+    void seek(std::uint64_t pos) override;
+
+  private:
+    std::FILE *m_file = nullptr;
+    std::string m_path;
+};
+
+/// In-memory writer. Bytes accumulate in an internal `std::vector`.
+class MemoryBinaryWriter final : public BinaryWriter {
+  public:
+    MemoryBinaryWriter() = default;
+
+    void writeBytes(const void *data, std::size_t size) override;
+    std::uint64_t tell() const override {
+        return m_pos;
+    }
+    void seek(std::uint64_t pos) override;
+
+    const std::vector<std::uint8_t> &buffer() const {
+        return m_buffer;
+    }
+    std::vector<std::uint8_t> takeBuffer() {
+        return std::move(m_buffer);
+    }
+
+  private:
+    std::vector<std::uint8_t> m_buffer;
+    std::uint64_t m_pos = 0;
+};
+
+// ---- Reader ------------------------------------------------------------
+
+/// Abstract byte source for binary reads. All `read*` primitives return
+/// `Result<T>` and never throw; a truncated file yields a `Truncated`
+/// error with file path + offset in the message.
+class BinaryReader {
+  public:
+    virtual ~BinaryReader() = default;
+
+    /// Read exactly @p size bytes into @p dest. Returns `Truncated` if
+    /// fewer bytes were available (and leaves @p dest partially written).
+    virtual BinaryStatus readBytes(void *dest, std::size_t size) = 0;
+
+    /// Current read position from the start, in bytes.
+    virtual std::uint64_t tell() const = 0;
+
+    /// Seek to absolute position. Returns an error if @p pos is past EOF.
+    virtual BinaryStatus seek(std::uint64_t pos) = 0;
+
+    /// Total size in bytes (file or buffer).
+    virtual std::uint64_t size() const = 0;
+
+    /// Identifier for diagnostics (file path for file backends; "<memory>"
+    /// for in-memory ones).
+    virtual std::string sourceName() const = 0;
+
+    /// Bytes remaining from the current position.
+    std::uint64_t remaining() const {
+        const std::uint64_t s = size();
+        const std::uint64_t t = tell();
+        return s > t ? s - t : 0;
+    }
+
+    Result<std::uint8_t> readU8();
+    Result<std::uint16_t> readU16();
+    Result<std::uint32_t> readU32();
+    Result<std::uint64_t> readU64();
+    Result<std::int8_t> readI8();
+    Result<std::int16_t> readI16();
+    Result<std::int32_t> readI32();
+    Result<std::int64_t> readI64();
+    Result<float> readF32();
+    Result<double> readF64();
+    Result<std::uint64_t> readVarUInt();
+    Result<std::string> readString();
+};
+
+/// File-backed reader. Wraps a `FILE*` opened in binary read mode.
+class FileBinaryReader final : public BinaryReader {
+  public:
+    explicit FileBinaryReader(const std::string &path);
+    ~FileBinaryReader() override;
+
+    FileBinaryReader(const FileBinaryReader &) = delete;
+    FileBinaryReader &operator=(const FileBinaryReader &) = delete;
+
+    bool ok() const {
+        return m_file != nullptr;
+    }
+
+    BinaryStatus readBytes(void *dest, std::size_t size) override;
+    std::uint64_t tell() const override;
+    BinaryStatus seek(std::uint64_t pos) override;
+    std::uint64_t size() const override {
+        return m_size;
+    }
+    std::string sourceName() const override {
+        return m_path;
+    }
+
+  private:
+    std::FILE *m_file = nullptr;
+    std::string m_path;
+    std::uint64_t m_size = 0;
+};
+
+/// In-memory reader. Borrows the input buffer; caller keeps it alive.
+class MemoryBinaryReader final : public BinaryReader {
+  public:
+    MemoryBinaryReader(const void *data, std::size_t size, std::string sourceName = "<memory>");
+
+    BinaryStatus readBytes(void *dest, std::size_t size) override;
+    std::uint64_t tell() const override {
+        return m_pos;
+    }
+    BinaryStatus seek(std::uint64_t pos) override;
+    std::uint64_t size() const override {
+        return m_size;
+    }
+    std::string sourceName() const override {
+        return m_sourceName;
+    }
+
+  private:
+    const std::uint8_t *m_data = nullptr;
+    std::uint64_t m_size = 0;
+    std::uint64_t m_pos = 0;
+    std::string m_sourceName;
+};
+
+} // namespace IRAsset
+
+#endif /* IR_ASSET_BINARY_IO_H */

--- a/engine/asset/include/irreden/asset/chunk_header.hpp
+++ b/engine/asset/include/irreden/asset/chunk_header.hpp
@@ -1,0 +1,126 @@
+#ifndef IR_ASSET_CHUNK_HEADER_H
+#define IR_ASSET_CHUNK_HEADER_H
+
+/// Asset-file header + chunk-table primitives. Every binary asset format
+/// (`.vxs`, `.rig`, the ECS world snapshot, future formats) starts with
+///
+///     AssetHeader  { char magic[4]; uint32 version; uint32 chunkCount; }   // 12 bytes
+///     ChunkTableEntry[chunkCount]  { char tag[4]; uint64 offset; uint64 size; }
+///     <chunk bodies, in arbitrary order>
+///
+/// Loaders iterate the chunk table and **silently skip unknown chunk
+/// tags** (Save Format Extensibility Rule #1) — adding a new chunk to a
+/// future writer doesn't break older readers and doesn't require a
+/// version bump.
+///
+/// Order in the chunk table is not load-bearing: a reader's "find this
+/// tag" lookup is the only path. `findChunk()` returns the first match.
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace IRAsset {
+
+/// 12-byte fixed-size asset-file header. The trailing `kHeaderSize`
+/// constant is the on-disk size; do not use `sizeof(AssetHeader)` since
+/// struct padding could differ across compilers.
+struct AssetHeader {
+    std::array<char, 4> magic_{};
+    std::uint32_t version_ = 0;
+    std::uint32_t chunkCount_ = 0;
+};
+
+constexpr std::size_t kAssetHeaderSize = 4 + 4 + 4;
+constexpr std::size_t kChunkTableEntrySize = 4 + 8 + 8;
+
+/// One entry in the chunk table that follows the header.
+/// `offset_` is the absolute byte offset from the start of the file/buffer
+/// to the chunk body. `size_` is the body length in bytes.
+struct ChunkTableEntry {
+    std::array<char, 4> tag_{};
+    std::uint64_t offset_ = 0;
+    std::uint64_t size_ = 0;
+};
+
+/// A chunk body produced by `writeChunked()`. `data_` holds the raw
+/// bytes that will be written under this `tag_`.
+struct ChunkPayload {
+    std::array<char, 4> tag_{};
+    std::vector<std::uint8_t> data_;
+};
+
+/// A chunk surfaced by `readChunks()`. `data_` holds a copy of the raw
+/// bytes (the reader is fully detached from the source after `readChunks`
+/// returns). Unknown chunks come through with their raw bytes intact so
+/// loaders can ignore or pass-through-on-save (Extensibility Rule #1).
+struct LoadedChunk {
+    std::array<char, 4> tag_{};
+    std::vector<std::uint8_t> data_;
+};
+
+/// Build a 4-byte tag from a string literal at compile time. `"VOXR"` →
+/// `{'V', 'O', 'X', 'R'}`. The input must be exactly 4 characters
+/// (asserted at runtime via the `length() != 4` branch — caller passes a
+/// fixed literal).
+inline std::array<char, 4> makeTag(std::string_view s) {
+    std::array<char, 4> out{};
+    for (std::size_t i = 0; i < 4 && i < s.size(); ++i) {
+        out[i] = s[i];
+    }
+    return out;
+}
+
+inline bool tagsEqual(const std::array<char, 4> &a, const std::array<char, 4> &b) {
+    return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3];
+}
+
+inline std::string tagToString(const std::array<char, 4> &t) {
+    return std::string(t.data(), 4);
+}
+
+/// Write the 12-byte header followed by the chunk table, then each
+/// chunk's body. Offsets in the table are computed automatically.
+/// Returns the writer's failure state on completion.
+BinaryStatus writeChunked(
+    BinaryWriter &w,
+    const std::array<char, 4> &magic,
+    std::uint32_t version,
+    std::span<const ChunkPayload> chunks
+);
+
+/// Read just the 12-byte header. Does NOT validate `magic_` — callers
+/// pass an expected magic to `readChunks` for that check.
+Result<AssetHeader> readHeader(BinaryReader &r);
+
+/// Read the chunk table following @p header. Validates each entry's
+/// `offset_` + `size_` fits within the reader's size; returns
+/// `ChunkOutOfBounds` otherwise.
+Result<std::vector<ChunkTableEntry>> readChunkTable(BinaryReader &r, const AssetHeader &header);
+
+/// Combined helper: read header, validate magic, validate version against
+/// @p maxKnownVersion, read chunk table, and pull every chunk body into
+/// memory. Returns every chunk in load order (table order, which may not
+/// match write order if a future writer re-orders).
+///
+/// `expectedMagic` mismatch → `BadMagic`. A header version above
+/// @p maxKnownVersion → `VersionTooNew` (callers can still recover by
+/// inspecting `r` position).
+Result<std::vector<LoadedChunk>> readChunks(
+    BinaryReader &r,
+    const std::array<char, 4> &expectedMagic,
+    std::uint32_t maxKnownVersion,
+    AssetHeader *outHeader = nullptr
+);
+
+/// Linear search for the first chunk with @p tag. Returns nullptr if
+/// missing. O(n) but n is tiny — every format has well under 100 chunks.
+const LoadedChunk *findChunk(std::span<const LoadedChunk> chunks, const std::array<char, 4> &tag);
+
+} // namespace IRAsset
+
+#endif /* IR_ASSET_CHUNK_HEADER_H */

--- a/engine/asset/include/irreden/asset/json_sidecar.hpp
+++ b/engine/asset/include/irreden/asset/json_sidecar.hpp
@@ -1,0 +1,98 @@
+#ifndef IR_ASSET_JSON_SIDECAR_H
+#define IR_ASSET_JSON_SIDECAR_H
+
+/// Minimal stdlib-only JSON emitter for asset sidecars. No third-party
+/// JSON dependency — sidecars are write-only and small, and the binary
+/// asset is always the source of truth.
+///
+/// **Read side is not implemented by design.** Save Format Extensibility
+/// Rule #6: the JSON sidecar is regenerated from the binary on every
+/// save and ignored on load. Extending the binary side never forces a
+/// sidecar schema migration; the emitter just learns the new field.
+///
+/// Supported shape: any nesting of objects + arrays containing strings,
+/// integers, floats, and booleans. The emitter pretty-prints with
+/// 2-space indentation.
+///
+/// Caller usage:
+///
+///     JsonSidecarWriter j;
+///     j.beginObject();
+///         j.key("version"); j.valueInt(1);
+///         j.key("name");    j.valueString("torus_knot");
+///         j.key("voxels");
+///         j.beginArray();
+///             j.beginObject();
+///                 j.key("xyz"); j.beginArray();
+///                     j.valueInt(0); j.valueInt(1); j.valueInt(2);
+///                 j.endArray();
+///                 j.key("color"); j.valueString("#ff8800");
+///             j.endObject();
+///         j.endArray();
+///     j.endObject();
+///     std::string out = j.str();
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace IRAsset {
+
+class JsonSidecarWriter {
+  public:
+    JsonSidecarWriter();
+
+    /// Begin a `{ ... }` object. Inside, alternate `key(...)` then a
+    /// `value*` or `begin*`. Caller must close with `endObject()`.
+    void beginObject();
+    void endObject();
+
+    /// Begin a `[ ... ]` array. Inside, repeated `value*` or `begin*`
+    /// without keys. Caller must close with `endArray()`.
+    void beginArray();
+    void endArray();
+
+    /// Emit a key inside the current object scope. Must be followed by
+    /// exactly one value or begin*.
+    void key(std::string_view k);
+
+    void valueString(std::string_view s);
+    void valueInt(std::int64_t v);
+    void valueUInt(std::uint64_t v);
+    void valueFloat(double v);
+    void valueBool(bool v);
+    void valueNull();
+
+    /// Final JSON document as a string. Safe to call mid-build but the
+    /// caller almost always wants it after the outer scope closes.
+    std::string str() const {
+        return m_out;
+    }
+
+  private:
+    /// Scope tracker — top-of-stack records which container is open and
+    /// whether the next item is the first (commas live between items).
+    struct Scope {
+        enum Kind { OBJECT, ARRAY };
+        Kind kind_;
+        bool firstItem_ = true;
+    };
+
+    void prefixItem();
+    void prefixValue();
+    void writeIndent();
+    void writeEscaped(std::string_view s);
+
+    std::string m_out;
+    std::vector<Scope> m_scopes;
+    bool m_keyPending = false; // a key has been emitted; next value attaches to it
+};
+
+/// Convenience: write the sidecar string to @p path. Returns false on
+/// I/O failure.
+bool writeJsonSidecarToFile(const std::string &path, const std::string &json);
+
+} // namespace IRAsset
+
+#endif /* IR_ASSET_JSON_SIDECAR_H */

--- a/engine/asset/include/irreden/asset/name_table.hpp
+++ b/engine/asset/include/irreden/asset/name_table.hpp
@@ -64,6 +64,7 @@ class NameTable {
     std::optional<std::uint32_t> idByName(std::string_view name) const;
 
     /// Returns the disk-side name for @p id, or `nullopt` if absent.
+    /// Invalidated by any subsequent call to `add()`.
     std::optional<std::string_view> nameById(std::uint32_t id) const;
 
     const std::vector<NameTableEntry> &entries() const {

--- a/engine/asset/include/irreden/asset/name_table.hpp
+++ b/engine/asset/include/irreden/asset/name_table.hpp
@@ -1,0 +1,88 @@
+#ifndef IR_ASSET_NAME_TABLE_H
+#define IR_ASSET_NAME_TABLE_H
+
+/// Name-table chunk helper for Save Format Extensibility Rule #2:
+/// **Enums travel by name + id.** Anywhere a registered enum is stored
+/// (`ShapeType`, `ComponentId`, `RelationType`, `MaterialId`, ...) the
+/// format writes both the numeric id and a string-name table at the head
+/// of the chunk. On load the consumer prefers `name → current enum`
+/// lookup; the numeric id is a fallback when the name table is absent or
+/// the name has been removed from the enum.
+///
+/// A save written by a future build with a new `ShapeType::TORUS_KNOT`
+/// loads on an older build as "unknown shape, skipped" — not "corrupt
+/// file."
+///
+/// On-disk format (one chunk body):
+///
+///     varuint  count
+///     repeat count times:
+///       varuint  id
+///       string   name
+///
+/// Strings are UTF-8 with a varuint byte-length prefix.
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace IRAsset {
+
+/// One (numeric-id, name) pair as it lives in a name-table chunk.
+struct NameTableEntry {
+    std::uint32_t id_ = 0;
+    std::string name_;
+};
+
+/// Serialize @p entries into a name-table chunk body. Caller wraps the
+/// result in a `ChunkPayload` with whatever tag the format uses
+/// (`SHPN`, `CMPN`, `RELN`, ...).
+BinaryStatus writeNameTable(BinaryWriter &w, std::span<const NameTableEntry> entries);
+
+/// Read a name-table chunk body up to EOF/buffer-end. Stops cleanly at
+/// the declared `count` even if more data follows (the chunk-table
+/// `size_` already bounds the input slice).
+Result<std::vector<NameTableEntry>> readNameTable(BinaryReader &r);
+
+/// Bidirectional lookup over a name-table. Built from a vector of
+/// entries; used by the consumer to translate disk-side ids to the
+/// build's current enum values (or vice versa, on save).
+class NameTable {
+  public:
+    NameTable() = default;
+    explicit NameTable(std::vector<NameTableEntry> entries);
+
+    void add(std::uint32_t id, std::string name);
+
+    /// Returns the disk-side id for @p name, or `nullopt` if absent.
+    std::optional<std::uint32_t> idByName(std::string_view name) const;
+
+    /// Returns the disk-side name for @p id, or `nullopt` if absent.
+    std::optional<std::string_view> nameById(std::uint32_t id) const;
+
+    const std::vector<NameTableEntry> &entries() const {
+        return m_entries;
+    }
+
+    bool empty() const {
+        return m_entries.empty();
+    }
+    std::size_t size() const {
+        return m_entries.size();
+    }
+
+  private:
+    std::vector<NameTableEntry> m_entries;
+    std::unordered_map<std::string, std::uint32_t> m_byName;
+    std::unordered_map<std::uint32_t, std::size_t> m_byId;
+};
+
+} // namespace IRAsset
+
+#endif /* IR_ASSET_NAME_TABLE_H */

--- a/engine/asset/src/binary_io.cpp
+++ b/engine/asset/src/binary_io.cpp
@@ -1,0 +1,390 @@
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/ir_profile.hpp>
+
+#include <cstring>
+#include <utility>
+
+namespace IRAsset {
+
+namespace detail {
+
+constexpr bool kHostIsLittleEndian = []() {
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+    return __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__;
+#else
+    return true; // x86/arm — every platform the engine supports is LE
+#endif
+}();
+
+// Write a fixed-width integer in little-endian, host-byte-order-agnostic.
+template <typename T> inline void writeLE(BinaryWriter &w, T v) {
+    static_assert(std::is_integral_v<T>);
+    std::uint8_t bytes[sizeof(T)];
+    for (std::size_t i = 0; i < sizeof(T); ++i) {
+        bytes[i] = static_cast<std::uint8_t>((static_cast<std::uint64_t>(v) >> (i * 8)) & 0xFF);
+    }
+    w.writeBytes(bytes, sizeof(T));
+}
+
+template <typename T> inline Result<T> readLE(BinaryReader &r) {
+    static_assert(std::is_integral_v<T>);
+    std::uint8_t bytes[sizeof(T)];
+    if (auto st = r.readBytes(bytes, sizeof(T)); !st.ok()) {
+        return Result<T>::error(st.code_, std::move(st.message_));
+    }
+    std::uint64_t v = 0;
+    for (std::size_t i = 0; i < sizeof(T); ++i) {
+        v |= static_cast<std::uint64_t>(bytes[i]) << (i * 8);
+    }
+    return Result<T>::success(static_cast<T>(v));
+}
+
+} // namespace detail
+
+// ---- BinaryWriter primitives -------------------------------------------
+
+void BinaryWriter::writeU8(std::uint8_t v) {
+    writeBytes(&v, 1);
+}
+void BinaryWriter::writeU16(std::uint16_t v) {
+    detail::writeLE<std::uint16_t>(*this, v);
+}
+void BinaryWriter::writeU32(std::uint32_t v) {
+    detail::writeLE<std::uint32_t>(*this, v);
+}
+void BinaryWriter::writeU64(std::uint64_t v) {
+    detail::writeLE<std::uint64_t>(*this, v);
+}
+void BinaryWriter::writeI8(std::int8_t v) {
+    writeBytes(&v, 1);
+}
+void BinaryWriter::writeI16(std::int16_t v) {
+    detail::writeLE<std::uint16_t>(*this, static_cast<std::uint16_t>(v));
+}
+void BinaryWriter::writeI32(std::int32_t v) {
+    detail::writeLE<std::uint32_t>(*this, static_cast<std::uint32_t>(v));
+}
+void BinaryWriter::writeI64(std::int64_t v) {
+    detail::writeLE<std::uint64_t>(*this, static_cast<std::uint64_t>(v));
+}
+void BinaryWriter::writeF32(float v) {
+    std::uint32_t bits;
+    std::memcpy(&bits, &v, sizeof(bits));
+    detail::writeLE<std::uint32_t>(*this, bits);
+}
+void BinaryWriter::writeF64(double v) {
+    std::uint64_t bits;
+    std::memcpy(&bits, &v, sizeof(bits));
+    detail::writeLE<std::uint64_t>(*this, bits);
+}
+
+void BinaryWriter::writeVarUInt(std::uint64_t v) {
+    while (v >= 0x80) {
+        const std::uint8_t b = static_cast<std::uint8_t>((v & 0x7F) | 0x80);
+        writeBytes(&b, 1);
+        v >>= 7;
+    }
+    const std::uint8_t b = static_cast<std::uint8_t>(v & 0x7F);
+    writeBytes(&b, 1);
+}
+
+void BinaryWriter::writeString(std::string_view s) {
+    writeVarUInt(static_cast<std::uint64_t>(s.size()));
+    if (!s.empty()) {
+        writeBytes(s.data(), s.size());
+    }
+}
+
+// ---- FileBinaryWriter --------------------------------------------------
+
+FileBinaryWriter::FileBinaryWriter(const std::string &path)
+    : m_path(path) {
+    m_file = std::fopen(path.c_str(), "wb");
+    if (!m_file) {
+        setFailed("FileBinaryWriter: fopen failed for " + path);
+        IRE_LOG_ERROR("FileBinaryWriter: fopen failed for {}", path);
+    }
+}
+
+FileBinaryWriter::~FileBinaryWriter() {
+    if (m_file) {
+        std::fclose(m_file);
+    }
+}
+
+void FileBinaryWriter::writeBytes(const void *data, std::size_t size) {
+    if (!m_file || failed() || size == 0) {
+        return;
+    }
+    const std::size_t written = std::fwrite(data, 1, size, m_file);
+    if (written != size) {
+        setFailed("FileBinaryWriter: short write on " + m_path);
+        IRE_LOG_ERROR(
+            "FileBinaryWriter: short write on {} ({} of {} bytes)",
+            m_path,
+            written,
+            size
+        );
+    }
+}
+
+std::uint64_t FileBinaryWriter::tell() const {
+    if (!m_file) {
+        return 0;
+    }
+    const long pos = std::ftell(m_file);
+    return pos < 0 ? 0 : static_cast<std::uint64_t>(pos);
+}
+
+void FileBinaryWriter::seek(std::uint64_t pos) {
+    if (!m_file) {
+        return;
+    }
+    if (std::fseek(m_file, static_cast<long>(pos), SEEK_SET) != 0) {
+        setFailed("FileBinaryWriter: fseek failed on " + m_path);
+    }
+}
+
+// ---- MemoryBinaryWriter ------------------------------------------------
+
+void MemoryBinaryWriter::writeBytes(const void *data, std::size_t size) {
+    if (failed() || size == 0) {
+        return;
+    }
+    const std::uint64_t end = m_pos + size;
+    if (end > m_buffer.size()) {
+        m_buffer.resize(static_cast<std::size_t>(end));
+    }
+    std::memcpy(m_buffer.data() + m_pos, data, size);
+    m_pos = end;
+}
+
+void MemoryBinaryWriter::seek(std::uint64_t pos) {
+    if (pos > m_buffer.size()) {
+        m_buffer.resize(static_cast<std::size_t>(pos));
+    }
+    m_pos = pos;
+}
+
+// ---- BinaryReader primitives -------------------------------------------
+
+Result<std::uint8_t> BinaryReader::readU8() {
+    std::uint8_t v = 0;
+    if (auto st = readBytes(&v, 1); !st.ok()) {
+        return Result<std::uint8_t>::error(st.code_, std::move(st.message_));
+    }
+    return Result<std::uint8_t>::success(v);
+}
+Result<std::uint16_t> BinaryReader::readU16() {
+    return detail::readLE<std::uint16_t>(*this);
+}
+Result<std::uint32_t> BinaryReader::readU32() {
+    return detail::readLE<std::uint32_t>(*this);
+}
+Result<std::uint64_t> BinaryReader::readU64() {
+    return detail::readLE<std::uint64_t>(*this);
+}
+Result<std::int8_t> BinaryReader::readI8() {
+    auto r = readU8();
+    if (!r.ok()) {
+        return Result<std::int8_t>::error(r.status_.code_, std::move(r.status_.message_));
+    }
+    return Result<std::int8_t>::success(static_cast<std::int8_t>(r.value_));
+}
+Result<std::int16_t> BinaryReader::readI16() {
+    auto r = readU16();
+    if (!r.ok()) {
+        return Result<std::int16_t>::error(r.status_.code_, std::move(r.status_.message_));
+    }
+    return Result<std::int16_t>::success(static_cast<std::int16_t>(r.value_));
+}
+Result<std::int32_t> BinaryReader::readI32() {
+    auto r = readU32();
+    if (!r.ok()) {
+        return Result<std::int32_t>::error(r.status_.code_, std::move(r.status_.message_));
+    }
+    return Result<std::int32_t>::success(static_cast<std::int32_t>(r.value_));
+}
+Result<std::int64_t> BinaryReader::readI64() {
+    auto r = readU64();
+    if (!r.ok()) {
+        return Result<std::int64_t>::error(r.status_.code_, std::move(r.status_.message_));
+    }
+    return Result<std::int64_t>::success(static_cast<std::int64_t>(r.value_));
+}
+Result<float> BinaryReader::readF32() {
+    auto r = readU32();
+    if (!r.ok()) {
+        return Result<float>::error(r.status_.code_, std::move(r.status_.message_));
+    }
+    float v;
+    std::memcpy(&v, &r.value_, sizeof(v));
+    return Result<float>::success(v);
+}
+Result<double> BinaryReader::readF64() {
+    auto r = readU64();
+    if (!r.ok()) {
+        return Result<double>::error(r.status_.code_, std::move(r.status_.message_));
+    }
+    double v;
+    std::memcpy(&v, &r.value_, sizeof(v));
+    return Result<double>::success(v);
+}
+
+Result<std::uint64_t> BinaryReader::readVarUInt() {
+    std::uint64_t value = 0;
+    int shift = 0;
+    // ULEB128 caps at 10 bytes for a 64-bit value (each byte contributes 7 bits,
+    // 10 * 7 = 70 ≥ 64). Any longer is malformed.
+    for (int i = 0; i < 10; ++i) {
+        std::uint8_t b = 0;
+        if (auto st = readBytes(&b, 1); !st.ok()) {
+            return Result<std::uint64_t>::error(
+                BinaryIOError::InvalidVarUInt,
+                "varint truncated at offset " + std::to_string(tell()) + " in " + sourceName()
+            );
+        }
+        const std::uint64_t chunk = static_cast<std::uint64_t>(b & 0x7F);
+        // Reject overflow: on byte 10 only the lowest bit is legal (bits >= 64).
+        if (shift >= 64 || (shift == 63 && chunk > 1)) {
+            return Result<std::uint64_t>::error(
+                BinaryIOError::InvalidVarUInt,
+                "varint overflows uint64 at offset " + std::to_string(tell()) + " in " +
+                    sourceName()
+            );
+        }
+        value |= chunk << shift;
+        if ((b & 0x80) == 0) {
+            return Result<std::uint64_t>::success(value);
+        }
+        shift += 7;
+    }
+    return Result<std::uint64_t>::error(
+        BinaryIOError::InvalidVarUInt,
+        "varint has no terminator (>10 bytes) at offset " + std::to_string(tell()) + " in " +
+            sourceName()
+    );
+}
+
+Result<std::string> BinaryReader::readString() {
+    auto lenR = readVarUInt();
+    if (!lenR.ok()) {
+        return Result<std::string>::error(lenR.status_.code_, std::move(lenR.status_.message_));
+    }
+    if (lenR.value_ > remaining()) {
+        return Result<std::string>::error(
+            BinaryIOError::InvalidString,
+            "string length " + std::to_string(lenR.value_) + " exceeds remaining bytes (" +
+                std::to_string(remaining()) + ") in " + sourceName()
+        );
+    }
+    std::string out(static_cast<std::size_t>(lenR.value_), '\0');
+    if (lenR.value_ > 0) {
+        if (auto st = readBytes(out.data(), static_cast<std::size_t>(lenR.value_)); !st.ok()) {
+            return Result<std::string>::error(st.code_, std::move(st.message_));
+        }
+    }
+    return Result<std::string>::success(std::move(out));
+}
+
+// ---- FileBinaryReader --------------------------------------------------
+
+FileBinaryReader::FileBinaryReader(const std::string &path)
+    : m_path(path) {
+    m_file = std::fopen(path.c_str(), "rb");
+    if (!m_file) {
+        IRE_LOG_ERROR("FileBinaryReader: fopen failed for {}", path);
+        return;
+    }
+    std::fseek(m_file, 0, SEEK_END);
+    const long sz = std::ftell(m_file);
+    std::fseek(m_file, 0, SEEK_SET);
+    m_size = sz < 0 ? 0 : static_cast<std::uint64_t>(sz);
+}
+
+FileBinaryReader::~FileBinaryReader() {
+    if (m_file) {
+        std::fclose(m_file);
+    }
+}
+
+BinaryStatus FileBinaryReader::readBytes(void *dest, std::size_t size) {
+    if (!m_file) {
+        return BinaryStatus::error(BinaryIOError::OpenFailed, "file not open: " + m_path);
+    }
+    if (size == 0) {
+        return BinaryStatus::success();
+    }
+    const std::size_t got = std::fread(dest, 1, size, m_file);
+    if (got != size) {
+        return BinaryStatus::error(
+            BinaryIOError::Truncated,
+            "truncated read at offset " + std::to_string(tell()) + " (" + std::to_string(got) +
+                " of " + std::to_string(size) + " bytes) in " + m_path
+        );
+    }
+    return BinaryStatus::success();
+}
+
+std::uint64_t FileBinaryReader::tell() const {
+    if (!m_file) {
+        return 0;
+    }
+    const long p = std::ftell(m_file);
+    return p < 0 ? 0 : static_cast<std::uint64_t>(p);
+}
+
+BinaryStatus FileBinaryReader::seek(std::uint64_t pos) {
+    if (!m_file) {
+        return BinaryStatus::error(BinaryIOError::OpenFailed, "file not open: " + m_path);
+    }
+    if (pos > m_size) {
+        return BinaryStatus::error(
+            BinaryIOError::Truncated,
+            "seek to " + std::to_string(pos) + " past EOF (" + std::to_string(m_size) + ") in " +
+                m_path
+        );
+    }
+    if (std::fseek(m_file, static_cast<long>(pos), SEEK_SET) != 0) {
+        return BinaryStatus::error(BinaryIOError::Truncated, "fseek failed on " + m_path);
+    }
+    return BinaryStatus::success();
+}
+
+// ---- MemoryBinaryReader ------------------------------------------------
+
+MemoryBinaryReader::MemoryBinaryReader(const void *data, std::size_t size, std::string sourceName)
+    : m_data(static_cast<const std::uint8_t *>(data))
+    , m_size(size)
+    , m_sourceName(std::move(sourceName)) {}
+
+BinaryStatus MemoryBinaryReader::readBytes(void *dest, std::size_t size) {
+    if (size == 0) {
+        return BinaryStatus::success();
+    }
+    if (m_pos + size > m_size) {
+        const std::uint64_t avail = m_size > m_pos ? m_size - m_pos : 0;
+        return BinaryStatus::error(
+            BinaryIOError::Truncated,
+            "truncated read at offset " + std::to_string(m_pos) + " (" + std::to_string(avail) +
+                " of " + std::to_string(size) + " bytes) in " + m_sourceName
+        );
+    }
+    std::memcpy(dest, m_data + m_pos, size);
+    m_pos += size;
+    return BinaryStatus::success();
+}
+
+BinaryStatus MemoryBinaryReader::seek(std::uint64_t pos) {
+    if (pos > m_size) {
+        return BinaryStatus::error(
+            BinaryIOError::Truncated,
+            "seek to " + std::to_string(pos) + " past end (" + std::to_string(m_size) + ") in " +
+                m_sourceName
+        );
+    }
+    m_pos = pos;
+    return BinaryStatus::success();
+}
+
+} // namespace IRAsset

--- a/engine/asset/src/chunk_header.cpp
+++ b/engine/asset/src/chunk_header.cpp
@@ -83,9 +83,9 @@ Result<std::vector<ChunkTableEntry>> readChunkTable(BinaryReader &r, const Asset
         }
         e.size_ = szR.value_;
 
-        // Validate the chunk body lies fully within the source. Catch overflow
-        // by checking the addends separately — `offset + size` could wrap.
-        if (e.offset_ > totalSize || e.size_ > totalSize || e.offset_ + e.size_ > totalSize) {
+        // Validate the chunk body lies fully within the source. The second guard
+        // is evaluated only when e.offset_ <= totalSize, so the subtraction is safe.
+        if (e.offset_ > totalSize || e.size_ > totalSize - e.offset_) {
             return Result<std::vector<ChunkTableEntry>>::error(
                 BinaryIOError::ChunkOutOfBounds,
                 "chunk '" + tagToString(e.tag_) + "' at offset " + std::to_string(e.offset_) +

--- a/engine/asset/src/chunk_header.cpp
+++ b/engine/asset/src/chunk_header.cpp
@@ -1,0 +1,168 @@
+#include <irreden/asset/chunk_header.hpp>
+
+#include <cstring>
+#include <utility>
+
+namespace IRAsset {
+
+BinaryStatus writeChunked(
+    BinaryWriter &w,
+    const std::array<char, 4> &magic,
+    std::uint32_t version,
+    std::span<const ChunkPayload> chunks
+) {
+    // Header
+    w.writeBytes(magic.data(), 4);
+    w.writeU32(version);
+    w.writeU32(static_cast<std::uint32_t>(chunks.size()));
+
+    // First chunk body starts immediately after the table.
+    std::uint64_t cursor = static_cast<std::uint64_t>(kAssetHeaderSize) +
+                           static_cast<std::uint64_t>(kChunkTableEntrySize) * chunks.size();
+
+    for (const auto &c : chunks) {
+        w.writeBytes(c.tag_.data(), 4);
+        w.writeU64(cursor);
+        w.writeU64(static_cast<std::uint64_t>(c.data_.size()));
+        cursor += c.data_.size();
+    }
+
+    for (const auto &c : chunks) {
+        if (!c.data_.empty()) {
+            w.writeBytes(c.data_.data(), c.data_.size());
+        }
+    }
+
+    if (w.failed()) {
+        return BinaryStatus::error(BinaryIOError::WriteFailed, w.failureMessage());
+    }
+    return BinaryStatus::success();
+}
+
+Result<AssetHeader> readHeader(BinaryReader &r) {
+    AssetHeader h{};
+    if (auto st = r.readBytes(h.magic_.data(), 4); !st.ok()) {
+        return Result<AssetHeader>::error(st.code_, std::move(st.message_));
+    }
+    auto verR = r.readU32();
+    if (!verR.ok()) {
+        return Result<AssetHeader>::error(verR.status_.code_, std::move(verR.status_.message_));
+    }
+    h.version_ = verR.value_;
+    auto cntR = r.readU32();
+    if (!cntR.ok()) {
+        return Result<AssetHeader>::error(cntR.status_.code_, std::move(cntR.status_.message_));
+    }
+    h.chunkCount_ = cntR.value_;
+    return Result<AssetHeader>::success(h);
+}
+
+Result<std::vector<ChunkTableEntry>> readChunkTable(BinaryReader &r, const AssetHeader &header) {
+    std::vector<ChunkTableEntry> table;
+    table.reserve(header.chunkCount_);
+    const std::uint64_t totalSize = r.size();
+    for (std::uint32_t i = 0; i < header.chunkCount_; ++i) {
+        ChunkTableEntry e{};
+        if (auto st = r.readBytes(e.tag_.data(), 4); !st.ok()) {
+            return Result<std::vector<ChunkTableEntry>>::error(st.code_, std::move(st.message_));
+        }
+        auto offR = r.readU64();
+        if (!offR.ok()) {
+            return Result<std::vector<ChunkTableEntry>>::error(
+                offR.status_.code_,
+                std::move(offR.status_.message_)
+            );
+        }
+        e.offset_ = offR.value_;
+        auto szR = r.readU64();
+        if (!szR.ok()) {
+            return Result<std::vector<ChunkTableEntry>>::error(
+                szR.status_.code_,
+                std::move(szR.status_.message_)
+            );
+        }
+        e.size_ = szR.value_;
+
+        // Validate the chunk body lies fully within the source. Catch overflow
+        // by checking the addends separately — `offset + size` could wrap.
+        if (e.offset_ > totalSize || e.size_ > totalSize || e.offset_ + e.size_ > totalSize) {
+            return Result<std::vector<ChunkTableEntry>>::error(
+                BinaryIOError::ChunkOutOfBounds,
+                "chunk '" + tagToString(e.tag_) + "' at offset " + std::to_string(e.offset_) +
+                    " size " + std::to_string(e.size_) + " exceeds source size " +
+                    std::to_string(totalSize) + " in " + r.sourceName()
+            );
+        }
+        table.push_back(std::move(e));
+    }
+    return Result<std::vector<ChunkTableEntry>>::success(std::move(table));
+}
+
+Result<std::vector<LoadedChunk>> readChunks(
+    BinaryReader &r,
+    const std::array<char, 4> &expectedMagic,
+    std::uint32_t maxKnownVersion,
+    AssetHeader *outHeader
+) {
+    auto headerR = readHeader(r);
+    if (!headerR.ok()) {
+        return Result<std::vector<LoadedChunk>>::error(
+            headerR.status_.code_,
+            std::move(headerR.status_.message_)
+        );
+    }
+    if (outHeader) {
+        *outHeader = headerR.value_;
+    }
+    if (!tagsEqual(headerR.value_.magic_, expectedMagic)) {
+        return Result<std::vector<LoadedChunk>>::error(
+            BinaryIOError::BadMagic,
+            "bad magic '" + tagToString(headerR.value_.magic_) + "' (expected '" +
+                tagToString(expectedMagic) + "') in " + r.sourceName()
+        );
+    }
+    if (headerR.value_.version_ > maxKnownVersion) {
+        return Result<std::vector<LoadedChunk>>::error(
+            BinaryIOError::VersionTooNew,
+            "version " + std::to_string(headerR.value_.version_) + " above max known " +
+                std::to_string(maxKnownVersion) + " in " + r.sourceName()
+        );
+    }
+
+    auto tableR = readChunkTable(r, headerR.value_);
+    if (!tableR.ok()) {
+        return Result<std::vector<LoadedChunk>>::error(
+            tableR.status_.code_,
+            std::move(tableR.status_.message_)
+        );
+    }
+
+    std::vector<LoadedChunk> chunks;
+    chunks.reserve(tableR.value_.size());
+    for (const auto &entry : tableR.value_) {
+        if (auto st = r.seek(entry.offset_); !st.ok()) {
+            return Result<std::vector<LoadedChunk>>::error(st.code_, std::move(st.message_));
+        }
+        LoadedChunk lc;
+        lc.tag_ = entry.tag_;
+        lc.data_.resize(static_cast<std::size_t>(entry.size_));
+        if (entry.size_ > 0) {
+            if (auto st = r.readBytes(lc.data_.data(), lc.data_.size()); !st.ok()) {
+                return Result<std::vector<LoadedChunk>>::error(st.code_, std::move(st.message_));
+            }
+        }
+        chunks.push_back(std::move(lc));
+    }
+    return Result<std::vector<LoadedChunk>>::success(std::move(chunks));
+}
+
+const LoadedChunk *findChunk(std::span<const LoadedChunk> chunks, const std::array<char, 4> &tag) {
+    for (const auto &c : chunks) {
+        if (tagsEqual(c.tag_, tag)) {
+            return &c;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace IRAsset

--- a/engine/asset/src/json_sidecar.cpp
+++ b/engine/asset/src/json_sidecar.cpp
@@ -1,0 +1,200 @@
+#include <irreden/asset/json_sidecar.hpp>
+#include <irreden/ir_profile.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+namespace IRAsset {
+
+JsonSidecarWriter::JsonSidecarWriter() {
+    m_out.reserve(256);
+}
+
+void JsonSidecarWriter::writeIndent() {
+    for (std::size_t i = 0; i < m_scopes.size(); ++i) {
+        m_out.append("  ");
+    }
+}
+
+void JsonSidecarWriter::writeEscaped(std::string_view s) {
+    m_out.push_back('"');
+    for (char c : s) {
+        switch (c) {
+        case '"':
+            m_out.append("\\\"");
+            break;
+        case '\\':
+            m_out.append("\\\\");
+            break;
+        case '\n':
+            m_out.append("\\n");
+            break;
+        case '\r':
+            m_out.append("\\r");
+            break;
+        case '\t':
+            m_out.append("\\t");
+            break;
+        case '\b':
+            m_out.append("\\b");
+            break;
+        case '\f':
+            m_out.append("\\f");
+            break;
+        default:
+            if (static_cast<unsigned char>(c) < 0x20) {
+                char buf[8];
+                std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned int>(c) & 0xFF);
+                m_out.append(buf);
+            } else {
+                m_out.push_back(c);
+            }
+            break;
+        }
+    }
+    m_out.push_back('"');
+}
+
+void JsonSidecarWriter::prefixItem() {
+    if (m_scopes.empty()) {
+        return;
+    }
+    Scope &s = m_scopes.back();
+    if (s.firstItem_) {
+        m_out.push_back('\n');
+        s.firstItem_ = false;
+    } else {
+        m_out.append(",\n");
+    }
+    writeIndent();
+}
+
+void JsonSidecarWriter::prefixValue() {
+    // A value either follows a key (no scope-level prefix needed; we're on
+    // the same line as the key) or appears as a direct array element (needs
+    // the comma/newline + indent prefix).
+    if (m_keyPending) {
+        m_keyPending = false;
+        return;
+    }
+    prefixItem();
+}
+
+void JsonSidecarWriter::beginObject() {
+    prefixValue();
+    m_out.push_back('{');
+    m_scopes.push_back({Scope::OBJECT, true});
+}
+
+void JsonSidecarWriter::endObject() {
+    if (m_scopes.empty() || m_scopes.back().kind_ != Scope::OBJECT) {
+        IRE_LOG_ERROR("JsonSidecarWriter::endObject called outside an object scope");
+        return;
+    }
+    const bool empty = m_scopes.back().firstItem_;
+    m_scopes.pop_back();
+    if (!empty) {
+        m_out.push_back('\n');
+        writeIndent();
+    }
+    m_out.push_back('}');
+}
+
+void JsonSidecarWriter::beginArray() {
+    prefixValue();
+    m_out.push_back('[');
+    m_scopes.push_back({Scope::ARRAY, true});
+}
+
+void JsonSidecarWriter::endArray() {
+    if (m_scopes.empty() || m_scopes.back().kind_ != Scope::ARRAY) {
+        IRE_LOG_ERROR("JsonSidecarWriter::endArray called outside an array scope");
+        return;
+    }
+    const bool empty = m_scopes.back().firstItem_;
+    m_scopes.pop_back();
+    if (!empty) {
+        m_out.push_back('\n');
+        writeIndent();
+    }
+    m_out.push_back(']');
+}
+
+void JsonSidecarWriter::key(std::string_view k) {
+    if (m_scopes.empty() || m_scopes.back().kind_ != Scope::OBJECT) {
+        IRE_LOG_ERROR("JsonSidecarWriter::key called outside an object scope");
+        return;
+    }
+    prefixItem();
+    writeEscaped(k);
+    m_out.append(": ");
+    m_keyPending = true;
+}
+
+void JsonSidecarWriter::valueString(std::string_view s) {
+    prefixValue();
+    writeEscaped(s);
+}
+
+void JsonSidecarWriter::valueInt(std::int64_t v) {
+    prefixValue();
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%lld", static_cast<long long>(v));
+    m_out.append(buf);
+}
+
+void JsonSidecarWriter::valueUInt(std::uint64_t v) {
+    prefixValue();
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%llu", static_cast<unsigned long long>(v));
+    m_out.append(buf);
+}
+
+void JsonSidecarWriter::valueFloat(double v) {
+    prefixValue();
+    // NaN/Inf are not valid JSON. Emit `null` and log; sidecars are
+    // human-diffable summaries, not canonical, so this is recoverable.
+    if (std::isnan(v) || std::isinf(v)) {
+        IRE_LOG_WARN("JsonSidecarWriter: non-finite float emitted as null");
+        m_out.append("null");
+        return;
+    }
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%g", v);
+    // %g may emit "1" for integer-valued doubles, which still parses as
+    // a JSON number — fine.
+    m_out.append(buf);
+}
+
+void JsonSidecarWriter::valueBool(bool v) {
+    prefixValue();
+    m_out.append(v ? "true" : "false");
+}
+
+void JsonSidecarWriter::valueNull() {
+    prefixValue();
+    m_out.append("null");
+}
+
+bool writeJsonSidecarToFile(const std::string &path, const std::string &json) {
+    std::FILE *f = std::fopen(path.c_str(), "wb");
+    if (!f) {
+        IRE_LOG_ERROR("writeJsonSidecarToFile: fopen failed for {}", path);
+        return false;
+    }
+    const std::size_t written = std::fwrite(json.data(), 1, json.size(), f);
+    std::fclose(f);
+    if (written != json.size()) {
+        IRE_LOG_ERROR(
+            "writeJsonSidecarToFile: short write on {} ({} of {} bytes)",
+            path,
+            written,
+            json.size()
+        );
+        return false;
+    }
+    return true;
+}
+
+} // namespace IRAsset

--- a/engine/asset/src/name_table.cpp
+++ b/engine/asset/src/name_table.cpp
@@ -1,0 +1,89 @@
+#include <irreden/asset/name_table.hpp>
+
+#include <utility>
+
+namespace IRAsset {
+
+BinaryStatus writeNameTable(BinaryWriter &w, std::span<const NameTableEntry> entries) {
+    w.writeVarUInt(static_cast<std::uint64_t>(entries.size()));
+    for (const auto &e : entries) {
+        w.writeVarUInt(e.id_);
+        w.writeString(e.name_);
+    }
+    if (w.failed()) {
+        return BinaryStatus::error(BinaryIOError::WriteFailed, w.failureMessage());
+    }
+    return BinaryStatus::success();
+}
+
+Result<std::vector<NameTableEntry>> readNameTable(BinaryReader &r) {
+    auto countR = r.readVarUInt();
+    if (!countR.ok()) {
+        return Result<std::vector<NameTableEntry>>::error(
+            countR.status_.code_,
+            std::move(countR.status_.message_)
+        );
+    }
+    // Cap the upfront reserve to the remaining bytes — a corrupted count
+    // claiming billions of entries shouldn't pre-allocate that much.
+    const std::uint64_t cap = r.remaining();
+    std::vector<NameTableEntry> out;
+    out.reserve(static_cast<std::size_t>(countR.value_ < cap ? countR.value_ : cap));
+    for (std::uint64_t i = 0; i < countR.value_; ++i) {
+        NameTableEntry e{};
+        auto idR = r.readVarUInt();
+        if (!idR.ok()) {
+            return Result<std::vector<NameTableEntry>>::error(
+                idR.status_.code_,
+                std::move(idR.status_.message_)
+            );
+        }
+        e.id_ = static_cast<std::uint32_t>(idR.value_);
+        auto nameR = r.readString();
+        if (!nameR.ok()) {
+            return Result<std::vector<NameTableEntry>>::error(
+                nameR.status_.code_,
+                std::move(nameR.status_.message_)
+            );
+        }
+        e.name_ = std::move(nameR.value_);
+        out.push_back(std::move(e));
+    }
+    return Result<std::vector<NameTableEntry>>::success(std::move(out));
+}
+
+NameTable::NameTable(std::vector<NameTableEntry> entries)
+    : m_entries(std::move(entries)) {
+    for (std::size_t i = 0; i < m_entries.size(); ++i) {
+        m_byName.emplace(m_entries[i].name_, m_entries[i].id_);
+        m_byId.emplace(m_entries[i].id_, i);
+    }
+}
+
+void NameTable::add(std::uint32_t id, std::string name) {
+    const std::size_t idx = m_entries.size();
+    m_byName.emplace(name, id);
+    m_byId.emplace(id, idx);
+    m_entries.push_back(NameTableEntry{id, std::move(name)});
+}
+
+std::optional<std::uint32_t> NameTable::idByName(std::string_view name) const {
+    // unordered_map keyed on std::string — need a transparent-lookup-friendly
+    // hash to use string_view directly. Allocate the temporary string here
+    // (this lookup is not in a hot path; serialization runs once per save).
+    auto it = m_byName.find(std::string(name));
+    if (it == m_byName.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::optional<std::string_view> NameTable::nameById(std::uint32_t id) const {
+    auto it = m_byId.find(id);
+    if (it == m_byId.end()) {
+        return std::nullopt;
+    }
+    return std::string_view(m_entries[it->second].name_);
+}
+
+} // namespace IRAsset

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ include(GoogleTest)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(IrredenEngineTest
+  asset/binary_io_test.cpp
   asset/sprite_sheet_test.cpp
   audio/music_theory_test.cpp
   common/ir_platform_test.cpp

--- a/test/asset/binary_io_test.cpp
+++ b/test/asset/binary_io_test.cpp
@@ -1,0 +1,455 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/json_sidecar.hpp>
+#include <irreden/asset/name_table.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace IRAsset;
+
+const std::string kTmpDir = "/tmp";
+
+// ---- BinaryWriter / BinaryReader primitive round-trips ------------------
+
+TEST(BinaryIO, RoundTripIntegerPrimitives) {
+    MemoryBinaryWriter w;
+    w.writeU8(0x12);
+    w.writeU16(0x1234);
+    w.writeU32(0xDEADBEEFu);
+    w.writeU64(0x0123456789ABCDEFull);
+    w.writeI8(-1);
+    w.writeI16(-12345);
+    w.writeI32(-987654321);
+    w.writeI64(-1234567890123456789ll);
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    EXPECT_EQ(r.readU8().value_, 0x12u);
+    EXPECT_EQ(r.readU16().value_, 0x1234u);
+    EXPECT_EQ(r.readU32().value_, 0xDEADBEEFu);
+    EXPECT_EQ(r.readU64().value_, 0x0123456789ABCDEFull);
+    EXPECT_EQ(r.readI8().value_, -1);
+    EXPECT_EQ(r.readI16().value_, -12345);
+    EXPECT_EQ(r.readI32().value_, -987654321);
+    EXPECT_EQ(r.readI64().value_, -1234567890123456789ll);
+    EXPECT_EQ(r.remaining(), 0u);
+}
+
+TEST(BinaryIO, RoundTripFloatsPreservesBits) {
+    MemoryBinaryWriter w;
+    w.writeF32(3.14159f);
+    w.writeF32(-0.0f);
+    w.writeF32(std::numeric_limits<float>::infinity());
+    w.writeF64(2.718281828459045);
+    w.writeF64(std::numeric_limits<double>::lowest());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    EXPECT_FLOAT_EQ(r.readF32().value_, 3.14159f);
+    // -0.0 vs 0.0: compare bit patterns.
+    float zero = r.readF32().value_;
+    EXPECT_EQ(std::signbit(zero), 1);
+    EXPECT_EQ(zero, 0.0f);
+    EXPECT_TRUE(std::isinf(r.readF32().value_));
+    EXPECT_DOUBLE_EQ(r.readF64().value_, 2.718281828459045);
+    EXPECT_DOUBLE_EQ(r.readF64().value_, std::numeric_limits<double>::lowest());
+}
+
+TEST(BinaryIO, RoundTripLittleEndianBytePattern) {
+    // Independent-of-host: the on-disk bytes for 0xDEADBEEF in little-endian
+    // are EF BE AD DE. Verify the writer produces that exact pattern.
+    MemoryBinaryWriter w;
+    w.writeU32(0xDEADBEEFu);
+    ASSERT_EQ(w.buffer().size(), 4u);
+    EXPECT_EQ(w.buffer()[0], 0xEFu);
+    EXPECT_EQ(w.buffer()[1], 0xBEu);
+    EXPECT_EQ(w.buffer()[2], 0xADu);
+    EXPECT_EQ(w.buffer()[3], 0xDEu);
+}
+
+TEST(BinaryIO, VarUIntEdgeCases) {
+    struct Case {
+        std::uint64_t value_;
+        std::size_t expectedBytes_;
+    };
+    const Case cases[] = {
+        {0, 1},
+        {1, 1},
+        {127, 1},
+        {128, 2},
+        {16383, 2},
+        {16384, 3},
+        {std::numeric_limits<std::uint32_t>::max(), 5},
+        {std::numeric_limits<std::uint64_t>::max(), 10},
+    };
+    for (const auto &c : cases) {
+        MemoryBinaryWriter w;
+        w.writeVarUInt(c.value_);
+        EXPECT_EQ(w.buffer().size(), c.expectedBytes_) << "value=" << c.value_;
+        MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+        auto got = r.readVarUInt();
+        ASSERT_TRUE(got.ok()) << got.status_.message_;
+        EXPECT_EQ(got.value_, c.value_);
+        EXPECT_EQ(r.remaining(), 0u);
+    }
+}
+
+TEST(BinaryIO, VarUIntWithNoTerminatorErrors) {
+    // 11 bytes all with continuation bit set — never terminates.
+    std::vector<std::uint8_t> bad(11, 0xFF);
+    MemoryBinaryReader r(bad.data(), bad.size());
+    auto got = r.readVarUInt();
+    EXPECT_FALSE(got.ok());
+    EXPECT_EQ(got.status_.code_, BinaryIOError::InvalidVarUInt);
+}
+
+TEST(BinaryIO, RoundTripStrings) {
+    MemoryBinaryWriter w;
+    w.writeString("");
+    w.writeString("hello");
+    w.writeString("UTF-8: café — emoji 🦀 — newline\nand tab\there");
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto a = r.readString();
+    auto b = r.readString();
+    auto c = r.readString();
+    ASSERT_TRUE(a.ok());
+    ASSERT_TRUE(b.ok());
+    ASSERT_TRUE(c.ok());
+    EXPECT_EQ(a.value_, "");
+    EXPECT_EQ(b.value_, "hello");
+    EXPECT_EQ(c.value_, "UTF-8: café — emoji 🦀 — newline\nand tab\there");
+}
+
+TEST(BinaryIO, ReadTruncated) {
+    std::vector<std::uint8_t> buf = {0x01, 0x02};
+    MemoryBinaryReader r(buf.data(), buf.size());
+    EXPECT_TRUE(r.readU8().ok());
+    auto u32 = r.readU32(); // only 1 byte left
+    EXPECT_FALSE(u32.ok());
+    EXPECT_EQ(u32.status_.code_, BinaryIOError::Truncated);
+}
+
+TEST(BinaryIO, StringLengthExceedsBufferReturnsInvalid) {
+    // Write a varuint length of 100 then no body.
+    MemoryBinaryWriter w;
+    w.writeVarUInt(100);
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto s = r.readString();
+    EXPECT_FALSE(s.ok());
+    EXPECT_EQ(s.status_.code_, BinaryIOError::InvalidString);
+}
+
+TEST(BinaryIO, FileBackendRoundTrip) {
+    const std::string path = kTmpDir + "/ir_test_binary_io_file.bin";
+    {
+        FileBinaryWriter w(path);
+        ASSERT_TRUE(w.ok());
+        w.writeU32(0xCAFEBABEu);
+        w.writeString("trixel");
+        w.writeF64(1.5);
+    }
+    {
+        FileBinaryReader r(path);
+        ASSERT_TRUE(r.ok());
+        EXPECT_EQ(r.readU32().value_, 0xCAFEBABEu);
+        EXPECT_EQ(r.readString().value_, "trixel");
+        EXPECT_DOUBLE_EQ(r.readF64().value_, 1.5);
+    }
+    std::remove(path.c_str());
+}
+
+// ---- Chunk header tests -------------------------------------------------
+
+TEST(ChunkHeader, RoundTripWithMultipleChunks) {
+    const auto magic = makeTag("IRVS");
+    std::vector<std::uint8_t> bndsData = {0x10, 0x20, 0x30};
+    std::vector<std::uint8_t> voxrData = {0xAA, 0xBB, 0xCC, 0xDD};
+    std::vector<ChunkPayload> chunks = {
+        {makeTag("BNDS"), bndsData},
+        {makeTag("VOXR"), voxrData},
+    };
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, magic, 1, chunks).ok());
+
+    // Header (12 bytes) + 2 entries (40 bytes each = 80 bytes total
+    // for chunkCount=2... wait: 4+8+8 = 20 each) + body.
+    // Expected total = 12 + 2*20 + 3 + 4 = 59.
+    EXPECT_EQ(w.buffer().size(), 12u + 2u * 20u + 3u + 4u);
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    AssetHeader header;
+    auto chunksR = readChunks(r, magic, 1, &header);
+    ASSERT_TRUE(chunksR.ok()) << chunksR.status_.message_;
+    ASSERT_EQ(chunksR.value_.size(), 2u);
+    EXPECT_EQ(header.version_, 1u);
+    EXPECT_EQ(header.chunkCount_, 2u);
+    EXPECT_EQ(chunksR.value_[0].data_, bndsData);
+    EXPECT_EQ(chunksR.value_[1].data_, voxrData);
+
+    auto *bnds = findChunk(chunksR.value_, makeTag("BNDS"));
+    auto *voxr = findChunk(chunksR.value_, makeTag("VOXR"));
+    auto *miss = findChunk(chunksR.value_, makeTag("MISS"));
+    ASSERT_NE(bnds, nullptr);
+    ASSERT_NE(voxr, nullptr);
+    EXPECT_EQ(miss, nullptr);
+    EXPECT_EQ(bnds->data_, bndsData);
+}
+
+TEST(ChunkHeader, BadMagicReturnsError) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, makeTag("WRNG"), 1, {}).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto chunksR = readChunks(r, makeTag("IRVS"), 1);
+    EXPECT_FALSE(chunksR.ok());
+    EXPECT_EQ(chunksR.status_.code_, BinaryIOError::BadMagic);
+}
+
+TEST(ChunkHeader, VersionTooNewReturnsError) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, makeTag("IRVS"), 99, {}).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto chunksR = readChunks(r, makeTag("IRVS"), 1);
+    EXPECT_FALSE(chunksR.ok());
+    EXPECT_EQ(chunksR.status_.code_, BinaryIOError::VersionTooNew);
+}
+
+TEST(ChunkHeader, TruncatedHeaderReturnsTruncated) {
+    std::vector<std::uint8_t> tiny = {'I', 'R', 'V', 'S'}; // only magic, no version/count
+    MemoryBinaryReader r(tiny.data(), tiny.size());
+    auto chunksR = readChunks(r, makeTag("IRVS"), 1);
+    EXPECT_FALSE(chunksR.ok());
+    EXPECT_EQ(chunksR.status_.code_, BinaryIOError::Truncated);
+}
+
+TEST(ChunkHeader, UnknownChunkTagSurvivesAsRawBytes) {
+    // Save written by a future build with a new chunk tag the current
+    // loader doesn't know. The reader must still produce the bytes so
+    // the caller can skip-without-erroring (Extensibility Rule #1).
+    std::vector<std::uint8_t> futureData = {0xDE, 0xAD};
+    std::vector<ChunkPayload> chunks = {
+        {makeTag("KNWN"), {0x01, 0x02}},
+        {makeTag("NEWX"), futureData}, // hypothetical future chunk
+    };
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, makeTag("IRVS"), 1, chunks).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto chunksR = readChunks(r, makeTag("IRVS"), 1);
+    ASSERT_TRUE(chunksR.ok());
+    // Older loader walks all chunks, processes KNWN, surfaces NEWX as-is.
+    const LoadedChunk *unknown = findChunk(chunksR.value_, makeTag("NEWX"));
+    ASSERT_NE(unknown, nullptr);
+    EXPECT_EQ(unknown->data_, futureData);
+}
+
+TEST(ChunkHeader, ChunkTableOffsetOutOfBoundsRejected) {
+    // Hand-craft a file with a chunk offset past EOF.
+    MemoryBinaryWriter w;
+    const auto magic = makeTag("IRVS");
+    w.writeBytes(magic.data(), 4);
+    w.writeU32(1); // version
+    w.writeU32(1); // chunkCount
+    w.writeBytes(makeTag("BNDS").data(), 4);
+    w.writeU64(9999); // offset past EOF
+    w.writeU64(10);   // size
+    // No body — chunk offset+size would exceed buffer.
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto chunksR = readChunks(r, magic, 1);
+    EXPECT_FALSE(chunksR.ok());
+    EXPECT_EQ(chunksR.status_.code_, BinaryIOError::ChunkOutOfBounds);
+}
+
+TEST(ChunkHeader, EmptyChunksRoundTrip) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, makeTag("EMPT"), 1, {}).ok());
+    EXPECT_EQ(w.buffer().size(), 12u);
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto chunksR = readChunks(r, makeTag("EMPT"), 1);
+    ASSERT_TRUE(chunksR.ok());
+    EXPECT_TRUE(chunksR.value_.empty());
+}
+
+// ---- Name table tests --------------------------------------------------
+
+TEST(NameTable, RoundTrip) {
+    std::vector<NameTableEntry> entries = {
+        {0, "SPHERE"},
+        {1, "CUBE"},
+        {7, "CYLINDER"},
+        {12, "TORUS_KNOT"}, // future enum value
+    };
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), entries.size());
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+        EXPECT_EQ(loaded.value_[i].id_, entries[i].id_);
+        EXPECT_EQ(loaded.value_[i].name_, entries[i].name_);
+    }
+}
+
+TEST(NameTable, BidirectionalLookup) {
+    NameTable nt;
+    nt.add(0, "SPHERE");
+    nt.add(1, "CUBE");
+    nt.add(7, "CYLINDER");
+
+    EXPECT_EQ(nt.idByName("CUBE").value(), 1u);
+    EXPECT_EQ(nt.idByName("CYLINDER").value(), 7u);
+    EXPECT_FALSE(nt.idByName("TORUS_KNOT").has_value());
+
+    EXPECT_EQ(nt.nameById(0).value(), "SPHERE");
+    EXPECT_EQ(nt.nameById(7).value(), "CYLINDER");
+    EXPECT_FALSE(nt.nameById(99).has_value());
+}
+
+TEST(NameTable, UnknownIdSurfacesAsLookupMiss) {
+    // Saved by a future build with shape id 12. Current build's enum has
+    // only 0..1. After load, the consumer prefers name→current_enum lookup;
+    // when both name and id are unknown, the consumer skips the entry.
+    std::vector<NameTableEntry> entries = {{12, "TORUS_KNOT"}};
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    NameTable nt(loaded.value_);
+
+    // Consumer-side build knows SPHERE=0, CUBE=1. Look up TORUS_KNOT → not in
+    // the consumer's enum, so the loader logs "unknown shape, skipped" — but
+    // the disk-side name table still contains it for diagnostics.
+    EXPECT_EQ(nt.nameById(12).value(), "TORUS_KNOT");
+    EXPECT_FALSE(nt.idByName("SPHERE").has_value()); // not in this disk table
+}
+
+TEST(NameTable, EmptyTableRoundTrip) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, {}).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_TRUE(loaded.value_.empty());
+}
+
+// ---- JSON sidecar tests ------------------------------------------------
+
+TEST(JsonSidecar, FlatObject) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("version");
+    j.valueInt(1);
+    j.key("name");
+    j.valueString("torus");
+    j.key("count");
+    j.valueUInt(42);
+    j.endObject();
+
+    const std::string out = j.str();
+    // Pretty-printed but structural: contains keys and types.
+    EXPECT_NE(out.find("\"version\": 1"), std::string::npos);
+    EXPECT_NE(out.find("\"name\": \"torus\""), std::string::npos);
+    EXPECT_NE(out.find("\"count\": 42"), std::string::npos);
+    EXPECT_EQ(out.front(), '{');
+    EXPECT_EQ(out.back(), '}');
+}
+
+TEST(JsonSidecar, NestedObjectsAndArrays) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("voxels");
+    j.beginArray();
+    j.beginObject();
+    j.key("xyz");
+    j.beginArray();
+    j.valueInt(0);
+    j.valueInt(1);
+    j.valueInt(2);
+    j.endArray();
+    j.key("color");
+    j.valueString("#ff8800");
+    j.endObject();
+    j.endArray();
+    j.endObject();
+
+    const std::string out = j.str();
+    // Just make sure brackets nest correctly and key/value pairs appear.
+    EXPECT_NE(out.find("\"voxels\""), std::string::npos);
+    EXPECT_NE(out.find("\"xyz\""), std::string::npos);
+    EXPECT_NE(out.find("[\n"), std::string::npos);
+    EXPECT_NE(out.find("\"#ff8800\""), std::string::npos);
+}
+
+TEST(JsonSidecar, StringEscaping) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("path");
+    j.valueString("C:\\foo\\bar");
+    j.key("notes");
+    j.valueString("line1\nline2\ttab\"quote");
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("\"C:\\\\foo\\\\bar\""), std::string::npos);
+    EXPECT_NE(out.find("\\n"), std::string::npos);
+    EXPECT_NE(out.find("\\t"), std::string::npos);
+    EXPECT_NE(out.find("\\\""), std::string::npos);
+}
+
+TEST(JsonSidecar, BoolNullFloat) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("enabled");
+    j.valueBool(true);
+    j.key("disabled");
+    j.valueBool(false);
+    j.key("missing");
+    j.valueNull();
+    j.key("ratio");
+    j.valueFloat(0.5);
+    j.key("nan");
+    j.valueFloat(std::nan(""));
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("\"enabled\": true"), std::string::npos);
+    EXPECT_NE(out.find("\"disabled\": false"), std::string::npos);
+    EXPECT_NE(out.find("\"missing\": null"), std::string::npos);
+    EXPECT_NE(out.find("\"ratio\": 0.5"), std::string::npos);
+    // NaN emits as null per the implementation.
+    EXPECT_NE(out.find("\"nan\": null"), std::string::npos);
+}
+
+TEST(JsonSidecar, WriteToFile) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("v");
+    j.valueInt(1);
+    j.endObject();
+    const std::string path = kTmpDir + "/ir_test_json_sidecar.json";
+    ASSERT_TRUE(writeJsonSidecarToFile(path, j.str()));
+    std::FILE *f = std::fopen(path.c_str(), "rb");
+    ASSERT_NE(f, nullptr);
+    char buf[64];
+    const std::size_t n = std::fread(buf, 1, sizeof(buf) - 1, f);
+    std::fclose(f);
+    buf[n] = '\0';
+    EXPECT_NE(std::strstr(buf, "\"v\": 1"), nullptr);
+    std::remove(path.c_str());
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Foundation for the editor-epic asset-format work. Adds shared binary
I/O primitives in `engine/asset/` so every upcoming binary format
(`.vxs`, `.rig`, ECS world snapshot, future formats) has one place
to consume rather than each new format hand-rolling `fread`/`fwrite`
+ its own magic-bytes discipline.

- **`binary_io.{hpp,cpp}`** — `BinaryWriter` / `BinaryReader`
  abstract sinks with file + in-memory backends. Little-endian
  fixed-width integers, IEEE 754 floats, ULEB128 varuints,
  length-prefixed strings. Reads return `Result<T>` with typed
  `status_` / `value_` so a truncated file or malformed varint
  surfaces as a recoverable diagnostic (path + offset), not a
  crash — Extensibility Rule #5.
- **`chunk_header.{hpp,cpp}`** — 12-byte `AssetHeader` (magic +
  version + chunkCount) + chunk table of `{ tag, offset, size }`
  entries. `writeChunked()` computes offsets and writes header +
  table + bodies in one pass; `readChunks()` validates magic +
  max-known-version and surfaces unknown chunk tags as raw bytes so
  older loaders silently skip them — Extensibility Rule #1.
- **`name_table.{hpp,cpp}`** — `(uint32 id, string name)` pairs
  serialized as a chunk body; `NameTable` helper for bidirectional
  lookup. Supports Extensibility Rule #2: prefer name → current
  enum, fall back to id only when the name table is absent.
- **`json_sidecar.{hpp,cpp}`** — stdlib-only write-only JSON
  emitter. No third-party dep, no read side (Extensibility Rule #6
  — sidecars regenerate from the binary on every save, ignored on
  load).
- **`engine/asset/CLAUDE.md`** — documents the four new headers as
  the module contract and inlines the seven Save Format
  Extensibility Rules (long-form home stays in
  `docs/design/entity-editor-epic.md`).

No functional consumer in this PR. T-167 (`.vxs` dense), T-168
(`.vxs` shape-group), T-169 (`.rig`), and the ECS world snapshot
in `engine/world/` are the first consumers.

## Test plan

- [x] `fleet-build --target IrredenEngineAsset` — clean on macOS
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] 25 new tests in `test/asset/binary_io_test.cpp`:
  - Round-trip integer/float primitives + verified little-endian
    byte pattern (`0xDEADBEEF` → `EF BE AD DE`)
  - Varuint edge cases: 0, 127, 128, u32 max, u64 max, no-terminator
  - Length-prefixed string round-trip (incl. UTF-8 / emoji / control
    chars) + invalid-length rejection
  - Truncated reads, bad magic, version-too-new
  - Unknown-chunk-tag survives as raw bytes (Rule #1)
  - Chunk-table out-of-bounds offset rejected
  - Name-table round-trip + bidirectional lookup +
    unknown-id passthrough (Rule #2)
  - JSON: flat object, nested object/array, string escaping
    (`"`, `\`, `\n`, `\t`, control chars), bool/null/float, NaN
    sanitization, file write
- [x] Full `IrredenEngineTest` suite: **519/519 pass**

## Notes for reviewer

- Result wrapper uses trailing-underscore public members
  (`status_`, `value_`) per the engine naming convention.
- `kAssetHeaderSize` / `kChunkTableEntrySize` are explicit byte
  constants — `sizeof(AssetHeader)` would include compiler-dependent
  padding.
- The detail-namespace endianness helpers in `binary_io.cpp` are
  byte-shift based, host-byte-order agnostic (no `__builtin_bswap`
  or memcpy-of-bytes-reversed shortcuts), so they're safe on
  big-endian even though the engine doesn't target any today.
- `JsonSidecarWriter` emits `null` for NaN/Inf with a log warning
  rather than producing invalid JSON.

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)