### PR TITLE
docs: agent-rule additions — math binary I/O, contract asserts, deprecation markers

### DIFF
--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -53,7 +53,7 @@ The "every format author writes their own" failure mode produces near-duplicate 
 
 If the helper you need doesn't exist yet:
 
-1. Add it to `engine/math/include/irreden/math/binary_io.hpp` as a free function (`writeVec3(BinaryWriter &, vec3)` / `readVec3(BinaryReader &)`). Forward-declare `BinaryWriter` / `BinaryReader` to keep the math module from physically depending on `engine/asset/`.
+1. Add it to `engine/math/include/irreden/math/binary_io.hpp` as a free function (`writeVec3(BinaryWriter &, IRMath::vec3)` / `readVec3(BinaryReader &)`). Forward-declare `BinaryWriter` / `BinaryReader` to keep the math module from physically depending on `engine/asset/`.
 2. Or, if the type owns its own representation (`Color` knows how to pack-RGBA), put the serializer on the type as a static method (`Color::toPackedRGBA()` / `Color::fromPackedRGBA(uint32_t)`).
 3. Then call it from the format code. Standardize naming on `read` / `write` to match `BinaryReader::readU32` / `BinaryWriter::writeU32`; do not introduce `encode` / `decode` / `pack` / `unpack` aliases.
 

--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -45,6 +45,18 @@ Always call the named helpers — never inline these equations in system code:
 
 One place to fix a coordinate-system bug.
 
+## Binary I/O of math types
+
+Serialization helpers for `IRMath::vec*`, `IRMath::Color`, `IRMath::quat`, and other math types belong in `engine/math/` (or alongside `BinaryWriter` / `BinaryReader` in `engine/asset/`) — never inline in a format-specific `.cpp`. Each binary asset format (`.vxs`, `.rig`, future `.prefab.lua`) is a consumer; the helpers are shared infrastructure.
+
+The "every format author writes their own" failure mode produces near-duplicate helpers under different names — historically `writeVec3` / `encodeVec3` defined twice across `voxel_set_format.cpp` and `rig_format.cpp`, with different signatures and byte layouts. Centralizing the helpers keeps the byte layout consistent across formats and concentrates the round-trip tests in one place.
+
+If the helper you need doesn't exist yet:
+
+1. Add it to `engine/math/include/irreden/math/binary_io.hpp` as a free function (`writeVec3(BinaryWriter &, vec3)` / `readVec3(BinaryReader &)`). Forward-declare `BinaryWriter` / `BinaryReader` to keep the math module from physically depending on `engine/asset/`.
+2. Or, if the type owns its own representation (`Color` knows how to pack-RGBA), put the serializer on the type as a static method (`Color::toPackedRGBA()` / `Color::fromPackedRGBA(uint32_t)`).
+3. Then call it from the format code. Standardize naming on `read` / `write` to match `BinaryReader::readU32` / `BinaryWriter::writeU32`; do not introduce `encode` / `decode` / `pack` / `unpack` aliases.
+
 ## When the wrapper doesn't exist yet
 
 If you need a primitive `IRMath` doesn't expose, **add the wrapper to `engine/math/` first**, then call it. Don't reach for `glm::` "just for now" — that's the path that produced the 164 violations this rule exists to clean up.

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -249,3 +249,83 @@ a demo creation for it, not to remove it. Removal requires an explicit
 human decision. See the "Engine API removal rule" section of
 `role-opus-architect.md` and `role-opus-worker.md` for the full
 guidance.
