### PR TITLE
T-170: asset: .vxs hybrid mode + sidecar emitter + full test suite

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -287,19 +287,23 @@ uint8   csgOp            // CsgOp: NONE | UNION | SMOOTH_UNION | SUBTRACT | INTE
 High-level entry points:
 
 - `saveShapeGroup(path, span<ShapeRecord>)` — writes MODE=SHAPES, SREF,
-  SHPG chunks under the `VXS1` header.
+  SHPG chunks under the `VXS1` header. Emits a `.vxs.json` sidecar at
+  `path + ".json"` (Rule #6) on successful binary write.
 - `loadShapeGroup(path)` — returns `VoxelSetFile { mode_, shapeRecords_,
   unknownShapesSkipped_ }` after resolving SREF and SHPG. Container
   errors (`BadMagic`, `VersionTooNew`, truncation, chunk-out-of-bounds)
   surface as `BinaryIOError` results.
 - `saveDenseVoxelSet(path, DenseVoxelSet)` — writes MODE=DENSE plus
-  BNDS, VOXR, and (if non-empty) LAYR / FRAM / META chunks.
+  BNDS, VOXR, and (if non-empty) LAYR / FRAM / META chunks. Emits a
+  `.vxs.json` sidecar at `path + ".json"` (Rule #6) on successful
+  binary write.
 - `loadDenseVoxelSet(path)` — returns `DenseVoxelSetFile { mode_,
   dense_, skippedFrames_ }`. Loading a SHAPES-only file through this
   path is a no-op: `mode_ = SHAPES` and `dense_` stays empty.
 - `saveVoxelSet(path, span<ShapeRecord>, DenseVoxelSet)` — writes
-  MODE=HYBRID with SREF + SHPG (shapes) and BNDS + VOXR (dense). Also
-  emits a `.vxs.json` sidecar at `path + ".json"` (Rule #6).
+  MODE=HYBRID with SREF + SHPG (shapes) and BNDS + VOXR (dense). Emits
+  a `.vxs.json` sidecar at `path + ".json"` (Rule #6) on successful
+  binary write.
 - `loadVoxelSet(path)` — unified loader; returns `VoxelSetAllFile {
   mode_, shapeRecords_, dense_, ... }`. Works for all three modes —
   SHAPES-only leaves `dense_` empty; DENSE-only leaves `shapeRecords_`

--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -296,10 +296,14 @@ High-level entry points:
   BNDS, VOXR, and (if non-empty) LAYR / FRAM / META chunks.
 - `loadDenseVoxelSet(path)` — returns `DenseVoxelSetFile { mode_,
   dense_, skippedFrames_ }`. Loading a SHAPES-only file through this
-  path is a no-op: `mode_ = SHAPES` and `dense_` stays empty. Callers
-  that need both halves of a HYBRID save invoke `loadShapeGroup` and
-  `loadDenseVoxelSet` against the same path until T-668 ships the
-  unified entry point.
+  path is a no-op: `mode_ = SHAPES` and `dense_` stays empty.
+- `saveVoxelSet(path, span<ShapeRecord>, DenseVoxelSet)` — writes
+  MODE=HYBRID with SREF + SHPG (shapes) and BNDS + VOXR (dense). Also
+  emits a `.vxs.json` sidecar at `path + ".json"` (Rule #6).
+- `loadVoxelSet(path)` — unified loader; returns `VoxelSetAllFile {
+  mode_, shapeRecords_, dense_, ... }`. Works for all three modes —
+  SHAPES-only leaves `dense_` empty; DENSE-only leaves `shapeRecords_`
+  empty; HYBRID populates both.
 
 For callers working with `C_ShapeDescriptor`, the prefab-side adapter at
 `engine/prefabs/irreden/asset/voxel_set_io.hpp` (`#include

--- a/engine/asset/include/irreden/asset/voxel_set_format.hpp
+++ b/engine/asset/include/irreden/asset/voxel_set_format.hpp
@@ -432,10 +432,44 @@ struct DenseVoxelSetFile {
 /// - `DenseVoxelSetFile` with the resolved dense data otherwise.
 ///
 /// SHAPES-only files (no BNDS / VOXR chunks present) load as `mode_ =
-/// VoxelSetMode::SHAPES` with an empty `dense_`. A loader that needs
-/// both shapes and dense data uses `loadShapeGroup` and
-/// `loadDenseVoxelSet` against the same path.
+/// VoxelSetMode::SHAPES` with an empty `dense_`. Callers that need both
+/// halves should use `loadVoxelSet` instead.
 Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path);
+
+// ---- Unified HYBRID save/load -------------------------------------------
+
+/// Combined loader result covering all three `.vxs` modes (SHAPES, DENSE,
+/// HYBRID). For SHAPES-only saves `dense_` is default-constructed (empty
+/// bounds and voxels). For DENSE-only saves `shapeRecords_` is empty. For
+/// HYBRID both halves are populated. Callers inspect `mode_` to decide
+/// which entities to spawn.
+struct VoxelSetAllFile {
+    VoxelSetMode mode_ = VoxelSetMode::UNKNOWN;
+    std::vector<ShapeRecord> shapeRecords_;
+    std::size_t unknownShapesSkipped_ = 0;
+    DenseVoxelSet dense_;
+    std::size_t skippedFrames_ = 0;
+};
+
+/// Save a HYBRID-mode `.vxs` asset to @p path. Writes MODE=HYBRID, SREF,
+/// SHPG, BNDS, VOXR, and (if non-empty) LAYR/FRAM/META chunks. Also emits
+/// a `.vxs.json` sidecar at `path + ".json"` (Save Format Extensibility
+/// Rule #6 — sidecar regenerated from the binary on every save, never the
+/// source of truth). The sidecar is not emitted when the binary write fails.
+BinaryStatus saveVoxelSet(
+    const std::string &path, std::span<const ShapeRecord> shapes, const DenseVoxelSet &dense
+);
+
+/// Load any `.vxs` asset and populate both the shape-group and dense
+/// halves. Returns:
+/// - `BadMagic` if magic isn't `VXS1`
+/// - `VersionTooNew` if file version > `kVoxelSetVersion`
+/// - `Truncated` / `ChunkOutOfBounds` for malformed chunk tables
+/// - `VoxelSetAllFile` with all available halves populated on success.
+///
+/// SHAPES-only files leave `dense_` empty; DENSE-only files leave
+/// `shapeRecords_` empty; HYBRID files populate both.
+Result<VoxelSetAllFile> loadVoxelSet(const std::string &path);
 
 } // namespace IRAsset
 

--- a/engine/asset/include/irreden/asset/voxel_set_format.hpp
+++ b/engine/asset/include/irreden/asset/voxel_set_format.hpp
@@ -381,7 +381,10 @@ Result<std::vector<MetaEntry>> readMetaChunk(std::span<const std::uint8_t> body)
 // ---- High-level save/load ----------------------------------------------
 
 /// Save a shape-group `.vxs` asset to @p path. Writes MODE=SHAPES,
-/// SREF, and SHPG chunks. Returns the writer's failure state.
+/// SREF, and SHPG chunks. Also emits a `.vxs.json` sidecar at
+/// `path + ".json"` (Rule #6) when the binary write succeeds; a failed
+/// binary write skips the sidecar so a stale sidecar never outlives a
+/// missing binary.
 BinaryStatus saveShapeGroup(const std::string &path, std::span<const ShapeRecord> records);
 
 /// Loader-side view of a shape-group `.vxs` file.
@@ -406,7 +409,10 @@ Result<VoxelSetFile> loadShapeGroup(const std::string &path);
 /// Save a DENSE-mode `.vxs` asset to @p path. Writes MODE=DENSE plus
 /// BNDS / VOXR / LAYR / FRAM / META chunks. Empty optional sections
 /// (no layers / no frames / no meta) omit the corresponding chunk so
-/// older loaders need no special-casing.
+/// older loaders need no special-casing. Also emits a `.vxs.json`
+/// sidecar at `path + ".json"` (Rule #6) when the binary write
+/// succeeds; the sidecar's `shape_primitives_summary` is empty for
+/// DENSE saves.
 BinaryStatus saveDenseVoxelSet(const std::string &path, const DenseVoxelSet &dense);
 
 /// Loader-side view of a DENSE-mode `.vxs` file. `mode_` is read from

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -1,4 +1,5 @@
 #include <irreden/asset/voxel_set_format.hpp>
+#include <irreden/asset/json_sidecar.hpp>
 
 #include <irreden/ir_profile.hpp>
 
@@ -83,6 +84,97 @@ constexpr ShapeTypeNameEntry kShapeTypeTable[] = {
     {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::CONE), "CONE"},
     {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::TORUS), "TORUS"},
 };
+
+// Emit a .vxs.json sidecar alongside the binary. `dense` is null for
+// SHAPES-only saves; `shapes` is empty for DENSE-only saves.
+void emitVoxelSetSidecar(
+    const std::string &path,
+    VoxelSetMode mode,
+    const DenseVoxelSet *dense,
+    std::span<const ShapeRecord> shapes
+) {
+    const std::string sidecarPath = path + ".json";
+    JsonSidecarWriter j;
+    j.beginObject();
+
+    j.key("version");
+    j.valueUInt(kVoxelSetVersion);
+
+    const char *modeStr = "UNKNOWN";
+    switch (mode) {
+    case VoxelSetMode::DENSE:
+        modeStr = "DENSE";
+        break;
+    case VoxelSetMode::SHAPES:
+        modeStr = "SHAPES";
+        break;
+    case VoxelSetMode::HYBRID:
+        modeStr = "HYBRID";
+        break;
+    default:
+        break;
+    }
+    j.key("mode");
+    j.valueString(modeStr);
+
+    if (dense != nullptr) {
+        j.key("bounds");
+        j.beginObject();
+        j.key("min");
+        j.beginArray();
+        j.valueInt(dense->boundsMin_.x);
+        j.valueInt(dense->boundsMin_.y);
+        j.valueInt(dense->boundsMin_.z);
+        j.endArray();
+        j.key("max");
+        j.beginArray();
+        j.valueInt(dense->boundsMax_.x);
+        j.valueInt(dense->boundsMax_.y);
+        j.valueInt(dense->boundsMax_.z);
+        j.endArray();
+        j.endObject();
+    } else {
+        j.key("bounds");
+        j.valueNull();
+    }
+
+    j.key("material_registry_refs");
+    j.beginArray();
+    j.endArray();
+
+    j.key("layer_names");
+    j.beginArray();
+    if (dense != nullptr) {
+        for (const auto &layer : dense->layers_) {
+            j.valueString(layer.name_);
+        }
+    }
+    j.endArray();
+
+    const std::uint64_t frameCount =
+        (dense != nullptr) ? static_cast<std::uint64_t>(dense->frames_.size()) : 0u;
+    j.key("frame_count");
+    j.valueUInt(frameCount);
+
+    // Count shapes per type using kShapeTypeTable for deterministic ordering.
+    j.key("shape_primitives_summary");
+    j.beginObject();
+    for (const auto &entry : kShapeTypeTable) {
+        std::size_t count = 0;
+        for (const auto &rec : shapes) {
+            if (rec.shapeTypeId_ == entry.id_)
+                ++count;
+        }
+        if (count > 0) {
+            j.key(entry.name_);
+            j.valueUInt(static_cast<std::uint64_t>(count));
+        }
+    }
+    j.endObject();
+
+    j.endObject();
+    writeJsonSidecarToFile(sidecarPath, j.str());
+}
 
 } // namespace
 
@@ -833,6 +925,142 @@ Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path) {
         out.dense_.meta_ = std::move(mR.value_);
     }
     return Result<DenseVoxelSetFile>::success(std::move(out));
