### PR TITLE
fleet: merger projection skips human:needs-fix/fleet:needs-fix (#1533)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1196,6 +1196,19 @@ def _merger_action_signal(labels, mergeable, base_ref):
     issue; only the human decides (close-as-superseded / replace /
     reconcile). Re-dispatching the merger just re-triggers the
     opus-worker thrash cycle (observed game #101, three passes).
+
+    The human-owes-a-fix labels — `human:needs-fix`, `human:blocker`,
+    `fleet:needs-fix`, `human:re-review` — are skipped to keep the
+    projection consistent with the merge gate. `role-merger.md` step 3
+    already skips these (the human/reviewer owes a change; the merger
+    must not loop on the PR), but the projection omitted them, so an
+    approved-then-needs-fix PR (e.g. game #144) was projected
+    `merge-ready` and woke the merger every scout tick to find nothing
+    to do. No merge hazard today — the fleet doesn't auto-merge — but the
+    wasted wakes are real and the projection/gate disagreement is a
+    latent footgun. These are durable reviewer/human labels, not
+    merger-set transients, so skipping them preserves the self-trigger
+    invariant above.
     """
     skip = labels & {
         "fleet:wip", "human:wip", "fleet:blocker",
@@ -1203,6 +1216,13 @@ def _merger_action_signal(labels, mergeable, base_ref):
         "fleet:needs-info", "fleet:needs-linux-smoke",
         "fleet:needs-macos-smoke",
         "fleet:human-deferred",
+        # Human-owes-a-fix labels — mirror role-merger.md step 3. NOT
+        # `FEEDBACK_LABELS`: that set carries `fleet:has-nits` (an
+        # approved+has-nits PR is still merge-ready, so the merger must
+        # see it) and omits `human:re-review` (a reviewer concern that
+        # IS the merger's cue to skip). Hand-list the four deliberately.
+        "human:needs-fix", "human:blocker",
+        "fleet:needs-fix", "human:re-review",
     }
     if skip:
         return None

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -169,6 +169,54 @@ class SkipLabelsRemovedFromProjection(unittest.TestCase):
         self.assertEqual(_hash(empty), _hash(deferred))
 
 
+class HumanOwesFixLabelsDropped(unittest.TestCase):
+    """An approved PR that also carries a human-owes-a-fix label must drop
+    out of the projection so the merger isn't woken every scout tick to
+    find nothing to do. These labels mirror role-merger.md step 3's skip
+    list, keeping the projection consistent with the merge gate (#1533;
+    observed live on game #144: fleet:approved + human:needs-fix projected
+    merge-ready forever)."""
+
+    def _dropped(self, *extra_labels, mergeable="MERGEABLE"):
+        empty = _state([])
+        flagged = _state([_pr(101, labels=[
+            "fleet:approved", *extra_labels,
+        ], mergeable=mergeable)])
+        self.assertEqual(_hash(empty), _hash(flagged))
+        self.assertEqual(project_merger(flagged), [])
+
+    def test_human_needs_fix_dropped(self):
+        self._dropped("human:needs-fix")
+
+    def test_human_needs_fix_conflicting_dropped(self):
+        # Even CONFLICTING: the human owes a fix, so the merger must not
+        # try to resolve — the author will force-push when addressing it,
+        # invalidating any rebase the merger does now.
+        self._dropped("human:needs-fix", mergeable="CONFLICTING")
+
+    def test_human_blocker_dropped(self):
+        self._dropped("human:blocker")
+
+    def test_fleet_needs_fix_dropped(self):
+        self._dropped("fleet:needs-fix")
+
+    def test_human_re_review_dropped(self):
+        self._dropped("human:re-review")
+
+    def test_repo_agnostic_game_human_needs_fix_dropped(self):
+        # The projection loops both repos; the skip must hold for game too
+        # (game #144 was the live offender).
+        empty = _state_eng_game(engine_prs=[], game_prs=[])
+        flagged = _state_eng_game(
+            engine_prs=[],
+            game_prs=[_pr(144, labels=[
+                "fleet:approved", "human:needs-fix",
+            ])],
+        )
+        self.assertEqual(_hash(empty), _hash(flagged))
+        self.assertEqual(project_merger(flagged), [])
+
+
 class SignalSemantics(unittest.TestCase):
     """Verify the action signal categorization matches the role doc."""
 
@@ -176,6 +224,14 @@ class SignalSemantics(unittest.TestCase):
         items = project_merger(_state([_pr(101, labels=["fleet:approved"])]))
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0]["signal"], "merge-ready")
+
+    def test_approved_needs_fix_not_merge_ready(self):
+        # Acceptance criterion #1533: fleet:approved + human:needs-fix must
+        # yield no signal (not merge-ready) so it drops out of the merger.
+        items = project_merger(_state([_pr(101, labels=[
+            "fleet:approved", "human:needs-fix",
+        ])]))
+        self.assertEqual(items, [])
 
     def test_approved_conflicting_is_needs_resolve(self):
         items = project_merger(_state([_pr(101, labels=["fleet:approved"],


### PR DESCRIPTION
## Summary
- `_merger_action_signal` (`scripts/fleet/fleet-state-scout`) now skips the human-owes-a-fix labels — `human:needs-fix`, `human:blocker`, `fleet:needs-fix`, `human:re-review` — so an approved-then-needs-fix PR returns no signal instead of `merge-ready`.
- Aligns the projection with the merge gate: `role-merger.md` step 3 already skips these, so the merger no longer wakes every scout tick on a PR it would skip anyway (observed live on game #144). No merge hazard today — the human merges — but the wasted wakes were real.
- Repo-agnostic: the projection already loops both engine and game `prs[]`.
- Deliberately a hand-listed set, not a reuse of `FEEDBACK_LABELS`: that set carries `fleet:has-nits` (an approved+has-nits PR is still merge-ready, so the merger must see it) and omits `human:re-review`. An inline comment documents the divergence to pre-empt a future "just reuse FEEDBACK_LABELS" refactor.

## Notes
- The projection is now a slight, intentional superset of `role-merger.md` step 3 (which lists `human:needs-fix`/`human:blocker`/`human:re-review` but not `fleet:needs-fix`). Skipping `fleet:needs-fix` too is safe and correct — a PR that owes a fleet fix is not merge-ready — and matches the issue's explicit four-label list. `role-merger.md` is left untouched (out of scope; role-doc edits are gated).

## Test plan
- [x] `python3 -m unittest scripts.fleet.tests.test_merger_projection` — 28 tests pass (21 existing + 7 new).
- [x] New coverage: each of the four skip labels drops the PR from the projection; a repo-agnostic game case; `fleet:approved + human:needs-fix` yields no signal (acceptance criterion); `approved + mergeable + clean → merge-ready` unchanged (existing test).
- [x] `python3 -m py_compile scripts/fleet/fleet-state-scout` clean.

Closes #1533