### PR TITLE
T-252: docs: engine/prefabs/CLAUDE.md — de-dup vs .claude/rules/cpp-ecs.md

### DIFF
--- a/.claude/rules/cpp-ecs.md
+++ b/.claude/rules/cpp-ecs.md
@@ -44,34 +44,7 @@ Use the deferred variants (`IREntity::deferredCreate`, `deferredSetComponent`, e
 
 ## Component method tiers
 
-A component's methods fall into three categories. Anything outside (a) and (b), and not on the documented exceptions list, is a violation.
-
-**(a) Pure data.** Fields and a constructor that initializes them. Most components in `common/`, `input/`, and tag-style components.
-
-**(b) Self-only helpers (allowed).** Methods that read or write only the component's own fields (and stack-locals derived from them). Examples:
-
-- `C_PeriodicIdle::tick()` advances its own angle.
-- `C_CanvasFogOfWar::setCell()` writes its own grid.
-- `toGPUFormat()` converts own fields into a render struct.
-
-**(c) Cross-entity reaches (forbidden).** Methods that look up *another* entity through a stored `EntityId` field via `IREntity::getComponent`, `setComponent`, `createEntity`, `setParent`, or `getEntity`.
-
-These belong in **a system** (per-frame work) or one of:
-
-- **Entity builder** — `template <> struct IREntity::Prefab<NAME>` with a `create()` that wires up the entity bundle. Example: `engine/prefabs/irreden/render/entities/entity_trixel_canvas.hpp`.
-- **Prefab-scoped namespace** — a sibling `<feature>.hpp` exposing a `namespace IRPrefab::Foo` with free functions. The namespace owns the entity-lookup logic; callers don't carry the entity id. Example: `engine/prefabs/irreden/render/fog_of_war.hpp`. Use this when an API needs an ergonomic free-function shape and the caller is unlikely to hold the entity id.
-
-The split keeps component layout trivial (good for archetype iteration) and concentrates per-entity orchestration where it belongs.
-
-### Documented exceptions to (c)
-
-These patterns *look* like (c) but are accepted because the alternatives are worse:
-
-- **GPU / IO resource RAII.** A constructor that calls `IRRender::createResource<>` and a destructor that calls `destroyResource<>` is fine — the component IS the resource owner, and splitting allocation into a system makes the lifetime contract harder to enforce. Examples: `C_TriangleCanvasTextures`, `C_TrixelFramebuffer`, `C_CanvasFogOfWar`, `C_CanvasSunShadow`, `C_CanvasAOTexture`, `C_CanvasLightVolume`.
-- **`onDestroy()` IO cleanup.** A component that hooks the entity's destroy event to flush an external side effect (e.g. `C_MidiNote::onDestroy()` sending NOTE_OFF) is fine when the cleanup must be synchronized with entity death and a per-component hook is simpler than a "scan dying entities" system. Document the side effect in the domain `CLAUDE.md`.
-- **Constructor snapshots ambient state.** A constructor that reads `IRRender::getActiveCanvasEntity()` (or similar) to bind the component to the currently-active canvas is fine — no other entity is mutated, and the alternative is forcing every caller to thread the canvas id. Examples: `C_VoxelSetNew`, `C_ShapeDescriptor`.
-
-Anything outside (a)/(b) and not on the exceptions list above is a (c) violation and should be moved to a system, builder, or namespace.
+See [`engine/prefabs/CLAUDE.md` — Component method rules](../../engine/prefabs/CLAUDE.md#component-method-rules) — canonical home for the (a)/(b)/(c) categorization and documented exceptions.
 
 ## No dirty flags on components
 

--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -14,11 +14,7 @@ components. The full reasoning, allowlists, and canonical patterns live in
 [`.claude/rules/cpp-ecs.md`](../../.claude/rules/cpp-ecs.md) — those auto-load
 when you open any C++ file. The capsules here are reminders.
 
-- **Math primitives go through IRMath.** Never `glm::*` or
-  `std::sin/cos/sqrt/abs/min/max/clamp` outside `engine/math/`.
-  Use `IRMath::vec3` not `glm::vec3`, `IRMath::clamp` not `std::clamp`,
-  `IRMath::kPi` not `glm::pi<float>()`. Need a primitive that isn't
-  there? Add the wrapper to `engine/math/` first, then call it.
+- **Math primitives go through IRMath** — never `glm::*` or `std::sin/cos/sqrt/abs/min/max/clamp` directly; see [`.claude/rules/cpp-math.md`](../../.claude/rules/cpp-math.md).
 - **System state lives on `System<N>` or in `SystemParams`.** Never
   function-local `static` for mutable or system-owned state —
   `static constexpr` / `static const` for genuine compile-time
@@ -29,31 +25,7 @@ when you open any C++ file. The capsules here are reminders.
   Both forms have the same per-tick cost. Full pattern in
   [`engine/system/CLAUDE.md`](../system/CLAUDE.md) and
   [`.claude/rules/cpp-systems.md`](../../.claude/rules/cpp-systems.md).
-- **No per-entity `getComponent` inside a system tick.** Add the
-  component to the system's template parameters instead. Foreign-entity
-  lookups for collisions/messages should batch the entities as a vector
-  rather than per-call inside the tick — see
-  [`.claude/rules/cpp-ecs.md`](../../.claude/rules/cpp-ecs.md).
-
-## Layout
-
-```
-engine/prefabs/irreden/
-  common/   — position, transform, name, player, tags, selection
-  update/   — physics, movement, collision, animation, particles
-  voxel/    — voxel pools, voxel sets, sculpting, shape descriptors
-  input/    — key/mouse/gamepad input components, hover detect, hitboxes
-  render/   — trixel canvases, framebuffers, cameras, text
-  audio/    — MIDI messages, sequences, channels, devices
-  video/    — screenshot + recording commands
-  asset/    — asset-related prefabs (currently small)
-  demo/     — demo-specific scratch prefabs (do not ship into creations)
-  wip/      — experimental prefabs not ready for production
-```
-
-Each domain has its own `CLAUDE.md` with the components/systems/commands
-catalog and the patterns specific to that domain. Read the nearest one
-before adding or modifying.
+- **No per-entity `getComponent` inside a system tick** — add the component to template params instead; see [`.claude/rules/cpp-ecs.md`](../../.claude/rules/cpp-ecs.md).
 
 ## File pattern
 
@@ -148,26 +120,9 @@ and should be moved to a system, builder, or namespace.
 
 ## Anti-patterns
 
-- ❌ Per-entity `getComponent` inside a system tick function. Fix: add the
-  component to the system's template parameters.
-- ❌ Allocating memory in a hot tick path (`std::vector` push, string
-  concat, `new`). Reserve once at `beginTick`.
 - ❌ Adding a new system without updating the `SystemName` enum.
 - ❌ Storing references to other entities' component storage across frames
   — archetype changes invalidate addresses.
 - ❌ Cross-domain includes inside a prefab header (e.g. `voxel/` component
   including `audio/` component). Prefabs are grouped by domain on purpose;
   cross-domain composition belongs in a creation.
-- ❌ Function-local `static` for system-owned state. Use the
-  member-on-`System<N>` form via `registerSystem` (preferred) or the
-  explicit `Params` + `setSystemParams` form — both have the same
-  per-tick cost, correct lifetime, and are multi-instance safe.
-  See `engine/system/CLAUDE.md` "Per-system parameters" for the
-  rule, rationale, and canonical patterns.
-- ❌ `bool dirty_` (or `needsUpload_`, `changed_`) on a component to
-  gate a per-frame CPU→GPU sync step. Push at mutation time (per-write
-  `subData` / `subImage2D`) or let the GPU own ongoing state and seed
-  the resource once in the ctor. The only documented exception is
-  `C_CanvasFogOfWar` (CPU-authored, GPU-read-only, full-texture upload).
-  See [`.claude/rules/cpp-ecs.md`](../../.claude/rules/cpp-ecs.md) "No
-  dirty flags on components".


### PR DESCRIPTION
## Summary

- Trim IRMath capsule in Hard rules to one-liner + pointer to `.claude/rules/cpp-math.md`
- Trim getComponent capsule to one-liner + pointer to `.claude/rules/cpp-ecs.md`
- Delete `## Layout` section (directory tree — direct CLAUDE-BASELINE violation)
- Remove anti-patterns 1, 2, 6, 7 that restate rules already in `cpp-ecs.md` / `cpp-systems.md`
- Delete the "Component method tiers" section from `.claude/rules/cpp-ecs.md`; replace with a one-line pointer to `engine/prefabs/CLAUDE.md` as the canonical home (per CLAUDE-BASELINE.md §74–79)

## Test plan

- [ ] `engine/prefabs/CLAUDE.md` — no directory tree, no duplicate anti-patterns, Component method rules section intact as canonical
- [ ] `.claude/rules/cpp-ecs.md` — Component method tiers section now a one-line pointer; all other rules (ECS footgun, dirty flags, allocations, foreign-entity lookups, deferred ops) untouched

Closes #835