### PR TITLE
T-233: docs/skills: replace naming-table copies with one-line refs to CLAUDE-BASELINE

### DIFF
--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -122,7 +122,7 @@ and `.../metal/`.
 |----------------------------------------------------------|-------------------------------------------------------------|
 | `engine/render/src/shaders/*.glsl` (flat)                | `engine/render/src/shaders/metal/*.metal`                    |
 
-GLSL prefixes (`c_`, `v_`, `f_`, `g_`) indicate the stage. MSL files
+GLSL prefixes (`c_`, `v_`, `f_`, `g_`) follow CLAUDE-BASELINE §Naming and indicate the shader stage. MSL files
 use one `.metal` file per shader with the stage inferred from the
 `kernel` / `vertex` / `fragment` declaration inside. A single `.metal`
 file sometimes bundles a vertex and a fragment stage together (see

--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -122,7 +122,7 @@ and `.../metal/`.
 |----------------------------------------------------------|-------------------------------------------------------------|
 | `engine/render/src/shaders/*.glsl` (flat)                | `engine/render/src/shaders/metal/*.metal`                    |
 
-GLSL prefixes (`c_`, `v_`, `f_`, `g_`) follow CLAUDE-BASELINE §Naming and indicate the shader stage. MSL files
+GLSL prefixes (`c_`, `v_`, `f_`, `g_`) follow [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming and indicate the shader stage. MSL files
 use one `.metal` file per shader with the stage inferred from the
 `kernel` / `vertex` / `fragment` declaration inside. A single `.metal`
 file sometimes bundles a vertex and a fragment stage together (see

--- a/.claude/skills/ecs-prefab-creator/SKILL.md
+++ b/.claude/skills/ecs-prefab-creator/SKILL.md
@@ -19,7 +19,7 @@ Prefabs are header-only files under `engine/prefabs/irreden/<domain>/`. They com
 
 1. Use include guard `COMPONENT_<NAME>_H`.
 2. Namespace `IRComponents`, struct name `C_<PascalName>`.
-3. Public members use trailing `_`. Private members use `m_` prefix.
+3. Follow naming conventions in [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming (public trailing `_`, private `m_` prefix, struct name `C_<PascalName>`).
 4. Provide a default constructor and at least one parameterized constructor.
 
 ```cpp
@@ -197,7 +197,7 @@ Pipelines run in order: **INPUT -> UPDATE -> RENDER**. System order within a pip
 
 ## Checklist
 
-- [ ] Component: `C_` prefix, `IRComponents` namespace, trailing `_` on public members
+- [ ] Component: `C_` prefix, `IRComponents` namespace (see CLAUDE-BASELINE §Naming for member conventions)
 - [ ] System: enum added to `ir_system_types.hpp` first
 - [ ] System: `System<NAME>` specialization with `create()`
 - [ ] Command: enum added to `ir_command_types.hpp` first

--- a/.claude/skills/render-trixel-pipeline/SKILL.md
+++ b/.claude/skills/render-trixel-pipeline/SKILL.md
@@ -103,14 +103,7 @@ Mapped in the compute shader via `localIDToFace()` with work group size `(2, 3, 
 
 ## Shaders
 
-All shaders live in `engine/render/src/shaders/`. Naming convention:
-
-| Prefix | Type | Example |
-|--------|------|---------|
-| `c_` | Compute | `c_voxel_to_trixel_stage_1.glsl` |
-| `v_` | Vertex | `v_trixel_to_framebuffer.glsl` |
-| `f_` | Fragment | `f_trixel_to_framebuffer.glsl` |
-| `g_` | Geometry | (none currently) |
+All shaders live in `engine/render/src/shaders/`. Shader prefixes follow the naming table in [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming (`c_` compute, `v_` vertex, `f_` fragment, `g_` geometry).
 
 Metal equivalents exist under `engine/render/src/shaders/metal/`.
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -280,12 +280,8 @@ or any `c_compute_*shadow*.glsl` / `.metal`)
   simplify and review-pr checks cannot guard it without the annotation. Add the annotation
   and set `kSaveVersion = 1` on the struct.
 
-**Naming / style**
-- ❌ `m_` on public members, trailing `_` on private members (backwards).
-- ❌ `MinimapDetail`-style feature-specific helper namespaces instead of
-  `detail`.
-- ❌ Abbreviations in new names where a full word would read more clearly.
-- ❌ Anonymous namespaces in headers.
+**Naming / style** — follow the table in [`docs/agents/CLAUDE-BASELINE.md`](../../docs/agents/CLAUDE-BASELINE.md) §Naming.
+- ❌ `m_` on public members, trailing `_` on private members (backwards — the single most common slip).
 
 **Tests / build**
 - ❌ Code change with no corresponding test change where a test existed.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -307,18 +307,7 @@ Run this additional check in the same scope as the version-bump check
 
 ### 3. Naming convention slips
 
-These are the rules from [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md):
-
-| Context           | Convention            |
-|-------------------|-----------------------|
-| Private members   | `m_` prefix           |
-| Public members    | trailing `_`          |
-| Components        | `C_` prefix           |
-| Compute shaders   | `c_` prefix           |
-| Vertex shaders    | `v_` prefix           |
-| Fragment shaders  | `f_` prefix           |
-| Geometry shaders  | `g_` prefix           |
-
+Follow the naming table in [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming.
 Backwards usage (`m_` on public, trailing `_` on private) is the
 single most common slip — fix it inline. Same for missing `C_` on a
 new component class, missing shader prefixes, anonymous namespaces in


### PR DESCRIPTION
## Summary

- Removes the full naming-convention table from `simplify/SKILL.md` §3 (9-row table) and replaces it with a one-sentence ref to CLAUDE-BASELINE.md §Naming
- Replaces the 4-row shader-prefix table in `render-trixel-pipeline/SKILL.md` with a one-liner that inlines the prefix list
- Condenses the 4 naming/style anti-pattern bullets in `review-pr/SKILL.md` to a ref + the single most actionable anti-pattern (backwards m_/trailing_ usage)
- Replaces the inline naming step in `ecs-prefab-creator/SKILL.md` with a ref; updates the checklist entry to drop the redundant trailing_ mention
- Adds a CLAUDE-BASELINE ref to the GLSL prefix mention in `backend-parity/SKILL.md` (backend-specific porting context kept intact)

Net: -22 lines across 5 files.

## Test plan
- [ ] Verify `simplify/SKILL.md` no longer contains the 7-row naming table; §3 opens with the CLAUDE-BASELINE ref
- [ ] Verify `render-trixel-pipeline/SKILL.md` has no standalone prefix table; §Shaders has the one-liner
- [ ] Verify `review-pr/SKILL.md` **Naming / style** section has the baseline ref + backwards-usage bullet
- [ ] Verify `ecs-prefab-creator/SKILL.md` step 3 references CLAUDE-BASELINE; checklist item retains `C_` prefix check
- [ ] Verify `backend-parity/SKILL.md` GLSL prefix line now includes the CLAUDE-BASELINE pointer

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)