### PR TITLE
T-165: Editor F-0.5 Phase 3 — gizmo hover + drag interaction

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -40,6 +40,8 @@
 #include <irreden/render/systems/system_sprites_to_screen.hpp>
 #include <irreden/render/systems/system_camera_mouse_pan.hpp>
 #include <irreden/render/systems/system_render_velocity_2d_iso.hpp>
+#include <irreden/render/systems/system_gizmo_hover.hpp>
+#include <irreden/render/systems/system_gizmo_drag.hpp>
 
 // Camera prefab namespace (Z-yaw API)
 #include <irreden/render/camera.hpp>
@@ -117,9 +119,15 @@ void initSystems() {
          IRSystem::createSystem<IRSystem::LIFETIME>()
         }
     );
+    // GIZMO_HOVER reads the previous frame's entity-id GPU readback;
+    // GIZMO_DRAG runs immediately after so press detection sees a fresh
+    // hover flag in the same INPUT pipeline pass.
     IRSystem::registerPipeline(
         IRTime::Events::INPUT,
-        {IRSystem::createSystem<IRSystem::INPUT_KEY_MOUSE>(), scrollZoomSystem}
+        {IRSystem::createSystem<IRSystem::INPUT_KEY_MOUSE>(),
+         scrollZoomSystem,
+         IRSystem::createSystem<IRSystem::GIZMO_HOVER>(),
+         IRSystem::createSystem<IRSystem::GIZMO_DRAG>()}
     );
 
     // Right-click drag rotates the camera Z-yaw (turntable), which in the

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -191,6 +191,12 @@ constexpr float sqrt(float value) {
     return glm::sqrt(value);
 }
 
+/// Two-argument arctangent (radians). Result is in (-π, π]; sign matches
+/// GLSL/std::atan2 convention. GLM wrapper.
+inline float atan2(float y, float x) {
+    return glm::atan(y, x);
+}
+
 /// 2D rotation of @p v by @p angle radians around the origin. The rotation
 /// is CCW for positive angle in a Y-up coordinate system; the visible
 /// direction reverses when applied in a Y-down system.

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -36,16 +36,24 @@ the ECS surface.
 - `C_GizmoHandle` — marker on editor gizmo entities, tagging handle kind
   (translate-arrow, rotate-ring, scale-stick / scale-center, joint /
   bind-point / IK marker) + axis. Carries the Phase 2 (T-164) baseline
-  fields: `referenceParams_` (the unscaled shape descriptor params written
-  at construction), `referenceLocalPos_` (the unscaled local position),
-  and `isAnchor_` (true for single-entity markers whose own
+  fields — `referenceParams_` (the unscaled shape descriptor params
+  written at construction), `referenceLocalPos_` (the unscaled local
+  position), and `isAnchor_` (true for single-entity markers whose own
   `C_Position3D` is the world-space anchor — false for child handles
-  parented under a group root). The `hover_` flag is reserved for the
-  F-0.9 picking pass. Visible geometry comes from a sibling
+  parented under a group root). Also carries the Phase 3 (T-165)
+  interaction fields — `hover_` (stamped each frame by `GIZMO_HOVER`
+  from the GPU entity-id readback), `baseColor_` (the unmodulated
+  color captured at spawn — the hover system writes a brightened tint
+  onto the sibling `C_ShapeDescriptor` while hovered and restores the
+  base on the same frame the hover bit clears), and `anchorEntity_`
+  (the entity whose `C_Position3D` `GIZMO_DRAG` mutates — by
+  convention the gizmo group parent, so all axes of a multi-handle
+  gizmo share one anchor; `kNullEntity` keeps the handle hoverable
+  but disables drag). Visible geometry comes from a sibling
   `C_ShapeDescriptor` on the same entity (SDF primitive rendered by
   `SHAPES_TO_TRIXEL`); the marker carries no rendering state itself.
