### PR TITLE
T-181: prefab/runtime: C_BindPoints + entity:bindPoint Lua API

### DIFF
--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -86,7 +86,7 @@ layout used by `IRComponents::Joint::rotation_` and
   unit quaternion. Same algebra as `glm::rotate(quat, vec3)`.
 
 These are the helpers `IRPrefab::Rig::worldTransformForBindPoint`
-uses to walk a joint chain when resolving `entity:bindPoint(name)`.
+uses to walk a joint chain when resolving `IREntity.bindPoint(entity, name)`.
 
 ## Random
 

--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -73,6 +73,21 @@ Helpers that take `PlaneIso` (most of them): double-check the plane axis —
 
 Use these; don't re-derive the kinematics inline.
 
+## Quaternions
+
+Quaternions are stored as `IRMath::vec4(qx, qy, qz, qw)` — the same
+layout used by `IRComponents::Joint::rotation_` and
+`IRAsset::RigJoint::rotation_` (identity is `vec4(0, 0, 0, 1)`, i.e.
+`.w` is the scalar).
+
+- `IRMath::quatMul(a, b) → vec4` — compose two unit quaternions.
+  Rotating by `quatMul(a, b)` rotates by `a` first then by `b`.
+- `IRMath::rotateVectorByQuat(v, q) → vec3` — rotate a vec3 by a
+  unit quaternion. Same algebra as `glm::rotate(quat, vec3)`.
+
+These are the helpers `IRPrefab::Rig::worldTransformForBindPoint`
+uses to walk a joint chain when resolving `entity:bindPoint(name)`.
+
 ## Random
 
 - `randomBool()`, `randomInt(min, max)`, `randomFloat(min, max)`.

--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -80,8 +80,8 @@ layout used by `IRComponents::Joint::rotation_` and
 `IRAsset::RigJoint::rotation_` (identity is `vec4(0, 0, 0, 1)`, i.e.
 `.w` is the scalar).
 
-- `IRMath::quatMul(a, b) → vec4` — compose two unit quaternions.
-  Rotating by `quatMul(a, b)` rotates by `a` first then by `b`.
+- `IRMath::quatMul(a, b) → vec4` — Hamilton product; in column-vector
+  convention, rotates by `b` first then `a` (bone usage: `quatMul(parent_world, local)`).
 - `IRMath::rotateVectorByQuat(v, q) → vec3` — rotate a vec3 by a
   unit quaternion. Same algebra as `glm::rotate(quat, vec3)`.
 

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -128,6 +128,29 @@ template <typename VecType> constexpr VecType cross(const VecType &value1, const
     return glm::cross(value1, value2);
 }
 
+/// Multiplies two unit quaternions stored as `vec4(qx, qy, qz, qw)` — the
+/// same in-memory layout the engine uses for `IRComponents::Joint::rotation_`
+/// and `IRAsset::RigJoint::rotation_`. Result composes `a` then `b`
+/// (rotating by `quatMul(a, b)` is the same as rotating by `a` first then
+/// by `b`).
+inline vec4 quatMul(const vec4 &a, const vec4 &b) {
+    return vec4(
+        a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+        a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+        a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+        a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z
+    );
+}
+
+/// Rotates a vec3 by a unit quaternion stored as `vec4(qx, qy, qz, qw)`.
+/// Uses the standard `v + 2 * cross(q.xyz, cross(q.xyz, v) + q.w * v)`
+/// identity — same algebra glm::rotate(quat, vec3) would compute.
+inline vec3 rotateVectorByQuat(const vec3 &v, const vec4 &q) {
+    const vec3 u{q.x, q.y, q.z};
+    const vec3 t = 2.0f * glm::cross(u, v);
+    return v + q.w * t + glm::cross(u, t);
+}
+
 /// Inverse of @ref pos3DtoPos2DIso: reconstructs the unique world position
 /// at iso (x, y) on the depth plane @p depth (= x+y+z). The iso depth axis
 /// is (1,1,1), so a 2D iso point and a depth value pin a single 3D point.

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -128,11 +128,7 @@ template <typename VecType> constexpr VecType cross(const VecType &value1, const
     return glm::cross(value1, value2);
 }
 
