### PR TITLE
fleet: shared branch↔issue matcher so game claims aren't mis-swept (#1425)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -99,6 +99,12 @@ while [[ $# -gt 0 && "$1" == --* ]]; do
     esac
 done
 
+# Directory of this script, so inline `python3` blocks can import the shared
+# branch<->issue matcher (fleet_branch_match.py) regardless of cwd. Exported
+# so it survives the subshells/pipes those blocks run in. See #1425.
+FLEET_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export FLEET_LIB_DIR
+
 # --- input validation -----------------------------------------------------
 
 # require_issue_number <input>
@@ -767,9 +773,22 @@ cmd_claim() {
         if [[ -n "$repo_for_pr_check" ]]; then
             local existing_pr
             existing_pr=$(gh pr list --repo "$repo_for_pr_check" --state open \
-                --json number,headRefName \
-                --jq ".[] | select(.headRefName | startswith(\"claude/${issue_num}-\")) | .number" \
-                2>/dev/null | head -1)
+                --json number,headRefName 2>/dev/null \
+                | ISSUE_NUM="$issue_num" REPO_NS="$REPO_NS" python3 -c '
+import json, os, sys
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_branch_match import branch_matches_issue
+issue = os.environ["ISSUE_NUM"]
+repo = os.environ.get("REPO_NS", "")
+try:
+    prs = json.load(sys.stdin)
+except Exception:
+    prs = []
+for pr in prs:
+    if branch_matches_issue(pr.get("headRefName") or "", issue, repo):
+        print(pr.get("number"))
+        break
+' 2>/dev/null | head -1)
             if [[ -n "$existing_pr" ]]; then
                 echo "fleet-claim claim: #${issue_num} already has open PR #${existing_pr} (head claude/${issue_num}-…); refusing duplicate claim" >&2
                 return 1
@@ -909,6 +928,8 @@ cmd_find_stackable_blockers() {
     local blocker
     blocker=$(BODY_B64="$body_b64" REPO="$repo" python3 <<'PYEOF'
 import base64, json, os, re, subprocess, sys
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_branch_match import branch_matches_issue
 
 body = base64.b64decode(os.environ["BODY_B64"]).decode("utf-8", errors="replace")
 repo = os.environ.get("REPO", "")
@@ -950,8 +971,7 @@ _resolve_cache = {}
 def is_satisfied(ref):
     if ref in _resolve_cache:
         return _resolve_cache[ref]
-    prefix = f"claude/{ref}-"
-    if any(h.startswith(prefix) for h in merged_heads):
+    if any(branch_matches_issue(h, ref, repo) for h in merged_heads):
         _resolve_cache[ref] = True
         return True
     if not repo:
@@ -982,6 +1002,8 @@ PYEOF
 
     BLOCKER="$blocker" REPO="$repo" python3 <<'PYEOF'
 import json, os, re, subprocess, sys
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_branch_match import branch_matches_issue
 blocker = os.environ["BLOCKER"]
 repo = os.environ["REPO"]
 try:
@@ -1000,14 +1022,13 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
-branch_prefix = f"claude/{blocker}-"
 closes_re = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#" + re.escape(blocker) + r"\b", re.IGNORECASE)
 
 matches = []
 for pr in prs:
     head = pr.get("headRefName", "") or ""
     body = pr.get("body", "") or ""
-    if head.startswith(branch_prefix) or closes_re.search(body):
+    if branch_matches_issue(head, blocker, repo) or closes_re.search(body):
         matches.append(pr)
 if len(matches) != 1:
     sys.exit(0)
@@ -1394,19 +1415,22 @@ except Exception:
             [[ $age -lt $claim_issue_stale_secs ]] && continue
 
             local has_wip_pr
-            has_wip_pr=$(echo "$open_pr_branches_json" | ISSUE_NUM="$issue_num" python3 -c "
+            has_wip_pr=$(echo "$open_pr_branches_json" | ISSUE_NUM="$issue_num" REPO="$repo" python3 -c '
 import json, os, sys
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_branch_match import branch_matches_issue
 try:
     prs = json.load(sys.stdin)
 except Exception:
     prs = []
-prefix = f\"claude/{os.environ['ISSUE_NUM']}-\"
+issue = os.environ["ISSUE_NUM"]
+repo = os.environ.get("REPO", "")
 for pr in prs:
-    if (pr.get('headRefName') or '').startswith(prefix):
+    if branch_matches_issue(pr.get("headRefName") or "", issue, repo):
         print(1)
         sys.exit(0)
 print(0)
-" 2>/dev/null || echo 0)
+' 2>/dev/null || echo 0)
 
             [[ "$has_wip_pr" -eq 1 ]] && continue
 
@@ -1485,19 +1509,22 @@ for issue in issues:
             [[ -z "$issue_num" || -z "$label_name" ]] && continue
 
             local has_wip_pr
-            has_wip_pr=$(echo "$open_pr_branches_json" | ISSUE_NUM="$issue_num" python3 -c "
+            has_wip_pr=$(echo "$open_pr_branches_json" | ISSUE_NUM="$issue_num" REPO="$repo" python3 -c '
 import json, os, sys
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_branch_match import branch_matches_issue
 try:
     prs = json.load(sys.stdin)
 except Exception:
     prs = []
-prefix = f\"claude/{os.environ['ISSUE_NUM']}-\"
+issue = os.environ["ISSUE_NUM"]
+repo = os.environ.get("REPO", "")
 for pr in prs:
-    if (pr.get('headRefName') or '').startswith(prefix):
+    if branch_matches_issue(pr.get("headRefName") or "", issue, repo):
         print(1)
         sys.exit(0)
 print(0)
-" 2>/dev/null || echo 0)
+' 2>/dev/null || echo 0)
 
             [[ "$has_wip_pr" -eq 1 ]] && continue
 
@@ -1815,6 +1842,8 @@ cmd_reconcile() {
         "$work/fs_claims.json" "$work/reservations.json" \
         > "$findings" <<'PYEOF'
 import sys, os, json, re
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_branch_match import issue_from_branch
 
 work, host, now_s, ttl_s = sys.argv[1:5]
 repos = sys.argv[5].split() if sys.argv[5] else []
@@ -1845,17 +1874,9 @@ def labelset(obj):
                if isinstance(l, dict))
 
 def head_issue(head):
-    # claude/<N>-... -> N
-    if not head.startswith("claude/"):
-        return None
-    rest = head[len("claude/"):]
-    num = ""
-    for ch in rest:
-        if ch.isdigit():
-            num += ch
-        else:
-            break
-    return int(num) if num else None
+    # claude/<N>-... or claude/game-<N>-... -> N. Routed through the shared
+    # matcher so the game `game-` infix is handled here too (#1425).
+    return issue_from_branch(head or "")
 
 # A PR resolves an issue when its head branch is claude/<N>-* OR its body
 # carries a Closes/Fixes/Resolves #N reference — the same dual-match
@@ -2853,8 +2874,10 @@ cmd_molecule_rebase_downstream() {
     if [[ $explicit -eq 0 ]]; then
         local current_branch
         current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-        if [[ "$current_branch" =~ ^claude/([0-9]+) ]]; then
-            upstream_id="${BASH_REMATCH[1]}"
+        if [[ "$current_branch" =~ ^claude/(game-)?([0-9]+) ]]; then
+            # Optional `game-` infix mirrors issue_from_branch / the shared
+            # matcher so legacy claude/game-<N>-… branches resolve too (#1425).
+            upstream_id="${BASH_REMATCH[2]}"
             echo "auto-detected upstream issue: #${upstream_id} (from branch $current_branch)"
         elif [[ "$current_branch" =~ ^claude/[Tt]-([0-9]+) ]]; then
             echo "auto-detect: legacy claude/T-NNN branch ($current_branch) — pass the issue number explicitly" >&2

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -790,7 +790,7 @@ for pr in prs:
         break
 ' 2>/dev/null | head -1)
             if [[ -n "$existing_pr" ]]; then
-                echo "fleet-claim claim: #${issue_num} already has open PR #${existing_pr} (head claude/${issue_num}-…); refusing duplicate claim" >&2
+                echo "fleet-claim claim: #${issue_num} already has open PR #${existing_pr} (head claude/[game-]${issue_num}-…); refusing duplicate claim" >&2
                 return 1
             fi
         fi

--- a/scripts/fleet/fleet-reconcile-amendments
+++ b/scripts/fleet/fleet-reconcile-amendments
@@ -61,15 +61,19 @@ import shutil
 import subprocess
 import sys
 
+# Shared branch<->issue matcher, so game claude/game-<N>-* branches resolve
+# to their issue number here too (engine-only regex used to drop them; #1425).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fleet_branch_match import issue_from_branch
+
 # Branch shapes the reconciler can resolve to a task identifier:
-#   claude/<N>-…       → new convention (post-#1216). Captures the issue
-#                        number; the reconciler passes it straight to
+#   claude/<N>-…       → new convention (post-#1216). issue_from_branch
+#   claude/game-<N>-…    yields the issue number (it strips the optional
+#                        game- infix); the reconciler passes it straight to
 #                        `fleet-claim reserve`.
-#   claude/T-NNN-…     → legacy. Captures the T-NNN; no way to resolve
-#                        back to the issue number, so reconstruction
-#                        skips it and the worker manually re-reserves
-#                        on next iteration.
-ISSUE_BRANCH_RE = re.compile(r"^claude/(\d+)-")
+#   claude/T-NNN-…     → legacy. No way to resolve back to the issue number,
+#                        so reconstruction skips it and the worker manually
+#                        re-reserves on next iteration.
 LEGACY_TASK_BRANCH_RE = re.compile(r"^claude/T-\d+-")
 
 # Resolve home-relative paths consistently with the fleet-up shell parent.
@@ -227,8 +231,8 @@ def reconcile_repo(repo: str, wt_root: pathlib.Path) -> None:
         if reservation_exists(basename):
             log(f"{repo}#{number} ({branch}): worktree {basename} has reservation → leave alone")
             continue
-        match = ISSUE_BRANCH_RE.match(branch)
-        if not match:
+        issue_num = issue_from_branch(branch)
+        if issue_num is None:
             if LEGACY_TASK_BRANCH_RE.match(branch):
                 warn(
                     f"{repo}#{number} ({branch}): legacy claude/T-NNN-* branch "
@@ -241,7 +245,7 @@ def reconcile_repo(repo: str, wt_root: pathlib.Path) -> None:
                     f"but branch isn't claude/<issue>-* — can't reconstruct, leaving alone"
                 )
             continue
-        task_id = match.group(1)
+        task_id = str(issue_num)
         if reconstruct_reservation(basename, task_id, branch):
             log(
                 f"{repo}#{number} ({branch}): reconstructed reservation for {basename} "

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -30,6 +30,12 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+# Shared branch<->issue matcher, also imported by fleet-claim's inline
+# python. Insert this script's own dir so the import resolves whether the
+# scout is run directly or loaded by-path in the unit tests (#1425).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fleet_branch_match import branch_matches_issue
+
 ENGINE = Path.home() / "src" / "IrredenEngine"
 GAME = ENGINE / "creations" / "game"
 
@@ -878,7 +884,7 @@ def resolve_blocked_by(state):
             for ref in refs:
                 if ref in closed_nums:
                     continue
-                if any(h.startswith(f"claude/{ref}-") for h in merged_heads):
+                if any(branch_matches_issue(h, ref, repo_key) for h in merged_heads):
                     continue
                 if _resolve_ref_satisfied(repo_slug, ref, per_tick_cache):
                     continue
@@ -921,9 +927,8 @@ def enrich_stackable_blocker_prs(state):
             issue_num = _single_blocker_issue(blocked_by)
             if not issue_num:
                 continue
-            prefix = f"claude/{issue_num}-"
             matches = [pr for pr in prs
-                       if pr.get("headRefName", "").startswith(prefix)]
+                       if branch_matches_issue(pr.get("headRefName", ""), issue_num, repo_key)]
             if len(matches) != 1:
                 continue
             pr = matches[0]

--- a/scripts/fleet/fleet_branch_match.py
+++ b/scripts/fleet/fleet_branch_match.py
@@ -1,0 +1,84 @@
+"""Shared branch <-> issue matching for the fleet coordination scripts.
+
+Both `fleet-claim` (bash, via inline `python3`) and `fleet-state-scout`
+(pure Python) repeatedly ask "does this `claude/...` PR branch belong to
+issue #N?" or "which issue does this branch belong to?". Engine branches
+are `claude/<N>-<topic>`; game branches were historically minted as
+`claude/game-<N>-<topic>`. Every call site previously hardcoded the engine
+form (`claude/<N>-`), so the `game-` infix made the check silently miss
+live game branches.
+
+That miss is the #1425 incident: a game claim with an open
+`claude/game-105-*` PR was not recognized as live, the TTL sweep judged it
+abandoned and re-freed the issue, and a second worker produced a duplicate
+PR. Centralizing the convention here makes the two scripts share one
+matcher so they can't drift, and fixes every inference at once.
+
+The matcher accepts BOTH forms for the game repo, so in-flight
+`claude/game-<N>-*` branches keep resolving while the convention migrates
+to the prefix-less form. Engine accepts only `claude/<N>-`.
+"""
+
+
+def _is_game(repo):
+    """True when `repo` names the game repo.
+
+    Accepts any identifier the call sites carry: a `--repo` namespace token
+    ("" / "engine" / "game"), the scout's repo key ("engine" / "game"), or a
+    GitHub `owner/repo` path ("jakildev/irreden" vs "jakildev/IrredenEngine").
+    """
+    r = (repo or "").strip().lower()
+    if not r or r in ("engine", "jakildev/irredenengine"):
+        return False
+    if r in ("game", "irreden", "jakildev/irreden"):
+        return True
+    # owner/repo fallback: the game path ends in "/irreden"; the engine path
+    # ends in "/irredenengine", so the suffix test does not catch it.
+    return r.endswith("/irreden")
+
+
+def _norm_issue(issue):
+    """Normalize an issue identifier to a bare digit string (drops a '#')."""
+    return str(issue).strip().lstrip("#")
+
+
+def issue_branch_prefixes(repo, issue):
+    """Accepted `claude/...` branch prefixes for `issue` in `repo`.
+
+    Engine -> ["claude/<N>-"]; game -> ["claude/<N>-", "claude/game-<N>-"].
+    The trailing "-" is load-bearing: it stops `claude/105-` from matching
+    issue 1050's `claude/1050-` branch.
+    """
+    n = _norm_issue(issue)
+    prefixes = ["claude/%s-" % n]
+    if _is_game(repo):
+        prefixes.append("claude/game-%s-" % n)
+    return prefixes
+
+
+def branch_matches_issue(head_ref, issue, repo):
+    """True when `head_ref` is the working branch for `issue` in `repo`."""
+    head = head_ref or ""
+    return any(head.startswith(p) for p in issue_branch_prefixes(repo, issue))
+
+
+def issue_from_branch(head_ref):
+    """Extract the issue number from a `claude/...` branch, or None.
+
+    Repo-agnostic inverse of `branch_matches_issue`: handles both
+    `claude/<N>-...` (engine / new game) and `claude/game-<N>-...` (legacy
+    game) by stripping the optional `game-` infix before reading the digits.
+    """
+    head = head_ref or ""
+    if not head.startswith("claude/"):
+        return None
+    rest = head[len("claude/"):]
+    if rest.startswith("game-"):
+        rest = rest[len("game-"):]
+    num = ""
+    for ch in rest:
+        if ch.isdigit():
+            num += ch
+        else:
+            break
+    return int(num) if num else None

--- a/scripts/fleet/tests/test_branch_matches_issue.py
+++ b/scripts/fleet/tests/test_branch_matches_issue.py
@@ -1,0 +1,100 @@
+"""Tests for the shared branch<->issue matcher (fleet_branch_match.py, #1425).
+
+Pins the contract both fleet-claim and fleet-state-scout rely on:
+  - engine accepts only `claude/<N>-`
+  - game accepts both `claude/<N>-` and `claude/game-<N>-`
+  - cross-repo and wrong-issue branches do not match
+  - issue_from_branch is the repo-agnostic inverse (strips optional game-)
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from fleet_branch_match import (
+    branch_matches_issue,
+    issue_branch_prefixes,
+    issue_from_branch,
+    _is_game,
+)
+
+
+class BranchMatchesIssue(unittest.TestCase):
+    # --- acceptance criteria (#1425) -------------------------------------
+    def test_game_legacy_prefix_matches_game(self):
+        self.assertTrue(branch_matches_issue("claude/game-105-x", 105, "game"))
+
+    def test_engine_prefix_matches_engine(self):
+        self.assertTrue(branch_matches_issue("claude/105-x", 105, "engine"))
+
+    def test_cross_repo_negative(self):
+        # A game-shaped branch is not an engine branch.
+        self.assertFalse(branch_matches_issue("claude/game-105-x", 105, "engine"))
+
+    def test_wrong_issue_negative(self):
+        self.assertFalse(branch_matches_issue("claude/106-x", 105, "engine"))
+        self.assertFalse(branch_matches_issue("claude/game-106-x", 105, "game"))
+
+    # --- game also accepts the new prefix-less form ----------------------
+    def test_game_accepts_engine_form(self):
+        # New game branches drop the game- prefix; the matcher must still
+        # recognize them so the convention can migrate.
+        self.assertTrue(branch_matches_issue("claude/105-x", 105, "game"))
+
+    # --- the trailing '-' guards the issue-number boundary ---------------
+    def test_issue_number_is_not_a_prefix_of_another(self):
+        self.assertFalse(branch_matches_issue("claude/1050-x", 105, "engine"))
+        self.assertFalse(branch_matches_issue("claude/1050-x", 105, "game"))
+        self.assertFalse(branch_matches_issue("claude/game-1050-x", 105, "game"))
+
+    # --- repo identifiers the call sites actually pass -------------------
+    def test_repo_identifier_forms(self):
+        # owner/repo paths (fleet-claim's $repo)
+        self.assertTrue(branch_matches_issue("claude/game-105-x", 105, "jakildev/irreden"))
+        self.assertFalse(branch_matches_issue("claude/game-105-x", 105, "jakildev/IrredenEngine"))
+        # --repo namespace token (empty == engine)
+        self.assertTrue(branch_matches_issue("claude/105-x", 105, ""))
+        self.assertFalse(branch_matches_issue("claude/game-105-x", 105, ""))
+
+    def test_is_game(self):
+        for game in ("game", "irreden", "jakildev/irreden", "JAKILDEV/IRREDEN"):
+            self.assertTrue(_is_game(game), game)
+        for engine in ("", "engine", "jakildev/IrredenEngine", "jakildev/irredenengine", None):
+            self.assertFalse(_is_game(engine), engine)
+
+    # --- issue arg accepts int or str (with or without '#') --------------
+    def test_issue_arg_int_str_hash(self):
+        for issue in (105, "105", "#105"):
+            self.assertTrue(branch_matches_issue("claude/105-x", issue, "engine"), issue)
+
+    def test_issue_branch_prefixes(self):
+        self.assertEqual(issue_branch_prefixes("engine", 105), ["claude/105-"])
+        self.assertEqual(
+            issue_branch_prefixes("game", 105),
+            ["claude/105-", "claude/game-105-"],
+        )
+
+
+class IssueFromBranch(unittest.TestCase):
+    def test_engine_branch(self):
+        self.assertEqual(issue_from_branch("claude/105-gear-foo"), 105)
+
+    def test_legacy_game_branch(self):
+        # The reconcile head_issue bug: this used to return None.
+        self.assertEqual(issue_from_branch("claude/game-105-gear-foo"), 105)
+
+    def test_non_claude_branch(self):
+        self.assertIsNone(issue_from_branch("master"))
+        self.assertIsNone(issue_from_branch("feature/105-x"))
+
+    def test_no_digits(self):
+        self.assertIsNone(issue_from_branch("claude/game-scratch"))
+        self.assertIsNone(issue_from_branch("claude/topic-only"))
+
+    def test_empty_and_none(self):
+        self.assertIsNone(issue_from_branch(""))
+        self.assertIsNone(issue_from_branch(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Every branch→issue inference in the fleet scripts hardcoded the engine `claude/<N>-` form, so game `claude/game-<N>-` branches silently fell through — the #1425 incident (a live game claim swept as abandoned past the 2h TTL → duplicate PRs game #111/#113).
- New `scripts/fleet/fleet_branch_match.py` centralizes the convention: `branch_matches_issue` / `issue_branch_prefixes` / `issue_from_branch`. Game accepts both `claude/<N>-` and `claude/game-<N>-`; engine only `claude/<N>-`. The trailing `-` guards the issue-number boundary (`claude/105-` ≠ `claude/1050-`).
- Wired into **all 9** branch→issue sites across `fleet-claim`, `fleet-state-scout`, and `fleet-reconcile-amendments`: the 6 the issue enumerated (cleanup sweep, reset-sweep, claim open-PR sanity check, blocker resolution, scout blocked_by/merged-head + stackable enrichment) **plus 3 identical same-bug inferences** found while implementing — reconcile `head_issue`, molecule-rebase auto-detect, and the amendment-reconciler's game-repo reservation reconstruction. The issue's framing ("game silently falls through *all* of them") justified covering these too.
- The FS-claim `game-` slug namespace is **deliberately untouched** — per the issue's Option-B decision it's the real cross-repo disambiguator on the shared filesystem.
- Part 2 (drop the `game-` *mint* in the game repo's `creations/game/CLAUDE.md` — a cross-repo, optional cleanup) is filed as follow-up **jakildev/irreden#116**. The matcher already accepts both forms, so the bug is fully fixed without it.

## Acceptance criteria (from #1425)
- [x] A game claim with an open `claude/game-<N>-*` PR is not swept as abandoned (the sweep recognizes the game PR as the live owner).
- [x] Blocker resolution, stackable enrichment, and the claim open-PR sanity check recognize game branches.
- [x] Unit test pins `branch_matches_issue("claude/game-105-x", 105, game)` True; `("claude/105-x", 105, engine)` True; cross-repo + wrong-issue negatives False.
- [x] Existing fleet-claim claim/cleanup + scout projection tests still pass.

## Test plan
- [x] `scripts/fleet/tests/test_branch_matches_issue.py` (new) — 15 cases incl. boundary (`1050` vs `105`), repo-identifier forms (`game` / `jakildev/irreden` / owner-paths), int/str/`#` issue args, and `issue_from_branch` inverse.
- [x] Full claim/scout suite green (16 files): blockers, acquire, stackable-live-resolve, reconcile, reconcile-c2, reconcile-amendments, model-gate, live-blocker-resolution, enrich-stackable, worker/merger/queue projections, issue-queue-parser, scope-shipped.
- [x] `bash -n` (fleet-claim) + `python3` ast-parse (fleet-state-scout, fleet-reconcile-amendments, fleet_branch_match) clean.
- [x] Scripts-only change — no C++ build.

Closes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)