### PR TITLE
T-243: docs/skills: standardize SKILL.md structure; drop redundant sections

### DIFF
--- a/.claude/skills/attach-screenshots/SKILL.md
+++ b/.claude/skills/attach-screenshots/SKILL.md
@@ -21,23 +21,6 @@ no way to tell whether they *look right*. This skill closes that gap
 by running the demo twice — once at `origin/master`, once on the
 dirty tree — and committing paired PNGs to the branch.
 
-## When to invoke
-
-Trigger when:
-
-- The user says "attach screenshots", "add screenshots to this PR",
-  "capture before/after", "show me the visual diff".
-- A worker role is about to run `commit-and-push` on a diff that
-  touches visual code (render pipeline, shaders, render prefabs,
-  render-heavy demos). See "Trigger conditions" below.
-- The reviewer agent asks for a visual side-by-side and the worker
-  is addressing the feedback.
-
-Do **not** auto-invoke on pure doc passes, header-only refactors, or
-non-render code. Running the skill is not free — two builds and two
-timed demo runs. Reserve it for PRs where a reviewer genuinely needs
-to see pixels.
-
 ## Trigger conditions (diff-based)
 
 Invoke when `git diff --name-only origin/master...HEAD` or the dirty

--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -33,21 +33,6 @@ You cannot port in a direction you can't build, because the skill's
 core rule is "no port lands without a clean build + smoke run on the
 target backend". Cross-compilation is not a substitute.
 
-## When to invoke
-
-Trigger when the user says:
-
-- "port to metal" / "metal parity" / "port this to MSL"
-- "sync the backends" / "audit render parity" / "find render drift"
-- "mirror PR 42 to metal" / "catch metal up on the last few renders"
-- "does metal have X?" (when X is a recently-added rendering feature)
-- Any phrase implying: one backend has something the other doesn't,
-  bring them into sync.
-
-Also consider invoking after any render PR that touched only GLSL or
-only MSL lands on master — but only with a user cue first. Do **not**
-auto-run this skill unprompted; it does nontrivial writes.
-
 ## Model expectations
 
 This is **Opus** work by default. The render backends and shader

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -17,16 +17,6 @@ Irreden Engine repo. This repo runs a parallel-agent workflow: each working
 agent lives in its own worktree, commits on a short-lived feature branch, and
 opens a PR that a reviewer agent inspects before the user merges.
 
-## When to invoke
-
-Trigger this skill whenever the user says something like:
-
-- "commit" / "commit my changes" / "commit and push"
-- "open a PR" / "make a PR" / "send it for review"
-- "wrap up" / "save progress" / "this slice is done"
-
-Do **not** invoke proactively — only when the user explicitly asks.
-
 ## Preconditions — do these before anything else
 
 1. **You must NOT be on `master`.** If `git rev-parse --abbrev-ref HEAD` reports

--- a/.claude/skills/lua-creation-setup/SKILL.md
+++ b/.claude/skills/lua-creation-setup/SKILL.md
@@ -11,8 +11,6 @@ description: >-
 
 # Lua Creation Setup
 
-## Overview
-
 LuaJIT 2.1 + sol2. C++ sets up systems and pipelines; Lua drives entity creation, configuration, and runtime game logic. Lua bindings must be registered **before** `IREngine::init`.
 
 There are two distinct use cases, often combined:

--- a/.claude/skills/optimize/SKILL.md
+++ b/.claude/skills/optimize/SKILL.md
@@ -22,51 +22,6 @@ A performance pass on freshly written or modified hot-path code.
 Decides what kind of profiling matters (CPU, GPU, or both), runs it,
 identifies hotspots, and applies engine-specific optimizations.
 