+}
+
+BinaryStatus saveVoxelSet(
+    const std::string &path, std::span<const ShapeRecord> shapes, const DenseVoxelSet &dense
+) {
+    FileBinaryWriter fw(path);
+    if (!fw.ok()) {
+        return BinaryStatus::error(
+            BinaryIOError::OpenFailed,
+            "saveVoxelSet: could not open '" + path + "' for write"
+        );
+    }
+    const auto shapeTypeEntries = buildCurrentShapeTypeNameTable();
+    std::vector<ChunkPayload> chunks;
+    chunks.reserve(8);
+    chunks.push_back(makeModeChunk(VoxelSetMode::HYBRID));
+    chunks.push_back(makeShapeRefsChunk(shapeTypeEntries));
+    chunks.push_back(makeShapeGroupChunk(shapes));
+    chunks.push_back(makeBoundsChunk(dense.boundsMin_, dense.boundsMax_));
+    chunks.push_back(makeVoxelRecordsChunk(dense.voxels_));
+    if (!dense.layers_.empty()) {
+        chunks.push_back(makeLayersChunk(dense.layers_));
+    }
+    if (!dense.frames_.empty()) {
+        chunks.push_back(makeFramesChunk(dense.frames_));
+    }
+    if (!dense.meta_.empty()) {
+        chunks.push_back(makeMetaChunk(dense.meta_));
+    }
+    const auto status = writeChunked(fw, kVoxelSetMagic, kVoxelSetVersion, chunks);
+    if (status.ok()) {
+        emitVoxelSetSidecar(path, VoxelSetMode::HYBRID, &dense, shapes);
+    }
+    return status;
+}
+
+Result<VoxelSetAllFile> loadVoxelSet(const std::string &path) {
+    FileBinaryReader fr(path);
+    if (!fr.ok()) {
+        return Result<VoxelSetAllFile>::error(
+            BinaryIOError::OpenFailed,
+            "loadVoxelSet: could not open '" + path + "' for read"
+        );
+    }
+    auto chunksR = readChunks(fr, kVoxelSetMagic, kVoxelSetVersion);
+    if (!chunksR.ok()) {
+        return Result<VoxelSetAllFile>::error(
+            chunksR.status_.code_,
+            std::move(chunksR.status_.message_)
+        );
+    }
+    VoxelSetAllFile out;
+    out.mode_ = readModeChunk(chunksR.value_);
+
+    // Shape half
+    NameTable diskShapeTypes;
+    if (const LoadedChunk *sref = findChunk(chunksR.value_, kChunkTagShapeRefs)) {
+        auto entriesR = readShapeRefsChunk(sref->data_);
+        if (!entriesR.ok()) {
+            return Result<VoxelSetAllFile>::error(
+                entriesR.status_.code_,
+                std::move(entriesR.status_.message_)
+            );
+        }
+        diskShapeTypes = NameTable(std::move(entriesR.value_));
+    }
+    if (const LoadedChunk *shpg = findChunk(chunksR.value_, kChunkTagShapeGroup)) {
+        auto recR = readShapeGroupChunk(shpg->data_, diskShapeTypes);
+        if (!recR.ok()) {
+            return Result<VoxelSetAllFile>::error(
+                recR.status_.code_,
+                std::move(recR.status_.message_)
+            );
+        }
+        out.shapeRecords_ = std::move(recR.value_.records_);
+        out.unknownShapesSkipped_ = recR.value_.unknownShapesSkipped_;
+    }
+
+    // Dense half — absent BNDS means no dense data.
+    const LoadedChunk *bndsChunk = findChunk(chunksR.value_, kChunkTagBounds);
+    if (bndsChunk == nullptr) {
+        return Result<VoxelSetAllFile>::success(std::move(out));
+    }
+    auto boundsR = readBoundsChunk(bndsChunk->data_);
+    if (!boundsR.ok()) {
+        return Result<VoxelSetAllFile>::error(
+            boundsR.status_.code_,
+            std::move(boundsR.status_.message_)
+        );
+    }
+    out.dense_.boundsMin_ = boundsR.value_.boundsMin_;
+    out.dense_.boundsMax_ = boundsR.value_.boundsMax_;
+    const std::size_t expectedCount = out.dense_.voxelCount();
+
+    if (const LoadedChunk *voxr = findChunk(chunksR.value_, kChunkTagVoxelRecords)) {
+        auto vR = readVoxelRecordsChunk(voxr->data_, expectedCount);
+        if (!vR.ok()) {
+            return Result<VoxelSetAllFile>::error(vR.status_.code_, std::move(vR.status_.message_));
+        }
+        out.dense_.recordVersion_ = vR.value_.recordVersion_;
+        out.dense_.voxels_ = std::move(vR.value_.voxels_);
+    } else if (expectedCount > 0) {
+        IRE_LOG_WARN(
+            "loadVoxelSet: BNDS present (voxelCount={}) but VOXR "
+            "chunk missing in '{}'; voxels_ left empty",
+            expectedCount,
+            path
+        );
+    }
+
+    if (const LoadedChunk *layr = findChunk(chunksR.value_, kChunkTagLayers)) {
+        auto lR = readLayersChunk(layr->data_);
+        if (!lR.ok()) {
+            return Result<VoxelSetAllFile>::error(lR.status_.code_, std::move(lR.status_.message_));
+        }
+        out.dense_.layers_ = std::move(lR.value_);
+    }
+
+    if (const LoadedChunk *fram = findChunk(chunksR.value_, kChunkTagFrames)) {
+        auto fR = readFramesChunk(fram->data_, expectedCount);
+        if (!fR.ok()) {
+            return Result<VoxelSetAllFile>::error(fR.status_.code_, std::move(fR.status_.message_));
+        }
+        out.dense_.frames_ = std::move(fR.value_.frames_);
+        out.skippedFrames_ = fR.value_.skippedFrames_;
+    }
+
+    if (const LoadedChunk *meta = findChunk(chunksR.value_, kChunkTagMeta)) {
+        auto mR = readMetaChunk(meta->data_);
+        if (!mR.ok()) {
+            return Result<VoxelSetAllFile>::error(mR.status_.code_, std::move(mR.status_.message_));
+        }
+        out.dense_.meta_ = std::move(mR.value_);
+    }
+
+    return Result<VoxelSetAllFile>::success(std::move(out));
 }
 
 } // namespace IRAsset

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -85,8 +85,10 @@ constexpr ShapeTypeNameEntry kShapeTypeTable[] = {
     {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::TORUS), "TORUS"},
 };
 
