### PR TITLE
fleet: separate worktree for queue-ingest to fix git race with queue-tick

### DIFF
--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -392,8 +392,9 @@ git worktree add -b fleet/opus-worker-2   .claude/worktrees/opus-worker-2   orig
 git worktree add -b fleet/sonnet-fleet-1  .claude/worktrees/sonnet-fleet-1  origin/master
 git worktree add -b fleet/sonnet-reviewer .claude/worktrees/sonnet-reviewer origin/master
 git worktree add -b fleet/opus-reviewer   .claude/worktrees/opus-reviewer   origin/master
-git worktree add -b fleet/queue-manager   .claude/worktrees/queue-manager   origin/master
-git worktree add -b fleet/merger          .claude/worktrees/merger          origin/master
+git worktree add -b fleet/queue-manager        .claude/worktrees/queue-manager        origin/master
+git worktree add -b fleet/queue-manager-ingest .claude/worktrees/queue-manager-ingest origin/master
+git worktree add -b fleet/merger               .claude/worktrees/merger               origin/master
 
 cd ~/src/IrredenEngine/creations/game
 git fetch origin master

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -29,7 +29,11 @@ ENGINE="${FLEET_ENGINE:-$HOME/src/IrredenEngine}"
 LOCK_DIR="${FLEET_QUEUE_INGEST_LOCK:-$HOME/.fleet/state/queue-ingest.lock}"
 LOG_FILE="$HOME/.fleet/logs/queue-ingest.log"
 PROJECTION_FILE="$HOME/.fleet/state/projections/queue-manager-ingest.json"
-QM_WT="$ENGINE/.claude/worktrees/queue-manager"
+# Dedicated worktree (fleet-queue-tick owns the queue-manager one). When
+# scout fires both on the same projection change, the shared .git/index.lock
+# races — queue-tick wins, queue-ingest's silenced checkout fails under
+# set -e, and the spent seen-hash strands the trigger. Provisioned by fleet-up.
+QM_WT="$ENGINE/.claude/worktrees/queue-manager-ingest"
 
 mkdir -p "$(dirname "$LOG_FILE")"
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -633,7 +633,7 @@ with open(settings_file, "w") as f:
 PYEOF
 }
 
-for wt in opus-architect opus-worker-1 opus-worker-2 sonnet-fleet-1 sonnet-fleet-2 sonnet-reviewer opus-reviewer queue-manager merger; do
+for wt in opus-architect opus-worker-1 opus-worker-2 sonnet-fleet-1 sonnet-fleet-2 sonnet-reviewer opus-reviewer queue-manager queue-manager-ingest merger; do
     write_worktree_settings "$ENGINE/.claude/worktrees/$wt" "$ENGINE"
 done
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -206,8 +206,9 @@ ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-1    fleet/sonnet-fleet
 ensure_worktree "$ENGINE" .claude/worktrees/sonnet-fleet-2    fleet/sonnet-fleet-2
 ensure_worktree "$ENGINE" .claude/worktrees/sonnet-reviewer   fleet/sonnet-reviewer
 ensure_worktree "$ENGINE" .claude/worktrees/opus-reviewer     fleet/opus-reviewer
