### PR TITLE
T-246: docs/skills: sweep stale tooling/version refs

### DIFF
--- a/.claude/skills/lua-creation-setup/SKILL.md
+++ b/.claude/skills/lua-creation-setup/SKILL.md
@@ -252,7 +252,7 @@ IRSystem.registerSystem({
 
 Whole-number float defaults (e.g. `0.0`) are indistinguishable from `0` at the C level under LuaJIT — use `{ type = "float", default = 0 }` for those. A bad inference is a hard error at script-load time naming the offending field.
 
-**Field order:** the codegen-emitted C++ struct and `ComponentName.new(...)` constructor list fields in **alphabetical order** (T-106 invariant). Match that order when constructing values in `setAt` calls.
+**Field order:** the codegen-emitted C++ struct and `ComponentName.new(...)` constructor list fields in **alphabetical order** (codegen invariant). Match that order when constructing values in `setAt` calls.
 
 #### `IRSystem.registerSystem` — declare a new system
 

--- a/.claude/skills/render-debug-loop/SKILL.md
+++ b/.claude/skills/render-debug-loop/SKILL.md
@@ -94,8 +94,7 @@ detail lives.
 
 If `engine/render/tests/render-baselines/<demo>/<SHA>/` exists for the
 target demo, Read each baseline crop alongside its current counterpart.
-(`<SHA>` is the HEAD commit SHA at baseline-capture time; the capture
-procedure and directory convention are defined by #433.)
+(`<SHA>` is the HEAD commit SHA at baseline-capture time.)
 Pairwise eyeballing catches drift that any single
 shot would not flag in isolation.
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -19,7 +19,7 @@ description: >-
 own launch prompt told it to poll `gh pr list` on an interval and review
 anything new. In that mode the reviewer agent resolves the set of unreviewed
 PRs itself and invokes this skill once per PR without the user typing a fresh
-phrase each time. The loop pattern is documented in `docs/AGENT_FLEET_SETUP.md`.
+phrase each time. The loop pattern is documented in `docs/agents/FLEET.md`.
 
 Do **not** invoke proactively inside an unrelated working session — e.g. while
 an author-agent is mid-refactor on its own PR, don't auto-jump into reviewing
@@ -251,7 +251,7 @@ or any `c_compute_*shadow*.glsl` / `.metal`)
 - New feature with no new test at all (flag as needs-fix unless the user
   explicitly said "no tests").
 - Build or format-check not run before opening the PR (check commit
-  message for mention, or run `cmake --build build --target format-check`
+  message for mention, or run `fleet-build --target format-changed`
   yourself if cheap).
 
 **Opus-only items** (Sonnet should not attempt these — escalate via the

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -80,9 +80,7 @@ For everything else, flag with the IRMath equivalent. See [`.claude/rules/cpp-ma
 
 If the IRMath wrapper does not exist yet, **don't auto-substitute** —
 flag with: "IRMath::<name> does not exist; add the wrapper to
-`engine/math/` first, then call it." (The `IRMath::kPi` / `kHalfPi` /
-`kTwoPi` constants in particular may not be merged yet — verify before
-suggesting.)
+`engine/math/` first, then call it."
 
 **Check 2: function-local `static` in system tick files.**
 
@@ -116,7 +114,6 @@ Live deviations already on the list (don't re-flag, but note in the
 report if touched):
 
 - `engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp:41-43`
-- `engine/prefabs/irreden/audio/systems/system_rhythmic_launch.hpp:29`
 - `engine/prefabs/irreden/update/systems/system_gravity.hpp:17`
 - `engine/prefabs/irreden/update/systems/system_animation_color.hpp:25-26`
 


### PR DESCRIPTION
## Summary

Sweep of 6 stale hardcoded refs flagged in `docs/agents/audit-skills.md` §4.2:

- **review-pr/SKILL.md**: `cmake --build build --target format-check` → `fleet-build --target format-changed`
- **review-pr/SKILL.md**: dead `docs/AGENT_FLEET_SETUP.md` → `docs/agents/FLEET.md`
- **simplify/SKILL.md**: removed stale "kPi/kHalfPi/kTwoPi may not be merged yet" hedge (all three are confirmed in `engine/math/ir_math.hpp`)
- **simplify/SKILL.md**: removed dead `system_rhythmic_launch.hpp:29` from Live deviations list (file no longer exists)
- **lua-creation-setup/SKILL.md**: `(T-106 invariant)` → `(codegen invariant)` — task IDs rot
- **render-debug-loop/SKILL.md**: removed unresolvable `#433` ref from baseline-crops section

Two audit-flagged items were already fixed in prior PRs:
- review-pr Opus stamp (now uses `<model>` placeholder)
- backend-parity Windows PATH-fix personal username

## Test plan
- [ ] Docs-only — confirm `review-pr/SKILL.md` uses `fleet-build --target format-changed` and `docs/agents/FLEET.md`
- [ ] Confirm `simplify/SKILL.md` Live deviations list has no `rhythmic_launch` entry and no kPi hedge
- [ ] Confirm `lua-creation-setup/SKILL.md` says "codegen invariant" not "T-106 invariant"
- [ ] Confirm `render-debug-loop/SKILL.md` does not reference `#433`

Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)