### PR TITLE
fleet: queue blocked tasks with a fleet:blocked marker + feed stacking (#1527)

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -105,15 +105,21 @@ coordination mechanisms prevent duplicate work:
   re-check immediately before each `gh issue edit` so two hosts that
   observe the same `human:approved` issue converge without duplicate
   label additions.
-- **Blocked-by gating (#1476):** ingest stamps `fleet:queued` only when
-  every `**Blocked by:** #N` predecessor is closed. A freshly-filed
-  stacked epic therefore shows only its head queued; each child is queued
-  as its blocker closes. The scout's ingest projection keeps blocked
-  children out of the pending set (so the trigger re-fires when a blocker
-  closes), and `fleet-queue-ingest` does an authoritative live
-  `gh issue view <ref> --json state` re-check before it stamps. This makes
-  the label honest — `fleet-claim` already enforced Blocked-by at claim
-  time, but the label previously showed every child queued at once.
+- **Queue-all / mark-blocked (#1527, supersedes #1476's queue-one-at-a-time):**
+  ingest stamps `fleet:queued` + a model label on *every* approved, non-skip
+  task — including ones whose `**Blocked by:** #N` predecessor is still open,
+  which additionally get a `fleet:blocked` marker. The whole approved queue is
+  visible up front (`fleet-queue-list`, `tasks.open[].blocked`) instead of one
+  child at a time. Claimability is unchanged: `fleet-claim` still refuses a
+  plain claim on a blocked task via its own Blocked-by gate, and a
+  `--stackable-on` claim against the blocker's open PR still works. When the
+  last blocker closes, the next ingest pass removes `fleet:blocked` (driven off
+  the scout's tasks.open unblock projection); `fleet-queue-ingest` does an
+  authoritative live `gh issue view <ref> --json state` re-check before it
+  stamps or clears the marker. See
+  [`docs/design/fleet-queue-stacking.md`](../design/fleet-queue-stacking.md)
+  for the full model (claimability rule, stacking lifecycle, per-repo merger
+  requirement).
 
 **Review claiming:**
 - Review claims use `fleet:reviewing-<host>-<agent>` labels on PRs via

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -78,6 +78,18 @@ Specifically, **never pass these via `--label` when filing**:
   classifies the issue (or left unset for the human to add manually
   on edge cases). Workers filter pickup by their model label;
   `fleet-queue-list` groups by these.
+- `fleet:blocked` — owned by **`fleet-queue-ingest`**. Since #1527 the
+  ingest queues *every* approved, non-skip task up front (full queue
+  visibility) instead of one child at a time; a task whose
+  `**Blocked by:**` predecessor is still open is stamped `fleet:queued` +
+  model + `fleet:blocked` in one pass. The marker means "queued but a
+  predecessor is still open": claimability is unchanged (`fleet-claim`
+  refuses a plain claim via its own Blocked-by gate; a `--stackable-on`
+  claim against the blocker's open PR still works). The ingest removes it
+  on the next pass after the last blocker closes (driven off the
+  tasks.open unblock projection). Surfaced on `tasks.open[].blocked`.
+  Don't add manually. See [`fleet-queue-stacking.md`](../design/fleet-queue-stacking.md)
+  for the full model.
 - `fleet:approved` / `fleet:needs-fix` / `fleet:has-nits` /
   `fleet:blocker` — owned by the **reviewer agents** as PR verdicts.
 - `fleet:needs-opus-recheck` — owned by the **sonnet-reviewer**.

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -51,6 +51,12 @@
       "description": "Model-affinity tag set by fleet-queue-ingest; sonnet-author picks tasks with this label"
     },
     {
+      "name": "fleet:blocked",
+      "scope": "issue",
+      "color": "c5def5",
+      "description": "Queued task whose **Blocked by:** predecessor is still open; not plainly claimable (fleet-claim refuses a plain claim; --stackable-on works). Stamped/cleared by fleet-queue-ingest as blockers close"
+    },
+    {
       "name": "fleet:needs-info",
       "scope": "issue",
       "color": "fbca04",

--- a/docs/design/fleet-queue-stacking.md
+++ b/docs/design/fleet-queue-stacking.md
@@ -1,0 +1,138 @@
+# Fleet queue stacking — design
+
+Source-of-truth model for how the fleet queues blocked tasks and feeds the
+autonomous stacking path. Supersedes the earlier "queue one child at a time"
+behavior (#1476) with a **queue-all / mark-blocked** model (#1527).
+
+Companion to [`../agents/FLEET.md`](../agents/FLEET.md) (the operational
+workflow) and [`../agents/fleet-labels-reference.md`](../agents/fleet-labels-reference.md)
+(per-label ownership). This doc owns the *why* and the lifecycle.
+
+## Problem
+
+A stacked epic decomposes into a dependency chain — child *B* is
+`**Blocked by:** #A`, *C* by *B*, and so on. Two behaviors are in tension:
+
+1. **Visibility.** An operator (and `fleet-queue-list`) should see the whole
+   approved backlog, not just the one workable head. Under the old model a
+   ten-ticket epic showed a single queued issue; the other nine were invisible
+   until each predecessor closed, so the shape of the remaining work was
+   impossible to read from the queue.
+2. **Correct claimability.** A worker must not *plainly* claim a task whose
+   predecessor hasn't merged — its diff would be built on the wrong base. But a
+   worker that wants to *stack* (open a PR based on the blocker's open branch)
+   must be able to, when context makes it worth the coupling.
+
+The old model resolved the tension by keeping blocked children out of the
+queue entirely (`fleet:queued` was withheld until every blocker closed). That
+made claimability trivially correct but sacrificed visibility, and it meant the
+stacking-enrichment pass (`stackable_blocker_pr`) had nothing to enrich for
+engine epics — a blocked child wasn't in `tasks.open[]` to carry the field.
+
+## Model: queue-all, mark-blocked
+
+Ingestion queues **every** approved, non-skip task regardless of blocked
+state. A task whose `**Blocked by:** #N` predecessor is still open is queued
+with an extra `fleet:blocked` marker.
+
+| State | Labels | In `tasks.open[]`? | Plain claim | `--stackable-on` |
+|---|---|---|---|---|
+| approved, unblocked | `fleet:queued` + model | yes, `blocked:false` | ✅ granted | ✅ |
+| approved, blocked | `fleet:queued` + model + `fleet:blocked` | yes, `blocked:true` | ❌ refused | ✅ (against blocker's open PR) |
+| skip (epic / needs-plan / needs-info / needs-human / scope-shipped) | — | no | — | — |
+
+The `fleet:blocked` label is the **visible** half of the contract; it does not
+itself gate claims. Claimability is enforced independently by `fleet-claim`'s
+own `**Blocked by:**` parse, which is unchanged — so a blocked task is queued
+and visible, yet a plain `fleet-claim claim` against it is still refused
+(`fleet-claim claim <N> <agent> --stackable-on <PR>` succeeds because that path
+deliberately bases the new branch on the blocker's open branch).
+
+## Lifecycle
+
+```
+file issue ──(human:approved)──▶ ingest pass
+                                    │
+              blocker open? ── yes ─┼─▶ + fleet:queued, model, fleet:blocked
+                                    │       │
+                                    no      │  (last blocker closes)
+                                    │       ▼
+                                    │   unblock pass ──▶ − fleet:blocked
+                                    ▼       │
+                              + fleet:queued, model   ◀──┘
+                                    │
+                              worker claims ──▶ fleet:in-progress ──▶ PR ──▶ merged ──▶ closed
+```
+
+Both transitions are **edge-triggered** off the scout's
+`queue-manager-ingest` projection hash, which fires `fleet-queue-ingest`:
+
+- **Add path** — a newly `human:approved` task enters the projection (sourced
+  from `human_approved[]`, which excludes `fleet:queued`). Ingest stamps
+  `fleet:queued` + model, plus `fleet:blocked` if a live `gh issue view`
+  recheck finds an open predecessor. The task then carries `fleet:queued` and
+  drops out of `human_approved[]`.
+- **Remove path** — once queued, a blocked task has left `human_approved[]`, so
+  the removal can't be sourced there. It is sourced instead from
+  `tasks.open[]` (the `fleet:queued` surface): the scout's
+  `_ingest_unblock_candidates` yields any open task that carries `fleet:blocked`
+  but whose `resolve_blocked_by` has reduced `blocked_by` to `(none)` — i.e.
+  the last blocker just closed. That candidate enters the projection (the hash
+  flips), ingest re-fires, live-rechecks the blockers, and removes
+  `fleet:blocked`. The next tick the candidate is gone (label cleared) and the
+  hash settles — the same "one wasted no-op iteration" the add path has always
+  had.
+
+The **live `gh issue view <ref> --json state` recheck** in `fleet-queue-ingest`
+is authoritative for both add and remove. The scout's in-memory `blocked` flags
+(`human_approved[].blocked`, `tasks.open[].blocked`) only decide *when the
+trigger fires*; the label is applied or cleared only after the live recheck
+agrees. This keeps the mechanism correct even when ingest runs against a
+hand-built projection (tests, a manual invocation).
+
+## Stacking enrichment
+
+Because blocked children now appear in `tasks.open[]`, the
+`enrich_stackable_blocker_prs` pass can attach a `stackable_blocker_pr` field to
+a single-blocker task when the blocker has exactly one matching open
+`claude/<N>-*` PR (and the two filters pass — no design-block on the blocker,
+no file-area overlap). A worker with no plainly-claimable task falls through to
+the stackable tier and claims `--stackable-on <PR>`. This is the autonomous
+"feed stacking" half: the queue surfaces a blocked task *and* the PR it can
+stack on, in one record.
+
+Per-repo note: worker pickup honors `stackable_blocker_pr` for **engine** tasks
+only in v1 — the merger's cascade-rebase processes engine stacked PRs but the
+game pass does not yet. Game tasks are enriched in state but not picked up
+stackably (the gating lives in the role doc). Multi-blocker tasks are not
+eligible for stacking in v1 (`_single_blocker_issue` returns nothing for them).
+
+## Why reconcile leaves these alone
+
+A `fleet:queued` + `fleet:blocked` task with no claim and no PR matches **no**
+`fleet-claim reconcile` rule: R4b requires `fleet:in-progress`, R6 requires
+`human:owned`, and R2/R7 require an open PR. So a queued-blocked task sits
+quietly in the queue — visible, not claimable, not swept — until either a
+worker stacks on it or its blocker closes and the unblock pass clears the
+marker.
+
+## Acceptance invariants
+
+- A blocked, approved, non-skip task → `fleet:queued` + model + `fleet:blocked`;
+  an unblocked one → `fleet:queued` + model only.
+- The task appears in `tasks.open[]` with `blocked: true`; with a single open
+  blocker PR it also carries `stackable_blocker_pr`.
+- `fleet-claim claim <blocked-N> <agent>` is refused; `… --stackable-on <PR>`
+  succeeds.
+- When the last blocker closes, the next ingest pass removes `fleet:blocked`.
+- Reconcile/cleanup never sweeps a `fleet:queued` + `fleet:blocked` no-claim
+  issue.
+
+## References
+
+- #1527 (this mechanism), #1526 (umbrella epic), #1476 (the queue-one-at-a-time
+  behavior this revises), #1521 (`(none)` / bare-none Blocked-by parser).
+- `fleet-queue-ingest` (add + unblock passes), `fleet-state-scout`
+  (`_ingest_unblock_candidates`, `project_queue_manager_ingest`,
+  `slice_queue_manager_ingest`, `enrich_stackable_blocker_prs`,
+  `fetch_task_queue`'s `blocked` flag).

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -105,6 +105,7 @@ LABELS=(
     "fleet:queued|c5def5|Queued for fleet pickup (requires human:approved)"
     "fleet:opus|1d76db|Model-affinity tag set by fleet-queue-ingest; opus-worker picks tasks with this label"
     "fleet:sonnet|1d76db|Model-affinity tag set by fleet-queue-ingest; sonnet-author picks tasks with this label"
+    "fleet:blocked|c5def5|Queued task whose **Blocked by:** predecessor is still open; not plainly claimable (fleet-claim refuses a plain claim; --stackable-on works). Stamped/cleared by fleet-queue-ingest as blockers close"
     "fleet:needs-info|fbca04|Needs more info from the author before triage"
     "fleet:needs-plan|fbca04|Needs an architect plan before a worker can pick it up"
     "fleet:in-progress|c5def5|A fleet worker has claimed this task"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -4,23 +4,26 @@
 # picks them up.
 #
 # Invoked directly by fleet-state-scout when the queue-manager-ingest
-# projection changes (new human:approved issue appears, or an existing
-# one gets fleet:queued and drops out of the set).
+# projection changes (new human:approved issue appears, an existing one gets
+# fleet:queued and drops out of the set, or a queued task's last blocker closes
+# and it enters the unblock set).
 #
 # Pure label-stamping — no LLM, no master push.
-# Idempotent: if there are no pending issues, exits in <1s. Per-host
+# Idempotent: if there is no pending or unblock work, exits in <1s. Per-host
 # lockfile prevents same-host concurrent runs; cross-host races are
 # caught by the live `gh issue view` re-check inside the stamping loop
 # (gh issue edit --add-label converges either way, but the re-check
 # avoids burning API budget on already-stamped issues).
 #
-# Blocked-by gate (#1476): an issue is stamped fleet:queued only when every
-# `**Blocked by:** #N` predecessor is CLOSED/MERGED. The scout's ingest
-# projection already keeps blocked children out of the pending set; the
-# per-issue live `gh issue view <ref> --json state` re-check here is the
-# authoritative gate at the actual stamp point (and the sole gate when ingest
-# runs against a hand-built projection). So a freshly-filed stacked epic shows
-# only its head queued; each child is queued as its blocker closes.
+# Queue-all / mark-blocked (#1527, supersedes the #1476 defer-the-stamp gate):
+# every approved, non-skip task is stamped fleet:queued + model up front; a task
+# whose `**Blocked by:** #N` predecessor is still open additionally gets a
+# fleet:blocked marker (the whole queue is visible immediately, not one child at
+# a time). The unblock pass strips fleet:blocked once the last blocker closes.
+# The per-issue live `gh issue view <ref> --json state` re-check is authoritative
+# for both add and remove (and the sole blocker gate when ingest runs against a
+# hand-built projection). Claimability is unchanged — fleet-claim's own
+# Blocked-by gate still refuses a plain claim; see docs/design/fleet-queue-stacking.md.
 #
 # Source of truth: scripts/fleet/fleet-queue-ingest in the engine repo.
 # Installed to ~/bin/fleet-queue-ingest by scripts/fleet/install.sh.
@@ -52,19 +55,21 @@ fi
 trap 'rmdir "$LOCK_DIR" 2>/dev/null; true' EXIT INT TERM
 
 # Fast-path: scout's projection-diff fires on BOTH set-grow (new approved
-# issue) AND set-shrink (issue ingested, dropped out of the human:approved-
-# minus-fleet:queued set). On the post-stamp drop-out the set is empty.
+# issue, or a queued task whose last blocker just closed) AND set-shrink
+# (issue ingested / fleet:blocked removed, dropped out of the set). On a
+# post-action drop-out both work lists are empty.
 if [[ -f "$PROJECTION_FILE" ]]; then
-    pending_count=$(python3 -c "
+    counts=$(python3 -c "
 import json, sys
 try:
     data = json.load(open('$PROJECTION_FILE'))
-    print(len(data.get('pending_issues', [])))
+    print(len(data.get('pending_issues', [])), len(data.get('unblock_issues', [])))
 except Exception:
-    print(0)
+    print(0, 0)
 ")
-    if [[ "$pending_count" == "0" ]]; then
-        log "no pending issues — empty projection, exiting"
+    read -r pending_count unblock_count <<< "$counts"
+    if [[ "${pending_count:-0}" == "0" && "${unblock_count:-0}" == "0" ]]; then
+        log "no pending or unblock issues — empty projection, exiting"
         exit 0
     fi
 fi
@@ -256,7 +261,7 @@ def _blocker_open(repo, ref, cache):
 
 stamped = 0
 skipped_already = 0
-skipped_blocked = 0
+blocked_marked = 0
 failed = 0
 blocker_cache = {}
 
@@ -297,22 +302,18 @@ for issue in pending:
         print(f'INFO issue {repo}#{n}: human:owned — skipping ingest (human de-queued)', file=sys.stderr)
         continue
 
-    # Blocked-by gate (#1476): never stamp fleet:queued onto a child whose
-    # **Blocked by:** predecessors aren't all closed. fleet-claim already
-    # enforces this at claim time, but stamping a blocked child anyway makes a
-    # stacked epic show every child queued at once, defeating "queue one at a
-    # time". The scout's projection normally keeps blocked children out of the
-    # pending set; this is the authoritative live re-check at the actual stamp
-    # point — and the only gate when ingest runs against a hand-built
-    # projection (e.g. tests, or a manual fleet-queue-ingest invocation).
+    # Blocked-by handling (#1527): queue blocked tasks too. A task whose
+    # **Blocked by:** predecessors aren't all closed still gets fleet:queued +
+    # a model label, plus a fleet:blocked marker — the whole approved queue is
+    # visible up front instead of one child at a time (the old #1476 "defer the
+    # stamp" behavior). Claimability is unchanged: fleet-claim's own Blocked-by
+    # gate still refuses a plain claim on it, and --stackable-on still works;
+    # fleet:blocked is the operator-visible "queued but not plainly claimable
+    # yet" signal that the unblock pass below removes once the last blocker
+    # closes. The live re-check is authoritative — it's the only blocker gate
+    # when ingest runs against a hand-built projection (tests, manual run).
     open_blockers = [ref for ref in _blocker_refs(body)
                      if _blocker_open(repo, ref, blocker_cache)]
-    if open_blockers:
-        skipped_blocked += 1
-        joined = ', '.join(f'#{r}' for r in open_blockers)
-        print(f'INFO issue {repo}#{n}: blocked by open {joined} — '
-              'deferring fleet:queued until predecessors close', file=sys.stderr)
-        continue
 
     # Parse model from body. Default to fleet:opus on ambiguity — mirrors
     # the safer default when model intent is unclear.
@@ -332,6 +333,11 @@ for issue in pending:
     add_labels = ['fleet:queued']
     if model_label not in labels:
         add_labels.append(model_label)
+    if open_blockers and 'fleet:blocked' not in labels:
+        add_labels.append('fleet:blocked')
+        joined = ', '.join(f'#{r}' for r in open_blockers)
+        print(f'INFO issue {repo}#{n}: queuing with fleet:blocked '
+              f'(blocked by open {joined})', file=sys.stderr)
 
     cmd = ['gh', 'issue', 'edit', str(n), '--repo', repo]
     for lbl in add_labels:
@@ -342,14 +348,62 @@ for issue in pending:
         print(f'WARN issue {repo}#{n}: label edit failed: {er.stderr.strip()}', file=sys.stderr)
         continue
     stamped += 1
+    if open_blockers:
+        blocked_marked += 1
 
-print(f'{stamped},{skipped_already},{failed},{skipped_blocked}')
+# Unblock pass (#1527): drop fleet:blocked from queued tasks whose last blocker
+# has closed. Sourced from unblock_issues (tasks.open-derived in the scout)
+# since a fleet:queued issue has already left the human:approved add set above.
+# Reuses the same blocker parsers + per-run cache as the stamping pass.
+unblocked = 0
+unblock_still = 0
+for issue in data.get('unblock_issues', []):
+    n = issue.get('number', 0)
+    repo = REPO_SLUGS.get(issue.get('repo', 'engine'), 'jakildev/IrredenEngine')
+    if not n:
+        continue
+    r = subprocess.run(
+        ['gh', 'issue', 'view', str(n), '--repo', repo, '--json', 'body,labels'],
+        capture_output=True, text=True, timeout=15,
+    )
+    if r.returncode != 0:
+        failed += 1
+        print(f'WARN issue {repo}#{n}: fetch failed: {r.stderr.strip()}', file=sys.stderr)
+        continue
+    try:
+        view = json.loads(r.stdout)
+    except Exception:
+        failed += 1
+        continue
+    labels = {(l['name'] if isinstance(l, dict) else l) for l in view.get('labels', [])}
+    # Already cleared (or never marked) — nothing to do. Guards the one-tick
+    # window where the scout still lists the candidate after a prior removal.
+    if 'fleet:blocked' not in labels:
+        continue
+    body = view.get('body', '') or ''
+    open_blockers = [ref for ref in _blocker_refs(body)
+                     if _blocker_open(repo, ref, blocker_cache)]
+    if open_blockers:
+        unblock_still += 1
+        continue  # still genuinely blocked — leave the marker
+    er = subprocess.run(
+        ['gh', 'issue', 'edit', str(n), '--repo', repo,
+         '--remove-label', 'fleet:blocked'],
+        capture_output=True, text=True, timeout=15,
+    )
+    if er.returncode != 0:
+        failed += 1
+        print(f'WARN issue {repo}#{n}: remove fleet:blocked failed: {er.stderr.strip()}', file=sys.stderr)
+        continue
+    unblocked += 1
+
+print(f'{stamped},{skipped_already},{failed},{blocked_marked},{unblocked},{unblock_still}')
 STAMP_PY
 )
 
 if [[ -n "$stamping_out" ]]; then
-    IFS=',' read -r stamped_count skipped_count failed_count blocked_count <<< "$stamping_out"
-    log "stamped ${stamped_count:-0} issue(s); skipped ${skipped_count:-0} already-labeled; ${blocked_count:-0} blocked (deferred); ${failed_count:-0} failed"
+    IFS=',' read -r stamped_count skipped_count failed_count blocked_count unblocked_count unblock_still_count <<< "$stamping_out"
+    log "stamped ${stamped_count:-0} issue(s) (${blocked_count:-0} marked fleet:blocked); skipped ${skipped_count:-0} already-labeled; unblocked ${unblocked_count:-0} (${unblock_still_count:-0} still blocked); ${failed_count:-0} failed"
 fi
 
 log "ingestion iteration complete"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -327,7 +327,7 @@ for issue in pending:
         model_label = 'fleet:opus'
         print(f'WARN issue {repo}#{n}: **Model:** field missing or unrecognized; defaulting to fleet:opus', file=sys.stderr)
 
-    if not BLOCKED_RE.search(body) and not _has_header_blocker(body):
+    if not BLOCKED_RE.search(body) and not _has_header_blocker(body) and not BLOCKED_INLINE_RE.search(body):
         print(f'WARN issue {repo}#{n}: **Blocked by:** field missing; scout will treat as unblocked', file=sys.stderr)
 
     add_labels = ['fleet:queued']

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -419,6 +419,12 @@ def fetch_task_queue(repo_slug):
             "owner": owner,
             "area": area,
             "blocked_by": blocked_by,
+            # #1527: `fleet:blocked` is the visible "queued but a predecessor is
+            # still open" marker stamped by fleet-queue-ingest. Surface it on the
+            # task so workers see the blocked state directly and the ingest
+            # projection can drive fleet:blocked removal once the blocker closes
+            # (see _ingest_unblock_candidates).
+            "blocked": "fleet:blocked" in labels,
             "issue": task_id,
         }
 
@@ -937,22 +943,20 @@ def resolve_human_approved_blockers(state):
     """Annotate each human:approved issue with `blocked` — True when one or
     more of its `**Blocked by:**` predecessors is still open.
 
-    The queue-manager-ingest projector/slicer treat a blocked issue like a
-    skip-label issue: it stays OUT of the actionable set, so a freshly-filed
-    stacked epic contributes only its workable head to the trigger hash and
-    the ingest pass. The moment the last blocker closes (and lands in this
-    repo's closed_fleet_queued / recent_merged_prs window) `blocked` flips
-    False, the issue ENTERS the set, the hash flips, and the scout spawns
-    fleet-queue-ingest to queue the now-workable child — the "queue one at a
-    time / queue the next child when a blocker closes" behavior (#1476).
+    Since #1527 the ingest queues EVERY approved, non-skip task regardless of
+    blocked state (a blocked one gets `fleet:queued` + a `fleet:blocked`
+    marker), so this flag no longer gates the queue-manager-ingest projection.
+    It is kept for state.json visibility — `repos.*.human_approved[].blocked`
+    tells an operator at a glance which not-yet-queued approved issues will be
+    stamped blocked on the next ingest. The fleet:blocked label round-trip
+    (add on queue-while-blocked, remove when the last blocker closes) is driven
+    off the live `gh issue view` recheck in fleet-queue-ingest plus the
+    tasks.open-sourced _ingest_unblock_candidates, not off this flag.
 
     Resolution is in-memory only (closed_fleet_queued + merged `claude/<N>-*`
     heads), mirroring resolve_blocked_by()'s cheap path — NO live gh here, so
-    the per-tick projection stays fast. fleet-queue-ingest does the
-    authoritative live `gh issue view` re-check before it actually stamps
-    fleet:queued, so this flag only decides *when the trigger fires*, never
-    whether the label is applied. `body` is popped after parsing so it never
-    bloats state.json or the per-role slices.
+    the per-tick projection stays fast. `body` is popped after parsing so it
+    never bloats state.json or the per-role slices.
     """
     for repo_key, repo_state in state["repos"].items():
         closed_nums = {
@@ -1210,40 +1214,64 @@ def project_merger(state):
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
+def _ingest_unblock_candidates(repo_state):
+    """Queued tasks carrying `fleet:blocked` whose blockers have all closed —
+    the remove-half of the fleet:blocked round-trip (#1527).
+
+    resolve_blocked_by() has already reduced each open task's `blocked_by` to
+    only its still-open refs, so a task that carries the `fleet:blocked` label
+    but now resolves to `(none)` is newly unblocked and needs the label
+    stripped. These re-enter the ingest set from `tasks.open` — NOT
+    human_approved, which excludes `fleet:queued`, so a queued-blocked issue
+    has already left that surface — which makes the removal edge-triggered the
+    same way the add is: the candidate appears the tick its last blocker
+    closes (hash flips → ingest fires → label removed), then disappears the
+    tick after (hash flips → ingest re-fires → no-op → quiescent). Returns a
+    list of issue numbers (ints)."""
+    out = []
+    for task in repo_state.get("tasks", {}).get("open", []):
+        if not task.get("blocked"):
+            continue
+        raw = (task.get("blocked_by") or "").strip().lower()
+        if raw and not raw.startswith("(none"):
+            continue
+        try:
+            out.append(int((task.get("issue") or "").lstrip("#")))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
 def project_queue_manager_ingest(state):
     """Hash-input projection for the queue-manager-ingest auto-fire.
 
-    Tracks the SET of actionable `human:approved` issues — i.e., issues the
-    human has approved but the queue hasn't yet stamped `fleet:queued` onto,
-    and that are not in a skip category (epic, needs-plan, needs-info,
-    queued). The hash flips when this set CHANGES:
+    Tracks the SET of ingest-actionable issues. The hash flips when this set
+    CHANGES, and each change spawns fleet-queue-ingest:
 
-    - Operator adds `human:approved` to issue #N: #N enters the set,
-      hash flips, scout spawns fleet-queue-ingest, which stamps
-      `fleet:queued` (plus a model-affinity label) onto #N.
-    - After ingestion, #N has `fleet:queued` so it drops from the
-      set; hash flips again. fleet-queue-ingest re-fires, finds the
-      set is empty, exits in <1s. One wasted iteration per ingestion
-      cycle, acceptable cost.
+    - **Add path** — every `human:approved` issue not yet stamped
+      `fleet:queued` and not in a skip category (epic, needs-plan, needs-info,
+      needs-human, scope-shipped). Since #1527 a `**Blocked by:**`-blocked
+      issue is NO LONGER excluded: it enters the set, ingest stamps
+      `fleet:queued` + a model label + `fleet:blocked`, and it drops out
+      (now carrying fleet:queued). The whole queue is visible immediately
+      rather than one child at a time.
+    - **Remove path** — a queued task carrying `fleet:blocked` whose last
+      blocker just closed (`_ingest_unblock_candidates`, sourced from
+      tasks.open since the issue has left human_approved). It enters the set,
+      ingest removes `fleet:blocked`, and it drops out (label gone).
 
     `human_approved` already excludes `fleet:queued` via fetch_human_approved;
     _INGEST_SKIP_LABELS mirrors the role-doc Step 5 filter so epics and
     un-planned issues don't hold the hash non-zero indefinitely.
-
-    `blocked` issues (set by resolve_human_approved_blockers — a `**Blocked
-    by:**` predecessor is still open) are excluded too, so a stacked epic
-    contributes only its workable head to the hash. When the last blocker
-    closes the child's `blocked` flips False, it re-enters the set, the hash
-    flips, and ingest re-fires to queue it (#1476).
     """
     items = []
     for repo, repo_state in state["repos"].items():
         for issue in repo_state.get("human_approved", []):
             if set(issue.get("labels", [])) & _INGEST_SKIP_LABELS:
                 continue
-            if issue.get("blocked"):
-                continue
             items.append({"repo": repo, "issue": issue["number"]})
+        for num in _ingest_unblock_candidates(repo_state):
+            items.append({"repo": repo, "issue": num, "op": "unblock"})
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
@@ -1396,21 +1424,26 @@ def slice_queue_manager(state):
 
 
 def slice_queue_manager_ingest(state):
-    """Slice for fleet-queue-ingest. Mirrors the projector — list of
-    actionable issues the human has approved but the queue hasn't filed yet.
-    Applies _INGEST_SKIP_LABELS so the LLM slice never includes epics or
-    un-planned issues that the role-doc skips at Step 5, and skips `blocked`
-    issues (an open `**Blocked by:**` predecessor) so fleet-queue-ingest's
-    pending set only carries workable issues — the head of a stacked epic,
-    then each child as its blocker closes (#1476)."""
-    out = {"pending_issues": []}
+    """Slice for fleet-queue-ingest. Mirrors the projector:
+
+    - `pending_issues` — approved issues the queue hasn't filed yet, applying
+      _INGEST_SKIP_LABELS so the set never includes epics or un-planned issues
+      the role-doc skips at Step 5. Since #1527 this INCLUDES blocked issues:
+      fleet-queue-ingest stamps a blocked one `fleet:queued` + model +
+      `fleet:blocked` in one pass (the whole queue is queued up front, not one
+      child at a time).
+    - `unblock_issues` — queued tasks carrying `fleet:blocked` whose last
+      blocker just closed (`_ingest_unblock_candidates`). fleet-queue-ingest
+      drops `fleet:blocked` from each. Minimal `{number, repo}` records — the
+      ingest does its own live recheck before removing the label."""
+    out = {"pending_issues": [], "unblock_issues": []}
     for repo_key, repo_state in state["repos"].items():
         for issue in repo_state.get("human_approved", []):
             if set(issue.get("labels", [])) & _INGEST_SKIP_LABELS:
                 continue
-            if issue.get("blocked"):
-                continue
             out["pending_issues"].append(_slice_issue_with_repo(repo_key, issue))
+        for num in _ingest_unblock_candidates(repo_state):
+            out["unblock_issues"].append({"number": num, "repo": repo_key})
     return out
 
 

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -68,6 +68,19 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
                          "claude/1111-scout-stackable-blocker-pr")
         self.assertEqual(task["stackable_blocker_pr"]["author"], "jakildev")
 
+    def test_queued_blocked_task_is_enriched(self):
+        """#1527: a queued-blocked task (carries the fleet:blocked-derived
+        `blocked: True` flag) now lives in tasks.open, so enrichment attaches
+        the blocker's open PR — the autonomous "feed stacking" half. The
+        `blocked` flag must not interfere with enrichment."""
+        task = {"id": "#1112", "blocked_by": "#1111", "blocked": True}
+        prs = [_pr(536, "claude/1111-scout-stackable-blocker-pr", author="jakildev")]
+        state = _state(engine_tasks=[task], engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        out = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("stackable_blocker_pr", out)
+        self.assertEqual(out["stackable_blocker_pr"]["number"], 536)
+
     def test_zero_matches_no_field(self):
         """No open PR matches prefix → field absent."""
         tasks = [_task("#1112", "#1111")]

--- a/scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# Test that fleet-queue-ingest honors `**Blocked by:**` (Gap 2 of #1476).
+# Test that fleet-queue-ingest queues blocked tasks with a fleet:blocked
+# marker and removes the marker once the last blocker closes (#1527,
+# supersedes the #1476 "defer the stamp until unblocked" behavior).
 #
-# An issue is stamped fleet:queued only when every `**Blocked by:** #N`
-# predecessor is CLOSED/MERGED. A freshly-filed stacked epic must therefore
-# show only its head queued, not every child at once. fleet-claim already
-# enforces Blocked-by at claim time; this gate makes the LABEL honest.
+# Add path: every approved, non-skip task is stamped fleet:queued + model;
+# a task whose **Blocked by:** predecessor is still open additionally gets
+# fleet:blocked. Remove path: a queued task carrying fleet:blocked whose
+# blocker has closed (surfaced in unblock_issues) has the marker stripped.
+# The blocker issues are only READ (live state probe), never edited.
 #
 # HOME is redirected to a temp dir so the script's hardcoded projection/log/lock
 # paths land in the sandbox, and `gh` is stubbed to canned issue/PR surfaces.
@@ -32,13 +35,18 @@ export HOME="$TMPROOT/home"
 mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
 
 PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
-# A stacked epic: #730 is the head (no blocker), #731 is blocked by an OPEN
-# predecessor (#719), #732 is blocked by a CLOSED predecessor (#718).
+# Add path: a stacked epic. #730 = head (no blocker), #731 = blocked by an OPEN
+# predecessor (#719), #732 = blocked by a CLOSED predecessor (#718).
+# Remove path: #733 = queued+fleet:blocked, blocker #717 now CLOSED (unblock);
+#              #734 = queued+fleet:blocked, blocker #719 still OPEN (stay).
 cat > "$PROJ" <<'JSON'
 {"pending_issues":[
   {"number":730,"repo":"engine"},
   {"number":731,"repo":"engine"},
   {"number":732,"repo":"engine"}
+],"unblock_issues":[
+  {"number":733,"repo":"engine"},
+  {"number":734,"repo":"engine"}
 ]}
 JSON
 
@@ -52,12 +60,13 @@ case "$1" in
     issue)
         case "$2" in
             view)
-                # Blocker-state probes pass `--jq .state`; the stamping fetch
+                # Blocker-state probes pass `--jq .state`; the body/labels fetch
                 # asks for `--json body,labels`. Dispatch on which one this is.
                 if [[ "$*" == *"--jq"* ]]; then
                     case "$3" in
+                        717) echo "CLOSED" ;;   # #733's predecessor — satisfied
                         718) echo "CLOSED" ;;   # #732's predecessor — satisfied
-                        719) echo "OPEN" ;;     # #731's predecessor — still open
+                        719) echo "OPEN" ;;     # #731/#734's predecessor — open
                         *)   echo "OPEN" ;;
                     esac
                     exit 0
@@ -66,6 +75,8 @@ case "$1" in
                     730) echo '{"body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
                     731) echo '{"body":"**Model:** sonnet\n**Blocked by:** #719","labels":[{"name":"human:approved"}]}' ;;
                     732) echo '{"body":"**Model:** opus\n**Blocked by:** #718","labels":[{"name":"human:approved"}]}' ;;
