### PR TITLE
T-331: docs: acquire-late, release-early lock rule in worker-role docs

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -18,6 +18,10 @@ See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE
 
 See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
+## Resource coordination
+
+See [docs/agents/FLEET.md § Resource coordination](../../docs/agents/FLEET.md#resource-coordination) for the acquire-late, release-early lock-discipline rule.
+
 ## Responsibilities
 
 - Core engine architecture: ECS design, ownership and lifetime rules,

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -28,6 +28,10 @@ See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE
 
 See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
+## Resource coordination
+
+See [docs/agents/FLEET.md § Resource coordination](../../docs/agents/FLEET.md#resource-coordination) for the acquire-late, release-early lock-discipline rule.
+
 ## Exit protocol
 
 See [docs/agents/FLEET-RUNTIME.md § Exit protocol](../../docs/agents/FLEET-RUNTIME.md#exit-protocol--transient-roles)

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -18,6 +18,10 @@ See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE
 
 See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
 
+## Resource coordination
+
+See [docs/agents/FLEET.md § Resource coordination](../../docs/agents/FLEET.md#resource-coordination) for the acquire-late, release-early lock-discipline rule.
+
 ## Exit protocol
 
 See [docs/agents/FLEET-RUNTIME.md § Exit protocol](../../docs/agents/FLEET-RUNTIME.md#exit-protocol--transient-roles)

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -42,14 +42,33 @@ it in a dedicated PR, not to work around it.
 
 In all three cases:
 
-- **Each worktree has its own build tree.** `fleet-build` auto-detects
-  the worktree root (`git rev-parse --show-toplevel`) and uses
-  `<worktree>/build/`. If the build hasn't been configured yet,
-  `fleet-build` runs `cmake --preset` automatically. Agents edit
-  files in their own worktree and build there — no need to touch the
-  main clone.
+- **Each worktree has its own build tree.** `ir-build` (and the legacy
+  `fleet-build` shim) auto-detects the worktree root
+  (`git rev-parse --show-toplevel`) and uses `<worktree>/build/`. If
+  the build hasn't been configured yet, `ir-build` runs `cmake
+  --preset` automatically. Agents edit files in their own worktree and
+  build there — no need to touch the main clone.
 - `CMAKE_CXX_STANDARD` is **23**; your compiler must support it.
   (gcc ≥ 13 on Linux/WSL, gcc ≥ 13 via MSYS2 on Windows.)
+
+### `ir-build` / `ir-run` (canonical) vs `fleet-build` / `fleet-run` (aliases)
+
+The canonical build/run wrappers live at `engine/tools/bin/ir-build`
+and `engine/tools/bin/ir-run` — they coordinate the same machine
+across the fleet, a solo dev, and CI, so the canonical home is
+engine-tools, not fleet. `scripts/fleet/fleet-build` and
+`scripts/fleet/fleet-run` are one-line shims that `exec` into the
+canonical names; every existing invocation continues to work.
+
+`ir-build` wraps `cmake --build` in `ir-acquire cpu N`, and `ir-run`
+wraps `--auto-screenshot` runs in `ir-acquire gpu` (and
+`--auto-profile` in `ir-acquire benchmark`). Two parallel fleet
+workers therefore serialize on the configured CPU budget or split it
+in half (`IR_FLEET_WORKERS=2` → each build caps at `budget/2` cores)
+without any per-call accounting.
+
+Use whichever name you prefer; the rest of this doc mixes them and
+both keep working.
 
 ---
 

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -305,6 +305,30 @@ The skill drives any creation that supports `--auto-screenshot` (today:
 SDF shapes, lighting, and backend parity. See `engine/render/CLAUDE.md`
 "Verifying render changes" for the exceptions list.
 
+### Resource coordination
+
+`ir-acquire` gates CPU-heavy builds and GPU-heavy bench runs so parallel
+fleet workers don't saturate the machine. The rule for holding that lock:
+
+**Acquire late, release early.** Acquire a lock immediately before the
+operation that needs it and release immediately after. Never hold a lock
+across "decide what to do next," "draft a comment," or "read review
+feedback." Idle reasoning time should never block another worker's build.
+
+Examples:
+
+- A **build** step acquires the cpu lock for exactly the cmake invocation
+  (via `exec ir-acquire cpu … -- cmake --build …`) and releases on exit.
+  The lock is NOT held during the simplify pass, the commit, or the PR
+  comment that follows.
+- A **perf measurement** holds the perf lock for the perf-grid run only
+  — not for the `optimize` analysis or `simplify` pass that follows.
+  Claim → measure → release; iterate without the lock; reclaim only for
+  the next measurement.
+
+This applies to every role that calls `ir-build`, `ir-run`, or any other
+tool that wraps `ir-acquire`.
+
 ---
 
 ## Stacked PRs

--- a/engine/tools/README.md
+++ b/engine/tools/README.md
@@ -12,17 +12,24 @@ primitives and host probe they will sit on top of.
 
 ## Status
 
-Sub-task 1 of issue #1074 (T-318). Lands:
+Sub-tasks 1–2 of issue #1074 (T-318, T-329). Lands:
 
 - `ir-host-probe` — deterministic hardware fingerprint
 - `ir-acquire` — CPU / GPU / perf lock primitives + `benchmark` canned mode
+- `ir-build` — cmake wrapper, wraps the build in `ir-acquire cpu`
+- `ir-run` — exe runner, verb-conditional `ir-acquire` (`gpu` for
+  `--auto-screenshot`, `benchmark` for `--auto-profile`)
 - shared library (`lib/concurrency_helpers.sh`) and engine defaults
   (`concurrency.toml`)
 - `test/tools/concurrency_test.sh` / `test/tools/calibration_test.sh`
 
-Sub-tasks 2–4 (`ir-build` / `ir-run` migration; `ir-perf-grid` +
-fingerprinted baselines; doc-only worker-role updates) are split into
-follow-up issues per the parent issue's "Suggested PR sequence".
+`scripts/fleet/fleet-build` and `scripts/fleet/fleet-run` are one-line
+shims that exec into `ir-build` / `ir-run`. Old invocations continue to
+work; agents need not rewrite call sites.
+
+Sub-tasks 3–4 (`ir-perf-grid` + fingerprinted baselines; doc-only
+worker-role updates) are split into follow-up issues per the parent
+issue's "Suggested PR sequence".
 
 ## Inventory
 
@@ -30,6 +37,8 @@ follow-up issues per the parent issue's "Suggested PR sequence".
 |---|---|
 | `bin/ir-host-probe` | Print this host's JSON fingerprint. Cached at `$XDG_CACHE_HOME/irreden/host-fingerprint.json`. |
 | `bin/ir-acquire` | Acquire CPU slots, GPU, perf, or all three (`benchmark`). Releases on command exit. |
+| `bin/ir-build` | `cmake --build` wrapper, holds `ir-acquire cpu` for the build window. Each worktree builds into its own `build/`. |
+| `bin/ir-run` | Run a built executable from its own directory; wraps `--auto-screenshot` in `ir-acquire gpu` and `--auto-profile` in `ir-acquire benchmark`. |
 | `lib/concurrency_helpers.sh` | Sourced by `bin/ir-*`. Lock primitives + 3-layer config resolver. |
 | `py/ir_hardware_probe.py` | Python module called by `ir-host-probe`. Linux + macOS. |
 | `concurrency.toml` | Committed engine defaults — first layer of the three-layer config. |

--- a/engine/tools/bin/ir-build
+++ b/engine/tools/bin/ir-build
@@ -93,6 +93,8 @@ while (( i <= nargs )); do
                 val="${!next}"
                 user_jobs="$val"
                 i=$next
+            else
+                echo "ir-build: -j requires a value; using default" >&2
             fi
             ;;
         -j*)

--- a/engine/tools/bin/ir-build
+++ b/engine/tools/bin/ir-build
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# ir-build — cmake --build wrapper with auto-parallelism, worktree
+# detection, and ir-acquire cpu coordination.
+#
+# Removes the need for agents to embed $(nproc) or $(sysctl -n hw.ncpu)
+# in their Bash calls, which triggers Claude Code's command_substitution
+# security gate.
+#
+# The cmake --build invocation is wrapped in `ir-acquire cpu <jobs>`,
+# holding N CPU slots out of the engine-level budget (ir_cpu_budget)
+# for the duration of the build. Two parallel fleet workers serialize
+# on the configured CPU budget instead of fighting over the same cores.
+#
+# Auto-detects the *invoker's* git worktree root (not this script's
+# checkout) and builds into <worktree>/build/. Each worktree gets its
+# own build tree — no conflicts between parallel agents. If the build
+# tree hasn't been configured yet, ir-build runs cmake --preset
+# automatically.
+#
+# Usage:
+#   ir-build --target IRShapeDebug
+#   ir-build --target IRCreationDefault
+#   ir-build --target IrredenEngineTest -- -j4   # override parallelism
+#
+# All arguments are forwarded to `cmake --build`. If no -j flag is
+# provided, one is injected automatically using ir_per_build_max
+# (budget/workers floor, min 1).
+#
+# Source of truth: engine/tools/bin/ir-build in the engine repo.
+# Installed to ~/bin/ir-build (as a symlink) by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+# Walk through symlinks to the real script location so we can locate
+# the helpers library + ir-acquire sibling regardless of how ir-build
+# was invoked (direct, ~/bin symlink, or via the fleet-build shim).
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"; done
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+HELPERS="$SCRIPT_DIR/../lib/concurrency_helpers.sh"
+IR_ACQUIRE="$SCRIPT_DIR/ir-acquire"
+
+if [[ ! -f "$HELPERS" ]]; then
+    echo "ir-build: missing $HELPERS" >&2
+    exit 1
+fi
+if [[ ! -x "$IR_ACQUIRE" ]]; then
+    echo "ir-build: missing or non-executable $IR_ACQUIRE" >&2
+    exit 1
+fi
+# shellcheck source=../lib/concurrency_helpers.sh
+source "$HELPERS"
+
+# --- Build directory resolution ---
+# Priority: $IRREDEN_BUILD_DIR > <invoker-worktree-root>/build
+WORKTREE_ROOT="$(ir_worktree_root)"
+BUILD_DIR="${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}"
+
+# --- Auto-configure if the build tree doesn't exist yet ---
+if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+    case "$(uname -s)" in
+        Darwin)               PRESET="macos-debug" ;;
+        Linux)                PRESET="linux-debug" ;;
+        MINGW*|MSYS*|CYGWIN*) PRESET="windows-debug" ;;
+        *)
+            echo "ir-build: unsupported platform $(uname -s)" >&2
+            exit 1
+            ;;
+    esac
+    echo "ir-build: no build tree at $BUILD_DIR"
+    echo "ir-build: configuring with preset '$PRESET'..."
+    cmake --preset "$PRESET" -S "$WORKTREE_ROOT"
+    echo "ir-build: configure done."
+fi
+
+# --- Detect or compute -j N for cmake AND the ir-acquire cpu count ---
+#
+# If the caller passed -jN / --parallel N, that wins (we still acquire
+# the same number of CPU slots). Otherwise we default to ir_per_build_max
+# (budget/workers floor) so two parallel fleet workers each get their
+# fair share of cores without manual math.
+user_jobs=""
+forward_args=()
+i=1
+nargs=$#
+while (( i <= nargs )); do
+    arg="${!i}"
+    case "$arg" in
+        -j)
+            # -j with separate value
+            next=$(( i + 1 ))
+            if (( next <= nargs )); then
+                val="${!next}"
+                user_jobs="$val"
+                i=$next
+            fi
+            ;;
+        -j*)
+            user_jobs="${arg#-j}"
+            ;;
+        --parallel)
+            next=$(( i + 1 ))
+            if (( next <= nargs )); then
+                val="${!next}"
+                user_jobs="$val"
+                i=$next
+            fi
+            ;;
+        --parallel=*)
+            user_jobs="${arg#--parallel=}"
+            ;;
+        *)
+            forward_args+=("$arg")
+            ;;
+    esac
+    i=$(( i + 1 ))
+done
+
+if [[ -n "$user_jobs" ]]; then
+    JOBS="$user_jobs"
+else
+    JOBS="$(ir_per_build_max)"
+fi
+
+# Hand off to ir-acquire so the lock is held for exactly the cmake --build
+# call and released by ir-acquire's trap on exit (acquire-late, release-
+# early). exec replaces this process with ir-acquire, which then exec's
+# cmake — final exit status is cmake's.
+exec "$IR_ACQUIRE" cpu "$JOBS" -- cmake --build "$BUILD_DIR" -j"$JOBS" "${forward_args[@]}"

--- a/engine/tools/bin/ir-run
+++ b/engine/tools/bin/ir-run
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# ir-run — find and run a built executable, with verb-conditional
+# ir-acquire wrapping.
+#
+# Avoids the `cd <dir> && ./<exe>` pattern that triggers Claude Code's
+# compound-command security gate, and runs the executable from its
+# own directory so sibling data/, shaders/, and scripts/ are on its
+# CWD.
+#
+# The run is wrapped with ir-acquire when the program's args indicate
+# exclusive resource use:
+#   --auto-screenshot N  → ir-acquire gpu
+#   --auto-profile N     → ir-acquire benchmark (cpu(budget-1) + gpu + perf)
+#   interactive (none)   → no acquire (human-supervised)
+# Two parallel screenshot-capture runs on macOS serialize automatically,
+# and a perf measurement does not share cores with a concurrent build.
+#
+# Usage:
+#   ir-run IrredenEngineTest --gtest_brief=1
+#   ir-run IRShapeDebug
+#   ir-run --timeout 5 IRShapeDebug          # auto-kill after 5 seconds
+#   ir-run --timeout 0 IRShapeDebug          # explicit opt-out of any default
+#   ir-run --build-dir /path/to/build IrredenEngineTest
+#   ir-run --targets [--plain|--plan|--built] [--build-dir DIR]
+#
+# Fleet agents should always use --timeout for interactive (non-
+# auto-screenshot) GUI executables to avoid leaving windows open and
+# stealing focus from the human.
+#
+# Default timeout (safety net): if --timeout is not passed, the env
+# var FLEET_RUN_DEFAULT_TIMEOUT (seconds) is honored. Unset or 0 means
+# "no watchdog" (exec the binary as before). Per-invocation `--timeout
+# 0` opts out for that call when you want to run interactively under
+# a set default.
+#
+# Source of truth: engine/tools/bin/ir-run in the engine repo.
+# Installed to ~/bin/ir-run (as a symlink) by scripts/fleet/install.sh.
+
+set -euo pipefail
+
+# Walk through symlinks to the real script location so we can locate
+# the helpers library + ir-acquire sibling regardless of how ir-run
+# was invoked (direct, ~/bin symlink, or via the fleet-run shim).
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"; done
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+HELPERS="$SCRIPT_DIR/../lib/concurrency_helpers.sh"
+IR_ACQUIRE="$SCRIPT_DIR/ir-acquire"
+
+if [[ ! -f "$HELPERS" ]]; then
+    echo "ir-run: missing $HELPERS" >&2
+    exit 1
+fi
+if [[ ! -x "$IR_ACQUIRE" ]]; then
+    echo "ir-run: missing or non-executable $IR_ACQUIRE" >&2
+    exit 1
+fi
+# shellcheck source=../lib/concurrency_helpers.sh
+source "$HELPERS"
+
+BUILD_DIR=""
+TIMEOUT=""
+TIMEOUT_EXPLICIT=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build-dir)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "ir-run: --build-dir requires a directory path" >&2
+                exit 2
+            fi
+            BUILD_DIR="$2"
+            shift 2
+            ;;
+        --timeout|-t)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "ir-run: --timeout|-t requires a non-negative integer (seconds); 0 disables" >&2
+                exit 2
+            fi
+            TIMEOUT="$2"
+            TIMEOUT_EXPLICIT=1
+            shift 2
+            ;;
+        --targets)
+            shift
+            # fleet-run-targets still lives under scripts/fleet/. It uses
+            # the same worktree-root build-dir detection ir-run does, so
+            # we hand off cleanly. Resolve from the invoker's worktree
+            # (IR_ENGINE_ROOT is the script's source clone, which may be
+            # a different worktree when invoked via ~/bin symlink).
+            WORKTREE_ROOT="$(ir_worktree_root)"
+            HELPER="$WORKTREE_ROOT/scripts/fleet/fleet-run-targets"
+            if [[ ! -x "$HELPER" ]]; then
+                echo "ir-run: missing $HELPER (fleet-run-targets is currently engine-tooling-adjacent; expected under scripts/fleet/)" >&2
+                exit 1
+            fi
+            if [[ -n "$BUILD_DIR" ]]; then
+                exec "$HELPER" --build-dir "$BUILD_DIR" "$@"
+            fi
+            exec "$HELPER" "$@"
+            ;;
+        --help|-h)
+            cat <<'USAGE'
+usage: ir-run [options] <executable-name> [args...]
+   or: ir-run [options] --targets [list-options...]
+
+Run mode
+  Finds <executable-name> anywhere under the build tree, cd's to that
+  executable's directory, and runs it so sibling data/, shaders/, and
+  scripts/ are on the process cwd.
+
+  Arguments after <executable-name> are passed through to the program.
+
+  Verb-conditional ir-acquire wrapping:
+    --auto-screenshot N  → wrapped in ir-acquire gpu
+    --auto-profile N     → wrapped in ir-acquire benchmark (cpu+gpu+perf)
+    no exclusive verb    → no acquire (interactive / unit-test mode)
+
+  Options (run mode):
+    --build-dir <dir>   CMake build directory (must contain the built binary).
+                        Default: see "Build directory" below.
+    --timeout N | -t N  Run under a watchdog: kill after N whole seconds.
+                        Exit 0 if still running at timeout (treat as healthy
+                        for smoke tests). Exit 1 if the process died early
+                        with non-zero status. `--timeout 0` is the explicit
+                        opt-out (exec the binary, no watchdog). Omit for the
+                        FLEET_RUN_DEFAULT_TIMEOUT default if set, else exec.
+
+  Env vars:
+    FLEET_RUN_DEFAULT_TIMEOUT   Default for --timeout when not passed.
+                                Unset or 0 = no watchdog (historic behavior).
+                                Set in ~/.fleet/fleet-up.conf or shell init
+                                to catch fleet agents that forgot --timeout.
+
+  Build directory (when not using --build-dir):
+    1. $IRREDEN_BUILD_DIR if set
+    2. <git-worktree-root>/build from git rev-parse
+    3. $IR_ENGINE_ROOT/build if not in a git worktree
+
+Target listing mode
+  ir-run --targets [list-options...]
+
+  Delegates to scripts/fleet/fleet-run-targets (same as running that
+  script). Full option reference is printed below.
+
+Compat
+  scripts/fleet/fleet-run is a one-line shim that execs ir-run; old
+  fleet-run invocations continue to work unchanged.
+
+Other fleet tools (build, tmux fleet, claims, …): fleet-help
+
+USAGE
+            WORKTREE_ROOT="$(ir_worktree_root)"
+            HELPER="$WORKTREE_ROOT/scripts/fleet/fleet-run-targets"
+            if [[ -f "$HELPER" ]]; then
+                echo "---------- ir-run --targets (full options) ----------"
+                bash "$HELPER" --help
+            else
+                echo "ir-run: warning: $HELPER not found; target-listing help omitted." >&2
+            fi
+            exit 0
+            ;;
+        --) shift; break ;;
+        -*) echo "ir-run: unknown option '$1' (try ir-run --help)" >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
+if [[ $# -eq 0 ]]; then
+    echo "usage: ir-run [--build-dir <dir>] [--timeout <secs>] <executable-name> [args...]" >&2
+    echo "       ir-run --targets [--plain | --plan | --built] [--build-dir <dir>]" >&2
+    echo "       ir-run --help" >&2
+    exit 2
+fi
+
+# Apply FLEET_RUN_DEFAULT_TIMEOUT when --timeout was not passed. 0 (or
+# unset) means "no watchdog" — preserves the historic behavior of
+# `ir-run <exe>` exec'ing the binary in the current shell.
+if (( ! TIMEOUT_EXPLICIT )) && [[ -n "${FLEET_RUN_DEFAULT_TIMEOUT:-}" ]]; then
+    TIMEOUT="$FLEET_RUN_DEFAULT_TIMEOUT"
+fi
+
+if [[ -n "$TIMEOUT" ]]; then
+    if ! [[ "$TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]]; then
+        echo "ir-run: timeout must be a non-negative integer (seconds), got '$TIMEOUT'" >&2
+        exit 2
+    fi
+    if [[ "$TIMEOUT" == "0" ]]; then
+        TIMEOUT=""
+    fi
+fi
+
+EXE_NAME="$1"
+shift
+
+# Remaining "$@" is the program's args. Detect --auto-screenshot or
+# --auto-profile so we know which ir-acquire verb to wrap with.
+acquire_verb=""
+for arg in "$@"; do
+    case "$arg" in
+        --auto-screenshot) acquire_verb="gpu" ;;
+        --auto-profile)    acquire_verb="benchmark" ;;
+    esac
+done
+
+# Default build dir: invoker's worktree, not the script-source clone.
+if [[ -z "$BUILD_DIR" ]]; then
+    WORKTREE_ROOT="$(ir_worktree_root)"
+    BUILD_DIR="${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}"
+fi
+
+if [[ ! -d "$BUILD_DIR" ]]; then
+    echo "ir-run: build directory $BUILD_DIR does not exist." >&2
+    echo "        run 'ir-build --target $EXE_NAME' first." >&2
+    exit 1
+fi
+
+# Find the executable in the build tree.
+EXE_PATH=$(find "$BUILD_DIR" -name "$EXE_NAME" -type f -perm -u=x 2>/dev/null | head -1)
+
+if [[ -z "$EXE_PATH" ]]; then
+    echo "ir-run: could not find executable '$EXE_NAME' in $BUILD_DIR" >&2
+    echo "        build it first: ir-build --target $EXE_NAME" >&2
+    exit 1
+fi
+
+EXE_DIR=$(dirname "$EXE_PATH")
+
+# Pre-compose the ir-acquire prefix (empty when no exclusive verb).
+# Using an array preserves quoting around exe args containing spaces.
+# gpu and benchmark are the only verbs ir-run dispatches; both take no
+# args other than the wrapped command.
+acquire_prefix=()
+if [[ -n "$acquire_verb" ]]; then
+    acquire_prefix=("$IR_ACQUIRE" "$acquire_verb" "--")
+fi
+
+# --- No timeout: interactive mode, exec replaces this process --------------
+if [[ -z "$TIMEOUT" ]]; then
+    if (( ${#acquire_prefix[@]} > 0 )); then
+        echo "ir-run: ${acquire_prefix[*]} $EXE_PATH $*"
+    else
+        echo "ir-run: $EXE_PATH $*"
+    fi
+    cd "$EXE_DIR"
+    exec "${acquire_prefix[@]}" "./$EXE_NAME" "$@"
+fi
+
+# --- Timeout mode: launch, wait, kill, report ------------------------------
+if (( ${#acquire_prefix[@]} > 0 )); then
+    echo "ir-run: ${acquire_prefix[*]} $EXE_PATH $* (timeout: ${TIMEOUT}s)"
+else
+    echo "ir-run: $EXE_PATH $* (timeout: ${TIMEOUT}s)"
+fi
+cd "$EXE_DIR"
+"${acquire_prefix[@]}" "./$EXE_NAME" "$@" &
+PID=$!
+
+# Wait for either the timeout or the process to exit early (crash).
+elapsed=0
+while [[ $elapsed -lt $TIMEOUT ]]; do
+    if ! kill -0 "$PID" 2>/dev/null; then
+        # Process exited before timeout — check if it crashed.
+        exit_code=0
+        wait "$PID" 2>/dev/null || exit_code=$?
+        if [[ $exit_code -eq 0 ]]; then
+            echo "ir-run: $EXE_NAME exited cleanly after ${elapsed}s"
+            exit 0
+        else
+            echo "ir-run: $EXE_NAME crashed after ${elapsed}s (exit code $exit_code)"
+            exit 1
+        fi
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+done
+
+# Process survived the timeout — it's healthy. Kill it.
+kill "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null || true
+echo "ir-run: $EXE_NAME ran for ${TIMEOUT}s without crashing — killed"
+exit 0

--- a/engine/tools/bin/ir-run
+++ b/engine/tools/bin/ir-run
@@ -215,7 +215,7 @@ if [[ ! -d "$BUILD_DIR" ]]; then
 fi
 
 # Find the executable in the build tree.
-EXE_PATH=$(find "$BUILD_DIR" -name "$EXE_NAME" -type f -perm -u=x 2>/dev/null | head -1)
+EXE_PATH=$(find "$BUILD_DIR" -maxdepth 5 -name "$EXE_NAME" -type f -perm -u=x 2>/dev/null | head -1)
 
 if [[ -z "$EXE_PATH" ]]; then
     echo "ir-run: could not find executable '$EXE_NAME' in $BUILD_DIR" >&2

--- a/engine/tools/lib/concurrency_helpers.sh
+++ b/engine/tools/lib/concurrency_helpers.sh
@@ -46,6 +46,28 @@ IR_TOOLS_DIR="$IR_ENGINE_ROOT/engine/tools"
 IR_DEFAULTS_TOML="$IR_TOOLS_DIR/concurrency.toml"
 IR_HOST_TOML="${IR_HOST_TOML:-$HOME/.config/irreden/host.toml}"
 
+# ir_worktree_root — the *invoker's* worktree, distinct from IR_ENGINE_ROOT
+# (which resolves to the script's own checkout via symlink walk-up). The
+# distinction matters because ir-build / ir-run are typically symlinked from
+# ~/bin/ into the main clone, but each fleet worktree builds into its own
+# <worktree>/build/. We want the build dir to follow the cwd, not the script
+# source.
+ir_worktree_root() {
+    local root
+    root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$IR_ENGINE_ROOT")"
+    # In a nested worktree (.claude/worktrees/<name>), the worktree's own
+    # CMakePresets.json sits at the root. Walk up only when it's missing
+    # (older checkouts, ad-hoc layouts).
+    if [[ ! -f "$root/CMakePresets.json" ]]; then
+        if [[ -f "$root/../../CMakePresets.json" ]]; then
+            root="$(cd "$root/../.." && pwd)"
+        elif [[ -f "$root/../CMakePresets.json" ]]; then
+            root="$(cd "$root/.." && pwd)"
+        fi
+    fi
+    echo "$root"
+}
+
 # Lock dir lives in a runtime-temp location so it survives across shells but
 # clears on reboot. XDG_RUNTIME_DIR is Linux-only; macOS doesn't set it.
 if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then

--- a/scripts/fleet/fleet-build
+++ b/scripts/fleet/fleet-build
@@ -1,76 +1,34 @@
 #!/usr/bin/env bash
-# fleet-build — cmake --build wrapper with auto-parallelism and worktree detection.
+# fleet-build — backwards-compatible shim for ir-build.
 #
-# Removes the need for agents to embed $(nproc) or $(sysctl -n hw.ncpu)
-# in their Bash calls, which triggers Claude Code's command_substitution
-# security gate and blocks unattended operation.
+# Execs ir-build (engine/tools/bin/ir-build) with the same arguments.
+# The worktree-aware build dir, auto-configure, parallelism injection,
+# and ir-acquire cpu lock wrapping all live in ir-build.
 #
-# Auto-detects the current git worktree root and uses <root>/build as
-# the build directory. Each worktree gets its own build tree — no more
-# conflicts between parallel agents. If the build tree hasn't been
-# configured yet, fleet-build runs cmake --preset automatically.
-#
-# Usage:
-#   fleet-build --target IRShapeDebug
-#   fleet-build --target IRCreationDefault
-#   fleet-build --target IrredenEngineTest -- -j4   # override parallelism
-#
-# All arguments are forwarded to `cmake --build`. If no -j flag is
-# provided, one is injected automatically using the detected CPU count.
-#
-# Source of truth: scripts/fleet/fleet-build in the engine repo.
+# Source of truth: scripts/fleet/fleet-build in the engine repo (shim).
 # Installed to ~/bin/fleet-build (as a symlink) by scripts/fleet/install.sh.
+# The real implementation lives at engine/tools/bin/ir-build, which is
+# also symlinked into ~/bin/.
 
 set -euo pipefail
 
-# --- Shared helpers (detect_engine_root) ---
-_FLEET_COMMON_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fleet-common.sh"
-if [[ ! -f "$_FLEET_COMMON_SH" ]]; then
-    echo "fleet-build: missing fleet-common.sh (expected next to fleet-build)" >&2
-    exit 1
-fi
-# shellcheck source=fleet-common.sh
-source "$_FLEET_COMMON_SH"
+# Resolve ir-build through the symlinked-script discipline used by every
+# other ir-* tool. Prefer the source tree adjacent to this shim (works
+# from a worktree before install.sh runs); fall back to PATH lookup.
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"; done
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+IR_BUILD="$SCRIPT_DIR/../../engine/tools/bin/ir-build"
 
-# --- Build directory resolution ---
-# Priority: $IRREDEN_BUILD_DIR > <worktree-root>/build > ~/src/IrredenEngine/build
-WORKTREE_ROOT=$(detect_engine_root)
-BUILD_DIR="${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}"
-
-# --- Auto-configure if the build tree doesn't exist yet ---
-if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
-    case "$(uname -s)" in
-        Darwin)          PRESET="macos-debug" ;;
-        Linux)           PRESET="linux-debug" ;;
-        MINGW*|MSYS*|CYGWIN*) PRESET="windows-debug" ;;
-        *)
-            echo "fleet-build: unsupported platform $(uname -s)" >&2
-            exit 1
-            ;;
-    esac
-    echo "fleet-build: no build tree at $BUILD_DIR"
-    echo "fleet-build: configuring with preset '$PRESET'..."
-    cmake --preset "$PRESET" -S "$WORKTREE_ROOT"
-    echo "fleet-build: configure done."
+if [[ -x "$IR_BUILD" ]]; then
+    exec "$IR_BUILD" "$@"
 fi
 
-# --- Auto-detect CPU count if no -j flag was passed ---
-has_j_flag=false
-for arg in "$@"; do
-    case "$arg" in
-        -j*|--parallel*) has_j_flag=true ;;
-    esac
-done
-
-if $has_j_flag; then
-    exec cmake --build "$BUILD_DIR" "$@"
-else
-    if command -v nproc >/dev/null 2>&1; then
-        JOBS=$(nproc)
-    elif command -v sysctl >/dev/null 2>&1; then
-        JOBS=$(sysctl -n hw.ncpu)
-    else
-        JOBS=4
-    fi
-    exec cmake --build "$BUILD_DIR" -j"$JOBS" "$@"
+# Fall back to PATH-resolved ir-build (~/bin/ir-build after install.sh).
+if command -v ir-build >/dev/null 2>&1; then
+    exec ir-build "$@"
 fi
+
+echo "fleet-build: cannot find ir-build (expected at $IR_BUILD or on PATH)" >&2
+echo "             run scripts/fleet/install.sh to set up the symlinks" >&2
+exit 1

--- a/scripts/fleet/fleet-run
+++ b/scripts/fleet/fleet-run
@@ -1,224 +1,36 @@
 #!/usr/bin/env bash
-# fleet-run — find and run a built executable from its own directory.
+# fleet-run — backwards-compatible shim for ir-run.
 #
-# Avoids the `cd <dir> && ./<exe>` pattern that triggers Claude Code's
-# compound-command security gate and blocks unattended operation.
+# Execs ir-run (engine/tools/bin/ir-run) with the same arguments.
+# The worktree-aware build dir, exe lookup, --timeout watchdog,
+# --targets delegation, and verb-conditional ir-acquire wrapping
+# (--auto-screenshot → gpu, --auto-profile → benchmark) all live
+# in ir-run.
 #
-# The executable runs from its own directory so sibling data/, shaders/,
-# and scripts/ directories are on its CWD (required by most creations).
-#
-# Usage:
-#   fleet-run IrredenEngineTest --gtest_brief=1
-#   fleet-run IRShapeDebug
-#   fleet-run --timeout 5 IRShapeDebug       # auto-kill after 5 seconds
-#   fleet-run --timeout 0 IRShapeDebug       # explicit opt-out of any default
-#   fleet-run --build-dir /path/to/build IrredenEngineTest
-#   fleet-run --targets [--plain|--plan|--built] [--build-dir DIR]
-#
-# Fleet agents should always use --timeout for GUI executables to avoid
-# leaving windows open and stealing focus from the human.
-#
-# Default timeout (safety net): if --timeout is not passed, the env var
-# FLEET_RUN_DEFAULT_TIMEOUT (seconds) is honored. Unset or 0 means "no
-# watchdog" (exec the binary as before). Set in ~/.fleet/fleet-up.conf or
-# your shell init to catch agents that forgot to pass --timeout — observed
-# failure mode is stuck demo windows lingering on the WSL host after a
-# fleet iteration crashed. Per-invocation `--timeout 0` opts out for that
-# call when you want to run interactively under a set default.
-#
-# Source of truth: scripts/fleet/fleet-run in the engine repo.
+# Source of truth: scripts/fleet/fleet-run in the engine repo (shim).
 # Installed to ~/bin/fleet-run (as a symlink) by scripts/fleet/install.sh.
+# The real implementation lives at engine/tools/bin/ir-run, which is
+# also symlinked into ~/bin/.
 
 set -euo pipefail
 
-# --- Shared helpers (detect_engine_root) ---
-_FLEET_COMMON_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fleet-common.sh"
-if [[ ! -f "$_FLEET_COMMON_SH" ]]; then
-    echo "fleet-run: missing fleet-common.sh (expected next to fleet-run)" >&2
-    exit 1
-fi
-# shellcheck source=fleet-common.sh
-source "$_FLEET_COMMON_SH"
+# Resolve ir-run through the symlinked-script discipline used by every
+# other ir-* tool. Prefer the source tree adjacent to this shim (works
+# from a worktree before install.sh runs); fall back to PATH lookup.
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"; done
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+IR_RUN="$SCRIPT_DIR/../../engine/tools/bin/ir-run"
 
-BUILD_DIR=""
-TIMEOUT=""
-TIMEOUT_EXPLICIT=0
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --build-dir)
-            if [[ $# -lt 2 || "$2" == -* ]]; then
-                echo "fleet-run: --build-dir requires a directory path" >&2
-                exit 2
-            fi
-            BUILD_DIR="$2"
-            shift 2
-            ;;
-        --timeout|-t)
-            if [[ $# -lt 2 || "$2" == -* ]]; then
-                echo "fleet-run: --timeout|-t requires a non-negative integer (seconds); 0 disables" >&2
-                exit 2
-            fi
-            TIMEOUT="$2"
-            TIMEOUT_EXPLICIT=1
-            shift 2
-            ;;
-        --targets)
-            shift
-            SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-            HELPER="$SCRIPT_DIR/fleet-run-targets"
-            if [[ ! -f "$HELPER" ]]; then
-                echo "fleet-run: missing $HELPER (expected next to fleet-run in the repo)" >&2
-                exit 1
-            fi
-            if [[ -n "$BUILD_DIR" ]]; then
-                exec "$HELPER" --build-dir "$BUILD_DIR" "$@"
-            fi
-            exec "$HELPER" "$@"
-            ;;
-        --help|-h)
-            cat <<'USAGE'
-usage: fleet-run [options] <executable-name> [args...]
-   or: fleet-run [options] --targets [list-options...]
-
-Run mode
-  Finds <executable-name> anywhere under the build tree, cd's to that
-  executable's directory, and runs it so sibling data/, shaders/, and
-  scripts/ are on the process cwd.
-
-  Arguments after <executable-name> are passed through to the program.
-
-  Options (run mode):
-    --build-dir <dir>   CMake build directory (must contain the built binary).
-                        Default: see "Build directory" below.
-    --timeout N | -t N  Run under a watchdog: kill after N whole seconds.
-                        Exit 0 if still running at timeout (treat as healthy
-                        for smoke tests). Exit 1 if the process died early
-                        with non-zero status. `--timeout 0` is the explicit
-                        opt-out (exec the binary, no watchdog). Omit for the
-                        FLEET_RUN_DEFAULT_TIMEOUT default if set, else exec.
-
-  Env vars:
-    FLEET_RUN_DEFAULT_TIMEOUT   Default for --timeout when not passed.
-                                Unset or 0 = no watchdog (historic behavior).
-                                Set in ~/.fleet/fleet-up.conf or shell init
-                                to catch fleet agents that forgot --timeout.
-
-  Build directory (when not using --build-dir):
-    1. $IRREDEN_BUILD_DIR if set
-    2. <git-worktree-root>/build from git rev-parse
-    3. $HOME/src/IrredenEngine/build if not in a git worktree
-
-Target listing mode
-  fleet-run --targets [list-options...]
-
-  Delegates to scripts/fleet/fleet-run-targets (same as running that script).
-  Full option reference is printed below.
-
-Other fleet tools (build, tmux fleet, claims, …): fleet-help
-
-USAGE
-            HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fleet-run-targets"
-            if [[ -f "$HELPER" ]]; then
-                echo "---------- fleet-run --targets (full options) ----------"
-                bash "$HELPER" --help
-            else
-                echo "fleet-run: warning: $HELPER not found; target-listing help omitted." >&2
-            fi
-            exit 0
-            ;;
-        --) shift; break ;;
-        -*) echo "fleet-run: unknown option '$1' (try fleet-run --help)" >&2; exit 2 ;;
-        *) break ;;
-    esac
-done
-
-if [[ $# -eq 0 ]]; then
-    echo "usage: fleet-run [--build-dir <dir>] [--timeout <secs>] <executable-name> [args...]" >&2
-    echo "       fleet-run --targets [--plain | --plan | --built] [--build-dir <dir>]" >&2
-    echo "       fleet-run --help" >&2
-    exit 2
+if [[ -x "$IR_RUN" ]]; then
+    exec "$IR_RUN" "$@"
 fi
 
-# Apply FLEET_RUN_DEFAULT_TIMEOUT when --timeout was not passed.
-# 0 (or unset) means "no watchdog" — preserves the historic behavior of
-# `fleet-run <exe>` exec'ing the binary in the current shell. Any
-# positive integer in the env becomes the default.
-if (( ! TIMEOUT_EXPLICIT )) && [[ -n "${FLEET_RUN_DEFAULT_TIMEOUT:-}" ]]; then
-    TIMEOUT="$FLEET_RUN_DEFAULT_TIMEOUT"
+# Fall back to PATH-resolved ir-run (~/bin/ir-run after install.sh).
+if command -v ir-run >/dev/null 2>&1; then
+    exec ir-run "$@"
 fi
 
-if [[ -n "$TIMEOUT" ]]; then
-    if ! [[ "$TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]]; then
-        echo "fleet-run: timeout must be a non-negative integer (seconds), got '$TIMEOUT'" >&2
-        exit 2
-    fi
-    # 0 = explicit no-timeout. Clear so the rest of the script treats
-    # this the same as "--timeout not passed".
-    if [[ "$TIMEOUT" == "0" ]]; then
-        TIMEOUT=""
-    fi
-fi
-
-EXE_NAME="$1"
-shift
-
-# Default build dir: same auto-detection logic as fleet-build.
-if [[ -z "$BUILD_DIR" ]]; then
-    WORKTREE_ROOT=$(detect_engine_root)
-    BUILD_DIR="${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}"
-fi
-
-if [[ ! -d "$BUILD_DIR" ]]; then
-    echo "fleet-run: build directory $BUILD_DIR does not exist." >&2
-    echo "           run 'fleet-build --target $EXE_NAME' first." >&2
-    exit 1
-fi
-
-# Find the executable in the build tree.
-EXE_PATH=$(find "$BUILD_DIR" -name "$EXE_NAME" -type f -perm -u=x 2>/dev/null | head -1)
-
-if [[ -z "$EXE_PATH" ]]; then
-    echo "fleet-run: could not find executable '$EXE_NAME' in $BUILD_DIR" >&2
-    echo "           build it first: fleet-build --target $EXE_NAME" >&2
-    exit 1
-fi
-
-EXE_DIR=$(dirname "$EXE_PATH")
-
-# --- No timeout: interactive mode, exec replaces this process --------------
-if [[ -z "$TIMEOUT" ]]; then
-    echo "fleet-run: $EXE_PATH $*"
-    cd "$EXE_DIR"
-    exec "./$EXE_NAME" "$@"
-fi
-
-# --- Timeout mode: launch, wait, kill, report ------------------------------
-echo "fleet-run: $EXE_PATH $* (timeout: ${TIMEOUT}s)"
-cd "$EXE_DIR"
-"./$EXE_NAME" "$@" &
-PID=$!
-
-# Wait for either the timeout or the process to exit early (crash).
-elapsed=0
-while [[ $elapsed -lt $TIMEOUT ]]; do
-    if ! kill -0 "$PID" 2>/dev/null; then
-        # Process exited before timeout — check if it crashed.
-        exit_code=0
-        wait "$PID" 2>/dev/null || exit_code=$?
-        if [[ $exit_code -eq 0 ]]; then
-            echo "fleet-run: $EXE_NAME exited cleanly after ${elapsed}s"
-            exit 0
-        else
-            echo "fleet-run: $EXE_NAME crashed after ${elapsed}s (exit code $exit_code)"
-            exit 1
-        fi
-    fi
-    sleep 1
-    elapsed=$((elapsed + 1))
-done
-
-# Process survived the timeout — it's healthy. Kill it.
-kill "$PID" 2>/dev/null
-wait "$PID" 2>/dev/null || true
-echo "fleet-run: $EXE_NAME ran for ${TIMEOUT}s without crashing — killed"
-exit 0
+echo "fleet-run: cannot find ir-run (expected at $IR_RUN or on PATH)" >&2
+echo "           run scripts/fleet/install.sh to set up the symlinks" >&2
+exit 1


### PR DESCRIPTION
## Summary

- Adds `### Resource coordination` section to `docs/agents/FLEET.md` with the canonical acquire-late, release-early rule for `ir-acquire` lock discipline
- Adds a one-line pointer to that section from each of the three worker role docs (`role-opus-worker`, `role-sonnet-author`, `role-opus-architect`)
- Rule lives in exactly one canonical place; role docs reference rather than duplicate

## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/1111

## Test plan

- [x] Rule in exactly one canonical location (`docs/agents/FLEET.md` § "Resource coordination")
- [x] Each of the three role docs references it via one-line pointer
- [x] No duplicated prose
- [x] `ir-perf-grid` reference removed (tool doesn't exist yet; T-330 adds it)

Closes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)