### PR TITLE
render-verify: exclude ROI crop files from shape_debug shot glob (#1472)

### DIFF
--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -121,8 +122,20 @@ def _load_manifest(demo_dir: Path) -> dict[str, Any]:
     return data
 
 
+# Full-frame captures are ``screenshot_<6-digit-index>.png``. ROI crop files
+# share the prefix but append ``_<shotLabel>__crop_<crop>.png`` (see
+# VideoManager::writePendingRoiCrops). A bare ``screenshot_*.png`` glob matches
+# both, and since ``.`` < ``_`` the crops sort *between* full frames — so the
+# first-N slice below would pick 128x128 crops as full shots. Match the
+# index-only form so crops never enter the shot->reference mapping.
+_FULL_FRAME_RE = re.compile(r"screenshot_\d+\.png")
+
+
 def _collect_shots(shots_dir: Path, num_shots: int) -> list[Path]:
-    shots = sorted(shots_dir.glob("screenshot_*.png"))
+    shots = sorted(
+        p for p in shots_dir.glob("screenshot_*.png")
+        if _FULL_FRAME_RE.fullmatch(p.name)
+    )
     if len(shots) < num_shots:
         raise SystemExit(
             f"expected {num_shots} screenshots in {shots_dir}, got {len(shots)}"


### PR DESCRIPTION
## Summary
- `_collect_shots` globbed `screenshot_*.png` and sliced the first N. ROI crop files (`screenshot_<n>_<label>__crop_<crop>.png`) match that glob and — since `.` < `_` — sort *between* full frames, so a crop-bearing shot (e.g. `zoom4_origin`, which has 3 crops) pushed 128×128 crops into the first-N selection. They compared as `actual=128x128` "shape mismatch", and under `--update-references` would bless a crop as a full-frame reference.
- Filter the shot glob to the index-only `screenshot_<digits>.png` form (`_FULL_FRAME_RE.fullmatch`) so ROI crops never enter the shot→reference mapping.

## Scope note
This addresses the **glob-mapping** half of #1472. #1472 also calls for re-blessing the stale `macos-debug` references; that re-bless is consolidated into the stacked **#1478** PR, because a correct `--update-references` re-bless depends on this glob fix landing first (otherwise it blesses crops) *and* on #1478's manifest update (6→current shot list). #1478 fully covers the re-bless.

## Stack context
Stacked on: master
Full chain: #1472 → #1478

## Test plan
- [x] Filter check: full frames kept, `__crop_` files excluded (verified locally against the exact `zoom4_origin`/`zoom8_origin` crop names).
- [x] `render-verify.py` byte-compiles.
- [ ] `python3 scripts/render-verify.py --target IRShapeDebug` on a host with the demo built: shots 4–6 no longer report `actual=128x128`.

Closes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)