### PR TITLE
T-227: docs/skills: unify --auto-screenshot contract symbol names across render-debug-loop and render-verify

### DIFF
--- a/.claude/skills/render-debug-loop/SKILL.md
+++ b/.claude/skills/render-debug-loop/SKILL.md
@@ -36,25 +36,11 @@ directory before launching, so the demo picks up its sibling `data/`,
 
 ### Demo requirement: `--auto-screenshot`
 
-This skill drives a demo that opts into the reusable auto-screenshot
-helper in `engine/video/`. Conforming demos do three things in `main.cpp`:
-
-1. Call `IRVideo::parseAutoScreenshotArgv(argc, argv, &warmupFrames)` to
-   detect the flag and read its optional warmup-frames count.
-2. Declare an `IRVideo::AutoScreenshotShot` table (zoom + iso camera
-   position + label per shot).
-3. When `warmupFrames > 0`, append `IRVideo::createAutoScreenshotSystem(
-   cfg)`'s returned `SystemId` to the RENDER pipeline list before
-   `registerPipeline` fires.
-
-The helper handles warmup, settle frames, zoom / camera application,
-the screenshot request, and window close after the last shot.
-
-**Reference implementations:** `creations/demos/shape_debug/main.cpp` and
-`creations/demos/metal_clear_test/main.cpp` — both wire up the helper in
-under a dozen lines. If your target demo does not yet opt in, either
-(a) add the six-line wire-up shown there, or (b) use `shape_debug` if
-it exercises the code path you care about.
+The target demo must opt into the auto-screenshot helper. See
+[`engine/video/CLAUDE.md` § "Auto-screenshot helper"](../../../engine/video/CLAUDE.md)
+for the API, wire-up steps, and reference implementations. If your target
+demo does not yet opt in, either (a) add the wire-up shown in the reference
+callers, or (b) use `shape_debug` if it exercises the code path you care about.
 
 ## Loop Steps
 

--- a/.claude/skills/render-verify/SKILL.md
+++ b/.claude/skills/render-verify/SKILL.md
@@ -57,10 +57,9 @@ reference set on a host representative of where verify will run.
 
 ### Demo requirement: `--auto-screenshot`
 
-The target demo must implement `--auto-screenshot [warmup-frames]` (same
-contract as `render-debug-loop`). Reference implementation:
-`creations/demos/shape_debug/main.cpp` — see `ShotConfig`, `g_shots[]`,
-the `AutoScreenshot` system.
+The target demo must implement `--auto-screenshot [warmup-frames]`. See
+[`engine/video/CLAUDE.md` § "Auto-screenshot helper"](../../../engine/video/CLAUDE.md)
+for the API and reference implementations.
 
 ### Manifest
 

--- a/engine/video/CLAUDE.md
+++ b/engine/video/CLAUDE.md
@@ -76,8 +76,8 @@ plus five lines of wire-up. Used by the `render-debug-loop` and
 Wire-up order in `main.cpp`:
 
 1. Call `parseAutoScreenshotArgv(argc, argv, &warmupFrames)`.
-2. Declare a `const AutoScreenshotShot` table at file scope (must outlive
-   the game loop — `constexpr AutoScreenshotShot kShots[]` is idiomatic).
+2. Declare a `constexpr AutoScreenshotShot kShots[]` table at file scope
+   (must outlive the game loop).
 3. When `warmupFrames > 0`, build an `AutoScreenshotConfig` and call
    `createAutoScreenshotSystem(cfg)` — append the returned `SystemId` to
    the **RENDER** pipeline list before `registerPipeline` fires.

--- a/engine/video/CLAUDE.md
+++ b/engine/video/CLAUDE.md
@@ -73,10 +73,17 @@ plus five lines of wire-up. Used by the `render-debug-loop` and
   through shots, triggers one screenshot per shot, and calls
   `IRWindow::closeWindow()` when done.
 
+Wire-up order in `main.cpp`:
+
+1. Call `parseAutoScreenshotArgv(argc, argv, &warmupFrames)`.
+2. Declare a `const AutoScreenshotShot` table at file scope (must outlive
+   the game loop — `constexpr AutoScreenshotShot kShots[]` is idiomatic).
+3. When `warmupFrames > 0`, build an `AutoScreenshotConfig` and call
+   `createAutoScreenshotSystem(cfg)` — append the returned `SystemId` to
+   the **RENDER** pipeline list before `registerPipeline` fires.
+
 Reference callers: `creations/demos/shape_debug/main.cpp` and
-`creations/demos/metal_clear_test/main.cpp`. The shot table must outlive
-the game loop — `constexpr AutoScreenshotShot kShots[]` at file scope
-is the idiomatic shape.
+`creations/demos/metal_clear_test/main.cpp`.
 
 ## Commands and components (prefabs/irreden/video)
 


### PR DESCRIPTION
## Summary
- `render-verify/SKILL.md` cited stale pre-extraction symbol names (`ShotConfig`, `g_shots[]`, `AutoScreenshot` system) from before the auto-screenshot API was extracted into `engine/video/`.
- Both skills' \"Demo requirement\" sections duplicated the `--auto-screenshot` contract that belongs in `engine/video/CLAUDE.md`.
- Added a \"Wire-up order\" section to `engine/video/CLAUDE.md` covering the three-step main.cpp integration; shrunk both skill sections to a one-liner + link so future symbol renames only need fixing in one place.

## Test plan
- [ ] Verify `engine/video/CLAUDE.md` auto-screenshot section matches `auto_screenshot.hpp` API
- [ ] Verify no stale symbol names remain in either skill file

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)