### PR TITLE
T-172: tooling: simplify + review-pr serialized-struct version-bump check

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -270,6 +270,15 @@ or any `c_compute_*shadow*.glsl` / `.metal`)
 - ❌ Hard-coded `x + y + z` where `IRMath::pos3DtoDistance` exists.
 - ❌ PlaneIso axis swapped.
 
+**Serialization** (when the diff touches `engine/asset/`, `engine/prefabs/irreden/voxel/`, or `engine/world/`)
+- ❌ A struct annotated `// IRAsset: serialized` gained, lost, or renamed a field without
+  bumping `static constexpr uint16_t kSaveVersion = N;` in the same diff.
+  Fix: increment `kSaveVersion` and add a reader migration keyed on
+  `(structType, oldVersion)` in the format's load function. (Save Format Extensibility Rule #3.)
+- ❌ A new serialized record type with no `// IRAsset: serialized` annotation — the
+  simplify and review-pr checks cannot guard it without the annotation. Add the annotation
+  and set `kSaveVersion = 1` on the struct.
+
 **Naming / style**
 - ❌ `m_` on public members, trailing `_` on private members (backwards).
 - ❌ `MinimapDetail`-style feature-specific helper namespaces instead of

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -205,6 +205,52 @@ Already covered by section 6 (Reuse opportunities) — left here only as
 a cross-reference. The engine has `IRE_LOG_*` and `IR_LOG_*` macros;
 raw stdout/printf in non-debug code is a cleanup target.
 
+### 2c. Serialized-struct version-bump check
+
+When a struct annotated `// IRAsset: serialized` gains, loses, or renames a
+field, the matching `kSaveVersion` constant must be bumped in the same diff
+and a migration entry must exist (or be flagged as a `// TODO: migration`
+comment) in the format's reader. This is Save Format Extensibility Rule #3
+(`engine/asset/CLAUDE.md`).
+
+Run this check whenever any `.hpp` or `.cpp` file under `engine/asset/`,
+`engine/prefabs/irreden/voxel/`, or `engine/world/` is in the diff.
+
+**Detection:**
+
+1. Scan the diff's `+` lines for struct fields (member variable declarations)
+   inside a struct body that is preceded — anywhere in the same file — by the
+   comment `// IRAsset: serialized`. The struct name is on the line with
+   `struct <Name>`.
+
+2. For each struct type whose field layout changed (added/removed/renamed
+   field on a `+` or `-` line), check whether the diff also contains a
+   corresponding `kSaveVersion` change on a `+` line in the same file (or a
+   sibling sidecar file for the format):
+
+   ```
+   static constexpr uint16_t kSaveVersion = N;
+   ```
+
+3. If the field layout changed but no `kSaveVersion` bump appears in the
+   diff, emit a finding — **do not auto-fix**, this needs human judgment:
+
+   ```
+   reported 1 finding for review:
+     - <path>:<line> — <StructName> is annotated // IRAsset: serialized and
+       its field layout changed, but kSaveVersion was not bumped.
+       Add `static constexpr uint16_t kSaveVersion = N+1;` and a migration
+       entry in the format's reader for saves written at the old version.
+   ```
+
+**False-positive guard — do NOT flag:**
+- Changes to method bodies, constructors, or `static` helper functions within
+  the struct (these do not affect binary layout).
+- A struct whose `// IRAsset: serialized` annotation was itself added in the
+  same diff — version 1 never needs a migration.
+- Changes to the `kSaveVersion` line itself.
+- Changes that only touch comments or whitespace inside the struct.
+
 ### 3. Naming convention slips
 
 These are the rules from [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md):

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -219,9 +219,10 @@ Run this check whenever any `.hpp` or `.cpp` file under `engine/asset/`,
 **Detection:**
 
 1. Scan the diff's `+` lines for struct fields (member variable declarations)
-   inside a struct body that is preceded — anywhere in the same file — by the
-   comment `// IRAsset: serialized`. The struct name is on the line with
-   `struct <Name>`.
+   inside a struct body whose `struct <Name>` declaration is preceded **on
+   the immediately prior line** by the comment `// IRAsset: serialized`.
+   The annotation must be on the line directly above `struct <Name>` — an
+   annotation elsewhere in the file does not apply to subsequent structs.
 
 2. For each struct type whose field layout changed (added/removed/renamed
    field on a `+` or `-` line), check whether the diff also contains a

--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -203,6 +203,46 @@ worked examples live in `docs/design/entity-editor-epic.md`. The summary:
    chunk table, current chunks, version history, and the migration
    registry.
 
