### PR TITLE
perf: cap voxel-pool pending-position-range queue (catch-up blowup)

### DIFF
--- a/.claude/skills/optimize/reference/big_wins.md
+++ b/.claude/skills/optimize/reference/big_wins.md
@@ -117,3 +117,26 @@ worst-case matrix cell) land here as part of the optimization PR.
   hypothesis, **measure the next layer down**. The frame time was
   growing with zoom — the next-layer-down was "is culling actually
   shrinking the working set?" and the answer was "barely."
+
+## Pending-position-range catch-up blowup (optimize audit, 2026-05-21)
+
+- **What**: `C_VoxelPool`'s pending-position-range queue accumulated
+  one range per moving voxel set per UPDATE tick; the fixed-timestep
+  loop runs several UPDATE ticks per render frame, so
+  `VOXEL_TO_TRIXEL_STAGE_1`'s per-frame `std::sort` of the queue grew
+  to millions of entries. Capped the queue; a saturated queue falls
+  back to one whole-live-range upload.
+- **Where**:
+  `engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp`
+  (`kMaxPendingPositionRanges` + capped `queuePositionRange`),
+  `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp`
+  (`flushPendingPositionRanges` saturation path).
+- **Win**: `IRPerfGrid` frame time fell **55–66 % on every one of the
+  12 matrix cells** — zoom 8 / full 176 ms → 65 ms, zoom 1 / full
+  58 ms → 23 ms. `SingleVoxelToCanvasFirst` 19–62 ms → flat ~4.9 ms.
+  The feedback loop unwound: a faster render frame runs fewer
+  catch-up UPDATE ticks, so the UPDATE pipeline cost dropped too.
+- **Lesson**: Any UPDATE-populated / RENDER-drained queue is suspect
+  when UPDATE can run multiple times per render frame. The tell is a
+  system whose CPU cost tracks *frame time* rather than scene
+  content — sub-tick `IR_PROFILE_SCOPE` blocks pinpoint the region.

--- a/.claude/skills/optimize/reference/common_bottlenecks.md
+++ b/.claude/skills/optimize/reference/common_bottlenecks.md
@@ -71,6 +71,29 @@ session uncovers lands here in the same PR as the fix.
   flush). Never add a `bool dirty_` flag — full rule:
   `.claude/rules/cpp-ecs.md` §"No dirty flags on components".
 
+### 12. Pending-range queue accumulates across fixed-timestep catch-up ticks
+
+- **Pattern**: A per-frame "pending ranges" / dirty list populated by a
+  system in the **UPDATE** pipeline and drained by a system in the
+  **RENDER** pipeline. UPDATE runs N times per render frame (fixed-timestep
+  catch-up); a moving entity re-queues its range every UPDATE tick, so the
+  list grows to `N × (queuing entities)` and the RENDER-side drain (often a
+  `std::sort` + coalesce) blows up super-linearly. Worse: a slow frame
+  raises N, which slows the frame further — a feedback spiral.
+- **Where**: `C_VoxelPool::queuePositionRange` / `flushPendingPositionRanges`
+  in `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp`
+  (fixed in the PR that added this entry).
+- **Symptom**: A RENDER system's CPU avg scales with *frame time* rather
+  than with scene content — `SingleVoxelToCanvasFirst` measured 14 ms at a
+  46 ms frame but 62 ms at a 181 ms frame on the *same* scene. Sub-tick
+  `IR_PROFILE_SCOPE` blocks localize it to the queue-drain region.
+- **Fix**: Cap the queue. Once it saturates the queued ranges no longer
+  describe a small moved subset — fall back to one whole-buffer upload and
+  drop further queue calls (the full upload covers them). Caps both the
+  drain CPU cost and the queue's memory / `push_back` cost. The deeper fix
+  is dedupe-at-queue-time or drain-per-UPDATE-tick; the saturation cap is
+  the contained, provably-correct version.
+
 ---
 
 ## GPU bottlenecks (render pipeline)

