### PR TITLE
render: detached SO(3) per-voxel occlusion depth on R⁻¹·(1,1,1) (#1462)

### DIFF
--- a/docs/design/iso-depth-axis-invariant.md
+++ b/docs/design/iso-depth-axis-invariant.md
@@ -107,6 +107,31 @@ DETACHED rasterization because the per-canvas bake collapses the
 world-to-screen transform into a 2x2 (face deformation) instead of
 relying on the (1,1,1) depth-axis algebra.
 
+### Entity-rotation carve-out: per-voxel occlusion depth (#1462)
+
+One shortcut *did* survive on the DETACHED path and is carved out here.
+A detached canvas rasters its voxels at their model-space iso positions
+(camera yaw zeroed) and rotates only the face *shapes* via
+`faceDeformationMatrixSO3`; the voxel *centers* are not repositioned.
+The per-voxel occlusion depth that orders overlapping centers therefore
+cannot use the fixed world (1,1,1) — that is correct only when the
+entity rotation `R` fixes (1,1,1). Off that, the snapped order leaks
+back-face voxels through (the "pitch/roll reveals" bug, live since
+#1386 / #1398 landed full-SO(3) face selection on detached canvases).
+
+The fix (#1462) projects each detached voxel's model position onto the
+**entity-rotated** iso depth axis `R⁻¹·(1,1,1)` — symmetric with
+`IRMath::visibleTriplet`'s `R⁻¹·viewDir` face selection, so face
+visibility and occlusion order stay on one per-entity frame. The axis is
+computed CPU-side by `IRMath::isoDepthAxisModel`, uploaded in
+`FrameDataVoxelToCanvas::voxelDepthAxis_`, and projected GPU-side by
+`isoDepthAlongAxis` (ir_iso_common.{glsl,metal}) — its CPU twin
+`IRMath::isoDepthAlongAxis` rounds identically. This is **gated per
+ENTITY rotation only**: the world / GRID canvas keeps `voxelDepthAxis_
+== (1,1,1)`, so `isoDepthAlongAxis` collapses to `pos3DtoDistance`
+(`x+y+z`) and every GRID consumer above — and a zero-rotation detached
+entity — is byte-identical. The (1,1,1) world invariant is untouched.
+
 ## Full call-site map
 
 Re-greppable with `Z-yaw|rasterYaw|cardinalIndex|rotation-invariant` in
@@ -180,4 +205,4 @@ combined. Don't promise either in the same release.
 - [`docs/design/iso-basis-baked-assumptions.md`](iso-basis-baked-assumptions.md) — T-054 audit of what is baked into the iso basis (the consumer-side rasterYaw enabling work).
 - [`docs/agents/CLAUDE-BASELINE.md`](../agents/CLAUDE-BASELINE.md) — engine-wide ECS/style conventions.
 - Issue #1075 (T-319, PR #1087) — `PROPAGATE_CANVAS_ROTATION` composes camera yaw into per-canvas SO(3); the composition step that lets DETACHED entities pick up future camera pitch/roll.
-- Issue #1076 — camera SO(3) quaternion surface for DETACHED rotation; A/B decision still pending an opus-architect call.
+- Issue #1076 — camera SO(3) quaternion surface for DETACHED rotation; **RESOLVED (closed, Option B):** camera rotation lives in `C_LocalTransform.rotation_` and the DETACHED path reads the full quaternion (T-364). The detached SO(3) epic #1444 builds the smooth-deform + correct-occlusion pipeline on top of it.

--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -28,6 +28,13 @@ Helpers:
 - `IRMath::isoDepthShift(pos, d)` — returns `pos + (d, d, d)`, which shifts
   depth without affecting the 2D projection. Used for stacked depth layers
   at the same apparent position.
+- `IRMath::isoDepthAxisModel(rotation)` / `IRMath::isoDepthAlongAxis(pos, axis)`
+  — the entity-rotated generalization of the depth scalar. A DETACHED entity
+  rasters in model space, so its per-voxel occlusion projects onto
+  `R⁻¹·(1,1,1)` (the model-frame depth axis) rather than the fixed world
+  (1,1,1); at identity the axis is exactly (1,1,1) so it collapses to
+  `pos3DtoDistance`. GPU mirror `isoDepthAlongAxis` in `ir_iso_common.{glsl,metal}`.
+  See the design doc's entity-rotation carve-out (#1462).
 
 **Never inline these equations in system code.** Always call the helpers
 so there's one place to fix a coordinate-system bug.

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -513,6 +513,40 @@ constexpr std::array<FaceId, 3> visibleFaceTripletCardinal(CardinalIndex cardina
     }
 }
 
+/// Model-frame iso depth axis for a detached entity rotated by @p rotation:
+/// `R⁻¹ · (1,1,1)`. The iso projection's depth axis is the world (1,1,1)
+/// direction (@ref pos3DtoDistance, `depth = x+y+z`); a detached canvas
+/// rasters its voxels in model space (camera yaw zeroed), so the per-voxel
+/// metric that orders them front-to-back under the *rotated* view must
+/// project onto this model-frame axis rather than the fixed (1,1,1).
+/// Symmetric with @ref visibleTriplet's `R⁻¹·viewDir` face selection — one
+/// per-entity frame drives both which faces show and how they occlude. Using
+/// the fixed (1,1,1) instead is correct only when `R` fixes (1,1,1); off that
+/// the snapped order leaks back-face voxels through (the "pitch/roll reveals"
+/// bug, live since #1386/#1398 landed full-SO(3) face selection).
+///
+/// At identity the axis is exactly (1,1,1) — `rotateVectorByQuat` by the
+/// identity quat is the exact identity — so @ref isoDepthAlongAxis collapses
+/// to `x+y+z` and the detached path stays byte-identical to master; the GRID
+/// world canvas keeps the fixed (1,1,1) and is untouched.
+///
+/// CPU-computed and uploaded into `FrameDataVoxelToCanvas::voxelDepthAxis_`;
+/// the shader does only the `roundHalfUp(dot(pos, axis))` projection (GPU
+/// mirror `isoDepthAlongAxis` in ir_iso_common.glsl/.metal). Reused by the
+/// detached SO(3) forward-scatter composite (#1462 P1 → #1464 P3).
+inline vec3 isoDepthAxisModel(const vec4 &rotation) {
+    return rotateVectorByQuat(vec3(1.0f, 1.0f, 1.0f), quatInverse(rotation));
+}
+
+/// Per-voxel iso occlusion depth: model position @p pos projected onto a
+/// (possibly entity-rotated) iso depth @p axis. The SO(3) generalization of
+/// @ref pos3DtoDistance — identical to it when `axis == (1,1,1)`. Rounds via
+/// @ref roundHalfUp so it matches the GPU mirror (`isoDepthAlongAxis` in
+/// ir_iso_common.glsl/.metal) bit-for-bit at half-integer projections.
+inline Distance isoDepthAlongAxis(const ivec3 pos, const vec3 axis) {
+    return roundHalfUp(dot(vec3(pos), axis));
+}
+
 /// The three camera-visible cube faces for an entity rotated by @p rotation —
 /// the SO(3) generalization of @ref visibleFaceTripletCardinal (which only
 /// covers the camera's Z-yaw cardinals). A cube face is visible when its
@@ -541,9 +575,10 @@ constexpr std::array<FaceId, 3> visibleFaceTripletCardinal(CardinalIndex cardina
 /// like the cardinal path (#1278), so there is no GPU-side mirror to keep in
 /// sync. Reused verbatim by per-entity main-canvas SO(3) (#1299).
 inline std::array<FaceId, 3> visibleTriplet(const vec4 &rotation) {
-    // View direction expressed in the entity's model frame (R⁻¹ · viewDir).
-    // Only the per-axis signs matter, so viewDir need not be normalized.
-    const vec3 viewInModel = rotateVectorByQuat(vec3(1.0f, 1.0f, 1.0f), quatInverse(rotation));
+    // View direction expressed in the entity's model frame (R⁻¹ · viewDir) —
+    // the same axis the per-voxel occlusion depth projects onto (@ref
+    // isoDepthAxisModel). Only the per-axis signs matter here.
+    const vec3 viewInModel = isoDepthAxisModel(rotation);
     return {
         viewInModel.x < 0.0f ? FaceId::X_POS : FaceId::X_NEG,
         viewInModel.y < 0.0f ? FaceId::Y_POS : FaceId::Y_NEG,

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -81,6 +81,12 @@ inline void buildVoxelFrameData(
     frameData.voxelDispatchGrid_ = dispatchGrid;
     frameData.voxelCount_ = liveVoxelCount;
     frameData.canvasSizePixels_ = canvas.size_;
+    // Per-voxel occlusion depth axis (#1462). World canvas + the smooth-Z-yaw
+    // per-axis route keep the fixed (1,1,1) iso depth axis (byte-identical
+    // x+y+z); the detached branch below overrides it with the entity-rotated
+    // axis. frameData_ is a reused member, so this must be reset every frame so
+    // a prior detached canvas's axis can't leak into a world frame.
+    frameData.voxelDepthAxis_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
 
     // A non-zero `canvasRotation` marks a detached entity canvas (the main
     // world canvas keeps the all-zero `C_CanvasLocalRotation::kSentinelNoRotation`
@@ -109,6 +115,11 @@ inline void buildVoxelFrameData(
             static_cast<int>(visibleFaces[2]),
             0
         );
+        // Per-voxel occlusion depth projects onto the entity-rotated iso axis
+        // `R⁻¹·(1,1,1)` (#1462) — the same model-frame axis `visibleTriplet`
+        // selects faces from, so face visibility and occlusion order stay on
+        // one per-entity frame. Identity entity → (1,1,1) → byte-identical.
+        frameData.voxelDepthAxis_ = vec4(IRMath::isoDepthAxisModel(canvasRotation.rotation_), 0.0f);
         // Snap to the nearest of the 24 cube orientations and deform by the
         // residual only: a cube is invariant under the snap, so this keeps
         // the per-face skew small enough to stay clean (T-295).

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -194,6 +194,17 @@ struct FrameDataVoxelToCanvas {
     // outward normal / tangents). Single source of face metadata per
     // design-doc § "AO / lighting agree by construction".
     ivec4 visibleFaceIds_ = ivec4(0, 2, 4, 0);
+    // Model-frame iso depth axis `R⁻¹·(1,1,1)` for the per-voxel occlusion
+    // metric (#1462). The world canvas and any identity entity keep the
+    // default (1,1,1) so `isoDepthAlongAxis` collapses to `x+y+z` and the
+    // GRID / identity raster stays byte-identical; a rotated DETACHED canvas
+    // uploads `IRMath::isoDepthAxisModel(rotation)` so off-octahedral pitch /
+    // roll orders voxels along the entity-rotated axis instead of the snapped
+    // (1,1,1). `.w` is std140 padding. std140-appended after visibleFaceIds_
+    // (offset 144), so every prior field offset — and the world/GRID fast
+    // path — is unchanged; the gather shaders that read only the prefix
+    // (stage 2, AO, lighting) are unaffected and need no declaration update.
+    vec4 voxelDepthAxis_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
 };
 
 struct FrameDataTrixelToTrixel {
@@ -379,8 +390,15 @@ static_assert(
     "(faceDeform_ at 80 + 3 * 16 B = 128). std140 ivec4 alignment is 16 B"
 );
 static_assert(
-    sizeof(FrameDataVoxelToCanvas) == 144,
-    "FrameDataVoxelToCanvas size must mirror its std140 GLSL block"
+    offsetof(FrameDataVoxelToCanvas, voxelDepthAxis_) == 144,
+    "FrameDataVoxelToCanvas::voxelDepthAxis_ must land at offset 144 "
+    "(visibleFaceIds_ at 128 + 16 B). Appended after the prior last field so "
+    "every existing offset — and the world/GRID fast path — stays unchanged"
+);
+static_assert(
+    sizeof(FrameDataVoxelToCanvas) == 160,
+    "FrameDataVoxelToCanvas size must mirror its std140 GLSL block "
+    "(voxelDepthAxis_ vec4 append: 144 + 16 = 160)"
 );
 
 struct FrameDataSun {

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl
@@ -55,6 +55,14 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
     // `.w` is std140 padding. At cardinal 0 the default {0, 2, 4} = {X_NEG,
     // Y_NEG, Z_NEG} matches the pre-#1278 lower-coordinate semantics.
     uniform ivec4 visibleFaceIds;
+    // Model-frame iso depth axis `R⁻¹·(1,1,1)` for the per-voxel occlusion
+    // metric (#1462). (1,1,1) for the world canvas / identity entity, so
+    // isoDepthAlongAxis collapses to pos3DtoDistance and the GRID / identity
+    // raster stays byte-identical; a rotated DETACHED canvas uploads
+    // `IRMath::isoDepthAxisModel(rotation)`. `.w` is std140 padding. Appended
+    // after visibleFaceIds (offset 144) — the prefix the other binding-7
+    // shaders declare is unchanged, so only this stage reads it.
+    uniform vec4 voxelDepthAxis;
 };
 
 layout(std430, binding = 5) readonly buffer PositionBuffer {
@@ -234,8 +242,16 @@ void main() {
         // Encode `slot` (not faceId) in depth — keeps the 2-bit field
         // unchanged, and AO/lighting recover the world faceId via
         // visibleFaceIds[slot] from the same UBO.
-        const int voxelDistance = encodeDepthWithFace(
-            pos3DtoDistance(voxelPositionInt), slot);
+        // Detached entities raster in model space (camera yaw zeroed), so the
+        // occlusion order projects onto the entity-rotated iso axis (#1462).
+        // The world canvas keeps the fixed (1,1,1) via pos3DtoDistance, so its
+        // depth is byte-identical to master (voxelPositionInt is integer, so
+        // the detached path's roundHalfUp(dot(pos,(1,1,1))) would equal x+y+z
+        // at identity too — the branch only guards the GRID fast path).
+        const int rawDepth = isDetachedCanvas > 0.5
+            ? isoDepthAlongAxis(voxelPositionInt, voxelDepthAxis.xyz)
+            : pos3DtoDistance(voxelPositionInt);
+        const int voxelDistance = encodeDepthWithFace(rawDepth, slot);
         const ivec2 base =
             trixelFrameOffset(trixelCanvasOffsetZ1, frameCanvasOffset, voxelRenderOptions) +
             pos3DtoPos2DIso(voxelPositionInt);
@@ -264,8 +280,12 @@ void main() {
         // `voxelPositionFixed = round(worldPos * subdivisions)`.
         microPositionFixed += cardinalLowerCornerShift(cardinalIndex) * subdivisions;
     }
-    const int depthBase =
-        microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
+    // Detached entities project occlusion depth onto the entity-rotated iso
+    // axis (#1462); world/GRID keeps the (x+y+z) fixed-(1,1,1) form. Depth is
+    // in subdivision units on both branches, so the encode scale is unchanged.
+    const int depthBase = isDetachedCanvas > 0.5
+        ? isoDepthAlongAxis(microPositionFixed, voxelDepthAxis.xyz)
+        : (microPositionFixed.x + microPositionFixed.y + microPositionFixed.z);
     const int voxelDistance = encodeDepthWithFace(depthBase, slot);
     const ivec2 base = frameOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
     emitDeformedFace(base, D, voxelDistance);

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -292,6 +292,17 @@ ivec2 roundHalfUp(vec2 v) {
     return ivec2(floor(v + vec2(0.5)));
 }
 
+// Per-voxel iso occlusion depth of model position `pos` projected onto a
+// (possibly entity-rotated) iso depth `axis` — the SO(3) generalization of
+// pos3DtoDistance (identical to it when axis == (1,1,1)). For a rotated
+// DETACHED canvas `axis` is `R⁻¹·(1,1,1)` (uploaded in
+// FrameDataVoxelToTrixel.voxelDepthAxis); the world canvas keeps (1,1,1).
+// CPU twin: IRMath::isoDepthAlongAxis — roundHalfUp keeps the half-integer
+// rounding bit-identical across the CPU/GPU boundary (#1462).
+int isoDepthAlongAxis(ivec3 pos, vec3 axis) {
+    return roundHalfUp(dot(vec3(pos), axis));
+}
+
 ivec2 trixelOriginOffsetX1(ivec2 trixelCanvasSize) {
     return trixelCanvasSize / ivec2(2);
 }

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_1.metal
@@ -166,9 +166,13 @@ kernel void c_voxel_to_trixel_stage_1(
             voxelPositionInt = rotateCardinalZ(voxelPositionInt, cardinalIndex);
             voxelPositionInt += cardinalLowerCornerShift(cardinalIndex);
         }
-        const int voxelDistance = encodeDepthWithFace(
-            pos3DtoDistance(voxelPositionInt), slot
-        );
+        // Detached entities raster in model space; project occlusion depth
+        // onto the entity-rotated iso axis (#1462). World/GRID keeps the fixed
+        // (1,1,1) via pos3DtoDistance — byte-identical. See the GLSL twin.
+        const int rawDepth = frameData.isDetachedCanvas > 0.5f
+            ? isoDepthAlongAxis(voxelPositionInt, frameData.voxelDepthAxis.xyz)
+            : pos3DtoDistance(voxelPositionInt);
+        const int voxelDistance = encodeDepthWithFace(rawDepth, slot);
         const int2 base =
             trixelFrameOffset(
                 frameData.trixelCanvasOffsetZ1,
@@ -200,8 +204,12 @@ kernel void c_voxel_to_trixel_stage_1(
         // `voxelPositionFixed = round(worldPos * subdivisions)`.
         microPositionFixed += cardinalLowerCornerShift(cardinalIndex) * subdivisions;
     }
-    const int depthBase =
-        microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
+    // Detached entities project occlusion depth onto the entity-rotated iso
+    // axis (#1462); world/GRID keeps the (x+y+z) fixed-(1,1,1) form. Depth is
+    // in subdivision units on both branches, so the encode scale is unchanged.
+    const int depthBase = frameData.isDetachedCanvas > 0.5f
+        ? isoDepthAlongAxis(microPositionFixed, frameData.voxelDepthAxis.xyz)
+        : (microPositionFixed.x + microPositionFixed.y + microPositionFixed.z);
     const int voxelDistance = encodeDepthWithFace(depthBase, slot);
     const int2 base = frameOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
     emitDeformedFace(base, D, voxelDistance, localId, frameData.isDetachedCanvas > 0.5f, distanceScratch, canvasSize);

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -275,6 +275,17 @@ inline int2 roundHalfUp(float2 v) {
     return int2(floor(v + float2(0.5)));
 }
 
+// Per-voxel iso occlusion depth of model position `pos` projected onto a
+// (possibly entity-rotated) iso depth `axis` — the SO(3) generalization of
+// pos3DtoDistance (identical to it when axis == (1,1,1)). For a rotated
+// DETACHED canvas `axis` is `R⁻¹·(1,1,1)` (uploaded in
+// FrameDataVoxelToTrixel.voxelDepthAxis); the world canvas keeps (1,1,1).
+// CPU twin: IRMath::isoDepthAlongAxis — roundHalfUp keeps the half-integer
+// rounding bit-identical across the CPU/GPU boundary (#1462).
+inline int isoDepthAlongAxis(int3 pos, float3 axis) {
+    return roundHalfUp(dot(float3(pos), axis));
+}
+
 inline int2 trixelOriginOffsetX1(int2 trixelCanvasSize) {
     return trixelCanvasSize / int2(2);
 }
@@ -615,6 +626,14 @@ struct FrameDataVoxelToTrixel {
     // .w is std140 padding. Mirrors `ivec4 visibleFaceIds` in the GLSL
     // UBO declarations.
     int4 visibleFaceIds;
+    // Model-frame iso depth axis `R⁻¹·(1,1,1)` for the per-voxel occlusion
+    // metric (#1462). (1,1,1) for the world canvas / identity entity →
+    // isoDepthAlongAxis collapses to x+y+z (byte-identical); a rotated
+    // DETACHED canvas uploads IRMath::isoDepthAxisModel(rotation). .w is
+    // padding. Mirrors `vec4 voxelDepthAxis` appended in the GLSL stage-1 UBO
+    // and FrameDataVoxelToCanvas::voxelDepthAxis_. Other kernels that bind
+    // this struct never read it.
+    float4 voxelDepthAxis;
 };
 
 #endif // IR_ISO_COMMON_METAL_INCLUDED

--- a/test/math/ir_math_yaw_deformation_test.cpp
+++ b/test/math/ir_math_yaw_deformation_test.cpp
@@ -420,4 +420,97 @@ TEST(MatrixApplyToVoxelGridTest, RoundsHalfIntegerUp) {
     EXPECT_EQ(r.z, 0);
 }
 
+// ---------------------------------------------------------------------------
+// isoDepthAxisModel / isoDepthAlongAxis (#1462 — detached SO(3) occlusion depth)
+// ---------------------------------------------------------------------------
+
+// Identity entity → the model-frame iso depth axis is exactly (1,1,1) with no
+// FP drift (rotateVectorByQuat by the identity quat is the exact identity), so
+// isoDepthAlongAxis collapses to pos3DtoDistance and the detached path stays
+// byte-identical to master / the GRID world canvas.
+TEST(IsoDepthAxisModelTest, IdentityIsExactlyOnes) {
+    const IRMath::vec3 axis = IRMath::isoDepthAxisModel(IRMath::vec4(0, 0, 0, 1));
+    EXPECT_EQ(axis.x, 1.0f);
+    EXPECT_EQ(axis.y, 1.0f);
+    EXPECT_EQ(axis.z, 1.0f);
+}
+
+// A 180-deg entity rotation about Z negates the in-plane (x,y) components of
+// R⁻¹·(1,1,1) and leaves z — the depth order flips in x/y, exactly the
+// occlusion the fixed (1,1,1) got wrong for the camera-facing +X/+Y faces.
+TEST(IsoDepthAxisModelTest, Rotation180ZNegatesXY) {
+    const IRMath::vec4 q = IRMath::quatAxisAngle(IRMath::vec3(0, 0, 1), IRMath::kPi);
+    const IRMath::vec3 axis = IRMath::isoDepthAxisModel(q);
+    EXPECT_NEAR(axis.x, -1.0f, 1e-5f);
+    EXPECT_NEAR(axis.y, -1.0f, 1e-5f);
+    EXPECT_NEAR(axis.z, 1.0f, 1e-5f);
+}
+
+// The depth axis is the exact vector visibleTriplet selects faces from, so the
+// per-axis sign of the axis agrees with the visible face polarity — face
+// visibility and occlusion order share one per-entity frame by construction.
+TEST(IsoDepthAxisModelTest, SignsAgreeWithVisibleTriplet) {
+    const IRMath::vec4 rots[] = {
+        IRMath::vec4(0, 0, 0, 1),
+        IRMath::quatAxisAngle(IRMath::vec3(0, 0, 1), IRMath::kPi),
+        IRMath::quatAxisAngle(IRMath::vec3(1, 0, 0), IRMath::kHalfPi),
+        IRMath::quatAxisAngle(IRMath::vec3(1, 1, 1), IRMath::kTwoPi / 3.0f),
+        IRMath::quatAxisAngle(IRMath::vec3(0, 1, 0), IRMath::kPi / 3.0f),
+    };
+    for (const IRMath::vec4 &q : rots) {
+        const IRMath::vec3 axis = IRMath::isoDepthAxisModel(q);
+        const std::array<IRMath::FaceId, 3> faces = IRMath::visibleTriplet(q);
+        EXPECT_EQ(axis.x < 0.0f, IRMath::faceIsPositive(faces[0]));
+        EXPECT_EQ(axis.y < 0.0f, IRMath::faceIsPositive(faces[1]));
+        EXPECT_EQ(axis.z < 0.0f, IRMath::faceIsPositive(faces[2]));
+    }
+}
+
+// At the (1,1,1) axis the projection is exactly pos3DtoDistance (x+y+z) for
+// integer positions — the world/GRID byte-identical invariant.
+TEST(IsoDepthAlongAxisTest, OnesAxisMatchesPos3DtoDistance) {
+    const IRMath::ivec3 samples[] =
+        {{0, 0, 0}, {3, -2, 5}, {-7, 4, -1}, {10, 10, 10}, {-4, -4, -4}};
+    const IRMath::vec3 ones(1.0f, 1.0f, 1.0f);
+    for (const IRMath::ivec3 &p : samples) {
+        EXPECT_EQ(IRMath::isoDepthAlongAxis(p, ones), IRMath::pos3DtoDistance(p));
+    }
+}
+
+// The composition the renderer relies on for the identity-detached
+// byte-identical invariant: isoDepthAlongAxis(p, isoDepthAxisModel(identity))
+// reproduces pos3DtoDistance exactly.
+TEST(IsoDepthAlongAxisTest, IdentityEntityIsBitIdenticalToPos3DtoDistance) {
+    const IRMath::vec3 axis = IRMath::isoDepthAxisModel(IRMath::vec4(0, 0, 0, 1));
+    const IRMath::ivec3 samples[] = {{0, 0, 0}, {3, -2, 5}, {-7, 4, -1}, {10, 10, 10}};
+    for (const IRMath::ivec3 &p : samples) {
+        EXPECT_EQ(IRMath::isoDepthAlongAxis(p, axis), IRMath::pos3DtoDistance(p));
+    }
+}
+
+// roundHalfUp parity: a projection landing on a half-integer rounds UP, matching
+// the GLSL/Metal isoDepthAlongAxis mirror (floor(v + 0.5)).
+TEST(IsoDepthAlongAxisTest, RoundsHalfUpLikeShaderMirror) {
+    const IRMath::vec3 axis(0.5f, 0.0f, 0.0f);
+    EXPECT_EQ(IRMath::isoDepthAlongAxis(IRMath::ivec3(1, 0, 0), axis), 1);  // 0.5 → 1
+    EXPECT_EQ(IRMath::isoDepthAlongAxis(IRMath::ivec3(3, 0, 0), axis), 2);  // 1.5 → 2
+    EXPECT_EQ(IRMath::isoDepthAlongAxis(IRMath::ivec3(-1, 0, 0), axis), 0); // -0.5 → 0
+}
+
+// The fix in one assertion: a 180-deg-Z detached entity orders voxels along
+// (-1,-1,1), the opposite in-plane sense from the fixed (1,1,1). A voxel "in
+// front" under the old metric is "behind" under the rotated one — the occlusion
+// swap the pitch/roll-reveals bug (#1462) was missing.
+TEST(IsoDepthAlongAxisTest, Rotation180ZFlipsInPlaneOrder) {
+    const IRMath::vec3 axis =
+        IRMath::isoDepthAxisModel(IRMath::quatAxisAngle(IRMath::vec3(0, 0, 1), IRMath::kPi));
+    const IRMath::ivec3 front(5, 5, 0); // high x+y → "far" under (1,1,1)
+    const IRMath::ivec3 back(-5, -5, 0);
+    EXPECT_GT(IRMath::pos3DtoDistance(front), IRMath::pos3DtoDistance(back)); // old metric
+    EXPECT_LT(
+        IRMath::isoDepthAlongAxis(front, axis),
+        IRMath::isoDepthAlongAxis(back, axis)
+    ); // rotated metric reverses the in-plane order
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

P1 of epic #1444 (detached-canvas full SO(3)). Re-derive per-voxel occlusion depth for **DETACHED** entities on the entity-rotated iso axis `R⁻¹·(1,1,1)` instead of the fixed world `(1,1,1)` (`x+y+z`), which was correct only when the entity rotation fixes `(1,1,1)`. Off that, the snapped depth order leaked back-face voxels through — the "pitch/roll reveals" bug, live since #1386/#1398 landed full-SO(3) face selection on detached canvases.

- **New IRMath surface:** `isoDepthAxisModel(rotation)` = `R⁻¹·(1,1,1)` (the model-frame depth axis — `visibleTriplet` now reuses it, so face selection and occlusion share one per-entity frame) and `isoDepthAlongAxis(pos, axis)` = `roundHalfUp(dot(pos, axis))`.
- **GPU mirror:** `isoDepthAlongAxis` in `ir_iso_common.{glsl,metal}`; stage-1 (`c_voxel_to_trixel_stage_1.{glsl,metal}`) uses it for the depth write **gated on `isDetachedCanvas`**.
- **Contract change:** `FrameDataVoxelToCanvas::voxelDepthAxis_` — a `vec4` **appended** (std140 offset 144 → size 160). Every prior field offset is unchanged, so the gather shaders (stage-2, AO, lighting) that read only the prefix are untouched and the world/GRID fast path is byte-identical. Static asserts pin offset 144 / size 160.
- **Gated per-entity:** the world / GRID canvas keeps `voxelDepthAxis_ == (1,1,1)`, so `isoDepthAlongAxis` collapses to `pos3DtoDistance` → GRID and any zero-rotation detached entity are byte-identical to master.
- Doc: `iso-depth-axis-invariant.md` gains the entity-rotation carve-out + fixes the stale `#1076 … A/B pending` line (#1076 closed, Option B). `engine/math/CLAUDE.md` helper list updated.

## Verification

- **7 new IRMath unit tests** (`ir_math_yaw_deformation_test.cpp`): axis = `R⁻¹·(1,1,1)`; identity exactly `(1,1,1)`; identity-detached depth bit-identical to `pos3DtoDistance`; 180°-Z flips the in-plane occlusion order (the discriminating case); `roundHalfUp` parity with the shader mirror; sign-agreement with `visibleTriplet`. All 64 pre-existing yaw/render tests still green (the `visibleTriplet` extraction is a pure no-op refactor).
- **Byte-identical invariants (cmp, master vs branch):** IRShapeDebug `zoom8_origin` / `yaw45_inter_cardinal` / `pan16_yaw0_pivot` / `pan16_yaw45_pivot` all identical (GRID/world untouched); IRCanvasStress identical at the identity pose.
- **Both backends compile + run** (Metal verified locally; OpenGL via cross-host smoke).
- **No rotated-detached screenshot:** the auto-screenshot warmup freezes the UPDATE pipeline (`PROPAGATE_TRANSFORM`/`PROPAGATE_CANVAS_ROTATION`), so detached entities stay at **identity** headlessly — an injected fixed rotation produced byte-identical output, confirming the limitation. The rotated visual showcase lands with P3 (#1464, smooth deform) and the validation harness in P5 (#1466). The discriminating behavior is proven at the math level by the 180°-Z order-flip test.

## Test plan
- [ ] Opus recheck: confirm the depth axis `R⁻¹·(1,1,1)` is correct for the model-space detached raster (vs world-space) and the std140 append is layout-safe.
- [ ] Cross-host Linux/OpenGL smoke (build + IRShapeDebug).
- [ ] (P3/P5) rotated-detached occlusion visual once the validation harness exists.

Closes #1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)