### PR TITLE
fleet: per-role effort config via FLEET_EFFORT_<ROLE>

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -61,21 +61,22 @@ ROLE="${2:?usage: fleet-babysit <model> <role> [mode] [loop-interval]}"
 MODE="${3:-dry-run}"
 LOOP_INTERVAL="${4:-}"
 
-# Effort level — derived from model. Opus agents get xhigh (one notch
-# below `max`); architects, opus-workers, opus-reviewer, and merger
-# all do the hard reasoning, but `max` was burning budget faster than
-# the marginal quality justified on routine fleet iterations. Sonnet
-# agents get high (good output without burning budget on tasks where
-# diminishing returns kick in).
+# Effort level. Precedence: per-role FLEET_EFFORT_<ROLE> > global
+# FLEET_EFFORT > a model-derived default. The fleet's real per-role policy
+# is set by fleet-up (architects) and fleet-dispatcher (dispatched roles),
+# which export FLEET_EFFORT_<ROLE>; the model-derived default below only
+# fires when babysit is run by hand without those exports in the env.
+# Opus defaults to xhigh — the architects babysit launches do the heavy
+# design / render reasoning, which is where xhigh earns its budget; sonnet
+# defaults to high (diminishing returns past that on its task mix).
 case "$MODEL" in
-    opus|claude-opus*) EFFORT="xhigh" ;;
-    sonnet|claude-sonnet*) EFFORT="high" ;;
-    *) EFFORT="high" ;;
+    opus|claude-opus*) _effort_default="xhigh" ;;
+    sonnet|claude-sonnet*) _effort_default="high" ;;
+    *) _effort_default="high" ;;
 esac
-# Global override from env if set. Note: FLEET_EFFORT applies to
-# every pane in the fleet — fleet-up does not thread env per-pane.
-# To change one pane's effort, edit the case statement above.
-EFFORT="${FLEET_EFFORT:-$EFFORT}"
+_role_effort_var="FLEET_EFFORT_$(printf '%s' "$ROLE" | tr 'a-z-' 'A-Z_')"
+EFFORT="${!_role_effort_var:-${FLEET_EFFORT:-$_effort_default}}"
+unset _role_effort_var _effort_default
 
 # Architects boot with auto-memory disabled. The project-wide
 # MEMORY.md auto-injects past-session notes into every Claude Code

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -78,6 +78,15 @@ _role_effort_var="FLEET_EFFORT_$(printf '%s' "$ROLE" | tr 'a-z-' 'A-Z_')"
 EFFORT="${!_role_effort_var:-${FLEET_EFFORT:-$_effort_default}}"
 unset _role_effort_var _effort_default
 
+# Inspection hook: print the resolved effort for this <model> <role> and
+# exit, without launching a claude session. Lets an operator check what a
+# pane would get, and lets test_babysit_effort.sh cover the role→var
+# mapping + precedence. Mirrors `fleet-dispatcher --print-effort`.
+if [[ -n "${FLEET_BABYSIT_PRINT_EFFORT:-}" ]]; then
+    echo "$EFFORT"
+    exit 0
+fi
+
 # Architects boot with auto-memory disabled. The project-wide
 # MEMORY.md auto-injects past-session notes into every Claude Code
 # session — useful continuity for autonomous workers/reviewers, but

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -90,6 +90,14 @@ _env_opus_reviewer="${FLEET_CONCURRENCY_OPUS_REVIEWER:-}"
 _env_queue_manager="${FLEET_CONCURRENCY_QUEUE_MANAGER:-}"
 _env_merger="${FLEET_CONCURRENCY_MERGER:-}"
 _env_smoke_worker="${FLEET_CONCURRENCY_SMOKE_WORKER:-}"
