### PR TITLE
T-355: docs: T-189/T-190 disposition under SDF restriction (D4)

### DIFF
--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -94,11 +94,18 @@ for single voxels and particles.
 
 ## Prefab.spawn voxel_ref → ECS components
 
+**D2 restriction (Epic D #937):** SHAPES and HYBRID authoring are
+deprecated for primary entities. Going forward, primary entity shapes
+use DENSE `.vxs` assets; SHAPES (`C_ShapeDescriptor`) is reserved for
+effects-only SDF entities (sun shadow occluders, auras, soft glows).
+HYBRID authoring is fully deprecated — HYBRID `.vxs` files load for
+backward-compat but no new assets should be authored in HYBRID mode.
+
 `Prefab.spawn` (in `engine/script/`) routes a prefab's `voxel_ref`
 through to runtime components when the loaded `.vxs` carries shape
 records:
 
-- **SHAPES / HYBRID shape half** — one child entity per
+- **SHAPES shape half** (effects-only per D2) — one child entity per
   `IRAsset::ShapeRecord`, parented via `IREntity::setParent`. Each
   child gets `C_LocalTransform{record.offset_}` plus
   `C_ShapeDescriptor` populated from `record.shapeTypeId_` /
@@ -107,16 +114,16 @@ records:
   `C_LocalTransform` so the rendered translation equals
   `parent.world + record.offset`. Per-record `rotation_`, `csgOp_`,
   and `boneId_` are loaded but not attached in v1 (no renderer
-  consumes them; T-181 wires bone binding).
-- **DENSE / HYBRID dense half** — `C_VoxelSetNew` attached to the
-  spawned root entity via `IRPrefab::DenseVoxel::toComponent`
-  (`voxel/dense_bridge.hpp`). The bridge translates
-  `IRAsset::DenseVoxelSet` → `C_VoxelSetNew` via a per-record copy
-  (`VoxelRecord` and `C_Voxel` share the 12 B std430 layout but
-  remain distinct types so layout drift surfaces as a compile
-  error). For HYBRID, the SHAPES children and the DENSE
-  `C_VoxelSetNew` land on the same root entity in a single
-  `Prefab.spawn` call.
+  consumes them; T-181 wires bone binding). Also fires for HYBRID
+  assets during backward-compat load.
+- **DENSE dense half** (primary entity path) — `C_VoxelSetNew`
+  attached to the spawned root entity via
+  `IRPrefab::DenseVoxel::toComponent` (`voxel/dense_bridge.hpp`).
+  The bridge translates `IRAsset::DenseVoxelSet` → `C_VoxelSetNew`
+  via a per-record copy (`VoxelRecord` and `C_Voxel` share the 12 B
+  std430 layout but remain distinct types so layout drift surfaces as
+  a compile error). Also fires for HYBRID during backward-compat
+  load (both halves attach in a single spawn call).
 
 `C_ShapeDescriptor`'s constructors snapshot the active canvas via
 `IRRender::getActiveCanvasEntityOrNull()` rather than the

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -482,6 +482,12 @@ based on intent: voxel pool for "cubes-of-cubes" stylization, SDF for
 smooth analytical silhouettes. The lighting demo's `kShots[]`
 zoom8/zoom16 captures showcase the difference for visual reference.
 
+Per D2 (Epic D #937, SDF runtime restriction), `C_ShapeDescriptor` is
+effects-only for primary entity authoring. The silhouette delta
+documented above is intentional and **not a bug to fix**: effects
+entities (auras, shadow occluders, soft glows) do not require trixel
+parity with voxel-pool primary shapes.
+
 ## Gotchas
 
 - **Hardcoded uniform-buffer bind points.** Indices like

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -884,17 +884,20 @@ land:
   to a bind point), pre-resolve the integer bone index at spawn
   time and cache the offset/rotation in a flat component instead.
 - **`C_VoxelSetNew` canvas-attach pass for staged dense data** —
-  DENSE / HYBRID records do attach as `C_VoxelSetNew` on the
-  spawned entity (see "DENSE / HYBRID voxel_ref attachment"
-  below), but when the prefab spawns before a render canvas
-  exists the per-voxel records live in `pendingVoxels_` and no
-  pool allocation happens. A follow-up pass needs to seed the
-  pool the frame after a canvas activates and promote the staged
-  records into the pool span — track in the issue queue.
+  DENSE records do attach as `C_VoxelSetNew` on the spawned entity
+  (see "DENSE voxel_ref attachment" below), but when the prefab
+  spawns before a render canvas exists the per-voxel records live in
+  `pendingVoxels_` and no pool allocation happens. A follow-up pass
+  needs to seed the pool the frame after a canvas activates and
+  promote the staged records into the pool span — track in the issue
+  queue.
 
