### PR TITLE
T-248: docs/skills: trim Anti-patterns sections that restate flow-step requirements

### DIFF
--- a/.claude/skills/attach-screenshots/SKILL.md
+++ b/.claude/skills/attach-screenshots/SKILL.md
@@ -290,14 +290,6 @@ over stash:
 
 ## Anti-patterns
 
-- Committing screenshots in a separate commit. Stage and let
-  `commit-and-push` bundle them into the feature commit.
-- Running the capture from inside a worker role's tick function or
-  hot path. This skill is explicit, worker-invoked, and costs one
-  full rebuild + timed demo run per pass.
-- Capturing from any demo other than one that implements
-  `--auto-screenshot`. The "before" pass must be deterministic — a
-  hand-driven demo is not.
 - Deleting prior `docs/pr-screenshots/<other-branch>/` directories
   "for tidiness". Each branch owns its own; historical branches are a
   visual changelog.

--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -304,25 +304,11 @@ call, read its threadgroup size, and encode it as
 
 ## Anti-patterns
 
-- Shipping a port without building the lagging preset. The whole
-  point of the skill is that you *verified* it builds and runs.
-- Shipping a port without smoke-running the demo. Build-clean ≠
-  parity.
-- `#ifdef METAL` / `#ifdef OPENGL` stubs that silently return
-  wrong values. Either port properly or stop and flag.
-- Bundling multiple unrelated parity fixes into one PR. One logical
-  feature per PR; the reviewer can't usefully sign off on "ports
-  three shaders and rewrites the framebuffer path".
-- Changing the leading backend mid-port. If the leading side has a
-  bug, file it separately and then port the correct behavior.
-  This skill is parity, not drive-by cleanup.
-- Hardcoding dispatch sizes instead of reusing
-  `voxelDispatchGridForCount()` or the equivalent math helper.
-- Inventing new uniform layouts "because MSL is different". Match
-  the CPU-side feeder struct exactly; if the feeder struct is wrong
-  for Metal, that's a separate refactor in a separate PR.
-- Running this skill on a host whose backend matches the
-  *leading* side. You cannot verify the port — stop.
+- `#ifdef METAL` / `#ifdef OPENGL` stubs that silently return wrong values.
+  Either port properly or stop and flag.
+- Changing the leading backend mid-port. If the leading side has a bug,
+  file it separately and then port the correct behavior. This skill is
+  parity, not drive-by cleanup.
 
 ## Re-port after review feedback
 

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -319,17 +319,7 @@ if the user already asked for the next task).
 
 ## Anti-patterns
 
-- Committing to `master`. Always branch first.
-- `git add -A` / `git add .` — risk of committing secrets or build junk.
 - Amending a previous commit without being asked.
