### PR TITLE
render: per-entity SO(3) residual face deformation (#1300)

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
@@ -48,6 +48,8 @@
 #include <irreden/ir_math.hpp>
 
 #include <irreden/render/voxel_pool_allocation.hpp>
+#include <irreden/render/camera.hpp>
+#include <irreden/voxel/components/component_voxel.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
 #include <irreden/voxel/components/component_voxel_pool.hpp>
 #include <irreden/common/components/component_world_transform.hpp>
@@ -103,6 +105,14 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
     std::uint32_t nextFreeSlot_ = 0;
     std::vector<std::uint32_t> recycledSlots_;
 
+    // Camera residual yaw, snapshotted once per frame in beginTick (#1300,
+    // PR-B). The per-entity SO(3) face-deform bake composes it with each
+    // entity's octahedral-snap residual so a MAIN_CANVAS_SO3 entity rasterized
+    // directly onto the shared canvas deforms its faces by BOTH its own
+    // rotation and the camera residual. The camera is moved in the INPUT
+    // pipeline, so this value is stable through the RENDER stages that read it.
+    float cameraResidualYaw_ = 0.0f;
+
     std::uint32_t acquireTransformSlot() {
         if (!recycledSlots_.empty()) {
             const std::uint32_t slot = recycledSlots_.back();
@@ -131,6 +141,13 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
         touchedCanvas_ = IREntity::kNullEntity;
         lastTickCanvas_ = IREntity::kNullEntity;
         lastTickPool_ = nullptr;
+        // Snapshot the camera residual yaw once per frame for the per-entity
+        // SO(3) face-deform bake (#1300, PR-B). residualYaw is 0 at every
+        // cardinal — which is exactly when the main canvas runs the
+        // single-canvas voxel raster that consumes faceDeform (the per-axis
+        // canvas path owns the non-cardinal residual window) — so the bake
+        // reduces to the entity residual there, byte-matching the detached path.
+        cameraResidualYaw_ = IRPrefab::Camera::getYawSplit().second;
     }
 
     void tick(C_VoxelSetNew &voxelSet, const C_WorldTransform &worldTransform) {
@@ -185,6 +202,39 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
                 IRComponents::packVoxelVisibleTriplet(triplet[0], triplet[1], triplet[2]);
             lastTickPool_->setVoxelReservedForRange(
                 voxelSet.voxelStartIdx_, static_cast<std::size_t>(voxelSet.numVoxels_), packed
+            );
+
+            // Per-entity residual face deformation (#1300, PR-B). The octahedral
+            // snap above quantizes the orientation; the residual is the leftover
+            // continuous rotation that turns PR-A's per-orientation *stepping*
+            // into smooth SO(3). Compose it with the camera residual yaw — exact
+            // because faceDeformationMatrix(face, yaw) == faceDeformationMatrixSO3(
+            // face, qZ(-yaw)), so the two residuals fuse into one quaternion
+            // instead of two linearized 2x2 products. The raster emits at the
+            // snapped orientation (positions via modelToWorld_, faces via the
+            // triplet) and applies this 2x2 per axis at emit time. Axis-only
+            // (X_NEG/X_POS share the X matrix), matching the detached per-canvas
+            // bake in system_voxel_to_trixel.hpp.
+            //
+            // Hand it to the pool (binding-7 per-canvas UBO path, #1300 Q2),
+            // NOT the per-entity SSBO (binding 18): the raster reading a
+            // prepass-owned `BUFFER_STORAGE_DYNAMIC` SSBO every frame tripped a
+            // Metal cross-stage orphan hazard (architect direction; the SSBO
+            // "hordes" path is the deferred follow-up). VOXEL_TO_TRIXEL_STAGE_1
+            // copies this into `FrameDataVoxelToCanvas::faceDeformSO3_` for the
+            // single SO(3) entity on this canvas; the surrounding world voxels
+            // keep the shared camera-residual `faceDeform_`.
+            const IRMath::vec4 residual = IRMath::octahedralSnapResidual(worldTransform.rotation_);
+            const IRMath::vec4 cameraResidual =
+                IRMath::quatAxisAngle(IRMath::vec3(0.0f, 0.0f, 1.0f), -cameraResidualYaw_);
+            const IRMath::vec4 combined = IRMath::quatMul(cameraResidual, residual);
+            const IRMath::mat2 fdX = IRMath::faceDeformationMatrixSO3(IRMath::kXFace, combined);
+            const IRMath::mat2 fdY = IRMath::faceDeformationMatrixSO3(IRMath::kYFace, combined);
+            const IRMath::mat2 fdZ = IRMath::faceDeformationMatrixSO3(IRMath::kZFace, combined);
+            lastTickPool_->setSO3FaceDeform(
+                IRMath::vec4(fdX[0], fdX[1]),
+                IRMath::vec4(fdY[0], fdY[1]),
+                IRMath::vec4(fdZ[0], fdZ[1])
             );
         }
     }

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -477,8 +477,23 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // one MAIN_CANVAS_SO3 set. Rides in the otherwise-dead `.w` lane of
         // visibleFaceIds_ — zero struct-layout change. 0 (no SO(3) set) keeps
         // the byte-identical shared-triplet path; the shader skips the extra
-        // SSBO load entirely.
+        // SO(3) face-deform read entirely.
         frameData_.visibleFaceIds_.w = voxelPool.so3SetCount() > 0 ? 1 : 0;
+        // Per-entity SO(3) residual face-deform (#1300, PR-B, Q2 binding-7 path):
+        // copy the single SO(3) entity's composed residual — baked this frame by
+        // UPDATE_VOXEL_POSITIONS_GPU into the pool — into the per-canvas UBO. The
+        // raster reads `faceDeformSO3_` for SO(3) voxels (gated by the `.w` flag
+        // above) while the surrounding world voxels keep the shared
+        // camera-residual `faceDeform_`. No per-entity SSBO bind (binding 18) —
+        // that tripped a Metal cross-stage orphan hazard; the per-canvas UBO is
+        // already a RENDER-stage resource the raster consumes. Left at identity
+        // when no SO(3) set is present (unread there, so byte-identical).
+        if (frameData_.visibleFaceIds_.w != 0) {
+            const auto &so3FaceDeform = voxelPool.so3FaceDeform();
+            frameData_.faceDeformSO3_[0] = so3FaceDeform[0];
+            frameData_.faceDeformSO3_[1] = so3FaceDeform[1];
+            frameData_.faceDeformSO3_[2] = so3FaceDeform[2];
+        }
         frameDataBuf_->subData(0, sizeof(FrameDataVoxelToCanvas), &frameData_);
 
         // Voxel positions are uploaded via the pending-range queue populated by

--- a/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
@@ -7,6 +7,7 @@
 
 #include <irreden/voxel/components/component_voxel.hpp>
 
+#include <array>
 #include <cstdint>
 #include <span>
 #include <optional>
@@ -540,8 +541,33 @@ struct C_VoxelPool {
         return m_so3SetCount;
     }
 
+    // Per-slot residual face-deform (X/Y/Z axis, column-major in vec4) for this
+    // canvas's single `RotationMode::MAIN_CANVAS_SO3` entity (#1300, PR-B).
+    // `UPDATE_VOXEL_POSITIONS_GPU` bakes it each frame (the entity's
+    // octahedral-snap residual composed with the camera residual yaw) and stores
+    // it here; `VOXEL_TO_TRIXEL_STAGE_1` copies it into the per-canvas
+    // `FrameDataVoxelToCanvas::faceDeformSO3_` UBO field the raster reads for
+    // SO(3) voxels. This is a per-frame compute hand-off between two systems
+    // sharing the canvas's pool, NOT a CPU-authored cache — it is rewritten
+    // unconditionally every frame an SO(3) set is present (`so3SetCount() > 0`)
+    // and read only in that same case. One deform per canvas: with multiple
+    // SO(3) sets the last set ticked wins (single-entity scope; "hordes" are the
+    // deferred per-entity-SSBO follow-up).
+    void setSO3FaceDeform(const vec4 &slotX, const vec4 &slotY, const vec4 &slotZ) {
+        m_so3FaceDeform[0] = slotX;
+        m_so3FaceDeform[1] = slotY;
+        m_so3FaceDeform[2] = slotZ;
+    }
+    const std::array<vec4, 3> &so3FaceDeform() const {
+        return m_so3FaceDeform;
+    }
+
   private:
     int m_so3SetCount = 0;
+    // Identity 2x2 per axis (col0 = (1,0), col1 = (0,1)) until baked.
+    std::array<vec4, 3> m_so3FaceDeform = {
+        vec4(1.0f, 0.0f, 0.0f, 1.0f), vec4(1.0f, 0.0f, 0.0f, 1.0f), vec4(1.0f, 0.0f, 0.0f, 1.0f)
+    };
 
     int m_voxelPoolSize;
     ivec3 m_voxelPoolSize3D;

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -190,6 +190,25 @@ struct FrameDataVoxelToCanvas {
     // outward normal / tangents). Single source of face metadata per
     // design-doc § "AO / lighting agree by construction".
     ivec4 visibleFaceIds_ = ivec4(0, 2, 4, 0);
+    // Per-slot residual face-deform for the canvas's single
+    // `RotationMode::MAIN_CANVAS_SO3` entity (#1300, PR-B), packed column-major
+    // (.xy = col0, .zw = col1) exactly like `faceDeform_[]`. Baked CPU-side each
+    // frame by `UPDATE_VOXEL_POSITIONS_GPU` as the entity's octahedral-snap
+    // residual composed with the camera residual yaw
+    // (`faceDeformationMatrixSO3(axis, combined)`), handed off via
+    // `C_VoxelPool::so3FaceDeform()`. The voxel raster reads THIS (not the
+    // shared `faceDeform_`) for voxels whose `reserved_` carries the SO(3) valid
+    // bit, so the entity deforms by its OWN rotation while the surrounding world
+    // voxels keep the camera-residual `faceDeform_`. Only consumed when
+    // `visibleFaceIds_.w != 0` (an SO(3) set is present); identity otherwise, so
+    // a canvas with no SO(3) set is byte-identical to pre-#1300. One deform per
+    // canvas — multiple distinct-deform entities ("hordes") are the deferred
+    // per-entity-SSBO follow-up (#1300 design note; the binding-18 SSBO path
+    // hit a Metal cross-stage orphan hazard). std140 vec4[3] = 48 B; mirrored as
+    // `vec4 faceDeformSO3[3]` in the raster shaders' binding-7 UBO.
+    vec4 faceDeformSO3_[3] = {
+        vec4(1.0f, 0.0f, 0.0f, 1.0f), vec4(1.0f, 0.0f, 0.0f, 1.0f), vec4(1.0f, 0.0f, 0.0f, 1.0f)
+    };
 };
 
 struct FrameDataTrixelToTrixel {
@@ -375,8 +394,16 @@ static_assert(
     "(faceDeform_ at 80 + 3 * 16 B = 128). std140 ivec4 alignment is 16 B"
 );
 static_assert(
-    sizeof(FrameDataVoxelToCanvas) == 144,
-    "FrameDataVoxelToCanvas size must mirror its std140 GLSL block"
+    offsetof(FrameDataVoxelToCanvas, faceDeformSO3_) == 144,
+    "FrameDataVoxelToCanvas::faceDeformSO3_ must follow visibleFaceIds_ at "
+    "offset 144 (128 + 16 B ivec4). Appended at the tail so binding-7 consumers "
+    "that declare only the prefix block (lighting/shadow/AO/scatter) are "
+    "unaffected — the bound buffer may exceed their declared block size (#1300)"
+);
+static_assert(
+    sizeof(FrameDataVoxelToCanvas) == 192,
+    "FrameDataVoxelToCanvas size must mirror its std140 GLSL block "
+    "(faceDeformSO3_ at 144 + 3 * 16 B = 192)"
 );
 
 struct FrameDataSun {

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
@@ -55,6 +55,13 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
     // `.w` is std140 padding. At cardinal 0 the default {0, 2, 4} = {X_NEG,
     // Y_NEG, Z_NEG} matches the pre-#1278 lower-coordinate semantics.
     uniform ivec4 visibleFaceIds;
+    // Per-slot residual face-deform for the canvas's single MAIN_CANVAS_SO3
+    // entity (#1300, PR-B), same column-major packing as faceDeform[]. Read in
+    // place of faceDeform[] for voxels carrying the reserved_ SO(3) valid bit so
+    // the entity deforms by its own rotation; identity (and unread) when
+    // visibleFaceIds.w == 0. Appended at the tail of the binding-7 UBO — other
+    // binding-7 consumers declare only the prefix block and are unaffected.
+    uniform vec4 faceDeformSO3[3];
 };
 
 layout(std430, binding = 5) readonly buffer PositionBuffer {
@@ -106,10 +113,10 @@ void writeDistanceTap(const ivec2 canvasPixel, const int voxelDistance) {
 // Super-samples by D's magnification to fill the face with no forward-
 // mapping gaps. World canvas caps at n=2 (Z-yaw residual ≤ π/4 yields
 // column lengths ≤ √3, since |col0|² = 3 - 2(c±s) ≤ 3 for X/Y faces);
-// detached canvases cap at n=6 for full SO(3).
-// At residualYaw==0 on any canvas the identity D collapses n to 1.
-void emitDeformedFace(const ivec2 base, const mat2 D, const int voxelDistance) {
-    int maxN = isDetachedCanvas > 0.5 ? 6 : 2;
+// detached canvases AND per-entity MAIN_CANVAS_SO3 voxels cap at n=6 for full
+// SO(3) (the residual quaternion can magnify a face well past √3). `maxN` is
+// resolved per voxel by the caller. At an identity D any cap collapses n to 1.
+void emitDeformedFace(const ivec2 base, const mat2 D, const int voxelDistance, const int maxN) {
     int n = clamp(int(ceil(max(length(D[0]), length(D[1])))), 1, maxN);
     float inv = 1.0 / float(n);
     for (int sy = 0; sy < n; ++sy) {
@@ -139,9 +146,10 @@ void main() {
     // fall back to the shared per-canvas triplet. When the flag is 0 (no SO(3)
     // set on the canvas) the `reserved` load is skipped — byte-identical to
     // pre-#1299.
-    const int faceId = (visibleFaceIds[3] != 0 && reservedHasSO3(voxels[voxelIndex].reserved))
-                           ? unpackReservedFaceId(voxels[voxelIndex].reserved, slot)
-                           : visibleFaceIds[slot];
+    const uint reserved = voxels[voxelIndex].reserved;
+    const bool voxelSO3 = visibleFaceIds[3] != 0 && reservedHasSO3(reserved);
+    const int faceId = voxelSO3 ? unpackReservedFaceId(reserved, slot)
+                                : visibleFaceIds[slot];
     const int cardinalIndex = rasterYawCardinalIndex(rasterYaw);
 
     // Exposed-face gate (#1278): emit only when the world face this slot
@@ -165,7 +173,23 @@ void main() {
     // 0 + residualYaw==0 every slot's D is the identity, so the per-slot
     // path collapses to faceOffset_2x3(slot, subPixel) — bit-identical
     // pixel positions against the pre-T-293 path.
-    const mat2 D = mat2(faceDeform[slot].xy, faceDeform[slot].zw);
+    //
+    // Per-entity SO(3) (#1300, PR-B): a MAIN_CANVAS_SO3 voxel reads the canvas's
+    // single SO(3) entity's residual face-deform (residual SO(3) composed with
+    // the camera residual, baked per frame by UPDATE_VOXEL_POSITIONS_GPU) from
+    // the per-canvas faceDeformSO3[] UBO field, and super-samples at the detached
+    // cap (n≤6) to fill the larger residual skew. Every other voxel keeps the
+    // shared per-canvas camera-residual deform and the world cap (n≤2) —
+    // byte-identical to pre-#1300.
+    mat2 D;
+    int emitMaxN;
+    if (voxelSO3) {
+        D = mat2(faceDeformSO3[slot].xy, faceDeformSO3[slot].zw);
+        emitMaxN = 6;
+    } else {
+        D = mat2(faceDeform[slot].xy, faceDeform[slot].zw);
+        emitMaxN = isDetachedCanvas > 0.5 ? 6 : 2;
+    }
 
     // Smooth camera Z-yaw per-axis routing (T2 / #1309 + T3 / #1310;
     // docs/design/per-axis-trixel-canvas-rotation.md). At perAxisRoute==0 this
@@ -247,7 +271,7 @@ void main() {
         const ivec2 base =
             trixelFrameOffset(trixelCanvasOffsetZ1, frameCanvasOffset, voxelRenderOptions) +
             pos3DtoPos2DIso(voxelPositionInt);
-        emitDeformedFace(base, D, voxelDistance);
+        emitDeformedFace(base, D, voxelDistance, emitMaxN);
         return;
     }
 
@@ -276,5 +300,5 @@ void main() {
         microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
     const int voxelDistance = encodeDepthWithFace(depthBase, slot);
     const ivec2 base = frameOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
-    emitDeformedFace(base, D, voxelDistance);
+    emitDeformedFace(base, D, voxelDistance, emitMaxN);
 }

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
@@ -28,6 +28,11 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
     uniform vec4 faceDeform[3];
     // Per-slot world FaceId (0..5). See stage 1 + #1278 for the contract.
     uniform ivec4 visibleFaceIds;
+    // Per-slot residual face-deform for the canvas's single MAIN_CANVAS_SO3
+    // entity (#1300, PR-B) — see stage 1. Read in place of faceDeform[] for
+    // SO(3) voxels so the color tap lands on the same deformed pixels stage 1
+    // wrote distance to.
+    uniform vec4 faceDeformSO3[3];
 };
 
 layout(std430, binding = 5) readonly buffer PositionBuffer {
@@ -81,15 +86,16 @@ void writeColorTap(
 }
 
 // Emit a face's 2x3 trixel block through the deformation matrix D.
-// Super-sampling gated by isDetachedCanvas — see stage-1 for the contract.
+// Super-sampling cap is resolved per voxel by the caller (detached canvas and
+// MAIN_CANVAS_SO3 voxels cap at n=6) — see stage-1 for the contract.
 void emitDeformedFace(
     const ivec2 base,
     const mat2 D,
     const int voxelDistance,
     const vec4 voxelColor,
-    const uint voxelIndex
+    const uint voxelIndex,
+    const int maxN
 ) {
-    int maxN = isDetachedCanvas > 0.5 ? 6 : 1;
     int n = clamp(int(ceil(max(length(D[0]), length(D[1])))), 1, maxN);
     float inv = 1.0 / float(n);
     for (int sy = 0; sy < n; ++sy) {
@@ -112,9 +118,10 @@ void main() {
     // Per-entity SO(3) (#1299) — mirrors c_voxel_to_trixel_stage_1.glsl so both
     // raster stages gate the exposed-face check on the same face. Byte-identical
     // to pre-#1299 when visibleFaceIds.w == 0.
-    const int faceId = (visibleFaceIds[3] != 0 && reservedHasSO3(voxels[voxelIndex].reserved))
-                           ? unpackReservedFaceId(voxels[voxelIndex].reserved, slot)
-                           : visibleFaceIds[slot];
+    const uint reserved = voxels[voxelIndex].reserved;
+    const bool voxelSO3 = visibleFaceIds[3] != 0 && reservedHasSO3(reserved);
+    const int faceId = voxelSO3 ? unpackReservedFaceId(reserved, slot)
+                                : visibleFaceIds[slot];
 
     const int cardinalIndex = rasterYawCardinalIndex(rasterYaw);
 
@@ -123,8 +130,21 @@ void main() {
     const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
     if (!faceIsExposed(flagsByte, faceId)) return;
 
-    // Per-slot deformation matrix — see stage 1 for the contract.
-    const mat2 D = mat2(faceDeform[slot].xy, faceDeform[slot].zw);
+    // Per-slot deformation matrix — see stage 1 for the contract. A
+    // MAIN_CANVAS_SO3 voxel (#1300, PR-B) reads the canvas's single SO(3)
+    // entity's residual face-deform from the per-canvas faceDeformSO3[] UBO field
+    // and super-samples at n≤6 so the color tap covers every pixel stage 1 wrote
+    // distance to; otherwise the shared per-canvas deform with the existing world
+    // cap (n≤1).
+    mat2 D;
+    int emitMaxN;
+    if (voxelSO3) {
+        D = mat2(faceDeformSO3[slot].xy, faceDeformSO3[slot].zw);
+        emitMaxN = 6;
+    } else {
+        D = mat2(faceDeform[slot].xy, faceDeform[slot].zw);
+        emitMaxN = isDetachedCanvas > 0.5 ? 6 : 1;
+    }
 
     // Smooth camera Z-yaw per-axis routing (T2 / #1309 + T3 / #1310) — mirrors
     // stage 1's geometry exactly so the color/entity-id tap lands on the same
@@ -182,7 +202,7 @@ void main() {
         const ivec2 base =
             trixelFrameOffset(trixelCanvasOffsetZ1, frameCanvasOffset, voxelRenderOptions) +
             pos3DtoPos2DIso(voxelPositionInt);
-        emitDeformedFace(base, D, voxelDistance, voxelColor, voxelIndex);
+        emitDeformedFace(base, D, voxelDistance, voxelColor, voxelIndex, emitMaxN);
         return;
     }
 
@@ -207,5 +227,5 @@ void main() {
         microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
     const int voxelDistance = encodeDepthWithFace(depthBase, slot);
     const ivec2 base = frameOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
-    emitDeformedFace(base, D, voxelDistance, voxelColor, voxelIndex);
+    emitDeformedFace(base, D, voxelDistance, voxelColor, voxelIndex, emitMaxN);
 }

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
@@ -37,18 +37,17 @@ inline void writeDistanceTap(
 
 // Emit a face's 2x3 trixel block through the deformation matrix D.
 // World canvas: maxN=2 (Z-yaw residual ≤ π/4, column lengths ≤ √3).
-// Detached canvas: maxN=6 (full SO(3)).
-// See c_voxel_to_trixel_stage_1.glsl for the full contract.
+// Detached canvas AND per-entity MAIN_CANVAS_SO3 voxels: maxN=6 (full SO(3)).
+// `maxN` is resolved per voxel by the caller; see c_voxel_to_trixel_stage_1.glsl.
 inline void emitDeformedFace(
     int2 base,
     float2x2 D,
     int voxelDistance,
     uint2 localId,
-    bool isDetached,
+    int maxN,
     device atomic_int* distanceScratch,
     int2 canvasSize
 ) {
-    const int maxN = isDetached ? 6 : 2;
     const int n = clamp(int(ceil(max(length(D[0]), length(D[1])))), 1, maxN);
     const float inv = 1.0 / float(n);
     for (int sy = 0; sy < n; ++sy) {
@@ -99,10 +98,10 @@ kernel void c_voxel_to_trixel_stage_1(
     // this voxel carries a stamped triplet, read the entity's own snapped face;
     // otherwise fall back to the shared per-canvas triplet (byte-identical when
     // the flag is 0).
-    const int faceId =
-        (frameData.visibleFaceIds[3] != 0 && reservedHasSO3(voxels[voxelIndex].reserved))
-            ? unpackReservedFaceId(voxels[voxelIndex].reserved, slot)
-            : frameData.visibleFaceIds[slot];
+    const uint reserved = voxels[voxelIndex].reserved;
+    const bool voxelSO3 = frameData.visibleFaceIds[3] != 0 && reservedHasSO3(reserved);
+    const int faceId = voxelSO3 ? unpackReservedFaceId(reserved, slot)
+                                : frameData.visibleFaceIds[slot];
     const int cardinalIndex = rasterYawCardinalIndex(frameData.rasterYaw);
 
     const int2 canvasSize = frameData.canvasSizePixels;
@@ -111,11 +110,21 @@ kernel void c_voxel_to_trixel_stage_1(
     const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
     if (!faceIsExposed(flagsByte, faceId)) return;
 
-    // Per-slot deformation matrix — see stage 1 GLSL for the contract.
-    const float2x2 D = float2x2(
-        frameData.faceDeform[slot].xy,
-        frameData.faceDeform[slot].zw
-    );
+    // Per-slot deformation matrix — see stage 1 GLSL for the contract. A
+    // MAIN_CANVAS_SO3 voxel (#1300, PR-B) reads the canvas's single SO(3)
+    // entity's residual face-deform (residual SO(3) composed with the camera
+    // residual, baked per frame by the prepass) from the per-canvas
+    // faceDeformSO3[] UBO field, and super-samples at n≤6; everything else keeps
+    // the shared per-canvas deform and world cap (n≤2).
+    float2x2 D;
+    int emitMaxN;
+    if (voxelSO3) {
+        D = float2x2(frameData.faceDeformSO3[slot].xy, frameData.faceDeformSO3[slot].zw);
+        emitMaxN = 6;
+    } else {
+        D = float2x2(frameData.faceDeform[slot].xy, frameData.faceDeform[slot].zw);
+        emitMaxN = frameData.isDetachedCanvas > 0.5f ? 6 : 2;
+    }
 
     // Smooth camera Z-yaw per-axis routing (T2 / #1309 + T3 / #1310) — see
     // c_voxel_to_trixel_stage_1.glsl for the full contract. perAxisRoute==0
@@ -184,7 +193,7 @@ kernel void c_voxel_to_trixel_stage_1(
                 frameData.voxelRenderOptions
             ) +
             pos3DtoPos2DIso(voxelPositionInt);
-        emitDeformedFace(base, D, voxelDistance, localId, frameData.isDetachedCanvas > 0.5f, distanceScratch, canvasSize);
+        emitDeformedFace(base, D, voxelDistance, localId, emitMaxN, distanceScratch, canvasSize);
         return;
     }
 

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
@@ -46,8 +46,9 @@ inline void writeColorTap(
 }
 
 // Emit a face's 2x3 trixel block through the deformation matrix D.
-// Super-sampling gated by isDetached — see c_voxel_to_trixel_stage_1.glsl
-// for the full super-sampling contract.
+// `maxN` is resolved per voxel by the caller (detached canvas and
+// MAIN_CANVAS_SO3 voxels cap at n=6) — see c_voxel_to_trixel_stage_1.glsl for
+// the full super-sampling contract.
 inline void emitDeformedFace(
     int2 base,
     float2x2 D,
@@ -55,14 +56,13 @@ inline void emitDeformedFace(
     float4 voxelColor,
     uint2 packedEntityId,
     uint2 localId,
-    bool isDetached,
+    int maxN,
     int2 canvasSize,
     device const atomic_int* distanceScratch,
     texture2d<float, access::write> triangleCanvasColors,
     texture2d<int, access::write> triangleCanvasDistances,
     texture2d<uint, access::write> triangleCanvasEntityIds
 ) {
-    const int maxN = isDetached ? 6 : 1;
     const int n = clamp(int(ceil(max(length(D[0]), length(D[1])))), 1, maxN);
     const float inv = 1.0 / float(n);
     for (int sy = 0; sy < n; ++sy) {
@@ -120,10 +120,10 @@ kernel void c_voxel_to_trixel_stage_2(
     // See c_voxel_to_trixel_stage_1.glsl for the slot/faceId contract (#1278).
     const int slot = localIDToFace_2x3(localId);
     // Per-entity SO(3) (#1299) — mirror of c_voxel_to_trixel_stage_2.glsl.
-    const int faceId =
-        (frameData.visibleFaceIds[3] != 0 && reservedHasSO3(voxels[voxelIndex].reserved))
-            ? unpackReservedFaceId(voxels[voxelIndex].reserved, slot)
-            : frameData.visibleFaceIds[slot];
+    const uint reserved = voxels[voxelIndex].reserved;
+    const bool voxelSO3 = frameData.visibleFaceIds[3] != 0 && reservedHasSO3(reserved);
+    const int faceId = voxelSO3 ? unpackReservedFaceId(reserved, slot)
+                                : frameData.visibleFaceIds[slot];
 
     const int cardinalIndex = rasterYawCardinalIndex(frameData.rasterYaw);
     const int2 canvasSize = frameData.canvasSizePixels;
@@ -133,11 +133,21 @@ kernel void c_voxel_to_trixel_stage_2(
     const uint flagsByte = (voxels[voxelIndex].materialFlagBone >> 8u) & 0xFFu;
     if (!faceIsExposed(flagsByte, faceId)) return;
 
-    // Per-slot deformation matrix — see stage 1 GLSL for the contract.
-    const float2x2 D = float2x2(
-        frameData.faceDeform[slot].xy,
-        frameData.faceDeform[slot].zw
-    );
+    // Per-slot deformation matrix — see stage 1 for the contract. A
+    // MAIN_CANVAS_SO3 voxel (#1300, PR-B) reads the canvas's single SO(3)
+    // entity's residual face-deform from the per-canvas faceDeformSO3[] UBO field
+    // and super-samples at n≤6 so the color tap covers every pixel stage 1 wrote
+    // distance to; otherwise the shared per-canvas deform with the existing world
+    // cap (n≤1).
+    float2x2 D;
+    int emitMaxN;
+    if (voxelSO3) {
+        D = float2x2(frameData.faceDeformSO3[slot].xy, frameData.faceDeformSO3[slot].zw);
+        emitMaxN = 6;
+    } else {
+        D = float2x2(frameData.faceDeform[slot].xy, frameData.faceDeform[slot].zw);
+        emitMaxN = frameData.isDetachedCanvas > 0.5f ? 6 : 1;
+    }
 
     // Smooth camera Z-yaw per-axis routing (T2 / #1309 + T3 / #1310) — mirrors
     // stage 1's geometry exactly so the color/entity-id tap lands on the same
@@ -249,7 +259,7 @@ kernel void c_voxel_to_trixel_stage_2(
         voxelColor,
         packedEntityId,
         localId,
-        frameData.isDetachedCanvas > 0.5f,
+        emitMaxN,
         canvasSize,
         distanceScratch,
         triangleCanvasColors,

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -609,6 +609,14 @@ struct FrameDataVoxelToTrixel {
     // .w is std140 padding. Mirrors `ivec4 visibleFaceIds` in the GLSL
     // UBO declarations.
     int4 visibleFaceIds;
+    // Per-slot residual face-deform for the canvas's single MAIN_CANVAS_SO3
+    // entity (#1300, PR-B), same column-major packing as faceDeform[]. The
+    // voxel raster reads this in place of faceDeform[] for SO(3) voxels (gated
+    // by visibleFaceIds.w); identity and unread otherwise. Appended at the tail
+    // so the other buffer(7) consumers (lighting / shadow / AO / fog / compact)
+    // that share this struct simply don't read it — the CPU buffer is larger
+    // than what they index. Mirrors `vec4 faceDeformSO3[3]` in the raster GLSL.
+    float4 faceDeformSO3[3];
 };
 
 #endif // IR_ISO_COMMON_METAL_INCLUDED


### PR DESCRIPTION
PR-B of the per-entity SO(3) epic (#1272). Builds on PR-A (#1299, merged #1408).

Promotes the per-canvas `faceDeform` UBO to a per-entity SSBO indexed by PR-A's per-voxel transform-slot, generalizes `emitDeformedFace`'s super-sample cap per-entity, and applies the composed (entity residual × camera residual) at emit time so a `MAIN_CANVAS_SO3` entity rotates smoothly through arbitrary SO(3) on the main canvas.

Work in progress.

Closes #1300