+                    733) echo '{"body":"**Blocked by:** #717","labels":[{"name":"fleet:queued"},{"name":"fleet:opus"},{"name":"fleet:blocked"}]}' ;;
+                    734) echo '{"body":"**Blocked by:** #719","labels":[{"name":"fleet:queued"},{"name":"fleet:opus"},{"name":"fleet:blocked"}]}' ;;
                     *)   echo '{"body":"","labels":[]}' ;;
                 esac
                 exit 0 ;;
@@ -86,35 +97,61 @@ GHSTUB
 chmod +x "$STUB_DIR/gh"
 export PATH="$STUB_DIR:$PATH"
 
-echo "=== run fleet-queue-ingest over a stacked epic (head + blocked + unblocked children) ==="
+# Per-issue edit-log line (gh issue edit <N> ...) for assertions. Tolerates
+# no-match (empty) without tripping `set -e` / pipefail.
+edit_line() { grep -E "(^| )edit ${1}( |$)" "$EDIT_LOG" | head -1 || true; }
+
+echo "=== run fleet-queue-ingest over a stacked epic + unblock candidates ==="
 bash "$INGEST" >/dev/null 2>&1 || true
 
-# #730 (head, no blocker) must be stamped fleet:queued.
-if grep -qE '(^| )730( |$)' "$EDIT_LOG" && grep -q 'fleet:queued' "$EDIT_LOG"; then
-    ok "head #730 (no blocker) was stamped fleet:queued"
+# --- Add path -------------------------------------------------------------
+# #730 (head, no blocker) → fleet:queued, NO fleet:blocked.
+l730=$(edit_line 730)
+if [[ -n "$l730" && "$l730" == *"fleet:queued"* && "$l730" != *"fleet:blocked"* ]]; then
+    ok "head #730 stamped fleet:queued without fleet:blocked"
 else
