### PR TITLE
T-223: lua: concurrency field on IRSystem.registerSystem (EVAL + CODEGEN paths)

### DIFF
--- a/cmake/lua_codegen/main.cpp
+++ b/cmake/lua_codegen/main.cpp
@@ -482,6 +482,50 @@ void registerSystemCb(
 
     std::vector<std::string> excludes = readStringArray(ts, schema["excludes"], name, "excludes");
 
+    // T-223: optional `concurrency` field. Accepts integer-typed
+    // IRSystem.Concurrency.{SERIAL,PARALLEL_FOR,MAIN_THREAD}; strings
+    // are rejected per the cpp-lua-enums rule. The value is threaded
+    // into the emitted `IRSystem::createSystem<...>(...)` call's
+    // trailing concurrency arg — the engine-side
+    // `detail::validateConcurrencyForAccess` runs at template
+    // instantiation time and fires (IR_ASSERT in debug builds) when the
+    // requested policy conflicts with the tick signature. CODEGEN tick
+    // bodies today emit the per-archetype batch form, so PARALLEL_FOR
+    // would fail that assert — surfaced as a registration-time FATAL
+    // pointing at the schema, exactly matching the hand-written C++
+    // path's behavior.
+    IRLuaCodegen::Concurrency concurrency = IRLuaCodegen::Concurrency::SERIAL;
+    sol::object concVal = schema["concurrency"];
+    if (!concVal.is<sol::nil_t>()) {
+        if (concVal.get_type() == sol::type::string) {
+            schemaError(
+                ts,
+                "lua_codegen: system '" + name +
+                    "' field 'concurrency' must be an IRSystem.Concurrency.* "
+                    "value (e.g. IRSystem.Concurrency.PARALLEL_FOR), not a string"
+            );
+        }
+        if (concVal.get_type() != sol::type::number) {
+            schemaError(
+                ts,
+                "lua_codegen: system '" + name +
+                    "' field 'concurrency' must be an integer-typed "
+                    "IRSystem.Concurrency.* value"
+            );
+        }
+        const lua_Integer raw = concVal.as<lua_Integer>();
+        if (raw < static_cast<lua_Integer>(IRLuaCodegen::Concurrency::SERIAL) ||
+            raw > static_cast<lua_Integer>(IRLuaCodegen::Concurrency::MAIN_THREAD)) {
+            schemaError(
+                ts,
+                "lua_codegen: system '" + name + "' field 'concurrency' = " +
+                    std::to_string(raw) + " is out of range; use "
+                    "IRSystem.Concurrency.{SERIAL,PARALLEL_FOR,MAIN_THREAD}"
+            );
+        }
+        concurrency = static_cast<IRLuaCodegen::Concurrency>(raw);
+    }
+
     sol::object tickVal = schema["tick"];
     if (tickVal.get_type() != sol::type::function) {
         schemaError(
@@ -509,6 +553,7 @@ void registerSystemCb(
     IRLuaCodegen::SystemRecord rec;
     rec.name_ = name;
     rec.mode_ = resolvedMode;
+    rec.concurrency_ = concurrency;
     rec.components_ = std::move(components);
     rec.excludes_ = std::move(excludes);
     rec.sourceFile_ = std::move(file);
@@ -883,6 +928,19 @@ int main(int argc, char **argv) {
     irSystem.set_function("systemId", [](sol::variadic_args) { return 0; });
     irSystem.set_function("replaceSystemBody", [](sol::variadic_args) {});
     irSystem["SystemName"] = lua.create_table();
+
+    // T-223: expose IRSystem.Concurrency as an integer table so .lua
+    // schemas can reference `IRSystem.Concurrency.PARALLEL_FOR` etc. on
+    // the registerSystem spec. Values mirror IRLuaCodegen::Concurrency
+    // (which in turn mirrors IRSystem::Concurrency on the engine side).
+    sol::table concurrencyTbl = lua.create_table();
+    concurrencyTbl["SERIAL"] =
+        static_cast<lua_Integer>(IRLuaCodegen::Concurrency::SERIAL);
+    concurrencyTbl["PARALLEL_FOR"] =
+        static_cast<lua_Integer>(IRLuaCodegen::Concurrency::PARALLEL_FOR);
+    concurrencyTbl["MAIN_THREAD"] =
+        static_cast<lua_Integer>(IRLuaCodegen::Concurrency::MAIN_THREAD);
+    irSystem["Concurrency"] = concurrencyTbl;
 
     sol::table irTime = lua.create_named_table("IRTime");
     irTime["UPDATE"] = 0;

--- a/cmake/lua_codegen/system_dsl.cpp
+++ b/cmake/lua_codegen/system_dsl.cpp
@@ -1398,6 +1398,29 @@ void emitSystem(
 
     out += emitter.str();
     out += "        }\n";
+    // T-223: thread the per-system concurrency value through to the
+    // engine-side createSystem<>'s trailing Concurrency arg. The
+    // trailing-argument shape requires the begin/end/relation tick + the
+    // exclude-archetype slots to be filled first; pass the zero-value
+    // sentinels (`nullptr` lambdas, default-constructed `RelationParams`,
+    // and an empty `IREntity::Archetype`) so the named positional carries
+    // the meaning. SERIAL is the no-op default and is emitted explicitly
+    // for diffability — a reader sees the policy at a glance instead of
+    // having to look up the function's default.
+    const char *concCpp = "IRSystem::Concurrency::SERIAL";
+    switch (record.concurrency_) {
+        case Concurrency::SERIAL:       concCpp = "IRSystem::Concurrency::SERIAL"; break;
+        case Concurrency::PARALLEL_FOR: concCpp = "IRSystem::Concurrency::PARALLEL_FOR"; break;
+        case Concurrency::MAIN_THREAD:  concCpp = "IRSystem::Concurrency::MAIN_THREAD"; break;
+    }
+    out += "        ,\n";
+    out += "        /* functionBeginTick */ nullptr,\n";
+    out += "        /* functionEndTick */ nullptr,\n";
+    out += "        /* extraParams */ {},\n";
+    out += "        /* functionRelationTick */ nullptr,\n";
+    out += "        /* concurrency */ ";
+    out += concCpp;
+    out += "\n";
     out += "    );\n";
     out += "}\n\n";
 }

--- a/cmake/lua_codegen/system_dsl.hpp
+++ b/cmake/lua_codegen/system_dsl.hpp
@@ -239,9 +239,16 @@ struct ParsedBody {
 // `docs/design/lua-driven-ecs.md`.
 enum class SystemMode { CODEGEN, EVAL };
 
+// Mirrors `IRSystem::Concurrency` (engine/system/include/irreden/system/
+// ir_system_types.hpp). Kept as a separate enum here so system_dsl.hpp
+// stays free of an engine-header include — the codegen tool's link surface
+// is sol2 + Lua, not the engine static libraries.
+enum class Concurrency { SERIAL = 0, PARALLEL_FOR = 1, MAIN_THREAD = 2 };
+
 struct SystemRecord {
     std::string name_;                       // e.g. "MoveByVelocity"
     SystemMode mode_ = SystemMode::CODEGEN;  // per-system mode override
+    Concurrency concurrency_ = Concurrency::SERIAL;  // T-223 opt-in
     std::vector<std::string> components_;    // include archetype, in declared order
     std::vector<std::string> excludes_;      // exclude archetype, in declared order
     std::string sourceFile_;                 // resolved file path

--- a/cmake/lua_codegen/system_dsl.hpp
+++ b/cmake/lua_codegen/system_dsl.hpp
@@ -243,6 +243,7 @@ enum class SystemMode { CODEGEN, EVAL };
 // ir_system_types.hpp). Kept as a separate enum here so system_dsl.hpp
 // stays free of an engine-header include — the codegen tool's link surface
 // is sol2 + Lua, not the engine static libraries.
+// Values must match IRSystem::Concurrency in engine/system/include/irreden/system/ir_system_types.hpp
 enum class Concurrency { SERIAL = 0, PARALLEL_FOR = 1, MAIN_THREAD = 2 };
 
 struct SystemRecord {

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -489,6 +489,34 @@ local sysId = IRSystem.registerSystem({
 - **No begin/end ticks yet.** Lua-side `beginTick` / `endTick`
   hooks are not exposed; add them when a use case needs
   frame-scoped setup or teardown.
+- **Optional `concurrency` field** (T-223). Accepts the integer-typed
+  `IRSystem.Concurrency.{SERIAL, PARALLEL_FOR, MAIN_THREAD}` enum
+  value; default `SERIAL` matches the legacy behavior. The codegen
+  path threads the value through to the emitted
+  `IRSystem::createSystem<...>(...)` call's trailing concurrency
+  arg — engine-side `detail::validateConcurrencyForAccess` runs at
+  template instantiation time and FATALs on the same invalid
+  combinations a hand-written C++ system would (`PARALLEL_FOR` +
+  batch-form tick, `PARALLEL_FOR` + entity-id form without
+  `ParallelSafe`, `PARALLEL_FOR` + `MainThread` tag). The EVAL path
+  is more conservative: an EVAL system body is a
+  `sol::protected_function` call into LuaJIT, and **both sol2 and
+  LuaJIT's GC are single-threaded** — running an EVAL body on a
+  worker thread is unsound. The runtime shim therefore forces
+  `PARALLEL_FOR` → `MAIN_THREAD` (with a one-shot per-system warning
+  naming the spec) so the misuse surfaces in the log. Per the
+  [`cpp-lua-enums`](../../.claude/rules/cpp-lua-enums.md) rule the
+  field rejects string values (`concurrency = "parallel_for"`) with
+  a diagnostic pointing at the `IRSystem.Concurrency.*` spelling;
+  out-of-range integers raise an explicit error.
+
+  CODEGEN v1 caveat: the codegen tick body emits the per-archetype
+  batch form (`for i = 0, arch.length - 1 do ... end` lowered to a
+  single batch lambda over `vector<C_Foo>&` columns). The T-222
+  validator rejects `PARALLEL_FOR` + batch-form, so a CODEGEN
+  system spec asking for `PARALLEL_FOR` will FATAL at registration.
+  Lifting that restriction needs the codegen tool to emit the
+  per-component form instead — tracked as a follow-up issue.
 
 ## Hot-reload of Lua system bodies (`IRSystem.replaceSystemBody`)
 

--- a/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
@@ -160,6 +160,30 @@ inline void bindSystemNameEnum(LuaScript &script) {
     lua["IRSystem"]["SystemName"] = t;
 }
 
+// T-223: bind `IRSystem::Concurrency` as an integer table at
+// `IRSystem.Concurrency.{SERIAL, PARALLEL_FOR, MAIN_THREAD}`. The same
+// rationale as `IRSystem.SystemName` — strings drift; enum-keyed table
+// stays in sync with the C++ definition. Used by the optional
+// `concurrency` field on `IRSystem.registerSystem({...})` (EVAL +
+// CODEGEN paths) so Lua code can request a policy that mirrors the
+// hand-written C++ `createSystem<...>(...)` trailing `Concurrency` arg.
+inline void bindConcurrencyEnum(LuaScript &script) {
+    sol::state &lua = script.lua();
+    if (!lua["IRSystem"].valid()) {
+        lua["IRSystem"] = lua.create_table();
+    }
+    if (lua["IRSystem"]["Concurrency"].valid()) {
+        return; // idempotent
+    }
+    sol::table t = lua.create_table();
+#define IR_BIND_CONCURRENCY(name) t[#name] = static_cast<lua_Integer>(IRSystem::Concurrency::name)
+    IR_BIND_CONCURRENCY(SERIAL);
+    IR_BIND_CONCURRENCY(PARALLEL_FOR);
+    IR_BIND_CONCURRENCY(MAIN_THREAD);
+#undef IR_BIND_CONCURRENCY
+    lua["IRSystem"]["Concurrency"] = t;
+}
+
 // Bind `IRSystem.systemId(name)` and `IRSystem.registerPipeline(event, ids)`.
 // `prefabSystemIds` is the per-LuaScript map populated by C++-side
 // `registerPrefabSystem<N>()` calls; passed by pointer so the closure

--- a/engine/script/include/irreden/script/lua_script.hpp
+++ b/engine/script/include/irreden/script/lua_script.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace IRScript {
@@ -271,6 +272,13 @@ class LuaScript {
     // after `registerCodegenComponents()` so the runtime mirrors the
     // build-time default driven by `IR_LUA_ECS_DEFAULT_MODE`.
     EcsMode m_ecsDefaultMode = EcsMode::EVAL;
+
+    // T-223: per-system one-shot dedupe of the
+    // "PARALLEL_FOR requested under EVAL — forced to MAIN_THREAD"
+    // warning. Specs that re-register on hot-reload would otherwise
+    // log every call; one log per system name is enough to surface
+    // the misuse.
+    std::unordered_set<std::string> m_warnedParallelForEvalSystems;
 
     // Declared last so it destructs first: lua_close() runs before any
     // closure-captured map (m_prefabSystemIds etc.) is gone. Mirrors the

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -854,9 +854,10 @@ void LuaScript::bindLuaDrivenSystems() {
                         "Concurrency::PARALLEL_FOR but EVAL bodies are "
                         "sol::protected_function calls into LuaJIT — "
                         "both sol2 and LuaJIT GC are single-threaded. "
-                        "Forcing Concurrency::MAIN_THREAD; switch to "
+                        "Forcing Concurrency::MAIN_THREAD. When codegen "
+                        "lifts the batch-form restriction, switch to "
                         "mode='codegen' for native-speed parallel "
-                        "dispatch.",
+                        "dispatch (tracked in #1120).",
                         systemName.c_str()
                     );
                 }

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -605,6 +605,7 @@ void LuaScript::bindLuaDrivenEcs() {
     // `bindModifierFramework` populates `IRModifier`.
     detail::bindIRTimeEvents(*this);
     detail::bindSystemNameEnum(*this);
+    detail::bindConcurrencyEnum(*this);
     detail::bindRegisterPipelineAndSystemId(*this, prefabSystemIds());
     detail::bindModifierFramework(*this);
     detail::bindPrefabApi(*this);
@@ -808,6 +809,61 @@ void LuaScript::bindLuaDrivenSystems() {
             excludeIds = resolveComponentList(*excludes, "excludes", systemName, *this, em);
         }
 
+        // T-223: optional `concurrency` field. Accept the integer-typed
+        // `IRSystem.Concurrency.{SERIAL,PARALLEL_FOR,MAIN_THREAD}` table
+        // entry only; string names are rejected per the cpp-lua-enums
+        // rule. PARALLEL_FOR is structurally unsafe for EVAL — the body
+        // is a sol::protected_function call and both sol2 and LuaJIT's
+        // GC are single-threaded — so PARALLEL_FOR is forced to
+        // MAIN_THREAD with a one-time per-system warning so the misuse
+        // surfaces in the log. MAIN_THREAD is the explicit "do not pull
+        // me onto a worker" tag for pipeline groups (T-224); SERIAL is
+        // the legacy default.
+        IRSystem::Concurrency concurrency = IRSystem::Concurrency::SERIAL;
+        sol::object concObj = args["concurrency"];
+        if (concObj.valid() && concObj.get_type() != sol::type::lua_nil) {
+            if (concObj.get_type() == sol::type::string) {
+                throw sol::error{
+                    "IRSystem.registerSystem: '" + systemName +
+                    "' field 'concurrency' must be an IRSystem.Concurrency.* "
+                    "value (e.g. IRSystem.Concurrency.MAIN_THREAD), not a string"
+                };
+            }
+            if (!concObj.is<lua_Integer>()) {
+                throw sol::error{
+                    "IRSystem.registerSystem: '" + systemName +
+                    "' field 'concurrency' must be an integer-typed "
+                    "IRSystem.Concurrency.* value"
+                };
+            }
+            const lua_Integer raw = concObj.as<lua_Integer>();
+            if (raw < static_cast<lua_Integer>(IRSystem::Concurrency::SERIAL) ||
+                raw > static_cast<lua_Integer>(IRSystem::Concurrency::MAIN_THREAD)) {
+                throw sol::error{
+                    "IRSystem.registerSystem: '" + systemName +
+                    "' field 'concurrency' = " + std::to_string(raw) +
+                    " is out of range; use IRSystem.Concurrency.{SERIAL,"
+                    "PARALLEL_FOR,MAIN_THREAD}"
+                };
+            }
+            concurrency = static_cast<IRSystem::Concurrency>(raw);
+            if (concurrency == IRSystem::Concurrency::PARALLEL_FOR) {
+                if (m_warnedParallelForEvalSystems.insert(systemName).second) {
+                    IRE_LOG_WARN(
+                        "Lua EVAL system '{}' requested "
+                        "Concurrency::PARALLEL_FOR but EVAL bodies are "
+                        "sol::protected_function calls into LuaJIT — "
+                        "both sol2 and LuaJIT GC are single-threaded. "
+                        "Forcing Concurrency::MAIN_THREAD; switch to "
+                        "mode='codegen' for native-speed parallel "
+                        "dispatch.",
+                        systemName.c_str()
+                    );
+                }
+                concurrency = IRSystem::Concurrency::MAIN_THREAD;
+            }
+        }
+
         IREntity::Archetype includeArchetype{includeIds.begin(), includeIds.end()};
         IREntity::Archetype excludeArchetype{excludeIds.begin(), excludeIds.end()};
 
@@ -858,7 +914,8 @@ void LuaScript::bindLuaDrivenSystems() {
             systemName,
             std::move(includeArchetype),
             std::move(excludeArchetype),
-            std::move(body)
+            std::move(body),
+            concurrency
         );
         m_luaSystemTicks.emplace(systemId, tickRef);
         return sol::make_object(m_lua, static_cast<lua_Integer>(systemId));

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -329,13 +329,15 @@ inline SystemId createSystemDynamic(
     std::string name,
     IREntity::Archetype includeArchetype,
     IREntity::Archetype excludeArchetype,
-    std::function<void(IREntity::ArchetypeNode *)> body
+    std::function<void(IREntity::ArchetypeNode *)> body,
+    Concurrency concurrency = Concurrency::SERIAL
 ) {
     return getSystemManager().createSystemDynamic(
         std::move(name),
         std::move(includeArchetype),
         std::move(excludeArchetype),
-        std::move(body)
+        std::move(body),
+        concurrency
     );
 }
 

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -159,7 +159,8 @@ class SystemManager {
         std::string name,
         Archetype includeArchetype,
         Archetype excludeArchetype,
-        std::function<void(ArchetypeNode *)> body
+        std::function<void(ArchetypeNode *)> body,
+        Concurrency concurrency = Concurrency::SERIAL
     );
 
     /// Replace the per-archetype tick body of an existing system in place.

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -49,7 +49,8 @@ SystemId SystemManager::createSystemDynamic(
     std::string name,
     Archetype includeArchetype,
     Archetype excludeArchetype,
-    std::function<void(ArchetypeNode *)> body
+    std::function<void(ArchetypeNode *)> body,
+    Concurrency concurrency
 ) {
     m_systemNames.emplace_back(C_Name{std::move(name)});
     SystemId newSystemId = m_nextSystemId++;
@@ -68,9 +69,20 @@ SystemId SystemManager::createSystemDynamic(
     m_relations.emplace_back(C_SystemRelation{Relation::NONE});
     m_systemParams.emplace_back(nullptr);
     m_timingAccum.emplace_back();
-    // T-222: dynamic systems are SERIAL-only (the body is opaque to
-    // chunking) and have no compile-time access descriptor.
-    m_concurrency.emplace_back(Concurrency::SERIAL);
+    // T-222: dynamic systems are PARALLEL_FOR-ineligible (the body is
+    // opaque to row-level chunking — `m_ticks[…].rangedFunctionTick_` is
+    // never populated). T-223 still accepts SERIAL / MAIN_THREAD so the
+    // Lua surface can tag EVAL systems as MAIN_THREAD to opt them out of
+    // pipeline-group parallelism (the sol2 / LuaJIT GC singletons are
+    // not thread-safe). PARALLEL_FOR is normalized to MAIN_THREAD by the
+    // Lua-side `IRSystem.registerSystem` shim before reaching here; the
+    // assert is a defence in depth for any future direct C++ caller.
+    IR_ASSERT(
+        concurrency != Concurrency::PARALLEL_FOR,
+        "createSystemDynamic: PARALLEL_FOR not supported for runtime-typed "
+        "systems (no row-level ranged tick). Use SERIAL or MAIN_THREAD."
+    );
+    m_concurrency.emplace_back(concurrency);
     m_grainSize.emplace_back(kDefaultGrainSize);
     m_systemAccess.emplace_back();
     return newSystemId;

--- a/test/script/lua_system_register_test.cpp
+++ b/test/script/lua_system_register_test.cpp
@@ -591,4 +591,22 @@ TEST_F(LuaSystemRegisterTest, ConcurrencyOutOfRangeRejected) {
     EXPECT_NE(err.find("out of range"), std::string::npos) << err;
 }
 
+TEST_F(LuaSystemRegisterTest, ConcurrencyDefaultsToSerialWhenFieldOmitted) {
+    auto &lua = m_lua.lua();
+    auto regResult = lua.safe_script(
+        R"(
+        sysId = IRSystem.registerSystem({
+            name = 'NoConcurrencyField',
+            components = { 'TestPos' },
+            tick = function(arch) end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(regResult.valid()) << sol::error{regResult}.what();
+    const IRSystem::SystemId sysId = regResult.get<lua_Integer>();
+    EXPECT_EQ(m_system_manager.getConcurrency(sysId), IRSystem::Concurrency::SERIAL);
+}
+
 } // namespace

--- a/test/script/lua_system_register_test.cpp
+++ b/test/script/lua_system_register_test.cpp
@@ -495,4 +495,100 @@ TEST_F(LuaSystemRegisterTest, ExcludesFilterDropsTaggedArchetype) {
     EXPECT_FLOAT_EQ(IREntity::getComponent<TestPos>(entitySkip).x, 1.0f);
 }
 
+// ---- T-223: Concurrency field ----------------------------------------------
+
+TEST_F(LuaSystemRegisterTest, ConcurrencyExposedAsIntegerTable) {
+    auto &lua = m_lua.lua();
+    EXPECT_TRUE(lua["IRSystem"]["Concurrency"].valid());
+    EXPECT_EQ(
+        lua["IRSystem"]["Concurrency"]["SERIAL"].get<lua_Integer>(),
+        static_cast<lua_Integer>(IRSystem::Concurrency::SERIAL)
+    );
+    EXPECT_EQ(
+        lua["IRSystem"]["Concurrency"]["PARALLEL_FOR"].get<lua_Integer>(),
+        static_cast<lua_Integer>(IRSystem::Concurrency::PARALLEL_FOR)
+    );
+    EXPECT_EQ(
+        lua["IRSystem"]["Concurrency"]["MAIN_THREAD"].get<lua_Integer>(),
+        static_cast<lua_Integer>(IRSystem::Concurrency::MAIN_THREAD)
+    );
+}
+
+TEST_F(LuaSystemRegisterTest, MainThreadConcurrencyStored) {
+    auto &lua = m_lua.lua();
+    auto regResult = lua.safe_script(
+        R"(
+        sysId = IRSystem.registerSystem({
+            name = 'MainThreadSys',
+            components = { 'TestPos' },
+            concurrency = IRSystem.Concurrency.MAIN_THREAD,
+            tick = function(arch) end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(regResult.valid()) << sol::error{regResult}.what();
+    const IRSystem::SystemId sysId = regResult.get<lua_Integer>();
+    EXPECT_EQ(m_system_manager.getConcurrency(sysId), IRSystem::Concurrency::MAIN_THREAD);
+}
+
+TEST_F(LuaSystemRegisterTest, ParallelForUnderEvalForcedToMainThread) {
+    auto &lua = m_lua.lua();
+    auto regResult = lua.safe_script(
+        R"(
+        sysId = IRSystem.registerSystem({
+            name = 'WouldBeParallelSys',
+            components = { 'TestPos' },
+            concurrency = IRSystem.Concurrency.PARALLEL_FOR,
+            tick = function(arch) end,
+        })
+        return sysId
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(regResult.valid()) << sol::error{regResult}.what();
+    const IRSystem::SystemId sysId = regResult.get<lua_Integer>();
+    // EVAL bodies are sol2 calls — both sol2 and LuaJIT GC are
+    // single-threaded, so PARALLEL_FOR is downgraded to MAIN_THREAD
+    // rather than dispatched to workers.
+    EXPECT_EQ(m_system_manager.getConcurrency(sysId), IRSystem::Concurrency::MAIN_THREAD);
+}
+
+TEST_F(LuaSystemRegisterTest, ConcurrencyStringRejected) {
+    auto &lua = m_lua.lua();
+    auto regResult = lua.safe_script(
+        R"(
+        IRSystem.registerSystem({
+            name = 'StringConcurrencyBad',
+            components = { 'TestPos' },
+            concurrency = 'parallel_for',
+            tick = function(arch) end,
+        })
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_FALSE(regResult.valid());
+    const std::string err = sol::error{regResult}.what();
+    EXPECT_NE(err.find("IRSystem.Concurrency"), std::string::npos) << err;
+}
+
+TEST_F(LuaSystemRegisterTest, ConcurrencyOutOfRangeRejected) {
+    auto &lua = m_lua.lua();
+    auto regResult = lua.safe_script(
+        R"(
+        IRSystem.registerSystem({
+            name = 'OutOfRangeBad',
+            components = { 'TestPos' },
+            concurrency = 99,
+            tick = function(arch) end,
+        })
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_FALSE(regResult.valid());
+    const std::string err = sol::error{regResult}.what();
+    EXPECT_NE(err.find("out of range"), std::string::npos) << err;
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

Threads the optional `concurrency` field through both Lua-driven system-registration paths (EVAL + CODEGEN) so a Lua-defined system can mirror what hand-written C++ systems opt into via T-222's trailing `Concurrency` arg.

- **Lua surface:** new `IRSystem.Concurrency.{SERIAL, PARALLEL_FOR, MAIN_THREAD}` integer-table (per cpp-lua-enums.md; strings rejected with a diagnostic, out-of-range integers raise explicitly).
- **EVAL path:** `IRSystem.registerSystem({..., concurrency = X})` parses the field; `PARALLEL_FOR` is normalized to `MAIN_THREAD` with a one-shot per-system warning (sol2 + LuaJIT GC are single-threaded — running EVAL bodies on workers is unsound).
- **CODEGEN path:** the codegen tool's `IRSystem` stub now exposes the same enum table; `registerSystemCb` parses+validates the field and stores it on `SystemRecord`; `emitSystem` threads the value into the generated `IRSystem::createSystem<...>(...)` call's trailing `Concurrency` arg. T-222's `validateConcurrencyForAccess` runs at template instantiation and FATALs on the same invalid combinations a hand-written C++ system would.
- **`createSystemDynamic`:** gains `Concurrency concurrency = Concurrency::SERIAL` on both SystemManager method + free-function wrapper. Debug `IR_ASSERT` rejects `PARALLEL_FOR` on the dynamic path (no ranged tick exists for runtime-typed bodies) as defence in depth.

## Stack context

- **Stacked on:** #1097 (T-222 — Concurrency::PARALLEL_FOR + single-system access validation).
- **Base:** `claude/T-222-parallel-for-validation`. Review this PR's diff against that base; T-222 is approved separately.
- Will rebase onto master once T-222 lands.

## Scope adaptation

The original plan referenced a Python codegen (`cmake/lua_codegen/parser.py`, `emitter.py`) — the actual codegen tool is C++ (`cmake/lua_codegen/main.cpp`, `system_dsl.{hpp,cpp}`). Implementation adapted accordingly. The plan's `concurrency = "parallel_for"` string convention was also replaced with the integer-typed enum table to comply with the cpp-lua-enums rule.

## CODEGEN v1 caveat → follow-up #1120

The codegen tool emits the **per-archetype batch form** for tick bodies. T-222's validator rejects `PARALLEL_FOR + isBatchForm_`, so a CODEGEN spec asking for `PARALLEL_FOR` will FATAL at registration time. Lifting that restriction needs the codegen lowering to emit the **per-component form** — tracked in #1120.

The 262k-entity perf-parity criterion from the original T-223 plan depends on #1120. This PR delivers:
- The field plumbing (both paths)
- EVAL safety (force-MAIN_THREAD + warning)
- Validator coverage (CODEGEN path inherits T-222's FATAL behavior)
- Documentation

…not the perf parity (blocked on the per-component emit conversion).

## Test plan

- [x] `fleet-build --target IrredenEngine` clean
- [x] `fleet-build --target ir_lua_codegen` clean
- [x] `fleet-build --target IRLuaPerfGrid` clean (codegen-emitted header includes the new `/* concurrency */ IRSystem::Concurrency::SERIAL` arg)
- [x] `fleet-build --target IrredenEngineTest` clean
- [x] `IRLuaPerfGrid --auto-screenshot 10` — 2/2 screenshots captured, demo runs (shutdown segfault is the pre-existing T-336 issue, unrelated)
- [x] 5 new tests pass: `ConcurrencyExposedAsIntegerTable`, `MainThreadConcurrencyStored`, `ParallelForUnderEvalForcedToMainThread`, `ConcurrencyStringRejected`, `ConcurrencyOutOfRangeRejected`
- [x] 40 tests in the Lua/codegen/coexistence/concurrency suites pass — no regressions
- [ ] Linux smoke (author tags `fleet:needs-linux-smoke` after review)

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)