### PR TITLE
fleet-claim: allow `*` in task titles via non-greedy header regex

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -621,7 +621,7 @@ def edit_tasks_md(content, action, task_id, owner):
     found = False
     decision = None
 
-    header_re = re.compile(r'^- \[([ ~x!])\] \*\*([^*]+)\*\*(.*)$')
+    header_re = re.compile(r'^- \[([ ~x!])\] \*\*(.+?)\*\*(.*)$')
     field_re = re.compile(r'^(\s+)- \*\*([^:]+):\*\*\s*(.*?)\s*$')
 
     n = len(lines)
@@ -1198,7 +1198,7 @@ content = os.environ.get('FLEET_RECLAIM_TASKS_MD', '')
 block_status = None
 block_id = None
 block_owner = None
-header_re = re.compile(r'^- \[([ ~x!])\] \*\*([^*]+)\*\*')
+header_re = re.compile(r'^- \[([ ~x!])\] \*\*(.+?)\*\*')
 field_re = re.compile(r'^\s+- \*\*([^:]+):\*\*\s*(.*?)\s*$')
 for line in content.splitlines():
     m = header_re.match(line)


### PR DESCRIPTION
## Summary

- `fleet-claim`'s task-header regex `^- \[([ ~x!])\] \*\*([^*]+)\*\*` excluded `*` from the title group, so the inner block walk in `edit_tasks_md` failed to recognize T-218's header (`tooling: allow fleet agents to force-push claude/* branches in settings.json`) as a task boundary.
- Symptom: `fleet-claim claim "T-217" opus-worker-1` returned `T-217 not found in master/TASKS.md` even though T-217 is present and `Owner: free` — the walk past T-217's fields kept reading, overwriting `block_id_local` with T-218's (and beyond) ID, so the final equality check failed.
- Two regex occurrences (`edit_tasks_md` and the `cmd_reclaim` inner block) changed to `\*\*(.+?)\*\*`. Sibling fleet scripts (`fleet-tasks-render`, `fleet-state-scout`) already use the permissive form — this aligns `fleet-claim` with them.

## Verification

Ran an equivalent block-walk in python over the current `origin/master:TASKS.md` with the patched regex:

- All 56 task IDs parse cleanly, no duplicates
- T-215, T-217, T-218, T-219, T-220, T-221, T-222 all individually findable
- Block boundaries correctly land at each task header (T-217 ends at line 304, T-218 starts at line 305)

## Test plan

- [ ] `fleet-claim claim "T-217" opus-worker-1` from a fresh worktree succeeds (or correctly reports race-lost if already claimed)
- [ ] `fleet-claim claim "T-218" opus-worker-2` still works (was already working pre-fix because T-218 is followed by T-219 whose header is clean)
- [ ] `fleet-claim reclaim "T-217"` correctly inspects state via the patched `cmd_reclaim` regex

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)