### PR TITLE
skill: rewrite /optimize as script-first playbook + extracted reference

### DIFF
--- a/.claude/skills/optimize/SKILL.md
+++ b/.claude/skills/optimize/SKILL.md
@@ -18,241 +18,142 @@ description: >-
 
 # optimize
 
+A performance pass on freshly written or modified hot-path code.
+
+**This skill never tells you how to run a profiling step twice.** Every
+repeatable step is a script in `scripts/perf/`. The skill picks the
+script, runs it, reads the data, applies engine-specific fixes, and
+re-runs the same script to confirm the win. Engine knowledge that
+*doesn't* fit in a script lives in `reference/` files this skill points
+at — instrumentation recipes, the curated bottleneck catalog, partner
+skills, big-win case studies.
+
+If you find yourself writing prose instructions for the next agent on
+how to run profiling, stop — extract a script in `scripts/perf/` and
+have the skill call it. See [`reference/script_first.md`](reference/script_first.md)
+for the principle and where the boundary sits.
+
+## When to invoke
+
+Run optimize when the diff touches:
+
+- System tick functions (`engine/system/`, `engine/prefabs/irreden/.../systems/`, per-entity loops in creations)
+- Render pipeline stages (`engine/render/`, `engine/prefabs/irreden/render/`, shaders)
+- Audio / video processing (`engine/audio/`, `engine/video/`, ffmpeg paths, MIDI handling)
+- Math hot paths (`engine/math/` functions called from per-entity loops or per-pixel shader code)
+- Anything the author suspects is slow
+
+Skip optimize when the diff is tests, docs, build/CI, or pure refactors that preserve hot-path structure.
+
 ## Flow
 
-### 1. Identify the hot path
+### 1. Triage
 
 ```bash
 git diff --stat
 git diff
 ```
 
-For each touched file, ask:
-- Does this run per-frame?
-- Does this run per-entity inside a system tick?
-- Does this run per-pixel inside a shader?
-- Does this run per-sample in audio?
+Does any touched file run per-frame, per-entity, per-pixel, or per-sample? If yes → continue. Otherwise stop and let simplify run.
 
-If yes to any, that file is a candidate for profiling. Group
-candidates by **CPU-bound** (system ticks, math) and **GPU-bound**
-(shaders, dispatch sizes, frame buffer ops). Some changes are both.
+### 2. Baseline
 
-### 2. CPU profiling
-
-The engine has CPU profiling via `engine/profile/` — easy_profiler
-under the hood, exposed through the `IR_PROFILE_*` macros in
-`engine/profile/include/irreden/ir_profile.hpp`. Read
-`engine/profile/CLAUDE.md` for the full surface.
-
-**Instrument the hot path:**
-
-```cpp
-void IRSGlowPulse::tickEntity(C_GlowPulse& glow, C_Color& color) {
-    IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
-    // ... existing logic
-}
-```
-
-Wrap the **entry point** of the new code (system tick function,
-pipeline stage, audio callback). For inner sub-blocks worth
-isolating, use `IR_PROFILE_BLOCK("name", color)` / `IR_PROFILE_END_BLOCK`.
-
-Use the named `IR_PROFILER_COLOR_*` constants from
-`engine/profile/include/irreden/ir_profile.hpp` (`_RENDER`,
-`_ENTITY_OPS`, `_COMMANDS`, etc.). Every existing call site uses
-the named constants — raw ARGB hex literals are an anti-pattern.
-Pick the constant that matches the module of the system you're
-instrumenting; the colors group related blocks visually in the
-easy_profiler timeline.
-
-**Run with profiling enabled:**
+If the change touches `engine/render/`, `engine/prefabs/irreden/render/`, `engine/system/`, or a creation's hot path, capture a baseline before any code change:
 
 ```bash
-fleet-build --target <executable>
-fleet-run --timeout 15 <executable>
+scripts/perf/perf_grid_matrix.sh --label baseline
 ```
 
-`CPUProfiler::setEnabled(true)` is the runtime gate — check the
-creation's startup to confirm it's on, or temporarily enable in the
-demo's main.
+This writes one cell per `(zoom, sub_mode, sub_base)` combo into `save_files/perf/<sha>-baseline/`. The script is the canonical recipe — its `--help` lists the matrix sizes and target overrides. Don't paraphrase the flags in this skill or in PR bodies.
 
-The profiler dumps a `.prof` file when the executable exits. Open it
-with the `profiler_gui` tool from easy_profiler (the human runs this
-— you can't render the GUI from here). Ask the human for the
-hotspot read.
+For micro changes (one helper in `engine/math/`, one system tick body), `--quick` is enough — 2 cells, ~30s.
 
-If `IR_PROFILE_*` macros are no-ops (release build) or disabled at
-runtime, the run produces no data — switch the build to debug or
-re-enable the profiler before re-running.
+For broad changes, default matrix (12 cells, ~3 min) or `--full` (30 cells, ~10 min).
 
-### 3. GPU profiling
+### 3. Scan the diff for known smells
 
-The engine has **per-pass GPU stage timing** wired into the render
-pipeline. Every named GPU stage brackets its work with
-`device()->finish()` + `std::chrono::steady_clock` samples and writes
-the per-frame millisecond cost into `IRRender::gpuStageTiming()`.
+Cross-reference the diff against the curated catalog in [`reference/common_bottlenecks.md`](reference/common_bottlenecks.md). Each entry has the pattern, a file:line example from the codebase, the symptom in profiler output, and the canonical fix. Auto-flag any match.
 
-Enable it by setting `gpu_stage_timing = true` in the creation's
-`.irconf` file, or flip it at runtime from Lua:
+The catalog gets seeded with patterns this skill has found in prior runs. Step 7 below is where new patterns land.
 
-```lua
-ir.render.setGpuTimingEnabled(true)
--- ... let the scene render for a few frames ...
-local budget = ir.render.getFrameTimeBudgetMs()   -- 16.667
-for _, row in ipairs(ir.render.getPassTimings()) do
-    print(row.name, row.ms, row.budgetMs, row.overBudget)
-end
+### 4. Profile (if smell-scan was inconclusive)
+
+Two surfaces, both pointed at from this skill's references:
+
+- **CPU**: `IR_PROFILE_FUNCTION` / `IR_PROFILE_BLOCK` + easy_profiler — see [`reference/cpu_profiling.md`](reference/cpu_profiling.md).
+- **GPU**: per-stage timing via `ir.render.getPassTimings()` and `ir.render.getVoxelCullStats()` — see [`reference/gpu_profiling.md`](reference/gpu_profiling.md).
+
+The reference files have the instrumentation patterns. The skill body does not repeat them.
+
+### 5. Fix and re-measure
+
+Apply the fix. Then:
+
+```bash
+scripts/perf/perf_grid_matrix.sh --label head
+scripts/perf/compare_perf_runs.py \
+    save_files/perf/<baseline-sha>-baseline \
+    save_files/perf/<head-sha>-head
 ```
 
-`getPassTimings()` returns an ordered list of
-`{name, ms, budgetMs, budgetShare, overBudget}` rows; a row whose
-`overBudget` is true has exceeded its allocated slice of the 16.67 ms
-frame budget. `getPassTiming(name)` fetches a single pass by name.
+`compare_perf_runs.py` produces a markdown table with per-cell frame avg/p99, per-pass GPU breakdown, cull effectiveness, and top CPU systems. Flags regressions ≥10% and improvements ≥5% (configurable).
 
-When the flag is on, the end-of-run profile report
-(`save_files/profile_report.txt`) also includes the per-stage sum so
-pre/post A/B comparisons can be read from disk.
-
-Real async `GL_TIMESTAMP` / Metal counter-sample queries are not wired
-yet — the current path uses `glFinish()`-style stalls, which measure
-GPU cost accurately but at a small per-frame throughput cost. Default
-is **off**; leave it off in release runs. Turn it on while optimizing,
-then turn it off.
-
-Complementary tools when you need a finer single-frame view:
-
-- **RenderDoc / Xcode GPU capture** for a single-frame breakdown if
-  the human can run it (GUI tools; you can't drive them from here).
-  Tell the human which pass to focus on based on
-  `getPassTimings()` hot rows.
-- **Shader-side counters** as a proxy: a debug uniform incremented
-  per work-group, read back via SSBO, gives coarse "is this pass even
-  running" data.
-
-**Do not merge hot-path GPU work blind** — if a render PR's
-`getPassTimings()` output shows a pass over its budget share, either
-fix the regression or surface it explicitly in the PR body with
-before/after numbers.
-
-### 4. Engine-specific optimizations to check
-
-For **CPU hotspots** in system ticks:
-
-- Per-entity `getComponent<C_Foo>()` and allocation in per-entity paths — see [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md) for the full pattern catalogue. After applying the fix, re-run the benchmark to verify the measured ms improvement.
-- `std::map` / `std::unordered_map` lookups in the inner loop →
-  replace with a flat array indexed by entity ID, or move the
-  lookup outside the loop.
-- Virtual dispatch in the inner loop → if the type is known at
-  compile time, devirtualize via templates.
-
-For **GPU hotspots**:
-
-- Hand-rolled compute dispatch sizes → use
-  `voxelDispatchGridForCount()`. Wrong dispatch sizes either waste
-  workgroups (overestimate) or miss work (underestimate).
-- Compute shader workgroup-size mismatch with the dispatched size —
-  read the shader's `layout(local_size_x = ...)` and confirm the CPU
-  side's dispatch math accounts for it.
-- Excessive uniform block updates per frame → batch into one update.
-- Texture-format mismatch causing implicit conversions in the
-  fragment shader.
-- Read-back via `glReadPixels` or `glGetBufferSubData` synchronously
-  — kills the frame, force a fence + multi-frame ringbuffer instead.
-
-For **shader hot paths**:
-
-- Repeated math sequences across multiple shaders that should be in
-  a shared `.glsl` include (e.g. `ir_iso_common.glsl` for iso
-  projection math).
-- Per-pixel work that could be per-vertex — move it.
-- Branchy conditionals on a uniform value → consider a permutation.
-
-### 5. Measure, don't guess
-
-For each change you make based on profiling, **re-run the same
-benchmark** and confirm the improvement. A "fix" that doesn't move
-the needle isn't an optimization — revert it and look elsewhere.
-Pre/post numbers belong in the PR body so the reviewer doesn't have
-to re-profile.
-
-If pre/post measurement isn't possible (e.g. GPU pass without timer
-queries), say so explicitly in the PR — never claim "this is faster"
-without numbers.
+**A fix that doesn't move the needle isn't an optimization.** Revert it and look elsewhere.
 
 ### 6. Report
 
-Print a compact summary:
+Paste the `compare_perf_runs.py` output into the PR body. The skill's own report is six lines:
 
 ```
 optimize: <N> hot-path file(s) profiled
-  CPU hotspots:
-    - <path:line> — <function> — <ms before> → <ms after> (<change>)
-    - ...
-  GPU hotspots:
-    - <pass name> — <observation> — <action taken or blocker>
-  applied <X> optimization(s)
-  reported <Y> finding(s) needing more measurement
-  baselines: <link to docs/perf-reports/ entry, if added>
+  CPU hotspots: <count fixed> / <count flagged>
+  GPU hotspots: <count fixed> / <count flagged>
+  matrix delta: <best-case improvement> at <cell>
+  worst regression: <pp> at <cell>
+  reference updates: <appended bottleneck patterns>
 ```
 
-If the touched code didn't actually need optimization (after
-profiling, no hotspot), say so — the value here is the confidence,
-not the changes.
+If profiling found no hotspot, say so — the value here is the confidence, not the changes.
+
+### 7. Self-improve (mandatory)
+
+**This is what makes the skill compound.** Every run that finds a new bottleneck pattern, a new partner-skill cross-ref, or a new repeatable profiling step **must** update the reference in the same PR as the optimization fix:
+
+- New pattern → append to [`reference/common_bottlenecks.md`](reference/common_bottlenecks.md) with file:line example, symptom, and fix sketch.
+- New repeatable shell sequence → extract to `scripts/perf/<name>.{sh,py}` and have this skill point at it. Don't grow `SKILL.md` prose.
+- New partner skill found useful → add a line to [`reference/partner_skills.md`](reference/partner_skills.md).
+- New big win (>5% frame time at the worst-case matrix cell) → add a short case study to [`reference/big_wins.md`](reference/big_wins.md) with the PR link.
+
+If a step was hard, the next agent should have it as a script or a reference entry. The reference grows; the playbook stays small.
 
 ## Coordinating with simplify
 
-Run optimize **first** when the change is performance-relevant.
+Optimize runs **first** when the change is performance-relevant.
+
 Optimize may:
+
 - Add `IR_PROFILE_*` blocks at hot-path entry points
-- Add explanatory comments documenting non-obvious perf trade-offs
-  (e.g. "// pre-sized to avoid realloc in tick — see PR #N")
+- Add explanatory comments documenting non-obvious perf trade-offs (e.g. `// pre-sized to avoid realloc in tick — see PR #N`)
 - Restructure a tick function for better cache behavior
 
-Simplify, run after, will respect those additions because:
-- `IR_PROFILE_*` macros are part of the engine's profiling story,
-  not "debug logs"
-- Comments that explain a perf rationale are kept (they explain a
-  non-obvious why)
+Simplify, run after, respects those additions because `IR_PROFILE_*` macros are engine profiling, not debug logs, and perf-rationale comments are kept (they explain non-obvious why).
 
-If you're working on a non-perf-critical change (docs, tests,
-mechanical refactor), skip optimize and run simplify directly.
+For non-perf changes, skip optimize and run simplify directly.
 
 ## What this skill does NOT do
 
-- **Doesn't replace human profiling judgment.** A 0.1 ms regression
-  in a cold path may be fine; a 0.1 ms regression on the per-entity
-  hot path at 50K entities is 5 ms/frame. Surface the data, let the
-  human decide.
-- **Doesn't optimize without measuring.** Speculative optimization
-  is worth less than the readability it costs. Always measure.
+- **Doesn't replace human profiling judgment.** A 0.1 ms regression in a cold path may be fine; a 0.1 ms regression on the per-entity hot path at 50K entities is 5 ms/frame. Surface the data, let the human decide.
+- **Doesn't optimize without measuring.** Speculative optimization is worth less than the readability it costs. Always measure.
 - **Doesn't push.** Edits the working tree only.