+# Same capture-before-source guard for per-role effort (FLEET_EFFORT_<ROLE>),
+# consumed by the ROLE_EFFORT map further down. Caller env wins over conf.
+_env_effort_opus_worker="${FLEET_EFFORT_OPUS_WORKER:-}"
+_env_effort_sonnet_author="${FLEET_EFFORT_SONNET_AUTHOR:-}"
+_env_effort_sonnet_reviewer="${FLEET_EFFORT_SONNET_REVIEWER:-}"
+_env_effort_opus_reviewer="${FLEET_EFFORT_OPUS_REVIEWER:-}"
+_env_effort_merger="${FLEET_EFFORT_MERGER:-}"
+_env_effort_smoke_worker="${FLEET_EFFORT_SMOKE_WORKER:-}"
 if [[ -f "$FLEET_CONF" ]]; then
     # shellcheck disable=SC1090
     source "$FLEET_CONF"
@@ -280,15 +288,25 @@ declare -A ROLE_MODEL=(
     ["smoke-worker"]="$SONNET_MODEL"
 )
 
-# Per-role default effort level. Mirrors fleet-babysit's case stmt.
+# Per-role effort level. Override priority mirrors ROLE_CONCURRENCY:
+# caller env FLEET_EFFORT_<ROLE> > conf FLEET_EFFORT_<ROLE> > global
+# FLEET_EFFORT > built-in default. Defaults: the heavy-reasoning roles —
+# the opus-worker here, plus the architects (launched by fleet-babysit,
+# not dispatched) — run xhigh; everything else runs high. opus-reviewer
+# and merger run high (not xhigh): their reasoning is bounded by the diff
+# in front of them, so the extra budget buys little. Retune a default
+# here, or set FLEET_EFFORT_<ROLE> in ~/.fleet/fleet-up.conf.
 declare -A ROLE_EFFORT=(
-    ["sonnet-author"]="high"
-    ["opus-worker"]="xhigh"
-    ["sonnet-reviewer"]="high"
-    ["opus-reviewer"]="xhigh"
-    ["merger"]="xhigh"
-    ["smoke-worker"]="high"
+    ["sonnet-author"]="${_env_effort_sonnet_author:-${FLEET_EFFORT_SONNET_AUTHOR:-${FLEET_EFFORT:-high}}}"
+    ["opus-worker"]="${_env_effort_opus_worker:-${FLEET_EFFORT_OPUS_WORKER:-${FLEET_EFFORT:-xhigh}}}"
+    ["sonnet-reviewer"]="${_env_effort_sonnet_reviewer:-${FLEET_EFFORT_SONNET_REVIEWER:-${FLEET_EFFORT:-high}}}"
+    ["opus-reviewer"]="${_env_effort_opus_reviewer:-${FLEET_EFFORT_OPUS_REVIEWER:-${FLEET_EFFORT:-high}}}"
+    ["merger"]="${_env_effort_merger:-${FLEET_EFFORT_MERGER:-${FLEET_EFFORT:-high}}}"
+    ["smoke-worker"]="${_env_effort_smoke_worker:-${FLEET_EFFORT_SMOKE_WORKER:-${FLEET_EFFORT:-high}}}"
 )
+unset _env_effort_opus_worker _env_effort_sonnet_author \
+      _env_effort_sonnet_reviewer _env_effort_opus_reviewer \
+      _env_effort_merger _env_effort_smoke_worker
 
 # Tracks which panes have already had their cooldown logged this cycle so
 # the "in rate-limit cooldown" message fires once per pane per cooldown
@@ -1207,6 +1225,15 @@ case "${1:-}" in
             exit 2
         fi
         echo "${ROLE_CONCURRENCY[$2]:-0}"
+        exit 0
+        ;;
+    --print-effort)
+        # Print configured effort for a role. Used by tests and operators.
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-dispatcher --print-effort <role>" >&2
+            exit 2
+        fi
+        echo "${ROLE_EFFORT[$2]:-high}"
         exit 0
         ;;
     --gate-status)

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -110,6 +110,13 @@ _env_sonnet_author="${FLEET_CONCURRENCY_SONNET_AUTHOR:-}"
 _env_sonnet_reviewer="${FLEET_CONCURRENCY_SONNET_REVIEWER:-}"
 _env_opus_reviewer="${FLEET_CONCURRENCY_OPUS_REVIEWER:-}"
 _env_merger="${FLEET_CONCURRENCY_MERGER:-}"
