### PR TITLE
math/render: move ShapeFlags enum to IRMath::SDF (T-201 step 1)

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -231,7 +231,7 @@ uint32  shapeTypeId      // numeric; resolve via SREF name lookup
 uint16  recordVersion    // additive-only field evolution (Rule #3)
 float32 params[4]        // SDF parameters (semantics per ShapeType)
 uint32  packedRGBA       // Color::toPackedRGBA()
-uint32  flags            // IRRender::ShapeFlags bit field
+uint32  flags            // IRMath::SDF::ShapeFlags bit field
 uint8   boneId           // joint binding (T-146 / T-169); 0 = none
 float32 offset[3]        // local translation
 float32 rotation[4]      // quaternion (x, y, z, w)

--- a/engine/asset/include/irreden/asset/voxel_set_format.hpp
+++ b/engine/asset/include/irreden/asset/voxel_set_format.hpp
@@ -39,7 +39,7 @@
 ///                                  // (Rule #3); v1 fields fixed below
 ///       float32 params[4]          // SDF parameter vector
 ///       uint32  packedRGBA         // `Color::toPackedRGBA()` packing
-///       uint32  flags              // `IRRender::ShapeFlags` bit field
+///       uint32  flags              // `IRMath::SDF::ShapeFlags` bit field
 ///       uint8   boneId             // joint binding (T-146/T-169); 0 = none
 ///       float32 offset[3]          // local translation
 ///       float32 rotation[4]        // quaternion (x, y, z, w)

--- a/engine/math/include/irreden/math/sdf.hpp
+++ b/engine/math/include/irreden/math/sdf.hpp
@@ -24,6 +24,35 @@ enum class ShapeType : std::uint32_t {
     TORUS = 9,
 };
 
