### PR TITLE
fleet: gate cross-repo Blocked-by refs against the referenced repo (#1522)

### DIFF
--- a/docs/agents/skills/file-epic.md
+++ b/docs/agents/skills/file-epic.md
@@ -141,10 +141,12 @@ rm -f .file-epic-body.md
 > The scout, `fleet-claim`, and `fleet-queue-ingest` recognize only `(none)`
 > and `#N` (plus merged-PR URLs). Free-text like `none — first unblocked` is
 > read as an unresolved *prose* blocker, so the ticket is held out of the
-> queue forever and every child that chains off it stalls too. Cross-repo
-> dependencies are NOT auto-gated yet (the gate checks only the issue's own
-> repo): keep `Blocked by:` to same-repo `#N`/`(none)` and record any
-> cross-repo dependency as prose under `## Dependencies`.
+> queue forever and every child that chains off it stalls too. A cross-repo
+> dependency is machine-gated too — qualify the ref with its repo:
+> `**Blocked by:** jakildev/IrredenEngine#1476` (the bare `IrredenEngine#1476`
+> or `irreden#125` form also works). All three tools route the qualified ref's
+> state check to the *referenced* repo (#1522); a bare `#N` still resolves
+> against the issue's own repo.
 
 Then file:
 

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -545,29 +545,47 @@ if field_value is None:
 if field_value.lower().startswith("(none"):
     sys.exit(0)
 
-# Extract referenced issue numbers (#N) and PR URLs.
-issue_refs = re.findall(r"#(\d+)", field_value)
+# Extract referenced issue numbers and PR URLs. A `#N` may carry an optional
+# `[owner/]Repo#N` qualifier — route its live state check to the *referenced*
+# repo so a cross-repo dependency resolves against the right repo, not the
+# issue's own (#1522). Bare / unrecognized refs default to this issue's repo.
+_REF_NAME_TO_SLUG = {"irredenengine": "jakildev/IrredenEngine",
+                     "irreden": "jakildev/irreden"}
+
+
+def _ref_repo(name):
+    if name:
+        return _REF_NAME_TO_SLUG.get(name.lower(), repo)
+    return repo
+
+
+qual_ref_re = re.compile(r"(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)")
+issue_refs = [(_ref_repo(m.group(1)), m.group(2))
+              for m in qual_ref_re.finditer(field_value)]
 pr_urls = re.findall(r"https://github\.com/[^\s,)]+/pull/\d+", field_value)
 
 failed = []
 
-for ref in issue_refs:
-    if ref in skip_ids:
+for ref_repo_slug, ref in issue_refs:
+    # skip_ids are intra-stack issue numbers in *this* repo — only satisfy a
+    # same-repo ref, never a cross-repo number collision.
+    if ref_repo_slug == repo and ref in skip_ids:
         continue
-    if not repo:
+    if not ref_repo_slug:
         continue
+    disp = f"#{ref}" if ref_repo_slug == repo else f"{ref_repo_slug}#{ref}"
     try:
         r = subprocess.run(
-            ["gh", "issue", "view", ref, "--repo", repo,
+            ["gh", "issue", "view", ref, "--repo", ref_repo_slug,
              "--json", "state", "--jq", ".state"],
             capture_output=True, text=True, timeout=10,
         )
     except (subprocess.SubprocessError, OSError) as e:
-        failed.append(f"#{ref} (check failed: {e})")
+        failed.append(f"{disp} (check failed: {e})")
         continue
     state = (r.stdout or "").strip()
     if state not in ("CLOSED", "MERGED"):
-        failed.append(f"#{ref} (state: {state or 'unknown'}, need: CLOSED or MERGED)")
+        failed.append(f"{disp} (state: {state or 'unknown'}, need: CLOSED or MERGED)")
 
 for url in pr_urls:
     try:

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -209,7 +209,28 @@ BLOCKED_INLINE_RE = re.compile(r'\*\*(?:Suggested\s+)?Blocked by:\s+(.+?)\*\*', 
 # don't warn "treat as unblocked" for an issue whose blocker lives only in a
 # header (#1326). Only count prose that names a #N or PR reference.
 BLOCKED_ON_RE = re.compile(r'(?im)^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$')
-REF_RE = re.compile(r'#(\d+)')
+# A blocker ref may carry an optional `[owner/]Repo#N` qualifier pointing at
+# another repo (game #125 → `jakildev/IrredenEngine#1476`). group(1) is the
+# repo name (None/empty for a bare same-repo ref); group(2) is the number.
+# Kept consistent with fleet-state-scout._parse_blocker_refs and fleet-claim's
+# check_blockers. (#1522)
+REF_RE = re.compile(r'(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)')
+# Repo-name qualifier (case-insensitive, owner stripped) → GitHub slug.
+_REF_NAME_TO_SLUG = {'irredenengine': 'jakildev/IrredenEngine',
+                     'irreden': 'jakildev/irreden'}
+
+
+def _ref_slug(name, default_repo):
+    if name:
+        return _REF_NAME_TO_SLUG.get(name.lower(), default_repo)
+    return default_repo
+
+
+def _qual_refs(text, default_repo):
+    """(slug, number) pairs for every #N in text, routing each cross-repo ref
+    to the slug named by its `[owner/]Repo#N` qualifier (#1522)."""
+    return [(_ref_slug(m.group(1), default_repo), m.group(2))
+            for m in REF_RE.finditer(text or '')]
 
 
 def _has_header_blocker(text):
@@ -220,24 +241,27 @@ def _has_header_blocker(text):
     return False
 
 
-def _blocker_refs(body):
-    """All `#N` predecessor refs from canonical `**Blocked by:** #N` lines, the
-    inline-bold `**Blocked by: #N**` form, and `Blocked on` header prose.
-    Mirrors fleet-state-scout._parse_blocked_by so the gate reads the same refs
-    the scout and fleet-claim do. `(none)` values contribute nothing."""
+def _blocker_refs(body, default_repo):
+    """(slug, number) pairs for every `#N` predecessor — from canonical
+    `**Blocked by:** #N` lines, the inline-bold `**Blocked by: #N**` form, and
+    `Blocked on` header prose. Each ref is routed to the repo named by an
+    optional `[owner/]Repo#N` qualifier, defaulting to default_repo (the
+    child's own repo). Mirrors fleet-state-scout._parse_blocked_by so the gate
+    reads the same refs the scout and fleet-claim do. `(none)` values
+    contribute nothing."""
     vals = [m.group(1) for m in BLOCKED_RE.finditer(body)]
     vals += BLOCKED_INLINE_RE.findall(body)
     real = [v.strip() for v in vals if not v.strip().lower().startswith('(none')]
     refs = []
     for v in real:
-        refs.extend(REF_RE.findall(v))
+        refs.extend(_qual_refs(v, default_repo))
     if refs:
         return refs
     # No canonical/inline #N refs → fall back to a `Blocked on …` header.
     for m in BLOCKED_ON_RE.finditer(body):
         cand = m.group(1).strip().strip('*').strip()
         if cand and ('#' in cand or re.search(r'\bPR\b', cand, re.IGNORECASE)):
-            refs.extend(REF_RE.findall(cand))
+            refs.extend(_qual_refs(cand, default_repo))
     return refs
 
 
@@ -312,8 +336,8 @@ for issue in pending:
     # yet" signal that the unblock pass below removes once the last blocker
     # closes. The live re-check is authoritative — it's the only blocker gate
     # when ingest runs against a hand-built projection (tests, manual run).
-    open_blockers = [ref for ref in _blocker_refs(body)
-                     if _blocker_open(repo, ref, blocker_cache)]
+    open_blockers = [(slug, ref) for slug, ref in _blocker_refs(body, repo)
+                     if _blocker_open(slug, ref, blocker_cache)]
 
     # Parse model from body. Default to fleet:opus on ambiguity — mirrors
     # the safer default when model intent is unclear.
@@ -335,7 +359,8 @@ for issue in pending:
         add_labels.append(model_label)
     if open_blockers and 'fleet:blocked' not in labels:
         add_labels.append('fleet:blocked')
-        joined = ', '.join(f'#{r}' for r in open_blockers)
+        joined = ', '.join((f'#{ref}' if slug == repo else f'{slug}#{ref}')
+                           for slug, ref in open_blockers)
         print(f'INFO issue {repo}#{n}: queuing with fleet:blocked '
               f'(blocked by open {joined})', file=sys.stderr)
 
@@ -381,8 +406,8 @@ for issue in data.get('unblock_issues', []):
     if 'fleet:blocked' not in labels:
         continue
     body = view.get('body', '') or ''
-    open_blockers = [ref for ref in _blocker_refs(body)
-                     if _blocker_open(repo, ref, blocker_cache)]
+    open_blockers = [(slug, ref) for slug, ref in _blocker_refs(body, repo)
+                     if _blocker_open(slug, ref, blocker_cache)]
     if open_blockers:
         unblock_still += 1
         continue  # still genuinely blocked — leave the marker

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -884,11 +884,31 @@ def _blocker_pr_files(repo_key, pr_number):
 # collect_state() and updates each task's blocked_by in place to only
 # contain references that are still genuinely unresolved.
 
-_BLOCKER_REF_RE = re.compile(r"#(\d+)")
+# A blocker ref may carry an optional `[owner/]Repo#N` qualifier pointing at
+# another repo (game #125 → `jakildev/IrredenEngine#1476`). group(1) is the
+# repo name (None / empty for a bare same-repo `#N`); group(2) is the number.
+# Kept consistent with fleet-claim's check_blockers and
+# fleet-queue-ingest._blocker_refs parsers. (#1522)
+_BLOCKER_REF_RE = re.compile(r"(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)")
 _REPO_SLUG_MAP = {
     "engine": "jakildev/IrredenEngine",
     "game": "jakildev/irreden",
 }
+# Repo-name qualifier (case-insensitive, owner stripped) → canonical repo key.
+_REPO_NAME_TO_KEY = {"irredenengine": "engine", "irreden": "game"}
+
+
+def _parse_blocker_refs(raw, default_key):
+    """(repo_key, number) for every #N in a raw **Blocked by:** value, routing
+    each ref to the repo named by its optional `[owner/]Repo#N` qualifier. A
+    bare ref or an unrecognized qualifier falls back to default_key — the
+    issue's own repo. (#1522)"""
+    refs = []
+    for m in _BLOCKER_REF_RE.finditer(raw or ""):
+        name = m.group(1)
+        key = _REPO_NAME_TO_KEY.get(name.lower(), default_key) if name else default_key
+        refs.append((key, m.group(2)))
+    return refs
 
 
 def _resolve_ref_satisfied(repo_slug, ref_str, cache):
@@ -940,12 +960,18 @@ def resolve_blocked_by(state):
             raw = (task.get("blocked_by") or "").strip()
             if not raw or raw.lower().startswith("(none"):
                 continue
-            refs = _BLOCKER_REF_RE.findall(raw)
+            refs = _parse_blocker_refs(raw, repo_key)
             if not refs:
                 continue  # free-text or PR-URL form — leave unchanged
 
             unresolved = []
-            for ref in refs:
+            for ref_key, ref in refs:
+                if ref_key != repo_key:
+                    # Cross-repo blocker — the scout's window only covers this
+                    # repo, so it can't resolve the ref here. Don't surface it
+                    # as blocked; fleet-claim's check_blockers (routed to the
+                    # referenced repo) is the authoritative pickup gate. (#1522)
+                    continue
                 if ref in closed_nums:
                     continue
                 if any(branch_matches_issue(h, ref, repo_key) for h in merged_heads):
@@ -998,14 +1024,19 @@ def resolve_human_approved_blockers(state):
             raw = _parse_blocked_by(body)
             if not raw:
                 continue
-            refs = _BLOCKER_REF_RE.findall(raw)
+            refs = _parse_blocker_refs(raw, repo_key)
             if not refs:
                 # Blocker named only as prose / a PR URL with no resolvable #N
                 # (e.g. "Blocked on the redesign"). Hold the child out of the
                 # trigger set — matches resolve_blocked_by leaving it blocked.
                 issue["blocked"] = True
                 continue
-            for ref in refs:
+            for ref_key, ref in refs:
+                if ref_key != repo_key:
+                    # Cross-repo blocker: unresolvable from this repo's window.
+                    # Defer to fleet-queue-ingest's live cross-repo check rather
+                    # than blocking forever (this froze game #125 out — #1522).
+                    continue
                 if ref in closed_nums:
                     continue
                 if any(branch_matches_issue(h, ref, repo_key) for h in merged_heads):

--- a/scripts/fleet/tests/test_fleet_claim_blockers.sh
+++ b/scripts/fleet/tests/test_fleet_claim_blockers.sh
@@ -29,6 +29,9 @@
 #     form, which accepts MERGED only — if abandoned-PR refs ever need to
 #     fail the gate, the `#N` branch in fleet-claim.check_blockers needs
 #     to differentiate PR-state CLOSED from issue-state CLOSED.)
+#   - cross-repo ref `[owner/]Repo#N`, CLOSED in the referenced repo → pass;
+#     still OPEN in the referenced repo → fail (#1522 — the gate routes the
+#     state probe to the referenced repo, not the issue's own).
 
 set -euo pipefail
 
@@ -92,14 +95,18 @@ cat >"$STUB_DIR/gh" <<'GHSTUB'
 has_jq=0
 issue_num=""
 pr_url=""
+repo=""        # captured from `--repo R` so cross-repo refs (#1522) can be
+prev=""        # routed-checked: the same #N resolves differently per repo.
 for arg in "$@"; do
     [[ "$arg" == "--jq" ]] && has_jq=1
+    [[ "$prev" == "--repo" ]] && repo="$arg"
     if [[ -z "$issue_num" && "$arg" =~ ^[0-9]+$ ]]; then
         issue_num="$arg"
     fi
     if [[ -z "$pr_url" && "$arg" == https://github.com/*/pull/* ]]; then
         pr_url="$arg"
     fi
+    prev="$arg"
 done
 
 case "$1 $2" in
@@ -112,6 +119,15 @@ case "$1 $2" in
                 200) echo "MERGED" ;;   # PR, merged
                 201) echo "OPEN" ;;     # PR, still open
                 202) echo "CLOSED" ;;   # PR, abandoned (closed without merge)
+                125)
+                    # #1522 cross-repo routing probe: CLOSED only when the check
+                    # is routed to the *game* repo (the referenced repo); OPEN
+                    # if it's mis-routed to the issue's own (engine) repo.
+                    case "$repo" in
+                        jakildev/irreden) echo "CLOSED" ;;
+                        *)                 echo "OPEN" ;;
+                    esac ;;
+                126) echo "OPEN" ;;     # cross-repo (game) ref, still open
                 *)   echo "OPEN" ;;
             esac
             exit 0
