### PR TITLE
fleet-claim: persist issue claim labels + add open-PR guard

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -54,8 +54,10 @@ Once the worker opens its PR, `fleet-state-scout` derives Owner
 from the PR's `headRefName` (e.g. `claude/1195-foo` → Owner
 `claude/1195-foo`). The `fleet:in-progress` and
 `fleet:claim-<host>-<agent>` labels on the issue together drive
-ownership state until the PR merges and `fleet-claim release`
-clears the claim label.
+ownership state through the PR lifecycle and are retained on the
+closed issue as a historical "who worked on this" record.
+Abandoned claims (no matching open `claude/<N>-*` PR + age > TTL)
+are swept by `fleet-claim cleanup --gh`.
 
 ### Multi-host fleet coordination
 
@@ -775,9 +777,10 @@ Specifically, **never pass these via `--label` when filing**:
   timer; the sweep will re-comment on the next tick if the PR is
   still idle. The human owns the resolution — the fleet won't
   re-free the issue automatically (that would race the worker if it
-  ever resumes). Closing the PR is the canonical reap path; the
-  scout clears `fleet:in-progress` / `fleet:claim-*` from the linked
-  issue on PR close.
+  ever resumes). Closing the PR is the canonical reap path; once
+  the PR is closed and the abandonment TTL passes,
+  `fleet-claim cleanup --gh` sweeps `fleet:claim-*` and
+  `fleet:in-progress` off the open issue.
 - `fleet:authored-on-linux` / `fleet:authored-on-macos` / `fleet:authored-on-windows` — owned by
   the **author's `commit-and-push`** (set at PR creation based on
   `uname -s`). Records which host the PR was opened from so the
@@ -799,10 +802,14 @@ Specifically, **never pass these via `--label` when filing**:
   `fleet:reviewing-<host>-<agent>` (generic prefix is the race lock;
   lex-min wins under contention; losers self-remove and bail). The
   suffix encodes who claimed so issue-tracker views show ownership