-// Emit a .vxs.json sidecar alongside the binary. `dense` is null for
-// SHAPES-only saves; `shapes` is empty for DENSE-only saves.
+// Emit a .vxs.json sidecar alongside the binary. Three call paths:
+//   - SHAPES save:  dense=nullptr, shapes=records (bounds emit as null).
+//   - DENSE save:   dense=&dense,  shapes={}      (shape_primitives_summary empty).
+//   - HYBRID save:  dense=&dense,  shapes=records (both halves populated).
 void emitVoxelSetSidecar(
     const std::string &path,
     VoxelSetMode mode,
@@ -757,7 +759,11 @@ BinaryStatus saveShapeGroup(const std::string &path, std::span<const ShapeRecord
         makeShapeRefsChunk(shapeTypeEntries),
         makeShapeGroupChunk(records),
     };
-    return writeChunked(fw, kVoxelSetMagic, kVoxelSetVersion, chunks);
+    const auto status = writeChunked(fw, kVoxelSetMagic, kVoxelSetVersion, chunks);
+    if (status.ok()) {
+        emitVoxelSetSidecar(path, VoxelSetMode::SHAPES, nullptr, records);
+    }
+    return status;
 }
 
 Result<VoxelSetFile> loadShapeGroup(const std::string &path) {
@@ -829,7 +835,11 @@ BinaryStatus saveDenseVoxelSet(const std::string &path, const DenseVoxelSet &den
     if (!dense.meta_.empty()) {
         chunks.push_back(makeMetaChunk(dense.meta_));
     }
-    return writeChunked(fw, kVoxelSetMagic, kVoxelSetVersion, chunks);
+    const auto status = writeChunked(fw, kVoxelSetMagic, kVoxelSetVersion, chunks);
+    if (status.ok()) {
+        emitVoxelSetSidecar(path, VoxelSetMode::DENSE, &dense, {});
+    }
+    return status;
 }
 
 Result<DenseVoxelSetFile> loadDenseVoxelSet(const std::string &path) {

--- a/engine/prefabs/irreden/asset/CLAUDE.md
+++ b/engine/prefabs/irreden/asset/CLAUDE.md
@@ -10,11 +10,12 @@ below the component layer.
 
 - `voxel_set_io.hpp` — `IRAsset::saveVoxelSet(span<const
   C_ShapeDescriptor>, ...)` writes a SHAPES-mode `.vxs` shape-group
-  asset. Parallel optional spans (`offsets`, `rotations`, `csgOps`,
-  `boneIds`) carry the per-instance composition metadata that
-  `C_ShapeDescriptor` itself doesn't store. Loader path: callers use
-  `IRAsset::loadShapeGroup` (in `<irreden/asset/voxel_set_format.hpp>`)
-  and reconstruct entities from the returned `ShapeRecord`s.
+  asset (plus a `.vxs.json` sidecar; Rule #6). Parallel optional
+  spans (`offsets`, `rotations`, `csgOps`, `boneIds`) carry the
+  per-instance composition metadata that `C_ShapeDescriptor` itself
+  doesn't store. Loader path: callers use `IRAsset::loadShapeGroup`
+  (in `<irreden/asset/voxel_set_format.hpp>`) and reconstruct
+  entities from the returned `ShapeRecord`s.
 
 ## Commands
 

--- a/engine/prefabs/irreden/asset/voxel_set_io.hpp
+++ b/engine/prefabs/irreden/asset/voxel_set_io.hpp
@@ -24,7 +24,9 @@ namespace IRAsset {
 
 /// Persist a shape-group `.vxs` from a span of `C_ShapeDescriptor` plus
 /// parallel arrays for the runtime-only metadata the descriptor does
-/// not carry (offset / rotation / CSG op / bone-id binding).
+/// not carry (offset / rotation / CSG op / bone-id binding). The
+/// underlying `saveShapeGroup` also emits a `.vxs.json` sidecar
+/// (Rule #6) on a successful binary write.
 ///
 /// Empty parallel spans take the per-record default (identity
 /// transform, `CsgOp::NONE`, `boneId = 0`). Non-empty spans should

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(IrredenEngineTest
   asset/sprite_sheet_test.cpp
   asset/txl_sidecar_test.cpp
   asset/voxel_set_dense_test.cpp
+  asset/voxel_set_hybrid_test.cpp
   asset/voxel_set_shapes_test.cpp
   audio/music_theory_test.cpp
   common/ir_platform_test.cpp

--- a/test/asset/voxel_set_dense_test.cpp
+++ b/test/asset/voxel_set_dense_test.cpp
@@ -256,6 +256,7 @@ TEST(VoxelSetDense, TwentyCubeFixtureRoundTrip) {
     EXPECT_TRUE(loaded.value_.dense_.frames_.empty());
     EXPECT_TRUE(loaded.value_.dense_.meta_.empty());
     std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
 }
 
 TEST(VoxelSetDense, AllSectionsPopulatedRoundTrip) {
@@ -295,6 +296,7 @@ TEST(VoxelSetDense, AllSectionsPopulatedRoundTrip) {
     EXPECT_EQ(loaded.value_.dense_.meta_[0].key_, "author");
     EXPECT_EQ(loaded.value_.dense_.meta_[0].value_, "bob");
     std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
 }
 
 TEST(VoxelSetDense, EmptyVoxelSetRoundTrip) {
@@ -310,6 +312,7 @@ TEST(VoxelSetDense, EmptyVoxelSetRoundTrip) {
     EXPECT_EQ(loaded.value_.dense_.voxelCount(), 0u);
     EXPECT_TRUE(loaded.value_.dense_.voxels_.empty());
     std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
 }
 
 TEST(VoxelSetDense, FullVoxelSetEveryCellActive) {
@@ -332,6 +335,7 @@ TEST(VoxelSetDense, FullVoxelSetEveryCellActive) {
         EXPECT_EQ(v.flags_, 0x07);
     }
     std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
 }
 
 // ---- Byte-stability ----------------------------------------------------
@@ -357,6 +361,8 @@ TEST(VoxelSetDense, ReSerializingLoadedFileMatchesOriginalBytes) {
 
     std::remove(p1.c_str());
     std::remove(p2.c_str());
+    std::remove((p1 + ".json").c_str());
+    std::remove((p2 + ".json").c_str());
 }
 
 // ---- Container errors --------------------------------------------------
@@ -433,6 +439,7 @@ TEST(VoxelSetDense, TruncatedVoxRChunkSurfacesAsTruncated) {
     );
     std::remove(p1.c_str());
     std::remove(p2.c_str());
+    std::remove((p1 + ".json").c_str());
 }
 
 // ---- Unknown chunk silently skipped (Rule #1) --------------------------
@@ -504,6 +511,46 @@ TEST(VoxelSetDense, BoundsPresentVoxRMissingLoadsWithEmptyVoxels) {
     EXPECT_EQ(loaded.value_.dense_.voxelCount(), 8u);
     EXPECT_TRUE(loaded.value_.dense_.voxels_.empty());
     std::remove(path.c_str());
+}
+
+TEST(VoxelSetDense, SidecarEmittedAlongsideBinary) {
+    DenseVoxelSet dense;
+    dense.boundsMin_ = ivec3(-2, 0, 1);
+    dense.boundsMax_ = ivec3(3, 4, 4);
+    dense.voxels_.assign(dense.voxelCount(), VoxelRecord{});
+    LayerInfo layer;
+    layer.name_ = "active";
+    layer.bitmask_.assign((dense.voxelCount() + 63) / 64, 0);
+    dense.layers_.push_back(layer);
+    FramePose frame;
+    frame.frameIndex_ = 0;
+    frame.offsets_.assign(dense.voxelCount(), vec3(0.0f));
+    dense.frames_.push_back(frame);
+
+    const std::string path = kTmpDir + "/vxs_dense_sidecar.vxs";
+    const std::string sidecarPath = path + ".json";
+    std::remove(sidecarPath.c_str());
+
+    ASSERT_TRUE(saveDenseVoxelSet(path, dense).ok());
+
+    const auto sidecarBytes = readFileBytes(sidecarPath);
+    EXPECT_FALSE(sidecarBytes.empty());
+
+    const std::string json(sidecarBytes.begin(), sidecarBytes.end());
+    EXPECT_NE(json.find("\"mode\""), std::string::npos);
+    EXPECT_NE(json.find("DENSE"), std::string::npos);
+    EXPECT_NE(json.find("\"bounds\""), std::string::npos);
+    EXPECT_NE(json.find("\"layer_names\""), std::string::npos);
+    EXPECT_NE(json.find("active"), std::string::npos);
+    EXPECT_NE(json.find("\"frame_count\""), std::string::npos);
+    // DENSE save passes an empty shape span — the summary object exists but
+    // contains no per-type counts.
+    EXPECT_NE(json.find("\"shape_primitives_summary\""), std::string::npos);
+    EXPECT_EQ(json.find("SPHERE"), std::string::npos);
+    EXPECT_EQ(json.find("BOX"), std::string::npos);
+
+    std::remove(path.c_str());
+    std::remove(sidecarPath.c_str());
 }
 
 } // namespace

--- a/test/asset/voxel_set_hybrid_test.cpp
+++ b/test/asset/voxel_set_hybrid_test.cpp
@@ -106,12 +106,14 @@ DenseVoxelSet make50VoxelFixture() {
 
 std::vector<std::uint8_t> readFileBytes(const std::string &path) {
     std::FILE *fp = std::fopen(path.c_str(), "rb");
-    if (!fp) return {};
+    if (!fp)
+        return {};
     std::fseek(fp, 0, SEEK_END);
     const long size = std::ftell(fp);
     std::fseek(fp, 0, SEEK_SET);
     std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size < 0 ? 0 : size));
-    if (!bytes.empty()) std::fread(bytes.data(), 1, bytes.size(), fp);
+    if (!bytes.empty())
+        std::fread(bytes.data(), 1, bytes.size(), fp);
     std::fclose(fp);
     return bytes;
 }
@@ -130,6 +132,7 @@ TEST(VoxelSetHybrid, LoadShapesOnlyFileSanity) {
     EXPECT_EQ(loaded.value_.unknownShapesSkipped_, 0u);
     EXPECT_TRUE(loaded.value_.dense_.voxels_.empty());
     std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
 }
 
 TEST(VoxelSetHybrid, LoadDenseOnlyFileSanity) {
@@ -148,6 +151,7 @@ TEST(VoxelSetHybrid, LoadDenseOnlyFileSanity) {
     EXPECT_EQ(loaded.value_.dense_.voxels_.size(), 8000u);
     EXPECT_EQ(loaded.value_.dense_.voxels_[0].color_.red_, 100);
     std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
 }
 
 // ---- Hybrid round-trip --------------------------------------------------
@@ -208,8 +212,10 @@ TEST(VoxelSetHybrid, ReserializingHybridMatchesOriginalBytes) {
     EXPECT_EQ(b1, b2);
     EXPECT_FALSE(b1.empty());
 
-    std::remove(p1.c_str()); std::remove((p1 + ".json").c_str());
-    std::remove(p2.c_str()); std::remove((p2 + ".json").c_str());
+    std::remove(p1.c_str());
+    std::remove((p1 + ".json").c_str());
+    std::remove(p2.c_str());
+    std::remove((p2 + ".json").c_str());
 }
 
 // ---- JSON sidecar -------------------------------------------------------
@@ -266,7 +272,10 @@ TEST(VoxelSetHybrid, VersionTooNewReturnsVersionTooNew) {
         std::FILE *fp = std::fopen(path.c_str(), "wb");
         ASSERT_NE(fp, nullptr);
         char header[12] = {};
-        header[0] = 'V'; header[1] = 'X'; header[2] = 'S'; header[3] = '1';
+        header[0] = 'V';
+        header[1] = 'X';
+        header[2] = 'S';
+        header[3] = '1';
         header[4] = static_cast<char>(kVoxelSetVersion + 1u);
         std::fwrite(header, 1, sizeof(header), fp);
         std::fclose(fp);
@@ -303,7 +312,8 @@ TEST(VoxelSetHybrid, TruncatedMidVoxrReturnsTruncatedOrChunkOOB) {
         loaded.status_.code_ == BinaryIOError::ChunkOutOfBounds
     );
 
-    std::remove(p1.c_str()); std::remove((p1 + ".json").c_str());
+    std::remove(p1.c_str());
+    std::remove((p1 + ".json").c_str());
     std::remove(p2.c_str());
 }
 

--- a/test/asset/voxel_set_hybrid_test.cpp
+++ b/test/asset/voxel_set_hybrid_test.cpp
@@ -1,0 +1,406 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/voxel_set_format.hpp>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace IRAsset;
+
+const std::string kTmpDir = "/tmp";
+
+// ---- Fixtures ----------------------------------------------------------
+
+std::vector<ShapeRecord> makeFivePrimitiveFixture() {
+    std::vector<ShapeRecord> records;
+
+    ShapeRecord r1;
+    r1.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE);
+    r1.params_ = vec4(3.0f, 0.0f, 0.0f, 0.0f);
+    r1.color_ = Color{200, 50, 25, 255};
+    r1.flags_ = 1u << 3;
+    r1.boneId_ = 0;
+    r1.offset_ = vec3(1.0f, 2.0f, 3.0f);
+    r1.rotation_ = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+    r1.csgOp_ = CsgOp::NONE;
+    records.push_back(r1);
+
+    ShapeRecord r2;
+    r2.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::BOX);
+    r2.params_ = vec4(2.0f, 3.0f, 4.0f, 0.0f);
+    r2.color_ = Color{0, 200, 0, 255};
+    r2.flags_ = (1u << 3) | (1u << 0);
+    r2.boneId_ = 4;
+    r2.offset_ = vec3(-5.0f, 0.0f, 1.0f);
+    r2.rotation_ = vec4(0.7071068f, 0.0f, 0.0f, 0.7071068f);
+    r2.csgOp_ = CsgOp::UNION;
+    records.push_back(r2);
+
+    ShapeRecord r3;
+    r3.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::CYLINDER);
+    r3.params_ = vec4(1.5f, 6.0f, 0.0f, 0.0f);
+    r3.color_ = Color{0, 0, 255, 128};
+    r3.flags_ = 1u << 3;
+    r3.boneId_ = 7;
+    r3.offset_ = vec3(2.5f, -1.0f, 0.0f);
+    r3.rotation_ = vec4(0.0f, 0.7071068f, 0.0f, 0.7071068f);
+    r3.csgOp_ = CsgOp::SMOOTH_UNION;
+    records.push_back(r3);
+
+    ShapeRecord r4;
+    r4.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::ELLIPSOID);
+    r4.params_ = vec4(2.0f, 1.0f, 3.0f, 0.0f);
+    r4.color_ = Color{255, 255, 0, 255};
+    r4.flags_ = 1u << 3;
+    r4.boneId_ = 0;
+    r4.offset_ = vec3(0.0f, 4.0f, -2.0f);
+    r4.rotation_ = vec4(0.0f, 0.0f, 0.7071068f, 0.7071068f);
+    r4.csgOp_ = CsgOp::SUBTRACT;
+    records.push_back(r4);
+
+    ShapeRecord r5;
+    r5.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::WEDGE);
+    r5.params_ = vec4(2.0f, 2.0f, 2.0f, 1.0f);
+    r5.color_ = Color{128, 64, 200, 255};
+    r5.flags_ = 1u << 3;
+    r5.boneId_ = 2;
+    r5.offset_ = vec3(-3.0f, -3.0f, 5.0f);
+    r5.rotation_ = vec4(0.5f, 0.5f, 0.5f, 0.5f);
+    r5.csgOp_ = CsgOp::INTERSECT;
+    records.push_back(r5);
+
+    return records;
+}
+
+// 5×5×2 = 50 voxels; each field mixed from the slot index so byte-shift
+// bugs surface in byte-compare tests.
+DenseVoxelSet make50VoxelFixture() {
+    DenseVoxelSet dense;
+    dense.boundsMin_ = ivec3(0, 0, 0);
+    dense.boundsMax_ = ivec3(5, 5, 2);
+    const std::size_t count = dense.voxelCount(); // 50
+    dense.voxels_.resize(count);
+    for (std::size_t i = 0; i < count; ++i) {
+        VoxelRecord v;
+        v.color_ = Color{
+            static_cast<std::uint8_t>(i & 0xFFu),
+            static_cast<std::uint8_t>((i >> 2) & 0xFFu),
+            static_cast<std::uint8_t>((i >> 4) & 0xFFu),
+            255,
+        };
+        v.material_id_ = static_cast<std::uint8_t>(i % 8);
+        v.flags_ = 1u;
+        v.bone_id_ = 0;
+        v.pad0_ = 0;
+        v.reserved_ = 0;
+        dense.voxels_[i] = v;
+    }
+    return dense;
+}
+
+std::vector<std::uint8_t> readFileBytes(const std::string &path) {
+    std::FILE *fp = std::fopen(path.c_str(), "rb");
+    if (!fp) return {};
+    std::fseek(fp, 0, SEEK_END);
+    const long size = std::ftell(fp);
+    std::fseek(fp, 0, SEEK_SET);
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size < 0 ? 0 : size));
+    if (!bytes.empty()) std::fread(bytes.data(), 1, bytes.size(), fp);
+    std::fclose(fp);
+    return bytes;
+}
+
+// ---- Sanity: single-mode files load correctly via loadVoxelSet ---------
+
+TEST(VoxelSetHybrid, LoadShapesOnlyFileSanity) {
+    const auto shapes = makeFivePrimitiveFixture();
+    const std::string path = kTmpDir + "/vxs_hybrid_shapes_sanity.vxs";
+    ASSERT_TRUE(saveShapeGroup(path, shapes).ok());
+
+    auto loaded = loadVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::SHAPES);
+    ASSERT_EQ(loaded.value_.shapeRecords_.size(), shapes.size());
+    EXPECT_EQ(loaded.value_.unknownShapesSkipped_, 0u);
+    EXPECT_TRUE(loaded.value_.dense_.voxels_.empty());
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetHybrid, LoadDenseOnlyFileSanity) {
+    DenseVoxelSet dense;
+    dense.boundsMin_ = ivec3(0);
+    dense.boundsMax_ = ivec3(20, 20, 20);
+    dense.voxels_.assign(dense.voxelCount(), VoxelRecord{Color{100, 150, 200, 255}, 1, 0, 0, 0, 0});
+    const std::string path = kTmpDir + "/vxs_hybrid_dense_sanity.vxs";
+    ASSERT_TRUE(saveDenseVoxelSet(path, dense).ok());
+
+    auto loaded = loadVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::DENSE);
+    EXPECT_TRUE(loaded.value_.shapeRecords_.empty());
+    EXPECT_EQ(loaded.value_.dense_.voxelCount(), 8000u);
+    EXPECT_EQ(loaded.value_.dense_.voxels_.size(), 8000u);
+    EXPECT_EQ(loaded.value_.dense_.voxels_[0].color_.red_, 100);
+    std::remove(path.c_str());
+}
+
+// ---- Hybrid round-trip --------------------------------------------------
+
+TEST(VoxelSetHybrid, HybridRoundTrip) {
+    const auto shapes = makeFivePrimitiveFixture();
+    const auto dense = make50VoxelFixture();
+    const std::string path = kTmpDir + "/vxs_hybrid_roundtrip.vxs";
+
+    ASSERT_TRUE(saveVoxelSet(path, shapes, dense).ok());
+
+    auto loaded = loadVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::HYBRID);
+
+    // Shape half
+    ASSERT_EQ(loaded.value_.shapeRecords_.size(), 5u);
+    EXPECT_EQ(loaded.value_.unknownShapesSkipped_, 0u);
+    EXPECT_EQ(
+        loaded.value_.shapeRecords_[0].shapeTypeId_,
+        static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE)
+    );
+    EXPECT_EQ(loaded.value_.shapeRecords_[0].params_.x, 3.0f);
+    EXPECT_EQ(
+        loaded.value_.shapeRecords_[4].shapeTypeId_,
+        static_cast<std::uint32_t>(IRMath::SDF::ShapeType::WEDGE)
+    );
+    EXPECT_EQ(loaded.value_.shapeRecords_[4].csgOp_, CsgOp::INTERSECT);
+
+    // Dense half
+    EXPECT_EQ(loaded.value_.dense_.boundsMin_, dense.boundsMin_);
+    EXPECT_EQ(loaded.value_.dense_.boundsMax_, dense.boundsMax_);
+    ASSERT_EQ(loaded.value_.dense_.voxels_.size(), 50u);
+    for (std::size_t i = 0; i < dense.voxels_.size(); ++i) {
+        EXPECT_EQ(loaded.value_.dense_.voxels_[i].material_id_, dense.voxels_[i].material_id_);
+        EXPECT_EQ(loaded.value_.dense_.voxels_[i].color_.red_, dense.voxels_[i].color_.red_);
+    }
+
+    std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
+}
+
+// ---- Byte-stable reserialization ----------------------------------------
+
+TEST(VoxelSetHybrid, ReserializingHybridMatchesOriginalBytes) {
+    const auto shapes = makeFivePrimitiveFixture();
+    const auto dense = make50VoxelFixture();
+    const std::string p1 = kTmpDir + "/vxs_hybrid_bytecmp_1.vxs";
+    const std::string p2 = kTmpDir + "/vxs_hybrid_bytecmp_2.vxs";
+
+    ASSERT_TRUE(saveVoxelSet(p1, shapes, dense).ok());
+    auto loaded = loadVoxelSet(p1);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_TRUE(saveVoxelSet(p2, loaded.value_.shapeRecords_, loaded.value_.dense_).ok());
+
+    const auto b1 = readFileBytes(p1);
+    const auto b2 = readFileBytes(p2);
+    EXPECT_EQ(b1, b2);
+    EXPECT_FALSE(b1.empty());
+
+    std::remove(p1.c_str()); std::remove((p1 + ".json").c_str());
+    std::remove(p2.c_str()); std::remove((p2 + ".json").c_str());
+}
+
+// ---- JSON sidecar -------------------------------------------------------
+
+TEST(VoxelSetHybrid, SidecarEmittedAlongsideBinary) {
+    const auto shapes = makeFivePrimitiveFixture();
+    const auto dense = make50VoxelFixture();
+    const std::string path = kTmpDir + "/vxs_hybrid_sidecar.vxs";
+    const std::string sidecarPath = path + ".json";
+    std::remove(sidecarPath.c_str());
+
+    ASSERT_TRUE(saveVoxelSet(path, shapes, dense).ok());
+
+    const auto sidecarBytes = readFileBytes(sidecarPath);
+    EXPECT_FALSE(sidecarBytes.empty());
+
+    const std::string json(sidecarBytes.begin(), sidecarBytes.end());
+    EXPECT_NE(json.find("\"version\""), std::string::npos);
+    EXPECT_NE(json.find("\"mode\""), std::string::npos);
+    EXPECT_NE(json.find("HYBRID"), std::string::npos);
+    EXPECT_NE(json.find("\"bounds\""), std::string::npos);
+    EXPECT_NE(json.find("\"material_registry_refs\""), std::string::npos);
+    EXPECT_NE(json.find("\"layer_names\""), std::string::npos);
+    EXPECT_NE(json.find("\"frame_count\""), std::string::npos);
+    EXPECT_NE(json.find("\"shape_primitives_summary\""), std::string::npos);
+    // The fixture uses SPHERE and BOX among its 5 shapes.
+    EXPECT_NE(json.find("SPHERE"), std::string::npos);
+    EXPECT_NE(json.find("BOX"), std::string::npos);
+
+    std::remove(path.c_str());
+    std::remove(sidecarPath.c_str());
+}
+
+// ---- Error paths (via loadVoxelSet) ------------------------------------
+
+TEST(VoxelSetHybrid, CorruptMagicReturnsBadMagic) {
+    const std::string path = kTmpDir + "/vxs_hybrid_bad_magic.vxs";
+    {
+        std::FILE *fp = std::fopen(path.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        const char header[12] = {'B', 'A', 'D', '!', 1, 0, 0, 0, 0, 0, 0, 0};
+        std::fwrite(header, 1, sizeof(header), fp);
+        std::fclose(fp);
+    }
+    auto loaded = loadVoxelSet(path);
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::BadMagic);
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetHybrid, VersionTooNewReturnsVersionTooNew) {
+    const std::string path = kTmpDir + "/vxs_hybrid_too_new.vxs";
+    {
+        std::FILE *fp = std::fopen(path.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        char header[12] = {};
+        header[0] = 'V'; header[1] = 'X'; header[2] = 'S'; header[3] = '1';
+        header[4] = static_cast<char>(kVoxelSetVersion + 1u);
+        std::fwrite(header, 1, sizeof(header), fp);
+        std::fclose(fp);
+    }
+    auto loaded = loadVoxelSet(path);
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::VersionTooNew);
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetHybrid, TruncatedMidVoxrReturnsTruncatedOrChunkOOB) {
+    const auto shapes = makeFivePrimitiveFixture();
+    const auto dense = make50VoxelFixture();
+    const std::string p1 = kTmpDir + "/vxs_hybrid_full_for_trunc.vxs";
+    ASSERT_TRUE(saveVoxelSet(p1, shapes, dense).ok());
+
+    auto full = readFileBytes(p1);
+    ASSERT_FALSE(full.empty());
+    const std::size_t cut = full.size() > 16 ? full.size() - 12 : full.size() / 2;
+    full.resize(cut);
+
+    const std::string p2 = kTmpDir + "/vxs_hybrid_truncated.vxs";
+    {
+        std::FILE *fp = std::fopen(p2.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        std::fwrite(full.data(), 1, full.size(), fp);
+        std::fclose(fp);
+    }
+
+    auto loaded = loadVoxelSet(p2);
+    EXPECT_FALSE(loaded.ok());
+    EXPECT_TRUE(
+        loaded.status_.code_ == BinaryIOError::Truncated ||
+        loaded.status_.code_ == BinaryIOError::ChunkOutOfBounds
+    );
+
+    std::remove(p1.c_str()); std::remove((p1 + ".json").c_str());
+    std::remove(p2.c_str());
+}
+
+TEST(VoxelSetHybrid, UnknownChunkTagSilentlySkipped) {
+    const auto shapes = makeFivePrimitiveFixture();
+    const auto dense = make50VoxelFixture();
+    const auto shapeTypeEntries = buildCurrentShapeTypeNameTable();
+
+    ChunkPayload future;
+    future.tag_ = {'F', 'U', 'T', 'R'};
+    future.data_ = {0xDEu, 0xADu, 0xBEu, 0xEFu};
+
+    std::vector<ChunkPayload> chunks = {
+        makeModeChunk(VoxelSetMode::HYBRID),
+        makeShapeRefsChunk(shapeTypeEntries),
+        makeShapeGroupChunk(shapes),
+        makeBoundsChunk(dense.boundsMin_, dense.boundsMax_),
+        makeVoxelRecordsChunk(dense.voxels_),
+        future,
+    };
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kVoxelSetMagic, kVoxelSetVersion, chunks).ok());
+
+    const std::string path = kTmpDir + "/vxs_hybrid_unknown_chunk.vxs";
+    {
+        std::FILE *fp = std::fopen(path.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        std::fwrite(w.buffer().data(), 1, w.buffer().size(), fp);
+        std::fclose(fp);
+    }
+
+    auto loaded = loadVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    EXPECT_EQ(loaded.value_.mode_, VoxelSetMode::HYBRID);
+    EXPECT_EQ(loaded.value_.shapeRecords_.size(), 5u);
+    ASSERT_EQ(loaded.value_.dense_.voxels_.size(), 50u);
+    std::remove(path.c_str());
+}
+
+TEST(VoxelSetHybrid, UnknownShapeTypeIdLoggedAndSkipped) {
+    // One SPHERE record and one record with a future ShapeType not in the
+    // current build's enum. Loader keeps SPHERE and surfaces skipped=1.
+    const std::uint32_t kFutureId = 9999;
+    std::vector<NameTableEntry> diskEntries = {
+        {static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE), "SPHERE"},
+        {kFutureId, "FUTURE_SHAPE"},
+    };
+
+    std::vector<ShapeRecord> shapeRecords;
+    ShapeRecord sphere;
+    sphere.shapeTypeId_ = static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE);
+    sphere.params_ = vec4(1.0f);
+    sphere.color_ = Color{255, 255, 255, 255};
+    sphere.flags_ = 1u << 3;
+    shapeRecords.push_back(sphere);
+    ShapeRecord future;
+    future.shapeTypeId_ = kFutureId;
+    future.params_ = vec4(2.0f);
+    future.color_ = Color{255, 0, 0, 255};
+    future.flags_ = 1u << 3;
+    shapeRecords.push_back(future);
+
+    DenseVoxelSet dense;
+    dense.boundsMin_ = ivec3(0);
+    dense.boundsMax_ = ivec3(2, 2, 2);
+    dense.voxels_.assign(dense.voxelCount(), VoxelRecord{});
+
+    std::vector<ChunkPayload> chunks = {
+        makeModeChunk(VoxelSetMode::HYBRID),
+        makeShapeRefsChunk(diskEntries),
+        makeShapeGroupChunk(shapeRecords),
+        makeBoundsChunk(dense.boundsMin_, dense.boundsMax_),
+        makeVoxelRecordsChunk(dense.voxels_),
+    };
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kVoxelSetMagic, kVoxelSetVersion, chunks).ok());
+
+    const std::string path = kTmpDir + "/vxs_hybrid_unknown_shape.vxs";
+    {
+        std::FILE *fp = std::fopen(path.c_str(), "wb");
+        ASSERT_NE(fp, nullptr);
+        std::fwrite(w.buffer().data(), 1, w.buffer().size(), fp);
+        std::fclose(fp);
+    }
+
+    auto loaded = loadVoxelSet(path);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.shapeRecords_.size(), 1u);
+    EXPECT_EQ(loaded.value_.unknownShapesSkipped_, 1u);
+    EXPECT_EQ(
+        loaded.value_.shapeRecords_[0].shapeTypeId_,
+        static_cast<std::uint32_t>(IRMath::SDF::ShapeType::SPHERE)
+    );
+    EXPECT_EQ(loaded.value_.dense_.voxels_.size(), 8u);
+    std::remove(path.c_str());
+}
+
+} // namespace

