### PR TITLE
T-318: engine/tools: ir-host-probe + ir-acquire (sub-task 1 of #1074)

### DIFF
--- a/engine/tools/README.md
+++ b/engine/tools/README.md
@@ -1,0 +1,108 @@
+# engine/tools/
+
+Engine-level utilities that the fleet, a solo dev, and CI all use to
+coordinate the same machine: who owns the CPU right now, who owns the
+GPU, who is mid-perf-measurement.
+
+This directory is the new home for tooling that has historically lived
+under `scripts/fleet/` (`fleet-build`, `fleet-run`) but is really an
+engine concern — the fleet is just the noisiest client. Sub-task 2 of
+#1074 migrates those scripts here; this PR (sub-task 1) lands the lock
+primitives and host probe they will sit on top of.
+
+## Status
+
+Sub-task 1 of issue #1074 (T-318). Lands:
+
+- `ir-host-probe` — deterministic hardware fingerprint
+- `ir-acquire` — CPU / GPU / perf lock primitives + `benchmark` canned mode
+- shared library (`lib/concurrency_helpers.sh`) and engine defaults
+  (`concurrency.toml`)
+- `test/tools/concurrency_test.sh` / `test/tools/calibration_test.sh`
+
+Sub-tasks 2–4 (`ir-build` / `ir-run` migration; `ir-perf-grid` +
+fingerprinted baselines; doc-only worker-role updates) are split into
+follow-up issues per the parent issue's "Suggested PR sequence".
+
+## Inventory
+
+| Path | Role |
+|---|---|
+| `bin/ir-host-probe` | Print this host's JSON fingerprint. Cached at `$XDG_CACHE_HOME/irreden/host-fingerprint.json`. |
+| `bin/ir-acquire` | Acquire CPU slots, GPU, perf, or all three (`benchmark`). Releases on command exit. |
+| `lib/concurrency_helpers.sh` | Sourced by `bin/ir-*`. Lock primitives + 3-layer config resolver. |
+| `py/ir_hardware_probe.py` | Python module called by `ir-host-probe`. Linux + macOS. |
+| `concurrency.toml` | Committed engine defaults — first layer of the three-layer config. |
+
+## Three-layer config
+
+Highest specificity wins:
+
+1. **Env vars** — `IR_CPU_BUDGET`, `IR_FLEET_WORKERS`, `IR_BUILD_JOBS`,
+   `IR_GPU_EXCLUSIVE`, `IR_QUEUE_TIMEOUT`.
+2. **Host overrides** at `~/.config/irreden/host.toml` — per-host
+   quirks (thermal-throttling box wants `per_build_max = 6`, etc.).
+3. **Engine defaults** in this directory's `concurrency.toml`.
+
+The values themselves (CPU budget, per-build cap, GPU exclusivity, perf
+target ms) are documented inline in `concurrency.toml`.
+
+## Lock model
+
+Atomic `mkdir`-based locks under `$XDG_RUNTIME_DIR/irreden/locks/` (Linux)
+or `/tmp/irreden-$USER/locks/` (macOS / hosts without `$XDG_RUNTIME_DIR`).
+Three resource types:
+
+- `cpu/slot-{1..budget}/` — N independent slot dirs, one per core in the
+  budget. Acquiring N slots = grabbing N free slot dirs.
+- `gpu/lock/` — single exclusive lock dir.
+- `perf/lock/` — single exclusive lock dir.
+
+Each lock dir contains a `pid` file with the holding process PID. Stale
+locks (holder PID is dead) are reclaimed on the next acquire attempt.
+`ir-acquire --info` runs a passive stale-sweep before printing state.
+
+## Acquire-late, release-early
+
+`ir-acquire` wraps a single command and releases on its exit. Don't keep
+a perf or GPU lock open across "drafting a PR comment" or "deciding what
+to do next" — reclaim per measurement. Letting the wrapping process exit
+is the cleanest way to release.
+
+The `optimize` skill, render demos with `--auto-profile`, and
+`ir-perf-grid` (sub-task 3) all use `ir-acquire benchmark` to take
+`(budget-1)` CPU slots + GPU + perf in one shot for the measurement
+window, then release.
+
+## Examples
+
+```sh
+# Print the host fingerprint.
+ir-host-probe
+ir-host-probe --slug                  # just "linux-x86_64-ryzen-7950x-rtx-4080"
+
+# Show what's currently held.
+ir-acquire --info
+
+# Take 4 CPU slots for a build.
+ir-acquire cpu 4 -- cmake --build build -j4
+
+# Lock the GPU exclusively for a screenshot capture.
+ir-acquire gpu -- ./build/IRShapeDebug --auto-screenshot 10
+
+# Heavy-measurement mode — cpu(budget-1) + gpu + perf, all serialized.
+ir-acquire benchmark -- ./build/IRPerfGrid --auto-profile 300
+
+# Fail fast on contention instead of waiting.
+ir-acquire --nonblock gpu -- ./tool
+```
+
+## Tests
+
+```sh
+test/tools/concurrency_test.sh    # lock primitives, PID-death recovery
+test/tools/calibration_test.sh    # probe JSON + determinism
+```
+
+Both isolate via temp `$XDG_RUNTIME_DIR` / `$XDG_CACHE_HOME` so they
+don't conflict with a live fleet on the same host.

--- a/engine/tools/bin/ir-acquire
+++ b/engine/tools/bin/ir-acquire
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# ir-acquire — engine-level resource coordinator.
+#
+# Acquires CPU slots, GPU exclusivity, and/or perf-measurement exclusivity,
+# then exec()s the wrapped command with those resources held. Locks are
+# released automatically on exit (normal, signal, or process death).
+#
+# Usage:
+#   ir-acquire cpu N -- <cmd...>          # take N CPU slots, run cmd, release
+#   ir-acquire gpu -- <cmd...>            # take the GPU lock, run cmd, release
+#   ir-acquire perf -- <cmd...>           # take the perf lock, run cmd, release
+#   ir-acquire benchmark -- <cmd...>      # take (budget-1) CPU + GPU + perf
+#   ir-acquire --info                     # show what's currently held
+#
+# Flags (before the resource verb):
+#   --nonblock        fail fast if any required lock is contended
+#   --timeout SECS    wait at most SECS for each lock (default 600)
+#
+# Reservation semantics — "acquire-late, release-early":
+#   Hold a lock for the operation that needs it and nothing more. The script
+#   wraps a single command. Don't keep a perf lock open while drafting the
+#   next PR comment; reclaim per measurement. The trap on EXIT makes this
+#   automatic for normal use.
+
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"; done
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+HELPERS="$SCRIPT_DIR/../lib/concurrency_helpers.sh"
+
+if [[ ! -f "$HELPERS" ]]; then
+    echo "ir-acquire: missing $HELPERS" >&2
+    exit 1
+fi
+# shellcheck source=../lib/concurrency_helpers.sh
+source "$HELPERS"
+
+# Release everything we hold on any kind of exit.
+trap 'ir_release_all' EXIT INT TERM HUP
+
+usage() {
+    sed -n '2,28p' "$0"
+}
+
+nonblock=false
+timeout_secs=""
+
+# Pre-verb flags
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --nonblock) nonblock=true; shift ;;
+        --timeout)  timeout_secs="$2"; shift 2 ;;
+        --info)
+            ir_print_lock_state
+            exit 0
+            ;;
+        -h|--help) usage; exit 0 ;;
+        *) break ;;
+    esac
+done
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 2
+fi
+
+verb="$1"
+shift
+
+acquire_args=()
+$nonblock && acquire_args+=(--nonblock)
+[[ -n "$timeout_secs" ]] && acquire_args+=(--timeout "$timeout_secs")
+
+case "$verb" in
+    cpu)
+        if [[ $# -lt 1 || "$1" == "--" ]]; then
+            echo "ir-acquire cpu: need a slot count (e.g. ir-acquire cpu 4 -- make)" >&2
+            exit 2
+        fi
+        count="$1"
+        shift
+        ir_acquire_cpu "$count" "${acquire_args[@]}"
+        ;;
+    gpu)
+        ir_acquire_exclusive lock gpu "${acquire_args[@]}"
+        ;;
+    perf)
+        ir_acquire_exclusive lock perf "${acquire_args[@]}"
+        ;;
+    benchmark)
+        # The canonical heavy-measurement lock. cpu = budget-1 leaves one
+        # core for the OS / shell / responsiveness so a runaway worker
+        # doesn't lock up the whole box. The order matters: take cpu first
+        # (most contended), then gpu, then perf — releases happen in
+        # reverse via the trap.
+        budget="$(ir_cpu_budget)"
+        cpu_take=$(( budget - 1 ))
+        (( cpu_take < 1 )) && cpu_take=1
+        ir_acquire_cpu "$cpu_take" "${acquire_args[@]}"
+        ir_acquire_exclusive lock gpu "${acquire_args[@]}"
+        ir_acquire_exclusive lock perf "${acquire_args[@]}"
+        ;;
+    *)
+        echo "ir-acquire: unknown verb '$verb' (cpu|gpu|perf|benchmark|--info)" >&2
+        exit 2
+        ;;
+esac
+
+# Skip the optional '--' separator if present.
+if [[ $# -gt 0 && "$1" == "--" ]]; then
+    shift
+fi
+
+if [[ $# -lt 1 ]]; then
+    # No command — sleep until SIGINT/SIGTERM. Useful for manual experiments
+    # ("hold the gpu lock for 30s while I run X by hand").
+    echo "ir-acquire: held; ctrl-c or kill -TERM $$ to release" >&2
+    while true; do sleep 60; done
+fi
+
+# Run the command with the locks held; trap releases on exit.
+"$@"

--- a/engine/tools/bin/ir-host-probe
+++ b/engine/tools/bin/ir-host-probe
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# ir-host-probe — emit a deterministic JSON fingerprint of this host.
+#
+# Output is cached at $XDG_CACHE_HOME/irreden/host-fingerprint.json (or
+# ~/.cache/irreden/) and invalidated when the probe-output checksum changes.
+# Re-probe is cheap (~50ms) so the cache exists mostly to give baselines
+# a stable filename until the probe output materially changes.
+#
+# Usage:
+#   ir-host-probe               # print the cached (or fresh) fingerprint
+#   ir-host-probe --refresh     # re-probe and rewrite the cache
+#   ir-host-probe --slug        # print just the slug (used by other ir-* tools)
+
+set -euo pipefail
+
+# --- Resolve our lib via the symlink-aware pattern fleet-build uses. -------
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+    SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+done
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+HELPERS="$SCRIPT_DIR/../lib/concurrency_helpers.sh"
+
+if [[ ! -f "$HELPERS" ]]; then
+    echo "ir-host-probe: missing $HELPERS" >&2
+    exit 1
+fi
+# shellcheck source=../lib/concurrency_helpers.sh
+source "$HELPERS"
+
+PY="$IR_TOOLS_DIR/py/ir_hardware_probe.py"
+CACHE="$IR_CACHE_ROOT/host-fingerprint.json"
+
+mode=full
+refresh=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --refresh) refresh=true ;;
+        --slug)    mode=slug ;;
+        -h|--help)
+            sed -n '2,20p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "ir-host-probe: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if $refresh || [[ ! -f "$CACHE" ]]; then
+    python3 "$PY" > "$CACHE.tmp"
+    mv "$CACHE.tmp" "$CACHE"
+fi
+
+case "$mode" in
+    full)
+        cat "$CACHE"
+        ;;
+    slug)
+        python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["slug"])' "$CACHE"
+        ;;
+esac

