### PR TITLE
T-167: .vxs v1 dense-mode reader/writer (BNDS, VOXR, LAYR, FRAM, META chunks)

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -238,8 +238,8 @@ The voxel-set container holds three persistence modes — DENSE (per-voxel
 records, T-167), SHAPES (SDF composition, T-168), HYBRID (DENSE + SHAPES,
 T-668) — under one magic (`VXS1`) and one version (`kVoxelSetVersion = 1`).
 Magic + version together govern the **container**; per-record additive
-versioning (`kShapeRecordVersion`) covers field-level evolution inside
-records (Extensibility Rule #3).
+versioning (`kShapeRecordVersion`, `kVoxelRecordVersion`) covers
+field-level evolution inside records (Extensibility Rule #3).
 
 Container chunks:
 
@@ -254,6 +254,21 @@ Container chunks:
 - `SHPG` — SHAPES-mode primitive records (`ShapeRecord` array). Records
   with an unresolvable disk-side `ShapeType` are skipped and counted
   in `unknownShapesSkipped_`.
+- `BNDS` — DENSE-mode bounds. Six i32 (`min.xyz, max.xyz`); inclusive
+  min, exclusive max. `voxelCount() = (max - min).x * .y * .z`.
+- `VOXR` — DENSE-mode per-voxel records. `kVoxelRecordVersion` u16 +
+  varuint count + tightly-packed 12 B records matching `C_Voxel`. A
+  count mismatch against the bounds-derived voxel volume logs a warning
+  and proceeds with the chunk's count (Rule #5).
+- `LAYR` — DENSE-mode named layer membership bitmasks. One layer is
+  `(name, ceil(voxelCount/64) u64 words)`; bit i = membership of voxel
+  i.
+- `FRAM` — DENSE-mode per-frame position offsets. Each frame is
+  `(frameIndex u32, varuint offsetCount, offsetCount × vec3)`. A frame
+  whose `offsetCount != voxelCount` is dropped and counted in
+  `skippedFrames_` so a corrupt or partial frame can't corrupt the
+  whole asset.
+- `META` — DENSE-mode free-form `(key, value)` UTF-8 string pairs.
 
 SHPG record layout (one per primitive):
 
@@ -277,6 +292,14 @@ High-level entry points:
   unknownShapesSkipped_ }` after resolving SREF and SHPG. Container
   errors (`BadMagic`, `VersionTooNew`, truncation, chunk-out-of-bounds)
   surface as `BinaryIOError` results.
+- `saveDenseVoxelSet(path, DenseVoxelSet)` — writes MODE=DENSE plus
+  BNDS, VOXR, and (if non-empty) LAYR / FRAM / META chunks.
+- `loadDenseVoxelSet(path)` — returns `DenseVoxelSetFile { mode_,
+  dense_, skippedFrames_ }`. Loading a SHAPES-only file through this
+  path is a no-op: `mode_ = SHAPES` and `dense_` stays empty. Callers
+  that need both halves of a HYBRID save invoke `loadShapeGroup` and
+  `loadDenseVoxelSet` against the same path until T-668 ships the
+  unified entry point.
 
 For callers working with `C_ShapeDescriptor`, the prefab-side adapter at
 `engine/prefabs/irreden/asset/voxel_set_io.hpp` (`#include

--- a/engine/asset/include/irreden/asset/voxel_set_format.hpp
+++ b/engine/asset/include/irreden/asset/voxel_set_format.hpp
@@ -240,13 +240,20 @@ struct DenseVoxelSet {
     std::vector<FramePose> frames_;
     std::vector<MetaEntry> meta_;
 
+    /// Bounds-derived voxel slot count. Adversarially large positive
+    /// dimensions can wrap `std::size_t` (three values near INT32_MAX
+    /// product to ~9.9e27, which exceeds u64). The wrap is benign in
+    /// practice because the downstream `readVoxelRecordsChunk` reserve
+    /// cap (`remaining_bytes / 12`) bounds any actual allocation, so
+    /// the only observable effect is a spurious VOXR count-mismatch
+    /// warning. Callers indexing `DenseVoxelSet::voxels_` must still
+    /// validate `voxels_.size() == voxelCount()` before random access.
     std::size_t voxelCount() const {
         const ivec3 d = boundsMax_ - boundsMin_;
         if (d.x <= 0 || d.y <= 0 || d.z <= 0) {
             return 0;
         }
-        return static_cast<std::size_t>(d.x) *
-               static_cast<std::size_t>(d.y) *
+        return static_cast<std::size_t>(d.x) * static_cast<std::size_t>(d.y) *
                static_cast<std::size_t>(d.z);
     }
 };
@@ -297,10 +304,8 @@ struct ShapeGroupLoadResult {
 /// is dropped and counted in `unknownShapesSkipped_`. If
 /// @p diskShapeTypes is empty, the disk-side numeric id is taken
 /// verbatim (legacy save with no SREF chunk).
-Result<ShapeGroupLoadResult> readShapeGroupChunk(
-    std::span<const std::uint8_t> body,
-    const NameTable &diskShapeTypes
-);
+Result<ShapeGroupLoadResult>
+readShapeGroupChunk(std::span<const std::uint8_t> body, const NameTable &diskShapeTypes);
 
 // ---- BNDS chunk --------------------------------------------------------
 
@@ -329,10 +334,8 @@ struct VoxelRecordsLoadResult {
 /// Parse a VOXR chunk body. @p expectedCount comes from the BNDS
 /// volume; a mismatch is logged and the loader trusts the chunk's own
 /// varuint count (Rule #5 — recoverable, never fatal).
-Result<VoxelRecordsLoadResult> readVoxelRecordsChunk(
-    std::span<const std::uint8_t> body,
-    std::size_t expectedCount
-);
+Result<VoxelRecordsLoadResult>
+readVoxelRecordsChunk(std::span<const std::uint8_t> body, std::size_t expectedCount);
 
 // ---- LAYR chunk --------------------------------------------------------
 
@@ -361,10 +364,8 @@ struct FramesLoadResult {
 /// Parse a FRAM chunk body. A frame whose `offsetCount != voxelCount`
 /// is read in full (so the next frame's offset is correct) but dropped
 /// from the result; the skip count surfaces in `skippedFrames_`.
-Result<FramesLoadResult> readFramesChunk(
-    std::span<const std::uint8_t> body,
-    std::size_t voxelCount
-);
+Result<FramesLoadResult>
+readFramesChunk(std::span<const std::uint8_t> body, std::size_t voxelCount);
 
 // ---- META chunk --------------------------------------------------------
 
@@ -408,6 +409,13 @@ BinaryStatus saveDenseVoxelSet(const std::string &path, const DenseVoxelSet &den
 /// Loader-side view of a DENSE-mode `.vxs` file. `mode_` is read from
 /// the MODE chunk; `dense_` is populated from BNDS + VOXR + LAYR +
 /// FRAM + META. `skippedFrames_` carries the FRAM-chunk diagnostic.
+///
+/// Per Extensibility Rule #5 (unknown is recoverable, never fatal),
+/// partial loads can leave `dense_.voxels_.size() != dense_.voxelCount()`
+/// — e.g. a malformed file with BNDS present but VOXR absent loads as
+/// `dense_.voxels_.empty()` with `dense_.voxelCount() > 0`, plus a
+/// warning log. **Callers that index `dense_.voxels_` must validate
+/// `voxels_.size() == dense_.voxelCount()` before random access.**
 struct DenseVoxelSetFile {
     VoxelSetMode mode_ = VoxelSetMode::UNKNOWN;
     DenseVoxelSet dense_;

--- a/engine/asset/include/irreden/asset/voxel_set_format.hpp
+++ b/engine/asset/include/irreden/asset/voxel_set_format.hpp
@@ -196,7 +196,10 @@ constexpr std::uint16_t kVoxelRecordVersion = 1;
 /// the runtime can copy disk → memory without per-field translation.
 /// `engine/asset/` lives below the prefab layer, so the format owns
 /// its own struct rather than including the component header.
+// IRAsset: serialized
 struct VoxelRecord {
+    static constexpr std::uint16_t kSaveVersion = kVoxelRecordVersion;
+
     Color color_ = Color{0, 0, 0, 0};
     std::uint8_t material_id_ = 0;
     std::uint8_t flags_ = 0;

--- a/engine/asset/include/irreden/asset/voxel_set_format.hpp
+++ b/engine/asset/include/irreden/asset/voxel_set_format.hpp
@@ -1,14 +1,14 @@
 #ifndef IR_ASSET_VOXEL_SET_FORMAT_H
 #define IR_ASSET_VOXEL_SET_FORMAT_H
 
-/// `.vxs` v1 voxel-set asset format. Two coexisting persistence modes
+/// `.vxs` v1 voxel-set asset format. Three coexisting persistence modes
 /// share one container:
 ///
-/// - **SHAPES** (this header, T-168 / #665) — composition of SDF
-///   primitive instances; rendered directly by `SHAPES_TO_TRIXEL` with
-///   no voxel pool allocation.
+/// - **SHAPES** (T-168 / #665) — composition of SDF primitive instances;
+///   rendered directly by `SHAPES_TO_TRIXEL` with no voxel pool allocation.
 /// - **DENSE** (T-167 / #664) — bounded 3D voxel grid with per-voxel
-///   records.
+///   records, named layer membership bitmasks, per-frame position-offset
+///   poses, and free-form metadata. Round-trips `C_Voxel`-shaped data.
 /// - **HYBRID** (T-668) — DENSE base plus SHAPES overrides.
 ///
 /// On-disk container layout (built on `chunk_header.hpp`):
@@ -18,7 +18,11 @@
 ///     MODE chunk             4-byte mode tag (DENS | SHPS | HYBR)
 ///     SREF chunk             name-table for `IRMath::SDF::ShapeType`
 ///     SHPG chunk             shape-group primitive records (SHAPES mode)
-///     [BNDS | VOXR | LAYR | FRAM | META chunks added by T-167 for DENSE]
+///     BNDS chunk             dense bounds (ivec3 min, ivec3 max) (DENSE)
+///     VOXR chunk             dense per-voxel records, 12 B/record (DENSE)
+///     LAYR chunk             dense layer membership bitmasks (DENSE)
+///     FRAM chunk             dense per-frame position offsets (DENSE)
+///     META chunk             free-form key/value strings (DENSE)
 ///
 /// Order in the chunk table is not load-bearing (Save Format Extensibility
 /// Rule #1). A reader skips chunks it doesn't know without erroring; the
@@ -44,6 +48,56 @@
 /// `IRMath::SDF::ShapeType` values that resolve via name on load become
 /// the current-build numeric id; unknown names/ids surface as
 /// `unknownShapesSkipped_` and the rest of the asset loads cleanly.
+///
+/// BNDS chunk body — DENSE bounds:
+///
+///     int32 min.x, min.y, min.z, max.x, max.y, max.z   (6 × i32)
+///
+/// `min` is inclusive, `max` is exclusive — the voxel volume contains
+/// `(max.x - min.x) × (max.y - min.y) × (max.z - min.z)` slots indexed
+/// row-major in (x, y, z) order.
+///
+/// VOXR chunk body — DENSE per-voxel records:
+///
+///     uint16  recordVersion        // chunk-level version (Rule #3); v1
+///                                  // fields fixed below
+///     varuint count                // must equal volume from BNDS; loader
+///                                  // validates and surfaces mismatches
+///     repeat count times (12 B per record, matches `C_Voxel` layout):
+///       uint32  packedRGBA         // `Color::toPackedRGBA()`
+///       uint8   material_id
+///       uint8   flags
+///       uint8   bone_id
+///       uint8   pad0               // reserved (zero on write)
+///       uint32  reserved           // reserved for future per-voxel fields
+///
+/// LAYR chunk body — DENSE layer membership bitmasks (Phase 1):
+///
+///     varuint layerCount
+///     repeat layerCount times:
+///       string  name               // UTF-8 layer name
+///       varuint bitmaskWordCount   // u64 words; expected
+///                                  // ceil(voxelCount / 64)
+///       uint64[bitmaskWordCount]   // packed bits, LE; 1 = member
+///
+/// FRAM chunk body — DENSE per-frame position offsets (Phase 1.4):
+///
+///     varuint frameCount
+///     repeat frameCount times:
+///       uint32  frameIndex
+///       varuint offsetCount        // expected to equal voxelCount; a
+///                                  // mismatch logs + drops the frame
+///       float32[offsetCount][3]    // per-voxel position offset (x, y, z)
+///
+/// META chunk body — DENSE free-form metadata:
+///
+///     varuint entryCount
+///     repeat entryCount times:
+///       string  key
+///       string  value
+///
+/// All strings are UTF-8 with a varuint byte-length prefix (see
+/// `BinaryReader::readString`).
 
 #include <irreden/asset/binary_io.hpp>
 #include <irreden/asset/chunk_header.hpp>
@@ -59,6 +113,7 @@
 namespace IRAsset {
 
 using IRMath::Color;
+using IRMath::ivec3;
 using IRMath::vec3;
 using IRMath::vec4;
 
@@ -68,6 +123,11 @@ constexpr std::uint32_t kVoxelSetVersion = 1;
 constexpr std::array<char, 4> kChunkTagMode = {'M', 'O', 'D', 'E'};
 constexpr std::array<char, 4> kChunkTagShapeRefs = {'S', 'R', 'E', 'F'};
 constexpr std::array<char, 4> kChunkTagShapeGroup = {'S', 'H', 'P', 'G'};
+constexpr std::array<char, 4> kChunkTagBounds = {'B', 'N', 'D', 'S'};
+constexpr std::array<char, 4> kChunkTagVoxelRecords = {'V', 'O', 'X', 'R'};
+constexpr std::array<char, 4> kChunkTagLayers = {'L', 'A', 'Y', 'R'};
+constexpr std::array<char, 4> kChunkTagFrames = {'F', 'R', 'A', 'M'};
+constexpr std::array<char, 4> kChunkTagMeta = {'M', 'E', 'T', 'A'};
 
 /// 4-byte ASCII tag stored as the MODE chunk body. Adding a future
 /// mode is a new constant + a new branch in `readModeChunk`; older
@@ -123,6 +183,74 @@ struct ShapeRecord {
     CsgOp csgOp_ = CsgOp::NONE;
 };
 
+// ---- DENSE-mode types --------------------------------------------------
+
+/// VOXR chunk-level version (Rule #3). Bump when the on-disk record
+/// layout changes; older loaders default the appended fields. The v1
+/// layout is byte-identical to `C_Voxel` so the runtime can blit a
+/// dense block into the voxel pool without per-record translation.
+constexpr std::uint16_t kVoxelRecordVersion = 1;
+
+/// 12 B per-voxel record. Layout MUST match `C_Voxel` (in
+/// `engine/prefabs/irreden/voxel/components/component_voxel.hpp`) so
+/// the runtime can copy disk → memory without per-field translation.
+/// `engine/asset/` lives below the prefab layer, so the format owns
+/// its own struct rather than including the component header.
+struct VoxelRecord {
+    Color color_ = Color{0, 0, 0, 0};
+    std::uint8_t material_id_ = 0;
+    std::uint8_t flags_ = 0;
+    std::uint8_t bone_id_ = 0;
+    std::uint8_t pad0_ = 0;
+    std::uint32_t reserved_ = 0;
+};
+
+static_assert(sizeof(VoxelRecord) == 12, "VoxelRecord must be 12 B (matches C_Voxel)");
+
+/// Named voxel-slot membership bitmask. `bitmask_` is 1 bit per slot,
+/// packed LE into u64 words; word count is `ceil(voxelCount / 64)`.
+struct LayerInfo {
+    std::string name_;
+    std::vector<std::uint64_t> bitmask_;
+};
+
+/// Per-frame position offset for every voxel slot. `offsets_.size()`
+/// must equal the dense voxel volume; a mismatch logs and drops the
+/// frame (Rule #5: unknown is recoverable).
+struct FramePose {
+    std::uint32_t frameIndex_ = 0;
+    std::vector<vec3> offsets_;
+};
+
+/// Free-form `(key, value)` metadata pair. Both UTF-8 strings.
+struct MetaEntry {
+    std::string key_;
+    std::string value_;
+};
+
+/// In-memory representation of a DENSE-mode `.vxs` file. Bounds are
+/// inclusive-min / exclusive-max; the voxel volume contains
+/// `voxelCount()` slots indexed row-major in (x, y, z) order.
+struct DenseVoxelSet {
+    ivec3 boundsMin_ = ivec3(0);
+    ivec3 boundsMax_ = ivec3(0);
+    std::uint16_t recordVersion_ = kVoxelRecordVersion;
+    std::vector<VoxelRecord> voxels_;
+    std::vector<LayerInfo> layers_;
+    std::vector<FramePose> frames_;
+    std::vector<MetaEntry> meta_;
+
+    std::size_t voxelCount() const {
+        const ivec3 d = boundsMax_ - boundsMin_;
+        if (d.x <= 0 || d.y <= 0 || d.z <= 0) {
+            return 0;
+        }
+        return static_cast<std::size_t>(d.x) *
+               static_cast<std::size_t>(d.y) *
+               static_cast<std::size_t>(d.z);
+    }
+};
+
 // ---- MODE chunk --------------------------------------------------------
 
 /// Build a MODE chunk payload from a known mode. `VoxelSetMode::UNKNOWN`
@@ -174,6 +302,78 @@ Result<ShapeGroupLoadResult> readShapeGroupChunk(
     const NameTable &diskShapeTypes
 );
 
+// ---- BNDS chunk --------------------------------------------------------
+
+/// Build a BNDS chunk payload (6 × i32: min.xyz + max.xyz).
+ChunkPayload makeBoundsChunk(const ivec3 &boundsMin, const ivec3 &boundsMax);
+
+struct BoundsPair {
+    ivec3 boundsMin_ = ivec3(0);
+    ivec3 boundsMax_ = ivec3(0);
+};
+
+/// Parse a BNDS chunk body. Returns `Truncated` if the body is < 24 B.
+Result<BoundsPair> readBoundsChunk(std::span<const std::uint8_t> body);
+
+// ---- VOXR chunk --------------------------------------------------------
+
+/// Serialize @p voxels into a VOXR chunk body. Writes `kVoxelRecordVersion`
+/// + varuint count + tightly-packed 12 B records.
+ChunkPayload makeVoxelRecordsChunk(std::span<const VoxelRecord> voxels);
+
+struct VoxelRecordsLoadResult {
+    std::vector<VoxelRecord> voxels_;
+    std::uint16_t recordVersion_ = kVoxelRecordVersion;
+};
+
+/// Parse a VOXR chunk body. @p expectedCount comes from the BNDS
+/// volume; a mismatch is logged and the loader trusts the chunk's own
+/// varuint count (Rule #5 — recoverable, never fatal).
+Result<VoxelRecordsLoadResult> readVoxelRecordsChunk(
+    std::span<const std::uint8_t> body,
+    std::size_t expectedCount
+);
+
+// ---- LAYR chunk --------------------------------------------------------
+
+/// Serialize @p layers into a LAYR chunk body.
+ChunkPayload makeLayersChunk(std::span<const LayerInfo> layers);
+
+/// Parse a LAYR chunk body.
+Result<std::vector<LayerInfo>> readLayersChunk(std::span<const std::uint8_t> body);
+
+// ---- FRAM chunk --------------------------------------------------------
+
+/// Serialize @p frames into a FRAM chunk body. Each frame writes
+/// `frameIndex + varuint offsetCount + offsetCount × vec3` — the count
+/// is taken from `frames[i].offsets_.size()` so a hand-built frame with
+/// a mismatched offset count round-trips faithfully (the loader logs
+/// the mismatch).
+ChunkPayload makeFramesChunk(std::span<const FramePose> frames);
+
+struct FramesLoadResult {
+    std::vector<FramePose> frames_;
+    /// Frames dropped because their on-disk per-voxel offset count did
+    /// not match the dense voxel volume. Surfaced for diagnostics.
+    std::size_t skippedFrames_ = 0;
+};
+
+/// Parse a FRAM chunk body. A frame whose `offsetCount != voxelCount`
+/// is read in full (so the next frame's offset is correct) but dropped
+/// from the result; the skip count surfaces in `skippedFrames_`.
+Result<FramesLoadResult> readFramesChunk(
+    std::span<const std::uint8_t> body,
+    std::size_t voxelCount
+);
+
+// ---- META chunk --------------------------------------------------------
+
+/// Serialize @p entries into a META chunk body.
+ChunkPayload makeMetaChunk(std::span<const MetaEntry> entries);
+
+/// Parse a META chunk body.
+Result<std::vector<MetaEntry>> readMetaChunk(std::span<const std::uint8_t> body);
+
 // ---- High-level save/load ----------------------------------------------
 
 /// Save a shape-group `.vxs` asset to @p path. Writes MODE=SHAPES,
@@ -198,6 +398,33 @@ struct VoxelSetFile {
 /// surfaced through `mode_` but their record arrays are empty for v1
 /// (loaders for those modes land in T-167/T-668).
 Result<VoxelSetFile> loadShapeGroup(const std::string &path);
+
+/// Save a DENSE-mode `.vxs` asset to @p path. Writes MODE=DENSE plus
+/// BNDS / VOXR / LAYR / FRAM / META chunks. Empty optional sections
+/// (no layers / no frames / no meta) omit the corresponding chunk so
+/// older loaders need no special-casing.
+BinaryStatus saveDenseVoxelSet(const std::string &path, const DenseVoxelSet &dense);
+
+/// Loader-side view of a DENSE-mode `.vxs` file. `mode_` is read from
+/// the MODE chunk; `dense_` is populated from BNDS + VOXR + LAYR +
+/// FRAM + META. `skippedFrames_` carries the FRAM-chunk diagnostic.
+struct DenseVoxelSetFile {
+    VoxelSetMode mode_ = VoxelSetMode::UNKNOWN;
+    DenseVoxelSet dense_;
+    std::size_t skippedFrames_ = 0;
+};
+
+/// Load a DENSE-mode `.vxs` asset from @p path. Returns:
+/// - `BadMagic` if magic isn't `VXS1`
+/// - `VersionTooNew` if file version > `kVoxelSetVersion`
+/// - `Truncated` / `ChunkOutOfBounds` for malformed chunk tables
+/// - `DenseVoxelSetFile` with the resolved dense data otherwise.
+///
+/// SHAPES-only files (no BNDS / VOXR chunks present) load as `mode_ =
+/// VoxelSetMode::SHAPES` with an empty `dense_`. A loader that needs
+/// both shapes and dense data uses `loadShapeGroup` and
+/// `loadDenseVoxelSet` against the same path.
+Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path);
 
 } // namespace IRAsset
 

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -314,6 +314,330 @@ readShapeGroupChunk(std::span<const std::uint8_t> body, const NameTable &diskSha
     return Result<ShapeGroupLoadResult>::success(std::move(out));
 }
 
+// ---- BNDS chunk -------------------------------------------------------
+
+ChunkPayload makeBoundsChunk(const ivec3 &boundsMin, const ivec3 &boundsMax) {
+    MemoryBinaryWriter w;
+    w.writeI32(boundsMin.x);
+    w.writeI32(boundsMin.y);
+    w.writeI32(boundsMin.z);
+    w.writeI32(boundsMax.x);
+    w.writeI32(boundsMax.y);
+    w.writeI32(boundsMax.z);
+    ChunkPayload out;
+    out.tag_ = kChunkTagBounds;
+    out.data_ = w.takeBuffer();
+    return out;
+}
+
+Result<BoundsPair> readBoundsChunk(std::span<const std::uint8_t> body) {
+    MemoryBinaryReader r(body.data(), body.size(), "<BNDS chunk>");
+    BoundsPair out;
+    auto minX = r.readI32();
+    if (!minX.ok())
+        return Result<BoundsPair>::error(minX.status_.code_, std::move(minX.status_.message_));
+    auto minY = r.readI32();
+    if (!minY.ok())
+        return Result<BoundsPair>::error(minY.status_.code_, std::move(minY.status_.message_));
+    auto minZ = r.readI32();
+    if (!minZ.ok())
+        return Result<BoundsPair>::error(minZ.status_.code_, std::move(minZ.status_.message_));
+    auto maxX = r.readI32();
+    if (!maxX.ok())
+        return Result<BoundsPair>::error(maxX.status_.code_, std::move(maxX.status_.message_));
+    auto maxY = r.readI32();
+    if (!maxY.ok())
+        return Result<BoundsPair>::error(maxY.status_.code_, std::move(maxY.status_.message_));
+    auto maxZ = r.readI32();
+    if (!maxZ.ok())
+        return Result<BoundsPair>::error(maxZ.status_.code_, std::move(maxZ.status_.message_));
+    out.boundsMin_ = ivec3(minX.value_, minY.value_, minZ.value_);
+    out.boundsMax_ = ivec3(maxX.value_, maxY.value_, maxZ.value_);
+    return Result<BoundsPair>::success(out);
+}
+
+// ---- VOXR chunk -------------------------------------------------------
+
+ChunkPayload makeVoxelRecordsChunk(std::span<const VoxelRecord> voxels) {
+    MemoryBinaryWriter w;
+    w.writeU16(kVoxelRecordVersion);
+    w.writeVarUInt(static_cast<std::uint64_t>(voxels.size()));
+    for (const auto &v : voxels) {
+        writeColorPacked(w, v.color_);
+        w.writeU8(v.material_id_);
+        w.writeU8(v.flags_);
+        w.writeU8(v.bone_id_);
+        w.writeU8(v.pad0_);
+        w.writeU32(v.reserved_);
+    }
+    ChunkPayload out;
+    out.tag_ = kChunkTagVoxelRecords;
+    out.data_ = w.takeBuffer();
+    return out;
+}
+
+Result<VoxelRecordsLoadResult> readVoxelRecordsChunk(
+    std::span<const std::uint8_t> body,
+    std::size_t expectedCount
+) {
+    MemoryBinaryReader r(body.data(), body.size(), "<VOXR chunk>");
+    auto verR = r.readU16();
+    if (!verR.ok()) {
+        return Result<VoxelRecordsLoadResult>::error(
+            verR.status_.code_, std::move(verR.status_.message_)
+        );
+    }
+    auto countR = r.readVarUInt();
+    if (!countR.ok()) {
+        return Result<VoxelRecordsLoadResult>::error(
+            countR.status_.code_, std::move(countR.status_.message_)
+        );
+    }
+    if (countR.value_ != static_cast<std::uint64_t>(expectedCount)) {
+        IRE_LOG_WARN(
+            "readVoxelRecordsChunk: chunk count={} != bounds-derived count={}",
+            countR.value_,
+            expectedCount
+        );
+    }
+    // Cap upfront reserve to remaining bytes / record size (12 B) so a
+    // corrupted count claiming billions of records doesn't pre-allocate.
+    constexpr std::uint64_t kRecordBytes = 12;
+    const std::uint64_t maxRecords = r.remaining() / kRecordBytes;
+    VoxelRecordsLoadResult out;
+    out.recordVersion_ = verR.value_;
+    out.voxels_.reserve(
+        static_cast<std::size_t>(countR.value_ < maxRecords ? countR.value_ : maxRecords)
+    );
+    for (std::uint64_t i = 0; i < countR.value_; ++i) {
+        VoxelRecord v{};
+        auto colorR = r.readU32();
+        if (!colorR.ok())
+            return Result<VoxelRecordsLoadResult>::error(
+                colorR.status_.code_, std::move(colorR.status_.message_)
+            );
+        v.color_ = unpackColor(colorR.value_);
+        auto matR = r.readU8();
+        if (!matR.ok())
+            return Result<VoxelRecordsLoadResult>::error(
+                matR.status_.code_, std::move(matR.status_.message_)
+            );
+        v.material_id_ = matR.value_;
+        auto flagsR = r.readU8();
+        if (!flagsR.ok())
+            return Result<VoxelRecordsLoadResult>::error(
+                flagsR.status_.code_, std::move(flagsR.status_.message_)
+            );
+        v.flags_ = flagsR.value_;
+        auto boneR = r.readU8();
+        if (!boneR.ok())
+            return Result<VoxelRecordsLoadResult>::error(
+                boneR.status_.code_, std::move(boneR.status_.message_)
+            );
+        v.bone_id_ = boneR.value_;
+        auto padR = r.readU8();
+        if (!padR.ok())
+            return Result<VoxelRecordsLoadResult>::error(
+                padR.status_.code_, std::move(padR.status_.message_)
+            );
+        v.pad0_ = padR.value_;
+        auto resR = r.readU32();
+        if (!resR.ok())
+            return Result<VoxelRecordsLoadResult>::error(
+                resR.status_.code_, std::move(resR.status_.message_)
+            );
+        v.reserved_ = resR.value_;
+        out.voxels_.push_back(v);
+    }
+    return Result<VoxelRecordsLoadResult>::success(std::move(out));
+}
+
+// ---- LAYR chunk -------------------------------------------------------
+
+ChunkPayload makeLayersChunk(std::span<const LayerInfo> layers) {
+    MemoryBinaryWriter w;
+    w.writeVarUInt(static_cast<std::uint64_t>(layers.size()));
+    for (const auto &layer : layers) {
+        w.writeString(layer.name_);
+        w.writeVarUInt(static_cast<std::uint64_t>(layer.bitmask_.size()));
+        for (std::uint64_t word : layer.bitmask_) {
+            w.writeU64(word);
+        }
+    }
+    ChunkPayload out;
+    out.tag_ = kChunkTagLayers;
+    out.data_ = w.takeBuffer();
+    return out;
+}
+
+Result<std::vector<LayerInfo>> readLayersChunk(std::span<const std::uint8_t> body) {
+    MemoryBinaryReader r(body.data(), body.size(), "<LAYR chunk>");
+    auto countR = r.readVarUInt();
+    if (!countR.ok()) {
+        return Result<std::vector<LayerInfo>>::error(
+            countR.status_.code_, std::move(countR.status_.message_)
+        );
+    }
+    std::vector<LayerInfo> out;
+    const std::uint64_t cap = r.remaining();
+    out.reserve(static_cast<std::size_t>(countR.value_ < cap ? countR.value_ : cap));
+    for (std::uint64_t i = 0; i < countR.value_; ++i) {
+        LayerInfo layer;
+        auto nameR = r.readString();
+        if (!nameR.ok())
+            return Result<std::vector<LayerInfo>>::error(
+                nameR.status_.code_, std::move(nameR.status_.message_)
+            );
+        layer.name_ = std::move(nameR.value_);
+        auto wordCountR = r.readVarUInt();
+        if (!wordCountR.ok())
+            return Result<std::vector<LayerInfo>>::error(
+                wordCountR.status_.code_, std::move(wordCountR.status_.message_)
+            );
+        // Cap u64 word count by remaining bytes / 8 to defuse a corrupted
+        // count that claims billions of words.
+        const std::uint64_t maxWords = r.remaining() / 8;
+        layer.bitmask_.reserve(
+            static_cast<std::size_t>(
+                wordCountR.value_ < maxWords ? wordCountR.value_ : maxWords
+            )
+        );
+        for (std::uint64_t w_i = 0; w_i < wordCountR.value_; ++w_i) {
+            auto wordR = r.readU64();
+            if (!wordR.ok())
+                return Result<std::vector<LayerInfo>>::error(
+                    wordR.status_.code_, std::move(wordR.status_.message_)
+                );
+            layer.bitmask_.push_back(wordR.value_);
+        }
+        out.push_back(std::move(layer));
+    }
+    return Result<std::vector<LayerInfo>>::success(std::move(out));
+}
+
+// ---- FRAM chunk -------------------------------------------------------
+
+ChunkPayload makeFramesChunk(std::span<const FramePose> frames) {
+    MemoryBinaryWriter w;
+    w.writeVarUInt(static_cast<std::uint64_t>(frames.size()));
+    for (const auto &frame : frames) {
+        w.writeU32(frame.frameIndex_);
+        w.writeVarUInt(static_cast<std::uint64_t>(frame.offsets_.size()));
+        for (const auto &off : frame.offsets_) {
+            writeVec3(w, off);
+        }
+    }
+    ChunkPayload out;
+    out.tag_ = kChunkTagFrames;
+    out.data_ = w.takeBuffer();
+    return out;
+}
+
+Result<FramesLoadResult> readFramesChunk(
+    std::span<const std::uint8_t> body,
+    std::size_t voxelCount
+) {
+    MemoryBinaryReader r(body.data(), body.size(), "<FRAM chunk>");
+    auto frameCountR = r.readVarUInt();
+    if (!frameCountR.ok()) {
+        return Result<FramesLoadResult>::error(
+            frameCountR.status_.code_, std::move(frameCountR.status_.message_)
+        );
+    }
+    FramesLoadResult out;
+    const std::uint64_t cap = r.remaining();
+    out.frames_.reserve(
+        static_cast<std::size_t>(frameCountR.value_ < cap ? frameCountR.value_ : cap)
+    );
+    for (std::uint64_t i = 0; i < frameCountR.value_; ++i) {
+        auto frameIdxR = r.readU32();
+        if (!frameIdxR.ok())
+            return Result<FramesLoadResult>::error(
+                frameIdxR.status_.code_, std::move(frameIdxR.status_.message_)
+            );
+        auto offCountR = r.readVarUInt();
+        if (!offCountR.ok())
+            return Result<FramesLoadResult>::error(
+                offCountR.status_.code_, std::move(offCountR.status_.message_)
+            );
+        FramePose frame;
+        frame.frameIndex_ = frameIdxR.value_;
+        // Cap reserve by remaining bytes / 12 B per vec3.
+        constexpr std::uint64_t kVec3Bytes = 12;
+        const std::uint64_t maxOffsets = r.remaining() / kVec3Bytes;
+        frame.offsets_.reserve(
+            static_cast<std::size_t>(
+                offCountR.value_ < maxOffsets ? offCountR.value_ : maxOffsets
+            )
+        );
+        for (std::uint64_t off_i = 0; off_i < offCountR.value_; ++off_i) {
+            auto vR = readVec3(r);
+            if (!vR.ok())
+                return Result<FramesLoadResult>::error(
+                    vR.status_.code_, std::move(vR.status_.message_)
+                );
+            frame.offsets_.push_back(vR.value_);
+        }
+        if (frame.offsets_.size() != voxelCount) {
+            IRE_LOG_WARN(
+                "readFramesChunk: frame {} has {} offsets, expected {} (dropping)",
+                frame.frameIndex_,
+                frame.offsets_.size(),
+                voxelCount
+            );
+            ++out.skippedFrames_;
+            continue;
+        }
+        out.frames_.push_back(std::move(frame));
+    }
+    return Result<FramesLoadResult>::success(std::move(out));
+}
+
+// ---- META chunk -------------------------------------------------------
+
+ChunkPayload makeMetaChunk(std::span<const MetaEntry> entries) {
+    MemoryBinaryWriter w;
+    w.writeVarUInt(static_cast<std::uint64_t>(entries.size()));
+    for (const auto &entry : entries) {
+        w.writeString(entry.key_);
+        w.writeString(entry.value_);
+    }
+    ChunkPayload out;
+    out.tag_ = kChunkTagMeta;
+    out.data_ = w.takeBuffer();
+    return out;
+}
+
+Result<std::vector<MetaEntry>> readMetaChunk(std::span<const std::uint8_t> body) {
+    MemoryBinaryReader r(body.data(), body.size(), "<META chunk>");
+    auto countR = r.readVarUInt();
+    if (!countR.ok()) {
+        return Result<std::vector<MetaEntry>>::error(
+            countR.status_.code_, std::move(countR.status_.message_)
+        );
+    }
+    std::vector<MetaEntry> out;
+    const std::uint64_t cap = r.remaining();
+    out.reserve(static_cast<std::size_t>(countR.value_ < cap ? countR.value_ : cap));
+    for (std::uint64_t i = 0; i < countR.value_; ++i) {
+        MetaEntry entry;
+        auto keyR = r.readString();
+        if (!keyR.ok())
+            return Result<std::vector<MetaEntry>>::error(
+                keyR.status_.code_, std::move(keyR.status_.message_)
+            );
+        entry.key_ = std::move(keyR.value_);
+        auto valR = r.readString();
+        if (!valR.ok())
+            return Result<std::vector<MetaEntry>>::error(
+                valR.status_.code_, std::move(valR.status_.message_)
+            );
+        entry.value_ = std::move(valR.value_);
+        out.push_back(std::move(entry));
+    }
+    return Result<std::vector<MetaEntry>>::success(std::move(out));
+}
+
 // ---- High-level save/load ---------------------------------------------
 
 BinaryStatus saveShapeGroup(const std::string &path, std::span<const ShapeRecord> records) {
@@ -375,6 +699,113 @@ Result<VoxelSetFile> loadShapeGroup(const std::string &path) {
         out.unknownShapesSkipped_ = recR.value_.unknownShapesSkipped_;
     }
     return Result<VoxelSetFile>::success(std::move(out));
+}
+
+BinaryStatus saveDenseVoxelSet(const std::string &path, const DenseVoxelSet &dense) {
+    FileBinaryWriter fw(path);
+    if (!fw.ok()) {
+        return BinaryStatus::error(
+            BinaryIOError::OpenFailed,
+            "saveDenseVoxelSet: could not open '" + path + "' for write"
+        );
+    }
+    // Build the chunk set in order: MODE, BNDS, VOXR (always); LAYR /
+    // FRAM / META only if the caller has data (Rule #1 — extra chunks
+    // are additive, missing chunks degrade to empty on load).
+    std::vector<ChunkPayload> chunks;
+    chunks.reserve(6);
+    chunks.push_back(makeModeChunk(VoxelSetMode::DENSE));
+    chunks.push_back(makeBoundsChunk(dense.boundsMin_, dense.boundsMax_));
+    chunks.push_back(makeVoxelRecordsChunk(dense.voxels_));
+    if (!dense.layers_.empty()) {
+        chunks.push_back(makeLayersChunk(dense.layers_));
+    }
+    if (!dense.frames_.empty()) {
+        chunks.push_back(makeFramesChunk(dense.frames_));
+    }
+    if (!dense.meta_.empty()) {
+        chunks.push_back(makeMetaChunk(dense.meta_));
+    }
+    return writeChunked(fw, kVoxelSetMagic, kVoxelSetVersion, chunks);
+}
+
+Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path) {
+    FileBinaryReader fr(path);
+    if (!fr.ok()) {
+        return Result<DenseVoxelSetFile>::error(
+            BinaryIOError::OpenFailed,
+            "loadDenseVoxelSet: could not open '" + path + "' for read"
+        );
+    }
+    auto chunksR = readChunks(fr, kVoxelSetMagic, kVoxelSetVersion);
+    if (!chunksR.ok()) {
+        return Result<DenseVoxelSetFile>::error(
+            chunksR.status_.code_,
+            std::move(chunksR.status_.message_)
+        );
+    }
+    DenseVoxelSetFile out;
+    out.mode_ = readModeChunk(chunksR.value_);
+
+    // BNDS must be present for DENSE mode to populate; absent BNDS
+    // means this is a SHAPES-only save (the SHPG branch above stays
+    // empty in the dense file view).
+    const LoadedChunk *bndsChunk = findChunk(chunksR.value_, kChunkTagBounds);
+    if (bndsChunk == nullptr) {
+        return Result<DenseVoxelSetFile>::success(std::move(out));
+    }
+    auto boundsR = readBoundsChunk(bndsChunk->data_);
+    if (!boundsR.ok()) {
+        return Result<DenseVoxelSetFile>::error(
+            boundsR.status_.code_, std::move(boundsR.status_.message_)
+        );
+    }
+    out.dense_.boundsMin_ = boundsR.value_.boundsMin_;
+    out.dense_.boundsMax_ = boundsR.value_.boundsMax_;
+    const std::size_t expectedCount = out.dense_.voxelCount();
+
+    if (const LoadedChunk *voxr = findChunk(chunksR.value_, kChunkTagVoxelRecords)) {
+        auto vR = readVoxelRecordsChunk(voxr->data_, expectedCount);
+        if (!vR.ok()) {
+            return Result<DenseVoxelSetFile>::error(
+                vR.status_.code_, std::move(vR.status_.message_)
+            );
+        }
+        out.dense_.recordVersion_ = vR.value_.recordVersion_;
+        out.dense_.voxels_ = std::move(vR.value_.voxels_);
+    }
+
+    if (const LoadedChunk *layr = findChunk(chunksR.value_, kChunkTagLayers)) {
+        auto lR = readLayersChunk(layr->data_);
+        if (!lR.ok()) {
+            return Result<DenseVoxelSetFile>::error(
+                lR.status_.code_, std::move(lR.status_.message_)
+            );
+        }
+        out.dense_.layers_ = std::move(lR.value_);
+    }
+
+    if (const LoadedChunk *fram = findChunk(chunksR.value_, kChunkTagFrames)) {
+        auto fR = readFramesChunk(fram->data_, expectedCount);
+        if (!fR.ok()) {
+            return Result<DenseVoxelSetFile>::error(
+                fR.status_.code_, std::move(fR.status_.message_)
+            );
+        }
+        out.dense_.frames_ = std::move(fR.value_.frames_);
+        out.skippedFrames_ = fR.value_.skippedFrames_;
+    }
+
+    if (const LoadedChunk *meta = findChunk(chunksR.value_, kChunkTagMeta)) {
+        auto mR = readMetaChunk(meta->data_);
+        if (!mR.ok()) {
+            return Result<DenseVoxelSetFile>::error(
+                mR.status_.code_, std::move(mR.status_.message_)
+            );
+        }
+        out.dense_.meta_ = std::move(mR.value_);
+    }
+    return Result<DenseVoxelSetFile>::success(std::move(out));
 }
 
 } // namespace IRAsset

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -360,7 +360,7 @@ Result<BoundsPair> readBoundsChunk(std::span<const std::uint8_t> body) {
 
 ChunkPayload makeVoxelRecordsChunk(std::span<const VoxelRecord> voxels) {
     MemoryBinaryWriter w;
-    w.writeU16(kVoxelRecordVersion);
+    w.writeU16(VoxelRecord::kSaveVersion);
     w.writeVarUInt(static_cast<std::uint64_t>(voxels.size()));
     for (const auto &v : voxels) {
         writeColorPacked(w, v.color_);

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -376,21 +376,21 @@ ChunkPayload makeVoxelRecordsChunk(std::span<const VoxelRecord> voxels) {
     return out;
 }
 
-Result<VoxelRecordsLoadResult> readVoxelRecordsChunk(
-    std::span<const std::uint8_t> body,
-    std::size_t expectedCount
-) {
+Result<VoxelRecordsLoadResult>
+readVoxelRecordsChunk(std::span<const std::uint8_t> body, std::size_t expectedCount) {
     MemoryBinaryReader r(body.data(), body.size(), "<VOXR chunk>");
     auto verR = r.readU16();
     if (!verR.ok()) {
         return Result<VoxelRecordsLoadResult>::error(
-            verR.status_.code_, std::move(verR.status_.message_)
+            verR.status_.code_,
+            std::move(verR.status_.message_)
         );
     }
     auto countR = r.readVarUInt();
     if (!countR.ok()) {
         return Result<VoxelRecordsLoadResult>::error(
-            countR.status_.code_, std::move(countR.status_.message_)
+            countR.status_.code_,
+            std::move(countR.status_.message_)
         );
     }
     if (countR.value_ != static_cast<std::uint64_t>(expectedCount)) {
@@ -414,37 +414,43 @@ Result<VoxelRecordsLoadResult> readVoxelRecordsChunk(
         auto colorR = r.readU32();
         if (!colorR.ok())
             return Result<VoxelRecordsLoadResult>::error(
-                colorR.status_.code_, std::move(colorR.status_.message_)
+                colorR.status_.code_,
+                std::move(colorR.status_.message_)
             );
         v.color_ = unpackColor(colorR.value_);
         auto matR = r.readU8();
         if (!matR.ok())
             return Result<VoxelRecordsLoadResult>::error(
-                matR.status_.code_, std::move(matR.status_.message_)
+                matR.status_.code_,
+                std::move(matR.status_.message_)
             );
         v.material_id_ = matR.value_;
         auto flagsR = r.readU8();
         if (!flagsR.ok())
             return Result<VoxelRecordsLoadResult>::error(
-                flagsR.status_.code_, std::move(flagsR.status_.message_)
+                flagsR.status_.code_,
+                std::move(flagsR.status_.message_)
             );
         v.flags_ = flagsR.value_;
         auto boneR = r.readU8();
         if (!boneR.ok())
             return Result<VoxelRecordsLoadResult>::error(
-                boneR.status_.code_, std::move(boneR.status_.message_)
+                boneR.status_.code_,
+                std::move(boneR.status_.message_)
             );
         v.bone_id_ = boneR.value_;
         auto padR = r.readU8();
         if (!padR.ok())
             return Result<VoxelRecordsLoadResult>::error(
-                padR.status_.code_, std::move(padR.status_.message_)
+                padR.status_.code_,
+                std::move(padR.status_.message_)
             );
         v.pad0_ = padR.value_;
         auto resR = r.readU32();
         if (!resR.ok())
             return Result<VoxelRecordsLoadResult>::error(
-                resR.status_.code_, std::move(resR.status_.message_)
+                resR.status_.code_,
+                std::move(resR.status_.message_)
             );
         v.reserved_ = resR.value_;
         out.voxels_.push_back(v);
@@ -475,7 +481,8 @@ Result<std::vector<LayerInfo>> readLayersChunk(std::span<const std::uint8_t> bod
     auto countR = r.readVarUInt();
     if (!countR.ok()) {
         return Result<std::vector<LayerInfo>>::error(
-            countR.status_.code_, std::move(countR.status_.message_)
+            countR.status_.code_,
+            std::move(countR.status_.message_)
         );
     }
     std::vector<LayerInfo> out;
@@ -486,27 +493,28 @@ Result<std::vector<LayerInfo>> readLayersChunk(std::span<const std::uint8_t> bod
         auto nameR = r.readString();
         if (!nameR.ok())
             return Result<std::vector<LayerInfo>>::error(
-                nameR.status_.code_, std::move(nameR.status_.message_)
+                nameR.status_.code_,
+                std::move(nameR.status_.message_)
             );
         layer.name_ = std::move(nameR.value_);
         auto wordCountR = r.readVarUInt();
         if (!wordCountR.ok())
             return Result<std::vector<LayerInfo>>::error(
-                wordCountR.status_.code_, std::move(wordCountR.status_.message_)
+                wordCountR.status_.code_,
+                std::move(wordCountR.status_.message_)
             );
         // Cap u64 word count by remaining bytes / 8 to defuse a corrupted
         // count that claims billions of words.
         const std::uint64_t maxWords = r.remaining() / 8;
         layer.bitmask_.reserve(
-            static_cast<std::size_t>(
-                wordCountR.value_ < maxWords ? wordCountR.value_ : maxWords
-            )
+            static_cast<std::size_t>(wordCountR.value_ < maxWords ? wordCountR.value_ : maxWords)
         );
         for (std::uint64_t w_i = 0; w_i < wordCountR.value_; ++w_i) {
             auto wordR = r.readU64();
             if (!wordR.ok())
                 return Result<std::vector<LayerInfo>>::error(
-                    wordR.status_.code_, std::move(wordR.status_.message_)
+                    wordR.status_.code_,
+                    std::move(wordR.status_.message_)
                 );
             layer.bitmask_.push_back(wordR.value_);
         }
@@ -533,15 +541,14 @@ ChunkPayload makeFramesChunk(std::span<const FramePose> frames) {
     return out;
 }
 
-Result<FramesLoadResult> readFramesChunk(
-    std::span<const std::uint8_t> body,
-    std::size_t voxelCount
-) {
+Result<FramesLoadResult>
+readFramesChunk(std::span<const std::uint8_t> body, std::size_t voxelCount) {
     MemoryBinaryReader r(body.data(), body.size(), "<FRAM chunk>");
     auto frameCountR = r.readVarUInt();
     if (!frameCountR.ok()) {
         return Result<FramesLoadResult>::error(
-            frameCountR.status_.code_, std::move(frameCountR.status_.message_)
+            frameCountR.status_.code_,
+            std::move(frameCountR.status_.message_)
         );
     }
     FramesLoadResult out;
@@ -553,12 +560,14 @@ Result<FramesLoadResult> readFramesChunk(
         auto frameIdxR = r.readU32();
         if (!frameIdxR.ok())
             return Result<FramesLoadResult>::error(
-                frameIdxR.status_.code_, std::move(frameIdxR.status_.message_)
+                frameIdxR.status_.code_,
+                std::move(frameIdxR.status_.message_)
             );
         auto offCountR = r.readVarUInt();
         if (!offCountR.ok())
             return Result<FramesLoadResult>::error(
-                offCountR.status_.code_, std::move(offCountR.status_.message_)
+                offCountR.status_.code_,
+                std::move(offCountR.status_.message_)
             );
         FramePose frame;
         frame.frameIndex_ = frameIdxR.value_;
@@ -566,15 +575,14 @@ Result<FramesLoadResult> readFramesChunk(
         constexpr std::uint64_t kVec3Bytes = 12;
         const std::uint64_t maxOffsets = r.remaining() / kVec3Bytes;
         frame.offsets_.reserve(
-            static_cast<std::size_t>(
-                offCountR.value_ < maxOffsets ? offCountR.value_ : maxOffsets
-            )
+            static_cast<std::size_t>(offCountR.value_ < maxOffsets ? offCountR.value_ : maxOffsets)
         );
         for (std::uint64_t off_i = 0; off_i < offCountR.value_; ++off_i) {
             auto vR = readVec3(r);
             if (!vR.ok())
                 return Result<FramesLoadResult>::error(
-                    vR.status_.code_, std::move(vR.status_.message_)
+                    vR.status_.code_,
+                    std::move(vR.status_.message_)
                 );
             frame.offsets_.push_back(vR.value_);
         }
@@ -613,7 +621,8 @@ Result<std::vector<MetaEntry>> readMetaChunk(std::span<const std::uint8_t> body)
     auto countR = r.readVarUInt();
     if (!countR.ok()) {
         return Result<std::vector<MetaEntry>>::error(
-            countR.status_.code_, std::move(countR.status_.message_)
+            countR.status_.code_,
+            std::move(countR.status_.message_)
         );
     }
     std::vector<MetaEntry> out;
@@ -624,13 +633,15 @@ Result<std::vector<MetaEntry>> readMetaChunk(std::span<const std::uint8_t> body)
         auto keyR = r.readString();
         if (!keyR.ok())
             return Result<std::vector<MetaEntry>>::error(
-                keyR.status_.code_, std::move(keyR.status_.message_)
+                keyR.status_.code_,
+                std::move(keyR.status_.message_)
             );
         entry.key_ = std::move(keyR.value_);
         auto valR = r.readString();
         if (!valR.ok())
             return Result<std::vector<MetaEntry>>::error(
-                valR.status_.code_, std::move(valR.status_.message_)
+                valR.status_.code_,
+                std::move(valR.status_.message_)
             );
         entry.value_ = std::move(valR.value_);
         out.push_back(std::move(entry));
@@ -757,7 +768,8 @@ Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path) {
     auto boundsR = readBoundsChunk(bndsChunk->data_);
     if (!boundsR.ok()) {
         return Result<DenseVoxelSetFile>::error(
-            boundsR.status_.code_, std::move(boundsR.status_.message_)
+            boundsR.status_.code_,
+            std::move(boundsR.status_.message_)
         );
     }
     out.dense_.boundsMin_ = boundsR.value_.boundsMin_;
@@ -768,18 +780,31 @@ Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path) {
         auto vR = readVoxelRecordsChunk(voxr->data_, expectedCount);
         if (!vR.ok()) {
             return Result<DenseVoxelSetFile>::error(
-                vR.status_.code_, std::move(vR.status_.message_)
+                vR.status_.code_,
+                std::move(vR.status_.message_)
             );
         }
         out.dense_.recordVersion_ = vR.value_.recordVersion_;
         out.dense_.voxels_ = std::move(vR.value_.voxels_);
+    } else if (expectedCount > 0) {
+        // BNDS present but VOXR absent → malformed save. Rule #5
+        // requires we proceed (caller may still want the bounds), but
+        // log loudly so the caller knows `voxels_` is empty while
+        // `voxelCount()` reports a positive number.
+        IRE_LOG_WARN(
+            "loadDenseVoxelSet: BNDS present (voxelCount={}) but VOXR "
+            "chunk missing in '{}'; voxels_ left empty",
+            expectedCount,
+            path
+        );
     }
 
     if (const LoadedChunk *layr = findChunk(chunksR.value_, kChunkTagLayers)) {
         auto lR = readLayersChunk(layr->data_);
         if (!lR.ok()) {
             return Result<DenseVoxelSetFile>::error(
-                lR.status_.code_, std::move(lR.status_.message_)
+                lR.status_.code_,
+                std::move(lR.status_.message_)
             );
         }
         out.dense_.layers_ = std::move(lR.value_);
@@ -789,7 +814,8 @@ Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path) {
         auto fR = readFramesChunk(fram->data_, expectedCount);
         if (!fR.ok()) {
             return Result<DenseVoxelSetFile>::error(
-                fR.status_.code_, std::move(fR.status_.message_)
+                fR.status_.code_,
+                std::move(fR.status_.message_)
             );
         }
         out.dense_.frames_ = std::move(fR.value_.frames_);
@@ -800,7 +826,8 @@ Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path) {
         auto mR = readMetaChunk(meta->data_);
         if (!mR.ok()) {
             return Result<DenseVoxelSetFile>::error(
-                mR.status_.code_, std::move(mR.status_.message_)
+                mR.status_.code_,
+                std::move(mR.status_.message_)
             );
         }
         out.dense_.meta_ = std::move(mR.value_);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(IrredenEngineTest
   asset/rig_format_test.cpp
   asset/sprite_sheet_test.cpp
   asset/txl_sidecar_test.cpp
+  asset/voxel_set_dense_test.cpp
   asset/voxel_set_shapes_test.cpp
   audio/music_theory_test.cpp
   common/ir_platform_test.cpp

--- a/test/asset/voxel_set_dense_test.cpp
+++ b/test/asset/voxel_set_dense_test.cpp
@@ -1,0 +1,478 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/voxel_set_format.hpp>
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace IRAsset;
+
+const std::string kTmpDir = "/tmp";
+
+void expectVoxelEq(const VoxelRecord &a, const VoxelRecord &b) {
+    EXPECT_EQ(a.color_.red_, b.color_.red_);
+    EXPECT_EQ(a.color_.green_, b.color_.green_);
+    EXPECT_EQ(a.color_.blue_, b.color_.blue_);
+    EXPECT_EQ(a.color_.alpha_, b.color_.alpha_);
+    EXPECT_EQ(a.material_id_, b.material_id_);
+    EXPECT_EQ(a.flags_, b.flags_);
+    EXPECT_EQ(a.bone_id_, b.bone_id_);
+    EXPECT_EQ(a.pad0_, b.pad0_);
+    EXPECT_EQ(a.reserved_, b.reserved_);
+}
+
+DenseVoxelSet make20CubeFixture() {
+    DenseVoxelSet dense;
+    dense.boundsMin_ = ivec3(0, 0, 0);
+    dense.boundsMax_ = ivec3(20, 20, 20);
+    const std::size_t count = dense.voxelCount();
+    dense.voxels_.resize(count);
+    for (std::size_t i = 0; i < count; ++i) {
+        VoxelRecord v;
+        // Mix the index across all fields so a byte-shift bug surfaces.
+        v.color_ = Color{
+            static_cast<std::uint8_t>(i & 0xFFu),
+            static_cast<std::uint8_t>((i >> 4) & 0xFFu),
+            static_cast<std::uint8_t>((i >> 8) & 0xFFu),
+            255,
+        };
+        v.material_id_ = static_cast<std::uint8_t>(i & 0x3Fu);
+        v.flags_ = static_cast<std::uint8_t>((i & 1u) ? 0x01u : 0x02u);
+        v.bone_id_ = static_cast<std::uint8_t>(i & 0x0Fu);
+        v.pad0_ = 0;
+        v.reserved_ = static_cast<std::uint32_t>(i * 7u);
+        dense.voxels_[i] = v;
+    }
+    return dense;
+}
+
+std::vector<std::uint8_t> readFileBytes(const std::string &path) {
+    std::FILE *fp = std::fopen(path.c_str(), "rb");
+    if (!fp)
+        return {};
+    std::fseek(fp, 0, SEEK_END);
+    const long size = std::ftell(fp);
+    std::fseek(fp, 0, SEEK_SET);
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size < 0 ? 0 : size));
+    if (!bytes.empty()) {
+        std::fread(bytes.data(), 1, bytes.size(), fp);
+    }
+    std::fclose(fp);
+    return bytes;
+}
+
+// ---- BNDS chunk --------------------------------------------------------
+
+TEST(VoxelSetDense, BoundsChunkRoundTrip) {
+    const ivec3 mn(-5, 2, -100);
+    const ivec3 mx(15, 42, 7);
+    auto payload = makeBoundsChunk(mn, mx);
+    ASSERT_EQ(payload.tag_, kChunkTagBounds);
+    ASSERT_EQ(payload.data_.size(), 24u);
+
+    auto loaded = readBoundsChunk(payload.data_);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.boundsMin_, mn);
+    EXPECT_EQ(loaded.value_.boundsMax_, mx);
+}
+
+TEST(VoxelSetDense, BoundsChunkTruncatedReturnsError) {
+    std::vector<std::uint8_t> body(8, 0); // half a BNDS body
+    auto loaded = readBoundsChunk(body);
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::Truncated);
+}
+
+// ---- VOXR chunk --------------------------------------------------------
+
+TEST(VoxelSetDense, VoxelRecordIs12Bytes) {
+    static_assert(sizeof(VoxelRecord) == 12, "VoxelRecord must be 12 B");
+    SUCCEED();
+}
+
+TEST(VoxelSetDense, VoxelRecordsChunkRoundTrip) {
+    std::vector<VoxelRecord> voxels;
+    for (std::uint32_t i = 0; i < 8; ++i) {
+        VoxelRecord v;
+        v.color_ = Color{static_cast<std::uint8_t>(i * 32u), 100, 200, 255};
+        v.material_id_ = static_cast<std::uint8_t>(i);
+        v.flags_ = 0x07u;
+        v.bone_id_ = static_cast<std::uint8_t>(i * 3u);
+        v.pad0_ = 0;
+        v.reserved_ = i * 0xCAFEu;
+        voxels.push_back(v);
+    }
+    auto payload = makeVoxelRecordsChunk(voxels);
+    ASSERT_EQ(payload.tag_, kChunkTagVoxelRecords);
+
+    auto loaded = readVoxelRecordsChunk(payload.data_, voxels.size());
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.recordVersion_, kVoxelRecordVersion);
+    ASSERT_EQ(loaded.value_.voxels_.size(), voxels.size());
+    for (std::size_t i = 0; i < voxels.size(); ++i) {
+        expectVoxelEq(voxels[i], loaded.value_.voxels_[i]);
+    }
+}
+
+TEST(VoxelSetDense, VoxelRecordsCountMismatchStillLoads) {
+    // Loader logs a warning but does not fail when the chunk's count
+    // doesn't match the bounds-derived count — Rule #5.
+    std::vector<VoxelRecord> voxels(3);
+    auto payload = makeVoxelRecordsChunk(voxels);
+    auto loaded = readVoxelRecordsChunk(payload.data_, /*expectedCount=*/99);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.voxels_.size(), 3u);
+}
+
+// ---- LAYR chunk --------------------------------------------------------
+
+TEST(VoxelSetDense, LayersChunkRoundTrip) {
+    std::vector<LayerInfo> layers;
+    LayerInfo skin;
+    skin.name_ = "skin";
+    skin.bitmask_ = {0xDEADBEEFCAFEBABEull, 0x0123456789ABCDEFull};
+    layers.push_back(skin);
+    LayerInfo metal;
+    metal.name_ = "metal-plates";
+    metal.bitmask_ = {0xFFFFFFFFFFFFFFFFull};
+    layers.push_back(metal);
+
+    auto payload = makeLayersChunk(layers);
+    ASSERT_EQ(payload.tag_, kChunkTagLayers);
+
+    auto loaded = readLayersChunk(payload.data_);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), 2u);
+    EXPECT_EQ(loaded.value_[0].name_, "skin");
+    EXPECT_EQ(loaded.value_[0].bitmask_, skin.bitmask_);
+    EXPECT_EQ(loaded.value_[1].name_, "metal-plates");
+    EXPECT_EQ(loaded.value_[1].bitmask_, metal.bitmask_);
+}
+
+TEST(VoxelSetDense, EmptyLayersListRoundTrip) {
+    std::vector<LayerInfo> layers;
+    auto payload = makeLayersChunk(layers);
+    auto loaded = readLayersChunk(payload.data_);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_TRUE(loaded.value_.empty());
+}
+
+// ---- FRAM chunk --------------------------------------------------------
+
+TEST(VoxelSetDense, FramesChunkRoundTripWhenOffsetCountsMatch) {
+    constexpr std::size_t voxelCount = 4;
+    std::vector<FramePose> frames;
+    FramePose f0;
+    f0.frameIndex_ = 0;
+    f0.offsets_ = {vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0), vec3(0, 0, 0)};
+    frames.push_back(f0);
+    FramePose f1;
+    f1.frameIndex_ = 7;
+    f1.offsets_ = {vec3(1, 2, 3), vec3(-1, 0, 5), vec3(0, 0, 0), vec3(0, 0, 0)};
+    frames.push_back(f1);
+
+    auto payload = makeFramesChunk(frames);
+    ASSERT_EQ(payload.tag_, kChunkTagFrames);
+
+    auto loaded = readFramesChunk(payload.data_, voxelCount);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.frames_.size(), 2u);
+    EXPECT_EQ(loaded.value_.skippedFrames_, 0u);
+    EXPECT_EQ(loaded.value_.frames_[0].frameIndex_, 0u);
+    EXPECT_EQ(loaded.value_.frames_[1].frameIndex_, 7u);
+    ASSERT_EQ(loaded.value_.frames_[1].offsets_.size(), 4u);
+    EXPECT_EQ(loaded.value_.frames_[1].offsets_[1].x, -1.0f);
+    EXPECT_EQ(loaded.value_.frames_[1].offsets_[1].z, 5.0f);
+}
+
+TEST(VoxelSetDense, FrameWithMismatchedOffsetCountIsDroppedSiblingSurvives) {
+    // Construct a chunk with two frames: the first has 2 offsets (wrong)
+    // and the second has 3 offsets (matches expectedCount). The loader
+    // must drop the first frame, keep the second, and surface the skip.
+    constexpr std::size_t voxelCount = 3;
+    std::vector<FramePose> frames;
+    FramePose bad;
+    bad.frameIndex_ = 11;
+    bad.offsets_ = {vec3(9, 9, 9), vec3(8, 8, 8)};
+    frames.push_back(bad);
+    FramePose good;
+    good.frameIndex_ = 12;
+    good.offsets_ = {vec3(1, 0, 0), vec3(0, 1, 0), vec3(0, 0, 1)};
+    frames.push_back(good);
+
+    auto payload = makeFramesChunk(frames);
+    auto loaded = readFramesChunk(payload.data_, voxelCount);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.skippedFrames_, 1u);
+    ASSERT_EQ(loaded.value_.frames_.size(), 1u);
+    EXPECT_EQ(loaded.value_.frames_[0].frameIndex_, 12u);
+}
+
+// ---- META chunk --------------------------------------------------------
+
+TEST(VoxelSetDense, MetaChunkRoundTrip) {
+    std::vector<MetaEntry> meta;
+    meta.push_back({"author", "alice"});
+    meta.push_back({"material_registry_version", "v3"});
+    meta.push_back({"empty-value", ""});
+
+    auto payload = makeMetaChunk(meta);
+    ASSERT_EQ(payload.tag_, kChunkTagMeta);
+
+    auto loaded = readMetaChunk(payload.data_);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), meta.size());
+    for (std::size_t i = 0; i < meta.size(); ++i) {
+        EXPECT_EQ(loaded.value_[i].key_, meta[i].key_);
+        EXPECT_EQ(loaded.value_[i].value_, meta[i].value_);
+    }
+}
+
+// ---- High-level save/load: 20³ fixture ---------------------------------
+
+TEST(VoxelSetDense, TwentyCubeFixtureRoundTrip) {
+    const auto dense = make20CubeFixture();
+    const std::string path = kTmpDir + "/vxs_dense_20cube.vxs";
+
+    ASSERT_TRUE(saveDenseVoxelSet(path, dense).ok());
+
+    auto loaded = loadDenseVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::DENSE);
+    EXPECT_EQ(loaded.value_.dense_.boundsMin_, dense.boundsMin_);
+    EXPECT_EQ(loaded.value_.dense_.boundsMax_, dense.boundsMax_);
+    ASSERT_EQ(loaded.value_.dense_.voxels_.size(), dense.voxels_.size());
+    for (std::size_t i = 0; i < dense.voxels_.size(); ++i) {
+        expectVoxelEq(dense.voxels_[i], loaded.value_.dense_.voxels_[i]);
+    }
+    EXPECT_TRUE(loaded.value_.dense_.layers_.empty());
+    EXPECT_TRUE(loaded.value_.dense_.frames_.empty());
+    EXPECT_TRUE(loaded.value_.dense_.meta_.empty());
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetDense, AllSectionsPopulatedRoundTrip) {
+    DenseVoxelSet dense = make20CubeFixture();
+    // 8000-bit bitmask — 125 u64 words.
+    const std::size_t wordCount = (dense.voxelCount() + 63) / 64;
+    LayerInfo layer;
+    layer.name_ = "interactive";
+    layer.bitmask_.assign(wordCount, 0);
+    layer.bitmask_[0] = 0xAAAAAAAAAAAAAAAAull;
+    layer.bitmask_[wordCount - 1] = 0x1ull;
+    dense.layers_.push_back(layer);
+
+    FramePose frame;
+    frame.frameIndex_ = 42;
+    frame.offsets_.assign(dense.voxelCount(), vec3(0, 0, 0));
+    frame.offsets_[3] = vec3(0.5f, -1.25f, 2.0f);
+    dense.frames_.push_back(frame);
+
+    dense.meta_.push_back({"author", "bob"});
+
+    const std::string path = kTmpDir + "/vxs_dense_full.vxs";
+    ASSERT_TRUE(saveDenseVoxelSet(path, dense).ok());
+
+    auto loaded = loadDenseVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.skippedFrames_, 0u);
+    ASSERT_EQ(loaded.value_.dense_.layers_.size(), 1u);
+    EXPECT_EQ(loaded.value_.dense_.layers_[0].name_, "interactive");
+    EXPECT_EQ(loaded.value_.dense_.layers_[0].bitmask_, layer.bitmask_);
+    ASSERT_EQ(loaded.value_.dense_.frames_.size(), 1u);
+    EXPECT_EQ(loaded.value_.dense_.frames_[0].frameIndex_, 42u);
+    EXPECT_EQ(loaded.value_.dense_.frames_[0].offsets_[3].x, 0.5f);
+    EXPECT_EQ(loaded.value_.dense_.frames_[0].offsets_[3].y, -1.25f);
+    EXPECT_EQ(loaded.value_.dense_.frames_[0].offsets_[3].z, 2.0f);
+    ASSERT_EQ(loaded.value_.dense_.meta_.size(), 1u);
+    EXPECT_EQ(loaded.value_.dense_.meta_[0].key_, "author");
+    EXPECT_EQ(loaded.value_.dense_.meta_[0].value_, "bob");
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetDense, EmptyVoxelSetRoundTrip) {
+    DenseVoxelSet dense;
+    // Bounds (0,0,0) → (0,0,0) ⇒ zero voxels. The VOXR chunk still
+    // round-trips as a zero-count blob.
+    const std::string path = kTmpDir + "/vxs_dense_empty.vxs";
+    ASSERT_TRUE(saveDenseVoxelSet(path, dense).ok());
+
+    auto loaded = loadDenseVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::DENSE);
+    EXPECT_EQ(loaded.value_.dense_.voxelCount(), 0u);
+    EXPECT_TRUE(loaded.value_.dense_.voxels_.empty());
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetDense, FullVoxelSetEveryCellActive) {
+    DenseVoxelSet dense;
+    dense.boundsMin_ = ivec3(0);
+    dense.boundsMax_ = ivec3(4, 4, 4);
+    dense.voxels_.assign(
+        dense.voxelCount(),
+        VoxelRecord{Color{255, 255, 255, 255}, 1, 0x07, 0, 0, 0}
+    );
+
+    const std::string path = kTmpDir + "/vxs_dense_full4.vxs";
+    ASSERT_TRUE(saveDenseVoxelSet(path, dense).ok());
+    auto loaded = loadDenseVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.dense_.voxels_.size(), 64u);
+    for (const auto &v : loaded.value_.dense_.voxels_) {
+        EXPECT_EQ(v.color_.red_, 255);
+        EXPECT_EQ(v.material_id_, 1);
+        EXPECT_EQ(v.flags_, 0x07);
+    }
+    std::remove(path.c_str());
+}
+
+// ---- Byte-stability ----------------------------------------------------
+
+TEST(VoxelSetDense, ReSerializingLoadedFileMatchesOriginalBytes) {
+    // save → load → save → bytes equal. Catches non-deterministic
+    // ordering inside chunks or fields.
+    DenseVoxelSet dense = make20CubeFixture();
+    dense.layers_.push_back(LayerInfo{"a", {0xAAull, 0x55ull}});
+    dense.meta_.push_back({"k", "v"});
+    const std::string p1 = kTmpDir + "/vxs_dense_bytecmp_1.vxs";
+    const std::string p2 = kTmpDir + "/vxs_dense_bytecmp_2.vxs";
+
+    ASSERT_TRUE(saveDenseVoxelSet(p1, dense).ok());
+    auto loaded = loadDenseVoxelSet(p1);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_TRUE(saveDenseVoxelSet(p2, loaded.value_.dense_).ok());
+
+    const auto b1 = readFileBytes(p1);
+    const auto b2 = readFileBytes(p2);
+    EXPECT_EQ(b1, b2);
+    EXPECT_FALSE(b1.empty());
+
+    std::remove(p1.c_str());
+    std::remove(p2.c_str());
+}
+
+// ---- Container errors --------------------------------------------------
+
+TEST(VoxelSetDense, BadMagicSurfacesAsBadMagic) {
+    const std::string path = kTmpDir + "/vxs_dense_bad_magic.vxs";
+    {
+        std::FILE *fp = std::fopen(path.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        // 12-byte header with wrong magic + valid version + 0 chunks.
+        const char header[12] = {'B', 'A', 'D', '!', 1, 0, 0, 0, 0, 0, 0, 0};
+        std::fwrite(header, 1, sizeof(header), fp);
+        std::fclose(fp);
+    }
+    auto loaded = loadDenseVoxelSet(path);
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::BadMagic);
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetDense, VersionTooNewSurfacesAsVersionTooNew) {
+    const std::string path = kTmpDir + "/vxs_dense_too_new.vxs";
+    {
+        std::FILE *fp = std::fopen(path.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        // Valid magic but a future version number.
+        char header[12] = {0};
+        header[0] = 'V';
+        header[1] = 'X';
+        header[2] = 'S';
+        header[3] = '1';
+        header[4] = static_cast<char>(kVoxelSetVersion + 1u);
+        std::fwrite(header, 1, sizeof(header), fp);
+        std::fclose(fp);
+    }
+    auto loaded = loadDenseVoxelSet(path);
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::VersionTooNew);
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetDense, TruncatedVoxRChunkSurfacesAsTruncated) {
+    // Build a valid file in memory, then truncate it mid-VOXR.
+    DenseVoxelSet dense;
+    dense.boundsMin_ = ivec3(0);
+    dense.boundsMax_ = ivec3(2, 2, 2);
+    dense.voxels_.assign(dense.voxelCount(), VoxelRecord{});
+
+    const std::string p1 = kTmpDir + "/vxs_dense_full_for_trunc.vxs";
+    ASSERT_TRUE(saveDenseVoxelSet(p1, dense).ok());
+
+    auto full = readFileBytes(p1);
+    ASSERT_FALSE(full.empty());
+    // Truncate ~12 bytes off the end (mid-VOXR record).
+    const std::size_t cut = full.size() > 16 ? full.size() - 12 : full.size() / 2;
+    full.resize(cut);
+
+    const std::string p2 = kTmpDir + "/vxs_dense_truncated.vxs";
+    {
+        std::FILE *fp = std::fopen(p2.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        std::fwrite(full.data(), 1, full.size(), fp);
+        std::fclose(fp);
+    }
+
+    auto loaded = loadDenseVoxelSet(p2);
+    EXPECT_FALSE(loaded.ok());
+    // Either ChunkOutOfBounds (truncation inside chunk table) or
+    // Truncated (truncation inside chunk body). Both are recoverable
+    // diagnostics per Rule #5.
+    EXPECT_TRUE(
+        loaded.status_.code_ == BinaryIOError::Truncated ||
+        loaded.status_.code_ == BinaryIOError::ChunkOutOfBounds
+    );
+    std::remove(p1.c_str());
+    std::remove(p2.c_str());
+}
+
+// ---- Unknown chunk silently skipped (Rule #1) --------------------------
+
+TEST(VoxelSetDense, UnknownChunkSilentlySkipped) {
+    // Hand-build a chunk list containing the standard DENSE chunks
+    // plus a future "FUTR" chunk that the current loader doesn't know.
+    DenseVoxelSet dense;
+    dense.boundsMin_ = ivec3(0);
+    dense.boundsMax_ = ivec3(2, 2, 2);
+    dense.voxels_.assign(dense.voxelCount(), VoxelRecord{Color{1, 2, 3, 4}, 5, 6, 7, 0, 0});
+
+    ChunkPayload future;
+    future.tag_ = {'F', 'U', 'T', 'R'};
+    future.data_ = {0xDEu, 0xADu, 0xBEu, 0xEFu};
+
+    std::vector<ChunkPayload> chunks = {
+        makeModeChunk(VoxelSetMode::DENSE),
+        makeBoundsChunk(dense.boundsMin_, dense.boundsMax_),
+        makeVoxelRecordsChunk(dense.voxels_),
+        future,
+    };
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kVoxelSetMagic, kVoxelSetVersion, chunks).ok());
+
+    const std::string path = kTmpDir + "/vxs_dense_unknown_chunk.vxs";
+    {
+        std::FILE *fp = std::fopen(path.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        std::fwrite(w.buffer().data(), 1, w.buffer().size(), fp);
+        std::fclose(fp);
+    }
+
+    auto loaded = loadDenseVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::DENSE);
+    ASSERT_EQ(loaded.value_.dense_.voxels_.size(), 8u);
+    EXPECT_EQ(loaded.value_.dense_.voxels_[0].material_id_, 5u);
+    std::remove(path.c_str());
+}
+
+} // namespace

