### PR TITLE
engine/time: deterministic fixed-step UPDATE under --auto-screenshot (animated headless capture)

### DIFF
--- a/engine/time/CLAUDE.md
+++ b/engine/time/CLAUDE.md
@@ -80,15 +80,16 @@ of lag manually (used by the loading-screen / pause path).
   catches up via extra ticks; it doesn't "drop" anything.
 - **`skipUpdate()` is a footgun.** Skipping ticks silently desyncs any
   system that counts ticks. Use only for loading screens.
-- **`setFixedStep(true)` decouples UPDATE from wall-clock.** Set by
+- **`enableFixedStep()` decouples UPDATE from wall-clock.** Set by
   `World::gameLoop` when `IRVideo::isAutoCaptureActive()` (a headless
-  `--auto-screenshot` run). `beginMainLoop` then feeds exactly one fixed
-  period per render frame, so the loop runs **one UPDATE tick per render
-  frame** regardless of wall-clock. This makes per-tick animation
-  (`AUTO_SPIN`, particles) advance deterministically across the
-  frame-counted capture window; without it the uncapped (vsync-off) capture
-  loop races through the window in under one update period and animated
-  state is captured at ~identity and non-deterministically. No effect on
-  interactive runs (defaults off).
+  `--auto-screenshot` run). Resets the UPDATE lag accumulator to zero and
+  switches `beginMainLoop` to feed exactly one fixed period per render frame,
+  so the loop runs **exactly one UPDATE tick per render frame** and
+  `warmup=N` render frames advance exactly N animation ticks. Without the
+  lag reset, the profiler's initial `m_lag = kFPSNanoDuration` seeds two
+  UPDATE ticks on frame 0 (N+1 ticks total). Without the fixed-step mode
+  itself, the uncapped (vsync-off) capture loop races through the window in
+  under one update period and animated state is captured at ~identity and
+  non-deterministically. No effect on interactive runs (defaults off).
 - **FPS windows don't match display frequency.** The 1-second rolling
   window is in engine time, not vsync time. Numbers can look noisy.

--- a/engine/time/CLAUDE.md
+++ b/engine/time/CLAUDE.md
@@ -80,5 +80,15 @@ of lag manually (used by the loading-screen / pause path).
   catches up via extra ticks; it doesn't "drop" anything.
 - **`skipUpdate()` is a footgun.** Skipping ticks silently desyncs any
   system that counts ticks. Use only for loading screens.
+- **`setFixedStep(true)` decouples UPDATE from wall-clock.** Set by
+  `World::gameLoop` when `IRVideo::isAutoCaptureActive()` (a headless
+  `--auto-screenshot` run). `beginMainLoop` then feeds exactly one fixed
+  period per render frame, so the loop runs **one UPDATE tick per render
+  frame** regardless of wall-clock. This makes per-tick animation
+  (`AUTO_SPIN`, particles) advance deterministically across the
+  frame-counted capture window; without it the uncapped (vsync-off) capture
+  loop races through the window in under one update period and animated
+  state is captured at ~identity and non-deterministically. No effect on
+  interactive runs (defaults off).
 - **FPS windows don't match display frequency.** The 1-second rolling
   window is in engine time, not vsync time. Numbers can look noisy.

--- a/engine/time/include/irreden/time/event_profiler.hpp
+++ b/engine/time/include/irreden/time/event_profiler.hpp
@@ -69,6 +69,10 @@ template <> class EventProfiler<UPDATE> {
         m_tickCount++;
     }
 
+    void resetLag() {
+        m_lag = NanoDuration{0};
+    }
+
     bool shouldUpdate() {
         return m_lag >= kFPSNanoDuration;
     }

