### PR TITLE
fleet/fleet-claim: exempt design-blocked PRs from reconcile R2 (#1381)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1896,6 +1896,16 @@ for repo in repos:
     for issue_n, prlist in d["pr_by_issue"].items():
         for pr in prlist:
             labs = pr["labels"]
+            # A design-blocked PR is intentionally parked with no claim: the
+            # design-escalation protocol (role-opus-worker.md step 8) mandates
+            # releasing the fleet-claim + worktree reservation when a PR goes
+            # design-blocked, so ANY opus-worker can resume it once the
+            # architect re-arms it as fleet:design-unblocked. Its no-claim
+            # state is correct-by-protocol, not orphaned drift, and there is no
+            # re-adoption pickup decision to make here (it waits on the
+            # architect, not a worker). Flagging it every tick is pure noise.
+            if "fleet:design-blocked" in labs:
+                continue
             if "fleet:wip" not in labs and not (labs & FEEDBACK):
                 continue
             issue_labs = d["issue_labels"].get(issue_n, set())
@@ -3427,8 +3437,10 @@ commands:
                                   R4b   queued + in-progress with no claim
                                         (any host) + no open PR → remove the
                                         stale fleet:in-progress.
-                                R2 (orphaned WIP/feedback PR with no claim)
-                                is report-only. Cross-host is flag-only by
+                                R2 (orphaned WIP/feedback PR with no claim;
+                                fleet:design-blocked PRs exempt — their
+                                no-claim state is protocol-correct) is
+                                report-only. Cross-host is flag-only by
                                 construction — never auto-releases another
                                 host's FS state or claim label. Defaults to
                                 engine + game (when reachable); --repo

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1896,14 +1896,9 @@ for repo in repos:
     for issue_n, prlist in d["pr_by_issue"].items():
         for pr in prlist:
             labs = pr["labels"]
-            # A design-blocked PR is intentionally parked with no claim: the
-            # design-escalation protocol (role-opus-worker.md step 8) mandates
-            # releasing the fleet-claim + worktree reservation when a PR goes
-            # design-blocked, so ANY opus-worker can resume it once the
-            # architect re-arms it as fleet:design-unblocked. Its no-claim
-            # state is correct-by-protocol, not orphaned drift, and there is no
-            # re-adoption pickup decision to make here (it waits on the
-            # architect, not a worker). Flagging it every tick is pure noise.
+            # design-escalation protocol mandates releasing the fleet-claim when
+            # going blocked (role-opus-worker.md step 8); no-claim is
+            # correct-by-protocol here, not orphaned drift.
             if "fleet:design-blocked" in labs:
                 continue
             if "fleet:wip" not in labs and not (labs & FEEDBACK):

--- a/scripts/fleet/tests/test_fleet_claim_reconcile.sh
+++ b/scripts/fleet/tests/test_fleet_claim_reconcile.sh
@@ -20,6 +20,9 @@
 #     (design-unblocked applied later → remove the older design-blocked).
 #   - issue #504 carries queued + in-progress, no claim/PR → R4b stale in-progress.
 #   - PR #600 (head claude/505-orphan, fleet:wip) with no claim → R2 flag only.
+#   - PR #602 (head claude/507-design-blocked, fleet:wip + fleet:design-blocked)
+#     with no claim → R2 EXEMPT (design-blocked PRs release their claim by
+#     protocol; their no-claim state is correct, not orphaned drift).
 #
 # Covers the acceptance criteria of #1356:
 #   - report-only mutates nothing and writes a well-formed drift-report.json
@@ -97,7 +100,8 @@ JSON
 cat > "$PRS_JSON" <<'JSON'
 [
   {"number":600,"headRefName":"claude/505-orphan","labels":[{"name":"fleet:wip"}],"body":"Work in progress."},
-  {"number":601,"headRefName":"claude/topic-506","labels":[{"name":"fleet:wip"}],"body":"Implements the thing.\n\nCloses #506\n"}
+  {"number":601,"headRefName":"claude/topic-506","labels":[{"name":"fleet:wip"}],"body":"Implements the thing.\n\nCloses #506\n"},
+  {"number":602,"headRefName":"claude/507-design-blocked","labels":[{"name":"fleet:wip"},{"name":"fleet:design-blocked"}],"body":"Parked on the architect."}
 ]
 JSON
 
@@ -201,6 +205,11 @@ assert 506 not in r1_targets, "R1 must NOT flag #506 (PR closes it via body)"
 # Flag-only R2 carries no apply action.
 r2 = [f for f in r["findings"] if f["rule"] == "R2"]
 assert all(f["apply"] is None for f in r2), "R2 must be flag-only"
+# R2 flags the orphaned WIP PR but EXEMPTS the design-blocked PR (#602): a
+# design-blocked PR is parked with no claim by protocol, not orphaned drift.
+r2_targets = {f["target"] for f in r2}
+assert 600 in r2_targets, "R2 should flag orphaned WIP PR #600"
+assert 602 not in r2_targets, "R2 must NOT flag design-blocked PR #602"
 PY
 
 echo "=== Phase 2: --apply (gated host-local repairs) ==="


### PR DESCRIPTION
## Summary

Reconcile's **R2** rule (orphaned WIP/feedback PR with no claim) was
false-flagging `fleet:design-blocked` PRs. A design-blocked PR is *intentionally
parked* with no claim — the design-escalation protocol (`role-opus-worker.md`
step 8) **mandates releasing** the `fleet-claim` + worktree reservation when a
PR goes design-blocked, so any opus-worker can resume it once the architect
re-arms it as `fleet:design-unblocked`. Its no-claim state is correct-by-protocol,
not orphaned drift, and there is no re-adoption pickup decision to make (it waits
on the architect, not a worker).

The recurring false positive on the design-blocked PR **#1366** (lua-ecs
foreign-entity read) is exactly what escalated into the persistent
`fleet:state-drift` tracker this PR closes.

## What changed

- `scripts/fleet/fleet-claim` — R2 now `continue`s past any PR carrying
  `fleet:design-blocked` before the orphaned-PR test. Also brings the code in
  line with FLEET.md's "orphaned" framing (a parked PR is not orphaned). Usage
  text for `reconcile` updated to note the exemption.
- `scripts/fleet/tests/test_fleet_claim_reconcile.sh` — adds a design-blocked PR
  fixture (#602, `fleet:wip` + `fleet:design-blocked`, no claim) and asserts R2
  flags the orphaned WIP PR (#600) but **exempts** #602.

## Test plan

- [x] `bash -n scripts/fleet/fleet-claim` — clean
- [x] `test_fleet_claim_reconcile.sh` — 22/22 PASS (R2 flags #600, exempts #602)
- [x] `test_fleet_claim_reconcile_c2.sh` — 16/16 PASS (incl. "cleared drift
      resets counter → no new tracker filed" — confirms #1381 won't re-file once
      this deploys)
- [x] `test_reconcile_amendments.sh` — 17/17 PASS

Closes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)