### PR TITLE
T-219: extend castVoxelRay to walk C_VoxelSetNew entities

### DIFF
--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -91,11 +91,19 @@ the ECS surface.
 - `VOXEL_PICKING` — editor input driver. On left-click PRESSED, casts a
   ray through the cursor (via `IRPrefab::Picking::castVoxelRay` —
   composes the same screen→world inverse `IRRender::mouseWorldPos3DAtIsoDepth`
-  uses) and walks SDF shapes to find the first hit. Writes
-  `C_VoxelSelection` on the highlight entity and toggles its
+  uses) and walks the union of visible `C_ShapeDescriptor` entities
+  plus the active voxels of every `C_VoxelSetNew` entity to find the
+  first hit. Voxel-set hits also carry a `faceNormal_` (±1 along the
+  dominant axis of `worldHitPos − voxelCenter`) so consumers can
+  compute place-adjacent target coords as `voxelPos + faceNormal`.
+  Writes `C_VoxelSelection` on the highlight entity and toggles its
   `C_ShapeDescriptor::flags_` visibility. Register after the camera
   systems and before `VOXEL_TO_TRIXEL_STAGE_1` so the highlight
-  rasterizes at the new voxel the same frame.
+  rasterizes at the new voxel the same frame. The CPU-side path is
+  the default; `picking.hpp`'s header doc names the
+  `IRRender::getEntityIdAtMouseTrixel` GPU readback as a documented
+  fallback for perf-critical creations that can absorb a one-frame
+  lag.
 
 ## Level-of-detail (UPDATE pipeline; Phase 1)
 

--- a/engine/prefabs/irreden/render/picking.hpp
+++ b/engine/prefabs/irreden/render/picking.hpp
@@ -2,26 +2,36 @@
 #define IR_PREFAB_PICKING_H
 
 // Editor-side voxel picking: convert the cursor into a world-space ray
-// (in the engine's isometric projection) and find the first SDF shape
-// it intersects. The picking inverse is the same one used by
+// (in the engine's isometric projection) and find the first surface it
+// intersects. The picking inverse is the same one used by
 // `IRRender::mouseWorldPos3DAtIsoDepth`, so the recovered world point
 // matches what the voxel rasterizer wrote at any visualYaw.
 //
-// Relationship to the GPU trixel/distance infrastructure:
-//   `castVoxelRay` reuses `IRRender::mouseWorldPos3DAtIsoDepth()` — the same
-//   screen→world inverse the GPU pipeline builds into `TRIXEL_TO_FRAMEBUFFER` —
-//   so the picking coordinate system is consistent with the rendered output at any
-//   visualYaw. It does NOT call `IRRender::getEntityIdAtMouseTrixel()`.
+// Two paths exist for "which entity is under the cursor":
 //
-//   `IRRender::getEntityIdAtMouseTrixel()` is the O(1) GPU alternative: it reads
-//   the entity-id texture written by `VOXEL_TO_TRIXEL_STAGE_2` and
-//   `SHAPES_TO_TRIXEL` (via a persistent-mapped buffer) and returns the frontmost
-//   entity at the cursor pixel in O(1). Its trade-off is a one-frame lag (the
-//   buffer holds the previous frame's render) and it yields the entity only — not
-//   the sub-voxel surface hit position. `castVoxelRay` instead evaluates the SDF at
-//   each depth step to recover the exact surface intersection (needed for sub-voxel
-//   accurate voxel placement), and fires only on click frames so the per-click cost
-//   is proportional to visible shapes × depth range, not per-frame cost.
+//   1. CPU-side `castVoxelRay` (this header) — **default for click-frame
+//      picking.** Walks the cursor's iso-depth axis, SDF-tests every
+//      `C_ShapeDescriptor` plus every active voxel of every `C_VoxelSetNew`
+//      whose bounding box overlaps the current depth slice. Returns the
+//      first surface intersection with sub-voxel world position, the
+//      integer voxel coordinate, the owning entity, and (for voxel-set
+//      hits) the face normal needed for place-adjacent computation.
+//      Cost is `O(visibleSurfaces × depthSteps)` per click and fires
+//      only on click frames — never per-frame.
+//
+//   2. GPU `IRRender::getEntityIdAtMouseTrixel()` — **documented fallback.**
+//      Reads the entity-id texture populated by `VOXEL_TO_TRIXEL_STAGE_2`
+//      and `SHAPES_TO_TRIXEL` (via a persistent-mapped buffer) and returns
+//      the frontmost entity id at the cursor pixel in `O(1)`. Trade-offs:
+//      one-frame lag (the buffer holds the previous frame's render), and
+//      it yields the entity id only — no sub-voxel hit position and no
+//      face normal. Reach for this when the CPU path's per-click cost
+//      becomes a bottleneck (e.g., scenes with hundreds of thousands of
+//      active voxels) and the lag is acceptable.
+//
+// The CPU path is preferred because click responsiveness matters in
+// editor workflows; the GPU path stays available for perf-critical
+// creations to swap in without rewriting consumer logic.
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -30,8 +40,11 @@
 #include <irreden/common/components/component_position_global_3d.hpp>
 #include <irreden/render/camera.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
 
