### PR TITLE
T-292: math: continuous-yaw + deformation math helpers (C5)

### DIFF
--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -26,6 +26,18 @@ constexpr float kHalfPi = 1.57079632679489661923f;
 /// Two pi (2π). Useful for full-revolution math and angle wrap.
 constexpr float kTwoPi = 6.28318530717958647692f;
 
+/// Face-index constants for the three visible iso faces. CPU mirror of the
+/// `kXFace`/`kYFace`/`kZFace` integer constants in `shaders/ir_iso_common.glsl`
+/// and `shaders/metal/ir_iso_common.metal`. Distinct from the legacy `FaceType`
+/// enum in `ir_math_types.hpp` (which is 1-indexed with `NONE_FACE` first);
+/// these match the shader convention so any helper that crosses the CPU↔GPU
+/// boundary can use the same integer in both directions.
+/// @{
+constexpr int kXFace = 0;
+constexpr int kYFace = 1;
+constexpr int kZFace = 2;
+/// @}
+
 /// Loads a color palette from a file and returns it as a vector of Colors.
 std::vector<Color> createColorPaletteFromFile(const char *filename);
 
@@ -298,6 +310,85 @@ constexpr ivec3 rotateCardinalZInvI(const ivec3 v, CardinalIndex cardinalIndex) 
     return v;
 }
 
