### PR TITLE
fleet: export IR_FLEET_WORKERS from fleet-up so builds share the CPU budget

### DIFF
--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -146,23 +146,9 @@ export FLEET_EFFORT_OPUS_ARCHITECT FLEET_EFFORT_GAME_ARCHITECT
 if [[ -n "${FLEET_EFFORT:-}" ]]; then export FLEET_EFFORT; fi
 
 # --- Build-parallelism budget for ir-build's CPU semaphore -----------------
-#
-# ir-build (engine/tools) sizes both `cmake -j N` and the `ir-acquire cpu N`
-# slot count from per_build_max = cpu_budget / workers, where `workers`
-# resolves from $IR_FLEET_WORKERS (concurrency.toml's `[concurrency]
-# workers = "auto"`). Nothing exported IR_FLEET_WORKERS, so it fell back to
-# 1 and every fleet build ran `ir-acquire cpu <nproc>` — grabbing the whole
-# CPU budget. Concurrent builds then serialized on the slot semaphore and
-# could hit ir-acquire's 600 s queue timeout ("can't allocate enough CPU").
-#
-# Size it to the build-heavy panes — the two author tiers, which build on
-# nearly every iteration — so per_build_max = cpu_budget / (opus-worker +
-# sonnet-author panes). Reviewers / merger / architects build occasionally
-# and share the remaining slots or queue briefly; the point is that no
-# single build hogs all cores. Overrides, highest first: IR_FLEET_WORKERS in
-# the environment, FLEET_BUILD_WORKERS in fleet-up.conf, then this derived
-# default. (A ~/.config/irreden/host.toml [concurrency] workers still applies
-# to non-fleet `ir-build` invocations, where this env is unset.)
+# ir-build reads $IR_FLEET_WORKERS; it was never exported so workers fell
+# back to 1 and every fleet build grabbed all cores. Default: OPUS_WORKER +
+# SONNET_AUTHOR panes. Override order: IR_FLEET_WORKERS > FLEET_BUILD_WORKERS.
 FLEET_BUILD_WORKERS="${FLEET_BUILD_WORKERS:-$(( FLEET_CONCURRENCY_OPUS_WORKER + FLEET_CONCURRENCY_SONNET_AUTHOR ))}"
 if (( FLEET_BUILD_WORKERS < 1 )); then FLEET_BUILD_WORKERS=1; fi
 export IR_FLEET_WORKERS="${IR_FLEET_WORKERS:-$FLEET_BUILD_WORKERS}"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -145,6 +145,28 @@ export FLEET_EFFORT_OPUS_ARCHITECT FLEET_EFFORT_GAME_ARCHITECT
 # (a bare `FLEET_EFFORT=` in the conf is otherwise a non-exported shell var).
 if [[ -n "${FLEET_EFFORT:-}" ]]; then export FLEET_EFFORT; fi
 
+# --- Build-parallelism budget for ir-build's CPU semaphore -----------------
+#
+# ir-build (engine/tools) sizes both `cmake -j N` and the `ir-acquire cpu N`
+# slot count from per_build_max = cpu_budget / workers, where `workers`
+# resolves from $IR_FLEET_WORKERS (concurrency.toml's `[concurrency]
+# workers = "auto"`). Nothing exported IR_FLEET_WORKERS, so it fell back to
+# 1 and every fleet build ran `ir-acquire cpu <nproc>` — grabbing the whole
+# CPU budget. Concurrent builds then serialized on the slot semaphore and
+# could hit ir-acquire's 600 s queue timeout ("can't allocate enough CPU").
+#
+# Size it to the build-heavy panes — the two author tiers, which build on
+# nearly every iteration — so per_build_max = cpu_budget / (opus-worker +
+# sonnet-author panes). Reviewers / merger / architects build occasionally
+# and share the remaining slots or queue briefly; the point is that no
+# single build hogs all cores. Overrides, highest first: IR_FLEET_WORKERS in
+# the environment, FLEET_BUILD_WORKERS in fleet-up.conf, then this derived
+# default. (A ~/.config/irreden/host.toml [concurrency] workers still applies
+# to non-fleet `ir-build` invocations, where this env is unset.)
+FLEET_BUILD_WORKERS="${FLEET_BUILD_WORKERS:-$(( FLEET_CONCURRENCY_OPUS_WORKER + FLEET_CONCURRENCY_SONNET_AUTHOR ))}"
+if (( FLEET_BUILD_WORKERS < 1 )); then FLEET_BUILD_WORKERS=1; fi
+export IR_FLEET_WORKERS="${IR_FLEET_WORKERS:-$FLEET_BUILD_WORKERS}"
+
 if ! command -v tmux >/dev/null 2>&1; then
     echo "fleet-up: tmux not found. Install tmux (brew install tmux / apt install tmux) first." >&2
     exit 1
@@ -1141,6 +1163,12 @@ TRANSIENT_PANE_CMD='exec $SHELL -i'
 tmux new-session -d -s "$SESSION" -n fleet \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-1" \
     "$TRANSIENT_PANE_CMD"
