### PR TITLE
fleet: extract review-fleet-feedback pipeline into a script

### DIFF
--- a/.claude/skills/review-fleet-feedback/SKILL.md
+++ b/.claude/skills/review-fleet-feedback/SKILL.md
@@ -17,234 +17,181 @@ description: >-
 
 # review-fleet-feedback
 
-## Purpose
+A closed-loop reviewer for `~/.fleet/feedback/`. Each role appends
+timestamped notes when it sees something the human should know about;
+this skill turns that one-way channel into a track of proposed → applied
+→ closed fixes.
 
-Fleet agents (`opus-worker-*`, `sonnet-reviewer`, `merger`, `queue-manager`, etc.) append timestamped notes to `~/.fleet/feedback/<role>.md` whenever they observe something the human should know about: fleet bugs, missing permissions, recurring failure patterns, skill UX friction, suggestions. The channel is one-way and easy to forget about.
-
-This skill turns it into a closed loop:
-
-1. Pull every entry newer than the `.last-reviewed` marker.
-2. Cluster them into recurring patterns with stable signatures.
-3. For each cluster, check `.fix-log.jsonl` — if a previous fix targeted this signature and the cluster has new entries since the fix was applied, the fix didn't work. Surface as **RECURRING**.
-4. For fresh clusters with ≥2 occurrences, draft concrete fix proposals.
-5. For previously applied fixes with no recurrence in ≥7 days, auto-promote to `closed`.
-6. Ask the human which proposals to log, which previously-proposed fixes have been applied, then bump the marker.
+**Deterministic work lives in
+[`scripts/fleet/review-fleet-feedback`](../../../scripts/fleet/review-fleet-feedback).**
+This skill body picks the script, reads its JSON output, makes the two
+decisions only a human can make (which proposals are worth logging, which
+previously proposed fixes are now applied), and writes the decisions back
+through the script's `apply` subcommand. If you find yourself parsing
+feedback entries with regex in the skill body, stop — extend the script's
+`SIGNATURES` table instead.
 
 ## State files
 
 | Path | Purpose |
 |---|---|
-| `~/.fleet/feedback/<role>.md` | Source feedback entries (one file per role). Read-only here. |
-| `~/.fleet/feedback/.last-reviewed` | ISO 8601 timestamp — the watermark for "I've seen everything up to here." |
-| `~/.fleet/feedback/.fix-log.jsonl` | One JSON object per line. The closed-loop tracker. |
+| `~/.fleet/feedback/<role>.md` | Source entries (one file per role). Read-only here — agents append. |
+| `~/.fleet/feedback/.last-reviewed` | ISO timestamp watermark. Bumped on completion. |
+| `~/.fleet/feedback/.fix-log.jsonl` | Tracker. One JSON object per line. Tolerates manual edits. |
 
-Both state files live in `~/.fleet/feedback/` (not in the repo) and are managed entirely by this skill. They are not committed.
+Both state files live in `~/.fleet/feedback/` (not in the repo) and are
+managed entirely by this skill via the script. They are not committed.
 
 ## Preconditions
 
-1. `~/.fleet/feedback/` exists and contains at least one `<role>.md` file. If not, report "no fleet feedback yet" and exit.
-2. `~/bin/fleet-feedback` is installed (it is by `scripts/fleet/install.sh`). If not, fall back to reading the role files directly.
+If `~/.fleet/feedback/` is missing or empty, report "no fleet feedback yet"
+and exit.
 
 ## Flow
 
-### 1. Read the read-watermark
+### 1. Pull the digest
 
 ```bash
-MARKER=$(cat ~/.fleet/feedback/.last-reviewed 2>/dev/null || echo "")
+scripts/fleet/review-fleet-feedback digest > /tmp/fleet-digest.json
 ```
 
-- If `MARKER` is empty or unparseable, default to a 7-day window. Tell the user: "No `.last-reviewed` found — defaulting to last 7d. The marker will be created on completion."
-- If `MARKER` is present, compute the duration from `MARKER` to `now()` in hours, then pad by 1h for clock skew. Pass that as `--since Nh` to `fleet-feedback` in step 2.
+The script reads `.last-reviewed`, computes `--since`, clusters every
+entry by signature, cross-references the fix-log, and emits a single
+JSON document. Key fields:
 
-Duration math (Python one-liner). The marker is written by `date -u` (step 8), so the comparison must also be in UTC — using `datetime.now()` here would skew `--since` by the host's UTC offset:
-```bash
-SINCE=$(python3 -c "
-from datetime import datetime
-m = datetime.fromisoformat('$MARKER')
-h = int((datetime.utcnow() - m).total_seconds() // 3600) + 1
-print(f'{h}h')
-")
-```
+- `clusters` — count ≥ 2, grouped by signature. Each carries `examples`
+  (top 3) and `all` entries.
+- `singletons` — count 1 or unmatched. Surfaced for awareness; never
+  proposable.
+- `recurring` — applied fixes that have new entries after `applied_at`.
+- `still_proposed` — proposed fixes with new entries after `proposed_at`.
+- `closed_this_run` — applied fixes quiet for ≥ 7 days, auto-promoted.
+- `fresh_proposable` — clusters ≥ 2 with no open fix-log row.
+- `pending_mutations` — flips the agent will pass back to `apply` verbatim.
+- `fix_log_counts` — running totals by status.
 
-Cap the duration: if `MARKER` is more than 90 days stale, cap `SINCE` at `90d` and warn the user — anything older than 90 days is no longer load-bearing for current fixes.
+If `total_entries == 0`, skip to step 5 (still print the open fix-log and
+bump the marker — the contract is "seen," not "fixed").
 
-### 2. Pull new entries
+### 2. Draft proposals for `fresh_proposable` clusters
 
-```bash
-~/bin/fleet-feedback --since "$SINCE"
-```
+Read the JSON. For each cluster in `fresh_proposable`, write a
+one-paragraph proposal that **names the concrete artifact to change**
+(a file path or named script). Examples:
 
