### PR TITLE
T-228: docs/skills: align model-version stamps emitted by review-pr and commit-and-push

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -211,7 +211,7 @@ default. Read the nearest `CLAUDE.md` before drafting.
   `docs:`) derived from the dominant changed path.
 - Body wraps at ~72 chars per line.
 - Describe *why* over *what*.
-- Always include the `Co-Authored-By` trailer exactly as shown.
+- Always include the `Co-Authored-By` trailer; the harness system prompt specifies the exact form with the current model version.
 
 ### 5. Stage files
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -390,7 +390,7 @@ tool**, then pass it with `--body-file`:
 - [ ] <...>
 - [ ] <...>
 
-🤖 Reviewed by Claude (review-pr skill)
+🤖 Reviewed by Claude <model> (review-pr skill)
 ```
 
 2. Post the review:

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -390,7 +390,7 @@ tool**, then pass it with `--body-file`:
 - [ ] <...>
 - [ ] <...>
 
-🤖 Reviewed by Claude Opus 4.6 (review-pr skill)
+🤖 Reviewed by Claude (review-pr skill)
 ```
 
 2. Post the review:


### PR DESCRIPTION
## Summary

- Drop stale `Opus 4.6` version from the `review-pr` skill's reviewer footer stamp — now model-agnostic since both Sonnet and Opus agents run this skill
- Update `commit-and-push` rule to defer to the harness system prompt for the exact `Co-Authored-By` form with current model version, instead of saying "exactly as shown" for a versionless template

## Test plan
- [ ] `review-pr` skill footer now reads `🤖 Reviewed by Claude (review-pr skill)` — no stale version
- [ ] `commit-and-push` rule references harness as authority for the Co-Authored-By model stamp

Closes #811