### PR TITLE
fleet: close gaps in design-escalation handling surfaced by fleet feedback (#1326)

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -269,6 +269,14 @@ the question to the architect and resume cleanly:
    addresses the direction, removes the label, pushes via
    `commit-and-push`. PR re-enters normal review flow.
 
+If at step 3 the worker finds the architect's direction surfaces a
+*further* design decision it can't make, it **re-escalates**: it must
+swap `fleet:design-unblocked` back to `fleet:design-blocked` (not leave
+both on the PR), so the PR returns to escalation limbo instead of being
+re-picked as unblocked next iteration. Use
+`fleet-pr-clear-feedback-labels <N> --labels "fleet:design-unblocked"`
+(a no-op when the label is absent) before adding `fleet:design-blocked`.
+
 Reviewer agents skip `fleet:design-blocked` PRs (they're in
 escalation limbo, not awaiting review). The full per-role procedure
 is in `role-opus-worker.md` (escalate + resume) and
@@ -926,7 +934,11 @@ Specifically, **never pass these via `--label` when filing**:
   "Design-escalation flow" above). `design-blocked` is set by the
   **worker** when it escalates and cleared by the **architect** when
   responding (replaced by `design-unblocked`). `design-unblocked`
-  is then cleared by the **worker** when it picks the PR back up.
+  is then cleared by the **worker** when it picks the PR back up — or,
+  if picking it up surfaces a *further* design decision, swapped back to
+  `design-blocked` (re-escalation). The two labels are mutually
+  exclusive: a PR never carries both, or it would be re-picked as
+  unblocked while actually re-blocked.
   Coexist with `fleet:wip` — they're qualifiers, not transfers of
   ownership. Distinct from `fleet:needs-fix` because the worker
   isn't fixing a defect, they're following architectural direction

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -383,6 +383,26 @@ for line in body.splitlines():
         field_value = m.group(1).strip()
         break
 
+# Fall back to free-form header prose like `## Blocked on #1300` / `Blocked
+# on PR-x` when the canonical field is absent, so a header-only dependency
+# still gates the claim — #1301 slipped through as claimable because its
+# blocker lived in a `Blocked on #1300` header (#1326). Mirrors
+# fleet-state-scout._parse_blocked_by; #1296 covered #N refs INSIDE the
+# field, this covers the header-prose form. Only honor prose that names a #N
+# or PR so an incidental "blocked on the redesign" sentence isn't a gate.
+if field_value is None:
+    blocked_on_re = re.compile(
+        r"^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$",
+        re.IGNORECASE,
+    )
+    for line in body.splitlines():
+        m = blocked_on_re.match(line)
+        if m:
+            cand = m.group(1).strip().strip("*").strip()
+            if cand and ("#" in cand or re.search(r"\bPR\b", cand, re.IGNORECASE)):
+                field_value = cand
+                break
+
 if field_value is None:
     sys.exit(0)
 

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -187,6 +187,19 @@ except Exception:
 # label issues by the same fields the scout reads back out.
 MODEL_RE = re.compile(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
 BLOCKED_RE = re.compile(r'\*\*(?:Suggested\s+)?Blocked by:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
+# Free-form header prose like `## Blocked on #1300` / `Blocked on PR-x` is an
+# alternate dependency declaration the scout's _parse_blocked_by also reads, so
+# don't warn "treat as unblocked" for an issue whose blocker lives only in a
+# header (#1326). Only count prose that names a #N or PR reference.
+BLOCKED_ON_RE = re.compile(r'(?im)^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$')
+
+
+def _has_header_blocker(text):
+    for m in BLOCKED_ON_RE.finditer(text):
+        cand = m.group(1).strip().strip('*').strip()
+        if cand and ('#' in cand or re.search(r'\bPR\b', cand, re.IGNORECASE)):
+            return True
+    return False
 
 stamped = 0
 skipped_already = 0
@@ -231,7 +244,7 @@ for issue in pending:
         model_label = 'fleet:opus'
         print(f'WARN issue {repo}#{n}: **Model:** field missing or unrecognized; defaulting to fleet:opus', file=sys.stderr)
 
-    if not BLOCKED_RE.search(body):
+    if not BLOCKED_RE.search(body) and not _has_header_blocker(body):
         print(f'WARN issue {repo}#{n}: **Blocked by:** field missing; scout will treat as unblocked', file=sys.stderr)
 
     add_labels = ['fleet:queued']

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -276,6 +276,33 @@ def _parse_issue_field(body, field):
     return m.group(1).strip() if m else ""
 
 
+# A dependency may be declared two ways: the canonical `**Blocked by:** #N`
+# field, or free-form header prose like `## Blocked on #1300` / `Blocked on
+# PR-x`. `_parse_blocked_by` prefers the field and falls back to the header
+# form so a header-only dependency still surfaces as blocked — #1301 was
+# mis-listed as claimable (owner=free, blocked_by=(none)) because its blocker
+# lived in a `Blocked on #1300` header the field parser never read (#1326).
+# Complements #1296, which handled #N refs that already live inside the field.
+_BLOCKED_ON_RE = re.compile(
+    r'^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _parse_blocked_by(body):
+    field = _parse_issue_field(body, "Blocked by")
+    if field:
+        return field
+    for m in _BLOCKED_ON_RE.finditer(body or ""):
+        cand = m.group(1).strip().strip("*").strip()
+        # Only treat header prose as a blocker when it actually names a #N
+        # issue or a PR; an incidental "Blocked on the redesign" sentence
+        # must not gate the task forever.
+        if cand and ("#" in cand or re.search(r'\bPR\b', cand, re.IGNORECASE)):
+            return cand
+    return ""
+
+
 def fetch_task_queue(repo_slug):
     """Fetch open task queue from GitHub Issues with the fleet:queued label."""
     issues_out = run_capture([
@@ -329,7 +356,7 @@ def fetch_task_queue(repo_slug):
         in_progress = "fleet:in-progress" in labels or owner != "free"
         status = "~" if in_progress else " "
 
-        blocked_by = _parse_issue_field(body, "Blocked by") or "(none)"
+        blocked_by = _parse_blocked_by(body) or "(none)"
 
         area_parts = [_AREA_LABEL_MAP[l] for l in labels if l in _AREA_LABEL_MAP]
         area = (

--- a/scripts/fleet/tests/test_fleet_claim_blockers.sh
+++ b/scripts/fleet/tests/test_fleet_claim_blockers.sh
@@ -150,6 +150,24 @@ case "$1 $2" in
                 # Parenthetical PR ref, PR closed without merging.
                 printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"**Blocked by:** #100 (PR #202 abandoned)\n"}'
                 ;;
+            2009)
+                # #1326: dependency declared only as `## Blocked on #N` header
+                # prose (no **Blocked by:** field), the referenced issue OPEN.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"## Scope\n\n## Blocked on #101\n\nWork.\n"}'
+                ;;
+            2010)
+                # Header prose, referenced issue CLOSED → no longer a blocker.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"Blocked on #100\n"}'
+                ;;
+            2011)
+                # Header prose with no #N / PR reference → not a real blocker.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"## Blocked on the redesign\n"}'
+                ;;
+            2012)
+                # Canonical field wins over header prose: field says (none),
+                # so the `## Blocked on #101` header must be ignored.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"**Blocked by:** (none — independent)\n\n## Blocked on #101\n"}'
+                ;;
             *)
                 printf '%s' '{"state":"OPEN","labels":[],"body":""}'
                 ;;