-/// Multiplies two unit quaternions stored as `vec4(qx, qy, qz, qw)` — the
-/// same in-memory layout the engine uses for `IRComponents::Joint::rotation_`
-/// and `IRAsset::RigJoint::rotation_`. Result composes `a` then `b`
-/// (rotating by `quatMul(a, b)` is the same as rotating by `a` first then
-/// by `b`).
+// Hamilton product: in column-vector convention, rotates b first then a (bone hierarchy: quatMul(parent_world, local)).
 inline vec4 quatMul(const vec4 &a, const vec4 &b) {
     return vec4(
         a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
@@ -142,9 +138,7 @@ inline vec4 quatMul(const vec4 &a, const vec4 &b) {
     );
 }
 
-/// Rotates a vec3 by a unit quaternion stored as `vec4(qx, qy, qz, qw)`.
-/// Uses the standard `v + 2 * cross(q.xyz, cross(q.xyz, v) + q.w * v)`
-/// identity — same algebra glm::rotate(quat, vec3) would compute.
+// Rodrigues' formula: v + q.w*t + cross(q.xyz, t), t = 2*cross(q.xyz, v).
 inline vec3 rotateVectorByQuat(const vec3 &v, const vec4 &q) {
     const vec3 u{q.x, q.y, q.z};
     const vec3 t = 2.0f * glm::cross(u, v);

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -25,7 +25,7 @@ for single voxels and particles.
   `{boneId, offset, rotation}` keyed by name. Populated by
   `Prefab.spawn` from `rig_ref`; the per-name world transform is
   composed lazily by `IRPrefab::Rig::worldTransformForBindPoint` and
-  surfaced to Lua as `entity:bindPoint("name")`. Per-name lookups use
+  surfaced to Lua as `IREntity.bindPoint(entity, "name")`. Per-name lookups use
   `unordered_map` and are documented as one-time queries at spawn or
   on interaction, not per-tick — see `engine/script/CLAUDE.md` for
   the Lua surface.

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -20,6 +20,15 @@ for single voxels and particles.
 - `C_ShapeDescriptor` — SDF shape type + params + color + flags (visible,
   hollow, mirror). Rendered directly by the GPU; **does not allocate voxels**.
 - `C_JointHierarchy` — WIP; articulated voxel rigs.
+- `C_BindPoints` — runtime mirror of an asset rig's BIND chunk
+  (`IRAsset::Rig::bindPoints_`). Each entry stores
+  `{boneId, offset, rotation}` keyed by name. Populated by
+  `Prefab.spawn` from `rig_ref`; the per-name world transform is
+  composed lazily by `IRPrefab::Rig::worldTransformForBindPoint` and
+  surfaced to Lua as `entity:bindPoint("name")`. Per-name lookups use
+  `unordered_map` and are documented as one-time queries at spawn or
+  on interaction, not per-tick — see `engine/script/CLAUDE.md` for
+  the Lua surface.
 
 ## Key systems
 

--- a/engine/prefabs/irreden/voxel/components/component_bind_points.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_bind_points.hpp
@@ -1,7 +1,7 @@
 #ifndef COMPONENT_BIND_POINTS_H
 #define COMPONENT_BIND_POINTS_H
 
-// Per-entity bind-point map; treat entity:bindPoint(name) as a one-time query, not per-tick.
+// Per-entity bind-point map; treat IREntity.bindPoint(entity, name) as a one-time query, not per-tick.
 
 #include <irreden/ir_math.hpp>
 

--- a/engine/prefabs/irreden/voxel/components/component_bind_points.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_bind_points.hpp
@@ -1,0 +1,48 @@
+#ifndef COMPONENT_BIND_POINTS_H
+#define COMPONENT_BIND_POINTS_H
+
+/// Runtime mirror of the asset-side bind-point set
+/// (`IRAsset::Rig::bindPoints_`). Each entry records a named attachment
+/// point parented to a bone — local-space offset + rotation relative to
+/// that bone. The world transform for a named point is composed from the
+/// joint chain at query time; see `IRPrefab::Rig::worldTransformForBindPoint`
+/// in `rig_bridge.hpp` and the `entity:bindPoint(name)` Lua method.
+///
+/// Storage is `std::unordered_map<string, BindPointRuntime>` — name lookup
+/// is the only access pattern, and binding points per entity are small (a
+/// few to a few dozen). Per-frame lookups are documented as a no-go in
+/// `engine/prefabs/irreden/voxel/CLAUDE.md`; resolve once at spawn or on
+/// interaction, then cache the integer bone index in a hot-path component
+/// if a use case appears.
+
+#include <irreden/ir_math.hpp>
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace IRComponents {
+
+struct BindPointRuntime {
+    std::uint32_t boneId_ = 0;
+    IRMath::vec3 offset_{0.0f, 0.0f, 0.0f};
+    IRMath::vec4 rotation_{0.0f, 0.0f, 0.0f, 1.0f};
+};
+
+struct C_BindPoints {
+    std::unordered_map<std::string, BindPointRuntime> points_;
+
+    C_BindPoints() = default;
+
+    void setPoint(const std::string &name, const BindPointRuntime &point) {
+        points_[name] = point;
+    }
+
+    bool hasPoint(const std::string &name) const {
+        return points_.find(name) != points_.end();
+    }
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_BIND_POINTS_H */

--- a/engine/prefabs/irreden/voxel/components/component_bind_points.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_bind_points.hpp
@@ -1,19 +1,7 @@
 #ifndef COMPONENT_BIND_POINTS_H
 #define COMPONENT_BIND_POINTS_H
 
-/// Runtime mirror of the asset-side bind-point set
-/// (`IRAsset::Rig::bindPoints_`). Each entry records a named attachment
-/// point parented to a bone — local-space offset + rotation relative to
-/// that bone. The world transform for a named point is composed from the
-/// joint chain at query time; see `IRPrefab::Rig::worldTransformForBindPoint`
-/// in `rig_bridge.hpp` and the `entity:bindPoint(name)` Lua method.
-///
-/// Storage is `std::unordered_map<string, BindPointRuntime>` — name lookup
-/// is the only access pattern, and binding points per entity are small (a
-/// few to a few dozen). Per-frame lookups are documented as a no-go in
-/// `engine/prefabs/irreden/voxel/CLAUDE.md`; resolve once at spawn or on
-/// interaction, then cache the integer bone index in a hot-path component
-/// if a use case appears.
+// Per-entity bind-point map; treat entity:bindPoint(name) as a one-time query, not per-tick.
 
 #include <irreden/ir_math.hpp>
 

--- a/engine/prefabs/irreden/voxel/components/component_bind_points_lua.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_bind_points_lua.hpp
@@ -1,7 +1,7 @@
 #ifndef COMPONENT_BIND_POINTS_LUA_H
 #define COMPONENT_BIND_POINTS_LUA_H
 
-// Exposes hasPoint/pointCount; entity:bindPoint(name) lives on LuaEntity in lua_script.cpp.
+// Exposes hasPoint/pointCount; IREntity.bindPoint(entity, name) lives in the IREntity table in lua_script.cpp.
 
 #include <irreden/voxel/components/component_bind_points.hpp>
 #include <irreden/script/lua_script.hpp>

--- a/engine/prefabs/irreden/voxel/components/component_bind_points_lua.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_bind_points_lua.hpp
@@ -1,0 +1,32 @@
+#ifndef COMPONENT_BIND_POINTS_LUA_H
+#define COMPONENT_BIND_POINTS_LUA_H
+
+/// Lua usertype for `C_BindPoints`. Exposes `hasPoint(name)` and
+/// `pointCount()` for scripts that want to introspect the bind-point
+/// set; the per-name world-transform query is `entity:bindPoint(name)`
+/// on `LuaEntity` (registered in `bindLuaDrivenEcs`) rather than a
+/// component-side method so it can compose `C_JointHierarchy` from the
+/// owning entity without holding a per-component pointer to it.
+
+#include <irreden/voxel/components/component_bind_points.hpp>
+#include <irreden/script/lua_script.hpp>
+
+namespace IRScript {
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_BindPoints> = true;
+
+template <> inline void bindLuaType<IRComponents::C_BindPoints>(LuaScript &luaScript) {
+    luaScript.registerType<IRComponents::C_BindPoints, IRComponents::C_BindPoints()>(
+        "C_BindPoints",
+        "hasPoint",
+        [](IRComponents::C_BindPoints &self, const std::string &name) {
+            return self.hasPoint(name);
+        },
+        "pointCount",
+        [](IRComponents::C_BindPoints &self) {
+            return static_cast<std::int64_t>(self.points_.size());
+        }
+    );
+}
+} // namespace IRScript
+
+#endif /* COMPONENT_BIND_POINTS_LUA_H */

--- a/engine/prefabs/irreden/voxel/components/component_bind_points_lua.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_bind_points_lua.hpp
@@ -1,12 +1,7 @@
 #ifndef COMPONENT_BIND_POINTS_LUA_H
 #define COMPONENT_BIND_POINTS_LUA_H
 
-/// Lua usertype for `C_BindPoints`. Exposes `hasPoint(name)` and
-/// `pointCount()` for scripts that want to introspect the bind-point
-/// set; the per-name world-transform query is `entity:bindPoint(name)`
-/// on `LuaEntity` (registered in `bindLuaDrivenEcs`) rather than a
-/// component-side method so it can compose `C_JointHierarchy` from the
-/// owning entity without holding a per-component pointer to it.
+// Exposes hasPoint/pointCount; entity:bindPoint(name) lives on LuaEntity in lua_script.cpp.
 
 #include <irreden/voxel/components/component_bind_points.hpp>
 #include <irreden/script/lua_script.hpp>

--- a/engine/prefabs/irreden/voxel/rig_bridge.hpp
+++ b/engine/prefabs/irreden/voxel/rig_bridge.hpp
@@ -5,12 +5,15 @@
 
 #include <irreden/asset/rig_format.hpp>
 
+#include <irreden/voxel/components/component_bind_points.hpp>
 #include <irreden/voxel/components/component_joint_hierarchy.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <span>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace IRPrefab::Rig {
 
@@ -25,6 +28,73 @@ inline IRComponents::C_JointHierarchy toComponent(const IRAsset::Rig &rig) {
         hierarchy.joints_.push_back(runtime);
     }
     return hierarchy;
+}
+
+// Records with empty names are skipped; later duplicate names win.
+inline IRComponents::C_BindPoints toBindPoints(const IRAsset::Rig &rig) {
+    IRComponents::C_BindPoints bindPoints;
+    bindPoints.points_.reserve(rig.bindPoints_.size());
+    for (const auto &record : rig.bindPoints_) {
+        if (record.name_.empty()) {
+            continue;
+        }
+        IRComponents::BindPointRuntime runtime;
+        runtime.boneId_ = record.boneId_;
+        runtime.offset_ = record.offset_;
+        runtime.rotation_ = record.rotation_;
+        bindPoints.points_[record.name_] = runtime;
+    }
+    return bindPoints;
+}
+
+struct BindPointWorldTransform {
+    IRMath::vec3 offset_{0.0f, 0.0f, 0.0f};
+    IRMath::vec4 rotation_{0.0f, 0.0f, 0.0f, 1.0f};
+};
+
+// Walks chain root-first; (parent == current || parent >= size) sentinel stops malformed cycles.
+inline BindPointWorldTransform worldTransformForBindPoint(
+    const IRComponents::BindPointRuntime &point, const IRComponents::C_JointHierarchy &hierarchy
+) {
+    BindPointWorldTransform world;
+    if (point.boneId_ >= hierarchy.joints_.size()) {
+        world.offset_ = point.offset_;
+        world.rotation_ = point.rotation_;
+        return world;
+    }
+
+    IRMath::vec3 chainTranslation{0.0f, 0.0f, 0.0f};
+    IRMath::vec4 chainRotation{0.0f, 0.0f, 0.0f, 1.0f};
+
+    std::vector<std::uint32_t> chain;
+    chain.reserve(hierarchy.joints_.size());
+    std::uint32_t current = point.boneId_;
+    const std::size_t maxDepth = hierarchy.joints_.size();
+    for (std::size_t step = 0; step < maxDepth; ++step) {
+        chain.push_back(current);
+        const std::uint32_t parent = hierarchy.joints_[current].parentIndex_;
+        if (parent == current || parent >= hierarchy.joints_.size()) {
+            break;
+        }
+        current = parent;
+    }
+
+    for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
+        const auto &joint = hierarchy.joints_[*it];
+        const IRMath::vec3 localTranslation{
+            joint.translation_.x,
+            joint.translation_.y,
+            joint.translation_.z
+        };
+        const IRMath::vec3 rotatedLocal =
+            IRMath::rotateVectorByQuat(localTranslation, chainRotation);
+        chainTranslation = chainTranslation + rotatedLocal;
+        chainRotation = IRMath::quatMul(chainRotation, joint.rotation_);
+    }
+
+    world.offset_ = chainTranslation + IRMath::rotateVectorByQuat(point.offset_, chainRotation);
+    world.rotation_ = IRMath::quatMul(chainRotation, point.rotation_);
+    return world;
 }
 
 inline IRAsset::Rig fromComponent(

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -711,11 +711,42 @@ land:
   (Phase 5 risks) flags this as a design call. Use the `setup`
   callback in the meantime — it lets the prefab call any Lua-bound
   `IREntity.setComponent(entity, C_Foo.new(...))` directly.
-- **`bind_point_overrides = { ... }`** — requires a runtime
-  `C_BindPoints` component. T-171 added the asset-side BIND chunk to
-  `.rig`, but the runtime ECS component + the `entity:bindPoint(name)`
-  Lua accessor are deferred. spawn() loads bind points but does not
-  attach them yet.
+- **`bind_point_overrides = { ... }`** — landed via T-181. The
+  optional `bind_point_overrides` table on a prefab maps names to
+  `{ offset = vec3, rotation = vec4, boneId = uint }` (any subset);
+  spawn() merges the override into the rig's BIND-chunk entry,
+  overwriting only the fields the override specifies. Unknown names
+  are inserted as fresh bind points so a prefab can extend a rig's
+  defaults without re-saving the asset.
+
+  At spawn time, `Prefab.spawn` translates the rig's BIND chunk into
+  a runtime `IRComponents::C_BindPoints` via
+  `IRPrefab::Rig::toBindPoints` and attaches it alongside the
+  `C_JointHierarchy`. Bind-point world transforms are queried via
+  `IREntity.bindPoint(entity, name)` on the `IREntity` table:
+
+  ```lua
+  -- Returns (offset, rotation) as vec3 + vec4 in entity-local
+  -- world space (composed from the joint chain). Returns nil, nil
+  -- if the entity has no C_BindPoints or the named point is absent.
+  local offset, rotation = IREntity.bindPoint(entity, "right_hand")
+  ```
+
+  The composition algorithm walks the bone chain root-first via the
+  `C_JointHierarchy.joints_[].parentIndex_` field, accumulating
+  per-joint local rotations (quaternion multiply, see
+  `IRMath::quatMul`) and translations (rotated by the chain
+  rotation, see `IRMath::rotateVectorByQuat`), then applies the
+  bind point's local offset/rotation on top. If the entity has no
+  `C_JointHierarchy` component, the bind point's local transform
+  is returned as-is.
+
+  Cost contract: `IREntity.bindPoint` performs an
+  `unordered_map<string, ...>` lookup plus an O(chainDepth) walk.
+  Treat as a **one-time query at spawn or on interaction**, not per
+  tick. If a hot use case appears (e.g. attaching a per-tick light
+  to a bind point), pre-resolve the integer bone index at spawn
+  time and cache the offset/rotation in a flat component instead.
 - **DENSE / HYBRID dense voxel_ref attachment** — DENSE per-voxel
   records are loaded and validated but not attached as an ECS
   component. The current `C_VoxelSetNew` constructor allocates

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -29,6 +29,13 @@ target_link_libraries(
     IrredenEngineSystem
     IrredenEngineAsset
 )
+# PRIVATE so render headers don't leak through script's PUBLIC interface
+# (T-188 layering rule). prefab_api.cpp uses IRRender::ShapeType via
+# C_ShapeDescriptor when attaching SHAPES voxel_ref records.
+target_link_libraries(
+    IrredenEngineScripting PRIVATE
+    IrredenEngineRendering
+)
 # Force sol2 to use its try/catch trampoline rather than letting C++
 # exceptions propagate through the LuaJIT VM. With LuaJIT 2.1 sol2's
 # default is exception propagation; in practice the exception message

--- a/engine/script/include/irreden/script/prefab_api.hpp
+++ b/engine/script/include/irreden/script/prefab_api.hpp
@@ -87,13 +87,14 @@ void clearPrefabs();
 ///   `flags_` are copied from the record. Per-record `rotation_` /
 ///   `csgOp_` / `boneId_` are loaded but not stamped onto runtime
 ///   components in v1 (no current renderer consumes them; T-181
-///   wires bone binding). DENSE / HYBRID dense voxel data is loaded
-///   but **not** attached — `C_VoxelSetNew` requires an active
-///   render-canvas pool; the headless attach path is deferred.
-/// - If `rig_ref` is present, loads the `.rig` via `IRAsset::loadRig`
-///   and attaches `C_JointHierarchy` via
-///   `IRPrefab::Rig::toComponent`. Bind-points are loaded but not
-///   attached pending the runtime `C_BindPoints` component.
+///   wires bone binding via `C_BindPoints` below; CSG composition is
+///   a render-pipeline decision). DENSE / HYBRID dense voxel data is
+///   loaded but **not** attached — `C_VoxelSetNew` requires an
+///   active render-canvas pool; the headless attach path is deferred.
+/// - If `rig_ref` is present, loads the `.rig` via `IRAsset::loadRig`,
+///   attaches `C_JointHierarchy` via `IRPrefab::Rig::toComponent`, and
+///   attaches `C_BindPoints` from the rig's BIND chunk (merged with any
+///   `bind_point_overrides` from the prefab table).
 /// - If `setup` is a Lua function, invokes it with the entity wrapped
 ///   as `LuaEntity{entity}`. Lua errors in `setup` propagate as a
 ///   failed `SpawnResult` with the error string forwarded.

--- a/engine/script/include/irreden/script/prefab_api.hpp
+++ b/engine/script/include/irreden/script/prefab_api.hpp
@@ -1,20 +1,7 @@
 #ifndef IR_SCRIPT_PREFAB_API_H
 #define IR_SCRIPT_PREFAB_API_H
 
-/// Lua prefab format — entity template with voxel/rig refs and a setup
-/// callback. Runtime contract and v1 scope: engine/script/CLAUDE.md
-/// "Prefab format".
-///
-/// Lua schema (v1):
-///
-///     return {
-///         prefab_version = 1,                  -- REQUIRED, must be 1
-///         voxel_ref      = "foo.vxs",          -- OPTIONAL, loaded via loadVoxelSet
-///         rig_ref        = "foo.rig",          -- OPTIONAL, loaded via loadRig
-///         setup          = function(entity)    -- OPTIONAL, user-provided
-///             -- IREntity.setComponent(entity, ...)
-///         end,
-///     }
+// Lua prefab API: Prefab.register/spawn — v1 schema and behavioral contract in engine/script/CLAUDE.md "Prefab format".
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -26,82 +13,35 @@
 namespace IRScript {
 class LuaScript;
 namespace detail {
-/// Wire `Prefab.register` and `Prefab.spawn` into `script`'s Lua state.
-/// Idempotent: re-binding overwrites the previous closures.
-/// Called from `LuaScript::bindLuaDrivenEcs()`.
+// Wire Prefab.register and Prefab.spawn into the Lua state; called from bindLuaDrivenEcs().
 void bindPrefabApi(LuaScript &script);
 } // namespace detail
 } // namespace IRScript
 
 namespace IRPrefab::Prefab {
 
-/// v1 of the prefab Lua schema. Older builds reading a v1 prefab load
-/// fine; newer builds reading a future v2 surface a clear diagnostic
-/// rather than misinterpreting the fields.
+// v1 schema version; unknown versions surface a diagnostic rather than silently misinterpreting fields.
 constexpr int kPrefabSchemaVersion = 1;
 
-/// Outcome of `spawnPrefab`. `entity_ == IREntity::kNullEntity` means
-/// the spawn failed for one of the reasons listed in `error_` —
-/// callers should check `entity_` before using it. The id and resolved
-/// path are surfaced for diagnostics regardless of success.
+// Outcome of spawnPrefab; check entity_ != kNullEntity before use.
 struct SpawnResult {
     IREntity::EntityId entity_ = IREntity::kNullEntity;
     std::string id_;
     std::string path_;
-    /// One-line diagnostic when `entity_ == IREntity::kNullEntity`.
-    /// Empty on success. Same string is logged at error level by
-    /// `spawnPrefab` itself; the field exists so call sites (Lua
-    /// bindings, tests) can surface it without re-running the logger.
+    // Non-empty iff entity_ == kNullEntity; same string spawnPrefab logs at error level.
     std::string error_;
 };
 
-/// Add @p id → @p path to the in-process prefab registry. Re-registering
-/// an existing id overwrites the prior path with a log; clearing happens
-/// at process shutdown (no explicit lifetime owner today). Use
-/// `clearPrefabs()` to reset between tests.
+// Re-registering an id overwrites the prior path; clearPrefabs() resets between tests.
 void registerPrefab(std::string id, std::string path);
 
-/// Look up the registered path for @p id. Returns `std::nullopt` if
-/// the id was never registered.
+// Returns nullopt if the id was never registered.
 std::optional<std::string> prefabPath(std::string_view id);
 
-/// Erase every entry from the in-process registry. Test helper; not
-/// exposed to Lua.
+// Test helper; not exposed to Lua.
 void clearPrefabs();
 
-/// Load the prefab Lua file registered under @p id and instantiate it
-/// at @p position. The Lua file is executed via @p script (whose
-/// `sol::state` provides the eval environment); the file must return a
-/// table matching the v1 schema documented at the top of this header.
-///
-/// Behavior:
-/// - Validates `prefab_version == kPrefabSchemaVersion`. Missing or
-///   mismatched versions return `SpawnResult{entity_ = kNullEntity}`
-///   with a `VersionMismatch`-style error string.
-/// - Creates an entity with `C_Position3D(position)`.
-/// - If `voxel_ref` is present, loads the `.vxs` via
-///   `IRAsset::loadVoxelSet`. SHAPES records (and the SHAPES half of
-///   HYBRID files) attach as child entities — one per `ShapeRecord`,
-///   each carrying `C_Position3D(record.offset_)` plus a
-///   `C_ShapeDescriptor` whose `shapeType_` / `params_` / `color_` /
-///   `flags_` are copied from the record. Per-record `rotation_` /
-///   `csgOp_` / `boneId_` are loaded but not stamped onto runtime
-///   components in v1 (no current renderer consumes them; T-181
-///   wires bone binding via `C_BindPoints` below; CSG composition is
-///   a render-pipeline decision). DENSE / HYBRID dense voxel data is
-///   loaded but **not** attached — `C_VoxelSetNew` requires an
-///   active render-canvas pool; the headless attach path is deferred.
-/// - If `rig_ref` is present, loads the `.rig` via `IRAsset::loadRig`,
-///   attaches `C_JointHierarchy` via `IRPrefab::Rig::toComponent`, and
-///   attaches `C_BindPoints` from the rig's BIND chunk (merged with any
-///   `bind_point_overrides` from the prefab table).
-/// - If `setup` is a Lua function, invokes it with the entity wrapped
-///   as `LuaEntity{entity}`. Lua errors in `setup` propagate as a
-///   failed `SpawnResult` with the error string forwarded.
-///
-/// Additive component packs: unknown top-level keys in the prefab
-/// table are silently ignored, so a future schema field doesn't break
-/// older loaders. New required fields bump `kPrefabSchemaVersion`.
+// Load the prefab file registered under id, validate v1 schema, and instantiate at position.
 SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath::vec3 position);
 
 } // namespace IRPrefab::Prefab

--- a/engine/script/src/lua_bindings_prefab.cpp
+++ b/engine/script/src/lua_bindings_prefab.cpp
@@ -21,11 +21,7 @@ void bindPrefabApi(LuaScript &script) {
         IRPrefab::Prefab::registerPrefab(id, path);
     };
 
-    // `Prefab.spawn(id, position)` — accepts the position as either an
-    // `IRMath::vec3` userdata or a `{x, y, z}` table for ergonomics
-    // mirroring `IREntity.create*` patterns. Returns a `LuaEntity`
-    // table on success and `nil` on failure (the error is logged at
-    // C++-side ERROR level and surfaced via the second return value).
+    // Accepts vec3 or {x,y,z}/{1,2,3} table; returns LuaEntity+nil on success, nil+error on failure.
     lua["Prefab"]["spawn"] = [&script](
                                  const std::string &id, sol::object positionObj
                              ) -> std::tuple<sol::object, sol::object> {

--- a/engine/script/src/lua_bindings_prefab.cpp
+++ b/engine/script/src/lua_bindings_prefab.cpp
@@ -11,10 +11,6 @@
 
 namespace IRScript::detail {
 
-/// Wires `Prefab.register(id, path)` and `Prefab.spawn(id, position)`
-/// into `script`'s Lua state. The bound closures forward into the
-/// `IRPrefab::Prefab` C++ API, so the Lua surface stays a thin shim
-/// over the typed entry points.
 void bindPrefabApi(LuaScript &script) {
     sol::state &lua = script.lua();
     if (!lua["Prefab"].valid()) {

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -435,55 +435,11 @@ void LuaScript::bindLuaDrivenEcs() {
 
     m_lua["IRComponent"]["register"] = registerComponent;
 
-    // Register the LuaEntity usertype centrally so every creation /
-    // test that calls bindLuaDrivenEcs() gets the shared instance
-    // method set — including `entity:bindPoint(name)` for prefab bind
-    // points. Creations may still call `registerType<LuaEntity>` after
-    // this to extend or replace the binding (sol2's `new_usertype`
-    // overwrites; we accept that to keep the central registration
-    // simple — creations wanting extra methods can re-register with
-    // the full method set).
     m_lua.new_usertype<IRScript::LuaEntity>(
         "LuaEntity",
         sol::constructors<IRScript::LuaEntity(IREntity::EntityId)>(),
         "entity",
-        &IRScript::LuaEntity::entity,
-        "bindPoint",
-        [](IRScript::LuaEntity self,
-           const std::string &name,
-           sol::this_state L) -> std::tuple<sol::object, sol::object> {
-            sol::state_view sv{L};
-            auto returnNil = [&]() {
-                return std::make_tuple(
-                    sol::make_object(sv, sol::lua_nil),
-                    sol::make_object(sv, sol::lua_nil)
-                );
-            };
-            auto bindPointsOpt =
-                IREntity::getComponentOptional<IRComponents::C_BindPoints>(self.entity);
-            if (!bindPointsOpt.has_value()) {
-                return returnNil();
-            }
-            const auto *bindPoints = bindPointsOpt.value();
-            auto it = bindPoints->points_.find(name);
-            if (it == bindPoints->points_.end()) {
-                return returnNil();
-            }
-            auto hierarchyOpt =
-                IREntity::getComponentOptional<IRComponents::C_JointHierarchy>(self.entity);
-            IRPrefab::Rig::BindPointWorldTransform world;
-            if (hierarchyOpt.has_value()) {
-                world =
-                    IRPrefab::Rig::worldTransformForBindPoint(it->second, *hierarchyOpt.value());
-            } else {
-                world.offset_ = it->second.offset_;
-                world.rotation_ = it->second.rotation_;
-            }
-            return std::make_tuple(
-                sol::make_object(sv, world.offset_),
-                sol::make_object(sv, world.rotation_)
-            );
-        }
+        &IRScript::LuaEntity::entity
     );
 
     if (!m_lua["IREntity"].valid()) {
@@ -526,6 +482,43 @@ void LuaScript::bindLuaDrivenEcs() {
     m_lua["IREntity"]["hasLuaComponent"] = [](IRScript::LuaEntity entity, sol::table componentDef) {
         const IREntity::ComponentId componentId = componentDef.get<lua_Integer>("componentId");
         return IREntity::getEntityManager().hasComponent(entity.entity, componentId);
+    };
+
+    m_lua["IREntity"]["bindPoint"] =
+        [](IRScript::LuaEntity self,
+           const std::string &name,
+           sol::this_state L) -> std::tuple<sol::object, sol::object> {
+        sol::state_view sv{L};
+        auto returnNil = [&]() {
+            return std::make_tuple(
+                sol::make_object(sv, sol::lua_nil),
+                sol::make_object(sv, sol::lua_nil)
+            );
+        };
+        auto bindPointsOpt =
+            IREntity::getComponentOptional<IRComponents::C_BindPoints>(self.entity);
+        if (!bindPointsOpt.has_value()) {
+            return returnNil();
+        }
+        const auto *bindPoints = bindPointsOpt.value();
+        auto it = bindPoints->points_.find(name);
+        if (it == bindPoints->points_.end()) {
+            return returnNil();
+        }
+        auto hierarchyOpt =
+            IREntity::getComponentOptional<IRComponents::C_JointHierarchy>(self.entity);
+        IRPrefab::Rig::BindPointWorldTransform world;
+        if (hierarchyOpt.has_value()) {
+            world =
+                IRPrefab::Rig::worldTransformForBindPoint(it->second, *hierarchyOpt.value());
+        } else {
+            world.offset_ = it->second.offset_;
+            world.rotation_ = it->second.rotation_;
+        }
+        return std::make_tuple(
+            sol::make_object(sv, world.offset_),
+            sol::make_object(sv, world.rotation_)
+        );
     };
 
     // ECS singleton-component lookup. One entity per component type,

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -8,6 +8,9 @@
 #include <irreden/script/lua_modifier_bindings.hpp>
 #include <irreden/script/lua_pipeline_bindings.hpp>
 #include <irreden/script/prefab_api.hpp>
+#include <irreden/voxel/components/component_bind_points.hpp>
+#include <irreden/voxel/components/component_joint_hierarchy.hpp>
+#include <irreden/voxel/rig_bridge.hpp>
 
 #include <deque>
 #include <string>
@@ -431,6 +434,57 @@ void LuaScript::bindLuaDrivenEcs() {
     };
 
     m_lua["IRComponent"]["register"] = registerComponent;
+
+    // Register the LuaEntity usertype centrally so every creation /
+    // test that calls bindLuaDrivenEcs() gets the shared instance
+    // method set — including `entity:bindPoint(name)` for prefab bind
+    // points. Creations may still call `registerType<LuaEntity>` after
+    // this to extend or replace the binding (sol2's `new_usertype`
+    // overwrites; we accept that to keep the central registration
+    // simple — creations wanting extra methods can re-register with
+    // the full method set).
+    m_lua.new_usertype<IRScript::LuaEntity>(
+        "LuaEntity",
+        sol::constructors<IRScript::LuaEntity(IREntity::EntityId)>(),
+        "entity",
+        &IRScript::LuaEntity::entity,
+        "bindPoint",
+        [](IRScript::LuaEntity self,
+           const std::string &name,
+           sol::this_state L) -> std::tuple<sol::object, sol::object> {
+            sol::state_view sv{L};
+            auto returnNil = [&]() {
+                return std::make_tuple(
+                    sol::make_object(sv, sol::lua_nil),
+                    sol::make_object(sv, sol::lua_nil)
+                );
+            };
+            auto bindPointsOpt =
+                IREntity::getComponentOptional<IRComponents::C_BindPoints>(self.entity);
+            if (!bindPointsOpt.has_value()) {
+                return returnNil();
+            }
+            const auto *bindPoints = bindPointsOpt.value();
+            auto it = bindPoints->points_.find(name);
+            if (it == bindPoints->points_.end()) {
+                return returnNil();
+            }
+            auto hierarchyOpt =
+                IREntity::getComponentOptional<IRComponents::C_JointHierarchy>(self.entity);
+            IRPrefab::Rig::BindPointWorldTransform world;
+            if (hierarchyOpt.has_value()) {
+                world =
+                    IRPrefab::Rig::worldTransformForBindPoint(it->second, *hierarchyOpt.value());
+            } else {
+                world.offset_ = it->second.offset_;
+                world.rotation_ = it->second.rotation_;
+            }
+            return std::make_tuple(
+                sol::make_object(sv, world.offset_),
+                sol::make_object(sv, world.rotation_)
+            );
+        }
+    );
 
     if (!m_lua["IREntity"].valid()) {
         m_lua["IREntity"] = m_lua.create_table();

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -172,12 +172,8 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
         IREntity::setComponent(entity, IRPrefab::Rig::toComponent(*loadedRig));
     }
 
-    // Attach C_BindPoints from the loaded rig's BIND chunk, then apply
-    // any `bind_point_overrides` from the prefab table. Overrides target
-    // by name and may rewrite `offset`, `rotation`, and `boneId` (any
-    // subset); unknown names are added as fresh bind points so a prefab
-    // can extend a rig's defaults without re-saving the asset. Overrides
-    // only take effect when the rig's BIND chunk is non-empty.
+    // Attach C_BindPoints from the loaded rig's BIND chunk; apply any bind_point_overrides on top.
+    // Overrides only take effect when the rig's BIND chunk is non-empty (the guard below).
     if (loadedRig && !loadedRig->bindPoints_.empty()) {
         IRComponents::C_BindPoints bindPoints = IRPrefab::Rig::toBindPoints(*loadedRig);
         sol::optional<sol::table> overridesOpt = prefab["bind_point_overrides"];

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -8,11 +8,13 @@
 #include <irreden/ir_render.hpp>
 #include <irreden/script/ir_script_types.hpp>
 #include <irreden/script/lua_script.hpp>
+#include <irreden/voxel/components/component_bind_points.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
 #include <irreden/voxel/rig_bridge.hpp>
 
 #include <sol/sol.hpp>
 
+#include <cstdint>
 #include <exception>
 #include <optional>
 #include <string>
@@ -170,14 +172,56 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
         IREntity::setComponent(entity, IRPrefab::Rig::toComponent(*loadedRig));
     }
 
+    // Attach C_BindPoints from the loaded rig's BIND chunk, then apply
+    // any `bind_point_overrides` from the prefab table. Overrides target
+    // by name and may rewrite `offset`, `rotation`, and `boneId` (any
+    // subset); unknown names are added as fresh bind points so a prefab
+    // can extend a rig's defaults without re-saving the asset. Overrides
+    // only take effect when the rig's BIND chunk is non-empty.
+    if (loadedRig && !loadedRig->bindPoints_.empty()) {
+        IRComponents::C_BindPoints bindPoints = IRPrefab::Rig::toBindPoints(*loadedRig);
+        sol::optional<sol::table> overridesOpt = prefab["bind_point_overrides"];
+        if (overridesOpt) {
+            for (auto &kv : *overridesOpt) {
+                sol::optional<std::string> nameOpt = kv.first.as<sol::optional<std::string>>();
+                if (!nameOpt) {
+                    continue;
+                }
+                if (!kv.second.is<sol::table>()) {
+                    continue;
+                }
+                sol::table desc = kv.second.as<sol::table>();
+                auto existing = bindPoints.points_.find(*nameOpt);
+                IRComponents::BindPointRuntime point = (existing != bindPoints.points_.end())
+                                                           ? existing->second
+                                                           : IRComponents::BindPointRuntime{};
+                sol::optional<std::uint32_t> boneIdOpt = desc["boneId"];
+                if (boneIdOpt) {
+                    point.boneId_ = *boneIdOpt;
+                }
+                sol::optional<IRMath::vec3> offsetOpt = desc["offset"];
+                if (offsetOpt) {
+                    point.offset_ = *offsetOpt;
+                }
+                sol::optional<IRMath::vec4> rotationOpt = desc["rotation"];
+                if (rotationOpt) {
+                    point.rotation_ = *rotationOpt;
+                }
+                bindPoints.points_[*nameOpt] = point;
+            }
+        }
+        IREntity::setComponent(entity, std::move(bindPoints));
+    }
+
     // SHAPES voxel_ref attachment — one child entity per ShapeRecord,
     // CHILD_OF the spawned root so per-record `offset_` composes
     // through the standard C_PositionGlobal3D + C_PositionOffset3D
     // pipeline. Per-record `rotation_`, `csgOp_`, and `boneId_` are
     // persisted but not consumed by the current renderer; loading them
-    // is a no-op until a runtime system reads them (T-181 will wire
-    // bone bindings; CSG composition is a render-side decision). v1
-    // intentionally drops these to avoid stamping unused state.
+    // is a no-op until a runtime system reads them (T-181 wires bone
+    // bindings via C_BindPoints above; CSG composition is a render-side
+    // decision). v1 intentionally drops these to avoid stamping unused
+    // state.
     //
     // DENSE / HYBRID dense data is left unattached — `C_VoxelSetNew`
     // allocates against the active render-canvas pool, and the
@@ -203,10 +247,10 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
     }
 
     // Optional setup function — last so the user sees a fully-formed
-    // entity (position + rig + shape children already attached).
-    // Distinguish "absent" (sol::type::lua_nil) from "present but not
-    // a function" so a schema typo like `setup = 42` surfaces a
-    // diagnostic instead of silently no-op'ing.
+    // entity (position + rig + bind points + shape children already
+    // attached). Distinguish "absent" (sol::type::lua_nil) from
+    // "present but not a function" so a schema typo like `setup = 42`
+    // surfaces a diagnostic instead of silently no-op'ing.
     sol::object setupObj = prefab["setup"];
     if (setupObj.valid() && setupObj.get_type() != sol::type::lua_nil) {
         if (setupObj.get_type() != sol::type::function) {

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -7,6 +7,7 @@
 #include <irreden/ir_render.hpp>
 #include <irreden/script/lua_script.hpp>
 #include <irreden/script/prefab_api.hpp>
+#include <irreden/voxel/components/component_bind_points.hpp>
 #include <irreden/voxel/components/component_joint_hierarchy.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
 
@@ -65,6 +66,31 @@ class PrefabApi : public testing::Test {
   protected:
     PrefabApi() {
         m_lua.bindLuaDrivenEcs();
+        // vec3 / vec4 are bound per-creation (see creations/demos/default/
+        // lua_bindings.cpp); bind a minimal version here so tests can
+        // construct them in Lua bodies and read return-value fields.
+        m_lua.lua().new_usertype<IRMath::vec3>(
+            "vec3",
+            sol::constructors<IRMath::vec3(float, float, float)>(),
+            "x",
+            &IRMath::vec3::x,
+            "y",
+            &IRMath::vec3::y,
+            "z",
+            &IRMath::vec3::z
+        );
+        m_lua.lua().new_usertype<IRMath::vec4>(
+            "vec4",
+            sol::constructors<IRMath::vec4(float, float, float, float)>(),
+            "x",
+            &IRMath::vec4::x,
+            "y",
+            &IRMath::vec4::y,
+            "z",
+            &IRMath::vec4::z,
+            "w",
+            &IRMath::vec4::w
+        );
         IRPrefab::Prefab::clearPrefabs();
     }
 
@@ -75,6 +101,48 @@ class PrefabApi : public testing::Test {
     IRScript::LuaScript m_lua;
     IREntity::EntityManager m_entity_manager;
 };
+
+// Build a rig fixture extended with two named bind points: "root" on joint 0
+// with offset (10, 0, 0), and "tip" on joint 1 with offset (0, 0, 1). The
+// joint chain remains the same shape as `writeFixtureSet` (joint 0 at
+// translation (1,2,3); joint 1 child of 0 at translation (4,5,6); identity
+// rotations).
+PrefabFiles writeBindPointFixtureSet(const std::string &tag, const std::string &prefabBody) {
+    PrefabFiles f;
+    f.voxel_path_ = std::string{kTmpDir} + "/prefab_test_" + tag + ".vxs";
+    f.rig_dir_ = kTmpDir;
+    f.rig_name_ = "prefab_test_" + tag;
+    f.prefab_path_ = std::string{kTmpDir} + "/prefab_test_" + tag + ".prefab.lua";
+
+    std::vector<IRAsset::ShapeRecord> shapes(1);
+    shapes[0].shapeTypeId_ = 0;
+    shapes[0].params_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
+    IRAsset::saveShapeGroup(f.voxel_path_, shapes);
+
+    IRAsset::Rig rig;
+    rig.joints_.resize(2);
+    rig.joints_[0].translation_ = vec4(1.0f, 2.0f, 3.0f, 0.0f);
+    rig.joints_[0].parentIndex_ = 0;
+    rig.joints_[0].name_ = "root";
+    rig.joints_[1].translation_ = vec4(4.0f, 5.0f, 6.0f, 0.0f);
+    rig.joints_[1].parentIndex_ = 0;
+    rig.joints_[1].name_ = "tip_joint";
+
+    rig.bindPoints_.resize(2);
+    rig.bindPoints_[0].boneId_ = 0;
+    rig.bindPoints_[0].offset_ = vec3(10.0f, 0.0f, 0.0f);
+    rig.bindPoints_[0].name_ = "root";
+    rig.bindPoints_[1].boneId_ = 1;
+    rig.bindPoints_[1].offset_ = vec3(0.0f, 0.0f, 1.0f);
+    rig.bindPoints_[1].name_ = "tip";
+
+    IRAsset::saveRig(f.rig_name_, f.rig_dir_, rig);
+
+    std::ofstream out(f.prefab_path_);
+    out << prefabBody;
+
+    return f;
+}
 
 // ---- registry round-trip --------------------------------------------------
 
@@ -339,6 +407,112 @@ TEST_F(PrefabApi, SpawnSkipsShapesAttachmentWhenAbsent) {
     ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
 
     EXPECT_EQ(IREntity::countComponents<IRComponents::C_ShapeDescriptor>(), 0);
+}
+
+// ---- bind points: attach + entity:bindPoint() Lua API ---------------------
+
+TEST_F(PrefabApi, SpawnAttachesBindPointsFromRig) {
+    PrefabFiles f = writeBindPointFixtureSet(
+        "bind_points",
+        std::string{"return { prefab_version = 1, rig_ref = '"} + std::string{kTmpDir} +
+            "/prefab_test_bind_points.rig' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    auto bpOpt = IREntity::getComponentOptional<IRComponents::C_BindPoints>(r.entity_);
+    ASSERT_TRUE(bpOpt.has_value());
+    const auto &bp = *bpOpt.value();
+    ASSERT_EQ(bp.points_.size(), 2u);
+    ASSERT_TRUE(bp.hasPoint("root"));
+    ASSERT_TRUE(bp.hasPoint("tip"));
+    EXPECT_EQ(bp.points_.at("tip").boneId_, 1u);
+    EXPECT_FLOAT_EQ(bp.points_.at("tip").offset_.z, 1.0f);
+}
+
+TEST_F(PrefabApi, BindPointResolvesViaJointChain) {
+    PrefabFiles f = writeBindPointFixtureSet(
+        "bind_resolve",
+        std::string{"return {\n"} +
+            "  prefab_version = 1,\n"
+            "  rig_ref = '" +
+            std::string{kTmpDir} +
+            "/prefab_test_bind_resolve.rig',\n"
+            "  setup = function(entity)\n"
+            "    local off, rot = entity:bindPoint('tip')\n"
+            "    g_off_x, g_off_y, g_off_z = off.x, off.y, off.z\n"
+            "    g_rot_x, g_rot_y, g_rot_z, g_rot_w = rot.x, rot.y, rot.z, rot.w\n"
+            "  end,\n"
+            "}\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    auto &lua = m_lua.lua();
+    // Joint 0 at (1,2,3) identity; joint 1 (child of 0) local (4,5,6)
+    // identity; bp "tip" on joint 1 with offset (0,0,1). World offset
+    // composes to (1+4+0, 2+5+0, 3+6+1) = (5, 7, 10).
+    EXPECT_FLOAT_EQ(lua["g_off_x"].get<float>(), 5.0f);
+    EXPECT_FLOAT_EQ(lua["g_off_y"].get<float>(), 7.0f);
+    EXPECT_FLOAT_EQ(lua["g_off_z"].get<float>(), 10.0f);
+    // Identity rotation propagates unchanged.
+    EXPECT_FLOAT_EQ(lua["g_rot_w"].get<float>(), 1.0f);
+    EXPECT_FLOAT_EQ(lua["g_rot_x"].get<float>(), 0.0f);
+}
+
+TEST_F(PrefabApi, BindPointOverridesApplied) {
+    PrefabFiles f = writeBindPointFixtureSet(
+        "bind_override",
+        std::string{"return {\n"} +
+            "  prefab_version = 1,\n"
+            "  rig_ref = '" +
+            std::string{kTmpDir} +
+            "/prefab_test_bind_override.rig',\n"
+            "  bind_point_overrides = {\n"
+            "    tip = { offset = vec3.new(2, 2, 2) },\n"
+            "  },\n"
+            "  setup = function(entity)\n"
+            "    local off, _ = entity:bindPoint('tip')\n"
+            "    g_off_x, g_off_y, g_off_z = off.x, off.y, off.z\n"
+            "  end,\n"
+            "}\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    auto &lua = m_lua.lua();
+    // Override changes bp.offset from (0,0,1) to (2,2,2). World offset
+    // = chain world (5,7,9) + override (2,2,2) = (7,9,11).
+    EXPECT_FLOAT_EQ(lua["g_off_x"].get<float>(), 7.0f);
+    EXPECT_FLOAT_EQ(lua["g_off_y"].get<float>(), 9.0f);
+    EXPECT_FLOAT_EQ(lua["g_off_z"].get<float>(), 11.0f);
+}
+
+TEST_F(PrefabApi, BindPointMissingReturnsNil) {
+    PrefabFiles f = writeBindPointFixtureSet(
+        "bind_missing",
+        std::string{"return {\n"} +
+            "  prefab_version = 1,\n"
+            "  rig_ref = '" +
+            std::string{kTmpDir} +
+            "/prefab_test_bind_missing.rig',\n"
+            "  setup = function(entity)\n"
+            "    local off, rot = entity:bindPoint('nope')\n"
+            "    g_off_is_nil = (off == nil)\n"
+            "    g_rot_is_nil = (rot == nil)\n"
+            "  end,\n"
+            "}\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    auto &lua = m_lua.lua();
+    EXPECT_TRUE(lua["g_off_is_nil"].get<bool>());
+    EXPECT_TRUE(lua["g_rot_is_nil"].get<bool>());
 }
 
 // ---- additivity: unknown top-level keys do not break the load -------------

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -409,7 +409,7 @@ TEST_F(PrefabApi, SpawnSkipsShapesAttachmentWhenAbsent) {
     EXPECT_EQ(IREntity::countComponents<IRComponents::C_ShapeDescriptor>(), 0);
 }
 
-// ---- bind points: attach + entity:bindPoint() Lua API ---------------------
+// ---- bind points: attach + IREntity.bindPoint() Lua API ---------------------
 
 TEST_F(PrefabApi, SpawnAttachesBindPointsFromRig) {
     PrefabFiles f = writeBindPointFixtureSet(
@@ -440,7 +440,7 @@ TEST_F(PrefabApi, BindPointResolvesViaJointChain) {
             std::string{kTmpDir} +
             "/prefab_test_bind_resolve.rig',\n"
             "  setup = function(entity)\n"
-            "    local off, rot = entity:bindPoint('tip')\n"
+            "    local off, rot = IREntity.bindPoint(entity, 'tip')\n"
             "    g_off_x, g_off_y, g_off_z = off.x, off.y, off.z\n"
             "    g_rot_x, g_rot_y, g_rot_z, g_rot_w = rot.x, rot.y, rot.z, rot.w\n"
             "  end,\n"
@@ -499,7 +499,7 @@ TEST_F(PrefabApi, BindPointResolvesWithNonIdentityParentRotation) {
             << std::string{kTmpDir} << "/" << rigName
             << ".rig',\n"
                "  setup = function(entity)\n"
-               "    local off, rot = entity:bindPoint('end')\n"
+               "    local off, rot = IREntity.bindPoint(entity, 'end')\n"
                "    g_off_x, g_off_y, g_off_z = off.x, off.y, off.z\n"
                "    g_rot_x, g_rot_y, g_rot_z, g_rot_w = rot.x, rot.y, rot.z, rot.w\n"
                "  end,\n"
@@ -534,7 +534,7 @@ TEST_F(PrefabApi, BindPointOverridesApplied) {
             "    tip = { offset = vec3.new(2, 2, 2) },\n"
             "  },\n"
             "  setup = function(entity)\n"
-            "    local off, _ = entity:bindPoint('tip')\n"
+            "    local off, _ = IREntity.bindPoint(entity, 'tip')\n"
             "    g_off_x, g_off_y, g_off_z = off.x, off.y, off.z\n"
             "  end,\n"
             "}\n"
@@ -560,7 +560,7 @@ TEST_F(PrefabApi, BindPointMissingReturnsNil) {
             std::string{kTmpDir} +
             "/prefab_test_bind_missing.rig',\n"
             "  setup = function(entity)\n"
-            "    local off, rot = entity:bindPoint('nope')\n"
+            "    local off, rot = IREntity.bindPoint(entity, 'nope')\n"
             "    g_off_is_nil = (off == nil)\n"
             "    g_rot_is_nil = (rot == nil)\n"
             "  end,\n"

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -462,6 +462,66 @@ TEST_F(PrefabApi, BindPointResolvesViaJointChain) {
     EXPECT_FLOAT_EQ(lua["g_rot_x"].get<float>(), 0.0f);
 }
 
+TEST_F(PrefabApi, BindPointResolvesWithNonIdentityParentRotation) {
+    // Joint 0 (root): translation (0,0,0), 90° rotation around Y axis.
+    // Joint 1 (child of 0): local translation (1,0,0), identity rotation.
+    // Under 90°Y, (1,0,0) → (0,0,-1), so chain translation = (0,0,-1).
+    // Bind point "end" on joint 1, offset (1,0,0) → (0,0,-1) under 90°Y.
+    // Expected world offset = (0,0,-1) + (0,0,-1) = (0,0,-2).
+    constexpr float kS = 0.70710678118f;  // sqrt(2)/2: sin/cos of 45°, the 90°Y quaternion components
+
+    const std::string rigName = "prefab_test_rot_parent";
+    const std::string prefabPath = std::string{kTmpDir} + "/prefab_test_rot_parent.prefab.lua";
+
+    IRAsset::Rig rig;
+    rig.joints_.resize(2);
+    rig.joints_[0].translation_ = vec4(0.0f, 0.0f, 0.0f, 0.0f);
+    rig.joints_[0].rotation_ = vec4(0.0f, kS, 0.0f, kS);  // 90° around Y: (qx=0, qy=kS, qz=0, qw=kS)
+    rig.joints_[0].parentIndex_ = 0;
+    rig.joints_[0].name_ = "root";
+    rig.joints_[1].translation_ = vec4(1.0f, 0.0f, 0.0f, 0.0f);
+    rig.joints_[1].rotation_ = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+    rig.joints_[1].parentIndex_ = 0;
+    rig.joints_[1].name_ = "end_joint";
+
+    rig.bindPoints_.resize(1);
+    rig.bindPoints_[0].boneId_ = 1;
+    rig.bindPoints_[0].offset_ = vec3(1.0f, 0.0f, 0.0f);
+    rig.bindPoints_[0].name_ = "end";
+
+    IRAsset::saveRig(rigName, kTmpDir, rig);
+
+    {
+        std::ofstream out(prefabPath);
+        out << "return {\n"
+               "  prefab_version = 1,\n"
+               "  rig_ref = '"
+            << std::string{kTmpDir} << "/" << rigName
+            << ".rig',\n"
+               "  setup = function(entity)\n"
+               "    local off, rot = entity:bindPoint('end')\n"
+               "    g_off_x, g_off_y, g_off_z = off.x, off.y, off.z\n"
+               "    g_rot_x, g_rot_y, g_rot_z, g_rot_w = rot.x, rot.y, rot.z, rot.w\n"
+               "  end,\n"
+               "}\n";
+    }
+
+    IRPrefab::Prefab::registerPrefab("p", prefabPath);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    auto &lua = m_lua.lua();
+    constexpr float kEps = 1e-5f;
+    EXPECT_NEAR(lua["g_off_x"].get<float>(), 0.0f, kEps);
+    EXPECT_NEAR(lua["g_off_y"].get<float>(), 0.0f, kEps);
+    EXPECT_NEAR(lua["g_off_z"].get<float>(), -2.0f, kEps);
+    // World rotation = 90°Y: (qx=0, qy=kS, qz=0, qw=kS).
+    EXPECT_NEAR(lua["g_rot_x"].get<float>(), 0.0f, kEps);
+    EXPECT_NEAR(lua["g_rot_y"].get<float>(), kS, kEps);
+    EXPECT_NEAR(lua["g_rot_z"].get<float>(), 0.0f, kEps);
+    EXPECT_NEAR(lua["g_rot_w"].get<float>(), kS, kEps);
+}
+
 TEST_F(PrefabApi, BindPointOverridesApplied) {
     PrefabFiles f = writeBindPointFixtureSet(
         "bind_override",


### PR DESCRIPTION
## Summary
- New runtime ECS component `C_BindPoints` stores `unordered_map<name, {boneId, offset, rotation}>` mirroring `IRAsset::RigBindPoint`.
- `IRPrefab::Rig::toBindPoints(asset::Rig)` bridge alongside existing `toComponent/fromComponent`.
- `Prefab.spawn` attaches `C_BindPoints` from `rig_ref` automatically and applies `bind_point_overrides` from the prefab table.
- `LuaEntity:bindPoint("name")` Lua method composes joint-chain world transform from `C_JointHierarchy` and the bind point's local offset/rotation; returns `(vec3 offset, vec4 rotation)`.
- Adds `IRMath::quatMul` and `IRMath::rotateVectorByQuat` wrappers.

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/703 (T-173 — Prefab.spawn API)
Resolves: #700

## Test plan
- [ ] `fleet-build --target IRShapeDebug` clean
- [ ] `fleet-build --target IrredenEngineTest` clean
- [ ] Round-trip test in `test/script/prefab_api_test.cpp`: register prefab with named bind points; spawn; verify `entity:bindPoint('tip')` matches expected joint-chain transform; verify override changes the result

Closes #700