### PR TITLE
T-305: math: IRMath::SDF::evaluateGrid batch helper + refactor applyFillSDF

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -568,8 +568,9 @@ void applyFillFace(
 
 // CPU SDF voxel bake — fill every voxel in `set` whose SDF value for
 // `shapeType`/`sdfParams` is ≤ kSurfaceThreshold. The shape is centered on
-// the voxel set; each voxel sample point is offset by 0.5 so integer indices
-// map to voxel centers. Always produces DENSE output (no SHAPES chunk).
+// the voxel set; the SDF math is batched into `IRMath::SDF::evaluateGrid`,
+// so this function only owns the placement decision. Always produces
+// DENSE output (no SHAPES chunk).
 void applyFillSDF(
     IREntity::EntityId entity,
     C_VoxelSetNew &set,
@@ -578,15 +579,17 @@ void applyFillSDF(
     bool place,
     Color color
 ) {
-    const vec3 center = vec3(set.size_) * 0.5f;
+    const std::size_t total = static_cast<std::size_t>(set.size_.x) *
+                              static_cast<std::size_t>(set.size_.y) *
+                              static_cast<std::size_t>(set.size_.z);
+    std::vector<float> distances(total);
+    IRMath::SDF::evaluateGrid(set.size_, shapeType, sdfParams, distances);
     IRMath::iterateAABB({0, 0, 0}, set.size_ - ivec3(1), [&](int x, int y, int z) {
-        const vec3 sdfPos = vec3(x, y, z) - center + vec3(0.5f);
-        const float d = IRMath::SDF::evaluate(sdfPos, shapeType, sdfParams);
-        if (d > IRMath::SDF::kSurfaceThreshold)
-            return;
         const ivec3 local{x, y, z};
         const std::size_t flat =
             static_cast<std::size_t>(IRMath::index3DtoIndex1D(local, set.size_));
+        if (distances[flat] > IRMath::SDF::kSurfaceThreshold)
+            return;
         if (flat < set.voxels_.size())
             applyEdit(entity, set, local, flat, place, color);
     });

--- a/engine/math/include/irreden/math/sdf.hpp
+++ b/engine/math/include/irreden/math/sdf.hpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <span>
 
 namespace IRMath::SDF {
 
@@ -171,6 +172,30 @@ inline vec3 boundingHalf(ShapeType type, vec4 params) {
     }
     default:
         return vec3(params) * 0.5f;
+    }
+}
+
+/// Batch-evaluate an SDF primitive over a voxel grid centered on the shape
+/// origin. Each cell samples at the voxel center
+/// (`vec3(x, y, z) + vec3(0.5f) - vec3(size) * 0.5f`); output is laid out
+/// to match @ref IRMath::index3DtoIndex1D (x-major, then y, then z).
+///
+/// The caller must size @p outDistances to at least
+/// `size.x * size.y * size.z`; smaller spans are a no-op.
+inline void evaluateGrid(ivec3 size, ShapeType type, vec4 params, std::span<float> outDistances) {
+    const std::size_t total = static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) *
+                              static_cast<std::size_t>(size.z);
+    if (outDistances.size() < total)
+        return;
+    const vec3 center = vec3(size) * 0.5f;
+    std::size_t flat = 0;
+    for (int z = 0; z < size.z; ++z) {
+        for (int y = 0; y < size.y; ++y) {
+            for (int x = 0; x < size.x; ++x) {
+                const vec3 sdfPos = vec3(x, y, z) - center + vec3(0.5f);
+                outDistances[flat++] = evaluate(sdfPos, type, params);
+            }
+        }
     }
 }
 

--- a/test/math/sdf_test.cpp
+++ b/test/math/sdf_test.cpp
@@ -104,8 +104,7 @@ TEST(SdfEvaluateGrid, BoxInteriorBelowSurfaceThreshold) {
         if (d <= IRMath::SDF::kSurfaceThreshold)
             ++filledCount;
     }
-    EXPECT_GT(filledCount, 0);
-    EXPECT_LE(static_cast<std::size_t>(filledCount), grid.size());
+    EXPECT_EQ(static_cast<std::size_t>(filledCount), grid.size());
 }
 
 TEST(SdfEvaluateGrid, UndersizedSpanIsNoop) {

--- a/test/math/sdf_test.cpp
+++ b/test/math/sdf_test.cpp
@@ -2,6 +2,9 @@
 
 #include <irreden/ir_math.hpp>
 
+#include <span>
+#include <vector>
+
 namespace {
 
 constexpr float kTolerance = 1e-5f;
@@ -55,6 +58,63 @@ TEST(SdfEvaluate, TaperedBoxKeepsBaseWiderThanTop) {
         IRMath::SDF::evaluate(IRMath::vec3(2.5f, 0.0f, 2.5f), ShapeType::TAPERED_BOX, params),
         IRMath::SDF::kSurfaceThreshold
     );
+}
+
+TEST(SdfEvaluateGrid, SphereMatchesPerCellEvaluate) {
+    const IRMath::ivec3 size{8, 8, 8};
+    const IRMath::vec4 params{4.0f, 4.0f, 4.0f, 0.0f};
+    std::vector<float> grid(
+        static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) *
+        static_cast<std::size_t>(size.z)
+    );
+    IRMath::SDF::evaluateGrid(size, ShapeType::SPHERE, params, grid);
+
+    const IRMath::vec3 center = IRMath::vec3(size) * 0.5f;
+    for (int z = 0; z < size.z; ++z) {
+        for (int y = 0; y < size.y; ++y) {
+            for (int x = 0; x < size.x; ++x) {
+                const IRMath::vec3 sdfPos = IRMath::vec3(x, y, z) - center + IRMath::vec3(0.5f);
+                const float expected = IRMath::SDF::evaluate(sdfPos, ShapeType::SPHERE, params);
+                const std::size_t flat = static_cast<std::size_t>(
+                    IRMath::index3DtoIndex1D(IRMath::ivec3{x, y, z}, size)
+                );
+                EXPECT_NEAR(grid[flat], expected, kTolerance);
+            }
+        }
+    }
+}
+
+TEST(SdfEvaluateGrid, BoxInteriorBelowSurfaceThreshold) {
+    const IRMath::ivec3 size{6, 6, 6};
+    const IRMath::vec4 params =
+        IRMath::SDF::effectiveParams(ShapeType::BOX, IRMath::vec4(6.0f, 6.0f, 6.0f, 0.0f));
+    std::vector<float> grid(
+        static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) *
+        static_cast<std::size_t>(size.z)
+    );
+    IRMath::SDF::evaluateGrid(size, ShapeType::BOX, params, grid);
+
+    const IRMath::ivec3 centerCell{size.x / 2, size.y / 2, size.z / 2};
+    const std::size_t centerFlat =
+        static_cast<std::size_t>(IRMath::index3DtoIndex1D(centerCell, size));
+    EXPECT_LE(grid[centerFlat], IRMath::SDF::kSurfaceThreshold);
+
+    int filledCount = 0;
+    for (float d : grid) {
+        if (d <= IRMath::SDF::kSurfaceThreshold)
+            ++filledCount;
+    }
+    EXPECT_GT(filledCount, 0);
+    EXPECT_LE(static_cast<std::size_t>(filledCount), grid.size());
+}
+
+TEST(SdfEvaluateGrid, UndersizedSpanIsNoop) {
+    const IRMath::ivec3 size{4, 4, 4};
+    std::vector<float> grid(8, 99.0f);
+    IRMath::SDF::evaluateGrid(size, ShapeType::SPHERE, IRMath::vec4(2.0f, 2.0f, 2.0f, 0.0f), grid);
+    for (float d : grid) {
+        EXPECT_FLOAT_EQ(d, 99.0f);
+    }
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Closes the editor → IRMath leak in `applyFillSDF` (T-305 / issue #1013).

- Adds `IRMath::SDF::evaluateGrid(ivec3 size, ShapeType, vec4 params, std::span<float> out)` to `engine/math/include/irreden/math/sdf.hpp`. Centers the SDF on the voxel set; samples at voxel centers; output layout matches `IRMath::index3DtoIndex1D` (x-major, then y, then z).
- Refactors `creations/editors/voxel_editor/main.cpp::applyFillSDF` to call the helper. The editor now contains the placement loop only — no SDF math.
- Adds unit test coverage for sphere + box primitives in `test/math/sdf_test.cpp`.

## Test plan

- [ ] `fleet-build --target IrredenEngineTest` clean
- [ ] `fleet-run --timeout 15 IrredenEngineTest` — new sphere/box grid tests pass
- [ ] `fleet-build --target IRVoxelEditor` clean
- [ ] Visual: bake an SDF sphere in the voxel editor at the same size before/after — output identical
- [ ] `grep -rn 'IRMath::SDF::evaluate' creations/editors/voxel_editor/` returns zero hits (math gone from editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)