### PR TITLE
T-241: docs/skills: rewrite render-trixel-pipeline/SKILL.md to concepts-only

### DIFF
--- a/.claude/skills/render-trixel-pipeline/SKILL.md
+++ b/.claude/skills/render-trixel-pipeline/SKILL.md
@@ -10,225 +10,41 @@ description: >-
 
 # Render / Trixel Pipeline
 
-## Pipeline Overview
+Read `engine/render/CLAUDE.md` first — it has the authoritative pipeline
+diagram, gotchas (hardcoded bind points, distance-clear semantics, canvas
+destruction ordering), and the SDF-vs-voxel-pool parity rules. For isometric
+projection equations, see `engine/math/CLAUDE.md` §"Isometric projection — the
+equations".
 
-```
-Voxels (C_VoxelPool positions/colors)
-    |
-    v
-Stage 1: Depth pass (c_voxel_to_trixel_stage_1.glsl)
-    |    Writes distance buffer (per-trixel depth)
-    v
-Stage 2: Color pass (c_voxel_to_trixel_stage_2.glsl)
-    |    Writes RGBA colors, distances, entity IDs
-    v
-Shapes to Trixel (c_shapes_to_trixel.glsl)  [optional]
-    |    SDF-based shape rasterization
-    v
-Text to Trixel (c_text_to_trixel.glsl)  [optional]
-    |    Glyph rendering via TrixelFont
-    v
-Trixel to Trixel (c_trixel_to_trixel.glsl)  [optional]
-    |    Composites child canvases onto parent canvas
-    v
-Trixel to Framebuffer (v/f_trixel_to_framebuffer.glsl)
-    |    Renders trixel canvas to screen-sized framebuffer
-    v
-Debug Overlay (v/f_debug_overlay.glsl)  [optional]
-    v
-Framebuffer to Screen (v/f_framebuffer_to_screen.glsl)
-    |    Final blit to window
-```
+## Two-stage depth split
 
-## System Registration Order
+Stage 1 (`c_voxel_to_trixel_stage_1.glsl`) writes only depth via
+`imageAtomicMin`. Stage 2 (`c_voxel_to_trixel_stage_2.glsl`) reads that depth
+before writing color and entity IDs. Never merge or reorder these two — the
+`imageAtomicMin` in Stage 1 is the only thing that resolves overdraw; if Stage
+2 runs first, every voxel writes unconditionally and the color pass is garbage.
 
-Systems must be registered in the RENDER pipeline in dependency order:
+A minimal creation needs exactly four systems in the RENDER pipeline:
+`VOXEL_TO_TRIXEL_STAGE_1`, `VOXEL_TO_TRIXEL_STAGE_2`,
+`TRIXEL_TO_FRAMEBUFFER`, `FRAMEBUFFER_TO_SCREEN`. All other systems
+(lighting passes, SHAPES_TO_TRIXEL, TRIXEL_TO_TRIXEL, etc.) are optional
+overlays inserted between Stage 2 and TRIXEL_TO_FRAMEBUFFER.
 
-```cpp
-IRSystem::registerPipeline(
-    IRTime::Events::RENDER,
-    {IRSystem::createSystem<IRSystem::CAMERA_MOUSE_PAN>(),
-     IRSystem::createSystem<IRSystem::UPDATE_VOXEL_POSITIONS_GPU>(),
-     IRSystem::createSystem<IRSystem::VOXEL_TO_TRIXEL_STAGE_1>(),
-     IRSystem::createSystem<IRSystem::VOXEL_TO_TRIXEL_STAGE_2>(),
-     IRSystem::createSystem<IRSystem::SHAPES_TO_TRIXEL>(),
-     IRSystem::createSystem<IRSystem::TEXT_TO_TRIXEL>(),
-     IRSystem::createSystem<IRSystem::TRIXEL_TO_TRIXEL>(),
-     IRSystem::createSystem<IRSystem::TRIXEL_TO_FRAMEBUFFER>(),
-     IRSystem::createSystem<IRSystem::DEBUG_OVERLAY>(),
-     IRSystem::createSystem<IRSystem::FRAMEBUFFER_TO_SCREEN>()}
-);
-```
+## Trixel compositing (CHILD_OF)
 
-Not all systems are required. A minimal setup needs: `VOXEL_TO_TRIXEL_STAGE_1`, `VOXEL_TO_TRIXEL_STAGE_2`, `TRIXEL_TO_FRAMEBUFFER`, `FRAMEBUFFER_TO_SCREEN`.
+`TRIXEL_TO_TRIXEL` uses `CHILD_OF` relations. For each child-canvas →
+parent-canvas pair the system calls:
 
-## Coordinate Systems
+1. `beginTick` — binds the shader, sets camera offset in frame data.
+2. `relationTick` — binds parent canvas textures to image slots 0 and 1.
+3. `tick` — binds child canvas textures to slots 2 and 3, uploads frame data, dispatches.
 