+# Per-role effort: capture caller-env architect overrides before the conf
+# source (same precedence guard as the caps above). Dispatched-role effort
+# is resolved inside fleet-dispatcher; fleet-up only needs the architect
+# efforts here because fleet-babysit — which launches them — does not source
+# the conf itself.
+_env_effort_opus_architect="${FLEET_EFFORT_OPUS_ARCHITECT:-}"
+_env_effort_game_architect="${FLEET_EFFORT_GAME_ARCHITECT:-}"
 if [[ -f "$FLEET_CONF" ]]; then
     # shellcheck disable=SC1090
     source "$FLEET_CONF"
@@ -119,11 +126,21 @@ FLEET_CONCURRENCY_SONNET_AUTHOR="${_env_sonnet_author:-${FLEET_CONCURRENCY_SONNE
 FLEET_CONCURRENCY_SONNET_REVIEWER="${_env_sonnet_reviewer:-${FLEET_CONCURRENCY_SONNET_REVIEWER:-1}}"
 FLEET_CONCURRENCY_OPUS_REVIEWER="${_env_opus_reviewer:-${FLEET_CONCURRENCY_OPUS_REVIEWER:-1}}"
 FLEET_CONCURRENCY_MERGER="${_env_merger:-${FLEET_CONCURRENCY_MERGER:-1}}"
+# Architect effort: env > conf > global FLEET_EFFORT > built-in xhigh.
+# Exported so fleet-babysit (which launches the architect panes) inherits
+# the resolved value; it does not read the conf itself.
+FLEET_EFFORT_OPUS_ARCHITECT="${_env_effort_opus_architect:-${FLEET_EFFORT_OPUS_ARCHITECT:-${FLEET_EFFORT:-xhigh}}}"
+FLEET_EFFORT_GAME_ARCHITECT="${_env_effort_game_architect:-${FLEET_EFFORT_GAME_ARCHITECT:-${FLEET_EFFORT:-xhigh}}}"
 unset _env_opus_worker _env_sonnet_author _env_sonnet_reviewer \
-      _env_opus_reviewer _env_merger
+      _env_opus_reviewer _env_merger \
+      _env_effort_opus_architect _env_effort_game_architect
 export FLEET_CONCURRENCY_OPUS_WORKER FLEET_CONCURRENCY_SONNET_AUTHOR
 export FLEET_CONCURRENCY_SONNET_REVIEWER FLEET_CONCURRENCY_OPUS_REVIEWER
 export FLEET_CONCURRENCY_MERGER
+export FLEET_EFFORT_OPUS_ARCHITECT FLEET_EFFORT_GAME_ARCHITECT
+# Propagate a conf-set global FLEET_EFFORT to the dispatcher + babysit
+# (a bare `FLEET_EFFORT=` in the conf is otherwise a non-exported shell var).
+if [[ -n "${FLEET_EFFORT:-}" ]]; then export FLEET_EFFORT; fi
 
 if ! command -v tmux >/dev/null 2>&1; then
     echo "fleet-up: tmux not found. Install tmux (brew install tmux / apt install tmux) first." >&2
@@ -1228,12 +1245,10 @@ layout (two windows):
     top    — queue-manager  merger
     bottom — witness        terminal (\$HOME, free-form shell)
 
-effort levels:
-  opus agents (architects, opus-workers, opus-reviewer, merger) — xhigh
-  sonnet agents (sonnet-fleet-1/2, sonnet-reviewer, queue-manager) — high
-  override globally by exporting FLEET_EFFORT=<level> before fleet-up.
-  (to change one pane, edit fleet-babysit's case statement — fleet-up
-  does not thread env per-pane.)
+effort levels (per-role; override with FLEET_EFFORT_<ROLE> in env or
+~/.fleet/fleet-up.conf, or FLEET_EFFORT=<level> to force all panes):
+  xhigh — opus-architect, game-architect, opus-worker
+  high  — opus-reviewer, merger, sonnet-author, sonnet-reviewer, smoke-worker
 
 permission mode: auto (model decides when to ask vs proceed)
 

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -31,6 +31,33 @@
 # FLEET_CONCURRENCY_MERGER=1
 # FLEET_CONCURRENCY_SMOKE_WORKER=1   # concurrent cap for the smoke-only worker pane
 
