### PR TITLE
T-178: engine/entity singleton reentrancy guard doc + cache-reset test

### DIFF
--- a/engine/entity/CLAUDE.md
+++ b/engine/entity/CLAUDE.md
@@ -110,6 +110,18 @@ Constraints:
   entities (other ids) is fine.
 - A hook MAY call `markEntityForDeletion` on peer entities, but SHOULD
   NOT call `destroyEntity` reentrantly during the hook.
+- A hook MUST NOT call the lazy-create singleton accessor
+  (`IREntity::singletonEntity<T>` / `IREntity::singleton<T>`) during
+  `destroyAllEntities`. The bulk teardown iterates a snapshot of
+  `m_entityIndex` and clears `m_singletonEntityByComponent` only at
+  the end; a mid-loop lazy-create would mint a fresh singleton entity
+  that the snapshot can't see, leaving an unreachable "ghost" entity
+  in the index after the cache is cleared (cache empty, but
+  `forEachComponent<T>` still iterates the row — no way back to it
+  via `singletonEntity<T>`). Use the no-create variants
+  `singletonEntityOrNull<T>` / `singletonOrNull<T>` instead, or check
+  `entityExists` before reading; the same applies in any pre-destroy
+  hook that might run during a bulk reset.
 - The cost is O(hooks × destructions); each hook should be O(world)
   at worst. Don't register hooks that run an expensive search per
   destroy.

--- a/test/ecs/entity_manager_test.cpp
+++ b/test/ecs/entity_manager_test.cpp
@@ -220,6 +220,29 @@ TEST_F(IREntityTest, SingletonLazyRecreateAfterExternalDestroy) {
     EXPECT_EQ(IREntity::singleton<TestSingleton>().counter_, 0);
 }
 
+// destroyAllEntities() resets the singleton cache in one bulk clear, distinct
+// from the per-entry eviction path covered by
+// SingletonLazyRecreateAfterExternalDestroy above. Direct regression guard for
+// the cache-clear invariant documented in EntityManager::destroyAllEntities().
+TEST_F(IREntityTest, SingletonCacheResetAfterDestroyAllEntities) {
+    auto firstEntity = IREntity::singletonEntity<TestSingleton>();
+    IREntity::singleton<TestSingleton>().counter_ = 5;
+    ASSERT_NE(firstEntity, IREntity::kNullEntity);
+    ASSERT_EQ(IREntity::singletonEntityOrNull<TestSingleton>(), firstEntity);
+
+    m_entity_manager.destroyAllEntities();
+
+    EXPECT_EQ(IREntity::singletonEntityOrNull<TestSingleton>(), IREntity::kNullEntity);
+    EXPECT_EQ(IREntity::singletonOrNull<TestSingleton>(), nullptr);
+
+    // Lazy-recreate post-bulk-reset mints a fresh entity id with a
+    // default-constructed component.
+    auto secondEntity = IREntity::singletonEntity<TestSingleton>();
+    EXPECT_NE(secondEntity, IREntity::kNullEntity);
+    EXPECT_NE(secondEntity, firstEntity);
+    EXPECT_EQ(IREntity::singleton<TestSingleton>().counter_, 0);
+}
+
 // setComponent must construct the new archetype slot directly from the
 // caller's value rather than default-construct + assign — components like
 // C_CanvasAOTexture rely on this so they can `= delete` their default ctor.


### PR DESCRIPTION
## Summary
- Doc note under `engine/entity/CLAUDE.md` "Pre-destroy hooks" forbidding `singletonEntity<T>` (lazy-create) inside hooks during `destroyAllEntities`; recommend `singletonEntityOrNull<T>` instead.
- New `SingletonCacheResetAfterDestroyAllEntities` test in `test/ecs/entity_manager_test.cpp` directly asserting the bulk cache clear documented in `EntityManager::destroyAllEntities()`.

Closes #655