### PR TITLE
fleet: close the carve-off planning gate in the architect role

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -236,6 +236,35 @@ See [docs/agents/TASK-FILING.md § Multi-issue stacks](../../docs/agents/TASK-FI
 for the rules (one `#N` per blocker line; issue-number blockers only;
 gate docs-PR dependencies by withholding `human:approved`).
 
+**Carve-offs are unplanned tickets — never queue a hypothesis.** When
+you split a residual, follow-up, or "investigate later" half out of an
+in-flight or over-scoped ticket (the #1370 → #1414 / #1431 / #1435
+pattern), the carve-off is a **new, unplanned** ticket — splitting does
+not transfer the parent's planning to it. A body that ends in "Likely
+suspects / approach (confirm during investigation)" is a *hypothesis*,
+not a plan. If it goes straight to `human:approved` + `fleet:queued`
+(skipping `fleet:needs-plan`, with no `~/.fleet/plans/issue-<N>.md`),
+the worker is the first person to open the code: it finds the premise
+wrong, the root cause in an out-of-scope path, or the approach
+undecided, and design-blocks on claim. Every #1370 carve-off blocked
+exactly this way. So **route carve-offs through planning before they're
+queue-ready**: file them unlabeled per [Filing tasks](#filing-tasks)
+(the human triages → `fleet:needs-plan` → you plan it per
+[PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md) and
+commit `~/.fleet/plans/issue-<N>.md`), or — if the residual is part of a
+dependent stack — file the whole stack via `file-epic` so each child
+gets its own plan file. The committed plan (not the issue body) is what
+must (1) name a **confirmed repro** of the symptom against the actual
+code path, (2) **pick one approach** rather than hand the choice to the
+worker, and (3) **reconcile siblings + in-flight PRs** on the same
+surface (a carve-off's fix often duplicates or contradicts an active PR
+or a sibling ticket's recorded conclusion — e.g. #1440's planned
+approach was the one #1420 had already proved wrong). A carve-off that
+cannot yet clear those three is not a queued task — it is either a
+`fleet:needs-plan` issue or, if you genuinely need a worker to
+investigate before the design exists, an explicit investigation spike,
+never a `human:approved` build task.
+
 **Fleet self-config changes are human-only — don't file them for
 autonomous pickup.** Edits to the role/command/agent configs the fleet
 loads (`.claude/commands/role-*.md`, `.claude/agents/*`) can't be applied


### PR DESCRIPTION
## Summary
- Adds a **"Carve-offs are unplanned tickets"** gate to `.claude/commands/role-opus-architect.md` (Filing tasks section).
- Root cause of 3 of the 4 current `fleet:design-blocked` PRs: #1414 / #1431 / #1435 were split out of the over-scoped #1370 and queued (`human:approved` + `fleet:queued`) **without ever passing through `fleet:needs-plan`** — no `~/.fleet/plans/issue-<N>.md` was written, so the worker was the first to open the code and design-blocked on claim (premise wrong / approach undecided / fork open).
- `file-epic` was used for the #1437 epic (its children got plan files); the #1370 carve-offs bypassed both `file-epic` and `needs-plan`. The gate routes splits through `needs-plan`/`file-epic` and requires the committed plan to (1) name a confirmed repro, (2) pick one approach, (3) reconcile siblings + in-flight PRs before the ticket is queue-ready.

## Test plan
- [ ] Doc-only — renders correctly; intra-doc anchor `#filing-tasks` and `../../docs/agents/PLANNING-PROTOCOL.md` resolve (both already used elsewhere in the same doc).

Part of the planning-process fix; broader targeted fixes (PLANNING-PROTOCOL gates + mechanical enforcement) tracked in a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)