### PR TITLE
fleet: tmux 3.4 + bash 5.2 compat for Ubuntu 24.04 bring-up

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -771,10 +771,17 @@ build_dispatch_command() {
     # exit code and record rate-limit exits — the pipe to fleet-claude-stream
     # would otherwise swallow claude's exit code (PIPESTATUS is only available
     # in the pane's shell, not in the dispatcher). See fleet-dispatch-wrap.
+    #
+    # Leading-space sacrificial character: bash 5.2 readline (Ubuntu 24.04)
+    # eats the first input byte that arrives during the post-prompt redraw
+    # window after C-c. Without the space, `tmux send-keys C-c C-u "fleet-…" C-m`
+    # delivers `leet-…` to readline and the pane loops on
+    # `leet-dispatch-wrap: command not found`. Bash ignores leading whitespace
+    # on command lines, so the eaten space is harmless.
     local role="$1" pane_key="$2"
     local model="${ROLE_MODEL[$role]:-sonnet}"
     local effort="${ROLE_EFFORT[$role]:-high}"
-    printf 'fleet-dispatch-wrap %q %q %q %q\n' "$pane_key" "$model" "$effort" "$role"
+    printf ' fleet-dispatch-wrap %q %q %q %q\n' "$pane_key" "$model" "$effort" "$role"
 }
 
 dispatch_role() {
@@ -860,11 +867,19 @@ dispatch_role() {
         # Safe at a shell prompt — find_idle_panes_for_role only picks
         # panes whose pane_current_command is bash/zsh/sh/fish, so C-c
         # acts on the input loop, not a running command.
-        if ! dispatch_send_keys -t "$pane_id" C-c C-u "$cmd" C-m; then
-            # send-keys timed out or failed for this pane (pane vanished,
-            # tmux server died, pty buffer wedged, etc.). Try the next
-            # pane; if none succeed, keep the trigger for next tick.
-            log "send-keys timeout/failed for $role -> $pane_id; trying next idle pane"
+        # Split the burst: C-c interrupts whatever's at the prompt and
+        # triggers bash to redraw; without a gap, the first char of
+        # "$cmd" arrives while readline is mid-redraw and gets eaten
+        # ("fleet-dispatch-wrap" → "leet-dispatch-wrap: command not
+        # found"). 50ms is enough on tmux 3.4 / Ubuntu 24.04; cheap on
+        # every other host.
+        if ! dispatch_send_keys -t "$pane_id" C-c C-u; then
+            log "send-keys (reset) timeout/failed for $role -> $pane_id; trying next idle pane"
+            continue
+        fi
+        sleep 0.05
+        if ! dispatch_send_keys -t "$pane_id" "$cmd" C-m; then
+            log "send-keys (cmd) timeout/failed for $role -> $pane_id; trying next idle pane"
             continue
         fi
         write_dispatch_record "$role" "$pane_id"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -1011,14 +1011,14 @@ set_fleet_role "$TOP_LEFT" "sonnet-author"
 pane_stagger
 
 # Split bottom 2/3 off — that becomes the middle row's leftmost pane.
-MID_LEFT=$(tmux split-window -v -t "$TOP_LEFT" -p 67 -P -F "#{pane_id}" \
+MID_LEFT=$(tmux split-window -v -t "$TOP_LEFT" -l 67% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-architect" \
     "$(launch_cmd "$OPUS_MODEL" opus-architect)")
 label_pane_id "$MID_LEFT" "opus-architect [opus 4.7]"
 pane_stagger
 
 # Split bottom 1/2 of the middle off — that becomes bottom row leftmost.
-BOT_LEFT=$(tmux split-window -v -t "$MID_LEFT" -p 50 -P -F "#{pane_id}" \
+BOT_LEFT=$(tmux split-window -v -t "$MID_LEFT" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-1" \
     "$TRANSIENT_PANE_CMD")
 label_pane_id "$BOT_LEFT" "opus-worker-1 [opus 4.7]"
@@ -1026,17 +1026,17 @@ set_fleet_role "$BOT_LEFT" "opus-worker"
 pane_stagger
 
 # Top row: split TOP_LEFT horizontally to add sonnet-fleet-2 and
-# sonnet-reviewer. -p 67 leaves 33% for the new pane (right 2/3
-# of the original TOP_LEFT region); the second split halves what's
-# left, giving three equal columns.
-TOP_MID=$(tmux split-window -h -t "$TOP_LEFT" -p 67 -P -F "#{pane_id}" \
+# sonnet-reviewer. -l 67% gives the new pane 67% of the original
+# TOP_LEFT region (TOP_LEFT shrinks to 33%); the second split halves
+# what's left, giving three equal columns.
+TOP_MID=$(tmux split-window -h -t "$TOP_LEFT" -l 67% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-2" \
     "$TRANSIENT_PANE_CMD")
 label_pane_id "$TOP_MID" "sonnet-fleet-2 [sonnet]"
 set_fleet_role "$TOP_MID" "sonnet-author"
 pane_stagger
 
-TOP_RIGHT=$(tmux split-window -h -t "$TOP_MID" -p 50 -P -F "#{pane_id}" \
+TOP_RIGHT=$(tmux split-window -h -t "$TOP_MID" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/sonnet-reviewer" \
     "$TRANSIENT_PANE_CMD")
 label_pane_id "$TOP_RIGHT" "sonnet-reviewer [sonnet]"
@@ -1047,7 +1047,7 @@ pane_stagger
 # the game worktree exists). 50/50 split since architects coexist as
 # equals (engine + game).
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
-    MID_RIGHT=$(tmux split-window -h -t "$MID_LEFT" -p 50 -P -F "#{pane_id}" \
+    MID_RIGHT=$(tmux split-window -h -t "$MID_LEFT" -l 50% -P -F "#{pane_id}" \
         -c "$GAME/.claude/worktrees/game-architect" \
         "$(launch_cmd "$OPUS_MODEL" game-architect)")
     label_pane_id "$MID_RIGHT" "game-architect [opus 4.7]"
@@ -1057,14 +1057,14 @@ fi
 # Bottom row: split BOT_LEFT horizontally for opus-worker-2 and
 # opus-reviewer. Same 67/50 pattern as the top row to get three
 # equal columns.
-BOT_MID=$(tmux split-window -h -t "$BOT_LEFT" -p 67 -P -F "#{pane_id}" \
+BOT_MID=$(tmux split-window -h -t "$BOT_LEFT" -l 67% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-2" \
     "$TRANSIENT_PANE_CMD")
 label_pane_id "$BOT_MID" "opus-worker-2 [opus 4.7]"
 set_fleet_role "$BOT_MID" "opus-worker"
 pane_stagger
 
-BOT_RIGHT=$(tmux split-window -h -t "$BOT_MID" -p 50 -P -F "#{pane_id}" \
+BOT_RIGHT=$(tmux split-window -h -t "$BOT_MID" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
     "$TRANSIENT_PANE_CMD")
 label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.7]"
@@ -1090,18 +1090,18 @@ OPS_TL=$(tmux new-window -a -t "$SESSION:fleet" -n ops -P -F "#{pane_id}" \
 label_pane_id "$OPS_TL" "queue-mgr/scratch [human]"
 pane_stagger
 
-OPS_TR=$(tmux split-window -h -t "$OPS_TL" -p 50 -P -F "#{pane_id}" \
+OPS_TR=$(tmux split-window -h -t "$OPS_TL" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/merger" \
     "$TRANSIENT_PANE_CMD")
 label_pane_id "$OPS_TR" "merger [opus 4.7]"
 set_fleet_role "$OPS_TR" "merger"
 
-OPS_BL=$(tmux split-window -v -t "$OPS_TL" -p 50 -P -F "#{pane_id}" \
+OPS_BL=$(tmux split-window -v -t "$OPS_TL" -l 50% -P -F "#{pane_id}" \
     -c "$HOME/.fleet" \
     "witness; exec $SHELL")
 label_pane_id "$OPS_BL" "witness"
 
-OPS_BR=$(tmux split-window -v -t "$OPS_TR" -p 50 -P -F "#{pane_id}" \
+OPS_BR=$(tmux split-window -v -t "$OPS_TR" -l 50% -P -F "#{pane_id}" \
     -c "$HOME" \
     "exec $SHELL")
 label_pane_id "$OPS_BR" "terminal"


### PR DESCRIPTION
## Summary
- `fleet-up`: replace deprecated `tmux split-window -p N` with `-l N%`; tmux 3.4 removed `-p` and every split was failing with "size missing", collapsing the 9-pane layout to a single bash pane.
- `fleet-dispatcher`: split the `tmux send-keys C-c C-u "<cmd>" C-m` burst with a 50ms gap and prepend a sacrificial leading space to the dispatched command, so bash 5.2's post-prompt-redraw input-eating window consumes the space instead of the command's first byte (the "leet-dispatch-wrap: command not found" loop).

## Cross-platform safety
Both fixes are no-ops on macOS and Windows-native MSYS2:
- `-l N%` is the supported form on every tmux version that has `split-window` (Homebrew ships 3.5a; the deprecated `-p` is the only thing that breaks).
- macOS bash 3.2 and zsh don't exhibit the readline-redraw race. The leading space is harmless (bash any-version ignores leading whitespace on a command line); the 50ms gap adds a few ms of dispatch latency.

## Root-cause notes
- The bash 5.2 readline race was reproduced via `strace -e read` on a live worker pane: bash *did* receive `f`, `l`, `e`, `e`, `t`, `-`, ... in order, but the buffer at submit time was missing the first byte. Disabling `enable-bracketed-paste` in `~/.inputrc` did not fix it; the race is in readline's prompt-redraw path itself.
- A user-side workaround (`set enable-bracketed-paste off` in `~/.inputrc`, `set -g default-size 240x60` / `assume-paste-time 0` / `escape-time 0` in `~/.tmux.conf`) is also viable but requires every Ubuntu 24.04 fleet operator to ship the same dotfiles. The dispatcher patch removes the requirement.

## Test plan
- [x] `fleet-up` creates the full 9-pane fleet window + 4-pane ops window on Ubuntu 24.04 / tmux 3.4.
- [x] Worker panes receive ` fleet-dispatch-wrap ...` (note leading space) and launch `claude` instead of looping on "command not found".
- [ ] `fleet-up` still works on macOS (Homebrew tmux ≥ 3.5).
- [ ] `fleet-up` still works on Windows-native MSYS2 tmux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)