### PR TITLE
T-257: docs: engine/system/CLAUDE.md ↔ .claude/rules/cpp-systems.md de-dup

### DIFF
--- a/.claude/rules/cpp-systems.md
+++ b/.claude/rules/cpp-systems.md
@@ -13,16 +13,7 @@ Rule:
 
 Allowed: `static constexpr`, `static const` for genuine compile-time constants. Those are program constants, not system state.
 
-## Why this matters
-
-Function-local `static` for system state is broken on four axes:
-
-1. **Hidden state** — not visible to ECS inspectors, system-walking tools, or anyone reading the prefab catalog.
-2. **Lifetime mismatch** — persists for program lifetime, doesn't free when the system entity is destroyed. Every reload leaks.
-3. **Single-instance assumption** — all instances of `System<X>` share the same statics. Multi-instance use silently cross-talks.
-4. **Conflicts with the ECS philosophy** — "everything on an entity" is the design; statics are the back door.
-
-The performance argument doesn't hold either: both supported forms have the same per-tick access cost as `static`. The instance pointer is captured into the lambdas at `create()` time — the lookup happens once, not per tick.
+See `engine/system/CLAUDE.md` § "Don't use function-local `static` for system state" for the full rationale.
 
 ## Preferred: member-on-`System<N>` via `registerSystem`
 
@@ -77,28 +68,7 @@ Notes (apply to both forms):
 
 ## Three valid TICK function signatures
 
-`createSystem<Components...>` detects the signature at compile time via `std::is_invocable_v<>`:
-
-```cpp
-// 1. Per-component (most common — pick this by default)
-createSystem<C_Velocity3D, C_VelocityDrag>(
-    "VelocityDrag",
-    [](C_Velocity3D& velocity, C_VelocityDrag& drag) {
-        // deltaTime(UPDATE) is the tick's dt
-    });
-
-// 2. Per-entity-id (when the system truly needs the entity id)
-createSystem<C_NavAgent, C_MoveOrder>(
-    "GridPathfind",
-    [](EntityId id, C_NavAgent& agent, C_MoveOrder& order) { ... });
-
-// 3. Per-archetype / batch (bulk-processing, SIMD, sort, partition)
-createSystem<C_NavAgent>(
-    "GridBake",
-    [](const Archetype& arch,
-       std::vector<EntityId>& ids,
-       std::vector<C_NavAgent>& agents) { ... });
-```
+See `engine/system/CLAUDE.md` § "Three valid TICK function signatures".
 
 ## beginTick / endTick contract
 

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -6,12 +6,6 @@ Systems are themselves entities: `SystemId` is an alias for `EntityId`, and a
 system's behavior is stored as `C_SystemEvent<TICK>` etc. components on the
 system entity.
 
-## Public API
-
-`IRSystem::` exposes: `createSystem<...>()`, `createSystemDynamic()`,
-`replaceSystemBody()`, `registerPipeline()`, `executePipeline()`,
-system tag helpers, and per-system-parameters.
-
 ## `createSystemDynamic` for runtime-typed systems
 
 `createSystem<Components...>()` is the canonical path — component types
@@ -225,10 +219,6 @@ happens once, not per tick.
 named-resource pointers fetched once at engine init that never change — is
 fine as `static`. Those are program constants, not system state. The rule
 applies to *mutable* or *system-owned* state.
-
-See `.fleet/status/system-static-deviations.md` (queue-manager-owned;
-feature PRs do not edit) for the current list of files still using
-function-local `static` for system state.
 
 ## Pipelines
 


### PR DESCRIPTION
## Summary

- `engine/system/CLAUDE.md` is now the canonical home for the three valid TICK function signatures (formerly duplicated in the rule file) and the function-local-static anti-pattern rationale (the four-bullet "Why it's wrong" section + perf argument)
- Removed both duplicate blocks from `.claude/rules/cpp-systems.md`; replaced with one-line pointers to the CLAUDE.md sections
- Removed the `IRSystem::` function-name catalog (`## Public API` L9-13) from `engine/system/CLAUDE.md` — the sections below carry the actual contract
- Removed the dead `.fleet/status/system-static-deviations.md` pointer from `engine/system/CLAUDE.md` (file confirmed absent); the rule file's `## Live deviations` section with the actual file list is the live record

## Test plan
- [ ] `engine/system/CLAUDE.md` still contains the canonical TICK signatures section and the static anti-pattern section
- [ ] `.claude/rules/cpp-systems.md` has one-line pointers in place of the removed duplicates
- [ ] No other files changed

Closes #841