### PR TITLE
T-274: docs/roles: decide whether queue-manager produces feedback; document either way

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -188,6 +188,16 @@ Repeat for `repos.game.human_approved[]` against the game TASKS.md
 3. Paste the PR URL back to the human.
 4. For cross-repo tasks: file the engine PR first.
 
+## End-of-iteration feedback
+
+If you noticed something this iteration that the human should know
+about — an issue with unclear scope that you had to defer, a stale
+plan file, a surprising queue state, or a suggestion for improving
+the ingestion workflow — append a structured entry to
+`~/.fleet/feedback/queue-manager.md`. See
+[`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Fleet feedback channel" for the format and the bar
+(high — most iterations write nothing).
+
 ## Hard rules
 
 See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles). Queue-manager-specific additions:


### PR DESCRIPTION
## Summary
- Added `## End-of-iteration feedback` section to `role-queue-manager.md` (Option A)
- Queue-manager now explicitly documents that it appends to `~/.fleet/feedback/queue-manager.md` when it notices actionable observations (stale plan files, unclear scope, queue anomalies, workflow suggestions)
- Pattern is consistent with all other transient role files (sonnet-author, opus-worker, merger, etc.)

## Test plan
- [ ] Confirm `role-queue-manager.md` now has an `## End-of-iteration feedback` section
- [ ] Confirm section matches the format used by other role docs

Closes #875