### PR TITLE
T-210: generalize APPLY_POSITION_OFFSET into applyVec3ModifierTo<>

### DIFF
--- a/docs/design/modifiers.md
+++ b/docs/design/modifiers.md
@@ -481,3 +481,83 @@ bob writer in the UPDATE pipeline. The reader-side sprite, hitbox,
 canvas-to-framebuffer, gizmo-drag, and picking systems read
 `C_PositionGlobal3D` directly; the `global + offset` manual sum is
 gone.
+
+## Inline-apply pattern (T-210)
+
+The `APPLY_POSITION_OFFSET` shape — *iterate
+`<TargetComponent, C_Modifiers>`, compose one vec3 field against a
+`vec3(0)` base, add the result to a vec3 member of the target
+component* — generalizes to any per-frame additive vec3 channel with
+exactly one consumer. Capturing the shape as a function-template
+factory keeps a future "screen-shake offset", "hit-stagger nudge", or
+"recoil sway" channel to one line of code:
+
+```cpp
+namespace IRPrefab::Modifier {
+
+template <typename TargetComponent, IRMath::vec3 TargetComponent::*Member>
+inline IRSystem::SystemId applyVec3ModifierTo(
+    const char *name,
+    IRComponents::FieldBindingId field
+);
+
+} // engine/prefabs/irreden/common/modifier_apply.hpp
+```
+
+`Member` is a member-pointer (compile-time, so the per-tick body
+collapses to `target.*Member += compose(...)` with no field-name
+lookup). `field` is captured at `create()` time because
+`FieldBindingId`s register lazily — the compile-time-template form
+("`Field` as a non-type template parameter") is rejected here because
+the field id is only known after `registerFieldVec3(...)` runs at
+init.
+
+`APPLY_POSITION_OFFSET` then reduces to:
+
+```cpp
+template <> struct System<APPLY_POSITION_OFFSET> {
+    static SystemId create() {
+        return IRPrefab::Modifier::applyVec3ModifierTo<
+            IRComponents::C_PositionGlobal3D,
+            &IRComponents::C_PositionGlobal3D::pos_>(
+            "ApplyPositionOffset",
+            IRPrefab::PositionModifier::positionOffsetField()
+        );
+    }
+};
+```
+
+### Inline-apply vs. structured-resolver: when to pick which
+
+Two compose-and-apply paths now coexist; pick by these gates:
+
+- **Inline-apply (`applyVec3ModifierTo`).** Exactly one consumer of
+  the vec3 field, ADD-onto-target semantics, and the channel does NOT
+  need `C_GlobalModifiers` integration. The compose runs once per
+  entity per frame and writes the destination directly. No
+  `C_ResolvedFields` slot consumed; no resolver tick on this field.
+- **Structured-resolver path
+  (`MODIFIER_RESOLVE_GLOBAL`/`_EXEMPT` + read from
+  `C_ResolvedFields`).** Two or more consumers want the same resolved
+  value, the channel needs global modifiers (e.g. "world-wide slow"
+  in modifier_demo), or the apply step is multiplicative / set-style
+  (e.g. `TRANSFORM_SCALE` folded into world transform). The cache
+  amortizes the compose across readers, and the global-modifier
+  archetype routing falls out for free.
+
+Globals integration is the single sharpest discriminator: the
+inline-apply factory reads only `mods.modifiersVec3_` on the
+iterating entity. `C_GlobalModifiers` are NOT folded in. Channels
+that must respond to globals — common case for a "buff/debuff that
+also moves the camera" — belong on the structured-resolver path.
+
+### Apply combine mode is fixed at ADD
+
+The factory's combine step is `target.*Member += result`, hard-coded.
+`MULTIPLY` / `SET` / `OVERRIDE` semantics already exist *inside*
+`composeForFieldVec3` (in the modifier vector itself); the outer apply
+step is the one knob that's fixed because the inline path's job is
+specifically the "per-frame additive delta" pattern. Channels that
+need a multiplicative or replace-style outer combine belong on the
+structured-resolver path (consumers read the resolved value and apply
+whatever combine they want).

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -142,6 +142,20 @@ Runtime entry points (all `inline`, header-only):
   `registerResolverPipeline()`. Intended for tests and diagnostics;
   production code should use `pushGlobal` / `removeBySource`.
 