-This prints entries in chronological order, one block per entry:
-```
-[2026-05-14 16:49] [sonnet-reviewer] <headline>
-    <optional body line 1>
-    <optional body line 2>
-```
+> **Cluster `label-absent-after-verdict`** (37 occurrences, 5 roles, 2026-04-30 → 2026-05-20)
+> Replace the combined `gh pr edit --remove-label A --add-label B` in
+> `.claude/skills/review-pr/SKILL.md` with two separate calls and wrap
+> the add in a retry-and-verify guard (re-query labels, fail loud if the
+> verdict label is still missing after one retry). Cross-ref
+> `role-sonnet-reviewer.md` step 5b and `role-opus-reviewer.md`.
 
-If the output is empty, skip to step 8 (still surface the open fix-log and bump the marker).
+If you can't name a file path or script, the proposal is too vague — say
+so in the proposal text and tag the cluster `needs-investigation` instead.
+**One occurrence is noise; two is a pattern. Do not propose for singletons.**
 
-### 3. Cluster by signature
-
-Group entries by matching their headline + first body line against this pattern bank. Each cluster's `signature` is the join key against the fix-log — it must stay stable across runs.
-
-| Signature | Regex (case-insensitive against headline + first body line) |
-|---|---|
-| `label-absent-after-verdict` | `label\s+absent\s+after\s+verdict` |
-| `stale-task-row` | `T-\d+\b.*\b(stale\|stranded\|no-op\|stale-row)` |
-| `worktree-tracker-drift` | `fleet-worktree-busy-branches.*(drift\|stale\|missed)` |
-| `state-cache-lag` | `(cache\|projection).*(lag\|stale)` |
-| `permission-gate-friction` | `(auto.*classifier\|Self-Modification\s+gate)` |
-| `skill-flow-friction` | `(attach-screenshots\|skill\s+flow).*(friction\|surprise)` |
-| `queue-staleness` | `queue.*(staleness\|stale-queue\|starved)` |
-| `uncategorized` | anything not matching the above |
-
-For each cluster, compute:
-- `signature`
-- `count` (number of entries)
-- `roles` (set of role names involved)
-- `first_seen` / `last_seen` (timestamps)
-- 2-3 representative example entries (role, timestamp, one-line headline)
-
-Singletons (count == 1) still surface but never get a fix proposal — too thin a signal.
-
-### 4. Cross-reference the fix-log
-
-Load `~/.fleet/feedback/.fix-log.jsonl` (or treat as empty if absent). Each line is a JSON object — schema below.
-
-For every cluster:
-
-- **Look up open fixes** (`status ∈ {proposed, applied, recurring}`) whose `signature` matches.
-- **If a matching `applied` fix has entries in this cluster newer than its `applied_at`:** the fix didn't close the loop. Update the row in place: `status: recurring`, bump `recurrence_count`, set `last_recurrence_at` to the cluster's `last_seen`. Surface as **RECURRING**.
-- **If a matching `proposed` fix has entries newer than its `proposed_at`:** the proposal is still active but the pattern is still happening — surface as **STILL PROPOSED — N new occurrences** to nudge the human.
-- **If a matching `applied` fix has `last_recurrence_at` null or before `applied_at` AND `(now - applied_at) ≥ 7 days`:** auto-promote to `closed`. Set `verified_closed_at` to now. Surface in **Closed this run**. The check uses the stored `last_recurrence_at` rather than "no entries in this cluster this run" because a previous run's bumped marker can hide a recurrence outside the current window — `last_recurrence_at` is the cross-run invariant.
-- **If no matching open fix exists** for the cluster: it's a fresh cluster — falls through to step 5.
-
-### 5. Draft fix proposals for fresh clusters
-
-For each fresh cluster with `count ≥ 2`, draft a one-paragraph proposal that names the **concrete artifact to change**. Examples:
-
-> **Cluster `label-absent-after-verdict`** (6 occurrences, 2 reviewers, 2026-05-14 → 2026-05-19)
-> Proposed fix: harden the verdict-label step in `.claude/skills/review-pr/SKILL.md` — wrap `gh pr edit --add-label` in a retry-and-verify guard that exits non-zero if the label is still missing after one retry. Cross-reference [.claude/commands/role-sonnet-reviewer.md](.claude/commands/role-sonnet-reviewer.md) step 5b.
-
-> **Cluster `stale-task-row`** (12 occurrences, T-166/T-217/T-279/T-300, 2026-05-14 → 2026-05-21)
-> Proposed fix: add a maintenance-sync step to `.claude/commands/role-queue-manager.md` that re-derives `TASKS.md` from issue bodies on every queue-manager wake. Today the issue body says "done" but the row stays `free`, so workers keep claiming no-ops.
-
-A "concrete artifact" means a specific file path or named script. If you can't name one, the proposal is too vague — say so in the proposal text and leave the cluster as **needs-investigation** instead of generating a low-quality proposal.
-
-### 6. Present the digest
+### 3. Present the digest
 
 Print three sections in this order (most urgent first):
 
 ```
 RECURRING (previous fixes didn't close the loop):
-  ! fix-003 (worktree-tracker-drift) — 2 new occurrences since applied 2026-05-10
-    Last recurrence: 2026-05-20 18:30 (opus-worker-2)
-    Original proposal: <one-line summary>
+  ! fix-NNN (<signature>) — <N> occurrences since applied <date>
 
 STILL PROPOSED (not yet applied, still recurring):
-  · fix-005 (state-cache-lag) — 1 new occurrence since proposed 2026-05-15
+  · fix-NNN (<signature>) — <N> new occurrences since proposed <date>
 
 NEW PROPOSALS:
-  1. [6x] label-absent-after-verdict
+  1. [Nx] <signature>
      <proposal text>
-  2. [12x] stale-task-row
-     <proposal text>
-
-SINGLETONS (no proposal — surfaced for awareness):
-  - 2026-05-20 02:14 opus-worker-2: attach-screenshots skill flow has two friction points
-  - 2026-05-20 02:21 opus-reviewer: Projection-cache 6-second lag…
-  - …
+  …
 
 CLOSED THIS RUN (no recurrence in ≥7d):
-  ✓ fix-002 (state-cache-lag) — closed after 11d clean
+  ✓ fix-NNN (<signature>) — closed after <N>d clean
 
-Open fix-log: 4 proposed, 2 applied, 1 recurring, 8 closed (lifetime).
+Open fix-log: <P> proposed, <A> applied, <R> recurring, <C> closed.
 ```
 
