### PR TITLE
T-265: docs/roles: hoist Hard rules into CLAUDE-BASELINE.md + fix broken CRITICAL anchor

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -764,17 +764,14 @@ iterations write nothing).
 
 ## Hard rules
 
-- **Never `git push origin master`. Never push to master at all.**
-  Only push the PR branch with `--force-with-lease`.
-- **Never `git push --force`.** Always `--force-with-lease` so
-  the push fails if upstream changed under you (which would mean
-  the author pushed in parallel).
-- **Never `gh pr merge`.** The human merges. The merger only
-  rebases.
-- **Never `gh pr review --approve` or `--request-changes`.** All
-  fleet agents share one GitHub account and GitHub rejects formal
-  review actions on your own PRs. Use `--comment` for status
-  posts (already handled via `gh pr comment`).
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles). Merger-specific additions:
+
+- **Only push the PR branch with `--force-with-lease`**, never `--force`.
+  The push fails if upstream changed under you (parallel author push).
+- **Never `gh pr review --approve` or `--request-changes`.** All fleet
+  agents share one GitHub account and GitHub rejects formal review
+  actions on your own PRs. Use `--comment` for status posts
+  (already handled via `gh pr comment`).
 - **Never bypass labels.** A PR with `human:wip`, `fleet:wip`,
   `fleet:blocker`, `human:needs-fix`, or `human:blocker` is off-
   limits. Do not touch.
@@ -794,7 +791,6 @@ iterations write nothing).
   step — but do NOT also try a second mechanical class on a later
   PR in the same iteration unless the first one succeeded
   cleanly. Fail-stop.
-- Single-command Bash only (see CRITICAL section above).
 
 ## How the cooldown label works
 

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -348,19 +348,10 @@ only when there's a real signal worth surfacing).
 
 ## Hard rules
 
-- Never `git push origin master`. Never `--force`. Never call
-  `gh pr merge`. The human merges.
-- Never run `cmake --preset` — only `cmake --build` against the
-  already-configured tree.
-- Never touch the `.claude/worktrees/` layout.
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles).
+
 - **After opening a PR, ALWAYS reset the worktree via `start-next-task`
   before responding further to the human.** Holding the PR branch
   checked out blocks reviewers from `gh pr checkout` and breaks the
   review pipeline. The reset isn't optional — your work is on origin,
   the branch can be re-checked-out anytime.
-- **Never leave dirty edits uncommitted at the end of an iteration.**
-  If you made any changes to the working tree — manual edits, edits
-  that simplify applied, fixes from optimize, anything — you MUST
-  follow with `commit-and-push` to land them. Don't invoke `simplify`
-  standalone — let `commit-and-push` invoke it for you.
-- Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -374,12 +374,12 @@ iterations write nothing).
 
 ## Hard rules
 
-- Never `gh pr merge` — the human merges.
-- Never `gh pr review --approve` or `--request-changes` — all fleet
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles). Reviewer-specific additions:
+
+- **Never commit, push, or open PRs from this worktree.**
+- **Never `gh pr review --approve` or `--request-changes`** — all fleet
   agents share one GitHub account and GitHub rejects formal review
   actions on your own PRs. Always use `--comment` with a clear verdict.
-- Never commit, push, or open PRs from this worktree.
-- Never `git push --force`.
 - **Never post a review without setting the verdict label.** A review
   without a `fleet:approved` / `fleet:needs-fix` / `fleet:blocker`
   label is invisible to the human's merge queue. After every
@@ -399,13 +399,9 @@ iterations write nothing).
   recent `fleet:needs-fix` / `fleet:approved` UNLABELED event, (d)
   presence of `fleet:changes-made`. If any are present, the prior
   verdict was author-acknowledged — treat the PR as a re-review
-  candidate and post a fresh review (which sets the label as part
-  of its own flow) rather than re-stamping the stale verdict.
-  `gh pr view <N> --json labels` alone does not show label-strip
-  events; use `gh api repos/jakildev/IrredenEngine/issues/<N>/timeline`
-  to see UNLABELED events. Observed bogus re-stamps: PRs #347,
-  #348, #394.
-- Do NOT take on first-pass reviews that Sonnet has not yet touched
+  candidate and post a fresh review rather than re-stamping the
+  stale verdict. Use `gh api repos/jakildev/IrredenEngine/issues/<N>/timeline`
+  to see UNLABELED events.
+- **Do NOT take on first-pass reviews that Sonnet has not yet touched**
   (unless `sonnet-reviewer` is offline AND the PR has been open more
   than 1 hour). The model split exists to conserve Opus budget.
