### PR TITLE
T-182: prefab: attach voxel_ref data as ECS components on Prefab.spawn

### DIFF
--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -30,6 +30,34 @@ for single voxels and particles.
   re-enable without a design pass.**
 - A WIP scene/skeleton hierarchy traversal system is present but incomplete.
 
+## Prefab.spawn voxel_ref → ECS components
+
+`Prefab.spawn` (in `engine/script/`) routes a prefab's `voxel_ref`
+through to runtime components when the loaded `.vxs` carries shape
+records:
+
+- **SHAPES / HYBRID shape half** — one child entity per
+  `IRAsset::ShapeRecord`, parented via `IREntity::setParent`. Each
+  child gets `C_Position3D{record.offset_}` plus
+  `C_ShapeDescriptor` populated from `record.shapeTypeId_` /
+  `params_` / `color_` / `flags_`. CHILD_OF composition keeps the
+  rendered position equal to `parent.global + record.offset`. Per-
+  record `rotation_`, `csgOp_`, and `boneId_` are loaded but not
+  attached in v1 (no renderer consumes them; T-181 wires bone
+  binding).
+- **DENSE / HYBRID dense half** — per-voxel records are loaded and
+  validated but not attached. `C_VoxelSetNew` constructs against
+  the active render-canvas pool; a headless attach path needs its
+  own design. Track follow-up at the issue queue (deferred from
+  T-182).
+
+`C_ShapeDescriptor`'s constructors snapshot the active canvas via
+`IRRender::getActiveCanvasEntityOrNull()` rather than the
+asserting `getActiveCanvasEntity()`. Headless construction
+(prefab spawn in a test, asset tooling) gets
+`canvasEntity_ = kNullEntity` instead of an `IR_ASSERT` failure;
+iterating systems gate work on the field already.
+
 ## Gotchas
 
 - **Never add `C_VoxelPool` to a non-canvas entity.** Pools are

--- a/engine/prefabs/irreden/voxel/components/component_shape_descriptor.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_shape_descriptor.hpp
@@ -27,13 +27,13 @@ struct C_ShapeDescriptor {
     IREntity::EntityId canvasEntity_ = IREntity::kNullEntity;
 
     C_ShapeDescriptor()
-        : canvasEntity_{IRRender::getActiveCanvasEntity()} {}
+        : canvasEntity_{IRRender::getActiveCanvasEntityOrNull()} {}
 
     C_ShapeDescriptor(IRRender::ShapeType type, vec4 params, Color color)
         : shapeType_{type}
         , params_{params}
         , color_{color}
-        , canvasEntity_{IRRender::getActiveCanvasEntity()} {}
+        , canvasEntity_{IRRender::getActiveCanvasEntityOrNull()} {}
 };
 
 } // namespace IRComponents

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -116,13 +116,7 @@ inline IREntity::EntityId getActiveCanvasEntity() {
     return getRenderManager().getActiveCanvasEntity();
 }
 
