### PR TITLE
docs: codify point-don't-dump rule + canonical-home map

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -308,6 +308,31 @@ top-level `CLAUDE.md` and module-level `CLAUDE.md` files.
   Either rename the heading or refocus the body.
 - **Contradictions within a doc.** Step 3 says X, step 7 (added
   later in a different change) says NOT X. Reconcile or report.
+- **Point-don't-dump violations.** Per
+  [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md)
+  §"What belongs in agent-facing docs", agent-facing docs (`CLAUDE.md`,
+  `SKILL.md`, role files) restate canonical content far too often. Flag
+  any of the following for replacement with a one-line pointer to the
+  canonical home (see the Canonical-home map in `CLAUDE-BASELINE.md`):
+  - File/directory tree listings, layout blocks, "Key components" /
+    "Key systems" sections, type/class/function name catalogs,
+    function-signature catalogs — agents can `Glob` / `Grep`.
+  - Restated baseline rules — ECS footgun, naming table, IRMath
+    substitution, Bash rules, cross-repo isolation, Hard rules,
+    build commands, fleet workflow, feedback-handling, reviewer
+    protocols.
+  - In `SKILL.md`: `## When to invoke` / `## Why this exists` bodies
+    paraphrasing the YAML `description:`.
+  - In `SKILL.md`: `## Anti-patterns` entries that restate flow-step
+    requirements (keep entries that capture non-obvious things to
+    avoid).
+  - Decorative emoji bullets (`❌`, `✅`) — codebase convention is bare
+    list bullets.
+- **Broken cross-refs.** Every `[text](path)` / `[text](path#anchor)`
+  link in the diff resolves to an existing file / heading. Section
+  references cited as `§Foo` match an actual `## Foo` heading. Named
+  symbols (type, function, label, task ID) still exist in the tree.
+  Use the Grep tool to verify, then fix or report.
 
 For role docs and skill docs specifically, also report (don't
 auto-fix — these need human judgment on scope):

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -108,33 +108,114 @@ namespaces in headers; keep them in `.cpp`.
 
 ---
 
-## What belongs in CLAUDE.md files
+## What belongs in agent-facing docs
 
-CLAUDE.md files document **concepts, constraints, and gotchas** — things
-that aren't obvious from reading the code. They are NOT inventories.
+This rule covers every doc loaded into an agent's context: `CLAUDE.md`
+files (one per module), `SKILL.md` files under `.claude/skills/`, and
+role files under `.claude/commands/role-*.md`. They differ in scope but
+share one editorial rule:
 
-**Do NOT include:**
-- File/directory tree listings or layout blocks. Agents can Glob/Grep.
-- Catalogs of type, class, or struct names. Agents can Grep for them.
-- Variable or field name references (e.g., `m_foo`, `kBar`). Grep.
-- Lists of "files in this module" that just mirror `ls`.
+**Point, don't dump.** State each rule, table, procedure, or template
+once in its canonical home; everywhere else, link to it. Two copies
+drift; one copy + N pointers does not. Before adding anything, ask:
+"Could I replace this with a one-line link to a doc that already owns
+it?" The `## Canonical-home map` below names the common ones.
+
+**Do NOT include** (any agent-facing doc):
+
+- File/directory tree listings or layout blocks. Agents can `Glob`.
+- Catalogs of type/class/component/system/function names. Agents `Grep`.
+- "Key components" / "Key systems" sections that mirror `ls <dir>`.
+- Function-signature catalogs (the signature lives in the header).
+- Restated rules owned by another doc — ECS footgun, naming, IRMath,
+  Bash rules, cross-repo isolation, build commands, fleet workflow.
+  See the canonical-home map for who owns what.
+
+**SKILL.md-specific don'ts:**
+
+- `## When to invoke` / `## Why this exists` sections that paraphrase
+  the front-matter `description:` — the description already triggered
+  the skill, so a second copy in the body is filler.
+- `## Anti-patterns` entries that just restate flow-step requirements.
+  Keep entries that capture genuinely non-obvious things to avoid.
+- Decorative emoji bullets (`❌`, `✅`). Bare list bullets are the
+  codebase convention.
+- Procedures owned by a sibling skill. Compose by reference
+  (`Skill: simplify`) rather than restating.
+- Heavy worked examples (PR-body templates, full code scaffolds,
+  HEREDOC blocks) — move to `<skill>/procedures/<topic>.md`.
+
+**Role-file-specific don'ts:**
+
+- Restated protocols owned by another fleet doc — `FLEET.md`,
+  `FLEET-RUNTIME.md`, `FLEET-FEEDBACK-HANDLING.md`,
+  `FLEET-CROSS-HOST-SMOKE.md`, `REVIEWER-PROTOCOL.md`,
+  `FLEET-CACHE.md`, `BUILD.md`. Reference by anchor; don't paraphrase.
+- The baseline `## Hard rules` list — it lives in this doc §"Hard rules
+  for autonomous fleet roles". Role files keep only role-specific
+  exceptions.
 
 **DO include:**
