### PR TITLE
perf: scripts/perf/ matrix harness + perf_grid subdivision CLI flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ compile_commands.json
 .cache/
 CMakeUserPresets.json
 
+# runtime output from creations (profile reports, screenshots, perf matrix runs)
+save_files/
+
 # editor files: keep shareable config, ignore local state
 .vscode/*
 !.vscode/settings.json

--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -84,6 +84,10 @@ struct CliOverrides {
     int gridSize_ = 16;
     bool zoomSet_ = false;
     float zoom_ = 0.5f;
+    bool subdivisionModeSet_ = false;
+    IRRender::SubdivisionMode subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+    bool baseSubdivisionsSet_ = false;
+    int baseSubdivisions_ = 1;
 };
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
@@ -149,6 +153,31 @@ void parseArgs(int argc, char **argv) {
             if (zoom > 0.0f) {
                 g_cliOverrides.zoom_ = zoom;
                 g_cliOverrides.zoomSet_ = true;
+            }
+            ++i;
+        } else if (std::strcmp(argv[i], "--subdivision-mode") == 0 && i + 1 < argc) {
+            std::string mode = argv[i + 1];
+            if (mode == "none") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::NONE;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else if (mode == "position_only") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::POSITION_ONLY;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else if (mode == "full") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else {
+                IR_LOG_WARN(
+                    "Unknown --subdivision-mode '{}'; expected none|position_only|full",
+                    mode
+                );
+            }
+            ++i;
+        } else if (std::strcmp(argv[i], "--base-subdivisions") == 0 && i + 1 < argc) {
+            int sub = std::atoi(argv[i + 1]);
+            if (sub > 0) {
+                g_cliOverrides.baseSubdivisions_ = sub;
+                g_cliOverrides.baseSubdivisionsSet_ = true;
             }
             ++i;
         }
@@ -440,6 +469,12 @@ int main(int argc, char **argv) {
     IREngine::init(argv[0]);
     if (g_autoProfileFrames > 0) {
         IREngine::enableFrameTiming(true);
+    }
+    if (g_cliOverrides.subdivisionModeSet_) {
+        IRRender::setSubdivisionMode(g_cliOverrides.subdivisionMode_);
+    }
+    if (g_cliOverrides.baseSubdivisionsSet_) {
+        IRRender::setVoxelRenderSubdivisions(g_cliOverrides.baseSubdivisions_);
     }
     IREngine::gameLoop();
     return 0;

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -107,6 +107,10 @@ struct CliOverrides {
     float zoom_ = 0.5f;
     bool waveAmplitudeSet_ = false;
     float waveAmplitude_ = 0.0f;
+    bool subdivisionModeSet_ = false;
+    IRRender::SubdivisionMode subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+    bool baseSubdivisionsSet_ = false;
+    int baseSubdivisions_ = 1;
 };
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
@@ -229,6 +233,31 @@ void parseArgs(int argc, char **argv) {
             // isolating per-frame upload cost in profiler runs.
             g_cliOverrides.waveAmplitude_ = static_cast<float>(std::atof(argv[i + 1]));
             g_cliOverrides.waveAmplitudeSet_ = true;
+            ++i;
+        } else if (std::strcmp(argv[i], "--subdivision-mode") == 0 && i + 1 < argc) {
+            std::string mode = argv[i + 1];
+            if (mode == "none") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::NONE;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else if (mode == "position_only") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::POSITION_ONLY;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else if (mode == "full") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else {
+                IR_LOG_WARN(
+                    "Unknown --subdivision-mode '{}'; expected none|position_only|full",
+                    mode
+                );
+            }
+            ++i;
+        } else if (std::strcmp(argv[i], "--base-subdivisions") == 0 && i + 1 < argc) {
+            int sub = std::atoi(argv[i + 1]);
+            if (sub > 0) {
+                g_cliOverrides.baseSubdivisions_ = sub;
+                g_cliOverrides.baseSubdivisionsSet_ = true;
+            }
             ++i;
         }
     }
@@ -427,6 +456,13 @@ int main(int argc, char **argv) {
 
     if (g_autoProfileFrames > 0) {
         IREngine::enableFrameTiming(true);
+    }
+
+    if (g_cliOverrides.subdivisionModeSet_) {
+        IRRender::setSubdivisionMode(g_cliOverrides.subdivisionMode_);
+    }
+    if (g_cliOverrides.baseSubdivisionsSet_) {
+        IRRender::setVoxelRenderSubdivisions(g_cliOverrides.baseSubdivisions_);
     }
 
     initSystems();

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,0 +1,102 @@
+# docs/perf — perf measurement workflow
+
+This directory holds:
+
+- the **measurement scripts** index for the perf demos (`scripts/perf/`)
+- **committed baselines** for major perf phases (e.g. `metal_perf_grid_baseline.md`)
+- **per-PR diffs** when an optimization PR captures before/after data
+
+The day-to-day flow is run a matrix on master, run the same matrix on
+your dirty tree, diff the two — all three steps are scripts. No GUI
+profiler, no per-cell stopwatch.
+
+## The scripts
+
+| Script                                | What it does                                                           |
+|---------------------------------------|------------------------------------------------------------------------|
+| `scripts/perf/perf_grid_matrix.sh`    | Run `IRPerfGrid` (or `IRLuaPerfGrid`) across a zoom × subdivision matrix |
+| `scripts/perf/perf_summary.py`        | One-screen markdown summary of a single run                            |
+| `scripts/perf/compare_perf_runs.py`   | Diff two runs as a markdown table for the PR body                      |
+
+All scripts are stdlib-only and run from anywhere in the repo. The
+matrix script writes `save_files/perf/<git-sha>[-<label>]/` so multiple
+runs coexist without overwriting each other.
+
+## Canonical ritual: before/after a perf change
+
+```bash
+# 1. Capture baseline on master before you start.
+git checkout master
+git pull
+scripts/perf/perf_grid_matrix.sh --label baseline
+
+# 2. Switch to your feature branch and run the same matrix.
+git checkout claude/my-optimization
+scripts/perf/perf_grid_matrix.sh --label head
+
+# 3. Diff. The output is markdown — paste it into the PR body.
+scripts/perf/compare_perf_runs.py \
+    save_files/perf/<master-sha>-baseline \
+    save_files/perf/<head-sha>-head
+```
+
+If you only want a quick read on the current state:
+
+```bash
+scripts/perf/perf_grid_matrix.sh --quick
+scripts/perf/perf_summary.py save_files/perf/<sha>
+```
+
+## Matrix size knobs
+
+| Flag       | Cells | Typical use                                  |
+|------------|-------|----------------------------------------------|
+| `--quick`  | 2     | Smoke test, ~30s total                       |
+| (default)  | 12    | Routine PR comparison, ~3 min                |
+| `--full`   | 30    | Deep audit, ~10 min                          |
+
+Customize what to vary by editing the matrix arrays at the top of
+`perf_grid_matrix.sh` — keep the defaults narrow so PR runs stay fast.
+
+## CLI flags the scripts depend on
+
+`IRPerfGrid` and `IRLuaPerfGrid` accept these flags (used by the matrix
+script):
+
+- `--auto-profile <N>` — collect N frames of timing then exit; writes
+  `save_files/profile_report.txt`.
+- `--zoom <F>` — initial camera zoom (snapped to power of 2 in
+  `[kTrixelCanvasZoomMin, kTrixelCanvasZoomMax]`).
+- `--subdivision-mode <none|position_only|full>` — overrides the
+  world-config default for the run.
+- `--base-subdivisions <N>` — overrides `voxel_render_subdivisions`
+  (clamped 1..16 by the render manager).
+- `--mode <voxel_set|sdf>` (IRPerfGrid only) — voxel-pool vs SDF-only
+  geometry.
+- `--grid-size <N>` — overrides the demo's default grid size.
+
+The subdivision flags exist precisely so the matrix script can sweep
+them without editing config files.
+
+## Committed baselines
+
+When a major phase lands (Phase 1a GPU light volume, T-289 push-at-mutation,
+…), commit the matrix output as `docs/perf/baseline_<date>_<phase>.md`
+generated via `perf_summary.py`. Subsequent PRs diff against the most
+recent baseline. The older free-form file
+`docs/perf/metal_perf_grid_baseline.md` remains as historical context.
+
+## Where this is going
+
+A CI gate (`perf/baseline-ci-gate` issue) will eventually re-run the
+matrix on every PR touching `engine/render/`, `engine/system/`, or
+`engine/math/` and post `compare_perf_runs.py` output as a PR comment.
+Until that lands, the human author (or an `/optimize` skill run) does
+the comparison locally and pastes the markdown into the PR body.
+
+The current GPU timings use `glFinish()`-style synchronous bracketing
+(see `engine/prefabs/irreden/render/gpu_stage_timing.hpp`). That is
+accurate but adds a small per-frame overhead — keep `gpu_stage_timing`
+off in shipping builds, on during a matrix run. Replacing the sync path
+with async `GL_TIMESTAMP` / `MTLCounterSample` queries is tracked in
+the `perf/async-gpu-timers` issue.

--- a/scripts/perf/compare_perf_runs.py
+++ b/scripts/perf/compare_perf_runs.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""compare_perf_runs.py — diff two perf_grid_matrix output directories.
+
+Parses the plain-text profile_report.txt files written into both runs by
+perf_grid_matrix.sh and prints a markdown table suitable for pasting into
+a PR body. Highlights regressions (slower head) with ⚠ and improvements
+with ↓.
+
+Usage:
+    scripts/perf/compare_perf_runs.py <baseline_dir> <head_dir>
+        [--regress-pct N] [--improve-pct N] [--gpu-only] [--cpu-only]
+
+Both directories must contain manifest.json plus one .txt file per cell.
+Cells are matched by their "id" field; cells present in only one side
+appear in a separate "unmatched cells" section.
+
+Stdlib only — must run on any Python 3.9+ without extra deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+# --- Parser --------------------------------------------------------------
+
+FRAME_RE = re.compile(
+    r"Frame time:\s+avg=([\d.]+)ms\s+p50=([\d.]+)ms\s+p95=([\d.]+)ms\s+"
+    r"p99=([\d.]+)ms\s+min=([\d.]+)ms\s+max=([\d.]+)ms"
+)
+ENTITY_RE = re.compile(r"Entity count:\s+(\d+)\s+\((\d+)\s+archetypes\)")
+SYSTEM_RE = re.compile(
+    r"^(INPUT|UPDATE|RENDER)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+"
+    r"([\d.]+)\s+(\d+)\s+(\d+)"
+)
+GPU_RE = re.compile(r"^(\S+)\s+([\d.]+)\s+([\d.]+)\s*$")
+
+
+@dataclass
+class FrameTiming:
+    avg: float = 0.0
+    p50: float = 0.0
+    p95: float = 0.0
+    p99: float = 0.0
+    min_: float = 0.0
+    max_: float = 0.0
+
+
+@dataclass
+class SystemTiming:
+    pipeline: str
+    name: str
+    total_ms: float
+    avg_ms: float
+    min_ms: float
+    max_ms: float
+    calls: int
+    entities: int
+
+
+@dataclass
+class GpuStage:
+    name: str
+    avg_ms: float
+    max_ms: float
+
+
+@dataclass
+class CellReport:
+    cell_id: str
+    frame: FrameTiming = field(default_factory=FrameTiming)
+    entity_count: int = 0
+    archetype_count: int = 0
+    systems: List[SystemTiming] = field(default_factory=list)
+    gpu_stages: List[GpuStage] = field(default_factory=list)
+    raw: str = ""
+
+    def system_by_name(self, name: str) -> Optional[SystemTiming]:
+        for s in self.systems:
+            if s.name == name:
+                return s
+        return None
+
+    def gpu_by_name(self, name: str) -> Optional[GpuStage]:
+        for s in self.gpu_stages:
+            if s.name == name:
+                return s
+        return None
+
+
+def parse_report(path: Path, cell_id: str) -> CellReport:
+    report = CellReport(cell_id=cell_id)
+    if not path.exists():
+        return report
+    text = path.read_text()
+    report.raw = text
+
+    m = FRAME_RE.search(text)
+    if m:
+        report.frame = FrameTiming(
+            avg=float(m.group(1)),
+            p50=float(m.group(2)),
+            p95=float(m.group(3)),
+            p99=float(m.group(4)),
+            min_=float(m.group(5)),
+            max_=float(m.group(6)),
+        )
+
+    m = ENTITY_RE.search(text)
+    if m:
+        report.entity_count = int(m.group(1))
+        report.archetype_count = int(m.group(2))
+
+    # Section-aware scan so SYSTEM_RE and GPU_RE don't cross-match each
+    # other's rows (their token shapes are similar enough to confuse a
+    # full-file regex sweep).
+    section: Optional[str] = None
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("--- Per-system timing"):
+            section = "systems"
+            continue
+        if s.startswith("--- GPU stage timing"):
+            section = "gpu"
+            continue
+        if s.startswith("--- CPU phase timing"):
+            section = "cpu_phase"
+            continue
+        if s.startswith("=== END REPORT"):
+            section = None
+            continue
+        if not s or s.startswith("Pipeline") or s.startswith("Stage") or s.startswith("Phase"):
+            continue
+
+        if section == "systems":
+            m = SYSTEM_RE.match(s)
+            if m:
+                report.systems.append(SystemTiming(
+                    pipeline=m.group(1),
+                    name=m.group(2),
+                    total_ms=float(m.group(3)),
+                    avg_ms=float(m.group(4)),
+                    min_ms=float(m.group(5)),
+                    max_ms=float(m.group(6)),
+                    calls=int(m.group(7)),
+                    entities=int(m.group(8)),
+                ))
+        elif section == "gpu":
+            m = GPU_RE.match(s)
+            if m:
+                report.gpu_stages.append(GpuStage(
+                    name=m.group(1),
+                    avg_ms=float(m.group(2)),
+                    max_ms=float(m.group(3)),
+                ))
+    return report
+
+
+def load_run(run_dir: Path) -> Dict[str, CellReport]:
+    cells: Dict[str, CellReport] = {}
+    manifest = run_dir / "manifest.json"
+    if not manifest.exists():
+        print(f"compare_perf_runs: no manifest.json in {run_dir}", file=sys.stderr)
+        return cells
+    data = json.loads(manifest.read_text())
+    for cell in data.get("cells", []):
+        cell_id = cell.get("id")
+        if not cell_id:
+            continue
+        report_name = cell.get("report") or f"{cell_id}.txt"
+        cells[cell_id] = parse_report(run_dir / report_name, cell_id)
+    return cells
+
+
+# --- Comparator ----------------------------------------------------------
+
+def pct_delta(baseline: float, head: float) -> float:
+    if baseline <= 0.0:
+        return 0.0
+    return (head - baseline) / baseline * 100.0
+
+
+def mark(delta_pct: float, regress_pct: float, improve_pct: float) -> str:
+    if delta_pct >= regress_pct:
+        return " ⚠"
+    if delta_pct <= -improve_pct:
+        return " ↓"
+    return ""
+
+
+def format_frame_row(
+    cell_id: str,
+    base: CellReport,
+    head: CellReport,
+    regress_pct: float,
+    improve_pct: float,
+) -> str:
+    avg_b, avg_h = base.frame.avg, head.frame.avg
+    p99_b, p99_h = base.frame.p99, head.frame.p99
+    avg_delta = pct_delta(avg_b, avg_h)
+    p99_delta = pct_delta(p99_b, p99_h)
+    return (
+        f"| `{cell_id}` "
+        f"| {avg_b:.2f} → {avg_h:.2f} ({avg_delta:+.1f}%){mark(avg_delta, regress_pct, improve_pct)} "
+        f"| {p99_b:.2f} → {p99_h:.2f} ({p99_delta:+.1f}%){mark(p99_delta, regress_pct, improve_pct)} |"
+    )
+
+
+def collect_gpu_names(cells: Iterable[CellReport]) -> List[str]:
+    names: List[str] = []
+    seen = set()
+    for c in cells:
+        for s in c.gpu_stages:
+            if s.name not in seen:
+                seen.add(s.name)
+                names.append(s.name)
+    return names
+
+
+def render_markdown(
+    base_dir: Path,
+    head_dir: Path,
+    base: Dict[str, CellReport],
+    head: Dict[str, CellReport],
+    regress_pct: float,
+    improve_pct: float,
+    gpu_only: bool,
+    cpu_only: bool,
+) -> str:
+    out: List[str] = []
+    out.append(f"# perf comparison: {base_dir.name} → {head_dir.name}")
+    out.append("")
+    out.append(f"baseline: `{base_dir}`")
+    out.append(f"head:     `{head_dir}`")
+    out.append("")
+    out.append(f"thresholds: regress ≥ {regress_pct:.0f}%, improve ≥ {improve_pct:.0f}%")
+    out.append("")
+
+    matched = sorted(set(base) & set(head))
+    base_only = sorted(set(base) - set(head))
+    head_only = sorted(set(head) - set(base))
+
+    if not cpu_only:
+        out.append("## frame timing (ms)")
+        out.append("")
+        out.append("| cell | avg | p99 |")
+        out.append("|------|-----|-----|")
+        for cell_id in matched:
+            out.append(format_frame_row(cell_id, base[cell_id], head[cell_id], regress_pct, improve_pct))
+        out.append("")
+
+    if not cpu_only:
+        gpu_names = collect_gpu_names(list(base.values()) + list(head.values()))
+        if gpu_names:
+            out.append("## GPU stage timing (avg ms per frame)")
+            out.append("")
+            header = "| cell | " + " | ".join(gpu_names) + " |"
+            sep = "|------|" + "|".join(["----"] * len(gpu_names)) + "|"
+            out.append(header)
+            out.append(sep)
+            for cell_id in matched:
+                row = [f"`{cell_id}`"]
+                for name in gpu_names:
+                    sb = base[cell_id].gpu_by_name(name)
+                    sh = head[cell_id].gpu_by_name(name)
+                    if sb is None and sh is None:
+                        row.append("—")
+                        continue
+                    bv = sb.avg_ms if sb else 0.0
+                    hv = sh.avg_ms if sh else 0.0
+                    delta = pct_delta(bv, hv)
+                    row.append(f"{bv:.2f}→{hv:.2f}{mark(delta, regress_pct, improve_pct)}")
+                out.append("| " + " | ".join(row) + " |")
+            out.append("")
+
+    if not gpu_only:
+        out.append("## top CPU systems by avg ms (head)")
+        out.append("")
+        for cell_id in matched:
+            head_cell = head[cell_id]
+            base_cell = base[cell_id]
+            top = sorted(head_cell.systems, key=lambda s: s.avg_ms, reverse=True)[:8]
+            if not top:
+                continue
+            out.append(f"### `{cell_id}`")
+            out.append("")
+            out.append("| pipeline | system | avg ms (base→head) |")
+            out.append("|----------|--------|--------------------|")
+            for s in top:
+                sb = base_cell.system_by_name(s.name)
+                bv = sb.avg_ms if sb else 0.0
+                delta = pct_delta(bv, s.avg_ms)
+                out.append(
+                    f"| {s.pipeline} | `{s.name}` "
+                    f"| {bv:.3f} → {s.avg_ms:.3f} ({delta:+.1f}%){mark(delta, regress_pct, improve_pct)} |"
+                )
+            out.append("")
+
+    if base_only or head_only:
+        out.append("## unmatched cells")
+        out.append("")
+        if base_only:
+            out.append(f"only in baseline: {', '.join(f'`{c}`' for c in base_only)}")
+        if head_only:
+            out.append(f"only in head: {', '.join(f'`{c}`' for c in head_only)}")
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("baseline")
+    p.add_argument("head")
+    p.add_argument("--regress-pct", type=float, default=10.0)
+    p.add_argument("--improve-pct", type=float, default=5.0)
+    p.add_argument("--gpu-only", action="store_true")
+    p.add_argument("--cpu-only", action="store_true")
+    args = p.parse_args()
+
+    base_dir = Path(args.baseline).resolve()
+    head_dir = Path(args.head).resolve()
+
+    if not base_dir.is_dir() or not head_dir.is_dir():
+        print("compare_perf_runs: both arguments must be existing directories", file=sys.stderr)
+        return 2
+
+    base = load_run(base_dir)
+    head = load_run(head_dir)
+
+    if not base or not head:
+        print("compare_perf_runs: one of the runs has no cells", file=sys.stderr)
+        return 1
+
+    print(render_markdown(base_dir, head_dir, base, head,
+                          args.regress_pct, args.improve_pct,
+                          args.gpu_only, args.cpu_only), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf/compare_perf_runs.py
+++ b/scripts/perf/compare_perf_runs.py
@@ -325,6 +325,9 @@ def main() -> int:
     p.add_argument("--cpu-only", action="store_true")
     args = p.parse_args()
 
+    if args.gpu_only and args.cpu_only:
+        p.error("--gpu-only and --cpu-only are mutually exclusive")
+
     base_dir = Path(args.baseline).resolve()
     head_dir = Path(args.head).resolve()
 

--- a/scripts/perf/perf_grid_matrix.sh
+++ b/scripts/perf/perf_grid_matrix.sh
@@ -10,8 +10,8 @@
 #   scripts/perf/perf_grid_matrix.sh --target IRLuaPerfGrid
 #   scripts/perf/perf_grid_matrix.sh --label baseline    # output dir suffix
 #   scripts/perf/perf_grid_matrix.sh --frames 600        # frames per cell (default 300)
-#   scripts/perf/perf_grid_matrix.sh --full              # extended matrix (24 cells)
-#   scripts/perf/perf_grid_matrix.sh --quick             # smoke matrix (3 cells)
+#   scripts/perf/perf_grid_matrix.sh --full              # extended matrix (30 cells)
+#   scripts/perf/perf_grid_matrix.sh --quick             # smoke matrix (2 cells)
 #   scripts/perf/perf_grid_matrix.sh --grid-size 32      # smaller grid (default 64)
 #
 # Output:

--- a/scripts/perf/perf_grid_matrix.sh
+++ b/scripts/perf/perf_grid_matrix.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# perf_grid_matrix.sh — drive IRPerfGrid (or IRLuaPerfGrid) across a
+# matrix of (zoom × subdivision_mode × base_subdivisions) cells and
+# collect one save_files/profile_report.txt per cell into a single
+# output directory. Output is consumed by scripts/perf/compare_perf_runs.py
+# and scripts/perf/perf_summary.py.
+#
+# Usage:
+#   scripts/perf/perf_grid_matrix.sh                     # default 12-cell matrix, IRPerfGrid
+#   scripts/perf/perf_grid_matrix.sh --target IRLuaPerfGrid
+#   scripts/perf/perf_grid_matrix.sh --label baseline    # output dir suffix
+#   scripts/perf/perf_grid_matrix.sh --frames 600        # frames per cell (default 300)
+#   scripts/perf/perf_grid_matrix.sh --full              # extended matrix (24 cells)
+#   scripts/perf/perf_grid_matrix.sh --quick             # smoke matrix (3 cells)
+#   scripts/perf/perf_grid_matrix.sh --grid-size 32      # smaller grid (default 64)
+#
+# Output:
+#   save_files/perf/<git-sha>[-<label>]/<cell-id>.txt    # raw profile_report.txt
+#   save_files/perf/<git-sha>[-<label>]/manifest.json    # cell metadata + git state
+#
+# Cell ID format: target=<exe>,zoom=<z>,sub_mode=<m>,sub_base=<n>,grid=<g>
+#
+# Skills/agents: invoke this once before a change, once after, then
+# pass both output dirs to compare_perf_runs.py.
+
+set -euo pipefail
+
+_FLEET_COMMON_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../fleet" && pwd)/fleet-common.sh"
+if [[ -f "$_FLEET_COMMON_SH" ]]; then
+    # shellcheck source=../fleet/fleet-common.sh
+    source "$_FLEET_COMMON_SH"
+else
+    detect_engine_root() {
+        git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/src/IrredenEngine"
+    }
+fi
+
+ENGINE_ROOT="$(detect_engine_root)"
+TARGET="IRPerfGrid"
+LABEL=""
+FRAMES=300
+GRID_SIZE=""
+TIMEOUT=90
+MATRIX="default"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target) TARGET="$2"; shift 2 ;;
+        --label) LABEL="$2"; shift 2 ;;
+        --frames) FRAMES="$2"; shift 2 ;;
+        --grid-size) GRID_SIZE="$2"; shift 2 ;;
+        --timeout) TIMEOUT="$2"; shift 2 ;;
+        --full) MATRIX="full"; shift ;;
+        --quick) MATRIX="quick"; shift ;;
+        --default) MATRIX="default"; shift ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "perf_grid_matrix.sh: unknown arg '$1' (try --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$MATRIX" in
+    quick)
+        ZOOMS=(1 4)
+        SUB_MODES=(full)
+        SUB_BASES=(1)
+        ;;
+    default)
+        ZOOMS=(1 2 4 8)
+        SUB_MODES=(full position_only none)
+        SUB_BASES=(1)
+        ;;
+    full)
+        ZOOMS=(1 2 4 8 16)
+        SUB_MODES=(full position_only none)
+        SUB_BASES=(1 4)
+        ;;
+esac
+
+SHA="$(git -C "$ENGINE_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+DIRTY=""
+if ! git -C "$ENGINE_ROOT" diff --quiet 2>/dev/null; then
+    DIRTY="-dirty"
+fi
+RUN_NAME="${SHA}${DIRTY}"
+if [[ -n "$LABEL" ]]; then
+    RUN_NAME="${RUN_NAME}-${LABEL}"
+fi
+OUT_DIR="$ENGINE_ROOT/save_files/perf/$RUN_NAME"
+mkdir -p "$OUT_DIR"
+
+CELL_COUNT=$(( ${#ZOOMS[@]} * ${#SUB_MODES[@]} * ${#SUB_BASES[@]} ))
+echo "perf_grid_matrix: target=$TARGET matrix=$MATRIX cells=$CELL_COUNT frames=$FRAMES out=$OUT_DIR"
+
+if ! command -v fleet-run >/dev/null 2>&1; then
+    echo "perf_grid_matrix: fleet-run not on PATH; aborting" >&2
+    exit 1
+fi
+
+# The demo runs from its own build dir (via fleet-run), so the profile
+# report lands under build/creations/demos/<demo>/save_files/. Snapshot
+# mtime before each cell and copy the freshest profile_report.txt
+# afterwards — robust to whatever build dir layout fleet-run picks.
+BUILD_ROOT="$ENGINE_ROOT/build"
+find_latest_report() {
+    find "$BUILD_ROOT" -path "*/save_files/profile_report.txt" \
+        -newer "$1" -print 2>/dev/null | head -1
+}
+
+# manifest.json header — we append cell entries inside the loop.
+MANIFEST="$OUT_DIR/manifest.json"
+{
+    echo "{"
+    echo "  \"target\": \"$TARGET\","
+    echo "  \"matrix\": \"$MATRIX\","
+    echo "  \"frames\": $FRAMES,"
+    echo "  \"git_sha\": \"$SHA\","
+    echo "  \"git_dirty\": $([[ -n "$DIRTY" ]] && echo true || echo false),"
+    echo "  \"run_name\": \"$RUN_NAME\","
+    echo "  \"started_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+    echo "  \"cells\": ["
+} > "$MANIFEST"
+
+FIRST=1
+INDEX=0
+for ZOOM in "${ZOOMS[@]}"; do
+    for SUB_MODE in "${SUB_MODES[@]}"; do
+        for SUB_BASE in "${SUB_BASES[@]}"; do
+            INDEX=$((INDEX + 1))
+            CELL_ID="target=${TARGET},zoom=${ZOOM},sub_mode=${SUB_MODE},sub_base=${SUB_BASE}"
+            if [[ -n "$GRID_SIZE" ]]; then
+                CELL_ID="${CELL_ID},grid=${GRID_SIZE}"
+            fi
+            CELL_TXT="$OUT_DIR/${CELL_ID}.txt"
+            CELL_LOG="$OUT_DIR/${CELL_ID}.log"
+            echo "[$INDEX/$CELL_COUNT] $CELL_ID"
+
+            CELL_ARGS=(--auto-profile "$FRAMES" --zoom "$ZOOM"
+                       --subdivision-mode "$SUB_MODE"
+                       --base-subdivisions "$SUB_BASE")
+            if [[ -n "$GRID_SIZE" ]]; then
+                CELL_ARGS+=(--grid-size "$GRID_SIZE")
+            fi
+
+            MARKER="$OUT_DIR/.cell_marker"
+            touch "$MARKER"
+
+            STATUS=0
+            fleet-run --timeout "$TIMEOUT" "$TARGET" "${CELL_ARGS[@]}" \
+                > "$CELL_LOG" 2>&1 || STATUS=$?
+
+            REPORT="$(find_latest_report "$MARKER")"
+            if [[ -n "$REPORT" && -f "$REPORT" ]]; then
+                cp "$REPORT" "$CELL_TXT"
+                CELL_STATUS="ok"
+            else
+                CELL_STATUS="no_report"
+                echo "  (no profile_report.txt produced; see $CELL_LOG)"
+            fi
+
+            if [[ $FIRST -eq 1 ]]; then
+                FIRST=0
+            else
+                echo "," >> "$MANIFEST"
+            fi
+            cat >> "$MANIFEST" <<EOF
+    {"id": "$CELL_ID", "zoom": $ZOOM, "sub_mode": "$SUB_MODE", "sub_base": $SUB_BASE, "exit_status": $STATUS, "status": "$CELL_STATUS", "report": "${CELL_ID}.txt"}
+EOF
+        done
+    done
+done
+
+{
+    echo ""
+    echo "  ],"
+    echo "  \"finished_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\""
+    echo "}"
+} >> "$MANIFEST"
+
+echo "perf_grid_matrix: done, output in $OUT_DIR"
+echo "  next: scripts/perf/perf_summary.py $OUT_DIR"
+echo "  diff: scripts/perf/compare_perf_runs.py <baseline> $OUT_DIR"

