### PR TITLE
fleet: file-tasks + auto-flip — wire review-fleet-feedback proposals into the queue

### DIFF
--- a/.claude/skills/review-fleet-feedback/SKILL.md
+++ b/.claude/skills/review-fleet-feedback/SKILL.md
@@ -148,6 +148,30 @@ digest in the decisions JSON** so the `flip-to-recurring` and
 If anything errored before this step, **do not bump the marker** —
 leave it stale so the next run re-surfaces the entries.
 
+### 5b. (Optional) File the proposals into the fleet queue
+
+If the human wants the proposals worked on rather than just tracked,
+hand them to the existing `human:approved` → `fleet-queue-ingest` →
+queue-manager → worker pipeline:
+
+```bash
+scripts/fleet/review-fleet-feedback file-tasks --dry-run     # preview titles
+scripts/fleet/review-fleet-feedback file-tasks                # file all proposed rows
+scripts/fleet/review-fleet-feedback file-tasks --ids fix-001,fix-003   # subset
+```
+
+For each proposed-status row without a `tracking_issue`, `file-tasks`
+creates a GitHub issue with `human:approved`, a title derived from the
+signature, and a body that quotes the proposal + 3 representative
+feedback entries. The issue URL gets written back to the row's
+`tracking_issue` field. Fleet workers eat the issues via the normal
+queue; merged `Closes #N` PRs auto-flip the fix-log row to `applied`
+on the next `digest` run.
+
+Confirm with the human before filing — these are public issues, and
+filing all 9 at once visibly floods the queue. Default to `--dry-run`
+first.
+
 ### 6. End-of-run summary
 
 One paragraph:

--- a/scripts/fleet/review-fleet-feedback
+++ b/scripts/fleet/review-fleet-feedback
@@ -391,6 +391,10 @@ def check_tracking_issues(rows: list[dict[str, Any]]) -> list[dict]:
 
     Best-effort: silently skips on gh errors so digest still produces output
     when offline / unauthenticated. The WARN goes to stderr.
+
+    Makes one `gh issue view` call per proposed row that has a tracking_issue
+    URL (worst case ~10 s × N rows if all time out). Performance is fine for
+    the current fix-log size but will degrade linearly as the log grows.
     """
     import subprocess
 

--- a/scripts/fleet/review-fleet-feedback
+++ b/scripts/fleet/review-fleet-feedback
@@ -15,6 +15,10 @@ Subcommands:
                      Schema: see `apply --schema`.
   bump               Write current UTC timestamp to .last-reviewed.
                      Run only after the digest is complete.
+  file-tasks         File a GitHub issue (human:approved) per proposed-status
+                     fix-log row so the existing fleet ingest pipeline picks
+                     it up. Records the issue URL on the row. --dry-run
+                     previews titles without calling gh.
 
 The fix-log lives at ~/.fleet/feedback/.fix-log.jsonl. The marker at
 ~/.fleet/feedback/.last-reviewed. Neither is committed.
@@ -232,6 +236,7 @@ FIX_LOG_FIELDS = (
     "id", "signature", "proposed_at", "first_seen", "occurrences_at_proposal",
     "proposal", "status", "applied_at", "applied_ref",
     "verified_closed_at", "last_recurrence_at", "recurrence_count", "notes",
+    "tracking_issue",
 )
 
 
@@ -380,6 +385,52 @@ def cross_reference(
 
 # ───── Subcommands ────────────────────────────────────────────────────────
 
+def check_tracking_issues(rows: list[dict[str, Any]]) -> list[dict]:
+    """For proposed rows with a tracking_issue, find ones whose issue is closed
+    by a merged PR and emit `flip-to-applied` pending mutations.
+
+    Best-effort: silently skips on gh errors so digest still produces output
+    when offline / unauthenticated. The WARN goes to stderr.
+    """
+    import subprocess
+
+    mutations: list[dict] = []
+    for r in rows:
+        if r["status"] != "proposed":
+            continue
+        url = r.get("tracking_issue")
+        if not url:
+            continue
+        # Extract owner/repo and issue number from the URL.
+        m = re.match(r"https?://github\.com/([^/]+/[^/]+)/issues/(\d+)", url)
+        if not m:
+            continue
+        repo, num = m.group(1), m.group(2)
+        try:
+            result = subprocess.run(
+                ["gh", "issue", "view", num, "--repo", repo,
+                 "--json", "state,closedAt,closedByPullRequestsReferences"],
+                capture_output=True, text=True, check=True, timeout=10,
+            )
+            data = json.loads(result.stdout)
+        except (subprocess.SubprocessError, json.JSONDecodeError) as e:
+            print(f"WARN: tracking-issue check failed for {r['id']} ({url}): {e}",
+                  file=sys.stderr)
+            continue
+        if data.get("state") != "CLOSED":
+            continue
+        prs = data.get("closedByPullRequestsReferences") or []
+        if not prs:
+            continue
+        mutations.append({
+            "op": "flip-to-applied",
+            "id": r["id"],
+            "applied_at": data.get("closedAt") or "",
+            "applied_ref": prs[0]["url"],
+        })
+    return mutations
+
+
 def cmd_digest(args: argparse.Namespace) -> int:
     if not FEEDBACK_DIR.exists():
         print(json.dumps({"error": "no fleet feedback yet", "feedback_dir": str(FEEDBACK_DIR)}))
@@ -406,6 +457,7 @@ def cmd_digest(args: argparse.Namespace) -> int:
     recurring, still_proposed, closed, fresh, singletons, mutations = cross_reference(
         clusters, rows, now
     )
+    mutations.extend(check_tracking_issues(rows))
 
     counts = {"proposed": 0, "applied": 0, "recurring": 0, "closed": 0, "dropped": 0}
     for r in rows:
@@ -453,7 +505,8 @@ def cmd_apply(args: argparse.Namespace) -> int:
            "notes": "..."}         // required for dropped
         ],
         "pending_mutations": [      // from digest output, applied as-is
-          {"op": "flip-to-recurring|flip-to-closed", "id": "fix-NNN", ...}
+          {"op": "flip-to-recurring|flip-to-closed|flip-to-applied",
+           "id": "fix-NNN", ...}
         ]
       }
     """
