### PR TITLE
T-268: fleet: add fleet:awaiting-base to FLEET.md label dictionary

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -518,6 +518,20 @@ Specifically, **never pass these via `--label` when filing**:
   **author** rebases manually onto the new upstream tip and removes
   the label, or an **opus-worker** drives the resolution similar to
   `fleet:semantic-conflict`.
+- `fleet:awaiting-base` — owned by the **merger** (sets in step 5a.5
+  sub-case i when a stacked child PR is CONFLICTING because its base
+  already merged, or carried forward by step 2.5 while the base PR is
+  still OPEN). Signals that the child is waiting for its base PR to
+  merge before it can be re-targeted to master. Cleared automatically
+  by the merger in step 2.5 ii when the base merges (re-targets the
+  child to master and removes the label) or in step 2.5 iii when the
+  base closes (replaced by `fleet:needs-info`).
+  **Distinct from `fleet:awaiting-upstream-review`**: this label is
+  about *merge state* (has the upstream PR landed?), not *review state*
+  (has the upstream PR been approved?). A stacked child can be waiting
+  for its upstream to be *approved* (reviewer-owned gate) while the
+  upstream is still OPEN, or waiting for its upstream to *merge*
+  (merger-owned gate) after it has already been approved.
 - `fleet:awaiting-upstream-review` — owned by the **reviewer**. Set
   on a stacked child PR when the upstream PR is not yet approved
   (the child's review is deferred until the upstream verdict


### PR DESCRIPTION
## Summary
- Investigated `fleet:awaiting-base` (role-merger.md) vs `fleet:awaiting-upstream-review` (FLEET.md + REVIEWER-PROTOCOL.md) — confirmed they are **two genuinely distinct states**
- `fleet:awaiting-base` = merger-owned, base PR not yet **merged** (binary merge-state gate)
- `fleet:awaiting-upstream-review` = reviewer-owned, upstream PR not yet **approved** (review-approval gate)
- Added `fleet:awaiting-base` to FLEET.md's label dictionary between `fleet:needs-base-update` and `fleet:awaiting-upstream-review`, with an explicit distinction note

## Test plan
- [x] FLEET.md label dictionary now has entries for both labels
- [x] `fleet:awaiting-base` entry correctly identifies merger as owner and step 2.5 as the clear path
- [x] Explicit distinction sentence prevents future confusion between the two labels
- [x] No role file changes needed — role-merger.md's usage is correct and now matches the documented semantics

Closes #869