--- a/test/asset/voxel_set_dense_test.cpp
+++ b/test/asset/voxel_set_dense_test.cpp
@@ -475,4 +475,35 @@ TEST(VoxelSetDense, UnknownChunkSilentlySkipped) {
     std::remove(path.c_str());
 }
 
+TEST(VoxelSetDense, BoundsPresentVoxRMissingLoadsWithEmptyVoxels) {
+    // Malformed save: BNDS chunk claims a non-zero voxel volume but the
+    // VOXR chunk is absent. Loader must succeed (Rule #5) with bounds
+    // populated and `voxels_` empty — the doc-comment on
+    // `DenseVoxelSetFile` requires the caller to validate
+    // `voxels_.size() == voxelCount()` before indexing.
+    std::vector<ChunkPayload> chunks = {
+        makeModeChunk(VoxelSetMode::DENSE),
+        makeBoundsChunk(ivec3(0), ivec3(2, 2, 2)),
+        // No VOXR.
+    };
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kVoxelSetMagic, kVoxelSetVersion, chunks).ok());
+
+    const std::string path = kTmpDir + "/vxs_dense_missing_voxr.vxs";
+    {
+        std::FILE *fp = std::fopen(path.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        std::fwrite(w.buffer().data(), 1, w.buffer().size(), fp);
+        std::fclose(fp);
+    }
+
+    auto loaded = loadDenseVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::DENSE);
+    EXPECT_EQ(loaded.value_.dense_.voxelCount(), 8u);
+    EXPECT_TRUE(loaded.value_.dense_.voxels_.empty());
+    std::remove(path.c_str());
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
- Adds DENSE-mode chunks to the `.vxs` voxel-set asset format introduced by T-168 (#679): `BNDS` (inclusive/exclusive `ivec3` bounds), `VOXR` (tightly-packed 12 B per-voxel records matching `C_Voxel`), `LAYR` (named layer membership bitmasks), `FRAM` (per-frame position offsets), `META` (free-form `(key, value)` strings).
- Ships `saveDenseVoxelSet(path, DenseVoxelSet)` and `loadDenseVoxelSet(path) -> DenseVoxelSetFile`. Empty layer / frame / meta sections omit the corresponding chunk so the file stays compact and older loaders treat it as "no data" rather than "missing chunk."
- Chunk-table format obeys the seven Save Format Extensibility Rules: unknown chunks silently skip (Rule #1), per-record version (`kVoxelRecordVersion`) lives at the chunk head for tight packing (Rule #3), bad-magic / version-too-new / truncated / chunk-out-of-bounds all surface as recoverable diagnostics (Rule #5).

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/679 (T-168 — currently `fleet:approved`, mergeable). When #679 merges, GitHub auto-rebases this PR's base to `master`. The two PRs share `voxel_set_format.{hpp,cpp}` so stacking is the right shape — the alternative (parallel branches off master) would mechanically conflict on every chunk-tag declaration.

Full chain: T-168 → T-167.

## Acceptance criteria — issue #664

- [x] `IRAsset::saveDenseVoxelSet(path, DenseVoxelSet)` / `loadDenseVoxelSet(path)` ship. (Single-path style matches T-168's `saveShapeGroup`; the issue body's `name, path` two-arg signature was approximate.)
- [x] MODE chunk extends to `DENSE` tag; existing SHAPES read path unchanged.
- [x] BNDS chunk: `ivec3 min, ivec3 max` (6 × i32, 24 B).
- [x] VOXR chunk: `u16 recordVersion + varuint count + count × 12 B records`. Record layout matches `C_Voxel` byte-for-byte (Color, material_id, flags, bone_id, pad0, reserved). `kVoxelRecordVersion` at chunk head, not per record, to keep records tightly packed for the 262 144-cell case (20³ × 12 B = 3 MB; per-record version would inflate by ~17%).
- [x] LAYR chunk: per-layer `(name, ceil(voxelCount/64) × u64)` bitmask.
- [x] FRAM chunk: per-frame `(frameIndex, varuint offsetCount, offsetCount × vec3)`. Frames with `offsetCount != voxelCount` are dropped and the count surfaces as `skippedFrames_`.
- [x] META chunk: `(key, value)` UTF-8 string pairs.
- [x] Reader silently ignores unknown chunk tags (Rule #1) — covered by `VoxelSetDense.UnknownChunkSilentlySkipped`.
- [x] Clear diagnostics with file path on bad magic / version-too-new / truncated chunks — covered by `BadMagicSurfacesAsBadMagic`, `VersionTooNewSurfacesAsVersionTooNew`, `TruncatedVoxRChunkSurfacesAsTruncated`.
- [x] Round-trip 20³ fixture with byte-compared VOXR records + BNDS — `TwentyCubeFixtureRoundTrip`.
- [x] Edge cases: empty set (bounds 0×0×0), every-cell-active set, byte-stable save→load→save (`ReSerializingLoadedFileMatchesOriginalBytes`).
- [x] Chunk table documented in the `.hpp` header block (Rule #7).

## Test plan

- [x] `IrredenEngineTest` 552/552 pass on macOS (Metal backend, fleet env), including 19 new `VoxelSetDense` tests.
- [x] `IrredenEngineAsset` builds clean.
- [ ] (Reviewer / cross-host smoke) Linux build + test sanity check once base merges.

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)