### PR TITLE
T-173: prefab: Lua prefab format — Prefab.register/spawn + schema validation

### DIFF
--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -697,6 +697,8 @@ Lua side:
 - `voxel_ref` that fails to load (bad magic, truncated, missing file)
   → error; no entity created.
 - `rig_ref` that fails to load → error.
+- `setup` present but not a function (e.g. `setup = 42`) → error;
+  catches the typo class instead of silently no-op'ing.
 - Unknown top-level keys are silently ignored — adding a future field
   doesn't break older loaders (Rule #1 mirror).
 

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -652,6 +652,74 @@ IRModifier.resolved(entity, fieldNameOrId, fallback) -- read C_ResolvedFields
   evaluator with the resolver pipeline, so the two paths agree on the
   same input regardless of whether the resolver tick has run yet.
 
+## Prefab format (`Prefab.register`, `Prefab.spawn`)
+
+`bindLuaDrivenEcs()` also exposes the `Prefab` Lua table — the runtime
+half of Phase 5 of the editor epic (#608). A prefab is a Lua file that
+returns a table describing an entity template; `Prefab.spawn(id, pos)`
+loads the file and reconstitutes the entity. The schema is versioned
+from day one so the editor's component-palette emissions stay
+forward-compatible.
+
+v1 schema:
+
+```lua
+return {
+    prefab_version = 1,                  -- REQUIRED, must equal 1
+    voxel_ref      = "creations/...vxs", -- OPTIONAL, loaded via loadVoxelSet
+    rig_ref        = "creations/...rig", -- OPTIONAL, loaded via loadRig
+    setup          = function(entity)    -- OPTIONAL, user-provided
+        IREntity.setComponent(entity, ...)
+    end,
+}
+```
+
+C++ surface lives at `engine/script/include/irreden/script/prefab_api.hpp`
+in `namespace IRPrefab::Prefab`:
+
+- `registerPrefab(id, path)` / `prefabPath(id)` / `clearPrefabs()` — the
+  in-process registry. Process-singleton lifetime; `clearPrefabs()` is
+  test-only.
+- `spawnPrefab(LuaScript&, id, position) → SpawnResult` — load + execute.
+
+Lua side:
+
+- `Prefab.register("ant", "creations/foo/ant.prefab.lua")` — register.
+- `Prefab.spawn("ant", {x=0, y=0, z=0})` — spawn. Returns a `LuaEntity`
+  on success and `(nil, errorMessage)` on failure.
+
+**Schema-validation behaviors:**
+
+- Missing `prefab_version` → error (`prefab_version field missing or
+  not an integer`).
+- `prefab_version != 1` → error with the unsupported version surfaced.
+- Non-table return from the prefab file → error.
+- `voxel_ref` that fails to load (bad magic, truncated, missing file)
+  → error; no entity created.
+- `rig_ref` that fails to load → error.
+- Unknown top-level keys are silently ignored — adding a future field
+  doesn't break older loaders (Rule #1 mirror).
+
+**v1 scope notes** — three follow-up areas the editor will eventually
+land:
+
+- **Declarative `components = { C_Name = { ... } }` table** — needs a
+  reflection layer so an arbitrary C++ component type can be
+  constructed from a Lua table of named fields. The editor-epic doc
+  (Phase 5 risks) flags this as a design call. Use the `setup`
+  callback in the meantime — it lets the prefab call any Lua-bound
+  `IREntity.setComponent(entity, C_Foo.new(...))` directly.
+- **`bind_point_overrides = { ... }`** — requires a runtime
+  `C_BindPoints` component. T-171 added the asset-side BIND chunk to
+  `.rig`, but the runtime ECS component + the `entity:bindPoint(name)`
+  Lua accessor are deferred. spawn() loads bind points but does not
+  attach them yet.
+- **`C_VoxelSetNew` attachment from voxel_ref** — voxel data is
+  loaded and validated but not attached as an ECS component. The
+  current `C_VoxelSetNew` constructor allocates against the active
+  render-canvas pool; a headless prefab path needs a different entry
+  shape.
+
 ## Script resolution
 
 `scriptFile(path)` passes the path straight to sol2 / `dofile`. Behavior:
@@ -691,3 +759,9 @@ Creations ship `.lua` files in `creations/<name>/scripts/` and a top-level
   header does *not* expose the component — every creation that wants it
   still has to include the header and add the type to its component
   pack.
+- **Prefab registry is process-global.** `IRPrefab::Prefab` keeps a
+  static `std::unordered_map<std::string, std::string>` of id→path. It
+  survives `World` shutdown. Tests must call
+  `IRPrefab::Prefab::clearPrefabs()` between fixtures to avoid id
+  bleed. Production creations register prefabs once at init and don't
+  need to clear.

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -735,6 +735,25 @@ There is no sandbox, no path-traversal check, and no archive support.
 Creations ship `.lua` files in `creations/<name>/scripts/` and a top-level
 `main.lua`.
 
+## C++ ↔ Lua math type helpers
+
+When a binding accepts a math type that Lua callers may pass as either a
+registered userdata or a table literal, use the canonical helpers in
+`engine/script/include/irreden/script/ir_script_utils.hpp` rather than writing
+ad-hoc extraction lambdas per binding:
+
+| Task | Helper |
+|------|--------|
+| `sol::object` → `IRMath::vec3` | `IRScript::vec3FromLua(obj)` |
+
+`vec3FromLua` accepts an `IRMath::vec3` userdata **or** a `{x,y,z}` / `{1,2,3}`
+table. Returns `{0,0,0}` for nil/none. Validate the type at the callsite and
+return an error string *before* calling the helper — it zero-defaults on
+unrecognized types so bad-type errors need a caller-side check.
+
+To add a helper for a new math type, add an `inline` free function to
+`ir_script_utils.hpp` and extend the table above.
+
 ## Gotchas
 
 - **Trait missing → link error.** `registerTypeFromTraits<T>()`

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(IrredenEngineScripting STATIC
     src/lua_script.cpp
+    src/prefab_api.cpp
+    src/lua_bindings_prefab.cpp
 )
 
 add_subdirectory(third_party/luajit)
@@ -25,6 +27,8 @@ target_link_libraries(
     sol2
     IrredenEngineEntity
     IrredenEngineSystem
+    IrredenEngineAsset
+    IrredenEngineRendering
 )
 # Force sol2 to use its try/catch trampoline rather than letting C++
 # exceptions propagate through the LuaJIT VM. With LuaJIT 2.1 sol2's

--- a/engine/script/include/irreden/script/ir_script_utils.hpp
+++ b/engine/script/include/irreden/script/ir_script_utils.hpp
@@ -5,15 +5,7 @@
 
 namespace IRScript {
 
-/// Extract an IRMath::vec3 from a Lua value. Accepts an IRMath::vec3 userdata
-/// or a {x,y,z} / {1,2,3} table. Returns {0,0,0} for nil/none/absent.
-/// Validate the type at the callsite before calling this helper — it
-/// zero-defaults on unrecognized types so bad-type errors need a caller-side
-/// check to surface a descriptive message.
-///
-/// Named-or-indexed field lookup uses sol::optional<float> per key because
-/// sol2's get_or<T> overload resolution is ambiguous with mixed string/integer
-/// key types.
+// sol::optional<float> per key — get_or<T> overload resolution is ambiguous with mixed string/integer key types.
 inline IRMath::vec3 vec3FromLua(sol::object obj) {
     if (obj.is<IRMath::vec3>())
         return obj.as<IRMath::vec3>();

--- a/engine/script/include/irreden/script/ir_script_utils.hpp
+++ b/engine/script/include/irreden/script/ir_script_utils.hpp
@@ -1,4 +1,34 @@
-#ifndef IR_SCRIPT_UTILS_H
-#define IR_SCRIPT_UTILS_H
+#pragma once
 
-#endif /* IR_SCRIPT_UTILS_H */
+#include <irreden/ir_math.hpp>
+#include <sol/sol.hpp>
+
+namespace IRScript {
+
+/// Extract an IRMath::vec3 from a Lua value. Accepts an IRMath::vec3 userdata
+/// or a {x,y,z} / {1,2,3} table. Returns {0,0,0} for nil/none/absent.
+/// Validate the type at the callsite before calling this helper — it
+/// zero-defaults on unrecognized types so bad-type errors need a caller-side
+/// check to surface a descriptive message.
+///
+/// Named-or-indexed field lookup uses sol::optional<float> per key because
+/// sol2's get_or<T> overload resolution is ambiguous with mixed string/integer
+/// key types.
+inline IRMath::vec3 vec3FromLua(sol::object obj) {
+    if (obj.is<IRMath::vec3>())
+        return obj.as<IRMath::vec3>();
+    if (obj.is<sol::table>()) {
+        sol::table t = obj.as<sol::table>();
+        auto pickFloat = [&t](const char *key, int idx) -> float {
+            if (sol::optional<float> v = t[key])
+                return *v;
+            if (sol::optional<float> v = t[idx])
+                return *v;
+            return 0.0f;
+        };
+        return {pickFloat("x", 1), pickFloat("y", 2), pickFloat("z", 3)};
+    }
+    return {0.0f, 0.0f, 0.0f};
+}
+
+} // namespace IRScript

--- a/engine/script/include/irreden/script/prefab_api.hpp
+++ b/engine/script/include/irreden/script/prefab_api.hpp
@@ -1,0 +1,119 @@
+#ifndef IR_SCRIPT_PREFAB_API_H
+#define IR_SCRIPT_PREFAB_API_H
+
+/// Lua prefab format — an entity template that references a `.vxs` voxel
+/// set, an optional `.rig` rig, and a setup callback. Phase 5 of the
+/// editor epic (#608); see `docs/design/entity-editor-epic.md` for the
+/// long-form design and `engine/script/CLAUDE.md` "Prefab format" for
+/// the runtime contract.
+///
+/// Lua schema (v1):
+///
+///     return {
+///         prefab_version = 1,                  -- REQUIRED, must be 1
+///         voxel_ref      = "foo.vxs",          -- OPTIONAL, loaded via loadVoxelSet
+///         rig_ref        = "foo.rig",          -- OPTIONAL, loaded via loadRig
+///         setup          = function(entity)    -- OPTIONAL, user-provided
+///             -- IREntity.setComponent(entity, ...)
+///         end,
+///     }
+///
+/// Round-trip surface used by the editor (#608) is the same shape:
+/// the component palette emits a Lua file matching this schema and
+/// `Prefab.spawn(id, position)` reconstitutes the entity.
+///
+/// **v1 deferred** (filed as follow-ups):
+/// - declarative `components = { C_Name = { ... } }` table — needs the
+///   reflection layer the editor-epic doc flags as a Phase 5 risk
+///   ("Component-palette schema"). Use the `setup` callback in the
+///   meantime.
+/// - `bind_point_overrides = { name = { offset = {...} } }` — needs a
+///   runtime `C_BindPoints` component (only the `.rig` asset side ships
+///   so far; see T-171 and engine/asset/include/irreden/asset/rig_format.hpp).
+/// - `entity:bindPoint("name")` Lua API — same dependency as above.
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace IRScript {
+class LuaScript;
+namespace detail {
+/// Wire `Prefab.register` and `Prefab.spawn` into `script`'s Lua state.
+/// Idempotent: re-binding overwrites the previous closures and clears
+/// the in-process registry, so tests can call it once per fixture.
+/// Called from `LuaScript::bindLuaDrivenEcs()`.
+void bindPrefabApi(LuaScript &script);
+} // namespace detail
+} // namespace IRScript
+
+namespace IRPrefab::Prefab {
+
+/// v1 of the prefab Lua schema. Older builds reading a v1 prefab load
+/// fine; newer builds reading a future v2 surface a clear diagnostic
+/// rather than misinterpreting the fields.
+constexpr int kPrefabSchemaVersion = 1;
+
+/// Outcome of `spawnPrefab`. `entity_ == IREntity::kNullEntity` means
+/// the spawn failed for one of the reasons listed in `error_` —
+/// callers should check `entity_` before using it. The id and resolved
+/// path are surfaced for diagnostics regardless of success.
+struct SpawnResult {
+    IREntity::EntityId entity_ = IREntity::kNullEntity;
+    std::string id_;
+    std::string path_;
+    /// One-line diagnostic when `entity_ == IREntity::kNullEntity`.
+    /// Empty on success. Same string is logged at error level by
+    /// `spawnPrefab` itself; the field exists so call sites (Lua
+    /// bindings, tests) can surface it without re-running the logger.
+    std::string error_;
+};
+
+/// Add @p id → @p path to the in-process prefab registry. Re-registering
+/// an existing id overwrites the prior path with a log; clearing happens
+/// at process shutdown (no explicit lifetime owner today). Use
+/// `clearPrefabs()` to reset between tests.
+void registerPrefab(std::string id, std::string path);
+
+/// Look up the registered path for @p id. Returns `std::nullopt` if
+/// the id was never registered.
+std::optional<std::string> prefabPath(std::string_view id);
+
+/// Erase every entry from the in-process registry. Test helper; not
+/// exposed to Lua.
+void clearPrefabs();
+
+/// Load the prefab Lua file registered under @p id and instantiate it
+/// at @p position. The Lua file is executed via @p script (whose
+/// `sol::state` provides the eval environment); the file must return a
+/// table matching the v1 schema documented at the top of this header.
+///
+/// Behavior:
+/// - Validates `prefab_version == kPrefabSchemaVersion`. Missing or
+///   mismatched versions return `SpawnResult{entity_ = kNullEntity}`
+///   with a `VersionMismatch`-style error string.
+/// - Creates an entity with `C_Position3D(position)`.
+/// - If `voxel_ref` is present, loads the `.vxs` via
+///   `IRAsset::loadVoxelSet`. The loaded shape records / dense voxel
+///   data are validated to load cleanly but **not** attached as
+///   runtime components in v1 (`C_VoxelSetNew` requires an active
+///   render canvas pool). A follow-up task wires the attachment.
+/// - If `rig_ref` is present, loads the `.rig` via `IRAsset::loadRig`
+///   and attaches `C_JointHierarchy` via
+///   `IRPrefab::Rig::toComponent`. Bind-points are loaded but not
+///   attached pending the runtime `C_BindPoints` component.
+/// - If `setup` is a Lua function, invokes it with the entity wrapped
+///   as `LuaEntity{entity}`. Lua errors in `setup` propagate as a
+///   failed `SpawnResult` with the error string forwarded.
+///
+/// Additive component packs: unknown top-level keys in the prefab
+/// table are silently ignored, so a future schema field doesn't break
+/// older loaders. New required fields bump `kPrefabSchemaVersion`.
+SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 position);
+
+} // namespace IRPrefab::Prefab
+
+#endif /* IR_SCRIPT_PREFAB_API_H */

--- a/engine/script/include/irreden/script/prefab_api.hpp
+++ b/engine/script/include/irreden/script/prefab_api.hpp
@@ -1,11 +1,9 @@
 #ifndef IR_SCRIPT_PREFAB_API_H
 #define IR_SCRIPT_PREFAB_API_H
 
-/// Lua prefab format — an entity template that references a `.vxs` voxel
-/// set, an optional `.rig` rig, and a setup callback. Phase 5 of the
-/// editor epic (#608); see `docs/design/entity-editor-epic.md` for the
-/// long-form design and `engine/script/CLAUDE.md` "Prefab format" for
-/// the runtime contract.
+/// Lua prefab format — entity template with voxel/rig refs and a setup
+/// callback. Runtime contract and v1 scope: engine/script/CLAUDE.md
+/// "Prefab format".
 ///
 /// Lua schema (v1):
 ///
@@ -17,20 +15,6 @@
 ///             -- IREntity.setComponent(entity, ...)
 ///         end,
 ///     }
-///
-/// Round-trip surface used by the editor (#608) is the same shape:
-/// the component palette emits a Lua file matching this schema and
-/// `Prefab.spawn(id, position)` reconstitutes the entity.
-///
-/// **v1 deferred** (filed as follow-ups):
-/// - declarative `components = { C_Name = { ... } }` table — needs the
-///   reflection layer the editor-epic doc flags as a Phase 5 risk
-///   ("Component-palette schema"). Use the `setup` callback in the
-///   meantime.
-/// - `bind_point_overrides = { name = { offset = {...} } }` — needs a
-///   runtime `C_BindPoints` component (only the `.rig` asset side ships
-///   so far; see T-171 and engine/asset/include/irreden/asset/rig_format.hpp).
-/// - `entity:bindPoint("name")` Lua API — same dependency as above.
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -43,8 +27,7 @@ namespace IRScript {
 class LuaScript;
 namespace detail {
 /// Wire `Prefab.register` and `Prefab.spawn` into `script`'s Lua state.
-/// Idempotent: re-binding overwrites the previous closures and clears
-/// the in-process registry, so tests can call it once per fixture.
+/// Idempotent: re-binding overwrites the previous closures.
 /// Called from `LuaScript::bindLuaDrivenEcs()`.
 void bindPrefabApi(LuaScript &script);
 } // namespace detail

--- a/engine/script/src/lua_bindings_prefab.cpp
+++ b/engine/script/src/lua_bindings_prefab.cpp
@@ -1,0 +1,75 @@
+#include <irreden/script/prefab_api.hpp>
+
+#include <irreden/ir_math.hpp>
+#include <irreden/script/ir_script_types.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <sol/sol.hpp>
+
+#include <string>
+
+namespace IRScript::detail {
+
+/// Wires `Prefab.register(id, path)` and `Prefab.spawn(id, position)`
+/// into `script`'s Lua state. The bound closures forward into the
+/// `IRPrefab::Prefab` C++ API, so the Lua surface stays a thin shim
+/// over the typed entry points.
+void bindPrefabApi(LuaScript &script) {
+    sol::state &lua = script.lua();
+    if (!lua["Prefab"].valid()) {
+        lua["Prefab"] = lua.create_table();
+    }
+
+    lua["Prefab"]["register"] = [](const std::string &id, const std::string &path) {
+        IRPrefab::Prefab::registerPrefab(id, path);
+    };
+
+    // `Prefab.spawn(id, position)` — accepts the position as either an
+    // `IRMath::vec3` userdata or a `{x, y, z}` table for ergonomics
+    // mirroring `IREntity.create*` patterns. Returns a `LuaEntity`
+    // table on success and `nil` on failure (the error is logged at
+    // C++-side ERROR level and surfaced via the second return value).
+    lua["Prefab"]["spawn"] = [&script](
+                                 const std::string &id, sol::object positionObj
+                             ) -> std::tuple<sol::object, sol::object> {
+        sol::state_view sv{script.lua().lua_state()};
+        IRMath::vec3 position{0.0f, 0.0f, 0.0f};
+        if (positionObj.is<IRMath::vec3>()) {
+            position = positionObj.as<IRMath::vec3>();
+        } else if (positionObj.is<sol::table>()) {
+            sol::table t = positionObj.as<sol::table>();
+            // Accept either `{x=…, y=…, z=…}` or `{1, 2, 3}`. Use a
+            // helper to keep sol2's overload set unambiguous —
+            // `get_or<T>` with mixed key types confuses overload
+            // resolution.
+            auto pickFloat = [&t](const char *key, int idx) -> float {
+                sol::optional<float> byName = t[key];
+                if (byName)
+                    return *byName;
+                sol::optional<float> byIndex = t[idx];
+                if (byIndex)
+                    return *byIndex;
+                return 0.0f;
+            };
+            position.x = pickFloat("x", 1);
+            position.y = pickFloat("y", 2);
+            position.z = pickFloat("z", 3);
+        } else if (positionObj.valid() && positionObj.get_type() != sol::type::lua_nil &&
+                   positionObj.get_type() != sol::type::none) {
+            return {sol::make_object(sv, sol::lua_nil),
+                    sol::make_object(
+                        sv, std::string{"Prefab.spawn: position must be a vec3 or {x,y,z} table"}
+                    )};
+        }
+
+        IRPrefab::Prefab::SpawnResult result =
+            IRPrefab::Prefab::spawnPrefab(script, id, position);
+        if (result.entity_ == IREntity::kNullEntity) {
+            return {sol::make_object(sv, sol::lua_nil), sol::make_object(sv, result.error_)};
+        }
+        return {sol::make_object(sv, IRScript::LuaEntity{result.entity_}),
+                sol::make_object(sv, sol::lua_nil)};
+    };
+}
+
+} // namespace IRScript::detail

--- a/engine/script/src/lua_bindings_prefab.cpp
+++ b/engine/script/src/lua_bindings_prefab.cpp
@@ -2,6 +2,7 @@
 
 #include <irreden/ir_math.hpp>
 #include <irreden/script/ir_script_types.hpp>
+#include <irreden/script/ir_script_utils.hpp>
 #include <irreden/script/lua_script.hpp>
 
 #include <sol/sol.hpp>
@@ -33,34 +34,15 @@ void bindPrefabApi(LuaScript &script) {
                                  const std::string &id, sol::object positionObj
                              ) -> std::tuple<sol::object, sol::object> {
         sol::state_view sv{script.lua().lua_state()};
-        IRMath::vec3 position{0.0f, 0.0f, 0.0f};
-        if (positionObj.is<IRMath::vec3>()) {
-            position = positionObj.as<IRMath::vec3>();
-        } else if (positionObj.is<sol::table>()) {
-            sol::table t = positionObj.as<sol::table>();
-            // Accept either `{x=…, y=…, z=…}` or `{1, 2, 3}`. Use a
-            // helper to keep sol2's overload set unambiguous —
-            // `get_or<T>` with mixed key types confuses overload
-            // resolution.
-            auto pickFloat = [&t](const char *key, int idx) -> float {
-                sol::optional<float> byName = t[key];
-                if (byName)
-                    return *byName;
-                sol::optional<float> byIndex = t[idx];
-                if (byIndex)
-                    return *byIndex;
-                return 0.0f;
-            };
-            position.x = pickFloat("x", 1);
-            position.y = pickFloat("y", 2);
-            position.z = pickFloat("z", 3);
-        } else if (positionObj.valid() && positionObj.get_type() != sol::type::lua_nil &&
-                   positionObj.get_type() != sol::type::none) {
+        if (positionObj.valid() && positionObj.get_type() != sol::type::lua_nil &&
+            positionObj.get_type() != sol::type::none && !positionObj.is<IRMath::vec3>() &&
+            !positionObj.is<sol::table>()) {
             return {sol::make_object(sv, sol::lua_nil),
                     sol::make_object(
                         sv, std::string{"Prefab.spawn: position must be a vec3 or {x,y,z} table"}
                     )};
         }
+        IRMath::vec3 position = IRScript::vec3FromLua(positionObj);
 
         IRPrefab::Prefab::SpawnResult result =
             IRPrefab::Prefab::spawnPrefab(script, id, position);

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -7,6 +7,7 @@
 #include <irreden/common/modifier_field_registry.hpp>
 #include <irreden/script/lua_modifier_bindings.hpp>
 #include <irreden/script/lua_pipeline_bindings.hpp>
+#include <irreden/script/prefab_api.hpp>
 
 #include <deque>
 #include <string>
@@ -536,6 +537,7 @@ void LuaScript::bindLuaDrivenEcs() {
     detail::bindSystemNameEnum(*this);
     detail::bindRegisterPipelineAndSystemId(*this, prefabSystemIds());
     detail::bindModifierFramework(*this);
+    detail::bindPrefabApi(*this);
 }
 
 namespace {

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -33,9 +33,7 @@ std::unordered_map<std::string, std::string> &registry() {
 /// Build an error-state result. Logs at error level so failures are
 /// visible even when the caller discards the returned struct.
 SpawnResult makeError(std::string id, std::string path, std::string message) {
-    IRE_LOG_ERROR(
-        "Prefab.spawn('{}'): {} (path='{}')", id.c_str(), message.c_str(), path.c_str()
-    );
+    IRE_LOG_ERROR("Prefab.spawn('{}'): {} (path='{}')", id.c_str(), message.c_str(), path.c_str());
     SpawnResult r;
     r.id_ = std::move(id);
     r.path_ = std::move(path);
@@ -74,8 +72,7 @@ void clearPrefabs() {
     registry().clear();
 }
 
-SpawnResult
-spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 position) {
+SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 position) {
     std::string idStr{id};
     auto pathOpt = prefabPath(id);
     if (!pathOpt) {
@@ -92,9 +89,7 @@ spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 posit
         sol::protected_function_result eval = script.lua().script_file(path);
         if (!eval.valid()) {
             sol::error err = eval;
-            return makeError(
-                idStr, path, std::string{"file evaluation failed: "} + err.what()
-            );
+            return makeError(idStr, path, std::string{"file evaluation failed: "} + err.what());
         }
         root = eval;
     } catch (const std::exception &e) {
@@ -116,8 +111,8 @@ spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 posit
         return makeError(
             idStr,
             path,
-            "prefab_version=" + std::to_string(*versionOpt) +
-                " not supported (expected " + std::to_string(kPrefabSchemaVersion) + ")"
+            "prefab_version=" + std::to_string(*versionOpt) + " not supported (expected " +
+                std::to_string(kPrefabSchemaVersion) + ")"
         );
     }
 
@@ -127,11 +122,7 @@ spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 posit
     if (voxelRef) {
         auto loadResult = IRAsset::loadVoxelSet(*voxelRef);
         if (!loadResult.ok()) {
-            return makeError(
-                idStr,
-                path,
-                std::string{"voxel_ref load failed: "} + *voxelRef
-            );
+            return makeError(idStr, path, std::string{"voxel_ref load failed: "} + *voxelRef);
         }
     }
 
@@ -146,7 +137,8 @@ spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 posit
         // `.rig` from the basename since `loadRig` appends it.
         std::string rigPath = *rigRef;
         std::string::size_type slash = rigPath.find_last_of("/\\");
-        std::string dir = (slash == std::string::npos) ? std::string{"."} : rigPath.substr(0, slash);
+        std::string dir =
+            (slash == std::string::npos) ? std::string{"."} : rigPath.substr(0, slash);
         std::string base = (slash == std::string::npos) ? rigPath : rigPath.substr(slash + 1);
         constexpr std::string_view kExt{".rig"};
         if (base.size() >= kExt.size() &&
@@ -164,18 +156,25 @@ spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 posit
     // components arrive in one createEntity call; the joint hierarchy
     // is set on the resulting entity (setComponent migrates the
     // archetype once, which is fine for spawn — it isn't in a tick).
-    const IREntity::EntityId entity =
-        IREntity::createEntity(IRComponents::C_Position3D{position});
+    const IREntity::EntityId entity = IREntity::createEntity(IRComponents::C_Position3D{position});
 
     if (loadedRig) {
         IREntity::setComponent(entity, IRPrefab::Rig::toComponent(*loadedRig));
     }
 
     // Optional setup function — last so the user sees a fully-formed
-    // entity (position + rig already attached).
-    sol::optional<sol::protected_function> setupFn = prefab["setup"];
-    if (setupFn) {
-        sol::protected_function_result setupResult = (*setupFn)(IRScript::LuaEntity{entity});
+    // entity (position + rig already attached). Distinguish "absent"
+    // (sol::type::lua_nil) from "present but not a function" so a
+    // schema typo like `setup = 42` surfaces a diagnostic instead of
+    // silently no-op'ing.
+    sol::object setupObj = prefab["setup"];
+    if (setupObj.valid() && setupObj.get_type() != sol::type::lua_nil) {
+        if (setupObj.get_type() != sol::type::function) {
+            IREntity::destroyEntity(entity);
+            return makeError(idStr, path, "setup must be a function");
+        }
+        sol::protected_function setupFn = setupObj.as<sol::protected_function>();
+        sol::protected_function_result setupResult = setupFn(IRScript::LuaEntity{entity});
         if (!setupResult.valid()) {
             sol::error err = setupResult;
             IREntity::destroyEntity(entity);

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -178,10 +178,7 @@ spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 posit
         sol::protected_function_result setupResult = (*setupFn)(IRScript::LuaEntity{entity});
         if (!setupResult.valid()) {
             sol::error err = setupResult;
-            // The entity is already in the world; surface the error
-            // and leave it in place for the caller to inspect or
-            // destroy. Destroying here would mask the partial-mutation
-            // story of the failed setup body.
+            IREntity::destroyEntity(entity);
             return makeError(idStr, path, std::string{"setup callback failed: "} + err.what());
         }
     }

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -1,0 +1,196 @@
+#include <irreden/script/prefab_api.hpp>
+
+#include <irreden/asset/rig_format.hpp>
+#include <irreden/asset/voxel_set_format.hpp>
+#include <irreden/common/components/component_position_3d.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_profile.hpp>
+#include <irreden/script/ir_script_types.hpp>
+#include <irreden/script/lua_script.hpp>
+#include <irreden/voxel/rig_bridge.hpp>
+
+#include <sol/sol.hpp>
+
+#include <exception>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+namespace IRPrefab::Prefab {
+
+namespace {
+
+/// In-process registry. Module-local; no cross-process or cross-World
+/// sharing. Mirrors the lifetime story of `IRPrefab::Modifier`'s
+/// `globalFieldRegistry()` — process-singleton, cleared by tests via
+/// `clearPrefabs()`.
+std::unordered_map<std::string, std::string> &registry() {
+    static std::unordered_map<std::string, std::string> g_registry;
+    return g_registry;
+}
+
+/// Build an error-state result. Logs at error level so failures are
+/// visible even when the caller discards the returned struct.
+SpawnResult makeError(std::string id, std::string path, std::string message) {
+    IRE_LOG_ERROR(
+        "Prefab.spawn('{}'): {} (path='{}')", id.c_str(), message.c_str(), path.c_str()
+    );
+    SpawnResult r;
+    r.id_ = std::move(id);
+    r.path_ = std::move(path);
+    r.error_ = std::move(message);
+    return r;
+}
+
+} // namespace
+
+void registerPrefab(std::string id, std::string path) {
+    auto &reg = registry();
+    auto it = reg.find(id);
+    if (it != reg.end()) {
+        IRE_LOG_WARN(
+            "Prefab.register: '{}' already registered (path='{}'); overwriting with '{}'",
+            id.c_str(),
+            it->second.c_str(),
+            path.c_str()
+        );
+        it->second = std::move(path);
+        return;
+    }
+    reg.emplace(std::move(id), std::move(path));
+}
+
+std::optional<std::string> prefabPath(std::string_view id) {
+    auto &reg = registry();
+    auto it = reg.find(std::string{id});
+    if (it == reg.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+void clearPrefabs() {
+    registry().clear();
+}
+
+SpawnResult
+spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 position) {
+    std::string idStr{id};
+    auto pathOpt = prefabPath(id);
+    if (!pathOpt) {
+        return makeError(idStr, std::string{}, "no prefab registered for this id");
+    }
+    const std::string path = *pathOpt;
+
+    // Evaluate the prefab file. With `SOL_ALL_SAFETIES_ON` set on this
+    // target, `script_file` returns a `protected_function_result`
+    // rather than throwing — but the file-open path can still throw
+    // for missing files, so the try/catch is load-bearing.
+    sol::object root;
+    try {
+        sol::protected_function_result eval = script.lua().script_file(path);
+        if (!eval.valid()) {
+            sol::error err = eval;
+            return makeError(
+                idStr, path, std::string{"file evaluation failed: "} + err.what()
+            );
+        }
+        root = eval;
+    } catch (const std::exception &e) {
+        return makeError(idStr, path, std::string{"file evaluation threw: "} + e.what());
+    }
+
+    if (!root.is<sol::table>()) {
+        return makeError(idStr, path, "prefab file did not return a table");
+    }
+    sol::table prefab = root.as<sol::table>();
+
+    // Schema version. Required; missing → bad-format; mismatched →
+    // VersionTooNew/Old style diagnostic.
+    sol::optional<int> versionOpt = prefab["prefab_version"];
+    if (!versionOpt) {
+        return makeError(idStr, path, "prefab_version field missing or not an integer");
+    }
+    if (*versionOpt != kPrefabSchemaVersion) {
+        return makeError(
+            idStr,
+            path,
+            "prefab_version=" + std::to_string(*versionOpt) +
+                " not supported (expected " + std::to_string(kPrefabSchemaVersion) + ")"
+        );
+    }
+
+    // Optional voxel_ref — load + verify but defer attachment to a
+    // follow-up task (C_VoxelSetNew requires an active canvas pool).
+    sol::optional<std::string> voxelRef = prefab["voxel_ref"];
+    if (voxelRef) {
+        auto loadResult = IRAsset::loadVoxelSet(*voxelRef);
+        if (!loadResult.ok()) {
+            return makeError(
+                idStr,
+                path,
+                std::string{"voxel_ref load failed: "} + *voxelRef
+            );
+        }
+    }
+
+    // Optional rig_ref — load and translate to C_JointHierarchy via the
+    // existing prefab-side bridge.
+    sol::optional<std::string> rigRef = prefab["rig_ref"];
+    std::optional<IRAsset::Rig> loadedRig;
+    if (rigRef) {
+        // loadRig takes (name, path). The prefab schema gives one
+        // string — split into (basename, directory) so the loader
+        // composes the right `<path>/<name>.rig`. Strip a trailing
+        // `.rig` from the basename since `loadRig` appends it.
+        std::string rigPath = *rigRef;
+        std::string::size_type slash = rigPath.find_last_of("/\\");
+        std::string dir = (slash == std::string::npos) ? std::string{"."} : rigPath.substr(0, slash);
+        std::string base = (slash == std::string::npos) ? rigPath : rigPath.substr(slash + 1);
+        constexpr std::string_view kExt{".rig"};
+        if (base.size() >= kExt.size() &&
+            base.compare(base.size() - kExt.size(), kExt.size(), kExt) == 0) {
+            base = base.substr(0, base.size() - kExt.size());
+        }
+        auto rigResult = IRAsset::loadRig(base, dir);
+        if (!rigResult.ok()) {
+            return makeError(idStr, path, std::string{"rig_ref load failed: "} + rigPath);
+        }
+        loadedRig = std::move(rigResult.value_);
+    }
+
+    // Create the entity. C_Position3D + the auto-added position
+    // components arrive in one createEntity call; the joint hierarchy
+    // is set on the resulting entity (setComponent migrates the
+    // archetype once, which is fine for spawn — it isn't in a tick).
+    const IREntity::EntityId entity =
+        IREntity::createEntity(IRComponents::C_Position3D{position});
+
+    if (loadedRig) {
+        IREntity::setComponent(entity, IRPrefab::Rig::toComponent(*loadedRig));
+    }
+
+    // Optional setup function — last so the user sees a fully-formed
+    // entity (position + rig already attached).
+    sol::optional<sol::protected_function> setupFn = prefab["setup"];
+    if (setupFn) {
+        sol::protected_function_result setupResult = (*setupFn)(IRScript::LuaEntity{entity});
+        if (!setupResult.valid()) {
+            sol::error err = setupResult;
+            // The entity is already in the world; surface the error
+            // and leave it in place for the caller to inspect or
+            // destroy. Destroying here would mask the partial-mutation
+            // story of the failed setup body.
+            return makeError(idStr, path, std::string{"setup callback failed: "} + err.what());
+        }
+    }
+
+    SpawnResult r;
+    r.entity_ = entity;
+    r.id_ = std::move(idStr);
+    r.path_ = path;
+    return r;
+}
+
+} // namespace IRPrefab::Prefab

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(IrredenEngineTest
   script/lua_component_register_test.cpp
   script/lua_pipeline_register_test.cpp
   script/lua_system_codegen_test.cpp
+  script/prefab_api_test.cpp
   script/lua_system_coexistence_test.cpp
   script/lua_system_register_test.cpp
   script/modifier_lua_test.cpp

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -1,0 +1,252 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/rig_format.hpp>
+#include <irreden/asset/voxel_set_format.hpp>
+#include <irreden/common/components/component_position_3d.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/script/lua_script.hpp>
+#include <irreden/script/prefab_api.hpp>
+#include <irreden/voxel/components/component_joint_hierarchy.hpp>
+
+#include <fstream>
+#include <string>
+
+namespace {
+
+using IRMath::vec3;
+using IRMath::vec4;
+
+constexpr const char *kTmpDir = "/tmp";
+
+struct PrefabFiles {
+    std::string voxel_path_;
+    std::string rig_dir_;
+    std::string rig_name_;
+    std::string prefab_path_;
+};
+
+// Build a 3-shape `.vxs` + 2-joint `.rig` + matching prefab Lua on disk,
+// pointing the prefab at the absolute paths. Returns the artifact set so
+// individual tests can address subsets.
+PrefabFiles writeFixtureSet(const std::string &tag, const std::string &prefabBody) {
+    PrefabFiles f;
+    f.voxel_path_ = std::string{kTmpDir} + "/prefab_test_" + tag + ".vxs";
+    f.rig_dir_ = kTmpDir;
+    f.rig_name_ = "prefab_test_" + tag;
+    f.prefab_path_ = std::string{kTmpDir} + "/prefab_test_" + tag + ".prefab.lua";
+
+    // Tiny shape group — 1 box primitive, default everything.
+    std::vector<IRAsset::ShapeRecord> shapes(1);
+    shapes[0].shapeTypeId_ = 0;
+    shapes[0].params_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
+    IRAsset::saveShapeGroup(f.voxel_path_, shapes);
+
+    // 2-joint rig with deterministic translations.
+    IRAsset::Rig rig;
+    rig.joints_.resize(2);
+    rig.joints_[0].translation_ = vec4(1.0f, 2.0f, 3.0f, 0.0f);
+    rig.joints_[0].parentIndex_ = 0;
+    rig.joints_[0].name_ = "root";
+    rig.joints_[1].translation_ = vec4(4.0f, 5.0f, 6.0f, 0.0f);
+    rig.joints_[1].parentIndex_ = 0;
+    rig.joints_[1].name_ = "tip";
+    IRAsset::saveRig(f.rig_name_, f.rig_dir_, rig);
+
+    // Prefab Lua — write the supplied body verbatim, plus a return.
+    std::ofstream out(f.prefab_path_);
+    out << prefabBody;
+
+    return f;
+}
+
+class PrefabApi : public testing::Test {
+  protected:
+    PrefabApi() {
+        m_lua.bindLuaDrivenEcs();
+        IRPrefab::Prefab::clearPrefabs();
+    }
+
+    ~PrefabApi() override {
+        IRPrefab::Prefab::clearPrefabs();
+    }
+
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+};
+
+// ---- registry round-trip --------------------------------------------------
+
+TEST_F(PrefabApi, RegisterAndLookup) {
+    IRPrefab::Prefab::registerPrefab("ant", "/tmp/ant.prefab.lua");
+    auto p = IRPrefab::Prefab::prefabPath("ant");
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(*p, "/tmp/ant.prefab.lua");
+
+    // Unknown id surfaces as nullopt rather than crashing.
+    EXPECT_FALSE(IRPrefab::Prefab::prefabPath("missing").has_value());
+}
+
+TEST_F(PrefabApi, RegisterOverwrite) {
+    IRPrefab::Prefab::registerPrefab("ant", "/tmp/v1.lua");
+    IRPrefab::Prefab::registerPrefab("ant", "/tmp/v2.lua");
+    EXPECT_EQ(*IRPrefab::Prefab::prefabPath("ant"), "/tmp/v2.lua");
+}
+
+TEST_F(PrefabApi, LuaRegisterBinding) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(Prefab.register("via_lua", "/tmp/via_lua.lua"))",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+    auto p = IRPrefab::Prefab::prefabPath("via_lua");
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(*p, "/tmp/via_lua.lua");
+}
+
+// ---- schema validation ----------------------------------------------------
+
+TEST_F(PrefabApi, SpawnRejectsUnregisteredId) {
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "nope", vec3(0.0f));
+    EXPECT_EQ(r.entity_, IREntity::kNullEntity);
+    EXPECT_FALSE(r.error_.empty());
+}
+
+TEST_F(PrefabApi, SpawnRejectsMissingPrefabVersion) {
+    PrefabFiles f = writeFixtureSet(
+        "missing_version", "return { voxel_ref = '/tmp/whatever.vxs' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    EXPECT_EQ(r.entity_, IREntity::kNullEntity);
+    EXPECT_NE(r.error_.find("prefab_version"), std::string::npos) << r.error_;
+}
+
+TEST_F(PrefabApi, SpawnRejectsFutureSchemaVersion) {
+    PrefabFiles f =
+        writeFixtureSet("future_version", "return { prefab_version = 99 }\n");
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    EXPECT_EQ(r.entity_, IREntity::kNullEntity);
+    EXPECT_NE(r.error_.find("99"), std::string::npos) << r.error_;
+}
+
+TEST_F(PrefabApi, SpawnRejectsNonTableReturn) {
+    PrefabFiles f = writeFixtureSet("non_table_return", "return 42\n");
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    EXPECT_EQ(r.entity_, IREntity::kNullEntity);
+    EXPECT_NE(r.error_.find("did not return a table"), std::string::npos) << r.error_;
+}
+
+// ---- happy path: minimum-viable spawn -------------------------------------
+
+TEST_F(PrefabApi, SpawnAttachesPosition) {
+    PrefabFiles f = writeFixtureSet("minimal", "return { prefab_version = 1 }\n");
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(7.0f, 8.0f, 9.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    const auto &pos =
+        IREntity::getComponent<IRComponents::C_Position3D>(r.entity_);
+    EXPECT_FLOAT_EQ(pos.pos_.x, 7.0f);
+    EXPECT_FLOAT_EQ(pos.pos_.y, 8.0f);
+    EXPECT_FLOAT_EQ(pos.pos_.z, 9.0f);
+}
+
+// ---- voxel_ref load -------------------------------------------------------
+
+TEST_F(PrefabApi, SpawnLoadsVoxelRef) {
+    PrefabFiles f = writeFixtureSet(
+        "voxel_ref",
+        std::string{"return { prefab_version = 1, voxel_ref = '"} + std::string{kTmpDir} +
+            "/prefab_test_voxel_ref.vxs' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+}
+
+TEST_F(PrefabApi, SpawnRejectsBadVoxelRef) {
+    PrefabFiles f = writeFixtureSet(
+        "bad_voxel_ref",
+        "return { prefab_version = 1, voxel_ref = '/tmp/does_not_exist.vxs' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    EXPECT_EQ(r.entity_, IREntity::kNullEntity);
+    EXPECT_NE(r.error_.find("voxel_ref load failed"), std::string::npos) << r.error_;
+}
+
+// ---- rig_ref load → C_JointHierarchy attached -----------------------------
+
+TEST_F(PrefabApi, SpawnLoadsRigRefAndAttachesJointHierarchy) {
+    PrefabFiles f = writeFixtureSet(
+        "rig_ref",
+        std::string{"return { prefab_version = 1, rig_ref = '"} + std::string{kTmpDir} +
+            "/prefab_test_rig_ref.rig' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    const auto &hierarchy =
+        IREntity::getComponent<IRComponents::C_JointHierarchy>(r.entity_);
+    ASSERT_EQ(hierarchy.joints_.size(), 2u);
+    EXPECT_FLOAT_EQ(hierarchy.joints_[0].translation_.x, 1.0f);
+    EXPECT_FLOAT_EQ(hierarchy.joints_[1].translation_.x, 4.0f);
+}
+
+// ---- setup callback -------------------------------------------------------
+
+TEST_F(PrefabApi, SetupCallbackReceivesEntity) {
+    // Stash the entity id the setup function saw in a Lua global so the
+    // test can read it back after spawn.
+    PrefabFiles f = writeFixtureSet(
+        "setup_callback",
+        "g_setup_entity = nil\n"
+        "return {\n"
+        "  prefab_version = 1,\n"
+        "  setup = function(entity)\n"
+        "    g_setup_entity = entity\n"
+        "  end,\n"
+        "}\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    auto &lua = m_lua.lua();
+    sol::object stored = lua["g_setup_entity"];
+    ASSERT_TRUE(stored.is<IRScript::LuaEntity>())
+        << "setup did not receive a LuaEntity userdata";
+    EXPECT_EQ(stored.as<IRScript::LuaEntity>().entity, r.entity_);
+}
+
+TEST_F(PrefabApi, SetupCallbackErrorSurfaced) {
+    PrefabFiles f = writeFixtureSet(
+        "setup_error",
+        "return {\n"
+        "  prefab_version = 1,\n"
+        "  setup = function(entity) error('boom') end,\n"
+        "}\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    EXPECT_EQ(r.entity_, IREntity::kNullEntity);
+    EXPECT_NE(r.error_.find("setup callback failed"), std::string::npos) << r.error_;
+}
+
+// ---- additivity: unknown top-level keys do not break the load -------------
+
+TEST_F(PrefabApi, UnknownTopLevelFieldsIgnored) {
+    PrefabFiles f = writeFixtureSet(
+        "additive",
+        "return { prefab_version = 1, future_feature = { a = 1 }, another = 'x' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    EXPECT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+}
+
+} // namespace

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -113,9 +113,8 @@ TEST_F(PrefabApi, SpawnRejectsUnregisteredId) {
 }
 
 TEST_F(PrefabApi, SpawnRejectsMissingPrefabVersion) {
-    PrefabFiles f = writeFixtureSet(
-        "missing_version", "return { voxel_ref = '/tmp/whatever.vxs' }\n"
-    );
+    PrefabFiles f =
+        writeFixtureSet("missing_version", "return { voxel_ref = '/tmp/whatever.vxs' }\n");
     IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
     auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
     EXPECT_EQ(r.entity_, IREntity::kNullEntity);
@@ -123,8 +122,7 @@ TEST_F(PrefabApi, SpawnRejectsMissingPrefabVersion) {
 }
 
 TEST_F(PrefabApi, SpawnRejectsFutureSchemaVersion) {
-    PrefabFiles f =
-        writeFixtureSet("future_version", "return { prefab_version = 99 }\n");
+    PrefabFiles f = writeFixtureSet("future_version", "return { prefab_version = 99 }\n");
     IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
     auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
     EXPECT_EQ(r.entity_, IREntity::kNullEntity);
@@ -147,8 +145,7 @@ TEST_F(PrefabApi, SpawnAttachesPosition) {
     auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(7.0f, 8.0f, 9.0f));
     ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
 
-    const auto &pos =
-        IREntity::getComponent<IRComponents::C_Position3D>(r.entity_);
+    const auto &pos = IREntity::getComponent<IRComponents::C_Position3D>(r.entity_);
     EXPECT_FLOAT_EQ(pos.pos_.x, 7.0f);
     EXPECT_FLOAT_EQ(pos.pos_.y, 8.0f);
     EXPECT_FLOAT_EQ(pos.pos_.z, 9.0f);
@@ -190,8 +187,7 @@ TEST_F(PrefabApi, SpawnLoadsRigRefAndAttachesJointHierarchy) {
     auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
     ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
 
-    const auto &hierarchy =
-        IREntity::getComponent<IRComponents::C_JointHierarchy>(r.entity_);
+    const auto &hierarchy = IREntity::getComponent<IRComponents::C_JointHierarchy>(r.entity_);
     ASSERT_EQ(hierarchy.joints_.size(), 2u);
     EXPECT_FLOAT_EQ(hierarchy.joints_[0].translation_.x, 1.0f);
     EXPECT_FLOAT_EQ(hierarchy.joints_[1].translation_.x, 4.0f);
@@ -218,9 +214,22 @@ TEST_F(PrefabApi, SetupCallbackReceivesEntity) {
 
     auto &lua = m_lua.lua();
     sol::object stored = lua["g_setup_entity"];
-    ASSERT_TRUE(stored.is<IRScript::LuaEntity>())
-        << "setup did not receive a LuaEntity userdata";
+    ASSERT_TRUE(stored.is<IRScript::LuaEntity>()) << "setup did not receive a LuaEntity userdata";
     EXPECT_EQ(stored.as<IRScript::LuaEntity>().entity, r.entity_);
+}
+
+TEST_F(PrefabApi, SetupNonFunctionRejected) {
+    PrefabFiles f = writeFixtureSet(
+        "setup_not_function",
+        "return {\n"
+        "  prefab_version = 1,\n"
+        "  setup = 42,\n"
+        "}\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    EXPECT_EQ(r.entity_, IREntity::kNullEntity);
+    EXPECT_NE(r.error_.find("setup must be a function"), std::string::npos) << r.error_;
 }
 
 TEST_F(PrefabApi, SetupCallbackErrorSurfaced) {


### PR DESCRIPTION
## Summary
- New `IRPrefab::Prefab::{registerPrefab, spawnPrefab, prefabPath, clearPrefabs}` C++ API at `engine/script/include/irreden/script/prefab_api.hpp`.
- New `Prefab.register(id, path)` and `Prefab.spawn(id, position)` Lua surface, wired into `bindLuaDrivenEcs()` via `engine/script/src/lua_bindings_prefab.cpp`.
- v1 schema: `prefab_version` (required, must equal 1), `voxel_ref` (optional, loaded via `IRAsset::loadVoxelSet`), `rig_ref` (optional, loaded via `IRAsset::loadRig` → attaches `C_JointHierarchy`), `setup` callback (optional; runs with the spawned entity).
- 14 new tests in `test/script/prefab_api_test.cpp` covering registry round-trip, Lua bindings, version validation, voxel/rig load, setup callback success + error surface, additive-field load.
- Linker deps: `IrredenEngineScripting` now links `IrredenEngineAsset` + `IrredenEngineRendering` (the latter for `C_JointHierarchy`'s `GPUJointTransform` header chain). No back-edges into script.

## v1 scope reduction (follow-up issues filed)
Three pieces from the original issue body are deferred — each needs either a design call or a runtime component that doesn't exist yet. Filed:

- **#698** — declarative `components = { C_Name = { ... } }` table. Needs a per-component table-construction mechanism; the editor-epic doc flags this as a Phase 5 risk (Component-palette schema). The `setup` callback is the v1 escape hatch.
- **#700** — `bind_point_overrides` + `entity:bindPoint(\"name\")` Lua API. T-171 added the asset-side BIND chunk to `.rig`; the runtime `C_BindPoints` component + Lua accessor are deferred.
- **#701** — voxel_ref → ECS component attachment. `C_VoxelSetNew` currently requires an active render-canvas pool; the headless attach path needs more design.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` clean on macos-debug
- [x] `fleet-build --target IRShapeDebug` clean
- [x] All 600 existing tests + 14 new `PrefabApi.*` tests pass
- [ ] Cross-host linux smoke (will be tagged via `fleet:needs-linux-smoke` automatically)

Closes #671