-### 3D Voxel Space
+Canvas entities without `CHILD_OF` do not participate in `TRIXEL_TO_TRIXEL` -- they render independently into their own textures.
 
-- **X axis** -- lower-left in isometric view
-- **Y axis** -- lower-right in isometric view
-- **Z axis** -- upward (vertical)
+## Adding a new render stage
 
-Ground plane is XY. Entities at the same Z sit on the same horizontal plane.
-
-### 3D to Isometric 2D
-
-```
-iso.x = -x + y
-iso.y = -x - y + 2z
-```
-
-Function: `IRMath::pos3DtoPos2DIso(ivec3 position)`.
-
-### Isometric Depth
-
-```
-distance = x + y + z
-```
-
-Objects with the same `x+y+z` share a depth layer. Higher distance = further from camera. `IRMath::isoDepthShift(pos, d)` shifts by `(d,d,d)` -- changes depth without altering the 2D projection.
-
-### Face Types
-
-Each voxel exposes up to three visible faces:
-
-| FaceType | Perpendicular to | Visible side | Trixels per face |
-|----------|-------------------|--------------|-----------------|
-| `Z_FACE` | Z axis | Top | 2 triangles |
-| `X_FACE` | X axis | Right | 2 triangles |
-| `Y_FACE` | Y axis | Left | 2 triangles |
-
-Mapped in the compute shader via `localIDToFace()` with work group size `(2, 3, 1)`: 6 invocations per voxel, 2 trixels per face.
-
-## Shaders
-
-All shaders live in `engine/render/src/shaders/`. Shader prefixes follow the naming table in [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming (`c_` compute, `v_` vertex, `f_` fragment, `g_` geometry).
-
-Metal equivalents exist under `engine/render/src/shaders/metal/`.
-
-### Key Compute Shaders
-
-**`c_voxel_to_trixel_stage_1.glsl`** -- Depth pass. Work group `(2,3,1)`. Reads position/color SSBOs and chunk visibility mask. Writes `r32i` distance buffer via `imageAtomicMin`. Each invocation handles one trixel of one face.
-
-**`c_voxel_to_trixel_stage_2.glsl`** -- Color pass. Same work group. Reads distance buffer written by stage 1. Writes `rgba8` color, `r32i` distance, and `rg32ui` entity ID images. Only writes trixels whose distance matches the depth buffer (painter's algorithm resolved).
-
-**`c_shapes_to_trixel.glsl`** -- SDF shape rasterization. Evaluates `GPUShapeDescriptor` shapes (box, sphere, cylinder, ellipsoid, wing, prism, tapered box, custom SDF) with joint transforms and LOD.
-
-**`c_trixel_to_trixel.glsl`** -- Canvas compositing. Copies trixels from a child canvas onto a parent canvas with position offset and depth testing.
-
-## GPU Data Structures
-
-### Buffer Bindings (from `ir_render_types.hpp`)
-
-| Binding | Name | Type |
-|---------|------|------|
-| 0 | `FrameDataUniform` | UBO |
-| 5 | `SingleVoxelPositions` | SSBO (`vec4[]`) |
-| 6 | `SingleVoxelColors` | SSBO (`uint[]`, packed RGBA) |
-| 7 | `FrameDataVoxelToCanvas` | UBO |
-| 10 | `FrameDataTrixelToTrixel` | UBO |
-| 13 | `VoxelEntityIds` | SSBO (`uvec2[]`) |
-| 20 | `ShapeDescriptors` | SSBO |
-| 21 | `JointTransforms` | SSBO |
-| 24 | `ChunkVisibility` | SSBO (`uint[]`, bitmask) |
-
-### Image Bindings (trixel canvas)
-
-| Binding | Format | Purpose |
-|---------|--------|---------|
-| 0 | `rgba8` | Trixel canvas colors |
-| 1 | `r32i` | Trixel canvas distances |
-| 2 | `rg32ui` | Trixel canvas entity IDs |
-
-### FrameDataVoxelToCanvas (binding 7)
-
-```cpp
-struct FrameDataVoxelToCanvas {
-    vec2 cameraTrixelOffset_;
-    ivec2 trixelCanvasOffsetZ1_;
-    ivec2 voxelRenderOptions_;   // x = SubdivisionMode, y = subdivisions
-    ivec2 voxelDispatchGrid_;
-    int voxelCount_;
-    int _voxelDispatchPadding_;
-    ivec2 canvasSizePixels_;
-    ivec2 _canvasPadding_;
-};
-```
-
-## Key Components
-
-### C_VoxelPool
-
-Allocates contiguous GPU-friendly storage for voxel positions, colors, and entity IDs. Partitioned into chunks of `kVoxelChunkSize = 256` for frustum culling.
-
-**File:** `engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp`
-
-### C_TriangleCanvasTextures
-
-Owns the trixel canvas GPU textures (color, distance, entity ID images). Each canvas entity has one. The voxel-to-trixel system renders into this canvas.
-
-**File:** `engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp`
-
-### C_EntityCanvas (WIP)
-
-Wraps a canvas entity for per-entity rendering. Creates its own `C_VoxelPool` + `C_TriangleCanvasTextures`.
-
-### C_CanvasTarget (WIP)
-
-Points an entity to a specific canvas entity for rendering (defaults to main canvas).
-
-## Render Modes
-
-| Mode | Enum | Effect |
-|------|------|--------|
-| None | `SubdivisionMode::NONE` (0) | Integer-aligned voxel positions (no subdivision) |
-| Position Only | `SubdivisionMode::POSITION_ONLY` (1) | Subdivided positioning, base-resolution SDF eval |
-| Full | `SubdivisionMode::FULL` (2) | Full subdivision: positions × subdivisions × zoom |
-
-`voxelRenderOptions_.x` controls mode, `.y` controls subdivision level.
-
-## Shape Types (for SHAPES_TO_TRIXEL)
-
-| ShapeType | Value |
-|-----------|-------|
-| `BOX` | 0 |
-| `SPHERE` | 1 |
-| `CYLINDER` | 2 |
-| `ELLIPSOID` | 3 |
-| `WING` | 4 |
-| `PRISM` | 5 |
-| `TAPERED_BOX` | 6 |
-| `CUSTOM_SDF` | 7 |
-
-Shapes support flags: `HOLLOW`, `MIRROR_X`, `MIRROR_Y`, `VISIBLE`, `DISCRETE_ROTATION`.
-
-## LOD Levels
-
-```cpp
-enum class LodLevel : uint32_t {
-    LOD_0 = 0,  // full detail
-    LOD_1 = 1,
-    LOD_2 = 2,
-    LOD_3 = 3,
-    LOD_4 = 4   // most reduced
-};
-```
-
-LOD utilities live in `engine/prefabs/irreden/render/lod_utils.hpp`.
-
-## Trixel Compositing Pattern
-
-`TRIXEL_TO_TRIXEL` uses `CHILD_OF` relations: child canvas entities render their trixels onto the parent canvas with position offset and depth testing. The system:
-
-1. `beginTick`: binds the compute shader, sets camera offset in frame data
-2. `relationTick`: binds the parent canvas textures (images 0, 1)
-3. `tick`: binds child canvas textures (images 2, 3), uploads frame data, dispatches compute
-
-## Adding a New Render Stage
-
-1. Write a GLSL compute/vertex/fragment shader in `engine/render/src/shaders/`
-2. Add a `SystemName` enum entry in `ir_system_types.hpp`
-3. Create a system header in `engine/prefabs/irreden/render/systems/`
-4. In the system's `create()`: create named GPU resources, set up the compute dispatch or draw call
-5. Register in the creation's RENDER pipeline in the correct order relative to existing stages
+1. Write the GLSL shader in `engine/render/src/shaders/`.
+2. Add a `SystemName` enum entry in `ir_system_types.hpp`.
+3. Create a system header under `engine/prefabs/irreden/render/systems/`.
+4. In `create()`: create named GPU resources and set up the compute dispatch or draw call.
+5. Register in the creation's RENDER pipeline in dependency order relative to the stages above.

--- a/.claude/skills/render-trixel-pipeline/SKILL.md
+++ b/.claude/skills/render-trixel-pipeline/SKILL.md
@@ -39,7 +39,7 @@ parent-canvas pair the system calls:
 2. `relationTick` — binds parent canvas textures to image slots 0 and 1.
 3. `tick` — binds child canvas textures to slots 2 and 3, uploads frame data, dispatches.
 
-Canvas entities without `CHILD_OF` do not participate in `TRIXEL_TO_TRIXEL` -- they render independently into their own textures.
+Canvas entities without `CHILD_OF` do not participate in `TRIXEL_TO_TRIXEL` — they render independently into their own textures.
 
 ## Adding a new render stage
 


### PR DESCRIPTION
## Summary
- Remove six inventory sections (buffer/image binding tables, struct copy, key-component file-path subsections, render-modes/shape-types/LOD enum tables) — all greppable from the code.
- Remove the pipeline ASCII diagram (already in engine/render/CLAUDE.md, more complete) and the Coordinate Systems section (iso equations already in engine/math/CLAUDE.md).
- Retain concepts-only content: two-stage depth split rationale, minimal system set, TRIXEL_TO_TRIXEL CHILD_OF compositing pattern, new render-stage procedure, pointers to authoritative docs.
- Result: 235 lines → 51 lines.

## Test plan
- [ ] SKILL.md renders correctly (no broken Markdown)
- [ ] All referenced files exist: `engine/render/CLAUDE.md`, `engine/math/CLAUDE.md`, shader paths, `engine/prefabs/irreden/render/systems/`

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)