### PR TITLE
fleet: opus-worker step 1c resolves game semantic conflicts (closes #1418)

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -230,11 +230,14 @@ Do the work, then exit cleanly:
     PR matches the filter.
 
 1c. **Resolve one `fleet:semantic-conflict` PR per iteration
-    (engine only).** The merger sets this label when mechanical
+    (engine + game).** The merger sets this label when mechanical
     rebase fails (label semantics: see [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md) "Issue/PR labeling
-    discipline"). That's your lane.
+    discipline"). That's your lane — for **both** repos, since the
+    merger now runs a game pass too (PR #1371) and flags game PRs
+    `fleet:semantic-conflict`.
 
-    From the cached `repos.engine.prs[]`, pick PRs whose `labels`
+    From the cached `repos.engine.prs[]` **and `repos.game.prs[]`**,
+    pick PRs whose `labels`
     array contains `fleet:semantic-conflict` AND contains NONE of
     `fleet:wip`, `human:wip`, `human:needs-fix`, `human:blocker`,
     `fleet:awaiting-base`, `fleet:awaiting-upstream-review`,
@@ -257,11 +260,24 @@ Do the work, then exit cleanly:
     (step c) and `--force-with-lease` push (step h) remain in place as
     safety nets; the resolving label is the first-line prevention.
 
-    Game repo is intentionally out of scope for v1: the merger is
-    engine-only, so no game PR ever gets the label.
-    All `--repo` flags in this step use `jakildev/IrredenEngine`
-    (`<engine-repo>` in the merger-role convention — same slug, not
-    auto-derived here since this step is always engine-only).
+    **Repo routing.** Each candidate carries its source repo (the
+    `repo` field on the cached PR record: `engine` or `game`). Resolve
+    engine PRs first (engine is the priority lane), then game. For the
+    chosen PR, substitute throughout the steps below:
+
+    | | engine PR | game PR |
+    |---|---|---|
+    | `gh` repo flag | `--repo jakildev/IrredenEngine` | `--repo jakildev/irreden` |
+    | cwd for git/gh | your engine worktree | `cd ~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-name>` **first** |
+    | `fleet-claim` | `fleet-claim resolving-claim …` | `fleet-claim --repo game resolving-claim …` |
+    | `fleet-pr-checkout-detached` | `--repo jakildev/IrredenEngine` | `--repo jakildev/irreden` |
+    | build-verify (step g) | `fleet-build --target IRShapeDebug` | game build — see step g |
+
+    For a game PR, `cd` into the game worktree before any git/gh op (the
+    bash cwd persists across calls in the iteration), and reset *that*
+    worktree to scratch in step k. Game stacked-PRs don't exist (game
+    worker pickup skips stackables), so the stack-aware filter above is a
+    no-op for game.
 
     If the filtered list is empty, skip to step 2. Otherwise pick
     the oldest (smallest `number`) and:
@@ -303,12 +319,41 @@ Do the work, then exit cleanly:
        surface in subsequent commits, repeat step e for each.
     g. **Build before pushing.** Safety net for resolutions that
        compile-broke without a textual conflict marker (the most
-       common Opus failure mode):
-       `fleet-build --target IRShapeDebug`
-       If the build fails AND the failure is in code that this PR
-       touched, fix it inline and rebuild. If the failure is in
-       unrelated code, your resolution introduced a regression —
-       jump to step j (escalate).
+       common Opus failure mode).
+
+       **Engine PR:** `fleet-build --target IRShapeDebug`.
+
+       **Game PR:** the game can't build standalone — it compiles via
+       the engine with your game worktree added as a user project. Use a
+       **dedicated** game build dir (so it doesn't clobber your engine
+       worktree's preset build) and point `ir-build` at it with the
+       `IRREDEN_BUILD_DIR` env var (that's the override knob — there is
+       no `--build-dir` flag). `ir-build` only auto-configures with the
+       bare preset, which omits `IRREDEN_USER_PROJECTS`, so you must
+       configure this dir yourself **once** (idempotent; reuse across
+       iterations) with the game worktree as the user project, then
+       build the **affected project's** target:
+       ```
+       ENG=<your-engine-worktree-abs-path>
+       GAME_WT=~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-name>
+       # one-time configure (skip if $ENG/build-game/CMakeCache.txt exists):
+       cmake --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"
+       # build the affected project target via ir-build, pointed at that dir:
+       IRREDEN_BUILD_DIR="$ENG/build-game" fleet-build --target IRIrredenAll
+       ```
+       `<host>-debug` is your host preset (`macos-debug` / `linux-debug`).
+       Pick the target that matches what the PR touches — `IRIrredenAll`
+       (or `IRGame` for the demo) for `irreden/`, the corresponding
+       `IR<Project>All` otherwise. **Never build `IRGameAll`** — it
+       depends on the midi project, currently broken (game #88), so it
+       always fails regardless of your resolution.
+
+       Then, for either repo: if the build fails AND the failure is in
+       code this PR touched, fix it inline and rebuild. If the failure
+       is in unrelated code — or (game) you cannot get a clean
+       configure/build at all — your resolution can't be verified, so
+       **do NOT push**: jump to step j (escalate to the human). An
+       unverified game push is worse than a human handoff.
     h. Push. You're on detached HEAD (from step c), so the wrapper
        reads the head ref from `.git/fleet-amend-ref` and runs
        `git push --force-with-lease origin HEAD:<head-ref>`:
@@ -349,9 +394,15 @@ Do the work, then exit cleanly:
     k. Reset to scratch (runs at the end of every step 1c branch —
        success, lease-fail, or escalation — so the next iteration
        starts clean and reviewers aren't blocked from `gh pr
-       checkout`ing this branch). Release the resolving lock first:
+       checkout`ing this branch). Release the resolving lock first;
+       reset the worktree the PR was checked out in (engine worktree
+       for an engine PR, game worktree for a game PR — the `git
+       checkout` runs there):
        `fleet-claim resolving-release <N> <your-worktree-basename>`
+       (game: `fleet-claim --repo game resolving-release <N> <your-worktree-basename>`)
        `git checkout -B claude/<your-worktree-basename>-scratch origin/master`
+       The `build-game` dir, if you created one, is reused next iteration
+       — leave it.
 
     Conflicts are slow work (read both sides, judge intent, build,
     push) and force-push retriggers CI — keep this step bounded to

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -884,9 +884,13 @@ Specifically, **never pass these via `--label` when filing**:
 - `fleet:merger-cooldown` / `fleet:changes-made` — owned by the
   worker / merger pipeline.
 - `fleet:semantic-conflict` — owned by the **merger** (sets when it
-  can't auto-rebase). Cleared by the **opus-worker** after it
-  resolves the conflict, or escalated to `human:needs-fix` if even
-  Opus can't resolve.
+  can't auto-rebase), on **either repo** (the merger runs a game pass
+  too — PR #1371). Cleared by the **opus-worker** after it resolves the
+  conflict — its step 1c covers **both** engine and game PRs (game via
+  the game worktree + `--repo jakildev/irreden` + the
+  `IRREDEN_USER_PROJECTS` build-verify) — or escalated to
+  `human:needs-fix` if even Opus can't resolve (or, for a game PR, can't
+  build-verify the resolution).
 - `fleet:fork-of-other-pr` — owned by the **merger** (sets when it
   detects this PR's branch was forked from another open PR's branch
   rather than from master, meaning the diff carries inherited commits


### PR DESCRIPTION
Closes #1418.

## Problem

PR #1371 gave the merger a game pass — it now flags game PRs
`fleet:semantic-conflict`. But the *resolver*, opus-worker step 1c, was
engine-only, so game conflicts (**game #99**, **#101**) sat flagged with no
autonomous actor. Producer-without-consumer, one layer down from the
original merger gap.

## Fix — Option A: extend step 1c to both repos

- **Candidate source:** `repos.engine.prs[]` **and** `repos.game.prs[]`
  (engine first, then game).
- **Repo-routing table:** for a game PR, `cd` into the game worktree,
  `--repo jakildev/irreden` on `gh`, `fleet-claim --repo game
  resolving-claim`/`-release`, `fleet-pr-checkout-detached --repo
  jakildev/irreden`. Game PRs are never stacked, so the stack-aware filter
  is a no-op for them.
- **Build-verify (the crux):** the game can't build standalone — it
  compiles via the engine with the game worktree as a user project. The
  doc now specifies the real mechanism:
  ```
  cmake --preset <host>-debug -B "$ENG/build-game" -DIRREDEN_USER_PROJECTS="$GAME_WT"
  IRREDEN_BUILD_DIR="$ENG/build-game" fleet-build --target IRIrredenAll
  ```
  (`IRREDEN_BUILD_DIR` is `ir-build`'s actual override knob — there is no
  `--build-dir` flag. `ir-build`'s auto-configure uses the bare preset
  without `IRREDEN_USER_PROJECTS`, so the dir is configured once,
  explicitly.) Build the **affected project target** (`IRIrredenAll` /
  `IRGame`), **never `IRGameAll`** — it pulls in the broken midi project
  (game #88).
- **Fail-safe:** if a game resolution can't be configured/built cleanly,
  the worker **escalates** (`human:needs-fix`) rather than pushing. An
  unverified game push is worse than a human handoff — so Option A
  degrades safely even where the game build is awkward.
- Fixes the now-false *"merger is engine-only, so no game PR ever gets the
  label"* comment; updates FLEET.md's `fleet:semantic-conflict` ownership
  note to say the resolver covers both repos.

## Why no scout change

`fleet:semantic-conflict` is **deliberately not a scout trigger** (including
it self-loops the merger/worker — see the projection rationale). The worker
checks step 1c **opportunistically** every iteration (the live log that
surfaced this showed *"Step 1c: No engine PR carries fleet:semantic-conflict"*),
so extending the candidate source gives game the same handling as engine
with no trigger change.

## Notes

- Doc-only (`role-opus-worker.md` + `FLEET.md`).
- The verify uses the documented `IRREDEN_USER_PROJECTS` path. A dedicated
  `fleet-build --game` wrapper would collapse the configure+build to a
  one-liner — a reasonable follow-up if this proves clunky in practice.
- Once merged, an opus-worker will pick up game #99/#101 on its next
  iteration (or escalate them if the resolution can't build-verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
