### PR TITLE
docs: agent-discipline notes — verify pushes, --body-file for backtick comments

### DIFF
--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -301,7 +301,18 @@ Read/Glob/Grep tools instead of Bash when possible.
 - **Body files for `--body-file`** — write them to a worktree-local path
   (e.g. `.review-body.md`, `.merger-body.md`) via the **Write** tool,
   not `/tmp/`; run `rm -f <path>` first if a prior session may have
-  left the file behind.
+  left the file behind. **Always use `--body-file` (never inline
+  `--body "..."`) for any PR/issue comment containing backticks or `$`** —
+  an inline `gh ... comment --body "...\`code\`..."` lets the shell execute
+  the backticked text and expand `$vars`, corrupting the comment or running
+  arbitrary tokens (observed on PR #1336).
+- **Verify before you report a push.** Stalled Bash output can flush late,
+  out of order, or duplicated — never state that a commit "landed", or cite a
+  SHA, from such a view. Confirm with a fresh `git fetch` then
+  `git rev-parse origin/<branch>` matching local `HEAD` first; if any tool
+  result looks empty or stale, run one trivial probe before the next
+  state-changing call or status-reporting comment (false SHAs `ab12cd34` /
+  `f3a9b2c1` were posted this way on PR #1336 — the real commit was different).
 
 This rule exists because the user-level allowlist (`~/.claude/settings.json`)
 matches on the first token of each Bash command. A compound command like


### PR DESCRIPTION
## What

Two recurring agent-runtime hazards from the PR #1336 case study, captured as cross-cutting **Bash tool rules** in `CLAUDE-BASELINE.md` (inherited by every role and creation):

- **F8 — gh-comment shell execution.** An inline `gh ... comment --body "...\`code\`..."` lets the shell run the backticked text and expand `$vars`, corrupting the comment or executing arbitrary tokens. Rule: always `--body-file` for any comment with backticks or `$` (extends the existing `--body-file` bullet).
- **F6 — false-SHA reporting from laggy output.** Stalled Bash output flushes late / out of order / duplicated; agents posted SHAs that never existed (`ab12cd34`, `f3a9b2c1`) from that view. Rule: never claim a commit landed or cite a SHA without a fresh `git fetch` + `git rev-parse origin/<branch>` matching local `HEAD`; probe once before any state-changing call or status comment.

## Why docs, not tooling

These are the **discipline-tier** complements to the enforced fixes: #1337 (claim handoff), #1338 (base-SHA lease), and the worktree-edit guard hook (#1341, the enforced version of the Read/Edit-path class). F6 (don't trust laggy output) and F8 (shell quoting) are hard to gate cleanly in tooling, so they live as rules where every role reads them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
