### PR TITLE
docs: voxel-face rasterization design + architect design-doc discipline

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -298,19 +298,59 @@ When working a `fleet:design-blocked` PR:
    suggested options.
 2. Decide on the architectural questions. You are not coding the
    fix yourself; you are providing direction the worker will execute.
-3. **Update the canonical plan file at `~/.fleet/plans/issue-<N>.md`**
+3. **Capture durable design decisions in `docs/design/`, not just the
+   plan file.** The plan file (`~/.fleet/plans/issue-<N>.md`) is
+   task-scoped and transient — it informs the worker resuming THIS PR
+   and then stops mattering once the task completes. If your decision
+   establishes or changes an **engine-level architectural invariant,
+   model, or contract** that outlives the task (a rasterizer face-
+   selection model, a coordinate-system invariant, a component-
+   ownership rule, a pipeline-ordering contract, a data-layout
+   decision), it belongs in a durable `docs/design/<feature>.md` that
+   is the **source of truth** — otherwise the decision evaporates when
+   the PR merges and a future worker re-derives or contradicts it.
+   Decide which bucket the decision is in:
+
+   - **Task-local** (this PR's approach, no reuse implication beyond
+     this deliverable) → plan file only (step 3a).
+   - **Engine-level architecture** (any future consumer needs to know
+     this; it constrains or enables work beyond this PR) → design doc
+     (step 3b) AND reference it from the plan file + nearest module
+     `CLAUDE.md`.
+
+   When in doubt, ask: "would a worker on a *different* task six weeks
+   from now need this decision to avoid re-deriving it or contradicting
+   it?" If yes, it's a design doc.
+
+   3a. **Plan file** (always): update `~/.fleet/plans/issue-<N>.md`
    (where `<N>` is the issue number referenced in the PR body via
-   `Closes #<N>` — assumes the task was ingested from a backing
-   issue, which is the common case). Add a revision-history entry
-   at the bottom and update the scope / acceptance criteria
-   sections in place. The worker reads the updated plan when it
-   picks the PR back up — open a follow-up PR to land the
-   `issue-<N>.md` change in `.fleet/plans/` if the direction is
-   substantial enough to need a repo-side trail. If the PR has no
-   backing issue (rare — ad-hoc work), skip the plan-file update and
-   put the full direction inline in the PR comment in step 4.
+   `Closes #<N>`). Add a revision-history entry at the bottom and
+   update scope / acceptance criteria in place. The worker reads the
+   updated plan when it picks the PR back up. If the PR has no backing
+   issue (rare), skip the plan-file update and put the full direction
+   inline in the PR comment in step 4. For an engine-level decision,
+   keep the plan file short and **point at the design doc** rather than
+   duplicating it — the doc is canonical, the plan file is the worker's
+   task pointer into it.
+
+   3b. **Design doc** (for engine-level architecture): create or update
+   `docs/design/<feature>.md` as the source of truth for the
+   model/invariant/contract. Match the existing docs' conventions
+   (`docs/design/iso-depth-axis-invariant.md` is a good template:
+   states the invariant, why it holds, what consumes it, migration
+   status, what to verify). Cross-reference it from the nearest module
+   `CLAUDE.md` so the next person opening that subtree finds it. Land
+   the doc in the **same PR as the implementation** (the worker adds
+   it), OR — when the redesign supersedes the PR's existing approach
+   and the model itself needs review independent of the code — open a
+   small **docs-only PR for the design doc first** and have the
+   implementation PR reference it. Prefer the docs-first PR for any
+   redesign that invalidates a worker's in-flight approach: it gives
+   the model a reviewable home before the worker rebuilds against it,
+   and it survives even if the original PR is abandoned.
 4. Post a PR comment with concrete decisions, re-scoped acceptance
