### PR TITLE
fleet: fleet-claim master-lock parser accepts '*' in task titles

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -621,7 +621,7 @@ def edit_tasks_md(content, action, task_id, owner):
     found = False
     decision = None
 
-    header_re = re.compile(r'^- \[([ ~x!])\] \*\*([^*]+)\*\*(.*)$')
+    header_re = re.compile(r'^- \[([ ~x!])\] \*\*(.+?)\*\*(.*)$')
     field_re = re.compile(r'^(\s+)- \*\*([^:]+):\*\*\s*(.*?)\s*$')
 
     n = len(lines)
@@ -1198,7 +1198,7 @@ content = os.environ.get('FLEET_RECLAIM_TASKS_MD', '')
 block_status = None
 block_id = None
 block_owner = None
-header_re = re.compile(r'^- \[([ ~x!])\] \*\*([^*]+)\*\*')
+header_re = re.compile(r'^- \[([ ~x!])\] \*\*(.+?)\*\*')
 field_re = re.compile(r'^\s+- \*\*([^:]+):\*\*\s*(.*?)\s*$')
 for line in content.splitlines():
     m = header_re.match(line)


### PR DESCRIPTION
## Summary
- `scripts/fleet/fleet-claim` lines 624 and 1201 used `[^*]+` between the `**...**` title delimiters, which fails on titles containing a literal `*` (e.g. T-221's `role-*.md`).
- When the master-lock parser was scanning T-217's block, T-221's header line at line 274 of `TASKS.md` failed the header regex → the inner block-scan walked past T-221's header and absorbed T-221's `**ID:** T-221` field line. T-217 was then effectively missing from the parsed task map.
- Result: `fleet-claim claim "T-217" opus-worker-1` exited 2 with `T-217 not found in master/TASKS.md` even though T-217 is present, free, and unblocked.
- Replace `[^*]+` with `.+?` (lazy match), matching the sibling parsers at lines 192 (blocked-by) and 1077 (cleanup) that have used the correct form all along.

## Root cause writeup
Issue #882 has the full reproduction + trace.

## Test plan
- [x] Direct parser-logic exercise against current `origin/master` TASKS.md sees 39 task IDs (was 38); T-217 and T-221 both visible.
- [ ] `fleet-claim claim "T-217" opus-worker-1` on a fresh worktree should succeed (no longer "not found").
- [ ] No behaviour change on any task whose title contains no `*` (the lazy form is equivalent to the negated-class form when the delimiter doesn't appear in the title).

## Notes for reviewer
Two surgical lines. The sibling parsers in the same file (192, 1077) already use `.+?`, so this is parity cleanup rather than a new pattern choice. No test infrastructure exists for the parsers; if one is desired, a follow-up issue could add a `tests/fleet/test_fleet_claim_parser.py` with a couple of `*`-bearing-title fixtures.

Closes #882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)