### PR TITLE
fleet-claim: sole-holder claim closes _acquire_label_on co-win hole

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -45,10 +45,14 @@ itself). Together they catch:
 - **Cross-host races** — both hosts' FS locks succeed independently
   (separate filesystems). Both attempt to apply
   `fleet:claim-<host>-<agent>` on the issue. After applying, each
-  host re-reads the issue's label set and runs an atomic lex-min
-  tie-break: if any other `fleet:claim-*` label has a lower name,
-  the loser removes its own label and rolls back its FS claim with
-  exit 1 ("race lost on issue-label tie-break").
+  host re-reads the issue's label set and resolves a **sole-holder**
+  claim: you win only if no other `fleet:claim-*` label is present.
+  If others are present and yours is the lex-min you drop and retry
+  (so a simultaneous race converges to exactly one winner); otherwise
+  you yield to the existing holder, remove your own label, and roll
+  back the FS claim with exit 1. This closes the co-win hole where a
+  later, lex-smaller claimant beat an existing holder that had passed
+  its own snapshot check and never re-validated (#1384).
 
 Once the worker opens its PR, `fleet-state-scout` derives Owner
 from the PR's `headRefName` (e.g. `claude/1195-foo` → Owner
@@ -67,11 +71,13 @@ coordination mechanisms prevent duplicate work:
 **Task claiming (two layers):**
 1. **FS lock** (`~/.fleet/claims/<issue-slug>/` via atomic `mkdir`) —
    prevents same-host races. Per-host only.
-2. **Issue-label tie-break** (`fleet:claim-<host>-<agent>` on the
-   GitHub issue) — atomic lex-min tie-break. After applying the
-   label, each host re-reads the issue's labels; if another
-   `fleet:claim-*` label has a lower name, the loser removes its
-   label and rolls back its FS claim.
+2. **Issue-label claim** (`fleet:claim-<host>-<agent>` on the
+   GitHub issue) — atomic sole-holder claim. After applying the
+   label, each host re-reads the issue's labels: a claimant wins only
+   as the sole `fleet:claim-*` holder; the lex-min of a simultaneous
+   race drops and retries to re-acquire alone, and any later claimant
+   that finds an existing holder yields and rolls back its FS claim
+   (#1384).
 
 **Requirements for cross-host safety:**
 - The GitHub issue must be reachable at claim time. If `gh issue edit
@@ -926,17 +932,19 @@ Specifically, **never pass these via `--label` when filing**:
   is set, or on abort paths. Host disambiguation
   (mac / linux / windows) is required for correctness — both hosts
   can have an `opus-reviewer` agent; without the host prefix the
-  deterministic-min tie-break would collide. The lex-min of all
-  `fleet:reviewing-*` labels on the PR wins; losers self-remove their
-  label and exit 1. Reviewer / smoke-pickup agents **skip any PR
-  carrying any `fleet:reviewing-*` label** as a fast-path filter,
-  but the real mutex is `fleet-claim review-claim` itself (TOCTOU on
-  the label list is benign — the atomic POST resolves the race).
+  sole-holder claim would collide. A claimant wins only as the sole
+  `fleet:reviewing-*` holder; in a simultaneous race the lex-min drops
+  and retries to re-acquire alone, and any later claimant that finds an
+  existing holder yields (exit 1). Reviewer / smoke-pickup agents
+  **skip any PR carrying any `fleet:reviewing-*` label** as a fast-path
+  filter, but the real mutex is `fleet-claim review-claim` itself — and
+  it now holds even when a later claim is lex-smaller than the existing
+  holder (#1384), so two same-prefix holders never coexist.
   The scout's `fleet-claim cleanup --gh` pass sweeps labels older
   than 30 min and replays orphan sentinels from failed removals.
   Don't add manually; don't add to issues.
 - `fleet:amending-<host>-<agent>` — owned by the **`fleet-claim`
-  script** (atomic feedback-claim primitive; same lex-min tie-break as
+  script** (atomic feedback-claim primitive; same sole-holder claim as
   `fleet:reviewing-`). The **single mutex for all feedback handling**:
   the author worker acquires it via `fleet-claim amending-claim` as the
   **first** action of feedback pickup — before reading feedback,

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -372,7 +372,9 @@ for name in sorted(
                 # Drop and retry: in a simultaneous race the lex-larger
                 # contenders yield, so the next POST re-acquires alone.
                 gh_release_label "$repo" "$target" "$label" || true
-                _acquire_jitter_sleep
+                if (( attempt < retries )); then
+                    _acquire_jitter_sleep
+                fi
                 continue
                 ;;
             *)  # lose

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -7,8 +7,8 @@
 #
 # Same-host atomicity: atomic mkdir(2) under $CLAIMS_DIR. Cross-host
 # atomicity: a `fleet:claim-<host>-<agent>` label on the linked issue
-# with lex-min tie-break (the same primitive used by review-claim,
-# resolving-claim, and amending-claim).
+# with a sole-holder claim (the same primitive used by review-claim,
+# resolving-claim, and amending-claim — see _acquire_label_on / #1384).
 #
 # Slug canonicalization: the issue number itself, optionally prefixed
 # with the global --repo namespace (engine → "<N>", game → "game-<N>").
@@ -144,9 +144,11 @@ slugify() {
 # Cross-host atomicity for task claims is provided by a
 # `fleet:claim-<host>-<agent>` label on the linked issue. POST .../labels
 # is atomic; the response includes the resulting label set, which we
-# filter to the `fleet:claim-*` prefix and take the lex-min as the winner.
-# If our label isn't the lex-min we lost the race; we remove our label and
-# the caller exits 1.
+# filter to the `fleet:claim-*` prefix. We win only as the SOLE holder of
+# the prefix; if others are present and ours is the lex-min we drop and
+# retry to re-acquire alone, otherwise we yield to the existing holder,
+# remove our label, and the caller exits 1. See _acquire_label_on for the
+# full algorithm and #1384 for the co-win hole this closes.
 #
 # The same _acquire_label_on primitive backs:
 #   - fleet:reviewing-<host>-<agent>  (reviewer + cross-host smoke claim)
@@ -266,50 +268,126 @@ except Exception:
 ' 2>/dev/null || echo 0
 }
 
+# _claim_decision <mine> <matching-label>...
+#   PURE decision helper (no I/O) — the table-testable seam for the claim
+#   mutex. Given my just-POSTed label and the full set of <prefix>* labels
+#   present on the POST response (which includes mine), decide the outcome:
+#     win   — I am the SOLE holder of the prefix → own the lock.
+#     retry — other holders are present but I am the lex-min → drop my label
+#             and retry alone; in a simultaneous race the lex-larger
+#             contenders also drop, so the retry re-acquires uncontested.
+#     lose  — other holders are present and an earlier/lex-smaller one
+#             remains → yield to it.
+#   This replaces the old "win iff I'm the lex-min of the snapshot" rule,
+#   which let a LATER, lex-smaller claimant co-win with an existing holder
+#   that had already passed its own check and never re-validated (#1384).
+_claim_decision() {
+    local mine="$1"; shift
+    local has_other=0 lbl
+    for lbl in "$@"; do
+        [[ "$lbl" != "$mine" ]] && has_other=1
+    done
+    if [[ "$has_other" -eq 0 ]]; then
+        echo win
+        return 0
+    fi
+    local lexmin
+    lexmin=$(printf '%s\n' "$@" | LC_ALL=C sort | head -n1)
+    if [[ "$mine" == "$lexmin" ]]; then
+        echo retry
+    else
+        echo lose
+    fi
+}
+
+# _acquire_jitter_sleep
+#   Brief jittered backoff between claim retries so simultaneous racers
+#   don't lock-step. No-op under FLEET_CLAIM_NO_SLEEP=1 (test determinism).
+_acquire_jitter_sleep() {
+    [[ "${FLEET_CLAIM_NO_SLEEP:-0}" == "1" ]] && return 0
+    local ms=$(( (RANDOM % 400) + 100 ))   # 100–499 ms
+    sleep "$(printf '0.%03d' "$ms")"
+}
+
 # _acquire_label_on <repo> <pr-or-issue> <label> <label-prefix>
-#   Atomic-add + deterministic-min tie-break primitive. PRs and issues
-#   share GitHub's /issues/N/labels endpoint, so this works for both.
+#   Atomic-add + sole-holder-wins claim primitive. PRs and issues share
+#   GitHub's /issues/N/labels endpoint, so this works for both.
 #
-#   Returns 0 if our label is the lex-min of all <label-prefix>*
-#   labels on the response (we own the lock); 1 otherwise (we lost
-#   the race and self-removed our label). On API error, returns 1.
+#   Contract: at most one holder of <label-prefix>* on the target at a
+#   time. Returns 0 if we own the lock (sole holder after our POST), 1
+#   otherwise (we lost / yielded and self-removed our label). On API
+#   error, returns 1.
+#
+#   Algorithm (Option A from #1384): POST our label, re-read the <prefix>*
+#   set, and route through _claim_decision. `win` → hold; `retry` → drop
+#   and re-POST (bounded by FLEET_CLAIM_ACQUIRE_RETRIES, default 3, with a
+#   jittered backoff) so a simultaneous race converges to one winner;
+#   `lose` → yield to the existing holder. This closes the co-win hole
+#   where a later, lex-smaller claimant beat an existing holder that had
+#   passed its own snapshot check and never re-validated.
 _acquire_label_on() {
     local repo="$1" target="$2" label="$3" prefix="$4"
+    local retries="${FLEET_CLAIM_ACQUIRE_RETRIES:-3}"
+    local attempt
+    for (( attempt = 1; attempt <= retries; attempt++ )); do
+        local labels_json
+        if ! labels_json=$(gh api "repos/${repo}/issues/${target}/labels" \
+                --method POST -f "labels[]=${label}" 2>&1); then
+            echo "fleet-claim: gh api POST labels failed on $repo#$target:" >&2
+            echo "$labels_json" >&2
+            return 1
+        fi
 
-    local labels_json
-    if ! labels_json=$(gh api "repos/${repo}/issues/${target}/labels" \
-            --method POST -f "labels[]=${label}" 2>&1); then
-        echo "fleet-claim: gh api POST labels failed on $repo#$target:" >&2
-        echo "$labels_json" >&2
-        return 1
-    fi
-
-    local min_label
-    min_label=$(echo "$labels_json" | python3 -c '
+        # Extract the full <prefix>* set from the POST response, one per line.
+        local matching
+        matching=$(echo "$labels_json" | python3 -c '
 import json, sys
 try:
     labels = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
 prefix = sys.argv[1]
-matching = sorted(l["name"] for l in labels if isinstance(l, dict) and l.get("name", "").startswith(prefix))
-if matching:
-    print(matching[0])
+for name in sorted(
+        l["name"] for l in labels
+        if isinstance(l, dict) and l.get("name", "").startswith(prefix)):
+    print(name)
 ' "$prefix" 2>/dev/null || echo "")
 
-    if [[ -z "$min_label" ]]; then
-        echo "fleet-claim: WARN gh api response missing ${prefix}* labels on $repo#$target; aborting" >&2
-        gh_release_label "$repo" "$target" "$label" || true
-        return 1
-    fi
+        if [[ -z "$matching" ]]; then
+            echo "fleet-claim: WARN gh api response missing ${prefix}* labels on $repo#$target; aborting" >&2
+            gh_release_label "$repo" "$target" "$label" || true
+            return 1
+        fi
 
-    if [[ "$min_label" != "$label" ]]; then
-        echo "fleet-claim: lost tie-break to ${min_label#$prefix} on $repo#$target" >&2
-        gh_release_label "$repo" "$target" "$label" || true
-        return 1
-    fi
+        local -a matching_arr
+        mapfile -t matching_arr <<< "$matching"
 
-    return 0
+        local decision
+        decision=$(_claim_decision "$label" "${matching_arr[@]}")
+        case "$decision" in
+            win)
+                return 0
+                ;;
+            retry)
+                # Drop and retry: in a simultaneous race the lex-larger
+                # contenders yield, so the next POST re-acquires alone.
+                gh_release_label "$repo" "$target" "$label" || true
+                _acquire_jitter_sleep
+                continue
+                ;;
+            *)  # lose
+                echo "fleet-claim: lost tie-break on $repo#$target; yielding to an existing ${prefix}* holder" >&2
+                gh_release_label "$repo" "$target" "$label" || true
+                return 1
+                ;;
+        esac
+    done
+
+    # Exhausted the retry budget while always lex-min: an earlier holder
+    # persists and never yielded (the non-simultaneous #1384 case). Our
+    # label was already removed by the final retry's release. Yield.
+    echo "fleet-claim: gave up after ${retries} attempt(s); an earlier ${prefix}* holder persists on $repo#$target" >&2
+    return 1
 }
 
 # --- issue lookup ---------------------------------------------------------
@@ -3081,6 +3159,13 @@ for line in body.splitlines():
 }
 
 # --- main -----------------------------------------------------------------
+
+# Sourcing seam for unit tests: `FLEET_CLAIM_LIB=1 source fleet-claim`
+# defines every helper (e.g. _claim_decision, _acquire_label_on) without
+# running the dispatch below. See tests/test_fleet_claim_acquire.sh.
+if [[ "${FLEET_CLAIM_LIB:-}" == "1" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
 
 case "${1:-}" in
     claim)

--- a/scripts/fleet/fleet-pr-claim-feedback
+++ b/scripts/fleet/fleet-pr-claim-feedback
@@ -141,7 +141,7 @@ if [[ -n "$repo_slug" ]]; then
     esac
 fi
 
-# Step 1 — atomic claim FIRST. The lex-min tie-break decides one winner;
+# Step 1 — atomic claim FIRST. The sole-holder claim decides one winner;
 # the loser (or a gh outage) exits here having mutated nothing.
 if ! fleet-claim "${claim_repo_args[@]}" amending-claim "$pr_number" "$agent"; then
     echo "fleet-pr-claim-feedback: did not win the amending claim for PR #$pr_number — skip it." >&2

--- a/scripts/fleet/tests/test_fleet_claim_acquire.sh
+++ b/scripts/fleet/tests/test_fleet_claim_acquire.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim's atomic-claim primitive (_acquire_label_on) and its
+# pure decision seam (_claim_decision).
+#
+# Regression coverage for #1384: the old primitive won "iff my label is the
+# lex-min of the POST-response snapshot". That let a LATER, lex-smaller
+# claimant co-win with an existing holder that had already passed its own
+# (smaller) snapshot check and never re-validated. Live incident on PR #1377:
+#
+#   20:27:43  +fleet:reviewing-windows-sonnet-fleet-2   ← holder, passes check
+#   20:31:48  +fleet:reviewing-windows-sonnet-fleet-1   ← later, lex-SMALLER,
+#                                                          also computes itself
+#                                                          as min → both hold.
+#
+# The fix (Option A): a claimant wins only as the SOLE holder of the prefix.
+# If others are present and I'm the lex-min I drop + retry (so a simultaneous
+# race converges to one winner); if an earlier/lex-smaller holder remains I
+# yield. Two same-prefix claims can therefore never coexist regardless of
+# arrival order or lex order.
+#
+# _claim_decision is table-tested directly (pure, no gh). _acquire_label_on is
+# driven end-to-end through a stateful gh stub for the terminal behaviors
+# (sole-holder win, persistent-holder yield).
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: '$expected'"
+        echo "        actual:   '$actual'"
+    fi
+}
+
+assert_exit() {
+    local actual_exit="$1" expected_exit="$2" msg="$3"
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected exit: $expected_exit"
+        echo "        actual exit:   $actual_exit"
+    fi
+}
+
+# Source fleet-claim as a library (defines helpers, skips the dispatch). Clear
+# positional args first so the script's top-level --repo parse is a no-op.
+set --
+FLEET_CLAIM_LIB=1 source "$FLEET_CLAIM"
+
+# Label names used throughout. opus-worker-1 is lex-SMALLER than
+# sonnet-fleet-2 ('o' 0x6f < 's' 0x73), matching the #1377 incident geometry
+# (the later, lex-smaller claimant is the one that wrongly co-won).
+P="fleet:reviewing-windows-"
+SMALL="${P}opus-worker-1"
+LARGE="${P}sonnet-fleet-2"
+
+echo "== _claim_decision (pure) =="
+
+# T1: sole holder → win.
+echo "T1: sole holder of the prefix → win"
+assert_eq "$(_claim_decision "$SMALL" "$SMALL")" "win" \
+    "only my label present → win"
+
+# T2: THE #1384 regression — I am the later, lex-smaller claimant; an existing
+# holder is present. Old code returned 'win' (the bug); fix returns 'retry'
+# (drop + re-acquire alone), never an outright co-win.
+echo "T2: later lex-smaller claimant + existing holder → retry (NOT win)"
+assert_eq "$(_claim_decision "$SMALL" "$SMALL" "$LARGE")" "retry" \
+    "lex-min among present holders → retry, not a co-win"
+
+# T3: I am the lex-larger of two present holders → yield to the smaller one.
+echo "T3: lex-larger claimant + lex-smaller holder present → lose"
+assert_eq "$(_claim_decision "$LARGE" "$SMALL" "$LARGE")" "lose" \
+    "an earlier/lex-smaller holder remains → lose"
+
+# T4: order-independence — the matching set is the same regardless of the
+# order labels are passed; decision must not depend on arg order.
+echo "T4: decision is independent of argument order"
+assert_eq "$(_claim_decision "$LARGE" "$LARGE" "$SMALL")" "lose" \
+    "reversed arg order still yields lose for the lex-larger label"
+
+# T5: three-way contention — lex-min wins-to-retry, the rest lose.
+echo "T5: three present holders — only the lex-min retries"
+THIRD="${P}sonnet-fleet-9"
+assert_eq "$(_claim_decision "$SMALL" "$SMALL" "$LARGE" "$THIRD")" "retry" \
+    "lex-min of three → retry"
+assert_eq "$(_claim_decision "$LARGE" "$SMALL" "$LARGE" "$THIRD")" "lose" \
+    "middle of three → lose"
+assert_eq "$(_claim_decision "$THIRD" "$SMALL" "$LARGE" "$THIRD")" "lose" \
+    "lex-max of three → lose"
+
+echo "== _acquire_label_on (end-to-end via gh stub) =="
+
+# Stateful gh stub. STUB_HOLDERS = labels that are "already present" on the
+# target; the POST response always echoes those plus the just-posted label.
+# remove-label is a no-op success (mirrors gh_release_label's happy path).
+STUB_HOLDERS=""
+gh() {
+    case "${1:-}" in
+        api)
+            local posted="" a
+            for a in "$@"; do
+                case "$a" in
+                    labels\[\]=*) posted="${a#labels[]=}" ;;
+                esac
+            done
+            local out='[' first=1 h
+            for h in $STUB_HOLDERS $posted; do
+                [[ $first -eq 1 ]] || out+=','
+                out+="{\"name\":\"$h\"}"
+                first=0
+            done
+            out+=']'
+            printf '%s\n' "$out"
+            return 0
+            ;;
+        issue|pr|label)
+            return 0  # edit/remove-label/etc. → no-op success
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# Keep retries/sleeps test-fast and deterministic.
+export FLEET_CLAIM_NO_SLEEP=1
+export FLEET_CLAIM_ACQUIRE_RETRIES=2
+
+# T6: no existing holder → sole-holder win (exit 0).
+echo "T6: no existing holder → acquire succeeds"
+STUB_HOLDERS=""
+rc=0
+_acquire_label_on "owner/repo" 1 "$SMALL" "$P" >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 0 "sole holder → exit 0 (own the lock)"
+
+# T7: persistent lex-LARGER holder, I am lex-smaller and arrive later — the
+# exact #1377 geometry. I retry (drop + re-POST) but the holder never yields,
+# so after the bounded retries I lose. Critically: I do NOT co-win.
+echo "T7: later lex-smaller claimant vs persistent holder → yield (exit 1)"
+STUB_HOLDERS="$LARGE"
+rc=0
+_acquire_label_on "owner/repo" 1 "$SMALL" "$P" >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 1 "persistent holder present → exit 1 (never a co-win)"
+
+# T8: persistent lex-SMALLER holder, I am lex-larger → immediate yield.
+echo "T8: lex-larger claimant vs lex-smaller holder → yield (exit 1)"
+STUB_HOLDERS="$SMALL"
+rc=0
+_acquire_label_on "owner/repo" 1 "$LARGE" "$P" >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 1 "earlier/lex-smaller holder remains → exit 1"
+
+echo
+echo "fleet-claim acquire tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`_acquire_label_on` — the atomic-claim primitive behind every
`fleet:claim-`/`reviewing-`/`resolving-`/`amending-` label — won "iff my
label is the lex-min of the POST-response snapshot". A holder that passed
its check against a smaller snapshot never re-validates, so a **later,
lex-smaller** claimant also computes itself as the min and **co-wins** —
two holders of one prefix. Hit live on PR #1377
(`fleet:reviewing-windows-sonnet-fleet-{1,2}` both held for minutes) and
re-reproduced this iteration (an `opus-worker-1` smoke claim co-won with
`sonnet-fleet-2`).

This implements the issue's recommended **Option A**:

- Win only as the **sole holder** of the prefix.
- Others present + I'm the lex-min → drop + retry (bounded by
  `FLEET_CLAIM_ACQUIRE_RETRIES`, default 3, jittered) so a *simultaneous*
  race still converges to exactly one winner.
- Others present + an earlier/lex-smaller holder remains → yield (exit 1).

The win/retry/lose decision is factored into a pure `_claim_decision`
helper (the table-testable seam the issue asks for), exposed for unit
testing via a new `FLEET_CLAIM_LIB=1` sourcing seam. Callers are
unchanged — the 0/win, 1/lose contract is preserved.

## Changes

- `scripts/fleet/fleet-claim` — `_claim_decision` (pure) + `_acquire_jitter_sleep` + rewritten `_acquire_label_on` loop; `FLEET_CLAIM_LIB` sourcing guard; header/section comments synced to sole-holder semantics.
- `scripts/fleet/tests/test_fleet_claim_acquire.sh` — new. 10 assertions: `_claim_decision` win/retry/lose matrix (incl. the exact #1377 geometry and arg-order independence) + end-to-end `_acquire_label_on` via a stateful `gh` stub (sole-holder win, persistent-holder yield).
- `docs/agents/FLEET.md`, `scripts/fleet/fleet-pr-claim-feedback` — doc/comment accuracy: the old "lex-min wins / TOCTOU is benign" contract is replaced by the sole-holder description.

## Test plan

- [x] `bash scripts/fleet/tests/test_fleet_claim_acquire.sh` → 10 passed, 0 failed
- [x] Regression: `test_fleet_claim_blockers.sh` (12/0), `test_fleet_pr_claim_feedback.sh` (27/0), `test_fleet_claim_model_gate.sh` (11/0), `test_fleet_claim_reconcile{,_c2}.sh`, `test_fleet_claim_stackable_live_resolve.sh` — all pass
- [x] `bash -n` syntax clean on both scripts; live CLI (`fleet-claim help` / `list`) still dispatches (sourcing guard not triggered in normal execution)

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)