### PR TITLE
#1258: render: camera pitch/roll for 3D orbit

### DIFF
--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -14,9 +14,12 @@ the ECS surface.
 - `C_TrixelFramebuffer` — wraps a `Framebuffer` (color + depth). Also
   ctor-allocated, `onDestroy()`-freed.
 - Camera rotation lives in `C_LocalTransform.rotation_` (the same SQT
-  quaternion every entity uses). `camera.hpp` exposes `IRPrefab::Camera::`
-  helpers that extract Z-yaw for the cardinal/residual split consumed by
-  the trixel rasterizer. `C_CameraYaw` was retired in T-364.
+  quaternion every entity uses), composed as `qZ(yaw) × qX(pitch)`.
+  `camera.hpp` exposes `IRPrefab::Camera::` helpers for both halves;
+  the GRID trixel rasterizer reads only Z-yaw (via the cardinal/residual
+  split), while DETACHED canvases consume the full quaternion through
+  `system_propagate_canvas_rotation`. Pitch is clamped to ±(π/2 − ε)
+  to avoid gimbal lock. `C_CameraYaw` was retired in T-364.
 - `C_Sprite` / `C_SpriteSheet` / `C_SpriteAnimation` — 2D screen-composite
   sprite + atlas metadata + per-instance playback state. Sprites bypass the
   trixel pipeline and draw at the `FRAMEBUFFER_TO_SCREEN` stage;

--- a/engine/prefabs/irreden/render/camera.hpp
+++ b/engine/prefabs/irreden/render/camera.hpp
@@ -45,7 +45,8 @@ inline IRComponents::C_LocalTransform *cameraTransform() {
 }
 
 // Extract Z-yaw from the ZX-composed camera quaternion, wrapped to [-π, π).
