### PR TITLE
fleet: drop [1m] from Sonnet model — 1M context needs usage credits

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -274,11 +274,12 @@ DISPATCHED_ROLES=(
 # OPUS_MODEL / SONNET_MODEL (the single source of truth — bump there).
 # The fallbacks apply only when the dispatcher is run standalone (e.g.
 # for debugging) without fleet-up in the environment; keep them in sync
-# with fleet-up. The "[1m]" suffix selects the 1M-token context variant —
-# standard pricing on the same weights as 200K, so it's free headroom for
-# the occasional long iteration.
+# with fleet-up. The "[1m]" suffix selects the 1M-token context variant:
+# kept for Opus, dropped for Sonnet — sonnet[1m] errors "Usage credits
+# required for 1M context" on this plan (see fleet-up's OPUS_MODEL /
+# SONNET_MODEL comment for the full rationale).
 OPUS_MODEL="${OPUS_MODEL:-claude-opus-4-8[1m]}"
-SONNET_MODEL="${SONNET_MODEL:-sonnet[1m]}"
+SONNET_MODEL="${SONNET_MODEL:-sonnet}"
 declare -A ROLE_MODEL=(
     ["sonnet-author"]="$SONNET_MODEL"
     ["opus-worker"]="$OPUS_MODEL"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -28,14 +28,17 @@ SESSION="fleet"
 # reviewers, merger, smoke), and launch_cmd threads OPUS_MODEL into the
 # architect panes via fleet-babysit. Bump here and every role moves.
 #
-# The "[1m]" suffix selects the 1M-token context variant. For Opus 4.8 and
-# Sonnet 4.6 the full 1M window bills at standard per-token rates (no long-
-# context premium) on the same weights as the 200K variant — so it's free
-# headroom for the occasional long iteration and identical on the common
-# short ones. Opus is pinned to a full version (the bare "opus" alias would
-# silently upgrade); sonnet stays an alias since its budget is cheap.
+# The "[1m]" suffix selects the 1M-token context variant. On this Max plan the
+# 1M-context beta is covered for Opus but NOT for Sonnet: a sonnet[1m] dispatch
+# dies instantly with "API Error: Usage credits required for 1M context" (turn
+# 1, $0.00). So Opus keeps [1m] (real headroom for long architect/worker
+# iterations); Sonnet uses the standard 200K alias, which its bounded
+# review/author iterations fit fine. (If you ever want sonnet[1m], enable usage
+# credits at claude.ai/settings/usage and re-add the suffix.) Opus is pinned to
+# a full version (the bare "opus" alias would silently upgrade); sonnet stays an
+# alias since its budget is cheap.
 OPUS_MODEL="claude-opus-4-8[1m]"
-SONNET_MODEL="sonnet[1m]"
+SONNET_MODEL="sonnet"
 export OPUS_MODEL SONNET_MODEL
 
 # Minimum seconds between opus-reviewer relaunches (cooldown floor).


### PR DESCRIPTION
## Problem

`sonnet[1m]` dispatches die instantly:

```
[claude claude-sonnet-4-6[1m] ...]
[done success turns=1 $0.0000 0.3s]
API Error: Usage credits required for 1M context · turn on usage credits at
claude.ai/settings/usage, or use --model to switch to standard context
```

The 1M-context beta isn't covered for **Sonnet** on the current Max plan (Opus 1M **is** — the opus[1m] roles run fine). Commit e3320ea7 ("move to Opus 4.8 + 1M-context variants") over-applied `[1m]` to Sonnet, which silently killed the entire Sonnet half of the fleet: `sonnet-reviewer`, `sonnet-author`, and `smoke-worker` errored on turn 1 every dispatch, so open PRs stopped getting first-pass reviews.

## Fix

- `SONNET_MODEL`: `sonnet[1m]` → `sonnet` (standard 200K alias). Sonnet's bounded review/author iterations fit comfortably; no real loss.
- Keep `OPUS_MODEL="claude-opus-4-8[1m]"` — Opus 1M is covered and the architects/heavy workers benefit from the headroom.
- Fixed in both the `fleet-up` source of truth **and** the `fleet-dispatcher` standalone fallback, and corrected the stale "free headroom" comments (true for Opus, false for Sonnet here).

To re-enable `sonnet[1m]` later: enable usage credits at `claude.ai/settings/usage` and re-add the `[1m]` suffix in `fleet-up`.

## Activation

Takes effect on the next `fleet-up` once this is on master (fleet-up exports `SONNET_MODEL` at startup; the dispatcher reads it at launch). The fleet is currently down, so no live restart needed — just bring it up after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
