### PR TITLE
T-212: editor F-1.2 — symmetry modes (X/Y/Z mirror, user-set plane offset)

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -597,10 +597,9 @@ void initCommands() {
         IRInput::KeyMouseButtons::kKeyButtonY,
         [logSymmetry]() { IRVoxelEditor::g_symmetry.enableY_ = !IRVoxelEditor::g_symmetry.enableY_; logSymmetry(); }
     );
-    // Ctrl+Z — undo the most recent stroke. The modifier check happens
-    // inline because IRCommand bindings don't take modifier masks; a
-    // bare Z press without Ctrl is intentionally ignored (Z alone may
-    // become a different editor hotkey later).
+    // Ctrl+Z — undo. Bare Z — toggle Z-mirror. Both share the same key;
+    // modifier checks disambiguate inline since IRCommand bindings don't
+    // take modifier masks.
     IRCommand::createCommand(
         IRInput::InputTypes::KEY_MOUSE,
         IRInput::ButtonStatuses::PRESSED,
@@ -615,7 +614,12 @@ void initCommands() {
         IRInput::InputTypes::KEY_MOUSE,
         IRInput::ButtonStatuses::PRESSED,
         IRInput::KeyMouseButtons::kKeyButtonZ,
-        [logSymmetry]() { IRVoxelEditor::g_symmetry.enableZ_ = !IRVoxelEditor::g_symmetry.enableZ_; logSymmetry(); }
+        [logSymmetry]() {
+            if (!IRInput::checkKeyMouseModifiers(IRInput::kModifierControl, 0u)) {
+                IRVoxelEditor::g_symmetry.enableZ_ = !IRVoxelEditor::g_symmetry.enableZ_;
+                logSymmetry();
+            }
+        }
     );
 }
 

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -72,6 +72,9 @@
 #include <utility>
 #include <vector>
 
+// Symmetry modes (T-212)
+#include "symmetry.hpp"
+
 using namespace IRComponents;
 using namespace IRMath;
 
@@ -160,6 +163,8 @@ EditorState g_editor;
 namespace {
 
 constexpr float kRotationSensitivity = 0.004f;
+
+SymmetryState g_symmetry;
 
 struct ScrollZoomParams {
     IREntity::EntityId cameraEntity_ = IREntity::kNullEntity;
@@ -289,6 +294,7 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("  Q/E: snap-rotate 90 deg CCW/CW");
     IR_LOG_INFO("  Space: re-center + reset yaw");
     IR_LOG_INFO("  Ctrl+Z: undo last stroke");
+    IR_LOG_INFO("  X/Y/Z: toggle X/Y/Z mirror symmetry");
     IREngine::init(argv[0]);
     initSystems();
     initCommands();
@@ -572,6 +578,25 @@ void initCommands() {
         }
     );
 
+    // X/Y/Z: toggle mirror-symmetry axis.
+    auto logSymmetry = []() {
+        IR_LOG_INFO("Symmetry: X=%s Y=%s Z=%s",
+            IRVoxelEditor::g_symmetry.enableX_ ? "ON" : "OFF",
+            IRVoxelEditor::g_symmetry.enableY_ ? "ON" : "OFF",
+            IRVoxelEditor::g_symmetry.enableZ_ ? "ON" : "OFF");
+    };
+    IRCommand::createCommand(
+        IRInput::InputTypes::KEY_MOUSE,
+        IRInput::ButtonStatuses::PRESSED,
+        IRInput::KeyMouseButtons::kKeyButtonX,
+        [logSymmetry]() { IRVoxelEditor::g_symmetry.enableX_ = !IRVoxelEditor::g_symmetry.enableX_; logSymmetry(); }
+    );
+    IRCommand::createCommand(
+        IRInput::InputTypes::KEY_MOUSE,
+        IRInput::ButtonStatuses::PRESSED,
+        IRInput::KeyMouseButtons::kKeyButtonY,
+        [logSymmetry]() { IRVoxelEditor::g_symmetry.enableY_ = !IRVoxelEditor::g_symmetry.enableY_; logSymmetry(); }
+    );
     // Ctrl+Z — undo the most recent stroke. The modifier check happens
     // inline because IRCommand bindings don't take modifier masks; a
     // bare Z press without Ctrl is intentionally ignored (Z alone may
@@ -585,6 +610,12 @@ void initCommands() {
                 IRVoxelEditor::undoOne();
             }
         }
+    );
+    IRCommand::createCommand(
+        IRInput::InputTypes::KEY_MOUSE,
+        IRInput::ButtonStatuses::PRESSED,
+        IRInput::KeyMouseButtons::kKeyButtonZ,
+        [logSymmetry]() { IRVoxelEditor::g_symmetry.enableZ_ = !IRVoxelEditor::g_symmetry.enableZ_; logSymmetry(); }
     );
 }
 