+# --- Per-role effort levels -------------------------------------------------
+#
+# Reasoning effort per role: "high" or "xhigh" (xhigh ≈ one notch below the
+# model's max — deeper reasoning, more budget per iteration). Override
+# priority: env var FLEET_EFFORT_<ROLE> > this conf > global FLEET_EFFORT >
+# built-in default.
+#
+# Built-in defaults — the heavy design / render-reasoning roles run xhigh,
+# the rest run high (their work is bounded by the diff / task in front of
+# them, so xhigh buys little):
+#   opus-architect   xhigh        opus-reviewer    high
+#   game-architect   xhigh        merger           high
+#   opus-worker      xhigh        sonnet-author    high
+#                                 sonnet-reviewer  high
+#                                 smoke-worker     high
+#
+# Set FLEET_EFFORT (no role suffix) to force one level on every pane.
+
+# FLEET_EFFORT_OPUS_ARCHITECT=xhigh
+# FLEET_EFFORT_GAME_ARCHITECT=xhigh
+# FLEET_EFFORT_OPUS_WORKER=xhigh
+# FLEET_EFFORT_OPUS_REVIEWER=high
+# FLEET_EFFORT_MERGER=high
+# FLEET_EFFORT_SONNET_AUTHOR=high
+# FLEET_EFFORT_SONNET_REVIEWER=high
+# FLEET_EFFORT_SMOKE_WORKER=high
+
 # --- Usage gate (per-rate-limit-type thresholds) ----------------------------
 #
 # Soft, fleet-wide pre-emption: when any rate_limit_event observation

