### PR TITLE
T-231: docs/skills: extract ECS-invariants checklist into .claude/rules/cpp-ecs-smells.md

### DIFF
--- a/.claude/rules/cpp-ecs-smells.md
+++ b/.claude/rules/cpp-ecs-smells.md
@@ -1,0 +1,74 @@
+---
+paths:
+  - "engine/**/*.{hpp,cpp,h,cc}"
+  - "engine/prefabs/**/system_*.{hpp,cpp}"
+  - "creations/**/*.{hpp,cpp,h,cc}"
+  - "creations/**/*.lua"
+---
+
+# ECS smell checklist
+
+Diagnostic checklist for catching common ECS pattern violations. Use during
+code review, pre-commit passes, and performance audits. Full rule rationale
+lives in [`.claude/rules/cpp-ecs.md`](cpp-ecs.md) and `engine/system/CLAUDE.md`.
+
+## Per-entity tick violations
+
+In any system `tick` function:
+
+- **`getComponent<C_Foo>()` or `getComponentOptional<C_Foo>()`** on the
+  iterating entity. Fix: add `C_Foo` to the system's template parameters so
+  it arrives via dense-column iteration. Auto-fix when the call is
+  unconditional and the component is small; flag when the call is conditional
+  or the component may not exist on every entity in the archetype.
+
+- **`createEntity`, `addComponent`, `removeComponent`, or `removeEntity`**
+  mid-iteration without the deferred variant. Fix: use
+  `IREntity::deferredCreate` / `deferredSetComponent` etc.; let
+  `flushStructuralChanges` run at pipeline end.
+
+- **Allocation in the tick body** -- `new`, `std::vector::push_back` on a hot
+  vector, `std::string` construction/concatenation, `std::map::operator[]`
+  insertion. Fix: pre-size in `beginTick` (or at component construction for
+  member buffers) and reuse across frames.
+
+## System registration
+
+- **New prefab system not added to `SystemName`** in
+  `engine/system/include/irreden/system/ir_system_types.hpp`. Fix: add a
+  `SCREAMING_SNAKE_CASE` entry under the appropriate group comment.
+
+## Tick-function signatures
+
+- **`functionBeginTick` / `functionEndTick` with `Archetype&` or component
+  parameters** -- they must be `void()`. Entity data is only valid inside the
+  per-entity `tick`; `begin`/`endTick` are for once-per-frame setup/flush.
+
+- **`endTick` reads `ids[0]` or indexes `ids` without a `ids.size() == 0`
+  guard** -- `begin`/`endTick` fire even when the archetype is empty.
+
+## Component discipline
+
+- **New component not `C_`-prefixed**, or public members without trailing `_`.
+
+- **Component method calls `IREntity::getComponent` / `setComponent` /
+  `createEntity` / `setParent` on a different entity** (tier-c violation per
+  `engine/prefabs/CLAUDE.md`). Confirm the method is on the documented
+  exceptions list in `cpp-ecs.md`; otherwise move logic to a system, builder,
+  or prefab-scoped namespace.
+
+- **`C_Position3D` read in a render-related system for visual placement** --
+  rendered position must be `C_PositionGlobal3D`, which `APPLY_POSITION_OFFSET`
+  keeps folded with any modifier-driven offset.
+
+## Lua-side ECS bindings
+
+- **Bare C++ component name in a Lua `components = { "C_..." }` or
+  `excludes = { "C_..." }` table** -- must use `IRComponent.C_Name`, not the
+  string `"C_Name"`. Applies only in creations that call
+  `IRSystem.registerSystem`; bare strings for Lua-defined components (no `C_`
+  prefix) are fine.
+
+- **Hand-written `IRTime` / `SystemName` string keys** in new C++ binding code
+  (`t["NAME"] = ...`). Use `IR_BIND_TIME(NAME)` / `IR_BIND_SYS(NAME)` so the
+  key is derived from the enum and stays in sync.

--- a/.claude/skills/ecs-prefab-creator/SKILL.md
+++ b/.claude/skills/ecs-prefab-creator/SKILL.md
@@ -129,7 +129,7 @@ Systems support multiple event hooks via optional lambdas after the tick functio
 
 ### Anti-patterns
 
-- No `getComponent` / `getComponentOptional` in per-entity ticks, no structural changes (add/remove/create entity) mid-iteration — see [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md) for the full checklist.
+- No `getComponent` / `getComponentOptional` in per-entity ticks, no structural changes (add/remove/create entity) mid-iteration — see [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md) for the full checklist, and [`.claude/rules/cpp-ecs.md`](../../rules/cpp-ecs.md) for alternative patterns (template-param widening, caching at creation time, `relationTick` for per-parent-group lookups, batching foreign-entity lookups).
 
 ## Creating a Command
 

