### PR TITLE
demos/lua_perf_grid: bridge C_LuaWaveState → C_Modifiers so wave motion reaches rendered position

### DIFF
--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -28,6 +28,9 @@
 #include <irreden/common/components/component_name.hpp>
 #include <irreden/common/components/component_local_transform.hpp>
 #include <irreden/common/components/component_local_transform_lua.hpp>
+#include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/common/modifier.hpp>
+#include <irreden/common/transform_modifier_fields.hpp>
 #include <irreden/render/components/component_canvas_ao_texture.hpp>
 #include <irreden/render/components/component_canvas_fog_of_war.hpp>
 #include <irreden/render/components/component_canvas_light_volume.hpp>
@@ -276,6 +279,7 @@ void createGridEntities() {
                 IREntity::createEntity(
                     C_LocalTransform{positionForCell(x, y, z)},
                     C_VoxelSetNew{ivec3(1, 1, 1), colorForCell(x, y, z, n), false},
+                    C_Modifiers{},
                     makeWaveState(x, y, z)
                 );
             }
@@ -381,10 +385,36 @@ void registerLuaBindings() {
 
         const IRSystem::SystemId waveSysId = resolveLuaWaveTickId(script);
 
+        // Bridge: read the wave-eased vec3 out of C_LuaWaveState (written by
+        // waveSysId above) and upsert it as the entity's TRANSFORM_TRANSLATION
+        // ADD modifier. PROPAGATE_TRANSFORM next folds the modifier into
+        // C_WorldTransform.translation_. Mirrors PERIODIC_IDLE_POSITION_OFFSET
+        // for the C++ perf_grid demo, but reads the Lua-codegen-produced
+        // C_LuaWaveState instead of C_PeriodicIdle. Without this bridge the
+        // wave runs but never reaches the rendered position (T-302 / T-300
+        // retired the legacy C_PositionOffset3D path, so a creation-side
+        // writer is the only way to drive per-frame additive translation).
+        const IRSystem::SystemId luaWaveOffsetId =
+            IRSystem::createSystem<C_LuaWaveState, C_Modifiers>(
+                "LuaWaveStateToOffset",
+                [](IREntity::EntityId entity,
+                   C_LuaWaveState &wave,
+                   C_Modifiers &mods) {
+                    IRPrefab::Modifier::upsertBySourceInPlace(
+                        mods,
+                        IRPrefab::TransformModifier::translationField(),
+                        IRComponents::TransformKind::ADD,
+                        vec3(wave.out_x_, wave.out_y_, wave.out_z_),
+                        entity
+                    );
+                }
+            );
+
         IRSystem::registerPipeline(
             IRTime::Events::UPDATE,
             {
                 waveSysId,
+                luaWaveOffsetId,
                 IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>(),
                 IRSystem::createSystem<IRSystem::UPDATE_VOXEL_SET_CHILDREN>(),
             }


### PR DESCRIPTION
## Summary

`IRLuaPerfGrid` was rendering as a static cube — the codegen-emitted `LuaWaveTick` system was correctly ticking and writing the sine-eased wave value into `C_LuaWaveState.out_{x,y,z}_`, but nothing was reading those fields and applying them to the entity's transform. The C++ baseline (`creations/demos/perf_grid/main.cpp`) wires this via `PERIODIC_IDLE_POSITION_OFFSET`, which reads `C_PeriodicIdle` and writes a per-frame `TRANSFORM_TRANSLATION/ADD` modifier on `C_Modifiers`; the Lua demo's equivalent had no bridge.

This PR:

1. Attaches `C_Modifiers{}` to each grid entity at creation (matches the C++ baseline's line 438 — required so the modifier slot exists for the bridge to upsert into).
2. Adds an inline `LuaWaveStateToOffset` system in `main_lua.cpp` that reads `C_LuaWaveState + C_Modifiers` and calls `IRPrefab::Modifier::upsertBySourceInPlace` under `TRANSFORM_TRANSLATION/ADD`. Mirrors `system_periodic_idle_position_offset.hpp` but reads the Lua-codegen-produced component instead of `C_PeriodicIdle`.
3. Inserts the new system between `waveSysId` and `PROPAGATE_TRANSFORM` in the UPDATE pipeline. `PROPAGATE_TRANSFORM`'s modifier-fallback path (composes directly from `C_Modifiers` when `C_ResolvedFields` is absent) then folds the wave value into `C_WorldTransform.translation_`.

## Visual verification

| Before (`origin/master`) | After (this branch) |
|---|---|
| Static cube — no wave motion despite `LuaWaveTick` firing each frame. All 4 captured PNGs were byte-identical (261,152 bytes each). | Clear sine-wave displacement pattern in vertical bands. Post-fix shots differ in size (338,674 / 336,453 bytes) because motion captures different wave phases. |

## Known follow-up (not in this PR)

The bridge + modifier-fold path adds per-entity work that pushes `IRLuaPerfGrid`'s exit-clean budget from ~21s (pre-fix, no motion — auto-screenshot fires and the demo cleanly exits) to >45s (post-fix, with motion — exceeds the bash watchdog backstop in the platform-catchup smoke script). For 64×64×64 = 262,144 entities this is the same perf class as #1154 (IRPerfGrid 1 FPS on OpenGL). Worth a follow-up `optimize` pass on the `PROPAGATE_TRANSFORM` modifier-fallback compose path or the `upsertBySourceInPlace` iteration cost — but the motion fix is the right move regardless.

## Test plan

- [x] `fleet-build --target IRLuaPerfGrid` builds clean on `linux-debug`.
- [x] `fleet-run IRLuaPerfGrid --auto-screenshot 30` captures both `fit_grid` and `zoom1_origin` shots; PNG byte sizes differ from pre-fix baseline, confirming motion.
- [x] Visual side-by-side (read PNGs in tool) shows static cube → wave pattern.
- [ ] macOS reviewer to confirm `IRLuaPerfGrid` on Metal also gains visible wave motion (the bug is host-agnostic; this fix should help both backends).

Discovered during the platform-catchup smoke run on 2026-05-24 (matches user observation: "one of the perf_grid demos doesn't have any motion, maybe the new system doesn't work well for lua code as far as transforms").

🤖 Generated with [Claude Code](https://claude.com/claude-code)