### PR TITLE
T-239: docs/skills: lift commit-and-push host-stamp logic into procedures/host-label.md

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -384,43 +384,7 @@ permissions.
 
 ### 8b. Tag the host the PR was authored on
 
-After `gh pr create` succeeds, stamp a `fleet:authored-on-<host>`
-label so the reviewer knows which backend the author already
-implicitly smoke-tested. Per the engine `CLAUDE.md` "Verifying
-render changes" section, render-PR authors are expected to build
-and run the demo on their host before opening — so authoring on a
-host is reasonable evidence that host's smoke is at least
-baseline-validated.
-
-This is the **author's host fact**, not a state label. Reviewers
-read it to skip the matching `fleet:needs-<host>-smoke` label so
-the author's host doesn't get tagged for redundant validation.
-The OTHER host's smoke label (if needed per the diff) still gets
-added — backend drift between OpenGL and Metal is the whole point
-of cross-host validation.
-
-```bash
-host_kernel=$(uname -s)
-case "$host_kernel" in
-    Linux)  host_label="fleet:authored-on-linux" ;;
-    Darwin) host_label="fleet:authored-on-macos" ;;
-    *)      host_label="" ;;  # unknown host (Windows native, etc.) — skip
-esac
-if [[ -n "$host_label" ]]; then
-    gh pr edit <N> --add-label "$host_label"
-fi
-```
-
-This applies to **all** PRs (engine and game, render-touching or
-not). The label is cheap and consistent — having it always present
-makes the reviewer's logic simple ("subtract author host from smoke
-labels"). Game PRs don't currently get smoke labels, so the host
-label is just informational there; that's fine.
-
-If the host kernel is neither `Linux` nor `Darwin` (Windows
-native via MSYS2, etc.), skip the label — the cross-host smoke
-flow is OpenGL-on-Linux vs Metal-on-macOS, and a Windows author
-doesn't fit either bucket cleanly.
+See [`procedures/host-label.md`](procedures/host-label.md). Applies to all PRs.
 
 ### 9. Report the result
 

--- a/.claude/skills/commit-and-push/procedures/host-label.md
+++ b/.claude/skills/commit-and-push/procedures/host-label.md
@@ -1,0 +1,21 @@
+# Host label (authored-on stamp)
+
+After `gh pr create` succeeds, stamp a `fleet:authored-on-<host>` label so the reviewer knows which backend the author already implicitly smoke-tested. Per the engine `CLAUDE.md` "Verifying render changes" section, render-PR authors are expected to build and run the demo on their host before opening — so authoring on a host is reasonable evidence that host's smoke is at least baseline-validated.
+
+This is the **author's host fact**, not a state label. Reviewers read it to skip the matching `fleet:needs-<host>-smoke` label so the author's host doesn't get tagged for redundant validation. The OTHER host's smoke label (if needed per the diff) still gets added — backend drift between OpenGL and Metal is the whole point of cross-host validation. The reviewer's logic for reading this label and deciding which smoke tag to add lives in [`review-pr/procedures/cross-host-smoke.md`](../../review-pr/procedures/cross-host-smoke.md).
+
+```bash
+host_kernel=$(uname -s)
+case "$host_kernel" in
+    Linux)  host_label="fleet:authored-on-linux" ;;
+    Darwin) host_label="fleet:authored-on-macos" ;;
+    *)      host_label="" ;;  # unknown host (Windows native, etc.) — skip
+esac
+if [[ -n "$host_label" ]]; then
+    gh pr edit <N> --add-label "$host_label"
+fi
+```
+
+This applies to **all** PRs (engine and game, render-touching or not). The label is cheap and consistent — having it always present makes the reviewer's logic simple ("subtract author host from smoke labels"). Game PRs don't currently get smoke labels, so the host label is just informational there; that's fine.
+
+If the host kernel is neither `Linux` nor `Darwin` (Windows native via MSYS2, etc.), skip the label — the cross-host smoke flow is OpenGL-on-Linux vs Metal-on-macOS, and a Windows author doesn't fit either bucket cleanly.


### PR DESCRIPTION
## Summary

- Extracts the 37-line `fleet:authored-on-{linux,macos}` host-stamp block from `commit-and-push/SKILL.md §8b` into `commit-and-push/procedures/host-label.md`
- Follows the existing `procedures/` pattern (fleet-stack, cursor-stack, rebase-guard)
- Cross-references `review-pr/procedures/cross-host-smoke.md` (the reviewer-side counterpart) so both sides point at one another
- Net: -36 lines from the main SKILL.md (37 removed, 1 pointer added)

## Test plan

- [x] Docs-only change — no code modified
- [x] `procedures/host-label.md` contains the full shell snippet and rationale
- [x] `SKILL.md §8b` body is replaced with a one-line pointer
- [x] Cross-reference link to `review-pr/procedures/cross-host-smoke.md` is correct

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)