### PR TITLE
T-209: modifier: replace ticksRemaining footgun with pushFrameLocal / pushOneFrame

### DIFF
--- a/docs/design/modifiers.md
+++ b/docs/design/modifiers.md
@@ -314,6 +314,40 @@ Lua mirrors this (child 4): `ir.modifier.registerField`,
 `TransformKind` enum is exposed as
 `ir.modifier.ADD/MULTIPLY/SET/CLAMP_MIN/CLAMP_MAX/OVERRIDE`.
 
+### Named one-frame wrappers: `pushFrameLocal` / `pushOneFrame`
+
+Raw `push(..., ticksRemaining)` carries a subtle pipeline-ordering
+invariant that new callers almost always get wrong. The `ticksRemaining`
+value must be chosen based on where the caller sits relative to
+`MODIFIER_DECAY` in the UPDATE pipeline:
+
+| Caller position | Correct `ticksRemaining` | Named wrapper |
+|---|---|---|
+| INSIDE the resolver pipeline, after `MODIFIER_DECAY` | `1` | `pushFrameLocal` |
+| OUTSIDE the pipeline (Lua, input handler, command) | `2` | `pushOneFrame` |
+
+**`pushFrameLocal`** — caller runs after `MODIFIER_DECAY` in the same
+UPDATE tick. The entry survives this frame's compose, then next frame's
+DECAY removes it. The "use 2 to fire for one frame" rule does NOT apply
+here.
+
+**`pushOneFrame`** — caller runs outside the resolver pipeline (Lua,
+input handler, command). The entry must survive the next frame's DECAY
+(which runs before compose on the next tick) and compose; the frame after
+removes it. The extra tick is headroom so `DECAY` doesn't sweep the entry
+before its first compose.
+
+Both expose scalar (float) and vec3 overloads; the Lua surface adds
+`ir.modifier.pushFrameLocal`, `ir.modifier.pushOneFrame`,
+`ir.modifier.pushFrameLocalVec3`, `ir.modifier.pushOneFrameVec3`.
+
+Reserve raw `push(..., ticksRemaining)` for callers that genuinely need
+custom multi-frame decay (buffs, timed debuffs, cooldowns). For
+anything that should survive exactly one compose cycle, prefer the named
+wrappers — they encode the pipeline position in the API name so future
+writers don't need to read the `MODIFIER_DECAY` header to pick the right
+integer.
+
 ## Existing-pattern audit
 
 The engine already hand-rolls the "base + modulation → effective"

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -168,6 +168,49 @@ inline void pushFrameLocal(
     push(target, field, kind, param, source, 1);
 }
 
+// Direct-reference overloads for tick functions that already hold the
+// component reference from the archetype iterator. Avoids the per-entity
+// getComponentOptional lookup in push(EntityId, ...).
+inline void pushFrameLocal(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    mods.modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, 1});
+}
+
+inline void pushFrameLocal(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    mods.modifiersVec3_.push_back(IRComponents::ModifierVec3{field, kind, param, source, 1});
+}
+
+inline void pushFrameLocal(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec4 param,
+    IREntity::EntityId source
+) {
+    const bool unitQuatIncompatible = kind == IRComponents::TransformKind::ADD ||
+                                      kind == IRComponents::TransformKind::CLAMP_MIN ||
+                                      kind == IRComponents::TransformKind::CLAMP_MAX;
+    IR_ASSERT(
+        !unitQuatIncompatible,
+        "Quat modifier kind: ADD/CLAMP_MIN/CLAMP_MAX are not meaningful on unit "
+        "quaternions; use MULTIPLY for compose, OVERRIDE/SET for replacement."
+    );
+    if (unitQuatIncompatible)
+        return;
+    mods.modifiersQuat_.push_back(IRComponents::ModifierQuat{field, kind, param, source, 1});
+}
+
 // Caller runs OUTSIDE the resolver pipeline (Lua, input handler, command).
 // Modifier survives the next frame's DECAY + compose; the frame after removes
 // it. The extra tick accounts for DECAY running before the first compose.
