### PR TITLE
update/lua: bind C_RotationTarget for Lua field access (#1541)

### DIFF
--- a/engine/prefabs/irreden/update/CLAUDE.md
+++ b/engine/prefabs/irreden/update/CLAUDE.md
@@ -21,7 +21,11 @@ in the `UPDATE` pipeline unless explicitly noted.
   input-driven, not time-driven — a creation updates `input_` each frame from
   a CC, slider, or any [0,1] signal, and the entity holds the last mapped
   angle when the input is unchanged. Owns the entity's local rotation (writes
-  it absolutely); don't pair with `C_AutoSpin` on the same entity.
+  it absolutely); don't pair with `C_AutoSpin` on the same entity. Lua-bindable
+  via `component_rotation_target_lua.hpp` — the scalar fields (`input_`,
+  `minAngle_`/`maxAngle_`, `inputMin_`/`inputMax_`) are read-write member
+  pointers, so a Lua automation lane drives `input_` straight through the
+  column view; `axis_` + easing stay constructor-only config.
 
 ## Key systems (all UPDATE pipeline)
 

--- a/engine/prefabs/irreden/update/components/component_rotation_target_lua.hpp
+++ b/engine/prefabs/irreden/update/components/component_rotation_target_lua.hpp
@@ -1,0 +1,39 @@
+#ifndef COMPONENT_ROTATION_TARGET_LUA_H
+#define COMPONENT_ROTATION_TARGET_LUA_H
+
+#include <irreden/update/components/component_rotation_target.hpp>
+#include <irreden/script/lua_script.hpp>
+
+namespace IRScript {
+template <> inline constexpr bool kHasLuaBinding<IRComponents::C_RotationTarget> = true;
+
+template <> inline void bindLuaType<IRComponents::C_RotationTarget>(LuaScript &luaScript) {
+    using IRComponents::C_RotationTarget;
+    // Scalar fields are bound as read-write member pointers (the C_MidiNote /
+    // C_ZoomLevel shape), so a Lua automation lane can drive `input_` in place
+    // — `arch.C_RotationTarget:at(i).input = cc` writes straight through the
+    // column (`:at` hands Lua a std::ref to the row). The axis + easing curve
+    // are construction-time config, set through the constructors below; `axis_`
+    // (a vec3) follows the C_LocalTransform / C_Velocity3D precedent of staying
+    // constructor-only rather than a directly-mutable usertype member.
+    luaScript.registerType<
+        C_RotationTarget,
+        C_RotationTarget(),
+        C_RotationTarget(IRMath::vec3, float, float),
+        C_RotationTarget(IRMath::vec3, float, float, float)>(
+        "C_RotationTarget",
+        "input",
+        &C_RotationTarget::input_,
+        "minAngle",
+        &C_RotationTarget::minAngle_,
+        "maxAngle",
+        &C_RotationTarget::maxAngle_,
+        "inputMin",
+        &C_RotationTarget::inputMin_,
+        "inputMax",
+        &C_RotationTarget::inputMax_
+    );
+}
+} // namespace IRScript
+
+#endif /* COMPONENT_ROTATION_TARGET_LUA_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(IrredenEngineTest
   script/lua_component_register_test.cpp
   script/lua_enum_register_test.cpp
   script/lua_pipeline_register_test.cpp
+  script/lua_rotation_target_lua_test.cpp
   script/lua_system_codegen_test.cpp
   script/prefab_api_test.cpp
   script/lua_system_coexistence_test.cpp

