### PR TITLE
T-191: vec3 modifier kind — extend modifier compose for vector fields

### DIFF
--- a/docs/design/modifiers.md
+++ b/docs/design/modifiers.md
@@ -433,3 +433,42 @@ needs all four predecessors.
   kInvalidFieldId` — a default-constructed `Modifier{}` produces this
   state (`kind_ == ADD`, `field_ == 0`). Fail fast rather than silently
   adding an invalid modifier to the vector.
+
+## vec3 extension (T-191)
+
+The framework was extended in T-191 to carry vec3-typed fields
+alongside the scalar path. The shape stays parallel rather than
+variant-based:
+
+- `ModifierVec3` mirrors `Modifier` with `IRMath::vec3 param_` in
+  place of `float param_`. Stays trivially-copyable; `sizeof == 32`,
+  `alignof == 8`.
+- `ResolvedFieldVec3` mirrors `ResolvedField`. `C_Modifiers`,
+  `C_GlobalModifiers`, and `C_ResolvedFields` each carry both a
+  scalar vector (unchanged from v1) and a sibling vec3 vector —
+  one component, two internal columns.
+- The field registry tracks `FieldValueType::{SCALAR, VEC3}` per
+  binding id. `registerField` defaults to SCALAR; `registerFieldVec3`
+  declares a vec3 field. `push`/`pushGlobal` are overloaded on
+  scalar vs `vec3` param; pushing the wrong type silently no-ops
+  (caller bug, not data error).
+- Compose semantics are component-wise: ADD/MULTIPLY/SET apply
+  per-axis in push-order; CLAMP_MIN/CLAMP_MAX bound each axis
+  independently via `IRMath::max`/`IRMath::min`; OVERRIDE replaces
+  the entire vec3 and short-circuits prior ops. Resolver evaluation
+  order matches the scalar path — `composeForFieldVec3` is the vec3
+  twin of `composeForField`.
+- Resolver systems iterate both vectors on the same archetype each
+  tick (`MODIFIER_RESOLVE_GLOBAL`, `MODIFIER_RESOLVE_EXEMPT`).
+  Decay systems sweep both vectors. `removeBySource` sweeps both.
+- `LambdaModifier` stays scalar-only in v1. A `std::function<vec3
+  (vec3)>` channel and a quat modifier kind are Phase 2 follow-ups.
+- Lua surface: `IRModifier.registerFieldVec3`, `addVec3`,
+  `addGlobalVec3`, `applyToFieldVec3`, `resolvedVec3` mirror the
+  scalar Lua API. Param tables accept either an `IRMath::vec3`
+  userdata or a `{x, y, z}` keyed table via the `vec3FromLua`
+  helper.
+
+T-192 (delete `C_PositionOffset3D`) is the first consumer — it
+migrates idle-bob and gizmo-drag writers off the hand-rolled offset
+component onto a `POSITION` vec3 modifier field.

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -92,11 +92,43 @@ capability (Haste, Stun, Slow, Stack, GlobalSlow, LambdaSine,
 SourceKill, Clamp) live. The HUD shows per-cube resolved speed
 each tick.
 
+### Typed fields: scalar vs vec3
+
+Fields are typed at registration time. `IRPrefab::Modifier::registerField`
+declares a scalar field; `registerFieldVec3` declares a vec3 field.
+`fieldType(id)` returns `FieldValueType::{SCALAR,VEC3}`. The `push`
+overload set is type-driven: `push(target, field, kind, float, ...)`
+routes into `C_Modifiers::modifiers_` (scalar) and `push(target, field,
+kind, IRMath::vec3, ...)` routes into `C_Modifiers::modifiersVec3_`.
+Pushing the wrong scalar/vec3 against a typed field silently no-ops
+(caller bug — wrong-type push doesn't corrupt the resolved-field
+storage). The same applies to `pushGlobal`.
+
+Compose semantics for vec3 mirror the scalar path component-wise:
+`ADD`/`MULTIPLY`/`SET` apply per-axis in push-order; `OVERRIDE`
+replaces the entire vec3 and short-circuits prior ops; `CLAMP_MIN`/
+`CLAMP_MAX` bound each axis independently, always last. The compose
+helper is `composeForFieldVec3`; the per-frame resolver systems
+(`MODIFIER_RESOLVE_GLOBAL`, `MODIFIER_RESOLVE_EXEMPT`) iterate both
+scalar and vec3 vectors on the same `C_Modifiers` /
+`C_GlobalModifiers` archetype and write to the matching scalar /
+vec3 vector on `C_ResolvedFields`.
+
+`C_ResolvedFields` carries two parallel vectors: `fields_` (scalar)
+and `fieldsVec3_` (vec3). Read with `get(field)` / `getVec3(field)`;
+seed with `reset(field, base)` / `resetVec3(field, base)`. A scalar
+field id and a vec3 field id may share the same name but are distinct
+`FieldBindingId`s, so their resolved values live in separate slots.
+
+`LambdaModifier` stays scalar-only in v1 — `C_LambdaModifiers` does
+not have a vec3 counterpart. A vec3 lambda channel is a Phase 2
+follow-up alongside the quat modifier kind.
+
 Key invariants the design rests on:
 
-- `Modifier` stays **trivially-copyable**. Anything needing inline
-  `std::function` or `std::string` belongs in `C_LambdaModifiers`,
-  not `C_Modifiers`.
+- `Modifier` and `ModifierVec3` both stay **trivially-copyable**.
+  Anything needing inline `std::function` or `std::string` belongs
+  in `C_LambdaModifiers`, not `C_Modifiers`.
 - Public API lives in the `IRPrefab::Modifier::` namespace per the
   prefab-layer principle in `engine/prefabs/irreden/render/CLAUDE.md`,
   NOT in `IRRender::` or any engine-library-level namespace.

--- a/engine/prefabs/irreden/common/components/component_modifiers.hpp
+++ b/engine/prefabs/irreden/common/components/component_modifiers.hpp
@@ -6,6 +6,7 @@
 // resolver-pipeline contract, and the existing-pattern audit.
 
 #include <irreden/entity/ir_entity_types.hpp>
+#include <irreden/math/ir_math_types.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -17,6 +18,16 @@ namespace IRComponents {
 using FieldBindingId = std::uint16_t;
 inline constexpr FieldBindingId kInvalidFieldId = 0;
 
+/// Typed dispatch for a field-binding id. Set at registration time
+/// (`registerField` for scalars, `registerFieldVec3` for vector fields).
+/// Push/read paths consult this on the registry to route to the
+/// correct internal vector. Pushing a typed param against a field of
+/// the wrong type is a no-op (defensive — caller bug, not data error).
+enum class FieldValueType : std::uint8_t {
+    SCALAR,
+    VEC3,
+};
+
 enum class TransformKind : std::uint8_t {
     ADD,
     MULTIPLY,
@@ -26,18 +37,18 @@ enum class TransformKind : std::uint8_t {
     OVERRIDE,
 };
 
-/// Dense modulation request on one field. The `static_assert` below
+/// Dense modulation request on one scalar field. The `static_assert` below
 /// enforces trivial-copyability; anything that needs `std::function`
 /// or `std::string` belongs in `LambdaModifier`. `ticksRemaining_ == -1`
 /// is the sentinel for "no decay"; the decay system drops the modifier
 /// once the counter reaches 0. See `docs/design/modifiers.md` §Data shapes
 /// for per-field semantics.
 struct Modifier {
-    FieldBindingId       field_;
-    TransformKind        kind_;
-    float                param_;
-    IREntity::EntityId   source_;
-    std::int32_t         ticksRemaining_;
+    FieldBindingId field_;
+    TransformKind kind_;
+    float param_;
+    IREntity::EntityId source_;
+    std::int32_t ticksRemaining_;
 };
 
 static_assert(
@@ -46,16 +57,38 @@ static_assert(
     "std::function/std::string belongs in LambdaModifier."
 );
 
+/// vec3 counterpart to `Modifier`. Compose semantics are component-wise:
+/// ADD/MULTIPLY/SET apply per-axis in push-order; CLAMP_MIN/CLAMP_MAX
+/// bound each axis independently. OVERRIDE replaces the entire vec3 and
+/// short-circuits prior ops just like the scalar path.
+struct ModifierVec3 {
+    FieldBindingId field_;
+    TransformKind kind_;
+    IRMath::vec3 param_;
+    IREntity::EntityId source_;
+    std::int32_t ticksRemaining_;
+};
+
+static_assert(
+    std::is_trivially_copyable_v<ModifierVec3>,
+    "ModifierVec3 must remain trivially-copyable; the param_ field stays vec3."
+);
+
 struct LambdaModifier {
-    FieldBindingId              field_;
+    FieldBindingId field_;
     std::function<float(float)> fn_;
-    IREntity::EntityId          source_;
-    std::int32_t                ticksRemaining_;
+    IREntity::EntityId source_;
+    std::int32_t ticksRemaining_;
 };
 
 struct ResolvedField {
     FieldBindingId field_;
-    float          value_;
+    float value_;
+};
+
+struct ResolvedFieldVec3 {
+    FieldBindingId field_;
+    IRMath::vec3 value_;
 };
 
 namespace detail {
@@ -64,21 +97,31 @@ namespace detail {
 // counts are small (~5); a hash map would cost more than it saves. If a
 // future entity carries dozens of fields, swap this for a sorted-binary
 // or small-flat-map lookup — the API stays unchanged.
-inline ResolvedField *findResolvedField(std::vector<ResolvedField> &fields,
-                                        FieldBindingId field) {
+inline ResolvedField *findResolvedField(std::vector<ResolvedField> &fields, FieldBindingId field) {
     for (auto &rf : fields) {
-        if (rf.field_ == field) return &rf;
+        if (rf.field_ == field)
+            return &rf;
+    }
+    return nullptr;
+}
+
+inline ResolvedFieldVec3 *
+findResolvedFieldVec3(std::vector<ResolvedFieldVec3> &fields, FieldBindingId field) {
+    for (auto &rf : fields) {
+        if (rf.field_ == field)
+            return &rf;
     }
     return nullptr;
 }
 
 // Shared decay predicate for the three modifier-decay systems
 // (`MODIFIER_DECAY`, `GLOBAL_MODIFIER_DECAY`, `LAMBDA_MODIFIER_DECAY`).
-// `T` is `Modifier` or `LambdaModifier` — both expose `ticksRemaining_`
-// with identical semantics. Mutates `mod.ticksRemaining_` in place.
-template <typename T>
-inline bool tickAndExpired(T &mod) {
-    if (mod.ticksRemaining_ == -1) return false;
+// `T` is `Modifier`, `ModifierVec3`, or `LambdaModifier` — all three
+// expose `ticksRemaining_` with identical semantics. Mutates
+// `mod.ticksRemaining_` in place.
+template <typename T> inline bool tickAndExpired(T &mod) {
+    if (mod.ticksRemaining_ == -1)
+        return false;
     --mod.ticksRemaining_;
     return mod.ticksRemaining_ <= 0;
 }
@@ -87,10 +130,12 @@ inline bool tickAndExpired(T &mod) {
 
 struct C_Modifiers {
     std::vector<Modifier> modifiers_;
+    std::vector<ModifierVec3> modifiersVec3_;
 };
 
 struct C_GlobalModifiers {
     std::vector<Modifier> modifiers_;
+    std::vector<ModifierVec3> modifiersVec3_;
 };
 
 /// Empty tag opting an entity out of `C_GlobalModifiers`. The
@@ -105,6 +150,7 @@ struct C_LambdaModifiers {
 
 struct C_ResolvedFields {
     std::vector<ResolvedField> fields_;
+    std::vector<ResolvedFieldVec3> fieldsVec3_;
 
     // Insert or update (field, base) so the resolver's compose pass
     // starts from `base`. Consumer systems call this in a pre-resolver
@@ -117,38 +163,102 @@ struct C_ResolvedFields {
         fields_.push_back(ResolvedField{field, base});
     }
 
+    void resetVec3(FieldBindingId field, IRMath::vec3 base) {
+        if (auto *rf = detail::findResolvedFieldVec3(fieldsVec3_, field)) {
+            rf->value_ = base;
+            return;
+        }
+        fieldsVec3_.push_back(ResolvedFieldVec3{field, base});
+    }
+
     // Convenience — apply one structured modifier in place. The
     // resolver pipeline does not use this incrementally (OVERRIDE
     // semantics need a full pass; see modifier_compose.hpp); the helper
     // is here for callers building tests or one-off composes.
     void apply(const Modifier &mod) {
         auto *rf = detail::findResolvedField(fields_, mod.field_);
-        if (!rf) return;
+        if (!rf)
+            return;
         switch (mod.kind_) {
-            case TransformKind::ADD:       rf->value_ += mod.param_; break;
-            case TransformKind::MULTIPLY:  rf->value_ *= mod.param_; break;
-            case TransformKind::SET:       rf->value_  = mod.param_; break;
-            case TransformKind::OVERRIDE:  rf->value_  = mod.param_; break;
-            case TransformKind::CLAMP_MIN:
-                if (rf->value_ < mod.param_) rf->value_ = mod.param_;
-                break;
-            case TransformKind::CLAMP_MAX:
-                if (rf->value_ > mod.param_) rf->value_ = mod.param_;
-                break;
+        case TransformKind::ADD:
+            rf->value_ += mod.param_;
+            break;
+        case TransformKind::MULTIPLY:
+            rf->value_ *= mod.param_;
+            break;
+        case TransformKind::SET:
+            rf->value_ = mod.param_;
+            break;
+        case TransformKind::OVERRIDE:
+            rf->value_ = mod.param_;
+            break;
+        case TransformKind::CLAMP_MIN:
+            if (rf->value_ < mod.param_)
+                rf->value_ = mod.param_;
+            break;
+        case TransformKind::CLAMP_MAX:
+            if (rf->value_ > mod.param_)
+                rf->value_ = mod.param_;
+            break;
+        }
+    }
+
+    // vec3 counterpart of `apply`. CLAMP_MIN/MAX bound each axis
+    // independently; OVERRIDE replaces the whole vec3. Same single-step
+    // semantics as the scalar variant — the resolver pipeline uses the
+    // pure-function compose in modifier_compose.hpp instead.
+    void apply(const ModifierVec3 &mod) {
+        auto *rf = detail::findResolvedFieldVec3(fieldsVec3_, mod.field_);
+        if (!rf)
+            return;
+        switch (mod.kind_) {
+        case TransformKind::ADD:
+            rf->value_ += mod.param_;
+            break;
+        case TransformKind::MULTIPLY:
+            rf->value_ *= mod.param_;
+            break;
+        case TransformKind::SET:
+            rf->value_ = mod.param_;
+            break;
+        case TransformKind::OVERRIDE:
+            rf->value_ = mod.param_;
+            break;
+        case TransformKind::CLAMP_MIN:
+            rf->value_.x = (rf->value_.x < mod.param_.x) ? mod.param_.x : rf->value_.x;
+            rf->value_.y = (rf->value_.y < mod.param_.y) ? mod.param_.y : rf->value_.y;
+            rf->value_.z = (rf->value_.z < mod.param_.z) ? mod.param_.z : rf->value_.z;
+            break;
+        case TransformKind::CLAMP_MAX:
+            rf->value_.x = (rf->value_.x > mod.param_.x) ? mod.param_.x : rf->value_.x;
+            rf->value_.y = (rf->value_.y > mod.param_.y) ? mod.param_.y : rf->value_.y;
+            rf->value_.z = (rf->value_.z > mod.param_.z) ? mod.param_.z : rf->value_.z;
+            break;
         }
     }
 
     void applyLambda(const LambdaModifier &lambda) {
-        if (!lambda.fn_) return;
+        if (!lambda.fn_)
+            return;
         auto *rf = detail::findResolvedField(fields_, lambda.field_);
-        if (!rf) return;
+        if (!rf)
+            return;
         rf->value_ = lambda.fn_(rf->value_);
     }
 
     // Read with a fallback when the field hasn't been registered.
     float get(FieldBindingId field, float fallback = 0.0f) const {
         for (const auto &rf : fields_) {
-            if (rf.field_ == field) return rf.value_;
+            if (rf.field_ == field)
+                return rf.value_;
+        }
+        return fallback;
+    }
+
+    IRMath::vec3 getVec3(FieldBindingId field, IRMath::vec3 fallback = IRMath::vec3(0.0f)) const {
+        for (const auto &rf : fieldsVec3_) {
+            if (rf.field_ == field)
+                return rf.value_;
         }
         return fallback;
     }

--- a/engine/prefabs/irreden/common/components/component_modifiers.hpp
+++ b/engine/prefabs/irreden/common/components/component_modifiers.hpp
@@ -225,14 +225,10 @@ struct C_ResolvedFields {
             rf->value_ = mod.param_;
             break;
         case TransformKind::CLAMP_MIN:
-            rf->value_.x = (rf->value_.x < mod.param_.x) ? mod.param_.x : rf->value_.x;
-            rf->value_.y = (rf->value_.y < mod.param_.y) ? mod.param_.y : rf->value_.y;
-            rf->value_.z = (rf->value_.z < mod.param_.z) ? mod.param_.z : rf->value_.z;
+            rf->value_ = IRMath::max(rf->value_, mod.param_);
             break;
         case TransformKind::CLAMP_MAX:
-            rf->value_.x = (rf->value_.x > mod.param_.x) ? mod.param_.x : rf->value_.x;
-            rf->value_.y = (rf->value_.y > mod.param_.y) ? mod.param_.y : rf->value_.y;
-            rf->value_.z = (rf->value_.z > mod.param_.z) ? mod.param_.z : rf->value_.z;
+            rf->value_ = IRMath::min(rf->value_, mod.param_);
             break;
         }
     }

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -41,8 +41,19 @@ inline IRComponents::FieldBindingId registerField(const char *name) {
     return detail::globalFieldRegistry().registerField(name);
 }
 
+// vec3-typed field. Pushes against this id must use the vec3 push()
+// overloads; the scalar-typed overloads silently no-op for vec3 fields
+// (caller bug, not data error).
+inline IRComponents::FieldBindingId registerFieldVec3(const char *name) {
+    return detail::globalFieldRegistry().registerFieldVec3(name);
+}
+
 inline const char *fieldName(IRComponents::FieldBindingId id) {
     return detail::globalFieldRegistry().fieldName(id);
+}
+
+inline IRComponents::FieldValueType fieldType(IRComponents::FieldBindingId id) {
+    return detail::globalFieldRegistry().fieldType(id);
 }
 
 inline std::size_t fieldCount() {
@@ -51,7 +62,9 @@ inline std::size_t fieldCount() {
 
 // Push a structured modifier onto the target entity. Defensively rejects
 // kInvalidFieldId so a default-constructed Modifier{} can't slip into
-// the pipeline.
+// the pipeline. Also rejects mismatched typing (pushing a scalar against
+// a vec3-registered field, or vice versa) so the resolver sees one type
+// per field.
 inline void push(
     IREntity::EntityId target,
     IRComponents::FieldBindingId field,
@@ -62,10 +75,32 @@ inline void push(
 ) {
     if (field == IRComponents::kInvalidFieldId)
         return;
+    if (fieldType(field) != IRComponents::FieldValueType::SCALAR)
+        return;
     auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
     if (!c)
         return;
     c->modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, ticksRemaining});
+}
+
+inline void push(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source,
+    std::int32_t ticksRemaining = -1
+) {
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    if (fieldType(field) != IRComponents::FieldValueType::VEC3)
+        return;
+    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
+    if (!c)
+        return;
+    c->modifiersVec3_.push_back(
+        IRComponents::ModifierVec3{field, kind, param, source, ticksRemaining}
+    );
 }
 
 inline void pushGlobal(
@@ -77,6 +112,8 @@ inline void pushGlobal(
 ) {
     if (field == IRComponents::kInvalidFieldId)
         return;
+    if (fieldType(field) != IRComponents::FieldValueType::SCALAR)
+        return;
     auto entity = detail::globalsEntityId();
     if (entity == IREntity::kNullEntity)
         return;
@@ -85,6 +122,29 @@ inline void pushGlobal(
     if (!c)
         return;
     c->modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, ticksRemaining});
+}
+
+inline void pushGlobal(
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source,
+    std::int32_t ticksRemaining = -1
+) {
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    if (fieldType(field) != IRComponents::FieldValueType::VEC3)
+        return;
+    auto entity = detail::globalsEntityId();
+    if (entity == IREntity::kNullEntity)
+        return;
+    auto *c =
+        IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
+    if (!c)
+        return;
+    c->modifiersVec3_.push_back(
+        IRComponents::ModifierVec3{field, kind, param, source, ticksRemaining}
+    );
 }
 
 // `ticksRemaining` is honored by `LAMBDA_MODIFIER_DECAY`, registered alongside
@@ -111,7 +171,8 @@ inline void pushLambda(
 }
 
 // Sweep both per-entity and global modifier vectors, removing any whose
-// source_ matches `source`. Linear in the total number of (entity ×
+// source_ matches `source`. Sweeps scalar AND vec3 vectors on every
+// component touched. Linear in the total number of (entity ×
 // modifier) pairs in the world. Wired automatically into
 // `EntityManager::destroyEntity` by `registerResolverPipeline()` — a
 // pre-destroy hook fires `removeBySource(destroyedEntity)` before the
@@ -132,9 +193,13 @@ inline void removeBySource(IREntity::EntityId source) {
 
     IREntity::forEachComponent<IRComponents::C_Modifiers>([&](IRComponents::C_Modifiers &c) {
         stripVec(c.modifiers_);
+        stripVec(c.modifiersVec3_);
     });
     IREntity::forEachComponent<IRComponents::C_GlobalModifiers>(
-        [&](IRComponents::C_GlobalModifiers &c) { stripVec(c.modifiers_); }
+        [&](IRComponents::C_GlobalModifiers &c) {
+            stripVec(c.modifiers_);
+            stripVec(c.modifiersVec3_);
+        }
     );
     IREntity::forEachComponent<IRComponents::C_LambdaModifiers>(
         [&](IRComponents::C_LambdaModifiers &c) { stripVec(c.modifiers_); }
@@ -163,6 +228,28 @@ applyToField(IREntity::EntityId target, IRComponents::FieldBindingId field, floa
     const auto &globals = globalsPtr ? *globalsPtr : detail::emptyModifiers();
 
     return detail::composeForField(baseValue, field, globals, entityMods);
+}
+
+// vec3 counterpart of `applyToField`. Same direct-query semantics; reads
+// from the vec3 modifier vectors on C_Modifiers and C_GlobalModifiers.
+inline IRMath::vec3 applyToFieldVec3(
+    IREntity::EntityId target, IRComponents::FieldBindingId field, IRMath::vec3 baseValue
+) {
+    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
+    const auto &entityMods = c ? c->modifiersVec3_ : detail::emptyModifiersVec3();
+
+    const std::vector<IRComponents::ModifierVec3> *globalsPtr = nullptr;
+    auto entity = detail::globalsEntityId();
+    if (entity != IREntity::kNullEntity) {
+        auto *g = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(
+            nullptr
+        );
+        if (g)
+            globalsPtr = &g->modifiersVec3_;
+    }
+    const auto &globals = globalsPtr ? *globalsPtr : detail::emptyModifiersVec3();
+
+    return detail::composeForFieldVec3(baseValue, field, globals, entityMods);
 }
 
 // Wires up the singleton globals entity and registers the six resolver

--- a/engine/prefabs/irreden/common/modifier_compose.hpp
+++ b/engine/prefabs/irreden/common/modifier_compose.hpp
@@ -15,8 +15,8 @@
 // See docs/design/modifiers.md §Resolver evaluation order.
 
 #include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/ir_math.hpp>
 
-#include <algorithm>
 #include <cstddef>
 #include <vector>
 
@@ -56,12 +56,20 @@ inline float composeForField(
 
     auto applyAlgebra = [&](const std::vector<IRComponents::Modifier> &v, std::size_t from) {
         for (std::size_t i = from; i < v.size(); ++i) {
-            if (v[i].field_ != field) continue;
+            if (v[i].field_ != field)
+                continue;
             switch (v[i].kind_) {
-                case TransformKind::ADD:      value += v[i].param_; break;
-                case TransformKind::MULTIPLY: value *= v[i].param_; break;
-                case TransformKind::SET:      value  = v[i].param_; break;
-                default: break;
+            case TransformKind::ADD:
+                value += v[i].param_;
+                break;
+            case TransformKind::MULTIPLY:
+                value *= v[i].param_;
+                break;
+            case TransformKind::SET:
+                value = v[i].param_;
+                break;
+            default:
+                break;
             }
         }
     };
@@ -70,11 +78,17 @@ inline float composeForField(
 
     auto applyClamp = [&](const std::vector<IRComponents::Modifier> &v, std::size_t from) {
         for (std::size_t i = from; i < v.size(); ++i) {
-            if (v[i].field_ != field) continue;
+            if (v[i].field_ != field)
+                continue;
             switch (v[i].kind_) {
-                case TransformKind::CLAMP_MIN: value = std::max(value, v[i].param_); break;
-                case TransformKind::CLAMP_MAX: value = std::min(value, v[i].param_); break;
-                default: break;
+            case TransformKind::CLAMP_MIN:
+                value = IRMath::max(value, v[i].param_);
+                break;
+            case TransformKind::CLAMP_MAX:
+                value = IRMath::min(value, v[i].param_);
+                break;
+            default:
+                break;
             }
         }
     };
@@ -90,11 +104,103 @@ inline const std::vector<IRComponents::Modifier> &emptyModifiers() {
 }
 
 inline float composeForField(
-    float base,
-    IRComponents::FieldBindingId field,
-    const std::vector<IRComponents::Modifier> &mods
+    float base, IRComponents::FieldBindingId field, const std::vector<IRComponents::Modifier> &mods
 ) {
     return composeForField(base, field, emptyModifiers(), mods);
+}
+
+// vec3 counterpart. Same OVERRIDE-wins / push-order-algebra /
+// clamp-last evaluation rule; ops are component-wise via IRMath
+// (ADD/MULTIPLY/SET use vec3 operators, CLAMP_MIN/MAX use IRMath::max
+// and IRMath::min, which template-dispatch to glm component-wise on
+// vec3).
+inline IRMath::vec3 composeForFieldVec3(
+    IRMath::vec3 base,
+    IRComponents::FieldBindingId field,
+    const std::vector<IRComponents::ModifierVec3> &modsA,
+    const std::vector<IRComponents::ModifierVec3> &modsB
+) {
+    using IRComponents::TransformKind;
+
+    int overrideA = -1;
+    for (std::size_t i = 0; i < modsA.size(); ++i) {
+        if (modsA[i].field_ == field && modsA[i].kind_ == TransformKind::OVERRIDE) {
+            overrideA = static_cast<int>(i);
+        }
+    }
+    int overrideB = -1;
+    for (std::size_t i = 0; i < modsB.size(); ++i) {
+        if (modsB[i].field_ == field && modsB[i].kind_ == TransformKind::OVERRIDE) {
+            overrideB = static_cast<int>(i);
+        }
+    }
+
+    IRMath::vec3 value = base;
+    std::size_t startA = 0, startB = 0;
+    if (overrideB >= 0) {
+        value = modsB[overrideB].param_;
+        startA = modsA.size();
+        startB = static_cast<std::size_t>(overrideB) + 1;
+    } else if (overrideA >= 0) {
+        value = modsA[overrideA].param_;
+        startA = static_cast<std::size_t>(overrideA) + 1;
+    }
+
+    auto applyAlgebra = [&](const std::vector<IRComponents::ModifierVec3> &v, std::size_t from) {
+        for (std::size_t i = from; i < v.size(); ++i) {
+            if (v[i].field_ != field)
+                continue;
+            switch (v[i].kind_) {
+            case TransformKind::ADD:
+                value += v[i].param_;
+                break;
+            case TransformKind::MULTIPLY:
+                value *= v[i].param_;
+                break;
+            case TransformKind::SET:
+                value = v[i].param_;
+                break;
+            default:
+                break;
+            }
+        }
+    };
+    applyAlgebra(modsA, startA);
+    applyAlgebra(modsB, startB);
+
+    auto applyClamp = [&](const std::vector<IRComponents::ModifierVec3> &v, std::size_t from) {
+        for (std::size_t i = from; i < v.size(); ++i) {
+            if (v[i].field_ != field)
+                continue;
+            switch (v[i].kind_) {
+            case TransformKind::CLAMP_MIN:
+                value = IRMath::max(value, v[i].param_);
+                break;
+            case TransformKind::CLAMP_MAX:
+                value = IRMath::min(value, v[i].param_);
+                break;
+            default:
+                break;
+            }
+        }
+    };
+    applyClamp(modsA, startA);
+    applyClamp(modsB, startB);
+
+    return value;
+}
+
+inline const std::vector<IRComponents::ModifierVec3> &emptyModifiersVec3() {
+    static const std::vector<IRComponents::ModifierVec3> kEmpty;
+    return kEmpty;
+}
+
+inline IRMath::vec3 composeForFieldVec3(
+    IRMath::vec3 base,
+    IRComponents::FieldBindingId field,
+    const std::vector<IRComponents::ModifierVec3> &mods
+) {
+    return composeForFieldVec3(base, field, emptyModifiersVec3(), mods);
 }
 
 } // namespace IRPrefab::Modifier::detail

--- a/engine/prefabs/irreden/common/modifier_field_registry.hpp
+++ b/engine/prefabs/irreden/common/modifier_field_registry.hpp
@@ -20,19 +20,38 @@ class FieldRegistry {
   public:
     FieldRegistry() {
         m_names.reserve(64);
+        m_types.reserve(64);
         m_names.push_back(nullptr); // index 0 reserved (kInvalidFieldId)
+        m_types.push_back(IRComponents::FieldValueType::SCALAR);
     }
 
-    IRComponents::FieldBindingId registerField(const char *name) {
+    IRComponents::FieldBindingId registerField(
+        const char *name, IRComponents::FieldValueType type = IRComponents::FieldValueType::SCALAR
+    ) {
         const auto id = static_cast<IRComponents::FieldBindingId>(m_names.size());
         m_names.push_back(name);
+        m_types.push_back(type);
         return id;
+    }
+
+    IRComponents::FieldBindingId registerFieldVec3(const char *name) {
+        return registerField(name, IRComponents::FieldValueType::VEC3);
     }
 
     const char *fieldName(IRComponents::FieldBindingId id) const {
         if (id == IRComponents::kInvalidFieldId || id >= m_names.size())
             return nullptr;
         return m_names[id];
+    }
+
+    // Returns SCALAR for unregistered ids. Push paths consult this to
+    // route to the correct internal vector (scalar vs vec3); a wrong-type
+    // push is a silent no-op rather than a defensive crash since the
+    // caller bug is local.
+    IRComponents::FieldValueType fieldType(IRComponents::FieldBindingId id) const {
+        if (id == IRComponents::kInvalidFieldId || id >= m_types.size())
+            return IRComponents::FieldValueType::SCALAR;
+        return m_types[id];
     }
 
     // Linear scan over registered names. v1 field counts are small
@@ -61,6 +80,7 @@ class FieldRegistry {
 
   private:
     std::vector<const char *> m_names;
+    std::vector<IRComponents::FieldValueType> m_types;
 };
 
 inline FieldRegistry &globalFieldRegistry() {

--- a/engine/prefabs/irreden/common/modifier_lua.hpp
+++ b/engine/prefabs/irreden/common/modifier_lua.hpp
@@ -28,12 +28,12 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
     }
     auto modTbl = lua.create_table();
 
-    modTbl["ADD"]       = static_cast<int>(IRComponents::TransformKind::ADD);
-    modTbl["MULTIPLY"]  = static_cast<int>(IRComponents::TransformKind::MULTIPLY);
-    modTbl["SET"]       = static_cast<int>(IRComponents::TransformKind::SET);
+    modTbl["ADD"] = static_cast<int>(IRComponents::TransformKind::ADD);
+    modTbl["MULTIPLY"] = static_cast<int>(IRComponents::TransformKind::MULTIPLY);
+    modTbl["SET"] = static_cast<int>(IRComponents::TransformKind::SET);
     modTbl["CLAMP_MIN"] = static_cast<int>(IRComponents::TransformKind::CLAMP_MIN);
     modTbl["CLAMP_MAX"] = static_cast<int>(IRComponents::TransformKind::CLAMP_MAX);
-    modTbl["OVERRIDE"]  = static_cast<int>(IRComponents::TransformKind::OVERRIDE);
+    modTbl["OVERRIDE"] = static_cast<int>(IRComponents::TransformKind::OVERRIDE);
 
     modTbl["registerField"] = [](const char *name) -> int {
         static std::unordered_set<std::string> s_luaNames;
@@ -41,18 +41,25 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
         return static_cast<int>(IRPrefab::Modifier::registerField(interned));
     };
 
+    modTbl["registerFieldVec3"] = [](const char *name) -> int {
+        static std::unordered_set<std::string> s_luaNames;
+        const char *interned = s_luaNames.emplace(name).first->c_str();
+        return static_cast<int>(IRPrefab::Modifier::registerFieldVec3(interned));
+    };
+
     struct PushOpts {
         IRComponents::FieldBindingId field_;
-        IRComponents::TransformKind  kind_;
-        float                        param_;
-        IREntity::EntityId           source_;
-        std::int32_t                 ticks_;
+        IRComponents::TransformKind kind_;
+        float param_;
+        IREntity::EntityId source_;
+        std::int32_t ticks_;
     };
     auto parseOpts = [](sol::table t) -> PushOpts {
         return {
             static_cast<IRComponents::FieldBindingId>(t.get<int>("field")),
             static_cast<IRComponents::TransformKind>(
-                t.get_or("kind", static_cast<int>(IRComponents::TransformKind::ADD))),
+                t.get_or("kind", static_cast<int>(IRComponents::TransformKind::ADD))
+            ),
             t.get_or("param", 0.0f),
             t.get_or<IREntity::EntityId>("source", IREntity::kNullEntity),
             t.get_or("ticks", -1)
@@ -69,6 +76,45 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
         IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
     };
 
+    // vec3 push paths. `param` is expected as a keyed sub-table with
+    // `x`, `y`, `z` fields. Missing components default to 0.
+    struct PushOptsVec3 {
+        IRComponents::FieldBindingId field_;
+        IRComponents::TransformKind kind_;
+        IRMath::vec3 param_;
+        IREntity::EntityId source_;
+        std::int32_t ticks_;
+    };
+    auto parseOptsVec3 = [](sol::table t) -> PushOptsVec3 {
+        IRMath::vec3 param{0.0f, 0.0f, 0.0f};
+        sol::object paramObj = t["param"];
+        if (paramObj.is<sol::table>()) {
+            sol::table pt = paramObj.as<sol::table>();
+            param.x = pt.get_or("x", 0.0f);
+            param.y = pt.get_or("y", 0.0f);
+            param.z = pt.get_or("z", 0.0f);
+        }
+        return PushOptsVec3{
+            static_cast<IRComponents::FieldBindingId>(t.get<int>("field")),
+            static_cast<IRComponents::TransformKind>(
+                t.get_or("kind", static_cast<int>(IRComponents::TransformKind::ADD))
+            ),
+            param,
+            t.get_or<IREntity::EntityId>("source", IREntity::kNullEntity),
+            t.get_or("ticks", -1)
+        };
+    };
+
+    modTbl["pushVec3"] = [parseOptsVec3](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOptsVec3(opts);
+        IRPrefab::Modifier::push(target, o.field_, o.kind_, o.param_, o.source_, o.ticks_);
+    };
+
+    modTbl["pushGlobalVec3"] = [parseOptsVec3](sol::table opts) {
+        auto o = parseOptsVec3(opts);
+        IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
+    };
+
     // fn: Lua function(base: float) -> float.
     // ticks is reserved for a future lambda-decay system; lambda modifiers
     // never auto-expire regardless of the value passed. Use removeBySource to clean up.
@@ -77,13 +123,16 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
     modTbl["pushLambda"] = [](IREntity::EntityId target, sol::table opts) {
         auto field = static_cast<IRComponents::FieldBindingId>(opts.get<int>("field"));
         sol::function fn = opts["fn"];
-        if (!fn.valid()) return;
+        if (!fn.valid())
+            return;
         auto source = opts.get_or<IREntity::EntityId>("source", IREntity::kNullEntity);
         int32_t ticks = opts.get_or("ticks", -1);
         IRPrefab::Modifier::pushLambda(
-            target, field,
+            target,
+            field,
             [fn](float base) -> float { return fn.call<float>(base); },
-            source, ticks
+            source,
+            ticks
         );
     };
 

--- a/engine/prefabs/irreden/common/modifier_lua.hpp
+++ b/engine/prefabs/irreden/common/modifier_lua.hpp
@@ -13,6 +13,7 @@
 // should pass the .entity field: ir.modifier.push(entity.entity, { ... }).
 
 #include <irreden/common/modifier.hpp>
+#include <irreden/script/ir_script_utils.hpp>
 #include <irreden/script/lua_script.hpp>
 
 #include <string>
@@ -76,8 +77,7 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
         IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
     };
 
-    // vec3 push paths. `param` is expected as a keyed sub-table with
-    // `x`, `y`, `z` fields. Missing components default to 0.
+    // vec3 push paths. `param` accepts an IRMath::vec3 userdata or a {x,y,z} table.
     struct PushOptsVec3 {
         IRComponents::FieldBindingId field_;
         IRComponents::TransformKind kind_;
@@ -86,20 +86,12 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
         std::int32_t ticks_;
     };
     auto parseOptsVec3 = [](sol::table t) -> PushOptsVec3 {
-        IRMath::vec3 param{0.0f, 0.0f, 0.0f};
-        sol::object paramObj = t["param"];
-        if (paramObj.is<sol::table>()) {
-            sol::table pt = paramObj.as<sol::table>();
-            param.x = pt.get_or("x", 0.0f);
-            param.y = pt.get_or("y", 0.0f);
-            param.z = pt.get_or("z", 0.0f);
-        }
         return PushOptsVec3{
             static_cast<IRComponents::FieldBindingId>(t.get<int>("field")),
             static_cast<IRComponents::TransformKind>(
                 t.get_or("kind", static_cast<int>(IRComponents::TransformKind::ADD))
             ),
-            param,
+            vec3FromLua(t.get<sol::object>("param")),
             t.get_or<IREntity::EntityId>("source", IREntity::kNullEntity),
             t.get_or("ticks", -1)
         };

--- a/engine/prefabs/irreden/common/systems/system_global_modifier_decay.hpp
+++ b/engine/prefabs/irreden/common/systems/system_global_modifier_decay.hpp
@@ -22,9 +22,19 @@ template <> struct System<GLOBAL_MODIFIER_DECAY> {
             [](IRComponents::C_GlobalModifiers &g) {
                 auto &v = g.modifiers_;
                 auto newEnd = std::remove_if(
-                    v.begin(), v.end(), IRComponents::detail::tickAndExpired<IRComponents::Modifier>
+                    v.begin(),
+                    v.end(),
+                    IRComponents::detail::tickAndExpired<IRComponents::Modifier>
                 );
                 v.erase(newEnd, v.end());
+
+                auto &v3 = g.modifiersVec3_;
+                auto newEnd3 = std::remove_if(
+                    v3.begin(),
+                    v3.end(),
+                    IRComponents::detail::tickAndExpired<IRComponents::ModifierVec3>
+                );
+                v3.erase(newEnd3, v3.end());
             }
         );
     }

--- a/engine/prefabs/irreden/common/systems/system_modifier_decay.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_decay.hpp
@@ -26,9 +26,19 @@ template <> struct System<MODIFIER_DECAY> {
             [](IRComponents::C_Modifiers &m) {
                 auto &v = m.modifiers_;
                 auto newEnd = std::remove_if(
-                    v.begin(), v.end(), IRComponents::detail::tickAndExpired<IRComponents::Modifier>
+                    v.begin(),
+                    v.end(),
+                    IRComponents::detail::tickAndExpired<IRComponents::Modifier>
                 );
                 v.erase(newEnd, v.end());
+
+                auto &v3 = m.modifiersVec3_;
+                auto newEnd3 = std::remove_if(
+                    v3.begin(),
+                    v3.end(),
+                    IRComponents::detail::tickAndExpired<IRComponents::ModifierVec3>
+                );
+                v3.erase(newEnd3, v3.end());
             }
         );
     }

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
@@ -23,15 +23,23 @@ template <> struct System<MODIFIER_RESOLVE_EXEMPT> {
         return createSystem<
             IRComponents::C_Modifiers,
             IRComponents::C_ResolvedFields,
-            IRComponents::C_NoGlobalModifiers
-        >(
+            IRComponents::C_NoGlobalModifiers>(
             "ModifierResolveExempt",
             [](IRComponents::C_Modifiers &m,
                IRComponents::C_ResolvedFields &resolved,
                [[maybe_unused]] IRComponents::C_NoGlobalModifiers &) {
                 for (auto &rf : resolved.fields_) {
                     rf.value_ = IRPrefab::Modifier::detail::composeForField(
-                        rf.value_, rf.field_, m.modifiers_
+                        rf.value_,
+                        rf.field_,
+                        m.modifiers_
+                    );
+                }
+                for (auto &rf : resolved.fieldsVec3_) {
+                    rf.value_ = IRPrefab::Modifier::detail::composeForFieldVec3(
+                        rf.value_,
+                        rf.field_,
+                        m.modifiersVec3_
                     );
                 }
             }

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
@@ -36,6 +36,11 @@ inline const std::vector<IRComponents::Modifier> *&currentGlobalModifiersPtr() {
     return p;
 }
 
+inline const std::vector<IRComponents::ModifierVec3> *&currentGlobalModifiersVec3Ptr() {
+    static const std::vector<IRComponents::ModifierVec3> *p = nullptr;
+    return p;
+}
+
 // No-create accessor for the singleton globals entity. Returns
 // `kNullEntity` if `registerResolverPipeline` has not yet wired up
 // the singleton, so `beginTick` below can no-op cleanly when the
@@ -70,19 +75,35 @@ template <> struct System<MODIFIER_RESOLVE_GLOBAL> {
                         m.modifiers_
                     );
                 }
+                const auto *globalsVec3Ptr =
+                    IRPrefab::Modifier::detail::currentGlobalModifiersVec3Ptr();
+                const auto &globalsVec3 = globalsVec3Ptr
+                                              ? *globalsVec3Ptr
+                                              : IRPrefab::Modifier::detail::emptyModifiersVec3();
+                for (auto &rf : resolved.fieldsVec3_) {
+                    rf.value_ = IRPrefab::Modifier::detail::composeForFieldVec3(
+                        rf.value_,
+                        rf.field_,
+                        globalsVec3,
+                        m.modifiersVec3_
+                    );
+                }
             },
-            // beginTick: cache the singleton's modifier vector pointer.
+            // beginTick: cache the singleton's modifier vector pointers.
             []() {
                 using IRComponents::C_GlobalModifiers;
                 auto &cachedPtr = IRPrefab::Modifier::detail::currentGlobalModifiersPtr();
+                auto &cachedVec3Ptr = IRPrefab::Modifier::detail::currentGlobalModifiersVec3Ptr();
                 auto entity = IRPrefab::Modifier::detail::globalsEntityId();
                 if (entity == IREntity::kNullEntity) {
                     cachedPtr = nullptr;
+                    cachedVec3Ptr = nullptr;
                     return;
                 }
                 auto *gm =
                     IREntity::getComponentOptional<C_GlobalModifiers>(entity).value_or(nullptr);
                 cachedPtr = gm ? &gm->modifiers_ : nullptr;
+                cachedVec3Ptr = gm ? &gm->modifiersVec3_ : nullptr;
             }
         );
     }

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -615,7 +615,8 @@ The canonical example is `creations/demos/lua_pipeline_demo/`: zero C++
 ```lua
 IRModifier.Transform.{ADD, MULTIPLY, SET, CLAMP_MIN, CLAMP_MAX, OVERRIDE}
 
