### PR TITLE
fleet: sync reconcile --help with R2 design-blocked exemption

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -3548,8 +3548,10 @@ commands:
                                   R4b   queued + in-progress with no claim
                                         (any host) + no open PR → remove the
                                         stale fleet:in-progress.
-                                R2 (orphaned WIP/feedback PR with no claim)
-                                is report-only. Cross-host is flag-only by
+                                R2 (orphaned WIP/feedback PR with no claim;
+                                fleet:design-blocked PRs exempt — their
+                                no-claim state is protocol-correct) is
+                                report-only. Cross-host is flag-only by
                                 construction — never auto-releases another
                                 host's FS state or claim label. Defaults to
                                 engine + game (when reachable); --repo


### PR DESCRIPTION
## Summary
- Ports the one surviving distinct delta from semantic-conflict PR #1390 (closed as a parallel duplicate of merged #1389).
- #1389 added the R2 reconcile exemption for `fleet:design-blocked` PRs — their claim-less state is protocol-correct, not orphaned drift — to the reconcile loop (`if "fleet:design-blocked" in labs: continue`) and the `#602` regression fixture, but **did not** update the `reconcile` command's `--help` text, which still described R2 without the exemption.
- This 4-line change syncs that help string so the CLI docs match shipped behavior. No logic change.

## Context
- #1390 (macOS-authored) and merged #1389 (`6afb0354`) implemented the identical R2 exemption. #1390 was closed as superseded; this PR carries forward only the help-text line that #1389 missed.
- No `Closes #` line: #1381 was already closed by #1389; this is a fleet-tooling doc-sync with no separate tracking issue.

## Test plan
- [x] `bash -n scripts/fleet/fleet-claim` — syntax clean
- [x] `test_fleet_claim_reconcile.sh` — 22/22 PASS (no behavior change)
- [x] Help text reads correctly in context; em-dash style matches the surrounding `reconcile` help block

🤖 Generated with [Claude Code](https://claude.com/claude-code)