@@ -185,6 +201,16 @@ case "$1 $2" in
             2016)
                 # #1423: inline-bold form with no #N/PR ref — must not gate.
                 printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"**Part of epic:** #104 · **Blocked by: the redesign**\n"}'
+                ;;
+            2017)
+                # #1522: cross-repo blocker in another repo (owner-qualified),
+                # CLOSED there → claim succeeds once routed to the right repo.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"**Blocked by:** jakildev/irreden#125\n"}'
+                ;;
+            2018)
+                # #1522: cross-repo blocker (bare repo qualifier), still OPEN in
+                # the referenced repo → claim fails.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"**Blocked by:** irreden#126\n"}'
                 ;;
             *)
                 printf '%s' '{"state":"OPEN","labels":[],"body":""}'
@@ -340,6 +366,20 @@ echo "T16: inline-bold 'Blocked by: the redesign' (no ref) → claim succeeds"
 actual=0; "$FLEET_CLAIM" claim 2016 test-agent 2>/dev/null || actual=$?
 assert_exit "$actual" 0 "inline-bold no-ref bypasses gate → exit 0"
 release_quiet 2016
+
+# --- T17: cross-repo blocker, CLOSED in the referenced repo → succeeds (#1522)
+# The same #125 reads OPEN in engine but CLOSED in game; the gate must route
+# `jakildev/irreden#125` to game (where it's CLOSED) and let the claim through.
+# Before #1522 it checked engine (OPEN) and froze the task out forever.
+echo "T17: cross-repo 'jakildev/irreden#125' CLOSED in game → claim succeeds"
+actual=0; "$FLEET_CLAIM" claim 2017 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "cross-repo game#125 CLOSED → exit 0 (routed to game, not engine)"
+release_quiet 2017
+
+# --- T18: cross-repo blocker, still OPEN in the referenced repo → fails (#1522)
+echo "T18: cross-repo 'irreden#126' OPEN in game → claim fails"
+actual=0; "$FLEET_CLAIM" claim 2018 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "cross-repo game#126 OPEN → exit 1"
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh
@@ -37,13 +37,18 @@ mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
 PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
 # Add path: a stacked epic. #730 = head (no blocker), #731 = blocked by an OPEN
 # predecessor (#719), #732 = blocked by a CLOSED predecessor (#718).
