### PR TITLE
T-339: fleet: review-pr verdict-label retry-and-verify guard

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -155,11 +155,13 @@ iteration of polling, reviewing, and exiting cleanly:
       [REVIEWER-PROTOCOL.md § Posting the review body](../../docs/agents/REVIEWER-PROTOCOL.md#posting-the-review-body)
       for the `Write` → `.review-body.md` → `gh pr review --body-file`
       mechanics.
-   g. **Set the verdict label.** Use the canonical 4-command block in
+   g. **Set the verdict label.** Use the split remove + add +
+      retry-and-verify pattern in
       [REVIEWER-PROTOCOL.md § Verdict label-swap commands](../../docs/agents/REVIEWER-PROTOCOL.md#verdict-label-swap-commands)
       (add `--repo <game-repo>` for game PRs). Your VERY NEXT bash
-      call after `gh pr review` MUST be the `gh pr edit ... --add-label`
-      — a review without a verdict label is invisible to the human's
+      calls after `gh pr review` MUST be the removes (`|| true`),
+      the `--add-label`, and the verify re-query — in that order.
+      A review without a verdict label is invisible to the human's
       merge queue.
    h. **Release the review claim** immediately after the verdict
       label-swap (and on no-verdict skip paths — broken stack, gated

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -159,13 +159,13 @@ iteration of polling, reviewing, and exiting cleanly:
       <reason>` per the same section.
    e. **Set the verdict label IMMEDIATELY after posting the review.**
       This is the single most-skipped step in the loop. Use the
-      canonical 4-command block in
+      split remove + add + retry-and-verify pattern in
       [REVIEWER-PROTOCOL.md § Verdict label-swap commands](../../docs/agents/REVIEWER-PROTOCOL.md#verdict-label-swap-commands)
       (add `--repo <game-repo>` for game PRs). Your VERY NEXT bash
-      call after `gh pr review` MUST be the `gh pr edit ... --add-label`
-      — a review without a verdict label is invisible to the human's
-      merge queue. Confirm with `gh pr view <N> --json labels --jq
-      '.labels[].name'` after the edit if unsure.
+      calls after `gh pr review` MUST be the removes (`|| true`),
+      the `--add-label`, and the verify re-query — in that order.
+      A review without a verdict label is invisible to the human's
+      merge queue.
 
       The `review-pr` skill (invoked for engine single-task PRs)
       writes its own label per the same rules, but if you find a PR

--- a/docs/agents/REVIEWER-PROTOCOL.md
+++ b/docs/agents/REVIEWER-PROTOCOL.md
@@ -122,12 +122,11 @@ re-review the parent.
 The verdict label is the primary signal the human uses to decide what
 to merge — a review without a label is invisible to the human's merge
 queue. After every `gh pr review --comment ...`, your VERY NEXT bash
-call MUST be a `gh pr edit <N> ... --add-label "fleet:..."` from the
-table below.
+calls MUST be the split remove + add + verify sequence below.
 
-Always remove stale verdict labels in the same call as adding the new
-one. Each verdict also clears three derived-state labels so a single
-verdict re-evaluation cleans them up:
+Always remove stale verdict labels before adding the new one. Each
+verdict also clears three derived-state labels so a single verdict
+re-evaluation cleans them up:
 
 - `fleet:awaiting-upstream-review` — a previously-gated stacked PR
   exits the gate cleanly when the reviewer finally proceeds.
@@ -140,22 +139,38 @@ verdict re-evaluation cleans them up:
 
 For game PRs, add `--repo <game-repo>` to each `gh pr edit` call.
 
+**Two-call split required.** `gh pr edit --remove-label X` exits
+non-zero when label X is absent, aborting any trailing `--add-label`
+in the same call. Split the removes from the add into separate
+calls; suffix the remove call with `|| true` so absent labels don't
+block the add. After the add, re-query labels and retry once if the
+verdict label didn't land (observed as `label-absent-after-verdict`
+feedback cluster — fix-002 in the fleet fix-log):
+
 ```
-# Verdict approve, no Nits section:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved"
+# Verdict approve, no Nits section — removes first (absent OK), then add + verify:
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --add-label "fleet:approved"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:approved" || gh pr edit <N> --add-label "fleet:approved"
 
 # Verdict approve WITH a non-empty `### Nits` section (also set fleet:has-nits):
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved" --add-label "fleet:has-nits"
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --add-label "fleet:approved" --add-label "fleet:has-nits"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:approved" || gh pr edit <N> --add-label "fleet:approved"
 
 # Verdict needs-fix:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:needs-fix"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --add-label "fleet:needs-fix"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:needs-fix" || gh pr edit <N> --add-label "fleet:needs-fix"
 
 # Verdict blocker:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:blocker"
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --add-label "fleet:blocker"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:blocker" || gh pr edit <N> --add-label "fleet:blocker"
 
 # Re-review of a previously fleet:has-nits PR that's now clean:
 #   removes the has-nits flag while keeping fleet:approved
-gh pr edit <N> --remove-label "fleet:has-nits"
+gh pr edit <N> --remove-label "fleet:has-nits" 2>/dev/null || true
 ```
 
 **Sonnet-reviewer special case: verdict approve + "Opus recheck
@@ -165,11 +180,11 @@ set `fleet:has-nits` here if there are nits, even without a verdict
 label.)
 
 The `review-pr` skill (invoked for engine single-task PRs by
-sonnet-reviewer) writes its own label per the same rules — but if
-you find a PR you reviewed without a label after the skill returns,
-run the `gh pr edit` yourself immediately. Don't assume the skill
-did it; verify with `gh pr view <N> --json labels --jq
-'.labels[].name'` if unsure.
+sonnet-reviewer) prescribes its own label-swap in step 5b — if you
+find a PR you reviewed without a label after the skill returns, run
+the `gh pr edit` yourself using the pattern above immediately. Don't
+assume the skill did it; verify with `gh pr view <N> --json labels
+--jq '.labels[].name'` if unsure.
 
 ---
 


### PR DESCRIPTION
## Summary

- Split `gh pr edit --remove-label ... --add-label` into two separate calls in `REVIEWER-PROTOCOL.md`, `role-sonnet-reviewer.md`, and `role-opus-reviewer.md`
- The combined form exits non-zero on the first absent remove-label target, silently dropping the add-label — root cause of the `label-absent-after-verdict` cluster (fix-002, 37 occurrences since 2026-04-30)
- New canonical three-line pattern per verdict: removes with `|| true`, add, then re-query-and-retry-once verify

## Manual TODO — SKILL.md step 5b

`.claude/skills/review-pr/SKILL.md` step 5b also needs the same update. The auto-mode classifier blocked the edit (Self-Modification rule for `.claude/skills/` inside worktrees; see T-344). Apply this diff manually:

```diff
-### 5b. Set the verdict label (step 5 sequence, continued)
+### 5b. Set the verdict label (step 5 sequence, continued)
 
-**Immediately after** `gh pr review --comment --body-file .review-body.md`,
-run the verdict label command — your very next bash call. No intervening
-calls. Always remove stale verdict labels before adding the new one — a PR
+**Immediately after** `gh pr review --comment --body-file .review-body.md`,
+run the verdict label commands — your very next bash calls. No intervening
+calls. Always remove stale verdict labels before adding the new one — a PR
 should have exactly one verdict label ...
 
+**Two-call split required.** `gh pr edit --remove-label X` exits non-zero
+when label X is absent, aborting any trailing `--add-label` in the same
+call. Split the removes from the add; suffix the remove call with `|| true`
+so absent labels don't block the add. After the add, re-query and retry
+once if the verdict label didn't land (see also `role-sonnet-reviewer.md`
+step e and `role-opus-reviewer.md` step g via `REVIEWER-PROTOCOL.md §
+Verdict label-swap commands`):
+
 ```bash
-# For approve, no nits in body:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved"
+# For approve, no nits in body — removes first (absent OK), then add + verify:
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --add-label "fleet:approved"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:approved" || gh pr edit <N> --add-label "fleet:approved"
 
-# For approve WITH a non-empty Nits section in the body:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved" --add-label "fleet:has-nits"
+# For approve WITH a non-empty Nits section in the body:
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --add-label "fleet:approved" --add-label "fleet:has-nits"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:approved" || gh pr edit <N> --add-label "fleet:approved"
 
-# For needs-fix:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:needs-fix"
+# For needs-fix:
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --add-label "fleet:needs-fix"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:needs-fix" || gh pr edit <N> --add-label "fleet:needs-fix"
 
-# For blocker:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:blocker"
+# For blocker:
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --add-label "fleet:blocker"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:blocker" || gh pr edit <N> --add-label "fleet:blocker"
 ```
```

## Test plan

- [ ] Verify `docs/agents/REVIEWER-PROTOCOL.md` § "Verdict label-swap commands" shows the three-line remove/add/verify pattern for all four verdicts
- [ ] Verify `role-sonnet-reviewer.md` step e and `role-opus-reviewer.md` step g reference "retry-and-verify pattern"
- [ ] Manually apply the SKILL.md step 5b diff above (or re-enable via T-344 classifier fix)
- [ ] Next reviewer invocation that sets a verdict label: confirm `fleet:approved` / `fleet:needs-fix` appears in `gh pr view --json labels` immediately after

Closes #1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)