### PR TITLE
T-288: voxel: face-aware shader skip + per-voxel face-occlusion bits (B2)

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -284,6 +284,7 @@ void applyLayerVisibility(std::uint8_t layerId, bool visible) {
             v.deactivate();
     }
     set.syncActiveMask();
+    IRPrefab::Voxel::recomputeFaceOccupancy(set.voxels_, set.size_);
 }
 
 // Apply a single placement / erasure edit to the voxel set, appending
@@ -330,6 +331,10 @@ void commitStroke() {
     while (g_editor.undoTotalBytes_ > kUndoByteBudget && !g_editor.undoRecords_.empty()) {
         g_editor.undoTotalBytes_ -= g_editor.undoRecords_.front().byteSize();
         g_editor.undoRecords_.pop_front();
+    }
+    if (g_sceneVoxelSetEntity != IREntity::kNullEntity) {
+        auto &set = IREntity::getComponent<C_VoxelSetNew>(g_sceneVoxelSetEntity);
+        IRPrefab::Voxel::recomputeFaceOccupancy(set.voxels_, set.size_);
     }
 }
 
@@ -1045,6 +1050,7 @@ void initSystems() {
                             v.deactivate();
                     }
                     set.syncActiveMask();
+                    IRPrefab::Voxel::recomputeFaceOccupancy(set.voxels_, set.size_);
                     g_layerManager.deleteLayer(delId);
                 }
             }

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -366,7 +366,9 @@ void undoOne() {
         }
     }
     for (auto id : touchedSets) {
-        IREntity::getComponent<C_VoxelSetNew>(id).syncActiveMask();
+        auto &set = IREntity::getComponent<C_VoxelSetNew>(id);
+        set.syncActiveMask();
+        IRPrefab::Voxel::recomputeFaceOccupancy(set.voxels_, set.size_);
     }
 }
 

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -7,13 +7,17 @@ for single voxels and particles.
 ## Key components
 
 - `C_Voxel` — per-voxel record (12 B std430): RGBA color + `material_id`,
-  `flags` (bit-packed `VoxelFlags::kAoContrib | kEmissive | kInteractive`),
-  `bone_id`, `layer_id` (editor layer membership; 0 = default layer).
-  Default ctor sets `flags = kAoContrib` and the rest zero so v1 scenes
-  render unchanged. Usually handled as spans inside a `C_VoxelPool`.
-  Layout matches the GPU SSBO at slot 6 — see
-  `components/component_voxel.hpp` and the per-pipeline shaders for the
-  struct mirror.
+  `flags` (bit-packed: bit 0 `kAoContrib`, bit 1 `kEmissive`, bits 2..7
+  face-occlusion bits `kFaceOccluded{Neg,Pos}{X,Y,Z}`), `bone_id`,
+  `layer_id` (editor layer membership; 0 = default layer). Default ctor
+  sets `flags = kAoContrib` and the rest zero so v1 scenes render
+  unchanged. Face-occlusion bits are maintained by
+  `IRPrefab::Voxel::recomputeFaceOccupancy` (`voxel/face_occupancy.hpp`),
+  invoked from set-level `C_VoxelSetNew` mutators (`reshape`, `fillPlane`,
+  `activate/deactivateAll`, dense-data ctor). Voxels usually handled as
+  spans inside a `C_VoxelPool`. Layout matches the GPU SSBO at slot 6 —
+  see `components/component_voxel.hpp` and the per-pipeline shaders for
+  the struct mirror.
 - `C_VoxelPool` — master allocator; allocates/deallocates contiguous spans,
   tracks per-chunk bounds for visibility culling, and owns a per-slot
   active-mask (`m_activeMask`) that mirrors `m_voxelColors[i].color_.alpha_ != 0`.