-/// Same as `getActiveCanvasEntity()` but returns `IREntity::kNullEntity`
-/// when no `RenderManager` has been constructed yet (headless tests,
-/// asset-only tooling). Component constructors that snapshot the
-/// active canvas (`C_ShapeDescriptor`, `C_VoxelSetNew`) use this
-/// instead of the asserting variant so spawn-time helpers stay
-/// portable across runtime + test contexts; iterating systems already
-/// gate work on the field being non-null.
+// Returns kNullEntity instead of asserting when no RenderManager exists — safe for headless and test contexts.
 inline IREntity::EntityId getActiveCanvasEntityOrNull() {
     return g_renderManager != nullptr ? g_renderManager->getActiveCanvasEntity()
                                       : IREntity::kNullEntity;

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -115,6 +115,18 @@ inline void setActiveCanvas(const std::string &name) {
 inline IREntity::EntityId getActiveCanvasEntity() {
     return getRenderManager().getActiveCanvasEntity();
 }
+
+/// Same as `getActiveCanvasEntity()` but returns `IREntity::kNullEntity`
+/// when no `RenderManager` has been constructed yet (headless tests,
+/// asset-only tooling). Component constructors that snapshot the
+/// active canvas (`C_ShapeDescriptor`, `C_VoxelSetNew`) use this
+/// instead of the asserting variant so spawn-time helpers stay
+/// portable across runtime + test contexts; iterating systems already
+/// gate work on the field being non-null.
+inline IREntity::EntityId getActiveCanvasEntityOrNull() {
+    return g_renderManager != nullptr ? g_renderManager->getActiveCanvasEntity()
+                                      : IREntity::kNullEntity;
+}
 /// @}
 
 /// @{

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -716,11 +716,38 @@ land:
   `.rig`, but the runtime ECS component + the `entity:bindPoint(name)`
   Lua accessor are deferred. spawn() loads bind points but does not
   attach them yet.
-- **`C_VoxelSetNew` attachment from voxel_ref** — voxel data is
-  loaded and validated but not attached as an ECS component. The
-  current `C_VoxelSetNew` constructor allocates against the active
-  render-canvas pool; a headless prefab path needs a different entry
-  shape.
+- **DENSE / HYBRID dense voxel_ref attachment** — DENSE per-voxel
+  records are loaded and validated but not attached as an ECS
+  component. The current `C_VoxelSetNew` constructor allocates
+  against the active render-canvas pool; a headless prefab path
+  needs a different entry shape. SHAPES records — and the SHAPES
+  half of HYBRID files — do attach (see "SHAPES voxel_ref
+  attachment" below).
+
+**SHAPES voxel_ref attachment.** When `voxel_ref` points at a
+SHAPES or HYBRID `.vxs`, `Prefab.spawn` attaches one child entity
+per `ShapeRecord` under the spawned root via `IREntity::setParent`.
+Each child carries:
+
+- `C_Position3D{record.offset_}` — record-local position; the
+  CHILD_OF relation + `system_update_positions_global` compose it
+  with the parent's position so the rendered position is
+  `parent.global + record.offset`.
+- `C_ShapeDescriptor{shapeType, params, color}` with `flags_`
+  copied from the record. The SDF primitive renders through the
+  normal `SHAPES_TO_TRIXEL` pass once a canvas is active.
+
+`ShapeRecord::rotation_`, `csgOp_`, and `boneId_` are loaded from
+disk but not stamped onto runtime components in v1 — the current
+renderer doesn't consume them. T-181 wires bone bindings; CSG
+composition is a render-pipeline design call.
+
+`C_ShapeDescriptor`'s default + 3-arg constructors snapshot the
+active canvas via `IRRender::getActiveCanvasEntityOrNull()` so
+headless contexts (tests, asset-only tooling) construct descriptors
+with `canvasEntity_ = kNullEntity` instead of asserting on the
+absent `RenderManager`. Iterating render systems already gate work
+on a non-null canvas binding.
 
 ## Script resolution
 

--- a/engine/script/include/irreden/script/prefab_api.hpp
+++ b/engine/script/include/irreden/script/prefab_api.hpp
@@ -80,10 +80,16 @@ void clearPrefabs();
 ///   with a `VersionMismatch`-style error string.
 /// - Creates an entity with `C_Position3D(position)`.
 /// - If `voxel_ref` is present, loads the `.vxs` via
-///   `IRAsset::loadVoxelSet`. The loaded shape records / dense voxel
-///   data are validated to load cleanly but **not** attached as
-///   runtime components in v1 (`C_VoxelSetNew` requires an active
-///   render canvas pool). A follow-up task wires the attachment.
+///   `IRAsset::loadVoxelSet`. SHAPES records (and the SHAPES half of
+///   HYBRID files) attach as child entities — one per `ShapeRecord`,
+///   each carrying `C_Position3D(record.offset_)` plus a
+///   `C_ShapeDescriptor` whose `shapeType_` / `params_` / `color_` /
+///   `flags_` are copied from the record. Per-record `rotation_` /
+///   `csgOp_` / `boneId_` are loaded but not stamped onto runtime
+///   components in v1 (no current renderer consumes them; T-181
+///   wires bone binding). DENSE / HYBRID dense voxel data is loaded
+///   but **not** attached — `C_VoxelSetNew` requires an active
+///   render-canvas pool; the headless attach path is deferred.
 /// - If `rig_ref` is present, loads the `.rig` via `IRAsset::loadRig`
 ///   and attaches `C_JointHierarchy` via
 ///   `IRPrefab::Rig::toComponent`. Bind-points are loaded but not

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -5,17 +5,21 @@
 #include <irreden/common/components/component_position_3d.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_profile.hpp>
+#include <irreden/ir_render.hpp>
 #include <irreden/script/ir_script_types.hpp>
 #include <irreden/script/lua_script.hpp>
+#include <irreden/voxel/components/component_shape_descriptor.hpp>
 #include <irreden/voxel/rig_bridge.hpp>
 
 #include <sol/sol.hpp>
 
 #include <exception>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace IRPrefab::Prefab {
 
@@ -116,14 +120,18 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
         );
     }
 
-    // Optional voxel_ref — load + verify but defer attachment to a
-    // follow-up task (C_VoxelSetNew requires an active canvas pool).
+    // Optional voxel_ref — SHAPES records attach as child entities (one
+    // per record) below; DENSE data is loaded but not attached in v1
+    // (C_VoxelSetNew requires an active render-canvas pool — the
+    // headless attach path is deferred; see CLAUDE.md "Prefab format").
     sol::optional<std::string> voxelRef = prefab["voxel_ref"];
+    std::optional<IRAsset::VoxelSetAllFile> loadedVoxels;
     if (voxelRef) {
         auto loadResult = IRAsset::loadVoxelSet(*voxelRef);
         if (!loadResult.ok()) {
             return makeError(idStr, path, std::string{"voxel_ref load failed: "} + *voxelRef);
         }
+        loadedVoxels = std::move(loadResult.value_);
     }
 
     // Optional rig_ref — load and translate to C_JointHierarchy via the
@@ -162,14 +170,49 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
         IREntity::setComponent(entity, IRPrefab::Rig::toComponent(*loadedRig));
     }
 
