### PR TITLE
T-313: perf: Lua-vs-C++ parity dashboard

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -12,12 +12,13 @@ profiler, no per-cell stopwatch.
 
 ## The scripts
 
-| Script                                | What it does                                                           |
-|---------------------------------------|------------------------------------------------------------------------|
-| `scripts/perf/perf_grid_matrix.sh`    | Run `IRPerfGrid` (or `IRLuaPerfGrid`) across a zoom × subdivision matrix |
-| `scripts/perf/perf_summary.py`        | One-screen markdown summary of a single run                            |
-| `scripts/perf/compare_perf_runs.py`   | Diff two runs as a markdown table for the PR body                      |
-| `scripts/perf/check_regression.py`    | Same as compare, but exits non-zero on regression — used by CI gate    |
+| Script                                | What it does                                                                       |
+|---------------------------------------|------------------------------------------------------------------------------------|
+| `scripts/perf/perf_grid_matrix.sh`    | Run `IRPerfGrid` (or `IRLuaPerfGrid`, or both) across a zoom × subdivision matrix |
+| `scripts/perf/perf_summary.py`        | One-screen markdown summary of a single run                                        |
+| `scripts/perf/compare_perf_runs.py`   | Diff two runs as a markdown table for the PR body                                  |
+| `scripts/perf/check_regression.py`    | Same as compare, but exits non-zero on regression — used by CI gate                |
+| `scripts/perf/lua_cpp_parity.py`      | Lua-vs-C++ overhead table from a `--target both` run                               |
 
 All scripts are stdlib-only and run from anywhere in the repo. The
 matrix script writes `save_files/perf/<git-sha>[-<label>]/` so multiple
@@ -151,6 +152,39 @@ What to look for:
 Lua surface for ad-hoc inspection: `ir.render.getVoxelCullStats()`
 returns `{visible, total, samples, avgVisible, avgTotal, maxVisible,
 maxTotal}`.
+
+## Lua-vs-C++ parity
+
+`IRLuaPerfGrid` mirrors `IRPerfGrid` but drives the scene through the
+codegen/EVAL path instead of hand-written C++ systems. Comparing the two
+answers: *is the Lua hot path drifting from the C++ baseline?*
+
+Run both targets in one pass, then generate the parity table:
+
+```bash
+scripts/perf/perf_grid_matrix.sh --target both --label parity
+scripts/perf/lua_cpp_parity.py save_files/perf/<sha>-parity
+```
+
+`lua_cpp_parity.py` prints a markdown table with `ratio = lua_avg /
+cpp_avg` and `delta = lua_avg - cpp_avg` per `(zoom, sub_mode,
+sub_base)` cell. Cells where the Lua overhead exceeds the threshold
+(default 20%) are flagged with ⚠. Paste the output into the PR body
+whenever a change touches codegen or the EVAL path.
+
+Options:
+
+```
+lua_cpp_parity.py <run_dir> [--gap-pct N] [--cpp NAME] [--lua NAME]
+```
+
+- `--gap-pct N` — change the flagging threshold (default 20)
+- `--cpp / --lua` — override target names if non-default builds were used
+
+The matrix script stores each cell under
+`target=IRPerfGrid,zoom=…` / `target=IRLuaPerfGrid,zoom=…`, so both
+sets live in the same output directory and the parity script can cross-
+reference them without a second run directory.
 
 ## Committed baselines
 

