### PR TITLE
T-235: docs/skills: consolidate fleet-build/fleet-run snippets into one canonical block in BUILD.md

### DIFF
--- a/.claude/skills/attach-screenshots/SKILL.md
+++ b/.claude/skills/attach-screenshots/SKILL.md
@@ -182,13 +182,12 @@ Build and run:
 
 ```bash
 fleet-build --target <demo-name>
-fleet-run --timeout 30 <demo-name> --auto-screenshot 10
+fleet-run <demo-name> --auto-screenshot 10
 ```
 
-`IRShapeDebug` finishes its 6-shot sequence in ~3s; `--timeout 30`
-gives a safety margin for slower hosts without leaving windows open
-if something hangs. `fleet-run` reports `exited cleanly after Ns`
-on normal completion.
+`fleet-run` reports `exited cleanly after Ns` on normal completion.
+Do not add `--timeout` — auto-screenshot fires `closeWindow()` when the
+shot sequence is done; a timeout would mask hangs (see [BUILD.md §Timeout choices](../../../docs/agents/BUILD.md#timeout-choices)).
 
 If `fleet-build` or `fleet-run` fails, **restore** before
 propagating the failure:
@@ -228,7 +227,7 @@ second `rm` needed:
 
 ```bash
 fleet-build --target <demo-name>
-fleet-run --timeout 30 <demo-name> --auto-screenshot 10
+fleet-run <demo-name> --auto-screenshot 10
 ```
 
 Move the PNGs to the output directory with `-after` suffixes,

--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -246,27 +246,17 @@ either:
 
 ### 5. Build the lagging backend
 
-After every port, the skill must **build the lagging preset clean**:
-
-**macOS (porting to Metal):**
-
-```bash
-cmake --build build --target IRShapeDebug -j$(sysctl -n hw.ncpu)
-```
-
-**Linux/WSL (porting to OpenGL):**
+After every port, the skill must **build the lagging preset clean**.
+Use `fleet-build` — it avoids the `$(nproc)` / `$(sysctl)` command-substitution
+gate and auto-detects the worktree's build tree:
 
 ```bash
-cmake --build build --target IRShapeDebug -j$(nproc)
+fleet-build --target IRShapeDebug
 ```
 
-**Windows-native (porting to OpenGL):**
-
-Use the PATH-fix wrapper from [`docs/agents/BUILD.md`](../../../docs/agents/BUILD.md):
-
-```bash
-cmd.exe /c "set PATH=C:\\msys64\\mingw64\\bin;%PATH% && \"C:/Program Files/CMake/bin/cmake.EXE\" --build C:/Users/evinj/VSCODE_PROJECTS/repos/IrredenEngine/build --target IRShapeDebug -- -j4" 2>&1
-```
+This works on macOS (`macos-debug` preset) and Linux/WSL (`linux-debug` preset).
+For Windows-native, use the PATH-fix wrapper documented in
+[`docs/agents/BUILD.md`](../../../docs/agents/BUILD.md).
 
 **Watch for the build-hygiene canary** — a "Built target" line without
 any "Building CXX object" / "Building C object" / "Building Metal
@@ -282,12 +272,10 @@ submitting a half-port.
 
 A clean build is necessary but not sufficient. Also launch the
 demo that exercises the feature and confirm it doesn't crash on the
-first frame. At minimum:
+first frame:
 
 ```bash
-# macOS:
-cd build/creations/demos/shape_debug && ./IRShapeDebug
-# Linux/WSL: same (WSLg routes the window to Windows host)
+fleet-run --timeout 15 IRShapeDebug
 ```
 
 Let it render at least a few frames. If it's a deterministic scene,

--- a/.claude/skills/render-verify/SKILL.md
+++ b/.claude/skills/render-verify/SKILL.md
@@ -100,7 +100,7 @@ The driver:
 2. Detects the backend from `build/CMakeCache.txt`.
 3. Runs `fleet-build --target IRShapeDebug`.
 4. Clears `<exe_dir>/save_files/screenshots/`.
-5. Runs `fleet-run --timeout 60 IRShapeDebug --auto-screenshot 10`.
+5. Runs `fleet-run IRShapeDebug --auto-screenshot 10`.
 6. For each shot, runs `scripts/render-compare.py` against the reference.
 7. Prints a pass/fail table and exits non-zero on any failure.
 

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -186,6 +186,23 @@ fleet-run IRShapeDebug
 fleet-run IrredenEngineTest --gtest_brief=1
 ```
 
+### Timeout choices
+
+Two modes; never mix them:
+
+- **`--auto-screenshot` demos** — omit `--timeout`:
+  `fleet-run <demo> --auto-screenshot 10`
+  Auto-screenshot fires `closeWindow()` when the shot sequence is done.
+  Adding `--timeout` would mask hangs: `fleet-run` reports "alive at deadline"
+  as success even when `--auto-screenshot` never completes.
+
+- **All other executables** (interactive demos, test binaries, profiling runs) —
+  use `--timeout 15`:
+  `fleet-run --timeout 15 <exe>`
+  The fleet-wide default; 5 s is too short for a demo mid-init.
+
+---
+
 `fleet-run --targets` lists names you can pass to `fleet-run` (built
 executables under `creations/` and `test/` by default; add `--plan` for
 CMake demo/test targets from `cmake --build --target help`). Same as

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -199,7 +199,7 @@ Two modes; never mix them:
 - **All other executables** (interactive demos, test binaries, profiling runs) —
   use `--timeout 15`:
   `fleet-run --timeout 15 <exe>`
-  The fleet-wide default; 5 s is too short for a demo mid-init.
+  15 s gives demos time to init; omitting `--timeout` would block indefinitely.
 
 ---
 


### PR DESCRIPTION
## Summary
- Added canonical Timeout choices block to docs/agents/BUILD.md: no --timeout for --auto-screenshot demos, --timeout 15 for all other executables
- Fixed attach-screenshots: removed --timeout 30 from both before-pass and after-pass --auto-screenshot calls (timeouts mask hangs; auto-screenshot fires closeWindow when done)
- Fixed render-verify: removed --timeout 60 from --auto-screenshot call
- Fixed backend-parity section 5: replaced per-platform raw cmake --build ... -j$(nproc) / -j$(sysctl) blocks with fleet-build --target IRShapeDebug (eliminates command-substitution gate + CLAUDE-BASELINE cmake violation)
- Fixed backend-parity section 6: replaced cd build/... && ./IRShapeDebug compound command with fleet-run --timeout 15 IRShapeDebug

Closes #818

## Test plan
- [ ] No `cmake --build` raw calls remain in any SKILL.md except the Windows PATH-fix wrapper in backend-parity (which is the only valid form for Windows-native)
- [ ] No `--timeout` flag paired with `--auto-screenshot` remains in any SKILL.md
- [ ] `docs/agents/BUILD.md` has the canonical Timeout choices block under "Running an executable"