### PR TITLE
widgets: three post-merge nit fixes from PR #702 review

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_widget_apply_dropdown.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_apply_dropdown.hpp
@@ -3,7 +3,6 @@
 
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_entity.hpp>
-#include <irreden/ir_input.hpp>
 #include <irreden/ir_math.hpp>
 
 #include <irreden/render/components/component_widget.hpp>
@@ -25,14 +24,9 @@ namespace IRSystem {
 //      check on the global mouse-button state).
 template <> struct System<WIDGET_APPLY_DROPDOWN> {
     IRMath::vec2 mouseGuiTrixel_ = IRMath::vec2(0.0f);
-    bool mouseLeftReleasedThisFrame_ = false;
 
     void beginTick() {
         mouseGuiTrixel_ = IRPrefab::Layout::mousePositionInGuiTrixels();
-        mouseLeftReleasedThisFrame_ = IRInput::checkKeyMouseButton(
-            IRInput::KeyMouseButtons::kMouseButtonLeft,
-            IRInput::ButtonStatuses::RELEASED
-        );
     }
 
     void tick(
@@ -86,10 +80,9 @@ template <> struct System<WIDGET_APPLY_DROPDOWN> {
         }
         dd.isOpen_ = false;
         hitbox.size_ = widget.size_;
-        (void)mouseLeftReleasedThisFrame_; // currently unused; kept for future
-                                           // outside-click-to-close logic that
-                                           // doesn't rely on the captured widget
-                                           // firing its own action.
+        // TODO: outside-click-to-close — close if mouse released outside the
+        // expanded hitbox; needs a direct mouse-released check rather than
+        // state.fireAction_ (which requires the click to land inside the widget).
     }
 
     static SystemId create() {

--- a/engine/prefabs/irreden/render/systems/system_widget_render_text_input.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_text_input.hpp
@@ -60,15 +60,12 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
             scratch_
         );
 
-        const IRMath::ivec2 textPos(
-            guiPos.pos_.x + theme.padding_ * 2,
-            guiPos.pos_.y + (widget.size_.y - IRRender::kGlyphHeight) / 2
-        );
+        const int textX = guiPos.pos_.x + theme.padding_ * 2;
         if (!textInput.text_.empty()) {
             IRPrefab::Widget::detail::drawLeftText(
                 *canvas_,
                 textInput.text_,
-                IRMath::ivec2(textPos.x, guiPos.pos_.y),
+                IRMath::ivec2(textX, guiPos.pos_.y),
                 widget.size_.y,
                 IRPrefab::Widget::detail::stateText(theme, widget)
             );
@@ -86,7 +83,10 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
         const int cursorChars = IRMath::clamp(
             textInput.cursorPos_, 0, static_cast<int>(textInput.text_.size())
         );
-        const int cursorX = textPos.x + cursorChars * IRRender::kGlyphStepX;
+        const int cursorX = IRMath::min(
+            textX + cursorChars * IRRender::kGlyphStepX,
+            guiPos.pos_.x + widget.size_.x - theme.textInputCursorWidth_
+        );
         const int cursorH = IRRender::kGlyphHeight;
         const int cursorY = guiPos.pos_.y + (widget.size_.y - cursorH) / 2;
         IRRender::fillRect(


### PR DESCRIPTION
## Summary

Follow-up to #702 (T-177 widget follow-up) — three reviewer nits that were flagged with `fleet:has-nits` but didn't land before the PR merged:

- **WIDGET_APPLY_DROPDOWN**: Remove dead `mouseLeftReleasedThisFrame_` field and its `ir_input.hpp` include; add TODO comment for future outside-click-to-close logic
- **WIDGET_RENDER_TEXT_INPUT**: Clamp `cursorX` to `guiPos.pos_.x + widget.size_.x - theme.textInputCursorWidth_` so the cursor cannot render outside the widget boundary when `maxLength_ = 0` (real visual bug, hidden in practice because all current demos use a bounded maxLength)
- **WIDGET_RENDER_TEXT_INPUT**: Replace `textPos` `ivec2` (whose `.y` was discarded) with `textX` `int` to eliminate the misleading dead member

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean
- [ ] Visual regression: text input cursor stays within widget boundary at all text lengths

Closes (no issue — follow-up from PR #702 review comments)