### PR TITLE
render: extract shared voxelDispatchGridForCount dispatch-grid helper

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
@@ -15,6 +15,7 @@
 #include <irreden/render/lod_utils.hpp>
 #include <irreden/render/sun_shadow_constants.hpp>
 #include <irreden/render/camera.hpp>
+#include <irreden/render/voxel_dispatch_grid.hpp>
 
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/gpu_stage_timing_observer.hpp>
@@ -550,17 +551,15 @@ template <> struct System<SHAPES_TO_TRIXEL> {
             gridXOut = 1;
             return 0;
         }
-        constexpr int kMaxDispatchGroupsX = 1024;
-        const int gridX = IRMath::min(tileCount, kMaxDispatchGroupsX);
-        const int gridY = IRMath::divCeil(tileCount, gridX);
-        const int paddedCount = gridX * gridY;
+        const ivec2 grid = voxelDispatchGridForCount(tileCount);
+        const int paddedCount = grid.x * grid.y;
         ShapeTileDescriptor sentinel{};
         sentinel.shapeIndex = -1;
         while (static_cast<int>(tiles.size()) < paddedCount) {
             tiles.push_back(sentinel);
         }
         tileDescBuf->subData(0, paddedCount * sizeof(ShapeTileDescriptor), tiles.data());
-        gridXOut = gridX;
+        gridXOut = grid.x;
         return tileCount;
     }
 };

--- a/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
@@ -48,6 +48,7 @@
 #include <irreden/ir_math.hpp>
 
 #include <irreden/render/voxel_pool_allocation.hpp>
+#include <irreden/render/voxel_dispatch_grid.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
 #include <irreden/voxel/components/component_voxel_pool.hpp>
 #include <irreden/common/components/component_world_transform.hpp>
@@ -153,11 +154,8 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
         // CPU mirror of the GLSL/Metal `transform * localPos`: sqtToMat4 is
         // bit-identical to the shader-side helper, so the same operands classify
         // the same on both sides (the CPU↔GPU consistency the plan flags).
-        transforms_[slot].modelToWorld_ = IRMath::sqtToMat4(
-            worldTransform.scale_,
-            rotation,
-            worldTransform.translation_
-        );
+        transforms_[slot].modelToWorld_ =
+            IRMath::sqtToMat4(worldTransform.scale_, rotation, worldTransform.translation_);
         maxSlotUsed_ = IRMath::max(maxSlotUsed_, static_cast<int>(slot));
         anyDynamic_ = true;
 
@@ -184,7 +182,9 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
             const std::uint32_t packed =
                 IRComponents::packVoxelVisibleTriplet(triplet[0], triplet[1], triplet[2]);
             lastTickPool_->setVoxelReservedForRange(
-                voxelSet.voxelStartIdx_, static_cast<std::size_t>(voxelSet.numVoxels_), packed
+                voxelSet.voxelStartIdx_,
+                static_cast<std::size_t>(voxelSet.numVoxels_),
+                packed
             );
         }
     }
@@ -246,16 +246,13 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
 
         // One thread per live voxel; the 2D workgroup grid mirrors the visibility
         // compact dispatch exactly so the shader's linear-index reconstruction
-        // (workGroupIndex * 64 + localId.x) lines up with what we dispatch. This
-        // is the same fold as `voxelDispatchGridForCount` in system_voxel_to_trixel.hpp;
-        // it is inlined here to avoid depending on that heavy STAGE_1 header just
-        // for the helper. Extraction tracked in #1422.
+        // (workGroupIndex * 64 + localId.x) lines up with what we dispatch. The
+        // count→grid fold is shared with VOXEL_TO_TRIXEL_STAGE_1 via the
+        // lightweight voxel_dispatch_grid.hpp helper (#1422) — no dependency on
+        // the heavy STAGE_1 system header.
         constexpr int kLocalSize = 64;
-        constexpr int kMaxGroupsX = 1024;
-        const int groups = IRMath::divCeil(liveCount, kLocalSize);
-        const int groupsX = IRMath::min(groups, kMaxGroupsX);
-        const int groupsY = IRMath::divCeil(groups, groupsX);
-        IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
+        const ivec2 grid = voxelDispatchGridForCount(IRMath::divCeil(liveCount, kLocalSize));
+        IRRender::device()->dispatchCompute(grid.x, grid.y, 1);
         IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
     }
 

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -21,6 +21,7 @@
 #include <irreden/render/sun_shadow_constants.hpp>
 #include <irreden/render/camera.hpp>
 #include <irreden/render/per_axis_canvas.hpp>
