### PR TITLE
T-190: SDF→trixel half-voxel/lone-trixel discrepancy investigation

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -453,6 +453,52 @@ of the lighting pass. Invoke from a creation via the engine API
 (`IRRender::setDebugOverlay`) or in `shape_debug` via
 `--debug-overlay <none|ao|light_level|shadow>`.
 
+## SDF (`SHAPES_TO_TRIXEL`) vs voxel-pool (`VOXEL_TO_TRIXEL_*`) parity
+
+A `C_ShapeDescriptor` (SDF, GPU-evaluated) and a `C_VoxelSetNew` carved
+from the same SDF (CPU-quantized at construction) are intentionally NOT
+trixel-for-trixel identical at every render configuration. The
+relationship varies by `SubdivisionMode`:
+
+- **`NONE` / `POSITION_ONLY` and `SMOOTH` at effective `sub == 1`** —
+  bit-identical at the silhouette. The SDF shader skips the analytical
+  surface solver entirely and routes through `snapLatticeWalk`
+  (`c_shapes_to_trixel.glsl` `smoothMode = (renderMode != 0) &&
+  (subdivisions > 1)` — the `subdivisions > 1` half of that gate
+  was added in commit 87d2b681 so `sub == 1` falls back to the
+  parity-gated lattice walk instead of the analytical 2x3 emit
+  that aliased against the voxel-pool tiling). The walk only
+  evaluates iso pixels with `(isoRel.x + isoRel.y) & 1 == 0` — the same
+  even-parity set integer voxels project to — and rounds each candidate
+  via `roundHalfUp` to the same integer voxel the CPU carve evaluates.
+  The SDF surface check uses `<= 0.5` with no bias, matching CPU's
+  `> kSurfaceThreshold` exclusion exactly.
+- **`SMOOTH` at `sub > 1`** — silhouette differs by design. The SDF
+  shader runs `findSurfaceDepth` analytically: each iso sub-pixel solves
+  for the smooth surface depth, producing a continuous (sub-pixel)
+  silhouette. The voxel pool runs `faceMicroPositionFixed` over `sub²`
+  micro-positions per active voxel, producing a stair-stepped silhouette
+  that snaps to the discrete carved voxel set scaled up by `sub`. At any
+  given silhouette iso pixel one path may emit where the other doesn't
+  — that's the "lone trixel" / "half-extent voxel" effect on a
+  side-by-side comparison. It is NOT a bug; it is the entire reason
+  smooth mode has two implementations.
+
+The `kSdfBiasEpsilon` (1e-3) used in the analytical surface check
+(`sdf <= 0.5 + kSdfBiasEpsilon`) is for FMA-noise stability across
+frames at integer-edge depths, not a deliberate widening of the surface
+shell. It can keep one extra sub-pixel column at borderline analytical
+hits where the CPU carve drops; the visual effect is bounded by the
+epsilon and only visible at static analysis with a per-pixel diff.
+
+If you need bit-identical voxel-pool output from a `C_ShapeDescriptor`,
+the only correct configuration is `SubdivisionMode::NONE` (or any
+`sub == 1` configuration) where both paths route through the same
+parity-gated lattice walk. At higher subdivisions, choose the path
+based on intent: voxel pool for "cubes-of-cubes" stylization, SDF for
+smooth analytical silhouettes. The lighting demo's `kShots[]`
+zoom8/zoom16 captures showcase the difference for visual reference.
+
 ## Gotchas
 
 - **Hardcoded uniform-buffer bind points.** Indices like

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -457,32 +457,35 @@ of the lighting pass. Invoke from a creation via the engine API
 
 A `C_ShapeDescriptor` (SDF, GPU-evaluated) and a `C_VoxelSetNew` carved
 from the same SDF (CPU-quantized at construction) are intentionally NOT
-trixel-for-trixel identical at every render configuration. The
-relationship varies by `SubdivisionMode`:
+trixel-for-trixel identical at every render configuration. The SDF
+shader's `smoothMode` gate (`c_shapes_to_trixel.glsl`:
+`smoothMode = (renderMode != 0) && (subdivisions > 1)` — `renderMode`
+is the `SubdivisionMode` enum value, 0 = `NONE`, 1 = `POSITION_ONLY`,
+2 = `FULL`) selects between two paths:
 
