### PR TITLE
fleet: repo-scope worker claims via FLEET_ROLE_REPO gate

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -504,6 +504,37 @@ PYEOF
     return 0
 }
 
+check_repo_tag() {
+    # Refuse the claim when the calling role serves a different repo than the
+    # task lives in. A worker is bound to one repo's worktree — it can't build,
+    # commit to, or open PRs in another repo — so an engine-worktree worker
+    # must never claim a game task (or vice versa). The repo-scoped sibling of
+    # check_model_tag.
+    #
+    # The task's repo is the global `--repo` namespace: empty (or "engine")
+    # means the engine repo, "game" means the game repo. The role's repo comes
+    # from FLEET_ROLE_REPO (set by fleet-dispatch-wrap from the pane's
+    # worktree). Cheap and local — no GitHub round-trip — so cmd_claim runs it
+    # before the blocker/model gates. Opt-in: no-op when FLEET_ROLE_REPO is
+    # unset/empty, so manual claims and babysit-launched roles are unaffected.
+    local issue_num="$1"
+    local role_repo="${FLEET_ROLE_REPO:-}"
+    [[ -z "$role_repo" ]] && return 0
+
+    local task_repo="${REPO_NS:-}"
+    [[ -z "$task_repo" ]] && task_repo="engine"
+
+    role_repo="${role_repo,,}"
+    task_repo="${task_repo,,}"
+
+    if [[ "$task_repo" != "$role_repo" ]]; then
+        echo "fleet-claim: refuse #${issue_num} — task is in the [${task_repo}] repo, this role serves [${role_repo}]; route it to a ${task_repo} worker" >&2
+        return 1
+    fi
+
+    return 0
+}
+
 # --- subcommands ----------------------------------------------------------
 
 cmd_claim() {
@@ -588,6 +619,13 @@ cmd_claim() {
                 return 1
                 ;;
         esac
+    fi
+
+    # Repo gate: refuse when FLEET_ROLE_REPO is set and doesn't match the
+    # task's --repo namespace. Cheap, local, and first — a wrong-repo claim
+    # short-circuits before any GitHub round-trip (blockers, model, PR check).
+    if ! check_repo_tag "$issue_num"; then
+        return 1
     fi
 
     # Standard blocker gate. Skipped only when we have a verified-OPEN

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -36,6 +36,16 @@ else
     export FLEET_ROLE_MODEL=sonnet
 fi
 
+# Expose the role's repo so fleet-claim can enforce the repo gate
+# (check_repo_tag). A pane whose worktree lives under creations/game/ serves
+# the game repo; everything else serves the engine repo. Stops an
+# engine-worktree worker from claiming a game task (or vice versa) — it can't
+# build, commit, or open a PR in the other repo.
+case "$PWD" in
+    */creations/game/*) export FLEET_ROLE_REPO=game ;;
+    *)                  export FLEET_ROLE_REPO=engine ;;
+esac
+
 claude --model "$MODEL" --effort "$EFFORT" --print \
     --output-format stream-json --include-partial-messages --verbose \
     "/role-$ROLE live" | fleet-claude-stream

--- a/scripts/fleet/tests/test_fleet_claim_repo_gate.sh
+++ b/scripts/fleet/tests/test_fleet_claim_repo_gate.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim's check_repo_tag gate.
+#
+# The gate refuses a claim when the calling role's repo (FLEET_ROLE_REPO,
+# set by fleet-dispatch-wrap from the pane's worktree) doesn't match the
+# task's `--repo` namespace (empty/"engine" => engine, "game" => game). It
+# keeps an engine-worktree worker from claiming a game task (and vice versa).
+# A `gh` stub lets accepted claims complete without a live GitHub round-trip.
+#
+# Covers:
+#   - engine role accepts an engine task, rejects a game task
+#   - game role accepts a game task, rejects an engine task
+#   - FLEET_ROLE_REPO unset/empty passes any repo (opt-in no-op)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_exit() {
+    local actual_exit="$1" expected_exit="$2" msg="$3"
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected exit: $expected_exit"
+        echo "        actual exit:   $actual_exit"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR"
+
+# Stub `gh` so accepted claims complete without GitHub. Issue 2001 is OPEN,
+# fleet:queued, no blockers, no model label (so the model gate is a no-op).
+# The label-acquire POST echoes the requested label back as the lex-min
+# winner; pr list / issue edit are no-ops.
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+cat >"$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+    "issue view")
+        echo '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":""}'
+        exit 0
+        ;;
+    "api "*)
+        label=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -f) shift; case "$1" in labels\[\]=*) label="${1#labels[]=}" ;; esac ;;
+            esac
+            shift || true
+        done
+        if [[ -n "$label" ]]; then printf '[{"name":"%s"}]\n' "$label"; else echo '[]'; fi
+        exit 0
+        ;;
+esac
+# Everything else (incl. `gh pr list --json … --jq …` open-PR check) returns
+# empty stdout — matching real gh+jq output for "no matching PRs".
+exit 0
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+rel_engine() { "$FLEET_CLAIM" release "$1" >/dev/null 2>&1 || true; }
+rel_game()   { "$FLEET_CLAIM" --repo game release "$1" >/dev/null 2>&1 || true; }
+
+# --- T1: engine role accepts an engine task --------------------------------
+echo "T1: engine role accepts engine task (no --repo)"
+actual=0; FLEET_ROLE_REPO=engine "$FLEET_CLAIM" claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "engine role + engine task → exit 0"
+rel_engine 2001
+
+# --- T2: engine role rejects a game task -----------------------------------
+echo "T2: engine role rejects game task (--repo game)"
+actual=0; FLEET_ROLE_REPO=engine "$FLEET_CLAIM" --repo game claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "engine role + game task → exit 1"
+rel_game 2001
+
+# --- T3: game role accepts a game task -------------------------------------
+echo "T3: game role accepts game task (--repo game)"
+actual=0; FLEET_ROLE_REPO=game "$FLEET_CLAIM" --repo game claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "game role + game task → exit 0"
+rel_game 2001
+
+# --- T4: game role rejects an engine task ----------------------------------
+echo "T4: game role rejects engine task (no --repo)"
+actual=0; FLEET_ROLE_REPO=game "$FLEET_CLAIM" claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "game role + engine task → exit 1"
+rel_engine 2001
+
+# --- T5: FLEET_ROLE_REPO unset passes a game task (opt-in no-op) ------------
+echo "T5: unset FLEET_ROLE_REPO passes game task"
+actual=0; "$FLEET_CLAIM" --repo game claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "unset role + game task → exit 0"
+rel_game 2001
+
+# --- T6: FLEET_ROLE_REPO unset passes an engine task -----------------------
+echo "T6: unset FLEET_ROLE_REPO passes engine task"
+actual=0; "$FLEET_CLAIM" claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "unset role + engine task → exit 0"
+rel_engine 2001
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Problem

A worker is bound to one repo's worktree, but the fleet queue offers tasks from **both** repos (engine + game). Claims and tasks are already repo-aware (`fleet-claim --repo game`, scout tags `repo: engine|game`), and there's a `FLEET_ROLE_MODEL` claim-gate — but **no repo gate**. So an engine-worktree `opus-worker` claimed game tasks (#72, #75) it can't build, commit to, or open PRs for, and game `gh issue create` hit the auto-mode permission classifier.

## Fix

`check_repo_tag` — the repo-scoped sibling of `check_model_tag`:
- **fleet-claim** refuses a claim when `FLEET_ROLE_REPO` is set and ≠ the task's `--repo` namespace (empty/`engine` → engine, `game` → game). Runs **first** in `cmd_claim` — local, no GitHub round-trip. Opt-in: a no-op when `FLEET_ROLE_REPO` is unset, so manual claims and babysit-launched roles are unaffected.
- **fleet-dispatch-wrap** exports `FLEET_ROLE_REPO` from the pane's worktree (`…/creations/game/…` → `game`, else `engine`), mirroring how it sets `FLEET_ROLE_MODEL`.

Result: engine-worktree panes now refuse game tasks (and vice versa) — the durable guard that stops the cross-repo claiming churn, and the **foundation for repo-scoped game workers** (game-worktree panes will set `FLEET_ROLE_REPO=game` and claim only game tasks).

## Tests

- New `test_fleet_claim_repo_gate.sh` — 6/0 (engine↔game accept/reject matrix + opt-in no-op).
- `test_fleet_claim_model_gate.sh` — still 11/0 (no regression).
- `bash -n` clean on both edited scripts.

## Follow-on (separate work)

Stand up the game worker pool: game worker role commands + dispatcher/fleet-up pane wiring in the existing `creations/game/.claude/worktrees/` worktrees + game-repo gh-write permissions. With this gate in place those panes claim only game tasks while engine panes stay engine-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
