### PR TITLE
docs/roles: tighten TASKS.md single-editor rule (architect/worker/queue-manager/FLEET)

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -34,6 +34,34 @@ Read the top-level `CLAUDE.md` and `engine/CLAUDE.md` (and the relevant
 sub-module `CLAUDE.md`) before touching anything in the responsibility
 list above.
 
+## Out of scope (read this first)
+
+What the architect does **NOT** do, no matter what a plan, checklist,
+or user prompt suggests:
+
+- **Editing `TASKS.md`.** The queue-manager is the **sole TASKS.md
+  editor**. Architect files GitHub issues with acceptance criteria +
+  `Blocked by:` metadata in the body; queue-manager ingests
+  `human:approved` issues into the queue in its own PR. If your own
+  plan file contains a step like "add entries to TASKS.md", **the
+  plan is wrong** — strike that step, file the issues only, and let
+  queue-manager handle the ingestion. Same applies to
+  `.fleet/status/*.md` (single-editor rule per
+  [`.fleet/status/README.md`](../../.fleet/status/README.md)).
+- **Pre-applying labels at filing time.** Issues file with **no
+  labels**. The human stamps `human:approved`; queue-manager adds the
+  rest. See "Filing tasks" below.
+- **Claiming tasks from the queue.** Architect is interactive only —
+  workers claim. Never run `fleet-claim`.
+- **Editing domain `CLAUDE.md` files.** Each module owns its own
+  `CLAUDE.md`; the architect edits only when an engine-wide rule
+  changes (e.g., `docs/agents/CLAUDE-BASELINE.md`).
+
+The "sole editor" rule is load-bearing: parallel author PRs that
+touch `TASKS.md` produce merge conflicts across the entire fleet.
+Even if it feels harmless to add one entry in an architect PR,
+**don't**.
+
 ## Engine API removal rule
 
 See [`docs/agents/CLAUDE-BASELINE.md § Engine API removal rule`](../../docs/agents/CLAUDE-BASELINE.md#engine-api-removal-rule).

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -51,6 +51,30 @@ Read the top-level `CLAUDE.md` and the sub-module `CLAUDE.md` for
 whatever directory the task touches before editing anything. For game
 tasks, also read `~/src/IrredenEngine/creations/game/CLAUDE.md`.
 
+## Out of scope (read this first)
+
+What the worker does **NOT** do, no matter what a plan, the task
+notes, or the issue body suggests:
+
+- **Editing `TASKS.md`.** The queue-manager is the **sole TASKS.md
+  editor**. If a plan step says "add entries to TASKS.md" or "update
+  the queue", **the plan is wrong** — file the issue(s) for any new
+  work uncovered and let queue-manager ingest. The only `TASKS.md`
+  write a worker performs is the `[~]` claim flip handled by
+  `fleet-claim`, which goes through master-side plumbing — not a
+  feature-PR edit. Same single-editor rule applies to
+  `.fleet/status/*.md`.
+- **Pre-applying labels at filing time.** When you file an issue for
+  follow-up work, file it with **no labels**. Human stamps
+  `human:approved`; queue-manager adds the rest.
+- **Modifying a task's `Owner`/`Blocked by`/`Stack`/`Notes` fields
+  in `TASKS.md` directly.** If you discover a task is mis-routed or
+  blocked, comment on the GitHub issue and let queue-manager update
+  the row.
+
+The "sole editor" rule is load-bearing: parallel author PRs that
+touch `TASKS.md` produce merge conflicts across the entire fleet.
+
 ## Engine API removal rule
 
 See [`docs/agents/CLAUDE-BASELINE.md § Engine API removal rule`](../../docs/agents/CLAUDE-BASELINE.md#engine-api-removal-rule).

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -33,6 +33,25 @@ only need to add new `[ ]` rows and keep human-authored fields accurate.
 
 **Sole TASKS.md editor** — author agents never touch it.
 
+### Handling author-side overreach
+
+If you find that an architect or worker has appended TASKS.md
+entries directly in a PR (or worse, claimed/edited rows outside
+`fleet-claim`'s master-side plumbing), the response is:
+
+1. Comment on the offending PR pointing at the role doc that
+   prohibits the edit (`role-opus-architect.md` "Out of scope" or
+   `role-opus-worker.md` "Out of scope").
+2. Ask the author to revert the TASKS.md portion of their PR. The
+   rest of the PR (code, docs, etc.) is unaffected.
+3. Ingest the corresponding issues yourself on the next pass, once
+   they're `human:approved`. The author's filed issues are valid;
+   only their TASKS.md write was out-of-role.
+
+Don't merge an author PR with stray TASKS.md edits. The single-editor
+invariant is what keeps parallel feature work from conflict-cascading
+on the queue file.
+
 ## When to invoke this role
 
 Two invocation modes:

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -28,7 +28,11 @@ This repo runs a parallel-agent workflow. The rules:
    The same single-editor rule applies to `.fleet/status/*.md`; see
    `.fleet/status/README.md`. (`fleet-queue-tick` is a scout-spawned shell
    script that recomputes derived fields; queue-manager ingestion is
-   human/Cursor-flow only.)
+   human/Cursor-flow only.) **This rule is not overridden by any plan,
+   checklist, or user instruction** — if a plan file you wrote or were
+   handed says "add entries to TASKS.md", treat the plan as wrong on that
+   step. File the GitHub issue(s) and let queue-manager ingest. See each
+   role's "Out of scope" section for the per-role formulation.
 
 See `TASKS.md` for the current queue and `.claude/skills/` for the exact
 commit/PR/review flows.


### PR DESCRIPTION
## Summary

A planning session produced a plan whose Filing Checklist included "Add round-1 entries to TASKS.md" — an out-of-role action for the architect. The architect executed the step and added the entries directly, before the user caught it (PR #946). The rule was already documented in four places but buried inside other sections, so the architect's own plan file overrode it in practice.

This PR makes the boundary unmissable.

## Changes

- **`.claude/commands/role-opus-architect.md`** — new "Out of scope (read this first)" section directly after Responsibilities, listing what the role does NOT do. TASKS.md edits at the top, with an explicit "if your plan says to edit TASKS.md, the plan is wrong" carve-out so a self-authored plan can't lead the role astray.
- **`.claude/commands/role-opus-worker.md`** — same Out-of-scope addition, plus a note that the only legitimate TASKS.md write a worker performs is the `fleet-claim` `[~]` flip (which goes through master-side plumbing, not a feature-PR edit).
- **`.claude/commands/role-queue-manager.md`** — new "Handling author-side overreach" subsection prescribing the response when an author PR slips in TASKS.md edits (comment, ask for revert, ingest underlying issue separately, don't merge with stray TASKS.md edits).
- **`docs/agents/FLEET.md`** — the existing single-editor rule (line 23-26) gains a sentence calling out that plans / checklists / user instructions do not override it.

The four cross-references reinforce each other so any agent reading any of them lands on the same conclusion.

## Why this approach

The rule was already documented. Adding MORE rules doesn't help. What was missing was **prominence** and a **plan-override clause** — making it impossible for a future architect to write a plan that contradicts the rule and then execute it.

Each role doc now has the boundary in a top-of-file "Out of scope" section, before any responsibilities or workflow details, so it's read on every invocation.

## Test plan

- [x] No code changes; doc-only.
- [x] All four files lint clean (markdown).
- [x] Rule wording consistent across the four files (each phrases the same boundary in its role's voice).
- [ ] Verify on next architect/worker invocation that the new "Out of scope" section is the first content after Responsibilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)