### PR TITLE
fleet/fleet-claim: clear parked-PR claim labels on release + sweep (#1488 Fixes A+B)

### DIFF
--- a/docs/agents/AUTHOR-PIPELINE.md
+++ b/docs/agents/AUTHOR-PIPELINE.md
@@ -155,10 +155,16 @@ Paste the PR URL.
 > **Claim-label lifecycle.** `fleet-claim release` clears the local
 > filesystem lock and the worktree reservation. The issue's
 > `fleet:claim-<host>-<agent>` and `fleet:in-progress` labels are
-> **left in place** — they persist through the PR's review/merge
-> lifecycle and are swept by `fleet-claim cleanup --gh` only when the
-> issue closes or the claim goes stale with no matching open
-> `claude/<N>-*` PR. Don't hand-strip them.
+> normally **left in place** — they persist through the PR's
+> review/merge lifecycle and are swept by `fleet-claim cleanup --gh`
+> only when the issue closes or the claim goes stale with no matching
+> open `claude/<N>-*` PR. Don't hand-strip them. The one exception is
+> a **design-blocked / design-unblocked** escalation: when the issue's
+> matching PR is parked, `release` clears those two labels itself so
+> the scout stops treating the issue as in-progress and any worker can
+> re-claim once the architect unblocks it (#1488). You don't do
+> anything special — the design-escalation step's existing
+> `fleet-claim release <N>` call handles it.
 
 Then run the shared shutdown ceremony — see
 [`FLEET-RUNTIME.md § Per-iteration shutdown`](FLEET-RUNTIME.md#per-iteration-shutdown--final-step).

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1058,6 +1058,61 @@ if url and head:
 PYEOF
 }
 
+# _issue_pr_state_from <prs-json> <issue-num> <repo>
+#   Echo the shared issue_pr_state() classification ("active" / "parked" /
+#   "none") for <issue-num> over a `gh pr list --json headRefName,labels` blob.
+#   Defaults to "none" on any parse/import failure so callers fail safe (treat
+#   the claim as abandoned rather than wedged-active).
+_issue_pr_state_from() {
+    echo "$1" | ISSUE_NUM="$2" REPO="$3" python3 -c '
+import json, os, sys
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_branch_match import issue_pr_state
+try:
+    prs = json.load(sys.stdin)
+except Exception:
+    prs = []
+print(issue_pr_state(prs, os.environ["ISSUE_NUM"], os.environ.get("REPO", "")))
+' 2>/dev/null || echo none
+}
+
+# _release_parked_issue_labels <issue-num>
+#   When the issue's matching open PR is PARKED (fleet:design-blocked /
+#   fleet:design-unblocked), clear this host's `fleet:claim-<host>-*` and
+#   `fleet:in-progress` labels off the issue so the scout stops seeing it as
+#   in-progress and any worker can re-claim after the architect unblocks it
+#   (#1488 Fix A). Returns 0 only when a parked PR was detected and the sweep
+#   ran; returns 1 otherwise (gh missing, no GH repo for the namespace, or the
+#   matching PR is active — the normal PR-open release keeps its labels through
+#   the merge lifecycle, per AUTHOR-PIPELINE.md "Claim-label lifecycle").
+#   Multi-host safe: only this host's `fleet:claim-<host>-*` labels are touched.
+_release_parked_issue_labels() {
+    local issue_num="$1"
+    command -v gh >/dev/null 2>&1 || return 1
+    local repo host
+    repo=$(repo_from_ns)
+    host=$(derive_host)
+    [[ -z "$repo" ]] && return 1
+
+    local prs_json
+    prs_json=$(gh pr list --repo "$repo" --state open \
+        --json number,headRefName,labels --limit 300 2>/dev/null || echo "[]")
+
+    [[ "$(_issue_pr_state_from "$prs_json" "$issue_num" "$repo")" == "parked" ]] || return 1
+
+    # Remove this host's claim label(s) + fleet:in-progress (mirrors the
+    # cleanup --gh open-issue sweep).
+    local issue_labels lbl
+    issue_labels=$(gh issue view "$issue_num" --repo "$repo" \
+        --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+    while IFS= read -r lbl; do
+        [[ "$lbl" == fleet:claim-${host}-* ]] || continue
+        gh_release_label "$repo" "$issue_num" "$lbl" || true
+    done <<< "$issue_labels"
+    gh_release_label "$repo" "$issue_num" "fleet:in-progress" || true
+    return 0
+}
+
 cmd_release() {
     local issue_num
     if ! issue_num=$(require_issue_number "$1"); then
@@ -1083,14 +1138,23 @@ cmd_release() {
                 cmd_release_worktree "$owner" >/dev/null 2>&1 || true
             fi
         fi
-        # Issue-side `fleet:claim-*` and `fleet:in-progress` are NOT
-        # cleared here. The claim label is the canonical lock through
-        # PR lifecycle and stays as a historical record after merge;
-        # `fleet:in-progress` follows the same lifecycle so queue-list
-        # accurately reflects "active work present" until the issue
-        # closes. Abandoned claims (no matching open PR + TTL) are
-        # swept by `fleet-claim cleanup --gh` (second pass).
-        echo "released: #${issue_num} (slug: $slug, FS lock + worktree reservation cleared; issue labels retained)"
+        # Issue-side `fleet:claim-*` + `fleet:in-progress` normally persist
+        # through the PR's review/merge lifecycle (see AUTHOR-PIPELINE.md
+        # "Claim-label lifecycle"): the queue reflects "active work present"
+        # until the issue closes, and `cleanup --gh` ages out abandoned
+        # claims. The ONE exception is a design-blocked / design-unblocked
+        # escalation — the worker releases precisely so ANY worker can resume
+        # after the architect responds, but the lingering claim/in-progress
+        # labels make the scout treat the issue as in-progress and block
+        # re-claim (#1488 Fix A). The escalation step adds fleet:design-blocked
+        # to the PR before calling release, so we detect the park here and
+        # clear both sides. (cleanup --gh's parked-PR carve-out is the TTL
+        # safety net if the label landed late or release was skipped.)
+        if _release_parked_issue_labels "$issue_num"; then
+            echo "released: #${issue_num} (slug: $slug, FS lock + worktree reservation + parked issue labels cleared)"
+        else
+            echo "released: #${issue_num} (slug: $slug, FS lock + worktree reservation cleared; issue labels retained)"
+        fi
     else
         echo "not claimed: #${issue_num} (slug: $slug)"
     fi
@@ -1379,8 +1443,12 @@ except Exception:
     # closed-issue label sweep runs here.
 
     # Second pass: sweep `fleet:claim-*` labels off OPEN issues when the
-    # claim is stale — no matching open WIP PR (head-branch claude/<N>-*)
-    # exists and age > TTL.
+    # claim is stale (age > TTL) and no *active* matching PR exists. A
+    # matching PR that is parked (fleet:design-blocked / -unblocked) does NOT
+    # count as active: the worker released its claim to let any worker resume
+    # after the architect responds, so its lingering claim is sweepable just
+    # like a no-PR abandon (#1488 Fix B). Only an active (non-parked) matching
+    # WIP PR (head-branch claude/<N>-*) keeps the claim.
     local claim_issue_stale_secs="${FLEET_CLAIM_STALE_SECS_ISSUES:-7200}"
     for repo in "${repos[@]}"; do
         local open_claim_plan open_pr_branches_json
@@ -1404,7 +1472,7 @@ for issue in issues:
         [[ -z "$open_claim_plan" ]] && continue
 
         open_pr_branches_json=$(gh pr list --repo "$repo" --state open \
-            --json headRefName --limit 300 2>/dev/null || echo "[]")
+            --json headRefName,labels --limit 300 2>/dev/null || echo "[]")
 
         while IFS=$'\t' read -r issue_num label_name; do
             [[ -z "$issue_num" || -z "$label_name" ]] && continue
@@ -1430,29 +1498,20 @@ except Exception:
             local age=$(( now - added_epoch ))
             [[ $age -lt $claim_issue_stale_secs ]] && continue
 
-            local has_wip_pr
-            has_wip_pr=$(echo "$open_pr_branches_json" | ISSUE_NUM="$issue_num" REPO="$repo" python3 -c '
-import json, os, sys
-sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
-from fleet_branch_match import branch_matches_issue
-try:
-    prs = json.load(sys.stdin)
-except Exception:
-    prs = []
-issue = os.environ["ISSUE_NUM"]
-repo = os.environ.get("REPO", "")
-for pr in prs:
-    if branch_matches_issue(pr.get("headRefName") or "", issue, repo):
-        print(1)
-        sys.exit(0)
-print(0)
-' 2>/dev/null || echo 0)
+            local pr_state
+            pr_state=$(_issue_pr_state_from "$open_pr_branches_json" "$issue_num" "$repo")
 
-            [[ "$has_wip_pr" -eq 1 ]] && continue
+            # Keep the claim only while a matching PR is *active* work; a
+            # parked (design-blocked/-unblocked) or absent matching PR falls
+            # through to the sweep below (#1488 Fix B).
+            [[ "$pr_state" == "active" ]] && continue
+
+            local sweep_reason="no open PR"
+            [[ "$pr_state" == "parked" ]] && sweep_reason="parked PR (design-blocked/unblocked)"
 
             if gh issue edit "$issue_num" --repo "$repo" \
                     --remove-label "$label_name" >/dev/null 2>&1; then
-                echo "cleanup --gh: removed stale '$label_name' on $repo issue#$issue_num (age: $((age / 60))m, no open PR)"
+                echo "cleanup --gh: removed stale '$label_name' on $repo issue#$issue_num (age: $((age / 60))m, ${sweep_reason})"
                 total_removed=$((total_removed + 1))
                 gh issue edit "$issue_num" --repo "$repo" \
                     --remove-label "fleet:in-progress" >/dev/null 2>&1 || true
@@ -3539,9 +3598,15 @@ commands:
                                 reservation + --stackable-on .meta
                                 sidecar). Issue-side `fleet:claim-*`
                                 and `fleet:in-progress` labels are
-                                retained — abandoned-claim sweep in
-                                `cleanup --gh` handles those when no
-                                matching open PR exists.
+                                retained through the PR's review/merge
+                                lifecycle — EXCEPT when the issue's
+                                matching open PR is parked
+                                (fleet:design-blocked/-unblocked), in
+                                which case they are cleared so any
+                                worker can re-claim after the architect
+                                unblocks (#1488). The abandoned-claim
+                                sweep in `cleanup --gh` is the TTL
+                                safety net.
   check <issue-number>          check if free (exit 0=free, 1=taken).
   list                          list all active claims.
   host [uname-string]           print this host's canonical key
@@ -3572,11 +3637,13 @@ commands:
                                     PRs (>30 min age),
                                 (2) fleet:claim-* labels off open
                                     issues where the claim is
-                                    abandoned — no matching WIP PR
-                                    (head-branch claude/<N>-*) exists
-                                    and age > TTL (default 7200s).
-                                    `fleet:in-progress` is removed
-                                    alongside the claim label.
+                                    abandoned — age > TTL (default
+                                    7200s) AND no *active* matching PR
+                                    exists. A matching PR that is parked
+                                    (fleet:design-blocked/-unblocked)
+                                    counts as abandoned, not active
+                                    (#1488). `fleet:in-progress` is
+                                    removed alongside the claim label.
                                 `fleet:claim-*` labels on CLOSED
                                 issues are preserved as a historical
                                 "who worked on this" record.

--- a/scripts/fleet/fleet_branch_match.py
+++ b/scripts/fleet/fleet_branch_match.py
@@ -62,6 +62,45 @@ def branch_matches_issue(head_ref, issue, repo):
     return any(head.startswith(p) for p in issue_branch_prefixes(repo, issue))
 
 
+# A PR carrying either of these is *parked*: a worker hit a design wall and
+# released its claim so ANY worker can resume once the architect responds.
+# Such a PR is NOT active work even though it is open and `fleet:wip` — its
+# lingering issue-side `fleet:claim-*` / `fleet:in-progress` labels would
+# otherwise wedge the issue as "in progress" and block re-claim (#1488).
+PARKED_PR_LABELS = frozenset({"fleet:design-blocked", "fleet:design-unblocked"})
+
+
+def issue_pr_state(prs, issue, repo):
+    """Classify the open PRs whose branch matches `issue` in `repo`.
+
+    Returns one of:
+      "active" — a matching PR exists that is NOT parked: live work, so the
+                 issue's claim/in-progress labels should stay.
+      "parked" — every matching PR is parked (PARKED_PR_LABELS). The claim is
+                 awaiting-resume, not active, so its issue-side labels are
+                 stale and safe to clear/sweep (#1488 Fix A/B).
+      "none"   — no open PR branch matches the issue.
+
+    `prs` is a list of `gh pr list --json headRefName,labels` records (any
+    extra keys are ignored). Callers that only distinguish "keep the claim"
+    from "release the claim" treat "parked" and "none" identically.
+    """
+    saw_parked = False
+    for pr in (prs or []):
+        if not branch_matches_issue(pr.get("headRefName") or "", issue, repo):
+            continue
+        names = {
+            (lbl or {}).get("name", "")
+            for lbl in (pr.get("labels") or [])
+            if isinstance(lbl, dict)
+        }
+        if names & PARKED_PR_LABELS:
+            saw_parked = True
+            continue
+        return "active"
+    return "parked" if saw_parked else "none"
+
+
 def issue_from_branch(head_ref):
     """Extract the issue number from a `claude/...` branch, or None.
 

--- a/scripts/fleet/tests/test_branch_matches_issue.py
+++ b/scripts/fleet/tests/test_branch_matches_issue.py
@@ -15,6 +15,7 @@ from fleet_branch_match import (
     branch_matches_issue,
     issue_branch_prefixes,
     issue_from_branch,
+    issue_pr_state,
     _is_game,
 )
 
@@ -94,6 +95,58 @@ class IssueFromBranch(unittest.TestCase):
     def test_empty_and_none(self):
         self.assertIsNone(issue_from_branch(""))
         self.assertIsNone(issue_from_branch(None))
+
+
+class IssuePrState(unittest.TestCase):
+    """Classifier behind the #1488 claim-lifecycle fixes: a matching PR that
+    is design-blocked/-unblocked is PARKED (awaiting resume), not active, so
+    its issue-side claim labels are sweepable like a no-PR abandon."""
+
+    def _pr(self, head, *labels):
+        return {"headRefName": head, "labels": [{"name": n} for n in labels]}
+
+    def test_active_when_matching_pr_not_parked(self):
+        prs = [self._pr("claude/1488-x", "fleet:wip", "fleet:approved")]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "active")
+
+    def test_parked_on_design_blocked(self):
+        prs = [self._pr("claude/1488-x", "fleet:wip", "fleet:design-blocked")]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "parked")
+
+    def test_parked_on_design_unblocked(self):
+        prs = [self._pr("claude/1488-x", "fleet:design-unblocked")]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "parked")
+
+    def test_none_when_no_branch_matches(self):
+        prs = [self._pr("claude/9999-x", "fleet:wip")]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "none")
+        self.assertEqual(issue_pr_state([], 1488, "engine"), "none")
+
+    def test_active_wins_over_parked_dup(self):
+        # Two PRs match the same issue; one parked, one active. Any active
+        # matching PR means the claim is still live work -> "active".
+        prs = [
+            self._pr("claude/1488-parked", "fleet:design-blocked"),
+            self._pr("claude/1488-live", "fleet:wip"),
+        ]
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "active")
+
+    def test_game_legacy_branch_parked(self):
+        # The matcher must recognize the legacy game- prefix here too.
+        prs = [self._pr("claude/game-45-x", "fleet:design-blocked")]
+        self.assertEqual(issue_pr_state(prs, 45, "game"), "parked")
+        # A game-shaped branch is not an engine branch -> no match.
+        self.assertEqual(issue_pr_state(prs, 45, "engine"), "none")
+
+    def test_malformed_records_are_ignored(self):
+        # Defensive: missing/None labels and non-dict label entries.
+        prs = [
+            {"headRefName": "claude/1488-x"},                       # no labels key
+            {"headRefName": "claude/1488-y", "labels": None},
+            {"headRefName": "claude/1488-z", "labels": ["junk", None]},
+        ]
+        # None are parked, all match -> first match is active.
+        self.assertEqual(issue_pr_state(prs, 1488, "engine"), "active")
 
 
 if __name__ == "__main__":

--- a/scripts/fleet/tests/test_fleet_claim_parked_release.sh
+++ b/scripts/fleet/tests/test_fleet_claim_parked_release.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Tests for the #1488 claim-lifecycle hardening in fleet-claim:
+#
+#   Fix A — `fleet-claim release` clears this host's `fleet:claim-<host>-*`
+#           + `fleet:in-progress` labels off the issue ONLY when the issue's
+#           matching open PR is parked (fleet:design-blocked/-unblocked). A
+#           normal PR-open release (active matching PR) keeps the labels, per
+#           AUTHOR-PIPELINE.md "Claim-label lifecycle".
+#
+#   Fix B — `fleet-claim cleanup --gh` open-issue claim sweep treats a parked
+#           matching PR like a no-PR abandon: a stale claim whose only matching
+#           PR is design-blocked/-unblocked is swept (claim label +
+#           fleet:in-progress), while an active matching PR keeps the claim.
+#
+# `gh` is stubbed so the label/PR surfaces are canned JSON. Host is pinned to
+# `mac` via FLEET_TEST_HOST so claim-label construction is deterministic.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+assert_removed_contains() {
+    if grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; then ok "$2"; else bad "$2 (not in removed log)"; fi
+}
+assert_removed_absent() {
+    if ! grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; then ok "$2"; else bad "$2 (unexpectedly removed)"; fi
+}
+assert_dir_absent() {
+    if [[ ! -d "$1" ]]; then ok "$2"; else bad "$2 (dir still present: $1)"; fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+export FLEET_TEST_HOST="mac"
+# Drive the open-issue claim sweep without waiting on the real 2h TTL: the gh
+# stub reports every claim label as added long ago, and we keep the threshold
+# tiny so any age clears it.
+export FLEET_CLAIM_STALE_SECS_ISSUES=1
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR" "$FLEET_STATE_DIR" "$FLEET_ORPHANS_DIR"
+
+export ISSUES_JSON="$TMPROOT/issues.json"
+export PRS_JSON="$TMPROOT/prs.json"
+REMOVED_FILE="$TMPROOT/removed.log"
+: > "$REMOVED_FILE"
+export REMOVED_FILE
+
+# --- gh stub --------------------------------------------------------------
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+# Stub gh for the #1488 parked-release / parked-sweep tests.
+case "$1" in
+    issue)
+        case "$2" in
+            list) cat "$ISSUES_JSON"; exit 0 ;;
+            view)
+                # `gh issue view <N> --json labels|state [--jq ...]`
+                num="$3"
+                want="state"
+                printf '%s ' "$@" | grep -q -- '--json labels' && want="labels"
+                NUM="$num" WANT="$want" python3 -c '
+import json, os, sys
+num = int(os.environ["NUM"])
+want = os.environ["WANT"]
+issues = json.load(open(os.environ["ISSUES_JSON"]))
+issue = next((i for i in issues if i.get("number") == num), None)
+if want == "labels":
+    if issue:
+        for l in issue.get("labels", []):
+            print(l.get("name", ""))
+else:
+    print((issue or {}).get("state", "OPEN"))
+'
+                exit 0
+                ;;
+            edit)
+                shift 2
+                issue="$1"; shift
+                while [[ $# -gt 0 ]]; do
+                    case "$1" in
+                        --remove-label) printf '%s\t%s\n' "$issue" "$2" >> "$REMOVED_FILE"; shift 2 ;;
+                        *) shift ;;
+                    esac
+                done
+                exit 0
+                ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    pr)
+        case "$2" in
+            list) cat "$PRS_JSON"; exit 0 ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    api)
+        # events endpoint — report every claim label as added long ago so the
+        # TTL gate in the open-issue sweep always clears.
+        printf '%s ' "$@" | grep -q 'events' && echo "2020-01-01T00:00:00Z"
+        exit 0
+        ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+mk_claim() {
+    local slug="$1" owner="$2"
+    mkdir -p "$FLEET_CLAIMS_DIR/$slug"
+    echo "$owner" > "$FLEET_CLAIMS_DIR/$slug/owner"
+    echo "$slug"  > "$FLEET_CLAIMS_DIR/$slug/title"
+    date +%s      > "$FLEET_CLAIMS_DIR/$slug/created"
+}
+
+# =========================================================================
+echo "=== Phase 1: release clears labels only for a PARKED matching PR (Fix A) ==="
+# =========================================================================
+# #700 parked (design-blocked PR) -> release clears claim + in-progress.
+# #701 active  (plain wip PR)      -> release keeps claim + in-progress.
+cat > "$ISSUES_JSON" <<'JSON'
+[
+  {"number":700,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:in-progress"}]},
+  {"number":701,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:in-progress"}]}
+]
+JSON
+cat > "$PRS_JSON" <<'JSON'
+[
+  {"number":800,"headRefName":"claude/700-parked","labels":[{"name":"fleet:wip"},{"name":"fleet:design-blocked"}]},
+  {"number":801,"headRefName":"claude/701-live","labels":[{"name":"fleet:wip"}]}
+]
+JSON
+mk_claim 700 opus-worker-1
+mk_claim 701 opus-worker-1
+
+REL700=$("$FLEET_CLAIM" release 700 2>&1); echo "$REL700" | sed 's/^/    /'
+assert_dir_absent "$FLEET_CLAIMS_DIR/700" "release dropped FS claim #700"
+assert_removed_contains $'700\tfleet:claim-mac-opus-worker-1' "parked release cleared #700 claim label"
+assert_removed_contains $'700\tfleet:in-progress' "parked release cleared #700 fleet:in-progress"
+
+REL701=$("$FLEET_CLAIM" release 701 2>&1); echo "$REL701" | sed 's/^/    /'
+assert_dir_absent "$FLEET_CLAIMS_DIR/701" "release dropped FS claim #701"
+assert_removed_absent $'701\tfleet:claim-mac-opus-worker-1' "active release KEPT #701 claim label"
+assert_removed_absent $'701\tfleet:in-progress' "active release KEPT #701 fleet:in-progress"
+
+# =========================================================================
+echo "=== Phase 2: cleanup --gh sweeps a PARKED claim like a no-PR abandon (Fix B) ==="
+# =========================================================================
+: > "$REMOVED_FILE"
+rm -rf "$FLEET_CLAIMS_DIR"/*   # Pass 2 operates on GH labels, not FS claims.
+# #710 parked  (design-unblocked PR) -> swept.
+# #711 active  (plain wip PR)        -> kept.
+# #712 no PR                          -> swept (pre-existing behavior, unchanged).
+cat > "$ISSUES_JSON" <<'JSON'
+[
+  {"number":710,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:in-progress"}]},
+  {"number":711,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-2"},{"name":"fleet:in-progress"}]},
+  {"number":712,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-opus-worker-1"},{"name":"fleet:in-progress"}]}
+]
+JSON
+cat > "$PRS_JSON" <<'JSON'
+[
+  {"number":810,"headRefName":"claude/710-parked","labels":[{"name":"fleet:wip"},{"name":"fleet:design-unblocked"}]},
+  {"number":811,"headRefName":"claude/711-live","labels":[{"name":"fleet:wip"}]}
+]
+JSON
+
+CLEAN_OUT=$("$FLEET_CLAIM" cleanup --gh --repo jakildev/IrredenEngine 2>&1); echo "$CLEAN_OUT" | sed 's/^/    /'
+
+assert_removed_contains $'710\tfleet:claim-mac-opus-worker-1' "parked-PR sweep removed #710 claim label"
+assert_removed_contains $'710\tfleet:in-progress' "parked-PR sweep removed #710 fleet:in-progress"
+assert_removed_absent  $'711\tfleet:claim-mac-opus-worker-2' "active-PR claim #711 retained"
+assert_removed_absent  $'711\tfleet:in-progress' "active-PR #711 fleet:in-progress retained"
+assert_removed_contains $'712\tfleet:claim-mac-opus-worker-1' "no-PR sweep removed #712 claim label (unchanged)"
+assert_removed_contains $'712\tfleet:in-progress' "no-PR sweep removed #712 fleet:in-progress (unchanged)"
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Hardens the design-blocked → unblock → resume lifecycle against the
stale-claim trap from #1488's observed incident (an opus-worker sat idle
while a parked PR went unworked). Implements **Fixes A and B**; **Fix C is
carved out** for the human (gated — see below).

Root cause: a worker that escalates `fleet:design-blocked` releases its
claim so any worker can resume after the architect unblocks — but the
issue's `fleet:claim-<host>-<agent>` + `fleet:in-progress` GitHub labels
lingered. The scout then kept seeing the issue as in-progress, so no worker
could re-claim it.

### Fix A — `fleet-claim release` clears a parked PR's claim labels
`cmd_release` now detects when the issue's matching open PR is *parked*
(`fleet:design-blocked`/`-unblocked`) and clears this host's
`fleet:claim-<host>-*` + `fleet:in-progress` labels off the issue. A normal
PR-open release (active matching PR) keeps the labels through the merge
lifecycle, exactly as documented in `AUTHOR-PIPELINE.md` "Claim-label
lifecycle" — so the duplicate-work guard on the common path is unchanged.
The design-escalation step already calls `fleet-claim release <N>` (after
adding `fleet:design-blocked`), so this needs **no role-doc change**.

### Fix B — `cleanup --gh` sweeps a parked claim like a no-PR abandon
The open-issue claim sweep previously kept a claim whenever *any* matching
open PR existed. It now keeps the claim only when an *active* (non-parked)
matching PR exists; a parked matching PR is treated like a no-PR abandon and
swept (subject to the existing TTL). This is the safety net that makes Fix A
self-correcting even if the `fleet:design-blocked` label landed late or
release was skipped.

### Shared classifier
Both fixes route through a new `issue_pr_state(prs, issue, repo)` →
`active` / `parked` / `none` helper in `fleet_branch_match.py` (the existing
shared branch↔issue matcher), so the two call sites can't drift. A small
`_issue_pr_state_from` bash wrapper feeds it from a `gh pr list` blob.

## Fix C — carved out (gated, human action required)

Fix C ("the merger re-targets `fleet:wip` PRs whose base merged") is a
behavior change to the **merger**, which is a pure LLM role: the re-target
logic lives only as prose in `.claude/commands/role-merger.md` steps 2.5/2.6
(no script performs a `gh pr edit --base`). Editing `role-*.md` is blocked
for queue-sourced workers by the deterministic self-config gate, so this PR
cannot apply it.

**Human action for Fix C:** in `.claude/commands/role-merger.md`, allow the
**re-target step specifically** to run on `fleet:wip` PRs — when a base PR
merges, re-target any open PR stacked on it to `master` and drop
`fleet:stacked`, keeping the actual *merge* gated on non-wip. Concretely,
the `fleet:wip` exclusion in the stacked-PR collection at steps 2.5/2.6
needs a carve-out for the re-target-only path. #1488 is parked
`fleet:needs-human` for this remainder.

## Test plan

- [x] `scripts/fleet/tests/test_branch_matches_issue.py` — 7 new
  `IssuePrState` cases (active / parked-blocked / parked-unblocked / none /
  active-wins-over-parked-dup / game-legacy / malformed-record).
- [x] `scripts/fleet/tests/test_fleet_claim_parked_release.sh` — new
  gh-stubbed integration test: release clears labels only for a parked PR
  (keeps them for an active PR); `cleanup --gh` sweeps a parked claim, keeps
  an active claim, and preserves the no-PR sweep.
- [x] Full suite green: 208 python tests + existing fleet-claim bash suite
  (acquire / blockers / reconcile / reconcile_c2 / reconcile_amendments /
  stackable / model_gate).

## Follow-up (reuse, not blocking)

`cmd_reset_sweep_host_claims`'s inline `has_wip_pr` branch-match block
(~75% overlap with the new `_issue_pr_state_from`) could collapse to
`[[ "$(_issue_pr_state_from ...)" != "none" ]]` after adding `labels` to its
`gh pr list` fetch — deliberately left out here to keep this PR scoped to the
fleet-up reset-sweep-untouched #1488 surface.

Refs #1488 (Fixes A + B; Fix C carved out for human application)

🤖 Generated with [Claude Code](https://claude.com/claude-code)