-IRModifier.registerField("Movement.speed")           -- → FieldBindingId
+IRModifier.registerField("Movement.speed")           -- → FieldBindingId (scalar)
+IRModifier.registerFieldVec3("Idle.bobOffset")       -- → FieldBindingId (vec3)
 IRModifier.fieldId("Movement.speed")                 -- → FieldBindingId
 IRModifier.fieldName(id)                             -- → string | nil
 
@@ -625,12 +626,21 @@ IRModifier.add(entity, fieldNameOrId, {
     source = sourceEntity,           -- optional
     ticks = 60,                      -- optional, -1 = no decay
 })
+IRModifier.addVec3(entity, fieldNameOrId, {
+    transform = IRModifier.Transform.ADD,
+    value = { x = 0, y = 0.25, z = 0 },  -- {x,y,z} table or IRMath::vec3 userdata
+    source = sourceEntity,
+    ticks = -1,
+})
 IRModifier.addGlobal(fieldNameOrId, opts)
+IRModifier.addGlobalVec3(fieldNameOrId, opts)
 IRModifier.addLambda(entity, fieldNameOrId, fn, opts)
 IRModifier.removeBySource(sourceEntity)
 
 IRModifier.applyToField(entity, fieldNameOrId, base) -- → resolved float
+IRModifier.applyToFieldVec3(entity, fieldNameOrId, base) -- → resolved vec3
 IRModifier.resolved(entity, fieldNameOrId, fallback) -- read C_ResolvedFields
