### PR TITLE
T-208: modifier: writer-owned slot API — upsertBySource to eliminate per-frame push_back churn

### DIFF
--- a/docs/design/modifiers.md
+++ b/docs/design/modifiers.md
@@ -435,6 +435,84 @@ needs all four predecessors.
   state (`kind_ == ADD`, `field_ == 0`). Fail fast rather than silently
   adding an invalid modifier to the vector.
 
+## Writer-owned slot API — `upsertBySource` (T-208)
+
+The `push()` family always appends a new entry to the modifier vector and
+relies on `ticksRemaining_` decay to remove stale copies. That model forces
+every steady-state writer (e.g. an idle-bob system that fires every tick) to:
+
+1. Run `MODIFIER_DECAY` before itself in the pipeline, and
+2. Set `ticksRemaining_ = 1` to survive the current frame's compose and be
+   removed by the next frame's decay.
+
+This is fragile: it ties the system's pipeline position to the decay system,
+and the per-frame `push_back` allocates on the first tick and reallocates
+whenever the vector outgrows its capacity.
+
+`upsertBySource` (T-208) replaces this with a **writer-owned slot** pattern:
+
+### Slot contract
+
+The triple `(source_, field_, kind_)` is the slot key. At most one entry with
+a given triple may exist in the modifier vector (per-entity or global).
+Callers that own a slot call `upsertBySource` instead of `push` — on the first
+call the slot is created; on subsequent calls only `param_` is overwritten and
+`ticksRemaining_` is reset to `-1`. The slot persists until the source entity
+is destroyed or `removeBySource` is called explicitly.
+
+`push` remains the correct choice for **transient effects** that should expire
+naturally (e.g. a one-shot screen-shake, a key-triggered pulse). Use `push`
+with a `ticksRemaining` countdown when the caller does NOT own the slot
+long-term. Use `upsertBySource` when the caller writes the same slot every
+tick forever (e.g. idle-bob, a continuous aura).
+
+### API additions
+
+```cpp
+namespace IRPrefab::Modifier {
+
+// External writers (Lua, input handlers, init code) — performs the same
+// getComponentOptional + field-type checks as push().
+void upsertBySource(EntityId target, FieldBindingId field,
+                    TransformKind kind, float param, EntityId source);
+void upsertBySource(EntityId target, FieldBindingId field,
+                    TransformKind kind, IRMath::vec3 param, EntityId source);
+
+// Targeting the singleton globals entity.
+void upsertBySourceGlobal(FieldBindingId field, TransformKind kind,
+                           float param, EntityId source);
+void upsertBySourceGlobal(FieldBindingId field, TransformKind kind,
+                           IRMath::vec3 param, EntityId source);
+
+// For system ticks — caller already holds C_Modifiers& from archetype
+// iteration; skips getComponentOptional and the field-type registry probe.
+void upsertBySourceInPlace(C_Modifiers &mods, FieldBindingId field,
+                            TransformKind kind, float param, EntityId source);
+void upsertBySourceInPlace(C_Modifiers &mods, FieldBindingId field,
+                            TransformKind kind, IRMath::vec3 param, EntityId source);
+}
+```
+
+`upsertBySourceInPlace` is the canonical form for tick functions: it bypasses
+the `getComponentOptional` lookup and the registry type-check because the
+system already has the component reference from the archetype iterator and
+already knows the field type from init-time registration.
+
+### Pipeline impact
+
+`PERIODIC_IDLE_POSITION_OFFSET` (the first consumer) no longer requires
+`MODIFIER_DECAY` to run before it. The pipeline ordering becomes:
+
+```
+PERIODIC_IDLE → PERIODIC_IDLE_POSITION_OFFSET
+→ ... → GLOBAL_POSITION_3D → APPLY_POSITION_OFFSET
+```
+
+Existing creations that still run `MODIFIER_DECAY` before
+`PERIODIC_IDLE_POSITION_OFFSET` are safe — `MODIFIER_DECAY` leaves entries
+with `ticksRemaining_ == -1` untouched, so the upsert slot is never dropped by
+decay.
+
 ## vec3 extension (T-191)
 
 The framework was extended in T-191 to carry vec3-typed fields

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -118,9 +118,22 @@ Runtime entry points (all `inline`, header-only):
 - `registerField(name)` / `fieldName(id)` / `fieldCount()` — dense
   registry, init-time only.
 - `push(target, field, kind, param, source, ticks)` — push one
