### PR TITLE
T-360: world: markChunkDirty API + chunk-mutation routing contract

### DIFF
--- a/docs/design/world-streaming.md
+++ b/docs/design/world-streaming.md
@@ -764,12 +764,20 @@ full content as the upload budget catches up.
 
 ### Dirty tracking + eviction-write
 
-Each `ChunkResidencySlot` carries a `dirty_` bit. The bit is set by:
+Each `ChunkResidencySlot` carries a private dirty bit, set only
+through `ChunkResidencyManager::markChunkDirty(key)` and read via
+`ChunkResidencySlot::isDirty()`. The bit must be set by:
 
 - Any voxel mutation to a voxel owned by the chunk's
   `VoxelPoolAllocation`.
 - Any entity creation, destruction, component change, or migration
   affecting an entity in the chunk's `ownedEntities_`.
+
+The manager's `attachEntity` / `migrateEntity` self-route through
+`markChunkDirty` already; new mutation paths (voxel writes from a
+push-at-mutation upload, future component-write hooks) must do the
+same — there is no other supported way to flip the bit, and a
+missed call drops the save silently.
 
 The bit is consulted at `EVICTING → EVICTED` transition: if dirty,
 schedule a save to disk before deallocating the pool slice. The

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -125,7 +125,16 @@ itself needs regardless of which features a creation enables:
 - GPU resource CRUD (`RenderingResourceManager`).
 - Pipeline execution (frame loop, canvas dispatch, framebuffer flip).
 - Camera, viewport, subdivision mode — the pipeline reads these every frame.