--- a/test/asset/voxel_set_shapes_test.cpp
+++ b/test/asset/voxel_set_shapes_test.cpp
@@ -175,6 +175,7 @@ TEST(VoxelSetFormat, FivePrimitiveGroupRoundTrip) {
         expectRecordEq(records[i], loaded.value_.shapeRecords_[i]);
     }
     std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
 }
 
 TEST(VoxelSetFormat, ReSerializingLoadedFileMatchesOriginalBytes) {
@@ -197,6 +198,8 @@ TEST(VoxelSetFormat, ReSerializingLoadedFileMatchesOriginalBytes) {
 
     std::remove(p1.c_str());
     std::remove(p2.c_str());
+    std::remove((p1 + ".json").c_str());
+    std::remove((p2 + ".json").c_str());
 }
 
 TEST(VoxelSetFormat, EmptyShapeGroupRoundTrip) {
@@ -209,6 +212,34 @@ TEST(VoxelSetFormat, EmptyShapeGroupRoundTrip) {
     EXPECT_TRUE(loaded.value_.shapeRecords_.empty());
     EXPECT_EQ(loaded.value_.unknownShapesSkipped_, 0u);
     std::remove(path.c_str());
+    std::remove((path + ".json").c_str());
+}
+
+TEST(VoxelSetFormat, SidecarEmittedAlongsideShapeGroupBinary) {
+    const auto records = makeFivePrimitiveGroup();
+    const std::string path = kTmpDir + "/vxs_shape_group_sidecar.vxs";
+    const std::string sidecarPath = path + ".json";
+    std::remove(sidecarPath.c_str());
+
+    ASSERT_TRUE(saveShapeGroup(path, records).ok());
+
+    const auto sidecarBytes = readFileBytes(sidecarPath);
+    EXPECT_FALSE(sidecarBytes.empty());
+
+    const std::string json(sidecarBytes.begin(), sidecarBytes.end());
+    EXPECT_NE(json.find("\"mode\""), std::string::npos);
+    EXPECT_NE(json.find("SHAPES"), std::string::npos);
+    // SHAPES save passes dense=nullptr — bounds collapses to null and the
+    // frame_count + layer_names sections degrade to defaults.
+    EXPECT_NE(json.find("\"bounds\""), std::string::npos);
+    EXPECT_NE(json.find("null"), std::string::npos);
+    EXPECT_NE(json.find("\"frame_count\""), std::string::npos);
+    EXPECT_NE(json.find("\"shape_primitives_summary\""), std::string::npos);
+    EXPECT_NE(json.find("SPHERE"), std::string::npos);
+    EXPECT_NE(json.find("BOX"), std::string::npos);
+
+    std::remove(path.c_str());
+    std::remove(sidecarPath.c_str());
 }
 
 // ---- SHPG chunk: forward-compat ----------------------------------------
@@ -306,10 +337,8 @@ TEST(VoxelSetFormat, FutureBuildRenamedSphereResolvesByName) {
     ASSERT_TRUE(diskRefs.ok());
     NameTable diskShapeTypes(diskRefs.value_);
 
-    auto loadedR = readShapeGroupChunk(
-        findChunk(chunksR.value_, kChunkTagShapeGroup)->data_,
-        diskShapeTypes
-    );
+    auto loadedR =
+        readShapeGroupChunk(findChunk(chunksR.value_, kChunkTagShapeGroup)->data_, diskShapeTypes);
     ASSERT_TRUE(loadedR.ok());
     EXPECT_EQ(loadedR.value_.unknownShapesSkipped_, 0u);
     ASSERT_EQ(loadedR.value_.records_.size(), 1u);
@@ -343,10 +372,8 @@ TEST(VoxelSetFormat, LegacySaveWithoutSrefPassesIdsVerbatim) {
     ASSERT_TRUE(chunksR.ok());
 
     NameTable empty;
-    auto loadedR = readShapeGroupChunk(
-        findChunk(chunksR.value_, kChunkTagShapeGroup)->data_,
-        empty
-    );
+    auto loadedR =
+        readShapeGroupChunk(findChunk(chunksR.value_, kChunkTagShapeGroup)->data_, empty);
     ASSERT_TRUE(loadedR.ok());
     EXPECT_EQ(loadedR.value_.unknownShapesSkipped_, 0u);
     ASSERT_EQ(loadedR.value_.records_.size(), 1u);


### PR DESCRIPTION
## Summary
- Adds `HYBRID` tag to the `.vxs` `MODE` chunk so a single file carries both `VOXR` (dense) and `SHPG` (shape-group) chunks
- `IRAsset::saveVoxelSet` accepts both dense records + shape descriptors in one call; loader returns struct with both populated
- `.vxs.json` sidecar emitter writes human-diffable JSON alongside every binary save (Extensibility Rule #6)
- Comprehensive test suite: corrupt-magic, truncated mid-chunk, version-too-new, unknown-chunk-tag, unknown-ShapeType-id, and hybrid round-trip cases

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/691 (T-167 — currently `fleet:approved`)
Full chain: T-168 → T-167 → T-170

## Test plan
- [ ] `IrredenEngineTest` passes (all existing + new hybrid + sidecar tests)
- [ ] 20³ dense round-trip sanity
- [ ] 5-primitive shape group round-trip sanity
- [ ] Hybrid: 5 shapes + 50 dense overrides, round-trip, byte-compare both chunks
- [ ] Corrupt-magic → clear diagnostic, no crash
- [ ] Truncated mid-VOXR → clear diagnostic with byte offset
- [ ] Version-too-new → clear diagnostic, no crash
- [ ] Unknown chunk tag → skip + continue
- [ ] Unknown ShapeType id → log + skip + return rest

Closes #668