### PR TITLE
docs: three more agent-rule additions — simplify 2c extension, no-raw-fwrite, source-citation convention

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -252,6 +252,59 @@ Run this check whenever any `.hpp` or `.cpp` file under `engine/asset/`,
 - Changes to the `kSaveVersion` line itself.
 - Changes that only touch comments or whitespace inside the struct.
 
+**Detection extension — unannotated serialized structs:**
+
+The version-bump check above protects structs that are *already* annotated.
+A second class of bug is structs whose fields are individually serialized
+but which lack the `// IRAsset: serialized` annotation entirely — the
+version-bump check then never fires, even on layout changes that need a
+migration. `ShapeRecord` (`engine/asset/include/irreden/asset/voxel_set_format.hpp`)
+shipped in T-168 / T-170 without the annotation despite each of its
+fields being individually written and read by the format's chunk
+handlers; the gap stayed invisible until an audit pass surfaced it.
+
+Run this additional check in the same scope as the version-bump check
+(diff in `engine/asset/`, `engine/prefabs/irreden/voxel/`, or
+`engine/world/`):
+
+1. Scan the diff's `+` lines for any sequence of two or more
+   `<writer>.write*(<expr>.<field>_)` calls where `<expr>` is a
+   reference to a struct instance and `<field>_` is a public member.
+   Likewise for `<reader>.read*` paired with assignment back to
+   `<expr>.<field>_`. Two-or-more is the heuristic for "this struct
+   is being serialized field-by-field" rather than "one field of a
+   struct happens to be written."
+
+2. For each struct type touched this way, resolve its declaration
+   (same file or sibling header) and check whether the declaration
+   is preceded by `// IRAsset: serialized` on the immediately prior
+   line per the annotation rule.
+
+3. If the struct is serialized field-by-field and lacks the
+   annotation, emit a finding — **do not auto-fix**, the annotation
+   carries a `kSaveVersion` constant whose initial value is a human
+   call:
+
+   ```
+   reported 1 finding for review:
+     - <header-path>:<line> — <StructName> is serialized field-by-field
+       by <function-path>:<line> but lacks the `// IRAsset: serialized`
+       annotation. Add the comment line directly above the struct
+       declaration plus a `static constexpr uint16_t kSaveVersion = 1;`
+       member so the version-bump check (Rule #3) covers future changes.
+   ```
+
+**False-positive guard for the extension — do NOT flag:**
+- Structs that only carry transient binary I/O state (`BinaryStatus`,
+  `LoadedChunk`, `ChunkPayload`, `Result<T>`). These pass through
+  format code without being the format's persisted record.
+- Structs declared in `engine/asset/include/irreden/asset/binary_io.hpp`
+  or `chunk_header.hpp` — framework types, not format records.
+- Cases where the writer/reader calls operate on a temporary or a
+  function-local variable that doesn't correspond to a named struct
+  type. The "this is the format's record" heuristic requires a
+  resolvable struct type.
+
 ### 3. Naming convention slips
 
 These are the rules from [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md):

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -138,6 +138,45 @@ doesn't belong.
 
 ---
 
+## Citing source in filed artifacts
+
+When an artifact you're filing or writing references the codebase —
+GitHub issue bodies, PR descriptions, design docs, TASKS.md entries,
+review comments — **prefer symbol citations over line-number
+citations** for anything that will be read after the next refactor.
+
+| Prefer | Avoid |
+|--------|-------|
+| `voxel_set_format.cpp::makeModeChunk` | `voxel_set_format.cpp:91` |
+| `system_shapes_to_trixel.hpp::beginTick` | `system_shapes_to_trixel.hpp:111` |
+| `C_ShapeDescriptor::lodMin_` | `component_shape_descriptor.hpp:26` |
+
+Symbols don't drift; line numbers do. An issue filed today against
+"see `<file>:<line>`" routinely points at the wrong code by the time
+a worker picks it up — somebody added an import block or a helper
+function above the cited line. A symbol citation survives every
+refactor short of the rename itself, and a rename leaves a loud
+`grep` failure rather than a silent wrong-line read.
+
+**When line numbers are still appropriate:**
+
+- Citations inside a PR body referencing the PR's own diff. The diff
+  is frozen; the line number doesn't drift.
+- Pointing at a specific unnamed line (e.g. a magic number, an
+  inline comment, a hunk of inline shader code). Use symbol-plus-
+  offset where possible: ``inside `makeModeChunk`, the second case``.
+- Citing a stack trace or compiler diagnostic verbatim.
+
+**Mixed form is fine:** `chunk_header.hpp::makeTag (~line 72)` gives
+the symbol for stability plus a hint for the reader's first scroll.
+The line is decorative; the symbol is the contract.
+
+This rule applies to any artifact that gets filed against the repo
+or shipped to a reviewer. It does not apply to ephemeral logs,
+debug output, or scratch notes the human will read immediately.
+
+---
+
 ## Bash tool rules
 
 **Every Bash invocation must be a single, simple command.** Never use

--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -184,6 +184,21 @@ read/write building blocks every new asset format uses. Existing
 formats (`.txl`, `.irsprite`) predate the contract; new formats must
 use these.
 
+**Hard rule — no raw `fopen` + `fwrite` / `fread` for new format I/O.**
+All new binary format save/load paths route through
+`FileBinaryWriter` / `FileBinaryReader` (or `MemoryBinaryWriter` /
+`MemoryBinaryReader` for in-memory round-trips); all reads return
+`Result<T>` and surface errors with file path + byte offset. Raw
+`fwrite` / `fread` is forbidden outside the two legacy formats listed
+above — those will be migrated or deleted, not extended.
+
+The historical liability is concrete: `.txl`'s raw-binary save and
+load paths in `engine/asset/src/ir_asset.cpp` left every `fwrite` and
+`fread` return value unchecked. A truncated file loaded as garbage
+with no error; a corrupted save succeeded silently. The
+`BinaryWriter` / `BinaryReader` abstraction exists exactly to make
+that class of bug unrepresentable for new code.
+
 ### `binary_io.hpp` — `BinaryWriter` / `BinaryReader`
 
 Abstract sinks/sources with two backends each:


### PR DESCRIPTION
## Summary
Follow-up to PR #715 — second batch of three rule additions from the same engine/asset cleanup-pass audit. Each codifies a pattern the fleet would otherwise re-rediscover with every adjacent PR.

- **`simplify` §2c — unannotated serialized structs check.** The existing version-bump check only protects already-annotated structs; structs that are serialized field-by-field but never annotated (`ShapeRecord` shipped this way in T-168 / T-170) escape entirely. New detection heuristic: two-or-more `<writer>.write*(<expr>.<field>_)` calls referencing the same struct instance, paired with a struct declaration that lacks `// IRAsset: serialized` on the immediately prior line. Flag, don't auto-fix — the initial `kSaveVersion` is a human call. False-positive guards listed for framework types.
- **`engine/asset/CLAUDE.md` — hard rule on `BinaryWriter`/`BinaryReader`.** Promote the implicit "new formats must use these" sentence to its own paragraph at the top of the Binary-I/O primitives section: no raw `fopen` + `fwrite` / `fread` for new format I/O, with the `.txl` unchecked-fread liability as the concrete failure example.
- **`CLAUDE-BASELINE.md` — citing source in filed artifacts.** Prefer `file::symbol` over `file:line` in anything that gets read after the next refactor (GitHub issues, PR bodies, design docs, TASKS.md). Includes the preferred-vs-avoided table, the carve-outs for cases where line numbers are still right (PR-internal diff citations, magic-number pointers, verbatim stack traces), and a mixed-form fallback.

## Failure modes each rule catches

| Rule | Canonical failure |
|---|---|
| Unannotated-serialized-struct check | `ShapeRecord` shipped in T-168 / T-170 with every field individually serialized but no `// IRAsset: serialized` annotation; gap surfaced only on later audit |
| No raw `fwrite` / `fread` rule | `.txl` v1 save/load with unchecked return codes — truncated files load as garbage, corrupted saves succeed silently |
| Symbol-over-line-number citations | Issue #708 cited `system_shapes_to_trixel.hpp:154`; actual line was `111`. A `system_shapes_to_trixel::beginTick` citation would have survived |

## Test plan
- [ ] Doc-only diff; +107 lines across three files.
- [ ] `simplify` §2c extension's false-positive guards explicitly exclude framework types (`BinaryStatus`, `LoadedChunk`, `ChunkPayload`, `Result<T>`) and binary-I/O header types, so the existing simplify pass on a normal-format-extension PR stays quiet.
- [ ] New baseline section sits between "What belongs in CLAUDE.md files" and "Bash tool rules" — far enough from PR #715's tail-of-file additions that merge order doesn't matter.

## Notes for reviewer
- PR #715 (math binary I/O / contract asserts / deprecation markers) and this PR are independent appends to the same set of doc files. If #715 merges first, this PR will rebase cleanly; same in the reverse order.
- Three more items remain on the original session list (Explore-agent rebase-before-audit, architect-role grep-for-stubs reminder, periodic CLAUDE.md audit). Per the prior conversation we're leaving those for a future session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)