-- **Doesn't run RenderDoc or other GUI profilers.** Hand off the
-  capture instructions and ask the human to run it.
+- **Doesn't run RenderDoc or other GUI profilers.** Hand off the capture instructions and ask the human to run it.
+- **Doesn't grow itself.** Prose belongs in `reference/`; recipes belong in `scripts/perf/`. If the playbook is getting longer, something needs to move out.
 
-## Example
+## See also
 
-User: "I added a new lighting pass — optimize it before I push"
-
-```
-optimize: 3 files profiled (engine/render/, shaders/glsl/)
-
-CPU hotspots: none. The new pass is GPU-bound.
-
-GPU profiling: `ir.render.setGpuTimingEnabled(true)` + 300-frame
-averages from `ir.render.getPassTimings()`:
-  - lightingToTrixel:    0.4 ms → 3.0 ms  (budget 1.7 ms — OVER)
-  - trixelToFb:          2.1 ms → 2.1 ms  (budget 2.5 ms — ok)
-  - fbToScreen:          0.3 ms → 0.3 ms  (budget 0.8 ms — ok)
-  - total frame:        14.2 ms → 16.8 ms (+2.6 ms, 16% over budget)
-
-Hotspot confirmed: lightingToTrixel jumped 2.6 ms on its own —
-matches the per-pixel 3x3x3 sample loop I added.
-
-Optimization applied:
-  - Switched to a 2D shadow texture lookup once per pixel instead
-    of per-sample, then modulated by the precomputed AO texture.
-  - Re-measured lightingToTrixel: 0.7 ms (within budget).
-  - Total frame: 14.5 ms ± 0.3 (+0.3 ms over original — acceptable).
-
-ready for simplify pass.
-```
+- [`reference/script_first.md`](reference/script_first.md) — why scripts beat prose for recurring work
+- [`reference/profiling_recipe.md`](reference/profiling_recipe.md) — concrete commands for the matrix → diff loop
+- [`reference/cpu_profiling.md`](reference/cpu_profiling.md) — `IR_PROFILE_*` macros and the easy_profiler workflow
+- [`reference/gpu_profiling.md`](reference/gpu_profiling.md) — `getPassTimings()`, `getVoxelCullStats()`, async timer queries
+- [`reference/common_bottlenecks.md`](reference/common_bottlenecks.md) — curated bottleneck catalog with file:line examples
+- [`reference/big_wins.md`](reference/big_wins.md) — case studies of the largest wins
+- [`reference/partner_skills.md`](reference/partner_skills.md) — `simplify`, `render-verify`, `render-debug-loop`, etc.

--- a/.claude/skills/optimize/reference/big_wins.md
+++ b/.claude/skills/optimize/reference/big_wins.md
@@ -1,0 +1,119 @@
+# big wins — case studies of the largest perf improvements
+
+One-paragraph summaries of the largest measured improvements landed.
+Worth reading when sizing the budget for a new optimization — "is this
+likely to be worth a session of work?"
+
+Each entry has:
+
+- **What** — one sentence on the change.
+- **Where** — file:line or PR link.
+- **Win** — the measured improvement, with the matrix cell that
+  surfaced it.
+- **Lesson** — what to look for next time.
+
+Append in chronological order. New big wins (>5% mean frame ms at the
+worst-case matrix cell) land here as part of the optimization PR.
+
+---
+
+## GPU light volume rewrite (Phase 1a)
+
+- **What**: Replaced CPU flood-fill of the per-frame
+  light-occupancy grid with a GPU dilation chain over a ping-pong
+  pair of 128³ RGBA8 textures, plus per-frame seeding from a
+  `LightSourceBuffer` SSBO. No more CPU populate / upload.
+- **Where**: `engine/prefabs/irreden/render/systems/system_compute_light_volume.hpp`,
+  shader chain `c_clear_light_volume + c_seed_light_volume +
+  c_propagate_light_volume`.
+- **Win**: COMPUTE_LIGHT_VOLUME CPU populate **72 ms → 0.04 ms**
+  (≈1800× CPU win); total frame time dropped 8.7–10.6× at the
+  262K-entity perf_grid cell. Largest single render-pipeline win
+  to date.
+- **Lesson**: When a per-frame CPU computation feeds a per-frame
+  GPU read, **the GPU should own it**. CPU-side flood-fills are
+  almost always rewritable as GPU dilation passes if the destination
+  resource is a 3D texture.
+
+## Voxel position push-at-mutation (T-289)
+
+- **What**: Position SSBO uploads moved from per-frame `subData(0,
+  liveCount × sizeof(vec4))` to mutator-time pending-range queues
+  drained once per frame. Static entities cost zero bytes/frame;
+  moving entities coalesce into runs.
+- **Where**: `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp`,
+  pending-list flush pattern documented in `cpp-ecs.md` §"No dirty
+  flags on components".
+- **Win**: Eliminated a steady-state CPU→GPU upload that scaled with
+  pool size, freeing bandwidth on Metal where `subData` orphans the
+  whole buffer.
+- **Lesson**: Any per-frame "rebroadcast the CPU mirror" upload is
+  suspect. Audit for push-at-mutation candidates: positions (done),
+  colors (open), entity IDs (open).
+
+## Sparse occupancy bitmask (T-287)
+
+- **What**: Replaced the per-voxel `alpha != 0` check (read full color
+  SSBO) with a `kVoxelActiveMaskBits` (32-voxel-per-word) bitfield. The
+  compact shader now does a 1-bit lookup before touching the wider
+  color buffer.
+- **Where**: `engine/render/src/shaders/c_voxel_visibility_compact.glsl:34-36, 63-64`,
+  CPU mirror in `C_VoxelPool::m_activeMask`.
+- **Win**: voxelCompact pass GPU time dropped when most pool slots
+  are inactive (common in editor / sparse scenes). Memory-bound win,
+  not compute-bound.
+- **Lesson**: For "is this slot active" predicates on large SSBOs,
+  a sidecar bitfield pays off when reads dominate writes. Don't add
+  the bitfield unless mutation cadence is much lower than read
+  cadence (otherwise the sync cost negates the read win).
+
+## Per-stage CPU+GPU timing infrastructure (T-275)
+
+- **What**: Added `gpuStageTiming()` + `cpuFrameHistogram()` +
+  `system_perf_stats_overlay.hpp` HUD. Not a perf win itself —
+  but every subsequent optimization PR cited it for before/after
+  numbers.
+- **Where**: `engine/prefabs/irreden/render/gpu_stage_timing.hpp`,
+  `engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp`.
+- **Win**: Indirect. Made every later optimization measurable, and
+  was the precursor to PR #1016's matrix script + PR #1019's cull
+  diagnostic.
+- **Lesson**: Infrastructure PRs that make a class of future work
+  measurable are worth landing even when they don't ship a win
+  themselves. The measurement is what unlocks the optimization
+  budget.
+
+## Perf measurement scripts (PR #1016)
+
+- **What**: Added `scripts/perf/perf_grid_matrix.sh`,
+  `compare_perf_runs.py`, `perf_summary.py`. Sweeps `IRPerfGrid` /
+  `IRLuaPerfGrid` across `(zoom, sub_mode, sub_base)` and produces
+  markdown diffs.
+- **Where**: PR #1016, `scripts/perf/`, `docs/perf/README.md`.
+- **Win**: Indirect. Replaced ad-hoc "run demo, eyeball FPS overlay"
+  with a reproducible diff. Every subsequent perf PR cites the
+  matrix output.
+- **Lesson**: Same as T-275 — measurement infrastructure pays off
+  over the long tail. Especially when extracted as scripts (this
+  skill never tells you how to run the matrix; it just calls the
+  script).
+
+## Voxel cull-effectiveness diagnostic (PR #1019)
+
+- **What**: VOXEL_TO_TRIXEL_STAGE_1 reads prior frame's
+  `IndirectDispatchParams.visibleCount` before zeroing — sync-free
+  per-frame sample of how many voxels survived the iso-bounds cull.
+  Surfaced via `getVoxelCullStats()` + the matrix scripts' new
+  cull table.
+- **Where**: PR #1019,
+  `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp`,
+  `engine/prefabs/irreden/render/gpu_stage_timing.hpp` (accumulator).
+- **Win**: Indirect — but surfaced the actual root cause of the
+  user-reported "zoom past full coverage and FPS still drops"
+  symptom. Visible/total at zoom 8 is 0.47 when ideal is 0.02 —
+  cull bounds are dominated by the shadow-feeder sweep, not the
+  visible region. Issue #1020 has the proposed fix.
+- **Lesson**: When a perf symptom doesn't match the obvious
+  hypothesis, **measure the next layer down**. The frame time was
+  growing with zoom — the next-layer-down was "is culling actually
+  shrinking the working set?" and the answer was "barely."