-  structured modifier onto an entity. `pushGlobal(...)` targets the
-  singleton; `pushLambda(...)` writes the escape-hatch component.
-  All three reject `kInvalidFieldId` defensively.
+  **transient** modifier onto an entity (use `ticksRemaining` for decay).
+  `pushGlobal(...)` targets the singleton; `pushLambda(...)` writes the
+  escape-hatch component. All three reject `kInvalidFieldId` defensively.
+  Use `push` for one-shot effects (screen-shake, triggered pulses). Use
+  `upsertBySource` / `upsertBySourceInPlace` for steady-state writers.
+- `upsertBySource(target, field, kind, param, source)` — **steady-state
+  writer-owned slot** API. Slot key is `(source, field, kind)`. On hit:
+  overwrites `param_` and resets `ticksRemaining_ = -1` (no decay). On
+  miss: appends with `ticksRemaining_ = -1`. No `MODIFIER_DECAY`
+  dependency; the slot persists until `removeBySource` or source
+  destruction. `upsertBySourceGlobal(...)` targets the singleton.
+- `upsertBySourceInPlace(mods, field, kind, param, source)` — same slot
+  semantics as `upsertBySource` but takes a `C_Modifiers&` directly
+  (caller is a system tick that already holds the archetype reference);
+  skips `getComponentOptional` and the field-type check. Canonical for
+  system ticks that push the same slot every frame.
 - `removeBySource(source)` — sweeps every `C_Modifiers`,
   `C_GlobalModifiers`, and `C_LambdaModifiers` in the world,
   dropping entries whose `source_` matches. Wired automatically

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -354,6 +354,157 @@ inline IRMath::vec4 applyToFieldQuat(
     return detail::composeForFieldQuat(baseValue, field, globals, entityMods);
 }
 
