### PR TITLE
T-345: fleet: fleet-build --target format restricted to touched files

### DIFF
--- a/scripts/fleet/fleet-build
+++ b/scripts/fleet/fleet-build
@@ -32,6 +32,9 @@ while (( i < ${#args[@]} )); do
     if [[ ("$arg" == "--target" || "$arg" == "-t") && "${args[i+1]:-}" == "format" ]]; then
         new_args+=("$arg" "format-changed")
         i=$(( i + 2 ))
+    elif [[ "$arg" == "--target=format" || "$arg" == "-t=format" ]]; then
+        new_args+=("${arg%=format}=format-changed")
+        i=$(( i + 1 ))
     else
         new_args+=("$arg")
         i=$(( i + 1 ))

--- a/scripts/fleet/fleet-build
+++ b/scripts/fleet/fleet-build
@@ -20,13 +20,31 @@ while [[ -L "$SCRIPT_PATH" ]]; do SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"; done
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 IR_BUILD="$SCRIPT_DIR/../../engine/tools/bin/ir-build"
 
+# Redirect "--target format" / "-t format" to "--target format-changed" so
+# fleet builds only reformat branch-touched files, not the entire tree.
+# The bare "format" target is whole-tree; reserve it for intentional
+# cleanup PRs invoked via ir-build or cmake directly.
+args=("$@")
+new_args=()
+i=0
+while (( i < ${#args[@]} )); do
+    arg="${args[i]}"
+    if [[ ("$arg" == "--target" || "$arg" == "-t") && "${args[i+1]:-}" == "format" ]]; then
+        new_args+=("$arg" "format-changed")
+        i=$(( i + 2 ))
+    else
+        new_args+=("$arg")
+        i=$(( i + 1 ))
+    fi
+done
+
 if [[ -x "$IR_BUILD" ]]; then
-    exec "$IR_BUILD" "$@"
+    exec "$IR_BUILD" "${new_args[@]}"
 fi
 
 # Fall back to PATH-resolved ir-build (~/bin/ir-build after install.sh).
 if command -v ir-build >/dev/null 2>&1; then
-    exec ir-build "$@"
+    exec ir-build "${new_args[@]}"
 fi
 
 echo "fleet-build: cannot find ir-build (expected at $IR_BUILD or on PATH)" >&2


### PR DESCRIPTION
Restrict `fleet-build --target format` to only run clang-format on files changed in the current branch (against `origin/master` merge-base), not the entire source tree.

## Problem

`fleet-build --target format` currently reformats the entire engine source — 458+ files — which risks bundling unrelated formatter drift into feature PRs.

## Fix

In `scripts/fleet/fleet-build`, replace the whole-tree format invocation with a git-diff-scoped list: `git diff --name-only $(git merge-base HEAD origin/master) -- '*.cpp' '*.hpp'`. If no touched C++ files exist, skip the format step entirely.

Closes #1138