### PR TITLE
fleet: recognize bare `none` as no-blocker + deterministic Blocked-by filing

### DIFF
--- a/docs/agents/skills/file-epic.md
+++ b/docs/agents/skills/file-epic.md
@@ -114,7 +114,7 @@ rm -f .file-epic-body.md
 **Model:** <opus|sonnet>
 **Part of epic:** #<umbrella>
 **Plan file:** `<plans-dir>/issue-<umbrella>.md` (full epic plan)
-**Blocked by:** #<prior-child-number> (if applicable)
+**Blocked by:** (none)
 
 ## Scope
 <one paragraph>
@@ -134,6 +134,17 @@ rm -f .file-epic-body.md
 ## References
 <links to related design sections, prior PRs>
 ```
+
+> **`Blocked by:` MUST be machine-parseable — this is not stylistic.** Write
+> it as literally `(none)` for an unblocked head ticket, or as one or more
+> same-repo `#N` refs (`**Blocked by:** #1487, #1490`) for a dependent one.
+> The scout, `fleet-claim`, and `fleet-queue-ingest` recognize only `(none)`
+> and `#N` (plus merged-PR URLs). Free-text like `none — first unblocked` is
+> read as an unresolved *prose* blocker, so the ticket is held out of the
+> queue forever and every child that chains off it stalls too. Cross-repo
+> dependencies are NOT auto-gated yet (the gate checks only the issue's own
+> repo): keep `Blocked by:` to same-repo `#N`/`(none)` and record any
+> cross-repo dependency as prose under `## Dependencies`.
 
 Then file:
 
@@ -161,7 +172,7 @@ the tracker-assigned number):
 - **Model:** <opus|sonnet>
 - **Date:** <YYYY-MM-DD>
 - **Epic:** #<umbrella> — see `<plans-dir>/issue-<umbrella>.md` for full context
-- **Blocked by:** #<prior> (if applicable)
+- **Blocked by:** (none)   <!-- or same-repo `#<prior>[, #<other>]`; same exact form as the issue body -->
 
 ## Scope
 <focused subset of the umbrella plan that applies to THIS ticket>

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -307,6 +307,29 @@ _BLOCKED_ON_RE = re.compile(
 )
 
 
+def _is_no_blocker_value(value):
+    """True when a **Blocked by:** value declares NO blocker.
+
+    The canonical form is `(none)`, but agents also hand-write a bare `none`,
+    `n/a`, `tbd`, a lone dash, or `(none) — prose`, all of which mean "nothing
+    blocks this". The old filter recognized only the parenthesized `(none)`
+    form, so a bare `none — first unblocked.` fell through to the prose-blocker
+    path and stranded the issue as permanently blocked — freezing the whole
+    downstream chain out of the queue (game #138 → #143). A value that names a
+    `#N` or describes a real blocker in prose ("the auth redesign") is NOT a
+    sentinel and must still gate.
+    """
+    # A concrete `#N` ref anywhere in the value means there IS a blocker —
+    # never let a leading "none" word swallow a real reference.
+    if re.search(r"#\d+", value):
+        return False
+    head = value.strip().lower().lstrip("(").strip()
+    if not head or head[0] in "-–—.":
+        return True
+    token = re.split(r"[\s.,;:)\-–—]", head, maxsplit=1)[0]
+    return token in {"none", "n/a", "na", "tbd"}
+
+
 def _parse_blocked_by(body):
     # Union every standalone **Blocked by:** line (multi-line + multi-ref) so a
     # child blocked by several refs surfaces all of them — check_blockers gates
@@ -326,11 +349,11 @@ def _parse_blocked_by(body):
     # are mutually exclusive — canonical bold closes at ":**", inline bold stays
     # open past the value — so a single line cannot match both patterns.
     all_vals = vals + inline_vals
-    real = [v.strip() for v in all_vals if not v.strip().lower().startswith("(none")]
+    real = [v.strip() for v in all_vals if not _is_no_blocker_value(v)]
     if real:
         return ", ".join(real)
     if all_vals:
-        # Every matched form says (none) → genuinely unblocked.
+        # Every matched form is a no-blocker sentinel → genuinely unblocked.
         return ""
     for m in _BLOCKED_ON_RE.finditer(body or ""):
         cand = m.group(1).strip().strip("*").strip()

