### PR TITLE
fleet: consolidate role docs into shared directives

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -802,17 +802,13 @@ If Mode above is `review-only`: behave as `live`. Auto-rebasing
 mechanical conflicts helps close out PRs, which IS the point of
 review-only mode.
 
-If you hit a usage-limit error: print the error and exit.
-`fleet-dispatcher` does NOT implement usage-limit back-off; flag the limit in your iteration summary so the human can intervene.
+If you hit a usage-limit error, see [docs/agents/FLEET-RUNTIME.md § Usage-limit handling](../../docs/agents/FLEET-RUNTIME.md#usage-limit-handling)
+— print the error and exit; flag it in your iteration summary.
 
 ## End-of-iteration feedback
 
-If you noticed something this iteration that the human should know
-about — a fleet bug, missing permission, surprising state, or
-suggestion for the fleet itself — append a structured entry to
-`~/.fleet/feedback/merger.md`. See [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Fleet
-feedback channel" for the format and the bar (high — most
-iterations write nothing).
+See [docs/agents/FLEET-RUNTIME.md § End-of-iteration feedback](../../docs/agents/FLEET-RUNTIME.md#end-of-iteration-feedback).
+Your feedback file is `~/.fleet/feedback/merger.md`.
 
 ## Hard rules
 

--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -144,20 +144,11 @@ When you do pick a task:
 3. Build the target you touched with `fleet-build --target <name>`.
    Run the relevant executable if one exists for the touched code:
    `fleet-run <executable-name>`
-4. **Optimize before commit.** Run the `optimize` skill before
-   invoking `commit-and-push`. This rule applies to architects too —
-   the architect's PRs touch core engine code (render, ECS, math,
-   audio, video) and almost always need a profiling pass. Skip only
-   for pure docs or mechanical refactors.
-
-   You don't need to invoke `simplify` separately — `commit-and-push`
-   runs it as part of its flow. Running `optimize` first matters
-   because optimize may add `IR_PROFILE_*` blocks and rationale
-   comments that simplify should leave alone.
-
-   When **addressing review feedback** (amending or pushing fixes),
-   re-run `optimize` (if the perf surface changed) before invoking
-   `commit-and-push` to push the fix.
+4. **Optimize before commit.** See [docs/agents/AUTHOR-PIPELINE.md § Optimize before commit](../../docs/agents/AUTHOR-PIPELINE.md#optimize-before-commit).
+   This applies to architects too — your PRs touch core engine code
+   (render, ECS, math, audio, video) and almost always need a profiling
+   pass; skip only for pure docs or mechanical refactors. Don't invoke
+   `simplify` separately — `commit-and-push` runs it.
 5. Use the `commit-and-push` skill to open the PR. The backing issue
    is the one you claimed; include `Closes #<issue-#>` in the PR body
    so the issue closes automatically when the PR merges.
@@ -201,72 +192,40 @@ behavior here.
 ## Filing tasks
 
 When you identify work that needs doing — by you, a Sonnet agent, or
-anyone — file it as a GitHub issue **with NO labels**:
+anyone — file it per
+[docs/agents/TASK-FILING.md](../../docs/agents/TASK-FILING.md): a
+GitHub issue with **no labels** and a structured body
+(Area / Model / Blocked by / Acceptance criteria / Context). The human
+stamps `human:approved` when they want it picked up; the scout ingests
+it on its next pass and adds the rest.
 
-`gh issue create --repo jakildev/IrredenEngine --title "<short title>" --body "<description>"`
-
-Do NOT pre-apply `fleet:task`, `fleet:queued`, `fleet:needs-plan`, or
-any other state label. Per [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Issue/PR labeling discipline":
-state labels are owned by specific roles (reviewers, the human).
-Author-side filing should add zero labels and let the human stamp
-`human:approved` when they want it picked up. The scout / role
-triage flow adds the appropriate state labels post-triage.
-
-Include in the body:
-- **Area:** e.g. `engine/render`, `engine/math`, `docs`
-- **Model:** `opus` or `sonnet`
-- **Blocked by:** `(none)` or `#NNN`
-- **Acceptance criteria** (concrete check: build passes, test X works)
-- **Context** (why this matters, what you observed)
-
-The issue will sit in the backlog until the **human triages and adds
-the `human:approved` label**. Only then does the scout ingest it into
-the live queue on its next pass.
+**Multi-issue stacks (epic decomposition).** When the work decomposes
+into a stack of N issues that each depend on the prior — the canonical
+smooth-yaw / SO(3) / rotation / streaming patterns — do NOT hand-file
+the children. Invoke the **`file-epic`** skill, which enforces the
+structured `**Blocked by:** #<prior>` chain the scout and `fleet-claim`
+parsers require (`/file-epic <path-to-approved-plan>`). Hand-filing
+reliably drops the standalone `**Blocked by:**` line into header prose,
+where the parsers can't see it and the chain silently fails to stack.
+See [docs/agents/TASK-FILING.md § Multi-issue stacks](../../docs/agents/TASK-FILING.md#multi-issue-stacks-epic-decomposition)
+for the rules (one `#N` per blocker line; issue-number blockers only;
+gate docs-PR dependencies by withholding `human:approved`).
 
 ## Planning issues
 
-The **opus worker** autonomously handles `fleet:needs-plan` issues
-as a transient, scout-triggered invocation — reading the issue thread, posting a plan
-comment, saving a plan file to `~/.fleet/plans/`, and swapping labels.
-You do not need to poll for these.
+The **opus worker** autonomously handles `fleet:needs-plan` issues as a
+transient, scout-triggered invocation. You do not need to poll for them.
 
-If the human asks you to plan an issue directly (e.g., during a design
-conversation), use the same flow:
-
-1. Read the full issue thread (title, body, all comments).
-2. Assess the scope and propose a plan as an issue comment:
-   - What files/modules are involved
-   - Whether it should be one task or broken into subtasks
-   - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
-   - Acceptance criteria
-   - **Cross-system audit (when planning a deletion or migration of
-     a shared resource — component, SSBO, GPU buffer, system,
-     coordinate convention, etc.).** List every consumer of the
-     resource being changed and a per-consumer migration plan.
-     Audit by grep on the type/symbol name and on slot/binding
-     numbers (some consumers reference resources by index, not
-     name). Without this section the worker discovers gaps mid-task
-     and escalates: T-071's design doc planned `BUILD_OCCUPANCY_GRID`
-     deletion based on the sun-shadow consumer alone, missing AO
-     (`c_compute_voxel_ao.glsl` slot 28) and light-volume
-     (`detail::hasLineOfSight`) which both also depend on it. T-072
-     then expected the grid to still exist as a GPU resource T-071
-     was deleting. Sign-convention drift between parallel PRs
-     (T-055 vs T-056 on `visualYaw`→world rotation) is the same
-     class of bug — name the convention and the consumers that
-     must agree on it.
-3. Save the plan to `~/.fleet/plans/issue-<N>.md` using the Write tool.
-4. Remove `fleet:needs-plan`. Do NOT touch `human:approved` —
-   it's still on the issue from when the human triaged it, and
-   removing it would erase the human's signal:
-   `gh issue edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:needs-plan"`
-   The scout picks this issue up on its next pass — `human:approved`
-   without `fleet:needs-plan` (and without `fleet:needs-info`) is the
-   signal that the issue is queue-ready. The plan file stays at
-   `~/.fleet/plans/issue-<N>.md`.
-
-If you disagree with the issue's direction, comment with your
-concerns but leave `fleet:needs-plan` on — let the human decide.
+If the human asks you to plan an issue directly (e.g. during a design
+conversation), follow the shared
+[docs/agents/PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md)
+— read the full thread, post the structured plan comment (including the
+**cross-system audit** when planning a deletion/migration of a shared
+resource), save `~/.fleet/plans/issue-<N>.md`, and remove
+`fleet:needs-plan` (leaving `human:approved`). If you disagree with the
+issue's direction, comment but leave `fleet:needs-plan` on. If the work
+decomposes into a multi-issue stack, file it via `file-epic` per
+[Filing tasks](#filing-tasks) above.
 
 **Game-side scope.** The architect does not autonomously claim game
 tasks. The responsibility list above is engine-only. When the human
@@ -427,12 +386,8 @@ Stop and surface to the human when:
 
 ## End-of-iteration feedback
 
-If during a session you noticed something the human should know
-about — a fleet bug, missing permission, surprising state, or
-suggestion for the fleet itself — append a structured entry to
-`~/.fleet/feedback/opus-architect.md`. See [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md)
-"Fleet feedback channel" for the format and the bar (high — write
-only when there's a real signal worth surfacing).
+See [docs/agents/FLEET-RUNTIME.md § End-of-iteration feedback](../../docs/agents/FLEET-RUNTIME.md#end-of-iteration-feedback).
+Your feedback file is `~/.fleet/feedback/opus-architect.md`.
 
 ## Hard rules
 

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -188,8 +188,8 @@ iteration of polling, reviewing, and exiting cleanly:
    scratch reset already happened in step 3 above. Print
    `[opus-reviewer] Iteration complete. Will re-fire on next dispatcher trigger.`
    and exit cleanly.
-5. If you hit a usage-limit error: print the error and exit.
-   `fleet-dispatcher` does NOT implement usage-limit back-off; flag the limit in your iteration summary so the human can intervene.
+5. If you hit a usage-limit error, see [docs/agents/FLEET-RUNTIME.md § Usage-limit handling](../../docs/agents/FLEET-RUNTIME.md#usage-limit-handling)
+   — print the error and exit; flag it in your iteration summary.
 
 If Mode above is `dry-run`: review exactly **one** flagged PR
 end-to-end, then stop and wait for human instruction. Do not loop.
@@ -209,43 +209,21 @@ point of review-only mode — keep reviewing PRs as normal.
 
 ## End-of-iteration feedback
 
-If you noticed something this iteration that the human should know
-about — a fleet bug, missing permission, surprising state, or
-suggestion for the fleet itself — append a structured entry to
-`~/.fleet/feedback/opus-reviewer.md`. See
-[`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Fleet feedback channel" for the format and the bar (high — most
-iterations write nothing).
+See [docs/agents/FLEET-RUNTIME.md § End-of-iteration feedback](../../docs/agents/FLEET-RUNTIME.md#end-of-iteration-feedback).
+Your feedback file is `~/.fleet/feedback/opus-reviewer.md`.
 
 ## Hard rules
 
-See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles). Reviewer-specific additions:
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles)
+and the shared reviewer rules in
+[`docs/agents/REVIEWER-PROTOCOL.md § Reviewer hard rules`](../../docs/agents/REVIEWER-PROTOCOL.md#reviewer-hard-rules)
+(never commit/push/open-PRs from this worktree; never `--approve` /
+`--request-changes`; never post a review without the verdict label;
+never re-apply a verdict without a fresh review — including the live
+timeline check before re-stamping a "missing" verdict).
 
-- **Never commit, push, or open PRs from this worktree.**
-- **Never `gh pr review --approve` or `--request-changes`** — all fleet
-  agents share one GitHub account and GitHub rejects formal review
-  actions on your own PRs. Always use `--comment` with a clear verdict.
-- **Never post a review without setting the verdict label.** A review
-  without a `fleet:approved` / `fleet:needs-fix` / `fleet:blocker`
-  label is invisible to the human's merge queue. After every
-  `gh pr review --comment ...`, your VERY NEXT bash call MUST be
-  `gh pr edit <N> ... --add-label "fleet:..."`. Describing the label
-  change in the review body does NOT set the label — only the gh
-  command does. Verify with `gh pr view <N> --json labels` if unsure.
-- **Never re-apply a verdict label without posting a new review in
-  the same iteration.** A PR with a prior Opus needs-fix verdict in
-  history but no current label is NOT automatically a label-fixup
-  candidate — the label may have been legitimately cleared by the
-  author's `commit-and-push` after a fix push, by an ESCALATE
-  handoff (swap of `fleet:needs-fix` for `fleet:changes-made`), or
-  by a worker mid-claim. Before re-stamping a "missing" verdict
-  label, do one live check for ANY of: (a) a new commit since your
-  last review's `submittedAt`, (b) a new author comment, (c) a
-  recent `fleet:needs-fix` / `fleet:approved` UNLABELED event, (d)
-  presence of `fleet:changes-made`. If any are present, the prior
-  verdict was author-acknowledged — treat the PR as a re-review
-  candidate and post a fresh review rather than re-stamping the
-  stale verdict. Use `gh api repos/jakildev/IrredenEngine/issues/<N>/timeline`
-  to see UNLABELED events.
+Opus-reviewer-specific addition:
+
 - **Do NOT take on first-pass reviews that Sonnet has not yet touched**
   (unless `sonnet-reviewer` is offline AND the PR has been open more
   than 1 hour). The model split exists to conserve Opus budget.

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -63,13 +63,14 @@ body suggests:
 
 - **Modifying the issue queue directly to add new work.** If a plan
   step says "add entries to the queue" or "create follow-up tasks",
-  file the GitHub issue(s) for any new work uncovered via
-  `gh issue create` (no labels). The human stamps `human:approved` and
-  the scout ingests on its next pass. Do not edit other issues' bodies
-  or labels to retitle / re-scope them.
+  file the GitHub issue(s) per
+  [docs/agents/TASK-FILING.md](../../docs/agents/TASK-FILING.md)
+  (no labels). The human stamps `human:approved` and the scout
+  ingests on its next pass. Do not edit other issues' bodies or labels
+  to retitle / re-scope them.
 - **Pre-applying labels at filing time.** When you file an issue for
-  follow-up work, file it with **no labels**. The human stamps
-  `human:approved`; the scout adds the rest.
+  follow-up work, file it with **no labels** (see TASK-FILING.md). The
+  human stamps `human:approved`; the scout adds the rest.
 - **Editing another issue's `Blocked by:` / labels to declare a
   reservation.** Reservations are held by `fleet-claim`'s atomic
   lock fabric (filesystem locks + `fleet:claim-*` labels), not by
@@ -353,68 +354,17 @@ Do the work, then exit cleanly:
     push) and force-push retriggers CI — keep this step bounded to
     one PR per iteration.
 
-2. **Plan any `fleet:needs-plan` issues on either repo.** The
-   cached `repos.engine.needs_plan[]` and `repos.game.needs_plan[]`
-   arrays hold the open needs-plan issues. Pick the oldest
-   unprocessed entry (smallest `number`) across both repos.
-
-   The cache only stores list-shaped data — for per-issue body and
-   comments, pull live (per-item lookup, stays inline):
-   `fleet-issue view <N>` (engine; for game issues add `--repo game`).
-
-   For each issue:
-   a. Read the full issue thread (title, body, all comments).
-   b. Assess the scope and write a structured plan. Post it as an
-      issue comment covering:
-      - What files/modules are involved
-      - Step-by-step implementation approach
-      - Whether it should be one task or broken into subtasks
-      - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
-      - Acceptance criteria
-      - Known gotchas or pitfalls
-   c. **Save the plan locally** for workers to read later:
-      `mkdir -p ~/.fleet/plans`
-      Then use the **Write tool** to create `~/.fleet/plans/issue-<N>.md`
-      (where N is the issue number). Use this format:
-
-      ```markdown
-      # Plan: <issue title>
-
-      - **Issue:** #N
-      - **Model:** opus | sonnet
-      - **Date:** YYYY-MM-DD
-
-      ## Scope
-      <what this task achieves>
-
-      ## Approach
-      <step-by-step: which files, what order, key decisions>
-
-      ## Affected files
-      - `path/to/file.hpp` — <what changes>
-
-      ## Acceptance criteria
-      <concrete checks>
-
-      ## Gotchas
-      <pitfalls the worker should watch for>
-      ```
-
-   d. Remove the `fleet:needs-plan` label. Do NOT touch
-      `human:approved` — it's still on the issue from when the
-      human triaged it, and removing it would erase the human's
-      original signal. Use the issue's repo:
-      `gh issue edit <N> --repo <owner/repo> --remove-label "fleet:needs-plan"`
-      (where `<owner/repo>` is `jakildev/IrredenEngine` for engine
-      issues or `jakildev/irreden` for game issues — the repo where
-      the issue lives, not your worktree's repo).
-      The scout picks this issue up on its next pass — `human:approved`
-      without `fleet:needs-plan` (and without `fleet:needs-info`) is
-      the signal that the issue is queue-ready. The plan file stays
-      at `~/.fleet/plans/issue-<N>.md` for the lifetime of the task.
-
-   If you disagree with the issue's direction, comment with your
-   concerns but leave `fleet:needs-plan` on — let the human decide.
+2. **Plan any `fleet:needs-plan` issues on either repo.** The cached
+   `repos.engine.needs_plan[]` and `repos.game.needs_plan[]` arrays
+   hold the open needs-plan issues. Pick the oldest unprocessed entry
+   (smallest `number`) across both repos, then follow
+   [docs/agents/PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md)
+   — read the full thread (`fleet-issue view <N>`, add `--repo game`
+   for game), post the structured plan comment, save
+   `~/.fleet/plans/issue-<N>.md`, and remove `fleet:needs-plan`
+   (leaving `human:approved`). If the work decomposes into a stack,
+   that doc routes you to `file-epic` via
+   [docs/agents/TASK-FILING.md](../../docs/agents/TASK-FILING.md).
 
 3. **Resume an active molecule first, then pick the next task.**
 
@@ -585,24 +535,10 @@ Do the work, then exit cleanly:
    rule, early returns, `unique_ptr` over `shared_ptr`, and the rest of
    the engine style guide.
 
-7. **Build and run.**
-   `fleet-build --target <name>`
-
-   **If the diff adds files under `engine/prefabs/**/systems/`**, also
-   build `IrredenEngineTest` (or the engine static library) — creation
-   targets like `IRShapeDebug` only link the systems they reference, so
-   a new system with a missing `SystemName` enum entry is a silent
-   linker error from the creation perspective.
-
-   If the touched code has an executable target, run it to confirm it
-   launches cleanly:
-   - **Demos that support `--auto-screenshot`:** `fleet-run <name> --auto-screenshot 10` (no `--timeout` — auto-screenshot fires `closeWindow()` when done).
-   - **All other GUI executables:** `fleet-run --timeout 15 <name>` — 5 seconds is too short for a demo mid-init.
-   - **Test executables:** `fleet-run --timeout 15 <name>` as a safety net.
-
-   **Never** use `cd <dir> && ./<exe>` — that triggers the
-   compound-command security gate. Untested commits are the single
-   biggest waste of reviewer-agent time.
+7. **Build and run.** See [docs/agents/AUTHOR-PIPELINE.md § Build and run](../../docs/agents/AUTHOR-PIPELINE.md#build-and-run)
+   for the `fleet-build` invocation, the `engine/prefabs/**/systems/`
+   linker-error caveat, the `--auto-screenshot` vs `--timeout` run
+   matrix, and the no-`cd && ./exe` gate. Re-touch the heartbeat first.
 
 8. **Stop and escalate if the task scope grows.** If:
    - The scope grows beyond one PR's worth of work
@@ -653,88 +589,31 @@ Do the work, then exit cleanly:
 
    For non-architectural escalations (scope grew, build break is
    structural, public-API surface) where there's no design call to
-   route — file a GitHub issue (no labels), comment on your PR
-   linking it with the blocker context, release the claim with
+   route — file a GitHub issue per
+   [docs/agents/TASK-FILING.md](../../docs/agents/TASK-FILING.md)
+   (no labels, structured body), comment on your PR linking it with
+   the blocker context, release the claim with
    `fleet-claim release <issue-#>`, reset via `start-next-task`,
    and exit. The human will add `human:approved` to the follow-up
    issue when ready to resume.
 
-9. **Verify visual output (when it changed).** Check whether the diff
-   touches visual/render code:
-   `git diff --name-only origin/master...HEAD`
+9. **Verify visual output (when it changed).** See [docs/agents/AUTHOR-PIPELINE.md § Verify visual output](../../docs/agents/AUTHOR-PIPELINE.md#verify-visual-output-when-it-changed)
+   — the render-path trigger file set, the mandatory
+   `attach-screenshots` + `render-debug-loop` pair, the skip
+   conditions, and the "both complete before optimize/commit" ordering.
 
-   The trigger file set is the same for both skills below:
-   - `engine/render/` (any file)
-   - `engine/prefabs/irreden/render/` (any file)
-   - Any `*.glsl` or `*.metal` shader file anywhere in the tree
-   - `creations/demos/*/src/**` or `creations/demos/*/main*.cpp`
+10. **Optimize before commit.** See [docs/agents/AUTHOR-PIPELINE.md § Optimize before commit](../../docs/agents/AUTHOR-PIPELINE.md#optimize-before-commit).
+    The **[opus-worker]** delta applies: run `optimize` almost always
+    (`[opus]` work almost always touches a hot path); skip only for
+    pure docs or mechanical refactors. Don't invoke `simplify`
+    separately — `commit-and-push` runs it.
 
-   When the diff includes any of those, you must invoke BOTH skills:
-
-   a. **`attach-screenshots`** — captures before/after pairs (master
-      vs working tree) and writes them under
-      `docs/pr-screenshots/<branch>/` so the PR body can embed them
-      via raw GitHub URLs. Does not diagnose — see (b). Skip if
-      `docs/pr-screenshots/<branch>/` already contains screenshots
-      from a prior run on this branch.
-
-   b. **`render-debug-loop`** — drives any creation that supports
-      `--auto-screenshot` (today: `shape_debug`), reads each
-      captured frame, and diagnoses rendering issues against the
-      topic-indexed reference (trixel/SDF shapes, lighting,
-      backend-parity symptoms). Catches visual regressions that
-      would otherwise reach the reviewer (or, worse, ship). Required
-      by `engine/render/CLAUDE.md` "Verifying render changes" for
-      any PR touching shaders, render systems, or pipeline ordering.
-
-   The two skills serve different purposes — `attach-screenshots`
-   produces the PR record; `render-debug-loop` is the diagnostic
-   pass that confirms the change actually renders correctly. Run
-   both; do not substitute one for the other.
-
-   Skip BOTH if the diff is purely docs, tests, mechanical refactors
-   (rename, extract-header, add-logging), or build/CI changes with no
-   visual effect. The exceptions list in `engine/render/CLAUDE.md`
-   "Verifying render changes" is authoritative — when in doubt, run
-   the loop; a missing diagnostic pass is a fast reviewer-rejection.
-
-   Both must complete before `optimize` and `commit-and-push` so any
-   resulting fixes land in the same commit as the code change.
-
-10. **Optimize before commit.** Run the `optimize` skill — `[opus]`
-    work almost always touches perf-critical code (engine/render,
-    engine/system, engine/world, engine/audio, engine/video,
-    engine/math). Optimize profiles the new code, identifies hotspots,
-    and verifies no regressions. Skip only for pure docs or mechanical
-    refactors that preserve hot-path structure.
-
-    You don't need to invoke `simplify` separately — `commit-and-push`
-    runs it as part of its flow. Running `optimize` first matters
-    because optimize may add `IR_PROFILE_*` blocks and rationale
-    comments that simplify should leave alone.
-
-    The same applies when **addressing review feedback** — after
-    editing in response to comments, re-run `optimize` (if the perf
-    surface changed) before invoking `commit-and-push` to push the fix.
-
-11. **Finalize the PR.** Use `commit-and-push` to push work commits
-    (commit-and-push uses cwd's git repo automatically — for game
-    tasks, you cd'd in step 4, so it targets the right repo).
-    Remove the WIP label and release the claim. **For game tasks,
-    add `--repo jakildev/irreden` to gh and `--repo game` to
-    fleet-claim release** so the right PR + the right slug are
-    targeted:
-
-    ```
-    # engine task
-    gh pr edit <N> --remove-label "fleet:wip"
-    fleet-claim release <issue-#>
-
-    # game task
-    gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:wip"
-    fleet-claim --repo game release <issue-#>
-    ```
-    Paste the PR URL.
+11. **Finalize the PR.** See [docs/agents/AUTHOR-PIPELINE.md § Finalize the PR](../../docs/agents/AUTHOR-PIPELINE.md#finalize-the-pr)
+    for the `commit-and-push` → remove-`fleet:wip` → `fleet-claim
+    release` sequence and the claim-label lifecycle note. The
+    **[opus-worker] game task** variant (`--repo jakildev/irreden` on
+    `gh`, `--repo game` on `fleet-claim`) applies when you cd'd into the
+    game worktree at step 4. Paste the PR URL.
 
 12. **Reset.** See [docs/agents/FLEET-RUNTIME.md § Per-iteration shutdown](../../docs/agents/FLEET-RUNTIME.md#per-iteration-shutdown--final-step).
     Summary template:
@@ -784,22 +663,16 @@ or `review-only` (passed by `fleet-dispatcher` from `fleet-up`'s mode arg).
   and exit. fleet-dispatcher will re-fire when scout sees new
   actionable state.
 
-If you hit a usage-limit error: print the error and exit. The pane
-returns to shell; fleet-dispatcher's next tick clears the dispatch
-record. The dispatcher does not implement usage-limit back-off, so
-the next scout-trigger will re-fire and may hit the same limit —
-flag the limit in your iteration summary so the human can adjust.
+If you hit a usage-limit error, see [docs/agents/FLEET-RUNTIME.md § Usage-limit handling](../../docs/agents/FLEET-RUNTIME.md#usage-limit-handling)
+— print the error and exit; flag the limit in your iteration summary.
 
 ## End-of-iteration feedback
 
-If you noticed something this iteration that the human should know
-about — a fleet bug, missing permission, surprising state, or
-suggestion for the fleet itself — append a structured entry to
+See [docs/agents/FLEET-RUNTIME.md § End-of-iteration feedback](../../docs/agents/FLEET-RUNTIME.md#end-of-iteration-feedback).
+Your feedback file is per-worktree:
 `~/.fleet/feedback/<your-worktree-basename>.md` (e.g.
-`~/.fleet/feedback/opus-worker-1.md`). Per-worktree filename so the
-human can tell which opus-worker observed what. See
-[`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Fleet feedback channel" for the format and the bar
-(high — most iterations write nothing).
+`~/.fleet/feedback/opus-worker-1.md`), so the human can tell which
+opus-worker observed what.
 
 ## Hard rules
 

--- a/.claude/commands/role-smoke-worker.md
+++ b/.claude/commands/role-smoke-worker.md
@@ -221,11 +221,11 @@ Per [docs/agents/FLEET-RUNTIME.md § Per-iteration shutdown](../../docs/agents/F
 
 ## End-of-iteration feedback
 
-If you noticed something worth surfacing — a persistent smoke label across
-multiple iterations, a systematic build failure pattern, a missing label —
-append an entry to `~/.fleet/feedback/<your-worktree-basename>.md`.
-See [docs/agents/FLEET.md § "Fleet feedback channel"](../../docs/agents/FLEET.md#fleet-feedback-channel)
-for the format. High bar — most iterations write nothing.
+See [docs/agents/FLEET-RUNTIME.md § End-of-iteration feedback](../../docs/agents/FLEET-RUNTIME.md#end-of-iteration-feedback).
+Your feedback file is per-worktree
+(`~/.fleet/feedback/<your-worktree-basename>.md`). Worth surfacing for
+smoke: a persistent smoke label across multiple iterations, a systematic
+build-failure pattern, or a missing label.
 
 ---
 

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -254,24 +254,10 @@ Each iteration:
    rule, early returns, `unique_ptr` over `shared_ptr`, and the rest of
    the engine style guide.
 
-6. **Build and run.**
-   `fleet-build --target <name>`
-
-   **If the diff adds files under `engine/prefabs/**/systems/`**, also
-   build `IrredenEngineTest` (or the engine static library) — creation
-   targets like `IRShapeDebug` only link the systems they reference, so
-   a new system with a missing `SystemName` enum entry is a silent
-   linker error from the creation perspective.
-
-   If the touched code has an executable target, run it to confirm it
-   launches cleanly:
-   - **Demos that support `--auto-screenshot`:** `fleet-run <executable-name> --auto-screenshot 10` (no `--timeout` — auto-screenshot fires `closeWindow()` when done).
-   - **All other GUI executables:** `fleet-run --timeout 15 <executable-name>` — 5 seconds is too short for a demo mid-init.
-   - **Test executables:** `fleet-run --timeout 15 <executable-name>` as a safety net.
-
-   **Never** use `cd <dir> && ./<exe>` — that triggers the
-   compound-command security gate. Untested commits are the single
-   biggest waste of reviewer-agent time.
+6. **Build and run.** See [docs/agents/AUTHOR-PIPELINE.md § Build and run](../../docs/agents/AUTHOR-PIPELINE.md#build-and-run)
+   for the `fleet-build` invocation, the `engine/prefabs/**/systems/`
+   linker-error caveat, the `--auto-screenshot` vs `--timeout` run
+   matrix, and the no-`cd && ./exe` gate. Re-touch the heartbeat first.
 
 7. **Stop and escalate if the task is subtler than expected.** If the
    work touches:
@@ -281,85 +267,35 @@ Each iteration:
    - The public `ir_*.hpp` surface across multiple modules
    - Lifetime/ownership decisions
 
-   STOP. File a GitHub issue for the opus work (no labels — see
-   [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Issue/PR labeling discipline") and note the escalation
-   on your PR:
-   `gh issue create --repo jakildev/IrredenEngine --title "<what needs opus attention>" --body "Escalated from sonnet.\n\n**Area:** ...\n**Model:** opus\n**Blocked by:** (none)\n\nContext: ..."`
-   Then comment on your PR: "escalated — filed issue #N for opus".
-   The human will triage the issue and add `human:approved` when
-   ready. The scout ingests it on its next pass and the opus-workers
-   become eligible to claim it. Move on to the next task.
+   STOP. File the opus follow-up as a GitHub issue per
+   [docs/agents/TASK-FILING.md § Escalation issues](../../docs/agents/TASK-FILING.md#escalation-issues-sonnet--opus-or-scope-grew)
+   (no labels, `Escalated from sonnet.` + structured body). Then
+   comment on your PR: "escalated — filed issue #N for opus". The
+   human triages and adds `human:approved` when ready; the scout
+   ingests it and the opus-workers become eligible to claim it. Move
+   on to the next task.
 
-8. **Verify visual output (when it changed).** Check whether the diff
-   touches visual/render code:
-   `git diff --name-only origin/master...HEAD`
+8. **Verify visual output (when it changed).** See [docs/agents/AUTHOR-PIPELINE.md § Verify visual output](../../docs/agents/AUTHOR-PIPELINE.md#verify-visual-output-when-it-changed)
+   — the render-path trigger file set, the mandatory
+   `attach-screenshots` + `render-debug-loop` pair, the skip
+   conditions, and the ordering before optimize/commit. The
+   **[sonnet-author]** delta applies: if `render-debug-loop` surfaces
+   something subtler than a known symptom (or a fix that would touch
+   core render pipeline code), STOP and escalate per step 7 — that's
+   an Opus-tier debugging session.
 
-   The trigger file set is the same for both skills below:
-   - `engine/render/` (any file)
-   - `engine/prefabs/irreden/render/` (any file)
-   - Any `*.glsl` or `*.metal` shader file anywhere in the tree
-   - `creations/demos/*/src/**` or `creations/demos/*/main*.cpp`
+9. **Optimize before commit (when relevant).** See [docs/agents/AUTHOR-PIPELINE.md § Optimize before commit](../../docs/agents/AUTHOR-PIPELINE.md#optimize-before-commit).
+   The **[sonnet-author]** delta applies: run `optimize` ONLY if the
+   change touches a system tick, render pipeline stage, shader,
+   audio/video, or math hot path; skip for docs/tests/mechanical
+   refactors. Don't invoke `simplify` separately — `commit-and-push`
+   runs it.
 
-   When the diff includes any of those, you must invoke BOTH skills:
-
-   a. **`attach-screenshots`** — captures before/after pairs (master
-      vs working tree) and writes them under
-      `docs/pr-screenshots/<branch>/` so the PR body can embed them
-      via raw GitHub URLs. Does not diagnose — see (b). Skip if
-      `docs/pr-screenshots/<branch>/` already contains screenshots
-      from a prior run on this branch.
-
-   b. **`render-debug-loop`** — drives any creation that supports
-      `--auto-screenshot` (today: `shape_debug`), reads each
-      captured frame, and diagnoses rendering issues against the
-      topic-indexed reference (trixel/SDF shapes, lighting,
-      backend-parity symptoms). Catches visual regressions that
-      would otherwise reach the reviewer (or, worse, ship). Required
-      by `engine/render/CLAUDE.md` "Verifying render changes" for
-      any PR touching shaders, render systems, or pipeline ordering.
-
-   The two skills serve different purposes — `attach-screenshots`
-   produces the PR record; `render-debug-loop` is the diagnostic
-   pass that confirms the change actually renders correctly. Run
-   both; do not substitute one for the other.
-
-   If `render-debug-loop` surfaces something subtler than expected
-   (the diagnostic table doesn't match a known symptom, or the fix
-   would touch core render pipeline code), STOP and escalate per
-   step 7 — that's an Opus-tier debugging session, not a Sonnet
-   one.
-
-   Skip BOTH if the diff is purely docs, tests, mechanical refactors
-   (rename, extract-header, add-logging), or build/CI changes with no
-   visual effect. The exceptions list in `engine/render/CLAUDE.md`
-   "Verifying render changes" is authoritative — when in doubt, run
-   the loop; a missing diagnostic pass is a fast reviewer-rejection.
-
-   Both must complete before `optimize` and `commit-and-push` so any
-   resulting fixes land in the same commit as the code change.
-
-9. **Optimize before commit (when relevant).** Run the `optimize`
-   skill ONLY if the change touches a system tick, a render pipeline
-   stage, a shader, audio/video, math hot paths, or anywhere on the
-   per-frame critical path. Skip for pure docs, tests, mechanical
-   refactors, or build/CI changes.
-
-   You don't need to invoke `simplify` here — `commit-and-push`
-   runs it as part of its flow. Running `optimize` first matters
-   because optimize may add `IR_PROFILE_*` blocks and rationale
-   comments that simplify should leave alone; commit-and-push's
-   simplify pass then polishes everything together.
-
-   The same applies when **addressing review feedback** — after
-   editing in response to comments, re-run `optimize` (if the perf
-   surface changed) before invoking `commit-and-push` to push the fix.
-
-10. **Finalize the PR.** Use the `commit-and-push` skill to push your
-   work commits to the existing PR branch. Then remove the WIP label
-   and release the claim:
-   `gh pr edit <N> --remove-label "fleet:wip"`
-   `fleet-claim release <issue-#>`
-   Paste the PR URL.
+10. **Finalize the PR.** See [docs/agents/AUTHOR-PIPELINE.md § Finalize the PR](../../docs/agents/AUTHOR-PIPELINE.md#finalize-the-pr)
+   for the `commit-and-push` → remove-`fleet:wip` → `fleet-claim
+   release` sequence and the claim-label lifecycle note. Sonnet-author
+   is engine-only, so the game-task variant doesn't apply. Paste the
+   PR URL.
 
 11. **Reset and exit cleanly.** See [docs/agents/FLEET-RUNTIME.md § Per-iteration shutdown](../../docs/agents/FLEET-RUNTIME.md#per-iteration-shutdown--final-step).
    Summary template:
@@ -408,24 +344,17 @@ or `review-only` (passed by `fleet-dispatcher` from `fleet-up`'s mode arg).
 
 ## Usage-limit handling
 
-If you hit a usage-limit error:
-1. Print the error and the stated reset time.
-2. Wait until that reset time.
-3. Resume from where you stopped.
-
-Do NOT switch to `/model opus` to keep working — that defeats the
-budget split. Just wait.
+See [docs/agents/FLEET-RUNTIME.md § Usage-limit handling](../../docs/agents/FLEET-RUNTIME.md#usage-limit-handling).
+As a Sonnet role: do NOT switch to `/model opus` to keep working —
+that defeats the budget split. Wait for the stated reset window.
 
 ## End-of-iteration feedback
 
-If you noticed something this iteration that the human should know
-about — a fleet bug, missing permission, surprising state, or
-suggestion for the fleet itself — append a structured entry to
+See [docs/agents/FLEET-RUNTIME.md § End-of-iteration feedback](../../docs/agents/FLEET-RUNTIME.md#end-of-iteration-feedback).
+Your feedback file is per-worktree:
 `~/.fleet/feedback/<your-worktree-basename>.md` (e.g.
-`~/.fleet/feedback/sonnet-fleet-1.md`). Per-worktree filename so
-the human can tell which sonnet pane observed what. See
-[`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Fleet feedback channel" for the format and the bar
-(high — most iterations write nothing).
+`~/.fleet/feedback/sonnet-fleet-1.md`), so the human can tell which
+sonnet pane observed what.
 
 ## Hard rules
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -201,8 +201,8 @@ iteration of polling, reviewing, and exiting cleanly:
    scratch reset already happened in step 3 above. Print
    `[sonnet-reviewer] Iteration complete. Will re-fire on next dispatcher trigger.`
    and exit cleanly.
-5. If you hit a usage-limit error: print the error and exit.
-   `fleet-dispatcher` does NOT implement usage-limit back-off; flag the limit in your iteration summary so the human can intervene.
+5. If you hit a usage-limit error, see [docs/agents/FLEET-RUNTIME.md § Usage-limit handling](../../docs/agents/FLEET-RUNTIME.md#usage-limit-handling)
+   — print the error and exit; flag it in your iteration summary.
 
 If Mode above is `dry-run`: review exactly **one** PR end-to-end
 (complete one iteration of step 2 with one PR), then stop and wait
@@ -225,35 +225,15 @@ point of review-only mode — keep reviewing PRs as normal.
 
 ## End-of-iteration feedback
 
-If you noticed something this iteration that the human should know
-about — a fleet bug, missing permission, surprising state, or
-suggestion for the fleet itself — append a structured entry to
-`~/.fleet/feedback/sonnet-reviewer.md`. See
-[`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Fleet feedback channel" for the format and the bar (high — most
-iterations write nothing).
+See [docs/agents/FLEET-RUNTIME.md § End-of-iteration feedback](../../docs/agents/FLEET-RUNTIME.md#end-of-iteration-feedback).
+Your feedback file is `~/.fleet/feedback/sonnet-reviewer.md`.
 
 ## Hard rules
 
-See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles). Reviewer-specific additions:
-
-- **Never commit, push, or open PRs from this worktree.**
-- **Never `gh pr review --approve` or `--request-changes`** — all fleet
-  agents share one GitHub account and GitHub rejects formal review
-  actions on your own PRs. Always use `--comment` with a clear
-  verdict line (`Verdict: approve`, `Verdict: needs-fix`, etc.).
-- **Never post a review without setting the verdict label.** A review
-  comment without a `fleet:approved` / `fleet:needs-fix` /
-  `fleet:blocker` label is invisible to the human's merge queue —
-  the human filters PRs by label, not by review body. After every
-  `gh pr review --comment ...`, your VERY NEXT bash call MUST be
-  `gh pr edit <N> ... --add-label "fleet:..."`. Verify with
-  `gh pr view <N> --json labels`.
-- **Never re-apply a verdict label without posting a new review in
-  the same iteration.** If a PR you previously verdicted is now
-  missing its verdict label, that is NOT a label-fixup trigger —
-  the label may have been legitimately cleared by the author's
-  `commit-and-push` after a fix push, by an ESCALATE handoff (which
-  swaps `fleet:needs-fix` for `fleet:changes-made`), or by a worker
-  mid-claim on a `fleet:has-nits` PR. If you decide to re-review,
-  post a new review and set the label as part of THAT review's flow.
-  Otherwise leave the label alone.
+See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`](../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles)
+and the shared reviewer rules in
+[`docs/agents/REVIEWER-PROTOCOL.md § Reviewer hard rules`](../../docs/agents/REVIEWER-PROTOCOL.md#reviewer-hard-rules)
+(never commit/push/open-PRs from this worktree; never `--approve` /
+`--request-changes`; never post a review without setting the verdict
+label; never re-apply a verdict without a fresh review). No
+sonnet-reviewer-specific additions beyond those.

--- a/docs/agents/AUTHOR-PIPELINE.md
+++ b/docs/agents/AUTHOR-PIPELINE.md
@@ -1,0 +1,164 @@
+# AUTHOR-PIPELINE.md — shared build → verify → optimize → ship pipeline
+
+The execution pipeline shared by the two author-side roles
+(`role-opus-worker.md` and `role-sonnet-author.md`). Once a task is
+claimed and the plan is read, both roles run the same build → run →
+verify-visual → optimize → finalize sequence. Both role files point
+here rather than restating it, so the two cannot drift on shared
+mechanics.
+
+Role-specific deltas (Opus-vs-Sonnet, engine-vs-game) are called out
+inline below with **[opus-worker]** / **[sonnet-author]** tags. Where
+no tag appears, the step is identical for both.
+
+The per-iteration runtime ceremonies (heartbeat, reservation check,
+shutdown) live in [`FLEET-RUNTIME.md`](FLEET-RUNTIME.md); the
+claim / PR-open / stacked-PR command sequences live in
+[`FLEET.md`](FLEET.md). This doc covers only the work-and-ship steps
+between "branch is ready" and "PR is finalized."
+
+---
+
+## Build and run
+
+```
+fleet-build --target <name>
+```
+
+**If the diff adds files under `engine/prefabs/**/systems/`**, also
+build `IrredenEngineTest` (or the engine static library) — creation
+targets like `IRShapeDebug` only link the systems they reference, so
+a new system with a missing `SystemName` enum entry is a silent
+linker error from the creation perspective.
+
+If the touched code has an executable target, run it to confirm it
+launches cleanly:
+
+- **Demos that support `--auto-screenshot`:** `fleet-run <name> --auto-screenshot 10` (no `--timeout` — auto-screenshot fires `closeWindow()` when done).
+- **All other GUI executables:** `fleet-run --timeout 15 <name>` — 5 seconds is too short for a demo mid-init.
+- **Test executables:** `fleet-run --timeout 15 <name>` as a safety net.
+
+**Never** use `cd <dir> && ./<exe>` — that triggers the
+compound-command security gate. Untested commits are the single
+biggest waste of reviewer-agent time.
+
+---
+
+## Verify visual output (when it changed)
+
+Check whether the diff touches visual/render code:
+
+```
+git diff --name-only origin/master...HEAD
+```
+
+The trigger file set:
+
+- `engine/render/` (any file)
+- `engine/prefabs/irreden/render/` (any file)
+- Any `*.glsl` or `*.metal` shader file anywhere in the tree
+- `creations/demos/*/src/**` or `creations/demos/*/main*.cpp`
+
+When the diff includes any of those, you must invoke **BOTH** skills:
+
+a. **`attach-screenshots`** — captures before/after pairs (master vs
+   working tree) and writes them under `docs/pr-screenshots/<branch>/`
+   so the PR body can embed them via raw GitHub URLs. Does not
+   diagnose — see (b). Skip if `docs/pr-screenshots/<branch>/` already
+   contains screenshots from a prior run on this branch.
+
+b. **`render-debug-loop`** — drives any creation that supports
+   `--auto-screenshot` (today: `shape_debug`), reads each captured
+   frame, and diagnoses rendering issues against the topic-indexed
+   reference (trixel/SDF shapes, lighting, backend-parity symptoms).
+   Catches visual regressions that would otherwise reach the reviewer
+   (or, worse, ship). Required by `engine/render/CLAUDE.md` "Verifying
+   render changes" for any PR touching shaders, render systems, or
+   pipeline ordering.
+
+The two skills serve different purposes — `attach-screenshots`
+produces the PR record; `render-debug-loop` is the diagnostic pass
+that confirms the change actually renders correctly. Run both; do not
+substitute one for the other.
+
+Skip BOTH if the diff is purely docs, tests, mechanical refactors
+(rename, extract-header, add-logging), or build/CI changes with no
+visual effect. The exceptions list in `engine/render/CLAUDE.md`
+"Verifying render changes" is authoritative — when in doubt, run the
+loop; a missing diagnostic pass is a fast reviewer-rejection.
+
+Both must complete before `optimize` and `commit-and-push` so any
+resulting fixes land in the same commit as the code change.
+
+**[sonnet-author]** If `render-debug-loop` surfaces something subtler
+than expected (the diagnostic table doesn't match a known symptom, or
+the fix would touch core render pipeline code), STOP and escalate (file
+the opus follow-up issue per [`TASK-FILING.md`](TASK-FILING.md) and note
+it on your PR). That's an Opus-tier debugging session, not a Sonnet one.
+
+---
+
+## Optimize before commit
+
+Run the `optimize` skill. It profiles the new code, identifies
+hotspots, and verifies no regressions.
+
+**When to run:**
+
+- **[opus-worker]** Almost always — `[opus]` work almost always
+  touches perf-critical code (engine/render, engine/system,
+  engine/world, engine/audio, engine/video, engine/math). Skip only
+  for pure docs or mechanical refactors that preserve hot-path
+  structure.
+- **[sonnet-author]** Only if the change touches a system tick, a
+  render pipeline stage, a shader, audio/video, math hot paths, or
+  anywhere on the per-frame critical path. Skip for pure docs, tests,
+  mechanical refactors, or build/CI changes.
+
+You don't need to invoke `simplify` separately — `commit-and-push`
+runs it as part of its flow. Running `optimize` first matters because
+optimize may add `IR_PROFILE_*` blocks and rationale comments that
+simplify should leave alone; commit-and-push's simplify pass then
+polishes everything together.
+
+The same applies when **addressing review feedback** — after editing
+in response to comments, re-run `optimize` (if the perf surface
+changed) before invoking `commit-and-push` to push the fix.
+
+---
+
+## Finalize the PR
+
+Use the `commit-and-push` skill to push your work commits to the
+existing PR branch (commit-and-push uses cwd's git repo automatically).
+Then remove the WIP label and release the claim.
+
+```
+# engine task
+gh pr edit <N> --remove-label "fleet:wip"
+fleet-claim release <issue-#>
+```
+
+**[opus-worker] game task** — you `cd`'d into the game worktree at
+claim time, so `commit-and-push` already targets the right repo; add
+`--repo jakildev/irreden` to `gh` and `--repo game` to `fleet-claim`
+so the right PR + the right slug are targeted:
+
+```
+# game task
+gh pr edit <N> --repo jakildev/irreden --remove-label "fleet:wip"
+fleet-claim --repo game release <issue-#>
+```
+
+Paste the PR URL.
+
+> **Claim-label lifecycle.** `fleet-claim release` clears the local
+> filesystem lock and the worktree reservation. The issue's
+> `fleet:claim-<host>-<agent>` and `fleet:in-progress` labels are
+> **left in place** — they persist through the PR's review/merge
+> lifecycle and are swept by `fleet-claim cleanup --gh` only when the
+> issue closes or the claim goes stale with no matching open
+> `claude/<N>-*` PR. Don't hand-strip them.
+
+Then run the shared shutdown ceremony — see
+[`FLEET-RUNTIME.md § Per-iteration shutdown`](FLEET-RUNTIME.md#per-iteration-shutdown--final-step).

--- a/docs/agents/FLEET-RUNTIME.md
+++ b/docs/agents/FLEET-RUNTIME.md
@@ -6,7 +6,29 @@ every iteration: heartbeat → reservation check → ...work... → shutdown.
 Each role file points here rather than restating the protocol.
 
 The architect role (`role-opus-architect.md`) is interactive, not
-transient, and does not run these ceremonies.
+transient, and skips the loop ceremonies (heartbeat, reservation check,
+per-iteration shutdown). It still shares the **startup cache read** and
+**end-of-iteration feedback** sections below.
+
+---
+
+## Startup — shared fleet state cache read
+
+Every role's startup reads the scout's cache before doing anything else.
+The *which slice* differs by role — most read the full
+`~/.fleet/state/state.json`; sonnet-author reads its projection slice
+`~/.fleet/state/projections/sonnet-author.json`; reviewers also discover
+repo slugs (see [`FLEET-CACHE.md`](FLEET-CACHE.md)). The **stale-scout
+guard is identical for all of them**:
+
+> If the cache file is missing or its `generated_at` is older than
+> ~5 minutes, the scout is down — print
+> `scout cache stale or missing — run fleet-up` and exit.
+
+Do not fall back to direct `gh` / `git` polling when the cache is stale;
+that's the cost the cache exists to avoid (see
+[`FLEET-CACHE.md`](FLEET-CACHE.md)). The role file names the specific
+arrays it reads from the cache.
 
 ---
 
@@ -143,6 +165,30 @@ this piece is a no-op at shutdown.
 Then exit cleanly. `fleet-dispatcher` launches a fresh `claude` for the
 role when the scout's projection sees new actionable state — no
 carry-over between iterations.
+
+---
+
+## End-of-iteration feedback
+
+If you noticed something this iteration that the human should know about
+— a fleet bug, a missing permission, surprising state, or a suggestion
+for the fleet itself — append a structured entry to your feedback file:
+
+```
+~/.fleet/feedback/<your-feedback-name>.md
+```
+
+The feedback name is per-role:
+
+| Role | File |
+|---|---|
+| opus-worker, sonnet-author | `<your-worktree-basename>.md` (e.g. `opus-worker-1.md`, `sonnet-fleet-1.md`) — per-worktree so the human can tell which pane observed what |
+| opus-reviewer, sonnet-reviewer, merger, smoke-worker | the fixed role name (e.g. `opus-reviewer.md`) |
+| opus-architect | `opus-architect.md` |
+
+See [`FLEET.md § Fleet feedback channel`](FLEET.md) for the entry format
+and the bar — which is **high**. Most iterations write nothing; only
+durable, actionable observations belong here, not per-iteration status.
 
 ---
 

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -1,0 +1,105 @@
+# PLANNING-PROTOCOL.md — handling `fleet:needs-plan` issues
+
+The shared procedure for turning a `fleet:needs-plan` issue into a
+queue-ready task with a plan. Used by `role-opus-worker.md` (which
+plans these autonomously as a scout-triggered step) and
+`role-opus-architect.md` (which plans them on request during a design
+conversation). Both point here rather than restating the flow.
+
+Sonnet roles do not plan — planning is `[opus]` work.
+
+---
+
+## The flow
+
+For each `fleet:needs-plan` issue:
+
+1. **Read the full issue thread** — title, body, and every comment.
+   The plan is often seeded in a comment, and the human may have left
+   scope refinements there too. Use the cache-aware wrapper:
+   `fleet-issue view <N>` (engine; for game issues add `--repo game`).
+   Do **not** use bare `gh issue view <N>` — it omits comments by
+   default and silently drops context.
+
+2. **Assess scope and post a structured plan as an issue comment**
+   covering:
+   - What files/modules are involved
+   - Step-by-step implementation approach
+   - Whether it should be **one task or broken into subtasks**
+   - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
+   - Acceptance criteria
+   - Known gotchas or pitfalls
+   - **Cross-system audit (when planning a deletion or migration of a
+     shared resource** — component, SSBO, GPU buffer, system,
+     coordinate convention, etc.). List every consumer of the resource
+     being changed and a per-consumer migration plan. Audit by grep on
+     the type/symbol name AND on slot/binding numbers (some consumers
+     reference resources by index, not name). Without this section the
+     worker discovers gaps mid-task and escalates.
+
+   **If the work breaks into a multi-issue stack, do not hand-file the
+   children** — follow [`TASK-FILING.md § Multi-issue stacks`](TASK-FILING.md#multi-issue-stacks-epic-decomposition)
+   (the `file-epic` skill enforces the structured `**Blocked by:** #N`
+   chain the scout and `fleet-claim` parsers require).
+
+3. **Save the plan locally** for workers to read later:
+   `mkdir -p ~/.fleet/plans`, then use the **Write tool** to create
+   `~/.fleet/plans/issue-<N>.md` (where N is the issue number). Format:
+
+   ```markdown
+   # Plan: <issue title>
+
+   - **Issue:** #N
+   - **Model:** opus | sonnet
+   - **Date:** YYYY-MM-DD
+
+   ## Scope
+   <what this task achieves>
+
+   ## Approach
+   <step-by-step: which files, what order, key decisions>
+
+   ## Affected files
+   - `path/to/file.hpp` — <what changes>
+
+   ## Acceptance criteria
+   <concrete checks>
+
+   ## Gotchas
+   <pitfalls the worker should watch for>
+   ```
+
+4. **Remove the `fleet:needs-plan` label. Do NOT touch
+   `human:approved`** — it's still on the issue from when the human
+   triaged it, and removing it would erase the human's original
+   signal. Use the issue's repo:
+   `gh issue edit <N> --repo <owner/repo> --remove-label "fleet:needs-plan"`
+   (`<owner/repo>` is `jakildev/IrredenEngine` for engine issues or
+   `jakildev/irreden` for game issues — the repo where the issue lives,
+   not your worktree's repo).
+
+   The scout picks the issue up on its next pass — `human:approved`
+   without `fleet:needs-plan` (and without `fleet:needs-info`) is the
+   signal that the issue is queue-ready. The plan file stays at
+   `~/.fleet/plans/issue-<N>.md` for the lifetime of the task.
+
+**If you disagree with the issue's direction**, comment with your
+concerns but leave `fleet:needs-plan` on — let the human decide.
+
+---
+
+## Role-specific notes
+
+**[opus-worker]** The cached `repos.engine.needs_plan[]` and
+`repos.game.needs_plan[]` arrays hold the open needs-plan issues; pick
+the oldest unprocessed entry (smallest `number`) across both repos.
+This runs as a scout-triggered loop step — see the worker role file
+for where it sits in the iteration. Cross-repo: add `--repo game` to
+`fleet-issue` / `gh issue edit` for game-side issues.
+
+**[opus-architect]** You plan these when the human asks during a design
+conversation (the opus-worker handles the autonomous queue). Same flow;
+you do not poll for them. If the plan needs an independently-reviewed
+design doc first, see [`role-opus-architect.md § Handling
+fleet:design-blocked PRs`](../../.claude/commands/role-opus-architect.md)
+for the docs-first-PR + `**Blocked by:** #<docs-PR>` routing.

--- a/docs/agents/REVIEWER-PROTOCOL.md
+++ b/docs/agents/REVIEWER-PROTOCOL.md
@@ -314,3 +314,43 @@ exactly one of:
 explicitly — "Sonnet flagged X; on closer read I confirm/disagree
 because Y" — so the diff between Sonnet's pass and yours is visible
 in the body.
+
+---
+
+## Reviewer hard rules
+
+Shared by both reviewer roles, on top of
+[`CLAUDE-BASELINE.md § Hard rules for autonomous fleet roles`](CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles).
+Each reviewer file points here; role-specific additions stay in the
+role file.
+
+- **Never commit, push, or open PRs from a reviewer worktree.** The
+  `review-pr` skill documents this as an anti-pattern; treat it as a
+  hard rule.
+- **Never `gh pr review --approve` or `--request-changes`.** All fleet
+  agents share one GitHub account and GitHub rejects formal review
+  actions on your own PRs. Always use `--comment` with a clear verdict
+  line (`Verdict: approve`, `Verdict: needs-fix`, etc.).
+- **Never post a review without setting the verdict label.** A review
+  comment without a `fleet:approved` / `fleet:needs-fix` /
+  `fleet:blocker` label is invisible to the human's merge queue — the
+  human filters PRs by label, not by review body. After every
+  `gh pr review --comment ...`, your VERY NEXT bash call MUST be the
+  verdict label-swap (see § Verdict label-swap commands). Describing
+  the label change in the review body does NOT set it — only the `gh`
+  command does. Verify with `gh pr view <N> --json labels`.
+- **Never re-apply a verdict label without posting a new review in the
+  same iteration.** A PR with a prior verdict in history but no current
+  label is NOT automatically a label-fixup candidate — the label may
+  have been legitimately cleared by the author's `commit-and-push`
+  after a fix push, by an ESCALATE handoff (swap of `fleet:needs-fix`
+  for `fleet:changes-made`), or by a worker mid-claim on a
+  `fleet:has-nits` PR. Before re-stamping a "missing" verdict, do one
+  live check for ANY of: (a) a new commit since your last review's
+  `submittedAt`, (b) a new author comment, (c) a recent
+  `fleet:needs-fix` / `fleet:approved` UNLABELED event
+  (`gh api repos/<owner>/<repo>/issues/<N>/timeline`), (d) presence of
+  `fleet:changes-made`. If any are present, the prior verdict was
+  author-acknowledged — treat the PR as a re-review candidate and post
+  a fresh review rather than re-stamping the stale verdict. Otherwise
+  leave the label alone.

--- a/docs/agents/TASK-FILING.md
+++ b/docs/agents/TASK-FILING.md
@@ -107,11 +107,11 @@ Rules that make the stack actually stack:
   satisfied ref. (Live multi-blocker resolution is planned but not
   landed — track via the open scout/fleet-claim blocker-resolution
   issue.)
-- **The blocker must be an issue number, not a PR number.**
-  `fleet-claim`'s blocker gate resolves `#N` via `gh issue view --json
-  state` (CLOSED = satisfied). To gate on a docs PR that has no backing
-  issue, withhold `human:approved` on the first task until that PR
-  merges, rather than writing `**Blocked by:** #<pr>`.
+- **Use issue numbers as blockers; PR numbers are unreliable.**
+  `fleet-claim` treats a `#N` ref as gate-blocked until CLOSED (issues
+  close when their PR merges), whereas a PR number left as blocker adds
+  ambiguity. To gate on a docs PR that has no backing issue, withhold
+  `human:approved` on the dependent task instead.
 
 Once filed correctly, the cascade is automatic: T1 claims plain and
 opens `claude/<T1>-*`; the scout enriches T2 with `stackable_blocker_pr`

--- a/docs/agents/TASK-FILING.md
+++ b/docs/agents/TASK-FILING.md
@@ -1,0 +1,120 @@
+# TASK-FILING.md — filing issues into the fleet queue
+
+How fleet roles file new work as GitHub issues. Used by the architect
+(files work it identifies), opus-worker (files follow-ups + escalations),
+and sonnet-author (files opus escalations). All point here rather than
+restating the convention.
+
+The label state machine these issues flow through lives in
+[`FLEET.md § Issue/PR labeling discipline`](FLEET.md). This doc covers
+the filing mechanics only.
+
+---
+
+## Single issue
+
+File with **no labels**:
+
+```
+gh issue create --repo jakildev/IrredenEngine --title "<short title>" --body "<body>"
+```
+
+(For game-side work: `--repo jakildev/irreden`.)
+
+Do NOT pre-apply `fleet:task`, `fleet:queued`, `fleet:needs-plan`,
+`fleet:opus` / `fleet:sonnet`, or any other state label. State labels
+are owned by specific roles (reviewers, the human) and by the scout's
+triage flow. **Author-side filing adds zero labels** and lets the human
+stamp `human:approved` when they want it picked up; the scout ingests it
+on its next pass and stamps the rest.
+
+The body should include these standalone lines (the scout's queue-ingest
+and `fleet-claim`'s blocker gate parse them):
+
+- **Area:** e.g. `engine/render`, `engine/math`, `docs`
+- **Model:** `opus` or `sonnet`
+- **Blocked by:** `(none)` or `#NNN`
+- **Acceptance criteria** — concrete check (build passes, test X works)
+- **Context** — why this matters, what you observed
+
+The issue sits in the backlog until the **human triages and adds
+`human:approved`**. Only then does the scout ingest it.
+
+### Escalation issues (sonnet → opus, or scope-grew)
+
+When a `[sonnet]` task turns out to need Opus, or a worker hits a
+non-architectural blocker (scope grew, structural build break,
+multi-module public-API surface), file the follow-up as a single issue
+with the same body shape, prefixed with the escalation context:
+
+```
+gh issue create --repo jakildev/IrredenEngine --title "<what needs opus attention>" \
+  --body "Escalated from sonnet.
+
+**Area:** ...
+**Model:** opus
+**Blocked by:** (none)
+
+Context: ..."
+```
+
+Then comment on your PR linking the filed issue, release the claim,
+reset, and move on. The human triages and stamps `human:approved`.
+
+> Architectural blockers route differently — via the
+> `fleet:design-blocked` label on the open PR, not a fresh issue. See
+> the worker / architect role files for the design-escalation flow.
+
+---
+
+## Multi-issue stacks (epic decomposition)
+
+When work decomposes into a **stack of N issues that each depend on the
+prior** (the canonical smooth-yaw / SO(3) / rotation / streaming
+patterns), do NOT hand-file the children. Invoke the **`file-epic`**
+skill instead:
+
+```
+/file-epic <path-to-approved-plan>
+```
+
+**Why it matters.** The scout's `blocked_by` parser and `fleet-claim`'s
+`find-stackable-blockers` predicate both read a **standalone**
+`**Blocked by:** #N` line in the issue body. Prose forms buried in a
+header bullet ("Blocked on T1 + docs PR #1306") are NOT parsed — the
+child projects as Available, no `--stackable-on` claim fires, and the
+chain doesn't stack. Hand-filing reliably produces this drift.
+`file-epic` enforces the template (umbrella `fleet:epic` + one
+`fleet:task` child per phase + per-ticket plan files + a standalone
+`**Blocked by:** #<prior>` chain).
+
+**If you must hand-file a stack** (one-off, plan not yet written), each
+child MUST carry these as standalone lines, placed immediately under the
+header/epic bullet and before `## Scope`:
+
+```
+**Blocked by:** #<prior> (<one-line rationale>)
+**Model:** <opus|sonnet>
+```
+
+Rules that make the stack actually stack:
+
+- **One `#N` per `**Blocked by:**` line.** Multi-blocker forms
+  (`**Blocked by:** #1299, #1300`) do NOT stack-claim under the current
+  implementation — the scout only enriches single-blocker tasks with
+  `stackable_blocker_pr`. A multi-blocker child projects as "blocked"
+  and is skipped until at least one upstream merges and you strip the
+  satisfied ref. (Live multi-blocker resolution is planned but not
+  landed — track via the open scout/fleet-claim blocker-resolution
+  issue.)
+- **The blocker must be an issue number, not a PR number.**
+  `fleet-claim`'s blocker gate resolves `#N` via `gh issue view --json
+  state` (CLOSED = satisfied). To gate on a docs PR that has no backing
+  issue, withhold `human:approved` on the first task until that PR
+  merges, rather than writing `**Blocked by:** #<pr>`.
+
+Once filed correctly, the cascade is automatic: T1 claims plain and
+opens `claude/<T1>-*`; the scout enriches T2 with `stackable_blocker_pr`
+pointing at T1's PR; the next worker claims T2 `--stackable-on <T1-PR>`
+and branches off T1's head; and so on. The merger re-targets each
+child's base onto master as upstreams merge.


### PR DESCRIPTION
## Summary

Role docs had drifted toward heavy duplication. This extracts the proven duplications into shared directive docs that each role references — roles become orchestration over a shared library rather than parallel copies that drift apart. **Targeted dedup, not a rewrite:** every role-specific delta stays inline; no directive is dropped.

Net: role docs shrink ~450 lines (worker 815→688, author 431→360, architect 444→399, reviewers ~250→~230 each); shared content gains a single canonical home.

## New shared docs (`docs/agents/`)

| Doc | Content | Replaces inline copies in |
|---|---|---|
| **AUTHOR-PIPELINE.md** | build/run, verify-visual-output, optimize-before-commit, finalize-PR | opus-worker steps 7/9/10/11, sonnet-author steps 6/8/9/10 (several byte-identical) |
| **PLANNING-PROTOCOL.md** | the `fleet:needs-plan` flow (read thread → plan comment → save plan file → swap labels) | opus-worker step 2, opus-architect "Planning issues" |
| **TASK-FILING.md** | `gh issue create` body template + no-labels discipline **+ new "Multi-issue stacks" → `file-epic`** | architect "Filing tasks", worker "Out of scope" + escalation, author step 7 |

## Extended shared docs

- **FLEET-RUNTIME.md** — added "Startup cache read + stale-scout exit" and "End-of-iteration feedback" (the two remaining all-role ceremonies; 7 copies each collapsed).
- **REVIEWER-PROTOCOL.md** — added "Reviewer hard rules" (the near-identical block both reviewers inlined; the richer never-re-apply-verdict timeline check is now canonical).

## Gap closed (was #1312 Part A)

The architect's epic-filing section now routes multi-issue stacks through the **`file-epic`** skill and documents the standalone `**Blocked by:** #N` requirement (one ref per line, issue-number blockers only, gate docs-PR deps by withholding `human:approved`). This is the exact drift that bit #1300 / #1308–#1311 — prose-only "Blocked on T1" headers the scout/fleet-claim parsers can't read. With this, #1312 narrows to just its Part B (file-epic post-filing validation) + Part C.

## Role-specific deltas preserved inline (not extracted)

- opus-worker: step 1c semantic-conflict resolution, cross-repo (game) flow, molecule resume
- sonnet-author: escalate-on-render-subtlety, engine-only scope
- opus-architect: `fleet:design-blocked` routing, docs-first-PR flow
- opus-reviewer: "don't take Sonnet's first-pass" budget rule
- merger / smoke-worker: only their feedback + usage-limit pointers updated

## Verification

- **Losslessness:** grepped every extracted directive (linker-error caveat, `cd && ./exe` gate, `attach-screenshots`/`render-debug-loop` pair, `IR_PROFILE_` note, issue-body template, never-`--approve` rule, plan-file template) — all still reachable in a canonical home.
- **Link integrity:** scripted check that all `docs/agents/*.md#anchor` references from the 7 role docs resolve to real headings (GitHub anchor rules), plus all outbound file links from the 5 shared docs resolve. Both pass.
- **Structure:** worker step numbering 1–12 intact with the interleaved escalate step; architect internal `#filing-tasks` anchor resolves.

Docs-only; no code, no build impact. Independent of the in-flight Opus-4.8 migration branch (disjoint file sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)