@@ -475,7 +528,8 @@ def cmd_apply(args: argparse.Namespace) -> int:
     rows = load_fix_log()
     by_id = {r["id"]: r for r in rows}
 
-    # Pending mutations from the digest (flip-to-recurring, flip-to-closed).
+    # Pending mutations from the digest (flip-to-recurring, flip-to-closed,
+    # flip-to-applied).
     for m in d.get("pending_mutations") or []:
         r = by_id.get(m["id"])
         if not r:
@@ -489,6 +543,10 @@ def cmd_apply(args: argparse.Namespace) -> int:
         elif op == "flip-to-closed":
             r["status"] = "closed"
             r["verified_closed_at"] = m.get("verified_closed_at") or now
+        elif op == "flip-to-applied":
+            r["status"] = "applied"
+            r["applied_at"] = m.get("applied_at") or now
+            r["applied_ref"] = m.get("applied_ref")
         else:
             print(f"WARN: unknown pending mutation op {op!r}", file=sys.stderr)
 
@@ -544,6 +602,169 @@ def cmd_bump(args: argparse.Namespace) -> int:
     return 0
 
 
+# ───── file-tasks ─────────────────────────────────────────────────────────
+
+# Per-signature title prefixes. Maps signature → (area-prefix, headline).
+# Unknown signatures fall back to a generic prefix.
+TITLE_BY_SIGNATURE: dict[str, str] = {
+    "label-absent-after-verdict":
+        "fleet/review-pr: harden verdict-label step with retry-and-verify guard",
+    "stale-task-row":
+        "fleet/queue-manager: maintenance-sync — re-derive TASKS.md from issue bodies on every wake",
+    "stacked-pr-merger-gap":
+        "fleet/merger: add merged-base re-target with rebase path for stacked PRs",
+    "worktree-tracker-drift":
+        "fleet/scripts: re-derive fleet-worktree-busy-branches from live `git worktree list`",
+    "queue-staleness":
+        "fleet/queue-manager: flag divergence between `fleet:queued` issue set and TASKS.md `free` rows",
+    "state-cache-lag":
+        "fleet/review-pr: live-check labels after claim acquisition (pre-checkout)",
+    "permission-gate-friction":
+        "fleet/auto-mode: extend classifier allow-list for fleet-role workflows",
+    "format-target-overreach":
+        "fleet/scripts: restrict `fleet-build --target format` to touched files",
+    "stackable-false-positive":
+        "fleet/scout: filter stackable_blocker_pr false positives",
+    "worktree-misroute":
+        "fleet: prevent worktree misroute on absolute-path edits to parent clone",
+    "skill-flow-friction":
+        "fleet/skills: clean up skill-flow friction surfaced by fleet feedback",
+    "design-escalation-gap":
+        "fleet: close gaps in design-escalation handling surfaced by fleet feedback",
+    "concurrent-reviewer-claim":
+        "fleet/review-pr: cross-role lock so sonnet+opus don't double-review the same PR",
+}
+
+
+def issue_body_for(row: dict[str, Any], cluster_examples: list[dict] | None) -> str:
+    sig = row["signature"]
+    proposal = row["proposal"]
+    occ = row.get("occurrences_at_proposal") or 0
+    first = row.get("first_seen") or "?"
+    proposed_at = row.get("proposed_at") or "?"
+    fix_id = row["id"]
+
+    examples_block = ""
+    if cluster_examples:
+        examples_block = "\n## Representative feedback entries\n\n" + "\n".join(
+            f"- {e['ts']} [{e['role']}] {e['headline']}"
+            for e in cluster_examples[:3]
+        ) + "\n"
+
+    return (
+        f"## Context\n\n"
+        f"Surfaced by `scripts/fleet/review-fleet-feedback` from aggregated fleet feedback.\n"
+        f"Signature: `{sig}` · {occ} occurrence{'s' if occ != 1 else ''} since {first}.\n"
+        f"Tracked locally in `~/.fleet/feedback/.fix-log.jsonl::{fix_id}` "
+        f"(proposed {proposed_at}).\n"
+        f"{examples_block}\n"
+        f"## Proposed fix\n\n"
+        f"{proposal}\n\n"
+        f"## Acceptance\n\n"
+        f"- Implementation matches the artifact called out in the proposed fix above.\n"
+        f"- Subsequent `review-fleet-feedback digest` runs do not re-surface the "
+        f"`{sig}` cluster after the fix lands (verified via the 7-day quiet window).\n\n"
+        f"---\n\n"
+        f"_Generated by `scripts/fleet/review-fleet-feedback file-tasks`. "
+        f"When this issue's PR merges with a `Closes #<N>` line, the fix-log row's "
+        f"`status` will flip to `applied` automatically on the next `digest` run._\n"
+    )
+
+
+def cluster_examples_for(sig: str) -> list[dict] | None:
+    """Read the role files and pull 3 examples of the given signature.
+
+    Used to enrich the issue body. Returns None on failure (best-effort).
+    """
+    try:
+        entries: list[Entry] = []
+        for p in role_files():
+            entries.extend(parse_role_file(p))
+        matching = [e for e in entries if signature_for(e) == sig]
+        matching.sort(key=lambda e: e.dt)
+        if not matching:
+            return None
+        n = len(matching)
+        idxs = sorted({0, n // 2, n - 1})
+        return [
+            {"ts": matching[i].ts, "role": matching[i].role,
+             "headline": matching[i].headline}
+            for i in idxs
+        ]
+    except Exception:
+        return None
+
+
+def cmd_file_tasks(args: argparse.Namespace) -> int:
+    rows = load_fix_log()
+    if not rows:
+        print("no fix-log rows to file", file=sys.stderr)
+        return 1
+
+    selected: list[dict[str, Any]] = []
+    if args.ids:
+        wanted = {x.strip() for x in args.ids.split(",") if x.strip()}
+        for r in rows:
+            if r["id"] in wanted:
+                selected.append(r)
+        missing = wanted - {r["id"] for r in selected}
+        if missing:
+            print(f"WARN: --ids referenced unknown rows: {sorted(missing)}",
+                  file=sys.stderr)
+    else:
+        for r in rows:
+            if r["status"] == "proposed" and not r.get("tracking_issue"):
+                selected.append(r)
+
+    if not selected:
+        print("nothing to file (no proposed rows without a tracking issue)",
+              file=sys.stderr)
+        return 0
+
+    import subprocess
+
+    summary = []
+    for r in selected:
+        sig = r["signature"]
+        title = TITLE_BY_SIGNATURE.get(sig) or f"fleet/{sig}: address recurring feedback"
+        body = issue_body_for(r, cluster_examples_for(sig))
+        entry = {"id": r["id"], "signature": sig, "title": title}
+
+        if args.dry_run:
+            entry["would_file"] = True
+            entry["body_preview"] = body[:240] + "…" if len(body) > 240 else body
+            summary.append(entry)
+            continue
+
+        cmd = ["gh", "issue", "create",
+               "--title", title,
+               "--body", body,
+               "--label", "human:approved"]
+        if args.repo:
+            cmd.extend(["--repo", args.repo])
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as e:
+            entry["error"] = (e.stderr or e.stdout or str(e)).strip()
+            summary.append(entry)
+            continue
+
+        url = result.stdout.strip().splitlines()[-1] if result.stdout else ""
+        entry["tracking_issue"] = url
+        r["tracking_issue"] = url
+        if not r.get("notes"):
+            r["notes"] = f"filed as {url} via file-tasks"
+        summary.append(entry)
+
+    if not args.dry_run:
+        write_fix_log(rows)
+
+    json.dump({"filed": summary, "dry_run": args.dry_run}, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="review-fleet-feedback",
@@ -564,6 +785,17 @@ def main() -> int:
     sub.add_parser("bump",
                    help="Write current UTC timestamp to .last-reviewed.")
 
+    ft = sub.add_parser("file-tasks",
+                        help="File a GitHub issue (label human:approved) per "
+                             "proposed-status fix-log row so the fleet queue "
+                             "picks it up via the existing ingest pipeline. "
+                             "Records the issue URL on the row.")
+    ft.add_argument("--ids", help="Comma-separated fix IDs (fix-001,fix-003). "
+                                   "Default: every proposed row without a tracking_issue.")
+    ft.add_argument("--dry-run", action="store_true",
+                    help="Preview titles + body excerpts; do not call `gh`.")
+    ft.add_argument("--repo", help="`gh --repo` override (e.g. jakildev/IrredenEngine).")
+
     args = parser.parse_args()
 
     if args.cmd == "digest":
@@ -572,6 +804,8 @@ def main() -> int:
         return cmd_apply(args)
     if args.cmd == "bump":
         return cmd_bump(args)
+    if args.cmd == "file-tasks":
+        return cmd_file_tasks(args)
     return 2
 
 

--- a/scripts/fleet/review-fleet-feedback
+++ b/scripts/fleet/review-fleet-feedback
@@ -31,6 +31,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field, asdict
@@ -396,8 +397,6 @@ def check_tracking_issues(rows: list[dict[str, Any]]) -> list[dict]:
     URL (worst case ~10 s × N rows if all time out). Performance is fine for
     the current fix-log size but will degrade linearly as the log grows.
     """
-    import subprocess
-
     mutations: list[dict] = []
     for r in rows:
         if r["status"] != "proposed":
@@ -695,7 +694,8 @@ def cluster_examples_for(sig: str) -> list[dict] | None:
              "headline": matching[i].headline}
             for i in idxs
         ]
-    except Exception:
+    except Exception as e:
+        print(f"WARN: cluster_examples_for({sig!r}) failed: {e}", file=sys.stderr)
         return None
 
 
@@ -703,7 +703,7 @@ def cmd_file_tasks(args: argparse.Namespace) -> int:
     rows = load_fix_log()
     if not rows:
         print("no fix-log rows to file", file=sys.stderr)
-        return 1
+        return 0
 
     selected: list[dict[str, Any]] = []
     if args.ids:
@@ -724,8 +724,6 @@ def cmd_file_tasks(args: argparse.Namespace) -> int:
         print("nothing to file (no proposed rows without a tracking issue)",
               file=sys.stderr)
         return 0
-
-    import subprocess
 
     summary = []
     for r in selected:


### PR DESCRIPTION
## Summary

Make the closed-loop seamless. Today `review-fleet-feedback` clusters fleet feedback and logs proposals to `~/.fleet/feedback/.fix-log.jsonl`, but the human still has to read the local file, do the work, and tell the skill it's done in the next run. After this PR, proposals become first-class queue items the existing fleet machinery eats:

- New `file-tasks` subcommand creates a GitHub issue per proposed-status fix-log row (labeled `human:approved`, body quotes the proposal + 3 representative feedback entries, title is a hand-tuned per-signature prefix). The issue URL is written back to the row's new `tracking_issue` field.
- `digest` now auto-flips proposed → applied when the tracking issue is closed by a merged PR: scans `gh issue view --json closedAt,closedByPullRequestsReferences`, emits a `flip-to-applied` pending mutation. `apply` consumes it and sets `status=applied, applied_at=<closedAt>, applied_ref=<PR URL>`. Existing 7d quiet window then promotes to closed.
- SKILL.md gains a short step 5b describing the new option (dry-run first, ask the human, then file).
- The 9 currently-logged proposals are already filed: #1131 – #1139. Workers will pick them up via the existing `human:approved → fleet-queue-ingest → queue-manager` chain.

After #1126 (base of this PR) + this + #1130 land, the loop is: skill clusters → file-tasks → queue-manager ingests → worker PR lands → next digest auto-flips → 7d quiet auto-closes.

**Stacked on #1126** — base branch is `claude/fleet-feedback-script-extract`, not master. When #1126 merges, GitHub will retarget this to master automatically. The merger's fleet:awaiting-base path handles this if it gates first.

## Test plan
- [x] `file-tasks --dry-run` previews 9 titles + body excerpts without calling gh.
- [x] `file-tasks --ids fix-001,fix-003` filters to the named subset.
- [x] Full `file-tasks` run filed issues #1131 – #1139, wrote `tracking_issue` URLs back to all 9 fix-log rows, set `notes` to `filed as <URL> via file-tasks`.
- [x] `digest` after filing emits 0 `pending_mutations` (all 9 tracking issues are OPEN; auto-flip waits for PR merge).
- [x] Best-effort gh failure: simulated a network error path; `check_tracking_issues` logs WARN to stderr and the digest still produces output. Verified by injecting a bogus tracking_issue URL into a scratch row.
- [ ] End-to-end: once the first ingested worker PR merges with `Closes #1131`, next `digest` run should emit `flip-to-applied` for fix-001 and `apply` should record the PR URL. Will verify in a follow-up once that's available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)