### PR TITLE
T-244: docs/skills: drop decorative emoji bullets from Anti-patterns sections

### DIFF
--- a/.claude/skills/attach-screenshots/SKILL.md
+++ b/.claude/skills/attach-screenshots/SKILL.md
@@ -314,18 +314,18 @@ over stash:
 
 ## Anti-patterns
 
-- ❌ Committing screenshots in a separate commit. Stage and let
+- Committing screenshots in a separate commit. Stage and let
   `commit-and-push` bundle them into the feature commit.
-- ❌ Running the capture from inside a worker role's tick function or
+- Running the capture from inside a worker role's tick function or
   hot path. This skill is explicit, worker-invoked, and costs one
   full rebuild + timed demo run per pass.
-- ❌ Capturing from any demo other than one that implements
+- Capturing from any demo other than one that implements
   `--auto-screenshot`. The "before" pass must be deterministic — a
   hand-driven demo is not.
-- ❌ Deleting prior `docs/pr-screenshots/<other-branch>/` directories
+- Deleting prior `docs/pr-screenshots/<other-branch>/` directories
   "for tidiness". Each branch owns its own; historical branches are a
   visual changelog.
-- ❌ Invoking this skill on PRs that don't touch visual code. Pure
+- Invoking this skill on PRs that don't touch visual code. Pure
   refactors and doc passes should skip it — the build and run cost
   is not worth no-op screenshots.
 

--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -355,24 +355,24 @@ call, read its threadgroup size, and encode it as
 
 ## Anti-patterns
 
-- ❌ Shipping a port without building the lagging preset. The whole
+- Shipping a port without building the lagging preset. The whole
   point of the skill is that you *verified* it builds and runs.
-- ❌ Shipping a port without smoke-running the demo. Build-clean ≠
+- Shipping a port without smoke-running the demo. Build-clean ≠
   parity.
-- ❌ `#ifdef METAL` / `#ifdef OPENGL` stubs that silently return
+- `#ifdef METAL` / `#ifdef OPENGL` stubs that silently return
   wrong values. Either port properly or stop and flag.
-- ❌ Bundling multiple unrelated parity fixes into one PR. One logical
+- Bundling multiple unrelated parity fixes into one PR. One logical
   feature per PR; the reviewer can't usefully sign off on "ports
   three shaders and rewrites the framebuffer path".
-- ❌ Changing the leading backend mid-port. If the leading side has a
+- Changing the leading backend mid-port. If the leading side has a
   bug, file it separately and then port the correct behavior.
   This skill is parity, not drive-by cleanup.
-- ❌ Hardcoding dispatch sizes instead of reusing
+- Hardcoding dispatch sizes instead of reusing
   `voxelDispatchGridForCount()` or the equivalent math helper.
-- ❌ Inventing new uniform layouts "because MSL is different". Match
+- Inventing new uniform layouts "because MSL is different". Match
   the CPU-side feeder struct exactly; if the feeder struct is wrong
   for Metal, that's a separate refactor in a separate PR.
-- ❌ Running this skill on a host whose backend matches the
+- Running this skill on a host whose backend matches the
   *leading* side. You cannot verify the port — stop.
 
 ## Re-port after review feedback

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -413,18 +413,18 @@ if the user already asked for the next task).
 
 ## Anti-patterns
 
-- ❌ Committing to `master`. Always branch first.
-- ❌ `git add -A` / `git add .` — risk of committing secrets or build junk.
-- ❌ Amending a previous commit without being asked.
-- ❌ Force-pushing master. Never.
-- ❌ Skipping hooks (`--no-verify`) unless the user explicitly requests it.
-- ❌ Bypass-pushing to master with admin — the new workflow uses PRs and
+- Committing to `master`. Always branch first.
+- `git add -A` / `git add .` — risk of committing secrets or build junk.
+- Amending a previous commit without being asked.
+- Force-pushing master. Never.
+- Skipping hooks (`--no-verify`) unless the user explicitly requests it.
+- Bypass-pushing to master with admin — the new workflow uses PRs and
   reviewer agents. If you feel tempted to bypass, something upstream is
   broken; flag it to the user instead.
