### PR TITLE
T-168: asset: .vxs v1 shape-group save format (SHPG, SREF, MODE chunks)

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -47,6 +47,10 @@ snapshot (issue #199). It walks the archetype graph, so it lives in
   `loadTrixelTextureData(...)` — trixel binary round-trip.
 - `saveSpriteSheetMeta(name, path, meta)` /
   `loadSpriteSheetMeta(name, path)` — sidecar text round-trip.
+- `saveShapeGroup(path, span<ShapeRecord>)` / `loadShapeGroup(path)` —
+  `.vxs` SHAPES-mode SDF primitive composition round-trip. See
+  `voxel_set_format.hpp` for record layout and the
+  "How to add a new SDF primitive" walkthrough below.
 
 The `name` is embedded in the trixel file header; the `path` is the
 output directory. For sprite sheets, `name` is the basename shared
@@ -153,6 +157,85 @@ current build's enum values. **Extensibility Rule #2**: prefer
 table is absent, so a save written by a future build with a new
 `ShapeType` value loads on an older build as "unknown shape, skipped"
 — not "corrupt file."
+
+### `voxel_set_format.hpp` — `.vxs` voxel-set asset
+
+The voxel-set container holds three persistence modes — DENSE (per-voxel
+records, T-167), SHAPES (SDF composition, T-168), HYBRID (DENSE + SHAPES,
+T-668) — under one magic (`VXS1`) and one version (`kVoxelSetVersion = 1`).
+Magic + version together govern the **container**; per-record additive
+versioning (`kShapeRecordVersion`) covers field-level evolution inside
+records (Extensibility Rule #3).
+
+Container chunks:
+
+- `MODE` — 4-byte ASCII mode tag (`DENS` / `SHPS` / `HYBR`). Missing →
+  defaults to SHAPES (legacy single-mode files). Unknown tag → returns
+  `VoxelSetMode::UNKNOWN` with a logged warning; the caller decides
+  whether to refuse the asset or render what's parseable.
+- `SREF` — `ShapeType` id↔name table; `buildCurrentShapeTypeNameTable()`
+  emits the writer's view of the canonical enum so a future build's
+  save survives the read on an older build (name lookup misses → record
+  skipped, no failure).
+- `SHPG` — SHAPES-mode primitive records (`ShapeRecord` array). Records
+  with an unresolvable disk-side `ShapeType` are skipped and counted
+  in `unknownShapesSkipped_`.
+
+SHPG record layout (one per primitive):
+
+```
+uint32  shapeTypeId      // numeric; resolve via SREF name lookup
+uint16  recordVersion    // additive-only field evolution (Rule #3)
+float32 params[4]        // SDF parameters (semantics per ShapeType)
+uint32  packedRGBA       // Color::toPackedRGBA()
+uint32  flags            // IRRender::ShapeFlags bit field
+uint8   boneId           // joint binding (T-146 / T-169); 0 = none
+float32 offset[3]        // local translation
+float32 rotation[4]      // quaternion (x, y, z, w)
+uint8   csgOp            // CsgOp: NONE | UNION | SMOOTH_UNION | SUBTRACT | INTERSECT
+```
+
+High-level entry points:
+
+- `saveShapeGroup(path, span<ShapeRecord>)` — writes MODE=SHAPES, SREF,
+  SHPG chunks under the `VXS1` header.
+- `loadShapeGroup(path)` — returns `VoxelSetFile { mode_, shapeRecords_,
+  unknownShapesSkipped_ }` after resolving SREF and SHPG. Container
+  errors (`BadMagic`, `VersionTooNew`, truncation, chunk-out-of-bounds)
+  surface as `BinaryIOError` results.
+
+For callers working with `C_ShapeDescriptor`, the prefab-side adapter at
+`engine/prefabs/irreden/asset/voxel_set_io.hpp` (`#include
+<irreden/asset/voxel_set_io.hpp>`) exposes
+`IRAsset::saveVoxelSet(span<const C_ShapeDescriptor>, ...)` with parallel
+offset / rotation / csgOp / boneId arrays — the per-entity composition
+metadata `C_ShapeDescriptor` does not itself carry. The adapter lives in
+prefabs to keep `engine/asset/` from depending on the component layer.
+
+#### How to add a new SDF primitive
+
+Adding a new shape that participates in `.vxs` shape-group saves is
+designed to require **no format change**:
+
+1. Append the new enum value to `IRMath::SDF::ShapeType` in
+   `engine/math/include/irreden/math/sdf.hpp` (e.g. `TORUS_KNOT = 10`).
+2. Append the corresponding `(id, name)` pair to the `kShapeTypeTable`
+   constant in `engine/asset/src/voxel_set_format.cpp`. The name string
+   is the disk-side identity; older builds use it to recognize the new
+   type via SREF name-lookup, drop a "unknown shape, skipped" warning,
+   and load the rest of the asset cleanly.
+3. Add the SDF evaluator: a new `inline float yourShape(vec3 p, ...)`
+   in `sdf.hpp`, a new `IRMath::SDF::ShapeType` dispatch case in
+   `IRMath::SDF::evaluate` / `boundingHalf`, and matching GLSL +
+   Metal implementations under `engine/render/src/shaders/`. The
+   trixel pipeline (`SHAPES_TO_TRIXEL`) picks it up automatically once
+   the dispatch tables route to your evaluator.
+
+Steps 1 + 2 + the shader pair are sufficient for an old `.vxs` save to
+keep loading after a future build adds `TORUS_KNOT`. The format version
+stays at `1`; the per-record `recordVersion_` field is the lever for
+future field additions inside the record itself (Rule #3 — append +
+bump + default the new field in the older-build load path).
 
 ### `json_sidecar.hpp` — write-only JSON emitter
 

--- a/engine/asset/CMakeLists.txt
+++ b/engine/asset/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(IrredenEngineAsset STATIC
     src/chunk_header.cpp
     src/name_table.cpp
     src/json_sidecar.cpp
+    src/voxel_set_format.cpp
 )
 
 target_compile_options(

--- a/engine/asset/include/irreden/asset/voxel_set_format.hpp
+++ b/engine/asset/include/irreden/asset/voxel_set_format.hpp
@@ -1,0 +1,204 @@
+#ifndef IR_ASSET_VOXEL_SET_FORMAT_H
+#define IR_ASSET_VOXEL_SET_FORMAT_H
+
+/// `.vxs` v1 voxel-set asset format. Two coexisting persistence modes
+/// share one container:
+///
+/// - **SHAPES** (this header, T-168 / #665) — composition of SDF
+///   primitive instances; rendered directly by `SHAPES_TO_TRIXEL` with
+///   no voxel pool allocation.
+/// - **DENSE** (T-167 / #664) — bounded 3D voxel grid with per-voxel
+///   records.
+/// - **HYBRID** (T-668) — DENSE base plus SHAPES overrides.
+///
+/// On-disk container layout (built on `chunk_header.hpp`):
+///
+///     AssetHeader            { 'V', 'X', 'S', '1' | version | chunkCount }
+///     ChunkTableEntry[]      one entry per chunk below
+///     MODE chunk             4-byte mode tag (DENS | SHPS | HYBR)
+///     SREF chunk             name-table for `IRMath::SDF::ShapeType`
+///     SHPG chunk             shape-group primitive records (SHAPES mode)
+///     [BNDS | VOXR | LAYR | FRAM | META chunks added by T-167 for DENSE]
+///
+/// Order in the chunk table is not load-bearing (Save Format Extensibility
+/// Rule #1). A reader skips chunks it doesn't know without erroring; the
+/// engine version drops to "older build receiving a future save" handling
+/// when an unknown chunk tag, mode tag, or `ShapeType` id appears.
+///
+/// SHPG chunk body (one record per primitive instance):
+///
+///     varuint  shapeCount
+///     repeat shapeCount times:
+///       uint32  shapeTypeId        // numeric id from disk; cross-reference
+///                                  // SREF to map to the current build's enum
+///       uint16  recordVersion      // per-record additive-only versioning
+///                                  // (Rule #3); v1 fields fixed below
+///       float32 params[4]          // SDF parameter vector
+///       uint32  packedRGBA         // `Color::toPackedRGBA()` packing
+///       uint32  flags              // `IRRender::ShapeFlags` bit field
+///       uint8   boneId             // joint binding (T-146/T-169); 0 = none
+///       float32 offset[3]          // local translation
+///       float32 rotation[4]        // quaternion (x, y, z, w)
+///       uint8   csgOp              // `CsgOp` (see below)
+///
+/// `IRMath::SDF::ShapeType` values that resolve via name on load become
+/// the current-build numeric id; unknown names/ids surface as
+/// `unknownShapesSkipped_` and the rest of the asset loads cleanly.
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/name_table.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace IRAsset {
+
+using IRMath::Color;
+using IRMath::vec3;
+using IRMath::vec4;
+
+constexpr std::array<char, 4> kVoxelSetMagic = {'V', 'X', 'S', '1'};
+constexpr std::uint32_t kVoxelSetVersion = 1;
+
+constexpr std::array<char, 4> kChunkTagMode = {'M', 'O', 'D', 'E'};
+constexpr std::array<char, 4> kChunkTagShapeRefs = {'S', 'R', 'E', 'F'};
+constexpr std::array<char, 4> kChunkTagShapeGroup = {'S', 'H', 'P', 'G'};
+
+/// 4-byte ASCII tag stored as the MODE chunk body. Adding a future
+/// mode is a new constant + a new branch in `readModeChunk`; older
+/// builds receiving the new tag return `Unknown` and the caller falls
+/// back to "skip body chunks for modes I don't recognize."
+constexpr std::array<char, 4> kModeTagDense = {'D', 'E', 'N', 'S'};
+constexpr std::array<char, 4> kModeTagShapes = {'S', 'H', 'P', 'S'};
+constexpr std::array<char, 4> kModeTagHybrid = {'H', 'Y', 'B', 'R'};
+
+enum class VoxelSetMode : std::uint8_t {
+    DENSE = 0,
+    SHAPES = 1,
+    HYBRID = 2,
+    UNKNOWN = 255, ///< Set when the on-disk mode tag isn't in the table.
+};
+
+/// Per-instance composition operator inside a shape group. NONE means
+/// "render this primitive standalone"; the others form a flat
+/// composition tree against the running accumulator in evaluation order.
+/// Tree-shaped CSG would land in a separate `SHPT` chunk later without
+/// bumping the file version.
+enum class CsgOp : std::uint8_t {
+    NONE = 0,
+    UNION = 1,
+    SMOOTH_UNION = 2,
+    SUBTRACT = 3,
+    INTERSECT = 4,
+};
+
+/// v1 SHPG record layout version. Bump per Rule #3 when fields are
+/// added; older loaders default the appended fields. Removed/renamed
+/// fields need an explicit migration keyed by `(recordType, oldVersion)`.
+constexpr std::uint16_t kShapeRecordVersion = 1;
+
+/// One persisted SDF primitive instance. Mirrors `C_ShapeDescriptor`'s
+/// on-screen fields plus the composition metadata (`offset_`,
+/// `rotation_`, `boneId_`, `csgOp_`) the runtime caller decides whether
+/// to map onto separate components or fold into the descriptor itself.
+struct ShapeRecord {
+    /// Numeric id read from the SHPG chunk. After `readShapeGroupChunk`
+    /// resolves the SREF name table, this holds the **current build's**
+    /// `IRMath::SDF::ShapeType` value; the on-disk id is dropped once
+    /// the mapping succeeds.
+    std::uint32_t shapeTypeId_ = 0;
+    std::uint16_t recordVersion_ = kShapeRecordVersion;
+    vec4 params_ = vec4(1.0f);
+    Color color_ = Color{255, 255, 255, 255};
+    std::uint32_t flags_ = 0;
+    std::uint8_t boneId_ = 0;
+    vec3 offset_ = vec3(0.0f);
+    /// Quaternion (x, y, z, w). Default is identity.
+    vec4 rotation_ = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+    CsgOp csgOp_ = CsgOp::NONE;
+};
+
+// ---- MODE chunk --------------------------------------------------------
+
+/// Build a MODE chunk payload from a known mode. `VoxelSetMode::UNKNOWN`
+/// is rejected (returns an empty payload with a log) — callers should
+/// never persist an unknown mode.
+ChunkPayload makeModeChunk(VoxelSetMode mode);
+
+/// Inspect the chunk list for a MODE chunk. Missing chunk → returns
+/// `SHAPES` (legacy default — the only writer in v1.0 emits shape
+/// groups). Unknown tag → returns `UNKNOWN` with a one-line log.
+VoxelSetMode readModeChunk(std::span<const LoadedChunk> chunks);
+
+// ---- SREF chunk --------------------------------------------------------
+
+/// Build a SREF chunk payload from `(id, name)` pairs covering every
+/// `IRMath::SDF::ShapeType` value the writer's build knows about.
+ChunkPayload makeShapeRefsChunk(std::span<const NameTableEntry> entries);
+
+/// Convenience: emit the SREF entries for the **current build's**
+/// `IRMath::SDF::ShapeType` enum. Add to this list whenever the enum
+/// gains a value.
+std::vector<NameTableEntry> buildCurrentShapeTypeNameTable();
+
+/// Parse a SREF chunk body.
+Result<std::vector<NameTableEntry>> readShapeRefsChunk(std::span<const std::uint8_t> body);
+
+// ---- SHPG chunk --------------------------------------------------------
+
+/// Serialize @p records to a SHPG chunk body.
+ChunkPayload makeShapeGroupChunk(std::span<const ShapeRecord> records);
+
+/// One read result: the records the loader could resolve, plus the
+/// count of records dropped because their disk-side `ShapeType` id /
+/// name resolves to nothing in the current build. The skip count is
+/// surfaced for diagnostics (Rule #5: unknown is recoverable).
+struct ShapeGroupLoadResult {
+    std::vector<ShapeRecord> records_;
+    std::size_t unknownShapesSkipped_ = 0;
+};
+
+/// Parse a SHPG chunk body. @p diskShapeTypes maps disk-side ids to
+/// names (built from the file's SREF chunk). A record whose disk id
+/// resolves to a name absent from `buildCurrentShapeTypeNameTable()`
+/// is dropped and counted in `unknownShapesSkipped_`. If
+/// @p diskShapeTypes is empty, the disk-side numeric id is taken
+/// verbatim (legacy save with no SREF chunk).
+Result<ShapeGroupLoadResult> readShapeGroupChunk(
+    std::span<const std::uint8_t> body,
+    const NameTable &diskShapeTypes
+);
+
+// ---- High-level save/load ----------------------------------------------
+
+/// Save a shape-group `.vxs` asset to @p path. Writes MODE=SHAPES,
+/// SREF, and SHPG chunks. Returns the writer's failure state.
+BinaryStatus saveShapeGroup(const std::string &path, std::span<const ShapeRecord> records);
+
+/// Loader-side view of a shape-group `.vxs` file.
+struct VoxelSetFile {
+    VoxelSetMode mode_ = VoxelSetMode::UNKNOWN;
+    std::vector<ShapeRecord> shapeRecords_;
+    std::size_t unknownShapesSkipped_ = 0;
+};
+
+/// Load a shape-group `.vxs` asset from @p path. Returns:
+/// - `BadMagic` if magic isn't `VXS1`
+/// - `VersionTooNew` if file version > `kVoxelSetVersion`
+/// - underlying primitive error for truncated / out-of-bounds chunks
+/// - `ShapeGroupLoadResult` populated with resolved records and the
+///   count of dropped unknowns otherwise.
+///
+/// Mode-aware: DENSE/HYBRID chunks present in a future save are
+/// surfaced through `mode_` but their record arrays are empty for v1
+/// (loaders for those modes land in T-167/T-668).
+Result<VoxelSetFile> loadShapeGroup(const std::string &path);
+
+} // namespace IRAsset
+
+#endif /* IR_ASSET_VOXEL_SET_FORMAT_H */

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -2,7 +2,6 @@
 
 #include <irreden/ir_profile.hpp>
 
-#include <cstring>
 #include <utility>
 
 namespace IRAsset {
@@ -105,10 +104,11 @@ ChunkPayload makeModeChunk(VoxelSetMode mode) {
         IRE_LOG_ERROR("makeModeChunk: refusing to persist VoxelSetMode::UNKNOWN");
         return ChunkPayload{kChunkTagMode, {}};
     }
+    MemoryBinaryWriter w;
+    w.writeBytes(tag.data(), tag.size());
     ChunkPayload out;
     out.tag_ = kChunkTagMode;
-    out.data_.resize(4);
-    std::memcpy(out.data_.data(), tag.data(), 4);
+    out.data_ = w.takeBuffer();
     return out;
 }
 
@@ -122,7 +122,8 @@ VoxelSetMode readModeChunk(std::span<const LoadedChunk> chunks) {
         return VoxelSetMode::UNKNOWN;
     }
     std::array<char, 4> tag{};
-    std::memcpy(tag.data(), mode->data_.data(), 4);
+    MemoryBinaryReader r(mode->data_.data(), 4, "<MODE chunk>");
+    r.readBytes(tag.data(), 4);
     if (tagsEqual(tag, kModeTagDense))
         return VoxelSetMode::DENSE;
     if (tagsEqual(tag, kModeTagShapes))
@@ -184,10 +185,8 @@ ChunkPayload makeShapeGroupChunk(std::span<const ShapeRecord> records) {
     return out;
 }
 
-Result<ShapeGroupLoadResult> readShapeGroupChunk(
-    std::span<const std::uint8_t> body,
-    const NameTable &diskShapeTypes
-) {
+Result<ShapeGroupLoadResult>
+readShapeGroupChunk(std::span<const std::uint8_t> body, const NameTable &diskShapeTypes) {
     MemoryBinaryReader r(body.data(), body.size(), "<SHPG chunk>");
     auto countR = r.readVarUInt();
     if (!countR.ok()) {
@@ -200,9 +199,7 @@ Result<ShapeGroupLoadResult> readShapeGroupChunk(
     // claiming billions of records doesn't pre-allocate that much.
     const std::uint64_t cap = r.remaining();
     ShapeGroupLoadResult out;
-    out.records_.reserve(
-        static_cast<std::size_t>(countR.value_ < cap ? countR.value_ : cap)
-    );
+    out.records_.reserve(static_cast<std::size_t>(countR.value_ < cap ? countR.value_ : cap));
 
     NameTable currentTable(buildCurrentShapeTypeNameTable());
 

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -1,0 +1,380 @@
+#include <irreden/asset/voxel_set_format.hpp>
+
+#include <irreden/ir_profile.hpp>
+
+#include <cstring>
+#include <utility>
+
+namespace IRAsset {
+
+namespace {
+
+void writeColorPacked(BinaryWriter &w, Color color) {
+    w.writeU32(color.toPackedRGBA());
+}
+
+Color unpackColor(std::uint32_t packed) {
+    return Color{
+        static_cast<std::uint8_t>(packed & 0xFFu),
+        static_cast<std::uint8_t>((packed >> 8) & 0xFFu),
+        static_cast<std::uint8_t>((packed >> 16) & 0xFFu),
+        static_cast<std::uint8_t>((packed >> 24) & 0xFFu),
+    };
+}
+
+void writeVec3(BinaryWriter &w, const vec3 &v) {
+    w.writeF32(v.x);
+    w.writeF32(v.y);
+    w.writeF32(v.z);
+}
+
+void writeVec4(BinaryWriter &w, const vec4 &v) {
+    w.writeF32(v.x);
+    w.writeF32(v.y);
+    w.writeF32(v.z);
+    w.writeF32(v.w);
+}
+
+Result<vec3> readVec3(BinaryReader &r) {
+    auto x = r.readF32();
+    if (!x.ok())
+        return Result<vec3>::error(x.status_.code_, std::move(x.status_.message_));
+    auto y = r.readF32();
+    if (!y.ok())
+        return Result<vec3>::error(y.status_.code_, std::move(y.status_.message_));
+    auto z = r.readF32();
+    if (!z.ok())
+        return Result<vec3>::error(z.status_.code_, std::move(z.status_.message_));
+    return Result<vec3>::success(vec3(x.value_, y.value_, z.value_));
+}
+
+Result<vec4> readVec4(BinaryReader &r) {
+    auto x = r.readF32();
+    if (!x.ok())
+        return Result<vec4>::error(x.status_.code_, std::move(x.status_.message_));
+    auto y = r.readF32();
+    if (!y.ok())
+        return Result<vec4>::error(y.status_.code_, std::move(y.status_.message_));
+    auto z = r.readF32();
+    if (!z.ok())
+        return Result<vec4>::error(z.status_.code_, std::move(z.status_.message_));
+    auto w = r.readF32();
+    if (!w.ok())
+        return Result<vec4>::error(w.status_.code_, std::move(w.status_.message_));
+    return Result<vec4>::success(vec4(x.value_, y.value_, z.value_, w.value_));
+}
+
+// Canonical (id, name) table for `IRMath::SDF::ShapeType`. Keep in
+// lockstep with the enum declaration. Adding a value here is the
+// "extends an enum across save format" step — older builds receiving
+// the new save look up by name, fail, and skip that record.
+struct ShapeTypeNameEntry {
+    std::uint32_t id_;
+    const char *name_;
+};
+constexpr ShapeTypeNameEntry kShapeTypeTable[] = {
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::BOX), "BOX"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE), "SPHERE"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::CYLINDER), "CYLINDER"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::ELLIPSOID), "ELLIPSOID"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::CURVED_PANEL), "CURVED_PANEL"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::WEDGE), "WEDGE"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::TAPERED_BOX), "TAPERED_BOX"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::CUSTOM_SDF), "CUSTOM_SDF"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::CONE), "CONE"},
+    {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::TORUS), "TORUS"},
+};
+
+} // namespace
+
+// ---- MODE chunk --------------------------------------------------------
+
+ChunkPayload makeModeChunk(VoxelSetMode mode) {
+    std::array<char, 4> tag{};
+    switch (mode) {
+    case VoxelSetMode::DENSE:
+        tag = kModeTagDense;
+        break;
+    case VoxelSetMode::SHAPES:
+        tag = kModeTagShapes;
+        break;
+    case VoxelSetMode::HYBRID:
+        tag = kModeTagHybrid;
+        break;
+    default:
+        IRE_LOG_ERROR("makeModeChunk: refusing to persist VoxelSetMode::UNKNOWN");
+        return ChunkPayload{kChunkTagMode, {}};
+    }
+    ChunkPayload out;
+    out.tag_ = kChunkTagMode;
+    out.data_.resize(4);
+    std::memcpy(out.data_.data(), tag.data(), 4);
+    return out;
+}
+
+VoxelSetMode readModeChunk(std::span<const LoadedChunk> chunks) {
+    const LoadedChunk *mode = findChunk(chunks, kChunkTagMode);
+    if (mode == nullptr) {
+        return VoxelSetMode::SHAPES;
+    }
+    if (mode->data_.size() < 4) {
+        IRE_LOG_ERROR("readModeChunk: MODE body is {} bytes, expected 4", mode->data_.size());
+        return VoxelSetMode::UNKNOWN;
+    }
+    std::array<char, 4> tag{};
+    std::memcpy(tag.data(), mode->data_.data(), 4);
+    if (tagsEqual(tag, kModeTagDense))
+        return VoxelSetMode::DENSE;
+    if (tagsEqual(tag, kModeTagShapes))
+        return VoxelSetMode::SHAPES;
+    if (tagsEqual(tag, kModeTagHybrid))
+        return VoxelSetMode::HYBRID;
+    IRE_LOG_WARN("readModeChunk: unknown mode tag '{}'", tagToString(tag));
+    return VoxelSetMode::UNKNOWN;
+}
+
+// ---- SREF chunk --------------------------------------------------------
+
+ChunkPayload makeShapeRefsChunk(std::span<const NameTableEntry> entries) {
+    MemoryBinaryWriter w;
+    const auto status = writeNameTable(w, entries);
+    if (!status.ok()) {
+        IRE_LOG_ERROR("makeShapeRefsChunk: writeNameTable failed: {}", status.message_);
+        return ChunkPayload{kChunkTagShapeRefs, {}};
+    }
+    ChunkPayload out;
+    out.tag_ = kChunkTagShapeRefs;
+    out.data_ = w.takeBuffer();
+    return out;
+}
+
+std::vector<NameTableEntry> buildCurrentShapeTypeNameTable() {
+    std::vector<NameTableEntry> out;
+    out.reserve(std::size(kShapeTypeTable));
+    for (const auto &e : kShapeTypeTable) {
+        out.push_back(NameTableEntry{e.id_, e.name_});
+    }
+    return out;
+}
+
+Result<std::vector<NameTableEntry>> readShapeRefsChunk(std::span<const std::uint8_t> body) {
+    MemoryBinaryReader r(body.data(), body.size(), "<SREF chunk>");
+    return readNameTable(r);
+}
+
+// ---- SHPG chunk --------------------------------------------------------
+
+ChunkPayload makeShapeGroupChunk(std::span<const ShapeRecord> records) {
+    MemoryBinaryWriter w;
+    w.writeVarUInt(static_cast<std::uint64_t>(records.size()));
+    for (const auto &r : records) {
+        w.writeU32(r.shapeTypeId_);
+        w.writeU16(r.recordVersion_);
+        writeVec4(w, r.params_);
+        writeColorPacked(w, r.color_);
+        w.writeU32(r.flags_);
+        w.writeU8(r.boneId_);
+        writeVec3(w, r.offset_);
+        writeVec4(w, r.rotation_);
+        w.writeU8(static_cast<std::uint8_t>(r.csgOp_));
+    }
+    ChunkPayload out;
+    out.tag_ = kChunkTagShapeGroup;
+    out.data_ = w.takeBuffer();
+    return out;
+}
+
+Result<ShapeGroupLoadResult> readShapeGroupChunk(
+    std::span<const std::uint8_t> body,
+    const NameTable &diskShapeTypes
+) {
+    MemoryBinaryReader r(body.data(), body.size(), "<SHPG chunk>");
+    auto countR = r.readVarUInt();
+    if (!countR.ok()) {
+        return Result<ShapeGroupLoadResult>::error(
+            countR.status_.code_,
+            std::move(countR.status_.message_)
+        );
+    }
+    // Cap the upfront reserve to remaining bytes so a corrupted count
+    // claiming billions of records doesn't pre-allocate that much.
+    const std::uint64_t cap = r.remaining();
+    ShapeGroupLoadResult out;
+    out.records_.reserve(
+        static_cast<std::size_t>(countR.value_ < cap ? countR.value_ : cap)
+    );
+
+    NameTable currentTable(buildCurrentShapeTypeNameTable());
+
+    for (std::uint64_t i = 0; i < countR.value_; ++i) {
+        ShapeRecord rec{};
+
+        auto typeIdR = r.readU32();
+        if (!typeIdR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                typeIdR.status_.code_,
+                std::move(typeIdR.status_.message_)
+            );
+        const std::uint32_t diskTypeId = typeIdR.value_;
+
+        auto verR = r.readU16();
+        if (!verR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                verR.status_.code_,
+                std::move(verR.status_.message_)
+            );
+        rec.recordVersion_ = verR.value_;
+
+        auto paramsR = readVec4(r);
+        if (!paramsR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                paramsR.status_.code_,
+                std::move(paramsR.status_.message_)
+            );
+        rec.params_ = paramsR.value_;
+
+        auto colorR = r.readU32();
+        if (!colorR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                colorR.status_.code_,
+                std::move(colorR.status_.message_)
+            );
+        rec.color_ = unpackColor(colorR.value_);
+
+        auto flagsR = r.readU32();
+        if (!flagsR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                flagsR.status_.code_,
+                std::move(flagsR.status_.message_)
+            );
+        rec.flags_ = flagsR.value_;
+
+        auto boneR = r.readU8();
+        if (!boneR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                boneR.status_.code_,
+                std::move(boneR.status_.message_)
+            );
+        rec.boneId_ = boneR.value_;
+
+        auto offsetR = readVec3(r);
+        if (!offsetR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                offsetR.status_.code_,
+                std::move(offsetR.status_.message_)
+            );
+        rec.offset_ = offsetR.value_;
+
+        auto rotR = readVec4(r);
+        if (!rotR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                rotR.status_.code_,
+                std::move(rotR.status_.message_)
+            );
+        rec.rotation_ = rotR.value_;
+
+        auto csgR = r.readU8();
+        if (!csgR.ok())
+            return Result<ShapeGroupLoadResult>::error(
+                csgR.status_.code_,
+                std::move(csgR.status_.message_)
+            );
+        rec.csgOp_ = static_cast<CsgOp>(csgR.value_);
+
+        // Resolve the disk shape id to the current build's enum.
+        // Rule #2: prefer name → current_enum; fall back to verbatim id
+        // when the file has no SREF chunk (legacy save).
+        if (diskShapeTypes.empty()) {
+            rec.shapeTypeId_ = diskTypeId;
+            out.records_.push_back(rec);
+            continue;
+        }
+        auto diskName = diskShapeTypes.nameById(diskTypeId);
+        if (!diskName.has_value()) {
+            IRE_LOG_WARN(
+                "readShapeGroupChunk: unknown shape ID={} (not in disk SREF), skipping",
+                diskTypeId
+            );
+            ++out.unknownShapesSkipped_;
+            continue;
+        }
+        auto currentId = currentTable.idByName(*diskName);
+        if (!currentId.has_value()) {
+            IRE_LOG_WARN(
+                "readShapeGroupChunk: unknown shape ID={} name={}, skipping",
+                diskTypeId,
+                std::string(*diskName)
+            );
+            ++out.unknownShapesSkipped_;
+            continue;
+        }
+        rec.shapeTypeId_ = *currentId;
+        out.records_.push_back(rec);
+    }
+    return Result<ShapeGroupLoadResult>::success(std::move(out));
+}
+
+// ---- High-level save/load ---------------------------------------------
+
+BinaryStatus saveShapeGroup(const std::string &path, std::span<const ShapeRecord> records) {
+    FileBinaryWriter fw(path);
+    if (!fw.ok()) {
+        return BinaryStatus::error(
+            BinaryIOError::OpenFailed,
+            "saveShapeGroup: could not open '" + path + "' for write"
+        );
+    }
+    const auto shapeTypeEntries = buildCurrentShapeTypeNameTable();
+    std::array<ChunkPayload, 3> chunks = {
+        makeModeChunk(VoxelSetMode::SHAPES),
+        makeShapeRefsChunk(shapeTypeEntries),
+        makeShapeGroupChunk(records),
+    };
+    return writeChunked(fw, kVoxelSetMagic, kVoxelSetVersion, chunks);
+}
+
+Result<VoxelSetFile> loadShapeGroup(const std::string &path) {
+    FileBinaryReader fr(path);
+    if (!fr.ok()) {
+        return Result<VoxelSetFile>::error(
+            BinaryIOError::OpenFailed,
+            "loadShapeGroup: could not open '" + path + "' for read"
+        );
+    }
+    auto chunksR = readChunks(fr, kVoxelSetMagic, kVoxelSetVersion);
+    if (!chunksR.ok()) {
+        return Result<VoxelSetFile>::error(
+            chunksR.status_.code_,
+            std::move(chunksR.status_.message_)
+        );
+    }
+    VoxelSetFile out;
+    out.mode_ = readModeChunk(chunksR.value_);
+
+    NameTable diskShapeTypes;
+    if (const LoadedChunk *sref = findChunk(chunksR.value_, kChunkTagShapeRefs)) {
+        auto entriesR = readShapeRefsChunk(sref->data_);
+        if (!entriesR.ok()) {
+            return Result<VoxelSetFile>::error(
+                entriesR.status_.code_,
+                std::move(entriesR.status_.message_)
+            );
+        }
+        diskShapeTypes = NameTable(std::move(entriesR.value_));
+    }
+
+    if (const LoadedChunk *shpg = findChunk(chunksR.value_, kChunkTagShapeGroup)) {
+        auto recR = readShapeGroupChunk(shpg->data_, diskShapeTypes);
+        if (!recR.ok()) {
+            return Result<VoxelSetFile>::error(
+                recR.status_.code_,
+                std::move(recR.status_.message_)
+            );
+        }
+        out.shapeRecords_ = std::move(recR.value_.records_);
+        out.unknownShapesSkipped_ = recR.value_.unknownShapesSkipped_;
+    }
+    return Result<VoxelSetFile>::success(std::move(out));
+}
+
+} // namespace IRAsset

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -279,6 +279,9 @@ Result<ShapeGroupLoadResult> readShapeGroupChunk(
                 csgR.status_.code_,
                 std::move(csgR.status_.message_)
             );