-### 7. Reconcile and log
+If there are also singletons worth surfacing (a one-off but interesting
+gap), list 3-5 of them in a collapsed block; don't dump all of them.
 
-Ask the human two questions in sequence (use `AskUserQuestion`, one question at a time so the user can think):
+### 4. Reconcile
 
-**Q1: New proposals.** For each new proposal numbered above, ask: "Log proposal #N (`<signature>`) to the fix-log?" Options: `log` / `skip` / `tweak text`. For each `log`, append a new line to `.fix-log.jsonl` with `status: proposed`, fields per the schema below.
+Pick the question shape by count:
 
-**Q2: Previously proposed fixes.** For each existing row with `status: proposed`, ask: "Fix `<id>` (`<signature>`) was proposed on `<date>`. Status now?" Options: `applied` / `still-proposed` / `drop`.
-- `applied` → also ask for an `applied_ref` (PR URL, commit SHA, or file path). Flip `status: applied`, set `applied_at` = now, store `applied_ref`.
-- `still-proposed` → no change.
-- `drop` → ask for a one-line `notes` reason. Flip `status: dropped`, store the reason.
+- **≤ 4 new proposals**: ask one `AskUserQuestion` with each proposal as
+  an option (multiSelect = true).
+- **> 4 new proposals**: ask one bulk question — "log all / log top N /
+  log none / let me pick" — then drill in only if they pick the last.
+- **Previously proposed fixes** (any number): one question per fix is
+  acceptable when count ≤ 3; otherwise batch with options
+  `applied / still-proposed / drop`.
 
-Don't ask about recurring fixes here — those need design work, not a status flip. Tell the user "the recurring fixes above need new proposals; treat them as fresh clusters next run, or open a follow-up task now."
+Don't ask about `recurring` fixes here — they need a fresh proposal, not
+a status flip. Tell the human: "the recurring fixes need new design;
+treat them as fresh clusters next run, or open a follow-up task now."
 
-### 8. Bump the marker
+### 5. Apply and bump
+
+Write decisions to a JSON file (`apply --schema` prints the schema), then:
 
 ```bash
-date -u +"%Y-%m-%dT%H:%M:%S" > ~/.fleet/feedback/.last-reviewed
+scripts/fleet/review-fleet-feedback apply --decisions /tmp/fleet-decisions.json
+scripts/fleet/review-fleet-feedback bump
 ```
 
-Always bump at the end, even if the user dismissed everything without acting. The contract is "I've seen these," not "I've fixed these."
+The script handles ID assignment (`fix-NNN`, monotonic), status flips,
+and atomic file rewrites. **Always include `pending_mutations` from the
+digest in the decisions JSON** so the `flip-to-recurring` and
+`flip-to-closed` transitions land.
 
-If the skill errors out before reaching this step, **do not** bump the marker — leave it stale so the next run re-surfaces the entries.
+If anything errored before this step, **do not bump the marker** —
+leave it stale so the next run re-surfaces the entries.
 
-### 9. End-of-run summary
+### 6. End-of-run summary
 
-Print a one-paragraph summary:
+One paragraph:
 
 ```
-Reviewed N entries since YYYY-MM-DD HH:MM (X clusters, Y singletons).
-M new proposals logged, K previously proposed fixes resolved, L auto-closed.
-Marker bumped to YYYY-MM-DDTHH:MM:SS UTC.
-Open fix-log: <proposed-count> proposed, <applied-count> applied, <recurring-count> recurring.
+Reviewed N entries since <date> (C clusters, S singletons).
+M new proposals logged, K previously proposed resolved, L auto-closed.
+Marker bumped to <ts> UTC.
+Open fix-log: <counts>.
 ```
 
-## Fix-log schema (`~/.fleet/feedback/.fix-log.jsonl`)
+## Fix-log schema
 
-One JSON object per line. New rows append; updates rewrite the file (fine — log stays small).
+The script owns the schema; run `apply --schema` for the canonical form.
+Manual edits to `.fix-log.jsonl` are tolerated — the script `setdefault`s
+missing fields and re-emits a valid line on rewrite.
 
-```json
-{
-  "id": "fix-007",
-  "signature": "label-absent-after-verdict",
-  "proposed_at": "2026-05-21T18:42:00",
-  "first_seen": "2026-05-14T16:49:00",
-  "occurrences_at_proposal": 6,
-  "proposal": "Harden verdict-label step in review-pr/SKILL.md — wrap gh pr edit in retry-and-verify guard…",
-  "status": "proposed",
-  "applied_at": null,
-  "applied_ref": null,
-  "verified_closed_at": null,
-  "last_recurrence_at": null,
-  "recurrence_count": 0,
-  "notes": null
-}
-```
-
-**ID assignment:** `fix-NNN`, monotonically increasing. Read the highest existing ID, add 1. Pad to 3 digits.
-
-**Status transitions:**
+Status transitions (driven by step 5 + the script):
 
 | From | To | Trigger |
 |---|---|---|
