### PR TITLE
render: smooth camera Z-yaw — T1 per-axis trixel canvas infra (#1308)

### DIFF
--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -47,8 +47,9 @@ constexpr float kHalfPi = 1.57079632679489661923f;
 constexpr float kTwoPi = 6.28318530717958647692f;
 /// Quarter pi (π/4). Cardinal-yaw residual bound, diagonal transforms.
 constexpr float kQuarterPi = 0.78539816339744830961f;
-/// √2. Worst-case footprint growth of a stretched / rotated iso face at the
-/// residual-yaw bound ±π/4 (see perAxisTrixelCanvasWorstCaseSize).
+/// √2. Horizontal in-plane growth factor of the Y/X-face deformation at the
+/// residual-yaw bound ±π/4. The full stretched column is (√2, −1), length √3;
+/// √2 is its horizontal component (see perAxisTrixelCanvasWorstCaseSize).
 constexpr float kSqrt2 = 1.41421356237309504880f;
 
 /// Face-index constants for the three visible iso faces. CPU mirror of the
@@ -1270,8 +1271,13 @@ gameResolutionToSize2DIso(const vec2 gameResolution, const vec2 scaleFactor = ve
 /// only paid while the camera rotates.
 ///
 /// Per dimension the size is the larger of two bounds:
-///   • Footprint — the stretched / rotated axis grows by at most √2 at residual
-///     ±π/4 (faceDeformationMatrix's stretched column has length √2 there).
+///   • Footprint — derived from the per-face deformation matrix D_φ at the
+///     residual-yaw bound ±π/4. Horizontal: the in-plane stretch gives √2·W
+///     (D_φ row-0 column magnitude is √2 there). Vertical: the Y/X-face row-1
+///     `(c−s−1, 1)` at ±π/4 gives `(−1, 1)`, so the worst-case AABB height is
+///     |−1|·W + 1·H = W + H, which exceeds √2·H for any W > (√2−1)·H. The
+///     full stretched column is (√2, −1) with length √3, not √2; √2 is only its
+///     horizontal component.
 ///   • Density — a face going edge-on would otherwise need unbounded trixels
 ///     along the skinny axis; the minimum on-screen trixel size floors it. The
 ///     cardinal iso canvas packs 2 framebuffer px per trixel horizontally and 1
@@ -1284,12 +1290,14 @@ inline ivec2 perAxisTrixelCanvasWorstCaseSize(
     const ivec2 cardinalExtent, const float minOnScreenTrixelPx = 1.0f
 ) {
     const float floorPx = max(minOnScreenTrixelPx, 1.0f);
+    const float W = static_cast<float>(cardinalExtent.x);
+    const float H = static_cast<float>(cardinalExtent.y);
+    // Horizontal: √2 in-plane stretch vs. 2px/trixel density floor.
     const float scaleX = max(kSqrt2, 2.0f / floorPx);
-    const float scaleY = max(kSqrt2, 1.0f / floorPx);
-    return ivec2{
-        static_cast<int>(ceil(static_cast<float>(cardinalExtent.x) * scaleX)),
-        static_cast<int>(ceil(static_cast<float>(cardinalExtent.y) * scaleY))
-    };
+    // Vertical: Y/X-face row-1 shear at ±π/4 gives AABB height W + H, which
+    // exceeds the density floor H/floorPx (≤ H ≤ W + H) for any W ≥ 0.
+    const float boundsY = max(W + H, H / floorPx);
+    return ivec2{static_cast<int>(ceil(W * scaleX)), static_cast<int>(ceil(boundsY))};
 }
 
 /// Returns the screen-pixel size of one iso triangle at the given zoom and

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -47,6 +47,9 @@ constexpr float kHalfPi = 1.57079632679489661923f;
 constexpr float kTwoPi = 6.28318530717958647692f;
 /// Quarter pi (π/4). Cardinal-yaw residual bound, diagonal transforms.
 constexpr float kQuarterPi = 0.78539816339744830961f;
+/// √2. Worst-case footprint growth of a stretched / rotated iso face at the
+/// residual-yaw bound ±π/4 (see perAxisTrixelCanvasWorstCaseSize).
+constexpr float kSqrt2 = 1.41421356237309504880f;
 
 /// Face-index constants for the three visible iso faces. CPU mirror of the
 /// `kXFace`/`kYFace`/`kZFace` integer constants in `shaders/ir_iso_common.glsl`
@@ -1257,6 +1260,36 @@ constexpr uvec2 gameResolutionToSize2DIso(const uvec2 gameResolution, const uvec
 constexpr vec2
 gameResolutionToSize2DIso(const vec2 gameResolution, const vec2 scaleFactor = vec2(1.0f)) {
     return gameResolution / vec2(2, 1) / scaleFactor;
+}
+
+/// Worst-case texel dimensions for one per-axis trixel canvas used by the
+/// smooth camera Z-yaw path (#1308;
+/// docs/design/per-axis-trixel-canvas-rotation.md §"Bounded textures + minimum
+/// on-screen trixel size"). The three axis canvases are allocated once at this
+/// size and reused — never reallocated per frame — so the cost is bounded and
+/// only paid while the camera rotates.
+///
+/// Per dimension the size is the larger of two bounds:
+///   • Footprint — the stretched / rotated axis grows by at most √2 at residual
+///     ±π/4 (faceDeformationMatrix's stretched column has length √2 there).
+///   • Density — a face going edge-on would otherwise need unbounded trixels
+///     along the skinny axis; the minimum on-screen trixel size floors it. The
+///     cardinal iso canvas packs 2 framebuffer px per trixel horizontally and 1
+///     vertically (see gameResolutionToSize2DIso), so flooring at
+///     @p minOnScreenTrixelPx framebuffer px caps extra subdivision at
+///     2 / floor horizontally and 1 / floor vertically over the cardinal texel
+///     count. Zoom scales trixels at TRIXEL_TO_FRAMEBUFFER (not by resizing the
+///     canvas), so it does not enter this bound.
+inline ivec2 perAxisTrixelCanvasWorstCaseSize(
+    const ivec2 cardinalExtent, const float minOnScreenTrixelPx = 1.0f
+) {
+    const float floorPx = max(minOnScreenTrixelPx, 1.0f);
+    const float scaleX = max(kSqrt2, 2.0f / floorPx);
+    const float scaleY = max(kSqrt2, 1.0f / floorPx);
+    return ivec2{
+        static_cast<int>(ceil(static_cast<float>(cardinalExtent.x) * scaleX)),
+        static_cast<int>(ceil(static_cast<float>(cardinalExtent.y) * scaleY))
+    };
 }
 
 /// Returns the screen-pixel size of one iso triangle at the given zoom and

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -8,7 +8,18 @@ the ECS surface.
 ## Key components
 
 - `C_TriangleCanvasTextures` — owns 3 GPU textures (color / distance /
-  entity-id). **Created in ctor, destroyed in `onDestroy()`.**
+  entity-id). **Created in ctor, destroyed in `onDestroy()`.** The
+  color/distance/entity-id format triple is centralized in
+  `detail::makeCanvas*Texture` factories in its header so other canvas
+  components can't drift from it.
+- `C_PerAxisTrixelCanvases` — three per-axis (X/Y/Z) trixel texture sets
+  for smooth camera Z-yaw (#1308; `docs/design/per-axis-trixel-canvas-rotation.md`).
+  Same GPU-RAII pattern as `C_TriangleCanvasTextures` but allocated
+  **lazily** — only on the main world canvas while the camera sits at a
+  non-cardinal residual yaw, freed at the cardinal (byte-identical fast
+  path). Lifecycle driven by `IRPrefab::PerAxisCanvas::syncAllocationToCameraYaw()`
+  from `VOXEL_TO_TRIXEL_STAGE_1::beginTick`. T1 stands up the storage only —
+  no voxel faces route here yet (T2 / #1309).
 - `C_TrixelCanvasRenderBehavior` — toggles: use camera pan/zoom, run
   subdivisions, hover detection, pixel offset, etc.
 - `C_TrixelFramebuffer` — wraps a `Framebuffer` (color + depth). Also

--- a/engine/prefabs/irreden/render/components/component_per_axis_trixel_canvases.hpp
+++ b/engine/prefabs/irreden/render/components/component_per_axis_trixel_canvases.hpp
@@ -1,0 +1,102 @@
+#ifndef COMPONENT_PER_AXIS_TRIXEL_CANVASES_H
+#define COMPONENT_PER_AXIS_TRIXEL_CANVASES_H
+
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_render.hpp>
+
+#include <irreden/render/texture.hpp>
+#include <irreden/render/components/component_triangle_canvas_textures.hpp>
+
+#include <array>
+#include <utility>
+
+using namespace IRMath;
+using namespace IRRender;
+
+namespace IRComponents {
+
+// Three per-axis trixel canvases (one per face axis: X / Y / Z) that back the
+// smooth camera Z-yaw path
+// (#1308; docs/design/per-axis-trixel-canvas-rotation.md). Splitting the
+// voxel→trixel raster into one canvas per visible face axis lets each canvas
+// carry a single uniform deformation, so each tiles gap-free even as the camera
+// yaw moves between cardinals; the three are unified by depth at the framebuffer
+// (T3 / #1310).
+//
+// Lifecycle (T1): unlike C_TriangleCanvasTextures (which allocates its GPU
+// textures in its constructor), this component allocates LAZILY — only while the
+// camera sits at a non-cardinal residual yaw. At residualYaw == 0 the textures
+// are released and the renderer falls back to the single main canvas (the
+// byte-identical fast path), so a static / cardinal scene pays zero extra GPU
+// memory. Allocation is driven once per frame by
+// IRPrefab::PerAxisCanvas::syncAllocationToCameraYaw().
+//
+// T1 stands up the storage + allocation lifecycle only; no voxel faces route
+// here yet (Stage-1 routing is T2 / #1309), so allocating or releasing these
+// textures never changes the rendered output.
+//
+// This is the GPU-resource-RAII component pattern (engine/prefabs/CLAUDE.md
+// §"Documented exceptions") — the component owns the textures and frees them in
+// onDestroy(); the only twist is that allocation is deferred to the lifecycle
+// rather than the constructor (the gate needs the per-frame camera yaw).
+struct C_PerAxisTrixelCanvases {
+    static constexpr int kAxisCount = 3; // indexed by face axis: 0=X, 1=Y, 2=Z
+
+    // One color / distance / entity-id texture set per face axis. Mirrors the
+    // C_TriangleCanvasTextures texture layout so the existing trixel machinery
+    // (image binds, atomicMin distance writes, clears) applies per axis unchanged.
+    struct AxisTextures {
+        std::pair<ResourceId, Texture2D *> colors_{0, nullptr};
+        std::pair<ResourceId, Texture2D *> distances_{0, nullptr};
+        std::pair<ResourceId, Texture2D *> entityIds_{0, nullptr};
+    };
+
+    ivec2 size_{0, 0}; // worst-case texel size shared by all axes; (0,0) while unallocated
+    std::array<AxisTextures, kAxisCount> axes_{};
+
+    // Allocation state is the texture handles themselves — no separate bool to
+    // drift out of sync (cf. the no-dirty-flags rule in .claude/rules/cpp-ecs.md).
+    bool isAllocated() const {
+        return axes_[0].colors_.second != nullptr;
+    }
+
+    // Allocate all three axis texture sets at @p size. No-op if already
+    // allocated. Called at rotation start by the lifecycle.
+    void allocate(ivec2 size) {
+        if (isAllocated()) {
+            return;
+        }
+        size_ = size;
+        // Reuse the canonical canvas-texture factories so the per-axis textures
+        // stay format-identical to the single canvas (detail:: in
+        // component_triangle_canvas_textures.hpp).
+        for (AxisTextures &axis : axes_) {
+            axis.colors_ = detail::makeCanvasColorTexture(size);
+            axis.distances_ = detail::makeCanvasDistanceTexture(size);
+            axis.entityIds_ = detail::makeCanvasEntityIdTexture(size);
+        }
+    }
+
+    // Release all three axis texture sets and reset to the unallocated state.
+    // No-op if not allocated. Called at rotation stop by the lifecycle.
+    void release() {
+        if (!isAllocated()) {
+            return;
+        }
+        for (AxisTextures &axis : axes_) {
+            IRRender::destroyResource<Texture2D>(axis.colors_.first);
+            IRRender::destroyResource<Texture2D>(axis.distances_.first);
+            IRRender::destroyResource<Texture2D>(axis.entityIds_.first);
+            axis = AxisTextures{};
+        }
+        size_ = ivec2{0, 0};
+    }
+
+    void onDestroy() {
+        release();
+    }
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_PER_AXIS_TRIXEL_CANVASES_H */

--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
@@ -11,6 +11,47 @@ using namespace IRRender;
 
 namespace IRComponents {
 
+// Factories for the trixel-canvas texture triple (color / distance / entity-id).
+// Centralized here so C_TriangleCanvasTextures and C_PerAxisTrixelCanvases
+// (smooth camera Z-yaw, #1308) cannot drift on format / wrap / filter — a
+// silent mismatch between the two would corrupt the per-axis distance composite.
+namespace detail {
+
+inline std::pair<ResourceId, Texture2D *> makeCanvasColorTexture(ivec2 size) {
+    return IRRender::createResource<IRRender::Texture2D>(
+        TextureKind::TEXTURE_2D,
+        size.x,
+        size.y,
+        TextureFormat::RGBA8,
+        TextureWrap::REPEAT,
+        TextureFilter::NEAREST
+    );
+}
+
+inline std::pair<ResourceId, Texture2D *> makeCanvasDistanceTexture(ivec2 size) {
+    return IRRender::createResource<IRRender::Texture2D>(
+        TextureKind::TEXTURE_2D,
+        size.x,
+        size.y,
+        TextureFormat::R32I,
+        TextureWrap::REPEAT,
+        TextureFilter::NEAREST
+    );
+}
+
+inline std::pair<ResourceId, Texture2D *> makeCanvasEntityIdTexture(ivec2 size) {
+    return IRRender::createResource<IRRender::Texture2D>(
+        TextureKind::TEXTURE_2D,
+        size.x,
+        size.y,
+        TextureFormat::RG32UI,
+        TextureWrap::CLAMP_TO_EDGE,
+        TextureFilter::NEAREST
+    );
+}
+
+} // namespace detail
+
 struct C_TriangleCanvasTextures {
     ivec2 size_;
     std::pair<ResourceId, Texture2D *> textureTriangleColors_;
@@ -19,30 +60,9 @@ struct C_TriangleCanvasTextures {
 
     C_TriangleCanvasTextures(ivec2 size)
         : size_{size}
-        , textureTriangleColors_{IRRender::createResource<IRRender::Texture2D>(
-              TextureKind::TEXTURE_2D,
-              size.x,
-              size.y,
-              TextureFormat::RGBA8,
-              TextureWrap::REPEAT,
-              TextureFilter::NEAREST
-          )}
-        , textureTriangleDistances_{IRRender::createResource<IRRender::Texture2D>(
-              TextureKind::TEXTURE_2D,
-              size.x,
-              size.y,
-              TextureFormat::R32I,
-              TextureWrap::REPEAT,
-              TextureFilter::NEAREST
-          )}
-        , textureTriangleEntityIds_{IRRender::createResource<IRRender::Texture2D>(
-              TextureKind::TEXTURE_2D,
-              size.x,
-              size.y,
-              TextureFormat::RG32UI,
-              TextureWrap::CLAMP_TO_EDGE,
-              TextureFilter::NEAREST
-          )} {}
+        , textureTriangleColors_{detail::makeCanvasColorTexture(size)}
+        , textureTriangleDistances_{detail::makeCanvasDistanceTexture(size)}
+        , textureTriangleEntityIds_{detail::makeCanvasEntityIdTexture(size)} {}
 
     C_TriangleCanvasTextures() {}
 
@@ -76,89 +96,83 @@ struct C_TriangleCanvasTextures {
     }
 
     void clear() const {
-        textureTriangleColors_.second->clear(
-            PixelDataFormat::RGBA,
-            PixelDataType::UNSIGNED_BYTE,
-            &u8vec4(0, 0, 0, 0)[0]
+        textureTriangleColors_.second
+            ->clear(PixelDataFormat::RGBA, PixelDataType::UNSIGNED_BYTE, &u8vec4(0, 0, 0, 0)[0]);
+        textureTriangleDistances_.second->clear(
+            PixelDataFormat::RED_INTEGER,
+            PixelDataType::INT32,
+            &ivec1(IRConstants::kTrixelDistanceMaxDistance)[0]
         );
-        textureTriangleDistances_.second
-            ->clear(
-                PixelDataFormat::RED_INTEGER,
-                PixelDataType::INT32,
-                &ivec1(IRConstants::kTrixelDistanceMaxDistance)[0]
-            );
         uvec2 zero{0u, 0u};
         textureTriangleEntityIds_.second
             ->clear(PixelDataFormat::RG_INTEGER, PixelDataType::UINT32, &zero);
     }
 
     void clearWithColor(const Color &color) const {
-        textureTriangleColors_.second->clear(
-            PixelDataFormat::RGBA,
-            PixelDataType::UNSIGNED_BYTE,
-            &color
-        );
+        textureTriangleColors_.second
+            ->clear(PixelDataFormat::RGBA, PixelDataType::UNSIGNED_BYTE, &color);
         clearDistanceTexture();
     }
 
     void clearWithColorData(ivec2 size, const std::vector<Color> &colorData) const {
-        textureTriangleColors_.second
-            ->subImage2D(
-                0,
-                0,
-                size.x,
-                size.y,
-                PixelDataFormat::RGBA,
-                PixelDataType::UNSIGNED_BYTE,
-                colorData.data()
-            );
+        textureTriangleColors_.second->subImage2D(
+            0,
+            0,
+            size.x,
+            size.y,
+            PixelDataFormat::RGBA,
+            PixelDataType::UNSIGNED_BYTE,
+            colorData.data()
+        );
         clearDistanceTexture();
     }
 
     void setTrixel(ivec2 index, Color color, int distance = 0) {
-        textureTriangleColors_.second
-            ->subImage2D(
-                index.x,
-                index.y,
-                1,
-                1,
-                PixelDataFormat::RGBA,
-                PixelDataType::UNSIGNED_BYTE,
-                &color
-            );
-        textureTriangleDistances_.second
-            ->subImage2D(
-                index.x,
-                index.y,
-                1,
-                1,
-                PixelDataFormat::RED_INTEGER,
-                PixelDataType::INT32,
-                &distance
-            );
+        textureTriangleColors_.second->subImage2D(
+            index.x,
+            index.y,
+            1,
+            1,
+            PixelDataFormat::RGBA,
+            PixelDataType::UNSIGNED_BYTE,
+            &color
+        );
+        textureTriangleDistances_.second->subImage2D(
+            index.x,
+            index.y,
+            1,
+            1,
+            PixelDataFormat::RED_INTEGER,
+            PixelDataType::INT32,
+            &distance
+        );
     }
 
     IREntity::EntityId readEntityIdAt(ivec2 trixelPos) const {
-        if (trixelPos.x < 0 || trixelPos.x >= size_.x ||
-            trixelPos.y < 0 || trixelPos.y >= size_.y) {
+        if (trixelPos.x < 0 || trixelPos.x >= size_.x || trixelPos.y < 0 ||
+            trixelPos.y >= size_.y) {
             return IREntity::kNullEntity;
         }
         uvec2 packed{0u, 0u};
         textureTriangleEntityIds_.second->getSubImage2D(
-            trixelPos.x, trixelPos.y, 1, 1,
-            PixelDataFormat::RG_INTEGER, PixelDataType::UINT32, &packed
+            trixelPos.x,
+            trixelPos.y,
+            1,
+            1,
+            PixelDataFormat::RG_INTEGER,
+            PixelDataType::UINT32,
+            &packed
         );
         return static_cast<IREntity::EntityId>(packed.x) |
                (static_cast<IREntity::EntityId>(packed.y) << 32);
     }
 
     void clearDistances() const {
-        textureTriangleDistances_.second
-            ->clear(
-                PixelDataFormat::RED_INTEGER,
-                PixelDataType::INT32,
-                &ivec1(IRConstants::kTrixelDistanceMaxDistance)[0]
-            );
+        textureTriangleDistances_.second->clear(
+            PixelDataFormat::RED_INTEGER,
+            PixelDataType::INT32,
+            &ivec1(IRConstants::kTrixelDistanceMaxDistance)[0]
+        );
     }
 
     void saveAsPNG() {}
@@ -178,12 +192,11 @@ struct C_TriangleCanvasTextures {
     // on call-sites (e.g. entity_trixel_canvas.hpp) that invoke clearWithColor()
     // or clearWithColorData() without a subsequent clearDistances().
     void clearDistanceTexture() const {
-        textureTriangleDistances_.second
-            ->clear(
-                PixelDataFormat::RED_INTEGER,
-                PixelDataType::INT32,
-                &ivec1(IRConstants::kTrixelDistanceMaxDistance - 1)[0]
-            );
+        textureTriangleDistances_.second->clear(
+            PixelDataFormat::RED_INTEGER,
+            PixelDataType::INT32,
+            &ivec1(IRConstants::kTrixelDistanceMaxDistance - 1)[0]
+        );
     }
 };
 

--- a/engine/prefabs/irreden/render/per_axis_canvas.hpp
+++ b/engine/prefabs/irreden/render/per_axis_canvas.hpp
@@ -1,0 +1,76 @@
+#ifndef IR_PREFAB_PER_AXIS_CANVAS_H
+#define IR_PREFAB_PER_AXIS_CANVAS_H
+
+// Driver-side lifecycle for the main world canvas's per-axis trixel canvases
+// (smooth camera Z-yaw, #1308; docs/design/per-axis-trixel-canvas-rotation.md).
+// Cross-entity orchestration — look up the main canvas, read the camera yaw,
+// allocate/release the GPU textures — lives here in a prefab-scoped namespace
+// rather than on the component (engine/prefabs/CLAUDE.md Pattern B), so the
+// C_PerAxisTrixelCanvases layout stays trivial and archetype-iteration friendly.
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_render.hpp>
+
+#include <irreden/render/camera.hpp>
+#include <irreden/render/components/component_per_axis_trixel_canvases.hpp>
+#include <irreden/render/components/component_triangle_canvas_textures.hpp>
+
+namespace IRPrefab::PerAxisCanvas {
+
+// Minimum on-screen trixel size (framebuffer px) bounding the skinny-axis
+// texture density (see IRMath::perAxisTrixelCanvasWorstCaseSize). ≈1 px is the
+// starting point from the design doc's open decisions; tune against seam-free
+// coverage vs texture size once Stage-1 routing (T2) and the framebuffer passes
+// (T3) land.
+inline constexpr float kMinOnScreenTrixelSizePx = 1.0f;
+
+// Residual-yaw deadband for the allocation gate. |residualYaw| at or below this
+// counts as "cardinal" (not rotating): the per-axis textures stay released and
+// the renderer stays on the byte-identical single-canvas fast path. A small
+// deadband avoids allocate/release churn from float noise right at a cardinal.
+inline constexpr float kResidualYawDeadband = 1e-4f;
+
+// Allocate the main canvas's per-axis trixel textures while the camera sits at
+// a non-cardinal residual yaw, and release them at a cardinal. Idempotent —
+// safe to call every frame; it only allocates / frees on the rotation-start /
+// rotation-stop transitions. No-op when the main canvas has no
+// C_PerAxisTrixelCanvases (e.g. before the renderer is wired). Called once per
+// frame from VOXEL_TO_TRIXEL_STAGE_1::beginTick.
+inline void syncAllocationToCameraYaw() {
+    const IREntity::EntityId mainCanvas = IRRender::getCanvas("main");
+    if (mainCanvas == IREntity::kNullEntity) {
+        return;
+    }
+    auto perAxis =
+        IREntity::getComponentOptional<IRComponents::C_PerAxisTrixelCanvases>(mainCanvas);
+    if (!perAxis.has_value()) {
+        return;
+    }
+    IRComponents::C_PerAxisTrixelCanvases &axes = *perAxis.value();
+
+    const float residualYaw =
+        IRPrefab::Camera::computeYawSplit(IRPrefab::Camera::getYaw()).second;
+    const bool rotating = IRMath::abs(residualYaw) > kResidualYawDeadband;
+
+    if (rotating == axes.isAllocated()) {
+        return; // already in the desired allocation state
+    }
+    if (rotating) {
+        auto cardinal =
+            IREntity::getComponentOptional<IRComponents::C_TriangleCanvasTextures>(mainCanvas);
+        if (!cardinal.has_value()) {
+            return;
+        }
+        axes.allocate(IRMath::perAxisTrixelCanvasWorstCaseSize(
+            (*cardinal.value()).size_,
+            kMinOnScreenTrixelSizePx
+        ));
+    } else {
+        axes.release();
+    }
+}
+
+} // namespace IRPrefab::PerAxisCanvas
+
+#endif /* IR_PREFAB_PER_AXIS_CANVAS_H */

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -20,6 +20,7 @@
 #include <irreden/render/cull_viewport_state.hpp>
 #include <irreden/render/sun_shadow_constants.hpp>
 #include <irreden/render/camera.hpp>
+#include <irreden/render/per_axis_canvas.hpp>
 
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/gpu_stage_timing_observer.hpp>
@@ -338,8 +339,11 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // runs per entity.
         const float sweepDistance = sweepDistance_;
 
-        const IsoBounds2D chunkVp =
-            IRMath::shadowFeederIsoBounds(cull.isoViewport(kCullChunkMargin), sunDir_, sweepDistance);
+        const IsoBounds2D chunkVp = IRMath::shadowFeederIsoBounds(
+            cull.isoViewport(kCullChunkMargin),
+            sunDir_,
+            sweepDistance
+        );
         const CardinalIndex chunkCardinal = IRMath::rasterYawCardinalIndex(frameData_.rasterYaw_);
         const auto &uploadMask = buildChunkVisibilityMask(voxelPool, chunkVp, chunkCardinal);
         chunkVisBuf_->subData(0, uploadMask.size() * sizeof(std::uint32_t), uploadMask.data());
@@ -464,6 +468,13 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         if (background.has_value() && backgroundTextures.has_value()) {
             (*background.value()).clearCanvasWithBackground(*backgroundTextures.value());
         }
+
+        // Allocate / release the main canvas's per-axis trixel canvases for
+        // smooth camera Z-yaw (#1308). Idempotent and once-per-frame; only
+        // transitions on rotation start/stop. No faces route here in T1, so this
+        // never alters the rendered output — it just stands up the storage that
+        // T2 (#1309) routing will write into.
+        IRPrefab::PerAxisCanvas::syncAllocationToCameraYaw();
     }
 
     static SystemId create() {

--- a/engine/render/src/render_manager.cpp
+++ b/engine/render/src/render_manager.cpp
@@ -13,6 +13,7 @@
 #include <irreden/render/components/component_texture_scroll.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
+#include <irreden/render/components/component_per_axis_trixel_canvases.hpp>
 #include <irreden/input/systems/system_input_key_mouse.hpp>
 
 #include <irreden/common/components/component_position_2d_iso.hpp>
@@ -162,6 +163,16 @@ RenderManager::RenderManager(
     );
 
     m_activeCanvas = m_mainCanvas;
+
+    // The main world canvas owns the three per-axis trixel canvases used by the
+    // smooth camera Z-yaw path (#1308;
+    // docs/design/per-axis-trixel-canvas-rotation.md). Their GPU textures are
+    // allocated lazily — only while the camera sits at a non-cardinal residual
+    // yaw — by IRPrefab::PerAxisCanvas::syncAllocationToCameraYaw(), so a static
+    // / cardinal scene pays nothing (the byte-identical fast path). Only the
+    // main GRID canvas carries this: detached canvases rotate via full SO(3)
+    // (PROPAGATE_CANVAS_ROTATION), a separate mechanism.
+    IREntity::setComponent(m_mainCanvas, C_PerAxisTrixelCanvases{});
 
     initRenderingResources();
     initRenderingSystems();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(IrredenEngineTest
   math/ir_math_yaw_deformation_test.cpp
   math/sdf_test.cpp
   render/camera_yaw_test.cpp
+  render/per_axis_canvas_size_test.cpp
   render/frame_data_sun_layout_test.cpp
   render/per_canvas_light_scope_test.cpp
   render/picking_face_normal_test.cpp

--- a/test/render/per_axis_canvas_size_test.cpp
+++ b/test/render/per_axis_canvas_size_test.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_math.hpp>
+
+// Contract tests for IRMath::perAxisTrixelCanvasWorstCaseSize, the bounded
+// worst-case allocation size for the smooth-camera-Z-yaw per-axis trixel
+// canvases (#1308; docs/design/per-axis-trixel-canvas-rotation.md
+// §"Bounded textures + minimum on-screen trixel size").
+
+namespace {
+
+using IRMath::ivec2;
+using IRMath::kSqrt2;
+using IRMath::perAxisTrixelCanvasWorstCaseSize;
+
+// Helper: ceil(scale * extent) the same way the implementation does.
+int ceilScale(int extent, float scale) {
+    return static_cast<int>(IRMath::ceil(static_cast<float>(extent) * scale));
+}
+
+// At the default 1px floor the horizontal axis is bounded by the density term
+// (2× — the iso canvas packs 2 framebuffer px per trixel horizontally) and the
+// vertical axis by the √2 footprint term (1 px per trixel vertically ⇒ no extra
+// vertical subdivision).
+TEST(PerAxisCanvasSize, DefaultFloorMatchesBoundsExactly) {
+    const ivec2 size = perAxisTrixelCanvasWorstCaseSize(ivec2{100, 80}, 1.0f);
+    EXPECT_EQ(size.x, ceilScale(100, 2.0f));    // density-bound horizontally
+    EXPECT_EQ(size.y, ceilScale(80, kSqrt2));   // footprint-bound vertically
+}
+
+// The √2 footprint growth is always a lower bound per dimension — the
+// stretched / rotated axis needs at least this many texels at residual ±π/4.
+TEST(PerAxisCanvasSize, NeverBelowSqrt2Footprint) {
+    const ivec2 extent{321, 217};
+    const ivec2 size = perAxisTrixelCanvasWorstCaseSize(extent, 1.0f);
+    EXPECT_GE(size.x, ceilScale(extent.x, kSqrt2));
+    EXPECT_GE(size.y, ceilScale(extent.y, kSqrt2));
+}
+
+// Bounded above: no unbounded growth as a face goes edge-on. The min-on-screen
+// trixel-size floor caps the skinny axis at 2× the cardinal extent horizontally
+// and √2× vertically — never more.
+TEST(PerAxisCanvasSize, BoundedAboveByTwoTimesCardinal) {
+    const ivec2 extent{640, 360};
+    const ivec2 size = perAxisTrixelCanvasWorstCaseSize(extent, 1.0f);
+    EXPECT_LE(size.x, ceilScale(extent.x, 2.0f));
+    EXPECT_LE(size.y, ceilScale(extent.y, kSqrt2));
+    // And never smaller than the cardinal canvas it must be able to represent.
+    EXPECT_GE(size.x, extent.x);
+    EXPECT_GE(size.y, extent.y);
+}
+
+// A coarser minimum trixel size needs fewer texels: the horizontal density
+// term shrinks while the √2 footprint floor still holds.
+TEST(PerAxisCanvasSize, CoarserFloorShrinksTowardFootprint) {
+    const ivec2 extent{200, 200};
+    const ivec2 fine = perAxisTrixelCanvasWorstCaseSize(extent, 1.0f);
+    const ivec2 coarse = perAxisTrixelCanvasWorstCaseSize(extent, 2.0f);
+    EXPECT_LE(coarse.x, fine.x);
+    // 2px floor ⇒ horizontal density term 2/2 = 1 < √2 ⇒ footprint-bound.
+    EXPECT_EQ(coarse.x, ceilScale(extent.x, kSqrt2));
+    EXPECT_EQ(coarse.y, ceilScale(extent.y, kSqrt2));
+}
+
+// Sub-pixel floors are clamped to 1 px — a trixel is never subdivided below a
+// single framebuffer pixel, so the worst case stays finite.
+TEST(PerAxisCanvasSize, SubPixelFloorClampsToOnePixel) {
+    const ivec2 extent{128, 96};
+    const ivec2 atOne = perAxisTrixelCanvasWorstCaseSize(extent, 1.0f);
+    const ivec2 belowOne = perAxisTrixelCanvasWorstCaseSize(extent, 0.25f);
+    EXPECT_EQ(belowOne.x, atOne.x);
+    EXPECT_EQ(belowOne.y, atOne.y);
+}
+
+// Pure function of its inputs — no per-frame variance (the size is allocated
+// once and reused; the design forbids per-frame reallocation).
+TEST(PerAxisCanvasSize, Deterministic) {
+    const ivec2 extent{480, 270};
+    EXPECT_EQ(
+        perAxisTrixelCanvasWorstCaseSize(extent, 1.0f).x,
+        perAxisTrixelCanvasWorstCaseSize(extent, 1.0f).x
+    );
+    EXPECT_EQ(
+        perAxisTrixelCanvasWorstCaseSize(extent, 1.0f).y,
+        perAxisTrixelCanvasWorstCaseSize(extent, 1.0f).y
+    );
+}
+
+} // namespace

--- a/test/render/per_axis_canvas_size_test.cpp
+++ b/test/render/per_axis_canvas_size_test.cpp
@@ -20,46 +20,48 @@ int ceilScale(int extent, float scale) {
 
 // At the default 1px floor the horizontal axis is bounded by the density term
 // (2× — the iso canvas packs 2 framebuffer px per trixel horizontally) and the
-// vertical axis by the √2 footprint term (1 px per trixel vertically ⇒ no extra
-// vertical subdivision).
+// vertical axis by the face-shear bound W + H (Y/X-face row-1 shear at ±π/4
+// folds the horizontal span into the vertical footprint).
 TEST(PerAxisCanvasSize, DefaultFloorMatchesBoundsExactly) {
     const ivec2 size = perAxisTrixelCanvasWorstCaseSize(ivec2{100, 80}, 1.0f);
-    EXPECT_EQ(size.x, ceilScale(100, 2.0f));    // density-bound horizontally
-    EXPECT_EQ(size.y, ceilScale(80, kSqrt2));   // footprint-bound vertically
+    EXPECT_EQ(size.x, ceilScale(100, 2.0f)); // density-bound horizontally
+    EXPECT_EQ(size.y, 100 + 80);             // face-shear bound: W + H vertically
 }
 
-// The √2 footprint growth is always a lower bound per dimension — the
-// stretched / rotated axis needs at least this many texels at residual ±π/4.
-TEST(PerAxisCanvasSize, NeverBelowSqrt2Footprint) {
+// The face-shear bound W + H is always a lower bound for Y (and √2·W for X) —
+// the per-axis canvas is never smaller than the worst-case deformed footprint.
+TEST(PerAxisCanvasSize, NeverBelowWorstCaseFootprint) {
     const ivec2 extent{321, 217};
     const ivec2 size = perAxisTrixelCanvasWorstCaseSize(extent, 1.0f);
-    EXPECT_GE(size.x, ceilScale(extent.x, kSqrt2));
-    EXPECT_GE(size.y, ceilScale(extent.y, kSqrt2));
+    EXPECT_GE(size.x, ceilScale(extent.x, kSqrt2)); // horizontal: √2·W
+    EXPECT_GE(size.y, extent.x + extent.y);         // vertical: W + H (face-shear)
 }
 
-// Bounded above: no unbounded growth as a face goes edge-on. The min-on-screen
-// trixel-size floor caps the skinny axis at 2× the cardinal extent horizontally
-// and √2× vertically — never more.
-TEST(PerAxisCanvasSize, BoundedAboveByTwoTimesCardinal) {
+// Bounded above: no unbounded growth as a face goes edge-on. Horizontal is
+// capped at 2× cardinal (density floor at 1px/trixel). Vertical is capped at
+// W + H (face-shear bound from Y/X-face row-1 at ±π/4) — never more.
+TEST(PerAxisCanvasSize, BoundedAboveByWorstCaseFootprint) {
     const ivec2 extent{640, 360};
     const ivec2 size = perAxisTrixelCanvasWorstCaseSize(extent, 1.0f);
     EXPECT_LE(size.x, ceilScale(extent.x, 2.0f));
-    EXPECT_LE(size.y, ceilScale(extent.y, kSqrt2));
+    EXPECT_LE(size.y, extent.x + extent.y); // face-shear bound: W + H
     // And never smaller than the cardinal canvas it must be able to represent.
     EXPECT_GE(size.x, extent.x);
     EXPECT_GE(size.y, extent.y);
 }
 
-// A coarser minimum trixel size needs fewer texels: the horizontal density
-// term shrinks while the √2 footprint floor still holds.
-TEST(PerAxisCanvasSize, CoarserFloorShrinksTowardFootprint) {
+// A coarser minimum trixel size reduces horizontal texels (density term shrinks)
+// but leaves vertical unchanged — Y is always dominated by the face-shear bound
+// W + H, which is independent of the density floor.
+TEST(PerAxisCanvasSize, CoarserFloorShrinksHorizontalOnly) {
     const ivec2 extent{200, 200};
     const ivec2 fine = perAxisTrixelCanvasWorstCaseSize(extent, 1.0f);
     const ivec2 coarse = perAxisTrixelCanvasWorstCaseSize(extent, 2.0f);
     EXPECT_LE(coarse.x, fine.x);
-    // 2px floor ⇒ horizontal density term 2/2 = 1 < √2 ⇒ footprint-bound.
+    // 2px floor ⇒ horizontal density term 2/2 = 1 < √2 ⇒ footprint-bound for X.
     EXPECT_EQ(coarse.x, ceilScale(extent.x, kSqrt2));
-    EXPECT_EQ(coarse.y, ceilScale(extent.y, kSqrt2));
+    // Y is face-shear-bound (W + H) regardless of the density floor.
+    EXPECT_EQ(coarse.y, extent.x + extent.y);
 }
 
 // Sub-pixel floors are clamped to 1 px — a trixel is never subdivided below a


### PR DESCRIPTION
## Summary

T1 of the smooth-camera-Z-yaw epic (**#1307**; design: `docs/design/per-axis-trixel-canvas-rotation.md`, PR #1306). **PR-1 of 4.**

Stands up the **three per-axis (X/Y/Z) trixel canvases** + bounded worst-case sizing + min-on-screen-trixel-size floor + `residualYaw == 0` fast-path collapse. **Infrastructure only** — no Stage-1 routing or per-canvas geometry (that is T2 / #1309), so rendered output is **byte-identical to master**.

- **`C_PerAxisTrixelCanvases`** (new component) — three color/distance/entity-id texture sets, owned by the main world canvas, allocated **lazily**. Reuses the canonical canvas-texture factories, newly extracted to `detail::makeCanvas*Texture` in `component_triangle_canvas_textures.hpp` so the two canvas components can't drift on texture format.
- **`IRPrefab::PerAxisCanvas::syncAllocationToCameraYaw`** (new) — once-per-frame lifecycle from `VOXEL_TO_TRIXEL_STAGE_1::beginTick`: allocates the textures while the camera sits at a non-cardinal residual yaw, frees them at the cardinal. A static/cardinal scene pays **zero** extra GPU memory (the byte-identical fast path).
- **`IRMath::perAxisTrixelCanvasWorstCaseSize`** (new) — bounded worst-case texel size (max of the √2 footprint growth and the min-trixel-size density floor), allocated once, never reallocated per frame. Unit-tested (`test/render/per_axis_canvas_size_test.cpp`).
- Only the **main GRID world canvas** carries the component — detached canvases rotate via full SO(3) (`PROPAGATE_CANVAS_ROTATION`), a separate mechanism the design doc keeps distinct.

## Acceptance criteria

- [x] **Non-rotating scene byte-identical to master (fast path).** `img_diff` of every deterministic `shape_debug` shot = **0 drift** vs master (cardinal shots + the `zoom4_yaw45` inter-cardinal shot where allocation fires). The only shots that vary (000006/000009/000010) show the *same* drift in a master-vs-master capture — pre-existing renderer run-to-run non-determinism, not this change.
- [x] **Textures sized once to the worst case; no per-frame realloc; no unbounded growth.** Worst-case size derived from the √2 footprint and the min-trixel-size floor; allocate/release only on rotation-start/stop transitions. Covered by the sizing unit tests (bounded above/below, sub-pixel floor clamps).
- [x] **Memory only consumed while rotating.** Resource log confirms **9 textures created only at the `yaw=45°` shot, none at the cardinals**, and released on return to a cardinal.

## Test plan

- [x] `fleet-build --target IRShapeDebug` + `IrredenEngineTest` — clean.
- [x] `IrredenEngineTest --gtest_filter=PerAxisCanvasSize.*` — 6/6 pass.
- [x] Camera/math/yaw/grid suites (64 tests) — pass (no regression from the `ir_math` / `C_TriangleCanvasTextures` edits).
- [x] `shape_debug --auto-screenshot` renders all 12 shots cleanly; allocation gating verified via resource log.

**Screenshots intentionally not committed:** the change has no pixel-path consumer (the new textures are written/read by no system or shader), so before/after pairs would be identical — `attach-screenshots`' own anti-patterns advise against committing no-op screenshots for non-visual PRs. The `img_diff` zero-drift evidence above is the stronger proof.

Closes #1308