### PR TITLE
T-256: docs: small modules — delete inline directory trees from CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,21 +81,8 @@ For the full workflow — fleet rules, cursor cues, stacking, design escalation,
 
 ## Project layout
 
-```
-engine/                        # Core static libs — see engine/CLAUDE.md
-  entity/   system/   world/   # ECS runtime
-  math/     common/            # Shared primitives
-  render/   audio/   video/    # IO and GPU
-  script/   input/   command/  # Scripting + input
-  window/   time/    profile/  asset/
-  prefabs/irreden/             # Header-only components/systems/commands/entities
-    common/ update/ voxel/ input/ render/ audio/ video/
-creations/                     # Applications — see creations/CLAUDE.md
-  demos/   editors/   template/
-```
-
-Each of the listed directories has its own `CLAUDE.md` with the module-
-specific patterns, gotchas, and file maps. Read the most specific one for
-whatever you're touching. Creations layered on top of the engine (including
-gitignored private implementations) define their own conventions in their
-own `CLAUDE.md` — when working there, those override the engine baseline.
+Each directory has its own `CLAUDE.md` with module-specific patterns,
+gotchas, and file maps. Read the most specific one for whatever you're
+touching. Creations layered on top of the engine (including gitignored
+private implementations) define their own conventions in their own
+`CLAUDE.md` — when working there, those override the engine baseline.

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -17,34 +17,6 @@ Core engine static libraries. Everything here is shared by every creation.
   modules (`common/`, `math/`, `profile/`) do not depend on high-level
   ones (`render/`, `world/`).
 
-## Layer map (bottom-up)
-
-```
-common/   — shared primitives (ir_constants, ir_platform)
-math/     — GLM aliases, iso projection, easing, color, physics
-profile/  — easy_profiler + spdlog logging wrappers
-time/     — TimeManager + EventProfiler (fixed-step loop)
-
-entity/   — IRECS archetype store, EntityManager, Archetype, relations
-system/   — SystemManager, pipeline scheduler, SystemName enum
-command/  — CommandManager, input-triggered action binding
-
-input/    — InputManager, GLFW keyboard/mouse/gamepad polling
-window/   — IRGLFWWindow, OpenGL context bring-up
-render/   — RenderManager, RenderingResourceManager, trixel pipeline, shaders
-audio/    — AudioManager, MIDI in/out (RtMidi, RtAudio)
-video/    — VideoRecorder, ffmpeg encoder, screenshot path
-script/   — LuaScript, sol2 bindings, kHasLuaBinding<T> traits
-
-asset/    — trixel texture + SDF load/save
-world/    — World class, owns all managers above
-
-prefabs/  — header-only C_* / System<> / Command<> definitions, grouped
-            by domain: common/ update/ voxel/ input/ render/ audio/ video/
-```
-
-Read the `CLAUDE.md` inside each subdirectory for the module-specific story.
-
 ## `SystemName` enum is authoritative
 
 Every prefab system that uses the `System<NAME>::create()` template pattern

--- a/engine/common/CLAUDE.md
+++ b/engine/common/CLAUDE.md
@@ -34,15 +34,6 @@ systems.
   NDC Y direction, depth range convention (0..1 vs -1..1), mouse Y flip.
   Use this instead of `#ifdef`ing backends in call sites.
 
-## Internal layout
-
-```
-engine/common/
-└── include/irreden/
-    ├── ir_constants.hpp
-    └── ir_platform.hpp
-```
-
 No `src/` — everything is header-only.
 
 ## Gotchas

--- a/engine/profile/CLAUDE.md
+++ b/engine/profile/CLAUDE.md
@@ -50,19 +50,6 @@ Colors are ARGB hex: `0xff0000ff` = pure blue, `0xffff0000` = pure red, etc.
 `CPUProfiler::setEnabled(bool)` gates all profile macros. Call it from a
 creation's startup if you want profiling off by default.
 
-## Internal layout
-
-```
-engine/profile/
-└── include/irreden/
-    ├── ir_profile.hpp             — public macros
-    └── profile/
-        ├── ir_profile.tpp         — template impls for log macros
-        ├── ir_profile_types.hpp   — shared type helpers
-        ├── logger_spd.hpp         — spdlog singleton (engine/gl/game sinks)
-        └── cpu_profiler.hpp       — easy_profiler singleton
-```
-
 ## Gotchas
 
 - **Macros are no-ops in release.** Don't put side-effectful calls inside

--- a/engine/utility/CLAUDE.md
+++ b/engine/utility/CLAUDE.md
@@ -22,16 +22,6 @@ functions for reading files and composing paths. Used by `asset/`,
   `("screenshot", 7, 4, "png") → "screenshot_0007.png"`. Used for
   screenshot/recording serial numbers.
 
-## Internal layout
-
-```
-engine/utility/
-└── ir_utility.hpp            — umbrella
-    └── utility/
-        ├── file_utils.hpp
-        └── path_utils.hpp
-```
-
 ## Gotchas
 
 - **`readFileAsString` failure is build-mode dependent.** In debug builds


### PR DESCRIPTION
## Summary
- Remove 5 ASCII directory-tree blocks from CLAUDE.md files that violate CLAUDE-BASELINE §"Do NOT include: File/directory tree listings"
- Files: root CLAUDE.md, engine/CLAUDE.md, engine/common/CLAUDE.md, engine/utility/CLAUDE.md, engine/profile/CLAUDE.md
- Keep useful prose content (e.g. "No src/ — everything is header-only") around removed trees

## Test plan
- [ ] Verify each tree block is removed
- [ ] Verify surrounding prose is preserved
- [ ] Verify no useful non-tree content was lost

Closes #840