### PR TITLE
T-346: fleet: scout stackable_blocker_pr false-positive filter

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -630,9 +630,7 @@ _DESIGN_BLOCK_LABELS = frozenset({"fleet:design-blocked", "fleet:design-escalate
 
 
 def _area_prefixes(area_str):
-    # Parse 'engine/render, engine/prefabs/irreden/render' into normalized
-    # path prefixes for PR file-overlap checking. Entries without '/' (e.g.
-    # 'tooling') are meta-tags that don't map to a diff path and are dropped.
+    # Drops entries without '/' (meta-tags like 'tooling') that can't match diff paths.
     if not area_str:
         return []
     prefixes = []
@@ -644,8 +642,7 @@ def _area_prefixes(area_str):
 
 
 def _blocker_pr_files(repo_key, pr_number):
-    # Return changed file paths for a blocker PR from the per-PR cache.
-    # Returns [] if cache is missing (caller treats as no overlap detected).
+    # Returns [] on cache miss so the caller treats it as no overlap (safe degradation).
     pr_path = PRS_DIR / repo_key / f"{pr_number}.json"
     try:
         data = json.loads(pr_path.read_text())

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -626,6 +626,34 @@ def model_tags(task):
     return set(MODEL_TOKEN_RE.findall((task.get("model") or "").lower()))
 
 
+_DESIGN_BLOCK_LABELS = frozenset({"fleet:design-blocked", "fleet:design-escalated"})
+
+
+def _area_prefixes(area_str):
+    # Parse 'engine/render, engine/prefabs/irreden/render' into normalized
+    # path prefixes for PR file-overlap checking. Entries without '/' (e.g.
+    # 'tooling') are meta-tags that don't map to a diff path and are dropped.
+    if not area_str:
+        return []
+    prefixes = []
+    for entry in area_str.split(","):
+        entry = entry.strip()
+        if "/" in entry:
+            prefixes.append(entry.rstrip("/") + "/")
+    return prefixes
+
+
+def _blocker_pr_files(repo_key, pr_number):
+    # Return changed file paths for a blocker PR from the per-PR cache.
+    # Returns [] if cache is missing (caller treats as no overlap detected).
+    pr_path = PRS_DIR / repo_key / f"{pr_number}.json"
+    try:
+        data = json.loads(pr_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+    return [f.get("path", "") for f in data.get("files", [])]
+
+
 def enrich_stackable_blocker_prs(state):
     # Per T-110 PR 2: for each task whose blocked_by is exactly one T-NNN
     # ID with exactly one matching open PR (head ref `claude/T-NNN-…`)
@@ -640,11 +668,13 @@ def enrich_stackable_blocker_prs(state):
     #     yet started, or already merged and dropped from open list)
     #   - more than one open PR matches (rare but possible if a stale
     #     branch lingers — caller can't pick one safely)
+    #   - blocker PR has fleet:design-blocked or fleet:design-escalated (filter b)
+    #   - downstream task's area files appear in the blocker PR diff (filter a)
     #
     # Engine and game tasks are both enriched; worker pickup only honors
     # the field for engine in v1 (the merger's cascade-rebase doesn't
     # process game PRs yet) — that gating lives in the role doc.
-    for repo_state in state["repos"].values():
+    for repo_key, repo_state in state["repos"].items():
         prs = repo_state.get("prs", [])
         for task in repo_state.get("tasks", {}).get("open", []):
             blocked_by = (task.get("blocked_by") or "").strip()
@@ -656,6 +686,22 @@ def enrich_stackable_blocker_prs(state):
             if len(matches) != 1:
                 continue
             pr = matches[0]
+
+            # Filter (b): blocker PR is stalled on a design question — the
+            # downstream task can't make forward progress on it.
+            if set(pr.get("labels", [])) & _DESIGN_BLOCK_LABELS:
+                continue
+
+            # Filter (a): downstream task's area already overlaps with the
+            # blocker PR's diff — a stackable claim would conflict at review.
+            area_prefixes = _area_prefixes(task.get("area") or "")
+            if area_prefixes:
+                blocker_files = _blocker_pr_files(repo_key, pr["number"])
+                if any(
+                    f.startswith(p) for f in blocker_files for p in area_prefixes
+                ):
+                    continue
+
             task["stackable_blocker_pr"] = {
                 "number": pr["number"],
                 "headRefName": pr["headRefName"],


### PR DESCRIPTION
## Summary

Adds two false-positive filters to `fleet-state-scout`'s `enrich_stackable_blocker_prs`:

- **(b) Design-blocked label filter**: if the blocker PR carries `fleet:design-blocked` or `fleet:design-escalated`, the blocker is waiting for architect input and a downstream stackable claim would be unproductive.
- **(a) Area-overlap filter**: if the downstream task's `area` field (parsed as path prefixes, e.g. `engine/system/`) overlaps with files already changed in the blocker PR's cached diff, the stackable claim would produce a conflict-prone diff. Entries without `/` (e.g. `tooling`) are meta-tags that can't be mapped to diff paths and are skipped cleanly. Cache miss on the blocker PR JSON is treated as no overlap so the filter degrades gracefully.

Two new helpers:
- `_area_prefixes(area_str)` — splits area string into normalized path prefixes (drops non-path tags)
- `_blocker_pr_files(repo_key, pr_number)` — reads `PRS_DIR/<repo_key>/<N>.json` and extracts `files[].path` list

Outer loop in `enrich_stackable_blocker_prs` changed from `.values()` to `.items()` to pass `repo_key` into `_blocker_pr_files`.

## Test plan
- [ ] Scout no longer sets `stackable_blocker_pr` when the blocker PR carries `fleet:design-blocked`
- [ ] Scout no longer sets `stackable_blocker_pr` when the blocker PR carries `fleet:design-escalated`
- [ ] Scout no longer sets `stackable_blocker_pr` when the downstream task's area path overlaps with files in the blocker PR's diff
- [ ] Scout still sets `stackable_blocker_pr` for clean candidates (no design labels, no area overlap)
- [ ] `tooling`-area tasks (no `/`) pass filter (a) cleanly — no false suppression

Closes #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)