### PR TITLE
T-226: docs/skills: add missing name: field to request-re-review/SKILL.md front-matter

### DIFF
--- a/.claude/skills/request-re-review/SKILL.md
+++ b/.claude/skills/request-re-review/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: request-re-review
 description: >-
   Push changes on the current PR branch and request a fleet re-review.
   Use when the user says "request re-review", "push and re-review",


### PR DESCRIPTION
## Summary
- Added `name: request-re-review` to the YAML front-matter of `.claude/skills/request-re-review/SKILL.md`
- This was the only one of 16 SKILL.md files missing the `name:` field; 15/16 carry both `name:` and `description:`
- Value matches the skill directory name and the registered skill name in the harness

## Test plan
- [x] Front-matter now matches the pattern of all other skills (verified against `simplify/SKILL.md`)
- [x] No behavioral change — docs-only, single-line addition

Closes #809