-    bad "head #730 was NOT stamped — gate is over-blocking or harness broken"
+    bad "head #730 mis-stamped: '$l730'"
 fi
 
-# #732 (blocker CLOSED) must be stamped — a satisfied predecessor does not gate.
-if grep -qE '(^| )732( |$)' "$EDIT_LOG"; then
-    ok "#732 (predecessor #718 CLOSED) was stamped"
+# #732 (blocker CLOSED) → fleet:queued, NO fleet:blocked.
+l732=$(edit_line 732)
+if [[ -n "$l732" && "$l732" == *"fleet:queued"* && "$l732" != *"fleet:blocked"* ]]; then
+    ok "#732 (predecessor #718 CLOSED) stamped without fleet:blocked"
 else
-    bad "#732 was NOT stamped — gate wrongly blocked on a CLOSED predecessor"
+    bad "#732 mis-stamped: '$l732'"
 fi
 
-# #731 (blocker OPEN) must NOT be stamped — deferred until #719 closes.
-if grep -qE '(^| )731( |$)' "$EDIT_LOG"; then
-    bad "#731 was stamped despite OPEN predecessor #719: $(grep 731 "$EDIT_LOG")"
+# #731 (blocker OPEN) → fleet:queued + fleet:blocked (queued, marked).
+l731=$(edit_line 731)
+if [[ -n "$l731" && "$l731" == *"fleet:queued"* && "$l731" == *"fleet:blocked"* ]]; then
+    ok "#731 (predecessor #719 OPEN) stamped fleet:queued + fleet:blocked"
 else