--- a/scripts/perf/lua_cpp_parity.py
+++ b/scripts/perf/lua_cpp_parity.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""lua_cpp_parity.py — Lua-vs-C++ parity dashboard from a --target both matrix run.
+
+Reads a single perf_grid_matrix output directory produced with --target both
+(containing cells for both IRPerfGrid and IRLuaPerfGrid) and prints a markdown
+table comparing frame timing per (zoom, sub_mode, sub_base) dimension set.
+
+  ratio = lua_avg_ms / cpp_avg_ms
+  delta = lua_avg_ms - cpp_avg_ms
+
+Cells where ratio > 1 + gap_pct/100 are flagged with ⚠.
+
+Usage:
+    scripts/perf/lua_cpp_parity.py <run_dir>
+        [--gap-pct N]   # overhead threshold for flagging (default 20)
+        [--cpp  NAME]   # C++ target name (default IRPerfGrid)
+        [--lua  NAME]   # Lua target name (default IRLuaPerfGrid)
+
+Stdlib only — must run on any Python 3.9+ without extra deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+_PARENT = Path(__file__).resolve().parent
+sys.path.insert(0, str(_PARENT))
+from compare_perf_runs import CellReport, load_run  # noqa: E402
+
+
+def _dim_key(cell_id: str) -> str:
+    """Strip 'target=...' segment and return the remaining dimension string."""
+    return ",".join(p for p in cell_id.split(",") if not p.startswith("target="))
+
+
+def _group_by_target(
+    cells: Dict[str, CellReport],
+    cpp_name: str,
+    lua_name: str,
+) -> Tuple[Dict[str, CellReport], Dict[str, CellReport]]:
+    cpp: Dict[str, CellReport] = {}
+    lua: Dict[str, CellReport] = {}
+    for cell_id, report in cells.items():
+        if f"target={cpp_name}" in cell_id:
+            cpp[_dim_key(cell_id)] = report
+        elif f"target={lua_name}" in cell_id:
+            lua[_dim_key(cell_id)] = report
+    return cpp, lua
+
+
+def render_markdown(
+    run_dir: Path,
+    cpp: Dict[str, CellReport],
+    lua: Dict[str, CellReport],
+    cpp_name: str,
+    lua_name: str,
+    gap_pct: float,
+) -> str:
+    matched = sorted(set(cpp) & set(lua))
+    cpp_only = sorted(set(cpp) - set(lua))
+    lua_only = sorted(set(lua) - set(cpp))
+
+    threshold = 1.0 + gap_pct / 100.0
+    flagged: List[str] = []
+
+    lines: List[str] = []
+    lines.append(f"# Lua-vs-C++ parity: {run_dir.name}")
+    lines.append("")
+    lines.append(f"location: `{run_dir}`")
+    lines.append(f"cpp target: `{cpp_name}`   lua target: `{lua_name}`")
+    lines.append(f"flag threshold: >{gap_pct:.0f}% overhead (ratio > {threshold:.2f}x)")
+    lines.append(
+        f"matched cells: {len(matched)}"
+        f"   cpp-only: {len(cpp_only)}"
+        f"   lua-only: {len(lua_only)}"
+    )
+    lines.append("")
+    lines.append(
+        "| dims | cpp avg (ms) | lua avg (ms) | ratio | delta (ms) | p99 cpp | p99 lua |"
+    )
+    lines.append(
+        "|------|-------------|-------------|-------|------------|---------|---------|"
+    )
+
+    for key in matched:
+        cpp_cell = cpp[key]
+        lua_cell = lua[key]
+        cpp_avg = cpp_cell.frame.avg
+        lua_avg = lua_cell.frame.avg
+        delta = lua_avg - cpp_avg
+        if cpp_avg > 0.0:
+            ratio = lua_avg / cpp_avg
+            is_flagged = ratio > threshold
+            ratio_str = f"{ratio:.3f}x{' ⚠' if is_flagged else ''}"
+            if is_flagged:
+                flagged.append(key)
+        else:
+            ratio_str = "n/a"
+        lines.append(
+            f"| `{key}` "
+            f"| {cpp_avg:.3f} "
+            f"| {lua_avg:.3f} "
+            f"| {ratio_str} "
+            f"| {delta:+.3f} "
+            f"| {cpp_cell.frame.p99:.3f} "
+            f"| {lua_cell.frame.p99:.3f} |"
+        )
+
+    lines.append("")
+
+    if flagged:
+        lines.append(
+            f"**{len(flagged)} cell(s) flagged** — Lua overhead exceeds"
+            f" {gap_pct:.0f}% threshold: {', '.join(f'`{k}`' for k in flagged)}"
+        )
+    else:
+        lines.append(f"All {len(matched)} cell(s) within {gap_pct:.0f}% parity threshold.")
+    lines.append("")
+
+    if cpp_only or lua_only:
+        lines.append("## unmatched cells")
+        lines.append("")
+        if cpp_only:
+            lines.append(f"cpp-only: {', '.join(f'`{k}`' for k in cpp_only)}")
+        if lua_only:
+            lines.append(f"lua-only: {', '.join(f'`{k}`' for k in lua_only)}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("run_dir", help="perf_grid_matrix output directory (--target both run)")
+    p.add_argument(
+        "--gap-pct",
+        type=float,
+        default=20.0,
+        metavar="N",
+        help="flag cells where Lua overhead exceeds N%% (default 20)",
+    )
+    p.add_argument(
+        "--cpp",
+        default="IRPerfGrid",
+        metavar="NAME",
+        help="C++ target name (default IRPerfGrid)",
+    )
+    p.add_argument(
+        "--lua",
+        default="IRLuaPerfGrid",
+        metavar="NAME",
+        help="Lua target name (default IRLuaPerfGrid)",
+    )
+    args = p.parse_args()
+
+    run_dir = Path(args.run_dir).resolve()
+    if not run_dir.is_dir():
+        print(f"lua_cpp_parity: {run_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    cells = load_run(run_dir)
+    if not cells:
+        print("lua_cpp_parity: no cells found (missing manifest.json?)", file=sys.stderr)
+        return 1
+
+    cpp, lua = _group_by_target(cells, args.cpp, args.lua)
+    if not cpp:
+        print(
+            f"lua_cpp_parity: no cells with target={args.cpp} found —"
+            f" run perf_grid_matrix.sh with --target both first",
+            file=sys.stderr,
+        )
+        return 1
+    if not lua:
+        print(
+            f"lua_cpp_parity: no cells with target={args.lua} found —"
+            f" run perf_grid_matrix.sh with --target both first",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        render_markdown(run_dir, cpp, lua, args.cpp, args.lua, args.gap_pct),
+        end="",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf/lua_cpp_parity.py
+++ b/scripts/perf/lua_cpp_parity.py
@@ -44,9 +44,10 @@ def _group_by_target(
     cpp: Dict[str, CellReport] = {}
     lua: Dict[str, CellReport] = {}
     for cell_id, report in cells.items():
-        if f"target={cpp_name}" in cell_id:
+        segments = cell_id.split(",")
+        if f"target={cpp_name}" in segments:
             cpp[_dim_key(cell_id)] = report
-        elif f"target={lua_name}" in cell_id:
+        elif f"target={lua_name}" in segments:
             lua[_dim_key(cell_id)] = report
     return cpp, lua
 
@@ -82,7 +83,7 @@ def render_markdown(
         "| dims | cpp avg (ms) | lua avg (ms) | ratio | delta (ms) | p99 cpp | p99 lua |"
     )
     lines.append(
-        "|------|-------------|-------------|-------|------------|---------|---------|"
+        "|------|------------|------------|-------|------------|---------|---------|"
     )
 
     for key in matched:

--- a/scripts/perf/perf_grid_matrix.sh
+++ b/scripts/perf/perf_grid_matrix.sh
@@ -8,6 +8,7 @@
 # Usage:
 #   scripts/perf/perf_grid_matrix.sh                     # default 12-cell matrix, IRPerfGrid
 #   scripts/perf/perf_grid_matrix.sh --target IRLuaPerfGrid
+#   scripts/perf/perf_grid_matrix.sh --target both       # IRPerfGrid + IRLuaPerfGrid (parity run)
 #   scripts/perf/perf_grid_matrix.sh --label baseline    # output dir suffix
 #   scripts/perf/perf_grid_matrix.sh --frames 600        # frames per cell (default 300)
 #   scripts/perf/perf_grid_matrix.sh --full              # extended matrix (30 cells)
@@ -19,11 +20,12 @@
 #   save_files/perf/<git-sha>[-<label>]/<cell-id>.txt    # raw profile_report.txt
 #   save_files/perf/<git-sha>[-<label>]/manifest.json    # cell metadata + git state
 #
-# Cell ID format (matrix mode): target=<exe>,zoom=<z>,sub_mode=<m>,sub_base=<n>,grid=<g>
+# Cell ID format (matrix mode): target=<exe>,zoom=<z>,sub_mode=<m>,sub_base=<n>[,grid=<g>]
 # Cell ID format (preset mode):  target=<exe>,preset=<filename-without-ext>
 #
-# Skills/agents: invoke this once before a change, once after, then
-# pass both output dirs to compare_perf_runs.py.
+# Skills/agents: for before/after comparisons invoke once per tree and diff
+# with compare_perf_runs.py. For Lua-vs-C++ parity, use --target both and
+# feed the output dir to scripts/perf/lua_cpp_parity.py.
 
 set -euo pipefail
 
@@ -39,6 +41,7 @@ fi
 
 ENGINE_ROOT="$(detect_engine_root)"
 TARGET="IRPerfGrid"
+TARGET_BOTH=false
 LABEL=""
 FRAMES=300
 GRID_SIZE=""
@@ -48,7 +51,13 @@ PRESETS_DIR=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --target) TARGET="$2"; shift 2 ;;
+        --target)
+            if [[ "$2" == "both" ]]; then
+                TARGET_BOTH=true
+            else
+                TARGET="$2"
+            fi
+            shift 2 ;;
         --label) LABEL="$2"; shift 2 ;;
         --frames) FRAMES="$2"; shift 2 ;;
         --grid-size) GRID_SIZE="$2"; shift 2 ;;
