### PR TITLE
#1299: render: MAIN_CANVAS_SO3 RotationMode value + plumbing (PR-A foundation, render half design-blocked)

### DIFF
--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -23,18 +23,24 @@ in `update/`.
   `C_RotationMode::DETACHED` (GRID-mode entities snap to world cells
   regardless).
 - `C_RotationMode` (Epic C C2) — `enum class RotationMode { GRID,
-  DETACHED }`. GRID (default) puts the entity in the shared world
-  voxel pool with grid-quantized rotation; DETACHED lives in a
-  per-entity `C_EntityCanvas` whose voxel emit bakes the entity's full
-  SO(3) rotation directly (T-295, via `PROPAGATE_CANVAS_ROTATION` →
+  DETACHED, MAIN_CANVAS_SO3 }`. GRID (default) puts the entity in the
+  shared world voxel pool with grid-quantized rotation; DETACHED lives
+  in a per-entity `C_EntityCanvas` whose voxel emit bakes the entity's
+  full SO(3) rotation directly (T-295, via `PROPAGATE_CANVAS_ROTATION` →
   `C_CanvasLocalRotation`) — the composite stage just places the canvas.
-  Attached by
+  MAIN_CANVAS_SO3 (#1272 PR-A) carries a full SO(3) rotation like
+  DETACHED but allocates no canvas — the entity renders rotated on the
+  *shared* main canvas (shared textures/lighting/depth). **The mode
+  value + plumbing (spawn, `setMode`, Lua surface) land first; the
+  main-canvas voxel-to-trixel raster that consumes the mode is in
+  progress (#1299/#1300).** Attached by
   `IRPrefab::Prefab::spawnPrefab` (default GRID, or
   `rotation_mode = IRComponent.RotationMode.DETACHED` in the prefab
   table — the enum value, not the string). Mutate at runtime with
   `IRPrefab::RotationMode::setMode(entity, newMode, name, size)` —
-  allocates or destroys the canvas as needed. Non-prefab entities
-  without the component are implicitly GRID.
+  allocates or destroys the canvas as needed (GRID and MAIN_CANVAS_SO3
+  are canvas-free). Non-prefab entities without the component are
+  implicitly GRID.
 - `C_ChunkMembership` — which streaming chunk an entity belongs to
   (Epic E / `IRPrefab::Chunk::ChunkKey`). **NOT auto-added** —
   single-chunk creations carry no chunk metadata. Attached by the

--- a/engine/prefabs/irreden/common/components/component_rotation_mode.hpp
+++ b/engine/prefabs/irreden/common/components/component_rotation_mode.hpp
@@ -15,8 +15,20 @@
 //   `C_LocalTransform` through the per-canvas TRS so the canvas
 //   pitches/rolls/yaws as a unit without per-voxel rebake. Pair with
 //   `C_LocalTransform::unbounded_ = true` to opt into sub-trixel
-//   positioning (only meaningful when DETACHED — GRID quantizes
-//   regardless).
+//   positioning (only meaningful when DETACHED — GRID and
+//   MAIN_CANVAS_SO3 quantize regardless).
+// - MAIN_CANVAS_SO3: full per-entity SO(3) rotation rendered onto the
+//   *shared* main world canvas — shared canvas textures, shared
+//   lighting volume, shared depth buffer — instead of a per-entity
+//   detached render target (#1272 PR-A). Like DETACHED it carries an
+//   arbitrary rotation, but unlike DETACHED it allocates NO canvas: the
+//   main-canvas voxel-to-trixel raster places the entity's voxels at
+//   their rotated configuration in place. Targets medium-detail
+//   rotating entities (falling enemies, tumbling projectiles, debris)
+//   where a detached canvas per entity is wasteful. The render-side
+//   raster that consumes this mode is in progress (#1299/#1300); the
+//   mode value + plumbing land first so spawn / `setMode` / the Lua
+//   surface can reference it.
 //
 // Entities without `C_RotationMode` are implicitly GRID — consumers
 // default to GRID when the component is absent so non-prefab entities
@@ -28,8 +40,9 @@
 // Mode is mutable at runtime via `IRPrefab::RotationMode::setMode`
 // (in `engine/prefabs/irreden/common/rotation_mode.hpp`) at a
 // re-allocation cost — switching to DETACHED allocates a new entity
-// canvas; switching to GRID destroys it. Don't mutate `mode_`
-// directly; the helper keeps `C_EntityCanvas` in sync.
+// canvas; switching to GRID or MAIN_CANVAS_SO3 destroys it (those two
+// modes are canvas-free). Don't mutate `mode_` directly; the helper
+// keeps `C_EntityCanvas` in sync.
 
 #include <cstdint>
 
@@ -44,9 +57,10 @@ namespace IRComponents {
 enum class RotationMode : std::uint8_t {
     GRID = 0,
     DETACHED = 1,
+    MAIN_CANVAS_SO3 = 2,
 
     kFirst = GRID,
-    kLast = DETACHED,
+    kLast = MAIN_CANVAS_SO3,
 };
 
 struct C_RotationMode {

--- a/engine/prefabs/irreden/common/rotation_mode.hpp
+++ b/engine/prefabs/irreden/common/rotation_mode.hpp
@@ -25,17 +25,19 @@ namespace IRPrefab::RotationMode {
 /// Transition an entity to `newMode`, allocating or destroying its
 /// per-entity canvas as required.
 ///
-/// - GRID → DETACHED: allocates a child canvas via
+/// - → DETACHED: allocates a child canvas via
 ///   `IRPrefab::EntityCanvas::create(canvasName, canvasSize)` and
 ///   attaches `C_EntityCanvas` to `entity`. The previous canvas (if
 ///   any) is left alone — re-entering DETACHED from DETACHED is a
 ///   no-op rather than a re-allocation churn.
-/// - DETACHED → GRID: destroys the entity's `C_EntityCanvas` child
-///   entity (freeing its GPU textures via `onDestroy`) and removes
-///   the component from `entity`.
+/// - → GRID or MAIN_CANVAS_SO3 (both canvas-free): destroys the
+///   entity's `C_EntityCanvas` child entity (freeing its GPU textures
+///   via `onDestroy`) if one exists and removes the component from
+///   `entity`. MAIN_CANVAS_SO3 rotates on the shared main canvas, so
+///   like GRID it owns no detached canvas.
 /// - Same mode in/out: no-op.
 ///
-/// `canvasName` and `canvasSize` are only consulted on a GRID→DETACHED
+/// `canvasName` and `canvasSize` are only consulted on a →DETACHED
 /// transition; pass sensible defaults otherwise.
 inline void setMode(
     IREntity::EntityId entity,
@@ -62,7 +64,7 @@ inline void setMode(
         if (!existing) {
             IREntity::setComponent(entity, IRPrefab::EntityCanvas::create(canvasName, canvasSize));
         }
-    } else { // GRID
+    } else { // GRID or MAIN_CANVAS_SO3 — both canvas-free
         auto existing = IREntity::getComponentOptional<C_EntityCanvas>(entity);
         if (existing) {
             const IREntity::EntityId canvas = existing.value()->canvasEntity_;

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -741,7 +741,8 @@ return {
     voxel_ref      = "creations/...vxs", -- OPTIONAL, loaded via loadVoxelSet
     rig_ref        = "creations/...rig", -- OPTIONAL, loaded via loadRig
     rotation_mode  = IRComponent.RotationMode.GRID
-                  | IRComponent.RotationMode.DETACHED,
+                  | IRComponent.RotationMode.DETACHED
+                  | IRComponent.RotationMode.MAIN_CANVAS_SO3,
                                          -- OPTIONAL, default GRID
     unbounded      = true | false,       -- OPTIONAL, default false
     canvas_size    = { x = 64, y = 64 }, -- REQUIRED when DETACHED
@@ -756,13 +757,17 @@ root. GRID (default) renders into the world voxel pool with grid-
 quantized rotation; DETACHED allocates a per-entity `C_EntityCanvas`
 via `IRPrefab::EntityCanvas::create()` so a future C3 composite pass
 threads the entity's `C_LocalTransform` through the per-canvas TRS
-without per-voxel rebake. `canvas_size = { x, y }` is required for
-DETACHED — sized in trixels — and is ignored for GRID. `unbounded =
-true` sets `C_LocalTransform::unbounded_` for sub-trixel positioning;
-only meaningful with DETACHED.
+without per-voxel rebake. MAIN_CANVAS_SO3 (#1272 PR-A) carries a full
+SO(3) rotation like DETACHED but allocates no canvas — the entity
+renders rotated on the shared main canvas (the consuming raster is in
+progress; the mode value + spawn plumbing land first). `canvas_size =
+{ x, y }` is required for DETACHED — sized in trixels — and is ignored
+for GRID / MAIN_CANVAS_SO3. `unbounded = true` sets
+`C_LocalTransform::unbounded_` for sub-trixel positioning; only
+meaningful with DETACHED.
 
-**The schema accepts the `IRComponent.RotationMode.{GRID,DETACHED}`
-enum value (an integer), not a string.** String-name lookups —
+**The schema accepts the `IRComponent.RotationMode.{GRID,DETACHED,
+MAIN_CANVAS_SO3}` enum value (an integer), not a string.** String-name lookups —
 `rotation_mode = 'GRID'` — surface a schema error with the
 `IRComponent.RotationMode.X` spelling in the diagnostic. This keeps
 the Lua-side authoring surface in lockstep with the C++ enum, the

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -457,6 +457,7 @@ void LuaScript::bindLuaDrivenEcs() {
     rotationModeTable[#name] = static_cast<lua_Integer>(IRComponents::RotationMode::name)
     IR_BIND_ROTMODE(GRID);
     IR_BIND_ROTMODE(DETACHED);
+    IR_BIND_ROTMODE(MAIN_CANVAS_SO3);
 #undef IR_BIND_ROTMODE
     m_lua["IRComponent"]["RotationMode"] = rotationModeTable;
 

--- a/engine/script/src/prefab_api.cpp
+++ b/engine/script/src/prefab_api.cpp
@@ -145,10 +145,12 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
     // Default rotation mode is GRID (today's behavior). DETACHED allocates
     // a per-entity canvas via `IRPrefab::EntityCanvas::create` so the C3
     // composite pass can thread `C_LocalTransform` through the per-canvas
-    // TRS without re-rasterizing voxels per frame. The schema accepts the
-    // `IRComponent.RotationMode.{GRID,DETACHED}` enum value (an integer),
-    // not a string — string-name lookups are deliberately avoided so the
-    // Lua surface stays in lockstep with the C++ enum.
+    // TRS without re-rasterizing voxels per frame. MAIN_CANVAS_SO3 rotates
+    // on the shared main canvas with no canvas allocation (#1272 PR-A). The
+    // schema accepts the `IRComponent.RotationMode.{GRID,DETACHED,
+    // MAIN_CANVAS_SO3}` enum value (an integer), not a string — string-name
+    // lookups are deliberately avoided so the Lua surface stays in lockstep
+    // with the C++ enum.
     IRComponents::RotationMode rotationMode = IRComponents::RotationMode::GRID;
     sol::object modeObj = prefab["rotation_mode"];
     if (modeObj.valid() && modeObj.get_type() != sol::type::lua_nil) {
@@ -156,15 +158,16 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
             return makeError(
                 idStr,
                 path,
-                "rotation_mode must be an IRComponent.RotationMode.{GRID,DETACHED} "
-                "value; string names are not accepted"
+                "rotation_mode must be an IRComponent.RotationMode.{GRID,DETACHED,"
+                "MAIN_CANVAS_SO3} value; string names are not accepted"
             );
         }
         if (!modeObj.is<lua_Integer>()) {
             return makeError(
                 idStr,
                 path,
-                "rotation_mode must be an IRComponent.RotationMode.{GRID,DETACHED} value"
+                "rotation_mode must be an IRComponent.RotationMode.{GRID,DETACHED,"
+                "MAIN_CANVAS_SO3} value"
             );
         }
         const lua_Integer raw = modeObj.as<lua_Integer>();
@@ -174,7 +177,8 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
                 idStr,
                 path,
                 "rotation_mode=" + std::to_string(raw) +
-                    " not recognized (expected IRComponent.RotationMode.GRID or .DETACHED)"
+                    " not recognized (expected IRComponent.RotationMode.GRID, "
+                    ".DETACHED, or .MAIN_CANVAS_SO3)"
             );
         }
         rotationMode = static_cast<IRComponents::RotationMode>(raw);
