### PR TITLE
T-219: extend castVoxelRay to walk C_VoxelSetNew entities

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -9,6 +9,7 @@
 // Components
 #include <irreden/common/components/component_position_3d.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
 #include <irreden/render/components/component_canvas_ao_texture.hpp>
 #include <irreden/render/components/component_canvas_light_volume.hpp>
 #include <irreden/render/components/component_canvas_sun_shadow.hpp>
@@ -309,6 +310,22 @@ void initEntities() {
 
         EntityId ikMarker = IRPrefab::Gizmo::createIKMarker();
         IREntity::getComponent<C_Position3D>(ikMarker).pos_ = vec3(16.0f, -12.0f, -3.0f);
+    }
+
+    // Two small voxel sets to exercise multi-`C_VoxelSetNew` picking
+    // (T-219). Placed left and right of the origin so a click on either
+    // returns the correct owning entity. Voxels are integer-aligned —
+    // left-clicking any visible voxel selects it; the highlight
+    // (created below) snaps to its world center via `selection.voxelPos_`.
+    {
+        IREntity::createEntity(
+            C_Position3D{vec3(-8.0f, 0.0f, -4.0f)},
+            C_VoxelSetNew{ivec3(4, 4, 4), Color{120, 180, 240, 255}}
+        );
+        IREntity::createEntity(
+            C_Position3D{vec3(8.0f, 0.0f, -4.0f)},
+            C_VoxelSetNew{ivec3(4, 4, 4), Color{240, 180, 120, 255}}
+        );
     }
 
     // Selection-highlight entity: a slightly oversized box marker

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -91,7 +91,12 @@ the ECS surface.
 - `VOXEL_PICKING` — editor input driver. On left-click PRESSED, casts a
   ray through the cursor (via `IRPrefab::Picking::castVoxelRay` —
   composes the same screen→world inverse `IRRender::mouseWorldPos3DAtIsoDepth`
-  uses) and walks SDF shapes to find the first hit. Writes
+  uses) and walks both visible `C_ShapeDescriptor` SDF shapes and
+  active voxels of every `C_VoxelSetNew` to find the first hit.
+  Voxel-set hits return the owning entity, the world-aligned voxel
+  coordinate, and a face normal suitable for place-adjacent math
+  (`hit.faceNormal_` — ±1 along the dominant axis of
+  `hit.worldHitPos_ - voxelCenter`). Writes
   `C_VoxelSelection` on the highlight entity and toggles its
   `C_ShapeDescriptor::flags_` visibility. Register after the camera
   systems and before `VOXEL_TO_TRIXEL_STAGE_1` so the highlight

--- a/engine/prefabs/irreden/render/picking.hpp
+++ b/engine/prefabs/irreden/render/picking.hpp
@@ -3,25 +3,35 @@
 
 // Editor-side voxel picking: convert the cursor into a world-space ray
 // (in the engine's isometric projection) and find the first SDF shape
-// it intersects. The picking inverse is the same one used by
-// `IRRender::mouseWorldPos3DAtIsoDepth`, so the recovered world point
-// matches what the voxel rasterizer wrote at any visualYaw.
+// or `C_VoxelSetNew` voxel it intersects. The picking inverse is the
+// same one used by `IRRender::mouseWorldPos3DAtIsoDepth`, so the
+// recovered world point matches what the voxel rasterizer wrote at any
+// visualYaw.
 //
-// Relationship to the GPU trixel/distance infrastructure:
-//   `castVoxelRay` reuses `IRRender::mouseWorldPos3DAtIsoDepth()` — the same
-//   screen→world inverse the GPU pipeline builds into `TRIXEL_TO_FRAMEBUFFER` —
-//   so the picking coordinate system is consistent with the rendered output at any
-//   visualYaw. It does NOT call `IRRender::getEntityIdAtMouseTrixel()`.
+// CPU-side vs GPU-readback picking — pick the right path:
 //