-// For q = qZ(yaw) × qX(pitch): atan2(q.z, q.w) = yaw/2 when |pitch| < π.
+// For q = qZ(yaw) × qX(pitch): atan2(q.z, q.w) = yaw/2 when pitch is
+// clamped to ±(π/2 − ε) as guaranteed by clampPitch.
 inline float yawFromQuat(const IRMath::vec4 &q) {
     float yaw = 2.0f * IRMath::atan2(q.z, q.w);
     yaw = IRMath::fmod(yaw + IRMath::kPi, IRMath::kTwoPi);
@@ -56,7 +57,7 @@ inline float yawFromQuat(const IRMath::vec4 &q) {
 
 // Extract X-pitch from the ZX-composed camera quaternion.
 // For q = qZ(yaw) × qX(pitch): atan2(q.x, q.w) = pitch/2 when
-// yaw is in [-π, π) (cos(yaw/2) > 0).
+// yaw is in (-π, π) (cos(yaw/2) > 0); wrapYaw guarantees this.
 inline float pitchFromQuat(const IRMath::vec4 &q) {
     return 2.0f * IRMath::atan2(q.x, q.w);
 }
@@ -65,7 +66,10 @@ inline float wrapYaw(float yaw) {
     float wrapped = IRMath::fmod(yaw + IRMath::kPi, IRMath::kTwoPi);
     if (wrapped < 0.0f)
         wrapped += IRMath::kTwoPi;
-    return wrapped - IRMath::kPi;
+    wrapped = wrapped - IRMath::kPi;
+    // Keep strictly above -π so pitchFromQuat's atan2(q.x, q.w) stays valid.
+    // The 1e-4 gap is invisible to the rasterizer (<1/10 000 of π/2 ≈ 0°0.006').
+    return IRMath::max(wrapped, -IRMath::kPi + 1e-4f);
 }
 
 static constexpr float kPitchLimit = IRMath::kHalfPi - 0.01f;

--- a/engine/prefabs/irreden/render/camera.hpp
+++ b/engine/prefabs/irreden/render/camera.hpp
@@ -57,7 +57,8 @@ inline float yawFromQuat(const IRMath::vec4 &q) {
 
 // Extract X-pitch from the ZX-composed camera quaternion.
 // For q = qZ(yaw) × qX(pitch): atan2(q.x, q.w) = pitch/2 when
-// yaw is in (-π, π) (cos(yaw/2) > 0); wrapYaw guarantees this.
+// cos(yaw/2) > 0 (yaw ≠ ±π). The ε guard in wrapYaw keeps the result
+// strictly above -π, so cos(yaw/2) > 0 is guaranteed for all callers.
 inline float pitchFromQuat(const IRMath::vec4 &q) {
     return 2.0f * IRMath::atan2(q.x, q.w);
 }

--- a/engine/prefabs/irreden/render/camera.hpp
+++ b/engine/prefabs/irreden/render/camera.hpp
@@ -7,8 +7,10 @@
 // camera is fully wired without crashing.
 //
 // Rotation lives in C_LocalTransform.rotation_ (the same SQT quaternion
-// every entity uses). The yaw helpers extract the Z-component for the
-// cardinal/residual split consumed by the integer trixel rasterizer.
+// every entity uses). The primary convention is ZX composition:
+// q = qZ(yaw) × qX(pitch). The GRID trixel rasterizer extracts only
+// Z-yaw for its cardinal/residual split; DETACHED canvases use the full
+// quaternion via system_propagate_canvas_rotation.
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -42,22 +44,41 @@ inline IRComponents::C_LocalTransform *cameraTransform() {
     return *opt;
 }
 
-// Extract Z-yaw from a unit quaternion and wrap to [-π, π).
+// Extract Z-yaw from the ZX-composed camera quaternion, wrapped to [-π, π).
+// For q = qZ(yaw) × qX(pitch): atan2(q.z, q.w) = yaw/2 when |pitch| < π.
 inline float yawFromQuat(const IRMath::vec4 &q) {
     float yaw = 2.0f * IRMath::atan2(q.z, q.w);
-    // Wrap to [-π, π)
     yaw = IRMath::fmod(yaw + IRMath::kPi, IRMath::kTwoPi);
     if (yaw < 0.0f)
         yaw += IRMath::kTwoPi;
     return yaw - IRMath::kPi;
 }
 
-// Wrap a yaw value to [-π, π).
+// Extract X-pitch from the ZX-composed camera quaternion.
+// For q = qZ(yaw) × qX(pitch): atan2(q.x, q.w) = pitch/2 when
+// yaw is in [-π, π) (cos(yaw/2) > 0).
+inline float pitchFromQuat(const IRMath::vec4 &q) {
+    return 2.0f * IRMath::atan2(q.x, q.w);
+}
+
 inline float wrapYaw(float yaw) {
     float wrapped = IRMath::fmod(yaw + IRMath::kPi, IRMath::kTwoPi);
     if (wrapped < 0.0f)
         wrapped += IRMath::kTwoPi;
     return wrapped - IRMath::kPi;
+}
+
+static constexpr float kPitchLimit = IRMath::kHalfPi - 0.01f;
+
+inline float clampPitch(float pitch) {
+    return IRMath::clamp(pitch, -kPitchLimit, kPitchLimit);
+}
+
+// Compose a ZX quaternion from yaw (Z) and pitch (X).
+inline IRMath::vec4 quatFromYawPitch(float yaw, float pitch) {
+    const IRMath::vec4 qZ = IRMath::quatAxisAngle(IRMath::vec3(0.0f, 0.0f, 1.0f), yaw);
+    const IRMath::vec4 qX = IRMath::quatAxisAngle(IRMath::vec3(1.0f, 0.0f, 0.0f), pitch);
+    return IRMath::quatMul(qZ, qX);
 }
 
 } // namespace detail
@@ -76,13 +97,6 @@ inline IRMath::vec4 getRotationQuat() {
     return IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f);
 }
 
-/// Set the camera's continuous Z-yaw to @p yaw radians (normalized to [-π, π)).
-/// Backward-compat shim: writes quatAxisAngle(z, yaw) into C_LocalTransform.
-inline void setYaw(float yaw) {
-    float wrapped = detail::wrapYaw(yaw);
-    setRotationQuat(IRMath::quatAxisAngle(IRMath::vec3(0.0f, 0.0f, 1.0f), wrapped));
-}
-
 /// Read the camera's Z-yaw (radians, in [-π, π)) extracted from the rotation
 /// quaternion. Returns 0 if the camera entity is not yet wired.
 inline float getYaw() {
@@ -91,14 +105,39 @@ inline float getYaw() {
     return 0.0f;
 }
 
-/// Add @p delta (radians) to the camera's yaw, normalized to [-π, π).
-/// NOTE: Rebuilds rotation as quatAxisAngle(z, yaw+delta), clobbering any
-/// non-Z components. Use setRotationQuat directly for full SO(3) compositions.
-/// If another driver calls setRotationQuat in the same frame, the last ECS
-/// writer wins — safe while a single rotation driver is active per frame;
-/// document any future GRID + SO(3) driver coexistence.
+/// Read the camera's X-pitch (radians) from the ZX-composed quaternion.
+/// Returns 0 if the camera entity is not yet wired.
+inline float getPitch() {
+    if (auto *t = detail::cameraTransform())
+        return detail::pitchFromQuat(t->rotation_);
+    return 0.0f;
+}
+
+/// Set both yaw and pitch in one call. Composes as qZ(yaw) × qX(pitch).
+/// Pitch is clamped to ±(π/2 - ε) to avoid gimbal lock.
+inline void setYawPitch(float yaw, float pitch) {
+    setRotationQuat(detail::quatFromYawPitch(detail::wrapYaw(yaw), detail::clampPitch(pitch)));
+}
+
+/// Set the camera's Z-yaw, preserving the current pitch.
+inline void setYaw(float yaw) {
+    setYawPitch(yaw, getPitch());
+}
+
+/// Add @p delta (radians) to the camera's yaw, preserving pitch.
 inline void rotateYaw(float delta) {
     setYaw(getYaw() + delta);
+}
+
+/// Set the camera's X-pitch, preserving the current yaw.
+/// Clamped to ±(π/2 - ε) to avoid gimbal lock.
+inline void setPitch(float pitch) {
+    setYawPitch(getYaw(), pitch);
+}
+
+/// Add @p delta (radians) to the camera's pitch, preserving yaw.
+inline void rotatePitch(float delta) {
+    setPitch(getPitch() + delta);
 }
 
 /// Both halves of the yaw split in one call. Prefer this over calling

--- a/engine/prefabs/irreden/render/camera_controls.hpp
+++ b/engine/prefabs/irreden/render/camera_controls.hpp
@@ -15,14 +15,14 @@
 // any creation that registers LIFETIME in UPDATE.
 //
 // Control scheme:
-//   Pan         Space + left-drag  (mouse + trackpad)
-//                or  middle-drag   (mouse only, legacy)
-//   Rotate yaw  Alt + left-drag    (mouse + trackpad)
-//                or  Ctrl + middle-drag (mouse only, legacy)
-//   Zoom        scroll wheel / two-finger scroll  (register in INPUT)
-//   Pan         WASD               (keyboard)
-//   Zoom        +/-                (keyboard)
-//   Close       Escape             (keyboard)
+//   Pan              Space + left-drag  (mouse + trackpad)
+//                     or  middle-drag   (mouse only, legacy)
+//   Orbit (yaw+pitch) Alt + left-drag  (mouse + trackpad)
+//                     or  Ctrl + middle-drag (mouse only, legacy)
+//   Zoom             scroll wheel / two-finger scroll  (register in INPUT)
+//   Pan              WASD               (keyboard)
+//   Zoom             +/-                (keyboard)
+//   Close            Escape             (keyboard)
 
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_command.hpp>

--- a/engine/prefabs/irreden/render/systems/system_camera_key_drag_rotate.hpp
+++ b/engine/prefabs/irreden/render/systems/system_camera_key_drag_rotate.hpp
@@ -13,9 +13,10 @@ using namespace IRMath;
 
 namespace IRSystem {
 
-// Alt + left-mouse drag: rotates camera yaw. Mirror of
+// Alt + left-mouse drag: orbit camera (yaw + pitch). Horizontal drag
+// controls Z-yaw, vertical drag controls X-pitch. Mirror of
 // CAMERA_MOUSE_ROTATE but bound to Alt+left so trackpad users (no
-// middle button) have a rotate gesture.
+// middle button) have an orbit gesture.
 //
 // Modifier gate is latched at the left-press frame: if Alt wasn't
 // held at PRESSED, no rotation engages — keeps widget/gizmo/picking
@@ -26,6 +27,7 @@ template <> struct System<CAMERA_KEY_DRAG_ROTATE> {
     bool dragging_ = false;
     vec2 dragStartMouse_ = vec2(0.0f);
     float dragStartYaw_ = 0.0f;
+    float dragStartPitch_ = 0.0f;
 
     void tick(C_Camera &) {}
 
@@ -40,13 +42,16 @@ template <> struct System<CAMERA_KEY_DRAG_ROTATE> {
             dragging_ = true;
             dragStartMouse_ = IRInput::getMousePositionScreen();
             dragStartYaw_ = IRPrefab::Camera::getYaw();
+            dragStartPitch_ = IRPrefab::Camera::getPitch();
         }
 
         if (dragging_ && leftDown) {
             const vec2 currentMouse = IRInput::getMousePositionScreen();
-            const float deltaPx = currentMouse.x - dragStartMouse_.x;
-            const float yawDelta = (deltaPx / kPixelsPerRevolution) * IRMath::kTwoPi;
-            IRPrefab::Camera::setYaw(dragStartYaw_ + yawDelta);
+            const float deltaX = currentMouse.x - dragStartMouse_.x;
+            const float deltaY = currentMouse.y - dragStartMouse_.y;
+            const float yawDelta = (deltaX / kPixelsPerRevolution) * IRMath::kTwoPi;
+            const float pitchDelta = -(deltaY / kPixelsPerRevolution) * IRMath::kTwoPi;
+            IRPrefab::Camera::setYawPitch(dragStartYaw_ + yawDelta, dragStartPitch_ + pitchDelta);
         } else {
             dragging_ = false;
         }

--- a/engine/prefabs/irreden/render/systems/system_camera_key_drag_rotate.hpp
+++ b/engine/prefabs/irreden/render/systems/system_camera_key_drag_rotate.hpp
@@ -50,6 +50,7 @@ template <> struct System<CAMERA_KEY_DRAG_ROTATE> {
             const float deltaX = currentMouse.x - dragStartMouse_.x;
             const float deltaY = currentMouse.y - dragStartMouse_.y;
             const float yawDelta = (deltaX / kPixelsPerRevolution) * IRMath::kTwoPi;
+            // negate: screen +Y is down; pitch up requires negative deltaY
             const float pitchDelta = -(deltaY / kPixelsPerRevolution) * IRMath::kTwoPi;
             IRPrefab::Camera::setYawPitch(dragStartYaw_ + yawDelta, dragStartPitch_ + pitchDelta);
         } else {

--- a/engine/prefabs/irreden/render/systems/system_camera_mouse_rotate.hpp
+++ b/engine/prefabs/irreden/render/systems/system_camera_mouse_rotate.hpp
@@ -45,6 +45,7 @@ template <> struct System<CAMERA_MOUSE_ROTATE> {
             const float deltaX = currentMouse.x - dragStartMouse_.x;
             const float deltaY = currentMouse.y - dragStartMouse_.y;
             const float yawDelta = (deltaX / kPixelsPerRevolution) * IRMath::kTwoPi;
+            // negate: screen +Y is down; pitch up requires negative deltaY
             const float pitchDelta = -(deltaY / kPixelsPerRevolution) * IRMath::kTwoPi;
             IRPrefab::Camera::setYawPitch(dragStartYaw_ + yawDelta, dragStartPitch_ + pitchDelta);
         } else {

--- a/engine/prefabs/irreden/render/systems/system_camera_mouse_rotate.hpp
+++ b/engine/prefabs/irreden/render/systems/system_camera_mouse_rotate.hpp
@@ -13,8 +13,8 @@ using namespace IRMath;
 
 namespace IRSystem {
 
-// Ctrl + middle-mouse drag: rotates camera yaw. Horizontal pixel delta
-// maps linearly to yaw; one full revolution = kPixelsPerRevolution pixels.
+// Ctrl + middle-mouse drag: orbit camera (yaw + pitch). Horizontal drag
+// controls Z-yaw, vertical drag controls X-pitch.
 // Middle drag without Ctrl falls through to CAMERA_MOUSE_PAN (unchanged).
 template <> struct System<CAMERA_MOUSE_ROTATE> {
     static constexpr float kPixelsPerRevolution = 1280.0f;
@@ -22,6 +22,7 @@ template <> struct System<CAMERA_MOUSE_ROTATE> {
     bool dragging_ = false;
     vec2 dragStartMouse_ = vec2(0.0f);
     float dragStartYaw_ = 0.0f;
+    float dragStartPitch_ = 0.0f;
 
     void tick(C_Camera &) {}
 
@@ -36,13 +37,16 @@ template <> struct System<CAMERA_MOUSE_ROTATE> {
             dragging_ = true;
             dragStartMouse_ = IRInput::getMousePositionScreen();
             dragStartYaw_ = IRPrefab::Camera::getYaw();
+            dragStartPitch_ = IRPrefab::Camera::getPitch();
         }
 
         if (dragging_ && middleDown) {
             const vec2 currentMouse = IRInput::getMousePositionScreen();
-            const float deltaPx = currentMouse.x - dragStartMouse_.x;
-            const float yawDelta = (deltaPx / kPixelsPerRevolution) * IRMath::kTwoPi;
-            IRPrefab::Camera::setYaw(dragStartYaw_ + yawDelta);
+            const float deltaX = currentMouse.x - dragStartMouse_.x;
+            const float deltaY = currentMouse.y - dragStartMouse_.y;
+            const float yawDelta = (deltaX / kPixelsPerRevolution) * IRMath::kTwoPi;
+            const float pitchDelta = -(deltaY / kPixelsPerRevolution) * IRMath::kTwoPi;
+            IRPrefab::Camera::setYawPitch(dragStartYaw_ + yawDelta, dragStartPitch_ + pitchDelta);
         } else {
             dragging_ = false;
         }

--- a/test/render/camera_yaw_test.cpp
+++ b/test/render/camera_yaw_test.cpp
@@ -78,6 +78,93 @@ TEST(CameraYawPitchPreservation, PitchPreservedAfterYawRotateThroughBoundary) {
 }
 
 // ---------------------------------------------------------------------------
+// clampPitch: values within ±kPitchLimit pass through; values beyond are
+// clamped. kPitchLimit = π/2 - 0.01 (avoids gimbal lock).
+// ---------------------------------------------------------------------------
+
+TEST(CameraClampPitch, ZeroPassesThrough) {
+    EXPECT_NEAR(IRPrefab::Camera::detail::clampPitch(0.0f), 0.0f, kTolerance);
+}
+
+TEST(CameraClampPitch, PositiveLimitPassesThrough) {
+    const float limit = IRPrefab::Camera::detail::kPitchLimit;
+    EXPECT_NEAR(IRPrefab::Camera::detail::clampPitch(limit), limit, kTolerance);
+}
+
+TEST(CameraClampPitch, NegativeLimitPassesThrough) {
+    const float limit = IRPrefab::Camera::detail::kPitchLimit;
+    EXPECT_NEAR(IRPrefab::Camera::detail::clampPitch(-limit), -limit, kTolerance);
+}
+
+TEST(CameraClampPitch, AboveLimitClampedToLimit) {
+    const float limit = IRPrefab::Camera::detail::kPitchLimit;
+    EXPECT_NEAR(IRPrefab::Camera::detail::clampPitch(limit + 0.5f), limit, kTolerance);
+}
+
+TEST(CameraClampPitch, BelowNegativeLimitClampedToNegativeLimit) {
+    const float limit = IRPrefab::Camera::detail::kPitchLimit;
+    EXPECT_NEAR(IRPrefab::Camera::detail::clampPitch(-(limit + 0.5f)), -limit, kTolerance);
+}
+
+TEST(CameraClampPitch, HalfPiClampedToLimit) {
+    const float limit = IRPrefab::Camera::detail::kPitchLimit;
+    EXPECT_NEAR(IRPrefab::Camera::detail::clampPitch(IRMath::kHalfPi), limit, kTolerance);
+}
+
+// ---------------------------------------------------------------------------
+// Pitch round-trip: quatFromYawPitch → pitchFromQuat.
+// For any valid (yaw, pitch) pair, pitchFromQuat(quatFromYawPitch(yaw, pitch))
+// must recover pitch (yaw must be strictly above -π so cos(yaw/2) ≠ 0).
+// ---------------------------------------------------------------------------
+
+TEST(CameraYawPitchRoundTrip, ZeroPitchRoundTrips) {
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(0.0f, 0.0f);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), 0.0f, kTolerance);
+}
+
+TEST(CameraYawPitchRoundTrip, PositivePitchAtZeroYawRoundTrips) {
+    const float pitch = 0.5f;
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(0.0f, pitch);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), pitch, kTolerance);
+}
+
+TEST(CameraYawPitchRoundTrip, NegativePitchAtZeroYawRoundTrips) {
+    const float pitch = -0.5f;
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(0.0f, pitch);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), pitch, kTolerance);
+}
+
+TEST(CameraYawPitchRoundTrip, PitchAtNonZeroYawRoundTrips) {
+    const float yaw = IRMath::kHalfPi;
+    const float pitch = 0.3f;
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(yaw, pitch);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), pitch, kTolerance);
+}
+
+TEST(CameraYawPitchRoundTrip, NegativePitchAtNegativeYawRoundTrips) {
+    const float yaw = -IRMath::kHalfPi;
+    const float pitch = -0.4f;
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(yaw, pitch);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), pitch, kTolerance);
+}
+
+TEST(CameraYawPitchRoundTrip, MaxPitchAtArbitraryYawRoundTrips) {
+    const float yaw = 1.2f;
+    const float pitch = IRPrefab::Camera::detail::kPitchLimit;
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(yaw, pitch);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), pitch, kTolerance);
+}
+
+TEST(CameraYawPitchRoundTrip, PitchSurvivesWrapYawClamp) {
+    // Regression: the wrapYaw ε guard keeps yaw strictly above -π, so
+    // pitchFromQuat's atan2(q.x, q.w) stays valid at the boundary.
+    const float pitch = 0.3f;
+    const float yaw = IRPrefab::Camera::detail::wrapYaw(-IRMath::kPi);
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(yaw, pitch);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), pitch, kTolerance);
+}
+
+// ---------------------------------------------------------------------------
 // Quaternion round-trip: setYaw → getYaw via quatAxisAngle(z, angle).
 // Verifies yawFromQuat extracts the Z-component correctly.
 // ---------------------------------------------------------------------------