+#include <limits>
 #include <optional>
+#include <span>
 #include <vector>
 
 namespace IRPrefab::Picking {
@@ -40,6 +53,11 @@ struct RayHit {
     IREntity::EntityId entity_ = IREntity::kNullEntity;
     IRMath::vec3 worldHitPos_ = IRMath::vec3(0.0f);
     IRMath::ivec3 voxelPos_ = IRMath::ivec3(0);
+    // Axis-aligned unit vector pointing out of the face the ray entered.
+    // Populated only for `C_VoxelSetNew` hits (voxels are unit cubes with
+    // an unambiguous face). Stays at the default zero for `C_ShapeDescriptor`
+    // hits, where smooth SDFs make a per-face normal ill-defined.
+    IRMath::ivec3 faceNormal_ = IRMath::ivec3(0);
 };
 
 // Step size along the canvas-frame iso depth axis. One iso-depth unit
@@ -106,34 +124,137 @@ gatherVisibleShapes(IRMath::CardinalIndex cardinalIndex, IREntity::EntityId excl
     return snapshot;
 }
 
+struct VoxelSetSnapshot {
+    IREntity::EntityId entity_;
+    // World position of grid coord (0,0,0)'s voxel center for this set.
+    // Equals `entityGlobalPos + positions_[0].pos_` — the same compose
+    // `updateAsChild` uses to drive the per-voxel global pool span,
+    // minus the per-voxel `positionOffsets_` (squash/stretch animation
+    // offset). Picking treats the rest pose; the editor's place/erase
+    // operates on integer grid coords, not the deformed pose.
+    IRMath::vec3 originWorld_;
+    IRMath::ivec3 size_;
+    float isoDepthMin_;
+    float isoDepthMax_;
+    std::span<const IRComponents::C_Voxel> voxels_;
+};
+
+inline std::vector<VoxelSetSnapshot>
+gatherVisibleVoxelSets(IRMath::CardinalIndex cardinalIndex, IREntity::EntityId excludeEntity) {
+    std::vector<VoxelSetSnapshot> snapshot;
+    IREntity::forEachComponent<IRComponents::C_VoxelSetNew>([&](IREntity::EntityId id,
+                                                                IRComponents::C_VoxelSetNew &vs) {
+        if (id == excludeEntity)
+            return;
+        // Skip headless-staged sets — they have no pool span and no
+        // rendered footprint, so they can't be picked. A future
+        // canvas-attach pass moves staged voxels into the pool; once
+        // that lands the set will pass this guard naturally.
+        if (vs.numVoxels_ <= 0 || vs.voxels_.empty() || vs.positions_.empty())
+            return;
+        if (vs.size_.x <= 0 || vs.size_.y <= 0 || vs.size_.z <= 0)
+            return;
+
+        // Same per-entity getComponent rationale as gatherVisibleShapes:
+        // click-frame path, not a per-frame tick.
+        auto &gpos = IREntity::getComponent<IRComponents::C_PositionGlobal3D>(id);
+        const IRMath::vec3 originWorld = gpos.pos_ + vs.positions_[0].pos_;
+
+        // Grid AABB half-extents are `size * 0.5` (voxels are unit
+        // cubes centered on integer coords; the grid spans
+        // `[origin - 0.5, origin + (size - 1) + 0.5]`). The iso-depth
+        // sum `bx + by + bz` is invariant under `rotateCardinalZ`
+        // because cardinal rotations permute axes but preserve their
+        // magnitudes — same trick `gatherVisibleShapes` uses.
+        const IRMath::vec3 gridCenterWorld =
+            originWorld + IRMath::vec3(vs.size_ - IRMath::ivec3(1)) * 0.5f;
+        const IRMath::vec3 rotatedCenter = IRMath::rotateCardinalZ(gridCenterWorld, cardinalIndex);
+        const float center = rotatedCenter.x + rotatedCenter.y + rotatedCenter.z;
+        const IRMath::vec3 boundHalf = IRMath::vec3(vs.size_) * 0.5f;
+        const float halfRange = boundHalf.x + boundHalf.y + boundHalf.z;
+
+        snapshot.push_back(
+            {id,
+             originWorld,
+             vs.size_,
+             center - halfRange - kPickingDepthMargin,
+             center + halfRange + kPickingDepthMargin,
+             std::span<const IRComponents::C_Voxel>(vs.voxels_)}
+        );
+    });
+    return snapshot;
+}
+
+// Face normal for a voxel hit: ±1 along the dominant axis of the
+// `worldHitPos − voxelCenter` vector. Voxels are unit cubes centered on
+// integer coords, so `(worldHitPos − voxelCenter)` lies inside
+// `[-0.5, 0.5]³`; the component of largest magnitude tells us which face
+// the ray crossed to enter. Ties (corner hits) fall through to the next
+// axis in x→y→z order — corner hits are rare in practice, and any of
+// the three faces is a valid place-adjacent direction.
+inline IRMath::ivec3
+voxelFaceNormal(const IRMath::vec3 &worldHitPos, const IRMath::ivec3 &voxelWorldCoord) {
+    const IRMath::vec3 delta = worldHitPos - IRMath::vec3(voxelWorldCoord);
+    const float ax = IRMath::abs(delta.x);
+    const float ay = IRMath::abs(delta.y);
+    const float az = IRMath::abs(delta.z);
+    IRMath::ivec3 normal(0);
+    if (ax >= ay && ax >= az) {
+        normal.x = (delta.x >= 0.0f) ? 1 : -1;
+    } else if (ay >= az) {
+        normal.y = (delta.y >= 0.0f) ? 1 : -1;
+    } else {
+        normal.z = (delta.z >= 0.0f) ? 1 : -1;
+    }
+    return normal;
+}
+
 } // namespace detail
 
 // Casts a ray from the cursor into the scene and returns the first
