### PR TITLE
fleet: support multiple Blocked-by refs across the claim/stack pipeline (#1296)

### DIFF
--- a/.claude/skills/file-epic/SKILL.md
+++ b/.claude/skills/file-epic/SKILL.md
@@ -253,8 +253,8 @@ fills in when each child explicitly references the umbrella.
 Before reporting success, assert every child carries the structured
 fields the queue machinery actually reads — a standalone
 `**Model:** opus|sonnet` line, a standalone `**Part of epic:**
-#<umbrella>` line, and (for every non-head child) a **single-ref**
-standalone `**Blocked by:** #N` line. The `fleet-validate-stack`
+#<umbrella>` line, and (for every non-head child) a standalone
+`**Blocked by:** #N` line (one or more `#N` refs). The `fleet-validate-stack`
 helper (shipped #1317) checks exactly this, auto-discovers the
 children, and fails loudly:
 
@@ -268,11 +268,12 @@ each malformed child; patch the offending issue bodies (`gh issue
 edit <N> --body-file ...`) or re-file, then re-run until it passes.
 
 Never report success on a stack the validator rejects. A prose-only
-`Blocked on ...` header or a multi-`#N` `Blocked by:` line is
-**invisible to the scout and `fleet-claim` parsers** — the stack
-projects wrong at queue time and costs hours of triage downstream.
-This is the belt that the hand-filing convention (step 5) is the
-suspenders for.
+`Blocked on ...` header is read only as a *fallback* (#1326); the
+canonical standalone `**Blocked by:** #N` line is what file-epic's
+`--search "Part of epic: #N"` discovery relies on, so the validator
+still wants it. Multiple blockers are fine (`#A, #B` on one line or
+several `**Blocked by:**` lines; #1296). This is the belt that the
+hand-filing convention (step 5) is the suspenders for.
 
 ### 8. Report
 
@@ -300,13 +301,11 @@ Reply with:
   lines; header prose is invisible to the queue machinery. This is
   the #1 hand-filing drift (#1300 / #1308–#1311 all hit it). Step 7.5
   catches it — don't rely on catching it; write the standalone line.
-- ❌ Multiple `#N` refs on one `**Blocked by:**` line
-  (`**Blocked by:** #1299, #1300`). The current
-  `find-stackable-blockers` predicate requires exactly one blocker;
-  multi-ref forms project as "blocked" but never stack-claim, so
-  workers skip them indefinitely. Wait for an upstream to merge, then
-  strip the satisfied ref from the body. (#1296 will live-resolve
-  this; until it lands, one `#N` per `Blocked by:` line.)
+- ✅ Multiple blockers are supported (#1296): `**Blocked by:** #1299,
+  #1300` on one line, or several `**Blocked by:**` lines. The gate
+  unions every ref, and `find-stackable-blockers` live-resolves them —
+  stacking on the last unresolved ref as the upstreams merge. (Single
+  `#N` is still the simplest form when a child has just one blocker.)
 - ❌ Per-ticket plan files that duplicate the issue body verbatim.
   The plan adds implementation detail (file paths, code-level
   approach); the issue is the discussion surface.

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -489,12 +489,17 @@ repo = os.environ.get("REPO", "")
 #   **Blocked by:** (none — explanatory text)
 # Accept either bare `**Blocked by:**` or list-bullet `- **Blocked by:**`.
 field_re = re.compile(r"^\s*-?\s*\*\*Blocked by:\*\*\s*(.+?)\s*$", re.IGNORECASE)
-field_value = None
+field_values = []
 for line in body.splitlines():
     m = field_re.match(line)
     if m:
-        field_value = m.group(1).strip()
-        break
+        field_values.append(m.group(1).strip())
+# Union every canonical line (multi-line + multi-ref); drop explicit (none)
+# declarations. If every **Blocked by:** line is (none), the task is unblocked.
+real = [v for v in field_values if not v.lower().startswith("(none")]
+if field_values and not real:
+    sys.exit(0)
+field_value = ", ".join(real) if real else None
 
 # Fall back to free-form header prose like `## Blocked on #1300` / `Blocked
 # on PR-x` when the canonical field is absent, so a header-only dependency
@@ -909,14 +914,16 @@ body = base64.b64decode(os.environ["BODY_B64"]).decode("utf-8", errors="replace"
 repo = os.environ.get("REPO", "")
 
 field_re = re.compile(r"^\s*-?\s*\*\*Blocked by:\*\*\s*(.+?)\s*$", re.IGNORECASE)
-value = None
+field_values = []
 for line in body.splitlines():
     m = field_re.match(line)
     if m:
-        value = m.group(1).strip()
-        break
-if value is None or value.lower().startswith("(none"):
+        field_values.append(m.group(1).strip())
+# Union every canonical line (multi-line + multi-ref); drop (none).
+real = [v for v in field_values if not v.lower().startswith("(none")]
+if not real:
     sys.exit(0)
+value = ", ".join(real)
 
 issue_refs = re.findall(r"#(\d+)", value)
 pr_urls = re.findall(r"https://github\.com/[^\s,)]+/pull/\d+", value)

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -293,9 +293,19 @@ _BLOCKED_ON_RE = re.compile(
 
 
 def _parse_blocked_by(body):
-    field = _parse_issue_field(body, "Blocked by")
-    if field:
-        return field
+    # Union every standalone **Blocked by:** line (multi-line + multi-ref) so a
+    # child blocked by several refs surfaces all of them — check_blockers gates
+    # on the union and find-stackable-blockers live-resolves them (#1296). Falls
+    # back to a `Blocked on` header (#1326) only when no canonical line exists.
+    # Kept consistent with fleet-claim's check_blockers parser.
+    vals = re.findall(r'^\s*-?\s*\*\*Blocked by:\*\*\s*(.+?)\s*$',
+                      body or "", re.IGNORECASE | re.MULTILINE)
+    real = [v.strip() for v in vals if not v.strip().lower().startswith("(none")]
+    if real:
+        return ", ".join(real)
+    if vals:
+        # Every canonical line says (none) → genuinely unblocked.
+        return ""
     for m in _BLOCKED_ON_RE.finditer(body or ""):
         cand = m.group(1).strip().strip("*").strip()
         # Only treat header prose as a blocker when it actually names a #N

--- a/scripts/fleet/fleet_validate_stack.py
+++ b/scripts/fleet/fleet_validate_stack.py
@@ -11,11 +11,13 @@ an umbrella issue plus one child per phase, each child chaining
     **Blocked by:** #<prior>            # non-root children only
 
 Prose forms — a header bullet like ``**Epic:** #1307 · **Blocked on T1 + docs
-PR #1306**`` — are invisible to both parsers, so a child filed that way
-projects as Available (never stack-claims) and is undiscoverable by
-``file-epic``'s own ``--search "Part of epic: #N"`` step. Multi-ref
-``**Blocked by:** #A, #B`` lines defeat stack-claim too (the predicate wants
-exactly one blocker). This module is the pure predicate half of
+PR #1306**`` — are read by check_blockers / the scout only as a ``Blocked on``
+fallback (#1326); the canonical standalone ``**Blocked by:** #N`` line is what
+``file-epic``'s own ``--search "Part of epic: #N"`` discovery and the queue
+rely on, so a prose-only child still warrants a warning. Multiple blockers —
+whether ``#A, #B`` on one line or several ``**Blocked by:**`` lines — are
+supported (#1296): the gate unions every ref and find-stackable-blockers
+live-resolves them. This module is the pure predicate half of
 ``fleet-validate-stack``; the executable supplies the ``gh`` I/O.
 
 Severity split — a finding is an ``error`` only when it is an unambiguous
@@ -43,11 +45,10 @@ _EPIC_HEADER_TMPL = r"^\*\*Epic:\*\*\s+#{n}(?!\d)"
 _MODEL_RE = re.compile(r"^\*\*Model:\*\* (opus|sonnet)\b", re.MULTILINE)
 _BLOCKED_BY_LINE_RE = re.compile(r"^\*\*Blocked by:\*\*.*$", re.MULTILINE)
 _HASH_REF_RE = re.compile(r"#(\d+)\b")
-# A well-formed single-blocker line: ``#N`` is the only ref, optionally
-# followed by a `` (rationale)``. The trailing ``( \(|$)`` rejects a second
-# ``, #M`` (multi-blocker) by requiring the char after the number to be the
-# start of a parenthetical or end-of-line.
-_SINGLE_BLOCKED_BY_RE = re.compile(r"^\*\*Blocked by:\*\* #\d+( \(|$)", re.MULTILINE)
+# Multiple blockers are supported as of #1296 (see validate_child): a line may
+# carry one or more ``#N`` refs, and a child may carry more than one
+# ``**Blocked by:**`` line. The only malformed shape is a line that names no
+# ``#N`` at all.
 
 ERROR = "error"
 WARN = "warn"
@@ -116,20 +117,24 @@ def validate_child(body, umbrella, is_head):
         if not bb_lines:
             warn("no standalone `**Blocked by:** #N` line — drift if this "
                  "child chains on a sibling (prose `Blocked on ...` headers "
-                 "are invisible to the scout / fleet-claim parsers); fine if "
-                 "it is a genuine independent root")
-        elif len(bb_lines) > 1:
-            err("multiple separate `**Blocked by:**` lines — use a single "
-                "`**Blocked by:** #N` line; stack-claim requires exactly one")
+                 "are read only as a fallback; the standalone line is "
+                 "canonical); fine if it is a genuine independent root")
         else:
-            refs = _HASH_REF_RE.findall(bb_lines[0])
-            if len(refs) > 1:
-                err("multi-blocker `**Blocked by:** #%s` line — stack-claim "
-                    "needs exactly one ref (strip satisfied refs once "
-                    "upstreams merge)" % ", #".join(refs))
-            elif not _SINGLE_BLOCKED_BY_RE.search(b):
-                err("malformed `**Blocked by:**` line (expected `**Blocked "
-                    "by:** #N` or `**Blocked by:** #N (rationale)`)")
+            # Multiple blockers are supported (#1296): check_blockers gates on
+            # the union of every `#N` across all `**Blocked by:**` lines, and
+            # find-stackable-blockers live-resolves them (stacking on the last
+            # unresolved ref as the others merge). So neither multi-ref
+            # (`#A, #B`) nor several lines is an error — only a line that names
+            # no `#N` at all is malformed.
+            for ln in bb_lines:
+                val = re.sub(r"^\*\*Blocked by:\*\*\s*", "", ln,
+                             flags=re.IGNORECASE).strip()
+                if val.lower().startswith("(none"):
+                    continue
+                if not _HASH_REF_RE.search(val):
+                    err("malformed `**Blocked by:**` line (expected one or "
+                        "more `#N` refs, e.g. `**Blocked by:** #1308` or "
+                        "`**Blocked by:** #1308, #1309`): %r" % ln)
 
     return findings
 

--- a/scripts/fleet/tests/test_fleet_claim_blockers.sh
+++ b/scripts/fleet/tests/test_fleet_claim_blockers.sh
@@ -168,6 +168,11 @@ case "$1 $2" in
                 # so the `## Blocked on #101` header must be ignored.
                 printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"**Blocked by:** (none — independent)\n\n## Blocked on #101\n"}'
                 ;;
+            2013)
+                # #1296: two separate **Blocked by:** lines — the gate unions
+                # them; #101 is still OPEN so the claim must be blocked.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"**Blocked by:** #100\n**Blocked by:** #101\n"}'
+                ;;
             *)
                 printf '%s' '{"state":"OPEN","labels":[],"body":""}'
                 ;;
@@ -300,6 +305,11 @@ echo "T12: field '(none)' overrides a '## Blocked on #101' header → succeeds"
 actual=0; "$FLEET_CLAIM" claim 2012 test-agent 2>/dev/null || actual=$?
 assert_exit "$actual" 0 "field (none) takes precedence over header prose → exit 0"
 release_quiet 2012
+
+# --- T13: multi-line **Blocked by:** — a later ref still OPEN → fail (#1296) -
+echo "T13: two **Blocked by:** lines (#100 CLOSED, #101 OPEN) → claim fails"
+actual=0; "$FLEET_CLAIM" claim 2013 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "multi-line blocked-by, #101 OPEN → exit 1"
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
+++ b/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
@@ -137,6 +137,11 @@ case "$1 $2" in
             3004)
                 printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** (none)\n"}'
                 ;;
+            3005)
+                # #1296: two separate **Blocked by:** lines — #100 CLOSED,
+                # #101 OPEN with a PR → stacks on the remaining #101.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:sonnet"}],"body":"**Blocked by:** #100\n**Blocked by:** #101\n"}'
+                ;;
             *)
                 printf '%s' '{"state":"OPEN","labels":[],"body":""}'
                 ;;
@@ -206,6 +211,19 @@ assert_output "$result" "" "single closed blocker → empty (no stackable needed
 echo "T4: (none) blocker → empty output"
 result=$("$FLEET_CLAIM" find-stackable-blockers 3004 2>/dev/null || true)
 assert_output "$result" "" "(none) blocker → empty"
+
+# --- T5: multi-LINE blockers (#100 closed, #101 open) → returns #101 PR ------
+echo "T5: two **Blocked by:** lines (#100 closed, #101 open) → returns PR for #101"
+result=$("$FLEET_CLAIM" find-stackable-blockers 3005 2>/dev/null || true)
+assert_nonempty "$result" "multi-line: find-stackable-blockers returns PR line"
+echo "  result: $result"
+if echo "$result" | grep -q "claude/101-work-branch"; then
+    PASS=$((PASS + 1))
+    echo "  ok: multi-line result includes claude/101-work-branch"
+else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: multi-line result does not include claude/101-work-branch"
+fi
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_fleet_validate_stack.py
+++ b/scripts/fleet/tests/test_fleet_validate_stack.py
@@ -5,8 +5,10 @@ prose-only / missing `**Blocked by:**` (the #1300, #1309-#1311 shape, treated
 as an ambiguous *warning* since it may be a legit root), `**Epic:**` header
 bullets in place of the canonical `**Part of epic:**` line (the #1308-#1311
 shape, which also breaks file-epic's own discovery — a hard *error*),
-multi-ref `**Blocked by:**` (the #1301/#1070 shape that never stack-claims — a
-hard error), and a missing `**Model:**` line.
+malformed `**Blocked by:**` lines that name no `#N`, and a missing
+`**Model:**` line. Multiple blockers — multi-ref `#A, #B` or several
+`**Blocked by:**` lines — are accepted as of #1296 (the gate unions every ref
+and find-stackable-blockers live-resolves them).
 
 The module is loaded via importlib (mirroring test_scope_shipped_reference.py)
 so the test runs regardless of cwd.
@@ -114,26 +116,35 @@ class ValidateChildNonHead(unittest.TestCase):
         self.assertEqual(epic[0]["severity"], _mod.ERROR)
         self.assertEqual(blocked[0]["severity"], _mod.WARN)
 
-    def test_multi_blocker_line_is_error(self):
+    def test_multi_ref_blocked_by_line_is_accepted(self):
+        # #1296: multiple refs on one line are supported — the gate unions them
+        # and find-stackable-blockers live-resolves them. No longer an error.
         body = (
             "**Model:** opus\n**Part of epic:** #1307\n"
             "**Blocked by:** #1299, #1300\n"
         )
-        findings = validate_child(body, 1307, is_head=False)
-        multi = [f for f in findings if "multi-blocker" in f["msg"]]
-        self.assertEqual(len(multi), 1)
-        self.assertEqual(multi[0]["severity"], _mod.ERROR)
+        self.assertEqual(validate_child(body, 1307, is_head=False), [])
 
-    def test_multiple_separate_blocked_by_lines_is_error(self):
+    def test_multiple_separate_blocked_by_lines_are_accepted(self):
+        # #1296: several **Blocked by:** lines are unioned by the gate and
+        # live-resolved by find-stackable-blockers. No longer an error.
         body = (
             "**Model:** opus\n**Part of epic:** #1307\n"
             "**Blocked by:** #1308\n"
             "**Blocked by:** #1309\n"
         )
+        self.assertEqual(validate_child(body, 1307, is_head=False), [])
+
+    def test_blocked_by_line_without_ref_is_error(self):
+        # A **Blocked by:** line that names no #N is still malformed.
+        body = (
+            "**Model:** opus\n**Part of epic:** #1307\n"
+            "**Blocked by:** the upstream redesign\n"
+        )
         findings = validate_child(body, 1307, is_head=False)
-        multi = [f for f in findings if "multiple separate" in f["msg"]]
-        self.assertEqual(len(multi), 1)
-        self.assertEqual(multi[0]["severity"], _mod.ERROR)
+        bad = [f for f in findings if "malformed" in f["msg"]]
+        self.assertEqual(len(bad), 1)
+        self.assertEqual(bad[0]["severity"], _mod.ERROR)
 
     def test_single_blocker_with_rationale_passes(self):
         body = (


### PR DESCRIPTION
## Summary

Implements **#1296** — multiple blockers, fully supported across the claim / stack / validate pipeline, with all the parsers standardized on one convention.

A task may now declare more than one blocker, in either form:

- multiple refs on one line — `**Blocked by:** #1299, #1300`
- several lines:
  ```
  **Blocked by:** #1299
  **Blocked by:** #1300
  ```

Multi-`#N`-on-one-line already gated and live-resolved; the genuinely-missing piece was **multiple lines**, which all three parsers silently dropped after the first.

## Changes

| File | Change |
|---|---|
| `scripts/fleet/fleet-claim` · `check_blockers` | Gate on the **union** of every `#N`/PR across all `**Blocked by:**` lines (was: first line only). `(none)`-aware; keeps the `Blocked on` fallback (#1326). |
| `scripts/fleet/fleet-state-scout` · `_parse_blocked_by` | Same union → the projection's `blocked_by` reflects all refs. Kept consistent with `check_blockers`. |
| `scripts/fleet/fleet-claim` · `find-stackable-blockers` | Collect all lines before the existing live-resolve, so a multi-line/multi-ref child stacks on its **last unresolved** blocker as the upstreams merge. |
| `scripts/fleet/fleet_validate_stack.py` | Multi-ref and multiple `**Blocked by:**` lines are no longer **errors** — both are supported. Only a line that names no `#N` is malformed. |
| `.claude/skills/file-epic/SKILL.md` | Convention doc: multiple blockers supported; prose `Blocked on` is a fallback, the standalone `**Blocked by:** #N` line stays canonical (file-epic discovery + validate rely on it). |

The single-blocker rule was deliberately enforced because `find-stackable-blockers` needed exactly one blocker; that predicate already live-resolves multiple refs on one line (shipped earlier), so the validator's rejection was stale. This finishes the job for multiple lines and removes the obsolete restriction.

## Testing (all green)
- `test_fleet_validate_stack.py` — **22** (flipped the two multi-blocker "is_error" cases to "accepted"; added a ref-less-line "malformed" case).
- `test_fleet_claim_blockers.sh` — **13** (added T13: two `**Blocked by:**` lines, a later ref OPEN → claim correctly blocked).
- `test_fleet_claim_stackable_live_resolve.sh` — **7** (added T5: two lines, `#100` closed + `#101` open → stacks on `#101`).
- `test_issue_queue_parser.py` 26 · `test_live_blocker_resolution.py` 14 · `test_enrich_stackable_blocker_prs.py` 14 · worker/queue/merger projections 25/14/18 · claim acquire/model/reconcile/reconcile_c2 10/11/22/16 — unchanged.
- `bash -n` / `py_compile` clean on all touched scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