-| `proposed` | `applied` | Human confirms during step 7 |
-| `proposed` | `dropped` | Human drops during step 7 |
-| `applied` | `recurring` | Step 4 sees fresh entries after `applied_at` |
-| `applied` | `closed` | Step 4 sees `last_recurrence_at` null-or-before-`applied_at` and `(now - applied_at) ≥ 7d` |
-| `recurring` | `applied` | Human re-applies a tweaked fix (manual JSON edit, or surface a fresh proposal next run that supersedes) |
-| `recurring` | `dropped` | Give up |
-
-**Manual edits:** the human can hand-edit `.fix-log.jsonl` between runs. The skill must tolerate missing fields gracefully (treat as `null`) and re-emit a valid line on rewrite.
+| `proposed` | `applied` | Human confirms during step 4 (requires `applied_ref`). |
+| `proposed` | `dropped` | Human drops during step 4 (requires `notes`). |
+| `applied`  | `recurring` | Digest sees fresh entries after `applied_at`. |
+| `applied`  | `closed` | Digest sees no recurrence for ≥ 7d. |
+| `recurring`| `applied` | Human re-applies a tweaked fix (manual edit or new proposal supersedes). |
+| `recurring`| `dropped` | Give up. |
 
 ## Anti-patterns
 
-- **Don't bump `.last-reviewed` before the digest is complete.** If the skill crashes mid-run, the entries must still be there next time.
-- **Don't auto-close a fix on the same run it was applied.** The 7-day no-recurrence window is the whole verification mechanism — collapsing it defeats the closed loop.
-- **Don't propose a duplicate fix for a signature that already has an open log entry.** That cluster should be surfaced as RECURRING or STILL PROPOSED, never re-proposed.
-- **Don't propose fixes for singletons.** One occurrence is noise. Two is a pattern.
-- **Don't propose vague fixes.** Every proposal must name a concrete file path or script. Vague ones go to **needs-investigation** instead.
-- **Don't touch the role feedback files** (`<role>.md`). They are append-only from the agents' side; rewriting them would corrupt the agents' future appends and lose history.
-- **Don't apply fixes inline.** This skill is propose-only. The human (or a follow-up skill) applies the fix in a separate edit, then confirms in the next run.
-- **Don't scrape PR comments in v1.** That's a separate feedback channel with different semantics. Adding it here would double the surface area for marginal gain.
+- **Don't bump the marker before the digest is complete.** If anything
+  errors mid-run, entries must still be there next time.
+- **Don't auto-close on the same run a fix was applied.** The 7-day quiet
+  window is the whole verification mechanism.
+- **Don't propose duplicates of an open fix-log row.** The script surfaces
+  the cluster as `recurring` or `still_proposed`; re-proposing it
+  bypasses the closed-loop.
+- **Don't extend `SIGNATURES` in the skill body.** It lives in the script
+  so it's diff-able and (when needed) testable. The skill body refers to
+  it by name.
 
 ## Recovery
 
-- **Corrupt `.fix-log.jsonl`** (a line fails to parse): print the offending line, skip it, continue with the rest. Tell the user at the end so they can fix it manually.
-- **`fleet-feedback` CLI missing**: fall back to reading `~/.fleet/feedback/*.md` directly with the same regex used in [scripts/fleet/fleet-feedback](../../../scripts/fleet/fleet-feedback): `^## (\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?)`.
-- **Marker file unwritable**: error out before the digest. Don't half-bump.
+- **Corrupt fix-log line**: the script logs `WARN: …; skipping` to stderr
+  and continues. Surface the warning to the human at the end.
+- **Marker `>90d` stale**: the script caps `--since` at 90d and sets
+  `marker_note`. Print the note in the digest header.

--- a/scripts/fleet/review-fleet-feedback
+++ b/scripts/fleet/review-fleet-feedback
@@ -464,8 +464,12 @@ def cmd_apply(args: argparse.Namespace) -> int:
         print("error: --decisions <file.json> is required", file=sys.stderr)
         return 2
 
-    with open(args.decisions) as f:
-        d = json.load(f)
+    try:
+        with open(args.decisions) as f:
+            d = json.load(f)
+    except FileNotFoundError:
+        print(f"error: decisions file not found: {args.decisions}", file=sys.stderr)
+        return 2
     now = d.get("now") or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
 
     rows = load_fix_log()

