### PR TITLE
T-310: render: graceful per-pair fallback for Metal timestamp allocation

### DIFF
--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -634,12 +634,25 @@ metalCurrentDepthPixelFormat(),
         descriptor->release();
 
         if (sampleBuffer == nullptr) {
-            const char *description =
-                error != nullptr && error->localizedDescription() != nullptr
-                    ? error->localizedDescription()->utf8String()
-                    : "<unknown>";
-            IR_LOG_WARN("Failed to create Metal timestamp counter sample buffer: {}", description);
-            m_supportsTimestampPairs = false;
+            // Per-pair failure (quota exhaustion mid-tagStage loop is the
+            // common cause) is non-fatal: stages that already got valid
+            // pairs keep timing, the observer no-ops on this stage's invalid
+            // handles (see `nextAvailableSlot`), and `useLegacyTiming` does
+            // not flip — global state matches the constructor probe, not
+            // a per-call result. Log once so the operator notices the
+            // degradation but doesn't get spammed.
+            if (!m_loggedTimestampAllocFailure) {
+                const char *description =
+                    error != nullptr && error->localizedDescription() != nullptr
+                        ? error->localizedDescription()->utf8String()
+                        : "<unknown>";
+                IR_LOG_WARN(
+                    "Failed to create Metal timestamp counter sample buffer "
+                    "(quota likely exhausted; later-tagged stages skip per-stage GPU timing): {}",
+                    description
+                );
+                m_loggedTimestampAllocFailure = true;
+            }
             return kInvalidGpuTimestampHandle;
         }
 
@@ -661,8 +674,18 @@ metalCurrentDepthPixelFormat(),
     }
 
     int recommendedTimestampPairsInFlight() const override {
-        // This backend waits at present today, so one pair per tagged stage is
-        // enough and avoids exhausting Metal's limited sample-buffer quota.
+        // Today's Metal pipeline blocks at `present()` (one frame of GPU work
+        // in flight, then `waitUntilCompleted`), so a single `MTL::CounterSampleBuffer`
+        // per tagged stage is sufficient: by the top of frame N+1 the GPU has
+        // already finished frame N's samples and `resolveCounterRange` returns
+        // valid data without stalling. Bumping past 1 is wasted on this
+        // pipeline and risks exhausting the device's limited sample-buffer
+        // quota (Apple Silicon devices observed at ~stages × 2 = ~40-pair
+        // ceiling, 2026-05-21). Once `present()` is made async (separate task),
+        // raise this to 2-3 so frame N-2 readback survives the deeper
+        // GPU latency without dropping per-frame samples. The per-pair
+        // graceful-fallback in `createTimestampPair` keeps already-tagged
+        // stages timing-functional even when a future bump exceeds quota.
         return 1;
     }
 
@@ -731,6 +754,7 @@ metalCurrentDepthPixelFormat(),
     std::vector<MetalTimestampPair> m_timestamps;
     MTL::CounterSet *m_timestampCounterSet = nullptr;
     bool m_supportsTimestampPairs = false;
+    bool m_loggedTimestampAllocFailure = false;
 };
 
 MetalRenderDevice g_metalRenderDevice;


### PR DESCRIPTION
## Summary

- **The async-timestamp deliverables T-310 calls for already exist** — landed in T-275 (PR #977). `GpuStageTimingObserver` uses `device()->writeTimestamp` / `readTimestampPairMs`; OpenGL backs that with double-buffered `glQueryCounter(GL_TIMESTAMP)` queries (3 pairs in flight by default), Metal backs it with `MTL::CounterSampleBuffer` (1 pair in flight, sufficient while `present()` blocks). `gpu_stage_timing_legacy` defaults to `false`, so the `glFinish + steady_clock` path the issue describes is already an A/B opt-in, not the default.
- **This PR closes the one robustness gap that surfaced** when I probed bumping Metal's `recommendedTimestampPairsInFlight()` to 3 to chase a more aggressive N-1 readback. Apple Silicon's sample-buffer quota tapped out around `stages × 2` ≈ 40 pairs, and the existing code's failure handling was too aggressive: a single `newCounterSampleBuffer` returning `nullptr` flipped `m_supportsTimestampPairs = false`, which **both** stopped allocating pairs for every later-tagged stage **and** tripped `useLegacyTiming()` into the `glFinish` path on every subsequent frame. So any future bump would silently regress the async path back to glFinish — the exact failure mode T-310 was meant to retire.
- **Fix:** make per-pair allocation failure local. Log the warning once (quota is steady state, repeating doesn't help), return `kInvalidGpuTimestampHandle` so the observer's `nextAvailableSlot` skips that slot, and leave `m_supportsTimestampPairs` matching the constructor probe so `useLegacyTiming()` stays correct. Already-tagged stages keep their async pairs; later-tagged stages skip per-stage timing rather than dragging everyone onto the legacy path.
- **Reverted the in-flight bump back to 1** with an expanded comment explaining why: today's Metal `present()` blocks (one frame of GPU work in flight, then `waitUntilCompleted`), so frame N+1 reads frame N's samples cleanly without ever stalling on `resolveCounterRange`. Bumping past 1 is wasted on this pipeline AND exceeds quota on Apple Silicon. The next bump point is when `present()` is made async (separate task) — at that point raise to 2-3 and rely on the now-graceful fallback to absorb any per-device quota differences.

## What T-310 doesn't include here

- **Cross-host parity smoke** on a matrix run (linux/OpenGL vs macos/Metal) — the perf scripts that make this trivial are in flight (#1016) and not on master yet. Recommend handing the parity verification to a follow-up once #1016 lands; macOS smoke for this PR confirms Metal works in isolation, but the per-stage ms numbers across the two backends haven't been compared.
- **`legacyFinishTiming_` flag removal** — kept as the documented A/B opt-in per the issue text ("Keep `legacyFinishTiming_` as an A/B opt-in until the async path proves itself"). Removing it is a follow-up once the matrix-run parity check above passes on both backends.

## Test plan

- [x] `fleet-build --target IRShapeDebug` clean on macos-debug.
- [x] `fleet-run IRShapeDebug --auto-screenshot 30` with `gpu_stage_timing = false` (engine default) — clean run, zero warnings, full 7-shot list completes.
- [x] `fleet-run IRShapeDebug --auto-screenshot 30` with `gpu_stage_timing = true` (temp config override, reverted) — clean run, zero `Failed to create Metal timestamp counter sample buffer` warnings, exercises `createTimestampPair` (~20 stages) → `writeTimestamp` → `readTimestampPairMs` end-to-end without falling back to legacy.
- [ ] Linux/OpenGL smoke — non-render fallback-path change with no GLSL touch; OpenGL behaviour is unchanged by this commit, but cross-host smoke applies because the file is under `engine/render/`.
- [ ] Cross-host parity matrix (deferred to follow-up post #1016).

## Screenshots

Skipped per `engine/render/CLAUDE.md` "Verifying render changes" exception — the diff is purely error-handling + comments on a fallback path with zero visual effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)