### PR TITLE
T-324: editors/voxel_editor: migrate EditorViewportRotate to shared-ptr state capture

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -1196,33 +1196,31 @@ void initSystems() {
     // scene clicks under the palette. Gizmo input lands after the
     // widget chain so an over-gizmo click doesn't trip the scene-
     // edit path either.
-    auto rotParams = std::make_unique<RotateParams>();
-    auto *rp = rotParams.get();
+    auto rotState = std::make_shared<RotateParams>();
     auto rotateSystem = IRSystem::createSystem<C_CameraYaw>(
         "EditorViewportRotate",
         [](C_CameraYaw &) {},
-        [rp]() {
+        [rotState]() {
             bool rightPressed =
                 IRInput::checkKeyMouseButton(IRInput::kMouseButtonRight, IRInput::PRESSED);
             bool rightHeld =
                 IRInput::checkKeyMouseButton(IRInput::kMouseButtonRight, IRInput::HELD);
 
             if (rightPressed) {
-                rp->firstRotFrame_ = true;
+                rotState->firstRotFrame_ = true;
             }
 
             if (rightHeld) {
                 vec2 mouse = IRInput::getMousePositionScreen();
-                if (!rp->firstRotFrame_) {
-                    float deltaX = mouse.x - rp->prevMouseX_;
+                if (!rotState->firstRotFrame_) {
+                    float deltaX = mouse.x - rotState->prevMouseX_;
                     IRPrefab::Camera::rotateYaw(deltaX * IRVoxelEditor::kRotationSensitivity);
                 }
-                rp->prevMouseX_ = mouse.x;
-                rp->firstRotFrame_ = false;
+                rotState->prevMouseX_ = mouse.x;
+                rotState->firstRotFrame_ = false;
             }
         }
     );
-    IRSystem::setSystemParams(rotateSystem, std::move(rotParams));
 
     // Scrubber + FPS sync (T-214). Runs in INPUT, after WIDGET_APPLY_SLIDER
     // so the drag value is already committed to C_WidgetSlider::currentValue_.


### PR DESCRIPTION
## Summary
- Replace `unique_ptr<RotateParams> + raw pointer + setSystemParams` with `shared_ptr<RotateParams>` captured by value in the endTick lambda, eliminating the `setSystemParams(std::move(...))` dance.
- `unique_ptr` cannot be captured by value (move-only), so `shared_ptr` is the right tool for this pattern; the lambda is the sole owner in practice.
- System stays in `creations/editors/voxel_editor/main.cpp` — right-drag binding is editor-specific and is not promoted to an engine prefab.
- Functional behaviour is identical: right-drag rotates camera yaw at the same sensitivity.

## Test plan
- [x] `fleet-build --target IRVoxelEditor` clean on macos-debug
- [ ] `fleet-build --target IRVoxelEditor` clean on linux-debug
- [x] `fleet-run --timeout 15 IRVoxelEditor` — launches cleanly, no crash
- [ ] Verify right-drag in the running editor rotates camera Z-yaw at expected sensitivity

Closes #1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)