### PR TITLE
T-249: docs/skills: pull pipeline-ordering (INPUT -> UPDATE -> RENDER) into one canonical doc

### DIFF
--- a/.claude/skills/create-creation/SKILL.md
+++ b/.claude/skills/create-creation/SKILL.md
@@ -170,15 +170,7 @@ For the Lua binding files, see the `lua-creation-setup` skill.
 
 ## Pipeline Ordering
 
-Pipelines execute in this order each frame: **INPUT -> UPDATE -> RENDER**.
-
-Within each pipeline, systems execute in the order listed in `registerPipeline`. Common orderings:
-
-**UPDATE:** velocity/acceleration -> goto/easing -> global position -> voxel children -> lifetime
-
-**INPUT:** key/mouse -> gamepad -> hover detect
-
-**RENDER:** camera pan -> velocity render -> voxel-to-trixel stages -> shapes/text -> trixel compositing -> framebuffer -> debug overlay -> screen
+See [`engine/system/CLAUDE.md`](../../engine/system/CLAUDE.md) §Pipelines for the INPUT → UPDATE → RENDER order and common system orderings within each pipeline.
 
 ## Reference Creations
 

--- a/.claude/skills/ecs-prefab-creator/SKILL.md
+++ b/.claude/skills/ecs-prefab-creator/SKILL.md
@@ -192,7 +192,7 @@ After creating prefabs, the creation must:
 2. Add `createSystem<IRSystem::MY_SYSTEM>()` in the appropriate `registerPipeline()` call.
 3. Add `createCommand<IRCommand::MY_COMMAND>(...)` in `initCommands()`.
 
-Pipelines run in order: **INPUT -> UPDATE -> RENDER**. System order within a pipeline matters.
+See [`engine/system/CLAUDE.md`](../../engine/system/CLAUDE.md) §Pipelines for the INPUT → UPDATE → RENDER order and system ordering within each pipeline.
 
 ## Checklist
 

--- a/.claude/skills/midi-scene-creator/SKILL.md
+++ b/.claude/skills/midi-scene-creator/SKILL.md
@@ -65,7 +65,7 @@ Key API:
 
 ## MIDI Systems
 
-Register these in your creation's `initSystems()` under the appropriate pipeline:
+Register these in your creation's `initSystems()` under the appropriate pipeline (pipelines execute in order INPUT → UPDATE → RENDER; see [`engine/system/CLAUDE.md`](../../engine/system/CLAUDE.md) §Pipelines):
 
 | System | Pipeline | Purpose |
 |--------|----------|---------|

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -232,6 +232,16 @@ function-local `static` for system state.
 
 ## Pipelines
 
+Three built-in pipelines execute in this order each frame: **INPUT → UPDATE → RENDER**.
+
+Within each pipeline, systems execute in the order listed in `registerPipeline`. Common orderings:
+
+**UPDATE:** velocity/acceleration → goto/easing → global position → voxel children → lifetime
+
+**INPUT:** key/mouse → gamepad → hover detect
+
+**RENDER:** camera pan → velocity render → voxel-to-trixel stages → shapes/text → trixel compositing → framebuffer → debug overlay → screen
+
 ```cpp
 IRSystem::registerPipeline(IRTime::Events::UPDATE, {
     velocitySystem,


### PR DESCRIPTION
## Summary

- Move the INPUT → UPDATE → RENDER pipeline ordering description (and common per-pipeline system orderings) from `create-creation/SKILL.md` into `engine/system/CLAUDE.md` §Pipelines — the canonical home already mentioned at line 4 of that file
- Replace the full 9-line "## Pipeline Ordering" section in `create-creation/SKILL.md` with a one-line ref
- Replace the single-line restatement in `ecs-prefab-creator/SKILL.md` with a one-line ref
- Inline a one-line ref in `midi-scene-creator/SKILL.md` at the point where pipeline context is first implied (the MIDI systems table intro)

## Test plan
- [x] `engine/system/CLAUDE.md` §Pipelines now carries the canonical INPUT → UPDATE → RENDER ordering and common per-pipeline orderings
- [x] `create-creation/SKILL.md:171-181` — replaced with one-line ref
- [x] `ecs-prefab-creator/SKILL.md:195` — replaced with one-line ref
- [x] `midi-scene-creator/SKILL.md:68` — ref inlined in the intro sentence
- [x] No content changes to any other section

Closes #832