### PR TITLE
T-250: docs: engine/render/CLAUDE.md — fix dead render-baselines pointer, trim catalogs

### DIFF
--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -106,8 +106,7 @@ Location: `engine/render/src/shaders/` (GLSL) and
 `engine/render/src/shaders/metal/` (Metal).
 
 Naming prefixes follow the convention in
-[`CLAUDE-BASELINE.md §Naming`](../../docs/agents/CLAUDE-BASELINE.md#naming)
-(`c_` compute, `v_` vertex, `f_` fragment, `g_` geometry).
+[`CLAUDE-BASELINE.md §Naming`](../../docs/agents/CLAUDE-BASELINE.md#naming).
 Shared includes: `ir_iso_common.glsl`, `ir_constants.glsl`.
 Shader file paths are stored in `render/shader_names.hpp`. Update that
 header when you add or rename a shader.


### PR DESCRIPTION
## Summary
- Removed redundant shader-prefix parenthetical (`c_` compute, `v_` vertex, `f_` fragment, `g_` geometry) from the Shaders section — the existing pointer to `CLAUDE-BASELINE.md §Naming` already covers this content.

**Note:** Most other items from the T-250 audit were already cleaned up in prior refactors (render-baselines dead pointer, T-09Y placeholder, function/component name catalogs, C_GizmoHandle per-field docs). This PR addresses the last remaining duplication identified in issue #833.

## Test plan
- [x] `render-baselines` dead pointer absent from engine/render/CLAUDE.md (already absent before this PR — cleaned in prior refactors)
- [x] `T-09Y` placeholder absent (already absent)
- [x] No function-name or component-name catalog sections (already absent)
- [x] Shader naming prefix parenthetical removed — pointer to CLAUDE-BASELINE.md is the only reference now

Closes #833