### PR TITLE
render: light detached-canvas entities (#1375) — WIP, design-blocked

### DIFF
--- a/engine/prefabs/irreden/render/entity_canvas.hpp
+++ b/engine/prefabs/irreden/render/entity_canvas.hpp
@@ -58,6 +58,17 @@ createWithVoxelPool(std::string canvasName, IRMath::ivec2 canvasSize, IRMath::iv
         canvasSize
     );
     IREntity::setComponent(canvas, IRComponents::C_DetachedCanvas{});
+    // #1375 (lighting-receive) — DESIGN-BLOCKED, do not wire here yet. A detached
+    // canvas renders in entity-LOCAL (model) space on both its render paths
+    // (per-axis scatter off-snap #1475, single-canvas faceDeformationMatrixSO3
+    // blit at-snap), so the existing world-frame lighting reconstruction
+    // (perAxisCellToWorld3D / trixelCanvasPixelToWorld3D) would sample the shared
+    // world sun-map + light volume at the wrong place. Attaching
+    // C_CanvasAOTexture / C_CanvasSunShadow / C_CanvasLightVolume here without the
+    // model->world reconstruction would regress the path (wrong shading) and
+    // C_CanvasLightVolume is a per-canvas 128^3 (~8MB) — see the NEEDS-DESIGN note
+    // on the #1375 PR for the open architecture questions (shared-vs-owned light
+    // volume, lighting both model-frame paths, GLSL+Metal reconstruction).
     return IRComponents::C_EntityCanvas{canvas, canvasSize};
 }
 


### PR DESCRIPTION
## Summary
- WIP scaffold + escalation for #1375 (make detached-canvas entities **receive** world lighting: AO + sun shadow + light volume).
- On investigation the original plan/issue approach no longer cleanly maps onto the current detached render pipeline (the per-axis scatter split landed after the plan was written). This PR carries a design-block marker comment at the detached-canvas creation site and a `## NEEDS-DESIGN` writeup below; **no functional change yet.**
- See the NEEDS-DESIGN comment for the precise code findings and the architecture questions the architect needs to rule on before implementation.

## Status
- `fleet:design-blocked` — parked pending architect input. Branch reset for `gh pr checkout`; claim released.

## Test plan
- [ ] (deferred until design resolved) detached entity receives AO + sun shadow + light, matching a GRID entity; correct under SO(3) rotation; ambient floor (no black faces); GLSL + Metal parity.

Closes #1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)