### PR TITLE
fleet: fleet-feedback CLI parses the same entry formats as the reviewer

### DIFF
--- a/scripts/fleet/fleet-feedback
+++ b/scripts/fleet/fleet-feedback
@@ -39,11 +39,25 @@ from pathlib import Path
 FEEDBACK_DIR = Path.home() / ".fleet" / "feedback"
 ARCHIVE_DIR = FEEDBACK_DIR / ".archive"
 
-# `## YYYY-MM-DD HH:MM` (24h time, optional seconds, optional TZ suffix
-# we ignore). The agent writes this when it appends an entry — see
-# CLAUDE.md "Fleet feedback channel" for the format.
+# Entry header grammar. Kept matching `ENTRY_HEAD_FILE` in
+# scripts/fleet/review-fleet-feedback (the closed-loop reviewer that reads
+# the SAME ~/.fleet/feedback/*.md files) so the quick CLI and the skill never
+# disagree on which entries exist. Agents write several shapes — all accepted:
+#   ## 2026-05-26 14:15              (date + time; headline on the next line)
+#   ## 2026-05-08T17:34Z — headline  (ISO-T date, Z/UTC suffix, inline headline)
+#   ## 2026-05-13 — headline         (date only, inline headline)
+#   ## 2026-05-19 opus-worker-1: …   (date only, inline headline, ':' separator)
+# Group 1 = timestamp (date, optional time); group 2 = optional inline
+# headline (when absent, the first non-blank body line is the headline).
+# The earlier regex required a time AND a bare next-line headline, so the
+# date-only / inline-headline entries agents actually write were all dropped —
+# the CLI reported "no entries" while the files held weeks of feedback. See
+# FLEET.md "Fleet feedback channel" for the writer-facing format.
 HEADER_RE = re.compile(
-    r"^## (\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?)(?:\s+\S+)?\s*$"
+    r"^##\s+"
+    r"(\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}(?::\d{2})?)?)"   # date, optional time
+    r"(?:\s*(?:Z|UTC))?"                                      # optional Z / UTC suffix
+    r"(?:\s*(?:[—–:-]+\s*)?(.*?))?\s*$"                       # optional inline headline
 )
 
 
@@ -85,22 +99,29 @@ def parse_role_file(path: Path) -> list[Entry]:
 
     entries: list[Entry] = []
     cur_ts: datetime | None = None
+    cur_inline: str = ""  # headline captured from the header line, if any
     cur_body: list[str] = []
 
     def flush() -> None:
         if cur_ts is None:
             return
-        # First non-blank line of body is the headline; rest is context.
-        non_blank_idx = next(
-            (i for i, ln in enumerate(cur_body) if ln.strip()), None
-        )
-        if non_blank_idx is None:
-            headline = "(no headline)"
-            body = ""
+        if cur_inline:
+            # Headline was inline on the header line (## DATE — headline);
+            # every following non-blank line is context.
+            headline = cur_inline
+            body = "\n".join(cur_body).strip()
         else:
-            headline = cur_body[non_blank_idx].strip()
-            rest = cur_body[non_blank_idx + 1 :]
-            body = "\n".join(rest).strip()
+            # No inline headline: first non-blank body line is the headline,
+            # the rest is context.
+            non_blank_idx = next(
+                (i for i, ln in enumerate(cur_body) if ln.strip()), None
+            )
+            if non_blank_idx is None:
+                headline = "(no headline)"
+                body = ""
+            else:
+                headline = cur_body[non_blank_idx].strip()
+                body = "\n".join(cur_body[non_blank_idx + 1 :]).strip()
         entries.append(Entry(role=role, timestamp=cur_ts, headline=headline, body=body))
 
     for line in lines:
@@ -108,8 +129,10 @@ def parse_role_file(path: Path) -> list[Entry]:
         if match:
             flush()
             cur_body = []
+            cur_inline = (match.group(2) or "").strip()
             ts_str = match.group(1).replace("T", " ")
-            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+            # Date-only headers ("## 2026-05-13 — …") anchor to midnight.
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
                 try:
                     cur_ts = datetime.strptime(ts_str, fmt)
                     break
@@ -121,6 +144,7 @@ def parse_role_file(path: Path) -> list[Entry]:
                     file=sys.stderr,
                 )
                 cur_ts = None
+                cur_inline = ""
         else:
             cur_body.append(line)
     flush()


### PR DESCRIPTION
## Problem

`fleet-feedback` is the human-facing CLI digest of the **agent→human feedback channel** (`~/.fleet/feedback/<role>.md`). Its header regex was strict:

```
## YYYY-MM-DD HH:MM      ← required a time
<headline on the next line>
```

But agents actually write date-only, inline-headline entries:

```
## 2026-05-30 — #1383 also corrupts normal task-claims...
## 2026-05-24 opus-worker-1 — worktree absolute-path trap...
## 2026-05-08T17:34Z — headline
```

So the CLI matched almost nothing. On the live host, `fleet-feedback --since 7d` reported **"no entries"** while the files held ~48 recent entries (50 KB+ in `opus-worker-1.md` alone). The closed-loop reviewer `scripts/fleet/review-fleet-feedback` had already widened its `ENTRY_HEAD_FILE` regex to a superset (it sees all 48) — its own comment says it is *"intentionally a superset of fleet-feedback's writer regex … so the reviewer never drops an entry the append tool accepted."* The quick CLI just never followed, so two readers of the same files disagreed.

## Fix

Port the reviewer's tolerant grammar into `fleet-feedback` verbatim:
- date with **optional** time (`## 2026-05-13` or `## 2026-05-26 14:15`),
- optional `Z`/`UTC` suffix,
- optional **inline headline** after a `—` / `–` / `:` / `-` separator,
- date-only headers anchor to midnight for `--since` filtering,
- inline headline used when present; otherwise the first non-blank body line (unchanged).

The header grammar is now a verbatim copy of `ENTRY_HEAD_FILE`, with a comment cross-referencing the reviewer so they don't drift again.

## Testing
- `python3 -m py_compile` clean.
- On the live `~/.fleet/feedback/` files: `fleet-feedback --since 7d --headlines` goes **0 → 48 entries**, matching `review-fleet-feedback`'s digest (`total_entries: 48`). `--role` filter and default-24h paths verified; no malformed-timestamp warnings.
- The strict `## DATE HH:MM` + next-line-headline form still parses (no regression).

## Scope
`fleet-feedback` is invoked by no role/script/cron (human CLI only), so this only affects manual spot-checks — the automated `review-fleet-feedback` loop was already working. This is the agent→human channel, distinct from the PR-feedback-label machinery (`fleet-pr-claim-feedback`, `fleet-pr-clear-feedback-labels`), which is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