-   criteria (if changed), and a pointer to the plan file:
+   criteria (if changed), and a pointer to the design doc (if step 3b
+   applied) and/or the plan file:
    ```
    gh pr comment <N> --body "## Architect direction
 
@@ -318,8 +358,9 @@ When working a `fleet:design-blocked` PR:
 
    <re-scoped acceptance criteria if the original ones changed>
 
-   The canonical plan at \`~/.fleet/plans/issue-<N>.md\` has been
-   updated."
+   Source of truth for this model: \`docs/design/<feature>.md\`
+   (engine-level decisions). Task pointer:
+   \`~/.fleet/plans/issue-<N>.md\` has been updated."
    ```
 5. Swap labels — remove `fleet:design-blocked`, add
    `fleet:design-unblocked`. The worker's next iteration picks

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -348,6 +348,39 @@ When working a `fleet:design-blocked` PR:
    redesign that invalidates a worker's in-flight approach: it gives
    the model a reviewable home before the worker rebuilds against it,
    and it survives even if the original PR is abandoned.
+
+   **Docs-first ⇒ block the implementation on the docs-PR MERGE, not
+   its open.** The whole point of a separate docs PR is to review the
+   model independently. If you let implementation resume the moment the
+   docs PR is *opened*, the worker builds against an unreviewed model
+   that review may change, reading the spec from an unmerged branch
+   (awkward and error-prone). Block on merge so the worker reads a
+   reviewed, stable spec from master via the normal workflow. Docs PRs
+   review fast (no build, no tests), so the latency cost is small.
+
+   **Route the block through a fresh task, not the blocked PR.** When
+   the resolution needs a docs-first PR, do NOT keep the original PR
+   `fleet:design-blocked` waiting on the doc — that strands it on a
+   manual re-flip nobody owns (who swaps the label when the docs PR
+   merges?). Instead:
+   - **Open the docs-first PR** for the model.
+   - **File a fresh implementation issue** carrying a structured
+     `**Blocked by:** #<docs-PR-number>` line in its body (the scout /
+     fleet-claim gate on that field — prose like "blocked on PR #X" is
+     NOT parsed, it must be the `**Blocked by:** #N` form). When the
+     docs PR merges (→ closed), the block clears automatically and the
+     task becomes claimable. This reuses the existing blocked-by-on-
+     merge machinery and needs no manual label flip.
+   - **Unblock the original PR immediately** (step 5) with wind-down
+     direction: keep any independently-correct prep work (helpers,
+     mechanical fixes), and either close it or narrow it to land just
+     that prep. The original PR is superseded by the fresh task; it is
+     not the thing waiting on the doc.
+
+   The canonical worked example of this whole flow is
+   #1275 (blocked PR, unblocked with wind-down) → #1277 (docs-first PR,
+   `docs/design/voxel-face-rasterization.md`) → #1278 (fresh impl task,
+   `**Blocked by:** #1277`).
 4. Post a PR comment with concrete decisions, re-scoped acceptance
    criteria (if changed), and a pointer to the design doc (if step 3b
    applied) and/or the plan file:

