### PR TITLE
#1272: render: per-entity SO(3) on main canvas (design-blocked)

### DIFF
--- a/docs/design/voxel-face-rasterization.md
+++ b/docs/design/voxel-face-rasterization.md
@@ -145,7 +145,13 @@ exposed-face gating are new.
   changes what comes next: replace the four options in that PR's NEEDS-DESIGN
   comment with this model.
 - **#1272** — per-entity SO(3) on the main canvas; consumes this model with a
-  per-entity visible triplet.
+  per-entity visible triplet. **Blocked pending an architect call on the
+  per-voxel→transform-slot indirection mechanism**, which overlaps the reserved
+  skeletal `bone_id_` path (#605): both are a per-voxel index into a per-frame
+  transform SSBO, so whether they share one indirection convention or run two
+  parallel ones is a cross-feature decision. The model above fixes face
+  *selection*; it does not pin *how a voxel finds its entity's transform slot*.
+  See the `fleet:design-blocked` PR on #1272 for the candidate mechanisms.
 - **#1265** (merged) — camera pitch via quaternion; the visible-triplet resolver
   reads that quaternion, so pitch shifts the triplet for free on detached
   canvases.


### PR DESCRIPTION
## Summary

Per-entity SO(3) rotation on the main canvas (#1272) is **design-blocked** on a cross-feature architecture decision the worker lacks authority to make. This PR records that state in the design doc and routes the decision to the architect via `fleet:design-blocked`; see the `## NEEDS-DESIGN` comment below for the specific call.

- `docs/design/voxel-face-rasterization.md` — the #1272 status entry now notes the open per-voxel→transform-slot indirection-mechanism decision and its overlap with the reserved skeletal `bone_id_` path (#605).

## Why this is blocked, not in-flight

The merged design doc (PR #1277) resolves the **raster/deformation model** (visible-triplet × exposed-mask, per-entity `FaceRenderContext` indexing). It does **not** pin **how a voxel finds its entity's transform slot**. That per-voxel→transform-slot indirection is structurally identical to the reserved skeletal `bone_id_` path: both are a per-voxel index into a per-frame transform SSBO. `C_Voxel.bone_id_` (offset 6) is already reserved for #605 (open epic). Choosing whether #1272 and #605 share one indirection convention or run two parallel ones affects both features — it is an architect call, and the plan on #1272 explicitly says *"do not implement until the architect rules on the `bone_id_` reconciliation."*

Picking a mechanism unilaterally risks a convention that diverges from #605 and would later have to be unwound, so this escalates instead.

## Test plan

- [ ] N/A — docs-only diff. No code change to verify.
- [ ] Architect resolves the indirection-mechanism decision (see NEEDS-DESIGN comment), then re-arms #1272 for implementation via `fleet:design-unblocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)