--- a/test/render/camera_yaw_test.cpp
+++ b/test/render/camera_yaw_test.cpp
@@ -20,14 +20,18 @@ TEST(CameraYawWrap, ZeroStaysZero) {
     EXPECT_NEAR(yaw, 0.0f, kTolerance);
 }
 
-TEST(CameraYawWrap, PositivePiMapsToNegativePi) {
+TEST(CameraYawWrap, PositivePiClampsToEpsilonAboveNegativePi) {
+    // Both +π and -π map to -π before the ε guard, which then bumps to
+    // -π + 1e-4 so pitchFromQuat's atan2(q.x, q.w) never sees cos(yaw/2)=0.
     float yaw = IRPrefab::Camera::detail::wrapYaw(IRMath::kPi);
-    EXPECT_NEAR(yaw, -IRMath::kPi, kTolerance);
+    EXPECT_NEAR(yaw, -IRMath::kPi + 1e-4f, kTolerance);
 }
 
-TEST(CameraYawWrap, NegativePiStaysNegativePi) {
+TEST(CameraYawWrap, NegativePiClampsToEpsilonAbove) {
+    // -π is the wrap boundary where cos(yaw/2) = 0; the ε guard nudges the
+    // result to -π + 1e-4 so pitchFromQuat remains valid.
     float yaw = IRPrefab::Camera::detail::wrapYaw(-IRMath::kPi);
-    EXPECT_NEAR(yaw, -IRMath::kPi, kTolerance);
+    EXPECT_NEAR(yaw, -IRMath::kPi + 1e-4f, kTolerance);
 }
 
 TEST(CameraYawWrap, FullRotationWrapsToZero) {
@@ -47,6 +51,30 @@ TEST(CameraYawWrap, ManyFullRotationsDoNotDriftMaterially) {
         yaw = IRPrefab::Camera::detail::wrapYaw(yaw);
     }
     EXPECT_NEAR(yaw, 0.5f, 1e-3f);
+}
+
+// ---------------------------------------------------------------------------
+// Pitch preservation at the wrapYaw boundary.
+// Verifies the ε guard in wrapYaw keeps pitchFromQuat valid at yaw = -π.
+// ---------------------------------------------------------------------------
+
+TEST(CameraYawPitchPreservation, PitchPreservedAtNegativePiBoundary) {
+    // wrapYaw(-π) returns -π + 1e-4 instead of -π, so cos(yaw/2) ≠ 0 and
+    // pitchFromQuat can recover the pitch without reading atan2(0, 0) = 0.
+    const float pitch = 0.3f;
+    const float wrappedYaw = IRPrefab::Camera::detail::wrapYaw(-IRMath::kPi);
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(wrappedYaw, pitch);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), pitch, kTolerance);
+}
+
+TEST(CameraYawPitchPreservation, PitchPreservedAfterYawRotateThroughBoundary) {
+    // Simulates rotateYaw(δ) when the camera sits near yaw = -π.
+    // The pitch must survive even as wrapYaw clamps the result.
+    const float pitch = 0.5f;
+    float yaw = -IRMath::kPi - 0.001f;  // just past the boundary
+    yaw = IRPrefab::Camera::detail::wrapYaw(yaw);
+    const auto q = IRPrefab::Camera::detail::quatFromYawPitch(yaw, pitch);
+    EXPECT_NEAR(IRPrefab::Camera::detail::pitchFromQuat(q), pitch, kTolerance);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `setPitch` / `rotatePitch` / `setYawPitch` / `getPitch` to `IRPrefab::Camera::`, composing camera rotation as `qZ(yaw) × qX(pitch)` and clamping pitch to ±(π/2 − ε) to avoid gimbal lock.
- `setYaw` / `rotateYaw` route through `setYawPitch`, so yaw-only callers preserve any existing pitch instead of zeroing it.
- `CAMERA_KEY_DRAG_ROTATE` (Alt + left-drag) and `CAMERA_MOUSE_ROTATE` (Ctrl + middle-drag) snapshot both yaw and pitch at press time and apply horizontal + vertical mouse deltas in one `setYawPitch` call — a single drag orbits in both axes.

## Design choice (Option A from #1258)
GRID canvases continue to read only Z-yaw through the cardinal / residual split, preserving the iso-depth-axis invariant (`p.x + p.y + p.z` depth closed-form, cardinal-index APIs). DETACHED canvases already consume the full camera quaternion via `system_propagate_canvas_rotation` + `faceDeformationMatrixSO3`, so they pick up pitch with no pipeline change. Option B (full free camera) would require rewriting every consumer in `docs/design/iso-depth-axis-invariant.md` and is intentionally out of scope.

## Pre-existing test failure
`IrredenEngineTest::FrameDataSunLayout::MatchesStd140Packing` fails on `origin/master` independently of this change (filed as #1269). All 997 other tests pass.

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean.
- [x] `fleet-build --target IrredenEngineTest` — 997/998 pass; the one failure is the pre-existing #1269.
- [x] Default-state visual regression: ran `IRShapeDebug --auto-screenshot` against `origin/master` and dirty tree. All 7 shots match within the pre-existing GPU non-determinism floor (two consecutive master runs show larger pixel deltas than before/after at default pitch=0). No regression on the GRID-only path.
- [ ] Reviewer manual: Alt+left-drag should orbit the camera in yaw (horizontal) **and** pitch (vertical); DETACHED entities should render correctly at non-zero pitch; GRID rendering should look identical at the default cardinal orientation.

Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)