### PR TITLE
T-333: engine/system: pre-resolve component vectors on main thread for PARALLEL_FOR

### DIFF
--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -351,10 +351,16 @@ A system opts into PARALLEL_FOR by either:
 
 `SystemManager::executeSystem` reads the per-system Concurrency at
 dispatch time and, for `PARALLEL_FOR` systems with a populated
-range-aware tick fn and a node larger than the grain size, drives
-`IRJob::parallelFor(0, node->length_, grainSize, ...)`. The
-`beginTick` / `endTick` hooks and the archetype-node iteration order
-always serialize on the main thread regardless of policy.
+main-thread binder (`prepareRangedTick_`, T-333) and a node larger
+than the grain size, calls the binder once on the main thread to
+resolve per-component vector refs, then passes the returned
+`void(begin, end)` worker closure to `IRJob::parallelFor(0,
+node->length_, grainSize, ...)`. Resolving the component vectors on
+the main thread is what keeps PARALLEL_FOR workers off
+`EntityManager::m_pureComponentTypes`'s hash lookup — that map is
+not safe under concurrent reads from workers. The `beginTick` /
+`endTick` hooks and the archetype-node iteration order always
+serialize on the main thread regardless of policy.
 
 **Registration-time validation** (in `IRSystem::createSystem`):
 

