### PR TITLE
test: re-pin FrameDataSun std140 layout to 128-byte CSM block

### DIFF
--- a/test/render/frame_data_sun_layout_test.cpp
+++ b/test/render/frame_data_sun_layout_test.cpp
@@ -4,11 +4,7 @@
 
 #include <cstddef>
 
-// Runtime tripwire mirroring the compile-time static_asserts on FrameDataSun
-// in ir_render_types.hpp. The struct is the std140 leading edge: the GLSL UBO
-// (binding 29, c_compute_sun_shadow.glsl et al.) and the Metal struct must
-// match it field-for-field. CSM widened the block from 80 to 128 bytes by
-// appending the per-cascade AABB params after the legacy single-map fields.
+// Runtime tripwire mirroring the compile-time static_asserts in ir_render_types.hpp (std140 leading edge).
 TEST(FrameDataSunLayout, MatchesStd140Packing) {
     EXPECT_EQ(sizeof(IRRender::FrameDataSun), 128u);
     EXPECT_EQ(offsetof(IRRender::FrameDataSun, sunDirection_), 0u);

--- a/test/render/frame_data_sun_layout_test.cpp
+++ b/test/render/frame_data_sun_layout_test.cpp
@@ -4,8 +4,13 @@
 
 #include <cstddef>
 
+// Runtime tripwire mirroring the compile-time static_asserts on FrameDataSun
+// in ir_render_types.hpp. The struct is the std140 leading edge: the GLSL UBO
+// (binding 29, c_compute_sun_shadow.glsl et al.) and the Metal struct must
+// match it field-for-field. CSM widened the block from 80 to 128 bytes by
+// appending the per-cascade AABB params after the legacy single-map fields.
 TEST(FrameDataSunLayout, MatchesStd140Packing) {
-    EXPECT_EQ(sizeof(IRRender::FrameDataSun), 80u);
+    EXPECT_EQ(sizeof(IRRender::FrameDataSun), 128u);
     EXPECT_EQ(offsetof(IRRender::FrameDataSun, sunDirection_), 0u);
     EXPECT_EQ(offsetof(IRRender::FrameDataSun, sunIntensity_), 16u);
     EXPECT_EQ(offsetof(IRRender::FrameDataSun, sunAmbient_), 20u);
@@ -15,4 +20,10 @@ TEST(FrameDataSunLayout, MatchesStd140Packing) {
     EXPECT_EQ(offsetof(IRRender::FrameDataSun, sunBasisV_), 48u);
     EXPECT_EQ(offsetof(IRRender::FrameDataSun, sunBufferOriginUV_), 64u);
     EXPECT_EQ(offsetof(IRRender::FrameDataSun, sunBufferTexelSize_), 72u);
+    EXPECT_EQ(offsetof(IRRender::FrameDataSun, cascadeOriginUV_0_), 80u);
+    EXPECT_EQ(offsetof(IRRender::FrameDataSun, cascadeTexelSize_0_), 88u);
+    EXPECT_EQ(offsetof(IRRender::FrameDataSun, cascadeOriginUV_1_), 96u);
+    EXPECT_EQ(offsetof(IRRender::FrameDataSun, cascadeTexelSize_1_), 104u);
+    EXPECT_EQ(offsetof(IRRender::FrameDataSun, cascadeSplitDepth_), 112u);
+    EXPECT_EQ(offsetof(IRRender::FrameDataSun, cascadeCount_), 116u);
 }


### PR DESCRIPTION
## Summary
- `FrameDataSunLayout.MatchesStd140Packing` failed on a fresh build of `origin/master`: it still expected the pre-CSM **80-byte** layout, but `IRRender::FrameDataSun` grew to **128 bytes** when the cascaded shadow-map fields were appended after the legacy single-map fields.
- The C++ struct is the std140 leading edge and already carries compile-time `static_asserts` for the new layout; the GLSL UBO (binding 29, `c_compute_sun_shadow.glsl` et al.) and the Metal struct were updated in lockstep. Only this runtime tripwire test was left behind.
- Re-pin `sizeof` to 128 and add `offsetof` checks for the six new cascade fields (`cascadeOriginUV_0_`/`cascadeTexelSize_0_`/`cascadeOriginUV_1_`/`cascadeTexelSize_1_`/`cascadeSplitDepth_`/`cascadeCount_`) so the test mirrors the struct's static_asserts.

## Verification
- Cross-checked the C++ struct, the GLSL UBO, and the Metal struct — all three match field-for-field at 128 bytes; no struct/shader drift, the test was the only stale artifact.
- Test-only diff (no engine/render, shader, or demo changes) → render-debug-loop / screenshots / optimize not applicable.

## Test plan
- [x] `fleet-run IrredenEngineTest --gtest_filter='FrameDataSunLayout.*'` → PASS
- [x] Full suite: `fleet-run IrredenEngineTest` → 1013/1013 pass

Closes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)