--- a/engine/prefabs/irreden/voxel/components/component_voxel.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel.hpp
@@ -12,13 +12,37 @@ namespace IRComponents {
 
 /// Per-voxel flag bits. Bit-packed into `C_Voxel::flags_`.
 ///
-/// Reserved bits 3-7 are available for future flags without re-versioning
-/// the 12 B record (the trailing pad bytes also leave room for new fields).
-/// Match the GPU-side constants if shader code starts to consume these.
+/// Layout:
+///   bit 0     — `kAoContrib`.
+///   bit 1     — `kEmissive`.
+///   bits 2..7 — face-occlusion bits (`kFaceOccluded*`). Each bit is set
+///               when the neighbor on that face exists, so the renderer
+///               can skip emitting that face. Default = 0 (all faces
+///               visible). Maintained at edit time by
+///               `IRPrefab::Voxel::recomputeFaceOccupancy` (see
+///               `voxel/face_occupancy.hpp`).
+///
+/// Bits 0..1 keep their pre-B2 positions so .vxs files saved before the
+/// face-occlusion bits existed still round-trip semantically — the old
+/// `kInteractive` bit (formerly bit 2) was never written by engine code
+/// (default ctor set only `kAoContrib`), so reusing bit 2 for the first
+/// face bit is safe for legacy saves.
+///
+/// The GPU mirror reads the same byte at offset 5 of the 12 B record
+/// (`(materialFlagBone >> 8) & 0xFFu` in stage 1). Face-bit indices
+/// match `kFace*` directions in `ir_iso_common.glsl`.
 namespace VoxelFlags {
 constexpr std::uint8_t kAoContrib = 1u << 0;
 constexpr std::uint8_t kEmissive = 1u << 1;
-constexpr std::uint8_t kInteractive = 1u << 2;
+constexpr std::uint8_t kFaceOccludedNegX = 1u << 2;
+constexpr std::uint8_t kFaceOccludedPosX = 1u << 3;
+constexpr std::uint8_t kFaceOccludedNegY = 1u << 4;
+constexpr std::uint8_t kFaceOccludedPosY = 1u << 5;
+constexpr std::uint8_t kFaceOccludedNegZ = 1u << 6;
+constexpr std::uint8_t kFaceOccludedPosZ = 1u << 7;
+constexpr std::uint8_t kFaceOccludedMask = kFaceOccludedNegX | kFaceOccludedPosX |
+                                           kFaceOccludedNegY | kFaceOccludedPosY |
+                                           kFaceOccludedNegZ | kFaceOccludedPosZ;
 } // namespace VoxelFlags
 
 /// Per-voxel record. 12 B std430 layout — matches the v2 entity-editor record
@@ -27,15 +51,16 @@ constexpr std::uint8_t kInteractive = 1u << 2;
 /// Layout (one record per voxel-pool slot, uploaded to SSBO @ slot 6):
 ///   [0:3]  color_         packed RGBA8
 ///   [4]    material_id_   material registry index (0 = default)
-///   [5]    flags_         bit-packed VoxelFlags bits
+///   [5]    flags_         bit-packed VoxelFlags bits (faces + AO + emissive)
 ///   [6]    bone_id_       skeletal-rig joint index (0 = identity)
 ///   [7]    layer_id_      editor layer membership (0 = default layer); keeps
 ///                         the trailing uint32 4-byte aligned
 ///   [8:11] reserved_      reserved for future per-voxel fields
 ///
 /// The compute shaders (`c_voxel_to_trixel_stage_*`) read `color_` from
-/// offset 0; `bone_id_` and `layer_id_` ride along for Phase 2 (#605)
-/// where stage 1 applies the skeletal joint matrix and layer visibility.
+/// offset 0; `flags_` is consumed by stage 1 to skip occluded faces;
+/// `bone_id_` and `layer_id_` ride along for Phase 2 (#605) where stage 1
+/// applies the skeletal joint matrix and layer visibility.
 struct C_Voxel {
     IRMath::Color color_;
     std::uint8_t material_id_;

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -5,6 +5,7 @@
 #include <irreden/ir_constants.hpp>
 
 #include <irreden/voxel/components/component_voxel.hpp>
+#include <irreden/voxel/face_occupancy.hpp>
 #include <irreden/voxel/voxel_pool_api.hpp>
 
 #include <vector>
@@ -128,6 +129,7 @@ struct C_VoxelSetNew {
         } else {
             IRPrefab::VoxelPool::markRangeInactive(voxelStartIdx_, numVoxels_);
         }
+        IRPrefab::Voxel::recomputeFaceOccupancy(voxels_, size_);
         IRE_LOG_DEBUG("Allocated {} voxel(s)", numVoxels_);
     }
 
@@ -214,6 +216,7 @@ struct C_VoxelSetNew {
         // Dense payload is a mix of active and inactive slots, so
         // resync from per-voxel alpha rather than the fast bulk path.
         IRPrefab::VoxelPool::resyncRangeFromColors(voxelStartIdx_, numVoxels_);
+        IRPrefab::Voxel::recomputeFaceOccupancy(voxels_, extent);
         IRE_LOG_DEBUG("Allocated {} dense voxel(s) from voxel_ref", numVoxels_);
     }
 
@@ -259,6 +262,7 @@ struct C_VoxelSetNew {
             voxels_[i].deactivate();
         }
         IRPrefab::VoxelPool::markRangeInactive(voxelStartIdx_, numVoxels_);
+        IRPrefab::Voxel::recomputeFaceOccupancy(voxels_, size_);
     }
 
     void activateAll() {
@@ -266,6 +270,7 @@ struct C_VoxelSetNew {
             voxels_[i].activate();
         }
         IRPrefab::VoxelPool::markRangeActive(voxelStartIdx_, numVoxels_);
+        IRPrefab::Voxel::recomputeFaceOccupancy(voxels_, size_);
     }
 
     // Activates all voxels in the plane perpendicular to `axis` at `planeIndex`
