### PR TITLE
T-381: fleet: scout reads issues instead of TASKS.md, eliminate queue-tick maintenance sync

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -526,9 +526,12 @@ PYEOF
 
 check_model_tag() {
     # Refuse the claim if the calling role's model doesn't match the task's
-    # Model: field in TASKS.md. Gate is opt-in — no-op when:
+    # model affinity. Checks fleet:opus / fleet:sonnet labels on the linked
+    # issue (T-381), falling back to **Model:** in the issue body, then to
+    # TASKS.md as a last resort.
+    # Gate is opt-in — no-op when:
     #   • FLEET_ROLE_MODEL is unset or empty (manual / ad-hoc claim)
-    #   • task has no Model: field in TASKS.md
+    #   • task has no model tag anywhere
     # Exits non-zero on mismatch; caller should return 1.
     local task_id="$1"
     local role_model="${FLEET_ROLE_MODEL:-}"
@@ -537,6 +540,44 @@ check_model_tag() {
         return 0
     fi
 
+    # Try issue-based model check first (T-381). fleet:opus / fleet:sonnet
+    # label wins; body's **Model:** field is the fallback. One gh call fetches
+    # both so the gate stays at one round-trip per claim.
+    local issue_num repo
+    issue_num=$(get_task_issue "$task_id" 2>/dev/null || echo "")
+    repo=$(repo_from_ns)
+    if [[ -n "$issue_num" && -n "$repo" ]] && command -v gh >/dev/null 2>&1; then
+        local issue_json task_model=""
+        issue_json=$(gh issue view "$issue_num" --repo "$repo" \
+            --json labels,body 2>/dev/null || echo "")
+        if [[ -n "$issue_json" ]]; then
+            if echo "$issue_json" | grep -q '"name":"fleet:opus"'; then
+                task_model="opus"
+            elif echo "$issue_json" | grep -q '"name":"fleet:sonnet"'; then
+                task_model="sonnet"
+            else
+                task_model=$(echo "$issue_json" \
+                    | python3 -c '
+import json, re, sys
+try:
+    body = json.load(sys.stdin).get("body", "") or ""
+except Exception:
+    body = ""
+m = re.search(r"\*\*Model:\*\*\s*(\S+)", body)
+print((m.group(1) if m else "").lower())
+' 2>/dev/null || echo "")
+            fi
+            if [[ -n "$task_model" ]]; then
+                if [[ "$task_model" != "$role_model" ]]; then
+                    echo "fleet-claim: refuse $task_id — tagged [$task_model], this role is [$role_model]; use a [$task_model] agent" >&2
+                    return 1
+                fi
+                return 0
+            fi
+        fi
+    fi
+
+    # Last resort: fall back to TASKS.md (transitional — T-382 removes).
     local tasks_file=""
     local repo_root
     repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -434,7 +434,7 @@ def fetch_task_queue(repo_slug, repo_root):
         else:
             sections["open"].append(task)
 
-    for key in sections:
+    for key in ("open", "in_progress"):
         sections[key].sort(
             key=lambda t: int((t.get("issue") or "#0").lstrip("#"))
         )

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -256,67 +256,222 @@ def fetch_recent_merged_prs(repo, limit=30):
     return prs
 
 
-TASK_HEADER_RE = re.compile(r"^- \[([ ~x!])\] \*\*(.+?)\*\*\s*(?:—\s*(.*))?$")
-TASK_FIELD_RE = re.compile(r"^\s+- \*\*([^:]+?):\*\*\s*(.+?)\s*$")
-SECTION_RE = re.compile(r"^##\s+(.+?)\s*$")
-KNOWN_FIELDS = {"id", "model", "owner", "area", "blocked_by", "issue"}
+# --- Issue-based task queue (T-381) ----------------------------------------
+#
+# The task queue is sourced from GitHub Issues with the fleet:queued label.
+# Model, blocked-by, and area are parsed from issue bodies and labels.
+# T-NNN IDs are mapped from TASKS.md during the transition period; T-382
+# will eliminate this mapping entirely.
+
+_AREA_LABEL_MAP = {
+    "IRRender": "engine/render",
+    "IREngine": "engine",
+    "IRSystem": "engine/system",
+    "IRAsset": "engine/asset",
+    "IRMath": "engine/math",
+}
 
 
-def parse_tasks_md(text):
-    sections = {"open": [], "in_progress": [], "done": []}
-    if not text:
-        return sections
+def _parse_issue_field(body, field):
+    if not body:
+        return ""
+    m = re.search(rf'\*\*{re.escape(field)}:\*\*\s*(.+?)(?:\n|$)', body)
+    return m.group(1).strip() if m else ""
 
-    section_key = None
-    current_task = None
-    for line in text.splitlines():
-        section_match = SECTION_RE.match(line)
-        if section_match:
-            label = section_match.group(1).strip().lower()
-            if label.startswith("open"):
-                section_key = "open"
-            elif label.startswith("in progress"):
-                section_key = "in_progress"
-            elif label.startswith("done"):
-                section_key = "done"
-            else:
-                section_key = None
-            current_task = None
-            continue
-        if section_key is None:
-            continue
 
-        header_match = TASK_HEADER_RE.match(line)
-        if header_match:
-            current_task = {
-                "status": header_match.group(1),
-                "title": header_match.group(2),
-                "summary": (header_match.group(3) or "").strip(),
-                "id": None, "model": None, "owner": None,
-                "area": None, "blocked_by": None, "issue": None,
+def _build_task_id_map(tasks_md_text):
+    """Build issue# → {id, model, blocked_by} mapping from TASKS.md (transitional).
+
+    Returns dict keyed by issue number: {1214: {"id": "T-380", "model": "opus", "blocked_by": "T-379"}, ...}
+    """
+    issue_map = {}
+    current_id = None
+    current_issue = None
+    current_model = None
+    current_blocked = None
+    def flush():
+        nonlocal current_id, current_issue, current_model, current_blocked
+        if current_id and current_issue:
+            issue_map[current_issue] = {
+                "id": current_id,
+                "model": current_model,
+                "blocked_by": current_blocked,
             }
-            sections[section_key].append(current_task)
+        current_id = current_issue = current_model = current_blocked = None
+    for line in (tasks_md_text or "").splitlines():
+        if re.match(r"^- \[.\] \*\*.+\*\*", line):
+            flush()
             continue
+        m = re.match(r"^\s+- \*\*ID:\*\*\s*(.+)", line)
+        if m:
+            current_id = m.group(1).strip()
+            continue
+        m = re.match(r"^\s+- \*\*Issue:\*\*\s*#(\d+)", line)
+        if m:
+            current_issue = int(m.group(1))
+            continue
+        m = re.match(r"^\s+- \*\*Model:\*\*\s*(.+)", line)
+        if m:
+            current_model = m.group(1).strip().lower()
+            continue
+        m = re.match(r"^\s+- \*\*Blocked by:\*\*\s*(.+)", line)
+        if m:
+            current_blocked = m.group(1).strip()
+    flush()
+    return issue_map
 
-        if current_task is not None:
-            field_match = TASK_FIELD_RE.match(line)
-            if field_match:
-                key = field_match.group(1).strip().lower().replace(" ", "_")
-                if key in KNOWN_FIELDS:
-                    current_task[key] = field_match.group(2).strip()
+
+def _convert_blocked_by(raw_blocked, issue_to_id):
+    """Convert #NNN blocked-by references to T-NNN using the mapping."""
+    if not raw_blocked or raw_blocked in ("(none)", "—"):
+        return "(none)"
+    parts = []
+    for part in raw_blocked.split(","):
+        part = part.strip()
+        m = re.match(r"#(\d+)", part)
+        if m:
+            parts.append(issue_to_id.get(int(m.group(1))) or part)
+        else:
+            parts.append(part)
+    return ", ".join(parts)
+
+
+def fetch_task_queue(repo_slug, repo_root):
+    """Fetch open task queue from GitHub Issues + TASKS.md ID mapping."""
+    issues_out = run_capture([
+        "gh", "issue", "list",
+        "--repo", repo_slug,
+        "--label", "fleet:queued",
+        "--state", "open",
+        "--json", "number,title,labels,body",
+        "--limit", "200",
+    ])
+
+    tasks_md = run_capture(
+        ["git", "-C", str(repo_root), "show", "origin/master:TASKS.md"]
+    )
+    issue_map = _build_task_id_map(tasks_md)
+
+    if not issues_out:
+        return {"open": [], "in_progress": [], "done": []}
+
+    try:
+        issues = json.loads(issues_out)
+    except json.JSONDecodeError as e:
+        log(f"fetch_task_queue {repo_slug}: bad JSON: {e}")
+        return {"open": [], "in_progress": [], "done": []}
+
+    sections = {"open": [], "in_progress": [], "done": []}
+
+    for issue in issues:
+        raw_labels = issue.get("labels", [])
+        labels = {
+            (l["name"] if isinstance(l, dict) else l)
+            for l in raw_labels
+        }
+        body = issue.get("body", "") or ""
+        title = issue.get("title", "")
+        number = issue.get("number", 0)
+
+        md_entry = issue_map.get(number, {})
+        task_id = md_entry.get("id")
+
+        if "fleet:opus" in labels:
+            model = "opus"
+        elif "fleet:sonnet" in labels:
+            model = "sonnet"
+        else:
+            model = (
+                _parse_issue_field(body, "Model")
+                or md_entry.get("model")
+                or None
+            )
+
+        # Claim labels are `fleet:claim-<host>-<agent>`; agent half is what
+        # roles see in `fleet-claim list`.
+        owner = "free"
+        for l in labels:
+            if l.startswith("fleet:claim-"):
+                suffix = l[len("fleet:claim-"):]
+                _, _, agent = suffix.partition("-")
+                owner = agent or suffix
+                break
+
+        in_progress = "fleet:in-progress" in labels or owner != "free"
+        status = "~" if in_progress else " "
+
+        raw_blocked = _parse_issue_field(body, "Blocked by")
+        if raw_blocked:
+            issue_to_id_simple = {
+                num: entry.get("id") for num, entry in issue_map.items()
+                if entry.get("id")
+            }
+            blocked_by = _convert_blocked_by(raw_blocked, issue_to_id_simple)
+        else:
+            blocked_by = md_entry.get("blocked_by") or "(none)"
+
+        area_parts = [_AREA_LABEL_MAP[l] for l in labels if l in _AREA_LABEL_MAP]
+        area = (
+            ", ".join(sorted(area_parts))
+            if area_parts
+            else _parse_issue_field(body, "Area") or None
+        )
+
+        task = {
+            "status": status,
+            "title": task_id or title,
+            "summary": title,
+            "id": task_id,
+            "model": model,
+            "owner": owner,
+            "area": area,
+            "blocked_by": blocked_by,
+            "issue": f"#{number}",
+        }
+
+        if status == "~":
+            sections["in_progress"].append(task)
+        else:
+            sections["open"].append(task)
+
+    for key in sections:
+        sections[key].sort(
+            key=lambda t: int((t.get("issue") or "#0").lstrip("#"))
+        )
+
+    sections["_issue_map"] = issue_map
     return sections
 
 
-def fetch_tasks(repo_root):
-    out = run_capture(["git", "-C", str(repo_root), "show", "origin/master:TASKS.md"])
-    return parse_tasks_md(out or "")
+def _populate_tasks_done(repo_state, issue_map):
+    """Convert closed_fleet_queued entries to tasks.done format."""
+    done = []
+    for issue in repo_state.get("closed_fleet_queued", []):
+        number = issue.get("number", 0)
+        title = issue.get("title", "")
+        md_entry = issue_map.get(number, {})
+        task_id = md_entry.get("id")
+        done.append({
+            "status": "x",
+            "title": task_id or title,
+            "summary": title,
+            "id": task_id,
+            "model": None,
+            "owner": None,
+            "area": None,
+            "blocked_by": None,
+            "issue": f"#{number}",
+        })
+    done.sort(key=lambda t: int((t.get("issue") or "#0").lstrip("#")))
+    return done
 
 
 # ---------------------------------------------------------------------------
 # Per-PR / per-issue detail cache
 #
 # The list-shaped state.json covers the queries every role makes at startup
-# (open PRs + their labels, issue lists, parsed TASKS.md). Per-item drill-in
+# (open PRs + their labels, issue lists, task queue from fleet:queued issues).
+# Per-item drill-in
 # (full PR body, comment timeline, inline review comments, raw diff, full
 # issue body+comments) used to be live `gh` calls fired per-role per-iteration
 # — the largest remaining token + API cost on the agent side. Scout now
@@ -799,21 +954,6 @@ def project_opus_reviewer(state):
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
-def _needs_flip_entries(repo_state):
-    # Yield (task_id, issue_num) for [~] tasks whose linked fleet:queued issue
-    # closed (PR merged) but TASKS.md hasn't been flipped to [x] yet.
-    closed_queued_nums = {
-        i["number"] for i in repo_state.get("closed_fleet_queued", [])
-    }
-    for task in repo_state.get("tasks", {}).get("open", []):
-        if task.get("status") != "~":
-            continue
-        issue_ref = task.get("issue") or ""
-        m = re.match(r"#(\d+)", issue_ref)
-        if m and int(m.group(1)) in closed_queued_nums:
-            yield task.get("id") or task.get("title"), int(m.group(1))
-
-
 def project_queue_manager(state):
     items = []
     for repo, repo_state in state["repos"].items():
@@ -826,14 +966,6 @@ def project_queue_manager(state):
         for task in repo_state.get("tasks", {}).get("done", []):
             items.append({"kind": "done", "repo": repo,
                           "id": task.get("id") or task.get("title")})
-        for task_id, issue_num in _needs_flip_entries(repo_state):
-            items.append({"kind": "needs_flip", "repo": repo,
-                          "task_id": task_id, "issue": issue_num})
-        # Recently-merged PRs feed the projection hash so a fresh merge
-        # fires queue-manager's trigger via update_role_trigger, even when
-        # the merge doesn't close a fleet:queued issue. Fixed-size window
-        # (no time filter) keeps the projection quiescent when no new PRs
-        # merge — see fetch_recent_merged_prs for rationale.
         for pr in repo_state.get("recent_merged_prs", []):
             items.append({"kind": "merged_pr", "repo": repo,
                           "pr": pr["number"],
@@ -1064,7 +1196,6 @@ def slice_queue_manager(state):
         "needs_plan": [],
         "human_approved": [],
         "tasks_done": [],
-        "needs_flip": [],
         "recent_merged_prs": [],
     }
     for repo_key, repo_state in state["repos"].items():
@@ -1074,10 +1205,6 @@ def slice_queue_manager(state):
             out["human_approved"].append(_slice_issue_with_repo(repo_key, issue))
         for task in repo_state.get("tasks", {}).get("done", []):
             out["tasks_done"].append(_slice_task_with_repo(repo_key, task))
-        for task_id, issue_num in _needs_flip_entries(repo_state):
-            out["needs_flip"].append(
-                {"repo": repo_key, "task_id": task_id, "issue": issue_num}
-            )
         for pr in repo_state.get("recent_merged_prs", []):
             out["recent_merged_prs"].append(_slice_pr_with_repo(repo_key, pr))
     return out
@@ -1180,7 +1307,7 @@ def collect_state():
             ("engine", "human_approved", lambda: fetch_human_approved("jakildev/IrredenEngine")),
             ("engine", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/IrredenEngine")),
             ("engine", "recent_merged_prs", lambda: fetch_recent_merged_prs("jakildev/IrredenEngine")),
-            ("engine", "tasks", lambda: fetch_tasks(ENGINE)),
+            ("engine", "tasks", lambda: fetch_task_queue("jakildev/IrredenEngine", ENGINE)),
         ]
     if "game" in repos:
         fetch_specs += [
@@ -1189,7 +1316,7 @@ def collect_state():
             ("game", "human_approved", lambda: fetch_human_approved("jakildev/irreden")),
             ("game", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/irreden")),
             ("game", "recent_merged_prs", lambda: fetch_recent_merged_prs("jakildev/irreden")),
-            ("game", "tasks", lambda: fetch_tasks(GAME)),
+            ("game", "tasks", lambda: fetch_task_queue("jakildev/irreden", GAME)),
         ]
 
     with ThreadPoolExecutor(max_workers=FETCH_MAX_WORKERS) as ex:
@@ -1215,8 +1342,17 @@ def collect_state():
     }
 
 
+def _populate_done_tasks(state):
+    """Populate tasks.done from closed_fleet_queued, reusing the cached ID map."""
+    for repo_key, repo_state in state["repos"].items():
+        tasks = repo_state.get("tasks", {})
+        issue_map = tasks.pop("_issue_map", {})
+        tasks["done"] = _populate_tasks_done(repo_state, issue_map)
+
+
 def tick_once():
     state = collect_state()
+    _populate_done_tasks(state)
     enrich_stackable_blocker_prs(state)
     write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
 
@@ -1233,9 +1369,9 @@ def tick_once():
             log(f"projector {role} failed: {e}")
             continue
         if role == "queue-manager":
-            # queue-manager maintenance is now script-driven.
-            # Invoke fleet-queue-tick directly on projection change instead
-            # of writing a trigger for the dispatcher to consume with an LLM.
+            # T-381: TASKS.md maintenance eliminated — scout reads issues
+            # directly. Stale-label sweep and stale-PR/epic close still run
+            # on projection change (same trigger, lighter payload).
             new_hash = stable_hash(projection)
             seen_file = SEEN_DIR / role
             try:
@@ -1244,21 +1380,28 @@ def tick_once():
                 old_hash = ""
             if new_hash != old_hash:
                 write_atomic(seen_file, new_hash + "\n")
-                try:
-                    tick_cmd = subprocess.run(
-                        ["which", "fleet-queue-tick"],
-                        capture_output=True, text=True,
-                    ).stdout.strip() or str(ENGINE / "scripts" / "fleet" / "fleet-queue-tick")
-                    subprocess.Popen(
-                        [tick_cmd],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        start_new_session=True,
+                sweep_cmds = [
+                    ["fleet-claim", "cleanup", "--gh",
+                     "--repo", "jakildev/IrredenEngine"],
+                    ["fleet-stale-sweep"],
+                ]
+                if (GAME / ".git").exists():
+                    sweep_cmds.append(
+                        ["fleet-claim", "--repo", "game", "cleanup",
+                         "--gh", "--repo", "jakildev/irreden"]
                     )
-                    log("queue-manager: spawned fleet-queue-tick (projection changed)")
-                    triggers_fired.append("queue-manager(queue-tick)")
-                except Exception as e:
-                    log(f"queue-manager: failed to spawn fleet-queue-tick: {e}")
+                for sweep_cmd in sweep_cmds:
+                    try:
+                        subprocess.Popen(
+                            sweep_cmd,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            start_new_session=True,
+                        )
+                    except Exception as e:
+                        log(f"queue-manager: sweep failed to spawn {sweep_cmd[0]}: {e}")
+                log("queue-manager: spawned stale sweeps (projection changed)")
+                triggers_fired.append("queue-manager(stale-sweep)")
         elif role == "queue-manager-ingest":
             # Auto-fire ingestion when the human:approved-and-not-yet-queued
             # set changes. Same spawn pattern as queue-tick but invokes an

--- a/scripts/fleet/tests/test_issue_queue_parser.py
+++ b/scripts/fleet/tests/test_issue_queue_parser.py
@@ -1,0 +1,212 @@
+"""Tests for the issue-based task queue parser in fleet-state-scout (T-381).
+
+Covers the pure-function helpers — _parse_issue_field, _build_task_id_map,
+_convert_blocked_by — and the label/body precedence rules inside
+fetch_task_queue's per-issue loop (model, owner, in_progress, area).
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+
+class ParseIssueField(unittest.TestCase):
+    def test_extracts_simple_value(self):
+        body = "**Model:** opus\n**Blocked by:** #1214\n"
+        self.assertEqual(_mod._parse_issue_field(body, "Model"), "opus")
+        self.assertEqual(_mod._parse_issue_field(body, "Blocked by"), "#1214")
+
+    def test_missing_field_returns_empty(self):
+        self.assertEqual(_mod._parse_issue_field("**Other:** x", "Model"), "")
+
+    def test_handles_empty_body(self):
+        self.assertEqual(_mod._parse_issue_field("", "Model"), "")
+        self.assertEqual(_mod._parse_issue_field(None, "Model"), "")
+
+    def test_stops_at_newline(self):
+        body = "**Model:** opus\nmore text\n"
+        self.assertEqual(_mod._parse_issue_field(body, "Model"), "opus")
+
+
+class BuildTaskIdMap(unittest.TestCase):
+    def test_maps_issue_to_task_id_and_fields(self):
+        md = (
+            "- [~] **fleet: scout reads issues** — summary\n"
+            "  - **ID:** T-381\n"
+            "  - **Model:** opus\n"
+            "  - **Issue:** #1215\n"
+            "  - **Blocked by:** #1214\n"
+            "- [ ] **next task**\n"
+            "  - **ID:** T-382\n"
+            "  - **Issue:** #1216\n"
+            "  - **Model:** sonnet\n"
+        )
+        m = _mod._build_task_id_map(md)
+        self.assertEqual(m[1215]["id"], "T-381")
+        self.assertEqual(m[1215]["model"], "opus")
+        self.assertEqual(m[1215]["blocked_by"], "#1214")
+        self.assertEqual(m[1216]["id"], "T-382")
+        self.assertEqual(m[1216]["model"], "sonnet")
+
+    def test_skips_entries_missing_id_or_issue(self):
+        md = (
+            "- [ ] **no id**\n"
+            "  - **Issue:** #999\n"
+            "- [ ] **no issue**\n"
+            "  - **ID:** T-099\n"
+        )
+        self.assertEqual(_mod._build_task_id_map(md), {})
+
+    def test_empty_input(self):
+        self.assertEqual(_mod._build_task_id_map(""), {})
+        self.assertEqual(_mod._build_task_id_map(None), {})
+
+
+class ConvertBlockedBy(unittest.TestCase):
+    def test_translates_issue_refs_to_task_ids(self):
+        issue_to_id = {1214: "T-380", 1215: "T-381"}
+        self.assertEqual(
+            _mod._convert_blocked_by("#1214", issue_to_id), "T-380"
+        )
+        self.assertEqual(
+            _mod._convert_blocked_by("#1214, #1215", issue_to_id),
+            "T-380, T-381",
+        )
+
+    def test_unknown_issue_passes_through(self):
+        self.assertEqual(_mod._convert_blocked_by("#9999", {}), "#9999")
+
+    def test_handles_none_and_sentinels(self):
+        self.assertEqual(_mod._convert_blocked_by("(none)", {}), "(none)")
+        self.assertEqual(_mod._convert_blocked_by("", {}), "(none)")
+        self.assertEqual(_mod._convert_blocked_by("—", {}), "(none)")
+
+    def test_preserves_non_issue_text(self):
+        self.assertEqual(
+            _mod._convert_blocked_by("free-text reason", {}),
+            "free-text reason",
+        )
+
+
+class FetchTaskQueueDispatch(unittest.TestCase):
+    """Exercise the per-issue loop with synthetic gh output.
+
+    Stubs run_capture so the test doesn't shell out to gh / git.
+    """
+    def _run(self, issues, tasks_md=""):
+        captured = []
+        def fake_run_capture(cmd, **kwargs):
+            captured.append(cmd)
+            if cmd[0] == "gh":
+                import json
+                return json.dumps(issues)
+            if cmd[0] == "git":
+                return tasks_md
+            return ""
+        original = _mod.run_capture
+        _mod.run_capture = fake_run_capture
+        try:
+            return _mod.fetch_task_queue("jakildev/IrredenEngine", _mod.ENGINE)
+        finally:
+            _mod.run_capture = original
+
+    def test_label_beats_body_for_model(self):
+        out = self._run([{
+            "number": 100, "title": "x",
+            "labels": [{"name": "fleet:queued"}, {"name": "fleet:sonnet"}],
+            "body": "**Model:** opus",
+        }])
+        self.assertEqual(out["open"][0]["model"], "sonnet")
+
+    def test_body_fallback_when_no_label(self):
+        out = self._run([{
+            "number": 100, "title": "x",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "**Model:** opus",
+        }])
+        self.assertEqual(out["open"][0]["model"], "opus")
+
+    def test_claim_label_sets_owner_and_in_progress(self):
+        out = self._run([{
+            "number": 100, "title": "x",
+            "labels": [
+                {"name": "fleet:queued"},
+                {"name": "fleet:claim-mac-opus-worker-1"},
+            ],
+            "body": "",
+        }])
+        self.assertEqual(len(out["open"]), 0)
+        self.assertEqual(len(out["in_progress"]), 1)
+        self.assertEqual(out["in_progress"][0]["owner"], "opus-worker-1")
+        self.assertEqual(out["in_progress"][0]["status"], "~")
+
+    def test_in_progress_label_alone_marks_in_progress(self):
+        out = self._run([{
+            "number": 100, "title": "x",
+            "labels": [
+                {"name": "fleet:queued"}, {"name": "fleet:in-progress"},
+            ],
+            "body": "",
+        }])
+        self.assertEqual(len(out["in_progress"]), 1)
+        self.assertEqual(out["in_progress"][0]["owner"], "free")
+
+    def test_area_from_label_map(self):
+        out = self._run([{
+            "number": 100, "title": "x",
+            "labels": [
+                {"name": "fleet:queued"}, {"name": "IRRender"},
+            ],
+            "body": "",
+        }])
+        self.assertEqual(out["open"][0]["area"], "engine/render")
+
+    def test_area_falls_back_to_body(self):
+        out = self._run([{
+            "number": 100, "title": "x",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "**Area:** docs",
+        }])
+        self.assertEqual(out["open"][0]["area"], "docs")
+
+    def test_task_id_pulled_from_tasks_md_during_transition(self):
+        md = (
+            "- [ ] **render: task**\n"
+            "  - **ID:** T-385\n"
+            "  - **Issue:** #100\n"
+        )
+        out = self._run([{
+            "number": 100, "title": "render: task",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "",
+        }], tasks_md=md)
+        self.assertEqual(out["open"][0]["id"], "T-385")
+        self.assertEqual(out["open"][0]["title"], "T-385")
+
+    def test_blocked_by_translated_via_id_map(self):
+        md = (
+            "- [ ] **a**\n  - **ID:** T-100\n  - **Issue:** #50\n"
+            "- [ ] **b**\n  - **ID:** T-200\n  - **Issue:** #100\n"
+        )
+        out = self._run([{
+            "number": 100, "title": "b",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "**Blocked by:** #50",
+        }], tasks_md=md)
+        self.assertEqual(out["open"][0]["blocked_by"], "T-100")
+
+    def test_empty_gh_output_returns_empty_sections(self):
+        out = self._run([])
+        self.assertEqual(out["open"], [])
+        self.assertEqual(out["in_progress"], [])
+        self.assertEqual(out["done"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Scout reads task queue from `gh issue list --label fleet:queued` instead of parsing `TASKS.md`.
- Per-issue parser derives model, owner, in-progress status, blocked-by, and area from labels + body, with TASKS.md fallback during the transition.
- Removes the scout's queue-manager projection-change spawn of `fleet-queue-tick`; the same trigger now fires the two stale-label sweeps.
- `fleet-claim`'s model gate consults the issue (labels first, body fallback) before reaching for TASKS.md — one `gh` round-trip per claim.
- Adds `test_issue_queue_parser.py` covering the new helpers and per-issue dispatch.

## Test plan

- [x] Existing fleet tests pass: `test_fleet_claim_model_gate.sh`, `test_enrich_stackable_blocker_prs.py`, `test_worker_projection.py`, `test_queue_manager_projection.py`, `test_merger_projection.py`, `test_stale_sweep.py`, `test_tasks_render.py`.
- [x] New `test_issue_queue_parser.py` (20 cases) green.
- [x] Manual `fleet-state-scout --once` produces a state.json with the expected open/in_progress/done split derived from issues.
- [ ] Reviewer: confirm no `queue: maintenance sync` commits land on master after this ships (acceptance #2).

## Follow-up (T-382)

- Delete `fleet-queue-tick`, `fleet-tasks-render`, and `TASKS.md`.
- Update FLEET.md / role-queue-manager / other role docs that still reference `fleet-queue-tick` / TASKS.md (~7 role docs + skills + FLEET.md, all in T-382's scope).

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)