### PR TITLE
T-186: test: JsonSidecarWriter + NameTable round-trips

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(IrredenEngineTest
   asset/binary_io_test.cpp
+  asset/json_sidecar_test.cpp
+  asset/name_table_test.cpp
   asset/rig_format_test.cpp
   asset/sprite_sheet_test.cpp
   asset/txl_sidecar_test.cpp

--- a/test/asset/json_sidecar_test.cpp
+++ b/test/asset/json_sidecar_test.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/json_sidecar.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace {
+
+using namespace IRAsset;
+
+TEST(JsonSidecar, EmptyObjectProducesEmptyBraces) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.endObject();
+    EXPECT_EQ(j.str(), "{}");
+}
+
+TEST(JsonSidecar, EmptyArrayProducesEmptyBrackets) {
+    JsonSidecarWriter j;
+    j.beginArray();
+    j.endArray();
+    EXPECT_EQ(j.str(), "[]");
+}
+
+TEST(JsonSidecar, ObjectInsideArrayInsideObject) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("items");
+    j.beginArray();
+    j.beginObject();
+    j.key("x");
+    j.valueInt(7);
+    j.endObject();
+    j.endArray();
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("\"items\""), std::string::npos);
+    EXPECT_NE(out.find("\"x\": 7"), std::string::npos);
+    EXPECT_EQ(out.front(), '{');
+    EXPECT_EQ(out.back(), '}');
+}
+
+TEST(JsonSidecar, StringEscapingCarriageReturnBackspaceFormfeed) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("cr");
+    j.valueString("\r");
+    j.key("bs");
+    j.valueString("\b");
+    j.key("ff");
+    j.valueString("\f");
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("\\r"), std::string::npos);
+    EXPECT_NE(out.find("\\b"), std::string::npos);
+    EXPECT_NE(out.find("\\f"), std::string::npos);
+}
+
+TEST(JsonSidecar, StringEscapingRawControlCharacters) {
+    // U+0001, U+001E, U+001F fall through to the \u00XX path.
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("ctrl");
+    j.valueString("\x01\x1e\x1f");
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("\\u0001"), std::string::npos);
+    EXPECT_NE(out.find("\\u001e"), std::string::npos);
+    EXPECT_NE(out.find("\\u001f"), std::string::npos);
+}
+
+TEST(JsonSidecar, Int64MinRoundTrip) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("min");
+    j.valueInt(std::numeric_limits<int64_t>::min());
+    j.endObject();
+    EXPECT_NE(j.str().find("-9223372036854775808"), std::string::npos);
+}
+
+TEST(JsonSidecar, Uint64MaxRoundTrip) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("max");
+    j.valueUInt(std::numeric_limits<uint64_t>::max());
+    j.endObject();
+    EXPECT_NE(j.str().find("18446744073709551615"), std::string::npos);
+}
+
+TEST(JsonSidecar, PositiveAndNegativeZeroAreFiniteNotNull) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("pz");
+    j.valueFloat(+0.0);
+    j.key("nz");
+    j.valueFloat(-0.0);
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_EQ(out.find("\"pz\": null"), std::string::npos);
+    EXPECT_EQ(out.find("\"nz\": null"), std::string::npos);
+}
+
+TEST(JsonSidecar, InfinityEmitsNull) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("pos_inf");
+    j.valueFloat(std::numeric_limits<double>::infinity());
+    j.key("neg_inf");
+    j.valueFloat(-std::numeric_limits<double>::infinity());
+    j.endObject();
+    const std::string out = j.str();
+    EXPECT_NE(out.find("\"pos_inf\": null"), std::string::npos);
+    EXPECT_NE(out.find("\"neg_inf\": null"), std::string::npos);
+}
+
+TEST(JsonSidecar, KeyOrderPreserved) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("alpha"); j.valueInt(1);
+    j.key("beta");  j.valueInt(2);
+    j.key("gamma"); j.valueInt(3);
+    j.endObject();
+    const std::string out = j.str();
+    const auto posA = out.find("\"alpha\"");
+    const auto posB = out.find("\"beta\"");
+    const auto posG = out.find("\"gamma\"");
+    ASSERT_NE(posA, std::string::npos);
+    ASSERT_NE(posB, std::string::npos);
+    ASSERT_NE(posG, std::string::npos);
+    EXPECT_LT(posA, posB);
+    EXPECT_LT(posB, posG);
+}
+
+TEST(JsonSidecar, WriteToFileFailsOnBadPath) {
+    JsonSidecarWriter j;
+    j.beginObject();
+    j.key("x");
+    j.valueInt(1);
+    j.endObject();
+    EXPECT_FALSE(writeJsonSidecarToFile("/nonexistent_dir_irreden/sidecar.json", j.str()));
+}
+
+} // namespace