--- a/.claude/skills/optimize/reference/common_bottlenecks.md
+++ b/.claude/skills/optimize/reference/common_bottlenecks.md
@@ -1,0 +1,197 @@
+# common bottlenecks — curated catalog
+
+Seed library of bottleneck patterns this skill has actually encountered.
+Each entry has:
+
+- **Pattern** — the smell to grep for.
+- **Where** — file:line example from the engine (kept fresh; if the
+  example moves, update this).
+- **Symptom** — what shows up in profiler output or matrix data.
+- **Fix** — the canonical pattern, with a cross-reference if longer.
+
+The catalog grows via step 7 of the optimize flow. Any new pattern a
+session uncovers lands here in the same PR as the fix.
+
+---
+
+## CPU bottlenecks (system tick paths)
+
+### 1. `getComponent` on the iterating entity inside a tick
+
+- **Pattern**: `IREntity::getComponent<C_Foo>(entity)` or
+  `getComponentOptional<C_Foo>(entity)` inside a per-entity `tick(...)`.
+- **Where**: `engine/prefabs/irreden/update/systems/system_spring_platform.hpp:54-55`
+  (active known violation in the codebase).
+- **Symptom**: That system shows up high on `compare_perf_runs.py`'s
+  "top CPU systems" with avg ms scaling linearly with archetype size.
+  Profiler trace shows a hash-map probe per entity.
+- **Fix**: Add `C_Foo` to the system's template parameters so it
+  iterates as a dense archetype column. Full rule:
+  `.claude/rules/cpp-ecs.md` §"The ECS footgun".
+
+### 2. Allocation in a per-entity tick
+
+- **Pattern**: `std::vector::push_back` on a non-pre-sized vector,
+  `std::string` concatenation, `std::make_unique`, `std::map::operator[]`
+  insertion — anywhere inside `tick(...)`.
+- **Where**: search for `m_X.push_back` or `m_X[key] = ...` in tick
+  bodies under `engine/prefabs/irreden/`.
+- **Symptom**: System's `max_ms` spikes occasionally above its `avg_ms`
+  by 5–10× — the spike is reallocs on growth boundaries. Easy_profiler
+  trace shows a `__malloc` block inside the tick.
+- **Fix**: Pre-size in `beginTick` with a high-water-mark `reserve`,
+  reuse across frames, `clear()` without `shrink_to_fit()`. Full rule:
+  `.claude/rules/cpp-ecs.md` §"Allocations in hot tick paths".
+
+### 3. Function-local `static` for system-owned mutable state
+
+- **Pattern**: `static std::vector<T>& getX() { static std::vector<T> x; return x; }`
+  or any function-local non-`constexpr` static inside a system file.
+- **Where**: `engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp:41-43`
+  (active known violation).
+- **Symptom**: Not directly a hotspot, but blocks future SIMD batching
+  and breaks `SystemParams` lifecycle. Often surfaces only when the
+  system gets recreated mid-run.
+- **Fix**: Move to `SystemParams` field. Full rule:
+  `.claude/rules/cpp-systems.md` §"Canonical SystemParams pattern".
+
+### 4. Per-frame buffer upload without push-at-mutation
+
+- **Pattern**: A `Buffer::subData(0, size, data)` call inside a
+  per-frame tick that uploads CPU-mirror state regardless of whether
+  it actually changed.
+- **Where**: `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp`
+  (positions migrated to push-at-mutation in T-289; color + entityId
+  still upload per-frame as of this writing — audit and migrate).
+- **Symptom**: GPU stage timing shows a `voxelStage1` baseline cost
+  proportional to live voxel count even when nothing changed. CPU
+  shows up in the easy_profiler trace under the upload path.
+- **Fix**: Push at mutation time in the setter that touches the field
+  (see `C_GPUParticlePool::writeSlot` for the canonical pending-list
+  flush). Never add a `bool dirty_` flag — full rule:
+  `.claude/rules/cpp-ecs.md` §"No dirty flags on components".
+
+---
+
+## GPU bottlenecks (render pipeline)
+
+### 5. Wrong compute dispatch grid (hand-rolled instead of helper)
+
+- **Pattern**: `dispatchCompute((n + 63) / 64, 1, 1)` or similar
+  hand-rolled math.
+- **Where**: search `engine/render/` and `engine/prefabs/irreden/render/`
+  for `dispatchCompute` without `voxelDispatchGridForCount` upstream.
+- **Symptom**: Stage runs but produces wrong output, or wastes ~2×
+  workgroups, or hits the GL `MAX_COMPUTE_WORK_GROUP_COUNT_X` limit at
+  scale.
+- **Fix**: Use `voxelDispatchGridForCount()` which packs into 2D when
+  X exceeds 1024.
+
+### 6. CPU→GPU sync stall (synchronous readback in hot path)
+
+- **Pattern**: `glReadPixels`, `glGetBufferSubData`, `Buffer::getSubData`
+  called inline in a system tick or render-stage execution.
+- **Where**: shipping code generally avoids this. Exception: cull-stats
+  readback in `system_voxel_to_trixel.hpp` (gated on
+  `gpuStageTiming().enabled_`, sync-free in shipping).
+- **Symptom**: Frame time ~16ms on what should be a fast frame.
+  GPU-side timing shows the readback's preceding pass at "full GPU
+  utilization" because the CPU is stalled waiting.
+- **Fix**: Use a fence + multi-frame ringbuffer, or read prior-frame
+  data (the cull-stats pattern). For genuine inline reads, use
+  persistent mapped buffers (`PERSISTENT | COHERENT`).
+
+### 7. Shadow-feeder sweep inflates cull bounds at high zoom
+
+- **Pattern**: `IRMath::shadowFeederIsoBounds(visible, sunDir,
+  sweepDistance)` expands the cull AABB by ~64 voxels in the sun
+  direction. At zoom 4–8 this expansion **dominates** the visible
+  AABB, so the cull lets through far more voxels than the viewport
+  would naively suggest.
+- **Where**: `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp:253-257`,
+  math in `engine/math/include/irreden/ir_math.hpp:601`.
+- **Symptom**: `compare_perf_runs.py` cull-effectiveness table shows a
+  ratio 10–30× looser than `1/zoom²` ideal at high zoom. Frame time
+  scales with `sub² × visible_count` and `visible_count` stays high.
+- **Fix**: Currently filed as issue #1020. Sketch: split shadow-feeder
+  voxels into a depth-only fast path that doesn't pay the `sub²` cost
+  in `voxel_to_trixel_stage_2`. Don't break the invariant
+  (`engine/render/CLAUDE.md` §"Lighting culling invariants") — feeder
+  voxels still need `trixelDistances` writes for the sun-shadow bake;
+  they just don't need color / AO / entity ID.
+
+### 8. O(sub²) per-shape tile generation in SHAPES_TO_TRIXEL
+
+- **Pattern**: CPU-side tile descriptor generation expands each shape's
+  iso bounds by `sub` and divides by `kShapeTileSize`, so tile count
+  per shape grows as `O(sub²)`. Many of those tiles never touch a
+  shape pixel.
+- **Where**: `engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp:412-429`.
+- **Symptom**: GPU stage timing shows `shapePass1` growing rapidly with
+  zoom in scenes that use SDF shapes (perf_grid `--mode sdf`).
+  Profiler shows tile-dispatch count >100 per shape at zoom 4 with
+  default subdivisions.
+- **Fix**: Pre-cull tiles on CPU against the shape's actual SDF/AABB
+  before emitting tile descriptors. Cheap conservative bounding-rect
+  test first, then full SDF intersection if needed. Not yet filed;
+  measure with `--mode sdf` matrix run to confirm before optimizing.
+
+### 9. `numGroupsZ = subdivisions²` voxel dispatch growth
+
+- **Pattern**: `c_voxel_visibility_compact.glsl` writes
+  `numGroupsZ = subdivisions²` for stage 2's indirect dispatch. By
+  design (each face needs sub² micro-pixel coverage), but at high zoom
+  with FULL mode this can hit `MAX_COMPUTE_WORK_GROUP_COUNT_Z` (≥65535
+  on most drivers) before the X×Y limit.
+- **Where**: `engine/render/src/shaders/c_voxel_visibility_compact.glsl:92-93`.
+- **Symptom**: Stage 2 returns wrong / missing output at sub ≥16 and
+  visible counts >65535/sub². No GL error.
+- **Fix**: Cap effective subdivisions OR repack Z into X×Y when sub²
+  exceeds a threshold. Not yet filed — currently the
+  `getVoxelRenderEffectiveSubdivisions` clamp to 16 keeps it under the
+  limit, but the headroom is small.
+
+---
+
+## Math / shader hot paths
+
+### 10. `glm::*` or `std::*` math primitives outside `engine/math/`
+
+- **Pattern**: `glm::sin(x)`, `std::max(a, b)`, etc. in C++ code
+  outside `engine/math/`.
+- **Where**: tracked in `.fleet/status/glm-deviations.md`.
+- **Symptom**: Not a runtime hotspot, but blocks the
+  IRMath-implementation-swap path and breaks CPU↔GPU consistency
+  (e.g. `glm::round` vs `IRMath::roundHalfUp`).
+- **Fix**: Use the `IRMath::` wrapper. If the wrapper doesn't exist,
+  add it to `engine/math/` first. Full rule:
+  `.claude/rules/cpp-math.md`.
+
+### 11. Repeated math sequences across multiple shaders
+
+- **Pattern**: Same iso-projection or SDF math copy-pasted across two
+  or more `.glsl` files.
+- **Where**: search `engine/render/src/shaders/` for duplicate
+  function bodies.
+- **Symptom**: Not a runtime hotspot directly, but a maintenance
+  hazard — a fix on one side gets forgotten on the other. Worth
+  flagging in code review even when perf isn't the immediate concern.
+- **Fix**: Move to a shared include (`ir_iso_common.glsl`,
+  `ir_constants.glsl`).
+
+---
+
+## How to extend this catalog
+
+Append to this file in the same PR as the optimization fix that
+discovered the pattern. Required fields:
+
+- **Pattern**: the regex or smell.
+- **Where**: file:line example.
+- **Symptom**: what surfaces in `compare_perf_runs.py` or the
+  easy_profiler trace.
+- **Fix**: the canonical pattern + a cross-reference to the rule or
+  PR that defines it.
+
+Don't add patterns you only suspect — only ones you've actually
+encountered and measured.

--- a/.claude/skills/optimize/reference/common_bottlenecks.md
+++ b/.claude/skills/optimize/reference/common_bottlenecks.md
@@ -159,7 +159,11 @@ session uncovers lands here in the same PR as the fix.
 
 - **Pattern**: `glm::sin(x)`, `std::max(a, b)`, etc. in C++ code
   outside `engine/math/`.
-- **Where**: tracked in `.fleet/status/glm-deviations.md`.
+- **Where**: tracked in `<engine-root>/.fleet/status/glm-deviations.md`
+  (queue-manager-owned, committed; not `~/.fleet/`) — or will be, once
+  the file is introduced. Until then, discover violations with
+  `rg 'glm::|std::(sin|cos|sqrt|abs|min|max|clamp)' --type cpp engine/
+  -g '!engine/math/**'`.
 - **Symptom**: Not a runtime hotspot, but blocks the
   IRMath-implementation-swap path and breaks CPU↔GPU consistency
   (e.g. `glm::round` vs `IRMath::roundHalfUp`).

