### PR TITLE
T-282: fleet: invalidate seen-hash on ingest lock-bail

### DIFF
--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -47,7 +47,7 @@ if ! mkdir "$LOCK_DIR" 2>/dev/null; then
     # Without this, scout writes the seen-hash before the spawn returns, so
     # a lock-bailed spawn silently consumes the projection-change signal and
     # approved issues can strand until the hash is manually deleted (issue #973).
-    rm -f "$HOME/.fleet/state/seen-hashes/queue-manager-ingest"
+    rm -f "$HOME/.fleet/state/seen-hashes/queue-manager-ingest" || true
     exit 0
 fi
 trap 'rmdir "$LOCK_DIR" 2>/dev/null; true' EXIT INT TERM

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -43,6 +43,11 @@ log() {
 # just exits.
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
     log "another fleet-queue-ingest is running; exiting"
+    # Invalidate the seen-hash so the next scout tick re-fires the trigger.
+    # Without this, scout writes the seen-hash before the spawn returns, so
+    # a lock-bailed spawn silently consumes the projection-change signal and
+    # approved issues can strand until the hash is manually deleted (issue #973).
+    rm -f "$HOME/.fleet/state/seen-hashes/queue-manager-ingest"
     exit 0
 fi
 trap 'rmdir "$LOCK_DIR" 2>/dev/null; true' EXIT INT TERM


### PR DESCRIPTION
## Summary

- On lock-bail, `fleet-queue-ingest` now deletes the `queue-manager-ingest` seen-hash so the next scout tick re-fires the trigger
- Without this fix, scout writes the seen-hash _before_ the spawned process returns; a lock-bailed spawn silently consumed the projection-change signal, stranding `human:approved` issues until the hash was deleted manually
- Added an inline comment explaining the invariant so the fix is self-documenting (regression note per acceptance criteria)
- Also deployed the fix to `~/bin/fleet-queue-ingest` on the host so it takes effect immediately

## Test plan

- [ ] Approve a new issue while `fleet-queue-ingest` is in-flight (lock is held) — the next scout tick after the in-flight iteration completes should spawn a new ingest that picks it up
- [ ] Verify `~/.fleet/state/seen-hashes/queue-manager-ingest` is deleted when the bail branch is taken
- [ ] Verify normal (non-bailed) completion still writes the seen-hash as before

## Notes

Companion issue #974 (T-283) extends the fix by filtering `fleet:epic` from the projector so epics can never keep the projection non-empty and re-trigger ingest unnecessarily.

Closes #973