### PR TITLE
T-269: docs/roles: adopt fleet-pr-clear-feedback-labels wrapper in sonnet-author + architect

### DIFF
--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -206,19 +206,22 @@ stripped. Observed on PR #637 on 2026-05-11 and 2026-05-12; the
 wrapper exists at `scripts/fleet/fleet-pr-clear-feedback-labels`.
 
 For `human:needs-fix` / `human:blocker` specifically, also mark
-the PR as in-progress and clear the prior approval so the human
-knows to hold the merge. **Two separate calls** — `fleet:approved`
-may not be present, and combining remove-when-absent with
-`--add-label` would abort the call:
+the PR as in-progress, clear the prior approval, and clear any
+prior ESCALATE state in case the human is forcing a transition
+from ESCALATE to AMEND mode. **Separate calls** — `fleet:approved`
+and `fleet:human-deferred` may not be present, and combining
+remove-when-absent with `--add-label` would abort the call:
 
 ```
 gh pr edit <N> --add-label "fleet:human-amending"
 gh pr edit <N> --remove-label "fleet:approved"
+fleet-pr-clear-feedback-labels <N> --labels "fleet:human-deferred"
 ```
 
 For `fleet:needs-fix` / `fleet:has-nits` / `fleet:design-unblocked`
-only (no human label): skip both — reviewer-flagged feedback and
-architect direction don't trigger the human-amending state.
+only (no human label): skip all three — reviewer-flagged feedback
+and architect direction don't trigger the human-amending state, and
+`fleet:human-deferred` belongs only to the ESCALATE→AMEND path.
 
 #### Worker-only: reserve the worktree for the in-flight amendment
 

--- a/scripts/fleet/fleet-pr-clear-feedback-labels
+++ b/scripts/fleet/fleet-pr-clear-feedback-labels
@@ -15,7 +15,13 @@
 # This wrapper queries the live label set first and only fires a
 # remove-label call for labels actually present, one per call so a
 # single failure doesn't strand the others. The default label list
-# is the worker AMEND set; override with --labels for other callers.
+# is the AMEND trigger set; override with --labels for other callers.
+#
+# Note: fleet:human-deferred is NOT in the default set — it is an
+# ESCALATE-path outcome, not a feedback trigger. It is cleared
+# separately via --labels "fleet:human-deferred" only on the
+# human:needs-fix / human:blocker ESCALATE→AMEND path in
+# FLEET-FEEDBACK-HANDLING.md step b.
 #
 # Usage:
 #   fleet-pr-clear-feedback-labels <N> [--repo <slug>] [--labels <csv>]
@@ -36,7 +42,7 @@
 
 set -euo pipefail
 
-DEFAULT_LABELS="human:needs-fix,human:blocker,fleet:needs-fix,fleet:has-nits,fleet:human-deferred,fleet:design-unblocked"
+DEFAULT_LABELS="human:needs-fix,human:blocker,fleet:needs-fix,fleet:has-nits,fleet:design-unblocked"
 
 pr_number=""
 repo_slug=""

--- a/scripts/fleet/fleet-pr-clear-feedback-labels
+++ b/scripts/fleet/fleet-pr-clear-feedback-labels
@@ -30,7 +30,7 @@
 #   --repo <slug>     Target repo (e.g. jakildev/IrredenEngine). Default:
 #                     the current git remote.
 #   --labels <csv>    Comma-separated label set to clear. Default:
-#                     the worker AMEND set.
+#                     the AMEND trigger set.
 #
 # Exit status:
 #   0  every label in --labels that was present has been removed


### PR DESCRIPTION
## Summary

- Remove `fleet:human-deferred` from `fleet-pr-clear-feedback-labels` DEFAULT_LABELS — it is an ESCALATE-path outcome, not a feedback trigger; the AMEND trigger set should not include it
- Add explicit `fleet-pr-clear-feedback-labels <N> --labels "fleet:human-deferred"` in `FLEET-FEEDBACK-HANDLING.md` step b's `human:needs-fix`/`human:blocker` subpath, covering the legitimate ESCALATE→AMEND transition
- Update the wrapper's header comment to explain why `fleet:human-deferred` is excluded from the default set

The two role-file edits (sonnet-author.md line 261, opus-architect.md lines 185-186) were already addressed by T-260's hoisting of the AMEND path into `FLEET-FEEDBACK-HANDLING.md`. This PR handles the remaining deliverable: scoping the `fleet:human-deferred` removal to only the ESCALATE→AMEND path instead of all AMEND paths unconditionally.

## Test plan

- [ ] `fleet-pr-clear-feedback-labels <N>` no longer removes `fleet:human-deferred` by default (verify DEFAULT_LABELS in script)
- [ ] `fleet-pr-clear-feedback-labels <N> --labels "fleet:human-deferred"` still removes it when called with override (wrapper logic unchanged)
- [ ] `FLEET-FEEDBACK-HANDLING.md` step b's `human:needs-fix`/`human:blocker` subpath includes explicit `fleet:human-deferred` clearance
- [ ] `fleet:needs-fix`/`fleet:has-nits`/`fleet:design-unblocked` AMEND paths do NOT touch `fleet:human-deferred`

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)