### PR TITLE
#1254: fleet-queue-ingest: accept Suggested model as alias for Model

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -213,8 +213,9 @@ Author-side filing should add zero labels and let the human stamp
 triage flow adds the appropriate state labels post-triage.
 
 Include in the body:
-- **Area** (e.g. `engine/render`, `engine/math`, `docs`)
-- **Suggested model** (`[opus]` or `[sonnet]`)
+- **Area:** e.g. `engine/render`, `engine/math`, `docs`
+- **Model:** `opus` or `sonnet`
+- **Blocked by:** `(none)` or `#NNN`
 - **Acceptance criteria** (concrete check: build passes, test X works)
 - **Context** (why this matters, what you observed)
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -284,7 +284,7 @@ Each iteration:
    STOP. File a GitHub issue for the opus work (no labels — see
    [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Issue/PR labeling discipline") and note the escalation
    on your PR:
-   `gh issue create --repo jakildev/IrredenEngine --title "<what needs opus attention>" --body "Escalated from sonnet. Area: ... Suggested model: [opus]. Context: ..."`
+   `gh issue create --repo jakildev/IrredenEngine --title "<what needs opus attention>" --body "Escalated from sonnet.\n\n**Area:** ...\n**Model:** opus\n**Blocked by:** (none)\n\nContext: ..."`
    Then comment on your PR: "escalated — filed issue #N for opus".
    The human will triage the issue and add `human:approved` when
    ready. The scout ingests it on its next pass and the opus-workers

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -148,9 +148,10 @@ that needs justification in the linked issue.
    - **Why escalating** — one paragraph: scope-expansion,
      downstream-dependency, tier-mismatch, deferred-by-prior-
      review, etc.
-   - **Suggested model** — `[opus]` or `[sonnet]`.
-   - **Suggested area** — module path.
-   - **Suggested approach** — bullets, for the picker to
+   - **Model:** `opus` or `sonnet`.
+   - **Area:** module path.
+   - **Blocked by:** `(none)` or `#NNN`.
+   - Suggested approach — bullets, for the picker to
      validate.
 2. Swap PR labels atomically — `fleet:changes-made` MUST be added
    in the same call as `human:needs-fix` is removed to prevent a

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -470,7 +470,7 @@ check_model_tag() {
         task_model=$(BODY_B64="$body_b64" python3 <<'PYEOF'
 import base64, os, re, sys
 body = base64.b64decode(os.environ["BODY_B64"]).decode("utf-8", errors="replace")
-field_re = re.compile(r"^\s*-?\s*\*\*Model:\*\*\s*(.+?)\s*$", re.IGNORECASE)
+field_re = re.compile(r"^\s*-?\s*\*\*(?:Suggested\s+)?Model:\*\*\s*(.+?)\s*$", re.IGNORECASE)
 for line in body.splitlines():
     m = field_re.match(line)
     if m:
@@ -2274,7 +2274,7 @@ if "fleet:opus" in labels:
 if "fleet:sonnet" in labels:
     print("sonnet"); sys.exit(0)
 body = d.get("body", "") or ""
-field_re = re.compile(r"^\s*-?\s*\*\*Model:\*\*\s*(.+?)\s*$", re.IGNORECASE)
+field_re = re.compile(r"^\s*-?\s*\*\*(?:Suggested\s+)?Model:\*\*\s*(.+?)\s*$", re.IGNORECASE)
 for line in body.splitlines():
     m = field_re.match(line)
     if m:

--- a/scripts/fleet/fleet-queue-backfill-model-labels
+++ b/scripts/fleet/fleet-queue-backfill-model-labels
@@ -63,7 +63,7 @@ for issue in issues:
         skipped += 1
         continue
 
-    m = re.search(r'\*\*Model:\*\*\s*(opus|sonnet)', body, re.IGNORECASE)
+    m = re.search(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(opus|sonnet)', body, re.IGNORECASE)
     model = m.group(1).lower() if m else "opus"
     label = f"fleet:{model}"
 

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -176,8 +176,8 @@ except Exception:
 
 # Body-field parsers mirror fleet-state-scout._parse_issue_field so we
 # label issues by the same fields the scout reads back out.
-MODEL_RE = re.compile(r'\*\*Model:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
-BLOCKED_RE = re.compile(r'\*\*Blocked by:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
+MODEL_RE = re.compile(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
+BLOCKED_RE = re.compile(r'\*\*(?:Suggested\s+)?Blocked by:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
 
 stamped = 0
 skipped_already = 0

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -272,7 +272,7 @@ _AREA_LABEL_MAP = {
 def _parse_issue_field(body, field):
     if not body:
         return ""
-    m = re.search(rf'\*\*{re.escape(field)}:\*\*\s*(.+?)(?:\n|$)', body)
+    m = re.search(rf'\*\*(?:Suggested\s+)?{re.escape(field)}:\*\*\s*(.+?)(?:\n|$)', body)
     return m.group(1).strip() if m else ""
 
 

--- a/scripts/fleet/tests/test_issue_queue_parser.py
+++ b/scripts/fleet/tests/test_issue_queue_parser.py
@@ -34,6 +34,17 @@ class ParseIssueField(unittest.TestCase):
         body = "**Model:** opus\nmore text\n"
         self.assertEqual(_mod._parse_issue_field(body, "Model"), "opus")
 
+    def test_suggested_prefix_accepted(self):
+        body = "**Suggested Model:** sonnet\n**Suggested Blocked by:** (none)\n"
+        self.assertEqual(_mod._parse_issue_field(body, "Model"), "sonnet")
+        self.assertEqual(
+            _mod._parse_issue_field(body, "Blocked by"), "(none)"
+        )
+
+    def test_suggested_area_accepted(self):
+        body = "**Suggested Area:** scripts/fleet\n"
+        self.assertEqual(_mod._parse_issue_field(body, "Area"), "scripts/fleet")
+
 
 class FetchTaskQueueDispatch(unittest.TestCase):
     """Exercise the per-issue loop with synthetic gh output.
@@ -124,6 +135,14 @@ class FetchTaskQueueDispatch(unittest.TestCase):
         self.assertEqual(out["open"][0]["issue"], "#100")
         self.assertEqual(out["open"][0]["title"], "#100")
         self.assertEqual(out["open"][0]["summary"], "render: task")
+
+    def test_suggested_model_body_fallback(self):
+        out = self._run([{
+            "number": 100, "title": "x",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "**Suggested Model:** sonnet\n",
+        }])
+        self.assertEqual(out["open"][0]["model"], "sonnet")
 
     def test_blocked_by_taken_verbatim_from_body(self):
         out = self._run([{


### PR DESCRIPTION
## Summary

- Loosen the `**Model:**` regex in all six fleet parser sites (fleet-queue-ingest, fleet-state-scout, fleet-claim ×2, fleet-queue-backfill-model-labels) to accept `**Suggested Model:**` as an optional alias
- Also loosen `**Blocked by:**` and `**Area:**` parsers with the same `(?:Suggested\s+)?` prefix
- Update issue-filing templates in role-opus-architect, role-sonnet-author, and FLEET-FEEDBACK-HANDLING to use the canonical field names going forward
- Add 3 new unit tests covering the `Suggested` prefix path

## Context

Issue #1250 was filed using the LLM-era escalation template which writes `**Suggested model:** [sonnet]`. The strict `fleet-queue-ingest` parser (T-391) didn't recognize this form, defaulted to `fleet:opus`, and the task was picked up by the wrong model tier.

## Test plan
- [x] `python3 -m unittest scripts/fleet/tests/test_issue_queue_parser.py -v` — 17/17 pass
- [x] New tests: `test_suggested_prefix_accepted`, `test_suggested_area_accepted`, `test_suggested_model_body_fallback`

Closes #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)