### PR TITLE
T-258: docs: creations/ + creations/demos/ CLAUDE.md — fix drift

### DIFF
--- a/creations/CLAUDE.md
+++ b/creations/CLAUDE.md
@@ -11,33 +11,12 @@ No opt-outs.
 
 ## Two visibility tiers
 
-```
-creations/
-├── demos/                       ← checked into git; shareable examples
-├── editors/voxel_editor/        ← checked into git; engine editor tool
-├── editors/<other>/             ← gitignored (personal tools)
-├── bazel_test/                  ← gitignored
-└── <private creations>/         ← gitignored (games, experiments, tools)
-```
-
-The top-level `.gitignore` says:
-
-```
-creations/*
-!creations/CLAUDE.md
-!creations/demos/
-!creations/demos/**
-!creations/editors/
-creations/editors/font_maker
-!creations/editors/voxel_editor/
-!creations/editors/voxel_editor/**
-```
-
 `creations/demos/` and `creations/editors/voxel_editor/` are checked into
-the engine repo. All other creations (games, personal tools, experimental
-editors) live locally and are never pushed to the engine repo. A private
-creation may have its own repo, its own conventions, its own review
-criteria, even its own CLAUDE.md hierarchy.
+the engine repo. All other subdirectories under `creations/` (games,
+personal tools, experimental editors) are gitignored and live only locally.
+The top-level `.gitignore` tracks only these two subtrees; see it for the
+exact allowlist. A private creation may have its own repo, its own
+conventions, its own review criteria, even its own CLAUDE.md hierarchy.
 
 ## Engine vs. creation separation
 
@@ -76,22 +55,10 @@ is gitignored).
 
 ## CMake boilerplate
 
-Every creation's `CMakeLists.txt` does three things:
-
-1. **Declare the executable** and link `IrredenEngine`.
-2. **Copy runtime data** — `engine/render/data`, `engine/data`,
-   `engine/render/src/shaders` next to the exe as `data/` and
-   `shaders/`, plus any creation-specific scripts.
-3. **Copy runtime DLLs** — Windows-only POST_BUILD step using
-   `$<TARGET_RUNTIME_DLLS:...>`. Note that MinGW runtime DLLs
-   (`libgcc_s_seh-1.dll`, etc.) are *not* copied — they come from
-   `C:\msys64\mingw64\bin` and must be on `PATH` at runtime.
-4. **Define an `IR<Name>Run` custom target** with
-   `WORKING_DIRECTORY` set to the runtime dir so VSCode launches it
-   from the right cwd.
-
-Use `creations/demos/shape_debug/CMakeLists.txt` as the canonical
-reference.
+Use `creations/demos/shape_debug/CMakeLists.txt` as the canonical reference.
+Note: MinGW runtime DLLs (`libgcc_s_seh-1.dll`, etc.) are not copied by
+the Windows `$<TARGET_RUNTIME_DLLS:...>` POST_BUILD step — they come from
+`C:\msys64\mingw64\bin` and must be on `PATH` at runtime.
 
 ## Gotchas
 

--- a/creations/demos/CLAUDE.md
+++ b/creations/demos/CLAUDE.md
@@ -11,60 +11,17 @@ personal editors, experiments) live as gitignored subdirectories under
 Applies the rules in [`docs/agents/CLAUDE-BASELINE.md`](../../docs/agents/CLAUDE-BASELINE.md).
 No opt-outs.
 
-## Current demos
+## Reference demos
 