-//   `IRRender::getEntityIdAtMouseTrixel()` is the O(1) GPU alternative: it reads
-//   the entity-id texture written by `VOXEL_TO_TRIXEL_STAGE_2` and
-//   `SHAPES_TO_TRIXEL` (via a persistent-mapped buffer) and returns the frontmost
-//   entity at the cursor pixel in O(1). Its trade-off is a one-frame lag (the
-//   buffer holds the previous frame's render) and it yields the entity only — not
-//   the sub-voxel surface hit position. `castVoxelRay` instead evaluates the SDF at
-//   each depth step to recover the exact surface intersection (needed for sub-voxel
-//   accurate voxel placement), and fires only on click frames so the per-click cost
-//   is proportional to visible shapes × depth range, not per-frame cost.
+//   - **CPU-side (`castVoxelRay`, this file)** — the default for click-
+//     driven editor input. No frame lag: the call returns a hit on the
+//     same frame as the click. Yields the sub-voxel surface intersection
+//     point AND the face normal of the hit (`RayHit::faceNormal_`), so
+//     downstream "place adjacent" math has everything it needs without a
+//     second round-trip. Cost per click is proportional to visible
+//     shapes × depth range PLUS visible `C_VoxelSetNew` entities × depth
+//     range (each set is tested via an inverse-lookup on its grid, NOT
+//     per-voxel — so cost is independent of voxel count per set). Tens
+//     of voxel sets in a scene is fine; scenes with hundreds of
+//     thousands of active voxels distributed across many sets should
+//     prefer the GPU path below.
+//
+//   - **GPU readback (`IRRender::getEntityIdAtMouseTrixel`)** — the O(1)
+//     GPU alternative. Reads the entity-id texture written by
+//     `VOXEL_TO_TRIXEL_STAGE_2` and `SHAPES_TO_TRIXEL` (via a
+//     persistent-mapped buffer) and returns the frontmost entity at the
+//     cursor pixel in O(1). The trade-off is a one-frame lag (the buffer
+//     holds the previous frame's render) and it yields the entity only
+//     — no sub-voxel surface hit position, no face normal. Use when the
+//     scene has many active voxels and per-click CPU cost dominates, or
+//     when only the entity id matters (selection without placement).
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -30,8 +40,11 @@
 #include <irreden/common/components/component_position_global_3d.hpp>
 #include <irreden/render/camera.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
+#include <irreden/voxel/components/component_voxel.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
 
 #include <optional>
