### PR TITLE
#1264: fleet: fix latch_usage_observation null overwrite in fleet-claude-stream

### DIFF
--- a/scripts/fleet/fleet-claude-stream
+++ b/scripts/fleet/fleet-claude-stream
@@ -141,12 +141,24 @@ def latch_usage_observation(rl_type, info):
     """
     if not isinstance(rl_type, str) or not rl_type:
         return
+    # "?" is the sentinel default used when rateLimitType is absent from the
+    # event payload; sanitizing it yields "_", which creates a junk _.json
+    # that the dispatcher would read. Skip it.
+    if rl_type == "?":
+        return
     safe_type = "".join(c if c.isalnum() or c in "_-" else "_" for c in rl_type)
     if not safe_type:
         return
+    util = info.get("utilization")
+    if util is None:
+        # status:"allowed" events carry no utilization field; only
+        # "allowed_warning" and "rejected" do. Preserve the last known
+        # warning observation so a bare "allowed" burst between warning
+        # events can't silently re-open the dispatcher's gate.
+        return
     payload = {
         "rateLimitType": rl_type,
-        "utilization": info.get("utilization"),
+        "utilization": util,
         "resetsAt": info.get("resetsAt"),
         "observed_at": int(time.time()),
     }

--- a/scripts/fleet/fleet-claude-stream
+++ b/scripts/fleet/fleet-claude-stream
@@ -149,6 +149,8 @@ def latch_usage_observation(rl_type, info):
     safe_type = "".join(c if c.isalnum() or c in "_-" else "_" for c in rl_type)
     if not safe_type:
         return
+    if safe_type == "_":
+        return
     util = info.get("utilization")
     if util is None:
         # status:"allowed" events carry no utilization field; only

--- a/scripts/fleet/tests/test_fleet_claude_stream_latch.py
+++ b/scripts/fleet/tests/test_fleet_claude_stream_latch.py
@@ -1,0 +1,87 @@
+"""Tests for fleet-claude-stream's latch_usage_observation.
+
+Covers:
+  - allowed_warning event (has utilization) => file written with correct value
+  - allowed event (no utilization) after warning => existing file NOT overwritten
+  - junk "?" rateLimitType => no file written (no _.json created)
+  - valid type with no utilization from the start => no file written
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).parent.parent / "fleet-claude-stream"
+_loader = importlib.machinery.SourceFileLoader("fleet_claude_stream", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_claude_stream", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+
+
+class LatchUsageObservation(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._usage_dir = pathlib.Path(self._tmpdir.name) / "usage"
+        self._usage_dir.mkdir()
+        _loader.exec_module(_mod)
+        _mod.USAGE_DIR = self._usage_dir
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _read(self, name):
+        p = self._usage_dir / f"{name}.json"
+        if not p.exists():
+            return None
+        return json.loads(p.read_text())
+
+    def test_warning_event_writes_utilization(self):
+        _mod.latch_usage_observation(
+            "five_hour",
+            {"utilization": 0.85, "resetsAt": "2026-05-28T00:00:00Z"},
+        )
+        data = self._read("five_hour")
+        self.assertIsNotNone(data)
+        self.assertEqual(data["utilization"], 0.85)
+        self.assertEqual(data["rateLimitType"], "five_hour")
+
+    def test_allowed_event_preserves_warning_value(self):
+        # First: latch a warning observation.
+        _mod.latch_usage_observation(
+            "five_hour",
+            {"utilization": 0.90, "resetsAt": "2026-05-28T00:00:00Z"},
+        )
+        # Then: an "allowed" event arrives with no utilization field.
+        _mod.latch_usage_observation(
+            "five_hour",
+            {"resetsAt": "2026-05-28T00:00:00Z"},
+        )
+        data = self._read("five_hour")
+        self.assertIsNotNone(data, "file must still exist")
+        self.assertEqual(
+            data["utilization"],
+            0.90,
+            "allowed event must NOT overwrite warning utilization with null",
+        )
+
+    def test_junk_question_mark_type_skipped(self):
+        _mod.latch_usage_observation(
+            "?",
+            {"resetsAt": "2026-05-28T00:00:00Z"},
+        )
+        # Neither _.json nor any other file should be created.
+        files = list(self._usage_dir.iterdir())
+        self.assertEqual(files, [], "junk '?' type must not create any file")
+
+    def test_no_utilization_on_first_event_writes_nothing(self):
+        _mod.latch_usage_observation(
+            "five_hour",
+            {"resetsAt": "2026-05-28T00:00:00Z"},
+        )
+        self.assertIsNone(self._read("five_hour"), "no file when first event has no utilization")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fleet/tests/test_fleet_claude_stream_latch.py
+++ b/scripts/fleet/tests/test_fleet_claude_stream_latch.py
@@ -17,7 +17,6 @@ import unittest
 _SCRIPT = pathlib.Path(__file__).parent.parent / "fleet-claude-stream"
 _loader = importlib.machinery.SourceFileLoader("fleet_claude_stream", str(_SCRIPT))
 _spec = importlib.util.spec_from_loader("fleet_claude_stream", _loader)
-_mod = importlib.util.module_from_spec(_spec)
 
 
 class LatchUsageObservation(unittest.TestCase):
@@ -25,8 +24,9 @@ class LatchUsageObservation(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self._usage_dir = pathlib.Path(self._tmpdir.name) / "usage"
         self._usage_dir.mkdir()
-        _loader.exec_module(_mod)
-        _mod.USAGE_DIR = self._usage_dir
+        self._mod = importlib.util.module_from_spec(_spec)
+        _loader.exec_module(self._mod)
+        self._mod.USAGE_DIR = self._usage_dir
 
     def tearDown(self):
         self._tmpdir.cleanup()
@@ -38,7 +38,7 @@ class LatchUsageObservation(unittest.TestCase):
         return json.loads(p.read_text())
 
     def test_warning_event_writes_utilization(self):
-        _mod.latch_usage_observation(
+        self._mod.latch_usage_observation(
             "five_hour",
             {"utilization": 0.85, "resetsAt": "2026-05-28T00:00:00Z"},
         )
@@ -49,12 +49,12 @@ class LatchUsageObservation(unittest.TestCase):
 
     def test_allowed_event_preserves_warning_value(self):
         # First: latch a warning observation.
-        _mod.latch_usage_observation(
+        self._mod.latch_usage_observation(
             "five_hour",
             {"utilization": 0.90, "resetsAt": "2026-05-28T00:00:00Z"},
         )
         # Then: an "allowed" event arrives with no utilization field.
-        _mod.latch_usage_observation(
+        self._mod.latch_usage_observation(
             "five_hour",
             {"resetsAt": "2026-05-28T00:00:00Z"},
         )
@@ -67,7 +67,7 @@ class LatchUsageObservation(unittest.TestCase):
         )
 
     def test_junk_question_mark_type_skipped(self):
-        _mod.latch_usage_observation(
+        self._mod.latch_usage_observation(
             "?",
             {"resetsAt": "2026-05-28T00:00:00Z"},
         )
@@ -76,7 +76,7 @@ class LatchUsageObservation(unittest.TestCase):
         self.assertEqual(files, [], "junk '?' type must not create any file")
 
     def test_no_utilization_on_first_event_writes_nothing(self):
-        _mod.latch_usage_observation(
+        self._mod.latch_usage_observation(
             "five_hour",
             {"resetsAt": "2026-05-28T00:00:00Z"},
         )


### PR DESCRIPTION
## Summary
- `latch_usage_observation` now skips the JSON write when `utilization` is absent (SDK `status:\"allowed\"` events have no utilization field)
- Preserves the last known warning value so bare `allowed` bursts between warning events can't silently re-open the dispatcher's usage gate
- Also guards against the `\"?\"` sentinel `rateLimitType` (produced when the field is absent from the event payload), which would sanitize to `\"_\"` and create a junk `_.json` the dispatcher reads

## Test plan
- [x] 4 unit tests in `scripts/fleet/tests/test_fleet_claude_stream_latch.py` — all pass (warning write, allowed-preserves-warning, junk-type skip, first-event-no-util no-write)
- [ ] Observe fleet run after merge: `~/.fleet/state/usage/five_hour.json` should retain non-null utilization after an `allowed` burst follows a `allowed_warning` event

Closes #1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)