-- **`NONE` / `POSITION_ONLY` and `SMOOTH` at effective `sub == 1`** —
-  bit-identical at the silhouette. The SDF shader skips the analytical
-  surface solver entirely and routes through `snapLatticeWalk`
-  (`c_shapes_to_trixel.glsl` `smoothMode = (renderMode != 0) &&
-  (subdivisions > 1)` — the `subdivisions > 1` half of that gate
-  was added in commit 87d2b681 so `sub == 1` falls back to the
-  parity-gated lattice walk instead of the analytical 2x3 emit
-  that aliased against the voxel-pool tiling). The walk only
-  evaluates iso pixels with `(isoRel.x + isoRel.y) & 1 == 0` — the same
-  even-parity set integer voxels project to — and rounds each candidate
-  via `roundHalfUp` to the same integer voxel the CPU carve evaluates.
-  The SDF surface check uses `<= 0.5` with no bias, matching CPU's
-  `> kSurfaceThreshold` exclusion exactly.
-- **`SMOOTH` at `sub > 1`** — silhouette differs by design. The SDF
-  shader runs `findSurfaceDepth` analytically: each iso sub-pixel solves
-  for the smooth surface depth, producing a continuous (sub-pixel)
-  silhouette. The voxel pool runs `faceMicroPositionFixed` over `sub²`
+- **`smoothMode == false`** — `SubdivisionMode::NONE` always, or
+  `POSITION_ONLY` / `FULL` with effective `sub == 1`. Bit-identical to
+  the voxel pool at the silhouette. The SDF shader skips the analytical
+  surface solver and routes through `snapLatticeWalk`. (The
+  `subdivisions > 1` half of the gate was added in commit 87d2b681 so
+  `sub == 1` falls back to the parity-gated lattice walk instead of the
+  analytical 2x3 emit that aliased against the voxel-pool tiling.) The
+  walk only evaluates iso pixels with `(isoRel.x + isoRel.y) & 1 == 0`
+  — the same even-parity set integer voxels project to — and rounds
+  each candidate via `roundHalfUp` to the same integer voxel the CPU
+  carve evaluates. The SDF surface check uses `<= 0.5` with no bias,
+  matching CPU's `> kSurfaceThreshold` exclusion exactly.
+- **`smoothMode == true`** — `POSITION_ONLY` or `FULL` with effective
+  `sub > 1`. Silhouette differs by design. The SDF shader runs
+  `findSurfaceDepth` analytically: each iso sub-pixel solves for the
+  smooth surface depth, producing a continuous (sub-pixel) silhouette.
+  The voxel pool runs `faceMicroPositionFixed` over `sub²`
   micro-positions per active voxel, producing a stair-stepped silhouette
   that snaps to the discrete carved voxel set scaled up by `sub`. At any
   given silhouette iso pixel one path may emit where the other doesn't
   — that's the "lone trixel" / "half-extent voxel" effect on a
   side-by-side comparison. It is NOT a bug; it is the entire reason
-  smooth mode has two implementations.
+  the smooth analytical path exists alongside the voxel-pool path.
 
 The `kSdfBiasEpsilon` (1e-3) used in the analytical surface check
 (`sdf <= 0.5 + kSdfBiasEpsilon`) is for FMA-noise stability across


### PR DESCRIPTION
## Summary
- Investigates the SDF→trixel vs voxel-pool→trixel discrepancy raised on PR #659.
- Concludes the silhouette difference at smooth-mode (sub > 1) is by design, not a bug.
- Documents the parity contract by `SubdivisionMode` in `engine/render/CLAUDE.md` so the next person doesn't re-investigate.

## What's actually happening

Two paths exist for getting an SDF onto the canvas:

| Mode | SDF (`SHAPES_TO_TRIXEL`) | Voxel pool (`VOXEL_TO_TRIXEL_*`) | Match? |
|------|--------------------------|-----------------------------------|--------|
| `sub == 1` (any render mode) | `snapLatticeWalk` — parity-gated, `roundHalfUp` to voxel, `sdf <= 0.5` no bias | Integer voxel projection at carve-set | bit-identical |
| `sub > 1` (smooth mode) | `findSurfaceDepth` — analytical solver, sub-pixel surface | `faceMicroPositionFixed` — `sub²` micro-emits per active voxel | by-design difference |

At smooth mode `sub > 1` the SDF renders the smooth analytical surface; the voxel pool renders the discrete carved voxel set scaled up. The "lone trixel" / "half-extent voxel" pattern visible in the lighting demo's zoom8/zoom16 captures is the difference between these two surface representations — exactly what smooth mode exists to provide. Forcing the SDF to match the voxel pool's stair-stepped silhouette would defeat the purpose of having an analytical path at all.

The `kSdfBiasEpsilon` (1e-3) used in the analytical surface check is for FMA-noise stability, not a deliberate widening — it can keep one extra sub-pixel column at borderline analytical hits where the CPU carve drops, but the visual effect is bounded by the epsilon and only visible at static analysis with a per-pixel diff.

## Resolution

Per the task acceptance ("Either a fix PR that eliminates the discrepancy, or a CLAUDE.md note in `engine/render/` documenting the intentional difference and its source"), this PR takes the documentation path. New section added in `engine/render/CLAUDE.md` covers:

- Threshold (`kSdfBiasEpsilon = 1e-3`) and its role
- Solver paths (`snapLatticeWalk` vs `findSurfaceDepth`) per `SubdivisionMode`
- The exact condition under which both paths are bit-identical (`sub == 1`)
- Where to look for visual reference (lighting demo `kShots[]`)

## Test plan
- [x] No code changed; doc-only diff
- [x] All cited identifiers verified present in tree (`snapLatticeWalk`, `findSurfaceDepth`, `roundHalfUp`, `faceMicroPositionFixed`, `kSurfaceThreshold`, `kSdfBiasEpsilon`, `SubdivisionMode::NONE`, commit `87d2b681`)

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)