-// shape it hits, or std::nullopt if the ray misses everything. The
-// caller passes the editor's highlight entity (or any entity to be
+// shape or voxel it hits, or std::nullopt if the ray misses everything.
+// The caller passes the editor's highlight entity (or any entity to be
 // skipped) so the highlight itself doesn't catch its own ray.
 //
 // Algorithm: walk along the canvas-frame iso depth axis in
-// `kPickingDepthStep` increments over the union of all visible shape
-// iso-depth ranges. At each step, evaluate every shape's SDF at the
-// recovered world point; the first surface (`SDF::evaluate <=
-// kSurfaceThreshold`) wins. The depth-range pre-filter keeps the
-// per-step cost proportional to the number of shapes whose bounding
-// box overlaps that depth slice, not the total scene shape count.
+// `kPickingDepthStep` increments over the union of all visible
+// surfaces' iso-depth ranges (`C_ShapeDescriptor` + `C_VoxelSetNew`).
+// At each step:
+//   - Evaluate every shape's SDF at the recovered world point; the
+//     first surface (`SDF::evaluate <= kSurfaceThreshold`) wins.
+//   - Check every voxel set whose AABB overlaps the depth slice: round
+//     the world point to an integer voxel coord, bounds-check against
+//     the set's grid extent, and consume the hit if the indexed voxel
+//     is active (`color_.alpha_ > 0`). Returns the per-set entity ID
+//     plus the face normal derived from the entry direction so the
+//     caller can compute the place-adjacent target world coord.
+// The depth-range pre-filter keeps the per-step cost proportional to
+// the number of surfaces whose bounding box overlaps that depth slice,
+// not the total scene surface count. Shapes and voxel sets are tested
+// in the same depth-step pass so the lowest-iso-depth hit wins
+// regardless of which surface kind produced it.
 inline std::optional<RayHit>
 castVoxelRay(IREntity::EntityId excludeEntity = IREntity::kNullEntity) {
     const auto [rasterYaw, residualYaw] = IRPrefab::Camera::getYawSplit();
     const IRMath::CardinalIndex cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
 
     auto shapes = detail::gatherVisibleShapes(cardinalIndex, excludeEntity);
-    if (shapes.empty())
+    auto voxelSets = detail::gatherVisibleVoxelSets(cardinalIndex, excludeEntity);
+    if (shapes.empty() && voxelSets.empty())
         return std::nullopt;
 
-    float depthMin = shapes[0].isoDepthMin_;
-    float depthMax = shapes[0].isoDepthMax_;
+    // Sentinel-driven union of every visible surface's iso-depth range.
+    // The empty-check above guarantees at least one source loop runs, so
+    // the infinities are always overwritten before the walk begins.
+    float depthMin = std::numeric_limits<float>::infinity();
+    float depthMax = -std::numeric_limits<float>::infinity();
     for (const auto &s : shapes) {
         depthMin = IRMath::min(depthMin, s.isoDepthMin_);
         depthMax = IRMath::max(depthMax, s.isoDepthMax_);
+    }
+    for (const auto &vs : voxelSets) {
+        depthMin = IRMath::min(depthMin, vs.isoDepthMin_);
+        depthMax = IRMath::max(depthMax, vs.isoDepthMax_);
     }
 
     for (float d = depthMin; d <= depthMax; d += kPickingDepthStep) {
@@ -150,6 +271,25 @@ castVoxelRay(IREntity::EntityId excludeEntity = IREntity::kNullEntity) {
             if (dist <= IRMath::SDF::kSurfaceThreshold) {
                 return RayHit{s.entity_, worldPoint, IRMath::roundVec3HalfUp(worldPoint)};
             }
+        }
+        for (const auto &vs : voxelSets) {
+            if (d < vs.isoDepthMin_ || d > vs.isoDepthMax_)
+                continue;
+            const IRMath::ivec3 gridCoord = IRMath::roundVec3HalfUp(worldPoint - vs.originWorld_);
+            if (gridCoord.x < 0 || gridCoord.x >= vs.size_.x || gridCoord.y < 0 ||
+                gridCoord.y >= vs.size_.y || gridCoord.z < 0 || gridCoord.z >= vs.size_.z) {
+                continue;
+            }
+            const int flatIdx = IRMath::index3DtoIndex1D(gridCoord, vs.size_);
+            if (vs.voxels_[flatIdx].color_.alpha_ == 0)
+                continue;
+            const IRMath::ivec3 voxelWorldCoord = IRMath::roundVec3HalfUp(worldPoint);
+            return RayHit{
+                vs.entity_,
+                worldPoint,
+                voxelWorldCoord,
+                detail::voxelFaceNormal(worldPoint, voxelWorldCoord)
+            };
         }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(IrredenEngineTest
   render/camera_yaw_test.cpp
   render/frame_data_sun_layout_test.cpp
   render/per_canvas_light_scope_test.cpp
+  render/picking_face_normal_test.cpp
   render/sun_direction_test.cpp
   render/sun_lighting_test.cpp
   render/sprite_animation_test.cpp

--- a/test/render/picking_face_normal_test.cpp
+++ b/test/render/picking_face_normal_test.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_math.hpp>
+#include <irreden/render/picking.hpp>
+
+// Pins the architect-locked face-normal derivation from #792:
+// `sign(largestAbsComponent(worldHitPos − voxelCenter))`. The editor
+// (T-211) computes place-adjacent voxel targets as
+// `hit.voxelPos_ + hit.faceNormal_`, so the normal must consistently
+// point out of the face the ray crossed to enter the cube. Voxels are
+// unit cubes centered on integer coords; `worldHitPos − voxelCenter`
+// lies inside `[-0.5, 0.5]^3`. The picker's caller can rely on each
+// component of the returned normal being in `{-1, 0, +1}` with
+// exactly one non-zero axis.
+
+namespace {
+
+using IRMath::ivec3;
+using IRMath::vec3;
+using IRPrefab::Picking::detail::voxelFaceNormal;
+
+TEST(PickingFaceNormal, PlusXFaceWhenHitOnRightSide) {
+    EXPECT_EQ(voxelFaceNormal(vec3(5.4f, 3.0f, 2.0f), ivec3(5, 3, 2)), ivec3(1, 0, 0));
+}
+
+TEST(PickingFaceNormal, MinusXFaceWhenHitOnLeftSide) {
+    EXPECT_EQ(voxelFaceNormal(vec3(4.6f, 3.0f, 2.0f), ivec3(5, 3, 2)), ivec3(-1, 0, 0));
+}
+
+TEST(PickingFaceNormal, PlusYFaceWhenHitOnFrontSide) {
+    EXPECT_EQ(voxelFaceNormal(vec3(5.0f, 3.4f, 2.0f), ivec3(5, 3, 2)), ivec3(0, 1, 0));
+}
+
+TEST(PickingFaceNormal, MinusYFaceWhenHitOnBackSide) {
+    EXPECT_EQ(voxelFaceNormal(vec3(5.0f, 2.6f, 2.0f), ivec3(5, 3, 2)), ivec3(0, -1, 0));
+}
+
+TEST(PickingFaceNormal, PlusZFaceWhenHitOnTopSide) {
+    EXPECT_EQ(voxelFaceNormal(vec3(5.0f, 3.0f, 2.4f), ivec3(5, 3, 2)), ivec3(0, 0, 1));
+}
+
+TEST(PickingFaceNormal, MinusZFaceWhenHitOnBottomSide) {
+    EXPECT_EQ(voxelFaceNormal(vec3(5.0f, 3.0f, 1.6f), ivec3(5, 3, 2)), ivec3(0, 0, -1));
+}
+
+TEST(PickingFaceNormal, NegativeVoxelCoordPlusXFace) {
+    // Mixed-sign coords — confirm the formula doesn't bias toward positive
+    // axes when the voxel sits at a negative world coord.
+    EXPECT_EQ(voxelFaceNormal(vec3(-2.4f, -1.0f, 4.0f), ivec3(-3, -1, 4)), ivec3(1, 0, 0));
+}
+
+TEST(PickingFaceNormal, OriginVoxelMinusZFace) {
+    EXPECT_EQ(voxelFaceNormal(vec3(0.0f, 0.0f, -0.4f), ivec3(0, 0, 0)), ivec3(0, 0, -1));
+}
+
+TEST(PickingFaceNormal, ExactCenterFavorsXAxisPositive) {
+    // Pure center hit: all three component magnitudes equal (zero). The
+    // tie-break order (x → y → z) lands on the +X face. Corner hits
+    // never arise in practice (ray sample lands strictly inside one cube
+    // before the next depth step), so any of the three faces would be a
+    // valid place-adjacent direction — this test pins the deterministic
+    // choice for regression-detection rather than asserting a semantic.
+    EXPECT_EQ(voxelFaceNormal(vec3(5.0f, 3.0f, 2.0f), ivec3(5, 3, 2)), ivec3(1, 0, 0));
+}
+
+TEST(PickingFaceNormal, ReturnsSingleNonzeroAxis) {
+    // Exhaustively spot-check that the returned normal has exactly one
+    // non-zero component — the place-adjacent compute `voxelPos + normal`
+    // breaks badly if two axes fire simultaneously.
+    const vec3 worldHits[] = {
+        vec3(5.49f, 3.40f, 2.30f),  // X dominant
+        vec3(5.30f, 3.49f, 2.40f),  // Y dominant
+        vec3(5.30f, 3.40f, 2.49f),  // Z dominant
+        vec3(4.51f, 2.60f, 1.70f),  // -X dominant
+    };
+    for (const vec3 &p : worldHits) {
+        const ivec3 normal = voxelFaceNormal(p, ivec3(5, 3, 2));
+        const int nonzero =
+            (normal.x != 0 ? 1 : 0) + (normal.y != 0 ? 1 : 0) + (normal.z != 0 ? 1 : 0);
+        EXPECT_EQ(nonzero, 1) << "world=(" << p.x << "," << p.y << "," << p.z << ") normal=("
+                              << normal.x << "," << normal.y << "," << normal.z << ")";
+    }
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Extend `IRPrefab::Picking::castVoxelRay` to walk every `C_VoxelSetNew`
  entity in the scene alongside the existing `C_ShapeDescriptor` SDF
  shapes. The first hit (across both surface kinds) at the lowest iso-
  depth wins.
- Add `RayHit::faceNormal_` — ±1 along the dominant axis of
  `worldHitPos − voxelCenter` for voxel-set hits, zero default for
  shape-descriptor hits. Consumers compute place-adjacent target world
  coords as `hit.voxelPos_ + hit.faceNormal_`.
- Pin the architect-locked design from PR #785: D1 (`C_VoxelSetNew` with
  no hard size cap, multi-sub-entity from day one) + D2 (CPU-side
  default, GPU `getEntityIdAtMouseTrixel` documented as fallback).

## Files
- `engine/prefabs/irreden/render/picking.hpp` — `VoxelSetSnapshot` +
  `gatherVisibleVoxelSets` + `voxelFaceNormal`; updated `castVoxelRay`
  loop; rewritten header doc covering CPU/GPU path choice.
- `engine/prefabs/irreden/render/CLAUDE.md` — `VOXEL_PICKING` entry now
  reflects the C_VoxelSetNew walk + face normal + CPU/GPU split.
- `test/render/picking_face_normal_test.cpp` (new) — 10 tests pinning the
  `sign(largestAbsComponent(worldHitPos − voxelCenter))` formula and the
  one-non-zero-axis invariant.
- `test/CMakeLists.txt` — register the new test source.

## Acceptance criteria mapping (issue #792)
1. ✅ `castVoxelRay` returns hits for active voxels of `C_VoxelSetNew`
   entities with world position, voxel coordinate, owning entity ID, and
   face normal.
2. ✅ Face normal is `sign(largestAbsComponent(...))` per architect
   direction; `picking_face_normal_test.cpp::ReturnsSingleNonzeroAxis`
   pins the place-adjacent-safe invariant.
3. ⚠️  Multi-voxel-set scene smoke is deferred to T-211 / PR #785's
   editor flow once it rebases onto this. The picker itself needs live
   camera + cursor state that the unit framework can't synthesize; T-211
   provides the end-to-end exercise.
4. ✅ `C_ShapeDescriptor` picking behavior unchanged. `system_voxel_picking`
   reads `voxelPos_` / `worldHitPos_` / `entity_` only — shape-descriptor
   return path is identical to before. `IRVoxelEditor` builds clean.
5. ✅ `picking.hpp` header doc names CPU-side default + GPU readback
   fallback explicitly.
6. ✅ Builds clean on `macos-debug`; cross-host smoke will validate
   `linux-debug` via the existing `fleet:needs-linux-smoke` flow.

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean.
- [x] `fleet-build --target IRVoxelEditor` clean (existing picker consumer).
- [x] `fleet-build --target IrredenEngineTest` clean.
- [x] `fleet-run IrredenEngineTest` — all 750 tests pass, including the 10
      new `PickingFaceNormal` tests.
- [ ] Linux/OpenGL smoke (auto-tagged via `fleet:needs-linux-smoke`).
- [ ] T-211 rebase + end-to-end voxel-set place/erase (follow-up PR #785).

## Notes for reviewer
- `gatherVisibleVoxelSets` mirrors the existing `gatherVisibleShapes`
  pattern — per-entity `getComponent<C_PositionGlobal3D>` is acceptable
  on the click-frame path (not per-frame), same as the shape walker.
- The "skip headless-staged sets" guard (`numVoxels_ <= 0 ||
  voxels_.empty()`) is for pre-canvas-attach `C_VoxelSetNew` instances;
  those have no rendered footprint so picking them would be a no-op
  anyway. Future canvas-attach pass will make them pass the guard.
- `originWorld = entityGlobalPos + positions_[0].pos_` is the
  picking-time analog of `updateAsChild`'s compose, minus the
  per-voxel `positionOffsets_` (squash/stretch animation). Picking
  treats the rest pose intentionally; the editor's place/erase
  operates on integer grid coords, not the deformed pose.

Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)