--- a/engine/tools/bin/ir-host-probe
+++ b/engine/tools/bin/ir-host-probe
@@ -2,9 +2,9 @@
 # ir-host-probe — emit a deterministic JSON fingerprint of this host.
 #
 # Output is cached at $XDG_CACHE_HOME/irreden/host-fingerprint.json (or
-# ~/.cache/irreden/) and invalidated when the probe-output checksum changes.
+# ~/.cache/irreden/). Valid until --refresh is passed or the file is absent.
 # Re-probe is cheap (~50ms) so the cache exists mostly to give baselines
-# a stable filename until the probe output materially changes.
+# a stable filename across repeated calls.
 #
 # Usage:
 #   ir-host-probe               # print the cached (or fresh) fingerprint

--- a/engine/tools/concurrency.toml
+++ b/engine/tools/concurrency.toml
@@ -1,0 +1,40 @@
+# Engine-level coordination defaults.
+#
+# Three-layer config: this file (engine defaults) → ~/.config/irreden/host.toml
+# (per-host overrides) → environment variables (process-level overrides).
+# Highest specificity wins. See engine/tools/README.md for the full model.
+
+[cpu]
+# auto = nproc / sysctl -n hw.ncpu. Integer overrides the auto value.
+budget = "auto"
+
+# Per ir-build invocation cap. Auto = budget / max(workers, 1) so N parallel
+# fleet workers each get budget/N cores without manual math.
+per_build_max = "auto"
+
+[gpu]
+# auto = true on macOS+Metal (Metal allows only one fullscreen GLFW window
+# cleanly), configurable elsewhere. Linux+OpenGL boxes can usually drive two
+# GLFW contexts, but we keep the default strict and let hosts opt in.
+exclusive = "auto"
+
+[perf]
+# Perf measurements always serialize. This is a correctness invariant, not
+# a tuning knob — concurrent perf runs corrupt each other's numbers.
+exclusive = true
+
+# Target wall-clock for the synthetic-load reference bench. The bench's
+# inner loop count adapts to hit this target on the calibration host.
+ref_bench_target_ms = 50
+
+# After this many days, cached calibration is considered stale and
+# re-runs on next perf invocation.
+calibration_max_age_days = 30
+
+[concurrency]
+# Number of concurrent fleet workers expected on this host. auto = read
+# $IR_FLEET_WORKERS env (set by fleet-up), else default to 1 (solo dev).
+workers = "auto"
+
+# How long ir-acquire blocks before giving up on a contended lock.
+queue_timeout_seconds = 600