+// Upsert a steady-state scalar modifier keyed on the triple
+// (source, field, kind). On hit: overwrite param_ and reset ticksRemaining_
+// to -1 (no decay). On miss: push_back with ticksRemaining_ = -1.
+// Performs the same defensive field-type and kInvalidFieldId checks as push().
+// Use when one source writes the same slot every tick forever (e.g. an idle
+// bob driven by a tick), so the vector holds exactly one entry per slot
+// instead of growing without bound.
+inline void upsertBySource(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    if (fieldType(field) != IRComponents::FieldValueType::SCALAR)
+        return;
+    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
+    if (!c)
+        return;
+    for (auto &m : c->modifiers_) {
+        if (m.source_ == source && m.field_ == field && m.kind_ == kind) {
+            m.param_ = param;
+            m.ticksRemaining_ = -1;
+            return;
+        }
+    }
+    c->modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, -1});
+}
+
+// vec3 counterpart of upsertBySource. Slot key is (source, field, kind).
+inline void upsertBySource(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    if (fieldType(field) != IRComponents::FieldValueType::VEC3)
+        return;
+    auto *c = IREntity::getComponentOptional<IRComponents::C_Modifiers>(target).value_or(nullptr);
+    if (!c)
+        return;
+    for (auto &m : c->modifiersVec3_) {
+        if (m.source_ == source && m.field_ == field && m.kind_ == kind) {
+            m.param_ = param;
+            m.ticksRemaining_ = -1;
+            return;
+        }
+    }
+    c->modifiersVec3_.push_back(IRComponents::ModifierVec3{field, kind, param, source, -1});
+}
+
+// upsertBySource targeting the singleton globals entity (scalar).
+inline void upsertBySourceGlobal(
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    if (fieldType(field) != IRComponents::FieldValueType::SCALAR)
+        return;
+    auto entity = detail::globalsEntityId();
+    if (entity == IREntity::kNullEntity)
+        return;
+    auto *c =
+        IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
+    if (!c)
+        return;
+    for (auto &m : c->modifiers_) {
+        if (m.source_ == source && m.field_ == field && m.kind_ == kind) {
+            m.param_ = param;
+            m.ticksRemaining_ = -1;
+            return;
+        }
+    }
+    c->modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, -1});
+}
+
+// upsertBySource targeting the singleton globals entity (vec3).
+inline void upsertBySourceGlobal(
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    if (field == IRComponents::kInvalidFieldId)
+        return;
+    if (fieldType(field) != IRComponents::FieldValueType::VEC3)
+        return;
+    auto entity = detail::globalsEntityId();
+    if (entity == IREntity::kNullEntity)
+        return;
+    auto *c =
+        IREntity::getComponentOptional<IRComponents::C_GlobalModifiers>(entity).value_or(nullptr);
+    if (!c)
+        return;
+    for (auto &m : c->modifiersVec3_) {
+        if (m.source_ == source && m.field_ == field && m.kind_ == kind) {
+            m.param_ = param;
+            m.ticksRemaining_ = -1;
+            return;
+        }
+    }
+    c->modifiersVec3_.push_back(IRComponents::ModifierVec3{field, kind, param, source, -1});
+}
+
+// In-place scalar upsert for system ticks that already hold C_Modifiers& from
+// archetype iteration. Skips the getComponentOptional probe and the field-type
+// check — caller (a system) already knows the field id from init-time
+// registration. Same slot key and overwrite semantics as upsertBySource.
+inline void upsertBySourceInPlace(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    for (auto &m : mods.modifiers_) {
+        if (m.source_ == source && m.field_ == field && m.kind_ == kind) {
+            m.param_ = param;
+            m.ticksRemaining_ = -1;
+            return;
+        }
+    }
+    mods.modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, -1});
+}
+
+// In-place vec3 upsert for system ticks that already hold C_Modifiers&.
+inline void upsertBySourceInPlace(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    for (auto &m : mods.modifiersVec3_) {
+        if (m.source_ == source && m.field_ == field && m.kind_ == kind) {
+            m.param_ = param;
+            m.ticksRemaining_ = -1;
+            return;
+        }
+    }
+    mods.modifiersVec3_.push_back(IRComponents::ModifierVec3{field, kind, param, source, -1});
+}
+
 // Wires up the singleton globals entity and registers the six resolver
 // systems in the canonical order. Must be called once at creation init,
 // before any system that depends on resolved fields.

--- a/engine/prefabs/irreden/update/CLAUDE.md
+++ b/engine/prefabs/irreden/update/CLAUDE.md
@@ -26,13 +26,13 @@ in the `UPDATE` pipeline unless explicitly noted.
   particle entity builder.
 - `LIFETIME` — decrements `C_Lifetime`; destroys entities at zero.
 - `PERIODIC_IDLE` — advances per-entity `C_PeriodicIdle` timer.
