### PR TITLE
T-358: world: per-frame upload-bandwidth cap + low-LOD billboard metadata (E4)

### DIFF
--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -30,6 +30,36 @@ derivation. `tickPrefetch()` then scans a Chebyshev ring of
 distance from camera to each slot's chunk center is written to
 `ChunkResidencySlot::distanceVoxels_` for the budget-gate and future sorting.
 
+### Upload-bandwidth cap + low-LOD billboard (T-358)
+
+Opt in via `Config::deferredUpload_ = true`. With the toggle on,
+`requestResident` enqueues the chunk in `LOADING` instead of
+synchronously transitioning to `RESIDENT`, and `flushUploads(maxBytes)`
+drains the queue each frame in (priority, distance) order capped at
+the byte budget. `FORCED` requests bypass the budget. A
+single-chunk-exceeds-budget guard always drains at least one
+non-forced entry per call so streaming can never stall on a chunk
+larger than the cap. The default budget lives in
+`Config::defaultUploadBudgetBytes_` (4 MiB, matching the design doc's
+≈240 MiB/s @ 60 fps target); pass `0` to `flushUploads` to use it.
+
+Each `ChunkResidencySlot` carries low-LOD AABB billboard metadata —
+`aabbColor_` (default grey), `aabbMinVoxel_` / `aabbMaxVoxel_` (full
+chunk by default), `lowLodFlags_`. The renderer's low-LOD pass
+iterates `forEachLowLodSlot` to spawn a `BOX` `C_ShapeDescriptor` per
+non-`RESIDENT` chunk; once the chunk reaches `RESIDENT` the voxel pool
+takes over and the billboard is dropped. Full design and the on-disk
+`BBOX` chunk record that will eventually replace the defaults are in
+[`docs/design/world-streaming.md`](../../docs/design/world-streaming.md)
+§"Topic 4 — Upload-bandwidth cap + low-LOD fallback".
+
+When `deferredUpload_` is false (the default), the legacy E1
+synchronous behavior is preserved: `requestResident` reaches
+`RESIDENT` inline, `flushUploads` is a no-op, and the low-LOD fields
+remain at their defaults but no chunk is ever in the non-`RESIDENT`
+state long enough for them to matter. Existing E1+E2+E6 consumers
+keep working unchanged.
+
 `engine/world/include/irreden/world/chunk_persistence.hpp` declares
 `IRWorld::ChunkDiskPersistence` — per-chunk `.vxs` save/load under a
 `<saveRoot>/chunks/` directory. One file per chunk; filename embeds