--- a/engine/time/include/irreden/time/time_manager.hpp
+++ b/engine/time/include/irreden/time/time_manager.hpp
@@ -23,7 +23,14 @@ class TimeManager {
     void beginMainLoop() {
         TimePoint current = Clock::now();
         m_mainLoopElapsed = current - m_mainLoopPrevious;
-        m_profilerUpdate.addLag(m_mainLoopElapsed);
+        // Fixed-step capture mode: during a headless --auto-screenshot run,
+        // advance the UPDATE accumulator by exactly one fixed period per render
+        // frame instead of real wall-clock elapsed. The capture window is
+        // counted in render frames, but per-tick animation (AUTO_SPIN, etc.)
+        // advances per UPDATE tick; without this, the uncapped (vsync-off) loop
+        // races through the window in under one update period and the animation
+        // is captured at ~identity and non-deterministically.
+        m_profilerUpdate.addLag(m_fixedStep ? kFPSNanoDuration : m_mainLoopElapsed);
         m_mainLoopPrevious = current;
     }
 
@@ -41,6 +48,14 @@ class TimeManager {
 
     void clampUpdateLag(uint32_t maxTicks) {
         m_profilerUpdate.clampLag(maxTicks);
+    }
+
+    /// Enable deterministic fixed-step UPDATE pacing: beginMainLoop feeds the
+    /// UPDATE accumulator exactly one fixed period per render frame instead of
+    /// real wall-clock elapsed. Used for headless --auto-screenshot capture so
+    /// per-tick animation advances reproducibly. Off in interactive runs.
+    void setFixedStep(bool enabled) {
+        m_fixedStep = enabled;
     }
 
     template <Events event> double deltaTime();
@@ -61,6 +76,7 @@ class TimeManager {
     TimePoint m_start;
     TimePoint m_mainLoopPrevious;
     NanoSeconds m_mainLoopElapsed;
+    bool m_fixedStep = false;
 };
 
 } // namespace IRTime

--- a/engine/time/include/irreden/time/time_manager.hpp
+++ b/engine/time/include/irreden/time/time_manager.hpp
@@ -52,10 +52,12 @@ class TimeManager {
 
     /// Enable deterministic fixed-step UPDATE pacing: beginMainLoop feeds the
     /// UPDATE accumulator exactly one fixed period per render frame instead of
-    /// real wall-clock elapsed. Used for headless --auto-screenshot capture so
-    /// per-tick animation advances reproducibly. Off in interactive runs.
-    void setFixedStep(bool enabled) {
-        m_fixedStep = enabled;
+    /// real wall-clock elapsed. Resets the UPDATE lag accumulator so warmup=N
+    /// render frames produce exactly N UPDATE ticks. Used for headless
+    /// --auto-screenshot capture so per-tick animation advances reproducibly.
+    void enableFixedStep() {
+        m_profilerUpdate.resetLag();
+        m_fixedStep = true;
     }
 
     template <Events event> double deltaTime();

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -93,6 +93,14 @@ struct AutoScreenshotConfig {
 /// own loop could interpret that token, skip past it explicitly.
 bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut);
 
+/// True once @c createAutoScreenshotSystem has been called this run — i.e. the
+/// process is doing a headless auto-screenshot capture. @c World reads this to
+/// switch the UPDATE loop to a deterministic fixed step (one tick per render
+/// frame) so per-tick animation (AUTO_SPIN, etc.) advances reproducibly during
+/// the frame-counted capture window instead of being starved by the uncapped
+/// (vsync-off) headless loop.
+bool isAutoCaptureActive();
+
 /// Create a system that cycles through @c config.shots_ — one screenshot per
 /// shot with @c settleFrames_ between shots — then calls
 /// @c IRWindow::closeWindow(). The caller must append the returned @c SystemId

--- a/engine/video/src/auto_screenshot.cpp
+++ b/engine/video/src/auto_screenshot.cpp
@@ -29,6 +29,12 @@ struct CyclingState {
     bool screenshotPending_ = false;
 };
 
+// Set true the first time createAutoScreenshotSystem runs this process, i.e. a
+// headless --auto-screenshot capture is active. Read by World via
+// isAutoCaptureActive() to switch the UPDATE loop to a deterministic fixed
+// step. Process-lifetime flag; capture is one-shot per process.
+bool g_autoCaptureActive = false;
+
 } // namespace
 
 bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut) {
@@ -48,7 +54,12 @@ bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut) {
     return false;
 }
 
+bool isAutoCaptureActive() {
+    return g_autoCaptureActive;
+}
+
 IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config) {
+    g_autoCaptureActive = true;
     auto state = std::make_shared<CyclingState>();
     state->config_ = config;
     state->warmupRemaining_ = config.warmupFrames_;

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -198,7 +198,7 @@ void World::gameLoop() {
             // UPDATE tick per render frame so per-tick animation (AUTO_SPIN,
             // etc.) is deterministic and not starved by the uncapped
             // (vsync-off) loop racing through the frame-counted capture window.
-            m_timeManager.setFixedStep(true);
+            m_timeManager.enableFixedStep();
         }
         if (m_waitForFirstUpdateInput) {
             // Prime render-facing state so paused mode shows initialized voxels.

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -6,6 +6,7 @@
 #include <irreden/ir_audio.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/profile/profile_report.hpp>
+#include <irreden/video/auto_screenshot.hpp>
 
 #include <irreden/world.hpp>
 
@@ -192,6 +193,13 @@ void World::gameLoop() {
     using Clock = std::chrono::steady_clock;
     try {
         start();
+        if (IRVideo::isAutoCaptureActive()) {
+            // Headless --auto-screenshot capture: advance the sim exactly one
+            // UPDATE tick per render frame so per-tick animation (AUTO_SPIN,
+            // etc.) is deterministic and not starved by the uncapped
+            // (vsync-off) loop racing through the frame-counted capture window.
+            m_timeManager.setFixedStep(true);
+        }
         if (m_waitForFirstUpdateInput) {
             // Prime render-facing state so paused mode shows initialized voxels.
             update();


### PR DESCRIPTION
## Summary
- Headless `--auto-screenshot` runs the loop **vsync-off** (`glfwSwapInterval(0)`) but gates UPDATE on real wall-clock lag (`shouldUpdate`: `m_lag >= kFPSNanoDuration`). The frame-counted capture window (warmup + settle) finishes in **less wall-clock time than one fixed-update period**, so per-tick animation (`AUTO_SPIN`, particles) barely advances — captured at ~identity and **non-deterministically**.
- Fix: in capture mode (`IRVideo::isAutoCaptureActive()`), `World::gameLoop` enables `TimeManager::setFixedStep(true)`; `beginMainLoop` then feeds exactly one fixed period per render frame → **one deterministic UPDATE tick per render frame**. `warmup=N` advances animation N ticks, reproducibly across machines. Interactive runs unaffected (`m_fixedStep` defaults false).
- Unblocks the #1444 detached-SO(3) **P5** validation harness — rotating entities can now be captured headlessly.

## Files
- `engine/video/auto_screenshot.{hpp,cpp}` — expose `IRVideo::isAutoCaptureActive()` (set when the capture system is created).
- `engine/time/time_manager.hpp` — `setFixedStep(bool)`; `beginMainLoop` feeds `kFPSNanoDuration` in capture mode. `+` `engine/time/CLAUDE.md` gotcha.
- `engine/world/world.cpp` — enable fixed-step when capture is active.

## Verification (macos-debug)
- **canvas_stress** — detached `C_AutoSpin` entities now render rotated + de-synced; rotation **scales with warmup** (5-tick vs 120-tick runs visibly differ) — deterministic, frame-proportional.
- **shape_debug** — shot-1 **byte-identical at warmup 10 vs 200** (`match=100%, max_delta=0`): **no regression** to static / camera-posed captures (the shot sets the full camera pose, so extra UPDATE ticks don't change posed static output).

## Note — pre-existing, not this PR
`render-verify shape_debug` currently fails on `macos-debug`: its references are from 2026-04-20 (`24a4ac62`) and the demo's shot table has grown to 28 shots vs the 6-shot manifest — stale across ~8 intervening render PRs. Filed separately; not introduced or affected by this change (confirmed via the byte-identical warmup-invariance check above).

## Test plan
- [ ] `fleet-build --target IRCanvasStress` + `fleet-run --auto-screenshot 120` → detached entities visibly rotated.
- [ ] Static demos warmup-invariant (shape_debug shot-1 identical across warmups).
- [ ] Interactive run (no `--auto-screenshot`) behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)