### PR TITLE
fleet: require closing keyword for scope-shipped, not bare #N mention

### DIFF
--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -1,43 +1,79 @@
-"""Genuine-reference predicate for fleet-queue-ingest's scope-shipped pre-flight.
+"""Genuine-ship predicate for fleet-queue-ingest's scope-shipped pre-flight.
 
 A merged PR is only evidence that an issue's scope "already landed" when the PR
-carries a genuine cross-reference to the issue — a word-boundary ``#N`` in its
-title or body (a real ``Closes #N`` / ``supersedes #N`` / ``#N`` mention).
+genuinely *ships* the issue — not when it merely names it. Two layers of
+incidental match have to be rejected:
 
-GitHub's PR search (``gh pr list --search '#N'``) strips the ``#`` and matches
-the bare token ``N`` anywhere it appears, including PR *comments* and source
-line numbers, and can even return relevance-only hits with no literal ``N`` at
-all. Trusting ``prs[0]`` from that search mislabels unrelated issues as
-``fleet:scope-shipped`` and posts a misleading "scope already landed" comment
-(#1304: #1243's #1300 line-number hit, #1160's #1284 relevance hit). This
-predicate is the verification step that rejects those incidental matches.
+1. No reference at all (#1304). GitHub's PR search (``gh pr list --search
+   '#N'``) strips the ``#`` and matches the bare token ``N`` anywhere it
+   appears — PR comments, source line numbers, even relevance-only hits with no
+   literal ``N``. Trusting ``prs[0]`` mislabels unrelated issues (#1243's #1300
+   line-number hit, #1160's #1284 relevance hit).
+
+2. Mentioned but not shipped. A bare word-boundary ``#N`` in a PR *body* is
+   still not proof: PRs routinely cite issues they explicitly do NOT fix —
+   "bug-fixing is downstream issues (#1260, etc)" (#1260 ← #1282),
+   "pre-existing #1269" / "filed as #1269" (#1269 ← #1265), "Refs #N". These
+   slipped past the layer-1 fix because the literal ``#N`` token is present.
+
+So a body ``#N`` counts only when a closing-action verb sits directly before it
+(``Closes #N``, ``fixes (#N)``, ``supersedes #N``). A ``#N`` in the *title* is
+trusted as-is: PRs in this repo are named ``#N: <desc>`` after the issue they
+implement, and every observed false positive came from the body, never the
+title. The asymmetry is deliberate.
 """
 import re
 
+# Closing-action verbs that signal a PR genuinely shipped an issue's scope.
+# Mirrors GitHub's auto-close keyword set plus the engine's "implement / ship /
+# supersede" idioms. Anchored with \b at the call site so "bug-fixing" never
+# satisfies "fix" and "preclose" never satisfies "close".
+_CLOSING_VERB = (
+    r'clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed)'
+    r'|implement(?:s|ed)?|ship(?:s|ped)?|supersed(?:e|es|ed)'
+)
+# Only whitespace, a colon, or a single opening bracket may sit between the verb
+# and the ref ("Closes #N", "resolved: #N", "fixes (#N)"). The gap is bounded on
+# purpose: a permissive ".*?" would let "Fixes #1258. Also see downstream #1260"
+# bind the verb across to the unrelated #1260.
+_VERB_TO_REF_GAP = r'[\s:]*[(\[]?\s*'
+
+
+def _ref_pattern(n):
+    # ``(?<!\w)`` rejects ``abc#1300``; ``(?!\d)`` stops ``#13000`` / ``#21300``
+    # from satisfying ``n=1300``. Matches GitHub's own link-detection bounds.
+    return r'(?<!\w)#' + str(int(n)) + r'(?!\d)'
+
 
 def pr_references_issue(title, body, n):
-    """True iff a word-boundary ``#{n}`` appears in the PR title or body.
+    """True iff the PR genuinely ships issue ``n`` (see module docstring).
 
-    The leading ``(?<!\\w)`` guard rejects ``abc#1300`` (alphanumeric immediately
-    before ``#``); the trailing ``(?!\\d)`` guard stops ``#13000`` from satisfying
-    ``n=1300``. Together they match GitHub's own link-detection boundaries.
-    Requiring the literal ``#`` rejects bare line-number and relevance hits that
-    carry no cross-reference at all.
+    Title: any word-boundary ``#n`` counts (the ``#N: <desc>`` PR-naming
+    convention). Body: ``#n`` counts only when immediately preceded by a
+    closing-action verb. A bare body mention ("downstream #n", "pre-existing
+    #n", "Refs #n") is rejected.
     """
     if not n:
         return False
     try:
-        pattern = re.compile(r'(?<!\w)#' + str(int(n)) + r'(?!\d)')
-    except ValueError:
+        ref = _ref_pattern(n)
+    except (ValueError, TypeError):
         return False
-    return bool(pattern.search(title or '')) or bool(pattern.search(body or ''))
+    if re.search(ref, title or ''):
+        return True
+    body_re = re.compile(
+        r'\b(?:' + _CLOSING_VERB + r')\b' + _VERB_TO_REF_GAP + ref,
+        re.IGNORECASE,
+    )
+    return bool(body_re.search(body or ''))
 
 
 def select_shipped_pr(prs, n):
-    """First PR in ``prs`` that genuinely references issue ``n``, else ``None``.
+    """First PR in ``prs`` that genuinely ships issue ``n``, else ``None``.
 
     Replaces the old ``prs[0]`` blind trust: a merged-PR search hit only counts
-    as scope-shipped evidence when the PR actually cross-references the issue.
+    as scope-shipped evidence when ``pr_references_issue`` confirms a genuine
+    ship (title ref or closing-verb body ref), not an incidental mention.
     """
     for pr in prs:
         if pr_references_issue(pr.get('title', ''), pr.get('body', ''), n):

--- a/scripts/fleet/tests/test_scope_shipped_reference.py
+++ b/scripts/fleet/tests/test_scope_shipped_reference.py
@@ -38,7 +38,7 @@ class PrReferencesIssue(unittest.TestCase):
     def test_genuine_closes_in_body(self):
         self.assertTrue(pr_references_issue("some PR", "Closes #1300.", 1300))
 
-    def test_genuine_hash_ref_in_body(self):
+    def test_genuine_closing_verb_in_body(self):
         self.assertTrue(pr_references_issue("title", "supersedes #1284 here", 1284))
 
     def test_genuine_ref_in_title(self):
@@ -110,7 +110,8 @@ class PrReferencesIssue(unittest.TestCase):
 
     def test_closing_verb_variants_in_body(self):
         for body in ("fixed #1300", "resolves #1300", "Resolved: #1300",
-                     "implements #1300", "shipped #1300", "supersedes #1300"):
+                     "implements #1300", "shipped #1300", "supersedes #1300",
+                     "closes #1300", "Fixes #1300"):
             self.assertTrue(pr_references_issue("", body, 1300), body)
 
 

--- a/scripts/fleet/tests/test_scope_shipped_reference.py
+++ b/scripts/fleet/tests/test_scope_shipped_reference.py
@@ -1,10 +1,16 @@
-"""Tests for the genuine-reference predicate in fleet_scope_shipped.
+"""Tests for the genuine-ship predicate in fleet_scope_shipped.
 
-Covers the #1304 false-positives: fleet-queue-ingest's scope-shipped
-pre-flight used to trust prs[0] from a `gh pr list --search '#N'` query, but
-GitHub matches the bare token N anywhere (titles, bodies, comments, line
-numbers, relevance). select_shipped_pr() must reject those incidental hits and
-only flag a PR that carries a genuine word-boundary #N cross-reference.
+Covers two false-positive classes:
+
+* #1304 — fleet-queue-ingest's scope-shipped pre-flight used to trust prs[0]
+  from a `gh pr list --search '#N'` query, but GitHub matches the bare token N
+  anywhere (titles, bodies, comments, line numbers, relevance). Incidental
+  hits with no literal #N must be rejected.
+* #1260 / #1269 — a bare word-boundary #N in a PR *body* is also not proof:
+  PRs cite issues they explicitly do NOT fix ("downstream issues (#1260)",
+  "pre-existing #1269", "filed as #1269", "Refs #N"). A body ref counts only
+  when a closing-action verb sits directly before it; a title ref is trusted
+  as-is (the `#N: <desc>` PR-naming convention).
 
 The module is a real .py, but it is loaded via importlib (mirroring
 test_enrich_stackable_blocker_prs.py) so the test runs regardless of cwd.
@@ -71,6 +77,42 @@ class PrReferencesIssue(unittest.TestCase):
         # int(n) raises ValueError for a truthy non-numeric string.
         self.assertFalse(pr_references_issue("", "Closes #1300", "abc"))
 
+    # --- mentioned-but-not-shipped body refs (#1260 / #1269) ---
+
+    def test_downstream_body_mention_rejected(self):
+        # The #1260 <- #1282 shape: PR names #1260 as explicitly-NOT-fixed work.
+        self.assertFalse(pr_references_issue(
+            "#1271: demo: IRShapeDebug --spin-yaw",
+            "bug-fixing is downstream issues (#1256, #1260, etc). This PR ships "
+            "the regression scaffolding.", 1260))
+
+    def test_pre_existing_body_mention_rejected(self):
+        # The #1269 <- #1265 shape: PR cites #1269 as a pre-existing failure.
+        self.assertFalse(pr_references_issue(
+            "#1258: render: camera pitch/roll",
+            "MatchesStd140Packing fails on origin/master independently of this "
+            "change (filed as #1269). 997/998 pass; the one failure is the "
+            "pre-existing #1269.", 1269))
+
+    def test_refs_body_mention_rejected(self):
+        # "Refs #N" deliberately does not auto-close — not ship evidence.
+        self.assertFalse(pr_references_issue("title", "Using Refs #1271 here", 1271))
+
+    def test_closing_verb_does_not_bind_across_sentence(self):
+        # A verb earlier in the body must not bind to a later unrelated #N.
+        self.assertFalse(pr_references_issue(
+            "", "Fixes #1258. Also see downstream #1260.", 1260))
+
+    def test_title_ref_counts_even_with_unrelated_body_mention(self):
+        # The same PR that mentions #1269 in its body genuinely ships #1258.
+        self.assertTrue(pr_references_issue(
+            "#1258: render: camera pitch/roll", "pre-existing #1269 still fails", 1258))
+
+    def test_closing_verb_variants_in_body(self):
+        for body in ("fixed #1300", "resolves #1300", "Resolved: #1300",
+                     "implements #1300", "shipped #1300", "supersedes #1300"):
+            self.assertTrue(pr_references_issue("", body, 1300), body)
+
 
 class SelectShippedPr(unittest.TestCase):
     def test_empty_candidates(self):
@@ -95,6 +137,19 @@ class SelectShippedPr(unittest.TestCase):
     def test_missing_title_body_keys(self):
         # Defensive: a candidate dict without title/body must not raise.
         self.assertIsNone(select_shipped_pr([{"number": 5}], 1300))
+
+    def test_real_world_1260_not_shipped_by_1282(self):
+        # #1282 only mentions #1260 as downstream-not-fixed -> no ship.
+        prs = [_pr(1282, "#1271: demo: IRShapeDebug --spin-yaw",
+                   "bug-fixing is downstream issues (#1256, #1260, etc)")]
+        self.assertIsNone(select_shipped_pr(prs, 1260))
+
+    def test_real_world_1265_ships_1258_not_1269(self):
+        # #1265 closes #1258 but only cites #1269 as a pre-existing failure.
+        pr = _pr(1265, "#1258: render: camera pitch/roll",
+                 "Closes #1258. The one failure is the pre-existing #1269.")
+        self.assertEqual(select_shipped_pr([pr], 1258)["number"], 1265)
+        self.assertIsNone(select_shipped_pr([pr], 1269))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`fleet:scope-shipped` is still firing false positives despite the genuine-reference fix (#1305). Two open tasks were wrongly flagged today, suppressed from the queue, and told to close:

| Issue | Flagged "shipped" by | Reality |
|---|---|---|
| #1260 (face-culling perf) | PR #1282 | body: *"bug-fixing is downstream issues (#1256, **#1260**, etc)"* — explicitly NOT fixed |
| #1269 (failing test) | PR #1265 | body: *"pre-existing **#1269**"* / *"filed as **#1269**"* — #1265 actually `Closes #1258` |

`#1305` closed the *no-reference* hole (line-number / relevance search hits with no literal `#N`). But `pr_references_issue` still accepted **any** word-boundary `#N` in a PR body as proof of shipping — and PRs routinely *mention* issues they don't fix (`downstream #N`, `pre-existing #N`, `filed as #N`, `Refs #N`). Both issues re-flagged on every ingest cycle (#1269 got the identical scope-check comment twice today).

## Fix

Tighten the body match: a `#N` in a PR **body** counts only when a closing-action verb (`closes/fixes/resolves/implements/ships/supersedes`) sits **directly** before it, with a bounded verb→ref gap so a verb can't bind across a sentence to an unrelated `#N`. A `#N` in the **title** is still trusted as-is — the `#N: <desc>` PR-naming convention is reliable, and every observed false positive came from the body, never the title. The asymmetry is deliberate and documented.

## Validation

Live `gh pr list --search` + predicate, exactly as the ingest runs it:

```
#1260: candidates [#1282, #1160] -> not shipped (kept in queue)   ✅
#1269: candidates [#1265]        -> not shipped (kept in queue)   ✅
#1258: candidates [#1265]        -> SHIPPED by #1265              ✅ (genuine `Closes #1258`)
```

Tests: all 23 pass (11 pre-existing unchanged — title-ref and `fixes (#N)` punctuation cases still accepted; 12 new covering the mentioned-but-not-shipped class and the two real-world PRs).

Already unstuck #1260 and #1269 (removed `fleet:scope-shipped`, posted corrections). This fix prevents them — and future "mentioned-not-shipped" cases — from re-flagging once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