+        // CsgOp is stable — future composition modes land in a separate
+        // SHPT chunk, not new CsgOp values, so no name-resolution fallback
+        // is needed (unlike ShapeType, which uses SREF for Rule #2).
         rec.csgOp_ = static_cast<CsgOp>(csgR.value_);
 
         // Resolve the disk shape id to the current build's enum.

--- a/engine/prefabs/irreden/asset/CLAUDE.md
+++ b/engine/prefabs/irreden/asset/CLAUDE.md
@@ -1,6 +1,20 @@
-# engine/prefabs/irreden/asset/ — asset I/O commands
+# engine/prefabs/irreden/asset/ — asset I/O commands + component adapters
 
-Prefab commands for saving and loading engine assets at runtime.
+Prefab commands for saving and loading engine assets at runtime, plus
+header-only adapters that bridge component types (`C_ShapeDescriptor`,
+`C_VoxelSetNew`, ...) to the low-level binary formats in
+`engine/asset/`. Adapters live here so `engine/asset/` itself stays
+below the component layer.
+
+## Adapters
+
+- `voxel_set_io.hpp` — `IRAsset::saveVoxelSet(span<const
+  C_ShapeDescriptor>, ...)` writes a SHAPES-mode `.vxs` shape-group
+  asset. Parallel optional spans (`offsets`, `rotations`, `csgOps`,
+  `boneIds`) carry the per-instance composition metadata that
+  `C_ShapeDescriptor` itself doesn't store. Loader path: callers use
+  `IRAsset::loadShapeGroup` (in `<irreden/asset/voxel_set_format.hpp>`)
+  and reconstruct entities from the returned `ShapeRecord`s.
 
 ## Commands
 