-- `PERIODIC_IDLE_POSITION_OFFSET` — pushes the resolved bob value as a
-  vec3 ADD modifier on the entity's `C_Modifiers` each tick (under
-  the `POSITION_OFFSET_3D` field). `APPLY_POSITION_OFFSET` later
-  folds the composed value into `C_PositionGlobal3D`. Requires
-  `C_Modifiers` on bob-eligible entities and `MODIFIER_DECAY` running
-  earlier in the UPDATE pipeline so the per-frame push doesn't
-  accumulate.
+- `PERIODIC_IDLE_POSITION_OFFSET` — upserts the resolved bob value as a
+  vec3 ADD modifier on the entity's `C_Modifiers` each tick via
+  `upsertBySourceInPlace` (under the `POSITION_OFFSET_3D` field).
+  Slot key is `(entity, POSITION_OFFSET_3D, ADD)` — one entry per
+  bob-eligible entity, updated in place. No `ticksRemaining_` countdown;
+  no `MODIFIER_DECAY` dependency. `APPLY_POSITION_OFFSET` later folds the
+  composed value into `C_PositionGlobal3D`.
 - `PROPAGATE_TRANSFORM` — walks the `CHILD_OF` parent chain in
   topological order and writes `C_WorldTransform` from each entity's
   `C_LocalTransform` composed with the parent chain. Modifier-resolved

--- a/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
+++ b/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
@@ -1,23 +1,16 @@
 #ifndef SYSTEM_PERIODIC_IDLE_POSITION_OFFSET_H
 #define SYSTEM_PERIODIC_IDLE_POSITION_OFFSET_H
 
-// Re-pushes the entity's idle-bob value as a vec3 ADD modifier each
-// UPDATE tick. APPLY_POSITION_OFFSET later composes the entity's
-// vec3 modifiers and adds the resolved offset to C_PositionGlobal3D.
-//
-// `ticksRemaining_ = 1` because this writer pushes AFTER MODIFIER_DECAY
-// has already run in the same UPDATE pipeline: the entry survives this
-// frame's compose, then next frame's DECAY decrements it (1 → 0) and
-// removes it before the next compose. The "use 2 to fire for one frame"
-// rule in MODIFIER_DECAY's header applies to entries pushed OUTSIDE the
-// pipeline (Lua, input handlers) — those see DECAY before their first
-// compose, so they need one extra tick of headroom.
+// Upserts the entity's idle-bob value as a vec3 ADD modifier each UPDATE
+// tick via upsertBySourceInPlace. The slot key is (entity, POSITION_OFFSET_3D,
+// ADD) — one entry per bob-eligible entity, updated in place each tick.
+// No ticksRemaining_ countdown; no MODIFIER_DECAY dependency.
+// APPLY_POSITION_OFFSET later composes the vec3 modifiers and adds the
+// resolved offset to C_PositionGlobal3D.
 //
 // Pipeline ordering required by callers:
-//   PERIODIC_IDLE → MODIFIER_DECAY → PERIODIC_IDLE_POSITION_OFFSET
+//   PERIODIC_IDLE → PERIODIC_IDLE_POSITION_OFFSET
 //   → ... → GLOBAL_POSITION_3D → APPLY_POSITION_OFFSET