-  Builders live in `IRPrefab::Gizmo::` (see "Exposing system public API"
-  below).
+  Builders live in `IRPrefab::Gizmo::` (see "Exposing system public
+  API" below).
 
 ## Key systems (all RENDER pipeline)
 
@@ -66,6 +74,46 @@ the ECS surface.
   Bypasses the trixel pipeline; runs after the main canvas's
   `FRAMEBUFFER_TO_SCREEN` tick. Empty-case fast-path means a creation
   can register the system unconditionally — zero sprites = zero draws.
+
+## Editor gizmo interaction (INPUT pipeline; F-0.5 Phase 3)
+
+Two co-pipelined systems drive the gizmo state machine. Both iterate
+`C_GizmoHandle` entities; the editor wires them in the **INPUT**
+pipeline immediately after `INPUT_KEY_MOUSE`, before any UPDATE work,
+so a click in the same frame can already see hover state and apply
+drag math.
+
+- `GIZMO_HOVER` — reads `IRRender::getEntityIdAtMouseTrixel()` once
+  per frame (one-frame-lag GPU readback of the persistent-mapped
+  `HoveredEntityIdBuffer` populated by `f_trixel_to_framebuffer`).
+  Stamps `C_GizmoHandle::hover_` on the handle whose entity id matches,
+  clears all others, and writes a brightened tint onto the sibling
+  `C_ShapeDescriptor` for visual highlight (restored from
+  `C_GizmoHandle::baseColor_` on the same frame the hover bit clears).
+- `GIZMO_DRAG` — left-mouse state machine. On press over a hovered
+  handle, captures the anchor's local position, the cursor's world
+  point projected onto a fixed iso-depth plane through the anchor,
+  and the cursor's canvas-iso angle around the anchor. Each frame the
+  mouse is down, applies kind-specific math to the anchor's
+  `C_Position3D` (translate) or to per-anchor accumulators on the
+  system (rotate / scale): TRANSLATE_ARROW projects cursor world
+  delta onto the handle's unit axis; ROTATE_RING tracks the canvas-
+  iso angle change with Shift snapping to 15° (π/12); SCALE_STICK
+  projects onto the axis with reference distance `kScaleStickRefWorld`
+  voxels; SCALE_CENTER reads diagonal cursor screen displacement with
+  reference `kScaleCenterRefPixels` pixels. Drag releases when the
+  mouse goes up. The "fixed iso-depth plane" anchored at press time
+  is what keeps the gizmo from running away from the cursor as its
+  iso depth changes mid-drag.
+
+Anchor convention: `IRPrefab::Gizmo::spawnHandle` records the
+*parent* passed into the builder as the handle's `anchorEntity_`.
+For `createTranslateGizmo` / `createRotateGizmo` / `createScaleGizmo`
+that's the group entity returned by the builder, so drag moves the
+gizmo as a unit. For `createJointMarker` / `createIKMarker` called
+with a real anchor parent, drag would move that parent — passing
+`kNullEntity` (Phase 1's default in `voxel_editor/main.cpp`) makes
+those handles still hoverable but no-op on drag.
 
 See `engine/render/CLAUDE.md` for the full pipeline diagram.
 
@@ -137,8 +185,11 @@ contest. The gizmo builders opt every spawned handle into the flag so
 occluded handles still read as a faint silhouette. Any other prefab
 that needs a "see through walls" overlay (selection highlight, debug
 marker) can opt in the same way without touching engine/render/.
-Hover + drag interaction lands once T-153 mouse picking is in place
-(Phase 3, blocked by T-153).
+Phase 3 (T-165) wires hover detection + drag interaction via the
+`GIZMO_HOVER` / `GIZMO_DRAG` INPUT-pipeline systems — see "Editor
+gizmo interaction" above for the state machine, the press-locked
+iso-depth plane convention, and the anchor-routing rules used by the
+builders.
 
 ## Trixel UI widget framework
 

--- a/engine/prefabs/irreden/render/components/component_gizmo_handle.hpp
+++ b/engine/prefabs/irreden/render/components/component_gizmo_handle.hpp
@@ -3,33 +3,51 @@
 
 #include <cstdint>
 
+#include <irreden/entity/ir_entity_types.hpp>
 #include <irreden/ir_math.hpp>
+#include <irreden/math/color.hpp>
 
 namespace IRComponents {
 
 /// Per-handle metadata for editor gizmo entities. The visible geometry is
 /// supplied by a sibling `C_ShapeDescriptor` on the same entity; this
-/// component is a marker that tags which gizmo + which axis + whether the
-/// mouse is currently hovering the handle (Phase 3 will read `hover_`).
+/// component is a marker that tags which gizmo + which axis + the runtime
+/// hover / drag state mutated by the input-pipeline gizmo systems.
 ///
-/// `referenceParams_` and `referenceLocalPos_` capture the construction-time
-/// values written by the Phase 1 builders. The Phase 2 screen-space sizing
-/// system (T-164) reads these as the unscaled baseline and writes scaled
-/// copies back to `C_ShapeDescriptor::params_` (and the sibling
-/// `C_Position3D::pos_` when `isAnchor_` is false) each UPDATE tick — so
-/// multiple frames of scaling don't compound. Phase 3 will use the same
-/// baseline for hover / drag.
+/// Phase 2 (T-164) sizing fields:
 ///
-/// `isAnchor_` distinguishes single-entity gizmo markers (joint, IK) — whose
-/// own `C_Position3D` IS the world-space anchor the caller wrote — from
-/// child handles inside a group (translate arrows, rotate rings, scale
-/// sticks/center) — whose `C_Position3D` is a local offset relative to a
-/// group-root parent. Phase 2 scales `params_` for both forms, but only
-/// scales `pos_` for child handles, so the anchor's editor-placed world
-/// position isn't clobbered.
+/// - `referenceParams_` and `referenceLocalPos_` capture the
+///   construction-time values written by the Phase 1 builders. The
+///   `GIZMO_SCREEN_SPACE_SIZE` UPDATE system reads these as the
+///   unscaled baseline and writes scaled copies back to
+///   `C_ShapeDescriptor::params_` (and the sibling `C_Position3D::pos_`
+///   when `isAnchor_` is false) each tick — so multiple frames of
+///   scaling don't compound.
+/// - `isAnchor_` distinguishes single-entity gizmo markers (joint, IK)
+///   — whose own `C_Position3D` IS the world-space anchor the caller
+///   wrote — from child handles inside a group (translate arrows,
+///   rotate rings, scale sticks/center) — whose `C_Position3D` is a
+///   local offset relative to a group-root parent. Phase 2 scales
+///   `params_` for both forms, but only scales `pos_` for child
+///   handles, so the anchor's editor-placed world position isn't
+///   clobbered.
 ///
-/// Phase 1 (F-0.5) does not yet wire hover or drag — `hover_` defaults to
-/// false and the field is reserved for the upcoming mouse-picking pass.
+/// Phase 3 (T-165) interaction fields:
+///
+/// - `hover_` is set each frame by `GIZMO_HOVER` from the GPU entity-id
+///   readback (`IRRender::getEntityIdAtMouseTrixel`). At most one
+///   handle per frame is flagged.
+/// - `baseColor_` is the unmodulated color of the handle (captured by
+///   the builder when the entity is spawned). `GIZMO_HOVER` writes
+///   this back onto `C_ShapeDescriptor::color_` when the handle is not
+///   hovered, and writes a brightened version when it is. Storing the
+///   base on the handle keeps the round-trip lossless across frames.
+/// - `anchorEntity_` is the entity whose `C_Position3D` `GIZMO_DRAG`
+///   mutates while this handle is being dragged. By convention it
+///   points at the gizmo *group* entity (the parent that owns the
+///   handle bundle), so all axes of a given gizmo move the same
+///   anchor together. `kNullEntity` disables drag for the handle
+///   (still hoverable).
 
 enum class GizmoKind : std::uint8_t {
     TRANSLATE_ARROW,   ///< Cylinder shaft + cone head along an axis.
@@ -55,6 +73,8 @@ struct C_GizmoHandle {
     bool isAnchor_ = true;
     IRMath::vec4 referenceParams_ = IRMath::vec4(1.0f, 1.0f, 1.0f, 0.0f);
     IRMath::vec3 referenceLocalPos_ = IRMath::vec3(0.0f);
+    IRMath::Color baseColor_ = IRMath::Color{220, 220, 220, 255};
+    IREntity::EntityId anchorEntity_ = IREntity::kNullEntity;
 
     C_GizmoHandle() = default;
 
@@ -67,13 +87,17 @@ struct C_GizmoHandle {
         GizmoAxis axis,
         IRMath::vec4 referenceParams,
         IRMath::vec3 referenceLocalPos,
-        bool isAnchor
+        bool isAnchor,
+        IRMath::Color baseColor,
+        IREntity::EntityId anchorEntity
     )
         : kind_{kind}
         , axis_{axis}
         , isAnchor_{isAnchor}
         , referenceParams_{referenceParams}
-        , referenceLocalPos_{referenceLocalPos} {}
+        , referenceLocalPos_{referenceLocalPos}
+        , baseColor_{baseColor}
+        , anchorEntity_{anchorEntity} {}
 };
 
 } // namespace IRComponents

--- a/engine/prefabs/irreden/render/gizmo.hpp
+++ b/engine/prefabs/irreden/render/gizmo.hpp
@@ -1,18 +1,23 @@
 #ifndef IR_PREFAB_GIZMO_H
 #define IR_PREFAB_GIZMO_H
 
-// Editor gizmo primitives — Phase 1 (geometry only).
+// Editor gizmo primitives — geometry + interaction wiring.
 //
 // Each builder spawns a small group of ECS entities, each carrying a
 // `C_ShapeDescriptor` (rendered by SHAPES_TO_TRIXEL) and a
-// `C_GizmoHandle` marker for the upcoming interaction work. Returns the
-// root entity of the group so callers can re-parent or destroy as a unit.
+// `C_GizmoHandle` marker for the interaction systems. Returns the root
+// entity of the group so callers can re-parent or destroy as a unit.
 //
-// Phase 1 renders handles at fixed world-space size. Phase 2 (T-164) adds
-// the screen-space sizing UPDATE system (`GIZMO_SCREEN_SPACE_SIZE`) and
-// opts each handle into the generic `SHAPE_FLAG_XRAY_OCCLUDED` shader path
-// so occluded handles still read as a faint silhouette. Phase 3 will wire
-// hover detection + drag interaction once T-153 (mouse picking) lands.
+// Phase 1 renders handles at fixed world-space size. Phase 2 (T-164)
+// adds the screen-space sizing UPDATE system (`GIZMO_SCREEN_SPACE_SIZE`)
+// and opts each handle into the generic `SHAPE_FLAG_XRAY_OCCLUDED`
+// shader path so occluded handles still read as a faint silhouette.
+// Phase 3 (T-165) wires hover detection + drag interaction via the
+// `GIZMO_HOVER` / `GIZMO_DRAG` INPUT-pipeline systems; each spawned
+// handle carries `baseColor_` (for the hover tint round-trip) and
+// `anchorEntity_` (the entity whose `C_Position3D` drag mutates — the
+// gizmo group parent for multi-handle gizmos, `kNullEntity` for
+// single-marker handles that should be hoverable but not draggable).
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -101,25 +106,30 @@ inline IREntity::EntityId spawnHandle(
     Color color,
     const char *name
 ) {
-    // Opt the handle's shape into the generic xray-occlusion shader path so
-    // SHAPES_TO_TRIXEL emits the faint-silhouette alpha blend where the
-    // handle sits behind closer geometry (T-164 Phase 2).
+    // Opt the handle's shape into the generic xray-occlusion shader path
+    // so SHAPES_TO_TRIXEL emits the faint-silhouette alpha blend where
+    // the handle sits behind closer geometry (T-164 Phase 2).
     C_ShapeDescriptor shapeDesc{shapeType, shapeParams, color};
     shapeDesc.flags_ = IRRender::SHAPE_FLAG_VISIBLE | IRRender::SHAPE_FLAG_XRAY_OCCLUDED;
 
-    // Capture the construction-time reference values on the handle. The
-    // Phase 2 screen-space sizing system reads `referenceParams_` /
-    // `referenceLocalPos_` as the unscaled baseline and writes
-    // (baseline × pixelSize / zoom) back to the sibling components each
-    // UPDATE tick. `isAnchor_` is true for single-entity markers whose
-    // own `C_Position3D` is the world-space anchor (the editor writes it
-    // post-construction) — Phase 2 then scales params but leaves pos
-    // alone so the editor placement isn't clobbered.
+    // Capture construction-time reference values on the handle for
+    // downstream systems. Phase 2 screen-space sizing reads
+    // `referenceParams_` / `referenceLocalPos_` as the unscaled baseline
+    // and writes scaled copies back each UPDATE tick. `isAnchor_` is
+    // true for single-entity markers whose own `C_Position3D` is the
+    // world-space anchor (the editor writes it post-construction) —
+    // Phase 2 then scales params but leaves pos alone. Phase 3 records
+    // `baseColor_` for the hover-tint round-trip and `anchorEntity_` =
+    // `parent` so drag mutations land on the gizmo group entity (so
+    // every axis of a multi-handle gizmo shares one anchor). For
+    // single-marker handles called with `parent == kNullEntity`, the
+    // anchor is null — the handle is still hoverable but drag is a
+    // no-op.
     const bool isAnchor = (parent == IREntity::kNullEntity);
     IREntity::EntityId handle = IREntity::createEntity(
         C_Position3D{localPos},
         shapeDesc,
-        C_GizmoHandle{kind, axis, shapeParams, localPos, isAnchor},
+        C_GizmoHandle{kind, axis, shapeParams, localPos, isAnchor, color, parent},
         C_Name{name}
     );
     if (!isAnchor) {

--- a/engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp
+++ b/engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp
@@ -62,8 +62,16 @@ template <> struct System<GIZMO_DRAG> {
     IRMath::vec2 dragAnchorScreenIso_ = IRMath::vec2(0.0f);
     float dragStartRotateAngle_ = 0.0f;
 
-    // Per-anchor accumulated state. Stays attached to the same anchor
-    // across drag sessions so successive rotate / scale gestures stack.
+    // Per-drag readouts for the rotate / scale gestures. applyDrag()
+    // OVERWRITES each frame with a fresh delta from THAT drag's press
+    // point — successive drags do NOT numerically stack here. Storage
+    // is keyed by anchor so beginDrag() can reset to identity when the
+    // gizmo target changes, keeping stale values from a previous
+    // gizmo's drag from appearing as the new gizmo's current state.
+    // endTick() reads these on the press→release transition to log the
+    // final per-drag value. Wiring rotate / scale to an accumulating
+    // render-side component is a follow-up once a canonical
+    // C_Rotation / C_Scale pair lands.
     IREntity::EntityId accumOwner_ = IREntity::kNullEntity;
     float accumRotateAngle_ = 0.0f;
     float accumScaleUniform_ = 1.0f;

--- a/engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp
+++ b/engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp
@@ -128,9 +128,6 @@ template <> struct System<GIZMO_DRAG> {
             // Release on previous frame's HELD slipping to RELEASED+up.
             dragHandle_ = IREntity::kNullEntity;
         }
-        if (dragHandle_ != IREntity::kNullEntity && mouseLeftReleasedThisFrame_) {
-            dragHandle_ = IREntity::kNullEntity;
-        }
     }
 
     void tick(IREntity::EntityId id, IRComponents::C_GizmoHandle &handle) {
@@ -144,7 +141,6 @@ template <> struct System<GIZMO_DRAG> {
         if (dragHandle_ == id && mouseLeftDown_) {
             applyDrag();
         }
-        (void)handle;
     }
 
     void endTick() {

--- a/engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp
+++ b/engine/prefabs/irreden/render/systems/system_gizmo_drag.hpp
@@ -1,0 +1,317 @@
+#ifndef SYSTEM_GIZMO_DRAG_H
+#define SYSTEM_GIZMO_DRAG_H
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_input.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_profile.hpp>
+#include <irreden/ir_render.hpp>
+#include <irreden/ir_system.hpp>
+
+#include <irreden/common/components/component_position_3d.hpp>
+#include <irreden/render/camera.hpp>
+#include <irreden/render/components/component_gizmo_handle.hpp>
+
+namespace IRSystem {
+
+// Editor gizmo drag — drives the interaction state machine over the
+// per-frame hover flag GIZMO_HOVER just wrote. One drag is active at a
+// time; the dragged handle's anchor entity (typically the gizmo group)
+// gets its C_Position3D / accumulated rotation / accumulated scale
+// updated until the mouse button releases.
+//
+// Pipeline: INPUT, after GIZMO_HOVER. Mutates anchor `C_Position3D::pos_`
+// (translate) and accumulates rotate / scale state on the system params
+// — render-side application of rotate/scale is a follow-up once a
+// canonical rotation/scale component lands.
+//
+// Drag math (translate):
+//   - At press, capture (a) the anchor's local position, (b) the
+//     cursor's world point projected onto a fixed iso-depth plane
+//     through the anchor.
+//   - Each frame, recompute the cursor world point at THAT SAME plane
+//     and project the world delta onto the handle's unit axis.
+//   - anchor.pos_ = startPos + axisUnit * dot(worldDelta, axisUnit).
+//   Fixing the plane prevents the gizmo from running away from the
+//   cursor as its iso depth changes.
+//
+// Drag math (rotate):
+//   - Use screen-space angle of cursor around the anchor's iso pixel.
+//     Phase 3 MVP: same screen-space angle for all three rings; later
+//     refinement can project the ring plane into screen and use a
+//     true axis-perpendicular angle.
+//   - Shift held → angle snaps to `kRotateSnapStep` (π/12 = 15°).
+//
+// Drag math (scale):
+//   - SCALE_CENTER: cursor screen-distance from press point → uniform
+//     scale delta.
+//   - SCALE_STICK: world axis projection (same as translate) → single-
+//     axis scale delta.
+template <> struct System<GIZMO_DRAG> {
+    // Active drag — kNullEntity when no handle is being dragged.
+    IREntity::EntityId dragHandle_ = IREntity::kNullEntity;
+    IREntity::EntityId dragAnchor_ = IREntity::kNullEntity;
+    IRComponents::GizmoKind dragKind_ = IRComponents::GizmoKind::TRANSLATE_ARROW;
+    IRComponents::GizmoAxis dragAxis_ = IRComponents::GizmoAxis::NONE;
+
+    // Press-time captures.
+    IRMath::vec3 dragStartAnchorPos_ = IRMath::vec3(0.0f);
+    IRMath::vec3 dragStartCursorWorld_ = IRMath::vec3(0.0f);
+    float dragPlaneIsoDepth_ = 0.0f;
+    IRMath::vec2 dragStartCursorScreen_ = IRMath::vec2(0.0f);
+    IRMath::vec2 dragAnchorScreenIso_ = IRMath::vec2(0.0f);
+    float dragStartRotateAngle_ = 0.0f;
+
+    // Per-anchor accumulated state. Stays attached to the same anchor
+    // across drag sessions so successive rotate / scale gestures stack.
+    IREntity::EntityId accumOwner_ = IREntity::kNullEntity;
+    float accumRotateAngle_ = 0.0f;
+    float accumScaleUniform_ = 1.0f;
+    IRMath::vec3 accumScalePerAxis_ = IRMath::vec3(1.0f);
+
+    // Per-frame input state.
+    bool mouseLeftPressedThisFrame_ = false;
+    bool mouseLeftReleasedThisFrame_ = false;
+    bool mouseLeftDown_ = false;
+    bool shiftHeld_ = false;
+    IRMath::vec2 mouseScreen_ = IRMath::vec2(0.0f);
+    IRMath::vec2 mouseCanvasIso_ = IRMath::vec2(0.0f);
+
+    // 15 degrees in radians for shift-snap rotate.
+    static constexpr float kRotateSnapStep = IRMath::kPi / 12.0f;
+    // Pixel reference scale for SCALE_CENTER uniform sensitivity.
+    static constexpr float kScaleCenterRefPixels = 200.0f;
+    // World-unit reference scale for SCALE_STICK per-axis sensitivity.
+    static constexpr float kScaleStickRefWorld = 8.0f;
+
+    // Track previous drag handle across frames so the release transition
+    // (any → kNullEntity) fires a one-shot final-state log; useful for
+    // verifying ROTATE_RING / SCALE_* whose state lives on the system
+    // params and isn't yet wired to a render-visible rotation / scale
+    // component on the anchor.
+    IREntity::EntityId prevDragHandle_ = IREntity::kNullEntity;
+
+    void beginTick() {
+        mouseLeftPressedThisFrame_ = IRInput::checkKeyMouseButton(
+            IRInput::KeyMouseButtons::kMouseButtonLeft,
+            IRInput::ButtonStatuses::PRESSED
+        );
+        mouseLeftReleasedThisFrame_ = IRInput::checkKeyMouseButton(
+            IRInput::KeyMouseButtons::kMouseButtonLeft,
+            IRInput::ButtonStatuses::RELEASED
+        );
+        const bool held = IRInput::checkKeyMouseButton(
+            IRInput::KeyMouseButtons::kMouseButtonLeft,
+            IRInput::ButtonStatuses::HELD
+        );
+        mouseLeftDown_ = held || mouseLeftPressedThisFrame_;
+        shiftHeld_ = IRInput::checkKeyMouseButton(
+                         IRInput::KeyMouseButtons::kKeyButtonLeftShift,
+                         IRInput::ButtonStatuses::HELD
+                     ) ||
+                     IRInput::checkKeyMouseButton(
+                         IRInput::KeyMouseButtons::kKeyButtonRightShift,
+                         IRInput::ButtonStatuses::HELD
+                     );
+        mouseScreen_ = IRInput::getMousePositionScreen();
+        mouseCanvasIso_ = IRRender::mousePosition2DIsoWorldRender();
+
+        if (dragHandle_ != IREntity::kNullEntity && !mouseLeftDown_) {
+            // Release on previous frame's HELD slipping to RELEASED+up.
+            dragHandle_ = IREntity::kNullEntity;
+        }
+        if (dragHandle_ != IREntity::kNullEntity && mouseLeftReleasedThisFrame_) {
+            dragHandle_ = IREntity::kNullEntity;
+        }
+    }
+
+    void tick(IREntity::EntityId id, IRComponents::C_GizmoHandle &handle) {
+        // 1) Drag-start: this handle is hovered + mouse just pressed + no other drag.
+        if (dragHandle_ == IREntity::kNullEntity && mouseLeftPressedThisFrame_ && handle.hover_ &&
+            handle.anchorEntity_ != IREntity::kNullEntity) {
+            beginDrag(id, handle);
+        }
+
+        // 2) Drag-update: this handle is the active one, mouse still down.
+        if (dragHandle_ == id && mouseLeftDown_) {
+            applyDrag();
+        }
+        (void)handle;
+    }
+
+    void endTick() {
+        if (prevDragHandle_ != IREntity::kNullEntity && dragHandle_ == IREntity::kNullEntity) {
+            // Drag released this frame. Log final state per kind so the
+            // ROTATE_RING / SCALE_* gestures are reviewable in headless
+            // smoke runs (no render-visible rotation/scale yet).
+            switch (dragKind_) {
+            case IRComponents::GizmoKind::ROTATE_RING:
+                IRE_LOG_INFO(
+                    "GIZMO_DRAG ROTATE_RING axis={} release: angle={:.4f} rad ({})",
+                    static_cast<int>(dragAxis_),
+                    accumRotateAngle_,
+                    shiftHeld_ ? "shift-snapped" : "free"
+                );
+                break;
+            case IRComponents::GizmoKind::SCALE_CENTER:
+                IRE_LOG_INFO("GIZMO_DRAG SCALE_CENTER release: uniform={:.4f}", accumScaleUniform_);
+                break;
+            case IRComponents::GizmoKind::SCALE_STICK:
+                IRE_LOG_INFO(
+                    "GIZMO_DRAG SCALE_STICK axis={} release: perAxis=({:.4f},{:.4f},{:.4f})",
+                    static_cast<int>(dragAxis_),
+                    accumScalePerAxis_.x,
+                    accumScalePerAxis_.y,
+                    accumScalePerAxis_.z
+                );
+                break;
+            default:
+                break;
+            }
+        }
+        prevDragHandle_ = dragHandle_;
+    }
+
+    void beginDrag(IREntity::EntityId id, const IRComponents::C_GizmoHandle &handle) {
+        dragHandle_ = id;
+        dragAnchor_ = handle.anchorEntity_;
+        dragKind_ = handle.kind_;
+        dragAxis_ = handle.axis_;
+
+        auto &anchorLocal = IREntity::getComponent<IRComponents::C_Position3D>(dragAnchor_);
+        auto &anchorGlobal = IREntity::getComponent<IRComponents::C_PositionGlobal3D>(dragAnchor_);
+        auto &anchorOffset = IREntity::getComponent<IRComponents::C_PositionOffset3D>(dragAnchor_);
+        const IRMath::vec3 anchorWorld = anchorGlobal.pos_ + anchorOffset.pos_;
+
+        dragStartAnchorPos_ = anchorLocal.pos_;
+        dragPlaneIsoDepth_ = canvasIsoDepthOfAnchor(anchorWorld);
+        dragStartCursorWorld_ = IRRender::mouseWorldPos3DAtIsoDepth(dragPlaneIsoDepth_);
+        dragStartCursorScreen_ = mouseScreen_;
+        dragAnchorScreenIso_ = anchorIsoPosition(anchorWorld);
+
+        // Reset per-anchor accumulators when the anchor changes so the
+        // rotate / scale displays don't carry over between different
+        // gizmos.
+        if (accumOwner_ != dragAnchor_) {
+            accumOwner_ = dragAnchor_;
+            accumRotateAngle_ = 0.0f;
+            accumScaleUniform_ = 1.0f;
+            accumScalePerAxis_ = IRMath::vec3(1.0f);
+        }
+
+        dragStartRotateAngle_ = cursorCanvasAngle(mouseCanvasIso_);
+    }
+
+    void applyDrag() {
+        auto &anchorLocal = IREntity::getComponent<IRComponents::C_Position3D>(dragAnchor_);
+
+        switch (dragKind_) {
+        case IRComponents::GizmoKind::TRANSLATE_ARROW: {
+            const IRMath::vec3 axisUnit = axisToUnit(dragAxis_);
+            const IRMath::vec3 cursorWorld =
+                IRRender::mouseWorldPos3DAtIsoDepth(dragPlaneIsoDepth_);
+            const IRMath::vec3 worldDelta = cursorWorld - dragStartCursorWorld_;
+            const float along = IRMath::dot(worldDelta, axisUnit);
+            anchorLocal.pos_ = dragStartAnchorPos_ + axisUnit * along;
+            break;
+        }
+        case IRComponents::GizmoKind::ROTATE_RING: {
+            const float currentAngle = cursorCanvasAngle(mouseCanvasIso_);
+            float delta = wrapToPi(currentAngle - dragStartRotateAngle_);
+            if (shiftHeld_) {
+                delta = IRMath::round(delta / kRotateSnapStep) * kRotateSnapStep;
+            }
+            accumRotateAngle_ = delta;
+            break;
+        }
+        case IRComponents::GizmoKind::SCALE_STICK: {
+            const IRMath::vec3 axisUnit = axisToUnit(dragAxis_);
+            const IRMath::vec3 cursorWorld =
+                IRRender::mouseWorldPos3DAtIsoDepth(dragPlaneIsoDepth_);
+            const IRMath::vec3 worldDelta = cursorWorld - dragStartCursorWorld_;
+            const float along = IRMath::dot(worldDelta, axisUnit);
+            const float factor = 1.0f + along / kScaleStickRefWorld;
+            IRMath::vec3 perAxis = IRMath::vec3(1.0f);
+            switch (dragAxis_) {
+            case IRComponents::GizmoAxis::X:
+                perAxis.x = factor;
+                break;
+            case IRComponents::GizmoAxis::Y:
+                perAxis.y = factor;
+                break;
+            case IRComponents::GizmoAxis::Z:
+                perAxis.z = factor;
+                break;
+            default:
+                break;
+            }
+            accumScalePerAxis_ = perAxis;
+            break;
+        }
+        case IRComponents::GizmoKind::SCALE_CENTER: {
+            const IRMath::vec2 screenDelta = mouseScreen_ - dragStartCursorScreen_;
+            const float signedMag = screenDelta.x + screenDelta.y; // diagonal-positive convention
+            accumScaleUniform_ = 1.0f + signedMag / kScaleCenterRefPixels;
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    static SystemId create() {
+        return registerSystem<GIZMO_DRAG, IRComponents::C_GizmoHandle>("GizmoDrag");
+    }
+
+  private:
+    static IRMath::vec3 axisToUnit(IRComponents::GizmoAxis axis) {
+        switch (axis) {
+        case IRComponents::GizmoAxis::X:
+            return IRMath::vec3(1.0f, 0.0f, 0.0f);
+        case IRComponents::GizmoAxis::Y:
+            return IRMath::vec3(0.0f, 1.0f, 0.0f);
+        case IRComponents::GizmoAxis::Z:
+            return IRMath::vec3(0.0f, 0.0f, 1.0f);
+        case IRComponents::GizmoAxis::NONE:
+        default:
+            return IRMath::vec3(0.0f);
+        }
+    }
+
+    static float canvasIsoDepthOfAnchor(IRMath::vec3 worldPos) {
+        const IRMath::CardinalIndex idx =
+            IRMath::rasterYawCardinalIndex(IRPrefab::Camera::getRasterYaw());
+        const IRMath::vec3 rotated = IRMath::rotateCardinalZ(worldPos, idx);
+        return static_cast<float>(IRMath::pos3DtoDistance(rotated));
+    }
+
+    static IRMath::vec2 anchorIsoPosition(IRMath::vec3 worldPos) {
+        const IRMath::CardinalIndex idx =
+            IRMath::rasterYawCardinalIndex(IRPrefab::Camera::getRasterYaw());
+        const IRMath::vec3 rotated = IRMath::rotateCardinalZ(worldPos, idx);
+        return IRMath::pos3DtoPos2DIso(rotated);
+    }
+
+    // Canvas-iso-space angle of the cursor measured from the anchor's
+    // iso position, in radians. Both terms live in the rasterYaw-
+    // rotated canvas iso frame (mousePosition2DIsoWorldRender ↔
+    // pos3DtoPos2DIso(rotateCardinalZ(worldPos))) so the relative
+    // vector is camera-pan invariant. wrapToPi normalizes deltas
+    // across the ±π discontinuity.
+    float cursorCanvasAngle(IRMath::vec2 cursorCanvas) const {
+        const IRMath::vec2 delta = cursorCanvas - dragAnchorScreenIso_;
+        return IRMath::atan2(delta.y, delta.x);
+    }
+
+    static float wrapToPi(float a) {
+        while (a > IRMath::kPi)
+            a -= IRMath::kTwoPi;
+        while (a < -IRMath::kPi)
+            a += IRMath::kTwoPi;
+        return a;
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_GIZMO_DRAG_H */

--- a/engine/prefabs/irreden/render/systems/system_gizmo_hover.hpp
+++ b/engine/prefabs/irreden/render/systems/system_gizmo_hover.hpp
@@ -1,0 +1,66 @@
+#ifndef SYSTEM_GIZMO_HOVER_H
+#define SYSTEM_GIZMO_HOVER_H
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_render.hpp>
+#include <irreden/ir_system.hpp>
+
+#include <irreden/render/components/component_gizmo_handle.hpp>
+#include <irreden/voxel/components/component_shape_descriptor.hpp>
+
+namespace IRSystem {
+
+// Editor gizmo hover detection. Reads the entity-id GPU readback
+// (`IRRender::getEntityIdAtMouseTrixel`, filled by f_trixel_to_framebuffer)
+// once per frame and stamps `C_GizmoHandle::hover_` accordingly. Also
+// writes the visual highlight back onto the sibling `C_ShapeDescriptor` —
+// hovered handles get a brightened tint, others get the base color
+// captured at spawn. Keeping both ends of the round-trip on this system
+// means the renderer needs no per-frame branch on hover_.
+//
+// Pipeline: INPUT, after INPUT_KEY_MOUSE (the cursor position used by the
+// previous frame's framebuffer pass is what `getEntityIdAtMouseTrixel`
+// returns; nothing in INPUT mutates it). Must come before GIZMO_DRAG so
+// press detection sees a fresh hover_.
+template <> struct System<GIZMO_HOVER> {
+    IREntity::EntityId cursorEntity_ = IREntity::kNullEntity;
+
+    void beginTick() {
+        cursorEntity_ = IRRender::getEntityIdAtMouseTrixel();
+    }
+
+    void tick(
+        IREntity::EntityId id,
+        IRComponents::C_GizmoHandle &handle,
+        IRComponents::C_ShapeDescriptor &shape
+    ) {
+        const bool hovered = (cursorEntity_ != IREntity::kNullEntity) && (id == cursorEntity_);
+        handle.hover_ = hovered;
+        shape.color_ = hovered ? brighten(handle.baseColor_) : handle.baseColor_;
+    }
+
+    static SystemId create() {
+        return registerSystem<
+            GIZMO_HOVER,
+            IRComponents::C_GizmoHandle,
+            IRComponents::C_ShapeDescriptor>("GizmoHover");
+    }
+
+  private:
+    // Lifts each non-alpha channel toward 255 by ~40%. Keeps relative
+    // hue (the brighten target is the same direction as the base color),
+    // restores cleanly from a saved baseColor_ on the same frame the
+    // hover bit clears.
+    static IRMath::Color brighten(IRMath::Color c) {
+        const auto lift = [](std::uint8_t v) -> std::uint8_t {
+            const int boosted = static_cast<int>(v) + (255 - static_cast<int>(v)) * 2 / 5;
+            return static_cast<std::uint8_t>(IRMath::min(255, boosted));
+        };
+        return IRMath::Color{lift(c.red_), lift(c.green_), lift(c.blue_), c.alpha_};
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_GIZMO_HOVER_H */

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -134,6 +134,13 @@ enum SystemName {
     WIDGET_INPUT_PANEL_DRAG,
     WIDGET_RENDER_DOCK_PREVIEW,
 
+    // Editor gizmo interaction (INPUT pipeline; F-0.5 Phase 3).
+    // GIZMO_HOVER reads the entity-id GPU readback and toggles
+    // C_GizmoHandle::hover_; GIZMO_DRAG drives the drag state machine
+    // (press → axis-projected translate / shift-snap rotate / scale).
+    GIZMO_HOVER,
+    GIZMO_DRAG,
+
     // Reserved for tests of the registerSystem<> member-on-System<N>
     // helper. Do not use from a creation or prefab system.
     TEST_REGISTER_SYSTEM_A,


### PR DESCRIPTION
## Summary

Phase 3 of the editor gizmo work — hover detection + drag state machine
on top of T-152's geometry. Stacks on **PR #672**.

- **`GIZMO_HOVER`** (INPUT pipeline) reads the entity-id GPU readback
  (`IRRender::getEntityIdAtMouseTrixel`) once per frame and stamps
  `C_GizmoHandle::hover_` on the handle whose pixel matches the cursor.
  Writes a brightened tint onto the sibling `C_ShapeDescriptor`,
  restored from `C_GizmoHandle::baseColor_` on the same frame the
  hover bit clears.
- **`GIZMO_DRAG`** (INPUT pipeline, right after hover) drives the
  left-mouse drag state:
  - `TRANSLATE_ARROW`: project cursor world delta onto unit axis,
    write anchor `C_Position3D::pos_`. Fixed iso-depth plane at press
    time keeps the gizmo from drifting away from the cursor as iso
    depth changes mid-drag.
  - `ROTATE_RING`: canvas-iso angle around the anchor; Shift snaps
    to π/12 (15°). Accumulated angle logged on release (no visible
    rotation yet — see Deferred below).
  - `SCALE_STICK`: world-axis projection with `kScaleStickRefWorld`
    reference (per-axis scale).
  - `SCALE_CENTER`: diagonal cursor screen displacement with
    `kScaleCenterRefPixels` reference (uniform scale).
- `C_GizmoHandle` grows `baseColor_` (round-trip for the hover tint)
  and `anchorEntity_` (the entity whose `C_Position3D` drag mutates;
  `IRPrefab::Gizmo::spawnHandle` sets it to the builder's `parent`
  argument).
- `SystemName` grows `GIZMO_HOVER` and `GIZMO_DRAG`.
- `IRMath` gains an `atan2` wrapper used by the rotate math (rule:
  never call `glm::` directly outside `engine/math/`).
- `voxel_editor/main.cpp` wires the two systems in the INPUT pipeline
  after `INPUT_KEY_MOUSE` + `scrollZoom`.

## Stack context

**Stacked on: #672** (T-152 gizmo primitive geometry, claude/T-152-gizmo-primitives)
Full chain: T-152 → T-165.

When PR #672 merges, this PR's base auto-rebases to `master`. Don't
review until #672 has been reviewed — `C_GizmoHandle::hover_` lands
in #672.

## Deferred (Phase 3 MVP boundary)

Rotate / scale accumulators live on the system params and log final
values on release. Wiring them to render-visible rotation / scale
components on the anchor needs a canonical `C_Rotation` / `C_Scale`
component pair (the current `engine/prefabs/irreden/common/components/
component_rotation.hpp` is an unused stub with a syntax error at
line 19) — that's a follow-up task. Translate is fully visible.

## Test plan

- [x] `fleet-build --target IRVoxelEditor` clean on macos-debug.
- [x] `fleet-build --target IRShapeDebug` clean — no engine-static-lib
  regression from the new SystemName enum entries.
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — all 6 shots
  captured cleanly; no static render regression in the SDF /
  shapes-to-trixel path I touch indirectly via entity-id texture
  readback.
- [x] `fleet-run --timeout 6 IRVoxelEditor` — boots, registers
  pipelines, no crash.
- [ ] **Interactive verification** (reviewer / human): launch
  `IRVoxelEditor`, hover each translate arrow / rotate ring / scale
  stick / scale center — handle brightens. Click-drag X arrow —
  gizmo moves in world X only. Click-drag rotate ring — log on
  release shows `angle=` value; with Shift held, value is a
  multiple of `0.2618` rad (π/12 = 15°). Click-drag scale center
  — log on release shows `uniform=` ≠ 1.0.

## Notes for reviewer

- ECS rules: drag system mutates a foreign entity (the anchor's
  `C_Position3D`) inside the per-handle tick — once per frame on
  the single active drag, which is the documented batched-foreign-
  entity exception, not a per-pair hot-path.
- Cross-host: macOS-authored. Engine code paths touched are pure
  C++; the entity-id texture readback path was already on master
  via `f_trixel_to_framebuffer` / `c_voxel_to_trixel_stage_2`
  (GLSL) and `trixel_to_framebuffer.metal` /
  `c_voxel_to_trixel_stage_2.metal` (Metal). No shader changes
  here.
- Static screenshots are unchanged — visual delta is interaction-
  only.

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)