### PR TITLE
T-379: system: bulk PARALLEL_FOR migration of trivially-safe prefab systems

### DIFF
--- a/engine/prefabs/irreden/common/systems/system_global_modifier_decay.hpp
+++ b/engine/prefabs/irreden/common/systems/system_global_modifier_decay.hpp
@@ -16,34 +16,37 @@
 namespace IRSystem {
 
 template <> struct System<GLOBAL_MODIFIER_DECAY> {
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    void tick(IRComponents::C_GlobalModifiers &g) {
+        auto &v = g.modifiers_;
+        auto newEnd = std::remove_if(
+            v.begin(),
+            v.end(),
+            IRComponents::detail::tickAndExpired<IRComponents::Modifier>
+        );
+        v.erase(newEnd, v.end());
+
+        auto &v3 = g.modifiersVec3_;
+        auto newEnd3 = std::remove_if(
+            v3.begin(),
+            v3.end(),
+            IRComponents::detail::tickAndExpired<IRComponents::ModifierVec3>
+        );
+        v3.erase(newEnd3, v3.end());
+
+        auto &vq = g.modifiersQuat_;
+        auto newEndQ = std::remove_if(
+            vq.begin(),
+            vq.end(),
+            IRComponents::detail::tickAndExpired<IRComponents::ModifierQuat>
+        );
+        vq.erase(newEndQ, vq.end());
+    }
+
     static SystemId create() {
-        return createSystem<IRComponents::C_GlobalModifiers>(
-            "GlobalModifierDecay",
-            [](IRComponents::C_GlobalModifiers &g) {
-                auto &v = g.modifiers_;
-                auto newEnd = std::remove_if(
-                    v.begin(),
-                    v.end(),
-                    IRComponents::detail::tickAndExpired<IRComponents::Modifier>
-                );
-                v.erase(newEnd, v.end());
-
-                auto &v3 = g.modifiersVec3_;
-                auto newEnd3 = std::remove_if(
-                    v3.begin(),
-                    v3.end(),
-                    IRComponents::detail::tickAndExpired<IRComponents::ModifierVec3>
-                );
-                v3.erase(newEnd3, v3.end());
-
-                auto &vq = g.modifiersQuat_;
-                auto newEndQ = std::remove_if(
-                    vq.begin(),
-                    vq.end(),
-                    IRComponents::detail::tickAndExpired<IRComponents::ModifierQuat>
-                );
-                vq.erase(newEndQ, vq.end());
-            }
+        return registerSystem<GLOBAL_MODIFIER_DECAY, IRComponents::C_GlobalModifiers>(
+            "GlobalModifierDecay"
         );
     }
 };

--- a/engine/prefabs/irreden/common/systems/system_modifier_decay.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_decay.hpp
@@ -20,35 +20,36 @@
 namespace IRSystem {
 
 template <> struct System<MODIFIER_DECAY> {
-    static SystemId create() {
-        return createSystem<IRComponents::C_Modifiers>(
-            "ModifierDecay",
-            [](IRComponents::C_Modifiers &m) {
-                auto &v = m.modifiers_;
-                auto newEnd = std::remove_if(
-                    v.begin(),
-                    v.end(),
-                    IRComponents::detail::tickAndExpired<IRComponents::Modifier>
-                );
-                v.erase(newEnd, v.end());
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
 
-                auto &v3 = m.modifiersVec3_;
-                auto newEnd3 = std::remove_if(
-                    v3.begin(),
-                    v3.end(),
-                    IRComponents::detail::tickAndExpired<IRComponents::ModifierVec3>
-                );
-                v3.erase(newEnd3, v3.end());
-
-                auto &vq = m.modifiersQuat_;
-                auto newEndQ = std::remove_if(
-                    vq.begin(),
-                    vq.end(),
-                    IRComponents::detail::tickAndExpired<IRComponents::ModifierQuat>
-                );
-                vq.erase(newEndQ, vq.end());
-            }
+    void tick(IRComponents::C_Modifiers &m) {
+        auto &v = m.modifiers_;
+        auto newEnd = std::remove_if(
+            v.begin(),
+            v.end(),
+            IRComponents::detail::tickAndExpired<IRComponents::Modifier>
         );
+        v.erase(newEnd, v.end());
+
+        auto &v3 = m.modifiersVec3_;
+        auto newEnd3 = std::remove_if(
+            v3.begin(),
+            v3.end(),
+            IRComponents::detail::tickAndExpired<IRComponents::ModifierVec3>
+        );
+        v3.erase(newEnd3, v3.end());
+
+        auto &vq = m.modifiersQuat_;
+        auto newEndQ = std::remove_if(
+            vq.begin(),
+            vq.end(),
+            IRComponents::detail::tickAndExpired<IRComponents::ModifierQuat>
+        );
+        vq.erase(newEndQ, vq.end());
+    }
+
+    static SystemId create() {
+        return registerSystem<MODIFIER_DECAY, IRComponents::C_Modifiers>("ModifierDecay");
     }
 };
 

--- a/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
+++ b/engine/prefabs/irreden/common/systems/system_modifier_resolve_exempt.hpp
@@ -19,38 +19,39 @@
 namespace IRSystem {
 
 template <> struct System<MODIFIER_RESOLVE_EXEMPT> {
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    void tick(
+        IRComponents::C_Modifiers &m,
+        IRComponents::C_ResolvedFields &resolved,
+        [[maybe_unused]] IRComponents::C_NoGlobalModifiers &
+    ) {
+        for (auto &rf : resolved.fields_) {
+            rf.value_ =
+                IRPrefab::Modifier::detail::composeForField(rf.value_, rf.field_, m.modifiers_);
+        }
+        for (auto &rf : resolved.fieldsVec3_) {
+            rf.value_ = IRPrefab::Modifier::detail::composeForFieldVec3(
+                rf.value_,
+                rf.field_,
+                m.modifiersVec3_
+            );
+        }
+        for (auto &rf : resolved.fieldsQuat_) {
+            rf.value_ = IRPrefab::Modifier::detail::composeForFieldQuat(
+                rf.value_,
+                rf.field_,
+                m.modifiersQuat_
+            );
+        }
+    }
+
     static SystemId create() {
-        return createSystem<
+        return registerSystem<
+            MODIFIER_RESOLVE_EXEMPT,
             IRComponents::C_Modifiers,
             IRComponents::C_ResolvedFields,
-            IRComponents::C_NoGlobalModifiers>(
-            "ModifierResolveExempt",
-            [](IRComponents::C_Modifiers &m,
-               IRComponents::C_ResolvedFields &resolved,
-               [[maybe_unused]] IRComponents::C_NoGlobalModifiers &) {
-                for (auto &rf : resolved.fields_) {
-                    rf.value_ = IRPrefab::Modifier::detail::composeForField(
-                        rf.value_,
-                        rf.field_,
-                        m.modifiers_
-                    );
-                }
-                for (auto &rf : resolved.fieldsVec3_) {
-                    rf.value_ = IRPrefab::Modifier::detail::composeForFieldVec3(
-                        rf.value_,
-                        rf.field_,
-                        m.modifiersVec3_
-                    );
-                }
-                for (auto &rf : resolved.fieldsQuat_) {
-                    rf.value_ = IRPrefab::Modifier::detail::composeForFieldQuat(
-                        rf.value_,
-                        rf.field_,
-                        m.modifiersQuat_
-                    );
-                }
-            }
-        );
+            IRComponents::C_NoGlobalModifiers>("ModifierResolveExempt");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_render_velocity_2d_iso.hpp
+++ b/engine/prefabs/irreden/render/systems/system_render_velocity_2d_iso.hpp
@@ -13,14 +13,17 @@ using namespace IRComponents;
 namespace IRSystem {
 
 template <> struct System<RENDERING_VELOCITY_2D_ISO> {
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    void tick(C_Position2DIso &position, const C_Velocity2DIso &velocity) {
+        position.pos_ += velocity.velocity_ *
+                         // TODO: Delta time based on event registered in pipeline
+                         vec2(IRTime::deltaTime(IRTime::RENDER));
+    }
+
     static SystemId create() {
-        return createSystem<C_Position2DIso, C_Velocity2DIso>(
-            "Camera",
-            [](C_Position2DIso &position, const C_Velocity2DIso &velocity) {
-                position.pos_ += velocity.velocity_ *
-                                 // TODO: Delta time based on event registered in pipeline
-                                 vec2(IRTime::deltaTime(IRTime::RENDER));
-            }
+        return registerSystem<RENDERING_VELOCITY_2D_ISO, C_Position2DIso, C_Velocity2DIso>(
+            "Camera"
         );
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_texture_scroll.hpp
+++ b/engine/prefabs/irreden/render/systems/system_texture_scroll.hpp
@@ -12,20 +12,25 @@ using namespace IRMath;
 namespace IRSystem {
 
 template <> struct System<TEXTURE_SCROLL> {
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    void tick(
+        C_TextureScrollPosition &textureScrollPosition,
+        const C_TextureScrollVelocity &textureScrollVelocity
+    ) {
+        vec2 textureStepThisFrame = vec2(
+            textureScrollVelocity.velocity_.x *
+                // IDEA: deltaTime should know what event based
+                // on some higher level pipeline thing
+                IRTime::deltaTime(IRTime::Events::RENDER),
+            textureScrollVelocity.velocity_.y * IRTime::deltaTime(IRTime::Events::RENDER)
+        );
+        textureScrollPosition.position_ += textureStepThisFrame;
+    }
+
     static SystemId create() {
-        return createSystem<C_TextureScrollPosition, C_TextureScrollVelocity>(
-            "TextureScroll",
-            [](C_TextureScrollPosition &textureScrollPosition,
-               const C_TextureScrollVelocity &textureScrollVelocity) {
-                vec2 textureStepThisFrame = vec2(
-                    textureScrollVelocity.velocity_.x *
-                        // IDEA: deltaTime should know what event based
-                        // on some higher level pipeline thing
-                        IRTime::deltaTime(IRTime::Events::RENDER),
-                    textureScrollVelocity.velocity_.y * IRTime::deltaTime(IRTime::Events::RENDER)
-                );
-                textureScrollPosition.position_ += textureStepThisFrame;
-            }
+        return registerSystem<TEXTURE_SCROLL, C_TextureScrollPosition, C_TextureScrollVelocity>(
+            "TextureScroll"
         );
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_widget_apply_slider.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_apply_slider.hpp
@@ -14,12 +14,15 @@ namespace IRSystem {
 // doesn't have to call `getComponent<C_WidgetSlider>` from inside a
 // per-entity tick.
 template <> struct System<WIDGET_APPLY_SLIDER> {
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
     void tick(
         const IRComponents::C_Widget &widget,
         const IRComponents::C_WidgetState &state,
         IRComponents::C_WidgetSlider &slider
     ) {
-        if (!state.pressed_) return;
+        if (!state.pressed_)
+            return;
         slider.currentValue_ =
             slider.minValue_ + state.dragValue_ * (slider.maxValue_ - slider.minValue_);
     }
@@ -29,8 +32,7 @@ template <> struct System<WIDGET_APPLY_SLIDER> {
             WIDGET_APPLY_SLIDER,
             IRComponents::C_Widget,
             IRComponents::C_WidgetState,
-            IRComponents::C_WidgetSlider
-        >("WidgetApplySlider");
+            IRComponents::C_WidgetSlider>("WidgetApplySlider");
     }
 };
 

--- a/engine/prefabs/irreden/update/systems/system_acceleration.hpp
+++ b/engine/prefabs/irreden/update/systems/system_acceleration.hpp
@@ -11,14 +11,14 @@ using namespace IRComponents;
 namespace IRSystem {
 
 template <> struct System<ACCELERATION_3D> {
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    void tick(C_Velocity3D &velocity, const C_Acceleration3D &acceleration) {
+        velocity.velocity_ += acceleration.acceleration_ * vec3(IRTime::deltaTime(IRTime::UPDATE));
+    }
+
     static SystemId create() {
-        return createSystem<C_Velocity3D, C_Acceleration3D>(
-            "Acceleration3D",
-            [](C_Velocity3D &velocity, const C_Acceleration3D &acceleration) {
-                velocity.velocity_ +=
-                    acceleration.acceleration_ * vec3(IRTime::deltaTime(IRTime::UPDATE));
-            }
-        );
+        return registerSystem<ACCELERATION_3D, C_Velocity3D, C_Acceleration3D>("Acceleration3D");
     }
 };
 

--- a/engine/prefabs/irreden/update/systems/system_goto_3d.hpp
+++ b/engine/prefabs/irreden/update/systems/system_goto_3d.hpp
@@ -10,26 +10,29 @@ using namespace IRComponents;
 namespace IRSystem {
 
 template <> struct System<GOTO_3D> {
-    static SystemId create() {
-        return createSystem<C_LocalTransform, C_GotoEasing3D>(
-            "Goto3D",
-            [](C_LocalTransform &localXform, C_GotoEasing3D &gotoComp) {
-                if (gotoComp.done_)
-                    return;
-                gotoComp.currentFrame_++;
-                localXform.translation_ = IRMath::mix(
-                    gotoComp.startPos_,
-                    gotoComp.endPos_,
-                    gotoComp.easingFunction_(
-                        static_cast<float>(gotoComp.currentFrame_) /
-                        static_cast<float>(gotoComp.durationFrames_)
-                    )
-                );
-                if (gotoComp.currentFrame_ >= gotoComp.durationFrames_) {
-                    gotoComp.done_ = true;
-                }
-            }
+    // kEasingFunctions is a const global map of stateless lambdas — safe to
+    // call from multiple threads simultaneously.
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    void tick(C_LocalTransform &localXform, C_GotoEasing3D &gotoComp) {
+        if (gotoComp.done_)
+            return;
+        gotoComp.currentFrame_++;
+        localXform.translation_ = IRMath::mix(
+            gotoComp.startPos_,
+            gotoComp.endPos_,
+            gotoComp.easingFunction_(
+                static_cast<float>(gotoComp.currentFrame_) /
+                static_cast<float>(gotoComp.durationFrames_)
+            )
         );
+        if (gotoComp.currentFrame_ >= gotoComp.durationFrames_) {
+            gotoComp.done_ = true;
+        }
+    }
+
+    static SystemId create() {
+        return registerSystem<GOTO_3D, C_LocalTransform, C_GotoEasing3D>("Goto3D");
     }
 };
 

--- a/engine/prefabs/irreden/update/systems/system_periodic_idle.hpp
+++ b/engine/prefabs/irreden/update/systems/system_periodic_idle.hpp
@@ -10,10 +10,14 @@ using namespace IRComponents;
 namespace IRSystem {
 
 template <> struct System<PERIODIC_IDLE> {
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    void tick(C_PeriodicIdle &periodicIdle) {
+        periodicIdle.tick();
+    }
+
     static SystemId create() {
-        return createSystem<C_PeriodicIdle>("PeriodicIdle", [](C_PeriodicIdle &periodicIdle) {
-            periodicIdle.tick();
-        });
+        return registerSystem<PERIODIC_IDLE, C_PeriodicIdle>("PeriodicIdle");
     }
 };
 

--- a/engine/prefabs/irreden/update/systems/system_reactive_return_3d.hpp
+++ b/engine/prefabs/irreden/update/systems/system_reactive_return_3d.hpp
@@ -15,54 +15,62 @@ using namespace IRMath;
 namespace IRSystem {
 
 template <> struct System<REACTIVE_RETURN_3D> {
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    void tick(
+        C_LocalTransform &localXform,
+        C_Velocity3D &velocity,
+        const C_ContactEvent &contact,
+        C_ReactiveReturn3D &reactive
+    ) {
+        float dt = IRTime::deltaTime(IRTime::UPDATE);
+
+        if (!reactive.originInitialized_) {
+            reactive.origin_ = localXform.translation_;
+            reactive.previousError_ = reactive.origin_ - localXform.translation_;
+            reactive.originInitialized_ = true;
+        }
+
+        if (reactive.triggerOnContactEnter_ && contact.entered_) {
+            velocity.velocity_ += reactive.triggerImpulseVelocity_;
+            reactive.active_ = true;
+        }
+
+        if (!reactive.active_) {
+            return;
+        }
+
+        vec3 error = reactive.origin_ - localXform.translation_;
+        float errorLen = IRMath::length(error);
+        float speedLen = IRMath::length(velocity.velocity_);
+
+        if (IRMath::dot(error, reactive.previousError_) < 0.0f) {
+            reactive.reboundCount_++;
+        }
+        reactive.previousError_ = error;
+
+        if (reactive.reboundCount_ >= reactive.maxRebounds_ &&
+            errorLen <= reactive.settleDistance_ && speedLen <= reactive.settleSpeed_) {
+            localXform.translation_ = reactive.origin_;
+            velocity.velocity_ = vec3(0.0f);
+            reactive.active_ = false;
+            reactive.reboundCount_ = 0;
+            reactive.previousError_ = vec3(0.0f);
+            return;
+        }
+
+        velocity.velocity_ += error * (reactive.springStrength_ * dt);
+        float damp = IRMath::max(0.0f, 1.0f - reactive.dampingPerSecond_ * dt);
+        velocity.velocity_ *= damp;
+    }
+
     static SystemId create() {
-        return createSystem<C_LocalTransform, C_Velocity3D, C_ContactEvent, C_ReactiveReturn3D>(
-            "ReactiveReturn3D",
-            [](C_LocalTransform &localXform,
-               C_Velocity3D &velocity,
-               const C_ContactEvent &contact,
-               C_ReactiveReturn3D &reactive) {
-                float dt = IRTime::deltaTime(IRTime::UPDATE);
-
-                if (!reactive.originInitialized_) {
-                    reactive.origin_ = localXform.translation_;
-                    reactive.previousError_ = reactive.origin_ - localXform.translation_;
-                    reactive.originInitialized_ = true;
-                }
-
-                if (reactive.triggerOnContactEnter_ && contact.entered_) {
-                    velocity.velocity_ += reactive.triggerImpulseVelocity_;
-                    reactive.active_ = true;
-                }
-
-                if (!reactive.active_) {
-                    return;
-                }
-
-                vec3 error = reactive.origin_ - localXform.translation_;
-                float errorLen = IRMath::length(error);
-                float speedLen = IRMath::length(velocity.velocity_);
-
-                if (IRMath::dot(error, reactive.previousError_) < 0.0f) {
-                    reactive.reboundCount_++;
-                }
-                reactive.previousError_ = error;
-
-                if (reactive.reboundCount_ >= reactive.maxRebounds_ &&
-                    errorLen <= reactive.settleDistance_ && speedLen <= reactive.settleSpeed_) {
-                    localXform.translation_ = reactive.origin_;
-                    velocity.velocity_ = vec3(0.0f);
-                    reactive.active_ = false;
-                    reactive.reboundCount_ = 0;
-                    reactive.previousError_ = vec3(0.0f);
-                    return;
-                }
-
-                velocity.velocity_ += error * (reactive.springStrength_ * dt);
-                float damp = IRMath::max(0.0f, 1.0f - reactive.dampingPerSecond_ * dt);
-                velocity.velocity_ *= damp;
-            }
-        );
+        return registerSystem<
+            REACTIVE_RETURN_3D,
+            C_LocalTransform,
+            C_Velocity3D,
+            C_ContactEvent,
+            C_ReactiveReturn3D>("ReactiveReturn3D");
     }
 };
 

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -388,12 +388,40 @@ serialize on the main thread regardless of policy.
 The first system to opt in is `VELOCITY_3D` (T-222 POC). T-328
 completed the other two POC ports from #1069: `VELOCITY_DRAG` is now
 `PARALLEL_FOR` (per-thread `IRMath::randomFloat` makes its
-`postHoverVelocity` reset path thread-safe); `ANIMATION_COLOR` stays
-`SERIAL` with `IR_ASSERT_MAIN_THREAD` because the tick reads the
-active clip's components through `IREntity::getComponentOptional` on
-a foreign entity id, and the entity manager is not yet thread-safe
-(T-225 owns the deferred-mutation surface). Re-evaluate the
-`ANIMATION_COLOR` opt-in after T-225 lands.
+`postHoverVelocity` reset path thread-safe). T-379 bulk-migrated 10
+trivially-safe prefab systems:
+
+**`PARALLEL_FOR` (active as of T-379):**
+
+| System | Domain |
+|---|---|
+| `VELOCITY_3D` | update |
+| `VELOCITY_DRAG` | update |
+| `ACCELERATION_3D` | update |
+| `PERIODIC_IDLE` | update |
+| `GOTO_3D` | update |
+| `REACTIVE_RETURN_3D` | update |
+| `MODIFIER_DECAY` | common |
+| `GLOBAL_MODIFIER_DECAY` | common |
+| `MODIFIER_RESOLVE_EXEMPT` | common |
+| `RENDERING_VELOCITY_2D_ISO` | render |
+| `TEXTURE_SCROLL` | render |
+| `WIDGET_APPLY_SLIDER` | render |
+
+**Kept `SERIAL` (with rationale):**
+
+- `ANIMATION_COLOR` — tick reads the active clip via
+  `IREntity::getComponentOptional` on a foreign entity id; the entity
+  manager is not thread-safe from workers. Re-evaluate after T-225.
+- `MODIFIER_LAMBDA_DECAY` — erasing `C_LambdaModifiers` entries calls
+  `sol::function`'s destructor which calls `lua_unref` into `LuaScript`
+  state; sol2 is not thread-safe.
+- `MODIFIER_RESOLVE_GLOBAL` — reads global modifier state via a
+  function-local static singleton (known `cpp-systems.md` violation);
+  the global pointer access is not worker-safe until the static is
+  migrated to `SystemParams`.
+- `GRAVITY_3D` — function-local static singleton instance (same
+  violation; migrate together with `MODIFIER_RESOLVE_GLOBAL`).
 
 ### IR_ASSERT_MAIN_THREAD
 

--- a/engine/time/include/irreden/ir_time.hpp
+++ b/engine/time/include/irreden/ir_time.hpp
@@ -15,6 +15,9 @@ TimeManager &getTimeManager();
 /// UPDATE: fixed step `1.0 / IRConstants::kFPS` (`const`-after-ctor; safe to read
 /// from PARALLEL_FOR worker bodies). RENDER: actual wall-clock dt of the last tick —
 /// use only for presentation-frame interpolation, not deterministic sim state.
+/// RENDER dt is set before the RENDER pipeline executes and is immutable during the
+/// pipeline run — also safe to read from PARALLEL_FOR worker bodies within the
+/// RENDER pipeline.
 double deltaTime(Events eventType);
 /// Returns `true` when the UPDATE accumulator has buffered at least one frame period
 /// (1 / @ref IRConstants::kFPS).  Call in a `while` loop to drain catch-up ticks.


### PR DESCRIPTION
## Summary
- Converts 10 prefab systems from lambda-form `createSystem<>` to member-on-`System<N>` with `registerSystem<>` and `static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR`
- Each system was audited for thread-safety before migration; all 10 operate solely on per-entity component fields with no shared mutable state
- Documents which systems were kept `SERIAL` and why (foreign entity lookup, sol2 thread-safety, function-local static violations)

**Migrated:** `ACCELERATION_3D`, `PERIODIC_IDLE`, `GOTO_3D`, `REACTIVE_RETURN_3D`, `MODIFIER_DECAY`, `GLOBAL_MODIFIER_DECAY`, `MODIFIER_RESOLVE_EXEMPT`, `RENDERING_VELOCITY_2D_ISO`, `TEXTURE_SCROLL`, `WIDGET_APPLY_SLIDER`

**Left SERIAL:** `ANIMATION_COLOR` (T-225 dependency), `MODIFIER_LAMBDA_DECAY` (sol2 thread-safety), `MODIFIER_RESOLVE_GLOBAL` + `GRAVITY_3D` (function-local static, see `cpp-systems.md` deviations list)

## Test plan
- [x] `IrredenEngineTest` builds clean (968/968 tests pass)
- [x] `IRShapeDebug --auto-screenshot 10` completes all 7 shots with no visual regression
- [x] `format-changed` applied; rebuilt and still clean
- [x] `engine/system/CLAUDE.md` updated with full PARALLEL_FOR / SERIAL table and rationale

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)