-    ok "#731 (predecessor #719 OPEN) was deferred — not stamped"
+    bad "#731 not queued-with-marker as expected: '$l731'"
 fi
 
+# --- Remove path ----------------------------------------------------------
+# #733 (blocker #717 now CLOSED) → fleet:blocked removed.
+l733=$(edit_line 733)
+if [[ -n "$l733" && "$l733" == *"--remove-label fleet:blocked"* ]]; then
+    ok "#733 (predecessor #717 CLOSED) had fleet:blocked removed"
+else
+    bad "#733 fleet:blocked NOT removed despite closed blocker: '$l733'"
+fi
+
+# #734 (blocker #719 still OPEN) → fleet:blocked NOT removed (no edit).
+l734=$(edit_line 734)
+if [[ -z "$l734" ]]; then
+    ok "#734 (predecessor #719 OPEN) left fleet:blocked in place (no edit)"
+else
+    bad "#734 fleet:blocked wrongly removed while blocker open: '$l734'"
+fi
+
+# --- Read-only blocker invariant -----------------------------------------
 # The blocker issues themselves must never be edited (we only read their state).
-if grep -qE '(^| )(718|719)( |$)' "$EDIT_LOG"; then
-    bad "a blocker issue (#718/#719) was edited — gate must only READ blocker state"
+if grep -qE '(^| )edit (717|718|719)( |$)' "$EDIT_LOG"; then
+    bad "a blocker issue (#717/#718/#719) was edited — must only READ blocker state"
 else