-- Voxel pool allocation (the pool is a device-level concept).
+- Voxel pool allocation (the pool is a device-level concept). When the
+  allocation is a slice owned by a streaming chunk
+  (`IRWorld::ChunkResidencySlot::poolAllocation_`), any system that writes
+  voxels through the slice MUST call
+  `IRWorld::ChunkResidencyManager::markChunkDirty(key)` immediately after
+  the write — without it, eviction silently drops the save and the chunk
+  reverts on re-resident. See
+  [`engine/world/CLAUDE.md`](../world/CLAUDE.md#chunk-mutation-must-route-through-markchunkdirty).
+  Single-chunk creations never see a residency manager and the rule does
+  not apply.
 
 Feature state — anything a creation opts into — belongs in
 `engine/prefabs/irreden/render/`. If the renderer can ship without the feature

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -31,6 +31,34 @@ residency worker pool without changing the surface. Entity-level
 state (components beyond the chunk's voxel pool) belongs to the
 parallel world-snapshot path (#199), not this layer.
 
+### Chunk mutation must route through `markChunkDirty`
+
+> Any code that writes to a chunk-owned `VoxelPoolAllocation` (the
+> slice exposed via `ChunkResidencySlot::poolAllocation_`) MUST call
+> `ChunkResidencyManager::markChunkDirty(key)` immediately after the
+> write. The same rule covers entity attach / detach / migrate when
+> a creation opts into streaming.
+
+The dirty bit is consulted at eviction and by `flushPendingSaves()`;
+a missed `markChunkDirty` call after a real mutation means the save
+is silently skipped and the chunk reverts to its pre-edit state on
+re-resident. This is the [ECS-footgun class](../../.claude/rules/cpp-ecs.md)
+of bug — invisible under single-chunk creations, fires only after
+streaming load surfaces an eviction-then-re-resident cycle.
+
+`ChunkResidencySlot::isDirty()` is the read side; the underlying
+field is private with `ChunkResidencyManager` as a `friend`, so
+`slot->dirty_ = true` no longer compiles. The manager's
+`attachEntity` / `migrateEntity` already self-route through
+`markChunkDirty`; the voxel-mutation routing lands when push-at-
+mutation uploads (Epic B / #944) wire in.
+
+When you add a new mutation path (voxel-pool write, entity move,
+component write within `ownedEntities_`), route it through
+`markChunkDirty`. The cross-link from
+[`engine/render/CLAUDE.md`](../render/CLAUDE.md) at the voxel-pool
+section is the reciprocal pointer for renderer-side authors.
+
 Most code never touches `World` directly. It accesses managers via the
 `IR<Module>::get*Manager()` free functions in each module's `ir_*.hpp`
 header, which reach through the global pointers `World` sets up at

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -42,8 +42,8 @@ parallel world-snapshot path (#199), not this layer.
 The dirty bit is consulted at eviction and by `flushPendingSaves()`;
 a missed `markChunkDirty` call after a real mutation means the save
 is silently skipped and the chunk reverts to its pre-edit state on
-re-resident. This is the [ECS-footgun class](../../.claude/rules/cpp-ecs.md)
-of bug — invisible under single-chunk creations, fires only after
+re-resident. This is the ECS-footgun class of bug — invisible under
+single-chunk creations, fires only after
 streaming load surfaces an eviction-then-re-resident cycle.
 
 `ChunkResidencySlot::isDirty()` is the read side; the underlying

--- a/engine/world/include/irreden/world/chunk_residency.hpp
+++ b/engine/world/include/irreden/world/chunk_residency.hpp
@@ -187,11 +187,12 @@ class ChunkResidencyManager {
     /// rationale (without it a missed `dirty` flip silently drops
     /// the save on eviction and the chunk reverts on re-resident).
     ///
-    /// No-op when @p key is not resident — the manager logs nothing
+    /// No-op when @p key has no slot at all — the manager logs nothing
     /// because the eventual streaming path will sometimes target a
     /// chunk that already evicted between request and write; callers
     /// that need stronger guarantees should check `isResident(key)`
-    /// before mutating.
+    /// before mutating. Note: a slot in LOADING or UPLOADING state
+    /// (not yet resident) will still be marked dirty by this call.
     void markChunkDirty(IRPrefab::Chunk::ChunkKey key);
 
     // ── Entity ownership ─────────────────────────────────────────────

--- a/engine/world/include/irreden/world/chunk_residency.hpp
+++ b/engine/world/include/irreden/world/chunk_residency.hpp
@@ -68,9 +68,19 @@ struct ChunkResidencySlot {
     float distanceVoxels_ = 0.0f;
     std::uint64_t lastTouchedFrame_ = 0;
 
-    // Set by any voxel/entity mutation; consulted at EVICTING → EVICTED
-    // by E6's save path. E1 leaves the writer hooks for E4/E6.
-    bool dirty_ = false;
+    /// True iff the chunk has been mutated since the last successful
+    /// save (or since allocation, for fresh slots). Consulted at
+    /// EVICTING → EVICTED by E6's save path. Set only by
+    /// `ChunkResidencyManager::markChunkDirty` — direct field writes
+    /// are not supported; see engine/world/CLAUDE.md "Chunk mutation
+    /// must route through markChunkDirty" for the contract.
+    bool isDirty() const noexcept {
+        return m_dirty;
+    }
+
+  private:
+    friend class ChunkResidencyManager;
+    bool m_dirty = false;
 };
 
 /// Owns the sparse resident-set; the engine-side API for chunk identity
@@ -148,15 +158,15 @@ class ChunkResidencyManager {
     void requestResident(IRPrefab::Chunk::ChunkKey key, RequestPriority priority);
 
     /// Drop the chunk from the resident set. When `Config::persistence_`
-    /// is wired and the slot's `dirty_` bit is set, the chunk is saved
+    /// is wired and the slot's dirty bit is set, the chunk is saved
     /// to disk before erasure. Pool allocation is currently leaked back
     /// to the global pool's free-list when the allocator supports it
     /// (today's RenderManager pool is bump-style — see
     /// engine/render/CLAUDE.md). E2 introduces the dealloc path.
     void requestEvict(IRPrefab::Chunk::ChunkKey key);
 
-    /// Force-save every resident slot whose `dirty_` bit is set
-    /// (design's "save-all path"). On success the slot's `dirty_` bit
+    /// Force-save every resident slot whose dirty bit is set
+    /// (design's "save-all path"). On success the slot's dirty bit
     /// clears so subsequent eviction skips the redundant save. Slots
     /// stay resident; only the on-disk copy is refreshed.
     ///
@@ -166,6 +176,23 @@ class ChunkResidencyManager {
     /// surface stays the same (the method still blocks until the
     /// queue drains).
     void flushPendingSaves();
+
+    /// Mark @p key's slot dirty so eviction (or `flushPendingSaves`)
+    /// will write its voxel slice to disk. **This is the only
+    /// supported way to flip the dirty bit** — `ChunkResidencySlot`'s
+    /// underlying field is private. Any system that writes to a
+    /// chunk-owned `VoxelPoolAllocation` must call this immediately
+    /// after the write; see engine/world/CLAUDE.md "Chunk mutation
+    /// must route through markChunkDirty" for the contract and the
+    /// rationale (without it a missed `dirty` flip silently drops
+    /// the save on eviction and the chunk reverts on re-resident).
+    ///
+    /// No-op when @p key is not resident — the manager logs nothing
+    /// because the eventual streaming path will sometimes target a
+    /// chunk that already evicted between request and write; callers
+    /// that need stronger guarantees should check `isResident(key)`
+    /// before mutating.
+    void markChunkDirty(IRPrefab::Chunk::ChunkKey key);
 
     // ── Entity ownership ─────────────────────────────────────────────
 

--- a/engine/world/src/chunk_residency.cpp
+++ b/engine/world/src/chunk_residency.cpp
@@ -124,8 +124,8 @@ void ChunkResidencyManager::requestResident(
         }
     }
     s.state_ = ChunkResidencyState::RESIDENT;
-    // dirty_ stays false — disk and memory agree after a fresh load /
-    // alloc. Mutators are responsible for flipping it.
+    // m_dirty stays false — disk and memory agree after a fresh load /
+    // alloc. Mutators are responsible for routing through markChunkDirty.
 }
 
 void ChunkResidencyManager::requestEvict(IRPrefab::Chunk::ChunkKey key) {
@@ -135,7 +135,7 @@ void ChunkResidencyManager::requestEvict(IRPrefab::Chunk::ChunkKey key) {
     }
 
     ChunkResidencySlot &s = it->second;
-    if (s.dirty_ && m_config.persistence_ && !s.poolAllocation_.voxels_.empty()) {
+    if (s.m_dirty && m_config.persistence_ && !s.poolAllocation_.voxels_.empty()) {
         // Synchronous save before erase — the "snapshot-at-schedule-time"
         // safety the design calls for is implicit here because we save
         // and erase in the same blocking call; nothing can mutate the
@@ -164,13 +164,13 @@ void ChunkResidencyManager::flushPendingSaves() {
     }
     for (auto &kv : m_slots) {
         ChunkResidencySlot &s = kv.second;
-        if (!s.dirty_ || s.poolAllocation_.voxels_.empty()) {
+        if (!s.m_dirty || s.poolAllocation_.voxels_.empty()) {
             continue;
         }
         auto records = poolSliceToRecords(s.poolAllocation_);
         auto status = m_config.persistence_->saveChunk(kv.first, records);
         if (status.ok()) {
-            s.dirty_ = false;
+            s.m_dirty = false;
         } else {
             IRE_LOG_ERROR(
                 "ChunkResidencyManager::flushPendingSaves: save failed for chunk (code={}): {}",
@@ -181,6 +181,14 @@ void ChunkResidencyManager::flushPendingSaves() {
     }
 }
 
+void ChunkResidencyManager::markChunkDirty(IRPrefab::Chunk::ChunkKey key) {
+    auto it = m_slots.find(key);
+    if (it == m_slots.end()) {
+        return;
+    }
+    it->second.m_dirty = true;
+}
+
 void ChunkResidencyManager::attachEntity(IREntity::EntityId id, IRPrefab::Chunk::ChunkKey key) {
     auto it = m_slots.find(key);
     if (it == m_slots.end()) {
@@ -189,7 +197,7 @@ void ChunkResidencyManager::attachEntity(IREntity::EntityId id, IRPrefab::Chunk:
     auto &owned = it->second.ownedEntities_;
     if (std::find(owned.begin(), owned.end(), id) == owned.end()) {
         owned.push_back(id);
-        it->second.dirty_ = true;
+        markChunkDirty(key);
     }
 }
 
@@ -205,7 +213,7 @@ void ChunkResidencyManager::migrateEntity(
         auto newEnd = std::remove(owned.begin(), owned.end(), id);
         if (newEnd != owned.end()) {
             owned.erase(newEnd, owned.end());
-            src->second.dirty_ = true;
+            markChunkDirty(oldKey);
         }
     }
 

--- a/test/world/chunk_persistence_test.cpp
+++ b/test/world/chunk_persistence_test.cpp
@@ -39,8 +39,7 @@ class ChunkPersistenceFixture : public ::testing::Test {
         // tests don't share a directory (would race if a previous test
         // crashed without cleanup).
         static std::atomic<std::uint64_t> counter{0};
-        const auto stamp =
-            std::chrono::steady_clock::now().time_since_epoch().count();
+        const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
         m_root = std::filesystem::temp_directory_path() /
                  ("ir-chunk-persistence-" + std::to_string(stamp) + "-" +
                   std::to_string(counter.fetch_add(1)));
@@ -197,15 +196,22 @@ TEST_F(ChunkPersistenceFixture, ManagerSavesDirtyChunkOnEvictAndLoadsOnReResiden
     ASSERT_NE(s, nullptr);
     ASSERT_EQ(s->state_, ChunkResidencyState::RESIDENT);
     ASSERT_EQ(s->poolAllocation_.voxels_.size(), kChunkVolume);
-    EXPECT_FALSE(s->dirty_) << "fresh-allocated chunk should not be dirty";
+    EXPECT_FALSE(s->isDirty()) << "fresh-allocated chunk should not be dirty";
 
-    // Mutate a few voxels through the pool slice and flag dirty.
-    s->poolAllocation_.voxels_[0] = C_Voxel{Color{10, 20, 30, 255}, /*mat=*/1, /*flags=*/2,
-                                            /*bone=*/3, /*layer=*/4};
+    // Mutate a few voxels through the pool slice and route the dirty
+    // flag through the manager's API (the load-bearing contract).
+    s->poolAllocation_.voxels_[0] = C_Voxel{
+        Color{10, 20, 30, 255},
+        /*mat=*/1,
+        /*flags=*/2,
+        /*bone=*/3,
+        /*layer=*/4
+    };
     s->poolAllocation_.voxels_[42] = C_Voxel{Color{99, 88, 77, 66}};
     s->poolAllocation_.voxels_[kChunkVolume - 1] =
         C_Voxel{Color{0, 0, 0, 0}}; // explicit empty slot to test alpha-0 round-trip
-    s->dirty_ = true;
+    mgr.markChunkDirty(key);
+    EXPECT_TRUE(s->isDirty()) << "markChunkDirty should flip the slot's bit";
 
     mgr.requestEvict(key);
     EXPECT_FALSE(mgr.isResident(key));
@@ -225,7 +231,7 @@ TEST_F(ChunkPersistenceFixture, ManagerSavesDirtyChunkOnEvictAndLoadsOnReResiden
     EXPECT_EQ(s2->poolAllocation_.voxels_[0].layer_id_, 4);
     EXPECT_EQ(s2->poolAllocation_.voxels_[42].color_.red_, 99);
     EXPECT_EQ(s2->poolAllocation_.voxels_[kChunkVolume - 1].color_.alpha_, 0u);
-    EXPECT_FALSE(s2->dirty_) << "post-load slice should not be dirty";
+    EXPECT_FALSE(s2->isDirty()) << "post-load slice should not be dirty";
 }
 
 TEST_F(ChunkPersistenceFixture, ManagerSkipsSaveForCleanChunkOnEvict) {
@@ -241,8 +247,7 @@ TEST_F(ChunkPersistenceFixture, ManagerSkipsSaveForCleanChunkOnEvict) {
     mgr.requestResident(key, RequestPriority::VISIBLE_RENDER);
     // No mutation, dirty stays false.
     mgr.requestEvict(key);
-    EXPECT_FALSE(persistence.chunkExists(key))
-        << "clean chunk should not write a file on evict";
+    EXPECT_FALSE(persistence.chunkExists(key)) << "clean chunk should not write a file on evict";
 }
 
 TEST_F(ChunkPersistenceFixture, FlushPendingSavesWritesDirtySlotsAndClearsDirty) {
@@ -262,13 +267,13 @@ TEST_F(ChunkPersistenceFixture, FlushPendingSavesWritesDirtySlotsAndClearsDirty)
     auto *s0 = mgr.slot(k0);
     ASSERT_NE(s0, nullptr);
     s0->poolAllocation_.voxels_[0] = C_Voxel{Color{1, 2, 3, 255}};
-    s0->dirty_ = true;
+    mgr.markChunkDirty(k0);
     // k1 stays clean.
 
     mgr.flushPendingSaves();
     EXPECT_TRUE(persistence.chunkExists(k0));
     EXPECT_FALSE(persistence.chunkExists(k1)) << "clean slot should not flush";
-    EXPECT_FALSE(mgr.slot(k0)->dirty_) << "dirty bit clears on successful save";
+    EXPECT_FALSE(mgr.slot(k0)->isDirty()) << "dirty bit clears on successful save";
 
     // Slots remain resident after flushPendingSaves.
     EXPECT_TRUE(mgr.isResident(k0));
@@ -291,7 +296,7 @@ TEST_F(ChunkPersistenceFixture, RequestResidentWithNoPriorSaveLeavesSliceFreshly
     ASSERT_NE(s, nullptr);
     // FakePool default-constructs C_Voxel which sets color to (0,0,0,255).
     EXPECT_EQ(s->poolAllocation_.voxels_[0].color_.alpha_, 255u);
-    EXPECT_FALSE(s->dirty_);
+    EXPECT_FALSE(s->isDirty());
 }
 
 TEST_F(ChunkPersistenceFixture, NoPersistenceWiredLeavesEvictBehaviorUnchanged) {
@@ -306,7 +311,7 @@ TEST_F(ChunkPersistenceFixture, NoPersistenceWiredLeavesEvictBehaviorUnchanged) 
 
     auto key = pack(IRMath::ivec3{0, 0, 0});
     mgr.requestResident(key, RequestPriority::VISIBLE_RENDER);
-    mgr.slot(key)->dirty_ = true;
+    mgr.markChunkDirty(key);
     mgr.requestEvict(key);
 
     // Nothing should have landed in the temp root because no


### PR DESCRIPTION
## Summary

Lands the load-bearing `[opus]` piece of #1008 (item 1) so creations can safely opt into `ChunkResidencyManager::Config::persistence_` without risking silent save drops.

- `ChunkResidencySlot::m_dirty` is now **private** with `ChunkResidencyManager` as a `friend`; the public surface is `isDirty()` (read) and `ChunkResidencyManager::markChunkDirty(ChunkKey)` (write). A missed mark turns from a silent runtime bug into a compile error.
- Internal manager callers (`attachEntity`, `migrateEntity`) self-route through `markChunkDirty`. The eventual push-at-mutation voxel upload path (Epic B / #944) wires through the same call when it lands.
- Tests demote direct `s->dirty_ = true` writes to `mgr.markChunkDirty(key)` so the API gets exercise. The `isDirty()` reader replaces the test-side field reads.

## Doc updates

- `engine/world/CLAUDE.md` — new "Chunk mutation must route through `markChunkDirty`" section.
- `engine/render/CLAUDE.md` — voxel-pool bullet cross-links to the world-side rule so the renderer-side author of a B5-style push-at-mutation path sees it.
- `docs/design/world-streaming.md` "Dirty tracking + eviction-write" — references the new API and notes the internal `attachEntity` / `migrateEntity` self-routing.

## Out of scope (filed separately)

Items 2 / 3 / 4 of #1008 were bundled into T-360 in TASKS.md, but the issue body tags them as `[sonnet]` and they're independently scoped. Filed as separate issues so the queue-manager can route them on their own cadence:

- #1169 — two-level directory split (`[sonnet]`)
- #1170 — wire a real in-engine consumer end-to-end (`[sonnet]`)
- #1171 — rename `ChunkDiskPersistence` → `ChunkVoxelDiskPersistence` (`[sonnet]`)

## Test plan

- [x] `fleet-build --target IrredenEngineTest` — clean on `linux-debug`.
- [x] `fleet-run IrredenEngineTest` — 940/940 pass (full suite).
- [x] `fleet-run IrredenEngineTest --gtest_filter='ChunkPersistence*:ChunkResidency*'` — 24/24 pass; the persistence integration tests now exercise `markChunkDirty` instead of poking the private field.
- [ ] Reviewer: confirm the private-field + friend approach is the right enforcement level (vs. keep-public + documentation only). The issue says "as the only supported way to flip the bit"; compile-time enforcement matches that intent, but the slot struct is otherwise all-public.

Closes #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)