### PR TITLE
skills: add Closes #N to canonical pr-body template

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -229,6 +229,8 @@ gh pr create --base master --title "<scope>: <title>" --body "$(cat <<'EOF'
 ## Test plan
 - [ ] <check>
 
+Closes #<issue-N>
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
@@ -236,6 +238,16 @@ EOF
 
 Title should match the commit title for a single commit; use a broader title
 for multi-commit PRs.
+
+**`Closes #N` line (required when the task has an `Issue:` field).** This is
+what makes GitHub auto-close the originating issue on merge. Without it the
+TASKS.md row still reaps via the title's `T-NNN:` prefix (per
+`fleet-tasks-render`'s closed-issue fallback) but the GitHub issue side
+stays open and the queue silently accumulates stale items. Omit the line
+only when the task's `Issue:` field is `(none)` — cleanup PRs, fleet-tooling
+PRs filed without a tracking issue, etc. See
+[`procedures/pr-body.md`](procedures/pr-body.md) for the full template and
+the stack-mode exceptions (cursor-stack non-leaf PRs deliberately drop it).
 
 **PR labels — `fleet:wip` (important):** For the **default Cursor /
 human-ready** single-PR open to `master`, **do not** pass

--- a/.claude/skills/commit-and-push/procedures/pr-body.md
+++ b/.claude/skills/commit-and-push/procedures/pr-body.md
@@ -15,10 +15,20 @@ stack modes apply a delta to the canonical template.
 ## Notes for reviewer
 <optional — include only when the reviewer needs specific guidance>
 
+Closes #<issue-N>
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
 Omit `## Notes for reviewer` when there is nothing non-obvious to call out.
+Omit the `Closes #<issue-N>` line when the task's `Issue:` field is `(none)`
+(e.g. cleanup PRs, fleet-tooling PRs filed without a tracking issue).
+
+The `Closes #N` line is what makes GitHub auto-close the originating issue on
+merge. Without it, the closed-issue auto-reaper in `fleet-tasks-render` still
+moves the TASKS.md row to Done (via the PR title's `T-NNN:` prefix), but the
+GitHub issue side stays open and accumulates. Always include it when an Issue
+number exists.
 
 ## Fleet stack delta
 
@@ -33,7 +43,8 @@ Stacked on: <previous PR URL, or "master" for the first PR>
 Full chain: T-<A>, T-<B>, T-<C>
 ```
 
-Also add `Closes #<issue-N>` before the robot footer. Drop `## Notes for reviewer`.
+Drop `## Notes for reviewer`. The `Closes #<issue-N>` line is already in the
+canonical template above — keep it as written.
 
 ## Cursor stack delta
 
@@ -47,5 +58,8 @@ When the parent PR merges, change this PR's base to `master`
 (via the GitHub UI or `gh pr edit <N> --base master`).
 ```
 
-No `Full chain:` line and no `Closes #<issue-N>`. Drop `## Notes for reviewer`.
+No `Full chain:` line. **Drop the `Closes #<issue-N>` line** — closing the
+issue while the parent PR is still open would orphan downstream review work.
+The leaf PR in the cursor-stack chain (the one that re-targets master) carries
+the `Closes` line instead. Drop `## Notes for reviewer`.
 `$parent_pr_ref` is the parent PR URL (or branch name if no PR exists yet). Use `<<EOF` (no quotes) in the HEREDOC so that `$parent_pr_ref` expands; `<<'EOF'` suppresses expansion and embeds the literal string.

--- a/.claude/skills/commit-and-push/procedures/pr-body.md
+++ b/.claude/skills/commit-and-push/procedures/pr-body.md
@@ -58,8 +58,9 @@ When the parent PR merges, change this PR's base to `master`
 (via the GitHub UI or `gh pr edit <N> --base master`).
 ```
 
-No `Full chain:` line. **Drop the `Closes #<issue-N>` line** — closing the
-issue while the parent PR is still open would orphan downstream review work.
-The leaf PR in the cursor-stack chain (the one that re-targets master) carries
-the `Closes` line instead. Drop `## Notes for reviewer`.
+No `Full chain:` line. **Drop the `Closes #<issue-N>` line** — the parent PR
+closes the shared issue when it merges to master. Avoid duplicating `Closes #N`
+on the child while the parent is still in review. The parent PR (which targets
+master directly via the canonical template) carries the `Closes` line and closes
+the shared issue when it merges first. Drop `## Notes for reviewer`.
 `$parent_pr_ref` is the parent PR URL (or branch name if no PR exists yet). Use `<<EOF` (no quotes) in the HEREDOC so that `$parent_pr_ref` expands; `<<'EOF'` suppresses expansion and embeds the literal string.


### PR DESCRIPTION
## Summary
- Move `Closes #<issue-N>` line from the fleet-stack-only delta into the canonical (single-PR) `pr-body.md` template so standalone PRs auto-close their originating issues on merge.
- Mirror the change in `commit-and-push/SKILL.md` step 8 inline example with a `**Required when…**` note documenting the auto-close mechanism.
- Cursor-stack non-leaf PRs continue to drop the line (would otherwise orphan downstream review work); document the reason explicitly.

## Why
Audit on 2026-05-21 found 7 issues sitting open even though their PRs had merged — `#1012, #1013, #1017, #1021, #1023` plus housekeeping `#714, #1007`. Root cause was a template omission: the canonical single-PR body never carried `Closes #N`, so the GitHub-side auto-close link was missing. The TASKS.md reaper in `fleet-tasks-render` still moved rows to Done via the `T-NNN:` title prefix, but the issue side stayed open and the queue silently grew.

This change makes the close-the-loop link the default for every new PR. The 7 stale issues from the audit were closed manually as part of the same cleanup pass.

## Test plan
- [ ] Next fleet PR that ingests from an issue includes `Closes #N` and the issue auto-closes on merge.
- [ ] Cursor-stack workflow non-leaf PRs continue to omit `Closes` (verified by re-reading cursor-stack delta).
- [ ] No behavior change for PRs without an `Issue:` field (line is documented as optional in that case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)