### PR TITLE
T-374: fleet: scope-shipped detection pass in queue-manager ingest

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -722,6 +722,15 @@ Specifically, **never pass these via `--label` when filing**:
       #M also closes ("done done").
   The CHILDREN go through the normal `human:approved` ingestion
   flow individually; the epic itself is just visible bookkeeping.
+- `fleet:scope-shipped` — owned by the **queue-manager** (`fleet-queue-ingest`
+  pre-flight). Set when a merged PR is found that references the issue number
+  (#N), indicating the scope landed under a different T-NNN prefix (sub-task-
+  of-epic shipping pattern). The scout's `_INGEST_SKIP_LABELS` excludes these
+  from the ingest projection so future triage passes skip them silently. The
+  human should close the issue once they verify coverage. Added with a comment
+  citing the landing PR; not added if the comment call fails (safe retry on
+  next tick). Don't add manually unless you've verified a merged PR covers the
+  scope.
 - `fleet:queued` / `fleet:task` — owned by the **queue-manager**, set
   AFTER it ingests an issue into `TASKS.md`. Adding it at filing time
   excludes the issue from queue-manager's triage search and strands

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -91,6 +91,7 @@ fi
 #      - human:* (purple 5319e7 / d4c5f9) — handoff to the human
 
 LABELS=(
+    "fleet:scope-shipped|fbca04|Issue scope already landed under a different T-NNN; queue-manager skipped ingest; human should close"
     "fleet:task|0366d6|Task tracked in TASKS.md"
     "fleet:epic|cc317c|Parent issue tracking a set of child issues; queue-manager auto-closes when all children close"
     "fleet:queued|c5def5|Queued for ingestion into TASKS.md"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -133,6 +133,7 @@ for issue in pending:
     if not n:
         kept.append(issue)
         continue
+    # Full-text search; may match incidental references — human verifies via comment before closing.
     r = subprocess.run(
         ['gh', 'pr', 'list', '--repo', 'jakildev/IrredenEngine', '--state', 'merged',
          '--search', f'#{n}', '--json', 'number,title,url,mergedAt', '--limit', '5'],

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -109,6 +109,92 @@ print(count)
     log "cross-host dedup: $still_pending issue(s) still pending after live label check"
 fi
 
+# Scope-shipped pre-flight: detect issues whose scope already landed in a
+# merged PR under a different T-NNN prefix (e.g. sub-task ingested after the
+# parent epic shipped the scope). Posts a comment on the issue, adds the
+# fleet:scope-shipped label so future triage passes skip it, and removes it
+# from the pending list. Avoids burning an LLM iteration on a no-op ingest
+# (issue #1175).
+if [[ -f "$PROJECTION_FILE" ]] && command -v gh >/dev/null 2>&1; then
+    scope_shipped_out=$(FLEET_PROJ_FILE="$PROJECTION_FILE" python3 - << 'SCOPE_PY' 2>>"$LOG_FILE"
+import json, os, subprocess, sys
+
+proj_path = os.environ['FLEET_PROJ_FILE']
+try:
+    data = json.load(open(proj_path))
+    pending = data.get('pending_issues', [])
+except Exception:
+    print('0,0')
+    sys.exit(0)
+
+kept, shipped = [], 0
+for issue in pending:
+    n = issue.get('number', 0)
+    if not n:
+        kept.append(issue)
+        continue
+    r = subprocess.run(
+        ['gh', 'pr', 'list', '--repo', 'jakildev/IrredenEngine', '--state', 'merged',
+         '--search', f'#{n}', '--json', 'number,title,url,mergedAt', '--limit', '5'],
+        capture_output=True, text=True, timeout=15,
+    )
+    try:
+        prs = json.loads(r.stdout or '[]') if r.returncode == 0 else []
+    except Exception:
+        prs = []
+    if not prs:
+        kept.append(issue)
+        continue
+    best = prs[0]
+    merged_date = best.get('mergedAt', '')[:10]
+    comment = (
+        f"Scope check: this issue's scope appears to have landed in "
+        f"\"{best['title']}\" (#{best['number']}, merged {merged_date}). "
+        "Skipping ingest; please close this issue if the scope is fully "
+        "addressed. — fleet-queue-ingest"
+    )
+    cr = subprocess.run(
+        ['gh', 'issue', 'comment', str(n), '--repo', 'jakildev/IrredenEngine',
+         '--body', comment],
+        capture_output=True, timeout=15,
+    )
+    if cr.returncode != 0:
+        kept.append(issue)
+        continue
+    subprocess.run(
+        ['gh', 'issue', 'edit', str(n), '--repo', 'jakildev/IrredenEngine',
+         '--add-label', 'fleet:scope-shipped'],
+        capture_output=True, timeout=15,
+    )
+    shipped += 1
+
+data['pending_issues'] = kept
+tmp_path = proj_path + '.tmp'
+try:
+    with open(tmp_path, 'w') as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp_path, proj_path)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except Exception:
+        pass
+
+print(f'{shipped},{len(kept)}')
+SCOPE_PY
+    )
+    if [[ -n "$scope_shipped_out" ]]; then
+        IFS=',' read -r shipped_count kept_count <<< "$scope_shipped_out"
+        if [[ "${shipped_count:-0}" -gt 0 ]]; then
+            log "scope-shipped: skipped $shipped_count issue(s) with merged PR coverage; $kept_count remaining"
+        fi
+        if [[ "${kept_count:-0}" == "0" ]] && [[ "${shipped_count:-0}" -gt "0" ]]; then
+            log "scope-shipped: all pending issues have merged coverage — no LLM ingest needed"
+            exit 0
+        fi
+    fi
+fi
+
 # Use the queue-manager worktree as an isolated working area (mirrors
 # fleet-queue-tick). Fall back to the main clone if the worktree
 # doesn't exist (e.g. fresh fleet install pre-fleet-up).

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -146,16 +146,17 @@ def fetch_prs(repo):
     return prs
 
 
-_ALREADY_QUEUED_LABELS = frozenset({"fleet:queued"})
+_ALREADY_QUEUED_LABELS = frozenset({"fleet:queued", "fleet:scope-shipped"})
 
 # Labels that mark issues the queue-manager role doc explicitly skips at
 # Step 5 — filter these out of the ingest projector/slicer so epics and
 # un-planned issues never hold the projection hash non-zero.
 _INGEST_SKIP_LABELS = frozenset({
-    "fleet:queued",      # pre-filtered by fetch_human_approved, included for explicitness
+    "fleet:queued",        # pre-filtered by fetch_human_approved, included for explicitness
     "fleet:epic",
     "fleet:needs-plan",
     "fleet:needs-info",
+    "fleet:scope-shipped", # scope landed under a different T-NNN; human should close
 })
 
 

--- a/scripts/fleet/tests/test_queue_manager_projection.py
+++ b/scripts/fleet/tests/test_queue_manager_projection.py
@@ -166,6 +166,31 @@ class IngestProjectionFiresOnNewApprovedIssue(unittest.TestCase):
         self.assertEqual(out["pending_issues"][0]["number"], 9001)
         self.assertEqual(out["pending_issues"][0]["repo"], "engine")
 
+    def test_scope_shipped_excluded_from_pending(self):
+        # fleet:scope-shipped marks issues whose scope already landed under a
+        # different T-NNN; the projector and slicer must exclude them so the
+        # queue-manager never tries to re-ingest them (issue #1175).
+        shipped = [{"number": 9002, "title": "Feature Y",
+                    "labels": ["human:approved", "fleet:scope-shipped"]}]
+        h = stable_hash(project_queue_manager_ingest(_state(engine_human_approved=shipped)))
+        self.assertEqual(h, stable_hash(project_queue_manager_ingest(_state())),
+                         "scope-shipped issue must not contribute to the ingest hash")
+        out = slice_queue_manager_ingest(_state(engine_human_approved=shipped))
+        self.assertEqual(out["pending_issues"], [],
+                         "scope-shipped issue must be absent from pending_issues slice")
+
+    def test_scope_shipped_mix_keeps_non_shipped(self):
+        # When some issues are scope-shipped and some are genuinely pending,
+        # only the pending ones should appear in the slice.
+        issues = [
+            {"number": 9003, "title": "Pending", "labels": ["human:approved"]},
+            {"number": 9004, "title": "Shipped", "labels": ["human:approved", "fleet:scope-shipped"]},
+        ]
+        out = slice_queue_manager_ingest(_state(engine_human_approved=issues))
+        nums = [i["number"] for i in out["pending_issues"]]
+        self.assertIn(9003, nums)
+        self.assertNotIn(9004, nums)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds scope-shipped pre-flight to `fleet-queue-ingest`: searches merged PRs for each pending human:approved issue number; if found, posts a comment citing the landing PR, stamps `fleet:scope-shipped`, removes the issue from the pending list, and skips the LLM spawn if the list empties (issue #1175)
- Adds `fleet:scope-shipped` to `_ALREADY_QUEUED_LABELS` in `fleet-state-scout` so `fetch_human_approved()` excludes these from `state.json` entirely — covers interactive queue-manager runs without needing a role-doc edit
- Adds `fleet:scope-shipped` to `_INGEST_SKIP_LABELS` for belt-and-suspenders projection/slicer filtering
- Registers `fleet:scope-shipped` label in `fleet-labels` catalog so `gh issue edit --add-label` succeeds on first use
- Documents the new label's ownership and semantics in `docs/agents/FLEET.md`
- 2 new tests verify scope-shipped issues are excluded from ingest projection hash and `pending_issues` slice (13/13 pass)

## Test plan
- [ ] Run `python3 scripts/fleet/tests/test_queue_manager_projection.py` — all 13 tests pass
- [ ] `fleet-labels --dry-run` shows `fleet:scope-shipped` in the would-create list (or already-existed if pre-applied)
- [ ] Simulate: add `fleet:scope-shipped` to `engine_human_approved` in `_state()` helper, confirm `project_queue_manager_ingest` hash matches empty state
- [ ] On next live fleet cycle with a genuinely stale human:approved issue whose scope shipped under another T-NNN: observe fleet-queue-ingest log showing "scope-shipped: skipped 1 issue(s)" and no LLM spawn

## Note on role-queue-manager.md
The interactive mode role doc (`.claude/commands/role-queue-manager.md`) ideally would reference the scope check at step 5, but the self-modification permission gate blocks editing `.claude/commands/` files in a worktree. The `_ALREADY_QUEUED_LABELS` addition achieves the same effect at the state-cache layer — scope-shipped issues never appear in `state.json`'s `human_approved[]` list regardless of the role doc content. A human-triggered follow-up iteration can add the belt-and-suspenders note to the role doc if desired.

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)