--- a/scripts/fleet/tests/test_babysit_effort.sh
+++ b/scripts/fleet/tests/test_babysit_effort.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Tests for fleet-babysit's per-role effort resolution.
+#
+# fleet-babysit launches the architect panes (and, for manual runs, any
+# role). Its effort resolution is the consumer side of the FLEET_EFFORT_<ROLE>
+# mechanism: a role->varname map (tr 'a-z-' 'A-Z_') + indirect expansion,
+# with precedence per-role FLEET_EFFORT_<ROLE> > global FLEET_EFFORT >
+# model-derived default. fleet-up exports FLEET_EFFORT_OPUS_ARCHITECT /
+# FLEET_EFFORT_GAME_ARCHITECT for it to read.
+#
+# Exercised through the FLEET_BABYSIT_PRINT_EFFORT=1 inspection hook, which
+# prints the resolved effort and exits before any claude launch.
+#
+# Covers:
+#   - model-derived defaults (opus -> xhigh, sonnet -> high) for manual runs
+#   - the full 1m model name still hits the opus glob
+#   - per-role FLEET_EFFORT_<ROLE> override
+#   - role->varname mapping for a hyphenated role (game-architect)
+#   - global FLEET_EFFORT fallback when no per-role value is set
+#   - per-role value beats the global FLEET_EFFORT
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+BABYSIT="$SCRIPT_DIR/fleet-babysit"
+
+if [[ ! -x "$BABYSIT" ]]; then
+    echo "test setup: fleet-babysit not found at $BABYSIT" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+# Resolve effort for <model> <role> with a clean env (no FLEET_EFFORT*).
+# Extra `KEY=VAL` pairs are exported into the subshell for override tests.
+effort_for() {
+    local model="$1" role="$2"; shift 2
+    env -u FLEET_EFFORT -u FLEET_EFFORT_OPUS_ARCHITECT -u FLEET_EFFORT_GAME_ARCHITECT \
+        -u FLEET_EFFORT_OPUS_REVIEWER -u FLEET_EFFORT_OPUS_WORKER \
+        FLEET_BABYSIT_PRINT_EFFORT=1 "$@" \
+        "$BABYSIT" "$model" "$role"
+}
+
+# --- Test 1: model-derived defaults (manual run, no env) -------------------
+echo "T1: model-derived defaults"
+assert_eq "$(effort_for opus opus-architect)"   "xhigh" "opus model -> xhigh default"
+assert_eq "$(effort_for sonnet sonnet-author)"  "high"  "sonnet model -> high default"
+# Manual run of a dispatched role keys on the model, not the dispatcher's
+# per-role policy — opus -> xhigh even for opus-reviewer (documented; the
+# real fleet launches reviewers via the dispatcher, not babysit).
+assert_eq "$(effort_for opus opus-reviewer)"    "xhigh" "manual opus opus-reviewer -> xhigh (model-derived)"
+
+# --- Test 2: full 1m model name still hits the opus glob -------------------
+echo "T2: full model name hits opus glob"
+assert_eq "$(effort_for 'claude-opus-4-8[1m]' opus-architect)" "xhigh" "claude-opus-4-8[1m] -> xhigh"
+
+# --- Test 3: per-role override ---------------------------------------------
+echo "T3: per-role FLEET_EFFORT_<ROLE> overrides the default"
+assert_eq "$(effort_for opus opus-architect FLEET_EFFORT_OPUS_ARCHITECT=high)" \
+    "high" "FLEET_EFFORT_OPUS_ARCHITECT=high lowers opus-architect"
+
+# --- Test 4: role->varname mapping for a hyphenated role -------------------
+echo "T4: tr maps game-architect -> FLEET_EFFORT_GAME_ARCHITECT"
+assert_eq "$(effort_for opus game-architect FLEET_EFFORT_GAME_ARCHITECT=high)" \
+    "high" "FLEET_EFFORT_GAME_ARCHITECT resolves for game-architect"
+
+# --- Test 5: global FLEET_EFFORT fallback ----------------------------------
+echo "T5: global FLEET_EFFORT applies when no per-role value is set"
+assert_eq "$(effort_for opus opus-architect FLEET_EFFORT=high)" \
+    "high" "global FLEET_EFFORT=high lowers opus-architect"
+
+# --- Test 6: per-role beats global -----------------------------------------
+echo "T6: per-role value wins over global FLEET_EFFORT"
+assert_eq "$(effort_for opus opus-architect FLEET_EFFORT=high FLEET_EFFORT_OPUS_ARCHITECT=xhigh)" \
+    "xhigh" "FLEET_EFFORT_OPUS_ARCHITECT beats global FLEET_EFFORT=high"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_babysit_effort.sh
+++ b/scripts/fleet/tests/test_babysit_effort.sh
@@ -51,6 +51,7 @@ effort_for() {
     local model="$1" role="$2"; shift 2
     env -u FLEET_EFFORT -u FLEET_EFFORT_OPUS_ARCHITECT -u FLEET_EFFORT_GAME_ARCHITECT \
         -u FLEET_EFFORT_OPUS_REVIEWER -u FLEET_EFFORT_OPUS_WORKER \
+        -u FLEET_EFFORT_SONNET_AUTHOR \
         FLEET_BABYSIT_PRINT_EFFORT=1 "$@" \
         "$BABYSIT" "$model" "$role"
 }

