### PR TITLE
T-273: fleet: verify and document merger.log rotation

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -565,8 +565,7 @@ exit cleanly:
       - `gh pr comment <N> --repo <engine-repo> --body-file .merger-body.md`
       - Add cooldown label so we don't re-attempt next iteration:
         `gh pr edit <N> --repo <engine-repo> --add-label "fleet:merger-cooldown"`
-      - Append a log line to `~/.fleet/logs/merger-audit.log`
-        (separate from `merger.log`):
+      - Append a log line to `~/.fleet/logs/merger-audit.log`:
         `[YYYY-MM-DD HH:MM:SS] PR #<N> <headRefName>: clean rebase, force-pushed`
 
       **Conflict (non-zero exit).** Identify which files are
@@ -785,8 +784,8 @@ iterations write nothing).
 - **Always log every action** to `~/.fleet/logs/merger-audit.log`
   AND comment on the PR. Two-channel audit: the log is the merger's
   internal trail; the comment is the human-visible trail. The
-  audit log is separate from `~/.fleet/logs/merger.log` (tail-rotated)
-  to keep the audit trail intact.
+  audit log is durable and append-only; pane output is ephemeral (tmux terminal
+  only — the dispatcher does not redirect it to disk).
 - **Process at most 2 PRs per iteration.** Auto-pushes retrigger
   CI; flooding the queue is worse than slow turnover.
 - **One conflict class per push.** If a rebase needs both TASKS.md
@@ -835,7 +834,7 @@ Every action lands in TWO places:
 
 1. `~/.fleet/logs/merger-audit.log` — append-only audit trail.
    One line per action with timestamp, PR number, branch, action,
-   outcome. Kept separate from `merger.log` (tail-rotated) so the audit history is preserved.
+   outcome. Append-only so the audit history survives across iterations; pane output is ephemeral.
 2. The PR comment thread — human-visible. Always end with
    `— fleet merger` so a human (or another agent) scanning the
    thread can identify merger comments without parsing the


### PR DESCRIPTION
## Summary

- Investigated merger.log rotation: the file was written by fleet-babysit (tail-rotated at >5000 lines, keeping last 1000). The merger role has since migrated to fleet-dispatcher, which sends output only to the tmux pane — no log file is written. merger.log last modified May 6; no longer active.
- Dropped the three stale "tail-rotated" references in role-merger.md (lines ~569, 788, 838) and replaced with accurate descriptions: merger-audit.log is durable and append-only; pane output is ephemeral.

## Test plan

- [x] Grepped scripts/fleet/ and fleet-dispatcher — no rotation config for merger.log
- [x] Confirmed fleet-babysit has rotate_log() (the old lifecycle runner)
- [x] Confirmed fleet-up uses TRANSIENT_PANE_CMD for merger pane (dispatcher model, not babysit)
- [x] No remaining merger.log or tail-rotated references in role-merger.md

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)