+# Cross-repo (#1522): #735 = engine task blocked by a CLOSED game ref
+# (jakildev/irreden#777) → routed to game, not blocked; #736 = engine task
+# blocked by an OPEN game ref (jakildev/irreden#778) → blocked.
 # Remove path: #733 = queued+fleet:blocked, blocker #717 now CLOSED (unblock);
 #              #734 = queued+fleet:blocked, blocker #719 still OPEN (stay).
 cat > "$PROJ" <<'JSON'
 {"pending_issues":[
   {"number":730,"repo":"engine"},
   {"number":731,"repo":"engine"},
-  {"number":732,"repo":"engine"}
+  {"number":732,"repo":"engine"},
+  {"number":735,"repo":"engine"},
+  {"number":736,"repo":"engine"}
 ],"unblock_issues":[
   {"number":733,"repo":"engine"},
   {"number":734,"repo":"engine"}
@@ -63,10 +68,24 @@ case "$1" in
                 # Blocker-state probes pass `--jq .state`; the body/labels fetch
                 # asks for `--json body,labels`. Dispatch on which one this is.
                 if [[ "$*" == *"--jq"* ]]; then
+                    # Capture the --repo value so cross-repo refs (#1522) resolve
+                    # against the referenced repo, not the issue's own.
+                    bref_repo=""; bprev=""
+                    for ba in "$@"; do
+                        [[ "$bprev" == "--repo" ]] && bref_repo="$ba"; bprev="$ba"
+                    done
                     case "$3" in
                         717) echo "CLOSED" ;;   # #733's predecessor — satisfied
                         718) echo "CLOSED" ;;   # #732's predecessor — satisfied
                         719) echo "OPEN" ;;     # #731/#734's predecessor — open
