### PR TITLE
T-349: engine/system: order validator rules most-specific-first for catch-all + PARALLEL_FOR

### DIFF
--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -36,21 +36,23 @@ template <typename... Cs> struct ArchetypeFromList<TypeList<Cs...>> {
 
 // T-222 / T-334: validate that a system's compile-time access
 // descriptor is compatible with its requested Concurrency policy. Four
-// rules, distilled from the multithreading epic (#226 §"Layer 4"):
+// rules, ordered most-specific-first so that a variadic catch-all tick
+// (which simultaneously satisfies every probe) emits the most useful
+// diagnostic. Distilled from the multithreading epic (#226 §"Layer 4"):
 //
+//   - PARALLEL_FOR + isRelationForm_ → FATAL. The relation branch in
+//     `rangedFn` calls `getRelatedEntityFromArchetype` +
+//     `getComponentOptional` on `EntityManager` inside the per-row
+//     loop; those lookups race on the manager's archetype map from
+//     worker threads. Checked first: the most specific form constraint.
+//   - PARALLEL_FOR + isBatchForm_ → FATAL. The per-archetype batch
+//     form consumes the whole column; row-level chunking would
+//     re-enter the body N times with overlapping handles.
 //   - PARALLEL_FOR + usesEntityId_ + !parallelSafe_ → FATAL. The
 //     per-entity-id tick form passes the iterated EntityId to the
 //     body; without an explicit `ParallelSafe` opt-in, the body is
 //     assumed to use the id to mutate non-thread-safe singletons
 //     (`g_entityManager`, render managers, sol2).
-//   - PARALLEL_FOR + isBatchForm_ → FATAL. The per-archetype batch
-//     form consumes the whole column; row-level chunking would
-//     re-enter the body N times with overlapping handles.
-//   - PARALLEL_FOR + isRelationForm_ → FATAL. The relation branch in
-//     `rangedFn` calls `getRelatedEntityFromArchetype` +
-//     `getComponentOptional` on `EntityManager` from inside the per-
-//     row loop, which races on the manager's archetype map from
-//     worker threads.
 //   - PARALLEL_FOR + mainThreadOnly_ → FATAL. The `MainThread` tag is
 //     explicit "do not parallelize", and silently downgrading would
 //     hide the conflict.
@@ -65,11 +67,13 @@ validateConcurrencyForAccess(const std::string &name, Concurrency c, SystemAcces
         return;
     }
     IR_ASSERT(
-        !access.usesEntityId_ || access.parallelSafe_,
-        "System '{}' requested Concurrency::PARALLEL_FOR with an "
-        "EntityId tick parameter but no IRSystem::ParallelSafe tag. The "
-        "id-aware tick form is presumed to look up other entities; tag "
-        "the component pack with `ParallelSafe` after auditing the body.",
+        !access.isRelationForm_,
+        "System '{}' requested Concurrency::PARALLEL_FOR with the "
+        "relation tick form (RelationParams<...> + std::optional<...*> "
+        "in the tick signature). The relation branch resolves the "
+        "related entity and its components via EntityManager lookups "
+        "inside the per-row loop; those manager accesses are not "
+        "thread-safe.",
         name
     );
     IR_ASSERT(
@@ -81,13 +85,11 @@ validateConcurrencyForAccess(const std::string &name, Concurrency c, SystemAcces
         name
     );
     IR_ASSERT(
-        !access.isRelationForm_,
-        "System '{}' requested Concurrency::PARALLEL_FOR with the "
-        "relation tick form (RelationParams<...> + std::optional<...*> "
-        "in the tick signature). The relation branch resolves the "
-        "related entity and its components via EntityManager lookups "
-        "inside the per-row loop; those manager accesses are not "
-        "thread-safe.",
+        !access.usesEntityId_ || access.parallelSafe_,
+        "System '{}' requested Concurrency::PARALLEL_FOR with an "
+        "EntityId tick parameter but no IRSystem::ParallelSafe tag. The "
+        "id-aware tick form is presumed to look up other entities; tag "
+        "the component pack with `ParallelSafe` after auditing the body.",
         name
     );
     IR_ASSERT(
@@ -155,12 +157,10 @@ constexpr SystemId createSystem(
     constexpr SystemAccess accessDescriptor = []() {
         SystemAccess a = deriveAccessFromSignature<FunctionTick, TickComponents...>();
         if constexpr (sizeof...(TickRelationComponents) > 0) {
-            if constexpr (
-                std::is_invocable_v<
-                    FunctionTick,
-                    std::remove_cvref_t<TickComponents> &...,
-                    std::optional<TickRelationComponents *>...>
-            ) {
+            if constexpr (std::is_invocable_v<
+                              FunctionTick,
+                              std::remove_cvref_t<TickComponents> &...,
+                              std::optional<TickRelationComponents *>...>) {
                 a.isRelationForm_ = true;
             }
         }
@@ -218,14 +218,12 @@ template <typename T, typename... Cs> struct MakeMemberTickFn<T, TypeList<Cs...>
             return [p](Cs &...cs) { p->tick(cs...); };
         } else if constexpr (requires(T &s, EntityId id, Cs &...cs) { s.tick(id, cs...); }) {
             return [p](EntityId id, Cs &...cs) { p->tick(id, cs...); };
-        } else if constexpr (
-            requires(
-                T &s,
-                const Archetype &a,
-                std::vector<EntityId> &ids,
-                std::vector<Cs> &...cols
-            ) { s.tick(a, ids, cols...); }
-        ) {
+        } else if constexpr (requires(
+                                 T &s,
+                                 const Archetype &a,
+                                 std::vector<EntityId> &ids,
+                                 std::vector<Cs> &...cols
+                             ) { s.tick(a, ids, cols...); }) {
             return [p](const Archetype &a, std::vector<EntityId> &ids, std::vector<Cs> &...cols) {
                 p->tick(a, ids, cols...);
             };
@@ -439,9 +437,7 @@ void registerPipeline(IRTime::Events systemType, std::list<SystemId> pipeline);
 ///         { globalPosition },            // group 1: serial
 ///         { lifetime },                  // group 2: serial
 ///     });
-void registerPipelineGroups(
-    IRTime::Events event, std::vector<std::vector<SystemId>> groups
-);
+void registerPipelineGroups(IRTime::Events event, std::vector<std::vector<SystemId>> groups);
 
 /// T-224: run the cross-system access-conflict validator across every
 /// registered pipeline group. FATALs on the first conflict, naming

--- a/test/system/system_concurrency_test.cpp
+++ b/test/system/system_concurrency_test.cpp
@@ -279,8 +279,7 @@ TEST_F(CreateSystemValidatorTest, CatchAllWithRelationParamsFatalsAtRegistration
     // T-349: a variadic catch-all tick simultaneously satisfies every
     // signature probe (entity-id, batch-form, relation-form). The
     // validator rules are ordered most-specific-first (relation →
-    // batch → entity-id) so the relation-form assertion fires first;
-    // the log output names the condition (!access.isRelationForm_).
+    // batch → entity-id) so the isRelationForm_ assertion fires first.
     // This test pins that PARALLEL_FOR + catch-all + RelationParams is
     // always rejected — a different shape than the explicit relation-
     // form case in RelationFormParallelForFatalsAtRegistration.

--- a/test/system/system_concurrency_test.cpp
+++ b/test/system/system_concurrency_test.cpp
@@ -60,17 +60,19 @@ using IRSystem::SystemAccess;
 // std::runtime_error via engAssert); we re-derive the predicate here
 // so the test can run in IR_RELEASE builds too, and so the diagnostics
 // stay stable across the validator's internal wording changes.
+// Rules are listed most-specific-first, mirroring the production validator
+// (T-349).
 constexpr bool isParallelForAcceptable(Concurrency c, SystemAccess access) {
     if (c != Concurrency::PARALLEL_FOR) {
         return true;
     }
-    if (access.usesEntityId_ && !access.parallelSafe_) {
+    if (access.isRelationForm_) {
         return false;
     }
     if (access.isBatchForm_) {
         return false;
     }
-    if (access.isRelationForm_) {
+    if (access.usesEntityId_ && !access.parallelSafe_) {
         return false;
     }
     if (access.mainThreadOnly_) {
@@ -101,8 +103,7 @@ class JobManagerFixture : public ::testing::Test {
 TEST(SystemConcurrencyValidator, PerComponentFormAcceptsParallelFor) {
     // void tick(C_VelA&, const C_VelB&) — the canonical clean case.
     // Writes C_VelA, reads C_VelB, no EntityId, not batch form.
-    auto access =
-        deriveAccessFromSignature<void(C_VelA &, const C_VelB &), C_VelA, const C_VelB>();
+    auto access = deriveAccessFromSignature<void(C_VelA &, const C_VelB &), C_VelA, const C_VelB>();
 
     EXPECT_FALSE(access.usesEntityId_);
     EXPECT_FALSE(access.isBatchForm_);
@@ -113,9 +114,7 @@ TEST(SystemConcurrencyValidator, PerEntityIdFormRejectedWithoutParallelSafe) {
     // void tick(EntityId, C_VelA&) — id-aware form. Without an
     // explicit ParallelSafe tag, the body is presumed to dereference
     // the id into a non-thread-safe singleton.
-    auto access = deriveAccessFromSignature<
-        void(IREntity::EntityId &, C_VelA &),
-        C_VelA>();
+    auto access = deriveAccessFromSignature<void(IREntity::EntityId &, C_VelA &), C_VelA>();
 
     EXPECT_TRUE(access.usesEntityId_);
     EXPECT_FALSE(access.parallelSafe_);
@@ -161,11 +160,7 @@ TEST(SystemConcurrencyValidator, BatchFormRejected) {
     // so row-level chunking would re-enter it with overlapping
     // vectors. PARALLEL_FOR is structurally incompatible.
     auto access = deriveAccessFromSignature<
-        void(
-            const IREntity::Archetype &,
-            std::vector<IREntity::EntityId> &,
-            std::vector<C_VelA> &
-        ),
+        void(const IREntity::Archetype &, std::vector<IREntity::EntityId> &, std::vector<C_VelA> &),
         C_VelA>();
 
     EXPECT_TRUE(access.isBatchForm_);
@@ -201,9 +196,7 @@ TEST(SystemConcurrencyValidator, RelationFormRejected) {
 TEST(SystemConcurrencyValidator, MainThreadTagRejectsParallelFor) {
     // The MainThread tag is explicit "do not parallelize"; the
     // validator must FATAL rather than silently downgrade.
-    auto access = deriveAccessFromSignature<
-        void(C_VelA &),
-        C_VelA, MainThread>();
+    auto access = deriveAccessFromSignature<void(C_VelA &), C_VelA, MainThread>();
 
     EXPECT_TRUE(access.mainThreadOnly_);
     EXPECT_FALSE(isParallelForAcceptable(Concurrency::PARALLEL_FOR, access));
@@ -280,6 +273,30 @@ TEST_F(CreateSystemValidatorTest, RelationFormSerialAcceptedAtRegistration) {
             Concurrency::SERIAL
         );
     });
+}
+
+TEST_F(CreateSystemValidatorTest, CatchAllWithRelationParamsFatalsAtRegistration) {
+    // T-349: a variadic catch-all tick simultaneously satisfies every
+    // signature probe (entity-id, batch-form, relation-form). The
+    // validator rules are ordered most-specific-first (relation →
+    // batch → entity-id) so the relation-form assertion fires first;
+    // the log output names the condition (!access.isRelationForm_).
+    // This test pins that PARALLEL_FOR + catch-all + RelationParams is
+    // always rejected — a different shape than the explicit relation-
+    // form case in RelationFormParallelForFatalsAtRegistration.
+    auto catchAllTick = [](auto &&...) {};
+    EXPECT_THROW(
+        (IRSystem::createSystem<C_VelA>(
+            "TestCatchAllRelationParallelFor",
+            catchAllTick,
+            nullptr,
+            nullptr,
+            IRSystem::RelationParams<C_VelB>{},
+            nullptr,
+            Concurrency::PARALLEL_FOR
+        )),
+        std::runtime_error
+    );
 }
 
 // ----------------------------------------------------------------------

--- a/test/system/system_concurrency_test.cpp
+++ b/test/system/system_concurrency_test.cpp
@@ -5,12 +5,19 @@
 #include <irreden/ir_system.hpp>
 #include <irreden/entity/entity_manager.hpp>
 #include <irreden/job/job_manager.hpp>
+#include <irreden/profile/logger_spd.hpp>
 #include <irreden/system/ir_assert_main_thread.hpp>
 #include <irreden/system/system_access.hpp>
 #include <irreden/system/system_manager.hpp>
 
+#include <spdlog/sinks/ostream_sink.h>
+
+#include <algorithm>
 #include <atomic>
+#include <memory>
 #include <optional>
+#include <sstream>
+#include <string>
 #include <vector>
 
 // T-222 Phase 2 — multithreading epic (#226). Two surfaces under test:
@@ -280,9 +287,32 @@ TEST_F(CreateSystemValidatorTest, CatchAllWithRelationParamsFatalsAtRegistration
     // signature probe (entity-id, batch-form, relation-form). The
     // validator rules are ordered most-specific-first (relation →
     // batch → entity-id) so the isRelationForm_ assertion fires first.
-    // This test pins that PARALLEL_FOR + catch-all + RelationParams is
-    // always rejected — a different shape than the explicit relation-
-    // form case in RelationFormParallelForFatalsAtRegistration.
+    //
+    // This test pins both that PARALLEL_FOR + catch-all + RelationParams
+    // is rejected AND that the rejection is the relation-form
+    // diagnostic specifically — silently re-introducing the prior rule
+    // order (relation moved back to last) would still throw, but the
+    // batch-form or EntityId assertion would fire first instead, and
+    // the captured-log substring check below would fail.
+    //
+    // IR_ASSERT throws `std::runtime_error("Engine assertion failed")`
+    // — the formatted diagnostic goes to the GL API spdlog logger at
+    // critical severity, NOT into the exception's `what()`. We attach
+    // a temporary ostream sink to the logger, run the call, and verify
+    // the captured text contains the relation-form diagnostic.
+    std::ostringstream captured;
+    auto captureSink = std::make_shared<spdlog::sinks::ostream_sink_st>(captured);
+    auto *glLogger = LoggerSpd::instance()->getGLAPILogger();
+    glLogger->sinks().push_back(captureSink);
+    struct SinkGuard {
+        spdlog::logger *logger_;
+        std::shared_ptr<spdlog::sinks::sink> sink_;
+        ~SinkGuard() {
+            auto &sinks = logger_->sinks();
+            sinks.erase(std::remove(sinks.begin(), sinks.end(), sink_), sinks.end());
+        }
+    } guard{glLogger, captureSink};
+
     auto catchAllTick = [](auto &&...) {};
     EXPECT_THROW(
         (IRSystem::createSystem<C_VelA>(
@@ -296,6 +326,10 @@ TEST_F(CreateSystemValidatorTest, CatchAllWithRelationParamsFatalsAtRegistration
         )),
         std::runtime_error
     );
+
+    const std::string logged = captured.str();
+    EXPECT_NE(logged.find("relation tick form"), std::string::npos)
+        << "expected relation-form assertion to fire first, got captured log: " << logged;
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reorders the four `validateConcurrencyForAccess` `IR_ASSERT` checks from entity-id/batch/relation/main-thread to **relation → batch → entity-id → main-thread** (most-specific-first)
- A variadic catch-all tick `[](auto&&...)` satisfies all three form probes simultaneously; the old order caused the less-specific "EntityId tick parameter" diagnostic to fire when "relation tick form" was the correct diagnosis
- Adds `CatchAllWithRelationParamsFatalsAtRegistration` test to pin the catch-all + RelationParams + PARALLEL_FOR rejection path

## Test plan
- [x] All 29 existing `SystemConcurrencyValidator` / `CreateSystemValidatorTest` / `ParallelDispatchFixture` tests pass
- [x] New `CatchAllWithRelationParamsFatalsAtRegistration` test verifies `EXPECT_THROW(std::runtime_error)` for the catch-all + RelationParams + PARALLEL_FOR combination
- [x] `isParallelForAcceptable` mirror in test file updated to match new production order (comment documents the intent)

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)