### PR TITLE
fleet: ship project-level permission allowlist so fresh hosts work out of the box

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Edit(*)", "Write(*)", "Read(*)",
+
+      "Bash(ls:*)", "Bash(cat:*)", "Bash(head:*)", "Bash(tail:*)",
+      "Bash(grep:*)", "Bash(rg:*)", "Bash(find:*)", "Bash(wc:*)",
+      "Bash(diff:*)", "Bash(stat:*)", "Bash(file:*)", "Bash(realpath:*)",
+      "Bash(basename:*)", "Bash(dirname:*)", "Bash(sort:*)", "Bash(uniq:*)",
+      "Bash(tr:*)", "Bash(cut:*)", "Bash(awk:*)", "Bash(sed:*)",
+      "Bash(xargs:*)", "Bash(tee:*)", "Bash(echo:*)", "Bash(printf:*)",
+      "Bash(jq:*)", "Bash(od:*)", "Bash(xxd:*)",
+      "Bash(date:*)", "Bash(env:*)", "Bash(which:*)", "Bash(type:*)",
+
+      "Bash(mkdir:*)", "Bash(cp:*)", "Bash(mv:*)", "Bash(touch:*)",
+      "Bash(chmod:*)", "Bash(ln:*)", "Bash(mktemp:*)",
+      "Bash(rm -rf /tmp/fleet-*)",
+
+      "Bash(python3:*)", "Bash(python:*)", "Bash(node:*)", "Bash(npm:*)",
+
+      "Bash(ps:*)", "Bash(pgrep:*)", "Bash(pkill -f fleet-*)",
+
+      "Bash(git:*)",
+      "Bash(GIT_EDITOR=true git:*)",
+      "Bash(GIT_PAGER=cat git:*)",
+
+      "Bash(gh:*)",
+
+      "Bash(cmake --build:*)",
+      "Bash(make:*)", "Bash(ninja:*)", "Bash(ctest:*)",
+
+      "Bash(fleet-claim:*)", "Bash(fleet-build:*)", "Bash(fleet-debug:*)",
+      "Bash(fleet-run:*)", "Bash(fleet-run-targets:*)", "Bash(fleet-help:*)",
+      "Bash(fleet-heartbeat:*)", "Bash(fleet-issue:*)", "Bash(fleet-pr:*)",
+      "Bash(fleet-pr-clear-feedback-labels:*)",
+      "Bash(fleet-worktree-busy-branches:*)", "Bash(fleet-labels:*)",
+      "Bash(fleet-feedback:*)", "Bash(fleet-gate-status:*)",
+      "Bash(fleet-tasks-render:*)", "Bash(fleet-queue-tick:*)",
+      "Bash(fleet-queue-ingest:*)", "Bash(fleet-reconcile-amendments:*)",
+      "Bash(fleet-state-scout:*)", "Bash(fleet-dispatcher:*)",
+      "Bash(fleet-dispatch-wrap:*)", "Bash(fleet-claude-stream:*)",
+      "Bash(fleet-up:*)", "Bash(fleet-down:*)", "Bash(fleet-babysit:*)",
+      "Bash(witness:*)",
+
+      "Bash(tmux list-:*)", "Bash(tmux display-message:*)",
+      "Bash(tmux capture-pane:*)", "Bash(tmux show-options:*)",
+
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:api.github.com)"
+    ],
+    "deny": [
+      "Bash(gh pr merge:*)",
+
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force-with-lease:*)",
+      "Bash(git push --delete:*)",
+      "Bash(git push origin :*)",
+
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -fd:*)",
+      "Bash(git clean -fdx:*)",
+      "Bash(git branch -D master)",
+      "Bash(git branch -D main)",
+
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf ~*)",
+      "Bash(rm -rf .claude/worktrees*)",
+      "Bash(rm -rf .git*)",
+
+      "Bash(sudo:*)",
+      "Bash(apt:*)", "Bash(apt-get:*)", "Bash(dpkg:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ creations/editors/font_maker
 !creations/editors/voxel_editor/
 !creations/editors/voxel_editor/**
 
-# claude code: share skills + roles + path-scoped rules + worker subagents, ignore worktrees and local session state
+# claude code: share skills + roles + path-scoped rules + worker subagents + project-level settings, ignore worktrees and per-session local state
 .claude/*
 !.claude/skills/
 !.claude/skills/**
@@ -52,3 +52,4 @@ creations/editors/font_maker
 !.claude/rules/**
 !.claude/agents/
 !.claude/agents/**
+!.claude/settings.json

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -644,38 +644,68 @@ Practical rule:
 
 ---
 
-## 7. `settings.json` — permissions and allowlist (optional but helpful)
+## 7. `settings.json` — permissions and allowlist
 
-If you want Sonnet-fleet agents to run unattended overnight, loosen the
-default confirmation prompts for commands they need. Edit your Claude
-Code settings (not the repo) and add an allowlist for build / test /
-`gh` / read-only shell commands. Keep **writes to master, force pushes,
-and destructive git commands** on the confirm list.
+The repo now ships a project-level allowlist at
+[`.claude/settings.json`](../.claude/settings.json) which Claude Code
+auto-loads for every session opened against any worktree under the
+repo. **No manual setup required on a fresh clone** — it just works.
 
-Rough starting allowlist (works identically on WSL and macOS — plain
-Unix commands, no `cmd.exe` wrappers):
+Coverage (the same one all fleet roles need to run unattended in
+`--print` mode without a human to approve permission prompts):
 
-- `cmake --build ...`
-- `cmake --preset linux-debug` (WSL) / `cmake --preset macos-debug` (Mac)
-- `ninja ...`, `make ...`
-- `gh pr view`, `gh pr diff`, `gh pr list`, `gh pr review --comment`,
-  `gh pr create` (but *not* `gh pr merge`)
-- `git status`, `git diff`, `git log`, `git fetch`, `git checkout -b`,
-  `git add`, `git commit`, `git push -u origin HEAD`
-- `ctest ...`
-- Common read-only shell: `ls`, `cat`, `head`, `tail`, `wc`, `find`
+- `Bash(git:*)` and `Bash(gh:*)` — broad allow with explicit deny for
+  force-push / `gh pr merge` / branch deletion / `git push origin :*`
+  etc.
+- `Bash(cmake --build:*)`, `make`, `ninja`, `ctest` — build/test only.
+  `cmake --preset` is excluded so agents don't re-configure the build
+  tree out from under you.
+- All `fleet-*` scripts.
+- `python3`, `node`, `npm` for tooling.
+- Read-only / safe shell utilities (`ls`, `cat`, `grep`, `find`,
+  `mkdir`, `cp`, `mv`, `chmod`, `mktemp`, `jq`, …).
+- `Edit(*)`, `Write(*)`, `Read(*)` — file operations.
+- `WebFetch(domain:github.com)` and friends — for skill flows that
+  pull PR/issue context over HTTPS.
+- `pkill -f fleet-*` — scoped so agents can restart fleet daemons but
+  can't kill arbitrary processes.
 
-Leave on prompt:
+Hard-denied (so even broad `Bash(git:*)` can't accidentally trigger):
+`gh pr merge:*`, `git push --force[--with-lease]:*`, `git push -f:*`,
+`git push --delete:*`, `git push origin :*` (branch-delete syntax),
+`git reset --hard:*`, `git clean -fd[x]:*`, `git branch -D master|main`,
+`rm -rf /*`, `rm -rf ~*`, `rm -rf .git*`, `rm -rf .claude/worktrees*`,
+`sudo:*`, `apt[-get]:*`, `dpkg:*`. The fleet's hard rule "agents never
+use sudo" is enforced at the permission layer, not just role docs.
 
-- `git push origin master`
-- `git push --force`
-- `git reset --hard`
-- `gh pr merge`
-- Anything destructive to `.claude/worktrees/`
-- `sudo ...` (any use of sudo)
-- `apt ...`, `apt-get ...`, `dpkg ...` (WSL package manager)
-- `brew install ...`, `brew upgrade ...`, `brew uninstall ...` (macOS)
-- `xcode-select --install`, `softwareupdate ...`
+### Personal overrides
+
+The committed file intentionally omits anything user-specific:
+- No `additionalDirectories` (those have absolute paths and vary per
+  host).
+- No `theme`, `defaultMode`, or other personal preferences.
+
+Per-worktree `.claude/settings.local.json` is auto-created by Claude
+Code on first session in a worktree and is the right place for those.
+Settings cascade is **user → project → local with allow/deny arrays
+merging (union)**, so you can add personal items at either level
+without touching the committed file.
+
+### Why the broad `Bash(git:*)` / `Bash(gh:*)` allow
+
+The fleet's queue-manager and worker roles run in
+`claude --print --output-format stream-json` (non-interactive). Any
+permission prompt in that mode auto-denies, so a narrow allowlist
+that misses one command (e.g. queue-manager's `git push origin
+HEAD:master` for TASKS.md, or `gh issue edit --add-label`) silently
+stalls a whole role. Broad-allow + targeted-deny avoids the
+maintenance burden of enumerating every command path each role
+might take, while still hard-blocking the actually-dangerous ones.
+
+If your security posture wants tighter rules, override at the
+worktree-local level with a narrower set, or set
+`permissions.defaultMode: "default"` in your user settings to force
+human confirmation on anything not explicitly listed.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `.claude/settings.json` with the allow/deny list every fleet role needs to run unattended in `--print` mode without a human approving each prompt. **Fresh fleet hosts now work out of the box** — no manual user-level `~/.claude/settings.json` editing required.

## Why

Diagnosed live on a fresh Ubuntu 24.04 fleet bring-up: queue-manager's first ingest after fleet-up hit **11 consecutive `permission_denials`** on `git fetch`, `git add TASKS.md`, `git commit`, `git push origin HEAD:master`, `gh issue view`, and `gh issue edit --add-label`. The agent eventually exited with:

> "Git and `gh` commands are consistently requiring approval that isn't being granted. The TASKS.md edits are written to disk — let me report what's been done so you can decide how to proceed."

Same failure mode applies to sonnet-author (commit-and-push), sonnet-reviewer (`gh pr checkout`), merger (`git rebase` + `git push`), etc. Without an allowlist, every role silently stalls until a human notices.

## Files

- **`.claude/settings.json`** (new) — broad `Bash(git:*)` + `Bash(gh:*)` with explicit deny for the actually-dangerous specifics. All `fleet-*` scripts. `cmake --build`, `make`, `ninja`, `ctest`. `python3`, `node`, `npm`. Read-only / safe shell utilities. `WebFetch` allowed for github.com / raw.githubusercontent.com / api.github.com.
- **`.gitignore`** — single `!.claude/settings.json` line. Keeps `.claude/settings.local.json` and the rest of `.claude/*` gitignored.
- **`docs/AGENT_FLEET_SETUP.md`** §7 — rewrite around the committed file. Notes the broad-allow + targeted-deny rationale and the user/project/local cascade.

## Deny list (what's hard-blocked even with broad git/gh allow)

- `gh pr merge:*` — fleet hard rule: agents never merge
- `git push --force:*`, `git push -f:*`, `git push --force-with-lease:*` — never force-push
- `git push --delete:*`, `git push origin :*` — never delete remote branches
- `git reset --hard:*`, `git clean -fd:*`, `git clean -fdx:*` — never destroy local state
- `git branch -D master`, `git branch -D main`
- `rm -rf /*`, `rm -rf ~*`, `rm -rf .claude/worktrees*`, `rm -rf .git*` — sweep guards
- `sudo:*`, `apt:*`, `apt-get:*`, `dpkg:*` — per CLAUDE.md "Agents never use sudo"

## Personal overrides (intentionally not committed)

- `additionalDirectories` — absolute paths like `/home/evinj/.fleet` are host-specific; auto-created per-worktree `.claude/settings.local.json` is the right place.
- `theme`, `defaultMode`, `skipAutoPermissionPrompt` — personal preferences, not project policy.

Settings cascade is user → project → local with allow/deny arrays merging (union), so any of these can be added at the worktree-local level without touching the committed file.

## Why broad `Bash(git:*)` / `Bash(gh:*)` instead of narrow

Fleet roles run in `claude --print --output-format stream-json /role-x`. Any permission prompt in `--print` auto-denies — so a narrow allowlist that misses one command (queue-manager's `git push origin HEAD:master`, reviewer's `gh pr checkout`, merger's `git rebase --onto`) silently stalls the role. Broad-allow + targeted-deny avoids the maintenance burden of enumerating every command path each role might take, while still hard-blocking the actually-dangerous ones.

If your security posture wants tighter rules, override at the worktree-local level with a narrower set, or set `permissions.defaultMode: "default"` in your user settings to force human confirmation on anything not explicitly listed.

## Cross-platform safety

Rules don't depend on host. macOS (zsh/brew), WSL Ubuntu (bash 5.2), and Windows MSYS2 (bash) all use the same `git`/`gh`/`cmake` CLIs. No `/home/evinj/` paths in the file; nothing macOS- or Linux-only.

## Test plan

- [x] Fresh clone on Ubuntu 24.04: settings.json loads, allow/deny rules visible via `/permissions`.
- [ ] queue-manager `--print` ingest completes without `permission_denials` in the stream output.
- [ ] sonnet-author commit-and-push opens a PR without manual approvals.
- [ ] sonnet-reviewer `gh pr checkout` + `gh pr review` posts a review without manual approvals.
- [ ] Hard-denied commands still trigger denial when an agent (or test) attempts them: `git push --force`, `gh pr merge`, `sudo`, `apt`.
- [ ] macOS fleet host: same settings.json loads cleanly, no Linux-specific paths break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)