### PR TITLE
T-266: docs/roles: invert Engine API removal rule citation (baseline owns it)

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -52,18 +52,7 @@ list above.
 
 ## Engine API removal rule
 
-**Never remove engine-defined systems, components, or entities.**
-External consumers of the engine may not have their code present in any
-`creations/` subdirectory — a local grep finding no consumers does not
-mean there are no consumers.
-
-When an engine API appears unused locally, the right action is to write
-a demo creation for it. Demos serve as living documentation and prevent
-the API from appearing dormant to future agents.
-
-If an engine API is genuinely superseded and removal is being considered,
-escalate to the human. Do not unilaterally delete engine-level systems,
-components, or entities.
+See [`docs/agents/CLAUDE-BASELINE.md § Engine API removal rule`](../../docs/agents/CLAUDE-BASELINE.md#engine-api-removal-rule).
 
 ## Startup actions (do these immediately, in order)
 

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -70,18 +70,7 @@ tasks, also read `~/src/IrredenEngine/creations/game/CLAUDE.md`.
 
 ## Engine API removal rule
 
-**Never remove engine-defined systems, components, or entities.**
-External consumers of the engine may not have their code present in any
-`creations/` subdirectory — a local grep finding no consumers does not
-mean there are no consumers.
-
-When an engine API appears unused locally, the right action is to write
-a demo creation for it. Demos serve as living documentation and prevent
-the API from appearing dormant to future agents.
-
-If an engine API is genuinely superseded and removal is being considered,
-escalate to the human. Do not unilaterally delete engine-level systems,
-components, or entities.
+See [`docs/agents/CLAUDE-BASELINE.md § Engine API removal rule`](../../docs/agents/CLAUDE-BASELINE.md#engine-api-removal-rule).
 
 ## Cross-repo model
 

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -279,15 +279,22 @@ treating its own repo as the private side and the engine repo as
 the public side. A creation that does not participate in the engine
 fleet at all may opt out of this section.
 
-**Engine API removal rule:** Systems, components, and entities defined
-in the engine must never be removed. External consumers of the engine
-may not have their code present in any `creations/` subdirectory — a
-local grep that finds no consumers does not mean there are no consumers.
+---
+
+## Engine API removal rule
+
+**Never remove engine-defined systems, components, or entities.**
+External consumers of the engine may not have their code present in any
+`creations/` subdirectory — a local grep finding no consumers does not
+mean there are no consumers.
+
 When an engine API appears unused locally, the right action is to write
-a demo creation for it, not to remove it. Removal requires an explicit
-human decision. See the "Engine API removal rule" section of
-`role-opus-architect.md` and `role-opus-worker.md` for the full
-guidance.
+a demo creation for it. Demos serve as living documentation and prevent
+the API from appearing dormant to future agents.
+
+If an engine API is genuinely superseded and removal is being considered,
+escalate to the human. Do not unilaterally delete engine-level systems,
+components, or entities.
 
 ---
 


### PR DESCRIPTION
## Summary
- Expand `CLAUDE-BASELINE.md` to host the full canonical Engine API removal rule as its own `## Engine API removal rule` section
- Collapse `role-opus-architect.md` and `role-opus-worker.md` to single-line pointers at the baseline section
- Drop the old inverted citation (baseline was pointing downstream to the role files)

## Test plan
- [x] Rule has exactly one canonical home: `CLAUDE-BASELINE.md § Engine API removal rule`
- [x] Both role files point at it with correct relative path
- [x] GitHub anchor `#engine-api-removal-rule` matches the heading

Closes #867