### PR TITLE
T-242: docs/skills: trim inventory tables from render-debug-loop, backend-parity, optimize

### DIFF
--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -96,40 +96,13 @@ Record the mode at the top of the PR body later.
 
 ### 2. Enumerate the deviation set
 
-The render module has a consistent directory split. Use it as the
-source of truth for parity:
-
-**Backend C++ sources (per pair):**
-
-| OpenGL path                                    | Metal path                                     |
-|------------------------------------------------|------------------------------------------------|
-| `engine/render/src/opengl/opengl_buffer.cpp`   | `engine/render/src/metal/metal_buffer.cpp`     |
-| `engine/render/src/opengl/opengl_framebuffer.cpp` | `engine/render/src/metal/metal_framebuffer.cpp` |
-| `engine/render/src/opengl/opengl_render_impl.cpp` | `engine/render/src/metal/metal_render_impl.cpp` |
-| `engine/render/src/opengl/opengl_shader.cpp`   | `engine/render/src/metal/metal_pipeline.cpp`   |
-| `engine/render/src/opengl/opengl_texture.cpp`  | `engine/render/src/metal/metal_texture.cpp`    |
-| `engine/render/src/opengl/opengl_vertex_layout.cpp` | *(bundled into metal_pipeline.cpp)*       |
-| *(glad.c)*                                     | `engine/render/src/metal/metal_runtime.cpp`    |
-|                                                | `engine/render/src/metal/metal_cocoa_bridge.mm` |
-|                                                | `engine/render/src/metal/metal_cpp_impl.cpp`   |
-
-**Headers** mirror under `engine/render/include/irreden/render/opengl/`
-and `.../metal/`.
-
-**Shaders:**
-
-| OpenGL location                                          | Metal location                                              |
-|----------------------------------------------------------|-------------------------------------------------------------|
-| `engine/render/src/shaders/*.glsl` (flat)                | `engine/render/src/shaders/metal/*.metal`                    |
-
-GLSL prefixes (`c_`, `v_`, `f_`, `g_`) follow [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming and indicate the shader stage. MSL files
-use one `.metal` file per shader with the stage inferred from the
-`kernel` / `vertex` / `fragment` declaration inside. A single `.metal`
-file sometimes bundles a vertex and a fragment stage together (see
-`framebuffer_to_screen.metal` for the canonical pattern). When porting
-a pair of GLSL v/f stages (e.g. `v_framebuffer_to_screen.glsl` +
-`f_framebuffer_to_screen.glsl`), produce **one** `.metal` file with
-both stages rather than two.
+OpenGL sources live under `engine/render/src/opengl/` and Metal counterparts
+under `engine/render/src/metal/` with matching names. Headers mirror under
+`engine/render/include/irreden/render/opengl/` and `.../metal/`. Shaders:
+`engine/render/src/shaders/*.glsl` (GLSL, prefixed per CLAUDE-BASELINE §Naming)
+↔ `engine/render/src/shaders/metal/*.metal` (MSL). MSL bundles a vertex + fragment
+pair into one `.metal` file — when porting GLSL v/f stages, produce **one** `.metal`
+file (see `framebuffer_to_screen.metal` for the canonical pattern).
 
 **Audit command** (to list missing counterparts when running on macOS
 porting GLSL → MSL):

--- a/.claude/skills/optimize/SKILL.md
+++ b/.claude/skills/optimize/SKILL.md
@@ -137,11 +137,7 @@ re-enable the profiler before re-running.
 ### 3. GPU profiling
 
 The engine has **per-pass GPU stage timing** wired into the render
-pipeline. Every major stage (`voxelCompact`, `voxelStage1`,
-`voxelStage2`, `shapeCompact`, `shapePass0`, `shapePass1`,
-`textToTrixel`, `computeVoxelAO`, `computeSunShadow`,
-`lightingToTrixel`, `trixelToTrixel`, `trixelToFb`, `entityCanvasToFb`,
-`fbToScreen`, `canvasClear`) brackets its GPU work with
+pipeline. Every named GPU stage brackets its work with
 `device()->finish()` + `std::chrono::steady_clock` samples and writes
 the per-frame millisecond cost into `IRRender::gpuStageTiming()`.
 

--- a/.claude/skills/render-debug-loop/SKILL.md
+++ b/.claude/skills/render-debug-loop/SKILL.md
@@ -158,21 +158,6 @@ After applying fixes, return to **Step 1**.
 
 ---
 
-## Key Files
-
-| File | Role |
-|------|------|
-| `engine/render/src/shaders/c_shapes_to_trixel.glsl` | SDF shape compute shader |
-| `engine/render/src/shaders/ir_iso_common.glsl` | Shared iso math (face offsets, depth encoding) |
-| `engine/render/src/shaders/f_trixel_to_framebuffer.glsl` | Fragment shader: canvas to framebuffer with parity |
-| `engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl` | Voxel pool stage 1 (reference) |
-| `engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl` | Voxel pool stage 2 (reference) |
-| `engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp` | CPU-side shape gather and dispatch |
-| `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp` | CPU-side framebuffer draw, zoom, camera |
-| `engine/prefabs/irreden/render/systems/system_lighting_to_trixel.hpp` | Screen-space lighting application (T-011) |
-| `engine/render/include/irreden/render/ir_render_types.hpp` | GPU struct definitions, ShapeFlags |
-| `engine/math/include/irreden/ir_math.hpp` | `trixelOriginOffsetZ1`, `pos2DIsoToTriangleIndex` |
-
 ## Notes
 
 - `--auto-screenshot` accepts an optional warmup frame count (default 10).


### PR DESCRIPTION
## Summary
- Delete four inventory sections that violate CLAUDE-BASELINE §no-inventories rule from render-debug-loop, backend-parity, and optimize SKILL.md files

## Test plan
- [ ] render-debug-loop/SKILL.md: inventory tables removed, concepts and gotchas preserved
- [ ] backend-parity/SKILL.md: inventory tables removed, essential info preserved
- [ ] optimize/SKILL.md: inventory tables removed, essential info preserved
- [ ] No functional guidance lost — only name/file catalogs deleted

Closes #825