### PR TITLE
fleet/scout: exclude fleet:human-deferred PRs from merger projection (#1486)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1167,12 +1167,19 @@ def _merger_action_signal(labels, mergeable, base_ref):
     skip signals — the merger isn't the agent that resolves those;
     a smoke-runner clears them. Including them as merger candidates
     just makes the merger fire repeatedly to find nothing to do.
+
+    `fleet:human-deferred` is a terminal handoff label — an opus-worker
+    diagnosed the conflict as not-agent-resolvable and filed a follow-up
+    issue; only the human decides (close-as-superseded / replace /
+    reconcile). Re-dispatching the merger just re-triggers the
+    opus-worker thrash cycle (observed game #101, three passes).
     """
     skip = labels & {
         "fleet:wip", "human:wip", "fleet:blocker",
         "fleet:fork-of-other-pr", "fleet:design-blocked",
         "fleet:needs-info", "fleet:needs-linux-smoke",
         "fleet:needs-macos-smoke",
+        "fleet:human-deferred",
     }
     if skip:
         return None

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -146,6 +146,28 @@ class SkipLabelsRemovedFromProjection(unittest.TestCase):
         ])])
         self.assertEqual(_hash(empty), _hash(with_blocker))
 
+    def test_human_deferred_conflicting_dropped(self):
+        # A fleet:human-deferred + CONFLICTING PR is at a terminal
+        # "human owns this decision" state. The merger re-applying
+        # fleet:semantic-conflict causes an opus-worker thrash loop
+        # (observed game #101, three identical passes). The projection
+        # must treat it as invisible so the merger is never dispatched.
+        empty = _state([])
+        deferred = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:human-deferred",
+        ], mergeable="CONFLICTING")])
+        self.assertEqual(_hash(empty), _hash(deferred),
+                         "human-deferred PRs must be invisible to merger")
+
+    def test_human_deferred_mergeable_dropped(self):
+        # Even a MERGEABLE human-deferred PR is not the merger's business —
+        # the deferral label means a human decides the fate.
+        empty = _state([])
+        deferred = _state([_pr(101, labels=[
+            "fleet:approved", "fleet:human-deferred",
+        ], mergeable="MERGEABLE")])
+        self.assertEqual(_hash(empty), _hash(deferred))
+
 
 class SignalSemantics(unittest.TestCase):
     """Verify the action signal categorization matches the role doc."""
@@ -168,6 +190,15 @@ class SignalSemantics(unittest.TestCase):
 
     def test_unapproved_is_dropped(self):
         items = project_merger(_state([_pr(101, labels=[])]))
+        self.assertEqual(items, [])
+
+    def test_human_deferred_conflicting_not_needs_resolve(self):
+        # fleet:human-deferred marks a terminal handoff state; the merger
+        # must not classify it as needs-resolve and re-apply
+        # fleet:semantic-conflict (game #101 thrash).
+        items = project_merger(_state([_pr(101, labels=[
+            "fleet:approved", "fleet:human-deferred",
+        ], mergeable="CONFLICTING")]))
         self.assertEqual(items, [])
 
 


### PR DESCRIPTION
## Summary
- Adds `fleet:human-deferred` to the `_merger_action_signal` skip set in `fleet-state-scout` so conflicting deferred PRs are excluded from the merger projection entirely
- The merger is never dispatched for `fleet:human-deferred` PRs; the projection hash stays stable and the opus-worker thrash cycle is broken (observed game #101: three identical worker passes before fix)
- Adds three `test_merger_projection.py` tests covering the CONFLICTING and MERGEABLE deferred cases

## Root cause
`fleet:human-deferred` marks a terminal handoff state — an opus-worker diagnosed a conflict as not-agent-resolvable and filed a follow-up issue. With this label absent from the projection skip set, the merger was re-dispatched and re-applied `fleet:semantic-conflict`, triggering another opus-worker iteration that reached the same "not-agent-resolvable" conclusion, dropped the label, and the cycle repeated indefinitely.

## What's NOT in this PR (gated)
The companion `role-merger.md` step 3 skip list should also list `fleet:human-deferred` for defense-in-depth (prevents re-labeling even when the merger is dispatched for other PRs in the same run). That edit is a gated self-config change (`role-merger.md`). Human must apply:

**File:** `.claude/commands/role-merger.md`  
**After line:** `- \`fleet:semantic-conflict\` — already handed off to opus-worker; ...` (around line 348)  
**Insert:**
```
   - `fleet:human-deferred` — agent diagnosed conflict as not-agent-resolvable
     and filed a follow-up issue; only the human decides close/replace/reconcile.
     Re-running rebase just re-triggers the opus-worker thrash cycle.
```

## Test plan
- [x] `python3 -m unittest discover -s scripts/fleet/tests -p "*.py"` — 201 tests pass
- [x] New tests: `test_human_deferred_conflicting_dropped`, `test_human_deferred_mergeable_dropped`, `test_human_deferred_conflicting_not_needs_resolve` all pass
- [ ] Verify game #101 labels are left unchanged when merger runs after this change (no `fleet:semantic-conflict` re-applied)

Closes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)