### PR TITLE
T-336: investigate + fix macOS demo segfault on shutdown

### DIFF
--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -238,6 +238,8 @@ class MetalRenderDevice final : public RenderDevice {
             releaseTimestampPair(pair);
         }
         m_timestamps.clear();
+        // counterSets() returns a non-owning pointer (the MTL::Device owns
+        // the set), so we clear the reference without ->release().
         m_timestampCounterSet = nullptr;
         m_supportsTimestampPairs = false;
         for (auto &[texture, buf] : m_clearSourceBuffers) {

--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -837,11 +837,24 @@ metalCurrentDepthPixelFormat(),
     std::unordered_map<MTL::Texture *, MTL::Buffer *> m_clearSourceBuffers;
 };
 
-MetalRenderDevice g_metalRenderDevice;
+// Intentionally leaked so the device state outlives all other statics.
+// Mirrors the same pattern in metal_runtime.cpp's `g_runtime()`. Prevents
+// use-after-destroy when `World`'s `RenderingResourceManager` destructs
+// its `Texture2D` resources at static-destruction time: each
+// `~MetalTexture2DImpl` calls `removeClearSourceBuffer(m_texture)`, which
+// dereferences `m_clearSourceBuffers` on this device. Static-destruction
+// order between this TU and the `inline` `g_world` in `ir_engine.hpp` is
+// implementation-defined; without the leak, the device can be destroyed
+// before the textures, and `find()` crashes on the corpse of its
+// unordered_map (T-336).
+MetalRenderDevice &metalRenderDevice() {
+    static auto *device = new MetalRenderDevice{};
+    return *device;
+}
 } // namespace
 
 void removeClearSourceBuffer(MTL::Texture *texture) {
-    g_metalRenderDevice.releaseClearSourceBuffer(texture);
+    metalRenderDevice().releaseClearSourceBuffer(texture);
 }
 
 std::unique_ptr<RenderImpl> createRenderer() {
@@ -855,7 +868,7 @@ MetalRenderImpl::MetalRenderImpl()
 }
 
 MetalRenderImpl::~MetalRenderImpl() {
-    g_metalRenderDevice.shutdown();
+    metalRenderDevice().shutdown();
     if (m_device != nullptr) {
         m_device->release();
         m_device = nullptr;
@@ -870,8 +883,8 @@ void MetalRenderImpl::init() {
     IR_ASSERT(layerPtr != nullptr, "Failed to create CAMetalLayer");
     m_layer = reinterpret_cast<CA::MetalLayer *>(layerPtr);
 
-    g_metalRenderDevice.init(m_device, m_layer);
-    setDevice(&g_metalRenderDevice);
+    metalRenderDevice().init(m_device, m_layer);
+    setDevice(&metalRenderDevice());
 
     IRWindow::getWindow().setCallbackFramebufferSize(metalCallback_framebuffer_size);
     IRE_LOG_INFO("Metal surface attached to window.");

--- a/engine/tools/bin/ir-run
+++ b/engine/tools/bin/ir-run
@@ -235,7 +235,33 @@ if [[ -n "$acquire_verb" ]]; then
 fi
 
 # --- No timeout: interactive mode, exec replaces this process --------------
+# Exception: `--auto-screenshot` is a self-terminating verb. The demo is
+# expected to call `closeWindow()` and exit 0 after its last shot — any
+# non-zero return is a crash on shutdown (e.g. T-336's Metal static-
+# destruction segfault that lands AFTER screenshots are saved). We still
+# need to surface that distinction at the script level, so swap exec for
+# a run-and-validate path when the verb is gpu/screenshot. Interactive
+# mode (no verb, no timeout) keeps the exec path so signals and stdin
+# pass straight through.
 if [[ -z "$TIMEOUT" ]]; then
+    if [[ "$acquire_verb" == "gpu" ]]; then
+        echo "ir-run: ${acquire_prefix[*]} $EXE_PATH $*"
+        cd "$EXE_DIR"
+        # Disarm `set -e` around the run so we can inspect the exit code
+        # ourselves rather than letting bash bail out on the first non-
+        # zero (which is exactly the signal we want to surface).
+        set +e
+        "${acquire_prefix[@]}" "./$EXE_NAME" "$@"
+        rc=$?
+        set -e
+        if [[ $rc -ne 0 ]]; then
+            echo "ir-run: $EXE_NAME crashed on shutdown (exit code $rc) — " \
+                 "screenshots may have been saved before the crash, but the " \
+                 "process did not exit cleanly. See engine/render/CLAUDE.md " \
+                 "and T-336 for the canonical static-destruction symptom." >&2
+        fi
+        exit "$rc"
+    fi
     if (( ${#acquire_prefix[@]} > 0 )); then
         echo "ir-run: ${acquire_prefix[*]} $EXE_PATH $*"
     else

--- a/engine/tools/lib/concurrency_helpers.sh
+++ b/engine/tools/lib/concurrency_helpers.sh
@@ -70,10 +70,13 @@ ir_worktree_root() {
 
 # Lock dir lives in a runtime-temp location so it survives across shells but
 # clears on reboot. XDG_RUNTIME_DIR is Linux-only; macOS doesn't set it.
-if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
-    IR_LOCK_ROOT="${XDG_RUNTIME_DIR}/irreden/locks"
-else
-    IR_LOCK_ROOT="/tmp/irreden-${USER:-$(id -un)}/locks"
+# A pre-set IR_LOCK_ROOT wins (used by tests to isolate from host locks).
+if [[ -z "${IR_LOCK_ROOT:-}" ]]; then
+    if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+        IR_LOCK_ROOT="${XDG_RUNTIME_DIR}/irreden/locks"
+    else
+        IR_LOCK_ROOT="/tmp/irreden-${USER:-$(id -un)}/locks"
+    fi
 fi
 IR_CACHE_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/irreden"
 

--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -211,15 +211,23 @@ def main(argv: list[str] | None = None) -> int:
     print("+ " + " ".join(run_cmd), flush=True)
     proc = subprocess.run(run_cmd, cwd=str(worktree),
                           capture_output=True, text=True)
+    # In `--auto-screenshot` mode the demo fires `closeWindow()` after the
+    # last shot and exits 0; any non-zero return is a crash (e.g. a Metal
+    # static-destruction segfault that lands AFTER the screenshots are
+    # saved, which the per-shot comparator would otherwise silently
+    # "pass" — T-336). With `--timeout`, ir-run returns 0 on timeout-kill
+    # too, so the only way we see non-zero here is a real early-exit
+    # crash. Surface the tail and let the run_crash flag block a PASS
+    # verdict below even when all shots compare clean.
+    run_crash: tuple[int, str] | None = None
     if proc.returncode != 0:
-        # Expected on timeout; also fires if the demo crashed. Surface the
-        # tail so a crash isn't hidden behind "expected N shots, got M".
         print(f"[render-verify] fleet-run exited {proc.returncode}; "
               f"tail of output follows (screenshot count will be checked "
               f"against manifest below):", file=sys.stderr)
         tail = (proc.stdout + proc.stderr).splitlines()[-40:]
         for line in tail:
             print(f"    {line}", file=sys.stderr)
+        run_crash = (proc.returncode, "\n".join(tail))
 
     captured = _collect_shots(shots_dir, len(shot_labels))
     ref_dir = demo_dir / "test" / "references" / backend
@@ -272,15 +280,22 @@ def main(argv: list[str] | None = None) -> int:
             failures.append((label, result))
 
     print()
-    if all_pass:
+    if all_pass and run_crash is None:
         print(f"[render-verify] all {len(shot_labels)} shots PASS")
         return 0
 
-    print(f"[render-verify] {len(failures)} of {len(shot_labels)} shots FAIL")
-    for label, result in failures:
-        reason = result.get("reason", "mismatch")
-        diff = result.get("diff_path", "(no diff)")
-        print(f"  - {label}: {reason}  diff={diff}")
+    if not all_pass:
+        print(f"[render-verify] {len(failures)} of {len(shot_labels)} shots FAIL")
+        for label, result in failures:
+            reason = result.get("reason", "mismatch")
+            diff = result.get("diff_path", "(no diff)")
+            print(f"  - {label}: {reason}  diff={diff}")
+
+    if run_crash is not None:
+        rc, _ = run_crash
+        print(f"[render-verify] demo crashed at shutdown (fleet-run exit={rc}); "
+              f"failing the verify run even when shots match — see tail above.",
+              file=sys.stderr)
     return 1
 
 

--- a/test/tools/ir_run_exit_code_test.sh
+++ b/test/tools/ir_run_exit_code_test.sh
@@ -22,10 +22,11 @@ BUILD_DIR="$(mktemp -d)"
 trap 'rm -rf "$BUILD_DIR"' EXIT
 
 # ir-run's --auto-screenshot detection wraps in ir-acquire gpu; that
-# requires a real lock dir. Override to a tmp dir so we don't trample
-# the user's host locks.
-export IR_ACQUIRE_LOCK_DIR
-IR_ACQUIRE_LOCK_DIR="$(mktemp -d)"
+# really takes the GPU lock. Point IR_LOCK_ROOT (read by
+# concurrency_helpers.sh) at a tmp dir so we don't trample the user's
+# host locks and parallel CI jobs don't serialize on this test.
+export IR_LOCK_ROOT
+IR_LOCK_ROOT="$(mktemp -d)"
 
 mkdir -p "$BUILD_DIR/creations/demos/clean/scripts"
 cat > "$BUILD_DIR/creations/demos/clean/IRFakeClean" <<'EOF'

--- a/test/tools/ir_run_exit_code_test.sh
+++ b/test/tools/ir_run_exit_code_test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# ir_run_exit_code_test.sh — assert ir-run validates exit codes for
+# self-terminating verbs.
+#
+# T-336 fixed a Metal static-destruction segfault that landed AFTER
+# screenshots were written, so the per-shot comparator passed while the
+# process crashed. ir-run's `--auto-screenshot` path now refuses to
+# exec'-replace (which would hide the signal behind a bash builtin); it
+# runs as a child and prints a "crashed on shutdown" diagnostic on
+# non-zero. This test pins that behavior so a future revert doesn't
+# silently re-open the gap.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IR_RUN="$REPO_ROOT/engine/tools/bin/ir-run"
+
+# Stage a fake build dir holding two scripts pretending to be demo exes.
+# One exits 0, the other exits 139 (the bash convention for SIGSEGV).
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+# ir-run's --auto-screenshot detection wraps in ir-acquire gpu; that
+# requires a real lock dir. Override to a tmp dir so we don't trample
+# the user's host locks.
+export IR_ACQUIRE_LOCK_DIR
+IR_ACQUIRE_LOCK_DIR="$(mktemp -d)"
+
+mkdir -p "$BUILD_DIR/creations/demos/clean/scripts"
+cat > "$BUILD_DIR/creations/demos/clean/IRFakeClean" <<'EOF'
+#!/usr/bin/env bash
+echo "fake-clean: ran with args: $*"
+exit 0
+EOF
+chmod +x "$BUILD_DIR/creations/demos/clean/IRFakeClean"
+
+mkdir -p "$BUILD_DIR/creations/demos/crash/scripts"
+cat > "$BUILD_DIR/creations/demos/crash/IRFakeCrash" <<'EOF'
+#!/usr/bin/env bash
+echo "fake-crash: ran with args: $*; pretending to segfault on shutdown"
+exit 139
+EOF
+chmod +x "$BUILD_DIR/creations/demos/crash/IRFakeCrash"
+
+pass=0
+fail=0
+check() {
+    local label="$1" cond="$2"
+    if eval "$cond"; then
+        echo "  PASS: $label"
+        pass=$(( pass + 1 ))
+    else
+        echo "  FAIL: $label"
+        fail=$(( fail + 1 ))
+    fi
+}
+
+echo "[1] auto-screenshot + clean exit: ir-run returns 0"
+"$IR_RUN" --build-dir "$BUILD_DIR" IRFakeClean --auto-screenshot 1 > /tmp/ir-run-clean.log 2>&1
+rc=$?
+check "exit code 0" "[[ $rc -eq 0 ]]"
+
+echo "[2] auto-screenshot + crash on shutdown: ir-run propagates non-zero"
+set +e
+"$IR_RUN" --build-dir "$BUILD_DIR" IRFakeCrash --auto-screenshot 1 > /tmp/ir-run-crash.log 2>&1
+rc=$?
+set -e
+check "exit code matches binary (139)" "[[ $rc -eq 139 ]]"
+check "diagnostic mentions 'crashed on shutdown'" \
+    "grep -q 'crashed on shutdown' /tmp/ir-run-crash.log"
+check "diagnostic mentions T-336" \
+    "grep -q 'T-336' /tmp/ir-run-crash.log"
+
+echo
+echo "ir_run_exit_code_test.sh: $pass passed, $fail failed"
+exit "$fail"


### PR DESCRIPTION
## Summary

Closes #1116. Fix the macOS Metal demo segfault that fired during shutdown after profiling was dumped but before the World destructor could finish — the symptom that prompted T-336.

**Root cause.** `MetalRenderDevice` lived as a plain static in `engine/render/src/metal/metal_render_impl.cpp`'s anonymous namespace. Static-destruction order between that TU and the `inline std::unique_ptr<World> g_world` in `engine/include/irreden/ir_engine.hpp` is implementation-defined. On macOS, the device's `m_clearSourceBuffers` unordered_map was destroyed before `World`'s `RenderingResourceManager` destructed its `Texture2D` resources. Each `~MetalTexture2DImpl` calls `removeClearSourceBuffer(m_texture)`, which dereferences that map → libc++ `__hash_table::find` reads the freed bucket array → SIGSEGV.

**Fix.** Swap the static device instance for the same leaked function-static pattern `metal_runtime.cpp` already uses for `g_runtime()`. The device state now outlives every other static; texture destructors at static-destruction time see a valid map.

**Tooling hardening.** Without these, the next regression on this surface would silently pass `render-verify` (all shots match — but the binary crashed on shutdown):

- `ir-run` `--auto-screenshot` path no longer `exec`-replaces the wrapper; runs the binary as a child, inspects the exit code, prints a "crashed on shutdown" diagnostic on non-zero. Interactive path (no auto-screenshot, no timeout) still execs for clean signal/stdin pass-through.
- `scripts/render-verify.py` treats non-zero `fleet-run` exit as a hard fail even when every shot matches; that exact failure mode (shots fine, shutdown crashes) was undetected before this change.
- `test/tools/ir_run_exit_code_test.sh` pins both behaviors with fake-binary fixtures (clean exit + shutdown crash) so a future revert is caught.

## Verification

All on Apple M4 Max / macOS 26.2:
- `IRPerfGrid --auto-screenshot 5` — exit 0 (was 139)
- `IRShapeDebug --auto-screenshot 5` — exit 0
- `IRGpuParticles --auto-screenshot 5` — exit 0
- `IRLightingCombined --auto-screenshot 5` — exit 0
- `test/tools/ir_run_exit_code_test.sh` — 4/4 pass

## Test plan

- [x] Reproduce the segfault with `fleet-run IRPerfGrid` on macOS
- [x] Identify root cause via lldb backtrace (libc++ `__hash_table::find` on the device's `m_clearSourceBuffers`)
- [x] Apply targeted fix; verify clean exit on four demos
- [x] Harden `ir-run` + `render-verify.py` to detect non-zero exit codes
- [x] Add regression test for the new `ir-run` validation path
- [ ] Linux smoke (engine/render touched — needs OpenGL build/run validation from the Linux fleet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)