### PR TITLE
fleet: pad usage-gate resetsAt with FLEET_DISPATCHER_RESET_GRACE_SECONDS

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -398,9 +398,12 @@ e.g. `five_hour`, `seven_day`). On every 10-second tick `fleet-dispatcher`
 evaluates each observation: if `utilization` is at or above the per-type
 threshold, the gate closes and **all** new dispatches defer (in-flight
 iterations finish normally; their next trigger waits). The gate
-auto-reopens on the first tick after the observation's `resetsAt`
-passes — at most ~10 s after the actual reset — or sooner if a fresh
-observation reports utilisation below threshold.
+auto-reopens on the first tick after the observation's `resetsAt` plus
+`FLEET_DISPATCHER_RESET_GRACE_SECONDS` passes — by default ~10 min after
+the actual reset — or sooner if a fresh observation reports utilisation
+below threshold. The grace pad exists because Anthropic's rolling window
+isn't zero at `resetsAt`; without it the first tick past the reset fires
+every queued trigger and they walk straight into the wall.
 
 Defaults and tuning:
 
@@ -412,6 +415,9 @@ Defaults and tuning:
 - Stale observations (older than `FLEET_DISPATCHER_USAGE_STALE_SECONDS`,
   default `3600`) are dropped from evaluation, so a single high-watermark
   reading can't latch the gate closed forever.
+- Reset grace (`FLEET_DISPATCHER_RESET_GRACE_SECONDS`, default `600`) —
+  observations stay in evaluation until `resetsAt + grace` is in the past.
+  Set to `0` to revert to the old "open instantly at resetsAt" behavior.
 
 **Per-pane cooldown** — post-mortem, applied after a single pane exits
 with code 2 (suspected wall-hit). `fleet-dispatch-wrap` writes

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -139,14 +139,24 @@ LIMIT_DELAY="${FLEET_DISPATCHER_LIMIT_DELAY:-900}"
 #   4. Final fallback 0.80
 #
 # Conservative against staleness: an observation older than
-# USAGE_STALE_SECONDS (default 1h) or whose resetsAt is in the past
-# is ignored, so the gate doesn't latch closed forever after a single
-# high-watermark reading.
+# USAGE_STALE_SECONDS (default 1h) or whose resetsAt + RESET_GRACE_SECONDS
+# is in the past is ignored, so the gate doesn't latch closed forever
+# after a single high-watermark reading.
+#
+# RESET_GRACE_SECONDS pads the resetsAt boundary so the gate doesn't flip
+# open on the exact second the latched window expires. Anthropic's rolling
+# window means util at resetsAt isn't zero — it's whatever the rest of the
+# window weighs, plus any side-channel consumption (e.g. interactive
+# architect chats) the fleet didn't observe. Without padding, the first
+# tick past resetsAt dispatches every queued trigger and they all walk
+# straight into the wall. Default 10 min — enough to absorb the rolloff
+# but not enough to feel like a real wait.
 #
 # Sibling to LIMIT_DELAY's per-pane post-mortem cooldown: that fires
 # AFTER a pane hits the wall and exits with code 2; this fires BEFORE
 # the wall to spread the remaining budget across in-flight work.
 USAGE_STALE_SECONDS="${FLEET_DISPATCHER_USAGE_STALE_SECONDS:-3600}"
+RESET_GRACE_SECONDS="${FLEET_DISPATCHER_RESET_GRACE_SECONDS:-600}"
 
 # Export the gate env vars so the inline-Python in usage_gate_status
 # sees them. Sourcing fleet-up.conf doesn't auto-export, so without
