### PR TITLE
docs: baseline rule — don't parallel-batch fallible Bash (the 'Cancelled: parallel tool call errored' cascade)

### DIFF
--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -273,8 +273,8 @@ reads like a hang, not an error. So one `which a b c` that doesn't find a
 tool, an `ls`/`cat` on a maybe-absent path, or a `gh` lookup that 404s
 silently kills every other call you batched with it. Therefore:
 
-- Only parallel-batch Bash calls you're confident exit 0 (e.g. a
-  `git -C <path> fetch` plus a `date`).
+- Only parallel-batch Bash calls you're confident exit 0 (e.g.
+  `git branch --show-current` plus `pwd`).
 - Issue **probing / maybe-failing** commands (`which`, `ls`/`cat` on
   paths that may not exist, `gh` lookups that may 404, a build that may
   break) **one per turn** — read each result before the next.
@@ -282,9 +282,10 @@ silently kills every other call you batched with it. Therefore:
   an empty/no-match result instead of a non-zero exit, so they never
   trigger the cascade.
 
-This compounds with the single-command rule above: a chain like
-`foo | head || echo x ; which a b c` both violates that rule *and*, by
-exiting non-zero, cancels its batch siblings.
+This compounds with the single-command rule above: even a
+single-command-compliant but fallible call like `which some-tool`,
+when batched alongside unrelated Bash calls, exits non-zero and
+cancels its batch siblings.
 
 - **No `cd <path> && git ...`** — use `git -C <path> ...` instead.
   `cd && git` triggers a hardcoded Claude Code security gate

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -265,6 +265,27 @@ shell compound operators (`&&`, `||`, `;`, `|`) to chain commands.
 Issue each command as its own separate Bash tool call, or use the
 Read/Glob/Grep tools instead of Bash when possible.
 
+**Don't put fallible Bash calls in the same parallel batch.** When you
+emit several Bash calls in one turn they run in parallel, and the harness
+**cancels the entire batch the moment any one call exits non-zero** — the
+siblings come back as `Cancelled: parallel tool call … errored`, which
+reads like a hang, not an error. So one `which a b c` that doesn't find a
+tool, an `ls`/`cat` on a maybe-absent path, or a `gh` lookup that 404s
+silently kills every other call you batched with it. Therefore:
+
+- Only parallel-batch Bash calls you're confident exit 0 (e.g. a
+  `git -C <path> fetch` plus a `date`).
+- Issue **probing / maybe-failing** commands (`which`, `ls`/`cat` on
+  paths that may not exist, `gh` lookups that may 404, a build that may
+  break) **one per turn** — read each result before the next.
+- Prefer Read/Glob/Grep over Bash for files and directories; they return
+  an empty/no-match result instead of a non-zero exit, so they never
+  trigger the cascade.
+
+This compounds with the single-command rule above: a chain like
+`foo | head || echo x ; which a b c` both violates that rule *and*, by
+exiting non-zero, cancels its batch siblings.
+
 - **No `cd <path> && git ...`** — use `git -C <path> ...` instead.
   `cd && git` triggers a hardcoded Claude Code security gate
   ("Compound commands with cd and git require approval to prevent


### PR DESCRIPTION
## Problem

Agents keep hitting `Cancelled: parallel tool call … errored` cascades. Root
cause: the Claude Code harness runs same-turn Bash calls in **parallel** and
**cancels the entire batch the instant any one call exits non-zero**. The
surviving calls report `Cancelled: parallel tool call … errored`, which reads
like a hang rather than an error.

Live example (an opus-worker probing its environment): one batch fired ~5
Bash calls; the first — `fleet-help … | head -40 || echo … ; which fleet-claim
…` — exited non-zero (the trailing `which <several tools>` returns 1 if any
isn't on PATH), and that single failure cancelled the other 4.

The baseline already bans compound operators and says "issue each command as
its own separate Bash tool call" — but separate calls *in one turn* **are** the
parallel batch, and nothing warned about the cancel-on-error cascade.

## Fix

This is harness behavior (not repo-fixable), but the *trigger* is reducible.
Add a rule to `CLAUDE-BASELINE.md` § Bash tool rules:

- Only parallel-batch Bash calls you're confident exit 0.
- Issue probing/maybe-failing commands (`which`, `ls`/`cat` on maybe-absent
  paths, `gh` lookups that may 404, builds that may break) **one per turn**.
- Prefer Read/Glob/Grep for files/dirs — they return empty/no-match instead
  of a non-zero exit, so they never trigger the cascade.

Doc-only; every agent reads the baseline.

## Possible follow-up (not in this PR)

The triggering batch was an opus-worker *probing its environment*
(`ls ~/.fleet`, `which fleet-claim`, `cat ~/.fleet/state/…`). A single
`fleet-doctor` command that prints host / paths / cache-age / claims / PATH
in one always-exit-0 call would both cut that probing and remove the
fallible-parallel-batch pattern at the source. Worth considering if the
env-probing keeps showing up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
