### PR TITLE
render: closed-form yaw-aware chunk cull region in IRMath (#1439)

### DIFF
--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -1017,18 +1017,31 @@ inline vec2 shapeIsoHalfExtent(vec3 voxelSize) {
     return vec2(extentX + extentY, extentX + extentY + 2.0f * extentZ);
 }
 
-/// Returns the tight iso-space axis-aligned bounding box of a rectangular
-/// prism entity at @p worldPos with @p voxelSize dimensions.  Enumerates
-/// all 8 corners for an exact result (prefer shapeIsoHalfExtent when a
-/// conservative approximation is acceptable).
-inline IsoBounds2D entityIsoBounds(vec3 worldPos, ivec3 voxelSize) {
+/// Returns the iso-space AABB of the world-space box [@p worldMin, @p worldMax]
+/// projected under a continuous camera Z-yaw of @p visualYaw. Enumerates the 8
+/// world corners through @ref pos3DtoPos2DIsoYawed and bounds the result.
+///
+/// Closed-form O(1) companion to per-voxel cull projection (#1439): a chunk
+/// caches its static world-AABB once, and its cull region under the live yaw is
+/// recovered by projecting 8 corners instead of re-projecting every voxel each
+/// frame. `pos3DtoPos2DIsoYawed` is linear, so the iso-AABB of the projected
+/// corners is the tight iso-AABB of the projected box — and for a voxel set
+/// that does not fill its world-AABB it is a *conservative superset* of the
+/// per-voxel iso bounds (never tighter), so the chunk-visibility gate keeps
+/// over-including rather than dropping on-screen geometry. At @p visualYaw == 0
+/// it reduces to the un-yawed iso projection of the box corners.
+inline IsoBounds2D isoAABBOfWorldAABBUnderYaw(vec3 worldMin, vec3 worldMax, float visualYaw) {
     vec2 corners[8];
     int idx = 0;
     for (int dx = 0; dx <= 1; ++dx) {
         for (int dy = 0; dy <= 1; ++dy) {
             for (int dz = 0; dz <= 1; ++dz) {
-                vec3 corner = worldPos + vec3(dx * voxelSize.x, dy * voxelSize.y, dz * voxelSize.z);
-                corners[idx++] = pos3DtoPos2DIso(corner);
+                const vec3 corner = vec3(
+                    dx ? worldMax.x : worldMin.x,
+                    dy ? worldMax.y : worldMin.y,
+                    dz ? worldMax.z : worldMin.z
+                );
+                corners[idx++] = pos3DtoPos2DIsoYawed(corner, visualYaw);
             }
         }
     }
@@ -1039,6 +1052,15 @@ inline IsoBounds2D entityIsoBounds(vec3 worldPos, ivec3 voxelSize) {
         bmax = glm::max(bmax, corners[i]);
     }
     return IsoBounds2D{bmin, bmax};
+}
+
+/// Returns the tight iso-space axis-aligned bounding box of a rectangular
+/// prism entity at @p worldPos with @p voxelSize dimensions.  The un-yawed,
+/// axis-aligned special case of @ref isoAABBOfWorldAABBUnderYaw over the box
+/// [worldPos, worldPos + voxelSize] (prefer shapeIsoHalfExtent when a
+/// conservative approximation is acceptable).
+inline IsoBounds2D entityIsoBounds(vec3 worldPos, ivec3 voxelSize) {
+    return isoAABBOfWorldAABBUnderYaw(worldPos, worldPos + vec3(voxelSize), 0.0f);
 }
 
 /// Returns true if a rectangular-prism entity's iso bounding box overlaps

--- a/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp
@@ -39,6 +39,26 @@ struct ChunkBounds {
     }
 };
 
+// Static (camera-independent) world-space AABB of a chunk's live voxels.
+// Cached once per allocation/position change so the continuous-yaw cull can
+// recover a chunk's iso bounds by projecting 8 corners under the live yaw
+// (`IRMath::isoAABBOfWorldAABBUnderYaw`) — O(chunks)/frame — instead of
+// re-projecting every voxel every frame (#1439).
+struct ChunkWorldBounds {
+    vec3 worldMin_ = vec3(std::numeric_limits<float>::max());
+    vec3 worldMax_ = vec3(std::numeric_limits<float>::lowest());
+
+    void expand(vec3 worldPos) {
+        worldMin_ = IRMath::min(worldMin_, worldPos);
+        worldMax_ = IRMath::max(worldMax_, worldPos);
+    }
+
+    // A chunk with no live voxels keeps the inverted sentinel.
+    bool empty() const {
+        return worldMin_.x > worldMax_.x;
+    }
+};
+
 struct C_VoxelPool {
   public:
     C_VoxelPool(ivec3 numVoxels)
@@ -103,6 +123,7 @@ struct C_VoxelPool {
                 m_freeSpanLookup.erase(size);
             }
             m_chunkBoundsDirty = true;
+            m_chunkWorldBoundsDirty = true;
             return IRRender::VoxelPoolAllocation{
                 startIndex,
                 std::span<IRRender::VoxelGpuPosition>{m_voxelPositions.data() + startIndex, size},
@@ -119,6 +140,7 @@ struct C_VoxelPool {
             size_t startIndex = static_cast<size_t>(m_voxelPoolIndex);
             m_voxelPoolIndex += size;
             m_chunkBoundsDirty = true;
+            m_chunkWorldBoundsDirty = true;
             IRE_LOG_DEBUG("Allocated voxels from {} to {}", startIndex, m_voxelPoolIndex - 1);
             return IRRender::VoxelPoolAllocation{
                 startIndex,
@@ -163,6 +185,7 @@ struct C_VoxelPool {
         );
         m_entityIdsDirty = true;
         m_chunkBoundsDirty = true;
+        m_chunkWorldBoundsDirty = true;
 
         m_freeVoxelSpans.push_back({startIndex, size});
         updateFreeSpanLookup(startIndex, size);
@@ -271,31 +294,60 @@ struct C_VoxelPool {
         for (auto &cb : m_chunkBounds)
             cb.reset();
 
+        if (useContinuousYaw) {
+            // Closed-form O(chunks) cull region (#1439): project each chunk's
+            // cached static world-AABB under the live yaw instead of
+            // re-projecting every voxel. The 8-corner projection is a
+            // conservative superset of the per-voxel iso bounds
+            // (`pos3DtoPos2DIsoYawed` is linear), so the gate over-includes
+            // rather than dropping on-screen chunks. The world-AABB cache is
+            // rebuilt (O(voxels)) only when voxel positions actually change
+            // (alloc/dealloc, in-place rewrites signalled via
+            // `markChunkWorldBoundsDirty`), so a static world under a rotating
+            // camera pays only O(chunks)/frame here.
+            ensureChunkWorldBounds(chunkCount);
+            for (int c = 0; c < chunkCount; ++c) {
+                const ChunkWorldBounds &wb = m_chunkWorldBounds[c];
+                if (wb.empty())
+                    continue; // leave the inverted sentinel → chunk never visible
+                const IsoBounds2D iso =
+                    IRMath::isoAABBOfWorldAABBUnderYaw(wb.worldMin_, wb.worldMax_, visualYaw);
+                m_chunkBounds[c].isoMin_ = iso.min_;
+                m_chunkBounds[c].isoMax_ = iso.max_;
+            }
+            // Never cache a per-frame yaw snapshot in the iso bounds; force the
+            // next cardinal-path call to rebuild rather than trust stale
+            // continuous bounds. (The world-AABB cache is yaw-independent and
+            // stays valid across yaw frames — only position changes evict it.)
+            m_chunkBoundsDirty = true;
+            return;
+        }
+
+        // Cardinal path: per-voxel iso expand, cached by cardinal index.
+        // Unchanged from master so the yaw==0 / cardinal render path stays
+        // byte-identical.
         for (int i = 0; i < m_voxelPoolIndex; ++i) {
             if (m_voxelColors[i].color_.alpha_ == 0)
                 continue;
             int chunk = i / IRRender::kVoxelChunkSize;
             vec3 pos = m_voxelPositionsGlobal[i].pos_;
-            vec2 isoPos;
-            if (useContinuousYaw) {
-                isoPos = IRMath::pos3DtoPos2DIsoYawed(pos, visualYaw);
-            } else {
-                if (cardinalIndex != CardinalIndex::k0) {
-                    pos = IRMath::rotateCardinalZ(pos, cardinalIndex);
-                    pos += vec3(IRMath::cardinalLowerCornerShift(cardinalIndex));
-                }
-                isoPos = IRMath::pos3DtoPos2DIso(pos);
+            if (cardinalIndex != CardinalIndex::k0) {
+                pos = IRMath::rotateCardinalZ(pos, cardinalIndex);
+                pos += vec3(IRMath::cardinalLowerCornerShift(cardinalIndex));
             }
-            m_chunkBounds[chunk].expand(isoPos);
+            m_chunkBounds[chunk].expand(IRMath::pos3DtoPos2DIso(pos));
         }
-        if (useContinuousYaw) {
-            // Never cache a per-frame yaw snapshot; force the next cardinal-path
-            // call to rebuild rather than trust stale continuous bounds.
-            m_chunkBoundsDirty = true;
-        } else {
-            m_lastBoundsCardinalIndex = cardinalIndex;
-            m_chunkBoundsDirty = false;
-        }
+        m_lastBoundsCardinalIndex = cardinalIndex;
+        m_chunkBoundsDirty = false;
+    }
+
+    // Signals that voxel world positions changed in place (no realloc) — e.g.
+    // a parent move (`UPDATE_VOXEL_SET_CHILDREN`) or a GRID re-voxelize
+    // (`REBUILD_GRID_VOXELS`). Evicts the cached chunk world-AABBs so the next
+    // continuous-yaw cull rebuilds them and stays a conservative superset of
+    // the live voxels (otherwise a moved/rotated chunk could be dropped).
+    void markChunkWorldBoundsDirty() {
+        m_chunkWorldBoundsDirty = true;
     }
 
     void markChunkBoundsDirty() {
@@ -558,6 +610,12 @@ struct C_VoxelPool {
     std::vector<std::pair<size_t, size_t>> m_freeVoxelSpans;
     std::map<size_t, std::set<std::pair<size_t, size_t>>> m_freeSpanLookup;
     std::vector<ChunkBounds> m_chunkBounds;
+    // Cached static (camera-independent) world-AABB per chunk, projected under
+    // the live yaw by the continuous-yaw cull (#1439). Rebuilt only when voxel
+    // positions change, so a static world under a rotating camera skips the
+    // per-voxel re-projection entirely.
+    std::vector<ChunkWorldBounds> m_chunkWorldBounds;
+    bool m_chunkWorldBoundsDirty = true;
     // Per-frame queue of position-global slices whose CPU contents were
     // rewritten since the last GPU flush. Drained + coalesced by
     // VOXEL_TO_TRIXEL_STAGE_1; capacity is preserved across frames so
@@ -574,6 +632,24 @@ struct C_VoxelPool {
 
     void updateFreeSpanLookup(size_t startIndex, size_t size) {
         m_freeSpanLookup[size].insert({startIndex, size});
+    }
+
+    // Rebuilds the per-chunk static world-AABB cache from the live voxels'
+    // world positions (O(voxels)). Runs only when the cache is dirty or its
+    // chunk count is stale; the result is camera-independent, so the
+    // continuous-yaw cull reuses it across yaw frames (#1439).
+    void ensureChunkWorldBounds(int chunkCount) {
+        if (!m_chunkWorldBoundsDirty && static_cast<int>(m_chunkWorldBounds.size()) == chunkCount) {
+            return;
+        }
+        m_chunkWorldBounds.assign(chunkCount, ChunkWorldBounds{});
+        for (int i = 0; i < m_voxelPoolIndex; ++i) {
+            if (m_voxelColors[i].color_.alpha_ == 0)
+                continue;
+            int chunk = i / IRRender::kVoxelChunkSize;
+            m_chunkWorldBounds[chunk].expand(m_voxelPositionsGlobal[i].pos_);
+        }
+        m_chunkWorldBoundsDirty = false;
     }
 
     void setMaskRange(std::size_t start, std::size_t count, bool value) {

--- a/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
@@ -138,6 +138,12 @@ template <> struct System<REBUILD_GRID_VOXELS> {
                 worldTransform
             );
         }
+        if (safeCount > 0) {
+            // The chunk world-AABB cache must follow the rewritten positions, or
+            // the continuous-yaw cull would project a stale (pre-rotation) box
+            // and could drop this set's chunks (#1439).
+            pool.markChunkWorldBoundsDirty();
+        }
     }
 
     static SystemId create() {

--- a/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
@@ -48,6 +48,12 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
             pool.getPositions(),
             pool.getPositionOffsets()
         );
+        if (writtenCount > 0) {
+            // CPU world positions moved in place; evict the chunk world-AABB
+            // cache so the continuous-yaw cull re-derives this set's bounds and
+            // stays a conservative superset of the live voxels (#1439).
+            pool.markChunkWorldBoundsDirty();
+        }
         // A GPU-transform-indirected set (#1396) has binding 5 written by the
         // UPDATE_VOXEL_POSITIONS_GPU prepass each frame. We still recompute its
         // CPU global mirror above (a sane translation-only fallback for the

--- a/test/math/ir_math_viewport_helpers_test.cpp
+++ b/test/math/ir_math_viewport_helpers_test.cpp
@@ -439,4 +439,74 @@ TEST(ShadowFeederIsoBoundsTest, DefaultSunDirectionExpandsCorrectAxes) {
     EXPECT_NEAR(r.max_.y, 10.0f, 1e-4f);
 }
 
+// ---------------------------------------------------------------------------
+// isoAABBOfWorldAABBUnderYaw
+// Iso-space AABB of a world box projected under continuous camera Z-yaw.
+// Enumerates the 8 world corners through pos3DtoPos2DIsoYawed and bounds them.
+// pos3DtoPos2DIsoYawed(p, yaw): vx = p.x*cos + p.y*sin, vy = -p.x*sin + p.y*cos
+//   iso = (-vx + vy, -vx - vy + 2*p.z)
+// ---------------------------------------------------------------------------
+
+TEST(IsoAABBUnderYawTest, ZeroYawMatchesUnYawedProjection) {
+    // yaw=0 reduces to the plain iso projection of the box corners.
+    // Box [0,0,0]-[2,2,2]: iso.x=-x+y ∈ [-2,2]; iso.y=-x-y+2z ∈ [-4,4].
+    auto b = IRMath::isoAABBOfWorldAABBUnderYaw(
+        IRMath::vec3(0.0f),
+        IRMath::vec3(2.0f, 2.0f, 2.0f),
+        0.0f
+    );
+    EXPECT_NEAR(b.min_.x, -2.0f, kTolerance);
+    EXPECT_NEAR(b.min_.y, -4.0f, kTolerance);
+    EXPECT_NEAR(b.max_.x, 2.0f, kTolerance);
+    EXPECT_NEAR(b.max_.y, 4.0f, kTolerance);
+}
+
+TEST(IsoAABBUnderYawTest, DegeneratePointBox) {
+    // Zero-size box → AABB collapses to the single yawed iso point.
+    // yaw=0, p=(1,2,3): iso = (-1+2, -1-2+6) = (1, 3).
+    auto b = IRMath::isoAABBOfWorldAABBUnderYaw(
+        IRMath::vec3(1.0f, 2.0f, 3.0f),
+        IRMath::vec3(1.0f, 2.0f, 3.0f),
+        0.0f
+    );
+    EXPECT_NEAR(b.min_.x, 1.0f, kTolerance);
+    EXPECT_NEAR(b.min_.y, 3.0f, kTolerance);
+    EXPECT_NEAR(b.max_.x, 1.0f, kTolerance);
+    EXPECT_NEAR(b.max_.y, 3.0f, kTolerance);
+}
+
+TEST(IsoAABBUnderYawTest, QuarterTurnYaw) {
+    // yaw=π/2 → cos≈0, sin=1: vx=y, vy=-x.
+    //   iso.x = -y - x, iso.y = x - y + 2z.
+    // Box [0,0,0]-[2,2,2]: iso.x ∈ [-4,0]; iso.y ∈ [-2,6].
+    auto b = IRMath::isoAABBOfWorldAABBUnderYaw(
+        IRMath::vec3(0.0f),
+        IRMath::vec3(2.0f, 2.0f, 2.0f),
+        IRMath::kHalfPi
+    );
+    EXPECT_NEAR(b.min_.x, -4.0f, 1e-4f);
+    EXPECT_NEAR(b.min_.y, -2.0f, 1e-4f);
+    EXPECT_NEAR(b.max_.x, 0.0f, 1e-4f);
+    EXPECT_NEAR(b.max_.y, 6.0f, 1e-4f);
+}
+
+TEST(IsoAABBUnderYawTest, ContainsInteriorPointProjection) {
+    // The core cull-safety property: the AABB conservatively contains the
+    // projection of any point inside the world box, at an arbitrary yaw.
+    const float yaw = 0.7f;
+    const IRMath::vec3 lo(0.0f, 0.0f, 0.0f);
+    const IRMath::vec3 hi(4.0f, 6.0f, 3.0f);
+    auto b = IRMath::isoAABBOfWorldAABBUnderYaw(lo, hi, yaw);
+    for (const IRMath::vec3 interior :
+         {IRMath::vec3(1.0f, 3.0f, 2.0f),
+          IRMath::vec3(4.0f, 0.0f, 3.0f),
+          IRMath::vec3(2.5f, 5.5f, 0.5f)}) {
+        const IRMath::vec2 iso = IRMath::pos3DtoPos2DIsoYawed(interior, yaw);
+        EXPECT_GE(iso.x, b.min_.x - kTolerance);
+        EXPECT_LE(iso.x, b.max_.x + kTolerance);
+        EXPECT_GE(iso.y, b.min_.y - kTolerance);
+        EXPECT_LE(iso.y, b.max_.y + kTolerance);
+    }
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
- P2 of the camera-yaw cull epic (#1437). Replaces the per-voxel, per-frame iso re-projection in the **continuous-yaw branch** of `C_VoxelPool::rebuildChunkBounds` with a **closed-form O(chunks)** cull region.
- New `IRMath::isoAABBOfWorldAABBUnderYaw(worldMin, worldMax, visualYaw)` — projects the 8 world-AABB corners through `pos3DtoPos2DIsoYawed`. Since that projection is **linear**, the result is a *conservative superset* of the per-voxel iso bounds, so the chunk-visibility mask can only over-include; the GPU's exact per-voxel test stays the final arbiter and **render output is unchanged**.
- `C_VoxelPool` caches a per-chunk static **world-space AABB** (`m_chunkWorldBounds`), rebuilt only when voxel positions change. The two in-place position writers (`REBUILD_GRID_VOXELS`, `UPDATE_VOXEL_SET_CHILDREN`) call the new `markChunkWorldBoundsDirty()` so the superset guarantee holds under movement/rotation.
- **Cardinal / yaw==0 path is untouched → byte-identical** (only the continuous-yaw branch changed; at yaw 0 the cardinal branch runs).
- `entityIsoBounds` refactored to the un-yawed, axis-aligned special case of the new general primitive (removes a duplicated 8-corner enumeration).

## Perf
- Static world under a rotating camera: per-frame cull projection drops from O(voxels) to O(chunks) — ~**32×** fewer projections (`kVoxelChunkSize`=256 voxels/chunk ÷ 8 corners). The O(voxels) world-AABB rebuild is amortized to ~0 (only on position change).
- `--spin-yaw 45 --auto-profile 300` on IRShapeDebug: 12.92 ms avg frame, no new CPU hotspot (`RebuildGridVoxels` 0.001 ms, `UpdateVoxelSetChildren` 0.003 ms).

## Test plan
- [x] New `IsoAABBUnderYawTest` suite (yaw=0 reduction, π/2 case, degenerate point, **conservative-superset containment**) — passes.
- [x] Full unit suite: 1057 tests pass.
- [x] `--cull-validate` frozen-cull free-fly harness (#1438) runs clean through a full yaw+move sweep; rotated-yaw frames render correctly (no dropped geometry).
- [x] `entityIsoBounds` delegation verified byte-identical (cos/sin(0) exact) — `IsEntityOnScreen` tests pass.
- No shader / frame-data-struct change → GLSL/Metal parity preserved trivially.

Closes #1439

🤖 Generated with [Claude Code](https://claude.com/claude-code)