### PR TITLE
fleet: share skills via docs-baseline + queue-ingest Blocked-by gating

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -10,428 +10,58 @@ description: >-
   GitHub UI. NEVER commit directly to master.
 ---
 
-# commit-and-push
-
-Do **not** invoke proactively — only when the user explicitly asks.
-
-## Preconditions — do these before anything else
-
-1. **Confirm you are in your own worktree, not the shared main clone.** Run
-   `fleet-assert-worktree` (optionally with your worktree basename, e.g.
-   `fleet-assert-worktree opus-worker-2`). If it exits non-zero, STOP and
-   `cd` into your worktree (`…/.claude/worktrees/<name>/`) before doing
-   anything — a commit run from the shared main clone collides with other
-   agents on that checkout (engine #1325). Human-only override:
-   `FLEET_ALLOW_MAIN_CLONE=1`.
-2. **You must NOT be on `master`.** If `git rev-parse --abbrev-ref HEAD` reports
-   `master`, stop and warn the user. Branch off master first (see step 2 of
-   the flow) — do not commit to master. The old direct-push workflow is
-   retired.
-3. **`gh` must be authenticated.** If `gh auth status` fails, stop and ask the
-   user to run `gh auth login`.
-4. **The working tree must have something to commit.** If `git status` is
-   clean, tell the user and stop. Also check that the *staged* tree is
-   non-empty before calling `git commit` (step 6) — `git diff --cached
-   --quiet` exits 0 when nothing is staged; that is an empty-commit
-   situation that must be rejected with the error message in step 6.
-
-## Mode detection
-
-This skill has three modes. Detect at the start of the flow, in priority order:
-
-1. **Fleet stack mode** — caller has an active `fleet-claim` stack chain. PRs are chained by `--base` (one PR per task). Detected via `fleet-claim stack-pr-state <worktree>`. See [`procedures/fleet-stack.md`](procedures/fleet-stack.md) for the deltas (branch name with `<issue#>` prefix (`claude/<NNN>-<slug>`), `stack-base` lookup for `--base`, `Stack context` body block, `fleet:stacked` label, `stack-set-pr` after PR open).
-2. **Cursor stack mode** — current branch has `branch.<name>.cursor-stack-base` git config set (written by `start-next-task` when the human cued stacking). PRs target the parent branch instead of `master`. See [`procedures/cursor-stack.md`](procedures/cursor-stack.md) for the detection check, the `Stacked on:` body line, and the macOS sandbox note.
-3. **Single-task mode (default)** — neither stack signal above. The PR base is resolved via `fleet-claim claim-base <issue#>`: `master` for a normal claim (or a plain human PR), or the blocker's branch for an opportunistic `--stackable-on` claim — which then also gets the `fleet:stacked` label. See [`procedures/stackable-on.md`](procedures/stackable-on.md).
-
-The three modes are mutually exclusive and checked in the order above. In single-task mode, ignore `procedures/fleet-stack.md` and `procedures/cursor-stack.md`; `procedures/pr-body.md` still applies for the step 8 body template, and `procedures/stackable-on.md` covers the base + `fleet:stacked` resolution.
-
-## Flow
-
-### 1. Gather state (parallel)
-
-Run these in a single Bash-tool batch (one message, multiple tool calls):
-
-```
-git rev-parse --abbrev-ref HEAD
-git status
-git diff --stat && git diff
-git log --oneline -10
-```
-
-- The branch name tells you whether you're already on a feature branch or
-  still on master.
-- `git status` / `git diff` — understand **what** changed and **why** so you
-  can write the PR body.
-- `git log --oneline -10` — match the tone of recent titles.
-
-### 2. Ensure you're on a feature branch
-
-If you're on `master`:
-
-- Derive a short, kebab-case branch name from the session's work. Examples:
-  `claude/render-iso-culling-fix`, `claude/game-ant-pheromone-trails`,
-  `claude/engine-entity-batch-cleanup`. Prefer prefix `claude/<area>-<topic>`.
-- Create the branch **before** staging so the commits land there:
-  ```bash
-  git checkout -b claude/<area>-<topic>
-  ```
-- **In fleet stack mode** (see [`procedures/fleet-stack.md`](procedures/fleet-stack.md)): use
-  `claude/<task-id>-<short-topic>` instead, and branch off the base
-  returned by `fleet-claim stack-base <agent> <task-id>` (which is
-  `master` for the first task in the chain, or the previous task's
-  branch for subsequent tasks):
-  ```bash
-  base=$(fleet-claim stack-base <agent> <task-id>)
-  git fetch origin "$base"
-  git checkout -b claude/<task-id>-<short-topic> "origin/$base"
-  ```
-
-If you're already on a feature branch, just use it. Do not rename mid-session.
-
-### 3. Pre-commit checks and `simplify`
-
-**First**, run the **Rebase guard** check (full procedure: [`procedures/rebase-guard.md`](procedures/rebase-guard.md)): if you saved a pre-capture earlier in this conversation (a `git diff origin/master` snapshot before rebasing), compare it now against a fresh `git diff origin/master`. If you don't have that snapshot in context, check `git reflog --since=2.hours.ago` for a recent rebase entry; if found, warn and inspect manually before proceeding.
-
-**Second**, check whether the diff touches visual/render files:
-
-```bash
-git diff --name-only origin/master...HEAD
-```
-
-If the diff includes any file under `engine/render/`,
-`engine/prefabs/irreden/render/`, any `*.glsl` or `*.metal` file,
-`creations/demos/*/src/**`, or any `creations/demos/*/main*.cpp` —
-and `docs/pr-screenshots/<current-branch>/` does **not** yet exist —
-stop and prompt the worker to run the `attach-screenshots` skill
-before proceeding. Screenshots must ship in the
-same commit as the code change; a separate follow-up commit for screenshots
-is harder to review and misses the "before" baseline.
-
-Skip the prompt if:
-- The diff is purely docs, tests, mechanical refactors, or build/CI changes.
-- `docs/pr-screenshots/<branch>/` already contains screenshots from a prior
-  run on this branch.
-
-**Then**, run the cross-repo information-isolation check per
-`docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation":
-scan staged paths with `git diff --cached --name-only -- 'creations/game/'`
-and the PR body draft with the Grep tool for the game-leakage tokens
-listed there. Surface any match to the user before committing.
-
-**Then** invoke the `simplify` skill to review the dirty changes for reuse,
-quality, and efficiency issues specific to Irreden Engine:
-
-```
-Skill: simplify
-```
-
-`simplify` reads the same diff you gathered and looks for things like
-per-entity `getComponent` inside system ticks, duplicated helpers, naming-
-convention slips, and other project-specific smells. It dispatches a
-parallel reuse-detection subagent fan-out (five scanners running
-concurrently) and surfaces an aggregated reuse-findings block alongside
-its main findings. It applies fixes directly.
-
-**Always run simplify, regardless of file types.** No "doc-only"
-or "small change" carve-out. The skill has a doc-side section
-(stale cross-references, change-narration prose, drifted examples,
-section drift) that earns its keep on markdown-heavy diffs too —
-exactly the failure mode that produced the wrong macOS smoke
-label on PR #319 (a stale cross-reference between the role doc
-and the actual host the author was on).
-
-After `simplify` finishes:
-
-- Re-run `git status` / `git diff --stat` to see the post-simplify state.
-- If `simplify` reported findings it **couldn't** fix automatically, surface
-  them to the user before committing and ask whether to proceed.
-- If the working tree is now clean, stop and report — nothing to commit.
-
-> **Autonomous-fleet guardrail (post-simplify boundary):** After processing
-> the simplify results above, your VERY NEXT action must be a **tool call**
-> — either advancing to step 4 (draft commit message) or confirming the
-> clean-tree stop (nothing to commit). Do not emit only prose summarizing
-> simplify's output and end the turn without a tool call. Phrases like
-> "Returning to commit-and-push" or "Clean pass — continuing…" without an
-> immediate following tool call are the signal you are about to drop the
-> flow. If you catch yourself writing them, issue the tool call instead —
-> the prose is redundant, the tool call is what matters.
-
-### 4. Draft the commit message
-
-Shape:
-
-```
-<area>: <one-line overview of what this slice accomplished>
-
-<1–3 short paragraphs describing the *why* and the non-obvious *what*.
-Group related edits. Mention each major subsystem touched. Skip things
-obvious from filenames.>
-
-<If the session unearthed build/runtime gotchas worth remembering, note
-them here so the commit doubles as a changelog entry.>
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
-
-If the work is entirely inside a subdirectory with its own `CLAUDE.md`
-that specifies a different commit-message shape (e.g. a private creation
-with its own conventions), prefer the subdirectory's shape over this
-default. Read the nearest `CLAUDE.md` before drafting.
-
-**Rules:**
-
-- Title ≤ 72 chars, lowercase, no trailing period.
-- Prefer a scope prefix (`render:`, `engine/voxel:`, `game/nav:`, `build:`,
-  `docs:`) derived from the dominant changed path.
-- Body wraps at ~72 chars per line.
-- Describe *why* over *what*.
-- Always include the `Co-Authored-By` trailer; the harness system prompt specifies the exact form with the current model version.
-
-### 5. Stage files
-
-Add specific paths. **Never** use `git add -A` or `git add .`:
-
-```
-git add <path1> <path2> ...
-```
-
-**Exclusions — never stage these unless the user explicitly asks:**
-
-- `.claude/worktrees/` and `.claude/settings.local.json` — worktree/session state.
-- `.vscode/*` unless the user asked for IDE changes.
-- Anything secret-shaped: `.env*`, `credentials*`, `*_key`, `*.pem`, `save_files/`, `build/`.
-- Large binaries or generated assets unless explicitly requested.
-- Anything under `creations/` that is gitignored by the root `.gitignore` — those are private per-implementation projects that may live in their own repos. If the user is actually working inside one of those private creations, the skill still applies but runs against that creation's own git repo / own remote; do not try to commit it into the engine repo from a worktree that doesn't own the files.
-
-If the diff includes any of the above, warn the user before committing.
-
-### 6. Create the commit
-
-**Empty-commit guard (run before every `git commit` call):** An empty
-staged tree produces a misleading commit — it leaves provenance evidence
-(a task-titled commit) with no real diff. Reject it explicitly:
-
-```bash
-if git diff --cached --quiet; then
-    echo "commit-and-push: refusing to commit — no staged changes." >&2
-    echo "Either stage real work (git add <files>) or release the claim" >&2
-    echo "(fleet-claim release <task-id>) and exit." >&2
-    exit 1
-fi
-```
-
-On fleet branches (`claude/<NNN>-*`), the error is especially important —
-an empty commit there leaves misleading task provenance in the repo. If
-`simplify` or `optimize` stripped every changed line, stop and investigate
-before proceeding.
-
-Pass the message via HEREDOC:
-
-```bash
-git commit -m "$(cat <<'EOF'
-render: match cpu/gpu iso culling bounds
-
-Stage-1 compute was over-culling near the left edge because the cpu-side
-visibleIsoViewport used the raw camera pos while the gpu used the
-trixel-offset-corrected one. Align both to the offset-corrected form.
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-EOF
-)"
-```
-
-If the commit fails due to a pre-commit hook, **do not** `--amend`. Fix the
-underlying issue, re-stage, and create a **new** commit.
-
-### 7. Push the feature branch
-
-```
-git push -u origin HEAD
-```
-
-`-u` sets upstream on the first push of a new branch; on subsequent pushes,
-plain `git push` works.
-
-### 8. Open the PR
-
-Use `gh pr create`. Body template per mode: [`procedures/pr-body.md`](procedures/pr-body.md).
-
-> **Before calling `gh pr create` in any snippet below, complete step 8a (Closes# cross-check) if the drafted body contains a `Closes #N` line.**
-
-For the **single-task flow** (default), resolve the base via `fleet-claim claim-base` — `master` for a normal claim or a plain human PR (the common case, shown below), or the blocker's branch for a `--stackable-on` claim (which also gets `fleet:stacked`). The issue-number lookup, the idempotent edit-or-create (the fleet-worker WIP PR is usually already open from claim time), and the `Stacked on:` body line all live in [`procedures/stackable-on.md`](procedures/stackable-on.md). The common `master` case:
-
-```bash
-gh pr create --base master --title "<scope>: <title>" --body "$(cat <<'EOF'
-## Summary
-- <bullet>
-
-## Test plan
-- [ ] <check>
-
-Closes #<issue-N>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
-
-Title should match the commit title for a single commit; use a broader title
-for multi-commit PRs.
-
-**`Closes #N` line (required when the task has an `Issue:` field).** This is
-what makes GitHub auto-close the originating issue on merge. Omit the line
-only when the task's `Issue:` field is `(none)` — cleanup PRs, fleet-tooling
-PRs filed without a tracking issue, etc. See
-[`procedures/pr-body.md`](procedures/pr-body.md) for the full template and
-the stack-mode exceptions (cursor-stack non-leaf PRs deliberately drop it).
-
-**PR labels — `fleet:wip` (important):** For the **default Cursor /
-human-ready** single-PR open to `master`, **do not** pass
-`--label fleet:wip`. Fleet reviewers **skip** PRs labeled `fleet:wip`
-(see `role-sonnet-reviewer.md`). Use `fleet:wip` only in the **fleet
-worker** lane: task **claim** / early-work PRs until the author removes
-it for review pickup. Step **8b** below adds `fleet:authored-on-*`
-where appropriate — that is unrelated and still applies. The
-**Stack-aware** block still uses `fleet:wip` for stacked fleet-worker
-PRs; that is intentional for that workflow.
-
-**Fleet stack override:** when the current task is part of a
-`fleet-claim stack`, compute the base via `stack-base` and record the
-resulting PR via `stack-set-pr`. When `$base` is a feature branch
-(i.e. not `master`), also pass `--label "fleet:stacked"` so the merger
-can filter stacked PRs via label without an extra `gh pr view --json
-baseRefName` call per candidate. Body adds a `## Stack context` block —
-see [`procedures/pr-body.md`](procedures/pr-body.md) fleet stack mode:
-
-```bash
-base=$(fleet-claim stack-base <agent> <task-id>)
-labels=(--label "fleet:wip")
-if [[ "$base" != "master" ]]; then
-    labels+=(--label "fleet:stacked")
-fi
-pr_url=$(gh pr create --base "$base" \
-    --title "T-<NNN>: <short title>" \
-    --body "$(cat <<'EOF'
-<fleet stack body — see procedures/pr-body.md fleet stack mode>
-EOF
-)" "${labels[@]}")
-fleet-claim stack-set-pr <agent> <task-id> "$(git branch --show-current)" "$pr_url"
-```
-
-**Cursor stack override:** when the current branch has a
-`cursor-stack-base` git config set (see [`procedures/cursor-stack.md`](procedures/cursor-stack.md)
-for the detection rule and full deltas), use that as the PR base instead of
-`master`. No `fleet-claim` calls and no `fleet:stacked` label. Body adds a
-`## Stack context` block — see [`procedures/pr-body.md`](procedures/pr-body.md)
-cursor stack mode:
-
-```bash
-parent_branch=$(git config --get branch."$(git branch --show-current)".cursor-stack-base)
-if [[ -n "$parent_branch" ]]; then
-    parent_pr_url=$(gh pr list --head "$parent_branch" --state all \
-        --json url -q '.[0].url' --limit 1)
-    parent_pr_ref="${parent_pr_url:-$parent_branch (no PR yet)}"
-    gh pr create --base "$parent_branch" \
-        --title "<scope>: <title>" \
-        --body "$(cat <<EOF
-<cursor stack body — see procedures/pr-body.md cursor stack mode; substitute $parent_pr_ref>
-EOF
-)"
-fi
-```
-
-### 8a. Cross-check `Closes #N` before PR creation
-
-When the PR body includes a `Closes #N` line, run this cross-check **before**
-calling `gh pr create`. It catches the class of error where the worker writes
-the wrong issue number, causing GitHub to auto-close an unrelated issue on merge.
-
-```bash
-closes_n="<N from the drafted body>"
-issue_title=$(gh issue view "$closes_n" --repo jakildev/IrredenEngine \
-    --json title --jq '.title' 2>/dev/null || echo "")
-```
-
-Tokenize both strings: lowercase, strip punctuation, remove stop words
-(`a`, `an`, `the`, `for`, `of`, `in`, `to`, `at`, `on`, `and`, `or`,
-`not`, `is`, `via`, `from`, `with`, `add`, `—`, `-`). Intersect the
-remaining word sets against the PR title + branch name + first commit line.
-
-If the intersection is **empty**, surface this warning. In interactive
-mode (Cursor / human-in-the-loop), pause for human acknowledgement. In
-autonomous mode (fleet worker / author role), log the warning prominently
-and verify the issue number independently before proceeding:
-
-```
-⚠️  Closes-crosscheck: issue #<N> title is:
-      "<issue title>"
-    This PR's scope appears to be:
-      "<PR title>"
-    Zero keyword overlap — verify the issue number is correct.
-    (Non-blocking: proceed only if the number is intentional.)
-```
-
-The check is non-blocking. If the worker has confirmed the number is
-correct (e.g. the PR deliberately closes an umbrella or tracking issue
-whose title differs from the implementation PR title), proceed after
-acknowledgement.
-
-Skip this check only when:
-- The PR body has no `Closes #N` line (cleanup PRs, fleet-tooling PRs
-  filed without a tracking issue).
-- You are the queue-manager role (maintenance-sync PRs use `Closes #` for
-  task rows, not GitHub issues — the queue-manager is exempt because its
-  `Closes #` semantics differ from the standard flow).
-
-**Incident note (2026-05):** PR #1212 (T-379 PARALLEL_FOR bulk migration)
-shipped with `Closes #1215` instead of `Closes #1196`. GitHub auto-closed
-an unrelated issue (#1215)
-and left the correct issue (#1196) open for re-claiming. This cross-check
-catches that class of error before the PR is created.
-
-### 8b. Tag the host the PR was authored on
-
-See [`procedures/host-label.md`](procedures/host-label.md) for the shell snippet and scope rules (applies to all PRs; Windows-native authors skip the label).
-
-### 9. Report the result
-
-**Fix-push convention:** if you are calling commit-and-push to push a
-fix in response to `fleet:needs-fix` feedback, add `fleet:changes-made`
-to the PR after the push so the reviewer knows new commits arrived and
-should re-verify. Your role file's feedback-fix flow handles the
-`fleet:changes-made` label step; check that step and do not skip it.
-Without `fleet:changes-made`, the reviewer has no signal to pick the
-PR back up and re-review.
-
-Reply with a compact summary:
-
-- The branch name you pushed.
-- The PR URL returned by `gh pr create`.
-- The list of files that went into the commit(s).
-- Confirmation that push + PR both succeeded.
-- Any files you intentionally did **not** stage (and why).
-
-**Do not** start new work in the same worktree after opening the PR. The
-`start-next-task` skill handles resetting the worktree to a fresh branch off
-master for the next chunk — tell the user to invoke it (or invoke it yourself
-if the user already asked for the next task).
-
-## Anti-patterns
-
-- Amending a previous commit without being asked.
-- Leaking game references into an engine PR — see `docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation".
-
-## Recovery
-
-If the working tree has changes that clearly weren't made during this
-session (e.g. a half-finished refactor in an unrelated file), ask the user
-whether to include them before staging. When in doubt, stage only the files
-you know the session touched. **Do not `git stash` to "park" unrelated WIP** —
-selective `git add <path>` already leaves it untouched in place, and
-`refs/stash` is shared across all worktrees, so a positional `git stash pop`
-can silently apply another agent's stash into your tree (see
-`docs/agents/CLAUDE-BASELINE.md` §"Hard rules for autonomous fleet roles").
-
-If `gh pr create` fails because a PR already exists for the branch, report
-the existing PR URL and tell the user — don't try to force a new one.
+# commit-and-push (Irreden Engine)
+
+**The flow lives in [`docs/agents/skills/commit-and-push.md`](../../../docs/agents/skills/commit-and-push.md).**
+Read it first, then apply the engine deltas below. This wrapper carries
+deltas only — see [`docs/design/skill-sharing.md`](../../../docs/design/skill-sharing.md)
+for why. Do **not** invoke proactively — only when the user explicitly asks.
+
+## Deltas (Irreden Engine)
+
+| Delta key | Engine value |
+|---|---|
+| **repo** | `jakildev/IrredenEngine` |
+| **default branch** | `master` |
+| **remote** | `origin` |
+| **branch prefix** | `claude/` |
+| **worktree-assert command** | `fleet-assert-worktree` (e.g. `fleet-assert-worktree opus-worker-2`) |
+| **claim tool** | `fleet-claim` |
+| **simplify skill** | `simplify` (`Skill: simplify`) |
+| **scope vocabulary** | `render:`, `engine/voxel:`, `game/nav:`, `build:`, `docs:` — derive from the dominant changed path |
+| **visual-file globs** | `engine/render/`, `engine/prefabs/irreden/render/`, any `*.glsl` / `*.metal`, `creations/demos/*/src/**`, `creations/demos/*/main*.cpp` |
+| **screenshot skill** | `attach-screenshots` (output under `docs/pr-screenshots/<branch>/`) |
+| **info-isolation check** | [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §"Cross-repo information isolation" — scan staged paths with `git diff --cached --name-only -- 'creations/game/'` and the body draft for the game-leakage tokens listed there |
+| **co-author trailer** | `Co-Authored-By: Claude <noreply@anthropic.com>` (exact model-versioned form per the harness system prompt) |
+| **procedures** | the files in [`procedures/`](procedures/) beside this wrapper |
+
+## Engine procedures
+
+The shared flow's mode-detection and step-8 references resolve to these
+engine procedure files (unchanged — they carry the engine's `fleet-claim`,
+label, and host specifics). Where a procedure says "`SKILL.md` step N", read
+it as **step N of the shared flow** in
+[`docs/agents/skills/commit-and-push.md`](../../../docs/agents/skills/commit-and-push.md)
+(the step numbers are preserved); this wrapper is the entry point that points
+there.
+
+- [`procedures/fleet-stack.md`](procedures/fleet-stack.md) — fleet-claim
+  stack chain detection and `--base` chaining.
+- [`procedures/cursor-stack.md`](procedures/cursor-stack.md) — cursor-flow
+  stacking via `branch.<name>.cursor-stack-base`.
+- [`procedures/stackable-on.md`](procedures/stackable-on.md) — single-task
+  base resolution + `--stackable-on`.
+- [`procedures/pr-body.md`](procedures/pr-body.md) — PR body templates +
+  stack-mode deltas.
+- [`procedures/host-label.md`](procedures/host-label.md) — the
+  `fleet:authored-on-<host>` stamp.
+- [`procedures/rebase-guard.md`](procedures/rebase-guard.md) — the
+  pre-rebase diff-snapshot guard against silently-dropped hunks.
+
+## Engine notes
+
+- Step 3's screenshot prompt fires only when the diff matches a
+  **visual-file glob** and `docs/pr-screenshots/<branch>/` doesn't already
+  exist — that directory is the engine's screenshot output path.
+- Build/format helpers are `fleet-build` / `fleet-build --target
+  format-changed` (see [`docs/agents/BUILD.md`](../../../docs/agents/BUILD.md)).

--- a/.claude/skills/file-epic/SKILL.md
+++ b/.claude/skills/file-epic/SKILL.md
@@ -6,345 +6,41 @@ description: >-
   files at ~/.fleet/plans/issue-<N>.md, and post-filing stack validation.
 ---
 
-# file-epic
-
-Take an architect plan that covers a multi-ticket epic and file it as
-the fleet expects: umbrella issue labeled `fleet:epic`, one child
-`fleet:task` per phase, per-ticket plan files at
-`~/.fleet/plans/issue-<N>.md` so the queue-manager copies them into
-the repo on ingest.
-
-> **Placement (per #1312):** this skill is repo-tracked as a project
-> skill in each repo's `.claude/skills/file-epic/` — this is the engine
-> copy; the private game repo carries its own. It loads by cwd, exactly
-> like `commit-and-push` / `review-pr`. Edit the copy in the repo you're
-> filing for; keep the shared core in sync.
-
-## When to invoke
-
-- `/file-epic` (with the architect plan already approved and saved at
-  `~/.claude/plans/<slug>.md`)
-- "file the epic", "ship the epic", "open the tickets for this plan"
-- After ExitPlanMode returns with a plan that proposes multiple
-  follow-up tickets and the user says "proceed" / "go" / "ship it"
-
-Do not invoke before the user has approved the plan. The user gates
-the move from "plan in `~/.claude/plans/`" to "tickets in
-`~/.fleet/plans/` + GitHub".
-
-## Preconditions
-
-1. **Plan file exists** at `~/.claude/plans/<slug>.md` (or the user
-   names a path). Plan must include:
-   - A clear umbrella issue number to attach to (e.g. "engine #226").
-   - One section per child ticket with a title, model tag
-     (`[opus]` / `[sonnet]`), and acceptance criteria.
-   - A dependency chain.
-2. **`gh` authenticated.** Verify via `gh auth status`.
-3. **Repo identified.** Most epics target `jakildev/IrredenEngine`
-   (engine) or the private game repo (game). Confirm from the plan
-   header or ask the user once.
-
-## Flow
-
-### 1. Identify umbrella issue + target repo
-
-From the plan's "Context" section, extract:
-- Umbrella issue number (e.g. `#226`).
-- Target repo (e.g. `jakildev/IrredenEngine`).
-
-If either is ambiguous, ask the user once before proceeding.
-
-Confirm the umbrella exists and isn't already labeled `fleet:epic`:
-
-```bash
-gh issue view <N> --repo <repo> --json number,title,labels,state
-```
-
-If it's already labeled and has child issues filed (check by
-`gh issue list --repo <repo> --search "Part of epic: #<N>"`), STOP
-and report — the epic is already filed. Don't double-file.
-
-### 2. Save the umbrella plan
-
-Copy the architect plan to the fleet plans dir:
-
-```bash
-cp ~/.claude/plans/<slug>.md ~/.fleet/plans/issue-<N>.md
-```
-
-This is the worker-facing reference. The queue-manager will copy
-it into the repo as `.fleet/plans/T-<NNN>.md` when each child gets
-ingested, but the umbrella plan itself stays at the issue-<N>
-filename for the umbrella's lifetime.
-
-### 3. Apply `fleet:epic` to the umbrella
-
-```bash
-gh issue edit <N> --repo <repo> --add-label "fleet:epic"
-```
-
-`fleet:epic` tells the queue-manager to skip this issue (children
-ingest individually). The queue-manager also auto-closes the
-umbrella when all children close.
-
-### 4. Parse the plan's child-ticket sections
-
-For each section like `### T-XXX — <title> `[model]``, extract:
-- The descriptive title (drop the `T-XXX` prefix — that's the
-  architect's internal slug; GitHub assigns its own number, and
-  the queue-manager assigns the canonical `T-NNN` at ingest).
-- Model tag (`opus` / `sonnet`).
-- Scope, approach, acceptance criteria, dependencies, gotchas.
-
-### 5. File children sequentially (NOT in parallel)
-
-Sequential filing matters because:
-- GitHub assigns issue numbers in order. Later issues can reference
-  earlier ones by number in their bodies.
-- The dependency chain in the plan often has shape "T-222 blocked by
-  T-221". You can only write `Blocked by: #<actual N>` after the
-  earlier issue is filed.
-
-For each child:
-
-Write the issue body to a temp file first (avoids command-substitution and
-backtick hazards in the body text):
-
-```
-rm -f .file-epic-body.md
-[Write tool → .file-epic-body.md → content:]
-**Model:** <opus|sonnet>
-**Part of epic:** #<umbrella>
-**Plan file:** `~/.fleet/plans/issue-<umbrella>.md` (full epic plan)
-**Blocked by:** #<prior-child-number> (if applicable)
-
-## Scope
-<one paragraph>
-
-## Approach
-<bulleted approach>
-
-## Acceptance criteria
-<bulleted criteria>
-
-## Dependencies
-<what blocks this, what this blocks>
-
-## Gotchas
-<watchouts not obvious from the scope>
-
-## References
-<links to related design sections, prior PRs>
-```
-
-Then file:
-
-```bash
-gh issue create --repo <repo> --label "fleet:task" \
-  --title "<area>: <descriptive title> (T-<slug>)" \
-  --body-file .file-epic-body.md
-rm -f .file-epic-body.md
-```
-
-Title convention: `<area>: <descriptive title> (T-<slug>)`. The
-`(T-<slug>)` suffix preserves the architect's internal numbering for
-cross-reference; the queue-manager assigns the canonical `T-NNN`
-separately and renames the plan file at ingest.
-
-Capture the issue number that `gh` returns.
-
-### 6. Write per-ticket plan file
-
-After each child issue is filed, write
-`~/.fleet/plans/issue-<N>.md` (where `<N>` is the GitHub-assigned
-number, not the architect's slug):
-
-```markdown
-# Plan: <ticket title>
-
-- **Issue:** #<N>
-- **Model:** <opus|sonnet>
-- **Date:** <YYYY-MM-DD>
-- **Epic:** #<umbrella> — see \`~/.fleet/plans/issue-<umbrella>.md\` for full context
-- **Blocked by:** #<prior> (if applicable)
-
-## Scope
-<focused subset of the umbrella plan that applies to THIS ticket>
-
-## Affected files
-<bullet list of file paths the implementer will touch>
-
-## Approach
-<more detail than the issue body — the issue is for discussion,
-this is the implementation guide>
-
-## Acceptance criteria
-<concrete, testable>
-
-## Gotchas
-<watchouts that need code-aware framing>
-
-## Verification
-<what to build, what to run, what passes>
-```
-
-The per-ticket plan adds **implementation detail beyond the issue
-body**. Don't duplicate — point at the umbrella plan for arch
-context, then add the file paths, code-level approach, and
-verification steps.
-
-### 7. Post the umbrella summary comment
-
-After all children are filed, write the summary comment body to a file
-first (avoids command-substitution and backtick hazards):
-
-```
-rm -f .file-epic-body.md
-[Write tool → .file-epic-body.md → content:]
-## Epic execution plan
-
-Architect plan filed: `~/.fleet/plans/issue-<umbrella>.md`.
-
-### Children — closing path
-
-| Phase | Ticket | Title | Model |
-|---|---|---|---|
-| 1 | #<id> | <title> | <opus/sonnet> |
-| ... | ... | ... | ... |
-
-### Independent follow-on (not gating)
-
-| Phase | Ticket | Title | Model |
-|---|---|---|---|
-| N | #<id> | <title> | opus |
-
-### Dependency chain
-
-```
-<ASCII dependency graph>
-```
-
-### Closing criteria
-
-<from the plan>
-
-### Shape changes from the original phasing
-
-<deltas explained, if the architect plan made any>
-
-Tickets ready for `human:approved` triage on individual basis.
-```
-
-Then post:
-
-```bash
-gh issue comment <umbrella> --repo <repo> --body-file .file-epic-body.md
-rm -f .file-epic-body.md
-```
-
-The summary comment is the single source of truth linking the
-umbrella to its children. Without it, navigating from #226 to
-#1067-#1073 requires GitHub's "Linked issues" sidebar, which only
-fills in when each child explicitly references the umbrella.
-
-### 7.5. Validate filed bodies (STOP on failure)
-
-Before reporting success, assert every child carries the structured
-fields the queue machinery actually reads — a standalone
-`**Model:** opus|sonnet` line, a standalone `**Part of epic:**
-#<umbrella>` line, and (for every non-head child) a standalone
-`**Blocked by:** #N` line (one or more `#N` refs). The `fleet-validate-stack`
-helper (shipped #1317) checks exactly this, auto-discovers the
-children, and fails loudly:
-
-```bash
-fleet-validate-stack <umbrella>              # engine
-fleet-validate-stack <umbrella> --repo game  # game repo
-```
-
-If it exits **non-zero, STOP — do not proceed to step 8.** It prints
-each malformed child; patch the offending issue bodies (`gh issue
-edit <N> --body-file ...`) or re-file, then re-run until it passes.
-
-Never report success on a stack the validator rejects. A prose-only
-`Blocked on ...` header is read only as a *fallback* (#1326); the
-canonical standalone `**Blocked by:** #N` line is what file-epic's
-`--search "Part of epic: #N"` discovery relies on, so the validator
-still wants it. Multiple blockers are fine (`#A, #B` on one line or
-several `**Blocked by:**` lines; #1296). This is the belt that the
-hand-filing convention (step 5) is the suspenders for.
-
-### 8. Report
-
-Reply with:
-
-- Umbrella issue URL + the `fleet:epic` label confirmation.
-- A list of child issue URLs.
-- The path to the umbrella plan file.
-- Per-ticket plan file paths (e.g.
-  `~/.fleet/plans/issue-1067.md ... issue-1073.md`).
-- The `fleet-validate-stack` result (must be passing).
-- Anything the user still needs to do (typically: triage each child
-  individually with `human:approved`, since the queue-manager won't
-  auto-approve).
-
-## Anti-patterns
-
-- ❌ Filing children in parallel via concurrent `gh issue create`.
-  Breaks the "later issues reference earlier ones" pattern.
-- ❌ Forgetting the `fleet:epic` label on the umbrella. The
-  queue-manager would otherwise ingest the umbrella itself.
-- ❌ Putting `Blocked by:` in header prose ("**Blocked on T1 + docs
-  PR #1306**") instead of a standalone line. The scout and
-  `fleet-claim` parsers read **only** standalone `**Blocked by:** #N`
-  lines; header prose is invisible to the queue machinery. This is
-  the #1 hand-filing drift (#1300 / #1308–#1311 all hit it). Step 7.5
-  catches it — don't rely on catching it; write the standalone line.
-- ✅ Multiple blockers are supported (#1296): `**Blocked by:** #1299,
-  #1300` on one line, or several `**Blocked by:**` lines. The gate
-  unions every ref, and `find-stackable-blockers` live-resolves them —
-  stacking on the last unresolved ref as the upstreams merge. (Single
-  `#N` is still the simplest form when a child has just one blocker.)
-- ❌ Per-ticket plan files that duplicate the issue body verbatim.
-  The plan adds implementation detail (file paths, code-level
-  approach); the issue is the discussion surface.
-- ❌ Skipping the umbrella summary comment. Without it, the
-  cross-reference between umbrella and children isn't visible from
-  the umbrella's own conversation thread.
-- ❌ Filing an epic for changes that are really one ticket. If the
-  scope fits in one PR, file one issue, not seven.
-- ❌ Inline-creating plan files for the umbrella. Always copy from
-  `~/.claude/plans/`, never re-author. The architect plan is the
-  canonical source.
-
-## Engine-repo vs game-repo
-
-The skill is repo-neutral — pass `--repo <owner>/<repo>` consistently
-or read it from the plan header. Cross-repo info-isolation rule
-applies: engine artifacts must not reference the private game repo by
-name or feature. If the architect plan was authored from a game-repo
-session and mentions game-specific features, scrub them from the
-engine child issues before filing.
-
-## Plan file lifecycle
-
-| Location | Purpose | Lifecycle |
-|---|---|---|
-| `~/.claude/plans/<slug>.md` | Architect's draft. Created in plan mode, approved by user. | Session-local; can be archived after epic ships. |
-| `~/.fleet/plans/issue-<N>.md` | Worker-facing plan. Either umbrella or per-ticket. | Persists. Queue-manager copies per-ticket files into the repo at ingest. |
-| `<repo>/.fleet/plans/T-<NNN>.md` | Final repo-side plan. Renamed by queue-manager at ingest time. | Lives in the repo until the ticket closes. |
-
-## When the architect plan is rough
-
-If the architect plan is missing per-ticket detail (just an umbrella
-sketch + "we'll figure out the children later"), STOP and ask the
-user whether to:
-
-1. Send the plan back for refinement (default — incomplete plans
-   produce thin tickets that get bounced).
-2. File a placeholder umbrella + one child per gap, with bodies that
-   say "scope TBD; plan refinement in flight".
-
-Don't file thin tickets without confirming. Worker-facing surfaces
-that get bounced for "not enough info to start" waste the queue.
+# file-epic (Irreden Engine)
+
+**The flow lives in [`docs/agents/skills/file-epic.md`](../../../docs/agents/skills/file-epic.md).**
+Read it first, then apply the engine deltas below. This wrapper carries
+deltas only — see [`docs/design/skill-sharing.md`](../../../docs/design/skill-sharing.md)
+for why.
+
+> **Placement (per #1312):** this skill is repo-tracked as a project skill
+> in each repo's `.claude/skills/file-epic/`. It loads by cwd, exactly like
+> `commit-and-push` / `review-pr`. The shared *flow* is now single-sourced
+> in `docs/agents/skills/file-epic.md`; only the deltas below are per-repo,
+> so the engine and game wrappers can no longer drift on the flow itself.
+
+## Deltas (Irreden Engine)
+
+| Delta key | Engine value |
+|---|---|
+| **repo** | `jakildev/IrredenEngine` (engine); pass `--repo game` for `jakildev/irreden` |
+| **epic label** | `fleet:epic` |
+| **task label** | `fleet:task` |
+| **architect plans dir** | `~/.claude/plans/<slug>.md` |
+| **plans dir** | `~/.fleet/plans/issue-<N>.md` |
+| **repo-side plan path** | `<repo>/.fleet/plans/T-<NNN>.md` |
+| **validate-stack command** | `fleet-validate-stack <umbrella>` (add `--repo game` for the game repo) |
+| **title area vocabulary** | `engine`, `render`, `engine/voxel`, `game`, etc. (the same scope vocabulary `commit-and-push` uses) |
+
+## Engine notes
+
+- The `fleet-validate-stack` helper (shipped #1317) is the **validate-stack
+  command**; it auto-discovers children and fails loudly on a malformed
+  body. It is the belt that the step-5 hand-filing convention is the
+  suspenders for.
+- Engine-repo vs game-repo: most epics target `jakildev/IrredenEngine`.
+  The cross-repo info-isolation rule (see
+  [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md)
+  §"Cross-repo information isolation") means engine child issues must not
+  reference the private game repo by name or feature; scrub a game-authored
+  plan before filing engine children.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -13,207 +13,33 @@ description: >-
   tests, and project-specific smells, then posts it as a PR comment.
 ---
 
-# review-pr
+# review-pr (Irreden Engine)
 
-**Trigger from a persistent reviewer-loop session**, where the session's
-own launch prompt told it to poll `gh pr list` on an interval and review
-anything new. In that mode the reviewer agent resolves the set of unreviewed
-PRs itself and invokes this skill once per PR without the user typing a fresh
-phrase each time. The loop pattern is documented in `docs/agents/FLEET.md`.
+**The flow lives in [`docs/agents/skills/review-pr.md`](../../../docs/agents/skills/review-pr.md).**
+Read it first, then apply the engine deltas below — most importantly the
+**engine review checklist** (the shared flow's step 4) and the exact
+verdict-label swap commands (step 5b). See
+[`docs/design/skill-sharing.md`](../../../docs/design/skill-sharing.md) for why.
 
-Do **not** invoke proactively inside an unrelated working session — e.g. while
-an author-agent is mid-refactor on its own PR, don't auto-jump into reviewing
-a third-party PR you happen to notice. The bar is: either the user asked, or
-this session's whole job is to be a reviewer.
+## Deltas (Irreden Engine)
 
-## Model expectations (two-tier review)
+| Delta key | Engine value |
+|---|---|
+| **repo** | `jakildev/IrredenEngine` (inline comments: `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments`) |
+| **claim tool** | `fleet-claim` (bail release: `fleet-claim review-release <N> <worktree>`) |
+| **default branch** | `master` |
+| **review checklist** | the engine checklist below |
+| **smoke procedure** | [`procedures/cross-host-smoke.md`](procedures/cross-host-smoke.md) |
+| **re-review procedure** | [`procedures/re-review.md`](procedures/re-review.md) |
+| **stacked-review procedure** | [`procedures/stacked-pr-review.md`](procedures/stacked-pr-review.md) |
+| **fleet doc** | [`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) — "Model split" |
 
-This skill runs on either Sonnet or Opus. The two roles are different:
+## Engine review checklist (shared-flow step 4)
 
-- **Sonnet first pass** — cheap and fast, catches the 80% of issues that
-  are style, obvious bugs, missing null checks, naming inconsistencies,
-  untested branches. A Sonnet reviewer should be thorough on the
-  checklist below but explicitly call out "I am not confident on this
-  invariant, please Opus-review:" for anything that looks subtle
-  (lifetime, concurrency, an ECS invariant three systems deep, a GPU
-  buffer handoff, an ffmpeg/audio-thread interaction).
-- **Opus second pass (or sole pass)** — for any PR touching core engine
-  invariants (`engine/render/`, `engine/entity/`, `engine/system/`,
-  `engine/world/`, `engine/audio/`, `engine/video/`, `engine/math/`),
-  anything that looks performance-sensitive, any GPU/CPU sync, anything
-  concurrency-touching, or any PR where the Sonnet first-pass review
-  flagged an Opus escalation. Opus also confirms that earlier Sonnet
-  nits were properly addressed.
+Go through each explicitly. For every item, confirm compliance or raise an
+issue.
 
-When running as Sonnet: finish the review, then in the verdict summary
-mention whether Opus escalation is needed. When running as Opus on a PR
-that already has a Sonnet review: read the Sonnet review first, treat
-it as a first pass, and focus on what Sonnet could not confirm. See
-[`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) "Model split" for the full split.
-
-## Preconditions
-
-1. `gh` authenticated (`gh auth status`).
-2. User supplied a PR number, PR URL, or said "latest" — resolve before starting.
-3. You are **not** the same agent that wrote the code. If the user is asking
-   the author agent to review its own work, warn them and offer to run the
-   review anyway with the caveat that author-agents have tunnel vision.
-
-## Flow
-
-### 1. Resolve the PR and pull its metadata
-
-Read author/human PR comments before walking the diff — they're how
-authors flag deliberate scope ("I deferred X to a follow-up") and how
-humans pre-flag concerns ("watch out for Y on macOS"). Missing them
-leads to reviews that re-raise points the author already addressed in
-conversation.
-
-```bash
-gh pr view <N> --json number,title,body,headRefName,baseRefName,author,files,additions,deletions,commits,mergeable,comments,reviews,labels
-gh api repos/jakildev/IrredenEngine/pulls/<N>/comments
-```
-
-The first command returns issue-level comments (`comments`) and review
-summaries (`reviews`), and also the live label set (`labels`) used for
-the bail check in step 1b. The second returns inline code-review comments
-(line-attached) — `gh pr view --json` does not include these. Together
-the two commands cover every kind of PR conversation.
-
-`gh pr diff <N>` is fetched **after** the label bail check in step 1b —
-not here — so bail-label PRs never pay the diff round-trip cost.
-
-If the user said "latest" / "most recent":
-
-```bash
-gh pr list --state open --limit 5
-```
-
-Pick the top result, confirm the title with the user if there's ambiguity.
-
-### 1b. Label bail check + diff fetch
-
-**Before** fetching the diff or examining the branch, check the `labels` array
-from step 1's `gh pr view --json` result for any bail labels. This prevents a
-diff round-trip on PRs that are not reviewable:
-
-- `fleet:semantic-conflict` — merger has a conflict resolution in progress.
-- `fleet:merger-cooldown` — branch was just re-targeted or rebased and may be
-  in an unsettled state.
-- `fleet:wip` — author marked the PR not-ready after the cache snapshot.
-- `human:wip` — human marked the PR not-ready after the cache snapshot.
-- any `fleet:amending-*` label — an author acquired the amend claim (started
-  fixing `fleet:needs-fix`) after the cache snapshot; the diff is mid-rewrite.
-  It re-enters with `fleet:changes-made` once released.
-
-If any bail label is present, release the claim and skip this PR without
-fetching the diff or posting any comment:
-
-```bash
-fleet-claim review-release <N> <your-worktree-name>
-```
-
-If none of the bail labels are present, fetch the diff now:
-
-```bash
-gh pr diff <N>
-```
-
-### 1c. Check whether the PR is stacked
-
-Every fleet PR today is single-task. Some are stacked: their `--base` is another open PR's branch rather than `master`. The review pass is still per-PR; you don't re-review the parent.
-
-**Quick detection** (from the metadata fetched in step 1):
-- `baseRefName != "master"` → stacked on that branch.
-- Body contains `Stacked on:` line → confirms it; gives the parent PR URL.
-
-If stacked: see [`procedures/stacked-pr-review.md`](procedures/stacked-pr-review.md) for the per-PR scoping rules, the body callout format, and the upstream-fragility flag — then return here for step 1d.
-
-If standalone (base `master`, no `Stacked on:`): continue with step 1d.
-
-### 1d. Churn audit when `mergeable == CONFLICTING`
-
-A PR in `CONFLICTING` state has a stale branch relative to `master`.
-A stale branch can silently carry reverted hunks — content that landed
-on `master` after the PR branch was cut but isn't reflected in the PR
-body because the author never rebased. `gh pr diff --stat` makes the
-actual scope visible before any code-path review.
-
-**When `mergeable` is `CONFLICTING`**, run:
-
-```bash
-gh pr diff <N> --stat
-```
-
-Apply two checks to the stat output:
-
-1. **Oversized churn** — any file with ≥100 added + deleted lines that
-   the PR body does not explicitly mention. Flag as **Needs-fix** (escalate
-   to **Blocker** if the churn includes deleted functions or files that
-   would break the build): the PR may be silently reverting work that
-   landed on master after the branch was cut. Classic pattern: a file
-   with 200+ line deletions in a PR that never claimed to touch it
-   (e.g. `system_compute_light_volume.hpp` appearing in a PR scoped to
-   12 other system files).
-2. **Out-of-scope file** — any file that appears in the stat output but
-   is neither described in the PR body nor a known mechanical side-effect
-   of the PR's claimed scope (e.g. a `CMakeLists.txt` accompanying a new
-   source file — not `.fleet/plans/` drift or unrelated docs).
-   Flag as **Needs-fix**: author must acknowledge the file in the PR
-   body or rebase to drop the accidental hunk.
-
-If neither check fires, note in the review body:
-> "CONFLICTING state checked — `gh pr diff --stat` shows no out-of-scope
-> files or oversized churn."
-
-If `mergeable` is anything other than `CONFLICTING`, skip this step.
-
-### 2. Check out the PR branch locally (read-only)
-
-```bash
-gh pr checkout <N>
-```
-
-This puts the reviewer worktree on the PR's head branch. You still have full
-read access to the rest of the repo for cross-reference. Do **not** commit or
-push from this worktree — you are a reader, not a writer.
-
-### 3. Read the diff in context
-
-For each changed file:
-
-- Read the **full file**, not just the diff hunks. ECS and render bugs often
-  hide in the surrounding code.
-- Cross-reference any component or system name against
-  `engine/prefabs/irreden/**/components/` and `**/systems/` to make sure the
-  change honors existing conventions.
-- If a shader changed, also read the CPU-side frame-data struct that feeds
-  it (GLSL layouts and C++ structs in `engine/render/include/irreden/render/`
-  must stay in sync).
-
-Keep a running mental list of issues, ranked by severity. The
-boundary between **blocker** and **needs-fix** is the question
-"would master survive this merge?" — if no, blocker; if yes-but-
-worse, needs-fix.
-
-- **Blocker** — master build breaks, the demo crashes/hangs, or data
-  on disk is corrupted if this lands. The PR is unmergeable as-is —
-  the human cannot ship it without a fix.
-- **Needs-fix** — the PR could compile and run on master, but
-  introduces a correctness or performance regression that must be
-  repaired before merge. Master survives, but in a worse state than
-  it should be.
-- **Nit** — style, naming, minor simplification, docs. Truly
-  optional; the PR may merge without addressing.
-- **Praise** — non-obvious good decision worth calling out so the
-  author-agent keeps doing it.
-
-### 4. Apply the Irreden-Engine-specific review checklist
-
-Go through each of these explicitly. For every item, either confirm
-compliance or raise an issue.
-
-**ECS invariants** — check against [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md). For each item, confirm compliance or raise an issue.
+**ECS invariants** — check against [`.claude/rules/cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md).
 
 **Ownership / lifetime**
 - `shared_ptr` where `unique_ptr` would do.
@@ -222,8 +48,8 @@ compliance or raise an issue.
   archetype changes invalidate addresses.
 - Capturing `this` or references to World managers in lambdas that outlive
   the World (e.g. lua callbacks registered before World teardown).
-- Stored `g_*Manager` pointer or reference in any object whose lifetime
-  can outlive `World` (background threads, sol2 callback closures, long-lived
+- Stored `g_*Manager` pointer or reference in any object whose lifetime can
+  outlive `World` (background threads, sol2 callback closures, long-lived
   caches) — see `engine/world/CLAUDE.md` and `engine/CLAUDE.md`.
 
 **Render pipeline**
@@ -232,23 +58,23 @@ compliance or raise an issue.
   bytes; members crossing a 16-byte boundary need `alignas(16)`. If either
   the C++ struct (in `engine/render/include/irreden/render/`) or its shader
   `uniform` block changed, cross-reference both sides.
-- shader references `binding = N` but the C++ `kBufferIndex_*` constant
-  was not updated — the mismatch is silent (wrong uniforms, no error).
-  Confirm every bind-point index agrees on both sides.
+- shader references `binding = N` but the C++ `kBufferIndex_*` constant was
+  not updated — the mismatch is silent. Confirm every bind-point index
+  agrees on both sides.
 - New shader file not following the `c_` / `v_` / `f_` / `g_` prefix.
 - Canvas allocation before the canvas entity exists.
 - Compute dispatch size doesn't match `voxelDispatchGridForCount()`.
-- new `*.glsl` added without a matching `*.metal` counterpart (if parity
-  is intentionally deferred, the PR body must acknowledge it and reference a
+- new `*.glsl` added without a matching `*.metal` counterpart (if parity is
+  intentionally deferred, the PR body must acknowledge it and reference a
   follow-up task).
 
 **Lighting** (if the diff touches `system_*ao*`, `system_*shadow*`,
-`system_*flood*`, `system_*fog*`, `system_build_light_occlusion_grid*`,
-or any `c_compute_*shadow*.glsl` / `.metal`)
-- Check 1 (grid coverage): `system_build_light_occlusion_grid.hpp`
-  iterates the full voxel pool — it does **not** include
-  `cull_viewport_state.hpp` and does not call `visibleIsoViewport`.
-  Off-screen geometry participates in lighting by design.
+`system_*flood*`, `system_*fog*`, `system_build_light_occlusion_grid*`, or
+any `c_compute_*shadow*.glsl` / `.metal`)
+- Check 1 (grid coverage): `system_build_light_occlusion_grid.hpp` iterates
+  the full voxel pool — it does **not** include `cull_viewport_state.hpp`
+  and does not call `visibleIsoViewport`. Off-screen geometry participates
+  in lighting by design.
 - Check 2 (shadow-ring extent): if chunk streaming is involved, the
   resident-chunk set extends past the view frustum by
   `maxCasterHeight × cot(sunAltitude)` in the sun-projection direction.
@@ -266,242 +92,82 @@ or any `c_compute_*shadow*.glsl` / `.metal`)
 - PlaneIso axis swapped.
 
 **Serialization** (when the diff touches `engine/asset/`, `engine/prefabs/irreden/voxel/`, or `engine/world/`)
-- A struct annotated `// IRAsset: serialized` gained, lost, or renamed a field without
-  bumping `static constexpr uint16_t kSaveVersion = N;` in the same diff.
-  Fix: increment `kSaveVersion` and add a reader migration keyed on
-  `(structType, oldVersion)` in the format's load function. (Save Format Extensibility Rule #3.)
-- A new serialized record type with no `// IRAsset: serialized` annotation — the
-  simplify and review-pr checks cannot guard it without the annotation. Add the annotation
-  and set `kSaveVersion = 1` on the struct.
+- A struct annotated `// IRAsset: serialized` gained, lost, or renamed a
+  field without bumping `static constexpr uint16_t kSaveVersion = N;` in the
+  same diff. Fix: increment `kSaveVersion` and add a reader migration keyed
+  on `(structType, oldVersion)` in the format's load function. (Save Format
+  Extensibility Rule #3.)
+- A new serialized record type with no `// IRAsset: serialized` annotation —
+  the simplify and review-pr checks cannot guard it without the annotation.
+  Add the annotation and set `kSaveVersion = 1` on the struct.
 
-**Naming / style** — follow the table in [`docs/agents/CLAUDE-BASELINE.md`](../../docs/agents/CLAUDE-BASELINE.md) §Naming.
-- `m_` on public members, trailing `_` on private members (backwards — the single most common slip).
+**Naming / style** — follow the table in [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming.
+- `m_` on public members, trailing `_` on private members (backwards — the
+  single most common slip).
 
 **Tests / build**
 - Code change with no corresponding test change where a test existed.
 - New feature with no new test at all (flag as needs-fix unless the user
   explicitly said "no tests").
-- Build or format-check not run before opening the PR (check commit
-  message for mention, or run `fleet-build --target format-changed`
-  yourself if cheap).
+- Build or format-check not run before opening the PR (check the commit
+  message, or run `fleet-build --target format-changed` yourself if cheap).
 
 **Opus-only items** (Sonnet should not attempt these — escalate via the
 verdict footer if any of these surfaces are touched)
-
-Sonnet's single-file diff scan can't reliably catch these — they live
-multiple frames deep, span modules, or only manifest under specific
-scheduling. If the PR touches any of these surfaces, append
-`Opus recheck required: <one-line reason>` to the verdict footer.
-
-- **GPU buffer lifetime across frames.** Does an SSBO/UBO get bound on
-  frame N and read on frame N+1 without a fence or explicit double-
-  buffer swap? Async readback (compute → CPU mapped pointer) is
-  especially prone to use-after-free if the destination buffer is
-  recycled before the readback completes.
-- **Archetype-mutation race during structural-change deferral.** A
-  system that calls `addComponent` / `removeComponent` /
-  `removeEntity` mid-iteration must use the deferred variant. If it
-  touches the live archetype while a parallel system is iterating,
-  component addresses are invalidated silently. Confirm every
-  structural call inside a tick path goes through the deferred queue.
-- **Race between `flushStructuralChanges` and async GPU readback.**
-  The readback's destination buffer (or the entity it indexes) may
-  vanish if the structural flush runs first. Verify the readback's
-  lifetime is decoupled from any entity that `flushStructuralChanges`
-  could remove — either it indexes by stable ID, or it has its own
-  refcount.
-- **Allocator behavior in long-lived caches.** A cache that uses
-  `std::unordered_map<EntityId, T>` with a poorly-chosen hash, or a
-  `std::vector<T>` that's never shrunk, grows unbounded across
-  frames. Confirm the cache has an eviction path (entity-removed
-  hook, LRU cap, periodic compact) or a clear teardown order.
-- **Hot-path register pressure.** A per-entity tick that touches >8
-  components or carries >12 live local variables across a loop body
-  is approaching the architecture's register file. The compiler may
-  spill to memory; the cost is invisible until profiled. Flag any
-  tick path that grew significantly in number of locals or component
-  reads, especially in `engine/render/` or `engine/world/`.
+- **GPU buffer lifetime across frames.** An SSBO/UBO bound on frame N and
+  read on frame N+1 without a fence or explicit double-buffer swap; async
+  readback recycled before completion (use-after-free).
+- **Archetype-mutation race during structural-change deferral.** A tick that
+  calls `addComponent`/`removeComponent`/`removeEntity` must use the
+  deferred variant; touching the live archetype while a parallel system
+  iterates invalidates component addresses silently.
+- **Race between `flushStructuralChanges` and async GPU readback.** The
+  readback's destination (or the entity it indexes) may vanish if the flush
+  runs first — verify the readback's lifetime is decoupled (stable ID or its
+  own refcount).
+- **Allocator behavior in long-lived caches.** An `unordered_map<EntityId,T>`
+  with a poor hash, or a never-shrunk `vector<T>`, grows unbounded — confirm
+  an eviction path or clear teardown order.
+- **Hot-path register pressure.** A per-entity tick touching >8 components or
+  carrying >12 live locals across a loop body approaches the register file;
+  flag tick paths that grew significantly, especially in `engine/render/` or
+  `engine/world/`.
 
 **Creation- or implementation-specific criteria**
-- If the PR touches a subdirectory under `creations/` (or any other
-  implementation layered on top of the engine), read the nearest
-  `CLAUDE.md` in that subdirectory *in addition to* this engine-level
-  checklist. Each creation/implementation defines its own domain-specific
-  review rules — e.g. a game creation may have rules about its simulation
-  model, an editor may have rules about UX, a test harness may have rules
-  about coverage. The engine-level checklist above is the baseline; the
-  creation's own `CLAUDE.md` is the delta. Apply both.
-- If the subdirectory has a dedicated `REVIEW.md`, prefer that over its
-  `CLAUDE.md` for the review-specific rules (some creations split the
-  two). If neither exists, the engine-level checklist is the only bar.
+- If the PR touches a subdirectory under `creations/` (or any implementation
+  layered on the engine), read the nearest `CLAUDE.md` there **in addition
+  to** this engine checklist. The engine checklist is the baseline; the
+  creation's `CLAUDE.md` is the delta. Apply both. If the subdirectory has a
+  dedicated `REVIEW.md`, prefer it for review-specific rules.
 
-### 5. Write the review and set the verdict label
+## Verdict-label swap commands (shared-flow step 5b)
 
-**These are one indivisible action.** Post the review comment and set
-the verdict label in immediate succession — no intervening bash calls,
-no context switches. A review without a verdict label is invisible to
-the human's merge queue (observed on PR #230 where both passes approved
-but the label was never set — PR sat unlabeled for hours).
-
-Post the review as a PR comment via `gh pr review`. **Do NOT use
-`--body "$(cat <<'EOF'...)"` or any `$(...)` command substitution** —
-it triggers Claude Code's `command_substitution` security gate and
-causes parse errors when the body contains backticks or special
-characters. Instead, write the body to a temp file with the **Write
-tool**, then pass it with `--body-file`:
-
-1. **First** run `rm -f .review-body.md` so the Write tool doesn't
-   refuse with "File has not been read yet" — that error fires when
-   an existing file at the path wasn't Read in this session, which
-   is the normal case when a previous review iteration left the
-   body file behind. Then use the **Write tool** to write the review
-   body to `.review-body.md` in the worktree root (NOT `/tmp/` —
-   the sandbox may block writes outside the project tree). This
-   file is gitignored:
-
-```markdown
-## Review — <title>
-
-**Verdict:** <approve | needs-fix | blocker>
-
-### Blockers
-- <path:line> — <issue> — <suggested fix>
-
-### Needs-fix
-- <path:line> — <issue> — <suggested fix>
-
-### Nits
-- <path:line> — <nit>
-
-### Praise
-- <non-obvious good decision, if any>
-
-### Test plan the author should run before merge
-- [ ] <...>
-- [ ] <...>
-
-🤖 Reviewed by Claude <model> (review-pr skill)
-```
-
-2. Post the review:
+Run the matching command as your very next bash call after `gh pr review`:
 
 ```bash
-gh pr review <N> --comment --body-file .review-body.md
-```
-
-Rules for the review body:
-
-- Cite **file path and line number** for every issue. Reviewers who say
-  "there's a bug in the render system" with no cite get ignored.
-- For each blocker/needs-fix, suggest a concrete fix, not just "this is
-  wrong". The author-agent will use your suggestion literally.
-- Empty sections are fine — drop them, don't write "None".
-- Verdict options (severity definitions live in step 3 — apply
-  "would master survive this merge?" as the deciding question):
-  - **approve** — no blockers, no needs-fix. Nits only, if any.
-  - **needs-fix** — one or more needs-fix items. No blockers.
-    Master would survive the merge but in a worse state.
-  - **blocker** — one or more blockers. Master breaks, the demo
-    crashes/hangs, or data on disk is corrupted if this lands.
-
-**The bright line between Nits and needs-fix:**
-
-A "Nit" is a **truly optional** improvement the author may skip without
-hurting the merge. Anything you describe with phrases like "must resolve
-before merge", "pre-merge ask", "the comment and code must agree",
-"safe to merge once X is resolved", or "needs to be reconciled" is
-**by definition NOT a Nit** — it is a **needs-fix** item. Move it. The
-verdict drops to `needs-fix`.
-
-The contradiction "approve, but please fix X before merge" is forbidden.
-If X must be fixed before merge, the verdict is needs-fix; if it doesn't,
-say so and stop putting it in the body. The author and the human both
-read the verdict label as the primary signal — equivocating in the body
-defeats the workflow.
-
-**Nits are still encouraged** — author-agents now scan approved PRs for
-any "Nits" section and address every item before considering the PR
-landed (see the role files). So put real nits in the Nits section
-freely; they will get acted on. The bar isn't "is this nit worth
-mentioning?" — it's "is this nit a merge blocker or not?"
-
-**Do not use `gh pr review --approve` or `--request-changes`.** All fleet
-agents share the same GitHub account, and GitHub's API rejects formal
-review actions on your own PRs. The `--comment` review above is sufficient;
-the verdict line in the body is what the human reads to decide whether to
-merge. Merging is always the user's call.
-
-### 5b. Set the verdict label (step 5 sequence, continued)
-
-**Immediately after** `gh pr review --comment --body-file .review-body.md`,
-run the verdict label command — your very next bash call. No intervening
-calls. Always remove stale verdict labels before adding the new one — a PR
-should have exactly one verdict label (`fleet:approved` / `fleet:needs-fix`
-/ `fleet:blocker`) at any time. `fleet:has-nits` is orthogonal — it rides
-on top of `fleet:approved`. The remove list also clears
-`fleet:awaiting-upstream-review` (previously-gated stacked PR exits cleanly),
-`fleet:stacked-rebase` (re-eval after a stacked-PR retarget completes
-the label's intent), and `fleet:needs-base-update` (stacked PR whose
-upstream has since been re-approved or merged).
-
-```bash
-# For approve, no nits in body:
+# approve, no nits in body:
 gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved"
 
-# For approve WITH a non-empty Nits section in the body:
+# approve WITH a non-empty Nits section:
 gh pr edit <N> --remove-label "fleet:needs-fix" --remove-label "fleet:blocker" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:approved" --add-label "fleet:has-nits"
 
-# For needs-fix (nits roll into the fix work; no separate label):
+# needs-fix (nits roll into the fix work; no separate label):
 gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:blocker" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:needs-fix"
 
-# For blocker:
+# blocker:
 gh pr edit <N> --remove-label "fleet:approved" --remove-label "fleet:needs-fix" --remove-label "fleet:has-nits" --remove-label "fleet:awaiting-upstream-review" --remove-label "fleet:stacked-rebase" --remove-label "fleet:needs-base-update" --add-label "fleet:blocker"
 ```
 
-The verdict label is the **primary signal** the human uses to decide
-what to merge. The comment body has the details. The `fleet:has-nits`
-label tells the author "you've been approved, and there are nits to
-clean up before this lands" — author roles poll for it and address
-the nits without losing the approval.
+`fleet:has-nits` rides on top of `fleet:approved` and tells the author
+"approved, clean up the nits before this lands" — author roles poll for it.
 
-### 5c. Tag render PRs for cross-host smoke validation
+## Engine notes
 
-If the diff touches `engine/render/`, `engine/prefabs/irreden/render/`, `engine/render/src/shaders/`, any `*.glsl`, or any `*.metal` file, the PR needs cross-host smoke validation. The standard tagging path subtracts the author's host (only the *other* backend needs validation).
-
-Render-touching PR? See [`procedures/cross-host-smoke.md`](procedures/cross-host-smoke.md) for the host-detection table, the `gh pr edit` calls per author host, and the skip conditions (game-repo PRs, non-render engine PRs).
-
-Non-render PR? Skip to step 6.
-
-### 6. Report back
-
-Reply with a compact summary to the calling session:
-
-- PR number + title + verdict.
-- Count of blockers / needs-fix / nits.
-- Link to the review comment (`gh pr view <N> --json reviews` to fetch).
-- One sentence on what the author-agent should do next (e.g. "address the
-  two blockers around entity lifetime, then re-ping for re-review").
-
-## Anti-patterns
-
-- Approving work that violates an ECS invariant "because the test passes"
-  — some invariants don't fail at test time.
-- Pushing commits to the PR branch from the reviewer worktree.
-
-## Re-review
-
-When the user says "re-review PR 42" or a reviewer-loop session sees `fleet:changes-made` on a previously-flagged PR, the flow is different — you must verify previously-flagged items against the new commits BEFORE running the standard checklist, otherwise you risk re-flagging items that were already fixed.
-
-See [`procedures/re-review.md`](procedures/re-review.md) for the full re-review procedure (Prior-review resolution table, post-cutoff commit scoping, re-apply guard).
-
-## Escalation footer
-
-Every review body ends with one of the following escalation hints so the
-calling session knows what to do next:
-
-- **Sonnet first-pass, approve** → `Escalation: none. Safe for merge.`
-- **Sonnet first-pass, approve-with-Opus-recheck** →
-  `Escalation: please Opus-recheck before merge (touches: <module(s)>).`
-- **Sonnet first-pass, needs-fix/blocker** →
-  `Escalation: author-agent to address, then re-request review.`
-- **Opus review** → no escalation line needed; the Opus verdict stands.
+- Step 1's metadata fetch uses `gh api repos/jakildev/IrredenEngine/pulls/<N>/comments`
+  for inline comments; `gh pr view --json` does not include them.
+- Bail-label release uses `fleet-claim review-release <N> <your-worktree-name>`.
+- The procedure files (`procedures/*.md`) say "`SKILL.md` step N" — read it as
+  **step N of the shared flow** in
+  [`docs/agents/skills/review-pr.md`](../../../docs/agents/skills/review-pr.md)
+  (the step numbers are preserved); this wrapper is the entry point that
+  points there.

--- a/.claude/skills/start-next-task/SKILL.md
+++ b/.claude/skills/start-next-task/SKILL.md
@@ -14,305 +14,38 @@ description: >-
   "stack the next on this PR".
 ---
 
-# start-next-task
-
-The skill operates in three modes, selected in priority order at step 4:
-
-- **Fleet stack mode** (active `fleet-claim` molecule with remaining
-  tasks): branch off the **old branch** — i.e. the head ref of the PR
-  that `commit-and-push` just opened. The downstream task's branch then
-  contains the upstream commits so the worker can keep building, while
-  its PR's `--base <upstream>` (set by `commit-and-push` at PR-open
-  time) keeps the diff scoped to its own changes. Selected via
-  `fleet-claim molecule resume`.
-- **Cursor stack mode** (cursor flow only, driven by user cue): same
-  mechanic as fleet stack mode (branch off the old branch) but no
-  molecule machinery. Activated by stacking cues ("stack this", "next
-  slice stacked", "keep stacking", "stack the next on this PR") when
-  no fleet molecule is active; see [FLEET.md](../../../docs/agents/FLEET.md)
-  "Stacking in cursor flow" for the git-config persistence mechanism.
-- **Standard mode** (no fleet molecule and no stack cue): branch off
-  fresh `origin/master`. The historical behavior and the most common
-  case for both fleet single-task work and cursor flow's "I merged it,
-  start something new" pattern.
-
-## Preconditions
-
-1. **You must be in your own worktree, not the shared main clone.** Run
-   `fleet-assert-worktree` (optionally with your worktree basename). If it
-   exits non-zero, STOP and `cd` into your worktree before resetting the
-   branch — a `git checkout -B` in the shared main clone yanks the branch
-   another agent or the operator has checked out there (engine #1325).
-   Human-only override: `FLEET_ALLOW_MAIN_CLONE=1`.
-2. The working tree should be **clean**. If `git status` shows uncommitted
-   changes, stop and warn — either they belong in the previous PR (go back
-   to `commit-and-push`) or they are a WIP the user wants to keep.
-3. You should be on a feature branch whose PR is **already open and pushed**.
-   If the current branch has unpushed commits, stop and warn — those commits
-   would be stranded by the branch switch.
-4. `gh` authenticated.
-
-## Flow
-
-### 1. Record what branch you were on
-
-```bash
-git rev-parse --abbrev-ref HEAD
-```
-
-Remember this — you'll reference it in the report at the end, the user may
-want to check that the PR is still tracking it, and stack mode (step 4)
-uses it as the new branch's base.
-
-### 2. Confirm the old branch's PR is pushed and open
-
-```bash
-gh pr list --head <old-branch-name> --state open --json number,url,title
-```
-
-- If **one PR** comes back: good, the previous slice is properly filed for
-  review. Note the number and URL for the report.
-- If **zero PRs** come back: stop and warn the user. Either the previous
-  `commit-and-push` didn't finish, or the PR was already closed. Do not
-  switch branches until the user tells you what to do — the uncommitted or
-  un-PR'd work would be lost.
-- If **multiple PRs** come back: unusual. Note all of them in the report and
-  continue.
-
-### 3. Fetch latest origin
-
-```bash
-git fetch origin master
-```
-
-Never rely on a stale local `master` ref. Always fetch before branching.
-
-### 4. Detect mode
-
-Three modes, checked in priority order. The first one that matches wins.
-
-#### 4a. Fleet stack mode
-
-If the current task is part of a `fleet-claim stack` chain, the next
-branch must build on the just-opened PR's head ref — not
-`origin/master` — so the downstream task's diff shows only its own
-changes. Probe the molecule (agents already know their own worktree
-name — it is passed in their role instructions, the same way
-`fleet-heartbeat <name>` is called):
-
-```bash
-fleet-claim molecule resume <your-worktree-name>
-```
-
-Interpret the output (the helper always exits 0; discriminate via stdout):
-
-- **stdout names an issue number** — there is an active stack with remaining
-  tasks. The returned number is the **next** task in the chain (resume marks
-  the first pending task as `in-progress` as a side effect).
-  - **Sanity-check:** if the returned number matches the old branch's issue
-    prefix (e.g. old branch `claude/1234-foo` and resume returned
-    `1234`), the worker forgot to run `fleet-claim molecule advance
-    <agent> 1234 done pr=<URL> commit=<SHA>` after `commit-and-push`.
-    Stop and tell the user to advance the molecule before retrying — do
-    not proceed, or you will branch back onto the same task.
-  - Otherwise the new branch is `claude/<returned-issue#>-<short-topic>`
-    based on the **old branch** (the just-opened PR's head ref). Set
-    `MODE=fleet-stack`, `BASE=<old-branch-name>`, and remember
-    `<returned-issue#>` for step 5.
-- **stdout is empty** — no fleet molecule. Continue to 4b.
-
-If `molecule resume` exits non-zero (malformed YAML, etc.), stop and
-surface the stderr message — that is a real fault, not a "no work" signal.
-
-In a cursor-flow session there is no fleet-claim machinery; this probe
-will return empty unless the user has set up fleet machinery on the
-side. That's the expected case for cursor flow.
-
-#### 4b. Cursor stack mode
-
-If 4a returned empty AND the cue contains a stacking phrase ("stack
-this", "next slice stacked", "keep stacking", "stack the next on this
-PR", "build on the last PR"): set `MODE=cursor-stack`,
-`BASE=<old-branch-name>`. Step 7b persists the parent branch.
-
-If the cue is fresh-start ("next task", "I merged it", "back to
-master", etc.): continue to 4c.
-
-If the cue is ambiguous and the old branch already has
-`cursor-stack-base` set, ask whether to continue the stack or branch
-from master — don't guess (see [FLEET.md](../../../docs/agents/FLEET.md)
-"Stacking in cursor flow").
-
-#### 4c. Standard mode
-
-Default. `MODE=standard`, `BASE=origin/master`. Proceed.
-
-### 5. Derive a new branch name
-
-In **fleet stack mode** (4a returned an issue number): the new branch is
-`claude/<issue#>-<short-topic>`. Pull the topic from the issue title via
-`fleet-issue view <issue#>` (falls back to `gh issue view <issue#>`). If
-the user already named the next slice in conversation, prefer that;
-otherwise `<short-topic>` can be a brief paraphrase of the title.
-
-In **cursor stack mode** (4b): the new branch is
-`claude/<area>-<topic>`, no issue-number prefix. Derive from the conversation: the user usually names the
-next slice when they cue stacking. If they didn't, ask. Examples:
-
-- `claude/render-glow-pulse-tuning` (stacked on
-  `claude/render-glow-pulse`)
-- `claude/game-pheromone-decay` (stacked on `claude/game-pheromones`)
-
-In **standard mode** (4c): ask the user what the next task is if they
-haven't already told you. Derive a short, kebab-case branch name from
-the task, prefixed `claude/<area>-`:
-
-- `claude/game-ant-pheromones`
-- `claude/engine-velocity-drag-refactor`
-- `claude/render-lod-threshold-tuning`
-
-Either way: do not pick a name with a random suffix — permanent worktrees
-work best with human-readable, topic-named branches.
-
-### 6. Discard any staged or working-tree changes from the old branch
-
-Before switching, ensure the working tree is fully clean — even of files
-that look like a no-op (a stale staged file blocks the next branch checkout):
-
-```bash
-git restore --staged .
-git checkout -- .
-```
-
-If `git status` reported clean in the preconditions, these are no-ops.
-If it didn't, these clear any leftover staged changes that would otherwise
-fail the next `git checkout -b` with "your local changes would be
-overwritten by checkout."
-
-### 7. Check out the new branch off the right base
-
-```bash
-git checkout -B <new-branch> origin/master      # standard mode
-git checkout -B <new-branch> <old-branch-name>  # fleet-stack or cursor-stack
-```
-
-The base is `origin/master` for the standard flow, `<old-branch-name>`
-for either stack mode (see step 4). `-B` (uppercase) creates the branch
-if it doesn't exist AND resets it to the named commit if it does.
-Lowercase `-b` errors out with "branch already exists" — surprisingly
-common because the worktree's previous scratch branches accumulate over
-many iterations. With `-B`, the branch always lands on the requested
-base regardless of its prior state.
-
-In **standard mode**, this starts the new branch from the tip of
-`origin/master`. Critical: without `origin/master`, you'd branch off
-your old PR branch and carry its commits forward.
-
-In **fleet stack mode** and **cursor stack mode**, this is intentional —
-the downstream slice is meant to contain the upstream commits so the
-human (or worker) can keep building. The downstream PR's `--base` (set
-later by `commit-and-push`) is the upstream branch, so the diff still
-shows only the downstream changes.
-
-**macOS sandbox note.** `git checkout -B` writes `.git/config` to set up
-branch tracking. On macOS Cursor's Bash sandbox, `.git/config` writes
-need the `all` permission — without it the checkout *appears* to
-succeed but the tracking config is missing, leaving the new branch
-without an upstream. Always run this checkout with sandbox bypass on
-macOS.
-
-**Do NOT** `git rebase origin/master` on the old branch and keep working
-on it. That would mix old PR commits with new work, which pollutes the
-old PR when you push. Always start a new branch.
-
-### 7b. Record cursor-stack-base (cursor stack mode only)
-
-```bash
-git config branch.<new-branch>.cursor-stack-base <old-branch-name>
-```
-
-Same `.git/config` write as step 7 — needs `all` permission on macOS.
-Skip in fleet stack mode and standard mode. See
-[FLEET.md](../../../docs/agents/FLEET.md) "Stacking in cursor flow"
-for the cross-chat persistence details.
-
-### 8. Sanity-check the state
-
-```bash
-git status
-git log --oneline -5
-```
-
-- `git status`: should be `nothing to commit, working tree clean`.
-- **Standard mode:** `git log --oneline -5` top commit should be the
-  latest `master` commit, not one of your previous PR's commits.
-- **Fleet/cursor stack mode:** the top commit should be the just-opened
-  PR's tip (i.e. the last commit on the old branch). The new branch's
-  merge-base with `origin/master` is whatever the old branch branched
-  from — not the old branch's tip. That's expected.
-
-In cursor stack mode, also run `git config --get branch.<new-branch>.cursor-stack-base` — should print `<old-branch-name>`; if empty, retry step 7b with `all` permissions.
-
-If the top commit is wrong for the mode you're in, the checkout went
-wrong — stop and investigate.
-
-### 9. Read the relevant CLAUDE.md for the new task area
-
-Before starting the next task, read the most specific `CLAUDE.md` for the
-directory you're about to work in. For example:
-
-- Task in `engine/render/` → read `engine/render/CLAUDE.md`.
-- Task in `engine/prefabs/irreden/update/` → read that file's CLAUDE.md.
-- Task inside a creation subdirectory → read that creation's own
-  `CLAUDE.md` (creations layered on top of the engine define their own
-  conventions, review criteria, and sometimes workflows).
-
-This primes your context with the module's conventions and gotchas before
-you start editing. If the subdirectory has a dedicated workflow that
-differs from the engine baseline, honor the subdirectory's rules.
-
-### 10. Report
-
-Reply with a compact summary:
-
-- **Mode** you ended up in (standard / fleet-stack / cursor-stack).
-- Old branch name + its PR URL (from step 2).
-- New branch name + the base it's tracking. In standard mode that's
-  fresh `origin/master`; in either stack mode call out the upstream
-  branch explicitly so the reviewer-and-merger pipeline (or the human
-  in cursor flow) isn't surprised when `commit-and-push` later sets
-  `--base <upstream>`.
-- In cursor stack mode: confirm `branch.<new>.cursor-stack-base` was
-  recorded.
-- The CLAUDE.md files you just read to prime context.
-- One sentence: "Ready for <next task>. Go ahead."
-
-## Anti-patterns
-
-- Running `git rebase origin/master` on the old branch to "catch it up",
-  then reusing it. Rebasing the same branch for new unrelated work is how
-  PR histories become unreadable.
-- Deleting the old local branch. Leave it alone — if the reviewer asks for
-  changes, you'll need to check it out again. Both stack modes REQUIRE the
-  old branch as the new branch's base.
-
-## Recovery
-
-If you discover after switching branches that the old branch had uncommitted
-work (somehow step 1's clean check missed it):
-
-1. `git checkout <old-branch>`
-2. Stash or commit the dirty work on the old branch.
-3. Push and update the PR.
-4. `git checkout <new-branch>` to return.
-
-If you set up cursor stack mode and later realize the new slice should
-not actually be stacked (e.g. you decide to base it on master after
-all):
-
-1. Clear the config: `git config --unset
-   branch.<new-branch>.cursor-stack-base` (needs `all` permissions on
-   macOS).
-2. Rebase the new branch onto master:
-   `git rebase --onto origin/master <old-branch> <new-branch>`.
-3. Continue work. `commit-and-push` will now open the PR vs `master`.
+# start-next-task (Irreden Engine)
+
+**The flow lives in [`docs/agents/skills/start-next-task.md`](../../../docs/agents/skills/start-next-task.md).**
+Read it first, then apply the engine deltas below. This wrapper carries
+deltas only — see [`docs/design/skill-sharing.md`](../../../docs/design/skill-sharing.md)
+for why.
+
+## Deltas (Irreden Engine)
+
+| Delta key | Engine value |
+|---|---|
+| **default branch** | `master` |
+| **remote** | `origin` |
+| **branch prefix** | `claude/` |
+| **worktree-assert command** | `fleet-assert-worktree` (optionally `fleet-assert-worktree <worktree-basename>`) |
+| **fleet doc** | [`docs/agents/FLEET.md`](../../../docs/agents/FLEET.md) — see "Stacking in cursor flow" |
+| **area examples** | `engine`, `render`, `game`, plus module names (`engine/voxel`, etc.) |
+
+Concrete branch-name examples for the engine:
+
+- Standard: `claude/engine-velocity-drag-refactor`,
+  `claude/render-lod-threshold-tuning`, `claude/game-save-format`.
+- Cursor stack: `claude/render-glow-pulse-tuning` (stacked on
+  `claude/render-glow-pulse`).
+- Fleet stack: `claude/1234-occupancy-grid` (issue-number prefix).
+
+## Engine notes
+
+- `fleet-issue view <issue#>` is the cache-aware title lookup used in
+  step 5's fleet-stack branch-name derivation; it falls back to
+  `gh issue view`.
+- The macOS Cursor sandbox is the concrete case of the shared flow's
+  "sandbox note" — run the `git checkout -B` and the
+  `git config branch.<new>.cursor-stack-base` writes with the `all`
+  permission so `.git/config` is actually written.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ working inside such a subdirectory, always read that subdirectory's own
 | Build commands and environment setup (Linux/WSL, Windows, macOS) | [`docs/agents/BUILD.md`](docs/agents/BUILD.md) |
 | Fleet workflow (parallel agents, PRs, cursor cues, design escalation, model split, labels, feedback) | [`docs/agents/FLEET.md`](docs/agents/FLEET.md) |
 | Skills (named workflows like `simplify`, `commit-and-push`, `review-pr`) | [`.claude/skills/`](.claude/skills/) — each has its own `SKILL.md` |
+| Shared skill flows (fleet skills factored for cross-repo reuse) | [`docs/agents/skills/`](docs/agents/skills/) — canonical flows; each repo's `SKILL.md` is a thin wrapper (mechanism: [`docs/design/skill-sharing.md`](docs/design/skill-sharing.md)) |
 | Roles (autonomous personas — worker, reviewer, merger, architect) | [`.claude/commands/role-*.md`](.claude/commands/) |
 | Task queue (when running fleet roles) | `fleet-queue-list` or `gh issue list --label fleet:queued --repo jakildev/IrredenEngine` |
 | Cross-repo info isolation rule (engine repo public, game repo private) | [`docs/agents/CLAUDE-BASELINE.md`](docs/agents/CLAUDE-BASELINE.md) §"Cross-repo information isolation" |

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -105,6 +105,15 @@ coordination mechanisms prevent duplicate work:
   re-check immediately before each `gh issue edit` so two hosts that
   observe the same `human:approved` issue converge without duplicate
   label additions.
+- **Blocked-by gating (#1476):** ingest stamps `fleet:queued` only when
+  every `**Blocked by:** #N` predecessor is closed. A freshly-filed
+  stacked epic therefore shows only its head queued; each child is queued
+  as its blocker closes. The scout's ingest projection keeps blocked
+  children out of the pending set (so the trigger re-fires when a blocker
+  closes), and `fleet-queue-ingest` does an authoritative live
+  `gh issue view <ref> --json state` re-check before it stamps. This makes
+  the label honest — `fleet-claim` already enforced Blocked-by at claim
+  time, but the label previously showed every child queued at once.
 
 **Review claiming:**
 - Review claims use `fleet:reviewing-<host>-<agent>` labels on PRs via

--- a/docs/agents/skills/commit-and-push.md
+++ b/docs/agents/skills/commit-and-push.md
@@ -1,0 +1,328 @@
+# commit-and-push — shared flow
+
+The canonical `commit-and-push` flow: stage, commit, push a feature branch,
+and open a PR against the repo's default branch. Assumes the parallel-agent
+workflow where work happens on short-lived feature branches, another agent
+reviews the PR, and the human merges. **NEVER commit directly to the default
+branch.**
+
+Every repo that runs a fleet keeps its
+`.claude/skills/commit-and-push/SKILL.md` as a thin wrapper that points here
+and supplies only its **deltas** (below) plus repo-specific procedure files.
+See [`docs/design/skill-sharing.md`](../../design/skill-sharing.md) for the
+mechanism. Wherever a step needs a repo-specific value it names a **delta
+key** in bold.
+
+Do **not** invoke proactively — only when the user explicitly asks.
+
+---
+
+## Repo deltas this flow needs
+
+| Delta key | What it is | Engine value |
+|---|---|---|
+| **repo** | The `gh --repo` slug. | `jakildev/IrredenEngine` |
+| **default branch** | The PR base in the common case. | `master` |
+| **remote** | Git remote pushed to. | `origin` |
+| **branch prefix** | New feature-branch prefix. | `claude/` |
+| **worktree-assert command** | Fails if you're in the shared main clone. | `fleet-assert-worktree` |
+| **claim tool** | The fleet claim/stack helper. | `fleet-claim` |
+| **simplify skill** | The repo's pre-commit quality skill. | `simplify` |
+| **scope vocabulary** | Commit-title scope prefixes. | `render:`, `engine/voxel:`, `game/nav:`, `build:`, `docs:` |
+| **visual-file globs** | Paths whose change requires screenshots. | `engine/render/`, `engine/prefabs/irreden/render/`, `*.glsl`, `*.metal`, `creations/demos/*/src/**`, `creations/demos/*/main*.cpp` |
+| **screenshot skill** | The repo's screenshot-capture skill. | `attach-screenshots` |
+| **info-isolation check** | The cross-repo leakage scan. | `docs/agents/CLAUDE-BASELINE.md` §"Cross-repo information isolation" |
+| **co-author trailer** | The commit trailer. | `Co-Authored-By: Claude <noreply@anthropic.com>` (exact form per the harness system prompt) |
+| **procedures** | Repo-specific step expansions. | the engine wrapper's `procedures/*.md` |
+
+---
+
+## Preconditions — do these before anything else
+
+1. **Confirm you are in your own worktree, not the shared main clone.** Run
+   the **worktree-assert command** (optionally with your worktree basename).
+   If it exits non-zero, STOP and `cd` into your worktree before doing
+   anything — a commit from the shared main clone collides with other agents
+   on that checkout. Human-only override: `FLEET_ALLOW_MAIN_CLONE=1`.
+2. **You must NOT be on the default branch.** If `git rev-parse
+   --abbrev-ref HEAD` reports the **default branch**, stop and warn. Branch
+   first (flow step 2) — do not commit to it.
+3. **`gh` must be authenticated.** If `gh auth status` fails, ask the user
+   to run `gh auth login`.
+4. **The working tree must have something to commit.** If `git status` is
+   clean, tell the user and stop. Also check the *staged* tree is non-empty
+   before `git commit` (step 6): `git diff --cached --quiet` exits 0 when
+   nothing is staged — reject that empty-commit case.
+
+---
+
+## Mode detection
+
+Three modes, detected at the start in priority order:
+
+1. **Fleet stack mode** — caller has an active **claim tool** stack chain.
+   One PR per task, chained by `--base`. Detected via `<claim-tool>
+   stack-pr-state <worktree>`. See the **procedures** `fleet-stack.md` for
+   the deltas (issue-number-prefixed branch name, `stack-base` lookup,
+   `Stack context` body block, stacked label, `stack-set-pr` after PR open).
+2. **Cursor stack mode** — current branch has `branch.<name>.cursor-stack-base`
+   git config (written by `start-next-task` when the human cued stacking).
+   PRs target the parent branch instead of the default branch. See the
+   **procedures** `cursor-stack.md`.
+3. **Single-task mode (default)** — neither stack signal. The base is
+   resolved via `<claim-tool> claim-base <issue#>`: the default branch for a
+   normal claim or a plain human PR, or the blocker's branch for an
+   opportunistic stackable claim (which also gets the stacked label). See
+   the **procedures** `stackable-on.md`.
+
+The modes are mutually exclusive and checked in this order. In single-task
+mode ignore the stack-mode procedures; the PR-body template and the
+base+label resolution still apply.
+
+---
+
+## Flow
+
+### 1. Gather state (parallel)
+
+Run in one Bash-tool batch:
+
+```
+git rev-parse --abbrev-ref HEAD
+git status
+git diff --stat && git diff
+git log --oneline -10
+```
+
+The branch name tells you whether you're already on a feature branch;
+`git status`/`git diff` tell you **what** changed and **why** (for the PR
+body); `git log` lets you match the tone of recent titles.
+
+### 2. Ensure you're on a feature branch
+
+If you're on the default branch, derive a short kebab-case name prefixed
+`<branch prefix><area>-<topic>` and create it **before** staging:
+
+```bash
+git checkout -b <branch prefix><area>-<topic>
+```
+
+**In fleet stack mode** use `<branch prefix><task-id>-<short-topic>` and
+branch off the base from `<claim-tool> stack-base <agent> <task-id>` (the
+default branch for the first task, else the previous task's branch). See the
+**procedures** `fleet-stack.md`.
+
+If you're already on a feature branch, use it — don't rename mid-session.
+
+### 3. Pre-commit checks and `simplify`
+
+**First**, run the **rebase guard** (**procedures** `rebase-guard.md`): if
+you saved a `git diff <remote>/<default-branch>` snapshot before rebasing,
+compare it now against a fresh one to catch silently-dropped hunks. If you
+have no snapshot, check `git reflog --since=2.hours.ago` for a recent rebase
+and inspect manually if found.
+
+**Second**, check whether the diff touches visual/render files:
+
+```bash
+git diff --name-only <remote>/<default-branch>...HEAD
+```
+
+If any path matches a **visual-file glob** AND
+`docs/pr-screenshots/<current-branch>/` does not yet exist, stop and prompt
+the worker to run the **screenshot skill** before proceeding. Screenshots
+ship in the same commit as the code change. Skip the prompt if the diff is
+purely docs/tests/mechanical/build, or the screenshots dir already exists
+for this branch.
+
+**Then**, run the **info-isolation check**: scan staged paths and the PR-body
+draft for the cross-repo leakage tokens listed in the **info-isolation
+check** reference. Surface any match before committing.
+
+**Then** invoke the **simplify skill** to review the dirty changes for
+reuse, quality, and efficiency issues. It reads the same diff and applies
+fixes directly. **Always run it, regardless of file types** — no doc-only or
+small-change carve-out (the doc-side checks earn their keep on
+markdown-heavy diffs too).
+
+After `simplify` finishes: re-run `git status`/`git diff --stat`; surface
+any findings it couldn't auto-fix and ask whether to proceed; if the tree is
+now clean, stop and report (nothing to commit).
+
+> **Autonomous-fleet guardrail (post-simplify boundary):** after processing
+> the simplify results, your VERY NEXT action must be a **tool call** —
+> either advancing to step 4 or confirming the clean-tree stop. Do not emit
+> only prose summarizing simplify and end the turn without a tool call.
+> Phrases like "Returning to commit-and-push" without an immediate following
+> tool call are the signal you're about to drop the flow; issue the tool
+> call instead.
+
+### 4. Draft the commit message
+
+```
+<area>: <one-line overview of what this slice accomplished>
+
+<1–3 short paragraphs describing the *why* and the non-obvious *what*.
+Group related edits. Mention each major subsystem touched. Skip things
+obvious from filenames.>
+
+<co-author trailer>
+```
+
+If the work is entirely inside a subdirectory with its own `CLAUDE.md`
+specifying a different commit-message shape, prefer that — read the nearest
+`CLAUDE.md` first.
+
+**Rules:** title ≤ 72 chars, lowercase, no trailing period; prefer a scope
+prefix from the **scope vocabulary** derived from the dominant changed path;
+body wraps at ~72 chars; describe *why* over *what*; always include the
+**co-author trailer**.
+
+### 5. Stage files
+
+Add specific paths. **Never** `git add -A` / `git add .`:
+
+```
+git add <path1> <path2> ...
+```
+
+**Exclusions — never stage unless the user explicitly asks:** worktree/
+session state (`.claude/worktrees/`, `.claude/settings.local.json`),
+`.vscode/*`, secret-shaped files (`.env*`, `credentials*`, `*_key`, `*.pem`,
+`save_files/`, `build/`), large binaries/generated assets, and anything
+gitignored under a private creation directory (those live in their own
+repos; run the skill against that creation's own repo/remote). If the diff
+includes any of the above, warn before committing.
+
+### 6. Create the commit
+
+**Empty-commit guard (run before every `git commit`):** an empty staged
+tree produces a misleading commit (task-titled, no diff). Reject it:
+
+```bash
+if git diff --cached --quiet; then
+    echo "commit-and-push: refusing to commit — no staged changes." >&2
+    echo "Either stage real work (git add <files>) or release the claim" >&2
+    echo "(<claim-tool> release <task-id>) and exit." >&2
+    exit 1
+fi
+```
+
+On fleet branches an empty commit leaves misleading task provenance — if
+`simplify`/`optimize` stripped every changed line, stop and investigate.
+
+Pass the message via HEREDOC. If the commit fails on a pre-commit hook, **do
+not** `--amend` — fix the issue, re-stage, create a **new** commit.
+
+### 7. Push the feature branch
+
+```
+git push -u <remote> HEAD
+```
+
+`-u` sets upstream on the first push; plain `git push` works thereafter.
+
+### 8. Open the PR
+
+Use `gh pr create`. Body template: **procedures** `pr-body.md`.
+
+> Before calling `gh pr create`, complete step 8a (Closes-crosscheck) if the
+> drafted body contains a `Closes #N` line.
+
+For the **single-task flow** (default), resolve the base via `<claim-tool>
+claim-base` — the **default branch** for a normal claim or plain human PR
+(common case below), or the blocker's branch for a stackable claim (also
+gets the stacked label). The idempotent edit-or-create and the `Stacked on:`
+body line live in the **procedures** `stackable-on.md`. Common case:
+
+```bash
+gh pr create --base <default-branch> --title "<scope>: <title>" --body "$(cat <<'EOF'
+## Summary
+- <bullet>
+
+## Test plan
+- [ ] <check>
+
+Closes #<issue-N>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**`Closes #N` line** (required when the task has an `Issue:` field) is what
+makes the tracker auto-close the originating issue on merge. Omit only when
+the `Issue:` field is `(none)` (cleanup PRs, fleet-tooling PRs). See
+**procedures** `pr-body.md` for the full template and the stack-mode
+exceptions (cursor-stack non-leaf PRs deliberately drop it).
+
+**PR labels — WIP (important):** for the default human-ready single-PR open
+to the default branch, **do not** add the WIP label — fleet reviewers skip
+WIP PRs. Use the WIP label only in the fleet-worker lane (claim/early-work
+PRs until the author removes it for review pickup). Step 8b's host label is
+unrelated and still applies.
+
+**Fleet stack override** and **cursor stack override** apply their base +
+label + `Stack context` body deltas per the **procedures** `fleet-stack.md`
+/ `cursor-stack.md`.
+
+### 8a. Cross-check `Closes #N` before PR creation
+
+When the body includes `Closes #N`, cross-check **before** `gh pr create` to
+catch a wrong issue number that would auto-close an unrelated issue:
+
+```bash
+closes_n="<N from the drafted body>"
+issue_title=$(gh issue view "$closes_n" --repo <repo> \
+    --json title --jq '.title' 2>/dev/null || echo "")
+```
+
+Tokenize both strings (lowercase, strip punctuation + stop words), intersect
+the remaining word sets against PR title + branch name + first commit line.
+If the intersection is **empty**, surface a warning: pause for human
+acknowledgement in interactive mode; in autonomous mode log it prominently
+and verify the number independently before proceeding. The check is
+non-blocking — proceed if the number is intentional (e.g. an umbrella).
+
+Skip when the body has no `Closes #N` line, or for the queue-manager role
+(its `Closes #` rows mean task IDs, not tracker issues).
+
+### 8b. Tag the host the PR was authored on
+
+See the **procedures** `host-label.md` for the shell snippet and scope
+rules (applies to all PRs; the host label tells the reviewer which backend
+the author already implicitly validated).
+
+### 9. Report the result
+
+**Fix-push convention:** if pushing a fix in response to a needs-fix review,
+add the changes-made label after the push so the reviewer re-verifies. Your
+role file's feedback-fix flow handles this step — don't skip it.
+
+Reply with a compact summary: the branch you pushed; the PR URL; the files
+in the commit(s); confirmation push + PR both succeeded; any files you
+intentionally did not stage (and why).
+
+**Do not** start new work in the same worktree after opening the PR.
+`start-next-task` handles resetting to a fresh branch — tell the user to
+invoke it (or invoke it yourself if they asked for the next task).
+
+---
+
+## Anti-patterns
+
+- Amending a previous commit without being asked.
+- Leaking another repo's references into this repo's PR — see the
+  **info-isolation check** reference.
+
+## Recovery
+
+If the working tree has changes that clearly weren't made this session, ask
+before staging. When in doubt, stage only files you know the session
+touched. **Do not `git stash` to "park" unrelated WIP** — selective
+`git add <path>` already leaves it untouched, and `refs/stash` is shared
+across all worktrees, so a positional `git stash pop` can apply another
+agent's stash into your tree.
+
+If `gh pr create` fails because a PR already exists for the branch, report
+the existing PR URL — don't force a new one.

--- a/docs/agents/skills/file-epic.md
+++ b/docs/agents/skills/file-epic.md
@@ -1,0 +1,278 @@
+# file-epic — shared flow
+
+The canonical `file-epic` flow: take an approved architect plan that covers
+a multi-ticket epic and file it as a fleet expects — an umbrella issue
+labelled with the repo's **epic label**, one child per phase labelled with
+the **task label**, per-ticket plan files in the **plans dir** so the
+queue-manager copies them into the repo on ingest, and post-filing stack
+validation.
+
+Every repo that runs a fleet keeps its
+`.claude/skills/file-epic/SKILL.md` as a thin wrapper that points here and
+supplies only its **deltas** (below). See
+[`docs/design/skill-sharing.md`](../../design/skill-sharing.md) for the
+mechanism.
+
+---
+
+## Repo deltas this flow needs
+
+| Delta key | What it is | Engine value |
+|---|---|---|
+| **repo** | The `gh --repo` slug the epic targets. | `jakildev/IrredenEngine` (or `--repo game` for the game repo) |
+| **epic label** | Marks the umbrella so the queue-manager skips it. | `fleet:epic` |
+| **task label** | Marks each child as a queue-ingestable task. | `fleet:task` |
+| **architect plans dir** | Where the approved architect draft lives. | `~/.claude/plans/<slug>.md` |
+| **plans dir** | Worker-facing plan store the queue-manager reads. | `~/.fleet/plans/issue-<N>.md` |
+| **repo-side plan path** | Final repo-side plan after ingest rename. | `<repo>/.fleet/plans/T-<NNN>.md` |
+| **validate-stack command** | Asserts every child carries the structured fields. | `fleet-validate-stack` |
+| **title area vocabulary** | `<area>` tokens for child titles. | `engine`, `render`, `game`, module names |
+
+---
+
+## When to invoke
+
+- `/file-epic` (architect plan already approved and saved in the
+  **architect plans dir**).
+- "file the epic", "ship the epic", "open the tickets for this plan".
+- After plan mode returns a plan proposing multiple follow-up tickets and
+  the user says "proceed" / "go" / "ship it".
+
+Do not invoke before the user has approved the plan. The user gates the
+move from "plan in **architect plans dir**" to "tickets in **plans dir** +
+the issue tracker".
+
+---
+
+## Preconditions
+
+1. **Plan file exists** in the **architect plans dir** (or the user names a
+   path). It must include: an umbrella issue number to attach to; one
+   section per child ticket with a title, model tag (`[opus]`/`[sonnet]`),
+   and acceptance criteria; and a dependency chain.
+2. **`gh` authenticated** (`gh auth status`).
+3. **Repo identified.** Confirm the **repo** from the plan header or ask
+   once.
+
+---
+
+## Flow
+
+### 1. Identify umbrella issue + target repo
+
+From the plan's Context section extract the umbrella issue number and target
+**repo**. If either is ambiguous, ask once.
+
+Confirm the umbrella exists and isn't already an epic:
+
+```bash
+gh issue view <N> --repo <repo> --json number,title,labels,state
+```
+
+If it already carries the **epic label** and has children filed (check
+`gh issue list --repo <repo> --search "Part of epic: #<N>"`), STOP and
+report — don't double-file.
+
+### 2. Save the umbrella plan
+
+```bash
+cp <architect-plans-dir>/<slug>.md <plans-dir>/issue-<N>.md
+```
+
+This is the worker-facing reference. The queue-manager copies per-ticket
+files into the repo as the **repo-side plan path** at ingest; the umbrella
+plan itself stays at the `issue-<N>` filename for the umbrella's lifetime.
+
+### 3. Apply the epic label to the umbrella
+
+```bash
+gh issue edit <N> --repo <repo> --add-label "<epic-label>"
+```
+
+The **epic label** tells the queue-manager to skip the umbrella (children
+ingest individually) and to auto-close the umbrella when all children close.
+
+### 4. Parse the plan's child-ticket sections
+
+For each child section extract: the descriptive title (drop the architect's
+internal `T-XXX` slug — the tracker assigns its own number and the
+queue-manager assigns the canonical `T-NNN` at ingest); model tag; scope,
+approach, acceptance criteria, dependencies, gotchas.
+
+### 5. File children sequentially (NOT in parallel)
+
+Sequential filing matters because the tracker assigns numbers in order
+(later issues reference earlier ones), and the dependency chain needs the
+real predecessor number before you can write `Blocked by: #<actual N>`.
+
+For each child, write the body to a temp file first (avoids
+command-substitution and backtick hazards):
+
+```
+rm -f .file-epic-body.md
+[Write tool → .file-epic-body.md → content:]
+**Model:** <opus|sonnet>
+**Part of epic:** #<umbrella>
+**Plan file:** `<plans-dir>/issue-<umbrella>.md` (full epic plan)
+**Blocked by:** #<prior-child-number> (if applicable)
+
+## Scope
+<one paragraph>
+
+## Approach
+<bulleted approach>
+
+## Acceptance criteria
+<bulleted criteria>
+
+## Dependencies
+<what blocks this, what this blocks>
+
+## Gotchas
+<watchouts not obvious from the scope>
+
+## References
+<links to related design sections, prior PRs>
+```
+
+Then file:
+
+```bash
+gh issue create --repo <repo> --label "<task-label>" \
+  --title "<area>: <descriptive title> (T-<slug>)" \
+  --body-file .file-epic-body.md
+rm -f .file-epic-body.md
+```
+
+Title convention: `<area>: <descriptive title> (T-<slug>)` using one of the
+repo's **title area vocabulary** tokens. The `(T-<slug>)` suffix preserves
+the architect's internal numbering; the queue-manager assigns the canonical
+`T-NNN` separately. Capture the issue number the tracker returns.
+
+### 6. Write per-ticket plan file
+
+After each child is filed, write `<plans-dir>/issue-<N>.md` (where `<N>` is
+the tracker-assigned number):
+
+```markdown
+# Plan: <ticket title>
+
+- **Issue:** #<N>
+- **Model:** <opus|sonnet>
+- **Date:** <YYYY-MM-DD>
+- **Epic:** #<umbrella> — see `<plans-dir>/issue-<umbrella>.md` for full context
+- **Blocked by:** #<prior> (if applicable)
+
+## Scope
+<focused subset of the umbrella plan that applies to THIS ticket>
+
+## Affected files
+<bullet list of file paths the implementer will touch>
+
+## Approach
+<more detail than the issue body — the implementation guide>
+
+## Acceptance criteria
+<concrete, testable>
+
+## Gotchas
+<watchouts that need code-aware framing>
+
+## Verification
+<what to build, what to run, what passes>
+```
+
+The per-ticket plan adds **implementation detail beyond the issue body**.
+Don't duplicate — point at the umbrella plan for arch context, then add file
+paths, code-level approach, and verification.
+
+### 7. Post the umbrella summary comment
+
+After all children are filed, write the summary body to a file first, then:
+
+```bash
+gh issue comment <umbrella> --repo <repo> --body-file .file-epic-body.md
+rm -f .file-epic-body.md
+```
+
+The summary is the single source of truth linking the umbrella to its
+children: a phase/ticket/title/model table for the closing path, an
+independent-follow-on table, an ASCII dependency chain, closing criteria,
+and any shape changes from the original phasing.
+
+### 7.5. Validate filed bodies (STOP on failure)
+
+Before reporting success, assert every child carries the structured fields
+the queue machinery reads — a standalone `**Model:** opus|sonnet` line, a
+standalone `**Part of epic:** #<umbrella>` line, and (for every non-head
+child) a standalone `**Blocked by:** #N` line. The **validate-stack
+command** checks exactly this, auto-discovers the children, and fails
+loudly:
+
+```bash
+<validate-stack-command> <umbrella>              # default repo
+<validate-stack-command> <umbrella> --repo game  # game repo
+```
+
+If it exits **non-zero, STOP** — do not proceed to step 8. Patch the
+offending bodies (`gh issue edit <N> --body-file ...`) or re-file, then
+re-run until it passes. Never report success on a stack the validator
+rejects. A prose-only `Blocked on …` header is read only as a *fallback*;
+the canonical standalone `**Blocked by:** #N` line is what the
+`--search "Part of epic: #N"` discovery and the queue parsers rely on.
+
+### 8. Report
+
+Reply with: the umbrella issue URL + epic-label confirmation; the child
+issue URLs; the umbrella plan-file path; the per-ticket plan-file paths; the
+validate-stack result (must pass); and what the user still must do
+(typically: triage each child individually — the queue-manager won't
+auto-approve).
+
+---
+
+## Anti-patterns
+
+- ❌ Filing children in parallel — breaks the "later issues reference
+  earlier ones" pattern.
+- ❌ Forgetting the **epic label** on the umbrella — the queue-manager
+  would ingest the umbrella itself.
+- ❌ Putting `Blocked by:` in header prose instead of a standalone line.
+  The scout and `fleet-claim` parsers read **only** standalone
+  `**Blocked by:** #N` lines (a `Blocked on …` header is a fallback). This
+  is the #1 hand-filing drift; step 7.5 catches it — don't rely on the
+  catch, write the standalone line.
+- ✅ Multiple blockers are supported: `**Blocked by:** #A, #B` on one line
+  or several `**Blocked by:**` lines. The gate unions every ref.
+- ❌ Per-ticket plan files that duplicate the issue body verbatim. The plan
+  adds implementation detail; the issue is the discussion surface.
+- ❌ Skipping the umbrella summary comment — the umbrella↔children
+  cross-reference then isn't visible from the umbrella's own thread.
+- ❌ Filing an epic for changes that are really one ticket. If the scope
+  fits in one PR, file one issue.
+- ❌ Inline-authoring the umbrella plan file. Always copy from the
+  **architect plans dir** — the architect plan is the canonical source.
+
+## Plan file lifecycle
+
+| Location | Purpose | Lifecycle |
+|---|---|---|
+| **architect plans dir** (`<slug>.md`) | Architect's draft, approved by user. | Session-local; archive after the epic ships. |
+| **plans dir** (`issue-<N>.md`) | Worker-facing plan (umbrella or per-ticket). | Persists. Queue-manager copies per-ticket files into the repo at ingest. |
+| **repo-side plan path** (`T-<NNN>.md`) | Final repo-side plan, renamed at ingest. | Lives in the repo until the ticket closes. |
+
+## When the architect plan is rough
+
+If the plan is missing per-ticket detail (just an umbrella sketch), STOP and
+ask whether to (1) send it back for refinement (default — incomplete plans
+make thin tickets that get bounced) or (2) file a placeholder umbrella + one
+child per gap with "scope TBD" bodies. Don't file thin tickets without
+confirming.
+
+## Cross-repo information isolation
+
+The flow is repo-neutral — pass `--repo` consistently or read it from the
+plan header. The cross-repo info-isolation rule still applies: artifacts in
+one repo must not reference another repo by name or feature. If a plan
+authored from one repo's session mentions another repo's specifics, scrub
+them before filing.

--- a/docs/agents/skills/review-pr.md
+++ b/docs/agents/skills/review-pr.md
@@ -21,6 +21,8 @@ Wherever a step needs a repo-specific value it names a **delta key** in bold.
 | Delta key | What it is | Engine value |
 |---|---|---|
 | **repo** | The `gh --repo` slug / `gh api repos/<repo>` path. | `jakildev/IrredenEngine` |
+| **claim tool** | The fleet claim/release helper. | `fleet-claim` |
+| **default branch** | The repo's main branch (step-1c base check). | `master` |
 | **review checklist** | The repo's domain-specific review items (step 4). | the engine checklist in the wrapper |
 | **smoke procedure** | Cross-host/backend validation tagging, if any. | the wrapper's `procedures/cross-host-smoke.md` |
 | **re-review procedure** | The repo's re-review expansion. | the wrapper's `procedures/re-review.md` |

--- a/docs/agents/skills/review-pr.md
+++ b/docs/agents/skills/review-pr.md
@@ -1,0 +1,282 @@
+# review-pr — shared flow
+
+The canonical `review-pr` flow: review an open PR and post a structured
+review covering ownership, project invariants, allocation hot paths, naming,
+tests, and project-specific smells, then set the verdict label.
+
+Every repo that runs a fleet keeps its
+`.claude/skills/review-pr/SKILL.md` as a thin wrapper that points here and
+supplies only its **deltas** — most importantly its own **review
+checklist**, which is inherently repo-specific (the engine checks ECS/render
+invariants; a game checks its simulation model; an editor checks UX). The
+*flow* is single-sourced here so the wrappers can't drift on mechanics. See
+[`docs/design/skill-sharing.md`](../../design/skill-sharing.md).
+
+Wherever a step needs a repo-specific value it names a **delta key** in bold.
+
+---
+
+## Repo deltas this flow needs
+
+| Delta key | What it is | Engine value |
+|---|---|---|
+| **repo** | The `gh --repo` slug / `gh api repos/<repo>` path. | `jakildev/IrredenEngine` |
+| **review checklist** | The repo's domain-specific review items (step 4). | the engine checklist in the wrapper |
+| **smoke procedure** | Cross-host/backend validation tagging, if any. | the wrapper's `procedures/cross-host-smoke.md` |
+| **re-review procedure** | The repo's re-review expansion. | the wrapper's `procedures/re-review.md` |
+| **stacked-review procedure** | Per-PR scoping for stacked PRs. | the wrapper's `procedures/stacked-pr-review.md` |
+| **fleet doc** | The repo's fleet reference (model split, reviewer loop). | [`docs/agents/FLEET.md`](../FLEET.md) |
+
+The fleet verdict-label set (`fleet:approved`, `fleet:needs-fix`,
+`fleet:blocker`, `fleet:has-nits`) and the bail-label set are shared fleet
+machinery and are used concretely below; a repo that renames them notes the
+mapping in its wrapper.
+
+---
+
+## When to run
+
+Trigger from a persistent reviewer-loop session whose launch prompt told it
+to poll `gh pr list` and review anything new; in that mode the reviewer
+resolves the unreviewed set itself and invokes this once per PR. Or when the
+user explicitly asks ("review PR <N>", "review the last PR", etc.).
+
+Do **not** invoke proactively inside an unrelated working session (e.g.
+mid-refactor on your own PR). The bar: either the user asked, or this
+session's whole job is to be a reviewer.
+
+## Model expectations (two-tier review)
+
+Runs on either Sonnet or Opus:
+
+- **Sonnet first pass** — cheap, catches the 80% (style, obvious bugs,
+  missing null checks, naming, untested branches). A Sonnet reviewer is
+  thorough on the checklist but explicitly flags anything subtle (lifetime,
+  concurrency, an invariant several layers deep, a GPU/CPU handoff) with
+  "I am not confident on this invariant, please Opus-review:".
+- **Opus second pass (or sole pass)** — for any PR touching core invariants,
+  anything performance-sensitive, any GPU/CPU sync, any concurrency, or any
+  PR the Sonnet pass escalated. Opus also confirms earlier Sonnet nits were
+  addressed.
+
+When running as Sonnet, mention in the verdict whether Opus escalation is
+needed. When running as Opus on a PR with a prior Sonnet review, read it
+first and focus on what Sonnet couldn't confirm. See the **fleet doc**
+"Model split".
+
+## Preconditions
+
+1. `gh` authenticated (`gh auth status`).
+2. A PR number/URL or "latest" — resolve before starting.
+3. You are **not** the agent that wrote the code. If the author asks to
+   review their own work, warn them and offer to run it anyway with the
+   tunnel-vision caveat.
+
+---
+
+## Flow
+
+### 1. Resolve the PR and pull its metadata
+
+Read author/human PR comments **before** walking the diff — they flag
+deliberate scope ("I deferred X") and pre-flag concerns ("watch out for Y on
+macOS"). Missing them produces reviews that re-raise addressed points.
+
+```bash
+gh pr view <N> --json number,title,body,headRefName,baseRefName,author,files,additions,deletions,commits,mergeable,comments,reviews,labels
+gh api repos/<repo>/pulls/<N>/comments
+```
+
+The first returns issue-level comments, review summaries, and the live label
+set (for the step-1b bail check). The second returns inline (line-attached)
+code-review comments that `gh pr view --json` omits. The diff is fetched
+**after** the bail check so bail-label PRs never pay the diff round-trip.
+
+For "latest"/"most recent": `gh pr list --state open --limit 5`, pick the
+top, confirm with the user if ambiguous.
+
+### 1b. Label bail check + diff fetch
+
+**Before** fetching the diff, check the step-1 `labels` for bail labels:
+`fleet:semantic-conflict`, `fleet:merger-cooldown`, `fleet:wip`, `human:wip`,
+any `fleet:amending-*`. If any is present, release the claim and skip the PR
+without fetching the diff or posting:
+
+```bash
+<claim-tool> review-release <N> <your-worktree-name>
+```
+
+If none present, fetch the diff: `gh pr diff <N>`.
+
+### 1c. Check whether the PR is stacked
+
+Some PRs are stacked: their `--base` is another open PR's branch, not the
+default branch. The review is still per-PR; you don't re-review the parent.
+
+Quick detection from step-1 metadata: `baseRefName != <default-branch>` →
+stacked on that branch; a `Stacked on:` body line confirms it and gives the
+parent PR URL. If stacked, apply the **stacked-review procedure**, then
+return for step 1d. If standalone, continue to step 1d.
+
+### 1d. Churn audit when `mergeable == CONFLICTING`
+
+A CONFLICTING PR has a stale branch that can silently carry reverted hunks.
+When `mergeable` is `CONFLICTING`, run `gh pr diff <N> --stat` and apply:
+
+1. **Oversized churn** — any file with ≥100 added+deleted lines the body
+   doesn't mention. Flag **Needs-fix** (escalate to **Blocker** if it
+   deletes functions/files that break the build): the PR may be silently
+   reverting work that landed after the branch was cut.
+2. **Out-of-scope file** — any file in the stat that's neither described in
+   the body nor a known mechanical side-effect of the claimed scope. Flag
+   **Needs-fix**: author must acknowledge it or rebase to drop the hunk.
+
+If neither fires, note in the body: "CONFLICTING state checked — no
+out-of-scope files or oversized churn." If `mergeable` is anything else,
+skip this step.
+
+### 2. Check out the PR branch locally (read-only)
+
+```bash
+gh pr checkout <N>
+```
+
+You still have full read access to the rest of the repo for cross-reference.
+Do **not** commit or push from this worktree — you are a reader.
+
+### 3. Read the diff in context
+
+For each changed file: read the **full file**, not just the hunks (bugs hide
+in surrounding code); cross-reference any component/system/symbol name
+against existing conventions; if a shader changed, also read the CPU-side
+struct that feeds it (GPU layouts and CPU structs must stay in sync).
+
+Keep a running list ranked by severity. The boundary between **blocker** and
+**needs-fix** is "would the default branch survive this merge?":
+
+- **Blocker** — the build breaks, the app crashes/hangs, or data on disk is
+  corrupted if this lands. Unmergeable as-is.
+- **Needs-fix** — compiles and runs, but introduces a correctness/perf
+  regression that must be repaired before merge. Survives, but worse.
+- **Nit** — style, naming, minor simplification, docs. Truly optional.
+- **Praise** — a non-obvious good decision worth reinforcing.
+
+### 4. Apply the repo's review checklist
+
+Go through the **review checklist** (in the wrapper) explicitly. For every
+item, either confirm compliance or raise an issue. This is the repo-specific
+heart of the review — the engine's checklist covers ECS invariants,
+ownership/lifetime, the render pipeline, lighting, math/coordinates,
+serialization, naming/style, tests/build, and Opus-only deep items; a
+creation layered on the engine adds (or replaces with) its own domain rules.
+
+If the PR touches a subdirectory with its own `CLAUDE.md` (or `REVIEW.md`),
+read it **in addition to** the repo checklist and apply both — the repo
+checklist is the baseline, the subdirectory's rules are the delta.
+
+### 5. Write the review and set the verdict label
+
+**These are one indivisible action.** Post the review comment and set the
+verdict label in immediate succession — no intervening bash calls. A review
+without a verdict label is invisible to the human's merge queue.
+
+Post via `gh pr review`. **Do NOT use `--body "$(cat <<'EOF'…)"` or any
+`$(...)` command substitution** — it trips the security gate on backticks.
+Instead: `rm -f .review-body.md` (so the Write tool doesn't refuse), Write
+the body to `.review-body.md` in the worktree root (gitignored; NOT `/tmp/`),
+then:
+
+```bash
+gh pr review <N> --comment --body-file .review-body.md
+```
+
+Body shape:
+
+```markdown
+## Review — <title>
+
+**Verdict:** <approve | needs-fix | blocker>
+
+### Blockers
+- <path:line> — <issue> — <suggested fix>
+
+### Needs-fix
+- <path:line> — <issue> — <suggested fix>
+
+### Nits
+- <path:line> — <nit>
+
+### Praise
+- <non-obvious good decision, if any>
+
+### Test plan the author should run before merge
+- [ ] <...>
+
+🤖 Reviewed by Claude <model> (review-pr skill)
+```
+
+Rules: cite **file:line** for every issue; suggest a concrete fix, not just
+"this is wrong"; drop empty sections (don't write "None").
+
+**The bright line between Nits and needs-fix:** a Nit is *truly optional*.
+Anything you describe with "must resolve before merge", "pre-merge ask",
+"the comment and code must agree", or "needs to be reconciled" is **NOT a
+Nit** — it's needs-fix; move it and drop the verdict to `needs-fix`. The
+contradiction "approve, but please fix X before merge" is forbidden. Nits
+are still encouraged — author roles scan approved PRs and address every nit
+before landing, so put real nits in freely.
+
+**Do not use `gh pr review --approve` or `--request-changes`** — all fleet
+agents share one account and the API rejects formal review actions on your
+own PRs. The `--comment` review plus the verdict line is sufficient; merging
+is always the user's call.
+
+### 5b. Set the verdict label (continued)
+
+**Immediately after** the `gh pr review` call — your very next bash call —
+run the verdict-label swap. A PR has exactly one verdict label
+(`fleet:approved` / `fleet:needs-fix` / `fleet:blocker`) at a time;
+`fleet:has-nits` is orthogonal and rides on top of `fleet:approved`. Always
+remove stale verdict labels before adding the new one, and clear the
+stacked-PR gates (`fleet:awaiting-upstream-review`, `fleet:stacked-rebase`,
+`fleet:needs-base-update`) in the same swap. The verdict label is the
+**primary signal** the human uses to decide what to merge.
+
+### 5c. Tag for cross-host/backend smoke validation
+
+If the diff touches the paths the **smoke procedure** covers, apply it after
+the verdict label (it subtracts the author's host so only the other
+backend(s) get tagged). Otherwise skip to step 6.
+
+### 6. Report back
+
+Reply to the calling session with: PR number + title + verdict; count of
+blockers/needs-fix/nits; a link to the review comment; one sentence on what
+the author should do next.
+
+---
+
+## Anti-patterns
+
+- Approving work that violates an invariant "because the test passes" — some
+  invariants don't fail at test time.
+- Pushing commits to the PR branch from the reviewer worktree.
+
+## Re-review
+
+When the user says "re-review PR <N>" or a reviewer-loop session sees
+`fleet:changes-made` on a previously-flagged PR, the flow differs — you
+verify previously-flagged items against the new commits BEFORE running the
+checklist, else you re-flag already-fixed items. See the **re-review
+procedure**. (First review of a PR → use the standard flow above.)
+
+## Escalation footer
+
+Every review body ends with one escalation hint:
+
+- Sonnet first-pass, approve → `Escalation: none. Safe for merge.`
+- Sonnet first-pass, approve-with-Opus-recheck →
+  `Escalation: please Opus-recheck before merge (touches: <module(s)>).`
+- Sonnet first-pass, needs-fix/blocker →
+  `Escalation: author-agent to address, then re-request review.`
+- Opus review → no escalation line; the Opus verdict stands.

--- a/docs/agents/skills/start-next-task.md
+++ b/docs/agents/skills/start-next-task.md
@@ -1,0 +1,290 @@
+# start-next-task — shared flow
+
+The canonical `start-next-task` flow. Every repo that runs a fleet keeps
+its `.claude/skills/start-next-task/SKILL.md` as a thin wrapper that points
+here and supplies only its repo-specific **deltas** (below), so the flow
+itself is single-sourced and the wrappers cannot drift. See
+[`docs/design/skill-sharing.md`](../../design/skill-sharing.md) for the
+mechanism.
+
+Phrased in repo-neutral terms: wherever a step needs a repo-specific value
+it names a **delta key** in bold and the invoking wrapper resolves it from
+its own `## Deltas` section.
+
+---
+
+## Repo deltas this flow needs
+
+| Delta key | What it is | Engine value (example) |
+|---|---|---|
+| **default branch** | The branch fresh work bases off in standard mode. | `master` |
+| **remote** | The git remote PRs target. | `origin` |
+| **branch prefix** | Prefix for new feature branches. | `claude/` |
+| **worktree-assert command** | Command that fails if you're in the shared main clone. | `fleet-assert-worktree` |
+| **fleet doc** | The repo's fleet reference for the stacking-persistence mechanism. | [`docs/agents/FLEET.md`](../FLEET.md) |
+| **area examples** | Example `<area>` tokens for branch names. | `engine`, `render`, `game` |
+
+A creation that does not stack, or has no fleet-claim machinery, simply
+declares those deltas as "n/a" in its wrapper; the corresponding modes
+below then never activate.
+
+---
+
+## Modes
+
+The skill operates in three modes, selected in priority order at step 4:
+
+- **Fleet stack mode** (active `fleet-claim` molecule with remaining
+  tasks): branch off the **old branch** — the head ref of the PR that
+  `commit-and-push` just opened — so the downstream task's branch contains
+  the upstream commits while its PR's `--base <upstream>` keeps the diff
+  scoped. Selected via `fleet-claim molecule resume`.
+- **Cursor stack mode** (cursor flow only, driven by user cue): same
+  mechanic (branch off the old branch) but no molecule machinery. Activated
+  by stacking cues ("stack this", "next slice stacked", "keep stacking",
+  "stack the next on this PR") when no fleet molecule is active; the
+  **fleet doc** "Stacking in cursor flow" section documents the git-config
+  persistence.
+- **Standard mode** (no fleet molecule, no stack cue): branch off fresh
+  **default branch** at the **remote**. The historical behavior and most
+  common case.
+
+---
+
+## Preconditions
+
+1. **You must be in your own worktree, not the shared main clone.** Run the
+   **worktree-assert command** (optionally with your worktree basename). If
+   it exits non-zero, STOP and `cd` into your worktree before resetting the
+   branch — a `git checkout -B` in the shared main clone yanks the branch
+   another agent or the operator has checked out there. Human-only override:
+   `FLEET_ALLOW_MAIN_CLONE=1`.
+2. The working tree should be **clean**. If `git status` shows uncommitted
+   changes, stop and warn — either they belong in the previous PR (go back
+   to `commit-and-push`) or they are a WIP the user wants to keep.
+3. You should be on a feature branch whose PR is **already open and
+   pushed**. If the current branch has unpushed commits, stop and warn —
+   those commits would be stranded by the branch switch.
+4. `gh` authenticated.
+
+---
+
+## Flow
+
+### 1. Record what branch you were on
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Remember this — you reference it in the report, the user may want to check
+the PR is still tracking it, and stack mode (step 4) uses it as the new
+branch's base.
+
+### 2. Confirm the old branch's PR is pushed and open
+
+```bash
+gh pr list --head <old-branch-name> --state open --json number,url,title
+```
+
+- **One PR** → good; note the number and URL for the report.
+- **Zero PRs** → stop and warn. Either the previous `commit-and-push`
+  didn't finish or the PR was closed. Do not switch branches until the user
+  says what to do — un-PR'd work would be lost.
+- **Multiple PRs** → unusual. Note all of them and continue.
+
+### 3. Fetch latest remote default branch
+
+```bash
+git fetch <remote> <default-branch>
+```
+
+Never rely on a stale local default-branch ref. Always fetch before
+branching.
+
+### 4. Detect mode
+
+Three modes, first match wins.
+
+#### 4a. Fleet stack mode
+
+If the current task is part of a `fleet-claim stack` chain, the next branch
+must build on the just-opened PR's head ref. Probe the molecule (agents
+know their own worktree name from their role instructions):
+
+```bash
+fleet-claim molecule resume <your-worktree-name>
+```
+
+Interpret stdout (the helper always exits 0; discriminate via stdout):
+
+- **stdout names an issue number** — active stack with remaining tasks. The
+  number is the **next** task (resume marks the first pending task
+  in-progress as a side effect).
+  - **Sanity-check:** if the returned number matches the old branch's issue
+    prefix, the worker forgot to run `fleet-claim molecule advance <agent>
+    <id> done pr=<URL> commit=<SHA>` after `commit-and-push`. Stop and tell
+    the user to advance the molecule first — else you branch back onto the
+    same task.
+  - Otherwise the new branch is `<branch prefix><returned-issue#>-<short-topic>`
+    based on the **old branch**. Set `MODE=fleet-stack`,
+    `BASE=<old-branch-name>`, remember `<returned-issue#>` for step 5.
+- **stdout is empty** — no fleet molecule. Continue to 4b.
+
+If `molecule resume` exits non-zero, stop and surface stderr — that's a
+real fault, not a "no work" signal. In a cursor-flow session with no
+fleet-claim machinery this probe returns empty (expected).
+
+#### 4b. Cursor stack mode
+
+If 4a returned empty AND the cue contains a stacking phrase ("stack this",
+"next slice stacked", "keep stacking", "stack the next on this PR", "build
+on the last PR"): set `MODE=cursor-stack`, `BASE=<old-branch-name>`.
+Step 7b persists the parent branch.
+
+If the cue is fresh-start ("next task", "I merged it", "back to master",
+etc.): continue to 4c.
+
+If the cue is ambiguous and the old branch already has `cursor-stack-base`
+set, ask whether to continue the stack or branch fresh — don't guess (see
+the **fleet doc** "Stacking in cursor flow").
+
+#### 4c. Standard mode
+
+Default. `MODE=standard`, `BASE=<remote>/<default-branch>`. Proceed.
+
+### 5. Derive a new branch name
+
+- **Fleet stack mode:** `<branch prefix><issue#>-<short-topic>`. Pull the
+  topic from the issue title (`fleet-issue view <issue#>`, falling back to
+  `gh issue view <issue#>`). Prefer a name the user already gave.
+- **Cursor stack mode:** `<branch prefix><area>-<topic>`, no issue-number
+  prefix. Derive from the conversation; the user usually names the next
+  slice when cueing the stack. If not, ask. Example: a tuning slice stacked
+  on a feature branch.
+- **Standard mode:** ask the user what the next task is if they haven't
+  said. Derive a short kebab-case name prefixed `<branch prefix><area>-`,
+  using one of the repo's **area examples**.
+
+Either way: no random suffixes — permanent worktrees work best with
+human-readable, topic-named branches.
+
+### 6. Discard any staged or working-tree changes from the old branch
+
+```bash
+git restore --staged .
+git checkout -- .
+```
+
+No-ops if the precondition clean-check passed; otherwise they clear
+leftovers that would fail the next `git checkout` with "your local changes
+would be overwritten by checkout."
+
+### 7. Check out the new branch off the right base
+
+```bash
+git checkout -B <new-branch> <remote>/<default-branch>   # standard mode
+git checkout -B <new-branch> <old-branch-name>           # fleet/cursor stack
+```
+
+`-B` (uppercase) creates the branch if absent AND resets it to the named
+commit if present — lowercase `-b` errors "branch already exists", common
+because a worktree accumulates scratch branches over many iterations.
+
+In **standard mode** this starts from the tip of the remote default branch;
+without it you'd carry the old PR's commits forward. In **stack modes** the
+downstream slice intentionally contains the upstream commits — the
+downstream PR's `--base` (set later by `commit-and-push`) is the upstream
+branch, so the diff still shows only the downstream changes.
+
+**Sandbox note.** `git checkout -B` writes `.git/config` for branch
+tracking. On a sandboxed Bash (e.g. macOS Cursor), `.git/config` writes
+need the elevated permission — without it the checkout *appears* to succeed
+but the tracking config is missing. Run this checkout with sandbox bypass
+where that applies.
+
+**Do NOT** `git rebase <remote>/<default-branch>` on the old branch and
+keep working on it — that mixes old PR commits with new work and pollutes
+the old PR when you push. Always start a new branch.
+
+### 7b. Record the cursor-stack base (cursor stack mode only)
+
+```bash
+git config branch.<new-branch>.cursor-stack-base <old-branch-name>
+```
+
+Same `.git/config` write as step 7 — needs the elevated sandbox
+permission where applicable. Skip in fleet stack and standard modes. See
+the **fleet doc** "Stacking in cursor flow" for the cross-chat persistence.
+
+### 8. Sanity-check the state
+
+```bash
+git status
+git log --oneline -5
+```
+
+- `git status`: `nothing to commit, working tree clean`.
+- **Standard mode:** top commit is the latest default-branch commit, not
+  one of your previous PR's commits.
+- **Stack modes:** top commit is the just-opened PR's tip. The new branch's
+  merge-base with the remote default branch is whatever the old branch
+  branched from — expected.
+
+In cursor stack mode also run
+`git config --get branch.<new-branch>.cursor-stack-base` — should print the
+old branch; if empty, retry step 7b with elevated permissions.
+
+If the top commit is wrong for the mode, the checkout went wrong — stop and
+investigate.
+
+### 9. Read the relevant CLAUDE.md for the new task area
+
+Before starting, read the most specific `CLAUDE.md` for the directory
+you're about to work in (e.g. a module's own `CLAUDE.md`, or a creation
+subdirectory's `CLAUDE.md` — creations define their own conventions). This
+primes your context with the module's gotchas. If the subdirectory has a
+dedicated workflow that differs from the repo baseline, honor it.
+
+### 10. Report
+
+Reply with a compact summary:
+
+- **Mode** (standard / fleet-stack / cursor-stack).
+- Old branch name + its PR URL (from step 2).
+- New branch name + the base it tracks. In standard mode that's the fresh
+  remote default branch; in either stack mode call out the upstream branch
+  explicitly so the pipeline isn't surprised when `commit-and-push` later
+  sets `--base <upstream>`.
+- In cursor stack mode: confirm `branch.<new>.cursor-stack-base` was
+  recorded.
+- The CLAUDE.md files you read to prime context.
+- One sentence: "Ready for <next task>. Go ahead."
+
+---
+
+## Anti-patterns
+
+- Running `git rebase <remote>/<default-branch>` on the old branch to
+  "catch it up", then reusing it. Rebasing the same branch for unrelated
+  new work is how PR histories become unreadable.
+- Deleting the old local branch. Leave it — if the reviewer asks for
+  changes you'll need it again, and both stack modes REQUIRE it as the new
+  branch's base.
+
+## Recovery
+
+If you discover after switching that the old branch had uncommitted work:
+
+1. `git checkout <old-branch>`
+2. Stash or commit the dirty work on the old branch.
+3. Push and update the PR.
+4. `git checkout <new-branch>` to return.
+
+If you set up cursor stack mode and later decide the slice should base on
+the default branch after all:
+
+1. `git config --unset branch.<new-branch>.cursor-stack-base` (elevated
+   permission where applicable).
+2. `git rebase --onto <remote>/<default-branch> <old-branch> <new-branch>`.
+3. Continue. `commit-and-push` will now open the PR vs the default branch.

--- a/docs/design/claude-md-sharing.md
+++ b/docs/design/claude-md-sharing.md
@@ -1,5 +1,12 @@
 # CLAUDE.md sharing — design
 
+> **Sibling:** [`skill-sharing.md`](skill-sharing.md) applies this same
+> reference-by-name-with-explicit-deltas pattern to fleet **skills** — the
+> shared *flow* of `commit-and-push` / `review-pr` / `start-next-task` /
+> `file-epic` lives in one canonical `docs/agents/skills/<name>.md` and each
+> repo's `SKILL.md` is a thin wrapper carrying only deltas. Read both
+> together: this doc covers cross-cutting rules, that one covers skills.
+
 ## Problem
 
 Multiple creations layer on the engine. Cross-cutting rules — naming

--- a/docs/design/skill-sharing.md
+++ b/docs/design/skill-sharing.md
@@ -1,0 +1,202 @@
+# Skill sharing — design
+
+Sibling to [`claude-md-sharing.md`](claude-md-sharing.md). That doc shares
+cross-cutting **rules** via a canonical baseline a creation references by
+name. This doc extends the same pattern to **fleet skills**: the shared
+*flow* of a skill lives in one canonical doc, and each repo's `SKILL.md` is
+a thin wrapper that references it and supplies only that repo's deltas.
+
+## Problem
+
+Several fleet skills — `commit-and-push`, `review-pr`, `start-next-task`,
+`file-epic` — are run by every repo that participates in the fleet (the
+engine, and each creation layered on it that runs its own fleet). They were
+kept as **full forked copies** in each repo's `.claude/skills/<name>/`.
+
+The copies differ only in **data** — the remote/repo slug, the branch
+prefix, the commit scope-prefix vocabulary, the visual-file globs, the
+host-smoke labels, the domain-specific review checklist — yet the entire
+step-by-step flow was duplicated. Forks drift: a skill gains a step in one
+repo and the copies lag. This is how a downstream fleet ended up still
+running a retired queue flow long after the engine moved on, and how a stale
+cross-reference produced a wrong smoke label on a PR.
+
+The same failure modes `claude-md-sharing.md` calls out for rules
+(duplication drifts; soft references depend on the agent actually reading
+the pointed-to file) apply here.
+
+---
+
+## Decision
+
+**Each shared skill's flow lives verbatim in a single canonical doc at
+`docs/agents/skills/<name>.md`, phrased in repo-neutral terms. Each repo's
+`.claude/skills/<name>/SKILL.md` is reduced to a thin wrapper: the harness
+frontmatter (which stays), a one-line pointer at the canonical flow, and a
+`## Deltas` section giving this repo's concrete value for every delta key the
+flow names.**
+
+Concretely:
+
+1. The canonical doc carries the ordered steps, preconditions, invariants,
+   anti-patterns, and report shape. Wherever a step needs a repo-specific
+   value it names a **delta key** in bold (e.g. **default branch**,
+   **branch prefix**, **scope vocabulary**, **review checklist**), and lists
+   every key in a `## Repo deltas this flow needs` table at the top.
+2. The wrapper keeps its YAML frontmatter (`name` + `description`) unchanged
+   — the harness reads it as the skill's identity and trigger surface, and
+   the trigger phrasing is itself per-repo. The body becomes: a pointer at
+   `docs/agents/skills/<name>.md`, and a `## Deltas` table answering each
+   delta key with this repo's value, plus any genuinely repo-specific
+   addenda (e.g. the engine's review checklist, or its procedure files).
+3. The delta-key names are the **stable contract** between a canonical flow
+   and its wrappers. Renaming a key is a breaking change that requires
+   sweeping every wrapper — same discipline as renaming a baseline heading
+   in `claude-md-sharing.md`.
+
+### Shared vs. delta — where the line falls
+
+The fleet itself (the `fleet-claim` tool, the `fleet:*` label vocabulary,
+the stack modes, the scout-driven reviewer loop) is **shared infrastructure**
+that both the engine and its creations run. So fleet mechanics live in the
+canonical flow concretely; they are not engine-specific. What is genuinely
+per-repo, and therefore a delta:
+
+- **Identity** — the repo slug / remote, the default branch.
+- **Vocabulary** — commit scope prefixes, child-title `<area>` tokens.
+- **Path sets** — the visual-file globs that trigger screenshots, the paths
+  the cross-host smoke procedure covers.
+- **Domain rules** — `review-pr`'s checklist is inherently repo-specific
+  (the engine checks ECS/render invariants; a game checks its simulation
+  model). It stays in the wrapper as a large but legitimate delta. This is
+  the "genuinely creation-specific skills/parts stay full" carve-out.
+- **Procedure files** — the per-skill `procedures/*.md` expansions carry the
+  repo's concrete command sequences (its `fleet-claim` calls, label strings,
+  host table). They remain beside the wrapper and are referenced from it as
+  a delta. A creation may point its wrapper at the engine's procedures when
+  they are pure fleet-mechanics, or supply its own; either way the *flow*
+  doc never embeds one repo's procedure paths.
+
+A skill with no meaningful shared flow (the rendering/Lua/creation-authoring
+skills) stays a full standalone `SKILL.md`. Only skills duplicated across
+fleets are factored.
+
+### Why runtime indirection, not a commit-time generator
+
+The ticket called for a decision: a wrapper means the agent **`Read`s the
+canonical flow at invoke time** (runtime indirection), OR a commit-time sync
+**generates** a full `SKILL.md` from shared-body + deltas (zero runtime
+indirection). **We choose runtime indirection**, for the same reasons
+`claude-md-sharing.md` rejected a build-time merge:
+
+- A generator introduces a generated-file invariant — it must run after
+  every canonical-flow edit, the output must be checked in, and a CI gate
+  must assert it is not stale. That staleness risk is exactly the drift this
+  design exists to remove, merely relocated from "human forgot to sync the
+  fork" to "human forgot to regenerate."
+- It adds tooling and cognitive overhead for a population of four skills and
+  a handful of repos.
+- The harness loads `SKILL.md` as the skill body and does **not** auto-inline
+  a referenced doc, but agents already follow prose pointers reliably — this
+  is the identical indirection the role docs use for the
+  `docs/agents/*-PROTOCOL.md` / `AUTHOR-PIPELINE.md` shared protocols, and
+  that `claude-md-sharing.md` uses for `CLAUDE-BASELINE.md`. One extra `Read`
+  per skill invocation is the whole cost.
+
+The benefit is the same single-source-of-truth: editing
+`docs/agents/skills/<name>.md` changes every repo's behavior at once, with
+each repo's deviations explicit and version-controlled in its wrapper.
+
+---
+
+## Wrapper shape (template)
+
+```markdown
+---
+name: <skill-name>
+description: >-
+  <unchanged — the harness trigger surface, per-repo by nature>
+---
+
+# <skill-name> (<Repo Name>)
+
+**The flow lives in [`docs/agents/skills/<name>.md`](<relative path>).**
+Read it first, then apply the deltas below. This wrapper carries deltas
+only — see [`docs/design/skill-sharing.md`](<relative path>) for why.
+
+## Deltas (<Repo Name>)
+
+| Delta key | <Repo> value |
+|---|---|
+| **<key>** | <value> |
+| ... | ... |
+
+## <Repo> notes / procedures   (optional — repo-specific addenda)
+```
+
+The relative paths differ per repo layout. In the engine repo a skill at
+`.claude/skills/<name>/SKILL.md` reaches the canonical flow at
+`../../../docs/agents/skills/<name>.md`. A creation whose worktree sits
+inside the engine clone uses the same `docs/agents/skills/` path (it reads
+the engine's canonical flow directly); a creation in a fully separate clone
+vendors or path-rewrites the reference, the same follow-up
+`claude-md-sharing.md` flags for out-of-clone creations.
+
+---
+
+## Discovery
+
+By reference, not inline — identical to `claude-md-sharing.md`. When a skill
+is invoked the agent reads two files: the wrapper (loaded by the harness as
+the skill body) and the canonical flow (the wrapper's first line points at
+it). Inlining the flow into every wrapper would solve discovery but recreate
+the duplication this design removes.
+
+---
+
+## Reference implementation
+
+The PR introducing this design ships, in the engine repo:
+
+- `docs/agents/skills/{commit-and-push,review-pr,start-next-task,file-epic}.md`
+  — the four canonical flows.
+- The four `.claude/skills/<name>/SKILL.md` reduced to wrappers (frontmatter
+  + pointer + `## Deltas`). The engine `procedures/` subdirectories are
+  unchanged and referenced from the wrappers as deltas.
+- This design doc, cross-linked from `claude-md-sharing.md`.
+
+The role-doc side of the same inheritance model (downstream role docs
+referencing the shared `docs/agents/*-PROTOCOL.md` protocols instead of
+carrying copies) is tracked downstream; this design is the engine-owned
+skills factoring.
+
+---
+
+## Future considerations
+
+### Sharing the `procedures/` too
+
+The per-skill `procedures/*.md` files are today per-repo deltas. Several
+(`rebase-guard.md`, the stack-mode mechanics, `re-review.md`) are pure
+fleet-mechanics with no engine-specific data and could themselves be
+promoted to `docs/agents/skills/procedures/` and referenced the same way.
+Out of scope for the first pass — promote a procedure only once a second
+repo would otherwise fork it.
+
+### CI validation
+
+A lint check can assert that (a) every wrapper's `## Deltas` table answers
+every delta key its canonical flow names, and (b) every canonical flow has at
+least one wrapper. A grep over `docs/agents/skills/*.md` for bold
+`**delta keys**` cross-referenced against each `SKILL.md`'s Deltas table
+would catch an unanswered key after a flow gains a new one. Out of scope
+while the set is four skills; revisit when wrappers start missing keys.
+
+### When to factor a new skill
+
+Factor a skill into a canonical flow only when it is **run by more than one
+fleet** and the copies **differ only in data**. A skill unique to one repo,
+or whose logic (not just its data) legitimately differs per repo, stays a
+full standalone `SKILL.md`. When in doubt, leave it standalone — the cost of
+a premature canonical flow that every repo wants to override is higher than
+one more fork.

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -14,6 +14,14 @@
 # (gh issue edit --add-label converges either way, but the re-check
 # avoids burning API budget on already-stamped issues).
 #
+# Blocked-by gate (#1476): an issue is stamped fleet:queued only when every
+# `**Blocked by:** #N` predecessor is CLOSED/MERGED. The scout's ingest
+# projection already keeps blocked children out of the pending set; the
+# per-issue live `gh issue view <ref> --json state` re-check here is the
+# authoritative gate at the actual stamp point (and the sole gate when ingest
+# runs against a hand-built projection). So a freshly-filed stacked epic shows
+# only its head queued; each child is queued as its blocker closes.
+#
 # Source of truth: scripts/fleet/fleet-queue-ingest in the engine repo.
 # Installed to ~/bin/fleet-queue-ingest by scripts/fleet/install.sh.
 
@@ -180,18 +188,23 @@ try:
     data = json.load(open(proj_path))
     pending = data.get('pending_issues', [])
 except Exception:
-    print('0,0,0')
+    print('0,0,0,0')
     sys.exit(0)
 
 # Body-field parsers mirror fleet-state-scout._parse_issue_field so we
 # label issues by the same fields the scout reads back out.
 MODEL_RE = re.compile(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
 BLOCKED_RE = re.compile(r'\*\*(?:Suggested\s+)?Blocked by:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
+# Inline-bold form `**Blocked by: #N (label)**` (#1423): colon + value inside
+# one bold span. Mutually exclusive with BLOCKED_RE (canonical bold closes at
+# the colon), so scanning both over the whole body never double-counts a line.
+BLOCKED_INLINE_RE = re.compile(r'\*\*(?:Suggested\s+)?Blocked by:\s+(.+?)\*\*', re.IGNORECASE)
 # Free-form header prose like `## Blocked on #1300` / `Blocked on PR-x` is an
 # alternate dependency declaration the scout's _parse_blocked_by also reads, so
 # don't warn "treat as unblocked" for an issue whose blocker lives only in a
 # header (#1326). Only count prose that names a #N or PR reference.
 BLOCKED_ON_RE = re.compile(r'(?im)^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$')
+REF_RE = re.compile(r'#(\d+)')
 
 
 def _has_header_blocker(text):
@@ -201,9 +214,51 @@ def _has_header_blocker(text):
             return True
     return False
 
+
+def _blocker_refs(body):
+    """All `#N` predecessor refs from canonical `**Blocked by:** #N` lines, the
+    inline-bold `**Blocked by: #N**` form, and `Blocked on` header prose.
+    Mirrors fleet-state-scout._parse_blocked_by so the gate reads the same refs
+    the scout and fleet-claim do. `(none)` values contribute nothing."""
+    vals = [m.group(1) for m in BLOCKED_RE.finditer(body)]
+    vals += BLOCKED_INLINE_RE.findall(body)
+    real = [v.strip() for v in vals if not v.strip().lower().startswith('(none')]
+    refs = []
+    for v in real:
+        refs.extend(REF_RE.findall(v))
+    if refs:
+        return refs
+    # No canonical/inline #N refs → fall back to a `Blocked on …` header.
+    for m in BLOCKED_ON_RE.finditer(body):
+        cand = m.group(1).strip().strip('*').strip()
+        if cand and ('#' in cand or re.search(r'\bPR\b', cand, re.IGNORECASE)):
+            refs.extend(REF_RE.findall(cand))
+    return refs
+
+
+def _blocker_open(repo, ref, cache):
+    """True when predecessor #ref is still open (state not CLOSED/MERGED).
+    Per-run cache dedupes repeated refs across the batch. An unreadable state
+    is treated as still-open — defer queuing rather than risk queuing a child
+    whose blocker we could not confirm closed."""
+    key = (repo, ref)
+    if key in cache:
+        return cache[key]
+    r = subprocess.run(
+        ['gh', 'issue', 'view', ref, '--repo', repo,
+         '--json', 'state', '--jq', '.state'],
+        capture_output=True, text=True, timeout=15,
+    )
+    state = r.stdout.strip() if r.returncode == 0 else ''
+    is_open = state not in ('CLOSED', 'MERGED')
+    cache[key] = is_open
+    return is_open
+
 stamped = 0
 skipped_already = 0
+skipped_blocked = 0
 failed = 0
+blocker_cache = {}
 
 for issue in pending:
     n = issue.get('number', 0)
@@ -242,6 +297,23 @@ for issue in pending:
         print(f'INFO issue {repo}#{n}: human:owned — skipping ingest (human de-queued)', file=sys.stderr)
         continue
 
+    # Blocked-by gate (#1476): never stamp fleet:queued onto a child whose
+    # **Blocked by:** predecessors aren't all closed. fleet-claim already
+    # enforces this at claim time, but stamping a blocked child anyway makes a
+    # stacked epic show every child queued at once, defeating "queue one at a
+    # time". The scout's projection normally keeps blocked children out of the
+    # pending set; this is the authoritative live re-check at the actual stamp
+    # point — and the only gate when ingest runs against a hand-built
+    # projection (e.g. tests, or a manual fleet-queue-ingest invocation).
+    open_blockers = [ref for ref in _blocker_refs(body)
+                     if _blocker_open(repo, ref, blocker_cache)]
+    if open_blockers:
+        skipped_blocked += 1
+        joined = ', '.join(f'#{r}' for r in open_blockers)
+        print(f'INFO issue {repo}#{n}: blocked by open {joined} — '
+              'deferring fleet:queued until predecessors close', file=sys.stderr)
+        continue
+
     # Parse model from body. Default to fleet:opus on ambiguity — mirrors
     # the safer default when model intent is unclear.
     model_match = MODEL_RE.search(body)
@@ -271,13 +343,13 @@ for issue in pending:
         continue
     stamped += 1
 
-print(f'{stamped},{skipped_already},{failed}')
+print(f'{stamped},{skipped_already},{failed},{skipped_blocked}')
 STAMP_PY
 )
 
 if [[ -n "$stamping_out" ]]; then
-    IFS=',' read -r stamped_count skipped_count failed_count <<< "$stamping_out"
-    log "stamped ${stamped_count:-0} issue(s); skipped ${skipped_count:-0} already-labeled; ${failed_count:-0} failed"
+    IFS=',' read -r stamped_count skipped_count failed_count blocked_count <<< "$stamping_out"
+    log "stamped ${stamped_count:-0} issue(s); skipped ${skipped_count:-0} already-labeled; ${blocked_count:-0} blocked (deferred); ${failed_count:-0} failed"
 fi
 
 log "ingestion iteration complete"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -170,11 +170,16 @@ _INGEST_SKIP_LABELS = frozenset({
 })
 
 
-def fetch_issues_by_label(repo, filter_label, exclude_labels=None):
+def fetch_issues_by_label(repo, filter_label, exclude_labels=None, with_body=False):
+    # with_body pulls the issue body too — the queue-manager-ingest projection
+    # needs it to resolve each human:approved issue's `**Blocked by:**` chain
+    # (resolve_human_approved_blockers); the cheaper label-only fetch is the
+    # default for callers that never inspect blockers (needs-plan).
+    fields = "number,title,labels,updatedAt" + (",body" if with_body else "")
     out = run_capture([
         "gh", "issue", "list", "--repo", repo,
         "--label", filter_label, "--state", "open",
-        "--json", "number,title,labels,updatedAt",
+        "--json", fields,
     ])
     if out is None:
         return []
@@ -197,7 +202,10 @@ def fetch_needs_plan(repo):
 
 def fetch_human_approved(repo):
     # Exclude already-ingested issues to avoid re-triggering queue-manager.
-    return fetch_issues_by_label(repo, "human:approved", _ALREADY_QUEUED_LABELS)
+    # with_body=True so resolve_human_approved_blockers can parse the
+    # `**Blocked by:**` chain and keep blocked children out of the ingest set.
+    return fetch_issues_by_label(repo, "human:approved", _ALREADY_QUEUED_LABELS,
+                                 with_body=True)
 
 
 def fetch_closed_fleet_queued(repo, limit=100):
@@ -925,6 +933,60 @@ def resolve_blocked_by(state):
                 task["blocked_by"] = ", ".join(f"#{r}" for r in unresolved)
 
 
+def resolve_human_approved_blockers(state):
+    """Annotate each human:approved issue with `blocked` — True when one or
+    more of its `**Blocked by:**` predecessors is still open.
+
+    The queue-manager-ingest projector/slicer treat a blocked issue like a
+    skip-label issue: it stays OUT of the actionable set, so a freshly-filed
+    stacked epic contributes only its workable head to the trigger hash and
+    the ingest pass. The moment the last blocker closes (and lands in this
+    repo's closed_fleet_queued / recent_merged_prs window) `blocked` flips
+    False, the issue ENTERS the set, the hash flips, and the scout spawns
+    fleet-queue-ingest to queue the now-workable child — the "queue one at a
+    time / queue the next child when a blocker closes" behavior (#1476).
+
+    Resolution is in-memory only (closed_fleet_queued + merged `claude/<N>-*`
+    heads), mirroring resolve_blocked_by()'s cheap path — NO live gh here, so
+    the per-tick projection stays fast. fleet-queue-ingest does the
+    authoritative live `gh issue view` re-check before it actually stamps
+    fleet:queued, so this flag only decides *when the trigger fires*, never
+    whether the label is applied. `body` is popped after parsing so it never
+    bloats state.json or the per-role slices.
+    """
+    for repo_key, repo_state in state["repos"].items():
+        closed_nums = {
+            str(i.get("number", ""))
+            for i in repo_state.get("closed_fleet_queued", [])
+            if i.get("number")
+        }
+        merged_heads = [
+            pr.get("headRefName", "") or ""
+            for pr in repo_state.get("recent_merged_prs", [])
+        ]
+
+        for issue in repo_state.get("human_approved", []):
+            body = issue.pop("body", "") or ""
+            issue["blocked"] = False
+            raw = _parse_blocked_by(body)
+            if not raw:
+                continue
+            refs = _BLOCKER_REF_RE.findall(raw)
+            if not refs:
+                # Blocker named only as prose / a PR URL with no resolvable #N
+                # (e.g. "Blocked on the redesign"). Hold the child out of the
+                # trigger set — matches resolve_blocked_by leaving it blocked.
+                issue["blocked"] = True
+                continue
+            for ref in refs:
+                if ref in closed_nums:
+                    continue
+                if any(branch_matches_issue(h, ref, repo_key) for h in merged_heads):
+                    continue
+                issue["blocked"] = True
+                break
+
+
 def enrich_stackable_blocker_prs(state):
     # Per T-110 PR 2: for each task whose blocked_by is exactly one issue
     # number (`#NNN`) with exactly one matching open PR (head ref
@@ -1160,11 +1222,19 @@ def project_queue_manager_ingest(state):
     `human_approved` already excludes `fleet:queued` via fetch_human_approved;
     _INGEST_SKIP_LABELS mirrors the role-doc Step 5 filter so epics and
     un-planned issues don't hold the hash non-zero indefinitely.
+
+    `blocked` issues (set by resolve_human_approved_blockers — a `**Blocked
+    by:**` predecessor is still open) are excluded too, so a stacked epic
+    contributes only its workable head to the hash. When the last blocker
+    closes the child's `blocked` flips False, it re-enters the set, the hash
+    flips, and ingest re-fires to queue it (#1476).
     """
     items = []
     for repo, repo_state in state["repos"].items():
         for issue in repo_state.get("human_approved", []):
             if set(issue.get("labels", [])) & _INGEST_SKIP_LABELS:
+                continue
+            if issue.get("blocked"):
                 continue
             items.append({"repo": repo, "issue": issue["number"]})
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
@@ -1322,11 +1392,16 @@ def slice_queue_manager_ingest(state):
     """Slice for fleet-queue-ingest. Mirrors the projector — list of
     actionable issues the human has approved but the queue hasn't filed yet.
     Applies _INGEST_SKIP_LABELS so the LLM slice never includes epics or
-    un-planned issues that the role-doc skips at Step 5."""
+    un-planned issues that the role-doc skips at Step 5, and skips `blocked`
+    issues (an open `**Blocked by:**` predecessor) so fleet-queue-ingest's
+    pending set only carries workable issues — the head of a stacked epic,
+    then each child as its blocker closes (#1476)."""
     out = {"pending_issues": []}
     for repo_key, repo_state in state["repos"].items():
         for issue in repo_state.get("human_approved", []):
             if set(issue.get("labels", [])) & _INGEST_SKIP_LABELS:
+                continue
+            if issue.get("blocked"):
                 continue
             out["pending_issues"].append(_slice_issue_with_repo(repo_key, issue))
     return out
@@ -1461,6 +1536,7 @@ def tick_once():
     state = collect_state()
     _populate_done_tasks(state)
     resolve_blocked_by(state)
+    resolve_human_approved_blockers(state)
     enrich_stackable_blocker_prs(state)
     write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
 

--- a/scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Test that fleet-queue-ingest honors `**Blocked by:**` (Gap 2 of #1476).
+#
+# An issue is stamped fleet:queued only when every `**Blocked by:** #N`
+# predecessor is CLOSED/MERGED. A freshly-filed stacked epic must therefore
+# show only its head queued, not every child at once. fleet-claim already
+# enforces Blocked-by at claim time; this gate makes the LABEL honest.
+#
+# HOME is redirected to a temp dir so the script's hardcoded projection/log/lock
+# paths land in the sandbox, and `gh` is stubbed to canned issue/PR surfaces.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INGEST="$SCRIPT_DIR/fleet-queue-ingest"
+
+if [[ ! -x "$INGEST" ]]; then
+    echo "test setup: fleet-queue-ingest not found at $INGEST" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
+
+PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
+# A stacked epic: #730 is the head (no blocker), #731 is blocked by an OPEN
+# predecessor (#719), #732 is blocked by a CLOSED predecessor (#718).
+cat > "$PROJ" <<'JSON'
+{"pending_issues":[
+  {"number":730,"repo":"engine"},
+  {"number":731,"repo":"engine"},
+  {"number":732,"repo":"engine"}
+]}
+JSON
+
+# --- gh stub --------------------------------------------------------------
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    issue)
+        case "$2" in
+            view)
+                # Blocker-state probes pass `--jq .state`; the stamping fetch
+                # asks for `--json body,labels`. Dispatch on which one this is.
+                if [[ "$*" == *"--jq"* ]]; then
+                    case "$3" in
+                        718) echo "CLOSED" ;;   # #732's predecessor — satisfied
+                        719) echo "OPEN" ;;     # #731's predecessor — still open
+                        *)   echo "OPEN" ;;
+                    esac
+                    exit 0
+                fi
+                case "$3" in
+                    730) echo '{"body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    731) echo '{"body":"**Model:** sonnet\n**Blocked by:** #719","labels":[{"name":"human:approved"}]}' ;;
+                    732) echo '{"body":"**Model:** opus\n**Blocked by:** #718","labels":[{"name":"human:approved"}]}' ;;
+                    *)   echo '{"body":"","labels":[]}' ;;
+                esac
+                exit 0 ;;
+            edit)
+                printf '%s\n' "$*" >> "$EDIT_LOG"
+                exit 0 ;;
+            comment) exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        case "$2" in
+            list) echo '[]'; exit 0 ;;   # scope-shipped: no merged coverage
+            *) exit 0 ;;
+        esac ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+echo "=== run fleet-queue-ingest over a stacked epic (head + blocked + unblocked children) ==="
+bash "$INGEST" >/dev/null 2>&1 || true
+
+# #730 (head, no blocker) must be stamped fleet:queued.
+if grep -qE '(^| )730( |$)' "$EDIT_LOG" && grep -q 'fleet:queued' "$EDIT_LOG"; then
+    ok "head #730 (no blocker) was stamped fleet:queued"
+else
+    bad "head #730 was NOT stamped — gate is over-blocking or harness broken"
+fi
+
+# #732 (blocker CLOSED) must be stamped — a satisfied predecessor does not gate.
+if grep -qE '(^| )732( |$)' "$EDIT_LOG"; then
+    ok "#732 (predecessor #718 CLOSED) was stamped"
+else
+    bad "#732 was NOT stamped — gate wrongly blocked on a CLOSED predecessor"
+fi
+
+# #731 (blocker OPEN) must NOT be stamped — deferred until #719 closes.
+if grep -qE '(^| )731( |$)' "$EDIT_LOG"; then
+    bad "#731 was stamped despite OPEN predecessor #719: $(grep 731 "$EDIT_LOG")"
+else
+    ok "#731 (predecessor #719 OPEN) was deferred — not stamped"
+fi
+
+# The blocker issues themselves must never be edited (we only read their state).
+if grep -qE '(^| )(718|719)( |$)' "$EDIT_LOG"; then
+    bad "a blocker issue (#718/#719) was edited — gate must only READ blocker state"
+else
+    ok "blocker issues #718/#719 were never edited (read-only state probe)"
+fi
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_queue_manager_projection.py
+++ b/scripts/fleet/tests/test_queue_manager_projection.py
@@ -26,10 +26,12 @@ project_queue_manager = _mod.project_queue_manager
 slice_queue_manager = _mod.slice_queue_manager
 project_queue_manager_ingest = _mod.project_queue_manager_ingest
 slice_queue_manager_ingest = _mod.slice_queue_manager_ingest
+resolve_human_approved_blockers = _mod.resolve_human_approved_blockers
 stable_hash = _mod.stable_hash
 
 
-def _state(*, engine_merged=None, engine_done=None, engine_human_approved=None):
+def _state(*, engine_merged=None, engine_done=None, engine_human_approved=None,
+           engine_closed=None):
     """Build a minimal scout-state dict with the fields the projection reads."""
     return {
         "repos": {
@@ -37,7 +39,7 @@ def _state(*, engine_merged=None, engine_done=None, engine_human_approved=None):
                 "needs_plan": [],
                 "human_approved": engine_human_approved or [],
                 "tasks": {"open": [], "in_progress": [], "done": engine_done or []},
-                "closed_fleet_queued": [],
+                "closed_fleet_queued": engine_closed or [],
                 "recent_merged_prs": engine_merged or [],
             },
         },
@@ -205,6 +207,98 @@ class IngestProjectionFiresOnNewApprovedIssue(unittest.TestCase):
         out = slice_queue_manager_ingest(_state(engine_human_approved=parked))
         self.assertEqual(out["pending_issues"], [],
                          "needs-human issue must be absent from pending_issues slice")
+
+
+class IngestHonorsBlockedBy(unittest.TestCase):
+    """resolve_human_approved_blockers() flags issues whose `**Blocked by:**`
+    predecessors are still open; the ingest projector + slicer then exclude
+    them, so a freshly-filed stacked epic only queues its head until each
+    blocker closes (#1476)."""
+
+    def _resolved(self, *, human_approved, closed=None, merged=None):
+        st = _state(engine_human_approved=human_approved,
+                    engine_closed=closed, engine_merged=merged)
+        resolve_human_approved_blockers(st)
+        return st
+
+    def test_open_blocker_marks_issue_blocked(self):
+        st = self._resolved(human_approved=[
+            {"number": 801, "title": "child", "labels": ["human:approved"],
+             "body": "**Model:** opus\n**Blocked by:** #800"},
+        ])
+        issue = st["repos"]["engine"]["human_approved"][0]
+        self.assertTrue(issue["blocked"], "open predecessor must mark child blocked")
+        self.assertNotIn("body", issue, "body must be stripped after resolution")
+
+    def test_closed_blocker_clears_blocked(self):
+        st = self._resolved(
+            human_approved=[
+                {"number": 801, "title": "child", "labels": ["human:approved"],
+                 "body": "**Model:** opus\n**Blocked by:** #800"},
+            ],
+            closed=[{"number": 800, "title": "head"}],
+        )
+        self.assertFalse(st["repos"]["engine"]["human_approved"][0]["blocked"],
+                         "predecessor in closed_fleet_queued must clear blocked")
+
+    def test_merged_head_pr_clears_blocked(self):
+        # A merged `claude/<N>-*` head satisfies the blocker the same way
+        # resolve_blocked_by() treats it, even before the issue's CLOSED state
+        # has propagated into closed_fleet_queued.
+        st = self._resolved(
+            human_approved=[
+                {"number": 811, "title": "child", "labels": ["human:approved"],
+                 "body": "**Blocked by:** #810"},
+            ],
+            merged=[{"number": 950, "title": "T", "headRefName": "claude/810-head",
+                     "baseRefName": "master", "mergedAt": "2026-06-01T00:00:00Z"}],
+        )
+        self.assertFalse(st["repos"]["engine"]["human_approved"][0]["blocked"],
+                         "a merged claude/810-* head must clear the child's blocker")
+
+    def test_no_blocker_is_not_blocked(self):
+        st = self._resolved(human_approved=[
+            {"number": 801, "title": "head", "labels": ["human:approved"],
+             "body": "**Model:** opus\n**Blocked by:** (none)"},
+        ])
+        self.assertFalse(st["repos"]["engine"]["human_approved"][0]["blocked"])
+
+    def test_prose_only_blocker_holds_child(self):
+        # A blocker named only in prose with no resolvable #N (e.g. a redesign)
+        # must hold the child back — matches resolve_blocked_by.
+        st = self._resolved(human_approved=[
+            {"number": 801, "title": "child", "labels": ["human:approved"],
+             "body": "## Blocked on the lighting redesign PR\n\n**Model:** opus"},
+        ])
+        self.assertTrue(st["repos"]["engine"]["human_approved"][0]["blocked"])
+
+    def test_blocked_child_excluded_from_projection_and_slice(self):
+        st = self._resolved(human_approved=[
+            {"number": 810, "title": "head", "labels": ["human:approved"],
+             "body": "**Blocked by:** (none)"},
+            {"number": 811, "title": "child", "labels": ["human:approved"],
+             "body": "**Blocked by:** #810"},
+        ])
+        proj_nums = [i["issue"] for i in project_queue_manager_ingest(st)]
+        self.assertIn(810, proj_nums, "workable head must contribute to the hash")
+        self.assertNotIn(811, proj_nums, "blocked child must not contribute to the hash")
+        slice_nums = [i["number"] for i in slice_queue_manager_ingest(st)["pending_issues"]]
+        self.assertIn(810, slice_nums)
+        self.assertNotIn(811, slice_nums)
+
+    def test_unblock_flips_hash(self):
+        # The crux of #1476: when the head closes, the child becomes workable,
+        # re-enters the ingest set, and the trigger hash flips so the scout
+        # re-fires fleet-queue-ingest to queue it.
+        child = {"number": 811, "title": "child", "labels": ["human:approved"],
+                 "body": "**Blocked by:** #810"}
+        blocked = self._resolved(human_approved=[dict(child)])
+        unblocked = self._resolved(human_approved=[dict(child)],
+                                   closed=[{"number": 810, "title": "head"}])
+        self.assertNotEqual(
+            stable_hash(project_queue_manager_ingest(blocked)),
+            stable_hash(project_queue_manager_ingest(unblocked)),
+            "closing the blocker must flip the ingest hash so ingest re-fires")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Gap 1 — share fleet skills via the docs-baseline pattern.** The flows of `commit-and-push`, `review-pr`, `start-next-task`, and `file-epic` were full forked copies per repo that differ only in data and drift. Factor each flow into a canonical, engine-neutral doc under `docs/agents/skills/<name>.md` and reduce each engine `.claude/skills/<name>/SKILL.md` to a thin wrapper (frontmatter + a pointer at the shared flow + a `## Deltas` table). New `docs/design/skill-sharing.md` (sibling to `claude-md-sharing.md`) documents the mechanism and the **runtime-indirection** decision the ticket asked for (the wrapper `Read`s the flow at invoke time — no commit-time generator, for the same reasons `claude-md-sharing` rejected a build-time merge).
- **Gap 2 — queue-manager honors `Blocked by:`.** The scout now resolves each `human:approved` issue's blocker chain (`resolve_human_approved_blockers`, in-memory via `closed_fleet_queued` + merged `claude/<N>-*` heads) and excludes blocked issues from the ingest projection + slice, so the trigger re-fires when a blocker closes. `fleet-queue-ingest` adds an authoritative live `gh issue view <ref> --json state` gate before stamping `fleet:queued`. A freshly-filed stacked epic now shows only its head queued; each child is queued as its blocker closes. `fleet-claim` already enforced this at claim time — the change makes the label honest.
- Engine `procedures/` subdirs are unchanged and referenced from the wrappers as deltas; `review-pr`'s ECS/render/lighting checklist stays in its wrapper as a legitimate per-repo delta. The four `SKILL.md` files shed ~1,500 lines of duplicated flow that now lives once in `docs/agents/skills/`.

## Test plan
- [x] New `scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh` — end-to-end gate: head stamped, closed-blocker child stamped, open-blocker child deferred, blocker issues never edited.
- [x] 7 new cases in `test_queue_manager_projection.py` — blocker resolution, projection/slice exclusion, unblock-flips-hash, merged-head, prose-only blocker.
- [x] Full fleet test sweep green (11 Python + 2 shell), including the rebased-in `test_opus_reviewer_projection.py`.
- [x] All 55 relative markdown links in the changed/new docs resolve; `simplify` doc-side pass clean.

## Notes for reviewer
- The runtime-indirection-vs-generator decision the ticket calls for is in `docs/design/skill-sharing.md` §"Why runtime indirection, not a commit-time generator".
- This is the engine-owned half of the work; the downstream creation's wrappers point at the same canonical `docs/agents/skills/` flows (per `skill-sharing.md` §Future / cross-repo).

Closes #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
