### PR TITLE
T-209: modifier: replace ticksRemaining footgun with pushFrameLocal / pushOneFrame

### DIFF
--- a/docs/design/modifiers.md
+++ b/docs/design/modifiers.md
@@ -314,6 +314,40 @@ Lua mirrors this (child 4): `ir.modifier.registerField`,
 `TransformKind` enum is exposed as
 `ir.modifier.ADD/MULTIPLY/SET/CLAMP_MIN/CLAMP_MAX/OVERRIDE`.
 
+### Named one-frame wrappers: `pushFrameLocal` / `pushOneFrame`
+
+Raw `push(..., ticksRemaining)` carries a subtle pipeline-ordering
+invariant that new callers almost always get wrong. The `ticksRemaining`
+value must be chosen based on where the caller sits relative to
+`MODIFIER_DECAY` in the UPDATE pipeline:
+
+| Caller position | Correct `ticksRemaining` | Named wrapper |
+|---|---|---|
+| INSIDE the resolver pipeline, after `MODIFIER_DECAY` | `1` | `pushFrameLocal` |
+| OUTSIDE the pipeline (Lua, input handler, command) | `2` | `pushOneFrame` |
+
+**`pushFrameLocal`** — caller runs after `MODIFIER_DECAY` in the same
+UPDATE tick. The entry survives this frame's compose, then next frame's
+DECAY removes it. The "use 2 to fire for one frame" rule does NOT apply
+here.
+
+**`pushOneFrame`** — caller runs outside the resolver pipeline (Lua,
+input handler, command). The entry must survive the next frame's DECAY
+(which runs before compose on the next tick) and compose; the frame after
+removes it. The extra tick is headroom so `DECAY` doesn't sweep the entry
+before its first compose.
+
+Both expose scalar (float) and vec3 overloads; the Lua surface adds
+`ir.modifier.pushFrameLocal`, `ir.modifier.pushOneFrame`,
+`ir.modifier.pushFrameLocalVec3`, `ir.modifier.pushOneFrameVec3`.
+
+Reserve raw `push(..., ticksRemaining)` for callers that genuinely need
+custom multi-frame decay (buffs, timed debuffs, cooldowns). For
+anything that should survive exactly one compose cycle, prefer the named
+wrappers — they encode the pipeline position in the API name so future
+writers don't need to read the `MODIFIER_DECAY` header to pick the right
+integer.
+
 ## Existing-pattern audit
 
 The engine already hand-rolls the "base + modulation → effective"

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -168,6 +168,49 @@ inline void pushFrameLocal(
     push(target, field, kind, param, source, 1);
 }
 
+// Direct-reference overloads for tick functions that already hold the
+// component reference from the archetype iterator. Avoids the per-entity
+// getComponentOptional lookup in push(EntityId, ...).
+inline void pushFrameLocal(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    mods.modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, 1});
+}
+
+inline void pushFrameLocal(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    mods.modifiersVec3_.push_back(IRComponents::ModifierVec3{field, kind, param, source, 1});
+}
+
+inline void pushFrameLocal(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec4 param,
+    IREntity::EntityId source
+) {
+    const bool unitQuatIncompatible = kind == IRComponents::TransformKind::ADD ||
+                                      kind == IRComponents::TransformKind::CLAMP_MIN ||
+                                      kind == IRComponents::TransformKind::CLAMP_MAX;
+    IR_ASSERT(
+        !unitQuatIncompatible,
+        "Quat modifier kind: ADD/CLAMP_MIN/CLAMP_MAX are not meaningful on unit "
+        "quaternions; use MULTIPLY for compose, OVERRIDE/SET for replacement."
+    );
+    if (unitQuatIncompatible)
+        return;
+    mods.modifiersQuat_.push_back(IRComponents::ModifierQuat{field, kind, param, source, 1});
+}
+
 // Caller runs OUTSIDE the resolver pipeline (Lua, input handler, command).
 // Modifier survives the next frame's DECAY + compose; the frame after removes
 // it. The extra tick accounts for DECAY running before the first compose.