--- a/engine/prefabs/irreden/asset/voxel_set_io.hpp
+++ b/engine/prefabs/irreden/asset/voxel_set_io.hpp
@@ -27,10 +27,9 @@ namespace IRAsset {
 /// not carry (offset / rotation / CSG op / bone-id binding).
 ///
 /// Empty parallel spans take the per-record default (identity
-/// transform, `CsgOp::NONE`, `boneId = 0`). Non-empty spans must match
-/// `descriptors.size()` — mismatched lengths are a programmer error,
-/// asserted with a logged warning and treated as "stop at the shorter
-/// length" rather than UB.
+/// transform, `CsgOp::NONE`, `boneId = 0`). Non-empty spans should
+/// match `descriptors.size()` — mismatched lengths log a warning and
+/// degrade gracefully by stopping at the shorter span, not UB.
 inline BinaryStatus saveVoxelSet(
     const std::string &path,
     std::span<const IRComponents::C_ShapeDescriptor> descriptors,

--- a/engine/prefabs/irreden/asset/voxel_set_io.hpp
+++ b/engine/prefabs/irreden/asset/voxel_set_io.hpp
@@ -1,0 +1,95 @@
+#ifndef IR_PREFAB_ASSET_VOXEL_SET_IO_H
+#define IR_PREFAB_ASSET_VOXEL_SET_IO_H
+
+/// `C_ShapeDescriptor`-aware adapter over the low-level
+/// `engine/asset/include/irreden/asset/voxel_set_format.hpp` API.
+///
+/// Lives in `engine/prefabs/` rather than `engine/asset/` because
+/// `engine/asset/` does not (and should not) depend on the prefab
+/// components — the layer map keeps engine/asset below render and
+/// entity. Callers that need the descriptor-shaped save/load surface
+/// include this header; callers working with raw `ShapeRecord` arrays
+/// can use the lower-level API directly.
+
+#include <irreden/asset/voxel_set_format.hpp>
+#include <irreden/ir_profile.hpp>
+#include <irreden/voxel/components/component_shape_descriptor.hpp>
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace IRAsset {
+
+/// Persist a shape-group `.vxs` from a span of `C_ShapeDescriptor` plus
+/// parallel arrays for the runtime-only metadata the descriptor does
+/// not carry (offset / rotation / CSG op / bone-id binding).
+///
+/// Empty parallel spans take the per-record default (identity
+/// transform, `CsgOp::NONE`, `boneId = 0`). Non-empty spans must match
+/// `descriptors.size()` — mismatched lengths are a programmer error,
+/// asserted with a logged warning and treated as "stop at the shorter
+/// length" rather than UB.
+inline BinaryStatus saveVoxelSet(
+    const std::string &path,
+    std::span<const IRComponents::C_ShapeDescriptor> descriptors,
+    std::span<const vec3> offsets = {},
+    std::span<const vec4> rotations = {},
+    std::span<const CsgOp> csgOps = {},
+    std::span<const std::uint8_t> boneIds = {}
+) {
+    if (!offsets.empty() && offsets.size() != descriptors.size()) {
+        IRE_LOG_WARN(
+            "saveVoxelSet: offsets.size()={} != descriptors.size()={}",
+            offsets.size(),
+            descriptors.size()
+        );
+    }
+    if (!rotations.empty() && rotations.size() != descriptors.size()) {
+        IRE_LOG_WARN(
+            "saveVoxelSet: rotations.size()={} != descriptors.size()={}",
+            rotations.size(),
+            descriptors.size()
+        );
+    }
+    if (!csgOps.empty() && csgOps.size() != descriptors.size()) {
+        IRE_LOG_WARN(
+            "saveVoxelSet: csgOps.size()={} != descriptors.size()={}",
+            csgOps.size(),
+            descriptors.size()
+        );
+    }
+    if (!boneIds.empty() && boneIds.size() != descriptors.size()) {
+        IRE_LOG_WARN(
+            "saveVoxelSet: boneIds.size()={} != descriptors.size()={}",
+            boneIds.size(),
+            descriptors.size()
+        );
+    }
+
+    std::vector<ShapeRecord> records;
+    records.reserve(descriptors.size());
+    for (std::size_t i = 0; i < descriptors.size(); ++i) {
+        const auto &d = descriptors[i];
+        ShapeRecord r;
+        r.shapeTypeId_ = static_cast<std::uint32_t>(d.shapeType_);
+        r.params_ = d.params_;
+        r.color_ = d.color_;
+        r.flags_ = d.flags_;
+        if (i < offsets.size())
+            r.offset_ = offsets[i];
+        if (i < rotations.size())
+            r.rotation_ = rotations[i];
+        if (i < csgOps.size())
+            r.csgOp_ = csgOps[i];
+        if (i < boneIds.size())
+            r.boneId_ = boneIds[i];
+        records.push_back(r);
+    }
+    return saveShapeGroup(path, records);
+}
+
+} // namespace IRAsset
+
+#endif /* IR_PREFAB_ASSET_VOXEL_SET_IO_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 add_executable(IrredenEngineTest
   asset/binary_io_test.cpp
   asset/sprite_sheet_test.cpp
+  asset/voxel_set_shapes_test.cpp
   audio/music_theory_test.cpp
   common/ir_platform_test.cpp
   ecs/entity_manager_test.cpp

--- a/test/asset/voxel_set_shapes_test.cpp
+++ b/test/asset/voxel_set_shapes_test.cpp
@@ -1,0 +1,428 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/voxel_set_format.hpp>
+#include <irreden/asset/voxel_set_io.hpp>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace IRAsset;
+
+const std::string kTmpDir = "/tmp";
+
+std::vector<ShapeRecord> makeFivePrimitiveGroup() {
+    std::vector<ShapeRecord> records;
+
+    ShapeRecord r1;
+    r1.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE);
+    r1.params_ = vec4(3.0f, 0.0f, 0.0f, 0.0f);
+    r1.color_ = Color{200, 50, 25, 255};
+    r1.flags_ = 1u << 3; // SHAPE_FLAG_VISIBLE
+    r1.boneId_ = 0;
+    r1.offset_ = vec3(1.0f, 2.0f, 3.0f);
+    r1.rotation_ = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+    r1.csgOp_ = CsgOp::NONE;
+    records.push_back(r1);
+
+    ShapeRecord r2;
+    r2.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::BOX);
+    r2.params_ = vec4(2.0f, 3.0f, 4.0f, 0.0f);
+    r2.color_ = Color{0, 200, 0, 255};
+    r2.flags_ = (1u << 3) | (1u << 0); // VISIBLE | HOLLOW
+    r2.boneId_ = 4;
+    r2.offset_ = vec3(-5.0f, 0.0f, 1.0f);
+    r2.rotation_ = vec4(0.7071068f, 0.0f, 0.0f, 0.7071068f);
+    r2.csgOp_ = CsgOp::UNION;
+    records.push_back(r2);
+
+    ShapeRecord r3;
+    r3.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::CYLINDER);
+    r3.params_ = vec4(1.5f, 6.0f, 0.0f, 0.0f);
+    r3.color_ = Color{0, 0, 255, 128};
+    r3.flags_ = 1u << 3;
+    r3.boneId_ = 7;
+    r3.offset_ = vec3(2.5f, -1.0f, 0.0f);
+    r3.rotation_ = vec4(0.0f, 0.7071068f, 0.0f, 0.7071068f);
+    r3.csgOp_ = CsgOp::SMOOTH_UNION;
+    records.push_back(r3);
+
+    ShapeRecord r4;
+    r4.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::ELLIPSOID);
+    r4.params_ = vec4(2.0f, 1.0f, 3.0f, 0.0f);
+    r4.color_ = Color{255, 255, 0, 255};
+    r4.flags_ = 1u << 3;
+    r4.boneId_ = 0;
+    r4.offset_ = vec3(0.0f, 4.0f, -2.0f);
+    r4.rotation_ = vec4(0.0f, 0.0f, 0.7071068f, 0.7071068f);
+    r4.csgOp_ = CsgOp::SUBTRACT;
+    records.push_back(r4);
+
+    ShapeRecord r5;
+    r5.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::WEDGE);
+    r5.params_ = vec4(2.0f, 2.0f, 2.0f, 1.0f);
+    r5.color_ = Color{128, 64, 200, 255};
+    r5.flags_ = 1u << 3;
+    r5.boneId_ = 2;
+    r5.offset_ = vec3(-3.0f, -3.0f, 5.0f);
+    r5.rotation_ = vec4(0.5f, 0.5f, 0.5f, 0.5f);
+    r5.csgOp_ = CsgOp::INTERSECT;
+    records.push_back(r5);
+
+    return records;
+}
+
+void expectRecordEq(const ShapeRecord &a, const ShapeRecord &b) {
+    EXPECT_EQ(a.shapeTypeId_, b.shapeTypeId_);
+    EXPECT_EQ(a.recordVersion_, b.recordVersion_);
+    EXPECT_EQ(a.params_.x, b.params_.x);
+    EXPECT_EQ(a.params_.y, b.params_.y);
+    EXPECT_EQ(a.params_.z, b.params_.z);
+    EXPECT_EQ(a.params_.w, b.params_.w);
+    EXPECT_EQ(a.color_.red_, b.color_.red_);
+    EXPECT_EQ(a.color_.green_, b.color_.green_);
+    EXPECT_EQ(a.color_.blue_, b.color_.blue_);
+    EXPECT_EQ(a.color_.alpha_, b.color_.alpha_);
+    EXPECT_EQ(a.flags_, b.flags_);
+    EXPECT_EQ(a.boneId_, b.boneId_);
+    EXPECT_EQ(a.offset_.x, b.offset_.x);
+    EXPECT_EQ(a.offset_.y, b.offset_.y);
+    EXPECT_EQ(a.offset_.z, b.offset_.z);
+    EXPECT_EQ(a.rotation_.x, b.rotation_.x);
+    EXPECT_EQ(a.rotation_.y, b.rotation_.y);
+    EXPECT_EQ(a.rotation_.z, b.rotation_.z);
+    EXPECT_EQ(a.rotation_.w, b.rotation_.w);
+    EXPECT_EQ(a.csgOp_, b.csgOp_);
+}
+
+std::vector<std::uint8_t> readFileBytes(const std::string &path) {
+    std::FILE *fp = std::fopen(path.c_str(), "rb");
+    if (!fp)
+        return {};
+    std::fseek(fp, 0, SEEK_END);
+    const long size = std::ftell(fp);
+    std::fseek(fp, 0, SEEK_SET);
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size < 0 ? 0 : size));
+    if (!bytes.empty()) {
+        std::fread(bytes.data(), 1, bytes.size(), fp);
+    }
+    std::fclose(fp);
+    return bytes;
+}
+
+// ---- MODE chunk --------------------------------------------------------
+
+TEST(VoxelSetFormat, ModeChunkRoundTripsAllKnownModes) {
+    for (auto mode : {VoxelSetMode::DENSE, VoxelSetMode::SHAPES, VoxelSetMode::HYBRID}) {
+        ChunkPayload mp = makeModeChunk(mode);
+        ASSERT_EQ(mp.tag_, kChunkTagMode);
+        ASSERT_EQ(mp.data_.size(), 4u);
+        std::vector<LoadedChunk> chunks = {LoadedChunk{mp.tag_, mp.data_}};
+        EXPECT_EQ(readModeChunk(chunks), mode);
+    }
+}
+
+TEST(VoxelSetFormat, ModeChunkAbsentDefaultsToShapes) {
+    std::vector<LoadedChunk> empty;
+    EXPECT_EQ(readModeChunk(empty), VoxelSetMode::SHAPES);
+}
+
+TEST(VoxelSetFormat, ModeChunkUnknownTagReturnsUnknown) {
+    LoadedChunk lc;
+    lc.tag_ = kChunkTagMode;
+    lc.data_ = {'F', 'U', 'T', 'R'};
+    std::vector<LoadedChunk> chunks = {lc};
+    EXPECT_EQ(readModeChunk(chunks), VoxelSetMode::UNKNOWN);
+}
+
+// ---- SREF chunk --------------------------------------------------------
+
+TEST(VoxelSetFormat, SrefChunkRoundTripsCurrentBuildEnum) {
+    auto entries = buildCurrentShapeTypeNameTable();
+    EXPECT_GE(entries.size(), 10u);
+
+    ChunkPayload payload = makeShapeRefsChunk(entries);
+    EXPECT_EQ(payload.tag_, kChunkTagShapeRefs);
+
+    auto loaded = readShapeRefsChunk(payload.data_);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), entries.size());
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+        EXPECT_EQ(loaded.value_[i].id_, entries[i].id_);
+        EXPECT_EQ(loaded.value_[i].name_, entries[i].name_);
+    }
+}
+
+// ---- SHPG chunk: round-trip --------------------------------------------
+
+TEST(VoxelSetFormat, FivePrimitiveGroupRoundTrip) {
+    const auto records = makeFivePrimitiveGroup();
+    const std::string path = kTmpDir + "/vxs_shape_group_roundtrip.vxs";
+
+    ASSERT_TRUE(saveShapeGroup(path, records).ok());
+
+    auto loaded = loadShapeGroup(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::SHAPES);
+    EXPECT_EQ(loaded.value_.unknownShapesSkipped_, 0u);
+    ASSERT_EQ(loaded.value_.shapeRecords_.size(), records.size());
+    for (std::size_t i = 0; i < records.size(); ++i) {
+        expectRecordEq(records[i], loaded.value_.shapeRecords_[i]);
+    }
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetFormat, ReSerializingLoadedFileMatchesOriginalBytes) {
+    // Byte-compare: save once, load, save again — second file is byte-
+    // identical to the first. Catches non-deterministic ordering in the
+    // chunk-table or record loop.
+    const auto records = makeFivePrimitiveGroup();
+    const std::string p1 = kTmpDir + "/vxs_shape_group_bytecmp_1.vxs";
+    const std::string p2 = kTmpDir + "/vxs_shape_group_bytecmp_2.vxs";
+
+    ASSERT_TRUE(saveShapeGroup(p1, records).ok());
+    auto loaded = loadShapeGroup(p1);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_TRUE(saveShapeGroup(p2, loaded.value_.shapeRecords_).ok());
+
+    const auto b1 = readFileBytes(p1);
+    const auto b2 = readFileBytes(p2);
+    EXPECT_EQ(b1, b2);
+    EXPECT_FALSE(b1.empty());
+
+    std::remove(p1.c_str());
+    std::remove(p2.c_str());
+}
+
+TEST(VoxelSetFormat, EmptyShapeGroupRoundTrip) {
+    const std::string path = kTmpDir + "/vxs_shape_group_empty.vxs";
+    ASSERT_TRUE(saveShapeGroup(path, {}).ok());
+
+    auto loaded = loadShapeGroup(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::SHAPES);
+    EXPECT_TRUE(loaded.value_.shapeRecords_.empty());
+    EXPECT_EQ(loaded.value_.unknownShapesSkipped_, 0u);
+    std::remove(path.c_str());
+}
+
+// ---- SHPG chunk: forward-compat ----------------------------------------
+
+TEST(VoxelSetFormat, UnknownShapeTypeIdSkippedWithCount) {
+    // Hand-craft a file with one known SPHERE record and one record
+    // whose disk ShapeType id maps to a name not in the current build's
+    // enum (simulates a future "TORUS_KNOT" save loaded on an older
+    // build). The loader keeps the SPHERE record and counts the skipped
+    // one — Save Format Extensibility Rule #2.
+    const std::uint32_t kFutureId = 9999;
+    const std::string kFutureName = "TORUS_KNOT";
+
+    std::vector<NameTableEntry> diskEntries = {
+        {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE), "SPHERE"},
+        {kFutureId, kFutureName},
+    };
+
+    std::vector<ShapeRecord> records;
+    ShapeRecord sphere;
+    sphere.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE);
+    sphere.params_ = vec4(1.0f, 0.0f, 0.0f, 0.0f);
+    sphere.color_ = Color{255, 255, 255, 255};
+    sphere.flags_ = 1u << 3;
+    records.push_back(sphere);
+
+    ShapeRecord future;
+    future.shapeTypeId_ = kFutureId;
+    future.params_ = vec4(2.0f, 0.5f, 0.0f, 0.0f);
+    future.color_ = Color{255, 0, 0, 255};
+    future.flags_ = 1u << 3;
+    records.push_back(future);
+
+    MemoryBinaryWriter w;
+    std::array<ChunkPayload, 3> chunks = {
+        makeModeChunk(VoxelSetMode::SHAPES),
+        makeShapeRefsChunk(diskEntries),
+        makeShapeGroupChunk(records),
+    };
+    ASSERT_TRUE(writeChunked(w, kVoxelSetMagic, kVoxelSetVersion, chunks).ok());
+
+    // Load it through the chunk reader directly (no on-disk file).
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto chunksR = readChunks(r, kVoxelSetMagic, kVoxelSetVersion);
+    ASSERT_TRUE(chunksR.ok());
+
+    auto srefChunk = findChunk(chunksR.value_, kChunkTagShapeRefs);
+    ASSERT_NE(srefChunk, nullptr);
+    auto diskRefs = readShapeRefsChunk(srefChunk->data_);
+    ASSERT_TRUE(diskRefs.ok());
+    NameTable diskShapeTypes(diskRefs.value_);
+
+    auto shpgChunk = findChunk(chunksR.value_, kChunkTagShapeGroup);
+    ASSERT_NE(shpgChunk, nullptr);
+    auto loadedR = readShapeGroupChunk(shpgChunk->data_, diskShapeTypes);
+    ASSERT_TRUE(loadedR.ok());
+    EXPECT_EQ(loadedR.value_.records_.size(), 1u);
+    EXPECT_EQ(loadedR.value_.unknownShapesSkipped_, 1u);
+    EXPECT_EQ(
+        loadedR.value_.records_[0].shapeTypeId_,
+        static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE)
+    );
+}
+
+TEST(VoxelSetFormat, FutureBuildRenamedSphereResolvesByName) {
+    // Save written by a future build that gave SPHERE a different
+    // numeric id (e.g. enum reorder). Current build's name table
+    // still has "SPHERE" — the loader resolves by name and maps to
+    // the current numeric id (Rule #2 happy path).
+    const std::uint32_t kRenumberedSphereId = 42;
+
+    std::vector<NameTableEntry> diskEntries = {{kRenumberedSphereId, "SPHERE"}};
+
+    std::vector<ShapeRecord> records;
+    ShapeRecord r;
+    r.shapeTypeId_ = kRenumberedSphereId;
+    r.params_ = vec4(2.5f, 0.0f, 0.0f, 0.0f);
+    r.color_ = Color{100, 100, 100, 255};
+    r.flags_ = 1u << 3;
+    records.push_back(r);
+
+    MemoryBinaryWriter w;
+    std::array<ChunkPayload, 3> chunks = {
+        makeModeChunk(VoxelSetMode::SHAPES),
+        makeShapeRefsChunk(diskEntries),
+        makeShapeGroupChunk(records),
+    };
+    ASSERT_TRUE(writeChunked(w, kVoxelSetMagic, kVoxelSetVersion, chunks).ok());
+
+    MemoryBinaryReader r2(w.buffer().data(), w.buffer().size());
+    auto chunksR = readChunks(r2, kVoxelSetMagic, kVoxelSetVersion);
+    ASSERT_TRUE(chunksR.ok());
+
+    auto diskRefs = readShapeRefsChunk(findChunk(chunksR.value_, kChunkTagShapeRefs)->data_);
+    ASSERT_TRUE(diskRefs.ok());
+    NameTable diskShapeTypes(diskRefs.value_);
+
+    auto loadedR = readShapeGroupChunk(
+        findChunk(chunksR.value_, kChunkTagShapeGroup)->data_,
+        diskShapeTypes
+    );
+    ASSERT_TRUE(loadedR.ok());
+    EXPECT_EQ(loadedR.value_.unknownShapesSkipped_, 0u);
+    ASSERT_EQ(loadedR.value_.records_.size(), 1u);
+    // Resolved to the CURRENT build's SPHERE id, not the disk-side 42.
+    EXPECT_EQ(
+        loadedR.value_.records_[0].shapeTypeId_,
+        static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE)
+    );
+}
+
+TEST(VoxelSetFormat, LegacySaveWithoutSrefPassesIdsVerbatim) {
+    // A future-tolerant loader should still handle a save that omits
+    // the SREF chunk: fall back to "the disk id IS the current id"
+    // mode. Used for tests / asset-tool-generated minimal files.
+    std::vector<ShapeRecord> records;
+    ShapeRecord r;
+    r.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::BOX);
+    r.params_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
+    r.color_ = Color{50, 50, 50, 255};
+    records.push_back(r);
+
+    MemoryBinaryWriter w;
+    std::array<ChunkPayload, 2> chunks = {
+        makeModeChunk(VoxelSetMode::SHAPES),
+        makeShapeGroupChunk(records),
+    };
+    ASSERT_TRUE(writeChunked(w, kVoxelSetMagic, kVoxelSetVersion, chunks).ok());
+
+    MemoryBinaryReader r2(w.buffer().data(), w.buffer().size());
+    auto chunksR = readChunks(r2, kVoxelSetMagic, kVoxelSetVersion);
+    ASSERT_TRUE(chunksR.ok());
+
+    NameTable empty;
+    auto loadedR = readShapeGroupChunk(
+        findChunk(chunksR.value_, kChunkTagShapeGroup)->data_,
+        empty
+    );
+    ASSERT_TRUE(loadedR.ok());
+    EXPECT_EQ(loadedR.value_.unknownShapesSkipped_, 0u);
+    ASSERT_EQ(loadedR.value_.records_.size(), 1u);
+    EXPECT_EQ(
+        loadedR.value_.records_[0].shapeTypeId_,
+        static_cast<std::uint32_t>(IRMath::SDF::ShapeType::BOX)
+    );
+}
+
+// ---- High-level load: error paths --------------------------------------
+
+TEST(VoxelSetFormat, LoadMissingFileReturnsOpenFailed) {
+    auto loaded = loadShapeGroup(kTmpDir + "/this_file_does_not_exist.vxs");
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::OpenFailed);
+}
+
+TEST(VoxelSetFormat, LoadBadMagicReturnsBadMagic) {
+    const std::string path = kTmpDir + "/vxs_bad_magic.vxs";
+    {
+        FileBinaryWriter fw(path);
+        ASSERT_TRUE(fw.ok());
+        // Write a wrong magic; rest of the header doesn't matter.
+        fw.writeBytes("WRNG", 4);
+        fw.writeU32(1);
+        fw.writeU32(0);
+    }
+    auto loaded = loadShapeGroup(path);
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::BadMagic);
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetFormat, LoadVersionTooNewReturnsVersionTooNew) {
+    const std::string path = kTmpDir + "/vxs_future_version.vxs";
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kVoxelSetMagic, 99, {}).ok());
+    {
+        FileBinaryWriter fw(path);
+        ASSERT_TRUE(fw.ok());
+        fw.writeBytes(w.buffer().data(), w.buffer().size());
+    }
+    auto loaded = loadShapeGroup(path);
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::VersionTooNew);
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetFormat, FutureChunkTagSilentlySkipped) {
+    // A future writer may add a SHPT (shape tree) chunk. Older loaders
+    // must tolerate it without erroring — Save Format Extensibility
+    // Rule #1.
+    std::vector<ShapeRecord> records;
+    ShapeRecord r;
+    r.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::BOX);
+    r.params_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
+    records.push_back(r);
+
+    std::array<ChunkPayload, 4> chunks = {
+        makeModeChunk(VoxelSetMode::SHAPES),
+        makeShapeRefsChunk(buildCurrentShapeTypeNameTable()),
+        makeShapeGroupChunk(records),
+        ChunkPayload{makeTag("SHPT"), {0xDE, 0xAD, 0xBE, 0xEF}}, // future
+    };
+
+    const std::string path = kTmpDir + "/vxs_future_chunk.vxs";
+    {
+        FileBinaryWriter fw(path);
+        ASSERT_TRUE(fw.ok());
+        ASSERT_TRUE(writeChunked(fw, kVoxelSetMagic, kVoxelSetVersion, chunks).ok());
+    }
+
+    auto loaded = loadShapeGroup(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.shapeRecords_.size(), 1u);
+    std::remove(path.c_str());
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- `.vxs` v1 SHAPES persistence mode: SDF primitive composition save/load via MODE / SREF / SHPG chunks.
- Forward-compat by name (`ShapeType` registry): future enum values load on older builds as "unknown shape, skipped".
- `C_ShapeDescriptor`-aware prefab adapter (`<irreden/asset/voxel_set_io.hpp>`) writes the same format with parallel offset / rotation / csgOp / boneId arrays.

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/678 (T-166 binary I/O primitives).

