### PR TITLE
render: stage-2 detached depth-axis parity + canvas_stress --no-auto-rotate clobber fix

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -82,6 +82,11 @@ struct CanvasStressSettings {
     bool fullRotate_ = false;
     bool noSpin_ = false;
     bool noLighting_ = false;
+    // readConfig() runs AFTER parseArgs() (it needs IREngine::init), so a
+    // config `auto_rotate` would otherwise clobber an explicit
+    // --auto-rotate / --no-auto-rotate flag. Latch CLI intent so config only
+    // supplies the default when the flag is absent (CLI overrides config).
+    bool autoRotateSetByCli_ = false;
 };
 
 // 0.5 degrees per frame → full revolution in ~720 frames (~12 s at 60 fps)
@@ -210,7 +215,7 @@ void readConfig() {
     if (zoom.is<float>())
         g_settings.initialZoom_ = zoom.as<float>();
     sol::object autoRotate = table["auto_rotate"];
-    if (autoRotate.is<bool>())
+    if (autoRotate.is<bool>() && !g_settings.autoRotateSetByCli_)
         g_settings.autoRotate_ = autoRotate.as<bool>();
 }
 
@@ -222,8 +227,10 @@ void parseArgs(int argc, char **argv) {
             ++i;
         } else if (std::strcmp(argv[i], "--auto-rotate") == 0) {
             g_settings.autoRotate_ = true;
+            g_settings.autoRotateSetByCli_ = true;
         } else if (std::strcmp(argv[i], "--no-auto-rotate") == 0) {
             g_settings.autoRotate_ = false;
+            g_settings.autoRotateSetByCli_ = true;
         } else if (std::strcmp(argv[i], "--full-rotate") == 0) {
             g_settings.fullRotate_ = true;
         } else if (std::strcmp(argv[i], "--no-spin") == 0) {

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -225,7 +225,7 @@ struct FrameDataVoxelToCanvas {
     // (1,1,1). `.w` is std140 padding. std140-appended after visibleFaceIds_
     // (offset 144), so every prior field offset — and the world/GRID fast
     // path — is unchanged; the gather shaders that read only the prefix
-    // (stage 2, AO, lighting) are unaffected and need no declaration update.
+    // (AO, lighting) are unaffected and need no declaration update.
     vec4 voxelDepthAxis_ = vec4(1.0f, 1.0f, 1.0f, 0.0f);
 };
 

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
@@ -28,6 +28,13 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
     uniform vec4 faceDeform[3];
     // Per-slot world FaceId (0..5). See stage 1 + #1278 for the contract.
     uniform ivec4 visibleFaceIds;
+    // Model-frame iso depth axis `R⁻¹·(1,1,1)` for the per-voxel occlusion
+    // metric (#1462). Stage 2 MUST read the same axis stage 1 wrote the
+    // distance tap on, or the depth re-test below rejects every detached
+    // color tap off a snap (the #1499 sliver). (1,1,1) for world / identity
+    // so the GRID path stays byte-identical. Appended after visibleFaceIds
+    // (offset 144) to match the CPU struct + stage 1's binding-7 layout.
+    uniform vec4 voxelDepthAxis;
 };
 
 layout(std430, binding = 5) readonly buffer PositionBuffer {
@@ -173,8 +180,14 @@ void main() {
             voxelPositionInt = rotateCardinalZ(voxelPositionInt, cardinalIndex);
             voxelPositionInt += cardinalLowerCornerShift(cardinalIndex);
         }
-        const int voxelDistance = encodeDepthWithFace(
-            pos3DtoDistance(voxelPositionInt), slot);
+        // Detached entities project occlusion depth onto the entity-rotated
+        // iso axis (#1462); world/GRID keeps the fixed (1,1,1) via
+        // pos3DtoDistance. MUST mirror stage 1's distance-tap depth or the
+        // re-test in writeColorTap rejects the tap (#1499).
+        const int rawDepth = isDetachedCanvas > 0.5
+            ? isoDepthAlongAxis(voxelPositionInt, voxelDepthAxis.xyz)
+            : pos3DtoDistance(voxelPositionInt);
+        const int voxelDistance = encodeDepthWithFace(rawDepth, slot);
         const ivec2 base =
             trixelFrameOffset(trixelCanvasOffsetZ1, frameCanvasOffset, voxelRenderOptions) +
             pos3DtoPos2DIso(voxelPositionInt);
@@ -199,8 +212,11 @@ void main() {
         // `voxelPositionFixed = round(worldPos * subdivisions)`.
         microPositionFixed += cardinalLowerCornerShift(cardinalIndex) * subdivisions;
     }
-    const int depthBase =
-        microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
+    // Detached: mirror stage 1's entity-rotated occlusion axis (#1462 / #1499);
+    // depth is in subdivision units on both branches so the encode is unchanged.
+    const int depthBase = isDetachedCanvas > 0.5
+        ? isoDepthAlongAxis(microPositionFixed, voxelDepthAxis.xyz)
+        : (microPositionFixed.x + microPositionFixed.y + microPositionFixed.z);
     const int voxelDistance = encodeDepthWithFace(depthBase, slot);
     const ivec2 base = frameOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
     emitDeformedFace(base, D, voxelDistance, voxelColor, voxelIndex);

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
@@ -190,9 +190,14 @@ kernel void c_voxel_to_trixel_stage_2(
             voxelPositionInt = rotateCardinalZ(voxelPositionInt, cardinalIndex);
             voxelPositionInt += cardinalLowerCornerShift(cardinalIndex);
         }
-        const int voxelDistance = encodeDepthWithFace(
-            pos3DtoDistance(voxelPositionInt), slot
-        );
+        // Detached entities project occlusion depth onto the entity-rotated
+        // iso axis (#1462); world/GRID keeps the fixed (1,1,1) via
+        // pos3DtoDistance. MUST mirror stage 1's distance-tap depth or the
+        // re-test in writeColorTap rejects the tap (#1499).
+        const int rawDepth = frameData.isDetachedCanvas > 0.5f
+            ? isoDepthAlongAxis(voxelPositionInt, frameData.voxelDepthAxis.xyz)
+            : pos3DtoDistance(voxelPositionInt);
+        const int voxelDistance = encodeDepthWithFace(rawDepth, slot);
         const int2 base =
             trixelFrameOffset(
                 frameData.trixelCanvasOffsetZ1,
@@ -235,8 +240,11 @@ kernel void c_voxel_to_trixel_stage_2(
         microPositionFixed = rotateCardinalZ(microPositionFixed, cardinalIndex);
         microPositionFixed += cardinalLowerCornerShift(cardinalIndex) * subdivisions;
     }
-    const int depthBase =
-        microPositionFixed.x + microPositionFixed.y + microPositionFixed.z;
+    // Detached: mirror stage 1's entity-rotated occlusion axis (#1462 / #1499);
+    // depth is in subdivision units on both branches so the encode is unchanged.
+    const int depthBase = frameData.isDetachedCanvas > 0.5f
+        ? isoDepthAlongAxis(microPositionFixed, frameData.voxelDepthAxis.xyz)
+        : (microPositionFixed.x + microPositionFixed.y + microPositionFixed.z);
     const int voxelDistance = encodeDepthWithFace(depthBase, slot);
     const int2 base = frameOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
     emitDeformedFace(


### PR DESCRIPTION
Two small render-correctness fixes that came out of the #1499 investigation. Per the architect's design call on this PR, **#1499 is closed as a misdiagnosis**: at TRUE identity (camera yaw=0) the gather/single-canvas path renders off-origin detached cubes correctly. The "off-origin identity sliver" premise was a compositing illusion (main-grid bleed-through) compounded by a CLI-flag clobber that ran every "identity" repro at a drifting ~30° yaw. The real sliver bug is the pose-dependent forward-scatter degeneracy tracked by #1494.

Both fixes below are byte-safe and correct regardless of that scoping — they stand on their own.

## Fix 1 — canvas_stress `--no-auto-rotate` clobber (`creations/demos/canvas_stress/main.cpp`)
`readConfig()` runs after `parseArgs()` (it needs `IREngine::init`), so a `config.lua` `auto_rotate=true` silently overwrote an explicit `--auto-rotate` / `--no-auto-rotate` flag. Every "identity / --no-auto-rotate" repro was actually running at a drifting camera yaw. Latch CLI intent (`autoRotateSetByCli_`) so config only supplies the default when the flag is absent (CLI overrides config). This is both a real demo bug and the #1494 repro enabler.

## Fix 2 — stage-2 detached depth-axis parity (`c_voxel_to_trixel_stage_2.{glsl,metal}`)
Stage 2 didn't mirror stage 1's #1462 entity-rotated occlusion axis: it computed occlusion depth on the fixed `(1,1,1)` iso axis while stage 1 wrote the distance tap on `voxelDepthAxis = R⁻¹·(1,1,1)`. Off a snap, the stage-2 depth re-test would reject every detached color tap. Stage 2 now reads the same binding-7 `voxelDepthAxis` uniform — already present in the CPU `FrameDataVoxelToCanvas` struct at offset 144 (static-asserted) and stage 1's UBO; Metal shares it via `ir_iso_common.metal` — and projects via `isoDepthAlongAxis` on the detached path. The world/GRID path keeps `pos3DtoDistance` / `x+y+z`, so this is byte-identical today (the gather only runs inside the 1e-4 deadband where the axis ≈ (1,1,1)): a latent correctness fix.

## Verification
- `fleet-build --target IRCanvasStress` clean (macOS/Metal).
- `fleet-run IRCanvasStress --auto-screenshot` — full 5-shot render loop, Metal stage-2 kernel compiles at runtime, no crash.
- Architect validated this branch on macOS/Metal: a single off-origin detached cube renders solid at yaw=0 (gather path correct); slivers reproduce only on the scatter path (#1494's domain).

Refs #1499 (closed — misdiagnosis), Refs #1494 (repro enabler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
