### PR TITLE
fleet: reconcile the two host detectors — WSL2 host taxonomy (#1383)

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -79,7 +79,16 @@ coordination mechanisms prevent duplicate work:
   retries on the next iteration). No silent fallback to FS-lock-only.
 - Each host must have its own unique `derive_host()` value (mac, linux,
   windows) — two hosts with the same host tag would generate identical
-  issue labels and skip the tie-break.
+  issue labels and skip the tie-break. The taxonomy is a single canonical
+  set shared by every host-name producer: claim labels (`derive_host`),
+  cross-host smoke (`uname -s` → linux/macos), the build presets, and
+  `commit-and-push`'s `fleet:authored-on-<host>` all agree. **WSL2 derives
+  `linux`** (it runs the `linux-debug` OpenGL build and provides the linux
+  smoke), so `windows` is reserved for native MSYS2/mingw. Run
+  `fleet-claim host` to print this machine's key. **Collision caveat:** a
+  WSL2 host and a native-Linux host both derive `linux`; do not run both as
+  separate fleets simultaneously without forcing `FLEET_TEST_HOST` to
+  disambiguate one. Today's topology (mac + WSL2) is collision-free.
 
 **Ingestion (cross-host race prevention):**
 - The scout fires `fleet-queue-ingest` when new `human:approved` issues

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -164,29 +164,36 @@ slugify() {
 # cleanup only sweeps them off OPEN issues whose claim is abandoned (no
 # matching open `claude/<N>-*` PR + age > TTL).
 
+host_from_uname() {
+    # Pure mapping from a `uname -s` string to the canonical host key
+    # (mac | linux | windows | unknown). Extracted as a seam so a test can
+    # pin every mapping without depending on the runner's real OS.
+    #
+    # WSL2 and native Linux BOTH map to "linux": both run the `linux-debug`
+    # OpenGL build, provide the *linux* cross-host smoke (`fleet:needs-linux-
+    # smoke`), and are stamped `fleet:authored-on-linux` by commit-and-push
+    # (which keys off this same `uname -s`). So the claim-label host token must
+    # also be "linux" for the whole taxonomy to agree on one name per host.
+    # Native Windows (MSYS2 / mingw, where `uname -s` is MINGW*/MSYS*/CYGWIN*)
+    # is the only "windows" host. See #1383.
+    case "$1" in
+        Darwin)                        echo mac ;;
+        Linux)                         echo linux ;;
+        MINGW*|MSYS*|CYGWIN*|Windows*) echo windows ;;
+        *)                             echo unknown ;;
+    esac
+}
+
 derive_host() {
-    # Normalize uname output to one of: mac | windows | linux.
-    # WSL2 (/proc/version contains "Microsoft" or "WSL") maps to "windows"
-    # because the user runs the WSL2 fleet as their Windows fleet.
-    # FLEET_TEST_HOST overrides for test scaffolding.
+    # Canonical host key for this machine: mac | linux | windows.
+    # FLEET_TEST_HOST overrides for test scaffolding (and lets an operator
+    # running WSL2 alongside native Linux force-disambiguate the collision
+    # documented in FLEET.md § Multi-host fleet coordination).
     if [[ -n "${FLEET_TEST_HOST:-}" ]]; then
         echo "$FLEET_TEST_HOST"
         return
     fi
-    local u
-    u=$(uname -s 2>/dev/null || echo Unknown)
-    case "$u" in
-        Darwin) echo mac ;;
-        Linux)
-            if [[ -f /proc/version ]] && grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
-                echo windows
-            else
-                echo linux
-            fi
-            ;;
-        MINGW*|MSYS*|CYGWIN*|Windows*) echo windows ;;
-        *) echo unknown ;;
-    esac
+    host_from_uname "$(uname -s 2>/dev/null || echo Unknown)"
 }
 
 repo_from_ns() {
@@ -3122,6 +3129,17 @@ case "${1:-}" in
     list)
         cmd_list "${2:-}"
         ;;
+    host)
+        # Print this machine's canonical host key (mac|linux|windows), the
+        # token behind every fleet:claim-*/reviewing-*/resolving-*/amending-*
+        # label. With an explicit `uname -s` string as $2, map that instead —
+        # the seam test_derive_host.sh uses to pin each mapping portably.
+        if [[ -n "${2:-}" ]]; then
+            host_from_uname "$2"
+        else
+            derive_host
+        fi
+        ;;
     check-stale)
         shift
         cmd_check_stale "${1:-7200}"
@@ -3355,6 +3373,11 @@ commands:
                                 matching open PR exists.
   check <issue-number>          check if free (exit 0=free, 1=taken).
   list                          list all active claims.
+  host [uname-string]           print this host's canonical key
+                                (mac|linux|windows) used in claim labels;
+                                WSL2 and native Linux both derive "linux".
+                                With an explicit `uname -s` string, map
+                                that instead (test seam).
   stack "<n1> <n2> ..." [agent]
                                 atomically claim a dependency chain
                                 (all-or-nothing).

