### PR TITLE
T-348: engine/system: SERIAL fast-path + dual-slot consolidation

### DIFF
--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -22,9 +22,12 @@ matched archetype. Per-entity iteration is the body's responsibility,
 not SystemManager's — the Lua surface uses this to keep the C++/Lua
 boundary at one `sol::function` call per archetype.
 
-Both paths share the same scheduler: `executePipeline` walks
-`m_ticks[system].functionTick_`, which is a `std::function<void(
-ArchetypeNode*)>` regardless of which factory created the system.
+Both paths share the same scheduler: `executePipeline` dispatches via
+`m_ticks[system].prepareRangedTick_` for row-iterating forms (the binder
+resolves component vectors on the main thread and returns a
+`void(begin,end)` closure), or via `m_ticks[system].functionTick_` for
+the batch form and dynamic systems; row-iterating forms leave
+`functionTick_` empty.
 
 ## `replaceSystemBody` for hot-reload
 

--- a/engine/system/include/irreden/system/components/component_system_event.hpp
+++ b/engine/system/include/irreden/system/components/component_system_event.hpp
@@ -37,20 +37,21 @@ template <> struct C_SystemEvent<IRSystem::TICK> {
     /// entirely through `prepareRangedTick_` (T-348).
     TickFn functionTick_;
 
-    /// Main-thread binder for `Concurrency::PARALLEL_FOR` dispatch.
+    /// Main-thread binder for row-iterating tick forms; used by
+    /// SERIAL/MAIN_THREAD and PARALLEL_FOR alike (T-348).
     /// SystemManager calls this **once on the main thread** per matched
-    /// archetype node before fanning chunks out to `IRJob::parallelFor`.
-    /// The binder resolves the per-component vector references from the
-    /// node (going through `EntityManager::getComponentType<>` →
-    /// `m_pureComponentTypes` hash lookup, which is NOT safe under
-    /// concurrent reads from worker threads), captures them in a
-    /// `void(rangeBegin, rangeEnd)` closure, and returns it for workers
-    /// to invoke without ever touching EntityManager state. Populated
-    /// by the template `createSystem<...>` path for tick signatures the
-    /// runtime can chunk safely; empty for `createSystemDynamic`
-    /// (opaque body) and the per-archetype batch form (consumes the
-    /// whole column) — the registration validator rejects
-    /// `PARALLEL_FOR` in both cases.
+    /// archetype node. The binder resolves the per-component vector
+    /// references from the node (going through
+    /// `EntityManager::getComponentType<>` → `m_pureComponentTypes`
+    /// hash lookup, which is NOT safe under concurrent reads from worker
+    /// threads), captures them in a `void(rangeBegin, rangeEnd)` closure,
+    /// and returns it. For SERIAL/MAIN_THREAD, `executeSystem` invokes
+    /// the closure immediately with `[0, length)`. For PARALLEL_FOR,
+    /// it fans the closure out to `IRJob::parallelFor`. Populated by the
+    /// template `createSystem<...>` path for tick signatures the runtime
+    /// can chunk safely; empty for `createSystemDynamic` (opaque body)
+    /// and the per-archetype batch form (consumes the whole column) —
+    /// the registration validator rejects `PARALLEL_FOR` in both cases.
     PrepareRangedTickFn prepareRangedTick_;
 
     IREntity::Archetype archetype_;

--- a/engine/system/include/irreden/system/components/component_system_event.hpp
+++ b/engine/system/include/irreden/system/components/component_system_event.hpp
@@ -27,13 +27,14 @@ template <> struct C_SystemEvent<IRSystem::TICK> {
     /// to resolve component vectors and return a worker closure that
     /// covers `[rangeBegin, rangeEnd)` of the resolved rows. See the
     /// `prepareRangedTick_` field below for the full contract.
-    using PrepareRangedTickFn = std::function<
-        std::function<void(int rangeBegin, int rangeEnd)>(IREntity::ArchetypeNode *)>;
+    using PrepareRangedTickFn =
+        std::function<std::function<void(int rangeBegin, int rangeEnd)>(IREntity::ArchetypeNode *)>;
 
-    /// Whole-node dispatch — the body iterates `[0, node->length_)`
-    /// internally. The legacy form; every system has one. For
-    /// `Concurrency::SERIAL` and `Concurrency::MAIN_THREAD` this is the
-    /// path SystemManager invokes.
+    /// Whole-node dispatch — used ONLY by the per-archetype batch form
+    /// (`InvocableWithNodeVectors`) and dynamic systems created via
+    /// `createSystemDynamic` / Lua hot-reload. Row-iterating forms
+    /// (per-component, per-entity-id) leave this empty and dispatch
+    /// entirely through `prepareRangedTick_` (T-348).
     TickFn functionTick_;
 
     /// Main-thread binder for `Concurrency::PARALLEL_FOR` dispatch.

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -193,8 +193,7 @@ class SystemManager {
     /// between systems within a group (group members are required to
     /// be structurally clean by the validator). Replaces any prior
     /// registration for `event`.
-    void
-    registerPipelineGroups(IRTime::Events event, std::vector<std::vector<SystemId>> groups);
+    void registerPipelineGroups(IRTime::Events event, std::vector<std::vector<SystemId>> groups);
 
     /// T-224: validate every registered pipeline group against the
     /// cross-system access rules in `system_access.hpp`. Call once
@@ -306,9 +305,8 @@ class SystemManager {
     }
 
     // Tick functions are operated on each entity in the system
-    // matching the archetype. The runtime stores **two** dispatch
-    // shapes per system (T-222 Phase 2 of the multithreading epic;
-    // worker-side reshaped by T-333):
+    // matching the archetype. The runtime stores one dispatch slot per
+    // system — the binder form established by T-222/T-333:
     //
     //   - `prepareRangedTick(node)` — main-thread binder. Resolves
     //     the per-component vector refs from `node` once via
@@ -317,15 +315,15 @@ class SystemManager {
     //     and returns a `void(rangeBegin, rangeEnd)` worker closure
     //     that captures those refs by value. Populated for every
     //     signature that iterates entities row-by-row (per-component,
-    //     per-entity-id, optional-relations). The per-archetype batch
-    //     form (`InvocableWithNodeVectors`) consumes the whole column
-    //     and is intentionally unchunkable — `prepareRangedTick` is
-    //     empty in that case; the per-node `functionTick_` does the
-    //     dispatch.
-    //   - `functionTick(node)` — back-compat per-node entry. For the
-    //     row-iterating forms it calls `prepareRangedTick(node)` and
-    //     invokes the returned closure with `[0, length)`; for the
-    //     batch form it carries the body directly.
+    //     per-entity-id, optional-relations). `executeSystem` calls
+    //     the binder once and invokes the returned closure with
+    //     `[0, length)` for SERIAL/MAIN_THREAD, or fans the closure
+    //     out to worker chunks via `IRJob::parallelFor` for
+    //     PARALLEL_FOR. No per-node heap allocation.
+    //   - `functionTick(node)` — used ONLY by the per-archetype batch
+    //     form (`InvocableWithNodeVectors`) and dynamic systems
+    //     (`createSystemDynamic` / Lua hot-reload). Row-iterating forms
+    //     leave this empty and dispatch entirely through the binder.
     //
     // `Concurrency::PARALLEL_FOR` requires `prepareRangedTick` to be
     // populated; the entry-point validator in `ir_system.hpp` rejects
@@ -354,14 +352,12 @@ class SystemManager {
                     paramTuple
                 );
             };
-            m_ticks.emplace_back(
-                C_SystemEvent<TICK>{
-                    std::function<void(ArchetypeNode *)>{std::move(perNodeFn)},
-                    std::function<std::function<void(int, int)>(ArchetypeNode *)>{},
-                    getArchetype<Components...>(),
-                    std::move(excludeArchetype)
-                }
-            );
+            m_ticks.emplace_back(C_SystemEvent<TICK>{
+                std::function<void(ArchetypeNode *)>{std::move(perNodeFn)},
+                std::function<std::function<void(int, int)>(ArchetypeNode *)>{},
+                getArchetype<Components...>(),
+                std::move(excludeArchetype)
+            });
             return;
         } else {
 
@@ -379,9 +375,8 @@ class SystemManager {
             // an `else` so the unsupported-signature static_assert below
             // only fires when the batch-form branch above has NOT
             // discarded this code.
-            auto prepareRangedTick =
-                [functionTick,
-                 extraParams](ArchetypeNode *node) -> std::function<void(int, int)> {
+            auto prepareRangedTick = [functionTick, extraParams](ArchetypeNode *node
+                                     ) -> std::function<void(int, int)> {
                 if constexpr (InvocableWithEntityId<FunctionTick, Components...>) {
                     auto componentsTuple = std::make_tuple(
                         std::ref(node->entities_),
@@ -410,12 +405,10 @@ class SystemManager {
                             );
                         }
                     };
-                } else if constexpr (
-                    std::is_invocable_v<
-                        FunctionTick,
-                        Components &...,
-                        std::optional<RelationComponents *>...>
-                ) {
+                } else if constexpr (std::is_invocable_v<
+                                         FunctionTick,
+                                         Components &...,
+                                         std::optional<RelationComponents *>...>) {
                     // Relation form: the validator (T-334 scope) rejects
                     // PARALLEL_FOR + relation, so this binder runs only
                     // on the main thread. Resolve component vectors AND
@@ -434,11 +427,9 @@ class SystemManager {
                             std::apply(
                                 [&functionTick](auto &&...args) { functionTick(args...); },
                                 std::tuple_cat(
-                                    std::make_tuple(
-                                        std::ref(
-                                            std::get<std::vector<Components> &>(componentsTuple)[i]
-                                        )...
-                                    ),
+                                    std::make_tuple(std::ref(
+                                        std::get<std::vector<Components> &>(componentsTuple)[i]
+                                    )...),
                                     relationComponentTuple
                                 )
                             );
@@ -448,23 +439,12 @@ class SystemManager {
                     static_assert(false, "Unsupported tick function signature.");
                 }
             };
-            C_SystemEvent<TICK>::PrepareRangedTickFn prepareRangedTickErased{
-                std::move(prepareRangedTick)
-            };
-            auto prepareRangedTickCopy = prepareRangedTickErased;
-            auto perNodeFn = [prepareRangedTickCopy =
-                                  std::move(prepareRangedTickCopy)](ArchetypeNode *node) {
-                auto rangedTick = prepareRangedTickCopy(node);
-                rangedTick(0, node->length_);
-            };
-            m_ticks.emplace_back(
-                C_SystemEvent<TICK>{
-                    std::function<void(ArchetypeNode *)>{std::move(perNodeFn)},
-                    std::move(prepareRangedTickErased),
-                    getArchetype<Components...>(),
-                    std::move(excludeArchetype)
-                }
-            );
+            m_ticks.emplace_back(C_SystemEvent<TICK>{
+                std::function<void(ArchetypeNode *)>{},
+                C_SystemEvent<TICK>::PrepareRangedTickFn{std::move(prepareRangedTick)},
+                getArchetype<Components...>(),
+                std::move(excludeArchetype)
+            });
         }
     }
 
@@ -488,11 +468,8 @@ class SystemManager {
             m_relationTicks.emplace_back(
                 C_SystemEvent<RELATION_TICK>{[functionRelationTick](EntityRecord entityRecord) {
                     auto componentsTuple = std::make_tuple(
-                        std::ref(
-                            getComponentData<RelationComponents>(
-                                entityRecord.archetypeNode
-                            )[entityRecord.row]
-                        )...
+                        std::ref(getComponentData<RelationComponents>(entityRecord.archetypeNode
+                        )[entityRecord.row])...
                     );
                     std::apply(
                         [functionRelationTick](auto &&...components) {

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -367,11 +367,11 @@ class SystemManager {
             // which goes through `EntityManager::m_pureComponentTypes`,
             // unsafe under concurrent reads — and returns a
             // `void(rangeBegin, rangeEnd)` worker closure that captures
-            // those refs. The SERIAL / MAIN_THREAD entry (`perNodeFn`)
-            // calls the binder once and invokes the returned closure
-            // with `[0, length)`; the PARALLEL_FOR dispatcher in
-            // `executeSystem` calls the binder once and fans the closure
-            // out to worker chunks via `IRJob::parallelFor`. Wrapped in
+            // those refs. The SERIAL / MAIN_THREAD path in `executeSystem`
+            // calls the binder once and invokes the returned closure with
+            // `[0, length)`; the PARALLEL_FOR dispatcher in `executeSystem`
+            // calls the binder once and fans the closure out to worker
+            // chunks via `IRJob::parallelFor`. Wrapped in
             // an `else` so the unsupported-signature static_assert below
             // only fires when the batch-form branch above has NOT
             // discarded this code.

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -56,13 +56,11 @@ SystemId SystemManager::createSystemDynamic(
     SystemId newSystemId = m_nextSystemId++;
 
     m_beginTicks.emplace_back(C_SystemEvent<BEGIN_TICK>{[]() {}});
-    m_ticks.emplace_back(
-        C_SystemEvent<TICK>{
-            std::move(body),
-            std::move(includeArchetype),
-            std::move(excludeArchetype),
-        }
-    );
+    m_ticks.emplace_back(C_SystemEvent<TICK>{
+        std::move(body),
+        std::move(includeArchetype),
+        std::move(excludeArchetype),
+    });
     m_endTicks.emplace_back(C_SystemEvent<END_TICK>{[]() {}});
     m_relationTicks.emplace_back(C_SystemEvent<RELATION_TICK>{[](EntityRecord) {}});
 
@@ -380,7 +378,14 @@ void SystemManager::executeSystem(SystemId system) {
             // SERIAL / MAIN_THREAD path, the small-node / no-pool
             // fallback for PARALLEL_FOR, and the nested-dispatch
             // fallback when executeSystem is called from a worker.
-            tickEvent.functionTick_(node);
+            // Row-iterating forms have prepareRangedTick_ only; batch
+            // and dynamic forms have functionTick_ only (T-348).
+            if (static_cast<bool>(tickEvent.prepareRangedTick_)) {
+                auto rangedTick = tickEvent.prepareRangedTick_(node);
+                rangedTick(0, node->length_);
+            } else {
+                tickEvent.functionTick_(node);
+            }
         }
     }
     m_endTicks[system].functionEndTick_();

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -94,6 +94,10 @@ void SystemManager::replaceSystemBody(SystemId system, std::function<void(Archet
         m_nextSystemId
     );
     IR_ASSERT(static_cast<bool>(body), "replaceSystemBody: body must be a non-empty std::function");
+    IR_ASSERT(
+        !static_cast<bool>(m_ticks[system].prepareRangedTick_),
+        "replaceSystemBody: row-iterating systems use prepareRangedTick_, not functionTick_"
+    );
     m_ticks[system].functionTick_ = std::move(body);
 }
 


### PR DESCRIPTION
## Summary
- Drop `functionTick_` for row-iterating tick forms (per-component, per-entity-id, optional-relation); only `prepareRangedTick_` is stored for these.
- Remove the `perNodeFn` wrapper lambda and the `prepareRangedTickCopy` that caused dual heap allocation per row-iterating system at registration time.
- `executeSystem` SERIAL/MAIN_THREAD else-path now branches: calls `prepareRangedTick_(node)(0, length)` when the binder is populated, falls back to `functionTick_` for batch/dynamic forms.
- `replaceSystemBody` + `createSystemDynamic` (Lua hot-reload) unaffected — those paths only use `functionTick_`.
- Update comments in `system_manager.hpp`, `component_system_event.hpp`, `system_manager.cpp`, and `engine/system/CLAUDE.md` to reflect the single-slot contract.

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean build, no new warnings
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — all 7 shots captured, no crash
- [x] `fleet-build --target format-changed && fleet-build --target IrredenEngineSystem` — clean rebuild after simplify pass

Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)