### PR TITLE
fleet: scout fetch_task_queue skips fleet:needs-human (fixes infinite pickup loop)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -356,6 +356,12 @@ def fetch_task_queue(repo_slug):
                 owner = agent or suffix
                 break
 
+        # fleet:needs-human marks tasks that require manual human action
+        # before agents can work them. Skip so they don't appear in
+        # tasks.open and trigger infinite autonomous pickup attempts.
+        if "fleet:needs-human" in labels:
+            continue
+
         in_progress = "fleet:in-progress" in labels or owner != "free"
         status = "~" if in_progress else " "
 


### PR DESCRIPTION
## Summary
- `fetch_task_queue` in `fleet-state-scout` now skips issues carrying `fleet:needs-human`, preventing them from appearing in `tasks.open[]`
- Root cause of the infinite pickup loop for issues #1378 and #1379: these issues had both `fleet:queued` and `fleet:needs-human`, but `fetch_task_queue` had no guard for `fleet:needs-human`

## Root cause analysis

The existing `_INGEST_SKIP_LABELS` set and the `fleet-queue-ingest` stamp-skip condition already include `fleet:needs-human` (guarding the ingest path). But `fetch_task_queue` — which reads live from GitHub's `fleet:queued` label, not from the ingest projection — had no such guard.

Result: any issue with both `fleet:queued + fleet:needs-human` landed in `tasks.open[]`, was picked up by a sonnet-author agent, hit the gated edit wall, parked itself (removing `fleet:queued`, adding `fleet:needs-human`), and then got re-queued by `fleet-queue-ingest` on the next scout cycle — beginning the loop again.

The fix is a single `continue` guard inside `fetch_task_queue`'s issue loop, consistent with how `_INGEST_SKIP_LABELS` already handles the same signal on the projection side.

## Test plan
- [ ] `python3 -c "import ast; ast.parse(open('scripts/fleet/fleet-state-scout').read())"` — syntax OK
- [ ] Scout next run: issues #1378 and #1379 (fleet:queued + fleet:needs-human) no longer appear in `tasks_open[]` in the sonnet-author projection

Related: #1378 (the underlying doc edit to role-sonnet-author.md still requires human action; this PR prevents agents from being stuck in a re-pickup loop while waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)