### PR TITLE
T-304: render: extract mask-grid pixel packing into renderer helper

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -94,9 +94,11 @@
 #include "scene_io.hpp"
 
 // Loft-tool mask rendering (trixel_rect fillRect, trixel_text renderText,
+// mask_grid_painter drawMaskGridOntoCanvas + hitTestGridCell,
 // layout mouse-in-GUI-trixels helper).
 #include <irreden/render/trixel_rect.hpp>
 #include <irreden/render/trixel_text.hpp>
+#include <irreden/render/mask_grid_painter.hpp>
 #include <irreden/render/layout.hpp>
 
 using namespace IRComponents;
@@ -647,67 +649,10 @@ void updateGhostShape(ivec3 worldA, ivec3 worldB, bool lineMode) {
     ghost.params_ = vec4(halfExt.x, halfExt.y, halfExt.z, 0.0f);
 }
 
-// Build and upload a loft-mask grid to the GUI canvas in two subImage2D
-// calls (one per texture channel). sizeH cells on the horizontal axis,
-// sizeV cells on the vertical axis; z=0 maps to the bottom of the panel
-// so the display orientation matches the 3D view. colorBuf / distBuf are
-// reused across calls to avoid per-frame allocation.
-void drawLoftGrid(
-    C_TriangleCanvasTextures &canvas,
-    const std::vector<bool> &mask,
-    ivec2 gridPos,
-    int sizeH,
-    int sizeV,
-    std::vector<Color> &colorBuf,
-    std::vector<int> &distBuf
-) {
-    const int gw = sizeH * kLoftCellPx;
-    const int gh = sizeV * kLoftCellPx;
-    if (gridPos.x < 0 || gridPos.y < 0 || gridPos.x + gw > canvas.size_.x ||
-        gridPos.y + gh > canvas.size_.y)
-        return;
-
-    const std::size_t pixels = static_cast<std::size_t>(gw * gh);
-    colorBuf.resize(pixels);
-    distBuf.resize(pixels);
-
-    static constexpr Color kOn{180, 220, 180, 230};
-    static constexpr Color kOff{35, 38, 48, 220};
-
-    for (int vz = 0; vz < sizeV; ++vz) {
-        const int displayRow = (sizeV - 1 - vz) * kLoftCellPx;
-        for (int hx = 0; hx < sizeH; ++hx) {
-            const Color c = mask[static_cast<std::size_t>(hx + vz * sizeH)] ? kOn : kOff;
-            for (int py = 0; py < kLoftCellPx; ++py) {
-                for (int px = 0; px < kLoftCellPx; ++px) {
-                    const std::size_t idx =
-                        static_cast<std::size_t>((displayRow + py) * gw + hx * kLoftCellPx + px);
-                    colorBuf[idx] = c;
-                    distBuf[idx] = IRRender::kWidgetBackgroundDistance;
-                }
-            }
-        }
-    }
-
-    canvas.textureTriangleColors_.second->subImage2D(
-        gridPos.x,
-        gridPos.y,
-        gw,
-        gh,
-        IRRender::PixelDataFormat::RGBA,
-        IRRender::PixelDataType::UNSIGNED_BYTE,
-        colorBuf.data()
-    );
-    canvas.textureTriangleDistances_.second->subImage2D(
-        gridPos.x,
-        gridPos.y,
-        gw,
-        gh,
-        IRRender::PixelDataFormat::RED_INTEGER,
-        IRRender::PixelDataType::INT32,
-        distBuf.data()
-    );
-}
+// Loft mask cell colors. Painted onto the GUI canvas by
+// IRRender::drawMaskGridOntoCanvas in the EditorLoftRender system.
+constexpr Color kLoftCellOn{180, 220, 180, 230};
+constexpr Color kLoftCellOff{35, 38, 48, 220};
 
 // Place voxels in the editable set wherever both loft masks agree (CSG
 // intersection). Works entirely in local voxel indices: mask[x + z*sizeX]
