### PR TITLE
fleet: merger covers the game repo (conflict loop), not engine-only

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -4,10 +4,12 @@ description: Merger orchestrator — auto-resolves mechanical PR conflicts, labe
 ---
 
 You are the **merger orchestrator** for the Irreden Engine fleet,
-running in `~/src/IrredenEngine/.claude/worktrees/merger` (host can
+launched in `~/src/IrredenEngine/.claude/worktrees/merger` (host can
 be WSL2 Ubuntu or macOS). You proactively rebase open PRs that have
 gone stale and auto-resolve mechanical conflicts so the human only
-sees the ones that need human judgement.
+sees the ones that need human judgement. You cover **both repos** —
+the engine pass runs in your engine worktree, then a game pass runs
+in `~/src/IrredenEngine/creations/game/.claude/worktrees/merger`.
 
 Inspired by gas town's **Refinery** role — a dedicated agent whose
 only job is sequential intelligent merging.
@@ -30,16 +32,25 @@ See [docs/agents/FLEET-RUNTIME.md § Exit protocol](../../docs/agents/FLEET-RUNT
 
 ## What you do
 
-You poll open PRs on the **engine repo** every 10 minutes. For each
-PR in CONFLICTING state, you try to auto-resolve and push, or mark
-it for the human if the conflict is non-mechanical.
+You poll open PRs on **both repos** (engine + game) every 10 minutes.
+For each PR in CONFLICTING state, you try to auto-resolve and push, or
+mark it for the human if the conflict is non-mechanical.
 
-**v1 scope: engine PRs only.** Game-repo PRs (`creations/game/`)
-are deferred to v2 — handling them requires the merger worktree to
-be able to switch its remote tracking, which is outside this
-iteration's scope.
+**Both repos, two passes.** Steps 1–6 below are the **engine pass**
+(cwd = your engine worktree, `repos.engine.prs[]`, default `gh` repo).
+After the engine pass, the **game pass** repeats the *core conflict
+loop* for `repos.game.prs[]` — see "## Game-repo pass" after step 5.
+The 2-candidate-per-iteration cap is **shared** across both passes, so
+you rebase at most 2 PRs total per iteration regardless of repo.
 
-You are conservative. The v1 scope is intentionally narrow:
+**Stacked-PR machinery is engine-only and that is correct, not a gap.**
+Steps 2.5, 2.6, a.5, and a.6 (stacked-base re-targeting, cascade
+rebase, fork detection) do not run in the game pass: game-side worker
+pickup skips stackable blockers (see FLEET.md "Cross-author stacking"),
+so game PRs are never stacked. The game pass is the plain conflict loop
+only.
+
+You are conservative. The auto-resolution scope is intentionally narrow:
 
 - **Plain rebase that has no conflicts** — the PR's commits replay
   cleanly on top of new master. Push the rebased branch.
@@ -785,6 +796,59 @@ exit cleanly:
       never claimed) — it's purely worktree hygiene:
       `git checkout -B claude/merger-scratch origin/master`
 
+## Game-repo pass
+
+After the engine pass (steps 1–5), repeat the **core conflict loop**
+for the game repo. This closes the gap where an approved game PR that
+goes CONFLICTING had no actor and rotted (observed game #99,
+2026-05-30). The logic is identical to the engine pass; only the repo,
+worktree, and `gh` target change.
+
+**Deltas from the engine pass:**
+
+- **cwd** — `cd ~/src/IrredenEngine/creations/game/.claude/worktrees/merger`
+  first. All `git` ops in this pass run there (it tracks the game
+  remote). The bash cwd persists across calls in the iteration.
+- **Every `gh` call gets `--repo jakildev/irreden`** — `gh pr edit`,
+  `gh pr comment`, `gh pr list`, `gh pr view`.
+- **PR source** — read `repos.game.prs[]` from the cache (not
+  `repos.engine.prs[]`).
+- **Scratch branch** — reset the game worktree to scratch up front and
+  after each PR: `git checkout -B claude/merger-scratch origin/master`
+  (run from the game worktree, so `origin` is the game remote).
+- **Shared cap** — the "at most 2 candidates per iteration" cap is a
+  **single budget across both passes**. If the engine pass already
+  rebased 2 PRs, do the game cooldown-clear (below) but process zero
+  game candidates this iteration; they'll be picked up next tick.
+
+**Steps for the game pass:**
+
+1g. **Clear game `fleet:merger-cooldown` labels** — same as step 1, but
+    over `repos.game.prs[]` and with `--repo jakildev/irreden`.
+2g. **Gather + filter candidates** — same candidate rule and skip-label
+    set as step 3 (CONFLICTING, or UNKNOWN updated >5m ago), over
+    `repos.game.prs[]`.
+3g. **Resolve each candidate (within the shared cap)** — run step 5's
+    core resolution: **a** (detached checkout in the game worktree),
+    **b** (rebase guard pre-capture), **c** (`git rebase origin/master`),
+    **d** (clean → push + comment + `fleet:merger-cooldown`;
+    whitespace-only → resolve + push; semantic → `git rebase --abort`,
+    remove stale verdict labels, `fleet:semantic-conflict` +
+    `fleet:merger-cooldown`, comment), **e** (post-rebase hunk check),
+    **f** (reset the game worktree to scratch).
+
+    **Skip the stacked-PR steps entirely** — 2.5, 2.6, a.5 (stacked
+    re-target / cascade) and a.6 (fork detection). Game PRs are never
+    stacked (worker pickup skips game stackables), so `baseRefName` is
+    always `master` on game PRs; treat any game PR as the step-a.5
+    "base is `master`, proceed to step b" case without the lookup.
+
+Semantic game conflicts get `fleet:semantic-conflict` exactly like
+engine — **opus-worker covers game** (it has its own game worktree),
+so the handoff has an actor. Log game-pass actions to the same
+`~/.fleet/logs/merger-audit.log` (prefix the PR with `game#` so the
+two repos' PR-number spaces don't collide in the audit trail).
+
 6. **Shutdown.** See [docs/agents/FLEET-RUNTIME.md § Per-iteration shutdown](../../docs/agents/FLEET-RUNTIME.md#per-iteration-shutdown--final-step).
    `fleet-iteration-summary merger "<PRs processed, outcomes, snags — under 100 words.>"`
    The merger does not reserve worktrees, so skip `release-worktree`;
@@ -833,8 +897,10 @@ See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`]
   internal trail; the comment is the human-visible trail. The
   audit log is durable and append-only; pane output is ephemeral (tmux terminal
   only — the dispatcher does not redirect it to disk).
-- **Process at most 2 PRs per iteration.** Auto-pushes retrigger
-  CI; flooding the queue is worse than slow turnover.
+- **Process at most 2 PRs per iteration — shared across the engine and
+  game passes.** Auto-pushes retrigger CI; flooding the queue is worse
+  than slow turnover. The cap is a single budget: if the engine pass
+  rebased 2 PRs, the game pass processes none this iteration.
 - **One conflict class per iteration.** Do not try a second
   mechanical class on a later PR in the same iteration unless the
   first one succeeded cleanly. Fail-stop.

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -75,7 +75,7 @@ just the items that role works on:
 | opus-worker | `tasks_open` (filtered to `[opus]` tasks, both repos), `needs_plan`, `feedback_prs` |
 | sonnet-reviewer | `candidate_prs` (review-skip filter applied) |
 | opus-reviewer | `flagged_prs` (`fleet:has-nits` / `fleet:needs-fix`) |
-| merger | `prs` (engine, approved or non-MERGEABLE only) |
+| merger | `prs` (engine + game, approved or non-MERGEABLE only; each tagged with its `repo`) |
 
 **opus-reviewer:** review bodies longer than 2 KB are stored as
 head + tail with an `…[truncated]…` separator (the verdict line

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -523,9 +523,11 @@ Two stacking modes exist in this fleet:
 
 **v1 limitations:**
 
-- Engine tasks only — game repo has no merger, so the cascade-rebase
-  step has no actor. The scout may populate `stackable_blocker_pr`
-  for game tasks for visibility, but worker pickup skips them.
+- Engine tasks only — the merger's game pass handles plain conflicts
+  but intentionally omits the stacked-PR cascade-rebase machinery
+  (steps 2.5/2.6/a.5/a.6), so a game stack would have no actor for the
+  cascade step. The scout may populate `stackable_blocker_pr` for game
+  tasks for visibility, but worker pickup skips them.
 - Single-blocker tasks only (see Q3).
 
 For role-specific framing (when to stack, role-specific edge cases),

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1284,19 +1284,19 @@ def slice_queue_manager_ingest(state):
 
 
 def slice_merger(state):
-    # Merger is engine-only (v1 scope per role-merger.md). Game-repo
-    # PRs would just be skipped by the merger's own filter, but
-    # including them in the slice bloats the file with full review
-    # records the role never reads.
+    # Merger covers both repos (role-merger.md runs an engine pass then a
+    # game pass each iteration). Each PR record is tagged with its repo via
+    # _slice_pr_with_repo so the role knows which worktree / --repo to use.
     out = {"prs": []}
-    repo_state = state["repos"].get("engine", {})
-    for pr in repo_state.get("prs", []):
-        labels = set(pr["labels"])
-        mergeable = pr.get("mergeable")
-        approved = "fleet:approved" in labels
-        blocked = mergeable not in (None, "", "MERGEABLE", "UNKNOWN")
-        if approved or blocked:
-            out["prs"].append(_slice_pr_with_repo("engine", pr))
+    for repo_key in ("engine", "game"):
+        repo_state = state["repos"].get(repo_key, {})
+        for pr in repo_state.get("prs", []):
+            labels = set(pr["labels"])
+            mergeable = pr.get("mergeable")
+            approved = "fleet:approved" in labels
+            blocked = mergeable not in (None, "", "MERGEABLE", "UNKNOWN")
+            if approved or blocked:
+                out["prs"].append(_slice_pr_with_repo(repo_key, pr))
     return out
 
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -262,6 +262,11 @@ if [[ -d "$GAME/.git" ]]; then
     # same dual-worktree model as the opus-workers above.
     ensure_worktree "$GAME" .claude/worktrees/sonnet-fleet-1  fleet/game-sonnet-fleet-1
     ensure_worktree "$GAME" .claude/worktrees/sonnet-fleet-2  fleet/game-sonnet-fleet-2
+    # The single merger pane covers both repos (one dispatcher role, two
+    # passes per iteration). This game worktree is where it checks out and
+    # rebases game PRs; the engine pass uses .claude/worktrees/merger under
+    # the engine root above. Same dual-worktree model as the opus-workers.
+    ensure_worktree "$GAME" .claude/worktrees/merger          fleet/game-merger
 else
     echo "fleet-up: game repo not found at $GAME — skipping game panes"
 fi

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -27,11 +27,17 @@ _spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
 _mod = importlib.util.module_from_spec(_spec)
 _loader.exec_module(_mod)
 project_merger = _mod.project_merger
+slice_merger = _mod.slice_merger
 stable_hash = _mod.stable_hash
 
 
 def _state(prs):
     return {"repos": {"engine": {"prs": prs}}}
+
+
+def _state_eng_game(engine_prs, game_prs):
+    return {"repos": {"engine": {"prs": engine_prs},
+                      "game": {"prs": game_prs}}}
 
 
 def _pr(num, *, labels=None, mergeable="MERGEABLE", base="master",
@@ -163,6 +169,38 @@ class SignalSemantics(unittest.TestCase):
     def test_unapproved_is_dropped(self):
         items = project_merger(_state([_pr(101, labels=[])]))
         self.assertEqual(items, [])
+
+
+class MergerCoversBothRepos(unittest.TestCase):
+    """The merger handles engine AND game PRs (the game pass added after the
+    engine-only v1). A CONFLICTING approved game PR must be visible to the
+    merger — the gap that left game #99 rotting with no actor."""
+
+    def test_game_conflict_in_projection(self):
+        items = project_merger(_state_eng_game(
+            engine_prs=[],
+            game_prs=[_pr(99, labels=["fleet:approved"], mergeable="CONFLICTING")],
+        ))
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["repo"], "game")
+        self.assertEqual(items[0]["signal"], "needs-resolve")
+
+    def test_game_conflict_in_slice_tagged_repo(self):
+        out = slice_merger(_state_eng_game(
+            engine_prs=[_pr(101, labels=["fleet:approved"], mergeable="CONFLICTING")],
+            game_prs=[_pr(99, labels=["fleet:approved"], mergeable="CONFLICTING")],
+        ))
+        repos = sorted(pr["repo"] for pr in out["prs"])
+        self.assertEqual(repos, ["engine", "game"])
+
+    def test_slice_excludes_clean_unapproved_game_pr(self):
+        # Same filter as engine: a MERGEABLE, unapproved game PR is not the
+        # merger's business and must not bloat the slice.
+        out = slice_merger(_state_eng_game(
+            engine_prs=[],
+            game_prs=[_pr(99, labels=[], mergeable="MERGEABLE")],
+        ))
+        self.assertEqual(out["prs"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Approved game PRs that go `CONFLICTING` have no actor. The merger is
engine-only ([role-merger.md](.claude/commands/role-merger.md) v1 scope;
`slice_merger` hardcoded `engine`), and nothing else inspects game PR
merge status. So a game PR that goes stale after approval just sits there
— observed live on **game #99** (`fleet:approved` + `CONFLICTING`, no
flag, no comment, no owner).

## Audit: only the merger was missing for game

| Status | Game coverage before this PR |
|---|---|
| Review (→ approve/needs-fix/has-nits) | ✅ reviewer projections iterate all repos (that's how #99 got approved) |
| Feedback (`needs-fix`/`has-nits`/`human:needs-fix`/`design-unblocked`) | ✅ opus-worker handles both repos via its game worktree |
| **Conflict / stale-rebase** | ❌ **merger engine-only — the gap** |
| Merge of approved+clean | human merges (both repos) — not a gap |

## Fix — give the single merger pane a game pass

Mirrors how opus-worker already spans both repos (engine worktree +
per-pane game worktree):

- **fleet-up** — provision `creations/game/.claude/worktrees/merger`.
- **scout `slice_merger`** — iterate `engine` + `game`, each PR tagged
  with its `repo`. `project_merger` already included game, so the slice
  now matches it (also stops the spurious-but-unactionable merger wakes
  that game conflicts were causing).
- **role-merger.md** — replace the "v1 engine-only" scope with a
  **two-pass** model: the engine pass (steps 1–6) runs as before, then a
  **Game-repo pass** repeats the core conflict loop (step 5 a–f) in the
  game worktree with `--repo jakildev/irreden`. The 2-candidate cap is a
  **shared budget** across both passes. Semantic game conflicts →
  `fleet:semantic-conflict`, which **opus-worker** (game-capable) resolves.
- **FLEET.md / FLEET-CACHE.md** — updated to reflect game coverage.

## Deliberately out of scope (not a gap)

The stacked-PR machinery (steps 2.5/2.6/a.5/a.6 — cascade-rebase,
stacked-base re-target, fork detection) stays **engine-only**. Game PRs
are never stacked (worker pickup skips game stackables, per FLEET.md
"Cross-author stacking"), so `baseRefName` is always `master` on game
PRs. FLEET.md now states this precisely instead of "game repo has no
merger."

## Tests

`test_merger_projection.py` +3 (game conflict surfaces in projection and
slice; clean-unapproved game PR excluded) — **18 pass**.
`test_worker_projection.py` unchanged — **25 pass** (no regression).
`fleet-up` / scout parse clean.

## Runtime step

Re-run `fleet-up` to create the game merger worktree; the change takes
effect on the merger's next 10-minute iteration. (In-flight game #99 can
be left for the merger to pick up, or resolved by hand — no dependency.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
