### PR TITLE
fleet: stagger dispatch + short-window 429 backoff

### DIFF
--- a/scripts/fleet/fleet-claude-stream
+++ b/scripts/fleet/fleet-claude-stream
@@ -193,6 +193,29 @@ BENIGN_WARNING_PREFIXES = (
 )
 
 
+# Short-window 429 throttle line: "API Error: Server is temporarily limiting
+# requests (not your usage limit)". claude retries these internally; the line
+# surfaces either as a post-result cleanup warning (the run still succeeded) or
+# after retries were exhausted (the run failed). It is NOT a usage-limit/quota
+# event, so it's annotated as a warning rather than a fatal error. When
+# FLEET_THROTTLE_FLAG is set (by fleet-dispatch-wrap), seeing this line also
+# touches that flag so the wrapper applies a short throttle cooldown + re-arm
+# the role IF the process also exits non-zero.
+THROTTLE_ERROR_PREFIX = "API Error: Server is temporarily limiting requests"
+
+
+def note_throttle():
+    flag = os.environ.get("FLEET_THROTTLE_FLAG")
+    if not flag:
+        return
+    try:
+        pathlib.Path(flag).touch()
+    except OSError:
+        # State-dir not writable, etc. — non-fatal; the wrapper just won't see
+        # the flag and skips the short cooldown.
+        pass
+
+
 def main():
     for line in sys.stdin:
         line = line.strip()
@@ -206,7 +229,10 @@ def main():
             # streams in temporal order). Annotate known post-result
             # warnings as warnings, pass through everything else
             # untouched so we don't accidentally hide a real error.
-            if any(line.startswith(p) for p in BENIGN_WARNING_PREFIXES):
+            if line.startswith(THROTTLE_ERROR_PREFIX):
+                note_throttle()
+                emit(f"{YELLOW}⚠ [claude-warn] {line}{RESET}\n")
+            elif any(line.startswith(p) for p in BENIGN_WARNING_PREFIXES):
                 emit(f"{YELLOW}⚠ [claude-warn] {line}{RESET}\n")
             else:
                 emit(line + "\n")

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -36,15 +36,38 @@ else
     export FLEET_ROLE_MODEL=sonnet
 fi
 
+# Short-window 429 detection. fleet-claude-stream touches this flag if it sees
+# the "Server is temporarily limiting requests (not your usage limit)" error in
+# the stream. Combined with a non-zero exit below, that's the signal to apply a
+# SHORT throttle cooldown + re-arm the role — distinct from the 15-min
+# usage-limit cooldown, which is the wrong tool for a per-minute load-shed.
+# Clear any stale flag from a previous run first.
+mkdir -p "$RATE_LIMIT_DIR"
+export FLEET_THROTTLE_FLAG="$RATE_LIMIT_DIR/$PANE_KEY.throttle-seen"
+rm -f "$FLEET_THROTTLE_FLAG"
+
 claude --model "$MODEL" --effort "$EFFORT" --print \
     --output-format stream-json --include-partial-messages --verbose \
     "/role-$ROLE live" | fleet-claude-stream
 
 rc="${PIPESTATUS[0]}"
+TRIGGERS_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}/triggers"
 if [[ "$rc" == "2" ]]; then
-    mkdir -p "$RATE_LIMIT_DIR"
+    # Usage-limit (quota) exit — long cooldown via the .ts marker.
     date +%s > "$RATE_LIMIT_DIR/$PANE_KEY.ts"
+elif [[ "$rc" != "0" && -f "$FLEET_THROTTLE_FLAG" ]]; then
+    # Short-window 429 failure: claude exhausted its internal retries against a
+    # per-minute load-shed (not a quota wall). Write the short throttle cooldown
+    # and re-arm the role so the dispatcher retries this pane once the window
+    # clears. The re-arm matters most for reviewer / smoke roles, which have no
+    # periodic safety re-arm and would otherwise stall until the scout
+    # projection next changes.
+    mkdir -p "$TRIGGERS_DIR"
+    date +%s > "$RATE_LIMIT_DIR/$PANE_KEY.throttle.ts"
+    touch "$TRIGGERS_DIR/$ROLE"
+    echo "fleet-dispatch-wrap: short-window 429 on $ROLE ($PANE_KEY); wrote throttle cooldown + re-armed $ROLE" >&2
 fi
