### PR TITLE
T-344: fleet/auto-mode: fix rm -f .review-body.md via Read-then-Write protocol

### DIFF
--- a/docs/agents/REVIEWER-PROTOCOL.md
+++ b/docs/agents/REVIEWER-PROTOCOL.md
@@ -223,13 +223,15 @@ to paths outside the worktree even if `/tmp/` is in
 `additionalDirectories` (the gate is broader than path matching).
 `.review-body.md` is gitignored.
 
-First run `rm -f .review-body.md` so the Write tool doesn't refuse
-with "File has not been read yet" — that error fires when an
-existing file at the path wasn't Read in this session (typical when
-a previous iteration left the body file behind).
+Use the **Read** tool on `.review-body.md` before writing — if the
+file exists from a previous iteration, this marks it as "read in this
+session" so the Write tool can overwrite it; if the file doesn't
+exist, Read returns an error that can be ignored and Write creates it
+fresh. Do **not** use `rm -f .review-body.md` — `rm -f` is not in
+the fleet's `settings.json` allow-list for worktree-local paths.
 
 ```
-rm -f .review-body.md
+# (Read tool: Read .review-body.md — error is fine if it doesn't exist)
 # (Write tool writes the body to .review-body.md)
 gh pr review <N> --comment --body-file .review-body.md
 ```

--- a/docs/agents/REVIEWER-PROTOCOL.md
+++ b/docs/agents/REVIEWER-PROTOCOL.md
@@ -231,8 +231,6 @@ fresh. Do **not** use `rm -f .review-body.md` — `rm -f` is not in
 the fleet's `settings.json` allow-list for worktree-local paths.
 
 ```
-# (Read tool: Read .review-body.md — error is fine if it doesn't exist)
-# (Write tool writes the body to .review-body.md)
 gh pr review <N> --comment --body-file .review-body.md
 ```
 


### PR DESCRIPTION
## Summary
- Replaces \`rm -f .review-body.md\` in \`docs/agents/REVIEWER-PROTOCOL.md\` with the Read-then-Write approach: use the Read tool on \`.review-body.md\` before writing so the Write tool can overwrite an existing file without needing \`rm -f\`
- The \`rm -f .review-body.md\` command is not in the \`settings.json\` Bash allow-list for worktree-local paths — replacing it with Read-then-Write eliminates the need for the permission entry entirely

## Bootstrap problem (T-344 partial — requires human action)

T-344 requested three changes. Two are addressed here; one hits the self-modification gate:

| Item | Status |
|---|---|
| `rm -f .review-body.md` permission gap | ✅ Fixed via protocol change (no allow-list entry needed) |
| `bash -c kill` exit pattern | ✅ Already obsolete — FLEET-RUNTIME.md switched to natural-exit |
| `.claude/commands/role-*.md` write gate | ⛔ Requires human action — see below |

**Why the self-modification gate can't be fixed autonomously:**

All attempts to modify `.claude/settings.json`, `.claude/settings.local.json`, or any file under `.claude/` (including `.claude/commands/`, `.claude/skills/`) are hard-blocked by the auto-mode classifier even with `Edit(*)` and `Write(*)` in the allow list. The classifier's hard block is at a level above the permissions system.

**Manual steps the human needs to apply after merge:**

1. Update `.claude/skills/review-pr/SKILL.md:322` (and any other skills under `.claude/`) — same Read-then-Write change:
   ```diff
   -1. **First** run `rm -f .review-body.md` so the Write tool doesn't
   -   refuse with "File has not been read yet" ...
   +1. Use the **Read tool** on `.review-body.md` first — if the file
   +   exists from a previous iteration, this marks it as "read in this
   +   session" so the **Write tool** can overwrite it ...
   ```

2. If fleet tasks that modify `.claude/commands/role-*.md` continue to be blocked despite `Edit(*)` in the allow list, manually add to `.claude/settings.json`:
   ```json
   "Edit(.claude/commands/role-*.md)",
   "Write(.claude/commands/role-*.md)",
   ```
   (Or confirm the existing `Edit(*)`/`Write(*)` wildcards ARE sufficient and the classifier behavior is intentional.)

## Test plan
- [ ] Reviewer roles (`role-sonnet-reviewer`, `role-opus-reviewer`) can write `.review-body.md` on a fresh iteration where the file already exists from a prior iteration — Read returns an error, Write succeeds in overwriting
- [ ] Subsequent `review-fleet-feedback digest` no longer surfaces the `permission-gate-friction` cluster for `rm -f .review-body.md` entries (7-day quiet window per acceptance criteria)

Closes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)