@@ -493,6 +503,7 @@ pane_in_rate_limit_cooldown() {
 usage_gate_status() {
     USAGE_DIR="$USAGE_DIR" \
     USAGE_STALE_SECONDS="$USAGE_STALE_SECONDS" \
+    RESET_GRACE_SECONDS="$RESET_GRACE_SECONDS" \
     python3 - <<'PY'
 import json
 import os
@@ -503,6 +514,7 @@ from datetime import datetime
 
 usage_dir = pathlib.Path(os.environ["USAGE_DIR"])
 stale_s = int(os.environ.get("USAGE_STALE_SECONDS", "3600"))
+reset_grace_s = int(os.environ.get("RESET_GRACE_SECONDS", "600"))
 
 # Built-in per-type defaults. Used only when neither the per-type env
 # override nor the global env override is set. This lets a fresh
@@ -573,12 +585,12 @@ for path in sorted(usage_dir.glob("*.json")):
         try:
             # datetime.fromisoformat accepts +00:00 but not Z until 3.11.
             dt = datetime.fromisoformat(resets_at.replace("Z", "+00:00"))
-            if dt.timestamp() <= now:
+            if dt.timestamp() + reset_grace_s <= now:
                 continue
         except ValueError:
             pass
     elif isinstance(resets_at, (int, float)):
-        if resets_at <= now:
+        if resets_at + reset_grace_s <= now:
             continue
     util_f = float(util)
     # Utilization comes back in [0,1]. Be defensive against a future

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -157,6 +157,16 @@ LIMIT_DELAY="${FLEET_DISPATCHER_LIMIT_DELAY:-900}"
 # the wall to spread the remaining budget across in-flight work.
 USAGE_STALE_SECONDS="${FLEET_DISPATCHER_USAGE_STALE_SECONDS:-3600}"
 RESET_GRACE_SECONDS="${FLEET_DISPATCHER_RESET_GRACE_SECONDS:-600}"
+# Validate-and-clamp: a non-numeric override (operator typo, trailing
+# unit suffix like "600s") would crash the inline-Python `int()` cast,
+# emit nothing on stdout, and silently flip the gate to OPEN — the same
+# silent-fail pattern this gate exists to prevent. Same shape as the
+# BOOT_FANOUT_WINDOW_SECONDS guard below.
+if ! [[ "$RESET_GRACE_SECONDS" =~ ^[0-9]+$ ]]; then
+    printf '[%s dispatcher] RESET_GRACE_SECONDS=%q is not a non-negative integer; falling back to 600\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$RESET_GRACE_SECONDS" >&2
+    RESET_GRACE_SECONDS=600
+fi
 
 # Export the gate env vars so the inline-Python in usage_gate_status
 # sees them. Sourcing fleet-up.conf doesn't auto-export, so without
@@ -491,11 +501,11 @@ pane_in_rate_limit_cooldown() {
 # Print the gate state on stdout: "open" / "open:<info>" / "closed:<reason>".
 #
 # Reads ~/.fleet/state/usage/*.json files (latched by fleet-claude-stream
-# on every rate_limit_event). For each fresh, not-yet-reset observation,
-# compares utilization against the per-type threshold (see threshold_for
-# below). Reports closed when at least one observation breaches its own
-# threshold; the highest-utilization breach wins the report when several
-# are over.
+# on every rate_limit_event). For each fresh observation still within
+# its window — or its post-reset grace pad — compares utilization
+# against the per-type threshold (see threshold_for below). Reports
+# closed when at least one observation breaches its own threshold; the
+# highest-utilization breach wins the report when several are over.
 #
 # Inlined python3 so we get JSON parsing + ISO-8601 timestamp math
 # without adding a shell dep. Same pattern rearm_periodic_meta_triggers

--- a/scripts/fleet/fleet-gate-status
+++ b/scripts/fleet/fleet-gate-status
@@ -7,9 +7,10 @@
 #   1. Fleet-wide usage gate — based on rate_limit_event observations
 #      latched by fleet-claude-stream into ~/.fleet/state/usage/*.json.
 #      Mirrors fleet-dispatcher's usage_gate_status(): same threshold
-#      lookup, same staleness check, same past-resetsAt prune. If those
-#      rules change there, mirror the change here. (`fleet-dispatcher
-#      --gate-status` exposes a one-line variant of the same evaluation.)
+#      lookup, same staleness check, same past-(resetsAt+grace) prune.
+#      If those rules change there, mirror the change here.
+#      (`fleet-dispatcher --gate-status` exposes a one-line variant of
+#      the same evaluation.)
 #
 #   2. Per-pane cooldowns — fleet-dispatch-wrap writes a Unix epoch to
 #      ~/.fleet/state/rate-limit/<pane_key>.ts when claude exits with
@@ -17,8 +18,10 @@
 #      LIMIT_DELAY seconds (default 900).
 #
 # Pure read-only: no mutations, no daemon contact. The dispatcher itself
-# auto-resumes when each rate-limit window's resetsAt passes — this
-# command does NOT trigger resume; it just shows the current state.
+# auto-resumes when each rate-limit window's `resetsAt + grace` passes
+# (grace = FLEET_DISPATCHER_RESET_GRACE_SECONDS, default 600s; see
+# --help) — this command does NOT trigger resume; it just shows the
+# current state.
 
 set -euo pipefail
 
@@ -105,7 +108,8 @@ limit_delay = int(os.environ.get("LIMIT_DELAY", "900"))
 poll_s = int(os.environ.get("POLL_INTERVAL_SECONDS", "10"))
 emit_json = os.environ.get("JSON") == "1"
 
-# Mirrors fleet-dispatcher:482-518. Keep in sync.
+# Mirrors fleet-dispatcher's threshold_for() / BUILTIN_PER_TYPE_DEFAULTS.
+# Keep in sync — same semantics, same defaults.
 BUILTIN_PER_TYPE_DEFAULTS = {
     "seven_day": 0.95,
     "five_hour": 0.80,
@@ -217,6 +221,9 @@ if usage_dir.is_dir():
             "etaSeconds": eta_s,
             "observed_at": observed_at,
             "stale": is_stale,
+            # past_reset = past `resetsAt + reset_grace_s`. Field name kept
+            # for back-compat with `--json` consumers; the meaning shifted
+            # when the grace pad was introduced.
             "past_reset": is_past,
             "breaching": breaching,
         }
@@ -301,8 +308,9 @@ else:
     for o in observations:
         if not (o["stale"] or o["past_reset"]):
             continue
+        past_label = "past-reset" if reset_grace_s == 0 else "past-reset+grace"
         reasons = "/".join(
-            r for r, on in (("stale", o["stale"]), ("past-reset", o["past_reset"])) if on
+            r for r, on in (("stale", o["stale"]), (past_label, o["past_reset"])) if on
         )
         print(fmt_obs(o, "pruned:", f"[{reasons}]"))
 

--- a/scripts/fleet/fleet-gate-status
+++ b/scripts/fleet/fleet-gate-status
@@ -29,6 +29,7 @@ RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
 # Same env vars and defaults as fleet-dispatcher, so output cannot
 # disagree with what the dispatcher actually evaluates.
 USAGE_STALE_SECONDS="${FLEET_DISPATCHER_USAGE_STALE_SECONDS:-3600}"
+RESET_GRACE_SECONDS="${FLEET_DISPATCHER_RESET_GRACE_SECONDS:-600}"
 LIMIT_DELAY="${FLEET_DISPATCHER_LIMIT_DELAY:-900}"
 POLL_INTERVAL_SECONDS="${FLEET_DISPATCHER_INTERVAL:-10}"
 
@@ -46,9 +47,10 @@ Reports both:
   • fleet-wide usage gate (5h / 7d / etc. rate-limit thresholds)
   • per-pane cooldowns (15-min default after a pane exits with code 2)
 
-Auto-resume is automatic: when a rate-limit window's resetsAt timestamp
-passes, the dispatcher re-opens the gate on its next poll (~10s). This
-command only visualises state — it does NOT trigger resume.
+Auto-resume is automatic: the dispatcher re-opens the gate on its next
+poll (~10s) once `resetsAt + FLEET_DISPATCHER_RESET_GRACE_SECONDS` has
+passed (default grace is 600s, so by default ~10 min after the actual
+reset). This command only visualises state — it does NOT trigger resume.
 
 State sources (read-only):
   ~/.fleet/state/usage/*.json         (written by fleet-claude-stream)
@@ -58,6 +60,7 @@ Tunables (env, shared with fleet-dispatcher):
   FLEET_DISPATCHER_USAGE_GATE_<TYPE>  per-type threshold (e.g. _FIVE_HOUR=0.7)
   FLEET_DISPATCHER_USAGE_GATE         global threshold override
   FLEET_DISPATCHER_USAGE_STALE_SECONDS  default 3600
+  FLEET_DISPATCHER_RESET_GRACE_SECONDS  default 600
   FLEET_DISPATCHER_LIMIT_DELAY        default 900
   FLEET_DISPATCHER_INTERVAL           default 10
 EOF
@@ -74,8 +77,8 @@ EOF
         ;;
 esac
 
-export USAGE_DIR RATE_LIMIT_DIR USAGE_STALE_SECONDS LIMIT_DELAY \
-       POLL_INTERVAL_SECONDS JSON
+export USAGE_DIR RATE_LIMIT_DIR USAGE_STALE_SECONDS RESET_GRACE_SECONDS \
+       LIMIT_DELAY POLL_INTERVAL_SECONDS JSON
 
 # Pass through any per-type / global override env vars that fleet-dispatcher
 # reads, so threshold lookup matches the dispatcher's view.
@@ -97,6 +100,7 @@ from datetime import datetime, timezone
 usage_dir = pathlib.Path(os.environ["USAGE_DIR"])
 ratelimit_dir = pathlib.Path(os.environ["RATE_LIMIT_DIR"])
 stale_s = int(os.environ.get("USAGE_STALE_SECONDS", "3600"))
+reset_grace_s = int(os.environ.get("RESET_GRACE_SECONDS", "600"))
 limit_delay = int(os.environ.get("LIMIT_DELAY", "900"))
 poll_s = int(os.environ.get("POLL_INTERVAL_SECONDS", "10"))
 emit_json = os.environ.get("JSON") == "1"
@@ -190,7 +194,7 @@ if usage_dir.is_dir():
             if resets_dt is not None
             else (resets_raw if isinstance(resets_raw, str) else None)
         )
-        is_past = resets_dt is not None and resets_dt.timestamp() <= now
+        is_past = resets_dt is not None and resets_dt.timestamp() + reset_grace_s <= now
         eta_s = (
             int(resets_dt.timestamp() - now) if resets_dt is not None else None
         )
@@ -256,6 +260,7 @@ if emit_json:
         },
         "limit_delay_seconds": limit_delay,
         "usage_stale_seconds": stale_s,
+        "reset_grace_seconds": reset_grace_s,
         "poll_interval_seconds": poll_s,
         "now": now,
     }
@@ -315,5 +320,11 @@ else:
     print("Per-pane cooldowns: none active")
 
 print()
-print(f"Note: dispatcher polls every {poll_s}s; resume happens within ~{poll_s}s of reset.")
+if reset_grace_s > 0:
+    print(
+        f"Note: dispatcher polls every {poll_s}s; resume happens within "
+        f"~{poll_s}s of (reset + {reset_grace_s}s grace)."
+    )
+else:
+    print(f"Note: dispatcher polls every {poll_s}s; resume happens within ~{poll_s}s of reset.")
 PY

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -58,6 +58,14 @@
 # so the gate doesn't latch closed forever based on a single high
 # watermark. Default 1h.
 #
+# Reset grace: pad the resetsAt boundary so the gate doesn't flip open
+# on the exact second the latched window expires. Anthropic's rolling
+# window means util at resetsAt isn't zero — it's whatever the rest of
+# the window weighs, plus any side-channel consumption (e.g. interactive
+# architect chats) the fleet didn't observe. Without padding, the first
+# tick past resetsAt dispatches every queued trigger and they all walk
+# straight into the wall. Default 10 min.
+#
 # Sibling to FLEET_DISPATCHER_LIMIT_DELAY (per-pane post-mortem cooldown
 # after a usage_limit exit). Use --gate-status on fleet-dispatcher to
 # inspect the live state.
@@ -71,3 +79,4 @@
 # FLEET_DISPATCHER_USAGE_GATE_SEVEN_DAY=0.95
 
 # FLEET_DISPATCHER_USAGE_STALE_SECONDS=3600
+# FLEET_DISPATCHER_RESET_GRACE_SECONDS=600

--- a/scripts/fleet/tests/test_dispatcher_usage_gate.sh
+++ b/scripts/fleet/tests/test_dispatcher_usage_gate.sh
@@ -6,7 +6,11 @@
 #   - utilization >= threshold + fresh + future reset => gate closed
 #   - threshold override via env var (FLEET_DISPATCHER_USAGE_GATE)
 #   - stale observation (older than USAGE_STALE_SECONDS) => ignored
-#   - resetsAt in the past => observation ignored
+#   - resetsAt well in the past (past grace) => observation ignored
+#   - resetsAt recently in the past, within RESET_GRACE_SECONDS => still active
+#   - RESET_GRACE_SECONDS=0 reverts to instant open at resetsAt
+#   - epoch-int resetsAt within grace => still active (parity with ISO branch)
+#   - non-numeric RESET_GRACE_SECONDS override falls back to default
 #   - utilization < threshold => gate open with util reported
 #   - worst-of across multiple types when only one is over threshold
 #   - defensive percent path (utilization > 1.5 treated as percent)
@@ -87,6 +91,24 @@ assert_starts_with "$out" "closed:five_hour util=85%" "grace window keeps gate c
 echo "T5c: same fixture, grace=0 => open immediately"
 out=$(FLEET_DISPATCHER_RESET_GRACE_SECONDS=0 "$DISPATCHER" --gate-status)
 assert_starts_with "$out" "open" "grace=0 reverts to instant open at resetsAt"
+
+echo "T5d: epoch-int resetsAt 60s in the past, default grace => still closed"
+RECENT_RESET_EPOCH=$((NOW - 60))
+printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":%s,"observed_at":%s}\n' "$RECENT_RESET_EPOCH" "$NOW" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:five_hour util=85%" "epoch-int resetsAt also honors grace"
+
+echo "T5e: non-numeric RESET_GRACE_SECONDS falls back to default (still closed)"
+# Re-use the T5b ISO fixture (60s past reset) so a working grace keeps the
+# gate closed. Pass a typo'd value; the dispatcher must clamp to 600 and
+# stay closed. Without the validate-and-clamp guard the inline-Python int()
+# raises, the heredoc dies, stdout is empty, and usage_gate_open treats
+# empty as "not closed:" — silent gate-open.
+printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"%s","observed_at":%s}\n' "$RECENT_RESET" "$NOW" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$(FLEET_DISPATCHER_RESET_GRACE_SECONDS="600s" "$DISPATCHER" --gate-status 2>/dev/null)
+assert_starts_with "$out" "closed:five_hour util=85%" "non-numeric grace override falls back to default"
 
 echo "T6: utilization 0.50 => open with util reported"
 printf '{"rateLimitType":"five_hour","utilization":0.50,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$NOW" \

--- a/scripts/fleet/tests/test_dispatcher_usage_gate.sh
+++ b/scripts/fleet/tests/test_dispatcher_usage_gate.sh
@@ -71,11 +71,22 @@ printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"%s","observe
 out=$("$DISPATCHER" --gate-status)
 assert_starts_with "$out" "open" "stale observation ignored"
 
-echo "T5: resetsAt in the past => open"
+echo "T5: resetsAt in the past (well past grace) => open"
 printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"2020-01-01T00:00:00Z","observed_at":%s}\n' "$NOW" \
     > "$FLEET_STATE_DIR/usage/five_hour.json"
 out=$("$DISPATCHER" --gate-status)
 assert_starts_with "$out" "open" "expired window ignored"
+
+echo "T5b: resetsAt 60s in the past, default 600s grace => still closed"
+RECENT_RESET=$(python3 -c "import datetime,time; print(datetime.datetime.fromtimestamp(time.time()-60,tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"%s","observed_at":%s}\n' "$RECENT_RESET" "$NOW" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:five_hour util=85%" "grace window keeps gate closed past resetsAt"
+
+echo "T5c: same fixture, grace=0 => open immediately"
+out=$(FLEET_DISPATCHER_RESET_GRACE_SECONDS=0 "$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open" "grace=0 reverts to instant open at resetsAt"
 
 echo "T6: utilization 0.50 => open with util reported"
 printf '{"rateLimitType":"five_hour","utilization":0.50,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$NOW" \


### PR DESCRIPTION
## Summary
- Usage gate dropped an observation the instant `resetsAt` passed, so the next 10s tick fired every queued trigger straight into the wall (rolling-window util at `resetsAt` isn't zero, and side-channel consumption the fleet didn't observe pre-loads the new window). Operator-visible symptom: workers triggered "too early" after a 5h reset.
- Pad the boundary with `FLEET_DISPATCHER_RESET_GRACE_SECONDS` (default 600s). Set to 0 to revert.
- Mirror the change into `fleet-gate-status` so the read-only view doesn't disagree with the dispatcher.

## Test plan
- [x] `bash scripts/fleet/tests/test_dispatcher_usage_gate.sh` — 15/15 pass (13 original + 2 new: T5b grace-window keeps gate closed past resetsAt; T5c `RESET_GRACE_SECONDS=0` restores old behavior).
- [x] Parity smoke: dispatcher `--gate-status` and `fleet-gate-status` both report CLOSED for a 60s-past-reset 85% observation under default grace, both report OPEN under `FLEET_DISPATCHER_RESET_GRACE_SECONDS=0`.

## Notes for reviewer
- `fleet-dispatcher` re-reads conf at startup only, so this only takes effect on next dispatcher boot.
- The grace defaults to 10 min on the theory that it absorbs the rolloff without feeling like a real wait. Tunable; doc + sample call out the knob.
- Stronger fixes (canary worker, sticky observation surviving across cycles) discussed in conversation but explicitly deferred — operator wanted the cheap fix first and may want a "store original resetsAt + alarm process" follow-up if 10 min still feels off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)