### PR TITLE
T-328: system: complete T-222 POC ports + SystemAccess tag-shadow fix

### DIFF
--- a/engine/job/src/ir_job.cpp
+++ b/engine/job/src/ir_job.cpp
@@ -18,7 +18,6 @@ namespace detail {
 void registerSelf(enki::TaskScheduler &scheduler);
 
 extern thread_local int t_workerId;
-extern thread_local std::mt19937 t_workerRng;
 extern thread_local bool t_registered;
 } // namespace detail
 
@@ -120,7 +119,10 @@ int workerCount() {
 }
 
 std::mt19937 &workerRng() {
-    return detail::t_workerRng;
+    // Forwarder so existing callers keep working; the per-thread RNG
+    // storage now lives in `engine/math/` (`IRMath::threadRng`) so
+    // `IRMath::random*` callers share the same mt19937 state.
+    return IRMath::threadRng();
 }
 
 } // namespace IRJob

--- a/engine/job/src/job_manager.cpp
+++ b/engine/job/src/job_manager.cpp
@@ -9,7 +9,6 @@
 
 #include <cstdio>
 #include <cstdint>
-#include <random>
 #include <thread>
 
 // sys/sysctl.h only exists on Apple platforms — this guard is
@@ -33,8 +32,13 @@ namespace detail {
 // renames — every API path through parallelFor/run/pinTo funnels
 // through the same task body, and that body calls `registerSelf()`
 // once.
+//
+// The per-thread RNG lives in `engine/math/` (`IRMath::threadRng`) so
+// that `IRMath::random*` callers and `IRJob::workerRng` consumers share
+// one mt19937 per OS thread. `registerSelf` reseeds via
+// `IRMath::seedThreadRng(enkiThreadNum)` to keep cross-run determinism
+// for a given worker count.
 thread_local int t_workerId = 0;
-thread_local std::mt19937 t_workerRng{0u};
 thread_local bool t_registered = false;
 thread_local char t_workerName[32] = "main";
 
@@ -44,7 +48,7 @@ void registerSelf(enki::TaskScheduler &scheduler) {
     }
     const uint32_t enkiThreadNum = scheduler.GetThreadNum();
     t_workerId = static_cast<int>(enkiThreadNum);
-    t_workerRng.seed(enkiThreadNum);
+    IRMath::seedThreadRng(enkiThreadNum);
     std::snprintf(t_workerName, sizeof(t_workerName), "ir-worker-%u", enkiThreadNum);
     // registerThread() is idempotent per OS thread (only the first
     // call wins, per easy_profiler header docs).
@@ -120,7 +124,7 @@ JobManager::JobManager(int requestedWorkerCount)
     // Seed the main thread's RNG explicitly — workers seed themselves
     // on first task entry via `detail::registerSelf`.
     detail::t_workerId = 0;
-    detail::t_workerRng.seed(0u);
+    IRMath::seedThreadRng(0u);
     detail::t_registered = true;
     std::snprintf(detail::t_workerName, sizeof(detail::t_workerName), "main");
 

--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -57,7 +57,12 @@ Stored as `vec4(qx, qy, qz, qw)` — `.w` is the scalar (identity: `(0,0,0,1)`).
 
 ## Random
 
-`randomBool/Int/Float` and `randomVec<T>/randomColor` — uses `std::rand`; seed for determinism.
+`randomBool/Int/Float` and `randomVec<T>/randomColor` route through a
+per-thread `std::mt19937` (`IRMath::threadRng()`), so concurrent calls
+from IRJob workers do not race. Threads default to a seed of `0`;
+`IRJob::JobManager` reseeds the main thread and each worker from its
+enkiTS id so cross-run determinism holds for a fixed worker count.
+Non-job threads can seed explicitly via `IRMath::seedThreadRng(seed)`.
 
 ## Gotchas
 

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -11,6 +11,8 @@
 
 #include <glm/gtc/matrix_transform.hpp>
 
+#include <cstdint>
+#include <random>
 #include <utility>
 #include <vector>
 
@@ -18,6 +20,21 @@
 // rotation in 3D space
 
 namespace IRMath {
+
+/// Per-thread `std::mt19937` used by every `IRMath::random*` call.
+///
+/// Each OS thread holds its own RNG state (`thread_local`), so concurrent
+/// calls from IRJob workers never race. Threads default to a seed of `0`;
+/// `IRJob::JobManager` calls @ref seedThreadRng on the main thread at
+/// construction and on each worker the first time it enters a task body,
+/// so worker N's RNG is deterministically seeded from `N`. Outside the
+/// job system, callers can call @ref seedThreadRng directly (mirrors
+/// `std::srand` but per-thread).
+std::mt19937 &threadRng();
+
+/// Seeds the calling thread's RNG (see @ref threadRng). Idempotent —
+/// the most recent call wins.
+void seedThreadRng(uint32_t seed);
 
 /// Pi to float precision. Mirrors `glm::pi<float>()` but routes through the
 /// IRMath wrapper so callers don't have to reach for `glm::` directly.

--- a/engine/math/src/ir_math.cpp
+++ b/engine/math/src/ir_math.cpp
@@ -4,16 +4,40 @@
 
 namespace IRMath {
 
+namespace {
+
+// Default-seeded per-thread RNG. `IRJob::JobManager` reseeds the main
+// thread to id `0` at construction and each worker to its enkiTS id
+// the first time the worker enters a task body. Threads created
+// outside the job system keep this default seed until they call
+// `seedThreadRng` themselves.
+thread_local std::mt19937 t_rng{0u};
+
+} // namespace
+
+std::mt19937 &threadRng() {
+    return t_rng;
+}
+
+void seedThreadRng(uint32_t seed) {
+    t_rng.seed(seed);
+}
+
 const bool randomBool() {
-    return rand() % 2 == 0;
+    std::uniform_int_distribution<int> dist(0, 1);
+    return dist(t_rng) == 0;
 }
 
 const int randomInt(const int min, const int max) {
-    return min + (rand() % (max - min + 1));
+    std::uniform_int_distribution<int> dist(min, max);
+    return dist(t_rng);
 }
 
 const float randomFloat(const float min, const float max) {
-    return min + (static_cast<float>(rand()) / static_cast<float>(RAND_MAX / (max - min)));
+    // uniform_real_distribution is [min, max) by spec; range tests
+    // tolerate either bound so the half-open is fine.
+    std::uniform_real_distribution<float> dist(min, max);
+    return dist(t_rng);
 }
 const Color randomColor() {
     return Color{
@@ -217,22 +241,19 @@ vec3 layoutZigZagPath(
         float x, y;
         if (arm % 2 == 0) {
             x = -static_cast<float>((arm / 2) * S);
-            y =  static_cast<float>((arm / 2) * S + pos);
+            y = static_cast<float>((arm / 2) * S + pos);
         } else {
             x = -static_cast<float>(((arm - 1) / 2) * S + 1 + pos);
-            y =  static_cast<float>(((arm + 1) / 2) * S - 1);
+            y = static_cast<float>(((arm + 1) / 2) * S - 1);
         }
         return vec2(x, y);
     };
 
-    const vec2 cur  = zigzagPos(idx);
+    const vec2 cur = zigzagPos(idx);
     const vec2 last = zigzagPos(count - 1);
     const vec2 center(last.x * 0.5f, last.y * 0.5f);
 
-    const vec2 p(
-        (cur.x - center.x) * spacingPrimary,
-        (cur.y - center.y) * spacingSecondary
-    );
+    const vec2 p((cur.x - center.x) * spacingPrimary, (cur.y - center.y) * spacingSecondary);
     return mapPlaneToVec3(p, depth, plane);
 }
 
@@ -266,23 +287,23 @@ vec3 layoutSquareSpiral(int index, float spacing, PlaneIso plane, float depth) {
         }
     }
 
-    return mapPlaneToVec3(vec2(static_cast<float>(x), static_cast<float>(y)) * spacing, depth, plane);
+    return mapPlaneToVec3(
+        vec2(static_cast<float>(x), static_cast<float>(y)) * spacing,
+        depth,
+        plane
+    );
 }
 
 vec3 layoutCircle(
-    int index,
-    int count,
-    float radius,
-    float startAngleRad,
-    PlaneIso plane,
-    float depth
+    int index, int count, float radius, float startAngleRad, PlaneIso plane, float depth
 ) {
     if (count <= 0) {
         return mapPlaneToVec3(vec2(0.0f), depth, plane);
     }
     const int idx = std::clamp(index, 0, count - 1);
     const float pi = glm::pi<float>();
-    const float angle = startAngleRad + (static_cast<float>(idx) / static_cast<float>(count)) * 2.0f * pi;
+    const float angle =
+        startAngleRad + (static_cast<float>(idx) / static_cast<float>(count)) * 2.0f * pi;
     const float x = radius * std::cos(angle);
     const float y = radius * std::sin(angle);
     return mapPlaneToVec3(vec2(x, y), depth, plane);
@@ -292,9 +313,9 @@ vec3 layoutHelix(
     int index, int count, float radius, float turns, float heightSpan, CoordinateAxis axis
 ) {
     const int countSafe = std::max(1, count);
-    const float t =
-        (countSafe <= 1) ? 0.0f : (static_cast<float>(std::clamp(index, 0, countSafe - 1)) /
-                                    static_cast<float>(countSafe - 1));
+    const float t = (countSafe <= 1) ? 0.0f
+                                     : (static_cast<float>(std::clamp(index, 0, countSafe - 1)) /
+                                        static_cast<float>(countSafe - 1));
     const float angle = t * turns * 2.0f * glm::pi<float>();
     const float c = std::cos(angle);
     const float s = std::sin(angle);
@@ -324,9 +345,9 @@ vec3 layoutPathTangentArcs(
     // Chain of half-circles, each tangent to the next (centers 2*radius apart).
     // After each 180°, rotation switches CW/CCW so the path stays continuous.
     const int countSafe = std::max(1, count);
-    float t =
-        (countSafe <= 1) ? 0.0f : (static_cast<float>(std::clamp(index, 0, countSafe - 1)) /
-                                    static_cast<float>(countSafe - 1));
+    float t = (countSafe <= 1) ? 0.0f
+                               : (static_cast<float>(std::clamp(index, 0, countSafe - 1)) /
+                                  static_cast<float>(countSafe - 1));
     if (invert) {
         t = 1.0f - t;
     }

--- a/engine/math/src/ir_math.cpp
+++ b/engine/math/src/ir_math.cpp
@@ -34,8 +34,10 @@ const int randomInt(const int min, const int max) {
 }
 
 const float randomFloat(const float min, const float max) {
-    // uniform_real_distribution is [min, max) by spec; range tests
-    // tolerate either bound so the half-open is fine.
+    // uniform_real_distribution is [min, max) — half-open, upper bound
+    // excluded. This differs from the prior rand()-based implementation
+    // which was [min, max] (closed). Range tests tolerate either bound;
+    // callers must not rely on sampling the exact upper bound.
     std::uniform_real_distribution<float> dist(min, max);
     return dist(t_rng);
 }

--- a/engine/prefabs/irreden/update/systems/system_animation_color.hpp
+++ b/engine/prefabs/irreden/update/systems/system_animation_color.hpp
@@ -21,103 +21,6 @@ using namespace IRMath;
 namespace IRSystem {
 
 template <> struct System<ANIMATION_COLOR> {
-    // Per-tick caches replacing the prior function-local statics. Live
-    // on the System<N> instance so the engine owns the lifetime and
-    // multi-instance use cannot cross-talk. `endTick` clears both so
-    // entity-id reuse across frames never returns stale data.
-    std::unordered_map<IREntity::EntityId, const C_AnimClipColorTrack *> colorTrackCache_;
-    std::unordered_map<IREntity::EntityId, const C_AnimationClip *> clipCache_;
-
-    const C_AnimClipColorTrack *fetchColorTrack(IREntity::EntityId id) {
-        if (id == IREntity::kNullEntity) {
-            return nullptr;
-        }
-        auto it = colorTrackCache_.find(id);
-        if (it != colorTrackCache_.end()) {
-            return it->second;
-        }
-        auto opt = IREntity::getComponentOptional<C_AnimClipColorTrack>(id);
-        const C_AnimClipColorTrack *ptr = opt.has_value() ? opt.value() : nullptr;
-        colorTrackCache_[id] = ptr;
-        return ptr;
-    }
-
-    const C_AnimationClip *fetchClip(IREntity::EntityId id) {
-        if (id == IREntity::kNullEntity) {
-            return nullptr;
-        }
-        auto it = clipCache_.find(id);
-        if (it != clipCache_.end()) {
-            return it->second;
-        }
-        auto opt = IREntity::getComponentOptional<C_AnimationClip>(id);
-        const C_AnimationClip *ptr = opt.has_value() ? opt.value() : nullptr;
-        clipCache_[id] = ptr;
-        return ptr;
-    }
-
-    static double computeClipProgress(const C_ActionAnimation &anim, const C_AnimationClip &clip) {
-        if (clip.phaseCount_ <= 0) {
-            return 1.0;
-        }
-        if (anim.currentPhase_ < 0) {
-            return 0.0;
-        }
-        if (anim.currentPhase_ >= clip.phaseCount_) {
-            return 1.0;
-        }
-
-        double totalDuration = 0.0;
-        double elapsedBeforeCurrent = 0.0;
-        for (int i = 0; i < clip.phaseCount_; ++i) {
-            const double phaseDur = IRMath::max(0.001, clip.phases_[i].durationSeconds_);
-            totalDuration += phaseDur;
-            if (i < anim.currentPhase_) {
-                elapsedBeforeCurrent += phaseDur;
-            }
-        }
-        if (totalDuration <= 0.0) {
-            return 1.0;
-        }
-
-        const double currentPhaseDur =
-            IRMath::max(0.001, clip.phases_[anim.currentPhase_].durationSeconds_);
-        const double phaseT = IRMath::clamp(anim.phaseElapsed_ / currentPhaseDur, 0.0, 1.0);
-        const double elapsed = elapsedBeforeCurrent + (phaseT * currentPhaseDur);
-        return IRMath::clamp(elapsed / totalDuration, 0.0, 1.0);
-    }
-
-    static double computeElapsedAtPhaseStart(const C_AnimationClip &clip, int phase) {
-        if (phase <= 0) {
-            return 0.0;
-        }
-        const int phaseClamped = IRMath::clamp(phase, 0, clip.phaseCount_);
-        double elapsed = 0.0;
-        for (int i = 0; i < phaseClamped; ++i) {
-            elapsed += IRMath::max(0.001, clip.phases_[i].durationSeconds_);
-        }
-        return elapsed;
-    }
-
-    static double
-    computeCurrentClipElapsed(const C_ActionAnimation &anim, const C_AnimationClip &clip) {
-        if (clip.phaseCount_ <= 0) {
-            return 0.0;
-        }
-        if (anim.currentPhase_ <= 0) {
-            const double phaseDur = IRMath::max(0.001, clip.phases_[0].durationSeconds_);
-            return IRMath::clamp(anim.phaseElapsed_, 0.0, phaseDur);
-        }
-        if (anim.currentPhase_ >= clip.phaseCount_) {
-            return computeElapsedAtPhaseStart(clip, clip.phaseCount_);
-        }
-
-        const double phaseDur =
-            IRMath::max(0.001, clip.phases_[anim.currentPhase_].durationSeconds_);
-        return computeElapsedAtPhaseStart(clip, anim.currentPhase_) +
-               IRMath::clamp(anim.phaseElapsed_, 0.0, phaseDur);
-    }
-
     void
     tick(const C_ActionAnimation &anim, C_AnimColorState &colorState, C_VoxelSetNew &voxelSet) {
         // The body looks up the active clip's components through
@@ -303,8 +206,8 @@ template <> struct System<ANIMATION_COLOR> {
     }
 
     void endTick() {
-        colorTrackCache_.clear();
-        clipCache_.clear();
+        m_colorTrackCache.clear();
+        m_clipCache.clear();
     }
 
     static SystemId create() {
@@ -313,6 +216,104 @@ template <> struct System<ANIMATION_COLOR> {
             const C_ActionAnimation,
             C_AnimColorState,
             C_VoxelSetNew>("AnimationColor");
+    }
+
+private:
+    // Per-tick caches replacing the prior function-local statics. Live
+    // on the System<N> instance so the engine owns the lifetime and
+    // multi-instance use cannot cross-talk. `endTick` clears both so
+    // entity-id reuse across frames never returns stale data.
+    std::unordered_map<IREntity::EntityId, const C_AnimClipColorTrack *> m_colorTrackCache;
+    std::unordered_map<IREntity::EntityId, const C_AnimationClip *> m_clipCache;
+
+    const C_AnimClipColorTrack *fetchColorTrack(IREntity::EntityId id) {
+        if (id == IREntity::kNullEntity) {
+            return nullptr;
+        }
+        auto it = m_colorTrackCache.find(id);
+        if (it != m_colorTrackCache.end()) {
+            return it->second;
+        }
+        auto opt = IREntity::getComponentOptional<C_AnimClipColorTrack>(id);
+        const C_AnimClipColorTrack *ptr = opt.has_value() ? opt.value() : nullptr;
+        m_colorTrackCache[id] = ptr;
+        return ptr;
+    }
+
+    const C_AnimationClip *fetchClip(IREntity::EntityId id) {
+        if (id == IREntity::kNullEntity) {
+            return nullptr;
+        }
+        auto it = m_clipCache.find(id);
+        if (it != m_clipCache.end()) {
+            return it->second;
+        }
+        auto opt = IREntity::getComponentOptional<C_AnimationClip>(id);
+        const C_AnimationClip *ptr = opt.has_value() ? opt.value() : nullptr;
+        m_clipCache[id] = ptr;
+        return ptr;
+    }
+
+    static double computeClipProgress(const C_ActionAnimation &anim, const C_AnimationClip &clip) {
+        if (clip.phaseCount_ <= 0) {
+            return 1.0;
+        }
+        if (anim.currentPhase_ < 0) {
+            return 0.0;
+        }
+        if (anim.currentPhase_ >= clip.phaseCount_) {
+            return 1.0;
+        }
+
+        double totalDuration = 0.0;
+        double elapsedBeforeCurrent = 0.0;
+        for (int i = 0; i < clip.phaseCount_; ++i) {
+            const double phaseDur = IRMath::max(0.001, clip.phases_[i].durationSeconds_);
+            totalDuration += phaseDur;
+            if (i < anim.currentPhase_) {
+                elapsedBeforeCurrent += phaseDur;
+            }
+        }
+        if (totalDuration <= 0.0) {
+            return 1.0;
+        }
+
+        const double currentPhaseDur =
+            IRMath::max(0.001, clip.phases_[anim.currentPhase_].durationSeconds_);
+        const double phaseT = IRMath::clamp(anim.phaseElapsed_ / currentPhaseDur, 0.0, 1.0);
+        const double elapsed = elapsedBeforeCurrent + (phaseT * currentPhaseDur);
+        return IRMath::clamp(elapsed / totalDuration, 0.0, 1.0);
+    }
+
+    static double computeElapsedAtPhaseStart(const C_AnimationClip &clip, int phase) {
+        if (phase <= 0) {
+            return 0.0;
+        }
+        const int phaseClamped = IRMath::clamp(phase, 0, clip.phaseCount_);
+        double elapsed = 0.0;
+        for (int i = 0; i < phaseClamped; ++i) {
+            elapsed += IRMath::max(0.001, clip.phases_[i].durationSeconds_);
+        }
+        return elapsed;
+    }
+
+    static double
+    computeCurrentClipElapsed(const C_ActionAnimation &anim, const C_AnimationClip &clip) {
+        if (clip.phaseCount_ <= 0) {
+            return 0.0;
+        }
+        if (anim.currentPhase_ <= 0) {
+            const double phaseDur = IRMath::max(0.001, clip.phases_[0].durationSeconds_);
+            return IRMath::clamp(anim.phaseElapsed_, 0.0, phaseDur);
+        }
+        if (anim.currentPhase_ >= clip.phaseCount_) {
+            return computeElapsedAtPhaseStart(clip, clip.phaseCount_);
+        }
+
+        const double phaseDur =
+            IRMath::max(0.001, clip.phases_[anim.currentPhase_].durationSeconds_);
+        return computeElapsedAtPhaseStart(clip, anim.currentPhase_) +
+               IRMath::clamp(anim.phaseElapsed_, 0.0, phaseDur);
     }
 };
 

--- a/engine/prefabs/irreden/update/systems/system_animation_color.hpp
+++ b/engine/prefabs/irreden/update/systems/system_animation_color.hpp
@@ -4,6 +4,7 @@
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
+#include <irreden/system/ir_assert_main_thread.hpp>
 
 #include <irreden/update/components/component_action_animation.hpp>
 #include <irreden/update/components/component_animation_clip.hpp>
@@ -11,9 +12,8 @@
 #include <irreden/update/components/component_anim_color_state.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
 
-#include <unordered_map>
-#include <algorithm>
 #include <limits>
+#include <unordered_map>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -21,278 +21,298 @@ using namespace IRMath;
 namespace IRSystem {
 
 template <> struct System<ANIMATION_COLOR> {
-    static SystemId create() {
-        static std::unordered_map<IREntity::EntityId, const C_AnimClipColorTrack*> colorTrackCache;
-        static std::unordered_map<IREntity::EntityId, const C_AnimationClip*> clipCache;
+    // Per-tick caches replacing the prior function-local statics. Live
+    // on the System<N> instance so the engine owns the lifetime and
+    // multi-instance use cannot cross-talk. `endTick` clears both so
+    // entity-id reuse across frames never returns stale data.
+    std::unordered_map<IREntity::EntityId, const C_AnimClipColorTrack *> colorTrackCache_;
+    std::unordered_map<IREntity::EntityId, const C_AnimationClip *> clipCache_;
 
-        return createSystem<C_ActionAnimation, C_AnimColorState, C_VoxelSetNew>(
-            "AnimationColor",
-            [](const C_ActionAnimation &anim,
-               C_AnimColorState &colorState,
-               C_VoxelSetNew &voxelSet) {
-                if (voxelSet.numVoxels_ <= 0) return;
+    const C_AnimClipColorTrack *fetchColorTrack(IREntity::EntityId id) {
+        if (id == IREntity::kNullEntity) {
+            return nullptr;
+        }
+        auto it = colorTrackCache_.find(id);
+        if (it != colorTrackCache_.end()) {
+            return it->second;
+        }
+        auto opt = IREntity::getComponentOptional<C_AnimClipColorTrack>(id);
+        const C_AnimClipColorTrack *ptr = opt.has_value() ? opt.value() : nullptr;
+        colorTrackCache_[id] = ptr;
+        return ptr;
+    }
 
-                if (!colorState.baseInitialized_) {
-                    colorState.baseColor_ = voxelSet.voxels_[0].color_;
-                    colorState.currentColor_ = colorState.baseColor_;
-                    colorState.baseInitialized_ = true;
-                }
+    const C_AnimationClip *fetchClip(IREntity::EntityId id) {
+        if (id == IREntity::kNullEntity) {
+            return nullptr;
+        }
+        auto it = clipCache_.find(id);
+        if (it != clipCache_.end()) {
+            return it->second;
+        }
+        auto opt = IREntity::getComponentOptional<C_AnimationClip>(id);
+        const C_AnimationClip *ptr = opt.has_value() ? opt.value() : nullptr;
+        clipCache_[id] = ptr;
+        return ptr;
+    }
 
-                auto fetchColorTrack = [](IREntity::EntityId id) -> const C_AnimClipColorTrack* {
-                    if (id == IREntity::kNullEntity) return nullptr;
-                    auto it = colorTrackCache.find(id);
-                    if (it != colorTrackCache.end()) return it->second;
-                    auto opt = IREntity::getComponentOptional<C_AnimClipColorTrack>(id);
-                    const C_AnimClipColorTrack *ptr = opt.has_value() ? opt.value() : nullptr;
-                    colorTrackCache[id] = ptr;
-                    return ptr;
-                };
+    static double computeClipProgress(const C_ActionAnimation &anim, const C_AnimationClip &clip) {
+        if (clip.phaseCount_ <= 0) {
+            return 1.0;
+        }
+        if (anim.currentPhase_ < 0) {
+            return 0.0;
+        }
+        if (anim.currentPhase_ >= clip.phaseCount_) {
+            return 1.0;
+        }
 
-                auto fetchClip = [](IREntity::EntityId id) -> const C_AnimationClip* {
-                    if (id == IREntity::kNullEntity) return nullptr;
-                    auto it = clipCache.find(id);
-                    if (it != clipCache.end()) return it->second;
-                    auto opt = IREntity::getComponentOptional<C_AnimationClip>(id);
-                    const C_AnimationClip *ptr = opt.has_value() ? opt.value() : nullptr;
-                    clipCache[id] = ptr;
-                    return ptr;
-                };
-
-                auto computeClipProgress = [](const C_ActionAnimation &anim,
-                                              const C_AnimationClip &clip) -> double {
-                    if (clip.phaseCount_ <= 0) {
-                        return 1.0;
-                    }
-                    if (anim.currentPhase_ < 0) {
-                        return 0.0;
-                    }
-                    if (anim.currentPhase_ >= clip.phaseCount_) {
-                        return 1.0;
-                    }
-
-                    double totalDuration = 0.0;
-                    double elapsedBeforeCurrent = 0.0;
-                    for (int i = 0; i < clip.phaseCount_; ++i) {
-                        const double phaseDur =
-                            std::max(0.001, clip.phases_[i].durationSeconds_);
-                        totalDuration += phaseDur;
-                        if (i < anim.currentPhase_) {
-                            elapsedBeforeCurrent += phaseDur;
-                        }
-                    }
-                    if (totalDuration <= 0.0) {
-                        return 1.0;
-                    }
-
-                    const double currentPhaseDur =
-                        std::max(0.001, clip.phases_[anim.currentPhase_].durationSeconds_);
-                    const double phaseT =
-                        std::clamp(anim.phaseElapsed_ / currentPhaseDur, 0.0, 1.0);
-                    const double elapsed = elapsedBeforeCurrent + (phaseT * currentPhaseDur);
-                    return std::clamp(elapsed / totalDuration, 0.0, 1.0);
-                };
-
-                auto computeElapsedAtPhaseStart = [](const C_AnimationClip &clip, int phase) -> double {
-                    if (phase <= 0) {
-                        return 0.0;
-                    }
-                    const int phaseClamped = std::clamp(phase, 0, clip.phaseCount_);
-                    double elapsed = 0.0;
-                    for (int i = 0; i < phaseClamped; ++i) {
-                        elapsed += std::max(0.001, clip.phases_[i].durationSeconds_);
-                    }
-                    return elapsed;
-                };
-
-                auto computeCurrentClipElapsed = [&](const C_ActionAnimation &anim,
-                                                     const C_AnimationClip &clip) -> double {
-                    if (clip.phaseCount_ <= 0) {
-                        return 0.0;
-                    }
-                    if (anim.currentPhase_ <= 0) {
-                        const double phaseDur = std::max(0.001, clip.phases_[0].durationSeconds_);
-                        return std::clamp(anim.phaseElapsed_, 0.0, phaseDur);
-                    }
-                    if (anim.currentPhase_ >= clip.phaseCount_) {
-                        return computeElapsedAtPhaseStart(clip, clip.phaseCount_);
-                    }
-
-                    const double phaseDur =
-                        std::max(0.001, clip.phases_[anim.currentPhase_].durationSeconds_);
-                    return computeElapsedAtPhaseStart(clip, anim.currentPhase_) +
-                           std::clamp(anim.phaseElapsed_, 0.0, phaseDur);
-                };
-
-                if (anim.isPlaying()) {
-                    colorState.lastClipEntity_ = anim.activeClip_;
-
-                    const C_AnimClipColorTrack *track = fetchColorTrack(anim.activeClip_);
-                    const C_AnimationClip *clip = fetchClip(anim.activeClip_);
-
-                    if (track && clip &&
-                        anim.currentPhase_ >= 0 &&
-                        anim.currentPhase_ < clip->phaseCount_) {
-                        const auto &phase = clip->phases_[anim.currentPhase_];
-                        double phaseDur = static_cast<double>(phase.durationSeconds_);
-                        if (phaseDur <= 0.0) phaseDur = 0.001;
-
-                        double t = anim.phaseElapsed_ / phaseDur;
-                        if (t > 1.0) t = 1.0;
-
-                        Color resultColor = colorState.baseColor_;
-
-                        if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET &&
-                            anim.currentPhase_ < track->phaseCount_) {
-                            const auto &pm = track->phaseMods_[anim.currentPhase_];
-                            float eased = kEasingFunctions.at(pm.easingFunction_)(
-                                static_cast<float>(t));
-                            ColorHSV offset = IRMath::lerpHSV(pm.startMod_, pm.endMod_, eased);
-                            resultColor = IRMath::applyHSVOffset(colorState.baseColor_, offset);
-                        } else if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET_STATE_BLEND) {
-                            const double clipProgress = computeClipProgress(anim, *clip);
-                            ColorHSV offset = IRMath::lerpHSV(
-                                track->startMod_,
-                                track->endMod_,
-                                static_cast<float>(clipProgress)
-                            );
-                            resultColor = IRMath::applyHSVOffset(colorState.baseColor_, offset);
-                        } else if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET_TIMELINE) {
-                            ColorHSV offset = track->endMod_;
-                            const double currentElapsed = computeCurrentClipElapsed(anim, *clip);
-                            bool activeSegmentFound = false;
-
-                            double nearestFutureStart = std::numeric_limits<double>::infinity();
-                            ColorHSV nearestFutureStartMod = track->startMod_;
-
-                            double latestPastEnd = -1.0;
-                            ColorHSV latestPastEndMod = track->endMod_;
-
-                            for (int i = 0; i < track->timelineModCount_; ++i) {
-                                const auto &segment = track->timelineMods_[i];
-                                int fromPhase = std::min(segment.fromPhase_, segment.toPhase_);
-                                int toPhase = std::max(segment.fromPhase_, segment.toPhase_);
-                                fromPhase = std::clamp(fromPhase, 0, clip->phaseCount_ - 1);
-                                toPhase = std::clamp(toPhase, 0, clip->phaseCount_ - 1);
-
-                                const double segmentStart =
-                                    computeElapsedAtPhaseStart(*clip, fromPhase);
-                                const double segmentEnd =
-                                    computeElapsedAtPhaseStart(*clip, toPhase) +
-                                    std::max(0.001, clip->phases_[toPhase].durationSeconds_);
-                                const double segmentLength = std::max(0.001, segmentEnd - segmentStart);
-
-                                if (currentElapsed >= segmentStart &&
-                                    currentElapsed <= segmentEnd) {
-                                    const double localT = std::clamp(
-                                        (currentElapsed - segmentStart) / segmentLength,
-                                        0.0,
-                                        1.0
-                                    );
-                                    float eased = kEasingFunctions.at(segment.easingFunction_)(
-                                        static_cast<float>(localT)
-                                    );
-                                    offset = IRMath::lerpHSV(
-                                        segment.startMod_,
-                                        segment.endMod_,
-                                        eased
-                                    );
-                                    activeSegmentFound = true;
-                                    break;
-                                }
-
-                                if (currentElapsed < segmentStart &&
-                                    segmentStart < nearestFutureStart) {
-                                    nearestFutureStart = segmentStart;
-                                    nearestFutureStartMod = segment.startMod_;
-                                }
-                                if (currentElapsed > segmentEnd && segmentEnd > latestPastEnd) {
-                                    latestPastEnd = segmentEnd;
-                                    latestPastEndMod = segment.endMod_;
-                                }
-                            }
-
-                            if (!activeSegmentFound) {
-                                if (latestPastEnd >= 0.0) {
-                                    offset = latestPastEndMod;
-                                } else if (nearestFutureStart <
-                                           std::numeric_limits<double>::infinity()) {
-                                    offset = nearestFutureStartMod;
-                                }
-                            }
-
-                            resultColor = IRMath::applyHSVOffset(colorState.baseColor_, offset);
-                        } else {
-                            if (anim.currentPhase_ < track->phaseCount_) {
-                                const auto &pc = track->phaseColors_[anim.currentPhase_];
-                                float eased = kEasingFunctions.at(pc.easingFunction_)(
-                                    static_cast<float>(t));
-                                Color trackColor = IRMath::lerpColor(
-                                    pc.startColor_, pc.endColor_, eased);
-
-                                switch (colorState.blendMode_) {
-                                case ANIM_COLOR_BLEND_MULTIPLY:
-                                    resultColor = Color{
-                                        static_cast<uint8_t>((colorState.baseColor_.red_ * trackColor.red_) / 255),
-                                        static_cast<uint8_t>((colorState.baseColor_.green_ * trackColor.green_) / 255),
-                                        static_cast<uint8_t>((colorState.baseColor_.blue_ * trackColor.blue_) / 255),
-                                        static_cast<uint8_t>((colorState.baseColor_.alpha_ * trackColor.alpha_) / 255)
-                                    };
-                                    break;
-                                case ANIM_COLOR_BLEND_LERP:
-                                    resultColor = IRMath::lerpColor(
-                                        colorState.baseColor_, trackColor, eased);
-                                    break;
-                                case ANIM_COLOR_BLEND_REPLACE:
-                                default:
-                                    resultColor = trackColor;
-                                    break;
-                                }
-                            }
-                        }
-
-                        colorState.currentColor_ = resultColor;
-                    }
-                    // phaseCount == 0: no per-phase color, keep currentColor_ as-is
-                } else {
-                    // Idle: apply the last-played clip's idle color/modifier
-                    if (colorState.lastClipEntity_ != IREntity::kNullEntity) {
-                        const C_AnimClipColorTrack *track =
-                            fetchColorTrack(colorState.lastClipEntity_);
-                        if (track) {
-                            if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET) {
-                                colorState.currentColor_ =
-                                    IRMath::applyHSVOffset(colorState.baseColor_, track->idleMod_);
-                            } else if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET_STATE_BLEND) {
-                                colorState.currentColor_ =
-                                    IRMath::applyHSVOffset(colorState.baseColor_, track->endMod_);
-                            } else if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET_TIMELINE) {
-                                ColorHSV idleOffset = track->endMod_;
-                                int bestToPhase = std::numeric_limits<int>::min();
-                                for (int i = 0; i < track->timelineModCount_; ++i) {
-                                    const auto &segment = track->timelineMods_[i];
-                                    const int segmentTo =
-                                        std::max(segment.fromPhase_, segment.toPhase_);
-                                    if (segmentTo > bestToPhase) {
-                                        bestToPhase = segmentTo;
-                                        idleOffset = segment.endMod_;
-                                    }
-                                }
-                                colorState.currentColor_ =
-                                    IRMath::applyHSVOffset(colorState.baseColor_, idleOffset);
-                            } else {
-                                colorState.currentColor_ = track->idleColor_;
-                            }
-                        }
-                    }
-                }
-
-                voxelSet.changeVoxelColorAll(colorState.currentColor_);
-            },
-            []() {
-                colorTrackCache.clear();
-                clipCache.clear();
+        double totalDuration = 0.0;
+        double elapsedBeforeCurrent = 0.0;
+        for (int i = 0; i < clip.phaseCount_; ++i) {
+            const double phaseDur = IRMath::max(0.001, clip.phases_[i].durationSeconds_);
+            totalDuration += phaseDur;
+            if (i < anim.currentPhase_) {
+                elapsedBeforeCurrent += phaseDur;
             }
-        );
+        }
+        if (totalDuration <= 0.0) {
+            return 1.0;
+        }
+
+        const double currentPhaseDur =
+            IRMath::max(0.001, clip.phases_[anim.currentPhase_].durationSeconds_);
+        const double phaseT = IRMath::clamp(anim.phaseElapsed_ / currentPhaseDur, 0.0, 1.0);
+        const double elapsed = elapsedBeforeCurrent + (phaseT * currentPhaseDur);
+        return IRMath::clamp(elapsed / totalDuration, 0.0, 1.0);
+    }
+
+    static double computeElapsedAtPhaseStart(const C_AnimationClip &clip, int phase) {
+        if (phase <= 0) {
+            return 0.0;
+        }
+        const int phaseClamped = IRMath::clamp(phase, 0, clip.phaseCount_);
+        double elapsed = 0.0;
+        for (int i = 0; i < phaseClamped; ++i) {
+            elapsed += IRMath::max(0.001, clip.phases_[i].durationSeconds_);
+        }
+        return elapsed;
+    }
+
+    static double
+    computeCurrentClipElapsed(const C_ActionAnimation &anim, const C_AnimationClip &clip) {
+        if (clip.phaseCount_ <= 0) {
+            return 0.0;
+        }
+        if (anim.currentPhase_ <= 0) {
+            const double phaseDur = IRMath::max(0.001, clip.phases_[0].durationSeconds_);
+            return IRMath::clamp(anim.phaseElapsed_, 0.0, phaseDur);
+        }
+        if (anim.currentPhase_ >= clip.phaseCount_) {
+            return computeElapsedAtPhaseStart(clip, clip.phaseCount_);
+        }
+
+        const double phaseDur =
+            IRMath::max(0.001, clip.phases_[anim.currentPhase_].durationSeconds_);
+        return computeElapsedAtPhaseStart(clip, anim.currentPhase_) +
+               IRMath::clamp(anim.phaseElapsed_, 0.0, phaseDur);
+    }
+
+    void
+    tick(const C_ActionAnimation &anim, C_AnimColorState &colorState, C_VoxelSetNew &voxelSet) {
+        // The body looks up the active clip's components through
+        // `IREntity::getComponentOptional` on a foreign entity id. The
+        // entity manager is not thread-safe in this phase (T-225 owns
+        // the deferred-mutation surface), so the system stays SERIAL
+        // and asserts main-thread for defense in depth.
+        IR_ASSERT_MAIN_THREAD();
+
+        if (voxelSet.numVoxels_ <= 0) {
+            return;
+        }
+
+        if (!colorState.baseInitialized_) {
+            colorState.baseColor_ = voxelSet.voxels_[0].color_;
+            colorState.currentColor_ = colorState.baseColor_;
+            colorState.baseInitialized_ = true;
+        }
+
+        if (anim.isPlaying()) {
+            colorState.lastClipEntity_ = anim.activeClip_;
+
+            const C_AnimClipColorTrack *track = fetchColorTrack(anim.activeClip_);
+            const C_AnimationClip *clip = fetchClip(anim.activeClip_);
+
+            if (track && clip && anim.currentPhase_ >= 0 &&
+                anim.currentPhase_ < clip->phaseCount_) {
+                const auto &phase = clip->phases_[anim.currentPhase_];
+                double phaseDur = static_cast<double>(phase.durationSeconds_);
+                if (phaseDur <= 0.0) {
+                    phaseDur = 0.001;
+                }
+
+                double t = anim.phaseElapsed_ / phaseDur;
+                if (t > 1.0) {
+                    t = 1.0;
+                }
+
+                Color resultColor = colorState.baseColor_;
+
+                if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET &&
+                    anim.currentPhase_ < track->phaseCount_) {
+                    const auto &pm = track->phaseMods_[anim.currentPhase_];
+                    float eased = kEasingFunctions.at(pm.easingFunction_)(static_cast<float>(t));
+                    ColorHSV offset = IRMath::lerpHSV(pm.startMod_, pm.endMod_, eased);
+                    resultColor = IRMath::applyHSVOffset(colorState.baseColor_, offset);
+                } else if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET_STATE_BLEND) {
+                    const double clipProgress = computeClipProgress(anim, *clip);
+                    ColorHSV offset = IRMath::lerpHSV(
+                        track->startMod_,
+                        track->endMod_,
+                        static_cast<float>(clipProgress)
+                    );
+                    resultColor = IRMath::applyHSVOffset(colorState.baseColor_, offset);
+                } else if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET_TIMELINE) {
+                    ColorHSV offset = track->endMod_;
+                    const double currentElapsed = computeCurrentClipElapsed(anim, *clip);
+                    bool activeSegmentFound = false;
+
+                    double nearestFutureStart = std::numeric_limits<double>::infinity();
+                    ColorHSV nearestFutureStartMod = track->startMod_;
+
+                    double latestPastEnd = -1.0;
+                    ColorHSV latestPastEndMod = track->endMod_;
+
+                    for (int i = 0; i < track->timelineModCount_; ++i) {
+                        const auto &segment = track->timelineMods_[i];
+                        int fromPhase = IRMath::min(segment.fromPhase_, segment.toPhase_);
+                        int toPhase = IRMath::max(segment.fromPhase_, segment.toPhase_);
+                        fromPhase = IRMath::clamp(fromPhase, 0, clip->phaseCount_ - 1);
+                        toPhase = IRMath::clamp(toPhase, 0, clip->phaseCount_ - 1);
+
+                        const double segmentStart = computeElapsedAtPhaseStart(*clip, fromPhase);
+                        const double segmentEnd =
+                            computeElapsedAtPhaseStart(*clip, toPhase) +
+                            IRMath::max(0.001, clip->phases_[toPhase].durationSeconds_);
+                        const double segmentLength = IRMath::max(0.001, segmentEnd - segmentStart);
+
+                        if (currentElapsed >= segmentStart && currentElapsed <= segmentEnd) {
+                            const double localT = IRMath::clamp(
+                                (currentElapsed - segmentStart) / segmentLength,
+                                0.0,
+                                1.0
+                            );
+                            float eased = kEasingFunctions.at(segment.easingFunction_)(
+                                static_cast<float>(localT)
+                            );
+                            offset = IRMath::lerpHSV(segment.startMod_, segment.endMod_, eased);
+                            activeSegmentFound = true;
+                            break;
+                        }
+
+                        if (currentElapsed < segmentStart && segmentStart < nearestFutureStart) {
+                            nearestFutureStart = segmentStart;
+                            nearestFutureStartMod = segment.startMod_;
+                        }
+                        if (currentElapsed > segmentEnd && segmentEnd > latestPastEnd) {
+                            latestPastEnd = segmentEnd;
+                            latestPastEndMod = segment.endMod_;
+                        }
+                    }
+
+                    if (!activeSegmentFound) {
+                        if (latestPastEnd >= 0.0) {
+                            offset = latestPastEndMod;
+                        } else if (nearestFutureStart < std::numeric_limits<double>::infinity()) {
+                            offset = nearestFutureStartMod;
+                        }
+                    }
+
+                    resultColor = IRMath::applyHSVOffset(colorState.baseColor_, offset);
+                } else {
+                    if (anim.currentPhase_ < track->phaseCount_) {
+                        const auto &pc = track->phaseColors_[anim.currentPhase_];
+                        float eased =
+                            kEasingFunctions.at(pc.easingFunction_)(static_cast<float>(t));
+                        Color trackColor = IRMath::lerpColor(pc.startColor_, pc.endColor_, eased);
+
+                        switch (colorState.blendMode_) {
+                        case ANIM_COLOR_BLEND_MULTIPLY:
+                            resultColor = Color{
+                                static_cast<uint8_t>(
+                                    (colorState.baseColor_.red_ * trackColor.red_) / 255
+                                ),
+                                static_cast<uint8_t>(
+                                    (colorState.baseColor_.green_ * trackColor.green_) / 255
+                                ),
+                                static_cast<uint8_t>(
+                                    (colorState.baseColor_.blue_ * trackColor.blue_) / 255
+                                ),
+                                static_cast<uint8_t>(
+                                    (colorState.baseColor_.alpha_ * trackColor.alpha_) / 255
+                                )
+                            };
+                            break;
+                        case ANIM_COLOR_BLEND_LERP:
+                            resultColor =
+                                IRMath::lerpColor(colorState.baseColor_, trackColor, eased);
+                            break;
+                        case ANIM_COLOR_BLEND_REPLACE:
+                        default:
+                            resultColor = trackColor;
+                            break;
+                        }
+                    }
+                }
+
+                colorState.currentColor_ = resultColor;
+            }
+            // phaseCount == 0: no per-phase color, keep currentColor_ as-is
+        } else {
+            // Idle: apply the last-played clip's idle color/modifier
+            if (colorState.lastClipEntity_ != IREntity::kNullEntity) {
+                const C_AnimClipColorTrack *track = fetchColorTrack(colorState.lastClipEntity_);
+                if (track) {
+                    if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET) {
+                        colorState.currentColor_ =
+                            IRMath::applyHSVOffset(colorState.baseColor_, track->idleMod_);
+                    } else if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET_STATE_BLEND) {
+                        colorState.currentColor_ =
+                            IRMath::applyHSVOffset(colorState.baseColor_, track->endMod_);
+                    } else if (track->mode_ == ANIM_COLOR_TRACK_HSV_OFFSET_TIMELINE) {
+                        ColorHSV idleOffset = track->endMod_;
+                        int bestToPhase = std::numeric_limits<int>::min();
+                        for (int i = 0; i < track->timelineModCount_; ++i) {
+                            const auto &segment = track->timelineMods_[i];
+                            const int segmentTo = IRMath::max(segment.fromPhase_, segment.toPhase_);
+                            if (segmentTo > bestToPhase) {
+                                bestToPhase = segmentTo;
+                                idleOffset = segment.endMod_;
+                            }
+                        }
+                        colorState.currentColor_ =
+                            IRMath::applyHSVOffset(colorState.baseColor_, idleOffset);
+                    } else {
+                        colorState.currentColor_ = track->idleColor_;
+                    }
+                }
+            }
+        }
+
+        voxelSet.changeVoxelColorAll(colorState.currentColor_);
+    }
+
+    void endTick() {
+        colorTrackCache_.clear();
+        clipCache_.clear();
+    }
+
+    static SystemId create() {
+        return registerSystem<
+            ANIMATION_COLOR,
+            const C_ActionAnimation,
+            C_AnimColorState,
+            C_VoxelSetNew>("AnimationColor");
     }
 };
 