+## Serialized-struct annotation
+
+Any C++ struct whose fields are **directly mapped to bytes on disk** — per-voxel
+records, joint records, bind-point descriptors, world-snapshot component blobs — must
+carry two markers so automated checks can enforce Rule #3:
+
+1. A `// IRAsset: serialized` line comment on the `struct` declaration.
+2. A `static constexpr uint16_t kSaveVersion = N;` inside the struct body.
+
+Example:
+
+```cpp
+// IRAsset: serialized
+struct JointRecord {
+    static constexpr uint16_t kSaveVersion = 1;
+
+    IRMath::vec4 rotation_{0.f, 0.f, 0.f, 1.f};
+    IRMath::vec4 translation_{0.f, 0.f, 0.f, 0.f};
+    std::uint32_t parentIndex_ = 0;
+    std::string name_;
+};
+```
+
+**When you add, remove, or rename a field:**
+
+1. Increment `kSaveVersion`.
+2. Add a reader migration in the format's load function keyed on
+   `(structType, oldVersion)`.
+3. Update the per-format save/load header block (Extensibility Rule #7).
+
+The `simplify` skill (pre-commit) and `review-pr` skill both scan for
+`// IRAsset: serialized` structs with changed field layouts and emit a finding
+when `kSaveVersion` was not bumped. See `.claude/skills/simplify/SKILL.md`
+section 2c and `.claude/skills/review-pr/SKILL.md` step 4 "Serialization".
+
+Not every asset-related struct needs this annotation — only those whose fields
+are **directly serialized** into a chunk body byte-for-byte. Framework structs
+(`AssetHeader`, `ChunkTableEntry`, `LoadedChunk`) are governed by the file-level
+version in `AssetHeader.version_`, not per-struct versioning.
+
 ## Gotchas
 
 - **`fwrite`/`fread` return values unchecked.** A truncated file loads as

--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -205,11 +205,13 @@ worked examples live in `docs/design/entity-editor-epic.md`. The summary:
 
 ## Serialized-struct annotation
 
-Any C++ struct whose fields are **directly mapped to bytes on disk** — per-voxel
-records, joint records, bind-point descriptors, world-snapshot component blobs — must
-carry two markers so automated checks can enforce Rule #3:
+Any C++ struct whose fields are **individually serialized into the asset
+format** — per-voxel records, joint records, bind-point descriptors,
+world-snapshot component blobs — must carry two markers so automated checks
+can enforce Rule #3:
 
-1. A `// IRAsset: serialized` line comment on the `struct` declaration.
+1. A `// IRAsset: serialized` line comment on the line immediately
+   preceding the `struct` declaration.
 2. A `static constexpr uint16_t kSaveVersion = N;` inside the struct body.
 
 Example:
@@ -222,9 +224,15 @@ struct JointRecord {
     IRMath::vec4 rotation_{0.f, 0.f, 0.f, 1.f};
     IRMath::vec4 translation_{0.f, 0.f, 0.f, 0.f};
     std::uint32_t parentIndex_ = 0;
-    std::string name_;
+    std::string name_;  // serialized via writeString(), not raw fwrite
 };
 ```
+
+Fixed-size POD fields (numeric scalars, `IRMath::vec*`) are written by
+direct `fwrite` of their bytes; variable-length fields like `std::string`
+go through `writeString()` / `readString()`. The struct itself is not
+`fwrite`'d as a single blob — the per-field serialization is what
+`kSaveVersion` covers.
 
 **When you add, remove, or rename a field:**
 


### PR DESCRIPTION
## Summary
- `simplify/SKILL.md` gains section 2c: detects `// IRAsset: serialized` struct field changes without a `kSaveVersion` bump; emits a finding (not auto-fix) with a concrete migration hint.
- `review-pr/SKILL.md` step 4 gains a **Serialization** subsection with the same criteria as a reviewer checklist item.
- `engine/asset/CLAUDE.md` gains a **Serialized-struct annotation** section: documents the `// IRAsset: serialized` + `static constexpr uint16_t kSaveVersion = N;` two-marker contract, shows a canonical example, and cross-references both skill checks.

## False-positive validation
No structs in the current codebase carry `// IRAsset: serialized` — the check only fires when the annotation is present, so false-positive rate against master is zero.

## Test plan
- [ ] Open a future PR that modifies a `// IRAsset: serialized` struct field without bumping `kSaveVersion` — simplify should emit a finding.
- [ ] Open a PR that correctly bumps `kSaveVersion` alongside the field change — no finding.
- [ ] Confirm `engine/asset/CLAUDE.md` cross-references resolve: `.claude/skills/simplify/SKILL.md` section 2c and `.claude/skills/review-pr/SKILL.md` step 4 "Serialization" both exist.

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)
