### PR TITLE
fleet: reconcile auto-closes the state-drift tracker when findings clear (#1392)

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -1029,9 +1029,10 @@ Specifically, **never pass these via `--label` when filing**:
   `fleet:queued`+`human:owned`) that persisted across N reconcile
   `--apply` ticks (`FLEET_RECONCILE_DRIFT_TICKS`, default 3). Reconcile
   refreshes one open issue's body in place and never opens a second; the
-  human resolves the listed rows and closes it. The counter resets the
-  moment a finding stops recurring, so a transient one-tick blip never
-  escalates.
+  human resolves the listed rows, and reconcile auto-closes the tracker
+  once every finding clears (re-filing a fresh one if drift recurs). The
+  counter resets the moment a finding stops recurring, so a transient
+  one-tick blip never escalates.
 
 **The cross-surface `reconcile` pass.** `fleet-claim reconcile`
 cross-checks the four claim surfaces (issue/PR labels, open-PR state,

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -2236,8 +2236,9 @@ lines = [
     "deduped tracker for claim-surface drift the cross-surface reconcile pass",
     "could **not** auto-fix and that persisted across **%d+ reconcile ticks**."
     % threshold,
-    "Resolve each row, then close this issue — reconcile refreshes this body in",
-    "place and will not open a second tracker.",
+    "Resolve each row — `fleet-claim reconcile` auto-closes this tracker when",
+    "all findings clear. Reconcile also refreshes this body in place and will not",
+    "open a second tracker.",
     "",
     "| Rule | Repo | Target | Ticks | Detail |",
     "| --- | --- | --- | --- | --- |",

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -2139,6 +2139,17 @@ reconcile_apply_field() {
         'import sys,os,json; a=(json.load(sys.stdin).get("apply") or {}); print(a.get(os.environ["KEY"],""))'
 }
 
+# reconcile_open_drift_tracker
+#   Echo the number of the single open fleet:state-drift tracker, or empty if
+#   none. `// empty` keeps gojq from emitting the literal `null` (which would
+#   otherwise read as a real issue number). Both the refresh/create path and
+#   the auto-close path resolve the tracker the same way.
+reconcile_open_drift_tracker() {
+    gh issue list --repo "$FLEET_GITHUB_REPO" --state open \
+        --label "fleet:state-drift" --json number --jq '.[0].number // empty' \
+        2>/dev/null || true
+}
+
 # reconcile_escalate_drift <findings-jsonl> <state-dir> <threshold>
 #   Persistence-gated, deduped escalation of flag-only drift (R2/R6/...).
 #   Maintains a per-key tick counter in <state-dir>/drift-persistence.json:
@@ -2147,6 +2158,8 @@ reconcile_apply_field() {
 #   transient one-tick blip never escalates). When ANY key crosses <threshold>
 #   ticks, file or update a SINGLE open fleet:state-drift tracking issue on the
 #   engine repo (deduped — body refreshed in place, never one issue per tick).
+#   When NO finding remains persistent (all cleared), close any open tracker so
+#   a fixed claim surface does not leave a stale issue open forever.
 #   Mutates local state + a GH issue, so cmd_reconcile only calls it on --apply.
 reconcile_escalate_drift() {
     local findings="$1" state_dir="$2" threshold="$3"
@@ -2247,6 +2260,22 @@ PYEOF
     fi
     if [[ "$persistent_count" -le 0 ]]; then
         rm -f "$body_file"
+        # No persistent drift this run. If a tracker is still open, every row
+        # it lists has cleared, so close it — reconcile filed the tracker and
+        # owns its lifecycle, and a fixed claim surface must not leave a stale
+        # tracker lingering open with findings that no longer reproduce. The
+        # counter reset above means a genuinely-recurring finding re-accrues
+        # from zero and re-files a fresh tracker once it crosses threshold.
+        local cleared
+        cleared=$(reconcile_open_drift_tracker)
+        if [[ -n "$cleared" && "$cleared" != "null" ]]; then
+            if gh issue close "$cleared" --repo "$FLEET_GITHUB_REPO" \
+                --comment "All tracked claim-surface drift has cleared across reconcile ticks; auto-closing. \`fleet-claim reconcile\` re-files a fresh tracker if new persistent drift appears." >/dev/null 2>&1; then
+                echo "  reconcile --apply: drift cleared — auto-closed fleet:state-drift tracker #$cleared"
+            else
+                echo "  reconcile --apply: drift cleared but failed to auto-close fleet:state-drift tracker #$cleared" >&2
+            fi
+        fi
         return 0
     fi
 
@@ -2258,10 +2287,7 @@ PYEOF
 
     local existing title
     title="fleet: claim-surface drift — $persistent_count persistent finding(s)"
-    # `// empty` so an empty match prints nothing rather than gojq's literal
-    # `null` (which would otherwise read as an existing-issue number).
-    existing=$(gh issue list --repo "$FLEET_GITHUB_REPO" --state open \
-        --label "fleet:state-drift" --json number --jq '.[0].number // empty' 2>/dev/null || true)
+    existing=$(reconcile_open_drift_tracker)
     if [[ -n "$existing" && "$existing" != "null" ]]; then
         if gh issue edit "$existing" --repo "$FLEET_GITHUB_REPO" \
             --title "$title" --body-file "$body_file" >/dev/null 2>&1; then

--- a/scripts/fleet/tests/test_fleet_claim_reconcile_c2.sh
+++ b/scripts/fleet/tests/test_fleet_claim_reconcile_c2.sh
@@ -59,6 +59,7 @@ STUB_DIR="$TMPROOT/bin"
 mkdir -p "$STUB_DIR"
 export CREATE_LOG="$TMPROOT/create.log"; : > "$CREATE_LOG"
 export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
+export CLOSE_LOG="$TMPROOT/close.log"; : > "$CLOSE_LOG"
 export TRACKER_STATE="$TMPROOT/tracker.exists"
 cat > "$STUB_DIR/gh" <<'GHSTUB'
 #!/usr/bin/env bash
@@ -82,6 +83,12 @@ case "$1" in
                 exit 0 ;;
             edit)
                 printf '%s\n' "$*" >> "$EDIT_LOG"
+                exit 0 ;;
+            close)
+                # Auto-close path: log the call and flip the tracker marker off
+                # so a later `issue list --label fleet:state-drift` reports none.
+                printf '%s\n' "$*" >> "$CLOSE_LOG"
+                rm -f "$TRACKER_STATE"
                 exit 0 ;;
             *) exit 0 ;;
         esac ;;
@@ -157,12 +164,34 @@ create_n=$(wc -l < "$CREATE_LOG" | tr -d ' ')
 edit_n=$(wc -l < "$EDIT_LOG" | tr -d ' ')
 [[ "$edit_n" -ge "1" ]] && ok "tick 4 refreshed the existing tracker via issue edit" || bad "tick 4 did not edit the tracker"
 
-echo "=== Phase 5: drift clears → counter resets, no new tracker ==="
+echo "=== Phase 5: drift clears → counter resets + tracker auto-closed ==="
 echo '[]' > "$ISSUES_JSON"   # #700 no longer queued+human:owned
 run_reconcile --apply
 c=$(persist_count); [[ "$c" == "0" ]] && ok "cleared drift resets #700 counter to 0" || bad "counter not reset (count=$c)"
 create_n=$(wc -l < "$CREATE_LOG" | tr -d ' ')
 [[ "$create_n" == "1" ]] && ok "no new tracker filed after drift cleared" || bad "filed a tracker after clear (create count=$create_n)"
+close_n=$(wc -l < "$CLOSE_LOG" | tr -d ' ')
+[[ "$close_n" == "1" ]] && ok "drift cleared → auto-closed the open tracker exactly once" || bad "tracker not auto-closed on clear (close count=$close_n)"
+if grep -q '9001' "$CLOSE_LOG"; then ok "auto-close targeted the existing tracker #9001"; else bad "auto-close did not target the tracker number"; fi
+
+# An idempotent re-run with no drift must NOT keep trying to close (tracker gone).
+run_reconcile --apply
+close_n=$(wc -l < "$CLOSE_LOG" | tr -d ' ')
+[[ "$close_n" == "1" ]] && ok "no-drift re-run does not re-close (tracker already gone)" || bad "re-run closed again (close count=$close_n)"
+
+echo "=== Phase 6: drift re-appears → fresh tracker re-filed after threshold ==="
+cat > "$ISSUES_JSON" <<'JSON'
+[
+  {"number":700,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"human:owned"}]}
+]
+JSON
+run_reconcile --apply   # count 1
+run_reconcile --apply   # count 2
+create_n=$(wc -l < "$CREATE_LOG" | tr -d ' ')
+[[ "$create_n" == "1" ]] && ok "re-accrual below threshold files no tracker yet" || bad "re-accrual filed early (create count=$create_n)"
+run_reconcile --apply   # count 3 == threshold → re-file
+create_n=$(wc -l < "$CREATE_LOG" | tr -d ' ')
+[[ "$create_n" == "2" ]] && ok "recurring drift re-files a fresh tracker after auto-close" || bad "no fresh tracker after recurrence (create count=$create_n)"
 
 echo
 echo "================================"


