### PR TITLE
#1266: fleet: guard against end_turn after simplify in commit-and-push flow

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -140,6 +140,15 @@ After `simplify` finishes:
   them to the user before committing and ask whether to proceed.
 - If the working tree is now clean, stop and report — nothing to commit.
 
+> **Autonomous-fleet guardrail (post-simplify boundary):** After processing
+> the simplify results above, your VERY NEXT action must be a **tool call**
+> advancing this skill to step 4 (draft commit message). Do not emit only
+> prose summarizing simplify's output and end the turn without a tool call.
+> Phrases like "Returning to commit-and-push" or "Clean pass — continuing…"
+> without an immediate following tool call are the signal you are about to
+> drop the flow. If you catch yourself writing them, issue the tool call
+> instead — the prose is redundant, the tool call is what matters.
+
 ### 4. Draft the commit message
 
 Shape:

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -142,12 +142,13 @@ After `simplify` finishes:
 
 > **Autonomous-fleet guardrail (post-simplify boundary):** After processing
 > the simplify results above, your VERY NEXT action must be a **tool call**
-> advancing this skill to step 4 (draft commit message). Do not emit only
-> prose summarizing simplify's output and end the turn without a tool call.
-> Phrases like "Returning to commit-and-push" or "Clean pass — continuing…"
-> without an immediate following tool call are the signal you are about to
-> drop the flow. If you catch yourself writing them, issue the tool call
-> instead — the prose is redundant, the tool call is what matters.
+> — either advancing to step 4 (draft commit message) or confirming the
+> clean-tree stop (nothing to commit). Do not emit only prose summarizing
+> simplify's output and end the turn without a tool call. Phrases like
+> "Returning to commit-and-push" or "Clean pass — continuing…" without an
+> immediate following tool call are the signal you are about to drop the
+> flow. If you catch yourself writing them, issue the tool call instead —
+> the prose is redundant, the tool call is what matters.
 
 ### 4. Draft the commit message
 

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -45,3 +45,22 @@ if [[ "$rc" == "2" ]]; then
     mkdir -p "$RATE_LIMIT_DIR"
     date +%s > "$RATE_LIMIT_DIR/$PANE_KEY.ts"
 fi
+
+# Auto-retrigger: when a worker role exits cleanly (rc=0) with a dirty
+# worktree and an active reservation, the session likely dropped the
+# commit-and-push flow mid-way (e.g. end_turn after simplify). Write a
+# trigger so the dispatcher re-fires the worker on the next tick; the
+# reservation gate at step 0.5 will resume the same task.
+if [[ "$rc" == "0" && ("$ROLE" == "opus-worker" || "$ROLE" == "sonnet-author") ]]; then
+    worktree_name=$(basename "$PWD")
+    reservation_issue=$(fleet-claim reservation-of "$worktree_name" 2>/dev/null || true)
+    if [[ -n "$reservation_issue" ]]; then
+        dirty=$(git -C "$PWD" status --porcelain 2>/dev/null || true)
+        if [[ -n "$dirty" ]]; then
+            trigger_dir="${FLEET_STATE_DIR:-$HOME/.fleet/state}/triggers"
+            mkdir -p "$trigger_dir"
+            touch "$trigger_dir/$ROLE"
+            echo "fleet-dispatch-wrap: dirty worktree '$worktree_name' + reservation #$reservation_issue after clean exit — wrote retrigger for $ROLE" >&2
+        fi
+    fi
+fi


### PR DESCRIPTION
Closes #1266

## Summary

- **`commit-and-push/SKILL.md`** — adds a blockquote guardrail at the post-simplify boundary (step 3). Names the exact failure pattern ("Returning to commit-and-push") and requires a tool call as the very next action.
- **`scripts/fleet/fleet-dispatch-wrap`** — adds auto-retrigger: when a worker role exits with rc=0, the worktree is dirty, and there is an active reservation, writes a trigger file so the dispatcher re-fires on the next tick.

## Blocked changes (needs human or non-self-modifying agent)

The auto-mode self-modification guard blocked edits to `.claude/commands/`. These two lines of the fix need to be applied manually:

**`role-sonnet-author.md` — insert after "Finalize the PR." sentence, before "Then remove the WIP label":**

```
   > **Post-simplify guardrail:** `commit-and-push` runs `simplify`
   > internally. After `simplify` returns, your VERY NEXT action must be
   > a tool call advancing `commit-and-push` (step 4: draft commit
   > message). Do NOT emit prose like "returning to commit-and-push" and
   > end the turn — that drops the flow. If you feel the urge to write a
   > transition sentence, issue the tool call instead.
```

**`role-opus-worker.md` — insert after "Finalize the PR." sentence, before "Remove the WIP label":**

Same text as above.

## Test plan
- [ ] Worker iteration hitting simplify boundary proceeds to tool call immediately after simplify returns (guardrail visible in SKILL.md)
- [ ] Simulate failure: leave dirty worktree + active reservation, exit with rc=0 → dispatcher re-fires worker on next tick (via trigger file in `~/.fleet/state/triggers/<role>`)
- [ ] Existing fleet-dispatch-wrap rate-limit behavior (rc=2) unchanged

Closes #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)