### PR TITLE
T-350: docs/role-merger — explain re-target + label cleanup order on stacked-base merged path

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -431,6 +431,30 @@ exit cleanly:
          The detached HEAD at `origin/<headRefName>` from step a is
          already set up — `git rebase` operates on it directly.
 
+         **Order rationale (re-target + label cleanup BEFORE rebase).**
+         On the rebase-conflict branch below, the re-target and label
+         cleanup are intentionally NOT rolled back — and they intentionally
+         run FIRST, before the rebase attempt. Two coupled reasons:
+         (1) opus-worker's `fleet:semantic-conflict` filter at step 1c
+         excludes `fleet:awaiting-base` / `fleet:awaiting-upstream-review`
+         / `fleet:fork-of-other-pr` (PRs not yet rebaseable against
+         master), so those labels MUST be cleared for opus-worker to
+         pick the PR up.
+         (2) opus-worker's step 1c rebases against the PR's current
+         `baseRefName` (`git rebase origin/<baseRefName>`), so
+         `baseRefName` MUST point at master for opus-worker to rebase
+         against the master tip rather than the merged-but-still-extant
+         base branch — which would replay the stacked-merge conflict
+         against the pre-merge base tip without actually resolving it
+         (master may have moved further).
+         Inverting (rebase first, re-target + label cleanup only on
+         clean exit) would silently strand conflict-path PRs: either
+         the labels survive and opus-worker skips the PR indefinitely,
+         or the labels are cleared but `baseRefName` still points at
+         the stale base and opus-worker's rebase target is wrong. The
+         current order keeps the merger ↔ opus-worker contract
+         coherent. See issue #1149 for the full trade-off analysis.
+
          - `gh pr edit <N> --base master`
          - `gh pr edit <N> --remove-label "fleet:awaiting-base"`
          - `gh pr edit <N> --remove-label "fleet:stacked"`


### PR DESCRIPTION
## Summary

Adds an **Order rationale** paragraph to `.claude/commands/role-merger.md`
step a.5 sub-case ii (base PR is MERGED) explaining why re-target +
label cleanup intentionally run BEFORE the rebase attempt — and why
neither is rolled back on the conflict branch.

Selects **Option A (doc-only)** from issue #1149's trade-off analysis.
The reviewer of PR #1146 flagged the current order as a nit; this PR
documents the rationale rather than inverting the order.

## Why Option A over Option B

Option B (invert: rebase first, re-target + cleanup only on clean exit)
sounds cleaner but breaks the merger ↔ opus-worker handoff contract on
the conflict path. Two coupled reasons:

1. **opus-worker step 1c filter.** The `fleet:semantic-conflict`
   resolver excludes PRs labeled `fleet:awaiting-base` /
   `fleet:awaiting-upstream-review` / `fleet:fork-of-other-pr`. Under
   inverted order, those labels would survive on conflict, stranding
   the PR indefinitely.

2. **opus-worker step 1c rebase target.** Step 1c rebases against
   `git rebase origin/<baseRefName>`. Under inverted order on the
   conflict path, `baseRefName` would still point at the merged base
   branch, so opus-worker would replay the conflict against the
   pre-merge base tip — not master — and never actually resolve the
   stacked-merge conflict.

To make Option B work on the conflict path, you would still need to
clear those labels AND re-target to master — collapsing to the same
end-state as Option A.

## Test plan
- [x] Inserted paragraph between the "detached HEAD ... already set up" prose and the `gh pr edit <N> --base master` command list (the surrounding text remains intact)
- [x] Verified cross-references: `fleet:semantic-conflict`, `fleet:awaiting-base`, `fleet:awaiting-upstream-review`, `fleet:fork-of-other-pr` all match role-opus-worker.md step 1c (lines 230-231); `git rebase origin/<baseRefName>` matches step 1c line 271
- [x] Doc-only diff (no build needed)

Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)