### PR TITLE
T-188: script: decouple IrredenEngineScripting from IrredenEngineRendering

### DIFF
--- a/engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp
@@ -20,10 +20,11 @@
 //      apply parent-chain rotation/translation to voxel positions.
 //   4. Create a demo entity with joints (e.g. a 3-joint articulated arm
 //      oscillating sinusoidally) to test the full pipeline.
-// DEPENDENCIES: IRRender (GPUJointTransform), IRMath (vec4).
+// DEPENDENCIES: IRMath (vec4).
+// GPU conversion (GPUJointTransform) lives in joint_hierarchy_gpu.hpp — include
+// that header only in files that explicitly depend on IRRender.
 
 #include <irreden/ir_math.hpp>
-#include <irreden/render/ir_render_types.hpp>
 
 #include <vector>
 
@@ -62,18 +63,6 @@ struct C_JointHierarchy {
         }
     }
 
-    std::vector<IRRender::GPUJointTransform> toGPUFormat() const {
-        std::vector<IRRender::GPUJointTransform> gpu;
-        gpu.reserve(joints_.size());
-        for (const auto &j : joints_) {
-            IRRender::GPUJointTransform t{};
-            t.rotation = j.rotation_;
-            t.translation = j.translation_;
-            t.parentJointIndex = j.parentIndex_;
-            gpu.push_back(t);
-        }
-        return gpu;
-    }
 };
 
 } // namespace IRComponents

--- a/engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp
@@ -2,10 +2,8 @@
 #define COMPONENT_JOINT_HIERARCHY_H
 
 // PURPOSE: Per-entity joint tree for skeletal-style procedural animation.
-//   Each joint has a rotation quaternion (vec4), translation, and parent
-//   index. Converts to GPUJointTransform for upload to the JointBuffer
-//   SSBO (binding 21) consumed by the shapes compute shader.
-// STATUS: WIP stub -- component defined with toGPUFormat() but:
+//   Each joint has a rotation quaternion (vec4), translation, and parent index.
+// STATUS: WIP stub -- system integration pending:
 //   - No system reads or writes joint data.
 //   - system_shapes_to_trixel.hpp creates the JointTransformBuffer SSBO
 //     but never uploads data; c_shapes_to_trixel.glsl declares JointBuffer
@@ -20,9 +18,7 @@
 //      apply parent-chain rotation/translation to voxel positions.
 //   4. Create a demo entity with joints (e.g. a 3-joint articulated arm
 //      oscillating sinusoidally) to test the full pipeline.
-// DEPENDENCIES: IRMath (vec4).
-// GPU conversion (GPUJointTransform) lives in joint_hierarchy_gpu.hpp — include
-// that header only in files that explicitly depend on IRRender.
+// DEPENDENCIES: IRMath (vec4). GPU conversion lives in joint_hierarchy_gpu.hpp.
 
 #include <irreden/ir_math.hpp>
 

--- a/engine/prefabs/irreden/voxel/joint_hierarchy_gpu.hpp
+++ b/engine/prefabs/irreden/voxel/joint_hierarchy_gpu.hpp
@@ -1,12 +1,7 @@
 #ifndef IR_PREFAB_VOXEL_JOINT_HIERARCHY_GPU_H
 #define IR_PREFAB_VOXEL_JOINT_HIERARCHY_GPU_H
 
-/// GPU-format conversion for C_JointHierarchy.
-///
-/// Kept separate from component_joint_hierarchy.hpp so that the component
-/// header (included by prefab_api.cpp and rig_bridge.hpp, which live in the
-/// scripting layer) does not pull in IRRender types. Only files that
-/// explicitly depend on IrredenEngineRendering should include this header.
+// GPU-format bridge for C_JointHierarchy; include only in files that link IrredenEngineRendering.
 
 #include <irreden/voxel/components/component_joint_hierarchy.hpp>
 #include <irreden/render/ir_render_types.hpp>
