### PR TITLE
fleet: pin amend-push force-with-lease to checkout base SHA (anti-clobber)

### DIFF
--- a/scripts/fleet/fleet-pr-amend-push
+++ b/scripts/fleet/fleet-pr-amend-push
@@ -63,7 +63,10 @@ if [[ ! -f "$sentinel" ]]; then
     exit 1
 fi
 
-head_ref=$(cat "$sentinel")
+# Sentinel is two lines: head ref (line 1) + checkout-time base SHA (line 2;
+# absent on legacy sentinels written before the base-sha lease landed). The
+# base SHA is what makes the lease safe — see the push below.
+{ read -r head_ref; read -r base_sha; } < "$sentinel" 2>/dev/null || true
 if [[ -z "$head_ref" ]]; then
     echo "fleet-pr-amend-push: sentinel $sentinel is empty" >&2
     exit 1
@@ -82,11 +85,21 @@ if git symbolic-ref -q HEAD >/dev/null 2>&1; then
     exit 1
 fi
 
-# Push with force-with-lease. Quoting HEAD:$head_ref defensively in
-# case a future fleet adopts head refs with shell-significant chars
-# (today they're all `claude/...` which is safe, but cheap to harden).
-if ! git push --force-with-lease origin "HEAD:$head_ref"; then
-    echo "fleet-pr-amend-push: push failed — lease may be broken (concurrent amendment) or remote rejected the push" >&2
+# Push with force-with-lease pinned to the CHECKOUT-TIME base SHA, not the bare
+# remote-tracking ref. A bare --force-with-lease leases against origin/<head_ref>,
+# which an intervening `git fetch` refreshes to a concurrent agent's push — so
+# the lease passes and clobbers their commit (the #1310 dual-worker clobber,
+# 2026-05-29). Pinning the expected SHA makes the push REFUSE if origin/<head_ref>
+# moved since checkout, full stop. (Quoting HEAD:$head_ref defensively in case a
+# future fleet adopts head refs with shell-significant chars.)
+if [[ -n "$base_sha" ]]; then
+    lease="--force-with-lease=$head_ref:$base_sha"
+else
+    echo "fleet-pr-amend-push: sentinel has no base SHA (legacy checkout) — using a bare lease, which does NOT guard against an intervening fetch. Re-run fleet-pr-checkout-detached for full clobber protection." >&2
+    lease="--force-with-lease"
+fi
+if ! git push "$lease" origin "HEAD:$head_ref"; then
+    echo "fleet-pr-amend-push: push REFUSED — origin/$head_ref moved since you checked out (another agent pushed). Do NOT force past this: re-run fleet-pr-checkout-detached to re-base on their commit, re-apply your amendment, then push again." >&2
     exit 1
 fi
 

--- a/scripts/fleet/fleet-pr-checkout-detached
+++ b/scripts/fleet/fleet-pr-checkout-detached
@@ -145,8 +145,15 @@ fi
 # the right one for both layouts). Using `--git-dir` avoids needing
 # to special-case the worktree case.
 git_dir=$(git rev-parse --git-dir)
-printf '%s\n' "$head_ref" >"$git_dir/fleet-amend-ref"
+# Record the checkout-time base SHA next to the head ref (line 2).
+# fleet-pr-amend-push leases its force-push against THIS sha
+# (--force-with-lease=<ref>:<sha>), so a concurrent push that moved
+# origin/<head_ref> after this checkout is REJECTED, not clobbered. A bare
+# --force-with-lease leases against the remote-tracking ref, which any
+# intervening `git fetch` silently refreshes to the other agent's commit —
+# defeating the protection (observed dual-worker clobber on #1310, 2026-05-29).
+base_sha=$(git rev-parse HEAD)
+printf '%s\n%s\n' "$head_ref" "$base_sha" >"$git_dir/fleet-amend-ref"
 
-printf 'fleet-pr-checkout-detached: PR #%s on detached HEAD at origin/%s\n' "$pr_number" "$head_ref"
-printf '  Push the amendment with: git push --force-with-lease origin HEAD:%s\n' "$head_ref"
-printf '  Or use:                   fleet-pr-amend-push\n'
+printf 'fleet-pr-checkout-detached: PR #%s on detached HEAD at origin/%s (base %s)\n' "$pr_number" "$head_ref" "${base_sha:0:8}"
+printf '  Push the amendment with: fleet-pr-amend-push  (lease pinned to base %s)\n' "${base_sha:0:8}"


### PR DESCRIPTION
## Problem

`fleet-pr-amend-push` already used `git push --force-with-lease` — but **bare**, with no explicit expected SHA. A bare lease checks against the remote-tracking ref `origin/<head>`, and **any `git fetch` between checkout and push refreshes that ref** to whatever a concurrent agent just pushed. So the lease passes and clobbers their commit.

That's the **#1310 dual-worker clobber** (2026-05-29): both opus-workers resumed the same design-unblocked PR; worker-1 pushed `f39c8d49`, worker-2 fetched + amend-pushed `6557d097` straight over it. No functional code lost that time, but the mechanism is a live data-loss path.

## Fix

- `fleet-pr-checkout-detached` records the **checkout-time base SHA** on line 2 of the `.git/fleet-amend-ref` sentinel.
- `fleet-pr-amend-push` leases against that exact SHA: `--force-with-lease=<head>:<base>`. If `origin/<head>` moved since checkout, the push is **REFUSED** (with a "re-checkout, re-apply, push again" message) instead of clobbering.
- Legacy single-line sentinels (mid-flight checkouts) fall back to the bare lease + a warning.

## Scope

This is **D** of the #1310 escalation hardening. **A + B** (design-block releases ownership; design-unblocked acquires the atomic mutex claim + reads the architect plan file) are in **#1337**. **C** (issue/PR/claim/reservation reconciliation) is a tracked follow-up. Belt-and-suspenders: even if the claim-mutex fix in #1337 misses a race, the push itself can no longer clobber.

`bash -n` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
