### PR TITLE
T-272: docs/roles: move PR-number examples out of reviewer role docs

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -284,8 +284,7 @@ iterations write nothing).
   of its own flow) rather than re-stamping the stale verdict.
   `gh pr view <N> --json labels` alone does not show label-strip
   events; use `gh api repos/jakildev/IrredenEngine/issues/<N>/timeline`
-  to see UNLABELED events. Observed bogus re-stamps: PRs #347,
-  #348, #394.
+  to see UNLABELED events.
 - Do NOT take on first-pass reviews that Sonnet has not yet touched
   (unless `sonnet-reviewer` is offline AND the PR has been open more
   than 1 hour). The model split exists to conserve Opus budget.

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -293,8 +293,7 @@ iterations write nothing).
   swaps `fleet:needs-fix` for `fleet:changes-made`), or by a worker
   mid-claim on a `fleet:has-nits` PR. Heuristically re-stamping a
   stale verdict overwrites those transitions and produces
-  invisible-needs-fix states (observed: PRs #347, #348, #394, plus
-  the 65s `fleet:has-nits` re-stamp race on #402). If you decide to
-  re-review, post a new review and set the label as part of THAT
-  review's flow. Otherwise leave the label alone.
+  invisible-needs-fix states. If you decide to re-review, post a new
+  review and set the label as part of THAT review's flow. Otherwise
+  leave the label alone.
 - Single-command Bash only (see CRITICAL section above).


### PR DESCRIPTION
## Summary
- Dropped specific PR number citations (#347, #348, #394, #402) from the re-stamp failure-mode prose in `role-opus-reviewer.md` and `role-sonnet-reviewer.md`
- Kept the failure-mode explanation intact — it stands alone without the historical examples
- Chose Option B (drop inline) over Option A (new lessons-learned.md) as the simpler bounded change

## Test plan
- [x] No PR-number citations remain in either reviewer role doc
- [x] Failure-mode prose (re-stamping produces invisible-needs-fix states) is preserved in both files

Closes #873