### PR TITLE
T-384: render: restore device-level distance texture clear (viewport clipping regression)

### DIFF
--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
@@ -171,8 +171,9 @@ struct C_TriangleCanvasTextures {
     //
     // When invoked via clearCanvasWithBackground() → clearCanvasAndDistances(),
     // the 65534 value is immediately overwritten by the unconditional
-    // canvas.clearDistances() call at the end of clearCanvasAndDistances(),
-    // which restores kTrixelDistanceMaxDistance (65535) on every frame. The
+    // IRRender::device()->clearTexImage(...) call at the end of
+    // clearCanvasAndDistances(), which restores kTrixelDistanceMaxDistance
+    // (65535) on every frame. The
     // redundant GPU clear here is negligible in cost but retained for correctness
     // on call-sites (e.g. entity_trixel_canvas.hpp) that invoke clearWithColor()
     // or clearWithColorData() without a subsequent clearDistances().

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -128,7 +128,12 @@ clearCanvasAndDistances(IREntity::EntityId canvasEntity, C_TriangleCanvasTexture
     // background updated the color canvas. clearCanvasWithBackground may
     // skip on throttled frames (kPulsePattern) or no-op (kGradient), but
     // the voxel-to-trixel pass writes per-pixel distances each frame.
-    canvas.clearDistances();
+    // Use device-level clearTexImage rather than Texture2D::clear —
+    // on Metal the Texture2D::clear path fails to clear R32I textures
+    // reliably, leaving stale distances that cull visible voxels.
+    static const std::int32_t kDistanceClear =
+        static_cast<std::int32_t>(IRConstants::kTrixelDistanceMaxDistance);
+    IRRender::device()->clearTexImage(canvas.getTextureDistances(), 0, &kDistanceClear);
 }
 
 inline void syncEntityIds(C_VoxelPool &pool, int liveCount, Buffer *entityIdBuf) {

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -131,7 +131,7 @@ clearCanvasAndDistances(IREntity::EntityId canvasEntity, C_TriangleCanvasTexture
     // Use device-level clearTexImage rather than Texture2D::clear —
     // on Metal the Texture2D::clear path fails to clear R32I textures
     // reliably, leaving stale distances that cull visible voxels.
-    static const std::int32_t kDistanceClear =
+    static constexpr std::int32_t kDistanceClear =
         static_cast<std::int32_t>(IRConstants::kTrixelDistanceMaxDistance);
     IRRender::device()->clearTexImage(canvas.getTextureDistances(), 0, &kDistanceClear);
 }


### PR DESCRIPTION
## Summary
- **P0 regression fix**: restores the `device()->clearTexImage()` call for the R32I distance texture that T-352 (PR #1174, `e05f24f0`) incorrectly removed
- On Metal, `Texture2D::clear()` does not reliably clear R32I textures — stale distance values survive across frames and cause the voxel compact shader to cull visible content, producing the "left half of scene missing at yaw=0" symptom
- Bisected to the exact offending commit via 6 build-run-screenshot cycles across the regression window (`61f6424c` → `e05f24f0`)

## Root cause
T-352's commit message described the `clearTexImage` call as "redundant" because `canvas.clear()` already cleared the distance texture through `Texture2D::clear()`. On OpenGL this is true — both paths produce the same result. On Metal, `Texture2D::clear()` routes through the blit encoder which does not reliably clear integer-format (R32I) textures, leaving stale distance values that persist frame-over-frame. The compact shader then sees voxels at "closer" distances than real content and culls the actual geometry.

## Test plan
- [x] Build + run IRShapeDebug on macOS/Metal — full scene visible at yaw=0 (3/3 consecutive runs pass, 166409-byte screenshots vs 147948-byte broken baseline)
- [x] Visual comparison confirms match with pre-regression reference (T-353 screenshots)
- [ ] Linux/OpenGL smoke (fleet cross-host validation)

Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)