### PR TITLE
T-169: asset: .rig v1 — joints (JNTS) chunk; persist C_JointHierarchy

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -51,10 +51,14 @@ snapshot (issue #199). It walks the archetype graph, so it lives in
   `.vxs` SHAPES-mode SDF primitive composition round-trip. See
   `voxel_set_format.hpp` for record layout and the
   "How to add a new SDF primitive" walkthrough below.
+- `saveRig(name, path, rig)` / `loadRig(name, path)` — joints-first
+  rig asset round-trip (see `.rig format` below). Buffer-mode
+  `writeRig` / `readRig` are exposed for in-memory consumers.
 
 The `name` is embedded in the trixel file header; the `path` is the
 output directory. For sprite sheets, `name` is the basename shared
-by the `.png` atlas and its `.irsprite` sidecar.
+by the `.png` atlas and its `.irsprite` sidecar. For rigs, `name` is
+the basename shared by the `.rig` binary and its `.rig.json` sidecar.
 
 ## Trixel format
 
@@ -86,6 +90,35 @@ anim <name> <firstFrame> <frameCount> <fps>
 Animation names must not contain whitespace (the loader scans with
 `%127s` and would silently truncate); `saveSpriteSheetMeta` asserts on
 this at write time.
+
+## .rig format
+
+`.rig` v1 — joint hierarchy first slice. Bind points (#669) and
+animation keyframes (#606) land as additional chunks without bumping
+the file version (Save Format Extensibility Rule #1).
+
+```
+AssetHeader { magic = "IRRG", version = 1, chunkCount }
+ChunkTableEntry[chunkCount]
+JNTS chunk body:
+    varuint  jointCount
+    repeat jointCount times:
+        uint16   recordVersion    (Rule #3 per-record additive-only)
+        float32  rotation { x, y, z, w }    // quaternion as { qw, qx, qy, qz }
+        float32  translation { x, y, z, w }
+        uint32   parentIndex
+        string   name             // varuint-prefixed UTF-8, may be empty
+```
+
+The accompanying `<name>.rig.json` sidecar emits per-joint
+`{ index, name, parentIndex }` for designer diffing. Sidecars are
+write-only; the loader ignores them (Rule #6).
+
+The asset-side `IRAsset::Rig` is distinct from the runtime
+`IRComponents::C_JointHierarchy` (no names at draw time) — translate
+via `engine/prefabs/irreden/voxel/rig_bridge.hpp`
+(`IRPrefab::Rig::toComponent` / `fromComponent`). Splitting the two
+keeps `engine/asset/` independent of the prefab voxel component.
 
 ## Typical usage
 

--- a/engine/asset/CMakeLists.txt
+++ b/engine/asset/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(IrredenEngineAsset STATIC
     src/name_table.cpp
     src/json_sidecar.cpp
     src/voxel_set_format.cpp
+    src/rig_format.cpp
 )
 
 target_compile_options(

--- a/engine/asset/include/irreden/asset/rig_format.hpp
+++ b/engine/asset/include/irreden/asset/rig_format.hpp
@@ -1,0 +1,97 @@
+#ifndef IR_ASSET_RIG_FORMAT_H
+#define IR_ASSET_RIG_FORMAT_H
+
+/// `.rig` v1 — joint hierarchy for skeletal voxel rigs. First slice of
+/// the rig asset format; subsequent issues add chunks for bind points
+/// (#669) and animation keyframes (#606) without bumping `.rig` v1 —
+/// older readers silently skip the new tags (Save Format Extensibility
+/// Rule #1).
+///
+/// `.rig` is intentionally separate from `.vxs` so the same skeleton can
+/// be shared across voxel variants (same rig, different paint job).
+///
+/// On-disk layout
+/// --------------
+///
+///     AssetHeader  { magic = "IRRG", version = 1, chunkCount }
+///     ChunkTableEntry[chunkCount]
+///     JNTS chunk body:
+///         varuint  jointCount
+///         repeat jointCount times:
+///             uint16  recordVersion    (Rule #3, per-record additive-only)
+///             float32 rotation { x, y, z, w }   // quaternion as { qw, qx, qy, qz }
+///             float32 translation { x, y, z, w }
+///             uint32  parentIndex
+///             string  name             // varuint-prefixed UTF-8, may be empty
+///
+/// Sidecar (regenerated from binary on every save, ignored on load —
+/// Rule #6):
+///
+///     <path>/<name>.rig.json    per-joint { index, name, parentIndex }
+///
+/// Version history
+/// ---------------
+/// v1 (initial) — joints-only via JNTS chunk.
+/// Reserved chunk tags for forward compatibility (not yet written):
+///   - "BIND" — bind points (#669)
+///   - "ANIM" — animation keyframes (#606)
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <irreden/ir_math.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace IRAsset {
+
+constexpr std::array<char, 4> kRigMagic{'I', 'R', 'R', 'G'};
+constexpr std::uint32_t kRigFormatVersion = 1;
+
+/// Per-joint record version. Field additions append + bump the version;
+/// the load path defaults the appended fields. See Save Format
+/// Extensibility Rule #3.
+constexpr std::uint16_t kJointRecordVersion = 1;
+
+/// Asset representation of a single joint. Mirrors `IRComponents::Joint`
+/// (engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp)
+/// with the addition of an optional designer-facing name. The rotation
+/// `vec4` carries a quaternion in `{ qw, qx, qy, qz }` order — same
+/// convention as the runtime component and the GPU upload struct.
+struct RigJoint {
+    IRMath::vec4 rotation_{0.0f, 0.0f, 0.0f, 1.0f};
+    IRMath::vec4 translation_{0.0f, 0.0f, 0.0f, 0.0f};
+    std::uint32_t parentIndex_ = 0;
+    std::string name_;
+};
+
+/// Asset-side rig — a flat list of joints. Conversion to/from the
+/// runtime `IRComponents::C_JointHierarchy` lives in the prefab bridge
+/// at `engine/prefabs/irreden/voxel/rig_bridge.hpp` so `engine/asset/`
+/// has no dependency on the voxel component.
+struct Rig {
+    std::vector<RigJoint> joints_;
+};
+
+/// File-mode save. Writes `<path>/<name>.rig` plus a designer-readable
+/// `<path>/<name>.rig.json` sidecar. Returns the writer's failure state.
+BinaryStatus saveRig(const std::string &name, const std::string &path, const Rig &rig);
+
+/// File-mode load. Returns an empty `Rig` with a recoverable error when
+/// the file cannot be opened, has bad magic, or carries a version above
+/// `kRigFormatVersion`. Unknown chunks are silently skipped (Rule #1).
+Result<Rig> loadRig(const std::string &name, const std::string &path);
+
+/// Buffer-mode write — exposed so tests (and any future in-memory
+/// consumer such as network-streamed rigs) can exercise the format
+/// without touching disk.
+BinaryStatus writeRig(BinaryWriter &w, const Rig &rig);
+
+/// Buffer-mode read counterpart.
+Result<Rig> readRig(BinaryReader &r);
+
+} // namespace IRAsset
+
+#endif /* IR_ASSET_RIG_FORMAT_H */

--- a/engine/asset/src/rig_format.cpp
+++ b/engine/asset/src/rig_format.cpp
@@ -14,7 +14,7 @@ namespace {
 constexpr const char *kRigExtension = ".rig";
 constexpr const char *kRigSidecarExtension = ".rig.json";
 
-const std::array<char, 4> kJntsTag{'J', 'N', 'T', 'S'};
+constexpr std::array<char, 4> kJntsTag{'J', 'N', 'T', 'S'};
 
 void encodeVec4(BinaryWriter &w, const IRMath::vec4 &v) {
     w.writeF32(v.x);
@@ -61,7 +61,10 @@ Result<Rig> decodeJntsChunk(const LoadedChunk &chunk, const std::string &sourceN
     if (!countR.ok()) {
         return Result<Rig>::error(countR.status_.code_, std::move(countR.status_.message_));
     }
-    rig.joints_.reserve(static_cast<std::size_t>(countR.value_));
+    // Cap the upfront reserve to the remaining bytes so a corrupted
+    // jointCount claiming billions of joints can't pre-allocate.
+    const std::uint64_t cap = r.remaining();
+    rig.joints_.reserve(static_cast<std::size_t>(countR.value_ < cap ? countR.value_ : cap));
     for (std::uint64_t i = 0; i < countR.value_; ++i) {
         auto verR = r.readU16();
         if (!verR.ok()) {

--- a/engine/asset/src/rig_format.cpp
+++ b/engine/asset/src/rig_format.cpp
@@ -1,0 +1,192 @@
+#include <irreden/asset/rig_format.hpp>
+
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/json_sidecar.hpp>
+#include <irreden/ir_profile.hpp>
+#include <irreden/ir_utility.hpp>
+
+#include <utility>
+
+namespace IRAsset {
+
+namespace {
+
+constexpr const char *kRigExtension = ".rig";
+constexpr const char *kRigSidecarExtension = ".rig.json";
+
+const std::array<char, 4> kJntsTag{'J', 'N', 'T', 'S'};
+
+void encodeVec4(BinaryWriter &w, const IRMath::vec4 &v) {
+    w.writeF32(v.x);
+    w.writeF32(v.y);
+    w.writeF32(v.z);
+    w.writeF32(v.w);
+}
+
+Result<IRMath::vec4> decodeVec4(BinaryReader &r) {
+    auto x = r.readF32();
+    if (!x.ok())
+        return Result<IRMath::vec4>::error(x.status_.code_, std::move(x.status_.message_));
+    auto y = r.readF32();
+    if (!y.ok())
+        return Result<IRMath::vec4>::error(y.status_.code_, std::move(y.status_.message_));
+    auto z = r.readF32();
+    if (!z.ok())
+        return Result<IRMath::vec4>::error(z.status_.code_, std::move(z.status_.message_));
+    auto w = r.readF32();
+    if (!w.ok())
+        return Result<IRMath::vec4>::error(w.status_.code_, std::move(w.status_.message_));
+    return Result<IRMath::vec4>::success(IRMath::vec4(x.value_, y.value_, z.value_, w.value_));
+}
+
+BinaryStatus encodeJntsChunk(MemoryBinaryWriter &body, const Rig &rig) {
+    body.writeVarUInt(rig.joints_.size());
+    for (const auto &j : rig.joints_) {
+        body.writeU16(kJointRecordVersion);
+        encodeVec4(body, j.rotation_);
+        encodeVec4(body, j.translation_);
+        body.writeU32(j.parentIndex_);
+        body.writeString(j.name_);
+    }
+    if (body.failed()) {
+        return BinaryStatus::error(BinaryIOError::WriteFailed, body.failureMessage());
+    }
+    return BinaryStatus::success();
+}
+
+Result<Rig> decodeJntsChunk(const LoadedChunk &chunk, const std::string &sourceName) {
+    MemoryBinaryReader r(chunk.data_.data(), chunk.data_.size(), sourceName + ":JNTS");
+    Rig rig;
+    auto countR = r.readVarUInt();
+    if (!countR.ok()) {
+        return Result<Rig>::error(countR.status_.code_, std::move(countR.status_.message_));
+    }
+    rig.joints_.reserve(static_cast<std::size_t>(countR.value_));
+    for (std::uint64_t i = 0; i < countR.value_; ++i) {
+        auto verR = r.readU16();
+        if (!verR.ok()) {
+            return Result<Rig>::error(verR.status_.code_, std::move(verR.status_.message_));
+        }
+        if (verR.value_ > kJointRecordVersion) {
+            return Result<Rig>::error(
+                BinaryIOError::VersionTooNew,
+                "joint record version " + std::to_string(verR.value_) + " above max known " +
+                    std::to_string(kJointRecordVersion) + " in " + r.sourceName()
+            );
+        }
+        RigJoint joint;
+        auto rot = decodeVec4(r);
+        if (!rot.ok())
+            return Result<Rig>::error(rot.status_.code_, std::move(rot.status_.message_));
+        joint.rotation_ = rot.value_;
+        auto tra = decodeVec4(r);
+        if (!tra.ok())
+            return Result<Rig>::error(tra.status_.code_, std::move(tra.status_.message_));
+        joint.translation_ = tra.value_;
+        auto parent = r.readU32();
+        if (!parent.ok()) {
+            return Result<Rig>::error(parent.status_.code_, std::move(parent.status_.message_));
+        }
+        joint.parentIndex_ = parent.value_;
+        auto nm = r.readString();
+        if (!nm.ok())
+            return Result<Rig>::error(nm.status_.code_, std::move(nm.status_.message_));
+        joint.name_ = std::move(nm.value_);
+        rig.joints_.push_back(std::move(joint));
+    }
+    return Result<Rig>::success(std::move(rig));
+}
+
+std::string emitSidecarJson(const Rig &rig) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("format");
+    j.valueString("rig");
+    j.key("version");
+    j.valueUInt(kRigFormatVersion);
+    j.key("jointCount");
+    j.valueUInt(static_cast<std::uint64_t>(rig.joints_.size()));
+    j.key("joints");
+    j.beginArray();
+    for (std::size_t i = 0; i < rig.joints_.size(); ++i) {
+        const auto &joint = rig.joints_[i];
+        j.beginObject();
+        j.key("index");
+        j.valueUInt(static_cast<std::uint64_t>(i));
+        j.key("name");
+        j.valueString(joint.name_);
+        j.key("parentIndex");
+        j.valueUInt(joint.parentIndex_);
+        j.endObject();
+    }
+    j.endArray();
+    j.endObject();
+    return j.str();
+}
+
+} // namespace
+
+BinaryStatus writeRig(BinaryWriter &w, const Rig &rig) {
+    MemoryBinaryWriter body;
+    if (auto st = encodeJntsChunk(body, rig); !st.ok()) {
+        return st;
+    }
+    std::vector<ChunkPayload> chunks;
+    chunks.push_back(ChunkPayload{kJntsTag, body.takeBuffer()});
+    return writeChunked(w, kRigMagic, kRigFormatVersion, chunks);
+}
+
+Result<Rig> readRig(BinaryReader &r) {
+    AssetHeader header{};
+    auto chunksR = readChunks(r, kRigMagic, kRigFormatVersion, &header);
+    if (!chunksR.ok()) {
+        return Result<Rig>::error(chunksR.status_.code_, std::move(chunksR.status_.message_));
+    }
+    const LoadedChunk *jnts = findChunk(chunksR.value_, kJntsTag);
+    if (!jnts) {
+        // No joints chunk — return an empty rig. A future writer might emit
+        // BIND/ANIM with no JNTS (e.g. a pose-only override) and an older
+        // loader should treat that as "no skeleton" rather than corrupt.
+        return Result<Rig>::success(Rig{});
+    }
+    return decodeJntsChunk(*jnts, r.sourceName());
+}
+
+BinaryStatus saveRig(const std::string &name, const std::string &path, const Rig &rig) {
+    const std::string filename = IRUtility::joinPath(path, name, kRigExtension);
+    FileBinaryWriter w(filename);
+    if (!w.ok()) {
+        IRE_LOG_ERROR("Failed to open rig file for writing: {}", filename);
+        return BinaryStatus::error(BinaryIOError::OpenFailed, "failed to open " + filename);
+    }
+    if (auto st = writeRig(w, rig); !st.ok()) {
+        IRE_LOG_ERROR("Failed to write rig {}: {}", filename, st.message_);
+        return st;
+    }
+
+    const std::string sidecarPath = IRUtility::joinPath(path, name, kRigSidecarExtension);
+    if (!writeJsonSidecarToFile(sidecarPath, emitSidecarJson(rig))) {
+        IRE_LOG_WARN("Saved {} but sidecar emit to {} failed", filename, sidecarPath);
+    }
+
+    IRE_LOG_INFO("Saved rig with {} joint(s) to {}", rig.joints_.size(), filename);
+    return BinaryStatus::success();
+}
+
+Result<Rig> loadRig(const std::string &name, const std::string &path) {
+    const std::string filename = IRUtility::joinPath(path, name, kRigExtension);
+    FileBinaryReader r(filename);
+    if (!r.ok()) {
+        IRE_LOG_ERROR("Failed to open rig file for reading: {}", filename);
+        return Result<Rig>::error(BinaryIOError::OpenFailed, "failed to open " + filename);
+    }
+    auto rigR = readRig(r);
+    if (!rigR.ok()) {
+        IRE_LOG_ERROR("Failed to load rig {}: {}", filename, rigR.status_.message_);
+    } else {
+        IRE_LOG_INFO("Loaded rig with {} joint(s) from {}", rigR.value_.joints_.size(), filename);
+    }
+    return rigR;
+}
+
+} // namespace IRAsset

--- a/engine/prefabs/irreden/voxel/rig_bridge.hpp
+++ b/engine/prefabs/irreden/voxel/rig_bridge.hpp
@@ -1,0 +1,69 @@
+#ifndef IR_PREFAB_VOXEL_RIG_BRIDGE_H
+#define IR_PREFAB_VOXEL_RIG_BRIDGE_H
+
+/// Translate between the asset-side `IRAsset::Rig` (on-disk, designer-
+/// facing — carries per-joint names) and the runtime
+/// `IRComponents::C_JointHierarchy` (ECS-resident, GPU-feeding — no names
+/// because names are not needed at draw time). The split keeps
+/// `engine/asset/` independent of the prefab voxel component (asset has
+/// no dependency on prefabs) while still letting an editor or load path
+/// produce a `C_JointHierarchy` directly from a `.rig` round-trip.
+///
+/// Pattern is the same shape as `engine/prefabs/irreden/render/fog_of_war.hpp`
+/// (`engine/prefabs/CLAUDE.md` §"Component method rules", "Prefab-scoped
+/// namespace") — the bridge owns the cross-type translation logic so
+/// callers don't have to hand-roll it.
+
+#include <irreden/asset/rig_format.hpp>
+
+#include <irreden/voxel/components/component_joint_hierarchy.hpp>
+
+#include <cstddef>
+#include <span>
+#include <string>
+#include <utility>
+
+namespace IRPrefab::Rig {
+
+/// Build a runtime `C_JointHierarchy` from an asset `IRAsset::Rig`.
+/// Joint order is preserved; names are dropped (the runtime component
+/// has no name field — see `component_joint_hierarchy.hpp`).
+inline IRComponents::C_JointHierarchy toComponent(const IRAsset::Rig &rig) {
+    IRComponents::C_JointHierarchy hierarchy;
+    hierarchy.joints_.reserve(rig.joints_.size());
+    for (const auto &assetJoint : rig.joints_) {
+        IRComponents::Joint runtime;
+        runtime.rotation_ = assetJoint.rotation_;
+        runtime.translation_ = assetJoint.translation_;
+        runtime.parentIndex_ = assetJoint.parentIndex_;
+        hierarchy.joints_.push_back(runtime);
+    }
+    return hierarchy;
+}
+
+/// Build an asset `IRAsset::Rig` from a runtime `C_JointHierarchy`.
+/// @p jointNames is paired by index; pass an empty span to leave every
+/// joint name blank. Names shorter than the joint count default the
+/// remaining names to empty strings, so partial-name authoring
+/// (root-named, children anonymous) costs nothing.
+inline IRAsset::Rig fromComponent(
+    const IRComponents::C_JointHierarchy &hierarchy, std::span<const std::string> jointNames = {}
+) {
+    IRAsset::Rig rig;
+    rig.joints_.reserve(hierarchy.joints_.size());
+    for (std::size_t i = 0; i < hierarchy.joints_.size(); ++i) {
+        IRAsset::RigJoint assetJoint;
+        assetJoint.rotation_ = hierarchy.joints_[i].rotation_;
+        assetJoint.translation_ = hierarchy.joints_[i].translation_;
+        assetJoint.parentIndex_ = hierarchy.joints_[i].parentIndex_;
+        if (i < jointNames.size()) {
+            assetJoint.name_ = jointNames[i];
+        }
+        rig.joints_.push_back(std::move(assetJoint));
+    }
+    return rig;
+}
+
+} // namespace IRPrefab::Rig
+
+#endif /* IR_PREFAB_VOXEL_RIG_BRIDGE_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(IrredenEngineTest
   asset/binary_io_test.cpp
+  asset/rig_format_test.cpp
   asset/sprite_sheet_test.cpp
   asset/voxel_set_shapes_test.cpp
   audio/music_theory_test.cpp

--- a/test/asset/rig_format_test.cpp
+++ b/test/asset/rig_format_test.cpp
@@ -1,0 +1,294 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/rig_format.hpp>
+#include <irreden/voxel/components/component_joint_hierarchy.hpp>
+#include <irreden/voxel/rig_bridge.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace IRAsset;
+
+const std::string kTmpDir = "/tmp";
+
+Rig makeSnakeRig(std::size_t numJoints) {
+    Rig rig;
+    rig.joints_.reserve(numJoints);
+    for (std::size_t i = 0; i < numJoints; ++i) {
+        RigJoint j;
+        // Distinct deterministic values per joint so a stale read surfaces.
+        const float f = static_cast<float>(i);
+        j.rotation_ = IRMath::vec4(0.0f, 0.0f, f * 0.01f, 1.0f - f * 0.001f);
+        j.translation_ = IRMath::vec4(f * 0.5f, 1.0f + f, -2.0f, 0.0f);
+        j.parentIndex_ = (i == 0) ? 0u : static_cast<std::uint32_t>(i - 1);
+        j.name_ = "joint_" + std::to_string(i);
+        rig.joints_.push_back(j);
+    }
+    return rig;
+}
+
+void expectRigsEqual(const Rig &a, const Rig &b) {
+    ASSERT_EQ(a.joints_.size(), b.joints_.size());
+    for (std::size_t i = 0; i < a.joints_.size(); ++i) {
+        const auto &ja = a.joints_[i];
+        const auto &jb = b.joints_[i];
+        EXPECT_EQ(ja.rotation_.x, jb.rotation_.x) << "joint " << i;
+        EXPECT_EQ(ja.rotation_.y, jb.rotation_.y) << "joint " << i;
+        EXPECT_EQ(ja.rotation_.z, jb.rotation_.z) << "joint " << i;
+        EXPECT_EQ(ja.rotation_.w, jb.rotation_.w) << "joint " << i;
+        EXPECT_EQ(ja.translation_.x, jb.translation_.x) << "joint " << i;
+        EXPECT_EQ(ja.translation_.y, jb.translation_.y) << "joint " << i;
+        EXPECT_EQ(ja.translation_.z, jb.translation_.z) << "joint " << i;
+        EXPECT_EQ(ja.translation_.w, jb.translation_.w) << "joint " << i;
+        EXPECT_EQ(ja.parentIndex_, jb.parentIndex_) << "joint " << i;
+        EXPECT_EQ(ja.name_, jb.name_) << "joint " << i;
+    }
+}
+
+std::string readFileBytes(const std::string &path) {
+    std::ifstream f(path, std::ios::binary);
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+// ---- Buffer round-trips --------------------------------------------------
+
+TEST(RigFormat, EmptyRigRoundTrip) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeRig(w, Rig{}).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readRig(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    EXPECT_TRUE(loaded.value_.joints_.empty());
+}
+
+TEST(RigFormat, ThirtyBoneSnakeRoundTrip) {
+    const Rig original = makeSnakeRig(30);
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeRig(w, original).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readRig(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    expectRigsEqual(original, loaded.value_);
+}
+
+TEST(RigFormat, AnonymousJointsRoundTrip) {
+    Rig original;
+    for (int i = 0; i < 4; ++i) {
+        RigJoint j;
+        j.translation_ = IRMath::vec4(static_cast<float>(i), 0.0f, 0.0f, 0.0f);
+        j.parentIndex_ = i == 0 ? 0 : static_cast<std::uint32_t>(i - 1);
+        original.joints_.push_back(j);
+    }
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeRig(w, original).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readRig(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    expectRigsEqual(original, loaded.value_);
+}
+
+// ---- Recoverable errors --------------------------------------------------
+
+TEST(RigFormat, BadMagicIsRecoverable) {
+    // 12-byte header + a single empty chunk-table entry's worth of nothing
+    // is enough to fail BadMagic before reaching any chunk read.
+    std::vector<std::uint8_t> bad(64, 0);
+    bad[0] = 'X';
+    bad[1] = 'X';
+    bad[2] = 'X';
+    bad[3] = 'X';
+    MemoryBinaryReader r(bad.data(), bad.size());
+    auto loaded = readRig(r);
+    ASSERT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::BadMagic);
+}
+
+TEST(RigFormat, VersionTooNewIsRecoverable) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeRig(w, makeSnakeRig(3)).ok());
+    // Patch the version dword (bytes 4..7) to a future value.
+    auto buffer = w.takeBuffer();
+    buffer[4] = 0xFF;
+    buffer[5] = 0xFF;
+    buffer[6] = 0xFF;
+    buffer[7] = 0xFF;
+    MemoryBinaryReader r(buffer.data(), buffer.size());
+    auto loaded = readRig(r);
+    ASSERT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::VersionTooNew);
+}
+
+TEST(RigFormat, MissingFileIsRecoverable) {
+    auto loaded = loadRig("definitely_not_a_real_rig_filename", kTmpDir);
+    ASSERT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::OpenFailed);
+    EXPECT_TRUE(loaded.value_.joints_.empty());
+}
+
+// ---- Forward-compat: unknown chunks survive a load -----------------------
+
+TEST(RigFormat, UnknownChunksAreSilentlySkipped) {
+    // Hand-roll a file with JNTS + a fake "BIND" chunk + a fake "MORE" chunk.
+    // A v1 loader should pull JNTS through and silently ignore the others —
+    // Save Format Extensibility Rule #1.
+    const Rig original = makeSnakeRig(5);
+    MemoryBinaryWriter jntsBody;
+    jntsBody.writeVarUInt(original.joints_.size());
+    for (const auto &j : original.joints_) {
+        jntsBody.writeU16(kJointRecordVersion);
+        jntsBody.writeF32(j.rotation_.x);
+        jntsBody.writeF32(j.rotation_.y);
+        jntsBody.writeF32(j.rotation_.z);
+        jntsBody.writeF32(j.rotation_.w);
+        jntsBody.writeF32(j.translation_.x);
+        jntsBody.writeF32(j.translation_.y);
+        jntsBody.writeF32(j.translation_.z);
+        jntsBody.writeF32(j.translation_.w);
+        jntsBody.writeU32(j.parentIndex_);
+        jntsBody.writeString(j.name_);
+    }
+
+    std::vector<ChunkPayload> chunks;
+    chunks.push_back(ChunkPayload{makeTag("BIND"), {0xCA, 0xFE, 0xBA, 0xBE}});
+    chunks.push_back(ChunkPayload{makeTag("JNTS"), jntsBody.takeBuffer()});
+    chunks.push_back(ChunkPayload{makeTag("MORE"), {0x01, 0x02, 0x03}});
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kRigMagic, kRigFormatVersion, chunks).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readRig(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    expectRigsEqual(original, loaded.value_);
+}
+
+TEST(RigFormat, NoJntsChunkReturnsEmptyRig) {
+    // A file with only an unknown chunk and no JNTS should still load
+    // (as an empty rig) rather than erroring — future writer might emit
+    // BIND/ANIM without JNTS for a pose-only override.
+    std::vector<ChunkPayload> chunks;
+    chunks.push_back(ChunkPayload{makeTag("BIND"), {0xCA, 0xFE, 0xBA, 0xBE}});
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kRigMagic, kRigFormatVersion, chunks).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readRig(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    EXPECT_TRUE(loaded.value_.joints_.empty());
+}
+
+// ---- File-mode round-trip ------------------------------------------------
+
+TEST(RigFormat, FileRoundTripAndSidecarEmitted) {
+    const std::string name = "snake_test";
+    const Rig original = makeSnakeRig(30);
+
+    // Cleanup any prior fixture.
+    std::remove((kTmpDir + "/" + name + ".rig").c_str());
+    std::remove((kTmpDir + "/" + name + ".rig.json").c_str());
+
+    ASSERT_TRUE(saveRig(name, kTmpDir, original).ok());
+
+    auto loaded = loadRig(name, kTmpDir);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    expectRigsEqual(original, loaded.value_);
+
+    // Sidecar should be present and contain per-joint names + parent
+    // indices for a few joints we can recognize.
+    const std::string sidecar = readFileBytes(kTmpDir + "/" + name + ".rig.json");
+    ASSERT_FALSE(sidecar.empty());
+    EXPECT_NE(sidecar.find("\"format\""), std::string::npos);
+    EXPECT_NE(sidecar.find("\"rig\""), std::string::npos);
+    EXPECT_NE(sidecar.find("\"jointCount\""), std::string::npos);
+    EXPECT_NE(sidecar.find("\"joint_0\""), std::string::npos);
+    EXPECT_NE(sidecar.find("\"joint_29\""), std::string::npos);
+    EXPECT_NE(sidecar.find("\"parentIndex\""), std::string::npos);
+}
+
+// ---- Bridge: round-trip preserves C_JointHierarchy::toGPUFormat() --------
+
+TEST(RigFormat, GPUMatrixParityAfterRoundTrip) {
+    // The fundamental acceptance criterion from #666: a save → load
+    // round-trip must produce the same GPU upload payload, byte for byte,
+    // so the shapes compute shader reads identical joint transforms.
+    IRComponents::C_JointHierarchy original;
+    for (int i = 0; i < 30; ++i) {
+        IRComponents::Joint j;
+        const float f = static_cast<float>(i);
+        j.rotation_ = IRMath::vec4(0.0f, 0.0f, f * 0.01f, 1.0f - f * 0.001f);
+        j.translation_ = IRMath::vec4(f * 0.5f, 1.0f + f, -2.0f, 0.0f);
+        j.parentIndex_ = (i == 0) ? 0u : static_cast<std::uint32_t>(i - 1);
+        original.joints_.push_back(j);
+    }
+
+    std::vector<std::string> names;
+    names.reserve(30);
+    for (int i = 0; i < 30; ++i) {
+        names.push_back("joint_" + std::to_string(i));
+    }
+    const IRAsset::Rig rig =
+        IRPrefab::Rig::fromComponent(original, std::span<const std::string>(names));
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeRig(w, rig).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loadedRig = readRig(r);
+    ASSERT_TRUE(loadedRig.ok());
+
+    const IRComponents::C_JointHierarchy roundTripped =
+        IRPrefab::Rig::toComponent(loadedRig.value_);
+
+    const auto gpuBefore = original.toGPUFormat();
+    const auto gpuAfter = roundTripped.toGPUFormat();
+    ASSERT_EQ(gpuBefore.size(), gpuAfter.size());
+    EXPECT_EQ(
+        0,
+        std::memcmp(
+            gpuBefore.data(),
+            gpuAfter.data(),
+            gpuBefore.size() * sizeof(IRRender::GPUJointTransform)
+        )
+    );
+}
+
+TEST(RigFormat, BridgeAnonymousJointsPreserveTransforms) {
+    // No names supplied — bridge should leave name_ empty on every joint,
+    // and the round-trip transforms still match.
+    IRComponents::C_JointHierarchy hierarchy;
+    for (int i = 0; i < 5; ++i) {
+        IRComponents::Joint j;
+        j.translation_ = IRMath::vec4(static_cast<float>(i), 2.0f, 3.0f, 0.0f);
+        j.parentIndex_ = i == 0 ? 0u : static_cast<std::uint32_t>(i - 1);
+        hierarchy.joints_.push_back(j);
+    }
+    const IRAsset::Rig rig = IRPrefab::Rig::fromComponent(hierarchy);
+    for (const auto &j : rig.joints_) {
+        EXPECT_TRUE(j.name_.empty());
+    }
+    const auto restored = IRPrefab::Rig::toComponent(rig);
+    ASSERT_EQ(restored.joints_.size(), hierarchy.joints_.size());
+    for (std::size_t i = 0; i < restored.joints_.size(); ++i) {
+        EXPECT_EQ(restored.joints_[i].parentIndex_, hierarchy.joints_[i].parentIndex_);
+        EXPECT_EQ(restored.joints_[i].translation_.x, hierarchy.joints_[i].translation_.x);
+    }
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- New `.rig` v1 asset format — `IRRG` magic + `JNTS` chunk for joint hierarchies
- `IRAsset::saveRig` / `loadRig` (file) + `writeRig` / `readRig` (buffer) on top of the T-166 binary-I/O primitives
- `engine/prefabs/irreden/voxel/rig_bridge.hpp` translates between asset `Rig` and runtime `C_JointHierarchy` without dragging engine/asset into prefabs
- JSON sidecar emits per-joint `{ index, name, parentIndex }` for designer diffing (Extensibility Rule #6 — write-only)
- Forward-compat: future `BIND` / `ANIM` chunks land without bumping `.rig` v1; per-joint records carry their own `uint16` version (Rules #1 + #3)

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/678
Full chain: T-166 → T-169

When #678 merges, GitHub will auto-retarget this PR's base to `master`.

## Test plan
- [x] `fleet-build --target IrredenEngineAsset` — clean on macOS
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] 11 new `RigFormat.*` tests pass:
  - Empty-rig and 30-bone snake round-trips (buffer + file modes)
  - Bad-magic, version-too-new, missing-file return recoverable errors
  - Forward-compat: unknown `BIND` / `MORE` chunks survive a v1 load
  - No-JNTS chunk returns an empty rig (pose-only override case)
  - Sidecar emission: file present, contains `format`, `jointCount`, joint names, `parentIndex`
  - GPU-matrix parity: `C_JointHierarchy::toGPUFormat()` identical pre- and post-round-trip (the headline acceptance criterion)
  - Bridge anonymous-joints round-trip without names
- [x] Full `IrredenEngineTest`: **530 / 530 pass**

## Notes for reviewer
- `Rig` lives in `engine/asset/`; `C_JointHierarchy` stays in `engine/prefabs/irreden/voxel/`; the bridge in `engine/prefabs/irreden/voxel/rig_bridge.hpp` is the only place the two types meet. This keeps `engine/asset/` free of any dependency on the voxel component (asset stays at its current dependency level — below `world/` / `entity/`).
- Joint records use the same quaternion convention as the runtime component (`{ qw, qx, qy, qz }` packed into `vec4.xyzw`). Documented at the field declaration in `rig_format.hpp` and in the format spec block in `engine/asset/CLAUDE.md`.
- `JsonSidecarWriter` only emits valid JSON (NaN/Inf already sanitized by the T-166 emitter), so no escaping work is needed here.
- No render code, no system added, no `SystemName` enum entry needed.

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)