--- a/scripts/perf/perf_summary.py
+++ b/scripts/perf/perf_summary.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""perf_summary.py — one-screen markdown summary of a perf_grid_matrix run.
+
+Reads <run_dir>/manifest.json and the per-cell profile_report.txt files,
+then prints a compact markdown table: cell, frame avg/p99, entity count,
+top GPU stage. Use this on its own when you don't have a baseline to
+diff against (e.g. first run on a fresh checkout).
+
+Usage:
+    scripts/perf/perf_summary.py <run_dir>
+
+Stdlib only — must run on any Python 3.9+ without extra deps.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PARENT = Path(__file__).resolve().parent
+sys.path.insert(0, str(_PARENT))
+from compare_perf_runs import load_run  # noqa: E402
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    run_dir = Path(sys.argv[1]).resolve()
+    if not run_dir.is_dir():
+        print(f"perf_summary: {run_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    cells = load_run(run_dir)
+    if not cells:
+        print("perf_summary: no cells found (missing manifest.json?)", file=sys.stderr)
+        return 1
+
+    print(f"# perf summary: {run_dir.name}")
+    print()
+    print(f"location: `{run_dir}`")
+    print(f"cells: {len(cells)}")
+    print()
+    print("| cell | frame avg | p99 | entities | top GPU stage |")
+    print("|------|-----------|-----|----------|---------------|")
+    for cell_id in sorted(cells):
+        c = cells[cell_id]
+        top_gpu = ""
+        if c.gpu_stages:
+            top = max(c.gpu_stages, key=lambda s: s.avg_ms)
+            top_gpu = f"`{top.name}` ({top.avg_ms:.2f}ms)"
+        print(
+            f"| `{cell_id}` | {c.frame.avg:.2f}ms | {c.frame.p99:.2f}ms "
+            f"| {c.entity_count} | {top_gpu} |"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR 1 of a multi-PR perf series. Pure measurement infrastructure — no engine code, no behavior change to default demo runs.

- `scripts/perf/perf_grid_matrix.sh` — drives `IRPerfGrid` / `IRLuaPerfGrid` across a zoom × subdivision_mode × base_subdivisions matrix via `fleet-run`, captures one `profile_report.txt` per cell + `manifest.json`. Matrix sizes: `--quick` (2 cells, ~30s), default (12, ~3 min), `--full` (30, ~10 min).
- `scripts/perf/compare_perf_runs.py` — stdlib-only diff between two matrix runs; emits markdown for the PR body (frame avg/p99 per cell, per-pass GPU table, top CPU systems). Flags regressions ≥10%, improvements ≥5% (configurable).
- `scripts/perf/perf_summary.py` — single-run summary when there's no baseline yet.
- `docs/perf/README.md` — workflow index + CLI dependency list.
- `IRPerfGrid` / `IRLuaPerfGrid` gain `--subdivision-mode <none|position_only|full>` and `--base-subdivisions <N>` so the matrix script can sweep without rewriting `world_config` between cells.
- `save_files/` → `.gitignore` (runtime output, never belongs in the repo).

Subsequent PRs in this series — visible-voxel-count instrumentation, then data-driven optimization PRs — will stack on this branch.

## Why now

The current perf-pass ritual is ad-hoc: run a demo, eyeball the FPS overlay, edit `world_config.lua` to vary subdivisions, re-run, eyeball again. A reproducible matrix + a markdown diff means every optimization PR can paste before/after numbers without anyone re-doing the work.

## Test plan

- [x] `fleet-build --target IRPerfGrid` clean (worktree, macos-debug)
- [x] `fleet-build --target IRLuaPerfGrid` clean
- [x] `fleet-build --target format-changed` clean
- [x] `scripts/perf/perf_grid_matrix.sh --quick --frames 60` runs end-to-end, produces 2 cells + manifest.json
- [x] `scripts/perf/perf_summary.py <run>` parses cells, prints markdown table
- [x] `scripts/perf/compare_perf_runs.py <run> <run>` self-diff shows 0% deltas
- [x] `--subdivision-mode none --base-subdivisions 4` propagates (log: `Voxel render mode=0, base_subdivisions=4, effective_subdivisions=1`)
- [ ] Reviewer: run `scripts/perf/perf_grid_matrix.sh --quick` on linux-debug and confirm the harness finds the build's `profile_report.txt`

## Notes for the reviewer

Screenshots not attached — diff touches `creations/demos/*/main*.cpp` (matches the visual-files glob in `commit-and-push`) but the change is pure CLI flag plumbing with no render path touched. Default demo behavior is byte-identical to master.

The text-format profile_report.txt parser is regex-based; a JSON sidecar in `engine/profile/` is a reasonable follow-up but out of scope here. The follow-up perf-infrastructure issues (`perf/async-gpu-timers`, `perf/baseline-ci-gate`, `perf/math-microbench`, `perf/lua-cpp-parity-tracking`) will be filed alongside the next PR in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)