@@ -289,6 +294,7 @@ struct C_VoxelSetNew {
                 }
             }
         });
+        IRPrefab::Voxel::recomputeFaceOccupancy(voxels_, sz);
     }
 
     // take positions of all voxels in voxel object and form a new shape. This could
@@ -335,6 +341,7 @@ struct C_VoxelSetNew {
             // bulk active/inactive.
             IRPrefab::VoxelPool::resyncRangeFromColors(voxelStartIdx_, numVoxels_);
         }
+        IRPrefab::Voxel::recomputeFaceOccupancy(voxels_, size_);
     }
 
     // TODO each individual voxel should be treated like this

--- a/engine/prefabs/irreden/voxel/face_occupancy.hpp
+++ b/engine/prefabs/irreden/voxel/face_occupancy.hpp
@@ -1,0 +1,104 @@
+#ifndef IR_VOXEL_FACE_OCCUPANCY_H
+#define IR_VOXEL_FACE_OCCUPANCY_H
+
+#include <cstdint>
+#include <span>
+
+#include <irreden/ir_math.hpp>
+
+#include <irreden/voxel/components/component_voxel.hpp>
+
+namespace IRPrefab::Voxel {
+
+namespace detail {
+
+inline bool voxelIsActive(const IRComponents::C_Voxel &voxel) {
+    return voxel.color_.alpha_ > 0;
+}
+
+} // namespace detail
+
+/// Recompute per-voxel face-occlusion bits for every voxel in a regular
+/// `size.x × size.y × size.z` grid stored in `voxels` (row-major via
+/// `IRMath::index3DtoIndex1D`). Each active voxel's six face bits are set
+/// when the in-grid neighbor at that face is active; inactive voxels are
+/// cleared to all-zero (no faces blocked). Existing non-face bits in
+/// `flags_` (`kAoContrib`, `kEmissive`) are preserved.
+///
+/// Neighbor lookup is in-grid only — voxels at the grid boundary do not
+/// see voxels in adjacent sets. That matches the acceptance benchmark (a
+/// solid 64³ cube is a single set; interior faces all block, surface faces
+/// all emit) and avoids a global spatial index.
+///
+/// Pushed at mutation time per `.claude/rules/cpp-ecs.md` §"No dirty flags":
+/// callers invoke this from any set-level mutator that toggles voxel
+/// occupancy (`activateAll`, `deactivateAll`, `fillPlane`, `reshape`,
+/// dense-data ctor). Per-voxel `activate`/`deactivate` on
+/// `C_VoxelSetNew::voxels_[i]` do not auto-update — the caller pays the
+/// per-set recompute cost if needed.
+inline void recomputeFaceOccupancy(std::span<IRComponents::C_Voxel> voxels, IRMath::ivec3 size) {
+    if (size.x <= 0 || size.y <= 0 || size.z <= 0) {
+        return;
+    }
+    const std::size_t requiredCount = static_cast<std::size_t>(size.x) *
+                                      static_cast<std::size_t>(size.y) *
+                                      static_cast<std::size_t>(size.z);
+    if (voxels.size() < requiredCount) {
+        return;
+    }
+    for (int x = 0; x < size.x; ++x) {
+        for (int y = 0; y < size.y; ++y) {
+            for (int z = 0; z < size.z; ++z) {
+                const int idx = IRMath::index3DtoIndex1D(IRMath::ivec3(x, y, z), size);
+                auto &voxel = voxels[idx];
+                std::uint8_t face = 0u;
+                if (detail::voxelIsActive(voxel)) {
+                    if (x > 0 &&
+                        detail::voxelIsActive(
+                            voxels[IRMath::index3DtoIndex1D(IRMath::ivec3(x - 1, y, z), size)]
+                        )) {
+                        face |= IRComponents::VoxelFlags::kFaceOccludedNegX;
+                    }
+                    if (x + 1 < size.x &&
+                        detail::voxelIsActive(
+                            voxels[IRMath::index3DtoIndex1D(IRMath::ivec3(x + 1, y, z), size)]
+                        )) {
+                        face |= IRComponents::VoxelFlags::kFaceOccludedPosX;
+                    }
+                    if (y > 0 &&
+                        detail::voxelIsActive(
+                            voxels[IRMath::index3DtoIndex1D(IRMath::ivec3(x, y - 1, z), size)]
+                        )) {
+                        face |= IRComponents::VoxelFlags::kFaceOccludedNegY;
+                    }
+                    if (y + 1 < size.y &&
+                        detail::voxelIsActive(
+                            voxels[IRMath::index3DtoIndex1D(IRMath::ivec3(x, y + 1, z), size)]
+                        )) {
+                        face |= IRComponents::VoxelFlags::kFaceOccludedPosY;
+                    }
+                    if (z > 0 &&
+                        detail::voxelIsActive(
+                            voxels[IRMath::index3DtoIndex1D(IRMath::ivec3(x, y, z - 1), size)]
+                        )) {
+                        face |= IRComponents::VoxelFlags::kFaceOccludedNegZ;
+                    }
+                    if (z + 1 < size.z &&
+                        detail::voxelIsActive(
+                            voxels[IRMath::index3DtoIndex1D(IRMath::ivec3(x, y, z + 1), size)]
+                        )) {
+                        face |= IRComponents::VoxelFlags::kFaceOccludedPosZ;
+                    }
+                }
+                voxel.flags_ = static_cast<std::uint8_t>(
+                                   voxel.flags_ & ~IRComponents::VoxelFlags::kFaceOccludedMask
+                               ) |
+                               face;
+            }
+        }
+    }
+}
+
+} // namespace IRPrefab::Voxel
+
+#endif /* IR_VOXEL_FACE_OCCUPANCY_H */

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
@@ -45,13 +45,20 @@ struct Voxel {
     uint reserved;
 };
 
