### PR TITLE
T-247: docs/skills: sweep Bash-rule violations in skill-prescribed snippets

### DIFF
--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -154,10 +154,11 @@ and fragment stages should produce **both** `v_<key>.glsl` and
 
 **C++ backend audit:**
 
-```bash
-diff <(ls engine/render/src/opengl/ | sed 's/^opengl_//') \
-     <(ls engine/render/src/metal/   | sed 's/^metal_//')
-```
+Use the Glob tool to list backend source files and compare stems:
+- `engine/render/src/opengl/opengl_*.cpp`
+- `engine/render/src/metal/metal_*.cpp`
+
+Strip the `opengl_`/`metal_` prefix from each result and compare — any stem present on one side but absent on the other is a potential parity gap.
 
 Read the diff carefully — Metal has runtime-bridge files
 (`metal_runtime.cpp`, `metal_cocoa_bridge.mm`, `metal_cpp_impl.cpp`)

--- a/.claude/skills/polish-checkpoint/SKILL.md
+++ b/.claude/skills/polish-checkpoint/SKILL.md
@@ -71,7 +71,11 @@ tree just means the commit-and-push pre-checks find nothing to do.
 ```bash
 git rev-parse --abbrev-ref HEAD
 git status
-git diff --stat && git diff
+git diff --stat
+```
+
+```bash
+git diff
 ```
 
 Group touched files by module (`engine/render/`, `engine/system/`,


### PR DESCRIPTION
## Summary

- Split `git diff --stat && git diff` in `polish-checkpoint/SKILL.md` into two separate bash blocks — the `&&` compound operator is blocked by the Bash tool in auto-mode
- Replace `diff <(ls engine/render/src/opengl/ | sed ...) <(ls engine/render/src/metal/ | sed ...)` in `backend-parity/SKILL.md` with Glob-tool guidance — process substitution and pipes are both blocked forms

`cmake --build … -j$(nproc)` violations at lines 254/260 are **not** touched — those are addressed separately in issue #818.

## Test plan
- [x] `polish-checkpoint/SKILL.md:74` — `&&` removed; each command in its own block
- [x] `backend-parity/SKILL.md:158-160` — process substitution replaced with Glob instructions
- [x] No other lines modified
- [x] Surrounding prose unchanged

Closes #830