### PR TITLE
fleet: move to Opus 4.8 + 1M-context variants, single source of truth

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -277,9 +277,12 @@ is in `role-opus-worker.md` (escalate + resume) and
 ### Model split: Opus for core, Sonnet for the fleet
 
 The user has much more Sonnet budget than Opus budget. Spend each where it
-pays off:
+pays off. Both tiers run the 1M-token context variant; the exact model
+versions are pinned in `scripts/fleet/fleet-up` (`OPUS_MODEL` /
+`SONNET_MODEL`), not here — bump there when moving the fleet to a new
+release.
 
-**Opus 4.6** — use for:
+**Opus 4.8** — use for:
 
 - Core engine architecture. ECS design, ownership and lifetime rules,
   render pipeline decisions.

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -4,7 +4,7 @@
 #
 # Called by fleet-dispatcher via tmux send-keys. Arguments:
 #   $1  pane_key  e.g. "pane-3"
-#   $2  model     e.g. "sonnet" or "claude-opus-4-7"
+#   $2  model     e.g. "sonnet[1m]" or "claude-opus-4-8[1m]"
 #   $3  effort    e.g. "high" or "xhigh"
 #   $4  role      e.g. "sonnet-author"
 #

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -262,15 +262,22 @@ DISPATCHED_ROLES=(
 # now issue-based. Ingestion (new issues → queue) fires on its own
 # scout-driven trigger when human:approved-not-yet-queued issues appear.
 
-# Per-role default claude model. Sourced from fleet-up's
-# OPUS_MODEL / SONNET_MODEL convention.
+# Per-role default claude model. Inherited from fleet-up's exported
+# OPUS_MODEL / SONNET_MODEL (the single source of truth — bump there).
+# The fallbacks apply only when the dispatcher is run standalone (e.g.
+# for debugging) without fleet-up in the environment; keep them in sync
+# with fleet-up. The "[1m]" suffix selects the 1M-token context variant —
+# standard pricing on the same weights as 200K, so it's free headroom for
+# the occasional long iteration.
+OPUS_MODEL="${OPUS_MODEL:-claude-opus-4-8[1m]}"
+SONNET_MODEL="${SONNET_MODEL:-sonnet[1m]}"
 declare -A ROLE_MODEL=(
-    ["sonnet-author"]="sonnet"
-    ["opus-worker"]="claude-opus-4-7"
-    ["sonnet-reviewer"]="sonnet"
-    ["opus-reviewer"]="claude-opus-4-7"
-    ["merger"]="claude-opus-4-7"
-    ["smoke-worker"]="sonnet"
+    ["sonnet-author"]="$SONNET_MODEL"
+    ["opus-worker"]="$OPUS_MODEL"
+    ["sonnet-reviewer"]="$SONNET_MODEL"
+    ["opus-reviewer"]="$OPUS_MODEL"
+    ["merger"]="$OPUS_MODEL"
+    ["smoke-worker"]="$SONNET_MODEL"
 )
 
 # Per-role default effort level. Mirrors fleet-babysit's case stmt.

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -23,10 +23,20 @@ GAME="$ENGINE/creations/game"
 SESSION="fleet"
 
 # Model versions — change these when bumping the fleet to a new release.
-# Use full model names (not aliases) so the fleet is pinned to a known
-# version. The alias "opus" tracks latest and would silently upgrade.
-OPUS_MODEL="claude-opus-4-7"
-SONNET_MODEL="sonnet"   # alias is fine for sonnet — budget is cheap
+# This is the single source of truth: they're exported below so the
+# nohup'd fleet-dispatcher inherits them for its transient roles (workers,
+# reviewers, merger, smoke), and launch_cmd threads OPUS_MODEL into the
+# architect panes via fleet-babysit. Bump here and every role moves.
+#
+# The "[1m]" suffix selects the 1M-token context variant. For Opus 4.8 and
+# Sonnet 4.6 the full 1M window bills at standard per-token rates (no long-
+# context premium) on the same weights as the 200K variant — so it's free
+# headroom for the occasional long iteration and identical on the common
+# short ones. Opus is pinned to a full version (the bare "opus" alias would
+# silently upgrade); sonnet stays an alias since its budget is cheap.
+OPUS_MODEL="claude-opus-4-8[1m]"
+SONNET_MODEL="sonnet[1m]"
+export OPUS_MODEL SONNET_MODEL
 
 # Minimum seconds between opus-reviewer relaunches (cooldown floor).
 # fleet-babysit reads this via FLEET_MIN_BACKOFF; keep the two in sync.
@@ -1004,11 +1014,14 @@ launch_cmd() {
     local model="$1"
     local role="$2"
     local loop="${3:-}"
+    # Single-quote the model: it can carry a "[1m]" suffix, and this string
+    # is replayed as a shell command line inside the tmux pane — unquoted,
+    # bash would treat "[1m]" as a glob bracket expression.
     if [[ -n "$loop" ]]; then
-        printf 'fleet-babysit %s %s %s %s; exec $SHELL\n' \
+        printf "fleet-babysit '%s' %s %s %s; exec \$SHELL\n" \
             "$model" "$role" "$MODE" "$loop"
     else
-        printf 'fleet-babysit %s %s %s; exec $SHELL\n' \
+        printf "fleet-babysit '%s' %s %s; exec \$SHELL\n" \
             "$model" "$role" "$MODE"
     fi
 }
@@ -1086,14 +1099,14 @@ pane_stagger
 MID_LEFT=$(tmux split-window -v -t "$TOP_LEFT" -l 67% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-architect" \
     "$(launch_cmd "$OPUS_MODEL" opus-architect)")
-label_pane_id "$MID_LEFT" "opus-architect [opus 4.7]"
+label_pane_id "$MID_LEFT" "opus-architect [opus 4.8]"
 pane_stagger
 
 # Split bottom 1/2 of the middle off — that becomes bottom row leftmost.
 BOT_LEFT=$(tmux split-window -v -t "$MID_LEFT" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-1" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$BOT_LEFT" "opus-worker-1 [opus 4.7]"
+label_pane_id "$BOT_LEFT" "opus-worker-1 [opus 4.8]"
 set_fleet_role "$BOT_LEFT" "opus-worker"
 pane_stagger
 
@@ -1122,7 +1135,7 @@ if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     MID_RIGHT=$(tmux split-window -h -t "$MID_LEFT" -l 50% -P -F "#{pane_id}" \
         -c "$GAME/.claude/worktrees/game-architect" \
         "$(launch_cmd "$OPUS_MODEL" game-architect)")
-    label_pane_id "$MID_RIGHT" "game-architect [opus 4.7]"
+    label_pane_id "$MID_RIGHT" "game-architect [opus 4.8]"
     pane_stagger
 fi
 
@@ -1132,14 +1145,14 @@ fi
 BOT_MID=$(tmux split-window -h -t "$BOT_LEFT" -l 67% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-2" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$BOT_MID" "opus-worker-2 [opus 4.7]"
+label_pane_id "$BOT_MID" "opus-worker-2 [opus 4.8]"
 set_fleet_role "$BOT_MID" "opus-worker"
 pane_stagger
 
 BOT_RIGHT=$(tmux split-window -h -t "$BOT_MID" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.7]"
+label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.8]"
 set_fleet_role "$BOT_RIGHT" "opus-reviewer"
 pane_stagger
 
@@ -1166,7 +1179,7 @@ pane_stagger
 OPS_TR=$(tmux split-window -h -t "$OPS_TL" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/merger" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$OPS_TR" "merger [opus 4.7]"
+label_pane_id "$OPS_TR" "merger [opus 4.8]"
 set_fleet_role "$OPS_TR" "merger"
 
 OPS_BL=$(tmux split-window -v -t "$OPS_TL" -l 50% -P -F "#{pane_id}" \


### PR DESCRIPTION
## Summary
- **Bump the Opus tier to 4.8.** The fleet was pinned to `claude-opus-4-7` and Opus tracks no auto-upgrading alias, so it never moved off 4.7 on its own. Now `claude-opus-4-8[1m]`.
- **Both tiers run the 1M-token context variant** (`claude-opus-4-8[1m]`, `sonnet[1m]`). For Opus 4.8 / Sonnet 4.6 the full 1M window bills at standard per-token rates on the same weights as the 200K variant — free headroom for the occasional long iteration, identical behaviour/price on the common short ones. Covers workers, reviewers, merger, smoke, and the architects.
- **Single source of truth.** `fleet-up`'s `OPUS_MODEL` / `SONNET_MODEL` are now `export`ed so the nohup'd `fleet-dispatcher` inherits them; `ROLE_MODEL` reads those vars (with matching standalone-run fallbacks) instead of an independently-hardcoded copy. A stale comment claimed the dispatcher already sourced them — it didn't. Bumping the fleet is now a one-line edit in `fleet-up`.
- **`launch_cmd` single-quotes the model** so the `[1m]` suffix survives the tmux→shell replay; unquoted, bash would treat `[1m]` as a glob bracket expression.
- Pane labels (`[opus 4.7]` → `[opus 4.8]`) and the `FLEET.md` model-split section updated to 4.8.

## Test plan
- [x] `bash -n` passes on `fleet-up`, `fleet-dispatcher`, `fleet-dispatch-wrap`, `fleet-babysit`.
- [x] Simulated `launch_cmd` output single-quotes the model; a shell re-parse of the emitted command line yields `argv[…]=claude-opus-4-8[1m]` intact (brackets not glob-expanded).
- [x] `ROLE_MODEL` resolves opus roles → `$OPUS_MODEL` and sonnet roles → `$SONNET_MODEL` from the inherited env, falling back to the 4.8/1M defaults when run standalone.
- [ ] Confidence check on next `fleet-up`: panes show `[opus 4.8]`; a dispatched iteration runs `claude --model "claude-opus-4-8[1m]"` (verify in `~/.fleet/logs/dispatcher.log` or a pane).

## Notes for reviewer
- Scope is intentionally **all** Opus/Sonnet roles, not just workers+reviewers — the change flows through the shared `OPUS_MODEL`/`SONNET_MODEL` vars, and since 1M is free at standard pricing there's no reason to leave merger/architects behind. Easy to narrow by re-introducing per-role divergence in `ROLE_MODEL` if desired.
- Bracketed model IDs (`[1m]`) are quoted everywhere they hit a shell: `fleet-dispatch-wrap` and `fleet-babysit` already quote `--model "$MODEL"`; `launch_cmd` is the one spot that re-emits the value onto a command line, hence the added single-quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)