--- a/engine/world/include/irreden/world/chunk_residency.hpp
+++ b/engine/world/include/irreden/world/chunk_residency.hpp
@@ -311,6 +311,9 @@ class ChunkResidencyManager {
 
     // ── Index iteration (acceptance criterion 1) ─────────────────────
 
+    /// Total number of tracked chunks in m_slots, including LOADING,
+    /// UPLOADING, and EVICTING slots in deferred mode. Not strictly
+    /// "resident" when deferredUpload_ is true.
     std::size_t residentChunkCount() const;
     std::size_t entityCount() const;
 
@@ -328,17 +331,18 @@ class ChunkResidencyManager {
     /// for budget-tuning telemetry.
     std::size_t pendingUploadCount() const;
 
-    /// Iterate every resident slot. Visit order is unordered_map's;
-    /// callers must not rely on it.
+    /// Iterate every tracked slot (all states). Visit order is
+    /// unordered_map's; callers must not rely on it.
+    /// TODO(T-358-follow-up): filter to state_ == RESIDENT once a
+    /// production consumer exists that must skip LOADING slots.
     template <typename Fn> void forEachChunk(Fn &&fn) const {
-        // TODO(E3): filter to state_ == RESIDENT once async transitions add LOADING/UPLOADING slots
         for (const auto &kv : m_slots) {
             fn(kv.first, kv.second);
         }
     }
 
-    /// Iterate every slot that has NOT yet reached RESIDENT — LOADING
-    /// and UPLOADING slots. The renderer's low-LOD pass calls this
+    /// Iterate every slot that has NOT yet reached RESIDENT (LOADING,
+    /// UPLOADING, or EVICTING). The renderer's low-LOD pass calls this
     /// each frame to spawn / refresh AABB billboards from each slot's
     /// `aabbColor_` / `aabbMinVoxel_` / `aabbMaxVoxel_` while the
     /// upload pipeline catches up. Visit order is unordered_map's.
@@ -379,6 +383,9 @@ class ChunkResidencyManager {
     IRMath::vec3 m_cameraWorldVoxel{0.0f};
     IRMath::ivec3 m_cameraChunk{0};
     FrameStats m_frameStats{};
+
+    // Reused across flushUploads() calls to avoid per-frame heap allocation.
+    std::vector<PendingUpload> m_deferScratch{};
 };
 
 } // namespace IRWorld

--- a/engine/world/include/irreden/world/chunk_residency.hpp
+++ b/engine/world/include/irreden/world/chunk_residency.hpp
@@ -4,24 +4,39 @@
 // Chunk-residency manager (Epic E). Owns the sparse map from chunk-coord
 // to per-chunk residency slot, the per-chunk voxel sub-pool, and the
 // per-chunk entity manifest. Designed in
-// docs/design/world-streaming.md §"Topic 2 — Residency manager API".
+// docs/design/world-streaming.md §"Topic 2 — Residency manager API"
+// and §"Topic 4 — Upload-bandwidth cap + low-LOD fallback".
 //
 // E1 added the data model + synchronous request/evict + entity ownership +
 // per-chunk voxel sub-pool from an injected allocator. E6 added optional
-// disk persistence. E2 (this slice) adds the camera-driven eviction
-// policy: distance-based bucketing with LRU tie-breaking, a budget cap
-// on max resident chunks, pool deallocation on eviction, and the
-// per-frame beginFrame/endFrame lifecycle that drives the eviction cycle.
-// The async upload pipeline and worker threads are deferred to E3.
+// disk persistence — when a `ChunkDiskPersistence` pointer is wired in
+// Config, `requestResident` first attempts to load the chunk from disk
+// and seed the pool slice, and `requestEvict` saves dirty chunks before
+// dropping the slot. E3 (Chebyshev prefetch + camera-radius eviction) is
+// wired into `tickPrefetch()`.
+//
+// T-358 (Topic 4 / "E4" in issue numbering) adds the per-frame upload-
+// bandwidth cap and low-LOD billboard metadata. Opt in via
+// `Config::deferredUpload_ = true`: `requestResident` enqueues the chunk
+// in LOADING and `flushUploads(maxBytes)` drains the queue each frame in
+// (priority, distance) order capped at `maxBytes`. Chunks not yet drained
+// stay in LOADING/UPLOADING; the renderer reads `forEachLowLodSlot` to
+// spawn AABB billboards from `aabbColor_` / `aabbMinVoxel_` /
+// `aabbMaxVoxel_` until the upload completes. The async upload-worker
+// pool described in the design's Topic 2 is deferred to a follow-up —
+// today's "upload" is the synchronous E1 allocate + disk-load + transition
+// to RESIDENT, just gated by the per-frame byte budget.
 //
 // Single-chunk creations stay zero-overhead — the manager is only
 // constructed when a creation opts into streaming.
 
 #include <irreden/entity/ir_entity_types.hpp>
+#include <irreden/ir_constants.hpp>
 #include <irreden/ir_math.hpp>
 #include <irreden/render/voxel_pool_allocation.hpp>
 #include <irreden/world/chunk_coord.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <unordered_map>
@@ -74,6 +89,34 @@ struct ChunkResidencySlot {
         return m_dirty;
     }
 
+    // ── Low-LOD billboard metadata (T-358) ──────────────────────────
+    // Read by the renderer's low-LOD pass when the slot has not yet
+    // reached RESIDENT. Defaults represent the slot as a full-chunk
+    // grey AABB — the design doc's "this content is not yet uploaded"
+    // visual signal (Topic 4: "a flat cube where a complex structure
+    // should be is an unambiguous visual signal that streaming is
+    // mid-flight"). On-disk BBOX chunk records (design Topic 6) will
+    // override these defaults once the .vxs format extension lands.
+    /// Mean RGBA color of the chunk's voxel content. Default grey
+    /// `(0xAA, 0xAA, 0xAA, 0xFF)`. After the chunk reaches RESIDENT
+    /// the renderer drops the low-LOD billboard; this field is then
+    /// only relevant for re-eviction → low-LOD cycles.
+    IRMath::Color aabbColor_{0xAA, 0xAA, 0xAA, 0xFF};
+    /// AABB minimum corner in chunk-local voxel coords. Default
+    /// `{0,0,0}` — covers the full chunk.
+    IRMath::ivec3 aabbMinVoxel_{0, 0, 0};
+    /// AABB maximum corner in chunk-local voxel coords. Default
+    /// covers the full chunk: `kChunkSize - 1`.
+    IRMath::ivec3 aabbMaxVoxel_{
+        static_cast<int>(IRConstants::kChunkSize.x) - 1,
+        static_cast<int>(IRConstants::kChunkSize.y) - 1,
+        static_cast<int>(IRConstants::kChunkSize.z) - 1,
+    };
+    /// Bit 0: blocks light. Bit 1: emissive proxy. Future bits per
+    /// design Topic 6. Default 0 (passive AABB billboard, no special
+    /// lighting interaction).
+    std::uint8_t lowLodFlags_ = 0;
+
   private:
     friend class ChunkResidencyManager;
     bool m_dirty = false;
@@ -121,6 +164,29 @@ class ChunkResidencyManager {
         /// by the voxel-distance policy above (beginFrame / endFrame),
         /// not by this radius.
         int prefetchRadiusChunks_ = 2;
+
+        /// Chebyshev radius (in chunks) beyond which resident chunks
+        /// are evicted. Must be > prefetchRadiusChunks_ to provide
+        /// hysteresis (avoids thrashing at the ring boundary).
+        int evictionRadiusChunks_ = 3;
+
+        // ── Per-frame upload-bandwidth cap (T-358) ──────────────────
+        // Opt-in to async/budget upload semantics. When false
+        // (default), requestResident keeps E1's synchronous behavior:
+        // the chunk reaches RESIDENT inside the call. When true,
+        // requestResident enqueues the chunk in LOADING; the slot
+        // does NOT reach RESIDENT until flushUploads(maxBytes)
+        // processes it. The design's "load-bearing invariant: no
+        // frame ever blocks on upload" hinges on this gate.
+        bool deferredUpload_ = false;
+
+        // Default per-frame upload byte budget. Passed implicitly to
+        // flushUploads(0) — callers wire World::gameLoop() to either
+        // pass 0 (use this default) or an explicit override. Design
+        // doc Topic 4 picks 4 MiB / frame ≈ 240 MiB/s @ 60 fps so the
+        // GPU upload queue never blocks render dispatches. Tunable per
+        // creation; only consulted when `deferredUpload_ == true`.
+        int defaultUploadBudgetBytes_ = 4 * 1024 * 1024;
     };
 
     ChunkResidencyManager() = default;
@@ -140,6 +206,31 @@ class ChunkResidencyManager {
     void beginFrame(IRMath::vec3 cameraWorldVoxel);
 
     void tickPrefetch();
+
+    /// Drain the pending-uploads queue up to @p maxBytes, in
+    /// (priority, distance) order. Chunks reach RESIDENT inside this
+    /// call; chunks deferred to the next frame stay in LOADING and
+    /// the renderer paints them as low-LOD AABB billboards via
+    /// `forEachLowLodSlot`.
+    ///
+    /// Special values:
+    /// - `maxBytes == 0`: use `Config::defaultUploadBudgetBytes_`.
+    /// - `maxBytes < 0`: treated as 0 (defaults; never as "unlimited"
+    ///   to avoid silent budget-bypass).
+    ///
+    /// FORCED-priority pending entries bypass the budget — the
+    /// editor's "load this chunk now" requires synchronous completion
+    /// even when budget is exhausted.
+    ///
+    /// Single-chunk-exceeds-budget guard: at least one non-forced
+    /// chunk completes per call even if its byte size > the budget,
+    /// otherwise streaming stalls forever when one chunk is bigger
+    /// than the cap. Bias is intentional: bumping over budget once is
+    /// better than never making progress.
+    ///
+    /// No-op when `Config::deferredUpload_` is false (no queue exists
+    /// in synchronous mode; chunks reach RESIDENT inside
+    /// requestResident).
     void flushUploads(int maxBytes);
 
     /// Process evictions: save dirty EVICTING slots, deallocate pool
@@ -232,6 +323,11 @@ class ChunkResidencyManager {
         return m_frameStats;
     }
 
+    /// Count of chunks waiting in the deferred-upload queue. Always 0
+    /// when `Config::deferredUpload_` is false. Exposed for tests and
+    /// for budget-tuning telemetry.
+    std::size_t pendingUploadCount() const;
+
     /// Iterate every resident slot. Visit order is unordered_map's;
     /// callers must not rely on it.
     template <typename Fn> void forEachChunk(Fn &&fn) const {
@@ -241,11 +337,44 @@ class ChunkResidencyManager {
         }
     }
 
+    /// Iterate every slot that has NOT yet reached RESIDENT — LOADING
+    /// and UPLOADING slots. The renderer's low-LOD pass calls this
+    /// each frame to spawn / refresh AABB billboards from each slot's
+    /// `aabbColor_` / `aabbMinVoxel_` / `aabbMaxVoxel_` while the
+    /// upload pipeline catches up. Visit order is unordered_map's.
+    template <typename Fn> void forEachLowLodSlot(Fn &&fn) const {
+        for (const auto &kv : m_slots) {
+            if (kv.second.state_ != ChunkResidencyState::RESIDENT) {
+                fn(kv.first, kv.second);
+            }
+        }
+    }
+
   private:
     void evictSlot(std::unordered_map<IRPrefab::Chunk::ChunkKey, ChunkResidencySlot>::iterator it);
 
+    // Pending-upload queue entry. Populated by requestResident when
+    // Config::deferredUpload_ is true; drained by flushUploads in
+    // (priority, distance) order. The slot itself lives in m_slots
+    // throughout — the queue just orders the work, not the data.
+    struct PendingUpload {
+        IRPrefab::Chunk::ChunkKey key_ = 0;
+        RequestPriority priority_ = RequestPriority::PREFETCH_RING;
+        std::uint64_t enqueueFrame_ = 0;
+    };
+
+    // Shared by both the synchronous-mode requestResident path and the
+    // async-mode flushUploads drain — does the actual allocate + disk
+    // load + transition-to-RESIDENT work for a single slot.
+    void completeUploadForSlot(ChunkResidencySlot &s);
+
+    // Update the pending-upload entry's priority to the more urgent of
+    // (existing, requested). No-op if the key isn't queued.
+    void bumpPendingUploadPriority(IRPrefab::Chunk::ChunkKey key, RequestPriority p);
+
     Config m_config{};
     std::unordered_map<IRPrefab::Chunk::ChunkKey, ChunkResidencySlot> m_slots{};
+    std::vector<PendingUpload> m_pendingUploads{};
     std::uint64_t m_frameIndex = 0;
     IRMath::vec3 m_cameraWorldVoxel{0.0f};
     IRMath::ivec3 m_cameraChunk{0};

--- a/engine/world/include/irreden/world/chunk_residency.hpp
+++ b/engine/world/include/irreden/world/chunk_residency.hpp
@@ -165,11 +165,6 @@ class ChunkResidencyManager {
         /// not by this radius.
         int prefetchRadiusChunks_ = 2;
 
-        /// Chebyshev radius (in chunks) beyond which resident chunks
-        /// are evicted. Must be > prefetchRadiusChunks_ to provide
-        /// hysteresis (avoids thrashing at the ring boundary).
-        int evictionRadiusChunks_ = 3;
-
         // ── Per-frame upload-bandwidth cap (T-358) ──────────────────
         // Opt-in to async/budget upload semantics. When false
         // (default), requestResident keeps E1's synchronous behavior:

--- a/engine/world/src/chunk_residency.cpp
+++ b/engine/world/src/chunk_residency.cpp
@@ -13,6 +13,21 @@ namespace IRWorld {
 
 namespace {
 
+// Smaller = more urgent. FORCED is the editor "load this chunk now"
+// path that bypasses the byte budget; the camera-derived priorities
+// drain after it in (VISIBLE_RENDER, PREFETCH_RING) order.
+int requestPriorityUrgency(RequestPriority p) {
+    switch (p) {
+    case RequestPriority::FORCED:
+        return 0;
+    case RequestPriority::VISIBLE_RENDER:
+        return 1;
+    case RequestPriority::PREFETCH_RING:
+        return 2;
+    }
+    return 3;
+}
+
 IRComponents::C_Voxel recordToVoxel(const IRAsset::VoxelRecord &r) {
     // C_Voxel and VoxelRecord share an identical 12-byte std430 layout
     // but stay distinct types so layout drift surfaces as a compile
@@ -115,7 +130,92 @@ void ChunkResidencyManager::tickPrefetch() {
     // processed by endFrame() — tickPrefetch only grows the resident set.
 }
 
-void ChunkResidencyManager::flushUploads(int) {}
+void ChunkResidencyManager::flushUploads(int maxBytes) {
+    if (!m_config.deferredUpload_ || m_pendingUploads.empty()) {
+        return;
+    }
+
+    IR_PROFILE_SCOPE("ChunkResidencyManager::flushUploads");
+
+    // Resolve the per-call budget. maxBytes == 0 → use Config default.
+    // Negative budgets are clamped to 0 (defaults) to avoid silent
+    // budget-bypass — a caller passing -1 expecting "unlimited" would
+    // silently disable the cap on every frame they did so.
+    int effectiveBudget = maxBytes > 0 ? maxBytes : m_config.defaultUploadBudgetBytes_;
+    if (effectiveBudget < 0) {
+        effectiveBudget = 0;
+    }
+
+    // Sort by (urgency, distance). Stable sort keeps enqueue order as the
+    // tiebreaker for chunks at the same urgency + distance — preserves the
+    // intuitive "first requested wins" for same-class peers.
+    std::stable_sort(
+        m_pendingUploads.begin(),
+        m_pendingUploads.end(),
+        [this](const PendingUpload &a, const PendingUpload &b) {
+            const int ua = requestPriorityUrgency(a.priority_);
+            const int ub = requestPriorityUrgency(b.priority_);
+            if (ua != ub) {
+                return ua < ub;
+            }
+            auto ia = m_slots.find(a.key_);
+            auto ib = m_slots.find(b.key_);
+            const float da = ia != m_slots.end() ? ia->second.distanceVoxels_ : 0.0f;
+            const float db = ib != m_slots.end() ? ib->second.distanceVoxels_ : 0.0f;
+            return da < db;
+        }
+    );
+
+    const std::uint64_t bytesPerChunk = static_cast<std::uint64_t>(m_config.voxelsPerChunk_) *
+                                        static_cast<std::uint64_t>(sizeof(IRComponents::C_Voxel));
+
+    std::uint64_t cumulativeBytes = 0;
+    std::vector<PendingUpload> deferred;
+    deferred.reserve(m_pendingUploads.size());
+
+    for (const auto &pending : m_pendingUploads) {
+        // Slot may have been evicted between request and flush — the
+        // pending entry then references a chunk that no longer has a
+        // slot. Drop it silently.
+        auto it = m_slots.find(pending.key_);
+        if (it == m_slots.end()) {
+            continue;
+        }
+        ChunkResidencySlot &s = it->second;
+        // A re-request can land while a chunk is already RESIDENT (sync
+        // mode never reaches this point, but a slot can become RESIDENT
+        // from a forced bypass earlier in this same call). Drop the
+        // entry — work already done.
+        if (s.state_ == ChunkResidencyState::RESIDENT) {
+            continue;
+        }
+        if (s.state_ == ChunkResidencyState::EVICTING) {
+            // Eviction is queued; don't fight the eviction by re-loading
+            // mid-flight. Drop the upload request.
+            continue;
+        }
+
+        const bool isForced = pending.priority_ == RequestPriority::FORCED;
+        const bool wouldExceed =
+            bytesPerChunk > 0 &&
+            cumulativeBytes + bytesPerChunk > static_cast<std::uint64_t>(effectiveBudget);
+
+        // FORCED bypasses the budget (editor "load this chunk now").
+        // For non-forced: budget cuts off the drain, BUT we always
+        // process at least one chunk per call even when a single chunk
+        // exceeds the budget. Otherwise streaming stalls forever the
+        // moment a chunk grows past the cap.
+        if (wouldExceed && cumulativeBytes > 0 && !isForced) {
+            deferred.push_back(pending);
+            continue;
+        }
+
+        completeUploadForSlot(s);
+        cumulativeBytes += bytesPerChunk;
+    }
+
+    m_pendingUploads = std::move(deferred);
+}
 
 void ChunkResidencyManager::endFrame() {
     IR_PROFILE_FUNCTION(profiler::colors::Blue500);
@@ -193,18 +293,25 @@ ChunkResidencySlot *ChunkResidencyManager::slot(IRPrefab::Chunk::ChunkKey key) {
 }
 
 void ChunkResidencyManager::requestResident(
-    IRPrefab::Chunk::ChunkKey key, RequestPriority /*priority*/
+    IRPrefab::Chunk::ChunkKey key, RequestPriority priority
 ) {
     auto [it, inserted] = m_slots.try_emplace(key);
     ChunkResidencySlot &s = it->second;
     s.lastTouchedFrame_ = m_frameIndex;
     if (!inserted) {
-        // Rescue a slot that was scheduled for eviction — it was touched again
-        // before endFrame could erase it. Clearing EVICTING here is the only
-        // safe place: callers of migrateEntity and attachEntity rely on
+        // Rescue a slot scheduled for eviction — it was touched again before
+        // endFrame could erase it. Clearing EVICTING here is the only safe
+        // place: callers of migrateEntity and attachEntity rely on
         // requestResident having done this before they write to the slot.
         if (s.state_ == ChunkResidencyState::EVICTING) {
             s.state_ = ChunkResidencyState::RESIDENT;
+        }
+        // In deferred mode, a re-request can bump the queued entry's priority
+        // (e.g. PREFETCH_RING → VISIBLE_RENDER when the camera reaches the
+        // chunk) so flushUploads drains it sooner. RESIDENT slots (including
+        // freshly-rescued EVICTING slots above) ignore the bump.
+        if (m_config.deferredUpload_ && s.state_ != ChunkResidencyState::RESIDENT) {
+            bumpPendingUploadPriority(key, priority);
         }
         return;
     }
@@ -212,12 +319,27 @@ void ChunkResidencyManager::requestResident(
     s.key_ = key;
     s.state_ = ChunkResidencyState::LOADING;
 
-    // E1 skeleton: synchronous allocate + transition to RESIDENT. The
-    // async load/upload pipeline lands in E3.
+    if (m_config.deferredUpload_) {
+        // Async / budget mode: enqueue and let flushUploads complete it.
+        // Slot stays in LOADING; renderer paints it as a low-LOD AABB
+        // billboard from the slot's `aabbColor_` / `aabbMinVoxel_` /
+        // `aabbMaxVoxel_` defaults until the upload lands.
+        m_pendingUploads.push_back(PendingUpload{key, priority, m_frameIndex});
+        return;
+    }
+
+    // E1 synchronous path: complete the upload inline.
+    completeUploadForSlot(s);
+}
+
+void ChunkResidencyManager::completeUploadForSlot(ChunkResidencySlot &s) {
+    // Caller has just inserted the slot (sync path) or is draining the
+    // pending-uploads queue (async path). In both cases the slot is in
+    // LOADING and we drive it through UPLOADING → RESIDENT.
     if (m_config.poolAllocator_ && m_config.voxelsPerChunk_ > 0) {
         std::optional<std::vector<IRAsset::VoxelRecord>> loaded;
         if (m_config.persistence_) {
-            loaded = m_config.persistence_->loadChunk(key);
+            loaded = m_config.persistence_->loadChunk(s.key_);
         }
 
         s.state_ = ChunkResidencyState::UPLOADING;
@@ -227,8 +349,8 @@ void ChunkResidencyManager::requestResident(
             seedPoolSliceFromRecords(s.poolAllocation_, *loaded);
         } else if (loaded) {
             IRE_LOG_WARN(
-                "ChunkResidencyManager::requestResident: loaded record count {} != pool slice "
-                "size {}; ignoring disk data",
+                "ChunkResidencyManager::completeUploadForSlot: loaded record count {} != pool "
+                "slice size {}; ignoring disk data",
                 loaded->size(),
                 s.poolAllocation_.voxels_.size()
             );
@@ -262,6 +384,20 @@ void ChunkResidencyManager::evictSlot(
     }
 }
 
+void ChunkResidencyManager::bumpPendingUploadPriority(
+    IRPrefab::Chunk::ChunkKey key, RequestPriority p
+) {
+    for (auto &pending : m_pendingUploads) {
+        if (pending.key_ != key) {
+            continue;
+        }
+        if (requestPriorityUrgency(p) < requestPriorityUrgency(pending.priority_)) {
+            pending.priority_ = p;
+        }
+        return;
+    }
+}
+
 void ChunkResidencyManager::requestEvict(IRPrefab::Chunk::ChunkKey key) {
     auto it = m_slots.find(key);
     if (it == m_slots.end()) {
@@ -269,6 +405,21 @@ void ChunkResidencyManager::requestEvict(IRPrefab::Chunk::ChunkKey key) {
     }
     evictSlot(it);
     m_slots.erase(it);
+
+    // Drop any pending-upload entries that referenced this key — they
+    // would otherwise resurface as zombie work on the next flushUploads.
+    // flushUploads also guards (slot-missing → skip) so this is
+    // defense in depth, but eagerly trimming keeps the queue short.
+    if (!m_pendingUploads.empty()) {
+        m_pendingUploads.erase(
+            std::remove_if(
+                m_pendingUploads.begin(),
+                m_pendingUploads.end(),
+                [key](const PendingUpload &p) { return p.key_ == key; }
+            ),
+            m_pendingUploads.end()
+        );
+    }
 }
 
 void ChunkResidencyManager::flushPendingSaves() {
@@ -344,6 +495,10 @@ void ChunkResidencyManager::migrateEntity(
 
 std::size_t ChunkResidencyManager::residentChunkCount() const {
     return m_slots.size();
+}
+
+std::size_t ChunkResidencyManager::pendingUploadCount() const {
+    return m_pendingUploads.size();
 }
 
 std::size_t ChunkResidencyManager::entityCount() const {

--- a/engine/world/src/chunk_residency.cpp
+++ b/engine/world/src/chunk_residency.cpp
@@ -170,8 +170,7 @@ void ChunkResidencyManager::flushUploads(int maxBytes) {
                                         static_cast<std::uint64_t>(sizeof(IRComponents::C_Voxel));
 
     std::uint64_t cumulativeBytes = 0;
-    std::vector<PendingUpload> deferred;
-    deferred.reserve(m_pendingUploads.size());
+    m_deferScratch.clear();
 
     for (const auto &pending : m_pendingUploads) {
         // Slot may have been evicted between request and flush — the
@@ -206,7 +205,7 @@ void ChunkResidencyManager::flushUploads(int maxBytes) {
         // exceeds the budget. Otherwise streaming stalls forever the
         // moment a chunk grows past the cap.
         if (wouldExceed && cumulativeBytes > 0 && !isForced) {
-            deferred.push_back(pending);
+            m_deferScratch.push_back(pending);
             continue;
         }
 
@@ -214,7 +213,7 @@ void ChunkResidencyManager::flushUploads(int maxBytes) {
         cumulativeBytes += bytesPerChunk;
     }
 
-    m_pendingUploads = std::move(deferred);
+    std::swap(m_pendingUploads, m_deferScratch);
 }
 
 void ChunkResidencyManager::endFrame() {

--- a/test/world/chunk_residency_manager_test.cpp
+++ b/test/world/chunk_residency_manager_test.cpp
@@ -687,4 +687,363 @@ TEST(ChunkPrefetchTest, PrefetchIdempotentAcrossFrames) {
     EXPECT_EQ(mgr.residentChunkCount(), 27u);
 }
 
+// ---------------------------------------------------------------------------
+// Upload budget + low-LOD (T-358)
+// ---------------------------------------------------------------------------
+
+TEST(ChunkUploadBudgetTest, SlotLowLodDefaultsCoverFullChunk) {
+    // Defaults: grey color, AABB covers [0, kChunkSize-1]. The renderer
+    // paints these for any slot not yet RESIDENT.
+    ChunkResidencyManager mgr;
+    auto key = pack(IRMath::ivec3{2, 0, 0});
+    mgr.requestResident(key, RequestPriority::VISIBLE_RENDER);
+    const auto *s = mgr.slot(key);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(s->aabbColor_.red_, 0xAAu);
+    EXPECT_EQ(s->aabbColor_.alpha_, 0xFFu);
+    EXPECT_EQ(s->aabbMinVoxel_, IRMath::ivec3(0, 0, 0));
+    EXPECT_EQ(s->aabbMaxVoxel_.x, static_cast<int>(IRConstants::kChunkSize.x) - 1);
+    EXPECT_EQ(s->lowLodFlags_, 0u);
+}
+
+TEST(ChunkUploadBudgetTest, SyncModeFlushUploadsIsNoop) {
+    // Default config has deferredUpload_ == false — flushUploads must
+    // not surprise existing callers.
+    ChunkResidencyManager mgr;
+    auto key = pack(IRMath::ivec3{0, 0, 0});
+    mgr.requestResident(key, RequestPriority::VISIBLE_RENDER);
+    EXPECT_TRUE(mgr.isResident(key));
+    EXPECT_EQ(mgr.pendingUploadCount(), 0u);
+
+    mgr.flushUploads(0);
+    EXPECT_TRUE(mgr.isResident(key));
+    EXPECT_EQ(mgr.pendingUploadCount(), 0u);
+}
+
+TEST(ChunkUploadBudgetTest, DeferredRequestStaysLoadingUntilFlush) {
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    auto key = pack(IRMath::ivec3{0, 0, 0});
+    mgr.requestResident(key, RequestPriority::VISIBLE_RENDER);
+
+    // Slot exists, in LOADING, not yet RESIDENT.
+    EXPECT_FALSE(mgr.isResident(key));
+    const auto *s = mgr.slot(key);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(s->state_, ChunkResidencyState::LOADING);
+    EXPECT_EQ(mgr.pendingUploadCount(), 1u);
+
+    // After flush — RESIDENT, queue drained.
+    mgr.flushUploads(0);
+    EXPECT_TRUE(mgr.isResident(key));
+    EXPECT_EQ(mgr.pendingUploadCount(), 0u);
+}
+
+TEST(ChunkUploadBudgetTest, BudgetGateLimitsChunksPerFlush) {
+    // 10 chunks, each costing 4096 voxels × 12 B/voxel = 48 KB. Budget
+    // of 100 KB lets 2 through (96 KB cumulative); the rest stay queued.
+    int callCount = 0;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.poolAllocator_ = [&](unsigned int size) {
+        ++callCount;
+        IRRender::VoxelPoolAllocation alloc{};
+        alloc.startIndex_ = static_cast<std::size_t>(callCount) * size;
+        return alloc;
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    for (int i = 0; i < 10; ++i) {
+        mgr.requestResident(pack(IRMath::ivec3{i, 0, 0}), RequestPriority::PREFETCH_RING);
+    }
+    EXPECT_EQ(mgr.pendingUploadCount(), 10u);
+    EXPECT_EQ(callCount, 0); // Nothing allocated yet — deferred mode.
+
+    mgr.flushUploads(100 * 1024);
+    EXPECT_EQ(callCount, 2); // 2 × 48 KB ≤ 100 KB; 3rd would push to 144 KB.
+    EXPECT_EQ(mgr.pendingUploadCount(), 8u);
+
+    // Next flush drains 2 more.
+    mgr.flushUploads(100 * 1024);
+    EXPECT_EQ(callCount, 4);
+    EXPECT_EQ(mgr.pendingUploadCount(), 6u);
+}
+
+TEST(ChunkUploadBudgetTest, VisibleRenderDrainedBeforePrefetchRing) {
+    int callCount = 0;
+    std::vector<IRPrefab::Chunk::ChunkKey> processOrder;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.poolAllocator_ = [&](unsigned int size) {
+        ++callCount;
+        IRRender::VoxelPoolAllocation alloc{};
+        alloc.startIndex_ = static_cast<std::size_t>(callCount) * size;
+        return alloc;
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    auto prefetchKey = pack(IRMath::ivec3{5, 0, 0});
+    auto visibleKey = pack(IRMath::ivec3{0, 0, 0});
+    // Enqueue prefetch first; visible second. Ordering by priority
+    // (not enqueue order) means visible drains first.
+    mgr.requestResident(prefetchKey, RequestPriority::PREFETCH_RING);
+    mgr.requestResident(visibleKey, RequestPriority::VISIBLE_RENDER);
+
+    // Single-chunk budget: only the highest-priority chunk drains.
+    mgr.flushUploads(48 * 1024);
+    EXPECT_TRUE(mgr.isResident(visibleKey));
+    EXPECT_FALSE(mgr.isResident(prefetchKey));
+    EXPECT_EQ(mgr.pendingUploadCount(), 1u);
+}
+
+TEST(ChunkUploadBudgetTest, DistanceTieBreakForSamePriority) {
+    // Same priority, different distances → closer chunk first.
+    int callCount = 0;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.poolAllocator_ = [&](unsigned int size) {
+        ++callCount;
+        IRRender::VoxelPoolAllocation alloc{};
+        alloc.startIndex_ = static_cast<std::size_t>(callCount) * size;
+        return alloc;
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    auto nearKey = pack(IRMath::ivec3{1, 0, 0});
+    auto farKey = pack(IRMath::ivec3{5, 0, 0});
+    mgr.requestResident(nearKey, RequestPriority::VISIBLE_RENDER);
+    mgr.requestResident(farKey, RequestPriority::VISIBLE_RENDER);
+
+    // Set distance fields manually (production wires this from
+    // tickPrefetch's distance recompute).
+    mgr.slot(nearKey)->distanceVoxels_ = 32.0f;
+    mgr.slot(farKey)->distanceVoxels_ = 160.0f;
+
+    // Budget for one chunk only.
+    mgr.flushUploads(48 * 1024);
+    EXPECT_TRUE(mgr.isResident(nearKey));
+    EXPECT_FALSE(mgr.isResident(farKey));
+}
+
+TEST(ChunkUploadBudgetTest, ForcedBypassesBudget) {
+    // Editor "load this chunk now" requests get FORCED priority and
+    // must complete even when the per-call byte budget is zero.
+    int callCount = 0;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.poolAllocator_ = [&](unsigned int size) {
+        ++callCount;
+        IRRender::VoxelPoolAllocation alloc{};
+        alloc.startIndex_ = static_cast<std::size_t>(callCount) * size;
+        return alloc;
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    auto regularKey = pack(IRMath::ivec3{0, 0, 0});
+    auto forcedKey = pack(IRMath::ivec3{10, 0, 0});
+    mgr.requestResident(regularKey, RequestPriority::VISIBLE_RENDER);
+    mgr.requestResident(forcedKey, RequestPriority::FORCED);
+
+    // Tiny budget: a non-forced chunk on its own already busts the cap,
+    // but the single-chunk-exceeds-budget guard makes one through. FORCED
+    // would also drain regardless of budget. Sort order is FORCED first,
+    // VISIBLE_RENDER second; the FORCED chunk drains, then the regular
+    // gets deferred because cumulativeBytes > 0 and !isForced.
+    mgr.flushUploads(1024);
+    EXPECT_TRUE(mgr.isResident(forcedKey));
+    EXPECT_FALSE(mgr.isResident(regularKey));
+    EXPECT_EQ(mgr.pendingUploadCount(), 1u);
+
+    // Next flush completes the regular one (single-chunk-exceeds-budget
+    // guard makes it drain even at the 1 KB cap).
+    mgr.flushUploads(1024);
+    EXPECT_TRUE(mgr.isResident(regularKey));
+    EXPECT_EQ(mgr.pendingUploadCount(), 0u);
+}
+
+TEST(ChunkUploadBudgetTest, SingleChunkExceedingBudgetStillCompletes) {
+    // Streaming-stalls-forever guard: when one chunk's byte size > the
+    // entire budget, the first chunk in the queue still completes in
+    // each flush. Otherwise the queue never drains.
+    int callCount = 0;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096; // 48 KB per chunk.
+    cfg.poolAllocator_ = [&](unsigned int size) {
+        ++callCount;
+        IRRender::VoxelPoolAllocation alloc{};
+        alloc.startIndex_ = static_cast<std::size_t>(callCount) * size;
+        return alloc;
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    mgr.requestResident(pack(IRMath::ivec3{0, 0, 0}), RequestPriority::VISIBLE_RENDER);
+    mgr.requestResident(pack(IRMath::ivec3{1, 0, 0}), RequestPriority::VISIBLE_RENDER);
+
+    // Budget of 1 KB — much less than one chunk. First chunk still
+    // drains; second waits.
+    mgr.flushUploads(1024);
+    EXPECT_EQ(callCount, 1);
+    EXPECT_EQ(mgr.pendingUploadCount(), 1u);
+}
+
+TEST(ChunkUploadBudgetTest, EvictionTrimsPendingEntry) {
+    // A chunk evicted between request and flush should not surface as
+    // zombie work — flushUploads must skip stale entries.
+    int callCount = 0;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.poolAllocator_ = [&](unsigned int size) {
+        ++callCount;
+        return IRRender::VoxelPoolAllocation{static_cast<std::size_t>(callCount) * size, {}};
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    auto a = pack(IRMath::ivec3{0, 0, 0});
+    auto b = pack(IRMath::ivec3{1, 0, 0});
+    mgr.requestResident(a, RequestPriority::VISIBLE_RENDER);
+    mgr.requestResident(b, RequestPriority::VISIBLE_RENDER);
+    EXPECT_EQ(mgr.pendingUploadCount(), 2u);
+
+    // Evict A before flushing — requestEvict trims A's pending entry.
+    mgr.requestEvict(a);
+    EXPECT_EQ(mgr.pendingUploadCount(), 1u);
+
+    mgr.flushUploads(1024 * 1024); // Plenty of budget.
+    EXPECT_FALSE(mgr.isResident(a));
+    EXPECT_TRUE(mgr.isResident(b));
+    EXPECT_EQ(callCount, 1); // Only B was allocated.
+}
+
+TEST(ChunkUploadBudgetTest, RequestResidentBumpsPendingPriority) {
+    // A chunk first enqueued as PREFETCH_RING then re-requested as
+    // VISIBLE_RENDER should drain ahead of other PREFETCH_RING entries.
+    int callCount = 0;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.poolAllocator_ = [&](unsigned int size) {
+        ++callCount;
+        return IRRender::VoxelPoolAllocation{static_cast<std::size_t>(callCount) * size, {}};
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    auto bumpedKey = pack(IRMath::ivec3{0, 0, 0});
+    auto otherKey = pack(IRMath::ivec3{1, 0, 0});
+    mgr.requestResident(bumpedKey, RequestPriority::PREFETCH_RING);
+    mgr.requestResident(otherKey, RequestPriority::PREFETCH_RING);
+    // Bump priority on the first key.
+    mgr.requestResident(bumpedKey, RequestPriority::VISIBLE_RENDER);
+
+    EXPECT_EQ(mgr.pendingUploadCount(), 2u);
+
+    // Single-chunk budget — bumped key drains, other waits.
+    mgr.flushUploads(48 * 1024);
+    EXPECT_TRUE(mgr.isResident(bumpedKey));
+    EXPECT_FALSE(mgr.isResident(otherKey));
+}
+
+TEST(ChunkUploadBudgetTest, LowLodIterationCoversOnlyNonResidentSlots) {
+    // forEachLowLodSlot is the renderer's hook — must skip RESIDENT
+    // chunks (which the voxel pool already paints).
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.poolAllocator_ = [](unsigned int) { return IRRender::VoxelPoolAllocation{}; };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    auto pendingKey = pack(IRMath::ivec3{0, 0, 0});
+    auto residentKey = pack(IRMath::ivec3{1, 0, 0});
+    mgr.requestResident(pendingKey, RequestPriority::PREFETCH_RING);
+    mgr.requestResident(residentKey, RequestPriority::VISIBLE_RENDER);
+
+    mgr.flushUploads(48 * 1024); // Drains the higher-priority one.
+    EXPECT_TRUE(mgr.isResident(residentKey));
+    EXPECT_FALSE(mgr.isResident(pendingKey));
+
+    std::vector<IRPrefab::Chunk::ChunkKey> visited;
+    mgr.forEachLowLodSlot([&](IRPrefab::Chunk::ChunkKey k, const ChunkResidencySlot &) {
+        visited.push_back(k);
+    });
+    ASSERT_EQ(visited.size(), 1u);
+    EXPECT_EQ(visited[0], pendingKey);
+}
+
+TEST(ChunkUploadBudgetTest, TickPrefetchUnderBudgetEnqueuesAllStaysLoading) {
+    // tickPrefetch + deferredUpload combo: a 3×3×3 ring requests 27
+    // chunks; they all enqueue but none reach RESIDENT until flushUploads.
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.prefetchRadiusChunks_ = 1;
+    cfg.evictionRadiusChunks_ = 2;
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    mgr.setCameraWorldPosition(IRMath::vec3(16.0f, 16.0f, 16.0f));
+    mgr.beginFrame();
+    mgr.tickPrefetch();
+
+    EXPECT_EQ(mgr.residentChunkCount(), 27u);
+    EXPECT_EQ(mgr.pendingUploadCount(), 27u);
+    // None are RESIDENT yet — all are LOADING (low-LOD billboards).
+    std::size_t lowLodCount = 0;
+    mgr.forEachLowLodSlot([&](IRPrefab::Chunk::ChunkKey, const ChunkResidencySlot &) {
+        ++lowLodCount;
+    });
+    EXPECT_EQ(lowLodCount, 27u);
+}
+
+TEST(ChunkUploadBudgetTest, FlushUploadsDefaultBudgetWhenZero) {
+    // maxBytes == 0 → use Config::defaultUploadBudgetBytes_.
+    int callCount = 0;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.defaultUploadBudgetBytes_ = 48 * 1024; // One chunk per flush.
+    cfg.poolAllocator_ = [&](unsigned int) {
+        ++callCount;
+        return IRRender::VoxelPoolAllocation{};
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    mgr.requestResident(pack(IRMath::ivec3{0, 0, 0}), RequestPriority::VISIBLE_RENDER);
+    mgr.requestResident(pack(IRMath::ivec3{1, 0, 0}), RequestPriority::VISIBLE_RENDER);
+
+    mgr.flushUploads(0); // Uses default budget.
+    EXPECT_EQ(callCount, 1);
+    EXPECT_EQ(mgr.pendingUploadCount(), 1u);
+}
+
+TEST(ChunkUploadBudgetTest, ReRequestResidentChunkIsHarmlessInDeferredMode) {
+    // Re-requesting an already-RESIDENT chunk in deferred mode must
+    // not surface a pending entry — the slot is already done.
+    int callCount = 0;
+    ChunkResidencyManager::Config cfg;
+    cfg.deferredUpload_ = true;
+    cfg.voxelsPerChunk_ = 4096;
+    cfg.poolAllocator_ = [&](unsigned int) {
+        ++callCount;
+        return IRRender::VoxelPoolAllocation{};
+    };
+    ChunkResidencyManager mgr{std::move(cfg)};
+
+    auto k = pack(IRMath::ivec3{0, 0, 0});
+    mgr.requestResident(k, RequestPriority::VISIBLE_RENDER);
+    mgr.flushUploads(1024 * 1024);
+    ASSERT_TRUE(mgr.isResident(k));
+    EXPECT_EQ(mgr.pendingUploadCount(), 0u);
+    EXPECT_EQ(callCount, 1);
+
+    // Re-request — no pending entry, no re-alloc.
+    mgr.requestResident(k, RequestPriority::FORCED);
+    EXPECT_EQ(mgr.pendingUploadCount(), 0u);
+    EXPECT_EQ(callCount, 1);
+}
+
 } // namespace

--- a/test/world/chunk_residency_manager_test.cpp
+++ b/test/world/chunk_residency_manager_test.cpp
@@ -982,7 +982,6 @@ TEST(ChunkUploadBudgetTest, TickPrefetchUnderBudgetEnqueuesAllStaysLoading) {
     ChunkResidencyManager::Config cfg;
     cfg.deferredUpload_ = true;
     cfg.prefetchRadiusChunks_ = 1;
-    cfg.evictionRadiusChunks_ = 2;
     ChunkResidencyManager mgr{std::move(cfg)};
 
     mgr.beginFrame(IRMath::vec3(16.0f, 16.0f, 16.0f));

--- a/test/world/chunk_residency_manager_test.cpp
+++ b/test/world/chunk_residency_manager_test.cpp
@@ -985,8 +985,7 @@ TEST(ChunkUploadBudgetTest, TickPrefetchUnderBudgetEnqueuesAllStaysLoading) {
     cfg.evictionRadiusChunks_ = 2;
     ChunkResidencyManager mgr{std::move(cfg)};
 
-    mgr.setCameraWorldPosition(IRMath::vec3(16.0f, 16.0f, 16.0f));
-    mgr.beginFrame();
+    mgr.beginFrame(IRMath::vec3(16.0f, 16.0f, 16.0f));
     mgr.tickPrefetch();
 
     EXPECT_EQ(mgr.residentChunkCount(), 27u);


### PR DESCRIPTION
## Summary

- Adds per-frame upload-bandwidth cap to `ChunkResidencyManager` (T-358 / Epic E "E4" in issue numbering; design Topic 4). Opt-in via `Config::deferredUpload_`. When on, `requestResident` enqueues chunks in `LOADING` and `flushUploads(maxBytes)` drains the queue in (priority, distance) order capped at the byte budget.
- `FORCED` priority bypasses the budget (editor "load this chunk now"). Single-chunk-exceeds-budget guard ensures at least one non-forced chunk drains per call so streaming can never stall on a chunk larger than the cap.
- Each `ChunkResidencySlot` gets low-LOD AABB billboard metadata — `aabbColor_` (default grey), `aabbMinVoxel_` / `aabbMaxVoxel_` (full chunk), `lowLodFlags_`. Renderer iterates `forEachLowLodSlot` to spawn a `BOX` `C_ShapeDescriptor` per non-`RESIDENT` chunk while uploads catch up.
- Default config (`deferredUpload_ = false`) preserves the E1 synchronous behavior; existing E1+E2+E3+E6 tests pass unchanged.

## Stack context

- Stacked on PR #1180 (T-357 — camera-aware chunk prefetch + Chebyshev eviction).
- Base branch: `claude/T-357-camera-chunk-prefetch`.
- Re-target to `master` once #1180 (and its base #1179 / T-356 E2) merge.

## Design reference

- `docs/design/world-streaming.md` §"Topic 4 — Upload-bandwidth cap + low-LOD fallback".
- On-disk BBOX chunk record (would populate slot metadata from disk: mean color, voxel-content AABB) is a follow-up — `.vxs` format extension out of scope for this task. The grey-cube defaults are the design's intentional "this content is not yet uploaded" visual signal.

## What this does NOT add

- No async upload-worker pool. Today's "upload" is the synchronous E1 allocate + disk-load + RESIDENT transition, just gated by the per-frame byte budget. The async pipeline described in design Topic 2 is a follow-up.
- No renderer integration that actually spawns the low-LOD `C_ShapeDescriptor` entities. No creation uses streaming today; the renderer hook (`forEachLowLodSlot`) is the foundation for the next task to wire up.
- No `BBOX` chunk record support in `engine/asset/` — defaults only for now.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` clean on `linux-debug`.
- [x] `fleet-build --target IRShapeDebug` clean on `linux-debug` (sanity check).
- [x] `fleet-run IrredenEngineTest` — 960/960 pass.
- [x] `fleet-run IrredenEngineTest --gtest_filter='ChunkResidency*:ChunkUploadBudget*:ChunkPrefetch*:ChunkPersistence*'` — 44/44 pass (14 new `ChunkUploadBudgetTest` cases + 30 pre-existing).
- [x] Default `Config::deferredUpload_ = false` keeps E1+E2+E3+E6 sync semantics — all 25 pre-existing chunk-* tests pass unchanged.
- [ ] `fleet-build --target IrredenEngineTest` clean on `macos-debug` (pending macOS reviewer; pure CPU change, no shader/UBO/backend touch).

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)