### PR TITLE
T-303: math: IRMath grid-iteration and 3D-mask helpers

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -446,14 +446,12 @@ void applyFillAABB(
         IRMath::max(worldA.y, worldB.y),
         IRMath::max(worldA.z, worldB.z)
     };
-    for (int z = lo.z; z <= hi.z; ++z)
-        for (int y = lo.y; y <= hi.y; ++y)
-            for (int x = lo.x; x <= hi.x; ++x) {
-                ivec3 local{};
-                std::size_t flat = 0;
-                if (worldVoxelToLocal(set, gpos, {x, y, z}, local, flat))
-                    applyEdit(entity, set, local, flat, place, color);
-            }
+    IRMath::iterateAABB(lo, hi, [&](int x, int y, int z) {
+        ivec3 local{};
+        std::size_t flat = 0;
+        if (worldVoxelToLocal(set, gpos, {x, y, z}, local, flat))
+            applyEdit(entity, set, local, flat, place, color);
+    });
 }
 
 // Fill voxels along the dominant axis between worldA and worldB.
@@ -529,12 +527,12 @@ void applyFillFace(
     std::vector<bool> visited(static_cast<std::size_t>(totalCells), false);
 
     // 4-connected neighbor offsets in the plane perpendicular to fixedAxis
-    const ivec3 neighborSteps[4] = {
-        fixedAxis == 0 ? ivec3{0, 1, 0} : ivec3{1, 0, 0},
-        fixedAxis == 0 ? ivec3{0, -1, 0} : ivec3{-1, 0, 0},
-        fixedAxis == 2 ? ivec3{0, 1, 0} : ivec3{0, 0, 1},
-        fixedAxis == 2 ? ivec3{0, -1, 0} : ivec3{0, 0, -1},
-    };
+    auto [dim0, dim1] = IRMath::perpendicularAxes(fixedAxis);
+    ivec3 step0{0, 0, 0};
+    ivec3 step1{0, 0, 0};
+    step0[dim0] = 1;
+    step1[dim1] = 1;
+    const ivec3 neighborSteps[4] = {step0, -step0, step1, -step1};
 
     const int startFlat = IRMath::index3DtoIndex1D(startLocal, set.size_);
     if (startFlat < 0 || static_cast<std::size_t>(startFlat) >= set.voxels_.size())
@@ -579,21 +577,17 @@ void applyFillSDF(
     Color color
 ) {
     const vec3 center = vec3(set.size_) * 0.5f;
-    for (int z = 0; z < set.size_.z; ++z) {
-        for (int y = 0; y < set.size_.y; ++y) {
-            for (int x = 0; x < set.size_.x; ++x) {
-                const vec3 sdfPos = vec3(x, y, z) - center + vec3(0.5f);
-                const float d = IRMath::SDF::evaluate(sdfPos, shapeType, sdfParams);
-                if (d > IRMath::SDF::kSurfaceThreshold)
-                    continue;
-                const ivec3 local{x, y, z};
-                const std::size_t flat =
-                    static_cast<std::size_t>(IRMath::index3DtoIndex1D(local, set.size_));
-                if (flat < set.voxels_.size())
-                    applyEdit(entity, set, local, flat, place, color);
-            }
-        }
-    }
+    IRMath::iterateAABB({0, 0, 0}, set.size_ - ivec3(1), [&](int x, int y, int z) {
+        const vec3 sdfPos = vec3(x, y, z) - center + vec3(0.5f);
+        const float d = IRMath::SDF::evaluate(sdfPos, shapeType, sdfParams);
+        if (d > IRMath::SDF::kSurfaceThreshold)
+            return;
+        const ivec3 local{x, y, z};
+        const std::size_t flat =
+            static_cast<std::size_t>(IRMath::index3DtoIndex1D(local, set.size_));
+        if (flat < set.voxels_.size())
+            applyEdit(entity, set, local, flat, place, color);
+    });
 }
 
 // Update the ghost shape entity to visualize the fill region during drag.
@@ -724,27 +718,25 @@ void applyLoft(Color color) {
         return;
     if (static_cast<int>(g_loftTool.maskYZ_.size()) < sy * sz)
         return;
-    for (int z = 0; z < sz; ++z) {
-        for (int y = 0; y < sy; ++y) {
-            for (int x = 0; x < sx; ++x) {
-                if (!g_loftTool.maskXZ_[static_cast<std::size_t>(x + z * sx)])
-                    continue;
-                if (!g_loftTool.maskYZ_[static_cast<std::size_t>(y + z * sy)])
-                    continue;
-                const int flat = IRMath::index3DtoIndex1D({x, y, z}, set.size_);
-                if (flat < 0 || static_cast<std::size_t>(flat) >= set.voxels_.size())
-                    continue;
-                applyEdit(
-                    g_editor.editableVoxelSet_,
-                    set,
-                    {x, y, z},
-                    static_cast<std::size_t>(flat),
-                    true,
-                    color
-                );
-            }
+    IRMath::apply3DMaskIntersection(
+        g_loftTool.maskXZ_,
+        {sx, sz},
+        g_loftTool.maskYZ_,
+        {sy, sz},
+        [&](int x, int y, int z) {
+            const int flat = IRMath::index3DtoIndex1D({x, y, z}, set.size_);
+            if (flat < 0 || static_cast<std::size_t>(flat) >= set.voxels_.size())
+                return;
+            applyEdit(
+                g_editor.editableVoxelSet_,
+                set,
+                {x, y, z},
+                static_cast<std::size_t>(flat),
+                true,
+                color
+            );
         }
-    }
+    );
     commitStroke();
 }
 

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -722,7 +722,7 @@ void applyLoft(Color color) {
         g_loftTool.maskXZ_,
         {sx, sz},
         g_loftTool.maskYZ_,
-        {sy, sz},
+        sy,
         [&](int x, int y, int z) {
             const int flat = IRMath::index3DtoIndex1D({x, y, z}, set.size_);
             if (flat < 0 || static_cast<std::size_t>(flat) >= set.voxels_.size())

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -807,18 +807,14 @@ constexpr int index3DtoIndex1D(const ivec3 index, const ivec3 size) {
     return index.z * size.x * size.y + index.y * size.x + index.x;
 }
 
-/// Returns the two axis indices perpendicular to @p axis: {(axis+1)%3, (axis+2)%3}.
-/// Use with structured bindings to name perpendicular dimensions without
-/// repeating the modular arithmetic at each call site.
+/// Perpendicular axis pair for structured bindings; avoids repeating (axis+k)%3 at each call site.
 constexpr std::pair<int, int> perpendicularAxes(int axis) {
     return {(axis + 1) % 3, (axis + 2) % 3};
 }
 
 /// Invokes @p cb(x, y, z) for every integer grid cell in the inclusive
-/// AABB [lo, hi]. Mirrors the naming of index3DtoIndex1D; use this to
-/// retire hand-written triple-nested loops over voxel volumes.
-template <typename Callback>
-inline void iterateAABB(ivec3 lo, ivec3 hi, Callback cb) {
+/// AABB [lo, hi]. Use this to retire hand-written triple-nested loops over voxel volumes.
+template <typename Callback> inline void iterateAABB(ivec3 lo, ivec3 hi, Callback cb) {
     for (int z = lo.z; z <= hi.z; ++z)
         for (int y = lo.y; y <= hi.y; ++y)
             for (int x = lo.x; x <= hi.x; ++x)
@@ -827,21 +823,23 @@ inline void iterateAABB(ivec3 lo, ivec3 hi, Callback cb) {
 
 /// Invokes @p cb(x, y, z) for every cell where both 2D masks agree.
 /// @p maskXZ is indexed as [x + z * sizeXZ.x] (front/XZ silhouette);
-/// @p maskYZ is indexed as [y + z * sizeYZ.x] (side/YZ silhouette).
-/// sizeXZ.y and sizeYZ.y (the shared Z extent) must match.
+/// @p maskYZ is indexed as [y + z * sizeY] (side/YZ silhouette).
+/// sizeXZ.y is the shared Z extent; sizeY is the Y extent.
 template <typename Callback>
 inline void apply3DMaskIntersection(
-    const std::vector<bool>& maskXZ,
+    const std::vector<bool> &maskXZ,
     ivec2 sizeXZ,
-    const std::vector<bool>& maskYZ,
-    ivec2 sizeYZ,
+    const std::vector<bool> &maskYZ,
+    int sizeY,
     Callback cb
 ) {
     for (int z = 0; z < sizeXZ.y; ++z)
-        for (int y = 0; y < sizeYZ.x; ++y)
+        for (int y = 0; y < sizeY; ++y)
             for (int x = 0; x < sizeXZ.x; ++x) {
-                if (!maskXZ[static_cast<std::size_t>(x + z * sizeXZ.x)]) continue;
-                if (!maskYZ[static_cast<std::size_t>(y + z * sizeYZ.x)]) continue;
+                if (!maskXZ[static_cast<std::size_t>(x + z * sizeXZ.x)])
+                    continue;
+                if (!maskYZ[static_cast<std::size_t>(y + z * sizeY)])
+                    continue;
                 cb(x, y, z);
             }
 }

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -11,6 +11,7 @@
 
 #include <glm/gtc/matrix_transform.hpp>
 
+#include <utility>
 #include <vector>
 
 // TODO: The game engine needs transformations for voxel sets
@@ -804,6 +805,45 @@ constexpr int index2DtoIndex1D(const ivec2 index, const ivec2 size) {
 /// Linearises a 3D index into a 1D array index (z-major, row-major order).
 constexpr int index3DtoIndex1D(const ivec3 index, const ivec3 size) {
     return index.z * size.x * size.y + index.y * size.x + index.x;
+}
+
+/// Returns the two axis indices perpendicular to @p axis: {(axis+1)%3, (axis+2)%3}.
+/// Use with structured bindings to name perpendicular dimensions without
+/// repeating the modular arithmetic at each call site.
+constexpr std::pair<int, int> perpendicularAxes(int axis) {
+    return {(axis + 1) % 3, (axis + 2) % 3};
+}
+
+/// Invokes @p cb(x, y, z) for every integer grid cell in the inclusive
+/// AABB [lo, hi]. Mirrors the naming of index3DtoIndex1D; use this to
+/// retire hand-written triple-nested loops over voxel volumes.
+template <typename Callback>
+inline void iterateAABB(ivec3 lo, ivec3 hi, Callback cb) {
+    for (int z = lo.z; z <= hi.z; ++z)
+        for (int y = lo.y; y <= hi.y; ++y)
+            for (int x = lo.x; x <= hi.x; ++x)
+                cb(x, y, z);
+}
+
+/// Invokes @p cb(x, y, z) for every cell where both 2D masks agree.
+/// @p maskXZ is indexed as [x + z * sizeXZ.x] (front/XZ silhouette);
+/// @p maskYZ is indexed as [y + z * sizeYZ.x] (side/YZ silhouette).
+/// sizeXZ.y and sizeYZ.y (the shared Z extent) must match.
+template <typename Callback>
+inline void apply3DMaskIntersection(
+    const std::vector<bool>& maskXZ,
+    ivec2 sizeXZ,
+    const std::vector<bool>& maskYZ,
+    ivec2 sizeYZ,
+    Callback cb
+) {
+    for (int z = 0; z < sizeXZ.y; ++z)
+        for (int y = 0; y < sizeYZ.x; ++y)
+            for (int x = 0; x < sizeXZ.x; ++x) {
+                if (!maskXZ[static_cast<std::size_t>(x + z * sizeXZ.x)]) continue;
+                if (!maskYZ[static_cast<std::size_t>(y + z * sizeYZ.x)]) continue;
+                cb(x, y, z);
+            }
 }
 
 // ISOMETRIC THINGS

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -278,8 +278,7 @@ struct C_VoxelSetNew {
     // axis: 0=X, 1=Y, 2=Z. planeIndex must be in [0, size_[axis]).
     void fillPlane(int axis, int planeIndex, Color color) {
         const ivec3 sz = size_;
-        const int dim0 = (axis + 1) % 3;
-        const int dim1 = (axis + 2) % 3;
+        auto [dim0, dim1] = IRMath::perpendicularAxes(axis);
         IRPrefab::VoxelPool::withPoolByEntity(canvasEntity_, [&](IRComponents::C_VoxelPool &pool) {
             for (int a = 0; a < sz[dim0]; ++a) {
                 for (int b = 0; b < sz[dim1]; ++b) {


### PR DESCRIPTION
Closes #1011

## Summary

- Adds `IRMath::iterateAABB`, `IRMath::apply3DMaskIntersection`, and `IRMath::perpendicularAxes` to `engine/math/include/irreden/ir_math.hpp`
- Refactors `applyFillAABB`, `applyFillSDF`, and `applyLoft` in `voxel_editor/main.cpp` to use the new helpers
- Replaces ternary axis-swizzle in `applyFillFace` with `perpendicularAxes`
- Replaces `(axis + 1) % 3` / `(axis + 2) % 3` inline math in `C_VoxelSetNew::fillPlane` with `perpendicularAxes`

## Test plan
- [ ] `grep -rn 'for (int z' creations/editors/voxel_editor/main.cpp` returns near-zero hits
- [ ] `grep -rn '(axis + 1) % 3' engine/ creations/` returns no hits
- [ ] Build `IRVoxelEditor` — no compile errors
- [ ] AABB fill, SDF fill, loft tool, face flood-fill, and fillPlane still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)