### PR TITLE
render: fix stale residualYaw comment in ir_iso_common.glsl (T-323 follow-up)

### DIFF
--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -226,8 +226,9 @@ ivec2 trixelCanvasPixelToIsoRel(
 // the camera-side split helper (engine/prefabs/irreden/render/camera.hpp); the
 // renderer uses one of four basis-vector permutations selected by an integer
 // index in [0, 3] so integer voxel positions still land on integer trixel
-// pixels post-rotation. residualYaw is consumed by a downstream screen-space
-// composite pass; these helpers ignore it.
+// pixels post-rotation. residualYaw is absorbed by faceDeform[] in the trixel
+// emit (T-293); the screen-space composite pass was retired by T-323. These
+// helpers ignore it.
 //
 // Sign convention: rotateCardinalZ is world->view = R_z(-rasterYaw) — same as
 // the continuous-yaw matrix in c_shapes_to_trixel.glsl (T-056). At


### PR DESCRIPTION
## Summary
- Fix stale comment in `engine/render/src/shaders/ir_iso_common.glsl` (line 229) that still described `residualYaw` as "consumed by a downstream screen-space composite pass" — that pass was retired by T-323
- Updated to correctly describe the current state: `residualYaw` is absorbed by `faceDeform[]` in the trixel emit (T-293), and the composite pass is gone

## Test plan
- [ ] Pure comment change — no runtime effect, no build verification needed
- [ ] `grep -n "consumed by a downstream screen-space" engine/render/src/shaders/ir_iso_common.glsl` returns no matches

Closes #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)