### PR TITLE
render: cull-gate REBUILD_GRID_VOXELS, drop snapshot-compare cache

### DIFF
--- a/.claude/rules/cpp-ecs.md
+++ b/.claude/rules/cpp-ecs.md
@@ -66,6 +66,29 @@ Why the dirty-flag pattern is wrong:
 
 Allowed exception: the destination resource is **strictly CPU-authored, GPU-read-only, and re-uploading the whole buffer is genuinely expensive enough** that the optimization pays off. The fog-of-war texture is the only current example — `C_CanvasFogOfWar` uploads a 256×256 RGBA8 texture (256 KiB), the GPU never writes back, and per-cell `subImage2D` would split `revealRadius`'s loop into ~hundreds of API calls. Document the exception in the component header and in the `## Live deviations` block below; new components should not introduce dirty flags.
 
+### A snapshot-compare-and-early-return is a dirty flag in disguise
+
+The rule covers more than a literal `bool dirty_`. **Caching last frame's inputs on the component and early-returning when they match is the same anti-pattern** — the stored snapshot IS the "did this change since last frame" side-channel, regardless of whether the field is named `dirty_`, `lastFoo_`, or `cachedTransform_`. A naming argument ("these are component fields, not a dirty flag") does not exempt it.
+
+```cpp
+// FORBIDDEN — snapshot-compare-and-early-return (a dirty flag in disguise).
+if (set.hasLastTransform_ &&
+    set.lastRotation_ == xform.rotation_ &&
+    set.lastScale_ == xform.scale_ &&
+    set.lastTranslation_ == xform.translation_) {
+    return;                       // "nothing changed since last frame"
+}
+doWork(...);
+set.lastRotation_ = xform.rotation_;   // re-stamp the snapshot
+set.lastScale_ = xform.scale_;
+set.lastTranslation_ = xform.translation_;
+set.hasLastTransform_ = true;
+```
+
+It carries every cost the boolean does — it bloats the component (hurting archetype iteration density), accumulates re-stamp sites that silently drift, and hides the real ownership question. **Assume per-frame work is unconditional for entities that are actually being rendered**; the only honest reason to skip is that the result isn't observable this frame. Gate on **visibility / cull** (the work product is off-screen), not on input-equality.
+
+Worked example (#1288): `SYSTEM_REBUILD_GRID_VOXELS` cached `lastRebuildWorld{Rotation,Scale,Translation}_` on `C_VoxelSetNew` and early-returned when the live `C_WorldTransform` matched. That snapshot was a dirty flag wearing component-field clothing. The fix dropped the snapshot entirely: on-screen voxel sets re-rasterize every frame, and the system instead skips sets whose pool chunks are outside the cull viewport (`C_VoxelPool::isRangeVisible`). The cull gate answers "is this work observable?" — the honest question — instead of "did the inputs change?".
+
 ### Live deviations
 
 - `engine/prefabs/irreden/render/components/component_canvas_fog_of_war.hpp` — `C_CanvasFogOfWar::dirty_` and `allUnexplored_` gate the per-frame `subImage2D` upload of the 256² fog texture. Documented exception (CPU-authored, GPU-read-only, full-texture upload). T-161 evaluated migration to per-region `subImage2D` and deferred; see [`docs/design/fog-of-war-upload-strategy.md`](../../docs/design/fog-of-war-upload-strategy.md) for the analysis, the trigger conditions for revisiting, and the mechanical Strategy C migration sketch.

--- a/engine/prefabs/irreden/render/cull_viewport_state.hpp
+++ b/engine/prefabs/irreden/render/cull_viewport_state.hpp
@@ -8,6 +8,12 @@ using namespace IRMath;
 
 namespace IRRender {
 
+// Chunk margin for the CPU-side cull gate in REBUILD_GRID_VOXELS and the GPU
+// chunk-visibility mask in VOXEL_TO_TRIXEL_STAGE_1.  Both use this value so
+// the CPU skip decision is never tighter than the GPU raster decision:
+// if the GPU still renders a chunk's voxels, the CPU must still rebuild them.
+constexpr int kCullChunkMargin = 8;
+
 // Shared cull viewport state.  Updated once per frame (during the render
 // event) so that every render system sees a consistent frozen-or-live
 // viewport without maintaining its own snapshot.

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -312,9 +312,8 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // runs per entity.
         const float sweepDistance = sweepDistance_;
 
-        constexpr int kChunkMargin = 8;
         const IsoBounds2D chunkVp =
-            IRMath::shadowFeederIsoBounds(cull.isoViewport(kChunkMargin), sunDir_, sweepDistance);
+            IRMath::shadowFeederIsoBounds(cull.isoViewport(kCullChunkMargin), sunDir_, sweepDistance);
         const CardinalIndex chunkCardinal = IRMath::rasterYawCardinalIndex(frameData_.rasterYaw_);
         const auto &uploadMask = buildChunkVisibilityMask(voxelPool, chunkVp, chunkCardinal);
         chunkVisBuf_->subData(0, uploadMask.size() * sizeof(std::uint32_t), uploadMask.data());

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -74,9 +74,12 @@ for single voxels and particles.
 - `REBUILD_GRID_VOXELS` (UPDATE pipeline, T-294) — Epic C C6. Runs AFTER
   `UPDATE_VOXEL_SET_CHILDREN`. Re-rasterizes GRID-mode entities (entities
   carrying `C_RotationMode::GRID`, the default) into rotated world cells
-  whenever their `C_WorldTransform` changes. Cache lives on
-  `C_VoxelSetNew::lastRebuild*_`; ticks are O(1) when the transform is
-  unchanged. DETACHED-mode entities are skipped — they rotate through
+  from their live `C_WorldTransform`. On-screen sets re-rasterize every
+  frame (no per-set transform-comparison early-out — that was a dirty flag
+  in disguise, see `.claude/rules/cpp-ecs.md` "No dirty flags"); the only
+  skip is a frustum-cull gate (`C_VoxelPool::isRangeVisible` against the
+  shadow-feeder-expanded cull viewport), so sets whose pool chunks are all
+  off-screen pay nothing. DETACHED-mode entities are skipped — they rotate through
   the per-canvas TRS composite (`ENTITY_CANVAS_TO_FRAMEBUFFER`) and
   never touch the world voxel pool's globals. Cell aliasing
   (multiple authored voxels collapsing into one world cell after

--- a/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
@@ -270,6 +270,42 @@ struct C_VoxelPool {
         m_chunkBoundsDirty = true;
     }
 
+    // Cull query: true if any chunk overlapping the pool slot range
+    // [startIdx, startIdx + count) has an iso-space AABB that intersects
+    // `viewport`. Reads the chunk bounds as last computed by
+    // `rebuildChunkBounds` (driven by the render pipeline) — a caller in
+    // the UPDATE pipeline gets a one-frame-lagged but self-consistent
+    // answer (both the bounds and the cull viewport are last-render state).
+    // Chunk granularity is conservative: a chunk shared by several voxel
+    // sets reports visible if ANY of its voxels are in view, so the gate
+    // over-rebuilds rather than dropping geometry. Fail-safe: returns true
+    // when the bounds aren't available yet (pre-first-render) or the range
+    // runs past the computed chunk set, so geometry is never silently
+    // culled before bounds exist. The intersection test mirrors
+    // `buildChunkVisibilityMask` in `system_voxel_to_trixel.hpp`.
+    bool
+    isRangeVisible(std::size_t startIdx, std::size_t count, const IsoBounds2D &viewport) const {
+        if (count == 0) {
+            return false;
+        }
+        if (m_chunkBounds.empty()) {
+            return true;
+        }
+        const std::size_t firstChunk = startIdx / IRRender::kVoxelChunkSize;
+        const std::size_t lastChunk = (startIdx + count - 1) / IRRender::kVoxelChunkSize;
+        for (std::size_t c = firstChunk; c <= lastChunk; ++c) {
+            if (c >= m_chunkBounds.size()) {
+                return true;
+            }
+            const ChunkBounds &cb = m_chunkBounds[c];
+            if (cb.isoMax_.x >= viewport.min_.x && cb.isoMin_.x <= viewport.max_.x &&
+                cb.isoMax_.y >= viewport.min_.y && cb.isoMin_.y <= viewport.max_.y) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // Active-slot mask: 1 bit per pool slot, mirroring `m_voxelColors[i].color_.alpha_ != 0`.
     // The GPU compact shader at `c_voxel_visibility_compact.{glsl,metal}` reads this in place
     // of the per-voxel alpha test (T-287 / #950). CPU storage is `std::vector<uint32_t>`; the

--- a/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_set.hpp
@@ -30,17 +30,6 @@ struct C_VoxelSetNew {
     vec3 lastParentPosition_ = vec3(0.0f);
     bool hasLastParentPosition_ = false;
 
-    // SYSTEM_REBUILD_GRID_VOXELS push-at-mutation cache. The rebuild system
-    // compares the entity's live `C_WorldTransform` against these values
-    // each tick and only re-rasterizes the pool span when something
-    // changed — quaternion rotation, scale, or world translation. Mirrors
-    // the `lastParentPosition_` early-out UPDATE_VOXEL_SET_CHILDREN uses
-    // (both systems now read `C_WorldTransform.translation_` — T-301a).
-    vec4 lastRebuildWorldRotation_ = vec4(0.0f, 0.0f, 0.0f, 1.0f);
-    vec3 lastRebuildWorldScale_ = vec3(1.0f, 1.0f, 1.0f);
-    vec3 lastRebuildWorldTranslation_ = vec3(0.0f);
-    bool hasLastRebuildWorldTransform_ = false;
-
     // Index into the canvas voxel pool's underlying arrays. Captured at
     // allocation time so consumers never recompute it from a pointer-diff
     // against a separately-cached @c C_VoxelPool* (a stale cached pool

--- a/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
@@ -82,12 +82,8 @@ template <> struct System<REBUILD_GRID_VOXELS> {
         const IRRender::CullViewportState &cull = IRRender::getCullViewport();
         cullValid_ = cull.canvasSize_.x > 0 && cull.canvasSize_.y > 0;
         if (cullValid_) {
-            // Same chunk margin the GPU chunk-visibility mask uses, plus the
-            // shadow-feeder sweep so off-screen voxels that still cast into
-            // the visible frustum keep rebuilding.
-            constexpr int kChunkMargin = 8;
             chunkVp_ = IRMath::shadowFeederIsoBounds(
-                cull.isoViewport(kChunkMargin),
+                cull.isoViewport(IRRender::kCullChunkMargin),
                 sunDir,
                 sweepDistance
             );

--- a/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
@@ -4,16 +4,19 @@
 // SYSTEM_REBUILD_GRID_VOXELS — Epic C, C6 (T-294).
 //
 // Re-rasterizes a GRID-mode entity's authored voxels into rotated world
-// cells whenever its `C_WorldTransform` changes. Runs AFTER
-// UPDATE_VOXEL_SET_CHILDREN in the UPDATE pipeline — the translate-only
-// path writes a baseline, this system overwrites for entities whose SQT
-// rotation/scale (or world translation) shifted relative to the cached
-// snapshot on the voxel set.
+// cells. Runs AFTER UPDATE_VOXEL_SET_CHILDREN in the UPDATE pipeline — the
+// translate-only path writes a baseline, this system overwrites with the
+// entity's full SQT (rotation/scale composed into world cells).
 //
-// Push-at-mutation: the snapshot lives in `C_VoxelSetNew::lastRebuild*_`
-// (component fields rather than a dirty flag — see `cpp-ecs.md`
-// "No dirty flags"). When all three components of the world transform
-// match the cache, the tick is a O(1) early return.
+// On-screen entities re-rasterize unconditionally each frame (assume
+// dynamic). The only work we skip is for entities the camera can't see —
+// a cull concern, not a "did the transform change" concern. The system
+// queries the canvas voxel pool's per-chunk iso bounds (the same data the
+// GPU chunk-visibility mask reads) and skips a voxel set whose pool chunks
+// are all outside the cull viewport. There is deliberately NO per-set
+// snapshot-compare early-out: a "did this change since last frame"
+// side-channel is a dirty flag in disguise (see `cpp-ecs.md` "No dirty
+// flags").
 //
 // Cell aliasing is accepted by design: multiple authored voxels may
 // collapse into the same world cell after rounding (e.g. a 45° Z-rotated
@@ -27,12 +30,15 @@
 //    the per-canvas TRS composite (system_entity_canvas_to_framebuffer)
 //    and never touch the world voxel pool's positions.
 //  - `numVoxels_ <= 0` — headless / pre-canvas staging.
-//  - Cached `lastRebuildWorldTransform_*` matches live world transform.
+//  - The voxel set's pool chunks are all outside the cull viewport.
 
 #include <irreden/common/components/component_rotation_mode.hpp>
 #include <irreden/common/components/component_world_transform.hpp>
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_render.hpp>
+#include <irreden/render/camera.hpp>
+#include <irreden/render/cull_viewport_state.hpp>
+#include <irreden/render/sun_shadow_constants.hpp>
 #include <irreden/render/voxel_pool_allocation.hpp>
 #include <irreden/voxel/components/component_voxel_pool.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
@@ -52,9 +58,40 @@ template <> struct System<REBUILD_GRID_VOXELS> {
     IREntity::EntityId lastCanvas_ = IREntity::kNullEntity;
     C_VoxelPool *lastPool_ = nullptr;
 
+    // Frame-scoped cull viewport, resolved once in beginTick. `cullValid_`
+    // is false on the very first frame (before any render populates the
+    // cull viewport) — the gate then treats every set as visible.
+    IsoBounds2D chunkVp_{};
+    bool cullValid_ = false;
+
     void beginTick() {
         lastCanvas_ = IREntity::kNullEntity;
         lastPool_ = nullptr;
+
+        // Resolve the cull viewport once per frame, mirroring the chunk
+        // visibility gate in system_voxel_to_trixel.hpp. This system runs
+        // in the UPDATE pipeline, so getCullViewport() holds the previous
+        // frame's render-event snapshot — a one-frame lag that stays
+        // consistent with the GPU cull and is invisible for camera pans.
+        const bool shadowsEnabled = IRRender::getSunShadowsEnabled();
+        const vec3 sunDir =
+            shadowsEnabled ? IRPrefab::SunShadow::getFrameSunDirection() : vec3(0.0f);
+        const float sweepDistance =
+            shadowsEnabled ? IRPrefab::SunShadow::kSunShadowMaxDistance : 0.0f;
+
+        const IRRender::CullViewportState &cull = IRRender::getCullViewport();
+        cullValid_ = cull.canvasSize_.x > 0 && cull.canvasSize_.y > 0;
+        if (cullValid_) {
+            // Same chunk margin the GPU chunk-visibility mask uses, plus the
+            // shadow-feeder sweep so off-screen voxels that still cast into
+            // the visible frustum keep rebuilding.
+            constexpr int kChunkMargin = 8;
+            chunkVp_ = IRMath::shadowFeederIsoBounds(
+                cull.isoViewport(kChunkMargin),
+                sunDir,
+                sweepDistance
+            );
+        }
     }
 
     void tick(
@@ -69,14 +106,6 @@ template <> struct System<REBUILD_GRID_VOXELS> {
             return;
         }
 
-        const bool unchanged = voxelSet.hasLastRebuildWorldTransform_ &&
-                               voxelSet.lastRebuildWorldRotation_ == worldTransform.rotation_ &&
-                               voxelSet.lastRebuildWorldScale_ == worldTransform.scale_ &&
-                               voxelSet.lastRebuildWorldTranslation_ == worldTransform.translation_;
-        if (unchanged) {
-            return;
-        }
-
         IREntity::EntityId canvas = voxelSet.canvasEntity_;
         if (canvas == IREntity::kNullEntity) {
             canvas = IRRender::getActiveCanvasEntity();
@@ -86,6 +115,16 @@ template <> struct System<REBUILD_GRID_VOXELS> {
             lastCanvas_ = canvas;
         }
         C_VoxelPool &pool = *lastPool_;
+
+        // Cull gate: skip re-rasterization when none of this set's pool
+        // chunks are visible. Visible sets re-rasterize every frame.
+        if (cullValid_ && !pool.isRangeVisible(
+                              voxelSet.voxelStartIdx_,
+                              static_cast<std::size_t>(voxelSet.numVoxels_),
+                              chunkVp_
+                          )) {
+            return;
+        }
 
         const std::vector<IRRender::VoxelGpuPosition> &poolPositions = pool.getPositions();
         const std::vector<vec3> &poolOffsets = pool.getPositionOffsets();
@@ -109,11 +148,6 @@ template <> struct System<REBUILD_GRID_VOXELS> {
                 worldTransform
             );
         }
-
-        voxelSet.lastRebuildWorldRotation_ = worldTransform.rotation_;
-        voxelSet.lastRebuildWorldScale_ = worldTransform.scale_;
-        voxelSet.lastRebuildWorldTranslation_ = worldTransform.translation_;
-        voxelSet.hasLastRebuildWorldTransform_ = true;
     }
 
     static SystemId create() {


### PR DESCRIPTION
## Summary

Drops the snapshot-compare cache from `SYSTEM_REBUILD_GRID_VOXELS` / `C_VoxelSetNew` and replaces it with a frustum-cull gate, per #1288.

- **Dropped the cache.** Removed `lastRebuildWorld{Rotation,Scale,Translation}_` + `hasLastRebuildWorldTransform_` from `C_VoxelSetNew` and the per-tick early-return that compared them. On-screen GRID voxel sets now re-rasterize every frame (assume dynamic).
- **Gate on cull instead.** New `C_VoxelPool::isRangeVisible(startIdx, count, IsoBounds2D)` maps a pool slot range to its chunks and tests their iso-AABBs against a viewport. REBUILD skips a set only when all its chunks are off-screen.
- **Rule.** Expanded `.claude/rules/cpp-ecs.md` "No dirty flags" to forbid the snapshot-compare-and-early-return pattern (a dirty flag in disguise), citing #1288 as the worked example.

## Design decisions (flagged for architect review)

The issue asked to "coordinate with the architect on the cull-query API surface." The cull infrastructure already exists and is proven on the GPU side; these are the calls I made — please vet:

1. **Cull-query API = `C_VoxelPool::isRangeVisible`.** Lives on the pool because the pool owns the chunk bounds. Conservative at chunk granularity (a chunk shared by several sets reports visible if any voxel is in view → over-rebuild, never drop). Fail-safe to *visible* when chunk bounds aren't built yet or the range runs past them.
2. **Cull-state source = last-render `getCullViewport()`.** REBUILD runs in the UPDATE pipeline; the cull viewport is populated during the render event, so REBUILD reads the previous frame's snapshot — a one-frame lag that stays *consistent with the GPU cull* (same viewport source) and respects the culling-freeze debug toggle. Invisible for camera pans; a moving entity entering view can lag one frame (documented).
3. **Shadow-feeder reuse.** The cull viewport is expanded via `IRMath::shadowFeederIsoBounds` with the same margin (8) the GPU chunk-visibility mask uses, so off-screen voxels that still cast into the visible frustum keep rebuilding. Verified shadows stay intact at offset camera.
4. **Perf trade.** The static-visible cache is gone, so a fully-on-screen static scene now re-rasterizes every frame (the issue's intended behavior). The win is the off-screen case: panning so most of the scene leaves view drops rebuild cost proportionally to visible-chunk count.

`isRangeVisible` shares the chunk-AABB predicate with `buildChunkVisibilityMask`, and the shadow-feeder cull-viewport derivation is now inlined in three systems. Consolidating both is a cross-module refactor (touches the render systems + `engine/math`), out of scope here — filed as #1291.

## Test plan

- [x] `fleet-build --target IRShapeDebug` — clean (pre- and post-clang-format).
- [x] `fleet-build --target IRCanvasStress` — clean.
- [x] IRShapeDebug `--auto-screenshot`: GRID voxel cubes render correctly at origin, **camera-offset (cam=3,5)**, and non-zero-cardinal yaw shots; shadows intact — no over-culling of visible geometry.
- [x] IRCanvasStress `--auto-screenshot`: 25-cube GRID grid + 4 GRID-spin cubes + 9 detached canvases all render; DETACHED entities unaffected.
- [x] optimize: no hot-path smell (no getComponent-in-tick, no tick allocation, no fn-local static). `perf_grid_matrix` N/A — IRPerfGrid doesn't register REBUILD_GRID_VOXELS.
- [ ] Reviewer: confirm the one-frame-lag cull-state sourcing (design decision 2) is acceptable for the UPDATE→RENDER ordering.
- [ ] Linux/OpenGL smoke.

Closes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)