-- Force-pushing master. Never.
-- Skipping hooks (`--no-verify`) unless the user explicitly requests it.
-- Bypass-pushing to master with admin — the new workflow uses PRs and
-  reviewer agents. If you feel tempted to bypass, something upstream is
-  broken; flag it to the user instead.
-- Opening a PR without running `simplify` first.
-- Continuing to commit on the same feature branch after opening its PR
-  unless the user explicitly asks for it — otherwise use `start-next-task`.
 - Leaking game references into an engine PR — see `docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation".
 
 ## Recovery

--- a/.claude/skills/polish-checkpoint/SKILL.md
+++ b/.claude/skills/polish-checkpoint/SKILL.md
@@ -152,20 +152,10 @@ state:
 
 ## Anti-patterns
 
-- Running this skill autonomously after every edit. It's a
-  user-invoked checkpoint, not a save-on-edit hook.
-- Following polish-checkpoint with `commit-and-push` unless the
-  user explicitly asks. The whole point is the human controls when
-  to PR.
-- Skipping the build step on code diffs to save time. The
-  checkpoint is not real if the build doesn't actually pass.
-- Editing files outside the dirty diff to "improve" them. Stay
-  scoped to what the session has already changed.
-- Switching branches mid-skill. The user's current branch state
-  is intentional; respect it.
-- Using this skill in fleet flow. Fleet workers run
-  `commit-and-push` end-to-end; intermediate checkpoints are an
-  interactive-session concept.
+- Following polish-checkpoint with `commit-and-push` unless the user
+  explicitly asks. The whole point is the human controls when to PR.
+- Switching branches mid-skill. The user's current branch state is
+  intentional; respect it.
 
 ## Recovery
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -453,15 +453,9 @@ Reply with a compact summary to the calling session:
 
 ## Anti-patterns
 
-- Reviewing only the diff, not the surrounding file. Context matters.
-- Vague review comments without file:line citations.
 - Approving work that violates an ECS invariant "because the test passes"
   — some invariants don't fail at test time.
-- Merging the PR yourself. The user merges.
 - Pushing commits to the PR branch from the reviewer worktree.
-- Leaving a review that just says "LGTM" with nothing specific. Either the
-  PR is actually clean (in which case call out one non-obvious good choice
-  as **praise**, to reinforce it) or it isn't.
 
 ## Re-review
 

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -288,39 +288,12 @@ Reply with a compact summary:
 
 ## Anti-patterns
 
-- Switching branches with a dirty working tree. Always clean first.
-- Branching off your previous PR branch in **standard mode** (no
-  active molecule and no stack cue). That stacks unrelated work and
-  pollutes the old PR. Either stack mode (4a returned a `T-NNN`, or
-  the human cued stacking) is the only case where the old branch is
-  the correct base.
-- Branching off `origin/master` in **either stack mode**. The
-  downstream slice's diff would then include the upstream changes
-  too, defeating the whole point of stacked PRs (one slice = one
-  isolated diff).
-- Skipping `fleet-claim molecule advance` after `commit-and-push`
-  and going straight to `start-next-task`. `molecule resume` would
-  return the just-completed task as still in-progress, branching you
-  onto the same thing you just shipped. The stack-mode sanity-check
-  in step 4a catches this — heed it.
-- Writing `cursor-stack-base` git config in fleet stack mode or
-  standard mode. The config is the cursor-flow stack signal; setting
-  it elsewhere confuses `commit-and-push`.
-- Auto-detecting cursor stack mode from "old branch happens to be
-  a feature branch" without a user cue. The cue is the only signal.
-  Without it, the human's intent is ambiguous (they may want a fresh
-  slice off master), and step 4b's "ask, don't guess" rule applies
-  for cursor flow.
-- Running `git rebase origin/master` on the old branch to "catch
-  it up", then reusing it. Rebasing the same branch for new unrelated
-  work is how PR histories become unreadable.
-- Deleting the old local branch. Leave it alone — if the reviewer
-  asks for changes, you'll need to check it out again. Both stack
-  modes REQUIRE the old branch as the new branch's base.
-- Starting the next task without reading the target area's
-  CLAUDE.md. That's where the module-specific invariants live.
-- Invoking this skill when no PR was actually opened (i.e. after a
-  `commit-and-push` failure). Check step 2.
+- Running `git rebase origin/master` on the old branch to "catch it up",
+  then reusing it. Rebasing the same branch for new unrelated work is how
+  PR histories become unreadable.
+- Deleting the old local branch. Leave it alone — if the reviewer asks for
+  changes, you'll need to check it out again. Both stack modes REQUIRE the
+  old branch as the new branch's base.
 
 ## Recovery
 


### PR DESCRIPTION
## Summary

Strips redundant anti-pattern bullets from 6 SKILL.md files where entries duplicated explicit flow steps, preconditions, or scope rules already stated earlier in the same file. Keeps only 1–2 non-obvious bullets per skill.

| Skill | Before | After | Kept |
|---|---|---|---|
| backend-parity | 8 | 2 | `#ifdef` stubs (silent failures), changing leading backend mid-port |
| start-next-task | 10 | 2 | rebase-old-branch antipattern, delete-old-branch |
| attach-screenshots | 5 | 2 | delete other-branch dirs, non-visual PRs cost |
| polish-checkpoint | 6 | 2 | follow-with-commit-and-push, switch-branches |
| commit-and-push | 9 | 2 | amend-without-being-asked, leak-game-refs |
| review-pr | 6 | 2 | ECS invariants, push-from-reviewer-worktree |

96 lines removed total.

## Test plan
- [ ] Each Anti-patterns section retains only genuinely non-obvious gotchas not already stated in the flow steps
- [ ] No cross-references broken

Closes #831