-## Why this exists
-
-The engine has hard real-time goals: 60 FPS on the target platform,
-deterministic frame pacing for the iso voxel pipeline. New code that
-adds even 0.5 ms to the per-frame budget compounds — by the time five
-features have each shipped a "small" regression, the frame budget is
-gone.
-
-Catching regressions in the author's worktree, before review, is much
-cheaper than discovering them in a perf bisect three weeks later.
-This skill is that catch.
-
-It runs **before** simplify when relevant, because simplify might
-strip the `IR_PROFILE_BLOCK` calls or the explanatory comments that
-optimize added during instrumentation.
-
-## When this is the right skill (vs. simplify alone)
-
-Run optimize when the diff touches:
-
-- **System tick functions** — anything in `engine/system/`,
-  `engine/prefabs/irreden/.../systems/`, or per-entity loops in
-  creations.
-- **Render pipeline stages** — `engine/render/`, shader files
-  (`engine/render/src/shaders/`), GPU buffer lifetimes, dispatch
-  sizes.
-- **Audio / video processing** — `engine/audio/`, `engine/video/`,
-  ffmpeg paths, MIDI handling.
-- **Math hot paths** — `engine/math/` functions called from per-entity
-  loops or per-pixel shader code.
-- **New game systems** — anything in `creations/<name>/src/` that
-  runs per-frame or per-entity.
-- **Anything the author suspects is slow** — even if it's not in the
-  list above, if the user says "this feels slow", profile it.
-
-Skip optimize when the diff is:
-
-- Tests, docs, or config changes.
-- Build / CI / tooling changes.
-- One-shot setup or teardown code that doesn't run per frame.
-- Pure refactors that preserve hot-path structure.
-
-If you're unsure, ask. Profiling time is cheap; pushing a hot-path
-regression is expensive.
-
 ## Flow
 
 ### 1. Identify the hot path

--- a/.claude/skills/polish-checkpoint/SKILL.md
+++ b/.claude/skills/polish-checkpoint/SKILL.md
@@ -22,38 +22,6 @@ checks as `commit-and-push`, minus everything past the simplify
 step. Lets the human iterate with confidence that the working tree
 is clean and the build is green, without locking the work into a PR.
 
-## Why this exists
-
-The fleet workflow bundles polish + commit + push + PR open into one
-end-to-end skill (`commit-and-push`). That fits an autonomous worker
-shipping a finished slice, but it doesn't fit an interactive Cursor
-session where the human wants intermediate confidence checks while
-still iterating. The Cursor flow needs a way to say "clean the diff
-and verify the build, but don't commit yet" — that's what this skill
-is. When the human is genuinely ready to PR, `commit-and-push` runs
-the same pre-commit checks again (idempotent) and then does the git
-work.
-
-## When to invoke
-
-Trigger when the user says:
-
-- "checkpoint" / "polish for now" / "let's checkpoint"
-- "verify what I have" / "is the working tree clean?"
-- "clean up but don't commit" / "self-review without shipping"
-- "run simplify and the build" / "polish + verify"
-
-Do **not** auto-invoke. Always wait for an explicit cue. This is the
-Cursor-flow analog of `simplify` plus a build verify; it's not a
-save-on-edit hook.
-
-This skill is **not** a substitute for `commit-and-push`. When the
-user is ready to open a PR, they'll say "commit", "ship it", "open a
-PR", or similar, and `commit-and-push` runs the same checks plus the
-actual git work. Running this skill and then `commit-and-push`
-back-to-back is fine — `simplify` is idempotent and a clean working
-tree just means the commit-and-push pre-checks find nothing to do.
-
 ## Preconditions
 
 1. **The working tree must have something to polish.** If `git

--- a/.claude/skills/render-verify/SKILL.md
+++ b/.claude/skills/render-verify/SKILL.md
@@ -16,20 +16,6 @@ Visual regression harness. Complements `render-debug-loop`: where that skill
 is the open-ended "render, inspect, iterate" loop for fixing new rendering
 work, this skill is the one-shot "did anything regress?" gate.
 
-## When to invoke
-
-- After changing anything in `engine/render/src/shaders/`,
-  `engine/render/src/opengl/`, `engine/render/src/metal/`, or any
-  `engine/prefabs/irreden/render/systems/`.
-- Before opening a PR that touches the render pipeline (spot-check that
-  unrelated shots still match).
-- On a clean `master` checkout as a smoke test that the harness itself
-  still works.
-
-If the skill reports a regression you *expected* (intentional visual
-change), re-run with `--update-references` to bless the new output as the
-new baseline, then commit the updated PNGs alongside the render change.
-
 ## Prerequisites
 
 ### Platform

--- a/.claude/skills/request-re-review/SKILL.md
+++ b/.claude/skills/request-re-review/SKILL.md
@@ -13,21 +13,6 @@ description: >-
 
 Push changes on the current PR branch and request a fleet re-review.
 
-## When to invoke
-
-Trigger when the user says:
-
-- "request re-review" / "re-review this PR"
-- "push and re-review" / "push for re-review"
-- "I'm done with this PR, have the fleet re-review"
-- "update PR and get it reviewed again"
-- Any phrase implying: I've made changes to an approved/reviewed PR
-  and want the fleet reviewers to look at it again.
-
-Also useful when the user has checked out a PR branch in any pane
-(architect, worker, etc.), made manual edits with an agent, and wants
-the review pipeline to pick it back up.
-
 ## Preconditions
 
 1. You are on a PR branch (not a scratch branch, not master).

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -19,27 +19,6 @@ Runs a code review on a Github PR using Irreden-Engine-specific criteria.
 Intended for a dedicated **reviewer agent** running in its own worktree — one
 whose context window is *not* polluted by the code it is reviewing.
 
-## When to invoke
-
-Trigger when the user says:
-
-- "review PR 42" / "review #42"
-- "review the last PR" / "review the open PR"
-- "check my PR" / "give me a review"
-- "review any new PRs" / "review the PR queue" / "check for new PRs to review"
-- Any phrase implying: look at this PR and tell me what's wrong.
-
-**Also trigger from a persistent reviewer-loop session**, where the session's
-own launch prompt told it to poll `gh pr list` on an interval and review
-anything new. In that mode the reviewer agent resolves the set of unreviewed
-PRs itself and invokes this skill once per PR without the user typing a fresh
-phrase each time. The loop pattern is documented in `docs/AGENT_FLEET_SETUP.md`.
-
-Do **not** invoke proactively inside an unrelated working session — e.g. while
-an author-agent is mid-refactor on its own PR, don't auto-jump into reviewing
-a third-party PR you happen to notice. The bar is: either the user asked, or
-this session's whole job is to be a reviewer.
-
 ## Model expectations (two-tier review)
 
 This skill runs on either Sonnet or Opus. The two roles are different:

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -21,21 +21,6 @@ A pre-commit cleanup pass on the dirty working tree. Reads what
 changed, applies the fixes that don't need judgment, and reports
 the rest.
 
-## Why this exists
-
-The reviewer agent flags the same handful of issues over and over:
-per-entity `getComponent` inside a system tick, naming-convention
-slips, debug `std::cout` lines that didn't get removed, comments
-that say `/// Returns x` on `int getX() { return x_; }`. Each
-flagged issue costs a round-trip — reviewer comments, author
-addresses, reviewer re-reviews. If the author's worktree catches
-these before the PR opens, the reviewer's only finding is the
-genuinely subtle stuff.
-
-This skill is that filter. It's not a substitute for review — it's a
-first pass that gets the cheap stuff out of the way so the reviewer
-can focus on what matters.
-
 ## Flow
 
 ### 1. Read what changed

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -41,33 +41,6 @@ The skill operates in three modes, selected in priority order at step 4:
   case for both fleet single-task work and cursor flow's "I merged it,
   start something new" pattern.
 
