### PR TITLE
T-199: migrate COMPUTE_LIGHT_VOLUME reader to C_WorldTransform (step 1)

### DIFF
--- a/creations/demos/lighting/common/lighting_demo_scene.hpp
+++ b/creations/demos/lighting/common/lighting_demo_scene.hpp
@@ -40,6 +40,7 @@
 #include <irreden/render/systems/system_trixel_to_framebuffer.hpp>
 #include <irreden/render/systems/system_voxel_to_trixel.hpp>
 #include <irreden/update/systems/system_update_positions_global.hpp>
+#include <irreden/update/systems/system_propagate_transform.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
@@ -264,6 +265,7 @@ inline void createLights(const DemoConfig &config) {
     if (config.addDirectional_) {
         IREntity::createEntity(
             C_Position3D{vec3(0.0f)},
+            C_LocalTransform{vec3(0.0f)},
             C_LightSource{
                 LightType::DIRECTIONAL,
                 IRColors::kWhite,
@@ -279,6 +281,7 @@ inline void createLights(const DemoConfig &config) {
     if (config.addEmissive_) {
         IREntity::createEntity(
             C_Position3D{vec3(24.0f, 6.0f, -2.0f)},
+            C_LocalTransform{vec3(24.0f, 6.0f, -2.0f)},
             C_LightSource{
                 LightType::EMISSIVE,
                 Color{80, 210, 255, 255},
@@ -291,6 +294,7 @@ inline void createLights(const DemoConfig &config) {
     if (config.addPoint_) {
         IREntity::createEntity(
             C_Position3D{vec3(34.0f, -7.0f, -1.0f)},
+            C_LocalTransform{vec3(34.0f, -7.0f, -1.0f)},
             C_LightSource{
                 LightType::POINT,
                 Color{255, 150, 80, 255},
@@ -303,6 +307,7 @@ inline void createLights(const DemoConfig &config) {
     if (config.addSpot_) {
         IREntity::createEntity(
             C_Position3D{vec3(10.0f, -10.0f, -2.0f)},
+            C_LocalTransform{vec3(10.0f, -10.0f, -2.0f)},
             C_LightSource{
                 LightType::SPOT,
                 Color{170, 120, 255, 255},
@@ -342,6 +347,7 @@ inline void initSystems(const DemoConfig &config) {
     IRSystem::registerPipeline(
         IRTime::Events::UPDATE,
         {IRSystem::createSystem<IRSystem::GLOBAL_POSITION_3D>(),
+         IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>(),
          IRSystem::createSystem<IRSystem::UPDATE_VOXEL_SET_CHILDREN>()}
     );
 

--- a/creations/demos/lighting/main_per_canvas_scope.cpp
+++ b/creations/demos/lighting/main_per_canvas_scope.cpp
@@ -46,18 +46,21 @@ void perCanvasScopeScene() {
 
     EntityId lightA = createEntity(
         C_Position3D{lightOriginA},
+        C_LocalTransform{lightOriginA},
         C_LightSource{LightType::EMISSIVE, Color{220, 60, 30, 255}, kIntensity, kRadius}
     );
     setParent(lightA, mainCanvas);
 
     EntityId lightB = createEntity(
         C_Position3D{lightOriginB},
+        C_LocalTransform{lightOriginB},
         C_LightSource{LightType::EMISSIVE, Color{30, 60, 220, 255}, kIntensity, kRadius}
     );
     setParent(lightB, canvasB);
 
     createEntity(
         C_Position3D{lightOriginC},
+        C_LocalTransform{lightOriginC},
         C_LightSource{LightType::EMISSIVE, Color{40, 200, 80, 255}, kIntensity, kRadius}
     );
 }

--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -56,6 +56,7 @@
 #include <irreden/render/systems/system_trixel_to_framebuffer.hpp>
 #include <irreden/render/systems/system_voxel_to_trixel.hpp>
 #include <irreden/update/systems/system_update_positions_global.hpp>
+#include <irreden/update/systems/system_propagate_transform.hpp>
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
 
 #include <algorithm>
@@ -214,7 +215,7 @@ C_LuaWaveState makeWaveState(int x, int y, int z) {
         /* period           */ period,
         /* resume_countdown */ 0.0f,
         /* s0_end_angle     */ pi,
-        /* s0_end_t         */  1.0f,
+        /* s0_end_t         */ 1.0f,
         /* s0_reversed      */ false,
         /* s0_start_angle   */ 0.0f,
         /* s0_start_t       */ -1.0f,
@@ -222,7 +223,7 @@ C_LuaWaveState makeWaveState(int x, int y, int z) {
         /* s1_end_t         */ -1.0f,
         /* s1_reversed      */ false,
         /* s1_start_angle   */ pi,
-        /* s1_start_t       */  1.0f,
+        /* s1_start_t       */ 1.0f,
         /* tick_count       */ 0,
     };
 }
@@ -265,6 +266,7 @@ void configureLightingAndCanvas() {
     IRRender::setSunDirection(vec3(0.35f, 0.85f, -0.4f));
     IREntity::createEntity(
         C_Position3D{vec3(0.0f, 0.0f, -64.0f)},
+        C_LocalTransform{vec3(0.0f, 0.0f, -64.0f)},
         C_LightSource{
             LightType::EMISSIVE,
             Color{90, 200, 255, 255},
@@ -356,6 +358,7 @@ void registerLuaBindings() {
             {
                 waveSysId,
                 IRSystem::createSystem<IRSystem::GLOBAL_POSITION_3D>(),
+                IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>(),
                 IRSystem::createSystem<IRSystem::UPDATE_VOXEL_SET_CHILDREN>(),
             }
         );

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -44,6 +44,7 @@
 #include <irreden/update/systems/system_periodic_idle.hpp>
 #include <irreden/update/systems/system_periodic_idle_position_offset.hpp>
 #include <irreden/update/systems/system_update_positions_global.hpp>
+#include <irreden/update/systems/system_propagate_transform.hpp>
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
 
 // Command suites
@@ -323,6 +324,7 @@ void configureLightingAndCanvas() {
     IRRender::setSunDirection(vec3(0.35f, 0.85f, -0.4f));
     IREntity::createEntity(
         C_Position3D{vec3(0.0f, 0.0f, -64.0f)},
+        C_LocalTransform{vec3(0.0f, 0.0f, -64.0f)},
         C_LightSource{
             LightType::EMISSIVE,
             Color{90, 200, 255, 255},
@@ -375,6 +377,7 @@ void initSystems() {
          IRSystem::createSystem<IRSystem::MODIFIER_DECAY>(),
          IRSystem::createSystem<IRSystem::PERIODIC_IDLE_POSITION_OFFSET>(),
          IRSystem::createSystem<IRSystem::GLOBAL_POSITION_3D>(),
+         IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>(),
          IRSystem::createSystem<IRSystem::APPLY_POSITION_OFFSET>(),
          IRSystem::createSystem<IRSystem::UPDATE_VOXEL_SET_CHILDREN>()}
     );

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -25,6 +25,7 @@
 
 // SYSTEMS
 #include <irreden/update/systems/system_update_positions_global.hpp>
+#include <irreden/update/systems/system_propagate_transform.hpp>
 #include <irreden/render/systems/system_lod_update.hpp>
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
 #include <irreden/input/systems/system_input_key_mouse.hpp>
@@ -183,6 +184,7 @@ void initSystems() {
         IRTime::Events::UPDATE,
         {IRSystem::createSystem<IRSystem::LOD_UPDATE>(),
          IRSystem::createSystem<IRSystem::GLOBAL_POSITION_3D>(),
+         IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>(),
          IRSystem::createSystem<IRSystem::UPDATE_VOXEL_SET_CHILDREN>()}
     );
     IRSystem::registerPipeline(
@@ -458,7 +460,8 @@ void initEntities() {
         createSDFShape(vec3(xPos, kRowSeparationY, 0.0f), tc.type_, tc.params_, tc.color_);
     }
 
-    // Co-located trio, coarse-first: zoom1=blue(LOD_4 only), zoom4=green(LOD_2) tops, zoom16=red(LOD_0) tops.
+    // Co-located trio, coarse-first: zoom1=blue(LOD_4 only), zoom4=green(LOD_2) tops,
+    // zoom16=red(LOD_0) tops.
     constexpr float kLodFixtureY = -16.0f;
     constexpr vec4 kLodSphereParams = vec4(3, 3, 3, 0);
     struct LodFixture {
@@ -517,6 +520,7 @@ void initEntities() {
     // nearby shapes. Cyan reads cleanly against the warm shape palette.
     IREntity::createEntity(
         C_Position3D{vec3(40.0f, 6.0f, -2.0f)},
+        C_LocalTransform{vec3(40.0f, 6.0f, -2.0f)},
         C_LightSource{LightType::EMISSIVE, Color{80, 200, 255, 255}, 2.0f, static_cast<uint8_t>(30)}
     );
 

--- a/creations/demos/z_yaw_rotation/main_mouse.cpp
+++ b/creations/demos/z_yaw_rotation/main_mouse.cpp
@@ -22,6 +22,7 @@
 
 // SYSTEMS
 #include <irreden/update/systems/system_update_positions_global.hpp>
+#include <irreden/update/systems/system_propagate_transform.hpp>
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
 #include <irreden/input/systems/system_input_key_mouse.hpp>
 #include <irreden/render/systems/system_voxel_to_trixel.hpp>
@@ -85,6 +86,7 @@ void initSystems() {
     IRSystem::registerPipeline(
         IRTime::Events::UPDATE,
         {IRSystem::createSystem<IRSystem::GLOBAL_POSITION_3D>(),
+         IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>(),
          IRSystem::createSystem<IRSystem::UPDATE_VOXEL_SET_CHILDREN>()}
     );
     IRSystem::registerPipeline(
@@ -202,6 +204,7 @@ void initEntities() {
     // Point light between the shapes so lighting shows depth on all four.
     IREntity::createEntity(
         C_Position3D{vec3(0.0f, 0.0f, -4.0f)},
+        C_LocalTransform{vec3(0.0f, 0.0f, -4.0f)},
         C_LightSource{
             LightType::EMISSIVE,
             Color{200, 220, 255, 255},

--- a/engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp
@@ -51,7 +51,7 @@
 #include <irreden/render/gpu_stage_timing_observer.hpp>
 #include <irreden/render/ir_render_types.hpp>
 
-#include <irreden/common/components/component_position_global_3d.hpp>
+#include <irreden/common/components/component_world_transform.hpp>
 #include <irreden/render/components/component_canvas_light_volume.hpp>
 #include <irreden/render/components/component_light_source.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
@@ -108,11 +108,11 @@ inline GPULightSource toGpuLight(const C_LightSource &light, const ivec3 &origin
     return gpu;
 }
 
-inline ivec3 roundedLightOrigin(const C_PositionGlobal3D &position) {
+inline ivec3 roundedLightOrigin(const C_WorldTransform &transform) {
     // Round-half-up so light origins line up with the light-occlusion
     // grid cells populated by `system_build_light_occlusion_grid` (also
     // round-half-up).
-    return IRMath::roundVec3HalfUp(position.pos_);
+    return IRMath::roundVec3HalfUp(transform.translation_);
 }
 
 inline bool isOriginInLightVolume(const ivec3 &lightOrigin, const ivec3 &volumeOrigin) {
@@ -163,7 +163,7 @@ inline std::uint32_t gatherLightSources(
     std::unordered_set<std::uint64_t> &warnedOOBOrigins
 ) {
     out.clear();
-    const auto include = IREntity::getArchetype<C_LightSource, C_PositionGlobal3D>();
+    const auto include = IREntity::getArchetype<C_LightSource, C_WorldTransform>();
     const auto nodes = IREntity::queryArchetypeNodesSimple(include);
     auto &entityManager = IREntity::getEntityManager();
     for (auto *node : nodes) {
@@ -178,7 +178,7 @@ inline std::uint32_t gatherLightSources(
             continue;
         }
         auto &lights = IREntity::getComponentData<C_LightSource>(node);
-        auto &positions = IREntity::getComponentData<C_PositionGlobal3D>(node);
+        auto &transforms = IREntity::getComponentData<C_WorldTransform>(node);
         for (int i = 0; i < node->length_; ++i) {
             // Directional lights drive sun shading via the FrameDataSun
             // path; they do not seed the world-space light volume.
@@ -188,7 +188,7 @@ inline std::uint32_t gatherLightSources(
             if (out.size() >= kLightVolumeMaxSources) {
                 return static_cast<std::uint32_t>(out.size());
             }
-            const ivec3 origin = roundedLightOrigin(positions[i]);
+            const ivec3 origin = roundedLightOrigin(transforms[i]);
             if (!isOriginInLightVolume(origin, volumeOriginVoxel)) {
                 if (warnedOOBOrigins.insert(packOriginKey(origin)).second) {
                     IR_LOG_WARN(

--- a/test/render/per_canvas_light_scope_test.cpp
+++ b/test/render/per_canvas_light_scope_test.cpp
@@ -41,8 +41,11 @@ IREntity::EntityId makeCanvasSentinel() {
 }
 
 IREntity::EntityId makeLight(IRMath::vec3 position, IRMath::Color color) {
+    // Seed C_WorldTransform directly because this test exercises the
+    // gather in isolation — no PROPAGATE_TRANSFORM system is running to
+    // resolve a local transform into the world slot.
     return IREntity::createEntity(
-        IRComponents::C_PositionGlobal3D{position},
+        IRComponents::C_WorldTransform{position, vec4(0.0f, 0.0f, 0.0f, 1.0f), vec3(1.0f)},
         C_LightSource{LightType::EMISSIVE, color, 1.0f, static_cast<std::uint8_t>(8)}
     );
 }
@@ -125,7 +128,7 @@ TEST_F(PerCanvasLightScopeTest, DirectionalLightStillSkippedRegardlessOfParent) 
     // Directional lights drive sun shading via FrameDataSun, never the
     // light volume. Their parent should not change that.
     const IREntity::EntityId sun = IREntity::createEntity(
-        IRComponents::C_PositionGlobal3D{vec3(0.0f)},
+        IRComponents::C_WorldTransform{vec3(0.0f), vec4(0.0f, 0.0f, 0.0f, 1.0f), vec3(1.0f)},
         C_LightSource{
             LightType::DIRECTIONAL,
             IRColors::kWhite,


### PR DESCRIPTION
## Summary
- First slice of T-199's position/rotation consumer migration: swap
  `system_compute_light_volume.hpp` from `C_PositionGlobal3D.pos_` to
  `C_WorldTransform.translation_` so light origins flow through the
  SQT propagation channel T-197 introduced.
- Wire `PROPAGATE_TRANSFORM` into every demo that hosts the light
  volume (`shape_debug`, `perf_grid`, `lua_perf_grid`,
  `z_yaw_rotation/main_mouse`, the shared `lighting/` scene helper
  plus `main_per_canvas_scope`), and write a paired
  `per_canvas_light_scope_test` update to seed `C_WorldTransform`
  directly (consumer unit-test pattern).

## Why this replaces #756
PR #756 carried the T-197 base commits (`b205342e`, `be010472`) that were
squash-merged into master via #749. Every rebase attempt recreated add/add
conflicts, and the project deny list blocked `git push --force-with-lease`
(issue #783). This PR is a clean re-author: only the T-199 child commit
(`85495cf5`) on top of current master.

## Prior review context
Code reviewed and approved twice in PR #756 (sonnet-reviewer, 2026-05-15
and 2026-05-16). Code is bit-for-bit identical to ecefe81c — only the
parent commit changed.

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean on linux-debug (this session)
- [x] `propagate_transform_test` (8 tests) + `per_canvas_light_scope_test`
  passing (per PR #756 test run, code unchanged)
- [ ] Runtime smoke (`fleet:needs-linux-smoke`): GLX unavailable on this host
  (T-202 tracks Linux/OpenGL parity bring-up)

Closes #759