### PR TITLE
demo: split perf_grid PARALLEL_FOR systems into singleton groups

### DIFF
--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -579,19 +579,24 @@ int main(int argc, char **argv) {
 }
 
 void initSystems() {
-    // T-332: First multi-system parallel group in a demo's UPDATE pipeline.
-    // PERIODIC_IDLE writes only C_PeriodicIdle and MODIFIER_DECAY writes only
-    // C_Modifiers — disjoint write sets per SystemAccess derivation, so the
-    // T-224 cross-system validator approves co-execution. The remaining four
-    // groups stay serial: PERIODIC_IDLE_POSITION_OFFSET reads C_PeriodicIdle
-    // (read-after-write on the prior group) and writes C_Modifiers, then
-    // PROPAGATE_TRANSFORM and UPDATE_VOXEL_SET_CHILDREN form a strict
-    // producer→consumer chain on C_WorldTransform. See
-    // docs/perf-reports/threading_phase3.md for measurement.
+    // Every UPDATE system runs in its own singleton group. PERIODIC_IDLE and
+    // MODIFIER_DECAY each carry Concurrency::PARALLEL_FOR (T-379 bulk
+    // migration), so each drives an inner IRJob::parallelFor that fans its
+    // per-entity work across the whole worker pool. A PARALLEL_FOR system
+    // therefore cannot share a multi-system parallel group: its inner
+    // parallelFor would be asked to fan out from a worker thread, which
+    // SystemManager::validateAllPipelineGroups rejects at boot. (T-332 grouped
+    // PERIODIC_IDLE + MODIFIER_DECAY back when both were SERIAL; T-379 tagged
+    // them PARALLEL_FOR without splitting the group, which is what aborted this
+    // demo at startup.) Per-system data-parallelism supersedes that old
+    // task-parallel co-execution. The three trailing systems are SERIAL and
+    // ordered as a producer→consumer chain: PERIODIC_IDLE_POSITION_OFFSET reads
+    // C_PeriodicIdle (after PERIODIC_IDLE), then PROPAGATE_TRANSFORM and
+    // UPDATE_VOXEL_SET_CHILDREN run in sequence on C_WorldTransform.
     IRSystem::registerPipelineGroups(
         IRTime::Events::UPDATE,
-        {{IRSystem::createSystem<IRSystem::PERIODIC_IDLE>(),
-          IRSystem::createSystem<IRSystem::MODIFIER_DECAY>()},
+        {{IRSystem::createSystem<IRSystem::PERIODIC_IDLE>()},
+         {IRSystem::createSystem<IRSystem::MODIFIER_DECAY>()},
          {IRSystem::createSystem<IRSystem::PERIODIC_IDLE_POSITION_OFFSET>()},
          {IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>()},
          {IRSystem::createSystem<IRSystem::UPDATE_VOXEL_SET_CHILDREN>()}}


### PR DESCRIPTION
## Summary
- `IRPerfGrid` aborted at `World::start()` with a pipeline-group validation assertion (`SystemManager::validateAllPipelineGroups`): `PERIODIC_IDLE` carries `Concurrency::PARALLEL_FOR` yet shared a multi-system parallel UPDATE group with `MODIFIER_DECAY`. A `PARALLEL_FOR` system's inner `IRJob::parallelFor` cannot fan out from a worker thread, so the validator requires it to live in its own singleton group.
- Split the offending group into singleton groups (`{PERIODIC_IDLE}`, `{MODIFIER_DECAY}`, …). Each system keeps its own per-entity data-parallelism; declaration order and the disjoint write sets are preserved, so simulation output is unchanged.
- Rewrote the comment to document the constraint and the regression history so the group isn't reintroduced.

## Root cause (regression chain)
- **T-332** (#1117) grouped `PERIODIC_IDLE` + `MODIFIER_DECAY` into one parallel group — valid then: both were `SERIAL` with disjoint write sets.
- **T-379** (#1212) "bulk PARALLEL_FOR migration of trivially-safe prefab systems" tagged **both** systems `PARALLEL_FOR` without splitting the group, silently invalidating it. The crash only surfaces at runtime when the demo boots.

## Scope
`perf_grid` is the **only** affected demo. It is the sole repo-wide caller of `registerPipelineGroups` with a multi-system group; every other demo (and `lua_pipeline_demo`) uses `registerPipeline`, which produces singleton groups and is always safe. No Lua creation builds multi-system groups.

## Test plan
- [x] `ir-build --target IRPerfGrid` — builds clean (macOS / Metal).
- [x] `ir-run --timeout 6 IRPerfGrid` — boots past `World::start()` validation and runs the full watchdog window without the abort (previously crashed immediately).
- [ ] Linux/OpenGL smoke (no backend-specific code changed; pure pipeline-group config).

## Notes for reviewer
No tracking issue — found ad-hoc while running the demo. Output is visually identical (scheduling-only change), so no screenshots attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)