### PR TITLE
T-186: test: JsonSidecarWriter + NameTable round-trips

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(IrredenEngineTest
   asset/binary_io_test.cpp
+  asset/json_sidecar_test.cpp
+  asset/name_table_test.cpp
   asset/rig_format_test.cpp
   asset/sprite_sheet_test.cpp
   asset/txl_sidecar_test.cpp

--- a/test/asset/json_sidecar_test.cpp
+++ b/test/asset/json_sidecar_test.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+#include <irreden/asset/json_sidecar.hpp>
+
+#include <limits>
+#include <string>
+
+namespace {
+
+using namespace IRAsset;
+
+TEST(JsonSidecar, EmptyObject) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.endObject();
+    EXPECT_EQ(j.str(), "{}");
+}
+
+TEST(JsonSidecar, EmptyArray) {
+    JsonSidecarWriter j;
+    j.beginArray();
+    j.endArray();
+    EXPECT_EQ(j.str(), "[]");
+}
+
+TEST(JsonSidecar, ControlCharactersEscapedAsUnicode) {
+    // Chars not handled by named escapes but in U+0000–U+001F emit \uXXXX.
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("nul");
+    j.valueString(std::string(1, '\x00'));  // U+0000 — null byte
+    j.key("esc");
+    j.valueString(std::string(1, '\x1b'));  // U+001B — ESC
+    j.key("us");
+    j.valueString(std::string(1, '\x1f'));  // U+001F — unit separator
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("\\u0000"), std::string::npos);
+    EXPECT_NE(out.find("\\u001b"), std::string::npos);
+    EXPECT_NE(out.find("\\u001f"), std::string::npos);
+}
+
+TEST(JsonSidecar, NumericEdgeCases) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("uint_max");
+    j.valueUInt(std::numeric_limits<std::uint64_t>::max());
+    j.key("int_min");
+    j.valueInt(std::numeric_limits<std::int64_t>::min());
+    j.key("neg");
+    j.valueInt(-1);
+    j.key("pos_zero");
+    j.valueFloat(+0.0);
+    j.key("neg_zero");
+    j.valueFloat(-0.0);
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("18446744073709551615"), std::string::npos);
+    EXPECT_NE(out.find("-9223372036854775808"), std::string::npos);
+    EXPECT_NE(out.find("-1"), std::string::npos);
+    // Both zeros are finite: must not emit "null".
+    EXPECT_EQ(out.find("\"pos_zero\": null"), std::string::npos);
+    EXPECT_EQ(out.find("\"neg_zero\": null"), std::string::npos);
+}
+
+TEST(JsonSidecar, InfinityEmitsNull) {
+    // Infinity is not valid JSON; like NaN, the writer emits null.
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("pos_inf");
+    j.valueFloat(std::numeric_limits<double>::infinity());
+    j.key("neg_inf");
+    j.valueFloat(-std::numeric_limits<double>::infinity());
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("\"pos_inf\": null"), std::string::npos);
+    EXPECT_NE(out.find("\"neg_inf\": null"), std::string::npos);
+    EXPECT_EQ(out.find("Infinity"), std::string::npos);
+    EXPECT_EQ(out.find("infinity"), std::string::npos);
+}
+
+TEST(JsonSidecar, KeyOrderPreserved) {
+    // Keys appear in insertion order — sidecars are PR-diffable.
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("c"); j.valueInt(3);
+    j.key("a"); j.valueInt(1);
+    j.key("b"); j.valueInt(2);
+    j.endObject();
+    const std::string out = j.str();
+    const auto c_pos = out.find("\"c\"");
+    const auto a_pos = out.find("\"a\"");
+    const auto b_pos = out.find("\"b\"");
+    ASSERT_NE(c_pos, std::string::npos);
+    ASSERT_NE(a_pos, std::string::npos);
+    ASSERT_NE(b_pos, std::string::npos);
+    EXPECT_LT(c_pos, a_pos);
+    EXPECT_LT(a_pos, b_pos);
+}
+
+TEST(JsonSidecar, WriteToFileFailsForBadPath) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("x"); j.valueInt(1);
+    j.endObject();
+    EXPECT_FALSE(writeJsonSidecarToFile("/nonexistent_ir_dir/ir_test_sidecar.json", j.str()));
+}
+
+} // namespace