--- a/test/script/lua_rotation_target_lua_test.cpp
+++ b/test/script/lua_rotation_target_lua_test.cpp
@@ -1,0 +1,172 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <irreden/common/components/component_local_transform.hpp>
+#include <irreden/common/components/component_world_transform.hpp>
+#include <irreden/update/components/component_rotation_target.hpp>
+#include <irreden/update/components/component_rotation_target_lua.hpp>
+#include <irreden/update/systems/system_propagate_transform.hpp>
+#include <irreden/update/systems/system_rotation_target_local_transform.hpp>
+
+#include <irreden/script/lua_script.hpp>
+
+namespace {
+
+using IRComponents::C_LocalTransform;
+using IRComponents::C_RotationTarget;
+using IRComponents::C_WorldTransform;
+
+constexpr float kEps = 1e-4f;
+
+// End-to-end coverage for the C_RotationTarget Lua binding (#1541): a
+// Lua-defined system drives `input_` each tick through the same column view
+// any creation's automation lane would use, and the engine's
+// ROTATION_TARGET_LOCAL_TRANSFORM maps it onto the entity's rotation. Proves
+// the field is reachable (read + write) from Lua via the standard
+// component-field path, not a bespoke one-off binding.
+class RotationTargetLuaTest : public testing::Test {
+  protected:
+    RotationTargetLuaTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_system_manager{} {
+        // bindLuaDrivenEcs() first so the IRComponent table exists before
+        // registerType records the C_RotationTarget handle under it.
+        m_lua.bindLuaDrivenEcs();
+        m_lua.registerTypeFromTraits<C_RotationTarget>();
+    }
+
+    static void expectVec3Near(IRMath::vec3 actual, IRMath::vec3 expected, float eps = kEps) {
+        EXPECT_NEAR(actual.x, expected.x, eps);
+        EXPECT_NEAR(actual.y, expected.y, eps);
+        EXPECT_NEAR(actual.z, expected.z, eps);
+    }
+
+    // q and -q are the same rotation; compare by action on the basis vectors.
+    static void expectSameRotation(IRMath::vec4 actual, IRMath::vec4 expected) {
+        for (const auto &v :
+             {IRMath::vec3(1, 0, 0), IRMath::vec3(0, 1, 0), IRMath::vec3(0, 0, 1)}) {
+            expectVec3Near(
+                IRMath::rotateVectorByQuat(v, actual),
+                IRMath::rotateVectorByQuat(v, expected)
+            );
+        }
+    }
+
+    // m_lua first so its sol::state outlives any sol::function-bearing columns
+    // held by the EntityManager (matches lua_system_register_test.cpp).
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(RotationTargetLuaTest, LuaWrittenInputDrivesRotation) {
+    auto &lua = m_lua.lua();
+
+    const IRMath::vec3 axis(0, 0, 1);
+    // input range [0,1] → angle range [0, pi/2]; start at input 0 (angle 0).
+    auto id = IREntity::createEntity(
+        C_LocalTransform{},
+        C_RotationTarget{axis, 0.0f, IRMath::kHalfPi, 0.0f}
+    );
+
+    // A Lua automation lane writing input_ in place via the column view —
+    // `:at(i)` hands Lua a std::ref to the row, so `.input = v` writes through.
+    lua["driveValue"] = 1.0;
+    auto registerResult = lua.safe_script(
+        R"(
+        return IRSystem.registerSystem({
+            name = 'DriveRotationInput',
+            components = { IRComponent.C_RotationTarget },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    arch.C_RotationTarget:at(i).input = driveValue
+                end
+            end,
+        })
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(registerResult.valid()) << sol::error{registerResult}.what();
+    const IRSystem::SystemId luaSysId = registerResult.get<lua_Integer>();
+
+    // Lua drives input_, then the engine systems map it onto the rotation.
+    m_system_manager.registerPipeline(
+        IRTime::Events::UPDATE,
+        {luaSysId,
+         IRSystem::createSystem<IRSystem::ROTATION_TARGET_LOCAL_TRANSFORM>(),
+         IRSystem::createSystem<IRSystem::PROPAGATE_TRANSFORM>()}
+    );
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    // input 1.0 of [0,1] → t=1 → maxAngle (pi/2): the Lua write landed in the
+    // C++ column and ROTATION_TARGET_LOCAL_TRANSFORM consumed it.
+    EXPECT_FLOAT_EQ(IREntity::getComponent<C_RotationTarget>(id).input_, 1.0f);
+    expectSameRotation(
+        IREntity::getComponent<C_WorldTransform>(id).rotation_,
+        IRMath::quatAxisAngle(axis, IRMath::kHalfPi)
+    );
+
+    // Drive to the midpoint on a second tick — proves the per-frame write path,
+    // not just a one-shot construction-time value.
+    lua["driveValue"] = 0.5;
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    EXPECT_FLOAT_EQ(IREntity::getComponent<C_RotationTarget>(id).input_, 0.5f);
+    expectSameRotation(
+        IREntity::getComponent<C_WorldTransform>(id).rotation_,
+        IRMath::quatAxisAngle(axis, IRMath::kHalfPi * 0.5f)
+    );
+}
+
+TEST_F(RotationTargetLuaTest, LuaReadsScalarFields) {
+    auto &lua = m_lua.lua();
+
+    // Non-default config so the read-back can't accidentally match a default.
+    IREntity::createEntity(
+        C_LocalTransform{},
+        C_RotationTarget{
+            IRMath::vec3(0, 1, 0),
+            -IRMath::kHalfPi,
+            IRMath::kHalfPi,
+            0.25f,
+            0.0f,
+            4.0f
+        }
+    );
+
+    auto registerResult = lua.safe_script(
+        R"(
+        readInput, readMinAngle, readMaxAngle, readInputMax = nil, nil, nil, nil
+        return IRSystem.registerSystem({
+            name = 'ReadRotationFields',
+            components = { IRComponent.C_RotationTarget },
+            tick = function(arch)
+                for i = 0, arch.length - 1 do
+                    local rt = arch.C_RotationTarget:at(i)
+                    readInput = rt.input
+                    readMinAngle = rt.minAngle
+                    readMaxAngle = rt.maxAngle
+                    readInputMax = rt.inputMax
+                end
+            end,
+        })
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(registerResult.valid()) << sol::error{registerResult}.what();
+    const IRSystem::SystemId luaSysId = registerResult.get<lua_Integer>();
+
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {luaSysId});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_FLOAT_EQ(lua["readInput"].get<float>(), 0.25f);
+    EXPECT_NEAR(lua["readMinAngle"].get<float>(), -IRMath::kHalfPi, kEps);
+    EXPECT_NEAR(lua["readMaxAngle"].get<float>(), IRMath::kHalfPi, kEps);
+    EXPECT_FLOAT_EQ(lua["readInputMax"].get<float>(), 4.0f);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Add `component_rotation_target_lua.hpp` — a `*_lua.hpp` binding for `C_RotationTarget` so a Lua-defined system listing `IRComponent.C_RotationTarget` can read and write `input_` (and `min/maxAngle_`, `input{Min,Max}_`).
- Scalar fields are read-write member pointers (the `C_MidiNote` / `C_ZoomLevel` shape), so `arch.C_RotationTarget:at(i).input = cc` writes straight through the column view; `axis_` + easing stay constructor-only config (the `C_LocalTransform` / `C_Velocity3D` vec3 precedent).
- New `test/script/lua_rotation_target_lua_test.cpp`: a Lua system writes `input_`, the engine's `ROTATION_TARGET_LOCAL_TRANSFORM` + `PROPAGATE_TRANSFORM` map it onto the entity's rotation across two ticks; a second test reads the scalar fields back.
- Doc note added to `engine/prefabs/irreden/update/CLAUDE.md`.

Closes the gap the gear-automation host spike (game #139) hit, where the automation lane had to be driven from C++ because `C_RotationTarget` had no Lua binding at all.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` clean (macOS).
- [x] `RotationTargetLuaTest.LuaWrittenInputDrivesRotation` + `LuaReadsScalarFields` pass.
- [x] Full Lua/script + rotation-target suite (128 tests) green — no regressions.
- [x] clang-format clean on the new files.

## Notes for reviewer
- Field access uses the engine's standard two-tier component-field path (member-pointer fields + column view), not a bespoke binding — per the issue's acceptance criterion 3.
- `optimize` skipped intentionally: this is a registration-only binding header + test; it adds no new per-frame C++ (the `ROTATION_TARGET_LOCAL_TRANSFORM` tick is unchanged), so there's no hot path to profile.
- `axis_` (vec3) and `easingFunction_` are deliberately not exposed as mutable usertype members — they're construction-time config, and direct vec3-member mutation follows the existing engine precedent of constructor-only access. A follow-up can add an easing-enum-arity constructor if a Lua creation needs a non-linear curve.

Closes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)