### PR TITLE
T-373: world: rename ChunkDiskPersistence → ChunkVoxelDiskPersistence

### DIFF
--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -61,7 +61,7 @@ state long enough for them to matter. Existing E1+E2+E6 consumers
 keep working unchanged.
 
 `engine/world/include/irreden/world/chunk_persistence.hpp` declares
-`IRWorld::ChunkDiskPersistence` — per-chunk `.vxs` save/load under a
+`IRWorld::ChunkVoxelDiskPersistence` — per-chunk `.vxs` save/load under a
 `<saveRoot>/chunks/<x_div_64>/<y_div_64>/` two-level directory tree. One
 file per chunk; filename embeds the signed chunk coord (e.g.
 `chunks/0/-1/+00003_-00007_+00011.vxs`). When wired

--- a/engine/world/include/irreden/world/chunk_persistence.hpp
+++ b/engine/world/include/irreden/world/chunk_persistence.hpp
@@ -38,9 +38,9 @@ namespace IRWorld {
 
 /// Stateless helper that knows where chunk files live for a given save.
 /// Construct one per save root; reusable across every chunk under it.
-class ChunkDiskPersistence {
+class ChunkVoxelDiskPersistence {
   public:
-    explicit ChunkDiskPersistence(std::string saveRoot);
+    explicit ChunkVoxelDiskPersistence(std::string saveRoot);
 
     /// Absolute path to the `.vxs` file for @p key. Exposed for tests
     /// and for editor tooling that wants to surface "where on disk
@@ -53,9 +53,8 @@ class ChunkDiskPersistence {
     /// 32³); @p voxels must hold exactly that many records (mismatch
     /// returns `WriteFailed` with a diagnostic, leaves disk untouched).
     /// Creates any missing parent directories before writing.
-    IRAsset::BinaryStatus saveChunk(
-        IRPrefab::Chunk::ChunkKey key, std::span<const IRAsset::VoxelRecord> voxels
-    );
+    IRAsset::BinaryStatus
+    saveChunk(IRPrefab::Chunk::ChunkKey key, std::span<const IRAsset::VoxelRecord> voxels);
 
     /// Load the chunk file under @p key. Returns `std::nullopt` when:
     /// - the file does not exist (chunk has never been saved — caller
@@ -67,8 +66,7 @@ class ChunkDiskPersistence {
     ///
     /// Save Format Extensibility Rule #5: unknown is recoverable,
     /// never fatal. The caller proceeds with an empty chunk either way.
-    std::optional<std::vector<IRAsset::VoxelRecord>>
-    loadChunk(IRPrefab::Chunk::ChunkKey key) const;
+    std::optional<std::vector<IRAsset::VoxelRecord>> loadChunk(IRPrefab::Chunk::ChunkKey key) const;
 
     /// True when the chunk file under @p key exists on disk. Cheap —
     /// a single `stat`-equivalent call; safe to use as a "should I

--- a/engine/world/include/irreden/world/chunk_residency.hpp
+++ b/engine/world/include/irreden/world/chunk_residency.hpp
@@ -9,7 +9,7 @@
 //
 // E1 added the data model + synchronous request/evict + entity ownership +
 // per-chunk voxel sub-pool from an injected allocator. E6 added optional
-// disk persistence — when a `ChunkDiskPersistence` pointer is wired in
+// disk persistence — when a `ChunkVoxelDiskPersistence` pointer is wired in
 // Config, `requestResident` first attempts to load the chunk from disk
 // and seed the pool slice, and `requestEvict` saves dirty chunks before
 // dropping the slot. E3 (Chebyshev prefetch + camera-radius eviction) is
@@ -44,7 +44,7 @@
 
 namespace IRWorld {
 
-class ChunkDiskPersistence;
+class ChunkVoxelDiskPersistence;
 
 /// What does the caller want this request urgency-classed as?
 /// VISIBLE_RENDER and PREFETCH_RING are camera-derived; FORCED is the
@@ -137,7 +137,7 @@ class ChunkResidencyManager {
 
         unsigned int voxelsPerChunk_ = 0;
 
-        ChunkDiskPersistence *persistence_ = nullptr;
+        ChunkVoxelDiskPersistence *persistence_ = nullptr;
 
         /// Budget: max chunks that may be RESIDENT simultaneously.
         /// When the set exceeds this cap, endFrame evicts the

--- a/engine/world/src/chunk_persistence.cpp
+++ b/engine/world/src/chunk_persistence.cpp
@@ -49,20 +49,20 @@ std::string buildChunkPath(
 
 } // namespace
 
-ChunkDiskPersistence::ChunkDiskPersistence(std::string saveRoot)
+ChunkVoxelDiskPersistence::ChunkVoxelDiskPersistence(std::string saveRoot)
     : m_saveRoot{std::move(saveRoot)}
     , m_chunksDir{(std::filesystem::path{m_saveRoot} / "chunks").string()} {}
 
-std::string ChunkDiskPersistence::chunkPath(IRPrefab::Chunk::ChunkKey key) const {
+std::string ChunkVoxelDiskPersistence::chunkPath(IRPrefab::Chunk::ChunkKey key) const {
     return buildChunkPath(m_chunksDir, IRPrefab::Chunk::unpack(key));
 }
 
-IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
+IRAsset::BinaryStatus ChunkVoxelDiskPersistence::saveChunk(
     IRPrefab::Chunk::ChunkKey key, std::span<const IRAsset::VoxelRecord> voxels
 ) {
     if (static_cast<int>(voxels.size()) != kChunkVolume) {
         std::ostringstream oss;
-        oss << "ChunkDiskPersistence::saveChunk: voxel span size " << voxels.size()
+        oss << "ChunkVoxelDiskPersistence::saveChunk: voxel span size " << voxels.size()
             << " does not match chunk volume " << kChunkVolume;
         IRE_LOG_ERROR("{}", oss.str());
         return IRAsset::BinaryStatus::error(IRAsset::BinaryIOError::WriteFailed, oss.str());
@@ -75,8 +75,8 @@ IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
     std::filesystem::create_directories(leafDir, ec);
     if (ec) {
         const std::string msg =
-            "ChunkDiskPersistence::saveChunk: create_directories failed: " + ec.message() + " (" +
-            leafDir + ")";
+            "ChunkVoxelDiskPersistence::saveChunk: create_directories failed: " + ec.message() +
+            " (" + leafDir + ")";
         IRE_LOG_ERROR("{}", msg);
         return IRAsset::BinaryStatus::error(IRAsset::BinaryIOError::OpenFailed, msg);
     }
@@ -92,7 +92,7 @@ IRAsset::BinaryStatus ChunkDiskPersistence::saveChunk(
 }
 
 std::optional<std::vector<IRAsset::VoxelRecord>>
-ChunkDiskPersistence::loadChunk(IRPrefab::Chunk::ChunkKey key) const {
+ChunkVoxelDiskPersistence::loadChunk(IRPrefab::Chunk::ChunkKey key) const {
     const std::string path = chunkPath(key);
 
     std::error_code ec;
@@ -103,7 +103,7 @@ ChunkDiskPersistence::loadChunk(IRPrefab::Chunk::ChunkKey key) const {
     auto result = IRAsset::loadDenseVoxelSet(path);
     if (!result.ok()) {
         IRE_LOG_WARN(
-            "ChunkDiskPersistence::loadChunk: {} read failed (code={}): {}",
+            "ChunkVoxelDiskPersistence::loadChunk: {} read failed (code={}): {}",
             path,
             static_cast<int>(result.status_.code_),
             result.status_.message_
@@ -114,7 +114,7 @@ ChunkDiskPersistence::loadChunk(IRPrefab::Chunk::ChunkKey key) const {
     auto &dense = result.value_.dense_;
     if (dense.voxels_.size() != static_cast<std::size_t>(kChunkVolume)) {
         IRE_LOG_WARN(
-            "ChunkDiskPersistence::loadChunk: {} record count {} != chunk volume {}; treating "
+            "ChunkVoxelDiskPersistence::loadChunk: {} record count {} != chunk volume {}; treating "
             "as empty",
             path,
             dense.voxels_.size(),
@@ -125,7 +125,7 @@ ChunkDiskPersistence::loadChunk(IRPrefab::Chunk::ChunkKey key) const {
     return std::move(dense.voxels_);
 }
 
-bool ChunkDiskPersistence::chunkExists(IRPrefab::Chunk::ChunkKey key) const {
+bool ChunkVoxelDiskPersistence::chunkExists(IRPrefab::Chunk::ChunkKey key) const {
     std::error_code ec;
     return std::filesystem::exists(chunkPath(key), ec) && !ec;
 }

--- a/test/world/chunk_persistence_test.cpp
+++ b/test/world/chunk_persistence_test.cpp
@@ -22,9 +22,9 @@ using IRComponents::C_Voxel;
 using IRMath::Color;
 using IRPrefab::Chunk::ChunkKey;
 using IRPrefab::Chunk::pack;
-using IRWorld::ChunkDiskPersistence;
 using IRWorld::ChunkResidencyManager;
 using IRWorld::ChunkResidencyState;
+using IRWorld::ChunkVoxelDiskPersistence;
 using IRWorld::RequestPriority;
 
 constexpr std::size_t kChunkVolume = static_cast<std::size_t>(IRConstants::kChunkSize.x) *
@@ -82,7 +82,7 @@ std::vector<IRAsset::VoxelRecord> makeRecordsWithSentinel(std::uint32_t sentinel
 TEST_F(ChunkPersistenceFixture, ChunkPathEmbedsSignedAxisFragments) {
     // Two-level layout: chunks/<x_div_64>/<y_div_64>/<sx>NNNNN_<sy>NNNNN_<sz>NNNNN.vxs
     // chunk(0,0,0) → floorDiv(0,64)=0, floorDiv(0,64)=0 → chunks/0/0/+00000_+00000_+00000.vxs
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     auto path = persistence.chunkPath(pack(IRMath::ivec3{0, 0, 0}));
     EXPECT_NE(path.find("/chunks/"), std::string::npos);
     EXPECT_NE(path.find("/0/0/"), std::string::npos);
@@ -103,7 +103,7 @@ TEST_F(ChunkPersistenceFixture, RoundTripPreservesNonEmptyRecords) {
     // ("Trailing empty slots ... are implicit ... Slots not covered by
     // any triple are decoded as VoxelRecord{}"). This test enforces
     // both halves of the contract.
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     auto key = pack(IRMath::ivec3{3, -7, 11});
     auto records = makeRecordsWithSentinel(0xABCDu);
 
@@ -137,14 +137,14 @@ TEST_F(ChunkPersistenceFixture, RoundTripPreservesNonEmptyRecords) {
 }
 
 TEST_F(ChunkPersistenceFixture, LoadOnMissingFileReturnsNullopt) {
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     auto key = pack(IRMath::ivec3{42, 42, 42});
     EXPECT_FALSE(persistence.chunkExists(key));
     EXPECT_FALSE(persistence.loadChunk(key).has_value());
 }
 
 TEST_F(ChunkPersistenceFixture, SaveWithMismatchedSizeReportsErrorAndDoesNotWrite) {
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     auto key = pack(IRMath::ivec3{0, 0, 0});
     std::vector<IRAsset::VoxelRecord> short_records(kChunkVolume - 1);
     auto status = persistence.saveChunk(key, short_records);
@@ -154,7 +154,7 @@ TEST_F(ChunkPersistenceFixture, SaveWithMismatchedSizeReportsErrorAndDoesNotWrit
 
 TEST_F(ChunkPersistenceFixture, ChunkFilesLandUnderTwoLevelSubdirectory) {
     // chunk(1,2,3) → floorDiv(1,64)=0, floorDiv(2,64)=0 → chunks/0/0/+00001_+00002_+00003.vxs
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     auto key = pack(IRMath::ivec3{1, 2, 3});
     auto status = persistence.saveChunk(key, makeRecordsWithSentinel(0x1u));
     ASSERT_TRUE(status.ok()) << status.message_;
@@ -170,7 +170,7 @@ TEST_F(ChunkPersistenceFixture, NegativeChunkCoordsFloorDivideIntoBucket) {
     // chunk(-1,-65,0) → floorDiv(-1,64)=-1, floorDiv(-65,64)=-2 → chunks/-1/-2/...
     // Floor division (not truncation) keeps negative coords in correct buckets:
     // floorDiv(-1,64)=-1 (not 0), floorDiv(-65,64)=-2 (not -1).
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     auto key = pack(IRMath::ivec3{-1, -65, 0});
     auto status = persistence.saveChunk(key, makeRecordsWithSentinel(0x2u));
     ASSERT_TRUE(status.ok()) << status.message_;
@@ -204,7 +204,7 @@ class FakePool {
 };
 
 TEST_F(ChunkPersistenceFixture, ManagerSavesDirtyChunkOnEvictAndLoadsOnReResident) {
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     FakePool pool;
 
     ChunkResidencyManager::Config cfg;
@@ -259,7 +259,7 @@ TEST_F(ChunkPersistenceFixture, ManagerSavesDirtyChunkOnEvictAndLoadsOnReResiden
 }
 
 TEST_F(ChunkPersistenceFixture, ManagerSkipsSaveForCleanChunkOnEvict) {
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     FakePool pool;
     ChunkResidencyManager::Config cfg;
     cfg.persistence_ = &persistence;
@@ -275,7 +275,7 @@ TEST_F(ChunkPersistenceFixture, ManagerSkipsSaveForCleanChunkOnEvict) {
 }
 
 TEST_F(ChunkPersistenceFixture, FlushPendingSavesWritesDirtySlotsAndClearsDirty) {
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     FakePool pool;
     ChunkResidencyManager::Config cfg;
     cfg.persistence_ = &persistence;
@@ -305,7 +305,7 @@ TEST_F(ChunkPersistenceFixture, FlushPendingSavesWritesDirtySlotsAndClearsDirty)
 }
 
 TEST_F(ChunkPersistenceFixture, RequestResidentWithNoPriorSaveLeavesSliceFreshlyAllocated) {
-    ChunkDiskPersistence persistence{rootStr()};
+    ChunkVoxelDiskPersistence persistence{rootStr()};
     FakePool pool;
     ChunkResidencyManager::Config cfg;
     cfg.persistence_ = &persistence;


### PR DESCRIPTION
## Summary
- Renamed `IRWorld::ChunkDiskPersistence` → `IRWorld::ChunkVoxelDiskPersistence` across 5 files
- Scope is explicit: the class saves the voxel-pool slice only — entity manifest and billboard metadata are deferred to #199 and E4; the old name was easy to misinterpret as covering entity state

## Test plan
- [x] `fleet-run IrredenEngineTest` — 968/968 tests pass

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)