### PR TITLE
fleet: trigger opus-reviewer via explicit needs-opus-recheck label

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -83,6 +83,10 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
    ~5 minutes, the scout is down — print
    `scout cache stale or missing — run fleet-up` and exit.
 5. Identify the candidates from both repos. A PR is a candidate if:
+   - Its `labels` contains `fleet:needs-opus-recheck` — the explicit
+     escalation the sonnet-reviewer stamps on an approve-and-escalate
+     first pass. This is the signal the scout projection wakes you on;
+     your verdict label-swap (step 2.g) removes it, OR
    - Its latest review (sort `reviews[]` by `submittedAt`) has a
      `body` containing `Opus recheck required`, OR
    - The PR touches core engine/game invariants (need to read its

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -179,10 +179,22 @@ iteration of polling, reviewing, and exiting cleanly:
       `gh pr edit` yourself immediately. Don't assume the skill did it.
 
       **Special case — Verdict approve + "Opus recheck required"** →
-      do NOT set any verdict label. Leave it unlabeled; opus-reviewer
-      will set the final label on its next pass. (Still set
-      `fleet:has-nits` here if there are nits, even without a verdict
-      label.)
+      do NOT set a verdict label (`fleet:approved` is opus-reviewer's
+      to set). Instead add `fleet:needs-opus-recheck` — the durable,
+      machine-readable escalation the scout's opus-reviewer projection
+      wakes the pane on. The review-body text alone is invisible to
+      that projection, so without this label the opus pane only fires
+      coincidentally on another PR's has-nits/needs-fix transition
+      (PR #1473 sat un-rechecked for exactly this reason). Still set
+      `fleet:has-nits` here if there are nits. opus-reviewer removes
+      `fleet:needs-opus-recheck` as part of its verdict label-swap
+      when its pass completes.
+
+      ```
+      gh pr edit <N> --add-label "fleet:needs-opus-recheck"
+      ```
+      (Add `--repo <game-repo>` for game PRs.) See
+      [REVIEWER-PROTOCOL.md § Verdict label-swap commands](../../docs/agents/REVIEWER-PROTOCOL.md#verdict-label-swap-commands).
    f. **Release the review claim** immediately after the verdict
       label-swap (or after a no-verdict skip path — broken stack,
       gated upstream-not-yet-approved, "Opus recheck required"). See

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -74,7 +74,7 @@ just the items that role works on:
 | sonnet-author | `tasks_open` (filtered to `[sonnet]` engine tasks), `feedback_prs` |
 | opus-worker | `tasks_open` (filtered to `[opus]` tasks, both repos), `needs_plan`, `feedback_prs` |
 | sonnet-reviewer | `candidate_prs` (review-skip filter applied) |
-| opus-reviewer | `flagged_prs` (`fleet:has-nits` / `fleet:needs-fix`) |
+| opus-reviewer | `flagged_prs` (`fleet:has-nits` / `fleet:needs-fix` / `fleet:needs-opus-recheck`) |
 | merger | `prs` (engine + game, approved or non-MERGEABLE only; each tagged with its `repo`) |
 
 **opus-reviewer:** review bodies longer than 2 KB are stored as

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -838,6 +838,21 @@ Specifically, **never pass these via `--label` when filing**:
   `fleet-queue-list` groups by these.
 - `fleet:approved` / `fleet:needs-fix` / `fleet:has-nits` /
   `fleet:blocker` — owned by the **reviewer agents** as PR verdicts.
+- `fleet:needs-opus-recheck` — owned by the **sonnet-reviewer**.
+  Stamped *instead of* a verdict label when a first-pass review
+  approves but ends `Opus recheck required:`. This is the durable
+  signal the scout's `project_opus_reviewer` wakes the opus-reviewer
+  pane on — the review-body text alone is invisible to the trigger
+  projection, so before this label the opus pane only woke
+  coincidentally on another PR's `fleet:has-nits` / `fleet:needs-fix`
+  transition (PR #1473 sat un-rechecked for exactly this reason).
+  Cleared by the **opus-reviewer** as part of its verdict label-swap,
+  whatever the verdict (approve consumes the escalation; needs-fix /
+  blocker also clear it and hand the PR back to the
+  author → sonnet-reviewer cycle). Gated by the standard review-skip
+  labels — dormant while a PR is `fleet:semantic-conflict` / `wip` /
+  amending, then re-activates once the PR is reviewable again. Don't
+  add to issues.
 - `fleet:needs-linux-smoke` / `fleet:needs-macos-smoke` / `fleet:needs-windows-smoke` — owned by the
   **reviewer agents**, added after the verdict to request a cross-host
   build + run validation. `fleet:needs-windows-smoke` is cleared by

--- a/docs/agents/REVIEWER-PROTOCOL.md
+++ b/docs/agents/REVIEWER-PROTOCOL.md
@@ -134,7 +134,7 @@ queue. After every `gh pr review --comment ...`, your VERY NEXT bash
 calls MUST be the split remove + add + verify sequence below.
 
 Always remove stale verdict labels before adding the new one. Each
-verdict also clears three derived-state labels so a single verdict
+verdict also clears four derived-state labels so a single verdict
 re-evaluation cleans them up:
 
 - `fleet:awaiting-upstream-review` — a previously-gated stacked PR
@@ -145,6 +145,12 @@ re-evaluation cleans them up:
 - `fleet:needs-base-update` — set by the merger when a stacked child
   PR conflicted on rebase and needed manual resolution; cleared by
   the next review verdict once the author has resolved and pushed.
+- `fleet:needs-opus-recheck` — the opus-reviewer consumes its own
+  escalation the moment it posts any verdict (approve clears it;
+  needs-fix / blocker also clear it and hand the PR back to the
+  author → sonnet-reviewer cycle). For the sonnet-reviewer this
+  remove is a harmless no-op — it only ever ADDS this label in the
+  special case below, which sets no verdict and bypasses this swap.
 
 For game PRs, add `--repo <game-repo>` to each `gh pr edit` call.
 
@@ -158,22 +164,22 @@ feedback cluster — fix-002 in the fleet fix-log):
 
 ```
 # Verdict approve, no Nits section — removes first (absent OK), then add + verify:
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:needs-opus-recheck" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
 gh pr edit <N> --add-label "fleet:approved"
 gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:approved" || gh pr edit <N> --add-label "fleet:approved"
 
 # Verdict approve WITH a non-empty `### Nits` section (also set fleet:has-nits):
-gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:needs-opus-recheck" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
 gh pr edit <N> --add-label "fleet:approved" --add-label "fleet:has-nits"
 gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:approved" || gh pr edit <N> --add-label "fleet:approved"
 
 # Verdict needs-fix:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:needs-opus-recheck" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
 gh pr edit <N> --add-label "fleet:needs-fix"
 gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:needs-fix" || gh pr edit <N> --add-label "fleet:needs-fix"
 
 # Verdict blocker:
-gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
+gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:needs-opus-recheck" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" 2>/dev/null || true
 gh pr edit <N> --add-label "fleet:blocker"
 gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:blocker" || gh pr edit <N> --add-label "fleet:blocker"
 
@@ -183,10 +189,21 @@ gh pr edit <N> --remove-label "fleet:has-nits" 2>/dev/null || true
 ```
 
 **Sonnet-reviewer special case: verdict approve + "Opus recheck
-required"** → do NOT set any verdict label. Leave it unlabeled;
-opus-reviewer will set the final label on its next pass. (You still
-set `fleet:has-nits` here if there are nits, even without a verdict
-label.)
+required"** → do NOT set a verdict label (`fleet:approved` is the
+opus-reviewer's to set). Instead stamp the explicit escalation so the
+scout's opus-reviewer projection wakes the pane — the review-body text
+alone is invisible to that projection, so without this label the opus
+pane only fires coincidentally on another PR's has-nits/needs-fix
+transition (PR #1473 sat un-rechecked for exactly this reason):
+
+```
+gh pr edit <N> --add-label "fleet:needs-opus-recheck"
+gh pr view <N> --json labels --jq '[.labels[].name]' | grep -q "fleet:needs-opus-recheck" || gh pr edit <N> --add-label "fleet:needs-opus-recheck"
+```
+
+(You still set `fleet:has-nits` here if there are nits, even without a
+verdict label.) The opus-reviewer removes `fleet:needs-opus-recheck`
+as part of its own verdict label-swap, whatever verdict it reaches.
 
 The `review-pr` skill (invoked for engine single-task PRs by
 sonnet-reviewer) prescribes its own label-swap in step 5b — if you

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -107,6 +107,7 @@ LABELS=(
     "fleet:has-nits|fbca04|Approved but author should clean up nits before merge"
     "fleet:needs-fix|d73a4a|Reviewer agent flagged correctness/quality issues"
     "fleet:blocker|800010|Reviewer agent flagged a blocker; do not merge"
+    "fleet:needs-opus-recheck|1d76db|Sonnet first-pass review approved but ended 'Opus recheck required'; the explicit signal the scout projection wakes the opus-reviewer on. opus-reviewer removes it when its pass completes, whatever the verdict"
     "fleet:semantic-conflict|d73a4a|Merger hit non-mechanical conflict; opus-worker resolves or escalates"
     "fleet:merger-cooldown|bfdadc|Merger touched this PR; skip until next iteration"
     "fleet:design-blocked|fbca04|Worker escalated for architectural input mid-task; architect should respond"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -760,6 +760,21 @@ REVIEW_SKIP_LABELS = frozenset({
 REVIEW_SKIP_PREFIXES = ("fleet:amending-",)
 RECHECK_LABELS = frozenset({"human:re-review", "fleet:changes-made"})
 
+# Labels that wake the opus-reviewer pane. fleet:needs-opus-recheck is the
+# explicit escalation the sonnet-reviewer stamps when its first-pass review
+# approves but ends "Opus recheck required:" — that case sets NO verdict
+# label, so before this marker existed the projection had no label-shaped
+# signal for it and the opus pane only woke coincidentally on some OTHER PR's
+# has-nits/needs-fix transition. PR #1473 sat un-rechecked for exactly this
+# reason (approve + recheck-required + no nits → zero flag labels → no
+# trigger). has-nits / needs-fix stay in the set: they already woke the pane
+# and a flagged PR may still warrant an Opus pass. opus-reviewer removes
+# fleet:needs-opus-recheck as part of its verdict label-swap (whatever the
+# verdict), so a handled escalation drops back out of the projection.
+OPUS_REVIEWER_FLAG_LABELS = frozenset({
+    "fleet:has-nits", "fleet:needs-fix", "fleet:needs-opus-recheck",
+})
+
 
 def _review_skipped(labels):
     """True if a PR's label set bars reviewer pickup — exact-name skip
@@ -1035,17 +1050,16 @@ def project_sonnet_reviewer(state):
 
 
 def project_opus_reviewer(state):
-    flag_labels = frozenset({"fleet:has-nits", "fleet:needs-fix"})
     items = []
     for repo, repo_state in state["repos"].items():
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
             if _review_skipped(labels):
                 continue
-            if not (labels & flag_labels):
+            if not (labels & OPUS_REVIEWER_FLAG_LABELS):
                 continue
             items.append({"repo": repo, "pr": pr["number"],
-                          "labels": sorted(labels & flag_labels)})
+                          "labels": sorted(labels & OPUS_REVIEWER_FLAG_LABELS)})
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
@@ -1273,14 +1287,13 @@ def slice_sonnet_reviewer(state):
 
 
 def slice_opus_reviewer(state):
-    flag_labels = frozenset({"fleet:has-nits", "fleet:needs-fix"})
     out = {"flagged_prs": []}
     for repo_key, repo_state in state["repos"].items():
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
             if _review_skipped(labels):
                 continue
-            if not (labels & flag_labels):
+            if not (labels & OPUS_REVIEWER_FLAG_LABELS):
                 continue
             out["flagged_prs"].append(_slice_pr_with_repo(repo_key, pr))
     return out

--- a/scripts/fleet/tests/test_opus_reviewer_projection.py
+++ b/scripts/fleet/tests/test_opus_reviewer_projection.py
@@ -1,0 +1,165 @@
+"""Tests for project_opus_reviewer() / slice_opus_reviewer() in fleet-state-scout.
+
+The opus-reviewer pane is woken purely by the scout writing a trigger when
+this projection's hash flips. The regression these tests lock in:
+
+  fleet:needs-opus-recheck — the explicit escalation the sonnet-reviewer
+  stamps on an "approve + Opus recheck required" first pass — MUST be a
+  trigger signal. Before it was added (PR #1473), the projection keyed only
+  on fleet:has-nits / fleet:needs-fix, so an approve-and-escalate PR carried
+  no flag label, the hash never flipped, and the opus pane never woke for it
+  (it only fired coincidentally on some OTHER PR's has-nits/needs-fix
+  transition).
+
+This harness pins:
+  - needs-opus-recheck appearing flips the hash (wakes the pane).
+  - needs-opus-recheck on a PR with no other flag label still appears.
+  - has-nits / needs-fix remain trigger signals (no regression).
+  - skip labels (semantic-conflict, wip, amending-*) drop the PR entirely,
+    so the escalation lies dormant until the PR is reviewable again.
+  - removing the label (opus consumed it) drops the PR from the projection.
+  - the slice tags each flagged PR with its repo, across both repos.
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+project_opus_reviewer = _mod.project_opus_reviewer
+slice_opus_reviewer = _mod.slice_opus_reviewer
+stable_hash = _mod.stable_hash
+
+
+def _state(prs):
+    return {"repos": {"engine": {"prs": prs}}}
+
+
+def _state_eng_game(engine_prs, game_prs):
+    return {"repos": {"engine": {"prs": engine_prs},
+                      "game": {"prs": game_prs}}}
+
+
+def _pr(num, *, labels=None, mergeable="MERGEABLE", base="master",
+        head="claude/feat", author="bot"):
+    return {
+        "number": num,
+        "title": f"#{num}: feat",
+        "headRefName": head,
+        "baseRefName": base,
+        "labels": sorted(labels or []),
+        "mergeable": mergeable,
+        "author": author,
+    }
+
+
+def _hash(state):
+    return stable_hash(project_opus_reviewer(state))
+
+
+class RecheckLabelWakesPane(unittest.TestCase):
+    """The core fix: fleet:needs-opus-recheck must be a trigger signal."""
+
+    def test_recheck_label_appears_flips_hash(self):
+        before = _state([_pr(101, labels=[])])
+        after = _state([_pr(101, labels=["fleet:needs-opus-recheck"])])
+        self.assertNotEqual(_hash(before), _hash(after),
+                            "stamping fleet:needs-opus-recheck must wake the opus pane")
+
+    def test_recheck_only_pr_is_in_projection(self):
+        # The approve+recheck case: no verdict label, no nits — only the
+        # escalation. This is exactly the state PR #1473 was in.
+        items = project_opus_reviewer(_state([
+            _pr(101, labels=["fleet:needs-opus-recheck"]),
+        ]))
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["pr"], 101)
+        self.assertEqual(items[0]["labels"], ["fleet:needs-opus-recheck"])
+
+    def test_recheck_with_nits_is_in_projection(self):
+        items = project_opus_reviewer(_state([
+            _pr(101, labels=["fleet:has-nits", "fleet:needs-opus-recheck"]),
+        ]))
+        self.assertEqual(len(items), 1)
+        self.assertEqual(
+            items[0]["labels"],
+            ["fleet:has-nits", "fleet:needs-opus-recheck"],
+        )
+
+    def test_recheck_removed_drops_from_projection(self):
+        # opus-reviewer consumed the escalation and posted fleet:approved.
+        # The PR must drop out so the pane isn't re-woken for it.
+        items = project_opus_reviewer(_state([
+            _pr(101, labels=["fleet:approved"]),
+        ]))
+        self.assertEqual(items, [])
+
+
+class ExistingSignalsUnchanged(unittest.TestCase):
+    """has-nits / needs-fix must remain trigger signals (no regression)."""
+
+    def test_has_nits_still_triggers(self):
+        items = project_opus_reviewer(_state([
+            _pr(101, labels=["fleet:has-nits"]),
+        ]))
+        self.assertEqual(len(items), 1)
+
+    def test_needs_fix_still_triggers(self):
+        items = project_opus_reviewer(_state([
+            _pr(101, labels=["fleet:needs-fix"]),
+        ]))
+        self.assertEqual(len(items), 1)
+
+
+class SkipLabelsGateTheEscalation(unittest.TestCase):
+    """Skip labels drop the PR entirely so the recheck escalation lies
+    dormant while the PR is not reviewable, then re-activates."""
+
+    def test_semantic_conflict_drops_recheck_pr(self):
+        # PR #1473's live state: needs-opus-recheck would be set, but the
+        # merger re-applied fleet:semantic-conflict. The PR must NOT be in
+        # the opus projection until the conflict clears.
+        empty = _state([])
+        conflicted = _state([_pr(101, labels=[
+            "fleet:needs-opus-recheck", "fleet:semantic-conflict",
+        ])])
+        self.assertEqual(_hash(empty), _hash(conflicted),
+                        "a conflicted PR must be invisible to the opus pane")
+
+    def test_wip_drops_recheck_pr(self):
+        empty = _state([])
+        wip = _state([_pr(101, labels=[
+            "fleet:needs-opus-recheck", "fleet:wip",
+        ])])
+        self.assertEqual(_hash(empty), _hash(wip))
+
+    def test_amending_prefix_drops_recheck_pr(self):
+        empty = _state([])
+        amending = _state([_pr(101, labels=[
+            "fleet:needs-opus-recheck", "fleet:amending-mac-opus-worker-1",
+        ])])
+        self.assertEqual(_hash(empty), _hash(amending))
+
+
+class SliceTagsRepo(unittest.TestCase):
+    """The slice carries full PR records tagged with their repo."""
+
+    def test_slice_includes_recheck_pr_both_repos(self):
+        out = slice_opus_reviewer(_state_eng_game(
+            engine_prs=[_pr(101, labels=["fleet:needs-opus-recheck"])],
+            game_prs=[_pr(99, labels=["fleet:needs-opus-recheck"])],
+        ))
+        repos = sorted(pr["repo"] for pr in out["flagged_prs"])
+        self.assertEqual(repos, ["engine", "game"])
+
+    def test_slice_excludes_approved_pr(self):
+        out = slice_opus_reviewer(_state([_pr(101, labels=["fleet:approved"])]))
+        self.assertEqual(out["flagged_prs"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Makes the opus-reviewer pane reliably wake when a Sonnet first pass approves but requests an Opus recheck.
- **Root cause:** the scout's `project_opus_reviewer` keyed only on `fleet:has-nits` / `fleet:needs-fix`. The approve-and-escalate case sets *no* verdict label, so the projection hash never flipped, `triggers/opus-reviewer` was never written, and the pane only woke coincidentally on another PR's has-nits/needs-fix transition. Engine PR #1473 sat un-rechecked for exactly this reason.
- **Fix:** add `fleet:needs-opus-recheck` as the explicit escalation. sonnet-reviewer stamps it; the scout projects on it; opus-reviewer removes it on *any* verdict (approve consumes it; needs-fix hands the PR back to the author → sonnet cycle). Gated by the existing review-skip set, so it lies dormant under `fleet:semantic-conflict`/`wip`/amending and re-activates when the PR is reviewable.

## Changes
- `scripts/fleet/fleet-state-scout` — new `OPUS_REVIEWER_FLAG_LABELS`, used by `project_opus_reviewer` + `slice_opus_reviewer`.
- `scripts/fleet/fleet-labels` — catalog entry so the label exists on both repos (auto-created on `fleet-up`).
- `docs/agents/REVIEWER-PROTOCOL.md` — verdict label-swap removes it on every verdict; sonnet special-case now stamps it.
- `docs/agents/FLEET.md` / `docs/agents/FLEET-CACHE.md` — label dictionary entry + slice-keys row.
- `.claude/commands/role-sonnet-reviewer.md` / `role-opus-reviewer.md` — set / pick-up wiring.
- `scripts/fleet/tests/test_opus_reviewer_projection.py` — 11 new tests.

## Test plan
- [x] `python3 -m unittest test_opus_reviewer_projection` (11) + `test_merger_projection` (18) + worker/queue (39) all pass.
- [ ] Restart the scout (`fleet-down && fleet-up`) so the daemon loads the new projection; `fleet-up` runs `fleet-labels` to create the label on both repos.
- [ ] On the next approve+recheck PR, confirm `~/.fleet/state/triggers/opus-reviewer` is written and the opus pane wakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)