@@ -189,6 +232,49 @@ inline void pushOneFrame(
     IREntity::EntityId source
 ) {
     push(target, field, kind, param, source, 2);
+}
+
+// Direct-reference overloads for out-of-pipeline callers that already hold
+// the component reference. ticksRemaining=2 accounts for DECAY running before
+// the next frame's compose.
+inline void pushOneFrame(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    mods.modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, 2});
+}
+
+inline void pushOneFrame(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    mods.modifiersVec3_.push_back(IRComponents::ModifierVec3{field, kind, param, source, 2});
+}
+
+inline void pushOneFrame(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec4 param,
+    IREntity::EntityId source
+) {
+    const bool unitQuatIncompatible = kind == IRComponents::TransformKind::ADD ||
+                                      kind == IRComponents::TransformKind::CLAMP_MIN ||
+                                      kind == IRComponents::TransformKind::CLAMP_MAX;
+    IR_ASSERT(
+        !unitQuatIncompatible,
+        "Quat modifier kind: ADD/CLAMP_MIN/CLAMP_MAX are not meaningful on unit "
+        "quaternions; use MULTIPLY for compose, OVERRIDE/SET for replacement."
+    );
+    if (unitQuatIncompatible)
+        return;
+    mods.modifiersQuat_.push_back(IRComponents::ModifierQuat{field, kind, param, source, 2});
 }
 
 inline void pushGlobal(

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -145,6 +145,52 @@ inline void push(
     );
 }
 
+// Caller runs INSIDE the resolver pipeline, after MODIFIER_DECAY in the same
+// UPDATE tick. Modifier survives this frame's compose; next frame's DECAY
+// removes it. Use for system ticks positioned inside the pipeline.
+inline void pushFrameLocal(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    push(target, field, kind, param, source, 1);
+}
+
+inline void pushFrameLocal(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    push(target, field, kind, param, source, 1);
+}
+
+// Caller runs OUTSIDE the resolver pipeline (Lua, input handler, command).
+// Modifier survives the next frame's DECAY + compose; the frame after removes
+// it. The extra tick accounts for DECAY running before the first compose.
+inline void pushOneFrame(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    push(target, field, kind, param, source, 2);
+}
+
+inline void pushOneFrame(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    push(target, field, kind, param, source, 2);
+}
+
 inline void pushGlobal(
     IRComponents::FieldBindingId field,
     IRComponents::TransformKind kind,

--- a/engine/prefabs/irreden/common/modifier_lua.hpp
+++ b/engine/prefabs/irreden/common/modifier_lua.hpp
@@ -83,6 +83,16 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
         IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
     };
 
