### PR TITLE
T-395: fleet: update skills for issue-based queue

### DIFF
--- a/.claude/skills/backend-parity/SKILL.md
+++ b/.claude/skills/backend-parity/SKILL.md
@@ -334,6 +334,6 @@ A Sonnet agent running this skill should escalate to Opus when:
 - The build break looks like it touches lifetime / ownership of a
   GPU resource (buffer creation, destruction, persistent mapping).
 
-Escalate by stopping, updating `TASKS.md` to re-tag the gap as
-`[opus]`, and posting a short note on why in the task body. Don't
+Escalate by stopping, filing a follow-up GitHub issue with the
+`fleet:opus` label and explaining the reason in the issue body. Don't
 ship a half-port.

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -32,7 +32,7 @@ Do **not** invoke proactively — only when the user explicitly asks.
 
 This skill has three modes. Detect at the start of the flow, in priority order:
 
-1. **Fleet stack mode** — caller has an active `fleet-claim` stack chain. PRs are chained by `--base` (one PR per task). Detected via `fleet-claim stack-pr-state <worktree>`. See [`procedures/fleet-stack.md`](procedures/fleet-stack.md) for the deltas (branch name with `T-NNN` prefix, `stack-base` lookup for `--base`, `Stack context` body block, `fleet:stacked` label, `stack-set-pr` after PR open).
+1. **Fleet stack mode** — caller has an active `fleet-claim` stack chain. PRs are chained by `--base` (one PR per task). Detected via `fleet-claim stack-pr-state <worktree>`. See [`procedures/fleet-stack.md`](procedures/fleet-stack.md) for the deltas (branch name with `<issue#>` prefix (`claude/<NNN>-<slug>`), `stack-base` lookup for `--base`, `Stack context` body block, `fleet:stacked` label, `stack-set-pr` after PR open).
 2. **Cursor stack mode** — current branch has `branch.<name>.cursor-stack-base` git config set (written by `start-next-task` when the human cued stacking). PRs target the parent branch instead of `master`. See [`procedures/cursor-stack.md`](procedures/cursor-stack.md) for the detection check, the `Stacked on:` body line, and the macOS sandbox note.
 3. **Single-PR mode (default)** — neither stack signal present. Proceed with the standard flow below.
 
@@ -204,7 +204,7 @@ if git diff --cached --quiet; then
 fi
 ```
 
-On fleet branches (`claude/T-NNN-*`), the error is especially important —
+On fleet branches (`claude/<NNN>-*`), the error is especially important —
 an empty commit there leaves misleading task provenance in the repo. If
 `simplify` or `optimize` stripped every changed line, stop and investigate
 before proceeding.
@@ -263,10 +263,7 @@ Title should match the commit title for a single commit; use a broader title
 for multi-commit PRs.
 
 **`Closes #N` line (required when the task has an `Issue:` field).** This is
-what makes GitHub auto-close the originating issue on merge. Without it the
-TASKS.md row still reaps via the title's `T-NNN:` prefix (per
-`fleet-tasks-render`'s closed-issue fallback) but the GitHub issue side
-stays open and the queue silently accumulates stale items. Omit the line
+what makes GitHub auto-close the originating issue on merge. Omit the line
 only when the task's `Issue:` field is `(none)` — cleanup PRs, fleet-tooling
 PRs filed without a tracking issue, etc. See
 [`procedures/pr-body.md`](procedures/pr-body.md) for the full template and

