### PR TITLE
fleet: fleet-worktree-busy-branches multi-repo support

### DIFF
--- a/scripts/fleet/fleet-worktree-busy-branches
+++ b/scripts/fleet/fleet-worktree-busy-branches
@@ -15,15 +15,20 @@
 #   - opus-worker step 1c semantic-conflict resolution.
 #
 # Outputs one branch name per line on stdout (no `refs/heads/` prefix),
-# suitable for `grep -F -x` filtering.
+# suitable for `grep -F -x` filtering.  Output is the union of all queried
+# repos (useful when engine + game worktrees can hold conflicting branch names).
 #
 # Usage:
-#   fleet-worktree-busy-branches [--exclude <path>] [--repo <path>]
+#   fleet-worktree-busy-branches [--exclude <path>] [--repo <path>] ...
 #
 # Options:
 #   --exclude <path>   Worktree path to exclude (the caller's own worktree).
 #                      Default: $PWD (the cwd's worktree).
-#   --repo <path>      Repo root to query. Default: $PWD's git toplevel.
+#   --repo <path>      Repo root to query. May be specified multiple times.
+#                      Default: discovers engine root ($FLEET_ENGINE_ROOT or
+#                      $PWD's git toplevel) plus game root ($FLEET_GAME_ROOT
+#                      or <engine-root>/creations/game) when the game root
+#                      exists on disk.
 #
 # Source of truth: scripts/fleet/fleet-worktree-busy-branches in the engine
 # repo. Installed to ~/bin/ by scripts/fleet/install.sh.
@@ -31,7 +36,7 @@
 set -euo pipefail
 
 exclude_path=""
-repo_path=""
+repo_paths=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -40,11 +45,11 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --repo)
-            repo_path="$2"
+            repo_paths+=("$2")
             shift 2
             ;;
         -h|--help)
-            sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,34p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -54,11 +59,19 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "$repo_path" ]]; then
-    repo_path="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -z "$repo_path" ]]; then
+if [[ ${#repo_paths[@]} -eq 0 ]]; then
+    _engine="${FLEET_ENGINE_ROOT:-}"
+    if [[ -z "$_engine" ]]; then
+        _engine="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    fi
+    if [[ -z "$_engine" ]]; then
         echo "fleet-worktree-busy-branches: not in a git repo and no --repo given" >&2
         exit 2
+    fi
+    repo_paths+=("$_engine")
+    _game="${FLEET_GAME_ROOT:-$_engine/creations/game}"
+    if [[ -d "$_game/.git" || -f "$_game/.git" ]]; then
+        repo_paths+=("$_game")
     fi
 fi
 
@@ -66,20 +79,24 @@ if [[ -z "$exclude_path" ]]; then
     exclude_path="$PWD"
 fi
 
-# Resolve both paths so the comparison is symlink-safe and trailing-slash-
-# safe. `realpath -m` doesn't fail on missing tail components, but we expect
-# both to exist; pwd -P would also work but is awk-unfriendly.
+# Resolve the exclude path so the comparison is symlink-safe and
+# trailing-slash-safe.
 exclude_real="$(cd "$exclude_path" 2>/dev/null && pwd -P || echo "$exclude_path")"
 
-git -C "$repo_path" worktree list --porcelain | awk -v exclude="$exclude_real" '
-    /^worktree / {
-        wt = $2
-        next
-    }
-    /^branch refs\/heads\// {
-        if (wt != exclude) {
-            sub(/^branch refs\/heads\//, "", $0)
-            print
+for repo_path in "${repo_paths[@]}"; do
+    if ! git -C "$repo_path" rev-parse --git-dir &>/dev/null; then
+        continue
+    fi
+    git -C "$repo_path" worktree list --porcelain | awk -v exclude="$exclude_real" '
+        /^worktree / {
+            wt = $2
+            next
         }
-    }
-'
+        /^branch refs\/heads\// {
+            if (wt != exclude) {
+                sub(/^branch refs\/heads\//, "", $0)
+                print
+            }
+        }
+    '
+done

--- a/scripts/fleet/fleet-worktree-busy-branches
+++ b/scripts/fleet/fleet-worktree-busy-branches
@@ -49,6 +49,8 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
+            # Update the sed range here when adding/removing lines in the
+            # comment header above (lines 2-34 today).
             sed -n '2,34p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;


### PR DESCRIPTION
## Summary
- `--repo` now accepts multiple values so engine + game worktree branches can be unioned in one call
- Default auto-discovery uses `FLEET_ENGINE_ROOT` / `FLEET_GAME_ROOT` (same env vars fleet-claim uses), adding the game root only when it exists on disk
- Non-existent repos in an explicit `--repo` list are skipped silently; single-arg callers are unaffected

## Test plan
- [ ] `fleet-worktree-busy-branches` (no args): lists branches from engine worktrees only (game root doesn't exist)
- [ ] `fleet-worktree-busy-branches --repo <engine> --repo <game>`: unions both repos
- [ ] `fleet-worktree-busy-branches --repo /nonexistent/path`: exits 0, no output (silently skipped)
- [ ] `fleet-worktree-busy-branches --help`: updated usage reflects multi-value --repo

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)