### PR TITLE
T-234: docs/skills: shrink commit-and-push cross-repo info-isolation procedure to a check + baseline ref

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -115,45 +115,11 @@ Skip the prompt if:
 - `docs/pr-screenshots/<branch>/` already contains screenshots from a prior
   run on this branch.
 
-**Then**, run the cross-repo information-isolation check (see engine
-`CLAUDE.md` "Cross-repo information isolation"). The engine repo is
-public; the game repo is private. Engine PRs MUST NOT leak game
-content. Scan the staged diff and the to-be-written PR body for any
-of the following game-leakage tokens:
-
-- `creations/game/` — engine PRs should never touch game files. If
-  the diff includes a path under `creations/game/`, this almost
-  certainly means the worker is in the wrong worktree (the engine
-  PR shouldn't be modifying the game tree). Stop and warn.
-- `jakildev/irreden` — the game repo slug. If a draft PR body or
-  commit message references it, scrub before continuing.
-- A `T-NNN` task ID that came from the game queue (cross-check
-  against `~/src/IrredenEngine/creations/game/TASKS.md` if present).
-  Engine PR bodies should reference engine task IDs only.
-- Game-specific feature names or design language. This one needs
-  human judgment — if the commit message you've drafted talks about
-  "ant pheromone trails" or "fungus sporulation" instead of the
-  underlying engine capability, rewrite in pure engine terms.
-
-Check for staged game-repo paths with a single git command using a
-pathspec filter — no pipe, no compound operator:
-
-```bash
-git diff --cached --name-only -- 'creations/game/'
-```
-
-If the output is non-empty, the commit includes `creations/game/`
-paths and you must stop and warn the user. (If the output is empty,
-git prints nothing and you proceed.)
-
-For the PR body / commit message scan (looking for `jakildev/irreden`
-references or game task IDs), use the **Grep tool** on the draft text
-rather than a shell pipe.
-
-If any leakage is found, surface it to the user before committing.
-The fix is usually a 30-second rewrite of the commit message and PR
-body in engine-level terms; rarely is a code change actually needed
-(if it is, the worker is in the wrong repo entirely).
+**Then**, run the cross-repo information-isolation check per
+`docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation":
+scan staged paths with `git diff --cached --name-only -- 'creations/game/'`
+and the PR body draft with the Grep tool for the game-leakage tokens
+listed there. Surface any match to the user before committing.
 
 **Then** invoke the `simplify` skill to review the dirty changes for reuse,
 quality, and efficiency issues specific to Irreden Engine:
@@ -458,10 +424,7 @@ if the user already asked for the next task).
 - ❌ Opening a PR without running `simplify` first.
 - ❌ Continuing to commit on the same feature branch after opening its PR
   unless the user explicitly asks for it — otherwise use `start-next-task`.
-- ❌ Leaking game references into an engine PR (file paths under
-  `creations/game/`, `jakildev/irreden`, game task IDs, game design
-  language). Engine repo is public; game repo is private. See engine
-  `CLAUDE.md` "Cross-repo information isolation".
+- ❌ Leaking game references into an engine PR — see `docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation".
 
 ## Recovery
 


### PR DESCRIPTION
## Summary
- Replace 38-line inline cross-repo info-isolation procedure in `commit-and-push/SKILL.md` (lines 118-156) with a ~4-line check + pointer to `docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation"
- Tighten the anti-pattern bullet (lines 461-464) to a one-liner pointing at the canonical baseline instead of restating the token list

Closes #817