### PR TITLE
T-267: docs/roles: shrink intro boilerplate (Bash rules, cache, repo-slug discovery) to pointers

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -16,36 +16,11 @@ Mode (optional argument): $ARGUMENTS
 
 ## Bash tool rules
 
-See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules)
-for the canonical list — single-command Bash only, no `cd && git`,
-no shell pipes / redirects, prefer Read / Glob / Grep tools.
-Violating these blocks unattended operation with interactive
-prompts.
-
-Role-specific: when posting a merger comment with `gh pr comment
---body-file`, write the body via the **Write** tool to a worktree-
-local path (`.merger-body.md`), not `/tmp/`. First run
-`rm -f .merger-body.md` so the Write tool doesn't refuse with
-"File has not been read yet" (that error fires when an existing
-file at the path wasn't Read in this session — typical when a
-previous iteration left the body file behind).
+See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules).
 
 ## Shared fleet state cache
 
-Read your pre-filtered slice at
-`~/.fleet/state/projections/merger.json` — `prs` (open engine PRs
-that are either `fleet:approved` or have a non-MERGEABLE state).
-~5 KB vs. ~32 KB for full `state.json`. Merger is engine-only;
-the slice ignores game.
-
-Per-item lookups stay direct: `gh pr view <N> --json mergeable`
-(UNKNOWN refresh — not in the wrapper), `git fetch`, `git rebase`,
-`gh pr comment`, `gh pr edit`. The wrappers are read-only and
-don't cover the conflict-resolution flow.
-
-Full cache protocol — staleness rules, layout of every cache
-file, what stays direct — lives in
-[docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
+See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
 ## Exit protocol
 
@@ -89,11 +64,7 @@ the cooldown label prevents an immediate retry.
 0. Print your role banner:
    `[merger] Auto-rebases stale PRs and sort-merges TASKS.md conflicts. Transient — re-fires when scout sees actionable PR state.`
 1. `pwd` — confirm you are in the `merger` worktree.
-2. **Discover engine repo slug** by Read'ing `~/.fleet/state/repos.json`
-   (written once by `fleet-up` at startup). Use the `engine` field
-   for the `<engine-repo>` placeholder. If the cache file is
-   missing, fall back to `gh repo view --json nameWithOwner --jq
-   .nameWithOwner`.
+2. **Discover repo slug** — see [docs/agents/FLEET-CACHE.md § Repo slug discovery](../../docs/agents/FLEET-CACHE.md#repo-slug-discovery).
 3. Reset to the throwaway branch unconditionally — `-B` makes it
    idempotent. Run as two separate Bash calls:
    `git -C ~/src/IrredenEngine fetch origin --quiet`

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -12,27 +12,11 @@ Mode (optional argument): $ARGUMENTS
 
 ## Bash tool rules
 
-See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules)
-for the canonical list — single-command Bash only, no `cd && git`,
-no shell pipes / redirects, prefer Read / Glob / Grep tools.
-Violating these blocks unattended operation with interactive
-prompts.
+See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules).
 
 ## Shared fleet state cache
 
-The architect doesn't have a dedicated per-role projection (it's
-interactive, not loop-driven). Read `~/.fleet/state/state.json`
-for the open-PR list, `fleet:design-blocked` PRs, feedback-label
-PRs, and parsed `TASKS.md`. Filter `repos.engine.prs[]` locally
-on labels.
-
-Per-item drill-ins use `fleet-pr view|diff|comments <N>` and
-`fleet-issue view <N>`. Writes (`gh pr edit`, `gh pr comment`,
-`gh issue create`, `gh issue edit`) stay direct.
-
-Full cache protocol — staleness rules, layout of every cache
-file, what stays direct — lives in
-[docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
+See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
 ## Responsibilities
 

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -13,41 +13,11 @@ Mode (optional argument): $ARGUMENTS
 
 ## Bash tool rules
 
-See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules)
-for the canonical list — single-command Bash only, no `cd && git`,
-no shell pipes / redirects, prefer Read / Glob / Grep tools.
-Violating these blocks unattended operation with interactive
-prompts.
-
-Role-specific: when posting a PR review with `gh pr review
---body-file`, write the body via the **Write** tool to a worktree-
-local path (e.g. `.review-body.md`), not `/tmp/`. First run
-`rm -f .review-body.md` so the Write tool doesn't refuse with
-"File has not been read yet" (that error fires when an existing
-file at the path wasn't Read in this session — typical when a
-previous iteration left the body file behind).
+See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules).
 
 ## Shared fleet state cache
 
