### PR TITLE
render: detached SO(3) P3a — per-axis face-local store (#1464)

### DIFF
--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -24,8 +24,12 @@ the ECS surface.
   while it sits off an octahedral snap (#1463), bounded by
   `kMaxDetachedRotatingCanvases` (overflow falls back to the single-canvas
   `faceDeformationMatrixSO3` path). Both free at the snap/cardinal so a static
-  scene is byte-identical (fast path). T2 (#1309) routes each
-  visible voxel face into its axis canvas with continuous
+  scene is byte-identical (fast path). A rotating detached entity's visible
+  faces are written into its own per-axis canvases by the model-space
+  face-local store (#1464, P3a) — additive, so the single-canvas octahedral emit
+  still renders the entity and the frame is unchanged until the resolve-scatter
+  that consumes them lands in P3b (#1475). For the **main world canvas**, T2
+  (#1309) routes each visible voxel face into its axis canvas with continuous
   (`pos3DtoPos2DIsoYawed`) center reposition + shared world depth; T3
   (#1310) composites the three by depth-tested forward scatter at the
   framebuffer; T4 (#1311) lights each per-axis canvas (AO + sun-shadow +

--- a/engine/prefabs/irreden/render/per_axis_canvas.hpp
+++ b/engine/prefabs/irreden/render/per_axis_canvas.hpp
@@ -18,6 +18,7 @@
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 
 #include <cstddef>
+#include <utility>
 #include <vector>
 
 namespace IRPrefab::PerAxisCanvas {
@@ -166,11 +167,26 @@ inline void setUboSubdivisionDensity(IRRender::Buffer *frameDataUbo, int density
 // C_PerAxisTrixelCanvases) but keeps the C_CanvasLocalRotation sentinel, so
 // isDetached() is false and it stays owned by syncAllocationToCameraYaw().
 //
-// Infrastructure only (#1463): no faces route into these textures yet, so the
-// rendered frame is unchanged — this just stands up (and bounds) the storage
-// the P3 forward-scatter composite (#1464) will write. Called once per frame
-// from VOXEL_TO_TRIXEL_STAGE_1::beginTick.
-inline void syncAllocationToDetachedEntities() {
+// When @p allocatedOut is non-null, it is filled (cleared first) with one
+// {canvasEntity, &axes} pair per detached canvas left ALLOCATED this frame —
+// the set the P3 forward-scatter store (#1464) routes into. Folding the
+// collection into this same scan keeps the per-frame archetype walk single-pass:
+// the consumer (VOXEL_TO_TRIXEL_STAGE_1) reuses the result by canvas entity in
+// its per-entity tick instead of re-querying the same archetype. The pointers
+// are column addresses, valid only for the rest of this pipeline pass (no
+// structural change runs before the per-entity ticks consume them).
+//
+// (#1463) stood the textures up as infrastructure; (#1464, P3a) is the first
+// consumer — the detached per-axis face-local store. Called once per frame from
+// VOXEL_TO_TRIXEL_STAGE_1::beginTick.
+inline void syncAllocationToDetachedEntities(
+    std::vector<std::pair<IREntity::EntityId, IRComponents::C_PerAxisTrixelCanvases *>>
+        *allocatedOut = nullptr
+) {
+    if (allocatedOut != nullptr) {
+        allocatedOut->clear();
+    }
+
     // Dense per-archetype-column iteration (no per-entity getComponent): the
     // three components arrive as parallel column vectors indexed by row.
     const std::vector<IREntity::ArchetypeNode *> nodes = IREntity::queryArchetypeNodesSimple(
@@ -207,6 +223,13 @@ inline void syncAllocationToDetachedEntities() {
                                        allocatedRotating < kMaxDetachedRotatingCanvases;
             if (wantAllocated) {
                 ++allocatedRotating; // counts whether kept from last frame or newly allocated
+                // wantAllocated == the post-sync allocation state (the block
+                // below only transitions a row that isn't already there), so
+                // collect here — before the already-in-state early-out — to
+                // catch rows kept allocated from the prior frame too.
+                if (allocatedOut != nullptr) {
+                    allocatedOut->emplace_back(node->entities_[i], &axes);
+                }
             }
 
             if (wantAllocated == axes.isAllocated()) {

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 using namespace IRComponents;
@@ -337,6 +338,28 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
     IREntity::EntityId perAxisCanvasEntity_ = IREntity::kNullEntity;
     C_PerAxisTrixelCanvases *perAxisCanvases_ = nullptr;
 
+    // Every rotating DETACHED entity's allocated per-axis canvases, resolved once
+    // per frame in beginTick and consumed by the per-entity tick (#1464). The
+    // canvas the system iterates is NOT in its template params (the main-canvas-
+    // only `perAxisCanvases_` is resolved by a single beginTick getComponent), and
+    // a voxel canvas built via `EntityCanvas::addVoxelPool` may lack
+    // C_PerAxisTrixelCanvases — so adding it to the archetype filter would silently
+    // drop such a canvas. We instead key the allocated set by canvas entity here and
+    // linear-scan it in the tick (bounded by kMaxDetachedRotatingCanvases, so a tiny
+    // list). The stored pointers are column addresses valid only within this frame's
+    // ticks — no structural change runs between beginTick and the per-entity ticks of
+    // the same pipeline pass, same contract as `perAxisCanvases_`.
+    std::vector<std::pair<IREntity::EntityId, C_PerAxisTrixelCanvases *>> detachedPerAxisAllocated_;
+
+    C_PerAxisTrixelCanvases *lookupDetachedPerAxis(IREntity::EntityId entity) const {
+        for (const auto &[id, axes] : detachedPerAxisAllocated_) {
+            if (id == entity) {
+                return axes;
+            }
+        }
+        return nullptr;
+    }
+
     // Route the visible voxel faces into the three per-axis trixel canvases for
     // smooth camera Z-yaw (T2 / #1309). Runs ONLY on the main world canvas and
     // ONLY while rotating (the per-axis textures are allocated). Reuses this
@@ -631,6 +654,28 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         if (entity == perAxisCanvasEntity_ && perAxisCanvases_ != nullptr &&
             perAxisCanvases_->isAllocated()) {
             dispatchPerAxisCanvases(*perAxisCanvases_);
+        } else if (canvasLocalRotation.isDetached()) {
+            // Detached entity SO(3) per-axis store (P3a / #1464). Route this
+            // entity's visible model-space faces into its OWN per-axis canvases
+            // — the SO(3) generalization of the camera-yaw store above. The
+            // store path is shared (perAxisRoute != 0 in the shaders): the
+            // detached frame data buildVoxelFrameData set this tick (model-frame
+            // visibleFaceIds_ from visibleTriplet, isDetachedCanvas_, the model
+            // iso depth axis) flows through unchanged, so each face is stored in
+            // its model-axis face-local lattice keyed on pos3DtoDistance — the
+            // exact origin-recovery key faceOriginFromInPlane consumes at scatter
+            // time (P3b / #1475, which applies the residual reposition).
+            //
+            // Purely ADDITIVE: the single-canvas octahedral emit above still
+            // renders this entity (skipSingleCanvasVoxels is main-canvas-only),
+            // so the populated per-axis textures are not yet consumed and the
+            // frame is byte-identical until P3b reads them. Only fires when the
+            // entity is rotating off an octahedral snap (textures allocated in
+            // beginTick by syncAllocationToDetachedEntities); at a snap / identity
+            // nothing is allocated, so lookup returns null → byte-identical.
+            if (C_PerAxisTrixelCanvases *detachedAxes = lookupDetachedPerAxis(entity)) {
+                dispatchPerAxisCanvases(*detachedAxes);
+            }
         }
     }
 
@@ -658,10 +703,13 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
 
         // Same lazy lifecycle for DETACHED entities rotating off an octahedral
         // snap (per-entity SO(3), #1463), bounded by kMaxDetachedRotatingCanvases.
-        // Infrastructure only — no faces route into these textures yet (the P3
-        // forward-scatter composite, #1464, consumes them), so the frame stays
-        // byte-identical and a non-rotating / cardinal scene pays nothing.
-        IRPrefab::PerAxisCanvas::syncAllocationToDetachedEntities();
+        // Pass detachedPerAxisAllocated_ so the single allocation scan also reports
+        // the {canvas, &axes} pairs it left allocated — the per-entity tick reuses
+        // that by canvas entity (#1464) instead of re-walking the same archetype.
+        // The column pointers stay valid for the rest of this pipeline pass (no
+        // structural change before the per-entity ticks consume them); the vector
+        // is cleared (capacity kept) inside the call. No per-entity getComponent.
+        IRPrefab::PerAxisCanvas::syncAllocationToDetachedEntities(&detachedPerAxisAllocated_);
 
         // Resolve the main canvas's per-axis trixel canvases once per frame for
         // the per-entity tick to consume without a getComponent on its own


### PR DESCRIPTION
Stacked on: #1473 (P2 #1463). Base = `claude/1463-detached-per-axis-canvas-infra`.

Closes #1464

## What

P3a of the detached-SO(3) epic (#1444): route a rotating detached entity's visible voxel faces into its **own** per-axis trixel canvases (allocated by P2 #1463), generalizing the camera-yaw per-axis store (#1310) to per-entity SO(3). **Purely additive** — the single-canvas octahedral emit (`faceDeformationMatrixSO3`) still renders the entity, so the per-axis textures are populated but not yet consumed; the resolve-scatter that consumes them lands in P3b (#1475).

## How

- `VOXEL_TO_TRIXEL_STAGE_1` dispatches the detached entity's per-axis store (reusing `dispatchPerAxisCanvases`) when the entity is rotating off an octahedral snap. **No shader change**: the shared `perAxisRoute != 0` store path already does the right thing once fed the detached frame data `buildVoxelFrameData` sets per tick — model-frame `visibleFaceIds_` (from `visibleTriplet`), `isDetachedCanvas_`, the model iso depth axis. Each visible face lands in its model-axis face-local lattice (`faceInPlaneCoords`) keyed on `pos3DtoDistance` (x+y+z) — the exact origin-recovery key `faceOriginFromInPlane` consumes at scatter time.
- The iterating canvas is **not** added to the system's template params: a voxel canvas built via `EntityCanvas::addVoxelPool` may lack `C_PerAxisTrixelCanvases`, so widening the archetype filter would silently drop it. Instead `syncAllocationToDetachedEntities` now optionally reports the `{canvas, &axes}` pairs it left allocated (single archetype scan in `beginTick`, reused by canvas entity in the per-entity tick — no per-entity `getComponent`).

## Verification

- **Build**: clean (macOS / Metal).
- **Identity + cardinal byte-identical**: the per-axis dispatch only fires for rotating detached entities, which freeze at identity headlessly (UPDATE warmup freeze), so it is inert for capturable scenes. `IRShapeDebug --auto-screenshot` (16 shots + ROI crops) is byte-identical to the P2 base modulo the renderer's known run-to-run AO noise at non-cardinal yaw — confirmed: a same-binary re-run differs on a *different* shot, so the deltas are non-determinism, not this change.
- **GLSL/Metal parity**: no shader change.
- The rotating-detached **visual** is unverifiable headlessly (per the epic verification note) and lands at **P5 (#1466)**.

## Note for P3b (#1475) — store frame / scatter rotation

P3a stores **raw model-space** face positions in the model-axis face-local lattice, with the origin-recovery key `pos3DtoDistance` (x+y+z) — mirroring #1310's world store (raw positions; the full rotation is applied at *scatter*). So P3b's scatter should reproject each recovered model origin by the **full composed** rotation (`pos3DtoPos2DIsoRotated(origin, composed)`), **not** just the residual: the octahedral snap and the residual do **not** commute in SO(3), so a "snap-pre-applied store + residual-only scatter" split would mis-rotate (`iso(R_residual·R_snap·m) ≠ iso(R_snap·R_residual·m)`). Storing raw + applying the full composed at scatter is the form that recovers `iso(R_composed·m)` and keeps the `faceOriginFromInPlane` round-trip valid (x+y+z key). The architect's plan phrased this as "octahedral-snapped store + residual scatter"; this is the same intent with the snap kept in the scatter rotation rather than pre-baked into the store (matching the world precedent). Flagging for confirmation since it refines the plan's wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
