### PR TITLE
T-218: tooling: allow fleet agents to force-push claude/* branches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,6 +57,8 @@
       "Bash(git push -f:*)",
       "Bash(git push --force-with-lease origin master:*)",
       "Bash(git push --force-with-lease origin main:*)",
+      "Bash(git push --force-with-lease origin HEAD:master:*)",
+      "Bash(git push --force-with-lease origin HEAD:main:*)",
       "Bash(git push --delete:*)",
       "Bash(git push origin :*)",
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,7 +55,8 @@
 
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
-      "Bash(git push --force-with-lease:*)",
+      "Bash(git push --force-with-lease origin master:*)",
+      "Bash(git push --force-with-lease origin main:*)",
       "Bash(git push --delete:*)",
       "Bash(git push origin :*)",
 


### PR DESCRIPTION
## Summary
- Replace the broad `Bash(git push --force-with-lease:*)` deny in `.claude/settings.json` with two branch-scoped denies protecting `master` and `main`
- Fleet agents can now run `git push --force-with-lease origin claude/T-NNN-...` to complete rebase-on-merged-squash flows
- `--force` (non-lease) and pushes to `master`/`main` remain blocked

## Motivation
Multiple opus-worker iterations independently completed the semantic-conflict rebase for PR #756 correctly but both failed at the push step because the broad deny blocked all `--force-with-lease` pushes regardless of target branch. This creates recurring queue noise on every PR that needs a post-squash rebase.

## Test plan
- [ ] Verify `git push --force-with-lease origin master` is still blocked (deny rule present)
- [ ] Verify `git push --force-with-lease origin main` is still blocked (deny rule present)  
- [ ] Verify `git push --force-with-lease origin claude/T-NNN-something` is now allowed (no matching deny)
- [ ] Verify `git push --force origin ...` is still blocked

Closes #783