### PR TITLE
render: consolidate inlined camera Z-yaw math into IRMath / ir_iso_common helpers (#1372)

### DIFF
--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -424,6 +424,22 @@ constexpr CardinalIndex rasterYawCardinalIndex(float rasterYaw) {
     return static_cast<CardinalIndex>(((q % 4) + 4) % 4);
 }
 
+/// `(cos, sin)` of the cardinal angle named by @p cardinalIndex — exact
+/// `±1`/`0`, the snapped Z-yaw the `GRID` voxel/SDF rasterizer projects at.
+/// Pairs with @ref rasterYawCardinalIndex to retire the open-coded
+/// `kCardinalCos`/`kCardinalSin` tables callers used to inline.
+///
+/// GPU mirror: `cardinalYawCosSin` in `shaders/ir_iso_common.glsl`.
+constexpr vec2 cardinalYawCosSin(CardinalIndex cardinalIndex) {
+    if (cardinalIndex == CardinalIndex::k90)
+        return vec2(0.0f, 1.0f);
+    if (cardinalIndex == CardinalIndex::k180)
+        return vec2(-1.0f, 0.0f);
+    if (cardinalIndex == CardinalIndex::k270)
+        return vec2(0.0f, -1.0f);
+    return vec2(1.0f, 0.0f);
+}
+
 /// CPU mirror of `rotateCardinalZ` in `shaders/ir_iso_common.glsl`.
 /// World→view = R_z(-rasterYaw) for the given cardinal snap. The voxel
 /// rasterizer applies this to world positions before iso projection, so
@@ -595,6 +611,24 @@ constexpr vec2 pos3DtoPos2DIsoYawed(const vec3 worldPos, float visualYaw) {
     const float vx = worldPos.x * c + worldPos.y * s;
     const float vy = -worldPos.x * s + worldPos.y * c;
     return vec2(-vx + vy, -vx - vy + 2.0f * worldPos.z);
+}
+
+/// Conservative XY growth of an axis-aligned half-extent swept under a Z-yaw of
+/// `(cosYaw, sinYaw)`: each in-plane axis grows to `|c|·hX + |s|·hY` (the
+/// footprint the rotated box covers, up to the √2 extent at ±45°); Z is
+/// unchanged. Centralizes the iso-cull / GPU-tile-dispatch footprint expansion
+/// the SDF + voxel paths used to inline at each call site, so the CPU cull and
+/// the GPU rasterizer grow their bounds identically.
+///
+/// GPU mirror: `yawGrownIsoHalfExtent` in `shaders/ir_iso_common.glsl`.
+constexpr vec3 yawGrownIsoHalfExtent(const vec3 halfExtent, float cosYaw, float sinYaw) {
+    const float absC = abs(cosYaw);
+    const float absS = abs(sinYaw);
+    return vec3(
+        halfExtent.x * absC + halfExtent.y * absS,
+        halfExtent.x * absS + halfExtent.y * absC,
+        halfExtent.z
+    );
 }
 
 /// 2x2 deformation matrix that maps a face's un-yawed iso-pixel offset to the

--- a/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_shapes_to_trixel.hpp
@@ -62,6 +62,10 @@ template <> struct System<SHAPES_TO_TRIXEL> {
     float residualYaw_ = 0.0f;
     float yawCos_ = 1.0f;
     float yawSin_ = 0.0f;
+    // Cardinal snap index of rasterYaw_, reused by the cull-pass view rotation
+    // (IRMath::rotateCardinalZ) so it shares the rasterizer's world->view
+    // permutation instead of open-coding the same cos/sin product.
+    IRMath::CardinalIndex cardinalIndex_ = IRMath::CardinalIndex::k0;
     bool yawZero_ = true;
     // Continuous-yaw snapshot for the smooth camera Z-yaw SDF path (#1345).
     // smoothYaw_ is true inside a residual bracket (residualYaw != 0); the cull
@@ -107,29 +111,14 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                 // and grow the iso half-extent by the continuous |c|,|s| (up to
                 // the sqrt(2) footprint at +/-45deg) so off-center shapes inside
                 // the rotated footprint survive the cardinal-snapped viewport.
-                const float absC = IRMath::abs(yawCosVisual_);
-                const float absS = IRMath::abs(yawSinVisual_);
-                sizeForExtent = vec3(
-                    sizeForExtent.x * absC + sizeForExtent.y * absS,
-                    sizeForExtent.x * absS + sizeForExtent.y * absC,
-                    sizeForExtent.z
-                );
+                sizeForExtent =
+                    IRMath::yawGrownIsoHalfExtent(sizeForExtent, yawCosVisual_, yawSinVisual_);
                 shapeIsoPosition = IRMath::pos3DtoPos2DIsoYawed(xform.translation_, visualYaw_);
             } else {
                 vec3 viewPos = xform.translation_;
                 if (!yawZero_) {
-                    viewPos = vec3(
-                        yawCos_ * xform.translation_.x + yawSin_ * xform.translation_.y,
-                        -yawSin_ * xform.translation_.x + yawCos_ * xform.translation_.y,
-                        xform.translation_.z
-                    );
-                    const float absC = IRMath::abs(yawCos_);
-                    const float absS = IRMath::abs(yawSin_);
-                    sizeForExtent = vec3(
-                        sizeForExtent.x * absC + sizeForExtent.y * absS,
-                        sizeForExtent.x * absS + sizeForExtent.y * absC,
-                        sizeForExtent.z
-                    );
+                    viewPos = IRMath::rotateCardinalZ(xform.translation_, cardinalIndex_);
+                    sizeForExtent = IRMath::yawGrownIsoHalfExtent(sizeForExtent, yawCos_, yawSin_);
                 }
                 shapeIsoPosition = IRMath::pos3DtoPos2DIso(viewPos);
             }
@@ -188,13 +177,10 @@ template <> struct System<SHAPES_TO_TRIXEL> {
         const auto [rasterYaw, residualYaw] = IRPrefab::Camera::computeYawSplit(visualYaw_);
         rasterYaw_ = rasterYaw;
         residualYaw_ = residualYaw;
-        static constexpr float kCardinalCos[4] = {1.f, 0.f, -1.f, 0.f};
-        static constexpr float kCardinalSin[4] = {0.f, 1.f, 0.f, -1.f};
-        constexpr float kHalfPi = 1.5707963267948966f;
-        const int q = IRMath::round(rasterYaw / kHalfPi);
-        const int cardinalIdx = ((q % 4) + 4) % 4;
-        yawCos_ = kCardinalCos[cardinalIdx];
-        yawSin_ = kCardinalSin[cardinalIdx];
+        cardinalIndex_ = IRMath::rasterYawCardinalIndex(rasterYaw);
+        const vec2 cardinalCosSin = IRMath::cardinalYawCosSin(cardinalIndex_);
+        yawCos_ = cardinalCosSin.x;
+        yawSin_ = cardinalCosSin.y;
         yawZero_ = (rasterYaw_ == 0.0f);
         // Smooth camera Z-yaw (#1345): continuous-yaw cull/footprint inside a
         // residual bracket. cos/sin of the full visualYaw (not the cardinal
@@ -456,18 +442,12 @@ template <> struct System<SHAPES_TO_TRIXEL> {
 
         const int sub = (renderMode != IRRender::SubdivisionMode::NONE) ? effectiveSubdivisions : 1;
         const bool yawZero = (rasterYaw == 0.0f);
-        const float absYawC = IRMath::abs(yawCos);
-        const float absYawS = IRMath::abs(yawSin);
+        const IRMath::CardinalIndex cardinalIndex = IRMath::rasterYawCardinalIndex(rasterYaw);
 
         for (int i = 0; i < static_cast<int>(gpuShapes.size()); ++i) {
             const auto &desc = gpuShapes[i];
             vec3 worldPos = vec3(desc.worldPosition);
-            vec3 viewPos = yawZero ? worldPos
-                                   : vec3(
-                                         yawCos * worldPos.x + yawSin * worldPos.y,
-                                         -yawSin * worldPos.x + yawCos * worldPos.y,
-                                         worldPos.z
-                                     );
+            vec3 viewPos = IRMath::rotateCardinalZ(worldPos, cardinalIndex);
             ivec3 origin = IRMath::roundVec3HalfUp(viewPos);
 
             // Canonical bounding half-extent lives in IRMath::SDF (shared with
@@ -499,13 +479,8 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                 // Continuous-yaw footprint: center on the full-visualYaw iso
                 // projection (matches the shader's originIsoScaled) and grow by
                 // the continuous |c|,|s| (sqrt(2) extent at +/-45deg).
-                const float absC = IRMath::abs(yawCosVisual);
-                const float absS = IRMath::abs(yawSinVisual);
-                boundingHalf = vec3(
-                    boundingHalf.x * absC + boundingHalf.y * absS,
-                    boundingHalf.x * absS + boundingHalf.y * absC,
-                    boundingHalf.z
-                );
+                boundingHalf =
+                    IRMath::yawGrownIsoHalfExtent(boundingHalf, yawCosVisual, yawSinVisual);
                 const vec2 originIsoF =
                     IRMath::pos3DtoPos2DIsoYawed(worldPos * static_cast<float>(sub), visualYaw);
                 const ivec2 originIsoScaled =
@@ -516,11 +491,7 @@ template <> struct System<SHAPES_TO_TRIXEL> {
                 isoMax = originIsoScaled + isoHalfExtent + ivec2(2);
             } else {
                 if (!yawZero) {
-                    boundingHalf = vec3(
-                        boundingHalf.x * absYawC + boundingHalf.y * absYawS,
-                        boundingHalf.x * absYawS + boundingHalf.y * absYawC,
-                        boundingHalf.z
-                    );
+                    boundingHalf = IRMath::yawGrownIsoHalfExtent(boundingHalf, yawCos, yawSin);
                 }
                 const ivec2 originIso = IRMath::pos3DtoPos2DIso(origin);
                 const ivec2 isoHalfExtent = ivec2(IRMath::shapeIsoHalfExtent(boundingHalf * 2.0f));

--- a/engine/render/src/shaders/c_shapes_to_trixel.glsl
+++ b/engine/render/src/shaders/c_shapes_to_trixel.glsl
@@ -766,8 +766,7 @@ void main() {
     // exact. See engine/render/CLAUDE.md and
     // docs/design/iso-basis-baked-assumptions.md for the model.
     int cardinalIndex = rasterYawCardinalIndex(rasterYaw);
-    const float cardinalCos[4] = float[]( 1.0, 0.0, -1.0, 0.0);
-    const float cardinalSin[4] = float[]( 0.0, 1.0,  0.0, -1.0);
+    vec2 cardinalCosSin = cardinalYawCosSin(cardinalIndex);
     // Smooth camera Z-yaw (#1345). Inside a residual bracket the SDF rotates by
     // the FULL continuous visualYaw (cardinal snap + residual) instead of
     // snapping to rasterYaw + faceDeform: the shape center repositions
@@ -781,8 +780,8 @@ void main() {
     // pixel-exact. Gated per-canvas by smoothYawEnabled (main world canvas
     // only; detached per-entity canvases keep the faceDeform path).
     bool smoothYaw = (smoothYawEnabled != 0);
-    float yawC = smoothYaw ? cos(visualYaw) : cardinalCos[cardinalIndex];
-    float yawS = smoothYaw ? sin(visualYaw) : cardinalSin[cardinalIndex];
+    float yawC = smoothYaw ? cos(visualYaw) : cardinalCosSin.x;
+    float yawS = smoothYaw ? sin(visualYaw) : cardinalCosSin.y;
     bool yawZero = (!smoothYaw) && (cardinalIndex == 0);
 
     vec3 worldPos = shape.worldPosition.xyz;
@@ -847,16 +846,9 @@ void main() {
     // (and symmetrically for Y).  Use this expanded half-extent for the iso
     // footprint check and the generalDepthSearch range so the full rotated
     // shape stays inside the search window.
-    vec3 boundingHalfView;
-    if (yawZero) {
-        boundingHalfView = boundingHalf;
-    } else {
-        float absC = abs(yawC);
-        float absS = abs(yawS);
-        boundingHalfView = vec3(boundingHalf.x * absC + boundingHalf.y * absS,
-                                boundingHalf.x * absS + boundingHalf.y * absC,
-                                boundingHalf.z);
-    }
+    vec3 boundingHalfView = yawZero
+        ? boundingHalf
+        : yawGrownIsoHalfExtent(boundingHalf, yawC, yawS);
     ivec3 extentScaled = ivec3(ceil(boundingHalfView)) + ivec3(1);
 
     // Smooth path repositions the center continuously: round the continuous-yaw

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -386,6 +386,17 @@ int rasterYawCardinalIndex(float rasterYaw) {
     return ((q % 4) + 4) % 4;
 }
 
+// (cos, sin) of the cardinal angle named by cardinalIndex — exact ±1/0, the
+// snapped Z-yaw the GRID rasterizer projects at. Mirrors
+// IRMath::cardinalYawCosSin; retires the open-coded cardinalCos/cardinalSin
+// tables that callers used to inline.
+vec2 cardinalYawCosSin(int cardinalIndex) {
+    if (cardinalIndex == 1) return vec2( 0.0,  1.0);
+    if (cardinalIndex == 2) return vec2(-1.0,  0.0);
+    if (cardinalIndex == 3) return vec2( 0.0, -1.0);
+    return vec2(1.0, 0.0);
+}
+
 ivec3 rotateCardinalZ(ivec3 v, int cardinalIndex) {
     if (cardinalIndex == 1) return ivec3( v.y, -v.x, v.z);   // R_z(-pi/2)
     if (cardinalIndex == 2) return ivec3(-v.x, -v.y, v.z);   // R_z(+/-pi)
@@ -488,6 +499,18 @@ vec2 pos3DtoPos2DIsoYawed(vec3 worldPos, float visualYaw) {
     float vx = worldPos.x * c + worldPos.y * s;
     float vy = -worldPos.x * s + worldPos.y * c;
     return vec2(-vx + vy, -vx - vy + 2.0 * worldPos.z);
+}
+
+// Conservative XY growth of an axis-aligned half-extent swept under a Z-yaw of
+// (cosYaw, sinYaw): each in-plane axis grows to |c|*hX + |s|*hY, Z unchanged.
+// CPU mirror: IRMath::yawGrownIsoHalfExtent. Keeps the SDF/voxel iso-cull
+// footprint identical on both sides.
+vec3 yawGrownIsoHalfExtent(vec3 halfExtent, float cosYaw, float sinYaw) {
+    float absC = abs(cosYaw);
+    float absS = abs(sinYaw);
+    return vec3(halfExtent.x * absC + halfExtent.y * absS,
+                halfExtent.x * absS + halfExtent.y * absC,
+                halfExtent.z);
 }
 
 // --- Smooth camera Z-yaw forward-scatter: face-local in-plane store (#1310) ---

--- a/engine/render/src/shaders/metal/c_shapes_to_trixel.metal
+++ b/engine/render/src/shaders/metal/c_shapes_to_trixel.metal
@@ -879,8 +879,7 @@ kernel void c_shapes_to_trixel(
     // every line below collapses to the integer-only yaw=0 path, and the
     // existing reference renders stay pixel-exact.
     const int cardinalIndex = rasterYawCardinalIndex(frameData.rasterYaw);
-    constexpr float cardinalCos[4] = { 1.0,  0.0, -1.0,  0.0};
-    constexpr float cardinalSin[4] = { 0.0,  1.0,  0.0, -1.0};
+    const float2 cardinalCosSin = cardinalYawCosSin(cardinalIndex);
     // Smooth camera Z-yaw (#1345). Mirrors c_shapes_to_trixel.glsl. Inside a
     // residual bracket the SDF rotates by the FULL continuous visualYaw
     // (cardinal snap + residual) instead of snapping to rasterYaw + faceDeform:
@@ -891,8 +890,8 @@ kernel void c_shapes_to_trixel(
     // per-axis voxel scatter (T3 #1310). residualYaw==0 keeps the byte-identical
     // cardinal path (faceDeform identity, view-space depth).
     const bool smoothYaw = (frameData.smoothYawEnabled != 0);
-    const float yawC = smoothYaw ? cos(frameData.visualYaw) : cardinalCos[cardinalIndex];
-    const float yawS = smoothYaw ? sin(frameData.visualYaw) : cardinalSin[cardinalIndex];
+    const float yawC = smoothYaw ? cos(frameData.visualYaw) : cardinalCosSin.x;
+    const float yawS = smoothYaw ? sin(frameData.visualYaw) : cardinalCosSin.y;
     const bool yawZero = (!smoothYaw) && (cardinalIndex == 0);
 
     const float3 worldPos = shape.worldPosition.xyz;
@@ -952,16 +951,9 @@ kernel void c_shapes_to_trixel(
     // (and symmetrically for Y). Use this expanded half-extent for the iso
     // footprint check and the generalDepthSearch range so the full rotated
     // shape stays inside the search window.
-    float3 boundingHalfView;
-    if (yawZero) {
-        boundingHalfView = boundingHalf;
-    } else {
-        const float absC = abs(yawC);
-        const float absS = abs(yawS);
-        boundingHalfView = float3(boundingHalf.x * absC + boundingHalf.y * absS,
-                                  boundingHalf.x * absS + boundingHalf.y * absC,
-                                  boundingHalf.z);
-    }
+    const float3 boundingHalfView = yawZero
+        ? boundingHalf
+        : yawGrownIsoHalfExtent(boundingHalf, yawC, yawS);
     const int3 extentScaled = int3(ceil(boundingHalfView)) + int3(1);
 
     // Smooth path repositions the center continuously (round the continuous-yaw

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -370,6 +370,17 @@ inline int rasterYawCardinalIndex(float rasterYaw) {
     return ((q % 4) + 4) % 4;
 }
 
+// (cos, sin) of the cardinal angle named by cardinalIndex — exact ±1/0, the
+// snapped Z-yaw the GRID rasterizer projects at. Mirrors
+// IRMath::cardinalYawCosSin and ir_iso_common.glsl; retires the open-coded
+// cardinalCos/cardinalSin tables that callers used to inline.
+inline float2 cardinalYawCosSin(int cardinalIndex) {
+    if (cardinalIndex == 1) return float2( 0.0,  1.0);
+    if (cardinalIndex == 2) return float2(-1.0,  0.0);
+    if (cardinalIndex == 3) return float2( 0.0, -1.0);
+    return float2(1.0, 0.0);
+}
+
 inline int3 rotateCardinalZ(int3 v, int cardinalIndex) {
     if (cardinalIndex == 1) return int3( v.y, -v.x, v.z);   // R_z(-pi/2)
     if (cardinalIndex == 2) return int3(-v.x, -v.y, v.z);   // R_z(+/-pi)
@@ -458,6 +469,17 @@ inline float2 pos3DtoPos2DIsoYawed(float3 worldPos, float visualYaw) {
     const float vx = worldPos.x * c + worldPos.y * s;
     const float vy = -worldPos.x * s + worldPos.y * c;
     return float2(-vx + vy, -vx - vy + 2.0f * worldPos.z);
+}
+
+// Conservative XY growth of an axis-aligned half-extent swept under a Z-yaw of
+// (cosYaw, sinYaw): each in-plane axis grows to |c|*hX + |s|*hY, Z unchanged.
+// CPU mirror: IRMath::yawGrownIsoHalfExtent; GLSL mirror in ir_iso_common.glsl.
+inline float3 yawGrownIsoHalfExtent(float3 halfExtent, float cosYaw, float sinYaw) {
+    const float absC = abs(cosYaw);
+    const float absS = abs(sinYaw);
+    return float3(halfExtent.x * absC + halfExtent.y * absS,
+                  halfExtent.x * absS + halfExtent.y * absC,
+                  halfExtent.z);
 }
 
 // --- Smooth camera Z-yaw forward-scatter: face-local in-plane store (#1310) ---


### PR DESCRIPTION
## Summary
Pure refactor (cleanup carved out of #1370 / smooth-yaw epic #1307): the camera Z-yaw cull/footprint math that landed inlined across the SDF rasterizer and its shaders is now expressed once per side as named, CPU↔GPU-mirrored helpers.

**New helpers**
- `IRMath::yawGrownIsoHalfExtent(halfExtent, cosYaw, sinYaw)` — the `|c|·hX + |s|·hY` conservative iso extent growth. Replaced **4** inline copies in `system_shapes_to_trixel.hpp` (cull tick + GPU tile dispatch × cardinal + smooth-yaw) and **1** each in `c_shapes_to_trixel.glsl` / `.metal`. GPU mirror in `ir_iso_common.{glsl,metal}`.
- `IRMath::cardinalYawCosSin(cardinalIndex)` — exact `(cos, sin)` of a cardinal Z-yaw. Replaced the open-coded `kCardinalCos`/`kCardinalSin` tables + a local `kHalfPi` shadow in `beginTick`, and the `float[] cardinalCos/cardinalSin` tables in both `c_shapes_to_trixel` shaders. GPU mirror in `ir_iso_common.{glsl,metal}`.

**Existing helpers now used**
- The two open-coded cardinal view rotations (`R_z(-rasterYaw)` cos/sin products) now call `IRMath::rasterYawCardinalIndex` + `rotateCardinalZ`.

Net call-site reduction; the shared helpers carry the CPU↔GPU contract in one place each. No behavior change (out of scope: cull-viewport derivation consolidation — that's #1291).

## Verification — byte-identical output
Captured `IRShapeDebug --auto-screenshot` against `origin/master` (before) and this branch (after), across the full shot set: yaw 0 / 90 / 180 / 270 / 45-inter-cardinal + zoom variants + panned-pivot yaw shots (23 PNGs incl. ROI crops).

- **Every yawed shot — where the new helpers actually execute — is byte-identical** before vs after.
- The only before/after deltas are 3 **yaw=0** shots (where the refactor is a provable no-op: the `yawZero` fast path skips every helper), differing by sparse scattered pixels (56–408 px of 3.69M, ≤0.011%).
- **Determinism control:** master-run-1 vs master-run-2 (same binary, two runs) also differs on 3 shots — a *different* set — at the same sparse magnitude. The before/after deltas sit within this GPU `atomicMin` run-to-run noise floor.

Conclusion: output is byte-identical modulo GPU run-to-run nondeterminism. Per `engine/render/CLAUDE.md`, an internal refactor with provably no runtime effect skips the committed screenshot loop; the before/after PNGs are near-identical by construction, so they are not committed.

## Test plan
- [x] `fleet-build --target IRShapeDebug` (macOS/Metal) — clean
- [x] Byte-identical before/after across the full `--auto-screenshot` shot set (cardinals + residual yaw45 + pivots), within the master-vs-master noise floor
- [ ] Linux/OpenGL cross-host build (GLSL mirror — parity confirmation)
- [ ] Windows cross-host build

Closes #1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)