### PR TITLE
render: voxel cull-effectiveness diagnostic (visible/total readback)

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -78,6 +78,33 @@ script):
 The subdivision flags exist precisely so the matrix script can sweep
 them without editing config files.
 
+## Voxel cull stats — the "is culling working?" diagnostic
+
+When `gpu_stage_timing` is enabled, `VOXEL_TO_TRIXEL_STAGE_1` reads the
+prior frame's `IndirectDispatchParams.visibleCount` before zeroing the
+buffer for the new frame. The result is a sync-free per-frame sample of
+*how many voxels survived the iso-bounds cull*, alongside the pool's
+live count. The matrix script surfaces this as the `cull (vis/total)`
+column on `perf_summary.py` and a dedicated `voxel cull effectiveness`
+table on `compare_perf_runs.py`.
+
+What to look for:
+
+- **Ratio shrinks with zoom**, roughly as `1/zoom²` once the camera is
+  past full-screen coverage. If the ratio stays flat or shrinks much
+  less than `1/zoom²` while zoom goes up, that's the signature of an
+  ineffective viewport cull — frame time grows with the
+  subdivision-driven work multiplier while the visible set barely
+  changes.
+- **Same ratio across two PRs at the same `(zoom, sub_mode, sub_base)`
+  cell** is the no-regression baseline for any optimization PR that
+  claims to improve culling — pre-PR vs post-PR ratios at the same
+  cell.
+
+Lua surface for ad-hoc inspection: `ir.render.getVoxelCullStats()`
+returns `{visible, total, samples, avgVisible, avgTotal, maxVisible,
+maxTotal}`.
+
 ## Committed baselines
 
 When a major phase lands (Phase 1a GPU light volume, T-289 push-at-mutation,

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -82,7 +82,9 @@ them without editing config files.
 
 When `gpu_stage_timing` is enabled, `VOXEL_TO_TRIXEL_STAGE_1` reads the
 prior frame's `IndirectDispatchParams.visibleCount` before zeroing the
-buffer for the new frame. The result is a sync-free per-frame sample of
+buffer for the new frame. No explicit fence is required — the driver
+serializes the CPU read against the prior frame's already-retired write.
+The result is a per-frame sample of
 *how many voxels survived the iso-bounds cull*, alongside the pool's
 live count. The matrix script surfaces this as the `cull (vis/total)`
 column on `perf_summary.py` and a dedicated `voxel cull effectiveness`

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -1,11 +1,12 @@
 #ifndef GPU_STAGE_TIMING_H
 #define GPU_STAGE_TIMING_H
 
-#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstdint>
 #include <string_view>
+
+#include <irreden/ir_math.hpp>
 
 namespace IRRender {
 
@@ -80,7 +81,7 @@ struct CpuPhaseTiming {
 
     void record(double ms) {
         totalMs_ += ms;
-        maxMs_ = std::max(maxMs_, ms);
+        maxMs_ = IRMath::max(maxMs_, ms);
         ++sampleCount_;
     }
 
@@ -123,8 +124,8 @@ struct VoxelCullAccumulator {
     void record(std::uint32_t visible, std::uint32_t total) {
         visibleSum_ += visible;
         totalSum_ += total;
-        maxVisible_ = std::max(maxVisible_, visible);
-        maxTotal_ = std::max(maxTotal_, total);
+        maxVisible_ = IRMath::max(maxVisible_, visible);
+        maxTotal_ = IRMath::max(maxTotal_, total);
         ++sampleCount_;
     }
 

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -34,6 +34,14 @@ struct GpuStageTiming {
     float fbToScreenMs_ = 0.0f;
     std::uint32_t visibleShapeCount_ = 0;
     std::uint32_t shapeGroupsZ_ = 0;
+    // Cull diagnostic. Populated by VOXEL_TO_TRIXEL_STAGE_1 each frame
+    // from the prior frame's indirect-dispatch params + the current
+    // pool live count, so the readback is sync-free (frame N+1 reads
+    // frame N's already-written value before zeroing the buffer).
+    // Reports the *last* sampled frame; running averages live in
+    // VoxelCullAccumulator below.
+    std::uint32_t visibleVoxelCount_ = 0;
+    std::uint32_t totalVoxelCount_ = 0;
     // Only flipped between frames by Lua on the main thread (Lua runs in
     // INPUT/UPDATE, never RENDER). Stable across the RENDER pipeline, so
     // probes can read `enabled_` twice and rely on both values matching.
@@ -97,6 +105,40 @@ struct ComputeLightVolumeTiming {
 
 inline ComputeLightVolumeTiming &computeLightVolumeTiming() {
     static ComputeLightVolumeTiming instance;
+    return instance;
+}
+
+// Running cull-effectiveness accumulator. Each per-frame sample comes
+// from VOXEL_TO_TRIXEL_STAGE_1 reading the prior frame's indirect
+// dispatch params. The world's profile-report builder drains this at
+// shutdown; `enableFrameTiming(true)` calls reset() so each measurement
+// run starts from zero.
+struct VoxelCullAccumulator {
+    std::uint64_t visibleSum_ = 0;
+    std::uint64_t totalSum_ = 0;
+    std::uint32_t maxVisible_ = 0;
+    std::uint32_t maxTotal_ = 0;
+    std::uint32_t sampleCount_ = 0;
+
+    void record(std::uint32_t visible, std::uint32_t total) {
+        visibleSum_ += visible;
+        totalSum_ += total;
+        maxVisible_ = std::max(maxVisible_, visible);
+        maxTotal_ = std::max(maxTotal_, total);
+        ++sampleCount_;
+    }
+
+    void reset() {
+        visibleSum_ = 0;
+        totalSum_ = 0;
+        maxVisible_ = 0;
+        maxTotal_ = 0;
+        sampleCount_ = 0;
+    }
+};
+
+inline VoxelCullAccumulator &voxelCullAccumulator() {
+    static VoxelCullAccumulator instance;
     return instance;
 }
 

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -294,6 +294,23 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         }
         syncEntityIds(voxelPool, liveVoxelCount, voxelEntityIdBuf_);
 
+        // Cull diagnostic readback (gated by gpu_stage_timing.enabled_).
+        // The buffer still holds the prior frame's visibleCount; reading
+        // it here — before we zero it for this frame's compact pass — is
+        // a sync-free way to surface culling effectiveness. Frame N+1
+        // reads frame N's value; the first frame reports 0 and is
+        // discarded by the running average's sampleCount_.
+        if (gpuStageTiming().enabled_) {
+            VoxelIndirectDispatchParams previous{};
+            indirectBuf_->getSubData(0, sizeof(VoxelIndirectDispatchParams), &previous);
+            gpuStageTiming().visibleVoxelCount_ = previous.visibleCount;
+            gpuStageTiming().totalVoxelCount_ = static_cast<std::uint32_t>(liveVoxelCount);
+            voxelCullAccumulator().record(
+                previous.visibleCount,
+                static_cast<std::uint32_t>(liveVoxelCount)
+            );
+        }
+
         const VoxelIndirectDispatchParams zeroed{};
         indirectBuf_->subData(0, sizeof(VoxelIndirectDispatchParams), &zeroed);
 

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -296,10 +296,12 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
 
         // Cull diagnostic readback (gated by gpu_stage_timing.enabled_).
         // The buffer still holds the prior frame's visibleCount; reading
-        // it here — before we zero it for this frame's compact pass — is
-        // a sync-free way to surface culling effectiveness. Frame N+1
-        // reads frame N's value; the first frame reports 0 and is
-        // discarded by the running average's sampleCount_.
+        // it here — before we zero it for this frame's compact pass —
+        // requires no explicit fence: the driver serializes the CPU read
+        // against the prior frame's already-retired compact write.
+        // Frame N+1 reads frame N's value; the first frame reports 0,
+        // contributing a 1/N bias to the running average — negligible
+        // over typical measurement runs.
         if (gpuStageTiming().enabled_) {
             VoxelIndirectDispatchParams previous{};
             indirectBuf_->getSubData(0, sizeof(VoxelIndirectDispatchParams), &previous);

--- a/engine/profile/include/irreden/profile/profile_report.hpp
+++ b/engine/profile/include/irreden/profile/profile_report.hpp
@@ -34,6 +34,18 @@ struct CpuPhaseEntry {
     uint32_t sampleCount_ = 0;
 };
 
+/// Voxel cull-effectiveness summary populated from a per-frame
+/// accumulator in VOXEL_TO_TRIXEL_STAGE_1. avgVisible / avgTotal at
+/// zoom Z answer "did culling actually shrink the working set?" A
+/// flat ratio across zooms is the signature of broken culling.
+struct VoxelCullStatsSummary {
+    uint64_t visibleSum_ = 0;
+    uint64_t totalSum_ = 0;
+    uint32_t maxVisible_ = 0;
+    uint32_t maxTotal_ = 0;
+    uint32_t sampleCount_ = 0;
+};
+
 /// Aggregated data for a profile report, populated by World at shutdown.
 struct ProfileReport {
     std::vector<float> frameTimesMs_;
@@ -45,6 +57,7 @@ struct ProfileReport {
     std::vector<SystemTimingEntry> systemTimings_;
     std::vector<GpuStageEntry> gpuStages_;
     std::vector<CpuPhaseEntry> cpuPhases_;
+    VoxelCullStatsSummary voxelCullStats_;
 };
 
 /// Write a plain-text profile report to the given file path.

--- a/engine/profile/src/profile_report.cpp
+++ b/engine/profile/src/profile_report.cpp
@@ -167,6 +167,32 @@ void writeProfileReport(const ProfileReport &report, const char *outputPath) {
         std::fprintf(f, "\n");
     }
 
+    // --- Voxel cull stats ---
+    if (report.voxelCullStats_.sampleCount_ > 0) {
+        const auto &c = report.voxelCullStats_;
+        const double samples = static_cast<double>(c.sampleCount_);
+        const double avgVisible = static_cast<double>(c.visibleSum_) / samples;
+        const double avgTotal = static_cast<double>(c.totalSum_) / samples;
+        const double ratio = avgTotal > 0.0 ? avgVisible / avgTotal : 0.0;
+        std::fprintf(f, "--- Voxel cull stats ---\n");
+        std::fprintf(f, "%-12s %14s %14s %10s\n", "", "Avg", "Max", "Samples");
+        std::fprintf(
+            f,
+            "%-12s %14.1f %14u %10u\n",
+            "Visible",
+            avgVisible,
+            c.maxVisible_,
+            c.sampleCount_
+        );
+        std::fprintf(f, "%-12s %14.1f %14u %10u\n", "Total", avgTotal, c.maxTotal_, c.sampleCount_);
+        std::fprintf(
+            f,
+            "Ratio:       %14.4f (visible/total — 1.0 = no cull, 0.0 = all culled)\n",
+            ratio
+        );
+        std::fprintf(f, "\n");
+    }
+
     // --- CPU phase timing ---
     if (!report.cpuPhases_.empty()) {
         std::fprintf(f, "--- CPU phase timing ---\n");

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -149,6 +149,23 @@ void World::setupLuaBindings(const std::vector<LuaBindingRegistration> &bindings
         }
         return 0.0f;
     };
+    // Voxel cull diagnostic. Returns last-sampled visible + total
+    // voxel counts plus the running average + max collected since the
+    // last enableFrameTiming(true). Only populated while
+    // gpu_stage_timing is enabled.
+    render["getVoxelCullStats"] = [&lua]() {
+        sol::table out = lua.create_table();
+        const auto &timing = IRRender::gpuStageTiming();
+        const auto &acc = IRRender::voxelCullAccumulator();
+        out["visible"] = timing.visibleVoxelCount_;
+        out["total"] = timing.totalVoxelCount_;
+        out["samples"] = acc.sampleCount_;
+        out["avgVisible"] = acc.sampleCount_ > 0 ? acc.visibleSum_ / acc.sampleCount_ : 0;
+        out["avgTotal"] = acc.sampleCount_ > 0 ? acc.totalSum_ / acc.sampleCount_ : 0;
+        out["maxVisible"] = acc.maxVisible_;
+        out["maxTotal"] = acc.maxTotal_;
+        return out;
+    };
 
     for (const auto &bind : bindings) {
         bind(m_lua);
@@ -287,6 +304,7 @@ void World::enableFrameTiming(bool enabled) {
         m_frameMaxUpdateTicksPerFrame = 0;
         m_systemManager.resetTimingStats();
         IRRender::computeLightVolumeTiming().reset();
+        IRRender::voxelCullAccumulator().reset();
     }
 }
 
@@ -320,6 +338,13 @@ void World::buildAndWriteProfileReport() {
          lightVolumeTiming.upload_.maxMs_,
          lightVolumeTiming.upload_.sampleCount_}
     );
+
+    const auto &cull = IRRender::voxelCullAccumulator();
+    report.voxelCullStats_.visibleSum_ = cull.visibleSum_;
+    report.voxelCullStats_.totalSum_ = cull.totalSum_;
+    report.voxelCullStats_.maxVisible_ = cull.maxVisible_;
+    report.voxelCullStats_.maxTotal_ = cull.maxTotal_;
+    report.voxelCullStats_.sampleCount_ = cull.sampleCount_;
 
     // Collect per-system timing, grouped by pipeline
     auto pipelineName = [](IRTime::Events e) -> const char * {

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -160,8 +160,10 @@ void World::setupLuaBindings(const std::vector<LuaBindingRegistration> &bindings
         out["visible"] = timing.visibleVoxelCount_;
         out["total"] = timing.totalVoxelCount_;
         out["samples"] = acc.sampleCount_;
-        out["avgVisible"] = acc.sampleCount_ > 0 ? acc.visibleSum_ / acc.sampleCount_ : 0;
-        out["avgTotal"] = acc.sampleCount_ > 0 ? acc.totalSum_ / acc.sampleCount_ : 0;
+        out["avgVisible"] =
+            acc.sampleCount_ > 0 ? static_cast<double>(acc.visibleSum_) / acc.sampleCount_ : 0.0;
+        out["avgTotal"] =
+            acc.sampleCount_ > 0 ? static_cast<double>(acc.totalSum_) / acc.sampleCount_ : 0.0;
         out["maxVisible"] = acc.maxVisible_;
         out["maxTotal"] = acc.maxTotal_;
         return out;

--- a/scripts/perf/compare_perf_runs.py
+++ b/scripts/perf/compare_perf_runs.py
@@ -36,6 +36,9 @@ FRAME_RE = re.compile(
     r"p99=([\d.]+)ms\s+min=([\d.]+)ms\s+max=([\d.]+)ms"
 )
 ENTITY_RE = re.compile(r"Entity count:\s+(\d+)\s+\((\d+)\s+archetypes\)")
+CULL_VISIBLE_RE = re.compile(r"^Visible\s+([\d.]+)\s+(\d+)\s+(\d+)")
+CULL_TOTAL_RE = re.compile(r"^Total\s+([\d.]+)\s+(\d+)\s+(\d+)")
+CULL_RATIO_RE = re.compile(r"^Ratio:\s+([\d.]+)")
 SYSTEM_RE = re.compile(
     r"^(INPUT|UPDATE|RENDER)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+"
     r"([\d.]+)\s+(\d+)\s+(\d+)"
@@ -73,6 +76,16 @@ class GpuStage:
 
 
 @dataclass
+class CullStats:
+    avg_visible: float = 0.0
+    avg_total: float = 0.0
+    max_visible: int = 0
+    max_total: int = 0
+    samples: int = 0
+    ratio: float = 0.0
+
+
+@dataclass
 class CellReport:
     cell_id: str
     frame: FrameTiming = field(default_factory=FrameTiming)
@@ -80,6 +93,7 @@ class CellReport:
     archetype_count: int = 0
     systems: List[SystemTiming] = field(default_factory=list)
     gpu_stages: List[GpuStage] = field(default_factory=list)
+    cull: CullStats = field(default_factory=CullStats)
     raw: str = ""
 
     def system_by_name(self, name: str) -> Optional[SystemTiming]:
@@ -130,6 +144,9 @@ def parse_report(path: Path, cell_id: str) -> CellReport:
         if s.startswith("--- GPU stage timing"):
             section = "gpu"
             continue
+        if s.startswith("--- Voxel cull stats"):
+            section = "cull"
+            continue
         if s.startswith("--- CPU phase timing"):
             section = "cpu_phase"
             continue
@@ -160,6 +177,21 @@ def parse_report(path: Path, cell_id: str) -> CellReport:
                     avg_ms=float(m.group(2)),
                     max_ms=float(m.group(3)),
                 ))
+        elif section == "cull":
+            m = CULL_VISIBLE_RE.match(s)
+            if m:
+                report.cull.avg_visible = float(m.group(1))
+                report.cull.max_visible = int(m.group(2))
+                report.cull.samples = int(m.group(3))
+                continue
+            m = CULL_TOTAL_RE.match(s)
+            if m:
+                report.cull.avg_total = float(m.group(1))
+                report.cull.max_total = int(m.group(2))
+                continue
+            m = CULL_RATIO_RE.match(s)
+            if m:
+                report.cull.ratio = float(m.group(1))
     return report
 
 
@@ -246,6 +278,27 @@ def render_markdown(
     matched = sorted(set(base) & set(head))
     base_only = sorted(set(base) - set(head))
     head_only = sorted(set(head) - set(base))
+
+    if not cpu_only:
+        has_cull = any(c.cull.samples > 0 for c in list(base.values()) + list(head.values()))
+        if has_cull:
+            out.append("## voxel cull effectiveness (visible / total)")
+            out.append("")
+            out.append("| cell | ratio (base→head) | avg visible | total |")
+            out.append("|------|-------------------|-------------|-------|")
+            for cell_id in matched:
+                bc = base[cell_id].cull
+                hc = head[cell_id].cull
+                if bc.samples == 0 and hc.samples == 0:
+                    continue
+                ratio_delta_pp = (hc.ratio - bc.ratio) * 100.0  # percentage points
+                out.append(
+                    f"| `{cell_id}` "
+                    f"| {bc.ratio:.3f} → {hc.ratio:.3f} ({ratio_delta_pp:+.1f}pp) "
+                    f"| {bc.avg_visible:.0f} → {hc.avg_visible:.0f} "
+                    f"| {bc.avg_total:.0f} → {hc.avg_total:.0f} |"
+                )
+            out.append("")
 
     if not cpu_only:
         out.append("## frame timing (ms)")

--- a/scripts/perf/perf_summary.py
+++ b/scripts/perf/perf_summary.py
@@ -42,17 +42,20 @@ def main() -> int:
     print(f"location: `{run_dir}`")
     print(f"cells: {len(cells)}")
     print()
-    print("| cell | frame avg | p99 | entities | top GPU stage |")
-    print("|------|-----------|-----|----------|---------------|")
+    print("| cell | frame avg | p99 | entities | cull (vis/total) | top GPU stage |")
+    print("|------|-----------|-----|----------|------------------|---------------|")
     for cell_id in sorted(cells):
         c = cells[cell_id]
         top_gpu = ""
         if c.gpu_stages:
             top = max(c.gpu_stages, key=lambda s: s.avg_ms)
             top_gpu = f"`{top.name}` ({top.avg_ms:.2f}ms)"
+        cull = ""
+        if c.cull.samples > 0:
+            cull = f"{c.cull.ratio:.2f} ({c.cull.avg_visible:.0f}/{c.cull.avg_total:.0f})"
         print(
             f"| `{cell_id}` | {c.frame.avg:.2f}ms | {c.frame.p99:.2f}ms "
-            f"| {c.entity_count} | {top_gpu} |"
+            f"| {c.entity_count} | {cull} | {top_gpu} |"
         )
     return 0
 


### PR DESCRIPTION
## Summary
- Re-open of [#1019](https://github.com/jakildev/IrredenEngine/pull/1019), which was accidentally merged into the stack parent `claude/perf-measurement-scripts` instead of `master`. The stack parent ([#1016](https://github.com/jakildev/IrredenEngine/pull/1016)) is now on master, so this PR cherry-picks the three cull-instrumentation commits onto a fresh branch off master.
- Original commits preserved as-is (cherry-pick rewrites SHAs but the diff is identical):
  - `5981e45e` render: voxel cull-effectiveness diagnostic (visible/total readback)
  - `334691de` render: replace std::max with IRMath::max in gpu_stage_timing.hpp
  - `7a3a539e` render: address nits from Opus review of cull-effectiveness diagnostic

Already reviewed and approved on #1019 — re-targeting only.

## Test plan
- [x] Build clean against current master (cherry-pick applied without conflicts).
- [ ] Validate `--cull-effectiveness` diagnostic still reports visible/total counts after the perf harness from #1016 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)