### PR TITLE
math: add IRMath::quatExtractZAngle + canvas_stress --full-rotate canary

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -11,6 +11,7 @@
 // Components
 #include <irreden/common/components/component_local_transform.hpp>
 #include <irreden/common/components/component_rotation_mode.hpp>
+#include <irreden/render/components/component_camera.hpp>
 #include <irreden/render/components/component_entity_canvas.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
@@ -58,10 +59,21 @@ struct CanvasStressSettings {
     float initialZoom_ = 1.0f;
     float cameraYaw_ = 0.0f;
     bool autoRotate_ = false;
+    bool fullRotate_ = false;
 };
 
 // 0.5 degrees per frame → full revolution in ~720 frames (~12 s at 60 fps)
 constexpr float kYawDeltaPerFrame = IRMath::kPi / 360.0f;
+
+// SO(3) camera-rotate canary. Per-frame rates are chosen so the three axes
+// never re-align at the same phase inside a normal capture window — GRID
+// canvases stay axis-aligned (only Z reaches them via the yaw helpers)
+// while DETACHED canvases tilt continuously, exercising the per-canvas
+// SO(3) bake.
+constexpr float kFullRotateYawPerFrame = IRMath::kPi / 540.0f; // ~3 rev / 1080 fr
+constexpr float kFullRotatePitchPerFrame = IRMath::kPi / 720.0f;
+constexpr float kFullRotatePitchYPerFrame =
+    IRMath::kPi / 900.0f; // Y-axis; Z=yaw, X=pitch in ISO frame
 
 CanvasStressSettings g_settings{};
 int g_autoWarmupFrames = 0;
@@ -144,6 +156,8 @@ void parseArgs(int argc, char **argv) {
             ++i;
         } else if (std::strcmp(argv[i], "--auto-rotate") == 0) {
             g_settings.autoRotate_ = true;
+        } else if (std::strcmp(argv[i], "--full-rotate") == 0) {
+            g_settings.fullRotate_ = true;
         }
     }
 }
