### PR TITLE
T-198: quat modifier kind — extend modifier compose for rotation perturbations

### DIFF
--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -94,17 +94,19 @@ capability (Haste, Stun, Slow, Stack, GlobalSlow, LambdaSine,
 SourceKill, Clamp) live. The HUD shows per-cube resolved speed
 each tick.
 
-### Typed fields: scalar vs vec3
+### Typed fields: scalar vs vec3 vs quat
 
 Fields are typed at registration time. `IRPrefab::Modifier::registerField`
-declares a scalar field; `registerFieldVec3` declares a vec3 field.
-`fieldType(id)` returns `FieldValueType::{SCALAR,VEC3}`. The `push`
-overload set is type-driven: `push(target, field, kind, float, ...)`
-routes into `C_Modifiers::modifiers_` (scalar) and `push(target, field,
-kind, IRMath::vec3, ...)` routes into `C_Modifiers::modifiersVec3_`.
-Pushing the wrong scalar/vec3 against a typed field silently no-ops
-(caller bug — wrong-type push doesn't corrupt the resolved-field
-storage). The same applies to `pushGlobal`.
+declares a scalar field; `registerFieldVec3` declares a vec3 field;
+`registerFieldQuat` declares a quaternion field. `fieldType(id)` returns
+`FieldValueType::{SCALAR,VEC3,QUAT}`. The `push` overload set is
+type-driven: `push(target, field, kind, float, ...)` routes into
+`C_Modifiers::modifiers_` (scalar), `push(target, field, kind,
+IRMath::vec3, ...)` routes into `C_Modifiers::modifiersVec3_`, and
+`push(target, field, kind, IRMath::vec4, ...)` routes into
+`C_Modifiers::modifiersQuat_`. Pushing the wrong type against a typed
+field silently no-ops (caller bug — wrong-type push doesn't corrupt the
+resolved-field storage). The same applies to `pushGlobal`.
 
 Compose semantics for vec3 mirror the scalar path component-wise:
 `ADD`/`MULTIPLY`/`SET` apply per-axis in push-order; `OVERRIDE`
@@ -116,21 +118,53 @@ scalar and vec3 vectors on the same `C_Modifiers` /
 `C_GlobalModifiers` archetype and write to the matching scalar /
 vec3 vector on `C_ResolvedFields`.
 
-`C_ResolvedFields` carries two parallel vectors: `fields_` (scalar)
-and `fieldsVec3_` (vec3). Read with `get(field)` / `getVec3(field)`;
-seed with `reset(field, base)` / `resetVec3(field, base)`. A scalar
-field id and a vec3 field id may share the same name but are distinct
-`FieldBindingId`s, so their resolved values live in separate slots.
+Quat compose follows the engine's quaternion convention
+(`IRMath::vec4(qx, qy, qz, qw)`, identity `vec4(0, 0, 0, 1)`) and the
+non-commutative nature of quaternion multiplication:
+
+- `MULTIPLY` → **left-multiply, post-rotate**:
+  `resolved = mod * base` via `IRMath::quatMul(mod.param_, value)`.
+  Stacked MULTIPLYs apply outer-first in push-order: for `[r1, r2, r3]`,
+  `resolved = r3 * r2 * r1 * base`. Consumers using the
+  `quatMul(parent_world, local)` bone-chain idiom are post-rotating in
+  the same direction.
+- `OVERRIDE` → replace value; latest OVERRIDE wins across the
+  combined `(globals ++ entity_mods)` sequence; everything earlier is
+  discarded (same short-circuit semantics as scalar/vec3).
+- `SET` → replace value in push-order (no short-circuit).
+- `ADD` / `CLAMP_MIN` / `CLAMP_MAX` → not meaningful on a unit
+  quaternion. The push API fires `IR_ASSERT` in debug and silently
+  skips in release; the compose path also defensively drops them so
+  direct-vector construction can't slip nonsense through. A future
+  "clamp angle around an axis" variant would land as a separate
+  `CLAMP_ANGLE_AXIS` kind.
+
+The compose helper is `composeForFieldQuat`; the resolver systems
+iterate the quat vector alongside scalar and vec3 on the same
+`C_Modifiers` archetype. The compose pass normalizes the final
+resolved quat **once** at the end (gate: only if any modifier touched
+the value — identity-only fast path skips the normalize and returns the
+caller's base unchanged, so callers passing a non-unit `baseValue` to
+`applyToFieldQuat` see it round-trip when no modifier is active).
+
+`C_ResolvedFields` carries three parallel vectors: `fields_` (scalar),
+`fieldsVec3_` (vec3), and `fieldsQuat_` (quat). Read with `get(field)` /
+`getVec3(field)` / `getQuat(field)`; seed with `reset(field, base)` /
+`resetVec3(field, base)` / `resetQuat(field, base)`. A scalar, vec3, and
+quat field id may share the same name but are distinct `FieldBindingId`s,
+so their resolved values live in separate slots.
 
 `LambdaModifier` stays scalar-only in v1 — `C_LambdaModifiers` does
-not have a vec3 counterpart. A vec3 lambda channel is a Phase 2
-follow-up alongside the quat modifier kind.
+not have vec3 or quat counterparts. A vec3 or quat lambda channel is a
+Phase 2 follow-up if a per-frame procedural rotation curve (rather
+than the structured `MULTIPLY` / `OVERRIDE` / `SET` modifiers covered
+above) is needed.
 
 Key invariants the design rests on:
 
-- `Modifier` and `ModifierVec3` both stay **trivially-copyable**.
-  Anything needing inline `std::function` or `std::string` belongs
-  in `C_LambdaModifiers`, not `C_Modifiers`.
+- `Modifier`, `ModifierVec3`, and `ModifierQuat` all stay
+  **trivially-copyable**. Anything needing inline `std::function` or
+  `std::string` belongs in `C_LambdaModifiers`, not `C_Modifiers`.
 - Public API lives in the `IRPrefab::Modifier::` namespace per the
   prefab-layer principle in `engine/prefabs/irreden/render/CLAUDE.md`,
   NOT in `IRRender::` or any engine-library-level namespace.

--- a/engine/prefabs/irreden/common/components/component_modifiers.hpp
+++ b/engine/prefabs/irreden/common/components/component_modifiers.hpp
@@ -19,13 +19,15 @@ using FieldBindingId = std::uint16_t;
 inline constexpr FieldBindingId kInvalidFieldId = 0;
 
 /// Typed dispatch for a field-binding id. Set at registration time