--- a/.claude/skills/optimize/reference/cpu_profiling.md
+++ b/.claude/skills/optimize/reference/cpu_profiling.md
@@ -1,0 +1,91 @@
+# CPU profiling — IR_PROFILE_* + easy_profiler
+
+The engine wraps easy_profiler under `engine/profile/`. The surface is
+three macros, three log routes, and one runtime gate. Compiles to
+no-ops in release builds.
+
+## Macros
+
+```cpp
+void IRSGlowPulse::tickEntity(C_GlowPulse& glow, C_Color& color) {
+    IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
+    // ... existing logic
+}
+
+void some_inner_block() {
+    IR_PROFILE_BLOCK("expensive_step", IR_PROFILER_COLOR_RENDER);
+    // ... work
+    IR_PROFILE_END_BLOCK;
+}
+```
+
+- `IR_PROFILE_FUNCTION(color)` — name taken from `__FUNCTION__`.
+- `IR_PROFILE_BLOCK(name, color)` / `IR_PROFILE_END_BLOCK` — manual scope.
+- Always use the named `IR_PROFILER_COLOR_*` constants from
+  `engine/profile/include/irreden/ir_profile.hpp`. Raw ARGB hex literals
+  are an anti-pattern; the named colors group related blocks visually
+  in the easy_profiler timeline.
+
+## Where to wrap
+
+- The entry point of a new system tick function.
+- The entry point of a new pipeline stage.
+- Audio / video callbacks.
+- Inner sub-blocks worth isolating in the timeline (e.g. a per-frame
+  upload step inside a tick).
+
+Don't wrap helpers called from a tick — easy_profiler's per-scope cost
+adds up if you put it inside the per-entity loop. Wrap the tick itself.
+
+## Per-frame CPU histogram (the HUD-facing one)
+
+`IR_PROFILE_SCOPE(name)` is a different scope timer that feeds the
+per-frame HUD via `IRProfile::cpuFrameHistogram()`. Use it when you want
+the HUD to see the cost live, not when you're producing an offline
+trace. Lua surface: `ir.render.getCpuPassTimings()` and
+`ir.render.getCpuPassTiming(name)`.
+
+The cost is bounded — disabled-by-default, two `now()` calls + one
+hashmap lookup per scope exit when enabled.
+
+## Runtime gating
+
+- `IRProfile::CPUProfiler::instance().setEnabled(bool)` — gates all
+  `IR_PROFILE_*` (the easy_profiler path).
+- `IRProfile::cpuFrameHistogram().enabled_` — gates `IR_PROFILE_SCOPE`
+  (the histogram path).
+- `IREngine::enableFrameTiming(true)` — flips per-system timing on. The
+  matrix script calls this implicitly via `--auto-profile`.
+
+## How the matrix script captures CPU timing
+
+`scripts/perf/perf_grid_matrix.sh` runs the demo with `--auto-profile N`
+which calls `IREngine::enableFrameTiming(true)`. The `World` dtor then
+writes `save_files/profile_report.txt` containing per-system avg/min/max
+ms. `compare_perf_runs.py` parses the "Per-system timing" section and
+surfaces the top systems per cell.
+
+The matrix output is the right input for "did my change slow down a
+system". The easy_profiler trace is the right input for "what inside
+this system is slow". Use both — matrix to detect the regression, trace
+to localize.
+
+## Reading the trace
+
+`.prof` files are dumped on exit. The human runs `profiler_gui` to view
+them (the agent cannot drive a GUI). When asking the human:
+
+- Point them at the specific frame number of interest.
+- Specify which color group (`IR_PROFILER_COLOR_RENDER` etc.) to filter on.
+- Ask for the top-N scopes by total time, not by raw duration.
+
+## When CPU profiling is the wrong tool
+
+- Frame time grew but `--- Per-system timing ---` shows nothing
+  unusual → GPU-bound, switch to [`gpu_profiling.md`](gpu_profiling.md).
+- One specific math helper looks suspicious → microbench (see issue
+  #1023; not yet built).
+- A render pipeline stage's avg is fine but its max spikes
+  occasionally → likely a per-frame GC or buffer realloc, not a CPU
+  hotspot. Look for allocation in tick paths
+  ([`common_bottlenecks.md`](common_bottlenecks.md)).

--- a/.claude/skills/optimize/reference/gpu_profiling.md
+++ b/.claude/skills/optimize/reference/gpu_profiling.md
@@ -1,0 +1,99 @@
+# GPU profiling — per-pass timing + cull diagnostics
+
+The engine has two GPU diagnostics wired into the render pipeline. Both
+gated on `gpuStageTiming().enabled_`.
+
+## Per-pass GPU timing
+
+Every major render stage brackets its GPU work with a timer; the
+result lands in `GpuStageTiming` (one `float ...Ms_` per stage in
+`engine/prefabs/irreden/render/gpu_stage_timing.hpp`).
+
+Registered stages (canvasClear, voxelCompact, voxelStage1, voxelStage2,
+shapeCompact, shapePass0, shapePass1, textToTrixel,
+buildLightOcclusionGrid, computeVoxelAO, bakeSunShadowMap,
+computeSunShadow, computeLightVolume, lightingToTrixel, fogToTrixel,
+trixelToTrixel, trixelToFb, entityCanvasToFb, screenSpaceResidualRotate,
+fbToScreen) each carry a soft budget share (`GpuStageInfo::budgetShare_`).
+A pass exceeding its share is flagged via `overBudget` in the Lua surface.
+
+Lua surface:
+
+```lua
+ir.render.setGpuTimingEnabled(true)
+-- ... let the scene render ...
+for _, row in ipairs(ir.render.getPassTimings()) do
+    print(row.name, row.ms, row.budgetMs, row.overBudget)
+end
+```
+
+C++ surface: `IRRender::gpuStageTiming().*Ms_` fields and the
+`IRRender::gpuStageRegistry()` table.
+
+The shutdown profile report (`save_files/profile_report.txt`) includes
+the same data under `--- GPU stage timing ---`. The matrix script
+aggregates this across cells.
+
+## Voxel cull effectiveness
+
+`VOXEL_TO_TRIXEL_STAGE_1` reads the prior frame's
+`IndirectDispatchParams.visibleCount` via `Buffer::getSubData` before
+zeroing the buffer — sync-free because frame N+1 reads frame N's
+already-committed value. Added in PR #1019.
+
+Surfaces:
+
+- `gpuStageTiming().visibleVoxelCount_` / `totalVoxelCount_` — last frame.
+- `voxelCullAccumulator()` — running sum / max / sample count across
+  the measurement window (reset on `enableFrameTiming(true)`).
+- Lua: `ir.render.getVoxelCullStats()` → `{visible, total, samples,
+  avgVisible, avgTotal, maxVisible, maxTotal}`.
+- Profile report: `--- Voxel cull stats ---` section with avg / max /
+  ratio.
+
+The matrix script parses this and `compare_perf_runs.py` renders a
+`voxel cull effectiveness` table. Ratio shrinks roughly as `1/zoom²` if
+culling is working; a flat ratio across zooms is the signature of
+ineffective viewport culling (see [`common_bottlenecks.md`](common_bottlenecks.md)
+"Shadow-feeder sweep inflates cull bounds at high zoom").
+
+## Backend caveat: sync vs async
+
+The current per-pass timer brackets are `glFinish()`-style (i.e. they
+stall the GPU at each boundary so the CPU clock sample is meaningful).
+Accurate but adds throughput cost — default is **off**, flip on only
+during a matrix run.
+
+Async path (`GL_TIMESTAMP` query objects, `MTLCounterSampleBuffer` for
+Metal) is tracked in issue #1021. Once that lands, per-pass timing can
+be on by default without measurable cost.
+
+The cull-stats `getSubData` readback is also synchronous but only fires
+when `gpuStageTiming().enabled_` is true. Shipping builds pay zero
+cost.
+
+## When per-pass timing isn't enough
+
+- Single-frame anomaly hidden in the average → RenderDoc / Xcode GPU
+  capture. The agent can't drive a GUI; hand off to the human with the
+  specific pass name to focus on (use the `compare_perf_runs.py` GPU
+  table to identify it).
+- Shader-internal cost split unclear → temporarily add a debug uniform
+  incremented per work-group, read back via SSBO. Coarse but works.
+- Compute dispatch grid suspected wrong → log
+  `gl_NumWorkGroups.{x,y,z}` from inside the shader once per frame.
+
+## Common GPU hotspots
+
+See [`common_bottlenecks.md`](common_bottlenecks.md). Recurring patterns
+that show up in `getPassTimings()`:
+
+- Wrong dispatch grid → `voxelStage1` or `shapePass1` 5–20× their
+  budget. Fix: use `voxelDispatchGridForCount()`.
+- Workgroup-size mismatch with dispatch math → stage runs but produces
+  wrong output (often invisible until visual regression hits).
+- `subdivisions²` Z-dimension growing with zoom — by design, but
+  amplifies any per-invocation cost.
+- Per-frame SSBO upload that could be push-at-mutation — kills GPU
+  throughput at scale. Fix per `cpp-ecs.md` "No dirty flags on
+  components".

--- a/.claude/skills/optimize/reference/partner_skills.md
+++ b/.claude/skills/optimize/reference/partner_skills.md
@@ -1,0 +1,126 @@
+# partner skills — what to invoke around optimize
+
+The optimize skill doesn't do regression checking, visual verification,
+or backend parity itself. It produces perf numbers; other skills do the
+adjacent work. Cross-reference these so the right one fires at the
+right time.
+
+## simplify (runs after optimize)
+
+Polishes the dirty tree before commit — catches ECS smells (per-entity
+getComponent in tick, function-local static, math primitive
+violations), naming convention slips, dead code, debug logs.
+
+**Order**: optimize first, then simplify. Optimize may add
+`IR_PROFILE_*` blocks and perf-rationale comments that simplify
+preserves (they're not the kind of "extraneous" simplify removes —
+profiling macros are engine surface, perf-rationale comments explain
+non-obvious why).
+
+**Cross-ref**: `.claude/skills/simplify/SKILL.md`.
+
+## render-verify (visual regression check)
+
+Automated pass/fail render-regression harness — builds a demo, runs
+with `--auto-screenshot`, compares each shot against a committed
+reference image. Run **after** any optimize change that touches the
+render pipeline, to catch visual regressions in pursuit of perf.
+
+A 20% frame-time win that breaks the shape silhouette is not a win.
+render-verify is the gate that catches this.
+
+**Cross-ref**: `.claude/skills/render-verify/SKILL.md`.
+
+## render-debug-loop (interactive iteration)
+
+Build → run → screenshot → diagnose loop for visual / render bugs.
+Different from render-verify (which is pass/fail) — used during active
+iteration when you're trying to understand a render bug or align two
+shapes pixel-for-pixel.
+
+Useful **before** optimize on render PRs where the visual semantics
+might be unclear — get the visual right, then optimize.
+
+**Cross-ref**: `.claude/skills/render-debug-loop/SKILL.md`.
+
+## attach-screenshots (PR-body evidence)
+
+Captures before/after screenshots for a render PR and commits them
+under `docs/pr-screenshots/<branch>/`. Runs against origin/master and
+against the dirty tree, pairs by shot label, produces markdown.
+
+Run **alongside** optimize when the perf PR touches render — reviewers
+need both the perf diff (from `compare_perf_runs.py`) and the visual
+diff (from attach-screenshots) to evaluate the trade-off.
+
+**Cross-ref**: `.claude/skills/attach-screenshots/SKILL.md`.
+
+## polish-checkpoint (mid-session verify)
+
+Runs the pre-commit phase of `commit-and-push` (simplify + build) but
+stops before any git operations. Useful when you want confidence that
+the working tree is clean and the build is green without committing
+yet.
+
+Run between iteration cycles in a long optimization session.
+
+**Cross-ref**: `.claude/skills/polish-checkpoint/SKILL.md`.
+
+## backend-parity (cross-platform sync)
+
+Keeps the OpenGL (Linux/Windows) and Metal (macOS) backends in
+functional sync. Render PRs almost always author against only one
+backend; the other lags until a fleet agent on that host catches up.
+
+If your optimize PR touches a shader (`*.glsl` or `*.metal`), run
+backend-parity **after** the perf measurement on the authoring backend
+to port the change to the other side. Both backends should show the
+matrix improvement; if Metal regresses where OpenGL improved (or vice
+versa), the port has a bug.
+
+**Cross-ref**: `.claude/skills/backend-parity/SKILL.md`.
+
+## commit-and-push (open the PR)
+
+When the optimization is done, `commit-and-push` packages the diff,
+runs simplify automatically, opens the PR. The PR body should include
+the `compare_perf_runs.py` markdown output.
+
+**Cross-ref**: `.claude/skills/commit-and-push/SKILL.md`.
+
+## start-next-task (stack the next optimization)
+
+If the optimization session uncovered a follow-up opportunity,
+`start-next-task` stacks the next branch on the current PR's head.
+Useful when an optimization is bounded but exposes a deeper issue —
+land what you have, stack the deeper fix.
+
+**Cross-ref**: `.claude/skills/start-next-task/SKILL.md`.
+
+---
+
+## Workflow shape
+
+```
+        ┌─────────────────────────────────────────────┐
+        │ start-next-task → branch off master or stack│
+        └────────────────────┬────────────────────────┘
+                             ▼
+        ┌─────────────────────────────────────────────┐
+        │ optimize → matrix baseline → fix → matrix → │
+        │           compare → step 7 self-improve     │
+        └────────────────────┬────────────────────────┘
+                             ▼
+                   ┌─────────────────────┐
+       render PR? ─▶ render-verify       │
+                   │ attach-screenshots  │
+                   │ backend-parity      │
+                   └──────────┬──────────┘
+                              ▼
+        ┌─────────────────────────────────────────────┐
+        │ commit-and-push → simplify auto-runs → PR   │
+        └─────────────────────────────────────────────┘
+```
+
+If a step in the diagram repeated more than once, it's a skill — not
+a manual instruction.

--- a/.claude/skills/optimize/reference/profiling_recipe.md
+++ b/.claude/skills/optimize/reference/profiling_recipe.md
@@ -23,6 +23,21 @@ scripts/perf/compare_perf_runs.py \
     save_files/perf/<head-sha>-head
 ```
 
+In a fleet worktree, plain `git checkout master` is unsafe — the main
+clone (or another worktree) already has `master` checked out and git
+will refuse, or the in-flight feature branch ends up orphaned. Use a
+worktree-safe alternative:
+
+- **Throwaway baseline worktree** (recommended):
+  ```bash
+  git worktree add /tmp/perf-baseline master
+  (cd /tmp/perf-baseline && scripts/perf/perf_grid_matrix.sh --label baseline)
+  git worktree remove /tmp/perf-baseline
+  ```
+- **Sibling clean clone** if you already maintain one (e.g.
+  `~/src/IrredenEngine.baseline`): run the matrix there and reference
+  its `save_files/perf/` output by absolute path when diffing.
+
 ## Quick check (no baseline, just see the current state)
 
 ```bash

--- a/.claude/skills/optimize/reference/profiling_recipe.md
+++ b/.claude/skills/optimize/reference/profiling_recipe.md
@@ -1,0 +1,99 @@
+# perf profiling recipe
+
+The full before/after measurement loop, written as the script commands
+to invoke. Do not paraphrase these in PR bodies — link this file
+instead.
+
+## The canonical ritual
+
+```bash
+# 1. Capture baseline on master before the change.
+git checkout master
+git pull
+scripts/perf/perf_grid_matrix.sh --label baseline
+
+# 2. Switch to your feature branch (or apply the dirty tree) and run
+#    the same matrix.
+git checkout claude/my-optimization
+scripts/perf/perf_grid_matrix.sh --label head
+
+# 3. Diff. Output is markdown — paste it into the PR body.
+scripts/perf/compare_perf_runs.py \
+    save_files/perf/<master-sha>-baseline \
+    save_files/perf/<head-sha>-head
+```
+
+## Quick check (no baseline, just see the current state)
+
+```bash
+scripts/perf/perf_grid_matrix.sh --quick
+scripts/perf/perf_summary.py save_files/perf/<sha>
+```
+
+## Matrix size choices
+
+| Flag       | Cells | Time   | When                                            |
+|------------|-------|--------|-------------------------------------------------|
+| `--quick`  | 2     | ~30s   | Smoke test, single-file change                  |
+| (default)  | 12    | ~3 min | Routine PR comparison                           |
+| `--full`   | 30    | ~10 min| Deep audit / engine-wide refactor               |
+
+## Targeting a specific demo
+
+```bash
+scripts/perf/perf_grid_matrix.sh --target IRLuaPerfGrid
+scripts/perf/perf_grid_matrix.sh --target IRShapeDebug      # when added
+```
+
+The script auto-resolves the build via `fleet-run`; no need to specify
+build paths.
+
+## What lands where
+
+- Per-cell `profile_report.txt` → `save_files/perf/<sha>[-<label>]/<cell-id>.txt`
+- Per-cell stdout/stderr → `save_files/perf/<sha>[-<label>]/<cell-id>.log`
+- Run metadata → `save_files/perf/<sha>[-<label>]/manifest.json`
+
+`save_files/` is gitignored. The committed perf baselines live in
+`docs/perf/baseline_<date>_<phase>.md` (rendered via `perf_summary.py`).
+
+## What the parser surfaces
+
+`compare_perf_runs.py` writes a markdown report with three or four
+sections:
+
+1. **Voxel cull effectiveness** — visible/total ratio per cell (added by PR #1019)
+2. **Frame timing** — avg + p99 ms per cell with delta vs baseline
+3. **GPU stage timing** — per-pass ms across all engine stages
+4. **Top CPU systems** — per-cell, sorted by avg ms
+
+Regression threshold defaults: ≥10% slower flagged with `⚠`, ≥5%
+faster flagged with `↓`. Pass `--regress-pct N --improve-pct M` to
+override.
+
+## When the demo is too slow to finish in the per-cell timeout
+
+The script's `--timeout` flag defaults to 90s per cell. At extreme
+zooms with high subdivisions, frames can take >300ms — 120 frames
+won't finish in 90s. Either:
+
+- Reduce frames: `--frames 60` (still gives a stable percentile)
+- Bump timeout: `--timeout 180`
+- Drop subdivisions for that probe: vary `--matrix` rules in the script
+
+If a cell consistently fails (`status: no_report` in the manifest),
+that's itself diagnostic information — log it in the PR body, don't
+silently drop the cell.
+
+## Where the same data shows up at runtime
+
+- Lua: `ir.render.getPassTimings()`, `ir.render.getVoxelCullStats()` —
+  see [`gpu_profiling.md`](gpu_profiling.md).
+- HUD: `system_perf_stats_overlay.hpp` reads both surfaces and renders
+  the per-stage breakdown live.
+- `save_files/profile_report.txt` — written at shutdown by every
+  creation that called `IREngine::enableFrameTiming(true)`.
+
+The matrix script aggregates the shutdown reports across cells. The
+HUD is the right tool for "is the bug visible right now"; the matrix
+is the right tool for "did the bug get worse with this change."

--- a/.claude/skills/optimize/reference/script_first.md
+++ b/.claude/skills/optimize/reference/script_first.md
@@ -60,7 +60,9 @@ benefit from the same script? If yes, extract.
 
 ## Cross-reference
 
-This principle is engine-wide, not optimize-specific. See
+This principle is engine-wide, not optimize-specific. The engine-wide
+version of this rule will live in
 [`docs/agents/CLAUDE-BASELINE.md`](../../../../docs/agents/CLAUDE-BASELINE.md)
-§"Script-first for repeatable work" for the version of this rule that
-applies across every skill and role.
+§"Script-first for repeatable work" (forthcoming — added by the
+follow-up PR that cross-references this file from CLAUDE-BASELINE and
+FLEET.md).

--- a/.claude/skills/optimize/reference/script_first.md
+++ b/.claude/skills/optimize/reference/script_first.md
@@ -1,0 +1,66 @@
+# script-first for repeatable perf work
+
+The `optimize` skill body is short by design. Every step it instructs
+the agent to run is either:
+
+1. A **script** the agent invokes verbatim (`scripts/perf/perf_grid_matrix.sh`,
+   `compare_perf_runs.py`, `perf_summary.py`, future microbench scripts).
+2. A **decision** the agent has to make from data (which fix to try
+   next, whether the matrix delta justifies the change).
+
+Anything that's neither — multi-step shell sequences in prose, copy-
+pasted command snippets, "do these N things in order" recipes — is a
+bug in the skill. Extract it to a script.
+
+## Why
+
+- **Scripts are testable.** A shell or python script can be smoke-tested
+  on master and on a worktree. A prose recipe can't.
+- **Scripts are diff-able.** When the recipe changes, the diff shows
+  exactly what changed. Prose drifts silently as code evolves around it.
+- **Scripts compound.** Every PR that wants a perf comparison gets the
+  same matrix output without re-deriving the flags. The next session
+  inherits the work.
+- **Scripts don't lie.** A prose paragraph that says "this takes about 5
+  minutes" stays true forever, even after a 10× regression slows it down.
+  A script run produces the actual number.
+- **Cache hit rate.** Skill bodies are loaded into context on every
+  invocation. A 150-line skill + 800 lines of reference (only loaded
+  when relevant) is cheaper than a 1000-line skill body.
+
+## What lives where
+
+| Lives in… | Examples |
+|-----------|----------|
+| `scripts/perf/` | Matrix run, before/after diff, summary, microbench harness, regression gate, baseline rotator |
+| `.claude/skills/optimize/reference/` | The bottleneck catalog, big-win case studies, profiling-macro reference, partner-skill cross-refs, this principle |
+| `.claude/skills/optimize/SKILL.md` | Triage → baseline → scan → profile → fix → measure → report → self-improve. ~150 lines. |
+
+## When to make a new script
+
+The first time you write a multi-step shell sequence in a PR body or
+in `SKILL.md`, it's prose. The second time you'd write something
+similar, **stop and extract a script**. The two-strike rule is the
+trigger.
+
+When in doubt: would two agents independently invoking this skill
+benefit from the same script? If yes, extract.
+
+## When NOT to make a script
+
+- Single-use commands tied to a specific PR (e.g. "reproduce issue
+  #1020 by running X with these args") — these live in the PR body, not
+  in `scripts/perf/`.
+- Decisions that require judgment (which optimization to pick, whether
+  the trade-off is worth it) — these stay in the skill body as
+  guidance, not as runnable code.
+- One-off measurement queries during a specific investigation —
+  scratch shell commands are fine. Promote to a script only when the
+  same query has run twice.
+
+## Cross-reference
+
+This principle is engine-wide, not optimize-specific. See
+[`docs/agents/CLAUDE-BASELINE.md`](../../../../docs/agents/CLAUDE-BASELINE.md)
+§"Script-first for repeatable work" for the version of this rule that
+applies across every skill and role.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ compile_commands.json
 .cache/
 CMakeUserPresets.json
 
+# runtime output from creations (profile reports, screenshots, perf matrix runs)
+save_files/
+
 # editor files: keep shareable config, ignore local state
 .vscode/*
 !.vscode/settings.json

--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -84,6 +84,10 @@ struct CliOverrides {
     int gridSize_ = 16;
     bool zoomSet_ = false;
     float zoom_ = 0.5f;
+    bool subdivisionModeSet_ = false;
+    IRRender::SubdivisionMode subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+    bool baseSubdivisionsSet_ = false;
+    int baseSubdivisions_ = 1;
 };
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
@@ -149,6 +153,31 @@ void parseArgs(int argc, char **argv) {
             if (zoom > 0.0f) {
                 g_cliOverrides.zoom_ = zoom;
                 g_cliOverrides.zoomSet_ = true;
+            }
+            ++i;
+        } else if (std::strcmp(argv[i], "--subdivision-mode") == 0 && i + 1 < argc) {
+            std::string mode = argv[i + 1];
+            if (mode == "none") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::NONE;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else if (mode == "position_only") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::POSITION_ONLY;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else if (mode == "full") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else {
+                IR_LOG_WARN(
+                    "Unknown --subdivision-mode '{}'; expected none|position_only|full",
+                    mode
+                );
+            }
+            ++i;
+        } else if (std::strcmp(argv[i], "--base-subdivisions") == 0 && i + 1 < argc) {
+            int sub = std::atoi(argv[i + 1]);
+            if (sub > 0) {
+                g_cliOverrides.baseSubdivisions_ = sub;
+                g_cliOverrides.baseSubdivisionsSet_ = true;
             }
             ++i;
         }
@@ -440,6 +469,12 @@ int main(int argc, char **argv) {
     IREngine::init(argv[0]);
     if (g_autoProfileFrames > 0) {
         IREngine::enableFrameTiming(true);
+    }
+    if (g_cliOverrides.subdivisionModeSet_) {
+        IRRender::setSubdivisionMode(g_cliOverrides.subdivisionMode_);
+    }
+    if (g_cliOverrides.baseSubdivisionsSet_) {
+        IRRender::setVoxelRenderSubdivisions(g_cliOverrides.baseSubdivisions_);
     }
     IREngine::gameLoop();
     return 0;

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -107,6 +107,10 @@ struct CliOverrides {
     float zoom_ = 0.5f;
     bool waveAmplitudeSet_ = false;
     float waveAmplitude_ = 0.0f;
+    bool subdivisionModeSet_ = false;
+    IRRender::SubdivisionMode subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+    bool baseSubdivisionsSet_ = false;
+    int baseSubdivisions_ = 1;
 };
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
@@ -229,6 +233,31 @@ void parseArgs(int argc, char **argv) {
             // isolating per-frame upload cost in profiler runs.
             g_cliOverrides.waveAmplitude_ = static_cast<float>(std::atof(argv[i + 1]));
             g_cliOverrides.waveAmplitudeSet_ = true;
+            ++i;
+        } else if (std::strcmp(argv[i], "--subdivision-mode") == 0 && i + 1 < argc) {
+            std::string mode = argv[i + 1];
+            if (mode == "none") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::NONE;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else if (mode == "position_only") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::POSITION_ONLY;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else if (mode == "full") {
+                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+                g_cliOverrides.subdivisionModeSet_ = true;
+            } else {
+                IR_LOG_WARN(
+                    "Unknown --subdivision-mode '{}'; expected none|position_only|full",
+                    mode
+                );
+            }
+            ++i;
+        } else if (std::strcmp(argv[i], "--base-subdivisions") == 0 && i + 1 < argc) {
+            int sub = std::atoi(argv[i + 1]);
+            if (sub > 0) {
+                g_cliOverrides.baseSubdivisions_ = sub;
+                g_cliOverrides.baseSubdivisionsSet_ = true;
+            }
             ++i;
         }
     }
@@ -427,6 +456,13 @@ int main(int argc, char **argv) {
 
     if (g_autoProfileFrames > 0) {
         IREngine::enableFrameTiming(true);
+    }
+
+    if (g_cliOverrides.subdivisionModeSet_) {
+        IRRender::setSubdivisionMode(g_cliOverrides.subdivisionMode_);
+    }
+    if (g_cliOverrides.baseSubdivisionsSet_) {
+        IRRender::setVoxelRenderSubdivisions(g_cliOverrides.baseSubdivisions_);
     }
 
     initSystems();

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,0 +1,102 @@
+# docs/perf — perf measurement workflow
+
+This directory holds:
+
+- the **measurement scripts** index for the perf demos (`scripts/perf/`)
+- **committed baselines** for major perf phases (e.g. `metal_perf_grid_baseline.md`)
+- **per-PR diffs** when an optimization PR captures before/after data
+
+The day-to-day flow is run a matrix on master, run the same matrix on
+your dirty tree, diff the two — all three steps are scripts. No GUI
+profiler, no per-cell stopwatch.
+
+## The scripts
+
+| Script                                | What it does                                                           |
+|---------------------------------------|------------------------------------------------------------------------|
+| `scripts/perf/perf_grid_matrix.sh`    | Run `IRPerfGrid` (or `IRLuaPerfGrid`) across a zoom × subdivision matrix |
+| `scripts/perf/perf_summary.py`        | One-screen markdown summary of a single run                            |
+| `scripts/perf/compare_perf_runs.py`   | Diff two runs as a markdown table for the PR body                      |
+
+All scripts are stdlib-only and run from anywhere in the repo. The
+matrix script writes `save_files/perf/<git-sha>[-<label>]/` so multiple
+runs coexist without overwriting each other.
+
+## Canonical ritual: before/after a perf change
+
+```bash
+# 1. Capture baseline on master before you start.
+git checkout master
+git pull
+scripts/perf/perf_grid_matrix.sh --label baseline
+
+# 2. Switch to your feature branch and run the same matrix.
+git checkout claude/my-optimization
+scripts/perf/perf_grid_matrix.sh --label head
+
+# 3. Diff. The output is markdown — paste it into the PR body.
+scripts/perf/compare_perf_runs.py \
+    save_files/perf/<master-sha>-baseline \
+    save_files/perf/<head-sha>-head
+```
+
+If you only want a quick read on the current state:
+
+```bash
+scripts/perf/perf_grid_matrix.sh --quick
+scripts/perf/perf_summary.py save_files/perf/<sha>
+```
+
+## Matrix size knobs
+
+| Flag       | Cells | Typical use                                  |
+|------------|-------|----------------------------------------------|
+| `--quick`  | 2     | Smoke test, ~30s total                       |
+| (default)  | 12    | Routine PR comparison, ~3 min                |
+| `--full`   | 30    | Deep audit, ~10 min                          |
+
+Customize what to vary by editing the matrix arrays at the top of
+`perf_grid_matrix.sh` — keep the defaults narrow so PR runs stay fast.
+
+## CLI flags the scripts depend on
+
+`IRPerfGrid` and `IRLuaPerfGrid` accept these flags (used by the matrix
+script):
+
+- `--auto-profile <N>` — collect N frames of timing then exit; writes
+  `save_files/profile_report.txt`.
+- `--zoom <F>` — initial camera zoom (snapped to power of 2 in
+  `[kTrixelCanvasZoomMin, kTrixelCanvasZoomMax]`).
+- `--subdivision-mode <none|position_only|full>` — overrides the
+  world-config default for the run.
+- `--base-subdivisions <N>` — overrides `voxel_render_subdivisions`
+  (clamped 1..16 by the render manager).
+- `--mode <voxel_set|sdf>` (IRPerfGrid only) — voxel-pool vs SDF-only
+  geometry.
+- `--grid-size <N>` — overrides the demo's default grid size.
+
+The subdivision flags exist precisely so the matrix script can sweep
+them without editing config files.
+
+## Committed baselines
+
+When a major phase lands (Phase 1a GPU light volume, T-289 push-at-mutation,
+…), commit the matrix output as `docs/perf/baseline_<date>_<phase>.md`
+generated via `perf_summary.py`. Subsequent PRs diff against the most
+recent baseline. The older free-form file
+`docs/perf/metal_perf_grid_baseline.md` remains as historical context.
+
+## Where this is going
+
+A CI gate (`perf/baseline-ci-gate` issue) will eventually re-run the
+matrix on every PR touching `engine/render/`, `engine/system/`, or
+`engine/math/` and post `compare_perf_runs.py` output as a PR comment.
+Until that lands, the human author (or an `/optimize` skill run) does
+the comparison locally and pastes the markdown into the PR body.
+
+The current GPU timings use `glFinish()`-style synchronous bracketing
+(see `engine/prefabs/irreden/render/gpu_stage_timing.hpp`). That is
+accurate but adds a small per-frame overhead — keep `gpu_stage_timing`
+off in shipping builds, on during a matrix run. Replacing the sync path
+with async `GL_TIMESTAMP` / `MTLCounterSample` queries is tracked in
+the `perf/async-gpu-timers` issue.

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -78,6 +78,33 @@ script):
 The subdivision flags exist precisely so the matrix script can sweep
 them without editing config files.
 
+## Voxel cull stats — the "is culling working?" diagnostic
+
+When `gpu_stage_timing` is enabled, `VOXEL_TO_TRIXEL_STAGE_1` reads the
+prior frame's `IndirectDispatchParams.visibleCount` before zeroing the
+buffer for the new frame. The result is a sync-free per-frame sample of
+*how many voxels survived the iso-bounds cull*, alongside the pool's
+live count. The matrix script surfaces this as the `cull (vis/total)`
+column on `perf_summary.py` and a dedicated `voxel cull effectiveness`
+table on `compare_perf_runs.py`.
+
+What to look for:
+
+- **Ratio shrinks with zoom**, roughly as `1/zoom²` once the camera is
+  past full-screen coverage. If the ratio stays flat or shrinks much
+  less than `1/zoom²` while zoom goes up, that's the signature of an
+  ineffective viewport cull — frame time grows with the
+  subdivision-driven work multiplier while the visible set barely
+  changes.
+- **Same ratio across two PRs at the same `(zoom, sub_mode, sub_base)`
+  cell** is the no-regression baseline for any optimization PR that
+  claims to improve culling — pre-PR vs post-PR ratios at the same
+  cell.
+
+Lua surface for ad-hoc inspection: `ir.render.getVoxelCullStats()`
+returns `{visible, total, samples, avgVisible, avgTotal, maxVisible,
+maxTotal}`.
+
 ## Committed baselines
 
 When a major phase lands (Phase 1a GPU light volume, T-289 push-at-mutation,

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -82,7 +82,9 @@ them without editing config files.
 
 When `gpu_stage_timing` is enabled, `VOXEL_TO_TRIXEL_STAGE_1` reads the
 prior frame's `IndirectDispatchParams.visibleCount` before zeroing the
-buffer for the new frame. The result is a sync-free per-frame sample of
+buffer for the new frame. No explicit fence is required — the driver
+serializes the CPU read against the prior frame's already-retired write.
+The result is a per-frame sample of
 *how many voxels survived the iso-bounds cull*, alongside the pool's
 live count. The matrix script surfaces this as the `cull (vis/total)`
 column on `perf_summary.py` and a dedicated `voxel cull effectiveness`

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -1,11 +1,12 @@
 #ifndef GPU_STAGE_TIMING_H
 #define GPU_STAGE_TIMING_H
 
-#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstdint>
 #include <string_view>
+
+#include <irreden/ir_math.hpp>
 
 namespace IRRender {
 
@@ -80,7 +81,7 @@ struct CpuPhaseTiming {
 
     void record(double ms) {
         totalMs_ += ms;
-        maxMs_ = std::max(maxMs_, ms);
+        maxMs_ = IRMath::max(maxMs_, ms);
         ++sampleCount_;
     }
 
@@ -123,8 +124,8 @@ struct VoxelCullAccumulator {
     void record(std::uint32_t visible, std::uint32_t total) {
         visibleSum_ += visible;
         totalSum_ += total;
-        maxVisible_ = std::max(maxVisible_, visible);
-        maxTotal_ = std::max(maxTotal_, total);
+        maxVisible_ = IRMath::max(maxVisible_, visible);
+        maxTotal_ = IRMath::max(maxTotal_, total);
         ++sampleCount_;
     }
 

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -34,6 +34,14 @@ struct GpuStageTiming {
     float fbToScreenMs_ = 0.0f;
     std::uint32_t visibleShapeCount_ = 0;
     std::uint32_t shapeGroupsZ_ = 0;
+    // Cull diagnostic. Populated by VOXEL_TO_TRIXEL_STAGE_1 each frame
+    // from the prior frame's indirect-dispatch params + the current
+    // pool live count, so the readback is sync-free (frame N+1 reads
+    // frame N's already-written value before zeroing the buffer).
+    // Reports the *last* sampled frame; running averages live in
+    // VoxelCullAccumulator below.
+    std::uint32_t visibleVoxelCount_ = 0;
+    std::uint32_t totalVoxelCount_ = 0;
     // Only flipped between frames by Lua on the main thread (Lua runs in
     // INPUT/UPDATE, never RENDER). Stable across the RENDER pipeline, so
     // probes can read `enabled_` twice and rely on both values matching.
@@ -97,6 +105,40 @@ struct ComputeLightVolumeTiming {
 
 inline ComputeLightVolumeTiming &computeLightVolumeTiming() {
     static ComputeLightVolumeTiming instance;
+    return instance;
+}
+
+// Running cull-effectiveness accumulator. Each per-frame sample comes
+// from VOXEL_TO_TRIXEL_STAGE_1 reading the prior frame's indirect
+// dispatch params. The world's profile-report builder drains this at
+// shutdown; `enableFrameTiming(true)` calls reset() so each measurement
+// run starts from zero.
+struct VoxelCullAccumulator {
+    std::uint64_t visibleSum_ = 0;
+    std::uint64_t totalSum_ = 0;
+    std::uint32_t maxVisible_ = 0;
+    std::uint32_t maxTotal_ = 0;
+    std::uint32_t sampleCount_ = 0;
+
+    void record(std::uint32_t visible, std::uint32_t total) {
+        visibleSum_ += visible;
+        totalSum_ += total;
+        maxVisible_ = std::max(maxVisible_, visible);
+        maxTotal_ = std::max(maxTotal_, total);
+        ++sampleCount_;
+    }
+
+    void reset() {
+        visibleSum_ = 0;
+        totalSum_ = 0;
+        maxVisible_ = 0;
+        maxTotal_ = 0;
+        sampleCount_ = 0;
+    }
+};
+
+inline VoxelCullAccumulator &voxelCullAccumulator() {
+    static VoxelCullAccumulator instance;
     return instance;
 }
 

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -294,6 +294,23 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         }
         syncEntityIds(voxelPool, liveVoxelCount, voxelEntityIdBuf_);
 
+        // Cull diagnostic readback (gated by gpu_stage_timing.enabled_).
+        // The buffer still holds the prior frame's visibleCount; reading
+        // it here — before we zero it for this frame's compact pass — is
+        // a sync-free way to surface culling effectiveness. Frame N+1
+        // reads frame N's value; the first frame reports 0 and is
+        // discarded by the running average's sampleCount_.
+        if (gpuStageTiming().enabled_) {
+            VoxelIndirectDispatchParams previous{};
+            indirectBuf_->getSubData(0, sizeof(VoxelIndirectDispatchParams), &previous);
+            gpuStageTiming().visibleVoxelCount_ = previous.visibleCount;
+            gpuStageTiming().totalVoxelCount_ = static_cast<std::uint32_t>(liveVoxelCount);
+            voxelCullAccumulator().record(
+                previous.visibleCount,
+                static_cast<std::uint32_t>(liveVoxelCount)
+            );
+        }
+
         const VoxelIndirectDispatchParams zeroed{};
         indirectBuf_->subData(0, sizeof(VoxelIndirectDispatchParams), &zeroed);
 

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -296,10 +296,12 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
 
         // Cull diagnostic readback (gated by gpu_stage_timing.enabled_).
         // The buffer still holds the prior frame's visibleCount; reading
-        // it here — before we zero it for this frame's compact pass — is
-        // a sync-free way to surface culling effectiveness. Frame N+1
-        // reads frame N's value; the first frame reports 0 and is
-        // discarded by the running average's sampleCount_.
+        // it here — before we zero it for this frame's compact pass —
+        // requires no explicit fence: the driver serializes the CPU read
+        // against the prior frame's already-retired compact write.
+        // Frame N+1 reads frame N's value; the first frame reports 0,
+        // contributing a 1/N bias to the running average — negligible
+        // over typical measurement runs.
         if (gpuStageTiming().enabled_) {
             VoxelIndirectDispatchParams previous{};
             indirectBuf_->getSubData(0, sizeof(VoxelIndirectDispatchParams), &previous);

--- a/engine/profile/include/irreden/profile/profile_report.hpp
+++ b/engine/profile/include/irreden/profile/profile_report.hpp
@@ -34,6 +34,18 @@ struct CpuPhaseEntry {
     uint32_t sampleCount_ = 0;
 };
 
+/// Voxel cull-effectiveness summary populated from a per-frame
+/// accumulator in VOXEL_TO_TRIXEL_STAGE_1. avgVisible / avgTotal at
+/// zoom Z answer "did culling actually shrink the working set?" A
+/// flat ratio across zooms is the signature of broken culling.
+struct VoxelCullStatsSummary {
+    uint64_t visibleSum_ = 0;
+    uint64_t totalSum_ = 0;
+    uint32_t maxVisible_ = 0;
+    uint32_t maxTotal_ = 0;
+    uint32_t sampleCount_ = 0;
+};
+
 /// Aggregated data for a profile report, populated by World at shutdown.
 struct ProfileReport {
     std::vector<float> frameTimesMs_;
@@ -45,6 +57,7 @@ struct ProfileReport {
     std::vector<SystemTimingEntry> systemTimings_;
     std::vector<GpuStageEntry> gpuStages_;
     std::vector<CpuPhaseEntry> cpuPhases_;
+    VoxelCullStatsSummary voxelCullStats_;
 };
 
 /// Write a plain-text profile report to the given file path.

--- a/engine/profile/src/profile_report.cpp
+++ b/engine/profile/src/profile_report.cpp
@@ -167,6 +167,32 @@ void writeProfileReport(const ProfileReport &report, const char *outputPath) {
         std::fprintf(f, "\n");
     }
 
+    // --- Voxel cull stats ---
+    if (report.voxelCullStats_.sampleCount_ > 0) {
+        const auto &c = report.voxelCullStats_;
+        const double samples = static_cast<double>(c.sampleCount_);
+        const double avgVisible = static_cast<double>(c.visibleSum_) / samples;
+        const double avgTotal = static_cast<double>(c.totalSum_) / samples;
+        const double ratio = avgTotal > 0.0 ? avgVisible / avgTotal : 0.0;
+        std::fprintf(f, "--- Voxel cull stats ---\n");
+        std::fprintf(f, "%-12s %14s %14s %10s\n", "", "Avg", "Max", "Samples");
+        std::fprintf(
+            f,
+            "%-12s %14.1f %14u %10u\n",
+            "Visible",
+            avgVisible,
+            c.maxVisible_,
+            c.sampleCount_
+        );
+        std::fprintf(f, "%-12s %14.1f %14u %10u\n", "Total", avgTotal, c.maxTotal_, c.sampleCount_);
+        std::fprintf(
+            f,
+            "Ratio:       %14.4f (visible/total — 1.0 = no cull, 0.0 = all culled)\n",
+            ratio
+        );
+        std::fprintf(f, "\n");
+    }
+
     // --- CPU phase timing ---
     if (!report.cpuPhases_.empty()) {
         std::fprintf(f, "--- CPU phase timing ---\n");

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -149,6 +149,23 @@ void World::setupLuaBindings(const std::vector<LuaBindingRegistration> &bindings
         }
         return 0.0f;
     };
+    // Voxel cull diagnostic. Returns last-sampled visible + total
+    // voxel counts plus the running average + max collected since the
+    // last enableFrameTiming(true). Only populated while
+    // gpu_stage_timing is enabled.
+    render["getVoxelCullStats"] = [&lua]() {
+        sol::table out = lua.create_table();
+        const auto &timing = IRRender::gpuStageTiming();
+        const auto &acc = IRRender::voxelCullAccumulator();
+        out["visible"] = timing.visibleVoxelCount_;
+        out["total"] = timing.totalVoxelCount_;
+        out["samples"] = acc.sampleCount_;
+        out["avgVisible"] = acc.sampleCount_ > 0 ? acc.visibleSum_ / acc.sampleCount_ : 0;
+        out["avgTotal"] = acc.sampleCount_ > 0 ? acc.totalSum_ / acc.sampleCount_ : 0;
+        out["maxVisible"] = acc.maxVisible_;
+        out["maxTotal"] = acc.maxTotal_;
+        return out;
+    };
 
     for (const auto &bind : bindings) {
         bind(m_lua);
@@ -287,6 +304,7 @@ void World::enableFrameTiming(bool enabled) {
         m_frameMaxUpdateTicksPerFrame = 0;
         m_systemManager.resetTimingStats();
         IRRender::computeLightVolumeTiming().reset();
+        IRRender::voxelCullAccumulator().reset();
     }
 }
 
@@ -320,6 +338,13 @@ void World::buildAndWriteProfileReport() {
          lightVolumeTiming.upload_.maxMs_,
          lightVolumeTiming.upload_.sampleCount_}
     );
+
+    const auto &cull = IRRender::voxelCullAccumulator();
+    report.voxelCullStats_.visibleSum_ = cull.visibleSum_;
+    report.voxelCullStats_.totalSum_ = cull.totalSum_;
+    report.voxelCullStats_.maxVisible_ = cull.maxVisible_;
+    report.voxelCullStats_.maxTotal_ = cull.maxTotal_;
+    report.voxelCullStats_.sampleCount_ = cull.sampleCount_;
 
     // Collect per-system timing, grouped by pipeline
     auto pipelineName = [](IRTime::Events e) -> const char * {

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -160,8 +160,10 @@ void World::setupLuaBindings(const std::vector<LuaBindingRegistration> &bindings
         out["visible"] = timing.visibleVoxelCount_;
         out["total"] = timing.totalVoxelCount_;
         out["samples"] = acc.sampleCount_;
-        out["avgVisible"] = acc.sampleCount_ > 0 ? acc.visibleSum_ / acc.sampleCount_ : 0;
-        out["avgTotal"] = acc.sampleCount_ > 0 ? acc.totalSum_ / acc.sampleCount_ : 0;
+        out["avgVisible"] =
+            acc.sampleCount_ > 0 ? static_cast<double>(acc.visibleSum_) / acc.sampleCount_ : 0.0;
+        out["avgTotal"] =
+            acc.sampleCount_ > 0 ? static_cast<double>(acc.totalSum_) / acc.sampleCount_ : 0.0;
         out["maxVisible"] = acc.maxVisible_;
         out["maxTotal"] = acc.maxTotal_;
         return out;

--- a/scripts/perf/compare_perf_runs.py
+++ b/scripts/perf/compare_perf_runs.py
@@ -36,6 +36,9 @@ FRAME_RE = re.compile(
     r"p99=([\d.]+)ms\s+min=([\d.]+)ms\s+max=([\d.]+)ms"
 )
 ENTITY_RE = re.compile(r"Entity count:\s+(\d+)\s+\((\d+)\s+archetypes\)")
+CULL_VISIBLE_RE = re.compile(r"^Visible\s+([\d.]+)\s+(\d+)\s+(\d+)")
+CULL_TOTAL_RE = re.compile(r"^Total\s+([\d.]+)\s+(\d+)\s+(\d+)")
+CULL_RATIO_RE = re.compile(r"^Ratio:\s+([\d.]+)")
 SYSTEM_RE = re.compile(
     r"^(INPUT|UPDATE|RENDER)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+"
     r"([\d.]+)\s+(\d+)\s+(\d+)"
@@ -73,6 +76,16 @@ class GpuStage:
 
 
 @dataclass
+class CullStats:
+    avg_visible: float = 0.0
+    avg_total: float = 0.0
+    max_visible: int = 0
+    max_total: int = 0
+    samples: int = 0
+    ratio: float = 0.0
+
+
+@dataclass
 class CellReport:
     cell_id: str
     frame: FrameTiming = field(default_factory=FrameTiming)
@@ -80,6 +93,7 @@ class CellReport:
     archetype_count: int = 0
     systems: List[SystemTiming] = field(default_factory=list)
     gpu_stages: List[GpuStage] = field(default_factory=list)
+    cull: CullStats = field(default_factory=CullStats)
     raw: str = ""
 
     def system_by_name(self, name: str) -> Optional[SystemTiming]:
@@ -130,6 +144,9 @@ def parse_report(path: Path, cell_id: str) -> CellReport:
         if s.startswith("--- GPU stage timing"):
             section = "gpu"
             continue
+        if s.startswith("--- Voxel cull stats"):
+            section = "cull"
+            continue
         if s.startswith("--- CPU phase timing"):
             section = "cpu_phase"
             continue
@@ -160,6 +177,21 @@ def parse_report(path: Path, cell_id: str) -> CellReport:
                     avg_ms=float(m.group(2)),
                     max_ms=float(m.group(3)),
                 ))
+        elif section == "cull":
+            m = CULL_VISIBLE_RE.match(s)
+            if m:
+                report.cull.avg_visible = float(m.group(1))
+                report.cull.max_visible = int(m.group(2))
+                report.cull.samples = int(m.group(3))
+                continue
+            m = CULL_TOTAL_RE.match(s)
+            if m:
+                report.cull.avg_total = float(m.group(1))
+                report.cull.max_total = int(m.group(2))
+                continue
+            m = CULL_RATIO_RE.match(s)
+            if m:
+                report.cull.ratio = float(m.group(1))
     return report
 
 
@@ -246,6 +278,27 @@ def render_markdown(
     matched = sorted(set(base) & set(head))
     base_only = sorted(set(base) - set(head))
     head_only = sorted(set(head) - set(base))
+
+    if not cpu_only:
+        has_cull = any(c.cull.samples > 0 for c in list(base.values()) + list(head.values()))
+        if has_cull:
+            out.append("## voxel cull effectiveness (visible / total)")
+            out.append("")
+            out.append("| cell | ratio (base→head) | avg visible | total |")
+            out.append("|------|-------------------|-------------|-------|")
+            for cell_id in matched:
+                bc = base[cell_id].cull
+                hc = head[cell_id].cull
+                if bc.samples == 0 and hc.samples == 0:
+                    continue
+                ratio_delta_pp = (hc.ratio - bc.ratio) * 100.0  # percentage points
+                out.append(
+                    f"| `{cell_id}` "
+                    f"| {bc.ratio:.3f} → {hc.ratio:.3f} ({ratio_delta_pp:+.1f}pp) "
+                    f"| {bc.avg_visible:.0f} → {hc.avg_visible:.0f} "
+                    f"| {bc.avg_total:.0f} → {hc.avg_total:.0f} |"
+                )
+            out.append("")
 
     if not cpu_only:
         out.append("## frame timing (ms)")

--- a/scripts/perf/compare_perf_runs.py
+++ b/scripts/perf/compare_perf_runs.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""compare_perf_runs.py — diff two perf_grid_matrix output directories.
+
+Parses the plain-text profile_report.txt files written into both runs by
+perf_grid_matrix.sh and prints a markdown table suitable for pasting into
+a PR body. Highlights regressions (slower head) with ⚠ and improvements
+with ↓.
+
+Usage:
+    scripts/perf/compare_perf_runs.py <baseline_dir> <head_dir>
+        [--regress-pct N] [--improve-pct N] [--gpu-only] [--cpu-only]
+
+Both directories must contain manifest.json plus one .txt file per cell.
+Cells are matched by their "id" field; cells present in only one side
+appear in a separate "unmatched cells" section.
+
+Stdlib only — must run on any Python 3.9+ without extra deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+# --- Parser --------------------------------------------------------------
+
+FRAME_RE = re.compile(
+    r"Frame time:\s+avg=([\d.]+)ms\s+p50=([\d.]+)ms\s+p95=([\d.]+)ms\s+"
+    r"p99=([\d.]+)ms\s+min=([\d.]+)ms\s+max=([\d.]+)ms"
+)
+ENTITY_RE = re.compile(r"Entity count:\s+(\d+)\s+\((\d+)\s+archetypes\)")
+SYSTEM_RE = re.compile(
+    r"^(INPUT|UPDATE|RENDER)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+"
+    r"([\d.]+)\s+(\d+)\s+(\d+)"
+)
+GPU_RE = re.compile(r"^(\S+)\s+([\d.]+)\s+([\d.]+)\s*$")
+
+
+@dataclass
+class FrameTiming:
+    avg: float = 0.0
+    p50: float = 0.0
+    p95: float = 0.0
+    p99: float = 0.0
+    min_: float = 0.0
+    max_: float = 0.0
+
+
+@dataclass
+class SystemTiming:
+    pipeline: str
+    name: str
+    total_ms: float
+    avg_ms: float
+    min_ms: float
+    max_ms: float
+    calls: int
+    entities: int
+
+
+@dataclass
+class GpuStage:
+    name: str
+    avg_ms: float
+    max_ms: float
+
+
+@dataclass
+class CellReport:
+    cell_id: str
+    frame: FrameTiming = field(default_factory=FrameTiming)
+    entity_count: int = 0
+    archetype_count: int = 0
+    systems: List[SystemTiming] = field(default_factory=list)
+    gpu_stages: List[GpuStage] = field(default_factory=list)
+    raw: str = ""
+
+    def system_by_name(self, name: str) -> Optional[SystemTiming]:
+        for s in self.systems:
+            if s.name == name:
+                return s
+        return None
+
+    def gpu_by_name(self, name: str) -> Optional[GpuStage]:
+        for s in self.gpu_stages:
+            if s.name == name:
+                return s
+        return None
+
+
+def parse_report(path: Path, cell_id: str) -> CellReport:
+    report = CellReport(cell_id=cell_id)
+    if not path.exists():
+        return report
+    text = path.read_text()
+    report.raw = text
+
+    m = FRAME_RE.search(text)
+    if m:
+        report.frame = FrameTiming(
+            avg=float(m.group(1)),
+            p50=float(m.group(2)),
+            p95=float(m.group(3)),
+            p99=float(m.group(4)),
+            min_=float(m.group(5)),
+            max_=float(m.group(6)),
+        )
+
+    m = ENTITY_RE.search(text)
+    if m:
+        report.entity_count = int(m.group(1))
+        report.archetype_count = int(m.group(2))
+
+    # Section-aware scan so SYSTEM_RE and GPU_RE don't cross-match each
+    # other's rows (their token shapes are similar enough to confuse a
+    # full-file regex sweep).
+    section: Optional[str] = None
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("--- Per-system timing"):
+            section = "systems"
+            continue
+        if s.startswith("--- GPU stage timing"):
+            section = "gpu"
+            continue
+        if s.startswith("--- CPU phase timing"):
+            section = "cpu_phase"
+            continue
+        if s.startswith("=== END REPORT"):
+            section = None
+            continue
+        if not s or s.startswith("Pipeline") or s.startswith("Stage") or s.startswith("Phase"):
+            continue
+
+        if section == "systems":
+            m = SYSTEM_RE.match(s)
+            if m:
+                report.systems.append(SystemTiming(
+                    pipeline=m.group(1),
+                    name=m.group(2),
+                    total_ms=float(m.group(3)),
+                    avg_ms=float(m.group(4)),
+                    min_ms=float(m.group(5)),
+                    max_ms=float(m.group(6)),
+                    calls=int(m.group(7)),
+                    entities=int(m.group(8)),
+                ))
+        elif section == "gpu":
+            m = GPU_RE.match(s)
+            if m:
+                report.gpu_stages.append(GpuStage(
+                    name=m.group(1),
+                    avg_ms=float(m.group(2)),
+                    max_ms=float(m.group(3)),
+                ))
+    return report
+
+
+def load_run(run_dir: Path) -> Dict[str, CellReport]:
+    cells: Dict[str, CellReport] = {}
+    manifest = run_dir / "manifest.json"
+    if not manifest.exists():
+        print(f"compare_perf_runs: no manifest.json in {run_dir}", file=sys.stderr)
+        return cells
+    data = json.loads(manifest.read_text())
+    for cell in data.get("cells", []):
+        cell_id = cell.get("id")
+        if not cell_id:
+            continue
+        report_name = cell.get("report") or f"{cell_id}.txt"
+        cells[cell_id] = parse_report(run_dir / report_name, cell_id)
+    return cells
+
+
+# --- Comparator ----------------------------------------------------------
+
+def pct_delta(baseline: float, head: float) -> float:
+    if baseline <= 0.0:
+        return 0.0
+    return (head - baseline) / baseline * 100.0
+
+
+def mark(delta_pct: float, regress_pct: float, improve_pct: float) -> str:
+    if delta_pct >= regress_pct:
+        return " ⚠"
+    if delta_pct <= -improve_pct:
+        return " ↓"
+    return ""
+
+
+def format_frame_row(
+    cell_id: str,
+    base: CellReport,
+    head: CellReport,
+    regress_pct: float,
+    improve_pct: float,
+) -> str:
+    avg_b, avg_h = base.frame.avg, head.frame.avg
+    p99_b, p99_h = base.frame.p99, head.frame.p99
+    avg_delta = pct_delta(avg_b, avg_h)
+    p99_delta = pct_delta(p99_b, p99_h)
+    return (
+        f"| `{cell_id}` "
+        f"| {avg_b:.2f} → {avg_h:.2f} ({avg_delta:+.1f}%){mark(avg_delta, regress_pct, improve_pct)} "
+        f"| {p99_b:.2f} → {p99_h:.2f} ({p99_delta:+.1f}%){mark(p99_delta, regress_pct, improve_pct)} |"
+    )
+
+
+def collect_gpu_names(cells: Iterable[CellReport]) -> List[str]:
+    names: List[str] = []
+    seen = set()
+    for c in cells:
+        for s in c.gpu_stages:
+            if s.name not in seen:
+                seen.add(s.name)
+                names.append(s.name)
+    return names
+
+
+def render_markdown(
+    base_dir: Path,
+    head_dir: Path,
+    base: Dict[str, CellReport],
+    head: Dict[str, CellReport],
+    regress_pct: float,
+    improve_pct: float,
+    gpu_only: bool,
+    cpu_only: bool,
+) -> str:
+    out: List[str] = []
+    out.append(f"# perf comparison: {base_dir.name} → {head_dir.name}")
+    out.append("")
+    out.append(f"baseline: `{base_dir}`")
+    out.append(f"head:     `{head_dir}`")
+    out.append("")
+    out.append(f"thresholds: regress ≥ {regress_pct:.0f}%, improve ≥ {improve_pct:.0f}%")
+    out.append("")
+
+    matched = sorted(set(base) & set(head))
+    base_only = sorted(set(base) - set(head))
+    head_only = sorted(set(head) - set(base))
+
+    if not cpu_only:
+        out.append("## frame timing (ms)")
+        out.append("")
+        out.append("| cell | avg | p99 |")
+        out.append("|------|-----|-----|")
+        for cell_id in matched:
+            out.append(format_frame_row(cell_id, base[cell_id], head[cell_id], regress_pct, improve_pct))
+        out.append("")
+
+    if not cpu_only:
+        gpu_names = collect_gpu_names(list(base.values()) + list(head.values()))
+        if gpu_names:
+            out.append("## GPU stage timing (avg ms per frame)")
+            out.append("")
+            header = "| cell | " + " | ".join(gpu_names) + " |"
+            sep = "|------|" + "|".join(["----"] * len(gpu_names)) + "|"
+            out.append(header)
+            out.append(sep)
+            for cell_id in matched:
+                row = [f"`{cell_id}`"]
+                for name in gpu_names:
+                    sb = base[cell_id].gpu_by_name(name)
+                    sh = head[cell_id].gpu_by_name(name)
+                    if sb is None and sh is None:
+                        row.append("—")
+                        continue
+                    bv = sb.avg_ms if sb else 0.0
+                    hv = sh.avg_ms if sh else 0.0
+                    delta = pct_delta(bv, hv)
+                    row.append(f"{bv:.2f}→{hv:.2f}{mark(delta, regress_pct, improve_pct)}")
+                out.append("| " + " | ".join(row) + " |")
+            out.append("")
+
+    if not gpu_only:
+        out.append("## top CPU systems by avg ms (head)")
+        out.append("")
+        for cell_id in matched:
+            head_cell = head[cell_id]
+            base_cell = base[cell_id]
+            top = sorted(head_cell.systems, key=lambda s: s.avg_ms, reverse=True)[:8]
+            if not top:
+                continue
+            out.append(f"### `{cell_id}`")
+            out.append("")
+            out.append("| pipeline | system | avg ms (base→head) |")
+            out.append("|----------|--------|--------------------|")
+            for s in top:
+                sb = base_cell.system_by_name(s.name)
+                bv = sb.avg_ms if sb else 0.0
+                delta = pct_delta(bv, s.avg_ms)
+                out.append(
+                    f"| {s.pipeline} | `{s.name}` "
+                    f"| {bv:.3f} → {s.avg_ms:.3f} ({delta:+.1f}%){mark(delta, regress_pct, improve_pct)} |"
+                )
+            out.append("")
+
+    if base_only or head_only:
+        out.append("## unmatched cells")
+        out.append("")
+        if base_only:
+            out.append(f"only in baseline: {', '.join(f'`{c}`' for c in base_only)}")
+        if head_only:
+            out.append(f"only in head: {', '.join(f'`{c}`' for c in head_only)}")
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("baseline")
+    p.add_argument("head")
+    p.add_argument("--regress-pct", type=float, default=10.0)
+    p.add_argument("--improve-pct", type=float, default=5.0)
+    p.add_argument("--gpu-only", action="store_true")
+    p.add_argument("--cpu-only", action="store_true")
+    args = p.parse_args()
+
+    base_dir = Path(args.baseline).resolve()
+    head_dir = Path(args.head).resolve()
+
+    if not base_dir.is_dir() or not head_dir.is_dir():
+        print("compare_perf_runs: both arguments must be existing directories", file=sys.stderr)
+        return 2
+
+    base = load_run(base_dir)
+    head = load_run(head_dir)
+
+    if not base or not head:
+        print("compare_perf_runs: one of the runs has no cells", file=sys.stderr)
+        return 1
+
+    print(render_markdown(base_dir, head_dir, base, head,
+                          args.regress_pct, args.improve_pct,
+                          args.gpu_only, args.cpu_only), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf/compare_perf_runs.py
+++ b/scripts/perf/compare_perf_runs.py
@@ -325,6 +325,9 @@ def main() -> int:
     p.add_argument("--cpu-only", action="store_true")
     args = p.parse_args()
 
+    if args.gpu_only and args.cpu_only:
+        p.error("--gpu-only and --cpu-only are mutually exclusive")
+
     base_dir = Path(args.baseline).resolve()
     head_dir = Path(args.head).resolve()
 

--- a/scripts/perf/perf_grid_matrix.sh
+++ b/scripts/perf/perf_grid_matrix.sh
@@ -10,8 +10,8 @@
 #   scripts/perf/perf_grid_matrix.sh --target IRLuaPerfGrid
 #   scripts/perf/perf_grid_matrix.sh --label baseline    # output dir suffix
 #   scripts/perf/perf_grid_matrix.sh --frames 600        # frames per cell (default 300)
-#   scripts/perf/perf_grid_matrix.sh --full              # extended matrix (24 cells)
-#   scripts/perf/perf_grid_matrix.sh --quick             # smoke matrix (3 cells)
+#   scripts/perf/perf_grid_matrix.sh --full              # extended matrix (30 cells)
+#   scripts/perf/perf_grid_matrix.sh --quick             # smoke matrix (2 cells)
 #   scripts/perf/perf_grid_matrix.sh --grid-size 32      # smaller grid (default 64)
 #
 # Output:

--- a/scripts/perf/perf_grid_matrix.sh
+++ b/scripts/perf/perf_grid_matrix.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# perf_grid_matrix.sh — drive IRPerfGrid (or IRLuaPerfGrid) across a
+# matrix of (zoom × subdivision_mode × base_subdivisions) cells and
+# collect one save_files/profile_report.txt per cell into a single
+# output directory. Output is consumed by scripts/perf/compare_perf_runs.py
+# and scripts/perf/perf_summary.py.
+#
+# Usage:
+#   scripts/perf/perf_grid_matrix.sh                     # default 12-cell matrix, IRPerfGrid
+#   scripts/perf/perf_grid_matrix.sh --target IRLuaPerfGrid
+#   scripts/perf/perf_grid_matrix.sh --label baseline    # output dir suffix
+#   scripts/perf/perf_grid_matrix.sh --frames 600        # frames per cell (default 300)
+#   scripts/perf/perf_grid_matrix.sh --full              # extended matrix (24 cells)
+#   scripts/perf/perf_grid_matrix.sh --quick             # smoke matrix (3 cells)
+#   scripts/perf/perf_grid_matrix.sh --grid-size 32      # smaller grid (default 64)
+#
+# Output:
+#   save_files/perf/<git-sha>[-<label>]/<cell-id>.txt    # raw profile_report.txt
+#   save_files/perf/<git-sha>[-<label>]/manifest.json    # cell metadata + git state
+#
+# Cell ID format: target=<exe>,zoom=<z>,sub_mode=<m>,sub_base=<n>,grid=<g>
+#
+# Skills/agents: invoke this once before a change, once after, then
+# pass both output dirs to compare_perf_runs.py.
+
+set -euo pipefail
+
+_FLEET_COMMON_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../fleet" && pwd)/fleet-common.sh"
+if [[ -f "$_FLEET_COMMON_SH" ]]; then
+    # shellcheck source=../fleet/fleet-common.sh
+    source "$_FLEET_COMMON_SH"
+else
+    detect_engine_root() {
+        git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/src/IrredenEngine"
+    }
+fi
+
+ENGINE_ROOT="$(detect_engine_root)"
+TARGET="IRPerfGrid"
+LABEL=""
+FRAMES=300
+GRID_SIZE=""
+TIMEOUT=90
+MATRIX="default"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target) TARGET="$2"; shift 2 ;;
+        --label) LABEL="$2"; shift 2 ;;
+        --frames) FRAMES="$2"; shift 2 ;;
+        --grid-size) GRID_SIZE="$2"; shift 2 ;;
+        --timeout) TIMEOUT="$2"; shift 2 ;;
+        --full) MATRIX="full"; shift ;;
+        --quick) MATRIX="quick"; shift ;;
+        --default) MATRIX="default"; shift ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "perf_grid_matrix.sh: unknown arg '$1' (try --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$MATRIX" in
+    quick)
+        ZOOMS=(1 4)
+        SUB_MODES=(full)
+        SUB_BASES=(1)
+        ;;
+    default)
+        ZOOMS=(1 2 4 8)
+        SUB_MODES=(full position_only none)
+        SUB_BASES=(1)
+        ;;
+    full)
+        ZOOMS=(1 2 4 8 16)
+        SUB_MODES=(full position_only none)
+        SUB_BASES=(1 4)
+        ;;
+esac
+
+SHA="$(git -C "$ENGINE_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+DIRTY=""
+if ! git -C "$ENGINE_ROOT" diff --quiet 2>/dev/null; then
+    DIRTY="-dirty"
+fi
+RUN_NAME="${SHA}${DIRTY}"
+if [[ -n "$LABEL" ]]; then
+    RUN_NAME="${RUN_NAME}-${LABEL}"
+fi
+OUT_DIR="$ENGINE_ROOT/save_files/perf/$RUN_NAME"
+mkdir -p "$OUT_DIR"
+
+CELL_COUNT=$(( ${#ZOOMS[@]} * ${#SUB_MODES[@]} * ${#SUB_BASES[@]} ))
+echo "perf_grid_matrix: target=$TARGET matrix=$MATRIX cells=$CELL_COUNT frames=$FRAMES out=$OUT_DIR"
+
+if ! command -v fleet-run >/dev/null 2>&1; then
+    echo "perf_grid_matrix: fleet-run not on PATH; aborting" >&2
+    exit 1
+fi
+
+# The demo runs from its own build dir (via fleet-run), so the profile
+# report lands under build/creations/demos/<demo>/save_files/. Snapshot
+# mtime before each cell and copy the freshest profile_report.txt
+# afterwards — robust to whatever build dir layout fleet-run picks.
+BUILD_ROOT="$ENGINE_ROOT/build"
+find_latest_report() {
+    find "$BUILD_ROOT" -path "*/save_files/profile_report.txt" \
+        -newer "$1" -print 2>/dev/null | head -1
+}
+
+# manifest.json header — we append cell entries inside the loop.
+MANIFEST="$OUT_DIR/manifest.json"
+{
+    echo "{"
+    echo "  \"target\": \"$TARGET\","
+    echo "  \"matrix\": \"$MATRIX\","
+    echo "  \"frames\": $FRAMES,"
+    echo "  \"git_sha\": \"$SHA\","
+    echo "  \"git_dirty\": $([[ -n "$DIRTY" ]] && echo true || echo false),"
+    echo "  \"run_name\": \"$RUN_NAME\","
+    echo "  \"started_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+    echo "  \"cells\": ["
+} > "$MANIFEST"
+
+FIRST=1
+INDEX=0
+for ZOOM in "${ZOOMS[@]}"; do
+    for SUB_MODE in "${SUB_MODES[@]}"; do
+        for SUB_BASE in "${SUB_BASES[@]}"; do
+            INDEX=$((INDEX + 1))
+            CELL_ID="target=${TARGET},zoom=${ZOOM},sub_mode=${SUB_MODE},sub_base=${SUB_BASE}"
+            if [[ -n "$GRID_SIZE" ]]; then
+                CELL_ID="${CELL_ID},grid=${GRID_SIZE}"
+            fi
+            CELL_TXT="$OUT_DIR/${CELL_ID}.txt"
+            CELL_LOG="$OUT_DIR/${CELL_ID}.log"
+            echo "[$INDEX/$CELL_COUNT] $CELL_ID"
+
+            CELL_ARGS=(--auto-profile "$FRAMES" --zoom "$ZOOM"
+                       --subdivision-mode "$SUB_MODE"
+                       --base-subdivisions "$SUB_BASE")
+            if [[ -n "$GRID_SIZE" ]]; then
+                CELL_ARGS+=(--grid-size "$GRID_SIZE")
+            fi
+
+            MARKER="$OUT_DIR/.cell_marker"
+            touch "$MARKER"
+
+            STATUS=0
+            fleet-run --timeout "$TIMEOUT" "$TARGET" "${CELL_ARGS[@]}" \
+                > "$CELL_LOG" 2>&1 || STATUS=$?
+
+            REPORT="$(find_latest_report "$MARKER")"
+            if [[ -n "$REPORT" && -f "$REPORT" ]]; then
+                cp "$REPORT" "$CELL_TXT"
+                CELL_STATUS="ok"
+            else
+                CELL_STATUS="no_report"
+                echo "  (no profile_report.txt produced; see $CELL_LOG)"
+            fi
+
+            if [[ $FIRST -eq 1 ]]; then
+                FIRST=0
+            else
+                echo "," >> "$MANIFEST"
+            fi
+            cat >> "$MANIFEST" <<EOF
+    {"id": "$CELL_ID", "zoom": $ZOOM, "sub_mode": "$SUB_MODE", "sub_base": $SUB_BASE, "exit_status": $STATUS, "status": "$CELL_STATUS", "report": "${CELL_ID}.txt"}
+EOF
+        done
+    done
+done
+
+{
+    echo ""
+    echo "  ],"
+    echo "  \"finished_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\""
+    echo "}"
+} >> "$MANIFEST"
+
+echo "perf_grid_matrix: done, output in $OUT_DIR"
+echo "  next: scripts/perf/perf_summary.py $OUT_DIR"
+echo "  diff: scripts/perf/compare_perf_runs.py <baseline> $OUT_DIR"

--- a/scripts/perf/perf_summary.py
+++ b/scripts/perf/perf_summary.py
@@ -42,17 +42,20 @@ def main() -> int:
     print(f"location: `{run_dir}`")
     print(f"cells: {len(cells)}")
     print()
-    print("| cell | frame avg | p99 | entities | top GPU stage |")
-    print("|------|-----------|-----|----------|---------------|")
+    print("| cell | frame avg | p99 | entities | cull (vis/total) | top GPU stage |")
+    print("|------|-----------|-----|----------|------------------|---------------|")
     for cell_id in sorted(cells):
         c = cells[cell_id]
         top_gpu = ""
         if c.gpu_stages:
             top = max(c.gpu_stages, key=lambda s: s.avg_ms)
             top_gpu = f"`{top.name}` ({top.avg_ms:.2f}ms)"
+        cull = ""
+        if c.cull.samples > 0:
+            cull = f"{c.cull.ratio:.2f} ({c.cull.avg_visible:.0f}/{c.cull.avg_total:.0f})"
         print(
             f"| `{cell_id}` | {c.frame.avg:.2f}ms | {c.frame.p99:.2f}ms "
-            f"| {c.entity_count} | {top_gpu} |"
+            f"| {c.entity_count} | {cull} | {top_gpu} |"
         )
     return 0
 

--- a/scripts/perf/perf_summary.py
+++ b/scripts/perf/perf_summary.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""perf_summary.py — one-screen markdown summary of a perf_grid_matrix run.
+
+Reads <run_dir>/manifest.json and the per-cell profile_report.txt files,
+then prints a compact markdown table: cell, frame avg/p99, entity count,
+top GPU stage. Use this on its own when you don't have a baseline to
+diff against (e.g. first run on a fresh checkout).
+
+Usage:
+    scripts/perf/perf_summary.py <run_dir>
+
+Stdlib only — must run on any Python 3.9+ without extra deps.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PARENT = Path(__file__).resolve().parent
+sys.path.insert(0, str(_PARENT))
+from compare_perf_runs import load_run  # noqa: E402
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    run_dir = Path(sys.argv[1]).resolve()
+    if not run_dir.is_dir():
+        print(f"perf_summary: {run_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    cells = load_run(run_dir)
+    if not cells:
+        print("perf_summary: no cells found (missing manifest.json?)", file=sys.stderr)
+        return 1
+
+    print(f"# perf summary: {run_dir.name}")
+    print()
+    print(f"location: `{run_dir}`")
+    print(f"cells: {len(cells)}")
+    print()
+    print("| cell | frame avg | p99 | entities | top GPU stage |")
+    print("|------|-----------|-----|----------|---------------|")
+    for cell_id in sorted(cells):
+        c = cells[cell_id]
+        top_gpu = ""
+        if c.gpu_stages:
+            top = max(c.gpu_stages, key=lambda s: s.avg_ms)
+            top_gpu = f"`{top.name}` ({top.avg_ms:.2f}ms)"
+        print(
+            f"| `{cell_id}` | {c.frame.avg:.2f}ms | {c.frame.p99:.2f}ms "
+            f"| {c.entity_count} | {top_gpu} |"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR N+1 of the perf series, **stacked on https://github.com/jakildev/IrredenEngine/pull/1019** (target base: `claude/perf-cull-instrumentation`).

Rewrites the `/optimize` skill around the `scripts/perf/` infrastructure landed in PR #1016 and the cull diagnostic from PR #1019. The previous SKILL.md was prose-heavy (319 lines); the new version is 159 lines plus a richer `reference/` library that loads on-demand.

## What changed

The skill now leans on **scripts for everything repeatable**. Decision-making (which optimization to pick, when the matrix delta justifies the change) stays in the playbook; copy-pasted command sequences move out to either `scripts/perf/` or `reference/`.

  | File | Lines | Purpose |
  |------|-------|---------|
  | `SKILL.md` | **159** (was 319) | 7-step playbook: triage → baseline → scan → profile → fix → measure → report → self-improve |
  | `reference/script_first.md` | 66 | The "no prose for repeatable work" principle, with the boundary rule |
  | `reference/profiling_recipe.md` | 99 | The `perf_grid_matrix.sh` / `compare_perf_runs.py` ritual |
  | `reference/cpu_profiling.md` | 91 | `IR_PROFILE_*` macros + easy_profiler |
  | `reference/gpu_profiling.md` | 99 | `getPassTimings()`, `getVoxelCullStats()`, sync/async caveat |
  | `reference/common_bottlenecks.md` | 197 | Curated catalog of 11 patterns with file:line examples |
  | `reference/big_wins.md` | 119 | Six case studies (Phase 1a GPU LV, T-289, T-287, T-275, PR #1016, PR #1019) |
  | `reference/partner_skills.md` | 126 | Cross-refs to simplify, render-verify, attach-screenshots, etc. |

## The mandatory step 7 (self-improve)

Every run that finds a new bottleneck pattern, a new repeatable shell sequence, or a new partner-skill cross-ref **must** update the reference in the same PR as the fix. The catalog grows; the playbook stays small.

This is what makes the skill compound — the next session inherits the work instead of re-deriving it.

## Catalog seeded with this session's findings

`reference/common_bottlenecks.md` is seeded with 11 patterns including:

- **Shadow-feeder sweep inflates cull bounds at high zoom** (issue #1020 — the actual root cause uncovered by PR #1019's diagnostic)
- O(sub²) per-shape tile generation in `SHAPES_TO_TRIXEL`
- `numGroupsZ = subdivisions²` voxel dispatch growth
- Per-frame buffer upload without push-at-mutation
- Plus the ECS footgun, allocation-in-tick, function-local-static, and four more

`reference/big_wins.md` includes the **Phase 1a GPU light volume rewrite** as the canonical "1800× single-pass win" case study (72 ms CPU populate → 0.04 ms after GPU dilation).

## Test plan

- [x] `SKILL.md` is valid YAML frontmatter + markdown body
- [x] All `reference/` cross-links resolve relative to `SKILL.md`
- [x] No broken links to scripts (`scripts/perf/perf_grid_matrix.sh` etc. all exist on this branch)
- [x] No broken links to issues (#1016, #1019, #1020, #1021, #1023 are real)
- [ ] Reviewer: invoke the new `/optimize` skill on a manufactured small render diff and confirm it actually reaches the matrix script and produces sensible output

## Stack context

Stacked on https://github.com/jakildev/IrredenEngine/pull/1019. Review independently — only touches `.claude/skills/optimize/`. When `claude/perf-cull-instrumentation` merges, I'll rebase mechanically.

The next PR in the series (`PR N+2`) adds a top-level "Script-first for repeatable work" subsection to `docs/agents/CLAUDE-BASELINE.md` so the principle applies engine-wide, not just to this skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)