### PR TITLE
fleet: ir-run bump -maxdepth 5→8 to reach user_projects executables

### DIFF
--- a/engine/tools/bin/ir-run
+++ b/engine/tools/bin/ir-run
@@ -215,7 +215,7 @@ if [[ ! -d "$BUILD_DIR" ]]; then
 fi
 
 # Find the executable in the build tree.
-EXE_PATH=$(find "$BUILD_DIR" -maxdepth 5 -name "$EXE_NAME" -type f -perm -u=x 2>/dev/null | head -1)
+EXE_PATH=$(find "$BUILD_DIR" -maxdepth 8 -name "$EXE_NAME" -type f -perm -u=x 2>/dev/null | head -1)
 
 if [[ -z "$EXE_PATH" ]]; then
     echo "ir-run: could not find executable '$EXE_NAME' in $BUILD_DIR" >&2


### PR DESCRIPTION
## Summary
- `ir-run`'s `find` command used `-maxdepth 5`, which never reaches executables built via `-DIRREDEN_USER_PROJECTS` (they land at depth 6 under `build/user_projects/<agent>/irreden/demos/<name>/<exe>`)
- Bumps to `-maxdepth 8`, covering the known depth-6 case with headroom for deeper project trees

## Test plan
- [ ] `fleet-run <game-demo-target>` succeeds without `--build-dir` after a `fleet-build` with `-DIRREDEN_USER_PROJECTS`
- [ ] `fleet-run IRShapeDebug` (standard depth ≤3 target) still works

Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)