### PR TITLE
T-370: perf: cap UPDATE ticks per frame to prevent IRPerfGrid death spiral

### DIFF
--- a/engine/time/CLAUDE.md
+++ b/engine/time/CLAUDE.md
@@ -71,8 +71,10 @@ of lag manually (used by the loading-screen / pause path).
   bodies can read it from worker threads without synchronization.
   `deltaTime(RENDER)` is wall-clock (variable per frame); use it for
   presentation-frame interpolation, not simulation state.
-- **Lag can cascade.** If one frame takes 50 ms, the next loop iteration
-  runs 3 UPDATE ticks back-to-back. Budget accordingly.
+- **Lag is capped.** `clampUpdateLag(maxTicks)` limits the accumulator
+  to at most `maxTicks` frames of debt (default 8, configurable via
+  `max_update_ticks_per_frame` in `config.lua`). Without the cap, a
+  single slow frame would spiral into hundreds of catch-up ticks.
 - **Dropped-frame counter is RENDER-only.** If UPDATE falls behind, it
   catches up via extra ticks; it doesn't "drop" anything.
 - **`skipUpdate()` is a footgun.** Skipping ticks silently desyncs any

--- a/engine/time/CLAUDE.md
+++ b/engine/time/CLAUDE.md
@@ -73,7 +73,8 @@ of lag manually (used by the loading-screen / pause path).
   presentation-frame interpolation, not simulation state.
 - **Lag is capped.** `clampUpdateLag(maxTicks)` limits the accumulator
   to at most `maxTicks` frames of debt (default 8, configurable via
-  `max_update_ticks_per_frame` in `config.lua`). Without the cap, a
+  `max_update_ticks_per_frame` in `config.lua`; parsed in
+  `engine/world/include/irreden/world/config.hpp`). Without the cap, a
   single slow frame would spiral into hundreds of catch-up ticks.
 - **Dropped-frame counter is RENDER-only.** If UPDATE falls behind, it
   catches up via extra ticks; it doesn't "drop" anything.