-    ok "blocker issues #718/#719 were never edited (read-only state probe)"
+    ok "blocker issues #717/#718/#719 were never edited (read-only state probe)"
 fi
 
 echo

--- a/scripts/fleet/tests/test_issue_queue_parser.py
+++ b/scripts/fleet/tests/test_issue_queue_parser.py
@@ -234,6 +234,24 @@ class FetchTaskQueueDispatch(unittest.TestCase):
         }])
         self.assertEqual(out["open"][0]["blocked_by"], "#1300")
 
+    def test_blocked_flag_set_from_label(self):
+        # #1527: the fleet:blocked label surfaces as task["blocked"] so workers
+        # see the state directly and the unblock projection can act on it.
+        out = self._run([{
+            "number": 100, "title": "b",
+            "labels": [{"name": "fleet:queued"}, {"name": "fleet:blocked"}],
+            "body": "**Blocked by:** #50",
+        }])
+        self.assertTrue(out["open"][0]["blocked"])
+
+    def test_blocked_flag_false_without_label(self):
+        out = self._run([{
+            "number": 100, "title": "b",
+            "labels": [{"name": "fleet:queued"}],
+            "body": "**Blocked by:** (none)",
+        }])
+        self.assertFalse(out["open"][0]["blocked"])
+
     def test_empty_gh_output_returns_empty_sections(self):
         out = self._run([])
         self.assertEqual(out["open"], [])

