### PR TITLE
T-371: world: chunk persistence — two-level directory split

### DIFF
--- a/docs/design/world-streaming.md
+++ b/docs/design/world-streaming.md
@@ -848,10 +848,12 @@ A 4096³-world worst-case would be `~2 M chunk files`. Filesystem
 considerations:
 
 - Two-level directory split: `chunks/<x_div_64>/<y_div_64>/...`.
-  Caps any one directory at `4096` files. Sketched here, decision
-  deferred to the implementation pass (filesystem behavior varies
-  enough that the right answer needs measurement on the target
-  platforms).
+  Landed in T-371. `kDirSplitN=64` gives up to 1024 x-buckets × 1024
+  y-buckets across the int16 chunk-coord range; a typical 4096³-voxel
+  world (128 chunks wide) uses 2×2=4 leaf dirs. On ext4 (dir_index /
+  htree) and NTFS, per-name `open()`/`stat()` are O(log N) and scale
+  well past 500 K entries per directory; the split primarily limits
+  readdir/tool-traversal cost rather than lookup cost.
 
 ---
 

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -21,8 +21,9 @@ full design contract in
 
 `engine/world/include/irreden/world/chunk_persistence.hpp` declares
 `IRWorld::ChunkDiskPersistence` — per-chunk `.vxs` save/load under a
-`<saveRoot>/chunks/` directory. One file per chunk; filename embeds
-the signed chunk coord (e.g. `+00003_-00007_+00011.vxs`). When wired
+`<saveRoot>/chunks/<x_div_64>/<y_div_64>/` two-level directory tree. One
+file per chunk; filename embeds the signed chunk coord (e.g.
+`chunks/0/-1/+00003_-00007_+00011.vxs`). When wired
 on `ChunkResidencyManager::Config::persistence_`, the manager loads
 the chunk slice from disk on first `requestResident` and saves dirty
 chunks on `requestEvict`. `flushPendingSaves()` is the editor's

--- a/engine/world/include/irreden/world/chunk_persistence.hpp
+++ b/engine/world/include/irreden/world/chunk_persistence.hpp
@@ -4,12 +4,16 @@
 // Chunk disk persistence (Epic E / E6, design at
 // docs/design/world-streaming.md §"Topic 6 — File layout"). One `.vxs`
 // file per chunk under `<saveRoot>/chunks/`. Filename is derived from
-// the chunk's signed-integer coord:
+// the chunk's signed-integer coord using a two-level directory split:
 //
-//     chunks/<sx>NNNNN_<sy>NNNNN_<sz>NNNNN.vxs
+//     chunks/<x_div_64>/<y_div_64>/<sx>NNNNN_<sy>NNNNN_<sz>NNNNN.vxs
 //
 // where `<sx>`/`<sy>`/`<sz>` is `+` or `-` and `NNNNN` is zero-padded
-// |axis| (axes are int16, so 5 digits cover ±32767).
+// |axis| (axes are int16, so 5 digits cover ±32767). `<x_div_64>` and
+// `<y_div_64>` are the floor-divided chunk-coord bucket indices (e.g.
+// chunk (3,-7,11) → `chunks/0/-1/+00003_-00007_+00011.vxs`). The
+// two-level split limits per-directory file pressure for large worlds;
+// see docs/design/world-streaming.md §"File layout" for the analysis.
 //
 // Save/load route through `IRAsset::saveDenseVoxelSet` /
 // `loadDenseVoxelSet` so the on-disk format is the same DENSE-mode
@@ -20,10 +24,6 @@
 // E1 / this slice is synchronous — the residency manager calls save
 // on dirty evict and load on first request. E2/E3 will lift the same
 // calls into the residency worker pool; the surface stays the same.
-//
-// File layout is flat under `chunks/` in v1; the two-level directory
-// split sketched in the design doc is a follow-up gated on profiling
-// the per-directory file count.
 
 #include <irreden/asset/binary_io.hpp>
 #include <irreden/asset/voxel_set_format.hpp>

--- a/engine/world/src/chunk_persistence.cpp
+++ b/engine/world/src/chunk_persistence.cpp
@@ -34,10 +34,17 @@ std::string axisFragment(int v) {
     return oss.str();
 }
 
-std::string filenameForKey(IRPrefab::Chunk::ChunkKey key) {
-    auto coord = IRPrefab::Chunk::unpack(key);
+std::string filenameForCoord(const IRMath::ivec3 &coord) {
     return axisFragment(coord.x) + "_" + axisFragment(coord.y) + "_" + axisFragment(coord.z) +
            ".vxs";
+}
+
+std::string buildChunkPath(
+    const std::string &chunksDir, const IRMath::ivec3 &coord
+) {
+    return (std::filesystem::path{chunksDir} / std::to_string(floorDiv(coord.x, kDirSplitN)) /
+            std::to_string(floorDiv(coord.y, kDirSplitN)) / filenameForCoord(coord))
+        .string();
 }
 
 } // namespace
