### PR TITLE
T-232: docs/skills: move IRMath substitution table into .claude/rules/cpp-math.md

### DIFF
--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -219,7 +219,7 @@ General rules:
   iso-projection helpers; the canonical forms live in
   `ir_iso_common.glsl` (GLSL) and should be mirrored in MSL as an
   equivalent header under `shaders/metal/` if more than two shaders
-  need them. See the Math section in top-level `CLAUDE.md`.
+  need them. See [`.claude/rules/cpp-math.md`](../../rules/cpp-math.md) for IRMath substitutions.
 - **Trailing sanity.** Every ported shader needs at least one
   end-to-end manual test: build the lagging preset, run
   `IRShapeDebug` (or whatever demo exercises the pipeline the shader

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -265,7 +265,7 @@ or any `c_compute_*shadow*.glsl` / `.metal`)
   resident chunk set includes a 1-chunk guard band in all six directions for
   correct AO neighbor-voxel sampling.
 
-**Math / coordinates**
+**Math / coordinates** (see [`.claude/rules/cpp-math.md`](../../rules/cpp-math.md) for the full glm→IRMath substitution table)
 - ❌ Mixing 3D world coords with iso 2D coords without going through
   `IRMath::pos3DtoPos2DIso` or a named helper.
 - ❌ Hard-coded `x + y + z` where `IRMath::pos3DtoDistance` exists.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -141,17 +141,7 @@ For each hit, manually exclude paths in the allowlist (do not flag):
 - `*.glsl` / `*.metal` files (the grep glob excludes these, but
   double-check).
 
-For everything else, flag with the IRMath equivalent. Common substitutions:
-
-| Found | Suggest |
-|-------|---------|
-| `glm::vec3` / `glm::ivec3` / `glm::mat4` | `IRMath::vec3` / `IRMath::ivec3` / `IRMath::mat4` |
-| `glm::min` / `glm::max` / `glm::clamp` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
-| `glm::length` / `glm::normalize` / `glm::dot` | `IRMath::length` / `IRMath::normalize` / `IRMath::dot` |
-| `glm::sin` / `glm::cos` / `glm::sqrt` | `IRMath::sin` / `IRMath::cos` / `IRMath::sqrt` |
-| `glm::pi<float>()` / `glm::half_pi<float>()` / `glm::two_pi<float>()` | `IRMath::kPi` / `IRMath::kHalfPi` / `IRMath::kTwoPi` |
-| `std::min` / `std::max` / `std::clamp` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
-| `std::sin` / `std::cos` / `std::sqrt` / `std::abs` | `IRMath::sin` / `IRMath::cos` / `IRMath::sqrt` / `IRMath::abs` |
+For everything else, flag with the IRMath equivalent. See [`.claude/rules/cpp-math.md`](../../rules/cpp-math.md) for the full substitution table.
 
 If the IRMath wrapper does not exist yet, **don't auto-substitute** —
 flag with: "IRMath::<name> does not exist; add the wrapper to


### PR DESCRIPTION
## Summary

- Remove the inline `glm::*` / `std::*` → `IRMath::*` substitution table from `simplify/SKILL.md:144-154`; replace with a one-line pointer to `.claude/rules/cpp-math.md` (which already has the canonical table).
- Update `backend-parity/SKILL.md` math ref from the vague "See the Math section in top-level CLAUDE.md" to a direct link to `.claude/rules/cpp-math.md`.
- Add a `.claude/rules/cpp-math.md` ref to the `review-pr/SKILL.md` **Math / coordinates** section header.
- `optimize/SKILL.md` was already clean (no inline table).

## Test plan

- [ ] `simplify/SKILL.md` no longer contains the inline `| Found | Suggest |` table; the ref to `cpp-math.md` is present.
- [ ] `backend-parity/SKILL.md` math bullet points to `cpp-math.md` instead of top-level `CLAUDE.md`.
- [ ] `review-pr/SKILL.md` **Math / coordinates** header links to `cpp-math.md`.
- [ ] `.claude/rules/cpp-math.md` is unchanged (already had the canonical table).
- [ ] No other skill files were modified.

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)