-// MODIFIER_DECAY must run before this system or the per-entity vector
-// grows without bound.
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_system.hpp>
@@ -35,16 +28,12 @@ template <> struct System<PERIODIC_IDLE_POSITION_OFFSET> {
             [](IREntity::EntityId entity,
                IRComponents::C_PeriodicIdle &idle,
                IRComponents::C_Modifiers &mods) {
-                // Push directly to the archetype-iterated mods to avoid
-                // a per-entity getComponent inside IRPrefab::Modifier::push.
-                mods.modifiersVec3_.push_back(
-                    IRComponents::ModifierVec3{
-                        IRPrefab::PositionModifier::positionOffsetField(),
-                        IRComponents::TransformKind::ADD,
-                        idle.getValue(),
-                        entity,
-                        1
-                    }
+                IRPrefab::Modifier::upsertBySourceInPlace(
+                    mods,
+                    IRPrefab::PositionModifier::positionOffsetField(),
+                    IRComponents::TransformKind::ADD,
+                    idle.getValue(),
+                    entity
                 );
             }
         );

--- a/test/ecs/modifier_runtime_test.cpp
+++ b/test/ecs/modifier_runtime_test.cpp
@@ -538,6 +538,62 @@ TEST_F(IRModifierScalarUpsertTest, SecondCallOverwrites) {
     EXPECT_EQ(mods[0].ticksRemaining_, -1);
 }
 
+TEST_F(IRModifierScalarUpsertTest, OverridesPriorTickRemaining) {
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(IRComponents::C_Modifiers{});
+
+    IRPrefab::Modifier::push(target, m_field, TransformKind::ADD, 1.0f, source, 1);
+    ASSERT_EQ(IREntity::getComponent<IRComponents::C_Modifiers>(target).modifiers_.size(), 1u);
+
+    IRPrefab::Modifier::upsertBySource(target, m_field, TransformKind::ADD, 5.0f, source);
+
+    auto &mods = IREntity::getComponent<IRComponents::C_Modifiers>(target).modifiers_;
+    ASSERT_EQ(mods.size(), 1u);
+    EXPECT_EQ(mods[0].ticksRemaining_, -1);
+    EXPECT_FLOAT_EQ(mods[0].param_, 5.0f);
+}
+
+// ---- upsertBySourceGlobal: scalar -------------------------------------------
+
+class IRModifierGlobalScalarUpsertTest : public testing::Test {
+  protected:
+    IRModifierGlobalScalarUpsertTest()
+        : m_entity_manager{} {
+        IREntity::singletonEntity<IRComponents::C_GlobalModifiers>();
+        m_field = IRPrefab::Modifier::registerField("test.upsert_global_scalar");
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRComponents::FieldBindingId m_field{IRComponents::kInvalidFieldId};
+};
+
+TEST_F(IRModifierGlobalScalarUpsertTest, FirstCallAppends) {
+    auto source = IREntity::createEntity();
+
+    IRPrefab::Modifier::upsertBySourceGlobal(m_field, TransformKind::ADD, 3.0f, source);
+
+    auto &c = IREntity::getComponent<IRComponents::C_GlobalModifiers>(
+        IRPrefab::Modifier::globalsEntity()
+    );
+    ASSERT_EQ(c.modifiers_.size(), 1u);
+    EXPECT_FLOAT_EQ(c.modifiers_[0].param_, 3.0f);
+    EXPECT_EQ(c.modifiers_[0].ticksRemaining_, -1);
+}
+
+TEST_F(IRModifierGlobalScalarUpsertTest, SecondCallOverwrites) {
+    auto source = IREntity::createEntity();
+
+    IRPrefab::Modifier::upsertBySourceGlobal(m_field, TransformKind::ADD, 3.0f, source);
+    IRPrefab::Modifier::upsertBySourceGlobal(m_field, TransformKind::ADD, 7.0f, source);
+
+    auto &c = IREntity::getComponent<IRComponents::C_GlobalModifiers>(
+        IRPrefab::Modifier::globalsEntity()
+    );
+    ASSERT_EQ(c.modifiers_.size(), 1u);
+    EXPECT_FLOAT_EQ(c.modifiers_[0].param_, 7.0f);
+    EXPECT_EQ(c.modifiers_[0].ticksRemaining_, -1);
+}
+
 // ---- upsertBySourceInPlace: scalar ------------------------------------------
 
 TEST(ModifierUpsertInPlaceScalar, RepeatedCallStaysSizeOne) {

--- a/test/ecs/modifier_runtime_test.cpp
+++ b/test/ecs/modifier_runtime_test.cpp
@@ -494,4 +494,66 @@ TEST(LambdaModifierDecay, DropRunsCapturedDestructor) {
     EXPECT_EQ(witness.use_count(), 1L); // capture released
 }
 
+// ---- upsertBySource: scalar -------------------------------------------------
+
+class IRModifierScalarUpsertTest : public testing::Test {
+  protected:
+    IRModifierScalarUpsertTest()
+        : m_entity_manager{} {
+        m_field = IRPrefab::Modifier::registerField("test.upsert_scalar");
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRComponents::FieldBindingId m_field{IRComponents::kInvalidFieldId};
+};
+
+TEST_F(IRModifierScalarUpsertTest, FirstCallAppends) {
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(IRComponents::C_Modifiers{});
+
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, 1.0f, source
+    );
+
+    auto &mods = IREntity::getComponent<IRComponents::C_Modifiers>(target).modifiers_;
+    ASSERT_EQ(mods.size(), 1u);
+    EXPECT_FLOAT_EQ(mods[0].param_, 1.0f);
+    EXPECT_EQ(mods[0].ticksRemaining_, -1);
+}
+
+TEST_F(IRModifierScalarUpsertTest, SecondCallOverwrites) {
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(IRComponents::C_Modifiers{});
+
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, 1.0f, source
+    );
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, 9.0f, source
+    );
+
+    auto &mods = IREntity::getComponent<IRComponents::C_Modifiers>(target).modifiers_;
+    ASSERT_EQ(mods.size(), 1u);
+    EXPECT_FLOAT_EQ(mods[0].param_, 9.0f);
+    EXPECT_EQ(mods[0].ticksRemaining_, -1);
+}
+
+// ---- upsertBySourceInPlace: scalar ------------------------------------------
+
+TEST(ModifierUpsertInPlaceScalar, RepeatedCallStaysSizeOne) {
+    IRComponents::C_Modifiers mods;
+    constexpr IRComponents::FieldBindingId kField{7};
+    auto source = IREntity::EntityId{42};
+
+    for (int i = 0; i < 100; ++i) {
+        IRPrefab::Modifier::upsertBySourceInPlace(
+            mods, kField, IRComponents::TransformKind::ADD, static_cast<float>(i), source
+        );
+    }
+
+    ASSERT_EQ(mods.modifiers_.size(), 1u);
+    EXPECT_FLOAT_EQ(mods.modifiers_[0].param_, 99.0f);
+    EXPECT_EQ(mods.modifiers_[0].ticksRemaining_, -1);
+}
+
 } // namespace