+rm -f "$FLEET_THROTTLE_FLAG"
 
 # Auto-retrigger: when a worker role exits cleanly (rc=0) with a dirty
 # worktree and an active reservation, the session likely dropped the

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -539,7 +539,7 @@ cleanup_stale_dispatches() {
 # is cleared so the next cooldown produces a fresh log.
 pane_in_rate_limit_cooldown() {
     local pane_key="$1"
-    local now in_cooldown=1 marker
+    local now found_active=0 marker
     now=$(date +%s)
     for marker in "ts:$LIMIT_DELAY" "throttle.ts:$RATE429_DELAY"; do
         local suffix="${marker%%:*}" delay="${marker#*:}"
@@ -549,12 +549,12 @@ pane_in_rate_limit_cooldown() {
         ts=$(cat "$ts_file" 2>/dev/null || printf '0')
         elapsed=$(( now - ts ))
         if (( elapsed < delay )); then
-            in_cooldown=0
+            found_active=1
         else
             rm -f "$ts_file"
         fi
     done
-    if (( in_cooldown == 0 )); then
+    if (( found_active )); then
         return 0
     fi
     unset "RATE_LIMIT_COOLDOWN_LOGGED[$pane_key]"
@@ -978,6 +978,8 @@ dispatch_role() {
     if [[ -n "$gap_blocked" ]]; then
         if (( dispatched > 0 )); then
             log "$role: dispatched $dispatched; min-gap (${DISPATCH_MIN_GAP_SECONDS}s) deferring remaining idle panes — trigger kept"
+        else
+            log "$role: min-gap deferring first idle pane — trigger kept"
         fi
         return
     fi

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -124,6 +124,31 @@ declare -A CAP_DEFER_LOGGED=()
 # panes hits a limit, the other keeps running.
 LIMIT_DELAY="${FLEET_DISPATCHER_LIMIT_DELAY:-900}"
 
+# Seconds to back off a pane after a short-window 429 ("Server is temporarily
+# limiting requests (not your usage limit)") — distinct from the usage-limit
+# LIMIT_DELAY above. The 429 is Anthropic's per-minute load-shed, not a quota
+# wall, so it clears in well under a minute; a short cooldown lets the pane
+# retry soon instead of burning the full 15-min usage-limit delay. The marker
+# is the per-pane `<pane>.throttle.ts` file written by fleet-dispatch-wrap when
+# claude exits non-zero AND fleet-claude-stream flagged a throttle error.
+RATE429_DELAY="${FLEET_DISPATCHER_RATE429_DELAY:-90}"
+
+# Minimum wall-clock gap between any two claude launches, across ALL roles and
+# panes. The dispatcher otherwise fires every idle pane in a single tick — at
+# fleet-up that's ~8 cold `claude` cold-starts (each doing a large state.json
+# read) inside one minute, which trips Anthropic's short-window 429. The gap
+# spreads the burst: with the default below and a 10s poll, launches land one
+# per tick (8 panes over ~80s) instead of all at once. It is a *minimum* gap,
+# not a fixed cadence — a lone steady-state dispatch whose last launch was long
+# ago fires immediately; only simultaneous bursts get spaced. Set to 0 to
+# disable (tests / single-pane setups). Tracked via LAST_DISPATCH_EPOCH below.
+DISPATCH_MIN_GAP_SECONDS="${FLEET_DISPATCH_MIN_GAP_SECONDS:-8}"
+# Wall-clock epoch of the most recent claude launch (0 = none yet). Updated in
+# dispatch_role after each successful send-keys; read by the min-gap gate.
+# Process-global on purpose: the gap must hold across roles within a tick and
+# across ticks, so it must NOT be declared `local` anywhere.
+LAST_DISPATCH_EPOCH=0
+
 # --- Usage gate (per-rate-limit-type thresholds) --------------------------
 #
 # Soft, fleet-wide pre-emption: when any rate_limit_event observation
@@ -505,24 +530,33 @@ cleanup_stale_dispatches() {
 
 # --- Rate-limit cooldown ---------------------------------------------------
 
-# Returns 0 (true) if the pane is still within its usage-limit cooldown
-# window; returns 1 (false) if the pane is free to dispatch.
-# As a side effect, removes the marker file when the cooldown expires and
-# clears the "already logged" flag so the next cooldown produces a fresh log.
+# Returns 0 (true) if the pane is still within a cooldown window; returns 1
+# (false) if the pane is free to dispatch. Two independent marker kinds are
+# checked: the usage-limit marker (`<pane>.ts`, LIMIT_DELAY) and the
+# short-window 429 marker (`<pane>.throttle.ts`, RATE429_DELAY). A pane is in
+# cooldown if EITHER is still within its window. As a side effect, expired
+# markers are reaped and — once no marker remains — the "already logged" flag
+# is cleared so the next cooldown produces a fresh log.
 pane_in_rate_limit_cooldown() {
     local pane_key="$1"
-    local ts_file="$RATE_LIMIT_DIR/$pane_key.ts"
-    if [[ ! -f "$ts_file" ]]; then
-        return 1
-    fi
-    local ts now elapsed
-    ts=$(cat "$ts_file" 2>/dev/null || printf '0')
+    local now in_cooldown=1 marker
     now=$(date +%s)
-    elapsed=$(( now - ts ))
-    if (( elapsed < LIMIT_DELAY )); then
+    for marker in "ts:$LIMIT_DELAY" "throttle.ts:$RATE429_DELAY"; do
+        local suffix="${marker%%:*}" delay="${marker#*:}"
+        local ts_file="$RATE_LIMIT_DIR/$pane_key.$suffix"
+        [[ -f "$ts_file" ]] || continue
+        local ts elapsed
+        ts=$(cat "$ts_file" 2>/dev/null || printf '0')
+        elapsed=$(( now - ts ))
+        if (( elapsed < delay )); then
+            in_cooldown=0
+        else
+            rm -f "$ts_file"
+        fi
+    done
+    if (( in_cooldown == 0 )); then
         return 0
     fi
-    rm -f "$ts_file"
     unset "RATE_LIMIT_COOLDOWN_LOGGED[$pane_key]"
     return 1
 }
@@ -864,6 +898,7 @@ dispatch_role() {
     fi
 
     local dispatched=0
+    local gap_blocked=""
     while IFS= read -r pane_id; do
         [[ -n "$pane_id" ]] || continue
         # Skip panes that already have an in-flight dispatch record.
@@ -885,6 +920,19 @@ dispatch_role() {
                 RATE_LIMIT_COOLDOWN_LOGGED["$pane_key"]=1
             fi
             continue
+        fi
+        # Global min-gap stagger. Stop fanning out once the most recent launch
+        # is younger than the gap, so a single tick can't fire every idle pane
+        # at once (the fleet-up 429 burst). `break` (not `continue`) — the gap
+        # is global, so if this pane is too soon, every later pane is too. The
+        # gap_blocked flag below makes the post-loop logic keep the trigger so
+        # the deferred panes fire on later ticks. now_epoch is reused to stamp
+        # LAST_DISPATCH_EPOCH only after a successful send.
+        local now_epoch
+        now_epoch=$(date +%s)
+        if (( DISPATCH_MIN_GAP_SECONDS > 0 && now_epoch - LAST_DISPATCH_EPOCH < DISPATCH_MIN_GAP_SECONDS )); then
+            gap_blocked=1
+            break
         fi
         local cmd
         cmd=$(build_dispatch_command "$role" "$pane_key")
@@ -919,8 +967,20 @@ dispatch_role() {
             continue
         fi
         write_dispatch_record "$role" "$pane_id"
+        LAST_DISPATCH_EPOCH=$now_epoch
         dispatched=$((dispatched + 1))
     done <<< "$idle_panes"
+
+    # If the global min-gap stopped us mid-fan-out (gap_blocked set on break),
+    # keep the trigger so the remaining idle panes launch on later ticks — one
+    # per gap — regardless of how many fired this tick or the boot-window
+    # state. This is what spreads the fleet-up burst to ~one launch per tick.
+    if [[ -n "$gap_blocked" ]]; then
+        if (( dispatched > 0 )); then
+            log "$role: dispatched $dispatched; min-gap (${DISPATCH_MIN_GAP_SECONDS}s) deferring remaining idle panes — trigger kept"
+        fi
+        return
+    fi
 
     if (( dispatched > 0 )); then
         # Boot fan-out guard. If the role's post-dispatch active count
@@ -1263,6 +1323,27 @@ case "${1:-}" in
             echo "retain"
         else
             echo "consume"
+        fi
+        exit 0
+        ;;
+    --dispatch-gap-check)
+        # Test/debug: print `ok` (a launch may proceed) or `wait` (the global
+        # min-gap is still holding) for a given last-launch epoch and now-epoch.
+        # Honors FLEET_DISPATCH_MIN_GAP_SECONDS (env override); 0 disables the
+        # gap so the answer is always `ok`. Same gate the dispatch_role loop
+        # applies per pane.
+        if [[ -z "${2:-}" || -z "${3:-}" ]]; then
+            echo "usage: fleet-dispatcher --dispatch-gap-check <last-epoch> <now-epoch>" >&2
+            exit 2
+        fi
+        if ! [[ "$2" =~ ^[0-9]+$ && "$3" =~ ^[0-9]+$ ]]; then
+            echo "fleet-dispatcher --dispatch-gap-check: <last-epoch> and <now-epoch> must be non-negative integers" >&2
+            exit 2
+        fi
+        if (( DISPATCH_MIN_GAP_SECONDS > 0 && $3 - $2 < DISPATCH_MIN_GAP_SECONDS )); then
+            echo "wait"
+        else
+            echo "ok"
         fi
         exit 0
         ;;

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -124,6 +124,29 @@
 # FLEET_DISPATCHER_USAGE_STALE_SECONDS=3600
 # FLEET_DISPATCHER_RESET_GRACE_SECONDS=600
 
+# --- Dispatch stagger + short-window 429 backoff --------------------------
+#
+# The dispatcher otherwise fires every idle pane in a single tick — at
+# fleet-up that's ~8 cold `claude` cold-starts (each doing a large
+# state.json read) inside one minute, which trips Anthropic's short-window
+# 429 ("Server is temporarily limiting requests (not your usage limit)").
+#
+# FLEET_DISPATCH_MIN_GAP_SECONDS is a MINIMUM wall-clock gap between any two
+# claude launches, across all roles and panes. It spreads the burst (with a
+# 10s poll, launches land ~one per tick); a lone steady-state dispatch whose
+# last launch was long ago still fires immediately. Default 8. Set 0 to
+# disable (single-pane / test setups).
+# FLEET_DISPATCH_MIN_GAP_SECONDS=8
+#
+# FLEET_DISPATCHER_RATE429_DELAY is the per-pane cooldown applied after a
+# short-window 429 *failure* (claude exhausted its internal retries). It is
+# deliberately much shorter than FLEET_DISPATCHER_LIMIT_DELAY (the usage /
+# quota cooldown): the 429 is a per-minute load-shed that clears in seconds,
+# not a quota wall. fleet-dispatch-wrap also re-arms the role's trigger on a
+# 429 failure so reviewer / smoke panes (no periodic re-arm) retry once the
+# window clears. Default 90s.
+# FLEET_DISPATCHER_RATE429_DELAY=90
+
 # --- fleet-run default watchdog -------------------------------------------
 #
 # When fleet-run is invoked without an explicit --timeout, apply this

--- a/scripts/fleet/tests/test_dispatcher_stagger.sh
+++ b/scripts/fleet/tests/test_dispatcher_stagger.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Tests for the startup-burst / 429 hardening (dispatch stagger + short-window
+# 429 backoff). Three pieces work together:
+#
+#   1. fleet-dispatcher's global min-gap (FLEET_DISPATCH_MIN_GAP_SECONDS) so a
+#      single tick can't fire every idle pane at once — exercised through the
+#      `--dispatch-gap-check <last-epoch> <now-epoch>` inspection subcommand.
+#   2. fleet-dispatch-wrap classifying a non-zero exit + a throttle flag as a
+#      short-window 429: writes `<pane>.throttle.ts` (short cooldown) and
+#      re-arms the role's trigger — vs. the usage-limit exit (code 2 → `.ts`)
+#      and the clean exit (no markers).
+#   3. fleet-claude-stream touching FLEET_THROTTLE_FLAG when it sees the
+#      "Server is temporarily limiting requests" line.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+WRAP="$SCRIPT_DIR/fleet-dispatch-wrap"
+STREAM="$SCRIPT_DIR/fleet-claude-stream"
+
+for f in "$DISPATCHER" "$WRAP" "$STREAM"; do
+    if [[ ! -e "$f" ]]; then
+        echo "test setup: missing $f" >&2
+        exit 1
+    fi
+done
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+assert_file() {
+    local path="$1" msg="$2"
+    if [[ -f "$path" ]]; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg (expected file to exist: $path)"
+    fi
+}
+
+assert_no_file() {
+    local path="$1" msg="$2"
+    if [[ ! -f "$path" ]]; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg (expected file to be absent: $path)"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_SESSION="fleet-test-$$"   # never touch a real fleet session
+
+# --- Part 1: global min-gap math (--dispatch-gap-check) --------------------
+echo "T1: dispatch min-gap gate (default 8s)"
+assert_eq "$("$DISPATCHER" --dispatch-gap-check 100 104)" "wait" "Δ4 < 8 → wait"
+assert_eq "$("$DISPATCHER" --dispatch-gap-check 100 107)" "wait" "Δ7 < 8 → wait"
+assert_eq "$("$DISPATCHER" --dispatch-gap-check 100 108)" "ok"   "Δ8 == 8 → ok (boundary)"
+assert_eq "$("$DISPATCHER" --dispatch-gap-check 100 120)" "ok"   "Δ20 > 8 → ok"
+
+echo "T2: gap is configurable / disable-able"
+assert_eq "$(FLEET_DISPATCH_MIN_GAP_SECONDS=0 "$DISPATCHER" --dispatch-gap-check 100 100)" \
+    "ok" "gap=0 disables the stagger (always ok)"
+assert_eq "$(FLEET_DISPATCH_MIN_GAP_SECONDS=30 "$DISPATCHER" --dispatch-gap-check 100 120)" \
+    "wait" "gap=30, Δ20 → wait"
+assert_eq "$(FLEET_DISPATCH_MIN_GAP_SECONDS=30 "$DISPATCHER" --dispatch-gap-check 100 130)" \
+    "ok" "gap=30, Δ30 → ok"
+
+echo "T3: --dispatch-gap-check arg validation"
+if "$DISPATCHER" --dispatch-gap-check 100 >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: missing now-epoch should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: missing now-epoch exits non-zero"
+fi
+if "$DISPATCHER" --dispatch-gap-check abc 100 >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: non-integer epoch should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: non-integer epoch exits non-zero"
+fi
+
+# --- Part 2: fleet-dispatch-wrap exit-code classification ------------------
+# Stub `claude` (chosen exit code) and `fleet-claude-stream` (optionally
+# touches FLEET_THROTTLE_FLAG) on PATH so the wrapper runs end-to-end offline.
+STUB_BIN="$TMPROOT/bin"
+mkdir -p "$STUB_BIN"
+cat >"$STUB_BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+exit ${FAKE_CLAUDE_RC:-0}
+STUB
+cat >"$STUB_BIN/fleet-claude-stream" <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null   # drain claude's stdout
+if [[ "${FAKE_STREAM_THROTTLE:-0}" == "1" && -n "${FLEET_THROTTLE_FLAG:-}" ]]; then
+    touch "$FLEET_THROTTLE_FLAG"
+fi
+exit 0
+STUB
+chmod +x "$STUB_BIN/claude" "$STUB_BIN/fleet-claude-stream"
+
+run_wrap() {
+    # $1 rc, $2 throttle(0/1), $3 role; uses a fresh state dir each call.
+    local rc="$1" throttle="$2" role="$3"
+    WRAP_STATE=$(mktemp -d "$TMPROOT/state.XXXXXX")
+    PATH="$STUB_BIN:$PATH" FLEET_STATE_DIR="$WRAP_STATE" \
+        FAKE_CLAUDE_RC="$rc" FAKE_STREAM_THROTTLE="$throttle" \
+        bash "$WRAP" pane-9 sonnet high "$role" >/dev/null 2>&1 || true
+    echo "$WRAP_STATE"
+}
+
+echo "T4: short-window 429 (rc!=0 + throttle flag) → throttle cooldown + re-arm"
+st=$(run_wrap 1 1 opus-reviewer)
+assert_file    "$st/rate-limit/pane-9.throttle.ts" "429 writes the short throttle marker"
+assert_file    "$st/triggers/opus-reviewer"        "429 re-arms the role trigger"
+assert_no_file "$st/rate-limit/pane-9.ts"          "429 does NOT write the usage-limit marker"
+assert_no_file "$st/rate-limit/pane-9.throttle-seen" "in-run throttle flag is cleaned up"
+
+echo "T5: usage-limit exit (rc==2) → long cooldown marker only"
+st=$(run_wrap 2 0 opus-reviewer)
+assert_file    "$st/rate-limit/pane-9.ts"          "rc==2 writes the usage-limit marker"
+assert_no_file "$st/rate-limit/pane-9.throttle.ts" "rc==2 does NOT write the throttle marker"
+assert_no_file "$st/triggers/opus-reviewer"        "rc==2 does NOT re-arm (usage gate handles quota)"
+
+echo "T6: clean exit (rc==0) → no markers, no re-arm, flag cleaned"
+st=$(run_wrap 0 1 opus-reviewer)
+assert_no_file "$st/rate-limit/pane-9.ts"            "clean exit writes no usage-limit marker"
+assert_no_file "$st/rate-limit/pane-9.throttle.ts"   "clean exit writes no throttle marker"
+assert_no_file "$st/triggers/opus-reviewer"          "clean exit does not re-arm a reviewer"
+assert_no_file "$st/rate-limit/pane-9.throttle-seen" "clean exit cleans up the in-run flag"
+
+echo "T7: non-zero exit WITHOUT a throttle flag → no throttle marker (generic failure)"
+st=$(run_wrap 1 0 opus-reviewer)
+assert_no_file "$st/rate-limit/pane-9.throttle.ts" "rc==1 w/o throttle flag → no throttle cooldown"
+assert_no_file "$st/triggers/opus-reviewer"        "rc==1 w/o throttle flag → no re-arm"
+
+# --- Part 3: fleet-claude-stream flag-touch on the 429 line ----------------
+echo "T8: fleet-claude-stream touches FLEET_THROTTLE_FLAG on the 429 line"
+flag="$TMPROOT/seen-429"
+rm -f "$flag"
+printf '%s\n' "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited" \
+    | FLEET_THROTTLE_FLAG="$flag" python3 "$STREAM" >/dev/null 2>&1
+assert_file "$flag" "throttle line touches the flag"
+
+echo "T9: a normal line does NOT touch the flag"
+flag2="$TMPROOT/seen-normal"
+rm -f "$flag2"
+printf '%s\n' "just some ordinary stderr output" \
+    | FLEET_THROTTLE_FLAG="$flag2" python3 "$STREAM" >/dev/null 2>&1
+assert_no_file "$flag2" "non-throttle line leaves the flag untouched"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Fixes the `fleet-up` startup burst that trips Anthropic's short-window 429 (`Server is temporarily limiting requests (not your usage limit)`) — observed with several panes erroring at once.
- **Root cause:** the dispatcher fires every idle pane in one tick (~8 cold `claude` cold-starts, each reading the large `state.json`, inside one minute). The existing `pane_stagger` only spaces pane *creation* + the per-pane `git fetch`, not the claude launches. And a 429 isn't exit code 2, so no cooldown engaged — panes could re-fire into it, and reviewer/smoke roles (no periodic re-arm) could stall.

## Changes
- **`fleet-dispatcher`** — global min-gap `FLEET_DISPATCH_MIN_GAP_SECONDS` (default 8) between any two launches across all roles/panes (tracked via `LAST_DISPATCH_EPOCH`); a *minimum* gap, so only simultaneous bursts get spread (~one launch per tick). Gap-deferred panes keep the trigger for later ticks. `pane_in_rate_limit_cooldown` now also honors a short 429 marker (`<pane>.throttle.ts`, `FLEET_DISPATCHER_RATE429_DELAY` default 90) next to the usage-limit marker. New `--dispatch-gap-check` test hook.
- **`fleet-dispatch-wrap`** — on a non-zero exit *with* the throttle flag set: short throttle cooldown + **re-arm the role trigger** so the pane retries when the window clears (critical for reviewer/smoke). `rc==2` keeps the long usage-limit cooldown; clean exits write nothing.
- **`fleet-claude-stream`** — detect the throttle line, touch `FLEET_THROTTLE_FLAG` for the wrapper, and annotate it as a warning (claude often retries it internally and still succeeds).
- **`fleet-up.conf.sample`** — documents both tunables.
- **`tests/test_dispatcher_stagger.sh`** — 24 cases (gap math, wrapper 429/usage/clean classification + re-arm, stream flag-touch).

## Test plan
- [x] `bash scripts/fleet/tests/test_dispatcher_stagger.sh` → 24/0.
- [x] Regressions: `test_dispatcher_effort.sh` 13/0, `test_dispatcher_concurrency_cap.sh` 22/0, `test_fleet_claude_stream_latch.py` 4/4. (`test_dispatcher_usage_gate.sh` has one **pre-existing** failure on master, unrelated — a `>=` vs `>` boundary; flagged separately.)
- [ ] After merge: pull master, `fleet-down && fleet-up`, watch `~/.fleet/logs/dispatcher.log` at boot — launches should land ~one per tick instead of all at once.

## Activation
The live dispatcher runs from the main checkout via `~/bin`; this goes live only after merge + `git pull` on master + a dispatcher restart (`fleet-down && fleet-up`). `fleet-dispatch-wrap` / `fleet-claude-stream` are invoked fresh each iteration, so they take effect on merge+pull with no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)