+                        777)
+                            # #1522: CLOSED only when routed to game (the
+                            # referenced repo); OPEN if mis-routed to engine.
+                            case "$bref_repo" in
+                                jakildev/irreden) echo "CLOSED" ;;
+                                *)                 echo "OPEN" ;;
+                            esac ;;
+                        778) echo "OPEN" ;;     # cross-repo game ref, still open
                         *)   echo "OPEN" ;;
                     esac
                     exit 0
@@ -77,6 +96,8 @@ case "$1" in
                     732) echo '{"body":"**Model:** opus\n**Blocked by:** #718","labels":[{"name":"human:approved"}]}' ;;
                     733) echo '{"body":"**Blocked by:** #717","labels":[{"name":"fleet:queued"},{"name":"fleet:opus"},{"name":"fleet:blocked"}]}' ;;
                     734) echo '{"body":"**Blocked by:** #719","labels":[{"name":"fleet:queued"},{"name":"fleet:opus"},{"name":"fleet:blocked"}]}' ;;
+                    735) echo '{"body":"**Model:** opus\n**Blocked by:** jakildev/irreden#777","labels":[{"name":"human:approved"}]}' ;;
+                    736) echo '{"body":"**Model:** opus\n**Blocked by:** jakildev/irreden#778","labels":[{"name":"human:approved"}]}' ;;
                     *)   echo '{"body":"","labels":[]}' ;;
                 esac
                 exit 0 ;;