--- a/test/ecs/modifier_vec3_runtime_test.cpp
+++ b/test/ecs/modifier_vec3_runtime_test.cpp
@@ -548,6 +548,55 @@ TEST_F(IRModifierVec3UpsertTest, OverridesPriorTickRemaining) {
     EXPECT_FLOAT_EQ(mods[0].param_.x, 5.0f);
 }
 
+// ---- upsertBySourceGlobal: vec3 ---------------------------------------------
+
+class IRModifierGlobalVec3UpsertTest : public testing::Test {
+  protected:
+    IRModifierGlobalVec3UpsertTest()
+        : m_entity_manager{} {
+        IREntity::singletonEntity<IRComponents::C_GlobalModifiers>();
+        m_field = IRPrefab::Modifier::registerFieldVec3("test.upsert_global_vec3");
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRComponents::FieldBindingId m_field{IRComponents::kInvalidFieldId};
+};
+
+TEST_F(IRModifierGlobalVec3UpsertTest, FirstCallAppends) {
+    auto source = IREntity::createEntity();
+
+    IRPrefab::Modifier::upsertBySourceGlobal(
+        m_field, TransformKind::ADD, IRMath::vec3(1.0f, 2.0f, 3.0f), source
+    );
+
+    auto &c = IREntity::getComponent<IRComponents::C_GlobalModifiers>(
+        IRPrefab::Modifier::globalsEntity()
+    );
+    ASSERT_EQ(c.modifiersVec3_.size(), 1u);
+    EXPECT_FLOAT_EQ(c.modifiersVec3_[0].param_.y, 2.0f);
+    EXPECT_EQ(c.modifiersVec3_[0].ticksRemaining_, -1);
+}
+
+TEST_F(IRModifierGlobalVec3UpsertTest, SecondCallOverwrites) {
+    auto source = IREntity::createEntity();
+
+    IRPrefab::Modifier::upsertBySourceGlobal(
+        m_field, TransformKind::ADD, IRMath::vec3(1.0f), source
+    );
+    IRPrefab::Modifier::upsertBySourceGlobal(
+        m_field, TransformKind::ADD, IRMath::vec3(9.0f, 8.0f, 7.0f), source
+    );
+
+    auto &c = IREntity::getComponent<IRComponents::C_GlobalModifiers>(
+        IRPrefab::Modifier::globalsEntity()
+    );
+    ASSERT_EQ(c.modifiersVec3_.size(), 1u);
+    EXPECT_FLOAT_EQ(c.modifiersVec3_[0].param_.x, 9.0f);
+    EXPECT_FLOAT_EQ(c.modifiersVec3_[0].param_.y, 8.0f);
+    EXPECT_FLOAT_EQ(c.modifiersVec3_[0].param_.z, 7.0f);
+    EXPECT_EQ(c.modifiersVec3_[0].ticksRemaining_, -1);
+}
+
 // ---- upsertBySourceInPlace: vec3 (simulates PERIODIC_IDLE_POSITION_OFFSET) --
 
 TEST(ModifierUpsertInPlaceVec3, RepeatedCallStaysSizeOne) {

--- a/test/ecs/modifier_vec3_runtime_test.cpp
+++ b/test/ecs/modifier_vec3_runtime_test.cpp
@@ -450,4 +450,126 @@ TEST_F(IRModifierVec3AutoSweepTest, DestroyingSourceLeavesOtherSourceVec3Modifie
     EXPECT_FLOAT_EQ(after[0].param_.x, 7.0f);
 }
 
+// ---- upsertBySource: vec3 ---------------------------------------------------
+
+class IRModifierVec3UpsertTest : public testing::Test {
+  protected:
+    IRModifierVec3UpsertTest()
+        : m_entity_manager{} {
+        m_field = IRPrefab::Modifier::registerFieldVec3("test.upsert_vec3");
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRComponents::FieldBindingId m_field{IRComponents::kInvalidFieldId};
+};
+
+TEST_F(IRModifierVec3UpsertTest, FirstCallAppends) {
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(C_Modifiers{});
+
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, IRMath::vec3(1.0f, 2.0f, 3.0f), source
+    );
+
+    auto &mods = IREntity::getComponent<C_Modifiers>(target).modifiersVec3_;
+    ASSERT_EQ(mods.size(), 1u);
+    EXPECT_FLOAT_EQ(mods[0].param_.y, 2.0f);
+    EXPECT_EQ(mods[0].ticksRemaining_, -1);
+}
+
+TEST_F(IRModifierVec3UpsertTest, SecondCallOverwrites) {
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(C_Modifiers{});
+
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, IRMath::vec3(1.0f), source
+    );
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, IRMath::vec3(9.0f, 8.0f, 7.0f), source
+    );
+
+    auto &mods = IREntity::getComponent<C_Modifiers>(target).modifiersVec3_;
+    ASSERT_EQ(mods.size(), 1u);
+    EXPECT_FLOAT_EQ(mods[0].param_.x, 9.0f);
+    EXPECT_FLOAT_EQ(mods[0].param_.y, 8.0f);
+    EXPECT_FLOAT_EQ(mods[0].param_.z, 7.0f);
+    EXPECT_EQ(mods[0].ticksRemaining_, -1);
+}
+
+TEST_F(IRModifierVec3UpsertTest, DifferentKindGetsItsOwnSlot) {
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(C_Modifiers{});
+
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, IRMath::vec3(1.0f), source
+    );
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::MULTIPLY, IRMath::vec3(2.0f), source
+    );
+
+    auto &mods = IREntity::getComponent<C_Modifiers>(target).modifiersVec3_;
+    ASSERT_EQ(mods.size(), 2u);
+}
+
+TEST_F(IRModifierVec3UpsertTest, DifferentSourceGetsItsOwnSlot) {
+    auto sourceA = IREntity::createEntity();
+    auto sourceB = IREntity::createEntity();
+    auto target  = IREntity::createEntity(C_Modifiers{});
+
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, IRMath::vec3(1.0f), sourceA
+    );
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, IRMath::vec3(2.0f), sourceB
+    );
+
+    auto &mods = IREntity::getComponent<C_Modifiers>(target).modifiersVec3_;
+    ASSERT_EQ(mods.size(), 2u);
+}
+
+TEST_F(IRModifierVec3UpsertTest, OverridesPriorTickRemaining) {
+    auto source = IREntity::createEntity();
+    auto target = IREntity::createEntity(C_Modifiers{});
+
+    // Simulate a prior push() with decay semantics.
+    IRPrefab::Modifier::push(
+        target, m_field, TransformKind::ADD, IRMath::vec3(1.0f), source, 1
+    );
+    ASSERT_EQ(IREntity::getComponent<C_Modifiers>(target).modifiersVec3_.size(), 1u);
+
+    // Upsert from the same triple must reset ticksRemaining_ to -1.
+    IRPrefab::Modifier::upsertBySource(
+        target, m_field, TransformKind::ADD, IRMath::vec3(5.0f), source
+    );
+
+    auto &mods = IREntity::getComponent<C_Modifiers>(target).modifiersVec3_;
+    ASSERT_EQ(mods.size(), 1u);
+    EXPECT_EQ(mods[0].ticksRemaining_, -1);
+    EXPECT_FLOAT_EQ(mods[0].param_.x, 5.0f);
+}
+
+// ---- upsertBySourceInPlace: vec3 (simulates PERIODIC_IDLE_POSITION_OFFSET) --
+
+TEST(ModifierUpsertInPlaceVec3, RepeatedCallStaysSizeOne) {
+    // Simulates 100 ticks of PERIODIC_IDLE_POSITION_OFFSET without
+    // MODIFIER_DECAY in the pipeline: the slot count must stay at 1.
+    C_Modifiers mods;
+    constexpr FieldBindingId kField{3};
+    auto source = IREntity::EntityId{1};
+
+    for (int i = 0; i < 100; ++i) {
+        IRPrefab::Modifier::upsertBySourceInPlace(
+            mods,
+            kField,
+            TransformKind::ADD,
+            IRMath::vec3(static_cast<float>(i), 0.0f, 0.0f),
+            source
+        );
+    }
+
+    ASSERT_EQ(mods.modifiersVec3_.size(), 1u);
+    EXPECT_FLOAT_EQ(mods.modifiersVec3_[0].param_.x, 99.0f);
+    EXPECT_EQ(mods.modifiersVec3_[0].ticksRemaining_, -1);
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

- Adds six inline overloads to `IRPrefab::Modifier::` in `modifier.hpp`: `upsertBySource` (scalar + vec3), `upsertBySourceGlobal` (scalar + vec3), `upsertBySourceInPlace` (scalar + vec3)
- Slot key is the triple `(source_, field_, kind_)`: on hit overwrites `param_` and resets `ticksRemaining_ = -1`; on miss appends with `ticksRemaining_ = -1`
- Migrates `PERIODIC_IDLE_POSITION_OFFSET` to `upsertBySourceInPlace`, eliminating per-frame `push_back` churn and the `MODIFIER_DECAY` pipeline dependency
- Documents the slot contract in `docs/design/modifiers.md` and updates `CLAUDE.md` files for `common/` and `update/`

## Test plan

- [x] 9 new unit tests cover: `FirstCallAppends`, `SecondCallOverwrites`, `DifferentKindGetsItsOwnSlot`, `DifferentSourceGetsItsOwnSlot`, `OverridesPriorTickRemaining`, and the 100-tick size-stays-1 invariant for both scalar and vec3 paths
- [x] Full test suite: 728/728 pass (`IrredenEngineTest`)
- [x] `IRShapeDebug` builds clean with the migrated system

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)