+    // SHAPES voxel_ref attachment — one child entity per ShapeRecord,
+    // CHILD_OF the spawned root so per-record `offset_` composes
+    // through the standard C_PositionGlobal3D + C_PositionOffset3D
+    // pipeline. Per-record `rotation_`, `csgOp_`, and `boneId_` are
+    // persisted but not consumed by the current renderer; loading them
+    // is a no-op until a runtime system reads them (T-181 will wire
+    // bone bindings; CSG composition is a render-side decision). v1
+    // intentionally drops these to avoid stamping unused state.
+    //
+    // DENSE / HYBRID dense data is left unattached — `C_VoxelSetNew`
+    // allocates against the active render-canvas pool, and the
+    // headless attach path needs its own design pass. The shape half
+    // of HYBRID still attaches here so SHAPES + HYBRID prefabs render
+    // their SDF primitives even when no canvas is active.
+    std::vector<IREntity::EntityId> spawnedChildren;
+    if (loadedVoxels && (loadedVoxels->mode_ == IRAsset::VoxelSetMode::SHAPES ||
+                         loadedVoxels->mode_ == IRAsset::VoxelSetMode::HYBRID)) {
+        spawnedChildren.reserve(loadedVoxels->shapeRecords_.size());
+        for (const auto &record : loadedVoxels->shapeRecords_) {
+            IRComponents::C_ShapeDescriptor descriptor{
+                static_cast<IRRender::ShapeType>(record.shapeTypeId_),
+                record.params_,
+                record.color_
+            };
+            descriptor.flags_ = record.flags_;
+            const IREntity::EntityId child =
+                IREntity::createEntity(IRComponents::C_Position3D{record.offset_}, descriptor);
+            IREntity::setParent(child, entity);
+            spawnedChildren.push_back(child);
+        }
+    }
+
     // Optional setup function — last so the user sees a fully-formed