--- a/test/asset/name_table_test.cpp
+++ b/test/asset/name_table_test.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/name_table.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace IRAsset;
+
+TEST(NameTable, SingleEntryRoundTrip) {
+    std::vector<NameTableEntry> entries = {{42, "SINGLE"}};
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), 1u);
+    EXPECT_EQ(loaded.value_[0].id_, 42u);
+    EXPECT_EQ(loaded.value_[0].name_, "SINGLE");
+}
+
+TEST(NameTable, ManyEntriesRoundTrip) {
+    std::vector<NameTableEntry> entries;
+    for (std::uint32_t i = 0; i < 100; ++i) {
+        entries.push_back({i, "SHAPE_" + std::to_string(i)});
+    }
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), 100u);
+    for (std::size_t i = 0; i < 100; ++i) {
+        EXPECT_EQ(loaded.value_[i].id_, static_cast<std::uint32_t>(i));
+        EXPECT_EQ(loaded.value_[i].name_, "SHAPE_" + std::to_string(i));
+    }
+}
+
+TEST(NameTable, NonAsciiNamesUtf8) {
+    // Non-ASCII UTF-8 bytes pass through the string/varuint layer unchanged.
+    std::vector<NameTableEntry> entries = {
+        {1, "\xc3\x84rger"},                               // Ärger (German)
+        {2, "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"},      // 日本語 (Japanese)
+    };
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), 2u);
+    EXPECT_EQ(loaded.value_[0].name_, entries[0].name_);
+    EXPECT_EQ(loaded.value_[1].name_, entries[1].name_);
+}
+
+TEST(NameTable, EmptyNameEntryRoundTrip) {
+    // Empty name string: the format does not forbid it; lock current behavior.
+    std::vector<NameTableEntry> entries = {{0, ""}};
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeNameTable(w, entries).ok());
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readNameTable(r);
+    ASSERT_TRUE(loaded.ok());
+    ASSERT_EQ(loaded.value_.size(), 1u);
+    EXPECT_EQ(loaded.value_[0].id_, 0u);
+    EXPECT_EQ(loaded.value_[0].name_, "");
+}
+
+TEST(NameTable, ConstructFromVectorMatchesSequentialAdd) {
+    std::vector<NameTableEntry> entries = {{1, "SPHERE"}, {3, "TORUS"}, {7, "BOX"}};
+    NameTable fromVector(entries);
+
+    NameTable fromAdd;
+    fromAdd.add(1, "SPHERE");
+    fromAdd.add(3, "TORUS");
+    fromAdd.add(7, "BOX");
+
+    EXPECT_EQ(fromVector.idByName("SPHERE"), fromAdd.idByName("SPHERE"));
+    EXPECT_EQ(fromVector.idByName("TORUS"),  fromAdd.idByName("TORUS"));
+    EXPECT_EQ(fromVector.idByName("BOX"),    fromAdd.idByName("BOX"));
+    EXPECT_EQ(fromVector.nameById(1).value(), fromAdd.nameById(1).value());
+    EXPECT_EQ(fromVector.nameById(7).value(), fromAdd.nameById(7).value());
+    EXPECT_EQ(fromVector.size(), fromAdd.size());
+}
+
+TEST(NameTable, DuplicateNameFirstInsertWins) {
+    // emplace() on unordered_map keeps the first mapping when the key exists.
+    NameTable nt;
+    nt.add(1, "SPHERE");
+    nt.add(99, "SPHERE"); // same name, different id
+
+    EXPECT_EQ(nt.idByName("SPHERE").value(), 1u);
+    EXPECT_EQ(nt.size(), 2u); // both entries in the vector
+}
+
+TEST(NameTable, DuplicateIdFirstInsertWins) {
+    // emplace() keeps the first index mapping for id → entry.
+    NameTable nt;
+    nt.add(5, "FIRST");
+    nt.add(5, "SECOND"); // same id, different name
+
+    EXPECT_EQ(std::string(nt.nameById(5).value()), "FIRST");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Add `test/asset/json_sidecar_test.cpp` with dedicated edge-case tests for `JsonSidecarWriter`: empty object/array, control-char escaping (`\r`, `\b`, `\f`, U+0001–U+001F), `INT64_MIN` / `UINT64_MAX` numerics, positive/negative zero, infinity-emits-null, key-ordering preserved, file-write failure path.
- Add `test/asset/name_table_test.cpp` with dedicated tests for `writeNameTable`/`readNameTable` + `NameTable`: single-entry round-trip, 100-entry round-trip, non-ASCII UTF-8 names, empty name string, vector-constructor vs sequential-add parity, duplicate-name/id first-insert-wins contracts.
- Register both files in `test/CMakeLists.txt`.

Existing coverage in `binary_io_test.cpp` covers the happy paths; these new files isolate the edge cases and make the per-unit contracts explicit.

## Test plan
- [ ] `fleet-build --target IrredenEngineTest` compiles clean
- [ ] All new tests pass (`fleet-run IrredenEngineTest`)

Closes #707