--- a/test/asset/name_table_test.cpp
+++ b/test/asset/name_table_test.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/name_table.hpp>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace IRAsset;
+
+TEST(NameTable, Utf8NamesRoundTrip) {
+    // Name strings are UTF-8 (Rule #2). Non-ASCII bytes survive the round-trip.
+    std::vector<NameTableEntry> entries = {
+        {0, "caf\xc3\xa9"},         // "café" in UTF-8
+        {1, "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"}, // "日本語" in UTF-8
+        {2, "\xf0\x9f\xa6\x80"},    // "🦀" (crab emoji) in UTF-8
+    };
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), 3u);
+    EXPECT_EQ(loaded.value_[0].name_, entries[0].name_);
+    EXPECT_EQ(loaded.value_[1].name_, entries[1].name_);
+    EXPECT_EQ(loaded.value_[2].name_, entries[2].name_);
+}
+
+TEST(NameTable, DuplicateNameFirstWins) {
+    // add() uses emplace; duplicate name → first id wins in the name→id map.
+    NameTable nt;
+    nt.add(0, "SPHERE");
+    nt.add(1, "SPHERE");
+    EXPECT_EQ(nt.idByName("SPHERE").value(), 0u);
+    EXPECT_EQ(nt.size(), 2u);
+}
+
+TEST(NameTable, DuplicateIdFirstWins) {
+    // add() uses emplace; duplicate id → first name wins in the id→name map.
+    NameTable nt;
+    nt.add(5, "FIRST");
+    nt.add(5, "SECOND");
+    EXPECT_EQ(nt.nameById(5).value(), "FIRST");
+    EXPECT_EQ(nt.size(), 2u);
+}
+
+TEST(NameTable, SpanConstructorMatchesSequentialAdd) {
+    // Both construction paths produce identical lookup results.
+    std::vector<NameTableEntry> entries = {
+        {0, "SPHERE"},
+        {1, "CUBE"},
+        {7, "CYLINDER"},
+    };
+    NameTable from_span(entries);
+    NameTable from_add;
+    for (const auto &e : entries) {
+        from_add.add(e.id_, e.name_);
+    }
+    for (const auto &e : entries) {
+        EXPECT_EQ(from_span.idByName(e.name_), from_add.idByName(e.name_)) << e.name_;
+        EXPECT_EQ(from_span.nameById(e.id_), from_add.nameById(e.id_)) << e.id_;
+    }
+    EXPECT_EQ(from_span.size(), from_add.size());
+}
+
+TEST(NameTable, EmptyNameStringRoundTrip) {
+    // Empty name string is not forbidden; lock the round-trip and lookup behavior.
+    std::vector<NameTableEntry> entries = {{42, ""}};
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), 1u);
+    EXPECT_EQ(loaded.value_[0].id_, 42u);
+    EXPECT_EQ(loaded.value_[0].name_, "");
+    NameTable nt(loaded.value_);
+    EXPECT_EQ(nt.idByName("").value(), 42u);
+    EXPECT_EQ(nt.nameById(42).value(), "");
+}
+
+TEST(NameTable, SingleEntryRoundTrip) {
+    std::vector<NameTableEntry> entries = {{3, "TORUS"}};
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), 1u);
+    EXPECT_EQ(loaded.value_[0].id_, 3u);
+    EXPECT_EQ(loaded.value_[0].name_, "TORUS");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Adds `test/asset/json_sidecar_test.cpp` with 7 focused tests for `JsonSidecarWriter` edge cases not covered in `binary_io_test.cpp`: empty object/array, control-character `\uXXXX` encoding, numeric extremes (UINT64_MAX, INT64_MIN, ±0.0), Inf→null contract, key-order preservation, and `writeJsonSidecarToFile` failure path.
- Adds `test/asset/name_table_test.cpp` with 6 focused tests for `NameTable`: UTF-8 name round-trip, duplicate-name/id first-wins semantics, span-constructor vs sequential-add parity, empty name string round-trip, single-entry round-trip.
- Both files registered in `test/CMakeLists.txt`; 22/22 tests pass.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` — clean build
- [x] `fleet-run IrredenEngineTest --gtest_filter="JsonSidecar.*:NameTable.*"` — 22/22 PASSED
- [ ] Linux smoke (fleet:needs-linux-smoke will be added by reviewer if needed)

Closes #707