@@ -47,12 +54,7 @@ ChunkDiskPersistence::ChunkDiskPersistence(std::string saveRoot)
     , m_chunksDir{(std::filesystem::path{m_saveRoot} / "chunks").string()} {}
 
 std::string ChunkDiskPersistence::chunkPath(IRPrefab::Chunk::ChunkKey key) const {
-    auto coord = IRPrefab::Chunk::unpack(key);
-    return (std::filesystem::path{m_chunksDir} /
-            std::to_string(floorDiv(coord.x, kDirSplitN)) /
-            std::to_string(floorDiv(coord.y, kDirSplitN)) /
-            filenameForKey(key))
-        .string();
+    return buildChunkPath(m_chunksDir, IRPrefab::Chunk::unpack(key));
 }
 
 IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
@@ -66,7 +68,8 @@ IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
         return IRAsset::BinaryStatus::error(IRAsset::BinaryIOError::WriteFailed, oss.str());
     }
 
-    const auto chunkFilePath = chunkPath(key);
+    auto chunkCoord = IRPrefab::Chunk::unpack(key);
+    const auto chunkFilePath = buildChunkPath(m_chunksDir, chunkCoord);
     const auto leafDir = std::filesystem::path{chunkFilePath}.parent_path().string();
     std::error_code ec;
     std::filesystem::create_directories(leafDir, ec);
@@ -78,7 +81,6 @@ IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
         return IRAsset::BinaryStatus::error(IRAsset::BinaryIOError::OpenFailed, msg);
     }
 
-    auto chunkCoord = IRPrefab::Chunk::unpack(key);
     auto origin = IRPrefab::Chunk::chunkOriginVoxel(chunkCoord);
 
     IRAsset::DenseVoxelSet dense;

--- a/engine/world/src/chunk_persistence.cpp
+++ b/engine/world/src/chunk_persistence.cpp
@@ -19,6 +19,14 @@ constexpr int kChunkVolume = static_cast<int>(IRConstants::kChunkSize.x) *
                              static_cast<int>(IRConstants::kChunkSize.y) *
                              static_cast<int>(IRConstants::kChunkSize.z);
 
+// Bucket size for the two-level x/y directory split (see header comment).
+constexpr int kDirSplitN = 64;
+
+// Floor division toward −∞ (C++ `/` truncates toward zero for negatives).
+constexpr int floorDiv(int a, int b) noexcept {
+    return a / b - (a % b < 0 ? 1 : 0);
+}
+
 std::string axisFragment(int v) {
     const int magnitude = (v >= 0) ? v : -v;
     std::ostringstream oss;
@@ -39,7 +47,12 @@ ChunkDiskPersistence::ChunkDiskPersistence(std::string saveRoot)
     , m_chunksDir{(std::filesystem::path{m_saveRoot} / "chunks").string()} {}
 
 std::string ChunkDiskPersistence::chunkPath(IRPrefab::Chunk::ChunkKey key) const {
-    return (std::filesystem::path{m_chunksDir} / filenameForKey(key)).string();
+    auto coord = IRPrefab::Chunk::unpack(key);
+    return (std::filesystem::path{m_chunksDir} /
+            std::to_string(floorDiv(coord.x, kDirSplitN)) /
+            std::to_string(floorDiv(coord.y, kDirSplitN)) /
+            filenameForKey(key))
+        .string();
 }
 
 IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
@@ -53,12 +66,14 @@ IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
         return IRAsset::BinaryStatus::error(IRAsset::BinaryIOError::WriteFailed, oss.str());
     }
 
+    const auto chunkFilePath = chunkPath(key);
+    const auto leafDir = std::filesystem::path{chunkFilePath}.parent_path().string();
     std::error_code ec;
-    std::filesystem::create_directories(m_chunksDir, ec);
+    std::filesystem::create_directories(leafDir, ec);
     if (ec) {
         const std::string msg =
             "ChunkDiskPersistence::saveChunk: create_directories failed: " + ec.message() + " (" +
-            m_chunksDir + ")";
+            leafDir + ")";
         IRE_LOG_ERROR("{}", msg);
         return IRAsset::BinaryStatus::error(IRAsset::BinaryIOError::OpenFailed, msg);
     }
@@ -71,7 +86,7 @@ IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
     dense.boundsMax_ = origin + IRMath::ivec3{IRConstants::kChunkSize};
     dense.voxels_.assign(voxels.begin(), voxels.end());
 