--- a/scripts/fleet/review-fleet-feedback
+++ b/scripts/fleet/review-fleet-feedback
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""review-fleet-feedback — closed-loop tracker for ~/.fleet/feedback/.
+
+Pipeline backing the .claude/skills/review-fleet-feedback skill.
+Splits the deterministic work (read entries, cluster by signature,
+cross-reference the fix-log, auto-close stale-applied fixes) from
+the judgment work (which proposals to log, which previously
+proposed fixes were applied), which stays in the skill body.
+
+Subcommands:
+  digest             Read role files, cluster, cross-reference the fix-log,
+                     emit a JSON document to stdout. Reads --since from
+                     .last-reviewed (with a 90d cap and a 7d default).
+  apply <file.json>  Mutate .fix-log.jsonl per the decisions in <file.json>.
+                     Schema: see `apply --schema`.
+  bump               Write current UTC timestamp to .last-reviewed.
+                     Run only after the digest is complete.
+
+The fix-log lives at ~/.fleet/feedback/.fix-log.jsonl. The marker at
+~/.fleet/feedback/.last-reviewed. Neither is committed.
+
+Source of truth: scripts/fleet/review-fleet-feedback in the engine repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+FEEDBACK_DIR = Path.home() / ".fleet" / "feedback"
+MARKER = FEEDBACK_DIR / ".last-reviewed"
+FIX_LOG = FEEDBACK_DIR / ".fix-log.jsonl"
+
+DEFAULT_SINCE_HOURS = 24 * 7      # 7d cold-start window
+MAX_SINCE_HOURS = 24 * 90         # cap stale markers at 90d
+AUTO_CLOSE_DAYS = 7               # quiet days before auto-close
+MIN_CLUSTER_SIZE_FOR_PROPOSAL = 2 # singletons never get a proposal
+
+ENTRY_HEAD_FILE = re.compile(r"^## (\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?)$")
+
+# Pattern bank — order matters; first match wins. Widen aggressively;
+# uncategorized noise drowns the signal otherwise.
+SIGNATURES: list[tuple[str, re.Pattern]] = [
+    ("label-absent-after-verdict", re.compile(
+        r"(label\s+(absent|missing|never\s+set|stripped|cleared|left\s+stale)"
+        r"|verdict\s+labels?\s+(absent|missing|never|stripped)"
+        r"|missing\s+verdict\s+labels?"
+        r"|fleet:(needs-fix|approved|changes-made|needs-base-update|has-nits|semantic-conflict)\b"
+        r".*(absent|missing|never|stripped|cleared|left\s+stale|re-?applies|re-?applied|stale)"
+        r"|verdict[- ]?(set|command|template)"
+        r"|swap.*label|label[- ]swap|no\s+fleet:[a-z-]+\s+label)", re.I)),
+    ("stale-task-row", re.compile(
+        r"(T-\d+\b.*(stale|stranded|no-op|already\s+complete|loop|trap|pickup|wedge"
+        r"|still\s+(open|in\s+TASKS|stuck)|reorder|decomposition|superseded|recur|TASKS\.md)"
+        r"|stale[- ]?(TASKS\.md|task\s+row|row|done|open)"
+        r"|TASKS\.md\s+(stale|sync\s+lag|race|still|relative)"
+        r"|queue-manager.*(sync|lag|reconcil|tick|flipped|re-opened|not\s+(tick|reconcil|mov))"
+        r"|maintenance-sync|sqt-phase-a\s+wedge)", re.I)),
+    ("worktree-tracker-drift", re.compile(
+        r"(fleet-worktree-busy-branches"
+        r"|worktree.*(branch-lock|race|drift|reservation|stranded|contention)"
+        r"|worktree\s+(reservation|prune)|stale\s+worktree)", re.I)),
+    ("state-cache-lag", re.compile(
+        r"((cache|projection|scout|state\.json|sonnet-reviewer\.json|tasks_open|snapshot)"
+        r".*(lag|stale|race|raced|miss|6-second|stale-cache|stale-data"
+        r"|stale\s+snapshot|stale\s+view|stale\s+projection|dropped|missed|mixes)"
+        r"|live[- ]state|Within-iteration\s+stale|stale-cache\s+race)", re.I)),
+    ("permission-gate-friction", re.compile(
+        r"(auto.*classifier|auto-mode\s+classifier|Self-Modification\s+gate"
+        r"|security\s+hook|sandbox)", re.I)),
+    ("skill-flow-friction", re.compile(
+        r"(attach-screenshots|skill\s+flow|skill\s+errored|review-pr\s+skill"
+        r"|fleet-iteration-summary|fleet-issue\s+view)", re.I)),
+    ("queue-staleness", re.compile(
+        r"(queue.*(staleness|stale-queue|starved|wall|wedge|wedged|starving|race|backlog|invisible)"
+        r"|stale-queue\s+wall|fleet:queued\b.*(diverge|no\s+TASKS|ingest))", re.I)),
+    ("worktree-misroute", re.compile(
+        r"(worktree\s+misroute|edited?\s+parent\s+clone"
+        r"|silently\s+(writes?|edited|failed)\s+(to\s+(wrong\s+worktree|parent)|to\s+persist)"
+        r"|Edit/Write\s+tools\s+silently)", re.I)),
+    ("stacked-pr-merger-gap", re.compile(
+        r"(stacked\s+PR|fleet:awaiting-base|MERGEABLE\s+stacked"
+        r"|merger\s+(re-?target|falls?\s+through|left\s+rebase|posted)"
+        r"|semantic-?conflict.*(comment|storm|stale)|merger-cooldown)", re.I)),
+    ("format-target-overreach", re.compile(
+        r"fleet-build\s+--target\s+format", re.I)),
+    ("stackable-false-positive", re.compile(
+        r"(stackable_blocker_pr"
+        r"|stackable\s+(false-positive|fallback|blocked-tier|blocker|premature)"
+        r"|stackable[- ]blocked|fallback-tier\s+candidate)", re.I)),
+    ("design-escalation-gap", re.compile(
+        r"(design[- ](blocked|unblocked|escalat|doc.*(gap|audit))"
+        r"|escalated\s+PR|twice-escalated|fleet:design-unblocked"
+        r"|cross-system\s+audit\s+gap)", re.I)),
+    ("concurrent-reviewer-claim", re.compile(
+        r"(both\s+claimed.*concurrent|fleet:reviewing-<role>"
+        r"|reviewing-(opus|sonnet)\s+lock"
+        r"|per-role.*does\s+not\s+cross-block)", re.I)),
+]
+
+
+# ───── Entry parsing ──────────────────────────────────────────────────────
+
+@dataclass
+class Entry:
+    ts: str             # ISO-ish "YYYY-MM-DD HH:MM"
+    role: str
+    headline: str
+    body: list[str] = field(default_factory=list)
+
+    @property
+    def dt(self) -> datetime:
+        s = self.ts.replace(" ", "T")
+        # Headlines from feedback files use "YYYY-MM-DD HH:MM" (no seconds);
+        # be permissive about the seconds variant.
+        for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M"):
+            try:
+                return datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+        raise ValueError(f"unparseable entry timestamp: {self.ts!r}")
+
+
+def role_files() -> list[Path]:
+    if not FEEDBACK_DIR.exists():
+        return []
+    return sorted(p for p in FEEDBACK_DIR.glob("*.md") if not p.name.startswith("."))
+
+
+def parse_role_file(path: Path) -> list[Entry]:
+    """Parse a role feedback file into Entry objects.
+
+    Same regex as scripts/fleet/fleet-feedback for entry boundaries.
+    """
+    role = path.stem
+    entries: list[Entry] = []
+    cur: Entry | None = None
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        m = ENTRY_HEAD_FILE.match(raw)
+        if m:
+            if cur:
+                entries.append(cur)
+            cur = Entry(ts=m.group(1).replace("T", " "), role=role, headline="")
+            continue
+        if cur is None:
+            continue
+        if not cur.headline:
+            stripped = raw.strip()
+            if stripped:
+                cur.headline = stripped
+        else:
+            stripped = raw.strip()
+            if stripped:
+                cur.body.append(stripped)
+    if cur:
+        entries.append(cur)
+    return entries
+
+
+def read_entries(since_hours: int) -> list[Entry]:
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=since_hours)
+    out: list[Entry] = []
+    for p in role_files():
+        for e in parse_role_file(p):
+            try:
+                if e.dt >= cutoff:
+                    out.append(e)
+            except ValueError:
+                # malformed timestamp — surface in stderr, skip the entry
+                print(f"WARN: skipping malformed entry in {p.name}: {e.ts!r}", file=sys.stderr)
+    out.sort(key=lambda x: x.dt)
+    return out
+
+
+# ───── Clustering ─────────────────────────────────────────────────────────
+
+def signature_for(entry: Entry) -> str:
+    first_body = entry.body[0] if entry.body else ""
+    text = entry.headline + "\n" + first_body
+    for sig, rx in SIGNATURES:
+        if rx.search(text):
+            return sig
+    return "uncategorized"
+
+
+@dataclass
+class Cluster:
+    signature: str
+    entries: list[Entry] = field(default_factory=list)
+
+    def to_dict(self, include_all: bool = True) -> dict[str, Any]:
+        first = self.entries[0]
+        last = self.entries[-1]
+        d = {
+            "signature": self.signature,
+            "count": len(self.entries),
+            "roles": sorted({e.role for e in self.entries}),
+            "first_seen": first.ts,
+            "last_seen": last.ts,
+            "examples": [
+                {"ts": e.ts, "role": e.role, "headline": e.headline}
+                for e in self.entries[:3]
+            ],
+        }
+        if include_all:
+            d["all"] = [
+                {"ts": e.ts, "role": e.role, "headline": e.headline}
+                for e in self.entries
+            ]
+        return d
+
+
+def cluster_entries(entries: list[Entry]) -> list[Cluster]:
+    buckets: dict[str, list[Entry]] = defaultdict(list)
+    for e in entries:
+        buckets[signature_for(e)].append(e)
+    clusters = [Cluster(sig, sorted(es, key=lambda x: x.dt)) for sig, es in buckets.items()]
+    clusters.sort(key=lambda c: -len(c.entries))
+    return clusters
+
+
+# ───── Fix-log ────────────────────────────────────────────────────────────
+
+FIX_LOG_FIELDS = (
+    "id", "signature", "proposed_at", "first_seen", "occurrences_at_proposal",
+    "proposal", "status", "applied_at", "applied_ref",
+    "verified_closed_at", "last_recurrence_at", "recurrence_count", "notes",
+)
+
+
+def load_fix_log() -> list[dict[str, Any]]:
+    """Read the fix-log, tolerating missing fields and bad lines."""
+    if not FIX_LOG.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for i, line in enumerate(FIX_LOG.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            print(f"WARN: .fix-log.jsonl line {i} is not valid JSON; skipping: {line[:120]!r}",
+                  file=sys.stderr)
+            continue
+        for f in FIX_LOG_FIELDS:
+            r.setdefault(f, None)
+        rows.append(r)
+    return rows
+
+
+def write_fix_log(rows: list[dict[str, Any]]) -> None:
+    """Rewrite the fix-log. Atomic via tmpfile+rename."""
+    FIX_LOG.parent.mkdir(parents=True, exist_ok=True)
+    tmp = FIX_LOG.with_suffix(".jsonl.tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        for r in rows:
+            ordered = {k: r.get(k) for k in FIX_LOG_FIELDS}
+            f.write(json.dumps(ordered) + "\n")
+    tmp.replace(FIX_LOG)
+
+
+def next_fix_id(rows: list[dict[str, Any]]) -> str:
+    nums = []
+    for r in rows:
+        m = re.match(r"^fix-(\d+)$", r.get("id", "") or "")
+        if m:
+            nums.append(int(m.group(1)))
+    n = (max(nums) if nums else 0) + 1
+    return f"fix-{n:03d}"
+
+
+def parse_dt(s: str | None) -> datetime | None:
+    if not s:
+        return None
+    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+        try:
+            return datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+# ───── Cross-reference ────────────────────────────────────────────────────
+
+def cross_reference(
+    clusters: list[Cluster], rows: list[dict[str, Any]], now: datetime
+) -> tuple[list[dict], list[dict], list[dict], list[Cluster], list[Cluster], list[dict]]:
+    """Bucket clusters against the fix-log.
+
+    Returns (recurring, still_proposed, closed, fresh, singletons, mutations).
+    `mutations` are pending status flips (flip-to-recurring, flip-to-closed)
+    that the digest emits so `apply` can write them back atomically.
+    """
+    recurring: list[dict] = []
+    still_proposed: list[dict] = []
+    closed: list[dict] = []
+    fresh: list[Cluster] = []
+    singletons: list[Cluster] = []
+    mutations: list[dict] = []
+
+    by_sig: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        by_sig[r["signature"]].append(r)
+
+    seen_sigs: set[str] = set()
+    for c in clusters:
+        seen_sigs.add(c.signature)
+        open_rows = [r for r in by_sig.get(c.signature, [])
+                     if r["status"] in ("proposed", "applied", "recurring")]
+
+        if not open_rows:
+            if c.signature == "uncategorized":
+                singletons.append(c)
+            elif c.entries and len(c.entries) >= MIN_CLUSTER_SIZE_FOR_PROPOSAL:
+                fresh.append(c)
+            else:
+                singletons.append(c)
+            continue
+
+        latest = max(open_rows, key=lambda r: r.get("proposed_at") or "")
+        last_entry_dt = c.entries[-1].dt
+
+        if latest["status"] == "applied":
+            applied_dt = parse_dt(latest["applied_at"])
+            new_after_apply = applied_dt and last_entry_dt > applied_dt
+            if new_after_apply:
+                recurring.append({"row": latest, "cluster": c.to_dict(False)})
+                mutations.append({
+                    "op": "flip-to-recurring",
+                    "id": latest["id"],
+                    "last_recurrence_at": c.entries[-1].ts.replace(" ", "T"),
+                })
+        elif latest["status"] == "proposed":
+            proposed_dt = parse_dt(latest["proposed_at"])
+            new_after_propose = proposed_dt and last_entry_dt > proposed_dt
+            if new_after_propose:
+                still_proposed.append({
+                    "row": latest,
+                    "new_occurrences": sum(
+                        1 for e in c.entries if e.dt > proposed_dt
+                    ),
+                    "last_entry": c.entries[-1].ts,
+                })
+        elif latest["status"] == "recurring":
+            # Already known — surface in recurring list with bumped count.
+            recurring.append({"row": latest, "cluster": c.to_dict(False)})
+
+    # Auto-close pass: applied fixes whose cluster did not surface this run
+    # AND whose last_recurrence_at is null-or-before-applied_at AND
+    # (now - applied_at) >= AUTO_CLOSE_DAYS.
+    for r in rows:
+        if r["status"] != "applied":
+            continue
+        if r["signature"] in seen_sigs:
+            continue  # cluster surfaced; either recurring or quiet-but-not-7d
+        applied_dt = parse_dt(r["applied_at"])
+        if not applied_dt:
+            continue
+        if (now - applied_dt).days < AUTO_CLOSE_DAYS:
+            continue
+        last_rec = parse_dt(r["last_recurrence_at"])
+        if last_rec and last_rec > applied_dt:
+            continue  # there was a recurrence we already logged
+        closed.append({"row": r, "quiet_days": (now - applied_dt).days})
+        mutations.append({
+            "op": "flip-to-closed",
+            "id": r["id"],
+            "verified_closed_at": now.strftime("%Y-%m-%dT%H:%M:%S"),
+        })
+
+    return recurring, still_proposed, closed, fresh, singletons, mutations
+
+
+# ───── Subcommands ────────────────────────────────────────────────────────
+
+def cmd_digest(args: argparse.Namespace) -> int:
+    if not FEEDBACK_DIR.exists():
+        print(json.dumps({"error": "no fleet feedback yet", "feedback_dir": str(FEEDBACK_DIR)}))
+        return 1
+
+    marker_dt: datetime | None = None
+    if MARKER.exists():
+        marker_dt = parse_dt(MARKER.read_text().strip())
+    if marker_dt is None:
+        since_hours = DEFAULT_SINCE_HOURS
+        marker_note = "no marker — defaulted to 7d"
+    else:
+        delta = datetime.now(timezone.utc) - marker_dt
+        since_hours = int(delta.total_seconds() // 3600) + 1
+        marker_note = None
+        if since_hours > MAX_SINCE_HOURS:
+            since_hours = MAX_SINCE_HOURS
+            marker_note = f"marker >90d stale; capped at {MAX_SINCE_HOURS}h"
+
+    entries = read_entries(since_hours)
+    clusters = cluster_entries(entries)
+    rows = load_fix_log()
+    now = datetime.now(timezone.utc)
+    recurring, still_proposed, closed, fresh, singletons, mutations = cross_reference(
+        clusters, rows, now
+    )
+
+    counts = {"proposed": 0, "applied": 0, "recurring": 0, "closed": 0, "dropped": 0}
+    for r in rows:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+
+    out = {
+        "since_hours": since_hours,
+        "marker": MARKER.read_text().strip() if MARKER.exists() else None,
+        "marker_note": marker_note,
+        "now": now.strftime("%Y-%m-%dT%H:%M:%S"),
+        "total_entries": len(entries),
+        "clusters": [c.to_dict() for c in clusters
+                     if c.signature != "uncategorized" and len(c.entries) >= MIN_CLUSTER_SIZE_FOR_PROPOSAL],
+        "singletons": [
+            {"ts": e.ts, "role": e.role, "headline": e.headline,
+             "signature": signature_for(e)}
+            for c in clusters for e in c.entries
+            if len(c.entries) < MIN_CLUSTER_SIZE_FOR_PROPOSAL or c.signature == "uncategorized"
+        ],
+        "recurring": recurring,
+        "still_proposed": still_proposed,
+        "closed_this_run": closed,
+        "fresh_proposable": [c.to_dict() for c in fresh],
+        "pending_mutations": mutations,
+        "fix_log_counts": counts,
+    }
+    json.dump(out, sys.stdout, indent=2, default=str)
+    sys.stdout.write("\n")
+    return 0
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    """Mutate the fix-log per the decisions in <decisions.json>.
+
+    Schema:
+      {
+        "now": "YYYY-MM-DDTHH:MM:SS",  // optional; defaults to now
+        "new_proposals": [
+          {"signature": "...", "first_seen": "YYYY-MM-DDTHH:MM:SS",
+           "occurrences_at_proposal": int, "proposal": "..."}
+        ],
+        "status_transitions": [
+          {"id": "fix-NNN", "to": "applied|dropped",
+           "applied_ref": "...",   // required for applied
+           "notes": "..."}         // required for dropped
+        ],
+        "pending_mutations": [      // from digest output, applied as-is
+          {"op": "flip-to-recurring|flip-to-closed", "id": "fix-NNN", ...}
+        ]
+      }
+    """
+    if args.schema:
+        print(cmd_apply.__doc__)
+        return 0
+    if not args.decisions:
+        print("error: --decisions <file.json> is required", file=sys.stderr)
+        return 2
+
+    with open(args.decisions) as f:
+        d = json.load(f)
+    now = d.get("now") or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+    rows = load_fix_log()
+    by_id = {r["id"]: r for r in rows}
+
+    # Pending mutations from the digest (flip-to-recurring, flip-to-closed).
+    for m in d.get("pending_mutations") or []:
+        r = by_id.get(m["id"])
+        if not r:
+            print(f"WARN: pending mutation references missing id {m['id']}", file=sys.stderr)
+            continue
+        op = m["op"]
+        if op == "flip-to-recurring":
+            r["status"] = "recurring"
+            r["last_recurrence_at"] = m.get("last_recurrence_at") or now
+            r["recurrence_count"] = (r.get("recurrence_count") or 0) + 1
+        elif op == "flip-to-closed":
+            r["status"] = "closed"
+            r["verified_closed_at"] = m.get("verified_closed_at") or now
+        else:
+            print(f"WARN: unknown pending mutation op {op!r}", file=sys.stderr)
+
+    # Human-driven status transitions.
+    for t in d.get("status_transitions") or []:
+        r = by_id.get(t["id"])
+        if not r:
+            print(f"WARN: status transition references missing id {t['id']}", file=sys.stderr)
+            continue
+        to = t["to"]
+        if to == "applied":
+            r["status"] = "applied"
+            r["applied_at"] = now
+            r["applied_ref"] = t.get("applied_ref")
+        elif to == "dropped":
+            r["status"] = "dropped"
+            r["notes"] = t.get("notes")
+        else:
+            print(f"WARN: unknown status transition {to!r}", file=sys.stderr)
+
+    # Append new proposals.
+    new_ids: list[str] = []
+    for p in d.get("new_proposals") or []:
+        nid = next_fix_id(rows)
+        new_row = {
+            "id": nid,
+            "signature": p["signature"],
+            "proposed_at": now,
+            "first_seen": p.get("first_seen"),
+            "occurrences_at_proposal": p.get("occurrences_at_proposal"),
+            "proposal": p["proposal"],
+            "status": "proposed",
+            "applied_at": None,
+            "applied_ref": None,
+            "verified_closed_at": None,
+            "last_recurrence_at": None,
+            "recurrence_count": 0,
+            "notes": None,
+        }
+        rows.append(new_row)
+        new_ids.append(nid)
+
+    write_fix_log(rows)
+    print(json.dumps({"new_proposal_ids": new_ids, "rows_after": len(rows)}))
+    return 0
+
+
+def cmd_bump(args: argparse.Namespace) -> int:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    MARKER.parent.mkdir(parents=True, exist_ok=True)
+    MARKER.write_text(ts + "\n")
+    print(ts)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="review-fleet-feedback",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("digest",
+                   help="Read role files, cluster, cross-reference fix-log, emit JSON.")
+
+    apply = sub.add_parser("apply",
+                           help="Mutate .fix-log.jsonl per decisions in <file.json>.")
+    apply.add_argument("--decisions", "-d", help="Path to decisions JSON.")
+    apply.add_argument("--schema", action="store_true",
+                       help="Print the decisions-JSON schema and exit.")
+
+    sub.add_parser("bump",
+                   help="Write current UTC timestamp to .last-reviewed.")
+
+    args = parser.parse_args()
+
+    if args.cmd == "digest":
+        return cmd_digest(args)
+    if args.cmd == "apply":
+        return cmd_apply(args)
+    if args.cmd == "bump":
+        return cmd_bump(args)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Move the deterministic work in `.claude/skills/review-fleet-feedback/SKILL.md` (clustering, fix-log I/O, status transitions, auto-close) into a new `scripts/fleet/review-fleet-feedback` executable with three subcommands: `digest`, `apply --decisions <file>`, `bump`.
- Widen the `SIGNATURES` pattern bank inside the script — combined-label-swap variants, T-NNN stale-row phrasings, queue-staleness body matches, design-escalation, concurrent-reviewer-claim. Drops uncategorized share from ~36% to ~11% on the current 149-entry corpus.
- Shrink the skill body from 13749 → 8037 bytes (~42%). The remaining prose is the agent-decisional path: which proposals to draft, how to present the digest, when to ask one-bulk vs per-proposal in `AskUserQuestion`. The pattern bank, atomic file rewrites, schema, and ID assignment all live in the script.
- Closed-loop semantics preserved: auto-close still requires `last_recurrence_at` null-or-before-`applied_at` AND `(now - applied_at) >= 7d`, computed against the persisted invariant rather than "didn't appear this run" — so a bumped marker can't hide a recurrence outside the current window.

Authored on the engine repo with no game-side touches; cross-repo isolation check is clean.

## Test plan
- [x] `scripts/fleet/review-fleet-feedback digest > /tmp/d.json` against the current `~/.fleet/feedback/` (149 entries since 2026-04-30) — clusters 12 patterns + 16 singletons, 9 proposals already logged in `.fix-log.jsonl`, marker bumped.
- [x] `apply --schema` prints the decisions-JSON shape.
- [x] No-op `apply --decisions` roundtrip leaves the fix-log byte-identical.
- [x] `apply --decisions` with a `status_transitions: [{id: "fix-009", to: "applied", applied_ref: "test-PR-9999"}]` flips the row in place; reverting the row file restores `proposed`.
- [x] Backdated marker (`echo "2026-04-30T18:10:01" > ~/.fleet/feedback/.last-reviewed`) replays the full window and emits the same 12 clusters; `still_proposed` stays empty (correctly — all 9 proposals' `proposed_at` is after every entry).
- [ ] Naming nit (reviewer judgment): every other tool in `scripts/fleet/` uses the `fleet-*` prefix. I kept `review-fleet-feedback` to match the skill name; happy to rename to `fleet-review-feedback` if you'd rather.

Follow-up not in this PR:
- Add an entry to `scripts/fleet/fleet-help` for the new tool (manual case-statement index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)