### PR TITLE
T-232: docs/skills: move IRMath substitution table into .claude/rules/cpp-math.md

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -141,23 +141,9 @@ For each hit, manually exclude paths in the allowlist (do not flag):
 - `*.glsl` / `*.metal` files (the grep glob excludes these, but
   double-check).
 
-For everything else, flag with the IRMath equivalent. Common substitutions:
-
-| Found | Suggest |
-|-------|---------|
-| `glm::vec3` / `glm::ivec3` / `glm::mat4` | `IRMath::vec3` / `IRMath::ivec3` / `IRMath::mat4` |
-| `glm::min` / `glm::max` / `glm::clamp` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
-| `glm::length` / `glm::normalize` / `glm::dot` | `IRMath::length` / `IRMath::normalize` / `IRMath::dot` |
-| `glm::sin` / `glm::cos` / `glm::sqrt` | `IRMath::sin` / `IRMath::cos` / `IRMath::sqrt` |
-| `glm::pi<float>()` / `glm::half_pi<float>()` / `glm::two_pi<float>()` | `IRMath::kPi` / `IRMath::kHalfPi` / `IRMath::kTwoPi` |
-| `std::min` / `std::max` / `std::clamp` | `IRMath::min` / `IRMath::max` / `IRMath::clamp` |
-| `std::sin` / `std::cos` / `std::sqrt` / `std::abs` | `IRMath::sin` / `IRMath::cos` / `IRMath::sqrt` / `IRMath::abs` |
-
-If the IRMath wrapper does not exist yet, **don't auto-substitute** —
-flag with: "IRMath::<name> does not exist; add the wrapper to
-`engine/math/` first, then call it." (The `IRMath::kPi` / `kHalfPi` /
-`kTwoPi` constants in particular may not be merged yet — verify before
-suggesting.)
+For everything else, flag with the IRMath equivalent — full substitution
+table and wrapper-addition protocol in
+[`.claude/rules/cpp-math.md`](../../rules/cpp-math.md).
 
 **Check 2: function-local `static` in system tick files.**
 


### PR DESCRIPTION
## Summary
- Move the IRMath substitution table from `simplify/SKILL.md` into `.claude/rules/cpp-math.md` (canonical home already referenced by simplify)
- Update `simplify`, `backend-parity`, `optimize`, and `review-pr` SKILL.md files to one-line refs instead of duplicated/paraphrased tables

Closes #815

## Test plan
- [ ] grep confirms no remaining IRMath substitution table in simplify/SKILL.md
- [ ] grep confirms no remaining IRMath substitution paraphrases in backend-parity, optimize, review-pr SKILL.md
- [ ] .claude/rules/cpp-math.md has the authoritative table (already present, verify not regressed)