### PR TITLE
fleet: drop C-c from dispatch send-keys (Windows alert sound on every worker spin-up)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -858,28 +858,33 @@ dispatch_role() {
         local cmd
         cmd=$(build_dispatch_command "$role" "$pane_key")
         log "dispatching $role -> $pane_id"
-        # C-c aborts any partial input the human may have typed into
-        # the idle pane (including multi-line continuations); C-u then
-        # clears the input line for good measure. Without this the
-        # typed-but-uncommitted prefix concatenates with our dispatch
-        # command — observed: stray "Ca" turned the next dispatch into
-        # "Caclaude --model …" / "zsh: command not found: Caclaude".
-        # Safe at a shell prompt — find_idle_panes_for_role only picks
-        # panes whose pane_current_command is bash/zsh/sh/fish, so C-c
-        # acts on the input loop, not a running command.
-        # Split the burst: C-c interrupts whatever's at the prompt and
-        # triggers bash to redraw; without a gap, the first char of
-        # "$cmd" arrives while readline is mid-redraw and gets eaten
-        # ("fleet-dispatch-wrap" → "leet-dispatch-wrap: command not
-        # found"). 50ms is enough on tmux 3.4 / Ubuntu 24.04; cheap on
-        # every other host.
-        if ! dispatch_send_keys -t "$pane_id" C-c C-u; then
-            log "send-keys (reset) timeout/failed for $role -> $pane_id; trying next idle pane"
-            continue
-        fi
-        sleep 0.05
-        if ! dispatch_send_keys -t "$pane_id" "$cmd" C-m; then
-            log "send-keys (cmd) timeout/failed for $role -> $pane_id; trying next idle pane"
+        # Reset the input line with C-u (kill-line) before sending the
+        # dispatch command. Catches any partial input the human may have
+        # typed into the idle pane (stray "Ca" from an in-flight tmux
+        # prefix that didn't complete a binding, etc.) — without it the
+        # uncommitted prefix concatenates with our dispatch command,
+        # observed: "Caclaude --model …" / "command not found: Caclaude".
+        #
+        # The earlier implementation also sent C-c. Dropped because:
+        #   - SIGINT triggers a Windows alert sound under WSLg /
+        #     Windows Terminal every time a worker spins up — audibly
+        #     annoying with multiple panes restarting per minute.
+        #   - find_idle_panes_for_role only picks bash/zsh/sh/fish
+        #     panes — there is no foreground command to interrupt, so
+        #     SIGINT was a no-op aside from echoing "^C\n" and the
+        #     associated terminal bell.
+        #   - The "post-prompt-redraw eats first byte" race that C-c
+        #     induced (the "leet-dispatch-wrap: command not found"
+        #     loop on bash 5.2 / Ubuntu 24.04) is also gone.
+        # Multi-line bash continuations (the one remaining edge case
+        # C-c handled) are vanishingly rare in fleet panes — humans
+        # don't type there — and a single malformed dispatch self-heals
+        # on the next tick.
+        #
+        # The leading-space sacrificial char in build_dispatch_command
+        # remains as defense-in-depth.
+        if ! dispatch_send_keys -t "$pane_id" C-u "$cmd" C-m; then
+            log "send-keys timeout/failed for $role -> $pane_id; trying next idle pane"
             continue
         fi
         write_dispatch_record "$role" "$pane_id"


### PR DESCRIPTION
## Summary

Stops the Windows Default Beep sound that played every time a fleet worker pane received a fresh dispatch — caused by SIGINT visualization in WSLg / Windows Terminal when `tmux send-keys C-c` hit a bash prompt.

## Background

`scripts/fleet/fleet-dispatcher` reset the worker pane's input line before typing each dispatched command with `tmux send-keys C-c C-u "<cmd>" C-m`. The C-c was there to abort:
1. Stray "Ca" buffered from an incomplete tmux prefix
2. Multi-line bash continuations

Case 1 is fully covered by C-u (`unix-line-discard`) which kills the line buffer regardless of stray characters. Case 2 is vanishingly rare in fleet panes — humans don't type there — and self-heals on the next dispatcher tick if it happens.

## What changed

- Drop C-c from the send-keys; just `C-u "<cmd>" C-m`
- Collapse the two-call split (with 50ms sleep) back into a single send-keys. The split was added to dodge the bash-5.2 readline race on Ubuntu 24.04 where the post-prompt-redraw window after C-c eats the first input byte (the "leet-dispatch-wrap: command not found" loop). With C-c gone, no redraw, no race.
- Leading-space sacrificial char in `build_dispatch_command` stays as defense-in-depth.
- Updated the inline rationale comment.

## Verification

Live test on a worker bash pane: typed stray "typed_garbage_no_enter", then `tmux send-keys C-u " echo NOISE_TEST_$RANDOM" C-m` — input cleared, command ran cleanly with the leading-space absorbed, no SIGINT echo, no Windows beep.

## Cross-platform safety

- macOS: bash 3.2 (or zsh) handles C-u identically; no Mac noise to begin with, but no regression.
- Windows-native MSYS2: same behavior — bash interactive at a prompt, C-u clears.
- All hosts: the original C-c-induced bash-5.2 readline race is gone, so the `assume-paste-time` / `escape-time` tmux workarounds in operator dotfiles become unnecessary (they remain defensive but optional).

## Test plan

- [x] `bash -n scripts/fleet/fleet-dispatcher` passes.
- [x] Manual send-keys repro with stray input shows clean dispatch.
- [ ] Live observation: restart dispatcher with the patch, watch a worker spin up — no Windows beep, dispatched command runs cleanly.
- [ ] Run a queue-manager iteration end-to-end without seeing the dropped-first-byte error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)