### PR TITLE
prefab/input: add missing ir_window.hpp include in command_close_window.hpp

### DIFF
--- a/engine/prefabs/irreden/input/commands/command_close_window.hpp
+++ b/engine/prefabs/irreden/input/commands/command_close_window.hpp
@@ -2,6 +2,7 @@
 #define COMMAND_CLOSE_WINDOW_H
 
 #include <irreden/ir_input.hpp>
+#include <irreden/ir_window.hpp>
 
 #include <irreden/command/ir_command_types.hpp>
 


### PR DESCRIPTION
## Summary

- `command_close_window.hpp` calls `IRWindow::closeWindow()` but does not include `<irreden/ir_window.hpp>`. The include was historically pulled in transitively by every translation unit that consumed the header — so the bug was latent.
- PR #1094 (T-325 unified camera-controls bundle) introduced the include chain `camera_controls.hpp → command_suite_camera.hpp → command_close_window.hpp`, which exposes `command_close_window.hpp` to translation units (`IRUIWidgetsDemo`, `IRUiDockspace`) that do not independently include `ir_window.hpp`. Both demos broke on Linux master with:

  ```
  error: 'closeWindow' is not a member of 'IRWindow'
  ```

- One-line fix: header now includes its own `<irreden/ir_window.hpp>` dependency. No call-site changes; no API surface change. Discovered during a platform-catchup smoke audit on `linux-debug` at master `3d031e44` (issue #1093 surface).

## Test plan

- [x] `fleet-build --target IRUIWidgetsDemo IRUiDockspace` now succeeds on `linux-debug`.
- [x] `fleet-build --target IRShapeDebug` still succeeds (sanity check — IRShapeDebug doesn't depend on this header but a broader rebuild verifies nothing else regresses).
- [ ] macOS reviewer to confirm no regression on `macos-debug` (the macOS author of #1094 did not exercise the ui_widgets / ui_dockspace path; the bug is latent on both backends but only Linux was the catch-up host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)