### PR TITLE
T-201: split LodLevel header + migrate component_shape_descriptor IRRender:: aliases

### DIFF
--- a/engine/prefabs/irreden/voxel/components/component_shape_descriptor.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_shape_descriptor.hpp
@@ -2,8 +2,9 @@
 #define COMPONENT_SHAPE_DESCRIPTOR_H
 
 #include <irreden/ir_math.hpp>
+#include <irreden/math/sdf.hpp>
 #include <irreden/render/active_canvas.hpp>
-#include <irreden/render/ir_render_types.hpp>
+#include <irreden/render/lod_level.hpp>
 
 using namespace IRMath;
 
@@ -13,7 +14,7 @@ namespace IRComponents {
 // shape's SDF directly -- no per-voxel allocation, no dirty tracking.
 // Rendered by SHAPES_TO_TRIXEL (two-pass distance + color/entityID).
 //
-// flags_ values (see ShapeFlags in ir_render_types.hpp):
+// flags_ values (see ShapeFlags in IRMath::SDF):
 //   SHAPE_FLAG_VISIBLE           - shape is rendered (default on)
 //   SHAPE_FLAG_HOLLOW            - only render the shell of the SDF
 //   SHAPE_FLAG_MIRROR_X/Y        - mirror the shape along an axis
@@ -30,17 +31,17 @@ namespace IRComponents {
 // where lodMin_ < activeLod (CPU-side, pre-GPU staging). See
 // docs/design/lod-strategy.md and engine/prefabs/irreden/render/lod_utils.hpp.
 struct C_ShapeDescriptor {
-    IRRender::ShapeType shapeType_ = IRRender::ShapeType::BOX;
+    IRMath::SDF::ShapeType shapeType_ = IRMath::SDF::ShapeType::BOX;
     vec4 params_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
     Color color_ = Color{255, 255, 255, 255};
-    std::uint32_t flags_ = IRRender::SHAPE_FLAG_VISIBLE;
+    std::uint32_t flags_ = IRMath::SDF::SHAPE_FLAG_VISIBLE;
     IRRender::LodLevel lodMin_ = IRRender::LodLevel::LOD_4;
     IREntity::EntityId canvasEntity_ = IREntity::kNullEntity;
 
     C_ShapeDescriptor()
         : canvasEntity_{IRRender::getActiveCanvasEntityOrNull()} {}
 
-    C_ShapeDescriptor(IRRender::ShapeType type, vec4 params, Color color)
+    C_ShapeDescriptor(IRMath::SDF::ShapeType type, vec4 params, Color color)
         : shapeType_{type}
         , params_{params}
         , color_{color}

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -167,11 +167,6 @@ enum class FitMode { FIT, STRETCH, UNKNOWN };
 /// @note Currently global (per-frame). Per-entity subdivision modes are future work.
 enum class SubdivisionMode { NONE = 0, POSITION_ONLY = 1, FULL = 2 };
 
-// LodLevel moved to its own header (irreden/render/lod_level.hpp) so
-// header-only ECS components can pick up the tier enum without pulling
-// the full ir_render_types.hpp surface. Still in namespace IRRender for
-// backward compat with existing IRRender::LodLevel call sites.
-
 struct GPUEntityTransform {
     vec4 worldPosition;
     std::uint32_t poolOffset;

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -4,6 +4,7 @@
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_constants.hpp>
 #include <irreden/math/sdf.hpp>
+#include <irreden/render/lod_level.hpp>
 
 #include <cstdint>
 
@@ -165,7 +166,11 @@ enum class FitMode { FIT, STRETCH, UNKNOWN };
 ///   SMOOTH mode. Changing mode or subdivisions mid-frame stalls the pipeline.
 /// @note Currently global (per-frame). Per-entity subdivision modes are future work.
 enum class SubdivisionMode { NONE = 0, POSITION_ONLY = 1, FULL = 2 };
-enum class LodLevel : std::uint32_t { LOD_0 = 0, LOD_1 = 1, LOD_2 = 2, LOD_3 = 3, LOD_4 = 4 };
+
+// LodLevel moved to its own header (irreden/render/lod_level.hpp) so
+// header-only ECS components can pick up the tier enum without pulling
+// the full ir_render_types.hpp surface. Still in namespace IRRender for
+// backward compat with existing IRRender::LodLevel call sites.
 
 struct GPUEntityTransform {
     vec4 worldPosition;

--- a/engine/render/include/irreden/render/lod_level.hpp
+++ b/engine/render/include/irreden/render/lod_level.hpp
@@ -1,0 +1,27 @@
+#ifndef IRREDEN_RENDER_LOD_LEVEL_H
+#define IRREDEN_RENDER_LOD_LEVEL_H
+
+#include <cstdint>
+
+namespace IRRender {
+
+// LOD tier index. Goes DOWN as detail goes UP: LOD_0 is highest-detail
+// (close zoom), LOD_4 is the coarsest silhouette tier (always drawn).
+// SHAPES_TO_TRIXEL filters C_ShapeDescriptor against the active tier
+// (see engine/prefabs/irreden/render/lod_utils.hpp).
+//
+// Split out of ir_render_types.hpp so consumers (component_shape_descriptor,
+// component_active_lod_level) that only need the enum can pick it up
+// without pulling the umbrella render types header. Mirrors the active_canvas
+// split (T-205) — see #739.
+enum class LodLevel : std::uint32_t {
+    LOD_0 = 0,
+    LOD_1 = 1,
+    LOD_2 = 2,
+    LOD_3 = 3,
+    LOD_4 = 4,
+};
+
+} // namespace IRRender
+
+#endif /* IRREDEN_RENDER_LOD_LEVEL_H */

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -28,10 +28,12 @@ target_link_libraries(
     IrredenEngineEntity
     IrredenEngineSystem
     IrredenEngineAsset
-    # Required: prefab_api.cpp uses IRRender::ShapeType (via
-    # ir_render_types.hpp) and IRRender::getActiveCanvasEntityOrNull (via
-    # render/active_canvas.hpp) through component_{shape_descriptor,voxel_set}.hpp.
-    # See #739 for the layering fix; #753 (T-205) moved the snapshot to its own header.
+    # Required: component_voxel_set.hpp still pulls in <irreden/ir_render.hpp>
+    # for IRRender::allocateVoxels / deallocateVoxels and active_canvas.hpp
+    # for IRRender::getActiveCanvasEntityOrNull. ShapeType + SHAPE_FLAG_* are
+    # already render-neutral (IRMath::SDF) so they no longer drag IRRender in.
+    # See #739 for the layering fix; T-205 (#772) split active_canvas.hpp;
+    # T-206 (re-landing) will split the voxel pool API.
     IrredenEngineRendering
     # T-193 PR 2: lua_command_bindings.hpp exposes IRCommand on the Lua
     # surface, so the public scripting interface needs the IRCommand
@@ -39,8 +41,8 @@ target_link_libraries(
     IrredenEngineCommand
 )
 # PRIVATE so render headers don't leak through script's PUBLIC interface
-# (T-188 layering rule). prefab_api.cpp uses IRRender::ShapeType via
-# C_ShapeDescriptor when attaching SHAPES voxel_ref records.
+# (T-188 layering rule). component_voxel_set.hpp drags IRRender symbols
+# in transitively until the T-206 voxel-pool API split re-lands on master.
 target_link_libraries(
     IrredenEngineScripting PRIVATE
     IrredenEngineRendering

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -5,7 +5,7 @@
 #include <irreden/common/components/component_position_3d.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_profile.hpp>
-#include <irreden/ir_render.hpp>
+#include <irreden/math/sdf.hpp>
 #include <irreden/script/ir_script_types.hpp>
 #include <irreden/script/lua_script.hpp>
 #include <irreden/voxel/components/component_bind_points.hpp>
@@ -235,7 +235,7 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
         spawnedChildren.reserve(loadedVoxels->shapeRecords_.size());
         for (const auto &record : loadedVoxels->shapeRecords_) {
             IRComponents::C_ShapeDescriptor descriptor{
-                static_cast<IRRender::ShapeType>(record.shapeTypeId_),
+                static_cast<IRMath::SDF::ShapeType>(record.shapeTypeId_),
                 record.params_,
                 record.color_
             };


### PR DESCRIPTION
## Summary

T-201 step toward dropping `IrredenEngineRendering` from `engine/script/`'s link list. This PR:

- Splits `IRRender::LodLevel` into its own slim header `engine/render/include/irreden/render/lod_level.hpp` so consumers (like `C_ShapeDescriptor`) can pick it up without dragging in the umbrella `ir_render_types.hpp` (which transitively pulls more render-side surface).
- Migrates `component_shape_descriptor.hpp` to use `IRMath::SDF::ShapeType` and `IRMath::SDF::SHAPE_FLAG_VISIBLE` directly (these aliases were renamed in PR #752 / T-201 step 1).
- Drops the direct `#include <irreden/ir_render.hpp>` from `engine/script/src/prefab_api.cpp` (only used `IRRender::ShapeType`, now via `IRMath::SDF::`).
- Keeps `IRRender::*` namespace aliases for backward compatibility — no creation-side changes needed.

The script library still links `IrredenEngineRendering` for `active_canvas.hpp` (T-205 partial split) and the voxel-pool API (T-206 hasn't fully landed on master); those are tracked separately by issue #739's design steps.

Work in progress.

Closes #739