--- a/engine/tools/lib/concurrency_helpers.sh
+++ b/engine/tools/lib/concurrency_helpers.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+# engine/tools/lib/concurrency_helpers.sh — shared helpers for ir-* tools.
+#
+# Sourced (not exec'd) by ir-host-probe, ir-acquire, and any future ir-* tool
+# that needs the engine-level coordination primitives. The functions defined
+# here are the only thing those tools should depend on from this library —
+# everything else (paths, defaults) is computed from the three-config-layer
+# resolver below.
+#
+# The lock primitives use atomic mkdir, which works identically on Linux,
+# macOS, and WSL — no flock dependency. Each lock holds a `pid` file so
+# `ir-acquire --info` can attribute waits to the holding process.
+
+set -euo pipefail
+
+# Re-entrancy guard — these tools chain (`ir-acquire benchmark -- ir-run ...`)
+# and would otherwise re-source the helpers on each hop.
+if [[ -n "${_IR_HELPERS_LOADED:-}" ]]; then
+    return 0
+fi
+_IR_HELPERS_LOADED=1
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+# Engine root: walk up from this file. Same approach as scripts/fleet/fleet-common.sh.
+_ir_helpers_resolve_engine_root() {
+    local here
+    here="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+    # bin/ scripts source this from lib/; lib/ is at $engine/engine/tools/lib/.
+    # Walk up to find the marker file CMakeLists.txt at engine root.
+    while [[ "$here" != "/" ]]; do
+        if [[ -f "$here/CMakePresets.json" && -d "$here/engine" ]]; then
+            echo "$here"
+            return 0
+        fi
+        here="$(dirname "$here")"
+    done
+    echo "ir-tools: cannot resolve engine root from $(dirname "${BASH_SOURCE[1]}")" >&2
+    return 1
+}
+
+IR_ENGINE_ROOT="$(_ir_helpers_resolve_engine_root)"
+IR_TOOLS_DIR="$IR_ENGINE_ROOT/engine/tools"
+IR_DEFAULTS_TOML="$IR_TOOLS_DIR/concurrency.toml"
+IR_HOST_TOML="${IR_HOST_TOML:-$HOME/.config/irreden/host.toml}"
+
+# Lock dir lives in a runtime-temp location so it survives across shells but
+# clears on reboot. XDG_RUNTIME_DIR is Linux-only; macOS doesn't set it.
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    IR_LOCK_ROOT="${XDG_RUNTIME_DIR}/irreden/locks"
+else
+    IR_LOCK_ROOT="/tmp/irreden-${USER:-$(id -un)}/locks"
+fi
+IR_CACHE_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/irreden"
+
+mkdir -p "$IR_LOCK_ROOT/cpu" "$IR_LOCK_ROOT/gpu" "$IR_LOCK_ROOT/perf" "$IR_CACHE_ROOT"
+
+# ---------------------------------------------------------------------------
+# Tiny TOML reader (handles only the subset this repo's tomls use:
+# `[section]` headers, `key = value` lines, # comments, quoted-string and
+# bare-token values). Adequate for concurrency.toml and host.toml.
+#
+# Usage: _ir_read_toml <file> <section> <key>
+# ---------------------------------------------------------------------------
+
+_ir_read_toml() {
+    local file="$1" section="$2" key="$3"
+    [[ -f "$file" ]] || return 1
+    awk -v want_sec="$section" -v want_key="$key" '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*\[/ {
+            gsub(/[][[:space:]]/, "", $0)
+            cur_sec = $0
+            next
+        }
+        /=/ {
+            if (cur_sec != want_sec) next
+            split($0, parts, "=")
+            k = parts[1]
+            gsub(/[[:space:]]/, "", k)
+            if (k != want_key) next
+            v = substr($0, index($0, "=") + 1)
+            sub(/#.*$/, "", v)            # strip trailing comment
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+            gsub(/^"|"$/, "", v)
+            print v
+            exit
+        }
+    ' "$file"
+}
+
+# Three-layer config: env var → host toml → defaults toml.
+# Usage: _ir_config <section> <key> <env-var-name>
+_ir_config() {
+    local section="$1" key="$2" env_name="$3"
+    local env_val
+    if [[ -n "${env_name:-}" ]]; then
+        eval "env_val=\${$env_name:-}"
+        if [[ -n "${env_val:-}" ]]; then
+            echo "$env_val"
+            return 0
+        fi
+    fi
+    local host_val
+    host_val="$(_ir_read_toml "$IR_HOST_TOML" "$section" "$key" 2>/dev/null || true)"
+    if [[ -n "${host_val:-}" ]]; then
+        echo "$host_val"
+        return 0
+    fi
+    _ir_read_toml "$IR_DEFAULTS_TOML" "$section" "$key"
+}
+
+# ---------------------------------------------------------------------------
+# Budget resolvers
+# ---------------------------------------------------------------------------
+
+ir_cpu_count() {
+    if command -v nproc >/dev/null 2>&1; then
+        nproc
+    elif command -v sysctl >/dev/null 2>&1; then
+        sysctl -n hw.ncpu
+    else
+        echo 4
+    fi
+}
+
+ir_cpu_budget() {
+    local v
+    v="$(_ir_config cpu budget IR_CPU_BUDGET)"
+    if [[ "$v" == "auto" ]]; then
+        ir_cpu_count
+    else
+        echo "$v"
+    fi
+}
+
+ir_workers() {
+    local v
+    v="$(_ir_config concurrency workers IR_FLEET_WORKERS)"
+    if [[ "$v" == "auto" || -z "$v" ]]; then
+        echo 1
+    else
+        echo "$v"
+    fi
+}
+
+ir_per_build_max() {
+    local v
+    v="$(_ir_config cpu per_build_max IR_BUILD_JOBS)"
+    if [[ "$v" == "auto" || -z "$v" ]]; then
+        local budget workers
+        budget="$(ir_cpu_budget)"
+        workers="$(ir_workers)"
+        # ceiling division; minimum 1 core per build
+        local cap=$(( budget / workers ))
+        (( cap < 1 )) && cap=1
+        echo "$cap"
+    else
+        echo "$v"
+    fi
+}
+
+ir_gpu_exclusive() {
+    local v
+    v="$(_ir_config gpu exclusive IR_GPU_EXCLUSIVE)"
+    if [[ "$v" == "auto" || -z "$v" ]]; then
+        case "$(uname -s)" in
+            Darwin) echo true ;;
+            *)      echo false ;;
+        esac
+    else
+        echo "$v"
+    fi
+}
+
+ir_perf_exclusive() {
+    # Always true; the toml key exists for documentation but isn't a knob.
+    echo true
+}
+
+ir_queue_timeout() {
+    local v
+    v="$(_ir_config concurrency queue_timeout_seconds IR_QUEUE_TIMEOUT)"
+    [[ -z "$v" ]] && v=600
+    echo "$v"
+}
+
+# ---------------------------------------------------------------------------
+# Lock primitives — atomic mkdir, PID-death recovery
+# ---------------------------------------------------------------------------
+#
+# A "lock" is a directory under $IR_LOCK_ROOT/{cpu,gpu,perf}/. mkdir is the
+# atomic operation: only one caller can create a given dir, the rest see
+# EEXIST. After creating it we write our PID into the dir; on acquire
+# contention, we re-check and reclaim if the holder PID is gone.
+#
+# Held resources are tracked in a per-process list at
+# $IR_LOCK_ROOT/.held/$pid/ — the trap in ir-acquire walks it on exit.
+
+_ir_pid_alive() {
+    local pid="$1"
+    [[ -n "$pid" ]] || return 1
+    kill -0 "$pid" 2>/dev/null
+}
+
+_ir_lock_holder() {
+    local lockdir="$1"
+    [[ -f "$lockdir/pid" ]] || return 1
+    cat "$lockdir/pid" 2>/dev/null
+}
+
+# Try to create a lock dir. If it exists, check whether the holder is dead;
+# if so, reclaim. Returns 0 on success, 1 if the lock is held by a live PID.
+_ir_try_lock() {
+    local lockdir="$1"
+    if mkdir "$lockdir" 2>/dev/null; then
+        echo "$$" > "$lockdir/pid"
+        date +%s > "$lockdir/acquired_at"
+        return 0
+    fi
+    local holder
+    holder="$(_ir_lock_holder "$lockdir" || echo "")"
+    if [[ -n "$holder" ]] && _ir_pid_alive "$holder"; then
+        return 1
+    fi
+    # Stale — reclaim. Use rm -rf to nuke any pid/acquired_at files left by
+    # the dead holder, then re-create atomically. The re-create may still
+    # lose to a concurrent reclaimer; that's correct (the other wins).
+    rm -rf "$lockdir" 2>/dev/null || true
+    if mkdir "$lockdir" 2>/dev/null; then
+        echo "$$" > "$lockdir/pid"
+        date +%s > "$lockdir/acquired_at"
+        return 0
+    fi
+    return 1
+}
+
+# Acquire a single named exclusive lock. Blocks until available or timeout.
+# Usage: ir_acquire_exclusive <name> <subdir> [--nonblock] [--timeout SECS]
+ir_acquire_exclusive() {
+    local name="$1" subdir="$2"
+    shift 2
+    local nonblock=false
+    local timeout
+    timeout="$(ir_queue_timeout)"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --nonblock) nonblock=true ;;
+            --timeout)  timeout="$2"; shift ;;
+        esac
+        shift
+    done
+    local lockdir="$IR_LOCK_ROOT/$subdir/$name"
+    local started
+    started="$(date +%s)"
+    while true; do
+        if _ir_try_lock "$lockdir"; then
+            _ir_record_held "$lockdir"
+            return 0
+        fi
+        if $nonblock; then
+            return 1
+        fi
+        local now elapsed
+        now="$(date +%s)"
+        elapsed=$(( now - started ))
+        if (( elapsed >= timeout )); then
+            echo "ir-acquire: timeout waiting for lock $name ($subdir, ${timeout}s)" >&2
+            return 1
+        fi
+        sleep 0.2
+    done
+}
+
+# Acquire N CPU slot locks out of the configured budget. Slots are
+# represented as slot-N dirs; we walk 1..budget and grab the first N free
+# ones. Slot identity is meaningless — only the count matters.
+# Usage: ir_acquire_cpu <count> [--nonblock] [--timeout SECS]
+ir_acquire_cpu() {
+    local want="$1"
+    shift
+    local nonblock=false
+    local timeout
+    timeout="$(ir_queue_timeout)"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --nonblock) nonblock=true ;;
+            --timeout)  timeout="$2"; shift ;;
+        esac
+        shift
+    done
+    local budget
+    budget="$(ir_cpu_budget)"
+    if (( want > budget )); then
+        echo "ir-acquire: requested $want CPU slots > budget $budget; capping" >&2
+        want=$budget
+    fi
+    local started
+    started="$(date +%s)"
+    local got=()
+    while true; do
+        local i
+        for (( i=1; i<=budget; i++ )); do
+            (( ${#got[@]} >= want )) && break
+            local slot="$IR_LOCK_ROOT/cpu/slot-$i"
+            if _ir_try_lock "$slot"; then
+                got+=("$slot")
+                _ir_record_held "$slot"
+            fi
+        done
+        if (( ${#got[@]} >= want )); then
+            return 0
+        fi
+        # Couldn't get enough — release the partials and either retry or fail.
+        for slot in "${got[@]}"; do
+            _ir_release_one "$slot"
+        done
+        got=()
+        if $nonblock; then
+            return 1
+        fi
+        local now elapsed
+        now="$(date +%s)"
+        elapsed=$(( now - started ))
+        if (( elapsed >= timeout )); then
+            echo "ir-acquire: timeout waiting for $want CPU slots (${timeout}s)" >&2
+            return 1
+        fi
+        sleep 0.2
+    done
+}
+
+_ir_record_held() {
+    local lockdir="$1"
+    mkdir -p "$IR_LOCK_ROOT/.held/$$" 2>/dev/null || true
+    # Use the basename plus the parent dir name so we can reconstruct the
+    # full path on release (cpu/slot-3, gpu/lock, etc.).
+    local rel="${lockdir#$IR_LOCK_ROOT/}"
+    local safe
+    safe="${rel//\//__}"
+    : > "$IR_LOCK_ROOT/.held/$$/$safe"
+}
+
+_ir_release_one() {
+    local lockdir="$1"
+    # Only release if we hold it (defensive against double-release).
+    local holder
+    holder="$(_ir_lock_holder "$lockdir" || echo "")"
+    if [[ "$holder" == "$$" ]]; then
+        rm -rf "$lockdir" 2>/dev/null || true
+    fi
+    local rel="${lockdir#$IR_LOCK_ROOT/}"
+    local safe="${rel//\//__}"
+    rm -f "$IR_LOCK_ROOT/.held/$$/$safe" 2>/dev/null || true
+}
+
+# Release every lock held by this process. Trap target.
+ir_release_all() {
+    local heldroot="$IR_LOCK_ROOT/.held/$$"
+    [[ -d "$heldroot" ]] || return 0
+    local f
+    for f in "$heldroot"/*; do
+        [[ -e "$f" ]] || continue
+        local safe
+        safe="$(basename "$f")"
+        local rel="${safe//__/\/}"
+        _ir_release_one "$IR_LOCK_ROOT/$rel"
+    done
+    rmdir "$heldroot" 2>/dev/null || true
+}
+
+# Sweep dead holders' locks. Cheap enough to run on every ir-acquire --info
+# call; deliberate (no separate gc daemon).
+ir_sweep_stale() {
+    local heldroot="$IR_LOCK_ROOT/.held"
+    [[ -d "$heldroot" ]] || return 0
+    local pdir
+    for pdir in "$heldroot"/*; do
+        [[ -d "$pdir" ]] || continue
+        local pid
+        pid="$(basename "$pdir")"
+        if ! _ir_pid_alive "$pid"; then
+            local f
+            for f in "$pdir"/*; do
+                [[ -e "$f" ]] || continue
+                local safe rel lockdir
+                safe="$(basename "$f")"
+                rel="${safe//__/\/}"
+                lockdir="$IR_LOCK_ROOT/$rel"
+                # Only nuke if the lock still attributes to the dead holder.
+                local holder
+                holder="$(_ir_lock_holder "$lockdir" || echo "")"
+                if [[ "$holder" == "$pid" ]]; then
+                    rm -rf "$lockdir" 2>/dev/null || true
+                fi
+            done
+            rm -rf "$pdir" 2>/dev/null || true
+        fi
+    done
+}
+
+# Print human-readable lock state. Used by ir-acquire --info.
+ir_print_lock_state() {
+    ir_sweep_stale
+    local budget
+    budget="$(ir_cpu_budget)"
+    local in_use=0
+    local i
+    local cpu_holders=()
+    for (( i=1; i<=budget; i++ )); do
+        local slot="$IR_LOCK_ROOT/cpu/slot-$i"
+        if [[ -d "$slot" ]]; then
+            local h
+            h="$(_ir_lock_holder "$slot" || echo "?")"
+            cpu_holders+=("$h")
+            in_use=$(( in_use + 1 ))
+        fi
+    done
+    local gpu_holder=""
+    [[ -d "$IR_LOCK_ROOT/gpu/lock" ]] && gpu_holder="$(_ir_lock_holder "$IR_LOCK_ROOT/gpu/lock" || echo "?")"
+    local perf_holder=""
+    [[ -d "$IR_LOCK_ROOT/perf/lock" ]] && perf_holder="$(_ir_lock_holder "$IR_LOCK_ROOT/perf/lock" || echo "?")"
+
+    echo "cpu budget: $budget ($in_use in use, $(( budget - in_use )) free)"
+    if (( ${#cpu_holders[@]} > 0 )); then
+        local uniq
+        uniq="$(printf '%s\n' "${cpu_holders[@]}" | sort -u | tr '\n' ' ' | sed 's/ $//')"
+        echo "  cpu holders (pids): $uniq"
+    fi
+    if [[ -n "$gpu_holder" ]]; then
+        echo "gpu lock: held by pid $gpu_holder"
+    else
+        echo "gpu lock: free"
+    fi
+    if [[ -n "$perf_holder" ]]; then
+        echo "perf lock: held by pid $perf_holder"
+    else
+        echo "perf lock: free"
+    fi
+}

--- a/engine/tools/lib/concurrency_helpers.sh
+++ b/engine/tools/lib/concurrency_helpers.sh
@@ -97,7 +97,7 @@ _ir_config() {
     local section="$1" key="$2" env_name="$3"
     local env_val
     if [[ -n "${env_name:-}" ]]; then
-        eval "env_val=\${$env_name:-}"
+        env_val="${!env_name:-}"
         if [[ -n "${env_val:-}" ]]; then
             echo "$env_val"
             return 0
@@ -153,7 +153,7 @@ ir_per_build_max() {
         local budget workers
         budget="$(ir_cpu_budget)"
         workers="$(ir_workers)"
-        # ceiling division; minimum 1 core per build
+        # floor (integer) division; minimum 1 core per build
         local cap=$(( budget / workers ))
         (( cap < 1 )) && cap=1
         echo "$cap"
@@ -337,6 +337,7 @@ _ir_record_held() {
     mkdir -p "$IR_LOCK_ROOT/.held/$$" 2>/dev/null || true
     # Use the basename plus the parent dir name so we can reconstruct the
     # full path on release (cpu/slot-3, gpu/lock, etc.).
+    # Path encoding: '/' → '__'; resource paths must not contain '__'.
     local rel="${lockdir#$IR_LOCK_ROOT/}"
     local safe
     safe="${rel//\//__}"

--- a/engine/tools/py/ir_hardware_probe.py
+++ b/engine/tools/py/ir_hardware_probe.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Detect the host's CPU, GPU, OS, and RAM; emit a deterministic JSON
+fingerprint plus a short slug.
+
+Output schema (stable — `host.json` sidecars in docs/perf/baseline_latest/
+read these keys directly):
+
+    {
+      "slug": "linux-x86_64-ryzen-7950x-rtx-4080",
+      "cpu":  {"model": "...", "cores": 16, "threads": 32, "mhz": 4500},
+      "gpu":  {"model": "..."},
+      "os":   {"kernel": "Linux 6.5.0", "distro": "Ubuntu 24.04"},
+      "ram":  {"gb": 64}
+    }
+
+Determinism: the JSON content for a given machine must not change between
+invocations (no timestamps, no uptime-derived values, no random ordering).
+"""
+
+import json
+import platform
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(*args, default=""):
+    try:
+        out = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        return out.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return default
+
+
+def _cpu_linux():
+    info = {"model": "unknown", "cores": 0, "threads": 0, "mhz": 0}
+    try:
+        text = Path("/proc/cpuinfo").read_text()
+    except (FileNotFoundError, PermissionError):
+        return info
+    model_match = re.search(r"^model name\s*:\s*(.+)$", text, re.MULTILINE)
+    if model_match:
+        info["model"] = model_match.group(1).strip()
+    info["threads"] = len(re.findall(r"^processor\s*:", text, re.MULTILINE))
+    core_match = re.search(r"^cpu cores\s*:\s*(\d+)", text, re.MULTILINE)
+    if core_match:
+        info["cores"] = int(core_match.group(1))
+    mhz_match = re.search(r"^cpu MHz\s*:\s*([\d.]+)", text, re.MULTILINE)
+    if mhz_match:
+        info["mhz"] = int(float(mhz_match.group(1)))
+    return info
+
+
+def _cpu_macos():
+    info = {"model": "unknown", "cores": 0, "threads": 0, "mhz": 0}
+    model = _run("sysctl", "-n", "machdep.cpu.brand_string")
+    if model:
+        info["model"] = model
+    cores = _run("sysctl", "-n", "hw.physicalcpu")
+    threads = _run("sysctl", "-n", "hw.logicalcpu")
+    freq = _run("sysctl", "-n", "hw.cpufrequency_max")
+    if cores.isdigit():
+        info["cores"] = int(cores)
+    if threads.isdigit():
+        info["threads"] = int(threads)
+    if freq.isdigit():
+        info["mhz"] = int(freq) // 1_000_000
+    return info
+
+
+def _gpu_linux():
+    out = _run("lspci", "-nn")
+    if not out:
+        return {"model": "unknown"}
+    # Apple-style: first VGA / 3D / Display line is the primary GPU.
+    for line in out.splitlines():
+        if re.search(r"(VGA compatible controller|3D controller|Display controller)",
+                     line):
+            # Strip the leading bus address and the trailing [vendor:device] tag.
+            tail = line.split(":", 1)[-1].strip()
+            tail = re.sub(r"\s*\[[0-9a-fA-F:]+\]\s*$", "", tail)
+            return {"model": tail}
+    return {"model": "unknown"}
+
+
+def _gpu_macos():
+    out = _run("system_profiler", "SPDisplaysDataType")
+    if not out:
+        return {"model": "unknown"}
+    # Chipset Model: ...
+    match = re.search(r"Chipset Model:\s*(.+)$", out, re.MULTILINE)
+    if match:
+        return {"model": match.group(1).strip()}
+    return {"model": "unknown"}
+
+
+def _ram_linux():
+    try:
+        text = Path("/proc/meminfo").read_text()
+    except (FileNotFoundError, PermissionError):
+        return {"gb": 0}
+    match = re.search(r"^MemTotal:\s+(\d+)\s+kB", text, re.MULTILINE)
+    if not match:
+        return {"gb": 0}
+    return {"gb": int(match.group(1)) // (1024 * 1024)}
+
+
+def _ram_macos():
+    bytes_str = _run("sysctl", "-n", "hw.memsize")
+    if not bytes_str.isdigit():
+        return {"gb": 0}
+    return {"gb": int(bytes_str) // (1024 ** 3)}
+
+
+def _os_info():
+    kernel = f"{platform.system()} {platform.release()}"
+    distro = ""
+    if platform.system() == "Linux":
+        # /etc/os-release is the canonical Linux source; fall back to uname.
+        try:
+            for line in Path("/etc/os-release").read_text().splitlines():
+                if line.startswith("PRETTY_NAME="):
+                    distro = line.split("=", 1)[1].strip().strip('"')
+                    break
+        except (FileNotFoundError, PermissionError):
+            pass
+    elif platform.system() == "Darwin":
+        version = _run("sw_vers", "-productVersion")
+        if version:
+            distro = f"macOS {version}"
+    return {"kernel": kernel, "distro": distro}
+
+
+def _slug(probe):
+    parts = [
+        platform.system().lower(),
+        platform.machine().lower(),
+        # Drop vendor noise and shorten — "AMD Ryzen 9 7950X 16-Core" → "ryzen-9-7950x".
+        _slugify(probe["cpu"]["model"]),
+        _slugify(probe["gpu"]["model"]),
+    ]
+    # Filter empty pieces so the slug doesn't end up with double dashes.
+    return "-".join(p for p in parts if p)
+
+
+def _slugify(s):
+    if not s or s == "unknown":
+        return "unknown"
+    # Aggressive normalization: lowercase, strip common vendor tokens,
+    # collapse runs of non-alphanumerics to single dashes.
+    s = s.lower()
+    s = re.sub(r"\b(amd|intel|nvidia|apple|corporation|inc|ltd|co|with radeon graphics)\b",
+               "", s)
+    s = re.sub(r"\(r\)|\(tm\)", "", s)
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    # Keep the first 3 hyphen-separated chunks — enough for identity, short
+    # enough for filenames.
+    chunks = s.split("-")[:3]
+    return "-".join(chunks)
+
+
+def probe():
+    system = platform.system()
+    if system == "Linux":
+        cpu, gpu, ram = _cpu_linux(), _gpu_linux(), _ram_linux()
+    elif system == "Darwin":
+        cpu, gpu, ram = _cpu_macos(), _gpu_macos(), _ram_macos()
+    else:
+        cpu = {"model": "unknown", "cores": 0, "threads": 0, "mhz": 0}
+        gpu = {"model": "unknown"}
+        ram = {"gb": 0}
+    result = {
+        "cpu": cpu,
+        "gpu": gpu,
+        "os": _os_info(),
+        "ram": ram,
+    }
+    result["slug"] = _slug(result)
+    return result
+
+
+def main():
+    print(json.dumps(probe(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -327,6 +327,22 @@ if [[ -f "$WITNESS_SRC" ]]; then
     echo "symlinked $WITNESS_DEST -> $WITNESS_SRC"
 fi
 
+# Engine-level ir-* tools (T-318 sub-task 1). These live under
+# engine/tools/bin/ — they're not fleet-specific, but they share the
+# install pattern. Symlink whichever ones are present in this checkout
+# so the next sub-tasks (ir-build / ir-run migration, ir-perf-grid) can
+# add themselves to this loop with a one-line append.
+IR_TOOLS_BIN="$REPO_ROOT/engine/tools/bin"
+if [[ -d "$IR_TOOLS_BIN" ]]; then
+    for ir_src in "$IR_TOOLS_BIN"/ir-*; do
+        [[ -f "$ir_src" ]] || continue
+        [[ -x "$ir_src" ]] || chmod +x "$ir_src"
+        ir_dest="$HOME/bin/$(basename "$ir_src")"
+        ln -sf "$ir_src" "$ir_dest"
+        echo "symlinked $ir_dest -> $ir_src"
+    done
+fi
+
 # Bash programmable completion (fleet-run / fleet-build). Loaded by the
 # bash-completion package from XDG path on many Linux setups and
 # Homebrew bash-completion@2 on macOS.

--- a/test/tools/calibration_test.sh
+++ b/test/tools/calibration_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# calibration_test.sh — sanity-check ir-host-probe.
+#
+# Two requirements: parseable JSON, deterministic across consecutive calls.
+# The actual host values aren't asserted — they vary per machine.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IR_PROBE="$REPO_ROOT/engine/tools/bin/ir-host-probe"
+
+# Isolate the cache so we don't trample a real fingerprint sidecar.
+export XDG_CACHE_HOME
+XDG_CACHE_HOME="$(mktemp -d)"
+trap 'rm -rf "$XDG_CACHE_HOME"' EXIT
+
+pass=0
+fail=0
+check() {
+    local label="$1" cond="$2"
+    if eval "$cond"; then
+        echo "  PASS: $label"
+        pass=$(( pass + 1 ))
+    else
+        echo "  FAIL: $label"
+        fail=$(( fail + 1 ))
+    fi
+}
+
+echo "[1] probe emits valid JSON"
+out1="$("$IR_PROBE" --refresh)"
+check "valid JSON" 'python3 -c "import json, sys; json.loads(sys.argv[1])" "$out1"'
+
+echo "[2] required keys present"
+check "has slug"         '[[ -n "$(echo "$out1" | python3 -c "import json,sys; print(json.load(sys.stdin)[\"slug\"])")" ]]'
+check "has cpu.model"    '[[ -n "$(echo "$out1" | python3 -c "import json,sys; print(json.load(sys.stdin)[\"cpu\"][\"model\"])")" ]]'
+check "has gpu.model"    '[[ -n "$(echo "$out1" | python3 -c "import json,sys; print(json.load(sys.stdin)[\"gpu\"][\"model\"])")" ]]'
+check "has os.kernel"    '[[ -n "$(echo "$out1" | python3 -c "import json,sys; print(json.load(sys.stdin)[\"os\"][\"kernel\"])")" ]]'
+
+echo "[3] determinism across consecutive refresh calls"
+out2="$("$IR_PROBE" --refresh)"
+check "two consecutive refreshes match" '[[ "$out1" == "$out2" ]]'
+
+echo "[4] --slug returns just the slug"
+slug="$("$IR_PROBE" --slug)"
+expected_slug="$(echo "$out1" | python3 -c "import json,sys; print(json.load(sys.stdin)['slug'])")"
+check "--slug matches the JSON 'slug' field" '[[ "$slug" == "$expected_slug" ]]'
+
+echo
+echo "calibration_test.sh: $pass passed, $fail failed"
+exit "$fail"

--- a/test/tools/concurrency_test.sh
+++ b/test/tools/concurrency_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# concurrency_test.sh — deterministic lock + budget tests for ir-acquire.
+#
+# Runs against the live ir-acquire binary in engine/tools/bin/. Uses an
+# isolated lock dir so the test doesn't trample a real fleet run on the
+# same host. No GPU needed — pure shell behavior.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IR_ACQUIRE="$REPO_ROOT/engine/tools/bin/ir-acquire"
+
+# Isolate the test from any concurrent ir-* invocation on the box.
+export XDG_RUNTIME_DIR
+XDG_RUNTIME_DIR="$(mktemp -d)"
+export IR_CPU_BUDGET=4   # small budget so contention is reachable
+
+cleanup() {
+    rm -rf "$XDG_RUNTIME_DIR"
+}
+trap cleanup EXIT
+
+pass=0
+fail=0
+check() {
+    local label="$1" expect="$2" actual="$3"
+    if [[ "$expect" == "$actual" ]]; then
+        echo "  PASS: $label"
+        pass=$(( pass + 1 ))
+    else
+        echo "  FAIL: $label (expected '$expect', got '$actual')"
+        fail=$(( fail + 1 ))
+    fi
+}
+
+echo "[1] free budget reports correctly"
+out="$("$IR_ACQUIRE" --info | awk '/cpu budget:/ {print $4}')"
+check "0 slots in use at start" "(0" "$out"
+
+echo "[2] cpu lock acquires + holds during wrapped command"
+"$IR_ACQUIRE" cpu 2 -- bash -c '
+    in_use="$('"$IR_ACQUIRE"' --info | awk "/cpu budget:/ {print \$4}")"
+    if [[ "$in_use" == "(2" ]]; then exit 0; else exit 42; fi
+'
+check "2 cpu slots seen as in-use during wrap" "0" "$?"
+
+echo "[3] cpu lock releases on EXIT"
+in_use_after="$("$IR_ACQUIRE" --info | awk '/cpu budget:/ {print $4}')"
+check "0 cpu slots after wrap exit" "(0" "$in_use_after"
+
+echo "[4] cpu lock contention with --nonblock fails fast"
+"$IR_ACQUIRE" cpu 3 -- bash -c '
+    if '"$IR_ACQUIRE"' --nonblock cpu 2 -- true 2>/dev/null; then
+        exit 1
+    else
+        exit 0
+    fi
+'
+check "second 2-slot acquire blocked when only 1 free" "0" "$?"
+
+echo "[5] gpu lock is exclusive"
+"$IR_ACQUIRE" gpu -- bash -c '
+    if '"$IR_ACQUIRE"' --nonblock gpu -- true 2>/dev/null; then
+        exit 1
+    else
+        exit 0
+    fi
+'
+check "second gpu acquire blocked under first" "0" "$?"
+
+echo "[6] perf lock is exclusive"
+"$IR_ACQUIRE" perf -- bash -c '
+    if '"$IR_ACQUIRE"' --nonblock perf -- true 2>/dev/null; then
+        exit 1
+    else
+        exit 0
+    fi
+'
+check "second perf acquire blocked under first" "0" "$?"
+
+echo "[7] benchmark mode acquires cpu(budget-1) + gpu + perf"
+"$IR_ACQUIRE" benchmark -- bash -c '
+    state="$('"$IR_ACQUIRE"' --info)"
+    grep -q "cpu budget: 4 (3 in use, 1 free)" <<< "$state" || exit 11
+    grep -q "gpu lock: held" <<< "$state" || exit 12
+    grep -q "perf lock: held" <<< "$state" || exit 13
+'
+check "benchmark mode holds cpu(budget-1)+gpu+perf" "0" "$?"
+
+echo "[8] PID-death recovery — kill a holder mid-flight, ensure stale-cleanup"
+(
+    "$IR_ACQUIRE" gpu -- bash -c 'sleep 30' &
+    holder_pid=$!
+    sleep 0.5
+    # Kill the holder; the trap WON'T run because SIGKILL bypasses it.
+    kill -KILL "$holder_pid" 2>/dev/null || true
+    wait "$holder_pid" 2>/dev/null || true
+    # The next acquire should detect the dead PID and reclaim.
+    if "$IR_ACQUIRE" --nonblock gpu -- true 2>/dev/null; then
+        exit 0
+    else
+        exit 1
+    fi
+)
+check "reclaim after SIGKILL'd holder" "0" "$?"
+
+echo
+echo "concurrency_test.sh: $pass passed, $fail failed"
+exit "$fail"


### PR DESCRIPTION
## Summary

Lands sub-task 1 of #1074 (T-318 in TASKS.md) — the lock primitives and host probe that the rest of the engine-level tooling split sits on top of. Pure new tooling under `engine/tools/`; no behavioral change to existing `fleet-build` / `fleet-run` callers.

- `engine/tools/bin/ir-host-probe` — deterministic JSON fingerprint (CPU / GPU / OS / RAM + slug). Linux + macOS. Cached at `$XDG_CACHE_HOME/irreden/host-fingerprint.json`.
- `engine/tools/bin/ir-acquire` — CPU-slot / GPU / perf locks built on atomic mkdir under `$XDG_RUNTIME_DIR` (Linux) or `/tmp/irreden-$USER` (macOS). `benchmark` canned mode acquires `(budget-1)` CPU + GPU + perf in one shot. Trap on EXIT/INT/TERM/HUP releases; dead holders reclaimed on next contended acquire.
- `engine/tools/lib/concurrency_helpers.sh` — shared lock + 3-layer config resolver (env → `~/.config/irreden/host.toml` → `engine/tools/concurrency.toml`).
- `engine/tools/concurrency.toml` — committed engine defaults.
- `engine/tools/py/ir_hardware_probe.py` — Linux + macOS hardware detection.
- `scripts/fleet/install.sh` — symlinks `engine/tools/bin/ir-*` into `~/bin` alongside the existing fleet-* tools.

## Scope split

Per the parent issue's "Suggested PR sequence", #1074 lands as four PRs. This is sub-task 1. The other three are filed as no-label follow-ups (human stamps `human:approved` to admit them to the queue):

- #1099 — sub-task 2: `ir-build` / `ir-run` migration; wires `ir-acquire` into build / run / screenshot / profile callers. Sonnet / Opus borderline.
- #1100 — sub-task 3: `ir-perf-grid` + hardware-fingerprinted baselines + synthetic-load normalization. Opus.
- #1101 — sub-task 4: doc-only rollout of the acquire-late, release-early rule into worker-role docs. Sonnet.

## Test plan

- [x] `test/tools/concurrency_test.sh` — 8/8 pass (slot accounting, exclusivity, --nonblock contention, benchmark composition, PID-death recovery)
- [x] `test/tools/calibration_test.sh` — 7/7 pass (probe JSON validity, key presence, two-call determinism, --slug isolation)
- [x] `fleet-build --target IRShapeDebug` clean on macos-debug
- [x] `ir-host-probe` + `ir-acquire --info` smoke runs by hand
- [x] `ir-acquire benchmark` + nested `--nonblock gpu` correctly reports contention
- [ ] Linux smoke: `fleet-build --target IRShapeDebug` + `test/tools/concurrency_test.sh` + `test/tools/calibration_test.sh`

Refs #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)