### PR TITLE
system: append/insert a system onto a live pipeline (#1540)

### DIFF
--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -739,13 +739,14 @@ IRSystem.registerPipeline(IRTime.UPDATE, {
   when the C++ pipeline is built before the script runs (e.g. the midi
   runtime's `initSystems()` runs before `main.lua`) and Lua wants to add
   one UPDATE / RENDER system — `registerPipeline` would wipe the C++
-  systems; `appendSystem` composes. Raises a Lua error if the system is
-  already in the pipeline (double-add → ticks twice).
+  systems; `appendSystem` composes. Asserts in debug if the system is
+  already in the pipeline (double-add → ticks twice in release).
 - **`IRSystem.insertSystemBefore(event, sysId, anchor)`** /
   **`IRSystem.insertSystemAfter(event, sysId, anchor)`** (#1540) — the
   position-aware variants; insert `sysId` as its own serial group
   immediately before / after `anchor` (a SystemId already in `event`'s
-  pipeline). Raises a Lua error if `anchor` isn't in the pipeline.
+  pipeline). Asserts in debug if `anchor` isn't in the pipeline; in
+  release a bad anchor silently front-inserts.
   Underlying semantics: `engine/system/CLAUDE.md` "Appending to a live
   pipeline".
 - **Game-side enums** (e.g. `IRGameSystem.GameSystemName`) extend the

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -731,6 +731,23 @@ IRSystem.registerPipeline(IRTime.UPDATE, {
   missing C++ registration if the name was never wired up.
 - **`IRSystem.registerPipeline(event, ids)`** — accepts any mix of prefab
   ids (from `systemId`) and Lua-defined ids (from `registerSystem`).
+  **Replaces** `event`'s whole system list (so does
+  `registerPipelineGroups`).
+- **`IRSystem.appendSystem(event, sysId)`** (#1540) — adds one system to
+  the END of `event`'s **already-registered** pipeline as its own serial
+  group, WITHOUT replacing the systems already there. The supported path
+  when the C++ pipeline is built before the script runs (e.g. the midi
+  runtime's `initSystems()` runs before `main.lua`) and Lua wants to add
+  one UPDATE / RENDER system — `registerPipeline` would wipe the C++
+  systems; `appendSystem` composes. Raises a Lua error if the system is
+  already in the pipeline (double-add → ticks twice).
+- **`IRSystem.insertSystemBefore(event, sysId, anchor)`** /
+  **`IRSystem.insertSystemAfter(event, sysId, anchor)`** (#1540) — the
+  position-aware variants; insert `sysId` as its own serial group
+  immediately before / after `anchor` (a SystemId already in `event`'s
+  pipeline). Raises a Lua error if `anchor` isn't in the pipeline.
+  Underlying semantics: `engine/system/CLAUDE.md` "Appending to a live
+  pipeline".
 - **Game-side enums** (e.g. `IRGameSystem.GameSystemName`) extend the
   same pattern — bind the game's own enum table at game-side init via
   `LuaScript::registerEnum<...>()` plus `registerPrefabSystemId` for each

--- a/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
@@ -305,8 +305,9 @@ inline void bindRegisterPipelineAndSystemId(
     // #1540: position-aware variants — insert `sysId` as its own serial
     // group immediately before / after `anchorId` (a SystemId already in
     // `event`'s pipeline). Same single-system, own-group semantics as
-    // appendSystem; raises a Lua error if the anchor isn't in the
-    // pipeline or the system is already present.
+    // appendSystem; asserts in debug if the anchor isn't in the pipeline
+    // or the system is already present (release: bad anchor front-inserts,
+    // duplicate ticks twice).
     //
     //     local anchor = IRSystem.systemId(IRSystem.SystemName.LIFETIME)
     //     IRSystem.insertSystemBefore(IRTime.UPDATE, luaSysId, anchor)

--- a/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
@@ -40,6 +40,21 @@
 
 namespace IRScript::detail {
 
+// Shared range-check for the pipeline-composition bindings — every one
+// takes an `event` integer that must name a valid `IRTime::Events`.
+// Raises a Lua-visible error (forwarded via lua_error under
+// SOL_EXCEPTIONS_ALWAYS_UNSAFE) naming the binding so the diagnostic
+// points at the caller. `fn` is the Lua-facing function name.
+inline void requireValidPipelineEvent(const char *fn, lua_Integer event) {
+    if (event < static_cast<lua_Integer>(IRTime::UPDATE) ||
+        event > static_cast<lua_Integer>(IRTime::END)) {
+        throw sol::error{
+            std::string{fn} + ": invalid event " + std::to_string(event) +
+            " — must be IRTime.UPDATE / RENDER / INPUT / START / END"
+        };
+    }
+}
+
 // Bind `IRTime.UPDATE / RENDER / INPUT / START / END` as integer table
 // entries. The underlying `IRTime::Events` enum is C-style; `IR_BIND_TIME`
 // derives each key from the enum name via stringization (same pattern as
@@ -217,13 +232,7 @@ inline void bindRegisterPipelineAndSystemId(
     };
 
     lua["IRSystem"]["registerPipeline"] = [](lua_Integer event, sol::table ids) {
-        if (event < static_cast<lua_Integer>(IRTime::UPDATE) ||
-            event > static_cast<lua_Integer>(IRTime::END)) {
-            throw sol::error{
-                "IRSystem.registerPipeline: invalid event " + std::to_string(event) +
-                " — must be IRTime.UPDATE / RENDER / INPUT / START / END"
-            };
-        }
+        requireValidPipelineEvent("IRSystem.registerPipeline", event);
         std::list<IRSystem::SystemId> pipeline;
         for (auto &kv : ids) {
             sol::optional<lua_Integer> id = kv.second.as<sol::optional<lua_Integer>>();
@@ -250,13 +259,7 @@ inline void bindRegisterPipelineAndSystemId(
     //         { sysC },         -- serial
     //     })
     lua["IRSystem"]["registerPipelineGroups"] = [](lua_Integer event, sol::table groups) {
-        if (event < static_cast<lua_Integer>(IRTime::UPDATE) ||
-            event > static_cast<lua_Integer>(IRTime::END)) {
-            throw sol::error{
-                "IRSystem.registerPipelineGroups: invalid event " + std::to_string(event) +
-                " — must be IRTime.UPDATE / RENDER / INPUT / START / END"
-            };
-        }
+        requireValidPipelineEvent("IRSystem.registerPipelineGroups", event);
         std::vector<std::vector<IRSystem::SystemId>> built;
         built.reserve(groups.size());
         for (auto &outerKv : groups) {
@@ -281,6 +284,52 @@ inline void bindRegisterPipelineAndSystemId(
         }
         IRSystem::registerPipelineGroups(static_cast<IRTime::Events>(event), std::move(built));
     };
+
+    // #1540: append a single system onto an ALREADY-REGISTERED event
+    // pipeline as its own serial group, WITHOUT replacing the systems
+    // already there. registerPipeline / registerPipelineGroups replace
+    // the event's whole list; this composes. The supported path when the
+    // C++ pipeline is built before the script runs (e.g. the midi
+    // runtime's initSystems() runs before main.lua) and Lua wants to add
+    // one UPDATE / RENDER system.
+    //
+    //     IRSystem.appendSystem(IRTime.UPDATE, luaSysId)
+    lua["IRSystem"]["appendSystem"] = [](lua_Integer event, lua_Integer sysId) {
+        requireValidPipelineEvent("IRSystem.appendSystem", event);
+        IRSystem::appendToPipeline(
+            static_cast<IRTime::Events>(event),
+            static_cast<IRSystem::SystemId>(sysId)
+        );
+    };
+
+    // #1540: position-aware variants — insert `sysId` as its own serial
+    // group immediately before / after `anchorId` (a SystemId already in
+    // `event`'s pipeline). Same single-system, own-group semantics as
+    // appendSystem; raises a Lua error if the anchor isn't in the
+    // pipeline or the system is already present.
+    //
+    //     local anchor = IRSystem.systemId(IRSystem.SystemName.LIFETIME)
+    //     IRSystem.insertSystemBefore(IRTime.UPDATE, luaSysId, anchor)
+    //     IRSystem.insertSystemAfter(IRTime.UPDATE, luaSysId, anchor)
+    lua["IRSystem"]["insertSystemBefore"] =
+        [](lua_Integer event, lua_Integer sysId, lua_Integer anchorId) {
+            requireValidPipelineEvent("IRSystem.insertSystemBefore", event);
+            IRSystem::insertIntoPipelineBefore(
+                static_cast<IRTime::Events>(event),
+                static_cast<IRSystem::SystemId>(sysId),
+                static_cast<IRSystem::SystemId>(anchorId)
+            );
+        };
+
+    lua["IRSystem"]["insertSystemAfter"] =
+        [](lua_Integer event, lua_Integer sysId, lua_Integer anchorId) {
+            requireValidPipelineEvent("IRSystem.insertSystemAfter", event);
+            IRSystem::insertIntoPipelineAfter(
+                static_cast<IRTime::Events>(event),
+                static_cast<IRSystem::SystemId>(sysId),
+                static_cast<IRSystem::SystemId>(anchorId)
+            );
+        };
 }
 
 } // namespace IRScript::detail

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -317,6 +317,37 @@ thread (main-thread assert, deadlock risk under full-pool saturation).
 In release builds where the validator is a no-op, `executeSystem` falls
 back to serial dispatch as a safety net.
 
+### Appending to a live pipeline (#1540)
+
+`registerPipeline` / `registerPipelineGroups` **replace** the event's
+whole system list. That's wrong for a runtime whose C++ pipeline is
+built before a script runs — the midi runtime calls `initSystems()`
+(knob CC driver, `ROTATION_TARGET_LOCAL_TRANSFORM`, render stages)
+before `runScript("main.lua")`, so a second `registerPipeline` from
+Lua would wipe those C++ systems (and re-listing them double-creates
+named GPU resources). The composition primitives add one system onto
+the existing pipeline instead:
+
+```cpp
+IRSystem::appendToPipeline(IRTime::Events::UPDATE, sysId);              // end
+IRSystem::insertIntoPipelineBefore(IRTime::Events::UPDATE, sysId, anchor);
+IRSystem::insertIntoPipelineAfter(IRTime::Events::UPDATE, sysId, anchor);
+```
+
+- Each adds `sysId` as its **own singleton (serial) group**, so it
+  never co-executes with a neighbor and needs no cross-system
+  validation (the validator skips size-1 groups).
+- `appendToPipeline` creates the event's first group if none exists
+  yet; the insert forms require the anchor's pipeline to already be
+  registered.
+- All three assert (debug; no-op in release) if `sysId` is already in
+  the event's pipeline (a double-add would tick it twice), and the
+  insert forms assert if `anchor` isn't found.
+- Lua surface: `IRSystem.appendSystem(event, sysId)`,
+  `IRSystem.insertSystemBefore(event, sysId, anchor)`,
+  `IRSystem.insertSystemAfter(event, sysId, anchor)` — see
+  `engine/script/CLAUDE.md` "Pipeline composition".
+
 ## SystemAccess derivation (T-221)
 
 `engine/system/include/irreden/system/system_access.hpp` defines

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -157,10 +157,12 @@ constexpr SystemId createSystem(
     constexpr SystemAccess accessDescriptor = []() {
         SystemAccess a = deriveAccessFromSignature<FunctionTick, TickComponents...>();
         if constexpr (sizeof...(TickRelationComponents) > 0) {
-            if constexpr (std::is_invocable_v<
-                              FunctionTick,
-                              std::remove_cvref_t<TickComponents> &...,
-                              std::optional<TickRelationComponents *>...>) {
+            if constexpr (
+                std::is_invocable_v<
+                    FunctionTick,
+                    std::remove_cvref_t<TickComponents> &...,
+                    std::optional<TickRelationComponents *>...>
+            ) {
                 a.isRelationForm_ = true;
             }
         }
@@ -218,12 +220,14 @@ template <typename T, typename... Cs> struct MakeMemberTickFn<T, TypeList<Cs...>
             return [p](Cs &...cs) { p->tick(cs...); };
         } else if constexpr (requires(T &s, EntityId id, Cs &...cs) { s.tick(id, cs...); }) {
             return [p](EntityId id, Cs &...cs) { p->tick(id, cs...); };
-        } else if constexpr (requires(
-                                 T &s,
-                                 const Archetype &a,
-                                 std::vector<EntityId> &ids,
-                                 std::vector<Cs> &...cols
-                             ) { s.tick(a, ids, cols...); }) {
+        } else if constexpr (
+            requires(
+                T &s,
+                const Archetype &a,
+                std::vector<EntityId> &ids,
+                std::vector<Cs> &...cols
+            ) { s.tick(a, ids, cols...); }
+        ) {
             return [p](const Archetype &a, std::vector<EntityId> &ids, std::vector<Cs> &...cols) {
                 p->tick(a, ids, cols...);
             };
@@ -438,6 +442,23 @@ void registerPipeline(IRTime::Events systemType, std::list<SystemId> pipeline);
 ///         { lifetime },                  // group 2: serial
 ///     });
 void registerPipelineGroups(IRTime::Events event, std::vector<std::vector<SystemId>> groups);
+
+/// #1540: append a single system to the end of `event`'s already-
+/// registered pipeline as its own serial group, without disturbing the
+/// systems already registered for `event`. Unlike `registerPipeline` /
+/// `registerPipelineGroups` (which *replace* the event's whole system
+/// list), this composes onto a live pipeline — the supported path for a
+/// creation whose C++ `initSystems()` ran before a Lua script wants to
+/// add an UPDATE / RENDER system. See `engine/system/CLAUDE.md`
+/// "Appending to a live pipeline".
+void appendToPipeline(IRTime::Events event, SystemId system);
+
+/// #1540: insert a single system as its own serial group immediately
+/// before / after the group containing `anchor` in `event`'s pipeline.
+/// The position-aware sibling of `appendToPipeline` for when ordering
+/// relative to an existing system matters.
+void insertIntoPipelineBefore(IRTime::Events event, SystemId system, SystemId anchor);
+void insertIntoPipelineAfter(IRTime::Events event, SystemId system, SystemId anchor);
 
 /// T-224: run the cross-system access-conflict validator across every
 /// registered pipeline group. FATALs on the first conflict, naming

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -195,6 +195,28 @@ class SystemManager {
     /// registration for `event`.
     void registerPipelineGroups(IRTime::Events event, std::vector<std::vector<SystemId>> groups);
 
+    /// #1540: append `system` to the END of `event`'s pipeline as its
+    /// own singleton (serial) group, leaving every previously-registered
+    /// group untouched. This is the composition primitive for a runtime
+    /// where the C++ pipeline is built before a script runs (e.g. the
+    /// midi runtime's `initSystems()` runs before `main.lua`): a Lua-
+    /// authored system can join the live UPDATE/RENDER pipeline without
+    /// re-listing — and double-creating — the existing C++ systems that
+    /// `registerPipeline` / `registerPipelineGroups` would otherwise
+    /// REPLACE. Creates the event's first group if none was registered
+    /// yet. Asserts if `system` already appears in `event`'s pipeline (a
+    /// second add would tick it twice per frame).
+    void appendToPipeline(IRTime::Events event, SystemId system);
+
+    /// #1540: insert `system` as its own singleton group immediately
+    /// before / after the group that contains `anchor` in `event`'s
+    /// pipeline. The position-aware sibling of `appendToPipeline` for
+    /// when ordering relative to an existing system matters. Asserts if
+    /// no pipeline is registered for `event`, `anchor` is absent, or
+    /// `system` is already present.
+    void insertIntoPipelineBefore(IRTime::Events event, SystemId system, SystemId anchor);
+    void insertIntoPipelineAfter(IRTime::Events event, SystemId system, SystemId anchor);
+
     /// T-224: validate every registered pipeline group against the
     /// cross-system access rules in `system_access.hpp`. Call once
     /// after all systems and pipelines are registered, before the
@@ -278,6 +300,13 @@ class SystemManager {
 
     void refreshFlattenedPipelines() const;
 
+    /// Shared impl for `insertIntoPipelineBefore` / `insertIntoPipelineAfter`.
+    /// `after == false` inserts the new singleton group at the anchor's
+    /// group index; `after == true` inserts immediately past it.
+    void insertSingletonGroupRelativeTo(
+        IRTime::Events event, SystemId system, SystemId anchor, bool after
+    );
+
     bool m_timingEnabled = false;
     std::vector<TimingAccum> m_timingAccum;
 
@@ -352,12 +381,14 @@ class SystemManager {
                     paramTuple
                 );
             };
-            m_ticks.emplace_back(C_SystemEvent<TICK>{
-                std::function<void(ArchetypeNode *)>{std::move(perNodeFn)},
-                std::function<std::function<void(int, int)>(ArchetypeNode *)>{},
-                getArchetype<Components...>(),
-                std::move(excludeArchetype)
-            });
+            m_ticks.emplace_back(
+                C_SystemEvent<TICK>{
+                    std::function<void(ArchetypeNode *)>{std::move(perNodeFn)},
+                    std::function<std::function<void(int, int)>(ArchetypeNode *)>{},
+                    getArchetype<Components...>(),
+                    std::move(excludeArchetype)
+                }
+            );
             return;
         } else {
 
@@ -375,8 +406,8 @@ class SystemManager {
             // an `else` so the unsupported-signature static_assert below
             // only fires when the batch-form branch above has NOT
             // discarded this code.
-            auto prepareRangedTick = [functionTick, extraParams](ArchetypeNode *node
-                                     ) -> std::function<void(int, int)> {
+            auto prepareRangedTick =
+                [functionTick, extraParams](ArchetypeNode *node) -> std::function<void(int, int)> {
                 if constexpr (InvocableWithEntityId<FunctionTick, Components...>) {
                     auto componentsTuple = std::make_tuple(
                         std::ref(node->entities_),
@@ -405,10 +436,12 @@ class SystemManager {
                             );
                         }
                     };
-                } else if constexpr (std::is_invocable_v<
-                                         FunctionTick,
-                                         Components &...,
-                                         std::optional<RelationComponents *>...>) {
+                } else if constexpr (
+                    std::is_invocable_v<
+                        FunctionTick,
+                        Components &...,
+                        std::optional<RelationComponents *>...>
+                ) {
                     // Relation form: the validator (T-334 scope) rejects
                     // PARALLEL_FOR + relation, so this binder runs only
                     // on the main thread. Resolve component vectors AND
@@ -427,9 +460,11 @@ class SystemManager {
                             std::apply(
                                 [&functionTick](auto &&...args) { functionTick(args...); },
                                 std::tuple_cat(
-                                    std::make_tuple(std::ref(
-                                        std::get<std::vector<Components> &>(componentsTuple)[i]
-                                    )...),
+                                    std::make_tuple(
+                                        std::ref(
+                                            std::get<std::vector<Components> &>(componentsTuple)[i]
+                                        )...
+                                    ),
                                     relationComponentTuple
                                 )
                             );
@@ -439,12 +474,14 @@ class SystemManager {
                     static_assert(false, "Unsupported tick function signature.");
                 }
             };
-            m_ticks.emplace_back(C_SystemEvent<TICK>{
-                std::function<void(ArchetypeNode *)>{},
-                C_SystemEvent<TICK>::PrepareRangedTickFn{std::move(prepareRangedTick)},
-                getArchetype<Components...>(),
-                std::move(excludeArchetype)
-            });
+            m_ticks.emplace_back(
+                C_SystemEvent<TICK>{
+                    std::function<void(ArchetypeNode *)>{},
+                    C_SystemEvent<TICK>::PrepareRangedTickFn{std::move(prepareRangedTick)},
+                    getArchetype<Components...>(),
+                    std::move(excludeArchetype)
+                }
+            );
         }
     }
 
@@ -468,8 +505,11 @@ class SystemManager {
             m_relationTicks.emplace_back(
                 C_SystemEvent<RELATION_TICK>{[functionRelationTick](EntityRecord entityRecord) {
                     auto componentsTuple = std::make_tuple(
-                        std::ref(getComponentData<RelationComponents>(entityRecord.archetypeNode
-                        )[entityRecord.row])...
+                        std::ref(
+                            getComponentData<RelationComponents>(
+                                entityRecord.archetypeNode
+                            )[entityRecord.row]
+                        )...
                     );
                     std::apply(
                         [functionRelationTick](auto &&...components) {

--- a/engine/system/src/ir_system.cpp
+++ b/engine/system/src/ir_system.cpp
@@ -12,10 +12,20 @@ void registerPipeline(IRTime::Events event, std::list<SystemId> pipeline) {
     getSystemManager().registerPipeline(event, pipeline);
 }
 
-void registerPipelineGroups(
-    IRTime::Events event, std::vector<std::vector<SystemId>> groups
-) {
+void registerPipelineGroups(IRTime::Events event, std::vector<std::vector<SystemId>> groups) {
     getSystemManager().registerPipelineGroups(event, std::move(groups));
+}
+
+void appendToPipeline(IRTime::Events event, SystemId system) {
+    getSystemManager().appendToPipeline(event, system);
+}
+
+void insertIntoPipelineBefore(IRTime::Events event, SystemId system, SystemId anchor) {
+    getSystemManager().insertIntoPipelineBefore(event, system, anchor);
+}
+
+void insertIntoPipelineAfter(IRTime::Events event, SystemId system, SystemId anchor) {
+    getSystemManager().insertIntoPipelineAfter(event, system, anchor);
 }
 
 void validateAllPipelineGroups() {

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -56,11 +56,13 @@ SystemId SystemManager::createSystemDynamic(
     SystemId newSystemId = m_nextSystemId++;
 
     m_beginTicks.emplace_back(C_SystemEvent<BEGIN_TICK>{[]() {}});
-    m_ticks.emplace_back(C_SystemEvent<TICK>{
-        std::move(body),
-        std::move(includeArchetype),
-        std::move(excludeArchetype),
-    });
+    m_ticks.emplace_back(
+        C_SystemEvent<TICK>{
+            std::move(body),
+            std::move(includeArchetype),
+            std::move(excludeArchetype),
+        }
+    );
     m_endTicks.emplace_back(C_SystemEvent<END_TICK>{[]() {}});
     m_relationTicks.emplace_back(C_SystemEvent<RELATION_TICK>{[](EntityRecord) {}});
 
@@ -119,6 +121,90 @@ void SystemManager::registerPipelineGroups(
     IRTime::Events event, std::vector<std::vector<SystemId>> groups
 ) {
     m_systemPipelineGroups[event] = std::move(groups);
+    m_flattenedPipelinesDirty = true;
+}
+
+namespace {
+// True if `system` appears in any group of `groups`. Used to reject a
+// double-add: appending / inserting a system already in the pipeline
+// would tick it twice per frame.
+bool pipelineGroupsContain(const std::vector<std::vector<SystemId>> &groups, SystemId system) {
+    for (const auto &group : groups) {
+        for (SystemId id : group) {
+            if (id == system) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+} // namespace
+
+void SystemManager::appendToPipeline(IRTime::Events event, SystemId system) {
+    // operator[] default-constructs an empty group sequence when the
+    // event has no pipeline yet, so the first append becomes its sole
+    // singleton group.
+    auto &groups = m_systemPipelineGroups[event];
+    IR_ASSERT(
+        !pipelineGroupsContain(groups, system),
+        "appendToPipeline: system '{}' is already registered for this event — "
+        "a second append would tick it twice. Append each system once.",
+        getSystemName(system)
+    );
+    groups.push_back({system});
+    m_flattenedPipelinesDirty = true;
+}
+
+void SystemManager::insertIntoPipelineBefore(
+    IRTime::Events event, SystemId system, SystemId anchor
+) {
+    insertSingletonGroupRelativeTo(event, system, anchor, /*after=*/false);
+}
+
+void SystemManager::insertIntoPipelineAfter(
+    IRTime::Events event, SystemId system, SystemId anchor
+) {
+    insertSingletonGroupRelativeTo(event, system, anchor, /*after=*/true);
+}
+
+void SystemManager::insertSingletonGroupRelativeTo(
+    IRTime::Events event, SystemId system, SystemId anchor, bool after
+) {
+    auto it = m_systemPipelineGroups.find(event);
+    IR_ASSERT(
+        it != m_systemPipelineGroups.end(),
+        "insertIntoPipeline{}: no pipeline registered for this event — register "
+        "the anchor's pipeline (registerPipeline / registerPipelineGroups) or use "
+        "appendToPipeline first.",
+        after ? "After" : "Before"
+    );
+    auto &groups = it->second;
+    IR_ASSERT(
+        !pipelineGroupsContain(groups, system),
+        "insertIntoPipeline{}: system '{}' is already registered for this event — "
+        "a second insert would tick it twice.",
+        after ? "After" : "Before",
+        getSystemName(system)
+    );
+    std::size_t anchorGroup = 0;
+    bool found = false;
+    for (std::size_t gi = 0; gi < groups.size() && !found; ++gi) {
+        for (SystemId id : groups[gi]) {
+            if (id == anchor) {
+                anchorGroup = gi;
+                found = true;
+                break;
+            }
+        }
+    }
+    IR_ASSERT(
+        found,
+        "insertIntoPipeline{}: anchor system '{}' is not in this event's pipeline.",
+        after ? "After" : "Before",
+        getSystemName(anchor)
+    );
+    const std::size_t pos = after ? anchorGroup + 1 : anchorGroup;
+    groups.insert(groups.begin() + static_cast<std::ptrdiff_t>(pos), std::vector<SystemId>{system});
     m_flattenedPipelinesDirty = true;
 }
 

--- a/test/script/lua_pipeline_register_test.cpp
+++ b/test/script/lua_pipeline_register_test.cpp
@@ -448,6 +448,35 @@ TEST_F(LuaPipelineRegisterTest, InsertSystemBeforeViaLuaPlacesGroup) {
     EXPECT_EQ(groups[1][0], lifetime);
 }
 
+TEST_F(LuaPipelineRegisterTest, InsertSystemAfterViaLuaPlacesGroup) {
+    const IRSystem::SystemId lifetime = m_lua.registerPrefabSystem<IRSystem::LIFETIME>();
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        IRSystem.registerPipeline(IRTime.UPDATE, {
+            IRSystem.systemId(IRSystem.SystemName.LIFETIME),
+        })
+        local Marker = IRComponent.register("InsertAfterMarker", { dummy = 0 })
+        local luaSys = IRSystem.registerSystem({
+            name = "InsertedAfterLuaSys",
+            components = { Marker },
+            tick = function(arch) end,
+        })
+        IRSystem.insertSystemAfter(IRTime.UPDATE, luaSys,
+            IRSystem.systemId(IRSystem.SystemName.LIFETIME))
+        return luaSys
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+    const auto luaSys = static_cast<IRSystem::SystemId>(result.get<lua_Integer>());
+
+    const auto &groups = m_system_manager.getPipelineGroups(IRTime::Events::UPDATE);
+    ASSERT_EQ(groups.size(), 2u);
+    EXPECT_EQ(groups[0][0], lifetime); // prefab system before the inserted one
+    EXPECT_EQ(groups[1][0], luaSys);   // inserted after the prefab system
+}
+
 TEST_F(LuaPipelineRegisterTest, AppendSystemRejectsInvalidEvent) {
     auto &lua = m_lua.lua();
     auto result = lua.safe_script("IRSystem.appendSystem(999, 0)", sol::script_pass_on_error);

--- a/test/script/lua_pipeline_register_test.cpp
+++ b/test/script/lua_pipeline_register_test.cpp
@@ -333,4 +333,125 @@ TEST_F(LuaPipelineRegisterTest, AddRejectsUnknownFieldName) {
     EXPECT_FALSE(result.valid());
 }
 
+// ---- #1540: IRSystem.appendSystem / insertSystemBefore/After --------------
+//
+// The gap these close: a runtime whose C++ pipeline is built before
+// main.lua runs (the midi runtime) had no way for Lua to add a system
+// without `registerPipeline` REPLACING — and double-creating — the
+// already-registered C++ systems. appendSystem composes onto the live
+// pipeline instead.
+
+TEST_F(LuaPipelineRegisterTest, AppendSystemComposesOntoPreBuiltPipeline) {
+    // A C++ prefab system is registered into UPDATE *before* the script
+    // runs (simulating initSystems()); a Lua-authored system then joins
+    // via IRSystem.appendSystem. The C++ system must survive.
+    const IRSystem::SystemId lifetime = m_lua.registerPrefabSystem<IRSystem::LIFETIME>();
+    auto &lua = m_lua.lua();
+
+    auto result = lua.safe_script(
+        R"(
+        -- "Pre-built C++ pipeline" (one prefab system).
+        IRSystem.registerPipeline(IRTime.UPDATE, {
+            IRSystem.systemId(IRSystem.SystemName.LIFETIME),
+        })
+        -- Lua-authored system appended afterward.
+        local Marker = IRComponent.register("AppendMarker", { dummy = 0 })
+        local luaSys = IRSystem.registerSystem({
+            name = "AppendedLuaSys",
+            components = { Marker },
+            tick = function(arch) end,
+        })
+        IRSystem.appendSystem(IRTime.UPDATE, luaSys)
+        return luaSys
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+    const auto luaSys = static_cast<IRSystem::SystemId>(result.get<lua_Integer>());
+
+    // The pre-built C++ system survived AND the Lua system was appended.
+    const auto &groups = m_system_manager.getPipelineGroups(IRTime::Events::UPDATE);
+    ASSERT_EQ(groups.size(), 2u);
+    ASSERT_EQ(groups[0].size(), 1u);
+    ASSERT_EQ(groups[1].size(), 1u);
+    EXPECT_EQ(groups[0][0], lifetime);
+    EXPECT_EQ(groups[1][0], luaSys);
+}
+
+TEST_F(LuaPipelineRegisterTest, AppendedLuaSystemTicksAlongsidePreBuiltPipeline) {
+    // Prove the appended Lua system actually RUNS in the live pipeline —
+    // not just that the group structure looks right. A Lua global is
+    // bumped once per archetype tick of the appended system.
+    m_lua.registerPrefabSystem<IRSystem::LIFETIME>();
+    auto &lua = m_lua.lua();
+    lua["g_appendTickCount"] = 0;
+
+    auto setup = lua.safe_script(
+        R"(
+        Marker = IRComponent.register("AppendTickMarker", { dummy = 0 })
+        IRSystem.registerPipeline(IRTime.UPDATE, {
+            IRSystem.systemId(IRSystem.SystemName.LIFETIME),
+        })
+        local sys = IRSystem.registerSystem({
+            name = "AppendTickSys",
+            components = { Marker },
+            tick = function(arch)
+                g_appendTickCount = g_appendTickCount + 1
+            end,
+        })
+        IRSystem.appendSystem(IRTime.UPDATE, sys)
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(setup.valid()) << sol::error{setup}.what();
+
+    // An entity in the Marker archetype so the appended system body fires.
+    const EntityId entity = IREntity::createEntity(C_Modifiers{});
+    lua["g_entity"] = static_cast<lua_Integer>(entity);
+    auto attach = lua.safe_script(
+        "IREntity.addLuaComponent(LuaEntity.new(g_entity), Marker)",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(attach.valid()) << sol::error{attach}.what();
+
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_EQ(lua["g_appendTickCount"].get<int>(), 1);
+}
+
+TEST_F(LuaPipelineRegisterTest, InsertSystemBeforeViaLuaPlacesGroup) {
+    const IRSystem::SystemId lifetime = m_lua.registerPrefabSystem<IRSystem::LIFETIME>();
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        R"(
+        IRSystem.registerPipeline(IRTime.UPDATE, {
+            IRSystem.systemId(IRSystem.SystemName.LIFETIME),
+        })
+        local Marker = IRComponent.register("InsertMarker", { dummy = 0 })
+        local luaSys = IRSystem.registerSystem({
+            name = "InsertedLuaSys",
+            components = { Marker },
+            tick = function(arch) end,
+        })
+        IRSystem.insertSystemBefore(IRTime.UPDATE, luaSys,
+            IRSystem.systemId(IRSystem.SystemName.LIFETIME))
+        return luaSys
+    )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << sol::error{result}.what();
+    const auto luaSys = static_cast<IRSystem::SystemId>(result.get<lua_Integer>());
+
+    const auto &groups = m_system_manager.getPipelineGroups(IRTime::Events::UPDATE);
+    ASSERT_EQ(groups.size(), 2u);
+    EXPECT_EQ(groups[0][0], luaSys); // inserted before the prefab system
+    EXPECT_EQ(groups[1][0], lifetime);
+}
+
+TEST_F(LuaPipelineRegisterTest, AppendSystemRejectsInvalidEvent) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script("IRSystem.appendSystem(999, 0)", sol::script_pass_on_error);
+    EXPECT_FALSE(result.valid());
+}
+
 } // namespace

--- a/test/system/pipeline_groups_test.cpp
+++ b/test/system/pipeline_groups_test.cpp
@@ -254,4 +254,99 @@ TEST_F(PipelineGroupsValidatorTest, RegisterPipelineProducesSingletonGroups) {
     EXPECT_EQ(groups[1][0], sysB);
 }
 
+// ----------------------------------------------------------------------
+// #1540 — appendToPipeline / insertIntoPipeline (compose onto a live
+// pipeline without replacing it)
+// ----------------------------------------------------------------------
+
+TEST_F(PipelineGroupsValidatorTest, AppendToPipelineAddsSingletonGroupAtEnd) {
+    auto preBuilt = IRSystem::createSystem<C_VelA>("PreBuiltA", [](C_VelA &) {});
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {preBuilt});
+    auto appended = IRSystem::createSystem<C_VelB>("AppendedB", [](C_VelB &) {});
+    m_system_manager.appendToPipeline(IRTime::Events::UPDATE, appended);
+
+    const auto &groups = m_system_manager.getPipelineGroups(IRTime::Events::UPDATE);
+    ASSERT_EQ(groups.size(), 2u);
+    ASSERT_EQ(groups[0].size(), 1u);
+    ASSERT_EQ(groups[1].size(), 1u);
+    EXPECT_EQ(groups[0][0], preBuilt); // pre-built system preserved, not replaced
+    EXPECT_EQ(groups[1][0], appended); // new system at the end
+}
+
+TEST_F(PipelineGroupsValidatorTest, AppendToEmptyEventCreatesFirstGroup) {
+    auto sys = IRSystem::createSystem<C_VelA>("LoneAppend", [](C_VelA &) {});
+    m_system_manager.appendToPipeline(IRTime::Events::UPDATE, sys);
+    const auto &groups = m_system_manager.getPipelineGroups(IRTime::Events::UPDATE);
+    ASSERT_EQ(groups.size(), 1u);
+    ASSERT_EQ(groups[0].size(), 1u);
+    EXPECT_EQ(groups[0][0], sys);
+}
+
+TEST_F(PipelineGroupsValidatorTest, AppendedSystemRunsAlongsidePreBuiltPipeline) {
+    // The #1540 acceptance case: a "pre-built" pipeline (the analog of a
+    // C++ initSystems()) plus a system appended afterward — both must
+    // tick. Proves append does NOT wipe the existing systems the way
+    // registerPipeline would.
+    auto preBuilt = IRSystem::createSystem<C_VelA>("Pre", [](C_VelA &v) { v.n_ += 1; });
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {preBuilt});
+    auto appended = IRSystem::createSystem<C_VelB>("Post", [](C_VelB &v) { v.m_ += 1; });
+    m_system_manager.appendToPipeline(IRTime::Events::UPDATE, appended);
+
+    const auto entity = IREntity::createEntity(C_VelA{0}, C_VelB{0});
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_EQ(IREntity::getComponent<C_VelA>(entity).n_, 1); // pre-built ran
+    EXPECT_EQ(IREntity::getComponent<C_VelB>(entity).m_, 1); // appended ran
+}
+
+TEST_F(PipelineGroupsValidatorTest, AppendDuplicateSystemAsserts) {
+    auto sys = IRSystem::createSystem<C_VelA>("DupA", [](C_VelA &) {});
+    m_system_manager.appendToPipeline(IRTime::Events::UPDATE, sys);
+    // A second append would tick the same system twice per frame.
+    EXPECT_THROW(
+        m_system_manager.appendToPipeline(IRTime::Events::UPDATE, sys),
+        std::runtime_error
+    );
+}
+
+TEST_F(PipelineGroupsValidatorTest, InsertBeforeAndAfterPlaceSingletonGroups) {
+    auto a = IRSystem::createSystem<C_VelA>("InsA", [](C_VelA &) {});
+    auto b = IRSystem::createSystem<C_VelB>("InsB", [](C_VelB &) {});
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {a, b});
+
+    auto before = IRSystem::createSystem<C_VelA>("InsBefore", [](C_VelA &) {});
+    m_system_manager.insertIntoPipelineBefore(IRTime::Events::UPDATE, before, b);
+    auto after = IRSystem::createSystem<C_VelB>("InsAfter", [](C_VelB &) {});
+    m_system_manager.insertIntoPipelineAfter(IRTime::Events::UPDATE, after, b);
+
+    // Resulting order: a, before, b, after.
+    const auto &groups = m_system_manager.getPipelineGroups(IRTime::Events::UPDATE);
+    ASSERT_EQ(groups.size(), 4u);
+    EXPECT_EQ(groups[0][0], a);
+    EXPECT_EQ(groups[1][0], before);
+    EXPECT_EQ(groups[2][0], b);
+    EXPECT_EQ(groups[3][0], after);
+}
+
+TEST_F(PipelineGroupsValidatorTest, InsertWithMissingAnchorAsserts) {
+    auto a = IRSystem::createSystem<C_VelA>("AnchorA", [](C_VelA &) {});
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {a});
+    auto orphan = IRSystem::createSystem<C_VelB>("Orphan", [](C_VelB &) {});
+    auto notInPipeline = IRSystem::createSystem<C_VelB>("Ghost", [](C_VelB &) {});
+    EXPECT_THROW(
+        m_system_manager.insertIntoPipelineBefore(IRTime::Events::UPDATE, orphan, notInPipeline),
+        std::runtime_error
+    );
+}
+
+TEST_F(PipelineGroupsValidatorTest, InsertWithNoPipelineForEventAsserts) {
+    auto sys = IRSystem::createSystem<C_VelA>("NoPipeSys", [](C_VelA &) {});
+    auto anchor = IRSystem::createSystem<C_VelB>("NoPipeAnchor", [](C_VelB &) {});
+    // RENDER never had a pipeline registered in this fixture.
+    EXPECT_THROW(
+        m_system_manager.insertIntoPipelineAfter(IRTime::Events::RENDER, sys, anchor),
+        std::runtime_error
+    );
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
- `registerPipeline` / `registerPipelineGroups` **replace** an event's whole system list — wrong for a runtime whose C++ pipeline is built before the script runs (the midi runtime's `initSystems()` runs before `main.lua`), where a second `registerPipeline` from Lua wipes the already-registered C++ systems and re-listing double-creates named GPU resources.
- Adds composition primitives that add **one** system onto the existing pipeline as its own serial group without disturbing it: `SystemManager::appendToPipeline` + `insertIntoPipelineBefore`/`After`, the `IRSystem::` free-function forwarders, and the Lua surface `IRSystem.appendSystem` / `insertSystemBefore` / `insertSystemAfter`.
- Each guards against a double-add (would tick the system twice per frame); the insert forms assert on a missing anchor. A new singleton group needs no cross-system validation (the validator skips size-1 groups).
- Documents the surface in `engine/system/CLAUDE.md` ("Appending to a live pipeline") and `engine/script/CLAUDE.md` ("Pipeline composition").

## Test plan
- [x] `test/system/pipeline_groups_test.cpp` — append/insert structure, append-runs-alongside-prebuilt execution, duplicate/missing-anchor/no-pipeline asserts.
- [x] `test/script/lua_pipeline_register_test.cpp` — `appendSystem` composes onto a pre-built (C++ prefab `LIFETIME`) pipeline, appended Lua system ticks in the live pipeline, `insertSystemBefore` placement, invalid-event rejection.
- [x] `fleet-build --target IrredenEngineTest` clean; all new + existing pipeline/system/script suites green (82 tests).

Closes #1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)