### PR TITLE
fleet: park gated tasks with fleet:needs-human instead of stripping human:approved

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -569,11 +569,17 @@ Do the work, then exit cleanly:
      below.
    - **A step you cannot perform** (e.g. the self-config edit above):
      comment on the issue naming exactly what a human must apply, then
-     bump it out of autonomous pickup so you stop re-claiming it —
-     `gh issue edit <N> --remove-label human:approved --remove-label fleet:queued` —
-     and release your `fleet-claim`. Do NOT re-claim it next iteration:
-     the gate is deterministic, so retrying only burns iterations on a
-     wall until a human applies it.
+     park it out of autonomous pickup so you stop re-claiming it —
+     `gh issue edit <N> --remove-label fleet:queued --add-label fleet:needs-human` —
+     and release your `fleet-claim`. **Keep `human:approved`** — it's the
+     human's durable approval signal, not yours to strip; removing it was
+     the old workaround for the ingest re-stamping `fleet:queued` (it
+     re-queues any `human:approved` issue lacking it), which is exactly
+     what `fleet:needs-human` now suppresses (it's in the ingest skip set,
+     like `fleet:scope-shipped`). Do NOT re-claim it next iteration: the
+     gate is deterministic, so retrying only burns iterations on a wall.
+     The label clears when the human applies the change — then the ingest
+     re-queues it — or the human closes the issue.
 
    **Design escalation via `fleet:design-blocked`.** When the
    blocker is specifically architectural — the assigned task can't

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -792,6 +792,19 @@ Specifically, **never pass these via `--label` when filing**:
   the landing PR; not added if the comment call fails (safe retry on
   next tick). Don't add manually unless you've verified a merged PR
   covers the scope.