-/// (`registerField` for scalars, `registerFieldVec3` for vector fields).
-/// Push/read paths consult this on the registry to route to the
-/// correct internal vector. Pushing a typed param against a field of
-/// the wrong type is a no-op (defensive — caller bug, not data error).
+/// (`registerField` for scalars, `registerFieldVec3` for vector fields,
+/// `registerFieldQuat` for quaternion fields). Push/read paths consult
+/// this on the registry to route to the correct internal vector.
+/// Pushing a typed param against a field of the wrong type is a no-op
+/// (defensive — caller bug, not data error).
 enum class FieldValueType : std::uint8_t {
     SCALAR,
     VEC3,
+    QUAT,
 };
 
 enum class TransformKind : std::uint8_t {
@@ -74,6 +76,33 @@ static_assert(
     "ModifierVec3 must remain trivially-copyable; the param_ field stays vec3."
 );
 
+/// Quaternion counterpart to `Modifier`. `param_` is stored as the engine's
+/// canonical quaternion layout (`IRMath::vec4(qx, qy, qz, qw)`, identity =
+/// `vec4(0, 0, 0, 1)`).
+///
+/// Compose rules differ from the scalar / vec3 path because quaternion
+/// multiplication is non-commutative:
+///   MULTIPLY → post-rotate: `value = quatMul(mod, value)` (mod * base)
+///   OVERRIDE → replace value; latest OVERRIDE wins; short-circuits prior ops
+///   SET      → replace value in push-order (no short-circuit)
+///   ADD / CLAMP_MIN / CLAMP_MAX → not meaningful for unit quaternions;
+///                                  the push API asserts and the compose path
+///                                  silently skips them as a defensive no-op
+///                                  (debug `IR_ASSERT` fires on direct vector
+///                                  construction).
+struct ModifierQuat {
+    FieldBindingId field_;
+    TransformKind kind_;
+    IRMath::vec4 param_;
+    IREntity::EntityId source_;
+    std::int32_t ticksRemaining_;
+};
+
+static_assert(
+    std::is_trivially_copyable_v<ModifierQuat>,
+    "ModifierQuat must remain trivially-copyable; param_ stays vec4."
+);
+
 struct LambdaModifier {
     FieldBindingId field_;
     std::function<float(float)> fn_;
@@ -89,6 +118,11 @@ struct ResolvedField {
 struct ResolvedFieldVec3 {
     FieldBindingId field_;
     IRMath::vec3 value_;
+};
+
+struct ResolvedFieldQuat {
+    FieldBindingId field_;
+    IRMath::vec4 value_;
 };
 
 namespace detail {
@@ -114,6 +148,15 @@ findResolvedFieldVec3(std::vector<ResolvedFieldVec3> &fields, FieldBindingId fie
     return nullptr;
 }
 
+inline ResolvedFieldQuat *
+findResolvedFieldQuat(std::vector<ResolvedFieldQuat> &fields, FieldBindingId field) {
+    for (auto &rf : fields) {
+        if (rf.field_ == field)
+            return &rf;
+    }
+    return nullptr;
+}
+
 // Shared decay predicate for the three modifier-decay systems
 // (`MODIFIER_DECAY`, `GLOBAL_MODIFIER_DECAY`, `LAMBDA_MODIFIER_DECAY`).
 // `T` is `Modifier`, `ModifierVec3`, or `LambdaModifier` — all three
@@ -131,11 +174,13 @@ template <typename T> inline bool tickAndExpired(T &mod) {
 struct C_Modifiers {
     std::vector<Modifier> modifiers_;
     std::vector<ModifierVec3> modifiersVec3_;
+    std::vector<ModifierQuat> modifiersQuat_;
 };
 
 struct C_GlobalModifiers {
     std::vector<Modifier> modifiers_;
     std::vector<ModifierVec3> modifiersVec3_;
+    std::vector<ModifierQuat> modifiersQuat_;
 };
 
 /// Empty tag opting an entity out of `C_GlobalModifiers`. The
@@ -151,6 +196,7 @@ struct C_LambdaModifiers {
 struct C_ResolvedFields {
     std::vector<ResolvedField> fields_;
     std::vector<ResolvedFieldVec3> fieldsVec3_;
+    std::vector<ResolvedFieldQuat> fieldsQuat_;
 
     // Insert or update (field, base) so the resolver's compose pass
     // starts from `base`. Consumer systems call this in a pre-resolver
@@ -169,6 +215,14 @@ struct C_ResolvedFields {
             return;
         }
         fieldsVec3_.push_back(ResolvedFieldVec3{field, base});
+    }
+
+    void resetQuat(FieldBindingId field, IRMath::vec4 base) {
+        if (auto *rf = detail::findResolvedFieldQuat(fieldsQuat_, field)) {
+            rf->value_ = base;
+            return;
+        }
+        fieldsQuat_.push_back(ResolvedFieldQuat{field, base});
     }
 
     // Convenience — apply one structured modifier in place. The
@@ -233,6 +287,34 @@ struct C_ResolvedFields {
         }
     }
 
+    // Quat counterpart of `apply`. MULTIPLY is left-multiply (post-rotate:
+    // `value = mod * value`); OVERRIDE/SET replace; ADD/CLAMP_* are
+    // not meaningful on unit quaternions and are silently dropped (the
+    // push API asserts on debug). The compose path is responsible for
+    // normalizing the stacked result once at the end; this single-step
+    // helper does not normalize on the assumption callers chain via the
+    // pure-function compose in modifier_compose.hpp instead.
+    void apply(const ModifierQuat &mod) {
+        auto *rf = detail::findResolvedFieldQuat(fieldsQuat_, mod.field_);
+        if (!rf)
+            return;
+        switch (mod.kind_) {
+        case TransformKind::MULTIPLY:
+            rf->value_ = IRMath::quatMul(mod.param_, rf->value_);
+            break;
+        case TransformKind::SET:
+            rf->value_ = mod.param_;
+            break;
+        case TransformKind::OVERRIDE:
+            rf->value_ = mod.param_;
+            break;
+        case TransformKind::ADD:
+        case TransformKind::CLAMP_MIN:
+        case TransformKind::CLAMP_MAX:
+            break;
+        }
+    }
+
     void applyLambda(const LambdaModifier &lambda) {
         if (!lambda.fn_)
             return;
@@ -253,6 +335,19 @@ struct C_ResolvedFields {
 
     IRMath::vec3 getVec3(FieldBindingId field, IRMath::vec3 fallback = IRMath::vec3(0.0f)) const {
         for (const auto &rf : fieldsVec3_) {
+            if (rf.field_ == field)
+                return rf.value_;
+        }
+        return fallback;
+    }
+
+    // Identity (`vec4(0, 0, 0, 1)`) is the canonical fallback for a missing
+    // quat field; callers that want a different "neutral" rotation should
+    // pass it explicitly.
+    IRMath::vec4 getQuat(
+        FieldBindingId field, IRMath::vec4 fallback = IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+    ) const {
+        for (const auto &rf : fieldsQuat_) {
             if (rf.field_ == field)
                 return rf.value_;
         }

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -48,6 +48,13 @@ inline IRComponents::FieldBindingId registerFieldVec3(const char *name) {
     return detail::globalFieldRegistry().registerFieldVec3(name);
 }
 
+// Quat-typed field. Pushes must use the vec4 push() overloads and the
+// quaternion compose semantics (MULTIPLY = left-multiply, OVERRIDE/SET
+// replace; ADD/CLAMP_MIN/CLAMP_MAX assert).
+inline IRComponents::FieldBindingId registerFieldQuat(const char *name) {
+    return detail::globalFieldRegistry().registerFieldQuat(name);
+}
+
 inline const char *fieldName(IRComponents::FieldBindingId id) {
     return detail::globalFieldRegistry().fieldName(id);
 }
@@ -103,6 +110,41 @@ inline void push(
     );
 }
 
+// Quat push. `param` is the engine's canonical quaternion layout
+// (`vec4(qx, qy, qz, qw)`, identity `vec4(0, 0, 0, 1)`). ADD / CLAMP_MIN /
+// CLAMP_MAX fire `IR_ASSERT` in debug and skip in release — they are
+// not meaningful operations on a unit quaternion. MULTIPLY composes
+// left-multiply (post-rotate); OVERRIDE/SET replace.
+inline void push(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec4 param,
+    IREntity::EntityId source,
+    std::int32_t ticksRemaining = -1
+) {
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    if (fieldType(field) != IRComponents::FieldValueType::QUAT)
+        return;
+    const bool unitQuatIncompatible = kind == IRComponents::TransformKind::ADD ||
+                                      kind == IRComponents::TransformKind::CLAMP_MIN ||
+                                      kind == IRComponents::TransformKind::CLAMP_MAX;
+    IR_ASSERT(
+        !unitQuatIncompatible,
+        "Quat modifier kind: ADD/CLAMP_MIN/CLAMP_MAX are not meaningful on unit "
+        "quaternions; use MULTIPLY for compose, OVERRIDE/SET for replacement."
+    );
+    if (unitQuatIncompatible)
+        return;
+    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
+    if (!c)
+        return;
+    c->modifiersQuat_.push_back(
+        IRComponents::ModifierQuat{field, kind, param, source, ticksRemaining}
+    );
+}
+
 inline void pushGlobal(
     IRComponents::FieldBindingId field,
     IRComponents::TransformKind kind,
@@ -144,6 +186,39 @@ inline void pushGlobal(
         return;
     c->modifiersVec3_.push_back(
         IRComponents::ModifierVec3{field, kind, param, source, ticksRemaining}
+    );
+}
+
+inline void pushGlobal(
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec4 param,
+    IREntity::EntityId source,
+    std::int32_t ticksRemaining = -1
+) {
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    if (fieldType(field) != IRComponents::FieldValueType::QUAT)
+        return;
+    const bool unitQuatIncompatible = kind == IRComponents::TransformKind::ADD ||
+                                      kind == IRComponents::TransformKind::CLAMP_MIN ||
+                                      kind == IRComponents::TransformKind::CLAMP_MAX;
+    IR_ASSERT(
+        !unitQuatIncompatible,
+        "Quat global modifier kind: ADD/CLAMP_MIN/CLAMP_MAX are not meaningful on unit "
+        "quaternions; use MULTIPLY for compose, OVERRIDE/SET for replacement."
+    );
+    if (unitQuatIncompatible)
+        return;
+    auto entity = detail::globalsEntityId();
+    if (entity == IREntity::kNullEntity)
+        return;
+    auto *c =
+        IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
+    if (!c)
+        return;
+    c->modifiersQuat_.push_back(
+        IRComponents::ModifierQuat{field, kind, param, source, ticksRemaining}
     );
 }
 
@@ -194,11 +269,13 @@ inline void removeBySource(IREntity::EntityId source) {
     IREntity::forEachComponent<IRComponents::C_Modifiers>([&](IRComponents::C_Modifiers &c) {
         stripVec(c.modifiers_);
         stripVec(c.modifiersVec3_);
+        stripVec(c.modifiersQuat_);
     });
     IREntity::forEachComponent<IRComponents::C_GlobalModifiers>(
         [&](IRComponents::C_GlobalModifiers &c) {
             stripVec(c.modifiers_);
             stripVec(c.modifiersVec3_);
+            stripVec(c.modifiersQuat_);
         }
     );
     IREntity::forEachComponent<IRComponents::C_LambdaModifiers>(
@@ -250,6 +327,31 @@ inline IRMath::vec3 applyToFieldVec3(
     const auto &globals = globalsPtr ? *globalsPtr : detail::emptyModifiersVec3();
 
     return detail::composeForFieldVec3(baseValue, field, globals, entityMods);
+}
+
+// Quat counterpart of `applyToField`. Reads from `modifiersQuat_` on
+// `C_Modifiers` and the singleton's `C_GlobalModifiers`; returns the
+// composed (and normalized, when any modifier touched the value)
+// rotation. `baseValue` defaults to identity at the caller site — pass
+// `vec4(0, 0, 0, 1)` if you have no other base rotation in mind.
+inline IRMath::vec4 applyToFieldQuat(
+    IREntity::EntityId target, IRComponents::FieldBindingId field, IRMath::vec4 baseValue
+) {
+    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
+    const auto &entityMods = c ? c->modifiersQuat_ : detail::emptyModifiersQuat();
+
+    const std::vector<IRComponents::ModifierQuat> *globalsPtr = nullptr;
+    auto entity = detail::globalsEntityId();
+    if (entity != IREntity::kNullEntity) {
+        auto *g = IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(
+            nullptr
+        );
+        if (g)
+            globalsPtr = &g->modifiersQuat_;
+    }
+    const auto &globals = globalsPtr ? *globalsPtr : detail::emptyModifiersQuat();
+
+    return detail::composeForFieldQuat(baseValue, field, globals, entityMods);
 }
 
 // Wires up the singleton globals entity and registers the six resolver

--- a/engine/prefabs/irreden/common/modifier_compose.hpp
+++ b/engine/prefabs/irreden/common/modifier_compose.hpp
@@ -203,6 +203,99 @@ inline IRMath::vec3 composeForFieldVec3(
     return composeForFieldVec3(base, field, emptyModifiersVec3(), mods);
 }
 
+// Quat counterpart. Same OVERRIDE-wins / push-order-algebra evaluation
+// rule as scalar/vec3, with the algebra reduced to MULTIPLY/SET (quat
+// rotation compose / replace) — ADD and CLAMP_MIN/MAX are not meaningful
+// on unit quaternions and are silently skipped here (the push API
+// asserts in debug, so direct-vector construction is the only path
+// that reaches this fallthrough).
+//
+// MULTIPLY is left-multiply (post-rotate): `value = quatMul(mod, value)`
+// composes the new rotation on top of the running base. This convention
+// matches `engine/math/ir_math.hpp::quatMul`'s comment ("rotates b first
+// then a") — `quatMul(parent_world, local)` is the bone-chain idiom.
+//
+// Final normalization is applied once at the end of the compose pass
+// to amortize stacked-MULTIPLY float drift; the per-step apply on
+// `C_ResolvedFields` (`apply(const ModifierQuat&)`) does not normalize.
+inline IRMath::vec4 composeForFieldQuat(
+    IRMath::vec4 base,
+    IRComponents::FieldBindingId field,
+    const std::vector<IRComponents::ModifierQuat> &modsA,
+    const std::vector<IRComponents::ModifierQuat> &modsB
+) {
+    using IRComponents::TransformKind;
+
+    int overrideA = -1;
+    for (std::size_t i = 0; i < modsA.size(); ++i) {
+        if (modsA[i].field_ == field && modsA[i].kind_ == TransformKind::OVERRIDE) {
+            overrideA = static_cast<int>(i);
+        }
+    }
+    int overrideB = -1;
+    for (std::size_t i = 0; i < modsB.size(); ++i) {
+        if (modsB[i].field_ == field && modsB[i].kind_ == TransformKind::OVERRIDE) {
+            overrideB = static_cast<int>(i);
+        }
+    }
+
+    IRMath::vec4 value = base;
+    std::size_t startA = 0, startB = 0;
+    bool touched = false;
+    if (overrideB >= 0) {
+        value = modsB[overrideB].param_;
+        startA = modsA.size();
+        startB = static_cast<std::size_t>(overrideB) + 1;
+        touched = true;
+    } else if (overrideA >= 0) {
+        value = modsA[overrideA].param_;
+        startA = static_cast<std::size_t>(overrideA) + 1;
+        touched = true;
+    }
+
+    auto applyAlgebra = [&](const std::vector<IRComponents::ModifierQuat> &v, std::size_t from) {
+        for (std::size_t i = from; i < v.size(); ++i) {
+            if (v[i].field_ != field)
+                continue;
+            switch (v[i].kind_) {
+            case TransformKind::MULTIPLY:
+                value = IRMath::quatMul(v[i].param_, value);
+                touched = true;
+                break;
+            case TransformKind::SET:
+                value = v[i].param_;
+                touched = true;
+                break;
+            default:
+                break;
+            }
+        }
+    };
+    applyAlgebra(modsA, startA);
+    applyAlgebra(modsB, startB);
+
+    // Only normalize when at least one modifier touched the value;
+    // identity-only fast path avoids a normalize on every entity with a
+    // C_Modifiers and a registered quat field but no active modifier.
+    if (touched) {
+        value = IRMath::normalize(value);
+    }
+    return value;
+}
+
+inline const std::vector<IRComponents::ModifierQuat> &emptyModifiersQuat() {
+    static const std::vector<IRComponents::ModifierQuat> kEmpty;
+    return kEmpty;
+}
+
+inline IRMath::vec4 composeForFieldQuat(
+    IRMath::vec4 base,
+    IRComponents::FieldBindingId field,
+    const std::vector<IRComponents::ModifierQuat> &mods
+) {
+    return composeForFieldQuat(base, field, emptyModifiersQuat(), mods);
+}
+
 } // namespace IRPrefab::Modifier::detail
 
 #endif /* MODIFIER_COMPOSE_H */

--- a/engine/prefabs/irreden/common/modifier_field_registry.hpp
+++ b/engine/prefabs/irreden/common/modifier_field_registry.hpp
@@ -38,6 +38,10 @@ class FieldRegistry {
         return registerField(name, IRComponents::FieldValueType::VEC3);
     }
 
+    IRComponents::FieldBindingId registerFieldQuat(const char *name) {
+        return registerField(name, IRComponents::FieldValueType::QUAT);
+    }
+
     const char *fieldName(IRComponents::FieldBindingId id) const {
         if (id == IRComponents::kInvalidFieldId || id >= m_names.size())
             return nullptr;

--- a/engine/prefabs/irreden/common/modifier_lua.hpp
+++ b/engine/prefabs/irreden/common/modifier_lua.hpp
@@ -48,6 +48,12 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
         return static_cast<int>(IRPrefab::Modifier::registerFieldVec3(interned));
     };
 
+    modTbl["registerFieldQuat"] = [](const char *name) -> int {
+        static std::unordered_set<std::string> s_luaNames;
+        const char *interned = s_luaNames.emplace(name).first->c_str();
+        return static_cast<int>(IRPrefab::Modifier::registerFieldQuat(interned));
+    };
+
     struct PushOpts {
         IRComponents::FieldBindingId field_;
         IRComponents::TransformKind kind_;
@@ -104,6 +110,36 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
 
     modTbl["pushGlobalVec3"] = [parseOptsVec3](sol::table opts) {
         auto o = parseOptsVec3(opts);
+        IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
+    };
+
+    // Quat push paths. `param` accepts an IRMath::vec4 userdata or a {x,y,z,w} table.
+    struct PushOptsQuat {
+        IRComponents::FieldBindingId field_;
+        IRComponents::TransformKind kind_;
+        IRMath::vec4 param_;
+        IREntity::EntityId source_;
+        std::int32_t ticks_;
+    };
+    auto parseOptsQuat = [](sol::table t) -> PushOptsQuat {
+        return PushOptsQuat{
+            static_cast<IRComponents::FieldBindingId>(t.get<int>("field")),
+            static_cast<IRComponents::TransformKind>(
+                t.get_or("kind", static_cast<int>(IRComponents::TransformKind::MULTIPLY))
+            ),
+            quatFromLua(t.get<sol::object>("param")),
+            t.get_or<IREntity::EntityId>("source", IREntity::kNullEntity),
+            t.get_or("ticks", -1)
+        };
+    };
+
+    modTbl["pushQuat"] = [parseOptsQuat](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOptsQuat(opts);
+        IRPrefab::Modifier::push(target, o.field_, o.kind_, o.param_, o.source_, o.ticks_);
+    };
+
+    modTbl["pushGlobalQuat"] = [parseOptsQuat](sol::table opts) {
+        auto o = parseOptsQuat(opts);
         IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
     };
 

--- a/engine/prefabs/irreden/common/systems/system_global_modifier_decay.hpp
+++ b/engine/prefabs/irreden/common/systems/system_global_modifier_decay.hpp
@@ -35,6 +35,14 @@ template <> struct System<GLOBAL_MODIFIER_DECAY> {
                     IRComponents::detail::tickAndExpired<IRComponents::ModifierVec3>
                 );
                 v3.erase(newEnd3, v3.end());
+
+                auto &vq = g.modifiersQuat_;
+                auto newEndQ = std::remove_if(
+                    vq.begin(),
+                    vq.end(),
+                    IRComponents::detail::tickAndExpired<IRComponents::ModifierQuat>
+                );
+                vq.erase(newEndQ, vq.end());
             }
         );
     }

--- a/engine/prefabs/irreden/common/systems/system_modifier_decay.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_decay.hpp
@@ -39,6 +39,14 @@ template <> struct System<MODIFIER_DECAY> {
                     IRComponents::detail::tickAndExpired<IRComponents::ModifierVec3>
                 );
                 v3.erase(newEnd3, v3.end());
+
+                auto &vq = m.modifiersQuat_;
+                auto newEndQ = std::remove_if(
+                    vq.begin(),
+                    vq.end(),
+                    IRComponents::detail::tickAndExpired<IRComponents::ModifierQuat>
+                );
+                vq.erase(newEndQ, vq.end());
             }
         );
     }

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
@@ -42,6 +42,13 @@ template <> struct System<MODIFIER_RESOLVE_EXEMPT> {
                         m.modifiersVec3_
                     );
                 }
+                for (auto &rf : resolved.fieldsQuat_) {
+                    rf.value_ = IRPrefab::Modifier::detail::composeForFieldQuat(
+                        rf.value_,
+                        rf.field_,
+                        m.modifiersQuat_
+                    );
+                }
             }
         );
     }

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_global.hpp
@@ -41,6 +41,11 @@ inline const std::vector<IRComponents::ModifierVec3> *&currentGlobalModifiersVec
     return p;
 }
 