+Inline-apply factory: `IRPrefab::Modifier::applyVec3ModifierTo<
+TargetComponent, Member>(name, field)` in
+[`modifier_apply.hpp`](modifier_apply.hpp) generalizes the
+`APPLY_POSITION_OFFSET` shape — *iterate
+`<TargetComponent, C_Modifiers>`, compose one vec3 field against a
+`vec3(0)` base, ADD the result to a vec3 member of the target
+component*. Use it for any per-frame additive vec3 channel with
+exactly one consumer where global-modifier integration is not
+required. Channels with multiple readers, global-modifier needs, or
+multiplicative apply semantics belong on the structured-resolver
+path (`MODIFIER_RESOLVE_GLOBAL` / `_EXEMPT` + read from
+`C_ResolvedFields`). See `docs/design/modifiers.md` §"Inline-apply
+pattern" for the discriminator and rationale.
+
 Composition core lives in `modifier_compose.hpp` and is called from
 both the resolver tick and `applyToField`. Order is non-obvious:
 

--- a/engine/prefabs/irreden/common/modifier_apply.hpp
+++ b/engine/prefabs/irreden/common/modifier_apply.hpp
@@ -1,0 +1,78 @@
+#ifndef MODIFIER_APPLY_H
+#define MODIFIER_APPLY_H
+
+// Generic factory for the inline-apply pattern: compose the entity's
+// vec3 modifiers for one field against a vec3(0) base and ADD the
+// result into a vec3 member of `TargetComponent`. Skips the
+// `C_ResolvedFields` cache and the resolver pipeline — the right shape
+// when a vec3 modifier channel has exactly one consumer and caching
+// would be pure overhead.
+//
+// Members of the family (anything that is "per-frame additive delta on
+// one vec3 field, written into one vec3 component member") collapse to
+// a single template instantiation:
+//
+//   template <> struct System<APPLY_POSITION_OFFSET> {
+//       static SystemId create() {
+//           return IRPrefab::Modifier::applyVec3ModifierTo<
+//               IRComponents::C_PositionGlobal3D,
+//               &IRComponents::C_PositionGlobal3D::pos_>(
+//               "ApplyPositionOffset",
+//               IRPrefab::PositionModifier::positionOffsetField()
+//           );
+//       }
+//   };
+//
+// Picking inline-apply vs. structured-resolver:
+//
+// - **Inline-apply (this helper):** exactly one consumer of the vec3
+//   field, no global modifiers needed for the channel, ADD-onto-target
+//   semantics. The compose runs once per entity per frame and writes
+//   the destination directly. No `C_ResolvedFields` slot consumed.
+//
+// - **Structured-resolver path (`MODIFIER_RESOLVE_*` + read from
+//   `C_ResolvedFields`):** two or more consumers want the same
+//   resolved value, the channel needs `C_GlobalModifiers` integration,
+//   or the apply step is multiplicative / set-style (e.g.
+//   `TRANSFORM_SCALE`). The cache amortizes the compose across
+//   readers and the global-modifier archetype routing falls out for
+//   free.
+//
+// Globals integration: the inline path reads the entity's modifier
+// vector only; `C_GlobalModifiers` are not folded in. Channels that
+// must respond to globals belong on the structured-resolver path.
+//
+// `Member` is a member-pointer (compile-time) so the per-tick body is
+// just `target.*Member += compose(...)` — no field-name lookup, no
+// branching on which vec3 field of the component is being written.
+// `field` is captured at create() time; `FieldBindingId`s register
+// dynamically (lazy via `position_modifier_fields.hpp` and friends),
+// so a runtime arg is the correct binding point.
+
+#include <irreden/ir_system.hpp>
+
+#include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/common/modifier_compose.hpp>
+
+namespace IRPrefab::Modifier {
+
+template <typename TargetComponent, IRMath::vec3 TargetComponent::*Member>
+inline IRSystem::SystemId applyVec3ModifierTo(
+    const char *name,
+    IRComponents::FieldBindingId field
+) {
+    return IRSystem::createSystem<TargetComponent, IRComponents::C_Modifiers>(
+        name,
+        [field](TargetComponent &target, IRComponents::C_Modifiers &mods) {
+            target.*Member += IRPrefab::Modifier::detail::composeForFieldVec3(
+                IRMath::vec3(0.0f),
+                field,
+                mods.modifiersVec3_
+            );
+        }
+    );
+}
+
+} // namespace IRPrefab::Modifier
+
+#endif /* MODIFIER_APPLY_H */