--- a/scripts/fleet/tests/test_queue_manager_projection.py
+++ b/scripts/fleet/tests/test_queue_manager_projection.py
@@ -27,18 +27,20 @@ slice_queue_manager = _mod.slice_queue_manager
 project_queue_manager_ingest = _mod.project_queue_manager_ingest
 slice_queue_manager_ingest = _mod.slice_queue_manager_ingest
 resolve_human_approved_blockers = _mod.resolve_human_approved_blockers
+_ingest_unblock_candidates = _mod._ingest_unblock_candidates
 stable_hash = _mod.stable_hash
 
 
 def _state(*, engine_merged=None, engine_done=None, engine_human_approved=None,
-           engine_closed=None):
+           engine_closed=None, engine_tasks_open=None):
     """Build a minimal scout-state dict with the fields the projection reads."""
     return {
         "repos": {
             "engine": {
                 "needs_plan": [],
                 "human_approved": engine_human_approved or [],
-                "tasks": {"open": [], "in_progress": [], "done": engine_done or []},
+                "tasks": {"open": engine_tasks_open or [],
+                          "in_progress": [], "done": engine_done or []},
                 "closed_fleet_queued": engine_closed or [],
                 "recent_merged_prs": engine_merged or [],
             },
@@ -211,9 +213,11 @@ class IngestProjectionFiresOnNewApprovedIssue(unittest.TestCase):
 
 class IngestHonorsBlockedBy(unittest.TestCase):
     """resolve_human_approved_blockers() flags issues whose `**Blocked by:**`
-    predecessors are still open; the ingest projector + slicer then exclude
-    them, so a freshly-filed stacked epic only queues its head until each
-    blocker closes (#1476)."""
+    predecessors are still open. Since #1527 that flag is informational only:
+    the ingest projector + slicer no longer exclude blocked issues — they are
+    queued up front (with a fleet:blocked marker). These tests cover both the
+    flag computation (still used for state.json visibility) and the new
+    include-blocked projection behavior."""
 
     def _resolved(self, *, human_approved, closed=None, merged=None):
         st = _state(engine_human_approved=human_approved,
@@ -272,7 +276,10 @@ class IngestHonorsBlockedBy(unittest.TestCase):
         ])
         self.assertTrue(st["repos"]["engine"]["human_approved"][0]["blocked"])
 
-    def test_blocked_child_excluded_from_projection_and_slice(self):
+    def test_blocked_child_included_in_projection_and_slice(self):
+        # #1527: blocked children are now ingestion targets — they get queued
+        # up front (fleet:queued + model + fleet:blocked), so both head AND
+        # child contribute to the hash and appear in pending_issues.
         st = self._resolved(human_approved=[
             {"number": 810, "title": "head", "labels": ["human:approved"],
              "body": "**Blocked by:** (none)"},
@@ -281,24 +288,75 @@ class IngestHonorsBlockedBy(unittest.TestCase):
         ])
         proj_nums = [i["issue"] for i in project_queue_manager_ingest(st)]
         self.assertIn(810, proj_nums, "workable head must contribute to the hash")
-        self.assertNotIn(811, proj_nums, "blocked child must not contribute to the hash")
+        self.assertIn(811, proj_nums,
+                      "blocked child is now an ingest target (#1527)")
         slice_nums = [i["number"] for i in slice_queue_manager_ingest(st)["pending_issues"]]
         self.assertIn(810, slice_nums)
-        self.assertNotIn(811, slice_nums)
+        self.assertIn(811, slice_nums)
 
-    def test_unblock_flips_hash(self):
-        # The crux of #1476: when the head closes, the child becomes workable,
-        # re-enters the ingest set, and the trigger hash flips so the scout
-        # re-fires fleet-queue-ingest to queue it.
-        child = {"number": 811, "title": "child", "labels": ["human:approved"],
-                 "body": "**Blocked by:** #810"}
-        blocked = self._resolved(human_approved=[dict(child)])
-        unblocked = self._resolved(human_approved=[dict(child)],
-                                   closed=[{"number": 810, "title": "head"}])
+    def test_skip_label_still_excluded_when_blocked(self):
+        # _INGEST_SKIP_LABELS still wins over the include-blocked change: a
+        # blocked epic/needs-plan/needs-info issue stays out of the set.
+        st = self._resolved(human_approved=[
+            {"number": 812, "title": "epic", "labels": ["human:approved", "fleet:epic"],
+             "body": "**Blocked by:** #810"},
+        ])
+        self.assertEqual(project_queue_manager_ingest(st), [],
+                         "skip-labeled issue stays out even when blocked")
+        self.assertEqual(slice_queue_manager_ingest(st)["pending_issues"], [])
+
+
+class IngestUnblockRemovePath(unittest.TestCase):
+    """#1527 remove-half: a queued task carrying fleet:blocked whose last
+    blocker has closed becomes an unblock-candidate sourced from tasks.open (it
+    has already left human_approved by carrying fleet:queued). The candidate
+    flips the ingest hash so fleet-queue-ingest re-fires and strips the marker,
+    then disappears the next tick once the label is gone."""
+
+    def _task(self, *, num, blocked, blocked_by):
+        return {"id": f"#{num}", "issue": f"#{num}", "title": f"#{num}",
+                "summary": "t", "status": " ", "owner": "free", "model": "opus",
+                "area": None, "blocked": blocked, "blocked_by": blocked_by}
+
+    def _st(self, tasks_open):
+        return _state(engine_tasks_open=tasks_open)
+
+    def test_unblocked_marked_task_is_candidate(self):
+        st = self._st([self._task(num=811, blocked=True, blocked_by="(none)")])
+        self.assertEqual(_ingest_unblock_candidates(st["repos"]["engine"]), [811])
+
+    def test_still_blocked_marked_task_is_not_candidate(self):
+        st = self._st([self._task(num=811, blocked=True, blocked_by="#810")])
+        self.assertEqual(_ingest_unblock_candidates(st["repos"]["engine"]), [])
+
+    def test_unmarked_task_is_not_candidate(self):
+        # No fleet:blocked label (blocked=False) → never an unblock candidate,
+        # even when blocked_by resolves to (none).
+        st = self._st([self._task(num=811, blocked=False, blocked_by="(none)")])
+        self.assertEqual(_ingest_unblock_candidates(st["repos"]["engine"]), [])
+
+    def test_candidate_in_projection_and_slice(self):
+        st = self._st([self._task(num=811, blocked=True, blocked_by="(none)")])
+        self.assertIn({"repo": "engine", "issue": 811, "op": "unblock"},
+                      project_queue_manager_ingest(st))
+        self.assertEqual(slice_queue_manager_ingest(st)["unblock_issues"],
+                         [{"number": 811, "repo": "engine"}])
+
+    def test_unblock_transition_flips_hash(self):
+        still_blocked = self._st([self._task(num=811, blocked=True, blocked_by="#810")])
+        now_unblocked = self._st([self._task(num=811, blocked=True, blocked_by="(none)")])
         self.assertNotEqual(
-            stable_hash(project_queue_manager_ingest(blocked)),
+            stable_hash(project_queue_manager_ingest(still_blocked)),
+            stable_hash(project_queue_manager_ingest(now_unblocked)),
+            "blocker closing must flip the ingest hash so fleet:blocked is removed")
+
+    def test_marker_cleared_settles_hash(self):
+        unblocked = self._st([self._task(num=811, blocked=True, blocked_by="(none)")])
+        cleared = self._st([self._task(num=811, blocked=False, blocked_by="(none)")])
+        self.assertNotEqual(
             stable_hash(project_queue_manager_ingest(unblocked)),
-            "closing the blocker must flip the ingest hash so ingest re-fires")
+            stable_hash(project_queue_manager_ingest(cleared)),
+            "clearing the marker flips the hash once more, then the set quiesces")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Queue **every** approved, non-skip task up front instead of one stacked-epic child at a time (#1476). A task whose `**Blocked by:** #N` predecessor is still open is stamped `fleet:queued` + a model label **plus a new `fleet:blocked` marker**; the whole approved backlog is now visible in `fleet-queue-list` / `tasks.open[].blocked`, and the stacking enrichment fires for queued-blocked tasks so a worker can fall through to a `--stackable-on` claim.

- **Add path** — `fleet-queue-ingest` stamps blocked tasks too (driven from `human_approved[]`, which excludes `fleet:queued`).
- **Remove path** — once queued, a blocked task has left `human_approved[]`, so the scout's new `_ingest_unblock_candidates` re-surfaces it from `tasks.open[]` when its last blocker closes; ingest then strips `fleet:blocked`.
- Both transitions feed the `queue-manager-ingest` projection hash → each is edge-triggered. The live `gh issue view` recheck in `fleet-queue-ingest` stays authoritative for add **and** remove.
- **Claimability unchanged:** `fleet-claim` still refuses a plain claim on a blocked task (its own Blocked-by gate); `--stackable-on` works. Reconcile leaves a `fleet:queued`+`fleet:blocked` no-claim issue alone (matches no rule).

Adds the `fleet:blocked` label (catalog + `fleet-state-machine.json` + reference doc, created in both repos), a `docs/design/fleet-queue-stacking.md` source-of-truth doc, and rewrites FLEET.md's Blocked-by section. **Engine-mechanism only — no role/command configs** (human-applied per epic #1526).

## Test plan
- [x] `test_queue_manager_projection.py` (27) — blocked add-candidate included; unblock remove-path projection/slice + hash transitions.
- [x] `test_issue_queue_parser.py` (33) — `tasks.open[].blocked` set from the `fleet:blocked` label.
- [x] `test_enrich_stackable_blocker_prs.py` — queued-blocked task still enriched with `stackable_blocker_pr`.
- [x] `test_fleet_queue_ingest_blocked_by.sh` (6) — stamp-with-marker on open blocker, no marker on closed/none, unblock-removal when blocker closes, blocker issues read-only.
- [x] Full Python fleet suite (11 files) green; `fleet-labels --check` agrees (47 labels); scout loads + bash `-n` clean.

Closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)