### PR TITLE
script: define closed enums in Lua (codegen/eval-bound), retiring the C++ registerEnum stopgap (#1403)

### DIFF
--- a/cmake/lua_codegen/CMakeLists.txt
+++ b/cmake/lua_codegen/CMakeLists.txt
@@ -11,6 +11,14 @@ add_executable(ir_lua_codegen main.cpp system_dsl.cpp)
 target_link_libraries(ir_lua_codegen PRIVATE lua sol2)
 target_compile_features(ir_lua_codegen PRIVATE cxx_std_20)
 
+# #1403: the IREnum.register shim shares engine/script's enum-validation
+# header (IRScript::detail::buildLuaEnumTable) so build-time and runtime
+# assign identical ordinals. Header is self-contained (sol2 + std only);
+# the path is engine-relative so it resolves under user-project superbuilds.
+target_include_directories(ir_lua_codegen PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../engine/script/include
+)
+
 # Codegen-time errors should surface verbatim; never strip the symbols
 # even on Release.
 set_target_properties(ir_lua_codegen PROPERTIES

--- a/cmake/lua_codegen/CMakeLists.txt
+++ b/cmake/lua_codegen/CMakeLists.txt
@@ -11,10 +11,7 @@ add_executable(ir_lua_codegen main.cpp system_dsl.cpp)
 target_link_libraries(ir_lua_codegen PRIVATE lua sol2)
 target_compile_features(ir_lua_codegen PRIVATE cxx_std_20)
 
-# #1403: the IREnum.register shim shares engine/script's enum-validation
-# header (IRScript::detail::buildLuaEnumTable) so build-time and runtime
-# assign identical ordinals. Header is self-contained (sol2 + std only);
-# the path is engine-relative so it resolves under user-project superbuilds.
+# The IREnum shim shares engine/script's lua_enum_def.hpp so ordinals are identical at build time and runtime.
 target_include_directories(ir_lua_codegen PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../engine/script/include
 )

--- a/cmake/lua_codegen/main.cpp
+++ b/cmake/lua_codegen/main.cpp
@@ -27,6 +27,8 @@
 
 #include "system_dsl.hpp"
 
+#include <irreden/script/lua_enum_def.hpp>
+
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
@@ -38,6 +40,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -905,6 +908,36 @@ int main(int argc, char **argv) {
             handle["componentId"] = 0;
             handle["fields"] = sv.create_table();
             return handle;
+        }
+    );
+
+    // #1403: IREnum.register shim — the build-time counterpart of the
+    // runtime binding in engine/script/src/lua_script.cpp. Lua-defined
+    // enums have no C++ lowering (an enum is a pure name->ordinal table),
+    // so codegen emits nothing for them — but the stub MUST build the real
+    // table and validate it, because codegen-mode .lua files reference enum
+    // members (e.g. as a component-field default) and those references are
+    // resolved during this capture pass. Calling the shared
+    // detail::registerLuaEnum (the same helper the runtime binding uses)
+    // guarantees the ordinals captured here match what the same .lua
+    // produces at runtime.
+    std::unordered_set<std::string> enumNames;
+    sol::table irEnum = lua.create_named_table("IREnum");
+    irEnum.set_function(
+        "register",
+        [&lua, &enumNames](
+            sol::this_state, const std::string &name, const sol::table &members
+        ) -> sol::table {
+            try {
+                return IRScript::detail::registerLuaEnum(lua, enumNames, name, members);
+            } catch (const std::exception &e) {
+                // Mirror schemaError(): print before the exception unwinds
+                // through LuaJIT, which drops what() in this tool (no
+                // SOL_EXCEPTIONS_ALWAYS_UNSAFE here). Keeps the diagnostic
+                // visible in the codegen build log / test 2>&1 capture.
+                std::cerr << e.what() << "\n";
+                throw;
+            }
         }
     );
 

--- a/cmake/lua_codegen/main.cpp
+++ b/cmake/lua_codegen/main.cpp
@@ -911,16 +911,7 @@ int main(int argc, char **argv) {
         }
     );
 
