### PR TITLE
audio/lua: add MIDI port-list query and non-asserting openMidiIn (#1503)

### DIFF
--- a/creations/demos/default/lua_bindings.cpp
+++ b/creations/demos/default/lua_bindings.cpp
@@ -284,11 +284,47 @@ void registerLuaBindings() {
 
         // Audio API
         luaScript.lua()["IRAudio"] = luaScript.lua().create_table();
-        luaScript.lua()["IRAudio"]["openMidiOut"] = [](const std::string &name) {
-            return IRAudio::openPortMidiOut(name);
+        luaScript.lua()["IRAudio"]["midiInPorts"] = [](sol::this_state L) {
+            sol::state_view lua(L);
+            sol::table t = lua.create_table();
+            const auto ports = IRAudio::midiInPorts();
+            for (int i = 0; i < static_cast<int>(ports.size()); i++) {
+                t[i + 1] = ports[i];
+            }
+            return t;
         };
-        luaScript.lua()["IRAudio"]["openMidiIn"] = [](const std::string &name) {
-            return IRAudio::openPortMidiIn(name);
+        luaScript.lua()["IRAudio"]["midiOutPorts"] = [](sol::this_state L) {
+            sol::state_view lua(L);
+            sol::table t = lua.create_table();
+            const auto ports = IRAudio::midiOutPorts();
+            for (int i = 0; i < static_cast<int>(ports.size()); i++) {
+                t[i + 1] = ports[i];
+            }
+            return t;
+        };
+        luaScript.lua()["IRAudio"]["openMidiIn"] = [](const std::string &name,
+                                                      sol::this_state L) -> sol::variadic_results {
+            sol::variadic_results results;
+            int port = IRAudio::openPortMidiIn(name);
+            if (port < 0) {
+                results.push_back({L, sol::in_place, sol::lua_nil});
+                results.push_back({L, sol::in_place, "no MIDI input port matching: " + name});
+            } else {
+                results.push_back({L, sol::in_place, port});
+            }
+            return results;
+        };
+        luaScript.lua()["IRAudio"]["openMidiOut"] = [](const std::string &name,
+                                                       sol::this_state L) -> sol::variadic_results {
+            sol::variadic_results results;
+            int port = IRAudio::openPortMidiOut(name);
+            if (port < 0) {
+                results.push_back({L, sol::in_place, sol::lua_nil});
+                results.push_back({L, sol::in_place, "no MIDI output port matching: " + name});
+            } else {
+                results.push_back({L, sol::in_place, port});
+            }
+            return results;
         };
 
         // Expose IRCommand.{bindPrefab, createCommand, fire, fireByName}

--- a/engine/audio/include/irreden/audio/midi_in.hpp
+++ b/engine/audio/include/irreden/audio/midi_in.hpp
@@ -38,6 +38,7 @@ class MidiIn {
 
     int openPort(MidiInInterfaces midiInInterface);
     int openPort(const std::string &deviceName);
+    const std::vector<std::string> &getPortNames() const;
     void processMidiMessageQueue();
     CCData checkCCMessageThisFrame(MidiChannel channel, CCMessage ccNumber) const;
     const std::vector<C_MidiMessage> &getMidiNotesOnThisFrame(MidiChannel channel) const;

--- a/engine/audio/include/irreden/audio/midi_out.hpp
+++ b/engine/audio/include/irreden/audio/midi_out.hpp
@@ -20,6 +20,7 @@ class MidiOut {
     int openPort(MidiOutInterfaces midiInInterface);
 
     int openPort(std::string portNameSubstring);
+    const std::vector<std::string> &getPortNames() const;
     void sendMessage(const std::vector<unsigned char> &message);
     void sendAllNotesOff();
 

--- a/engine/audio/include/irreden/ir_audio.hpp
+++ b/engine/audio/include/irreden/ir_audio.hpp
@@ -26,14 +26,20 @@ using AudioInputCallback = std::function<void(const float *, int, double, bool)>
 /// Returns the active `IAudioCaptureSource` (used by `VideoManager` for recording).
 IAudioCaptureSource &getAudioCaptureSource();
 
+/// Returns the names of all MIDI input ports discovered at startup.
+std::vector<std::string> midiInPorts();
+/// Returns the names of all MIDI output ports discovered at startup.
+std::vector<std::string> midiOutPorts();
 /// Opens a MIDI input port by hardcoded interface index.
 int openPortMidiIn(MidiInInterfaces midiInInterface);
 /// Opens the first MIDI input port whose name contains @p deviceName (substring match).
+/// Returns the port index on success, or -1 if no port matches (logs a warning).
 int openPortMidiIn(const std::string &deviceName);
 /// Opens a MIDI output port by hardcoded interface index.
 int openPortMidiOut(MidiOutInterfaces midiOutInterface);
-/// Opens the first MIDI output port whose name contains @p midiOutInterface (substring match).
-int openPortMidiOut(const std::string &midiOutInterface);
+/// Opens the first MIDI output port whose name contains @p deviceName (substring match).
+/// Returns the port index on success, or -1 if no port matches (logs a warning).
+int openPortMidiOut(const std::string &deviceName);
 /// Sends a raw MIDI message (fire-and-forget via `RtMidiOut`).
 void sendMidiMessage(const std::vector<unsigned char> &message);
 
@@ -57,10 +63,7 @@ void insertCCMessage(MidiChannel channel, const IRComponents::C_MidiMessage &mes
 /// @p callback is invoked on the RtAudio thread — copy data out before returning.
 /// Returns `false` if the device could not be opened.
 bool startAudioInputCapture(
-    const std::string &deviceName,
-    int sampleRate,
-    int channels,
-    AudioInputCallback callback
+    const std::string &deviceName, int sampleRate, int channels, AudioInputCallback callback
 );
 /// Stops the active RtAudio input stream.  Always call before `AudioManager` teardown.
 void stopAudioInputCapture();

--- a/engine/audio/src/ir_audio.cpp
+++ b/engine/audio/src/ir_audio.cpp
@@ -16,6 +16,14 @@ IAudioCaptureSource &getAudioCaptureSource() {
     return getAudioManager().getAudio();
 }
 
+std::vector<std::string> midiInPorts() {
+    return getAudioManager().getMidiIn().getPortNames();
+}
+
+std::vector<std::string> midiOutPorts() {
+    return getAudioManager().getMidiOut().getPortNames();
+}
+
 int openPortMidiIn(MidiInInterfaces port) {
     return getAudioManager().getMidiIn().openPort(port);
 }
@@ -59,10 +67,7 @@ void insertCCMessage(MidiChannel channel, const IRComponents::C_MidiMessage &mes
 }
 
 bool startAudioInputCapture(
-    const std::string &deviceName,
-    int sampleRate,
-    int channels,
-    AudioInputCallback callback
+    const std::string &deviceName, int sampleRate, int channels, AudioInputCallback callback
 ) {
     Audio &audio = getAudioManager().getAudio();
     if (!audio.openStreamIn(deviceName, sampleRate, channels, std::move(callback))) {

--- a/engine/audio/src/midi_in.cpp
+++ b/engine/audio/src/midi_in.cpp
@@ -84,12 +84,20 @@ int MidiIn::openPort(const std::string &portNameSubstring) {
             return i;
         }
     }
-    IR_ASSERT(false, "Attempted to open non-existant MIDI In port by name");
+    IRE_LOG_WARN(
+        "No MIDI input port matching '{}' — {} port(s) available",
+        portNameSubstring,
+        m_numberPorts
+    );
     return -1;
 }
 
 int MidiIn::openPort(MidiInInterfaces interface) {
     return openPort(kMidiInInterfaceNames[midiInInterfaceIndex(interface)]);
+}
+
+const std::vector<std::string> &MidiIn::getPortNames() const {
+    return m_portNames;
 }
 
 void MidiIn::processMidiMessageQueue() {

--- a/engine/audio/src/midi_out.cpp
+++ b/engine/audio/src/midi_out.cpp
@@ -25,11 +25,8 @@ void MidiOut::sendAllNotesOff() {
         return;
     }
     for (unsigned char ch = 0; ch < kNumMidiChannels; ++ch) {
-        std::vector<unsigned char> msg = {
-            buildMidiStatus(kMidiStatus_CONTROL_CHANGE, ch),
-            kMidiCC_ALL_NOTES_OFF,
-            0
-        };
+        std::vector<unsigned char> msg =
+            {buildMidiStatus(kMidiStatus_CONTROL_CHANGE, ch), kMidiCC_ALL_NOTES_OFF, 0};
         m_rtMidiOut.sendMessage(&msg);
     }
     IRE_LOG_INFO("Sent All Notes Off on all channels");
@@ -49,8 +46,16 @@ int MidiOut::openPort(std::string portNameSubstring) {
             return i;
         }
     }
-    IR_ASSERT(false, "Attempted to open non-existant MIDI Out port by name");
+    IRE_LOG_WARN(
+        "No MIDI output port matching '{}' — {} port(s) available",
+        portNameSubstring,
+        m_numberPorts
+    );
     return -1;
+}
+
+const std::vector<std::string> &MidiOut::getPortNames() const {
+    return m_portNames;
 }
 
 void MidiOut::sendMessage(const std::vector<unsigned char> &message) {


### PR DESCRIPTION
## Summary
- `MidiIn::openPort` and `MidiOut::openPort` no longer hard-assert on an absent port — swapped `IR_ASSERT(false, ...)` for `IRE_LOG_WARN` + return -1; the assert was a crash for any creation running headless (CI, `--auto-screenshot`, dev machine without hardware).
- Added `IRAudio.midiInPorts()` and `IRAudio.midiOutPorts()` to the Lua surface: returns a 1-based table of port names discovered at startup, letting scripts check availability before opening.
- `IRAudio.openMidiIn` / `IRAudio.openMidiOut` Lua bindings now return `nil, "message"` on failure instead of propagating the C++ assert; success still returns the port index (existing callers unaffected).
- Backed by new `MidiIn::getPortNames()` and `MidiOut::getPortNames()` accessors exposing the already-populated port-name vector.

## Test plan
- [ ] Build passes (`IRCreationDefault` links clean).
- [ ] 10-second run exits without crashing (`fleet-run --timeout 10 IRCreationDefault`).
- [ ] On a machine with MIDI hardware: `IRAudio.midiInPorts()` returns a non-empty table; `IRAudio.openMidiIn("substring")` returns port index.
- [ ] On a machine without MIDI hardware (or with a non-matching substring): `IRAudio.openMidiIn("nope")` returns `nil, "no MIDI input port matching: nope"` — no assertion, no crash.
- [ ] Existing callers that open a known-present port (`local p = IRAudio.openMidiIn("device")`) still receive the port index on the first return value.

Closes #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)