### PR TITLE
T-347: script/codegen: emit per-component tick to unlock PARALLEL_FOR

### DIFF
--- a/cmake/lua_codegen/system_dsl.cpp
+++ b/cmake/lua_codegen/system_dsl.cpp
@@ -890,10 +890,27 @@ struct Emitter {
     const std::vector<ComponentSchema> &registry_;
     std::unordered_map<std::string, Symbol> symbols_;
 
+    // T-347: per-row emission mode. When non-empty, the emitted lambda is
+    // the per-component form `[](C_X& _ir_row_X, ...)` rather than the
+    // batch form `[](Archetype&, vector<EntityId>&, vector<C_X>&, ...)`,
+    // and column-op index expressions that match `loopVarName_` lower to
+    // the per-row reference `_ir_row_X` (or `_ir_row_X.field_`) instead
+    // of `_ir_col_X[i]`. Indexing with any other expression is a parse
+    // error — per-row form has no column vector to scatter-index into.
+    std::string loopVarName_;
+
     Emitter(const std::string &file, const std::vector<ComponentSchema> &registry)
         : file_(file), registry_(registry) {}
 
     void writeIndent() { for (int i = 0; i < indent_; ++i) out_ << "    "; }
+
+    // True when this expression is exactly the per-row loop variable
+    // reference (used to validate column-op index args in per-row mode).
+    bool isLoopVarRef(const Expr &e) const {
+        return !loopVarName_.empty() &&
+               e.kind_ == ExprKind::NAME_REF &&
+               e.name_ == loopVarName_;
+    }
 
     const ComponentSchema *findComponent(const std::string &name) const {
         for (const auto &c : registry_) if (c.name_ == name) return &c;
@@ -1016,6 +1033,15 @@ struct Emitter {
                 // arch.length is a special case
                 if (e.receiver_->kind_ == ExprKind::NAME_REF &&
                     e.receiver_->name_ == "arch" && e.field_ == "length") {
+                    if (!loopVarName_.empty()) {
+                        // T-347: per-row form has no archetype column to size — the
+                        // canonical `for i = 0, arch.length - 1` outer loop is dropped
+                        // and the row count is implicit in the engine's per-row dispatch.
+                        fail(file_, e.line_,
+                             "`arch.length` is only valid as the upper bound of the "
+                             "canonical `for i = 0, arch.length - 1 do` loop; CODEGEN "
+                             "bodies have no archetype-length read outside that loop");
+                    }
                     out_ << "static_cast<std::int32_t>(_ir_codegen_ids.size())";
                     return ExprType::INT32;
                 }
@@ -1087,6 +1113,17 @@ struct Emitter {
                              "` is not declared via `IRComponent.register(...)` "
                              "(CODEGEN system bodies only support Lua-defined components)");
                 }
+                if (!loopVarName_.empty()) {
+                    if (!isLoopVarRef(*e.args_[0])) {
+                        fail(file_, e.line_,
+                             "`arch." + e.componentName_ +
+                                 ":at(...)` index must be the canonical loop variable `" +
+                                 loopVarName_ + "` (CODEGEN bodies dispatch per-row; "
+                                 "computed indexes have no per-row meaning)");
+                    }
+                    out_ << "_ir_row_" << e.componentName_;
+                    return ExprType::COMPONENT;
+                }
                 out_ << "_ir_col_" << e.componentName_ << "[";
                 emitExpr(*e.args_[0]);
                 out_ << "]";
@@ -1103,6 +1140,16 @@ struct Emitter {
                 if (!field) {
                     fail(file_, e.line_,
                          "component `" + schema->name_ + "` has no field `" + e.fieldNameLiteral_ + "`");
+                }
+                if (!loopVarName_.empty()) {
+                    if (!isLoopVarRef(*e.args_[0])) {
+                        fail(file_, e.line_,
+                             "`arch." + e.componentName_ +
+                                 ":getField(...)` index must be the canonical loop variable `" +
+                                 loopVarName_ + "`");
+                    }
+                    out_ << "_ir_row_" << e.componentName_ << "." << e.fieldNameLiteral_ << "_";
+                    return fieldTypeToExprType(field->type_);
                 }
                 out_ << "_ir_col_" << e.componentName_ << "[";
                 emitExpr(*e.args_[0]);
@@ -1202,6 +1249,18 @@ struct Emitter {
                                  "component `" + s.assignTarget_.componentName_ +
                                      "` is not declared via `IRComponent.register(...)`");
                         }
+                        if (!loopVarName_.empty()) {
+                            if (!isLoopVarRef(*s.assignTarget_.indexExpr_)) {
+                                fail(file_, s.line_,
+                                     "`arch." + s.assignTarget_.componentName_ +
+                                         ":setAt(...)` index must be the canonical loop "
+                                         "variable `" + loopVarName_ + "`");
+                            }
+                            out_ << "_ir_row_" << s.assignTarget_.componentName_ << " = ";
+                            emitExpr(*s.assignRhs_);
+                            out_ << ";\n";
+                            return;
+                        }
                         out_ << "_ir_col_" << s.assignTarget_.componentName_ << "[";
                         emitExpr(*s.assignTarget_.indexExpr_);
                         out_ << "] = ";
@@ -1221,6 +1280,20 @@ struct Emitter {
                             fail(file_, s.line_,
                                  "component `" + schema->name_ + "` has no field `" +
                                      s.assignTarget_.fieldNameLiteral_ + "`");
+                        }
+                        if (!loopVarName_.empty()) {
+                            if (!isLoopVarRef(*s.assignTarget_.indexExpr_)) {
+                                fail(file_, s.line_,
+                                     "`arch." + s.assignTarget_.componentName_ +
+                                         ":setField(...)` index must be the canonical loop "
+                                         "variable `" + loopVarName_ + "`");
+                            }
+                            out_ << "_ir_row_" << s.assignTarget_.componentName_ << "."
+                                 << s.assignTarget_.fieldNameLiteral_ << "_ = static_cast<"
+                                 << cppTypeForFieldType(field->type_) << ">(";
+                            emitExpr(*s.assignRhs_);
+                            out_ << ");\n";
+                            return;
                         }
                         out_ << "_ir_col_" << s.assignTarget_.componentName_ << "[";
                         emitExpr(*s.assignTarget_.indexExpr_);
@@ -1320,6 +1393,43 @@ ParsedBody parseSystemBody(
     return body;
 }
 
+// T-347: identify the canonical per-row loop body. The shape:
+//   for <loopVar> = 0, arch.length - 1 do <stmts> end
+// at the top level of the tick body, as the ONLY top-level statement.
+// Returns the for-statement pointer when matched, else nullptr. The
+// pointer is borrowed from `body`; callers must not outlive it.
+const Stmt *matchPerRowCanonicalLoop(const ParsedBody &body) {
+    if (body.stmts_.size() != 1) return nullptr;
+    const Stmt *s = body.stmts_[0].get();
+    if (s->kind_ != StmtKind::FOR_NUMERIC) return nullptr;
+
+    // Lo: integer literal 0.
+    if (!s->forLo_ || s->forLo_->kind_ != ExprKind::NUMBER_LITERAL ||
+        !s->forLo_->isInt_ || s->forLo_->intValue_ != 0) {
+        return nullptr;
+    }
+
+    // Hi: `arch.length - 1` (BinOp SUB; lhs INDEX(arch, length); rhs int 1).
+    const Expr *hi = s->forHi_.get();
+    if (!hi || hi->kind_ != ExprKind::BINARY_OP || hi->binOp_ != BinOp::SUB) {
+        return nullptr;
+    }
+    const Expr *hiLhs = hi->lhs_.get();
+    const Expr *hiRhs = hi->rhs_.get();
+    if (!hiLhs || hiLhs->kind_ != ExprKind::INDEX ||
+        hiLhs->field_ != "length" ||
+        !hiLhs->receiver_ || hiLhs->receiver_->kind_ != ExprKind::NAME_REF ||
+        hiLhs->receiver_->name_ != "arch") {
+        return nullptr;
+    }
+    if (!hiRhs || hiRhs->kind_ != ExprKind::NUMBER_LITERAL ||
+        !hiRhs->isInt_ || hiRhs->intValue_ != 1) {
+        return nullptr;
+    }
+
+    return s;
+}
+
 void emitSystem(
     std::string &out,
     const SystemRecord &record,
@@ -1360,6 +1470,28 @@ void emitSystem(
         }
     }
 
+    // T-347: CODEGEN system bodies must follow the canonical per-row shape
+    // so the emitted lambda is the per-component form
+    // (`[](C_X& _ir_row_X, ...)`). Per-component is the engine's default
+    // tick signature (engine/system/CLAUDE.md "Three valid TICK function
+    // signatures") and the only one compatible with
+    // `Concurrency::PARALLEL_FOR` — the batch form FATALs in
+    // `detail::validateConcurrencyForAccess` (engine/system/include/irreden/
+    // ir_system.hpp).
+    const Stmt *perRowLoop = matchPerRowCanonicalLoop(body);
+    if (!perRowLoop) {
+        ParseError err;
+        err.message_ = "system `" + record.name_ +
+            "` body must consist of exactly one canonical per-row loop: "
+            "`for i = 0, arch.length - 1 do ... end`. CODEGEN dispatches "
+            "per-row so column ops outside the loop or computed loop bounds "
+            "have no meaning. (Switch to `mode = \"eval\"` for bodies that "
+            "need the batch form.)";
+        err.file_ = record.sourceFile_;
+        err.line_ = record.linedefined_;
+        throw err;
+    }
+
     Emitter emitter(record.sourceFile_, componentRegistry);
 
     std::ostringstream sig;
@@ -1383,18 +1515,18 @@ void emitSystem(
     }
     sig << "    >(\n";
     sig << "        \"" << record.name_ << "\",\n";
-    sig << "        []([[maybe_unused]] const IREntity::Archetype& _ir_arch,\n";
-    sig << "           std::vector<IREntity::EntityId>& _ir_codegen_ids";
-    for (const auto &compName : record.components_) {
-        sig << ",\n";
-        sig << "           std::vector<IRComponents::C_" << compName << ">& _ir_col_"
-            << compName;
+    sig << "        [](";
+    for (size_t i = 0; i < record.components_.size(); ++i) {
+        if (i) sig << ",\n           ";
+        sig << "IRComponents::C_" << record.components_[i] << "& _ir_row_"
+            << record.components_[i];
     }
     sig << ") {\n";
     out += sig.str();
 
+    emitter.loopVarName_ = perRowLoop->forVar_;
     emitter.indent_ = 3;
-    for (const auto &s : body.stmts_) emitter.emitStmt(*s);
+    for (const auto &s : perRowLoop->forBody_) emitter.emitStmt(*s);
 
     out += emitter.str();
     out += "        }\n";

--- a/cmake/lua_codegen/system_dsl.cpp
+++ b/cmake/lua_codegen/system_dsl.cpp
@@ -890,7 +890,7 @@ struct Emitter {
     const std::vector<ComponentSchema> &registry_;
     std::unordered_map<std::string, Symbol> symbols_;
 
-    // T-347: per-row emission mode. When non-empty, the emitted lambda is
+    // Per-row emission mode. When non-empty, the emitted lambda is
     // the per-component form `[](C_X& _ir_row_X, ...)` rather than the
     // batch form `[](Archetype&, vector<EntityId>&, vector<C_X>&, ...)`,
     // and column-op index expressions that match `loopVarName_` lower to
@@ -1034,7 +1034,7 @@ struct Emitter {
                 if (e.receiver_->kind_ == ExprKind::NAME_REF &&
                     e.receiver_->name_ == "arch" && e.field_ == "length") {
                     if (!loopVarName_.empty()) {
-                        // T-347: per-row form has no archetype column to size — the
+                        // Per-row form has no archetype column to size — the
                         // canonical `for i = 0, arch.length - 1` outer loop is dropped
                         // and the row count is implicit in the engine's per-row dispatch.
                         fail(file_, e.line_,
@@ -1470,7 +1470,7 @@ void emitSystem(
         }
     }
 
-    // T-347: CODEGEN system bodies must follow the canonical per-row shape
+    // CODEGEN system bodies must follow the canonical per-row shape
     // so the emitted lambda is the per-component form
     // (`[](C_X& _ir_row_X, ...)`). Per-component is the engine's default
     // tick signature (engine/system/CLAUDE.md "Three valid TICK function

--- a/creations/demos/lua_perf_grid/main.lua
+++ b/creations/demos/lua_perf_grid/main.lua
@@ -76,6 +76,12 @@ IRComponent.register('LuaWaveState', {
 LuaWaveTickSysId = IRSystem.registerSystem({
     name = 'LuaWaveTick',
     components = { 'LuaWaveState' },
+    -- T-347: the per-component emit shape clears the `isBatchForm_`
+    -- FATAL in `validateConcurrencyForAccess`, unlocking PARALLEL_FOR
+    -- for codegen'd systems. The wave body only reads/writes its own
+    -- row and calls whitelisted intrinsics, so the worker dispatch is
+    -- race-free without further opt-in.
+    concurrency = IRSystem.Concurrency.PARALLEL_FOR,
     -- Tick body. Mirrors C_PeriodicIdle::tick() for the 2-stage
     -- SineEaseInOut case. The CODEGEN DSL forbids `while` loops, so
     -- the C++ stage-advance loop is unrolled into a single `if`

--- a/creations/demos/lua_perf_grid/main.lua
+++ b/creations/demos/lua_perf_grid/main.lua
@@ -76,7 +76,7 @@ IRComponent.register('LuaWaveState', {
 LuaWaveTickSysId = IRSystem.registerSystem({
     name = 'LuaWaveTick',
     components = { 'LuaWaveState' },
-    -- T-347: the per-component emit shape clears the `isBatchForm_`
+    -- The per-component emit shape clears the `isBatchForm_`
     -- FATAL in `validateConcurrencyForAccess`, unlocking PARALLEL_FOR
     -- for codegen'd systems. The wave body only reads/writes its own
     -- row and calls whitelisted intrinsics, so the worker dispatch is

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -510,13 +510,22 @@ local sysId = IRSystem.registerSystem({
   a diagnostic pointing at the `IRSystem.Concurrency.*` spelling;
   out-of-range integers raise an explicit error.
 
-  CODEGEN v1 caveat: the codegen tick body emits the per-archetype
-  batch form (`for i = 0, arch.length - 1 do ... end` lowered to a
-  single batch lambda over `vector<C_Foo>&` columns). The T-222
-  validator rejects `PARALLEL_FOR` + batch-form, so a CODEGEN
-  system spec asking for `PARALLEL_FOR` will FATAL at registration.
-  Lifting that restriction needs the codegen tool to emit the
-  per-component form instead — tracked as a follow-up issue.
+  The codegen tick body emits the per-component form: the canonical
+  `for i = 0, arch.length - 1 do ... end` outer loop is dropped at
+  emission time and the inner `arch.Comp:at(i)` / `setAt(i, ...)` /
+  `getField(i, "f")` / `setField(i, "f", ...)` column ops lower to
+  per-row `_ir_row_<CompName>` references, producing a
+  `[](C_Foo& _ir_row_Foo, ...)` lambda. This is the engine's default
+  tick signature (engine/system/CLAUDE.md "Three valid TICK function
+  signatures") and the only one compatible with `PARALLEL_FOR` — the
+  `isBatchForm_` validator path that would otherwise FATAL is now
+  unreachable from CODEGEN. Bodies that don't fit the canonical
+  per-row shape (multiple top-level statements, a non-canonical loop
+  bound, `arch.length` outside the loop bound, a column-op index
+  that isn't the loop variable) are rejected at codegen time with a
+  message pointing at the requirement; the EVAL path remains
+  available via `mode = "eval"` for bodies that need a different
+  shape.
 
 ## Hot-reload of Lua system bodies (`IRSystem.replaceSystemBody`)
 

--- a/test/script/lua_system_codegen_fixtures.lua
+++ b/test/script/lua_system_codegen_fixtures.lua
@@ -104,14 +104,7 @@ IRSystem.registerSystem({
     end,
 })
 
--- T-347: PARALLEL_FOR opt-in. After the codegen tool was switched from
--- batch-form `[](Archetype&, vector<EntityId>&, vector<C_X>&, ...)` to
--- per-component `[](C_X& _ir_row_X, ...)`, the trailing
--- `IRSystem::Concurrency::PARALLEL_FOR` arg the emitter has been threading
--- through since T-223 finally satisfies `validateConcurrencyForAccess`
--- — the per-component form clears the `isBatchForm_` FATAL. This system
--- exercises the unblocked path: registration must succeed without FATAL
--- and the body must run across every row of the column.
+-- PARALLEL_FOR: verifies registration succeeds and the body runs on every row.
 IRSystem.registerSystem({
     name = 'CodegenParallelInc',
     components = { 'CodegenSysPos' },

--- a/test/script/lua_system_codegen_fixtures.lua
+++ b/test/script/lua_system_codegen_fixtures.lua
@@ -103,3 +103,24 @@ IRSystem.registerSystem({
         end
     end,
 })
+
+-- T-347: PARALLEL_FOR opt-in. After the codegen tool was switched from
+-- batch-form `[](Archetype&, vector<EntityId>&, vector<C_X>&, ...)` to
+-- per-component `[](C_X& _ir_row_X, ...)`, the trailing
+-- `IRSystem::Concurrency::PARALLEL_FOR` arg the emitter has been threading
+-- through since T-223 finally satisfies `validateConcurrencyForAccess`
+-- — the per-component form clears the `isBatchForm_` FATAL. This system
+-- exercises the unblocked path: registration must succeed without FATAL
+-- and the body must run across every row of the column.
+IRSystem.registerSystem({
+    name = 'CodegenParallelInc',
+    components = { 'CodegenSysPos' },
+    concurrency = IRSystem.Concurrency.PARALLEL_FOR,
+    tick = function(arch)
+        for i = 0, arch.length - 1 do
+            local pos = arch.CodegenSysPos:at(i)
+            arch.CodegenSysPos:setAt(i,
+                CodegenSysPos.new(pos.x + 1.0, pos.y + 2.0))
+        end
+    end,
+})

--- a/test/script/lua_system_codegen_test.cpp
+++ b/test/script/lua_system_codegen_test.cpp
@@ -160,6 +160,41 @@ TEST_F(LuaSystemCodegenTest, RegistryReturnsAllCodegenSystemIds) {
     EXPECT_NE(ids.CodegenWobble, ids.CodegenClampPositive);
     EXPECT_NE(ids.CodegenClampPositive, ids.CodegenAddOne);
     EXPECT_NE(ids.CodegenAddOne, ids.CodegenDamage);
+    EXPECT_NE(ids.CodegenDamage, ids.CodegenParallelInc);
+}
+
+// ---- PARALLEL_FOR registers without FATAL and updates every row --------
+//
+// T-347: codegen now emits the per-component lambda shape, which clears
+// the `isBatchForm_` FATAL in
+// `IRSystem::detail::validateConcurrencyForAccess`. Registration must
+// succeed, and a populated archetype must see every row processed by the
+// per-component body (whether the scheduler fans out across workers or
+// falls back to serial under the test harness, every row's body must
+// fire — the per-component lambda has no per-row branching that could
+// skip rows).
+
+TEST_F(LuaSystemCodegenTest, ParallelIncRegistersAndUpdatesEveryRow) {
+    using IRComponents::C_CodegenSysPos;
+
+    constexpr int kCount = 256;
+    std::vector<IREntity::EntityId> entities;
+    entities.reserve(kCount);
+    for (int i = 0; i < kCount; ++i) {
+        entities.push_back(IREntity::createEntity(C_CodegenSysPos(static_cast<float>(i), 0.0f)));
+    }
+
+    const IRSystem::SystemId sys = IRScript::CodegenRegistry::createSystem_CodegenParallelInc();
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sys});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    for (int i = 0; i < kCount; ++i) {
+        EXPECT_FLOAT_EQ(
+            IREntity::getComponent<C_CodegenSysPos>(entities[i]).x_,
+            static_cast<float>(i) + 1.0f
+        );
+        EXPECT_FLOAT_EQ(IREntity::getComponent<C_CodegenSysPos>(entities[i]).y_, 2.0f);
+    }
 }
 
 } // namespace

--- a/test/script/lua_system_codegen_test.cpp
+++ b/test/script/lua_system_codegen_test.cpp
@@ -165,15 +165,6 @@ TEST_F(LuaSystemCodegenTest, RegistryReturnsAllCodegenSystemIds) {
 
 // ---- PARALLEL_FOR registers without FATAL and updates every row --------
 //
-// T-347: codegen now emits the per-component lambda shape, which clears
-// the `isBatchForm_` FATAL in
-// `IRSystem::detail::validateConcurrencyForAccess`. Registration must
-// succeed, and a populated archetype must see every row processed by the
-// per-component body (whether the scheduler fans out across workers or
-// falls back to serial under the test harness, every row's body must
-// fire — the per-component lambda has no per-row branching that could
-// skip rows).
-
 TEST_F(LuaSystemCodegenTest, ParallelIncRegistersAndUpdatesEveryRow) {
     using IRComponents::C_CodegenSysPos;
 


### PR DESCRIPTION
## Summary

- Codegen tool now emits the **per-component** tick lambda (`[](C_Foo& _ir_row_Foo, ...)`) instead of the per-archetype batch form. The canonical `for i = 0, arch.length - 1 do ... end` outer loop is dropped at emission time; inner `arch.Comp:at(i)` / `setAt(i, ...)` / `getField(i, "f")` / `setField(i, "f", ...)` column ops lower to per-row `_ir_row_<CompName>` references.
- This is the engine's default tick signature (engine/system/CLAUDE.md "Three valid TICK function signatures") and the only one compatible with `Concurrency::PARALLEL_FOR` — the T-222 `isBatchForm_` validator path is now unreachable from CODEGEN, so the trailing `IRSystem::Concurrency::PARALLEL_FOR` arg that T-223 already threads through finally satisfies registration.
- Bodies that don't fit the canonical shape (multiple top-level statements, non-canonical loop bound, `arch.length` outside the bound, column-op index that isn't the loop variable) are rejected at codegen time with a message pointing at the requirement. EVAL stays available via `mode = "eval"` for bodies that need a different shape.
- `IRLuaPerfGrid`'s `LuaWaveTick` opts in via `concurrency = IRSystem.Concurrency.PARALLEL_FOR`. New CODEGEN test fixture + test (`CodegenParallelInc` / `ParallelIncRegistersAndUpdatesEveryRow`) exercises the unblocked path.
- Updates `engine/script/CLAUDE.md` "CODEGEN v1 caveat" paragraph that asserted the opposite of the new behavior.

## Test plan

- [x] `fleet-build --target ir_lua_codegen` — codegen tool builds clean.
- [x] `fleet-build --target IrredenEngineTest` — full test suite builds.
- [x] `fleet-run --timeout 30 IrredenEngineTest --gtest_filter='LuaSystemCodegenTest*:LuaSystemCoexistence*'` — 11/11 pass (10 prior + 1 new `ParallelIncRegistersAndUpdatesEveryRow`).
- [x] `fleet-run --timeout 180 IrredenEngineTest` — 939/939 pass.
- [x] `fleet-build --target IRLuaPerfGrid` — demo builds; generated header confirmed to emit per-component lambda + `/* concurrency */ IRSystem::Concurrency::PARALLEL_FOR`.
- [x] `fleet-run IRLuaPerfGrid --auto-screenshot 30` — launches with 262k entities + PARALLEL_FOR, runs through both auto-screenshots, exits cleanly. No FATAL at registration.
- [ ] Hardware-fingerprinted perf-parity vs C++ `perf_grid` (acceptance ±10%) — best done via `perf_grid_matrix` on the same host; flagged as a follow-up measurement once the harness is wired against both demos.

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)