@@ -58,7 +67,7 @@ while [[ $# -gt 0 ]]; do
         --default) MATRIX="default"; shift ;;
         --presets) PRESETS_DIR="$2"; shift 2 ;;
         -h|--help)
-            sed -n '2,26p' "$0"
+            sed -n '2,28p' "$0"
             exit 0
             ;;
         *)
@@ -68,6 +77,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if $TARGET_BOTH; then
+    TARGETS=("IRPerfGrid" "IRLuaPerfGrid")
+else
+    TARGETS=("$TARGET")
+fi
+
 if [[ -n "$PRESETS_DIR" ]]; then
     # Resolve relative PRESETS_DIR relative to ENGINE_ROOT so preset absolute
     # paths are valid when passed through fleet-run to the demo's cwd.
@@ -75,7 +90,7 @@ if [[ -n "$PRESETS_DIR" ]]; then
         PRESETS_DIR="$ENGINE_ROOT/$PRESETS_DIR"
     fi
     mapfile -t PRESET_FILES < <(find "$PRESETS_DIR" -maxdepth 1 -name "*.lua" | sort)
-    CELL_COUNT=${#PRESET_FILES[@]}
+    CELL_COUNT=$(( ${#PRESET_FILES[@]} * ${#TARGETS[@]} ))
 else
     case "$MATRIX" in
         quick)
@@ -94,8 +109,10 @@ else
             SUB_BASES=(1 4)
             ;;
     esac
-    CELL_COUNT=$(( ${#ZOOMS[@]} * ${#SUB_MODES[@]} * ${#SUB_BASES[@]} ))
+    CELL_COUNT=$(( ${#ZOOMS[@]} * ${#SUB_MODES[@]} * ${#SUB_BASES[@]} * ${#TARGETS[@]} ))
 fi
+
+TARGET_LABEL="$($TARGET_BOTH && echo "both" || echo "$TARGET")"
 
 SHA="$(git -C "$ENGINE_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 DIRTY=""
@@ -110,9 +127,9 @@ OUT_DIR="$ENGINE_ROOT/save_files/perf/$RUN_NAME"
 mkdir -p "$OUT_DIR"
 
 if [[ -n "$PRESETS_DIR" ]]; then
-    echo "perf_grid_matrix: target=$TARGET presets=$PRESETS_DIR cells=$CELL_COUNT frames=$FRAMES out=$OUT_DIR"
+    echo "perf_grid_matrix: target=$TARGET_LABEL presets=$PRESETS_DIR cells=$CELL_COUNT frames=$FRAMES out=$OUT_DIR"
 else
-    echo "perf_grid_matrix: target=$TARGET matrix=$MATRIX cells=$CELL_COUNT frames=$FRAMES out=$OUT_DIR"
+    echo "perf_grid_matrix: target=$TARGET_LABEL matrix=$MATRIX cells=$CELL_COUNT frames=$FRAMES out=$OUT_DIR"
 fi
 
 if ! command -v fleet-run >/dev/null 2>&1; then
@@ -134,7 +151,7 @@ find_latest_report() {
 MANIFEST="$OUT_DIR/manifest.json"
 {
     echo "{"
-    echo "  \"target\": \"$TARGET\","
+    echo "  \"target\": \"$TARGET_LABEL\","
     echo "  \"matrix\": \"$MATRIX\","
     echo "  \"frames\": $FRAMES,"
     echo "  \"git_sha\": \"$SHA\","
@@ -145,9 +162,10 @@ MANIFEST="$OUT_DIR/manifest.json"
 } > "$MANIFEST"
 
 run_cell() {
-    local CELL_ID="$1"
-    local CELL_META="$2"
-    shift 2
+    local RUN_TARGET="$1"
+    local CELL_ID="$2"
+    local CELL_META="$3"
+    shift 3
     local CELL_ARGS=("$@")
 
     local CELL_TXT="$OUT_DIR/${CELL_ID}.txt"
@@ -158,7 +176,7 @@ run_cell() {
     touch "$MARKER"
 
     local STATUS=0
-    fleet-run --timeout "$TIMEOUT" "$TARGET" "${CELL_ARGS[@]}" \
+    fleet-run --timeout "$TIMEOUT" "$RUN_TARGET" "${CELL_ARGS[@]}" \
         > "$CELL_LOG" 2>&1 || STATUS=$?
 
     local REPORT
@@ -178,7 +196,7 @@ run_cell() {
         echo "," >> "$MANIFEST"
     fi
     cat >> "$MANIFEST" <<EOF
-    {"id": "$CELL_ID", $CELL_META, "exit_status": $STATUS, "status": "$CELL_STATUS", "report": "${CELL_ID}.txt"}
+    {"id": "$CELL_ID", "target": "$RUN_TARGET", $CELL_META, "exit_status": $STATUS, "status": "$CELL_STATUS", "report": "${CELL_ID}.txt"}
 EOF
 }
 
@@ -186,34 +204,38 @@ FIRST=1
 INDEX=0
 
 if [[ -n "$PRESETS_DIR" ]]; then
-    for PRESET in "${PRESET_FILES[@]}"; do
-        INDEX=$((INDEX + 1))
-        PRESET_NAME="$(basename "$PRESET" .lua)"
-        CELL_ID="target=${TARGET},preset=${PRESET_NAME}"
-        CELL_ARGS=(--auto-profile "$FRAMES" --config-preset "$PRESET")
-        if [[ -n "$GRID_SIZE" ]]; then
-            CELL_ARGS+=(--grid-size "$GRID_SIZE")
-        fi
-        run_cell "$CELL_ID" "\"preset\": \"$PRESET_NAME\"" "${CELL_ARGS[@]}"
+    for RUN_TARGET in "${TARGETS[@]}"; do
+        for PRESET in "${PRESET_FILES[@]}"; do
+            INDEX=$((INDEX + 1))
+            PRESET_NAME="$(basename "$PRESET" .lua)"
+            CELL_ID="target=${RUN_TARGET},preset=${PRESET_NAME}"
+            CELL_ARGS=(--auto-profile "$FRAMES" --config-preset "$PRESET")
+            if [[ -n "$GRID_SIZE" ]]; then
+                CELL_ARGS+=(--grid-size "$GRID_SIZE")
+            fi
+            run_cell "$RUN_TARGET" "$CELL_ID" "\"preset\": \"$PRESET_NAME\"" "${CELL_ARGS[@]}"
+        done
     done
 else
-    for ZOOM in "${ZOOMS[@]}"; do
-        for SUB_MODE in "${SUB_MODES[@]}"; do
-            for SUB_BASE in "${SUB_BASES[@]}"; do
-                INDEX=$((INDEX + 1))
-                CELL_ID="target=${TARGET},zoom=${ZOOM},sub_mode=${SUB_MODE},sub_base=${SUB_BASE}"
-                if [[ -n "$GRID_SIZE" ]]; then
-                    CELL_ID="${CELL_ID},grid=${GRID_SIZE}"
-                fi
-                CELL_ARGS=(--auto-profile "$FRAMES" --zoom "$ZOOM"
-                           --subdivision-mode "$SUB_MODE"
-                           --base-subdivisions "$SUB_BASE")
-                if [[ -n "$GRID_SIZE" ]]; then
-                    CELL_ARGS+=(--grid-size "$GRID_SIZE")
-                fi
-                run_cell "$CELL_ID" \
-                    "\"zoom\": $ZOOM, \"sub_mode\": \"$SUB_MODE\", \"sub_base\": $SUB_BASE" \
-                    "${CELL_ARGS[@]}"
+    for RUN_TARGET in "${TARGETS[@]}"; do
+        for ZOOM in "${ZOOMS[@]}"; do
+            for SUB_MODE in "${SUB_MODES[@]}"; do
+                for SUB_BASE in "${SUB_BASES[@]}"; do
+                    INDEX=$((INDEX + 1))
+                    CELL_ID="target=${RUN_TARGET},zoom=${ZOOM},sub_mode=${SUB_MODE},sub_base=${SUB_BASE}"
+                    if [[ -n "$GRID_SIZE" ]]; then
+                        CELL_ID="${CELL_ID},grid=${GRID_SIZE}"
+                    fi
+                    CELL_ARGS=(--auto-profile "$FRAMES" --zoom "$ZOOM"
+                               --subdivision-mode "$SUB_MODE"
+                               --base-subdivisions "$SUB_BASE")
+                    if [[ -n "$GRID_SIZE" ]]; then
+                        CELL_ARGS+=(--grid-size "$GRID_SIZE")
+                    fi
+                    run_cell "$RUN_TARGET" "$CELL_ID" \
+                        "\"zoom\": $ZOOM, \"sub_mode\": \"$SUB_MODE\", \"sub_base\": $SUB_BASE" \
+                        "${CELL_ARGS[@]}"
+                done
             done
         done
     done
@@ -229,3 +251,6 @@ fi
 echo "perf_grid_matrix: done, output in $OUT_DIR"
 echo "  next: scripts/perf/perf_summary.py $OUT_DIR"
 echo "  diff: scripts/perf/compare_perf_runs.py <baseline> $OUT_DIR"
+if $TARGET_BOTH; then
+    echo "  parity: scripts/perf/lua_cpp_parity.py $OUT_DIR"
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/perf/lua_cpp_parity.py` — reads a `--target both` matrix run and prints a markdown table of `lua_avg / cpp_avg` ratio per `(zoom, sub_mode, sub_base)` cell; flags cells exceeding the threshold (default 20%) with ⚠
- Extend `scripts/perf/perf_grid_matrix.sh` with `--target both` to run the zoom×subdivision matrix for both `IRPerfGrid` and `IRLuaPerfGrid` in a single pass, storing results in one output directory
- Document the parity workflow in `docs/perf/README.md` — new "Lua-vs-C++ parity" section with invocation recipe and option reference

## Why
The codegen/EVAL path's correctness bet: Lua-driven hot-path systems should be within ~20% of hand-written C++ performance. Without this tooling the gap accumulates invisibly between releases. This becomes the standard artifact for any PR touching codegen or the EVAL path.

## Test plan
- [ ] `lua_cpp_parity.py --help` prints usage cleanly
- [ ] Script errors with a useful message when given a single-target run dir
- [ ] `--target both --quick` on a machine with both demos built produces a parity table
- [ ] `--gap-pct 5` flags the zoom=4 cell in the synthetic test

## Notes
`lua_cpp_parity.py` reuses `compare_perf_runs.py`'s `load_run` / `CellReport` machinery via the same `sys.path.insert` pattern as `perf_summary.py`. No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)