### PR TITLE
demo/pipeline: gate lighting systems on noLighting_ flag in canvas_stress

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -311,13 +311,17 @@ void initSystems() {
         );
     }
 
-    renderPipeline.push_back(IRSystem::createSystem<IRSystem::BUILD_LIGHT_OCCLUSION_GRID>());
+    if (!g_settings.noLighting_) {
+        renderPipeline.push_back(IRSystem::createSystem<IRSystem::BUILD_LIGHT_OCCLUSION_GRID>());
+    }
     renderPipeline.push_back(IRSystem::createSystem<IRSystem::VOXEL_TO_TRIXEL_STAGE_1>());
-    renderPipeline.push_back(IRSystem::createSystem<IRSystem::COMPUTE_VOXEL_AO>());
-    renderPipeline.push_back(IRSystem::createSystem<IRSystem::BAKE_SUN_SHADOW_MAP>());
-    renderPipeline.push_back(IRSystem::createSystem<IRSystem::COMPUTE_SUN_SHADOW>());
-    renderPipeline.push_back(IRSystem::createSystem<IRSystem::COMPUTE_LIGHT_VOLUME>());
-    renderPipeline.push_back(IRSystem::createSystem<IRSystem::LIGHTING_TO_TRIXEL>());
+    if (!g_settings.noLighting_) {
+        renderPipeline.push_back(IRSystem::createSystem<IRSystem::COMPUTE_VOXEL_AO>());
+        renderPipeline.push_back(IRSystem::createSystem<IRSystem::BAKE_SUN_SHADOW_MAP>());
+        renderPipeline.push_back(IRSystem::createSystem<IRSystem::COMPUTE_SUN_SHADOW>());
+        renderPipeline.push_back(IRSystem::createSystem<IRSystem::COMPUTE_LIGHT_VOLUME>());
+        renderPipeline.push_back(IRSystem::createSystem<IRSystem::LIGHTING_TO_TRIXEL>());
+    }
     renderPipeline.push_back(IRSystem::createSystem<IRSystem::TRIXEL_TO_FRAMEBUFFER>());
     renderPipeline.push_back(IRSystem::createSystem<IRSystem::ENTITY_CANVAS_TO_FRAMEBUFFER>());
     renderPipeline.push_back(IRSystem::createSystem<IRSystem::FRAMEBUFFER_TO_SCREEN>());


### PR DESCRIPTION
## Summary
- `IRCanvasStress --no-lighting` segfaulted during init because six lighting-pipeline systems were registered unconditionally while their required canvas components (`C_CanvasAOTexture`, `C_CanvasSunShadow`, `C_CanvasLightVolume`) are only attached when lighting is on
- Gate `BUILD_LIGHT_OCCLUSION_GRID`, `COMPUTE_VOXEL_AO`, `BAKE_SUN_SHADOW_MAP`, `COMPUTE_SUN_SHADOW`, `COMPUTE_LIGHT_VOLUME`, and `LIGHTING_TO_TRIXEL` registration on `!g_settings.noLighting_`
- Pipeline ordering preserved: `BUILD_LIGHT_OCCLUSION_GRID` (before `VOXEL_TO_TRIXEL_STAGE_1`) is in its own guard block; the remaining five systems are in a second guard block after `VOXEL_TO_TRIXEL_STAGE_1`

## Test plan
- [x] `fleet-run IRCanvasStress --no-lighting --timeout 5` runs through the game loop for 5 seconds without crashing during init
- [x] `fleet-run IRCanvasStress --auto-screenshot 30` (lighting-on path) still runs and saves 5 screenshots correctly
- [x] `fleet-build --target IRCanvasStress` compiles cleanly on macOS/Metal

Closes #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)