--- a/engine/system/include/irreden/system/components/component_system_event.hpp
+++ b/engine/system/include/irreden/system/components/component_system_event.hpp
@@ -14,8 +14,6 @@ template <IRSystem::SystemEvent event> struct C_SystemEvent;
 template <> struct C_SystemEvent<IRSystem::BEGIN_TICK> {
     std::function<void()> functionBeginTick_;
 
-    // std::vector<std::function<void(IRECS::ArchetypeNode*)>> tickFunctions_ ;
-
     C_SystemEvent(const std::function<void()> &function)
         : functionBeginTick_(function) {}
     C_SystemEvent()
@@ -25,8 +23,12 @@ template <> struct C_SystemEvent<IRSystem::BEGIN_TICK> {
 template <> struct C_SystemEvent<IRSystem::TICK> {
     /// Whole-node dispatch — body iterates `[0, node->length_)` internally.
     using TickFn = std::function<void(IREntity::ArchetypeNode *)>;
-    /// Range-aware dispatch — body covers `[rangeBegin, rangeEnd)` only.
-    using RangedTickFn = std::function<void(IREntity::ArchetypeNode *, int, int)>;
+    /// Main-thread binder — invoked once per dispatched archetype node
+    /// to resolve component vectors and return a worker closure that
+    /// covers `[rangeBegin, rangeEnd)` of the resolved rows. See the
+    /// `prepareRangedTick_` field below for the full contract.
+    using PrepareRangedTickFn = std::function<
+        std::function<void(int rangeBegin, int rangeEnd)>(IREntity::ArchetypeNode *)>;
 
     /// Whole-node dispatch — the body iterates `[0, node->length_)`
     /// internally. The legacy form; every system has one. For
@@ -34,44 +36,51 @@ template <> struct C_SystemEvent<IRSystem::TICK> {
     /// path SystemManager invokes.
     TickFn functionTick_;
 
-    /// Range-aware dispatch — `[rangeBegin, rangeEnd)` substitutes the
-    /// internal loop bounds. Populated by `createSystem<...>` (template
-    /// path) for tick signatures the runtime can chunk safely; empty
-    /// for `createSystemDynamic` (the Lua-driven dynamic body is opaque
-    /// to chunking) and for the per-archetype batch form (the body
-    /// consumes the whole column). `Concurrency::PARALLEL_FOR` requires
-    /// this slot to be populated; the validator rejects otherwise.
-    RangedTickFn rangedFunctionTick_;
+    /// Main-thread binder for `Concurrency::PARALLEL_FOR` dispatch.
+    /// SystemManager calls this **once on the main thread** per matched
+    /// archetype node before fanning chunks out to `IRJob::parallelFor`.
+    /// The binder resolves the per-component vector references from the
+    /// node (going through `EntityManager::getComponentType<>` →
+    /// `m_pureComponentTypes` hash lookup, which is NOT safe under
+    /// concurrent reads from worker threads), captures them in a
+    /// `void(rangeBegin, rangeEnd)` closure, and returns it for workers
+    /// to invoke without ever touching EntityManager state. Populated
+    /// by the template `createSystem<...>` path for tick signatures the
+    /// runtime can chunk safely; empty for `createSystemDynamic`
+    /// (opaque body) and the per-archetype batch form (consumes the
+    /// whole column) — the registration validator rejects
+    /// `PARALLEL_FOR` in both cases.
+    PrepareRangedTickFn prepareRangedTick_;
 
     IREntity::Archetype archetype_;
     IREntity::Archetype excludeArchetype_;
 
     C_SystemEvent(
         TickFn tickFunction,
-        RangedTickFn rangedTickFunction,
+        PrepareRangedTickFn prepareRangedTick,
         IREntity::Archetype archetype,
         IREntity::Archetype excludeArchetype = {}
     )
         : functionTick_(std::move(tickFunction))
-        , rangedFunctionTick_(std::move(rangedTickFunction))
+        , prepareRangedTick_(std::move(prepareRangedTick))
         , archetype_(std::move(archetype))
         , excludeArchetype_(std::move(excludeArchetype)) {}
 
     /// Legacy two-arg overload — used by `createSystemDynamic`. Leaves
-    /// `rangedFunctionTick_` empty (validator rejects PARALLEL_FOR).
+    /// `prepareRangedTick_` empty (validator rejects PARALLEL_FOR).
     C_SystemEvent(
         TickFn tickFunction,
         IREntity::Archetype archetype,
         IREntity::Archetype excludeArchetype = {}
     )
         : functionTick_(std::move(tickFunction))
-        , rangedFunctionTick_()
+        , prepareRangedTick_()
         , archetype_(std::move(archetype))
         , excludeArchetype_(std::move(excludeArchetype)) {}
 
     C_SystemEvent()
         : functionTick_()
-        , rangedFunctionTick_() {}
+        , prepareRangedTick_() {}
 };
 
 template <> struct C_SystemEvent<IRSystem::END_TICK> {

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -365,7 +365,7 @@ class SystemManager {
             return;
         } else {
 
-// Row-iterating forms: build a main-thread binder
+            // Row-iterating forms: build a main-thread binder
             // (`prepareRangedTick`) that resolves the per-component
             // vector refs from the node once via `getComponentData<>` —
             // which goes through `EntityManager::m_pureComponentTypes`,

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -307,20 +307,27 @@ class SystemManager {
 
     // Tick functions are operated on each entity in the system
     // matching the archetype. The runtime stores **two** dispatch
-    // shapes per system (T-222 Phase 2 of the multithreading epic):
+    // shapes per system (T-222 Phase 2 of the multithreading epic;
+    // worker-side reshaped by T-333):
     //
-    //   - `rangedTick(node, begin, end)` — invokes the body across
-    //     `[begin, end)`. Populated for every signature that iterates
-    //     entities row-by-row (per-component, per-entity-id,
-    //     optional-relations). The per-archetype batch form
-    //     (`InvocableWithNodeVectors`) consumes the whole column and
-    //     is intentionally unchunkable — `rangedTick` is empty in that
-    //     case; the per-node `functionTick_` does the dispatch.
+    //   - `prepareRangedTick(node)` — main-thread binder. Resolves
+    //     the per-component vector refs from `node` once via
+    //     `getComponentData<>` (which touches the EntityManager's
+    //     hash map — unsafe under concurrent reads from workers),
+    //     and returns a `void(rangeBegin, rangeEnd)` worker closure
+    //     that captures those refs by value. Populated for every
+    //     signature that iterates entities row-by-row (per-component,
+    //     per-entity-id, optional-relations). The per-archetype batch
+    //     form (`InvocableWithNodeVectors`) consumes the whole column
+    //     and is intentionally unchunkable — `prepareRangedTick` is
+    //     empty in that case; the per-node `functionTick_` does the
+    //     dispatch.
     //   - `functionTick(node)` — back-compat per-node entry. For the
-    //     row-iterating forms it's a thin `rangedTick(node, 0, length)`
-    //     wrapper; for the batch form it carries the body directly.
+    //     row-iterating forms it calls `prepareRangedTick(node)` and
+    //     invokes the returned closure with `[0, length)`; for the
+    //     batch form it carries the body directly.
     //
-    // `Concurrency::PARALLEL_FOR` requires `rangedTick` to be
+    // `Concurrency::PARALLEL_FOR` requires `prepareRangedTick` to be
     // populated; the entry-point validator in `ir_system.hpp` rejects
     // batch-form + PARALLEL_FOR.
     template <typename... Components, typename... RelationComponents, typename FunctionTick>
@@ -350,7 +357,7 @@ class SystemManager {
             m_ticks.emplace_back(
                 C_SystemEvent<TICK>{
                     std::function<void(ArchetypeNode *)>{std::move(perNodeFn)},
-                    std::function<void(ArchetypeNode *, int, int)>{},
+                    std::function<std::function<void(int, int)>(ArchetypeNode *)>{},
                     getArchetype<Components...>(),
                     std::move(excludeArchetype)
                 }
@@ -358,76 +365,102 @@ class SystemManager {
             return;
         } else {
 
-            // Row-iterating forms: build the range-aware lambda once,
-            // synthesize the per-node entry as a thin wrapper that calls
-            // it with `[0, length)`. Wrapped in an `else` so the
-            // unsupported-signature static_assert below only fires when
-            // the batch-form branch above has NOT discarded this code.
-            auto rangedFn = [functionTick,
-                             extraParams](ArchetypeNode *node, int rangeBegin, int rangeEnd) {
+// Row-iterating forms: build a main-thread binder
+            // (`prepareRangedTick`) that resolves the per-component
+            // vector refs from the node once via `getComponentData<>` —
+            // which goes through `EntityManager::m_pureComponentTypes`,
+            // unsafe under concurrent reads — and returns a
+            // `void(rangeBegin, rangeEnd)` worker closure that captures
+            // those refs. The SERIAL / MAIN_THREAD entry (`perNodeFn`)
+            // calls the binder once and invokes the returned closure
+            // with `[0, length)`; the PARALLEL_FOR dispatcher in
+            // `executeSystem` calls the binder once and fans the closure
+            // out to worker chunks via `IRJob::parallelFor`. Wrapped in
+            // an `else` so the unsupported-signature static_assert below
+            // only fires when the batch-form branch above has NOT
+            // discarded this code.
+            auto prepareRangedTick =
+                [functionTick,
+                 extraParams](ArchetypeNode *node) -> std::function<void(int, int)> {
                 if constexpr (InvocableWithEntityId<FunctionTick, Components...>) {
                     auto componentsTuple = std::make_tuple(
                         std::ref(node->entities_),
                         std::ref(getComponentData<Components>(node))...
                     );
-                    for (int i = rangeBegin; i < rangeEnd; i++) {
-                        std::apply(
-                            [i, &functionTick](auto &&...components) {
-                                functionTick(components[i]...);
-                            },
-                            componentsTuple
-                        );
-                    }
+                    return [functionTick, componentsTuple](int rangeBegin, int rangeEnd) {
+                        for (int i = rangeBegin; i < rangeEnd; i++) {
+                            std::apply(
+                                [i, &functionTick](auto &&...components) {
+                                    functionTick(components[i]...);
+                                },
+                                componentsTuple
+                            );
+                        }
+                    };
                 } else if constexpr (InvocableWithComponents<FunctionTick, Components...>) {
                     auto componentsTuple =
                         std::make_tuple(std::ref(getComponentData<Components>(node))...);
-                    for (int i = rangeBegin; i < rangeEnd; i++) {
-                        std::apply(
-                            [i, &functionTick](auto &&...components) {
-                                functionTick(components[i]...);
-                            },
-                            componentsTuple
-                        );
-                    }
+                    return [functionTick, componentsTuple](int rangeBegin, int rangeEnd) {
+                        for (int i = rangeBegin; i < rangeEnd; i++) {
+                            std::apply(
+                                [i, &functionTick](auto &&...components) {
+                                    functionTick(components[i]...);
+                                },
+                                componentsTuple
+                            );
+                        }
+                    };
                 } else if constexpr (
                     std::is_invocable_v<
                         FunctionTick,
                         Components &...,
                         std::optional<RelationComponents *>...>
                 ) {
+                    // Relation form: the validator (T-334 scope) rejects
+                    // PARALLEL_FOR + relation, so this binder runs only
+                    // on the main thread. Resolve component vectors AND
+                    // the optional-relation pointers up-front; the
+                    // returned closure iterates rows over both.
                     auto componentsTuple =
                         std::make_tuple(std::ref(getComponentData<Components>(node))...);
                     EntityId relatedEntity =
                         getRelatedEntityFromArchetype(node->type_, extraParams.relation_);
                     auto relationComponentTuple =
                         std::make_tuple(getComponentOptional<RelationComponents>(relatedEntity)...);
-
-                    for (int i = rangeBegin; i < rangeEnd; i++) {
-                        std::apply(
-                            [&functionTick](auto &&...args) { functionTick(args...); },
-                            std::tuple_cat(
-                                std::make_tuple(
-                                    std::ref(
-                                        std::get<std::vector<Components> &>(componentsTuple)[i]
-                                    )...
-                                ),
-                                relationComponentTuple
-                            )
-                        );
-                    }
+                    return [functionTick,
+                            componentsTuple,
+                            relationComponentTuple](int rangeBegin, int rangeEnd) {
+                        for (int i = rangeBegin; i < rangeEnd; i++) {
+                            std::apply(
+                                [&functionTick](auto &&...args) { functionTick(args...); },
+                                std::tuple_cat(
+                                    std::make_tuple(
+                                        std::ref(
+                                            std::get<std::vector<Components> &>(componentsTuple)[i]
+                                        )...
+                                    ),
+                                    relationComponentTuple
+                                )
+                            );
+                        }
+                    };
                 } else {
                     static_assert(false, "Unsupported tick function signature.");
                 }
             };
-            std::function<void(ArchetypeNode *, int, int)> rangedFnErased{std::move(rangedFn)};
-            auto rangedFnCopy = rangedFnErased;
-            auto perNodeFn = [rangedFnCopy = std::move(rangedFnCopy)](ArchetypeNode *node) {
-                rangedFnCopy(node, 0, node->length_);
+            C_SystemEvent<TICK>::PrepareRangedTickFn prepareRangedTickErased{
+                std::move(prepareRangedTick)
+            };
+            auto prepareRangedTickCopy = prepareRangedTickErased;
+            auto perNodeFn = [prepareRangedTickCopy =
+                                  std::move(prepareRangedTickCopy)](ArchetypeNode *node) {
+                auto rangedTick = prepareRangedTickCopy(node);
+                rangedTick(0, node->length_);
             };
             m_ticks.emplace_back(
                 C_SystemEvent<TICK>{
                     std::function<void(ArchetypeNode *)>{std::move(perNodeFn)},
-                    std::move(rangedFnErased),
+                    std::move(prepareRangedTickErased),
                     getArchetype<Components...>(),
                     std::move(excludeArchetype)
                 }

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -362,27 +362,32 @@ void SystemManager::executeSystem(SystemId system) {
         previousRelatedEntity = handleRelationTick(node, system, previousRelatedEntity);
 
         if (concurrency == Concurrency::PARALLEL_FOR &&
-            static_cast<bool>(tickEvent.rangedFunctionTick_) && node->length_ > grainSize &&
+            static_cast<bool>(tickEvent.prepareRangedTick_) && node->length_ > grainSize &&
             g_jobManager != nullptr && IRJob::isMainThread()) {
             // Worker fan-out: split [0, length) into grainSize chunks
             // and run each on the pool. enkiTS' WaitforTask pumps the
             // main thread, so this blocks until every chunk finishes.
             //
-            // `isMainThread()` guards against nested dispatch: when
-            // executeSystem is reached from a worker (multi-system
+            // T-333: the binder resolves all per-component vector refs
+            // here on the main thread before any worker is spawned, so
+            // `EntityManager::m_pureComponentTypes`-touching code (the
+            // `getComponentType<>` hash lookup hidden inside
+            // `getComponentData<>`) never runs concurrently from
+            // workers. Workers only iterate captured refs.
+            //
+            // `isMainThread()` (T-224) guards against nested dispatch:
+            // when executeSystem is reached from a worker (multi-system
             // parallel group), IRJob::parallelFor would FATAL on its
-            // own main-thread assert. validateAllPipelineGroups now
-            // rejects PARALLEL_FOR members in multi-system groups at
-            // boot, so this path is unreachable in well-formed programs;
-            // the guard is kept as a release-build safety net.
-            const auto &rangedFn = tickEvent.rangedFunctionTick_;
+            // own main-thread assert. validateAllPipelineGroups rejects
+            // PARALLEL_FOR members in multi-system groups at boot, so
+            // this path is unreachable in well-formed programs; the
+            // guard is kept as a release-build safety net.
+            auto rangedTick = tickEvent.prepareRangedTick_(node);
             IRJob::parallelFor(
                 0,
                 node->length_,
                 grainSize,
-                [&rangedFn, node](int rangeBegin, int rangeEnd) {
-                    rangedFn(node, rangeBegin, rangeEnd);
-                }
+                [&rangedTick](int rangeBegin, int rangeEnd) { rangedTick(rangeBegin, rangeEnd); }
             );
         } else {
             // SERIAL / MAIN_THREAD path, the small-node / no-pool

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -70,7 +70,7 @@ SystemId SystemManager::createSystemDynamic(
     m_systemParams.emplace_back(nullptr);
     m_timingAccum.emplace_back();
     // T-222: dynamic systems are PARALLEL_FOR-ineligible (the body is
-    // opaque to row-level chunking — `m_ticks[…].rangedFunctionTick_` is
+    // opaque to row-level chunking — `m_ticks[…].prepareRangedTick_` is
     // never populated). T-223 still accepts SERIAL / MAIN_THREAD so the
     // Lua surface can tag EVAL systems as MAIN_THREAD to opt them out of
     // pipeline-group parallelism (the sol2 / LuaJIT GC singletons are


### PR DESCRIPTION
## Stack context

Stacked on: https://github.com/jakildev/IrredenEngine/pull/1097 (T-222)

Closes the Opus recheck nit-1 from #1097 — under `Concurrency::PARALLEL_FOR` dispatch the worker `rangedFn` called `getComponentData<>` → `getComponentType<>` → `m_pureComponentTypes::operator[]` from every chunk. `std::unordered_map::operator[]` is non-const; per the standard, concurrent calls on the same container are a data race even when no insertion happens. Worked in practice on libstdc++/libc++/MSVC because operator[] on an existing key is hash + bucket walk + reference return with no mutation — but it is latent UB that should be cleaned up before T-223 (Lua DSL opt-in) and T-225 (worker-side deferred mutations) broaden the rollout.

## Summary

- Replace `rangedFunctionTick_` (`void(ArchetypeNode*, int, int)`, called per worker chunk) with `prepareRangedTick_` (`std::function<void(int,int)>(ArchetypeNode*)`, called once on the main thread per dispatched node).
- The binder resolves `getComponentData<Components>(node)` on the main thread and returns a `void(begin, end)` worker closure that captures the resolved vector refs by value. Workers iterate captured refs without ever touching EntityManager state.
- `SystemManager::executeSystem`'s PARALLEL_FOR branch calls the binder once per node, then passes the returned closure to `IRJob::parallelFor`. SERIAL / MAIN_THREAD goes through the same binder for code-path uniformity (one extra `std::function` allocation per dispatched node per tick — bounded to a few hundred per frame, negligible vs frame budget).
- Adds `PrepareRangedTickFn` alias on `C_SystemEvent<TICK>` matching the `TickFn` / `RangedTickFn` style introduced in the rebased T-222 head.
- Updates the `engine/system/CLAUDE.md` Concurrency-policy section to describe the binder.

## Acceptance criteria (from #1105)

- [x] Worker bodies under PARALLEL_FOR no longer call `m_pureComponentTypes::operator[]` — verified by inspection; the returned closure captures vector refs by value and has no `getComponentData` call in its body.
- [x] VELOCITY_3D continues to tick correctly — IRPerfGrid runs 15 s clean.
- [ ] ThreadSanitizer-clean dispatch — deferred until the TSAN harness lands (per the original issue note).

## Test plan

- [x] `fleet-build --target IrredenEngineTest` clean (macOS Metal).
- [x] `IrredenEngineTest` — 905 / 905 pass.
- [x] `fleet-build --target IRPerfGrid` clean; `IRPerfGrid` runs 15 s without crashing (exercises PARALLEL_FOR on VELOCITY_3D / VELOCITY_DRAG / ANIMATION_COLOR).
- [x] `fleet-build --target IRShapeDebug` clean; `IRShapeDebug --auto-screenshot 10` produces all 7 shots (shutdown segfault is the existing macOS-specific issue tracked by T-336, not introduced here).
- [ ] Linux smoke (will inherit from upstream #1097's `fleet:needs-linux-smoke`).

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)