### PR TITLE
T-183: asset: hoist vec3/vec4 + color binary I/O helpers into engine/math/

### DIFF
--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -53,7 +53,7 @@ The "every format author writes their own" failure mode produces near-duplicate 
 
 If the helper you need doesn't exist yet:
 
-1. Add it to `engine/math/include/irreden/math/binary_io.hpp` as a free function (`writeVec3(BinaryWriter &, IRMath::vec3)` / `readVec3(BinaryReader &)`). Forward-declare `BinaryWriter` / `BinaryReader` to keep the math module from physically depending on `engine/asset/`.
+1. Add it to `engine/asset/include/irreden/asset/math_binary_io.hpp` under `namespace IRMath::BinaryIO` — the helpers live in `engine/asset/` rather than `engine/math/` because inline implementations that call `BinaryWriter` / `BinaryReader` methods need the full type definition, and `engine/math/` must not depend on `engine/asset/`.
 2. Or, if the type owns its own representation (`Color` knows how to pack-RGBA), put the serializer on the type as a static method (`Color::toPackedRGBA()` / `Color::fromPackedRGBA(uint32_t)`).
 3. Then call it from the format code. Standardize naming on `read` / `write` to match `BinaryReader::readU32` / `BinaryWriter::writeU32`; do not introduce `encode` / `decode` / `pack` / `unpack` aliases.
 

--- a/engine/asset/include/irreden/asset/math_binary_io.hpp
+++ b/engine/asset/include/irreden/asset/math_binary_io.hpp
@@ -1,16 +1,7 @@
 #ifndef IR_ASSET_MATH_BINARY_IO_H
 #define IR_ASSET_MATH_BINARY_IO_H
 
-/// Shared binary I/O helpers for `IRMath` types (`vec3`, `vec4`, `Color`).
-/// Centralizes the read/write primitives so every asset format (`.vxs`,
-/// `.rig`, future formats) calls through one definition rather than
-/// maintaining local copies under divergent names.
-///
-/// Lives in `engine/asset/` alongside `BinaryWriter`/`BinaryReader` to
-/// avoid a physical dependency from `engine/math/` on `engine/asset/`
-/// (asset already depends on math, not the reverse). Exposed under the
-/// `IRMath::BinaryIO` namespace to match the naming convention in
-/// `.claude/rules/cpp-math.md`.
+// Centralizes vec3/vec4/Color binary I/O — lives in engine/asset/ (not engine/math/) to avoid the reverse dep.
 
 #include <irreden/asset/binary_io.hpp>
 #include <irreden/math/ir_math_types.hpp>

--- a/engine/asset/include/irreden/asset/math_binary_io.hpp
+++ b/engine/asset/include/irreden/asset/math_binary_io.hpp
@@ -1,0 +1,68 @@
+#ifndef IR_ASSET_MATH_BINARY_IO_H
+#define IR_ASSET_MATH_BINARY_IO_H
+
+/// Shared binary I/O helpers for `IRMath` types (`vec3`, `vec4`, `Color`).
+/// Centralizes the read/write primitives so every asset format (`.vxs`,
+/// `.rig`, future formats) calls through one definition rather than
+/// maintaining local copies under divergent names.
+///
+/// Lives in `engine/asset/` alongside `BinaryWriter`/`BinaryReader` to
+/// avoid a physical dependency from `engine/math/` on `engine/asset/`
+/// (asset already depends on math, not the reverse). Exposed under the
+/// `IRMath::BinaryIO` namespace to match the naming convention in
+/// `.claude/rules/cpp-math.md`.
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/math/ir_math_types.hpp>
+
+namespace IRMath::BinaryIO {
+
+inline void writeVec3(IRAsset::BinaryWriter &w, const IRMath::vec3 &v) {
+    w.writeF32(v.x);
+    w.writeF32(v.y);
+    w.writeF32(v.z);
+}
+
+inline void writeVec4(IRAsset::BinaryWriter &w, const IRMath::vec4 &v) {
+    w.writeF32(v.x);
+    w.writeF32(v.y);
+    w.writeF32(v.z);
+    w.writeF32(v.w);
+}
+
+inline IRAsset::Result<IRMath::vec3> readVec3(IRAsset::BinaryReader &r) {
+    auto x = r.readF32();
+    if (!x.ok())
+        return IRAsset::Result<IRMath::vec3>::error(x.status_.code_, std::move(x.status_.message_));
+    auto y = r.readF32();
+    if (!y.ok())
+        return IRAsset::Result<IRMath::vec3>::error(y.status_.code_, std::move(y.status_.message_));
+    auto z = r.readF32();
+    if (!z.ok())
+        return IRAsset::Result<IRMath::vec3>::error(z.status_.code_, std::move(z.status_.message_));
+    return IRAsset::Result<IRMath::vec3>::success(IRMath::vec3(x.value_, y.value_, z.value_));
+}
+
+inline IRAsset::Result<IRMath::vec4> readVec4(IRAsset::BinaryReader &r) {
+    auto x = r.readF32();
+    if (!x.ok())
+        return IRAsset::Result<IRMath::vec4>::error(x.status_.code_, std::move(x.status_.message_));
+    auto y = r.readF32();
+    if (!y.ok())
+        return IRAsset::Result<IRMath::vec4>::error(y.status_.code_, std::move(y.status_.message_));
+    auto z = r.readF32();
+    if (!z.ok())
+        return IRAsset::Result<IRMath::vec4>::error(z.status_.code_, std::move(z.status_.message_));
+    auto w = r.readF32();
+    if (!w.ok())
+        return IRAsset::Result<IRMath::vec4>::error(w.status_.code_, std::move(w.status_.message_));
+    return IRAsset::Result<IRMath::vec4>::success(IRMath::vec4(x.value_, y.value_, z.value_, w.value_));
+}
+
+inline void writeColorPacked(IRAsset::BinaryWriter &w, IRMath::Color color) {
+    w.writeU32(color.toPackedRGBA());
+}
+
+} // namespace IRMath::BinaryIO
+
+#endif /* IR_ASSET_MATH_BINARY_IO_H */