+#include <span>
 #include <vector>
 
 namespace IRPrefab::Picking {
@@ -40,6 +53,12 @@ struct RayHit {
     IREntity::EntityId entity_ = IREntity::kNullEntity;
     IRMath::vec3 worldHitPos_ = IRMath::vec3(0.0f);
     IRMath::ivec3 voxelPos_ = IRMath::ivec3(0);
+    // Outward unit normal of the hit face along the dominant axis of
+    // `worldHitPos_ - voxelCenter` (±1 on exactly one axis). Only
+    // meaningful for voxel hits from `C_VoxelSetNew`; left at (0,0,0)
+    // for shape hits (the cube-face convention doesn't carry meaning
+    // for non-box SDF surfaces).
+    IRMath::ivec3 faceNormal_ = IRMath::ivec3(0);
 };
 
 // Step size along the canvas-frame iso depth axis. One iso-depth unit
@@ -61,6 +80,23 @@ struct ShapeSnapshot {
     IRRender::ShapeType type_;
     IRMath::vec4 params_;
     float boundingRadius_;
+    float isoDepthMin_;
+    float isoDepthMax_;
+};
+
+// Snapshot of one `C_VoxelSetNew` entity for the picking walk. Voxel
+// hits are resolved by inverse-lookup against the set's local grid
+// (O(1) per depth step per set) rather than SDF-testing every active
+// voxel — the local-position layout is integer-offset from
+// `worldOrigin_`, so the candidate voxel at any world point is a single
+// `roundVec3HalfUp` away.
+struct VoxelSetSnapshot {
+    IREntity::EntityId entity_;
+    // World position of the voxel at local index (0,0,0). All other
+    // voxels in the set sit at integer offsets from this origin.
+    IRMath::vec3 worldOrigin_;
+    IRMath::ivec3 size_;
+    std::span<const IRComponents::C_Voxel> voxels_;
     float isoDepthMin_;
     float isoDepthMax_;
 };
@@ -106,38 +142,114 @@ gatherVisibleShapes(IRMath::CardinalIndex cardinalIndex, IREntity::EntityId excl
     return snapshot;
 }
 
+inline std::vector<VoxelSetSnapshot>
+gatherVisibleVoxelSets(IRMath::CardinalIndex cardinalIndex, IREntity::EntityId excludeEntity) {
+    std::vector<VoxelSetSnapshot> snapshot;
+    IREntity::forEachComponent<IRComponents::C_VoxelSetNew>([&](IREntity::EntityId id,
+                                                                IRComponents::C_VoxelSetNew &vs) {
+        if (id == excludeEntity)
+            return;
+        // Headless / pre-canvas sets have no pool span yet — they
+        // can't be picked until a future canvas-attach pass moves
+        // staged data into the pool.
+        if (vs.numVoxels_ <= 0)
+            return;
+        if (vs.globalPositions_.empty() || vs.voxels_.empty())
+            return;
+        if (vs.size_.x <= 0 || vs.size_.y <= 0 || vs.size_.z <= 0)
+            return;
+
+        // worldOrigin = global position of local voxel (0,0,0).
+        // Subsequent voxels at local (x,y,z) sit at integer offsets
+        // from this origin in world space (axis-aligned; the engine
+        // currently translates voxel sets but does not rotate
+        // them). UPDATE_VOXEL_SET_CHILDREN has already refreshed
+        // globalPositions_ for this frame.
+        const IRMath::vec3 worldOrigin = vs.globalPositions_[0].pos_;
+        // Voxels at local [0, size-1] occupy world [-0.5, size-0.5],
+        // so the inflated AABB center is `worldOrigin + (size-1)/2`
+        // and the half-extent along each axis is `size/2`. Cardinal
+        // Z rotation permutes axes; the sum of half-extents
+        // (projected onto (1,1,1)) is rotation-invariant, so the
+        // iso-depth bound mirrors the shape-gather formulation.
+        const IRMath::vec3 bboxCenter =
+            worldOrigin + (IRMath::vec3(vs.size_) - IRMath::vec3(1.0f)) * 0.5f;
+        const IRMath::vec3 bboxHalf = IRMath::vec3(vs.size_) * 0.5f;
+        const IRMath::vec3 rotatedCenter = IRMath::rotateCardinalZ(bboxCenter, cardinalIndex);
+        const float center = rotatedCenter.x + rotatedCenter.y + rotatedCenter.z;
+        const float halfRange = bboxHalf.x + bboxHalf.y + bboxHalf.z;
+
+        snapshot.push_back(
+            {id,
+             worldOrigin,
+             vs.size_,
+             std::span<const IRComponents::C_Voxel>(vs.voxels_.data(), vs.voxels_.size()),
+             center - halfRange - kPickingDepthMargin,
+             center + halfRange + kPickingDepthMargin}
+        );
+    });
+    return snapshot;
+}
+
+// Picks the hit-face outward normal for a unit-cube voxel. Returns the
+// axis with the largest |delta| component, signed by that component —
+// "place adjacent" math just adds this normal to `voxelPos_` to land
+// on the cell on the entry side.
+inline IRMath::ivec3 voxelHitFaceNormal(IRMath::vec3 delta) {
+    const IRMath::vec3 absDelta = IRMath::abs(delta);
+    IRMath::ivec3 normal(0);
+    if (absDelta.x >= absDelta.y && absDelta.x >= absDelta.z) {
+        normal.x = delta.x >= 0.0f ? 1 : -1;
+    } else if (absDelta.y >= absDelta.z) {
+        normal.y = delta.y >= 0.0f ? 1 : -1;
+    } else {
+        normal.z = delta.z >= 0.0f ? 1 : -1;
+    }
+    return normal;
+}
+
 } // namespace detail
 
 // Casts a ray from the cursor into the scene and returns the first