-Read your pre-filtered slice at
-`~/.fleet/state/projections/opus-reviewer.json` — `flagged_prs`
-(open PRs flagged with `fleet:has-nits` or `fleet:needs-fix`,
-across both repos). ~5 KB vs. ~32 KB for full `state.json`.
-
-The slice carries each PR's `reviews[]` so the
-`Opus recheck required` line in the latest Sonnet review body is
-visible without a drill-in. Review bodies longer than 2 KB are
-stored as head + tail with an `…[truncated]…` separator (the
-verdict line typically lives in the tail); for full-body context,
-fetch with `fleet-pr view <N>`.
-
-Per-item drill-ins use `fleet-pr view|diff|comments <N>` and
-`fleet-issue view <N>`. Writes (`gh pr review`, `gh pr comment`,
-`gh pr edit`) stay direct.
-
-Full cache protocol — staleness rules, layout of every cache
-file, what stays direct — lives in
-[docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
+See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
 ## Exit protocol
 
@@ -97,15 +67,7 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
 0. Print your role banner:
    `[opus-reviewer] Final reviewer — Opus recheck on PRs touching core engine invariants or flagged by Sonnet. Transient — re-fires when scout sees actionable PR state.`
 1. `pwd` — confirm you are in the `opus-reviewer` worktree.
-2. **Discover repo slugs** by Read'ing `~/.fleet/state/repos.json`
-   (written once by `fleet-up` at startup). Use the `engine` field
-   for `<engine-repo>` and the `game` field (when present) for
-   `<game-repo>`. If `game` is absent, skip all game-repo steps.
-   If the cache file is missing, fall back to `gh repo view --json
-   nameWithOwner --jq .nameWithOwner` for engine and `git -C
-   ~/src/IrredenEngine/creations/game remote get-url origin` for
-   game. If the game-side fallback fails (directory absent), treat
-   as no game repo and skip all game-repo steps.
+2. **Discover repo slugs** — see [docs/agents/FLEET-CACHE.md § Repo slug discovery](../../docs/agents/FLEET-CACHE.md#repo-slug-discovery).
 3. Confirm you are on the throwaway branch
    `claude/opus-reviewer-scratch`. If not, run these two commands
    separately (do NOT wrap in `cd ... &&`):

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -22,28 +22,11 @@ Mode (optional argument): $ARGUMENTS
 
 ## Bash tool rules
 
-See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules)
-for the canonical list — single-command Bash only, no `cd && git`,
-no shell pipes / redirects, prefer Read / Glob / Grep tools.
-Violating these blocks unattended operation with interactive
-prompts.
+See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules).
 
 ## Shared fleet state cache
 
-Read your pre-filtered slice at
-`~/.fleet/state/projections/opus-worker.json` — `tasks_open` (open
-`[opus]` tasks across both repos), `needs_plan` (issues awaiting
-plans), and `feedback_prs` (PRs with feedback or
-`fleet:design-unblocked`). ~5 KB vs. ~32 KB for full
-`state.json`.
-
-Per-item drill-ins use `fleet-pr view|diff|comments <N>` and
-`fleet-issue view <N>`. Writes (`gh pr edit`, `gh pr comment`,
-`gh pr create`, `gh issue create`, `gh issue edit`) stay direct.
-
-Full cache protocol — staleness rules, layout of every cache
-file, what stays direct — lives in
-[docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
+See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
 ## Exit protocol
 

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -11,17 +11,11 @@ Mode (optional argument): $ARGUMENTS
 
 ## Bash tool rules
 
-See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules)
-for the canonical list — single-command Bash only, no `cd && git`,
-no shell pipes / redirects, prefer Read / Glob / Grep tools.
+See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules).
 
 ## Shared fleet state cache
 
