### PR TITLE
T-233: docs/skills: replace naming-table copies with one-line refs to CLAUDE-BASELINE

### DIFF
--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -122,7 +122,7 @@ and `.../metal/`.
 |----------------------------------------------------------|-------------------------------------------------------------|
 | `engine/render/src/shaders/*.glsl` (flat)                | `engine/render/src/shaders/metal/*.metal`                    |
 
-GLSL prefixes (`c_`, `v_`, `f_`, `g_`) indicate the stage. MSL files
+GLSL shader file prefixes follow CLAUDE-BASELINE.md §Naming. MSL files
 use one `.metal` file per shader with the stage inferred from the
 `kernel` / `vertex` / `fragment` declaration inside. A single `.metal`
 file sometimes bundles a vertex and a fragment stage together (see

--- a/.claude/skills/ecs-prefab-creator/SKILL.md
+++ b/.claude/skills/ecs-prefab-creator/SKILL.md
@@ -19,7 +19,7 @@ Prefabs are header-only files under `engine/prefabs/irreden/<domain>/`. They com
 
 1. Use include guard `COMPONENT_<NAME>_H`.
 2. Namespace `IRComponents`, struct name `C_<PascalName>`.
-3. Public members use trailing `_`. Private members use `m_` prefix.
+3. Follow naming conventions in CLAUDE-BASELINE.md §Naming (struct `C_<PascalName>`, trailing `_` public, `m_` private).
 4. Provide a default constructor and at least one parameterized constructor.
 
 ```cpp
@@ -196,7 +196,7 @@ Pipelines run in order: **INPUT -> UPDATE -> RENDER**. System order within a pip
 
 ## Checklist
 
-- [ ] Component: `C_` prefix, `IRComponents` namespace, trailing `_` on public members
+- [ ] Naming: `C_<PascalName>` struct in `IRComponents` namespace — see CLAUDE-BASELINE.md §Naming
 - [ ] System: enum added to `ir_system_types.hpp` first
 - [ ] System: `System<NAME>` specialization with `create()`
 - [ ] Command: enum added to `ir_command_types.hpp` first

--- a/.claude/skills/render-trixel-pipeline/SKILL.md
+++ b/.claude/skills/render-trixel-pipeline/SKILL.md
@@ -103,16 +103,7 @@ Mapped in the compute shader via `localIDToFace()` with work group size `(2, 3, 
 
 ## Shaders
 
-All shaders live in `engine/render/src/shaders/`. Naming convention:
-
-| Prefix | Type | Example |
-|--------|------|---------|
-| `c_` | Compute | `c_voxel_to_trixel_stage_1.glsl` |
-| `v_` | Vertex | `v_trixel_to_framebuffer.glsl` |
-| `f_` | Fragment | `f_trixel_to_framebuffer.glsl` |
-| `g_` | Geometry | (none currently) |
-
-Metal equivalents exist under `engine/render/src/shaders/metal/`.
+All shaders live in `engine/render/src/shaders/`. File prefixes (`c_` compute, `v_` vertex, `f_` fragment, `g_` geometry) follow CLAUDE-BASELINE.md §Naming. Metal equivalents exist under `engine/render/src/shaders/metal/`.
 
 ### Key Compute Shaders
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -257,12 +257,7 @@ or any `c_compute_*shadow*.glsl` / `.metal`)
   simplify and review-pr checks cannot guard it without the annotation. Add the annotation
   and set `kSaveVersion = 1` on the struct.
 
-**Naming / style**
-- ❌ `m_` on public members, trailing `_` on private members (backwards).
-- ❌ `MinimapDetail`-style feature-specific helper namespaces instead of
-  `detail`.
-- ❌ Abbreviations in new names where a full word would read more clearly.
-- ❌ Anonymous namespaces in headers.
+**Naming / style** — follow CLAUDE-BASELINE.md §Naming. Most common slip: `m_` on public / trailing `_` on private (backwards).
 
 **Tests / build**
 - ❌ Code change with no corresponding test change where a test existed.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -261,17 +261,7 @@ Run this additional check in the same scope as the version-bump check
 
 ### 3. Naming convention slips
 
-These are the rules from [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md):
-
-| Context           | Convention            |
-|-------------------|-----------------------|
-| Private members   | `m_` prefix           |
-| Public members    | trailing `_`          |
-| Components        | `C_` prefix           |
-| Compute shaders   | `c_` prefix           |
-| Vertex shaders    | `v_` prefix           |
-| Fragment shaders  | `f_` prefix           |
-| Geometry shaders  | `g_` prefix           |
+Follow the naming table in [`docs/agents/CLAUDE-BASELINE.md` §Naming](../../../docs/agents/CLAUDE-BASELINE.md).
 
 Backwards usage (`m_` on public, trailing `_` on private) is the
 single most common slip — fix it inline. Same for missing `C_` on a


### PR DESCRIPTION
## Summary

- `simplify/SKILL.md` §3 — drop the 9-row markdown table; keep BASELINE link + backwards-usage fix pattern
- `ecs-prefab-creator/SKILL.md` — replace inline step description + checklist item with refs to CLAUDE-BASELINE §Naming
- `render-trixel-pipeline/SKILL.md` §Shaders — collapse 6-row shader-prefix table into one prose line
- `backend-parity/SKILL.md` — replace GLSL prefix restatement with BASELINE ref; MSL-specific bundling note retained
- `review-pr/SKILL.md` — compress 4-bullet Naming/style section to one-line ref + most-common-slip reminder

Net: 5 files, −30 lines (duplicated tables removed), +6 lines (refs).

## Test plan

- [x] Each affected SKILL.md still names CLAUDE-BASELINE.md §Naming as the canonical source
- [x] Skill-specific fix patterns retained (backwards usage in simplify + review-pr, MSL bundling rule in backend-parity, shader location in render-trixel-pipeline)
- [x] No other content removed

Closes #816