### PR TITLE
T-189: prefab attach DENSE/HYBRID voxel_ref as C_VoxelSetNew on spawn

### DIFF
--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -54,11 +54,15 @@ records:
   record `rotation_`, `csgOp_`, and `boneId_` are loaded but not
   attached in v1 (no renderer consumes them; T-181 wires bone
   binding).
-- **DENSE / HYBRID dense half** — per-voxel records are loaded and
-  validated but not attached. `C_VoxelSetNew` constructs against
-  the active render-canvas pool; a headless attach path needs its
-  own design. Track follow-up at the issue queue (deferred from
-  T-182).
+- **DENSE / HYBRID dense half** — `C_VoxelSetNew` attached to the
+  spawned root entity via `IRPrefab::DenseVoxel::toComponent`
+  (`voxel/dense_bridge.hpp`). The bridge translates
+  `IRAsset::DenseVoxelSet` → `C_VoxelSetNew` via a per-record copy
+  (`VoxelRecord` and `C_Voxel` share the 12 B std430 layout but
+  remain distinct types so layout drift surfaces as a compile
+  error). For HYBRID, the SHAPES children and the DENSE
+  `C_VoxelSetNew` land on the same root entity in a single
+  `Prefab.spawn` call.
 
 `C_ShapeDescriptor`'s constructors snapshot the active canvas via
 `IRRender::getActiveCanvasEntityOrNull()` rather than the
@@ -66,6 +70,33 @@ asserting `getActiveCanvasEntity()`. Headless construction
 (prefab spawn in a test, asset tooling) gets
 `canvasEntity_ = kNullEntity` instead of an `IR_ASSERT` failure;
 iterating systems gate work on the field already.
+
+## C_VoxelSetNew headless / staged mode
+
+The dense-data ctor `C_VoxelSetNew(ivec3 boundsMin, ivec3 boundsMax,
+span<const C_Voxel>)` is headless-safe: it snapshots the active
+canvas via `getActiveCanvasEntityOrNull()` and branches:
+
+- **Canvas active** — allocates from the pool, copies records into
+  the span, seeds per-voxel positions at `boundsMin + indexToIvec3`.
+  `numVoxels_` reflects the allocation; `pendingVoxels_` is empty.
+- **Canvas absent (headless / pre-canvas)** — leaves `numVoxels_ = 0`
+  and the pool spans empty, stages records in `pendingVoxels_`, and
+  records the origin in `pendingBoundsMin_`. `canvasEntity_ ==
+  kNullEntity` is the sentinel.
+
+`recordCount()` returns the data count in either mode (test-friendly
+and order-independent of pool availability). A future task will add
+the canvas-attach pass that moves `pendingVoxels_` into a pool
+allocation once a canvas activates; until then the staged data
+participates in serialization round-trips but does not render.
+
+`system_update_voxel_set_children` gates on `numVoxels_ > 0`, so a
+staged headless set sitting in a canvas-active world contributes
+nothing to the pool's per-frame writes — no risk of clobbering
+adjacent voxel-set ranges. `onDestroy()` skips the pool
+deallocation when `numVoxels_ == 0`, so the staging vector frees
+with the component.
 
 ## Gotchas
 

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -6,7 +6,10 @@
 #include <irreden/ir_render.hpp>
 
 #include <irreden/render/texture.hpp>
+#include <irreden/voxel/components/component_voxel.hpp>
 #include <irreden/voxel/systems/system_voxel_pool.hpp>
+
+#include <vector>
 
 using namespace IRMath;
 using IRRender::ImageData;
