### PR TITLE
render: detached SO(3) P3b — forward-scatter composite (per-axis canvases → framebuffer) (#1475)

### DIFF
--- a/docs/design/per-axis-trixel-canvas-rotation.md
+++ b/docs/design/per-axis-trixel-canvas-rotation.md
@@ -511,7 +511,44 @@ canvas pays only the component slot, no GPU textures. Two once-per-frame gates i
 
 P2 (#1463) is **infrastructure only** — it stands up and bounds the textures and
 adds the reposition helper, but routes no faces into them, so the rendered frame
-is byte-identical; the P3 forward-scatter composite (#1464) is what reads them.
+is byte-identical. P3a (#1464) is the first writer: the model-space face-local
+store routes each rotating detached entity's visible faces into its own per-axis
+canvases (keyed by `faceInPlaneCoords`, depth `pos3DtoDistance` — the un-rotated
+`x+y+z` origin-recovery key), still additive (the single-canvas octahedral emit
+keeps rendering). P3b (#1475) is the first reader: the forward-scatter composite.
+
+**P3b — forward-scatter composite (#1475).** `ENTITY_CANVAS_TO_FRAMEBUFFER`
+forward-scatters a rotating detached entity's three per-axis canvases straight
+to the framebuffer (`PerAxisScatterDetachedProgram` =
+`v_peraxis_scatter_detached` + the reused `f_peraxis_scatter`, GL_LESS), the
+per-DETACHED-entity analog of the camera path's
+`system_trixel_to_framebuffer::drawPerAxisScatter`. Each non-empty cell recovers
+its exact model origin via `faceOriginFromInPlane` (the camera-iso baked into
+`perAxisBase` cancels), repositions the face corners under the octahedral-snap
+**residual** with `pos3DtoPos2DIsoRotated`, and places them at the entity's iso
+screen position via the same placement TRS the gather blit uses — so
+`perAxisBase` is recovery-only. Composite depth sorts by
+`isoDepthAlongAxis(origin, isoDepthAxisModel(residual))` (the reposition's
+rotation, **not** the store's `x+y+z` key and **not** the full composed
+rotation). `VOXEL_TO_TRIXEL_STAGE_1` retires the off-snap octahedral
+single-canvas emit for these entities (no double-draw); the at-snap path
+(per-axis released) keeps the single-canvas emit + blit, byte-identical to
+master. As with the camera path, detached rotating entities freeze at identity
+under `--auto-screenshot`, so the smooth-rotation visual is verified at P5 /
+#1466; identity / at-snap is the headless-verifiable byte-identical case.
+
+> **Anti-pattern (rejected — issue-1475 plan, architect 2026-06-02):** do
+> **not** "resolve" the per-axis canvases back into the entity's single trixel
+> canvas and reuse the unchanged `ENTITY_CANVAS_TO_FRAMEBUFFER` blit. That blit
+> is `CanvasToFramebufferProgram` = `f_trixel_to_framebuffer.glsl`, whose
+> `main()` de-tiles via `trixelFramebufferSamplePosition` — the
+> **single-global-parity gather**. A smooth resolve writes continuous
+> `pos3DtoPos2DIsoRotated` centers (mixed parity) into a trixel canvas; reading
+> them back through that gather re-introduces the #1256 stripe. The blit cannot
+> be both *unchanged* and *smooth*. Forward-scatter to the framebuffer (above)
+> is parity-correct by construction — no gather inverse, no single-parity
+> assumption — exactly as the camera path's T3 decision (`## Implementation
+> decision` above) established.
 
 ## Open decisions (resolve during implementation)
 

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -26,9 +26,13 @@ the ECS surface.
   `faceDeformationMatrixSO3` path). Both free at the snap/cardinal so a static
   scene is byte-identical (fast path). A rotating detached entity's visible
   faces are written into its own per-axis canvases by the model-space
-  face-local store (#1464, P3a) — additive, so the single-canvas octahedral emit
-  still renders the entity and the frame is unchanged until the resolve-scatter
-  that consumes them lands in P3b (#1475). For the **main world canvas**, T2
+  face-local store (#1464, P3a). P3b (#1475) is the consumer:
+  `ENTITY_CANVAS_TO_FRAMEBUFFER` forward-scatters those per-axis canvases to the
+  framebuffer (`PerAxisScatterDetachedProgram`, GL_LESS) under the entity's
+  octahedral-snap residual (`pos3DtoPos2DIsoRotated`), the SO(3) analog of the
+  camera path's `drawPerAxisScatter`; `VOXEL_TO_TRIXEL_STAGE_1` retires the
+  off-snap octahedral single-canvas emit for those entities (no double-draw),
+  keeping the at-snap emit + blit byte-identical. For the **main world canvas**, T2
   (#1309) routes each visible voxel face into its axis canvas with continuous
   (`pos3DtoPos2DIsoYawed`) center reposition + shared world depth; T3
   (#1310) composites the three by depth-tested forward scatter at the

--- a/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
@@ -9,6 +9,9 @@
 
 #include <irreden/render/components/component_entity_canvas.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
+#include <irreden/render/components/component_per_axis_trixel_canvases.hpp>
+#include <irreden/render/components/component_canvas_local_rotation.hpp>
+#include <irreden/render/per_axis_canvas.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/gpu_stage_timing_observer.hpp>
 #include <irreden/render/components/component_trixel_framebuffer.hpp>
@@ -42,7 +45,38 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
         return instances;
     }
 
+    // Detached SO(3) smooth-rotation forward-scatter instances (P3b / #1475).
+    // One per visible detached entity whose canvas has per-axis trixel canvases
+    // allocated (rotating off an octahedral snap). Drawn after the gather pass
+    // in endTick, scattering the three per-axis canvases straight to the
+    // framebuffer (the per-DETACHED-entity analog of the camera-yaw scatter in
+    // system_trixel_to_framebuffer::drawPerAxisScatter), depth-composited
+    // against the gather content by the framebuffer's GL_LESS test.
+    struct ScatterInstance {
+        FrameDataTrixelToFramebuffer frameData_;
+        const C_PerAxisTrixelCanvases *axes_;
+    };
+
+    static std::vector<ScatterInstance> &getScatterInstances() {
+        static std::vector<ScatterInstance> instances;
+        return instances;
+    }
+
     static SystemId create() {
+        // Per-DETACHED-entity SO(3) forward-scatter program (P3b / #1475).
+        // Reuses f_peraxis_scatter (the camera-yaw fragment is identical — write
+        // color + depth); only the vertex projection differs (residual quat +
+        // entity-TRS placement). The shared resources it draws with (QuadVAO,
+        // TrixelToFramebufferFrameData, GlobalConstants) are created by
+        // TRIXEL_TO_FRAMEBUFFER, which registers before this system.
+        IRRender::createNamedResource<ShaderProgram>(
+            "PerAxisScatterDetachedProgram",
+            std::vector{
+                ShaderStage{IRRender::kFileVertPerAxisScatterDetached, ShaderType::VERTEX},
+                ShaderStage{IRRender::kFileFragPerAxisScatter, ShaderType::FRAGMENT}
+            }
+        );
+
         SystemId s = createSystem<C_EntityCanvas, C_WorldTransform>(
             "EntityCanvasToFramebuffer",
             [](IREntity::EntityId entityId,
@@ -121,32 +155,140 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
                 inst.frameData_ = fd;
                 inst.textures_ = canvasTextures;
                 getInstances().push_back(inst);
+
+                // Detached SO(3) smooth rotation (P3b / #1475). If this canvas
+                // has per-axis trixel canvases ALLOCATED, the entity is rotating
+                // off an octahedral snap: VOXEL_TO_TRIXEL_STAGE_1 skipped its
+                // single-canvas voxel emit and routed the visible model faces
+                // into the three per-axis canvases instead. Forward-scatter those
+                // straight to the framebuffer (bypassing the single-parity de-tile
+                // gather, which cannot resolve the smooth mixed-parity centers —
+                // the #1256 stripe class). The gather instance pushed above still
+                // composites any SDF / text the single canvas holds; the scatter
+                // adds the smooth voxels by depth. At a snap nothing is allocated
+                // → no scatter, the single-canvas blit renders byte-identically.
+                // The cheap !isAllocated early-out keeps static entities off the
+                // C_CanvasLocalRotation lookup.
+                auto perAxisOpt = IREntity::getComponentOptional<C_PerAxisTrixelCanvases>(
+                    entityCanvas.canvasEntity_
+                );
+                if (!perAxisOpt.has_value() || !(*perAxisOpt.value()).isAllocated() ||
+                    static_cast<int>(getScatterInstances().size()) >= kMaxEntityCanvasInstances) {
+                    return;
+                }
+                auto rotationOpt = IREntity::getComponentOptional<C_CanvasLocalRotation>(
+                    entityCanvas.canvasEntity_
+                );
+                if (!rotationOpt.has_value() || !(*rotationOpt.value()).isDetached()) {
+                    return;
+                }
+                const C_PerAxisTrixelCanvases &axes = *perAxisOpt.value();
+                const vec4 residual =
+                    IRMath::octahedralSnapResidual((*rotationOpt.value()).rotation_);
+
+                // perAxisBase mirrors P3a's store trixelFrameOffset for this
+                // entity's axis canvases — the identical formula
+                // system_trixel_to_framebuffer's world scatter uses — so
+                // faceOriginFromInPlane recovers the exact stored model origin
+                // (the camera-iso term cancels in the recovery).
+                const int subdivisionScale =
+                    IRRender::getSubdivisionMode() != IRRender::SubdivisionMode::NONE
+                        ? IRPrefab::PerAxisCanvas::subdivisionDensity()
+                        : 1;
+                const vec2 storeCameraIso = IRRender::getEffectiveCameraIso();
+                const ivec2 perAxisBase =
+                    trixelOriginOffsetZ1(axes.size_) +
+                    ivec2(IRMath::floor(storeCameraIso * static_cast<float>(subdivisionScale)));
+
+                // Placement: map one capped-lattice iso unit (the recovered
+                // origin's units) straight to framebuffer px around the entity's
+                // screen center. One WORLD iso unit = fbRes*cameraZoom /
+                // mainCanvasSize fb px (the detached single-canvas trixel scale,
+                // matched so there is no size jump across the snap deadband);
+                // lattice = world * subdivisionScale, so divide. iso-y is
+                // screen-down and framebuffer y is up → negate the y scale. The
+                // entity's iso position + sub-pixel snap are already folded into
+                // entityFbCenter, so the scatter reuses the gather's placement.
+                const vec2 pixelsPerLattice =
+                    fbRes * cameraZoom / mainCanvasSize / static_cast<float>(subdivisionScale);
+                mat4 scatterModel = translate(mat4(1.0f), vec3(entityFbCenter, 0.0f));
+                scatterModel =
+                    scale(scatterModel, vec3(pixelsPerLattice.x, -pixelsPerLattice.y, 1.0f));
+
+                FrameDataTrixelToFramebuffer sfd{};
+                sfd.mpMatrix_ = calcProjectionMatrix(fbRes) * scatterModel;
+                sfd.distanceOffset_ = 0;
+                sfd.perAxisBase_ = perAxisBase;
+                sfd.detachedResidual_ = residual;
+                sfd.detachedDepthAxis_ = vec4(IRMath::isoDepthAxisModel(residual), 0.0f);
+
+                ScatterInstance sinst{};
+                sinst.frameData_ = sfd;
+                sinst.axes_ = &axes;
+                getScatterInstances().push_back(sinst);
             },
-            []() { getInstances().clear(); },
+            []() {
+                getInstances().clear();
+                getScatterInstances().clear();
+            },
             []() {
                 auto &allInstances = getInstances();
-                if (allInstances.empty())
+                auto &scatterInstances = getScatterInstances();
+                if (allInstances.empty() && scatterInstances.empty())
                     return;
 
                 auto &framebuffer =
                     IREntity::getComponent<C_TrixelCanvasFramebuffer>("mainFramebuffer");
                 framebuffer.bindFramebuffer();
 
-                IRRender::getNamedResource<ShaderProgram>("CanvasToFramebufferProgram")->use();
-                IRRender::getNamedResource<VAO>("QuadVAO")->bind();
                 auto *frameDataBuffer =
                     IRRender::getNamedResource<Buffer>("TrixelToFramebufferFrameData");
+                IRRender::getNamedResource<VAO>("QuadVAO")->bind();
+                IRRender::device()->setPolygonMode(PolygonMode::FILL);
 
-                for (auto &inst : allInstances) {
-                    frameDataBuffer
-                        ->subData(0, sizeof(FrameDataTrixelToFramebuffer), &inst.frameData_);
-                    inst.textures_->bind(0, 1, 2);
-                    IRRender::device()->setPolygonMode(PolygonMode::FILL);
-                    IRRender::device()->drawElements(
-                        DrawMode::TRIANGLES,
-                        IRShapes2D::kQuadIndicesLength,
-                        IndexType::UNSIGNED_SHORT
-                    );
+                // Gather pass: blit each detached canvas (octahedral-snap voxels +
+                // any SDF / text) via the single-parity de-tile gather.
+                if (!allInstances.empty()) {
+                    IRRender::getNamedResource<ShaderProgram>("CanvasToFramebufferProgram")->use();
+                    for (auto &inst : allInstances) {
+                        frameDataBuffer
+                            ->subData(0, sizeof(FrameDataTrixelToFramebuffer), &inst.frameData_);
+                        inst.textures_->bind(0, 1, 2);
+                        IRRender::device()->drawElements(
+                            DrawMode::TRIANGLES,
+                            IRShapes2D::kQuadIndicesLength,
+                            IndexType::UNSIGNED_SHORT
+                        );
+                    }
+                }
+
+                // Scatter pass (P3b / #1475): forward-scatter each rotating
+                // detached entity's three per-axis canvases straight to the
+                // framebuffer. Instanced over the canvas grid (one instance per
+                // cell), three axes per entity; the framebuffer GL_LESS depth test
+                // composites them against the gather content above and against
+                // each other. Mirrors system_trixel_to_framebuffer's world
+                // drawPerAxisScatter, retargeted at the entity's own canvases.
+                if (!scatterInstances.empty()) {
+                    IRRender::getNamedResource<ShaderProgram>("PerAxisScatterDetachedProgram")
+                        ->use();
+                    for (auto &inst : scatterInstances) {
+                        frameDataBuffer
+                            ->subData(0, sizeof(FrameDataTrixelToFramebuffer), &inst.frameData_);
+                        const int instanceCount = inst.axes_->size_.x * inst.axes_->size_.y;
+                        for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+                            const C_PerAxisTrixelCanvases::AxisTextures &tex =
+                                inst.axes_->axes_[axis];
+                            tex.colors_.second->bind(0);
+                            tex.distances_.second->bind(1);
+                            IRRender::device()->drawElementsInstanced(
+                                DrawMode::TRIANGLES,
+                                IRShapes2D::kQuadIndicesLength,
+                                IndexType::UNSIGNED_SHORT,
+                                instanceCount
+                            );
+                        }
+                    }
                 }
 
                 IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -603,20 +603,32 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
         IRRender::device()->memoryBarrier(BarrierType::COMMAND);
 
-        // Smooth camera Z-yaw (T3 / #1310): while the main canvas's per-axis
-        // canvases are active, SKIP the single-canvas voxel rasterization. The
-        // per-axis dispatch below writes the voxels (smooth), and the
-        // framebuffer scatter composites them; rasterizing the cardinal-snapped
+        // Detached entity with allocated per-axis canvases (rotating off an
+        // octahedral snap) → its smooth voxels are forward-scattered to the
+        // framebuffer by ENTITY_CANVAS_TO_FRAMEBUFFER (P3b / #1475). Resolve the
+        // lookup once: it gates BOTH the single-canvas skip just below and the
+        // per-axis store dispatch later in this tick. Null for the main canvas
+        // (not detached) and for at-snap detached entities (no allocation).
+        C_PerAxisTrixelCanvases *detachedAxes =
+            canvasLocalRotation.isDetached() ? lookupDetachedPerAxis(entity) : nullptr;
+
+        // Smooth camera Z-yaw (T3 / #1310) + detached SO(3) (P3b / #1475): while
+        // the per-axis canvases are active, SKIP the single-canvas voxel
+        // rasterization. The per-axis dispatch below writes the voxels (smooth),
+        // and the framebuffer scatter composites them; rasterizing the snapped
         // voxels into the single canvas too would double-draw them (the single
         // canvas is composited for its SDF / overlay content, which sits at the
-        // SAME world depth as the smooth copies → snapped ghosts). Skipping
-        // leaves the single canvas holding only SHAPES_TO_TRIXEL / text /
-        // overlay content, which the scatter path composites alongside the
-        // smooth voxels. The compact pass above still runs (the per-axis
-        // dispatch reuses its compacted-voxel list).
-        const bool skipSingleCanvasVoxels = entity == perAxisCanvasEntity_ &&
-                                            perAxisCanvases_ != nullptr &&
-                                            perAxisCanvases_->isAllocated();
+        // SAME depth as the smooth copies → snapped ghosts). Skipping leaves the
+        // single canvas holding only SHAPES_TO_TRIXEL / text / overlay content,
+        // which the composite draws alongside the smooth voxels. The compact pass
+        // above still runs (the per-axis dispatch reuses its compacted list). For
+        // a detached entity, skipping retires its off-snap octahedral
+        // single-canvas emit (P3a left it ADDITIVE); the at-snap path
+        // (detachedAxes == nullptr) still emits + blits, byte-identical to master.
+        const bool skipSingleCanvasVoxels =
+            (entity == perAxisCanvasEntity_ && perAxisCanvases_ != nullptr &&
+             perAxisCanvases_->isAllocated()) ||
+            detachedAxes != nullptr;
         if (!skipSingleCanvasVoxels) {
             stage1Program_->use();
             triangleCanvasTextures.getTextureDistances()
@@ -654,28 +666,24 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         if (entity == perAxisCanvasEntity_ && perAxisCanvases_ != nullptr &&
             perAxisCanvases_->isAllocated()) {
             dispatchPerAxisCanvases(*perAxisCanvases_);
-        } else if (canvasLocalRotation.isDetached()) {
-            // Detached entity SO(3) per-axis store (P3a / #1464). Route this
-            // entity's visible model-space faces into its OWN per-axis canvases
-            // — the SO(3) generalization of the camera-yaw store above. The
-            // store path is shared (perAxisRoute != 0 in the shaders): the
-            // detached frame data buildVoxelFrameData set this tick (model-frame
-            // visibleFaceIds_ from visibleTriplet, isDetachedCanvas_, the model
-            // iso depth axis) flows through unchanged, so each face is stored in
-            // its model-axis face-local lattice keyed on pos3DtoDistance — the
-            // exact origin-recovery key faceOriginFromInPlane consumes at scatter
-            // time (P3b / #1475, which applies the residual reposition).
-            //
-            // Purely ADDITIVE: the single-canvas octahedral emit above still
-            // renders this entity (skipSingleCanvasVoxels is main-canvas-only),
-            // so the populated per-axis textures are not yet consumed and the
-            // frame is byte-identical until P3b reads them. Only fires when the
-            // entity is rotating off an octahedral snap (textures allocated in
-            // beginTick by syncAllocationToDetachedEntities); at a snap / identity
-            // nothing is allocated, so lookup returns null → byte-identical.
-            if (C_PerAxisTrixelCanvases *detachedAxes = lookupDetachedPerAxis(entity)) {
-                dispatchPerAxisCanvases(*detachedAxes);
-            }
+        } else if (detachedAxes != nullptr) {
+            // Detached entity SO(3) per-axis store (P3a / #1464) → consumed by
+            // the P3b (#1475) framebuffer forward-scatter. Route this entity's
+            // visible model-space faces into its OWN per-axis canvases — the
+            // SO(3) generalization of the camera-yaw store above. The store path
+            // is shared (perAxisRoute != 0 in the shaders): the detached frame
+            // data buildVoxelFrameData set this tick (model-frame visibleFaceIds_
+            // from visibleTriplet, isDetachedCanvas_, the model iso depth axis)
+            // flows through unchanged, so each face is stored in its model-axis
+            // face-local lattice keyed on pos3DtoDistance — the exact
+            // origin-recovery key faceOriginFromInPlane consumes at scatter time.
+            // The single-canvas octahedral emit was skipped above
+            // (skipSingleCanvasVoxels), so these per-axis textures are now the
+            // sole render path for this off-snap entity (no double-draw). Only
+            // fires off an octahedral snap (textures allocated in beginTick by
+            // syncAllocationToDetachedEntities); at a snap / identity detachedAxes
+            // is null → single-canvas emit + blit, byte-identical to master.
+            dispatchPerAxisCanvases(*detachedAxes);
         }
     }
 

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -107,6 +107,19 @@ struct FrameDataTrixelToFramebuffer {
     float visualYaw_ = 0.0f;
     int scatterPad_ = 0;
     ivec4 visibleFaceIds_{0, 0, 0, 0};
+    /// Detached-entity SO(3) forward-scatter composite (P3b / #1475). Consumed
+    /// ONLY by v_peraxis_scatter_detached (the per-DETACHED-entity analog of the
+    /// camera-yaw scatter above), another std140 append so the world scatter +
+    /// gather shaders — which stop their UBO block at `visibleFaceIds_` — stay
+    /// byte-identical. The detached scatter projects each face corner under the
+    /// octahedral-snap RESIDUAL quaternion via `pos3DtoPos2DIsoRotated` (instead
+    /// of the camera path's scalar `visualYaw_`) and co-sorts the composite by
+    /// `isoDepthAlongAxis(origin, detachedDepthAxis_.xyz)`. `detachedResidual_`
+    /// is that residual quat (qx,qy,qz,qw); `detachedDepthAxis_.xyz` =
+    /// isoDepthAxisModel(residual). Both are computed CPU-side from the canvas's
+    /// C_CanvasLocalRotation by ENTITY_CANVAS_TO_FRAMEBUFFER.
+    vec4 detachedResidual_{0.0f, 0.0f, 0.0f, 1.0f};
+    vec4 detachedDepthAxis_{1.0f, 1.0f, 1.0f, 0.0f};
 };
 static_assert(
     offsetof(FrameDataTrixelToFramebuffer, visibleFaceIds_) == 128,
@@ -115,11 +128,20 @@ static_assert(
     "scatterPad_ 124, then std140 ivec4 alignment rounds to 128)"
 );
 static_assert(
-    sizeof(FrameDataTrixelToFramebuffer) == 144,
+    offsetof(FrameDataTrixelToFramebuffer, detachedResidual_) == 144 &&
+        offsetof(FrameDataTrixelToFramebuffer, detachedDepthAxis_) == 160,
+    "Detached scatter fields (P3b / #1475) must std140-append after "
+    "visibleFaceIds_ (ends at 144): detachedResidual_ 144 / detachedDepthAxis_ "
+    "160. Read only by v_peraxis_scatter_detached; the world scatter + gather "
+    "blocks stop at visibleFaceIds_, so they stay byte-identical"
+);
+static_assert(
+    sizeof(FrameDataTrixelToFramebuffer) == 176,
     "FrameDataTrixelToFramebuffer size must mirror its std140 GLSL block. The "
-    "T3 scatter shaders (v_/f_peraxis_scatter) read the appended perAxisBase_ / "
-    "visualYaw_ / scatterPad_ / visibleFaceIds_ fields; a silent reorder or "
-    "resize would corrupt the scatter UBO with no compile-time diagnostic"
+    "scatter shaders (v_/f_peraxis_scatter[_detached]) read the appended "
+    "perAxisBase_ / visualYaw_ / visibleFaceIds_ and the P3b detachedResidual_ "
+    "/ detachedDepthAxis_ fields; a silent reorder or resize would corrupt the "
+    "scatter UBO with no compile-time diagnostic"
 );
 
 struct FrameDataVoxelToCanvas {

--- a/engine/render/include/irreden/render/shader_names.hpp
+++ b/engine/render/include/irreden/render/shader_names.hpp
@@ -19,6 +19,14 @@ const char *const kFileFragTrixelToFramebuffer = "shaders/f_trixel_to_framebuffe
 const char *const kFileVertPerAxisScatter = "shaders/v_peraxis_scatter.glsl";
 const char *const kFileFragPerAxisScatter = "shaders/f_peraxis_scatter.glsl";
 
+// Detached-entity SO(3) forward-scatter composite (P3b / #1475): the
+// per-DETACHED-entity analog of the camera-yaw scatter above. Same instanced
+// per-axis-cell draw, but projects each cell under the entity's octahedral-snap
+// residual quaternion (pos3DtoPos2DIsoRotated) and places it at the entity's
+// iso screen position. Reuses f_peraxis_scatter for the fragment stage (Metal
+// mirror in metal/peraxis_scatter_detached.metal).
+const char *const kFileVertPerAxisScatterDetached = "shaders/v_peraxis_scatter_detached.glsl";
+
 const char *const kFileCompVoxelToTrixelStage1 = "shaders/c_voxel_to_trixel_stage_1.glsl";
 const char *const kFileCompVoxelToTrixelStage2 = "shaders/c_voxel_to_trixel_stage_2.glsl";
 const char *const kFileCompTrixelToTrixel = "shaders/c_trixel_to_trixel.glsl";

--- a/engine/render/src/shaders/metal/peraxis_scatter_detached.metal
+++ b/engine/render/src/shaders/metal/peraxis_scatter_detached.metal
@@ -1,0 +1,106 @@
+// Project: Irreden Engine
+// File: metal/peraxis_scatter_detached.metal
+// Detached-entity SO(3) — P3b (#1475) forward-scatter composite (Metal mirror
+// of v_peraxis_scatter_detached.glsl). The per-DETACHED-entity analog of
+// peraxis_scatter.metal: each instance is one cell of a rotating detached
+// entity's per-axis canvas; the vertex stage recovers the model face origin and
+// projects its deformed face quad under the octahedral-snap RESIDUAL quaternion,
+// placed by the entity's mpMatrix. Reuses f_peraxis_scatter (peraxis_scatter.metal)
+// for the fragment stage.
+
+#include <metal_stdlib>
+using namespace metal;
+
+#include "ir_iso_common.metal"
+
+struct VertexIn {
+    float2 position [[attribute(0)]];  // unit quad corner in [-0.5, 0.5]^2
+};
+
+struct GlobalConstants {
+    int kMinTriangleDistance;
+    int kMaxTriangleDistance;
+};
+
+// Shared with trixel_to_framebuffer.metal + peraxis_scatter.metal (buffer 3);
+// the detached scatter reads the two P3b fields appended after visibleFaceIds.
+struct FrameDataIsoTriangles {
+    float4x4 mpMatrix;
+    float2 zoomLevel;
+    float2 canvasOffset;
+    float2 textureOffset;
+    float2 mouseHoveredTriangleIndex;
+    float2 effectiveSubdivisionsForHover;
+    float showHoverHighlight;
+    int distanceOffset;
+    int2 perAxisBase;
+    float visualYaw;
+    int _scatterPad;
+    int4 visibleFaceIds;
+    float4 detachedResidual;   // octahedral-snap residual quat (qx,qy,qz,qw)
+    float4 detachedDepthAxis;  // isoDepthAxisModel(residual); .xyz used
+};
+
+// Must match f_peraxis_scatter's [[stage_in]] VertexOut (peraxis_scatter.metal).
+struct VertexOut {
+    float4 position [[position]];
+    float4 color [[flat]];
+    float depth [[flat]];
+};
+
+// Mirror of faceSpanCorner in v_peraxis_scatter_detached.glsl.
+static inline float3 faceSpanCorner(int axis, float3 origin, float2 cornerSel) {
+    if (axis == 0) return origin + float3(0.0, cornerSel.x, cornerSel.y); // X face: span y,z
+    if (axis == 1) return origin + float3(cornerSel.x, 0.0, cornerSel.y); // Y face: span x,z
+    return origin + float3(cornerSel.x, cornerSel.y, 0.0);                // Z face: span x,y
+}
+
+vertex VertexOut v_peraxis_scatter_detached(
+    VertexIn in [[stage_in]],
+    uint instanceId [[instance_id]],
+    texture2d<float> triangleColors [[texture(0)]],
+    texture2d<int> triangleDistances [[texture(1)]],
+    constant GlobalConstants& globals [[buffer(1)]],
+    constant FrameDataIsoTriangles& frameData [[buffer(3)]]
+) {
+    VertexOut out;
+    const int2 canvasSize = int2(triangleColors.get_width(), triangleColors.get_height());
+    const int cell = int(instanceId);
+    const uint2 ij = uint2(uint(cell % canvasSize.x), uint(cell / canvasSize.x));
+
+    const float4 color = triangleColors.read(ij);
+    if (color.a < 0.1f) {
+        out.position = float4(2.0, 2.0, 2.0, 1.0);
+        out.color = float4(0.0);
+        out.depth = 1.0;
+        return out;
+    }
+
+    const int rawDist = triangleDistances.read(ij).r;
+    const int rawDepth = rawDist >> 2;
+    const int slot = rawDist & 3;
+    const int faceId = frameData.visibleFaceIds[slot];
+    const int axis = faceId >> 1;
+
+    // Exact face-local recovery of the MODEL origin (mirror of the GLSL twin);
+    // the camera iso baked into perAxisBase by the store cancels here.
+    const int3 anchor = faceLocalAnchor(frameData.perAxisBase, canvasSize);
+    const int2 inPlane = int2(ij) - faceLocalBase(axis, anchor, canvasSize);
+    const int3 origin = faceOriginFromInPlane(faceId, inPlane, rawDepth);
+
+    const float2 cornerSel = in.position + float2(0.5);
+    const float3 modelCorner = faceSpanCorner(axis, float3(origin), cornerSel);
+    const float2 isoModel = pos3DtoPos2DIsoRotated(modelCorner, frameData.detachedResidual);
+    out.position = frameData.mpMatrix * float4(isoModel, 1.0, 1.0);
+    out.position.y = -out.position.y;
+
+    out.color = color;
+    // Composite depth along the residual's model iso axis (#1475) — mirror of
+    // v_peraxis_scatter_detached.glsl. rawDepth is the recovery key only; the
+    // sort uses isoDepthAlongAxis(origin, detachedDepthAxis), *4 + slot encoded.
+    const int residualDist =
+        isoDepthAlongAxis(origin, frameData.detachedDepthAxis.xyz) * 4 + slot;
+    out.depth = float(residualDist + frameData.distanceOffset - globals.kMinTriangleDistance) /
+                float(globals.kMaxTriangleDistance - globals.kMinTriangleDistance);
+    return out;
+}

--- a/engine/render/src/shaders/v_peraxis_scatter_detached.glsl
+++ b/engine/render/src/shaders/v_peraxis_scatter_detached.glsl
@@ -1,0 +1,120 @@
+/*
+ * Project: Irreden Engine
+ * File: v_peraxis_scatter_detached.glsl
+ * Author: Evin Killian jakildev@gmail.com
+ * Created Date: June 2026
+ * -----
+ * Detached-entity SO(3) — P3b (#1475) forward-scatter composite. The
+ * per-DETACHED-entity analog of v_peraxis_scatter.glsl: where the camera path
+ * scatters the world per-axis canvases under a scalar Z-yaw, this scatters a
+ * rotating detached entity's own three per-axis canvases (populated by P3a,
+ * #1464) under the entity's octahedral-snap RESIDUAL quaternion. Like the
+ * camera path it forward-projects each non-empty cell's true deformed face
+ * quad straight to the framebuffer (GL_LESS), bypassing the single-parity
+ * de-tile gather (f_trixel_to_framebuffer) — so the #1256 stripe class cannot
+ * occur. Pairs with f_peraxis_scatter.glsl (reused unchanged).
+ */
+
+#version 450 core
+
+#include "ir_iso_common.glsl"
+
+// Unit quad corner in [-0.5, 0.5]^2 from the shared QuadVAO. (aPos + 0.5)
+// gives the {0,1}^2 corner selector for the two in-plane face axes.
+layout (location = 0) in vec2 aPos;
+
+layout (binding = 0) uniform sampler2D  triangleColors;
+layout (binding = 1) uniform isampler2D triangleDistances;
+
+// binding = 1 is reused for the GlobalConstants UBO; sampler image units and
+// UBO binding points are separate GL namespaces (same pattern as
+// v_peraxis_scatter.glsl / f_trixel_to_framebuffer.glsl).
+layout(std140, binding = 1) uniform GlobalConstants {
+    int kMinTriangleDistance;
+    int kMaxTriangleDistance;
+};
+
+// Shared with v_/f_trixel_to_framebuffer + v_peraxis_scatter (binding 3). The
+// gather + camera-scatter shaders read only the prefix through visibleFaceIds;
+// the detached scatter reads the two P3b std140-appended fields at the end
+// (detachedResidual / detachedDepthAxis), so existing offsets are unchanged.
+layout (std140, binding = 3) uniform FrameDataIsoTriangles {
+    mat4 mpMatrix;
+    vec2 zoomLevel;
+    vec2 canvasOffset;
+    vec2 textureOffset;
+    vec2 mouseHoveredTriangleIndex;
+    vec2 effectiveSubdivisionsForHover;
+    float showHoverHighlight;
+    int distanceOffset;
+    ivec2 perAxisBase;       // recovery base for this entity's axis canvases
+    float visualYaw;         // unused on the detached path
+    int _scatterPad;
+    ivec4 visibleFaceIds;    // per-slot model FaceId (visibleTriplet); .w pad
+    vec4 detachedResidual;   // octahedral-snap residual quat (qx,qy,qz,qw)
+    vec4 detachedDepthAxis;  // isoDepthAxisModel(residual); .xyz used, .w pad
+};
+
+flat out vec4 vColor;
+flat out float vDepth;
+
+// Mirror of faceSpanCorner in v_peraxis_scatter.glsl: in-plane corner of a face
+// whose `origin` already sits on the face plane (the store bakes the polarity
+// via faceMicroPositionFixed6). cornerSel in {0,1}^2.
+vec3 faceSpanCorner(int axis, vec3 origin, vec2 cornerSel) {
+    if (axis == 0) return origin + vec3(0.0, cornerSel.x, cornerSel.y); // X face: span y,z
+    if (axis == 1) return origin + vec3(cornerSel.x, 0.0, cornerSel.y); // Y face: span x,z
+    return origin + vec3(cornerSel.x, cornerSel.y, 0.0);                // Z face: span x,y
+}
+
+void main() {
+    const ivec2 canvasSize = textureSize(triangleDistances, 0);
+    const int cell = gl_InstanceID;
+    const ivec2 ij = ivec2(cell % canvasSize.x, cell / canvasSize.x);
+
+    const vec4 color = texelFetch(triangleColors, ij, 0);
+    // Empty cell — degenerate the instance off-screen (matches the camera path).
+    if (color.a < 0.1) {
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+        vColor = vec4(0.0);
+        vDepth = 1.0;
+        return;
+    }
+
+    const int rawDist = texelFetch(triangleDistances, ij, 0).r;
+    const int rawDepth = rawDist >> 2;       // pos3DtoDistance of the model face origin
+    const int slot = rawDist & 3;            // visible-triplet slot
+    const int faceId = visibleFaceIds[slot];
+    const int axis = faceId >> 1;
+
+    // Recover the exact integer MODEL face origin from P3a's face-local store —
+    // one integer subtraction, no inverse, exact at every residual. The camera
+    // iso term baked into perAxisBase by the store cancels here (the anchor is
+    // computed identically from the same perAxisBase + canvasSize), so `origin`
+    // is the entity-local model position regardless of camera pan.
+    const ivec3 anchor = faceLocalAnchor(perAxisBase, canvasSize);
+    const ivec2 inPlane = ij - faceLocalBase(axis, anchor, canvasSize);
+    const ivec3 origin = faceOriginFromInPlane(faceId, inPlane, rawDepth);
+
+    // SO(3) reposition under the octahedral-snap residual (the detached analog
+    // of the camera path's pos3DtoPos2DIsoYawed). The result is iso relative to
+    // the entity's model origin (iso of model (0,0,0) == (0,0)); the entity's
+    // on-screen position + scale + sub-pixel snap live entirely in mpMatrix
+    // (built by ENTITY_CANVAS_TO_FRAMEBUFFER), so perAxisBase is recovery-only.
+    const vec2 cornerSel = aPos + vec2(0.5);
+    const vec3 modelCorner = faceSpanCorner(axis, vec3(origin), cornerSel);
+    const vec2 isoModel = pos3DtoPos2DIsoRotated(modelCorner, detachedResidual);
+    gl_Position = mpMatrix * vec4(isoModel, 1.0, 1.0);
+
+    vColor = color;
+    // Composite depth along the residual's model iso axis (#1475). NOT the store
+    // key (rawDepth = un-rotated x+y+z, the origin-recovery key only) and NOT the
+    // full composed rotation — the reposition's residual, so the entity's faces
+    // co-sort with the smooth on-screen placement above. Keep the *4 + slot
+    // encoding so it shares the world distance range (kMin/kMax). At identity
+    // residual detachedDepthAxis == (1,1,1) so this collapses to x+y+z — but the
+    // per-axis canvases are released at a snap, so the scatter never runs there.
+    int residualDist = isoDepthAlongAxis(origin, detachedDepthAxis.xyz) * 4 + slot;
+    vDepth = float(residualDist + distanceOffset - kMinTriangleDistance) /
+             float(kMaxTriangleDistance - kMinTriangleDistance);
+}


### PR DESCRIPTION
Forward-scatter a rotating detached entity's three per-axis canvases (populated by P3a, #1464) straight to the framebuffer under its octahedral-snap residual — the SO(3) generalization of the camera path's `system_trixel_to_framebuffer::drawPerAxisScatter`. Implements Option A from the architect's direction; the rejected "resolve into the entity canvas + reuse the de-tile blit" would re-introduce the #1256 single-parity stripe.

## Changes

- **`v_peraxis_scatter_detached.{glsl,metal}`** — recover the exact model face origin (`faceOriginFromInPlane` — the camera-iso baked into `perAxisBase` cancels), reproject corners under the residual via `pos3DtoPos2DIsoRotated`, and place at the entity's iso screen position via the existing placement TRS. Composite depth = `isoDepthAlongAxis(origin, isoDepthAxisModel(residual))`. Reuses `f_peraxis_scatter` for the (identical) fragment stage.
- **`ENTITY_CANVAS_TO_FRAMEBUFFER`** — collect a scatter instance per rotating detached entity (per-axis allocated) alongside the gather instance; draw the scatter after the gather pass, `GL_LESS` depth-composited.
- **`VOXEL_TO_TRIXEL_STAGE_1`** — skip the off-snap octahedral single-canvas emit for per-axis-allocated detached entities (no double-draw); the at-snap path (`detachedAxes` null) keeps the single-canvas emit + blit unchanged.
- **`FrameDataTrixelToFramebuffer`** — std140-append `detachedResidual_` / `detachedDepthAxis_` (read only by the detached scatter; the world scatter + gather blocks stop at `visibleFaceIds_`, so they stay byte-identical). `offsetof` assertions at 144 and 160 guard against accidental field insertion.

## Verification

Byte-identical at identity / at-snap (detached entities freeze at identity under `--auto-screenshot`). Build clean; `PerAxisScatterDetachedProgram` compiles on macOS/Metal. `IRShapeDebug` and `IRCanvasStress` (9 detached canvases) render unregressed. Smooth-rotation visual verified at P5 / #1466.

Closes #1475