+#include <irreden/render/voxel_dispatch_grid.hpp>
 #include <irreden/render/components/component_per_axis_trixel_canvases.hpp>
 
 #include <irreden/render/gpu_stage_timing.hpp>
@@ -36,13 +37,6 @@ using namespace IRMath;
 using namespace IRRender;
 
 namespace IRSystem {
-
-inline ivec2 voxelDispatchGridForCount(int voxelCount) {
-    constexpr int kMaxDispatchGroupsX = 1024;
-    const int groupsX = IRMath::min(voxelCount, kMaxDispatchGroupsX);
-    const int groupsY = IRMath::divCeil(voxelCount, groupsX);
-    return ivec2(groupsX, groupsY);
-}
 
 inline const std::vector<std::uint32_t> &buildChunkVisibilityMask(
     C_VoxelPool &pool,

--- a/engine/prefabs/irreden/render/voxel_dispatch_grid.hpp
+++ b/engine/prefabs/irreden/render/voxel_dispatch_grid.hpp
@@ -1,0 +1,30 @@
+#ifndef IR_RENDER_VOXEL_DISPATCH_GRID_H
+#define IR_RENDER_VOXEL_DISPATCH_GRID_H
+
+#include <irreden/ir_math.hpp>
+
+namespace IRSystem {
+
+// Folds a 1D compute-dispatch count into a 2D workgroup grid, capping the X
+// dimension at 1024 so anything larger spills into additional rows. Each
+// consuming compute shader reconstructs the linear work item index from the
+// 2D dispatch (e.g. `workGroupIndex * localSize + localId.x`), so the X cap
+// here is load-bearing: it must match what the shaders unfold. That coupling
+// is exactly why this is one shared helper rather than re-inlined per call
+// site — every voxel/shape dispatch must fold a given count identically.
+//
+// `count` is the number of work items to spread across the grid; for a
+// workgroup grid, callers divide their thread count by the shader's local
+// size first (e.g. `divCeil(liveCount, 64)`). Callers guard `count > 0`
+// before dispatching — `count == 0` divides by zero here, same as it always
+// has.
+inline IRMath::ivec2 voxelDispatchGridForCount(int count) {
+    constexpr int kMaxDispatchGroupsX = 1024;
+    const int groupsX = IRMath::min(count, kMaxDispatchGroupsX);
+    const int groupsY = IRMath::divCeil(count, groupsX);
+    return IRMath::ivec2(groupsX, groupsY);
+}
+
+} // namespace IRSystem
+
+#endif // IR_RENDER_VOXEL_DISPATCH_GRID_H


### PR DESCRIPTION
## Summary

The 1D-count → 2D-workgroup-grid fold (`groupsX = min(count, 1024)`,
`groupsY = divCeil(count, groupsX)`) was inlined **verbatim** in three
render-prefab systems:

- `UPDATE_VOXEL_POSITIONS_GPU` (inlined local copy)
- `VOXEL_TO_TRIXEL_STAGE_1` (defined `IRSystem::voxelDispatchGridForCount` locally)
- `SHAPES_TO_TRIXEL` (`buildAndUploadTileDescriptors`, inlined local copy)

The update-positions system re-derived the fold locally rather than depend on
the heavy STAGE_1 header just for the helper — the duplication was flagged as a
nit in the PR #1408 review (#1299).

This moves the helper into a new lightweight header
`engine/prefabs/irreden/render/voxel_dispatch_grid.hpp` (depends only on
`ir_math.hpp`) and routes all three call sites through it.

## Scope note — third call site

The issue names two systems. The `simplify` reuse scan surfaced a **third**
verbatim copy of the identical fold in `SHAPES_TO_TRIXEL` (same directory),
so I folded it in here too — leaving an identical inline copy one file over
would defeat the dedup the issue exists for. `SHAPES_TO_TRIXEL` still derives
its `paddedCount` as `grid.x * grid.y`.

## Byte-identical

Pure extract-header refactor. The fold arithmetic and the 1024 column cap are
preserved exactly; the update site still applies it to `divCeil(liveCount, 64)`
and shapes still pads to `grid.x * grid.y`. No dispatch grid changes for any
count, so no visual delta is possible — screenshots intentionally skipped per
the author-pipeline mechanical-refactor exception.

## Test plan

- [x] `fleet-build --target IRShapeDebug` clean (compiles all three consumers
  via `IrredenEngineRendering`).
- [x] `format-changed` applied.
- [ ] Linux/OpenGL cross-host smoke (parity confirmation — no behavior change).

Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)