### PR TITLE
update/propagate_transform: root-archetype fast path (skip quatMul + rotateVectorByQuat when parent is null)

### DIFF
--- a/engine/prefabs/irreden/update/systems/system_propagate_transform.hpp
+++ b/engine/prefabs/irreden/update/systems/system_propagate_transform.hpp
@@ -210,15 +210,9 @@ template <> struct System<PROPAGATE_TRANSFORM> {
                 &IREntity::getComponentData<IRComponents::C_Modifiers>(node);
         }
 
-        // Root archetypes (no CHILD_OF parent) have `parentWorld == identity`.
-        // In that case the SQT composition collapses to: world = local +
-        // modifiers, with quatMul/rotateVectorByQuat both no-ops. Hoist
-        // the root check out of the inner loop and take a quat-free fast
-        // path — saves one quatMul (~16 fp ops) and one rotateVectorByQuat
-        // (~30 fp ops) per entity per frame. At perf_grid / lua_perf_grid
-        // scale (262K root entities × 60 Hz) this is ~720M fp ops/sec
-        // off the CPU budget. Non-root archetypes (any with CHILD_OF) keep
-        // the full path — that's where the quat math is meaningful.
+        // parentWorld == identity for root archetypes, so quatMul and
+        // rotateVectorByQuat are both no-ops. Hoist the check out of the
+        // inner loop and skip the quat math — only meaningful with CHILD_OF.
         const bool isRootArchetype = (parent == IREntity::kNullEntity);
 
         for (int i = 0; i < node->length_; ++i) {

--- a/engine/prefabs/irreden/update/systems/system_propagate_transform.hpp
+++ b/engine/prefabs/irreden/update/systems/system_propagate_transform.hpp
@@ -210,6 +210,17 @@ template <> struct System<PROPAGATE_TRANSFORM> {
                 &IREntity::getComponentData<IRComponents::C_Modifiers>(node);
         }
 
+        // Root archetypes (no CHILD_OF parent) have `parentWorld == identity`.
+        // In that case the SQT composition collapses to: world = local +
+        // modifiers, with quatMul/rotateVectorByQuat both no-ops. Hoist
+        // the root check out of the inner loop and take a quat-free fast
+        // path — saves one quatMul (~16 fp ops) and one rotateVectorByQuat
+        // (~30 fp ops) per entity per frame. At perf_grid / lua_perf_grid
+        // scale (262K root entities × 60 Hz) this is ~720M fp ops/sec
+        // off the CPU budget. Non-root archetypes (any with CHILD_OF) keep
+        // the full path — that's where the quat math is meaningful.
+        const bool isRootArchetype = (parent == IREntity::kNullEntity);
+
         for (int i = 0; i < node->length_; ++i) {
             const auto &local = locals[i];
 
@@ -227,6 +238,15 @@ template <> struct System<PROPAGATE_TRANSFORM> {
                 modScale = IRPrefab::Modifier::detail::composeForFieldVec3(
                     IRMath::vec3(1.0f), scaleField, modsVec3
                 );
+            }
+
+            if (isRootArchetype) {
+                worlds[i] = IRComponents::C_WorldTransform{
+                    local.translation_ + modTranslation,
+                    local.rotation_,
+                    local.scale_ * modScale,
+                };
+                continue;
             }
 
             const IRMath::vec3 worldScale =


### PR DESCRIPTION
## Summary

Optimization for `SYSTEM_PROPAGATE_TRANSFORM`. For root archetypes (entities with no `CHILD_OF` parent), `parentWorld` stays at default-constructed identity. The SQT compose then reduces to:

```
identity_quat × local.rotation              = local.rotation
rotateVectorByQuat(local.translation, id)   = local.translation
identity_scale × local.scale × modScale     = local.scale × modScale
```

…with `quatMul` and `rotateVectorByQuat` both no-ops. The previous code ran them unconditionally — `parentWorld.rotation_` is loaded from memory, so the compiler can't constant-fold the identity check.

This change hoists the root check (`parent == kNullEntity`) out of the inner loop and takes a quat-free fast path. Saves ~1 `quatMul` (~16 fp ops) + ~1 `rotateVectorByQuat` (~30 fp ops) + ~1 parent-scale vec3 mul per root entity per frame.

## Measured impact

`IRLuaPerfGrid` (64×64×64 = 262,144 root entities with a per-frame `TRANSFORM_TRANSLATION` modifier per PR #1155's motion-fix wave, cherry-picked locally only to make the measurement valid — without the modifier the entities don't exercise the per-tick compose path):

| Build                                          | Update tick        | Demo runtime           |
|------------------------------------------------|--------------------|------------------------|
| master + PR #1155 (motion fix, no opt)         | 14-17 ms           | >45 s — bash watchdog killed, didn't auto-exit |
| master + PR #1155 + this PR                    | **12-15 ms**       | **~41 s** — auto-exits cleanly via `--auto-screenshot` close-window |

Both on `linux-x86_64` (WSLg Mesa-d3d12, master `3d031e44`). 10-20% Update-tick improvement, sufficient to bring back clean auto-exit.

The remaining slowdown vs the pre-motion-fix 21 s baseline is **GPU-bound** (the modifier-resolved wave displaces entities every frame and the lighting compute does real work instead of running on a static scene); see #1154 for the GPU side.

## Correctness

Mathematically equivalent for root entities — verified by running:
- All **10** `PropagateTransformTest` tests (including `RootEntityWorldEqualsLocal` which directly exercises the root branch + the multi-level chain tests which exercise the non-root branch).
- The broader `*Modifier*:*Transform*:*Skeleton*` filter suite, **159 tests** all green.

Non-root archetypes (any with `CHILD_OF`) keep the full quat path — quat math is meaningful when `parentWorld` is non-identity.

## Test plan

- [x] `IrredenEngineTest --gtest_filter='PropagateTransformTest.*'` — 10/10 pass.
- [x] `IrredenEngineTest --gtest_filter='*Modifier*:*Transform*:*Skeleton*'` — 159/159 pass.
- [x] `fleet-build --target IRLuaPerfGrid` clean on `linux-debug`.
- [x] `fleet-run IRLuaPerfGrid --auto-screenshot 30` measured against PR #1155's combined diff: 41 s clean exit, Update tick 12-15 ms (was 14-17 ms).
- [ ] macOS reviewer to confirm test suite passes on `macos-debug` and run a brief `IRPerfGrid` smoke to confirm no Metal regression.

Discovered during the platform-catchup `/optimize` flow on 2026-05-24. Standalone change — not coupled to #1155 (which is the standalone lua_perf_grid motion fix). They land independently and compound when both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)