-// shape it hits, or std::nullopt if the ray misses everything. The
-// caller passes the editor's highlight entity (or any entity to be
-// skipped) so the highlight itself doesn't catch its own ray.
+// shape or voxel it hits, or std::nullopt if the ray misses
+// everything. The caller passes the editor's highlight entity (or any
+// entity to be skipped) so the highlight itself doesn't catch its own
+// ray.
 //
 // Algorithm: walk along the canvas-frame iso depth axis in
 // `kPickingDepthStep` increments over the union of all visible shape
-// iso-depth ranges. At each step, evaluate every shape's SDF at the
-// recovered world point; the first surface (`SDF::evaluate <=
-// kSurfaceThreshold`) wins. The depth-range pre-filter keeps the
-// per-step cost proportional to the number of shapes whose bounding
-// box overlaps that depth slice, not the total scene shape count.
+// and voxel-set iso-depth ranges. At each step, evaluate (a) every
+// shape's SDF at the recovered world point and (b) for each visible
+// `C_VoxelSetNew`, look up the candidate voxel via inverse-grid
+// indexing — the first surface hit (`SDF::evaluate <=
+// kSurfaceThreshold` for shapes; inside-unit-cube for voxels) wins.
+// The depth-range pre-filter keeps the per-step cost proportional to
+// the count of shapes / sets whose bounding box overlaps that depth
+// slice, not the total scene count.
 inline std::optional<RayHit>
 castVoxelRay(IREntity::EntityId excludeEntity = IREntity::kNullEntity) {
     const auto [rasterYaw, residualYaw] = IRPrefab::Camera::getYawSplit();
     const IRMath::CardinalIndex cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
 
     auto shapes = detail::gatherVisibleShapes(cardinalIndex, excludeEntity);
-    if (shapes.empty())
+    auto voxelSets = detail::gatherVisibleVoxelSets(cardinalIndex, excludeEntity);
+    if (shapes.empty() && voxelSets.empty())
         return std::nullopt;
 
-    float depthMin = shapes[0].isoDepthMin_;
-    float depthMax = shapes[0].isoDepthMax_;
+    float depthMin = shapes.empty() ? voxelSets[0].isoDepthMin_ : shapes[0].isoDepthMin_;
+    float depthMax = shapes.empty() ? voxelSets[0].isoDepthMax_ : shapes[0].isoDepthMax_;
     for (const auto &s : shapes) {
         depthMin = IRMath::min(depthMin, s.isoDepthMin_);
         depthMax = IRMath::max(depthMax, s.isoDepthMax_);
     }
+    for (const auto &vs : voxelSets) {
+        depthMin = IRMath::min(depthMin, vs.isoDepthMin_);
+        depthMax = IRMath::max(depthMax, vs.isoDepthMax_);
+    }
 
     for (float d = depthMin; d <= depthMax; d += kPickingDepthStep) {
         const IRMath::vec3 worldPoint = IRRender::mouseWorldPos3DAtIsoDepth(d);
+
         for (const auto &s : shapes) {
             if (d < s.isoDepthMin_ || d > s.isoDepthMax_)
                 continue;
@@ -148,8 +260,42 @@ castVoxelRay(IREntity::EntityId excludeEntity = IREntity::kNullEntity) {
             const IRMath::vec4 effective = IRMath::SDF::effectiveParams(s.type_, s.params_);
             const float dist = IRMath::SDF::evaluate(localPos, s.type_, effective);
             if (dist <= IRMath::SDF::kSurfaceThreshold) {
-                return RayHit{s.entity_, worldPoint, IRMath::roundVec3HalfUp(worldPoint)};
+                return RayHit{
+                    s.entity_,
+                    worldPoint,
+                    IRMath::roundVec3HalfUp(worldPoint),
+                    IRMath::ivec3(0)
+                };
             }
+        }
+
+        for (const auto &vs : voxelSets) {
+            if (d < vs.isoDepthMin_ || d > vs.isoDepthMax_)
+                continue;
+            const IRMath::ivec3 localInt = IRMath::roundVec3HalfUp(worldPoint - vs.worldOrigin_);
+            if (localInt.x < 0 || localInt.x >= vs.size_.x || localInt.y < 0 ||
+                localInt.y >= vs.size_.y || localInt.z < 0 || localInt.z >= vs.size_.z) {
+                continue;
+            }
+            const IRMath::vec3 candidateCenter = vs.worldOrigin_ + IRMath::vec3(localInt);
+            const IRMath::vec3 delta = worldPoint - candidateCenter;
+            // Inside the unit voxel cube?
+            if (IRMath::SDF::box(delta, IRMath::vec3(0.0f)) > IRMath::SDF::kSurfaceThreshold)
+                continue;
+            const std::size_t flatIdx =
+                static_cast<std::size_t>(IRMath::index3DtoIndex1D(localInt, vs.size_));
+            if (flatIdx >= vs.voxels_.size())
+                continue;
+            // Active = non-zero alpha (matches `C_Voxel::activate` /
+            // `deactivate` and the GPU pipeline's per-voxel skip).
+            if (vs.voxels_[flatIdx].color_.alpha_ == 0)
+                continue;
+            return RayHit{
+                vs.entity_,
+                worldPoint,
+                IRMath::roundVec3HalfUp(candidateCenter),
+                detail::voxelHitFaceNormal(delta)
+            };
         }
     }
 

--- a/engine/prefabs/irreden/render/picking.hpp
+++ b/engine/prefabs/irreden/render/picking.hpp
@@ -280,7 +280,7 @@ castVoxelRay(IREntity::EntityId excludeEntity = IREntity::kNullEntity) {
             const IRMath::vec3 candidateCenter = vs.worldOrigin_ + IRMath::vec3(localInt);
             const IRMath::vec3 delta = worldPoint - candidateCenter;
             // Inside the unit voxel cube?
-            if (IRMath::SDF::box(delta, IRMath::vec3(0.0f)) > IRMath::SDF::kSurfaceThreshold)
+            if (IRMath::SDF::box(delta, IRMath::vec3(0.5f)) > 0.0f)
                 continue;
             const std::size_t flatIdx =
                 static_cast<std::size_t>(IRMath::index3DtoIndex1D(localInt, vs.size_));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(IrredenEngineTest
   render/camera_yaw_test.cpp
   render/frame_data_sun_layout_test.cpp
   render/per_canvas_light_scope_test.cpp
+  render/picking_face_normal_test.cpp
   render/sun_direction_test.cpp
   render/sun_lighting_test.cpp
   render/sprite_animation_test.cpp

--- a/test/render/picking_face_normal_test.cpp
+++ b/test/render/picking_face_normal_test.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include <irreden/render/picking.hpp>
+
+namespace {
+
+using IRPrefab::Picking::detail::voxelHitFaceNormal;
+
+TEST(PickingFaceNormal, PositiveXFace) {
+    EXPECT_EQ(
+        voxelHitFaceNormal(IRMath::vec3(0.4f, 0.1f, -0.2f)),
+        IRMath::ivec3(1, 0, 0)
+    );
+}
+
+TEST(PickingFaceNormal, NegativeXFace) {
+    EXPECT_EQ(
+        voxelHitFaceNormal(IRMath::vec3(-0.45f, 0.0f, 0.1f)),
+        IRMath::ivec3(-1, 0, 0)
+    );
+}
+
+TEST(PickingFaceNormal, PositiveZFace) {
+    EXPECT_EQ(
+        voxelHitFaceNormal(IRMath::vec3(0.1f, -0.2f, 0.4f)),
+        IRMath::ivec3(0, 0, 1)
+    );
+}
+
+TEST(PickingFaceNormal, NegativeYFace) {
+    EXPECT_EQ(
+        voxelHitFaceNormal(IRMath::vec3(0.2f, -0.45f, 0.3f)),
+        IRMath::ivec3(0, -1, 0)
+    );
+}
+
+TEST(PickingFaceNormal, CornerTieBreaksToFirstMaxAxis) {
+    // Tie between x and y at 0.4: x-axis wins by iteration order. Tie
+    // between x and z at 0.4: x wins. Documents the deterministic
+    // tie-break so callers know what to expect at corners.
+    EXPECT_EQ(
+        voxelHitFaceNormal(IRMath::vec3(0.4f, 0.4f, 0.1f)),
+        IRMath::ivec3(1, 0, 0)
+    );
+}
+
+TEST(PickingFaceNormal, ZeroDeltaProducesPositiveXFallback) {
+    // Degenerate input (ray hit exactly the voxel center). Picks +X
+    // deterministically — caller should treat zero-delta as "no
+    // preferred face" if it matters.
+    EXPECT_EQ(
+        voxelHitFaceNormal(IRMath::vec3(0.0f, 0.0f, 0.0f)),
+        IRMath::ivec3(1, 0, 0)
+    );
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Extends `IRPrefab::Picking::castVoxelRay` to walk active voxels of every `C_VoxelSetNew` in addition to `C_ShapeDescriptor` shapes.
- Adds `RayHit::faceNormal_` (ivec3) — ±1 along the dominant axis of `worldHitPos - voxelCenter`, suitable for place-adjacent math.
- Picker is O(1) per voxel-set per depth step (inverse-grid lookup), so cost is independent of voxel count per set.
- Documents the CPU `castVoxelRay` vs GPU `IRRender::getEntityIdAtMouseTrixel` trade-off in `picking.hpp`'s doc block.
- Prereq for T-211 voxel editor place/erase (PR #785).

## Approach
For each visible `C_VoxelSetNew`, snapshot world origin (= `globalPositions_[0]`), grid size, and the voxels span. At each ray depth step, compute `localInt = roundVec3HalfUp(worldPoint - worldOrigin)`, bounds-check against `size_`, SDF-test the resulting unit cube (`IRMath::SDF::box(delta, vec3(0))`), and check `alpha != 0`. First surface hit wins.

The shape walk in `gatherVisibleShapes` is unchanged; the voxel-set walk runs alongside it in the same depth loop so shape/voxel hit ordering follows iso depth, not list order.

## Test plan
- [x] `IrredenEngineTest --gtest_filter='PickingFaceNormal.*'` — 6 new tests covering positive/negative axis faces, corner tie-break, and zero-delta fallback.
- [x] Full suite: 755 tests pass.
- [x] `IRVoxelEditor` builds + runs 12s without crash with 2 new `C_VoxelSetNew` entities.
- [x] `IRShapeDebug --auto-screenshot 10` regression-clean (shape picking path unchanged).
- [ ] Reviewer: verify interactive multi-set picking in `IRVoxelEditor` — left-click either of the two new voxel sets (blue at `(-8,0,-4)`, orange at `(8,0,-4)`), confirm highlight snaps to the clicked voxel.

## Notes for reviewer
- No shader changes, no pipeline-ordering changes, no CPU/GPU struct changes. Picker only fires on click frames, so `--auto-screenshot` regression coverage for shape picking is sufficient evidence the existing path is unchanged.
- No `attach-screenshots` / `render-debug-loop` run: `picking.hpp` is a click handler (not under `engine/prefabs/irreden/render/systems/`), `shape_debug` doesn't exercise voxel-set picking, and `voxel_editor` has no `--auto-screenshot` support. Visual diff against an existing demo's auto-screenshot table is exactly zero.
- macOS smoke pending — flagged `fleet:needs-macos-smoke` on push.

Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)