--- a/engine/prefabs/irreden/common/modifier_apply.hpp
+++ b/engine/prefabs/irreden/common/modifier_apply.hpp
@@ -3,51 +3,17 @@
 
 // Generic factory for the inline-apply pattern: compose the entity's
 // vec3 modifiers for one field against a vec3(0) base and ADD the
-// result into a vec3 member of `TargetComponent`. Skips the
-// `C_ResolvedFields` cache and the resolver pipeline — the right shape
-// when a vec3 modifier channel has exactly one consumer and caching
-// would be pure overhead.
+// result into a vec3 member of `TargetComponent`. Globals are NOT
+// folded in here — that's the sharpest discriminator vs. the
+// structured-resolver path. See docs/design/modifiers.md "Inline-apply
+// pattern" for the full discriminator and rationale.
 //
-// Members of the family (anything that is "per-frame additive delta on
-// one vec3 field, written into one vec3 component member") collapse to
-// a single template instantiation:
-//
-//   template <> struct System<APPLY_POSITION_OFFSET> {
-//       static SystemId create() {
-//           return IRPrefab::Modifier::applyVec3ModifierTo<
-//               IRComponents::C_PositionGlobal3D,
-//               &IRComponents::C_PositionGlobal3D::pos_>(
-//               "ApplyPositionOffset",
-//               IRPrefab::PositionModifier::positionOffsetField()
-//           );
-//       }
-//   };
-//
-// Picking inline-apply vs. structured-resolver:
-//
-// - **Inline-apply (this helper):** exactly one consumer of the vec3
-//   field, no global modifiers needed for the channel, ADD-onto-target
-//   semantics. The compose runs once per entity per frame and writes
-//   the destination directly. No `C_ResolvedFields` slot consumed.
-//
-// - **Structured-resolver path (`MODIFIER_RESOLVE_*` + read from
-//   `C_ResolvedFields`):** two or more consumers want the same
-//   resolved value, the channel needs `C_GlobalModifiers` integration,
-//   or the apply step is multiplicative / set-style (e.g.
-//   `TRANSFORM_SCALE`). The cache amortizes the compose across
-//   readers and the global-modifier archetype routing falls out for
-//   free.
-//
-// Globals integration: the inline path reads the entity's modifier
-// vector only; `C_GlobalModifiers` are not folded in. Channels that
-// must respond to globals belong on the structured-resolver path.
-//
-// `Member` is a member-pointer (compile-time) so the per-tick body is
-// just `target.*Member += compose(...)` — no field-name lookup, no
-// branching on which vec3 field of the component is being written.
-// `field` is captured at create() time; `FieldBindingId`s register
-// dynamically (lazy via `position_modifier_fields.hpp` and friends),
-// so a runtime arg is the correct binding point.
+// `Member` is a member-pointer (compile-time non-type template param)
+// so the per-tick body is `target.*Member += compose(...)` with no
+// field-name lookup or branching. `field` is a runtime arg because
+// `FieldBindingId`s register lazily (via `position_modifier_fields.hpp`
+// and friends) and forcing callers to make their ids `constexpr` would
+// break that.
 
 #include <irreden/ir_system.hpp>
 

--- a/engine/prefabs/irreden/update/systems/system_apply_position_offset.hpp
+++ b/engine/prefabs/irreden/update/systems/system_apply_position_offset.hpp
@@ -10,27 +10,26 @@
 // Pipeline placement: AFTER GLOBAL_POSITION_3D so globalPos = local +
 // parent has been refreshed for this frame, and AFTER the per-frame
 // writer that pushes the offset modifier.
+//
+// Single-line instantiation of `applyVec3ModifierTo` — see
+// `engine/prefabs/irreden/common/modifier_apply.hpp` for the family
+// shape and inline-apply vs. structured-resolver guidance.
 
 #include <irreden/ir_system.hpp>
 
-#include <irreden/common/components/component_modifiers.hpp>
 #include <irreden/common/components/component_position_global_3d.hpp>
