### PR TITLE
T-205: move getActiveCanvasEntityOrNull out of ir_render.hpp

### DIFF
--- a/engine/prefabs/irreden/voxel/components/component_shape_descriptor.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_shape_descriptor.hpp
@@ -2,7 +2,8 @@
 #define COMPONENT_SHAPE_DESCRIPTOR_H
 
 #include <irreden/ir_math.hpp>
-#include <irreden/ir_render.hpp>
+#include <irreden/render/active_canvas.hpp>
+#include <irreden/render/ir_render_types.hpp>
 
 using namespace IRMath;
 

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -5,6 +5,7 @@
 #include <irreden/ir_constants.hpp>
 #include <irreden/ir_render.hpp>
 
+#include <irreden/render/active_canvas.hpp>
 #include <irreden/render/texture.hpp>
 #include <irreden/voxel/components/component_voxel.hpp>
 #include <irreden/voxel/systems/system_voxel_pool.hpp>

--- a/engine/render/CMakeLists.txt
+++ b/engine/render/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(RENDER_CORE_SRC
+    src/active_canvas.cpp
     src/ir_render.cpp
     src/buffer.cpp
     src/framebuffer.cpp

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -115,12 +115,10 @@ inline void setActiveCanvas(const std::string &name) {
 inline IREntity::EntityId getActiveCanvasEntity() {
     return getRenderManager().getActiveCanvasEntity();
 }
-
-// Returns kNullEntity instead of asserting when no RenderManager exists — safe for headless and test contexts.
-inline IREntity::EntityId getActiveCanvasEntityOrNull() {
-    return g_renderManager != nullptr ? g_renderManager->getActiveCanvasEntity()
-                                      : IREntity::kNullEntity;
-}
+// Null-safe variant `getActiveCanvasEntityOrNull()` lives in
+// `<irreden/render/active_canvas.hpp>` — included on demand by callers
+// (e.g. C_ShapeDescriptor, C_VoxelSetNew) that need the headless-safe
+// snapshot without pulling in the full render surface. See #753 (T-205).
 /// @}
 
 /// @{

--- a/engine/render/include/irreden/render/active_canvas.hpp
+++ b/engine/render/include/irreden/render/active_canvas.hpp
@@ -1,0 +1,20 @@
+#ifndef IRREDEN_RENDER_ACTIVE_CANVAS_H
+#define IRREDEN_RENDER_ACTIVE_CANVAS_H
+
+#include <irreden/entity/ir_entity_types.hpp>
+
+namespace IRRender {
+
+// Returns the active canvas entity, or IREntity::kNullEntity when no
+// RenderManager exists. Safe for headless and test contexts where the
+// asserting getActiveCanvasEntity() would abort.
+//
+// Lives in a dedicated header (out of ir_render.hpp) so component
+// constructors that need the snapshot — see "Constructor snapshots
+// ambient state" exception in .claude/rules/cpp-ecs.md — do not pull
+// in the full render surface. See #753 (T-205).
+IREntity::EntityId getActiveCanvasEntityOrNull();
+
+} // namespace IRRender
+
+#endif /* IRREDEN_RENDER_ACTIVE_CANVAS_H */

--- a/engine/render/src/active_canvas.cpp
+++ b/engine/render/src/active_canvas.cpp
@@ -1,0 +1,13 @@
+#include <irreden/render/active_canvas.hpp>
+
+#include <irreden/ir_render.hpp>
+#include <irreden/render/render_manager.hpp>
+
+namespace IRRender {
+
+IREntity::EntityId getActiveCanvasEntityOrNull() {
+    return g_renderManager != nullptr ? g_renderManager->getActiveCanvasEntity()
+                                      : IREntity::kNullEntity;
+}
+
+} // namespace IRRender

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -28,8 +28,10 @@ target_link_libraries(
     IrredenEngineEntity
     IrredenEngineSystem
     IrredenEngineAsset
-    # Required: prefab_api.cpp uses IRRender::ShapeType + getActiveCanvasEntityOrNull
-    # via component_{shape_descriptor,voxel_set}.hpp. See #739 for the layering fix.
+    # Required: prefab_api.cpp uses IRRender::ShapeType (via
+    # ir_render_types.hpp) and IRRender::getActiveCanvasEntityOrNull (via
+    # render/active_canvas.hpp) through component_{shape_descriptor,voxel_set}.hpp.
+    # See #739 for the layering fix; #753 (T-205) moved the snapshot to its own header.
     IrredenEngineRendering
     # T-193 PR 2: lua_command_bindings.hpp exposes IRCommand on the Lua
     # surface, so the public scripting interface needs the IRCommand


### PR DESCRIPTION
## Summary

- Moves `IRRender::getActiveCanvasEntityOrNull()` out of `<irreden/ir_render.hpp>` into a dedicated `<irreden/render/active_canvas.hpp>` (declaration) + `engine/render/src/active_canvas.cpp` (implementation).
- `C_ShapeDescriptor` drops `<irreden/ir_render.hpp>` entirely, picking up `<irreden/render/ir_render_types.hpp>` (for `ShapeType` / `LodLevel` / `SHAPE_FLAG_VISIBLE`) and `<irreden/render/active_canvas.hpp>` (for the snapshot).
- `C_VoxelSetNew` keeps `<irreden/ir_render.hpp>` (still calls `allocateVoxels` / `deallocateVoxels` / `getActiveCanvasEntity` — T-201 step 3 moves the pool allocator); adds `<irreden/render/active_canvas.hpp>` for the null-safe snapshot.
- `ir_render.hpp` keeps a 4-line breadcrumb comment pointing readers at the new header.

## Design call

The issue (#753) suggested `IRWorld::` namespace for the function's new home. I kept `IRRender::` and instead split the header. Reason: `engine/world/` PUBLIC-links `IrredenEngineScripting`, so a voxel-component header reaching `IRWorld::` would form a circular link dep (engine/script → engine/world → engine/script). A truly render-neutral home requires a dependency-inversion callback (engine/render registers a provider at init time) — that's the right shape but bigger than T-205's "include shuffle + 3 call-site updates" scope. T-201 step 4 (drop `IrredenEngineRendering` from `engine/script/`'s link list) is the natural place for that work since it's what the decoupling enables.

This PR meets T-205's acceptance criteria as written and does not regress what step 4 needs to do later.

## Acceptance criteria

- ✅ `ir_render.hpp` no longer exposes `getActiveCanvasEntityOrNull` (only the comment pointer remains).
- ✅ `component_shape_descriptor.hpp` no longer includes `<irreden/ir_render.hpp>` — the snapshot now arrives via `<irreden/render/active_canvas.hpp>`, types via `<irreden/render/ir_render_types.hpp>`.
- ✅ `component_voxel_set.hpp` no longer pulls in `<irreden/ir_render.hpp>` *for the canvas snapshot* — that call now routes through `<irreden/render/active_canvas.hpp>`. The other render APIs the file already uses (`allocateVoxels`, `deallocateVoxels`, `getActiveCanvasEntity`) keep the existing include until T-201 step 3.
- ✅ `IrredenEngineTest` builds; all 719 tests pass.
- ✅ `IRShapeDebug` builds clean (runtime smoke blocked by the pre-existing GLXBadFBConfig issue on this WSL2/Ubuntu 24.04 host — see T-202; PRs #752 and #756 hit the same wall before merge, so unrelated to this diff).
- ✅ `fleet-build` clean on linux-debug.

## Test plan

- [x] Full test suite passes (`fleet-run IrredenEngineTest` → 719/719).
- [x] `PrefabApi.*` tests pass (24/24 — exercises the headless `C_ShapeDescriptor` / `C_VoxelSetNew` ctor paths that use the snapshot).
- [x] `fleet-build --target IRShapeDebug` succeeds on linux-debug.
- [x] `fleet-build --target IrredenEngineTest` succeeds on linux-debug.
- [ ] macos-debug build (cross-host smoke validation — `fleet:needs-macos-smoke` if reviewer agrees).

## Notes for reviewer

- The new `.cpp` is a no-op refactor of the previously-inline body. `g_renderManager` access is identical; the only behavioral change is one extra function-call boundary (was an inline in a header, now a normal function). Called only from ctors, not from any tick.
- `engine/render/CLAUDE.md` is unchanged — the "Entry point" rule ("creations only include `ir_*.hpp`") still holds; `active_canvas.hpp` is engine-internal, used only by voxel-component headers.
- `engine/script/CMakeLists.txt` comment refreshed to cite both `ir_render_types.hpp` (ShapeType) and `render/active_canvas.hpp` (snapshot) as the reasons engine/script transitively needs `IrredenEngineRendering` for now.

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)