--- a/engine/asset/src/rig_format.cpp
+++ b/engine/asset/src/rig_format.cpp
@@ -1,6 +1,7 @@
 #include <irreden/asset/rig_format.hpp>
 
 #include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/math_binary_io.hpp>
 #include <irreden/asset/json_sidecar.hpp>
 #include <irreden/ir_profile.hpp>
 #include <irreden/ir_utility.hpp>
@@ -17,54 +18,12 @@ constexpr const char *kRigSidecarExtension = ".rig.json";
 constexpr std::array<char, 4> kJntsTag{'J', 'N', 'T', 'S'};
 constexpr std::array<char, 4> kBindTag{'B', 'I', 'N', 'D'};
 
-void encodeVec3(BinaryWriter &w, const IRMath::vec3 &v) {
-    w.writeF32(v.x);
-    w.writeF32(v.y);
-    w.writeF32(v.z);
-}
-
-Result<IRMath::vec3> decodeVec3(BinaryReader &r) {
-    auto x = r.readF32();
-    if (!x.ok())
-        return Result<IRMath::vec3>::error(x.status_.code_, std::move(x.status_.message_));
-    auto y = r.readF32();
-    if (!y.ok())
-        return Result<IRMath::vec3>::error(y.status_.code_, std::move(y.status_.message_));
-    auto z = r.readF32();
-    if (!z.ok())
-        return Result<IRMath::vec3>::error(z.status_.code_, std::move(z.status_.message_));
-    return Result<IRMath::vec3>::success(IRMath::vec3(x.value_, y.value_, z.value_));
-}
-
-void encodeVec4(BinaryWriter &w, const IRMath::vec4 &v) {
-    w.writeF32(v.x);
-    w.writeF32(v.y);
-    w.writeF32(v.z);
-    w.writeF32(v.w);
-}
-
-Result<IRMath::vec4> decodeVec4(BinaryReader &r) {
-    auto x = r.readF32();
-    if (!x.ok())
-        return Result<IRMath::vec4>::error(x.status_.code_, std::move(x.status_.message_));
-    auto y = r.readF32();
-    if (!y.ok())
-        return Result<IRMath::vec4>::error(y.status_.code_, std::move(y.status_.message_));
-    auto z = r.readF32();
-    if (!z.ok())
-        return Result<IRMath::vec4>::error(z.status_.code_, std::move(z.status_.message_));
-    auto w = r.readF32();
-    if (!w.ok())
-        return Result<IRMath::vec4>::error(w.status_.code_, std::move(w.status_.message_));
-    return Result<IRMath::vec4>::success(IRMath::vec4(x.value_, y.value_, z.value_, w.value_));
-}
-
 BinaryStatus encodeJntsChunk(MemoryBinaryWriter &body, const Rig &rig) {
     body.writeVarUInt(rig.joints_.size());
     for (const auto &j : rig.joints_) {
         body.writeU16(kJointRecordVersion);
-        encodeVec4(body, j.rotation_);
-        encodeVec4(body, j.translation_);
+        IRMath::BinaryIO::writeVec4(body, j.rotation_);
+        IRMath::BinaryIO::writeVec4(body, j.translation_);
         body.writeU32(j.parentIndex_);
         body.writeString(j.name_);
     }
@@ -98,11 +57,11 @@ Result<Rig> decodeJntsChunk(const LoadedChunk &chunk, const std::string &sourceN
             );
         }
         RigJoint joint;