@@ -256,6 +274,32 @@ echo "T8: parenthetical PR ref — PR CLOSED-abandoned → claim succeeds (curre
 actual=0; "$FLEET_CLAIM" claim 2008 test-agent 2>/dev/null || actual=$?
 assert_exit "$actual" 0 "#100 CLOSED + #202 CLOSED (abandoned) → exit 0"
 release_quiet 2008
+
+# --- T9: header-prose blocker — `## Blocked on #N`, #N OPEN → fail ----------
+# #1326: a dependency declared only in a `Blocked on #N` header (no
+# **Blocked by:** field) used to slip through as claimable. The gate now reads
+# the header-prose form.
+echo "T9: header prose '## Blocked on #101' — #101 OPEN → claim fails"
+actual=0; "$FLEET_CLAIM" claim 2009 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "header-prose #101 OPEN → exit 1"
+
+# --- T10: header-prose blocker — referenced issue CLOSED → pass --------------
+echo "T10: header prose 'Blocked on #100' — #100 CLOSED → claim succeeds"
+actual=0; "$FLEET_CLAIM" claim 2010 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "header-prose #100 CLOSED → exit 0"
+release_quiet 2010
+
+# --- T11: header prose without a #N / PR ref → not a gate --------------------
+echo "T11: header prose 'Blocked on the redesign' (no ref) → claim succeeds"
+actual=0; "$FLEET_CLAIM" claim 2011 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "ref-less header prose bypasses gate → exit 0"
+release_quiet 2011
+
+# --- T12: canonical field wins over header prose ----------------------------
+echo "T12: field '(none)' overrides a '## Blocked on #101' header → succeeds"
+actual=0; "$FLEET_CLAIM" claim 2012 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "field (none) takes precedence over header prose → exit 0"
+release_quiet 2012
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_issue_queue_parser.py
+++ b/scripts/fleet/tests/test_issue_queue_parser.py
@@ -71,7 +71,7 @@ class ParseBlockedBy(unittest.TestCase):
         # Incidental prose must not gate the task forever.
         self.assertEqual(_mod._parse_blocked_by("Blocked on the redesign\n"), "")
 
-    def test_mid_sentence_blocked_on_ignored(self):
+    def test_line_not_starting_with_blocked_ignored(self):
         self.assertEqual(
             _mod._parse_blocked_by("This was blocked on #99 last week.\n"), "")
 

