### PR TITLE
T-365: fleet: smoke-only mode — persistent cross-host smoke worker

### DIFF
--- a/.claude/commands/role-smoke-worker.md
+++ b/.claude/commands/role-smoke-worker.md
@@ -1,0 +1,234 @@
+---
+name: role-smoke-worker
+description: Smoke-only fleet worker — claims fleet:needs-<host>-smoke PRs, builds and runs IRShapeDebug, verdicts, releases
+---
+
+You are a **smoke-only fleet worker** for the Irreden Engine, running in
+`~/src/IrredenEngine/.claude/worktrees/smoke-worker` (or any worktree
+whose basename starts with `smoke-worker`). Your sole job is to pick up
+`fleet:needs-<host>-smoke` labels on approved engine PRs, execute the
+cross-host smoke protocol, post a verdict, and exit cleanly.
+
+Mode (optional argument): $ARGUMENTS
+
+## Bash tool rules
+
+See [docs/agents/CLAUDE-BASELINE.md § Bash tool rules](../../docs/agents/CLAUDE-BASELINE.md#bash-tool-rules).
+
+## Shared fleet state cache
+
+See [docs/agents/FLEET-CACHE.md](../../docs/agents/FLEET-CACHE.md).
+
+## Exit protocol
+
+See [docs/agents/FLEET-RUNTIME.md § Exit protocol](../../docs/agents/FLEET-RUNTIME.md#exit-protocol--transient-roles)
+— transient one-shot, natural-exit on the final turn, no looping, no
+`kill -TERM $PPID`.
+
+## Role constraints
+
+- You are **smoke-only**. You never pick tasks from TASKS.md, never
+  open new PRs, never commit code, and never review logic. The `review-pr`,
+  `commit-and-push`, and `simplify` skills are off-limits.
+- Engine repo only. Game-repo PRs do not get cross-host smoke labels.
+- You run **Sonnet-tier** smoke (exit-code + log inspection). You do
+  NOT inspect screenshots or run `render-debug-loop`. If compile warnings
+  appear in the run log but the process exits zero, escalate to Opus per
+  step 5e below — do not mark as clean.
+- `fleet:needs-windows-smoke` is **not** polled here — it is cleared by
+  the `platform-catchup` workflow (#1093), not by fleet agents.
+
+---
+
+## Startup actions (do these immediately, in order)
+
+0. Print your role banner:
+   `[smoke-worker] Smoke-only fleet worker — picks fleet:needs-<host>-smoke PRs, builds + runs IRShapeDebug, verdicts. Transient — re-fires when scout sees smoke-pending state.`
+
+1. `pwd` — confirm you are in a `smoke-worker` worktree.
+
+2. Derive your **worktree basename** from `pwd` (e.g. `smoke-worker`,
+   `smoke-worker-1`). Use this everywhere this file says
+   `<your-worktree-basename>`.
+
+3. Confirm you are on the scratch branch:
+   `git branch --show-current` should report `claude/<your-worktree-basename>-scratch`.
+   If not, check out the scratch branch before proceeding:
+   ```
+   git fetch origin --quiet
+   git checkout -B claude/<your-worktree-basename>-scratch origin/master
+   ```
+   `gh pr checkout` will rewrite this branch for each smoke run.
+
+4. **Detect your host key** from `uname -s`:
+   - `Linux`  → host key `linux`,  poll `fleet:needs-linux-smoke`
+   - `Darwin` → host key `macos`, poll `fleet:needs-macos-smoke`
+   `fleet:needs-windows-smoke` is not polled here — skip it.
+
+5. **Read the shared fleet state cache** with the Read tool:
+   `~/.fleet/state/state.json`. Check `generated_at` — if missing or
+   older than ~5 minutes, print `scout cache stale or missing — run fleet-up` and exit.
+
+6. **Find the oldest smoke-pending PR.** From `repos.engine.prs[]`, find
+   PRs whose `labels` array:
+   - **contains** `fleet:needs-<host>-smoke` (your host from step 4)
+   - **contains** `fleet:approved`
+   - contains **none** of: `fleet:needs-fix`, `fleet:blocker`, `human:wip`,
+     `fleet:wip`, `fleet:merger-cooldown`, `human:needs-fix`
+   - contains **no** `fleet:reviewing-*` label
+
+   If the list is empty, print
+   `[smoke-worker] No smoke-pending PRs for <host> — standing by. Will re-fire on next dispatcher trigger.`
+   and exit cleanly.
+
+   Otherwise pick the oldest (smallest PR number).
+
+---
+
+## Per-iteration loop
+
+Each invocation runs exactly one smoke run, then exits.
+
+### Step 0 — heartbeat
+
+```
+fleet-heartbeat <your-worktree-basename>
+```
+
+### Step 1 — acquire the claim
+
+**Always acquire BEFORE checking out the PR** — two same-host smoke
+workers racing on the same PR would otherwise both clone the branch.
+
+```
+fleet-claim review-claim <N> <your-worktree-basename>
+```
+
+- **Exit 0** — you own this smoke run. Proceed.
+- **Exit 1** — another agent grabbed it. Print
+  `[smoke-worker] PR #<N> already claimed — skipping.` and exit.
+
+### Step 2 — checkout
+
+Re-touch heartbeat so the witness doesn't alarm during checkout + build:
+```
+fleet-heartbeat <your-worktree-basename>
+gh pr checkout <N> --repo jakildev/IrredenEngine
+```
+
+### Step 3 — build
+
+```
+fleet-heartbeat <your-worktree-basename>
+fleet-build --target IRShapeDebug
+```
+
+If `fleet-build` exits nonzero, jump to **step 5 — failure verdict** with
+the build log excerpt.
+
+### Step 4 — run
+
+```
+fleet-run IRShapeDebug --auto-screenshot 10
+```
+
+Do **not** add `--timeout` — `fleet-run --timeout` reports "alive at
+deadline" as success, which masks an `--auto-screenshot` hang.
+
+If `fleet-run` exits nonzero or crashes, jump to **step 5 — failure
+verdict** with the run log.
+
+### Step 5 — verdict
+
+**5a. Inspect the run log for compile warnings before declaring success.**
+If the run log (stdout/stderr from `fleet-run`) contains lines matching
+`warning:` or `error:` from a shader or GLSL/Metal compilation step, but
+`fleet-run` itself exited zero, do NOT declare success. Instead post a
+comment:
+
+```
+gh pr comment <N> --repo jakildev/IrredenEngine \
+  --body "Cross-host smoke: run exited clean on <host> but log flagged compile warnings; leaving smoke label on for Opus recheck."
+```
+
+Then skip to **step 6 — release + reset** without removing the smoke
+label. An Opus iteration will re-validate and inspect screenshots.
+
+**5b. Success path** — build and run both exited zero, no compile warnings
+in log:
+
+```
+gh pr edit <N> --repo jakildev/IrredenEngine \
+  --remove-label "fleet:needs-<host>-smoke" \
+  --add-label "fleet:verified-<host>"
+gh pr comment <N> --repo jakildev/IrredenEngine \
+  --body "Cross-host smoke OK on <host> (fresh checkout + IRShapeDebug --auto-screenshot 10 — build clean, exit 0, no log warnings)."
+```
+
+**5c. Failure path** — build failed, run crashed, or nonzero exit:
+
+```
+gh pr comment <N> --repo jakildev/IrredenEngine \
+  --body "Cross-host smoke FAILED on <host>: <one-line symptom>. Build/run log excerpt: <paste relevant lines>"
+gh pr edit <N> --repo jakildev/IrredenEngine \
+  --remove-label "fleet:approved" \
+  --remove-label "fleet:has-nits" \
+  --add-label "fleet:needs-fix"
+```
+
+Leave `fleet:needs-<host>-smoke` on — the smoke label stays until a
+clean run clears it.
+
+### Step 6 — release + reset
+
+Always release the claim and reset to scratch, whether the smoke passed or
+failed:
+
+```
+fleet-claim review-release <N> <your-worktree-basename>
+git checkout -B claude/<your-worktree-basename>-scratch origin/master
+```
+
+### Step 7 — shutdown
+
+Per [docs/agents/FLEET-RUNTIME.md § Per-iteration shutdown](../../docs/agents/FLEET-RUNTIME.md#per-iteration-shutdown--final-step):
+
+1. Write a summary (no backticks in the text):
+   ```
+   fleet-iteration-summary <your-worktree-basename> "PR #<N>: smoke <OK|FAILED|escalated> on <host>."
+   ```
+2. No worktree reservation to release (smoke-worker is stateless — it
+   never reserves its worktree for a task).
+3. Reset is already done in step 6.
+4. Print `[smoke-worker] Iteration complete. Will re-fire on next dispatcher trigger.`
+   and exit cleanly.
+
+---
+
+## Mode behavior
+
+- **`live`** — each invocation runs one full smoke iteration (steps 0–7),
+  then exits. fleet-dispatcher re-fires when the scout sees new
+  smoke-pending PRs.
+- **`dry-run`** (default) — do the startup actions (read cache, find PR,
+  detect host), print which PR you would smoke, then stop and wait for
+  human instruction. Do NOT claim or checkout.
+- **`review-only`** — skip pickup; print
+  `[smoke-worker] review-only: nothing to do (smoke-worker has no feedback PRs).`
+  and exit. Smoke-worker is stateless and never accumulates feedback.
+
+---
+
+## End-of-iteration feedback
+
+If you noticed something worth surfacing — a persistent smoke label across
+multiple iterations, a systematic build failure pattern, a missing label —
+append an entry to `~/.fleet/feedback/<your-worktree-basename>.md`.
+See [docs/agents/FLEET.md § "Fleet feedback channel"](../../docs/agents/FLEET.md#fleet-feedback-channel)
+for the format. High bar — most iterations write nothing.
+
+---
+
+## Hard rules
+
+See [docs/agents/CLAUDE-BASELINE.md § "Hard rules for autonomous fleet roles"](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles).

--- a/docs/agents/FLEET-CROSS-HOST-SMOKE.md
+++ b/docs/agents/FLEET-CROSS-HOST-SMOKE.md
@@ -12,8 +12,19 @@ the **reviewer** tagging side and the **author** claiming side — live
 here. Role files ([`role-opus-reviewer.md`](../../.claude/commands/role-opus-reviewer.md),
 [`role-sonnet-reviewer.md`](../../.claude/commands/role-sonnet-reviewer.md),
 [`role-opus-worker.md`](../../.claude/commands/role-opus-worker.md),
-[`role-sonnet-author.md`](../../.claude/commands/role-sonnet-author.md))
+[`role-sonnet-author.md`](../../.claude/commands/role-sonnet-author.md),
+[`role-smoke-worker.md`](../../.claude/commands/role-smoke-worker.md))
 point here rather than restating the procedure.
+
+**Dedicated smoke-only mode.** When running a second host (e.g. Ubuntu
+alongside a macOS fleet) that should only handle smoke testing, set
+`FLEET_SMOKE_WORKER=1` in `~/.fleet/fleet-up.conf` and restart fleet-up.
+This creates a `smoke-worker` pane that picks smoke labels exclusively,
+leaving author panes free for task work. See
+[`role-smoke-worker.md`](../../.claude/commands/role-smoke-worker.md) for
+the role spec and
+[`scripts/fleet/fleet-up.conf.sample`](../../scripts/fleet/fleet-up.conf.sample)
+for the configuration option.
 
 Engine repo only. Game-repo PRs do not get cross-host smoke labels —
 backends live in the engine.
@@ -114,6 +125,11 @@ Both `role-opus-worker` and `role-sonnet-author` poll for the smoke
 label that matches their host and execute the protocol below. The
 fleet runs at most one smoke run per author iteration so task pickup
 isn't starved by back-to-back builds.
+
+`role-smoke-worker` is a dedicated alternative: it *only* claims and
+executes smoke runs, never picks tasks, and can run on a second host
+dedicated to cross-host validation. Enable it with `FLEET_SMOKE_WORKER=1`
+in `~/.fleet/fleet-up.conf`.
 
 ### Host detection
 

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -89,6 +89,7 @@ _env_sonnet_reviewer="${FLEET_CONCURRENCY_SONNET_REVIEWER:-}"
 _env_opus_reviewer="${FLEET_CONCURRENCY_OPUS_REVIEWER:-}"
 _env_queue_manager="${FLEET_CONCURRENCY_QUEUE_MANAGER:-}"
 _env_merger="${FLEET_CONCURRENCY_MERGER:-}"
+_env_smoke_worker="${FLEET_CONCURRENCY_SMOKE_WORKER:-}"
 if [[ -f "$FLEET_CONF" ]]; then
     # shellcheck disable=SC1090
     source "$FLEET_CONF"
@@ -100,9 +101,10 @@ declare -A ROLE_CONCURRENCY=(
     ["opus-reviewer"]="${_env_opus_reviewer:-${FLEET_CONCURRENCY_OPUS_REVIEWER:-1}}"
     ["queue-manager"]="${_env_queue_manager:-${FLEET_CONCURRENCY_QUEUE_MANAGER:-1}}"
     ["merger"]="${_env_merger:-${FLEET_CONCURRENCY_MERGER:-1}}"
+    ["smoke-worker"]="${_env_smoke_worker:-${FLEET_CONCURRENCY_SMOKE_WORKER:-1}}"
 )
 unset _env_opus_worker _env_sonnet_author _env_sonnet_reviewer \
-      _env_opus_reviewer _env_queue_manager _env_merger
+      _env_opus_reviewer _env_queue_manager _env_merger _env_smoke_worker
 
 # Tracks per-role "deferred-by-cap" log throttling so the at-cap message
 # doesn't spam every 10s tick while the cap is held. Cleared whenever a
@@ -253,6 +255,7 @@ DISPATCHED_ROLES=(
     "sonnet-reviewer"
     "opus-reviewer"
     "merger"
+    "smoke-worker"
 )
 # queue-manager is no longer LLM-dispatched. Maintenance (derived-field
 # rendering) is handled by fleet-queue-tick, spawned directly by
@@ -267,6 +270,7 @@ declare -A ROLE_MODEL=(
     ["sonnet-reviewer"]="sonnet"
     ["opus-reviewer"]="claude-opus-4-7"
     ["merger"]="claude-opus-4-7"
+    ["smoke-worker"]="sonnet"
 )
 
 # Per-role default effort level. Mirrors fleet-babysit's case stmt.
@@ -276,6 +280,7 @@ declare -A ROLE_EFFORT=(
     ["sonnet-reviewer"]="high"
     ["opus-reviewer"]="xhigh"
     ["merger"]="xhigh"
+    ["smoke-worker"]="high"
 )
 
 # Tracks which panes have already had their cooldown logged this cycle so

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1114,6 +1114,10 @@ def slice_merger(state):
 
 
 def slice_smoke_worker(state):
+    # No explicit human:wip / fleet:wip ownership check here — _smoke_pr_eligible
+    # already rejects both via _SMOKE_SKIP_LABELS. Smoke workers never hold WIP PRs,
+    # so the open-WIP-PR ownership filter the other per-role slicers apply is
+    # intentionally absent.
     out = {"smoke_pending_prs": []}
     repo_state = state["repos"].get("engine", {})
     for pr in repo_state.get("prs", []):

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -613,6 +613,16 @@ REVIEW_SKIP_LABELS = frozenset({
 })
 RECHECK_LABELS = frozenset({"human:re-review", "fleet:changes-made"})
 
+# Smoke-worker label sets. Windows smoke is excluded — cleared by
+# platform-catchup (#1093), not by fleet agents.
+_SMOKE_PENDING_LABELS = frozenset({
+    "fleet:needs-linux-smoke", "fleet:needs-macos-smoke",
+})
+_SMOKE_SKIP_LABELS = frozenset({
+    "fleet:needs-fix", "fleet:blocker", "human:wip", "fleet:wip",
+    "fleet:merger-cooldown", "human:needs-fix",
+})
+
 MODEL_TOKEN_RE = re.compile(r"\b(opus|sonnet)\b")
 
 # Single-T-NNN blocker. Reject multi-blocker (`T-101, T-102`), free-text
@@ -918,6 +928,33 @@ def project_queue_manager_ingest(state):
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
+def _smoke_pr_eligible(labels_set):
+    """Return True if the PR is eligible for smoke pickup."""
+    if "fleet:approved" not in labels_set:
+        return False
+    if not (labels_set & _SMOKE_PENDING_LABELS):
+        return False
+    if labels_set & _SMOKE_SKIP_LABELS:
+        return False
+    if any(l.startswith("fleet:reviewing-") for l in labels_set):
+        return False
+    return True
+
+
+def project_smoke_worker(state):
+    items = []
+    for repo_key, repo_state in state["repos"].items():
+        if repo_key != "engine":
+            continue
+        for pr in repo_state.get("prs", []):
+            labels = set(pr["labels"])
+            if not _smoke_pr_eligible(labels):
+                continue
+            smoke_pending = sorted(labels & _SMOKE_PENDING_LABELS)
+            items.append({"pr": pr["number"], "smoke_labels": smoke_pending})
+    return sorted(items, key=lambda x: x["pr"])
+
+
 PROJECTORS = {
     "sonnet-author": project_sonnet_author,
     "opus-worker": project_opus_worker,
@@ -926,6 +963,7 @@ PROJECTORS = {
     "queue-manager": project_queue_manager,
     "queue-manager-ingest": project_queue_manager_ingest,
     "merger": project_merger,
+    "smoke-worker": project_smoke_worker,
 }
 
 
@@ -1075,6 +1113,23 @@ def slice_merger(state):
     return out
 
 
+def slice_smoke_worker(state):
+    out = {"smoke_pending_prs": []}
+    repo_state = state["repos"].get("engine", {})
+    for pr in repo_state.get("prs", []):
+        labels = set(pr["labels"])
+        if not _smoke_pr_eligible(labels):
+            continue
+        out["smoke_pending_prs"].append({
+            "number": pr["number"],
+            "title": pr.get("title", ""),
+            "labels": pr.get("labels", []),
+            "headRefName": pr.get("headRefName", ""),
+        })
+    out["smoke_pending_prs"].sort(key=lambda p: p["number"])
+    return out
+
+
 SLICERS = {
     "sonnet-author": slice_sonnet_author,
     "opus-worker": slice_opus_worker,
@@ -1082,6 +1137,7 @@ SLICERS = {
     "opus-reviewer": slice_opus_reviewer,
     "queue-manager": slice_queue_manager,
     "queue-manager-ingest": slice_queue_manager_ingest,
+    "smoke-worker": slice_smoke_worker,
     "merger": slice_merger,
 }
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -209,6 +209,13 @@ ensure_worktree "$ENGINE" .claude/worktrees/opus-reviewer     fleet/opus-reviewe
 ensure_worktree "$ENGINE" .claude/worktrees/queue-manager        fleet/queue-manager
 ensure_worktree "$ENGINE" .claude/worktrees/queue-manager-ingest fleet/queue-manager-ingest
 ensure_worktree "$ENGINE" .claude/worktrees/merger               fleet/merger
+# smoke-worker worktree is optional — only created when FLEET_SMOKE_WORKER=1.
+# Useful for running a dedicated smoke pane on a second host (e.g. Ubuntu
+# alongside the primary macOS fleet). Set FLEET_SMOKE_WORKER=1 in
+# ~/.fleet/fleet-up.conf or as an env var before calling fleet-up.
+if [[ "${FLEET_SMOKE_WORKER:-0}" == "1" ]]; then
+    ensure_worktree "$ENGINE" .claude/worktrees/smoke-worker fleet/smoke-worker
+fi
 
 if [[ -d "$GAME/.git" ]]; then
     (cd "$GAME" && git fetch origin --quiet) || {
@@ -467,6 +474,7 @@ reset_worktree "$ENGINE/.claude/worktrees/opus-reviewer"   claude/opus-reviewer-
 reset_worktree "$ENGINE/.claude/worktrees/queue-manager"        claude/queue-manager-scratch
 reset_worktree "$ENGINE/.claude/worktrees/queue-manager-ingest" claude/queue-manager-ingest-scratch
 reset_worktree "$ENGINE/.claude/worktrees/merger"               claude/merger-scratch
+reset_worktree "$ENGINE/.claude/worktrees/smoke-worker"         claude/smoke-worker-scratch
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     reset_worktree "$GAME/.claude/worktrees/game-architect" claude/game-arch-scratch
@@ -636,6 +644,9 @@ PYEOF
 for wt in opus-architect opus-worker-1 opus-worker-2 sonnet-fleet-1 sonnet-fleet-2 sonnet-reviewer opus-reviewer queue-manager queue-manager-ingest merger; do
     write_worktree_settings "$ENGINE/.claude/worktrees/$wt" "$ENGINE"
 done
+if [[ -d "$ENGINE/.claude/worktrees/smoke-worker" ]]; then
+    write_worktree_settings "$ENGINE/.claude/worktrees/smoke-worker" "$ENGINE"
+fi
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     write_worktree_settings "$GAME/.claude/worktrees/game-architect" "$GAME"
@@ -838,12 +849,16 @@ def sonnet_reviewer_actionable(p):
 def opus_reviewer_actionable(p):
     return bool(p.get("flagged_prs"))
 
+def smoke_worker_actionable(p):
+    return bool(p.get("smoke_pending_prs"))
+
 for role, predicate in [
     ("merger", merger_actionable),
     ("sonnet-author", author_worker_actionable),
     ("opus-worker", opus_worker_actionable),
     ("sonnet-reviewer", sonnet_reviewer_actionable),
     ("opus-reviewer", opus_reviewer_actionable),
+    ("smoke-worker", smoke_worker_actionable),
 ]:
     proj = proj_dir / f"{role}.json"
     if not proj.is_file():
@@ -1126,9 +1141,10 @@ label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.7]"
 set_fleet_role "$BOT_RIGHT" "opus-reviewer"
 pane_stagger
 
-# --- Window 2: "ops" — 2x2 grid ---------------------------------------
+# --- Window 2: "ops" — 2x2 grid (+ optional smoke-worker pane) --------
 #
-# queue-manager (top-left), merger (top-right),
+# queue-manager (top-left), merger (top-right, with optional smoke-worker
+# below it when FLEET_SMOKE_WORKER=1),
 # witness (bottom-left), terminal (bottom-right, $HOME, free-form shell).
 
 # Anchor explicitly after the fleet window with `-a -t fleet`. Without
@@ -1160,6 +1176,17 @@ OPS_BR=$(tmux split-window -v -t "$OPS_TR" -l 50% -P -F "#{pane_id}" \
     -c "$HOME" \
     "exec $SHELL")
 label_pane_id "$OPS_BR" "terminal"
+
+# Optional smoke-worker pane — only launched when the worktree exists
+# (i.e. FLEET_SMOKE_WORKER=1 was set during ensure_worktree above).
+if [[ -d "$ENGINE/.claude/worktrees/smoke-worker" ]]; then
+    OPS_SMOKE=$(tmux split-window -v -t "$OPS_TR" -l 50% -P -F "#{pane_id}" \
+        -c "$ENGINE/.claude/worktrees/smoke-worker" \
+        "$TRANSIENT_PANE_CMD")
+    label_pane_id "$OPS_SMOKE" "smoke-worker [sonnet]"
+    set_fleet_role "$OPS_SMOKE" "smoke-worker"
+    pane_stagger
+fi
 
 # Enable pane border labels using @role (immune to program overrides).
 # Apply at session level so it covers both windows.

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -104,8 +104,9 @@
 # FLEET_SMOKE_WORKER=1 tells fleet-up to create and launch a dedicated
 # smoke-worker pane. Useful when running a second host (e.g. Ubuntu
 # alongside a macOS fleet) that should only smoke-test render PRs and not
-# pick up tasks. The pane appears in the ops window; the dispatcher claims
-# fleet:needs-<host>-smoke PRs for it automatically.
+# pick up tasks. The pane appears in the ops window and is dispatched by
+# fleet-dispatcher (session-scoped — the dispatcher for THIS session picks
+# it up; a second host needs its own fleet-dispatcher pointed at its session).
 #
 # When unset or 0, no smoke-worker worktree or pane is created. The
 # sonnet-author and opus-worker panes continue to run step-1b smoke as a

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -29,6 +29,7 @@
 # FLEET_CONCURRENCY_OPUS_REVIEWER=1
 # FLEET_CONCURRENCY_QUEUE_MANAGER=1
 # FLEET_CONCURRENCY_MERGER=1
+# FLEET_CONCURRENCY_SMOKE_WORKER=1   # concurrent cap for the smoke-only worker pane
 
 # --- Usage gate (per-rate-limit-type thresholds) ----------------------------
 #
@@ -97,3 +98,17 @@
 # overnight pile-up of stuck windows.
 
 # FLEET_RUN_DEFAULT_TIMEOUT=300
+
+# --- Smoke-only worker (cross-host) ----------------------------------------
+#
+# FLEET_SMOKE_WORKER=1 tells fleet-up to create and launch a dedicated
+# smoke-worker pane. Useful when running a second host (e.g. Ubuntu
+# alongside a macOS fleet) that should only smoke-test render PRs and not
+# pick up tasks. The pane appears in the ops window; the dispatcher claims
+# fleet:needs-<host>-smoke PRs for it automatically.
+#
+# When unset or 0, no smoke-worker worktree or pane is created. The
+# sonnet-author and opus-worker panes continue to run step-1b smoke as a
+# secondary responsibility — this flag is opt-in extra dedicated capacity.
+
+# FLEET_SMOKE_WORKER=0


### PR DESCRIPTION
## Summary
- Adds `role-smoke-worker.md` — a dedicated fleet role whose entire iteration is one smoke run (no task pickup, no feedback handling, no design escalation)
- Extends `fleet-dispatcher` with `smoke-worker` in `DISPATCHED_ROLES`, `ROLE_CONCURRENCY` (cap 1), `ROLE_MODEL` (sonnet), `ROLE_EFFORT` (high)
- Extends `fleet-state-scout` with `project_smoke_worker`, `slice_smoke_worker`, and `_smoke_pr_eligible` predicate; triggers on approved engine PRs with `fleet:needs-linux-smoke` or `fleet:needs-macos-smoke`
- Extends `fleet-up` with opt-in smoke-worker worktree + pane (`FLEET_SMOKE_WORKER=1`), settings, reset, and bootstrap-trigger support — existing fleets unaffected when flag is unset
- Updates `FLEET-CROSS-HOST-SMOKE.md` with dedicated-mode callout and `fleet-up.conf.sample` with the new option

## Test plan
- [ ] `scripts/fleet/fleet-state-scout` parses without syntax errors (`python3 -c "import scripts.fleet.fleet_state_scout"` or equivalent)
- [ ] Dispatcher loads smoke-worker in `ROLE_CONCURRENCY` without conflict
- [ ] `FLEET_SMOKE_WORKER=1 fleet-up --no-attach` creates the `smoke-worker` worktree and pane
- [ ] Role file cross-references resolve (FLEET-CACHE.md, FLEET-RUNTIME.md, FLEET.md §Fleet feedback channel)
- [ ] Docs-only: no build needed for role + doc changes

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)