-#include <irreden/common/modifier_compose.hpp>
+#include <irreden/common/modifier_apply.hpp>
 #include <irreden/common/position_modifier_fields.hpp>
 
 namespace IRSystem {
 
 template <> struct System<APPLY_POSITION_OFFSET> {
     static SystemId create() {
-        return createSystem<IRComponents::C_PositionGlobal3D, IRComponents::C_Modifiers>(
+        return IRPrefab::Modifier::applyVec3ModifierTo<
+            IRComponents::C_PositionGlobal3D,
+            &IRComponents::C_PositionGlobal3D::pos_>(
             "ApplyPositionOffset",
-            [](IRComponents::C_PositionGlobal3D &globalPos, IRComponents::C_Modifiers &mods) {
-                globalPos.pos_ += IRPrefab::Modifier::detail::composeForFieldVec3(
-                    IRMath::vec3(0.0f),
-                    IRPrefab::PositionModifier::positionOffsetField(),
-                    mods.modifiersVec3_
-                );
-            }
+            IRPrefab::PositionModifier::positionOffsetField()
         );
     }
 };


### PR DESCRIPTION
## Summary
- Generalizes the `APPLY_POSITION_OFFSET` shape — *iterate `<TargetComponent, C_Modifiers>`, compose one vec3 field against `vec3(0)`, ADD the result to a vec3 member of the target component* — into `IRPrefab::Modifier::applyVec3ModifierTo<TargetComponent, Member>(name, field)` in a new header `engine/prefabs/irreden/common/modifier_apply.hpp`.
- `APPLY_POSITION_OFFSET` reduces to a single-line instantiation. Behavior is byte-identical (same `composeForFieldVec3` call, same archetype iteration `<C_PositionGlobal3D, C_Modifiers>`, same in-place `pos_ +=`).
- `docs/design/modifiers.md` gets a new "Inline-apply pattern (T-210)" section that captures the design choices (template vs. runtime parameterization, ADD-only combine, no globals integration) and the inline-apply vs. structured-resolver discriminator.
- `engine/prefabs/irreden/common/CLAUDE.md` points readers at the new factory and links the discriminator.

## Design choices (architect picks from issue)
- **Member pointer = template parameter** (compile-time, so the per-tick body collapses to `target.*Member += compose(...)` with no field-name lookup).
- **`field` = runtime arg** captured into the lambda. `FieldBindingId`s register lazily at init, so a non-type template form would force every consumer to make their field id `constexpr` — they're not.
- **Combine mode = ADD against `vec3(0)`, hard-coded.** That's the universal "per-frame additive delta" pattern that motivates the inline-apply path. MUL/SET/OVERRIDE semantics already live *inside* `composeForFieldVec3`; the outer apply step doesn't need to be parameterized.
- **No globals integration.** Inline path reads only the entity's `mods.modifiersVec3_`, matching `APPLY_POSITION_OFFSET`'s pre-existing behavior. Channels that must respond to globals belong on the structured-resolver path.
- **Naming = `applyVec3ModifierTo`** per the issue sketch. `FOLD_MODIFIER_CHANNEL` was an alternative — kept the issue's name because it reads better at the call site (`applyVec3ModifierTo<C_PositionGlobal3D, &C_PositionGlobal3D::pos_>` says exactly what it does).

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean.
- [x] `fleet-build --target IRPerfGrid` — clean (perf_grid is one of two demos that instantiates `System<APPLY_POSITION_OFFSET>::create()`).
- [x] `fleet-build --target IRCreationDefault` — clean (the other instantiator, via `main_lua.cpp`).
- [x] `fleet-build --target format-changed` — clean (clang-format applied to the touched system header).
- [ ] WSL2 GLX is currently broken on this host (T-202 / PR #775 in flight) so a runtime smoke wasn't possible. Diff is a behavioral identity refactor — same lambda body, same compose call, same archetype, same `+=`. Reviewer should confirm idle bob still bobs on macOS / Windows.

## Acceptance criteria (from issue #760)
- [x] `APPLY_POSITION_OFFSET` reimplemented as instance of the generic pattern (one factory call, no inline lambda).
- [x] `docs/design/modifiers.md` documents the inline-apply pattern alongside the structured-resolver path with guidance on when to pick which.
- [ ] Idle bob in `default` + `perf_grid` continues to look identical to master (not visually verified on this host — see test plan note).
- [ ] No regression in `IRShapeDebug`, `voxel_editor`, or any demo that uses position offset (build-clean confirmed; visual confirmation pending reviewer / cross-host smoke).

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)