-  without anyone reading the PR. Cleared by `fleet-claim release` on
-  completion, by `fleet-claim cleanup --gh` when the linked issue
-  closes, or via orphan-sentinel replay on transient remove-label
-  failures. Don't add manually.
+  without anyone reading the PR. **Retained** through the PR
+  lifecycle and on the closed issue as a historical record;
+  `fleet-claim release` only clears the FS lock and worktree
+  reservation, not the issue-side label. Swept by
+  `fleet-claim cleanup --gh` only when the claim is **abandoned**
+  on an OPEN issue (no matching `claude/<N>-*` PR + TTL).
+  Orphan-sentinel replay retries transient remove-label failures.
+  Don't add manually.
 - `fleet:merger-cooldown` / `fleet:changes-made` — owned by the
   worker / merger pipeline.
 - `fleet:semantic-conflict` — owned by the **merger** (sets when it

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -155,6 +155,10 @@ slugify() {
 #
 # Stale label sweep runs from `fleet-claim cleanup --gh`; orphan sentinels
 # under ~/.fleet/orphans/ retry failed removals on the next cleanup pass.
+# `fleet:claim-*` labels are retained through the PR lifecycle and
+# preserved on closed issues as historical "who worked on this" record;
+# cleanup only sweeps them off OPEN issues whose claim is abandoned (no
+# matching open `claude/<N>-*` PR + age > TTL).
 
 derive_host() {
     # Normalize uname output to one of: mac | windows | linux.
@@ -608,6 +612,29 @@ cmd_claim() {
         return 1
     fi
 
+    # Open-PR sanity check: refuse if a PR with head `claude/<N>-*` is
+    # already open for this issue. The issue-side `fleet:claim-*` label
+    # tie-break (below) covers the active-work window, but the open PR
+    # itself is the canonical ownership signal — guarding here catches
+    # the case where the claim label was manually cleared while the PR
+    # is still live. Skipped on --stackable-on (stacking deliberately
+    # claims a task whose blocker has an open PR).
+    if [[ -z "$stackable_branch" ]] && command -v gh >/dev/null 2>&1; then
+        local repo_for_pr_check
+        repo_for_pr_check=$(repo_from_ns)
+        if [[ -n "$repo_for_pr_check" ]]; then
+            local existing_pr
+            existing_pr=$(gh pr list --repo "$repo_for_pr_check" --state open \
+                --json number,headRefName \
+                --jq ".[] | select(.headRefName | startswith(\"claude/${issue_num}-\")) | .number" \
+                2>/dev/null | head -1)
+            if [[ -n "$existing_pr" ]]; then
+                echo "fleet-claim claim: #${issue_num} already has open PR #${existing_pr} (head claude/${issue_num}-…); refusing duplicate claim" >&2
+                return 1
+            fi
+        fi
+    fi
+
     if mkdir "$CLAIMS_DIR/$slug" 2>/dev/null; then
         echo "$agent" > "$CLAIMS_DIR/$slug/owner"
         echo "$issue_num" > "$CLAIMS_DIR/$slug/title"
@@ -825,20 +852,14 @@ cmd_release() {
                 cmd_release_worktree "$owner" >/dev/null 2>&1 || true
             fi
         fi
-        # Issue-side cleanup: drop `fleet:claim-<host>-<agent>` so the
-        # next claimant doesn't trip the lex-min lock on a stale label.
-        if [[ -n "$owner" && "$owner" != "unknown" ]] && command -v gh >/dev/null 2>&1; then
-            local host repo issue_label
-            host=$(derive_host)
-            repo=$(repo_from_ns)
-            if [[ -n "$repo" ]]; then
-                issue_label="fleet:claim-${host}-${owner}"
-                gh_release_label "$repo" "$issue_num" "$issue_label" || true
-                gh issue edit "$issue_num" --repo "$repo" \
-                    --remove-label "fleet:in-progress" >/dev/null 2>&1 || true
-            fi
-        fi
-        echo "released: #${issue_num} (slug: $slug)"
+        # Issue-side `fleet:claim-*` and `fleet:in-progress` are NOT
+        # cleared here. The claim label is the canonical lock through
+        # PR lifecycle and stays as a historical record after merge;
+        # `fleet:in-progress` follows the same lifecycle so queue-list
+        # accurately reflects "active work present" until the issue
+        # closes. Abandoned claims (no matching open PR + TTL) are
+        # swept by `fleet-claim cleanup --gh` (second pass).
+        echo "released: #${issue_num} (slug: $slug, FS lock + worktree reservation cleared; issue labels retained)"
     else
         echo "not claimed: #${issue_num} (slug: $slug)"
     fi
@@ -983,7 +1004,9 @@ cmd_cleanup() {
     # merged "Closes #N" PR). Accepts zero or more --repo flags; defaults
     # to jakildev/IrredenEngine. With --gh, ALSO sweeps stale
     # fleet:reviewing-* / fleet:resolving-* labels off open PRs and
-    # stale fleet:claim-* labels off issues.
+    # abandoned fleet:claim-* labels off OPEN issues (no matching
+    # claude/<N>-* PR + TTL). Claim labels on CLOSED issues are kept
+    # as a historical record.
     mkdir -p "$CLAIMS_DIR"
 
     local -a repos=()
@@ -1116,46 +1139,11 @@ except Exception:
         done <<< "$pr_review_plan"
     done
 
-    # Second pass: sweep `fleet:claim-*` labels off CLOSED issues.
-    # Note: the fleet:queued search filter below only catches issues that
-    # were closed while still carrying fleet:queued. Issues whose
-    # fleet:queued label was manually removed before close will retain a
-    # stale fleet:claim-* indefinitely — low probability but worth knowing.
-    for repo in "${repos[@]}"; do
-        local claim_plan
-        claim_plan=$(gh issue list --repo "$repo" --state closed \
-            --search "label:\"fleet:queued\"" \
-            --json number,labels --limit 100 2>/dev/null \
-            | python3 -c '
-import json, sys
-try:
-    issues = json.load(sys.stdin)
-except Exception:
-    issues = []
-for issue in issues:
-    n = issue.get("number")
-    for l in (issue.get("labels") or []):
-        name = (l or {}).get("name", "") if isinstance(l, dict) else ""
-        if name.startswith("fleet:claim-"):
-            print(f"{n}\t{name}")
-' 2>/dev/null || echo "")
+    # `fleet:claim-*` labels on closed issues are intentionally
+    # preserved as a historical "who worked on this" record; no
+    # closed-issue label sweep runs here.
 
-        [[ -z "$claim_plan" ]] && continue
-
-        while IFS=$'\t' read -r issue_num label_name; do
-            [[ -z "$issue_num" || -z "$label_name" ]] && continue
-            if gh issue edit "$issue_num" --repo "$repo" \
-                    --remove-label "$label_name" >/dev/null 2>&1; then
-                echo "cleanup --gh: removed stale '$label_name' on $repo issue#$issue_num (closed)"
-                total_removed=$((total_removed + 1))
-            else
-                write_orphan_sentinel "$repo" "$issue_num" "$label_name" \
-                    "cleanup --gh: closed-issue remove-label failed"
-            fi
-        done <<< "$claim_plan"
-    done
-
-    # Third pass: sweep `fleet:claim-*` labels off OPEN issues when the
+    # Second pass: sweep `fleet:claim-*` labels off OPEN issues when the
     # claim is stale — no matching open WIP PR (head-branch claude/<N>-*)
     # exists and age > TTL.
     local claim_issue_stale_secs="${FLEET_CLAIM_STALE_SECS_ISSUES:-7200}"
@@ -2542,8 +2530,13 @@ commands:
                                 line:
                                 <url><TAB><headRefName><TAB><author><TAB><number>.
                                 Empty stdout means no eligible blocker.
-  release <issue-number>        release a claim (also clears the
-                                --stackable-on .meta sidecar).
+  release <issue-number>        release a claim (FS lock + worktree
+                                reservation + --stackable-on .meta
+                                sidecar). Issue-side `fleet:claim-*`
+                                and `fleet:in-progress` labels are
+                                retained — abandoned-claim sweep in
+                                `cleanup --gh` handles those when no
+                                matching open PR exists.
   check <issue-number>          check if free (exit 0=free, 1=taken).
   list                          list all active claims.
   stack "<n1> <n2> ..." [agent]
@@ -2561,18 +2554,21 @@ commands:
                                 (default: 7200).
   cleanup [--repo o/r] [--gh] ...
                                 Remove claims whose linked issue is
-                                CLOSED. With --gh also runs three
+                                CLOSED. With --gh also runs two
                                 GitHub sweeps:
                                 (1) stale fleet:reviewing-* and
                                     fleet:resolving-* labels off open
                                     PRs (>30 min age),
-                                (2) fleet:claim-* labels off
-                                    closed/merged issues,
-                                (3) fleet:claim-* labels off open
+                                (2) fleet:claim-* labels off open
                                     issues where the claim is
                                     abandoned — no matching WIP PR
                                     (head-branch claude/<N>-*) exists
                                     and age > TTL (default 7200s).
+                                    `fleet:in-progress` is removed
+                                    alongside the claim label.
+                                `fleet:claim-*` labels on CLOSED
+                                issues are preserved as a historical
+                                "who worked on this" record.
   review-claim <pr> <agent>     atomically claim a PR for review/smoke
                                 work via a
                                 fleet:reviewing-<host>-<agent> label.


### PR DESCRIPTION
## Summary

Two safety fixes for the post-T-390 claim machinery, with the cross-host fleet scenario as the motivating case.

**Persist `fleet:claim-*` and `fleet:in-progress` through the PR lifecycle.** `cmd_release` previously stripped both labels from the issue at PR-open time, so the issue showed "free" in queue-list while a `claude/<N>-*` PR was still live. In single-host operation that was harmless — workers iterate forward and don't loop back — but on a multi-host fleet a second host's worker scout would see the issue as available, win the lex-min tie-break trivially (no claim labels present), and race a duplicate PR. After this change `cmd_release` clears only the FS lock and worktree reservation; the issue-side labels persist through the PR lifecycle and stay on the closed issue as a historical "who worked on this" record.

**Open-PR cross-check in `cmd_claim`.** Belt-and-suspenders for the above: even if the persistent label is manually stripped, the open PR itself is the canonical ownership signal — `cmd_claim` now refuses if any open PR has head `claude/<N>-*` for the issue. Skipped on `--stackable-on` where the caller deliberately wants to stack on a blocker PR.

**Cleanup behavior.** `cleanup --gh` pass 2 (sweep claim labels off closed issues) is removed since the historical record is the whole point. The old pass 3 (abandonment sweep on OPEN issues, no matching open PR, age > TTL) is preserved and renumbered to pass 2; `fleet:in-progress` continues to be swept alongside the claim label in that path so an open issue never lingers as "in-progress with no owner" in queue-list.

**Ad-hoc cursor-flow work** continues to be unaffected — `fleet-claim` is opt-in for fleet workers, the new open-PR guard's prefix is `claude/<numeric>-`, so cursor-flow branches like `claude/<area>-<topic>` are invisible to it.

**FLEET.md updated** in the three spots that described the old release-clears-labels semantics: the ownership-state paragraph, the stale-PR reap note, and the `fleet:claim-<host>-<agent>` label-ownership entry.

## Test plan
- [x] `bash -n scripts/fleet/fleet-claim` (clean)
- [x] `bash scripts/fleet/tests/test_fleet_claim_model_gate.sh` (11/11)
- [x] `python3 scripts/fleet/tests/test_issue_queue_parser.py` (14/14)
- [x] `python3 scripts/fleet/tests/test_enrich_stackable_blocker_prs.py` (12/12)
- [ ] On a running fleet: claim a task, open a PR, observe `fleet:claim-mac-<agent>` and `fleet:in-progress` persist on the issue past `fleet-claim release`
- [ ] Manually `gh issue edit <N> --remove-label fleet:claim-...` while a `claude/<N>-*` PR is open, then attempt `fleet-claim claim <N>` — expect "already has open PR" refusal
- [ ] Allow the fleet to merge a PR closing an issue via `Closes #N` — verify the claim label remains on the closed issue (historical record)

## Follow-ups
- Add a dedicated `test_fleet_claim_open_pr_guard.sh` next to the existing model-gate suite. The model-gate stub falls through to `exit 0` for `gh pr list`, so the new guard isn't exercised by the existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)