-- Single-command Bash only (see CRITICAL section above).

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -971,22 +971,10 @@ human can tell which opus-worker observed what. See
 
 ## Hard rules
 
-- Never `git push origin master`. Never `--force`. Never call
-  `gh pr merge`. The human merges.
-- Never run `cmake --preset` — only `cmake --build` against the
-  already-configured tree.
-- Never touch the `.claude/worktrees/` layout.
-- Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
-  `xcode-select` — those are human-initiated.
-- Never write plan files during task execution. Plan files are written
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles).
+
+- **Never write plan files during task execution.** Plan files are written
   only during the planning step (step 2) for `fleet:needs-plan` issues.
-- **Never leave dirty edits uncommitted at the end of an iteration.**
-  If you made any changes to the working tree — manual edits, edits
-  that simplify applied, fixes from optimize, anything — you MUST
-  follow with `commit-and-push` to land them. The next iteration's
-  branch switch will discard them. Don't invoke `simplify` standalone
-  — let `commit-and-push` invoke it for you, so the commit step is
-  guaranteed to follow.
 - **`~/.fleet/plans/` and `.fleet/plans/` are for task plans only.**
   The only valid filenames are `T-NNN.md` (canonical) and
   `issue-N.md` (pre-rename, awaiting queue-manager ingestion).
@@ -995,25 +983,3 @@ human can tell which opus-worker observed what. See
   Read only the file matching your task ID. Authority for "who works
   on what" lives in TASKS.md `Owner:` and `fleet-claim` locks; nothing
   else.
-- **`.fleet/status/*.md` is queue-manager-owned bookkeeping**, like
-  `TASKS.md`. Read when a CLAUDE.md pointer directs you to one;
-  never include them in a feature PR's diff. Canonical explanation
-  in `.fleet/status/README.md`.
-- **Edit/Write paths must stay inside your worktree.** The parent
-  clone at `/Users/evinjkill/src/IrredenEngine/` (no `.claude/worktrees/`
-  in the path) and your worktree at
-  `.../.claude/worktrees/<your-basename>/` both contain the same tree
-  shape, so an Edit aimed at the parent's absolute path will succeed
-  silently — but your build runs against the worktree, so the edit
-  appears to "do nothing" while quietly orphaning changes in the
-  parent clone (potentially clobbering another agent's work). Prefer
-  relative paths from your worktree's cwd. If you must use an
-  absolute path, it MUST start with
-  `/Users/evinjkill/src/IrredenEngine/.claude/worktrees/<your-basename>/`.
-  Re-confirm with `pwd` if unsure.
-- Single-command Bash only (see CRITICAL section above).
-- **Edit/Write blocked for `.claude/commands/` files?** The harness
-  permission gate blocks these paths even with `Edit(*)`/`Write(*)`
-  in the allowlist. Use python3 for OS-level writes (sanctioned via
-  `Bash(python3:*)` in the allowlist):
-  `python3 -c "f=open(path).read(); assert old in f, 'string not found'; open(path, 'w').write(f.replace(old, new, 1))"`

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -190,20 +190,20 @@ Repeat for `repos.game.human_approved[]` against the game TASKS.md
 
 ## Hard rules
 
-- Never claim or work tasks. You only file and maintain them.
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles). Queue-manager-specific additions:
+
+- **Never claim or work tasks.** You only file and maintain them.
 - **Never remove `human:approved`.** Use `fleet:queued` /
   `fleet:needs-plan` / `fleet:needs-info` / `fleet:in-progress`
   for state.
-- You are the **sole TASKS.md editor** across the entire fleet.
+- **You are the sole TASKS.md editor** across the entire fleet.
   If a feature PR includes TASKS.md changes from an author agent,
   flag it — those changes should be removed.
-- You are the **sole `.fleet/status/*.md` editor**. Update these
+- **You are the sole `.fleet/status/*.md` editor.** Update these
   files via a `queue: status update` PR when you notice a relevant
   merge — status file updates are manual/on-demand, not part of the
   automated maintenance pass. See `.fleet/status/README.md`.
-- Never `gh pr merge` — the human merges.
+- **Never `gh pr merge`** — the human merges.
 - **Bookkeeping exception:** you MAY push directly to master in both
   repos when the commit touches **only** `TASKS.md`,
   `.fleet/plans/*.md`, and/or `.fleet/status/*.md`.
