### PR TITLE
fleet: stack single-blocker tasks even when blocked_by carries prose

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -700,11 +700,23 @@ _SMOKE_SKIP_LABELS = frozenset({
 
 MODEL_TOKEN_RE = re.compile(r"\b(opus|sonnet)\b")
 
-# Single-issue blocker (`#1234`). Rejects free-text, URL, and multi-blocker
-# forms. Evaluated AFTER resolve_blocked_by() reduces multi-ref bodies to
-# their unresolved set, so a task originally blocked on `#N1, #N2` where #N1
-# is now CLOSED will have blocked_by=`#N2` at this point and will match.
-SINGLE_TASK_BLOCKER_RE = re.compile(r"^#\d+$")
+# A blocked_by value is a "single blocker" — eligible for a stackable claim —
+# when it references exactly one issue. The reference may carry trailing
+# explanatory prose, e.g. "#1308 (T1 must land first)"; the epic decomposer
+# emits that shape, and rejecting it silently kept whole task chains from ever
+# stacking (observed on #1309 → #1316, 2026-05-28). Two or more #refs (a
+# genuine multi-blocker like "#1308, #1309" or "#1308 and #1309") and zero
+# refs ("(none)", free text, a bare URL, legacy "T-101") are NOT single-blocker
+# and get no stackable_blocker_pr.
+#
+# Evaluated AFTER resolve_blocked_by() reduces multi-ref bodies to their
+# unresolved set, so a task originally blocked on `#N1, #N2` where #N1 is now
+# CLOSED arrives here as `#N2` (one ref) and qualifies.
+def _single_blocker_issue(blocked_by):
+    """Return the sole blocker issue number (digits, no '#') when blocked_by
+    references exactly one issue, else None."""
+    refs = re.findall(r"#(\d+)", blocked_by or "")
+    return refs[0] if len(refs) == 1 else None
 
 
 def model_tags(task):
@@ -834,7 +846,9 @@ def enrich_stackable_blocker_prs(state):
     # unblocked tasks are free.
     #
     # The field is always omitted when:
-    #   - blocked_by isn't a single #NNN (multi-blocker, free-text, URL)
+    #   - blocked_by doesn't reference exactly one issue (multi-blocker,
+    #     free-text, URL, none) — see _single_blocker_issue; a single #NNN
+    #     followed by explanatory prose still qualifies
     #   - zero open PRs match the expected branch prefix (blocker not
     #     yet started, or already merged and dropped from open list)
     #   - more than one open PR matches (rare but possible if a stale
@@ -849,9 +863,9 @@ def enrich_stackable_blocker_prs(state):
         prs = repo_state.get("prs", [])
         for task in repo_state.get("tasks", {}).get("open", []):
             blocked_by = (task.get("blocked_by") or "").strip()
-            if not SINGLE_TASK_BLOCKER_RE.match(blocked_by):
+            issue_num = _single_blocker_issue(blocked_by)
+            if not issue_num:
                 continue
-            issue_num = blocked_by.lstrip("#")
             prefix = f"claude/{issue_num}-"
             matches = [pr for pr in prs
                        if pr.get("headRefName", "").startswith(prefix)]

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -700,18 +700,11 @@ _SMOKE_SKIP_LABELS = frozenset({
 
 MODEL_TOKEN_RE = re.compile(r"\b(opus|sonnet)\b")
 
-# A blocked_by value is a "single blocker" — eligible for a stackable claim —
-# when it references exactly one issue. The reference may carry trailing
-# explanatory prose, e.g. "#1308 (T1 must land first)"; the epic decomposer
-# emits that shape, and rejecting it silently kept whole task chains from ever
-# stacking (observed on #1309 → #1316, 2026-05-28). Two or more #refs (a
-# genuine multi-blocker like "#1308, #1309" or "#1308 and #1309") and zero
-# refs ("(none)", free text, a bare URL, legacy "T-101") are NOT single-blocker
-# and get no stackable_blocker_pr.
-#
-# Evaluated AFTER resolve_blocked_by() reduces multi-ref bodies to their
-# unresolved set, so a task originally blocked on `#N1, #N2` where #N1 is now
-# CLOSED arrives here as `#N2` (one ref) and qualifies.
+# Eligible when blocked_by references exactly one issue. The epic decomposer
+# emits prose suffixes (e.g. "#1308 (T1 must land first)") that the old strict
+# regex rejected, silently killing whole task chains (#1309→#1316, 2026-05-28).
+# Evaluated AFTER resolve_blocked_by(), so a two-ref task whose first blocker
+# is now CLOSED arrives here as one ref and qualifies.
 def _single_blocker_issue(blocked_by):
     """Return the sole blocker issue number (digits, no '#') when blocked_by
     references exactly one issue, else None."""

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -1,9 +1,9 @@
 """Tests for enrich_stackable_blocker_prs() in fleet-state-scout.
 
 Covers prefix-discrimination, multi-match safety, multi-blocker guard,
-None/empty/free-text blocked_by guards, cross-repo isolation, and author
-pass-through. Import the function via importlib because the script has no
-.py extension.
+single-ref-with-prose pass-through, None/empty/free-text blocked_by guards,
+cross-repo isolation, and author pass-through. Import the function via
+importlib because the script has no .py extension.
 """
 import importlib.machinery
 import importlib.util
@@ -98,13 +98,28 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
                          state["repos"]["engine"]["tasks"]["open"][0])
 
     def test_multi_blocker_no_field(self):
-        """blocked_by with two IDs doesn't match ^#\\d+$ → field absent."""
+        """blocked_by naming two issues is a multi-blocker → field absent."""
         tasks = [_task("#1115", "#1112, #1113")]
         prs = [_pr(540, "claude/1112-some-branch"), _pr(541, "claude/1113-other")]
         state = _state(engine_tasks=tasks, engine_prs=prs)
         enrich_stackable_blocker_prs(state)
         self.assertNotIn("stackable_blocker_pr",
                          state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_two_refs_with_prose_no_field(self):
+        """Two #refs is a multi-blocker regardless of surrounding prose
+        ("#A and #B", "#A, #B (note)") → field absent. Guards the single-ref
+        relaxation from over-matching genuine multi-blockers."""
+        for value in ("#101 and #102", "#101, #102 (both must land)"):
+            with self.subTest(blocked_by=value):
+                tasks = [_task("#999", value)]
+                prs = [_pr(1, "claude/101-x"), _pr(2, "claude/102-y")]
+                state = _state(engine_tasks=tasks, engine_prs=prs)
+                enrich_stackable_blocker_prs(state)
+                self.assertNotIn(
+                    "stackable_blocker_pr",
+                    state["repos"]["engine"]["tasks"]["open"][0],
+                )
 
     def test_none_blocked_by_no_field(self):
         """blocked_by is None → field absent."""
@@ -173,11 +188,11 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         self.assertEqual(open_tasks[1]["stackable_blocker_pr"]["author"], "other")
 
     def test_free_text_blocked_by_no_field(self):
-        """Free-text, URL, or legacy-T-NNN blocked_by values don't match regex → field absent."""
+        """blocked_by values that reference zero issues (free text, a bare
+        URL with no #ref, legacy T-NNN) → field absent."""
         values = [
             "pending design",
             "https://github.com/x/y/issues/1",
-            "#101 (waiting)",
             "T-101",
         ]
         for value in values:
@@ -190,6 +205,22 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
                     "stackable_blocker_pr",
                     state["repos"]["engine"]["tasks"]["open"][0],
                 )
+
+    def test_single_ref_with_prose_enriched(self):
+        """A single #ref followed by explanatory prose still stacks. The epic
+        decomposer emits "#NNN (why)"; the old terse-only gate silently
+        dropped the whole chain (#1309 blocked_by "#1308 (T1 must land
+        first…)" never stacked on #1316, observed 2026-05-28)."""
+        tasks = [_task("#1309", "#1308 (T1 must land first; stack on its PR)")]
+        prs = [_pr(1316, "claude/1308-per-axis-trixel-canvas-infra",
+                   author="jakildev")]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 1316)
+        self.assertEqual(task["stackable_blocker_pr"]["headRefName"],
+                         "claude/1308-per-axis-trixel-canvas-infra")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The scout's stackable-blocker enricher (`enrich_stackable_blocker_prs`) only
attaches `stackable_blocker_pr` to a task when its `blocked_by` field matches
`SINGLE_TASK_BLOCKER_RE = ^#\d+$` — i.e. the **entire** field must be exactly
`#NNN`. The epic decomposer routinely writes explanatory prose after the ref:

```
#1309  blocked_by: "#1308 (T1 must be implemented … worker should stack-claim on T1's PR)"
#1310  blocked_by: "#1309"
```

So `#1309` failed the gate, never got a `stackable_blocker_pr`, and the whole
`T1→T2→T3→T4` chain (#1308→#1309→#1310→#1311) could never stack — while the
terse-authored `#1310` enriched fine. The only difference was the prose.
Observed live on **#1309 → PR #1316, 2026-05-28**: the downstream task sat
through the upstream's entire review cycle instead of stacking on its open PR.

## Fix

Replace the whole-field regex with `_single_blocker_issue()`: a value is a
single blocker when it references **exactly one** issue
(`len(re.findall(r"#(\d+)", …)) == 1`).

- ✅ `#1308 (why)` → single blocker `#1308` (the case that was dropping chains)
- ✅ `#A, #B` **and** `#A and #B` → two refs → multi-blocker, rejected. This is
  *more* robust than a bare regex relaxation, which would have matched
  `#A and #B` as a single blocker.
- ✅ `(none)`, free text, a bare URL, legacy `T-101` → zero refs → rejected.

Everything else in the enricher (single-PR-match, multi-match safety, design-block
filter, area-overlap filter, cross-repo isolation) is unchanged.

## ⚠️ Behavior reversal — please note

The prior tests **intentionally** asserted that `#101 (waiting)` should *not*
stack (it was bucketed with free text). This PR makes a single ref + prose a
**pass-through**. The test moves from the negative list into a new positive
case (`test_single_ref_with_prose_enriched`), and `test_two_refs_with_prose_no_field`
is added to lock in the multi-blocker rejection.

## Tests

`python3 scripts/fleet/tests/test_enrich_stackable_blocker_prs.py` — **14 pass**
(12 prior + 2 new). Scout parses clean; `SINGLE_TASK_BLOCKER_RE` is fully removed
(only had the one call site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
