### PR TITLE
fleet: fleet-up --reset-usage flag for account-switch recovery

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -414,7 +414,11 @@ Defaults and tuning:
 - Global override (any unmatched type): `FLEET_DISPATCHER_USAGE_GATE`.
 - Stale observations (older than `FLEET_DISPATCHER_USAGE_STALE_SECONDS`,
   default `3600`) are dropped from evaluation, so a single high-watermark
-  reading can't latch the gate closed forever.
+  reading can't latch the gate closed forever. **Account-switch recovery:**
+  switching Claude accounts leaves the prior account's observations cached
+  and they will gate the new account until the stale window ages out.
+  `fleet-up --reset-usage` wipes `~/.fleet/state/usage/*.json` immediately;
+  safe to run on a live fleet (the gate re-evaluates on the next tick).
 - Reset grace (`FLEET_DISPATCHER_RESET_GRACE_SECONDS`, default `600`) —
   observations stay in evaluation until `resetsAt + grace` is in the past.
   Set to `0` to revert to the old "open instantly at resetsAt" behavior.

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -125,6 +125,51 @@ if ! command -v claude >/dev/null 2>&1; then
     exit 1
 fi
 
+# --- Early flag parsing -----------------------------------------------------
+#
+# Flags handled here take effect before the early-exit-if-session-exists
+# check, so they work on both fresh boots and live fleets. The main arg
+# parser further down recognizes the same flags as no-ops so the
+# unknown-arg guard doesn't reject them.
+RESET_USAGE=0
+for arg in "$@"; do
+    case "$arg" in
+        --reset-usage) RESET_USAGE=1 ;;
+    esac
+done
+
+# --reset-usage: wipe ~/.fleet/state/usage/*.json.
+#
+# Use case: the operator just switched Claude accounts. fleet-claude-stream
+# latches rate_limit_event observations per bucket (five_hour, seven_day,
+# ...), and the dispatcher reads those each tick to decide whether to gate
+# dispatches. A 94%-utilized cache file from the prior account will gate
+# the new account's dispatches for up to FLEET_DISPATCHER_USAGE_STALE_SECONDS
+# (default 1h) even though the new account has full budget.
+#
+# Safe to run on a live fleet — the dispatcher polls usage files every
+# tick (10s default), so the gate re-evaluates within one interval of
+# the wipe; no dispatcher restart needed. Cached observations re-populate
+# organically as the new account's events flow through fleet-claude-stream.
+if (( RESET_USAGE )); then
+    usage_dir="$HOME/.fleet/state/usage"
+    if [[ -d "$usage_dir" ]]; then
+        wiped=0
+        for f in "$usage_dir"/*.json; do
+            [[ -e "$f" ]] || continue
+            rm -f "$f"
+            wiped=$((wiped + 1))
+        done
+        if (( wiped > 0 )); then
+            echo "fleet-up: --reset-usage wiped $wiped cached observation(s) from $usage_dir"
+        else
+            echo "fleet-up: --reset-usage: $usage_dir already empty"
+        fi
+    else
+        echo "fleet-up: --reset-usage: $usage_dir does not exist (nothing to wipe)"
+    fi
+fi
+
 if tmux has-session -t "$SESSION" 2>/dev/null; then
     echo "fleet session already exists — attach with: tmux attach -t $SESSION"
     echo "(kill with \`tmux kill-session -t $SESSION\` first if you want a fresh layout)"
@@ -917,6 +962,7 @@ for arg in "$@"; do
     case "$arg" in
         dry-run|live|review-only) MODE="$arg" ;;
         --no-attach)  ATTACH_LIVE=0 ;;
+        --reset-usage) ;;  # handled in early parse loop near the top
         *) echo "fleet-up: unknown argument '$arg'" >&2; exit 2 ;;
     esac
 done
@@ -1193,6 +1239,12 @@ other modes you can pass to fleet-up:
   fleet-up live                  # full loop from the start, auto-attaches tmux
   fleet-up live --no-attach      # full loop, leave detached (CI / headless)
   fleet-up review-only           # close-out mode — no new work, finish in-flight
+
+flags (compose with any mode):
+  --reset-usage                  # wipe cached usage observations from a prior
+                                 #   account (use after switching Claude accounts;
+                                 #   safe to run on a live fleet — gate
+                                 #   re-evaluates within one dispatcher tick)
 
 graceful shutdown:
   fleet-down                     # graceful: send "exit", wait, kill, clear claims


### PR DESCRIPTION
## Summary
- Add `fleet-up --reset-usage` flag that wipes `~/.fleet/state/usage/*.json` before the dispatcher reads it, so an operator who switched Claude accounts can recover from the prior account's stale rate-limit observations without waiting on `FLEET_DISPATCHER_USAGE_STALE_SECONDS` (default 1h) to age them out.
- Parsed in an early-args pass so the flag works on a live fleet too — the dispatcher re-evaluates the gate on its next 10s tick, no restart needed. Cached observations re-populate organically once the new account's events flow through `fleet-claude-stream`.
- One-line doc bullet in `FLEET.md` "Fleet-wide usage gate" pointing at the new flag.

## Motivation
Hit live this session: the operator switched accounts and the fleet stayed gated for hours because `~/.fleet/state/usage/five_hour.json` still showed the prior account's `utilization: 0.94`. Manually `rm`-ing the file immediately reopened the gate and the dispatcher fired every role within seconds.

## Test plan
- [x] `bash -n` syntax check on the modified script.
- [x] `fleet-up --reset-usage` on a populated cache wipes the files and prints `wiped N cached observation(s)`.
- [x] Idempotent: second call on the now-empty dir prints `already empty` and exits cleanly.
- [x] Composes with the existing modes / flags via the early-parse + late-parse split (`--reset-usage` accepted by both parsers).
- [x] End-to-end: cache wipe (done by hand a few minutes before this PR was authored) immediately reopened a closed gate (`usage gate re-opened (open); resuming dispatch` in dispatcher.log) and every role fired within seconds.
- [x] Safe on a live fleet — no dispatcher restart needed; gate re-evaluates on the next 10s tick.

## Notes for reviewer
- Early-parse loop is intentionally a second pass (not folded into the existing MODE parser) because the wipe needs to happen before the `tmux has-session` early-exit, and the MODE parser sits well below that point. The late parser accepts `--reset-usage) ;;` as a no-op so the unknown-arg guard doesn't reject it.
- Pattern of "iterate files, count, log summary" mirrors the existing "sweep stale triggers" block (`scripts/fleet/fleet-up:648-659`). Two uses isn't enough to abstract a helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)