When #678 merges, GitHub auto-rebases this PR's base to master.

## What's in the diff
- `engine/asset/include/irreden/asset/voxel_set_format.hpp` — container API (MODE / SREF / SHPG primitives, high-level save/load).
- `engine/asset/src/voxel_set_format.cpp` — implementation; canonical `ShapeType` name table.
- `engine/prefabs/irreden/asset/voxel_set_io.hpp` — header-only `IRAsset::saveVoxelSet(span<C_ShapeDescriptor>, ...)` adapter.
- `test/asset/voxel_set_shapes_test.cpp` — 14 GoogleTest cases (round-trip, byte-stable re-serialization, unknown-shape skip, future-build rename, legacy no-SREF save, container errors, future-chunk-tag tolerance).
- `engine/asset/CLAUDE.md`, `engine/prefabs/irreden/asset/CLAUDE.md` — chunk layout doc + "How to add a new SDF primitive" walkthrough + adapter entry.

## Test plan
- [x] `fleet-build --target IrredenEngineAsset` clean.
- [x] `fleet-build --target IrredenEngineTest` clean.
- [x] `fleet-run --timeout 60 IrredenEngineTest` — 533/533 pass (14 new VoxelSetFormat cases included).

## Notes for reviewer
- Format version stays `1` — DENSE (#664) and HYBRID (#668) will reuse the same container under their own chunk tags; MODE chunk dispatches.
- Per-record `recordVersion_` is the additive-field lever (Save Format Extensibility Rule #3); v1 records share one fixed layout.
- SREF lookups go name→current_enum first, id verbatim only when no SREF chunk exists (legacy / hand-rolled minimal saves).
- The `C_ShapeDescriptor` adapter is exercised by inclusion only — its constructor reads `IRRender::getActiveCanvasEntity()`, so a runtime unit test needs a live `RenderManager`. Demos / creations will exercise the save path with a live world.

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)