+# Seed IR_FLEET_WORKERS into the tmux server env so the split-window panes
+# below inherit it even when this fleet-up attached to a pre-existing tmux
+# server (fleet-down kills the session, not the server, so the server's env
+# can predate this process). Panes feed it to ir-build -> ir-acquire for
+# correct per-build CPU sizing.
+tmux set-environment -g IR_FLEET_WORKERS "$IR_FLEET_WORKERS"
 TOP_LEFT=$(tmux display-message -t "$SESSION:fleet" -p "#{pane_id}")
 label_pane_id "$TOP_LEFT" "sonnet-fleet-1 [sonnet]"
 set_fleet_role "$TOP_LEFT" "sonnet-author"

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -31,6 +31,21 @@
 # FLEET_CONCURRENCY_MERGER=1
 # FLEET_CONCURRENCY_SMOKE_WORKER=1   # concurrent cap for the smoke-only worker pane
 
+# --- Build parallelism (ir-build CPU budget) --------------------------------
+#
+# How many concurrent fleet builds to size the CPU budget for. fleet-up
+# exports this as IR_FLEET_WORKERS, which ir-build uses to compute
+# per_build_max = cpu_budget / workers (each build takes that many of `nproc`
+# cores; the rest stay free for other panes' builds). Without it the engine
+# default is 1 -> every build grabs all cores and concurrent builds serialize
+# on the ir-acquire semaphore (600 s timeout = "can't allocate enough CPU").
+# Default = OPUS_WORKER + SONNET_AUTHOR caps (the build-heavy panes). Raise
+# for more build concurrency at fewer cores each; lower for faster individual
+# builds. A process-level IR_FLEET_WORKERS env var overrides this;
+# ~/.config/irreden/host.toml [concurrency] workers applies to non-fleet
+# ir-build invocations.
+# FLEET_BUILD_WORKERS=4
+
 # --- Per-role effort levels -------------------------------------------------
 #
 # Reasoning effort per role: "high" or "xhigh" (xhigh ≈ one notch below the


### PR DESCRIPTION
## Problem

`ir-build` (engine/tools) sizes both `cmake -j N` and its `ir-acquire cpu N` reservation from `per_build_max = cpu_budget / workers`. `workers` resolves from `$IR_FLEET_WORKERS` (per `concurrency.toml`'s `[concurrency] workers = "auto"`).

**Nothing exports `IR_FLEET_WORKERS`.** It appears in exactly three places — `concurrency.toml` (comment), `engine/tools/README.md` (doc), and `concurrency_helpers.sh` (the reader) — and is set nowhere. The original ir-tools design doc specified *"`fleet-up` exports `IR_FLEET_WORKERS=N`; per-build cap auto-divides to `nproc/N`"*, but that wiring never landed.

So `workers` always falls back to **1** → `per_build_max = nproc/1 = nproc`. Every fleet build runs `ir-acquire cpu <nproc> -- cmake -j<nproc>` and grabs the entire CPU budget. Concurrent builds from different panes then serialize on the slot semaphore and can hit `ir-acquire`'s 600 s queue timeout — observed as "can't allocate enough CPU for building" on the Ubuntu/WSL2 fleet host (24 threads), with three concurrent `ir-acquire cpu 24` calls queued.

## Fix

`fleet-up` now derives and exports `IR_FLEET_WORKERS`, sized to the build-heavy panes (`FLEET_CONCURRENCY_OPUS_WORKER + FLEET_CONCURRENCY_SONNET_AUTHOR`, default `2+2=4`), placed **before** the dispatcher `nohup` and pane creation so both inherit it. It also seeds the value into the tmux **server** env via `set-environment -g`, so panes inherit it even when `fleet-up` attaches to a pre-existing server (`fleet-down` kills the session, not the server, so the server env can predate this process).

Result on a 24-thread host with the stock layout: `per_build_max = 24/4 = 6`, so up to 4 builds run concurrently at `-j6` instead of one build hogging all 24 slots.

### Overrides (highest precedence first)
- `IR_FLEET_WORKERS` env var
- `FLEET_BUILD_WORKERS` in `~/.fleet/fleet-up.conf` (new knob, documented in `fleet-up.conf.sample`)
- the derived default (author-pane caps)
- `~/.config/irreden/host.toml` `[concurrency] workers` still applies to **non-fleet** `ir-build` invocations (where this env is unset)

## Testing
- `bash -n scripts/fleet/fleet-up` — clean.
- Exercised the derivation under `set -euo pipefail`: default → `4`, `FLEET_BUILD_WORKERS=6` → `6`, `IR_FLEET_WORKERS=8` → `8`.
- Not run end-to-end (would tear down the live fleet session); the change is confined to one env-export block plus a single `tmux set-environment` line.

## Note
A `~/.config/irreden/host.toml` with `[concurrency] workers = 4` is in place on the Ubuntu host as an immediate stopgap. Once this merges and the fleet restarts, the exported env supersedes it (same value, no conflict) and the stopgap can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