-    // #1403: IREnum.register shim — the build-time counterpart of the
-    // runtime binding in engine/script/src/lua_script.cpp. Lua-defined
-    // enums have no C++ lowering (an enum is a pure name->ordinal table),
-    // so codegen emits nothing for them — but the stub MUST build the real
-    // table and validate it, because codegen-mode .lua files reference enum
-    // members (e.g. as a component-field default) and those references are
-    // resolved during this capture pass. Calling the shared
-    // detail::registerLuaEnum (the same helper the runtime binding uses)
-    // guarantees the ordinals captured here match what the same .lua
-    // produces at runtime.
+    // IREnum.register shim — shared detail::registerLuaEnum guarantees identical ordinals at build time and runtime.
     std::unordered_set<std::string> enumNames;
     sol::table irEnum = lua.create_named_table("IREnum");
     irEnum.set_function(

--- a/docs/design/lua-driven-ecs.md
+++ b/docs/design/lua-driven-ecs.md
@@ -225,6 +225,15 @@ local C_Hp = IRComponent.register("Hp", {
 -- Manual field binding (Q5, schemaless field):
 IRComponent.bindField("Tag", "morale", "float")
 
+-- Enums (#1403) -----------------------------------------------------
+-- Closed enums defined in Lua, the Lua-native counterpart to the C++
+-- registerEnum stopgap. Members map to 0-based ordinals in declaration
+-- order; the returned handle is the enum table and is also stored at
+-- IREnum.<Name>. No C++ lowering — a pure name->int table built the same
+-- way in CODEGEN and EVAL (shared IRScript::detail::buildLuaEnumTable).
+local DeviceType = IREnum.register("DeviceType", { "EFFECT", "SYNTH", "CONTROLLER" })
+local kind = DeviceType.SYNTH                       -- 1; usable as an int32 default
+
 -- Systems -----------------------------------------------------------
 local regenSystemId = IRSystem.registerSystem({
     name       = "Regen",

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -187,6 +187,45 @@ out-of-range. Use index-style inside any per-tick Lua system body.
 
 The full design is in [`docs/design/lua-driven-ecs.md`](../../docs/design/lua-driven-ecs.md).
 
+## Lua-defined enums (`IREnum.register`)
+
+Closed enums can be defined in Lua, the Lua-native counterpart to the C++
+`registerEnum` stopgap (`*_lua.hpp` + `kHasLuaBinding`). Bound by the same
+`bindLuaDrivenEcs()` call, so no extra init:
+
+```lua
+local DeviceType = IREnum.register("DeviceType", { "EFFECT", "SYNTH", "CONTROLLER" })
+DeviceType.EFFECT       -- 0
+DeviceType.SYNTH        -- 1
+IREnum.DeviceType.SYNTH -- same table, reachable by name from any file
+```
+
+- **Members map to 0-based ordinals** in declaration order — same numbering
+  as a C++ `enum class` and the 0-based field `index` of
+  `IRComponent.register`. The returned handle *is* the enum table, and the
+  same table is also stored at `IREnum.<Name>` for cross-file reference.
+- **Validated at registration, not silently.** A non-string member, an
+  empty-string member, an empty member list, a duplicate member, a
+  duplicate enum name, or the reserved name `"register"` raises a Lua error
+  at the `IREnum.register` call. A *typo on access* (`DeviceType.EFEKT`) is
+  plain Lua `nil` — push enum members up to load time by spelling them
+  through the table, never as bare strings (see
+  [`.claude/rules/cpp-lua-enums.md`](../../.claude/rules/cpp-lua-enums.md)).
+- **Usable wherever a C++ `registerEnum` enum is** — the value is an
+  integer, so `kind = DeviceType.SYNTH` is a valid `int32` component-field
+  default, a function argument, etc.
+- **No native storage.** Unlike `IRComponent.register`, an enum is a pure
+  name→int table with nothing to lower to C++, so **CODEGEN and EVAL behave
+  identically**: both build the table at runtime, and the build-time codegen
+  tool carries a matching `IREnum.register` shim (sharing
+  `IRScript::detail::buildLuaEnumTable`, `lua_enum_def.hpp`) so codegen-mode
+  `.lua` files that reference enum members — e.g. as a component default —
+  resolve to the *same* ordinals at build time and validate the same way.
+- **Limitation:** an enum member used *inside a CODEGEN system tick body*
+  (lowered by `system_dsl`) is not yet folded to a literal by the DSL —
+  enums are for setup/identity/config and EVAL-mode logic in v1. Use a
+  literal in CODEGEN tick bodies, or keep the enum-consuming system in EVAL.
+
 ## Build-time codegen of Lua-defined components (CODEGEN mode)
 
 The same `IRComponent.register("Name", { ... })` schema can be **statically

--- a/engine/script/include/irreden/script/lua_enum_def.hpp
+++ b/engine/script/include/irreden/script/lua_enum_def.hpp
@@ -1,0 +1,115 @@
+#ifndef LUA_ENUM_DEF_H
+#define LUA_ENUM_DEF_H
+
+#ifndef SOL_ALL_SAFETIES_ON
+#define SOL_ALL_SAFETIES_ON 1
+#endif
+#include <sol/sol.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+
+namespace IRScript::detail {
+
+// Validate a Lua-defined enum member list and build its name->ordinal
+// table. Shared verbatim by the runtime `IREnum.register` binding (EVAL,
+// engine/script/src/lua_script.cpp) and the build-time codegen stub
+// (CODEGEN, cmake/lua_codegen/main.cpp) so both validate identically AND
+// assign the same ordinals — a divergence would let a codegen'd component
+// default (captured from `MyEnum.MEMBER` at build time) disagree with the
+// value the same .lua produces at runtime, a silent correctness bug. This
+// is why the validation is a shared header and not a mirrored copy.
+//
+// `members` must be a Lua array (1..#members) of unique, non-empty
+// strings. Members map to 0-based ordinals in declaration order, mirroring
+// the default numbering of a C++ `enum class` and the 0-based field
+// `index` of `IRComponent.register`. Returns a fresh Lua table mapping each
+// member name to its integer ordinal — the same shape the C++
+// `registerEnum`/`new_enum` surface produces, so a Lua-defined enum is
+// usable anywhere a C++-bound enum is (`MyEnum.MEMBER`).
+//
+// Throws std::runtime_error with a diagnostic on: empty enum name, empty
+// or non-array member list, a non-string / empty-string member, or a
+// duplicate member name. The engine-side binding runs with
+// SOL_EXCEPTIONS_ALWAYS_UNSAFE, so sol2 forwards what() to the Lua caller;
+// the codegen driver prints what() before the exception unwinds (LuaJIT
+// drops it there) and aborts the build with the same message.
+inline sol::table buildLuaEnumTable(
+    sol::state_view lua, const std::string &enumName, const sol::table &members
+) {
+    if (enumName.empty()) {
+        throw std::runtime_error{"IREnum.register: enum name must be a non-empty string"};
+    }
+
+    const std::size_t count = members.size();
+    if (count == 0) {
+        throw std::runtime_error{
+            "IREnum.register: '" + enumName +
+            "' has no members (expected an array of strings, e.g. { \"EFFECT\", \"SYNTH\" })"
+        };
+    }
+
+    sol::table result = lua.create_table();
+    std::unordered_set<std::string> seen;
+    seen.reserve(count);
+    for (std::size_t i = 1; i <= count; ++i) {
+        sol::object entry = members[i];
+        if (entry.get_type() != sol::type::string) {
+            throw std::runtime_error{
+                "IREnum.register: '" + enumName + "' member #" + std::to_string(i) +
+                " is not a string"
+            };
+        }
+        std::string member = entry.as<std::string>();
+        if (member.empty()) {
+            throw std::runtime_error{
+                "IREnum.register: '" + enumName + "' member #" + std::to_string(i) +
+                " is an empty string"
+            };
+        }
+        if (!seen.insert(member).second) {
+            throw std::runtime_error{
+                "IREnum.register: '" + enumName + "' has duplicate member '" + member + "'"
+            };
+        }
+        result[member] = static_cast<lua_Integer>(i - 1);
+    }
+    return result;
+}
+
+// The full IREnum.register implementation, shared verbatim by the runtime
+// binding (engine/script/src/lua_script.cpp) and the codegen stub
+// (cmake/lua_codegen/main.cpp) — sharing the whole path, not just member
+// validation, is what guarantees build-time and runtime register a given
+// enum identically. Rejects the reserved name "register" (it is the
+// function key on the IREnum table), rejects a duplicate enum name (tracked
+// in `registered`), builds + validates the table via buildLuaEnumTable,
+// records the name, stores the table at `IREnum.<enumName>` for cross-file
+// reference, and returns it. `registered` is the caller's set of
+// already-registered enum names (a LuaScript member at runtime, a local in
+// the codegen tool). Throws std::runtime_error on any validation failure;
+// the name is recorded and the table stored only after a successful build,
+// so a rejected call leaves the name free to retry.
+inline sol::table registerLuaEnum(
+    sol::state_view lua,
+    std::unordered_set<std::string> &registered,
+    const std::string &enumName,
+    const sol::table &members
+) {
+    if (enumName == "register") {
+        throw std::runtime_error{"IREnum.register: 'register' is a reserved name"};
+    }
+    if (registered.count(enumName) != 0) {
+        throw std::runtime_error{"IREnum.register: '" + enumName + "' is already registered"};
+    }
+    sol::table enumTable = buildLuaEnumTable(lua, enumName, members);
+    registered.insert(enumName);
+    lua["IREnum"][enumName] = enumTable;
+    return enumTable;
+}
+
+} // namespace IRScript::detail
+
+#endif /* LUA_ENUM_DEF_H */

--- a/engine/script/include/irreden/script/lua_enum_def.hpp
+++ b/engine/script/include/irreden/script/lua_enum_def.hpp
@@ -13,29 +13,7 @@
 
 namespace IRScript::detail {
 
-// Validate a Lua-defined enum member list and build its name->ordinal
-// table. Shared verbatim by the runtime `IREnum.register` binding (EVAL,
-// engine/script/src/lua_script.cpp) and the build-time codegen stub
-// (CODEGEN, cmake/lua_codegen/main.cpp) so both validate identically AND
-// assign the same ordinals — a divergence would let a codegen'd component
-// default (captured from `MyEnum.MEMBER` at build time) disagree with the
-// value the same .lua produces at runtime, a silent correctness bug. This
-// is why the validation is a shared header and not a mirrored copy.
-//
-// `members` must be a Lua array (1..#members) of unique, non-empty
-// strings. Members map to 0-based ordinals in declaration order, mirroring
-// the default numbering of a C++ `enum class` and the 0-based field
-// `index` of `IRComponent.register`. Returns a fresh Lua table mapping each
-// member name to its integer ordinal — the same shape the C++
-// `registerEnum`/`new_enum` surface produces, so a Lua-defined enum is
-// usable anywhere a C++-bound enum is (`MyEnum.MEMBER`).
-//
-// Throws std::runtime_error with a diagnostic on: empty enum name, empty
-// or non-array member list, a non-string / empty-string member, or a
-// duplicate member name. The engine-side binding runs with
-// SOL_EXCEPTIONS_ALWAYS_UNSAFE, so sol2 forwards what() to the Lua caller;
-// the codegen driver prints what() before the exception unwinds (LuaJIT
-// drops it there) and aborts the build with the same message.
+// This is why the validation is a shared header and not a mirrored copy: both paths must assign identical ordinals.
 inline sol::table buildLuaEnumTable(
     sol::state_view lua, const std::string &enumName, const sol::table &members
 ) {
@@ -79,19 +57,7 @@ inline sol::table buildLuaEnumTable(
     return result;
 }
 
-// The full IREnum.register implementation, shared verbatim by the runtime
-// binding (engine/script/src/lua_script.cpp) and the codegen stub
-// (cmake/lua_codegen/main.cpp) — sharing the whole path, not just member
-// validation, is what guarantees build-time and runtime register a given
-// enum identically. Rejects the reserved name "register" (it is the
-// function key on the IREnum table), rejects a duplicate enum name (tracked
-// in `registered`), builds + validates the table via buildLuaEnumTable,
-// records the name, stores the table at `IREnum.<enumName>` for cross-file
-// reference, and returns it. `registered` is the caller's set of
-// already-registered enum names (a LuaScript member at runtime, a local in
-// the codegen tool). Throws std::runtime_error on any validation failure;
-// the name is recorded and the table stored only after a successful build,
-// so a rejected call leaves the name free to retry.
+// Sharing the whole path, not just member validation, is what guarantees build-time and runtime register a given enum identically.
 inline sol::table registerLuaEnum(
     sol::state_view lua,
     std::unordered_set<std::string> &registered,

--- a/engine/script/include/irreden/script/lua_script.hpp
+++ b/engine/script/include/irreden/script/lua_script.hpp
@@ -280,11 +280,7 @@ class LuaScript {
     // the misuse.
     std::unordered_set<std::string> m_warnedParallelForEvalSystems;
 
-    // #1403: names of enums defined via `IREnum.register` (the Lua-defined
-    // closed-enum surface bound in bindLuaDrivenEcs). Tracked so a second
-    // registration of the same name raises rather than silently shadowing
-    // the prior table — the duplicate guard `IRComponent.register` gets
-    // from EntityManager::isComponentRegistered.
+    // Tracked so a second registration raises rather than silently shadowing the prior table.
     std::unordered_set<std::string> m_luaEnumNames;
 
     // Declared last so it destructs first: lua_close() runs before any

--- a/engine/script/include/irreden/script/lua_script.hpp
+++ b/engine/script/include/irreden/script/lua_script.hpp
@@ -280,6 +280,13 @@ class LuaScript {
     // the misuse.
     std::unordered_set<std::string> m_warnedParallelForEvalSystems;
 
+    // #1403: names of enums defined via `IREnum.register` (the Lua-defined
+    // closed-enum surface bound in bindLuaDrivenEcs). Tracked so a second
+    // registration of the same name raises rather than silently shadowing
+    // the prior table — the duplicate guard `IRComponent.register` gets
+    // from EntityManager::isComponentRegistered.
+    std::unordered_set<std::string> m_luaEnumNames;
+
     // Declared last so it destructs first: lua_close() runs before any
     // closure-captured map (m_prefabSystemIds etc.) is gone. Mirrors the
     // invariant in world.hpp where m_lua leads so EntityManager outlives

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -7,6 +7,7 @@
 #include <irreden/common/components/component_rotation_mode.hpp>
 #include <irreden/common/modifier_field_registry.hpp>
 #include <irreden/script/lua_command_bindings.hpp>
+#include <irreden/script/lua_enum_def.hpp>
 #include <irreden/script/lua_modifier_bindings.hpp>
 #include <irreden/script/lua_pipeline_bindings.hpp>
 #include <irreden/script/prefab_api.hpp>
@@ -459,6 +460,27 @@ void LuaScript::bindLuaDrivenEcs() {
     IR_BIND_ROTMODE(DETACHED);
 #undef IR_BIND_ROTMODE
     m_lua["IRComponent"]["RotationMode"] = rotationModeTable;
+
+    // IREnum.register("Name", { "MEMBER_A", "MEMBER_B", ... }) — define a
+    // closed enum in Lua, the Lua-native counterpart to the C++
+    // `registerEnum` stopgap (#1403). Members map to 0-based integer
+    // ordinals in declaration order; the returned handle IS the enum table
+    // (`handle.MEMBER_A == 0`) and the same table is stored at
+    // `IREnum.<Name>` for cross-file reference. Unlike IRComponent.register
+    // there is no native storage to allocate — an enum is a pure name->int
+    // table — so CODEGEN and EVAL register identically via the shared
+    // detail::registerLuaEnum helper (the codegen tool calls the same helper
+    // from its IREnum shim, so codegen-mode .lua files validate and ordinal-
+    // number the same way at build time).
+    // See .claude/rules/cpp-lua-enums.md and engine/script/CLAUDE.md.
+    m_lua["IREnum"] = m_lua.create_table();
+    m_lua["IREnum"]["register"] =
+        [this](const std::string &enumName, sol::table members) -> sol::object {
+        return sol::make_object(
+            m_lua,
+            detail::registerLuaEnum(m_lua, m_luaEnumNames, enumName, members)
+        );
+    };
 
     m_lua.new_usertype<IRScript::LuaEntity>(
         "LuaEntity",

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -461,18 +461,7 @@ void LuaScript::bindLuaDrivenEcs() {
 #undef IR_BIND_ROTMODE
     m_lua["IRComponent"]["RotationMode"] = rotationModeTable;
 
-    // IREnum.register("Name", { "MEMBER_A", "MEMBER_B", ... }) — define a
-    // closed enum in Lua, the Lua-native counterpart to the C++
-    // `registerEnum` stopgap (#1403). Members map to 0-based integer
-    // ordinals in declaration order; the returned handle IS the enum table
-    // (`handle.MEMBER_A == 0`) and the same table is stored at
-    // `IREnum.<Name>` for cross-file reference. Unlike IRComponent.register
-    // there is no native storage to allocate — an enum is a pure name->int
-    // table — so CODEGEN and EVAL register identically via the shared
-    // detail::registerLuaEnum helper (the codegen tool calls the same helper
-    // from its IREnum shim, so codegen-mode .lua files validate and ordinal-
-    // number the same way at build time).
-    // See .claude/rules/cpp-lua-enums.md and engine/script/CLAUDE.md.
+    // Shared detail::registerLuaEnum guarantees identical ordinals at build time and runtime.
     m_lua["IREnum"] = m_lua.create_table();
     m_lua["IREnum"]["register"] =
         [this](const std::string &enumName, sol::table members) -> sol::object {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(IrredenEngineTest
   script/lua_command_test.cpp
   script/lua_component_codegen_test.cpp
   script/lua_component_register_test.cpp
+  script/lua_enum_register_test.cpp
   script/lua_pipeline_register_test.cpp
   script/lua_system_codegen_test.cpp
   script/prefab_api_test.cpp
@@ -100,6 +101,7 @@ irreden_lua_codegen(IrredenEngineTest
 target_compile_definitions(IrredenEngineTest PRIVATE
     IR_LUA_CODEGEN_BINARY="$<TARGET_FILE:ir_lua_codegen>"
     IR_LUA_CODEGEN_OVERFLOW_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/script/lua_component_codegen_overflow_fixture.lua"
+    IR_LUA_CODEGEN_ENUM_ERROR_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/script/lua_enum_codegen_error_fixture.lua"
 )
 add_dependencies(IrredenEngineTest ir_lua_codegen)
 

--- a/test/script/lua_component_codegen_fixtures.lua
+++ b/test/script/lua_component_codegen_fixtures.lua
@@ -37,3 +37,14 @@ IRComponent.register("CodegenHpForced", {
 IRComponent.register("CodegenScore", {
     value = 0,
 })
+
+-- #1403: a Lua-defined enum consumed at codegen-capture time. CodegenDevice's
+-- `kind` field defaults to CodegenDeviceType.SYNTH (0-based ordinal 1), so the
+-- codegen IREnum shim must build the enum table and resolve the member to its
+-- ordinal during the capture pass — and to the SAME ordinal the runtime
+-- IREnum.register produces (both share detail::buildLuaEnumTable).
+local CodegenDeviceType = IREnum.register("CodegenDeviceType", { "EFFECT", "SYNTH", "CONTROLLER" })
+
+IRComponent.register("CodegenDevice", {
+    kind = CodegenDeviceType.SYNTH,
+})

--- a/test/script/lua_component_codegen_test.cpp
+++ b/test/script/lua_component_codegen_test.cpp
@@ -28,10 +28,10 @@
 
 // MSVC names the POSIX pipe-spawn helpers with a leading underscore.
 #ifdef _WIN32
-#define ir_popen  _popen
+#define ir_popen _popen
 #define ir_pclose _pclose
 #else
-#define ir_popen  popen
+#define ir_popen popen
 #define ir_pclose pclose
 #endif
 
@@ -173,6 +173,16 @@ TEST_F(LuaComponentCodegenTest, LuaFieldAccessorReturnsValue) {
 
 // ---- Schema-error coverage (subprocess invocation) -------------------------
 
+// #1403: CodegenDevice.kind defaults to CodegenDeviceType.SYNTH (0-based
+// ordinal 1). Proves the codegen IREnum shim built the enum table and
+// resolved the member during the capture pass, and that codegen and EVAL
+// assign identical ordinals (both go through detail::buildLuaEnumTable).
+TEST_F(LuaComponentCodegenTest, EnumMemberResolvesAsFieldDefaultDuringCodegen) {
+    static_assert(std::is_same_v<decltype(IRComponents::C_CodegenDevice::kind_), std::int32_t>);
+    IRComponents::C_CodegenDevice d;
+    EXPECT_EQ(d.kind_, 1);
+}
+
 // Runs the codegen binary on a fixture that uses the explicit
 // `{ type = 'int32', default = <out-of-range> }` form and verifies the tool
 // errors out with a clear diagnostic instead of silently truncating. The
@@ -184,8 +194,8 @@ TEST(LuaComponentCodegenSchemaError, ExplicitInt32OverflowRaisesError) {
         std::filesystem::temp_directory_path() / "ir_lua_codegen_overflow.hpp";
     std::filesystem::remove(outPath);
 
-    const std::string cmd = std::string{IR_LUA_CODEGEN_BINARY} + " --out " +
-        outPath.string() + " " + IR_LUA_CODEGEN_OVERFLOW_FIXTURE + " 2>&1";
+    const std::string cmd = std::string{IR_LUA_CODEGEN_BINARY} + " --out " + outPath.string() +
+                            " " + IR_LUA_CODEGEN_OVERFLOW_FIXTURE + " 2>&1";
 
     FILE *pipe = ir_popen(cmd.c_str(), "r");
     ASSERT_NE(pipe, nullptr) << "failed to spawn ir_lua_codegen";
@@ -200,6 +210,35 @@ TEST(LuaComponentCodegenSchemaError, ExplicitInt32OverflowRaisesError) {
     EXPECT_NE(status, 0) << "codegen tool should fail on int32 overflow; output: " << output;
     EXPECT_NE(output.find("out of int32 range"), std::string::npos)
         << "expected 'out of int32 range' diagnostic; got: " << output;
+    EXPECT_FALSE(std::filesystem::exists(outPath))
+        << "codegen tool should not write output on schema error";
+}
+
+// #1403: the codegen IREnum shim validates member lists at build time. A
+// non-string member must abort the tool with the same diagnostic the EVAL
+// path raises (shared detail::buildLuaEnumTable), and no header is written.
+TEST(LuaEnumCodegenSchemaError, NonStringMemberRaisesError) {
+    const std::filesystem::path outPath =
+        std::filesystem::temp_directory_path() / "ir_lua_codegen_enum_error.hpp";
+    std::filesystem::remove(outPath);
+
+    const std::string cmd = std::string{IR_LUA_CODEGEN_BINARY} + " --out " + outPath.string() +
+                            " " + IR_LUA_CODEGEN_ENUM_ERROR_FIXTURE + " 2>&1";
+
+    FILE *pipe = ir_popen(cmd.c_str(), "r");
+    ASSERT_NE(pipe, nullptr) << "failed to spawn ir_lua_codegen";
+
+    std::string output;
+    char buf[256];
+    while (std::fgets(buf, sizeof(buf), pipe) != nullptr) {
+        output += buf;
+    }
+    const int status = ir_pclose(pipe);
+
+    EXPECT_NE(status, 0) << "codegen tool should fail on non-string enum member; output: "
+                         << output;
+    EXPECT_NE(output.find("is not a string"), std::string::npos)
+        << "expected 'is not a string' diagnostic; got: " << output;
     EXPECT_FALSE(std::filesystem::exists(outPath))
         << "codegen tool should not write output on schema error";
 }

--- a/test/script/lua_enum_codegen_error_fixture.lua
+++ b/test/script/lua_enum_codegen_error_fixture.lua
@@ -1,0 +1,5 @@
+-- #1403 build-time error fixture: a non-string enum member must abort the
+-- codegen tool with a clear diagnostic (the CODEGEN mirror of the EVAL
+-- NonStringMemberRaises test). Spawned by the LuaEnumCodegenSchemaError test
+-- in lua_component_codegen_test.cpp; never wired into a build target.
+IREnum.register("BadEnum", { "OK", 42 })

--- a/test/script/lua_enum_register_test.cpp
+++ b/test/script/lua_enum_register_test.cpp
@@ -108,6 +108,11 @@ TEST_F(LuaEnumTest, NonStringMemberRaises) {
     EXPECT_FALSE(result.valid());
 }
 
+TEST_F(LuaEnumTest, EmptyEnumNameRaises) {
+    auto &lua = m_lua.lua();
+    EXPECT_FALSE(lua.safe_script("IREnum.register('', { 'A' })", sol::script_pass_on_error).valid());
+}
+
 TEST_F(LuaEnumTest, EmptyMemberListRaises) {
     auto &lua = m_lua.lua();
     auto result = lua.safe_script("IREnum.register('Empty', {})", sol::script_pass_on_error);

--- a/test/script/lua_enum_register_test.cpp
+++ b/test/script/lua_enum_register_test.cpp
@@ -1,0 +1,156 @@
+// #1403 EVAL coverage: the runtime `IREnum.register` surface bound in
+// LuaScript::bindLuaDrivenEcs — Lua-defined closed enums, the Lua-native
+// counterpart to the C++ registerEnum stopgap. The CODEGEN side (the
+// build-time stub sharing detail::buildLuaEnumTable) is covered in
+// lua_component_codegen_test.cpp, which proves an enum member resolves as a
+// component-field default during a real codegen invocation.
+
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <string>
+#include <tuple>
+
+namespace {
+
+// LuaScript first so its sol::state outlives sol::function-bearing columns
+// held by EntityManager (mirrors lua_component_register_test.cpp).
+class LuaEnumTest : public testing::Test {
+  protected:
+    LuaEnumTest()
+        : m_lua{}
+        , m_entity_manager{} {
+        m_lua.bindLuaDrivenEcs();
+    }
+
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+};
+
+// ---- Happy path ------------------------------------------------------------
+
+TEST_F(LuaEnumTest, MembersResolveToZeroBasedOrdinals) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "local E = IREnum.register('DeviceType', { 'EFFECT', 'SYNTH', 'CONTROLLER' })\n"
+        "return E.EFFECT, E.SYNTH, E.CONTROLLER"
+    );
+    ASSERT_TRUE(result.valid());
+    auto [effect, synth, controller] =
+        result.get<std::tuple<lua_Integer, lua_Integer, lua_Integer>>();
+    EXPECT_EQ(effect, 0);
+    EXPECT_EQ(synth, 1);
+    EXPECT_EQ(controller, 2);
+}
+
+TEST_F(LuaEnumTest, RegisteredEnumIsAccessibleByNameOnIREnumTable) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "IREnum.register('Tag', { 'RED', 'GREEN', 'BLUE' })\n"
+        "return IREnum.Tag.GREEN"
+    );
+    ASSERT_TRUE(result.valid());
+    EXPECT_EQ(result.get<lua_Integer>(), 1);
+}
+
+TEST_F(LuaEnumTest, ReturnedHandleAndGlobalEntryAreTheSameTable) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "local E = IREnum.register('Same', { 'A', 'B' })\n"
+        "return E == IREnum.Same"
+    );
+    ASSERT_TRUE(result.valid());
+    EXPECT_TRUE(result.get<bool>());
+}
+
+TEST_F(LuaEnumTest, EnumMemberUsableAsComponentFieldDefault) {
+    // An ordinal is a plain integer, so it infers as int32 exactly like a
+    // numeric literal default would — the enum is "usable wherever a
+    // registerEnum enum is today" (acceptance criterion).
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "local Kind = IREnum.register('Kind', { 'NONE', 'PLAYER', 'ENEMY' })\n"
+        "local C = IRComponent.register('Actor', { kind = Kind.ENEMY })\n"
+        "return Kind.ENEMY, C.fields.kind.type"
+    );
+    ASSERT_TRUE(result.valid());
+    auto [ordinal, fieldType] = result.get<std::tuple<lua_Integer, std::string>>();
+    EXPECT_EQ(ordinal, 2);
+    EXPECT_EQ(fieldType, "int32");
+}
+
+TEST_F(LuaEnumTest, TypoAccessYieldsNil) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "local E = IREnum.register('TypoCheck', { 'ALPHA', 'BETA' })\n"
+        "return E.GAMMA == nil"
+    );
+    ASSERT_TRUE(result.valid());
+    EXPECT_TRUE(result.get<bool>());
+}
+
+// ---- Validation (errors at registration, not silent) -----------------------
+
+TEST_F(LuaEnumTest, DuplicateEnumNameRaises) {
+    auto &lua = m_lua.lua();
+    auto first = lua.safe_script("IREnum.register('Dup', { 'A' })", sol::script_pass_on_error);
+    ASSERT_TRUE(first.valid());
+    auto second = lua.safe_script("IREnum.register('Dup', { 'B' })", sol::script_pass_on_error);
+    EXPECT_FALSE(second.valid());
+}
+
+TEST_F(LuaEnumTest, NonStringMemberRaises) {
+    auto &lua = m_lua.lua();
+    auto result =
+        lua.safe_script("IREnum.register('Bad', { 'A', 42, 'C' })", sol::script_pass_on_error);
+    EXPECT_FALSE(result.valid());
+}
+
+TEST_F(LuaEnumTest, EmptyMemberListRaises) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script("IREnum.register('Empty', {})", sol::script_pass_on_error);
+    EXPECT_FALSE(result.valid());
+}
+
+TEST_F(LuaEnumTest, DuplicateMemberRaises) {
+    auto &lua = m_lua.lua();
+    auto result =
+        lua.safe_script("IREnum.register('DupMem', { 'A', 'B', 'A' })", sol::script_pass_on_error);
+    EXPECT_FALSE(result.valid());
+}
+
+TEST_F(LuaEnumTest, EmptyStringMemberRaises) {
+    auto &lua = m_lua.lua();
+    auto result =
+        lua.safe_script("IREnum.register('EmptyMem', { 'A', '' })", sol::script_pass_on_error);
+    EXPECT_FALSE(result.valid());
+}
+
+TEST_F(LuaEnumTest, ReservedRegisterNameRaises) {
+    auto &lua = m_lua.lua();
+    auto result =
+        lua.safe_script("IREnum.register('register', { 'A' })", sol::script_pass_on_error);
+    EXPECT_FALSE(result.valid());
+    // The register function must survive the rejected call.
+    auto after =
+        lua.safe_script("return type(IREnum.register)", sol::script_pass_on_error);
+    ASSERT_TRUE(after.valid());
+    EXPECT_EQ(after.get<std::string>(), "function");
+}
+
+TEST_F(LuaEnumTest, FailedRegistrationDoesNotReserveTheName) {
+    // A registration that throws during validation must not leave the name
+    // marked as taken — a corrected re-registration should succeed.
+    auto &lua = m_lua.lua();
+    auto bad =
+        lua.safe_script("IREnum.register('Retry', { 'A', 7 })", sol::script_pass_on_error);
+    ASSERT_FALSE(bad.valid());
+    auto good =
+        lua.safe_script("return IREnum.register('Retry', { 'A', 'B' }).B", sol::script_pass_on_error);
+    ASSERT_TRUE(good.valid());
+    EXPECT_EQ(good.get<lua_Integer>(), 1);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Adds `IREnum.register("Name", { "MEMBER", ... })` — a Lua-native closed-enum surface, the counterpart to the C++ `enum class` + `kHasLuaBinding` + `registerEnum` stopgap (#1403).
- Members map to **0-based ordinals** in declaration order. The returned handle *is* the enum table (`E.MEMBER == 0`) and the same table is stored at `IREnum.<Name>` for cross-file reference.
- **Validated at registration:** non-string / empty-string / duplicate member, duplicate enum name, and the reserved name `"register"` all raise. A typo on *access* is plain Lua `nil`.
- **CODEGEN + EVAL compatible.** An enum has no C++ storage to lower, so both modes register identically via a shared sol2-only header (`lua_enum_def.hpp`, `detail::registerLuaEnum`) — called from both the runtime binding in `bindLuaDrivenEcs` and the build-time codegen stub. Codegen-mode `.lua` files that reference enum members as component-field defaults resolve to the **same** ordinals at build time and validate the same way. Sharing the whole registration path (not just member validation) is what guarantees build-time/runtime parity.
- The codegen tool gains an engine-relative include path to that one self-contained header; it otherwise stays decoupled (only `lua` + `sol2`).

## Design notes
- Enums are runtime-built name→int tables in both modes; codegen emits nothing for them (nothing to lower). The codegen stub still builds + validates the table so member references during the capture pass resolve.
- **Limitation (v1):** an enum member used *inside a CODEGEN system-tick body* is not yet folded to a literal by the `system_dsl` lowering — enums are for setup / identity / config and EVAL-mode logic. Documented in `engine/script/CLAUDE.md`; the EVAL escape hatch (`mode = "eval"`) covers tick-body use.

## Test plan
- [x] `IrredenEngineTest` builds clean (engine lib + `ir_lua_codegen` tool + tests).
- [x] `lua_enum_register_test.cpp` — 12 EVAL cases (ordinals, handle/global identity, component-default use, typo→nil, all five validation errors, failed-registration-doesn't-reserve-the-name).
- [x] `lua_component_codegen_test.cpp` — `EnumMemberResolvesAsFieldDefaultDuringCodegen` proves an enum member resolves to its ordinal as a component default during a real codegen run; `LuaEnumCodegenSchemaError` proves a bad member aborts the build with the same diagnostic.
- [x] Full suite green: 1035/1035.

Closes #1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)