@@ -191,6 +205,35 @@ void initSystems() {
     if (g_settings.autoRotate_) {
         renderPipeline.push_back(
             IRSystem::createSystem<IRSystem::AUTO_YAW_ROTATE>(kYawDeltaPerFrame)
+        );
+    }
+
+    if (g_settings.fullRotate_) {
+        // SO(3) camera driver — composes per-frame X/Y/Z spins into the
+        // camera's C_LocalTransform.rotation_ via setRotationQuat. C_Camera
+        // anchors the singleton tick; GRID canvases see only the Z-component
+        // (via IRPrefab::Camera::getYaw); DETACHED canvases pick up the full
+        // quat through PROPAGATE_CANVAS_ROTATION.
+        renderPipeline.push_back(
+            IRSystem::createSystem<C_Camera>(
+                "AutoFullRotate",
+                [](C_Camera &) {},
+                []() {
+                    const vec4 delta = IRMath::quatMul(
+                        IRMath::quatAxisAngle(vec3(0.0f, 0.0f, 1.0f), kFullRotateYawPerFrame),
+                        IRMath::quatMul(
+                            IRMath::quatAxisAngle(
+                                vec3(0.0f, 1.0f, 0.0f),
+                                kFullRotatePitchYPerFrame
+                            ),
+                            IRMath::quatAxisAngle(vec3(1.0f, 0.0f, 0.0f), kFullRotatePitchPerFrame)
+                        )
+                    );
+                    IRPrefab::Camera::setRotationQuat(
+                        IRMath::quatMul(delta, IRPrefab::Camera::getRotationQuat())
+                    );
+                }
+            )
         );
     }
 

--- a/docs/agents/audit-claude-md.md
+++ b/docs/agents/audit-claude-md.md
@@ -1025,7 +1025,7 @@ Cleanest large-ish file in the engine layer.
 - L8–68 ("Key components") — 60-line catalog mixing genuine
   semantic content with pure one-liners (`C_Camera — tag`,
   `C_CameraPosition2DIso — iso-space position`, `C_ZoomLevel — float
-  zoom`, `C_CameraYaw — continuous Z-yaw`).
+  zoom`, `C_Camera — singleton camera entity marker`).
 - L41–56 (`C_GizmoHandle` per-field documentation) — fields belong
   in the header, not the CLAUDE.md.
 

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -195,6 +195,17 @@ inline vec4 quatInverse(const vec4 &q) {
     return vec4(-q.x, -q.y, -q.z, q.w);
 }
 
+// Z-axis Tait-Bryan yaw extracted from a unit quaternion. For a pure-Z
+// rotation `q = quatAxisAngle(vec3(0,0,1), y)` this returns `y` exactly
+// (round-trip identity). For a general SO(3) quaternion this returns the
+// Z-component of the ZYX decomposition — the angle a pure-Z observer would
+// attribute to the orientation. Result lies in (-π, π].
+inline float quatExtractZAngle(const vec4 &q) {
+    const float numer = 2.0f * (q.w * q.z + q.x * q.y);
+    const float denom = 1.0f - 2.0f * (q.y * q.y + q.z * q.z);
+    return glm::atan(numer, denom);
+}
+
 /// Inverse of @ref pos3DtoPos2DIso: reconstructs the unique world position
 /// at iso (x, y) on the depth plane @p depth (= x+y+z). The iso depth axis
 /// is (1,1,1), so a 2D iso point and a depth value pin a single 3D point.
@@ -239,7 +250,9 @@ template <typename T> constexpr auto fract(const T &value) {
 }
 
 /// Floating-point remainder: x - y * trunc(x / y). std::fmod equivalent.
-inline float fmod(float x, float y) { return std::fmod(x, y); }
+inline float fmod(float x, float y) {
+    return std::fmod(x, y);
+}
 
 /// Fractional part of the absolute value; always in [0, 1). Ignores sign.
 template <typename T> constexpr auto fractAbs(const T &value) {

--- a/engine/prefabs/irreden/render/camera.hpp
+++ b/engine/prefabs/irreden/render/camera.hpp
@@ -94,6 +94,9 @@ inline float getYaw() {
 /// Add @p delta (radians) to the camera's yaw, normalized to [-π, π).
 /// NOTE: Rebuilds rotation as quatAxisAngle(z, yaw+delta), clobbering any
 /// non-Z components. Use setRotationQuat directly for full SO(3) compositions.
+/// If another driver calls setRotationQuat in the same frame, the last ECS
+/// writer wins — safe while a single rotation driver is active per frame;
+/// document any future GRID + SO(3) driver coexistence.
 inline void rotateYaw(float delta) {
     setYaw(getYaw() + delta);
 }

--- a/test/render/camera_yaw_test.cpp
+++ b/test/render/camera_yaw_test.cpp
@@ -149,4 +149,63 @@ TEST(YawSplit, ResidualStaysInsideCardinalQuarter) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// IRMath::quatExtractZAngle — ZYX Tait-Bryan yaw extraction
+//
+// For pure-Z quaternions (the only case the camera currently exercises)
+// this must round-trip exactly. The decomposition formula is also correct
+// for general SO(3) — verified for pure-pitch (extracts zero yaw) and for
+// the ±π branch-cut boundary.
+// ---------------------------------------------------------------------------
+
+float roundTripZ(float yaw) {
+    return IRMath::quatExtractZAngle(IRMath::quatAxisAngle(IRMath::vec3(0.0f, 0.0f, 1.0f), yaw));
+}
+
+TEST(QuatExtractZAngle, ZeroRoundTripsExactly) {
+    EXPECT_NEAR(roundTripZ(0.0f), 0.0f, kTolerance);
+}
+
+TEST(QuatExtractZAngle, HalfPiRoundTripsExactly) {
+    EXPECT_NEAR(roundTripZ(IRMath::kHalfPi), IRMath::kHalfPi, kTolerance);
+}
+
+TEST(QuatExtractZAngle, NegativeHalfPiRoundTripsExactly) {
+    EXPECT_NEAR(roundTripZ(-IRMath::kHalfPi), -IRMath::kHalfPi, kTolerance);
+}
+
+TEST(QuatExtractZAngle, QuarterPiRoundTripsExactly) {
+    EXPECT_NEAR(roundTripZ(IRMath::kPi / 4.0f), IRMath::kPi / 4.0f, kTolerance);
+}
+
+TEST(QuatExtractZAngle, ArbitraryAnglesInsideRangeRoundTrip) {
+    // Sweep across (-π, π) — ±π sit on the atan2 branch cut where fp
+    // rounding may flip sign. All other values must round-trip exactly.
+    for (int i = -99; i <= 99; ++i) {
+        const float yaw = (static_cast<float>(i) / 100.0f) * IRMath::kPi;
+        EXPECT_NEAR(roundTripZ(yaw), yaw, kTolerance) << "yaw=" << yaw;
+    }
+}
+
+TEST(QuatExtractZAngle, PiBoundaryWrapsToSymmetricNegative) {
+    // ±π represent the same rotation; atan2's branch cut means the result
+    // at exactly π may be either ±π at fp precision — both are correct.
+    const float result = roundTripZ(IRMath::kPi);
+    EXPECT_TRUE(
+        IRMath::abs(result - IRMath::kPi) < 1e-4f || IRMath::abs(result + IRMath::kPi) < 1e-4f
+    ) << "result="
+      << result;
+}
+
+TEST(QuatExtractZAngle, IdentityQuatExtractsZero) {
+    EXPECT_NEAR(IRMath::quatExtractZAngle(IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f)), 0.0f, kTolerance);
+}
+
+TEST(QuatExtractZAngle, PurePitchExtractsZeroYaw) {
+    // A pure-X rotation has no Z-component; extracted yaw must be 0.
+    const IRMath::vec4 pitchQuat =
+        IRMath::quatAxisAngle(IRMath::vec3(1.0f, 0.0f, 0.0f), IRMath::kPi / 3.0f);
+    EXPECT_NEAR(IRMath::quatExtractZAngle(pitchQuat), 0.0f, kTolerance);
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

- **`IRMath::quatExtractZAngle(q)`** — ZYX Tait-Bryan yaw extraction: `atan2(2(wz+xy), 1-2(y²+z²))`. Round-trips exactly for pure-Z quaternions (the only current engine use); correct for general SO(3) (future-proofs pitch/roll compositions). Addresses [issue #1193](https://github.com/jakildev/IrredenEngine/issues/1193).
- **Tests** — 8 new `QuatExtractZAngle` cases in `camera_yaw_test.cpp`: identity, ±π/2, quarter-pi, 199-point interior sweep, ±π branch-cut, identity quat, pure-X pitch (extracts zero yaw). 969/969 pass.
- **`canvas_stress --full-rotate`** — SO(3) camera canary preserved from the original PR: composes per-frame X/Y/Z spins via `setRotationQuat`. GRID canvases stay axis-aligned; DETACHED canvases tilt visibly.
- **Nits** — stale `C_CameraYaw — continuous Z-yaw` in `audit-claude-md.md` replaced with `C_Camera — singleton camera entity marker`; `rotateYaw` docstring gets a last-writer-wins caveat.

This PR extracts the unique content from the duplicate T-364 PR #1178 (now closed) onto a clean branch off master.

## Test plan

- [x] `fleet-build --target IrredenEngineTest IRCanvasStress` — clean on `macos-debug`
- [x] `fleet-run --timeout 30 IrredenEngineTest` — 969/969 pass
- [x] `fleet-run --timeout 15 IRCanvasStress --full-rotate` — runs cleanly; DETACHED cubes tilt with camera while GRID stays axis-aligned
- [ ] Linux/WSL: `fleet-build --target IrredenEngineTest IRCanvasStress` + test run (pure CPU math, no shader/UBO changes)
- [ ] Windows: smoke build

Closes #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)