--- a/scripts/fleet/tests/test_dispatcher_effort.sh
+++ b/scripts/fleet/tests/test_dispatcher_effort.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Tests for fleet-dispatcher's per-role effort resolution.
+#
+# Covers the FLEET_EFFORT_<ROLE> override mechanism that mirrors the
+# concurrency-cap pattern:
+#   - built-in defaults (heavy roles xhigh, the rest high)
+#   - per-role env var override
+#   - per-role conf-file override
+#   - env var beats conf
+#   - global FLEET_EFFORT fallback when no per-role value is set
+#   - per-role value beats the global FLEET_EFFORT
+#
+# Exercised through `fleet-dispatcher --print-effort <role>`, the inspection
+# subcommand that prints a role's resolved effort and exits before the
+# daemon loop.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+
+if [[ ! -x "$DISPATCHER" ]]; then
+    echo "test setup: fleet-dispatcher not found at $DISPATCHER" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_CONF="$TMPROOT/fleet-up.conf"
+# Point at a guaranteed non-existent tmux session so the dispatcher never
+# touches a real fleet running on the dev machine.
+export FLEET_SESSION="fleet-test-$$"
+mkdir -p "$FLEET_STATE_DIR"
+
+# Start from a clean slate: no conf, no per-role env, no global override.
+unset FLEET_EFFORT \
+      FLEET_EFFORT_OPUS_WORKER FLEET_EFFORT_OPUS_REVIEWER FLEET_EFFORT_MERGER \
+      FLEET_EFFORT_SONNET_AUTHOR FLEET_EFFORT_SONNET_REVIEWER \
+      FLEET_EFFORT_SMOKE_WORKER 2>/dev/null || true
+
+# --- Test 1: built-in defaults ---------------------------------------------
+echo "T1: effort defaults (no conf, no env)"
+rm -f "$FLEET_CONF"
+assert_eq "$("$DISPATCHER" --print-effort opus-worker)"     "xhigh" "opus-worker defaults to xhigh"
+assert_eq "$("$DISPATCHER" --print-effort opus-reviewer)"   "high"  "opus-reviewer defaults to high"
+assert_eq "$("$DISPATCHER" --print-effort merger)"          "high"  "merger defaults to high"
+assert_eq "$("$DISPATCHER" --print-effort sonnet-author)"   "high"  "sonnet-author defaults to high"
+assert_eq "$("$DISPATCHER" --print-effort smoke-worker)"    "high"  "smoke-worker defaults to high"
+
+# --- Test 2: per-role env var override -------------------------------------
+echo "T2: env var overrides default"
+assert_eq "$(FLEET_EFFORT_OPUS_REVIEWER=xhigh "$DISPATCHER" --print-effort opus-reviewer)" \
+    "xhigh" "FLEET_EFFORT_OPUS_REVIEWER promotes opus-reviewer to xhigh"
+
+# --- Test 3: conf file override --------------------------------------------
+echo "T3: conf file overrides default"
+cat >"$FLEET_CONF" <<'CONFEOF'
+FLEET_EFFORT_MERGER=xhigh
+CONFEOF
+assert_eq "$("$DISPATCHER" --print-effort merger)"        "xhigh" "conf sets merger to xhigh"
+assert_eq "$("$DISPATCHER" --print-effort opus-reviewer)" "high"  "untouched role keeps its default"
+
+# --- Test 4: env var beats conf --------------------------------------------
+echo "T4: env var has higher priority than conf"
+cat >"$FLEET_CONF" <<'CONFEOF'
+FLEET_EFFORT_OPUS_WORKER=high
+CONFEOF
+assert_eq "$(FLEET_EFFORT_OPUS_WORKER=xhigh "$DISPATCHER" --print-effort opus-worker)" \
+    "xhigh" "env FLEET_EFFORT_OPUS_WORKER beats conf value"
+rm -f "$FLEET_CONF"
+
+# --- Test 5: global FLEET_EFFORT fallback ----------------------------------
+echo "T5: global FLEET_EFFORT applies when no per-role value is set"
+assert_eq "$(FLEET_EFFORT=xhigh "$DISPATCHER" --print-effort opus-reviewer)" \
+    "xhigh" "global FLEET_EFFORT lifts opus-reviewer"
+assert_eq "$(FLEET_EFFORT=high "$DISPATCHER" --print-effort opus-worker)" \
+    "high"  "global FLEET_EFFORT lowers opus-worker"
+
+# --- Test 6: per-role beats global -----------------------------------------
+echo "T6: per-role value wins over global FLEET_EFFORT"
+assert_eq "$(FLEET_EFFORT=high FLEET_EFFORT_OPUS_WORKER=xhigh "$DISPATCHER" --print-effort opus-worker)" \
+    "xhigh" "FLEET_EFFORT_OPUS_WORKER beats global FLEET_EFFORT=high"
+
+# --- Test 7: usage error on missing role arg -------------------------------
+echo "T7: --print-effort with no role → usage error"
+if "$DISPATCHER" --print-effort >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: missing role arg should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: missing role arg exits non-zero"
+fi
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- **Per-role effort is now configurable**, mirroring the existing `FLEET_CONCURRENCY_<ROLE>` mechanism. Override priority: caller env `FLEET_EFFORT_<ROLE>` > `~/.fleet/fleet-up.conf` > global `FLEET_EFFORT` > built-in default. Previously effort was hardcoded in two disconnected places (`fleet-dispatcher`'s `ROLE_EFFORT` map for dispatched roles, `fleet-babysit`'s model-derived case stmt for architects) with only a blunt all-panes `FLEET_EFFORT` override.
- **New defaults** — the heavy design / render-reasoning roles run `xhigh`, the rest `high`:
  - `xhigh`: opus-architect, game-architect, **opus-worker**
  - `high`: opus-reviewer, merger, sonnet-author, sonnet-reviewer, smoke-worker
  - This drops **opus-reviewer** and **merger** from `xhigh` → `high` (their reasoning is bounded by the diff in front of them, so the extra budget bought little). opus-worker stays `xhigh`; architects stay `xhigh`.
