### PR TITLE
fleet: harden attach-screenshots against shared-stash-stack race (#1330)

### DIFF
--- a/.claude/skills/attach-screenshots/SKILL.md
+++ b/.claude/skills/attach-screenshots/SKILL.md
@@ -192,14 +192,13 @@ propagating the failure. Check the branch back out, then re-resolve
 
 ```bash
 git checkout <BRANCH>
-git stash list --format='%gd %H %gs'
+git stash list --format='%gd %H %gs' | grep "attach-screenshots:<BRANCH>"
 ```
 
-Find the line whose message ends `attach-screenshots:<BRANCH>` and
-note its `stash@{N}` index and `<SHA>`. Reapply by **SHA** (immutable —
-race-proof even if a parallel agent shifted the index), then drop that
-entry by its `stash@{N}` index (`git stash drop` requires the
-`stash@{N}` form, not a raw SHA):
+That returns exactly one line; note its `stash@{N}` index and `<SHA>`.
+Reapply by **SHA** (immutable — race-proof even if a parallel agent
+shifted the index), then drop that entry by its `stash@{N}` index
+(`git stash drop` requires the `stash@{N}` form, not a raw SHA):
 
 ```bash
 git stash apply <SHA>
@@ -236,11 +235,11 @@ SHA — never bare `git stash pop`:
 
 ```bash
 git checkout <BRANCH>
-git stash list --format='%gd %H %gs'
+git stash list --format='%gd %H %gs' | grep "attach-screenshots:<BRANCH>"
 ```
 
-Take the `stash@{N}` index and `<SHA>` of the line ending
-`attach-screenshots:<BRANCH>`, then:
+That returns the single matching line; take its `stash@{N}` index
+and `<SHA>`, then:
 
 ```bash
 git stash apply <SHA>

--- a/.claude/skills/attach-screenshots/SKILL.md
+++ b/.claude/skills/attach-screenshots/SKILL.md
@@ -138,6 +138,16 @@ git stash push -u -m "attach-screenshots:<BRANCH>"
 If the stash reports "No local changes to save", the tree was
 already clean — stop and report that there is no delta to capture.
 
+The `-m "attach-screenshots:<BRANCH>"` message is our **race-safe
+handle** for this stash. `refs/stash` is shared across every worktree
+on this clone (see [CLAUDE-BASELINE.md § Hard rules](../../../docs/agents/CLAUDE-BASELINE.md#hard-rules-for-autonomous-fleet-roles)),
+so a parallel agent's `git stash push` in another worktree can shift
+`stash@{0}` out from under us between now and the restore. Every
+restore below re-resolves *our* entry by this branch-unique message
+(`<BRANCH>` differs per worktree) and reapplies it **by commit SHA** —
+never by `stash@{0}` / bare `git stash pop`, which would silently
+apply or consume another worktree's entry.
+
 ```bash
 git checkout --detach origin/master
 ```
@@ -177,12 +187,29 @@ Do not add `--timeout` — auto-screenshot fires `closeWindow()` when the
 shot sequence is done; a timeout would mask hangs (see [BUILD.md §Timeout choices](../../../docs/agents/BUILD.md#timeout-choices)).
 
 If `fleet-build` or `fleet-run` fails, **restore** before
-propagating the failure:
+propagating the failure. Check the branch back out, then re-resolve
+*our* stash by its branch-unique message and reapply it by SHA:
 
 ```bash
 git checkout <BRANCH>
-git stash pop
+git stash list --format='%gd %H %gs'
 ```
+
+Find the line whose message ends `attach-screenshots:<BRANCH>` and
+note its `stash@{N}` index and `<SHA>`. Reapply by **SHA** (immutable —
+race-proof even if a parallel agent shifted the index), then drop that
+entry by its `stash@{N}` index (`git stash drop` requires the
+`stash@{N}` form, not a raw SHA):
+
+```bash
+git stash apply <SHA>
+git stash drop stash@{N}
+```
+
+Never use bare `git stash pop` / `git stash drop` here — both default
+to `stash@{0}`, which may be another worktree's entry. If the index
+shifted between the two commands above, re-run `git stash list` and
+take the index of the line matching `<SHA>`.
 
 Then report and exit. Do **not** stage any partial output.
 
@@ -203,11 +230,21 @@ build/creations/demos/<demo-dir>/save_files/screenshots/screenshot_000001.png
 If the PNG count differs from the label count, something crashed
 mid-sequence — report and exit without staging.
 
-Restore the branch state:
+Restore the branch state. As in the build-failure restore above,
+re-resolve *our* stash by its branch-unique message and reapply by
+SHA — never bare `git stash pop`:
 
 ```bash
 git checkout <BRANCH>
-git stash pop
+git stash list --format='%gd %H %gs'
+```
+
+Take the `stash@{N}` index and `<SHA>` of the line ending
+`attach-screenshots:<BRANCH>`, then:
+
+```bash
+git stash apply <SHA>
+git stash drop stash@{N}
 ```
 
 ### 6. Capture the "after" pass (dirty working tree)
@@ -306,7 +343,7 @@ over stash:
 | `fleet-run` crashes / times out        | Restore stash if mid-before-pass, report the crash, exit. No PNGs staged.                              |
 | Headless host (no display)             | Detect via `fleet-run`'s exit code + empty `save_files/screenshots/`. Report; recommend running on a host with a display (WSLg, native Linux desktop, macOS). |
 | Shot count mismatch (before ≠ after)   | Report both counts; do not stage a half-paired set.                                                    |
-| Stash pop conflicts on restore         | Do **not** force-pop; report and ask the worker to resolve manually. The stash ref is preserved.       |
+| Stash apply conflicts on restore       | Do **not** force; report and ask the worker to resolve manually. We `apply` (then `drop` only on a clean apply), so the entry survives — recover it by its `<SHA>` from `git stash list`. |
 
 ## Anti-patterns
 
@@ -322,11 +359,17 @@ over stash:
 If the skill exits mid-flight (usage-limit error, interrupted, crash
 during "before" pass):
 
-1. Check `git stash list` — the stash entry begins with
-   `attach-screenshots:<BRANCH>`.
+1. Find *our* entry by its branch-unique message — **do not assume
+   `stash@{0}` is ours**; `refs/stash` is shared across all worktrees
+   on this clone, so a parallel agent's stash may sit on top:
+   `git stash list --format='%gd %H %gs'` and pick the line ending
+   `attach-screenshots:<BRANCH>`. Note its `stash@{N}` index and `<SHA>`.
 2. If the worktree is detached (detached HEAD from step 5), check
    the branch back out: `git checkout <BRANCH>`.
-3. `git stash pop` to restore.
+3. Reapply by SHA, then drop that entry by its index (never bare
+   `git stash pop` / `git stash drop` — both default to `stash@{0}`
+   and may consume another worktree's entry):
+   `git stash apply <SHA>` then `git stash drop stash@{N}`.
 4. Verify with `git status` that the dirty tree matches what you had
    before the skill ran.
 5. Re-invoke the skill once the underlying issue is resolved.

--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -427,7 +427,11 @@ if the user already asked for the next task).
 If the working tree has changes that clearly weren't made during this
 session (e.g. a half-finished refactor in an unrelated file), ask the user
 whether to include them before staging. When in doubt, stage only the files
-you know the session touched.
+you know the session touched. **Do not `git stash` to "park" unrelated WIP** —
+selective `git add <path>` already leaves it untouched in place, and
+`refs/stash` is shared across all worktrees, so a positional `git stash pop`
+can silently apply another agent's stash into your tree (see
+`docs/agents/CLAUDE-BASELINE.md` §"Hard rules for autonomous fleet roles").
 
 If `gh pr create` fails because a PR already exists for the branch, report
 the existing PR URL and tell the user — don't try to force a new one.

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -513,9 +513,13 @@ additional role-specific restrictions.
   resolve it by that message and reapply **by commit SHA** (`git stash
   apply <SHA>` — the SHA is immutable; `drop` by re-resolving its
   current `stash@{N}` index, since `git stash drop` needs the
-  `stash@{N}` form). Better: skip the shared stack — `git stash create`
-  returns a SHA without touching `refs/stash`, or use a throwaway
-  temp-branch commit / a dedicated `git worktree`. See
+  `stash@{N}` form). Alternative if untracked files aren't needed
+  (or combine with `git add -A` first): skip the shared stack — `git
+  stash create` returns a SHA without touching `refs/stash`; or use a
+  throwaway temp-branch commit / a dedicated `git worktree`. Note:
+  `git stash create` has no `-u` equivalent, so it does not capture
+  untracked files — do not substitute it for `git stash push -u`
+  without staging untracked files first. See
   [`.claude/skills/attach-screenshots/SKILL.md`](../../.claude/skills/attach-screenshots/SKILL.md)
   for the reference message-keyed, SHA-restored pattern.
 - **Single-command Bash only** — see [`## Bash tool rules`](#bash-tool-rules)

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -501,6 +501,23 @@ additional role-specific restrictions.
   `.claude/worktrees/*` tree) as a preflight. If it fires, `cd` into your
   worktree and retry — only a human in a deliberate main-clone session
   should set the `FLEET_ALLOW_MAIN_CLONE=1` override.
+- **`refs/stash` is shared across all worktrees — never use positional
+  stash refs.** Unlike per-worktree `HEAD`, `refs/stash` lives in the
+  common git dir, so every worktree on this clone shares one stash
+  stack. A bare `git stash pop` / `git stash drop` (or any `stash@{N}`)
+  is a TOCTOU race: a parallel agent in another worktree can push/pop
+  between your push and your pop, so your positional ref operates on
+  *their* entry — silently applying their changes into your tree or
+  consuming your WIP. If a fleet flow must stash, tag the entry with a
+  worktree-unique message (include your branch name), then at restore
+  resolve it by that message and reapply **by commit SHA** (`git stash
+  apply <SHA>` — the SHA is immutable; `drop` by re-resolving its
+  current `stash@{N}` index, since `git stash drop` needs the
+  `stash@{N}` form). Better: skip the shared stack — `git stash create`
+  returns a SHA without touching `refs/stash`, or use a throwaway
+  temp-branch commit / a dedicated `git worktree`. See
+  [`.claude/skills/attach-screenshots/SKILL.md`](../../.claude/skills/attach-screenshots/SKILL.md)
+  for the reference message-keyed, SHA-restored pattern.
 - **Single-command Bash only** — see [`## Bash tool rules`](#bash-tool-rules)
   above.
 - **Edit/Write blocked for `.claude/commands/` files?** The harness


### PR DESCRIPTION
## Summary

`refs/stash` lives in the common git dir and is **shared across every worktree** on a clone (unlike per-worktree `HEAD`). Any positional stash ref — bare `git stash pop`/`drop`, or `stash@{N}` — is therefore a TOCTOU race in the multi-worktree fleet: a parallel agent can shift `stash@{0}` between one agent's push and pop, silently applying or consuming another worktree's entry. This bit PR #1328, whose `commit-and-push` flow popped an `attach-screenshots` stash left by a different worktree.

### Changes

- **`attach-screenshots/SKILL.md`** — the only skill that runs real `git stash` commands. Keeps `git stash push -u` (still needed to clean tracked+untracked for a pure `origin/master` "before" pass) but rewrites every restore to resolve *our* entry by its branch-unique message and reapply by **immutable commit SHA** (`git stash apply <SHA>`), then drop by re-resolving the `stash@{N}` index from that SHA (`drop` requires the index form). Never bare `pop`. Covers the build-fail restore, success restore, Recovery section, and the failure-mode row.
- **`docs/agents/CLAUDE-BASELINE.md`** — adds a Hard rule documenting the shared-`refs/stash` footgun and the message-keyed + SHA-restore pattern (or skipping the shared stack entirely via `git stash create` / temp-branch commit / dedicated `git worktree`).
- **`commit-and-push/SKILL.md`** — one-line guard in Recovery against ad-hoc `git stash` to "park" unrelated WIP (selective `git add <path>` already leaves it untouched in place). This is the exact locus of the PR #1328 incident.

### Audit (issue item 3)

Audited every named skill/script for `git stash`. Only `attach-screenshots` runs real stash ops. The rest are clean: `commit-and-push`/`start-next-task`/`polish-checkpoint` have no stash usage; `platform-catchup`/`fleet-up` only advise the human in prose; `ir-perf-grid`'s `stash` is a `mktemp` variable name.

## Test plan

- [x] Doc/skill-only diff — no build required.
- [x] Verified empirically: `git stash apply <SHA>` works (restores tracked+untracked from a `push -u` stash); `git stash drop <SHA>` fails (requires `stash@{N}`) — the rewrite reflects this.
- [x] New cross-references resolve (CLAUDE-BASELINE anchor `#hard-rules-for-autonomous-fleet-roles`; the `../../../docs/` link convention matches the existing BUILD.md link).
- [x] No bare `git stash pop` commands remain in the skill (only intentional "never use bare pop" warnings).

Closes #1330
