### PR TITLE
T-253: docs: engine/prefabs/irreden/ — prune name catalogs across subtree

### DIFF
--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -20,9 +20,6 @@ in `update/`.
   pair. **Both auto-added by `createEntity(...)`**. See
   [SQT transform pair + propagation](#sqt-transform-pair--propagation)
   below.
-- `C_Name` — debug/display string.
-- `C_Player` — tag for player-controlled entities.
-- `C_Selected` — tag for UI selection.
 - `C_Modifiers` / `C_GlobalModifiers` / `C_NoGlobalModifiers` /
   `C_LambdaModifiers` / `C_ResolvedFields` — generic modifier
   framework. See [Modifier framework](#modifier-framework) below.
@@ -42,7 +39,7 @@ quaternion layout `IRMath::vec4(qx, qy, qz, qw)` — identity is
 `vec4(0, 0, 0, 1)`. See `engine/math/CLAUDE.md` "Quaternions" for the
 algebra contract (`IRMath::quatMul`, `IRMath::rotateVectorByQuat`).
 
-`SYSTEM_PROPAGATE_TRANSFORM` in
+`PROPAGATE_TRANSFORM` in
 [`update/systems/system_propagate_transform.hpp`](../update/systems/system_propagate_transform.hpp)
 walks the parent chain in topological order each tick and writes
 `C_WorldTransform`. The composition formula:
@@ -71,7 +68,7 @@ Entities that don't push perturbations don't need `C_Modifiers`. The
 matching `ROTATION` quat field arrives with the quat modifier kind
 ticket (T-198); until then, `modifier_rotation` is identity.
 
-**Pipeline placement.** Register `SYSTEM_PROPAGATE_TRANSFORM`
+**Pipeline placement.** Register `PROPAGATE_TRANSFORM`
 after the modifier resolver pipeline so the resolved fields are
 current, and before any consumer (render, gizmo, physics) that reads
 `C_WorldTransform`.

--- a/engine/prefabs/irreden/input/CLAUDE.md
+++ b/engine/prefabs/irreden/input/CLAUDE.md
@@ -21,7 +21,6 @@ systems that populate button state. The underlying polling lives in
 - `C_KeyStatus` — a button state machine
   (`NOT_HELD`/`PRESSED`/`HELD`/`RELEASED`/`PRESSED_AND_RELEASED`) plus
   press/release frame counts.
-- `C_MousePosition` — cached cursor.
 - `C_MouseScroll` — ephemeral per-scroll event (`C_Lifetime{1}`).
 - `C_GLFWGamepadState` — 15 button states + 6 axes.
 
@@ -82,7 +81,7 @@ and falls through to the next priority tier.
 ## Gotchas
 
 - **Hover tests need cached camera state.** `HITBOX_MOUSE_TEST`'s
-  `beforeTick` caches `C_CameraPosition2DIso + C_ZoomLevel`. Moving
+  `beginTick` caches `C_CameraPosition2DIso + C_ZoomLevel`. Moving
   the camera inside the same tick with a separate system can desync
   the hover test by one frame.
 - **Mouse scroll is ephemeral by design.** The GLFW scroll callback

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -13,16 +13,8 @@ the ECS surface.
   subdivisions, hover detection, pixel offset, etc.
 - `C_TrixelFramebuffer` — wraps a `Framebuffer` (color + depth). Also
   ctor-allocated, `onDestroy()`-freed.
-- `C_Camera` — tag.
-- `C_CameraPosition2DIso` — iso-space position.
-- `C_ZoomLevel` — float zoom.
 - `C_CameraYaw` — continuous Z-yaw (radians), normalized to `[-π, π)`. See
   `camera.hpp` for the cardinal/residual split API.
-- `C_TextSegment` — UTF-8 string for text-to-trixel.
-- `C_TextStyle` — font, size, color.
-- `C_GeometricShape` — 2D overlay shape descriptor.
-- `C_FrameDataTrixelToFramebuffer` — per-frame UBO (MVP, hover coord,
-  distance offset).
 - `C_Sprite` / `C_SpriteSheet` / `C_SpriteAnimation` — 2D screen-composite
   sprite + atlas metadata + per-instance playback state. Sprites bypass the
   trixel pipeline and draw at the `FRAMEBUFFER_TO_SCREEN` stage;
@@ -35,21 +27,7 @@ the ECS surface.
   full data model, depth semantics, and cross-task scope.
 - `C_GizmoHandle` — marker on editor gizmo entities, tagging handle kind
   (translate-arrow, rotate-ring, scale-stick / scale-center, joint /
-  bind-point / IK marker) + axis. Carries the Phase 2 (T-164) baseline
-  fields — `referenceParams_` (the unscaled shape descriptor params
-  written at construction), `referenceLocalPos_` (the unscaled local
-  position), and `isAnchor_` (true for single-entity markers whose own
-  `C_Position3D` is the world-space anchor — false for child handles
-  parented under a group root). Also carries the Phase 3 (T-165)
-  interaction fields — `hover_` (stamped each frame by `GIZMO_HOVER`
-  from the GPU entity-id readback), `baseColor_` (the unmodulated
-  color captured at spawn — the hover system writes a brightened tint
-  onto the sibling `C_ShapeDescriptor` while hovered and restores the
-  base on the same frame the hover bit clears), and `anchorEntity_`
-  (the entity whose `C_Position3D` `GIZMO_DRAG` mutates — by
-  convention the gizmo group parent, so all axes of a multi-handle
-  gizmo share one anchor; `kNullEntity` keeps the handle hoverable
-  but disables drag). Visible geometry comes from a sibling
+  bind-point / IK marker) + axis. Visible geometry comes from a sibling
   `C_ShapeDescriptor` on the same entity (SDF primitive rendered by
   `SHAPES_TO_TRIXEL`); the marker carries no rendering state itself.
   Builders live in `IRPrefab::Gizmo::` (see "Exposing system public
@@ -67,7 +45,7 @@ the ECS surface.
   more detail than the camera is providing). Phase 1 of the LOD story;
   see `docs/design/lod-strategy.md`.
 
-## Key systems (all RENDER pipeline)
+## Key systems
 
 - `VOXEL_TO_TRIXEL_STAGE_1` / `STAGE_2` — compute-shader voxel
   rasterization to the 3 canvas textures.
@@ -358,7 +336,3 @@ when extending or composing widgets:
 - **Render-behavior flags are the knobs.** Changing pipeline behavior
   for a canvas (disable zoom tracking, turn off hover) is done via
   `C_TrixelCanvasRenderBehavior`, not by branching in the systems.
-- **`SystemName` enum registration.** Every render system name
-  (`VOXEL_TO_TRIXEL_STAGE_1`, ...) must exist in
-  `engine/system/include/irreden/ir_system_types.hpp` or the
-  specialization won't link.

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -126,7 +126,7 @@ single component on the rig root. Three pieces:
   joint-matrix uploader iterate joints without seeing rig roots or
   skinned voxel sets.
 - **`CHILD_OF`** relations between joint entities form the bone tree. The
-  same `SYSTEM_PROPAGATE_TRANSFORM` (from `#731` Phase 2) that walks
+  same `PROPAGATE_TRANSFORM` (from `#731` Phase 2) that walks
   every other CHILD_OF hierarchy composes the parent chain — no
   joint-specific traversal code.
 


### PR DESCRIPTION
## Summary

- `common/CLAUDE.md`: remove `C_Name` / `C_Player` / `C_Selected` tag-only bullets that restate component names; fix `SYSTEM_PROPAGATE_TRANSFORM` → `PROPAGATE_TRANSFORM` (actual `SystemName` enum value per `ir_system_types.hpp:56`)
- `render/CLAUDE.md`: remove 5 one-liner entries (`C_Camera`, `C_TextSegment`, `C_TextStyle`, `C_GeometricShape`, `C_FrameDataTrixelToFramebuffer`) from Key components; trim `C_GizmoHandle` per-field docs (field list belongs in component header); fix "all RENDER pipeline" header — `VOXEL_PICKING` is INPUT; delete `SystemName` enum rule (redundant with `engine/prefabs/CLAUDE.md`)
- `input/CLAUDE.md`: remove `C_MousePosition — cached cursor` one-liner; fix `beforeTick` → `beginTick` in Gotchas (now consistent with Key systems section)
- `voxel/CLAUDE.md`: fix `SYSTEM_PROPAGATE_TRANSFORM` → `PROPAGATE_TRANSFORM`

## Test plan

- [ ] Docs-only — confirm Key components sections contain only entries with non-obvious lifecycle or behavior
- [ ] Confirm `PROPAGATE_TRANSFORM` matches `ir_system_types.hpp:56`
- [ ] Confirm `beginTick` is used consistently in `input/CLAUDE.md`

Closes #836