+    modTbl["pushFrameLocal"] = [parseOpts](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOpts(opts);
+        IRPrefab::Modifier::pushFrameLocal(target, o.field_, o.kind_, o.param_, o.source_);
+    };
+
+    modTbl["pushOneFrame"] = [parseOpts](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOpts(opts);
+        IRPrefab::Modifier::pushOneFrame(target, o.field_, o.kind_, o.param_, o.source_);
+    };
+
     // vec3 push paths. `param` accepts an IRMath::vec3 userdata or a {x,y,z} table.
     struct PushOptsVec3 {
         IRComponents::FieldBindingId field_;
@@ -111,6 +121,16 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
     modTbl["pushGlobalVec3"] = [parseOptsVec3](sol::table opts) {
         auto o = parseOptsVec3(opts);
         IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
+    };
+
+    modTbl["pushFrameLocalVec3"] = [parseOptsVec3](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOptsVec3(opts);
+        IRPrefab::Modifier::pushFrameLocal(target, o.field_, o.kind_, o.param_, o.source_);
+    };
+
+    modTbl["pushOneFrameVec3"] = [parseOptsVec3](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOptsVec3(opts);
+        IRPrefab::Modifier::pushOneFrame(target, o.field_, o.kind_, o.param_, o.source_);
     };
 
     // Quat push paths. `param` accepts an IRMath::vec4 userdata or a {x,y,z,w} table.

--- a/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
+++ b/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
@@ -29,9 +29,9 @@ template <> struct System<PERIODIC_IDLE_POSITION_OFFSET> {
             "PeriodicIdlePositionOffset",
             [](IREntity::EntityId entity,
                IRComponents::C_PeriodicIdle &idle,
-               IRComponents::C_Modifiers &) {
+               IRComponents::C_Modifiers &mods) {
                 IRPrefab::Modifier::pushFrameLocal(
-                    entity,
+                    mods,
                     IRPrefab::PositionModifier::positionOffsetField(),
                     IRComponents::TransformKind::ADD,
                     idle.getValue(),

--- a/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
+++ b/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
@@ -5,13 +5,9 @@
 // UPDATE tick. APPLY_POSITION_OFFSET later composes the entity's
 // vec3 modifiers and adds the resolved offset to C_PositionGlobal3D.
 //
-// `ticksRemaining_ = 1` because this writer pushes AFTER MODIFIER_DECAY
-// has already run in the same UPDATE pipeline: the entry survives this
-// frame's compose, then next frame's DECAY decrements it (1 → 0) and
-// removes it before the next compose. The "use 2 to fire for one frame"
-// rule in MODIFIER_DECAY's header applies to entries pushed OUTSIDE the
-// pipeline (Lua, input handlers) — those see DECAY before their first
-// compose, so they need one extra tick of headroom.
+// Uses pushFrameLocal (ticksRemaining=1) because this writer runs AFTER
+// MODIFIER_DECAY in the same UPDATE pipeline: the entry survives this
+// frame's compose, then next frame's DECAY removes it.
 //
 // Pipeline ordering required by callers:
 //   PERIODIC_IDLE → MODIFIER_DECAY → PERIODIC_IDLE_POSITION_OFFSET
@@ -22,7 +18,6 @@
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_system.hpp>
 
-#include <irreden/common/components/component_modifiers.hpp>
 #include <irreden/common/position_modifier_fields.hpp>
 #include <irreden/update/components/component_periodic_idle.hpp>
 
@@ -34,17 +29,13 @@ template <> struct System<PERIODIC_IDLE_POSITION_OFFSET> {
             "PeriodicIdlePositionOffset",
             [](IREntity::EntityId entity,
                IRComponents::C_PeriodicIdle &idle,
-               IRComponents::C_Modifiers &mods) {
-                // Push directly to the archetype-iterated mods to avoid
-                // a per-entity getComponent inside IRPrefab::Modifier::push.
-                mods.modifiersVec3_.push_back(
-                    IRComponents::ModifierVec3{
-                        IRPrefab::PositionModifier::positionOffsetField(),
-                        IRComponents::TransformKind::ADD,
-                        idle.getValue(),
-                        entity,
-                        1
-                    }
+               IRComponents::C_Modifiers &) {
+                IRPrefab::Modifier::pushFrameLocal(
+                    entity,
+                    IRPrefab::PositionModifier::positionOffsetField(),
+                    IRComponents::TransformKind::ADD,
+                    idle.getValue(),
+                    entity
                 );
             }
         );

--- a/test/ecs/modifier_vec3_runtime_test.cpp
+++ b/test/ecs/modifier_vec3_runtime_test.cpp
@@ -326,6 +326,62 @@ TEST(ModifierVec3Decay, SixtyTickModifierExpiresAtSixty) {
     EXPECT_EQ(mods.size(), 0u);
 }
 
+// ---- Direct-reference overloads (C_Modifiers&) ----------------------------
+
+TEST(ModifierDirectRef, PushFrameLocalVec3DepositsInVec3VectorWithTicks1) {
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushFrameLocal(
+        mods,
+        kFieldA,
+        TransformKind::ADD,
+        IRMath::vec3(1.0f, 2.0f, 3.0f),
+        IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiers_.size(), 0u);
+    ASSERT_EQ(mods.modifiersVec3_.size(), 1u);
+    EXPECT_EQ(mods.modifiersVec3_[0].field_, kFieldA);
+    EXPECT_EQ(mods.modifiersVec3_[0].kind_, TransformKind::ADD);
+    EXPECT_FLOAT_EQ(mods.modifiersVec3_[0].param_.x, 1.0f);
+    EXPECT_FLOAT_EQ(mods.modifiersVec3_[0].param_.y, 2.0f);
+    EXPECT_FLOAT_EQ(mods.modifiersVec3_[0].param_.z, 3.0f);
+    EXPECT_EQ(mods.modifiersVec3_[0].ticksRemaining_, 1);
+}
+
+TEST(ModifierDirectRef, PushFrameLocalScalarDepositsInScalarVectorWithTicks1) {
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushFrameLocal(
+        mods, kFieldA, TransformKind::MULTIPLY, 2.5f, IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiersVec3_.size(), 0u);
+    ASSERT_EQ(mods.modifiers_.size(), 1u);
+    EXPECT_EQ(mods.modifiers_[0].field_, kFieldA);
+    EXPECT_FLOAT_EQ(mods.modifiers_[0].param_, 2.5f);
+    EXPECT_EQ(mods.modifiers_[0].ticksRemaining_, 1);
+}
+
+TEST(ModifierDirectRef, PushOneFrameVec3DepositsWithTicks2) {
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushOneFrame(
+        mods, kFieldA, TransformKind::ADD, IRMath::vec3(4.0f), IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiersVec3_.size(), 1u);
+    EXPECT_EQ(mods.modifiersVec3_[0].ticksRemaining_, 2);
+}
+
+TEST(ModifierDirectRef, PushFrameLocalVec3DoesNotTriggerEntityLookup) {
+    // Verify the direct-reference overload compiles and runs without an entity
+    // or an entity manager in scope — confirming no getComponentOptional path
+    // is taken.
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushFrameLocal(
+        mods, kFieldA, TransformKind::ADD, IRMath::vec3(0.0f), IREntity::kNullEntity
+    );
+    EXPECT_EQ(mods.modifiersVec3_.size(), 1u);
+}
+
 // ---- Push API: type-mismatch dispatch ------------------------------------
 
 class IRModifierVec3PushTest : public testing::Test {


### PR DESCRIPTION
## Summary

- Add `pushFrameLocal` (float + vec3 overloads) — in-pipeline callers that push AFTER `MODIFIER_DECAY` in the same UPDATE tick; bakes `ticksRemaining=1`.
- Add `pushOneFrame` (float + vec3 overloads) — out-of-pipeline callers (Lua, input handlers, commands) that need `ticksRemaining=2` to survive the next frame's DECAY before first compose.
- Expose all four via Lua bindings: `ir.modifier.pushFrameLocal`, `ir.modifier.pushOneFrame`, `ir.modifier.pushFrameLocalVec3`, `ir.modifier.pushOneFrameVec3`.
- Migrate `PERIODIC_IDLE_POSITION_OFFSET` from direct `modifiersVec3_.push_back` to `pushFrameLocal`, replacing a magic `1` with the named wrapper.
- Update `docs/design/modifiers.md` with a table and rationale explaining when to use each wrapper vs raw `push`.

## Test plan

- [x] All 90 existing modifier tests pass (`IrredenEngineTest --gtest_filter=Modifier*`)
- [x] `IRShapeDebug` builds cleanly
- [x] Both `pushFrameLocal` and `pushOneFrame` delegate to `push` with correct `ticksRemaining`
- [x] Lua bindings compile and expose both scalar and vec3 variants

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)