--- a/.claude/skills/commit-and-push/procedures/cursor-stack.md
+++ b/.claude/skills/commit-and-push/procedures/cursor-stack.md
@@ -22,7 +22,7 @@ git config --get branch.$(git branch --show-current).cursor-stack-base
   parent_pr_url=$(gh pr list --head "$parent_branch" --state all --json url -q '.[0].url' --limit 1)
   ```
   If the parent has no PR yet (e.g. the human hasn't run `commit-and-push` on it — unusual but possible), use the branch name instead: `Stacked on: <parent_branch>` and warn the user.
-- **Title** uses the normal cursor-flow shape (no `T-NNN:` prefix — cursor flow doesn't use the queue).
+- **Title** uses the normal cursor-flow shape (no issue-number prefix — cursor flow branches are named `claude/<area>-<topic>`).
 - **No labels** beyond what the normal flow adds. The `fleet:stacked` label is fleet-only; cursor flow just relies on `Stacked on:` in the PR body.
 
 ## After the PR opens

--- a/.claude/skills/commit-and-push/procedures/fleet-stack.md
+++ b/.claude/skills/commit-and-push/procedures/fleet-stack.md
@@ -17,7 +17,7 @@ fleet-claim stack-pr-state <your-worktree-name>
 
 ## Deltas vs. the single-PR flow
 
-- **Step 2 branch name** is `claude/<task-id>-<short-topic>` (e.g. `claude/T-005-occupancy-grid`). The task ID prefix lets the queue-manager, reviewers, and `stack-base` resolve the chain.
+- **Step 2 branch name** is `claude/<issue#>-<short-topic>` (e.g. `claude/1234-occupancy-grid`). The issue-number prefix lets reviewers and `stack-base` resolve the chain.
 - **Step 8 PR base** is `fleet-claim stack-base <agent> <task-id>` instead of `master`. For the first task this still returns `master`; for subsequent tasks it returns the previous task's branch.
 - **After `gh pr create`** record the PR in the stack so the next task can chain off it:
   ```bash
@@ -25,7 +25,7 @@ fleet-claim stack-pr-state <your-worktree-name>
   ```
 - **PR body** includes a `## Stack context` block with a `Stacked on:` line (the previous PR URL, or `master` for the first task in the chain) and a `Full chain:` line listing the task IDs the molecule covers. Reviewers use this to navigate sibling PRs without leaving the diff.
 - **Labels** include `fleet:stacked` whenever `--base != master` (i.e. every PR in the chain except the first). The merger reads `baseRefName` directly for routing decisions; the label is a derived convenience for human visibility and cheap GitHub-side filtering.
-- **Title** starts with `T-NNN: ` so the queue-manager's per-task matching works and reviewers can tell which task in the chain this PR belongs to.
+- **Title** starts with a scope prefix per the commit-message style guide; the issue number goes in the `Closes #N` line so reviewers can trace the chain.
 
 ## After the PR opens
 

--- a/.claude/skills/commit-and-push/procedures/fleet-stack.md
+++ b/.claude/skills/commit-and-push/procedures/fleet-stack.md
@@ -13,7 +13,7 @@ fleet-claim stack-pr-state <your-worktree-name>
 ```
 
 - Output `no stack claim for agent: <name>` → not stacked, proceed with the normal single-PR flow in [`SKILL.md`](../SKILL.md).
-- Output with `task`/`branch`/`pr` columns → stacked. The row whose PR column is `(pending)` and whose earlier rows (if any) are all filled is the current task. Note its `<task-id>`; you will need it in steps 2 and 8 of the main flow.
+- Output with `task`/`branch`/`pr` columns → stacked. The row whose PR column is `(pending)` and whose earlier rows (if any) are all filled is the current task. Note its `<task-id>` (for `fleet-claim` commands in step 8) and its `<issue#>` (for the branch name in step 2 — look it up from the task entry if the column only shows a T-NNN ID).
 
 ## Deltas vs. the single-PR flow
 

--- a/.claude/skills/commit-and-push/procedures/fleet-stack.md
+++ b/.claude/skills/commit-and-push/procedures/fleet-stack.md
@@ -13,7 +13,7 @@ fleet-claim stack-pr-state <your-worktree-name>
 ```
 
 - Output `no stack claim for agent: <name>` → not stacked, proceed with the normal single-PR flow in [`SKILL.md`](../SKILL.md).
-- Output with `task`/`branch`/`pr` columns → stacked. The row whose PR column is `(pending)` and whose earlier rows (if any) are all filled is the current task. Note its `<task-id>` (for `fleet-claim` commands in step 8) and its `<issue#>` (for the branch name in step 2 — look it up from the task entry if the column only shows a T-NNN ID).
+- Output with `task`/`branch`/`pr` columns → stacked. The row whose PR column is `(pending)` and whose earlier rows (if any) are all filled is the current task. Note its **T-NNN `<task-id>`** (for the `fleet-claim` commands in step 8 — `fleet-claim` takes T-NNN identifiers, not issue numbers) and its **`<issue#>`** (the linked GitHub issue number, for the branch name in step 2).
 
 ## Deltas vs. the single-PR flow
 