-- ❌ Opening a PR without running `simplify` first.
-- ❌ Continuing to commit on the same feature branch after opening its PR
+- Opening a PR without running `simplify` first.
+- Continuing to commit on the same feature branch after opening its PR
   unless the user explicitly asks for it — otherwise use `start-next-task`.
-- ❌ Leaking game references into an engine PR — see `docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation".
+- Leaking game references into an engine PR — see `docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation".
 
 ## Recovery
 

--- a/.claude/skills/polish-checkpoint/SKILL.md
+++ b/.claude/skills/polish-checkpoint/SKILL.md
@@ -174,18 +174,18 @@ state:
 
 ## Anti-patterns
 
-- ❌ Running this skill autonomously after every edit. It's a
+- Running this skill autonomously after every edit. It's a
   user-invoked checkpoint, not a save-on-edit hook.
-- ❌ Following polish-checkpoint with `commit-and-push` unless the
+- Following polish-checkpoint with `commit-and-push` unless the
   user explicitly asks. The whole point is the human controls when
   to PR.
-- ❌ Skipping the build step on code diffs to save time. The
+- Skipping the build step on code diffs to save time. The
   checkpoint is not real if the build doesn't actually pass.
-- ❌ Editing files outside the dirty diff to "improve" them. Stay
+- Editing files outside the dirty diff to "improve" them. Stay
   scoped to what the session has already changed.
-- ❌ Switching branches mid-skill. The user's current branch state
+- Switching branches mid-skill. The user's current branch state
   is intentional; respect it.
-- ❌ Using this skill in fleet flow. Fleet workers run
+- Using this skill in fleet flow. Fleet workers run
   `commit-and-push` end-to-end; intermediate checkpoints are an
   interactive-session concept.
 

--- a/.claude/skills/render-verify/SKILL.md
+++ b/.claude/skills/render-verify/SKILL.md
@@ -208,17 +208,17 @@ fleet doesn't need `pip install Pillow` on every new host.
 
 ## Anti-patterns
 
-- ❌ Updating references without visually inspecting the new PNGs. Blind
+- Updating references without visually inspecting the new PNGs. Blind
   `--update-references --force` masks real regressions.
-- ❌ Committing references for a backend you can't build. Each backend's
+- Committing references for a backend you can't build. Each backend's
   set must be captured on a host that can run that preset.
-- ❌ Loosening thresholds to make a failing shot pass. If the shot is
+- Loosening thresholds to make a failing shot pass. If the shot is
   legitimately flakey, fix the demo's determinism or exclude the shot
   from the manifest.
-- ❌ Adding the harness to a demo whose output is intentionally random or
+- Adding the harness to a demo whose output is intentionally random or
   time-dependent. The demo must be fully deterministic across runs for
   the harness to mean anything.
-- ❌ Sharing references across backends. OpenGL and Metal produce
+- Sharing references across backends. OpenGL and Metal produce
   pixel-different output; treating one as the canonical reference will
   produce false failures on the other.
 

--- a/.claude/skills/request-re-review/SKILL.md
+++ b/.claude/skills/request-re-review/SKILL.md
@@ -111,8 +111,8 @@ Re-review requested for PR #<N> (<title>).
 
 ## Anti-patterns
 
-- ❌ Leaving the PR branch checked out after requesting re-review.
+- Leaving the PR branch checked out after requesting re-review.
   The whole point is to release it for reviewers.
-- ❌ Using this on a PR that's still `fleet:wip` — that PR isn't
+- Using this on a PR that's still `fleet:wip` — that PR isn't
   ready for review at all. Tell the user to finalize first.