@@ -189,6 +232,49 @@ inline void pushOneFrame(
     IREntity::EntityId source
 ) {
     push(target, field, kind, param, source, 2);
+}
+
+// Direct-reference overloads for out-of-pipeline callers that already hold
+// the component reference. ticksRemaining=2 accounts for DECAY running before
+// the next frame's compose.
+inline void pushOneFrame(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    mods.modifiers_.push_back(IRComponents::Modifier{field, kind, param, source, 2});
+}
+
+inline void pushOneFrame(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    mods.modifiersVec3_.push_back(IRComponents::ModifierVec3{field, kind, param, source, 2});
+}
+
+inline void pushOneFrame(
+    IRComponents::C_Modifiers &mods,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec4 param,
+    IREntity::EntityId source
+) {
+    const bool unitQuatIncompatible = kind == IRComponents::TransformKind::ADD ||
+                                      kind == IRComponents::TransformKind::CLAMP_MIN ||
+                                      kind == IRComponents::TransformKind::CLAMP_MAX;
+    IR_ASSERT(
+        !unitQuatIncompatible,
+        "Quat modifier kind: ADD/CLAMP_MIN/CLAMP_MAX are not meaningful on unit "
+        "quaternions; use MULTIPLY for compose, OVERRIDE/SET for replacement."
+    );
+    if (unitQuatIncompatible)
+        return;
+    mods.modifiersQuat_.push_back(IRComponents::ModifierQuat{field, kind, param, source, 2});
 }
 
 inline void pushGlobal(

--- a/engine/prefabs/irreden/common/modifier.hpp
+++ b/engine/prefabs/irreden/common/modifier.hpp
@@ -145,6 +145,52 @@ inline void push(
     );
 }
 
+// Caller runs INSIDE the resolver pipeline, after MODIFIER_DECAY in the same
+// UPDATE tick. Modifier survives this frame's compose; next frame's DECAY
+// removes it. Use for system ticks positioned inside the pipeline.
+inline void pushFrameLocal(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    push(target, field, kind, param, source, 1);
+}
+
+inline void pushFrameLocal(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    push(target, field, kind, param, source, 1);
+}
+
+// Caller runs OUTSIDE the resolver pipeline (Lua, input handler, command).
+// Modifier survives the next frame's DECAY + compose; the frame after removes
+// it. The extra tick accounts for DECAY running before the first compose.
+inline void pushOneFrame(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    float param,
+    IREntity::EntityId source
+) {
+    push(target, field, kind, param, source, 2);
+}
+
+inline void pushOneFrame(
+    IREntity::EntityId target,
+    IRComponents::FieldBindingId field,
+    IRComponents::TransformKind kind,
+    IRMath::vec3 param,
+    IREntity::EntityId source
+) {
+    push(target, field, kind, param, source, 2);
+}
+
 inline void pushGlobal(
     IRComponents::FieldBindingId field,
     IRComponents::TransformKind kind,

--- a/engine/prefabs/irreden/common/modifier_lua.hpp
+++ b/engine/prefabs/irreden/common/modifier_lua.hpp
@@ -83,6 +83,16 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
         IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
     };
 