+
+---
+
+## Encode contracts in code, not in comments
+
+When a helper documents a precondition in its docstring — `// must be
+exactly 4 bytes`, `// caller guarantees non-null`, `// only call from
+the render thread` — enforce the precondition with `IR_ASSERT` /
+`static_assert` / `if constexpr`, not the comment alone. The docstring
+explains *why* the constraint exists; the assert ensures that violating
+it is loud rather than silent.
+
+This does **not** conflict with "don't add error handling for scenarios
+that can't happen." That rule is about not threading defensive checks
+through internal code that already has framework guarantees. This rule
+is the narrower point: **if you wrote a comment saying "must be X," the
+next line should make "not X" a crash, not a silent wrong answer.**
+
+Canonical failure mode this catches: `makeTag(std::string_view s)`
+documented as "must be exactly 4 chars," silently zero-pads when
+`s.length() < 4`. Two different callers passing `"VOX"` and `"VOXR"`
+(or worse, `"VOX"` and `"VOX\0"` via different conversion paths)
+produce identical tag bytes with no warning. The bug surfaces only when
+the format loader returns the wrong chunk type at runtime.
+
+Concrete forms:
+
+- **Compile-time constraint on a string-literal or template arg →
+  `static_assert`.** Cheapest. Use whenever the caller side is
+  consteval-reachable.
+- **Runtime constraint on a function parameter → `IR_ASSERT(predicate,
+  "diagnostic")` at function entry.** Use when the value is
+  user-supplied at runtime.
+- **Hybrid → `if consteval` branch that `static_assert`s, falling
+  through to a runtime `IR_ASSERT` at the non-consteval branch.** Use
+  for helpers that are sometimes called from `constexpr` contexts and
+  sometimes from runtime.
+
+The assertion message should restate the constraint in the same words
+the docstring uses, so a hit reads as one consistent contract violation
+rather than two separate signals.
+
+---
+
+## Deprecation markers
+
+When an API, file format, helper function, or module surface is being
+replaced — and the replacement has shipped or has a concrete landing
+plan — mark the deprecation explicitly in three places, no exceptions:
+
+1. **At the declaration site.** Add `// DEPRECATED — use <X> instead.`
+   directly above the function / struct / enum-value declaration in
+   the header. New consumers reading the header see the marker before
+   the docstring.
+2. **In the module's `CLAUDE.md`.** Add or extend a `## Deprecated`
+   section listing the surface, the replacement, and the date / PR /
+   issue that marked it.
+3. **In any new design doc** that proposes to extend the affected
+   surface: explicitly flag that the surface is on its way out.
+
+**Why this matters.** Concurrent fleet work routinely touches the same
+module from different angles. A task filed against the wrong format —
+because nothing in the code or docs said "this format is being
+replaced" — burns a full PR cycle on scaffolding the replacement
+supersedes. The canonical failure mode: F-0.7 (#626) filed a
+`.txl.json` sidecar against a format that was being migrated to
+`.vxs`; the sidecar shipped, was never adopted by the editor, and got
+deleted in the cleanup pass that followed (#705). Both the original
+filing and the cleanup PR were avoidable with a deprecation marker on
+`.txl`.
+
+**Tasks that propose to *extend* a deprecated surface must escalate to
+the human** rather than proceeding. The right move is almost always
+to redirect work to the replacement.
+
+This rule complements — does not replace — the **Engine API removal
+rule** above. Removal of engine ECS surface (systems, components,
+entities) is forbidden without explicit human sign-off; deprecation
+markers are the slower-moving "this surface is going away eventually"
+signal that applies to any API the human has decided to phase out.

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -257,7 +257,7 @@ guidance.
 When a helper documents a precondition in its docstring — `// must be
 exactly 4 bytes`, `// caller guarantees non-null`, `// only call from
 the render thread` — enforce the precondition with `IR_ASSERT` /
-`static_assert` / `if constexpr`, not the comment alone. The docstring
+`static_assert` / `if consteval`, not the comment alone. The docstring
 explains *why* the constraint exists; the assert ensures that violating
 it is loud rather than silent.
 


### PR DESCRIPTION
## Summary
Three small, independent rule additions captured from an engine/asset cleanup-pass audit (parent epic #603 closeout). Each codifies a pattern the fleet would otherwise re-rediscover with every adjacent PR.

- **`cpp-math.md` — "Binary I/O of math types".** Serialization helpers for `IRMath::vec*` / `Color` / `quat` must live in `engine/math/` (or alongside `BinaryWriter` / `BinaryReader` in `engine/asset/`), never inline in a format-specific `.cpp`. Standardize naming on `read` / `write`; no `encode` / `decode` / `pack` / `unpack` aliases.
- **`CLAUDE-BASELINE.md` — "Encode contracts in code, not in comments".** Helper preconditions in docstrings must be enforced with `IR_ASSERT` / `static_assert`, not the comment alone. Disambiguates from "don't add error handling for scenarios that can't happen" by being the narrower point: the comment says *why*; the assert ensures the violation is loud rather than silent.
- **`CLAUDE-BASELINE.md` — "Deprecation markers".** Three-place rule (declaration site / module `CLAUDE.md` / new design docs) for any API or format being phased out. Concurrent fleet tasks that propose to *extend* a deprecated surface must escalate.

## Failure modes each rule catches

| Rule | Canonical failure |
|---|---|
| Math binary I/O location | `writeVec3` / `encodeVec3` duplicated under two names across `voxel_set_format.cpp` and `rig_format.cpp` |
| Contract asserts | `makeTag(std::string_view s)` silently zero-pads when `s.length() < 4` despite the docstring saying "must be exactly 4" |
| Deprecation markers | F-0.7 (#626) filed a `.txl.json` sidecar against a format being migrated to `.vxs`; scaffolding shipped, was never adopted, got deleted in #705 |

## Test plan
- [ ] Doc-only diff. Each section's body cites file:symbol references that have been verified against current master.
- [ ] No conflict with existing rules — the contract-assert rule explicitly disambiguates from `simplify` §8's "don't validate scenarios that can't happen"; the deprecation rule explicitly complements (does not replace) the existing "Engine API removal rule."
- [ ] No new build target, no shader changes, no ECS surface change.

## Notes for reviewer
- The three sections were prioritized from a longer list of session catches (issue-filing line-number drift, simplify-2c extension to flag unannotated serialized structs, periodic CLAUDE.md audit, Explore-agent rebase-check). The top three are the highest leverage with the lowest cost; the others are deferred for a follow-up sweep when the trigger fires.
- Companion to PR #710 (LOD strategy design doc); both grew out of the same cleanup-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)