-- Design decisions and their rationale ("we use X because Y").
-- Constraints and invariants not obvious from the code ("never call
-  getComponent inside a tick function — here's why").
-- Gotchas and footguns that have bitten before.
-- Conceptual relationships that span multiple directories ("the trixel
-  pipeline spans prefabs/render, prefabs/update, and shaders/glsl").
-- Pipeline or ordering constraints that affect correctness.
-- Code examples that demonstrate a **pattern** (e.g., tick-function
-  signatures) — use illustrative names, but the pattern is the point.
 
-Names are fine when they're part of a pattern example or a gotcha where
-the specific name is the actionable fix. They're clutter when they're
-just listing what exists. The test: "would this section survive a
-rename refactor, or would it go stale?" If it would go stale, it
-doesn't belong.
+- Design decisions and their rationale ("we use X because Y").
+- Constraints and invariants not obvious from the code, with the *why*.
+- Gotchas and footguns that have bitten before.
+- Conceptual relationships spanning multiple directories.
+- Pipeline / ordering constraints that affect correctness.
+- Code examples that demonstrate a **pattern** — illustrative names
+  are fine, but the pattern is the point.
+- Trigger conditions, owner-role boundaries, and behavioral contracts
+  that no other doc owns.
+
+**Verify cross-refs before merging.** A pointer that doesn't resolve
+is worse than a duplicate.
+
+- Every `[text](path)` / `[text](path#anchor)` resolves to an existing
+  file / heading. GitHub anchors are lowercase-kebab of the heading
+  text — re-check after any heading rename.
+- Section refs cited as `§Foo` match an actual `## Foo` heading. Six
+  role files spent months with `(see CRITICAL section above)` pointing
+  at a `## CRITICAL` header that never existed (PR #917). Same shape
+  of bug to avoid.
+- Names cited (type, function, label, task ID) still exist. Renamed-
+  and-not-swept names are how `engine/input/CLAUDE.md` ended up
+  pointing at a `C_Hitbox2D` that never existed (PR #909).
+
+**The test for inclusion:** would this section survive a rename
+refactor, or would it go stale? Names are fine when part of a pattern
+example or a gotcha where the specific name is the actionable fix;
+they are clutter when they're just listing what exists. If it would
+go stale, it doesn't belong.
+
+If you can't find a canonical home for what you're about to write,
+that's a signal the topic *needs* one — file an issue rather than
+starting a third copy.
+
+---
+
+## Canonical-home map
+
+Where each cross-cutting rule lives. When authoring or improving an
+agent-facing doc, link to the canonical home rather than restating.
+
+| Topic | Canonical home |
+|---|---|
+| ECS footgun · Naming · Style · IRMath · Bash rules · Cross-repo isolation · Engine API removal · Encode contracts in code · Deprecation markers · Hard rules for fleet roles · What belongs in agent-facing docs · Citing source in filed artifacts | this doc (`docs/agents/CLAUDE-BASELINE.md`) |
+| Build commands · presets · `fleet-build` · `fleet-run` | `docs/agents/BUILD.md` |
+| Fleet workflow · labels · cursor cues · model split · cross-platform parity · stacking | `docs/agents/FLEET.md` |
+| Cross-host smoke validation (OpenGL ↔ Metal) | `docs/agents/FLEET-CROSS-HOST-SMOKE.md` |
+| Feedback-label handling (AMEND / ESCALATE / labels) | `docs/agents/FLEET-FEEDBACK-HANDLING.md` |
+| Per-iteration runtime (heartbeat / exit / shutdown) | `docs/agents/FLEET-RUNTIME.md` |
+| Reviewer protocols (stack gating · label-swap · claim · nits) | `docs/agents/REVIEWER-PROTOCOL.md` |
+| Shared fleet state cache | `docs/agents/FLEET-CACHE.md` |
+| ECS smell diagnostics (machine-checkable) | `.claude/rules/cpp-ecs-smells.md` |
+| Math substitution rules (machine-checkable) | `.claude/rules/cpp-math.md` |
+| System-state smells (machine-checkable) | `.claude/rules/cpp-systems.md` |
+| Tick-function signatures · INPUT → UPDATE → RENDER ordering | `engine/system/CLAUDE.md` |
+| Component-method tier rules | `engine/prefabs/CLAUDE.md` |
+| Asset serialization version-bump | `engine/asset/CLAUDE.md` |
+| `--auto-screenshot` contract | `engine/video/CLAUDE.md` |
+| PR-body templates · host-stamp logic | `.claude/skills/commit-and-push/procedures/` |
 
 ---
 

--- a/docs/design/claude-md-sharing.md
+++ b/docs/design/claude-md-sharing.md
@@ -177,7 +177,7 @@ everywhere)" or universal in scope:
 - ECS — the single biggest footgun
 - Naming
 - Style
-- What belongs in CLAUDE.md files
+- What belongs in agent-facing docs
 - Bash tool rules
 - Cross-repo information isolation
 


### PR DESCRIPTION
## Summary

- **Generalize `CLAUDE-BASELINE.md` §"What belongs in CLAUDE.md files" → §"What belongs in agent-facing docs"** — the rule now explicitly covers `CLAUDE.md`, `SKILL.md`, and role files. Adds the "point, don't dump" framing, doc-type-specific don'ts, a "Verify cross-refs before merging" subsection, and an "if you can't find a canonical home, file an issue" escape hatch.
- **Add a new `## Canonical-home map`** to `CLAUDE-BASELINE.md` listing where each cross-cutting rule lives (CLAUDE-BASELINE / FLEET / FLEET-RUNTIME / FLEET-FEEDBACK-HANDLING / FLEET-CROSS-HOST-SMOKE / REVIEWER-PROTOCOL / BUILD / `.claude/rules/` / module CLAUDE.md). Authors link to the canonical home instead of restating.
- **Extend `simplify §9a` (doc-side drift)** with two new checks: "Point-don't-dump violations" (inventory dumps, restated baseline content, restated front-matter, anti-patterns echoing flow steps, decorative emoji bullets) and "Broken cross-refs" (path / anchor / symbol verification). The rule gets enforced at commit time, not just author intention.

## Why

The last few days produced ~40 doc-cleanup PRs. Three foundational audits — #804 (SKILLs), #806 (CLAUDE.md), #857 (roles) — catalogued the problems; ~30 follow-up PRs (#876-#928 family) fixed them slice-by-slice. The common pattern across all of them: someone restated baseline content, dumped an inventory, or let a cross-ref rot. Without forward-facing guidance, the next round of doc additions will reintroduce the same drift.

`CLAUDE-BASELINE.md` is the right home because it's auto-loaded into every agent's context via the root CLAUDE.md, so future doc authors see it. The audit-fix wave's pattern was consolidation INTO this file (#917 Hard rules, #919 Engine API removal); creating a new sibling doc would fragment the very rule it's trying to enforce.

The `simplify §9a` addition gives runtime enforcement — `simplify` runs before every commit (via `commit-and-push`), so the check fires automatically rather than depending on the author having read the baseline that day.

## Test plan

- [x] Both new sections in `CLAUDE-BASELINE.md` are well-formed markdown; tables render correctly.
- [x] All cited paths exist on `origin/master` — verified 16: `.claude/rules/cpp-{ecs-smells,math,systems}.md`, `.claude/skills/commit-and-push/procedures/`, all `docs/agents/FLEET-*.md` + `BUILD.md` + `REVIEWER-PROTOCOL.md`, `engine/{system,prefabs,asset,video}/CLAUDE.md`.
- [x] `§Foo` references resolve to actual `## Foo` headings ("Hard rules for autonomous fleet roles", "Cross-repo information isolation", "Naming", "Style", etc.).
- [x] PR #917 / PR #909 references are valid historical PRs (T-265 hoist + T-255 C_Hitbox2D fix).
- [x] `simplify §9a` doc-side checks reference the new baseline section by anchor (Canonical-home map in CLAUDE-BASELINE.md).
- [x] Self-test: ran `simplify` against this PR's own diff during `commit-and-push` step 3 — clean (the new sections are canonical content, not restatements; no cross-ref breakage).
- [ ] Spot-check next doc PR after merge — does the author lean on the canonical-home map rather than restating?

## Notes for reviewer

This is the meta-PR for the audit / cleanup wave: it doesn't fix any specific doc instance, it tries to prevent the next round of drift. Two judgment calls worth a second eye:

1. Adding to `CLAUDE-BASELINE.md` adds context cost to every agent that loads it. The new sections are ~100 lines. If you think that's too much, the most-trimmable parts are the per-doc-type "don'ts" subsections — they could collapse into "see the Canonical-home map" alone, at the cost of authors not knowing what shape "dump" takes in their specific doc type.
2. The Canonical-home map is curated, so it will need maintenance when new hub docs land. The single-row "this doc" cell groups ~12 topics with `·` separators to stay compact; if that read awkwardly during review, splitting into one-row-per-topic is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)