### PR TITLE
fleet: atomic amend-claim so reviewers don't race fleet:needs-fix fixes

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -105,13 +105,16 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
    `fleet:human-amending`, `fleet:human-deferred`,
    `fleet:semantic-conflict`, `fleet:fork-of-other-pr`, or carrying
    any label starting with `fleet:reviewing-` (another reviewer holds
-   the atomic claim — see step 2 below) — those are
+   the atomic claim — see step 2 below) or `fleet:amending-` (the
+   author holds an atomic claim while fixing `fleet:needs-fix`; the
+   diff is mid-rewrite and re-enters with `fleet:changes-made` when
+   released) — those are
    either in-progress, human-owned, under active author fixes
-   (`fleet:human-amending`), in DEFER mode where the human decides
-   to merge as-is or re-flag (`fleet:human-deferred` — do NOT
-   re-apply `fleet:needs-fix` for deferred concerns), queued for
-   conflict resolution (diff against master is meaningless until the
-   rebase lands), or forked from another open PR (diff includes
+   (`fleet:human-amending` / `fleet:amending-*`), in DEFER mode where
+   the human decides to merge as-is or re-flag (`fleet:human-deferred`
+   — do NOT re-apply `fleet:needs-fix` for deferred concerns), queued
+   for conflict resolution (diff against master is meaningless until
+   the rebase lands), or forked from another open PR (diff includes
    inherited commits that don't belong to this PR's scope — skip
    until the human runs `rebase --onto` and clears this label).
 

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -89,6 +89,10 @@ treat it as a hard rule for this role.
      feedback is being addressed.
    - `fleet:human-amending` — author agent is actively addressing
      human feedback. Hold review until `fleet:changes-made` appears.
+   - `fleet:amending-*` — author agent holds an atomic claim while
+     fixing `fleet:needs-fix`. The diff is mid-rewrite; the scout
+     projection already excludes these, so you should never see one.
+     Re-enters with `fleet:changes-made` when the claim releases.
    - `fleet:human-deferred` — author chose DEFER mode: acknowledged
      concerns, filed a follow-up issue, and the human decides to
      merge as-is or re-add `human:needs-fix` to force inline fixes.
@@ -123,6 +127,8 @@ iteration of polling, reviewing, and exiting cleanly:
    - `human:wip` — human is working on it
    - `human:needs-fix` — human feedback is being addressed
    - `fleet:human-amending` — author actively addressing human feedback
+   - `fleet:amending-*` — author holds an amend claim on a `fleet:needs-fix`
+     fix; scout already excludes these (re-enters with `fleet:changes-made`)
    - `fleet:human-deferred` — DEFER mode; human decides to merge or re-flag
    - `fleet:semantic-conflict` — merger conflict pending resolution
    - `fleet:fork-of-other-pr` — inherited commits; skip until `rebase --onto`

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -102,6 +102,9 @@ diff round-trip on PRs that are not reviewable:
   in an unsettled state.
 - `fleet:wip` — author marked the PR not-ready after the cache snapshot.
 - `human:wip` — human marked the PR not-ready after the cache snapshot.
+- any `fleet:amending-*` label — an author acquired the amend claim (started
+  fixing `fleet:needs-fix`) after the cache snapshot; the diff is mid-rewrite.
+  It re-enters with `fleet:changes-made` once released.
 
 If any bail label is present, release the claim and skip this PR without
 fetching the diff or posting any comment:

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -197,8 +197,32 @@ If the wrapper fails (e.g. fetch error), **do NOT remove the
 feedback label**. Skip this PR and move to the next iteration —
 the label stays on the PR so a retry has something to pick up.
 
-With checkout confirmed, **remove the feedback label** to prevent
-another agent from also picking it up:
+**For `fleet:needs-fix`: acquire the amend claim before clearing
+the label.** `fleet:needs-fix` is the PR's only verdict label, so
+removing it leaves the PR verdict-less — indistinguishable from a
+fresh reviewable PR until `fleet:changes-made` lands. Without a
+marker over that window a reviewer poll claims and reviews the diff
+you're mid-rewrite on (observed on PR #1316, 2026-05-28). Acquire an
+atomic per-host claim — reviewers skip any `fleet:amending-*` PR
+(a `REVIEW_SKIP_PREFIXES` match), and the lex-min tie-break also
+prevents two workers from both grabbing the same flagged PR:
+
+```
+fleet-claim amending-claim <N> <your-worktree-basename>
+```
+
+If the claim fails (lost the tie-break, or `gh` unreachable),
+**do NOT remove the feedback label** — another worker owns the
+amendment, or a retry will. Skip this PR and move on. Released in
+step e alongside `fleet:changes-made`; an abandoned claim is swept
+by `fleet-claim cleanup --gh` on the 30-min TTL. Skip this claim for
+`fleet:has-nits` / `fleet:design-unblocked` (they keep
+`fleet:approved`, so the PR never goes verdict-less) and for the
+`human:*` paths (covered by `fleet:human-amending` below).
+
+With checkout confirmed (and, for `fleet:needs-fix`, the amend claim
+held), **remove the feedback label** to prevent another agent from
+also picking it up:
 
 ```
 fleet-pr-clear-feedback-labels <N>
@@ -304,9 +328,15 @@ Per original feedback label:
   gh pr edit <N> --remove-label "fleet:human-amending" --add-label "fleet:changes-made"
   ```
 - **`fleet:needs-fix`** — add `fleet:changes-made` so the reviewer
-  knows new commits arrived and should re-verify:
+  knows new commits arrived and should re-verify, **then** release
+  the amend claim. Order matters: add `fleet:changes-made` first so
+  the PR is never label-less between dropping the amend claim and
+  re-entering the review queue (while both are present the reviewer
+  still skips on the `fleet:amending-*` prefix; once the claim drops,
+  `fleet:changes-made` re-triggers review via `RECHECK_LABELS`):
   ```
   gh pr edit <N> --add-label "fleet:changes-made"
+  fleet-claim amending-release <N> <your-worktree-basename>
   ```
 - **`fleet:has-nits`** — no response label needed; the existing
   `fleet:approved` stays valid (cleanups don't invalidate approval).
@@ -411,9 +441,13 @@ Human can add multiple comments before re-tagging; ALL are picked
 up when the tag appears.
 
 **Fleet feedback cycle:** fleet reviewer adds `fleet:needs-fix` →
-author removes it (via the wrapper), fixes, pushes, adds
-`fleet:changes-made` → fleet reviewer sees the new commits on next
-poll and re-reviews.
+author acquires the `fleet:amending-<host>-<agent>` claim, removes
+`fleet:needs-fix` (via the wrapper), fixes, pushes, adds
+`fleet:changes-made` and releases the claim → fleet reviewer sees
+the new commits on next poll and re-reviews. The amend claim keeps
+reviewers off the PR for the whole fix (mirrors `fleet:human-amending`
+on the human path) and tie-breaks two workers racing the same
+flagged PR.
 
 **Design-unblocked cycle** (opus-worker only): the worker hits a
 mid-task design blocker and sets `fleet:design-blocked`; the

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -882,6 +882,22 @@ Specifically, **never pass these via `--label` when filing**:
   The scout's `fleet-claim cleanup --gh` pass sweeps labels older
   than 30 min and replays orphan sentinels from failed removals.
   Don't add manually; don't add to issues.
+- `fleet:amending-<host>-<agent>` — owned by the **`fleet-claim`
+  script** (atomic amend-claim primitive; same lex-min tie-break as
+  `fleet:reviewing-`). Applied by the **author worker** at the start
+  of a `fleet:needs-fix` amendment — `fleet-claim amending-claim`,
+  before it removes `fleet:needs-fix` — and removed by
+  `fleet-claim amending-release` once `fleet:changes-made` is set, or
+  swept on abort. It closes the gap that `fleet:needs-fix` is the
+  PR's only verdict label: once removed the PR is verdict-less and a
+  reviewer poll would otherwise claim and review the diff mid-rewrite
+  (observed on PR #1316, 2026-05-28). Reviewer projections **skip any
+  PR carrying a `fleet:amending-*` label** (a `REVIEW_SKIP_PREFIXES`
+  match in `fleet-state-scout`) — the host-suffixed analogue of the
+  static `fleet:human-amending` skip, doubling as a fixer-vs-fixer
+  mutex. The scout's `fleet-claim cleanup --gh` pass sweeps labels
+  older than 30 min and replays orphan sentinels. Don't add manually;
+  don't add to issues.
 - `fleet:human-amending` / `fleet:human-deferred` — owned by the
   **author worker** (sonnet-author / opus-worker) when picking up
   `human:needs-fix`. The two labels express which disposition the

--- a/docs/agents/REVIEWER-PROTOCOL.md
+++ b/docs/agents/REVIEWER-PROTOCOL.md
@@ -51,6 +51,15 @@ The queue-tick's `cleanup --gh` pass sweeps stranded
 `fleet:reviewing-*` labels after 30 min, but forgetting blocks
 re-review during that window — always release explicitly.
 
+You will never be handed a PR an author is actively amending: a
+worker fixing `fleet:needs-fix` holds a `fleet:amending-<host>-<agent>`
+claim for the whole fix, and the scout projection excludes any
+`fleet:amending-*` PR from your candidate list (a
+`REVIEW_SKIP_PREFIXES` match, the host-suffixed analogue of the
+`fleet:human-amending` skip). It re-enters your queue with
+`fleet:changes-made` once the worker releases the claim. No action
+on your part — just don't expect to see mid-amend PRs.
+
 ---
 
 ## Stack awareness — gate on upstream status, then note context

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -7,8 +7,8 @@
 #
 # Same-host atomicity: atomic mkdir(2) under $CLAIMS_DIR. Cross-host
 # atomicity: a `fleet:claim-<host>-<agent>` label on the linked issue
-# with lex-min tie-break (the same primitive used by review-claim and
-# resolving-claim).
+# with lex-min tie-break (the same primitive used by review-claim,
+# resolving-claim, and amending-claim).
 #
 # Slug canonicalization: the issue number itself, optionally prefixed
 # with the global --repo namespace (engine → "<N>", game → "game-<N>").
@@ -27,6 +27,8 @@
 #   fleet-claim review-release <pr-number> <agent>
 #   fleet-claim resolving-claim <pr-number> <agent>
 #   fleet-claim resolving-release <pr-number> <agent>
+#   fleet-claim amending-claim <pr-number> <agent>
+#   fleet-claim amending-release <pr-number> <agent>
 #   fleet-claim clear-all
 #   fleet-claim stack "<n1> <n2> ..." <agent>
 #   fleet-claim release-stack <agent>
@@ -148,6 +150,7 @@ slugify() {
 # The same _acquire_label_on primitive backs:
 #   - fleet:reviewing-<host>-<agent>  (reviewer + cross-host smoke claim)
 #   - fleet:resolving-<host>-<agent>  (semantic-conflict claim)
+#   - fleet:amending-<host>-<agent>   (fleet:needs-fix amendment claim)
 #   - fleet:claim-<host>-<agent>      (task claim)
 #
 # Host disambiguation is required for correctness — two hosts can both
@@ -917,9 +920,10 @@ cmd_release() {
 }
 
 # _cmd_pr_label_claim <prefix> <cmd-name> <pr-num> <agent>
-#   Shared implementation for review-claim and resolving-claim.
-#   Both commands use the same lex-min tie-break logic with different
-#   label prefixes; extract here to avoid 100% structural duplication.
+#   Shared implementation for review-claim, resolving-claim, and
+#   amending-claim. All use the same lex-min tie-break logic with
+#   different label prefixes; extract here to avoid 100% structural
+#   duplication.
 _cmd_pr_label_claim() {
     local prefix="$1" cmd_name="$2" pr="$3" agent="${4:-unknown}"
     if [[ ! "$pr" =~ ^[0-9]+$ ]]; then
@@ -949,7 +953,8 @@ _cmd_pr_label_claim() {
 }
 
 # _cmd_pr_label_release <prefix> <cmd-name> <pr-num> <agent>
-#   Shared implementation for review-release and resolving-release.
+#   Shared implementation for review-release, resolving-release, and
+#   amending-release.
 _cmd_pr_label_release() {
     local prefix="$1" cmd_name="$2" pr="$3" agent="${4:-unknown}"
     if [[ ! "$pr" =~ ^[0-9]+$ ]]; then
@@ -972,6 +977,8 @@ cmd_review_claim()   { _cmd_pr_label_claim   "fleet:reviewing-" "review-claim"  
 cmd_review_release() { _cmd_pr_label_release "fleet:reviewing-" "review-release" "$@"; }
 cmd_resolving_claim()   { _cmd_pr_label_claim   "fleet:resolving-" "resolving-claim"   "$@"; }
 cmd_resolving_release() { _cmd_pr_label_release "fleet:resolving-" "resolving-release" "$@"; }
+cmd_amending_claim()   { _cmd_pr_label_claim   "fleet:amending-" "amending-claim"   "$@"; }
+cmd_amending_release() { _cmd_pr_label_release "fleet:amending-" "amending-release" "$@"; }
 
 cmd_check() {
     # Exit 0 = free, exit 1 = claimed.
@@ -1054,8 +1061,8 @@ cmd_cleanup() {
     # Remove claims whose linked issue has been closed (typically via a
     # merged "Closes #N" PR). Accepts zero or more --repo flags; defaults
     # to jakildev/IrredenEngine. With --gh, ALSO sweeps stale
-    # fleet:reviewing-* / fleet:resolving-* labels off open PRs and
-    # abandoned fleet:claim-* labels off OPEN issues (no matching
+    # fleet:reviewing-* / fleet:resolving-* / fleet:amending-* labels off
+    # open PRs and abandoned fleet:claim-* labels off OPEN issues (no matching
     # claude/<N>-* PR + TTL). Claim labels on CLOSED issues are kept
     # as a historical record.
     mkdir -p "$CLAIMS_DIR"
@@ -1145,7 +1152,7 @@ for pr in prs:
     n = pr.get("number")
     for l in (pr.get("labels") or []):
         name = (l or {}).get("name", "") if isinstance(l, dict) else ""
-        if name.startswith("fleet:reviewing-") or name.startswith("fleet:resolving-"):
+        if name.startswith("fleet:reviewing-") or name.startswith("fleet:resolving-") or name.startswith("fleet:amending-"):
             print(f"{n}\t{name}")
 ' 2>/dev/null || echo "")
 
@@ -2536,6 +2543,20 @@ case "${1:-}" in
         fi
         cmd_resolving_release "$2" "$3"
         ;;
+    amending-claim)
+        if [[ -z "${3:-}" ]]; then
+            echo "usage: fleet-claim [--repo <ns>] amending-claim <pr-number> <agent>" >&2
+            exit 2
+        fi
+        cmd_amending_claim "$2" "$3"
+        ;;
+    amending-release)
+        if [[ -z "${3:-}" ]]; then
+            echo "usage: fleet-claim [--repo <ns>] amending-release <pr-number> <agent>" >&2
+            exit 2
+        fi
+        cmd_amending_release "$2" "$3"
+        ;;
     clear-all)
         cmd_clear_all
         ;;
@@ -2697,8 +2718,9 @@ commands:
                                 Remove claims whose linked issue is
                                 CLOSED. With --gh also runs two
                                 GitHub sweeps:
-                                (1) stale fleet:reviewing-* and
-                                    fleet:resolving-* labels off open
+                                (1) stale fleet:reviewing-*,
+                                    fleet:resolving-*, and
+                                    fleet:amending-* labels off open
                                     PRs (>30 min age),
                                 (2) fleet:claim-* labels off open
                                     issues where the claim is
@@ -2718,6 +2740,12 @@ commands:
                                 conflict resolution.
   resolving-release <pr> <agent>
                                 release a conflict-resolution claim.
+  amending-claim <pr> <agent>   atomically claim a PR for a
+                                fleet:needs-fix amendment via a
+                                fleet:amending-<host>-<agent> label
+                                (reviewers skip the PR while held).
+  amending-release <pr> <agent>
+                                release an amendment claim.
   clear-all                     wipe all claims (used by fleet-up on
                                 restart).
   reset-sweep-host-claims       unconditionally remove this host's

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -133,6 +133,10 @@ LABELS=(
     # first use) and removed by the verdict label-swap or by
     # `fleet-claim review-release`. Queue-tick's `fleet-claim cleanup --gh`
     # pass sweeps stale ones (>30 min) and replays orphan sentinels.
+    # Siblings on the same dynamic-PR-label pattern: fleet:resolving-* (the
+    # semantic-conflict claim) and fleet:amending-* (the fleet:needs-fix
+    # amendment claim — held by the author worker so reviewers skip the PR
+    # mid-fix). Both created/swept exactly like fleet:reviewing-*.
     #
     # Sibling: fleet:claim-<host>-<agent> on **issues** (not PRs) — stamped
     # by `fleet-claim claim` after FS lock + master push succeed. Generic

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -686,7 +686,23 @@ REVIEW_SKIP_LABELS = frozenset({
     # appears (which RECHECK_LABELS picks up).
     "fleet:human-amending",
 })
+# Dynamic per-host claim prefixes that also bar reviewer pickup. A worker
+# amending a fleet:needs-fix PR holds fleet:amending-<host>-<agent> (minted
+# by `fleet-claim amending-claim`) for the whole fix; reviewers must not
+# review a diff mid-amend. Same intent as the static fleet:human-amending
+# above, but host-suffixed so the label doubles as an atomic fixer-vs-fixer
+# claim. Released alongside fleet:changes-made, which re-triggers review via
+# RECHECK_LABELS.
+REVIEW_SKIP_PREFIXES = ("fleet:amending-",)
 RECHECK_LABELS = frozenset({"human:re-review", "fleet:changes-made"})
+
+
+def _review_skipped(labels):
+    """True if a PR's label set bars reviewer pickup — exact-name skip
+    labels or any dynamic per-host claim prefix (e.g. fleet:amending-*)."""
+    if labels & REVIEW_SKIP_LABELS:
+        return True
+    return any(l.startswith(p) for l in labels for p in REVIEW_SKIP_PREFIXES)
 
 # Smoke-worker label sets. Windows smoke is excluded — cleared by
 # platform-catchup (#1093), not by fleet agents.
@@ -934,7 +950,7 @@ def project_sonnet_reviewer(state):
     for repo, repo_state in state["repos"].items():
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
-            if labels & REVIEW_SKIP_LABELS:
+            if _review_skipped(labels):
                 continue
             if pr.get("isDraft"):
                 continue
@@ -954,7 +970,7 @@ def project_opus_reviewer(state):
     for repo, repo_state in state["repos"].items():
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
-            if labels & REVIEW_SKIP_LABELS:
+            if _review_skipped(labels):
                 continue
             if not (labels & flag_labels):
                 continue
@@ -1174,7 +1190,7 @@ def slice_sonnet_reviewer(state):
     for repo_key, repo_state in state["repos"].items():
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
-            if labels & REVIEW_SKIP_LABELS:
+            if _review_skipped(labels):
                 continue
             if pr.get("isDraft"):
                 continue
@@ -1192,7 +1208,7 @@ def slice_opus_reviewer(state):
     for repo_key, repo_state in state["repos"].items():
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
-            if labels & REVIEW_SKIP_LABELS:
+            if _review_skipped(labels):
                 continue
             if not (labels & flag_labels):
                 continue

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -29,6 +29,7 @@ _loader.exec_module(_mod)
 project_sonnet_author = _mod.project_sonnet_author
 project_opus_worker = _mod.project_opus_worker
 project_opus_reviewer = _mod.project_opus_reviewer
+project_sonnet_reviewer = _mod.project_sonnet_reviewer
 stable_hash = _mod.stable_hash
 
 
@@ -260,6 +261,47 @@ class OpusReviewerActionableTransitionsFlipHash(unittest.TestCase):
             "fleet:needs-fix", "fleet:merger-cooldown",
         ])])
         self.assertNotEqual(before, after)
+
+
+class AmendingClaimBarsReviewerPickup(unittest.TestCase):
+    """A worker amending a fleet:needs-fix PR holds a host-suffixed
+    fleet:amending-<host>-<agent> claim for the whole fix. Reviewers must
+    not review a diff mid-amend; the claim is a REVIEW_SKIP_PREFIXES match.
+    Closes the gap observed on PR #1316 (2026-05-28): the worker cleared
+    fleet:needs-fix to start fixing, leaving the PR with no skip label, so
+    a reviewer poll claimed and reviewed it mid-rewrite."""
+
+    def _sonnet(self, prs):
+        return project_sonnet_reviewer(_state(prs))
+
+    def _opus(self, prs):
+        return project_opus_reviewer(_state(prs))
+
+    def test_amending_drops_pr_from_sonnet_reviewer(self):
+        # needs-fix cleared, amend claim held -> not reviewable.
+        held = self._sonnet([_pr(101, labels=["fleet:amending-mac-sonnet-fleet-1"])])
+        self.assertEqual(held, [])
+
+    def test_amending_plus_needs_fix_drops_pr_from_opus_reviewer(self):
+        # Brief window before the worker removes needs-fix: still skipped.
+        held = self._opus([_pr(101, labels=[
+            "fleet:needs-fix", "fleet:amending-mac-opus-worker-1",
+        ])])
+        self.assertEqual(held, [])
+
+    def test_release_then_changes_made_re_enters_sonnet_reviewer(self):
+        # amend claim released, fleet:changes-made added -> recheck fires.
+        before = stable_hash(self._sonnet([
+            _pr(101, labels=["fleet:amending-mac-sonnet-fleet-1"])]))
+        after = stable_hash(self._sonnet([
+            _pr(101, labels=["fleet:changes-made"])]))
+        self.assertNotEqual(before, after)
+        self.assertEqual(len(self._sonnet([
+            _pr(101, labels=["fleet:changes-made"])])), 1)
+
+    def test_plain_needs_fix_unaffected(self):
+        # No amend claim -> opus-reviewer still sees the flagged PR.
+        self.assertEqual(len(self._opus([_pr(101, labels=["fleet:needs-fix"])])), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When a worker addresses a `fleet:needs-fix` PR it removes the label to begin
fixing. But `fleet:needs-fix` is the PR's **only** verdict label — once it's
gone the PR is verdict-less, indistinguishable from a fresh reviewable PR,
until `fleet:changes-made` lands after the push. With nothing marking that
window, a reviewer poll can claim and review a diff that's being actively
rewritten.

**Observed on [#1316](https://github.com/jakildev/IrredenEngine/pull/1316), 2026-05-28:**

```
21:00:02  −fleet:needs-fix                      worker starts fixing
            ── PR now carries no verdict / skip label ──
21:05:13  +fleet:reviewing-mac-sonnet-reviewer  reviewer claims mid-fix
21:07:12  +fleet:changes-made                   worker finishes pushing
21:07:39  reviewed                              verdict on a diff that just changed underneath it
```

The human-feedback path already covered its window with `fleet:human-amending`
(a reviewer skip label). The fleet-feedback path had no equivalent.

## Fix

Mint `fleet:amending-<host>-<agent>` — the host-suffixed analogue, via the same
atomic lex-min claim primitive as `fleet:reviewing-`/`fleet:resolving-`, so it
**also** tie-breaks two workers racing the same flagged PR.

- **`fleet-claim`** — `amending-claim` / `amending-release` subcommands (thin
  wrappers over the shared `_cmd_pr_label_claim`/`_release`), dispatch,
  usage/help, and `cleanup --gh` sweeps stale `fleet:amending-*` on the same
  30-min TTL as the sibling claims.
- **`fleet-state-scout`** — `REVIEW_SKIP_PREFIXES` + `_review_skipped()` route
  all four reviewer projection/slice sites to skip any `fleet:amending-*` PR.
- **`FLEET-FEEDBACK-HANDLING`** — step b acquires the claim *before* clearing
  `fleet:needs-fix` (skip the PR if the claim is lost); step e adds
  `fleet:changes-made` **then** releases, so there's no label-less gap.
- **Docs / role / skill** — FLEET.md label dictionary, `fleet-labels` note,
  REVIEWER-PROTOCOL + both reviewer role-doc skip-lists, and a live bail-label
  TOCTOU guard in the `review-pr` skill.

Scoped to `fleet:needs-fix`: `fleet:has-nits` / `fleet:design-unblocked` keep
`fleet:approved` (never go verdict-less), and the `human:*` paths already have
`fleet:human-amending`.

## Lifecycle

```
needs-fix → [worker] amending-claim → −needs-fix → fix+push → +changes-made → amending-release → [reviewer re-reviews]
```

On abort (build fails, worker bails), the claim lingers until the `cleanup --gh`
30-min sweep — identical backstop to a stranded `fleet:reviewing-*` claim.

## Tests

`python3 scripts/fleet/tests/test_worker_projection.py` — **25 pass** (21 prior
+ 4 new: mid-amend skip, brief-window skip, post-release recheck re-fires,
plain-needs-fix unaffected). `bash -n` clean on `fleet-claim`; scout parses;
`test_enrich_stackable_blocker_prs.py` unaffected (12 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
