### PR TITLE
T-259: docs: SQT transition notes across prefabs/ family CLAUDE.md

### DIFF
--- a/engine/prefabs/CLAUDE.md
+++ b/engine/prefabs/CLAUDE.md
@@ -72,6 +72,8 @@ Component methods fall into three tiers:
 
 **(a) Pure data.** Fields and a constructor that initializes them. Most
 components in `common/`, `input/`, and tag-style components fall here.
+(`common/` currently houses both the legacy `C_Position3D` / `C_PositionGlobal3D`
+and the new `C_WorldTransform` / `C_LocalTransform` SQT pair; T-199 in flight.)
 
 **(b) Self-only helpers (allowed).** Methods that read or write only the
 component's own fields (and stack-locals derived from them). Examples:

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -6,16 +6,17 @@ in `update/`.
 
 ## Key components
 
-- `C_Position3D` — local vec3 (legacy; superseded by `C_LocalTransform`,
-  retired in the T-199 migration).
+- `C_Position3D` — local vec3 (legacy; T-199 in flight — superseded by
+  `C_LocalTransform` when consumers migrate; new code should prefer SQT).
 - `C_PositionGlobal3D` — world-space vec3. **Auto-added by `createEntity(...)`**
-  (legacy parallel to `C_WorldTransform`; retired with `C_Position3D`).
+  (legacy parallel to `C_WorldTransform`; T-199 in flight — both still
+  active during the consumer sweep).
   Ephemeral per-frame deltas (idle bob, gizmo nudges) travel through
   the modifier framework's `POSITION_OFFSET_3D` vec3 field rather
   than a dedicated component — see [`position_modifier_fields.hpp`](position_modifier_fields.hpp)
   and the `APPLY_POSITION_OFFSET` system.
-- `C_Rotation` — Euler vec3 (legacy; superseded by the quat field on
-  `C_LocalTransform`).
+- `C_Rotation` — Euler vec3 (legacy; T-199 in flight — superseded by the
+  quat field on `C_LocalTransform` when consumers migrate).
 - `C_LocalTransform` / `C_WorldTransform` — canonical SQT transform
   pair. **Both auto-added by `createEntity(...)`**. See
   [SQT transform pair + propagation](#sqt-transform-pair--propagation)

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -320,6 +320,7 @@ when extending or composing widgets:
 
 ## Gotchas
 
+- **SQT transition (T-199 in flight).** `C_Position3D` / `C_PositionGlobal3D` references in this file are accurate-but-aging — new code should prefer `C_LocalTransform` + `C_WorldTransform`; legacy usages will be swept by the T-199 consumer migration.
 - **Canvas texture lifetime.** The 3 GPU textures owned by
   `C_TriangleCanvasTextures` are created in the ctor and only freed in
   `onDestroy()`. Destroying a canvas entity mid-frame while a system


### PR DESCRIPTION
## Summary

- Soften overstated "retired in T-199 migration" language in `engine/prefabs/irreden/common/CLAUDE.md` to "T-199 in flight" for `C_Position3D`, `C_PositionGlobal3D`, and `C_Rotation`
- Add one-line transition note in `engine/prefabs/irreden/render/CLAUDE.md` pointing at T-199 for legacy `C_Position3D` usages
- Add SQT transition note in `engine/prefabs/CLAUDE.md` "(a) Pure data" section acknowledging both legacy and new components coexist in `common/`

## Test plan

- [ ] Docs-only changes — no build needed
- [ ] Verify each file's transition note matches recommended phrasing from issue #843
- [ ] Confirm no prose says "retired" for components that are still active

Closes #843