### PR TITLE
T-327: broaden cross-host smoke criteria; add windows-* + verified-* labels

### DIFF
--- a/.claude/skills/commit-and-push/procedures/host-label.md
+++ b/.claude/skills/commit-and-push/procedures/host-label.md
@@ -21,9 +21,10 @@ smoke tag to add lives in
 ```bash
 host_kernel=$(uname -s)
 case "$host_kernel" in
-    Linux)  host_label="fleet:authored-on-linux" ;;
-    Darwin) host_label="fleet:authored-on-macos" ;;
-    *)      host_label="" ;;
+    Linux)                host_label="fleet:authored-on-linux" ;;
+    Darwin)               host_label="fleet:authored-on-macos" ;;
+    MINGW*|MSYS*|CYGWIN*) host_label="fleet:authored-on-windows" ;;
+    *)                    host_label="" ;;
 esac
 if [[ -n "$host_label" ]]; then
     gh pr edit <N> --add-label "$host_label"
@@ -35,8 +36,11 @@ fi
 Applies to **all** PRs (engine and game, render-touching or not). The label is
 cheap and consistent — having it always present makes the reviewer's logic simple
 ("subtract author host from smoke labels"). Game PRs don't currently get smoke
-labels, so the host label is just informational there; that's fine.
+labels in the engine-side flow, but the host label is still informational there;
+that's fine.
 
-If the host kernel is neither `Linux` nor `Darwin` (Windows native via MSYS2,
-etc.), skip the label — the cross-host smoke flow is OpenGL-on-Linux vs
-Metal-on-macOS, and a Windows author doesn't fit either bucket cleanly.
+The cross-host smoke flow now covers Linux (OpenGL), macOS (Metal), and Windows
+(MSYS2 mingw64 / OpenGL) — see the reviewer-side
+[`review-pr/procedures/cross-host-smoke.md`](../../review-pr/procedures/cross-host-smoke.md)
+for the author-host subtraction logic. If the host kernel is none of those, the
+label is skipped — uncommon hosts don't fit the smoke matrix.

--- a/.claude/skills/review-pr/procedures/cross-host-smoke.md
+++ b/.claude/skills/review-pr/procedures/cross-host-smoke.md
@@ -1,10 +1,10 @@
-# Cross-host smoke tagging (render PRs)
+# Cross-host smoke tagging
 
-Procedure for tagging an engine render PR for OpenGL ↔ Metal cross-host validation after the verdict label is set. Fires only when [`SKILL.md`](../SKILL.md) step 5c determines the diff touches render code; non-render PRs skip this entirely.
+Procedure for tagging an engine PR for cross-host (OpenGL ↔ Metal, plus Windows-native build) validation after the verdict label is set. Fires when [`SKILL.md`](../SKILL.md) step 5c determines the diff touches code that can silently break on a host the author didn't build against; otherwise the PR skips this entirely.
 
 ## When this fires
 
-Engine render PRs get built and run on whichever backend the author happened to be using (OpenGL on Linux, or Metal on macOS). The other backend's build + smoke path is not exercised until a fleet agent on that host picks the PR up. The `fleet:needs-<host>-smoke` labels surface that outstanding work so no render PR merges unvalidated on either backend.
+Engine PRs get built and run on whichever host the author happened to be using (OpenGL on Linux, Metal on macOS, or Windows-native via MSYS2). The other hosts' build + smoke paths are not exercised until a fleet agent on that host picks the PR up. The `fleet:needs-<host>-smoke` labels surface that outstanding work so no PR with cross-host risk merges unvalidated on any host.
 
 After setting the verdict label in `SKILL.md` step 5b, check the diff's file paths:
 
@@ -19,41 +19,53 @@ If any path matches **any** of these, the PR needs cross-host smoke:
 - `engine/render/src/shaders/`
 - any `*.glsl` file
 - any `*.metal` file
+- `engine/system/**` — platform-conditional blocks (`#ifdef _WIN32`, `__APPLE__`, etc.) can silently work on one host and break on another
+- any `CMakeLists.txt` and `CMakePresets.json` — build configuration is the most common silent-cross-host failure mode (a flag gcc accepts but clang rejects, a target that exists only on Metal, etc.)
+
+The working principle is "narrow + caught-as-we-go", not "smoke everything that might break." Lua-binding headers (`*_lua.hpp`), `engine/ecs/**`, and other "could theoretically break" categories are deliberately excluded.
 
 If none of these match, return to `SKILL.md` step 6 — no smoke tagging needed.
 
 ## Subtract the author's host before tagging
 
-`commit-and-push` stamps `fleet:authored-on-linux` or `fleet:authored-on-macos` at PR-create time based on the author's `uname -s`. Per [`engine/render/CLAUDE.md`](../../../../engine/render/CLAUDE.md) "Verifying render changes", render-PR authors build + run the demo on their host before opening, so authoring on a host is reasonable evidence its smoke is baseline-validated. Only the OTHER host actually needs cross-host validation.
+`commit-and-push` stamps `fleet:authored-on-linux`, `fleet:authored-on-macos`, or `fleet:authored-on-windows` at PR-create time based on the author's `uname -s`. Per [`engine/render/CLAUDE.md`](../../../../engine/render/CLAUDE.md) "Verifying render changes", render-PR authors build + run the demo on their host before opening, so authoring on a host is reasonable evidence its smoke is baseline-validated. Only the OTHER hosts actually need cross-host validation.
 
-Read the candidate's labels (already in the cache as `repos.engine.prs[].labels`) and add only the smoke label for the host the author was NOT on:
+Read the candidate's labels (already in the cache as `repos.engine.prs[].labels`) and add the smoke labels for the hosts the author was NOT on:
 
-| Author label present | Add smoke label |
+| Author label present | Add smoke labels |
 |---|---|
-| `fleet:authored-on-linux` | `fleet:needs-macos-smoke` only |
-| `fleet:authored-on-macos` | `fleet:needs-linux-smoke` only |
-| Neither (Windows-native author, or pre-fix PR) | Both labels |
+| `fleet:authored-on-linux` | `fleet:needs-macos-smoke`, `fleet:needs-windows-smoke` |
+| `fleet:authored-on-macos` | `fleet:needs-linux-smoke`, `fleet:needs-windows-smoke` |
+| `fleet:authored-on-windows` | `fleet:needs-linux-smoke`, `fleet:needs-macos-smoke` |
+| None (pre-fix PR) | All three labels |
 
 ```bash
-# Linux author  → one call:
+# Linux author:
+gh pr edit <N> --add-label "fleet:needs-macos-smoke"
+gh pr edit <N> --add-label "fleet:needs-windows-smoke"
+
+# macOS author:
+gh pr edit <N> --add-label "fleet:needs-linux-smoke"
+gh pr edit <N> --add-label "fleet:needs-windows-smoke"
+
+# Windows author:
+gh pr edit <N> --add-label "fleet:needs-linux-smoke"
 gh pr edit <N> --add-label "fleet:needs-macos-smoke"
 
-# macOS author  → one call:
-gh pr edit <N> --add-label "fleet:needs-linux-smoke"
-
-# Neither (Windows-native or pre-fix PR) → two calls, one per label
+# None (pre-fix PR) → three calls, one per label
 # (keep them separate so each is independently safe and idempotent):
 gh pr edit <N> --add-label "fleet:needs-linux-smoke"
 gh pr edit <N> --add-label "fleet:needs-macos-smoke"
+gh pr edit <N> --add-label "fleet:needs-windows-smoke"
 ```
 
-Each host's author agents (opus-worker, sonnet-author) poll for the label matching their host, run a clean-checkout build + `IRShapeDebug` smoke, and remove the label on success. While either label persists, the human should hold the merge — that's the whole point of the tally.
+Each host's author agents (opus-worker, sonnet-author) poll for the label matching their host, run a clean-checkout build + `IRShapeDebug` smoke, and remove the label on success. While any smoke label persists, the human should hold the merge — that's the whole point of the tally.
 
 ## Skip the tagging step for
 
-- **Game-repo PRs** — the game's render pipeline uses the engine's backend, so cross-host applies at engine level only.
-- **Non-render engine PRs** (tooling, docs, `.claude/`, non-render modules like `engine/system/`) — these don't exercise backends and don't benefit from cross-host smoke.
+- **Game-repo PRs** — tagged by the game-repo `review-pr` procedure (`creations/game/.claude/skills/review-pr/procedures/cross-host-smoke.md`); the engine-side procedure does not touch them.
+- **Engine PRs that match none of the path filters above** — tooling, docs, `.claude/`-only PRs, etc. don't exercise host-divergent code and don't benefit from cross-host smoke.
 
-If both labels are already present from a prior reviewer pass, no action needed — the `--add-label` call is a no-op when the label is already set.
+If the labels are already present from a prior reviewer pass, no action needed — `--add-label` is a no-op when the label is already set.
 
 After tagging (or skipping), return to `SKILL.md` step 6 to report.

--- a/.claude/skills/review-pr/procedures/cross-host-smoke.md
+++ b/.claude/skills/review-pr/procedures/cross-host-smoke.md
@@ -37,7 +37,7 @@ Read the candidate's labels (already in the cache as `repos.engine.prs[].labels`
 | `fleet:authored-on-linux` | `fleet:needs-macos-smoke`, `fleet:needs-windows-smoke` |
 | `fleet:authored-on-macos` | `fleet:needs-linux-smoke`, `fleet:needs-windows-smoke` |
 | `fleet:authored-on-windows` | `fleet:needs-linux-smoke`, `fleet:needs-macos-smoke` |
-| None (pre-fix PR) | All three labels |
+| None (unrecognized host or pre-fix PR) | All three labels |
 
 ```bash
 # Linux author:

--- a/docs/agents/FLEET-CROSS-HOST-SMOKE.md
+++ b/docs/agents/FLEET-CROSS-HOST-SMOKE.md
@@ -24,8 +24,9 @@ backends live in the engine.
 
 | Label | Owner | Purpose |
 |---|---|---|
-| `fleet:authored-on-linux` / `fleet:authored-on-macos` | `commit-and-push` at PR creation | Records which host the author built + smoked on. Permanent fact, not a state. |
-| `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` | reviewer (after verdict) | Requests a clean-checkout build + `IRShapeDebug` run from an agent on that host. Cleared by the smoking agent on success; flipped to `fleet:needs-fix` on failure. |
+| `fleet:authored-on-linux` / `fleet:authored-on-macos` / `fleet:authored-on-windows` | `commit-and-push` at PR creation | Records which host the author built + smoked on. Permanent fact, not a state. |
+| `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` / `fleet:needs-windows-smoke` | reviewer (after verdict) | Requests a clean-checkout build + `IRShapeDebug` run from an agent on that host. Cleared by the smoking agent (or `platform-catchup` for Windows) on success; flipped to `fleet:needs-fix` on failure. |
+| `fleet:verified-linux` / `fleet:verified-macos` / `fleet:verified-windows` | smoking agent / `platform-catchup` | Set on success to provide a permanent audit trail of which hosts validated the PR. Not used by the merge gate logic; informational. |
 | `fleet:reviewing-<host>-<agent>` | `fleet-claim` script | Atomic lock around the smoke run (same lock the reviewer roles use). Prevents two same-host author agents from racing on the same PR. Released by `fleet-claim review-release`. |
 
 A PR with an outstanding `fleet:needs-<host>-smoke` label is **not safe
@@ -49,12 +50,14 @@ happens at tagging time.
 Tag when **all** of the following hold:
 
 1. The PR is in the engine repo.
-2. The diff touches at least one render path:
+2. The diff touches at least one render-or-platform path:
    - `engine/render/` (any file)
    - `engine/prefabs/irreden/render/` (any file)
    - any `*.glsl` shader
    - any `*.metal` shader
    - any file under `engine/render/src/shaders/`
+   - `engine/system/**` — platform-conditional blocks (`#ifdef _WIN32`, `__APPLE__`, etc.) can silently work on one host and break on another
+   - any `CMakeLists.txt` or `CMakePresets.json` — build configuration is the most common silent cross-host failure mode
 
    Use `gh pr diff <N> --name-only` to read the changed paths.
 
@@ -75,12 +78,28 @@ Subtract the author's host (`commit-and-push` stamped
 `fleet:authored-on-<host>` at PR creation — the author already smoke-
 tested their own host per the workflow):
 
-- PR has `fleet:authored-on-linux` → add `fleet:needs-macos-smoke`
-- PR has `fleet:authored-on-macos` → add `fleet:needs-linux-smoke`
-- Neither label present (Windows-native author, or pre-fix PR) → add **both**
+- PR has `fleet:authored-on-linux` → add `fleet:needs-macos-smoke` + `fleet:needs-windows-smoke`
+- PR has `fleet:authored-on-macos` → add `fleet:needs-linux-smoke` + `fleet:needs-windows-smoke`
+- PR has `fleet:authored-on-windows` → add `fleet:needs-linux-smoke` + `fleet:needs-macos-smoke`
+- None of the above (unrecognized host or pre-fix PR) → add all three
 
 ```
-gh pr edit <N> --add-label "fleet:needs-<other-host>-smoke"
+# Linux author:
+gh pr edit <N> --add-label "fleet:needs-macos-smoke"
+gh pr edit <N> --add-label "fleet:needs-windows-smoke"
+
+# macOS author:
+gh pr edit <N> --add-label "fleet:needs-linux-smoke"
+gh pr edit <N> --add-label "fleet:needs-windows-smoke"
+
+# Windows author:
+gh pr edit <N> --add-label "fleet:needs-linux-smoke"
+gh pr edit <N> --add-label "fleet:needs-macos-smoke"
+
+# None → three calls:
+gh pr edit <N> --add-label "fleet:needs-linux-smoke"
+gh pr edit <N> --add-label "fleet:needs-macos-smoke"
+gh pr edit <N> --add-label "fleet:needs-windows-smoke"
 ```
 
 If `sonnet-reviewer` already added the labels on a first pass, the
@@ -102,6 +121,12 @@ Derive the host key from `uname -s`:
 
 - `Linux` → host key `linux`, poll `fleet:needs-linux-smoke`
 - `Darwin` → host key `macos`, poll `fleet:needs-macos-smoke`
+
+`fleet:needs-windows-smoke` is **not** polled by fleet author agents — it is
+cleared by the `platform-catchup` workflow (#1093) that runs outside the
+normal agent loop. No role currently claims and executes Windows smoke
+automatically; the label is cleared when the platform-catchup run reports a
+clean Windows build.
 
 ### Picking a PR
 
@@ -239,12 +264,19 @@ re-validates on the next iteration.
   invokes the [`render-debug-loop`](../../.claude/skills/render-debug-loop/SKILL.md)
   skill instead of a single-shot smoke run
 
+### Windows smoke
+
+`fleet:needs-windows-smoke` is outside the Sonnet/Opus split above — neither
+agent type polls for it. It is cleared by `platform-catchup` (#1093). If
+the label persists on a PR and platform-catchup has not run recently, surface
+it in the feedback channel.
+
 ### When the split breaks
 
-If a `fleet:needs-<host>-smoke` PR sits with the label for multiple
-iterations without an opus-worker picking it up (sonnet-fleet keeps
-deferring; opus-worker is busy with `[opus]` tasks), the queue is
-underweighted on Opus author capacity for that host. Surface the
+If a `fleet:needs-linux-smoke` or `fleet:needs-macos-smoke` PR sits with the
+label for multiple iterations without an opus-worker picking it up
+(sonnet-fleet keeps deferring; opus-worker is busy with `[opus]` tasks), the
+queue is underweighted on Opus author capacity for that host. Surface the
 backlog in the per-worktree feedback channel (see [`FLEET.md`](FLEET.md)
 § "Fleet feedback channel").
 

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -646,9 +646,10 @@ Specifically, **never pass these via `--label` when filing**:
   it (observed on issues #270-#273, #287).
 - `fleet:approved` / `fleet:needs-fix` / `fleet:has-nits` /
   `fleet:blocker` — owned by the **reviewer agents** as PR verdicts.
-- `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` — owned by the
+- `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` / `fleet:needs-windows-smoke` — owned by the
   **reviewer agents**, added after the verdict to request a cross-host
-  build + run validation.
+  build + run validation. `fleet:needs-windows-smoke` is cleared by
+  `platform-catchup`, not an author agent.
 - `fleet:wip` — owned by the **fleet author worker** while a **claimed /
   in-progress** PR is not ready for fleet review (reviewers **skip** this
   label). Set on claim / early fleet-worker PRs; remove when ready for
@@ -662,13 +663,16 @@ Specifically, **never pass these via `--label` when filing**:
   PR is still idle. The human owns the resolution — the fleet won't
   re-free the TASKS.md row automatically (that would race the worker
   if it ever resumes). Closing the PR is the canonical reap path.
-- `fleet:authored-on-linux` / `fleet:authored-on-macos` — owned by
+- `fleet:authored-on-linux` / `fleet:authored-on-macos` / `fleet:authored-on-windows` — owned by
   the **author's `commit-and-push`** (set at PR creation based on
   `uname -s`). Records which host the PR was opened from so the
   reviewer's cross-host smoke step subtracts the author's host
   (no point asking for a smoke label on the host that just built
   and ran the demo). Permanent label — it's a fact about the PR,
   not a state. Don't add to issues.
+- `fleet:verified-linux` / `fleet:verified-macos` / `fleet:verified-windows` — set by the
+  **smoking agent** (or `platform-catchup` for Windows) on a successful smoke
+  run. Permanent audit trail; not used by the merge gate. Don't add to issues.
 - `fleet:in-progress` — generic "a worker has claimed this issue"
   marker. Today this is mostly superseded by the dynamic per-host
   `fleet:claim-<host>-<agent>` issue label (see below); the static


### PR DESCRIPTION
## Summary

T-327 — broadens when cross-host smoke labels apply, wires Windows
authoring through the same label state machine, and adds the
`fleet:verified-*` labels the upcoming `platform-catchup` skill
(#1093) will set on successful catch-up runs.

Companion work: game-repo twin (`jakildev/irreden#66`) adds the
matching game-side procedure; `platform-catchup` skill (#1093) is the
consumer.

## Changes

- `.claude/skills/review-pr/procedures/cross-host-smoke.md` — path
  filter extended to `engine/system/**`, `CMakeLists.txt`,
  `CMakePresets.json`; subtraction table extended with the
  `fleet:authored-on-windows` row (and the pre-existing rows each
  now add two smoke labels rather than one); game-repo skip premise
  rewritten to point at the new game-side procedure.
- `.claude/skills/commit-and-push/procedures/host-label.md` — the
  `case` matches `MINGW*|MSYS*|CYGWIN*` → stamps
  `fleet:authored-on-windows`; scope note refreshed.
- Labels (created out-of-tree via `gh label`):
  - `fleet:needs-windows-smoke` (FBCA04)
  - `fleet:authored-on-windows` (ededed)
  - `fleet:verified-{linux,macos,windows}` (0E8A16)
  - `fleet:needs-{linux,macos}-smoke` descriptions rewritten to drop
    the "Render PR" framing.

## Out of scope

- Lua-binding header (`*_lua.hpp`) coverage — caught case-by-case.
- ECS core layout-change coverage — caught case-by-case.
- Force-push label invalidation hook — `platform-catchup` removes
  the smoke label on successful pass, which suffices: a force-push
  that lands new code just gets re-verified on the next catch-up
  run, against the new HEAD sha.
- The `platform-catchup` skill itself — #1093.

Closes #1091

## Test plan

- [x] `cross-host-smoke.md` and `host-label.md` re-read end-to-end —
      no dangling references; the table, shell snippet, and skip
      list all describe the three-host matrix consistently.
- [x] `gh label list --repo jakildev/IrredenEngine` shows the five
      new labels with the documented colors + descriptions.
- [ ] First Windows-host PR after merge stamps
      `fleet:authored-on-windows`; reviewer-side procedure picks the
      right two smoke labels per the new table.
- [ ] PR touching `engine/system/audio/<anything>.cpp` or
      `CMakePresets.json` fires the reviewer-side smoke procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)