### PR TITLE
fleet: automate --stackable-on base + fleet:stacked in commit-and-push

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -41,9 +41,9 @@ This skill has three modes. Detect at the start of the flow, in priority order:
 
 1. **Fleet stack mode** — caller has an active `fleet-claim` stack chain. PRs are chained by `--base` (one PR per task). Detected via `fleet-claim stack-pr-state <worktree>`. See [`procedures/fleet-stack.md`](procedures/fleet-stack.md) for the deltas (branch name with `<issue#>` prefix (`claude/<NNN>-<slug>`), `stack-base` lookup for `--base`, `Stack context` body block, `fleet:stacked` label, `stack-set-pr` after PR open).
 2. **Cursor stack mode** — current branch has `branch.<name>.cursor-stack-base` git config set (written by `start-next-task` when the human cued stacking). PRs target the parent branch instead of `master`. See [`procedures/cursor-stack.md`](procedures/cursor-stack.md) for the detection check, the `Stacked on:` body line, and the macOS sandbox note.
-3. **Single-PR mode (default)** — neither stack signal present. Proceed with the standard flow below.
+3. **Single-task mode (default)** — neither stack signal above. The PR base is resolved via `fleet-claim claim-base <issue#>`: `master` for a normal claim (or a plain human PR), or the blocker's branch for an opportunistic `--stackable-on` claim — which then also gets the `fleet:stacked` label. See [`procedures/stackable-on.md`](procedures/stackable-on.md).
 
-The two stack modes are mutually exclusive. In single-PR mode, ignore `procedures/fleet-stack.md` and `procedures/cursor-stack.md`; `procedures/pr-body.md` still applies for the step 8 body template.
+The three modes are mutually exclusive and checked in the order above. In single-task mode, ignore `procedures/fleet-stack.md` and `procedures/cursor-stack.md`; `procedures/pr-body.md` still applies for the step 8 body template, and `procedures/stackable-on.md` covers the base + `fleet:stacked` resolution.
 
 ## Flow
 
