### PR TITLE
T-179: asset: canonicalize memcpy in binary_io + voxel_set_format (bit_cast + chunk-tag helpers)

### DIFF
--- a/engine/asset/include/irreden/asset/binary_io.hpp
+++ b/engine/asset/include/irreden/asset/binary_io.hpp
@@ -16,6 +16,7 @@
 /// varint is recoverable — never a crash. The 7 Save Format Extensibility
 /// Rules in `docs/design/entity-editor-epic.md` mandate this contract.
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -134,6 +135,9 @@ class BinaryWriter {
     /// Length-prefixed UTF-8 string. Prefix is a varint byte-count.
     void writeString(std::string_view s);
 
+    /// Write a 4-byte chunk tag (e.g. `{'V','O','X','R'}`).
+    void writeTag(const std::array<char, 4> &tag);
+
   protected:
     void setFailed(std::string msg) {
         if (!m_failed) {
@@ -240,6 +244,9 @@ class BinaryReader {
     Result<double> readF64();
     Result<std::uint64_t> readVarUInt();
     Result<std::string> readString();
+
+    /// Read a 4-byte chunk tag.
+    Result<std::array<char, 4>> readTag();
 };
 
 /// File-backed reader. Wraps a `FILE*` opened in binary read mode.

--- a/engine/asset/src/binary_io.cpp
+++ b/engine/asset/src/binary_io.cpp
@@ -1,6 +1,7 @@
 #include <irreden/asset/binary_io.hpp>
 #include <irreden/ir_profile.hpp>
 
+#include <bit>
 #include <cstring>
 #include <utility>
 
@@ -68,14 +69,14 @@ void BinaryWriter::writeI64(std::int64_t v) {
     detail::writeLE<std::uint64_t>(*this, static_cast<std::uint64_t>(v));
 }
 void BinaryWriter::writeF32(float v) {
-    std::uint32_t bits;
-    std::memcpy(&bits, &v, sizeof(bits));
-    detail::writeLE<std::uint32_t>(*this, bits);
+    detail::writeLE<std::uint32_t>(*this, std::bit_cast<std::uint32_t>(v));
 }
 void BinaryWriter::writeF64(double v) {
-    std::uint64_t bits;
-    std::memcpy(&bits, &v, sizeof(bits));
-    detail::writeLE<std::uint64_t>(*this, bits);
+    detail::writeLE<std::uint64_t>(*this, std::bit_cast<std::uint64_t>(v));
+}
+
+void BinaryWriter::writeTag(const std::array<char, 4> &tag) {
+    writeBytes(tag.data(), tag.size());
 }
 
 void BinaryWriter::writeVarUInt(std::uint64_t v) {
@@ -155,7 +156,7 @@ void MemoryBinaryWriter::writeBytes(const void *data, std::size_t size) {
     if (end > m_buffer.size()) {
         m_buffer.resize(static_cast<std::size_t>(end));
     }
-    std::memcpy(m_buffer.data() + m_pos, data, size);
+    std::memcpy(m_buffer.data() + m_pos, data, size); // raw buffer copy — the primitive all higher-level writes go through
     m_pos = end;
 }
 
@@ -217,18 +218,22 @@ Result<float> BinaryReader::readF32() {
     if (!r.ok()) {
         return Result<float>::error(r.status_.code_, std::move(r.status_.message_));
     }
-    float v;
-    std::memcpy(&v, &r.value_, sizeof(v));
-    return Result<float>::success(v);
+    return Result<float>::success(std::bit_cast<float>(r.value_));
 }
 Result<double> BinaryReader::readF64() {
     auto r = readU64();
     if (!r.ok()) {
         return Result<double>::error(r.status_.code_, std::move(r.status_.message_));
     }
-    double v;
-    std::memcpy(&v, &r.value_, sizeof(v));
-    return Result<double>::success(v);
+    return Result<double>::success(std::bit_cast<double>(r.value_));
+}
+
+Result<std::array<char, 4>> BinaryReader::readTag() {
+    std::array<char, 4> tag{};
+    if (auto st = readBytes(tag.data(), 4); !st.ok()) {
+        return Result<std::array<char, 4>>::error(st.code_, std::move(st.message_));
+    }
+    return Result<std::array<char, 4>>::success(tag);
 }
 
 Result<std::uint64_t> BinaryReader::readVarUInt() {
@@ -370,7 +375,7 @@ BinaryStatus MemoryBinaryReader::readBytes(void *dest, std::size_t size) {
                 " of " + std::to_string(size) + " bytes) in " + m_sourceName
         );
     }
-    std::memcpy(dest, m_data + m_pos, size);
+    std::memcpy(dest, m_data + m_pos, size); // raw buffer copy — the primitive all higher-level reads go through
     m_pos += size;
     return BinaryStatus::success();
 }

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -199,7 +199,7 @@ ChunkPayload makeModeChunk(VoxelSetMode mode) {
         return ChunkPayload{kChunkTagMode, {}};
     }
     MemoryBinaryWriter w;
-    w.writeBytes(tag.data(), tag.size());
+    w.writeTag(tag);
     ChunkPayload out;
     out.tag_ = kChunkTagMode;
     out.data_ = w.takeBuffer();
@@ -215,9 +215,13 @@ VoxelSetMode readModeChunk(std::span<const LoadedChunk> chunks) {
         IRE_LOG_ERROR("readModeChunk: MODE body is {} bytes, expected 4", mode->data_.size());
         return VoxelSetMode::UNKNOWN;
     }
-    std::array<char, 4> tag{};
     MemoryBinaryReader r(mode->data_.data(), 4, "<MODE chunk>");
-    r.readBytes(tag.data(), 4);
+    auto tagResult = r.readTag();
+    if (!tagResult.ok()) {
+        IRE_LOG_ERROR("readModeChunk: failed to read tag: {}", tagResult.status_.message_);
+        return VoxelSetMode::UNKNOWN;
+    }
+    const auto &tag = tagResult.value_;
     if (tagsEqual(tag, kModeTagDense))
         return VoxelSetMode::DENSE;
     if (tagsEqual(tag, kModeTagShapes))

--- a/test/asset/binary_io_test.cpp
+++ b/test/asset/binary_io_test.cpp
@@ -166,6 +166,27 @@ TEST(BinaryIO, FileBackendRoundTrip) {
     std::remove(path.c_str());
 }
 
+TEST(BinaryIO, ChunkTagRoundTrip) {
+    const std::array<char, 4> tag = {'V', 'O', 'X', 'R'};
+    MemoryBinaryWriter w;
+    w.writeTag(tag);
+    ASSERT_EQ(w.buffer().size(), 4u);
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto result = r.readTag();
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+    EXPECT_EQ(result.value_, tag);
+    EXPECT_EQ(r.remaining(), 0u);
+}
+
+TEST(BinaryIO, ChunkTagReadTruncated) {
+    std::vector<std::uint8_t> buf = {'V', 'O'}; // only 2 bytes
+    MemoryBinaryReader r(buf.data(), buf.size());
+    auto result = r.readTag();
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.status_.code_, BinaryIOError::Truncated);
+}
+
 // ---- Chunk header tests -------------------------------------------------
 
 TEST(ChunkHeader, RoundTripWithMultipleChunks) {


### PR DESCRIPTION
## Summary
- Replace 4 `memcpy` bit-cast sites in `binary_io.cpp` with `std::bit_cast` (float↔uint32, double↔uint64)
- Add `writeTagBytes`/`readTagBytes` helpers to `binary_io.hpp`; adopt in two chunk-tag sites in `voxel_set_format.cpp`
- Leave the 2 raw-buffer-copy `memcpy` sites in `writeBytes`/`readBytes` with clarifying comments
- Add one round-trip unit test for the new chunk-tag helpers

## Test plan
- [ ] Existing `BinaryIO` tests (533+/- total) still pass
- [ ] New `writeTagBytes`/`readTagBytes` round-trip test passes
- [ ] `IrredenEngineTest` build succeeds

Closes #692