### PR TITLE
render: make gui_scale=1 (full-res GUI) the engine default

### DIFF
--- a/creations/demos/canvas_stress/config.lua
+++ b/creations/demos/canvas_stress/config.lua
@@ -14,7 +14,7 @@ config = {
     start_updates_on_first_key_press = false,
     profiling_enabled = false,
     gpu_stage_timing = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }
 

--- a/creations/demos/chunk_streaming_smoke/config.lua
+++ b/creations/demos/chunk_streaming_smoke/config.lua
@@ -25,6 +25,6 @@ config = {
     start_updates_on_first_key_press = false,
     start_recording_on_first_key_press = false,
     profiling_enabled = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }

--- a/creations/demos/default/config.lua
+++ b/creations/demos/default/config.lua
@@ -29,7 +29,7 @@ local config_2kfullscreen = {
     start_updates_on_first_key_press = false,
     start_recording_on_first_key_press = false,
     profiling_enabled = true,
-    gui_scale = 2, -- 1 = full res, higher = bigger GUI trixels
+    gui_scale = 1, -- 1 = full res, higher = bigger GUI trixels
     hovered_trixel_visible = true,
     -- END
 
@@ -63,7 +63,7 @@ local config_1080_windowed = {
     start_updates_on_first_key_press = true,
     start_recording_on_first_key_press = true,
     profiling_enabled = true,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = true,
     -- END
 
@@ -98,7 +98,7 @@ local config_1080_windowed_vertical = {
     start_updates_on_first_key_press = true,
     start_recording_on_first_key_press = true,
     profiling_enabled = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = true,
     -- END
 

--- a/creations/demos/ir_voxel_yaw/config.lua
+++ b/creations/demos/ir_voxel_yaw/config.lua
@@ -25,6 +25,6 @@ config = {
     start_updates_on_first_key_press = false,
     start_recording_on_first_key_press = false,
     profiling_enabled = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }

--- a/creations/demos/lighting/config.lua
+++ b/creations/demos/lighting/config.lua
@@ -26,6 +26,6 @@ config = {
     start_recording_on_first_key_press = false,
     profiling_enabled = false,
     gpu_stage_timing = true,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }

--- a/creations/demos/lua_perf_grid/config.lua
+++ b/creations/demos/lua_perf_grid/config.lua
@@ -27,7 +27,7 @@ config = {
     profiling_enabled = true,
     gpu_stage_timing = true,
     gpu_stage_timing_legacy = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }
 

--- a/creations/demos/modifier_demo/main.cpp
+++ b/creations/demos/modifier_demo/main.cpp
@@ -678,8 +678,7 @@ void initEntities() {
     }
 
     // HUD: combined per-cube status panel.
-    // Smallest font (fontSize=1) + gui_scale=1 keeps the HUD compact so it
-    // doesn't dominate the viewport. Press [H] to surface the extended help.
+    // Press [H] to surface the extended help.
     IRModifierDemo::g_hudStatusEntity = IREntity::createEntity(
         C_TextSegment{""},
         C_GuiPosition{12, 12},

--- a/creations/demos/perf_grid/config.lua
+++ b/creations/demos/perf_grid/config.lua
@@ -27,7 +27,7 @@ config = {
     profiling_enabled = true,
     gpu_stage_timing = true,
     gpu_stage_timing_legacy = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }
 

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -554,14 +554,6 @@ int main(int argc, char **argv) {
         IRRender::setVoxelRenderSubdivisions(g_settings.baseSubdivisions_);
     }
 
-    // Render the GUI canvas at the main canvas resolution (default is half).
-    // The text renderer's smallest fontSize is 1 trixel-per-bitmap-pixel, so
-    // doubling the GUI trixel grid effectively halves the on-screen glyph
-    // height — needed to make the perf overlay legible without dominating
-    // the viewport. perf_grid uses no widgets, so the higher-resolution
-    // GUI canvas has no cost to other consumers.
-    IRRender::setGuiScale(1);
-
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/shape_debug/config.lua
+++ b/creations/demos/shape_debug/config.lua
@@ -25,6 +25,6 @@ config = {
     start_updates_on_first_key_press = false,
     start_recording_on_first_key_press = false,
     profiling_enabled = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }

--- a/creations/demos/sprite_demo/config.lua
+++ b/creations/demos/sprite_demo/config.lua
@@ -25,6 +25,6 @@ config = {
     start_updates_on_first_key_press = false,
     start_recording_on_first_key_press = false,
     profiling_enabled = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }

--- a/creations/demos/z_yaw_rotation/config.lua
+++ b/creations/demos/z_yaw_rotation/config.lua
@@ -25,6 +25,6 @@ config = {
     start_updates_on_first_key_press = false,
     start_recording_on_first_key_press = false,
     profiling_enabled = false,
-    gui_scale = 2,
+    gui_scale = 1,
     hovered_trixel_visible = false,
 }

--- a/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
+++ b/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
@@ -305,8 +305,8 @@ template <> struct System<PERF_STATS_OVERLAY> {
 
     int columnTrixels() const {
         // Clamp to fit narrow canvases — the GUI canvas is
-        // `mainCanvasSize / guiScale` (default scale=2), so a 480-trixel
-        // main canvas yields a 240-trixel GUI canvas. The overlay's
+        // `mainCanvasSize / guiScale` (default scale=1), so a 480-trixel
+        // main canvas yields a 480-trixel GUI canvas. The overlay's
         // formatted lines truncate cleanly on the right at the canvas edge
         // if the column shrinks below the format's preferred width.
         const int available = canvasWidth_ - 2 * kPerfStatsPadding.x;

--- a/engine/render/include/irreden/render/render_manager.hpp
+++ b/engine/render/include/irreden/render/render_manager.hpp
@@ -122,7 +122,7 @@ class RenderManager {
     EntityId m_mainFramebuffer;
     EntityId m_mainCanvas;
     EntityId m_backgroundCanvas;
-    int m_guiScale = 2;
+    int m_guiScale = 1;
     EntityId m_guiCanvas;
     // EntityId m_playerCanvas;
     EntityId m_camera;

--- a/engine/world/include/irreden/world/config.hpp
+++ b/engine/world/include/irreden/world/config.hpp
@@ -144,7 +144,7 @@ class WorldConfig {
         );
         m_config.addEntry(
             "gui_scale",
-            std::make_unique<IRScript::LuaValue<IRScript::LuaType::INTEGER>>(2)
+            std::make_unique<IRScript::LuaValue<IRScript::LuaType::INTEGER>>(1)
         );
         m_config.addEntry(
             "hovered_trixel_visible",


### PR DESCRIPTION
## Summary
- Promote `gui_scale = 1` (full-res GUI) from a per-demo workaround to the **engine-wide default**: `RenderManager::m_guiScale`, the `world/config.hpp` schema default, and all 12 checked-in demo configs.
- Remove the now-redundant per-demo `IRRender::setGuiScale(1)` call in `perf_grid/main.cpp` and the stale comments in `modifier_demo/main.cpp` + `system_perf_stats_overlay.hpp` that explained the old half-res-GUI workaround.

## Why
Full-res GUI (1 trixel-per-bitmap-pixel) keeps overlay/HUD text legible without dominating the viewport — which is why demos were already overriding the old default of `2` one-by-one. Making `1` the default removes that boilerplate.

## Notes
- **Flips a global GUI default** (full-res GUI everywhere) — intended.
- `creations/editors/voxel_editor/config.lua` is **left at `gui_scale = 2`** on purpose: the editor's widget-heavy UI may want larger GUI trixels. Flagged for human decision, not changed here.
- **No `--auto-screenshot` pair attached:** the change's visual effect is on GUI/overlay *scale*, which the `shape_debug` screenshot harness (trixel-shape shots) doesn't capture — those shots are unaffected by `gui_scale`. A manual GUI screenshot can be added if a reviewer wants it.
- **No local build run:** the worktree build dir is many commits behind current master (an "incremental" build would recompile unrelated drift), and the change is constant flips + comment removals + one dead-block removal — none can affect compilation. Relying on cross-host smoke.

## Test plan
- [ ] Cross-host smoke builds clean (engine headers compile)
- [ ] A demo with a perf overlay (e.g. perf_grid) renders the overlay legibly at the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)