@@ -259,7 +259,7 @@ Use `gh pr create`. Body template per mode: [`procedures/pr-body.md`](procedures
 
 > **Before calling `gh pr create` in any snippet below, complete step 8a (Closes# cross-check) if the drafted body contains a `Closes #N` line.**
 
-For the **single-PR flow** (default), target is `master`:
+For the **single-task flow** (default), resolve the base via `fleet-claim claim-base` — `master` for a normal claim or a plain human PR (the common case, shown below), or the blocker's branch for a `--stackable-on` claim (which also gets `fleet:stacked`). The issue-number lookup, the idempotent edit-or-create (the fleet-worker WIP PR is usually already open from claim time), and the `Stacked on:` body line all live in [`procedures/stackable-on.md`](procedures/stackable-on.md). The common `master` case:
 
 ```bash
 gh pr create --base master --title "<scope>: <title>" --body "$(cat <<'EOF'

--- a/.claude/skills/commit-and-push/procedures/stackable-on.md
+++ b/.claude/skills/commit-and-push/procedures/stackable-on.md
@@ -1,0 +1,81 @@
+# Single-task base resolution + `--stackable-on` (commit-and-push procedure)
+
+**Single-task mode** is the default — it applies when neither
+[fleet stack mode](fleet-stack.md) (an active `fleet-claim stack` chain) nor
+[cursor stack mode](cursor-stack.md) (a `cursor-stack-base` git config) is in
+effect. It covers two cases through **one** path:
+
+- a **normal** fleet claim or a plain human PR → base is `master` (unchanged
+  from the historic default);
+- an opportunistic **`--stackable-on`** claim (the idle-worker fallback tier —
+  a task whose single `**Blocked by:**` blocker has an open PR) → base is the
+  blocker's branch, and the PR carries `fleet:stacked`.
+
+The `--stackable-on` behavior lives entirely in what `fleet-claim claim-base`
+returns, so there is nothing stackable-specific to remember: always resolve
+the base the same way and let the value decide.
+
+## Resolve the issue number, then the base
+
+1. **Issue number** (needed for `claim-base`):
+   - Primary: `fleet-claim reservation-of "<your-worktree-name>"` — the claim
+     auto-reserves the worktree↔task binding, so this prints the issue number
+     with no parsing.
+   - Fallback: parse `<N>` from a `claude/<N>-<topic>` branch name.
+   - Neither yields a numeric `<N>` (a plain human / ad-hoc PR with no fleet
+     claim) → base is `master`, no label; proceed with the standard `SKILL.md`
+     step-8 `master` flow.
+2. **Base:**
+   ```bash
+   base=$(fleet-claim claim-base "<N>")   # "master" for a normal claim; the blocker's branch for --stackable-on
+   ```
+   `claim-base` is a no-op for normal claims (no `.meta` sidecar → prints
+   `master`), so this is safe to run unconditionally once you have `<N>`.
+
+## Open (or reconcile) the PR — idempotent
+
+A fleet-worker WIP PR is usually **already open** (created at claim time, see
+`docs/agents/FLEET.md` §"Single-task base resolution (`claim-base`)"). So
+*ensure* the invariant rather than assume creation — repair base/label if the
+claim-time open missed them:
+
+```bash
+branch=$(git branch --show-current)
+labels=(--label "fleet:wip")
+[[ "$base" != "master" ]] && labels+=(--label "fleet:stacked")
+
+existing=$(gh pr list --head "$branch" --state open --json url -q '.[0].url')
+if [[ -n "$existing" ]]; then
+    gh pr edit "$existing" --base "$base"                       # no-op when already correct
+    [[ "$base" != "master" ]] && gh pr edit "$existing" --add-label "fleet:stacked"
+else
+    gh pr create --base "$base" "${labels[@]}" \
+        --title "<scope>: <title> (#<N>)" \
+        --body "$(cat <<EOF
+<single-task body — procedures/pr-body.md; include the Stacked on: line below when base != master>
+EOF
+)"
+fi
+```
+
+When `base != master`, add a `Stacked on:` line to the body, pointing at the
+upstream PR (look it up once — same pattern as cursor-stack.md):
+
+```bash
+upstream_pr=$(gh pr list --head "$base" --state all --json url -q '.[0].url')
+# body: "Stacked on: ${upstream_pr:-$base (no PR yet)}"
+```
+
+## Notes / non-goals
+
+- **No `stack-set-pr`.** That bookkeeping is molecule-only ([fleet-stack.md](fleet-stack.md)).
+  Single-task mode writes no claim state — it only *reads* `claim-base`.
+- **`fleet:wip` is unchanged.** The claim-time PR is WIP; the finalize step
+  removes `fleet:wip` for reviewer pickup, leaving `fleet:stacked` in place.
+- **Don't fight the merger.** When the upstream PR merges, the merger
+  re-targets this PR to `master` and removes `fleet:stacked`. Only set the
+  base/label from the *current* `claim-base` value at push time; never
+  re-stack a PR the merger has already re-targeted.
+- The merger routes stacked PRs by `baseRefName != "master"` regardless of the
+  label; `fleet:stacked` is the human-visibility / cheap-filter convenience
+  this procedure guarantees is present.

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -616,7 +616,7 @@ Always exits 0 (safe to include in a parallel tool batch with
   empty resume is also safe. Either way, proceed with the normal
   pickup flow.
 
-### Per-issue stacked PR command sequence
+### Per-task stacked PR command sequence
 
 When a stack-claim spans multiple issues
 (`fleet-claim stack "<A> <B> …"`), each issue in the chain gets its
@@ -684,9 +684,9 @@ conflict actually modified them.
 the same branch, push, and comment as usual. No cross-issue
 side-effects.
 
-### Single-issue base resolution (`claim-base`)
+### Single-task base resolution (`claim-base`)
 
-For single-issue claims (including stackable-on fallback claims),
+For single-task claims (including stackable-on fallback claims),
 determine the base branch before checking out:
 
 `fleet-claim claim-base "<issue-number>"`
@@ -711,6 +711,12 @@ First look up the upstream PR URL:
 
 Then open the PR:
 `gh pr create --base <upstream-branch> --title "<issue title> (#<N>)" --body "Stacked on: <upstream PR URL>\n\nWork in progress.\n\nCloses #<N>" --label "fleet:wip" --label "fleet:stacked"`
+
+> You don't have to get this exactly right by hand: **`commit-and-push`
+> resolves the base via `claim-base` and applies `fleet:stacked`
+> automatically for single-task claims** (idempotent edit-or-create), so a
+> missed `--base`/label here is repaired before review — see
+> [`commit-and-push/procedures/stackable-on.md`](../../.claude/skills/commit-and-push/procedures/stackable-on.md).
 
 ---
 


### PR DESCRIPTION
## Problem

The fleet has three stacking modes; two are automated in the `commit-and-push` skill (molecule via `stack-base`; cursor via git config), but the **`--stackable-on`** opportunistic single-task path (the idle-worker fallback tier) applied its `--base <blocker-branch>` + `fleet:stacked` label only via a **manual snippet a worker had to follow by hand** in `docs/agents/FLEET.md`. A worker that deviated could open a stacked PR against `master` and/or without the `fleet:stacked` tag. (The merger still routes on `baseRefName != "master"`, so the label is the human-visibility/cheap-filter convenience that should be reliably present.)

## Fix

Centralize single-task base resolution in the skill, so `--stackable-on` is as reliable as the molecule path:

- The default mode (renamed **"Single-task"**) resolves the base via `fleet-claim claim-base <N>` — `master` for a normal claim or a plain human PR, or the blocker's branch for a `--stackable-on` claim — and adds `fleet:stacked` when base ≠ master. The `--stackable-on` behavior lives entirely in `claim-base`'s return value, so normal and stackable-on claims share one path.
- **Idempotent**: the fleet-worker WIP PR is usually already open from claim time, so the skill *edits-or-creates* (`gh pr edit --base`/`--add-label`, both no-ops when already correct; `gh pr create` otherwise).
- Issue number via `fleet-claim reservation-of <worktree>` (branch-parse fallback; else `master`, no label).
- Mode precedence unchanged: molecule > cursor > single-task.

### Files
| File | Change |
|---|---|
| `.claude/skills/commit-and-push/procedures/stackable-on.md` | **NEW** — issue-number resolution, `claim-base` base resolution, idempotent edit-or-create PR open, `Stacked on:` body line. |
| `.claude/skills/commit-and-push/SKILL.md` | "Single-PR mode" → "Single-task mode" (resolves via `claim-base`); step 8 points at the new procedure. |
| `docs/agents/FLEET.md` | Heading-drift fix the role docs already reference: "Single-**issue**"/"Per-**issue**" → "Single-**task**"/"Per-**task**"; note that commit-and-push now guarantees base + `fleet:stacked`. |

Docs/skill only — no `fleet-claim` / `fleet-state-scout` change; the merger's stacked-PR label state machine (re-target on base merge, cascade-rebase, `fleet:awaiting-base`/`fleet:needs-base-update`/`fleet:stacked-rebase`) is unchanged. Stacking stays single-blocker (orthogonal to the multi-blocker gate in #1402).

## Testing
- No-regression (contracts the skill leans on): `test_fleet_claim_stackable_live_resolve.sh` 7/7, `test_enrich_stackable_blocker_prs.py` 14, `test_fleet_claim_blockers.sh` 16/16, `test_fleet_claim_acquire.sh` 10/10.
- Doc-consistency: role-doc "Single-task"/"Per-task" references now resolve to the renamed FLEET.md headings; no leftover "Single-issue"/"Per-issue"; `procedures/stackable-on.md` is linked from `SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
