### PR TITLE
T-240: docs/skills: lift simplify's serialization version-bump rule into engine/asset/CLAUDE.md

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -151,103 +151,10 @@ raw stdout/printf in non-debug code is a cleanup target.
 
 ### 2c. Serialized-struct version-bump check
 
-When a struct annotated `// IRAsset: serialized` gains, loses, or renames a
-field, the matching `kSaveVersion` constant must be bumped in the same diff
-and a migration entry must exist (or be flagged as a `// TODO: migration`
-comment) in the format's reader. This is Save Format Extensibility Rule #3
-(`engine/asset/CLAUDE.md`).
-
-Run this check whenever any `.hpp` or `.cpp` file under `engine/asset/`,
-`engine/prefabs/irreden/voxel/`, or `engine/world/` is in the diff.
-
-**Detection:**
-
-1. Scan the diff's `+` lines for struct fields (member variable declarations)
-   inside a struct body whose `struct <Name>` declaration is preceded **on
-   the immediately prior line** by the comment `// IRAsset: serialized`.
-   The annotation must be on the line directly above `struct <Name>` — an
-   annotation elsewhere in the file does not apply to subsequent structs.
-
-2. For each struct type whose field layout changed (added/removed/renamed
-   field on a `+` or `-` line), check whether the diff also contains a
-   corresponding `kSaveVersion` change on a `+` line in the same file (or a
-   sibling sidecar file for the format):
-
-   ```
-   static constexpr uint16_t kSaveVersion = N;
-   ```
-
-3. If the field layout changed but no `kSaveVersion` bump appears in the
-   diff, emit a finding — **do not auto-fix**, this needs human judgment:
-
-   ```
-   reported 1 finding for review:
-     - <path>:<line> — <StructName> is annotated // IRAsset: serialized and
-       its field layout changed, but kSaveVersion was not bumped.
-       Add `static constexpr uint16_t kSaveVersion = N+1;` and a migration
-       entry in the format's reader for saves written at the old version.
-   ```
-
-**False-positive guard — do NOT flag:**
-- Changes to method bodies, constructors, or `static` helper functions within
-  the struct (these do not affect binary layout).
-- A struct whose `// IRAsset: serialized` annotation was itself added in the
-  same diff — version 1 never needs a migration.
-- Changes to the `kSaveVersion` line itself.
-- Changes that only touch comments or whitespace inside the struct.
-
-**Detection extension — unannotated serialized structs:**
-
-The version-bump check above protects structs that are *already* annotated.
-A second class of bug is structs whose fields are individually serialized
-but which lack the `// IRAsset: serialized` annotation entirely — the
-version-bump check then never fires, even on layout changes that need a
-migration. `ShapeRecord` (`engine/asset/include/irreden/asset/voxel_set_format.hpp`)
-shipped in T-168 / T-170 without the annotation despite each of its
-fields being individually written and read by the format's chunk
-handlers; the gap stayed invisible until an audit pass surfaced it.
-
-Run this additional check in the same scope as the version-bump check
-(diff in `engine/asset/`, `engine/prefabs/irreden/voxel/`, or
-`engine/world/`):
-
-1. Scan the diff's `+` lines for any sequence of two or more
-   `<writer>.write*(<expr>.<field>_)` calls where `<expr>` is a
-   reference to a struct instance and `<field>_` is a public member.
-   Likewise for `<reader>.read*` paired with assignment back to
-   `<expr>.<field>_`. Two-or-more is the heuristic for "this struct
-   is being serialized field-by-field" rather than "one field of a
-   struct happens to be written."
-
-2. For each struct type touched this way, resolve its declaration
-   (same file or sibling header) and check whether the declaration
-   is preceded by `// IRAsset: serialized` on the immediately prior
-   line per the annotation rule.
-
-3. If the struct is serialized field-by-field and lacks the
-   annotation, emit a finding — **do not auto-fix**, the annotation
-   carries a `kSaveVersion` constant whose initial value is a human
-   call:
-
-   ```
-   reported 1 finding for review:
-     - <header-path>:<line> — <StructName> is serialized field-by-field
-       by <function-path>:<line> but lacks the `// IRAsset: serialized`
-       annotation. Add the comment line directly above the struct
-       declaration plus a `static constexpr uint16_t kSaveVersion = 1;`
-       member so the version-bump check (Rule #3) covers future changes.
-   ```
-
-**False-positive guard for the extension — do NOT flag:**
-- Structs that only carry transient binary I/O state (`BinaryStatus`,
-  `LoadedChunk`, `ChunkPayload`, `Result<T>`). These pass through
-  format code without being the format's persisted record.
-- Structs declared in `engine/asset/include/irreden/asset/binary_io.hpp`
-  or `chunk_header.hpp` — framework types, not format records.
-- Cases where the writer/reader calls operate on a temporary or a
-  function-local variable that doesn't correspond to a named struct
-  type. The "this is the format's record" heuristic requires a
-  resolvable struct type.
+See `engine/asset/CLAUDE.md` §"Automated version-bump detection" for the full
+detection policy, false-positive guards, and the detection extension for
+unannotated serialized structs. Trigger scope: any `.hpp` or `.cpp` under
+`engine/asset/`, `engine/prefabs/irreden/voxel/`, or `engine/world/`.
 
 ### 3. Naming convention slips
 

--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -383,10 +383,10 @@ go through `writeString()` / `readString()`. The struct itself is not
    `(structType, oldVersion)`.
 3. Update the per-format save/load header block (Extensibility Rule #7).
 
-The `simplify` skill (pre-commit) and `review-pr` skill both run the
-version-bump detection policy below whenever a `.hpp` or `.cpp` file under
-`engine/asset/`, `engine/prefabs/irreden/voxel/`, or `engine/world/` is in
-the diff.
+The `simplify` skill runs the version-bump detection policy below whenever a
+`.hpp` or `.cpp` file under `engine/asset/`, `engine/prefabs/irreden/voxel/`,
+or `engine/world/` is in the diff; `review-pr` applies the same principles
+via its step 4 Serialization checklist.
 
 ### Automated version-bump detection
 
@@ -466,8 +466,8 @@ invisible until an audit pass surfaced it.
 - Structs that only carry transient binary I/O state (`BinaryStatus`,
   `LoadedChunk`, `ChunkPayload`, `Result<T>`). These pass through format code
   without being the format's persisted record.
-- Structs declared in `binary_io.hpp` or `chunk_header.hpp` — framework types,
-  not format records.
+- Structs declared in `binary_io.hpp` or `chunk_header.hpp` (under
+  `engine/asset/include/irreden/asset/`) — framework types, not format records.
 - Cases where the writer/reader calls operate on a temporary or a
   function-local variable that doesn't correspond to a named struct type.
 

--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -383,10 +383,93 @@ go through `writeString()` / `readString()`. The struct itself is not
    `(structType, oldVersion)`.
 3. Update the per-format save/load header block (Extensibility Rule #7).
 
-The `simplify` skill (pre-commit) and `review-pr` skill both scan for
-`// IRAsset: serialized` structs with changed field layouts and emit a finding
-when `kSaveVersion` was not bumped. See `.claude/skills/simplify/SKILL.md`
-section 2c and `.claude/skills/review-pr/SKILL.md` step 4 "Serialization".
+The `simplify` skill (pre-commit) and `review-pr` skill both run the
+version-bump detection policy below whenever a `.hpp` or `.cpp` file under
+`engine/asset/`, `engine/prefabs/irreden/voxel/`, or `engine/world/` is in
+the diff.
+
+### Automated version-bump detection
+
+**Check 1 — annotated structs:**
+
+1. Scan the diff's `+` lines for struct fields (member variable declarations)
+   inside a struct body whose `struct <Name>` declaration is preceded **on the
+   immediately prior line** by `// IRAsset: serialized`. The annotation must be
+   on the line directly above `struct <Name>` — an annotation elsewhere in the
+   file does not apply to subsequent structs.
+
+2. For each struct type whose field layout changed (added/removed/renamed field
+   on a `+` or `-` line), check whether the diff also contains a corresponding
+   `kSaveVersion` change on a `+` line in the same file (or a sibling sidecar
+   file for the format):
+
+   ```
+   static constexpr uint16_t kSaveVersion = N;
+   ```
+
+3. If the field layout changed but no `kSaveVersion` bump appears in the diff,
+   emit a finding — **do not auto-fix**, this needs human judgment:
+
+   ```
+   reported 1 finding for review:
+     - <path>:<line> — <StructName> is annotated // IRAsset: serialized and
+       its field layout changed, but kSaveVersion was not bumped.
+       Add `static constexpr uint16_t kSaveVersion = N+1;` and a migration
+       entry in the format's reader for saves written at the old version.
+   ```
+
+**False-positive guard — do NOT flag:**
+- Changes to method bodies, constructors, or `static` helper functions within
+  the struct (these do not affect binary layout).
+- A struct whose `// IRAsset: serialized` annotation was itself added in the
+  same diff — version 1 never needs a migration.
+- Changes to the `kSaveVersion` line itself.
+- Changes that only touch comments or whitespace inside the struct.
+
+**Check 2 — unannotated serialized structs:**
+
+The check above protects structs that are *already* annotated. A second class
+of bug is structs whose fields are individually serialized but which lack the
+`// IRAsset: serialized` annotation entirely — the version-bump check then
+never fires, even on layout changes that need a migration. `ShapeRecord`
+(`engine/asset/include/irreden/asset/voxel_set_format.hpp`) shipped in
+T-168 / T-170 without the annotation despite each of its fields being
+individually written and read by the format's chunk handlers; the gap stayed
+invisible until an audit pass surfaced it.
+
+1. Scan the diff's `+` lines for any sequence of two or more
+   `<writer>.write*(<expr>.<field>_)` calls where `<expr>` is a reference to a
+   struct instance and `<field>_` is a public member. Likewise for
+   `<reader>.read*` paired with assignment back to `<expr>.<field>_`.
+   Two-or-more is the heuristic for "this struct is being serialized
+   field-by-field" rather than "one field of a struct happens to be written."
+
+2. For each struct type touched this way, resolve its declaration (same file or
+   sibling header) and check whether the declaration is preceded by
+   `// IRAsset: serialized` on the immediately prior line per the annotation
+   rule.
+
+3. If the struct is serialized field-by-field and lacks the annotation, emit a
+   finding — **do not auto-fix**, the annotation carries a `kSaveVersion`
+   constant whose initial value is a human call:
+
+   ```
+   reported 1 finding for review:
+     - <header-path>:<line> — <StructName> is serialized field-by-field
+       by <function-path>:<line> but lacks the `// IRAsset: serialized`
+       annotation. Add the comment line directly above the struct
+       declaration plus a `static constexpr uint16_t kSaveVersion = 1;`
+       member so the version-bump check covers future changes.
+   ```
+
+**False-positive guard for Check 2 — do NOT flag:**
+- Structs that only carry transient binary I/O state (`BinaryStatus`,
+  `LoadedChunk`, `ChunkPayload`, `Result<T>`). These pass through format code
+  without being the format's persisted record.
+- Structs declared in `binary_io.hpp` or `chunk_header.hpp` — framework types,
+  not format records.
+- Cases where the writer/reader calls operate on a temporary or a
+  function-local variable that doesn't correspond to a named struct type.
 
 Not every asset-related struct needs this annotation — only those whose fields
 are **directly serialized** into a chunk body byte-for-byte. Framework structs


### PR DESCRIPTION
## Summary
- Move the ~98-line serialization version-bump detection policy out of `.claude/skills/simplify/SKILL.md` into `engine/asset/CLAUDE.md` where it belongs canonically
- Replace the inline block in simplify with a one-line ref to `engine/asset/CLAUDE.md`

## Test plan
- [ ] Verify `engine/asset/CLAUDE.md` contains the serialization version-bump rule with full context
- [ ] Verify `simplify/SKILL.md` no longer duplicates the rule; has a pointer to `engine/asset/CLAUDE.md` instead
- [ ] No functional change — docs-only

Closes #823