### PR DESCRIPTION
## Summary
- `reconcile_escalate_drift` only ever *opened* or *refreshed* the single `fleet:state-drift` tracker. When its persistent findings dropped to zero it returned early **without closing the issue**, so a fixed claim surface left the tracker open forever with a stale body listing findings that no longer reproduce.
- Root cause of the **#1381 → #1392 churn**: #1389 made R2 skip design-blocked PRs (so PR #1366's finding became a resolved false positive), but reconcile never auto-closed the tracker, leaving #1392 lingering with a 13-tick stale finding.
- **Fix:** when no finding remains persistent, close any open tracker (with an explanatory comment). The per-key counter already resets when a finding stops recurring, so a genuinely-recurring finding re-accrues from zero and re-files a fresh tracker once it re-crosses threshold.
- Factored the tracker lookup into `reconcile_open_drift_tracker` so the refresh/create and close paths resolve it identically.
- Updated `docs/agents/FLEET.md` label reference to describe the auto-close.

## Test plan
- [x] `bash scripts/fleet/tests/test_fleet_claim_reconcile_c2.sh` — 21/21 (new Phase 5 auto-close + idempotent-reclose, new Phase 6 re-file-after-recurrence)
- [x] `bash scripts/fleet/tests/test_fleet_claim_reconcile.sh` — 22/22 (no regression in R1/R3/R4a/R4b/R6 paths)

Closes #1392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