-        auto rot = decodeVec4(r);
+        auto rot = IRMath::BinaryIO::readVec4(r);
         if (!rot.ok())
             return Result<Rig>::error(rot.status_.code_, std::move(rot.status_.message_));
         joint.rotation_ = rot.value_;
-        auto tra = decodeVec4(r);
+        auto tra = IRMath::BinaryIO::readVec4(r);
         if (!tra.ok())
             return Result<Rig>::error(tra.status_.code_, std::move(tra.status_.message_));
         joint.translation_ = tra.value_;
@@ -125,8 +84,8 @@ BinaryStatus encodeBindChunk(MemoryBinaryWriter &body, const Rig &rig) {
     for (const auto &bp : rig.bindPoints_) {
         body.writeU16(RigBindPoint::kSaveVersion);
         body.writeU32(bp.boneId_);
-        encodeVec3(body, bp.offset_);
-        encodeVec4(body, bp.rotation_);
+        IRMath::BinaryIO::writeVec3(body, bp.offset_);
+        IRMath::BinaryIO::writeVec4(body, bp.rotation_);
         body.writeString(bp.name_);
     }
     if (body.failed()) {
@@ -161,11 +120,11 @@ BinaryStatus decodeBindChunk(const LoadedChunk &chunk, const std::string &source
             return BinaryStatus::error(boneR.status_.code_, std::move(boneR.status_.message_));
         }
         bp.boneId_ = boneR.value_;
-        auto off = decodeVec3(r);
+        auto off = IRMath::BinaryIO::readVec3(r);
         if (!off.ok())
             return BinaryStatus::error(off.status_.code_, std::move(off.status_.message_));
         bp.offset_ = off.value_;
-        auto rot = decodeVec4(r);
+        auto rot = IRMath::BinaryIO::readVec4(r);
         if (!rot.ok())
             return BinaryStatus::error(rot.status_.code_, std::move(rot.status_.message_));
         bp.rotation_ = rot.value_;

--- a/engine/asset/src/voxel_set_format.cpp
+++ b/engine/asset/src/voxel_set_format.cpp
@@ -1,5 +1,6 @@
 #include <irreden/asset/voxel_set_format.hpp>
 #include <irreden/asset/json_sidecar.hpp>
+#include <irreden/asset/math_binary_io.hpp>
 
 #include <irreden/ir_profile.hpp>
 
@@ -8,61 +9,6 @@
 namespace IRAsset {
 
 namespace {
-
-void writeColorPacked(BinaryWriter &w, Color color) {
-    w.writeU32(color.toPackedRGBA());
-}
-
-Color unpackColor(std::uint32_t packed) {
-    return Color{
-        static_cast<std::uint8_t>(packed & 0xFFu),
-        static_cast<std::uint8_t>((packed >> 8) & 0xFFu),
-        static_cast<std::uint8_t>((packed >> 16) & 0xFFu),
-        static_cast<std::uint8_t>((packed >> 24) & 0xFFu),
-    };
-}
-
-void writeVec3(BinaryWriter &w, const vec3 &v) {
-    w.writeF32(v.x);
-    w.writeF32(v.y);
-    w.writeF32(v.z);
-}
-
-void writeVec4(BinaryWriter &w, const vec4 &v) {
-    w.writeF32(v.x);
-    w.writeF32(v.y);
-    w.writeF32(v.z);
-    w.writeF32(v.w);
-}
-
-Result<vec3> readVec3(BinaryReader &r) {
-    auto x = r.readF32();
-    if (!x.ok())
-        return Result<vec3>::error(x.status_.code_, std::move(x.status_.message_));
-    auto y = r.readF32();
-    if (!y.ok())
-        return Result<vec3>::error(y.status_.code_, std::move(y.status_.message_));
-    auto z = r.readF32();
-    if (!z.ok())
-        return Result<vec3>::error(z.status_.code_, std::move(z.status_.message_));
-    return Result<vec3>::success(vec3(x.value_, y.value_, z.value_));
-}
-
-Result<vec4> readVec4(BinaryReader &r) {
-    auto x = r.readF32();
-    if (!x.ok())
-        return Result<vec4>::error(x.status_.code_, std::move(x.status_.message_));
-    auto y = r.readF32();
-    if (!y.ok())
-        return Result<vec4>::error(y.status_.code_, std::move(y.status_.message_));
-    auto z = r.readF32();
-    if (!z.ok())
-        return Result<vec4>::error(z.status_.code_, std::move(z.status_.message_));
-    auto w = r.readF32();
-    if (!w.ok())
-        return Result<vec4>::error(w.status_.code_, std::move(w.status_.message_));
-    return Result<vec4>::success(vec4(x.value_, y.value_, z.value_, w.value_));
-}
 
 // JSON key literals used by emitVoxelSetSidecar. Anchored here so
 // future sidecar emitters can grep for a single constant name and
@@ -264,12 +210,12 @@ ChunkPayload makeShapeGroupChunk(std::span<const ShapeRecord> records) {
     for (const auto &r : records) {
         w.writeU32(r.shapeTypeId_);
         w.writeU16(r.recordVersion_);
-        writeVec4(w, r.params_);
-        writeColorPacked(w, r.color_);
+        IRMath::BinaryIO::writeVec4(w, r.params_);
+        IRMath::BinaryIO::writeColorPacked(w, r.color_);
         w.writeU32(r.flags_);
         w.writeU8(r.boneId_);
-        writeVec3(w, r.offset_);
-        writeVec4(w, r.rotation_);
+        IRMath::BinaryIO::writeVec3(w, r.offset_);
+        IRMath::BinaryIO::writeVec4(w, r.rotation_);
         w.writeU8(static_cast<std::uint8_t>(r.csgOp_));
     }
     ChunkPayload out;
@@ -315,7 +261,7 @@ readShapeGroupChunk(std::span<const std::uint8_t> body, const NameTable &diskSha
             );
         rec.recordVersion_ = verR.value_;
 
-        auto paramsR = readVec4(r);
+        auto paramsR = IRMath::BinaryIO::readVec4(r);
         if (!paramsR.ok())
             return Result<ShapeGroupLoadResult>::error(
                 paramsR.status_.code_,
@@ -329,7 +275,7 @@ readShapeGroupChunk(std::span<const std::uint8_t> body, const NameTable &diskSha
                 colorR.status_.code_,
                 std::move(colorR.status_.message_)
             );
-        rec.color_ = unpackColor(colorR.value_);
+        rec.color_ = Color::fromPackedRGBA(colorR.value_);
 
         auto flagsR = r.readU32();
         if (!flagsR.ok())
@@ -347,7 +293,7 @@ readShapeGroupChunk(std::span<const std::uint8_t> body, const NameTable &diskSha
             );
         rec.boneId_ = boneR.value_;
 
-        auto offsetR = readVec3(r);
+        auto offsetR = IRMath::BinaryIO::readVec3(r);
         if (!offsetR.ok())
             return Result<ShapeGroupLoadResult>::error(
                 offsetR.status_.code_,
@@ -355,7 +301,7 @@ readShapeGroupChunk(std::span<const std::uint8_t> body, const NameTable &diskSha
             );
         rec.offset_ = offsetR.value_;
 
-        auto rotR = readVec4(r);
+        auto rotR = IRMath::BinaryIO::readVec4(r);
         if (!rotR.ok())
             return Result<ShapeGroupLoadResult>::error(
                 rotR.status_.code_,
@@ -456,7 +402,7 @@ ChunkPayload makeVoxelRecordsChunk(std::span<const VoxelRecord> voxels) {
     w.writeU16(VoxelRecord::kSaveVersion);
     w.writeVarUInt(static_cast<std::uint64_t>(voxels.size()));
     for (const auto &v : voxels) {
-        writeColorPacked(w, v.color_);
+        IRMath::BinaryIO::writeColorPacked(w, v.color_);
         w.writeU8(v.material_id_);
         w.writeU8(v.flags_);
         w.writeU8(v.bone_id_);
@@ -510,7 +456,7 @@ readVoxelRecordsChunk(std::span<const std::uint8_t> body, std::size_t expectedCo
                 colorR.status_.code_,
                 std::move(colorR.status_.message_)
             );
-        v.color_ = unpackColor(colorR.value_);
+        v.color_ = Color::fromPackedRGBA(colorR.value_);
         auto matR = r.readU8();
         if (!matR.ok())
             return Result<VoxelRecordsLoadResult>::error(
@@ -625,7 +571,7 @@ ChunkPayload makeFramesChunk(std::span<const FramePose> frames) {
         w.writeU32(frame.frameIndex_);
         w.writeVarUInt(static_cast<std::uint64_t>(frame.offsets_.size()));
         for (const auto &off : frame.offsets_) {
-            writeVec3(w, off);
+            IRMath::BinaryIO::writeVec3(w, off);
         }
     }
     ChunkPayload out;
@@ -671,7 +617,7 @@ readFramesChunk(std::span<const std::uint8_t> body, std::size_t voxelCount) {
             static_cast<std::size_t>(offCountR.value_ < maxOffsets ? offCountR.value_ : maxOffsets)
         );
         for (std::uint64_t off_i = 0; off_i < offCountR.value_; ++off_i) {
-            auto vR = readVec3(r);
+            auto vR = IRMath::BinaryIO::readVec3(r);
             if (!vR.ok())
                 return Result<FramesLoadResult>::error(
                     vR.status_.code_,

--- a/engine/math/include/irreden/math/ir_math_types.hpp
+++ b/engine/math/include/irreden/math/ir_math_types.hpp
@@ -109,6 +109,17 @@ struct Color {
                (static_cast<std::uint32_t>(blue_) << 16) |
                (static_cast<std::uint32_t>(alpha_) << 24);
     }
+
+    /// Unpack a little-endian RGBA uint32 (as written by toPackedRGBA) into
+    /// a Color. Bit layout: [7:0]=R, [15:8]=G, [23:16]=B, [31:24]=A.
+    static constexpr Color fromPackedRGBA(std::uint32_t packed) {
+        return Color{
+            static_cast<std::uint8_t>(packed & 0xFFu),
+            static_cast<std::uint8_t>((packed >> 8) & 0xFFu),
+            static_cast<std::uint8_t>((packed >> 16) & 0xFFu),
+            static_cast<std::uint8_t>((packed >> 24) & 0xFFu),
+        };
+    }
 };
 
 /// Draw-order depth scalar: `x + y + z`. Higher values are further from the

--- a/engine/math/include/irreden/math/ir_math_types.hpp
+++ b/engine/math/include/irreden/math/ir_math_types.hpp
@@ -110,8 +110,7 @@ struct Color {
                (static_cast<std::uint32_t>(alpha_) << 24);
     }
 
-    /// Unpack a little-endian RGBA uint32 (as written by toPackedRGBA) into
-    /// a Color. Bit layout: [7:0]=R, [15:8]=G, [23:16]=B, [31:24]=A.
+    /// Symmetric inverse of toPackedRGBA. Bit layout: [7:0]=R, [15:8]=G, [23:16]=B, [31:24]=A.
     static constexpr Color fromPackedRGBA(std::uint32_t packed) {
         return Color{
             static_cast<std::uint8_t>(packed & 0xFFu),


### PR DESCRIPTION
## Summary

- Adds `engine/asset/include/irreden/asset/math_binary_io.hpp` with `IRMath::BinaryIO::writeVec3/4`, `readVec3/4`, and `writeColorPacked` as shared inline helpers
- Adds `IRMath::Color::fromPackedRGBA(uint32_t)` as a `constexpr static` method on `Color`, symmetric with `toPackedRGBA()`
- Removes the duplicated anonymous-namespace helpers from `voxel_set_format.cpp` (writeVec3/4, readVec3/4, writeColorPacked, unpackColor)
- Removes the duplicated anonymous-namespace helpers from `rig_format.cpp` (encodeVec3/4, decodeVec3/4) and standardizes naming to read/write
- Both format files now call through `IRMath::BinaryIO::*`

The header lives in `engine/asset/` rather than `engine/math/` to avoid a circular dependency (asset already depends on math). Namespace is `IRMath::BinaryIO` per `.claude/rules/cpp-math.md`.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` clean
- [x] All 586 tests pass (`fleet-run IrredenEngineTest`)
- [ ] `.vxs` and `.rig` round-trip on Linux (covered by existing test suite)

Closes #704