### PR TITLE
T-312: perf: Catch2 microbench harness for engine/math hot paths

### DIFF
--- a/engine/math/CMakeLists.txt
+++ b/engine/math/CMakeLists.txt
@@ -36,3 +36,7 @@ target_include_directories(
 #         ${PROJECT_BINARY_DIR}/libglm_sharedd.dll
 #     DEPENDS glm
 # )
+
+if(IRREDEN_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/engine/math/tests/CMakeLists.txt
+++ b/engine/math/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        v3.7.1
+)
+FetchContent_MakeAvailable(Catch2)
+
+add_executable(IrredenMathBench
+    bench_iso_projection.cpp
+    bench_sdf.cpp
+    bench_trixel.cpp
+)
+
+target_link_libraries(IrredenMathBench PRIVATE
+    IrredenEngineCommon
+    Catch2::Catch2WithMain
+)
+
+set_target_properties(IrredenMathBench PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)

--- a/engine/math/tests/bench_iso_projection.cpp
+++ b/engine/math/tests/bench_iso_projection.cpp
@@ -1,0 +1,81 @@
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <irreden/ir_math.hpp>
+
+#include <array>
+
+namespace {
+
+// Representative voxel grid coordinates: a 16×16×8 slab centred near the
+// origin, covering typical shapes placed at world-space positions the
+// editor and game creation demos actually use.
+constexpr int kN = 256;
+constexpr std::array<IRMath::ivec3, kN> kPoints = [] {
+    std::array<IRMath::ivec3, kN> pts{};
+    int idx = 0;
+    for (int z = 0; z < 8; ++z)
+        for (int y = -16; y < 16; ++y)
+            for (int x = -16; x < 0; ++x) {
+                if (idx < kN)
+                    pts[idx++] = IRMath::ivec3(x, y, z);
+            }
+    return pts;
+}();
+
+constexpr std::array<IRMath::vec3, kN> kPointsF = [] {
+    std::array<IRMath::vec3, kN> pts{};
+    for (int i = 0; i < kN; ++i)
+        pts[i] = IRMath::vec3(kPoints[i]);
+    return pts;
+}();
+
+} // namespace
+
+TEST_CASE("iso projection throughput") {
+    BENCHMARK("pos3DtoPos2DIso(ivec3) x256") {
+        IRMath::ivec2 acc{0, 0};
+        for (const auto& p : kPoints)
+            acc += IRMath::pos3DtoPos2DIso(p);
+        return acc;
+    };
+
+    BENCHMARK("pos3DtoPos2DIso(vec3) x256") {
+        IRMath::vec2 acc{0.0f, 0.0f};
+        for (const auto& p : kPointsF)
+            acc += IRMath::pos3DtoPos2DIso(p);
+        return acc;
+    };
+
+    BENCHMARK("pos3DtoDistance(ivec3) x256") {
+        IRMath::Distance acc = 0;
+        for (const auto& p : kPoints)
+            acc += IRMath::pos3DtoDistance(p);
+        return acc;
+    };
+
+    BENCHMARK("isoDepthShift x256") {
+        IRMath::vec3 acc{0.0f};
+        for (int i = 0; i < kN; ++i)
+            acc += IRMath::isoDepthShift(kPointsF[i], float(i & 7));
+        return acc;
+    };
+}
+
+TEST_CASE("iso projection single-call latency") {
+    BENCHMARK("pos3DtoPos2DIso(ivec3) one call") {
+        return IRMath::pos3DtoPos2DIso(IRMath::ivec3(10, 20, 30));
+    };
+
+    BENCHMARK("pos3DtoPos2DIso(vec3) one call") {
+        return IRMath::pos3DtoPos2DIso(IRMath::vec3(10.5f, 20.5f, 30.5f));
+    };
+
+    BENCHMARK("pos3DtoDistance(ivec3) one call") {
+        return IRMath::pos3DtoDistance(IRMath::ivec3(10, 20, 30));
+    };
+
+    BENCHMARK("pos3DtoDistance(vec3) one call") {
+        return IRMath::pos3DtoDistance(IRMath::vec3(10.5f, 20.5f, 30.5f));
+    };
+}

--- a/engine/math/tests/bench_sdf.cpp
+++ b/engine/math/tests/bench_sdf.cpp
@@ -1,0 +1,138 @@
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <irreden/ir_math.hpp>
+
+#include <array>
+
+namespace {
+
+// Query points: a 4×4×4 block of positions in [-1.5, 1.5]^3, covering
+// surface, interior, and exterior regions for each SDF primitive. The
+// spread ensures branch paths in taperedBox and curvedPanel are exercised.
+constexpr int kN = 64;
+constexpr std::array<IRMath::vec3, kN> kQueryPts = [] {
+    std::array<IRMath::vec3, kN> pts{};
+    int idx = 0;
+    for (int zi = 0; zi < 4; ++zi)
+        for (int yi = 0; yi < 4; ++yi)
+            for (int xi = 0; xi < 4; ++xi)
+                pts[idx++] = IRMath::vec3(
+                    -1.5f + xi * 1.0f,
+                    -1.5f + yi * 1.0f,
+                    -1.5f + zi * 1.0f
+                );
+    return pts;
+}();
+
+constexpr IRMath::vec3 kHalf{3.0f, 3.0f, 3.0f};
+constexpr IRMath::vec4 kParams{6.0f, 6.0f, 6.0f, 0.0f};
+constexpr IRMath::vec4 kParamsTapered{6.0f, 6.0f, 6.0f, 0.5f};
+constexpr IRMath::vec4 kParamsCurved{6.0f, 6.0f, 2.0f, 0.3f};
+constexpr IRMath::vec4 kParamsTorus{4.0f, 1.5f, 0.0f, 0.0f};
+
+} // namespace
+
+TEST_CASE("SDF primitive throughput") {
+    BENCHMARK("box x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::box(p, kHalf);
+        return acc;
+    };
+
+    BENCHMARK("sphere x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::sphere(p, 3.0f);
+        return acc;
+    };
+
+    BENCHMARK("cylinder x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::cylinder(p, 2.0f, 3.0f);
+        return acc;
+    };
+
+    BENCHMARK("ellipsoid x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::ellipsoid(p, kHalf);
+        return acc;
+    };
+
+    BENCHMARK("taperedBox x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::taperedBox(p, kHalf, 0.5f);
+        return acc;
+    };
+
+    BENCHMARK("cone x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::cone(p, 3.0f, 3.0f);
+        return acc;
+    };
+
+    BENCHMARK("torus x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::torus(p, 4.0f, 1.5f);
+        return acc;
+    };
+
+    BENCHMARK("wedge x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::wedge(p, kHalf);
+        return acc;
+    };
+
+    BENCHMARK("curvedPanel x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::curvedPanel(p, kHalf, 0.3f);
+        return acc;
+    };
+}
+
+TEST_CASE("SDF evaluate dispatcher") {
+    using IRMath::SDF::ShapeType;
+
+    BENCHMARK("evaluate BOX x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::evaluate(p, ShapeType::BOX, kParams);
+        return acc;
+    };
+
+    BENCHMARK("evaluate SPHERE x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::evaluate(p, ShapeType::SPHERE, kParams);
+        return acc;
+    };
+
+    BENCHMARK("evaluate TAPERED_BOX x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::evaluate(p, ShapeType::TAPERED_BOX, kParamsTapered);
+        return acc;
+    };
+
+    BENCHMARK("evaluate TORUS x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::evaluate(p, ShapeType::TORUS, kParamsTorus);
+        return acc;
+    };
+
+    BENCHMARK("evaluate CURVED_PANEL x64") {
+        float acc = 0.0f;
+        for (const auto& p : kQueryPts)
+            acc += IRMath::SDF::evaluate(p, ShapeType::CURVED_PANEL, kParamsCurved);
+        return acc;
+    };
+}

--- a/engine/math/tests/bench_trixel.cpp
+++ b/engine/math/tests/bench_trixel.cpp
@@ -17,9 +17,12 @@ TEST_CASE("deformedTrixelIsoPixel throughput") {
     // across the 24 (face, subPixel, yaw) combinations. constexpr inputs
     // with a small iteration count are fully foldable; std::vector breaks that.
     const std::vector<int> faces{
-        IRMath::kXFace, IRMath::kXFace,
-        IRMath::kYFace, IRMath::kYFace,
-        IRMath::kZFace, IRMath::kZFace,
+        IRMath::kXFace,
+        IRMath::kXFace,
+        IRMath::kYFace,
+        IRMath::kYFace,
+        IRMath::kZFace,
+        IRMath::kZFace,
     };
     const std::vector<int> subPixels{0, 1, 0, 1, 0, 1};
     const std::vector<float> yawSamples{0.0f, 0.25f, -0.25f, 0.1f};
@@ -67,6 +70,8 @@ TEST_CASE("trixel origin offsets") {
         acc += IRMath::trixelOriginOffsetY4(size);
         acc += IRMath::trixelOriginOffsetZ1(size);
         acc += IRMath::trixelOriginOffsetZ2(size);
+        acc += IRMath::trixelOriginOffsetZ3(size);
+        acc += IRMath::trixelOriginOffsetZ4(size);
         return acc;
     };
 }

--- a/engine/math/tests/bench_trixel.cpp
+++ b/engine/math/tests/bench_trixel.cpp
@@ -1,0 +1,72 @@
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <irreden/ir_math.hpp>
+
+#include <vector>
+
+namespace {
+
+// Canvas size representative of the IRShapeDebug 64-grid mode.
+constexpr IRMath::ivec2 kCanvasSize{256, 256};
+
+} // namespace
+
+TEST_CASE("deformedTrixelIsoPixel throughput") {
+    // Runtime-initialized inputs prevent the compiler from constant-folding
+    // across the 24 (face, subPixel, yaw) combinations. constexpr inputs
+    // with a small iteration count are fully foldable; std::vector breaks that.
+    const std::vector<int> faces{
+        IRMath::kXFace, IRMath::kXFace,
+        IRMath::kYFace, IRMath::kYFace,
+        IRMath::kZFace, IRMath::kZFace,
+    };
+    const std::vector<int> subPixels{0, 1, 0, 1, 0, 1};
+    const std::vector<float> yawSamples{0.0f, 0.25f, -0.25f, 0.1f};
+
+    BENCHMARK("deformedTrixelIsoPixel all faces x4 yaws") {
+        IRMath::ivec2 acc{0, 0};
+        for (float yaw : yawSamples)
+            for (std::size_t i = 0; i < faces.size(); ++i)
+                acc += IRMath::deformedTrixelIsoPixel(faces[i], subPixels[i], yaw);
+        return acc;
+    };
+
+    BENCHMARK("deformedTrixelIsoPixel yaw=0 all faces") {
+        IRMath::ivec2 acc{0, 0};
+        const float yaw = yawSamples[0];
+        for (std::size_t i = 0; i < faces.size(); ++i)
+            acc += IRMath::deformedTrixelIsoPixel(faces[i], subPixels[i], yaw);
+        return acc;
+    };
+
+    BENCHMARK("deformedTrixelIsoPixel yaw=0.25 all faces") {
+        IRMath::ivec2 acc{0, 0};
+        const float yaw = yawSamples[1];
+        for (std::size_t i = 0; i < faces.size(); ++i)
+            acc += IRMath::deformedTrixelIsoPixel(faces[i], subPixels[i], yaw);
+        return acc;
+    };
+}
+
+TEST_CASE("trixel origin offsets") {
+    // Each offset helper is called once per face-slot per canvas resize.
+    // These are constexpr so the timing reflects the call-site overhead
+    // at non-constexpr call sites (i.e., when canvasSize is not compile-time).
+    const IRMath::ivec2 size = kCanvasSize;
+
+    BENCHMARK("all 12 trixelOriginOffset helpers") {
+        IRMath::ivec2 acc{0, 0};
+        acc += IRMath::trixelOriginOffsetX1(size);
+        acc += IRMath::trixelOriginOffsetX2(size);
+        acc += IRMath::trixelOriginOffsetX3(size);
+        acc += IRMath::trixelOriginOffsetX4(size);
+        acc += IRMath::trixelOriginOffsetY1(size);
+        acc += IRMath::trixelOriginOffsetY2(size);
+        acc += IRMath::trixelOriginOffsetY3(size);
+        acc += IRMath::trixelOriginOffsetY4(size);
+        acc += IRMath::trixelOriginOffsetZ1(size);
+        acc += IRMath::trixelOriginOffsetZ2(size);
+        return acc;
+    };
+}

--- a/scripts/perf/run_math_bench.sh
+++ b/scripts/perf/run_math_bench.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# run_math_bench.sh — run the IrredenMathBench Catch2 microbenchmark suite
+# and write a JSON report to save_files/bench/<git-sha>[-<label>].json.
+#
+# Usage:
+#   scripts/perf/run_math_bench.sh
+#   scripts/perf/run_math_bench.sh --label before-refactor
+#   scripts/perf/run_math_bench.sh --out /tmp/custom.json
+#
+# Output:
+#   save_files/bench/<git-sha>[-<label>].json   (Catch2 JSON reporter format)
+#
+# The JSON schema is Catch2 v3's native benchmark reporter output.
+# Use jq '."test-run"."test-cases"' to extract per-test-case data, or
+# jq '."test-run"."test-cases"[].runs' for per-run timing details.
+
+set -euo pipefail
+
+_FLEET_COMMON_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../fleet" && pwd)/fleet-common.sh"
+if [[ -f "$_FLEET_COMMON_SH" ]]; then
+    # shellcheck source=../fleet/fleet-common.sh
+    source "$_FLEET_COMMON_SH"
+else
+    detect_engine_root() {
+        git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/src/IrredenEngine"
+    }
+fi
+
+ENGINE_ROOT="$(detect_engine_root)"
+LABEL=""
+OUT_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --label) LABEL="$2"; shift 2 ;;
+        --out) OUT_OVERRIDE="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,22p' "$0"
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+BUILD_DIR="$ENGINE_ROOT/build"
+BENCH_EXE="$BUILD_DIR/IrredenMathBench"
+
+if [[ ! -x "$BENCH_EXE" ]]; then
+    echo "error: $BENCH_EXE not found — run fleet-build --target IrredenMathBench first" >&2
+    exit 1
+fi
+
+SHA="$(git -C "$ENGINE_ROOT" rev-parse --short HEAD)"
+BENCH_DIR="$ENGINE_ROOT/save_files/bench"
+mkdir -p "$BENCH_DIR"
+
+if [[ -n "$OUT_OVERRIDE" ]]; then
+    OUT_FILE="$OUT_OVERRIDE"
+elif [[ -n "$LABEL" ]]; then
+    OUT_FILE="$BENCH_DIR/${SHA}-${LABEL}.json"
+else
+    OUT_FILE="$BENCH_DIR/${SHA}.json"
+fi
+
+echo "running IrredenMathBench → $OUT_FILE"
+"$BENCH_EXE" "--benchmark-warmup-time=100" "--reporter=json::out=${OUT_FILE}"
+echo "done: $OUT_FILE"


### PR DESCRIPTION
## Summary
- Add Catch2 microbenchmark harness under `engine/math/tests/` with bench targets for iso-projection, SDF evaluation, and trixel math
- Output benchmark results to `save_files/bench/<sha>.json` for tracking regressions over time
- Wire into `scripts/perf/` for sweep/comparison tooling

## Test plan
- [ ] All three bench targets build cleanly
- [ ] `fleet-run` on each target produces JSON output under `save_files/bench/`
- [ ] `scripts/perf/` comparison script correctly parses the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)