### PR TITLE
T-203: Linux demo validation suite — fix SHAPES_TO_TRIXEL 2D dispatch crash + all demos pass on linux-debug

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
@@ -236,6 +236,7 @@ template <> struct System<SHAPES_TO_TRIXEL> {
             // the shader uses to rasterize each shape — so the
             // per-tile iso footprint matches the SDF surface that
             // pixel ends up writing.
+            int gridX = 1;
             const int tileCount = buildAndUploadTileDescriptors(
                 gpuShapes,
                 shapeTileDescBuf_,
@@ -243,11 +244,14 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                 renderMode,
                 rasterYaw,
                 yawCos_,
-                yawSin_
+                yawSin_,
+                gridX
             );
             if (tileCount == 0) {
                 continue;
             }
+            const int gridY = IRMath::divCeil(tileCount, gridX);
+            frameData_.tileGridX = gridX;
 
             shapesProgram_->use();
             shapeDescBuf_->bindBase(BufferTarget::SHADER_STORAGE, kBufferIndex_ShapeDescriptors);
@@ -260,7 +264,7 @@ template <> struct System<SHAPES_TO_TRIXEL> {
             frameData_.passIndex = 0;
             shapesFrameDataBuf_->subData(0, sizeof(GPUShapesFrameData), &frameData_);
 
-            IRRender::device()->dispatchCompute(static_cast<std::uint32_t>(tileCount), 1, 1);
+            IRRender::device()->dispatchCompute(static_cast<std::uint32_t>(gridX), static_cast<std::uint32_t>(gridY), 1);
             IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
             // Pass 1: color + entity ID where depth matches. Colors is bound
@@ -277,7 +281,7 @@ template <> struct System<SHAPES_TO_TRIXEL> {
             frameData_.passIndex = 1;
             shapesFrameDataBuf_->subData(0, sizeof(GPUShapesFrameData), &frameData_);
 
-            IRRender::device()->dispatchCompute(static_cast<std::uint32_t>(tileCount), 1, 1);
+            IRRender::device()->dispatchCompute(static_cast<std::uint32_t>(gridX), static_cast<std::uint32_t>(gridY), 1);
             IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
 
             auto &timing = IRRender::gpuStageTiming();
@@ -368,7 +372,8 @@ template <> struct System<SHAPES_TO_TRIXEL> {
         IRRender::SubdivisionMode renderMode,
         float rasterYaw,
         float yawCos,
-        float yawSin
+        float yawSin,
+        int &gridXOut
     ) {
         static thread_local std::vector<ShapeTileDescriptor> tiles;
         tiles.clear();
@@ -432,9 +437,20 @@ template <> struct System<SHAPES_TO_TRIXEL> {
     upload:
         const int tileCount = static_cast<int>(tiles.size());
         if (tileCount == 0) {
+            gridXOut = 1;
             return 0;
         }
-        tileDescBuf->subData(0, tileCount * sizeof(ShapeTileDescriptor), tiles.data());
+        constexpr int kMaxDispatchGroupsX = 1024;
+        const int gridX = IRMath::min(tileCount, kMaxDispatchGroupsX);
+        const int gridY = IRMath::divCeil(tileCount, gridX);
+        const int paddedCount = gridX * gridY;
+        ShapeTileDescriptor sentinel{};
+        sentinel.shapeIndex = -1;
+        while (static_cast<int>(tiles.size()) < paddedCount) {
+            tiles.push_back(sentinel);
+        }
+        tileDescBuf->subData(0, paddedCount * sizeof(ShapeTileDescriptor), tiles.data());
+        gridXOut = gridX;
         return tileCount;
     }
 };

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -248,7 +248,10 @@ struct GPUShapesFrameData {
     float visualYaw = 0.0f;
     float rasterYaw = 0.0f;
     float residualYaw = 0.0f;
-    float _yawPadding = 0.0f;
+    // X dimension of the 2D dispatch grid used by SHAPES_TO_TRIXEL. The shader
+    // computes tileIdx = gl_WorkGroupID.x + gl_WorkGroupID.y * tileGridX so
+    // the dispatch stays within GL_MAX_COMPUTE_WORK_GROUP_COUNT[0].
+    int tileGridX = 1;
 };
 
 struct FrameDataSun {

--- a/engine/render/src/shaders/c_shapes_to_trixel.glsl
+++ b/engine/render/src/shaders/c_shapes_to_trixel.glsl
@@ -31,7 +31,7 @@ layout(std140, binding = 23) uniform ShapesFrameData {
     uniform float visualYaw;
     uniform float rasterYaw;
     uniform float residualYaw;
-    uniform float _yawPadding;
+    uniform int tileGridX;
 };
 
 struct ShapeDescriptor {
@@ -706,8 +706,10 @@ int findSurfaceDepth(ivec2 isoRel, uint shapeType, vec4 params, uint flags,
 }
 
 void main() {
-    ShapeTileDescriptor tile = tiles[gl_WorkGroupID.x];
+    int tileIdx = int(gl_WorkGroupID.x) + int(gl_WorkGroupID.y) * tileGridX;
+    ShapeTileDescriptor tile = tiles[tileIdx];
     int shapeIndex = tile.shapeIndex;
+    if (shapeIndex < 0) return;
     ivec2 isoOrigin = tile.tileIsoOrigin;
     ShapeDescriptor shape = shapes[shapeIndex];
 

--- a/engine/render/src/shaders/metal/c_shapes_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_shapes_to_trixel.metal
@@ -28,7 +28,7 @@ struct ShapesFrameData {
     float visualYaw;
     float rasterYaw;
     float residualYaw;
-    float _yawPadding;
+    int tileGridX;
 };
 
 struct ShapeDescriptor {
@@ -819,8 +819,10 @@ kernel void c_shapes_to_trixel(
     uint3 groupId [[threadgroup_position_in_grid]],
     uint3 localId [[thread_position_in_threadgroup]]
 ) {
-    const ShapeTileDescriptor tile = tiles[groupId.x];
+    const uint tileIdx = groupId.x + groupId.y * uint(frameData.tileGridX);
+    const ShapeTileDescriptor tile = tiles[tileIdx];
     const int shapeIndex = tile.shapeIndex;
+    if (shapeIndex < 0) return;
     const int2 isoOrigin = tile.tileIsoOrigin;
     const ShapeDescriptor shape = shapes[shapeIndex];
 


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `SHAPES_TO_TRIXEL` was dispatching `glDispatchCompute(tileCount, 1, 1)` where `tileCount` can reach 262144 at zoom=16 (effectiveSubdivisions=16). This exceeds `GL_MAX_COMPUTE_WORK_GROUP_COUNT[0]` (minimum 65535), causing `GL_INVALID_OPERATION`. The error was deferred to the next checked GL call (`glBindImageTexture`), giving a misleading assertion site.
- Applied the same 2D dispatch pattern used by `VOXEL_TO_TRIXEL`: `gridX = min(tileCount, 1024)`, `gridY = divCeil(tileCount, gridX)`, dispatch `(gridX, gridY, 1)`. Padded the tile SSBO with `shapeIndex = -1` sentinel tiles to fill the grid.
- Repurposed the std140 `_yawPadding` slot in `GPUShapesFrameData` as `tileGridX` (same 4-byte position at offset 68 — no layout change). GLSL `main()` computes `tileIdx = gl_WorkGroupID.x + gl_WorkGroupID.y * tileGridX` and early-returns on sentinels.

## Files changed

- `engine/render/include/irreden/render/ir_render_types.hpp` — rename `float _yawPadding` → `int tileGridX` in `GPUShapesFrameData`
- `engine/render/src/shaders/c_shapes_to_trixel.glsl` — rename UBO field + 2D tile indexing in `main()`
- `engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp` — 2D dispatch grid computation + sentinel padding in `buildAndUploadTileDescriptors`; 2D dispatch calls in `endTick`

## Linux demo validation results (linux-debug, gcc-13, OpenGL 4.5, WSLg)

All demos build cleanly. `--auto-screenshot` results:

| Demo | Build | Run | Auto-screenshot |
|------|-------|-----|-----------------|
| `shape_debug` (IRShapeDebug) | ✅ | ✅ | ✅ 7/7 shots (zoom=16 LOD fix) |
| `default` (IRCreationDefault) | ✅ | ✅ | n/a (no `--auto-screenshot`) |
| `gpu_particles` (IRGpuParticles) | ✅ | ✅ | ✅ 3/3 shots |
| `stateless_particles` (IRStatelessParticles) | ✅ | ✅ | ✅ all shots |
| `modifier_demo` (IRModifierDemo) | ✅ | ✅ | ✅ 2/2 shots |
| `perf_grid` (IRPerfGrid) | ✅ | ✅ | ✅ launched |
| `lua_perf_grid` (IRLuaPerfGrid) | ✅ | ✅ | ✅ 2/2 shots |
| `lua_pipeline_demo` (IRLuaPipelineDemo) | ✅ | ✅ | ✅ 1/1 shots |
| `sprite_demo` (IRSpriteDemo) | ✅ | ✅ | ✅ 2/2 shots |
| `ui_dockspace` (IRUiDockspace) | ✅ | ✅ | ✅ 1/1 shots |
| `ui_widgets` (IRUIWidgetsDemo) | ✅ | ✅ | ✅ 3/3 shots |
| `lighting/ao` (IRLightingAO) | ✅ | ✅ | ✅ 6/6 shots |
| `lighting/sun_shadow` (IRLightingSunShadow) | ✅ | ✅ | ✅ 6/6 shots |
| `lighting/emissive` (IRLightingEmissive) | ✅ | ✅ | ✅ 6/6 shots |
| `lighting/combined` (IRLightingCombined) | ✅ | ✅ | ✅ 6/6 shots |
| `lighting/debug_overlays` (IRLightingDebugOverlays) | ✅ | ✅ | ✅ 6/6 shots |
| `z_yaw_rotation/static` (IRZYawStatic) | ✅ | ✅ | ✅ 2/2 shots |
| `z_yaw_rotation/interactive` (IRZYawInteractive) | ✅ | ✅ | n/a (interactive) |
| `metal_clear_test` | n/a | n/a | Metal-only, correctly excluded on Linux |
| `midi_keyboard` | n/a | n/a | MIDI HW not forwarded under WSLg — documented |

ALSA noise (`snd_func_card_inum`, Jack not found) appears in all demos — expected under WSLg, audio device absent. No GL errors.

## Test plan

- [x] `IRShapeDebug --auto-screenshot 10` → 7/7 shots pass including zoom=16 (previously SIGABRT)
- [x] All other demos build on `linux-debug`
- [x] All `--auto-screenshot`-capable demos complete all shots without crashing
- [x] No GL error assertions in any run

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)