### PR TITLE
fleet: add fleet:needs-human to _ALREADY_QUEUED_LABELS to prevent re-queuing race (#1417)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -152,8 +152,9 @@ def fetch_prs(repo):
     return prs
 
 
-_ALREADY_QUEUED_LABELS = frozenset({"fleet:queued", "fleet:scope-shipped"})
-# fleet:needs-human intentionally absent; parked issues remain visible in human_approved[]
+_ALREADY_QUEUED_LABELS = frozenset({"fleet:queued", "fleet:scope-shipped", "fleet:needs-human"})
+# fleet:needs-human included: parked issues must not re-enter the queue even if the
+# two-step add+remove call creates a TOCTOU window where fleet:queued is transiently absent.
 
 # Labels that mark issues the queue-manager role doc explicitly skips at
 # Step 5 — filter these out of the ingest projector/slicer so epics and


### PR DESCRIPTION
## Summary

- Adds `fleet:needs-human` to `_ALREADY_QUEUED_LABELS` in `scripts/fleet/fleet-state-scout` so parked issues are excluded at fetch time (not just downstream at ingest-skip time).
- Updates the comment at line 156 to explain the TOCTOU motivation instead of saying it was "intentionally absent".

## Root cause

When a task is parked (agent adds `fleet:needs-human` while removing `fleet:queued` in two separate `gh issue edit` calls), the scout can fire between the two calls and see `human:approved` + no `fleet:queued` + no `fleet:needs-human`. `fetch_human_approved` would pick up the issue, and `fleet-queue-ingest` would re-add `fleet:queued`. The `_INGEST_SKIP_LABELS` guard catches it downstream, but this fix adds a belt-and-suspenders guard upstream at fetch time.

## Test plan
- [x] `test_queue_manager_projection.py` — 14 tests green (including `test_needs_human_excluded_from_pending`).
- [x] `test_issue_queue_parser.py` — 31 tests green.
- [x] Python-only change; no C++ build needed.

Closes #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)