### PR TITLE
fleet: verify genuine #N reference before stamping scope-shipped

### DIFF
--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -67,8 +67,14 @@ fi
 # list. Mutating the projection file lets the label-stamping pass below
 # skip scope-shipped issues without re-querying (#1175).
 if [[ -f "$PROJECTION_FILE" ]] && command -v gh >/dev/null 2>&1; then
-    scope_shipped_out=$(FLEET_PROJ_FILE="$PROJECTION_FILE" python3 - << 'SCOPE_PY' 2>>"$LOG_FILE"
+    scope_shipped_out=$(FLEET_PROJ_FILE="$PROJECTION_FILE" INGEST_SELF="${BASH_SOURCE[0]}" python3 - << 'SCOPE_PY' 2>>"$LOG_FILE"
 import json, os, subprocess, sys
+
+# Import the genuine-reference predicate from the sibling module. realpath
+# resolves the ~/bin/fleet-queue-ingest install symlink back to the versioned
+# scripts/fleet/ copy, where fleet_scope_shipped.py lives next to this script.
+sys.path.insert(0, os.path.dirname(os.path.realpath(os.environ['INGEST_SELF'])))
+from fleet_scope_shipped import select_shipped_pr
 
 REPO_SLUGS = {"engine": "jakildev/IrredenEngine", "game": "jakildev/irreden"}
 
@@ -87,20 +93,23 @@ for issue in pending:
     if not n:
         kept.append(issue)
         continue
-    # Full-text search; may match incidental references — human verifies via comment before closing.
+    # GitHub strips the '#' and matches the bare token n anywhere (titles,
+    # bodies, comments, line numbers, relevance) — so the search is a coarse
+    # candidate set, not a reference match. select_shipped_pr() verifies a
+    # genuine word-boundary #n cross-reference in title/body before trusting it.
     r = subprocess.run(
         ['gh', 'pr', 'list', '--repo', repo, '--state', 'merged',
-         '--search', f'#{n}', '--json', 'number,title,url,mergedAt', '--limit', '5'],
+         '--search', f'#{n}', '--json', 'number,title,body,url,mergedAt', '--limit', '5'],
         capture_output=True, text=True, timeout=15,
     )
     try:
         prs = json.loads(r.stdout or '[]') if r.returncode == 0 else []
     except Exception:
         prs = []
-    if not prs:
+    best = select_shipped_pr(prs, n)
+    if best is None:
         kept.append(issue)
         continue
-    best = prs[0]
     merged_date = best.get('mergedAt', '')[:10]
     comment = (
         f"Scope check: this issue's scope appears to have landed in "

--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -1,0 +1,40 @@
+"""Genuine-reference predicate for fleet-queue-ingest's scope-shipped pre-flight.
+
+A merged PR is only evidence that an issue's scope "already landed" when the PR
+carries a genuine cross-reference to the issue — a word-boundary ``#N`` in its
+title or body (a real ``Closes #N`` / ``supersedes #N`` / ``#N`` mention).
+
+GitHub's PR search (``gh pr list --search '#N'``) strips the ``#`` and matches
+the bare token ``N`` anywhere it appears, including PR *comments* and source
+line numbers, and can even return relevance-only hits with no literal ``N`` at
+all. Trusting ``prs[0]`` from that search mislabels unrelated issues as
+``fleet:scope-shipped`` and posts a misleading "scope already landed" comment
+(#1304: #1243's #1300 line-number hit, #1160's #1284 relevance hit). This
+predicate is the verification step that rejects those incidental matches.
+"""
+import re
+
+
+def pr_references_issue(title, body, n):
+    """True iff a word-boundary ``#{n}`` appears in the PR title or body.
+
+    The trailing ``(?!\\d)`` guard stops ``#13000`` from satisfying ``n=1300``;
+    requiring the literal ``#`` rejects bare line-number and relevance hits that
+    carry no cross-reference at all.
+    """
+    if not n:
+        return False
+    pattern = re.compile(r'#' + str(int(n)) + r'(?!\d)')
+    return bool(pattern.search(title or '')) or bool(pattern.search(body or ''))
+
+
+def select_shipped_pr(prs, n):
+    """First PR in ``prs`` that genuinely references issue ``n``, else ``None``.
+
+    Replaces the old ``prs[0]`` blind trust: a merged-PR search hit only counts
+    as scope-shipped evidence when the PR actually cross-references the issue.
+    """
+    for pr in prs:
+        if pr_references_issue(pr.get('title', ''), pr.get('body', ''), n):
+            return pr
+    return None

--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -18,13 +18,18 @@ import re
 def pr_references_issue(title, body, n):
     """True iff a word-boundary ``#{n}`` appears in the PR title or body.
 
-    The trailing ``(?!\\d)`` guard stops ``#13000`` from satisfying ``n=1300``;
-    requiring the literal ``#`` rejects bare line-number and relevance hits that
+    The leading ``(?<!\\w)`` guard rejects ``abc#1300`` (alphanumeric immediately
+    before ``#``); the trailing ``(?!\\d)`` guard stops ``#13000`` from satisfying
+    ``n=1300``. Together they match GitHub's own link-detection boundaries.
+    Requiring the literal ``#`` rejects bare line-number and relevance hits that
     carry no cross-reference at all.
     """
     if not n:
         return False
-    pattern = re.compile(r'#' + str(int(n)) + r'(?!\d)')
+    try:
+        pattern = re.compile(r'(?<!\w)#' + str(int(n)) + r'(?!\d)')
+    except ValueError:
+        return False
     return bool(pattern.search(title or '')) or bool(pattern.search(body or ''))
 
 

--- a/scripts/fleet/tests/test_scope_shipped_reference.py
+++ b/scripts/fleet/tests/test_scope_shipped_reference.py
@@ -63,6 +63,14 @@ class PrReferencesIssue(unittest.TestCase):
     def test_falsy_issue_number(self):
         self.assertFalse(pr_references_issue("#0 ref", "#0 ref", 0))
 
+    def test_alphanumeric_before_hash_is_not_a_reference(self):
+        # "abc#1300" — '#' immediately preceded by a word char must be rejected.
+        self.assertFalse(pr_references_issue("", "abc#1300 fix", 1300))
+
+    def test_non_numeric_truthy_n_returns_false(self):
+        # int(n) raises ValueError for a truthy non-numeric string.
+        self.assertFalse(pr_references_issue("", "Closes #1300", "abc"))
+
 
 class SelectShippedPr(unittest.TestCase):
     def test_empty_candidates(self):

--- a/scripts/fleet/tests/test_scope_shipped_reference.py
+++ b/scripts/fleet/tests/test_scope_shipped_reference.py
@@ -1,0 +1,93 @@
+"""Tests for the genuine-reference predicate in fleet_scope_shipped.
+
+Covers the #1304 false-positives: fleet-queue-ingest's scope-shipped
+pre-flight used to trust prs[0] from a `gh pr list --search '#N'` query, but
+GitHub matches the bare token N anywhere (titles, bodies, comments, line
+numbers, relevance). select_shipped_pr() must reject those incidental hits and
+only flag a PR that carries a genuine word-boundary #N cross-reference.
+
+The module is a real .py, but it is loaded via importlib (mirroring
+test_enrich_stackable_blocker_prs.py) so the test runs regardless of cwd.
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+_MODULE = Path(__file__).parent.parent / "fleet_scope_shipped.py"
+
+_loader = importlib.machinery.SourceFileLoader("fleet_scope_shipped", str(_MODULE))
+_spec = importlib.util.spec_from_loader("fleet_scope_shipped", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+pr_references_issue = _mod.pr_references_issue
+select_shipped_pr = _mod.select_shipped_pr
+
+
+def _pr(number, title="", body=""):
+    return {"number": number, "title": title, "body": body, "url": "", "mergedAt": ""}
+
+
+class PrReferencesIssue(unittest.TestCase):
+    def test_genuine_closes_in_body(self):
+        self.assertTrue(pr_references_issue("some PR", "Closes #1300.", 1300))
+
+    def test_genuine_hash_ref_in_body(self):
+        self.assertTrue(pr_references_issue("title", "supersedes #1284 here", 1284))
+
+    def test_genuine_ref_in_title(self):
+        self.assertTrue(pr_references_issue("#1300: render fix", "", 1300))
+
+    def test_bare_number_no_hash_is_not_a_reference(self):
+        # The #1243 -> #1300 shape: "1300" appears as a line number, no '#'.
+        self.assertFalse(
+            pr_references_issue("delete orphaned queue scripts",
+                                "touches lines 71, 176, 1300, 3619", 1300))
+
+    def test_no_literal_number_at_all(self):
+        # The #1160 -> #1284 shape: relevance-only hit, number absent entirely.
+        self.assertFalse(
+            pr_references_issue("codegen: emit per-component tick", "body text", 1284))
+
+    def test_longer_number_does_not_match_prefix(self):
+        # #13000 must not satisfy n=1300.
+        self.assertFalse(pr_references_issue("", "see #13000", 1300))
+
+    def test_longer_number_does_not_match_suffix(self):
+        # #1300 query must not be satisfied by a leading-digit token.
+        self.assertFalse(pr_references_issue("", "see #21300", 1300))
+
+    def test_hash_ref_with_adjacent_punctuation(self):
+        self.assertTrue(pr_references_issue("", "fixes (#1300) finally", 1300))
+
+    def test_falsy_issue_number(self):
+        self.assertFalse(pr_references_issue("#0 ref", "#0 ref", 0))
+
+
+class SelectShippedPr(unittest.TestCase):
+    def test_empty_candidates(self):
+        self.assertIsNone(select_shipped_pr([], 1300))
+
+    def test_no_genuine_reference_returns_none(self):
+        prs = [
+            _pr(1243, "delete orphaned queue scripts", "lines 71, 176, 1300"),
+            _pr(1160, "codegen: emit per-component tick", "unrelated"),
+        ]
+        self.assertIsNone(select_shipped_pr(prs, 1300))
+
+    def test_picks_first_genuine_reference(self):
+        prs = [
+            _pr(1243, "delete orphaned queue scripts", "lines 71, 176, 1300"),
+            _pr(900, "real shipper", "Closes #1300"),
+        ]
+        best = select_shipped_pr(prs, 1300)
+        self.assertIsNotNone(best)
+        self.assertEqual(best["number"], 900)
+
+    def test_missing_title_body_keys(self):
+        # Defensive: a candidate dict without title/body must not raise.
+        self.assertIsNone(select_shipped_pr([{"number": 5}], 1300))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `fleet-queue-ingest`'s scope-shipped pre-flight trusted `prs[0]` from `gh pr list --search '#N'`, but GitHub strips the `#` and matches the bare token `N` anywhere (titles, bodies, **comments**, line numbers) and can return relevance-only hits with no literal `N`. This mislabeled unrelated issues `fleet:scope-shipped`.
- Two live false positives this confirms against: **#1300** matched a line number inside a comment on PR #1243; **#1284** matched PR #1160 on relevance alone (no literal "1284" anywhere). Both re-stamped on every ingest cycle after a human cleared the label.
- Extracts the verification into a testable sibling module `scripts/fleet/fleet_scope_shipped.py`: a candidate PR counts as scope-shipped only if a **word-boundary `#{n}`** appears in its title or body (`select_shipped_pr`). The heredoc imports it via the script's `realpath` so the `~/bin/fleet-queue-ingest` install symlink resolves to the versioned copy — no `install.sh` change needed (the module ships beside the script in `scripts/fleet/`).
- Cleared the stale `fleet:scope-shipped` label from #1300 and #1284 (it had recurred since filing, as the issue predicted).

## Propagation note
Per the issue: the running queue-manager executes from its own worktree, so the recurrence stops once this lands on `master` **and** that worktree pulls. No behavior change until then.

## Test plan
- [x] `python3 scripts/fleet/tests/test_scope_shipped_reference.py` — 13 tests (comment-only, no-literal-match, longer-number prefix/suffix, genuine title/body ref, select-first-genuine).
- [x] Full fleet python suite green (`test_enrich_stackable_blocker_prs`, `test_queue_manager_projection`, `test_merger_projection`, `test_worker_projection`, `test_issue_queue_parser`, `test_fleet_claude_stream_latch`).
- [x] `bash -n scripts/fleet/fleet-queue-ingest` clean.
- [x] End-to-end heredoc run with stubbed `gh`: a comment-only `#1300` hit and a relevance `#1284` hit stay in pending; only a genuine `Closes #1500` PR is stamped (`1,2` shipped/kept).
- [x] Import resolution verified through the `~/bin` symlink realpath and the worktree path.

Closes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)