--- a/scripts/fleet/tests/test_derive_host.sh
+++ b/scripts/fleet/tests/test_derive_host.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim's host taxonomy (derive_host / host_from_uname).
+#
+# #1383 unified the WSL2 host key. derive_host once mapped WSL2 (uname Linux +
+# /proc/version "microsoft") to "windows", disagreeing with the smoke / build /
+# authored-on detectors, which all read raw `uname -s` and call WSL2 "linux".
+# These tests pin the unified mapping through the `fleet-claim host
+# [uname-string]` seam so they pass on any runner OS (no /proc/version or live
+# `uname` dependency).
+#
+# Covers:
+#   - Linux (WSL2 and native) → linux   (the #1383 regression pin)
+#   - Darwin → mac
+#   - MINGW*/MSYS*/CYGWIN* (native Windows) → windows
+#   - unrecognized uname → unknown
+#   - FLEET_TEST_HOST override takes precedence (test-scaffolding contract)
+#   - derive_host (no arg) delegates to host_from_uname with the real uname
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+# Don't let an ambient override leak in from the runner's environment.
+unset FLEET_TEST_HOST
+
+# --- T1: Linux (WSL2 + native) → linux --------------------------------------
+echo "T1: uname Linux → linux (WSL2 and native unified)"
+assert_eq "$("$FLEET_CLAIM" host Linux)" "linux" \
+    "uname Linux maps to linux (#1383: previously windows on WSL2)"
+
+# --- T2: Darwin → mac -------------------------------------------------------
+echo "T2: uname Darwin → mac"
+assert_eq "$("$FLEET_CLAIM" host Darwin)" "mac" "uname Darwin maps to mac"
+
+# --- T3: native Windows uname variants → windows ----------------------------
+echo "T3: native Windows uname variants → windows"
+assert_eq "$("$FLEET_CLAIM" host MINGW64_NT-10.0-19045)" "windows" "MINGW* → windows"
+assert_eq "$("$FLEET_CLAIM" host MSYS_NT-10.0)" "windows" "MSYS* → windows"
+assert_eq "$("$FLEET_CLAIM" host CYGWIN_NT-10.0)" "windows" "CYGWIN* → windows"
+
+# --- T4: unrecognized uname → unknown ---------------------------------------
+echo "T4: unrecognized uname → unknown"
+assert_eq "$("$FLEET_CLAIM" host FreeBSD)" "unknown" "unrecognized uname → unknown"
+
+# --- T5: FLEET_TEST_HOST override precedence --------------------------------
+echo "T5: FLEET_TEST_HOST overrides the real uname"
+assert_eq "$(FLEET_TEST_HOST=mac "$FLEET_CLAIM" host)" "mac" \
+    "FLEET_TEST_HOST=mac wins over real uname"
+
+# --- T6: derive_host delegates to host_from_uname with the real uname -------
+echo "T6: no-arg host == host(uname -s) (delegation wiring)"
+assert_eq "$("$FLEET_CLAIM" host)" "$("$FLEET_CLAIM" host "$(uname -s)")" \
+    "derive_host maps the live uname through host_from_uname"
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Reconciles the two host detectors that disagreed on WSL2 (#1383).

`derive_host()` in `scripts/fleet/fleet-claim` — the token behind every
`fleet:claim-*` / `reviewing-*` / `resolving-*` / `amending-*` label —
mapped WSL2 (`uname Linux` + `/proc/version` "microsoft") to **`windows`**,
on the retired premise that the WSL2 box stands in for a Windows fleet.
Every other host-name producer reads raw `uname -s` and calls WSL2
**`linux`**: the `linux-debug` OpenGL preset, the cross-host smoke poll
(`fleet:needs-linux-smoke`), and `commit-and-push`'s `fleet:authored-on-linux`.
One physical box answered "windows" to claims and "linux" to everything
else — surfaced on PR #1377 as a `fleet:amending-windows-*` label on the
linux/WSL2 host.

**Change (issue's recommended direction): WSL2 derives `linux`.**

- `derive_host()`: Linux (WSL2 or native) → `linux`. The `/proc/version`
  WSL probe is removed — there is no longer a WSL-vs-native distinction.
  `windows` is reserved for native MSYS2/mingw (`uname MINGW*/MSYS*/CYGWIN*`),
  unchanged.
- Mapping extracted into a pure `host_from_uname` seam, exposed via a new
  `fleet-claim host [uname-string]` subcommand (also a human-facing "which
  host am I?").
- `scripts/fleet/tests/test_derive_host.sh` pins every mapping through the
  seam, portably (no `/proc/version` or live-`uname` dependency). 8/8 green.
- `docs/agents/FLEET.md` § Multi-host coordination documents the single
  canonical taxonomy + the WSL2/native-Linux collision caveat.

No other producer/consumer needed a change — they already key off
`uname -s` and now agree with `derive_host`.

## ⚠️ Deploy / cutover note (for the human merger)

After this deploys, this host's claim labels switch from the `windows`
token to `linux`. Existing in-flight `*-windows-*` claim/reviewing labels
on open issues/PRs (e.g. #1377's `fleet:reviewing-windows-*`) orphan until
`fleet-claim cleanup --gh` sweeps them on the TTL. **Cut over at a
`fleet-down` / `fleet-up` boundary** so the old and new tokens don't run
concurrently on the same box.

## Out of scope (noted follow-up)

`commit-and-push`'s `host-label.md` and the smoke-worker still derive the
host inline via their own `uname -s` case statements. They agree with
`derive_host` today, so no change was required; a later cleanup could have
them all call `fleet-claim host` for a single implementation. Left out to
keep this PR focused on the reconciliation #1383 asked for.

## Test plan

- [x] `scripts/fleet/tests/test_derive_host.sh` — 8/8 (Linux→linux,
  Darwin→mac, MINGW/MSYS/CYGWIN→windows, unknown, FLEET_TEST_HOST
  precedence, derive_host↔uname delegation).
- [x] `test_fleet_claim_model_gate.sh` (11), `test_fleet_claim_blockers.sh`
  (12), `test_fleet_claim_reconcile.sh` (22), `test_fleet_claim_reconcile_c2.sh`
  (16) — all green, no regression.
- [x] `bash -n scripts/fleet/fleet-claim` clean; `fleet-claim host` → `linux`
  on this WSL2 box (was `windows`).

Closes #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)