### PR TITLE
engine/prefabs: drop const from ANIMATION_COLOR component registration

### DIFF
--- a/engine/prefabs/irreden/update/systems/system_animation_color.hpp
+++ b/engine/prefabs/irreden/update/systems/system_animation_color.hpp
@@ -216,7 +216,7 @@ template <> struct System<ANIMATION_COLOR> {
         );
     }
 
-  private:
+private:
     // Per-tick caches replacing the prior function-local statics. Live
     // on the System<N> instance so the engine owns the lifetime and
     // multi-instance use cannot cross-talk. `endTick` clears both so

--- a/engine/prefabs/irreden/update/systems/system_animation_color.hpp
+++ b/engine/prefabs/irreden/update/systems/system_animation_color.hpp
@@ -211,14 +211,12 @@ template <> struct System<ANIMATION_COLOR> {
     }
 
     static SystemId create() {
-        return registerSystem<
-            ANIMATION_COLOR,
-            const C_ActionAnimation,
-            C_AnimColorState,
-            C_VoxelSetNew>("AnimationColor");
+        return registerSystem<ANIMATION_COLOR, C_ActionAnimation, C_AnimColorState, C_VoxelSetNew>(
+            "AnimationColor"
+        );
     }
 
-private:
+  private:
     // Per-tick caches replacing the prior function-local statics. Live
     // on the System<N> instance so the engine owns the lifetime and
     // multi-instance use cannot cross-talk. `endTick` clears both so


### PR DESCRIPTION
## Summary
- `System<ANIMATION_COLOR>::create()` registered `const C_ActionAnimation` as a tracked component. `registerSystem<N, Components...>` builds a `std::vector<Component>` per archetype column, and `std::vector<const T>` is ill-formed (`std::allocator` rejects const element types), so any translation unit that instantiates `createSystem<ANIMATION_COLOR>()` failed to compile with `std::allocator does not support const types`.
- The breakage was **latent**: no engine target or test instantiates `ANIMATION_COLOR`, so the header parsed in isolation and CI stayed green. This fix drops the `const` from the template argument; the tick keeps `const C_ActionAnimation &anim`, so the system's read-only access to the component is unchanged.

## Test plan
- [x] Built a creation target that instantiates `createSystem<IRSystem::ANIMATION_COLOR>()` — compiles and links clean. (Previously failed at `std::vector<const IRComponents::C_ActionAnimation>` instantiation.)
- [ ] Follow-up: add a regression test that instantiates `createSystem<ANIMATION_COLOR>()` so a `const`-qualified registration cannot regress latently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)