+/// Bit-combinable shape flags stored in @c GPUShapeDescriptor::flags. Combine
+/// with @c |. Canonical definition lives here so the math-side SDF layer and
+/// the render layer share one source of truth; @c IRRender::ShapeFlags is a
+/// @c using alias of this type (the @c SHAPE_FLAG_* enumerators are also
+/// re-exported into @c IRRender by using-declarations in
+/// @c engine/render/include/irreden/render/ir_render_types.hpp).
+enum ShapeFlags : std::uint32_t {
+    SHAPE_FLAG_NONE = 0,
+    SHAPE_FLAG_HOLLOW = 1u << 0, ///< Render only the shell; skip interior voxels.
+    SHAPE_FLAG_MIRROR_X = 1u << 1,
+    SHAPE_FLAG_MIRROR_Y = 1u << 2,
+    SHAPE_FLAG_VISIBLE = 1u << 3,
+    /// Forward-looking: snap joint rotation to nearest 90° in iso-adjusted space.
+    /// Not yet implemented.
+    SHAPE_FLAG_DISCRETE_ROTATION = 1u << 4,
+    SHAPE_FLAG_CHECKERBOARD = 1u << 5,
+    /// Color each voxel by its LOCAL iso-depth along the camera's forward axis,
+    /// normalized to [0, 1] over the shape's own depth extent. Useful for
+    /// visually distinguishing individual shapes regardless of world position.
+    SHAPE_FLAG_DEPTH_COLOR = 1u << 6,
+    /// X-ray silhouette on occlusion. The shape writes its color normally
+    /// where it wins the depth contest; where it loses (something closer
+    /// already owns the pixel) `c_shapes_to_trixel` blends the shape color
+    /// at reduced alpha over the existing canvas color, so the shape still
+    /// reads as a faint silhouette through the occluder. Generic per-shape
+    /// opt-in (T-164).
+    SHAPE_FLAG_XRAY_OCCLUDED = 1u << 7,
+};
+
 constexpr float kSurfaceThreshold = 0.5f;
 
 inline vec4 effectiveParams(ShapeType type, vec4 params) {

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -186,30 +186,21 @@ struct GPUUpdateParams {
 /// stay in lockstep without two parallel enums to keep synchronized.
 using ShapeType = IRMath::SDF::ShapeType;
 
-/// Bit-combinable rendering flags stored in @c GPUShapeDescriptor::flags.
-/// Combine with @c |.
-enum ShapeFlags : std::uint32_t {
-    SHAPE_FLAG_NONE = 0,
-    SHAPE_FLAG_HOLLOW = 1u << 0, ///< Render only the shell; skip interior voxels.
-    SHAPE_FLAG_MIRROR_X = 1u << 1,
-    SHAPE_FLAG_MIRROR_Y = 1u << 2,
-    SHAPE_FLAG_VISIBLE = 1u << 3,
-    /// Forward-looking: snap joint rotation to nearest 90° in iso-adjusted space.
-    /// Not yet implemented.
-    SHAPE_FLAG_DISCRETE_ROTATION = 1u << 4,
-    SHAPE_FLAG_CHECKERBOARD = 1u << 5,
-    /// Color each voxel by its LOCAL iso-depth along the camera's forward axis,
-    /// normalized to [0, 1] over the shape's own depth extent. Useful for
-    /// visually distinguishing individual shapes regardless of world position.
-    SHAPE_FLAG_DEPTH_COLOR = 1u << 6,
-    /// X-ray silhouette on occlusion. The shape writes its color normally
-    /// where it wins the depth contest; where it loses (something closer
-    /// already owns the pixel) `c_shapes_to_trixel` blends the shape color
-    /// at reduced alpha over the existing canvas color, so the shape still
-    /// reads as a faint silhouette through the occluder. Generic per-shape
-    /// opt-in (T-164).
-    SHAPE_FLAG_XRAY_OCCLUDED = 1u << 7,
-};
+/// Bit-combinable shape flags stored in @c GPUShapeDescriptor::flags. The
+/// canonical definition lives in @ref IRMath::SDF::ShapeFlags so the math
+/// side and the renderer share one source of truth; the using-declarations
+/// below re-export the @c SHAPE_FLAG_* enumerators into @c IRRender so the
+/// existing @c IRRender::SHAPE_FLAG_VISIBLE spelling keeps working.
+using ShapeFlags = IRMath::SDF::ShapeFlags;
+using IRMath::SDF::SHAPE_FLAG_CHECKERBOARD;
+using IRMath::SDF::SHAPE_FLAG_DEPTH_COLOR;
+using IRMath::SDF::SHAPE_FLAG_DISCRETE_ROTATION;
+using IRMath::SDF::SHAPE_FLAG_HOLLOW;
+using IRMath::SDF::SHAPE_FLAG_MIRROR_X;
+using IRMath::SDF::SHAPE_FLAG_MIRROR_Y;
+using IRMath::SDF::SHAPE_FLAG_NONE;
+using IRMath::SDF::SHAPE_FLAG_VISIBLE;
+using IRMath::SDF::SHAPE_FLAG_XRAY_OCCLUDED;
 
 struct GPUShapeDescriptor {
     vec4 worldPosition;


### PR DESCRIPTION
## Summary

- Move the canonical `ShapeFlags` enum from `engine/render/include/irreden/render/ir_render_types.hpp` to `engine/math/include/irreden/math/sdf.hpp` alongside the existing `IRMath::SDF::ShapeType`.
- Preserve every existing `IRRender::SHAPE_FLAG_*` call site by re-exporting the enumerators (and the `ShapeFlags` type) into `IRRender::` via `using` declarations.
- No behavior change. Pure layering plumbing — the SDF flag set is now reachable from the math layer without any render dependency.

## Why

`#739` (T-201) is a multi-PR refactor that decouples the scripting layer from the rendering layer at the include-graph level. The architect's suggested approach lists this as step 1 ("move `ShapeType` + `SHAPE_FLAG_*` to a render-neutral header — pure rename / include-path shuffle, no behavior change"). `ShapeType` was already a `using` alias of `IRMath::SDF::ShapeType`; this PR finishes the move for `SHAPE_FLAG_*`.

This PR does **not** close `#739`. Follow-up steps remaining for the full T-201 layering goal:

1. Decide where `IRRender::getActiveCanvasEntityOrNull()` lives (design call).
2. Refactor `C_VoxelSetNew` to not directly call `IRRender::allocateVoxels` / `deallocateVoxels`.
3. Re-remove `IrredenEngineRendering` from `engine/script/CMakeLists.txt`.

I'll file separate follow-up issues for those after this lands.

## Test plan

- [x] `fleet-build --target IRShapeDebug` — clean.
- [x] `fleet-build --target IrredenEngineTest` — clean.
- [x] `fleet-run IrredenEngineTest` — 662 tests pass (3.6s).
- [x] All consumer call sites (`creations/demos/shape_debug/main.cpp`, `creations/editors/voxel_editor/main.cpp`, `engine/prefabs/irreden/render/picking.hpp`, `gizmo.hpp`, `system_voxel_picking.hpp`, etc.) continue to use the `IRRender::SHAPE_FLAG_*` spelling unchanged via the new using-declarations.

## Notes for reviewer

- `engine/render/include/irreden/render/ir_render_types.hpp` already `#include`d `<irreden/math/sdf.hpp>`, so no new transitive include surface was added.
- `clang-format` reordered the using-declarations alphabetically inside the render namespace; that's the expected reflow, not a separate edit.
- Asset format docs (`engine/asset/CLAUDE.md`, `engine/asset/include/irreden/asset/voxel_set_format.hpp`) now reference `IRMath::SDF::ShapeFlags` instead of `IRRender::ShapeFlags` since the adjacent `IRMath::SDF::ShapeType` reference already used that namespace — the doc block now reads consistently.
- Diff is pure type-relocation. No render output changes, so `attach-screenshots` / `render-debug-loop` skipped per role doc step 9's "mechanical refactor" exemption.

Refs #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)