### PR TITLE
render: restore unconditional per-frame distance-texture clear

### DIFF
--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
@@ -152,6 +152,15 @@ struct C_TriangleCanvasTextures {
                (static_cast<IREntity::EntityId>(packed.y) << 32);
     }
 
+    void clearDistances() const {
+        textureTriangleDistances_.second
+            ->clear(
+                PixelDataFormat::RED_INTEGER,
+                PixelDataType::INT32,
+                &ivec1(IRConstants::kTrixelDistanceMaxDistance)[0]
+            );
+    }
+
     void saveAsPNG() {}
 
   private:

--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
@@ -164,6 +164,18 @@ struct C_TriangleCanvasTextures {
     void saveAsPNG() {}
 
   private:
+    // Clears to kTrixelDistanceMaxDistance - 1 (= 65534) rather than
+    // kTrixelDistanceMaxDistance (= 65535). This predates the introduction of
+    // the public clearDistances() helper; the shader's "empty pixel" sentinel
+    // is 65535, so this value is one step below the canonical empty state.
+    //
+    // When invoked via clearCanvasWithBackground() → clearCanvasAndDistances(),
+    // the 65534 value is immediately overwritten by the unconditional
+    // canvas.clearDistances() call at the end of clearCanvasAndDistances(),
+    // which restores kTrixelDistanceMaxDistance (65535) on every frame. The
+    // redundant GPU clear here is negligible in cost but retained for correctness
+    // on call-sites (e.g. entity_trixel_canvas.hpp) that invoke clearWithColor()
+    // or clearWithColorData() without a subsequent clearDistances().
     void clearDistanceTexture() const {
         textureTriangleDistances_.second
             ->clear(

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -124,6 +124,11 @@ clearCanvasAndDistances(IREntity::EntityId canvasEntity, C_TriangleCanvasTexture
     } else {
         canvas.clear();
     }
+    // Distance buffer must be reset every frame regardless of whether the
+    // background updated the color canvas. clearCanvasWithBackground may
+    // skip on throttled frames (kPulsePattern) or no-op (kGradient), but
+    // the voxel-to-trixel pass writes per-pixel distances each frame.
+    canvas.clearDistances();
 }
 
 inline void syncEntityIds(C_VoxelPool &pool, int liveCount, Buffer *entityIdBuf) {


### PR DESCRIPTION
## Summary

- Fixes a visual regression introduced by e05f24f0 (PR #1174, T-352) where shapes and voxels are missing on Metal builds (and likely affected OpenGL too in edge cases).
- The commit removed an explicit `device->clearTexImage()` on the distance buffer in `clearCanvasAndDistances()`, assuming it was redundant with `canvas.clear()` / `clearCanvasWithBackground()`. It wasn't — two paths skip the distance clear:
  1. **`kGradient` backgrounds** — total no-op, nothing cleared at all.
  2. **`kPulsePattern` on throttled frames** — early return when `timeSincePulseUpdate < minPulseUpdateSeconds` skips all clears.
- Without per-frame distance reset to `kTrixelDistanceMaxDistance`, stale distances from prior frames block new voxels from passing the occlusion test, causing shapes to disappear.

## Fix

- Added public `clearDistances()` on `C_TriangleCanvasTextures` (uses `kTrixelDistanceMaxDistance`, matching `clear()`).
- Called unconditionally at the end of `clearCanvasAndDistances()`, after the background/canvas-specific clear. On paths that already clear distances internally, the extra clear is redundant but harmless (~one `clearTexImage` per frame per canvas).

## Test plan

- [ ] `IRLightingSunOrbit` — shapes visible and occluding correctly (was the reported regression demo)
- [ ] `IRShapeDebug` — all test shapes render
- [ ] Any demo with a `kPulsePattern` or `kGradient` background — verify shapes don't disappear on throttled frames
- [ ] `IrredenEngineTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)