--- a/engine/prefabs/irreden/update/systems/system_velocity_drag.hpp
+++ b/engine/prefabs/irreden/update/systems/system_velocity_drag.hpp
@@ -3,11 +3,10 @@
 
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_math.hpp>
+#include <irreden/ir_time.hpp>
 
 #include <irreden/update/components/component_velocity_3d.hpp>
 #include <irreden/update/components/component_velocity_drag.hpp>
-
-#include <cmath>
 
 using namespace IRComponents;
 using namespace IRMath;
@@ -15,94 +14,86 @@ using namespace IRMath;
 namespace IRSystem {
 
 template <> struct System<VELOCITY_DRAG> {
-    static SystemId create() {
-        return createSystem<C_Velocity3D, C_VelocityDrag>(
-            "VelocityDrag",
-            [](C_Velocity3D &velocity, C_VelocityDrag &drag) {
-                float dt = IRTime::deltaTime(IRTime::UPDATE);
-                drag.elapsedSeconds_ += dt;
+    // Per-component body that touches only its own row's components.
+    // `IRMath::randomFloat` is per-thread-safe (T-328 sub-task A) and
+    // `IRTime::deltaTime` is a per-frame snapshot set on the main thread
+    // before ticks dispatch, so the row body is safe to fan out across
+    // workers.
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
 
-                // XY drag is always active.
-                vec3 axisScale = IRMath::max(
-                    vec3(drag.dragScaleX_, drag.dragScaleY_, drag.dragScaleZ_),
-                    vec3(0.0f)
-                );
+    void tick(C_Velocity3D &velocity, C_VelocityDrag &drag) {
+        const float dt = static_cast<float>(IRTime::deltaTime(IRTime::UPDATE));
+        drag.elapsedSeconds_ += dt;
 
-                bool inBlendOrHover =
-                    !drag.zSettled_ &&
-                    drag.elapsedSeconds_ >= drag.driftDelaySeconds_ &&
-                    drag.hoverDurationSeconds_ > 0.0f;
+        // XY drag is always active.
+        vec3 axisScale =
+            IRMath::max(vec3(drag.dragScaleX_, drag.dragScaleY_, drag.dragScaleZ_), vec3(0.0f));
 
-                if (inBlendOrHover) {
-                    drag.hoverElapsedSec_ += dt;
-                    float blendDur = std::max(drag.hoverBlendSeconds_, 0.001f);
-                    float rawT = IRMath::clamp(
-                        drag.hoverElapsedSec_ / blendDur, 0.0f, 1.0f);
-                    float blend = kEasingFunctions.at(drag.hoverBlendEasing_)(rawT);
+        const bool inBlendOrHover = !drag.zSettled_ &&
+                                    drag.elapsedSeconds_ >= drag.driftDelaySeconds_ &&
+                                    drag.hoverDurationSeconds_ > 0.0f;
 
-                    float hoverVel =
-                        std::sin(drag.hoverElapsedSec_ * drag.hoverOscSpeed_)
-                        * drag.hoverOscAmplitude_ * blend;
+        if (inBlendOrHover) {
+            drag.hoverElapsedSec_ += dt;
+            const float blendDur = IRMath::max(drag.hoverBlendSeconds_, 0.001f);
+            const float rawT = IRMath::clamp(drag.hoverElapsedSec_ / blendDur, 0.0f, 1.0f);
+            const float blend = kEasingFunctions.at(drag.hoverBlendEasing_)(rawT);
 
-                    // Fade out Z drag as hover fades in
-                    axisScale.z *= (1.0f - blend);
+            const float hoverVel = IRMath::sin(drag.hoverElapsedSec_ * drag.hoverOscSpeed_) *
+                                   drag.hoverOscAmplitude_ * blend;
 
-                    vec3 dampFactor = IRMath::max(
-                        vec3(0.0f),
-                        vec3(1.0f) - (axisScale * (drag.dragPerSecond_ * dt))
-                    );
-                    velocity.velocity_ *= dampFactor;
+            // Fade out Z drag as hover fades in
+            axisScale.z *= (1.0f - blend);
 
-                    velocity.velocity_.z =
-                        velocity.velocity_.z * (1.0f - blend) + hoverVel;
+            vec3 dampFactor =
+                IRMath::max(vec3(0.0f), vec3(1.0f) - (axisScale * (drag.dragPerSecond_ * dt)));
+            velocity.velocity_ *= dampFactor;
 
-                    if (rawT >= 1.0f) {
-                        drag.zSettled_ = true;
-                    }
-                } else if (drag.zSettled_) {
-                    // Z drag disabled, hover/exit drives Z.
-                    axisScale.z = 0.0f;
-                    vec3 dampFactor = IRMath::max(
-                        vec3(0.0f),
-                        vec3(1.0f) - (axisScale * (drag.dragPerSecond_ * dt))
-                    );
-                    velocity.velocity_ *= dampFactor;
+            velocity.velocity_.z = velocity.velocity_.z * (1.0f - blend) + hoverVel;
 
-                    if (drag.hoverDurationSeconds_ > 0.0f
-                        && drag.hoverElapsedSec_ < drag.hoverDurationSeconds_) {
-                        drag.hoverElapsedSec_ += dt;
-                        float hoverT = drag.hoverElapsedSec_;
-                        velocity.velocity_.z =
-                            std::sin(hoverT * drag.hoverOscSpeed_)
-                            * drag.hoverOscAmplitude_;
-                    } else {
-                        if (drag.usePostHoverVelocityReset_
-                            && !drag.postHoverVelocityApplied_) {
-                            float var = drag.postHoverVelocityZVariance_;
-                            velocity.velocity_.z =
-                                drag.postHoverVelocityZ_
-                                + IRMath::randomFloat(-var, var);
-                            drag.postHoverVelocityApplied_ = true;
-                        } else {
-                            velocity.velocity_.z -=
-                                drag.driftUpAccelPerSecond_ * dt;
-                        }
-                    }
-                } else {
-                    // Pre-blend: pure drag on all axes.
-                    vec3 dampFactor = IRMath::max(
-                        vec3(0.0f),
-                        vec3(1.0f) - (axisScale * (drag.dragPerSecond_ * dt))
-                    );
-                    velocity.velocity_ *= dampFactor;
-                }
-
-                if (std::abs(velocity.velocity_.x) < drag.minSpeed_)
-                    velocity.velocity_.x = 0.0f;
-                if (std::abs(velocity.velocity_.y) < drag.minSpeed_)
-                    velocity.velocity_.y = 0.0f;
+            if (rawT >= 1.0f) {
+                drag.zSettled_ = true;
             }
-        );
+        } else if (drag.zSettled_) {
+            // Z drag disabled, hover/exit drives Z.
+            axisScale.z = 0.0f;
+            vec3 dampFactor =
+                IRMath::max(vec3(0.0f), vec3(1.0f) - (axisScale * (drag.dragPerSecond_ * dt)));
+            velocity.velocity_ *= dampFactor;
+
+            if (drag.hoverDurationSeconds_ > 0.0f &&
+                drag.hoverElapsedSec_ < drag.hoverDurationSeconds_) {
+                drag.hoverElapsedSec_ += dt;
+                const float hoverT = drag.hoverElapsedSec_;
+                velocity.velocity_.z =
+                    IRMath::sin(hoverT * drag.hoverOscSpeed_) * drag.hoverOscAmplitude_;
+            } else {
+                if (drag.usePostHoverVelocityReset_ && !drag.postHoverVelocityApplied_) {
+                    const float var = drag.postHoverVelocityZVariance_;
+                    velocity.velocity_.z =
+                        drag.postHoverVelocityZ_ + IRMath::randomFloat(-var, var);
+                    drag.postHoverVelocityApplied_ = true;
+                } else {
+                    velocity.velocity_.z -= drag.driftUpAccelPerSecond_ * dt;
+                }
+            }
+        } else {
+            // Pre-blend: pure drag on all axes.
+            vec3 dampFactor =
+                IRMath::max(vec3(0.0f), vec3(1.0f) - (axisScale * (drag.dragPerSecond_ * dt)));
+            velocity.velocity_ *= dampFactor;
+        }
+
+        if (IRMath::abs(velocity.velocity_.x) < drag.minSpeed_) {
+            velocity.velocity_.x = 0.0f;
+        }
+        if (IRMath::abs(velocity.velocity_.y) < drag.minSpeed_) {
+            velocity.velocity_.y = 0.0f;
+        }
+    }
+
+    static SystemId create() {
+        return registerSystem<VELOCITY_DRAG, C_Velocity3D, C_VelocityDrag>("VelocityDrag");
     }
 };
 

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -298,11 +298,15 @@ always serialize on the main thread regardless of policy.
 - `PARALLEL_FOR + mainThreadOnly_` → FATAL. Pick one — the
   `MainThread` tag is explicit "do not parallelize".
 
-The first system to opt in is `VELOCITY_3D` (T-222 POC). The other
-two POC ports from #1069 (`VELOCITY_DRAG`, `ANIMATION_COLOR`) need
-prior thread-safety audits (`IRMath::randomFloat` per-worker
-seeding; function-local static caches inside the
-`ANIMATION_COLOR` body) and are deferred to follow-up issues.
+The first system to opt in is `VELOCITY_3D` (T-222 POC). T-328
+completed the other two POC ports from #1069: `VELOCITY_DRAG` is now
+`PARALLEL_FOR` (per-thread `IRMath::randomFloat` makes its
+`postHoverVelocity` reset path thread-safe); `ANIMATION_COLOR` stays
+`SERIAL` with `IR_ASSERT_MAIN_THREAD` because the tick reads the
+active clip's components through `IREntity::getComponentOptional` on
+a foreign entity id, and the entity manager is not yet thread-safe
+(T-225 owns the deferred-mutation surface). Re-evaluate the
+`ANIMATION_COLOR` opt-in after T-225 lands.
 
 ### IR_ASSERT_MAIN_THREAD
 

--- a/engine/system/include/irreden/system/system_access.hpp
+++ b/engine/system/include/irreden/system/system_access.hpp
@@ -233,6 +233,51 @@ template <typename T> constexpr void applyComponent(SystemAccess &out) {
 // `&` themselves).
 template <typename T> using StripForConcept = std::remove_cvref_t<T>;
 
+// Tag-filter scaffolding for the invocability probes below. The
+// Components pack must be filtered because tag types (`MainThread`,
+// `ParallelSafe`, `Spawns`, ...) and `Exclude<...>` are not real tick
+// parameters; leaving them in front of `InvocableWithEntityId` /
+// `InvocableWithNodeVectors` makes the probe fail on every system that
+// mixes a real signature with tags, so `usesEntityId_` /
+// `isBatchForm_` stay false. T-328 sub-task D.
+//
+// `IRSystem::detail::TypeList` is already defined in ir_system_types.hpp
+// (used by the Exclude<...> partitioner); we reuse it here.
+
+// Recursive head/tail filter: drop `Head` from the result iff
+// `kIsTag<Head>` is true. Mirrors the same predicate `applyComponent`
+// already uses to classify the pack.
+template <typename... Components> struct FilterTagsImpl {
+    using type = TypeList<>;
+};
+
+template <typename Head, typename... Tail> struct FilterTagsImpl<Head, Tail...> {
+  private:
+    using TailFiltered = typename FilterTagsImpl<Tail...>::type;
+
+    template <typename TL> struct Prepend;
+    template <typename... Existing> struct Prepend<TypeList<Existing...>> {
+        using type = TypeList<Head, Existing...>;
+    };
+
+  public:
+    using type =
+        std::conditional_t<kIsTag<Head>, TailFiltered, typename Prepend<TailFiltered>::type>;
+};
+
+template <typename... Components> using FilterTags_t = typename FilterTagsImpl<Components...>::type;
+
+// Apply the invocability probes against an already-filtered TypeList.
+// Specialization on `TypeList<NonTags...>` unpacks the filtered pack
+// so the existing concepts can be instantiated with bare `T` args.
+template <typename TickFn, typename TL> struct ProbeSignatureForms;
+
+template <typename TickFn, typename... NonTags>
+struct ProbeSignatureForms<TickFn, TypeList<NonTags...>> {
+    static constexpr bool usesEntityId = InvocableWithEntityId<TickFn, NonTags...>;
+    static constexpr bool isBatchForm = InvocableWithNodeVectors<TickFn, NonTags...>;
+};
+
 } // namespace detail
 
 /// Constexpr trait. Returns the access descriptor for a system whose
@@ -246,16 +291,22 @@ template <typename T> using StripForConcept = std::remove_cvref_t<T>;
 /// - `Exclude<...>` → contributes nothing (archetype-matcher concern).
 /// - Signature form (per-component vs entity-id vs batch) via the
 ///   existing `InvocableWithEntityId` / `InvocableWithNodeVectors`
-///   concepts that drive `createSystem`'s dispatch.
+///   concepts that drive `createSystem`'s dispatch. Tag types are
+///   filtered out of the pack before probing so a tick that combines
+///   a real signature (e.g. `void(EntityId, C_Foo&)`) with tags
+///   (e.g. `ParallelSafe`, `MainThread`) still derives
+///   `usesEntityId_` / `isBatchForm_` correctly.
 template <typename TickFn, typename... Components>
 constexpr SystemAccess deriveAccessFromSignature() {
     SystemAccess out{};
     (detail::applyComponent<Components>(out), ...);
 
-    if constexpr (InvocableWithEntityId<TickFn, detail::StripForConcept<Components>...>) {
+    using NonTags = detail::FilterTags_t<detail::StripForConcept<Components>...>;
+    using Probe = detail::ProbeSignatureForms<TickFn, NonTags>;
+    if constexpr (Probe::usesEntityId) {
         out.usesEntityId_ = true;
     }
-    if constexpr (InvocableWithNodeVectors<TickFn, detail::StripForConcept<Components>...>) {
+    if constexpr (Probe::isBatchForm) {
         out.isBatchForm_ = true;
     }
     return out;

--- a/engine/time/CLAUDE.md
+++ b/engine/time/CLAUDE.md
@@ -8,8 +8,9 @@ time to run another UPDATE tick, and reads `deltaTime(event)` for dt.
 
 - `shouldUpdate()` — true when the UPDATE accumulator has buffered at
   least one frame period (1/kFPS).
-- `deltaTime(Events event)` — actual wall-clock dt for this event's last
-  tick.
+- `deltaTime(Events event)` — dt for this event's last tick. For UPDATE,
+  returns the fixed step `1.0 / kFPS` (`const`-after-ctor); for RENDER,
+  returns the actual wall-clock duration of the last tick.
 - `renderFps()`, `updateFps()` — 1-second rolling averages.
 - `renderFrameTimeMs()`, `droppedFrames()`, `resetDroppedFrames()`.
 
@@ -61,10 +62,15 @@ of lag manually (used by the loading-screen / pause path).
 
 ## Gotchas
 
-- **`deltaTime(UPDATE)` is wall-clock, not fixed.** It's the actual time
-  the last UPDATE tick took, not `1.0 / kFPS`. Good for physics
-  damping and decay, but **do not** use it to advance simulation state
-  you expect to be deterministic — that's why the fixed-step loop exists.
+- **`deltaTime(UPDATE)` is the fixed step, not wall-clock.** Returns
+  `m_deltaTimeFixed` (`const double = 1.0 / kFPS`, set once in the
+  `EventProfiler<UPDATE>` ctor). The fixed-step loop is what keeps
+  simulation deterministic — `shouldUpdate()` runs extra ticks to catch
+  up when the loop falls behind, each ticking the same fixed dt. This
+  also makes the dt immutable after construction, so PARALLEL_FOR
+  bodies can read it from worker threads without synchronization.
+  `deltaTime(RENDER)` is wall-clock (variable per frame); use it for
+  presentation-frame interpolation, not simulation state.
 - **Lag can cascade.** If one frame takes 50 ms, the next loop iteration
   runs 3 UPDATE ticks back-to-back. Budget accordingly.
 - **Dropped-frame counter is RENDER-only.** If UPDATE falls behind, it

--- a/engine/time/include/irreden/ir_time.hpp
+++ b/engine/time/include/irreden/ir_time.hpp
@@ -11,10 +11,10 @@ extern TimeManager *g_timeManager;
 /// Returns a reference to the active `TimeManager`. Asserts if not initialised.
 TimeManager &getTimeManager();
 
-/// Returns the actual wall-clock dt (seconds) for the last tick of @p eventType.
-/// Note: this is wall-clock time, **not** a fixed step — do not use it to advance
-/// deterministic simulation state.  For that, use the fixed-step accumulator pattern
-/// (see `shouldUpdate()`).
+/// Returns dt (seconds) for the last tick of @p eventType.
+/// UPDATE: fixed step `1.0 / IRConstants::kFPS` (`const`-after-ctor; safe to read
+/// from PARALLEL_FOR worker bodies). RENDER: actual wall-clock dt of the last tick —
+/// use only for presentation-frame interpolation, not deterministic sim state.
 double deltaTime(Events eventType);
 /// Returns `true` when the UPDATE accumulator has buffered at least one frame period
 /// (1 / @ref IRConstants::kFPS).  Call in a `while` loop to drain catch-up ticks.

--- a/test/job/ir_job_test.cpp
+++ b/test/job/ir_job_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <irreden/ir_job.hpp>
+#include <irreden/ir_math.hpp>
 #include <irreden/job/job_manager.hpp>
 
 #include <atomic>
@@ -141,6 +142,63 @@ TEST_F(IRJobFixture, WorkerRngIsSeededFromWorkerId) {
     std::mt19937 expected(0u);
     const auto expectedFirst = expected();
     EXPECT_EQ(IRJob::workerRng()(), expectedFirst);
+}
+
+TEST_F(IRJobFixture, IRMathThreadRngSharesStorageWithIRJobWorkerRng) {
+    // Single source of truth: IRJob::workerRng() is a thin forwarder
+    // over IRMath::threadRng(). Mutating one must be observed by the
+    // other on the same thread.
+    IRMath::seedThreadRng(123u);
+    std::mt19937 expected(123u);
+    EXPECT_EQ(IRJob::workerRng()(), expected());
+    EXPECT_EQ(IRMath::threadRng()(), expected());
+}
+
+TEST_F(IRJobFixture, IRMathRandomFromWorkersDoesNotRace) {
+    // Mirror the barrier strategy in `ParallelForRunsOnAtLeastOneWorker`
+    // to force at least 2 chunks to be in-flight before any body runs;
+    // otherwise enkiTS' work-stealing can pump every chunk on the main
+    // thread under `WaitforTask` and the "worker actually ran on a
+    // worker" property is left to luck. With that barrier in place we
+    // can assert the parallel-safety property directly: per-worker RNG
+    // state is isolated (no torn ints, no out-of-range values, no
+    // crashes) and at least one non-main worker contributed samples.
+    constexpr int kChunkCount = 32;
+    constexpr int kSamplesPerChunk = 16;
+    std::vector<int> samples(kChunkCount * kSamplesPerChunk, -1);
+    std::atomic<int> workerBitmask{0};
+    std::atomic<int> startedCount{0};
+    std::atomic<bool> release{false};
+
+    auto body = [&](int rangeBegin, int rangeEnd) {
+        startedCount.fetch_add(1, std::memory_order_relaxed);
+        while (!release.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        const int worker = IRJob::workerId();
+        workerBitmask.fetch_or(1 << worker, std::memory_order_relaxed);
+        for (int chunk = rangeBegin; chunk < rangeEnd; ++chunk) {
+            for (int i = 0; i < kSamplesPerChunk; ++i) {
+                samples[chunk * kSamplesPerChunk + i] = IRMath::randomInt(0, 1000);
+            }
+        }
+    };
+
+    std::thread releaser([&]() {
+        while (startedCount.load(std::memory_order_acquire) < 2) {
+            std::this_thread::yield();
+        }
+        release.store(true, std::memory_order_release);
+    });
+    IRJob::parallelFor(0, kChunkCount, 1, body);
+    releaser.join();
+
+    for (int i = 0; i < static_cast<int>(samples.size()); ++i) {
+        EXPECT_GE(samples[i], 0) << "sample " << i << " below range";
+        EXPECT_LE(samples[i], 1000) << "sample " << i << " above range";
+    }
+    EXPECT_NE(workerBitmask.load() & ~1, 0)
+        << "expected at least one non-main worker bit set; mask=" << workerBitmask.load();
 }
 
 TEST(IRJobManagerTest, ManagerClearsGlobalPointerOnDestruction) {

--- a/test/system/system_concurrency_test.cpp
+++ b/test/system/system_concurrency_test.cpp
@@ -107,19 +107,34 @@ TEST(SystemConcurrencyValidator, PerEntityIdFormRejectedWithoutParallelSafe) {
 }
 
 TEST(SystemConcurrencyValidator, PerEntityIdFormAcceptedWithParallelSafe) {
-    // Direct SystemAccess construction sidesteps a known T-221 trait
-    // limitation: `deriveAccessFromSignature` cannot derive
-    // `usesEntityId_` AND `parallelSafe_` from the SAME call when
-    // tags share the Components pack, because `InvocableWithEntityId`
-    // probes invocability with the tag types in argument position.
-    // The validator's predicate is the surface under test here — what
-    // it does with a SystemAccess that has BOTH flags set — not the
-    // trait's signature-detection-through-tags surface. See T-221
-    // follow-up filed against #1068 for the trait fix.
-    SystemAccess access{};
-    access.usesEntityId_ = true;
-    access.parallelSafe_ = true;
+    // Combining EntityId + ParallelSafe in the Components pack must
+    // derive BOTH flags — the trait filters tag types out of the
+    // signature probes (T-328 sub-task D), so the pack mixing a real
+    // tick signature with markers like `ParallelSafe` no longer
+    // suppresses `usesEntityId_`.
+    auto access =
+        deriveAccessFromSignature<void(IREntity::EntityId &, C_VelA &), C_VelA, ParallelSafe>();
+
+    EXPECT_TRUE(access.usesEntityId_);
+    EXPECT_TRUE(access.parallelSafe_);
     EXPECT_TRUE(isParallelForAcceptable(Concurrency::PARALLEL_FOR, access));
+}
+
+TEST(SystemAccessTagFilter, EntityIdAndMainThreadComposeWithSignatureProbe) {
+    // The signature probes used to fail when tag types appeared in the
+    // Components pack alongside a real `EntityId`-aware tick signature.
+    // Sub-task D filters tags before probing; this asserts the combined
+    // derivation now returns the expected flags from a single call.
+    auto access = deriveAccessFromSignature<
+        void(IREntity::EntityId &, C_VelA &),
+        C_VelA,
+        ParallelSafe,
+        MainThread>();
+
+    EXPECT_TRUE(access.usesEntityId_);
+    EXPECT_FALSE(access.isBatchForm_);
+    EXPECT_TRUE(access.parallelSafe_);
+    EXPECT_TRUE(access.mainThreadOnly_);
 }
 
 TEST(SystemConcurrencyValidator, BatchFormRejected) {


### PR DESCRIPTION
Stacked on: https://github.com/jakildev/IrredenEngine/pull/1097

## Summary
T-222 Phase 2 landed PARALLEL_FOR + the registration-time validator + one POC port (VELOCITY_3D). T-328 closes the four follow-ups #1069 / #1096 deferred:

- **A. Thread-safe IRMath random.** `randomFloat/Int/Bool` route through a per-thread `std::mt19937` owned by `engine/math/`. `IRJobs::JobManager` seeds the main thread and each worker from its enkiTS id at thread-startup; `IRJobs::workerRng()` is a forwarder so `IRMath::random*` and `IRJobs::workerRng()` share one mt19937 per OS thread. Concurrent calls from worker bodies stop racing on global `rand()` state.
- **B. ANIMATION_COLOR off function-local statics.** The two colorTrack / clip caches move to member fields on `System<ANIMATION_COLOR>`, with `tick` / `endTick` as named member functions via `registerSystem<N, Cs...>`. Helper lambdas fold into static member helpers; `std::min / std::max / std::clamp` swap for IRMath equivalents per cpp-math.md.
- **C. POC ports complete.** `VELOCITY_DRAG` opts in to `kConcurrency = PARALLEL_FOR` (per-row body, thread-safe IRMath::randomFloat post-(A), no foreign-entity lookups). `ANIMATION_COLOR` stays SERIAL with `IR_ASSERT_MAIN_THREAD` — the body still reads the active clip's components through `getComponentOptional` on a foreign entity (re-evaluate after T-225 lands the thread-safe lookup API).
- **D. SystemAccess tag-shadow fix.** `deriveAccessFromSignature` filters tag types out of the Components pack before probing `InvocableWithEntityId` / `InvocableWithNodeVectors`, so a pack mixing `EntityId + ParallelSafe + components` no longer silently drops `usesEntityId_`. The T-222 validator workaround in `system_concurrency_test.cpp` is replaced with a real `deriveAccessFromSignature` call; a new `SystemAccessTagFilter` test pins the multi-tag composition.

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean on macos-debug
- [x] `fleet-build --target IrredenEngineTest` clean on macos-debug
- [x] `fleet-run IrredenEngineTest` — 908/908 tests pass, including the new `IRJobsFixture.IRMathRandomFromWorkersDoesNotRace` (workers actually run via the barrier pattern), `IRJobsFixture.IRMathThreadRngSharesStorageWithIRJobsWorkerRng`, `SystemConcurrencyValidator.PerEntityIdFormAcceptedWithParallelSafe` (now derives via signature instead of direct construction), and `SystemAccessTagFilter.EntityIdAndMainThreadComposeWithSignatureProbe`
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — 7/7 captured cleanly (no render code touched)
- [ ] Linux smoke deferred — stacked on #1097 which carries `fleet:needs-linux-smoke`

## Notes
`.claude/rules/cpp-systems.md` still lists `system_animation_color.hpp:25-26` in its live deviations block — that file is agent-loaded config and outside this worker's edit scope. Worth a queue-manager pass to drop that entry once this lands.

Closes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)