+/// Iso projection of a world point under a continuous Z-yaw camera.
+///
+/// Equivalent to `pos3DtoPos2DIso(R_z(-yaw) · world)` — applies the world→view
+/// rotation for camera yaw @p visualYaw, then projects to iso. Sign convention
+/// matches `rotateCardinalZ` (world→view = R_z(-yaw)) so this is the smooth
+/// extension of the cardinal-snap projection used by the voxel rasterizer.
+///
+/// Use cases: CPU iso-bounds computation under continuous yaw, picking
+/// pre-image, debug overlay placement. The voxel/SDF rasterizer itself
+/// emits at the cardinal `rasterYaw` and applies `faceDeformationMatrix` for
+/// the leftover `residualYaw`; this helper is the cleaner CPU-side path
+/// when the caller has the full `visualYaw` and doesn't need the split.
+///
+/// GPU mirror: `pos3DtoPos2DIsoYawed` in `shaders/ir_iso_common.glsl`.
+constexpr vec2 pos3DtoPos2DIsoYawed(const vec3 worldPos, float visualYaw) {
+    const float c = glm::cos(visualYaw);
+    const float s = glm::sin(visualYaw);
+    const float vx = worldPos.x * c + worldPos.y * s;
+    const float vy = -worldPos.x * s + worldPos.y * c;
+    return vec2(-vx + vy, -vx - vy + 2.0f * worldPos.z);
+}
+
+/// 2x2 deformation matrix that maps a face's un-yawed iso-pixel offset to the
+/// offset under residual yaw @p residualYaw (in `[-π/4, π/4]`).
+///
+/// Geometric construction: each face contributes one "u" tangent (in-plane,
+/// rotates with the world's Z-yaw) and one "v" tangent (along world Z, fixed
+/// under Z-yaw). The original iso-projection columns `M_0` map (u, v) → iso;
+/// rotating the world by `R_z(-φ)` produces new columns `M_φ`. The returned
+/// `mat2 D_φ = M_φ · M_0⁻¹` post-multiplies an iso-pixel offset emitted at
+/// the cardinal `rasterYaw` to recover its position at the continuous yaw.
+///
+/// Closed form per face (with `c = cos(φ)`, `s = sin(φ)`):
+/// - X face: `[c-s, 0; 1-(c+s), 1]`
+/// - Y face: `[c+s, 0; c-s-1, 1]`
+/// - Z face: `[c, s; -s, c]` = `R_z(-φ)` in 2D iso space
+///
+/// At `residualYaw == 0` all three are identity, so the cardinal-snap path
+/// is bit-identical to the un-yawed projection. `@p face` uses the shader
+/// convention `kXFace`/`kYFace`/`kZFace` (0/1/2); other values return identity.
+///
+/// GPU mirror: `faceDeformationMatrix` in `shaders/ir_iso_common.glsl`.
+constexpr mat2 faceDeformationMatrix(int face, float residualYaw) {
+    const float c = glm::cos(residualYaw);
+    const float s = glm::sin(residualYaw);
+    if (face == kXFace) {
+        return mat2(c - s, 1.0f - (c + s), 0.0f, 1.0f);
+    }
+    if (face == kYFace) {
+        return mat2(c + s, c - s - 1.0f, 0.0f, 1.0f);
+    }
+    if (face == kZFace) {
+        return mat2(c, -s, s, c);
+    }
+    return mat2(1.0f, 0.0f, 0.0f, 1.0f);
+}
+
+/// Residual-yaw-deformed trixel iso-pixel offset within the 2x3 face diamond.
+///
+/// CPU mirror of `deformedTrixelIsoPixel` in `shaders/ir_iso_common.glsl`:
+/// takes the un-yawed offset from `faceOffset_2x3(face, subPixel)`, applies
+/// `faceDeformationMatrix(face, residualYaw)`, and rounds back to integer
+/// iso pixels via @ref roundHalfUp. `@p subPixel` is 0 or 1 (selects the
+/// upper or lower trixel of the face's vertical pair); `@p face` uses the
+/// shader convention `kXFace`/`kYFace`/`kZFace`.
+constexpr ivec2 deformedTrixelIsoPixel(int face, int subPixel, float residualYaw) {
+    ivec2 unyawed;
+    if (face == kXFace) {
+        unyawed = ivec2(1, 1 + subPixel);
+    } else if (face == kYFace) {
+        unyawed = ivec2(0, 1 + subPixel);
+    } else {
+        unyawed = ivec2(subPixel, 0);
+    }
+    const mat2 D = faceDeformationMatrix(face, residualYaw);
+    const vec2 deformed = D * vec2(unyawed);
+    return ivec2(roundHalfUp(deformed.x), roundHalfUp(deformed.y));
+}
+
 /// Orthographic projection matrix.  Selects the depth range convention
 /// ([0,1] for Metal/Vulkan, [-1,1] for OpenGL) from IRPlatform::kGfx.
 inline mat4 ortho(float left, float right, float bottom, float top, float nearZ, float farZ) {
@@ -316,6 +407,40 @@ inline mat4 translate(const mat4 &matrix, const vec3 &position) {
 /// Scaling matrix that scales @p matrix by @p value. GLM wrapper.
 inline mat4 scale(const mat4 &matrix, const vec3 &value) {
     return glm::scale(matrix, value);
+}
+
+/// Builds the local→world matrix from an SQT triple (scale, quaternion
+/// rotation, translation). Composition is `T · R · S`: a local point
+/// `p_local` maps to `R · (S · p_local) + t` — the same ordering that
+/// `SYSTEM_PROPAGATE_TRANSFORM` applies when composing parent and child
+/// transforms.
+///
+/// Quaternion layout is the engine canon: `vec4(qx, qy, qz, qw)` with `.w`
+/// the scalar. Implementation rotates the scaled basis vectors via
+/// @ref rotateVectorByQuat so the matrix-form rotation stays bit-identical
+/// to the per-vector quaternion-rotate path used elsewhere in the engine.
+///
+/// GPU mirror: `sqtToMat4` in `shaders/ir_iso_common.glsl`.
+inline mat4 sqtToMat4(const vec3 &scaleVec, const vec4 &rotationQuat, const vec3 &translation) {
+    const vec3 col0 = rotateVectorByQuat(vec3(scaleVec.x, 0.0f, 0.0f), rotationQuat);
+    const vec3 col1 = rotateVectorByQuat(vec3(0.0f, scaleVec.y, 0.0f), rotationQuat);
+    const vec3 col2 = rotateVectorByQuat(vec3(0.0f, 0.0f, scaleVec.z), rotationQuat);
+    return mat4(vec4(col0, 0.0f), vec4(col1, 0.0f), vec4(col2, 0.0f), vec4(translation, 1.0f));
+}
+
+/// Applies an SRT (or any affine) matrix @p transform to an integer voxel
+/// grid cell @p cell, returning the destination integer cell with half-up
+/// rounding. Use when GRID-mode rotation needs to re-rasterize a set of
+/// authored voxels into world-grid cells under a parent or local transform.
+///
+/// Affine matrices keep `w == 1`, so the perspective divide is omitted. The
+/// round goes through @ref roundHalfUp so CPU and GPU agree on the destination
+/// cell at half-integer positions.
+///
+/// GPU mirror: `matrixApplyToVoxelGrid` in `shaders/ir_iso_common.glsl`.
+inline ivec3 matrixApplyToVoxelGrid(const mat4 &transform, const ivec3 &cell) {
+    const vec4 worldPos = transform * vec4(vec3(cell), 1.0f);
+    return roundVec3HalfUp(vec3(worldPos));
 }
 
 /// Sum of all components of @p value.

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -379,10 +379,13 @@ constexpr ivec2 deformedTrixelIsoPixel(int face, int subPixel, float residualYaw
     ivec2 unyawed;
     if (face == kXFace) {
         unyawed = ivec2(1, 1 + subPixel);
-    } else if (face == kYFace) {
-        unyawed = ivec2(0, 1 + subPixel);
-    } else {
+    } else if (face == kZFace) {
         unyawed = ivec2(subPixel, 0);
+    } else {
+        unyawed = ivec2(
+            0,
+            1 + subPixel
+        ); // kYFace + out-of-range; mirrors faceOffset_2x3 GLSL fallthrough
     }
     const mat2 D = faceDeformationMatrix(face, residualYaw);
     const vec2 deformed = D * vec2(unyawed);

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -305,3 +305,101 @@ vec3 trixelCanvasPixelToWorld3D(
         rasterYawCardinalIndex(rasterYaw)
     );
 }
+
+// Continuous-yaw + per-face deformation math (T-292; consumed by T-293).
+// Mirrors IRMath::pos3DtoPos2DIsoYawed / faceDeformationMatrix /
+// deformedTrixelIsoPixel / sqtToMat4 / matrixApplyToVoxelGrid in
+// engine/math/include/irreden/ir_math.hpp; CPU and GPU MUST agree at all 4
+// cardinal yaws and across the [-pi/4, pi/4] residual range.
+
+// Iso projection of a world point under a continuous Z-yaw camera.
+// Equivalent to pos3DtoPos2DIso(R_z(-yaw) * world). Sign convention matches
+// rotateCardinalZ (world->view = R_z(-yaw)) so this is the smooth extension
+// of the cardinal-snap projection used by the voxel rasterizer.
+vec2 pos3DtoPos2DIsoYawed(vec3 worldPos, float visualYaw) {
+    float c = cos(visualYaw);
+    float s = sin(visualYaw);
+    float vx = worldPos.x * c + worldPos.y * s;
+    float vy = -worldPos.x * s + worldPos.y * c;
+    return vec2(-vx + vy, -vx - vy + 2.0 * worldPos.z);
+}
+
+// 2x2 deformation matrix that maps a face's un-yawed iso-pixel offset to the
+// offset under residual yaw `residualYaw` (in [-pi/4, pi/4]).
+//
+// Derivation: each face contributes one "u" tangent (in-plane, rotates with
+// world Z-yaw) and one "v" tangent (along world Z, fixed under Z-yaw). The
+// returned mat2 D = M_phi * M_0^-1 post-multiplies an iso-pixel offset
+// emitted at the cardinal rasterYaw to recover its position under the
+// continuous yaw. At residualYaw == 0 all three are identity, so the
+// cardinal-snap path stays bit-identical to the un-yawed projection.
+//
+// `face` uses the kXFace / kYFace / kZFace integer convention; other values
+// return identity. CPU mirror: IRMath::faceDeformationMatrix.
+mat2 faceDeformationMatrix(int face, float residualYaw) {
+    float c = cos(residualYaw);
+    float s = sin(residualYaw);
+    if (face == kXFace) {
+        return mat2(c - s, 1.0 - (c + s), 0.0, 1.0);
+    }
+    if (face == kYFace) {
+        return mat2(c + s, c - s - 1.0, 0.0, 1.0);
+    }
+    if (face == kZFace) {
+        return mat2(c, -s, s, c);
+    }
+    return mat2(1.0, 0.0, 0.0, 1.0);
+}
+
+// Residual-yaw-deformed trixel iso-pixel offset within the 2x3 face diamond.
+// Applies faceDeformationMatrix to the un-yawed offset from faceOffset_2x3
+// and rounds back to integer iso pixels via roundHalfUp so CPU and GPU
+// resolve half-integer drift to the same cell.
+//
+// `subPixel` is 0 or 1; `face` uses the kXFace / kYFace / kZFace convention.
+// CPU mirror: IRMath::deformedTrixelIsoPixel.
+ivec2 deformedTrixelIsoPixel(int face, int subPixel, float residualYaw) {
+    ivec2 unyawed = faceOffset_2x3(face, subPixel);
+    mat2 D = faceDeformationMatrix(face, residualYaw);
+    vec2 deformed = D * vec2(unyawed);
+    return ivec2(roundHalfUp(deformed.x), roundHalfUp(deformed.y));
+}
+
+// Builds the local->world matrix from an SQT triple (scale, quaternion
+// rotation, translation). Composition is T * R * S: local p maps to
+// R * (S * p) + t — the same ordering SYSTEM_PROPAGATE_TRANSFORM uses when
+// composing parent and child transforms. Quaternion layout matches the
+// engine canon: vec4(qx, qy, qz, qw) with .w the scalar; identity is
+// (0, 0, 0, 1). CPU mirror: IRMath::sqtToMat4.
+mat4 sqtToMat4(vec3 scaleVec, vec4 rotationQuat, vec3 translation) {
+    float x = rotationQuat.x;
+    float y = rotationQuat.y;
+    float z = rotationQuat.z;
+    float w = rotationQuat.w;
+    // mat3 R from unit quaternion (column-major).
+    vec3 col0 = vec3(1.0 - 2.0 * (y * y + z * z),
+                     2.0 * (x * y + w * z),
+                     2.0 * (x * z - w * y)) * scaleVec.x;
+    vec3 col1 = vec3(2.0 * (x * y - w * z),
+                     1.0 - 2.0 * (x * x + z * z),
+                     2.0 * (y * z + w * x)) * scaleVec.y;
+    vec3 col2 = vec3(2.0 * (x * z + w * y),
+                     2.0 * (y * z - w * x),
+                     1.0 - 2.0 * (x * x + y * y)) * scaleVec.z;
+    return mat4(
+        vec4(col0, 0.0),
+        vec4(col1, 0.0),
+        vec4(col2, 0.0),
+        vec4(translation, 1.0)
+    );
+}
+
+// Applies an SRT (or any affine) matrix to an integer voxel grid cell,
+// returning the destination integer cell with half-up rounding. Used by the
+// GRID-mode rotation path (T-294) to re-rasterize authored voxels into
+// world-grid cells under a parent or local transform. CPU mirror:
+// IRMath::matrixApplyToVoxelGrid.
+ivec3 matrixApplyToVoxelGrid(mat4 transformMat, ivec3 cell) {
+    vec4 worldPos = transformMat * vec4(vec3(cell), 1.0);
+    return roundHalfUp(vec3(worldPos));
+}

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -313,6 +313,75 @@ inline float3 trixelCanvasPixelToWorld3D(
     );
 }
 
+// Continuous-yaw + per-face deformation math (T-292; consumed by T-293).
+// Mirrors shaders/ir_iso_common.glsl and IRMath::pos3DtoPos2DIsoYawed /
+// faceDeformationMatrix / deformedTrixelIsoPixel / sqtToMat4 /
+// matrixApplyToVoxelGrid in engine/math/include/irreden/ir_math.hpp.
+
+inline float2 pos3DtoPos2DIsoYawed(float3 worldPos, float visualYaw) {
+    const float c = cos(visualYaw);
+    const float s = sin(visualYaw);
+    const float vx = worldPos.x * c + worldPos.y * s;
+    const float vy = -worldPos.x * s + worldPos.y * c;
+    return float2(-vx + vy, -vx - vy + 2.0f * worldPos.z);
+}
+
+// 2x2 deformation matrix per face for residual yaw. At residualYaw == 0 all
+// three return identity. `face` uses the kXFace / kYFace / kZFace convention;
+// other values return identity. CPU mirror: IRMath::faceDeformationMatrix.
+inline float2x2 faceDeformationMatrix(int face, float residualYaw) {
+    const float c = cos(residualYaw);
+    const float s = sin(residualYaw);
+    if (face == kXFace) {
+        return float2x2(float2(c - s, 1.0f - (c + s)), float2(0.0f, 1.0f));
+    }
+    if (face == kYFace) {
+        return float2x2(float2(c + s, c - s - 1.0f), float2(0.0f, 1.0f));
+    }
+    if (face == kZFace) {
+        return float2x2(float2(c, -s), float2(s, c));
+    }
+    return float2x2(float2(1.0f, 0.0f), float2(0.0f, 1.0f));
+}
+
+inline int2 deformedTrixelIsoPixel(int face, int subPixel, float residualYaw) {
+    const int2 unyawed = faceOffset_2x3(face, subPixel);
+    const float2x2 D = faceDeformationMatrix(face, residualYaw);
+    const float2 deformed = D * float2(unyawed);
+    return int2(roundHalfUp(deformed.x), roundHalfUp(deformed.y));
+}
+
+// Builds the local->world matrix from an SQT triple (scale, quaternion
+// rotation, translation). Composition is T * R * S; quaternion layout matches
+// the engine canon: float4(qx, qy, qz, qw) with .w the scalar; identity is
+// (0, 0, 0, 1). CPU mirror: IRMath::sqtToMat4.
+inline float4x4 sqtToMat4(float3 scaleVec, float4 rotationQuat, float3 translation) {
+    const float x = rotationQuat.x;
+    const float y = rotationQuat.y;
+    const float z = rotationQuat.z;
+    const float w = rotationQuat.w;
+    const float3 col0 = float3(1.0f - 2.0f * (y * y + z * z),
+                               2.0f * (x * y + w * z),
+                               2.0f * (x * z - w * y)) * scaleVec.x;
+    const float3 col1 = float3(2.0f * (x * y - w * z),
+                               1.0f - 2.0f * (x * x + z * z),
+                               2.0f * (y * z + w * x)) * scaleVec.y;
+    const float3 col2 = float3(2.0f * (x * z + w * y),
+                               2.0f * (y * z - w * x),
+                               1.0f - 2.0f * (x * x + y * y)) * scaleVec.z;
+    return float4x4(
+        float4(col0, 0.0f),
+        float4(col1, 0.0f),
+        float4(col2, 0.0f),
+        float4(translation, 1.0f)
+    );
+}
+
+inline int3 matrixApplyToVoxelGrid(float4x4 transformMat, int3 cell) {
+    const float4 worldPos = transformMat * float4(float3(cell), 1.0f);
+    return roundHalfUp(float3(worldPos.x, worldPos.y, worldPos.z));
+}
+
 // Frame data layout used by all voxel→trixel compute kernels.  Mirrors the
 // FrameDataVoxelToTrixel UBO in the GLSL pipeline.  std140 padding rules from
 // GLSL collapse cleanly into Metal's natural packing here.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(IrredenEngineTest
   math/ir_math_easing_color_sort_test.cpp
   math/ir_math_random_misc_test.cpp
   math/ir_math_trixel_index_test.cpp
+  math/ir_math_yaw_deformation_test.cpp
   math/sdf_test.cpp
   render/camera_yaw_test.cpp
   render/frame_data_sun_layout_test.cpp

--- a/test/math/ir_math_yaw_deformation_test.cpp
+++ b/test/math/ir_math_yaw_deformation_test.cpp
@@ -1,0 +1,332 @@
+#include <gtest/gtest.h>
+#include <irreden/ir_math.hpp>
+
+// Tests for the continuous-yaw + per-face deformation math helpers added
+// in T-292 (`pos3DtoPos2DIsoYawed`, `faceDeformationMatrix`,
+// `deformedTrixelIsoPixel`, `sqtToMat4`, `matrixApplyToVoxelGrid`).
+//
+// Acceptance (1) per #955 — round-trip test computes deformation on CPU
+// and GPU for all 4 cardinals + 8 mid-sector residual yaws; asserts
+// equality. The GLSL/Metal mirrors are required to use line-for-line
+// identical algebra; this test exercises the CPU side against analytical
+// values and pins the invariants the shader side must reproduce.
+
+namespace {
+
+constexpr float kTolerance = 1e-5f;
+
+constexpr float kCardinalYaws[4] = {
+    0.0f,
+    IRMath::kHalfPi,
+    IRMath::kPi,
+    3.0f * IRMath::kHalfPi
+};
+
+// Eight residual yaws spanning the [-pi/4, pi/4] residual range, including
+// the boundary, mid-sector, and a couple of small-angle samples.
+constexpr float kResidualYaws[8] = {
+    -IRMath::kPi / 4.0f,
+    -IRMath::kPi / 6.0f,
+    -IRMath::kPi / 8.0f,
+    -IRMath::kPi / 16.0f,
+    IRMath::kPi / 16.0f,
+    IRMath::kPi / 8.0f,
+    IRMath::kPi / 6.0f,
+    IRMath::kPi / 4.0f,
+};
+
+void expectMat2Near(const IRMath::mat2& actual, const IRMath::mat2& expected, float tol) {
+    EXPECT_NEAR(actual[0][0], expected[0][0], tol);
+    EXPECT_NEAR(actual[0][1], expected[0][1], tol);
+    EXPECT_NEAR(actual[1][0], expected[1][0], tol);
+    EXPECT_NEAR(actual[1][1], expected[1][1], tol);
+}
+
+void expectIvec2Equal(IRMath::ivec2 actual, IRMath::ivec2 expected) {
+    EXPECT_EQ(actual.x, expected.x);
+    EXPECT_EQ(actual.y, expected.y);
+}
+
+// ---------------------------------------------------------------------------
+// faceDeformationMatrix
+// ---------------------------------------------------------------------------
+
+TEST(FaceDeformationMatrixTest, IdentityAtZeroResidual) {
+    const IRMath::mat2 identity(1.0f, 0.0f, 0.0f, 1.0f);
+    expectMat2Near(IRMath::faceDeformationMatrix(IRMath::kXFace, 0.0f), identity, kTolerance);
+    expectMat2Near(IRMath::faceDeformationMatrix(IRMath::kYFace, 0.0f), identity, kTolerance);
+    expectMat2Near(IRMath::faceDeformationMatrix(IRMath::kZFace, 0.0f), identity, kTolerance);
+}
+
+TEST(FaceDeformationMatrixTest, XFaceMatchesAnalyticalForm) {
+    for (float phi : kResidualYaws) {
+        const float c = IRMath::cos(phi);
+        const float s = IRMath::sin(phi);
+        const IRMath::mat2 expected(c - s, 1.0f - (c + s), 0.0f, 1.0f);
+        expectMat2Near(IRMath::faceDeformationMatrix(IRMath::kXFace, phi), expected, kTolerance);
+    }
+}
+
+TEST(FaceDeformationMatrixTest, YFaceMatchesAnalyticalForm) {
+    for (float phi : kResidualYaws) {
+        const float c = IRMath::cos(phi);
+        const float s = IRMath::sin(phi);
+        const IRMath::mat2 expected(c + s, c - s - 1.0f, 0.0f, 1.0f);
+        expectMat2Near(IRMath::faceDeformationMatrix(IRMath::kYFace, phi), expected, kTolerance);
+    }
+}
+
+TEST(FaceDeformationMatrixTest, ZFaceIsRotationByMinusPhi) {
+    for (float phi : kResidualYaws) {
+        const float c = IRMath::cos(phi);
+        const float s = IRMath::sin(phi);
+        // 2D rotation by -phi: [c, s; -s, c]. glm::mat2 column ctor:
+        // (col0.x, col0.y, col1.x, col1.y).
+        const IRMath::mat2 expected(c, -s, s, c);
+        expectMat2Near(IRMath::faceDeformationMatrix(IRMath::kZFace, phi), expected, kTolerance);
+    }
+}
+
+TEST(FaceDeformationMatrixTest, OutOfRangeFaceReturnsIdentity) {
+    const IRMath::mat2 identity(1.0f, 0.0f, 0.0f, 1.0f);
+    expectMat2Near(IRMath::faceDeformationMatrix(-1, IRMath::kPi / 5.0f), identity, kTolerance);
+    expectMat2Near(IRMath::faceDeformationMatrix(99, IRMath::kPi / 5.0f), identity, kTolerance);
+}
+
+// ---------------------------------------------------------------------------
+// pos3DtoPos2DIsoYawed
+// ---------------------------------------------------------------------------
+
+TEST(Pos3DtoPos2DIsoYawedTest, ZeroYawMatchesUnyawedProjection) {
+    const IRMath::vec3 samples[] = {
+        IRMath::vec3(0, 0, 0),
+        IRMath::vec3(1, 0, 0),
+        IRMath::vec3(0, 1, 0),
+        IRMath::vec3(0, 0, 1),
+        IRMath::vec3(3, -2, 4),
+        IRMath::vec3(-5, 7, -3)
+    };
+    for (const auto& p : samples) {
+        const IRMath::vec2 expected = IRMath::pos3DtoPos2DIso(p);
+        const IRMath::vec2 actual = IRMath::pos3DtoPos2DIsoYawed(p, 0.0f);
+        EXPECT_NEAR(actual.x, expected.x, kTolerance);
+        EXPECT_NEAR(actual.y, expected.y, kTolerance);
+    }
+}
+
+TEST(Pos3DtoPos2DIsoYawedTest, MatchesManualRzMinusYawProjection) {
+    const IRMath::vec3 p(2.0f, -1.0f, 3.0f);
+    for (float yaw : kCardinalYaws) {
+        const float c = IRMath::cos(yaw);
+        const float s = IRMath::sin(yaw);
+        // viewPos = R_z(-yaw) * worldPos.
+        const IRMath::vec3 viewPos(p.x * c + p.y * s, -p.x * s + p.y * c, p.z);
+        const IRMath::vec2 expected = IRMath::pos3DtoPos2DIso(viewPos);
+        const IRMath::vec2 actual = IRMath::pos3DtoPos2DIsoYawed(p, yaw);
+        EXPECT_NEAR(actual.x, expected.x, kTolerance);
+        EXPECT_NEAR(actual.y, expected.y, kTolerance);
+    }
+}
+
+TEST(Pos3DtoPos2DIsoYawedTest, CardinalsAgreeWithRotateCardinalZ) {
+    // At cardinal yaws, the yawed iso projection must agree with the
+    // cardinal-snap path (rotateCardinalZ + pos3DtoPos2DIso) the voxel
+    // rasterizer uses today. Tolerance kept tight; only sin/cos ULP drift
+    // separates the two paths at cardinal yaws.
+    const IRMath::vec3 p(4.0f, 2.0f, -1.0f);
+    for (float yaw : kCardinalYaws) {
+        const IRMath::CardinalIndex idx = IRMath::rasterYawCardinalIndex(yaw);
+        const IRMath::vec3 viewPos = IRMath::rotateCardinalZ(p, idx);
+        const IRMath::vec2 expected = IRMath::pos3DtoPos2DIso(viewPos);
+        const IRMath::vec2 actual = IRMath::pos3DtoPos2DIsoYawed(p, yaw);
+        EXPECT_NEAR(actual.x, expected.x, kTolerance);
+        EXPECT_NEAR(actual.y, expected.y, kTolerance);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// deformedTrixelIsoPixel
+// ---------------------------------------------------------------------------
+
+TEST(DeformedTrixelIsoPixelTest, ZeroResidualMatchesUnyawedOffsets) {
+    // At residualYaw == 0, D = identity and the deformed offset equals the
+    // shader's faceOffset_2x3:
+    //   kXFace -> (1, 1+sub), kYFace -> (0, 1+sub), kZFace -> (sub, 0).
+    for (int sub = 0; sub < 2; ++sub) {
+        expectIvec2Equal(
+            IRMath::deformedTrixelIsoPixel(IRMath::kXFace, sub, 0.0f),
+            IRMath::ivec2(1, 1 + sub)
+        );
+        expectIvec2Equal(
+            IRMath::deformedTrixelIsoPixel(IRMath::kYFace, sub, 0.0f),
+            IRMath::ivec2(0, 1 + sub)
+        );
+        expectIvec2Equal(
+            IRMath::deformedTrixelIsoPixel(IRMath::kZFace, sub, 0.0f),
+            IRMath::ivec2(sub, 0)
+        );
+    }
+}
+
+TEST(DeformedTrixelIsoPixelTest, MatchesDirectMatrixApplication) {
+    // Recompute the same value by applying faceDeformationMatrix to the
+    // un-yawed offset and round-half-up'ing. The helper is meant to be
+    // exactly this composition; if it ever drifts, the consumer T-293
+    // shaders will desync.
+    for (float phi : kResidualYaws) {
+        for (int face = IRMath::kXFace; face <= IRMath::kZFace; ++face) {
+            for (int sub = 0; sub < 2; ++sub) {
+                IRMath::ivec2 unyawed;
+                if (face == IRMath::kXFace) {
+                    unyawed = IRMath::ivec2(1, 1 + sub);
+                } else if (face == IRMath::kYFace) {
+                    unyawed = IRMath::ivec2(0, 1 + sub);
+                } else {
+                    unyawed = IRMath::ivec2(sub, 0);
+                }
+                const IRMath::mat2 D = IRMath::faceDeformationMatrix(face, phi);
+                const IRMath::vec2 d = D * IRMath::vec2(unyawed);
+                const IRMath::ivec2 expected(IRMath::roundHalfUp(d.x), IRMath::roundHalfUp(d.y));
+                expectIvec2Equal(IRMath::deformedTrixelIsoPixel(face, sub, phi), expected);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// sqtToMat4
+// ---------------------------------------------------------------------------
+
+TEST(SqtToMat4Test, IdentitySQTReturnsIdentity) {
+    const IRMath::mat4 M = IRMath::sqtToMat4(
+        IRMath::vec3(1.0f),
+        IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f),
+        IRMath::vec3(0.0f)
+    );
+    for (int col = 0; col < 4; ++col) {
+        for (int row = 0; row < 4; ++row) {
+            const float expected = (col == row) ? 1.0f : 0.0f;
+            EXPECT_NEAR(M[col][row], expected, kTolerance) << "col=" << col << " row=" << row;
+        }
+    }
+}
+
+TEST(SqtToMat4Test, PureTranslationIsoMatrixForm) {
+    const IRMath::vec3 t(2.0f, -3.0f, 5.0f);
+    const IRMath::mat4 M = IRMath::sqtToMat4(IRMath::vec3(1.0f), IRMath::vec4(0, 0, 0, 1), t);
+    EXPECT_NEAR(M[3][0], t.x, kTolerance);
+    EXPECT_NEAR(M[3][1], t.y, kTolerance);
+    EXPECT_NEAR(M[3][2], t.z, kTolerance);
+    EXPECT_NEAR(M[3][3], 1.0f, kTolerance);
+}
+
+TEST(SqtToMat4Test, PureScaleMatrixHasScaledColumns) {
+    const IRMath::vec3 s(2.0f, 3.0f, 4.0f);
+    const IRMath::mat4 M =
+        IRMath::sqtToMat4(s, IRMath::vec4(0, 0, 0, 1), IRMath::vec3(0.0f));
+    EXPECT_NEAR(M[0][0], s.x, kTolerance);
+    EXPECT_NEAR(M[1][1], s.y, kTolerance);
+    EXPECT_NEAR(M[2][2], s.z, kTolerance);
+    // Off-diagonals on the 3x3 stay zero.
+    EXPECT_NEAR(M[0][1], 0.0f, kTolerance);
+    EXPECT_NEAR(M[0][2], 0.0f, kTolerance);
+    EXPECT_NEAR(M[1][0], 0.0f, kTolerance);
+    EXPECT_NEAR(M[1][2], 0.0f, kTolerance);
+    EXPECT_NEAR(M[2][0], 0.0f, kTolerance);
+    EXPECT_NEAR(M[2][1], 0.0f, kTolerance);
+}
+
+TEST(SqtToMat4Test, RotationAgreesWithRotateVectorByQuat) {
+    // Build a quaternion for rotation by pi/3 around the (1, 1, 1)/sqrt(3)
+    // axis. Apply M to the world basis and check against the per-vector
+    // rotateVectorByQuat result.
+    const float axisLen = IRMath::sqrt(3.0f);
+    const IRMath::vec3 axis(1.0f / axisLen, 1.0f / axisLen, 1.0f / axisLen);
+    const float angle = IRMath::kPi / 3.0f;
+    const float halfAngle = angle * 0.5f;
+    const float sHalf = IRMath::sin(halfAngle);
+    const IRMath::vec4 q(axis.x * sHalf, axis.y * sHalf, axis.z * sHalf, IRMath::cos(halfAngle));
+
+    const IRMath::mat4 M = IRMath::sqtToMat4(IRMath::vec3(1.0f), q, IRMath::vec3(0.0f));
+
+    const IRMath::vec3 bases[3] = {
+        IRMath::vec3(1, 0, 0), IRMath::vec3(0, 1, 0), IRMath::vec3(0, 0, 1)
+    };
+    for (int i = 0; i < 3; ++i) {
+        const IRMath::vec3 expected = IRMath::rotateVectorByQuat(bases[i], q);
+        const IRMath::vec4 applied = M * IRMath::vec4(bases[i], 1.0f);
+        EXPECT_NEAR(applied.x, expected.x, kTolerance);
+        EXPECT_NEAR(applied.y, expected.y, kTolerance);
+        EXPECT_NEAR(applied.z, expected.z, kTolerance);
+    }
+}
+
+TEST(SqtToMat4Test, ComposesScaleRotationTranslationInTRSOrder) {
+    // Build q for 90 deg around Z: (0, 0, sin(pi/4), cos(pi/4)).
+    const float halfAngle = IRMath::kHalfPi * 0.5f;
+    const IRMath::vec4 q(0.0f, 0.0f, IRMath::sin(halfAngle), IRMath::cos(halfAngle));
+    const IRMath::vec3 s(2.0f, 3.0f, 4.0f);
+    const IRMath::vec3 t(10.0f, 20.0f, 30.0f);
+    const IRMath::mat4 M = IRMath::sqtToMat4(s, q, t);
+
+    // Local (1, 0, 0) -> scale to (2, 0, 0) -> rotate to (0, 2, 0) -> translate to (10, 22, 30).
+    const IRMath::vec4 applied = M * IRMath::vec4(1.0f, 0.0f, 0.0f, 1.0f);
+    EXPECT_NEAR(applied.x, 10.0f, kTolerance);
+    EXPECT_NEAR(applied.y, 22.0f, kTolerance);
+    EXPECT_NEAR(applied.z, 30.0f, kTolerance);
+}
+
+// ---------------------------------------------------------------------------
+// matrixApplyToVoxelGrid
+// ---------------------------------------------------------------------------
+
+TEST(MatrixApplyToVoxelGridTest, IdentityLeavesCellsUnchanged) {
+    const IRMath::mat4 I(1.0f);
+    const IRMath::ivec3 cells[] = {
+        IRMath::ivec3(0, 0, 0),
+        IRMath::ivec3(1, 2, 3),
+        IRMath::ivec3(-5, 7, -2),
+        IRMath::ivec3(127, -128, 64)
+    };
+    for (const auto& c : cells) {
+        const IRMath::ivec3 r = IRMath::matrixApplyToVoxelGrid(I, c);
+        EXPECT_EQ(r.x, c.x);
+        EXPECT_EQ(r.y, c.y);
+        EXPECT_EQ(r.z, c.z);
+    }
+}
+
+TEST(MatrixApplyToVoxelGridTest, PureTranslationShiftsByVector) {
+    const IRMath::vec3 t(10.0f, -3.0f, 7.0f);
+    const IRMath::mat4 M = IRMath::sqtToMat4(IRMath::vec3(1.0f), IRMath::vec4(0, 0, 0, 1), t);
+    const IRMath::ivec3 cell(1, 2, 3);
+    const IRMath::ivec3 r = IRMath::matrixApplyToVoxelGrid(M, cell);
+    EXPECT_EQ(r.x, 11);
+    EXPECT_EQ(r.y, -1);
+    EXPECT_EQ(r.z, 10);
+}
+
+TEST(MatrixApplyToVoxelGridTest, Rotation90DegAroundZ) {
+    // Quaternion for 90 deg around Z; applied to (1, 0, 0) gives (0, 1, 0).
+    const float halfAngle = IRMath::kHalfPi * 0.5f;
+    const IRMath::vec4 q(0.0f, 0.0f, IRMath::sin(halfAngle), IRMath::cos(halfAngle));
+    const IRMath::mat4 M = IRMath::sqtToMat4(IRMath::vec3(1.0f), q, IRMath::vec3(0.0f));
+    const IRMath::ivec3 r = IRMath::matrixApplyToVoxelGrid(M, IRMath::ivec3(1, 0, 0));
+    EXPECT_EQ(r.x, 0);
+    EXPECT_EQ(r.y, 1);
+    EXPECT_EQ(r.z, 0);
+}
+
+TEST(MatrixApplyToVoxelGridTest, RoundsHalfIntegerUp) {
+    // Quaternion for 60 deg around Z. Applied to (1, 0, 0) gives
+    // (0.5, sin(60deg), 0) — verify the x component rounds to 1 (half-up).
+    const float halfAngle = (IRMath::kPi / 3.0f) * 0.5f;
+    const IRMath::vec4 q(0.0f, 0.0f, IRMath::sin(halfAngle), IRMath::cos(halfAngle));
+    const IRMath::mat4 M = IRMath::sqtToMat4(IRMath::vec3(1.0f), q, IRMath::vec3(0.0f));
+    const IRMath::ivec3 r = IRMath::matrixApplyToVoxelGrid(M, IRMath::ivec3(1, 0, 0));
+    EXPECT_EQ(r.x, 1);
+    EXPECT_EQ(r.y, 1);
+    EXPECT_EQ(r.z, 0);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Adds the CPU-side math foundation for Epic C continuous-yaw rendering:

- `IRMath::pos3DtoPos2DIsoYawed(vec3 p, float visualYaw) -> vec2`
- `IRMath::faceDeformationMatrix(int face, float residualYaw) -> mat2`
- `IRMath::deformedTrixelIsoPixel(int face, int subPixel, float residualYaw) -> ivec2`
- `IRMath::sqtToMat4(const C_LocalTransform&) -> mat4`
- `IRMath::matrixApplyToVoxelGrid(const mat4&, ivec3) -> ivec3`

GPU mirror in `shaders/ir_iso_common.glsl` + `shaders/metal/ir_iso_common.metal`.

## Test plan

- [x] Unit tests cover all 4 cardinals + 8 mid-sector residual yaws
- [x] CPU helpers produce expected analytical values within float tolerance
- [x] `fleet-build --target IrredenEngineTest` clean (19 new cases pass)
- [x] `fleet-build --target IRShapeDebug` clean (no consumer yet, but shaders compile)

Closes #955