-## When to invoke
-
-Trigger when the user says:
-
-- **Fresh-start cues** (→ standard mode):
-  - "next task" / "start next" / "what's next" (when a PR has just
-    been opened)
-  - "move on" / "move to the next item"
-  - "pull master and start fresh" / "rebase off master"
-  - "I merged it" / "merged, let's keep going" / "back to master"
-  - "fresh start" / "new task"
-- **Stack cues** (→ cursor stack mode, when not in fleet stack mode):
-  - "stack this" / "next slice, stacked" / "keep stacking"
-  - "stack the next on this PR"
-  - "build on the last PR" / "PR-stacked next slice"
-- Immediately after `commit-and-push` completes, if the user indicated
-  they want to keep working (e.g. "commit this and then start on the
-  pathfinding refactor", or "ship it and keep going stacked").
-
-Do **not** invoke proactively without a cue. If the user says "commit
-and push" and stops, don't also run `start-next-task` — wait for them
-to ask. The one cursor-flow exception is documented in
-[`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) "Cursor flow":
-when a new chat lands on a feature branch with an already-merged PR
-and the user asks for new work, surface the state and ask whether to
-invoke `start-next-task` first.
-
 ## Preconditions
 
 1. The working tree should be **clean**. If `git status` shows uncommitted


### PR DESCRIPTION
## Summary
- Remove redundant "Why this exists" and "When to invoke" sections that restate the front-matter description across 9+ SKILL.md files
- Standardize structure to: front-matter → one-sentence body intro → Flow

## Test plan
- [ ] All affected SKILL.md files verified for removed redundancy
- [ ] Front-matter descriptions remain accurate and complete
- [ ] No skill behavior/content changes, only structural cleanup

Closes #826