### PR TITLE
fleet: worker escalation/handoff hardening — design-block releases ownership, headless never asks (closes #1326)

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -211,6 +211,18 @@ See [docs/agents/TASK-FILING.md § Multi-issue stacks](../../docs/agents/TASK-FI
 for the rules (one `#N` per blocker line; issue-number blockers only;
 gate docs-PR dependencies by withholding `human:approved`).
 
+**Fleet self-config changes are human-only — don't file them for
+autonomous pickup.** Edits to the role/command/agent configs the fleet
+loads (`.claude/commands/role-*.md`, `.claude/agents/*`) can't be applied
+by a queue worker: the auto-mode classifier gates editing a role's own
+config from an issue-queue task as self-modification (it needs explicit
+human authorization for the specific change). A worker that claims such a
+task hits the wall deterministically and the dispatcher keeps re-feeding it,
+burning iterations on a no-op (see #1326). So for a self-config change,
+either apply it yourself in this interactive session (you have the human in
+the loop) or write it up for the human to apply directly — do NOT file it as
+a `human:approved` fleet task.
+
 ## Planning issues
 
 The **opus worker** autonomously handles `fleet:needs-plan` issues as a

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -546,9 +546,31 @@ Do the work, then exit cleanly:
    - You're about to touch the public `ir_*.hpp` surface across
      multiple modules in one PR
    - A build break looks structural
+   - The task can only be completed by editing fleet self-config you
+     load (`.claude/commands/role-*.md`, `.claude/agents/*`) — editing
+     your own role definition is gated as self-modification, and a
+     queue-sourced worker can NEVER apply it (the gate is deterministic
+     across workers, by design)
 
    STOP. Do NOT try to redesign mid-task — the architect handles
    design conversations.
+
+   **You run headless — never ask the human interactively.** You're a
+   dispatched `--print` one-shot; no human is attached to your pane, so
+   `AskUserQuestion` (or "let me confirm with you first…") has nowhere to
+   land — it stalls or burns the iteration. Resolve from the plan/issue,
+   or escalate **asynchronously** on the issue/PR (the artifact a human
+   reviews on their own schedule), then move to a different task:
+
+   - **A design call you can't make** → the `fleet:design-blocked` flow
+     below.
+   - **A step you cannot perform** (e.g. the self-config edit above):
+     comment on the issue naming exactly what a human must apply, then
+     bump it out of autonomous pickup so you stop re-claiming it —
+     `gh issue edit <N> --remove-label human:approved --remove-label fleet:queued` —
+     and release your `fleet-claim`. Do NOT re-claim it next iteration:
+     the gate is deterministic, so retrying only burns iterations on a
+     wall until a human applies it.
 
    **Design escalation via `fleet:design-blocked`.** When the
    blocker is specifically architectural — the assigned task can't
@@ -573,7 +595,15 @@ Do the work, then exit cleanly:
 
       <suggested options if you have a view; the architect picks,
       you don't have to know the right answer>"`
-   c. Add the `fleet:design-blocked` label:
+   c. Move the PR into the `fleet:design-blocked` state. If you reached
+      this PR via the `fleet:design-unblocked` feedback tier — i.e.
+      you're **re-escalating** after the architect already responded
+      once — the PR still carries `fleet:design-unblocked`. Clear it in
+      the same step, otherwise the PR keeps both labels and gets
+      re-picked as unblocked next iteration (step 1 priority 4). The
+      helper only removes labels that are present, so it's a safe no-op
+      on a first-time escalation straight from the queue:
+      `fleet-pr-clear-feedback-labels <N> --labels "fleet:design-unblocked"`
       `gh pr edit <N> --add-label "fleet:design-blocked"`
       Keep `fleet:wip` — design-blocked is a state qualifier on top
       of WIP, not a transfer of ownership. Don't release the

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -606,9 +606,18 @@ Do the work, then exit cleanly:
       `fleet-pr-clear-feedback-labels <N> --labels "fleet:design-unblocked"`
       `gh pr edit <N> --add-label "fleet:design-blocked"`
       Keep `fleet:wip` — design-blocked is a state qualifier on top
-      of WIP, not a transfer of ownership. Don't release the
-      `fleet-claim` lock — the open PR + the claim lock together
-      keep the issue reserved for resumption.
+      of WIP. But **release your `fleet-claim` and worktree
+      reservation** — a design-blocked task is NOT yours to hold.
+      Resolution can take the architect a while, and when it returns as
+      `fleet:design-unblocked` ANY opus-worker should resume it cleanly
+      (step d frees the branch; step 1 priority 4 re-picks it). The
+      handoff is the PR, not your claim: the pushed WIP commit (a), the
+      `## NEEDS-DESIGN` comment + the architect's reply, the plan file
+      (`~/.fleet/plans/issue-<N>.md`), and the `fleet:design-blocked`
+      label carry everything the next worker needs. Holding the claim
+      through the block is what let two workers race the #1310 resume
+      and force-push over each other — release it:
+      `fleet-claim release <N>` (add `--repo game` for game tasks)
    d. Reset the worktree via `start-next-task` so the branch is free
       for the architect (or anyone else) to `gh pr checkout`. Then
       pick a different unblocked task from the issue queue as your

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -234,10 +234,10 @@ exclusion**. A design-blocked task releases its owner on block
 opus-worker; without the atomic lex-min claim two workers both resume
 the same PR and force-push over each other (observed clobber on #1310,
 2026-05-29). Acquire `fleet-claim amending-claim <N> <your-worktree>`
-before checkout; if it fails, another worker is already resuming —
+before removing the feedback label; if it fails, another worker is already resuming —
 skip and move on.
 
-With checkout confirmed (and, for `fleet:needs-fix`, the amend claim
+With checkout confirmed (and, for `fleet:needs-fix` and `fleet:design-unblocked`, the amend claim
 held), **remove the feedback label** to prevent another agent from
 also picking it up:
 

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -97,9 +97,16 @@ output.
   section. Treat it like a checklist. Address every nit unless
   it's purely subjective preference.
 - **For `fleet:design-unblocked`** (opus-worker only): also re-read
-  the canonical plan file at `.fleet/plans/T-<NNN>.md`. The latest
-  architect comment is the authoritative direction; the plan file
-  is the long-form version. If the two diverge, the comment wins
+  the architect's plan file at `~/.fleet/plans/issue-<N>.md` (current
+  naming, keyed to the issue number; some older plans use `T-<NNN>.md`
+  — check both, prefer the `issue-` form). This is REQUIRED reading
+  before you resume — it is the architect's design for the task and
+  carries the decision + decomposition the latest comment summarizes.
+  Because a design-blocked task releases its owner (you may be resuming
+  someone else's escalation), the plan file + the PR are your only
+  handoff context — do not assume in-conversation memory of it. The
+  latest architect comment is the authoritative direction; the plan
+  file is the long-form version. If the two diverge, the comment wins
   for this PR.
 
 ## AMEND vs ESCALATE (human-label paths only)
@@ -216,9 +223,19 @@ If the claim fails (lost the tie-break, or `gh` unreachable),
 amendment, or a retry will. Skip this PR and move on. Released in
 step e alongside `fleet:changes-made`; an abandoned claim is swept
 by `fleet-claim cleanup --gh` on the 30-min TTL. Skip this claim for
-`fleet:has-nits` / `fleet:design-unblocked` (they keep
-`fleet:approved`, so the PR never goes verdict-less) and for the
-`human:*` paths (covered by `fleet:human-amending` below).
+`fleet:has-nits` (it keeps `fleet:approved`, so the PR never goes
+verdict-less) and for the `human:*` paths (covered by
+`fleet:human-amending` below).
+
+**`fleet:design-unblocked` DOES acquire this claim** — not for the
+verdict-less reason (it keeps `fleet:approved`) but for **mutual
+exclusion**. A design-blocked task releases its owner on block
+(`role-opus-worker.md` step 8c), so on unblock it is free for *any*
+opus-worker; without the atomic lex-min claim two workers both resume
+the same PR and force-push over each other (observed clobber on #1310,
+2026-05-29). Acquire `fleet-claim amending-claim <N> <your-worktree>`
+before checkout; if it fails, another worker is already resuming —
+skip and move on.
 
 With checkout confirmed (and, for `fleet:needs-fix`, the amend claim
 held), **remove the feedback label** to prevent another agent from


### PR DESCRIPTION
## Context

A recurring pattern: a headless worker hits something it can't resolve and tries to **ask interactively** (`AskUserQuestion`) — but workers run as dispatched `claude --print` one-shots with no human attached to the pane, so the question stalls or burns the iteration. The triggering case here (#1326) was sharper: the worker knew the exact edit but was blocked by the **self-modification gate** (editing its own role config from an untrusted-queue task), so every worker iteration re-claimed #1326 and walled.

## Changes

**`role-opus-worker.md` §8 (stop-and-escalate):**
- New escalation trigger: a task that can only be completed by editing fleet self-config the agent loads (`.claude/commands/role-*.md`, `.claude/agents/*`) — gated as self-modification, deterministically un-appliable by a queue worker.
- New directive: **never ask the human interactively** (headless = nowhere to land). Resolve from the plan/issue, or escalate **async** on the issue/PR. For a step it can't perform, comment what a human must apply, drop `human:approved` + `fleet:queued` so it leaves autonomous pickup, release the claim, and don't re-claim.

**`role-opus-architect.md` (filing):** don't file self-config edits as `human:approved` tasks — apply them in the interactive session or hand to the human. Prevents the re-pickup loop at the source.

**Closes #1326:** lands the prepared step-8c edit — on a *re-escalation*, clear `fleet:design-unblocked` before adding `fleet:design-blocked` (via `fleet-pr-clear-feedback-labels`) so the PR doesn't carry both labels and get re-picked as unblocked. This is the verified, human-authored edit the self-mod gate blocked workers from applying; applied here with explicit human authorization.

## Note / possible follow-ups

- The no-interactive principle applies to **all** headless roles; this PR codifies it in the worker doc (the incident role). Propagating the one-liner to `role-sonnet-reviewer.md` / `role-sonnet-author.md` / `role-smoke-worker.md` is a small follow-up.
- A harder enforcement would be removing `AskUserQuestion` from headless roles' tool set at dispatch — worth considering if the doc directive isn't enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