@@ -129,6 +150,24 @@ else
     bad "#731 not queued-with-marker as expected: '$l731'"
 fi
 
+# --- Cross-repo routing (#1522) -------------------------------------------
+# #735 (cross-repo blocker game#777 CLOSED) → routed to game → NO fleet:blocked.
+# If the gate mis-routed to engine, #777 would read OPEN and stamp fleet:blocked.
+l735=$(edit_line 735)
+if [[ -n "$l735" && "$l735" == *"fleet:queued"* && "$l735" != *"fleet:blocked"* ]]; then
+    ok "#735 cross-repo blocker (game#777 CLOSED) routed to game → no fleet:blocked"
+else
+    bad "#735 cross-repo routing wrong (expected queued, no marker): '$l735'"
+fi
+
+# #736 (cross-repo blocker game#778 OPEN) → routed to game → fleet:blocked.
+l736=$(edit_line 736)
+if [[ -n "$l736" && "$l736" == *"fleet:queued"* && "$l736" == *"fleet:blocked"* ]]; then
+    ok "#736 cross-repo blocker (game#778 OPEN) → fleet:queued + fleet:blocked"
+else
+    bad "#736 cross-repo open blocker not marked: '$l736'"
+fi
+
 # --- Remove path ----------------------------------------------------------
 # #733 (blocker #717 now CLOSED) → fleet:blocked removed.
 l733=$(edit_line 733)