+IRModifier.resolvedVec3(entity, fieldNameOrId, fallback) -- read vec3 slot
 ```
 
 - **`fieldNameOrId`** — accepts a string (resolved against the registry
@@ -651,6 +661,14 @@ IRModifier.resolved(entity, fieldNameOrId, fallback) -- read C_ResolvedFields
 - **`IRModifier.applyToField`** is a direct query; it shares one
   evaluator with the resolver pipeline, so the two paths agree on the
   same input regardless of whether the resolver tick has run yet.
+- **Typed fields: scalar vs vec3.** `registerField` declares a scalar
+  field; `registerFieldVec3` declares a vec3 field. Pushing the wrong
+  scalar/vec3 payload against a typed field silently no-ops — caller
+  bug, not a data error. Resolved values live in parallel slots on
+  `C_ResolvedFields` (`fields_` and `fieldsVec3_`), so a scalar field
+  and a vec3 field cannot accidentally cross-stream. `addLambda` is
+  scalar-only in v1; vec3 lambda channels (and quat fields) are a
+  Phase 2 follow-up.
 
 ## Prefab format (`Prefab.register`, `Prefab.spawn`)
 

--- a/engine/script/include/irreden/script/lua_modifier_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_modifier_bindings.hpp
@@ -7,16 +7,27 @@
 //
 //   IRModifier.Transform.{ADD, MULTIPLY, SET, CLAMP_MIN, CLAMP_MAX, OVERRIDE}
 //   IRModifier.registerField(name)                          → FieldBindingId
+//   IRModifier.registerFieldVec3(name)                      → FieldBindingId
 //   IRModifier.fieldId(name)                                → FieldBindingId
 //                                                            (kInvalidFieldId
 //                                                            when not registered)
 //   IRModifier.fieldName(id)                                → string | nil
 //   IRModifier.add(target, fieldNameOrId, opts)
+//   IRModifier.addVec3(target, fieldNameOrId, opts)
 //   IRModifier.addGlobal(fieldNameOrId, opts)
+//   IRModifier.addGlobalVec3(fieldNameOrId, opts)
 //   IRModifier.addLambda(target, fieldNameOrId, fn, opts)
 //   IRModifier.removeBySource(source)
 //   IRModifier.applyToField(target, fieldNameOrId, base)    → float
+//   IRModifier.applyToFieldVec3(target, fieldNameOrId, base) → vec3
 //   IRModifier.resolved(target, fieldNameOrId, fallback?)   → float
+//   IRModifier.resolvedVec3(target, fieldNameOrId, fallback?) → vec3
+//
+// The vec3 variants route to fields declared via `registerFieldVec3`;
+// scalar/vec3 fields are typed at registration time, so pushing the
+// wrong-typed payload silently no-ops (caller bug). `value` in
+// `addVec3` / `addGlobalVec3` opts is parsed via `vec3FromLua` — accept
+// either a registered `IRMath::vec3` userdata or a `{x,y,z}` table.
 //
 // `target` / `source` are entity ids (Lua integers — the same shape as
 // `arch.entityAt(i)` returns from a Lua-defined system, and the same
@@ -54,6 +65,7 @@
 #include <irreden/common/components/component_modifiers.hpp>
 #include <irreden/common/modifier.hpp>
 #include <irreden/common/modifier_field_registry.hpp>
+#include <irreden/script/ir_script_utils.hpp>
 #include <irreden/script/lua_script.hpp>
 
 #include <cstdint>
@@ -132,6 +144,15 @@ inline void bindModifierFramework(LuaScript &script) {
         return static_cast<lua_Integer>(IRPrefab::Modifier::registerField(names.back().c_str()));
     };
 
+    api["registerFieldVec3"] = [](const std::string &name) {
+        // Shares the same lifetime contract as registerField above.
+        static std::deque<std::string> names;
+        names.emplace_back(name);
+        return static_cast<lua_Integer>(
+            IRPrefab::Modifier::registerFieldVec3(names.back().c_str())
+        );
+    };
+
     api["fieldId"] = [](const std::string &name) {
         return static_cast<lua_Integer>(
             IRPrefab::Modifier::detail::globalFieldRegistry().findFieldId(name.c_str())
@@ -169,6 +190,39 @@ inline void bindModifierFramework(LuaScript &script) {
         const auto field = resolveFieldArg(fieldArg, "IRModifier.addGlobal");
         const auto kind = resolveTransform(opts, "IRModifier.addGlobal");
         const float value = opts.get_or("value", 0.0f);
+        const lua_Integer source =
+            opts.get_or("source", static_cast<lua_Integer>(IREntity::kNullEntity));
+        const std::int32_t ticks = opts.get_or("ticks", static_cast<std::int32_t>(-1));
+        IRPrefab::Modifier::pushGlobal(
+            field,
+            kind,
+            value,
+            static_cast<IREntity::EntityId>(source),
+            ticks
+        );
+    };
+
+    api["addVec3"] = [](lua_Integer target, sol::object fieldArg, sol::table opts) {
+        const auto field = resolveFieldArg(fieldArg, "IRModifier.addVec3");
+        const auto kind = resolveTransform(opts, "IRModifier.addVec3");
+        const IRMath::vec3 value = IRScript::vec3FromLua(opts.get<sol::object>("value"));
+        const lua_Integer source =
+            opts.get_or("source", static_cast<lua_Integer>(IREntity::kNullEntity));
+        const std::int32_t ticks = opts.get_or("ticks", static_cast<std::int32_t>(-1));
+        IRPrefab::Modifier::push(
+            static_cast<IREntity::EntityId>(target),
+            field,
+            kind,
+            value,
+            static_cast<IREntity::EntityId>(source),
+            ticks
+        );
+    };
+
+    api["addGlobalVec3"] = [](sol::object fieldArg, sol::table opts) {
+        const auto field = resolveFieldArg(fieldArg, "IRModifier.addGlobalVec3");
+        const auto kind = resolveTransform(opts, "IRModifier.addGlobalVec3");
+        const IRMath::vec3 value = IRScript::vec3FromLua(opts.get<sol::object>("value"));
         const lua_Integer source =
             opts.get_or("source", static_cast<lua_Integer>(IREntity::kNullEntity));
         const std::int32_t ticks = opts.get_or("ticks", static_cast<std::int32_t>(-1));
@@ -229,6 +283,17 @@ inline void bindModifierFramework(LuaScript &script) {
         );
     };
 
+    api["applyToFieldVec3"] =
+        [](lua_Integer target, sol::object fieldArg, sol::object baseObj) -> IRMath::vec3 {
+        const auto field = resolveFieldArg(fieldArg, "IRModifier.applyToFieldVec3");
+        const IRMath::vec3 base = IRScript::vec3FromLua(baseObj);
+        return IRPrefab::Modifier::applyToFieldVec3(
+            static_cast<IREntity::EntityId>(target),
+            field,
+            base
+        );
+    };
+
     api["resolved"] =
         [](lua_Integer target, sol::object fieldArg, sol::optional<float> fallbackOpt) -> float {
         const auto field = resolveFieldArg(fieldArg, "IRModifier.resolved");
@@ -240,6 +305,21 @@ inline void bindModifierFramework(LuaScript &script) {
         if (resolved == nullptr)
             return fallback;
         return resolved->get(field, fallback);
+    };
+
+    api["resolvedVec3"] = [](lua_Integer target,
+                             sol::object fieldArg,
+                             sol::optional<sol::object> fallbackOpt) -> IRMath::vec3 {
+        const auto field = resolveFieldArg(fieldArg, "IRModifier.resolvedVec3");
+        const IRMath::vec3 fallback =
+            fallbackOpt ? IRScript::vec3FromLua(*fallbackOpt) : IRMath::vec3(0.0f);
+        auto *resolved = IREntity::getComponentOptional<IRComponents::C_ResolvedFields>(
+                             static_cast<IREntity::EntityId>(target)
+        )
+                             .value_or(nullptr);
+        if (resolved == nullptr)
+            return fallback;
+        return resolved->getVec3(field, fallback);
     };
 
     lua["IRModifier"] = api;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(IrredenEngineTest
   ecs/hitbox_2d_gui_test.cpp
   ecs/modifier_runtime_test.cpp
   ecs/modifier_types_test.cpp
+  ecs/modifier_vec3_runtime_test.cpp
   ecs/system_exclude_test.cpp
   math/physics_test.cpp
   math/ir_math_test.cpp

--- a/test/ecs/modifier_types_test.cpp
+++ b/test/ecs/modifier_types_test.cpp
@@ -7,17 +7,20 @@
 
 namespace {
 
-using IRComponents::FieldBindingId;
-using IRComponents::kInvalidFieldId;
-using IRComponents::TransformKind;
-using IRComponents::Modifier;
-using IRComponents::LambdaModifier;
-using IRComponents::ResolvedField;
-using IRComponents::C_Modifiers;
 using IRComponents::C_GlobalModifiers;
-using IRComponents::C_NoGlobalModifiers;
 using IRComponents::C_LambdaModifiers;
+using IRComponents::C_Modifiers;
+using IRComponents::C_NoGlobalModifiers;
 using IRComponents::C_ResolvedFields;
+using IRComponents::FieldBindingId;
+using IRComponents::FieldValueType;
+using IRComponents::kInvalidFieldId;
+using IRComponents::LambdaModifier;
+using IRComponents::Modifier;
+using IRComponents::ModifierVec3;
+using IRComponents::ResolvedField;
+using IRComponents::ResolvedFieldVec3;
+using IRComponents::TransformKind;
 
 TEST(ModifierTypes, ModifierIsTriviallyCopyable) {
     static_assert(std::is_trivially_copyable_v<Modifier>);
@@ -56,13 +59,15 @@ TEST(ModifierTypes, ComponentsDefaultConstructEmpty) {
 
 TEST(ModifierTypes, ModifierPushAndRead) {
     C_Modifiers c{};
-    c.modifiers_.push_back(Modifier{
-        FieldBindingId{1},
-        TransformKind::ADD,
-        0.5f,
-        IREntity::EntityId{42},
-        std::int32_t{-1},
-    });
+    c.modifiers_.push_back(
+        Modifier{
+            FieldBindingId{1},
+            TransformKind::ADD,
+            0.5f,
+            IREntity::EntityId{42},
+            std::int32_t{-1},
+        }
+    );
 
     ASSERT_EQ(c.modifiers_.size(), std::size_t{1});
     EXPECT_EQ(c.modifiers_[0].field_, FieldBindingId{1});
@@ -74,12 +79,14 @@ TEST(ModifierTypes, ModifierPushAndRead) {
 
 TEST(ModifierTypes, LambdaModifierStoresFunction) {
     C_LambdaModifiers c{};
-    c.modifiers_.push_back(LambdaModifier{
-        FieldBindingId{2},
-        [](float base) { return base * 2.0f; },
-        IREntity::EntityId{7},
-        std::int32_t{60},
-    });
+    c.modifiers_.push_back(
+        LambdaModifier{
+            FieldBindingId{2},
+            [](float base) { return base * 2.0f; },
+            IREntity::EntityId{7},
+            std::int32_t{60},
+        }
+    );
 
     ASSERT_EQ(c.modifiers_.size(), std::size_t{1});
     EXPECT_FLOAT_EQ(c.modifiers_[0].fn_(3.0f), 6.0f);
@@ -94,6 +101,27 @@ TEST(ModifierTypes, ResolvedFieldsLookup) {
 
     EXPECT_EQ(c.fields_.size(), std::size_t{2});
     EXPECT_FLOAT_EQ(c.fields_[1].value_, 2.5f);
+}
+
+TEST(ModifierTypes, ModifierVec3IsTriviallyCopyable) {
+    static_assert(std::is_trivially_copyable_v<ModifierVec3>);
+    SUCCEED();
+}
+
+TEST(ModifierTypes, FieldValueTypeSize) {
+    static_assert(sizeof(FieldValueType) == 1);
+    SUCCEED();
+}
+
+TEST(ModifierTypes, CResolvedFieldsHoldsBothVectorsIndependently) {
+    C_ResolvedFields c{};
+    c.fields_.push_back(ResolvedField{FieldBindingId{1}, 1.5f});
+    c.fieldsVec3_.push_back(ResolvedFieldVec3{FieldBindingId{2}, IRMath::vec3(1.0f, 2.0f, 3.0f)});
+
+    EXPECT_EQ(c.fields_.size(), std::size_t{1});
+    EXPECT_EQ(c.fieldsVec3_.size(), std::size_t{1});
+    EXPECT_FLOAT_EQ(c.fields_[0].value_, 1.5f);
+    EXPECT_FLOAT_EQ(c.fieldsVec3_[0].value_.y, 2.0f);
 }
 
 } // namespace

--- a/test/ecs/modifier_types_test.cpp
+++ b/test/ecs/modifier_types_test.cpp
@@ -108,6 +108,12 @@ TEST(ModifierTypes, ModifierVec3IsTriviallyCopyable) {
     SUCCEED();
 }
 
+TEST(ModifierTypes, ModifierVec3LayoutLocked) {
+    static_assert(sizeof(ModifierVec3) == 32);
+    static_assert(alignof(ModifierVec3) == 8);
+    SUCCEED();
+}
+
 TEST(ModifierTypes, FieldValueTypeSize) {
     static_assert(sizeof(FieldValueType) == 1);
     SUCCEED();

--- a/test/ecs/modifier_vec3_runtime_test.cpp
+++ b/test/ecs/modifier_vec3_runtime_test.cpp
@@ -1,0 +1,453 @@
+#include <gtest/gtest.h>
+
+#include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/common/modifier.hpp>
+#include <irreden/common/modifier_compose.hpp>
+#include <irreden/common/modifier_field_registry.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <vector>
+
+namespace {
+
+using IRComponents::C_Modifiers;
+using IRComponents::C_ResolvedFields;
+using IRComponents::FieldBindingId;
+using IRComponents::FieldValueType;
+using IRComponents::kInvalidFieldId;
+using IRComponents::ModifierVec3;
+using IRComponents::ResolvedFieldVec3;
+using IRComponents::TransformKind;
+
+using IRPrefab::Modifier::detail::composeForFieldVec3;
+using IRPrefab::Modifier::detail::FieldRegistry;
+
+// ---- Field registry: typed binding -----------------------------------------
+
+TEST(ModifierRegistryVec3, RegisterFieldVec3AssignsType) {
+    FieldRegistry registry;
+    auto scalarId = registry.registerField("scalar.field");
+    auto vec3Id = registry.registerFieldVec3("vec3.field");
+
+    EXPECT_EQ(registry.fieldType(scalarId), FieldValueType::SCALAR);
+    EXPECT_EQ(registry.fieldType(vec3Id), FieldValueType::VEC3);
+    EXPECT_EQ(registry.fieldCount(), 2u);
+}
+
+TEST(ModifierRegistryVec3, FieldTypeForInvalidIdIsScalar) {
+    FieldRegistry registry;
+    EXPECT_EQ(registry.fieldType(kInvalidFieldId), FieldValueType::SCALAR);
+    EXPECT_EQ(registry.fieldType(FieldBindingId{42}), FieldValueType::SCALAR);
+}
+
+// ---- Compose: structured vec3 transforms ----------------------------------
+
+namespace {
+
+constexpr FieldBindingId kFieldA = FieldBindingId{1};
+constexpr FieldBindingId kFieldB = FieldBindingId{2};
+
+ModifierVec3 mkV(FieldBindingId field, TransformKind kind, IRMath::vec3 param) {
+    return ModifierVec3{field, kind, param, IREntity::EntityId{0}, -1};
+}
+
+} // namespace
+
+TEST(ModifierComposeVec3, NoModifiersReturnsBase) {
+    std::vector<ModifierVec3> mods;
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(1.0f, 2.0f, 3.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 1.0f);
+    EXPECT_FLOAT_EQ(result.y, 2.0f);
+    EXPECT_FLOAT_EQ(result.z, 3.0f);
+}
+
+TEST(ModifierComposeVec3, AddStacksComponentWise) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(1.0f, 0.0f, 0.0f)),
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(0.0f, 2.0f, 0.0f)),
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(0.0f, 0.0f, 3.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 11.0f);
+    EXPECT_FLOAT_EQ(result.y, 12.0f);
+    EXPECT_FLOAT_EQ(result.z, 13.0f);
+}
+
+TEST(ModifierComposeVec3, MultiplyScalesPerAxis) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::MULTIPLY, IRMath::vec3(2.0f, 0.5f, 1.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f, 10.0f, 10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 20.0f);
+    EXPECT_FLOAT_EQ(result.y, 5.0f);
+    EXPECT_FLOAT_EQ(result.z, 10.0f);
+}
+
+TEST(ModifierComposeVec3, AddThenMultiplyAppliesInPushOrder) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(5.0f, 5.0f, 5.0f)),
+        mkV(kFieldA, TransformKind::MULTIPLY, IRMath::vec3(2.0f, 2.0f, 2.0f)),
+    };
+    // (10 + 5) * 2 = 30 per axis
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 30.0f);
+    EXPECT_FLOAT_EQ(result.y, 30.0f);
+    EXPECT_FLOAT_EQ(result.z, 30.0f);
+}
+
+TEST(ModifierComposeVec3, SetReplacesEntireVector) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(5.0f)),
+        mkV(kFieldA, TransformKind::SET, IRMath::vec3(100.0f, 200.0f, 300.0f)),
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(1.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 101.0f);
+    EXPECT_FLOAT_EQ(result.y, 201.0f);
+    EXPECT_FLOAT_EQ(result.z, 301.0f);
+}
+
+TEST(ModifierComposeVec3, ClampMinPerAxis) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::CLAMP_MIN, IRMath::vec3(0.0f, 5.0f, -10.0f)),
+        mkV(kFieldA, TransformKind::MULTIPLY, IRMath::vec3(0.0f, 0.0f, 0.0f)),
+    };
+    // All axes go to 0; clamp_min bounds each axis to its own minimum.
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 0.0f);
+    EXPECT_FLOAT_EQ(result.y, 5.0f);
+    EXPECT_FLOAT_EQ(result.z, 0.0f);
+}
+
+TEST(ModifierComposeVec3, ClampMaxPerAxis) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::CLAMP_MAX, IRMath::vec3(50.0f, 10.0f, 5.0f)),
+        mkV(kFieldA, TransformKind::MULTIPLY, IRMath::vec3(100.0f)),
+    };
+    // 10 * 100 = 1000 per axis; clamp_max bounds each axis independently.
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 50.0f);
+    EXPECT_FLOAT_EQ(result.y, 10.0f);
+    EXPECT_FLOAT_EQ(result.z, 5.0f);
+}
+
+TEST(ModifierComposeVec3, ClampAppliedAfterAlgebraIrrespectiveOfPushOrder) {
+    std::vector<ModifierVec3> mods{
+        // Clamp pushed BEFORE the multiply; resolver still applies clamp last.
+        mkV(kFieldA, TransformKind::CLAMP_MIN, IRMath::vec3(5.0f)),
+        mkV(kFieldA, TransformKind::MULTIPLY, IRMath::vec3(0.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 5.0f);
+    EXPECT_FLOAT_EQ(result.y, 5.0f);
+    EXPECT_FLOAT_EQ(result.z, 5.0f);
+}
+
+TEST(ModifierComposeVec3, OverrideShortCircuitsPriorModifiers) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(5.0f)),
+        mkV(kFieldA, TransformKind::MULTIPLY, IRMath::vec3(10.0f)),
+        mkV(kFieldA, TransformKind::OVERRIDE, IRMath::vec3(7.0f, 8.0f, 9.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(100.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 7.0f);
+    EXPECT_FLOAT_EQ(result.y, 8.0f);
+    EXPECT_FLOAT_EQ(result.z, 9.0f);
+}
+
+TEST(ModifierComposeVec3, OverrideLetsLaterModifiersApply) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(100.0f)),
+        mkV(kFieldA, TransformKind::OVERRIDE, IRMath::vec3(5.0f, 5.0f, 5.0f)),
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(2.0f)),
+        mkV(kFieldA, TransformKind::CLAMP_MAX, IRMath::vec3(6.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    // OVERRIDE → 5, ADD 2 → 7, CLAMP_MAX 6 → 6 (per axis).
+    EXPECT_FLOAT_EQ(result.x, 6.0f);
+    EXPECT_FLOAT_EQ(result.y, 6.0f);
+    EXPECT_FLOAT_EQ(result.z, 6.0f);
+}
+
+TEST(ModifierComposeVec3, LatestOverrideWins) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::OVERRIDE, IRMath::vec3(1.0f)),
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(99.0f)),
+        mkV(kFieldA, TransformKind::OVERRIDE, IRMath::vec3(2.0f, 3.0f, 4.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 2.0f);
+    EXPECT_FLOAT_EQ(result.y, 3.0f);
+    EXPECT_FLOAT_EQ(result.z, 4.0f);
+}
+
+TEST(ModifierComposeVec3, OtherFieldsDoNotInfluenceTarget) {
+    std::vector<ModifierVec3> mods{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(5.0f)),
+        mkV(kFieldB, TransformKind::ADD, IRMath::vec3(1000.0f)),
+        mkV(kFieldA, TransformKind::MULTIPLY, IRMath::vec3(2.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 30.0f);
+    EXPECT_FLOAT_EQ(result.y, 30.0f);
+    EXPECT_FLOAT_EQ(result.z, 30.0f);
+}
+
+// ---- Compose: globals + entity layering -----------------------------------
+
+TEST(ModifierComposeVec3Globals, GlobalsApplyBeforeEntity) {
+    std::vector<ModifierVec3> globals{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(5.0f)),
+    };
+    std::vector<ModifierVec3> entity{
+        mkV(kFieldA, TransformKind::MULTIPLY, IRMath::vec3(2.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, globals, entity);
+    EXPECT_FLOAT_EQ(result.x, 30.0f);
+    EXPECT_FLOAT_EQ(result.y, 30.0f);
+    EXPECT_FLOAT_EQ(result.z, 30.0f);
+}
+
+TEST(ModifierComposeVec3Globals, EntityOverrideTrumpsGlobalAlgebra) {
+    std::vector<ModifierVec3> globals{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(100.0f)),
+    };
+    std::vector<ModifierVec3> entity{
+        mkV(kFieldA, TransformKind::OVERRIDE, IRMath::vec3(1.0f, 2.0f, 3.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, globals, entity);
+    EXPECT_FLOAT_EQ(result.x, 1.0f);
+    EXPECT_FLOAT_EQ(result.y, 2.0f);
+    EXPECT_FLOAT_EQ(result.z, 3.0f);
+}
+
+TEST(ModifierComposeVec3Globals, ClampSpansBothVectors) {
+    std::vector<ModifierVec3> globals{
+        mkV(kFieldA, TransformKind::CLAMP_MAX, IRMath::vec3(20.0f)),
+    };
+    std::vector<ModifierVec3> entity{
+        mkV(kFieldA, TransformKind::ADD, IRMath::vec3(100.0f)),
+    };
+    IRMath::vec3 result = composeForFieldVec3(IRMath::vec3(10.0f), kFieldA, globals, entity);
+    EXPECT_FLOAT_EQ(result.x, 20.0f);
+    EXPECT_FLOAT_EQ(result.y, 20.0f);
+    EXPECT_FLOAT_EQ(result.z, 20.0f);
+}
+
+// ---- C_ResolvedFields helpers ---------------------------------------------
+
+TEST(CResolvedFieldsVec3, ResetInsertsAndUpdates) {
+    C_ResolvedFields rf;
+    rf.resetVec3(kFieldA, IRMath::vec3(1.0f, 2.0f, 3.0f));
+    ASSERT_EQ(rf.fieldsVec3_.size(), 1u);
+    EXPECT_FLOAT_EQ(rf.getVec3(kFieldA).y, 2.0f);
+
+    rf.resetVec3(kFieldA, IRMath::vec3(7.0f));
+    ASSERT_EQ(rf.fieldsVec3_.size(), 1u);
+    EXPECT_FLOAT_EQ(rf.getVec3(kFieldA).x, 7.0f);
+
+    rf.resetVec3(kFieldB, IRMath::vec3(3.0f));
+    ASSERT_EQ(rf.fieldsVec3_.size(), 2u);
+    EXPECT_FLOAT_EQ(rf.getVec3(kFieldB).z, 3.0f);
+}
+
+TEST(CResolvedFieldsVec3, ApplyMutatesValuePerAxis) {
+    C_ResolvedFields rf;
+    rf.resetVec3(kFieldA, IRMath::vec3(10.0f));
+    rf.apply(mkV(kFieldA, TransformKind::ADD, IRMath::vec3(5.0f, 0.0f, -5.0f)));
+    auto v = rf.getVec3(kFieldA);
+    EXPECT_FLOAT_EQ(v.x, 15.0f);
+    EXPECT_FLOAT_EQ(v.y, 10.0f);
+    EXPECT_FLOAT_EQ(v.z, 5.0f);
+
+    rf.apply(mkV(kFieldA, TransformKind::CLAMP_MIN, IRMath::vec3(8.0f)));
+    v = rf.getVec3(kFieldA);
+    EXPECT_FLOAT_EQ(v.x, 15.0f);
+    EXPECT_FLOAT_EQ(v.y, 10.0f);
+    EXPECT_FLOAT_EQ(v.z, 8.0f);
+}
+
+TEST(CResolvedFieldsVec3, GetFallbackForUnknownField) {
+    C_ResolvedFields rf;
+    rf.resetVec3(kFieldA, IRMath::vec3(1.0f));
+    auto fallback = rf.getVec3(kFieldB, IRMath::vec3(-1.0f, -2.0f, -3.0f));
+    EXPECT_FLOAT_EQ(fallback.y, -2.0f);
+}
+
+TEST(CResolvedFieldsVec3, ScalarAndVec3PathsAreIndependent) {
+    // Both vectors live on the same C_ResolvedFields; resetVec3 must
+    // not stomp the scalar field with the same id, and vice versa.
+    C_ResolvedFields rf;
+    rf.reset(kFieldA, 1.5f);
+    rf.resetVec3(kFieldA, IRMath::vec3(10.0f, 20.0f, 30.0f));
+
+    EXPECT_FLOAT_EQ(rf.get(kFieldA), 1.5f);
+    EXPECT_FLOAT_EQ(rf.getVec3(kFieldA).y, 20.0f);
+}
+
+// ---- Decay semantics: in-place via std::remove_if -----------------------
+
+namespace {
+
+void decayVec3Once(std::vector<ModifierVec3> &v) {
+    auto end = std::remove_if(
+        v.begin(), v.end(), IRComponents::detail::tickAndExpired<ModifierVec3>
+    );
+    v.erase(end, v.end());
+}
+
+} // namespace
+
+TEST(ModifierVec3Decay, MinusOneSentinelIsKeptForever) {
+    std::vector<ModifierVec3> mods{
+        ModifierVec3{kFieldA, TransformKind::ADD, IRMath::vec3(1.0f), IREntity::EntityId{0}, -1},
+    };
+    decayVec3Once(mods);
+    EXPECT_EQ(mods.size(), 1u);
+}
+
+TEST(ModifierVec3Decay, ExactExpiryDropsAtZero) {
+    std::vector<ModifierVec3> mods{
+        ModifierVec3{kFieldA, TransformKind::ADD, IRMath::vec3(1.0f), IREntity::EntityId{0}, 1},
+    };
+    decayVec3Once(mods);
+    EXPECT_EQ(mods.size(), 0u);
+}
+
+TEST(ModifierVec3Decay, SixtyTickModifierExpiresAtSixty) {
+    std::vector<ModifierVec3> mods{
+        ModifierVec3{kFieldA, TransformKind::ADD, IRMath::vec3(1.0f), IREntity::EntityId{0}, 60},
+    };
+    for (int i = 0; i < 59; ++i) {
+        decayVec3Once(mods);
+        ASSERT_EQ(mods.size(), 1u) << "premature drop at tick " << i;
+    }
+    decayVec3Once(mods);
+    EXPECT_EQ(mods.size(), 0u);
+}
+
+// ---- Push API: type-mismatch dispatch ------------------------------------
+
+class IRModifierVec3PushTest : public testing::Test {
+  protected:
+    IRModifierVec3PushTest()
+        : m_entity_manager{} {}
+
+    IREntity::EntityManager m_entity_manager;
+};
+
+TEST_F(IRModifierVec3PushTest, ScalarPushAgainstVec3FieldNoOps) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto vec3FieldId = IRPrefab::Modifier::registerFieldVec3("test.vec3_only");
+
+    IRPrefab::Modifier::push(target, vec3FieldId, TransformKind::ADD, 1.0f, IREntity::kNullEntity);
+
+    auto &c = IREntity::getComponent<C_Modifiers>(target);
+    EXPECT_EQ(c.modifiers_.size(), 0u);
+    EXPECT_EQ(c.modifiersVec3_.size(), 0u);
+}
+
+TEST_F(IRModifierVec3PushTest, Vec3PushAgainstScalarFieldNoOps) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto scalarFieldId = IRPrefab::Modifier::registerField("test.scalar_only");
+
+    IRPrefab::Modifier::push(
+        target,
+        scalarFieldId,
+        TransformKind::ADD,
+        IRMath::vec3(1.0f),
+        IREntity::kNullEntity
+    );
+
+    auto &c = IREntity::getComponent<C_Modifiers>(target);
+    EXPECT_EQ(c.modifiers_.size(), 0u);
+    EXPECT_EQ(c.modifiersVec3_.size(), 0u);
+}
+
+TEST_F(IRModifierVec3PushTest, Vec3PushAgainstVec3FieldLandsInVec3Vector) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto vec3FieldId = IRPrefab::Modifier::registerFieldVec3("test.bob_offset");
+
+    IRPrefab::Modifier::push(
+        target,
+        vec3FieldId,
+        TransformKind::ADD,
+        IRMath::vec3(0.5f, 1.0f, 1.5f),
+        IREntity::kNullEntity
+    );
+
+    auto &c = IREntity::getComponent<C_Modifiers>(target);
+    EXPECT_EQ(c.modifiers_.size(), 0u);
+    ASSERT_EQ(c.modifiersVec3_.size(), 1u);
+    EXPECT_FLOAT_EQ(c.modifiersVec3_[0].param_.y, 1.0f);
+}
+
+TEST_F(IRModifierVec3PushTest, ApplyToFieldVec3ComposesDirectly) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto field = IRPrefab::Modifier::registerFieldVec3("test.apply_query");
+    IRPrefab::Modifier::push(
+        target, field, TransformKind::ADD, IRMath::vec3(2.0f, 4.0f, 6.0f), IREntity::kNullEntity
+    );
+
+    auto result = IRPrefab::Modifier::applyToFieldVec3(target, field, IRMath::vec3(10.0f));
+    EXPECT_FLOAT_EQ(result.x, 12.0f);
+    EXPECT_FLOAT_EQ(result.y, 14.0f);
+    EXPECT_FLOAT_EQ(result.z, 16.0f);
+}
+
+// ---- Auto-sweep on entity destruction (vec3 vectors) ---------------------
+
+class IRModifierVec3AutoSweepTest : public testing::Test {
+  protected:
+    IRModifierVec3AutoSweepTest()
+        : m_entity_manager{} {
+        m_hook_id = IREntity::getEntityManager().registerPreDestroyHook(
+            [](IREntity::EntityId destroyed) {
+                IRPrefab::Modifier::removeBySource(destroyed);
+            }
+        );
+    }
+
+    ~IRModifierVec3AutoSweepTest() override {
+        IREntity::getEntityManager().unregisterPreDestroyHook(m_hook_id);
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IREntity::PreDestroyHookId m_hook_id{IREntity::kInvalidPreDestroyHookId};
+};
+
+TEST_F(IRModifierVec3AutoSweepTest, DestroyingSourceStripsVec3ModifiersFromTarget) {
+    auto field = IRPrefab::Modifier::registerFieldVec3("test.sweep");
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(C_Modifiers{});
+
+    IRPrefab::Modifier::push(
+        target, field, TransformKind::ADD, IRMath::vec3(1.0f, 2.0f, 3.0f), source
+    );
+    auto &before = IREntity::getComponent<C_Modifiers>(target).modifiersVec3_;
+    ASSERT_EQ(before.size(), 1u);
+
+    m_entity_manager.destroyEntity(source);
+
+    auto &after = IREntity::getComponent<C_Modifiers>(target).modifiersVec3_;
+    EXPECT_EQ(after.size(), 0u);
+}
+
+TEST_F(IRModifierVec3AutoSweepTest, DestroyingSourceLeavesOtherSourceVec3ModifiersAlone) {
+    auto field = IRPrefab::Modifier::registerFieldVec3("test.sweep_partial");
+    auto sourceA = IREntity::createEntity();
+    auto sourceB = IREntity::createEntity();
+    auto target  = IREntity::createEntity(C_Modifiers{});
+
+    IRPrefab::Modifier::push(target, field, TransformKind::ADD, IRMath::vec3(1.0f), sourceA);
+    IRPrefab::Modifier::push(target, field, TransformKind::ADD, IRMath::vec3(7.0f), sourceB);
+
+    m_entity_manager.destroyEntity(sourceA);
+
+    auto &after = IREntity::getComponent<C_Modifiers>(target).modifiersVec3_;
+    ASSERT_EQ(after.size(), 1u);
+    EXPECT_EQ(after[0].source_, sourceB);
+    EXPECT_FLOAT_EQ(after[0].param_.x, 7.0f);
+}
+
+} // namespace

--- a/test/script/lua_pipeline_register_test.cpp
+++ b/test/script/lua_pipeline_register_test.cpp
@@ -266,6 +266,57 @@ TEST_F(LuaPipelineRegisterTest, AddMultiplyHalvesResolvedFieldFromLua) {
     EXPECT_FLOAT_EQ(fromLua, 50.0f);
 }
 
+// ---- IRModifier vec3 surface ----------------------------------------------
+
+TEST_F(LuaPipelineRegisterTest, AddVec3ComposesPerAxisFromLua) {
+    auto &lua = m_lua.lua();
+    const EntityId entity = IREntity::createEntity(C_Modifiers{});
+    lua["g_entity"] = static_cast<lua_Integer>(entity);
+
+    auto setup = lua.safe_script(
+        R"(
+        local field = IRModifier.registerFieldVec3("lua.test.bob_offset")
+        IRModifier.addVec3(g_entity, field, {
+            transform = IRModifier.Transform.ADD,
+            value = { x = 1.0, y = 2.0, z = 3.0 },
+        })
+        return field
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(setup.valid()) << "addVec3 setup failed";
+    const auto fieldId = static_cast<FieldBindingId>(setup.get<lua_Integer>());
+
+    const IRMath::vec3 base{10.0f, 10.0f, 10.0f};
+    const IRMath::vec3 resolved = IRPrefab::Modifier::applyToFieldVec3(entity, fieldId, base);
+    EXPECT_FLOAT_EQ(resolved.x, 11.0f);
+    EXPECT_FLOAT_EQ(resolved.y, 12.0f);
+    EXPECT_FLOAT_EQ(resolved.z, 13.0f);
+}
+
+TEST_F(LuaPipelineRegisterTest, AddVec3AgainstScalarFieldIsNoOp) {
+    auto &lua = m_lua.lua();
+    const EntityId entity = IREntity::createEntity(C_Modifiers{});
+    lua["g_entity"] = static_cast<lua_Integer>(entity);
+
+    auto result = lua.safe_script(
+        R"(
+        local scalarField = IRModifier.registerField("lua.test.cross_typed_scalar")
+        IRModifier.addVec3(g_entity, scalarField, {
+            transform = IRModifier.Transform.ADD,
+            value = { x = 1.0, y = 2.0, z = 3.0 },
+        })
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << "addVec3 raised on scalar-typed field";
+
+    // Neither vector should have an entry — the wrong-type push was a no-op.
+    const auto &c = IREntity::getComponent<C_Modifiers>(entity);
+    EXPECT_EQ(c.modifiers_.size(), 0u);
+    EXPECT_EQ(c.modifiersVec3_.size(), 0u);
+}
+
 TEST_F(LuaPipelineRegisterTest, AddRejectsUnknownFieldName) {
     auto &lua = m_lua.lua();
     const EntityId entity = IREntity::createEntity(C_Modifiers{});


### PR DESCRIPTION
## Summary
- Extends the modifier framework with vec3-typed fields alongside the existing scalar path.
- Adds parallel `ModifierVec3` / `ResolvedFieldVec3` types kept inside the same `C_Modifiers` / `C_GlobalModifiers` / `C_ResolvedFields` components — one component, two internal columns.
- Field registry tracks `FieldValueType::{SCALAR, VEC3}` per binding id. `push()` is overloaded on scalar vs `vec3`; pushing the wrong type against a typed field silently no-ops (caller bug, not data error).
- Compose semantics for vec3 mirror the scalar path component-wise: `ADD`/`MULTIPLY`/`SET` per-axis in push-order; `CLAMP_MIN`/`CLAMP_MAX` bound each axis independently; `OVERRIDE` replaces the entire vec3 and short-circuits prior ops.
- Lua surface: `IRModifier.registerFieldVec3` / `addVec3` / `addGlobalVec3` / `applyToFieldVec3` / `resolvedVec3` mirror the scalar API. Param values accept either `IRMath::vec3` userdata or a `{x,y,z}` table.

## Design choice — parallel types over `std::variant`

Architect's issue (#732) offered two paths: tagged-union param (one struct fits all) vs parallel `ModifierVec3` types. I went with parallel types because:

- `Modifier` stays trivially-copyable and unchanged at 24 B (passes the existing `static_assert`); `ModifierVec3` is also trivially-copyable at 32 B.
- The new vec3 work piggybacks on the existing archetype routing — no new component, no new resolver systems, no per-entity branching.
- Public `push()` API is overloaded on scalar vs `vec3`, so callers see a unified surface (type-driven dispatch) without exposing the internal split.
- `LambdaModifier` stays scalar-only per the architect's "defer if it complicates this ticket" note. vec3 lambda channels and quat modifier kind are Phase 2 follow-ups.

While extending `modifier_compose.hpp`, replaced the pre-existing `std::min`/`std::max` in the scalar path with `IRMath::min`/`IRMath::max` to satisfy the cpp-math rule (live-deviation migrate-when-touched policy).

## Test plan
- [x] All 659 existing tests pass (`./IrredenEngineTest`)
- [x] `sizeof(Modifier) == 24` invariant locked (existing test)
- [x] 37 new tests covering vec3 compose semantics, typed dispatch, removeBySource sweep over vec3 vectors, decay over vec3 vectors, scalar/vec3 isolation, Lua addVec3 round-trip, Lua cross-typed push no-op
- [x] `IRModifierDemo` still builds (sanity)

## Files
- `engine/prefabs/irreden/common/components/component_modifiers.hpp` — add `ModifierVec3`, `ResolvedFieldVec3`, `FieldValueType`; extend `C_Modifiers` / `C_GlobalModifiers` / `C_ResolvedFields` with vec3 vectors; add `apply(ModifierVec3)`, `resetVec3`, `getVec3`.
- `engine/prefabs/irreden/common/modifier_field_registry.hpp` — track `FieldValueType` per id; add `registerFieldVec3`, `fieldType`.
- `engine/prefabs/irreden/common/modifier_compose.hpp` — add `composeForFieldVec3`; replace `std::min`/`std::max` with `IRMath::min`/`IRMath::max` in the scalar path.
- `engine/prefabs/irreden/common/modifier.hpp` — overload `push`/`pushGlobal` on `vec3`; add `applyToFieldVec3`, `registerFieldVec3`, `fieldType`; extend `removeBySource` to sweep vec3 vectors.
- `engine/prefabs/irreden/common/modifier_lua.hpp` — add `registerFieldVec3`, `pushVec3`, `pushGlobalVec3` to the older `ir.modifier.*` namespace.
- `engine/prefabs/irreden/common/systems/system_modifier_{decay,resolve_global,resolve_exempt}.hpp` + `system_global_modifier_decay.hpp` — iterate / sweep both vectors.
- `engine/script/include/irreden/script/lua_modifier_bindings.hpp` — add `IRModifier.registerFieldVec3` / `addVec3` / `addGlobalVec3` / `applyToFieldVec3` / `resolvedVec3` to the canonical Lua surface.
- `engine/prefabs/irreden/common/CLAUDE.md` + `engine/script/CLAUDE.md` + `docs/design/modifiers.md` — document the typed-field model, the vec3 Lua surface, and add §"vec3 extension (T-191)" to the design doc.
- `test/ecs/modifier_vec3_runtime_test.cpp` (new), `test/ecs/modifier_types_test.cpp`, `test/script/lua_pipeline_register_test.cpp`, `test/CMakeLists.txt` — 37 new tests.

## Notes for reviewer
- The "wrong-type push silently no-ops" behavior is intentional and tested. Two failure modes considered: (a) silent no-op, (b) defensive assert/exception. Chose (a) because the type mismatch is a local caller bug, not a data-corruption risk — the resolved-field storage never sees a mismatched payload. Asserting would force creations to wrap pushes in try/catch for what is purely a misspelled field name.
- `composeForFieldVec3` is a near-copy of `composeForField` rather than a template. Templating would require constraining `T` to expose `+`/`*`/`max`/`min` and pull in concepts; given the framework has at most 2 value types (scalar + vec3) plus a future quat, two readable copies cost less than the concept overhead.
- Unblocks T-192 (delete `C_PositionOffset3D`) which is the first consumer.

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)