--- a/scripts/fleet/tests/test_parse_blocked_by_none_sentinel.py
+++ b/scripts/fleet/tests/test_parse_blocked_by_none_sentinel.py
@@ -1,0 +1,81 @@
+"""Tests for _parse_blocked_by()'s no-blocker sentinel handling in
+fleet-state-scout.
+
+Regression guard for the game-queue freeze: a child whose `**Blocked by:**`
+field said a bare `none — first unblocked.` (instead of the canonical
+`(none)`) was parsed as an unresolved prose blocker, so the scout marked it
+permanently blocked and it — plus the whole chain stacked behind it — never
+got `fleet:queued`.
+
+Covers:
+  - bare `none`, `(none)`, `none — prose`, `(none) — prose`, `n/a`, `tbd`,
+    lone dash, empty → no blocker (returns "")
+  - real `#N` refs (canonical + inline-bold) → still surfaced
+  - genuine prose blocker ("the auth redesign") → still gates
+  - mixed `none, #N` → the #N still surfaces
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+_parse_blocked_by = _mod._parse_blocked_by
+_is_no_blocker_value = _mod._is_no_blocker_value
+
+
+def _body(blocked_by_line):
+    return (
+        "**Model:** opus\n"
+        "**Part of epic:** #137\n"
+        f"**Blocked by:** {blocked_by_line}\n"
+        "\n## Scope\nstuff\n"
+    )
+
+
+class IsNoBlockerValue(unittest.TestCase):
+    def test_sentinels(self):
+        for v in ("(none)", "none", "None", "  none  ", "(none) — first unblocked.",
+                  "none — first unblocked.", "n/a", "N/A", "na", "tbd", "TBD",
+                  "—", "-", "–", "."):
+            self.assertTrue(_is_no_blocker_value(v), f"{v!r} should be a no-blocker sentinel")
+
+    def test_real_blockers(self):
+        for v in ("#138", "#138, #139", "#138 (migration)", "the auth redesign",
+                  "nonexistent #42 must land first"):
+            self.assertFalse(_is_no_blocker_value(v), f"{v!r} should NOT be a sentinel")
+
+
+class ParseBlockedBy(unittest.TestCase):
+    def test_bare_none_variants_unblocked(self):
+        # The exact form that froze the game queue, plus its siblings.
+        for line in ("none — first unblocked.", "none", "(none)",
+                     "(none) — first unblocked.", "n/a", "tbd", "—"):
+            self.assertEqual(_parse_blocked_by(_body(line)), "",
+                             f"{line!r} should parse as no blocker")
+
+    def test_real_ref_surfaced(self):
+        self.assertEqual(_parse_blocked_by(_body("#138")), "#138")
+        self.assertEqual(_parse_blocked_by(_body("#138, #139")), "#138, #139")
+
+    def test_inline_bold_ref_surfaced(self):
+        body = "intro\n**Blocked by: #138 (migration)** trailing\n"
+        self.assertIn("#138", _parse_blocked_by(body))
+
+    def test_prose_blocker_still_gates(self):
+        # No #N, but real prose → held (matches prior behavior; only the
+        # none/n-a/tbd sentinels are exempted).
+        self.assertEqual(_parse_blocked_by(_body("the auth redesign")),
+                         "the auth redesign")
+
+    def test_mixed_none_and_ref_keeps_ref(self):
+        self.assertEqual(_parse_blocked_by(_body("none, #138")), "none, #138")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The game queue was frozen: 7 `human:approved` game tasks (#138, #139–143, #125) were never stamped `fleet:queued`, so the workers had nothing to do — even though the dispatcher and scout were healthy.

Root cause: the scout's `_parse_blocked_by` recognized only the parenthesized `(none)` form as "no blocker". Game **#138** (the head of a phase chain) wrote `**Blocked by:** none — first unblocked.` — a bare `none`. That fell through to the prose-blocker path, so `resolve_human_approved_blockers` set `blocked=True` and #138 dropped out of the ingest projection. Because #139→#143 chain behind #138, the *entire* game queue stalled behind one mis-parse.

## Fix

- **`fleet-state-scout`**: add `_is_no_blocker_value()`, recognizing bare `none` / `n/a` / `tbd` / lone-dash / empty sentinels (canonical stays `(none)`). It fixes all three scout paths at once because they share `_parse_blocked_by`. A value containing a concrete `#N` is never treated as a sentinel, so refs are never swallowed (e.g. `none, #138` keeps `#138`).
- **`docs/agents/skills/file-epic.md`** (determinism): the child-ticket + plan templates said `**Blocked by:** #<prior> (if applicable)`, leaving the no-blocker case to the agent's improvisation — which is exactly how `none — first unblocked.` got filed. Templates now mandate the exact `(none)` / `#N` form, with a note explaining that free-text strands a ticket out of the queue.
- **test**: `test_parse_blocked_by_none_sentinel.py` covers the sentinel variants and asserts real `#N` refs / genuine prose still gate.

## Verification

- New test + existing `test_live_blocker_resolution` (14) + `test_enrich_stackable_blocker_prs` (14) all pass; scout `py_compile`s clean.
- Proven against the original bodies: `#138`'s bare-`none` now parses to unblocked.
- The live fleet was already recovered out-of-band by editing #138/#125 to the canonical `(none)` form (scout re-projected, ingest stamped both).

## Follow-up (not in this PR)

Cross-repo blockers (game **#125** → `IrredenEngine#1476`, which is closed) are still evaluated against the issue's *own* repo only — the scout, `fleet-claim`, and `fleet-queue-ingest` all capture just `#(\d+)` and never route to the referenced repo, and the scout's in-memory closed-window wouldn't hold an out-of-repo issue anyway. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)