### PR TITLE
fleet: fleet-claim reconcile core — report-only + boot --apply (#1356)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -23,6 +23,7 @@
 #   fleet-claim check <issue-number>
 #   fleet-claim list [--with-age]
 #   fleet-claim cleanup [--repo <owner/repo>] [--gh] ...
+#   fleet-claim reconcile [--apply] [--repo <owner/repo>] ...
 #   fleet-claim review-claim <pr-number> <agent>
 #   fleet-claim review-release <pr-number> <agent>
 #   fleet-claim resolving-claim <pr-number> <agent>
@@ -238,6 +239,30 @@ gh_release_label() {
     fi
     write_orphan_sentinel "$repo" "$issue" "$label" "remove-label failed after retry"
     return 1
+}
+
+# label_added_epoch <repo> <issue-or-pr> <label>
+#   Echo the Unix epoch of the most recent "labeled" event for <label> on
+#   the target issue/PR, or 0 when unknown (gh missing, no matching event,
+#   or a parse failure). Mirrors the events-API timestamp method
+#   cmd_cleanup_gh uses to age out stale labels; reconcile (R4a) uses it to
+#   keep the most-recently-applied of two contradictory labels.
+label_added_epoch() {
+    local repo="$1" target="$2" label="$3"
+    command -v gh >/dev/null 2>&1 || { echo 0; return 0; }
+    local added_at
+    added_at=$(gh api "repos/${repo}/issues/${target}/events" --paginate \
+        --jq '.[] | select(.event=="labeled" and .label.name=="'"$label"'") | .created_at' \
+        2>/dev/null | tail -n1 || true)
+    [[ -z "$added_at" ]] && { echo 0; return 0; }
+    ADDED_AT="$added_at" python3 -c '
+import os, datetime
+try:
+    dt = datetime.datetime.strptime(os.environ["ADDED_AT"], "%Y-%m-%dT%H:%M:%SZ")
+    print(int(dt.replace(tzinfo=datetime.timezone.utc).timestamp()))
+except Exception:
+    print(0)
+' 2>/dev/null || echo 0
 }
 
 # _acquire_label_on <repo> <pr-or-issue> <label> <label-prefix>
@@ -1554,6 +1579,437 @@ cmd_check_stale() {
     done < <(reservations_dump)
 }
 
+# --- cross-surface reconciliation (reconcile) -----------------------------
+#
+# reconcile cross-checks the FOUR claim surfaces against each other —
+# issue/PR labels, open-PR state, host-local FS claims, and worktree
+# reservations — and reports (or, with --apply, repairs) drift between
+# them. Every pre-existing sweep is single-surface (cmd_cleanup_gh,
+# cmd_check_stale, cmd_reset_sweep_host_claims); this is the pass that
+# catches inconsistencies BETWEEN surfaces. C1 (#1356) lands R1/R3/R4/R5
+# auto-fix + R2 flag; the periodic path and R6 are deferred to C2 (#1357).
+
+# reconcile_fs_claims_json
+#   Emit the host-local FS claim set as a JSON array, one object per claim
+#   dir under $CLAIMS_DIR (skipping _stack_* molecule dirs). Each record
+#   carries the repo derived from the slug namespace so the classifier can
+#   correlate a claim against the right repo's open-PR set.
+reconcile_fs_claims_json() {
+    python3 - "$CLAIMS_DIR" <<'PYEOF'
+import sys, os, json
+claims_dir = sys.argv[1]
+out = []
+if os.path.isdir(claims_dir):
+    for name in sorted(os.listdir(claims_dir)):
+        path = os.path.join(claims_dir, name)
+        if not os.path.isdir(path) or name.startswith('_stack_'):
+            continue
+        if name.startswith('game-'):
+            ns, num = 'game', name[len('game-'):]
+            repo = 'jakildev/irreden'
+        else:
+            ns, num = 'engine', name
+            repo = 'jakildev/IrredenEngine'
+        if not num.isdigit():
+            continue
+        def rd(f):
+            try:
+                return open(os.path.join(path, f)).read().strip()
+            except Exception:
+                return ''
+        try:
+            created = int(rd('created') or 0)
+        except ValueError:
+            created = 0
+        out.append({'slug': name, 'issue': int(num), 'ns': ns,
+                    'repo': repo, 'owner': rd('owner') or 'unknown',
+                    'created': created})
+print(json.dumps(out))
+PYEOF
+}
+
+# reconcile_reservations_json
+#   Emit the reservation set as a JSON array (worktree, task_id, branch,
+#   created_epoch) so the classifier can detect reservation/claim drift.
+reconcile_reservations_json() {
+    reservations_dump | python3 -c '
+import sys, json
+out = []
+for line in sys.stdin:
+    parts = line.rstrip("\n").split("\t")
+    if len(parts) < 5 or not parts[0]:
+        continue
+    wt, tid, branch, ts, epoch = parts[:5]
+    try:
+        ep = int(epoch)
+    except ValueError:
+        ep = 0
+    out.append({"worktree": wt, "task_id": tid, "branch": branch, "created_epoch": ep})
+print(json.dumps(out))
+'
+}
+
+cmd_reconcile() {
+    # Cross-surface reconciliation pass.
+    # Usage: fleet-claim reconcile [--apply] [--repo <owner/repo>] ...
+    # Report-only by default (detect + report, mutate nothing). With --apply,
+    # perform only the host-local, TTL/corroboration-gated auto-fixes
+    # (R1/R3/R4/R5); R2 stays report-only.
+    local do_apply=0
+    local -a repos=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --apply)  do_apply=1; shift ;;
+            --repo)   repos+=("$2"); shift 2 ;;
+            --repo=*) repos+=("${1#--repo=}"); shift ;;
+            *) echo "fleet-claim reconcile: unknown arg '$1'" >&2; return 2 ;;
+        esac
+    done
+
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "fleet-claim reconcile: 'gh' not on PATH; skipping" >&2
+        return 0
+    fi
+
+    # Default repo set mirrors reset-sweep-host-claims: engine always, game
+    # when reachable. An explicit --repo overrides the auto-discovery.
+    if [[ ${#repos[@]} -eq 0 ]]; then
+        repos=("jakildev/IrredenEngine")
+        if gh repo view "jakildev/irreden" >/dev/null 2>&1; then
+            repos+=("jakildev/irreden")
+        fi
+    fi
+
+    local host now claim_ttl state_dir
+    host=$(derive_host)
+    now=$(date +%s)
+    claim_ttl="${FLEET_CLAIM_STALE_SECS:-1800}"
+    state_dir="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
+    mkdir -p "$CLAIMS_DIR" "$state_dir"
+
+    local work
+    work=$(mktemp -d)
+
+    # ---- gather per-repo label/PR surfaces -------------------------------
+    local repo safe
+    for repo in "${repos[@]}"; do
+        safe="${repo//\//_}"
+        gh issue list --repo "$repo" --state open \
+            --search "label:\"fleet:queued\"" \
+            --json number,labels,state --limit 300 \
+            > "$work/issues-$safe.json" 2>/dev/null \
+            || echo "[]" > "$work/issues-$safe.json"
+        gh pr list --repo "$repo" --state open \
+            --json number,headRefName,labels,body --limit 300 \
+            > "$work/prs-$safe.json" 2>/dev/null \
+            || echo "[]" > "$work/prs-$safe.json"
+    done
+
+    # ---- gather host-local surfaces --------------------------------------
+    reconcile_fs_claims_json    > "$work/fs_claims.json"
+    reconcile_reservations_json > "$work/reservations.json"
+
+    # ---- classify drift across the four surfaces -------------------------
+    local findings="$work/findings.jsonl"
+    python3 - "$work" "$host" "$now" "$claim_ttl" "${repos[*]}" \
+        "$work/fs_claims.json" "$work/reservations.json" \
+        > "$findings" <<'PYEOF'
+import sys, os, json, re
+
+work, host, now_s, ttl_s = sys.argv[1:5]
+repos = sys.argv[5].split() if sys.argv[5] else []
+fs_path, res_path = sys.argv[6], sys.argv[7]
+now, ttl = int(now_s), int(ttl_s)
+
+def load(p, default):
+    try:
+        return json.load(open(p))
+    except Exception:
+        return default
+
+fs_claims = load(fs_path, [])
+reservations = load(res_path, [])
+
+FEEDBACK = {"human:needs-fix", "human:blocker", "fleet:needs-fix",
+            "fleet:has-nits", "fleet:design-unblocked"}
+
+findings = []
+def add(rule, repo, target, kind, surfaces, action, gated_by, apply=None):
+    findings.append({"rule": rule, "repo": repo, "target": target,
+                     "target_kind": kind, "surfaces": surfaces,
+                     "action": action, "gated_by": gated_by,
+                     "apply": apply, "applied": None})
+
+def labelset(obj):
+    return set(l.get("name", "") for l in (obj.get("labels") or [])
+               if isinstance(l, dict))
+
+def head_issue(head):
+    # claude/<N>-... -> N
+    if not head.startswith("claude/"):
+        return None
+    rest = head[len("claude/"):]
+    num = ""
+    for ch in rest:
+        if ch.isdigit():
+            num += ch
+        else:
+            break
+    return int(num) if num else None
+
+# A PR resolves an issue when its head branch is claude/<N>-* OR its body
+# carries a Closes/Fixes/Resolves #N reference — the same dual-match
+# find-stackable-blockers uses. Covers non-standard branch names (e.g.
+# claude/<topic>-<N>) that the head-prefix form alone would miss.
+CLOSES_RE = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b",
+                       re.IGNORECASE)
+
+repo_data = {}
+for repo in repos:
+    safe = repo.replace("/", "_")
+    issues = load(os.path.join(work, "issues-%s.json" % safe), [])
+    prs = load(os.path.join(work, "prs-%s.json" % safe), [])
+    issue_labels = {it.get("number"): labelset(it) for it in issues}
+    pr_by_issue, open_pr_issues = {}, set()
+    for pr in prs:
+        n = head_issue(pr.get("headRefName", "") or "")
+        if n is not None:
+            open_pr_issues.add(n)
+            pr_by_issue.setdefault(n, []).append(
+                {"number": pr.get("number"), "labels": labelset(pr)})
+        for m in CLOSES_RE.finditer(pr.get("body", "") or ""):
+            open_pr_issues.add(int(m.group(1)))
+    repo_data[repo] = {"issue_labels": issue_labels, "prs": prs,
+                       "pr_by_issue": pr_by_issue,
+                       "open_pr_issues": open_pr_issues}
+
+def has_open_pr(repo, issue):
+    d = repo_data.get(repo)
+    return None if d is None else (issue in d["open_pr_issues"])
+
+# ---- R1/R5: host-local stale claim (FS lock + label, no PR, age>TTL) ----
+fs_by_task = {}
+for c in fs_claims:
+    repo = c["repo"]
+    fs_by_task[(repo, c["issue"])] = c
+    age = now - c.get("created", 0)
+    op = has_open_pr(repo, c["issue"])
+    if op is None:
+        if age >= ttl:
+            add("R1", repo, c["issue"], "issue", ["fs_claim"],
+                "stale claim suspected but its repo is outside the scan set; skipped",
+                "repo-not-scanned")
+        continue
+    if not op and age >= ttl:
+        add("R1", repo, c["issue"], "issue", ["fs_claim", "label", "pr"],
+            "release host-local stale FS claim + remove this host's claim "
+            "label + fleet:in-progress",
+            "age %dm >= TTL %dm, no open claude/%d-* PR" % (age // 60, ttl // 60, c["issue"]),
+            apply={"type": "stale_claim", "slug": c["slug"], "issue": c["issue"],
+                   "repo": repo, "claim_label": "fleet:claim-%s-%s" % (host, c["owner"]),
+                   "owner": c["owner"]})
+
+# ---- R3: reservation/claim consistency ----
+for r in reservations:
+    wt, tid = r["worktree"], r["task_id"]
+    if not tid or not tid.isdigit():
+        continue
+    issue = int(tid)
+    repo = "jakildev/IrredenEngine"   # reservations carry no namespace; engine default
+    claim = fs_by_task.get((repo, issue))
+    if claim is not None:
+        if claim["owner"] != wt:
+            add("R3", repo, issue, "reservation", ["reservation", "fs_claim"],
+                "reservation owner '%s' != claim owner '%s'; claim authoritative, "
+                "drop stale reservation" % (wt, claim["owner"]),
+                "claim present with different owner",
+                apply={"type": "drop_reservation", "worktree": wt, "issue": issue})
+        continue
+    op = has_open_pr(repo, issue)
+    if op is None or op:
+        continue
+    add("R3", repo, issue, "reservation", ["reservation"],
+        "reservation for '%s' has no claim and no open claude/%d-* PR; drop" % (wt, issue),
+        "no claim, no open PR",
+        apply={"type": "drop_reservation", "worktree": wt, "issue": issue})
+
+# ---- R4a: design-blocked + design-unblocked contradiction ----
+for repo in repos:
+    d = repo_data[repo]
+    for n, labs in d["issue_labels"].items():
+        if "fleet:design-blocked" in labs and "fleet:design-unblocked" in labs:
+            add("R4a", repo, n, "issue", ["label"],
+                "contradictory design-blocked + design-unblocked; keep "
+                "most-recently-applied, remove older", "both labels present",
+                apply={"type": "resolve_design_contradiction", "target": n, "repo": repo})
+    for pr in d["prs"]:
+        labs = labelset(pr)
+        if "fleet:design-blocked" in labs and "fleet:design-unblocked" in labs:
+            add("R4a", repo, pr.get("number"), "pr", ["label"],
+                "contradictory design-blocked + design-unblocked; keep "
+                "most-recently-applied, remove older", "both labels present",
+                apply={"type": "resolve_design_contradiction",
+                       "target": pr.get("number"), "repo": repo})
+
+# ---- R4b: queued + in-progress, no claim (any host), no PR ----
+for repo in repos:
+    d = repo_data[repo]
+    for n, labs in d["issue_labels"].items():
+        if "fleet:queued" not in labs or "fleet:in-progress" not in labs:
+            continue
+        if any(l.startswith("fleet:claim-") for l in labs):
+            continue
+        if (repo, n) in fs_by_task or n in d["open_pr_issues"]:
+            continue
+        add("R4b", repo, n, "issue", ["label", "pr"],
+            "fleet:in-progress with no claim (any host) and no open PR; "
+            "remove stale fleet:in-progress",
+            "queued+in-progress, no claim-label, no FS claim, no open PR",
+            apply={"type": "remove_in_progress", "issue": n, "repo": repo})
+
+# ---- R2 (flag only): orphaned WIP/feedback PR ----
+reserved_tasks = set(r["task_id"] for r in reservations)
+for repo in repos:
+    d = repo_data[repo]
+    for issue_n, prlist in d["pr_by_issue"].items():
+        for pr in prlist:
+            labs = pr["labels"]
+            if "fleet:wip" not in labs and not (labs & FEEDBACK):
+                continue
+            issue_labs = d["issue_labels"].get(issue_n, set())
+            if (any(l.startswith("fleet:claim-") for l in issue_labs)
+                    or (repo, issue_n) in fs_by_task
+                    or str(issue_n) in reserved_tasks):
+                continue
+            kind = "WIP" if "fleet:wip" in labs else "feedback"
+            add("R2", repo, pr["number"], "pr", ["pr", "label"],
+                "open %s PR for #%d with no claim/reservation/claim-label "
+                "(re-adoption is a pickup decision)" % (kind, issue_n),
+                "flag-only (R2)")
+
+for f in findings:
+    print(json.dumps(f))
+PYEOF
+
+    # ---- report the findings ---------------------------------------------
+    local mode_label
+    if [[ $do_apply -eq 1 ]]; then mode_label="apply"; else mode_label="report-only"; fi
+    if [[ ! -s "$findings" ]]; then
+        echo "reconcile ($mode_label): no drift detected across ${repos[*]}"
+    else
+        echo "reconcile ($mode_label) drift findings:"
+        python3 - "$findings" <<'PYEOF'
+import sys, json
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line:
+        continue
+    f = json.loads(line)
+    mark = "fix " if f.get("apply") else "flag"
+    print("  [%-3s %s] %s %s#%s: %s"
+          % (f["rule"], mark, f["repo"], f["target_kind"], f["target"], f["action"]))
+PYEOF
+    fi
+
+    # ---- apply gated fixes ------------------------------------------------
+    if [[ $do_apply -eq 1 && -s "$findings" ]]; then
+        local line atype
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            atype=$(printf '%s' "$line" | python3 -c 'import sys,json; a=(json.load(sys.stdin).get("apply") or {}); print(a.get("type",""))')
+            case "$atype" in
+                stale_claim)
+                    local s_slug s_issue s_repo s_label s_owner s_reserved
+                    s_slug=$(reconcile_apply_field "$line" slug)
+                    s_issue=$(reconcile_apply_field "$line" issue)
+                    s_repo=$(reconcile_apply_field "$line" repo)
+                    s_label=$(reconcile_apply_field "$line" claim_label)
+                    s_owner=$(reconcile_apply_field "$line" owner)
+                    __remove_claim "$s_slug"
+                    if [[ -n "$s_owner" && "$s_owner" != "unknown" ]]; then
+                        s_reserved=$(reservation_task_id "$s_owner")
+                        if [[ "$s_reserved" == "$s_issue" ]]; then
+                            cmd_release_worktree "$s_owner" >/dev/null 2>&1 || true
+                        fi
+                    fi
+                    gh_release_label "$s_repo" "$s_issue" "$s_label" || true
+                    gh_release_label "$s_repo" "$s_issue" "fleet:in-progress" || true
+                    echo "  reconcile --apply: R1 released stale claim #$s_issue (slug $s_slug, owner $s_owner)"
+                    ;;
+                drop_reservation)
+                    local d_wt
+                    d_wt=$(reconcile_apply_field "$line" worktree)
+                    cmd_release_worktree "$d_wt" >/dev/null 2>&1 || true
+                    echo "  reconcile --apply: R3 dropped stale reservation for $d_wt"
+                    ;;
+                resolve_design_contradiction)
+                    local c_target c_repo e_block e_unblock older
+                    c_target=$(reconcile_apply_field "$line" target)
+                    c_repo=$(reconcile_apply_field "$line" repo)
+                    e_block=$(label_added_epoch "$c_repo" "$c_target" "fleet:design-blocked")
+                    e_unblock=$(label_added_epoch "$c_repo" "$c_target" "fleet:design-unblocked")
+                    if [[ "$e_block" -eq 0 && "$e_unblock" -eq 0 ]]; then
+                        echo "  reconcile --apply: R4a could not order labels on $c_repo #$c_target; skipping" >&2
+                    else
+                        if [[ "$e_block" -ge "$e_unblock" ]]; then
+                            older="fleet:design-unblocked"
+                        else
+                            older="fleet:design-blocked"
+                        fi
+                        gh_release_label "$c_repo" "$c_target" "$older" || true
+                        echo "  reconcile --apply: R4a removed older '$older' on $c_repo #$c_target"
+                    fi
+                    ;;
+                remove_in_progress)
+                    local p_issue p_repo
+                    p_issue=$(reconcile_apply_field "$line" issue)
+                    p_repo=$(reconcile_apply_field "$line" repo)
+                    gh_release_label "$p_repo" "$p_issue" "fleet:in-progress" || true
+                    echo "  reconcile --apply: R4b removed stale fleet:in-progress on $p_repo #$p_issue"
+                    ;;
+            esac
+        done < "$findings"
+    fi
+
+    # ---- write the structured drift report -------------------------------
+    local generated_at out_file
+    generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    out_file="$state_dir/drift-report.json"
+    GEN_AT="$generated_at" HOST="$host" DO_APPLY="$do_apply" \
+        REPOS="${repos[*]}" OUT="$out_file" \
+        python3 - "$findings" <<'PYEOF'
+import sys, os, json
+findings = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+do_apply = os.environ["DO_APPLY"] == "1"
+for f in findings:
+    f["applied"] = bool(do_apply) if f.get("apply") else None
+summary = {}
+for f in findings:
+    summary[f["rule"]] = summary.get(f["rule"], 0) + 1
+report = {
+    "generated_at": os.environ["GEN_AT"],
+    "host": os.environ["HOST"],
+    "apply": do_apply,
+    "repos": os.environ["REPOS"].split(),
+    "summary": summary,
+    "findings": findings,
+}
+with open(os.environ["OUT"], "w") as fh:
+    json.dump(report, fh, indent=2)
+    fh.write("\n")
+PYEOF
+    echo "reconcile: wrote drift report → $out_file"
+
+    rm -rf "$work"
+}
+
+# reconcile_apply_field <finding-json-line> <key>
+#   Echo apply.<key> from one finding JSONL line (apply helper for cmd_reconcile).
+reconcile_apply_field() {
+    printf '%s' "$1" | KEY="$2" python3 -c \
+        'import sys,os,json; a=(json.load(sys.stdin).get("apply") or {}); print(a.get(os.environ["KEY"],""))'
+}
+
 cmd_stack() {
     # Atomically claim a chain of dependent tasks. All-or-nothing.
     # Cross-host locking: FS lock only (atomic mkdir). Unlike cmd_claim,
@@ -2535,6 +2991,10 @@ case "${1:-}" in
         shift
         cmd_cleanup "$@"
         ;;
+    reconcile)
+        shift
+        cmd_reconcile "$@"
+        ;;
     review-claim)
         if [[ -z "${3:-}" ]]; then
             echo "usage: fleet-claim [--repo <ns>] review-claim <pr-number> <agent>" >&2
