### PR TITLE
fleet: claim-first feedback handling — one atomic claim, all paths

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -166,7 +166,10 @@ When you do pick a task:
    Re-Read `~/.fleet/state/state.json` if its contents are no
    longer in your conversation context. From
    `repos.engine.prs[]`, pick PRs whose `labels` array contains
-   any of `human:needs-fix`, `fleet:needs-fix`, `fleet:has-nits`.
+   any of `human:needs-fix`, `fleet:needs-fix`, `fleet:has-nits` —
+   but **skip any PR already carrying a `fleet:amending-*` label**
+   (another worker holds the atomic feedback claim; step a will
+   reject your claim anyway).
 
    Follow [`docs/agents/FLEET-FEEDBACK-HANDLING.md`](../../docs/agents/FLEET-FEEDBACK-HANDLING.md) —
    it owns the priority order, the AMEND-vs-ESCALATE decision (the

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -202,7 +202,10 @@ Do the work, then exit cleanly:
    longer in your conversation context. From `repos.engine.prs[]`
    and `repos.game.prs[]`, pick PRs whose `labels` array contains
    any of `human:needs-fix`, `human:blocker`, `fleet:needs-fix`,
-   `fleet:has-nits`, `fleet:design-unblocked`.
+   `fleet:has-nits`, `fleet:design-unblocked` — but **skip any PR
+   already carrying a `fleet:amending-*` label** (another worker
+   holds the atomic feedback claim and is handling it; step a will
+   reject your claim anyway).
 
    Follow [`docs/agents/FLEET-FEEDBACK-HANDLING.md`](../../docs/agents/FLEET-FEEDBACK-HANDLING.md) —
    it owns the priority order, the detached-HEAD checkout flow,

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -132,7 +132,10 @@ Each iteration:
    `~/.fleet/state/state.json` if its contents are no longer in your
    conversation context. From `repos.engine.prs[]`, pick PRs whose
    `labels` array contains any of `human:needs-fix`,
-   `human:blocker`, `fleet:needs-fix`, `fleet:has-nits`.
+   `human:blocker`, `fleet:needs-fix`, `fleet:has-nits` — but **skip
+   any PR already carrying a `fleet:amending-*` label** (another
+   worker holds the atomic feedback claim; step a will reject your
+   claim anyway).
 
    Follow [`docs/agents/FLEET-FEEDBACK-HANDLING.md`](../../docs/agents/FLEET-FEEDBACK-HANDLING.md) —
    it owns the priority order, the detached-HEAD checkout flow,

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -51,6 +51,53 @@ manual conflict resolution flow lives in the worker role's step
 `human:needs-fix`, which sonnet-author DOES pick up via the normal
 cycle.
 
+**Skip** PRs already carrying a `fleet:amending-*` label — another
+worker holds the atomic feedback claim and is handling that PR (see
+Step a). This is a fast-path filter only; the real mutex is the claim
+itself, so a PR that slips past this filter (claimed after your state
+snapshot) is still caught when your own `amending-claim` loses the
+lex-min in Step a.
+
+## Step a — claim the PR atomically (before anything else)
+
+Feedback pickup fans out: the dispatcher launches **every** idle pane
+of your role on a single trigger (`find_idle_panes_for_role` is plural
+by design — that's how `opus-worker-1` and `-2` run concurrently). So
+two workers routinely select the same flagged PR in the same tick
+(observed #1336, 2026-05-30 — two opus-workers both started the same
+`human:needs-fix` AMEND). The **only** thing that makes pickup safe is
+an atomic claim, acquired **first** — before reading the feedback,
+checking out, or touching any label:
+
+```
+fleet-claim amending-claim <N> <your-worktree-basename>
+```
+
+(Add `--repo jakildev/irreden` before the subcommand for game PRs.)
+
+- **Exit 0** — you own this PR's feedback handling. Continue to the rest
+  of the flow. The `fleet:amending-<host>-<agent>` label is the lex-min
+  mutex against every other worker, and reviewers skip it
+  (a `REVIEW_SKIP_PREFIXES` match) so no reviewer re-reviews your
+  in-flight diff.
+- **Exit 1** — another worker holds the claim, or `gh` is unreachable.
+  **Skip this PR** — do not read its feedback, check it out, or touch
+  any label — and move to the next candidate in the priority tier. The
+  loser exits in ~1s; that is what keeps the dispatcher's fan-out cheap
+  (without it, the loser burns a full iteration — reads comments,
+  downloads screenshots, checks out — before discovering the race).
+
+This claim is **universal**: every feedback path acquires it here —
+`human:needs-fix`/`blocker`, `fleet:needs-fix`, `fleet:has-nits`,
+`fleet:design-unblocked`, and both AMEND and ESCALATE dispositions. It
+replaces the per-path claim bolt-ons that were added reactively
+(`fleet:needs-fix` after #1316, `fleet:design-unblocked` after #1310)
+and the non-atomic guards (`fleet:human-amending`, the TOCTOU worktree
+reservation) that let the #1336 race through. Hold it for the whole
+iteration; release it once, in step e (AMEND) or at the end of the
+ESCALATE path. An abandoned claim (crash mid-iteration) is swept by
+`fleet-claim cleanup --gh` on the 30-min TTL.
+
 ## Detached-HEAD checkout (no busy-branch filter)
 
 Git refuses to check out the same local branch in two worktrees at
@@ -183,63 +230,43 @@ that needs justification in the linked issue.
    internally OK to merge if you accept the deferral; re-add \
    human:needs-fix to switch to AMEND mode. — <role-name>"
    ```
-5. Skip the AMEND-path steps below — the PR's code is unchanged.
+5. Release the step-a claim (the label swap above is complete, so the
+   PR is in its terminal ESCALATE state — `fleet:human-deferred` keeps
+   reviewers off it independently):
+   ```
+   fleet-claim amending-release <N> <your-worktree-basename>
+   ```
+6. Skip the AMEND-path steps below — the PR's code is unchanged.
    Move on to the next iteration.
 
 ## AMEND path
 
-### Step b — claim the branch and remove the feedback label
+### Step b — check out and remove the feedback label
 
-**First, check out the PR in detached HEAD.** The wrapper fetches
-the PR's head ref and checks it out detached — no busy-branch
-filter, no `branch is already used by worktree` error. Do this
-BEFORE removing any label so a checkout failure (network, unknown
-ref, fork PR) cannot leave the PR in a labeless state:
+You already hold the atomic claim from step a — no other worker can
+reach this point on the same PR. Now **check out the PR in detached
+HEAD.** The wrapper fetches the PR's head ref and checks it out
+detached — no busy-branch filter, no `branch is already used by
+worktree` error. Do this BEFORE removing any label so a checkout
+failure (network, unknown ref, fork PR) cannot leave the PR in a
+labeless state:
 
 ```
 fleet-pr-checkout-detached <N> --repo jakildev/IrredenEngine
 ```
 
 If the wrapper fails (e.g. fetch error), **do NOT remove the
-feedback label**. Skip this PR and move to the next iteration —
-the label stays on the PR so a retry has something to pick up.
-
-**For `fleet:needs-fix`: acquire the amend claim before clearing
-the label.** `fleet:needs-fix` is the PR's only verdict label, so
-removing it leaves the PR verdict-less — indistinguishable from a
-fresh reviewable PR until `fleet:changes-made` lands. Without a
-marker over that window a reviewer poll claims and reviews the diff
-you're mid-rewrite on (observed on PR #1316, 2026-05-28). Acquire an
-atomic per-host claim — reviewers skip any `fleet:amending-*` PR
-(a `REVIEW_SKIP_PREFIXES` match), and the lex-min tie-break also
-prevents two workers from both grabbing the same flagged PR:
+feedback label** — release the claim and skip this PR so a retry has
+something to pick up:
 
 ```
-fleet-claim amending-claim <N> <your-worktree-basename>
+fleet-claim amending-release <N> <your-worktree-basename>
 ```
 
-If the claim fails (lost the tie-break, or `gh` unreachable),
-**do NOT remove the feedback label** — another worker owns the
-amendment, or a retry will. Skip this PR and move on. Released in
-step e alongside `fleet:changes-made`; an abandoned claim is swept
-by `fleet-claim cleanup --gh` on the 30-min TTL. Skip this claim for
-`fleet:has-nits` (it keeps `fleet:approved`, so the PR never goes
-verdict-less) and for the `human:*` paths (covered by
-`fleet:human-amending` below).
-
-**`fleet:design-unblocked` DOES acquire this claim** — not for the
-verdict-less reason (it keeps `fleet:approved`) but for **mutual
-exclusion**. A design-blocked task releases its owner on block
-(`role-opus-worker.md` step 8c), so on unblock it is free for *any*
-opus-worker; without the atomic lex-min claim two workers both resume
-the same PR and force-push over each other (observed clobber on #1310,
-2026-05-29). Acquire `fleet-claim amending-claim <N> <your-worktree>`
-before removing the feedback label; if it fails, another worker is already resuming —
-skip and move on.
-
-With checkout confirmed (and, for `fleet:needs-fix` and `fleet:design-unblocked`, the amend claim
-held), **remove the feedback label** to prevent another agent from
-also picking it up:
+With checkout confirmed, **remove the feedback label** (the
+`fleet:amending-*` claim from step a already keeps other workers and
+reviewers off the PR, so this is just clearing the now-handled
+verdict, not a race guard):
 
 ```
 fleet-pr-clear-feedback-labels <N>
@@ -334,9 +361,13 @@ Do NOT invoke the `commit-and-push` skill here: it would try to
 new PR (one already exists for this head ref). The wrapper handles
 the right push semantics for amendments.
 
-### Step e — swap the in-progress label for the done label
+### Step e — swap the in-progress label, then release the claim
 
-Per original feedback label:
+First the per-path label swap. Do this **before** releasing the claim
+so the PR is never label-less between dropping the claim and re-entering
+the review queue: while `fleet:amending-*` is still on, reviewers skip;
+the moment it drops, `fleet:changes-made` (where added below) re-triggers
+review via `RECHECK_LABELS`.
 
 - **`human:needs-fix` / `human:blocker`** — swap `fleet:human-amending`
   for `fleet:changes-made` in one combine-safe call (the removed
@@ -345,15 +376,9 @@ Per original feedback label:
   gh pr edit <N> --remove-label "fleet:human-amending" --add-label "fleet:changes-made"
   ```
 - **`fleet:needs-fix`** — add `fleet:changes-made` so the reviewer
-  knows new commits arrived and should re-verify, **then** release
-  the amend claim. Order matters: add `fleet:changes-made` first so
-  the PR is never label-less between dropping the amend claim and
-  re-entering the review queue (while both are present the reviewer
-  still skips on the `fleet:amending-*` prefix; once the claim drops,
-  `fleet:changes-made` re-triggers review via `RECHECK_LABELS`):
+  knows new commits arrived and should re-verify:
   ```
   gh pr edit <N> --add-label "fleet:changes-made"
-  fleet-claim amending-release <N> <your-worktree-basename>
   ```
 - **`fleet:has-nits`** — no response label needed; the existing
   `fleet:approved` stays valid (cleanups don't invalidate approval).
@@ -361,6 +386,13 @@ Per original feedback label:
   re-enters the normal review flow once you push (sonnet-reviewer
   picks it up via `fleet:changes-made` / no-fleet-review criteria,
   not `fleet:wip` — `fleet:wip` is a skip label for the reviewer).
+
+**Then release the claim — every path, unconditionally** (acquired in
+step a):
+
+```
+fleet-claim amending-release <N> <your-worktree-basename>
+```
 
 Then post a summary comment regardless of which path:
 
@@ -438,21 +470,28 @@ checkout also needs the repo flag for game PRs:
 
 ## Label cycles at a glance
 
+Every cycle below starts the same way: the worker acquires the atomic
+`fleet:amending-<host>-<agent>` claim (step a) before touching anything,
+and releases it at the terminal step. The claim is the single mutex for
+all feedback handling; the path-specific labels below
+(`fleet:human-amending`, `fleet:changes-made`, …) are status/merge-hold
+signals layered on top of it, not concurrency guards.
+
 **Human feedback cycle:** human adds `human:needs-fix` (+ comments)
-→ agent picks up, decides AMEND vs ESCALATE.
+→ agent claims the PR (step a), decides AMEND vs ESCALATE.
 
 - **AMEND** (default): agent removes `human:needs-fix`, adds
   `fleet:human-amending` + clears `fleet:approved`, works, swaps
-  `fleet:human-amending` for `fleet:changes-made` after pushing.
-  Either the human or the next-poll fleet reviewer re-verifies
-  (whichever first; reviewer removes the label on pickup to avoid
-  double-processing). Reviewer's re-approval re-sets
+  `fleet:human-amending` for `fleet:changes-made` after pushing, then
+  releases the claim. Either the human or the next-poll fleet reviewer
+  re-verifies (whichever first; reviewer removes the label on pickup to
+  avoid double-processing). Reviewer's re-approval re-sets
   `fleet:approved`.
 - **ESCALATE**: agent files a follow-up issue, atomically swaps
   `human:needs-fix` for `fleet:human-deferred` + `fleet:changes-made`,
-  KEEPS `fleet:approved`. Human reviews the linked issue and either
-  accepts the deferral (PR ready to merge) or re-adds
-  `human:needs-fix` to force AMEND mode on the next iteration.
+  KEEPS `fleet:approved`, then releases the claim. Human reviews the
+  linked issue and either accepts the deferral (PR ready to merge) or
+  re-adds `human:needs-fix` to force AMEND mode on the next iteration.
 
 Human can add multiple comments before re-tagging; ALL are picked
 up when the tag appears.

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -921,21 +921,27 @@ Specifically, **never pass these via `--label` when filing**:
   than 30 min and replays orphan sentinels from failed removals.
   Don't add manually; don't add to issues.
 - `fleet:amending-<host>-<agent>` — owned by the **`fleet-claim`
-  script** (atomic amend-claim primitive; same lex-min tie-break as
-  `fleet:reviewing-`). Applied by the **author worker** at the start
-  of a `fleet:needs-fix` amendment — `fleet-claim amending-claim`,
-  before it removes `fleet:needs-fix` — and removed by
-  `fleet-claim amending-release` once `fleet:changes-made` is set, or
-  swept on abort. It closes the gap that `fleet:needs-fix` is the
-  PR's only verdict label: once removed the PR is verdict-less and a
-  reviewer poll would otherwise claim and review the diff mid-rewrite
-  (observed on PR #1316, 2026-05-28). Reviewer projections **skip any
-  PR carrying a `fleet:amending-*` label** (a `REVIEW_SKIP_PREFIXES`
-  match in `fleet-state-scout`) — the host-suffixed analogue of the
-  static `fleet:human-amending` skip, doubling as a fixer-vs-fixer
-  mutex. The scout's `fleet-claim cleanup --gh` pass sweeps labels
-  older than 30 min and replays orphan sentinels. Don't add manually;
-  don't add to issues.
+  script** (atomic feedback-claim primitive; same lex-min tie-break as
+  `fleet:reviewing-`). The **single mutex for all feedback handling**:
+  the author worker acquires it via `fleet-claim amending-claim` as the
+  **first** action of feedback pickup — before reading feedback,
+  checking out, or touching any label — for *every* feedback path
+  (`human:needs-fix`/`blocker`, `fleet:needs-fix`, `fleet:has-nits`,
+  `fleet:design-unblocked`, AMEND and ESCALATE alike). Released by
+  `fleet-claim amending-release` at the terminal step (after the
+  done-label swap), or swept on abort. It replaces the per-path guards
+  that were bolted on reactively and still left gaps — `fleet:needs-fix`
+  got an atomic claim after #1316, `fleet:design-unblocked` after a
+  #1310 clobber, while `human:needs-fix` had only the non-atomic
+  `fleet:human-amending` + a TOCTOU worktree reservation and let two
+  workers race the same PR (#1336, 2026-05-30). Two roles fire on one
+  dispatcher trigger, so the claim being **first** is also what makes
+  the loser exit in ~1s instead of burning a full iteration. Reviewer
+  projections **skip any PR carrying a `fleet:amending-*` label**
+  (a `REVIEW_SKIP_PREFIXES` match in `fleet-state-scout`), so no
+  reviewer touches an in-flight diff. The scout's `fleet-claim cleanup
+  --gh` pass sweeps labels older than 30 min and replays orphan
+  sentinels. Don't add manually; don't add to issues.
 - `fleet:human-amending` / `fleet:human-deferred` — owned by the
   **author worker** (sonnet-author / opus-worker) when picking up
   `human:needs-fix`. The two labels express which disposition the


### PR DESCRIPTION
## Problem

Feedback handling is the one pickup path whose atomic claim was added
**per-path and reactively** — and it still had a hole:

| Feedback path | Claim before this PR | Acquired |
|---|---|---|
| `fleet:needs-fix` | ✅ `fleet:amending-*` (added after #1316) | late (step b) |
| `fleet:design-unblocked` | ✅ `fleet:amending-*` (added after a #1310 clobber) | late (step b) — **and never released** in step e |
| `human:needs-fix` / `human:blocker` | ❌ only `fleet:human-amending` (static, idempotent) + a **TOCTOU** worktree reservation | late (step b) |
| `fleet:has-nits` | ❌ none | — |

`fleet:human-amending` is the same label for both racers (idempotent add → no mutex). `fleet-claim reserve` reads the holder then `O_EXCL`-creates the worker's *own* file — two different worktrees both pass the "no holder" check. And every guard was acquired **after** reading feedback + checkout.

**Result, observed on PR #1336 (2026-05-30):** two opus-workers both selected the same `human:needs-fix` PR on one dispatcher tick, both read the comments, both downloaded the screenshots, both started the AMEND — colliding on labels and reservations before either noticed (visible in the panes: one went ESCALATE, the other erroneously added `fleet:human-amending`, then had to back off and restore labels).

## Fix — one atomic claim, acquired first, for every path

The `fleet:amending-<host>-<agent>` primitive already exists (#1329) and is path-agnostic. This makes it **the single mutex for all feedback handling**, acquired as the very first action:

- **New Step a** — `fleet-claim amending-claim` before reading feedback, checking out, or touching any label, for *all* paths (`human:*`, `fleet:needs-fix`, `fleet:has-nits`, `fleet:design-unblocked`) and both AMEND and ESCALATE. Lose the lex-min → skip the PR, next candidate.
- **Step b** drops the per-path claim conditionals (universal now); releases the claim on checkout failure.
- **Step e** releases the claim **unconditionally, every path** — which also fixes a latent leak: `design-unblocked` acquired the claim but step e never released it (it lingered to the 30-min sweep).
- **ESCALATE** releases the claim at its terminal step.
- **Candidate filters** (protocol + role docs) skip PRs already carrying `fleet:amending-*`.

## Why this also fixes the "both workers invoked" waste

The dispatcher fans one trigger across **every** idle pane of a role (`find_idle_panes_for_role` is plural by design — that's how `opus-worker-1`/`-2` get concurrency). **Don't** narrow it to one pane — if that pane is busy/wedged the work goes unclaimed. The correct design is fan-out **+ claim-first**: the loser now exits in ~1s instead of burning a full iteration. This PR makes claim-first true for feedback (it was already true for task/review/conflict pickup).

## Scope

Doc/protocol-only. The `fleet:amending-` subcommands, the `REVIEW_SKIP_PREFIXES` reviewer-skip, and the `cleanup --gh` TTL sweep all already exist from #1329 — this changes only *which paths use the claim and when*. Touches `FLEET-FEEDBACK-HANDLING.md`, the `fleet:amending-` dictionary entry in `FLEET.md`, and the three authoring role docs' candidate filters.

After this, every PR/issue pickup point — task, review, smoke, conflict resolution, and now all feedback handling — is gated by an atomic, script-based lex-min claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