-Read your pre-filtered slice at
-`~/.fleet/state/projections/queue-manager.json` — `needs_plan`,
-`human_approved`, `tasks_done`, and `needs_flip`. Fall back to
-`state.json` for cross-role data. Full protocol in
-[docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
+See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
 Always Edit/Read the working-tree `TASKS.md` for ingestion, never
 the cache.
@@ -64,9 +58,7 @@ Two invocation modes:
      `[queue-manager] Task intake — ingests approved issues into TASKS.md. Cursor-flow / interactive.`
 1. `pwd`
 2. `git -C ~/src/IrredenEngine fetch origin --quiet`
-3. **Discover repo slugs** by Read'ing `~/.fleet/state/repos.json`.
-   Use `engine` for `<engine-repo>`, `game` (if present) for
-   `<game-repo>`. Fallback: `gh repo view --json nameWithOwner --jq .nameWithOwner`.
+3. **Discover repo slugs** — see [docs/agents/FLEET-CACHE.md § Repo slug discovery](../../docs/agents/FLEET-CACHE.md#repo-slug-discovery).
 4. Read tool -> `TASKS.md` (working-tree copy).
 5. Read tool -> `~/src/IrredenEngine/creations/game/TASKS.md` if game
    repo is present. Skip otherwise.

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -12,27 +12,11 @@ Mode (optional argument): $ARGUMENTS
 
 ## Bash tool rules
 
-See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules)
-for the canonical list — single-command Bash only, no `cd && git`,
-no shell pipes / redirects, prefer Read / Glob / Grep tools.
-Violating these blocks unattended operation with interactive
-prompts.
+See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules).
 
 ## Shared fleet state cache
 
-Read your pre-filtered slice at
-`~/.fleet/state/projections/sonnet-author.json` — `tasks_open`
-(open `[sonnet]` engine tasks) and `feedback_prs` (open PRs with
-`human:needs-fix` / `fleet:needs-fix` / `fleet:has-nits`). ~5 KB
-vs. ~32 KB for full `state.json`.
-
-Per-item drill-ins use `fleet-pr view|diff|comments <N>` and
-`fleet-issue view <N>`. Writes (`gh pr edit`, `gh pr comment`,
-`gh pr create`) stay direct.
-
-Full cache protocol — staleness rules, layout of every cache
-file, what stays direct — lives in
-[docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
+See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
 ## Exit protocol
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -12,36 +12,11 @@ Mode (optional argument): $ARGUMENTS
 
 ## Bash tool rules
 
-See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules)
-for the canonical list — single-command Bash only, no `cd && git`,
-no shell pipes / redirects, prefer Read / Glob / Grep tools.
-Violating these blocks unattended operation with interactive
-prompts.
-
-Role-specific: when posting a PR review with `gh pr review
---body-file`, write the body via the **Write** tool to a worktree-
-local path (e.g. `.review-body.md`), not `/tmp/`. First run
-`rm -f .review-body.md` so the Write tool doesn't refuse with
-"File has not been read yet" (that error fires when an existing
-file at the path wasn't Read in this session — typical when a
-previous iteration left the body file behind).
+See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules).
 
 ## Shared fleet state cache
 
-Read your pre-filtered slice at
-`~/.fleet/state/projections/sonnet-reviewer.json` — `candidate_prs`
-(open PRs across both repos with the review-skip filter already
-applied). ~5 KB vs. ~32 KB for full `state.json`. Fall back to
-`state.json` only when you need a PR not in your candidate list
-(e.g. looking up an upstream PR by `headRefName` for stack
-detection).
-
-Per-item drill-ins use `fleet-pr view|diff|comments <N>`. Writes
-(`gh pr review`, `gh pr comment`, `gh pr edit`) stay direct.
-
-Full cache protocol — staleness rules, layout of every cache
-file, what stays direct — lives in
-[docs/agents/FLEET-CACHE.md](docs/agents/FLEET-CACHE.md).
+See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
 ## Exit protocol
 