@@ -887,12 +832,12 @@ void initSystems() {
 
     // Loft-mask render: draws the XZ and YZ mask grids onto the GUI canvas.
     // Runs in the RENDER pipeline after TEXT_TO_TRIXEL (canvas clear) so
-    // the grids paint over the cleared canvas. colorBuf_ / distBuf_ are
-    // kept on params and grown to the largest grid size, never shrunk.
+    // the grids paint over the cleared canvas. Pixel-packing + texture
+    // upload live in IRRender::drawMaskGridOntoCanvas (mask_grid_painter.hpp);
+    // scratch_ is grown to the largest grid size and reused across frames.
     struct LoftRenderParams {
         C_TriangleCanvasTextures *canvas_ = nullptr;
-        std::vector<Color> colorBuf_;
-        std::vector<int> distBuf_;
+        IRRender::MaskGridPaintScratch scratch_;
     };
     auto loftRenderData = std::make_unique<LoftRenderParams>();
     auto *lrp = loftRenderData.get();
@@ -910,23 +855,27 @@ void initSystems() {
             const int sx = IRVoxelEditor::kEditableSceneSize.x;
             const int sy = IRVoxelEditor::kEditableSceneSize.y;
             const int sz = IRVoxelEditor::kEditableSceneSize.z;
-            IRVoxelEditor::drawLoftGrid(
+            IRRender::drawMaskGridOntoCanvas(
                 *lrp->canvas_,
                 loft.maskXZ_,
+                ivec2(sx, sz),
                 IRVoxelEditor::kLoftGridXZPos,
-                sx,
-                sz,
-                lrp->colorBuf_,
-                lrp->distBuf_
+                IRVoxelEditor::kLoftCellPx,
+                IRVoxelEditor::kLoftCellOn,
+                IRVoxelEditor::kLoftCellOff,
+                IRRender::kWidgetBackgroundDistance,
+                lrp->scratch_
             );
-            IRVoxelEditor::drawLoftGrid(
+            IRRender::drawMaskGridOntoCanvas(
                 *lrp->canvas_,
                 loft.maskYZ_,
+                ivec2(sy, sz),
                 IRVoxelEditor::kLoftGridYZPos,
-                sy,
-                sz,
-                lrp->colorBuf_,
-                lrp->distBuf_
+                IRVoxelEditor::kLoftCellPx,
+                IRVoxelEditor::kLoftCellOn,
+                IRVoxelEditor::kLoftCellOff,
+                IRRender::kWidgetBackgroundDistance,
+                lrp->scratch_
             );
             const int gridH = sz * IRVoxelEditor::kLoftCellPx;
             IRRender::renderText(
@@ -986,18 +935,18 @@ void initSystems() {
             if (!lip->painting_ && leftHeld)
                 return;
 
-            const int mx = static_cast<int>(lip->mouseGuiTrixel_.x);
-            const int my = static_cast<int>(lip->mouseGuiTrixel_.y);
+            const ivec2 mouseGui(
+                static_cast<int>(lip->mouseGuiTrixel_.x),
+                static_cast<int>(lip->mouseGuiTrixel_.y)
+            );
             const bool shiftHeld = IRInput::checkKeyMouseModifiers(IRInput::kModifierShift, 0u);
             const int sx = IRVoxelEditor::kEditableSceneSize.x;
             const int sy = IRVoxelEditor::kEditableSceneSize.y;
             const int sz = IRVoxelEditor::kEditableSceneSize.z;
             const int cell = IRVoxelEditor::kLoftCellPx;
 
-            auto paintCell = [&](std::vector<bool> &mask, int hIdx, int vIdx, int sH, int sV) {
-                if (hIdx < 0 || hIdx >= sH || vIdx < 0 || vIdx >= sV)
-                    return;
-                const std::size_t flat = static_cast<std::size_t>(hIdx + vIdx * sH);
+            auto paintCell = [&](std::vector<bool> &mask, ivec2 cellHV, int sH) {
+                const std::size_t flat = static_cast<std::size_t>(cellHV.x + cellHV.y * sH);
                 if (leftPressed) {
                     lip->paintVal_ = !mask[flat];
                     lip->painting_ = true;
@@ -1006,35 +955,28 @@ void initSystems() {
                     return;
                 mask[flat] = lip->paintVal_;
                 if (shiftHeld) {
-                    const int mirror = sH - 1 - hIdx;
-                    if (mirror != hIdx)
-                        mask[static_cast<std::size_t>(mirror + vIdx * sH)] = lip->paintVal_;
+                    const int mirror = sH - 1 - cellHV.x;
+                    if (mirror != cellHV.x)
+                        mask[static_cast<std::size_t>(mirror + cellHV.y * sH)] = lip->paintVal_;
                 }
             };
 
-            // XZ grid
-            const ivec2 &xzP = IRVoxelEditor::kLoftGridXZPos;
-            if (mx >= xzP.x && mx < xzP.x + sx * cell && my >= xzP.y && my < xzP.y + sz * cell) {
-                paintCell(
-                    IRVoxelEditor::g_loftTool.maskXZ_,
-                    (mx - xzP.x) / cell,
-                    sz - 1 - (my - xzP.y) / cell,
-                    sx,
-                    sz
-                );
+            if (auto hit = IRRender::hitTestGridCell(
+                    mouseGui,
+                    IRVoxelEditor::kLoftGridXZPos,
+                    cell,
+                    ivec2(sx, sz)
+                )) {
+                paintCell(IRVoxelEditor::g_loftTool.maskXZ_, *hit, sx);
                 return;
             }
-
-            // YZ grid
-            const ivec2 &yzP = IRVoxelEditor::kLoftGridYZPos;
-            if (mx >= yzP.x && mx < yzP.x + sy * cell && my >= yzP.y && my < yzP.y + sz * cell) {
-                paintCell(
-                    IRVoxelEditor::g_loftTool.maskYZ_,
-                    (mx - yzP.x) / cell,
-                    sz - 1 - (my - yzP.y) / cell,
-                    sy,
-                    sz
-                );
+            if (auto hit = IRRender::hitTestGridCell(
+                    mouseGui,
+                    IRVoxelEditor::kLoftGridYZPos,
+                    cell,
+                    ivec2(sy, sz)
+                )) {
+                paintCell(IRVoxelEditor::g_loftTool.maskYZ_, *hit, sy);
                 return;
             }
 

--- a/engine/render/include/irreden/render/mask_grid_painter.hpp
+++ b/engine/render/include/irreden/render/mask_grid_painter.hpp
@@ -1,0 +1,124 @@
+#ifndef MASK_GRID_PAINTER_H
+#define MASK_GRID_PAINTER_H
+
+#include <irreden/render/components/component_triangle_canvas_textures.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <optional>
+#include <vector>
+
+namespace IRRender {
+
+// Per-system scratch storage for batched mask-grid uploads. Mirrors the
+// RectFillScratch pattern in trixel_rect.hpp: a render system threads one
+// instance through every call across the frame so the color/distance
+// buffers grow to the largest grid ever drawn and stay sized after that.
+struct MaskGridPaintScratch {
+    std::vector<IRMath::Color> colors_;
+    std::vector<int> distances_;
+};
+
+// Paint a boolean-mask grid onto a canvas as a rectangle of cellPx-sized
+// cells. Each mask cell expands to a cellPx × cellPx block; cells where
+// mask[h + v * gridSize.x] is true take filledColor, false takes
+// emptyColor. The mask is stored with row 0 = canvas-bottom (display
+// orientation flipped vertically vs. the mask index), matching the
+// authoring convention where a mask "row" is a slice along the +Z axis.
+//
+// origin is the canvas-space top-left pixel of the grid region.
+// distance is the trixel-distance value written for every painted pixel;
+// callers in the GUI canvas typically pass kWidgetBackgroundDistance.
+//
+// scratch is reused across calls so only the first call (or one growing
+// past the prior largest size) allocates; subsequent calls of equal or
+// smaller area pay no allocation cost.
+//
+// No-op when the requested rect falls entirely outside the canvas. A
+// partial off-canvas region is rejected wholesale rather than partially
+// clipped — the GUI grid layouts that drive this helper always fit by
+// construction, so the simpler whole-rect guard is preferable to the
+// per-row clip arithmetic.
+inline void drawMaskGridOntoCanvas(
+    IRComponents::C_TriangleCanvasTextures &canvas,
+    const std::vector<bool> &mask,
+    IRMath::ivec2 gridSize,
+    IRMath::ivec2 origin,
+    int cellPx,
+    IRMath::Color filledColor,
+    IRMath::Color emptyColor,
+    int distance,
+    MaskGridPaintScratch &scratch
+) {
+    if (cellPx <= 0 || gridSize.x <= 0 || gridSize.y <= 0) return;
+
+    const int gridW = gridSize.x * cellPx;
+    const int gridH = gridSize.y * cellPx;
+    if (origin.x < 0 || origin.y < 0 ||
+        origin.x + gridW > canvas.size_.x ||
+        origin.y + gridH > canvas.size_.y)
+        return;
+
+    const std::size_t cellsExpected =
+        static_cast<std::size_t>(gridSize.x) * static_cast<std::size_t>(gridSize.y);
+    if (mask.size() < cellsExpected) return;
+
+    const std::size_t pixels = static_cast<std::size_t>(gridW) * static_cast<std::size_t>(gridH);
+    scratch.colors_.resize(pixels);
+    scratch.distances_.resize(pixels);
+
+    for (int v = 0; v < gridSize.y; ++v) {
+        // Mask row 0 sits at the canvas-bottom of the grid region.
+        const int displayRow = (gridSize.y - 1 - v) * cellPx;
+        for (int h = 0; h < gridSize.x; ++h) {
+            const IRMath::Color c =
+                mask[static_cast<std::size_t>(h + v * gridSize.x)] ? filledColor : emptyColor;
+            for (int py = 0; py < cellPx; ++py) {
+                const int rowBase = (displayRow + py) * gridW + h * cellPx;
+                for (int px = 0; px < cellPx; ++px) {
+                    const std::size_t idx = static_cast<std::size_t>(rowBase + px);
+                    scratch.colors_[idx] = c;
+                    scratch.distances_[idx] = distance;
+                }
+            }
+        }
+    }
+
+    canvas.textureTriangleColors_.second->subImage2D(
+        origin.x, origin.y, gridW, gridH,
+        IRRender::PixelDataFormat::RGBA,
+        IRRender::PixelDataType::UNSIGNED_BYTE,
+        scratch.colors_.data()
+    );
+    canvas.textureTriangleDistances_.second->subImage2D(
+        origin.x, origin.y, gridW, gridH,
+        IRRender::PixelDataFormat::RED_INTEGER,
+        IRRender::PixelDataType::INT32,
+        scratch.distances_.data()
+    );
+}
+
+// Map a GUI-trixel mouse position to the (h, v) cell of a mask grid
+// rendered with drawMaskGridOntoCanvas. The returned vertical index is
+// flipped to match the mask's storage convention (row 0 = canvas-bottom),
+// so the result can plug directly into mask[h + v * gridSize.x].
+// Returns std::nullopt when mouseGui lies outside the grid rect.
+inline std::optional<IRMath::ivec2> hitTestGridCell(
+    IRMath::ivec2 mouseGui,
+    IRMath::ivec2 origin,
+    int cellPx,
+    IRMath::ivec2 gridSize
+) {
+    if (cellPx <= 0 || gridSize.x <= 0 || gridSize.y <= 0) return std::nullopt;
+    const int gridW = gridSize.x * cellPx;
+    const int gridH = gridSize.y * cellPx;
+    if (mouseGui.x < origin.x || mouseGui.x >= origin.x + gridW ||
+        mouseGui.y < origin.y || mouseGui.y >= origin.y + gridH)
+        return std::nullopt;
+    const int h = (mouseGui.x - origin.x) / cellPx;
+    const int v = gridSize.y - 1 - (mouseGui.y - origin.y) / cellPx;
+    return IRMath::ivec2(h, v);
+}
+
+} // namespace IRRender
+
+#endif /* MASK_GRID_PAINTER_H */

--- a/engine/render/include/irreden/render/mask_grid_painter.hpp
+++ b/engine/render/include/irreden/render/mask_grid_painter.hpp
@@ -3,16 +3,15 @@
 
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/ir_math.hpp>
+#include <irreden/ir_profile.hpp>
 
 #include <optional>
 #include <vector>
 
 namespace IRRender {
 
-// Per-system scratch storage for batched mask-grid uploads. Mirrors the
-// RectFillScratch pattern in trixel_rect.hpp: a render system threads one
-// instance through every call across the frame so the color/distance
-// buffers grow to the largest grid ever drawn and stay sized after that.
+// Per-system scratch storage for batched mask-grid uploads; reused across
+// XZ/YZ calls to avoid per-frame allocation.
 struct MaskGridPaintScratch {
     std::vector<IRMath::Color> colors_;
     std::vector<int> distances_;
@@ -60,6 +59,9 @@ inline void drawMaskGridOntoCanvas(
 
     const std::size_t cellsExpected =
         static_cast<std::size_t>(gridSize.x) * static_cast<std::size_t>(gridSize.y);
+    IR_ASSERT(mask.size() >= cellsExpected,
+              "drawMaskGridOntoCanvas: mask undersized for gridSize ({} < {})",
+              mask.size(), cellsExpected);
     if (mask.size() < cellsExpected) return;
 
     const std::size_t pixels = static_cast<std::size_t>(gridW) * static_cast<std::size_t>(gridH);


### PR DESCRIPTION
## Summary

- New header `engine/render/include/irreden/render/mask_grid_painter.hpp` with `IRRender::drawMaskGridOntoCanvas` (pixel-pack + dual `subImage2D` upload) and `IRRender::hitTestGridCell` (origin/cellPx → cell coords with row-0-at-canvas-bottom flip baked in). Joins the `trixel_rect.hpp` / `trixel_text.hpp` family; uses the same `Scratch` pattern as `IRRender::fillRect` so per-frame allocations stay amortized.
- `creations/editors/voxel_editor/main.cpp` deletes local `drawLoftGrid` (~60 lines), replaces the inline two-grid mouse rect-in-grid checks with `hitTestGridCell`, swaps `LoftRenderParams::{colorBuf_, distBuf_}` for a single `IRRender::MaskGridPaintScratch scratch_`, and lifts `kOn`/`kOff` to file-scope `kLoftCellOn` / `kLoftCellOff`.
- Resolves the renderer-leak called out in #1012: `grep -rn 'subImage2D' creations/editors/voxel_editor/` now returns zero hits.

## Why this shape

The issue spec ([#1012](https://github.com/jakildev/IrredenEngine/issues/1012)) suggested exporting via `ir_render.hpp`, but `mask_grid_painter.hpp` transitively pulls in `component_triangle_canvas_textures.hpp` whose `onDestroy()` references `IRRender::destroyResource<Texture2D>` defined later in `ir_render.hpp`. Including the helper from the umbrella creates a circular dependency that breaks the build. `trixel_rect.hpp` and `trixel_text.hpp` already follow the same pattern of being included directly by callers rather than from the umbrella; the new helper joins that convention.

Helper takes `const std::vector<bool>&` instead of the suggested `std::span<const bool>` because `std::vector<bool>` is the special bitset specialization with no contiguous `.data()`, so a span view is not constructible from the current loft-mask storage without a wholesale storage change (out of scope here).

## Test plan

- [x] `fleet-build --target IRVoxelEditor` clean on macos-debug.
- [x] `fleet-run --timeout 15 IRVoxelEditor` launches without crash.
- [ ] Manual exercise of loft tool (`F` to toggle, click cells on XZ/YZ panels) — visual identity vs. master. Helper code path is byte-equivalent to the prior `drawLoftGrid`: same iteration order, same color/distance writes, same `subImage2D` invocations, same row-0-at-bottom flip. The hit-test refactor is a coordinate-math identity transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)