### PR TITLE
T-264: docs/roles: create FLEET-CROSS-HOST-SMOKE.md

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -204,7 +204,7 @@ iteration of polling, reviewing, and exiting cleanly:
       upstream-not-yet-approved, etc.). See
       [REVIEWER-PROTOCOL.md § Acquiring / releasing the review claim](../../docs/agents/REVIEWER-PROTOCOL.md#acquiring--releasing-the-review-claim).
    i. **Cross-host smoke tagging (engine render PRs only).** See
-      [REVIEWER-PROTOCOL.md § Cross-host smoke tagging](../../docs/agents/REVIEWER-PROTOCOL.md#cross-host-smoke-tagging).
+      [FLEET-CROSS-HOST-SMOKE.md § Reviewer side: tagging](../../docs/agents/FLEET-CROSS-HOST-SMOKE.md#reviewer-side-tagging).
       If Sonnet already added the labels on first pass, no action
       needed.
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -209,69 +209,14 @@ Do the work, then exit cleanly:
    Address all flagged PRs before doing any other work.
 
 1b. **Smoke-validate one cross-host render PR (engine only).** After
-    feedback PRs are clear, check whether any open engine PR is waiting
-    on a smoke validation from this host. Derive the host key from
-    `uname -s`:
-    - `Linux` → host key `linux`, poll `fleet:needs-linux-smoke`
-    - `Darwin` → host key `macos`, poll `fleet:needs-macos-smoke`
-
-    From the cached `repos.engine.prs[]`, pick PRs whose `labels`
-    array contains BOTH `fleet:needs-<host>-smoke` AND
-    `fleet:approved`, and contains NONE of `fleet:needs-fix`,
-    `fleet:blocker`, `human:wip`, `fleet:wip`,
-    `fleet:merger-cooldown`, `human:needs-fix`. (Cached equivalent
-    of the previous `gh pr list --label fleet:needs-<host>-smoke
-    ... --jq` chain — same filter, no API call.)
-
-    The filter keeps only PRs that are approved, not flagged for
-    fixes, and not claimed by the human. **Also drop PRs already
-    carrying any `fleet:reviewing-*` label** — another agent is
-    already smoking them. If the list is empty, skip
-    to step 2. Otherwise, pick the oldest (smallest number), then:
-
-    **Acquire the cross-host smoke claim FIRST.** Two same-host
-    author agents (`opus-worker-1` and `opus-worker-2`) both poll the
-    same `fleet:needs-<host>-smoke` label and could race to check out
-    + build the same PR. The same `fleet:reviewing-*` lock the
-    reviewer roles use serializes them:
-
-    `fleet-claim review-claim <N> <your-worktree-basename>`
-
-    - **Exit 0** — you own this smoke. Proceed to step a.
-    - **Exit 1** — another agent is already smoking it. Skip to step 2.
-
-    a. Re-touch heartbeat (`fleet-heartbeat <your-worktree-basename>`)
-       — the build can take minutes and you don't want the witness to
-       alarm.
-    b. Check out the PR: `gh pr checkout <N> --repo jakildev/IrredenEngine`
-    c. Build the demo smoke target: `fleet-build --target IRShapeDebug`.
-       If the PR breaks that build, the smoke has failed — jump to
-       step f with the build log.
-    d. Run the smoke: `fleet-run IRShapeDebug --auto-screenshot 10`.
-       The `10` is warmup-frame count; the creation's shot table
-       decides how many screenshots are taken, and `IRWindow::closeWindow()`
-       fires once they're done. Usually completes in 10–20 seconds.
-       Don't add `--timeout` — `fleet-run --timeout` reports "alive at
-       deadline" as success, which would mask an `--auto-screenshot`
-       hang.
-    e. If build + run both succeeded (no nonzero exit, no crash):
-       `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-<host>-smoke"`
-       `gh pr comment <N> --repo jakildev/IrredenEngine --body "Cross-host smoke OK on <host> (fresh checkout build + IRShapeDebug --auto-screenshot 10)."`
-    f. If build or run failed: leave the smoke label on (human/author
-       needs to fix the backend issue), post a comment describing the
-       failure, and add `fleet:needs-fix`:
-       `gh pr comment <N> --repo jakildev/IrredenEngine --body "Cross-host smoke FAILED on <host>: <one-line symptom>. Details: <attach log excerpt>"`
-       `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:approved" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"`
-    g. **Release the cross-host smoke claim**, then reset to scratch:
-       `fleet-claim review-release <N> <your-worktree-basename>`
-       `git checkout -B claude/<your-worktree-basename>-scratch origin/master`
-       Always release — runs whether smoke passed or failed. Queue-
-       tick's `cleanup --gh` would sweep a forgotten label after
-       30 min, but during that window the PR can't be re-smoked.
-
-    Validate ONE PR per iteration. Multiple outstanding render PRs
-    are handled across successive iterations so task pickup isn't
-    starved by back-to-back smoke runs.
+    feedback PRs are clear, run the author-side cross-host smoke
+    protocol per [`docs/agents/FLEET-CROSS-HOST-SMOKE.md`](../../docs/agents/FLEET-CROSS-HOST-SMOKE.md)
+    § "Author side: claiming + running". Opus-worker is the
+    judgment-bearing half of the protocol — see § "Sonnet-vs-Opus
+    split" § "What Opus catches": you inspect the captured
+    screenshots and diagnose visual regressions, not just exit
+    codes. Validate ONE PR per iteration; skip to step 1c if no
+    PR matches the filter.
 
 1c. **Resolve one `fleet:semantic-conflict` PR per iteration
     (engine only).** The merger sets this label when mechanical

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -127,79 +127,14 @@ Each iteration:
    Address all flagged PRs before picking new work.
 
 1b. **Smoke-validate one cross-host render PR (engine only).** After
-    feedback PRs are clear, check whether any open engine PR is waiting
-    on a smoke validation from this host. Derive the host key from
-    `uname -s`:
-    - `Linux` → host key `linux`, poll `fleet:needs-linux-smoke`
-    - `Darwin` → host key `macos`, poll `fleet:needs-macos-smoke`
-
-    From the cached `repos.engine.prs[]`, pick PRs whose `labels`
-    array contains BOTH `fleet:needs-<host>-smoke` AND
-    `fleet:approved`, and contains NONE of `fleet:needs-fix`,
-    `fleet:blocker`, `human:wip`, `fleet:wip`,
-    `fleet:merger-cooldown`, `human:needs-fix`. (Cached equivalent
-    of the previous `gh pr list --label fleet:needs-<host>-smoke
-    ... --jq` chain — same filter, no API call.)
-
-    The filter keeps only PRs that are approved, not flagged for
-    fixes, and not claimed by the human. **Also drop PRs already
-    carrying any `fleet:reviewing-*` label** — another agent is
-    already smoking them. If the list is empty, skip
-    to step 2. Otherwise, pick the oldest (smallest number), then:
-
-    **Acquire the cross-host smoke claim FIRST.** Two same-host
-    author agents (`sonnet-fleet-1` and `sonnet-fleet-2`) both poll
-    the same `fleet:needs-<host>-smoke` label and could race to check
-    out + build the same PR. The same `fleet:reviewing-*` lock the
-    reviewer roles use serializes them:
-
-    `fleet-claim review-claim <N> <your-worktree-basename>`
-
-    - **Exit 0** — you own this smoke. Proceed to step a.
-    - **Exit 1** — another agent is already smoking it. Skip to step 2.
-
-    a. Re-touch heartbeat (`fleet-heartbeat <your-worktree-basename>`)
-       — the build can take minutes and you don't want the witness to
-       alarm.
-    b. Check out the PR: `gh pr checkout <N> --repo jakildev/IrredenEngine`
-    c. Build the demo smoke target: `fleet-build --target IRShapeDebug`.
-       If the PR breaks that build, the smoke has failed — jump to
-       step f with the build log.
-    d. Run the smoke: `fleet-run IRShapeDebug --auto-screenshot 10`.
-       The `10` is warmup-frame count; the creation's shot table
-       decides how many screenshots are taken, and `IRWindow::closeWindow()`
-       fires once they're done. Usually completes in 10–20 seconds.
-       Don't add `--timeout` — `fleet-run --timeout` reports "alive at
-       deadline" as success, which would mask an `--auto-screenshot`
-       hang.
-    e. If build + run both succeeded (no nonzero exit, no crash):
-       `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-<host>-smoke"`
-       `gh pr comment <N> --repo jakildev/IrredenEngine --body "Cross-host smoke OK on <host> (fresh checkout build + IRShapeDebug --auto-screenshot 10)."`
-    f. If build or run failed: leave the smoke label on, post a
-       comment describing the failure, and add `fleet:needs-fix`:
-       `gh pr comment <N> --repo jakildev/IrredenEngine --body "Cross-host smoke FAILED on <host>: <one-line symptom>. Details: <attach log excerpt>"`
-       `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:approved" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"`
-    g. **Release the cross-host smoke claim**, then reset to scratch:
-       `fleet-claim review-release <N> <your-worktree-basename>`
-       `git checkout -B claude/<your-worktree-basename>-scratch origin/master`
-       (e.g. `claude/sonnet-fleet-1-scratch` for the sonnet-fleet-1
-       worktree.)
-       Always release — runs whether smoke passed or failed. Queue-
-       tick's `cleanup --gh` would sweep a forgotten label after
-       30 min, but during that window the PR can't be re-smoked.
-
-    Validate ONE PR per iteration. Multiple outstanding render PRs
-    are handled across successive iterations so task pickup isn't
-    starved by back-to-back smoke runs.
-
-    A Sonnet agent's host-smoke pass catches build breakage, nonzero
-    exit, crashes, and shader-compile errors in the run's stdout/stderr.
-    It does NOT inspect the generated screenshots — visual regressions
-    (missing voxels, inverted colors, black-but-exiting-clean) need
-    human or opus-worker eyes. If the run log mentions shader-compile
-    warnings/errors but still exits zero, escalate: comment "smoke run
-    exited clean but log flagged compile warnings; flagging for Opus
-    recheck" and leave the smoke label on so opus-worker re-validates.
+    feedback PRs are clear, run the author-side cross-host smoke
+    protocol per [`docs/agents/FLEET-CROSS-HOST-SMOKE.md`](../../docs/agents/FLEET-CROSS-HOST-SMOKE.md)
+    § "Author side: claiming + running". Sonnet is the
+    exit-code-bearing half of the protocol — see § "Sonnet-vs-Opus
+    split" § "What Sonnet escalates": do NOT inspect screenshots,
+    and escalate to opus-worker when the run log flags compile
+    warnings/errors but exits zero. Validate ONE PR per iteration;
+    skip to step 2 if no PR matches the filter.
 
 2. **Resume an active molecule first, then pick the next task.**
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -215,7 +215,7 @@ iteration of polling, reviewing, and exiting cleanly:
       gated upstream-not-yet-approved, "Opus recheck required"). See
       [REVIEWER-PROTOCOL.md § Acquiring / releasing the review claim](../../docs/agents/REVIEWER-PROTOCOL.md#acquiring--releasing-the-review-claim).
    g. **Cross-host smoke tagging (engine render PRs only).** See
-      [REVIEWER-PROTOCOL.md § Cross-host smoke tagging](../../docs/agents/REVIEWER-PROTOCOL.md#cross-host-smoke-tagging).
+      [FLEET-CROSS-HOST-SMOKE.md § Reviewer side: tagging](../../docs/agents/FLEET-CROSS-HOST-SMOKE.md#reviewer-side-tagging).
 
    **Nits vs needs-fix decisions** — see
    [REVIEWER-PROTOCOL.md § Nits vs needs-fix](../../docs/agents/REVIEWER-PROTOCOL.md#nits-vs-needs-fix--the-bright-line).

--- a/docs/agents/FLEET-CROSS-HOST-SMOKE.md
+++ b/docs/agents/FLEET-CROSS-HOST-SMOKE.md
@@ -1,0 +1,264 @@
+# Cross-host smoke validation
+
+OpenGL (Linux/Windows) and Metal (macOS) are two independent render backends.
+A render-touching PR built only on one host can compile-fail, fail at
+shader-link time, or render incorrectly on the other backend without any
+local signal. The cross-host smoke protocol catches this before merge by
+having a fleet agent on the *other* host check out the PR, build the smoke
+target, run it, and verdict the result.
+
+This doc is the single source of truth for the protocol. Both halves —
+the **reviewer** tagging side and the **author** claiming side — live
+here. Role files ([`role-opus-reviewer.md`](../../.claude/commands/role-opus-reviewer.md),
+[`role-sonnet-reviewer.md`](../../.claude/commands/role-sonnet-reviewer.md),
+[`role-opus-worker.md`](../../.claude/commands/role-opus-worker.md),
+[`role-sonnet-author.md`](../../.claude/commands/role-sonnet-author.md))
+point here rather than restating the procedure.
+
+Engine repo only. Game-repo PRs do not get cross-host smoke labels —
+backends live in the engine.
+
+---
+
+## Labels at a glance
+
+| Label | Owner | Purpose |
+|---|---|---|
+| `fleet:authored-on-linux` / `fleet:authored-on-macos` | `commit-and-push` at PR creation | Records which host the author built + smoked on. Permanent fact, not a state. |
+| `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` | reviewer (after verdict) | Requests a clean-checkout build + `IRShapeDebug` run from an agent on that host. Cleared by the smoking agent on success; flipped to `fleet:needs-fix` on failure. |
+| `fleet:reviewing-<host>-<agent>` | `fleet-claim` script | Atomic lock around the smoke run (same lock the reviewer roles use). Prevents two same-host author agents from racing on the same PR. Released by `fleet-claim review-release`. |
+
+A PR with an outstanding `fleet:needs-<host>-smoke` label is **not safe
+to merge** — the human merger waits for the label to clear.
+
+See [`FLEET.md`](FLEET.md) § "Issue/PR labeling discipline" for the
+canonical label list. This doc only restates the smoke-relevant
+subset.
+
+---
+
+## Reviewer side: tagging
+
+After a reviewer (`role-opus-reviewer` or `role-sonnet-reviewer`) sets
+a verdict label on an engine PR, they decide whether to add a smoke
+label. The decision is purely path-based — no host-side execution
+happens at tagging time.
+
+### When to tag
+
+Tag when **all** of the following hold:
+
+1. The PR is in the engine repo.
+2. The diff touches at least one render path:
+   - `engine/render/` (any file)
+   - `engine/prefabs/irreden/render/` (any file)
+   - any `*.glsl` shader
+   - any `*.metal` shader
+   - any file under `engine/render/src/shaders/`
+
+   Use `gh pr diff <N> --name-only` to read the changed paths.
+
+3. The PR is not in a `needs-fix` / `blocker` / WIP state (smoke runs
+   are wasted on PRs the reviewer is sending back).
+
+Skip for:
+
+- Game-repo PRs (no engine backends to validate)
+- Non-render engine PRs (tooling, docs, non-render modules) — smoke
+  labels narrow the "did this port build on the other backend"
+  question, not as general CI
+- PRs that already carry the smoke label from a prior pass
+
+### What to tag
+
+Subtract the author's host (`commit-and-push` stamped
+`fleet:authored-on-<host>` at PR creation — the author already smoke-
+tested their own host per the workflow):
+
+- PR has `fleet:authored-on-linux` → add `fleet:needs-macos-smoke`
+- PR has `fleet:authored-on-macos` → add `fleet:needs-linux-smoke`
+- Neither label present (Windows-native author, or pre-fix PR) → add **both**
+
+```
+gh pr edit <N> --add-label "fleet:needs-<other-host>-smoke"
+```
+
+If `sonnet-reviewer` already added the labels on a first pass, the
+later `opus-reviewer` recheck does nothing — the labels are
+idempotent.
+
+---
+
+## Author side: claiming + running
+
+Both `role-opus-worker` and `role-sonnet-author` poll for the smoke
+label that matches their host and execute the protocol below. The
+fleet runs at most one smoke run per author iteration so task pickup
+isn't starved by back-to-back builds.
+
+### Host detection
+
+Derive the host key from `uname -s`:
+
+- `Linux` → host key `linux`, poll `fleet:needs-linux-smoke`
+- `Darwin` → host key `macos`, poll `fleet:needs-macos-smoke`
+
+### Picking a PR
+
+From the cached `repos.engine.prs[]`, pick PRs whose `labels` array:
+
+- **contains** `fleet:needs-<host>-smoke`
+- **contains** `fleet:approved`
+- contains **none** of `fleet:needs-fix`, `fleet:blocker`,
+  `human:wip`, `fleet:wip`, `fleet:merger-cooldown`,
+  `human:needs-fix`
+- contains **no** `fleet:reviewing-*` label (another agent is
+  already smoking it)
+
+The filter keeps only approved PRs that aren't flagged for fixes and
+aren't claimed by the human. If the list is empty, skip the rest of
+the protocol. Otherwise pick the oldest (smallest number).
+
+### Acquiring the claim
+
+**Always acquire the claim BEFORE checking out the PR.** Two
+same-host author agents (`opus-worker-1` / `opus-worker-2`, or
+`sonnet-fleet-1` / `sonnet-fleet-2`) poll the same label and could
+race. The reviewer-claim lock serializes them:
+
+```
+fleet-claim review-claim <N> <your-worktree-basename>
+```
+
+- **Exit 0** — you own this smoke. Proceed.
+- **Exit 1** — another agent is already smoking it. Skip to the
+  next iteration's task pickup.
+
+### Build + run
+
+a. Re-touch heartbeat so the witness doesn't alarm during the build:
+   ```
+   fleet-heartbeat <your-worktree-basename>
+   ```
+b. Check out the PR:
+   ```
+   gh pr checkout <N> --repo jakildev/IrredenEngine
+   ```
+c. Build the smoke target:
+   ```
+   fleet-build --target IRShapeDebug
+   ```
+   If the build fails, jump to **failure verdict** with the build log.
+d. Run the smoke:
+   ```
+   fleet-run IRShapeDebug --auto-screenshot 10
+   ```
+   The `10` is the warmup-frame count; the creation's shot table
+   decides how many screenshots are taken, and
+   `IRWindow::closeWindow()` fires once they are done. Usually
+   completes in 10–20 seconds. **Do not** add `--timeout` —
+   `fleet-run --timeout` reports "alive at deadline" as success,
+   which would mask an `--auto-screenshot` hang.
+
+### Verdict
+
+**Success path** — build and run both exited zero, no crash:
+
+```
+gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-<host>-smoke"
+gh pr comment <N> --repo jakildev/IrredenEngine --body "Cross-host smoke OK on <host> (fresh checkout build + IRShapeDebug --auto-screenshot 10)."
+```
+
+**Failure path** — build failed, run crashed, or run exited nonzero.
+Leave the smoke label on (human/author needs to fix the backend
+issue), post a comment with the failure details, and drop the
+verdict to `needs-fix`:
+
+```
+gh pr comment <N> --repo jakildev/IrredenEngine --body "Cross-host smoke FAILED on <host>: <one-line symptom>. Details: <attach log excerpt>"
+gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:approved" --remove-label "fleet:has-nits" --add-label "fleet:needs-fix"
+```
+
+### Release + reset
+
+Always release the claim and reset to a scratch branch, whether the
+smoke passed or failed:
+
+```
+fleet-claim review-release <N> <your-worktree-basename>
+git checkout -B claude/<your-worktree-basename>-scratch origin/master
+```
+
+Queue-tick's `cleanup --gh` would sweep a forgotten
+`fleet:reviewing-*` label after 30 min, but during that window the
+PR cannot be re-smoked.
+
+---
+
+## Sonnet-vs-Opus split
+
+A Sonnet agent's host-smoke pass and an Opus agent's host-smoke pass
+**catch different bugs**. The split is deliberate and load-bearing —
+Sonnet is faster and cheaper, so it handles the common path; Opus
+handles the cases that need judgment.
+
+### What Sonnet catches
+
+`role-sonnet-author`'s smoke run catches anything visible in the
+`fleet-build` + `fleet-run` exit codes and logs:
+
+- Build breakage (compile errors, missing symbols, link failures)
+- Nonzero exit from `fleet-run`
+- Process crashes during the screenshot run
+- Shader-compile errors that surface in the run's stdout/stderr
+
+### What Sonnet escalates
+
+Sonnet does **NOT** inspect the generated screenshots. Visual
+regressions that exit clean — missing voxels, inverted colors, a
+fully black image that still hit `closeWindow()` — are invisible to
+Sonnet's pass.
+
+If the run log mentions shader-compile warnings/errors but still
+exits zero, the Sonnet agent comments
+"smoke run exited clean but log flagged compile warnings; flagging
+for Opus recheck" and **leaves the smoke label on** so an opus-worker
+re-validates on the next iteration.
+
+### What Opus catches
+
+`role-opus-worker`'s smoke run does everything Sonnet's does, plus:
+
+- Reads the captured screenshots and diagnoses visual regressions
+  against the reference behavior baked into
+  [`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md)
+  ("Verifying render changes")
+- Decides whether ambiguous output (slight color drift, half-voxel
+  silhouette differences) is acceptable or a regression
+- For diffs that touch shaders or render systems specifically,
+  invokes the [`render-debug-loop`](../../.claude/skills/render-debug-loop/SKILL.md)
+  skill instead of a single-shot smoke run
+
+### When the split breaks
+
+If a `fleet:needs-<host>-smoke` PR sits with the label for multiple
+iterations without an opus-worker picking it up (sonnet-fleet keeps
+deferring; opus-worker is busy with `[opus]` tasks), the queue is
+underweighted on Opus author capacity for that host. Surface the
+backlog in the per-worktree feedback channel (see [`FLEET.md`](FLEET.md)
+§ "Fleet feedback channel").
+
+---
+
+## See also
+
+- [`FLEET.md`](FLEET.md) — workflow rules, full label list, model
+  split, design escalation
+- [`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md) §
+  "Verifying render changes" — what diffs require visual
+  verification and what the visual baseline is
+- [`.claude/skills/attach-screenshots/SKILL.md`](../../.claude/skills/attach-screenshots/SKILL.md)
+  — before/after screenshot capture for the PR body
+- [`.claude/skills/render-debug-loop/SKILL.md`](../../.claude/skills/render-debug-loop/SKILL.md)
+  — Opus-side visual diagnostic loop used when the smoke run reveals
+  a regression

--- a/docs/agents/REVIEWER-PROTOCOL.md
+++ b/docs/agents/REVIEWER-PROTOCOL.md
@@ -175,43 +175,11 @@ did it; verify with `gh pr view <N> --json labels --jq
 
 ## Cross-host smoke tagging
 
-After the verdict label is set, check whether the PR's diff touches
-any render path:
-
-- `engine/render/` (any file)
-- `engine/prefabs/irreden/render/` (any file)
-- Any `*.glsl` or `*.metal` shader file
-- Any file under `engine/render/src/shaders/`
-
-Use `gh pr diff <N> --name-only` to read the changed paths. If any
-path matches, add the smoke label for the host the author was NOT
-on. The author already smoke-tested their own host per the workflow,
-so tagging it again is redundant.
-
-`commit-and-push` stamps `fleet:authored-on-<host>` at PR
-create-time:
-
-- PR has `fleet:authored-on-linux` → add `fleet:needs-macos-smoke`
-- PR has `fleet:authored-on-macos` → add `fleet:needs-linux-smoke`
-- Neither (Windows-native author, or pre-fix PR) → add both
-
-```
-gh pr edit <N> --add-label "fleet:needs-<other-host>-smoke"
-```
-
-Each host's author agents (opus-worker, sonnet-author) poll for the
-label matching their host, run a clean-checkout build +
-`IRShapeDebug` smoke, and remove the label on success. The PR cannot
-be safely merged until the outstanding label is gone.
-
-**Skip** for game-repo PRs — cross-host smoke applies to engine
-backends only. **Skip** for non-render engine PRs (tooling, docs,
-non-render modules) — the labels exist to narrow the "did this port
-build on the other backend" question, not as general CI.
-
-If the first-pass reviewer (sonnet-reviewer) already added the
-labels, the second-pass reviewer (opus-reviewer) does not need to
-re-add them.
+See [FLEET-CROSS-HOST-SMOKE.md § Reviewer side: tagging](FLEET-CROSS-HOST-SMOKE.md#reviewer-side-tagging)
+for the canonical protocol — what counts as a render path, which
+smoke label to apply based on `fleet:authored-on-<host>`, the
+opus-reviewer / sonnet-reviewer non-duplication rule, and skip
+conditions for game-repo and non-render PRs.
 
 ---
 


### PR DESCRIPTION
## Summary
- Extract the cross-host smoke validation protocol from four role files into `docs/agents/FLEET-CROSS-HOST-SMOKE.md`.
- Document both halves of the protocol in one place: reviewer-side tagging (when to add `fleet:needs-<host>-smoke`) and author-side claiming + build/run/verdict.
- Add an explicit "Sonnet-vs-Opus split" section: Sonnet catches build/exit/crash signals; Opus inspects screenshots and decides on visual regressions.
- Collapse the smoke blocks in `role-opus-worker.md`, `role-sonnet-author.md`, `role-opus-reviewer.md`, and `role-sonnet-reviewer.md` to ~5-line pointers at the new shared doc.

Net: +290 lines new doc, -180 across roles.

## Test plan
- [ ] Skim the new doc top-to-bottom for accuracy against the four prior role-file blocks.
- [ ] Verify the four role files still read cleanly with the collapsed pointers.
- [ ] Confirm cross-references resolve: `engine/render/CLAUDE.md` § "Verifying render changes", `attach-screenshots/SKILL.md`, `render-debug-loop/SKILL.md`, `FLEET.md` § "Issue/PR labeling discipline".

Closes #865.

🤖 Generated with [Claude Code](https://claude.com/claude-code)