### PR TITLE
fleet: PreToolUse hook blocks Edit/Write outside the current worktree

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -76,5 +76,18 @@
       "Bash(sudo:*)",
       "Bash(apt:*)", "Bash(apt-get:*)", "Bash(dpkg:*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/fleet/fleet-guard-worktree-edit"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/scripts/fleet/fleet-guard-worktree-edit
+++ b/scripts/fleet/fleet-guard-worktree-edit
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# fleet-guard-worktree-edit — PreToolUse hook for Edit | Write | MultiEdit.
+#
+# Refuses an edit whose absolute file_path lands OUTSIDE the fleet worktree the
+# session is working in. A fleet agent runs with its cwd inside
+# `.../.claude/worktrees/<name>/`; if it edits via a bare
+# `~/src/IrredenEngine/engine/...` absolute path, the write silently hits the
+# shared MAIN clone instead of the worktree. `fleet-build` (run in the worktree)
+# then compiles nothing and the agent wrongly concludes its fix "had no effect"
+# (observed on PR #1310 / #1336). The #1332 worktree-identity preflight guards
+# Bash/git, NOT the file tools — this closes that gap by enforcement instead of
+# role-doc discipline.
+#
+# Scope: ONLY constrains sessions whose cwd is inside a fleet worktree. The main
+# clone and isolated (e.g. /tmp) worktrees are unaffected. Relative paths
+# (resolved against the in-worktree cwd) are always allowed; only an absolute
+# path escaping the worktree root is blocked. Reads are NOT gated — the matcher
+# is Edit|Write|MultiEdit only (the silent-misroute hazard is mutations).
+#
+# Contract: reads the PreToolUse JSON on stdin; denies via the
+# hookSpecificOutput JSON form. ANY parse failure or missing field fails OPEN
+# (exit 0) — a hook must never wedge the fleet.
+set -uo pipefail
+
+input=$(cat 2>/dev/null || true)
+[[ -z "$input" ]] && exit 0
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
+file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+
+# Not in a fleet worktree → no restriction.
+case "$cwd" in
+    */.claude/worktrees/*) ;;
+    *) exit 0 ;;
+esac
+
+# No path, or a relative path (the tools resolve it against the in-worktree
+# cwd, so it stays in-worktree) → allow.
+[[ -z "$file" ]] && exit 0
+case "$file" in
+    /*) ;;
+    *)  exit 0 ;;
+esac
+
+# Derive the worktree root: <prefix>/.claude/worktrees/<name>
+prefix="${cwd%%/.claude/worktrees/*}"
+rest="${cwd#*/.claude/worktrees/}"
+wt_name="${rest%%/*}"
+[[ -z "$prefix" || -z "$wt_name" ]] && exit 0
+wt_root="$prefix/.claude/worktrees/$wt_name"
+
+# Inside the worktree (trailing slash on both sides so a sibling worktree like
+# `<name>-foo` can't prefix-match `<name>`) → allow.
+case "$file/" in
+    "$wt_root"/*) exit 0 ;;
+esac
+
+# Outside the worktree → deny with a corrective message.
+reason="fleet worktree guard: refusing to edit a path outside your worktree.
+  your worktree: $wt_root
+  edit target:   $file
+You are working in a fleet worktree, but this absolute path points into the
+shared main clone (or a sibling worktree). Editing it there silently misroutes
+the write — fleet-build runs in your worktree and compiles nothing, so the
+change looks like it 'had no effect' (PR #1310 / #1336). Redo this edit with a
+path INSIDE your worktree, or a path relative to your current directory."
+
+jq -n --arg r "$reason" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}' \
+    2>/dev/null && exit 0
+
+# jq output failed for some reason — fall back to the exit-2 block form so the
+# guard still fires rather than failing open on a deny.
+printf '%s\n' "$reason" >&2
+exit 2


### PR DESCRIPTION
## Problem (turning direction into tooling)

A fleet agent runs with cwd inside `.../.claude/worktrees/<name>/`. When it edits via a bare `~/src/IrredenEngine/engine/...` **absolute** path, the Read/Edit tools resolve it against the **main clone**, not the worktree — so the write silently lands in the shared checkout, `fleet-build` (run in the worktree) compiles nothing, and the agent wrongly concludes its fix *"had no effect."* Documented twice (PR #1310 / #1336).

The #1332 worktree-identity preflight guards **Bash/git**, not the **Read/Edit file tools** — so today this is pure (and repeatedly-ignored) discipline. This converts it to enforcement.

## Fix

`scripts/fleet/fleet-guard-worktree-edit` — a `PreToolUse` hook (matcher `Edit|Write|MultiEdit`) that **denies** an absolute `file_path` resolving outside the session's worktree root, with a corrective message. Wired in `.claude/settings.json`.

Deliberately narrow so it never wedges the fleet or false-blocks:
- **Only** constrains sessions whose cwd is inside a fleet worktree — the main clone and isolated `/tmp` worktrees are unaffected.
- Relative paths (resolved under the in-worktree cwd) are always allowed.
- Reads are **not** gated (mutations are the silent-misroute hazard).
- Any parse error / missing field **fails open** (a hook must never block legitimate work).

## Verification

Tested against 6 payloads:

| Scenario | Result |
|---|---|
| worktree session edits a file **in** its worktree | ✅ allow |
| worktree session edits the **main clone** (the bug) | ⛔ deny + message |
| worktree session edits a **sibling** worktree | ⛔ deny |
| main-clone session edits the main clone | ✅ allow |
| worktree session, **relative** path | ✅ allow |
| isolated `/tmp` worktree | ✅ allow |

Note: wiring it into `.claude/settings.json` is a self-config change; it's deliberate and scoped to mutations-outside-your-worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
