### PR TITLE
T-175: Move C_Voxel into namespace IRComponents

### DIFF
--- a/engine/prefabs/irreden/voxel/components/component_voxel.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel.hpp
@@ -21,8 +21,6 @@ constexpr std::uint8_t kEmissive = 1u << 1;
 constexpr std::uint8_t kInteractive = 1u << 2;
 } // namespace VoxelFlags
 
-} // namespace IRComponents
-
 /// Per-voxel record. 12 B std430 layout — matches the v2 entity-editor record
 /// budget (`docs/design/entity-editor-epic.md` "Per-voxel record extension").
 ///
@@ -49,7 +47,7 @@ struct C_Voxel {
     C_Voxel(
         IRMath::Color color,
         std::uint8_t material_id = 0,
-        std::uint8_t flags = IRComponents::VoxelFlags::kAoContrib,
+        std::uint8_t flags = VoxelFlags::kAoContrib,
         std::uint8_t bone_id = 0
     )
         : color_{color}
@@ -89,5 +87,7 @@ static_assert(offsetof(C_Voxel, flags_) == 5, "C_Voxel::flags_ must be at offset
 static_assert(offsetof(C_Voxel, bone_id_) == 6, "C_Voxel::bone_id_ must be at offset 6");
 static_assert(offsetof(C_Voxel, pad0_) == 7, "C_Voxel::pad0_ must be at offset 7");
 static_assert(offsetof(C_Voxel, reserved_) == 8, "C_Voxel::reserved_ must be at offset 8");
+
+} // namespace IRComponents
 
 #endif /* COMPONENT_VOXEL_H */

--- a/engine/render/include/irreden/render/voxel_pool_allocation.hpp
+++ b/engine/render/include/irreden/render/voxel_pool_allocation.hpp
@@ -24,9 +24,7 @@ struct VoxelPoolAllocation {
     std::span<IRComponents::C_Position3D> positions_;
     std::span<IRComponents::C_PositionOffset3D> positionOffsets_;
     std::span<IRComponents::C_PositionGlobal3D> positionGlobals_;
-    // C_Voxel lives at global scope (not in IRComponents) — see
-    // engine/prefabs/irreden/voxel/components/component_voxel.hpp.
-    std::span<C_Voxel> voxels_;
+    std::span<IRComponents::C_Voxel> voxels_;
 };
 
 } // namespace IRRender


### PR DESCRIPTION
## Summary
- Moved `C_Voxel` into `namespace IRComponents` to restore namespace symmetry with `VoxelFlags`
- `VoxelFlags` was already inside `IRComponents`; `C_Voxel` was the sole file-scope outlier in the same header
- Updated `VoxelPoolAllocation::voxels_` in `engine/render/include/irreden/render/voxel_pool_allocation.hpp` to use the fully-qualified `IRComponents::C_Voxel`; removed the stale "C_Voxel lives at global scope" comment
- All 76 prefab files that reach `C_Voxel` via `using namespace IRComponents;` are unaffected

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean on macOS/Metal
- [x] `fleet-build --target IrredenEngineTest` clean on macOS/Metal
- [x] `IRShapeDebug --auto-screenshot 10` exits clean, 6 screenshots saved

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)