--- a/.claude/skills/commit-and-push/procedures/pr-body.md
+++ b/.claude/skills/commit-and-push/procedures/pr-body.md
@@ -25,10 +25,7 @@ Omit the `Closes #<issue-N>` line when the task's `Issue:` field is `(none)`
 (e.g. cleanup PRs, fleet-tooling PRs filed without a tracking issue).
 
 The `Closes #N` line is what makes GitHub auto-close the originating issue on
-merge. Without it, the closed-issue auto-reaper in `fleet-tasks-render` still
-moves the TASKS.md row to Done (via the PR title's `T-NNN:` prefix), but the
-GitHub issue side stays open and accumulates. Always include it when an Issue
-number exists.
+merge. Always include it when an Issue number exists.
 
 ## Fleet stack delta
 
@@ -40,7 +37,7 @@ This PR is part of a stack. Reviewers: review this PR on its own;
 the chain is coordinated in the PR body's "Stacked on" line.
 
 Stacked on: <previous PR URL, or "master" for the first PR>
-Full chain: T-<A>, T-<B>, T-<C>
+Full chain: #<A>, #<B>, #<C>
 ```
 
 Drop `## Notes for reviewer`. The `Closes #<issue-N>` line is already in the

--- a/.claude/skills/platform-catchup/SKILL.md
+++ b/.claude/skills/platform-catchup/SKILL.md
@@ -401,7 +401,6 @@ platform-catchup: <repo> on <host-tag>
 - **Never commits to `master`.** All fixes go on a fresh branch off
   `origin/master`.
 - **Never `git pull --rebase` or `--force`.** Only `--ff-only`.
-- **Never edits `TASKS.md`.** Queue-manager owns that.
 - **Hard time budget: 60 minutes default.** Each step has a sub-budget;
   the report is emitted as soon as the budget is exhausted even if
   walk-back is mid-flight. The Bash tool's `timeout` parameter

--- a/.claude/skills/review-fleet-feedback/SKILL.md
+++ b/.claude/skills/review-fleet-feedback/SKILL.md
@@ -173,7 +173,7 @@ leave it stale so the next run re-surfaces the entries.
 
 If the human wants the proposals worked on rather than just tracked,
 hand them to the existing `human:approved` → `fleet-queue-ingest` →
-queue-manager → worker pipeline:
+worker pipeline:
 
 ```bash
 scripts/fleet/review-fleet-feedback file-tasks --dry-run     # preview titles

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -155,7 +155,7 @@ Apply two checks to the stat output:
 2. **Out-of-scope file** — any file that appears in the stat output but
    is neither described in the PR body nor a known mechanical side-effect
    of the PR's claimed scope (e.g. a `CMakeLists.txt` accompanying a new
-   source file — not `TASKS.md`, `.fleet/plans/` drift, or unrelated docs).
+   source file — not `.fleet/plans/` drift or unrelated docs).
    Flag as **Needs-fix**: author must acknowledge the file in the PR
    body or rebase to drop the accidental hunk.
 

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -393,7 +393,7 @@ top-level `CLAUDE.md` and module-level `CLAUDE.md` files.
   task ID, PR number, or skill name cited in the prose now refers
   to something that no longer exists or means something different.
   Common triggers: a renamed file, a removed label, a role that
-  got merged into another, a TASKS.md task ID that already shipped.
+  got merged into another, a GitHub issue number that already shipped.
   Grep the cited identifiers against the current tree and fix what
   drifted.
 - **Examples that drifted from the current API.** A doc shows a

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -100,19 +100,19 @@ fleet-claim molecule resume <your-worktree-name>
 
 Interpret the output (the helper always exits 0; discriminate via stdout):
 
-- **stdout names a `T-NNN`** — there is an active stack with remaining
-  tasks. The returned ID is the **next** task in the chain (resume marks
+- **stdout names an issue number** — there is an active stack with remaining
+  tasks. The returned number is the **next** task in the chain (resume marks
   the first pending task as `in-progress` as a side effect).
-  - **Sanity-check:** if the returned ID matches the old branch's task
-    prefix (e.g. old branch `claude/T-005-foo` and resume returned
-    `T-005`), the worker forgot to run `fleet-claim molecule advance
-    <agent> T-005 done pr=<URL> commit=<SHA>` after `commit-and-push`.
+  - **Sanity-check:** if the returned number matches the old branch's issue
+    prefix (e.g. old branch `claude/1234-foo` and resume returned
+    `1234`), the worker forgot to run `fleet-claim molecule advance
+    <agent> 1234 done pr=<URL> commit=<SHA>` after `commit-and-push`.
     Stop and tell the user to advance the molecule before retrying — do
     not proceed, or you will branch back onto the same task.
-  - Otherwise the new branch is `claude/<returned-T-NNN>-<short-topic>`
+  - Otherwise the new branch is `claude/<returned-issue#>-<short-topic>`
     based on the **old branch** (the just-opened PR's head ref). Set
     `MODE=fleet-stack`, `BASE=<old-branch-name>`, and remember
-    `<returned-T-NNN>` for step 5.
+    `<returned-issue#>` for step 5.
 - **stdout is empty** — no fleet molecule. Continue to 4b.
 
 If `molecule resume` exits non-zero (malformed YAML, etc.), stop and
@@ -143,17 +143,14 @@ Default. `MODE=standard`, `BASE=origin/master`. Proceed.
 
 ### 5. Derive a new branch name
 
-In **fleet stack mode** (4a returned a `T-NNN`): the new branch is
-`claude/<T-NNN>-<short-topic>`. Pull the topic from the task title in
-`TASKS.md` if obvious (read it via `git show origin/master:TASKS.md` —
-do NOT `git checkout origin/master -- TASKS.md`, which would stage it
-and break the next `git checkout -b`). If the user already named the
-next slice in conversation, prefer that; otherwise `<short-topic>` can
-be a brief paraphrase of the title.
+In **fleet stack mode** (4a returned an issue number): the new branch is
+`claude/<issue#>-<short-topic>`. Pull the topic from the issue title via
+`fleet-issue view <issue#>` (falls back to `gh issue view <issue#>`). If
+the user already named the next slice in conversation, prefer that;
+otherwise `<short-topic>` can be a brief paraphrase of the title.
 
 In **cursor stack mode** (4b): the new branch is
-`claude/<area>-<topic>`, no `T-NNN` prefix (cursor flow doesn't use
-the queue). Derive from the conversation: the user usually names the
+`claude/<area>-<topic>`, no issue-number prefix. Derive from the conversation: the user usually names the
 next slice when they cue stacking. If they didn't, ask. Examples:
 
 - `claude/render-glow-pulse-tuning` (stacked on
@@ -174,9 +171,7 @@ work best with human-readable, topic-named branches.
 ### 6. Discard any staged or working-tree changes from the old branch
 
 Before switching, ensure the working tree is fully clean — even of files
-that look like a no-op (e.g. `TASKS.md` that was checked out from
-`origin/master` to read the latest queue while you were on the feature
-branch — that staging blocks the next branch checkout):
+that look like a no-op (a stale staged file blocks the next branch checkout):
 
 ```bash
 git restore --staged .


### PR DESCRIPTION
## Summary

Update skill docs to remove references to the `T-NNN` TASKS.md-based queue convention and replace with the GitHub Issues-based queue pattern (`<issue#>`, `claude/<NNN>-<slug>` branches, `Closes #<N>` lines).

Affected files:
- `.claude/skills/commit-and-push/SKILL.md` and procedures
- `.claude/skills/start-next-task/SKILL.md`
- `.claude/skills/review-pr/SKILL.md`
- `.claude/skills/simplify/SKILL.md`
- `.claude/skills/backend-parity/SKILL.md`
- `.claude/skills/platform-catchup/SKILL.md`
- `.claude/skills/review-fleet-feedback/SKILL.md`

Closes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)