-    return IRAsset::saveDenseVoxelSet(chunkPath(key), dense);
+    return IRAsset::saveDenseVoxelSet(chunkFilePath, dense);
 }
 
 std::optional<std::vector<IRAsset::VoxelRecord>>

--- a/test/world/chunk_persistence_test.cpp
+++ b/test/world/chunk_persistence_test.cpp
@@ -80,12 +80,17 @@ std::vector<IRAsset::VoxelRecord> makeRecordsWithSentinel(std::uint32_t sentinel
 }
 
 TEST_F(ChunkPersistenceFixture, ChunkPathEmbedsSignedAxisFragments) {
+    // Two-level layout: chunks/<x_div_64>/<y_div_64>/<sx>NNNNN_<sy>NNNNN_<sz>NNNNN.vxs
+    // chunk(0,0,0) → floorDiv(0,64)=0, floorDiv(0,64)=0 → chunks/0/0/+00000_+00000_+00000.vxs
     ChunkDiskPersistence persistence{rootStr()};
     auto path = persistence.chunkPath(pack(IRMath::ivec3{0, 0, 0}));
     EXPECT_NE(path.find("/chunks/"), std::string::npos);
+    EXPECT_NE(path.find("/0/0/"), std::string::npos);
     EXPECT_NE(path.find("+00000_+00000_+00000.vxs"), std::string::npos);
 
+    // chunk(-1,2,-32767) → floorDiv(-1,64)=-1, floorDiv(2,64)=0 → chunks/-1/0/...
     auto negPath = persistence.chunkPath(pack(IRMath::ivec3{-1, 2, -32767}));
+    EXPECT_NE(negPath.find("/-1/0/"), std::string::npos);
     EXPECT_NE(negPath.find("-00001_+00002_-32767.vxs"), std::string::npos);
 }
 
@@ -147,13 +152,32 @@ TEST_F(ChunkPersistenceFixture, SaveWithMismatchedSizeReportsErrorAndDoesNotWrit
     EXPECT_FALSE(persistence.chunkExists(key));
 }
 
-TEST_F(ChunkPersistenceFixture, ChunkFilesLandUnderChunksSubdirectory) {
+TEST_F(ChunkPersistenceFixture, ChunkFilesLandUnderTwoLevelSubdirectory) {
+    // chunk(1,2,3) → floorDiv(1,64)=0, floorDiv(2,64)=0 → chunks/0/0/+00001_+00002_+00003.vxs
     ChunkDiskPersistence persistence{rootStr()};
     auto key = pack(IRMath::ivec3{1, 2, 3});
     auto status = persistence.saveChunk(key, makeRecordsWithSentinel(0x1u));
     ASSERT_TRUE(status.ok()) << status.message_;
     EXPECT_TRUE(std::filesystem::exists(m_root / "chunks"));
     EXPECT_TRUE(std::filesystem::is_directory(m_root / "chunks"));
+    EXPECT_TRUE(std::filesystem::is_directory(m_root / "chunks" / "0" / "0"));
+    EXPECT_TRUE(
+        std::filesystem::exists(m_root / "chunks" / "0" / "0" / "+00001_+00002_+00003.vxs")
+    );
+}
+
+TEST_F(ChunkPersistenceFixture, NegativeChunkCoordsFloorDivideIntoBucket) {
+    // chunk(-1,-65,0) → floorDiv(-1,64)=-1, floorDiv(-65,64)=-2 → chunks/-1/-2/...
+    // Floor division (not truncation) keeps negative coords in correct buckets:
+    // floorDiv(-1,64)=-1 (not 0), floorDiv(-65,64)=-2 (not -1).
+    ChunkDiskPersistence persistence{rootStr()};
+    auto key = pack(IRMath::ivec3{-1, -65, 0});
+    auto status = persistence.saveChunk(key, makeRecordsWithSentinel(0x2u));
+    ASSERT_TRUE(status.ok()) << status.message_;
+    EXPECT_TRUE(std::filesystem::is_directory(m_root / "chunks" / "-1" / "-2"));
+    EXPECT_TRUE(
+        std::filesystem::exists(m_root / "chunks" / "-1" / "-2" / "-00001_-00065_+00000.vxs")
+    );
 }
 
 // ── ChunkResidencyManager integration with persistence ──────────────────


### PR DESCRIPTION
## Summary

- Update `ChunkDiskPersistence::chunkPath` / `filenameForKey` to use `chunks/<x_div_N>/<y_div_N>/` two-level directory layout
- T-298 follow-up 2/4 — no migration tooling needed (nothing real persists today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)