-- ❌ Force-pushing. Never `--force`.
+- Force-pushing. Never `--force`.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -199,29 +199,29 @@ compliance or raise an issue.
 **ECS invariants** — check against [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md). For each item, confirm compliance or raise an issue.
 
 **Ownership / lifetime**
-- ❌ `shared_ptr` where `unique_ptr` would do.
-- ❌ Raw owning pointers (raw pointer = non-owning, always).
-- ❌ Storing references or pointers to ECS component storage across ticks —
+- `shared_ptr` where `unique_ptr` would do.
+- Raw owning pointers (raw pointer = non-owning, always).
+- Storing references or pointers to ECS component storage across ticks —
   archetype changes invalidate addresses.
-- ❌ Capturing `this` or references to World managers in lambdas that outlive
+- Capturing `this` or references to World managers in lambdas that outlive
   the World (e.g. lua callbacks registered before World teardown).
-- ❌ Stored `g_*Manager` pointer or reference in any object whose lifetime
+- Stored `g_*Manager` pointer or reference in any object whose lifetime
   can outlive `World` (background threads, sol2 callback closures, long-lived
   caches) — see `engine/world/CLAUDE.md` and `engine/CLAUDE.md`.
 
 **Render pipeline**
-- ❌ CPU frame-data struct out of sync with its GLSL `layout(std140)`
+- CPU frame-data struct out of sync with its GLSL `layout(std140)`
   counterpart. `vec3` members pad to 16 bytes; array elements stride to 16
   bytes; members crossing a 16-byte boundary need `alignas(16)`. If either
   the C++ struct (in `engine/render/include/irreden/render/`) or its shader
   `uniform` block changed, cross-reference both sides.
-- ❌ shader references `binding = N` but the C++ `kBufferIndex_*` constant
+- shader references `binding = N` but the C++ `kBufferIndex_*` constant
   was not updated — the mismatch is silent (wrong uniforms, no error).
   Confirm every bind-point index agrees on both sides.
-- ❌ New shader file not following the `c_` / `v_` / `f_` / `g_` prefix.
-- ❌ Canvas allocation before the canvas entity exists.
-- ❌ Compute dispatch size doesn't match `voxelDispatchGridForCount()`.
-- ❌ new `*.glsl` added without a matching `*.metal` counterpart (if parity
+- New shader file not following the `c_` / `v_` / `f_` / `g_` prefix.
+- Canvas allocation before the canvas entity exists.
+- Compute dispatch size doesn't match `voxelDispatchGridForCount()`.
+- new `*.glsl` added without a matching `*.metal` counterpart (if parity
   is intentionally deferred, the PR body must acknowledge it and reference a
   follow-up task).
 
@@ -243,28 +243,28 @@ or any `c_compute_*shadow*.glsl` / `.metal`)
   correct AO neighbor-voxel sampling.
 
 **Math / coordinates** (see [`.claude/rules/cpp-math.md`](../../rules/cpp-math.md) for the full glm→IRMath substitution table)
-- ❌ Mixing 3D world coords with iso 2D coords without going through
+- Mixing 3D world coords with iso 2D coords without going through
   `IRMath::pos3DtoPos2DIso` or a named helper.
-- ❌ Hard-coded `x + y + z` where `IRMath::pos3DtoDistance` exists.
-- ❌ PlaneIso axis swapped.
+- Hard-coded `x + y + z` where `IRMath::pos3DtoDistance` exists.
+- PlaneIso axis swapped.
 
 **Serialization** (when the diff touches `engine/asset/`, `engine/prefabs/irreden/voxel/`, or `engine/world/`)
-- ❌ A struct annotated `// IRAsset: serialized` gained, lost, or renamed a field without
+- A struct annotated `// IRAsset: serialized` gained, lost, or renamed a field without
   bumping `static constexpr uint16_t kSaveVersion = N;` in the same diff.
   Fix: increment `kSaveVersion` and add a reader migration keyed on
   `(structType, oldVersion)` in the format's load function. (Save Format Extensibility Rule #3.)