@@ -47,6 +50,22 @@ struct C_VoxelSetNew {
     std::span<C_PositionGlobal3D> globalPositions_;
 
     std::span<C_Voxel> voxels_;
+
+    // Headless / pre-canvas staging. Populated by the dense-data ctor
+    // when no render canvas is active at construction time (tests,
+    // asset-only tooling, prefab spawn before a canvas exists). When
+    // present, `numVoxels_` is 0 and the pool spans above are empty —
+    // the canonical data lives here and `recordCount()` reflects it.
+    // A future canvas-attach pass moves these into the pool span,
+    // then clears the staging vector.
+    std::vector<C_Voxel> pendingVoxels_;
+
+    // Origin of `pendingVoxels_` data in voxel-grid space, i.e. the
+    // value of `IRAsset::DenseVoxelSet::boundsMin_`. The staged
+    // entry at flat index i corresponds to grid position
+    // `pendingBoundsMin_ + index1DtoIndex3D(i, size_)`. Only
+    // meaningful when `pendingVoxels_` is non-empty.
+    ivec3 pendingBoundsMin_ = ivec3(0);
 
     C_VoxelSetNew(
         ivec3 size, Color color = IRColors::kGreen, bool centerAroundOrigin = false
@@ -107,6 +126,86 @@ struct C_VoxelSetNew {
     C_VoxelSetNew()
         : C_VoxelSetNew(ivec3(0, 0, 0)) {}
 
+    // Dense-data ctor: build from a bounded voxel grid carrying per-voxel
+    // records, used by `Prefab.spawn` to attach a `.vxs` DENSE / HYBRID
+    // dense half. Snapshots the active canvas via
+    // `getActiveCanvasEntityOrNull` so it works headless (no canvas →
+    // stages data in `pendingVoxels_`; canvas present → allocates from
+    // the pool, copies records into the span, and seeds positions).
+    //
+    // Mirrors the asset-side `IRAsset::DenseVoxelSet` semantics: bounds
+    // are inclusive-min / exclusive-max, voxels are row-major in
+    // (x, y, z) order. `voxels.size()` must equal the bounds-derived
+    // voxel volume — the bridge in `voxel/dense_bridge.hpp` validates
+    // this and falls back to an empty staging vector otherwise.
+    C_VoxelSetNew(ivec3 boundsMin, ivec3 boundsMax, std::span<const C_Voxel> voxels)
+        : numVoxels_{0}
+        , size_{boundsMax - boundsMin} {
+        canvasEntity_ = IRRender::getActiveCanvasEntityOrNull();
+        const ivec3 extent = size_;
+        const int requestedVoxels =
+            (extent.x > 0 && extent.y > 0 && extent.z > 0) ? extent.x * extent.y * extent.z : 0;
+        if (requestedVoxels == 0 || voxels.size() != static_cast<std::size_t>(requestedVoxels)) {
+            // Empty or mismatched payload — leave the set empty and let
+            // the caller diagnose via `recordCount()`. Avoids allocating
+            // pool slots we can't faithfully populate.
+            size_ = ivec3(0);
+            return;
+        }
+
+        if (canvasEntity_ == IREntity::kNullEntity) {
+            // Headless / pre-canvas staging path.
+            pendingVoxels_.assign(voxels.begin(), voxels.end());
+            pendingBoundsMin_ = boundsMin;
+            return;
+        }
+
+        auto allocation = IRRender::allocateVoxels(requestedVoxels);
+        voxelStartIdx_ = allocation.startIndex_;
+        positions_ = allocation.positions_;
+        positionOffsets_ = allocation.positionOffsets_;
+        globalPositions_ = allocation.positionGlobals_;
+        voxels_ = allocation.voxels_;
+
+        numVoxels_ = static_cast<int>(IRMath::min(
+            IRMath::min(positions_.size(), positionOffsets_.size()),
+            IRMath::min(globalPositions_.size(), voxels_.size())
+        ));
+        if (numVoxels_ != requestedVoxels) {
+            IRE_LOG_ERROR(
+                "VoxelSet dense allocation mismatch: requested={}, positions={}, voxels={}",
+                requestedVoxels,
+                positions_.size(),
+                voxels_.size()
+            );
+            size_ = ivec3(0);
+            numVoxels_ = 0;
+            return;
+        }
+
+        const vec3 originOffset{boundsMin};
+        for (int x = 0; x < extent.x; ++x) {
+            for (int y = 0; y < extent.y; ++y) {
+                for (int z = 0; z < extent.z; ++z) {
+                    const int idx = index3DtoIndex1D(ivec3(x, y, z), extent);
+                    positions_[idx] = C_Position3D{vec3(x, y, z) + originOffset};
+                    voxels_[idx] = voxels[idx];
+                }
+            }
+        }
+        IRE_LOG_DEBUG("Allocated {} dense voxel(s) from voxel_ref", numVoxels_);
+    }
+
+    // Number of voxel records the set carries, regardless of pool /
+    // staging mode. Pool-backed sets return `numVoxels_`; headless
+    // staged sets return `pendingVoxels_.size()`. Use this to assert
+    // record count without caring which side of the pool fence the
+    // set lives on.
+    std::size_t recordCount() const {
+        return pendingVoxels_.empty() ? static_cast<std::size_t>(numVoxels_)
+                                      : pendingVoxels_.size();
+    }
+
     // TODO: should a similar onCreate method be used for allocating
     // voxels, just in case the constructor might be called in more than
     // one place?
@@ -114,9 +213,13 @@ struct C_VoxelSetNew {
         // numVoxels_ equals requestedVoxels on all non-error paths (the
         // constructor min-span guard fires IR_ASSERT before returning a
         // mismatched allocation), so deallocateVoxels releases exactly
-        // what allocateVoxels reserved.
-        IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(numVoxels_));
-        IRE_LOG_DEBUG("Deallocated {} voxels", numVoxels_);
+        // what allocateVoxels reserved. Headless / pending sets never
+        // hit the pool (numVoxels_ == 0); the staging vector frees with
+        // the component.
+        if (numVoxels_ > 0) {
+            IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(numVoxels_));
+            IRE_LOG_DEBUG("Deallocated {} voxels", numVoxels_);
+        }
     }
 
     void changeVoxelColor(ivec3 index, Color color) {

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -97,6 +97,12 @@ struct C_VoxelSetNew {
                 globalPositions_.size(),
                 voxels_.size()
             );
+            // Release the reserved span before bailing — the pool reserved
+            // `requestedVoxels` slots regardless of the short span return, and
+            // the zeroed `size_` makes the headless-guard in `onDestroy()`
+            // skip the pool touch.
+            IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(requestedVoxels));
+            numVoxels_ = 0;
             size_ = ivec3(0);
             return;
         }