- `fleet-dispatcher` resolves `ROLE_EFFORT` from env/conf/global/default (capture-before-conf-source, like `ROLE_CONCURRENCY`) and gains a `--print-effort <role>` inspection subcommand.
- `fleet-up` resolves + exports the architect efforts (so `fleet-babysit`, which doesn't source the conf, inherits them) and propagates a conf-set global `FLEET_EFFORT`.
- `fleet-babysit` reads `FLEET_EFFORT_<ROLE>` → global `FLEET_EFFORT` → model-derived default (the last only for standalone/manual runs).
- Documents the knobs in `fleet-up.conf.sample` and the `fleet-up` startup banner.

Follow-up idea (not in this PR): effort could later be driven dynamically per-task (e.g. a `fleet:effort-xhigh` issue label the dispatcher reads), instead of per-role static defaults.

## Test plan
- [x] New `scripts/fleet/tests/test_dispatcher_effort.sh` — 13 assertions covering defaults, per-role env override, conf override, env-beats-conf, global `FLEET_EFFORT` fallback, per-role-beats-global, and the usage error. All pass.
- [x] `scripts/fleet/tests/test_dispatcher_concurrency_cap.sh` still green (22 assertions) — the effort capture sits adjacent to the concurrency block.
- [x] `bash -n` clean on fleet-up, fleet-dispatcher, fleet-babysit, and the new test.
- [x] `fleet-dispatcher --print-effort` returns xhigh for opus-worker, high for opus-reviewer/merger/sonnet-author/sonnet-reviewer/smoke-worker; model resolution (`claude-opus-4-8[1m]` / `sonnet[1m]`) from #1313 still resolves alongside.
- [x] `fleet-babysit` architect path resolves xhigh by default, honors `FLEET_EFFORT_<ROLE>` and global `FLEET_EFFORT` overrides (simulated).
- [ ] Confidence check on next `fleet-up`: dispatched panes launch `claude --effort high` for reviewers/merger, `xhigh` for opus-worker; architect panes stay `xhigh`.

## Notes for reviewer
- Builds on #1313 (merged): the model wiring (`OPUS_MODEL`/`SONNET_MODEL`, `claude-opus-4-8[1m]` / `sonnet[1m]`) is the base; this PR only adds the parallel effort axis.
- Defaults follow the discussed policy (architects + opus-worker xhigh, others high). Easy to retune per-role via `~/.fleet/fleet-up.conf` without a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)