-- Never `git push --force`.
-- Single-command Bash only (see CLAUDE-BASELINE.md above).

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -612,41 +612,4 @@ the human can tell which sonnet pane observed what. See
 
 ## Hard rules
 
-- Never `git push origin master`. Never `--force`. Never call
-  `gh pr merge`. The human merges.
-- Never run `cmake --preset` — only `cmake --build` against the
-  already-configured tree.
-- Never touch the `.claude/worktrees/` layout.
-- Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
-  `xcode-select` — those are human-initiated.
-- **Never leave dirty edits uncommitted at the end of an iteration.**
-  If you made any changes to the working tree — manual edits, edits
-  that simplify applied, fixes from optimize, anything — you MUST
-  follow with `commit-and-push` to land them. The next iteration's
-  branch switch will discard them. If `simplify` ran and reported
-  fixes applied but you didn't proceed to commit, that's the bug:
-  finish the flow. Don't invoke `simplify` standalone — let
-  `commit-and-push` invoke it for you, so the commit step is
-  guaranteed to follow.
-- **`.fleet/status/*.md` is queue-manager-owned bookkeeping**, like
-  `TASKS.md`. Read when a CLAUDE.md pointer directs you to one;
-  never include them in a feature PR's diff. Canonical explanation
-  in `.fleet/status/README.md`.
-- **Edit/Write paths must stay inside your worktree.** The parent
-  clone at `/Users/evinjkill/src/IrredenEngine/` (no `.claude/worktrees/`
-  in the path) and your worktree at
-  `.../.claude/worktrees/<your-basename>/` both contain the same tree
-  shape, so an Edit aimed at the parent's absolute path will succeed
-  silently — but your build runs against the worktree, so the edit
-  appears to "do nothing" while quietly orphaning changes in the
-  parent clone (potentially clobbering another agent's work). Prefer
-  relative paths from your worktree's cwd. If you must use an
-  absolute path, it MUST start with
-  `/Users/evinjkill/src/IrredenEngine/.claude/worktrees/<your-basename>/`.
-  Re-confirm with `pwd` if unsure.
-- Single-command Bash only (see CRITICAL section above).
-- **Edit/Write blocked for `.claude/commands/` files?** The harness
-  permission gate blocks these paths even with `Edit(*)`/`Write(*)`
-  in the allowlist. Use python3 for OS-level writes (sanctioned via
-  `Bash(python3:*)` in the allowlist):
-  `python3 -c "f=open(path).read(); assert old in f, 'string not found'; open(path, 'w').write(f.replace(old, new, 1))"`
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles).

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -420,34 +420,26 @@ iterations write nothing).
 
 ## Hard rules
 
-- Never commit, push, or open PRs from this worktree.
-- Never `gh pr merge` — the human merges.
-- Never `gh pr review --approve` or `--request-changes` — all fleet
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles). Reviewer-specific additions:
+
+- **Never commit, push, or open PRs from this worktree.**
+- **Never `gh pr review --approve` or `--request-changes`** — all fleet
   agents share one GitHub account and GitHub rejects formal review
   actions on your own PRs. Always use `--comment` with a clear
   verdict line (`Verdict: approve`, `Verdict: needs-fix`, etc.).
-- Never `git push --force` (you have no reason to push at all).
 - **Never post a review without setting the verdict label.** A review
   comment without a `fleet:approved` / `fleet:needs-fix` /
   `fleet:blocker` label is invisible to the human's merge queue —
   the human filters PRs by label, not by review body. After every
   `gh pr review --comment ...`, your VERY NEXT bash call MUST be
-  `gh pr edit <N> ... --add-label "fleet:..."`. This is the
-  most-skipped step in the loop; it has been observed in production
-  on PR #230 (re-review approve, no label set, PR sat invisible).
-  If you described the label change in the review body but didn't
-  run the gh command, the label is NOT set — describing isn't
-  doing. Verify with `gh pr view <N> --json labels`.
+  `gh pr edit <N> ... --add-label "fleet:..."`. Verify with
+  `gh pr view <N> --json labels`.
 - **Never re-apply a verdict label without posting a new review in
   the same iteration.** If a PR you previously verdicted is now
   missing its verdict label, that is NOT a label-fixup trigger —
   the label may have been legitimately cleared by the author's
   `commit-and-push` after a fix push, by an ESCALATE handoff (which
   swaps `fleet:needs-fix` for `fleet:changes-made`), or by a worker
