### PR TITLE
fleet: queue-manager maintenance-sync step

### DIFF
--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -88,7 +88,9 @@ Two invocation modes:
    to see the pending-ingestion set.
 
 7.5. **Maintenance-sync: re-derive open rows from issue bodies and
-   PR-merge state.** Run this step in all modes before step 8.
+   PR-merge state.** Run this step in all modes before step 8. A row
+   can match more than one rule — apply all three in order, not just
+   the first hit.
 
    Re-Read `~/.fleet/state/state.json` (the full cache, not a
    projection — the queue-manager projections in steps 6–7 lack the
@@ -108,7 +110,9 @@ Two invocation modes:
    a. **Issue-closed:** if `Issue: #N` and N is in the closed-issue
       set → flip the checkbox to `[x]`.
    b. **PR-merged:** if `ID: T-NNN` and any merged PR's `headRefName`
-      or `title` contains the string `T-NNN` → flip to `[x]`.
+      or `title` contains the string `T-NNN` followed by a non-digit
+      or end-of-string (so `T-100` does not match inside `T-1001`) →
+      flip to `[x]`.
    c. **Stale-owner:** if `Owner:` holds a branch path (matches
       `claude/*`) and that branch is **not** in the active-branch set
       → reset `Owner: free`.

--- a/.claude/commands/role-queue-manager.md
+++ b/.claude/commands/role-queue-manager.md
@@ -86,6 +86,46 @@ Two invocation modes:
    `scout cache stale or missing — run fleet-up` and exit.
 7. Read tool → `~/.fleet/state/projections/queue-manager-ingest.json`
    to see the pending-ingestion set.
+
+7.5. **Maintenance-sync: re-derive open rows from issue bodies and
+   PR-merge state.** Run this step in all modes before step 8.
+
+   Re-Read `~/.fleet/state/state.json` (the full cache, not a
+   projection — the queue-manager projections in steps 6–7 lack the
+   fields needed here). Then:
+
+   - Build a **closed-issue set**: all `number` values from
+     `repos.engine.closed_fleet_queued[]` (and `repos.game.*` if
+     present).
+   - Build a **merged-PR set**: all `{headRefName, title}` pairs from
+     `repos.engine.recent_merged_prs[]` (and game).
+   - Build an **active-branch set**: all `headRefName` values from
+     `repos.engine.prs[]` (and game) — i.e., open PRs.
+
+   Walk every `[ ]` row in TASKS.md (and game TASKS.md if loaded).
+   For each row apply three re-derive rules:
+
+   a. **Issue-closed:** if `Issue: #N` and N is in the closed-issue
+      set → flip the checkbox to `[x]`.
+   b. **PR-merged:** if `ID: T-NNN` and any merged PR's `headRefName`
+      or `title` contains the string `T-NNN` → flip to `[x]`.
+   c. **Stale-owner:** if `Owner:` holds a branch path (matches
+      `claude/*`) and that branch is **not** in the active-branch set
+      → reset `Owner: free`.
+
+   Rules are independent; apply all three to each row in order (a row
+   can match (a) or (b) before (c) is even reached).
+
+   If any rows changed:
+   - Print `maintenance-sync: updated N rows (M issue-closed,
+     K pr-merged, J stale-owner)`.
+   - Stage and commit on the current branch (in auto-ingest mode this
+     is `fleet-queue-ingest`; in interactive mode the human pushes):
+     `queue: maintenance-sync — re-derive N stale rows`
+   - Do NOT push — parent script or human handles the push.
+
+   If nothing changed: print `maintenance-sync: nothing to re-derive.`
+
 8. Print: `Queue: X open (Y opus, Z sonnet) · N in-progress · M done · P pending ingest`.
    - **If `$ARGUMENTS` is `ingest`:** if `pending_issues` is empty,
      print `[queue-manager] No pending issues; exiting.` and end the


### PR DESCRIPTION
## Summary

- Adds startup step 7.5 to `role-queue-manager.md`: a maintenance-sync pass that re-derives stale open TASKS.md rows before any ingestion work
- Runs in all modes (auto-ingest and interactive)
- Three re-derive rules: (a) issue-closed → flip `[x]`; (b) PR-merged → flip `[x]`; (c) stale-owner → reset to `free`
- Explicitly re-reads `~/.fleet/state/state.json` (full cache) because the queue-manager projections in steps 6–7 lack `closed_fleet_queued[]` and `prs[]`

## Test plan
- [ ] Queue-manager auto-ingest run with known-stale rows: maintenance-sync closes them before pickup
- [ ] Queue-manager run with no stale rows: prints `maintenance-sync: nothing to re-derive.` and continues normally
- [ ] Stale `Owner: claude/*` row (branch gone): owner reset to `free` after sync

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)