@@ -126,26 +132,21 @@ struct C_VoxelSetNew {
     C_VoxelSetNew()
         : C_VoxelSetNew(ivec3(0, 0, 0)) {}
 
-    // Dense-data ctor: build from a bounded voxel grid carrying per-voxel
-    // records, used by `Prefab.spawn` to attach a `.vxs` DENSE / HYBRID
-    // dense half. Snapshots the active canvas via
-    // `getActiveCanvasEntityOrNull` so it works headless (no canvas →
-    // stages data in `pendingVoxels_`; canvas present → allocates from
-    // the pool, copies records into the span, and seeds positions).
-    //
-    // Mirrors the asset-side `IRAsset::DenseVoxelSet` semantics: bounds
-    // are inclusive-min / exclusive-max, voxels are row-major in
-    // (x, y, z) order. `voxels.size()` must equal the bounds-derived
-    // voxel volume — the bridge in `voxel/dense_bridge.hpp` validates
-    // this and falls back to an empty staging vector otherwise.
+    // Dense-data ctor for Prefab.spawn — headless-safe: stages in
+    // `pendingVoxels_` without a canvas, allocates from the pool with one.
+    // Bounds + ordering semantics live in `voxel/CLAUDE.md` "C_VoxelSetNew
+    // headless / staged mode" and `voxel/dense_bridge.hpp`.
     C_VoxelSetNew(ivec3 boundsMin, ivec3 boundsMax, std::span<const C_Voxel> voxels)
         : numVoxels_{0}
         , size_{boundsMax - boundsMin} {
         canvasEntity_ = IRRender::getActiveCanvasEntityOrNull();
         const ivec3 extent = size_;
-        const int requestedVoxels =
-            (extent.x > 0 && extent.y > 0 && extent.z > 0) ? extent.x * extent.y * extent.z : 0;
-        if (requestedVoxels == 0 || voxels.size() != static_cast<std::size_t>(requestedVoxels)) {
+        const std::size_t requestedVoxels = (extent.x > 0 && extent.y > 0 && extent.z > 0)
+                                                ? static_cast<std::size_t>(extent.x) *
+                                                      static_cast<std::size_t>(extent.y) *
+                                                      static_cast<std::size_t>(extent.z)
+                                                : 0u;
+        if (requestedVoxels == 0u || voxels.size() != requestedVoxels) {
             // Empty or mismatched payload — leave the set empty and let
             // the caller diagnose via `recordCount()`. Avoids allocating
             // pool slots we can't faithfully populate.
@@ -160,7 +161,7 @@ struct C_VoxelSetNew {
             return;
         }
 
-        auto allocation = IRRender::allocateVoxels(requestedVoxels);
+        auto allocation = IRRender::allocateVoxels(static_cast<unsigned int>(requestedVoxels));
         voxelStartIdx_ = allocation.startIndex_;
         positions_ = allocation.positions_;
         positionOffsets_ = allocation.positionOffsets_;
@@ -171,13 +172,17 @@ struct C_VoxelSetNew {
             IRMath::min(positions_.size(), positionOffsets_.size()),
             IRMath::min(globalPositions_.size(), voxels_.size())
         ));
-        if (numVoxels_ != requestedVoxels) {
+        if (static_cast<std::size_t>(numVoxels_) != requestedVoxels) {
             IRE_LOG_ERROR(
                 "VoxelSet dense allocation mismatch: requested={}, positions={}, voxels={}",
                 requestedVoxels,
                 positions_.size(),
                 voxels_.size()
             );
+            // Release the reserved span before bailing — the pool reserved
+            // `requestedVoxels` slots regardless of the short span return, and
+            // zeroing `numVoxels_` makes `onDestroy()` skip the pool touch.
+            IRRender::deallocateVoxels(voxelStartIdx_, requestedVoxels);
             size_ = ivec3(0);
             numVoxels_ = 0;
             return;
@@ -196,11 +201,6 @@ struct C_VoxelSetNew {
         IRE_LOG_DEBUG("Allocated {} dense voxel(s) from voxel_ref", numVoxels_);
     }
 
-    // Number of voxel records the set carries, regardless of pool /
-    // staging mode. Pool-backed sets return `numVoxels_`; headless
-    // staged sets return `pendingVoxels_.size()`. Use this to assert
-    // record count without caring which side of the pool fence the
-    // set lives on.
     std::size_t recordCount() const {
         return pendingVoxels_.empty() ? static_cast<std::size_t>(numVoxels_)
                                       : pendingVoxels_.size();
@@ -210,12 +210,11 @@ struct C_VoxelSetNew {
     // voxels, just in case the constructor might be called in more than
     // one place?
     void onDestroy() {
-        // numVoxels_ equals requestedVoxels on all non-error paths (the
-        // constructor min-span guard fires IR_ASSERT before returning a
-        // mismatched allocation), so deallocateVoxels releases exactly
-        // what allocateVoxels reserved. Headless / pending sets never
-        // hit the pool (numVoxels_ == 0); the staging vector frees with
-        // the component.
+        // `numVoxels_ > 0` iff a pool allocation succeeded and was fully
+        // populated. Both ctors' mismatch paths deallocate the reservation
+        // inline and zero `numVoxels_`, and the headless staging path
+        // never touches the pool — so this guard skips exactly the cases
+        // that have nothing to release.
         if (numVoxels_ > 0) {
             IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(numVoxels_));
             IRE_LOG_DEBUG("Deallocated {} voxels", numVoxels_);

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -97,11 +97,14 @@ struct C_VoxelSetNew {
                 globalPositions_.size(),
                 voxels_.size()
             );
-            // Release the reserved span before bailing — the pool reserved
-            // `requestedVoxels` slots regardless of the short span return, and
-            // the zeroed `size_` makes the headless-guard in `onDestroy()`
-            // skip the pool touch.
-            IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(requestedVoxels));
+            // Release whatever the allocator handed back — `numVoxels_` is
+            // the min-span count, which on today's allocator either equals
+            // `requestedVoxels` (no mismatch, branch not taken) or is 0
+            // (out-of-voxels assert fall-through, no slots were reserved
+            // and this is a no-op). The dealloc is kept for symmetry with
+            // a hypothetical future allocator that returns partial spans.
+            // Zeroing `numVoxels_` then keeps `onDestroy()`'s guard correct.
+            IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(numVoxels_));
             numVoxels_ = 0;
             size_ = ivec3(0);
             return;
@@ -179,10 +182,14 @@ struct C_VoxelSetNew {
                 positions_.size(),
                 voxels_.size()
             );
-            // Release the reserved span before bailing — the pool reserved
-            // `requestedVoxels` slots regardless of the short span return, and
-            // zeroing `numVoxels_` makes `onDestroy()` skip the pool touch.
-            IRRender::deallocateVoxels(voxelStartIdx_, requestedVoxels);
+            // Release whatever the allocator handed back — `numVoxels_` is
+            // the min-span count, which on today's allocator either equals
+            // `requestedVoxels` (no mismatch, branch not taken) or is 0
+            // (out-of-voxels assert fall-through, no slots were reserved
+            // and this is a no-op). The dealloc is kept for symmetry with
+            // a hypothetical future allocator that returns partial spans.
+            // Zeroing `numVoxels_` then keeps `onDestroy()`'s guard correct.
+            IRRender::deallocateVoxels(voxelStartIdx_, static_cast<size_t>(numVoxels_));
             size_ = ivec3(0);
             numVoxels_ = 0;
             return;

--- a/engine/prefabs/irreden/voxel/dense_bridge.hpp
+++ b/engine/prefabs/irreden/voxel/dense_bridge.hpp
@@ -1,0 +1,67 @@
+#ifndef IR_PREFAB_VOXEL_DENSE_BRIDGE_H
+#define IR_PREFAB_VOXEL_DENSE_BRIDGE_H
+
+/// Translate between the asset-side `IRAsset::DenseVoxelSet` (on-disk
+/// per-voxel records, designer-facing — carries layers, frames, meta)
+/// and the runtime `IRComponents::C_VoxelSetNew` (ECS-resident,
+/// canvas-pool-backed or headless-staged). The split mirrors
+/// `voxel/rig_bridge.hpp` for joints: `engine/asset/` stays free of
+/// the prefab voxel component, and the bridge owns the cross-type
+/// translation so callers don't reach into either side's private
+/// representation.
+///
+/// `IRAsset::VoxelRecord` and `IRComponents::C_Voxel` share an
+/// identical 12-byte std430 layout (asserted at the asset-format
+/// header), but they are distinct types so the bridge does a
+/// per-field copy. The cost is irrelevant at prefab-spawn rate;
+/// in exchange the boundary stays explicit and a future divergence
+/// in either layout would show up as a compile error.
+
+#include <irreden/asset/voxel_set_format.hpp>
+
+#include <irreden/voxel/components/component_voxel.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace IRPrefab::DenseVoxel {
+
+/// Build a runtime `C_VoxelSetNew` from an asset `IRAsset::DenseVoxelSet`.
+/// When a render canvas is active the component allocates from its
+/// pool and seeds positions / voxels in one pass; without a canvas the
+/// data is staged in `pendingVoxels_` for a future seed step (see
+/// `component_voxel_set.hpp` and `engine/prefabs/irreden/voxel/CLAUDE.md`).
+///
+/// If `dense.voxels_.size() != dense.voxelCount()` (e.g. malformed
+/// `.vxs` with BNDS present but VOXR truncated — Save Format
+/// Extensibility Rule #5: unknown is recoverable), the returned
+/// component is empty (`recordCount() == 0`) so the caller can
+/// surface a diagnostic without crashing.
+inline IRComponents::C_VoxelSetNew toComponent(const IRAsset::DenseVoxelSet &dense) {
+    const std::size_t expected = dense.voxelCount();
+    if (expected == 0 || dense.voxels_.size() != expected) {
+        // Empty data path: route through the dense ctor (which is
+        // headless-safe) with an empty span instead of the legacy
+        // default ctor that asserts on an absent render manager.
+        return IRComponents::C_VoxelSetNew{
+            IRMath::ivec3(0), IRMath::ivec3(0), std::span<const IRComponents::C_Voxel>{}
+        };
+    }
+
+    std::vector<IRComponents::C_Voxel> runtimeVoxels;
+    runtimeVoxels.reserve(expected);
+    for (const auto &record : dense.voxels_) {
+        runtimeVoxels.emplace_back(
+            record.color_, record.material_id_, record.flags_, record.bone_id_
+        );
+    }
+
+    return IRComponents::C_VoxelSetNew{
+        dense.boundsMin_, dense.boundsMax_, std::span<const IRComponents::C_Voxel>{runtimeVoxels}
+    };
+}
+
+} // namespace IRPrefab::DenseVoxel
+
+#endif /* IR_PREFAB_VOXEL_DENSE_BRIDGE_H */

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -747,13 +747,14 @@ land:
   tick. If a hot use case appears (e.g. attaching a per-tick light
   to a bind point), pre-resolve the integer bone index at spawn
   time and cache the offset/rotation in a flat component instead.
-- **DENSE / HYBRID dense voxel_ref attachment** — DENSE per-voxel
-  records are loaded and validated but not attached as an ECS
-  component. The current `C_VoxelSetNew` constructor allocates
-  against the active render-canvas pool; a headless prefab path
-  needs a different entry shape. SHAPES records — and the SHAPES
-  half of HYBRID files — do attach (see "SHAPES voxel_ref
-  attachment" below).
+- **`C_VoxelSetNew` canvas-attach pass for staged dense data** —
+  DENSE / HYBRID records do attach as `C_VoxelSetNew` on the
+  spawned entity (see "DENSE / HYBRID voxel_ref attachment"
+  below), but when the prefab spawns before a render canvas
+  exists the per-voxel records live in `pendingVoxels_` and no
+  pool allocation happens. A follow-up pass needs to seed the
+  pool the frame after a canvas activates and promote the staged
+  records into the pool span — track in the issue queue.
 
 **SHAPES voxel_ref attachment.** When `voxel_ref` points at a
 SHAPES or HYBRID `.vxs`, `Prefab.spawn` attaches one child entity
@@ -779,6 +780,34 @@ headless contexts (tests, asset-only tooling) construct descriptors
 with `canvasEntity_ = kNullEntity` instead of asserting on the
 absent `RenderManager`. Iterating render systems already gate work
 on a non-null canvas binding.
+
+**DENSE / HYBRID voxel_ref attachment.** When `voxel_ref` points
+at a DENSE or HYBRID `.vxs`, `Prefab.spawn` attaches a
+`C_VoxelSetNew` on the spawned root entity via the bridge
+`IRPrefab::DenseVoxel::toComponent` in
+`engine/prefabs/irreden/voxel/dense_bridge.hpp`. The bridge calls
+the dense-data ctor `C_VoxelSetNew(boundsMin, boundsMax,
+span<const C_Voxel>)`, which is headless-safe:
+
+- **Active canvas** → allocates from the pool, copies records
+  into the pool span, seeds per-voxel positions at
+  `boundsMin + index3D`. `numVoxels_` reflects the allocation.
+- **Headless** (test / pre-canvas) → stages records in
+  `pendingVoxels_`, records `pendingBoundsMin_`, leaves
+  `numVoxels_ = 0` and `canvasEntity_ = kNullEntity`. The pool
+  is not touched.
+
+`C_VoxelSetNew::recordCount()` returns the data count regardless
+of mode, so the round-trip test asserts
+`recordCount() == dense.voxelCount()` without caring whether the
+pool was reachable. For HYBRID prefabs the SHAPES half attaches
+as child entities (per "SHAPES voxel_ref attachment") and the
+DENSE half attaches to the root in the same spawn call.
+
+If the loaded `.vxs` is malformed (e.g. BNDS present but VOXR
+truncated, so `dense.voxels_.size() != dense.voxelCount()`), the
+bridge returns an empty component and `setComponent` is skipped
+— Save Format Extensibility Rule #5: unknown is recoverable.
 
 ## Script resolution
 

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -28,6 +28,9 @@ target_link_libraries(
     IrredenEngineEntity
     IrredenEngineSystem
     IrredenEngineAsset
+    # Required: prefab_api.cpp uses IRRender::ShapeType + getActiveCanvasEntityOrNull
+    # via component_{shape_descriptor,voxel_set}.hpp. See #739 for the layering fix.
+    IrredenEngineRendering
 )
 # PRIVATE so render headers don't leak through script's PUBLIC interface
 # (T-188 layering rule). prefab_api.cpp uses IRRender::ShapeType via

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -10,6 +10,8 @@
 #include <irreden/script/lua_script.hpp>
 #include <irreden/voxel/components/component_bind_points.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
+#include <irreden/voxel/dense_bridge.hpp>
 #include <irreden/voxel/rig_bridge.hpp>
 
 #include <sol/sol.hpp>
@@ -219,11 +221,12 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
     // decision). v1 intentionally drops these to avoid stamping unused
     // state.
     //
-    // DENSE / HYBRID dense data is left unattached — `C_VoxelSetNew`
-    // allocates against the active render-canvas pool, and the
-    // headless attach path needs its own design pass. The shape half
-    // of HYBRID still attaches here so SHAPES + HYBRID prefabs render
-    // their SDF primitives even when no canvas is active.
+    // DENSE / HYBRID dense data attaches as `C_VoxelSetNew` on the
+    // root entity via `IRPrefab::DenseVoxel::toComponent` — the
+    // adapter routes through the dense-data ctor, which is
+    // headless-safe: with an active canvas it allocates from the
+    // pool and seeds positions; without one it stages records in
+    // `pendingVoxels_` for a later canvas-attach pass.
     std::vector<IREntity::EntityId> spawnedChildren;
     if (loadedVoxels && (loadedVoxels->mode_ == IRAsset::VoxelSetMode::SHAPES ||
                          loadedVoxels->mode_ == IRAsset::VoxelSetMode::HYBRID)) {
@@ -239,6 +242,15 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
                 IREntity::createEntity(IRComponents::C_Position3D{record.offset_}, descriptor);
             IREntity::setParent(child, entity);
             spawnedChildren.push_back(child);
+        }
+    }
+
+    if (loadedVoxels && (loadedVoxels->mode_ == IRAsset::VoxelSetMode::DENSE ||
+                         loadedVoxels->mode_ == IRAsset::VoxelSetMode::HYBRID)) {
+        IRComponents::C_VoxelSetNew voxelSet =
+            IRPrefab::DenseVoxel::toComponent(loadedVoxels->dense_);
+        if (voxelSet.recordCount() > 0) {
+            IREntity::setComponent(entity, std::move(voxelSet));
         }
     }
 

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -10,6 +10,8 @@
 #include <irreden/voxel/components/component_bind_points.hpp>
 #include <irreden/voxel/components/component_joint_hierarchy.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
+#include <irreden/voxel/components/component_voxel.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
 
 #include <fstream>
 #include <string>
@@ -573,6 +575,119 @@ TEST_F(PrefabApi, BindPointMissingReturnsNil) {
     auto &lua = m_lua.lua();
     EXPECT_TRUE(lua["g_off_is_nil"].get<bool>());
     EXPECT_TRUE(lua["g_rot_is_nil"].get<bool>());
+}
+
+// ---- voxel_ref DENSE / HYBRID attachment ----------------------------------
+
+// Build a small DENSE `.vxs` (2×2×2 = 8 voxels) at a non-zero origin so
+// the round-trip exercises both bounds and per-voxel record carry-over.
+// Returns the fixture set so individual tests can address subsets.
+PrefabFiles writeDenseFixture(const std::string &tag, const std::string &prefabBody) {
+    PrefabFiles f;
+    f.voxel_path_ = std::string{kTmpDir} + "/prefab_test_dense_" + tag + ".vxs";
+    f.rig_dir_ = kTmpDir;
+    f.rig_name_ = "prefab_test_dense_" + tag;
+    f.prefab_path_ = std::string{kTmpDir} + "/prefab_test_dense_" + tag + ".prefab.lua";
+
+    IRAsset::DenseVoxelSet dense;
+    dense.boundsMin_ = IRMath::ivec3(1, 2, 3);
+    dense.boundsMax_ = IRMath::ivec3(3, 4, 5); // 2x2x2 = 8 voxels
+    dense.voxels_.resize(8);
+    for (std::size_t i = 0; i < dense.voxels_.size(); ++i) {
+        // Per-voxel signature so a round-trip mismatch surfaces in a test
+        // assertion rather than a silent value drift.
+        dense.voxels_[i].color_ = IRMath::Color{static_cast<std::uint8_t>(10 + i), 0, 0, 255};
+        dense.voxels_[i].material_id_ = static_cast<std::uint8_t>(i);
+        dense.voxels_[i].bone_id_ = static_cast<std::uint8_t>(i * 2);
+    }
+    IRAsset::saveDenseVoxelSet(f.voxel_path_, dense);
+
+    std::ofstream out(f.prefab_path_);
+    out << prefabBody;
+    return f;
+}
+
+// Same shape as `writeDenseFixture` but emits a HYBRID `.vxs` — a small
+// SHAPES half (one BOX) plus the DENSE half — to confirm both attach
+// on the same root entity from a single voxel_ref.
+PrefabFiles writeHybridFixture(const std::string &tag, const std::string &prefabBody) {
+    PrefabFiles f;
+    f.voxel_path_ = std::string{kTmpDir} + "/prefab_test_hybrid_" + tag + ".vxs";
+    f.rig_dir_ = kTmpDir;
+    f.rig_name_ = "prefab_test_hybrid_" + tag;
+    f.prefab_path_ = std::string{kTmpDir} + "/prefab_test_hybrid_" + tag + ".prefab.lua";
+
+    std::vector<IRAsset::ShapeRecord> shapes(1);
+    shapes[0].shapeTypeId_ = static_cast<std::uint32_t>(IRRender::ShapeType::BOX);
+    shapes[0].params_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
+    shapes[0].color_ = IRMath::Color{200, 100, 50, 255};
+    shapes[0].offset_ = IRMath::vec3(5.0f, 0.0f, 0.0f);
+
+    IRAsset::DenseVoxelSet dense;
+    dense.boundsMin_ = IRMath::ivec3(0);
+    dense.boundsMax_ = IRMath::ivec3(2, 2, 1); // 2x2x1 = 4 voxels
+    dense.voxels_.resize(4);
+    for (std::size_t i = 0; i < dense.voxels_.size(); ++i) {
+        dense.voxels_[i].color_ = IRMath::Color{0, static_cast<std::uint8_t>(30 + i), 0, 255};
+    }
+    IRAsset::saveVoxelSet(f.voxel_path_, shapes, dense);
+
+    std::ofstream out(f.prefab_path_);
+    out << prefabBody;
+    return f;
+}
+
+TEST_F(PrefabApi, SpawnAttachesDenseVoxelSetHeadless) {
+    PrefabFiles f = writeDenseFixture(
+        "attach",
+        std::string{"return { prefab_version = 1, voxel_ref = '"} + std::string{kTmpDir} +
+            "/prefab_test_dense_attach.vxs' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    // Record count matches `dense.voxelCount()` per the T-189 acceptance
+    // criterion. The test runs headless (no canvas), so the data lives in
+    // `pendingVoxels_` and `numVoxels_` is 0 — `recordCount()` unifies
+    // the two paths.
+    const auto &voxelSet = IREntity::getComponent<IRComponents::C_VoxelSetNew>(r.entity_);
+    EXPECT_EQ(voxelSet.recordCount(), 8u);
+    EXPECT_EQ(voxelSet.numVoxels_, 0); // headless → staged, not pool-allocated
+    EXPECT_EQ(voxelSet.canvasEntity_, IREntity::kNullEntity);
+    EXPECT_EQ(voxelSet.pendingBoundsMin_.x, 1);
+    EXPECT_EQ(voxelSet.pendingBoundsMin_.y, 2);
+    EXPECT_EQ(voxelSet.pendingBoundsMin_.z, 3);
+
+    // The bounds → size derivation must agree with `voxelCount()`.
+    ASSERT_EQ(voxelSet.pendingVoxels_.size(), 8u);
+    // Spot-check a couple of records — the per-voxel signature emitted by
+    // the fixture carries through unmodified.
+    EXPECT_EQ(voxelSet.pendingVoxels_[0].color_.red_, 10);
+    EXPECT_EQ(voxelSet.pendingVoxels_[7].color_.red_, 17);
+    EXPECT_EQ(voxelSet.pendingVoxels_[3].material_id_, 3);
+    EXPECT_EQ(voxelSet.pendingVoxels_[3].bone_id_, 6);
+}
+
+TEST_F(PrefabApi, SpawnAttachesHybridShapesAndDenseOnSameEntity) {
+    PrefabFiles f = writeHybridFixture(
+        "attach",
+        std::string{"return { prefab_version = 1, voxel_ref = '"} + std::string{kTmpDir} +
+            "/prefab_test_hybrid_attach.vxs' }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    // SHAPES half — one BOX child entity attached under the root.
+    EXPECT_EQ(IREntity::countComponents<IRComponents::C_ShapeDescriptor>(), 1);
+
+    // DENSE half — C_VoxelSetNew on the same root entity, record count
+    // equals the dense voxel volume.
+    const auto &voxelSet = IREntity::getComponent<IRComponents::C_VoxelSetNew>(r.entity_);
+    EXPECT_EQ(voxelSet.recordCount(), 4u);
+    EXPECT_EQ(voxelSet.pendingVoxels_.size(), 4u);
+    EXPECT_EQ(voxelSet.pendingVoxels_[1].color_.green_, 31);
 }
 
 // ---- additivity: unknown top-level keys do not break the load -------------


### PR DESCRIPTION
## Summary
- `Prefab.spawn` now attaches DENSE / HYBRID `.vxs` dense data as `C_VoxelSetNew` on the spawned root entity, closing the deferred bit from #718.
- `C_VoxelSetNew` gains a headless-safe `(boundsMin, boundsMax, span<const C_Voxel>)` ctor: with an active canvas it allocates from the pool and seeds positions; without one it stages records in `pendingVoxels_` for a future canvas-attach pass.
- New prefab-layer adapter `IRPrefab::DenseVoxel::toComponent` in `engine/prefabs/irreden/voxel/dense_bridge.hpp` mirrors `voxel/rig_bridge.hpp` so `engine/asset/` stays free of the component layer.

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/718

This PR opens against `claude/T-182-prefab-voxel-attach` while #718 is reviewing. When #718 merges, GitHub auto-rebases the base to `master` and the diff narrows to T-189's adds only. Review this PR on its own — only the new dense-attach code is the surface here.

## Notes for reviewer
- The dense ctor's headless / pool-active branch boundary is `IRRender::getActiveCanvasEntityOrNull()`. In headless mode `numVoxels_` stays 0, so `system_update_voxel_set_children`'s pool-writing loop runs zero iterations and won't clobber adjacent voxel-set ranges; `onDestroy()` skips `deallocateVoxels` for the same reason.
- `IRAsset::VoxelRecord` and `IRComponents::C_Voxel` share the 12 B std430 layout (asserted in `component_voxel.hpp`), but the bridge does a per-field copy so a future layout drift surfaces as a compile error, not silent corruption.
- Malformed `.vxs` (BNDS present, VOXR truncated) flows through Save Format Extensibility Rule #5: bridge returns an empty component, `setComponent` is skipped.
- Documentation lives in `engine/prefabs/irreden/voxel/CLAUDE.md` (Prefab.spawn DENSE/HYBRID bullet + new "C_VoxelSetNew headless / staged mode" section) and `engine/script/CLAUDE.md` (DENSE / HYBRID voxel_ref attachment block + updated v1-scope-notes).

## Test plan
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] `IrredenEngineTest --gtest_filter='PrefabApi.*'` — 19/19 pass (including two new tests: `SpawnAttachesDenseVoxelSetHeadless`, `SpawnAttachesHybridShapesAndDenseOnSameEntity`)
- [x] `fleet-build --target IRShapeDebug` — clean (regression check on existing C_VoxelSetNew consumers)
- [ ] Reviewer: confirm the headless-staged set's interaction with `system_update_voxel_set_children` is benign in a canvas-active world (gate is `numVoxels_ > 0`).

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)