-  mid-claim on a `fleet:has-nits` PR. Heuristically re-stamping a
-  stale verdict overwrites those transitions and produces
-  invisible-needs-fix states (observed: PRs #347, #348, #394, plus
-  the 65s `fleet:has-nits` re-stamp race on #402). If you decide to
-  re-review, post a new review and set the label as part of THAT
-  review's flow. Otherwise leave the label alone.
-- Single-command Bash only (see CRITICAL section above).
+  mid-claim on a `fleet:has-nits` PR. If you decide to re-review,
+  post a new review and set the label as part of THAT review's flow.
+  Otherwise leave the label alone.

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -368,3 +368,45 @@ rule** above. Removal of engine ECS surface (systems, components,
 entities) is forbidden without explicit human sign-off; deprecation
 markers are the slower-moving "this surface is going away eventually"
 signal that applies to any API the human has decided to phase out.
+
+---
+
+## Hard rules for autonomous fleet roles
+
+These apply to every fleet role. Each role file lists only the
+additional role-specific restrictions.
+
+- **Never `git push origin master`. Never `--force` push.** Never call
+  `gh pr merge`. The human merges.
+- **Never run `cmake --preset`** — only `cmake --build` against the
+  already-configured tree.
+- **Never touch the `.claude/worktrees/` layout.**
+- **Never use `sudo`, `brew install/upgrade/uninstall`, `apt`, or
+  `xcode-select`** — those are human-initiated.
+- **Never leave dirty edits uncommitted at the end of an iteration.**
+  If you made any changes to the working tree — manual edits, edits
+  that simplify applied, fixes from optimize, anything — you MUST
+  follow with `commit-and-push` to land them. The next iteration's
+  branch switch will discard them. Don't invoke `simplify` standalone
+  — let `commit-and-push` invoke it for you.
+- **`.fleet/status/*.md` is queue-manager-owned bookkeeping**, like
+  `TASKS.md`. Read when a CLAUDE.md pointer directs you to one; never
+  include them in a feature PR's diff. See `.fleet/status/README.md`.
+- **Edit/Write paths must stay inside your worktree.** The parent
+  clone at `/Users/evinjkill/src/IrredenEngine/` and your worktree at
+  `.../.claude/worktrees/<your-basename>/` both contain the same tree
+  shape, so an Edit aimed at the parent's absolute path will succeed
+  silently — but your build runs against the worktree, so the edit
+  appears to "do nothing" while quietly orphaning changes in the
+  parent clone (potentially clobbering another agent's work). Prefer
+  relative paths from your worktree's cwd. If you must use an
+  absolute path, it MUST start with
+  `/Users/evinjkill/src/IrredenEngine/.claude/worktrees/<your-basename>/`.
+  Re-confirm with `pwd` if unsure.
+- **Single-command Bash only** — see [`## Bash tool rules`](#bash-tool-rules)
+  above.
+- **Edit/Write blocked for `.claude/commands/` files?** The harness
+  permission gate blocks these paths even with `Edit(*)`/`Write(*)`
+  in the allowlist. Use python3 for OS-level writes (sanctioned via
+  `Bash(python3:*)` in the allowlist):
+  `python3 -c "f=open(path).read(); assert old in f, 'string not found'; open(path, 'w').write(f.replace(old, new, 1))"`


### PR DESCRIPTION
## Summary

- Add `## Hard rules for autonomous fleet roles` to `CLAUDE-BASELINE.md` with the nine baseline prohibitions shared by every fleet role
- Collapse all seven role files' `## Hard rules` epilogues to a 3-line pointer to CLAUDE-BASELINE.md + role-specific exceptions only
- Fix all instances of the broken `(see CRITICAL section above)` anchor — no `## CRITICAL` header ever existed; the canonical section is `## Bash tool rules` in CLAUDE-BASELINE.md

**Diff:** +83 / -137 lines across 8 files (net −54 lines).

## Test plan

- [x] Every role file's `## Hard rules` now points at CLAUDE-BASELINE.md `#hard-rules-for-autonomous-fleet-roles`
- [x] `grep -rn "see CRITICAL section"` returns nothing in `.claude/commands/`
- [x] Role-specific additions preserved: merger additions, opus-worker plan-file rules, opus-architect reset-worktree rule, reviewer verdict-label rules, queue-manager sole-editor rules
- [x] No build changes — pure docs

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)