+inline const std::vector<IRComponents::ModifierQuat> *&currentGlobalModifiersQuatPtr() {
+    static const std::vector<IRComponents::ModifierQuat> *p = nullptr;
+    return p;
+}
+
 // No-create accessor for the singleton globals entity. Returns
 // `kNullEntity` if `registerResolverPipeline` has not yet wired up
 // the singleton, so `beginTick` below can no-op cleanly when the
@@ -88,22 +93,38 @@ template <> struct System<MODIFIER_RESOLVE_GLOBAL> {
                         m.modifiersVec3_
                     );
                 }
+                const auto *globalsQuatPtr =
+                    IRPrefab::Modifier::detail::currentGlobalModifiersQuatPtr();
+                const auto &globalsQuat = globalsQuatPtr
+                                              ? *globalsQuatPtr
+                                              : IRPrefab::Modifier::detail::emptyModifiersQuat();
+                for (auto &rf : resolved.fieldsQuat_) {
+                    rf.value_ = IRPrefab::Modifier::detail::composeForFieldQuat(
+                        rf.value_,
+                        rf.field_,
+                        globalsQuat,
+                        m.modifiersQuat_
+                    );
+                }
             },
             // beginTick: cache the singleton's modifier vector pointers.
             []() {
                 using IRComponents::C_GlobalModifiers;
                 auto &cachedPtr = IRPrefab::Modifier::detail::currentGlobalModifiersPtr();
                 auto &cachedVec3Ptr = IRPrefab::Modifier::detail::currentGlobalModifiersVec3Ptr();
+                auto &cachedQuatPtr = IRPrefab::Modifier::detail::currentGlobalModifiersQuatPtr();
                 auto entity = IRPrefab::Modifier::detail::globalsEntityId();
                 if (entity == IREntity::kNullEntity) {
                     cachedPtr = nullptr;
                     cachedVec3Ptr = nullptr;
+                    cachedQuatPtr = nullptr;
                     return;
                 }
                 auto *gm =
                     IREntity::getComponentOptional<C_GlobalModifiers>(entity).value_or(nullptr);
                 cachedPtr = gm ? &gm->modifiers_ : nullptr;
                 cachedVec3Ptr = gm ? &gm->modifiersVec3_ : nullptr;
+                cachedQuatPtr = gm ? &gm->modifiersQuat_ : nullptr;
             }
         );
     }

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -617,6 +617,7 @@ IRModifier.Transform.{ADD, MULTIPLY, SET, CLAMP_MIN, CLAMP_MAX, OVERRIDE}
 
 IRModifier.registerField("Movement.speed")           -- → FieldBindingId (scalar)
 IRModifier.registerFieldVec3("Idle.bobOffset")       -- → FieldBindingId (vec3)