-    // entity (position + rig already attached). Distinguish "absent"
-    // (sol::type::lua_nil) from "present but not a function" so a
-    // schema typo like `setup = 42` surfaces a diagnostic instead of
-    // silently no-op'ing.
+    // entity (position + rig + shape children already attached).
+    // Distinguish "absent" (sol::type::lua_nil) from "present but not
+    // a function" so a schema typo like `setup = 42` surfaces a
+    // diagnostic instead of silently no-op'ing.
     sol::object setupObj = prefab["setup"];
     if (setupObj.valid() && setupObj.get_type() != sol::type::lua_nil) {
         if (setupObj.get_type() != sol::type::function) {
+            for (auto child : spawnedChildren) {
+                IREntity::destroyEntity(child);
+            }
             IREntity::destroyEntity(entity);
             return makeError(idStr, path, "setup must be a function");
         }
@@ -177,6 +220,9 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
         sol::protected_function_result setupResult = setupFn(IRScript::LuaEntity{entity});
         if (!setupResult.valid()) {
             sol::error err = setupResult;
+            for (auto child : spawnedChildren) {
+                IREntity::destroyEntity(child);
+            }
             IREntity::destroyEntity(entity);
             return makeError(idStr, path, std::string{"setup callback failed: "} + err.what());
         }

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -303,6 +303,8 @@ TEST_F(PrefabApi, SpawnAttachesShapesAsChildren) {
         IRMath::Color color_;
     };
     std::vector<ChildSnapshot> children;
+    // forEachComponent only supports a single component type; getComponent<C_Position3D> per-entity
+    // is the cleanest option available until the API gains multi-component iteration.
     IREntity::forEachComponent<IRComponents::C_ShapeDescriptor>(
         [&](IREntity::EntityId id, IRComponents::C_ShapeDescriptor &desc) {
             const auto &pos = IREntity::getComponent<IRComponents::C_Position3D>(id);

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -4,9 +4,11 @@
 #include <irreden/asset/voxel_set_format.hpp>
 #include <irreden/common/components/component_position_3d.hpp>
 #include <irreden/ir_entity.hpp>
+#include <irreden/ir_render.hpp>
 #include <irreden/script/lua_script.hpp>
 #include <irreden/script/prefab_api.hpp>
 #include <irreden/voxel/components/component_joint_hierarchy.hpp>
+#include <irreden/voxel/components/component_shape_descriptor.hpp>
 
 #include <fstream>
 #include <string>
@@ -244,6 +246,97 @@ TEST_F(PrefabApi, SetupCallbackErrorSurfaced) {
     auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
     EXPECT_EQ(r.entity_, IREntity::kNullEntity);
     EXPECT_NE(r.error_.find("setup callback failed"), std::string::npos) << r.error_;
+}
+
+// ---- voxel_ref SHAPES attachment ------------------------------------------
+
+// Build a 3-record SHAPES `.vxs` with distinct offsets, shape types, and
+// colors so the round-trip test can verify per-record attachment by
+// inspecting each child entity.
+PrefabFiles writeShapesFixture(const std::string &tag, const std::string &prefabBody) {
+    PrefabFiles f;
+    f.voxel_path_ = std::string{kTmpDir} + "/prefab_test_shapes_" + tag + ".vxs";
+    f.rig_dir_ = kTmpDir;
+    f.rig_name_ = "prefab_test_shapes_" + tag;
+    f.prefab_path_ = std::string{kTmpDir} + "/prefab_test_shapes_" + tag + ".prefab.lua";
+
+    std::vector<IRAsset::ShapeRecord> shapes(3);
+    // BOX at (1, 0, 0), red
+    shapes[0].shapeTypeId_ = static_cast<std::uint32_t>(IRRender::ShapeType::BOX);
+    shapes[0].params_ = vec4(2.0f, 2.0f, 2.0f, 0.0f);
+    shapes[0].color_ = IRMath::Color{255, 0, 0, 255};
+    shapes[0].offset_ = IRMath::vec3(1.0f, 0.0f, 0.0f);
+    // SPHERE at (0, 2, 0), green
+    shapes[1].shapeTypeId_ = static_cast<std::uint32_t>(IRRender::ShapeType::SPHERE);
+    shapes[1].params_ = vec4(1.5f, 0.0f, 0.0f, 0.0f);
+    shapes[1].color_ = IRMath::Color{0, 255, 0, 255};
+    shapes[1].offset_ = IRMath::vec3(0.0f, 2.0f, 0.0f);
+    // CYLINDER at (0, 0, 3), blue
+    shapes[2].shapeTypeId_ = static_cast<std::uint32_t>(IRRender::ShapeType::CYLINDER);
+    shapes[2].params_ = vec4(0.5f, 4.0f, 0.0f, 0.0f);
+    shapes[2].color_ = IRMath::Color{0, 0, 255, 255};
+    shapes[2].offset_ = IRMath::vec3(0.0f, 0.0f, 3.0f);
+    IRAsset::saveShapeGroup(f.voxel_path_, shapes);
+
+    std::ofstream out(f.prefab_path_);
+    out << prefabBody;
+    return f;
+}
+
+TEST_F(PrefabApi, SpawnAttachesShapesAsChildren) {
+    PrefabFiles f = writeShapesFixture(
+        "attach",
+        std::string{"return { prefab_version = 1, voxel_ref = '"} + std::string{kTmpDir} +
+            "/prefab_test_shapes_attach.vxs' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(10.0f, 20.0f, 30.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    // Collect every C_ShapeDescriptor + C_Position3D entity in the world.
+    // The fixture starts with an empty manager, so these are exactly the
+    // SHAPES children attached by spawn (the root entity owns
+    // C_Position3D but no C_ShapeDescriptor).
+    struct ChildSnapshot {
+        IRMath::vec3 offset_;
+        IRRender::ShapeType shapeType_;
+        IRMath::Color color_;
+    };
+    std::vector<ChildSnapshot> children;
+    IREntity::forEachComponent<IRComponents::C_ShapeDescriptor>(
+        [&](IREntity::EntityId id, IRComponents::C_ShapeDescriptor &desc) {
+            const auto &pos = IREntity::getComponent<IRComponents::C_Position3D>(id);
+            children.push_back({pos.pos_, desc.shapeType_, desc.color_});
+        }
+    );
+
+    ASSERT_EQ(children.size(), 3u);
+
+    // The asset module's iteration order is insertion order; spawn preserves it.
+    EXPECT_EQ(children[0].shapeType_, IRRender::ShapeType::BOX);
+    EXPECT_FLOAT_EQ(children[0].offset_.x, 1.0f);
+    EXPECT_EQ(children[0].color_.red_, 255);
+    EXPECT_EQ(children[0].color_.green_, 0);
+
+    EXPECT_EQ(children[1].shapeType_, IRRender::ShapeType::SPHERE);
+    EXPECT_FLOAT_EQ(children[1].offset_.y, 2.0f);
+    EXPECT_EQ(children[1].color_.green_, 255);
+
+    EXPECT_EQ(children[2].shapeType_, IRRender::ShapeType::CYLINDER);
+    EXPECT_FLOAT_EQ(children[2].offset_.z, 3.0f);
+    EXPECT_EQ(children[2].color_.blue_, 255);
+}
+
+TEST_F(PrefabApi, SpawnSkipsShapesAttachmentWhenAbsent) {
+    // A prefab without voxel_ref must still spawn cleanly with zero
+    // shape children. Sanity check that the SHAPES path doesn't leak
+    // into prefabs that opted out.
+    PrefabFiles f = writeFixtureSet("no_voxel", "return { prefab_version = 1 }\n");
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    EXPECT_EQ(IREntity::countComponents<IRComponents::C_ShapeDescriptor>(), 0);
 }
 
 // ---- additivity: unknown top-level keys do not break the load -------------


### PR DESCRIPTION
## Summary
- Wire the SHAPES half of `voxel_ref` ECS attachment deferred from T-173 (#671 / PR #703).
- Each `ShapeRecord` becomes a child entity (`C_Position3D{offset} + C_ShapeDescriptor{...}`), parented via `IREntity::setParent` so position composes through the standard CHILD_OF pipeline.
- HYBRID files attach the SHAPES half; DENSE/HYBRID dense voxel data stays deferred (filed #721 — needs `C_VoxelSetNew` canvas-pool decoupling).
- New helper `IRRender::getActiveCanvasEntityOrNull()` lets `C_ShapeDescriptor`'s constructors construct safely in headless contexts (no `RenderManager` → `canvasEntity_ = kNullEntity` instead of `IR_ASSERT`).

Per-record `rotation_` / `csgOp_` / `boneId_` are loaded but not stamped on runtime components in v1 — no current renderer consumes them; T-181 wires bone bindings.

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/703
Stack: T-173 → T-182

## Render-pipeline touch (no visual change)
Diff includes `engine/render/include/irreden/ir_render.hpp` (added one inline null-tolerant accessor) and `engine/prefabs/irreden/voxel/components/component_shape_descriptor.hpp` (swapped accessor in ctor). The change is mechanical — when a `RenderManager` exists, both accessors return the same value. No `attach-screenshots` / `render-debug-loop` run; documented exception ("mechanical refactor with no visual effect"). Reviewers double-check the assertion still fires for production callers via `getRenderManager()` (the asserting accessor is unchanged).

## Test plan
- [x] `fleet-build --target IrredenEngineTest` clean on macos-debug
- [x] All 603 tests pass (was 601 baseline; +2 new `PrefabApi.SpawnAttachesShapesAsChildren`, `PrefabApi.SpawnSkipsShapesAttachmentWhenAbsent`)
- [x] Round-trip verifies per-record shape type, offset, and color for a 3-record SHAPES fixture
- [ ] Cross-host linux smoke (will be tagged via `fleet:needs-linux-smoke` when reviewer approves)

Closes #701