### PR TITLE
T-204: entity: fix sortArchetypeNodesByRelationChildOf — BFS seeds leaves instead of roots

### DIFF
--- a/engine/entity/src/archetype_graph.cpp
+++ b/engine/entity/src/archetype_graph.cpp
@@ -3,7 +3,6 @@
 #include <irreden/entity/archetype_graph.hpp>
 
 #include <iterator>
-#include <unordered_set>
 
 namespace IREntity {
 
@@ -52,38 +51,31 @@ void ArchetypeGraph::createAndConnectNode(ArchetypeNode *prevNode, ComponentId n
 
 // Not sure what happens here if a node has a parent with
 // a different archetype.
-std::vector<ArchetypeNode *> ArchetypeGraph::sortArchetypeNodesByRelationChildOf(
-    const std::vector<ArchetypeNode *> &nodes
+std::vector<ArchetypeNode *>
+ArchetypeGraph::sortArchetypeNodesByRelationChildOf(const std::vector<ArchetypeNode *> &nodes
 ) const {
-    // A breath first sort of nodes based on relation heirarchy
+    // BFS from true roots outward so parent archetypes appear before
+    // their children in the output — required for systems that propagate
+    // values down the hierarchy (e.g. SYSTEM_PROPAGATE_TRANSFORM).
     std::vector<ArchetypeNode *> sortedNodes;
     std::queue<ArchetypeNode *> nodeQueue;
 
-    // Step 1: Find all nodes that are children of some other nodes
-    std::unordered_set<NodeId> childNodes;
+    // Seed with roots: nodes that have no CHILD_OF relation of their own.
     for (const auto &node : nodes) {
-        RelationId childOfRelation = node->getChildOfRelation();
-        if (childOfRelation != kNullRelation) {
-            NodeId childNodeId = getParentNodeFromRelation(childOfRelation);
-            childNodes.insert(childNodeId);
-        }
-    }
-
-    // Step 2: Add nodes not in childNodes to the nodeQueue
-    for (const auto &node : nodes) {
-        if (childNodes.find(node->id_) == childNodes.end()) {
+        if (node->getChildOfRelation() == kNullRelation) {
             nodeQueue.push(node);
             sortedNodes.push_back(node);
         }
     }
 
-    // Step 3: Main BFS logic
+    // Walk outward: for each queued node, find children that point to it.
     while (!nodeQueue.empty()) {
         auto currentNode = nodeQueue.front();
         nodeQueue.pop();
         for (const auto &node : nodes) {
             RelationId childOfRelation = node->getChildOfRelation();
-            if (getParentNodeFromRelation(childOfRelation) == currentNode->id_) {
+            if (childOfRelation != kNullRelation &&
+                getParentNodeFromRelation(childOfRelation) == currentNode->id_) {
                 nodeQueue.push(node);
                 sortedNodes.push_back(node);
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(IrredenEngineTest
   ecs/modifier_types_test.cpp
   ecs/modifier_vec3_runtime_test.cpp
   ecs/propagate_transform_test.cpp
+  ecs/sort_archetype_relational_test.cpp
   ecs/system_exclude_test.cpp
   math/physics_test.cpp
   math/ir_math_test.cpp

--- a/test/ecs/sort_archetype_relational_test.cpp
+++ b/test/ecs/sort_archetype_relational_test.cpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+
+// Tests for sortArchetypeNodesByRelationChildOf exercised via
+// queryArchetypeNodesRelational.  The bug (issue #750) was that the BFS
+// seeded from leaf archetypes (pointed-to by CHILD_OF edges) and walked
+// toward children — but leaves have no children, so parent archetypes
+// were silently absent from the output.  The fix seeds from true roots
+// (archetypes with no CHILD_OF relation of their own) and walks outward.
+
+namespace {
+
+struct C_BfsTestTag {
+    int visited_ = 0;
+};
+
+class SortArchetypeRelationalTest : public testing::Test {
+  protected:
+    IREntity::EntityManager m_entity_manager;
+};
+
+// With the bug, only the child archetype node was returned; the parent
+// archetype node was silently dropped.
+TEST_F(SortArchetypeRelationalTest, ParentNodeIncludedInRelationalQuery) {
+    auto parent = IREntity::createEntity(C_BfsTestTag{});
+    auto child  = IREntity::createEntity(C_BfsTestTag{});
+    IREntity::setParent(child, parent);
+
+    auto include = IREntity::getArchetype<C_BfsTestTag>();
+    auto nodes   = IREntity::queryArchetypeNodesRelational(IREntity::CHILD_OF, include);
+
+    int total = 0;
+    for (auto *node : nodes) total += node->length_;
+    EXPECT_EQ(total, 2) << "both parent and child entities must be returned";
+}
+
+// Parent archetype node must appear before the child so a system that
+// propagates values down the chain reads the correct parent state.
+TEST_F(SortArchetypeRelationalTest, ParentNodeAppearsBeforeChildNode) {
+    auto parent = IREntity::createEntity(C_BfsTestTag{});
+    auto child  = IREntity::createEntity(C_BfsTestTag{});
+    IREntity::setParent(child, parent);
+
+    auto include = IREntity::getArchetype<C_BfsTestTag>();
+    auto nodes   = IREntity::queryArchetypeNodesRelational(IREntity::CHILD_OF, include);
+
+    ASSERT_EQ(nodes.size(), 2u);
+
+    bool parent_first = false, child_second = false;
+    for (auto id : nodes[0]->entities_) {
+        if (id == parent) {
+            parent_first = true;
+            break;
+        }
+    }
+    for (auto id : nodes[1]->entities_) {
+        if (id == child) {
+            child_second = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(parent_first)  << "parent entity should be in the first returned node";
+    EXPECT_TRUE(child_second)  << "child entity should be in the second returned node";
+}
+
+// Three-level chain: grandparent → parent → grandchild.  With the bug,
+// only the grandchild (the leaf) was returned.  After the fix all three
+// archetype nodes must appear.
+TEST_F(SortArchetypeRelationalTest, ThreeLevelChainAllNodesReturned) {
+    auto gp     = IREntity::createEntity(C_BfsTestTag{});
+    auto parent = IREntity::createEntity(C_BfsTestTag{});
+    auto child  = IREntity::createEntity(C_BfsTestTag{});
+    IREntity::setParent(parent, gp);
+    IREntity::setParent(child, parent);
+
+    auto include = IREntity::getArchetype<C_BfsTestTag>();
+    auto nodes   = IREntity::queryArchetypeNodesRelational(IREntity::CHILD_OF, include);
+
+    int total = 0;
+    for (auto *node : nodes) total += node->length_;
+    EXPECT_EQ(total, 3) << "all three entities across three levels must be visited";
+}
+
+// A flat set of entities with no CHILD_OF relations must be returned
+// unchanged (all nodes are roots).
+TEST_F(SortArchetypeRelationalTest, FlatSetWithNoRelationsReturnsAllNodes) {
+    IREntity::createEntity(C_BfsTestTag{});
+    IREntity::createEntity(C_BfsTestTag{});
+    IREntity::createEntity(C_BfsTestTag{});
+
+    auto include = IREntity::getArchetype<C_BfsTestTag>();
+    auto nodes   = IREntity::queryArchetypeNodesRelational(IREntity::CHILD_OF, include);
+
+    int total = 0;
+    for (auto *node : nodes) total += node->length_;
+    EXPECT_EQ(total, 3);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Inverts BFS seed in `sortArchetypeNodesByRelationChildOf`: was seeding from leaf archetypes (non-parents), now seeds from true roots (nodes with no CHILD_OF relation of their own)
- Parent archetypes now appear before their children in sorted output, fixing silent omission of all non-leaf archetypes from `queryArchetypeNodesRelational(CHILD_OF, ...)`
- Removes the first pass (unordered_set gather) and `<unordered_set>` include — no longer needed
- Guards inner-loop call to `getParentNodeFromRelation` against `kNullRelation` input

## Test plan
- [x] 4 new tests in `test/ecs/sort_archetype_relational_test.cpp`
  - `ParentNodeIncludedInRelationalQuery` — parent entity must be returned (was dropped pre-fix)
  - `ParentNodeAppearsBeforeChildNode` — correct parent-first ordering
  - `ThreeLevelChainAllNodesReturned` — 3-level GP→P→C, all 3 entities present
  - `FlatSetWithNoRelationsReturnsAllNodes` — no relations, all nodes returned
- [x] 723/723 tests pass (`fleet-run IrredenEngineTest`)

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)