+IRModifier.registerFieldQuat("Shake.rotation")       -- → FieldBindingId (quat)
 IRModifier.fieldId("Movement.speed")                 -- → FieldBindingId
 IRModifier.fieldName(id)                             -- → string | nil
 
@@ -632,15 +633,24 @@ IRModifier.addVec3(entity, fieldNameOrId, {
     source = sourceEntity,
     ticks = -1,
 })
+IRModifier.addQuat(entity, fieldNameOrId, {
+    transform = IRModifier.Transform.MULTIPLY,  -- MULTIPLY | OVERRIDE | SET
+    value = { x = 0, y = 0, z = 0.1736, w = 0.9848 }, -- {x,y,z,w} or IRMath::vec4
+    source = sourceEntity,
+    ticks = -1,
+})
 IRModifier.addGlobal(fieldNameOrId, opts)
 IRModifier.addGlobalVec3(fieldNameOrId, opts)
+IRModifier.addGlobalQuat(fieldNameOrId, opts)
 IRModifier.addLambda(entity, fieldNameOrId, fn, opts)
 IRModifier.removeBySource(sourceEntity)
 
 IRModifier.applyToField(entity, fieldNameOrId, base) -- → resolved float
 IRModifier.applyToFieldVec3(entity, fieldNameOrId, base) -- → resolved vec3
+IRModifier.applyToFieldQuat(entity, fieldNameOrId, base) -- → resolved vec4 quat
 IRModifier.resolved(entity, fieldNameOrId, fallback) -- read C_ResolvedFields
 IRModifier.resolvedVec3(entity, fieldNameOrId, fallback) -- read vec3 slot