--- a/.claude/skills/ecs-prefab-creator/SKILL.md
+++ b/.claude/skills/ecs-prefab-creator/SKILL.md
@@ -129,8 +129,7 @@ Systems support multiple event hooks via optional lambdas after the tick functio
 
 ### Anti-patterns
 
-- **Never** call `getComponent` or `getComponentOptional` inside a per-entity tick. Each call does hash-map + linear scan + hash-map lookups with profiler overhead.
-- Instead: include the component in the system's template parameters, store data at creation time, use `beginTick`/`endTick` for once-per-frame lookups, or use `relationTick` for per-parent-group lookups.
+- No `getComponent` / `getComponentOptional` in per-entity ticks, no structural changes (add/remove/create entity) mid-iteration — see [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md) for the full checklist.
 
 ## Creating a Command
 

--- a/.claude/skills/optimize/SKILL.md
+++ b/.claude/skills/optimize/SKILL.md
@@ -191,14 +191,7 @@ before/after numbers.
 
 For **CPU hotspots** in system ticks:
 
-- Per-entity `getComponent<C_Foo>()` → add `C_Foo` to the system's
-  template parameters so it's iterated as a dense column. (See
-  `engine/system/CLAUDE.md` for tick-function signature patterns.)
-  This is the single biggest engine-wide perf win and `simplify`
-  also flags it — but optimize is the place to actually verify the
-  measured ms improvement after fixing.
-- Allocation in per-entity paths → hoist to component construction
-  or pre-size + reuse a member buffer.
+- Per-entity `getComponent<C_Foo>()` and allocation in per-entity paths — see [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md) for the full pattern catalogue. After applying the fix, re-run the benchmark to verify the measured ms improvement.
 - `std::map` / `std::unordered_map` lookups in the inner loop →
   replace with a flat array indexed by entity ID, or move the
   lookup outside the loop.

