### PR TITLE
T-206: move IRRender::allocateVoxels/deallocateVoxels into dedicated header

### DIFF
--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -3,19 +3,15 @@
 
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_constants.hpp>
-#include <irreden/ir_render.hpp>
 
 #include <irreden/render/active_canvas.hpp>
-#include <irreden/render/texture.hpp>
+#include <irreden/render/voxel_pool_api.hpp>
 #include <irreden/voxel/components/component_voxel.hpp>
 #include <irreden/voxel/systems/system_voxel_pool.hpp>
 
 #include <vector>
 
 using namespace IRMath;
-using IRRender::ImageData;
-using IRRender::ResourceId;
-using IRRender::Texture2D;
 // TODO: add primitives to voxel set, not just setting individual voxels...
 // UPDATE: see component_geometric_shape.hpp
 
@@ -78,7 +74,10 @@ struct C_VoxelSetNew {
         : numVoxels_{size.x * size.y * size.z}
         , size_{size} {
         const int requestedVoxels = size.x * size.y * size.z;
-        canvasEntity_ = IRRender::getActiveCanvasEntity();
+        // Null-returning variant for symmetry with the dense-data ctor below;
+        // pool allocation still asserts inside RenderManager when no canvas
+        // exists, so the no-canvas crash site is the same.
+        canvasEntity_ = IRRender::getActiveCanvasEntityOrNull();
         auto allocation = IRRender::allocateVoxels(requestedVoxels);
         voxelStartIdx_ = allocation.startIndex_;
         positions_ = allocation.positions_;

--- a/engine/render/CMakeLists.txt
+++ b/engine/render/CMakeLists.txt
@@ -8,6 +8,7 @@ set(RENDER_CORE_SRC
     src/shader.cpp
     src/texture.cpp
     src/vao.cpp
+    src/voxel_pool_api.cpp
     src/image_data.cpp
 )
 

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -11,6 +11,7 @@
 #include <irreden/render/shader.hpp>
 #include <irreden/render/shader_names.hpp>
 #include <irreden/render/vao.hpp>
+#include <irreden/render/voxel_pool_api.hpp>
 
 namespace IRRender {
 
@@ -57,27 +58,17 @@ template <typename T> T *getNamedResource(std::string resourceName) {
 }
 /// @}
 
-/// @{
-/// @name Voxel pool
-/// Allocate / release contiguous spans of voxel component arrays from the named canvas
-/// pool. The four spans returned by @c allocateVoxels are co-indexed — element [i] of
-/// each span belongs to voxel i — and @c VoxelPoolAllocation::startIndex_ is the offset
-/// of those spans inside the pool's underlying voxel arrays. Pass that index back to
-/// @c deallocateVoxels (and to @c C_VoxelPool::setEntityIdForRange); never recompute it
-/// from `positions.data() - basePtr` against a separately-cached @c C_VoxelPool*, since
-/// a canvas archetype mutation can leave such a cache pointing at a different pool.
-/// @param size        Number of voxels to allocate.
-/// @param canvasName  Canvas pool to allocate from (default @c "main").
-inline VoxelPoolAllocation allocateVoxels(unsigned int size, std::string canvasName = "main") {
-    return getRenderManager().allocateVoxels(size, canvasName);
-}
-
-/// Release a previously-allocated voxel span back to the pool. Pass the start index
-/// returned by @c allocateVoxels and the same size used to allocate.
-inline void deallocateVoxels(size_t startIndex, size_t size, std::string canvasName = "main") {
-    getRenderManager().deallocateVoxels(startIndex, size, canvasName);
-}
-/// @}
+// Voxel pool API (allocateVoxels / deallocateVoxels) lives in
+// `<irreden/render/voxel_pool_api.hpp>` — included above so existing
+// `IRRender::allocateVoxels` callers via `ir_render.hpp` continue to compile.
+// Callers that allocate from a component ctor — see "GPU / IO resource
+// RAII" exception in .claude/rules/cpp-ecs.md — include the slim header
+// directly instead of pulling in the full render surface. The four spans
+// returned by `allocateVoxels` are co-indexed; `VoxelPoolAllocation::startIndex_`
+// is the source of truth for the pool offset — never recompute it from
+// `positions.data() - basePtr` against a separately-cached `C_VoxelPool*`,
+// since a canvas archetype mutation can leave such a cache pointing at a
+// different pool. See #754 (T-206).
 
 /// @{
 /// @name Canvas management

--- a/engine/render/include/irreden/render/voxel_pool_api.hpp
+++ b/engine/render/include/irreden/render/voxel_pool_api.hpp
@@ -1,0 +1,30 @@
+#ifndef IRREDEN_RENDER_VOXEL_POOL_API_H
+#define IRREDEN_RENDER_VOXEL_POOL_API_H
+
+#include <irreden/render/voxel_pool_allocation.hpp>
+
+#include <cstddef>
+#include <string>
+
+namespace IRRender {
+
+// Allocate / release contiguous spans of voxel component arrays from
+// the named canvas pool. Wraps RenderManager::allocateVoxels /
+// deallocateVoxels; full pool-allocation contract (co-indexed spans,
+// startIndex_ as source of truth, canvas-archetype-migration footgun)
+// lives in `ir_render.hpp`.
+//
+// Lives in a dedicated header (out of ir_render.hpp) so component
+// constructors that allocate voxels in their ctor — see "GPU / IO
+// resource RAII" exception in .claude/rules/cpp-ecs.md — do not pull
+// in the full render surface. Matches the T-205 split of
+// `getActiveCanvasEntityOrNull` into `active_canvas.hpp`. See #754.
+VoxelPoolAllocation allocateVoxels(unsigned int size, std::string canvasName = "main");
+
+void deallocateVoxels(
+    std::size_t startIndex, std::size_t size, std::string canvasName = "main"
+);
+
+} // namespace IRRender
+
+#endif /* IRREDEN_RENDER_VOXEL_POOL_API_H */

--- a/engine/render/src/voxel_pool_api.cpp
+++ b/engine/render/src/voxel_pool_api.cpp
@@ -1,0 +1,18 @@
+#include <irreden/render/voxel_pool_api.hpp>
+
+#include <irreden/ir_render.hpp>
+#include <irreden/render/render_manager.hpp>
+
+#include <utility>
+
+namespace IRRender {
+
+VoxelPoolAllocation allocateVoxels(unsigned int size, std::string canvasName) {
+    return getRenderManager().allocateVoxels(size, std::move(canvasName));
+}
+
+void deallocateVoxels(std::size_t startIndex, std::size_t size, std::string canvasName) {
+    getRenderManager().deallocateVoxels(startIndex, size, std::move(canvasName));
+}
+
+} // namespace IRRender


### PR DESCRIPTION
## Summary
- Split `IRRender::allocateVoxels` / `IRRender::deallocateVoxels` out of `ir_render.hpp` into a slim dedicated header so `C_VoxelSetNew` can drop its `ir_render.hpp` dependency.
- Drop dead `using IRRender::ImageData/ResourceId/Texture2D` plus the `<irreden/render/texture.hpp>` include from `component_voxel_set.hpp`.

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/772 (T-205)
Full chain: T-205 → T-206 → T-207

## Test plan
- [ ] `fleet-build --target IrredenEngineTest` (build clean)
- [ ] `fleet-build --target IRShapeDebug` + smoke render

Claiming task. Work in progress.

Closes #754