+IRModifier.resolvedQuat(entity, fieldNameOrId, fallback) -- read quat slot
 ```
 
 - **`fieldNameOrId`** — accepts a string (resolved against the registry
@@ -661,14 +671,21 @@ IRModifier.resolvedVec3(entity, fieldNameOrId, fallback) -- read vec3 slot
 - **`IRModifier.applyToField`** is a direct query; it shares one
   evaluator with the resolver pipeline, so the two paths agree on the
   same input regardless of whether the resolver tick has run yet.
-- **Typed fields: scalar vs vec3.** `registerField` declares a scalar
-  field; `registerFieldVec3` declares a vec3 field. Pushing the wrong
-  scalar/vec3 payload against a typed field silently no-ops — caller
-  bug, not a data error. Resolved values live in parallel slots on
-  `C_ResolvedFields` (`fields_` and `fieldsVec3_`), so a scalar field
-  and a vec3 field cannot accidentally cross-stream. `addLambda` is
-  scalar-only in v1; vec3 lambda channels (and quat fields) are a
-  Phase 2 follow-up.
+- **Typed fields: scalar vs vec3 vs quat.** `registerField` declares a
+  scalar field; `registerFieldVec3` declares a vec3 field;
+  `registerFieldQuat` declares a quaternion field. Pushing the wrong
+  type against a typed field silently no-ops — caller bug, not a data
+  error. Resolved values live in three parallel slots on
+  `C_ResolvedFields` (`fields_`, `fieldsVec3_`, `fieldsQuat_`) so the
+  same name across types cannot cross-stream. `addLambda` is scalar-only
+  in v1; vec3 / quat lambda channels are a Phase 2 follow-up.
+- **Quat compose semantics.** `MULTIPLY` is **left-multiply / post-rotate**
+  (`resolved = mod * base`), so stacked MULTIPLYs apply outer-first in
+  push-order: for `[r1, r2, r3]`, `resolved = r3 * r2 * r1 * base`.
+  `OVERRIDE` discards prior ops; `SET` replaces in push-order. The
+  unit-quaternion-only `ADD` / `CLAMP_MIN` / `CLAMP_MAX` raise an
+  engine assertion in debug and silently no-op in release. The compose
+  pass normalizes the final resolved quat once at the end.
 
 ## Prefab format (`Prefab.register`, `Prefab.spawn`)
 

--- a/engine/script/include/irreden/script/ir_script_utils.hpp
+++ b/engine/script/include/irreden/script/ir_script_utils.hpp
@@ -5,7 +5,8 @@
 
 namespace IRScript {
 
-// sol::optional<float> per key — get_or<T> overload resolution is ambiguous with mixed string/integer key types.
+// sol::optional<float> per key — get_or<T> overload resolution is ambiguous with mixed
+// string/integer key types.
 inline IRMath::vec3 vec3FromLua(sol::object obj) {
     if (obj.is<IRMath::vec3>())
         return obj.as<IRMath::vec3>();
@@ -21,6 +22,34 @@ inline IRMath::vec3 vec3FromLua(sol::object obj) {
         return {pickFloat("x", 1), pickFloat("y", 2), pickFloat("z", 3)};
     }
     return {0.0f, 0.0f, 0.0f};
+}
+
+// Returns identity-quat (`vec4(0, 0, 0, 1)`) for nil/unrecognized input,
+// per the engine convention that quats are stored as `vec4(qx, qy, qz, qw)`
+// with `.w` the scalar. Accepts either an `IRMath::vec4` userdata or a
+// `{x,y,z,w}` / `{1,2,3,4}` table. Asymmetric default vs. `vec3FromLua`
+// (which zero-defaults) because zero-quat is degenerate — every modifier
+// caller would have to override the default anyway.
+inline IRMath::vec4 quatFromLua(sol::object obj) {
+    if (obj.is<IRMath::vec4>())
+        return obj.as<IRMath::vec4>();
+    if (obj.is<sol::table>()) {
+        sol::table t = obj.as<sol::table>();
+        auto pickFloat = [&t](const char *key, int idx, float fallback) -> float {
+            if (sol::optional<float> v = t[key])
+                return *v;
+            if (sol::optional<float> v = t[idx])
+                return *v;
+            return fallback;
+        };
+        return {
+            pickFloat("x", 1, 0.0f),
+            pickFloat("y", 2, 0.0f),
+            pickFloat("z", 3, 0.0f),
+            pickFloat("w", 4, 1.0f)
+        };
+    }
+    return {0.0f, 0.0f, 0.0f, 1.0f};
 }
 
 } // namespace IRScript

--- a/engine/script/include/irreden/script/lua_modifier_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_modifier_bindings.hpp
@@ -8,26 +8,40 @@
 //   IRModifier.Transform.{ADD, MULTIPLY, SET, CLAMP_MIN, CLAMP_MAX, OVERRIDE}
 //   IRModifier.registerField(name)                          → FieldBindingId
 //   IRModifier.registerFieldVec3(name)                      → FieldBindingId
+//   IRModifier.registerFieldQuat(name)                      → FieldBindingId
 //   IRModifier.fieldId(name)                                → FieldBindingId
 //                                                            (kInvalidFieldId
 //                                                            when not registered)
 //   IRModifier.fieldName(id)                                → string | nil
 //   IRModifier.add(target, fieldNameOrId, opts)
 //   IRModifier.addVec3(target, fieldNameOrId, opts)
+//   IRModifier.addQuat(target, fieldNameOrId, opts)
 //   IRModifier.addGlobal(fieldNameOrId, opts)
 //   IRModifier.addGlobalVec3(fieldNameOrId, opts)
+//   IRModifier.addGlobalQuat(fieldNameOrId, opts)
 //   IRModifier.addLambda(target, fieldNameOrId, fn, opts)
 //   IRModifier.removeBySource(source)
 //   IRModifier.applyToField(target, fieldNameOrId, base)    → float
 //   IRModifier.applyToFieldVec3(target, fieldNameOrId, base) → vec3
+//   IRModifier.applyToFieldQuat(target, fieldNameOrId, base) → vec4 (quat)
 //   IRModifier.resolved(target, fieldNameOrId, fallback?)   → float
 //   IRModifier.resolvedVec3(target, fieldNameOrId, fallback?) → vec3
+//   IRModifier.resolvedQuat(target, fieldNameOrId, fallback?) → vec4 (quat)
 //
 // The vec3 variants route to fields declared via `registerFieldVec3`;
 // scalar/vec3 fields are typed at registration time, so pushing the
 // wrong-typed payload silently no-ops (caller bug). `value` in
 // `addVec3` / `addGlobalVec3` opts is parsed via `vec3FromLua` — accept
 // either a registered `IRMath::vec3` userdata or a `{x,y,z}` table.
+//
+// Quat variants route to fields declared via `registerFieldQuat`. The
+// `value` field accepts either an `IRMath::vec4` userdata or a
+// `{x,y,z,w}` table representing the quaternion `(qx, qy, qz, qw)`
+// (identity `vec4(0, 0, 0, 1)`). `transform` must be `MULTIPLY`,
+// `OVERRIDE`, or `SET` — `ADD` / `CLAMP_MIN` / `CLAMP_MAX` raise an
+// engine debug assertion and silently skip in release, since they have
+// no meaningful definition on unit quaternions. MULTIPLY composes in
+// the post-rotate convention (`resolved = mod * base`).
 //
 // `target` / `source` are entity ids (Lua integers — the same shape as
 // `arch.entityAt(i)` returns from a Lua-defined system, and the same
@@ -153,6 +167,15 @@ inline void bindModifierFramework(LuaScript &script) {
         );
     };
 
+    api["registerFieldQuat"] = [](const std::string &name) {
+        // Shares the same lifetime contract as registerField above.
+        static std::deque<std::string> names;
+        names.emplace_back(name);
+        return static_cast<lua_Integer>(
+            IRPrefab::Modifier::registerFieldQuat(names.back().c_str())
+        );
+    };
+
     api["fieldId"] = [](const std::string &name) {
         return static_cast<lua_Integer>(
             IRPrefab::Modifier::detail::globalFieldRegistry().findFieldId(name.c_str())
@@ -235,6 +258,39 @@ inline void bindModifierFramework(LuaScript &script) {
         );
     };
 
+    api["addQuat"] = [](lua_Integer target, sol::object fieldArg, sol::table opts) {
+        const auto field = resolveFieldArg(fieldArg, "IRModifier.addQuat");
+        const auto kind = resolveTransform(opts, "IRModifier.addQuat");
+        const IRMath::vec4 value = IRScript::quatFromLua(opts.get<sol::object>("value"));
+        const lua_Integer source =
+            opts.get_or("source", static_cast<lua_Integer>(IREntity::kNullEntity));
+        const std::int32_t ticks = opts.get_or("ticks", static_cast<std::int32_t>(-1));
+        IRPrefab::Modifier::push(
+            static_cast<IREntity::EntityId>(target),
+            field,
+            kind,
+            value,
+            static_cast<IREntity::EntityId>(source),
+            ticks
+        );
+    };
+
+    api["addGlobalQuat"] = [](sol::object fieldArg, sol::table opts) {
+        const auto field = resolveFieldArg(fieldArg, "IRModifier.addGlobalQuat");
+        const auto kind = resolveTransform(opts, "IRModifier.addGlobalQuat");
+        const IRMath::vec4 value = IRScript::quatFromLua(opts.get<sol::object>("value"));
+        const lua_Integer source =
+            opts.get_or("source", static_cast<lua_Integer>(IREntity::kNullEntity));
+        const std::int32_t ticks = opts.get_or("ticks", static_cast<std::int32_t>(-1));
+        IRPrefab::Modifier::pushGlobal(
+            field,
+            kind,
+            value,
+            static_cast<IREntity::EntityId>(source),
+            ticks
+        );
+    };
+
     api["addLambda"] = [](lua_Integer target,
                           sol::object fieldArg,
                           sol::protected_function fn,
@@ -294,6 +350,17 @@ inline void bindModifierFramework(LuaScript &script) {
         );
     };
 
+    api["applyToFieldQuat"] =
+        [](lua_Integer target, sol::object fieldArg, sol::object baseObj) -> IRMath::vec4 {
+        const auto field = resolveFieldArg(fieldArg, "IRModifier.applyToFieldQuat");
+        const IRMath::vec4 base = IRScript::quatFromLua(baseObj);
+        return IRPrefab::Modifier::applyToFieldQuat(
+            static_cast<IREntity::EntityId>(target),
+            field,
+            base
+        );
+    };
+
     api["resolved"] =
         [](lua_Integer target, sol::object fieldArg, sol::optional<float> fallbackOpt) -> float {
         const auto field = resolveFieldArg(fieldArg, "IRModifier.resolved");
@@ -320,6 +387,21 @@ inline void bindModifierFramework(LuaScript &script) {
         if (resolved == nullptr)
             return fallback;
         return resolved->getVec3(field, fallback);
+    };
+
+    api["resolvedQuat"] = [](lua_Integer target,
+                             sol::object fieldArg,
+                             sol::optional<sol::object> fallbackOpt) -> IRMath::vec4 {
+        const auto field = resolveFieldArg(fieldArg, "IRModifier.resolvedQuat");
+        const IRMath::vec4 fallback = fallbackOpt ? IRScript::quatFromLua(*fallbackOpt)
+                                                  : IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+        auto *resolved = IREntity::getComponentOptional<IRComponents::C_ResolvedFields>(
+                             static_cast<IREntity::EntityId>(target)
+        )
+                             .value_or(nullptr);
+        if (resolved == nullptr)
+            return fallback;
+        return resolved->getQuat(field, fallback);
     };
 
     lua["IRModifier"] = api;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(IrredenEngineTest
   common/ir_platform_test.cpp
   ecs/entity_manager_test.cpp
   ecs/hitbox_2d_gui_test.cpp
+  ecs/modifier_quat_runtime_test.cpp
   ecs/modifier_runtime_test.cpp
   ecs/modifier_types_test.cpp
   ecs/modifier_vec3_runtime_test.cpp

--- a/test/ecs/modifier_quat_runtime_test.cpp
+++ b/test/ecs/modifier_quat_runtime_test.cpp
@@ -1,0 +1,510 @@
+#include <gtest/gtest.h>
+
+#include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/common/modifier.hpp>
+#include <irreden/common/modifier_compose.hpp>
+#include <irreden/common/modifier_field_registry.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+using IRComponents::C_Modifiers;
+using IRComponents::C_ResolvedFields;
+using IRComponents::FieldBindingId;
+using IRComponents::FieldValueType;
+using IRComponents::kInvalidFieldId;
+using IRComponents::ModifierQuat;
+using IRComponents::ResolvedFieldQuat;
+using IRComponents::TransformKind;
+
+using IRPrefab::Modifier::detail::composeForFieldQuat;
+using IRPrefab::Modifier::detail::FieldRegistry;
+
+constexpr FieldBindingId kFieldA = FieldBindingId{1};
+constexpr FieldBindingId kFieldB = FieldBindingId{2};
+
+ModifierQuat mkQ(FieldBindingId field, TransformKind kind, IRMath::vec4 param) {
+    return ModifierQuat{field, kind, param, IREntity::EntityId{0}, -1};
+}
+
+// Quaternion around +Z by `radians` (the rotation axis that maps cleanly
+// onto the iso depth axis). All tests below stack rotations around the
+// same axis so float-stable expected values can be derived from a single
+// trig table per multiply count.
+IRMath::vec4 rotZ(float radians) {
+    const float halfAngle = radians * 0.5f;
+    return IRMath::vec4(0.0f, 0.0f, IRMath::sin(halfAngle), IRMath::cos(halfAngle));
+}
+
+constexpr float kEpsilon = 1e-5f;
+
+// Rotate +X by the quaternion and inspect the resulting vec3 — that's
+// the stable observable for "this quat actually represents the rotation
+// I think it does", independent of sign-flip aliasing.
+void expectRotZApplied(IRMath::vec4 q, float expectedRadians) {
+    const IRMath::vec3 x{1.0f, 0.0f, 0.0f};
+    const IRMath::vec3 rotated = IRMath::rotateVectorByQuat(x, q);
+    EXPECT_NEAR(rotated.x, IRMath::cos(expectedRadians), kEpsilon);
+    EXPECT_NEAR(rotated.y, IRMath::sin(expectedRadians), kEpsilon);
+    EXPECT_NEAR(rotated.z, 0.0f, kEpsilon);
+}
+
+// ---- Field registry: typed binding ----------------------------------------
+
+TEST(ModifierRegistryQuat, RegisterFieldQuatAssignsType) {
+    FieldRegistry registry;
+    auto scalarId = registry.registerField("scalar.field");
+    auto vec3Id = registry.registerFieldVec3("vec3.field");
+    auto quatId = registry.registerFieldQuat("quat.field");
+
+    EXPECT_EQ(registry.fieldType(scalarId), FieldValueType::SCALAR);
+    EXPECT_EQ(registry.fieldType(vec3Id), FieldValueType::VEC3);
+    EXPECT_EQ(registry.fieldType(quatId), FieldValueType::QUAT);
+    EXPECT_EQ(registry.fieldCount(), 3u);
+}
+
+// ---- Compose: structured quat transforms ---------------------------------
+
+TEST(ModifierComposeQuat, NoModifiersReturnsBase) {
+    std::vector<ModifierQuat> mods;
+    IRMath::vec4 base = rotZ(0.5f);
+    IRMath::vec4 result = composeForFieldQuat(base, kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, base.x);
+    EXPECT_FLOAT_EQ(result.y, base.y);
+    EXPECT_FLOAT_EQ(result.z, base.z);
+    EXPECT_FLOAT_EQ(result.w, base.w);
+}
+
+TEST(ModifierComposeQuat, MultiplyComposesPostRotate) {
+    // Base = rotZ(theta_base); mod = rotZ(theta_mod).
+    // mod * base should yield rotZ(theta_mod + theta_base).
+    const float thetaBase = 0.4f;
+    const float thetaMod = 0.6f;
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(thetaMod)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(thetaBase), kFieldA, mods);
+    expectRotZApplied(result, thetaMod + thetaBase);
+}
+
+TEST(ModifierComposeQuat, MultiplyStacksLeftMultiplyOrder) {
+    // mods pushed in order [r1, r2, r3]; resolved = r3 * r2 * r1 * base.
+    // For axis-aligned rotations around Z, that's additive in angle:
+    // theta_total = base + r1 + r2 + r3.
+    const float base = 0.1f;
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.2f)),
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.3f)),
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.4f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(base), kFieldA, mods);
+    expectRotZApplied(result, base + 0.2f + 0.3f + 0.4f);
+}
+
+TEST(ModifierComposeQuat, MultiplyResultIsNormalized) {
+    // Even without intentional unit-vec deviation, stacked MULTIPLYs
+    // accumulate float drift in real workloads. Force-feed an
+    // un-normalized base to confirm the compose pass normalizes the
+    // final output.
+    IRMath::vec4 unnormalized = rotZ(0.7f) * 1.5f; // intentionally off-unit
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.0f)), // identity
+    };
+    IRMath::vec4 result = composeForFieldQuat(unnormalized, kFieldA, mods);
+    const float length = IRMath::sqrt(IRMath::dot(result, result));
+    EXPECT_NEAR(length, 1.0f, kEpsilon);
+}
+
+TEST(ModifierComposeQuat, IdentityFastPathSkipsNormalize) {
+    // No modifiers means no MULTIPLY drift; the compose path should
+    // return base unchanged (including length) rather than normalizing
+    // an arbitrary caller-supplied vec4. Validates the
+    // `if (touched) normalize` gate.
+    IRMath::vec4 unnormalized{0.3f, 0.4f, 0.5f, 0.5f};
+    std::vector<ModifierQuat> mods;
+    IRMath::vec4 result = composeForFieldQuat(unnormalized, kFieldA, mods);
+    EXPECT_FLOAT_EQ(result.x, 0.3f);
+    EXPECT_FLOAT_EQ(result.y, 0.4f);
+    EXPECT_FLOAT_EQ(result.z, 0.5f);
+    EXPECT_FLOAT_EQ(result.w, 0.5f);
+}
+
+TEST(ModifierComposeQuat, SetReplacesValueInPushOrder) {
+    // SET replaces the running value in place — subsequent MULTIPLYs
+    // compose on top of the SET'd value, not the base.
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.5f)), // discarded by SET
+        mkQ(kFieldA, TransformKind::SET, rotZ(0.1f)),
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.2f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(99.0f), kFieldA, mods);
+    expectRotZApplied(result, 0.1f + 0.2f);
+}
+
+TEST(ModifierComposeQuat, OverrideShortCircuitsPriorModifiers) {
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.5f)),
+        mkQ(kFieldA, TransformKind::SET, rotZ(0.7f)),
+        mkQ(kFieldA, TransformKind::OVERRIDE, rotZ(0.2f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(99.0f), kFieldA, mods);
+    expectRotZApplied(result, 0.2f);
+}
+
+TEST(ModifierComposeQuat, OverrideLetsLaterModifiersApply) {
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(100.0f)),
+        mkQ(kFieldA, TransformKind::OVERRIDE, rotZ(0.1f)),
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.2f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(99.0f), kFieldA, mods);
+    expectRotZApplied(result, 0.1f + 0.2f);
+}
+
+TEST(ModifierComposeQuat, LatestOverrideWins) {
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::OVERRIDE, rotZ(0.1f)),
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.5f)),
+        mkQ(kFieldA, TransformKind::OVERRIDE, rotZ(0.3f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(99.0f), kFieldA, mods);
+    expectRotZApplied(result, 0.3f);
+}
+
+TEST(ModifierComposeQuat, OtherFieldsDoNotInfluenceTarget) {
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.1f)),
+        mkQ(kFieldB, TransformKind::MULTIPLY, rotZ(99.0f)),
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.2f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(0.0f), kFieldA, mods);
+    expectRotZApplied(result, 0.1f + 0.2f);
+}
+
+TEST(ModifierComposeQuat, AddCLAMPMINCLAMPMAXSilentlySkipped) {
+    // Direct-vector construction bypasses the push-API assertion;
+    // verify the compose path treats these as no-ops rather than
+    // applying nonsense.
+    std::vector<ModifierQuat> mods{
+        mkQ(kFieldA, TransformKind::ADD, rotZ(99.0f)),       // skipped
+        mkQ(kFieldA, TransformKind::CLAMP_MIN, rotZ(99.0f)), // skipped
+        mkQ(kFieldA, TransformKind::CLAMP_MAX, rotZ(99.0f)), // skipped
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.3f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(0.2f), kFieldA, mods);
+    expectRotZApplied(result, 0.3f + 0.2f);
+}
+
+// ---- Compose: globals + entity layering ----------------------------------
+
+TEST(ModifierComposeQuatGlobals, GlobalsApplyBeforeEntity) {
+    // Combined sequence is globals first, then entity (per
+    // modifier_compose.hpp's `modsA` = globals, `modsB` = entity-mods).
+    // Left-multiply order means entity's MULTIPLY ends up outermost:
+    //   resolved = entity * globals * base.
+    // For axis-aligned rotZ that's additive in angle.
+    std::vector<ModifierQuat> globals{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.1f)),
+    };
+    std::vector<ModifierQuat> entity{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.2f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(0.3f), kFieldA, globals, entity);
+    expectRotZApplied(result, 0.1f + 0.2f + 0.3f);
+}
+
+TEST(ModifierComposeQuatGlobals, EntityOverrideTrumpsGlobalAlgebra) {
+    std::vector<ModifierQuat> globals{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(99.0f)),
+    };
+    std::vector<ModifierQuat> entity{
+        mkQ(kFieldA, TransformKind::OVERRIDE, rotZ(0.4f)),
+    };
+    IRMath::vec4 result = composeForFieldQuat(rotZ(99.0f), kFieldA, globals, entity);
+    expectRotZApplied(result, 0.4f);
+}
+
+TEST(ModifierComposeQuatGlobals, GlobalOverrideAppliedWhenEntityHasNone) {
+    std::vector<ModifierQuat> globals{
+        mkQ(kFieldA, TransformKind::OVERRIDE, rotZ(0.2f)),
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.1f)),
+    };
+    std::vector<ModifierQuat> entity{
+        mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.3f)),
+    };
+    // Globals OVERRIDE → 0.2; globals MULTIPLY 0.1 → 0.3; entity MULTIPLY
+    // 0.3 (outermost) → 0.6.
+    IRMath::vec4 result = composeForFieldQuat(rotZ(99.0f), kFieldA, globals, entity);
+    expectRotZApplied(result, 0.2f + 0.1f + 0.3f);
+}
+
+// ---- C_ResolvedFields helpers -------------------------------------------
+
+TEST(CResolvedFieldsQuat, ResetInsertsAndUpdates) {
+    C_ResolvedFields rf;
+    rf.resetQuat(kFieldA, rotZ(0.1f));
+    ASSERT_EQ(rf.fieldsQuat_.size(), 1u);
+    EXPECT_NEAR(rf.getQuat(kFieldA).w, rotZ(0.1f).w, kEpsilon);
+
+    rf.resetQuat(kFieldA, rotZ(0.5f));
+    ASSERT_EQ(rf.fieldsQuat_.size(), 1u);
+    EXPECT_NEAR(rf.getQuat(kFieldA).w, rotZ(0.5f).w, kEpsilon);
+
+    rf.resetQuat(kFieldB, rotZ(0.2f));
+    ASSERT_EQ(rf.fieldsQuat_.size(), 2u);
+    EXPECT_NEAR(rf.getQuat(kFieldB).z, rotZ(0.2f).z, kEpsilon);
+}
+
+TEST(CResolvedFieldsQuat, ApplyMultiplyComposesPostRotate) {
+    C_ResolvedFields rf;
+    rf.resetQuat(kFieldA, rotZ(0.4f));
+    rf.apply(mkQ(kFieldA, TransformKind::MULTIPLY, rotZ(0.6f)));
+    // mod * base = rotZ(0.6 + 0.4).
+    expectRotZApplied(rf.getQuat(kFieldA), 0.6f + 0.4f);
+}
+
+TEST(CResolvedFieldsQuat, ApplyAddCLAMPNoops) {
+    C_ResolvedFields rf;
+    rf.resetQuat(kFieldA, rotZ(0.5f));
+    rf.apply(mkQ(kFieldA, TransformKind::ADD, rotZ(99.0f)));
+    rf.apply(mkQ(kFieldA, TransformKind::CLAMP_MIN, rotZ(99.0f)));
+    rf.apply(mkQ(kFieldA, TransformKind::CLAMP_MAX, rotZ(99.0f)));
+    expectRotZApplied(rf.getQuat(kFieldA), 0.5f);
+}
+
+TEST(CResolvedFieldsQuat, GetFallbackForUnknownFieldIsIdentity) {
+    C_ResolvedFields rf;
+    auto q = rf.getQuat(kFieldA);
+    EXPECT_FLOAT_EQ(q.x, 0.0f);
+    EXPECT_FLOAT_EQ(q.y, 0.0f);
+    EXPECT_FLOAT_EQ(q.z, 0.0f);
+    EXPECT_FLOAT_EQ(q.w, 1.0f);
+}
+
+TEST(CResolvedFieldsQuat, GetFallbackCustomOverrideRespected) {
+    C_ResolvedFields rf;
+    IRMath::vec4 customFallback = rotZ(1.234f);
+    auto q = rf.getQuat(kFieldA, customFallback);
+    EXPECT_FLOAT_EQ(q.x, customFallback.x);
+    EXPECT_FLOAT_EQ(q.y, customFallback.y);
+    EXPECT_FLOAT_EQ(q.z, customFallback.z);
+    EXPECT_FLOAT_EQ(q.w, customFallback.w);
+}
+
+TEST(CResolvedFieldsQuat, ScalarVec3AndQuatPathsAreIndependent) {
+    // All three vectors live on the same C_ResolvedFields; resetQuat must
+    // not stomp the scalar / vec3 fields with the same id, and vice versa.
+    C_ResolvedFields rf;
+    rf.reset(kFieldA, 1.5f);
+    rf.resetVec3(kFieldA, IRMath::vec3(10.0f, 20.0f, 30.0f));
+    rf.resetQuat(kFieldA, rotZ(0.7f));
+
+    EXPECT_FLOAT_EQ(rf.get(kFieldA), 1.5f);
+    EXPECT_FLOAT_EQ(rf.getVec3(kFieldA).y, 20.0f);
+    EXPECT_NEAR(rf.getQuat(kFieldA).w, rotZ(0.7f).w, kEpsilon);
+}
+
+// ---- Decay semantics: in-place via std::remove_if -----------------------
+
+void decayQuatOnce(std::vector<ModifierQuat> &v) {
+    auto end = std::remove_if(
+        v.begin(), v.end(), IRComponents::detail::tickAndExpired<ModifierQuat>
+    );
+    v.erase(end, v.end());
+}
+
+TEST(ModifierQuatDecay, MinusOneSentinelIsKeptForever) {
+    std::vector<ModifierQuat> mods{
+        ModifierQuat{kFieldA, TransformKind::MULTIPLY, rotZ(0.1f), IREntity::EntityId{0}, -1},
+    };
+    decayQuatOnce(mods);
+    EXPECT_EQ(mods.size(), 1u);
+}
+
+TEST(ModifierQuatDecay, ExactExpiryDropsAtZero) {
+    std::vector<ModifierQuat> mods{
+        ModifierQuat{kFieldA, TransformKind::MULTIPLY, rotZ(0.1f), IREntity::EntityId{0}, 1},
+    };
+    decayQuatOnce(mods);
+    EXPECT_EQ(mods.size(), 0u);
+}
+
+TEST(ModifierQuatDecay, SixtyTickModifierExpiresAtSixty) {
+    std::vector<ModifierQuat> mods{
+        ModifierQuat{kFieldA, TransformKind::MULTIPLY, rotZ(0.1f), IREntity::EntityId{0}, 60},
+    };
+    for (int i = 0; i < 59; ++i) {
+        decayQuatOnce(mods);
+        ASSERT_EQ(mods.size(), 1u) << "premature drop at tick " << i;
+    }
+    decayQuatOnce(mods);
+    EXPECT_EQ(mods.size(), 0u);
+}
+
+// ---- Push API: type-mismatch dispatch + assertions -----------------------
+
+class IRModifierQuatPushTest : public testing::Test {
+  protected:
+    IRModifierQuatPushTest()
+        : m_entity_manager{} {}
+
+    IREntity::EntityManager m_entity_manager;
+};
+
+TEST_F(IRModifierQuatPushTest, ScalarPushAgainstQuatFieldNoOps) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto quatFieldId = IRPrefab::Modifier::registerFieldQuat("test.quat_only");
+
+    IRPrefab::Modifier::push(target, quatFieldId, TransformKind::SET, 1.0f, IREntity::kNullEntity);
+
+    auto &c = IREntity::getComponent<C_Modifiers>(target);
+    EXPECT_EQ(c.modifiers_.size(), 0u);
+    EXPECT_EQ(c.modifiersVec3_.size(), 0u);
+    EXPECT_EQ(c.modifiersQuat_.size(), 0u);
+}
+
+TEST_F(IRModifierQuatPushTest, QuatPushAgainstScalarFieldNoOps) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto scalarFieldId = IRPrefab::Modifier::registerField("test.scalar_only_quat");
+
+    IRPrefab::Modifier::push(
+        target, scalarFieldId, TransformKind::MULTIPLY, rotZ(0.5f), IREntity::kNullEntity
+    );
+
+    auto &c = IREntity::getComponent<C_Modifiers>(target);
+    EXPECT_EQ(c.modifiers_.size(), 0u);
+    EXPECT_EQ(c.modifiersQuat_.size(), 0u);
+}
+
+TEST_F(IRModifierQuatPushTest, QuatPushAgainstVec3FieldNoOps) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto vec3FieldId = IRPrefab::Modifier::registerFieldVec3("test.vec3_only_for_quat");
+
+    IRPrefab::Modifier::push(
+        target, vec3FieldId, TransformKind::MULTIPLY, rotZ(0.5f), IREntity::kNullEntity
+    );
+
+    auto &c = IREntity::getComponent<C_Modifiers>(target);
+    EXPECT_EQ(c.modifiersQuat_.size(), 0u);
+    EXPECT_EQ(c.modifiersVec3_.size(), 0u);
+}
+
+TEST_F(IRModifierQuatPushTest, QuatPushAgainstQuatFieldLandsInQuatVector) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto quatFieldId = IRPrefab::Modifier::registerFieldQuat("test.quat_landing");
+
+    IRPrefab::Modifier::push(
+        target, quatFieldId, TransformKind::MULTIPLY, rotZ(0.3f), IREntity::kNullEntity
+    );
+
+    auto &c = IREntity::getComponent<C_Modifiers>(target);
+    EXPECT_EQ(c.modifiers_.size(), 0u);
+    EXPECT_EQ(c.modifiersVec3_.size(), 0u);
+    ASSERT_EQ(c.modifiersQuat_.size(), 1u);
+    EXPECT_NEAR(c.modifiersQuat_[0].param_.z, rotZ(0.3f).z, kEpsilon);
+}
+
+TEST_F(IRModifierQuatPushTest, ApplyToFieldQuatComposesDirectly) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto field = IRPrefab::Modifier::registerFieldQuat("test.apply_quat_query");
+    IRPrefab::Modifier::push(
+        target, field, TransformKind::MULTIPLY, rotZ(0.4f), IREntity::kNullEntity
+    );
+
+    auto result = IRPrefab::Modifier::applyToFieldQuat(target, field, rotZ(0.3f));
+    expectRotZApplied(result, 0.4f + 0.3f);
+}
+
+TEST_F(IRModifierQuatPushTest, AddOnQuatFieldAssertsAndSkips) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto field = IRPrefab::Modifier::registerFieldQuat("test.quat_add_assert");
+
+    // IR_ASSERT throws std::runtime_error in debug builds; the test
+    // binary is built debug, so EXPECT_THROW is the right harness.
+    EXPECT_THROW(
+        IRPrefab::Modifier::push(
+            target, field, TransformKind::ADD, rotZ(0.5f), IREntity::kNullEntity
+        ),
+        std::runtime_error
+    );
+}
+
+TEST_F(IRModifierQuatPushTest, ClampMinOnQuatFieldAssertsAndSkips) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto field = IRPrefab::Modifier::registerFieldQuat("test.quat_clamp_min_assert");
+
+    EXPECT_THROW(
+        IRPrefab::Modifier::push(
+            target, field, TransformKind::CLAMP_MIN, rotZ(0.5f), IREntity::kNullEntity
+        ),
+        std::runtime_error
+    );
+}
+
+TEST_F(IRModifierQuatPushTest, ClampMaxOnQuatFieldAssertsAndSkips) {
+    auto target = IREntity::createEntity(C_Modifiers{});
+    auto field = IRPrefab::Modifier::registerFieldQuat("test.quat_clamp_max_assert");
+
+    EXPECT_THROW(
+        IRPrefab::Modifier::push(
+            target, field, TransformKind::CLAMP_MAX, rotZ(0.5f), IREntity::kNullEntity
+        ),
+        std::runtime_error
+    );
+}
+
+// ---- Auto-sweep on entity destruction (quat vectors) --------------------
+
+class IRModifierQuatAutoSweepTest : public testing::Test {
+  protected:
+    IRModifierQuatAutoSweepTest()
+        : m_entity_manager{} {
+        m_hook_id = IREntity::getEntityManager().registerPreDestroyHook(
+            [](IREntity::EntityId destroyed) {
+                IRPrefab::Modifier::removeBySource(destroyed);
+            }
+        );
+    }
+
+    ~IRModifierQuatAutoSweepTest() override {
+        IREntity::getEntityManager().unregisterPreDestroyHook(m_hook_id);
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IREntity::PreDestroyHookId m_hook_id{IREntity::kInvalidPreDestroyHookId};
+};
+
+TEST_F(IRModifierQuatAutoSweepTest, DestroyingSourceStripsQuatModifiersFromTarget) {
+    auto field = IRPrefab::Modifier::registerFieldQuat("test.quat_sweep");
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(C_Modifiers{});
+
+    IRPrefab::Modifier::push(target, field, TransformKind::MULTIPLY, rotZ(0.4f), source);
+    ASSERT_EQ(IREntity::getComponent<C_Modifiers>(target).modifiersQuat_.size(), 1u);
+
+    m_entity_manager.destroyEntity(source);
+
+    EXPECT_EQ(IREntity::getComponent<C_Modifiers>(target).modifiersQuat_.size(), 0u);
+}
+
+TEST_F(IRModifierQuatAutoSweepTest, DestroyingSourceLeavesOtherSourceQuatModifiersAlone) {
+    auto field = IRPrefab::Modifier::registerFieldQuat("test.quat_sweep_partial");
+    auto sourceA = IREntity::createEntity();
+    auto sourceB = IREntity::createEntity();
+    auto target  = IREntity::createEntity(C_Modifiers{});
+
+    IRPrefab::Modifier::push(target, field, TransformKind::MULTIPLY, rotZ(0.1f), sourceA);
+    IRPrefab::Modifier::push(target, field, TransformKind::MULTIPLY, rotZ(0.2f), sourceB);
+
+    m_entity_manager.destroyEntity(sourceA);
+
+    auto &after = IREntity::getComponent<C_Modifiers>(target).modifiersQuat_;
+    ASSERT_EQ(after.size(), 1u);
+    EXPECT_EQ(after[0].source_, sourceB);
+}
+
+} // namespace

--- a/test/ecs/modifier_runtime_test.cpp
+++ b/test/ecs/modifier_runtime_test.cpp
@@ -261,12 +261,8 @@ TEST(CResolvedFields, ApplyMutatesValue) {
 TEST(CResolvedFields, ApplyLambdaUsesCurrentValue) {
     C_ResolvedFields rf;
     rf.reset(kFieldA, 4.0f);
-    IRComponents::LambdaModifier lambda{
-        kFieldA,
-        [](float v) { return v * v; },
-        IREntity::EntityId{0},
-        -1
-    };
+    IRComponents::LambdaModifier
+        lambda{kFieldA, [](float v) { return v * v; }, IREntity::EntityId{0}, -1};
     rf.applyLambda(lambda);
     EXPECT_FLOAT_EQ(rf.get(kFieldA), 16.0f);
 }
@@ -283,18 +279,18 @@ namespace {
 
 // Mirror the per-system tick: drop entries where `tickAndExpired` reports true.
 // Templated so the same harness covers both Modifier and LambdaModifier.
-template <typename T>
-void decayOnce(std::vector<T> &v) {
-    auto end = std::remove_if(v.begin(), v.end(),
-                              IRComponents::detail::tickAndExpired<T>);
+template <typename T> void decayOnce(std::vector<T> &v) {
+    auto end = std::remove_if(v.begin(), v.end(), IRComponents::detail::tickAndExpired<T>);
     v.erase(end, v.end());
 }
 
-IRComponents::LambdaModifier mkLambda(FieldBindingId field,
-                                      std::function<float(float)> fn,
-                                      std::int32_t ticksRemaining) {
+IRComponents::LambdaModifier
+mkLambda(FieldBindingId field, std::function<float(float)> fn, std::int32_t ticksRemaining) {
     return IRComponents::LambdaModifier{
-        field, std::move(fn), IREntity::EntityId{0}, ticksRemaining
+        field,
+        std::move(fn),
+        IREntity::EntityId{0},
+        ticksRemaining
     };
 }
 
@@ -337,9 +333,11 @@ TEST(ModifierDecay, SourceRemovalKeepsOnlyMatchingSourceOut) {
     };
     auto target = IREntity::EntityId{1};
     mods.erase(
-        std::remove_if(mods.begin(), mods.end(), [&](const Modifier &m) {
-            return m.source_ == target;
-        }),
+        std::remove_if(
+            mods.begin(),
+            mods.end(),
+            [&](const Modifier &m) { return m.source_ == target; }
+        ),
         mods.end()
     );
     ASSERT_EQ(mods.size(), 1u);
@@ -358,11 +356,18 @@ class IRModifierAutoSweepTest : public testing::Test {
         // only exercises the pre-destroy hook + sweep, not the resolver
         // pipeline). Stash the hook id so the destructor can unregister
         // it before the next test instance reinstalls one.
-        m_hook_id = IREntity::getEntityManager().registerPreDestroyHook(
-            [](IREntity::EntityId destroyed) {
+        m_hook_id =
+            IREntity::getEntityManager().registerPreDestroyHook([](IREntity::EntityId destroyed) {
                 IRPrefab::Modifier::removeBySource(destroyed);
-            }
-        );
+            });
+        // Register a scalar field explicitly so push() routes into the
+        // scalar vector regardless of what other tests have populated
+        // the global registry with first. Bare `FieldBindingId{1}`
+        // relies on id 1 being scalar-typed, but the global registry
+        // is shared across all tests — a vec3 / quat registration that
+        // lands first in the suite's execution order would otherwise
+        // make this push silently no-op.
+        m_scalar_field = IRPrefab::Modifier::registerField("test.modifier_autosweep_scalar");
     }
 
     ~IRModifierAutoSweepTest() override {
@@ -371,13 +376,14 @@ class IRModifierAutoSweepTest : public testing::Test {
 
     IREntity::EntityManager m_entity_manager;
     IREntity::PreDestroyHookId m_hook_id{IREntity::kInvalidPreDestroyHookId};
+    IRComponents::FieldBindingId m_scalar_field{IRComponents::kInvalidFieldId};
 };
 
 TEST_F(IRModifierAutoSweepTest, DestroyingSourceStripsModifiersFromTarget) {
     auto source = IREntity::createEntity();
     auto target = IREntity::createEntity(IRComponents::C_Modifiers{});
 
-    IRPrefab::Modifier::push(target, kFieldA, TransformKind::ADD, 5.0f, source);
+    IRPrefab::Modifier::push(target, m_scalar_field, TransformKind::ADD, 5.0f, source);
     auto &modsBefore = IREntity::getComponent<IRComponents::C_Modifiers>(target).modifiers_;
     ASSERT_EQ(modsBefore.size(), 1u);
     EXPECT_EQ(modsBefore[0].source_, source);
@@ -391,10 +397,10 @@ TEST_F(IRModifierAutoSweepTest, DestroyingSourceStripsModifiersFromTarget) {
 TEST_F(IRModifierAutoSweepTest, DestroyingSourceLeavesUnrelatedModifiersAlone) {
     auto sourceA = IREntity::createEntity();
     auto sourceB = IREntity::createEntity();
-    auto target  = IREntity::createEntity(IRComponents::C_Modifiers{});
+    auto target = IREntity::createEntity(IRComponents::C_Modifiers{});
 
-    IRPrefab::Modifier::push(target, kFieldA, TransformKind::ADD, 5.0f, sourceA);
-    IRPrefab::Modifier::push(target, kFieldA, TransformKind::ADD, 7.0f, sourceB);
+    IRPrefab::Modifier::push(target, m_scalar_field, TransformKind::ADD, 5.0f, sourceA);
+    IRPrefab::Modifier::push(target, m_scalar_field, TransformKind::ADD, 7.0f, sourceB);
 
     m_entity_manager.destroyEntity(sourceA);
 
@@ -409,9 +415,13 @@ TEST_F(IRModifierAutoSweepTest, DestroyingSourceStripsLambdaModifiers) {
     auto target = IREntity::createEntity(IRComponents::C_LambdaModifiers{});
 
     IRPrefab::Modifier::pushLambda(
-        target, kFieldA, [](float v) { return v * 2.0f; }, source
+        target,
+        m_scalar_field,
+        [](float v) { return v * 2.0f; },
+        source
     );
-    auto &lambdasBefore = IREntity::getComponent<IRComponents::C_LambdaModifiers>(target).modifiers_;
+    auto &lambdasBefore =
+        IREntity::getComponent<IRComponents::C_LambdaModifiers>(target).modifiers_;
     ASSERT_EQ(lambdasBefore.size(), 1u);
 
     m_entity_manager.destroyEntity(source);
@@ -474,11 +484,9 @@ TEST(LambdaModifierDecay, DropRunsCapturedDestructor) {
     // can hold heap state. Captured shared_ptr witnesses use_count drop.
     auto witness = std::make_shared<int>(7);
     std::vector<IRComponents::LambdaModifier> lambdas;
-    lambdas.push_back(mkLambda(
-        kFieldA,
-        [witness](float v) { return v + static_cast<float>(*witness); },
-        1
-    ));
+    lambdas.push_back(
+        mkLambda(kFieldA, [witness](float v) { return v + static_cast<float>(*witness); }, 1)
+    );
     EXPECT_EQ(witness.use_count(), 2L); // one capture + outer
 
     decayOnce(lambdas);

--- a/test/ecs/modifier_types_test.cpp
+++ b/test/ecs/modifier_types_test.cpp
@@ -17,8 +17,10 @@ using IRComponents::FieldValueType;
 using IRComponents::kInvalidFieldId;
 using IRComponents::LambdaModifier;
 using IRComponents::Modifier;
+using IRComponents::ModifierQuat;
 using IRComponents::ModifierVec3;
 using IRComponents::ResolvedField;
+using IRComponents::ResolvedFieldQuat;
 using IRComponents::ResolvedFieldVec3;
 using IRComponents::TransformKind;
 
@@ -128,6 +130,33 @@ TEST(ModifierTypes, CResolvedFieldsHoldsBothVectorsIndependently) {
     EXPECT_EQ(c.fieldsVec3_.size(), std::size_t{1});
     EXPECT_FLOAT_EQ(c.fields_[0].value_, 1.5f);
     EXPECT_FLOAT_EQ(c.fieldsVec3_[0].value_.y, 2.0f);
+}
+
+TEST(ModifierTypes, ModifierQuatIsTriviallyCopyable) {
+    static_assert(std::is_trivially_copyable_v<ModifierQuat>);
+    SUCCEED();
+}
+
+TEST(ModifierTypes, ModifierQuatLayoutLocked) {
+    // 2 (field_) + 1 (kind_) + 1 pad + 16 (vec4 param_) + 4 pad for
+    // 8-byte EntityId align + 8 (source_) + 4 (ticks_) + 4 tail = 40.
+    static_assert(sizeof(ModifierQuat) == 40);
+    static_assert(alignof(ModifierQuat) == 8);
+    SUCCEED();
+}
+
+TEST(ModifierTypes, CResolvedFieldsHoldsAllThreeVectorsIndependently) {
+    C_ResolvedFields c{};
+    c.fields_.push_back(ResolvedField{FieldBindingId{1}, 1.5f});
+    c.fieldsVec3_.push_back(ResolvedFieldVec3{FieldBindingId{2}, IRMath::vec3(1.0f, 2.0f, 3.0f)});
+    c.fieldsQuat_.push_back(
+        ResolvedFieldQuat{FieldBindingId{3}, IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)}
+    );
+
+    EXPECT_EQ(c.fields_.size(), std::size_t{1});
+    EXPECT_EQ(c.fieldsVec3_.size(), std::size_t{1});
+    EXPECT_EQ(c.fieldsQuat_.size(), std::size_t{1});
+    EXPECT_FLOAT_EQ(c.fieldsQuat_[0].value_.w, 1.0f);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Adds quaternion-typed fields to the modifier framework alongside scalar / vec3, with the non-commutative compose semantics rotation perturbations need. Unblocks T-197 (SYSTEM_PROPAGATE_TRANSFORM) — the SQT propagation system will consume the resolved ROTATION quat alongside POSITION / SCALE vec3 fields through the same modifier channel.

## Compose rules

- `MULTIPLY` → **post-rotate / left-multiply**: `value = quatMul(mod, value)`. Stacked MULTIPLYs apply outer-first in push-order, matching the engine's `quatMul(parent_world, local)` bone-chain idiom.
- `OVERRIDE` → latest OVERRIDE wins; short-circuits prior ops across the combined `(globals ++ entity_mods)` sequence.
- `SET` → replace value in push-order (no short-circuit).
- `ADD` / `CLAMP_MIN` / `CLAMP_MAX` → not meaningful on unit quaternions. Push API fires `IR_ASSERT` in debug and skips in release; compose path also defensively skips so direct-vector construction can't slip nonsense through.

Final result is normalized once per compose to amortize stacked-MULTIPLY float drift, gated behind a `touched` flag so an identity-only path round-trips the caller's base unchanged.

## Test plan

- [x] 37 new `ModifierQuat*` / `IRModifierQuat*` tests cover compose, decay, typed dispatch, push-time asserts, auto-sweep
- [x] All 699 existing tests pass
- [x] `sizeof(ModifierQuat) == 40`, trivially-copyable static_assert locked
- [x] `sizeof(Modifier)` and `sizeof(ModifierVec3)` unchanged
- [x] `IRModifier.addQuat` / `addGlobalQuat` / `applyToFieldQuat` / `resolvedQuat` exposed via Lua bindings
- [x] No `glm::*` or `std::sin/cos/...` outside the IRMath allowlist; uses `IRMath::quatMul` and `IRMath::normalize`

## Notes for reviewer

- The compose helper `composeForFieldQuat` mirrors `composeForFieldVec3`'s structure (two scans for latest OVERRIDE; one for the algebra) with the algebra reduced to MULTIPLY/SET and a final normalize. The `touched` flag matters: it skips the normalize when no modifier fired, so `applyToFieldQuat(target, field, unit_quat)` with no modifiers returns the caller's `unit_quat` verbatim.
- The legacy `IRModifierAutoSweepTest` fixture in `test/ecs/modifier_runtime_test.cpp` previously used bare `FieldBindingId{1}` and depended on the global registry's first registration being scalar. The new quat tests expose this latency (they happen to register a quat field first under the new alphabetical filename order), so I hardened the legacy fixture to register its own scalar field. The fix is correct independent of registration order.
- The Lua surface is added in BOTH binding files for parity with how the vec3 surface landed:
  - `engine/script/include/irreden/script/lua_modifier_bindings.hpp` — modern `IRModifier.*` API
  - `engine/prefabs/irreden/common/modifier_lua.hpp` — legacy `ir.modifier.*` API
- `quatFromLua` was added to `ir_script_utils.hpp` alongside `vec3FromLua`. Asymmetric default-ing (vec3 zero-defaults, quat identity-defaults) is documented inline because a zero quat would be degenerate.

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)