@@ -147,11 +186,12 @@ else
 fi
 
 # --- Read-only blocker invariant -----------------------------------------
-# The blocker issues themselves must never be edited (we only read their state).
-if grep -qE '(^| )edit (717|718|719)( |$)' "$EDIT_LOG"; then
-    bad "a blocker issue (#717/#718/#719) was edited — must only READ blocker state"
+# The blocker issues themselves must never be edited (we only read their state),
+# including the cross-repo blockers #777/#778 (#1522).
+if grep -qE '(^| )edit (717|718|719|777|778)( |$)' "$EDIT_LOG"; then
+    bad "a blocker issue (#717/#718/#719/#777/#778) was edited — must only READ blocker state"
 else
-    ok "blocker issues #717/#718/#719 were never edited (read-only state probe)"
+    ok "blocker issues #717/#718/#719/#777/#778 were never edited (read-only state probe)"
 fi
 
 echo

--- a/scripts/fleet/tests/test_live_blocker_resolution.py
+++ b/scripts/fleet/tests/test_live_blocker_resolution.py
@@ -221,5 +221,56 @@ class TestResolveAndEnrichIntegration(unittest.TestCase):
         self.assertNotIn("stackable_blocker_pr", state["repos"]["engine"]["tasks"]["open"][0])
 
 
+# ---------------------------------------------------------------------------
+# Part (c) — cross-repo blocker refs (#1522)
+# ---------------------------------------------------------------------------
+
+class TestCrossRepoBlocker(unittest.TestCase):
+    """#1522: a blocker in a *different* repo can't be resolved from this
+    repo's scout window, so resolve_blocked_by() defers it (treats it as
+    non-blocking). fleet-claim's check_blockers, routed to the referenced
+    repo, is the authoritative pickup gate. Mirrors the real game#125 →
+    IrredenEngine#1476 case, repo-flipped to the engine-only test state."""
+
+    def test_cross_repo_owner_qualified_ref_deferred(self):
+        # Even though the cross-repo ref reads OPEN, the scout never queries it
+        # (no gh routed here) and must not block on it.
+        tasks = [_task("#200", "jakildev/irreden#125")]
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"125": "OPEN"})):
+            state = _state(engine_tasks=tasks)
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "(none)")
+
+    def test_cross_repo_bare_repo_qualifier_deferred(self):
+        # `irreden#N` (no owner prefix) routes to game too.
+        tasks = [_task("#200", "irreden#125")]
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"125": "OPEN"})):
+            state = _state(engine_tasks=tasks)
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "(none)")
+
+    def test_cross_repo_plus_open_same_repo_keeps_same_repo(self):
+        tasks = [_task("#200", "#101, jakildev/irreden#125")]
+        with patch.object(_mod.subprocess, "run",
+                          _gh_state_stub({"101": "OPEN", "125": "OPEN"})):
+            state = _state(engine_tasks=tasks)
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "#101")
+
+    def test_same_repo_qualifier_resolves_in_repo(self):
+        # `IrredenEngine#N` on an engine task is a self-ref → in-memory resolve.
+        tasks = [_task("#200", "IrredenEngine#100")]
+        state = _state(engine_tasks=tasks, closed=[_closed_issue(100)])
+        resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "(none)")
+
+    def test_same_repo_qualifier_open_stays_blocked(self):
+        tasks = [_task("#200", "IrredenEngine#101")]
+        with patch.object(_mod.subprocess, "run", _gh_state_stub({"101": "OPEN"})):
+            state = _state(engine_tasks=tasks)
+            resolve_blocked_by(state)
+        self.assertEqual(tasks[0]["blocked_by"], "#101")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/fleet/tests/test_queue_manager_projection.py
+++ b/scripts/fleet/tests/test_queue_manager_projection.py
@@ -276,6 +276,38 @@ class IngestHonorsBlockedBy(unittest.TestCase):
         ])
         self.assertTrue(st["repos"]["engine"]["human_approved"][0]["blocked"])
 