-- `default/` — minimal example showing how to spin up a `World`, register
-  a component pack, and run a Lua script.
-- `shape_debug/` — stress test for the shape renderer and voxel pipeline
-  at varying subdivisions / zoom. Useful for chasing rendering glitches.
-- `midi_keyboard/` — keyboard-driven MIDI input demo.
-- `metal_clear_test/` — Metal-backend smoke test (clear-color only).
-- `lighting/` — lighting pipeline showcase (emissive voxels, light volume).
-- `modifier_demo/` — interactive modifier framework showcase. Eight cubes
-  each demonstrate one framework capability (Haste, Stun, Slow, Stack,
-  GlobalSlow, LambdaSine, SourceKill, Clamp) via number keys 1–8. Live
-  per-cube resolved-speed HUD. Canonical visual reference for the modifier
-  framework — see `engine/prefabs/irreden/common/CLAUDE.md`.
-- `sprite_demo/` — exercises `C_Sprite` / `C_SpriteAnimation` Lua bindings.
-  Three sprites demonstrate LOOP, ONCE, and PING_PONG loop modes against a
-  32×32 test sheet (4 × 16px cells: red, green, blue, yellow).
-- `lua_pipeline_demo/` — minimal-render demo whose entire `initSystems`
-  lives in `scripts/main.lua`. Exercises `IRSystem.registerPipeline`,
-  `IRSystem.systemId(SystemName.X)`, and a Lua-defined system mixed
-  into the UPDATE list alongside prefab systems and the modifier
-  resolver chain. Reference for the T-102 Lua-driven-ECS pattern.
-- `z_yaw_rotation/` — Z-axis world-rotation showcase. Two executables:
-  `IRZYawStatic` (four SDF/voxel shapes auto-rotating in a ring, good
-  as a visual-regression canary for `SCREEN_SPACE_RESIDUAL_ROTATE`) and
-  `IRZYawInteractive` (same scene with `R`-key-toggled mouse-driven yaw
-  and left-click per-voxel entity-pick via `getEntityIdAtMouseTrixel`).
-- `lua_perf_grid/` — Lua port of `perf_grid`'s wave-animation kernel
-  built on the T-106..T-108 codegen toolchain. The Lua-defined
-  `LuaWaveState` component and `LuaWaveTick` system body live in
-  `main.lua`; cmake/lua_codegen emits a typed C++ struct + System
-  specialisation at build time. Toggle `-DIR_LUA_ECS_DEFAULT_MODE=EVAL`
-  to flip the same source to LuaJIT-backed runtime dispatch. The
-  parity gate from `docs/design/lua-driven-ecs.md` "Retrospective"
-  closes here.
+Canonical starting points: `shape_debug` (C++-only reference and visual-regression
+smoke target), `default` (minimal Lua-driven), `lua_perf_grid` (codegen toolchain
+reference, T-106..T-108 pattern). Use `Glob creations/demos/*/` to see the full list.
 
 ## Adding a new demo
 
-1. Copy the closest matching existing demo (Lua-driven →
-   `default`, C++-only → `shape_debug`, minimal → `default`).
-2. Rename the target (`IRShapeDebug` → `IRYourName`) and update
-   `CMakeLists.txt`:
-   - `set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})`
-   - `add_executable(IRYourName main.cpp)` +
-     `target_link_libraries(IRYourName PUBLIC IrredenEngine)`
-   - The Windows DLL POST_BUILD step.
-   - Copy `engine/render/data`, `engine/data`,
-     `engine/render/src/shaders` to the runtime dir.
-   - An `IRYourNameRun` custom target with `WORKING_DIRECTORY
-     ${runtime_dir}` and `USES_TERMINAL`.
-3. Add `add_subdirectory(your_name)` to `creations/demos/CMakeLists.txt`.
-4. Build with `cmake --build build --target IRYourName`.
-5. Run with `IRYourNameRun` from VSCode, or manually with the PATH fix
-   from [`docs/agents/BUILD.md`](../../docs/agents/BUILD.md).
+Copy the closest demo, rename targets, add `add_subdirectory(your_name)` to
+`creations/demos/CMakeLists.txt`. See `shape_debug/CMakeLists.txt` for the
+canonical CMake shape.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

- `creations/CLAUDE.md`: replaced directory-tree block with prose, replaced verbatim `.gitignore` paste with a one-liner pointer, trimmed CMake boilerplate section to canonical-reference + MinGW-DLL gotcha.
- `creations/demos/CLAUDE.md`: replaced the stale full-demo inventory (missing 5 of 15 demos on disk) with a 3-line reference-demo summary; trimmed "Adding a new demo" from a 5-step CMake recipe to a one-sentence pointer to `shape_debug/CMakeLists.txt`.

Docs-only change; no code, test, build, or ECS changes.

Closes #842