@@ -66,15 +41,7 @@ treat it as a hard rule for this role.
 0. Print your role banner:
    `[sonnet-reviewer] First-pass PR reviewer — polls for unreviewed PRs, posts structured reviews, flags Opus escalations. Transient — re-fires when scout sees actionable PR state.`
 1. `pwd` — confirm you are in the `sonnet-reviewer` worktree.
-2. **Discover repo slugs** by Read'ing `~/.fleet/state/repos.json`
-   (written once by `fleet-up` at startup). Use the `engine` field
-   for `<engine-repo>` and the `game` field (when present) for
-   `<game-repo>`. If `game` is absent, skip all game-repo steps.
-   If the cache file is missing, fall back to `gh repo view --json
-   nameWithOwner --jq .nameWithOwner` for engine and `git -C
-   ~/src/IrredenEngine/creations/game remote get-url origin` for
-   game. If the game-side fallback fails (directory absent), treat
-   as no game repo and skip all game-repo steps.
+2. **Discover repo slugs** — see [docs/agents/FLEET-CACHE.md § Repo slug discovery](../../docs/agents/FLEET-CACHE.md#repo-slug-discovery).
 3. Confirm you are on the throwaway branch:
    `git branch --show-current` should report something like
    `claude/sonnet-reviewer-scratch`. If not, run these two commands

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -217,6 +217,10 @@ Read/Glob/Grep tools instead of Bash when possible.
 - **No `git show ref:file | sed/head/tail`** — run `git show ref:file`
   alone, or use `git -C <path> log`/`git -C <path> diff` with
   appropriate flags instead of piping.
+- **Body files for `--body-file`** — write them to a worktree-local path
+  (e.g. `.review-body.md`, `.merger-body.md`) via the **Write** tool,
+  not `/tmp/`; run `rm -f <path>` first if a prior session may have
+  left the file behind.
 
 This rule exists because the user-level allowlist (`~/.claude/settings.json`)
 matches on the first token of each Bash command. A compound command like

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -78,6 +78,11 @@ just the items that role works on:
 | queue-manager | `needs_plan`, `human_approved`, `tasks_done`, `needs_flip` (in-progress tasks whose linked issue closed) |
 | merger | `prs` (engine, approved or non-MERGEABLE only) |
 
+**opus-reviewer:** review bodies longer than 2 KB are stored as
+head + tail with an `…[truncated]…` separator (the verdict line
+typically lives in the tail); for full-body context fetch with
+`fleet-pr view <N>`.
+
 **Read the projection first.** It's ~5 KB vs. ~32 KB for full
 state.json — significant per-iteration token savings. Fall back to
 state.json only when you need cross-role data (e.g. sonnet-reviewer


### PR DESCRIPTION
## Summary

- Add `--body-file` worktree-local path rule to `CLAUDE-BASELINE.md` (one sentence covering reviewer + merger body files)
- Collapse `## Bash tool rules` in all 7 role files to a single-line pointer — removes 4-6 restated bullets per file, including role-specific body-file text now covered by the baseline
- Collapse `## Shared fleet state cache` in all 7 role files to a single-line pointer to `FLEET-CACHE.md`
- Collapse startup-step repo-slug discovery in 4 roles (merger, opus-reviewer, sonnet-reviewer, queue-manager) to a single-line pointer to `FLEET-CACHE.md § Repo slug discovery`

Net: -153 lines across 8 files. Any clarification now lands in one place.

## Test plan

- [ ] Build passes (docs-only PR, no code changes)
- [ ] All 7 role files: `## Bash tool rules` body is exactly one line (a pointer)
- [ ] All 7 role files: `## Shared fleet state cache` body is exactly one line (a pointer)
- [ ] 4 roles: startup-step repo-slug discovery is exactly one line (a pointer)
- [ ] `CLAUDE-BASELINE.md` has new body-file bullet in its Bash tool rules section
- [ ] No role-specific body-file text remains in opus-reviewer, sonnet-reviewer, merger

Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)