### PR TITLE
T-337: Tools: shell autocomplete for ir-build and ir-run targets

### DIFF
--- a/scripts/fleet/README.md
+++ b/scripts/fleet/README.md
@@ -53,10 +53,10 @@ fleet workflow.
   tmux fleet, claims, …) and how to install them; `fleet-help <cmd>`
   forwards to `--help` when the tool supports it (or a short summary).
 - **`completions/fleet-run.bash`** — bash tab completion for `fleet-run`
-  (built exe names when the word does not start with `-`) and
-  `fleet-build` (CMake demo names after `--target`) plus `fleet-debug`.
-  `install.sh`
-  symlinks it into `${XDG_DATA_HOME:-~/.local/share}/bash-completion/completions/`
+  and `ir-run` (built exe names when the word does not start with `-`),
+  `fleet-build` and `ir-build` (CMake demo names after `--target`), plus
+  `fleet-debug`. `install.sh` symlinks it into
+  `${XDG_DATA_HOME:-~/.local/share}/bash-completion/completions/`
   for bash-completion / Homebrew `bash-completion@2`.
 - **`completions/irreden-fleet.zsh`** — zsh entry: ensures `compinit` (if
   needed), runs `bashcompinit`, then sources `fleet-run.bash`. **macOS

--- a/scripts/fleet/completions/fleet-run.bash
+++ b/scripts/fleet/completions/fleet-run.bash
@@ -1,15 +1,15 @@
-# Bash programmable completion for fleet-run, fleet-build, and fleet-debug.
+# Bash programmable completion for fleet-run, fleet-build, fleet-debug, ir-run, ir-build.
 # Bash 3.2+ (macOS default). Uses compgen, not mapfile.
 #
-# fleet-run: words not starting with "-" complete built executable basenames
+# fleet-run / ir-run: words not starting with "-" complete built executable basenames
 # (same set as "fleet-run-targets --plain"). Leading "-" completes flags.
 # After "--targets", completes fleet-run-targets flags when appropriate.
 #
-# fleet-build: after "--target", completes curated CMake demo/test names
+# fleet-build / ir-build: after "--target", completes curated CMake demo/test names
 # (same as "fleet-run-targets --plan --plain").
 #
 # install.sh symlinks this file into:
-#   ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/{fleet-run,fleet-build,fleet-debug}
+#   ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/{fleet-run,fleet-build,fleet-debug,ir-run,ir-build}
 # Requires bash-completion to load ~/.local/share/bash-completion/completions/*
 # (many distros and Homebrew bash-completion@2 do). Otherwise: source this file.
 #
@@ -194,3 +194,5 @@ _irreden_fleet_debug_complete() {
 complete -F _irreden_fleet_run_complete fleet-run
 complete -F _irreden_fleet_build_complete fleet-build
 complete -F _irreden_fleet_debug_complete fleet-debug
+complete -F _irreden_fleet_run_complete ir-run
+complete -F _irreden_fleet_build_complete ir-build

--- a/scripts/fleet/completions/irreden-fleet.zsh
+++ b/scripts/fleet/completions/irreden-fleet.zsh
@@ -1,4 +1,4 @@
-# Zsh: fleet-run / fleet-build / fleet-debug completion via bashcompinit + fleet-run.bash
+# Zsh: fleet-run / fleet-build / fleet-debug / ir-run / ir-build completion via bashcompinit + fleet-run.bash
 #
 # Install: scripts/fleet/install.sh symlinks this file and fleet-run.bash into
 #   ~/.zsh/completions/ and idempotently appends a marked source line to

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -133,8 +133,8 @@ Irreden Engine — fleet tooling index
 One-time PATH setup (symlinks ~/bin/fleet-* and friends):
   scripts/fleet/install.sh
   (ensure ~/bin is on your PATH — install.sh prints a hint if not)
-  Same script installs tab completion for fleet-run / fleet-build (bash +
-  zsh); install.sh --help
+  Same script installs tab completion for fleet-run / fleet-build / ir-run / ir-build
+  (bash + zsh); install.sh --help
 
 More context:
   scripts/fleet/README.md

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -353,7 +353,9 @@ if [[ -f "$FLEET_COMP_SRC" ]]; then
     ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-run"
     ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-build"
     ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-debug"
-    echo "symlinked bash completion -> $BASH_COMP_DIR/fleet-run (+ fleet-build, fleet-debug)"
+    ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/ir-run"
+    ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/ir-build"
+    echo "symlinked bash completion -> $BASH_COMP_DIR/fleet-run (+ fleet-build, fleet-debug, ir-run, ir-build)"
 fi
 
 # Zsh: bash-completion dirs are not read by zsh; irreden-fleet.zsh uses
@@ -485,8 +487,8 @@ esac
 
 if [[ -f "$FLEET_COMP_SRC" ]]; then
     echo
-    echo "Bash tab-completion for fleet-run / fleet-build / fleet-debug (built targets and"
-    echo "  fleet-build --target names) installs under:"
+    echo "Bash tab-completion for fleet-run / fleet-build / fleet-debug / ir-run / ir-build"
+    echo "  (built targets and --target names) installs under:"
     echo "    $BASH_COMP_DIR"
     echo "  Open a new bash login shell (or: source your bash-completion init)"
     echo "  so it loads. Ubuntu/Debian: install the \`bash-completion\` package;"
@@ -495,7 +497,7 @@ fi
 
 if [[ -f "$FLEET_ZSH_COMP_SRC" ]]; then
     echo
-    echo "zsh: tab completion for fleet-run / fleet-build uses ~/.zsh/completions/"
+    echo "zsh: tab completion for fleet-run / fleet-build / ir-run / ir-build uses ~/.zsh/completions/"
     echo "  (bash-completion paths are not loaded by zsh by default.)"
     if ((INSTALL_APPEND_ZSHRC)); then
         echo "  If ~/.zshrc was updated, open a new terminal or \`source ~/.zshrc\`."


### PR DESCRIPTION
## Summary
- Add `complete` directives for `ir-run` (positional exe name) and `ir-build` (`--target <name>`) in `scripts/fleet/completions/fleet-run.bash`, reusing the existing `_irreden_fleet_run_complete` and `_irreden_fleet_build_complete` handlers
- `install.sh` now symlinks the bash completion file under `ir-run` and `ir-build` names in the bash-completion completions dir so bash-completion auto-loads them on shell start
- Zsh picks up the new `complete` calls automatically when `irreden-fleet.zsh` sources `fleet-run.bash` via `bashcompinit` — no changes needed there
- Updated `README.md`, `fleet-help`, and comment headers to reflect the new commands
- Target discovery routes through `fleet-run-targets`, which uses `ir_worktree_root` from the invoker's CWD — game-repo invocations naturally see game targets

## Test plan
- [ ] Run `scripts/fleet/install.sh` — confirm new symlinks appear in bash-completion completions dir and zsh completions dir
- [ ] Open a new shell; `ir-build --target <Tab>` completes CMake demo/test names
- [ ] `ir-run <Tab>` completes built executable basenames from the current worktree's build tree
- [ ] From a game-repo worktree, confirm `ir-run <Tab>` shows game targets

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)