### PR TITLE
fleet: reconcile R2 skips design-blocked PRs (not orphaned drift)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1898,6 +1898,17 @@ for repo in repos:
             labs = pr["labels"]
             if "fleet:wip" not in labs and not (labs & FEEDBACK):
                 continue
+            # A fleet:design-blocked PR is intentionally claim-less, not drift.
+            # The design-escalation protocol (role-opus-worker.md step 8c) has
+            # the worker RELEASE its claim + worktree reservation when parking
+            # the PR for the architect; re-adoption is gated on the architect
+            # flipping it to fleet:design-unblocked, not a free pickup decision.
+            # So "no claim / reservation / claim-label" here is the correct
+            # parked state. (fleet:design-unblocked stays flaggable — it IS in
+            # FEEDBACK above — because an unclaimed unblocked PR genuinely is
+            # awaiting re-adoption.)
+            if "fleet:design-blocked" in labs:
+                continue
             issue_labs = d["issue_labels"].get(issue_n, set())
             if (any(l.startswith("fleet:claim-") for l in issue_labs)
                     or (repo, issue_n) in fs_by_task

--- a/scripts/fleet/tests/test_fleet_claim_reconcile.sh
+++ b/scripts/fleet/tests/test_fleet_claim_reconcile.sh
@@ -20,6 +20,10 @@
 #     (design-unblocked applied later → remove the older design-blocked).
 #   - issue #504 carries queued + in-progress, no claim/PR → R4b stale in-progress.
 #   - PR #600 (head claude/505-orphan, fleet:wip) with no claim → R2 flag only.
+#   - PR #602 (head claude/507-parked, fleet:wip + fleet:design-blocked) with
+#     no claim → R2 must NOT flag: a design-blocked PR is intentionally
+#     claim-less (worker released its claim to park it for the architect per
+#     the design-escalation protocol), not orphaned drift (#1381).
 #
 # Covers the acceptance criteria of #1356:
 #   - report-only mutates nothing and writes a well-formed drift-report.json
@@ -97,7 +101,8 @@ JSON
 cat > "$PRS_JSON" <<'JSON'
 [
   {"number":600,"headRefName":"claude/505-orphan","labels":[{"name":"fleet:wip"}],"body":"Work in progress."},
-  {"number":601,"headRefName":"claude/topic-506","labels":[{"name":"fleet:wip"}],"body":"Implements the thing.\n\nCloses #506\n"}
+  {"number":601,"headRefName":"claude/topic-506","labels":[{"name":"fleet:wip"}],"body":"Implements the thing.\n\nCloses #506\n"},
+  {"number":602,"headRefName":"claude/507-parked","labels":[{"name":"fleet:wip"},{"name":"fleet:design-blocked"}],"body":"Parked for the architect."}
 ]
 JSON
 
@@ -201,6 +206,13 @@ assert 506 not in r1_targets, "R1 must NOT flag #506 (PR closes it via body)"
 # Flag-only R2 carries no apply action.
 r2 = [f for f in r["findings"] if f["rule"] == "R2"]
 assert all(f["apply"] is None for f in r2), "R2 must be flag-only"
+# R2 flags the genuinely-orphaned WIP PR #600 ...
+r2_targets = {f["target"] for f in r2}
+assert 600 in r2_targets, "R2 should flag orphaned WIP PR #600"
+# ... but NOT the design-blocked PR #602: it is intentionally claim-less
+# (parked for the architect), so flagging it as orphaned drift is the #1381
+# false-positive this fix removes.
+assert 602 not in r2_targets, "R2 must NOT flag design-blocked PR #602 (#1381)"
 PY
 
 echo "=== Phase 2: --apply (gated host-local repairs) ==="


### PR DESCRIPTION
## Summary
- `fleet-claim reconcile`'s **R2** rule flagged `fleet:design-blocked` WIP PRs as "orphaned WIP/feedback PRs," but a design-blocked PR is **intentionally** claim-less: the design-escalation protocol (`role-opus-worker.md` step 8c) has the worker **release** its `fleet-claim` + worktree reservation when parking the PR for the architect, with re-adoption gated on a later `fleet:design-unblocked`.
- This false-positive surfaced as the persistent state-drift tracker **#1381** — PR #1366 (`#1354`, design-blocked) was flagged for 9 reconcile ticks with no possible resolution, since the "no claim" state is correct.
- R2 now **skips** PRs carrying `fleet:design-blocked`. `fleet:design-unblocked` stays flaggable (it's in `FEEDBACK`) — an unclaimed *unblocked* PR genuinely awaits re-adoption, so that's a real pickup decision.

## Test plan
- [x] `scripts/fleet/tests/test_fleet_claim_reconcile.sh` — 22/22 (new fixture PR #602: `fleet:wip` + `fleet:design-blocked`, asserts R2 flags orphan PR #600 but NOT #602)
- [x] `scripts/fleet/tests/test_fleet_claim_reconcile_c2.sh` — 16/16 (no regression)
- [x] `bash -n scripts/fleet/fleet-claim` — clean

> Note: `test_reconcile_amendments.sh` has a **pre-existing** `T1 reservation untouched` failure on `origin/master`, unrelated to this change (reproduces identically with this diff stashed out; this PR does not touch that test path).

Closes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)