+    def test_cross_repo_blocker_does_not_block(self):
+        # #1522: a blocker in a *different* repo is unresolvable from this
+        # repo's window — the scout must defer (treat as non-blocking) rather
+        # than block forever. Mirrors game#125 → IrredenEngine#1476, flipped.
+        st = self._resolved(human_approved=[
+            {"number": 820, "title": "child", "labels": ["human:approved"],
+             "body": "**Model:** opus\n**Blocked by:** jakildev/irreden#125"},
+        ])
+        self.assertFalse(st["repos"]["engine"]["human_approved"][0]["blocked"],
+                         "cross-repo blocker must defer to ingest, not block")
+
+    def test_same_repo_qualified_blocker_still_blocks(self):
+        # `IrredenEngine#N` on an engine child names the issue's *own* repo —
+        # the qualifier must resolve via the in-memory same-repo path, so an
+        # open predecessor still blocks (#1522 must not turn self-refs into
+        # defers).
+        st = self._resolved(human_approved=[
+            {"number": 821, "title": "child", "labels": ["human:approved"],
+             "body": "**Blocked by:** IrredenEngine#800"},
+        ])
+        self.assertTrue(st["repos"]["engine"]["human_approved"][0]["blocked"])
+
+    def test_same_repo_qualified_blocker_clears_when_closed(self):
+        st = self._resolved(
+            human_approved=[
+                {"number": 822, "title": "child", "labels": ["human:approved"],
+                 "body": "**Blocked by:** IrredenEngine#800"},
+            ],
+            closed=[{"number": 800, "title": "head"}],
+        )
+        self.assertFalse(st["repos"]["engine"]["human_approved"][0]["blocked"])
+
     def test_blocked_child_included_in_projection_and_slice(self):
         # #1527: blocked children are now ingestion targets — they get queued
         # up front (fleet:queued + model + fleet:blocked), so both head AND


### PR DESCRIPTION
## Summary
- The Blocked-by gate resolved every `#N` ref against the issue's **own** repo, so a cross-repo dependency was never satisfied. Game #125's `Blocked by: jakildev/IrredenEngine#1476` (closed) stayed `blocked=True` forever and was frozen out of the queue (worked around live by editing its body to `(none)`).
- Ref parser in `fleet-state-scout`, `fleet-claim`, and `fleet-queue-ingest` now captures an optional `[owner/]Repo#N` qualifier (`IrredenEngine`→engine, `irreden`→game; bare/unknown → the issue's own repo). The three parsers stay mirrored (separate processes, can't share a module — same `kept consistent` convention as before).
- The two authoritative **live** gates route per-ref: `fleet-claim.check_blockers` (task pickup) and `fleet-queue-ingest._blocker_open` (queue stamp) now `gh issue view <ref> --repo <referenced-repo>`.
- The scout's in-memory projections (`resolve_blocked_by`, `resolve_human_approved_blockers`) can't resolve another repo from their own bounded window, so they **defer** cross-repo refs (treat as non-blocking) to those live gates rather than blocking permanently. Same-repo resolution is byte-for-byte unchanged.
- Updated the `file-epic` author guidance: cross-repo deps are now machine-gated via the qualified form (supersedes the #1521 "record as prose until this lands" interim).

## Test plan
- [x] `test_live_blocker_resolution.py` (19) — added cross-repo defer + same-repo-qualifier cases
- [x] `test_queue_manager_projection.py` (30) — added cross-repo defer + same-repo-qualifier cases
- [x] `test_fleet_claim_blockers.sh` (18) — T17/T18 route a `[owner/]Repo#N` ref to the referenced repo (CLOSED→pass, OPEN→fail)
- [x] `test_fleet_queue_ingest_blocked_by.sh` (8) — cross-repo CLOSED→no `fleet:blocked`, OPEN→`fleet:blocked`, blockers read-only
- [x] Full `scripts/fleet/tests` sweep — no new failures (2 pre-existing reds on master: `test_dispatcher_usage_gate.sh`, `test_fleet_claim_reconcile_heal_design_unblock.sh`, both unrelated)

Closes #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)