### PR TITLE
T-254: docs: engine/audio + engine/video CLAUDE.md — remove dead pointers

### DIFF
--- a/engine/audio/CLAUDE.md
+++ b/engine/audio/CLAUDE.md
@@ -47,16 +47,6 @@ functions:
   or Lua state from inside it**. Copy samples into a lock-free buffer and
   consume on the main thread.
 
-## Key components (prefabs/irreden/audio)
-
-- `C_MidiMessage` — status + data1 + data2. Unpacks channel/status.
-- `C_MidiNote`, `C_MidiSequence` — higher-level note/sequence types (with
-  Lua bindings).
-- `C_MidiDevice`, `C_MidiChannel`, `C_MidiDelay` — tag components.
-- `C_AudioFile` — placeholder, minimal.
-
-Plus `*_lua.hpp` variants for sequences and notes.
-
 ## Gotchas
 
 - **No hot-swap.** If a MIDI device is unplugged mid-run, the `RtMidiIn`

--- a/engine/video/CLAUDE.md
+++ b/engine/video/CLAUDE.md
@@ -90,9 +90,6 @@ Reference callers: `creations/demos/shape_debug/main.cpp` and
 - `command_take_screenshot` → `requestScreenshot()`.
 - `command_take_screenshot_canvas` → `requestCanvasScreenshot()`.
 - `command_toggle_recording` → `toggleRecording()`.
-- `C_FramebufferCapture`, `C_FramebufferOutputPosition`,
-  `C_OutputResolution` — placeholder components tagging framebuffers
-  that participate in capture.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Trim dead pointers from two engine CLAUDE.md files. Both removed sections were file-listing/component-name notes that duplicate information already discoverable from header names — no behavioral guidance was removed.

- `engine/audio/CLAUDE.md` — drop the "Key components (prefabs/irreden/audio)" block that enumerated `C_MidiMessage`, `C_MidiNote`, `C_MidiSequence`, `C_MidiDevice`, `C_MidiChannel`, `C_MidiDelay`, `C_AudioFile`, and the `*_lua.hpp` variant note. Each is a self-documenting component header in `engine/prefabs/irreden/audio/components/`; the MIDI model, Audio capture model, and Gotchas sections (which carry the non-obvious semantics) are unchanged.
- `engine/video/CLAUDE.md` — drop the placeholder-tagging note for `C_FramebufferCapture`, `C_FramebufferOutputPosition`, `C_OutputResolution`. Each header is 120-150 bytes and the names self-document the role; surrounding "Commands" and "Gotchas" sections are intact.

## Test plan

- [x] Docs-only diff; no build/run impact.

Closes #837