--- a/scripts/fleet/tests/test_issue_queue_parser.py
+++ b/scripts/fleet/tests/test_issue_queue_parser.py
@@ -46,6 +46,40 @@ class ParseIssueField(unittest.TestCase):
         self.assertEqual(_mod._parse_issue_field(body, "Area"), "scripts/fleet")
 
 
+class ParseBlockedBy(unittest.TestCase):
+    """`_parse_blocked_by` prefers the `**Blocked by:**` field but falls back
+    to free-form `Blocked on #N` / `Blocked on PR-x` header prose (#1326).
+    """
+    def test_prefers_canonical_field(self):
+        body = "**Blocked by:** #50\n\n## Blocked on #99\n"
+        self.assertEqual(_mod._parse_blocked_by(body), "#50")
+
+    def test_falls_back_to_header_prose(self):
+        self.assertEqual(_mod._parse_blocked_by("## Blocked on #1300\n"), "#1300")
+
+    def test_header_prose_plain_line(self):
+        self.assertEqual(_mod._parse_blocked_by("Blocked on #1300 merging\n"),
+                         "#1300 merging")
+
+    def test_header_prose_bold(self):
+        self.assertEqual(_mod._parse_blocked_by("**Blocked on #1300**\n"), "#1300")
+
+    def test_header_prose_pr_token(self):
+        self.assertEqual(_mod._parse_blocked_by("## Blocked on PR-x\n"), "PR-x")
+
+    def test_header_prose_without_ref_is_not_a_blocker(self):
+        # Incidental prose must not gate the task forever.
+        self.assertEqual(_mod._parse_blocked_by("Blocked on the redesign\n"), "")
+
+    def test_mid_sentence_blocked_on_ignored(self):
+        self.assertEqual(
+            _mod._parse_blocked_by("This was blocked on #99 last week.\n"), "")
+
+    def test_empty_body(self):
+        self.assertEqual(_mod._parse_blocked_by(""), "")
+        self.assertEqual(_mod._parse_blocked_by(None), "")
+
+
 class FetchTaskQueueDispatch(unittest.TestCase):
     """Exercise the per-issue loop with synthetic gh output.
 
@@ -159,6 +193,16 @@ class FetchTaskQueueDispatch(unittest.TestCase):
             "body": "",
         }])
         self.assertEqual(out["open"][0]["blocked_by"], "(none)")
+
+    def test_blocked_by_recovers_header_prose(self):
+        # #1326: a dependency declared only as a `Blocked on #N` header must
+        # surface as blocked, not (none).
+        out = self._run([{
+            "number": 100, "title": "b",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "## Scope\n\n## Blocked on #1300\n\nMore.\n",
+        }])
+        self.assertEqual(out["open"][0]["blocked_by"], "#1300")
 
     def test_empty_gh_output_returns_empty_sections(self):
         out = self._run([])


### PR DESCRIPTION
## What

Closes the design-escalation handling gaps from #1326 surfaced by `review-fleet-feedback` (cluster `design-escalation-gap`).

### Part (a) — blocked-by parsers miss `Blocked on #N` header prose ✅
The three blocked-by parsers only read the canonical `**Blocked by:** #N` field, so a dependency declared as free-form header prose (`## Blocked on #1300`) was invisible. #1301 surfaced as `owner=free / blocked_by=(none)` and its claim gate passed even though its blocker was still open.

- **`fleet-state-scout`** — new `_parse_blocked_by` helper (field first, then header-prose fallback); used when deriving each task's `blocked_by`.
- **`fleet-claim`** — `check_blockers` now gates on header-prose blockers when the canonical field is absent (the actual claim-gating fix).
- **`fleet-queue-ingest`** — suppresses the spurious *"treat as unblocked"* warning when a header-prose blocker is present.

Header prose is honored only when it names a `#N` or `PR`, so an incidental *"blocked on the redesign"* sentence can't gate a task. The canonical `**Blocked by:**` field always wins when present. Complements #1296 (which handled `#N` refs *inside* the field).

### Part (b) — re-escalation must swap `design-unblocked` → `design-blocked` — PARTIAL ⚠️
- **`FLEET.md`** ✅ — the design-escalation flow + label-state-machine now document that re-escalating a `fleet:design-unblocked` PR swaps it back to `fleet:design-blocked` (the two are mutually exclusive), via `fleet-pr-clear-feedback-labels`.
- **`role-opus-worker.md` step 8c** ❌ — the procedural command edit was **blocked by the auto-mode self-modification classifier** (editing my own role definition). The exact prepared diff is posted as a comment on #1326 for a human-authorized pass. This is why the PR says **Refs**, not Closes — #1326 stays open until that one-line role edit lands.

## Tests
- `test_issue_queue_parser.py` — +9 cases (`ParseBlockedBy` class + scout `blocked_by` header-prose recovery). 26/26 pass.
- `test_fleet_claim_blockers.sh` — +4 cases (T9–T12: header-prose OPEN→fail [the #1301 regression], CLOSED→pass, ref-less→pass, field-wins). 12/12 pass.

No C++ touched → no build/format step; verification is the two suites above.

Refs #1326