-**SHAPES voxel_ref attachment.** When `voxel_ref` points at a
-SHAPES or HYBRID `.vxs`, `Prefab.spawn` attaches one child entity
-per `ShapeRecord` under the spawned root via `IREntity::setParent`.
+**SHAPES voxel_ref attachment (effects-only per D2, Epic D #937).**
+When `voxel_ref` points at a SHAPES or HYBRID `.vxs`, `Prefab.spawn`
+attaches one child entity per `ShapeRecord` under the spawned root
+via `IREntity::setParent`. SHAPES is reserved for effects-only SDF
+entities (occluders, auras, soft glows); HYBRID is deprecated for new
+authoring but loads backward-compatibly.
 Each child carries:
 
 - `C_LocalTransform{record.offset_}` — record-local position;
@@ -916,9 +919,10 @@ with `canvasEntity_ = kNullEntity` instead of asserting on the
 absent `RenderManager`. Iterating render systems already gate work
 on a non-null canvas binding.
 
-**DENSE / HYBRID voxel_ref attachment.** When `voxel_ref` points
-at a DENSE or HYBRID `.vxs`, `Prefab.spawn` attaches a
-`C_VoxelSetNew` on the spawned root entity via the bridge
+**DENSE voxel_ref attachment (primary entity path; D2, Epic D #937).**
+When `voxel_ref` points at a DENSE `.vxs` (or a HYBRID file loading
+for backward-compat), `Prefab.spawn` attaches a `C_VoxelSetNew` on
+the spawned root entity via the bridge
 `IRPrefab::DenseVoxel::toComponent` in
 `engine/prefabs/irreden/voxel/dense_bridge.hpp`. The bridge calls
 the dense-data ctor `C_VoxelSetNew(boundsMin, boundsMax,
@@ -935,9 +939,11 @@ span<const C_Voxel>)`, which is headless-safe:
 `C_VoxelSetNew::recordCount()` returns the data count regardless
 of mode, so the round-trip test asserts
 `recordCount() == dense.voxelCount()` without caring whether the
-pool was reachable. For HYBRID prefabs the SHAPES half attaches
-as child entities (per "SHAPES voxel_ref attachment") and the
-DENSE half attaches to the root in the same spawn call.
+pool was reachable. For HYBRID files loading in backward-compat
+mode, the SHAPES half attaches as child entities (per "SHAPES
+voxel_ref attachment") and the DENSE half attaches to the root in
+the same spawn call. New prefabs should not rely on this dual-half
+path — HYBRID authoring is deprecated per D2.
 
 If the loaded `.vxs` is malformed (e.g. BNDS present but VOXR
 truncated, so `dense.voxels_.size() != dense.voxelCount()`), the

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -898,6 +898,7 @@ attaches one child entity per `ShapeRecord` under the spawned root
 via `IREntity::setParent`. SHAPES is reserved for effects-only SDF
 entities (occluders, auras, soft glows); HYBRID is deprecated for new
 authoring but loads backward-compatibly.
+
 Each child carries:
 
 - `C_LocalTransform{record.offset_}` — record-local position;


### PR DESCRIPTION
## Summary
- Records the D2 outcome (Epic D #937, SDF runtime restriction) in three CLAUDE.md files.
- **T-189 (DENSE/HYBRID Prefab.spawn wiring):** `engine/prefabs/irreden/voxel/CLAUDE.md` and `engine/script/CLAUDE.md` updated to mark HYBRID authoring deprecated per D2. DENSE is the primary entity path going forward; SHAPES is effects-only. Existing HYBRID `.vxs` assets load backward-compatibly via the same two-half spawn path; the docs no longer present HYBRID as a forward-looking feature.
- **T-190 (SDF silhouette investigation):** `engine/render/CLAUDE.md` gains a D2 cross-reference in the existing SDF/voxel-pool parity section, explicitly stating the silhouette delta is intentional — effects entities (occluders, auras, soft glows) do not require trixel parity with voxel-pool primary shapes.

## Test plan
- [ ] Docs-only change; no build needed.
- [ ] Verify `engine/prefabs/irreden/voxel/CLAUDE.md` "Prefab.spawn voxel_ref" section leads with the D2 restriction note.
- [ ] Verify `engine/script/CLAUDE.md` SHAPES/DENSE attachment headers reference D2 correctly.
- [ ] Verify `engine/render/CLAUDE.md` SDF parity section notes the intentional silhouette delta as effects-only, not a bug.

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)