-ensure_worktree "$ENGINE" .claude/worktrees/queue-manager     fleet/queue-manager
-ensure_worktree "$ENGINE" .claude/worktrees/merger            fleet/merger
+ensure_worktree "$ENGINE" .claude/worktrees/queue-manager        fleet/queue-manager
+ensure_worktree "$ENGINE" .claude/worktrees/queue-manager-ingest fleet/queue-manager-ingest
+ensure_worktree "$ENGINE" .claude/worktrees/merger               fleet/merger
 
 if [[ -d "$GAME/.git" ]]; then
     (cd "$GAME" && git fetch origin --quiet) || {
@@ -463,8 +464,9 @@ reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-1"  claude/sonnet-1-scrat
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-fleet-2"  claude/sonnet-2-scratch
 reset_worktree "$ENGINE/.claude/worktrees/sonnet-reviewer" claude/sonnet-reviewer-scratch
 reset_worktree "$ENGINE/.claude/worktrees/opus-reviewer"   claude/opus-reviewer-scratch
-reset_worktree "$ENGINE/.claude/worktrees/queue-manager"   claude/queue-manager-scratch
-reset_worktree "$ENGINE/.claude/worktrees/merger"          claude/merger-scratch
+reset_worktree "$ENGINE/.claude/worktrees/queue-manager"        claude/queue-manager-scratch
+reset_worktree "$ENGINE/.claude/worktrees/queue-manager-ingest" claude/queue-manager-ingest-scratch
+reset_worktree "$ENGINE/.claude/worktrees/merger"               claude/merger-scratch
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     reset_worktree "$GAME/.claude/worktrees/game-architect" claude/game-arch-scratch


### PR DESCRIPTION
## Summary
- When scout fires `queue-manager(queue-tick)` and `queue-manager-ingest(spawn)` on the same projection change, both scripts race on `.git/index.lock` in the shared `.claude/worktrees/queue-manager` worktree. queue-tick wins; queue-ingest's `>/dev/null 2>&1` checkout fails under `set -e`, the script dies before the first `log()` call, and the spent seen-hash strands the approved issues until manually cleared.
- Fix: give queue-ingest its own worktree (`.claude/worktrees/queue-manager-ingest`) so the two scripts run concurrently without contending. queue-tick keeps the original worktree (still used by the human-in-the-loop Cursor flow).
- The existing lock-contention `rm -f seen-hash` recovery from [commit d52ce270](https://github.com/jakildev/IrredenEngine/commit/d52ce270) still applies for the much narrower case of two queue-ingest spawns firing while one is mid-LLM-run.

## Root cause walkthrough
1. Scout at T0 detects the queue-manager-ingest projection has changed (new `human:approved` issue).
2. Scout writes the new seen-hash, then `subprocess.Popen` spawns `fleet-queue-ingest` (async, detached session).
3. Scout continues in the same tick and *also* fires queue-manager(queue-tick) — `fleet-queue-tick` Popens too.
4. Both scripts now race on `cd .claude/worktrees/queue-manager` + `git checkout -B fleet-queue-{tick,ingest} origin/master`.
5. queue-tick wins the `.git/index.lock`. queue-ingest's checkout fails — stderr swallowed by `>/dev/null 2>&1`, so `set -e` exits silently with no log line.
6. Trap removes the queue-ingest lockfile, leaving no trace. Scout has already written the seen-hash; nothing re-fires until the projection set changes again.

Empirical evidence from `~/.fleet/logs/state-scout.log` and `~/.fleet/logs/queue-ingest.log`: at `2026-05-21T18:10:44Z`, scout reported `spawned fleet-queue-ingest`, queue-tick logged its run, but the queue-ingest log was not touched. 7 approved issues sat stranded for ~10 minutes until the seen-hash was manually cleared.

## Why a separate worktree (not a shared outer lock)
A shared lock would serialize queue-tick (~3s mechanical sync) behind queue-ingest (~1–2 min LLM call). Cosmetic maintenance shouldn't block on the LLM. Separate worktrees keep them concurrent.

## Test plan
- [x] `python3 -m unittest scripts.fleet.tests.test_queue_manager_projection` — 11/11 pass.
- [x] Provisioned `.claude/worktrees/queue-manager-ingest` on the live fleet, cleared the stranded seen-hash, observed scout re-fire and `fleet-queue-ingest` run successfully in the new worktree (`lsof -p <pid>` confirmed cwd).
- [ ] Next `fleet-up` on a fresh checkout provisions the new worktree without prompting.

## Notes for reviewer
- `fleet-queue-ingest:32` — the new comment explains the race in 4 lines; intentionally compressed to match surrounding comment density.
- `fleet-up:209,467` — purely additive provisioning lines, no behavior change for existing worktrees.
- `docs/AGENT_FLEET_SETUP.md` — manual-setup walkthrough now lists the new worktree alongside the others.
- The role doc `.claude/commands/role-queue-manager.md` still references `worktrees/queue-manager` for the interactive Cursor flow — that's correct; only the autonomous spawn path moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)