@@ -186,8 +190,8 @@ SpawnResult spawnPrefab(IRScript::LuaScript &script, std::string_view id, IRMath
     }
     if (unbounded && rotationMode != IRComponents::RotationMode::DETACHED) {
         IRE_LOG_WARN(
-            "Prefab.spawn('{}'): unbounded=true has no effect with "
-            "rotation_mode=IRComponent.RotationMode.GRID.",
+            "Prefab.spawn('{}'): unbounded=true has no effect unless "
+            "rotation_mode=IRComponent.RotationMode.DETACHED.",
             idStr.c_str()
         );
     }

--- a/test/script/prefab_api_test.cpp
+++ b/test/script/prefab_api_test.cpp
@@ -869,6 +869,24 @@ TEST_F(PrefabApi, SpawnRotationModeDetachedAttachesComponent) {
     EXPECT_EQ(modeOpt.value()->mode_, IRComponents::RotationMode::DETACHED);
 }
 
+TEST_F(PrefabApi, SpawnRotationModeMainCanvasSo3AttachesComponent) {
+    // MAIN_CANVAS_SO3 (#1272 PR-A) rotates on the shared main canvas, so —
+    // like GRID — it requires no canvas_size and allocates no per-entity
+    // canvas. Spawn just tags the entity with the mode.
+    PrefabFiles f = writeFixtureSet(
+        "rot_main_canvas_so3",
+        "return { prefab_version = 1, rotation_mode = "
+        "IRComponent.RotationMode.MAIN_CANVAS_SO3 }\n"
+    );
+    IRPrefab::Prefab::registerPrefab("p", f.prefab_path_);
+    auto r = IRPrefab::Prefab::spawnPrefab(m_lua, "p", vec3(0.0f));
+    ASSERT_NE(r.entity_, IREntity::kNullEntity) << r.error_;
+
+    auto modeOpt = IREntity::getComponentOptional<IRComponents::C_RotationMode>(r.entity_);
+    ASSERT_TRUE(modeOpt.has_value());
+    EXPECT_EQ(modeOpt.value()->mode_, IRComponents::RotationMode::MAIN_CANVAS_SO3);
+}
+
 TEST_F(PrefabApi, SpawnUnboundedSetsLocalTransformFlag) {
     PrefabFiles f = writeFixtureSet(
         "rot_unbounded",


### PR DESCRIPTION
## Summary

Foundation slice of #1299 (per-entity SO(3) on the main canvas, PR-A of the #1272 series). Adds the new `RotationMode::MAIN_CANVAS_SO3` value and wires it through every **non-render** surface so spawn / `setMode` / the Lua authoring layer can reference it:

- `component_rotation_mode.hpp` — `MAIN_CANVAS_SO3 = 2`, `kLast` bumped (the `prefab_api` range validator auto-extends via `kFirst`/`kLast`).
- `rotation_mode.hpp` — `setMode` treats `MAIN_CANVAS_SO3` as canvas-free like `GRID` (no `C_EntityCanvas`; destroys one on a `DETACHED`→`MAIN_CANVAS_SO3` switch).
- `prefab_api.cpp` — validator accepts the new value; diagnostics + the `unbounded` warning updated to the three-mode set.
- `lua_script.cpp` — `IR_BIND_ROTMODE(MAIN_CANVAS_SO3)` Lua enum entry.
- `prefab_api_test.cpp` — spawn test for the new mode (asserts the component attaches with `MAIN_CANVAS_SO3`, no `canvas_size` required).
- `common/` + `script/` `CLAUDE.md` — documents the new mode, explicitly noting the render consumer is in progress.

**Does not close #1299** — the main-canvas voxel-to-trixel raster that *renders* this mode is held out (see the `## NEEDS-DESIGN` comment below). This slice is path-independent: the enum value + plumbing are needed regardless of which position mechanism the architect picks.

## Why split

While scoping PR-A's render half I found the architect plan's stated position mechanism (#1272 ratified comment, decision 1: "extend the existing GPU prepass, which already computes per-entity world voxel positions GPU-side, once per frame") rests on a **dead, unregistered WIP stub** (`UPDATE_VOXEL_POSITIONS_GPU`). The live position path is CPU-computed positions uploaded straight to binding 5. Picking a substitute mechanism unilaterally is exactly the call the #1299 issue body says to "coordinate with the architect on … **before implementing**." Details + options in the NEEDS-DESIGN comment.

## Test plan

- [x] `fleet-build --target IrredenEngineTest` — clean.
- [x] `PrefabApi.*RotationMode*` + new `SpawnRotationModeMainCanvasSo3AttachesComponent` — 6/6 pass.
- [ ] Render-half raster (deferred to the design-unblocked continuation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)