### PR TITLE
T-225: docs/skills: fix cross-repo info-isolation leaks in midi-scene-creator and create-creation

### DIFF
--- a/.claude/skills/create-creation/SKILL.md
+++ b/.claude/skills/create-creation/SKILL.md
@@ -183,5 +183,5 @@ Within each pipeline, systems execute in the order listed in `registerPipeline`.
 ## Reference Creations
 
 - **Minimal C++:** `creations/demos/default/main.cpp`
-- **Full Lua:** `creations/demos/default/` (complete Lua stack; MIDI-specific example has moved to the game repo)
+- **Full Lua:** `creations/demos/default/` (complete Lua stack)
 - **C++ + Lua hybrid:** `creations/demos/default/main_lua.cpp`

--- a/.claude/skills/midi-scene-creator/SKILL.md
+++ b/.claude/skills/midi-scene-creator/SKILL.md
@@ -163,10 +163,8 @@ IREntity.createMidiSequence(seq)
 
 ## Reference Creation
 
-The engine-side `midi_polyrhythm` demo has been removed from this repo. The canonical full-Lua
-MIDI example now lives in the game repo. For structural reference (Lua bindings layout, CMake
-script-sync pattern, component packs), use `creations/demos/default/` as the closest surviving
-engine-side example.
+For structural reference (Lua bindings layout, CMake script-sync pattern, component packs),
+use `creations/demos/default/`.
 
 ## Checklist
 


### PR DESCRIPTION
## Summary
- Removed game-repo reference from `midi-scene-creator/SKILL.md` §Reference Creation — replaced 4-line paragraph naming the private game repo with a 2-line pointer to `creations/demos/default/`.
- Removed trailing parenthetical from `create-creation/SKILL.md` §Reference Creations Full Lua bullet that named the private game repo.

Both violations were flagged in the T-222 docs audit (issue #801) and filed as issue #808.

## Test plan
- [ ] Neither SKILL.md file contains any reference to the private game repo
- [ ] `creations/demos/default/` pointer in both files remains accurate

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)