### PR TITLE
#1296: fleet-state-scout + fleet-claim: live blocker resolution + multi-blocker stacking

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -730,13 +730,18 @@ cmd_claim_base() {
 }
 
 cmd_find_stackable_blockers() {
-    # If the task is single-#N-blocked AND that blocker has exactly one
-    # open PR (matched via the head-branch `claude/<N>-*` or a body
-    # `Closes #N` reference), print one tab-separated line:
+    # If the task's **Blocked by:** field resolves to exactly one unresolved
+    # blocker with exactly one matching open PR (head-branch `claude/<N>-*`
+    # or body `Closes #N`), print one tab-separated line:
     #   <pr-url><TAB><headRefName><TAB><author-login><TAB><number>
-    # Otherwise print nothing (and exit 0). Multi-blocker, PR-URL-only,
-    # and zero/multiple-match cases all map to the empty output — callers
-    # treat the result as a strictly optional hint.
+    # Otherwise print nothing (and exit 0).
+    #
+    # Multi-blocker bodies are handled by resolving each #N reference live:
+    # references whose issue is CLOSED/MERGED, or whose claude/<N>-* PR is
+    # already merged, are filtered out first. If exactly one unresolved ref
+    # remains, it qualifies for single-stack (same contract as before, on
+    # the effective unresolved set rather than the raw body count).
+    # Two or more unresolved blockers → empty output (conservative).
     #
     # Usage: fleet-claim find-stackable-blockers <issue-number>
     local issue_num
@@ -755,10 +760,18 @@ cmd_find_stackable_blockers() {
 
     [[ -z "$body_b64" ]] && return 0
 
+    local repo
+    repo=$(repo_from_ns)
+    [[ -z "$repo" ]] && return 0
+    command -v gh >/dev/null 2>&1 || return 0
+
     local blocker
-    blocker=$(BODY_B64="$body_b64" python3 <<'PYEOF'
-import base64, os, re, sys
+    blocker=$(BODY_B64="$body_b64" REPO="$repo" python3 <<'PYEOF'
+import base64, json, os, re, subprocess, sys
+
 body = base64.b64decode(os.environ["BODY_B64"]).decode("utf-8", errors="replace")
+repo = os.environ.get("REPO", "")
+
 field_re = re.compile(r"^\s*-?\s*\*\*Blocked by:\*\*\s*(.+?)\s*$", re.IGNORECASE)
 value = None
 for line in body.splitlines():
@@ -768,13 +781,54 @@ for line in body.splitlines():
         break
 if value is None or value.lower().startswith("(none"):
     sys.exit(0)
-# v1: single-blocker only (matches the scout's stackable_blocker_pr filter
-# in fleet-state-scout). Multi-blocker stacking opens cherry-pick /
-# merge questions the merger has no machinery for.
+
 issue_refs = re.findall(r"#(\d+)", value)
 pr_urls = re.findall(r"https://github\.com/[^\s,)]+/pull/\d+", value)
-if len(issue_refs) == 1 and not pr_urls:
-    print(issue_refs[0])
+if not issue_refs or pr_urls:
+    sys.exit(0)
+
+# Fetch merged PR heads once for the "tracker-issue open, claude/<N>-* PR merged" case.
+merged_heads = []
+if repo:
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "list", "--repo", repo, "--state", "merged",
+             "--limit", "30", "--json", "headRefName",
+             "--jq", "[.[].headRefName]"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode == 0:
+            merged_heads = json.loads(r.stdout or "[]")
+    except Exception:
+        pass
+
+_resolve_cache = {}
+
+def is_satisfied(ref):
+    if ref in _resolve_cache:
+        return _resolve_cache[ref]
+    prefix = f"claude/{ref}-"
+    if any(h.startswith(prefix) for h in merged_heads):
+        _resolve_cache[ref] = True
+        return True
+    if not repo:
+        _resolve_cache[ref] = False
+        return False
+    try:
+        r = subprocess.run(
+            ["gh", "issue", "view", ref, "--repo", repo,
+             "--json", "state", "--jq", ".state"],
+            capture_output=True, text=True, timeout=10,
+        )
+        result = r.stdout.strip() in ("CLOSED", "MERGED")
+    except (subprocess.SubprocessError, OSError):
+        result = False
+    _resolve_cache[ref] = result
+    return result
+
+unresolved = [r for r in issue_refs if not is_satisfied(r)]
+if len(unresolved) == 1:
+    print(unresolved[0])
 PYEOF
 )
     [[ -z "$blocker" ]] && return 0
@@ -782,10 +836,6 @@ PYEOF
     # Find an open PR whose head-branch starts with claude/<N>- OR whose
     # body contains "Closes #N" (case-insensitive). Exactly one match
     # qualifies; zero or multiple → empty output.
-    local repo
-    repo=$(repo_from_ns)
-    [[ -z "$repo" ]] && return 0
-    command -v gh >/dev/null 2>&1 || return 0
 
     BLOCKER="$blocker" REPO="$repo" python3 <<'PYEOF'
 import json, os, re, subprocess, sys

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -700,10 +700,10 @@ _SMOKE_SKIP_LABELS = frozenset({
 
 MODEL_TOKEN_RE = re.compile(r"\b(opus|sonnet)\b")
 
-# Single-issue blocker (`#1234`). Reject multi-blocker (`#101, #102`),
-# free-text (`refactor lands`), and PR-URL (`https://...`) forms — all of
-# which the cross-author stacking flow can't resolve to one upstream branch
-# (multi-blocker decision deferred to v2 per T-110 plan Q3).
+# Single-issue blocker (`#1234`). Rejects free-text, URL, and multi-blocker
+# forms. Evaluated AFTER resolve_blocked_by() reduces multi-ref bodies to
+# their unresolved set, so a task originally blocked on `#N1, #N2` where #N1
+# is now CLOSED will have blocked_by=`#N2` at this point and will match.
 SINGLE_TASK_BLOCKER_RE = re.compile(r"^#\d+$")
 
 
@@ -734,6 +734,95 @@ def _blocker_pr_files(repo_key, pr_number):
     except (FileNotFoundError, json.JSONDecodeError):
         return []
     return [f.get("path", "") for f in data.get("files", [])]
+
+
+# ---------------------------------------------------------------------------
+# Live blocker resolution (T-1296)
+# ---------------------------------------------------------------------------
+#
+# The raw blocked_by field echoes the issue body's **Blocked by:** line
+# verbatim. When a blocker is CLOSED (or its work has shipped via a merged
+# claude/<N>-* PR) the field still shows it as live, causing workers to skip
+# tasks that are actually ready. resolve_blocked_by() runs after
+# collect_state() and updates each task's blocked_by in place to only
+# contain references that are still genuinely unresolved.
+
+_BLOCKER_REF_RE = re.compile(r"#(\d+)")
+_REPO_SLUG_MAP = {
+    "engine": "jakildev/IrredenEngine",
+    "game": "jakildev/irreden",
+}
+
+
+def _resolve_ref_satisfied(repo_slug, ref_str, cache):
+    """Return True if #ref_str is satisfied: issue CLOSED/MERGED, or a
+    claude/<ref>-* PR is MERGED. Uses per-tick cache to avoid redundant calls.
+    """
+    key = (repo_slug, ref_str)
+    if key in cache:
+        return cache[key]
+    result = False
+    try:
+        r = subprocess.run(
+            ["gh", "issue", "view", ref_str, "--repo", repo_slug,
+             "--json", "state", "--jq", ".state"],
+            capture_output=True, text=True, timeout=10,
+        )
+        result = r.stdout.strip() in ("CLOSED", "MERGED")
+    except (subprocess.SubprocessError, OSError):
+        pass
+    cache[key] = result
+    return result
+
+
+def resolve_blocked_by(state):
+    """Resolve blocked_by fields for all open tasks.
+
+    Uses already-fetched closed_fleet_queued and recent_merged_prs for
+    in-memory resolution; falls back to live gh issue view for refs not
+    covered by either. Mutates state in place.
+    """
+    per_tick_cache: dict = {}
+
+    for repo_key, repo_state in state["repos"].items():
+        repo_slug = _REPO_SLUG_MAP.get(repo_key)
+        if not repo_slug:
+            continue
+
+        closed_nums = {
+            str(i.get("number", ""))
+            for i in repo_state.get("closed_fleet_queued", [])
+            if i.get("number")
+        }
+        merged_heads = [
+            pr.get("headRefName", "") or ""
+            for pr in repo_state.get("recent_merged_prs", [])
+        ]
+
+        for task in repo_state.get("tasks", {}).get("open", []):
+            raw = (task.get("blocked_by") or "").strip()
+            if not raw or raw.lower().startswith("(none"):
+                continue
+            refs = _BLOCKER_REF_RE.findall(raw)
+            if not refs:
+                continue  # free-text or PR-URL form — leave unchanged
+
+            unresolved = []
+            for ref in refs:
+                if ref in closed_nums:
+                    continue
+                if any(h.startswith(f"claude/{ref}-") for h in merged_heads):
+                    continue
+                if _resolve_ref_satisfied(repo_slug, ref, per_tick_cache):
+                    continue
+                unresolved.append(ref)
+
+            if not unresolved:
+                task["blocked_by"] = "(none)"
+            elif len(unresolved) == 1:
+                task["blocked_by"] = f"#{unresolved[0]}"
+            else:
+                task["blocked_by"] = ", ".join(f"#{r}" for r in unresolved)
 
 
 def enrich_stackable_blocker_prs(state):
@@ -1272,6 +1361,7 @@ def _populate_done_tasks(state):
 def tick_once():
     state = collect_state()
     _populate_done_tasks(state)
+    resolve_blocked_by(state)
     enrich_stackable_blocker_prs(state)
     write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
 

--- a/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
+++ b/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim find-stackable-blockers with live blocker resolution (T-1296).
+#
+# Part (b) of the fix: cmd_find_stackable_blockers now resolves each #N ref
+# live before the single-blocker check. A task whose body says:
+#   **Blocked by:** #100, #101
+# where #100 is CLOSED and #101 has an open PR → returns the #101 PR.
+#
+# Stub dispatches:
+#   gh issue view N --json state --jq .state  → canned state
+#   gh pr list --state merged --json headRefName --jq ...  → empty list
+#   gh pr list --state open --json ...         → canned list with one PR
+#   fetch_issue_info shape: gh issue view N --json state,labels,body
+#
+# Issue stubs (for fetch_issue_info and check_blockers lookup):
+#   3001: **Blocked by:** #100 (done), #101 (still open)  — two refs, one closed
+#   3002: **Blocked by:** #101, #102                      — two open refs
+#   3003: **Blocked by:** #100                            — single ref, closed (all resolved)
+#   3004: **Blocked by:** (none)                          — no blocker
+#
+# Issue/PR state stubs:
+#   #100: CLOSED
+#   #101: OPEN (with an open PR claude/101-work-branch)
+#   #102: OPEN (no open PR)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_output() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $(printf '%q' "$expected")"
+        echo "        actual:   $(printf '%q' "$actual")"
+    fi
+}
+
+assert_nonempty() {
+    local actual="$1" msg="$2"
+    if [[ -n "$actual" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg (expected non-empty output, got nothing)"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR"
+
+# --- git stub (fleet-claim needs a git remote to derive repo_from_ns) -------
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+
+cat >"$STUB_DIR/git" <<'GITSTUB'
+#!/usr/bin/env bash
+if [[ "$*" == *"remote get-url"* ]]; then
+    echo "git@github.com:jakildev/IrredenEngine.git"
+    exit 0
+fi
+exec /usr/bin/git "$@"
+GITSTUB
+chmod +x "$STUB_DIR/git"
+
+# --- gh stub -----------------------------------------------------------------
+cat >"$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+#
+# Recognized invocations:
+#   gh issue view N --json state,labels,body             → full issue info
+#   gh issue view N --repo R --json state --jq .state    → state only
+#   gh pr list --state merged --limit 30 --json headRefName --jq ...
+#   gh pr list --state open --json url,headRefName,author,number,body --limit 200
+#   gh pr list --state open --json ... --jq ... (claim side)
+#   gh api .../labels ... / gh issue edit ... / gh label ...  → no-op
+
+has_jq=0
+issue_num=""
+pr_state=""
+is_merged_list=0
+is_open_list=0
+for arg in "$@"; do
+    [[ "$arg" == "--jq" ]] && has_jq=1
+    [[ "$arg" == "merged" ]] && pr_state="merged"
+    [[ "$arg" == "open"   ]] && pr_state="open"
+    if [[ -z "$issue_num" && "$arg" =~ ^[0-9]+$ ]]; then
+        issue_num="$arg"
+    fi
+done
+
+case "$1 $2" in
+    "issue view")
+        if [[ "$has_jq" -eq 1 ]]; then
+            # check_blockers / find-stackable-blockers state-only lookup
+            case "$issue_num" in
+                100) echo "CLOSED" ;;
+                101) echo "OPEN"   ;;
+                102) echo "OPEN"   ;;
+                *)   echo "OPEN"   ;;
+            esac
+            exit 0
+        fi
+        # fetch_issue_info: full body
+        case "$issue_num" in
+            3001)
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** #100 (done), #101 (still open)\n"}'
+                ;;
+            3002)
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** #101, #102\n"}'
+                ;;
+            3003)
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** #100\n"}'
+                ;;
+            3004)
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** (none)\n"}'
+                ;;
+            *)
+                printf '%s' '{"state":"OPEN","labels":[],"body":""}'
+                ;;
+        esac
+        exit 0
+        ;;
+    "pr list")
+        if [[ "$pr_state" == "merged" ]]; then
+            # No merged PRs in these fixtures — resolution uses gh issue view only.
+            echo "[]"
+            exit 0
+        fi
+        if [[ "$pr_state" == "open" ]]; then
+            # Return one open PR for issue #101.
+            printf '%s\n' '[{"url":"https://github.com/jakildev/IrredenEngine/pull/536","headRefName":"claude/101-work-branch","author":{"login":"bot"},"number":536,"body":"Closes #101"}]'
+            exit 0
+        fi
+        echo "[]"
+        exit 0
+        ;;
+    "api "*)
+        label=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -f) shift; case "$1" in labels\[\]=*) label="${1#labels[]=}" ;; esac ;;
+            esac
+            shift || true
+        done
+        [[ -n "$label" ]] && printf '[{"name":"%s"}]\n' "$label" || echo "[]"
+        exit 0
+        ;;
+    "issue edit"|"label "*)
+        exit 0
+        ;;
+esac
+exit 0
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+
+export PATH="$STUB_DIR:$PATH"
+
+# --- T1: two refs, one closed → returns the one open PR ----------------------
+echo "T1: multi-blocker (#100 closed, #101 open with PR) → returns PR for #101"
+result=$("$FLEET_CLAIM" find-stackable-blockers 3001 2>/dev/null || true)
+assert_nonempty "$result" "find-stackable-blockers returns PR line"
+# The returned line should reference #101's branch
+echo "  result: $result"
+if echo "$result" | grep -q "claude/101-work-branch"; then
+    PASS=$((PASS + 1))
+    echo "  ok: result includes claude/101-work-branch"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: result does not include claude/101-work-branch"
+fi
+
+# --- T2: two open refs → empty output ----------------------------------------
+echo "T2: two open blockers (#101, #102) → empty output"
+result=$("$FLEET_CLAIM" find-stackable-blockers 3002 2>/dev/null || true)
+assert_output "$result" "" "two open blockers → empty"
+
+# --- T3: single closed ref → empty output (all resolved, claim directly) -----
+echo "T3: single closed ref (#100) → empty output"
+result=$("$FLEET_CLAIM" find-stackable-blockers 3003 2>/dev/null || true)
+assert_output "$result" "" "single closed blocker → empty (no stackable needed)"
+
+# --- T4: (none) blocker → empty output ---------------------------------------
+echo "T4: (none) blocker → empty output"
+result=$("$FLEET_CLAIM" find-stackable-blockers 3004 2>/dev/null || true)
+assert_output "$result" "" "(none) blocker → empty"
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_live_blocker_resolution.py
+++ b/scripts/fleet/tests/test_live_blocker_resolution.py
@@ -1,0 +1,225 @@
+"""Tests for resolve_blocked_by() in fleet-state-scout (T-1296).
+
+Covers:
+  (a) one closed ref → (none)
+  (a) one still-open ref → unchanged bare #NNN
+  (a) two refs, one closed → bare #NNN for the remaining one
+  (a) both closed → (none)
+  (a) merged-PR variant: issue open but claude/<N>-* PR in merged list → satisfied
+  (a) free-text blocked_by not touched
+  (a) (none) field not touched
+  (b) integration with enrich_stackable_blocker_prs: multi-blocker reduces to
+      single-blocker after resolution → stackable_blocker_pr written
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+resolve_blocked_by = _mod.resolve_blocked_by
+enrich_stackable_blocker_prs = _mod.enrich_stackable_blocker_prs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _state(engine_tasks=None, engine_prs=None, closed=None, merged_prs=None):
+    return {
+        "repos": {
+            "engine": {
+                "tasks": {"open": engine_tasks or []},
+                "prs": engine_prs or [],
+                "closed_fleet_queued": closed or [],
+                "recent_merged_prs": merged_prs or [],
+            }
+        }
+    }
+
+
+def _task(id_, blocked_by):
+    return {"id": id_, "blocked_by": blocked_by, "area": None}
+
+
+def _pr(number, head_ref, author="bot"):
+    return {"number": number, "headRefName": head_ref, "author": author, "labels": []}
+
+
+def _closed_issue(number):
+    return {"number": number, "title": "done", "labels": []}
+
+
+def _merged_pr(head_ref):
+    return {"number": 0, "headRefName": head_ref, "baseRefName": "master"}
+
+
+def _gh_state_stub(state_map):
+    """Return a callable that stubs subprocess.run for gh issue view --jq .state."""
+    import subprocess
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "gh" and cmd[1] == "issue" and cmd[2] == "view":
+            ref = cmd[3]
+            state = state_map.get(ref, "OPEN")
+            result = subprocess.CompletedProcess(cmd, 0, stdout=state + "\n", stderr="")
+            return result
+        result = subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return result
+
+    return fake_run
+
+
+# ---------------------------------------------------------------------------
+# Part (a) — resolve_blocked_by
+# ---------------------------------------------------------------------------
+
+class TestResolveBlockedBy(unittest.TestCase):
+
+    def test_closed_ref_resolves_to_none(self):
+        """Single ref closed via closed_fleet_queued → (none)."""
+        tasks = [_task("#200", "#100")]
+        state = _state(engine_tasks=tasks, closed=[_closed_issue(100)])
+        resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "(none)")
+
+    def test_open_ref_unchanged(self):
+        """Single ref that is still open → bare #NNN."""
+        tasks = [_task("#200", "#101")]
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"101": "OPEN"})):
+            state = _state(engine_tasks=tasks)
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "#101")
+
+    def test_two_refs_one_closed_one_open(self):
+        """Two refs; closed one filtered out → bare #NNN for remaining."""
+        tasks = [_task("#200", "#100 (done), #101 (still open)")]
+        state = _state(engine_tasks=tasks, closed=[_closed_issue(100)])
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"101": "OPEN"})):
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "#101")
+
+    def test_both_refs_closed_resolves_to_none(self):
+        """Both refs closed → (none)."""
+        tasks = [_task("#200", "#100, #102")]
+        state = _state(engine_tasks=tasks, closed=[_closed_issue(100), _closed_issue(102)])
+        resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "(none)")
+
+    def test_merged_pr_variant_satisfies_open_issue(self):
+        """Issue still open but claude/<N>-* PR merged → satisfied."""
+        tasks = [_task("#200", "#101")]
+        state = _state(
+            engine_tasks=tasks,
+            merged_prs=[_merged_pr("claude/101-rotation-fix")],
+        )
+        resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "(none)")
+
+    def test_merged_pr_prefix_discrimination(self):
+        """claude/1011-* does NOT satisfy #101 (requires trailing dash)."""
+        tasks = [_task("#200", "#101")]
+        state = _state(
+            engine_tasks=tasks,
+            merged_prs=[_merged_pr("claude/1011-unrelated")],
+        )
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"101": "OPEN"})):
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "#101")
+
+    def test_free_text_blocked_by_not_touched(self):
+        """Free-text (no #N refs) blocked_by is left unchanged."""
+        tasks = [_task("#200", "pending design review")]
+        state = _state(engine_tasks=tasks)
+        resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "pending design review")
+
+    def test_none_string_not_touched(self):
+        """(none) field is not processed."""
+        tasks = [_task("#200", "(none)")]
+        state = _state(engine_tasks=tasks)
+        resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "(none)")
+
+    def test_none_value_not_touched(self):
+        """None blocked_by is not processed."""
+        tasks = [_task("#200", None)]
+        state = _state(engine_tasks=tasks)
+        resolve_blocked_by(state)
+        self.assertIsNone(tasks[0]["blocked_by"])
+
+    def test_two_unresolved_refs_stay_multi(self):
+        """Two open refs → comma-joined bare format, still multi-blocker."""
+        tasks = [_task("#200", "#101, #102")]
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"101": "OPEN", "102": "OPEN"})):
+            state = _state(engine_tasks=tasks)
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "#101, #102")
+
+    def test_live_gh_fallback_closed(self):
+        """Ref not in closed_fleet_queued: falls back to live gh issue view."""
+        tasks = [_task("#200", "#999")]
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"999": "CLOSED"})):
+            state = _state(engine_tasks=tasks)
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "(none)")
+
+
+# ---------------------------------------------------------------------------
+# Part (b) — integration: resolve then enrich gives stackable_blocker_pr
+# ---------------------------------------------------------------------------
+
+class TestResolveAndEnrichIntegration(unittest.TestCase):
+
+    def test_multi_blocker_reduces_to_stackable(self):
+        """Two refs, one closed → single unresolved → enrich finds PR → stackable written."""
+        tasks = [_task("#300", "#100, #101")]
+        open_prs = [_pr(536, "claude/101-work-branch")]
+        state = _state(
+            engine_tasks=tasks,
+            engine_prs=open_prs,
+            closed=[_closed_issue(100)],
+        )
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"101": "OPEN"})):
+            resolve_blocked_by(state)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertEqual(task["blocked_by"], "#101")
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 536)
+
+    def test_all_resolved_no_stackable_written(self):
+        """All refs resolved → (none) → enrich skips (no #NNN to match)."""
+        tasks = [_task("#300", "#100, #102")]
+        state = _state(
+            engine_tasks=tasks,
+            closed=[_closed_issue(100), _closed_issue(102)],
+        )
+        resolve_blocked_by(state)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertEqual(task["blocked_by"], "(none)")
+        self.assertNotIn("stackable_blocker_pr", task)
+
+    def test_two_unresolved_no_stackable(self):
+        """Two open refs → multi-blocker → enrich does not write stackable_blocker_pr."""
+        tasks = [_task("#300", "#101, #102")]
+        open_prs = [
+            _pr(536, "claude/101-work"),
+            _pr(537, "claude/102-other"),
+        ]
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"101": "OPEN", "102": "OPEN"})):
+            state = _state(engine_tasks=tasks, engine_prs=open_prs)
+            resolve_blocked_by(state)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr", state["repos"]["engine"]["tasks"]["open"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `fleet-state-scout`: add `resolve_blocked_by()` — runs after `collect_state()`, resolves each `#N` blocker ref against in-memory `closed_fleet_queued` and `recent_merged_prs`, falls back to live `gh issue view` with a per-tick cache; updates `blocked_by` to bare `#NNN` for one unresolved, `(none)` for zero
- `fleet-claim`: `cmd_find_stackable_blockers` now resolves all `#N` refs live (one merged-PR heads fetch + per-ref gh issue view with cache), filters to the effective unresolved set, proceeds only when exactly one ref remains
- `scripts/fleet/tests/`: 14 new Python unit tests + 4 new bash tests covering all spec scenarios from the issue

## Test plan
- [x] `python3 scripts/fleet/tests/test_live_blocker_resolution.py` — 14 tests, all pass
- [x] `bash scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh` — 5 assertions, all pass
- [x] All 37 prior fleet script tests remain green

Closes #1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)