--- a/engine/time/include/irreden/time/event_profiler.hpp
+++ b/engine/time/include/irreden/time/event_profiler.hpp
@@ -81,6 +81,7 @@ template <> class EventProfiler<UPDATE> {
     }
 
     void clampLag(uint32_t maxTicks) {
+        IR_ASSERT(maxTicks > 0, "max_update_ticks_per_frame must be > 0");
         NanoDuration maxLag = kFPSNanoDuration * static_cast<int64_t>(maxTicks);
         if (m_lag > maxLag) {
             m_lag = maxLag;

--- a/engine/time/include/irreden/time/event_profiler.hpp
+++ b/engine/time/include/irreden/time/event_profiler.hpp
@@ -80,6 +80,13 @@ template <> class EventProfiler<UPDATE> {
         }
     }
 
+    void clampLag(uint32_t maxTicks) {
+        NanoDuration maxLag = kFPSNanoDuration * static_cast<int64_t>(maxTicks);
+        if (m_lag > maxLag) {
+            m_lag = maxLag;
+        }
+    }
+
     TimePoint getTimePointBeginEvent() const {
         return m_timePointBeginEvent;
     }
@@ -93,14 +100,17 @@ template <> class EventProfiler<UPDATE> {
     }
 
     double fps() const {
-        if (m_fpsCount == 0) return 0.0;
+        if (m_fpsCount == 0)
+            return 0.0;
         auto now = Clock::now();
         auto cutoff = now - std::chrono::seconds(1);
         size_t count = 0;
         for (size_t i = 0; i < m_fpsCount; ++i) {
             size_t idx = (m_fpsHead + kFpsWindowCapacity - 1 - i) % kFpsWindowCapacity;
-            if (m_fpsTimestamps[idx] >= cutoff) ++count;
-            else break;
+            if (m_fpsTimestamps[idx] >= cutoff)
+                ++count;
+            else
+                break;
         }
         return static_cast<double>(count);
     }
@@ -109,7 +119,8 @@ template <> class EventProfiler<UPDATE> {
     void recordFrame(TimePoint tp) {
         m_fpsTimestamps[m_fpsHead] = tp;
         m_fpsHead = (m_fpsHead + 1) % kFpsWindowCapacity;
-        if (m_fpsCount < kFpsWindowCapacity) m_fpsCount++;
+        if (m_fpsCount < kFpsWindowCapacity)
+            m_fpsCount++;
     }
 
     TimePoint m_start;
@@ -185,14 +196,17 @@ template <> class EventProfiler<RENDER> {
     }
 
     double fps() const {
-        if (m_fpsCount == 0) return 0.0;
+        if (m_fpsCount == 0)
+            return 0.0;
         auto now = Clock::now();
         auto cutoff = now - std::chrono::seconds(1);
         size_t count = 0;
         for (size_t i = 0; i < m_fpsCount; ++i) {
             size_t idx = (m_fpsHead + kFpsWindowCapacity - 1 - i) % kFpsWindowCapacity;
-            if (m_fpsTimestamps[idx] >= cutoff) ++count;
-            else break;
+            if (m_fpsTimestamps[idx] >= cutoff)
+                ++count;
+            else
+                break;
         }
         return static_cast<double>(count);
     }
@@ -209,7 +223,8 @@ template <> class EventProfiler<RENDER> {
     void recordFrame(TimePoint tp) {
         m_fpsTimestamps[m_fpsHead] = tp;
         m_fpsHead = (m_fpsHead + 1) % kFpsWindowCapacity;
-        if (m_fpsCount < kFpsWindowCapacity) m_fpsCount++;
+        if (m_fpsCount < kFpsWindowCapacity)
+            m_fpsCount++;
     }
 
     TimePoint m_start;

--- a/engine/time/include/irreden/time/time_manager.hpp
+++ b/engine/time/include/irreden/time/time_manager.hpp
@@ -39,6 +39,10 @@ class TimeManager {
         m_profilerUpdate.skipEvent();
     }
 
+    void clampUpdateLag(uint32_t maxTicks) {
+        m_profilerUpdate.clampLag(maxTicks);
+    }
+
     template <Events event> double deltaTime();
     template <Events event> double fps();
     template <Events event> double frameTimeMs();

--- a/engine/world/include/irreden/world.hpp
+++ b/engine/world/include/irreden/world.hpp
@@ -60,6 +60,7 @@ class World {
     bool m_waitForFirstUpdateInput = false;
     bool m_startRecordingOnFirstInput = false;
     bool m_hasHandledFirstInput = false;
+    uint32_t m_maxUpdateTicksPerFrame = 8;
 
     // Agent-readable profiling: frame timing accumulation
     bool m_frameTimingEnabled = false;

--- a/engine/world/include/irreden/world/config.hpp
+++ b/engine/world/include/irreden/world/config.hpp
@@ -166,6 +166,10 @@ class WorldConfig {
             "worker_thread_count",
             std::make_unique<IRScript::LuaValue<IRScript::LuaType::INTEGER>>(-1)
         );
+        m_config.addEntry(
+            "max_update_ticks_per_frame",
+            std::make_unique<IRScript::LuaValue<IRScript::LuaType::INTEGER>>(8)
+        );
         sol::table configTable = m_lua.getTable("config");
         m_config.parse(configTable);
     }

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -47,7 +47,10 @@ World::World(const char *configFileName)
     , m_startRecordingOnFirstInput{
           m_worldConfig["start_recording_on_first_key_press"].get_boolean()
       }
-    , m_hasHandledFirstInput{false} {
+    , m_hasHandledFirstInput{false}
+    , m_maxUpdateTicksPerFrame{static_cast<uint32_t>(
+          m_worldConfig["max_update_ticks_per_frame"].get_integer()
+      )} {
     IRRender::setSubdivisionMode(
         static_cast<IRRender::SubdivisionMode>(m_worldConfig["subdivision_mode"].get_enum())
     );
@@ -83,9 +86,7 @@ World::World(const char *configFileName)
     // staging vector now that JobManager exists. Slot 0 is main,
     // slots 1..N are IRJob worker threads, so the total is
     // `workerCount() + 1`.
-    m_entityManager.resizeWorkerStaging(
-        static_cast<std::size_t>(m_jobManager.workerCount() + 1)
-    );
+    m_entityManager.resizeWorkerStaging(static_cast<std::size_t>(m_jobManager.workerCount() + 1));
     IR_PROFILE_MAIN_THREAD;
     IRE_LOG_INFO("Initalized game world");
 }
@@ -196,6 +197,7 @@ void World::gameLoop() {
         }
         while (!m_IRGLFWWindow.shouldClose()) {
             m_timeManager.beginMainLoop();
+            m_timeManager.clampUpdateLag(m_maxUpdateTicksPerFrame);
 
             Clock::time_point frameStart;
             if (m_frameTimingEnabled) {


### PR DESCRIPTION
## Summary

- Adds `max_update_ticks_per_frame` config entry (default 8) that caps the fixed-step accumulator, preventing the unbounded catch-up spiral that caused 454 UPDATE ticks per render frame (8.6s/frame) on linux-x86_64 with 262k entities.
- Adds `clampLag(maxTicks)` to `EventProfiler<UPDATE>` and a forwarding `clampUpdateLag` on `TimeManager`, called once per frame in `gameLoop()` after `beginMainLoop()`.
- Creations can override via `max_update_ticks_per_frame = N` in their `config.lua`.

## Profile results (macOS, 262k entities)

Before: 454 ticks/frame, 8.6s/frame (measured on linux �� death spiral)  
After: avg 1.1 ticks/frame (max 2), avg 17.82ms/frame (56 FPS)

## Test plan

- [x] `fleet-build --target IRShapeDebug` — clean
- [x] `fleet-build --target IRPerfGrid` — clean
- [x] `fleet-build --target IrredenEngineTest` — clean
- [x] `fleet-run IrredenEngineTest` — 961/961 pass
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — launches cleanly, all screenshots captured
- [x] `fleet-run IRPerfGrid --auto-screenshot 10` — 56 FPS, profile report confirms 1-2 ticks/frame
- [ ] Linux cross-host smoke: verify ≤33ms frame time on linux-x86_64

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)