-// Stage 1 writes distances only; voxels[] is unused here. It is bound so the
-// buffer slot layout stays identical across all three voxel-to-trixel stages
-// and for Phase 2 (#605), where stage 1 will multiply each voxel position by
+// Stage 1 reads `materialFlagBone.flags` (bits 0..5 are face-occlusion bits
+// — see VoxelFlags in component_voxel.hpp) to skip emitting iso-visible
+// faces that are blocked by a neighbor. `voxels[]` is still bound for
+// Phase 2 (#605), where stage 1 will multiply each voxel position by
 // bone_matrix[bone_id] before projecting.
 layout(std430, binding = 6) readonly buffer ColorBuffer {
     Voxel voxels[];
 };
+
+// Face-occlusion bit indices — mirror VoxelFlags::kFaceOccluded{Neg,Pos}{X,Y,Z}
+// in engine/prefabs/irreden/voxel/components/component_voxel.hpp.
+const uint kVoxelFlagFaceNegX = 1u << 2;
+const uint kVoxelFlagFaceNegY = 1u << 4;
+const uint kVoxelFlagFaceNegZ = 1u << 6;
 
 layout(std430, binding = 25) readonly buffer CompactedIndices {
     uint compactedVoxelIndices[];
@@ -80,6 +87,21 @@ void main() {
 
     const int face = localIDToFace_2x3(gl_LocalInvocationID.xy);
     const int cardinalIndex = rasterYawCardinalIndex(rasterYaw);
+
+    // Face-aware skip: at cardinalIndex==0 the iso camera renders the world
+    // -X/-Y/-Z faces. If the voxel's neighbor on that face is active, the
+    // face is blocked and emitting only wastes an atomicMin. Skipping the
+    // tap also keeps the depth texture's tile from a transient max-value
+    // overwrite at this pixel. At non-zero cardinalIndex the authored face
+    // bits no longer line up with the iso-visible world face direction;
+    // skip the optimization in that case until a follow-up wires the
+    // rotation-aware lookup (also gates the T-293 C5 deformation work).
+    if (cardinalIndex == 0) {
+        const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
+        if (face == kXFace && (flagsByte & kVoxelFlagFaceNegX) != 0u) return;
+        if (face == kYFace && (flagsByte & kVoxelFlagFaceNegY) != 0u) return;
+        if (face == kZFace && (flagsByte & kVoxelFlagFaceNegZ) != 0u) return;
+    }
 
     // At cardinalIndex==0 the rotation is the identity; gating it behind a
     // branch keeps the GLSL/MSL compilers from reshuffling instructions or

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
@@ -43,6 +43,12 @@ struct Voxel {
     uint reserved;
 };
 
+// Face-occlusion bit indices — mirror VoxelFlags::kFaceOccluded{Neg,Pos}{X,Y,Z}
+// in engine/prefabs/irreden/voxel/components/component_voxel.hpp.
+constant uint kVoxelFlagFaceNegX = 1u << 2;
+constant uint kVoxelFlagFaceNegY = 1u << 4;
+constant uint kVoxelFlagFaceNegZ = 1u << 6;
+
 kernel void c_voxel_to_trixel_stage_1(
     constant FrameDataVoxelToTrixel& frameData [[buffer(7)]],
     device const float4* positions [[buffer(5)]],
@@ -65,6 +71,18 @@ kernel void c_voxel_to_trixel_stage_1(
     const int cardinalIndex = rasterYawCardinalIndex(frameData.rasterYaw);
 
     const int2 canvasSize = frameData.canvasSizePixels;
+
+    // Face-aware skip: see c_voxel_to_trixel_stage_1.glsl for the matching
+    // GLSL block. Only the iso-visible world-axis -X/-Y/-Z faces are
+    // checked at cardinalIndex==0; non-zero cardinal rotations fall back
+    // to emitting all faces until a follow-up wires the rotation-aware
+    // lookup.
+    if (cardinalIndex == 0) {
+        const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
+        if (face == kXFace && (flagsByte & kVoxelFlagFaceNegX) != 0u) return;
+        if (face == kYFace && (flagsByte & kVoxelFlagFaceNegY) != 0u) return;
+        if (face == kZFace && (flagsByte & kVoxelFlagFaceNegZ) != 0u) return;
+    }
 
     // At cardinalIndex==0 the rotation is the identity; gating it behind a
     // branch keeps the GLSL/MSL compilers from reshuffling instructions or


### PR DESCRIPTION
## Summary

- New `IRPrefab::Voxel::recomputeFaceOccupancy` helper at
  `engine/prefabs/irreden/voxel/face_occupancy.hpp` sets per-voxel
  face-occlusion bits for an in-set grid.
- `C_Voxel::flags_` byte layout: bit 0 `kAoContrib`, bit 1 `kEmissive`,
  bits 2..7 `kFaceOccluded{Neg,Pos}{X,Y,Z}`. Default ctor unchanged
  (`flags = kAoContrib`); legacy `.vxs` saves round-trip semantically
  because the dropped `kInteractive` bit was never written by engine
  code.
- Stage 1 (`c_voxel_to_trixel_stage_1.glsl` + `.metal`) consults the
  three iso-visible -X/-Y/-Z face bits at `cardinalIndex == 0` and
  returns early before `writeDistanceTap` when the face is blocked.
- Set-level `C_VoxelSetNew` mutators (`reshape`, `fillPlane`,
  `activate/deactivateAll`, dense-data ctor) push-at-mutation by
  invoking `recomputeFaceOccupancy` after the edit.

## Stack context

Stacked on: #988 (T-287, B1 — sparse occupancy bitmask).
The B2 logic is intentionally orthogonal to B1's pool-level
`m_activeMask`: B1 changes which slots iterate; B2 changes which
faces each slot emits. They compose without conflict on the touched
files.

## Acceptance status

- **(1) 64³ cube emits ~24,576 surface trixels.** Reasoning: with all
  interior voxels having all six neighbors active, the three iso-
  visible bits (-X/-Y/-Z) are set for every interior voxel — stage 1
  returns early on all three faces for those voxels. Surface voxels
  emit at unblocked iso-visible faces only. Cube viewed at yaw=0
  with the iso camera: 3 × 64² = 12,288 face-emits × 2 sub-pixel
  invocations per face = 24,576 writeDistanceTap calls. Matches the
  acceptance target. Not yet verified live in a dense-cube demo (see
  perf_grid note below).
- **(2) perf_grid numbers.** Deferred. `perf_grid` as configured today
  uses 1×1×1 sets per cell — face-aware skip is a no-op for those
  (no in-set neighbors). To produce the requested before/after numbers
  a `--mode dense_cube` would need to be added that bundles all voxels
  into one `C_VoxelSetNew`. Filing as follow-up rather than scope-
  expanding this PR.
- **(3) Push-at-mutation correctness.** Wired through set-level
  mutators per `.claude/rules/cpp-ecs.md` §\"No dirty flags\". Per-
  voxel `activate`/`deactivate` on `voxels_[i]` does not auto-update
  (documented in `face_occupancy.hpp`); callers needing per-edit
  refresh invoke `recomputeFaceOccupancy(voxels_, size_)` themselves.
- **(4) `fleet-build` clean.** Verified on `macos-debug` against
  IRShapeDebug and IRPerfGrid. Linux-debug pending via the
  cross-host smoke flow.

## Known limitations / follow-ups

- **`cardinalIndex != 0` rotations** continue emitting all faces. The
  authored face bits no longer line up with the iso-visible world
  faces under cardinal rotation; a rotation-aware lookup needs to fold
  in `cardinalIndex` (also blocks T-293 / C5 deformation work).
- **Cross-set neighbor occupancy.** Voxels at the boundary between
  two `C_VoxelSetNew` don't see each other; would require a global
  spatial index (T-287's `m_activeMask` is the natural seam — easier
  to wire after B1 lands).
- **`perf_grid --mode dense_cube`** for the (2) benchmark.

## Test plan

- [x] `fleet-build --target IRShapeDebug` clean (macOS / Metal).
- [x] `fleet-build --target IRPerfGrid` clean.
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` runs without
      visual regression — shape_debug uses SDFs + small voxel sets,
      so the face-aware skip is a no-op-equivalent (skipped emits
      would be atomicMin losers anyway, identical final pixels).
- [ ] Linux/OpenGL smoke via the cross-host flow (PR will pick up
      `fleet:needs-linux-smoke` once approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)