### PR TITLE
T-230: docs/skills: reconcile backend-parity chaining vs start-next-task no-auto-invoke

### DIFF
--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -330,9 +330,9 @@ Title format: `metal: <what you ported>` or `opengl: <what you ported>`
 depending on the lagging side.
 
 After the PR is open, `commit-and-push` hands control back. The
-reviewer agent (`review-pr` skill) takes over. If the user wants you
-to continue with more parity work on the same run, chain to
-`start-next-task` and pick the next gap.
+reviewer agent (`review-pr` skill) takes over. Wait for a user cue
+before starting the next parity gap — do not invoke `start-next-task`
+proactively.
 
 ## Cross-backend translation cheatsheet
 


### PR DESCRIPTION
## Summary
- `backend-parity/SKILL.md` lines 332-335 instructed the agent to "chain to `start-next-task`" after opening a parity PR — this contradicts `start-next-task/SKILL.md`'s explicit "Do not invoke proactively" rule.
- Fix: replace the chaining instruction with a wait-for-cue note consistent with start-next-task's contract.

## Test plan
- [ ] `backend-parity/SKILL.md` no longer references proactive `start-next-task` chaining
- [ ] `start-next-task/SKILL.md` unchanged (exemption path not needed — drop is cleaner)

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)