### PR TITLE
#1261: render-debug: rotation coverage in auto-screenshot infrastructure

### DIFF
--- a/.claude/skills/render-debug-loop/SKILL.md
+++ b/.claude/skills/render-debug-loop/SKILL.md
@@ -128,6 +128,7 @@ render mode, or one specific edge.
 | Pixel-level edge fidelity  | Per ROI crop, every pixel along cube/voxel silhouettes matches the baseline; no zigzag, single-pixel parity drift, or color shift |
 | Parity stable              | Compare each crop pixel-by-pixel across camera-offset shots — any visible drift on a silhouette is a regression unless the PR explicitly intended it |
 | Zoom stable                | Same crop position at zoom 4 and zoom 8 should show the *same* edge geometry, just larger; mismatched stairs are a subdivision/zoom-rounding bug |
+| Rotation stable            | Compare yaw=0 vs yaw=π/2 / π / 3π/2 shots — the scene should rotate but every face remains solid (no checkerboard #1256), inter-cardinal yaw=π/4 shows visible face deformation vs yaw=0 (#1257), and lighting falls on the correct rotated face normals (#1218, #1220). Demos targeted at rotation regressions must include yaw-rotated shots in their `kShots[]` (engine/video `AutoScreenshotShot::yawRadians_`); a shot list at yaw=0 only is blind to every rotation bug. |
 | Backend parity             | OpenGL and Metal produce visually matching frames; backend-only drift in a crop signals a parity port (handoff to `backend-parity` skill) |
 
 Then open whichever diagnosis section below applies to the surface you're

--- a/.claude/skills/render-debug-loop/diagnosis/lighting.md
+++ b/.claude/skills/render-debug-loop/diagnosis/lighting.md
@@ -20,6 +20,8 @@ The lighting stack is mostly built out. The `LIGHTING_TO_TRIXEL` pipeline stage 
 | Cel-shade bands smeared | LUT sampler filter mode (`GL_LINEAR` instead of `GL_NEAREST`) |
 | Fog of war reveals through walls | LOS ray casting in `c_fog_to_trixel` not consulting columnar span lists |
 | Lighting fidelity drifts past static window | Missing camera-anchor on GPU light volume (T-094) — `worldOrigin_` not subtracted before volume sample |
+| Faces lit from wrong direction at non-zero camera yaw | Face normal not rotated by `rasterYaw` in lighting / shadow shaders (#1218). Check `c_lighting_to_trixel.{glsl,metal}` and `c_compute_sun_shadow.{glsl,metal}` apply `R_z(rasterYaw)` to the per-face normal before dotting with sun / light direction. |
+| Sun shadow misaligned at non-zero camera yaw | Shadow-map sweep AABB built in mismatched coordinate frame (#1220). Check `system_bake_sun_shadow_map.hpp` AABB construction is in world frame, not in iso frame derived under yaw=0. |
 
 ## Baseline-diff screenshots
 

--- a/.claude/skills/render-debug-loop/diagnosis/shapes-trixel-sdf.md
+++ b/.claude/skills/render-debug-loop/diagnosis/shapes-trixel-sdf.md
@@ -17,6 +17,11 @@ The original diagnosis surface — applies to anything in the `VOXEL_TO_TRIXEL_S
 | Edges OK at cam (0,0), broken at (1,0) | Camera offset parity — `canvasOffset` flooring mismatch |
 | Wrong position | `C_PositionGlobal3D` not propagated before RENDER |
 | Curved shape looks boxy | Wrong `shapeType` enum reaching GPU |
+| Every-other-trixel checkerboard on X/Y faces at non-zero cardinal yaw | Trixel parity not accounting for rotated iso frame (#1256). Check `trixelOriginModifier` / `originModifier` vs `rasterYaw`; `localIDToFace_2x3` face/sub-pixel mapping doesn't swap with cardinal rotation; `f_trixel_to_framebuffer.glsl` parity sampling. Z face usually clean — gap is X/Y only. |
+| Faces look identical at yaw=0 and yaw=π/8 (no inter-cardinal deformation) | Residual yaw deformation matrix collapsing to identity (#1257). Check `emitDeformedFace` `maxN` cap, `IRMath::faceDeformationMatrix` column lengths, world vs detached canvas branch in `c_voxel_to_trixel_stage_1.{glsl,metal}`. |
+| Half the scene clipped at yaw=0 after a render change | Distance-texture device-level clear regressed (#1217). Per-frame `clearTexture` on the distance buffer in `system_voxel_to_trixel.hpp` must run unconditionally; viewport-conditional clears mis-cull voxels at the cull-bounds boundary. |
+| Geometry pops in/out of view as camera yaw changes | Chunk visibility mask not rotation-aware (#1219). Check `system_voxel_chunk_visibility.hpp` AABB sweep uses world-space chunk bounds, not iso-space derived under yaw=0 only. |
+| Face colors swapped at exact 90° / 180° / 270° rotation | Cardinal face-index remapping bug. Check `rotateCardinalZ` permutation and `encodeDepthWithFace` face-priority encoding under non-zero `rasterYaw`. |
 
 ## The 2x3 trixel diamond
 

--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -79,8 +79,8 @@ CanvasStressSettings g_settings{};
 int g_autoWarmupFrames = 0;
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0, 0), "overview"},
-    {0.6f, vec2(0, 0), "wide"},
+    {1.0f, vec2(0, 0), 0.0f, "overview"},
+    {0.6f, vec2(0, 0), 0.0f, "wide"},
 };
 
 // One detached object: a per-entity canvas (textures + voxel pool), a voxel

--- a/creations/demos/chunk_streaming_smoke/main.cpp
+++ b/creations/demos/chunk_streaming_smoke/main.cpp
@@ -58,8 +58,8 @@
 namespace {
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {2.0f, vec2(0, 0), "zoom2_chunk_cube"},
-    {4.0f, vec2(0, 0), "zoom4_chunk_cube"},
+    {2.0f, vec2(0, 0), 0.0f, "zoom2_chunk_cube"},
+    {4.0f, vec2(0, 0), 0.0f, "zoom4_chunk_cube"},
 };
 
 int g_autoWarmupFrames = 0;

--- a/creations/demos/gpu_particles/main.cpp
+++ b/creations/demos/gpu_particles/main.cpp
@@ -37,9 +37,9 @@ constexpr float kVelocityRange = 6.0f;   // ± voxels/second
 constexpr float kLifetimeSeconds = 8.0f; // long enough that all 6 shots see live particles
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {0.5f, vec2(0, 0), "fit_field"},
-    {1.0f, vec2(0, 0), "zoom1_origin"},
-    {2.0f, vec2(0, 0), "zoom2_origin"},
+    {0.5f, vec2(0, 0), 0.0f, "fit_field"},
+    {1.0f, vec2(0, 0), 0.0f, "zoom1_origin"},
+    {2.0f, vec2(0, 0), 0.0f, "zoom2_origin"},
 };
 
 int g_autoWarmupFrames = 0;

--- a/creations/demos/lighting/common/lighting_demo_scene.hpp
+++ b/creations/demos/lighting/common/lighting_demo_scene.hpp
@@ -99,17 +99,17 @@ struct DemoConfig {
 namespace detail {
 
 inline constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0, 0), "zoom1_origin"},
-    {2.0f, vec2(0, 0), "zoom2_origin"},
-    {4.0f, vec2(0, 0), "zoom4_origin"},
-    {4.0f, vec2(3, 5), "zoom4_offset_3_5"},
+    {1.0f, vec2(0, 0), 0.0f, "zoom1_origin"},
+    {2.0f, vec2(0, 0), 0.0f, "zoom2_origin"},
+    {4.0f, vec2(0, 0), 0.0f, "zoom4_origin"},
+    {4.0f, vec2(3, 5), 0.0f, "zoom4_offset_3_5"},
     // Higher-zoom shots make per-voxel-pool / SDF parity issues
     // (self-shadowing, AO mismatch from rounding-half-integer voxel
     // positions) immediately visible — they're how the rounding bug
     // fixed in commit `<this>` was found and how regressions on it
     // would surface.
-    {8.0f, vec2(0, 0), "zoom8_origin"},
-    {16.0f, vec2(0, 0), "zoom16_origin"},
+    {8.0f, vec2(0, 0), 0.0f, "zoom8_origin"},
+    {16.0f, vec2(0, 0), 0.0f, "zoom16_origin"},
 };
 
 inline int g_autoWarmupFrames = 0;

--- a/creations/demos/lowres_pan/main.cpp
+++ b/creations/demos/lowres_pan/main.cpp
@@ -38,14 +38,14 @@ using namespace IRMath;
 namespace {
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0.00f, 0.0f), "pan_x_00"},
-    {1.0f, vec2(0.05f, 0.0f), "pan_x_05"},
-    {1.0f, vec2(0.10f, 0.0f), "pan_x_10"},
-    {1.0f, vec2(0.15f, 0.0f), "pan_x_15"},
-    {1.0f, vec2(0.20f, 0.0f), "pan_x_20"},
-    {1.0f, vec2(0.25f, 0.0f), "pan_x_25"},
-    {1.0f, vec2(0.30f, 0.0f), "pan_x_30"},
-    {1.0f, vec2(0.35f, 0.0f), "pan_x_35"},
+    {1.0f, vec2(0.00f, 0.0f), 0.0f, "pan_x_00"},
+    {1.0f, vec2(0.05f, 0.0f), 0.0f, "pan_x_05"},
+    {1.0f, vec2(0.10f, 0.0f), 0.0f, "pan_x_10"},
+    {1.0f, vec2(0.15f, 0.0f), 0.0f, "pan_x_15"},
+    {1.0f, vec2(0.20f, 0.0f), 0.0f, "pan_x_20"},
+    {1.0f, vec2(0.25f, 0.0f), 0.0f, "pan_x_25"},
+    {1.0f, vec2(0.30f, 0.0f), 0.0f, "pan_x_30"},
+    {1.0f, vec2(0.35f, 0.0f), 0.0f, "pan_x_35"},
 };
 
 int g_autoWarmupFrames = 0;

--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -93,8 +93,8 @@ struct CliOverrides {
 };
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {0.5f, vec2(0, 0), "fit_grid"},
-    {1.0f, vec2(0, 0), "zoom1_origin"},
+    {0.5f, vec2(0, 0), 0.0f, "fit_grid"},
+    {1.0f, vec2(0, 0), 0.0f, "zoom1_origin"},
 };
 
 LuaPerfGridSettings g_settings{};

--- a/creations/demos/lua_pipeline_demo/main_lua.cpp
+++ b/creations/demos/lua_pipeline_demo/main_lua.cpp
@@ -27,7 +27,7 @@
 namespace {
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0, 0), "lua_pipeline_demo_zoom1"},
+    {1.0f, vec2(0, 0), 0.0f, "lua_pipeline_demo_zoom1"},
 };
 
 void registerLuaBindings() {

--- a/creations/demos/metal_clear_test/main.cpp
+++ b/creations/demos/metal_clear_test/main.cpp
@@ -9,9 +9,9 @@
 namespace {
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0, 0),  "metal_clear_zoom1"},
-    {2.0f, vec2(0, 0),  "metal_clear_zoom2"},
-    {4.0f, vec2(4, 4),  "metal_clear_zoom4_offset"},
+    {1.0f, vec2(0, 0),  0.0f, "metal_clear_zoom1"},
+    {2.0f, vec2(0, 0),  0.0f, "metal_clear_zoom2"},
+    {4.0f, vec2(4, 4),  0.0f, "metal_clear_zoom4_offset"},
 };
 
 } // namespace

--- a/creations/demos/modifier_demo/main.cpp
+++ b/creations/demos/modifier_demo/main.cpp
@@ -119,8 +119,8 @@ inline vec3 rowWorldCenter(int i) {
 // Screenshot shots: an overview of the floor and a closer cube-lane view.
 namespace {
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {2.0f, vec2(20.0f, 0.0f), "overview"},
-    {2.5f, vec2(40.0f, 0.0f), "cubes_focus"},
+    {2.0f, vec2(20.0f, 0.0f), 0.0f, "overview"},
+    {2.5f, vec2(40.0f, 0.0f), 0.0f, "cubes_focus"},
 };
 } // namespace
 

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -124,12 +124,12 @@ struct CliOverrides {
 };
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {0.5f, vec2(0, 0), "fit_grid"},
-    {1.0f, vec2(0, 0), "zoom1_origin"},
+    {0.5f, vec2(0, 0), 0.0f, "fit_grid"},
+    {1.0f, vec2(0, 0), 0.0f, "zoom1_origin"},
     // Profiler-overlay regression shot — captures the perf_stats overlay
     // backing T-275 acceptance: future overlay-breaking diffs (font, layout,
     // CPU/GPU readout) trip the render-verify image compare.
-    {0.5f, vec2(0, 0), "profiler_overlay"},
+    {0.5f, vec2(0, 0), 0.0f, "profiler_overlay"},
 };
 
 PerfGridSettings g_settings{};

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -72,22 +72,40 @@ constexpr IRVideo::RoiCrop kCropsZoom8Origin[] = {
 };
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0, 0), "zoom1_origin"},
-    {2.0f, vec2(0, 0), "zoom2_origin"},
+    {1.0f, vec2(0, 0), 0.0f, "zoom1_origin"},
+    {2.0f, vec2(0, 0), 0.0f, "zoom2_origin"},
     {4.0f,
      vec2(0, 0),
+     0.0f,
      "zoom4_origin",
      kCropsZoom4Origin,
      sizeof(kCropsZoom4Origin) / sizeof(kCropsZoom4Origin[0])},
-    {1.0f, vec2(1, 0), "zoom1_odd_offset"},
+    {1.0f, vec2(1, 0), 0.0f, "zoom1_odd_offset"},
     {8.0f,
      vec2(0, 0),
+     0.0f,
      "zoom8_origin",
      kCropsZoom8Origin,
      sizeof(kCropsZoom8Origin) / sizeof(kCropsZoom8Origin[0])},
-    {4.0f, vec2(3, 5), "zoom4_offset_3_5"},
+    {4.0f, vec2(3, 5), 0.0f, "zoom4_offset_3_5"},
     // zoom16_lod_all_visible: active tier LOD_0, LOD_0 (red) tops the co-located stack.
-    {16.0f, vec2(0, 0), "zoom16_lod_all_visible"},
+    {16.0f, vec2(0, 0), 0.0f, "zoom16_lod_all_visible"},
+
+    // Rotation coverage (#1261): four cardinals + one inter-cardinal expose
+    // rotation-only regressions (#1256 checkerboard, #1257 inter-cardinal
+    // deformation, future face-normal / shadow-AABB / chunk-mask bugs) that
+    // a yaw=0 shot list cannot catch. zoom8 close-ups make sub-pixel
+    // parity artifacts visible at full pixel scale.
+    {4.0f, vec2(0, 0), IRMath::kHalfPi, "zoom4_yaw90"},
+    {4.0f, vec2(0, 0), IRMath::kPi, "zoom4_yaw180"},
+    {4.0f, vec2(0, 0), 3.0f * IRMath::kHalfPi, "zoom4_yaw270"},
+    {4.0f, vec2(0, 0), IRMath::kQuarterPi, "zoom4_yaw45_inter_cardinal"},
+    {8.0f,
+     vec2(0, 0),
+     IRMath::kPi,
+     "zoom8_yaw180",
+     kCropsZoom8Origin,
+     sizeof(kCropsZoom8Origin) / sizeof(kCropsZoom8Origin[0])},
 };
 
 int g_autoWarmupFrames = 0; // 0 = --auto-screenshot not requested

--- a/creations/demos/sprite_demo/main.cpp
+++ b/creations/demos/sprite_demo/main.cpp
@@ -27,8 +27,8 @@ using namespace IRMath;
 namespace {
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0.0f, 0.0f), "layout_zoom1"},
-    {2.0f, vec2(0.0f, 0.0f), "layout_zoom2"},
+    {1.0f, vec2(0.0f, 0.0f), 0.0f, "layout_zoom1"},
+    {2.0f, vec2(0.0f, 0.0f), 0.0f, "layout_zoom2"},
 };
 
 int g_autoWarmupFrames = 0;

--- a/creations/demos/stateless_particles/main.cpp
+++ b/creations/demos/stateless_particles/main.cpp
@@ -51,10 +51,10 @@ constexpr float kVelocityJitter = 3.0f;
 constexpr float kPositionJitter = 2.0f;
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0, 0), "zoom1_origin"},
-    {2.0f, vec2(0, 0), "zoom2_origin"},
-    {4.0f, vec2(0, 0), "zoom4_origin"},
-    {8.0f, vec2(0, 0), "zoom8_origin"},
+    {1.0f, vec2(0, 0), 0.0f, "zoom1_origin"},
+    {2.0f, vec2(0, 0), 0.0f, "zoom2_origin"},
+    {4.0f, vec2(0, 0), 0.0f, "zoom4_origin"},
+    {8.0f, vec2(0, 0), 0.0f, "zoom8_origin"},
 };
 
 int g_autoWarmupFrames = 0;

--- a/creations/demos/ui_dockspace/main.cpp
+++ b/creations/demos/ui_dockspace/main.cpp
@@ -56,7 +56,7 @@ constexpr int kBottomH = 160;
 
 namespace {
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, IRMath::vec2(0.0f, 0.0f), "dockspace_idle"},
+    {1.0f, IRMath::vec2(0.0f, 0.0f), 0.0f, "dockspace_idle"},
 };
 int g_autoWarmupFrames = 0;
 } // namespace

--- a/creations/demos/ui_widgets/main.cpp
+++ b/creations/demos/ui_widgets/main.cpp
@@ -86,9 +86,9 @@ namespace {
 // full widget set. Camera position is irrelevant for the GUI canvas but
 // the harness still varies it.
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, IRMath::vec2(0.0f, 0.0f), "widgets_idle"},
-    {1.0f, IRMath::vec2(0.0f, 0.0f), "widgets_after_settle"},
-    {1.0f, IRMath::vec2(0.0f, 0.0f), "widgets_followup"},
+    {1.0f, IRMath::vec2(0.0f, 0.0f), 0.0f, "widgets_idle"},
+    {1.0f, IRMath::vec2(0.0f, 0.0f), 0.0f, "widgets_after_settle"},
+    {1.0f, IRMath::vec2(0.0f, 0.0f), 0.0f, "widgets_followup"},
 };
 
 int g_autoWarmupFrames = 0;

--- a/creations/demos/z_yaw_rotation/main_static.cpp
+++ b/creations/demos/z_yaw_rotation/main_static.cpp
@@ -37,8 +37,8 @@ namespace {
 constexpr float kYawDeltaPerFrame = IRMath::kPi / 360.0f;
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0, 0), "zoom1_yaw0"},
-    {2.0f, vec2(0, 0), "zoom2_yaw0"},
+    {1.0f, vec2(0, 0), 0.0f, "zoom1_yaw0"},
+    {2.0f, vec2(0, 0), 0.0f, "zoom2_yaw0"},
 };
 
 int g_autoWarmupFrames = 0;

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -243,9 +243,9 @@ LoftToolState g_loftTool;
 // stable camera. Camera position is irrelevant to the GUI canvas but
 // it does anchor the world-space scene render.
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, IRMath::vec2(0.0f, 0.0f), "editor_idle"},
-    {0.75f, IRMath::vec2(0.0f, 0.0f), "editor_zoom_out"},
-    {1.5f, IRMath::vec2(0.0f, 0.0f), "editor_zoom_in"},
+    {1.0f, IRMath::vec2(0.0f, 0.0f), 0.0f, "editor_idle"},
+    {0.75f, IRMath::vec2(0.0f, 0.0f), 0.0f, "editor_zoom_out"},
+    {1.5f, IRMath::vec2(0.0f, 0.0f), 0.0f, "editor_zoom_in"},
 };
 
 int g_autoWarmupFrames = 0;

--- a/engine/video/CLAUDE.md
+++ b/engine/video/CLAUDE.md
@@ -64,7 +64,9 @@ shot-cycling helper that any creation can opt into with a shot table
 plus five lines of wire-up. Used by the `render-debug-loop` and
 `render-verify` skills.
 
-- `AutoScreenshotShot` — one shot: zoom, camera-iso position, label.
+- `AutoScreenshotShot` — one shot: zoom, camera-iso position,
+  Z-yaw radians (default 0 — set non-zero to cover rotation
+  regressions per render-debug-loop rotation-stable criterion), label.
 - `AutoScreenshotConfig` — warmup/settle frame counts and a
   caller-owned `const AutoScreenshotShot *` table.
 - `parseAutoScreenshotArgv` — CLI parser for

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -28,8 +28,14 @@ struct RoiCrop {
 };
 
 /// One entry in an auto-screenshot shot list. The cycling system applies
-/// @c zoom_ and @c cameraIso_ via @c IRRender before capture, waits the
-/// configured settle frames, then triggers a composite screenshot.
+/// @c zoom_, @c cameraIso_, and @c yawRadians_ via @c IRRender /
+/// @c IRPrefab::Camera before capture, waits the configured settle frames,
+/// then triggers a composite screenshot.
+///
+/// @c yawRadians_ writes the camera's continuous Z-yaw before each shot via
+/// @c IRPrefab::Camera::setYaw, letting a shot list cover rotation-variant
+/// regressions (#1261) without per-demo wiring. Default 0 keeps existing
+/// shot tables at the cardinal baseline.
 ///
 /// @c label_ is printed to the log around each capture and — when @c crops_
 /// is set — appears in each crop PNG's filename
@@ -42,6 +48,7 @@ struct RoiCrop {
 struct AutoScreenshotShot {
     float zoom_ = 1.0f;
     vec2 cameraIso_ = vec2(0.0f);
+    float yawRadians_ = 0.0f;
     const char *label_ = "shot";
     const RoiCrop *crops_ = nullptr;
     int numCrops_ = 0;

--- a/engine/video/src/auto_screenshot.cpp
+++ b/engine/video/src/auto_screenshot.cpp
@@ -5,6 +5,7 @@
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_video.hpp>
 #include <irreden/ir_window.hpp>
+#include <irreden/render/camera.hpp>
 
 #include <cstdlib>
 #include <cstring>
@@ -31,13 +32,16 @@ struct CyclingState {
 
 bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut) {
     for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--auto-screenshot") != 0) continue;
+        if (std::strcmp(argv[i], "--auto-screenshot") != 0)
+            continue;
         int warmup = 10;
         if (i + 1 < argc) {
             int parsed = std::atoi(argv[i + 1]);
-            if (parsed > 0) warmup = parsed;
+            if (parsed > 0)
+                warmup = parsed;
         }
-        if (warmupFramesOut != nullptr) *warmupFramesOut = warmup;
+        if (warmupFramesOut != nullptr)
+            *warmupFramesOut = warmup;
         return true;
     }
     return false;
@@ -66,12 +70,18 @@ IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config
             if (state->settleCounter_ == 0) {
                 const auto &shot = state->config_.shots_[state->currentShot_];
                 IR_LOG_INFO(
-                    "AutoScreenshot {}/{}: {} (zoom={}, cam=({},{}))",
-                    state->currentShot_ + 1, state->config_.numShots_,
-                    shot.label_, shot.zoom_, shot.cameraIso_.x, shot.cameraIso_.y
+                    "AutoScreenshot {}/{}: {} (zoom={}, cam=({},{}), yaw={})",
+                    state->currentShot_ + 1,
+                    state->config_.numShots_,
+                    shot.label_,
+                    shot.zoom_,
+                    shot.cameraIso_.x,
+                    shot.cameraIso_.y,
+                    shot.yawRadians_
                 );
                 IRRender::setCameraZoom(shot.zoom_);
                 IRRender::setCameraPosition2DIso(shot.cameraIso_);
+                IRPrefab::Camera::setYaw(shot.yawRadians_);
                 state->settleCounter_ = state->config_.settleFrames_;
                 state->screenshotPending_ = false;
                 return;
@@ -85,9 +95,7 @@ IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config
             if (!state->screenshotPending_) {
                 const auto &shot = state->config_.shots_[state->currentShot_];
                 if (shot.numCrops_ > 0 && shot.crops_ != nullptr) {
-                    IRVideo::requestScreenshotWithCrops(
-                        shot.label_, shot.crops_, shot.numCrops_
-                    );
+                    IRVideo::requestScreenshotWithCrops(shot.label_, shot.crops_, shot.numCrops_);
                 } else {
                     IRVideo::requestScreenshot();
                 }


### PR DESCRIPTION
## Summary

- `AutoScreenshotShot` gains a `yawRadians_` field (default 0, so existing shot tables compile unchanged). The cycling system writes the camera's continuous Z-yaw via `IRPrefab::Camera::setYaw` alongside the existing zoom/iso-position setters before each capture — the shot list now drives rotation the same way it drives zoom and pan.
- IRShapeDebug's `kShots[]` adds five rotation shots: `zoom4_yaw90`, `zoom4_yaw180`, `zoom4_yaw270`, `zoom4_yaw45_inter_cardinal`, and a `zoom8_yaw180` close-up that reuses the existing crop table.
- `render-debug-loop`'s SKILL.md grows a "Rotation stable" always-on criterion; the `shapes-trixel-sdf` and `lighting` diagnosis tables get four new rotation symptom → file mappings (checkerboard #1256, missing deformation #1257, face-normal rotation #1218, shadow-AABB frame mismatch #1220).
- `engine/video/CLAUDE.md` notes the new field in the auto-screenshot inventory.

## Why

Every rotation regression that shipped in the last week — #1256 trixel checkerboard, #1257 inter-cardinal deformation, #1218 face-normal lighting, #1220 sun-shadow AABB — was invisible to the automated validation pipeline because every shot fired at yaw=0. This wires the yaw axis into the infrastructure so future PRs can catch the same class of bug at PR-review time instead of reaching production.

The 5 new shots immediately reproduce #1256 visually: the every-other-trixel checkerboard on X/Y voxel faces is plainly visible in `zoom4_yaw180` and `zoom4_yaw45_inter_cardinal` — exactly the failure mode this infrastructure exists to catch. Confirms the coverage works.

## Test plan

- [x] `fleet-build --target IRShapeDebug` clean (macOS / Metal)
- [x] `fleet-run IRShapeDebug --auto-screenshot 10` — all 12 shots captured (7 existing yaw=0 + 5 new rotation), no crashes, log includes `yaw=<radians>` per shot
- [x] Manual eyeball of yaw=π and yaw=π/4 screenshots — scene rotated as expected, X/Y faces show the pre-existing #1256 checkerboard (proves the new shots actually exercise the rotation surface)
- [ ] OpenGL/Linux smoke (label set)
- [ ] Windows smoke (label set)

Closes #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)