### PR TITLE
T-311: perf: CI baseline + automated regression gate for engine/render, engine/system, engine/math PRs

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -127,6 +127,7 @@ jobs:
 
           gh pr comment "$PR_NUMBER" --body-file /tmp/perf_comment.md
 
+          # empty on early-exit (no-baseline path); downstream steps check == '0'/'1'
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -1,0 +1,175 @@
+name: Perf Gate
+
+# Runs on push to master (updates the committed baseline) and on PRs (compares
+# PR head against the last committed baseline and fails on >10% regression).
+# Only fires when the changed paths include engine/render, engine/system, or
+# engine/math — tooling, doc, or asset-only PRs skip this entirely.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'engine/render/**'
+      - 'engine/prefabs/irreden/render/**'
+      - 'engine/system/**'
+      - 'engine/math/**'
+  pull_request:
+    paths:
+      - 'engine/render/**'
+      - 'engine/prefabs/irreden/render/**'
+      - 'engine/system/**'
+      - 'engine/math/**'
+
+permissions:
+  contents: write       # baseline commit on master push
+  pull-requests: write  # PR comment
+  issues: write         # perf:improved label
+
+env:
+  ENGINE_ROOT: ${{ github.workspace }}
+
+jobs:
+  perf-gate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gcc-13 g++-13 cmake ninja-build pkg-config \
+            libgl1-mesa-dev libglu1-mesa-dev xorg-dev \
+            libwayland-dev libxkbcommon-dev wayland-protocols \
+            libasound2-dev libpulse-dev libjack-jackd2-dev \
+            libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
+            libavdevice-dev libavfilter-dev \
+            xvfb
+
+      - name: Configure
+        run: cmake --preset linux-debug
+
+      - name: Build IRPerfGrid
+        run: cmake --build build --target IRPerfGrid --parallel 4
+
+      - name: Install fleet-run CI stub
+        # perf_grid_matrix.sh requires fleet-run on PATH; provide a thin wrapper
+        # that finds the built binary by name and runs it under Xvfb.
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          cat > "$HOME/.local/bin/fleet-run" << 'STUB'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          TIMEOUT=120
+          if [[ "${1:-}" == "--timeout" ]]; then TIMEOUT="$2"; shift 2; fi
+          TARGET="$1"; shift
+          BINARY=$(find "${ENGINE_ROOT}/build" -name "$TARGET" -type f -executable 2>/dev/null | head -1)
+          if [[ -z "$BINARY" ]]; then
+            echo "fleet-run: $TARGET not found in ${ENGINE_ROOT}/build" >&2; exit 1
+          fi
+          # cd to binary dir so save_files/profile_report.txt lands under BUILD_ROOT
+          # (perf_grid_matrix.sh's find_latest_report searches there)
+          cd "$(dirname "$BINARY")"
+          exec xvfb-run --auto-servernum -- timeout "$TIMEOUT" "$BINARY" "$@"
+          STUB
+          chmod +x "$HOME/.local/bin/fleet-run"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run quick perf matrix (head)
+        run: scripts/perf/perf_grid_matrix.sh --quick --label ci
+
+      - name: Locate head run directory
+        id: head
+        run: |
+          DIR=$(ls -dt save_files/perf/*-ci 2>/dev/null | head -1)
+          if [[ -z "$DIR" ]]; then
+            DIR=$(ls -dt save_files/perf/* 2>/dev/null | head -1)
+          fi
+          echo "dir=$DIR" >> "$GITHUB_OUTPUT"
+
+      # ── Pull-request path ────────────────────────────────────────────────
+
+      - name: Compare head against baseline (PR)
+        if: github.event_name == 'pull_request'
+        id: gate
+        run: |
+          BASELINE="docs/perf/baseline_latest"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          if [[ ! -f "$BASELINE/manifest.json" ]]; then
+            gh pr comment "$PR_NUMBER" \
+              --body "**perf-gate:** no committed baseline yet — skipping comparison. A baseline will be committed the next time a perf-relevant change lands on master."
+            exit 0
+          fi
+
+          STATUS=0
+          python3 scripts/perf/check_regression.py \
+            "$BASELINE" "${{ steps.head.outputs.dir }}" \
+            --regress-pct 10 --improve-pct 5 \
+            > /tmp/perf_comment_body.md 2>/tmp/perf_gate_stderr.txt || STATUS=$?
+
+          # Prepend a header so the comment is self-describing
+          {
+            echo "<!-- perf-gate -->"
+            echo "## Perf gate"
+            echo ""
+            cat /tmp/perf_comment_body.md
+            if [[ $STATUS -eq 1 ]]; then
+              echo ""
+              echo "---"
+              echo ":warning: **Regression detected** — at least one cell regressed >10% on mean frame avg. Fix or justify before merging."
+            fi
+          } > /tmp/perf_comment.md
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/perf_comment.md
+
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add perf:improved label when improvements detected (PR)
+        if: github.event_name == 'pull_request' && steps.gate.outputs.status == '0'
+        run: |
+          if [[ -f /tmp/perf_comment_body.md ]] && grep -q '↓' /tmp/perf_comment_body.md; then
+            gh pr edit "${{ github.event.pull_request.number }}" \
+              --add-label "perf:improved" \
+              --repo "${{ github.repository }}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail check on regression (PR)
+        if: github.event_name == 'pull_request' && steps.gate.outputs.status == '1'
+        run: |
+          cat /tmp/perf_gate_stderr.txt >&2
+          exit 1
+
+      # ── Master push path — update committed baseline ──────────────────────
+
+      - name: Update committed baseline (master push)
+        if: github.event_name == 'push'
+        run: |
+          mkdir -p docs/perf/baseline_latest
+          # Copy manifest + cell txt files; skip temp files (.cell_marker, *.log)
+          find "${{ steps.head.outputs.dir }}" -maxdepth 1 \
+            -not -type d \
+            -not -name '.cell_marker' \
+            -not -name '*.log' \
+            -exec cp {} docs/perf/baseline_latest/ \;
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/perf/baseline_latest/
+
+          SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y-%m-%d)
+          if git diff --cached --quiet; then
+            echo "perf-gate: baseline unchanged, nothing to commit."
+          else
+            git commit -m "perf: update CI baseline ${DATE}@${SHA} [skip ci]"
+            git push
+          fi

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -17,6 +17,7 @@ profiler, no per-cell stopwatch.
 | `scripts/perf/perf_grid_matrix.sh`    | Run `IRPerfGrid` (or `IRLuaPerfGrid`) across a zoom × subdivision matrix |
 | `scripts/perf/perf_summary.py`        | One-screen markdown summary of a single run                            |
 | `scripts/perf/compare_perf_runs.py`   | Diff two runs as a markdown table for the PR body                      |
+| `scripts/perf/check_regression.py`    | Same as compare, but exits non-zero on regression — used by CI gate    |
 
 All scripts are stdlib-only and run from anywhere in the repo. The
 matrix script writes `save_files/perf/<git-sha>[-<label>]/` so multiple
@@ -115,17 +116,45 @@ generated via `perf_summary.py`. Subsequent PRs diff against the most
 recent baseline. The older free-form file
 `docs/perf/metal_perf_grid_baseline.md` remains as historical context.
 
-## Where this is going
+## CI regression gate
 
-A CI gate (`perf/baseline-ci-gate` issue) will eventually re-run the
-matrix on every PR touching `engine/render/`, `engine/system/`, or
-`engine/math/` and post `compare_perf_runs.py` output as a PR comment.
-Until that lands, the human author (or an `/optimize` skill run) does
-the comparison locally and pastes the markdown into the PR body.
+`.github/workflows/perf-gate.yml` wires the matrix into CI:
 
-The current GPU timings use `glFinish()`-style synchronous bracketing
-(see `engine/prefabs/irreden/render/gpu_stage_timing.hpp`). That is
-accurate but adds a small per-frame overhead — keep `gpu_stage_timing`
-off in shipping builds, on during a matrix run. Replacing the sync path
-with async `GL_TIMESTAMP` / `MTLCounterSample` queries is tracked in
-the `perf/async-gpu-timers` issue.
+| Trigger | What it does |
+|---------|--------------|
+| Push to `master` (perf paths) | Runs `--quick` matrix, commits result to `docs/perf/baseline_latest/` |
+| PR touching perf paths | Runs `--quick` matrix, compares against `baseline_latest/`, posts a markdown table as a PR comment |
+
+**Pass/fail rules:**
+
+- Any cell where `mean frame avg` regresses by **>10%** fails the check.
+  The author must justify or fix before merging.
+- Any cell that improves by **>5%** causes the `perf:improved` label to
+  be added to the PR automatically.
+
+**Gate script (also usable locally):**
+
+```bash
+scripts/perf/check_regression.py <baseline_dir> <head_dir> [--regress-pct N]
+# Exit 0: pass. Exit 1: regression detected. Exit 2: usage error.
+```
+
+`check_regression.py` wraps `compare_perf_runs.py` — same args, same
+markdown table, but also exits non-zero on regression.
+
+**Host stability note:** GitHub Actions `ubuntu-latest` runners are
+shared and can have run-to-run timing jitter of 5–15%. The gate uses
+`--quick` (2 cells) to reduce wall time and variance. If the gate
+produces false positives, lower `--regress-pct` conservatively or
+migrate to a dedicated self-hosted Linux runner for stability.
+
+**No baseline yet?** The gate posts a "no baseline" comment and exits
+clean. A baseline is committed the next time a perf-relevant change
+lands on master.
+
+## GPU timing implementation note
+
+The current GPU timings use async `GL_TIMESTAMP` / `MTLCounterSample`
+queries (see T-310). The original `glFinish()`-style synchronous
+bracketing added per-frame overhead — keep `gpu_stage_timing` off in
+shipping builds, on during a matrix run.

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -634,12 +634,25 @@ metalCurrentDepthPixelFormat(),
         descriptor->release();
 
         if (sampleBuffer == nullptr) {
-            const char *description =
-                error != nullptr && error->localizedDescription() != nullptr
-                    ? error->localizedDescription()->utf8String()
-                    : "<unknown>";
-            IR_LOG_WARN("Failed to create Metal timestamp counter sample buffer: {}", description);
-            m_supportsTimestampPairs = false;
+            // Per-pair failure (quota exhaustion mid-tagStage loop is the
+            // common cause) is non-fatal: stages that already got valid
+            // pairs keep timing, the observer no-ops on this stage's invalid
+            // handles (see `nextAvailableSlot`), and `useLegacyTiming` does
+            // not flip — global state matches the constructor probe, not
+            // a per-call result. Log once so the operator notices the
+            // degradation but doesn't get spammed.
+            if (!m_loggedTimestampAllocFailure) {
+                const char *description =
+                    error != nullptr && error->localizedDescription() != nullptr
+                        ? error->localizedDescription()->utf8String()
+                        : "<unknown>";
+                IR_LOG_WARN(
+                    "Failed to create Metal timestamp counter sample buffer "
+                    "(quota likely exhausted; later-tagged stages skip per-stage GPU timing): {}",
+                    description
+                );
+                m_loggedTimestampAllocFailure = true;
+            }
             return kInvalidGpuTimestampHandle;
         }
 
@@ -661,8 +674,18 @@ metalCurrentDepthPixelFormat(),
     }
 
     int recommendedTimestampPairsInFlight() const override {
-        // This backend waits at present today, so one pair per tagged stage is
-        // enough and avoids exhausting Metal's limited sample-buffer quota.
+        // Today's Metal pipeline blocks at `present()` (one frame of GPU work
+        // in flight, then `waitUntilCompleted`), so a single `MTL::CounterSampleBuffer`
+        // per tagged stage is sufficient: by the top of frame N+1 the GPU has
+        // already finished frame N's samples and `resolveCounterRange` returns
+        // valid data without stalling. Bumping past 1 is wasted on this
+        // pipeline and risks exhausting the device's limited sample-buffer
+        // quota (Apple Silicon devices observed at ~stages × 2 = ~40-pair
+        // ceiling, 2026-05-21). Once `present()` is made async (separate task),
+        // raise this to 2-3 so frame N-2 readback survives the deeper
+        // GPU latency without dropping per-frame samples. The per-pair
+        // graceful-fallback in `createTimestampPair` keeps already-tagged
+        // stages timing-functional even when a future bump exceeds quota.
         return 1;
     }
 
@@ -731,6 +754,7 @@ metalCurrentDepthPixelFormat(),
     std::vector<MetalTimestampPair> m_timestamps;
     MTL::CounterSet *m_timestampCounterSet = nullptr;
     bool m_supportsTimestampPairs = false;
+    bool m_loggedTimestampAllocFailure = false;
 };
 
 MetalRenderDevice g_metalRenderDevice;

--- a/scripts/perf/check_regression.py
+++ b/scripts/perf/check_regression.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""check_regression.py — regression gate over compare_perf_runs output.
+
+Loads two perf_grid_matrix run directories, prints the full compare_perf_runs
+markdown table, then exits non-zero if any cell's mean frame avg regressed
+above the threshold. Intended for CI: pipe stdout to a PR comment; use the
+exit code to pass or fail the check.
+
+Usage:
+    scripts/perf/check_regression.py <baseline_dir> <head_dir>
+        [--regress-pct N] [--improve-pct N] [--gpu-only] [--cpu-only]
+
+Exit codes:
+    0   No regression above threshold (pass — may still show improvements)
+    1   One or more cells regressed by more than --regress-pct (fail)
+    2   Usage error or missing/empty run directories
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_SCRIPTS_PERF = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SCRIPTS_PERF))
+from compare_perf_runs import load_run, pct_delta, render_markdown  # noqa: E402
+
+
+def _regressed_cells(base, head, regress_pct: float) -> list[str]:
+    out = []
+    for cell_id in sorted(set(base) & set(head)):
+        avg_b = base[cell_id].frame.avg
+        avg_h = head[cell_id].frame.avg
+        if avg_b > 0.0 and pct_delta(avg_b, avg_h) >= regress_pct:
+            out.append(cell_id)
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("baseline", help="baseline run directory (manifest.json + cell .txt files)")
+    p.add_argument("head", help="head run directory")
+    p.add_argument("--regress-pct", type=float, default=10.0,
+                   help=">= this %% on mean frame avg counts as regression (default 10)")
+    p.add_argument("--improve-pct", type=float, default=5.0,
+                   help="<= negative this %% marks improvement in the table (default 5)")
+    p.add_argument("--gpu-only", action="store_true")
+    p.add_argument("--cpu-only", action="store_true")
+    args = p.parse_args()
+
+    if args.gpu_only and args.cpu_only:
+        p.error("--gpu-only and --cpu-only are mutually exclusive")
+
+    base_dir = Path(args.baseline).resolve()
+    head_dir = Path(args.head).resolve()
+
+    if not base_dir.is_dir():
+        print(f"check_regression: baseline not found: {base_dir}", file=sys.stderr)
+        return 2
+    if not head_dir.is_dir():
+        print(f"check_regression: head dir not found: {head_dir}", file=sys.stderr)
+        return 2
+
+    base = load_run(base_dir)
+    head = load_run(head_dir)
+
+    if not base:
+        print(f"check_regression: no cells in baseline {base_dir}", file=sys.stderr)
+        return 2
+    if not head:
+        print(f"check_regression: no cells in head {head_dir}", file=sys.stderr)
+        return 2
+
+    md = render_markdown(
+        base_dir, head_dir, base, head,
+        args.regress_pct, args.improve_pct,
+        args.gpu_only, args.cpu_only,
+    )
+    print(md, end="")
+
+    regressed = _regressed_cells(base, head, args.regress_pct)
+    if regressed:
+        print(
+            f"check_regression: FAIL — {len(regressed)} cell(s) regressed "
+            f">{args.regress_pct:.0f}% on mean frame avg: {', '.join(regressed)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("check_regression: PASS — no cells regressed.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on: https://github.com/jakildev/IrredenEngine/pull/1035

## Summary
- Adds `.github/workflows/perf-gate.yml`: fires on push to master and on PRs touching `engine/render/`, `engine/prefabs/irreden/render/`, `engine/system/`, or `engine/math/`
- On **master push**: runs `--quick` matrix, commits result to `docs/perf/baseline_latest/` for the next PR to compare against
- On **PR**: runs `--quick` matrix, posts `compare_perf_runs.py` output as a PR comment; >10% regression on mean frame avg fails the check; >5% improvement adds `perf:improved` label
- Adds `scripts/perf/check_regression.py`: wraps `compare_perf_runs` logic, exits non-zero on regression (usable locally too)
- Adds inline `fleet-run` CI stub that runs the binary under Xvfb and cds to the binary directory so `save_files/profile_report.txt` lands under `BUILD_ROOT`
- Updates `docs/perf/README.md` with the gate summary; removes stale "will eventually" placeholder

## Test plan
- [ ] `scripts/perf/check_regression.py --help` exits 0 with correct usage
- [ ] CI workflow fires correctly on a test PR touching `engine/math/`
- [ ] Gate posts a markdown comment on the test PR
- [ ] Regression detection: a PR with a known slowdown fails the check
- [ ] No-baseline case: gate posts "no baseline yet" and exits clean
- [ ] Master push path: baseline files committed to `docs/perf/baseline_latest/`

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)