@@ -2772,6 +3232,33 @@ commands:
                                 fleet:claim-<host>-* labels from open
                                 issues with no matching open PR (called
                                 by fleet-up after clear-all).
+  reconcile [--apply] [--repo o/r] ...
+                                Cross-surface reconciliation pass: cross-
+                                checks labels, open-PR state, host-local FS
+                                claims, and reservations AGAINST each other
+                                and reports drift. Report-only by default
+                                (mutates nothing; writes
+                                ~/.fleet/state/drift-report.json). With
+                                --apply, performs only host-local,
+                                TTL/corroboration-gated auto-fixes:
+                                  R1/R5 stale FS claim (no open PR + age>TTL)
+                                        → release FS lock + this host's
+                                        claim label + fleet:in-progress;
+                                  R3    reservation/claim owner mismatch (or
+                                        reservation with no claim + no PR)
+                                        → drop the stale reservation;
+                                  R4a   design-blocked + design-unblocked on
+                                        the same issue/PR → keep the most-
+                                        recently-applied, remove the older;
+                                  R4b   queued + in-progress with no claim
+                                        (any host) + no open PR → remove the
+                                        stale fleet:in-progress.
+                                R2 (orphaned WIP/feedback PR with no claim)
+                                is report-only. Cross-host is flag-only by
+                                construction — never auto-releases another
+                                host's FS state or claim label. Defaults to
+                                engine + game (when reachable); --repo
+                                overrides. Run by fleet-up at boot (Step 3b).
 
 reservation commands (worktree-pinning, distinct from claims):
   reserve <issue-number> <worktree> [branch]

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -252,7 +252,8 @@ label_added_epoch() {
     command -v gh >/dev/null 2>&1 || { echo 0; return 0; }
     local added_at
     added_at=$(gh api "repos/${repo}/issues/${target}/events" --paginate \
-        --jq '.[] | select(.event=="labeled" and .label.name=="'"$label"'") | .created_at' \
+        --arg lname "$label" \
+        --jq '.[] | select(.event=="labeled" and .label.name==$lname) | .created_at' \
         2>/dev/null | tail -n1 || true)
     [[ -z "$added_at" ]] && { echo 0; return 0; }
     ADDED_AT="$added_at" python3 -c '
@@ -1631,6 +1632,8 @@ PYEOF
 # reconcile_reservations_json
 #   Emit the reservation set as a JSON array (worktree, task_id, branch,
 #   created_epoch) so the classifier can detect reservation/claim drift.
+#   Reservations carry no namespace (game tasks do not use worktree
+#   reservations), so the R3 block hardcodes the engine repo.
 reconcile_reservations_json() {
     reservations_dump | python3 -c '
 import sys, json
@@ -1951,7 +1954,7 @@ PYEOF
                     if [[ "$e_block" -eq 0 && "$e_unblock" -eq 0 ]]; then
                         echo "  reconcile --apply: R4a could not order labels on $c_repo #$c_target; skipping" >&2
                     else
-                        if [[ "$e_block" -ge "$e_unblock" ]]; then
+                        if [[ "$e_block" -ge "$e_unblock" ]]; then  # timestamp tie → keep blocked (conservative)
                             older="fleet:design-unblocked"
                         else
                             older="fleet:design-blocked"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -721,9 +721,16 @@ fi
 if command -v fleet-claim >/dev/null 2>&1; then
     fleet-claim clear-all
     fleet-claim reset-sweep-host-claims || true
+    # Cross-surface reconcile is safe to run aggressively at boot: the
+    # dispatcher hasn't launched yet (Step 3f), so no live pane can race
+    # the auto-fixes. Report-only by default; --apply repairs host-local
+    # drift the single-surface sweeps above can't see (reservation/claim
+    # mismatches, contradictory design labels, orphaned fleet:in-progress).
+    fleet-claim reconcile --apply || true
 elif [[ -x "$ENGINE/scripts/fleet/fleet-claim" ]]; then
     "$ENGINE/scripts/fleet/fleet-claim" clear-all
     "$ENGINE/scripts/fleet/fleet-claim" reset-sweep-host-claims || true
+    "$ENGINE/scripts/fleet/fleet-claim" reconcile --apply || true
 else
     echo "fleet-up: fleet-claim not found — skipping claims cleanup"
     echo "          (run scripts/fleet/install.sh to install it)"

--- a/scripts/fleet/tests/test_fleet_claim_reconcile.sh
+++ b/scripts/fleet/tests/test_fleet_claim_reconcile.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim's `reconcile` cross-surface reconciliation pass (#1356).
+#
+# reconcile cross-checks the four claim surfaces — issue/PR labels, open-PR
+# state, host-local FS claims, and reservations — and reports (report-only,
+# default) or repairs (--apply) drift between them.
+#
+# These tests stub `gh` so the label/PR surfaces are canned JSON instead of
+# live GitHub. The host is pinned to `mac` via FLEET_TEST_HOST so claim-label
+# construction is deterministic.
+#
+# Synthetic drift fixture (engine repo):
+#   - FS claim #500 (owner opus-worker-1, created 1h ago, no open PR) → R1
+#     stale host-local claim. Also reserved by opus-worker-1.
+#   - FS claim #501 (owner opus-worker-2, created now, no open PR) → fresh,
+#     must NOT be reaped.
+#   - FS claim #502 (owner opus-worker-3) + reservation opus-worker-9 → #502
+#     → R3 reservation/claim-owner mismatch (drop the reservation, keep claim).
+#   - issue #503 carries design-blocked + design-unblocked → R4a contradiction
+#     (design-unblocked applied later → remove the older design-blocked).
+#   - issue #504 carries queued + in-progress, no claim/PR → R4b stale in-progress.
+#   - PR #600 (head claude/505-orphan, fleet:wip) with no claim → R2 flag only.
+#
+# Covers the acceptance criteria of #1356:
+#   - report-only mutates nothing and writes a well-formed drift-report.json
+#   - --apply clears the stale claim (FS lock + label) and the mismatched
+#     reservation, but leaves the fresh claim alone
+#   - contradictory design labels collapse to the most-recently-applied
+#   - a `mac` reconcile only ever removes fleet:claim-mac-* labels
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad()  { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+assert_dir_present() {
+    if [[ -d "$1" ]]; then ok "$2"; else bad "$2 (dir missing: $1)"; fi
+}
+assert_dir_absent() {
+    if [[ ! -d "$1" ]]; then ok "$2"; else bad "$2 (dir still present: $1)"; fi
+}
+assert_file_present() {
+    if [[ -f "$1" ]]; then ok "$2"; else bad "$2 (file missing: $1)"; fi
+}
+assert_file_absent() {
+    if [[ ! -f "$1" ]]; then ok "$2"; else bad "$2 (file still present: $1)"; fi
+}
+assert_removed_contains() {
+    if grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; then ok "$2"; else bad "$2 (not in removed log)"; fi
+}
+assert_removed_absent() {
+    if ! grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; then ok "$2"; else bad "$2 (unexpectedly removed)"; fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+export FLEET_TEST_HOST="mac"
+export FLEET_CLAIM_STALE_SECS=1800
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR" "$FLEET_STATE_DIR"
+
+REPORT="$FLEET_STATE_DIR/drift-report.json"
+REMOVED_FILE="$TMPROOT/removed.log"
+: > "$REMOVED_FILE"
+export REMOVED_FILE
+
+# --- canned label/PR surfaces ---------------------------------------------
+export ISSUES_JSON="$TMPROOT/issues.json"
+export PRS_JSON="$TMPROOT/prs.json"
+cat > "$ISSUES_JSON" <<'JSON'
+[
+  {"number":500,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:in-progress"}]},
+  {"number":501,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-2"},{"name":"fleet:in-progress"}]},
+  {"number":503,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:design-blocked"},{"name":"fleet:design-unblocked"}]},
+  {"number":504,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:in-progress"}]}
+]
+JSON
+cat > "$PRS_JSON" <<'JSON'
+[
+  {"number":600,"headRefName":"claude/505-orphan","labels":[{"name":"fleet:wip"}],"body":"Work in progress."},
+  {"number":601,"headRefName":"claude/topic-506","labels":[{"name":"fleet:wip"}],"body":"Implements the thing.\n\nCloses #506\n"}
+]
+JSON
+
+# --- gh stub --------------------------------------------------------------
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+# Stub gh for reconcile tests.
+case "$1" in
+    issue)
+        case "$2" in
+            list) cat "$ISSUES_JSON"; exit 0 ;;
+            edit)
+                shift 2
+                issue="$1"; shift
+                while [[ $# -gt 0 ]]; do
+                    case "$1" in
+                        --remove-label) printf '%s\t%s\n' "$issue" "$2" >> "$REMOVED_FILE"; shift 2 ;;
+                        *) shift ;;
+                    esac
+                done
+                exit 0
+                ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    pr)
+        case "$2" in
+            list) cat "$PRS_JSON"; exit 0 ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    api)
+        # events endpoint; emulate --jq selecting created_at by label name.
+        # design-unblocked applied later than design-blocked.
+        if printf '%s ' "$@" | grep -q 'design-unblocked'; then
+            echo "2026-05-29T02:00:00Z"
+        elif printf '%s ' "$@" | grep -q 'design-blocked'; then
+            echo "2026-05-29T01:00:00Z"
+        fi
+        exit 0
+        ;;
+    repo) exit 1 ;;   # game repo "not reachable" (unused; explicit --repo)
+    label) exit 0 ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+# --- build the synthetic drift fixture ------------------------------------
+NOW=$(date +%s)
+mk_claim() {
+    local slug="$1" owner="$2" created="$3"
+    mkdir -p "$FLEET_CLAIMS_DIR/$slug"
+    echo "$owner"   > "$FLEET_CLAIMS_DIR/$slug/owner"
+    echo "$slug"    > "$FLEET_CLAIMS_DIR/$slug/title"
+    echo "$created" > "$FLEET_CLAIMS_DIR/$slug/created"
+}
+mk_claim 500 opus-worker-1 $((NOW - 3600))   # stale → R1
+mk_claim 501 opus-worker-2 "$NOW"            # fresh → survives
+mk_claim 502 opus-worker-3 "$NOW"            # fresh, but reservation mismatches
+mk_claim 506 opus-worker-4 $((NOW - 3600))   # stale age, BUT PR #601 closes it via body
+
+# Reservations: opus-worker-1 → #500 (consistent, dropped by R1 release),
+#               opus-worker-9 → #502 (owner mismatch vs claim → R3 drop)
+"$FLEET_CLAIM" reserve 500 opus-worker-1 >/dev/null
+"$FLEET_CLAIM" reserve 502 opus-worker-9 >/dev/null
+
+echo "=== Phase 1: report-only (must mutate nothing) ==="
+REPORT_OUT=$("$FLEET_CLAIM" reconcile --repo jakildev/IrredenEngine 2>&1)
+echo "$REPORT_OUT" | sed 's/^/    /'
+
+# Nothing mutated.
+assert_dir_present "$FLEET_CLAIMS_DIR/500" "report-only keeps stale FS claim #500"
+assert_dir_present "$FLEET_CLAIMS_DIR/501" "report-only keeps fresh FS claim #501"
+assert_dir_present "$FLEET_CLAIMS_DIR/502" "report-only keeps FS claim #502"
+assert_dir_present "$FLEET_CLAIMS_DIR/506" "report-only keeps FS claim #506 (PR closes it via body)"
+assert_file_present "$FLEET_RESERVATIONS_DIR/opus-worker-1.json" "report-only keeps reservation opus-worker-1"
+assert_file_present "$FLEET_RESERVATIONS_DIR/opus-worker-9.json" "report-only keeps reservation opus-worker-9"
+if [[ ! -s "$REMOVED_FILE" ]]; then ok "report-only issued no gh remove-label"; else bad "report-only mutated labels: $(cat "$REMOVED_FILE")"; fi
+assert_file_present "$REPORT" "report-only wrote drift-report.json"
+
+# Report is well-formed and classifies the expected rules.
+python3 - "$REPORT" <<'PY' && ok "drift-report.json well-formed + expected rules" || bad "drift-report.json malformed or missing rules"
+import sys, json
+r = json.load(open(sys.argv[1]))
+assert r["apply"] is False, "apply should be false in report-only"
+assert r["host"] == "mac"
+rules = {f["rule"] for f in r["findings"]}
+for want in ("R1", "R3", "R4a", "R4b", "R2"):
+    assert want in rules, f"missing rule {want}: {rules}"
+# Fresh claim #501 must NOT be an R1 finding.
+r1_targets = {f["target"] for f in r["findings"] if f["rule"] == "R1"}
+assert 500 in r1_targets, "R1 should flag #500"
+assert 501 not in r1_targets, "R1 must NOT flag fresh #501"
+# #506 is stale-aged but its PR closes it via a Closes #506 body ref (non-
+# standard branch claude/topic-506) — robust PR match must suppress R1.
+assert 506 not in r1_targets, "R1 must NOT flag #506 (PR closes it via body)"
+# Flag-only R2 carries no apply action.
+r2 = [f for f in r["findings"] if f["rule"] == "R2"]
+assert all(f["apply"] is None for f in r2), "R2 must be flag-only"
+PY
+
+echo "=== Phase 2: --apply (gated host-local repairs) ==="
+APPLY_OUT=$("$FLEET_CLAIM" reconcile --apply --repo jakildev/IrredenEngine 2>&1)
+echo "$APPLY_OUT" | sed 's/^/    /'
+
+# R1: stale claim released (FS lock gone + its reservation dropped).
+assert_dir_absent  "$FLEET_CLAIMS_DIR/500" "--apply released stale FS claim #500"
+assert_file_absent "$FLEET_RESERVATIONS_DIR/opus-worker-1.json" "--apply dropped #500 reservation"
+assert_removed_contains $'500\tfleet:claim-mac-opus-worker-1' "--apply removed #500 host claim label"
+assert_removed_contains $'500\tfleet:in-progress' "--apply removed #500 fleet:in-progress"
+
+# Fresh claim survives; #506 survives because its PR closes it via body.
+assert_dir_present "$FLEET_CLAIMS_DIR/501" "--apply keeps fresh FS claim #501"
+assert_dir_present "$FLEET_CLAIMS_DIR/506" "--apply keeps FS claim #506 (PR closes it via body)"
+
+# R3: mismatched reservation dropped, claim kept.
+assert_dir_present  "$FLEET_CLAIMS_DIR/502" "--apply keeps claim #502 (authoritative)"
+assert_file_absent  "$FLEET_RESERVATIONS_DIR/opus-worker-9.json" "--apply dropped mismatched reservation opus-worker-9"
+
+# R4a: older design-blocked removed, design-unblocked kept.
+assert_removed_contains $'503\tfleet:design-blocked' "--apply removed older design-blocked on #503"
+assert_removed_absent  $'503\tfleet:design-unblocked' "--apply kept newer design-unblocked on #503"
+
+# R4b: stale in-progress removed.
+assert_removed_contains $'504\tfleet:in-progress' "--apply removed stale fleet:in-progress on #504"
+
+# A mac reconcile must only ever touch fleet:claim-mac-* labels.
+if ! grep -q 'fleet:claim-linux' "$REMOVED_FILE" 2>/dev/null; then ok "mac reconcile removed no fleet:claim-linux-* labels"; else bad "mac reconcile touched a linux claim label"; fi
+
+# Report reflects apply mode.
+python3 - "$REPORT" <<'PY' && ok "apply drift-report.json marks fixes applied" || bad "apply drift-report.json wrong"
+import sys, json
+r = json.load(open(sys.argv[1]))
+assert r["apply"] is True
+applied = [f for f in r["findings"] if f.get("apply")]
+assert applied and all(f["applied"] is True for f in applied), "fix findings should be applied=true"
+PY
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds `fleet-claim reconcile [--apply] [--repo <owner/repo>]` — the C1 core of
the cross-surface reconciliation pass (epic #1339). Every existing sweep is
single-surface (`cmd_cleanup_gh`, `cmd_check_stale`,
`cmd_reset_sweep_host_claims`); `reconcile` is the first pass that cross-checks
the **four** claim surfaces against each other:

- issue/PR **labels** (`fleet:claim-*`, `fleet:in-progress`, design labels)
- open **PR state** (head `claude/<N>-*` **or** a `Closes/Fixes/Resolves #N` body ref)
- host-local **FS claims** (`$CLAIMS_DIR/*/`)
- worktree **reservations**

**Report-only by default** — classifies drift, prints a findings table, and
writes `~/.fleet/state/drift-report.json`, mutating nothing. **`--apply`** does
only the host-local, TTL/corroboration-gated auto-fixes:

- **R1/R5** — stale FS claim (no open PR + age > TTL) → release FS lock + this
  host's claim label + `fleet:in-progress`
- **R3** — reservation/claim owner mismatch (or reservation with no claim and
  no PR) → drop the stale reservation; the claim is authoritative
- **R4a** — `design-blocked` + `design-unblocked` on the same issue/PR → keep
  the most-recently-applied (events-API timestamp), remove the older
- **R4b** — `queued` + `in-progress` with no claim (any host) + no open PR →
  remove the stale `fleet:in-progress` (hard-gated)
- **R2** — orphaned WIP/feedback PR with no claim/reservation → **flag only**

Cross-host is flag-only by construction: a `mac` reconcile only ever touches
`fleet:claim-mac-*` labels and never another host's FS state. Reuses the
existing primitives (`__remove_claim`, `gh_release_label` + orphan sentinels,
`cmd_release_worktree`, `reservations_dump`, `derive_host`); the new
`label_added_epoch` helper generalizes the events-API timestamp method for R4a.

Wired into `fleet-up` Step 3b boot (`reconcile --apply` after
`reset-sweep-host-claims`), where aggressive auto-fix is safe — the dispatcher
hasn't launched yet, so no live pane can race.

The periodic scout path and R6 (`human:owned`) are **deferred to C2 (#1357)**,
deliberately, so the report-only output is observed before any periodic
auto-fix touches state a live pane also mutates.

## Test plan

- [x] `bash -n scripts/fleet/fleet-claim scripts/fleet/fleet-up` — syntax clean
- [x] New `scripts/fleet/tests/test_fleet_claim_reconcile.sh` (22 assertions):
      report-only mutates nothing + writes well-formed `drift-report.json`;
      `--apply` clears a synthetic stale claim (FS lock + label) and a
      mismatched reservation; fresh claim survives; contradictory design labels
      collapse to most-recent; a `Closes #N`-body PR with a non-standard branch
      suppresses a false R1; `mac` reconcile removes no `fleet:claim-linux-*`
- [x] No regression: `test_fleet_claim_blockers.sh`, `test_fleet_claim_model_gate.sh`,
      `test_fleet_claim_stackable_live_resolve.sh` all pass
- [x] Live read-only `fleet-claim reconcile` against both repos — clean report,
      well-formed `~/.fleet/state/drift-report.json`

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)