--- a/.claude/skills/polish-checkpoint/SKILL.md
+++ b/.claude/skills/polish-checkpoint/SKILL.md
@@ -86,12 +86,10 @@ Skill: simplify
 ```
 
 `simplify` reads the same diff and applies inline fixes for the usual
-Irreden-Engine smells: per-entity `getComponent` inside system tick
-functions, naming-convention slips (`m_` on public, missing `C_`
-prefix on a new component), debug `std::cout` lines left from
-troubleshooting, tautological doc comments, change-narration
-comments, allocation in hot loops, etc. It auto-fixes the safe ones
-and reports anything that needs human judgment.
+Irreden-Engine smells — ECS checks per [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md),
+naming-convention slips, debug `std::cout` lines, tautological doc comments,
+and change-narration comments. It auto-fixes the safe ones and reports anything
+that needs human judgment.
 
 After `simplify` finishes, re-check `git status` so you know the
 post-simplify state. If `simplify` reverted everything (rare — only

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -196,30 +196,7 @@ worse, needs-fix.
 Go through each of these explicitly. For every item, either confirm
 compliance or raise an issue.
 
-**ECS invariants**
-- ❌ Per-entity `getComponent` / `getComponentOptional` inside a system tick
-  function. Fix: add the component to the system's template parameters.
-- ❌ `createEntity` / `removeComponent` called mid-iteration in a system
-  tick without using the deferred variant.
-- ❌ Allocating memory (new, std::vector push in hot loop, std::string
-  concat) in per-entity tick paths.
-- ❌ New prefab system that isn't added to the `SystemName` enum in
-  `engine/system/include/irreden/system/ir_system_types.hpp`.
-- ❌ New component that isn't `C_`-prefixed, or whose public members don't
-  have a trailing `_`.
-- ❌ `functionBeginTick` / `functionEndTick` declared with `Archetype&` or
-  any component parameter — they must be `void()`. The per-entity tick is
-  where entity data arrives; `begin`/`endTick` receive no entity args.
-- ❌ `endTick` reads `ids[0]` or indexes `ids` without a `ids.size() == 0`
-  guard — `begin`/`endTick` fire even when the archetype is empty.
-- ❌ system reads `C_Position3D` for visual placement instead of
-  `C_PositionGlobal3D` — rendered position is `C_PositionGlobal3D`
-  after `APPLY_POSITION_OFFSET` has folded any modifier-driven offset
-  into it (see `engine/CLAUDE.md`).
-- ❌ component method calls `IREntity::getComponent` / `setComponent` /
-  `createEntity` / `setParent` on a *different* entity (tier-c violation per
-  `engine/prefabs/CLAUDE.md`). Confirm the method appears on the documented
-  exceptions list before allowing.
+**ECS invariants** — check against [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md). For each item, confirm compliance or raise an issue.
 
 **Ownership / lifetime**
 - ❌ `shared_ptr` where `unique_ptr` would do.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -59,59 +59,13 @@ relevant `CLAUDE.md` files in those directories define module-specific
 rules that override the defaults below; read them before touching
 anything in their scope.
 
-### 2. ECS smells (the biggest performance footgun)
+### 2. ECS smells
 
-Per-entity `getComponent<C_Foo>()` or `getComponentOptional<C_Foo>()`
-inside a system's per-entity tick is a hash-map lookup, an archetype
-scan, and another hash-map lookup — at scale it dominates the frame.
-The fix is mechanical: add the component to the system's template
-parameters so it iterates the dense column.
+Check the diff against every item in [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md) — that file is the canonical diagnostic checklist.
 
-**Apply the fix when** the call is unconditional and the component is
-small. Add the type to the system's `createSystem<...>` template
-params (or the equivalent template signature) and replace the
-`getComponent` call with the iteration variable.
+**Auto-fix** when a `getComponent` call is unconditional and the component is small: add the type to `createSystem<...>` template params and replace the call with the iteration variable.
 
-**Report instead of fixing when** the call is conditional, when the
-component might not exist on every entity in the archetype, or when
-the system signature is shared with other tick functions you can't
-see in the diff. Note `engine/system/CLAUDE.md` has the full
-tick-function-signature story.
-
-Also flag (don't auto-fix):
-- `createEntity` / `removeComponent` mid-iteration without the
-  deferred variant — race-prone, deferred is the right answer.
-- Allocation in per-entity tick paths (`new`, `vector::push_back` on
-  a hot vector, `string` concat, `map::operator[]` insertion).
-- A new prefab system that isn't added to `SystemName` in
-  `engine/system/include/irreden/ir_system_types.hpp` (the system
-  name enum is the registration mechanism).
-- `C_Position3D` read in a render-related system for visual placement
-  instead of `C_PositionGlobal3D` — `APPLY_POSITION_OFFSET` folds any
-  modifier-driven offset into globalPos each UPDATE tick. Flag;
-  confirm the component is intentional.
-- A component method that calls `IREntity::getComponent` /
-  `setComponent` / `createEntity` / `setParent` on a *different*
-  entity (tier-c violation per `engine/prefabs/CLAUDE.md`). Flag
-  unless the method is on the documented exceptions list.
-- `functionBeginTick` / `functionEndTick` declared with `Archetype&`
-  or any component parameter — they must be `void()`.
-- `endTick` body that reads `ids[0]` or indexes `ids` without first
-  guarding `ids.size() == 0`.
-- **Bare string C++ component references in Lua.** In `.lua` files, a
-  `components = { "C_..." }` or `excludes = { "C_..." }` entry that
-  spells a C++ component as a bare string (e.g. `"C_Position3D"`) instead
-  of the `IRComponent.C_Name` handle. Fix: replace `"C_Name"` with
-  `IRComponent.C_Name`. Only applicable when `bindLuaDrivenEcs()` is in
-  use (any creation that calls `IRSystem.registerSystem`). Bare strings
-  for Lua-defined components (no `C_` prefix) are still the only option —
-  don't flag those.
-- **Hand-written IRTime / SystemName string keys in new C++ binding code.**
-  In C++ binding files (e.g. `lua_pipeline_bindings.hpp`), new `IRTime`
-  or `SystemName` table entries written as `t["NAME"] = ...` without the
-  `IR_BIND_TIME` / `IR_BIND_SYS` macro. The macros derive the key from
-  the enum via stringization so the key stays in sync. Flag; suggest using
-  `IR_BIND_TIME(NAME)` or `IR_BIND_SYS(NAME)` instead.
+**Flag for human judgment** when: the call is conditional, the component might not exist on every archetype entity, the system signature spans files outside the diff, or the smell is a tier-c component method, a structural-change mid-iteration, a missing `SystemName` entry, or a Lua binding issue.
 
 ### 2b. Math primitives + system-state smells (mechanically detectable)
 


### PR DESCRIPTION
## Summary

- Creates `.claude/rules/cpp-ecs-smells.md` as the canonical diagnostic checklist for ECS pattern violations (per-entity `getComponent`, structural changes mid-iteration, allocation in tick, missing `SystemName` entry, tick-function signatures, component discipline, Lua-side bindings)
- Replaces inlined copies in 5 SKILL.md files (`simplify`, `review-pr`, `optimize`, `polish-checkpoint`, `ecs-prefab-creator`) with a one-line reference to the new rules file
- Follows the precedent established by `.claude/rules/cpp-math.md` and `.claude/rules/cpp-systems.md`

## Test plan

- [ ] `.claude/rules/cpp-ecs-smells.md` exists and contains the full checklist
- [ ] Each of the 5 SKILL.md files now references `cpp-ecs-smells.md` instead of inlining the list
- [ ] The action-level guidance (auto-fix vs flag) stays in `simplify/SKILL.md` since it is skill-specific

Closes #814