### PR TITLE
T-228: docs/skills: align model-version stamps emitted by review-pr and commit-and-push

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -196,7 +196,7 @@ obvious from filenames.>
 <If the session unearthed build/runtime gotchas worth remembering, note
 them here so the commit doubles as a changelog entry.>
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 If the work is entirely inside a subdirectory with its own `CLAUDE.md`
@@ -243,7 +243,7 @@ Stage-1 compute was over-culling near the left edge because the cpu-side
 visibleIsoViewport used the raw camera pos while the gpu used the
 trixel-offset-corrected one. Align both to the offset-corrected form.
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 EOF
 )"
 ```

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -390,7 +390,7 @@ tool**, then pass it with `--body-file`:
 - [ ] <...>
 - [ ] <...>
 
-🤖 Reviewed by Claude Opus 4.6 (review-pr skill)
+🤖 Reviewed by Claude Opus 4.7 (review-pr skill)
 ```
 
 2. Post the review:


### PR DESCRIPTION
## Summary
- Fix stale `Claude Opus 4.6` stamp in `review-pr/SKILL.md` → update to `Claude Opus 4.7`
- Add model-version to bare `Co-Authored-By: Claude` in `commit-and-push/SKILL.md` → `Claude Sonnet 4.6 <noreply@anthropic.com>` to align with harness format

## Test plan
- [ ] `review-pr/SKILL.md` stamp matches current canonical Opus model id
- [ ] `commit-and-push/SKILL.md` Co-Authored-By matches harness system-prompt format
- [ ] Docs-only change; no build step needed

Closes #811