### PR TITLE
T-200: joints as entities — C_Skeleton + C_Joint scaffolding (replace SoA C_JointHierarchy)

### DIFF
--- a/docs/design/entity-editor-epic.md
+++ b/docs/design/entity-editor-epic.md
@@ -78,8 +78,9 @@ to scope/plan flow through normal review.
   [game-side editor-needs doc](https://github.com/jakildev/irreden/blob/master/irreden/docs/editor-needs.md).
 - **Trixel-rendered editor UI** — no dear-imgui, no third-party UI libs.
   Reuses the existing trixel font + SDF/voxel rendering stack.
-- **Skeletal animation + IK in-engine** — wire the existing
-  `C_JointHierarchy` stub through to the GPU. FABRIK + Two-Bone IK.
+- **Skeletal animation + IK in-engine** — wire joint entities
+  (`C_Skeleton` rig roots + `C_Joint`-tagged joint entities related by
+  `CHILD_OF`) through to the GPU joint-matrix SSBO. FABRIK + Two-Bone IK.
   Runtime foot-IK and interaction-IK.
 - **Modular interpolation** — registry of named C++ curves plus Lua-defined
   custom interpolators per keyframe.
@@ -160,7 +161,7 @@ revisited per-phase:
 | Decision | Rationale |
 |---|---|
 | **GUI rendered via trixel** | See above. No dear-imgui. No third-party UI lib. |
-| **Skeletal animation + IK in-engine** | Wires existing `C_JointHierarchy`. FABRIK + Two-Bone. Foot-IK + interaction-IK at runtime. |
+| **Skeletal animation + IK in-engine** | Joints are entities (`C_Skeleton` rig root + `C_Joint`-tagged joint entities, parent chain via `CHILD_OF`). FABRIK + Two-Bone. Foot-IK + interaction-IK at runtime. |
 | **Modular interpolation** | Registry of built-in C++ curves; Lua-defined custom interpolators per keyframe. Zero-overhead for built-ins. |
 | **Editor exe lives at `creations/editors/voxel_editor/`** | Tracked in the engine repo (gitignore exception added in F-0.8). Private editor tools such as `font_maker` remain gitignored. |
 | **Per-voxel record extends to 12 B** | `{material_id, flags, bone_id}` added. `bone_id = 0` is identity (zero-cost back-compat). |
@@ -414,15 +415,22 @@ mode. `.vxs.json` sidecar is human-diffable.
 
 ### Scope
 
-Activate the existing `C_JointHierarchy` stub and the declared-but-unfilled
-GPU joint-matrix buffer SSBO. Per-voxel `bone_id` is consumed by the
-compute shader; multi-volume entities have each volume bound to a bone;
-FK pose editing works in the editor.
+Activate the GPU joint-matrix buffer SSBO and per-voxel `bone_id`
+consumption in the compute shader; multi-volume entities have each volume
+bound to a bone; FK pose editing works in the editor.
+
+Joints are entities, not vector entries in one component on the rig root.
+The scaffolding for that model — `C_Skeleton` (rig root) + `C_Joint` (tag
+on each joint entity) + CHILD_OF — lands in `#737` ahead of this phase so
+the consumer-side migration here has a stable target. The legacy
+`C_JointHierarchy` is deprecated; sub-task 2.1 reads from the new
+components.
 
 ### Sub-tasks
 
-- **2.1** Drive `C_JointHierarchy` — fill GPU joint buffer SSBO each
-  frame from CPU joint state.
+- **2.1** Drive the joint-matrix SSBO — iterate each `C_Skeleton`,
+  fetch each joint entity's world transform, pack into the SSBO at the
+  slot matching the joint's index in `C_Skeleton.joints_`.
 - **2.2** Per-voxel `bone_id` consumed by compute shader stage 1
   (`c_voxel_to_trixel_stage_1.glsl` applies
   `bone_matrix[bone_id] * local_offset`).

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -19,7 +19,16 @@ for single voxels and particles.
   position updates; supports reshape (box/sphere SDF).
 - `C_ShapeDescriptor` — SDF shape type + params + color + flags (visible,
   hollow, mirror). Rendered directly by the GPU; **does not allocate voxels**.
-- `C_JointHierarchy` — WIP; articulated voxel rigs.
+- `C_Skeleton` — rig-root component holding an ordered vector of joint
+  EntityIds. The position in the vector IS the bone_id used by
+  `C_Voxel.bone_id_` and indexed by the per-frame GPU joint-matrix SSBO.
+  See "Entity-based joints" below.
+- `C_Joint` — tag marking an entity as a skeletal joint. Paired with the
+  engine's canonical local-transform component and a `CHILD_OF` relation
+  to the rig root (or to a parent joint).
+- `C_JointHierarchy` — DEPRECATED; superseded by `C_Skeleton` + `C_Joint`.
+  Remains for one release as a compile shim. See `component_joint_hierarchy.hpp`
+  for the migration note.
 - `C_BindPoints` — runtime mirror of an asset rig's BIND chunk
   (`IRAsset::Rig::bindPoints_`). Each entry stores
   `{boneId, offset, rotation}` keyed by name. Populated by
@@ -97,6 +106,71 @@ nothing to the pool's per-frame writes — no risk of clobbering
 adjacent voxel-set ranges. `onDestroy()` skips the pool
 deallocation when `numVoxels_ == 0`, so the staging vector frees
 with the component.
+
+## Entity-based joints
+
+Joint hierarchies are first-class entities, not vector entries inside a
+single component on the rig root. Three pieces:
+
+- **`C_Skeleton`** on the rig root. Holds `std::vector<EntityId> joints_`
+  — the canonical, ordered list of joint entities. The index of an entry
+  in `joints_` IS the `bone_id` used by `C_Voxel.bone_id_` and indexed by
+  the per-frame GPU joint-matrix SSBO at binding 21.
+- **`C_Joint`** tag on each joint entity. Drives joint-only archetype
+  queries like `<C_Joint, C_LocalTransform>` so IK solvers and the GPU
+  joint-matrix uploader iterate joints without seeing rig roots or
+  skinned voxel sets.
+- **`CHILD_OF`** relations between joint entities form the bone tree. The
+  same `SYSTEM_PROPAGATE_TRANSFORM` (from `#731` Phase 2) that walks
+  every other CHILD_OF hierarchy composes the parent chain — no
+  joint-specific traversal code.
+
+Each joint entity carries the engine's canonical local-transform component
+(`C_Position3D` + `C_Rotation` today; `C_LocalTransform` once `#731` Phase 1
+lands). Joints can also carry arbitrary gameplay components — IK targets,
+constraints, hit-boxes, sound emitters, particle attachments — because the
+joint is just an ECS entity. That is the whole point of the entity-based
+model.
+
+### Bone-index stability and severance
+
+`C_Skeleton.joints_` is a flat ordered list — its indices are the bone-id
+space. **Indices are stable across saves and severance.** Severing a joint
+leaves a hole at the slot rather than splicing it out:
+
+```
+IRPrefab::Skeleton::severJoint(rigRoot, joint);
+// 1. removeRelation(joint, rigRoot, CHILD_OF) — joint becomes orphan.
+// 2. Walk descendants (still C_Joint, also orphaned).
+// 3. For each voxel whose bone_id matches joint or its descendants,
+//    bake the current world position into a new free-flying
+//    C_VoxelSetNew on a new entity.
+// 4. Mark the severed slot in C_Skeleton.joints_ as kNullEntity.
+//    The matching GPU SSBO slot uploads as identity.
+```
+
+The severance API is **declared in this design, not yet implemented**.
+It lives outside the current scaffolding ticket; the entity-based shape
+exists in code first so consumer migration in `#605` Phase 2 has a stable
+target. File a follow-up ticket when `#605` Phase 2 unblocks.
+
+### Bind pose
+
+Skinning math needs the bind-pose inverse to recover skinning matrices.
+`C_Skeleton` does **not** carry a `bindPose_` field yet — the canonical
+`IRMath::SQT` struct lands with `#731` Phase 1 (`C_LocalTransform`). Once
+SQT is available, a follow-up adds `std::vector<IRMath::SQT> bindPose_;`
+to `C_Skeleton` parallel to `joints_`. Until then, callers that need a
+bind pose load it from the `.rig` asset's BIND chunk via
+`IRPrefab::Rig::bindPose(rigRoot)`.
+
+### Optional follow-up: C_JointName
+
+The design also calls for an optional `C_JointName` tag carrying the
+bone name string for editor / animation reference. Filed as a separate
+follow-up rather than baked in here — `C_Skeleton.joints_[i]` is the
+authoritative reference; bone names are a UX convenience for editors and
+animation clips that want to address joints by string.
 
 ## Gotchas
 

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -115,7 +115,8 @@ single component on the rig root. Three pieces:
 - **`C_Skeleton`** on the rig root. Holds `std::vector<EntityId> joints_`
   — the canonical, ordered list of joint entities. The index of an entry
   in `joints_` IS the `bone_id` used by `C_Voxel.bone_id_` and indexed by
-  the per-frame GPU joint-matrix SSBO at binding 21.
+  the per-frame GPU joint-matrix SSBO at `kBufferIndex_JointTransforms`
+  (defined in `engine/render/include/irreden/render/ir_render_types.hpp`).
 - **`C_Joint`** tag on each joint entity. Drives joint-only archetype
   queries like `<C_Joint, C_LocalTransform>` so IK solvers and the GPU
   joint-matrix uploader iterate joints without seeing rig roots or

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -127,8 +127,8 @@ single component on the rig root. Three pieces:
   joint-specific traversal code.
 
 Each joint entity carries the engine's canonical local-transform component
-(`C_Position3D` + `C_Rotation` today; `C_LocalTransform` once `#731` Phase 1
-lands). Joints can also carry arbitrary gameplay components — IK targets,
+(`C_LocalTransform`, since `#731` Phase 1 landed — PR #749). Joints can also
+carry arbitrary gameplay components — IK targets,
 constraints, hit-boxes, sound emitters, particle attachments — because the
 joint is just an ECS entity. That is the whole point of the entity-based
 model.
@@ -158,12 +158,11 @@ target. File a follow-up ticket when `#605` Phase 2 unblocks.
 ### Bind pose
 
 Skinning math needs the bind-pose inverse to recover skinning matrices.
-`C_Skeleton` does **not** carry a `bindPose_` field yet — the canonical
-`IRMath::SQT` struct lands with `#731` Phase 1 (`C_LocalTransform`). Once
-SQT is available, a follow-up adds `std::vector<IRMath::SQT> bindPose_;`
-to `C_Skeleton` parallel to `joints_`. Until then, callers that need a
-bind pose load it from the `.rig` asset's BIND chunk via
-`IRPrefab::Rig::bindPose(rigRoot)`.
+`C_Skeleton` does **not** carry a `bindPose_` field yet — `IRMath::SQT` is
+available since `#731` Phase 1 landed (PR #749); a follow-up (#605 Phase 2)
+adds `std::vector<IRMath::SQT> bindPose_;` to `C_Skeleton` parallel to
+`joints_`. Until then, callers that need a bind pose load it from the `.rig`
+asset's BIND chunk via `IRPrefab::Rig::bindPose(rigRoot)`.
 
 ### Optional follow-up: C_JointName
 

--- a/engine/prefabs/irreden/voxel/components/component_joint.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_joint.hpp
@@ -1,0 +1,20 @@
+#ifndef COMPONENT_JOINT_H
+#define COMPONENT_JOINT_H
+
+// C_Joint — tag marking an entity as a skeletal joint owned by a C_Skeleton
+// rig root. Pairs with the engine's canonical local-transform component on
+// the same entity; CHILD_OF carries the parent reference up the bone chain.
+//
+// Drives archetype queries like `<C_Joint, C_LocalTransform>` so joint-only
+// systems (IK solvers, GPU joint-matrix uploaders) iterate joints without
+// also seeing rig roots or skinned voxel sets.
+//
+// See `component_skeleton.hpp` for the entity-based joint model.
+
+namespace IRComponents {
+
+struct C_Joint {};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_JOINT_H */

--- a/engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp
@@ -8,8 +8,7 @@
 //     See `component_skeleton.hpp`.
 //   - `C_Joint` tag on each joint entity. See `component_joint.hpp`.
 //   - Per-joint local transform via the engine's canonical local-transform
-//     component (`C_Position3D` + `C_Rotation` today; `C_LocalTransform`
-//     once #731 Phase 1 lands).
+//     component (`C_LocalTransform`, since #731 Phase 1 landed — PR #749).
 //   - `CHILD_OF` relations for the parent chain.
 //
 // The original SoA `C_JointHierarchy` packed every joint into one vector on

--- a/engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_joint_hierarchy.hpp
@@ -1,24 +1,35 @@
 #ifndef COMPONENT_JOINT_HIERARCHY_H
 #define COMPONENT_JOINT_HIERARCHY_H
 
-// PURPOSE: Per-entity joint tree for skeletal-style procedural animation.
-//   Each joint has a rotation quaternion (vec4), translation, and parent index.
-// STATUS: WIP stub -- system integration pending:
-//   - No system reads or writes joint data.
-//   - system_shapes_to_trixel.hpp creates the JointTransformBuffer SSBO
-//     but never uploads data; c_shapes_to_trixel.glsl declares JointBuffer
-//     but main() never reads from it.
-//   - system_shapes_to_trixel.hpp sets desc.jointIndex = 0 for all shapes.
-// TODO:
-//   1. Add JOINT_ANIMATION to SystemName enum.
-//   2. Create a system (or extend SHAPES_TO_TRIXEL) that:
-//      a. Uploads GPUJointTransform data per entity to JointTransformBuffer.
-//      b. Sets desc.jointIndex per shape to the correct joint.
-//   3. Update c_shapes_to_trixel.glsl main() to read joint transforms and
-//      apply parent-chain rotation/translation to voxel positions.
-//   4. Create a demo entity with joints (e.g. a 3-joint articulated arm
-//      oscillating sinusoidally) to test the full pipeline.
-// DEPENDENCIES: IRMath (vec4). GPU conversion lives in joint_hierarchy_gpu.hpp.
+// DEPRECATED — superseded by the entity-based joint model.
+//
+// New rigs should use:
+//   - `C_Skeleton` (rig root, holds an ordered vector of joint EntityIds).
+//     See `component_skeleton.hpp`.
+//   - `C_Joint` tag on each joint entity. See `component_joint.hpp`.
+//   - Per-joint local transform via the engine's canonical local-transform
+//     component (`C_Position3D` + `C_Rotation` today; `C_LocalTransform`
+//     once #731 Phase 1 lands).
+//   - `CHILD_OF` relations for the parent chain.
+//
+// The original SoA `C_JointHierarchy` packed every joint into one vector on
+// the rig root. The entity-based model unlocks severance, per-joint custom
+// components, dynamic re-parenting, and uniform reuse of the engine's
+// `CHILD_OF` traversal — see `engine/prefabs/irreden/voxel/CLAUDE.md`
+// "Entity-based joints" and the design refinement in `#737`.
+//
+// MIGRATION (#605 Phase 2 will do the consumer-side work):
+//   - The GPU joint-matrix SSBO uploader reads `C_Skeleton.joints_` on each
+//     rig root and packs per-joint world transforms (from
+//     `C_WorldTransform`) at the matching slot, indexed by `C_Voxel.bone_id_`.
+//   - The `setRotation` / `setTranslation` setters here have no equivalent —
+//     pose authoring writes the per-joint local-transform component
+//     directly, then `SYSTEM_PROPAGATE_TRANSFORM` walks the CHILD_OF chain
+//     to produce world transforms.
+//
+// This header remains for one release as a deprecation shim so existing
+// callers compile while the consumer migration lands. Do not add new code
+// that depends on it.
 
 #include <irreden/ir_math.hpp>
 
@@ -58,7 +69,6 @@ struct C_JointHierarchy {
             joints_[jointIndex].translation_ = translation;
         }
     }
-
 };
 
 } // namespace IRComponents

--- a/engine/prefabs/irreden/voxel/components/component_skeleton.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_skeleton.hpp
@@ -7,7 +7,8 @@
 // component) related to the rig root via CHILD_OF.
 //
 // The position of a joint in `joints_` IS the bone_id used by C_Voxel.bone_id_
-// and indexed by the per-frame GPU joint-matrix SSBO (binding 21). The index
+// and indexed by the per-frame GPU joint-matrix SSBO (binding
+// `kBufferIndex_JointTransforms` in `ir_render_types.hpp`). The index
 // space is stable across saves and severance — see "Severance leaves holes"
 // below — so re-baking voxel bone_ids is not required when a joint detaches.
 //

--- a/engine/prefabs/irreden/voxel/components/component_skeleton.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_skeleton.hpp
@@ -1,0 +1,69 @@
+#ifndef COMPONENT_SKELETON_H
+#define COMPONENT_SKELETON_H
+
+// C_Skeleton — rig-root component listing the rig's joint entities in
+// canonical GPU-upload order. Each entry in `joints_` is an EntityId of a
+// joint entity (carrying C_Joint + the engine's canonical local-transform
+// component) related to the rig root via CHILD_OF.
+//
+// The position of a joint in `joints_` IS the bone_id used by C_Voxel.bone_id_
+// and indexed by the per-frame GPU joint-matrix SSBO (binding 21). The index
+// space is stable across saves and severance — see "Severance leaves holes"
+// below — so re-baking voxel bone_ids is not required when a joint detaches.
+//
+// Replaces the SoA C_JointHierarchy. The legacy component remains for one
+// release as a deprecation shim; new rigs use C_Skeleton + per-joint entities.
+//
+// ## Joint entity shape
+//
+// Each entity listed in `joints_` carries:
+//   - C_Joint (tag — drives archetype queries like `<C_Joint, C_LocalTransform>`).
+//   - The engine's canonical local-transform component (currently
+//     C_Position3D / C_Rotation; will become C_LocalTransform once #731 Phase 1
+//     lands). C_Skeleton intentionally does NOT name a transform component in
+//     its API — joints carry whatever the engine's canonical transform is at
+//     spawn time, and SYSTEM_PROPAGATE_TRANSFORM (once it exists) composes the
+//     parent chain uniformly with every other CHILD_OF hierarchy.
+//   - (Optional) C_JointName for editor / animation lookup by bone name.
+//   - (Optional) gameplay components — IK targets, constraints, hit-boxes,
+//     sound emitters, particle attachments. The whole point of the
+//     entity-based model is that any ECS component composes onto a joint.
+//
+// ## Severance leaves holes, not shifts
+//
+// `IRPrefab::Skeleton::severJoint(rigRoot, joint)` (future ticket — declared
+// on the design side, not implemented here) removes the CHILD_OF relation
+// between `joint` and `rigRoot`, walks descendants (also C_Joint, also
+// orphaned), and bakes the world position of each voxel skinned to a
+// severed bone into a new free-flying C_VoxelSetNew. The slot in
+// `joints_` is left as kNullEntity rather than spliced out — this keeps the
+// bone-index space stable so voxel `bone_id`s remain valid without a
+// re-bake pass. The matching slot in the GPU SSBO is uploaded as identity
+// so any pre-severance voxels still referencing the slot render in their
+// last bound world transform until the asset is reloaded.
+//
+// ## Bind pose
+//
+// Skinning math needs the bind-pose inverse to recover skinning matrices.
+// `bindPose_` is intentionally NOT declared in this header yet — the
+// canonical IRMath::SQT struct lands with #731 Phase 1 (`C_LocalTransform`).
+// Once SQT is available, a follow-up task adds `std::vector<IRMath::SQT>
+// bindPose_;` here, parallel to `joints_`. Until then, callers that need a
+// bind pose load it from the `.rig` asset's BIND chunk via
+// `IRPrefab::Rig::bindPose(rigRoot)`.
+
+#include <irreden/entity/ir_entity_types.hpp>
+
+#include <vector>
+
+namespace IRComponents {
+
+struct C_Skeleton {
+    std::vector<IREntity::EntityId> joints_;
+
+    C_Skeleton() = default;
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_SKELETON_H */

--- a/engine/prefabs/irreden/voxel/components/component_skeleton.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_skeleton.hpp
@@ -19,12 +19,12 @@
 //
 // Each entity listed in `joints_` carries:
 //   - C_Joint (tag — drives archetype queries like `<C_Joint, C_LocalTransform>`).
-//   - The engine's canonical local-transform component (currently
-//     C_Position3D / C_Rotation; will become C_LocalTransform once #731 Phase 1
-//     lands). C_Skeleton intentionally does NOT name a transform component in
-//     its API — joints carry whatever the engine's canonical transform is at
-//     spawn time, and SYSTEM_PROPAGATE_TRANSFORM (once it exists) composes the
-//     parent chain uniformly with every other CHILD_OF hierarchy.
+//   - The engine's canonical local-transform component (C_LocalTransform,
+//     since #731 Phase 1 landed — PR #749). C_Skeleton intentionally does NOT
+//     name a transform component in its API — joints carry whatever the
+//     engine's canonical transform is at spawn time, and
+//     SYSTEM_PROPAGATE_TRANSFORM composes the parent chain uniformly with
+//     every other CHILD_OF hierarchy.
 //   - (Optional) C_JointName for editor / animation lookup by bone name.
 //   - (Optional) gameplay components — IK targets, constraints, hit-boxes,
 //     sound emitters, particle attachments. The whole point of the
@@ -46,12 +46,11 @@
 // ## Bind pose
 //
 // Skinning math needs the bind-pose inverse to recover skinning matrices.
-// `bindPose_` is intentionally NOT declared in this header yet — the
-// canonical IRMath::SQT struct lands with #731 Phase 1 (`C_LocalTransform`).
-// Once SQT is available, a follow-up task adds `std::vector<IRMath::SQT>
-// bindPose_;` here, parallel to `joints_`. Until then, callers that need a
-// bind pose load it from the `.rig` asset's BIND chunk via
-// `IRPrefab::Rig::bindPose(rigRoot)`.
+// `bindPose_` is intentionally NOT declared in this header yet — IRMath::SQT
+// is now available (since #731 Phase 1 landed — PR #749); a follow-up task
+// (#605 Phase 2) adds `std::vector<IRMath::SQT> bindPose_;` here, parallel
+// to `joints_`. Until then, callers that need a bind pose load it from the
+// `.rig` asset's BIND chunk via `IRPrefab::Rig::bindPose(rigRoot)`.
 
 #include <irreden/entity/ir_entity_types.hpp>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(IrredenEngineTest
   ecs/modifier_types_test.cpp
   ecs/modifier_vec3_runtime_test.cpp
   ecs/propagate_transform_test.cpp
+  ecs/skeleton_components_test.cpp
   ecs/system_exclude_test.cpp
   math/physics_test.cpp
   math/ir_math_test.cpp

--- a/test/ecs/skeleton_components_test.cpp
+++ b/test/ecs/skeleton_components_test.cpp
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/entity/entity_manager.hpp>
+#include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/voxel/components/component_joint.hpp>
+
+using IRComponents::C_Joint;
+using IRComponents::C_Skeleton;
+
+namespace {
+
+class SkeletonComponentsTest : public testing::Test {
+  protected:
+    IREntity::EntityManager m_entity_manager;
+};
+
+TEST_F(SkeletonComponentsTest, JointTagRegistersAndQueriesByArchetype) {
+    auto j0 = IREntity::createEntity(C_Joint{});
+    auto j1 = IREntity::createEntity(C_Joint{});
+
+    int count = 0;
+    IREntity::forEachComponent<C_Joint>([&](C_Joint &) { ++count; });
+    EXPECT_EQ(count, 2);
+
+    EXPECT_NE(j0, j1);
+}
+
+TEST_F(SkeletonComponentsTest, SkeletonHoldsJointEntityIds) {
+    auto root = IREntity::createEntity(C_Skeleton{});
+    auto j0 = IREntity::createEntity(C_Joint{});
+    auto j1 = IREntity::createEntity(C_Joint{});
+
+    auto &skel = IREntity::getComponent<C_Skeleton>(root);
+    skel.joints_ = {j0, j1};
+
+    auto &readback = IREntity::getComponent<C_Skeleton>(root);
+    ASSERT_EQ(readback.joints_.size(), 2u);
+    EXPECT_EQ(readback.joints_[0], j0);
+    EXPECT_EQ(readback.joints_[1], j1);
+}
+
+TEST_F(SkeletonComponentsTest, SeveredSlotIsKNullEntitySentinel) {
+    auto root = IREntity::createEntity(C_Skeleton{});
+    auto j0 = IREntity::createEntity(C_Joint{});
+    auto j1 = IREntity::createEntity(C_Joint{});
+
+    auto &skel = IREntity::getComponent<C_Skeleton>(root);
+    skel.joints_ = {j0, j1};
+    skel.joints_[0] = IREntity::kNullEntity;
+
+    EXPECT_EQ(skel.joints_[0], IREntity::kNullEntity)
+        << "severed slot preserves index space via kNullEntity sentinel";
+    EXPECT_EQ(skel.joints_[1], j1)
+        << "trailing joint indices are stable after severance at index 0";
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Declare `C_Skeleton` (rig-root component, ordered vector of joint
  EntityIds; the index IS the bone_id space) and `C_Joint` (tag
  component) as the entity-based replacement for the SoA
  `C_JointHierarchy`.
- Deprecate `C_JointHierarchy` via a header banner pointing at
  `C_Skeleton` + `C_Joint`; the legacy struct stays for one release as
  a compile shim so existing consumers keep building.
- Document the entity-based joint model in
  `engine/prefabs/irreden/voxel/CLAUDE.md` — three pieces (`C_Skeleton`,
  `C_Joint`, `CHILD_OF`), bone-index stability under severance (slots
  null out rather than shift), bind-pose deferral until `IRMath::SQT`
  lands with #731 Phase 1, and the optional `C_JointName` follow-up.
- Update `docs/design/entity-editor-epic.md` Phase 2 scope and
  sub-task 2.1 to reflect the refined approach.

Scaffolding only — consumer migration (GPU joint-matrix SSBO uploader,
per-voxel `bone_id` consumption, severance API implementation) is #605
Phase 2 and reads from these new components when it lands. The asset-
side `IRAsset::Rig` → runtime translation in `rig_bridge.hpp` and the
script-side bind-point composition still query `C_JointHierarchy`;
their migration moves alongside #605 Phase 2 work and is intentionally
out of scope here.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` clean.
- [x] `SkeletonComponentsTest.JointTagRegistersAndQueriesByArchetype` —
      `C_Joint` registers as a component type and a `forEachComponent<C_Joint>`
      walk visits every tagged entity.
- [x] `SkeletonComponentsTest.SkeletonHoldsJointEntityIds` — joint
      EntityIds round-trip through `C_Skeleton::joints_` via
      `getComponent`.
- [x] `SkeletonComponentsTest.SeveredSlotIsKNullEntitySentinel` — a
      slot set to `kNullEntity` leaves trailing joint indices stable
      (severance preserves bone-index space).

## Notes for reviewer

- Verify the deprecation banner in `component_joint_hierarchy.hpp`
  reads as a clear migration guide; the body of the header is
  intentionally unchanged so callers still compile.
- The bind-pose field is intentionally absent from `C_Skeleton` —
  follow-up adds `std::vector<IRMath::SQT> bindPose_;` once SQT lands
  with #731 Phase 1.

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)