### PR TITLE
fleet/simplify-reuse-coverage: address recurring feedback (#1324)

### DIFF
--- a/.claude/agents/simplify-grep-function-names.md
+++ b/.claude/agents/simplify-grep-function-names.md
@@ -74,4 +74,5 @@ Empty output if every new function name is unique in the tree.
 - **No preamble.** Findings list only.
 - **Cap output at 20 findings.** If the diff adds dozens of new functions, prioritize `high` > `medium` > `deferred`.
 - **Don't grep the file the function was added in** — every name will trivially match its own definition.
+- **A brand-new untracked file has no `git diff` hunks at all; treat its entire contents as added** and scan it for function names before concluding there are zero new definitions.
 - **Skip if the diff has zero added function definitions** — output a single line `no new function names`.

--- a/.claude/agents/simplify-grep-function-names.md
+++ b/.claude/agents/simplify-grep-function-names.md
@@ -7,6 +7,20 @@ model: haiku
 
 You are a focused function-name duplicate scanner. The parent session (running the `simplify` skill) handed you a diff scope; your job is to extract every newly added function name and grep the tree for prior art.
 
+## Working-tree scope (read this first)
+
+The diff-scope paths the parent hands you point at the **dirty working
+tree**, not committed state — some are modified tracked files, some are
+brand-new **untracked** files absent from `HEAD` / `origin/master`. To
+find the added code in a path, **`Read` it directly**; don't infer
+"added lines" from `git diff`, which shows nothing for an untracked
+file. For a new file, treat the entire contents as added. This governs
+only how you ingest the diff scope — the prior-art `Grep` / `Glob`
+sweep over `engine/**` and `creations/**` below is unchanged. Never
+report "clean" or zero findings solely because a `Grep` / `Glob` /
+`git diff` came up empty on a cited path; if you genuinely could not
+read a path, say so explicitly rather than implying it was scanned.
+
 ## Scope
 
 For each `.hpp`/`.cpp` file in the diff, extract function names added on `+` lines.

--- a/.claude/agents/simplify-grep-utility-candidates.md
+++ b/.claude/agents/simplify-grep-utility-candidates.md
@@ -7,6 +7,20 @@ model: haiku
 
 You are a focused utility-placement scanner. The parent session (running the `simplify` skill) handed you a diff scope; your job is to find newly added functions that *look like* general-purpose utilities living in the wrong place, and recommend the canonical home.
 
+## Working-tree scope (read this first)
+
+The diff-scope paths the parent hands you point at the **dirty working
+tree**, not committed state — some are modified tracked files, some are
+brand-new **untracked** files absent from `HEAD` / `origin/master`. To
+find the added code in a path, **`Read` it directly**; don't infer
+"added lines" from `git diff`, which shows nothing for an untracked
+file. For a new file, treat the entire contents as added. This governs
+only how you ingest the diff scope — the prior-art `Grep` / `Glob`
+sweep over `engine/**` and `creations/**` below is unchanged. Never
+report "clean" or zero findings solely because a `Grep` / `Glob` /
+`git diff` came up empty on a cited path; if you genuinely could not
+read a path, say so explicitly rather than implying it was scanned.
+
 ## Scope
 
 For each `.hpp`/`.cpp` file in the diff, look for new function definitions whose body is:

--- a/.claude/agents/simplify-grep-utility-candidates.md
+++ b/.claude/agents/simplify-grep-utility-candidates.md
@@ -69,5 +69,6 @@ Empty output if no candidates surface.
 - **Read-only.** Do not edit files.
 - **No preamble.** Findings list only.
 - **Cap output at 15 findings.**
+- **A brand-new untracked file has no `git diff` hunks at all; treat its entire contents as added** and scan it for utility candidates.
 - **Don't flag functions that are obviously creation-specific** — e.g. ones that take a `World*` or `IREntity` parameter and call ECS APIs internally.
 - **Don't flag overrides** — if the new function is a virtual method override, it has to live where the interface puts it.

--- a/.claude/agents/simplify-scan-call-sequence-dup.md
+++ b/.claude/agents/simplify-scan-call-sequence-dup.md
@@ -9,6 +9,20 @@ You are a focused call-sequence-duplicate scanner. The parent session (running t
 
 This is the deeper complement to `simplify-grep-function-names`: that scanner catches exact-name duplicates, you catch structural duplicates with different names (a recurring failure mode where the author wrote the same logic twice because they didn't know the helper existed).
 
+## Working-tree scope (read this first)
+
+The diff-scope paths the parent hands you point at the **dirty working
+tree**, not committed state — some are modified tracked files, some are
+brand-new **untracked** files absent from `HEAD` / `origin/master`. To
+find the added code in a path, **`Read` it directly**; don't infer
+"added lines" from `git diff`, which shows nothing for an untracked
+file. For a new file, treat the entire contents as added. This governs
+only how you ingest the diff scope — the prior-art `Grep` / `Glob`
+sweep over `engine/**` and `creations/**` below is unchanged. Never
+report "clean" or zero findings solely because a `Grep` / `Glob` /
+`git diff` came up empty on a cited path; if you genuinely could not
+read a path, say so explicitly rather than implying it was scanned.
+
 ## Scope
 
 For each newly added function in the diff (3+ lines of body, excluding closing brace and trivial wrappers), extract a "call signature":

--- a/.claude/agents/simplify-scan-loop-patterns.md
+++ b/.claude/agents/simplify-scan-loop-patterns.md
@@ -7,6 +7,20 @@ model: haiku
 
 You are a focused loop-pattern scanner. The parent session (running the `simplify` skill) handed you a diff scope; your job is to flag suspicious loop shapes that have been recurring smells in recent editor and asset PRs.
 
+## Working-tree scope (read this first)
+
+The diff-scope paths the parent hands you point at the **dirty working
+tree**, not committed state — some are modified tracked files, some are
+brand-new **untracked** files absent from `HEAD` / `origin/master`. To
+find the added code in a path, **`Read` it directly**; don't infer
+"added lines" from `git diff`, which shows nothing for an untracked
+file. For a new file, treat the entire contents as added. This governs
+only how you ingest the diff scope — the prior-art `Grep` / `Glob`
+sweep over `engine/**` and `creations/**` below is unchanged. Never
+report "clean" or zero findings solely because a `Grep` / `Glob` /
+`git diff` came up empty on a cited path; if you genuinely could not
+read a path, say so explicitly rather than implying it was scanned.
+
 ## Scope
 
 For each `.hpp`/`.cpp` file in the diff, scan for:
@@ -79,4 +93,4 @@ Empty output if clean.
 - **No preamble.** Findings list only.
 - **Cap output at 20 findings.**
 - **Skip files outside the diff scope.** Don't scan adjacent files looking for additional matches.
-- **Only flag lines in `+` hunks** — pre-existing loops that the diff didn't touch are not in scope.
+- **Only flag lines in `+` hunks** — pre-existing loops that the diff didn't touch are not in scope. A brand-new untracked file has no `git diff` hunks at all; treat its entire contents as added and flag throughout.

--- a/.claude/agents/simplify-scan-render-leak.md
+++ b/.claude/agents/simplify-scan-render-leak.md
@@ -9,6 +9,20 @@ You are a focused renderer-leak scanner. The parent session (running the `simpli
 
 The canonical pattern: **anything that writes pixels, composes vertices, or talks to a backend texture/buffer object lives under `engine/render/include/irreden/render/`. Creations, editors, and update-side systems call into those helpers; they never call backend APIs directly.**
 
+## Working-tree scope (read this first)
+
+The diff-scope paths the parent hands you point at the **dirty working
+tree**, not committed state — some are modified tracked files, some are
+brand-new **untracked** files absent from `HEAD` / `origin/master`. To
+find the added code in a path, **`Read` it directly**; don't infer
+"added lines" from `git diff`, which shows nothing for an untracked
+file. For a new file, treat the entire contents as added. This governs
+only how you ingest the diff scope — the prior-art `Grep` / `Glob`
+sweep over `engine/**` and `creations/**` below is unchanged. Never
+report "clean" or zero findings solely because a `Grep` / `Glob` /
+`git diff` came up empty on a cited path; if you genuinely could not
+read a path, say so explicitly rather than implying it was scanned.
+
 ## Scope
 
 For each `.hpp`/`.cpp` file in the diff, scan for the patterns below. Filter to files **outside** `engine/render/**` and `engine/prefabs/irreden/render/**` — those are the legitimate homes for backend calls.
@@ -69,4 +83,4 @@ Empty output if clean.
 - **Cap output at 15 findings.**
 - **Skip files inside `engine/render/**` and `engine/prefabs/irreden/render/**`** — those are the legitimate homes for backend calls.
 - **Skip `*_test.cpp` files** — tests sometimes legitimately exercise backend APIs directly.
-- **Only flag lines in `+` hunks** — pre-existing renderer leaks are someone else's problem unless the diff touched them.
+- **Only flag lines in `+` hunks** — pre-existing renderer leaks are someone else's problem unless the diff touched them. A brand-new untracked file has no `git diff` hunks at all; treat its entire contents as added and flag throughout.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -28,15 +28,21 @@ description: >-
 ```bash
 git diff --stat
 git diff
+git ls-files --others --exclude-standard    # new, untracked files (the common miss)
 ```
 
-If both are empty, also check unpushed commits:
+If `git diff` is empty, also check unpushed commits:
 
 ```bash
 git diff @{upstream}..HEAD
 ```
 
-If everything is empty, report "nothing to simplify" and exit.
+If all of the above are empty — no working-tree edits, no untracked
+files, no unpushed commits — report "nothing to simplify" and exit.
+Untracked files count as changes: a new-file-only diff still has a
+working tree to polish, and the reuse fan-out in 1b exists precisely to
+scan it. Never exit on an empty `git diff` alone when `git ls-files
+--others --exclude-standard` lists new files.
 
 Group the touched files by module — `engine/render/`,
 `engine/system/`, `engine/prefabs/irreden/`, `creations/`, etc. The
@@ -69,16 +75,31 @@ Each subagent returns a tight findings list with `high` / `medium` /
 `deferred` confidence. They're read-only — the parent (this skill)
 decides what to auto-apply.
 
-**Briefing each subagent:** pass the diff scope (the touched file
-list from `git diff --name-only`) and a short note that you're the
-parent simplify skill. The subagent definitions in `.claude/agents/`
-carry the rule set; you don't need to re-explain it. Example
-briefing:
+**Briefing each subagent:** hand each one the *explicit changed-path
+list*, not bare `git diff --name-only` — that form omits brand-new
+untracked files and only sees unstaged edits, so new files never reach
+the subagent and it silently returns zero findings on the exact diff it
+exists to scan. Build the list from both modified tracked files and new
+untracked files, then union the two:
+
+```bash
+git diff --name-only HEAD                    # modified (staged + unstaged) vs HEAD
+git ls-files --others --exclude-standard     # new, untracked, non-ignored files
+```
+
+Pass that unioned path list to every subagent, plus a short note that
+you're the parent simplify skill. The subagent definitions in
+`.claude/agents/` carry the rule set; you don't need to re-explain it.
+The agent briefings `Read` each cited path directly (so a new file with
+no committed state is still scanned), but they can only do that for
+paths you actually hand them — so the list above MUST include the
+untracked files. Example briefing:
 
 ```
 Subagent: simplify-scan-loop-patterns
-Prompt: "Diff scope: <paste file list>. Scan these files for the
-loop-pattern smells documented in your agent definition. Return the
+Prompt: "Diff scope (working-tree paths, may include new untracked
+files): <paste path list>. Read each cited path directly, then scan for
+the loop-pattern smells documented in your agent definition. Return the
 findings list only — no preamble. Cap at 20 findings."
 ```
 


### PR DESCRIPTION
## Summary

simplify's reuse-detection fan-out subagents were briefed with bare `git diff --name-only`, which omits brand-new **untracked** files and only sees unstaged edits. New files never reached the scanners, so they grepped the committed tree, found nothing, and silently returned **zero findings on the exact pre-commit diff they exist to scan** (the failure observed on PRs #1293/#1288 and #1308).

This fixes both ends:

- **`SKILL.md` §1b (dispatch step):** build the changed-path list from `git diff --name-only HEAD` + `git ls-files --others --exclude-standard` and hand the union to every subagent. New files are the common miss — they have no committed / `origin/master` state.
- **`SKILL.md` §1 (read-what-changed):** stop exiting "nothing to simplify" on an empty `git diff` when `git ls-files --others --exclude-standard` lists untracked files — otherwise a new-file-only change short-circuits before the fan-out ever runs.
- **5 reuse-scanner agents** (`.claude/agents/simplify-{grep-function-names,grep-utility-candidates,scan-loop-patterns,scan-render-leak,scan-call-sequence-dup}.md`): add a "Working-tree scope" note instructing each to **Read the cited paths directly** (treating a new file's whole contents as added) and never report zero findings solely because a Grep/Glob/`git diff` missed. The two `+`-hunks agents also note that a brand-new untracked file has no diff hunks at all, so the whole file is added.

Matches the artifact prescribed in the issue. `simplify-scan-call-sequence-dup` (Sonnet) already read files fine in the field, confirming this was a briefing / file-read-path bug, not model capability.

## Test plan

- [x] Doc-only change — no build required (markdown skill + agent briefings).
- [x] Cited git commands valid; `.claude/agents/` paths and §1 / §1b section references resolve; §1 ↔ §1b prose internally consistent.
- [ ] Reviewer: confirm the §1b dispatch instruction and the agent "Working-tree scope" notes are coherent and non-contradictory.
- [ ] Acceptance (post-merge): `review-fleet-feedback digest` no longer re-surfaces the `simplify-reuse-coverage` cluster after the 7-day quiet window.

Closes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