+    modTbl["pushFrameLocal"] = [parseOpts](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOpts(opts);
+        IRPrefab::Modifier::pushFrameLocal(target, o.field_, o.kind_, o.param_, o.source_);
+    };
+
+    modTbl["pushOneFrame"] = [parseOpts](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOpts(opts);
+        IRPrefab::Modifier::pushOneFrame(target, o.field_, o.kind_, o.param_, o.source_);
+    };
+
     // vec3 push paths. `param` accepts an IRMath::vec3 userdata or a {x,y,z} table.
     struct PushOptsVec3 {
         IRComponents::FieldBindingId field_;
@@ -111,6 +121,16 @@ inline void bindModifierNamespace(LuaScript &luaScript) {
     modTbl["pushGlobalVec3"] = [parseOptsVec3](sol::table opts) {
         auto o = parseOptsVec3(opts);
         IRPrefab::Modifier::pushGlobal(o.field_, o.kind_, o.param_, o.source_, o.ticks_);
+    };
+
+    modTbl["pushFrameLocalVec3"] = [parseOptsVec3](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOptsVec3(opts);
+        IRPrefab::Modifier::pushFrameLocal(target, o.field_, o.kind_, o.param_, o.source_);
+    };
+
+    modTbl["pushOneFrameVec3"] = [parseOptsVec3](IREntity::EntityId target, sol::table opts) {
+        auto o = parseOptsVec3(opts);
+        IRPrefab::Modifier::pushOneFrame(target, o.field_, o.kind_, o.param_, o.source_);
     };
 
     // Quat push paths. `param` accepts an IRMath::vec4 userdata or a {x,y,z,w} table.

--- a/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
+++ b/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
@@ -15,6 +15,7 @@
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_system.hpp>
 
+#include <irreden/common/components/component_modifiers.hpp>
 #include <irreden/common/position_modifier_fields.hpp>
 #include <irreden/update/components/component_periodic_idle.hpp>
 

--- a/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
+++ b/engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp
@@ -15,7 +15,6 @@
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_system.hpp>
 
-#include <irreden/common/components/component_modifiers.hpp>
 #include <irreden/common/position_modifier_fields.hpp>
 #include <irreden/update/components/component_periodic_idle.hpp>
 

--- a/test/ecs/modifier_vec3_runtime_test.cpp
+++ b/test/ecs/modifier_vec3_runtime_test.cpp
@@ -6,6 +6,7 @@
 #include <irreden/common/modifier_field_registry.hpp>
 #include <irreden/ir_entity.hpp>
 
+#include <stdexcept>
 #include <vector>
 
 namespace {
@@ -380,6 +381,69 @@ TEST(ModifierDirectRef, PushFrameLocalVec3DoesNotTriggerEntityLookup) {
         mods, kFieldA, TransformKind::ADD, IRMath::vec3(0.0f), IREntity::kNullEntity
     );
     EXPECT_EQ(mods.modifiersVec3_.size(), 1u);
+}
+
+TEST(ModifierDirectRef, PushOneFrameScalarDepositsInScalarVectorWithTicks2) {
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushOneFrame(
+        mods, kFieldA, TransformKind::MULTIPLY, 3.0f, IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiersVec3_.size(), 0u);
+    ASSERT_EQ(mods.modifiers_.size(), 1u);
+    EXPECT_EQ(mods.modifiers_[0].field_, kFieldA);
+    EXPECT_FLOAT_EQ(mods.modifiers_[0].param_, 3.0f);
+    EXPECT_EQ(mods.modifiers_[0].ticksRemaining_, 2);
+}
+
+TEST(ModifierDirectRef, PushFrameLocalQuatDepositsInQuatVectorWithTicks1) {
+    IRComponents::C_Modifiers mods;
+    IRMath::vec4 identity(0.0f, 0.0f, 0.0f, 1.0f);
+    IRPrefab::Modifier::pushFrameLocal(
+        mods, kFieldA, TransformKind::MULTIPLY, identity, IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiers_.size(), 0u);
+    ASSERT_EQ(mods.modifiersVec3_.size(), 0u);
+    ASSERT_EQ(mods.modifiersQuat_.size(), 1u);
+    EXPECT_EQ(mods.modifiersQuat_[0].field_, kFieldA);
+    EXPECT_EQ(mods.modifiersQuat_[0].kind_, TransformKind::MULTIPLY);
+    EXPECT_EQ(mods.modifiersQuat_[0].ticksRemaining_, 1);
+}
+
+TEST(ModifierDirectRef, PushOneFrameQuatDepositsInQuatVectorWithTicks2) {
+    IRComponents::C_Modifiers mods;
+    IRMath::vec4 identity(0.0f, 0.0f, 0.0f, 1.0f);
+    IRPrefab::Modifier::pushOneFrame(
+        mods, kFieldA, TransformKind::MULTIPLY, identity, IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiersQuat_.size(), 1u);
+    EXPECT_EQ(mods.modifiersQuat_[0].field_, kFieldA);
+    EXPECT_EQ(mods.modifiersQuat_[0].kind_, TransformKind::MULTIPLY);
+    EXPECT_EQ(mods.modifiersQuat_[0].ticksRemaining_, 2);
+}
+
+TEST(ModifierDirectRef, PushFrameLocalQuatAddKindFiresAssertAndNoOps) {
+    IRComponents::C_Modifiers mods;
+    IRMath::vec4 identity(0.0f, 0.0f, 0.0f, 1.0f);
+    EXPECT_THROW(
+        IRPrefab::Modifier::pushFrameLocal(
+            mods, kFieldA, TransformKind::ADD, identity, IREntity::kNullEntity),
+        std::runtime_error
+    );
+    EXPECT_EQ(mods.modifiersQuat_.size(), 0u);
+}
+
+TEST(ModifierDirectRef, PushOneFrameQuatClampMinKindFiresAssertAndNoOps) {
+    IRComponents::C_Modifiers mods;
+    IRMath::vec4 identity(0.0f, 0.0f, 0.0f, 1.0f);
+    EXPECT_THROW(
+        IRPrefab::Modifier::pushOneFrame(
+            mods, kFieldA, TransformKind::CLAMP_MIN, identity, IREntity::kNullEntity),
+        std::runtime_error
+    );
+    EXPECT_EQ(mods.modifiersQuat_.size(), 0u);
 }
 
 // ---- Push API: type-mismatch dispatch ------------------------------------

--- a/test/ecs/modifier_vec3_runtime_test.cpp
+++ b/test/ecs/modifier_vec3_runtime_test.cpp
@@ -326,6 +326,62 @@ TEST(ModifierVec3Decay, SixtyTickModifierExpiresAtSixty) {
     EXPECT_EQ(mods.size(), 0u);
 }
 
+// ---- Direct-reference overloads (C_Modifiers&) ----------------------------
+
+TEST(ModifierDirectRef, PushFrameLocalVec3DepositsInVec3VectorWithTicks1) {
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushFrameLocal(
+        mods,
+        kFieldA,
+        TransformKind::ADD,
+        IRMath::vec3(1.0f, 2.0f, 3.0f),
+        IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiers_.size(), 0u);
+    ASSERT_EQ(mods.modifiersVec3_.size(), 1u);
+    EXPECT_EQ(mods.modifiersVec3_[0].field_, kFieldA);
+    EXPECT_EQ(mods.modifiersVec3_[0].kind_, TransformKind::ADD);
+    EXPECT_FLOAT_EQ(mods.modifiersVec3_[0].param_.x, 1.0f);
+    EXPECT_FLOAT_EQ(mods.modifiersVec3_[0].param_.y, 2.0f);
+    EXPECT_FLOAT_EQ(mods.modifiersVec3_[0].param_.z, 3.0f);
+    EXPECT_EQ(mods.modifiersVec3_[0].ticksRemaining_, 1);
+}
+
+TEST(ModifierDirectRef, PushFrameLocalScalarDepositsInScalarVectorWithTicks1) {
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushFrameLocal(
+        mods, kFieldA, TransformKind::MULTIPLY, 2.5f, IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiersVec3_.size(), 0u);
+    ASSERT_EQ(mods.modifiers_.size(), 1u);
+    EXPECT_EQ(mods.modifiers_[0].field_, kFieldA);
+    EXPECT_FLOAT_EQ(mods.modifiers_[0].param_, 2.5f);
+    EXPECT_EQ(mods.modifiers_[0].ticksRemaining_, 1);
+}
+
+TEST(ModifierDirectRef, PushOneFrameVec3DepositsWithTicks2) {
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushOneFrame(
+        mods, kFieldA, TransformKind::ADD, IRMath::vec3(4.0f), IREntity::kNullEntity
+    );
+
+    ASSERT_EQ(mods.modifiersVec3_.size(), 1u);
+    EXPECT_EQ(mods.modifiersVec3_[0].ticksRemaining_, 2);
+}
+
+TEST(ModifierDirectRef, PushFrameLocalVec3DoesNotTriggerEntityLookup) {
+    // Verify the direct-reference overload compiles and runs without an entity
+    // or an entity manager in scope — confirming no getComponentOptional path
+    // is taken.
+    IRComponents::C_Modifiers mods;
+    IRPrefab::Modifier::pushFrameLocal(
+        mods, kFieldA, TransformKind::ADD, IRMath::vec3(0.0f), IREntity::kNullEntity
+    );
+    EXPECT_EQ(mods.modifiersVec3_.size(), 1u);
+}
+
 // ---- Push API: type-mismatch dispatch ------------------------------------
 
 class IRModifierVec3PushTest : public testing::Test {


### PR DESCRIPTION
## Summary
- Adds `pushFrameLocal` / `pushOneFrame` named wrappers to `IRPrefab::Modifier::` encoding pipeline-position semantics (replaces raw `ticksRemaining=1`/`2` magic numbers)
- Provides `C_Modifiers&` direct-reference overloads for in-tick callers that already hold the archetype-iterated component — no `getComponentOptional` on the hot path
- Exposes `ir.modifier.pushFrameLocal` / `ir.modifier.pushOneFrame` (scalar and vec3 variants) in Lua bindings
- Adds 4 `ModifierDirectRef` tests; 136 modifier tests pass total

## Conflict resolution note
This PR replaces #781 (same task, same diff content). PR #781 had a semantic conflict with T-208 (#776): both migrated `system_periodic_idle_position_offset.hpp` but using different APIs (`upsertBySourceInPlace` from T-208 vs `pushFrameLocal` from T-209). The resolution: **T-208 wins at the PERIODIC_IDLE call site** (`upsertBySourceInPlace` is strictly the better optimization for that use case). T-209's `pushFrameLocal` / `pushOneFrame` API ships in `modifier.hpp` for general use (Lua callers, future transient writers, any site where slot-reuse doesn't fit). Force-push to the original branch is blocked by the harness (issue #783); this rebased branch is the workaround.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` — clean build
- [x] 136 modifier tests pass (including `ModifierDirectRef` suite added in this PR)
- `system_periodic_idle_position_offset.hpp` unchanged from master — T-208's `upsertBySourceInPlace` preserved at that call site

Closes #759