--- a/.claude/skills/optimize/reference/cpu_profiling.md
+++ b/.claude/skills/optimize/reference/cpu_profiling.md
@@ -37,6 +37,40 @@ void some_inner_block() {
 Don't wrap helpers called from a tick — easy_profiler's per-scope cost
 adds up if you put it inside the per-entity loop. Wrap the tick itself.
 
+## When the tick itself is the hotspot — sub-tick breakdown
+
+The matrix's "top CPU systems" table tells you *which* system is slow.
+It does not tell you *which line of the tick*. When a once-per-frame
+system tick (a render-pipeline stage, not a per-entity loop) is the
+hotspot, break it down with `IR_PROFILE_SCOPE` sub-blocks:
+
+```cpp
+void tick(...) {
+    { IR_PROFILE_SCOPE("vs1_clear");  clearCanvasAndDistances(...); }
+    { IR_PROFILE_SCOPE("vs1_pos");    /* position upload */ }
+    { IR_PROFILE_SCOPE("vs1_color");  /* color upload */ }
+    // ...
+}
+```
+
+This is **not** the "don't wrap helpers" anti-pattern above — that
+caveat is about per-*entity*-loop bodies, where the scope cost is paid
+N times. A render-stage tick runs **once per frame**, so a handful of
+sub-scopes cost a few µs total. Name them `<system>_<region>` so they
+group in the dump.
+
+Surfacing them: `perf_grid`'s `--auto-profile` dump prints **every**
+`IR_PROFILE_SCOPE` that ran last frame, sorted by total ms (the
+`Auto-profile CPU-scope — <name>: <ms>` lines in each matrix `.log`).
+So any sub-scope you add shows up in the matrix output with no extra
+wiring. Leave the scopes on the one or two regions that turned out to
+matter — they are cheap permanent regression sensors on the hot path.
+
+This is how `common_bottlenecks.md` #12 was localized: the matrix
+flagged `SingleVoxelToCanvasFirst` as the hotspot, and `vs1_*`
+sub-scopes pinned it to the position-upload region (`vs1_pos`: 8 ms at
+zoom 1, 56 ms at zoom 8 — same scene).
+
 ## Per-frame CPU histogram (the HUD-facing one)
 
 `IR_PROFILE_SCOPE(name)` is a different scope timer that feeds the

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -61,6 +61,9 @@
 #include <cstdlib>
 #include <numbers>
 #include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 // IRPerfGrid stress test: voxel_set vs sdf share the same lattice (positions,
 // colors, periodic-idle wave). They are *not* lighting-equivalent today:
@@ -620,6 +623,22 @@ void initSystems() {
                         cpu.lastFrameMs("update"),
                         cpu.lastFrameMs("render")
                     );
+                    // Self-describing per-scope dump: every IR_PROFILE_SCOPE
+                    // that ran last frame, sorted by total ms descending. Lets
+                    // a profiling pass localize cost inside a system tick
+                    // without re-editing this hard-coded list each time.
+                    {
+                        std::vector<std::pair<std::string_view, double>> scopes;
+                        for (const auto &[name, stats] : cpu.lastFrame()) {
+                            scopes.emplace_back(name, stats.totalMs_);
+                        }
+                        std::sort(scopes.begin(), scopes.end(), [](const auto &a, const auto &b) {
+                            return a.second > b.second;
+                        });
+                        for (const auto &[name, ms] : scopes) {
+                            IR_LOG_INFO("Auto-profile CPU-scope — {}: {:.3f}ms", name, ms);
+                        }
+                    }
                     IR_LOG_INFO(
                         "Auto-profile GPU — voxelStage1:{:.3f} voxelStage2:{:.3f} "
                         "voxelCompact:{:.3f}",

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -3,6 +3,7 @@
 
 #include <irreden/ir_render.hpp>
 #include <irreden/ir_profile.hpp>
+#include <irreden/profile/scope_timer.hpp>
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_constants.hpp>
 #include <irreden/ir_entity.hpp>
@@ -121,6 +122,20 @@ inline void flushPendingPositionRanges(C_VoxelPool &pool, Buffer *buf) {
     constexpr size_t kStride = sizeof(C_PositionGlobal3D);
     const auto &globals = pool.getPositionGlobals();
 
+    // A saturated queue no longer represents a small moved subset — the
+    // ranges cover most of the live buffer (every moving voxel set
+    // re-queued across N catch-up update ticks). Sorting + coalescing
+    // thousands of fragments costs more than one whole-live-range
+    // upload, so take that path. See C_VoxelPool::kMaxPendingPositionRanges.
+    if (ranges.size() >= C_VoxelPool::kMaxPendingPositionRanges) {
+        const int liveCount = pool.getLiveVoxelCount();
+        if (liveCount > 0) {
+            buf->subData(0, static_cast<size_t>(liveCount) * kStride, globals.data());
+        }
+        pool.clearPendingPositionRanges();
+        return;
+    }
+
     std::sort(ranges.begin(), ranges.end());
     size_t runStart = ranges.front().first;
     size_t runEnd = runStart + ranges.front().second;
@@ -208,7 +223,10 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // stateless-particles demo, any pure-shape or pure-particle scene).
         // Keep this above the early-return so an empty voxel pool no
         // longer dictates whether the canvas refreshes.
-        clearCanvasAndDistances(entity, triangleCanvasTextures);
+        {
+            IR_PROFILE_SCOPE("vs1_clear");
+            clearCanvasAndDistances(entity, triangleCanvasTextures);
+        }
 
         if (liveVoxelCount == 0)
             return;
@@ -266,16 +284,19 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // by another canvas's mutator pushes since both write to the
         // shared `voxelPosBuf_`, so on a canvas switch we re-seed the
         // whole live range and drain this pool's queue.
-        if (lastUploadedCanvas_ != entity) {
-            voxelPosBuf_->subData(
-                0,
-                liveVoxelCount * sizeof(C_PositionGlobal3D),
-                voxelPool.getPositionGlobals().data()
-            );
-            voxelPool.clearPendingPositionRanges();
-            lastUploadedCanvas_ = entity;
-        } else {
-            flushPendingPositionRanges(voxelPool, voxelPosBuf_);
+        {
+            IR_PROFILE_SCOPE("vs1_pos");
+            if (lastUploadedCanvas_ != entity) {
+                voxelPosBuf_->subData(
+                    0,
+                    liveVoxelCount * sizeof(C_PositionGlobal3D),
+                    voxelPool.getPositionGlobals().data()
+                );
+                voxelPool.clearPendingPositionRanges();
+                lastUploadedCanvas_ = entity;
+            } else {
+                flushPendingPositionRanges(voxelPool, voxelPosBuf_);
+            }
         }
         voxelColorBuf_->subData(0, liveVoxelCount * sizeof(C_Voxel), voxelPool.getColors().data());
         // Active-mask covers the live prefix; upload the matching whole-word

--- a/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
@@ -324,14 +324,31 @@ struct C_VoxelPool {
         }
     }
 
+    // Cap on queued position ranges. The fixed-timestep loop runs
+    // UPDATE_VOXEL_SET_CHILDREN once per update tick, and a slow render
+    // frame accumulates several update ticks before VOXEL_TO_TRIXEL_STAGE_1
+    // drains the queue. Every moving voxel set re-queues its range each
+    // tick, so the list can reach (update ticks) × (moving sets) entries —
+    // millions in a stress scene. Past this cap the sort + coalesce in
+    // `flushPendingPositionRanges` costs far more than one whole-live-range
+    // upload, so the flusher treats a saturated queue as "re-upload
+    // everything" and further queue calls become no-ops (the full upload
+    // covers the dropped ranges anyway).
+    static constexpr std::size_t kMaxPendingPositionRanges = 8192;
+
     // Queue a slice of position-globals to upload to the GPU position
     // SSBO on the next `flushPendingPositionRanges` call. Mirrors the
     // pending-list-flush pattern documented in `cpp-ecs.md`: the
     // mutating system (UPDATE_VOXEL_SET_CHILDREN) queues the affected
     // slice; the GPU-buffer-owning system (VOXEL_TO_TRIXEL_STAGE_1)
     // coalesces contiguous queued ranges into one `subData` per run.
+    // Saturating `kMaxPendingPositionRanges` switches the flusher to a
+    // single whole-buffer upload — see `flushPendingPositionRanges`.
     void queuePositionRange(size_t startIdx, size_t count) {
         if (count == 0) {
+            return;
+        }
+        if (m_pendingPositionRanges.size() >= kMaxPendingPositionRanges) {
             return;
         }
         m_pendingPositionRanges.emplace_back(startIdx, count);


### PR DESCRIPTION
## Summary

A `/optimize` audit run against `IRPerfGrid` found the demo pinned at
**17-20 FPS** (≈55 ms/frame) regardless of zoom or subdivision mode.
Sub-tick `IR_PROFILE_SCOPE` instrumentation localized the dominant
render-side cost to **one block** of `VOXEL_TO_TRIXEL_STAGE_1`: the
voxel-position upload (`vs1_pos`), measured at 7.9 ms at zoom 1 but
**55.9 ms at zoom 8** — on the *same scene*.

Root cause: `C_VoxelPool`'s pending-position-range queue is filled by
`UPDATE_VOXEL_SET_CHILDREN` (UPDATE pipeline) and drained by
`flushPendingPositionRanges` (RENDER pipeline). The fixed-timestep loop
runs UPDATE several times per render frame; every moving voxel set
re-queues its range each tick. So the per-render-frame `std::sort` grows
to `(update ticks) × (moving sets)` entries — ~2.9M in the zoom-8 stress
cell. A slow frame runs more catch-up ticks → bigger sort → slower frame:
a feedback spiral.

Fix: cap the queue at `C_VoxelPool::kMaxPendingPositionRanges` (8192).
Once saturated, `queuePositionRange` becomes a no-op and
`flushPendingPositionRanges` does a single whole-live-range `subData`
instead of sort + coalesce. The full upload covers the dropped ranges,
so it stays correct; it also bounds the queue's memory and `push_back`
cost.

## Measured result — `perf_grid_matrix.sh` (12 cells, macOS / Metal, M4 Max)

`scripts/perf/compare_perf_runs.py` baseline → head, frame avg / p99:

| cell | avg ms | p99 ms |
|------|--------|--------|
| zoom1 full | 57.87 → 23.10 (-60%) | 100.77 → 42.86 |
| zoom1 none | 61.62 → 22.99 (-63%) | 109.98 → 37.39 |
| zoom1 position_only | 58.05 → 22.99 (-60%) | 85.22 → 37.28 |
| zoom2 full | 62.19 → 24.88 (-60%) | 106.00 → 39.20 |
| zoom2 none | 52.48 → 23.72 (-55%) | 83.83 → 36.84 |
| zoom2 position_only | 63.74 → 23.51 (-63%) | 100.92 → 35.87 |
| zoom4 full | 109.90 → 37.06 (-66%) | 119.95 → 54.00 |
| zoom4 none | 51.30 → 23.15 (-55%) | 82.92 → 39.97 |
| zoom4 position_only | 62.80 → 23.97 (-62%) | 225.43 → 36.78 |
| zoom8 full | 176.21 → 64.56 (-63%) | 187.01 → 75.60 |
| zoom8 none | 50.44 → 22.65 (-55%) | 83.03 → 33.03 |
| zoom8 position_only | 53.65 → 23.11 (-57%) | 82.48 → 35.77 |

Every cell improves 55-66%. `SingleVoxelToCanvasFirst` CPU drops from
19-62 ms to a flat ~4.9 ms. The feedback loop unwinds: a faster render
frame runs fewer catch-up UPDATE ticks, so the UPDATE pipeline cost also
falls. Voxel cull ratios are byte-for-byte unchanged (no culling change);
GPU stage timings are unchanged within noise.

This does not reach the 100 FPS goal — the remaining floor is the UPDATE
pipeline (~20 ms, 7 systems × 262K entities), the per-frame canvas/distance
clear (`vs1_clear` ~4.4 ms), and the zoom-8 `voxelStage2` GPU cost (the
shadow-feeder cull issue, #1020). Those are filed separately.

## Also in this PR

- `vs1_pos` / `vs1_clear` `IR_PROFILE_SCOPE` blocks left on the two
  material cost regions of `VOXEL_TO_TRIXEL_STAGE_1` — regression
  defense on exactly the code path this PR fixes.
- `perf_grid` auto-profile now dumps **every** `IR_PROFILE_SCOPE` by
  total ms (was a hard-coded 6-name list) — self-describing sub-tick
  breakdown for future profiling passes.
- `optimize` skill: new bottleneck-catalog entry (#12, catch-up queue
  blowup) and a big-wins case study.

## Test plan

- [x] `IRPerfGrid` builds clean (macOS / Metal)
- [x] 12-cell `perf_grid_matrix.sh` before/after — see table above
- [ ] OpenGL (Linux) parity run — backend-agnostic change (no shader /
      backend code touched), but a fleet Linux matrix run would confirm
- [ ] reviewer: confirm `kMaxPendingPositionRanges = 8192` is a sane
      threshold (a scene with <8192 distinct moving voxel runs keeps the
      precise partial-upload path)