### PR TITLE
T-337: tools: shell autocomplete for ir-build and ir-run targets

### DIFF
--- a/scripts/fleet/README.md
+++ b/scripts/fleet/README.md
@@ -52,12 +52,15 @@ fleet workflow.
 - **`fleet-help`** — prints an index of all `fleet-*` tools (build, run,
   tmux fleet, claims, …) and how to install them; `fleet-help <cmd>`
   forwards to `--help` when the tool supports it (or a short summary).
-- **`completions/fleet-run.bash`** — bash tab completion for `fleet-run`
-  (built exe names when the word does not start with `-`) and
-  `fleet-build` (CMake demo names after `--target`) plus `fleet-debug`.
-  `install.sh`
-  symlinks it into `${XDG_DATA_HOME:-~/.local/share}/bash-completion/completions/`
-  for bash-completion / Homebrew `bash-completion@2`.
+- **`completions/fleet-run.bash`** — bash tab completion for `fleet-run`,
+  `fleet-build`, `fleet-debug`, `ir-run`, and `ir-build`. The `fleet-*`
+  and `ir-*` counterparts share the same completion logic: `ir-run`
+  completes built exe names on the first positional; `ir-build` completes
+  CMake demo names after `--target`. Target discovery uses
+  `fleet-run-targets`, which resolves the invoker's git worktree root, so
+  game-repo invocations show game targets. `install.sh` symlinks it into
+  `${XDG_DATA_HOME:-~/.local/share}/bash-completion/completions/` for
+  bash-completion / Homebrew `bash-completion@2`.
 - **`completions/irreden-fleet.zsh`** — zsh entry: ensures `compinit` (if
   needed), runs `bashcompinit`, then sources `fleet-run.bash`. **macOS
   default shell is zsh**; the bash-completion directory is not used.

--- a/scripts/fleet/completions/fleet-run.bash
+++ b/scripts/fleet/completions/fleet-run.bash
@@ -194,3 +194,8 @@ _irreden_fleet_debug_complete() {
 complete -F _irreden_fleet_run_complete fleet-run
 complete -F _irreden_fleet_build_complete fleet-build
 complete -F _irreden_fleet_debug_complete fleet-debug
+
+# ir-run and ir-build share the same interface as their fleet-* counterparts —
+# same flags, same positional target, same fleet-run-targets discovery path.
+complete -F _irreden_fleet_run_complete ir-run
+complete -F _irreden_fleet_build_complete ir-build

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -353,7 +353,9 @@ if [[ -f "$FLEET_COMP_SRC" ]]; then
     ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-run"
     ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-build"
     ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/fleet-debug"
-    echo "symlinked bash completion -> $BASH_COMP_DIR/fleet-run (+ fleet-build, fleet-debug)"
+    ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/ir-run"
+    ln -sf "$FLEET_COMP_SRC" "$BASH_COMP_DIR/ir-build"
+    echo "symlinked bash completion -> $BASH_COMP_DIR/fleet-run (+ fleet-build, fleet-debug, ir-run, ir-build)"
 fi
 
 # Zsh: bash-completion dirs are not read by zsh; irreden-fleet.zsh uses


### PR DESCRIPTION
Add bash/zsh tab-completion for `--target` on `ir-build` and the positional target on `ir-run`. Completion discovers available targets from the current repo's build tree via `fleet-run-targets`, so game-repo invocations show game targets.

Closes #1127