--- a/docs/design/voxel-face-rasterization.md
+++ b/docs/design/voxel-face-rasterization.md
@@ -1,0 +1,168 @@
+# Voxel face rasterization: visible-face triplet × exposed-face mask
+
+The voxel-pool → trixel rasterizer emits voxel cube faces into the canvas
+distance/color/entity textures. This doc is the source of truth for **which
+faces a voxel emits and why**. It supersedes the historical "always emit the
+three lower-coordinate faces" model, which was correct only at cardinal yaw 0
+and produced the stripe/checkerboard artifact (#1256) at every other cardinal.
+
+Read this before touching `c_voxel_to_trixel_stage_{1,2}`,
+`c_voxel_visibility_compact`, `c_compute_voxel_ao`, `c_lighting_to_trixel`,
+the `C_VoxelPool` face metadata, or any per-entity rotation work (#1272).
+
+## The six faces are distinct, not three axes with a sign
+
+A voxel cube has six faces. The correct mental model treats them as six
+distinct enum values, not three axes each with a ± side:
+
+```
+FaceId : X_NEG=0, X_POS=1, Y_NEG=2, Y_POS=3, Z_NEG=4, Z_POS=5
+```
+
+The historical raster conflated "the three faces a voxel emits" with "the
+three lower-coordinate faces (−X, −Y, −Z)". That conflation is the bug: it
+hardcodes the cardinal-0 visible set into the geometry the rasterizer
+produces. At cardinal 1 the camera sees +X / −Y / −Z; the +X face is never
+emitted by any voxel, the back-of-cube −X face wins the depth tie at the
+wrong pixel, Lambert against its inward normal clamps to zero, and the result
+is the dark stripe pattern in #1256.
+
+## The model: visible triplet × exposed mask
+
+Exactly three of the six faces are camera-facing at any orientation (the
+three whose outward normal has a positive dot with the view direction). Which
+three is a pure function of the camera quaternion (cardinal + residual +
+pitch). Independently, each voxel has a fixed set of **exposed** faces — those
+whose neighbor cell is empty or absent. A face is worth emitting **iff it is
+both camera-visible and exposed.**
+
+```
+emit(voxel, face)  ⟺  (face ∈ visibleTriplet(cameraQuat))
+                       ∧ (face ∈ voxel.exposedFaces)
+```
+
+This is correct by construction:
+
+- **Right faces emitted.** The visible triplet is recomputed per frame from
+  the camera quaternion, so cardinal yaw, residual yaw, and pitch (PR #1265)
+  all shift the triplet automatically. No hardcoded face set anywhere.
+- **Only the exterior copy emitted.** Interior voxels have all six faces
+  occluded by neighbors → `exposedFaces == 0` → they emit nothing. Along any
+  screen-colliding column, only the boundary voxel's face is exposed, so
+  there are no interior-boundary copies competing for `atomicMin`. The
+  depth-ordering ambiguity that the visible-triplet change alone does NOT
+  resolve (interior boundary vs exterior at non-zero cardinal) disappears
+  because the interior copies are never emitted.
+- **AO / lighting agree by construction.** AO and lighting read the same
+  per-face render context (outward normal, in-plane tangents) the rasterizer
+  used. There is no second face-label interpretation to drift out of sync —
+  the double-rotation bug that #1275's partial fix had to patch in AO and
+  lighting cannot recur, because there is one source of face metadata.
+
+## Data flow
+
+### Pool side — exposed-face mask (build/mutate time)
+
+Each voxel in `C_VoxelPool` carries `exposedFaces : uint8` (6 bits used).
+On insert: probe the six neighbor cells; set bit `f` for each face whose
+neighbor is empty or absent. On insert/remove, update the affected neighbors'
+masks too (a new voxel hides its neighbor's facing face; a removed voxel
+re-exposes it). Cost is six O(1) spatial-index probes per mutation — the same
+neighbor query the visibility-compact pass already performs, so the mask can
+be produced in the existing pass rather than a new one.
+
+The mask is camera-independent: it changes only when voxels are added or
+removed, never per frame.
+
+### CPU prep — visible-face triplet (per frame)
+
+Resolve `visibleFaces[3]` from the camera quaternion. Each entry is a
+`FaceRenderContext` packing:
+
+- `face` — the `FaceId`
+- `deformation` — the 2×2 matrix composing cardinal rotation + residual yaw
+  (and, for detached / per-entity SO(3), the object rotation). This is the
+  generalization of today's `faceDeform[3]` UBO.
+- `outwardNormal` — world-frame normal for Lambert
+- `tangents` — in-plane tangents for AO neighbor sampling, pre-rotated so the
+  neighbor-sample direction lands on the canvas pixel that actually holds the
+  +tangent neighbor at this orientation
+- format / blend metadata as needed
+
+Uploaded as one small UBO per frame (3 × ~80 bytes).
+
+### Raster — per voxel
+
+The per-voxel emit walks `visibleFaces[0..2]` and branches on the exposed bit:
+
+```glsl
+for (int i = 0; i < 3; ++i) {
+    FaceId f = visibleFaces[i].face;
+    if ((voxel.exposedFaces & (1u << f)) != 0u) {
+        emitFace(voxel, visibleFaces[i]);   // deformation, normal, tangents from the context
+    }
+}
+```
+
+Interior voxels skip all three branches and do zero `atomicMin` work — a
+throughput win at high voxel counts (a solid 32³ cube does emit work for
+~6·32² boundary voxels instead of all 32³).
+
+## Per-entity SO(3) (#1272) is the same model, per entity
+
+For an entity with its own SO(3) rotation rendered onto the main canvas, the
+visible triplet is computed in the **entity-local** frame:
+`visibleTriplet(cameraQuat × entityRotation⁻¹)`. The exposed-face mask is the
+same camera-independent per-voxel value. Each entity reads its own
+`FaceRenderContext` triplet from its UBO slot; the deformation matrix in each
+context composes the entity rotation with the camera. No separate render path
+— the main-canvas raster generalizes to per-entity rotation by indexing the
+face-context source per entity.
+
+This is why the six-distinct-faces model matters: under arbitrary entity
+rotation, the visible triplet can be any three of the six (e.g. a voxel tipped
+45° around two axes exposes a different triplet than any cardinal). The model
+handles it with no special cases.
+
+## Relationship to the iso-depth-axis invariant
+
+This model does **not** relax the iso-depth-axis invariant
+([`iso-depth-axis-invariant.md`](iso-depth-axis-invariant.md)). The GRID
+camera is still Z-yaw + cardinal + (PR #1265) pitch-for-detached only; iso
+depth is still `x + y + z` in the cardinal-rotated frame. What this model
+fixes is the rasterizer's face selection within that invariant — emitting the
+faces the camera actually sees at the current cardinal, rather than a
+hardcoded set. The depth math is unchanged; only the emitted-face set and the
+exposed-face gating are new.
+
+## Migration / status
+
+- **#1256** — the stripe/checkerboard artifact this model fixes.
+- **#1275** — the partial fix that escalated `fleet:design-blocked` and led to
+  this design. Its `cardinalLowerCornerShift` helper (correct coordinate
+  offset after `rotateCardinalZ`) and its AO+lighting face-label fix are
+  independently correct preparatory work and should be kept. The design redirect
+  changes what comes next: replace the four options in that PR's NEEDS-DESIGN
+  comment with this model.
+- **#1272** — per-entity SO(3) on the main canvas; consumes this model with a
+  per-entity visible triplet.
+- **PR #1265** — camera pitch via quaternion; the visible-triplet resolver
+  reads that quaternion, so pitch shifts the triplet for free on detached
+  canvases.
+
+## What to verify when implementing
+
+1. **Cardinal sweep.** All four cardinals render every cube face the camera
+   sees, no stripes, no missing exterior sides. Use the #1271 continuous-yaw
+   demo to catch rebracket glitches.
+2. **Exposed-mask correctness under mutation.** Add/remove a voxel adjacent to
+   another; confirm both masks update so no interior face emits and no exterior
+   face is dropped.
+3. **AO/lighting parity.** AO and lighting read the same `FaceRenderContext`;
+   confirm no double-rotation (the #1275 partial-fix symptom) at non-zero
+   cardinal.
+4. **Throughput.** Interior voxels emit nothing; measure that a solid cube's
+   emit count scales with surface area, not volume.
+5. **Per-entity (when #1272 lands).** A rotated entity on the main canvas
+   renders matched to its detached-canvas equivalent (the #1272 side-by-side
+   demo).

--- a/docs/design/voxel-face-rasterization.md
+++ b/docs/design/voxel-face-rasterization.md
@@ -146,7 +146,7 @@ exposed-face gating are new.
   comment with this model.
 - **#1272** — per-entity SO(3) on the main canvas; consumes this model with a
   per-entity visible triplet.
-- **PR #1265** — camera pitch via quaternion; the visible-triplet resolver
+- **#1265** (merged) — camera pitch via quaternion; the visible-triplet resolver
   reads that quaternion, so pitch shifts the triplet for free on detached
   canvases.
 

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -442,6 +442,29 @@ of the lighting pass. Invoke from a creation via the engine API
 (`IRRender::setDebugOverlay`) or in `shape_debug` via
 `--debug-overlay <none|ao|light_level|shadow>`.
 
+## Voxel face rasterization (which faces a voxel emits)
+
+The voxel-pool raster's face-selection model — which of a voxel's six
+faces get emitted into the canvas at a given camera orientation — is
+specified in
+[`docs/design/voxel-face-rasterization.md`](../../docs/design/voxel-face-rasterization.md).
+The canonical model is **visible-face triplet × exposed-face mask**: the
+three camera-facing faces (a pure function of the camera quaternion,
+recomputed per frame) intersected with the voxel's exposed faces (the
+camera-independent `exposedFaces` mask set at pool build/mutate time). A
+voxel emits a face iff it is both camera-visible and exposed.
+
+This supersedes the historical "always emit the three lower-coordinate
+faces (−X, −Y, −Z)" model, which was correct only at cardinal yaw 0 and
+caused the stripe/checkerboard artifact (#1256) at every other cardinal.
+Treat the six faces as six distinct enum values, **not** three axes each
+with a ± sign — see the design doc for why that distinction is what fixes
+the bug, and how the same model generalizes to per-entity SO(3) (#1272)
+and camera pitch (PR #1265). Read it before touching
+`c_voxel_to_trixel_stage_{1,2}`, `c_voxel_visibility_compact`,
+`c_compute_voxel_ao`, `c_lighting_to_trixel`, or the `C_VoxelPool` face
+metadata.
+
 ## SDF (`SHAPES_TO_TRIXEL`) vs voxel-pool (`VOXEL_TO_TRIXEL_*`) parity
 
 A `C_ShapeDescriptor` (SDF, GPU-evaluated) and a `C_VoxelSetNew` carved


### PR DESCRIPTION
## Summary

Docs-first PR establishing the architecture that supersedes #1275's design-blocked escalation, plus a process fix so engine feature docs stay the design source of truth.

**1. `docs/design/voxel-face-rasterization.md`** (new) — source of truth for which faces a voxel emits. Model: **visible-face triplet × exposed-face mask**.
- The three camera-facing faces are a per-frame function of the camera quaternion (cardinal + residual + pitch).
- The voxel's exposed faces (neighbor empty/absent) are a camera-independent mask set at pool build/mutate time.
- A voxel emits a face **iff** it is both camera-visible and exposed.
- Six faces are six distinct enums, NOT three axes with a ± sign — that distinction is the fix for #1256.
- Interior voxels emit nothing (throughput win); only the exterior copy of a visible face is emitted, so the `atomicMin` depth-ordering ambiguity that broke non-zero cardinals disappears by construction.
- Generalizes to per-entity SO(3) (#1272) and camera pitch (PR #1265) with no special cases.

**2. `engine/render/CLAUDE.md`** — new "Voxel face rasterization" section cross-referencing the design doc, before the SDF-parity section.

**3. `.claude/commands/role-opus-architect.md`** — the design-blocked resolution flow now splits decisions into:
- **Task-local** → plan file only (transient, consumed when the task completes)
- **Engine-level architecture** → durable `docs/design/<feature>.md` as source of truth, cross-referenced from module CLAUDE.md

Adds the **docs-first-PR pattern** for redesigns that supersede a worker's in-flight approach — the model gets a reviewable home that survives even if the original PR is abandoned. This is the fix for the failure mode where architectural decisions evaporate into ephemeral PR comments + transient plan files, and a future worker re-derives or contradicts them.

## Context

#1275 (partial fix for #1256 stripe artifact) escalated `fleet:design-blocked` with four candidate options. This PR captures **Option 5** (the synthesis that subsumes all four) as a durable design doc rather than burying it in a PR comment. Follow-up: the redesign issue (#1273) consumes this doc; #1275's prep work (`cardinalLowerCornerShift` + AO/lighting face-label fix) stays in.

## Test plan
- [x] Docs-only + role-doc change — no build impact
- [x] Design doc matches `iso-depth-axis-invariant.md` conventions (states model, why, consumers, migration status, what-to-verify)
- [ ] Reviewer: confirm the visible-triplet × exposed-mask model is sound and the cross-references resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)