### PR TITLE
role-opus-architect: self-heal stale resume-state at design-unblock

### DIFF
--- a/.claude/commands/role-opus-architect.md
+++ b/.claude/commands/role-opus-architect.md
@@ -426,7 +426,47 @@ When working a `fleet:design-blocked` PR:
    ```
    gh pr edit <N> --remove-label "fleet:design-blocked" --add-label "fleet:design-unblocked"
    ```
-6. (Optional) If the re-scope changes the semantics significantly,
+6. **Self-heal stale resume-state (do this every unblock).** A worker
+   that escalated typically released its claim and reset/parked the
+   branch ("releasing the claim so any worker can resume"), but two
+   pieces of stale state routinely survive and silently keep the
+   unblocked PR from being picked up. The architect unblock is the one
+   chokepoint where both are always observable, so clear them here:
+
+   a. **Orphaned claim labels on the backing issue.** A parked
+      (design-blocked) PR is NOT active work, but its matching
+      `fleet:wip` PR makes the TTL cleanup sweep treat the issue's
+      `fleet:claim-<host>-<agent>` + `fleet:in-progress` labels as a
+      live claim, so they never get swept — the scout then sees the
+      issue as in-progress and no worker can claim it. Check and clear:
+      ```
+      gh issue view <issueN> --repo <repo> --json labels \
+        --jq '[.labels[].name] | map(select(startswith("fleet:claim-") or . == "fleet:in-progress"))'
+      # if non-empty:
+      gh issue edit <issueN> --repo <repo> \
+        --remove-label "fleet:in-progress" --remove-label "fleet:claim-<host>-<agent>"
+      ```
+      (Safe because design-blocked ⇒ parked-for-architect ⇒ the claim
+      is by definition not active. The released worker's FS claim is
+      already gone; only the GitHub labels linger.)
+
+   b. **Stacked-on-merged base.** If the PR's `baseRefName` is a branch
+      that has since merged, the merger never re-targeted it (the merger
+      skips `fleet:wip` PRs), so the worker's stacked-resume has no clean
+      rebase target. Re-target to `master` and drop the stacked label:
+      ```
+      gh pr view <N> --repo <repo> --json baseRefName,labels
+      # if base merged / is not master:
+      gh pr edit <N> --repo <repo> --base master --remove-label "fleet:stacked"
+      ```
+      (For a genuinely-stacked PR whose base is still open, leave the
+      base alone — only re-target when the base has merged.)
+
+   The root-cause fixes for both (full claim release on escalation; the
+   cleanup sweep ignoring parked PRs; merged-base re-target running on
+   `fleet:wip` PRs) are tracked separately; this step is the standing
+   safety net until they land. Worked example: PR #1483 / issue #1475.
+7. (Optional) If the re-scope changes the semantics significantly,
    update the PR title:
    ```
    gh pr edit <N> --title "<new title>"


### PR DESCRIPTION
## Summary

Adds a standing safety net to the architect's `fleet:design-blocked` handling: a step-6 **self-heal** that, at every unblock, clears the two pieces of stale state that routinely keep an unblocked PR from being picked up.

## Why (observed incident: PR #1483 / issue #1475)

opus-worker-1 was idle while detached-SO(3) P3b sat unworked. Two stale-state traps, both surviving a design-block escalation:

1. **Orphaned claim labels.** When the worker escalated, it released its FS claim and reset the branch ("releasing the claim so any worker can resume"), but the issue's `fleet:claim-mac-opus-worker-1` + `fleet:in-progress` GitHub labels lingered. The TTL cleanup sweep (`fleet-claim cleanup --gh` Pass 3) won't clear them because the matching `fleet:wip` PR makes the work look live — so the scout saw the issue as in-progress and nobody could claim it.
2. **Stacked-on-merged base.** The base P3a PR merged while #1483 was still `fleet:wip`; the merger never re-targeted it because the merger skips wip PRs. The worker's stacked-resume then had no clean rebase target.

The architect unblock is the one chokepoint where **both** are always observable from GitHub state, so it's the right place to self-heal — exactly the manual procedure that unstuck #1475 today.

## What the step does

- **(a)** Check the backing issue for `fleet:claim-*` / `fleet:in-progress`; clear them (safe — design-blocked ⇒ parked ⇒ claim is not active; the released worker's FS claim is already gone).
- **(b)** If the PR's `baseRefName` is a merged branch, re-target to `master` and drop `fleet:stacked` (only when the base has actually merged; leave genuinely-stacked open-base PRs alone).

## Follow-up (root-cause fixes, filed separately)

This is the safety net, not the cure. The root fixes — (1) full claim release on escalation, (2) cleanup sweep ignoring parked/design-blocked PRs, (3) merged-base re-target running on `fleet:wip` PRs — are filed as a separate infra-hardening task so they go through review (they touch `fleet-claim` and the merger).

## Test plan
- [x] Doc-only edit to `.claude/commands/role-opus-architect.md`; renders cleanly, step renumbered 6→7.
- [ ] Next design-unblock exercises the self-heal step end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)