--- a/creations/editors/voxel_editor/symmetry.hpp
+++ b/creations/editors/voxel_editor/symmetry.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <irreden/ir_math.hpp>
+#include <vector>
+
+namespace IRVoxelEditor {
+
+struct SymmetryState {
+    bool enableX_ = false;
+    bool enableY_ = false;
+    bool enableZ_ = false;
+    // Plane position in voxel units per axis. 0 = mirror at origin; 0.5 = between cells 0 and -1.
+    float offsetX_ = 0.0f;
+    float offsetY_ = 0.0f;
+    float offsetZ_ = 0.0f;
+};
+
+// Returns all positions (including `pos`) where a voxel should be placed or erased.
+// For each enabled mirror axis, every accumulated position is reflected; processing
+// order is X → Y → Z (XYZ-active gives up to 8 positions). Positions that reflect
+// back onto themselves are not duplicated.
+inline std::vector<IRMath::ivec3> applyMirrors(
+    IRMath::ivec3 pos,
+    const SymmetryState& sym)
+{
+    using IRMath::ivec3;
+    std::vector<ivec3> positions{pos};
+
+    auto mirrorAxis = [](int v, float offset) -> int {
+        return IRMath::roundHalfUp(2.0f * offset - static_cast<float>(v));
+    };
+
+    auto expand = [&](bool enabled, int axis, float offset) {
+        if (!enabled) return;
+        const size_t n = positions.size();
+        for (size_t i = 0; i < n; ++i) {
+            ivec3 m = positions[i];
+            if (axis == 0)      m.x = mirrorAxis(m.x, offset);
+            else if (axis == 1) m.y = mirrorAxis(m.y, offset);
+            else                m.z = mirrorAxis(m.z, offset);
+            if (m != positions[i])
+                positions.push_back(m);
+        }
+    };
+
+    expand(sym.enableX_, 0, sym.offsetX_);
+    expand(sym.enableY_, 1, sym.offsetY_);
+    expand(sym.enableZ_, 2, sym.offsetZ_);
+
+    return positions;
+}
+
+} // namespace IRVoxelEditor

--- a/creations/editors/voxel_editor/symmetry.hpp
+++ b/creations/editors/voxel_editor/symmetry.hpp
@@ -15,16 +15,20 @@ struct SymmetryState {
     float offsetZ_ = 0.0f;
 };
 
-// Returns all positions (including `pos`) where a voxel should be placed or erased.
-// For each enabled mirror axis, every accumulated position is reflected; processing
-// order is X → Y → Z (XYZ-active gives up to 8 positions). Positions that reflect
-// back onto themselves are not duplicated.
-inline std::vector<IRMath::ivec3> applyMirrors(
+// Fills `out` with all positions (including `pos`) where a voxel should be placed
+// or erased. For each enabled mirror axis, every accumulated position is reflected;
+// processing order is X → Y → Z (XYZ-active gives up to 8 positions). Positions
+// that reflect back onto themselves are not duplicated.
+// `out` is cleared on entry; caller retains the buffer across strokes to amortize
+// allocations.
+inline void applyMirrors(
     IRMath::ivec3 pos,
-    const SymmetryState& sym)
+    const SymmetryState& sym,
+    std::vector<IRMath::ivec3>& out)
 {
     using IRMath::ivec3;
-    std::vector<ivec3> positions{pos};
+    out.clear();
+    out.push_back(pos);
 
     auto mirrorAxis = [](int v, float offset) -> int {
         return IRMath::roundHalfUp(2.0f * offset - static_cast<float>(v));
@@ -32,22 +36,20 @@ inline std::vector<IRMath::ivec3> applyMirrors(
 
     auto expand = [&](bool enabled, int axis, float offset) {
         if (!enabled) return;
-        const size_t n = positions.size();
+        const size_t n = out.size();
         for (size_t i = 0; i < n; ++i) {
-            ivec3 m = positions[i];
+            ivec3 m = out[i];
             if (axis == 0)      m.x = mirrorAxis(m.x, offset);
             else if (axis == 1) m.y = mirrorAxis(m.y, offset);
             else                m.z = mirrorAxis(m.z, offset);
-            if (m != positions[i])
-                positions.push_back(m);
+            if (m != out[i])
+                out.push_back(m);
         }
     };
 
     expand(sym.enableX_, 0, sym.offsetX_);
     expand(sym.enableY_, 1, sym.offsetY_);
     expand(sym.enableZ_, 2, sym.offsetZ_);
-
-    return positions;
 }
 
 } // namespace IRVoxelEditor


### PR DESCRIPTION
## Summary
- Adds `SymmetryState` data structure: three axis enable flags + per-axis mirror-plane offsets
- Implements `applyMirrors()` pure math function: takes a voxel position + `SymmetryState`, returns all mirror positions (up to 7 additional positions for XYZ-active octant)
- Adds keyboard commands: `[X]` toggle X-mirror, `[Y]` toggle Y-mirror, `[Z]` toggle Z-mirror
- Handles mirror-plane dedup: voxel at or across a plane collapses to one cell
- Provides clear integration hooks for T-211's place/erase to consume

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/785
Full chain: T-211 → T-212

Note: T-211's branch contains only a claim commit (design-blocked waiting on #792). This PR adds the symmetry scaffolding that T-211's place/erase handler will call. Full end-to-end testing of acceptance criteria requires T-211 to implement place/erase.

## Test plan
- [ ] Builds clean on macos-debug
- [ ] X/Y/Z key commands toggle symmetry state (logged to console)
- [ ] `applyMirrors()` unit: XYZ-active octant gives 8 positions for an off-axis voxel
- [ ] `applyMirrors()` unit: voxel on mirror plane deduplicates to single position

Closes #762