### PR TITLE
T-363: tools: ir-host-probe survives non-exec lspci stub in PATH

### DIFF
--- a/engine/tools/py/ir_hardware_probe.py
+++ b/engine/tools/py/ir_hardware_probe.py
@@ -35,11 +35,11 @@ def _run(*args, default=""):
             timeout=5,
         )
         return out.stdout.strip()
-    except (OSError, subprocess.TimeoutExpired):
-        # OSError catches FileNotFoundError (binary missing from PATH) and
-        # PermissionError (binary exists but is not exec'able — happens on
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
+        # FileNotFoundError: binary missing from PATH.
+        # PermissionError: binary exists but is not exec'able — happens on
         # WSL2 hosts when PATH contains Windows-side stubs that match a
-        # Linux tool name but cannot be invoked from a Linux subprocess).
+        # Linux tool name but cannot be invoked from a Linux subprocess.
         return default
 
 

--- a/engine/tools/py/ir_hardware_probe.py
+++ b/engine/tools/py/ir_hardware_probe.py
@@ -35,7 +35,11 @@ def _run(*args, default=""):
             timeout=5,
         )
         return out.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
+        # OSError catches FileNotFoundError (binary missing from PATH) and
+        # PermissionError (binary exists but is not exec'able — happens on
+        # WSL2 hosts when PATH contains Windows-side stubs that match a
+        # Linux tool name but cannot be invoked from a Linux subprocess).
         return default
 
 

--- a/test/tools/calibration_test.sh
+++ b/test/tools/calibration_test.sh
@@ -57,13 +57,19 @@ check "--slug matches the JSON 'slug' field" '[[ "$slug" == "$expected_slug" ]]'
 # See engine/tools/py/ir_hardware_probe.py::_run.
 echo "[5] missing-helper resilience"
 stub_dir="$(mktemp -d)"
+trap 'rm -rf "$XDG_CACHE_HOME" "$stub_dir"' EXIT  # also clean stub_dir on early exit
 touch "$stub_dir/lspci"  # non-executable, mimics the WSL2 PATH stub case
 missing_out="$(PATH="$stub_dir:$PATH" "$IR_PROBE" --refresh)"
 rm -rf "$stub_dir"
+trap 'rm -rf "$XDG_CACHE_HOME"' EXIT  # restore original (stub_dir already gone)
 check "valid JSON when lspci is non-executable" \
     'python3 -c "import json,sys; json.loads(sys.argv[1])" "$missing_out"'
-check "gpu.model falls back to a non-empty string" \
-    '[[ -n "$(echo "$missing_out" | python3 -c "import json,sys; print(json.load(sys.stdin)[\"gpu\"][\"model\"])")" ]]'
+gpu_model="$(echo "$missing_out" | python3 -c "import json,sys; print(json.load(sys.stdin)[\"gpu\"][\"model\"])")"
+if [[ "$(uname -s)" == "Linux" ]]; then
+    check "gpu.model falls back to 'unknown' when lspci is non-executable" '[[ "$gpu_model" == "unknown" ]]'
+else
+    check "gpu.model falls back to a non-empty string" '[[ -n "$gpu_model" ]]'
+fi
 
 # ir_ref_bench schema check — skip silently if the bench isn't built.
 echo "[6] ir_ref_bench output schema"

--- a/test/tools/calibration_test.sh
+++ b/test/tools/calibration_test.sh
@@ -47,8 +47,26 @@ slug="$("$IR_PROBE" --slug)"
 expected_slug="$(echo "$out1" | python3 -c "import json,sys; print(json.load(sys.stdin)['slug'])")"
 check "--slug matches the JSON 'slug' field" '[[ "$slug" == "$expected_slug" ]]'
 
+# Regression for the WSL2-on-fleet host case: when PATH carries a
+# `lspci` entry that exists but cannot be exec'd (Windows-side stub or
+# non-executable file), subprocess raises PermissionError — not
+# FileNotFoundError — and the probe must still emit a valid JSON
+# document with the GPU model fallback ("unknown"). Drive this
+# deterministically by planting a non-executable `lspci` stub at the
+# front of PATH so the probe's subprocess call hits PermissionError.
+# See engine/tools/py/ir_hardware_probe.py::_run.
+echo "[5] missing-helper resilience"
+stub_dir="$(mktemp -d)"
+touch "$stub_dir/lspci"  # non-executable, mimics the WSL2 PATH stub case
+missing_out="$(PATH="$stub_dir:$PATH" "$IR_PROBE" --refresh)"
+rm -rf "$stub_dir"
+check "valid JSON when lspci is non-executable" \
+    'python3 -c "import json,sys; json.loads(sys.argv[1])" "$missing_out"'
+check "gpu.model falls back to a non-empty string" \
+    '[[ -n "$(echo "$missing_out" | python3 -c "import json,sys; print(json.load(sys.stdin)[\"gpu\"][\"model\"])")" ]]'
+
 # ir_ref_bench schema check — skip silently if the bench isn't built.
-echo "[5] ir_ref_bench output schema"
+echo "[6] ir_ref_bench output schema"
 IR_REF_BENCH="$(find "$REPO_ROOT/build" -maxdepth 6 -type f -name ir_ref_bench -perm -u=x 2>/dev/null | head -1 || true)"
 if [[ -n "$IR_REF_BENCH" && -x "$IR_REF_BENCH" ]]; then
     bench_out="$("$IR_REF_BENCH" 100)"


### PR DESCRIPTION
## Summary
- Broadens `ir_hardware_probe._run()`'s exception catch from `FileNotFoundError` to `OSError`, so a WSL2 host whose PATH contains a `/mnt/c/...` Windows-side stub matching `lspci` no longer crashes the whole probe with `PermissionError: [Errno 13] Permission denied: 'lspci'`. The documented `{model: unknown}` fallback now actually fires.
- Adds a regression test in `calibration_test.sh` that plants a non-executable `lspci` stub at the front of PATH and asserts the probe still emits valid JSON — reproduces the failure mode deterministically on any host (the existing tests would only catch it on WSL2 specifically).

## Why
T-363 (sub-task 1 of #1074) covers `ir-host-probe` + `ir-acquire`. The tools themselves shipped earlier via T-330 (PR #1115). On this fleet host (Ubuntu 24.04 / WSL2) `ir-host-probe --slug` crashed and `calibration_test.sh` failed at the first probe call. That broke any downstream caller — `ir-perf-grid` invocations, the calibration check, baselines comparator — and made the host effectively unsupported for the perf workflow despite being the standard fleet env.

## Test plan
- [x] `bash test/tools/calibration_test.sh` — 9 passed, 0 failed (was: crashes on step [1] with PermissionError)
- [x] `bash test/tools/concurrency_test.sh` — 8 passed, 0 failed (unchanged behavior; ran as a regression check)
- [x] `ir-host-probe --slug` returns a well-formed slug: `linux-x86_64-ryzen-9-5950x-unknown` (GPU correctly "unknown" since lspci isn't actually present)
- [ ] macOS reviewer: probe still works (no behavioral change on macOS — `_run` is only used for `sysctl`/`system_profiler`/`sw_vers`, all built-ins that don't hit this exception path)

Closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)