@@ -15,9 +10,6 @@
 
 namespace IRPrefab::Rig {
 
-/// Convert a runtime C_JointHierarchy to a flat GPU upload buffer.
-/// Joint order is preserved; the resulting vector maps 1:1 to the
-/// JointTransformBuffer SSBO slots consumed by c_shapes_to_trixel.
 inline std::vector<IRRender::GPUJointTransform>
 toGPUFormat(const IRComponents::C_JointHierarchy &h) {
     std::vector<IRRender::GPUJointTransform> gpu;

--- a/engine/prefabs/irreden/voxel/joint_hierarchy_gpu.hpp
+++ b/engine/prefabs/irreden/voxel/joint_hierarchy_gpu.hpp
@@ -1,0 +1,37 @@
+#ifndef IR_PREFAB_VOXEL_JOINT_HIERARCHY_GPU_H
+#define IR_PREFAB_VOXEL_JOINT_HIERARCHY_GPU_H
+
+/// GPU-format conversion for C_JointHierarchy.
+///
+/// Kept separate from component_joint_hierarchy.hpp so that the component
+/// header (included by prefab_api.cpp and rig_bridge.hpp, which live in the
+/// scripting layer) does not pull in IRRender types. Only files that
+/// explicitly depend on IrredenEngineRendering should include this header.
+
+#include <irreden/voxel/components/component_joint_hierarchy.hpp>
+#include <irreden/render/ir_render_types.hpp>
+
+#include <vector>
+
+namespace IRPrefab::Rig {
+
+/// Convert a runtime C_JointHierarchy to a flat GPU upload buffer.
+/// Joint order is preserved; the resulting vector maps 1:1 to the
+/// JointTransformBuffer SSBO slots consumed by c_shapes_to_trixel.
+inline std::vector<IRRender::GPUJointTransform>
+toGPUFormat(const IRComponents::C_JointHierarchy &h) {
+    std::vector<IRRender::GPUJointTransform> gpu;
+    gpu.reserve(h.joints_.size());
+    for (const auto &j : h.joints_) {
+        IRRender::GPUJointTransform t{};
+        t.rotation = j.rotation_;
+        t.translation = j.translation_;
+        t.parentJointIndex = j.parentIndex_;
+        gpu.push_back(t);
+    }
+    return gpu;
+}
+
+} // namespace IRPrefab::Rig
+
+#endif /* IR_PREFAB_VOXEL_JOINT_HIERARCHY_GPU_H */

--- a/engine/prefabs/irreden/voxel/rig_bridge.hpp
+++ b/engine/prefabs/irreden/voxel/rig_bridge.hpp
@@ -1,18 +1,7 @@
 #ifndef IR_PREFAB_VOXEL_RIG_BRIDGE_H
 #define IR_PREFAB_VOXEL_RIG_BRIDGE_H
 
-/// Translate between the asset-side `IRAsset::Rig` (on-disk, designer-
-/// facing — carries per-joint names) and the runtime
-/// `IRComponents::C_JointHierarchy` (ECS-resident, GPU-feeding — no names
-/// because names are not needed at draw time). The split keeps
-/// `engine/asset/` independent of the prefab voxel component (asset has
-/// no dependency on prefabs) while still letting an editor or load path
-/// produce a `C_JointHierarchy` directly from a `.rig` round-trip.
-///
-/// Pattern is the same shape as `engine/prefabs/irreden/render/fog_of_war.hpp`
-/// (`engine/prefabs/CLAUDE.md` §"Component method rules", "Prefab-scoped
-/// namespace") — the bridge owns the cross-type translation logic so
-/// callers don't have to hand-roll it.
+// IRAsset::Rig ↔ IRComponents::C_JointHierarchy bridge — keeps engine/asset/ free of prefab dependencies.
 
 #include <irreden/asset/rig_format.hpp>
 
@@ -25,9 +14,6 @@
 
 namespace IRPrefab::Rig {
 
-/// Build a runtime `C_JointHierarchy` from an asset `IRAsset::Rig`.
-/// Joint order is preserved; names are dropped (the runtime component
-/// has no name field — see `component_joint_hierarchy.hpp`).
 inline IRComponents::C_JointHierarchy toComponent(const IRAsset::Rig &rig) {
     IRComponents::C_JointHierarchy hierarchy;
     hierarchy.joints_.reserve(rig.joints_.size());
@@ -41,11 +27,6 @@ inline IRComponents::C_JointHierarchy toComponent(const IRAsset::Rig &rig) {
     return hierarchy;
 }
 
-/// Build an asset `IRAsset::Rig` from a runtime `C_JointHierarchy`.
-/// @p jointNames is paired by index; pass an empty span to leave every
-/// joint name blank. Names shorter than the joint count default the
-/// remaining names to empty strings, so partial-name authoring
-/// (root-named, children anonymous) costs nothing.
 inline IRAsset::Rig fromComponent(
     const IRComponents::C_JointHierarchy &hierarchy, std::span<const std::string> jointNames = {}
 ) {

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -28,7 +28,6 @@ target_link_libraries(
     IrredenEngineEntity
     IrredenEngineSystem
     IrredenEngineAsset
-    IrredenEngineRendering
 )
 # Force sol2 to use its try/catch trampoline rather than letting C++
 # exceptions propagate through the LuaJIT VM. With LuaJIT 2.1 sol2's

--- a/test/asset/rig_format_test.cpp
+++ b/test/asset/rig_format_test.cpp
@@ -4,6 +4,7 @@
 #include <irreden/asset/chunk_header.hpp>
 #include <irreden/asset/rig_format.hpp>
 #include <irreden/voxel/components/component_joint_hierarchy.hpp>
+#include <irreden/voxel/joint_hierarchy_gpu.hpp>
 #include <irreden/voxel/rig_bridge.hpp>
 
 #include <cstdint>
@@ -257,8 +258,8 @@ TEST(RigFormat, GPUMatrixParityAfterRoundTrip) {
     const IRComponents::C_JointHierarchy roundTripped =
         IRPrefab::Rig::toComponent(loadedRig.value_);
 
-    const auto gpuBefore = original.toGPUFormat();
-    const auto gpuAfter = roundTripped.toGPUFormat();
+    const auto gpuBefore = IRPrefab::Rig::toGPUFormat(original);
+    const auto gpuAfter = IRPrefab::Rig::toGPUFormat(roundTripped);
     ASSERT_EQ(gpuBefore.size(), gpuAfter.size());
     EXPECT_EQ(
         0,


### PR DESCRIPTION
## Summary
- `C_JointHierarchy::toGPUFormat()` returned `IRRender::GPUJointTransform`, forcing `component_joint_hierarchy.hpp` to include `ir_render_types.hpp`
- `prefab_api.cpp` (scripting layer) included `rig_bridge.hpp` → `component_joint_hierarchy.hpp` → `ir_render_types.hpp`, causing `IrredenEngineScripting` to link `IrredenEngineRendering` — a layering violation since script is lower-level than render
- Fix: remove `toGPUFormat()` from the component and drop the render-types include from `component_joint_hierarchy.hpp`; add `joint_hierarchy_gpu.hpp` with `IRPrefab::Rig::toGPUFormat()` as a free function for callers that explicitly depend on render; update `rig_format_test.cpp` accordingly; remove `IrredenEngineRendering` from the scripting CMakeLists

## Test plan
- [x] `IrredenEngineTest` builds cleanly
- [x] All 15 `RigFormat.*` tests pass, including `GPUMatrixParityAfterRoundTrip`
- [x] `IRShapeDebug` builds cleanly

Closes #709