+- `fleet:needs-human` — owned by the **author worker** (opus-worker).
+  Set when a queued task can only be completed by a step the fleet
+  can't perform autonomously — most often a gated self-config edit
+  (`.claude/commands/role-*.md`, `.claude/agents/*`). The worker
+  comments naming what the human must apply, removes `fleet:queued`,
+  adds this label, and releases its claim. **`human:approved` is
+  KEPT** — it is the human's durable approval, not the worker's to
+  strip. Like `fleet:scope-shipped`, this label is in the scout's
+  `_INGEST_SKIP_LABELS` and the ingest's stamping skip, so the ingest
+  does NOT re-stamp `fleet:queued` while it's present (removing
+  `human:approved` used to be the only way to defeat that re-stamp —
+  this label replaces that workaround). Clears when the human applies
+  the change (the ingest then re-queues the issue) or closes it.
 - `fleet:queued` / `fleet:task` — owned by **`fleet-queue-ingest`**,
   set after `human:approved` has been observed. Adding it at filing
   time excludes the issue from the ingest search (which looks for

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -92,6 +92,7 @@ fi
 
 LABELS=(
     "fleet:scope-shipped|fbca04|Issue scope already landed under a different T-NNN; queue-manager skipped ingest; human should close"
+    "fleet:needs-human|fbca04|Fleet can't complete this autonomously (e.g. a gated self-config edit); a human must act. Parks the issue out of the queue while KEEPING human:approved; clears when the human resolves it (ingest re-queues) or closes the issue"
     "fleet:state-drift|fbca04|reconcile surfaced unresolved/ambiguous claim-surface drift that persisted across N ticks; one deduped tracking issue, human resolves"
     "fleet:task|0366d6|Task from the fleet issue queue"
     "fleet:epic|cc317c|Parent issue tracking a set of child issues; queue-manager auto-closes when all children close"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -228,7 +228,8 @@ for issue in pending:
     body = view.get('body', '') or ''
     labels = {(l['name'] if isinstance(l, dict) else l) for l in view.get('labels', [])}
 
-    if 'fleet:queued' in labels or 'fleet:scope-shipped' in labels:
+    if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
+            or 'fleet:needs-human' in labels):
         skipped_already += 1
         continue
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -147,6 +147,7 @@ def fetch_prs(repo):
 
 
 _ALREADY_QUEUED_LABELS = frozenset({"fleet:queued", "fleet:scope-shipped"})
+# fleet:needs-human intentionally absent; parked issues remain visible in human_approved[]
 
 # Labels that mark issues the queue-manager role doc explicitly skips at
 # Step 5 — filter these out of the ingest projector/slicer so epics and

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -157,6 +157,8 @@ _INGEST_SKIP_LABELS = frozenset({
     "fleet:needs-plan",
     "fleet:needs-info",
     "fleet:scope-shipped", # scope landed under a different issue; human should close
+    "fleet:needs-human",   # parked: fleet can't do it autonomously, human must act;
+                           # keeps human:approved but must NOT be re-queued
 })
 
 

--- a/scripts/fleet/tests/test_queue_manager_projection.py
+++ b/scripts/fleet/tests/test_queue_manager_projection.py
@@ -191,6 +191,21 @@ class IngestProjectionFiresOnNewApprovedIssue(unittest.TestCase):
         self.assertIn(9003, nums)
         self.assertNotIn(9004, nums)
 
+    def test_needs_human_excluded_from_pending(self):
+        # fleet:needs-human parks an approved issue (fleet can't do it
+        # autonomously) while KEEPING human:approved. The ingest must not
+        # re-stamp fleet:queued — otherwise the worker would re-claim a task
+        # it can never complete. So the issue must be absent from the ingest
+        # set even though human:approved is still on it (#1312).
+        parked = [{"number": 1312, "title": "self-config edit",
+                   "labels": ["human:approved", "fleet:needs-human"]}]
+        h = stable_hash(project_queue_manager_ingest(_state(engine_human_approved=parked)))
+        self.assertEqual(h, stable_hash(project_queue_manager_ingest(_state())),
+                         "needs-human issue must not contribute to the ingest hash")
+        out = slice_queue_manager_ingest(_state(engine_human_approved=parked))
+        self.assertEqual(out["pending_issues"], [],
+                         "needs-human issue must be absent from pending_issues slice")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why `human:approved` was getting stripped

Tracked to one place: [role-opus-worker.md](.claude/commands/role-opus-worker.md)'s
escape hatch for a task that can only be completed by a step the fleet
can't perform autonomously — most often a **gated self-config edit**
(`.claude/commands/role-*.md`, `.claude/agents/*`). Exactly #1312's case
("point role doc at file-epic skill"). The worker comments what a human
must apply, then "bumps it out of pickup" by removing **both**
`human:approved` and `fleet:queued`.

It removed `human:approved` on purpose: `fleet-queue-ingest` **re-stamps
`fleet:queued`** on any `human:approved` issue that lacks it (it skips
only when `fleet:queued` or `fleet:scope-shipped` is already present). So
removing *only* `fleet:queued` would re-queue the issue next ingest tick
→ the worker re-claims a task it can never finish → loop. Stripping
`human:approved` was the only lever to drop it out of the ingest's set —
at the cost of destroying the human's durable approval signal.

Live trace on #1312 — both removed in the same second by the worker:
```
2026-05-30T00:49:36Z  unlabeled human:approved
2026-05-30T00:49:36Z  unlabeled fleet:queued
```

## Fix — `fleet:needs-human`, a park-label modeled on `fleet:scope-shipped`

`fleet:scope-shipped` already parks an approved issue out of the queue
*without* removing `human:approved` (it's in the ingest skip sets). This
adds the sibling for "fleet can't do it autonomously, a human must act":

- **fleet-labels** — new `fleet:needs-human`.
- **scout `_INGEST_SKIP_LABELS`** + **`fleet-queue-ingest`** stamping
  skip — treat `fleet:needs-human` like `fleet:scope-shipped`, so the
  ingest never re-stamps `fleet:queued` while it's present.
- **role-opus-worker** — the escape hatch now does
  `--remove-label fleet:queued --add-label fleet:needs-human` and
  **keeps `human:approved`**. The label clears when the human applies
  the change (ingest re-queues it) or closes the issue.
- **FLEET.md** — documents the label + ownership.

Net: `human:approved` is now only ever set or removed by the human — no
fleet role strips it.

## Tests

`test_queue_manager_projection.py` +1 (`test_needs_human_excluded_from_pending`:
a `human:approved` + `fleet:needs-human` issue contributes nothing to the
ingest projection/slice, so it won't be re-queued) — **14 pass**. Scout
parses; both embedded ingest Python blocks parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
