### PR TITLE
render: consolidate per-frame shadow-feeder cull-viewport derivation across 3 systems (#1291)

### DIFF
--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -872,10 +872,7 @@ struct IsoBounds2D {
 
     /// Returns true if the axis-aligned box spanning [@p aMin, @p aMax]
     /// overlaps these bounds (inclusive on every edge); @p aMin / @p aMax are
-    /// the box's min / max iso corners. The chunk-visibility gate shares this
-    /// test — `buildChunkVisibilityMask` (the GPU mask build) and
-    /// `C_VoxelPool::isRangeVisible` (the CPU rebuild cull) both delegate here
-    /// so the iso-AABB overlap predicate lives in one place.
+    /// the box's min / max iso corners.
     bool overlapsAABB(vec2 aMin, vec2 aMax) const {
         return aMax.x >= min_.x && aMin.x <= max_.x && aMax.y >= min_.y && aMin.y <= max_.y;
     }

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -870,6 +870,16 @@ struct IsoBounds2D {
         return point.x >= min_.x && point.x <= max_.x && point.y >= min_.y && point.y <= max_.y;
     }
 
+    /// Returns true if the axis-aligned box spanning [@p aMin, @p aMax]
+    /// overlaps these bounds (inclusive on every edge); @p aMin / @p aMax are
+    /// the box's min / max iso corners. The chunk-visibility gate shares this
+    /// test — `buildChunkVisibilityMask` (the GPU mask build) and
+    /// `C_VoxelPool::isRangeVisible` (the CPU rebuild cull) both delegate here
+    /// so the iso-AABB overlap predicate lives in one place.
+    bool overlapsAABB(vec2 aMin, vec2 aMax) const {
+        return aMax.x >= min_.x && aMin.x <= max_.x && aMax.y >= min_.y && aMin.y <= max_.y;
+    }
+
     /// Returns the centre of the bounds.
     vec2 center() const {
         return (min_ + max_) * 0.5f;

--- a/engine/prefabs/irreden/render/sun_shadow_constants.hpp
+++ b/engine/prefabs/irreden/render/sun_shadow_constants.hpp
@@ -6,6 +6,7 @@
 #include <irreden/ir_entity.hpp>
 
 #include <irreden/render/components/component_light_source.hpp>
+#include <irreden/render/cull_viewport_state.hpp>
 
 namespace IRPrefab::SunShadow {
 
@@ -48,6 +49,39 @@ inline IRMath::vec3 resolveDirection() {
 // caching by a RESOLVE_SUN_DIRECTION head-of-pipeline system.
 inline IRMath::vec3 getFrameSunDirection() {
     return resolveDirection();
+}
+
+// Per-frame shadow-feeder inputs: the active sun direction and the iso-AABB
+// sweep length, each gated on whether sun shadows are enabled (disabled →
+// zero, the no-widen case for IRMath::shadowFeederIsoBounds). The
+// C_LightSource archetype scan behind getFrameSunDirection() runs only when
+// shadows are on, so resolve this ONCE per frame (a system's beginTick) and
+// reuse the result; don't re-resolve per iterating entity/canvas.
+struct ShadowFeederParams {
+    IRMath::vec3 sunDir_ = IRMath::vec3(0.0f);
+    float sweepDistance_ = 0.0f;
+};
+
+inline ShadowFeederParams frameShadowFeederParams() {
+    if (!IRRender::getSunShadowsEnabled()) {
+        return {};
+    }
+    return {getFrameSunDirection(), kSunShadowMaxDistance};
+}
+
+// The shared frozen-or-live cull viewport at @p margin, widened to the
+// shadow-feeder AABB so off-screen casters within shadow range still feed the
+// sun-depth bake (see IRMath::shadowFeederIsoBounds). Pass the once-per-frame
+// @p params from frameShadowFeederParams(); a caller needing several margins
+// (the voxel rasterizer's chunk + GPU bounds) reuses a single params resolve.
+// Centralizes the cull-viewport → shadow-feeder derivation shared by
+// VOXEL_TO_TRIXEL_STAGE_1, SHAPES_TO_TRIXEL, and REBUILD_GRID_VOXELS.
+inline IRMath::IsoBounds2D shadowFeederCullViewport(int margin, const ShadowFeederParams &params) {
+    return IRMath::shadowFeederIsoBounds(
+        IRRender::getCullViewport().isoViewport(margin),
+        params.sunDir_,
+        params.sweepDistance_
+    );
 }
 
 } // namespace IRPrefab::SunShadow

--- a/engine/prefabs/irreden/render/sun_shadow_constants.hpp
+++ b/engine/prefabs/irreden/render/sun_shadow_constants.hpp
@@ -84,6 +84,18 @@ inline IRMath::IsoBounds2D shadowFeederCullViewport(int margin, const ShadowFeed
     );
 }
 
+inline IRMath::IsoBounds2D shadowFeederCullViewport(
+    int margin,
+    const ShadowFeederParams &params,
+    const IRRender::CullViewportState &cull
+) {
+    return IRMath::shadowFeederIsoBounds(
+        cull.isoViewport(margin),
+        params.sunDir_,
+        params.sweepDistance_
+    );
+}
+
 } // namespace IRPrefab::SunShadow
 
 #endif /* IRREDEN_RENDER_SUN_SHADOW_CONSTANTS_H */

--- a/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
@@ -219,16 +219,8 @@ template <> struct System<SHAPES_TO_TRIXEL> {
             // shaders never clip a shadow-feeder pixel. Sun-direction
             // resolution is gated on the shadow flag so a disabled-
             // shadow creation skips the C_LightSource archetype scan.
-            const bool shadowsEnabled = IRRender::getSunShadowsEnabled();
-            const vec3 sunDir =
-                shadowsEnabled ? IRPrefab::SunShadow::getFrameSunDirection() : vec3(0.0f);
-            const float sweepDistance =
-                shadowsEnabled ? IRPrefab::SunShadow::kSunShadowMaxDistance : 0.0f;
-            cullBounds_ = IRMath::shadowFeederIsoBounds(
-                IRRender::getCullViewport().isoViewport(kMargin),
-                sunDir,
-                sweepDistance
-            );
+            const auto shadowFeeder = IRPrefab::SunShadow::frameShadowFeederParams();
+            cullBounds_ = IRPrefab::SunShadow::shadowFeederCullViewport(kMargin, shadowFeeder);
         } else {
             cullBounds_.reset();
         }

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -58,8 +58,7 @@ inline const std::vector<std::uint32_t> &buildChunkVisibilityMask(
     auto &bounds = pool.getChunkBounds();
     for (int c = 0; c < chunkCount; ++c) {
         const auto &cb = bounds[c];
-        if (cb.isoMax_.x >= viewport.min_.x && cb.isoMin_.x <= viewport.max_.x &&
-            cb.isoMax_.y >= viewport.min_.y && cb.isoMin_.y <= viewport.max_.y) {
+        if (viewport.overlapsAABB(cb.isoMin_, cb.isoMax_)) {
             mask[c] = 1;
         }
     }
@@ -266,8 +265,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
     Buffer *indirectBuf_ = nullptr;
     FrameDataVoxelToCanvas frameData_{};
     // Resolved once per frame in beginTick; read by the per-entity tick.
-    vec3 sunDir_{};
-    float sweepDistance_ = 0.0f;
+    IRPrefab::SunShadow::ShadowFeederParams shadowFeederParams_{};
     // Log-throttle state — emit the render-mode log line only when
     // mode or effective subdivisions change.
     int previousRenderMode_ = -1;
@@ -388,7 +386,6 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             IRRender::getCameraZoom(),
             triangleCanvasTextures.size_
         );
-        const auto &cull = IRRender::getCullViewport();
 
         buildVoxelFrameData(
             frameData_,
@@ -413,17 +410,11 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             previousEffectiveSubdivisions_ = effectiveSub;
         }
 
-        // Sun direction and sweep distance are resolved once per
-        // frame in beginTick (via IRPrefab::SunShadow::getFrameSunDirection)
-        // and cached in params, so no C_LightSource archetype scan
-        // runs per entity.
-        const float sweepDistance = sweepDistance_;
-
-        const IsoBounds2D chunkVp = IRMath::shadowFeederIsoBounds(
-            cull.isoViewport(kCullChunkMargin),
-            sunDir_,
-            sweepDistance
-        );
+        // Shadow-feeder params are resolved once per frame in beginTick
+        // (frameShadowFeederParams), so no C_LightSource archetype scan runs
+        // per entity; shadowFeederCullViewport reuses them at both margins.
+        const IsoBounds2D chunkVp =
+            IRPrefab::SunShadow::shadowFeederCullViewport(kCullChunkMargin, shadowFeederParams_);
         const CardinalIndex chunkCardinal = IRMath::rasterYawCardinalIndex(frameData_.rasterYaw_);
         // Smooth camera Z-yaw (T3 / #1310): while rotating (residual yaw != 0,
         // i.e. the per-axis canvases are active), project the chunk-visibility
@@ -442,7 +433,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
 
         constexpr int kGpuMargin = 4;
         const IsoBounds2D gpuVp =
-            IRMath::shadowFeederIsoBounds(cull.isoViewport(kGpuMargin), sunDir_, sweepDistance);
+            IRPrefab::SunShadow::shadowFeederCullViewport(kGpuMargin, shadowFeederParams_);
         frameData_.cullIsoMin_ = ivec2(IRMath::floor(gpuVp.min_));
         frameData_.cullIsoMax_ = ivec2(IRMath::ceil(gpuVp.max_));
         frameDataBuf_->subData(0, sizeof(FrameDataVoxelToCanvas), &frameData_);
@@ -575,9 +566,7 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // Resolve sun direction once per frame so the per-entity tick
         // reads the cached value instead of scanning C_LightSource
         // once per voxel-pool-canvas pair.
-        const bool shadowsEnabled = IRRender::getSunShadowsEnabled();
-        sunDir_ = shadowsEnabled ? IRPrefab::SunShadow::getFrameSunDirection() : vec3(0.0f);
-        sweepDistance_ = shadowsEnabled ? IRPrefab::SunShadow::kSunShadowMaxDistance : 0.0f;
+        shadowFeederParams_ = IRPrefab::SunShadow::frameShadowFeederParams();
 
         IREntity::EntityId backgroundCanvas = IRRender::getCanvas("background");
         auto background =

--- a/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
@@ -320,8 +320,7 @@ struct C_VoxelPool {
                 return true;
             }
             const ChunkBounds &cb = m_chunkBounds[c];
-            if (cb.isoMax_.x >= viewport.min_.x && cb.isoMin_.x <= viewport.max_.x &&
-                cb.isoMax_.y >= viewport.min_.y && cb.isoMin_.y <= viewport.max_.y) {
+            if (viewport.overlapsAABB(cb.isoMin_, cb.isoMax_)) {
                 return true;
             }
         }

--- a/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
@@ -73,19 +73,12 @@ template <> struct System<REBUILD_GRID_VOXELS> {
         // in the UPDATE pipeline, so getCullViewport() holds the previous
         // frame's render-event snapshot — a one-frame lag that stays
         // consistent with the GPU cull and is invisible for camera pans.
-        const bool shadowsEnabled = IRRender::getSunShadowsEnabled();
-        const vec3 sunDir =
-            shadowsEnabled ? IRPrefab::SunShadow::getFrameSunDirection() : vec3(0.0f);
-        const float sweepDistance =
-            shadowsEnabled ? IRPrefab::SunShadow::kSunShadowMaxDistance : 0.0f;
-
         const IRRender::CullViewportState &cull = IRRender::getCullViewport();
         cullValid_ = cull.canvasSize_.x > 0 && cull.canvasSize_.y > 0;
         if (cullValid_) {
-            chunkVp_ = IRMath::shadowFeederIsoBounds(
-                cull.isoViewport(IRRender::kCullChunkMargin),
-                sunDir,
-                sweepDistance
+            chunkVp_ = IRPrefab::SunShadow::shadowFeederCullViewport(
+                IRRender::kCullChunkMargin,
+                IRPrefab::SunShadow::frameShadowFeederParams()
             );
         }
     }

--- a/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
@@ -78,7 +78,8 @@ template <> struct System<REBUILD_GRID_VOXELS> {
         if (cullValid_) {
             chunkVp_ = IRPrefab::SunShadow::shadowFeederCullViewport(
                 IRRender::kCullChunkMargin,
-                IRPrefab::SunShadow::frameShadowFeederParams()
+                IRPrefab::SunShadow::frameShadowFeederParams(),
+                cull
             );
         }
     }


### PR DESCRIPTION
## Summary

Behavior-preserving DRY cleanup uncovered by #1288's reuse pass. Two duplications consolidated:

**1. Shadow-feeder cull-viewport derivation (was 3 inlined copies).** The 5-step sequence (shadows-enabled gate → sun dir → sweep distance → `getCullViewport().isoViewport(margin)` → `IRMath::shadowFeederIsoBounds`) lived verbatim in `VOXEL_TO_TRIXEL_STAGE_1`, `SHAPES_TO_TRIXEL`, and `REBUILD_GRID_VOXELS`. Now two composable `IRPrefab::SunShadow` helpers in `sun_shadow_constants.hpp`:
- `frameShadowFeederParams()` → `{sunDir_, sweepDistance_}`, the gated resolve done once per frame.
- `shadowFeederCullViewport(margin, params)` → the cull viewport at `margin` widened by the shadow feeder.

The voxel rasterizer keeps its resolve-once / two-margin shape (params cached in `beginTick`), so no per-canvas `C_LightSource` scan is reintroduced.

**2. Chunk iso-AABB overlap test (was 2 copies).** `buildChunkVisibilityMask` (GPU mask build) and `C_VoxelPool::isRangeVisible` (CPU rebuild cull) had the same 4-comparison test against distinct corner types. Both now delegate to a new `IsoBounds2D::overlapsAABB(aMin, aMax)` method in `engine/math`.

No behavior change — every expression is preserved identically.

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean.
- [x] `IRShapeDebug --spin-yaw 90 --auto-screenshot 6` — renders identically to `origin/master` across the cardinal and non-cardinal yaw sweep (AO + sun shadows + voxel/shape culling all intact; no clipping or shadow regression).

## Notes
- Reuse pass flagged two pre-existing duplications in `sun_shadow_constants.hpp` left out of scope here: `resolveDirection` ~80% overlaps `detail::resolveSun` in `system_bake_sun_shadow_map.hpp`, and a `unordered_map::operator[]` in the `SHAPES_TO_TRIXEL` tick. Neither is touched by this PR.

Closes #1291

🤖 Generated with [Claude Code](https://claude.com/claude-code)