### PR TITLE
T-392: scout drops TASKS.md reads and T-NNN blocker parser

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -156,7 +156,7 @@ _INGEST_SKIP_LABELS = frozenset({
     "fleet:epic",
     "fleet:needs-plan",
     "fleet:needs-info",
-    "fleet:scope-shipped", # scope landed under a different T-NNN; human should close
+    "fleet:scope-shipped", # scope landed under a different issue; human should close
 })
 
 
@@ -191,14 +191,12 @@ def fetch_human_approved(repo):
 
 
 def fetch_closed_fleet_queued(repo, limit=100):
-    # Closed fleet:queued issues whose TASKS.md row hasn't been flipped to [x]
-    # yet. --limit caps API cost; recently-closed issues are returned first.
-    # 100 covers the realistic backlog window — observed 2026-05-19 that the
-    # original 20-item cap missed strands like T-166 (#663) which closed
-    # 2026-05-12 and stayed in TASKS.md `## Open` while ~40 fleet:queued
-    # issues closed after it. The renderer's closed-issue reaper consumes
-    # this slice; missing entries strand rows in Open until they're swept
-    # manually.
+    # Closed fleet:queued issues; the queue-manager projection consumes this
+    # to reap stale fleet:claim-* labels on resolved work. --limit caps API
+    # cost; recently-closed issues are returned first. 100 covers the
+    # realistic backlog window (observed 2026-05-19 that the original 20-item
+    # cap missed older strands when ~40 fleet:queued issues closed after one
+    # another in a tight window).
     out = run_capture([
         "gh", "issue", "list", "--repo", repo,
         "--label", "fleet:queued", "--state", "closed",
@@ -256,12 +254,11 @@ def fetch_recent_merged_prs(repo, limit=30):
     return prs
 
 
-# --- Issue-based task queue (T-381) ----------------------------------------
+# --- Issue-based task queue (T-381, T-392) ---------------------------------
 #
 # The task queue is sourced from GitHub Issues with the fleet:queued label.
 # Model, blocked-by, and area are parsed from issue bodies and labels.
-# T-NNN IDs are mapped from TASKS.md during the transition period; T-382
-# will eliminate this mapping entirely.
+# Task identity is the issue number itself (rendered as `#NNN`).
 
 _AREA_LABEL_MAP = {
     "IRRender": "engine/render",
@@ -279,65 +276,8 @@ def _parse_issue_field(body, field):
     return m.group(1).strip() if m else ""
 
 
-def _build_task_id_map(tasks_md_text):
-    """Build issue# → {id, model, blocked_by} mapping from TASKS.md (transitional).
-
-    Returns dict keyed by issue number: {1214: {"id": "T-380", "model": "opus", "blocked_by": "T-379"}, ...}
-    """
-    issue_map = {}
-    current_id = None
-    current_issue = None
-    current_model = None
-    current_blocked = None
-    def flush():
-        nonlocal current_id, current_issue, current_model, current_blocked
-        if current_id and current_issue:
-            issue_map[current_issue] = {
-                "id": current_id,
-                "model": current_model,
-                "blocked_by": current_blocked,
-            }
-        current_id = current_issue = current_model = current_blocked = None
-    for line in (tasks_md_text or "").splitlines():
-        if re.match(r"^- \[.\] \*\*.+\*\*", line):
-            flush()
-            continue
-        m = re.match(r"^\s+- \*\*ID:\*\*\s*(.+)", line)
-        if m:
-            current_id = m.group(1).strip()
-            continue
-        m = re.match(r"^\s+- \*\*Issue:\*\*\s*#(\d+)", line)
-        if m:
-            current_issue = int(m.group(1))
-            continue
-        m = re.match(r"^\s+- \*\*Model:\*\*\s*(.+)", line)
-        if m:
-            current_model = m.group(1).strip().lower()
-            continue
-        m = re.match(r"^\s+- \*\*Blocked by:\*\*\s*(.+)", line)
-        if m:
-            current_blocked = m.group(1).strip()
-    flush()
-    return issue_map
-
-
-def _convert_blocked_by(raw_blocked, issue_to_id):
-    """Convert #NNN blocked-by references to T-NNN using the mapping."""
-    if not raw_blocked or raw_blocked in ("(none)", "—"):
-        return "(none)"
-    parts = []
-    for part in raw_blocked.split(","):
-        part = part.strip()
-        m = re.match(r"#(\d+)", part)
-        if m:
-            parts.append(issue_to_id.get(int(m.group(1))) or part)
-        else:
-            parts.append(part)
-    return ", ".join(parts)
-
-
-def fetch_task_queue(repo_slug, repo_root):
-    """Fetch open task queue from GitHub Issues + TASKS.md ID mapping."""
+def fetch_task_queue(repo_slug):
+    """Fetch open task queue from GitHub Issues with the fleet:queued label."""
     issues_out = run_capture([
         "gh", "issue", "list",
         "--repo", repo_slug,
@@ -346,11 +286,6 @@ def fetch_task_queue(repo_slug, repo_root):
         "--json", "number,title,labels,body",
         "--limit", "200",
     ])
-
-    tasks_md = run_capture(
-        ["git", "-C", str(repo_root), "show", "origin/master:TASKS.md"]
-    )
-    issue_map = _build_task_id_map(tasks_md)
 
     if not issues_out:
         return {"open": [], "in_progress": [], "done": []}
@@ -372,20 +307,14 @@ def fetch_task_queue(repo_slug, repo_root):
         body = issue.get("body", "") or ""
         title = issue.get("title", "")
         number = issue.get("number", 0)
-
-        md_entry = issue_map.get(number, {})
-        task_id = md_entry.get("id")
+        task_id = f"#{number}"
 
         if "fleet:opus" in labels:
             model = "opus"
         elif "fleet:sonnet" in labels:
             model = "sonnet"
         else:
-            model = (
-                _parse_issue_field(body, "Model")
-                or md_entry.get("model")
-                or None
-            )
+            model = _parse_issue_field(body, "Model") or None
 
         # Claim labels are `fleet:claim-<host>-<agent>`; agent half is what
         # roles see in `fleet-claim list`.
@@ -400,15 +329,7 @@ def fetch_task_queue(repo_slug, repo_root):
         in_progress = "fleet:in-progress" in labels or owner != "free"
         status = "~" if in_progress else " "
 
-        raw_blocked = _parse_issue_field(body, "Blocked by")
-        if raw_blocked:
-            issue_to_id_simple = {
-                num: entry.get("id") for num, entry in issue_map.items()
-                if entry.get("id")
-            }
-            blocked_by = _convert_blocked_by(raw_blocked, issue_to_id_simple)
-        else:
-            blocked_by = md_entry.get("blocked_by") or "(none)"
+        blocked_by = _parse_issue_field(body, "Blocked by") or "(none)"
 
         area_parts = [_AREA_LABEL_MAP[l] for l in labels if l in _AREA_LABEL_MAP]
         area = (
@@ -419,14 +340,14 @@ def fetch_task_queue(repo_slug, repo_root):
 
         task = {
             "status": status,
-            "title": task_id or title,
+            "title": task_id,
             "summary": title,
             "id": task_id,
             "model": model,
             "owner": owner,
             "area": area,
             "blocked_by": blocked_by,
-            "issue": f"#{number}",
+            "issue": task_id,
         }
 
         if status == "~":
@@ -439,28 +360,26 @@ def fetch_task_queue(repo_slug, repo_root):
             key=lambda t: int((t.get("issue") or "#0").lstrip("#"))
         )
 
-    sections["_issue_map"] = issue_map
     return sections
 
 
-def _populate_tasks_done(repo_state, issue_map):
+def _populate_tasks_done(repo_state):
     """Convert closed_fleet_queued entries to tasks.done format."""
     done = []
     for issue in repo_state.get("closed_fleet_queued", []):
         number = issue.get("number", 0)
         title = issue.get("title", "")
-        md_entry = issue_map.get(number, {})
-        task_id = md_entry.get("id")
+        task_id = f"#{number}"
         done.append({
             "status": "x",
-            "title": task_id or title,
+            "title": task_id,
             "summary": title,
             "id": task_id,
             "model": None,
             "owner": None,
             "area": None,
             "blocked_by": None,
-            "issue": f"#{number}",
+            "issue": task_id,
         })
     done.sort(key=lambda t: int((t.get("issue") or "#0").lstrip("#")))
     return done
@@ -781,11 +700,11 @@ _SMOKE_SKIP_LABELS = frozenset({
 
 MODEL_TOKEN_RE = re.compile(r"\b(opus|sonnet)\b")
 
-# Single-T-NNN blocker. Reject multi-blocker (`T-101, T-102`), free-text
-# (`refactor lands`), and PR-URL (`https://...`) forms — all of which
-# the cross-author stacking flow can't resolve to one upstream branch
+# Single-issue blocker (`#1234`). Reject multi-blocker (`#101, #102`),
+# free-text (`refactor lands`), and PR-URL (`https://...`) forms — all of
+# which the cross-author stacking flow can't resolve to one upstream branch
 # (multi-blocker decision deferred to v2 per T-110 plan Q3).
-SINGLE_TASK_BLOCKER_RE = re.compile(r"^T-\d{3}$")
+SINGLE_TASK_BLOCKER_RE = re.compile(r"^#\d+$")
 
 
 def model_tags(task):
@@ -818,15 +737,15 @@ def _blocker_pr_files(repo_key, pr_number):
 
 
 def enrich_stackable_blocker_prs(state):
-    # Per T-110 PR 2: for each task whose blocked_by is exactly one T-NNN
-    # ID with exactly one matching open PR (head ref `claude/T-NNN-…`)
-    # in the same repo, attach a `stackable_blocker_pr` field carrying
-    # {number, headRefName, author}. Workers (T-114) read this to decide
-    # whether to fall through to a stackable claim when no unblocked
-    # tasks are free.
+    # Per T-110 PR 2: for each task whose blocked_by is exactly one issue
+    # number (`#NNN`) with exactly one matching open PR (head ref
+    # `claude/<NNN>-…`) in the same repo, attach a `stackable_blocker_pr`
+    # field carrying {number, headRefName, author}. Workers (T-114) read
+    # this to decide whether to fall through to a stackable claim when no
+    # unblocked tasks are free.
     #
     # The field is always omitted when:
-    #   - blocked_by isn't a single T-NNN (multi-blocker, free-text, URL)
+    #   - blocked_by isn't a single #NNN (multi-blocker, free-text, URL)
     #   - zero open PRs match the expected branch prefix (blocker not
     #     yet started, or already merged and dropped from open list)
     #   - more than one open PR matches (rare but possible if a stale
@@ -843,7 +762,8 @@ def enrich_stackable_blocker_prs(state):
             blocked_by = (task.get("blocked_by") or "").strip()
             if not SINGLE_TASK_BLOCKER_RE.match(blocked_by):
                 continue
-            prefix = f"claude/{blocked_by}-"
+            issue_num = blocked_by.lstrip("#")
+            prefix = f"claude/{issue_num}-"
             matches = [pr for pr in prs
                        if pr.get("headRefName", "").startswith(prefix)]
             if len(matches) != 1:
@@ -1036,13 +956,13 @@ def project_queue_manager_ingest(state):
     """Hash-input projection for the queue-manager-ingest auto-fire.
 
     Tracks the SET of actionable `human:approved` issues — i.e., issues the
-    human has approved but queue-manager hasn't yet filed into TASKS.md, and
-    that are not in a skip category (epic, needs-plan, needs-info, queued).
-    The hash flips when this set CHANGES:
+    human has approved but the queue hasn't yet stamped `fleet:queued` onto,
+    and that are not in a skip category (epic, needs-plan, needs-info,
+    queued). The hash flips when this set CHANGES:
 
     - Operator adds `human:approved` to issue #N: #N enters the set,
-      hash flips, scout spawns fleet-queue-ingest, the LLM iteration
-      categorizes #N and writes a task entry with `fleet:queued`.
+      hash flips, scout spawns fleet-queue-ingest, which stamps
+      `fleet:queued` (plus a model-affinity label) onto #N.
     - After ingestion, #N has `fleet:queued` so it drops from the
       set; hash flips again. fleet-queue-ingest re-fires, finds the
       set is empty, exits in <1s. One wasted iteration per ingestion
@@ -1307,7 +1227,7 @@ def collect_state():
             ("engine", "human_approved", lambda: fetch_human_approved("jakildev/IrredenEngine")),
             ("engine", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/IrredenEngine")),
             ("engine", "recent_merged_prs", lambda: fetch_recent_merged_prs("jakildev/IrredenEngine")),
-            ("engine", "tasks", lambda: fetch_task_queue("jakildev/IrredenEngine", ENGINE)),
+            ("engine", "tasks", lambda: fetch_task_queue("jakildev/IrredenEngine")),
         ]
     if "game" in repos:
         fetch_specs += [
@@ -1316,7 +1236,7 @@ def collect_state():
             ("game", "human_approved", lambda: fetch_human_approved("jakildev/irreden")),
             ("game", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/irreden")),
             ("game", "recent_merged_prs", lambda: fetch_recent_merged_prs("jakildev/irreden")),
-            ("game", "tasks", lambda: fetch_task_queue("jakildev/irreden", GAME)),
+            ("game", "tasks", lambda: fetch_task_queue("jakildev/irreden")),
         ]
 
     with ThreadPoolExecutor(max_workers=FETCH_MAX_WORKERS) as ex:
@@ -1343,11 +1263,10 @@ def collect_state():
 
 
 def _populate_done_tasks(state):
-    """Populate tasks.done from closed_fleet_queued, reusing the cached ID map."""
+    """Populate tasks.done from closed_fleet_queued."""
     for repo_key, repo_state in state["repos"].items():
         tasks = repo_state.get("tasks", {})
-        issue_map = tasks.pop("_issue_map", {})
-        tasks["done"] = _populate_tasks_done(repo_state, issue_map)
+        tasks["done"] = _populate_tasks_done(repo_state)
 
 
 def tick_once():
@@ -1403,9 +1322,9 @@ def tick_once():
                 triggers_fired.append("queue-manager(claim-cleanup)")
         elif role == "queue-manager-ingest":
             # Auto-fire ingestion when the human:approved-and-not-yet-queued
-            # set changes. Same spawn pattern as queue-tick but invokes an
-            # LLM iteration via fleet-queue-ingest. Lockfile inside the
-            # script prevents concurrent runs.
+            # set changes. Same backgrounded-subprocess pattern as the
+            # queue-manager claim-cleanup spawn above. Lockfile inside
+            # fleet-queue-ingest prevents concurrent runs.
             new_hash = stable_hash(projection)
             seen_file = SEEN_DIR / role
             try:

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -57,21 +57,21 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
 
     def test_happy_path_single_match(self):
         """Exactly one PR matches the blocked_by prefix → field is written."""
-        tasks = [_task("T-112", "T-111")]
-        prs = [_pr(536, "claude/T-111-scout-stackable-blocker-pr", author="jakildev")]
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(536, "claude/1111-scout-stackable-blocker-pr", author="jakildev")]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
         task = state["repos"]["engine"]["tasks"]["open"][0]
         self.assertIn("stackable_blocker_pr", task)
         self.assertEqual(task["stackable_blocker_pr"]["number"], 536)
         self.assertEqual(task["stackable_blocker_pr"]["headRefName"],
-                         "claude/T-111-scout-stackable-blocker-pr")
+                         "claude/1111-scout-stackable-blocker-pr")
         self.assertEqual(task["stackable_blocker_pr"]["author"], "jakildev")
 
     def test_zero_matches_no_field(self):
         """No open PR matches prefix → field absent."""
-        tasks = [_task("T-112", "T-111")]
-        prs = [_pr(999, "claude/T-200-unrelated")]
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(999, "claude/2000-unrelated")]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr",
@@ -79,18 +79,18 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
 
     def test_empty_prs_no_field(self):
         """No open PRs at all → field absent."""
-        tasks = [_task("T-112", "T-111")]
+        tasks = [_task("#1112", "#1111")]
         state = _state(engine_tasks=tasks, engine_prs=[])
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr",
                          state["repos"]["engine"]["tasks"]["open"][0])
 
     def test_multi_match_no_field(self):
-        """Two PRs share the same T-NNN prefix (stale branch) → field absent."""
-        tasks = [_task("T-112", "T-111")]
+        """Two PRs share the same issue-number prefix (stale branch) → field absent."""
+        tasks = [_task("#1112", "#1111")]
         prs = [
-            _pr(536, "claude/T-111-scout-stackable-blocker-pr"),
-            _pr(537, "claude/T-111-stale-bounced-branch"),
+            _pr(536, "claude/1111-scout-stackable-blocker-pr"),
+            _pr(537, "claude/1111-stale-bounced-branch"),
         ]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
@@ -98,9 +98,9 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
                          state["repos"]["engine"]["tasks"]["open"][0])
 
     def test_multi_blocker_no_field(self):
-        """blocked_by with two IDs doesn't match ^T-\\d{3}$ → field absent."""
-        tasks = [_task("T-115", "T-112, T-113")]
-        prs = [_pr(540, "claude/T-112-some-branch"), _pr(541, "claude/T-113-other")]
+        """blocked_by with two IDs doesn't match ^#\\d+$ → field absent."""
+        tasks = [_task("#1115", "#1112, #1113")]
+        prs = [_pr(540, "claude/1112-some-branch"), _pr(541, "claude/1113-other")]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr",
@@ -108,8 +108,8 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
 
     def test_none_blocked_by_no_field(self):
         """blocked_by is None → field absent."""
-        tasks = [_task("T-112", None)]
-        prs = [_pr(536, "claude/T-111-x")]
+        tasks = [_task("#1112", None)]
+        prs = [_pr(536, "claude/1111-x")]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr",
@@ -117,28 +117,28 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
 
     def test_explicit_none_string_no_field(self):
         """blocked_by is '(none)' → field absent."""
-        tasks = [_task("T-112", "(none)")]
-        prs = [_pr(536, "claude/T-111-x")]
+        tasks = [_task("#1112", "(none)")]
+        prs = [_pr(536, "claude/1111-x")]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr",
                          state["repos"]["engine"]["tasks"]["open"][0])
 
     def test_prefix_discrimination_no_match(self):
-        """T-101 prefix must not match a T-1011 branch (trailing dash prevents it)."""
-        tasks = [_task("T-102", "T-101")]
-        prs = [_pr(100, "claude/T-1011-longer-id")]
+        """#101 prefix must not match a 1011 branch (trailing dash prevents it)."""
+        tasks = [_task("#102", "#101")]
+        prs = [_pr(100, "claude/1011-longer-id")]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr",
                          state["repos"]["engine"]["tasks"]["open"][0])
 
     def test_prefix_discrimination_correct_match(self):
-        """T-101 with trailing dash matches T-101-something but not T-1011-something."""
-        tasks = [_task("T-102", "T-101")]
+        """#101 with trailing dash matches 101-something but not 1011-something."""
+        tasks = [_task("#102", "#101")]
         prs = [
-            _pr(100, "claude/T-1011-longer-id"),
-            _pr(101, "claude/T-101-real-branch"),
+            _pr(100, "claude/1011-longer-id"),
+            _pr(101, "claude/101-real-branch"),
         ]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
@@ -148,8 +148,8 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
 
     def test_cross_repo_isolation(self):
         """Engine task cannot match a game PR."""
-        engine_tasks = [_task("T-112", "T-111")]
-        game_prs = [_pr(536, "claude/T-111-in-game-repo")]
+        engine_tasks = [_task("#1112", "#1111")]
+        game_prs = [_pr(536, "claude/1111-in-game-repo")]
         state = _state(engine_tasks=engine_tasks, engine_prs=[], game_prs=game_prs)
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr",
@@ -158,12 +158,12 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
     def test_multiple_tasks_independent(self):
         """Two tasks in the same repo with different blockers are enriched independently."""
         tasks = [
-            _task("T-113", "T-111"),
-            _task("T-114", "T-112"),
+            _task("#1113", "#1111"),
+            _task("#1114", "#1112"),
         ]
         prs = [
-            _pr(536, "claude/T-111-branch-a"),
-            _pr(537, "claude/T-112-branch-b", author="other"),
+            _pr(536, "claude/1111-branch-a"),
+            _pr(537, "claude/1112-branch-b", author="other"),
         ]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
@@ -173,16 +173,17 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         self.assertEqual(open_tasks[1]["stackable_blocker_pr"]["author"], "other")
 
     def test_free_text_blocked_by_no_field(self):
-        """Free-text or URL blocked_by values don't match regex → field absent."""
+        """Free-text, URL, or legacy-T-NNN blocked_by values don't match regex → field absent."""
         values = [
             "pending design",
             "https://github.com/x/y/issues/1",
-            "T-101 (waiting)",
+            "#101 (waiting)",
+            "T-101",
         ]
         for value in values:
             with self.subTest(blocked_by=value):
-                tasks = [_task("T-999", value)]
-                prs = [_pr(1, "claude/T-101-x")]
+                tasks = [_task("#999", value)]
+                prs = [_pr(1, "claude/101-x")]
                 state = _state(engine_tasks=tasks, engine_prs=prs)
                 enrich_stackable_blocker_prs(state)
                 self.assertNotIn(

--- a/scripts/fleet/tests/test_issue_queue_parser.py
+++ b/scripts/fleet/tests/test_issue_queue_parser.py
@@ -1,8 +1,9 @@
-"""Tests for the issue-based task queue parser in fleet-state-scout (T-381).
+"""Tests for the issue-based task queue parser in fleet-state-scout
+(T-381, T-392).
 
-Covers the pure-function helpers — _parse_issue_field, _build_task_id_map,
-_convert_blocked_by — and the label/body precedence rules inside
-fetch_task_queue's per-issue loop (model, owner, in_progress, area).
+Covers the pure-function helper `_parse_issue_field` and the label/body
+precedence rules inside `fetch_task_queue`'s per-issue loop (model, owner,
+in_progress, area, blocked_by, task identity).
 """
 import importlib.machinery
 import importlib.util
@@ -34,85 +35,23 @@ class ParseIssueField(unittest.TestCase):
         self.assertEqual(_mod._parse_issue_field(body, "Model"), "opus")
 
 
-class BuildTaskIdMap(unittest.TestCase):
-    def test_maps_issue_to_task_id_and_fields(self):
-        md = (
-            "- [~] **fleet: scout reads issues** — summary\n"
-            "  - **ID:** T-381\n"
-            "  - **Model:** opus\n"
-            "  - **Issue:** #1215\n"
-            "  - **Blocked by:** #1214\n"
-            "- [ ] **next task**\n"
-            "  - **ID:** T-382\n"
-            "  - **Issue:** #1216\n"
-            "  - **Model:** sonnet\n"
-        )
-        m = _mod._build_task_id_map(md)
-        self.assertEqual(m[1215]["id"], "T-381")
-        self.assertEqual(m[1215]["model"], "opus")
-        self.assertEqual(m[1215]["blocked_by"], "#1214")
-        self.assertEqual(m[1216]["id"], "T-382")
-        self.assertEqual(m[1216]["model"], "sonnet")
-
-    def test_skips_entries_missing_id_or_issue(self):
-        md = (
-            "- [ ] **no id**\n"
-            "  - **Issue:** #999\n"
-            "- [ ] **no issue**\n"
-            "  - **ID:** T-099\n"
-        )
-        self.assertEqual(_mod._build_task_id_map(md), {})
-
-    def test_empty_input(self):
-        self.assertEqual(_mod._build_task_id_map(""), {})
-        self.assertEqual(_mod._build_task_id_map(None), {})
-
-
-class ConvertBlockedBy(unittest.TestCase):
-    def test_translates_issue_refs_to_task_ids(self):
-        issue_to_id = {1214: "T-380", 1215: "T-381"}
-        self.assertEqual(
-            _mod._convert_blocked_by("#1214", issue_to_id), "T-380"
-        )
-        self.assertEqual(
-            _mod._convert_blocked_by("#1214, #1215", issue_to_id),
-            "T-380, T-381",
-        )
-
-    def test_unknown_issue_passes_through(self):
-        self.assertEqual(_mod._convert_blocked_by("#9999", {}), "#9999")
-
-    def test_handles_none_and_sentinels(self):
-        self.assertEqual(_mod._convert_blocked_by("(none)", {}), "(none)")
-        self.assertEqual(_mod._convert_blocked_by("", {}), "(none)")
-        self.assertEqual(_mod._convert_blocked_by("—", {}), "(none)")
-
-    def test_preserves_non_issue_text(self):
-        self.assertEqual(
-            _mod._convert_blocked_by("free-text reason", {}),
-            "free-text reason",
-        )
-
-
 class FetchTaskQueueDispatch(unittest.TestCase):
     """Exercise the per-issue loop with synthetic gh output.
 
-    Stubs run_capture so the test doesn't shell out to gh / git.
+    Stubs run_capture so the test doesn't shell out to gh.
     """
-    def _run(self, issues, tasks_md=""):
+    def _run(self, issues):
         captured = []
         def fake_run_capture(cmd, **kwargs):
             captured.append(cmd)
             if cmd[0] == "gh":
                 import json
                 return json.dumps(issues)
-            if cmd[0] == "git":
-                return tasks_md
             return ""
         original = _mod.run_capture
         _mod.run_capture = fake_run_capture
         try:
-            return _mod.fetch_task_queue("jakildev/IrredenEngine", _mod.ENGINE)
+            return _mod.fetch_task_queue("jakildev/IrredenEngine")
         finally:
             _mod.run_capture = original
 
@@ -175,31 +114,32 @@ class FetchTaskQueueDispatch(unittest.TestCase):
         }])
         self.assertEqual(out["open"][0]["area"], "docs")
 
-    def test_task_id_pulled_from_tasks_md_during_transition(self):
-        md = (
-            "- [ ] **render: task**\n"
-            "  - **ID:** T-385\n"
-            "  - **Issue:** #100\n"
-        )
+    def test_task_id_is_issue_number(self):
         out = self._run([{
             "number": 100, "title": "render: task",
             "labels": [{"name": "fleet:queued"}],
             "body": "",
-        }], tasks_md=md)
-        self.assertEqual(out["open"][0]["id"], "T-385")
-        self.assertEqual(out["open"][0]["title"], "T-385")
+        }])
+        self.assertEqual(out["open"][0]["id"], "#100")
+        self.assertEqual(out["open"][0]["issue"], "#100")
+        self.assertEqual(out["open"][0]["title"], "#100")
+        self.assertEqual(out["open"][0]["summary"], "render: task")
 
-    def test_blocked_by_translated_via_id_map(self):
-        md = (
-            "- [ ] **a**\n  - **ID:** T-100\n  - **Issue:** #50\n"
-            "- [ ] **b**\n  - **ID:** T-200\n  - **Issue:** #100\n"
-        )
+    def test_blocked_by_taken_verbatim_from_body(self):
         out = self._run([{
             "number": 100, "title": "b",
             "labels": [{"name": "fleet:queued"}],
             "body": "**Blocked by:** #50",
-        }], tasks_md=md)
-        self.assertEqual(out["open"][0]["blocked_by"], "T-100")
+        }])
+        self.assertEqual(out["open"][0]["blocked_by"], "#50")
+
+    def test_blocked_by_defaults_to_none(self):
+        out = self._run([{
+            "number": 100, "title": "b",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "",
+        }])
+        self.assertEqual(out["open"][0]["blocked_by"], "(none)")
 
     def test_empty_gh_output_returns_empty_sections(self):
         out = self._run([])


### PR DESCRIPTION
## Summary
- Delete `_build_task_id_map` and `_convert_blocked_by` (TASKS.md parser + #NNN→T-NNN translator).
- Drop the `git show origin/master:TASKS.md` fetch and the `_issue_map` plumbing from `fetch_task_queue` / `_populate_tasks_done`.
- Update `SINGLE_TASK_BLOCKER_RE` to match `^#\d+$`; teach `enrich_stackable_blocker_prs` to strip `#` and match `claude/<NNN>-` branch prefixes.
- Render `task["id"]` and `task["issue"]` both as `#NNN` so projection hashes stay shape-stable across the cutover.
- Stale-comment cleanup on `fleet:scope-shipped`, `fetch_closed_fleet_queued`, `project_queue_manager_ingest`, and the queue-manager-ingest spawn block.
- Drop the unused `repo_root` param on `fetch_task_queue`.

## Stack context
This PR is part of a stack. Reviewers: review this PR on its own;
the chain is coordinated in the PR body's "Stacked on" line.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/1243
Full chain: T-389, T-392

## Test plan
- [x] `python3 -m unittest scripts/fleet/tests/test_issue_queue_parser.py scripts/fleet/tests/test_enrich_stackable_blocker_prs.py scripts/fleet/tests/test_merger_projection.py scripts/fleet/tests/test_queue_manager_projection.py scripts/fleet/tests/test_worker_projection.py` — 75/75 green.
- [x] `python3 scripts/fleet/fleet-state-scout --once` writes `state.json` with the new `task["id"] == "#NNN"` shape; `in_progress` correctly partitioned for issues carrying `fleet:in-progress` or `fleet:claim-*` labels.
- [x] `grep -n "TASKS\|queue-tick\|T-NNN" scripts/fleet/fleet-state-scout` returns only one historical-note hit (the T-381 elimination comment).
- [ ] Live fleet cycle: scout publishes `state.json` with the new shape and downstream workers + reviewers pick tasks via the issue-number form.

Closes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)