### PR TITLE
T-270: docs/roles: catch up architect doc on transient-loop, AMEND, game-repo wrinkle

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -218,7 +218,7 @@ it into TASKS.md. You do NOT edit TASKS.md directly.
 ## Planning issues
 
 The **opus worker** autonomously handles `fleet:needs-plan` issues
-on its 20-minute loop — reading the issue thread, posting a plan
+as a transient, scout-triggered invocation — reading the issue thread, posting a plan
 comment, saving a plan file to `~/.fleet/plans/`, and swapping labels.
 You do not need to poll for these.
 
@@ -258,6 +258,12 @@ conversation), use the same flow:
 
 If you disagree with the issue's direction, comment with your
 concerns but leave `fleet:needs-plan` on — let the human decide.
+
+**Game-side scope.** The architect does not autonomously claim game
+tasks. The responsibility list above is engine-only. When the human
+explicitly asks you to plan or work a game-side issue, use
+`--repo jakildev/irreden` instead of `jakildev/IrredenEngine` for
+all `gh issue` / `gh pr` calls touching that repo.
 
 ## Handling `fleet:design-blocked` PRs
 


### PR DESCRIPTION
## Summary

- Replaced stale "20-minute loop" language with "transient, scout-triggered invocation" to match actual opus-worker execution model (sonnet-author and opus-worker docs both describe transient invocations; architect doc was the only one still using the old loop framing)
- Verified fleet:approved clearing on human:needs-fix is already documented via the FLEET-FEEDBACK-HANDLING.md pointer added in prior tasks — no further edit needed there
- Added explicit "Game-side scope" paragraph clarifying the architect does not autonomously claim game tasks (engine-only responsibilities list), and that game-side work on human request uses --repo jakildev/irreden

## Test plan

- [x] "20-minute loop" no longer appears in role-opus-architect.md
- [x] AMEND flow fleet:approved clearing covered by FLEET-FEEDBACK-HANDLING.md pointer (verified in-file)
- [x] Explicit game-scope statement added in Planning issues section

Closes #871