-- ❌ A new serialized record type with no `// IRAsset: serialized` annotation — the
+- A new serialized record type with no `// IRAsset: serialized` annotation — the
   simplify and review-pr checks cannot guard it without the annotation. Add the annotation
   and set `kSaveVersion = 1` on the struct.
 
 **Naming / style** — follow the table in [`docs/agents/CLAUDE-BASELINE.md`](../../docs/agents/CLAUDE-BASELINE.md) §Naming.
-- ❌ `m_` on public members, trailing `_` on private members (backwards — the single most common slip).
+- `m_` on public members, trailing `_` on private members (backwards — the single most common slip).
 
 **Tests / build**
-- ❌ Code change with no corresponding test change where a test existed.
-- ❌ New feature with no new test at all (flag as needs-fix unless the user
+- Code change with no corresponding test change where a test existed.
+- New feature with no new test at all (flag as needs-fix unless the user
   explicitly said "no tests").
-- ❌ Build or format-check not run before opening the PR (check commit
+- Build or format-check not run before opening the PR (check commit
   message for mention, or run `cmake --build build --target format-check`
   yourself if cheap).
 
@@ -467,13 +467,13 @@ Reply with a compact summary to the calling session:
 
 ## Anti-patterns
 
-- ❌ Reviewing only the diff, not the surrounding file. Context matters.
-- ❌ Vague review comments without file:line citations.
-- ❌ Approving work that violates an ECS invariant "because the test passes"
+- Reviewing only the diff, not the surrounding file. Context matters.
+- Vague review comments without file:line citations.
+- Approving work that violates an ECS invariant "because the test passes"
   — some invariants don't fail at test time.
-- ❌ Merging the PR yourself. The user merges.
-- ❌ Pushing commits to the PR branch from the reviewer worktree.
-- ❌ Leaving a review that just says "LGTM" with nothing specific. Either the
+- Merging the PR yourself. The user merges.
+- Pushing commits to the PR branch from the reviewer worktree.
+- Leaving a review that just says "LGTM" with nothing specific. Either the
   PR is actually clean (in which case call out one non-obvious good choice
   as **praise**, to reinforce it) or it isn't.
 

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -320,38 +320,38 @@ Reply with a compact summary:
 
 ## Anti-patterns
 
-- ❌ Switching branches with a dirty working tree. Always clean first.
-- ❌ Branching off your previous PR branch in **standard mode** (no
+- Switching branches with a dirty working tree. Always clean first.
+- Branching off your previous PR branch in **standard mode** (no
   active molecule and no stack cue). That stacks unrelated work and
   pollutes the old PR. Either stack mode (4a returned a `T-NNN`, or
   the human cued stacking) is the only case where the old branch is
   the correct base.
-- ❌ Branching off `origin/master` in **either stack mode**. The
+- Branching off `origin/master` in **either stack mode**. The
   downstream slice's diff would then include the upstream changes
   too, defeating the whole point of stacked PRs (one slice = one
   isolated diff).
-- ❌ Skipping `fleet-claim molecule advance` after `commit-and-push`
+- Skipping `fleet-claim molecule advance` after `commit-and-push`
   and going straight to `start-next-task`. `molecule resume` would
   return the just-completed task as still in-progress, branching you
   onto the same thing you just shipped. The stack-mode sanity-check
   in step 4a catches this — heed it.
-- ❌ Writing `cursor-stack-base` git config in fleet stack mode or
+- Writing `cursor-stack-base` git config in fleet stack mode or
   standard mode. The config is the cursor-flow stack signal; setting
   it elsewhere confuses `commit-and-push`.
-- ❌ Auto-detecting cursor stack mode from "old branch happens to be
+- Auto-detecting cursor stack mode from "old branch happens to be
   a feature branch" without a user cue. The cue is the only signal.
   Without it, the human's intent is ambiguous (they may want a fresh
   slice off master), and step 4b's "ask, don't guess" rule applies
   for cursor flow.
-- ❌ Running `git rebase origin/master` on the old branch to "catch
+- Running `git rebase origin/master` on the old branch to "catch
   it up", then reusing it. Rebasing the same branch for new unrelated
   work is how PR histories become unreadable.
-- ❌ Deleting the old local branch. Leave it alone — if the reviewer
+- Deleting the old local branch. Leave it alone — if the reviewer
   asks for changes, you'll need to check it out again. Both stack
   modes REQUIRE the old branch as the new branch's base.
-- ❌ Starting the next task without reading the target area's
+- Starting the next task without reading the target area's
   CLAUDE.md. That's where the module-specific invariants live.
-- ❌ Invoking this skill when no PR was actually opened (i.e. after a
+- Invoking this skill when no PR was actually opened (i.e. after a
   `commit-and-push` failure). Check step 2.
 
 ## Recovery

--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -148,23 +148,23 @@ and should be moved to a system, builder, or namespace.
 
 ## Anti-patterns
 
-- ❌ Per-entity `getComponent` inside a system tick function. Fix: add the
+- Per-entity `getComponent` inside a system tick function. Fix: add the
   component to the system's template parameters.
-- ❌ Allocating memory in a hot tick path (`std::vector` push, string
+- Allocating memory in a hot tick path (`std::vector` push, string
   concat, `new`). Reserve once at `beginTick`.
-- ❌ Adding a new system without updating the `SystemName` enum.
-- ❌ Storing references to other entities' component storage across frames
+- Adding a new system without updating the `SystemName` enum.
+- Storing references to other entities' component storage across frames
   — archetype changes invalidate addresses.
-- ❌ Cross-domain includes inside a prefab header (e.g. `voxel/` component
+- Cross-domain includes inside a prefab header (e.g. `voxel/` component
   including `audio/` component). Prefabs are grouped by domain on purpose;
   cross-domain composition belongs in a creation.
-- ❌ Function-local `static` for system-owned state. Use the
+- Function-local `static` for system-owned state. Use the
   member-on-`System<N>` form via `registerSystem` (preferred) or the
   explicit `Params` + `setSystemParams` form — both have the same
   per-tick cost, correct lifetime, and are multi-instance safe.
   See `engine/system/CLAUDE.md` "Per-system parameters" for the
   rule, rationale, and canonical patterns.
-- ❌ `bool dirty_` (or `needsUpload_`, `changed_`) on a component to
+- `bool dirty_` (or `needsUpload_`, `changed_`) on a component to
   gate a per-frame CPU→GPU sync step. Push at mutation time (per-write
   `subData` / `subImage2D`) or let the GPU own ongoing state and seed
   the resource once in the ctor. The only documented exception is


### PR DESCRIPTION
## Summary

Drops decorative ❌ emoji bullets from Anti-patterns / "What this skill does NOT do" sections across SKILL.md files and engine/prefabs/CLAUDE.md. Replaces each `- ❌ text` with `- text` so the bullets are plain, consistent with the rest of the docs.

Files changed:
- `.claude/skills/attach-screenshots/SKILL.md`
- `.claude/skills/backend-parity/SKILL.md`
- `.claude/skills/commit-and-push/SKILL.md`
- `.claude/skills/polish-checkpoint/SKILL.md`
- `.claude/skills/render-verify/SKILL.md`
- `.claude/skills/request-re-review/SKILL.md`
- `.claude/skills/review-pr/SKILL.md`
- `.claude/skills/start-next-task/SKILL.md`
- `engine/prefabs/CLAUDE.md`

The ❌ in `review-pr/procedures/re-review.md` was intentionally left — it is a semantic status indicator (✅ fixed / ❌ still present / ↗ moved) in a template, not a decorative Anti-patterns bullet.

## Test plan
- [x] No `- ❌` lines remain in Anti-patterns sections across SKILL.md files
- [x] Retained ❌ in re-review.md template (semantic use, not decorative)

Closes #827