### PR TITLE
fleet: commit epic plans to repo + close the plan-in-repo producer gap

### DIFF
--- a/.claude/skills/file-epic/SKILL.md
+++ b/.claude/skills/file-epic/SKILL.md
@@ -28,7 +28,7 @@ for why.
 | **task label** | `fleet:task` |
 | **architect plans dir** | `~/.claude/plans/<slug>.md` |
 | **plans dir** | `~/.fleet/plans/issue-<N>.md` |
-| **repo-side plan path** | `<repo>/.fleet/plans/T-<NNN>.md` |
+| **repo-side plan path** | `<repo>/.fleet/plans/issue-<N>.md` (committed via the step-6.5 docs PR; no `T-<NNN>` rename) |
 | **validate-stack command** | `fleet-validate-stack <umbrella>` (add `--repo game` for the game repo) |
 | **title area vocabulary** | `engine`, `render`, `engine/voxel`, `game`, etc. (the same scope vocabulary `commit-and-push` uses) |
 

--- a/.fleet/plans/issue-1553.md
+++ b/.fleet/plans/issue-1553.md
@@ -1,0 +1,309 @@
+# Epic plan — detached GPU re-voxelize (true-3D asymmetric detached rotation)
+
+**Umbrella issue:** #1553
+**Target repo:** jakildev/IrredenEngine
+**Model:** opus (all children — core render/ECS invariant work)
+**Slug:** detached-gpu-revoxelize
+
+## Context
+
+The detached per-axis forward-scatter is a 2D image-warp of stored faces:
+it skews the octahedral-snap orientation's faces by the residual and never
+re-rasterizes the rotated solid, so voxel centers are never reorganized
+(source of truth: `docs/design/per-axis-trixel-canvas-rotation.md`
+§"Detached forward-scatter is terminal for asymmetric solids (#1551)"; root
+cause PR #1552). It is correct for a cube (silhouette-invariant under the
+snap) but wrong by construction for an asymmetric solid. The DoD's
+"asymmetric reads as true 3D" test is unreachable on that path.
+
+This epic builds the path that does meet it: the **detached analogue of the
+attached GRID re-voxelize model** (`voxel-face-rasterization.md`
+§"Per-entity SO(3) on the main canvas — RETIRED (#1443)"). Fill the
+detached entity's **private per-entity voxel pool** with its voxels at their
+**full-rotation cell positions**, render that pool with the **cardinal**
+(non-rotated) face/projection path — the rotation lives in the cell
+positions, not in a deform — and composite the canvas screen-locked. The
+end state moves the per-frame cell-fill to a GPU scatter (the "#1396 ever
+needed → GPU re-voxelize" path) and **retires the detached forward-scatter**.
+
+### Why this is tractable (verified against current master)
+
+- The **private per-detached-entity pool already exists**:
+  `IRPrefab::EntityCanvas::createWithVoxelPool` attaches a `C_VoxelPool` to
+  the detached canvas entity; multiple sets target it. No new pool model.
+- **`VOXEL_TO_TRIXEL_STAGE_1` is already multi-canvas** and ticks every
+  canvas entity with a pool + textures, with per-canvas frame data.
+- The **screen-locked composite TRS** in
+  `system_entity_canvas_to_framebuffer.hpp` is independent of pool contents
+  (no rotation in the TRS — rotation is baked into the canvas content) and
+  is reused unchanged.
+- The CPU cell-fill math already exists for attached GRID:
+  `IRPrefab::GridRotation::worldCellForGridVoxel` (scale → rotateVectorByQuat
+  → translate → round-to-cell), reusable for a private pool.
+- `#1396`'s GPU prepass (`UPDATE_VOXEL_POSITIONS_GPU`) transforms positions
+  of existing voxels but does **not** fill cells — the GPU scatter (P2) is a
+  new compute dispatch, not an extension of the prepass.
+
+### Architecture decisions (made here; do not re-litigate)
+
+1. **The rotation lives in cell positions, not a deform.** A re-voxelize
+   detached canvas renders its private pool through the **cardinal / static**
+   raster frame data (`visualYaw_ = 0`, no residual, no per-entity skew, no
+   per-entity `visibleTriplet` baked as a deform) — exactly like the main
+   GRID canvas, where "the camera alone drives faces; the entity's rotation
+   only changes which cells fill." This is the key departure from today's
+   detached frame data (which bakes rotation as a skew). Getting this wrong
+   re-introduces the 2D-warp.
+2. **CPU-first to prove the model, then GPU.** P1 reuses the CPU
+   `worldCellForGridVoxel` to fill the private pool and prove the model
+   cheaply; P2 replaces the fill with a GPU scatter for O(visible)-on-GPU
+   cost. P1 is a shippable correctness baseline (same cost model as attached
+   GRID, an accepted tradeoff), not a throwaway spike.
+3. **Both cubes and asymmetric solids go through re-voxelize.** Once the path
+   exists, all detached SO(3) content uses it; the forward-scatter is retired
+   wholesale (P6).
+
+### Reconciliation with #1551 (closed — folded into P1)
+
+#1551 / PR #1552 (the forward-scatter cube stopgap) were **closed as
+superseded** by this epic. The cube goal is **folded into P1**: P1 migrates
+the existing detached cube fringe to re-voxelize, so the visible cube crumple
++ #1539 pop are fixed correctly (a cube re-voxelizes cleanly) rather than
+band-aided on the terminal forward-scatter path. P6 retires the forward-scatter
+itself; there is no separate stopgap code to remove.
+
+### No current consumer — P1 must add the validating content
+
+There is no asymmetric detached *rotating* solid in current content (only
+cubes spin). P1 therefore **adds an asymmetric detached rotating test solid
+to `canvas_stress`** (a public demo) so the headline acceptance criterion is
+actually exercisable. Without it there is nothing to verify against.
+
+---
+
+## P1 — Re-voxelize model proof: CPU fill into the private pool + asymmetric demo solid
+
+**Model:** opus
+**Blocked by:** (none)
+
+### Scope
+Stand up the detached re-voxelize render path end-to-end with a CPU cell-fill,
+and prove it meets the true-3D criterion on an asymmetric solid. This is the
+headline-proving phase.
+
+### Approach
+- Add a detached re-voxelize mode/opt-in (a new `RotationMode` value or a
+  detached sub-flag — implementer picks the cleanest plumbing; reuse GRID
+  semantics where possible). Opting in routes the entity through re-voxelize
+  instead of the octahedral-snap + forward-scatter / per-axis path.
+- Each frame, for a re-voxelize detached entity, fill its **private pool's**
+  global cell positions via the reused `GridRotation::worldCellForGridVoxel`
+  math under the entity's **full** rotation (CPU; same shape as
+  `SYSTEM_REBUILD_GRID_VOXELS`, but writing the detached canvas's private
+  pool, not the shared world pool). Extend that system to handle the new mode
+  for detached canvases, or add a sibling — do not duplicate the transform
+  math.
+- Route the re-voxelize detached canvas through **cardinal/static raster
+  frame data** (decision 1 above): `visualYaw_ = 0`, no residual, no
+  per-entity skew — the canvas renders its pool exactly like a static canvas;
+  the rotation is already in the cell positions.
+- Bypass the off-snap octahedral single-canvas emit + the per-axis
+  forward-scatter for re-voxelize-opted entities (no double-draw).
+- Composite screen-locked via the **existing gather blit TRS** (unchanged).
+- **Add an asymmetric (non-cube) detached rotating test solid to
+  `canvas_stress`** (e.g. an L-tromino / slab / stepped solid, 3-DOF spin)
+  so the discriminating shot exists.
+
+### Acceptance criteria
+- The asymmetric detached solid at ~45° between octahedral snaps reads as a
+  **true 3D-rotated solid (voxel centers reorganized)**, not a 2D-skewed
+  cardinal arrangement — the criterion the forward-scatter cannot meet.
+- Clean, cohesive solid at **every** residual pose across a full SO(3) spin;
+  smooth through snap intervals, **no pop** (absorbs #1539 for these
+  entities).
+- A detached **cube** via re-voxelize is also clean at every pose (validates
+  the cube case the epic will use to supersede #1551).
+- Non-opted entities (static, and forward-scatter cubes) **byte-identical** to
+  master.
+- GLSL only this phase; Metal parity deferred to P5.
+
+### Gotchas
+- The cardinal-frame-data routing is the crux. If the re-voxelize canvas
+  inherits the per-entity skew frame data, the rotation gets applied twice (in
+  cells AND as a deform) — wrong. Verify the canvas renders its pool with the
+  same frame data a static canvas would.
+- Private-pool sizing: the pool must be large enough to hold the rotated
+  solid's bounding cells (a rotated solid's AABB is larger than its
+  axis-aligned one by up to √3). Size `poolSize` to the rotated worst case.
+- Round-to-cell aliasing (gaps / double-occupancy) is expected and is
+  refined in P3 — P1 only needs the solid to read as true-3D, not be
+  aliasing-perfect.
+
+---
+
+## P2 — GPU scatter fill (replace the CPU fill)
+
+**Model:** opus
+**Blocked by:** #P1
+
+### Scope
+Move the per-frame private-pool cell-fill from CPU to a GPU scatter compute
+dispatch, so a horde of rotating detached entities costs O(entities) CPU
+upload + GPU-parallel fill instead of O(authored voxels) CPU per frame.
+
+### Approach
+- Reuse `#1396`'s transform-slot indirection (`UPDATE_VOXEL_POSITIONS_GPU`,
+  binding-17 local + binding-18 transforms) to get each voxel's world
+  position on the GPU.
+- Add a **new compute dispatch** that scatters each visible voxel into the
+  detached pool's private grid cells: compute `floor(worldPos + 0.5)`,
+  scatter into the pool's binding-5 cell (atomicMin on depth to resolve
+  multiple source voxels landing in one cell). Run it **before**
+  `VOXEL_TO_TRIXEL_STAGE_1` ticks that canvas so binding 5 holds the
+  scattered cells.
+- Extract the `worldCellForGridVoxel` transform into a shared GLSL/Metal
+  helper (mirror the CPU math, CPU↔GPU bit-identical per the IRMath rule) —
+  reuse the math, not the CPU system.
+
+### Acceptance criteria
+- Visually **byte-identical to P1** for the asymmetric + cube test solids
+  across a full spin.
+- Per-frame CPU cost for a rotating detached entity is O(entities) upload,
+  not O(authored voxels) re-rasterize; GPU dispatch cost measured (run
+  `optimize`).
+- Binding-5 single-instance multi-canvas constraint respected: the scatter
+  populates the detached pool's positions correctly even with multiple
+  canvases (coordinate with `lastUploadedCanvas_` / the per-canvas re-seed).
+- GLSL only; Metal in P5.
+
+### Gotchas
+- Binding 5 / 17 / 18 are single-instance and shared across canvases; the
+  scatter for canvas A must complete and be consumed by A's STAGE_1 before
+  canvas B overwrites them. Sequence per-canvas.
+- Atomic cell-aliasing resolution overlaps P3 — keep P2 to the fill mechanism;
+  P3 owns aliasing/occlusion correctness.
+
+---
+
+## P3 — Round-to-cell occlusion + aliasing correctness
+
+**Model:** opus
+**Blocked by:** #P2
+
+### Scope
+Make the re-voxelized solid's coverage and occlusion correct at every pose —
+no aliasing holes/specks from the round-to-cell fill, no double-occupancy or
+dropped cells, back faces correctly hidden.
+
+### Approach
+- Resolve multiple source voxels mapping to one destination cell (keep the
+  nearest / correct color) and fill gaps where the rotated lattice
+  under-samples a cell column (the standard re-voxelize aliasing problem; the
+  attached GRID path's accepted round-to-cell tradeoff is the reference for
+  what is acceptable vs. what must be fixed).
+- Verify per-voxel occlusion through the normal STAGE_1 `atomicMin` depth is
+  correct on the re-voxelized pool.
+
+### Acceptance criteria
+- No aliasing holes / specks / dropped cells across a full SO(3) spin of the
+  asymmetric solid.
+- Occlusion correct: back faces hidden, exposed-face mask correct on the
+  re-voxelized cells.
+- Coverage quality at least matches the attached GRID re-voxelize path.
+
+### Gotchas
+- Don't reintroduce a CPU per-voxel loop to fix aliasing — keep the fix on the
+  GPU scatter (atomic resolution / a coverage pass), consistent with P2.
+
+---
+
+## P4 — AO / sun / light integration
+
+**Model:** opus
+**Blocked by:** #P3
+
+### Scope
+Light the re-voxelized detached canvas consistently with the rest of the
+engine (AO + sun-shadow + light-volume + Lambert), at parity with how an
+attached GRID solid or the per-axis path it replaces is lit.
+
+### Approach
+- Drive the existing per-canvas lighting passes over the re-voxelized detached
+  pool (the canvas renders cardinal cells, so the standard lighting path
+  applies — the rotation is in the cells, the normals are cardinal).
+- Confirm the detached lighting contract (cast/receive) from the per-axis
+  path (`per_axis_sun_shadow_resolve`, the P4/#1465 detached lighting) is
+  preserved or correctly superseded.
+
+### Acceptance criteria
+- Re-voxelized detached solid is lit equivalently to an attached GRID solid.
+- Shadows cast/receive per the existing detached lighting contract.
+- Identity / static byte-identical.
+
+---
+
+## P5 — Metal parity
+
+**Model:** opus
+**Blocked by:** #P4
+
+### Scope
+Port the new GPU scatter compute shader (+ any GLSL changes from P1–P4) to
+the Metal backend; build and run on macOS/Metal.
+
+### Approach
+- Mirror the scatter compute + any modified raster/lighting shaders to
+  `.metal`; keep the CPU↔GPU transform math bit-identical across backends.
+- Build `macos-debug`, run the `canvas_stress` re-voxelize demo, verify the
+  asymmetric solid renders identically to OpenGL.
+
+### Acceptance criteria
+- Metal output matches OpenGL for the re-voxelized detached path (full-frame +
+  ROI).
+- Backend parity verified per the `backend-parity` skill.
+
+---
+
+## P6 — Render-verify baselines + retire the detached forward-scatter
+
+**Model:** opus
+**Blocked by:** #P5
+
+### Scope
+Commit render-verify baselines for the re-voxelize detached path and retire
+the now-superseded detached per-axis forward-scatter (and the #1551 stopgap),
+making re-voxelize the sole detached SO(3) path.
+
+### Approach
+- Add render-verify reference images for the asymmetric + cube re-voxelize
+  detached shots.
+- Remove the detached forward-scatter (`v_peraxis_scatter_detached.{glsl,metal}`
+  + the `PerAxisScatterDetachedProgram` path) and the per-axis canvas
+  allocation for detached (`syncAllocationToDetachedEntities`,
+  `kMaxDetachedRotatingCanvases`) now that re-voxelize covers all detached
+  SO(3). Keep the per-axis machinery the **camera/main-canvas** path still
+  uses (only the detached consumer is retired).
+- Remove the #1551 cube-smoothness stopgap code on the forward-scatter.
+- Update `docs/design/per-axis-trixel-canvas-rotation.md`: flip the
+  "Detached forward-scatter is terminal" section from "deferred" to "shipped —
+  superseded by detached re-voxelize," and update
+  `voxel-face-rasterization.md` + the render `CLAUDE.md` to point at the new
+  path.
+
+### Acceptance criteria
+- Detached forward-scatter removed; re-voxelize is the sole detached SO(3)
+  path; cube + asymmetric both clean.
+- The camera/main-canvas per-axis path is untouched and byte-identical.
+- Cardinal / identity byte-identical; render-verify green; docs updated.
+
+### Gotchas
+- Scope the removal precisely: the per-axis canvas machinery is **shared**
+  with the camera smooth-yaw path — retire only the **detached** consumer, not
+  the camera path. Cross-check every `isDetached()`-gated branch.
+
+---
+
+## Dependency chain
+
+P1 (none) → P2 → P3 → P4 → P5 → P6. Strictly linear; each phase leaves the
+tree green and the non-re-voxelize paths byte-identical.

--- a/.fleet/plans/issue-1553.md
+++ b/.fleet/plans/issue-1553.md
@@ -59,7 +59,14 @@ needed → GPU re-voxelize" path) and **retires the detached forward-scatter**.
    cheaply; P2 replaces the fill with a GPU scatter for O(visible)-on-GPU
    cost. P1 is a shippable correctness baseline (same cost model as attached
    GRID, an accepted tradeoff), not a throwaway spike.
-3. **Both cubes and asymmetric solids go through re-voxelize.** Once the path
+3. **Per-pool resident GPU locals (P2 resource model — decided on PR #1562).**
+   Each re-voxelize pool owns a resident SSBO of its authored locals (GPU-RAII
+   on `C_VoxelPool`), seeded once; per frame only the canvas quat uploads
+   (O(entities)). The compute writes binding 5 per-canvas in place of
+   `flushStaticPositionRanges`. This supersedes the original "reuse #1396
+   binding-17/18" note — those are single-instance and break the demo's
+   two-canvas case. See `.fleet/plans/issue-1556.md`.
+4. **Both cubes and asymmetric solids go through re-voxelize.** Once the path
    exists, all detached SO(3) content uses it; the forward-scatter is retired
    wholesale (P6).
 

--- a/.fleet/plans/issue-1555.md
+++ b/.fleet/plans/issue-1555.md
@@ -1,0 +1,31 @@
+# Plan: detached re-voxelize — CPU model proof + asymmetric demo (P1)
+
+- **Issue:** #1555
+- **Model:** opus
+- **Date:** 2026-06-06
+- **Epic:** #1553 — see `.fleet/plans/issue-1553.md` for full context + architecture decisions
+- **Blocked by:** (none)
+
+## Scope
+Prove the detached re-voxelize model end-to-end with a CPU cell-fill. The headline phase: an asymmetric detached solid at ~45° must read as a true 3D-rotated solid (voxel centers reorganized). **Also migrate the existing `canvas_stress` detached cube fringe to re-voxelize** — #1551/#1552 (the forward-scatter cube stopgap) were closed as superseded by this epic, so P1 is the path that fixes the visible cube crumple + #1539 pop, correctly.
+
+## Affected files
+- `engine/prefabs/irreden/common/components/component_rotation_mode.hpp` — new detached re-voxelize mode/flag
+- `engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp` — extend (or sibling) to fill the detached private pool under the full rotation
+- `engine/prefabs/irreden/voxel/grid_rotation.hpp` — reuse `worldCellForGridVoxel` (no new math)
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp` — `buildVoxelFrameData`: route re-voxelize detached canvases through cardinal/static frame data (NOT the per-entity skew branch)
+- `creations/demos/canvas_stress/main.cpp` — add an asymmetric detached rotating test solid; opt the existing detached cube fringe into re-voxelize
+
+## Approach
+Per the epic plan §P1. Crux: the re-voxelize canvas renders its private pool exactly like a static canvas (rotation lives in cells, not a deform). Bypass the octahedral + per-axis path for opted entities. Both the existing cubes and the new asymmetric solid opt into re-voxelize.
+
+## Acceptance criteria
+- Asymmetric solid reads true-3D at 45°; clean at every residual; no pop.
+- The existing `canvas_stress` detached cube fringe renders via re-voxelize — clean at every pose, no #1539 pop (the cube crumple #1551 targeted, fixed correctly here).
+- Non-opted entities byte-identical; GLSL only.
+
+## Gotchas
+Double-rotation if the canvas inherits skew frame data. Size the private pool for the rotated AABB (×√3). Aliasing is P3's job.
+
+## Verification
+`fleet-build --target IRCanvasStress`; `fleet-run IRCanvasStress --auto-screenshot`; inspect the asymmetric solid AND the cube fringe at mid-residual read as true rotated solids; confirm a static scene is byte-identical.

--- a/.fleet/plans/issue-1556.md
+++ b/.fleet/plans/issue-1556.md
@@ -3,7 +3,7 @@
 - **Issue:** #1556
 - **Model:** opus
 - **Date:** 2026-06-06
-- **Epic:** #1553 — see `~/.fleet/plans/issue-1553.md`
+- **Epic:** #1553 — see `.fleet/plans/issue-1553.md`
 - **Blocked by:** #1555
 
 ## Scope

--- a/.fleet/plans/issue-1556.md
+++ b/.fleet/plans/issue-1556.md
@@ -7,22 +7,37 @@
 - **Blocked by:** #1555
 
 ## Scope
-Replace P1's CPU per-frame cell-fill with a GPU scatter compute dispatch; O(visible) on the GPU instead of O(authored) on the CPU.
+Move the per-frame private-pool cell-fill from CPU (P1) to the GPU, so a rotating detached entity costs O(entities) per-frame upload (one quat) + a GPU-parallel fill, not O(authored voxels) CPU re-rasterize.
+
+## Resource model — DECIDED (architect, design-block resolution on PR #1562)
+
+The plan's original "reuse #1396's binding-17/18 buffers" is **superseded** — those bindings are single-instance/shared, and the demo has **two** `DETACHED_REVOXELIZE` canvases, so a shared local buffer would re-seed per-canvas per-frame (O(authored voxels), and clobbers one solid). Use a **per-pool resident GPU locals buffer** instead:
+
+- Each `DETACHED_REVOXELIZE` pool **owns a resident SSBO** of its authored locals (+ per-voxel offsets) — GPU-RAII on `C_VoxelPool`, same pattern as `C_TriangleCanvasTextures`. **Seeded once** at pool allocation; re-seeded **only on pool mutation** (voxel add/remove), never per frame.
+- Per frame, the only upload is the **canvas rotation quat** — one per re-voxelize canvas → **O(entities)**.
+- A new compute `c_revoxelize_detached.glsl` binds the current pool's resident locals + its quat, computes `worldCellForGridVoxel(local, offset, {t=0, rot=canvasQuat, s=1})` **bit-identically to P1's CPU math** (`roundHalfUp` parity), and writes binding 5 (`VoxelPositionBuffer`) `[0, liveCount)` for that pool.
+- **Dispatched from STAGE_1's per-canvas tick, in place of `flushStaticPositionRanges`** for `reVoxelize_` canvases — so binding 5 is filled and consumed within that canvas's tick before the next canvas overwrites it (respects the single-instance binding-5 constraint).
+
+Why this and not #1396: #1396's per-voxel transform-slot indirection is for the **heterogeneous**-transform case (skeletal). A re-voxelize pool's voxels all share **one** transform (the canvas quat), so per-pool-resident-locals + a single quat is both correct for multi-canvas **and** simpler (no per-voxel slot). Rejected alternatives: a new per-canvas component (more plumbing, no benefit over pool-ownership since the pool already owns the CPU locals); a single concatenated buffer + offset table (a new drift-prone offset invariant).
 
 ## Affected files
-- New compute shader `c_*scatter*.glsl` (+ a shared `worldCellForGridVoxel` GLSL helper mirroring the CPU math)
-- `engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp` — reuse transform-slot indirection; add/sequence the scatter dispatch before STAGE_1
-- `engine/system/include/irreden/ir_system_types.hpp` — `SystemName` entry if a new system
-- `component_voxel_pool.hpp` — binding-5 population from the scatter
-
-## Approach
-Per the epic plan §P2. Reuse #1396 (binding 17 local + 18 transforms) → world pos; scatter `floor(worldPos+0.5)` into the private pool's binding-5 cell with `atomicMin` on depth.
+- `component_voxel_pool.hpp` — resident locals/offsets SSBO (GPU-RAII), seeded at allocation, re-seeded on mutation
+- new `engine/render/src/shaders/c_revoxelize_detached.glsl` (+ a shared `worldCellForGridVoxel` GLSL helper mirroring the CPU math)
+- `system_voxel_to_trixel.hpp` — STAGE_1 per-canvas tick: dispatch the compute for `reVoxelize_` canvases in place of `flushStaticPositionRanges`
+- `ir_system_types.hpp` — `SystemName` entry if a standalone system rather than folded into STAGE_1
 
 ## Acceptance criteria
-Byte-identical to P1 visually; CPU cost O(entities); GPU dispatch measured; multi-canvas binding-5 constraint respected; GLSL only.
+- Visually **byte-identical to P1** for both the asymmetric solid AND the cube across a full spin (both pools fill binding 5 correctly — no clobber).
+- Per-frame upload is O(entities) (one quat/canvas), not O(authored voxels); GPU dispatch cost measured (run `optimize`).
+- The two-canvas demo (L-prism + cube) renders both correctly — the multi-canvas case the original plan failed.
+- GLSL only; Metal in P5.
+
+## Sequencing
+Stacked on P1 (#1561), now `fleet:approved` + mergeable — P1's pool/demo model is **frozen**. Land P2 on merged P1 (rebase the stack when P1 merges). The resident-buffer model above is robust to P1's exact pool details.
 
 ## Gotchas
-Binding 5/17/18 single-instance — sequence per-canvas (`lastUploadedCanvas_`). Keep aliasing resolution to P3.
+- Re-seed the resident locals only on pool mutation — a per-frame re-seed silently reverts to O(authored voxels) (the exact trap the original plan fell into).
+- `worldCellForGridVoxel` GLSL must match the CPU `roundHalfUp` half-integer classification bit-for-bit, or P2 diverges from P1.
 
 ## Verification
-`fleet-build --target IRCanvasStress`; `fleet-run`; diff frames vs P1 (byte-identical); run `optimize` on the scatter dispatch.
+`fleet-build --target IRCanvasStress`; `fleet-run`; diff frames vs P1 (byte-identical, both solids); `optimize` on the dispatch; confirm per-frame upload is one quat/canvas.

--- a/.fleet/plans/issue-1556.md
+++ b/.fleet/plans/issue-1556.md
@@ -1,0 +1,28 @@
+# Plan: detached re-voxelize — GPU scatter fill (P2)
+
+- **Issue:** #1556
+- **Model:** opus
+- **Date:** 2026-06-06
+- **Epic:** #1553 — see `~/.fleet/plans/issue-1553.md`
+- **Blocked by:** #1555
+
+## Scope
+Replace P1's CPU per-frame cell-fill with a GPU scatter compute dispatch; O(visible) on the GPU instead of O(authored) on the CPU.
+
+## Affected files
+- New compute shader `c_*scatter*.glsl` (+ a shared `worldCellForGridVoxel` GLSL helper mirroring the CPU math)
+- `engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp` — reuse transform-slot indirection; add/sequence the scatter dispatch before STAGE_1
+- `engine/system/include/irreden/ir_system_types.hpp` — `SystemName` entry if a new system
+- `component_voxel_pool.hpp` — binding-5 population from the scatter
+
+## Approach
+Per the epic plan §P2. Reuse #1396 (binding 17 local + 18 transforms) → world pos; scatter `floor(worldPos+0.5)` into the private pool's binding-5 cell with `atomicMin` on depth.
+
+## Acceptance criteria
+Byte-identical to P1 visually; CPU cost O(entities); GPU dispatch measured; multi-canvas binding-5 constraint respected; GLSL only.
+
+## Gotchas
+Binding 5/17/18 single-instance — sequence per-canvas (`lastUploadedCanvas_`). Keep aliasing resolution to P3.
+
+## Verification
+`fleet-build --target IRCanvasStress`; `fleet-run`; diff frames vs P1 (byte-identical); run `optimize` on the scatter dispatch.

--- a/.fleet/plans/issue-1557.md
+++ b/.fleet/plans/issue-1557.md
@@ -3,7 +3,7 @@
 - **Issue:** #1557
 - **Model:** opus
 - **Date:** 2026-06-06
-- **Epic:** #1553 — see `~/.fleet/plans/issue-1553.md`
+- **Epic:** #1553 — see `.fleet/plans/issue-1553.md`
 - **Blocked by:** #1556
 
 ## Scope

--- a/.fleet/plans/issue-1557.md
+++ b/.fleet/plans/issue-1557.md
@@ -1,0 +1,26 @@
+# Plan: detached re-voxelize — round-to-cell occlusion + aliasing (P3)
+
+- **Issue:** #1557
+- **Model:** opus
+- **Date:** 2026-06-06
+- **Epic:** #1553 — see `~/.fleet/plans/issue-1553.md`
+- **Blocked by:** #1556
+
+## Scope
+Correct coverage + occlusion of the re-voxelized solid at every pose — no holes/specks/dropped cells from round-to-cell, back faces hidden.
+
+## Affected files
+- The GPU scatter shader from P2 (aliasing resolution / coverage pass)
+- `c_voxel_to_trixel_stage_1.glsl` if exposed-mask handling on re-voxelized cells needs adjustment
+
+## Approach
+Per the epic plan §P3. Resolve multi-voxel-per-cell + under-sampled columns on the GPU scatter; reference the attached GRID round-to-cell tradeoff for the acceptable bar.
+
+## Acceptance criteria
+No aliasing holes/specks across a full SO(3) spin; occlusion correct; coverage ≥ attached GRID quality.
+
+## Gotchas
+No CPU per-voxel loop to patch aliasing — keep it on the GPU scatter.
+
+## Verification
+`fleet-run IRCanvasStress --auto-screenshot` across the spin; inspect ROI crops at mid-residual for holes/specks.

--- a/.fleet/plans/issue-1557.md
+++ b/.fleet/plans/issue-1557.md
@@ -7,20 +7,34 @@
 - **Blocked by:** #1556
 
 ## Scope
-Correct coverage + occlusion of the re-voxelized solid at every pose — no holes/specks/dropped cells from round-to-cell, back faces hidden.
+Make the re-voxelized solid correct at every pose. P1 ships **two distinct defects** — fix both:
+1. **Coverage gaps** — round-to-cell holes (the rotated lattice maps non-bijectively; some destination cells get no source voxel → see-through holes).
+2. **Wrong-shaped / "flag" trixels** — faces emitting with the wrong set/orientation on the rotated cells (NOT a coverage problem; denser fill won't remove them).
+
+## Defect 2 root cause (the "flag" trixels) — confirm, then fix
+Observed (PR #1561 screenshots): the detached re-voxelize solids show angular "flag/pennant" trixels distinct from the holes. **Likely cause** (confirm with GPU/headless instrumentation — leads, not a mandate; the architect has been wrong on this surface before):
+- The **exposed-face mask is computed on model-space (un-rotated) adjacency** (`recomputeFaceOccupancy` on the authored voxels in the demo) but `SYSTEM_REBUILD_DETACHED_VOXELS` rewrites **only positions** (`globals[i].pos_`), never the mask. After re-voxelizing, the mask is **stale vs. the rotated cell grid**: a face that became interior in the rotated layout still passes the `exposed` test and emits (spurious back-face → flag), and a face newly exposed by the rotation is suppressed (extra hole).
+- Secondary lead if the above doesn't fully account for it: the re-voxelize cardinal `faceDeform_` / face-orientation for cells whose rotated neighbors changed.
+
+**Fix direction:** make face-emit correct on the **re-voxelized (destination) cell adjacency**, not the model-space mask — recompute the exposed mask against the rotated cells each frame (cheap on the small detached pool), or resolve exposure via GPU occlusion on the rotated grid rather than the precomputed mask. This is the same place the GRID attached path resolves it (it re-probes neighbors on the re-voxelized world cells).
 
 ## Affected files
-- The GPU scatter shader from P2 (aliasing resolution / coverage pass)
-- `c_voxel_to_trixel_stage_1.glsl` if exposed-mask handling on re-voxelized cells needs adjustment
+- The P2 GPU scatter / fill path (where the rotated cells are produced) — add re-voxelized-adjacency exposure
+- `system_rebuild_detached_voxels.hpp` / `component_voxel_pool.hpp` — exposed-mask recompute against rotated cells (if CPU-side), or
+- `c_voxel_to_trixel_stage_1.glsl` / the compact pass — if exposure resolves on the GPU
+- `c_voxel_to_trixel_stage_1.glsl` — coverage (defect 1)
 
 ## Approach
-Per the epic plan §P3. Resolve multi-voxel-per-cell + under-sampled columns on the GPU scatter; reference the attached GRID round-to-cell tradeoff for the acceptable bar.
+Per the epic plan §P3, plus defect 2 above. For defect 1: resolve multi-source-per-cell (atomicMin keep-nearest) and fill under-sampled columns so coverage ≥ the attached-GRID round-to-cell bar. For defect 2: re-derive the exposed set on the rotated cells.
 
 ## Acceptance criteria
-No aliasing holes/specks across a full SO(3) spin; occlusion correct; coverage ≥ attached GRID quality.
+- No coverage holes/specks across a full SO(3) spin of the asymmetric solid (defect 1).
+- **No wrong-shaped / flag trixels** — the emitted face set + orientation is correct on the rotated cell grid; no spurious interior/back faces, no suppressed exposed faces (defect 2).
+- Occlusion correct (back faces hidden); coverage + face-emit quality ≥ the attached GRID re-voxelize path.
 
 ## Gotchas
-No CPU per-voxel loop to patch aliasing — keep it on the GPU scatter.
+- The two defects have **different causes** — fixing coverage (denser fill) does NOT remove the flag trixels (stale exposed set). Verify both independently.
+- Don't reintroduce a CPU per-voxel loop on the hot path for either fix — keep coverage on the GPU scatter; if the exposed-mask recompute is CPU-side, it runs in the (already CPU) `SYSTEM_REBUILD_DETACHED_VOXELS`, bounded to the small detached pool.
 
 ## Verification
-`fleet-run IRCanvasStress --auto-screenshot` across the spin; inspect ROI crops at mid-residual for holes/specks.
+`fleet-run IRCanvasStress --auto-screenshot` across the spin; ROI crops at mid-residual: confirm (a) no holes AND (b) no flag trixels — the solid surface reads clean, faces correctly oriented. Compare against the attached GRID solid (clean reference) in the same scene.

--- a/.fleet/plans/issue-1558.md
+++ b/.fleet/plans/issue-1558.md
@@ -1,0 +1,26 @@
+# Plan: detached re-voxelize — AO / sun / light integration (P4)
+
+- **Issue:** #1558
+- **Model:** opus
+- **Date:** 2026-06-06
+- **Epic:** #1553 — see `~/.fleet/plans/issue-1553.md`
+- **Blocked by:** #1557
+
+## Scope
+Light the re-voxelized detached canvas at parity with an attached GRID solid (AO + sun-shadow + light-volume + Lambert).
+
+## Affected files
+- Per-canvas lighting systems (AO / sun-shadow / lighting-to-trixel) — confirm they run over the re-voxelized detached pool
+- `docs/design/per-axis-sun-shadow-resolve.md` if the detached lighting contract changes
+
+## Approach
+Per the epic plan §P4. The canvas uses cardinal normals (rotation is in cells), so the standard lighting path applies — do NOT port the per-axis residual-aware lighting (retired for detached in P6).
+
+## Acceptance criteria
+Lit equivalently to an attached GRID solid; shadows cast/receive per contract; identity/static byte-identical.
+
+## Gotchas
+Avoid pulling in the per-axis residual lighting machinery; that is the path being retired.
+
+## Verification
+`fleet-run IRCanvasStress --auto-screenshot`; compare lighting vs an attached GRID solid in the same scene.

--- a/.fleet/plans/issue-1558.md
+++ b/.fleet/plans/issue-1558.md
@@ -3,7 +3,7 @@
 - **Issue:** #1558
 - **Model:** opus
 - **Date:** 2026-06-06
-- **Epic:** #1553 — see `~/.fleet/plans/issue-1553.md`
+- **Epic:** #1553 — see `.fleet/plans/issue-1553.md`
 - **Blocked by:** #1557
 
 ## Scope

--- a/.fleet/plans/issue-1559.md
+++ b/.fleet/plans/issue-1559.md
@@ -1,0 +1,25 @@
+# Plan: detached re-voxelize — Metal parity (P5)
+
+- **Issue:** #1559
+- **Model:** opus
+- **Date:** 2026-06-06
+- **Epic:** #1553 — see `~/.fleet/plans/issue-1553.md`
+- **Blocked by:** #1558
+
+## Scope
+Port the GPU scatter compute (+ any GLSL changes from P1–P4) to Metal; build + run on macOS/Metal.
+
+## Affected files
+- `.metal` mirrors of the scatter compute + any modified raster/lighting shaders in `engine/render/src/shaders/`
+
+## Approach
+Per the epic plan §P5. Mirror the shaders; keep CPU↔GPU transform math bit-identical; build `macos-debug`; run the re-voxelize demo. Use the `backend-parity` skill.
+
+## Acceptance criteria
+Metal matches OpenGL (full-frame + ROI) for the re-voxelize detached path; parity verified.
+
+## Gotchas
+Metal has no free buffer index past 30 — keep the transform-slot bit-packed in the local-position `.w` lane (#1396 convention).
+
+## Verification
+`cmake --preset macos-debug`; build + run `IRCanvasStress`; side-by-side vs OpenGL captures.

--- a/.fleet/plans/issue-1559.md
+++ b/.fleet/plans/issue-1559.md
@@ -3,7 +3,7 @@
 - **Issue:** #1559
 - **Model:** opus
 - **Date:** 2026-06-06
-- **Epic:** #1553 — see `~/.fleet/plans/issue-1553.md`
+- **Epic:** #1553 — see `.fleet/plans/issue-1553.md`
 - **Blocked by:** #1558
 
 ## Scope

--- a/.fleet/plans/issue-1560.md
+++ b/.fleet/plans/issue-1560.md
@@ -1,0 +1,30 @@
+# Plan: detached re-voxelize — render-verify + retire forward-scatter (P6)
+
+- **Issue:** #1560
+- **Model:** opus
+- **Date:** 2026-06-06
+- **Epic:** #1553 — see `.fleet/plans/issue-1553.md`
+- **Blocked by:** #1559
+
+## Scope
+Commit render-verify baselines for the re-voxelize detached path and retire the now-superseded detached per-axis forward-scatter, making re-voxelize the sole detached SO(3) path.
+
+## Affected files
+- Remove: `v_peraxis_scatter_detached.{glsl,metal}`, the `PerAxisScatterDetachedProgram` path, `syncAllocationToDetachedEntities` / `kMaxDetachedRotatingCanvases` (detached only)
+- `per_axis_canvas.hpp`, `system_entity_canvas_to_framebuffer.hpp` — remove the detached forward-scatter branches
+- `docs/design/per-axis-trixel-canvas-rotation.md`, `docs/design/voxel-face-rasterization.md`, `engine/prefabs/irreden/render/CLAUDE.md` — flip the model from "committed epic" to "shipped"
+- render-verify reference images
+
+## Approach
+Per the epic plan §P6. Retire ONLY the detached consumer of the per-axis machinery — the camera/main-canvas smooth-yaw path keeps it. (No #1551 stopgap to remove — it was closed as superseded, never merged.)
+
+## Acceptance criteria
+- Forward-scatter removed for detached; re-voxelize sole path; cube + asymmetric both clean.
+- The camera/main-canvas per-axis path is untouched and byte-identical.
+- Cardinal/identity byte-identical; render-verify green; docs updated.
+
+## Gotchas
+Cross-check every `isDetached()`-gated branch — the per-axis machinery is shared with the camera path; retire only the detached consumer.
+
+## Verification
+`fleet-build`; `render-verify` on the re-voxelize shots; sweep the camera smooth-yaw path for byte-identical; build both backends.

--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -272,7 +272,10 @@ conversation), follow the shared
 [`docs/agents/PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md) — read the full
 thread, post the structured plan comment (including the **cross-system audit**
 when planning a deletion/migration of a shared resource), save
-`~/.fleet/plans/issue-<N>.md`, and remove `fleet:needs-plan` (leaving
+`~/.fleet/plans/issue-<N>.md` **and commit it into the repo at
+`.fleet/plans/issue-<N>.md`** (a small docs PR — workers read the plan from the
+repo copy synced from master; `~/.fleet/plans/` is same-host staging only, and
+there is no automatic copy), and remove `fleet:needs-plan` (leaving
 `human:approved`). If you disagree with the issue's direction, comment but
 leave `fleet:needs-plan` on. If the work decomposes into a multi-issue stack,
 file it via `file-epic` per Filing tasks above.
@@ -329,8 +332,16 @@ When working a `fleet:design-blocked` PR:
    3a. **Plan file** (always): update `~/.fleet/plans/issue-<N>.md` (where
    `<N>` is the issue number referenced in the PR body via `Closes #<N>`). Add
    a revision-history entry at the bottom and update scope / acceptance
-   criteria in place. The worker reads the updated plan when it picks the PR
-   back up. If the PR has no backing issue (rare), skip the plan-file update
+   criteria in place. **Then commit it into the repo at
+   `<repo-root>/.fleet/plans/issue-<N>.md`** — `~/.fleet/plans/` is local
+   staging visible only on this host, but the fleet runs across hosts and a
+   worker reads the plan from the **repo copy, synced from master** (per the
+   worker role docs). There is no automatic queue-manager copy; if you skip the
+   commit, a cross-host worker that resumes the PR finds no plan and falls back
+   to the issue body, losing your direction. The commit is docs-only — fold it
+   into the design-doc PR (step 3b) when there is one, else a small standalone
+   docs PR; filenames stay `issue-<N>.md` (the obsolete `T-<NNN>` rename is
+   retired). If the PR has no backing issue (rare), skip the plan-file update
    and put the full direction inline in the PR comment in step 4. For an
    engine-level decision, keep the plan file short and **point at the design
    doc** rather than duplicating it — the doc is canonical, the plan file is

--- a/docs/agents/skills/file-epic.md
+++ b/docs/agents/skills/file-epic.md
@@ -3,9 +3,9 @@
 The canonical `file-epic` flow: take an approved architect plan that covers
 a multi-ticket epic and file it as a fleet expects — an umbrella issue
 labelled with the repo's **epic label**, one child per phase labelled with
-the **task label**, per-ticket plan files in the **plans dir** so the
-queue-manager copies them into the repo on ingest, and post-filing stack
-validation.
+the **task label**, per-ticket plan files **committed into the repo** at the
+**repo-side plan path** so a worker on any host reads them from master, and
+post-filing stack validation.
 
 Every repo that runs a fleet keeps its
 `.claude/skills/file-epic/SKILL.md` as a thin wrapper that points here and
@@ -23,8 +23,8 @@ mechanism.
 | **epic label** | Marks the umbrella so the queue-manager skips it. | `fleet:epic` |
 | **task label** | Marks each child as a queue-ingestable task. | `fleet:task` |
 | **architect plans dir** | Where the approved architect draft lives. | `~/.claude/plans/<slug>.md` |
-| **plans dir** | Worker-facing plan store the queue-manager reads. | `~/.fleet/plans/issue-<N>.md` |
-| **repo-side plan path** | Final repo-side plan after ingest rename. | `<repo>/.fleet/plans/T-<NNN>.md` |
+| **plans dir** | Local staging for the plan, pre-commit. | `~/.fleet/plans/issue-<N>.md` |
+| **repo-side plan path** | Committed, authoritative plan workers read from master. | `<repo>/.fleet/plans/issue-<N>.md` |
 | **validate-stack command** | Asserts every child carries the structured fields. | `fleet-validate-stack` |
 | **title area vocabulary** | `<area>` tokens for child titles. | `engine`, `render`, `game`, module names |
 
@@ -79,9 +79,9 @@ report — don't double-file.
 cp <architect-plans-dir>/<slug>.md <plans-dir>/issue-<N>.md
 ```
 
-This is the worker-facing reference. The queue-manager copies per-ticket
-files into the repo as the **repo-side plan path** at ingest; the umbrella
-plan itself stays at the `issue-<N>` filename for the umbrella's lifetime.
+This stages the umbrella plan locally; step 6.5 commits it (and every
+per-ticket plan) into the repo at the **repo-side plan path**. The umbrella
+plan keeps the `issue-<N>` filename for the umbrella's lifetime.
 
 ### 3. Apply the epic label to the umbrella
 
@@ -94,9 +94,9 @@ ingest individually) and to auto-close the umbrella when all children close.
 
 ### 4. Parse the plan's child-ticket sections
 
-For each child section extract: the descriptive title (drop the architect's
-internal `T-XXX` slug — the tracker assigns its own number and the
-queue-manager assigns the canonical `T-NNN` at ingest); model tag; scope,
+For each child section extract: the descriptive title (drop any architect
+`T-XXX`/`P<n>` slug if you prefer — the tracker assigns the canonical issue
+number, which is what every downstream reference uses); model tag; scope,
 approach, acceptance criteria, dependencies, gotchas.
 
 ### 5. File children sequentially (NOT in parallel)
@@ -152,15 +152,17 @@ Then file:
 
 ```bash
 gh issue create --repo <repo> --label "<task-label>" \
-  --title "<area>: <descriptive title> (T-<slug>)" \
+  --title "<area>: <descriptive title> (<phase-slug>)" \
   --body-file .file-epic-body.md
 rm -f .file-epic-body.md
 ```
 
-Title convention: `<area>: <descriptive title> (T-<slug>)` using one of the
-repo's **title area vocabulary** tokens. The `(T-<slug>)` suffix preserves
-the architect's internal numbering; the queue-manager assigns the canonical
-`T-NNN` separately. Capture the issue number the tracker returns.
+Title convention: `<area>: <descriptive title> (<phase-slug>)` using one of the
+repo's **title area vocabulary** tokens. An optional `(<phase-slug>)` suffix
+(e.g. `(P1)`) preserves the architect's phase numbering for readability; the
+tracker's **issue number** is the canonical identifier every downstream
+reference (plan filename, `Blocked by:`, claim) uses. Capture the issue number
+the tracker returns.
 
 ### 6. Write per-ticket plan file
 
@@ -198,6 +200,35 @@ the tracker-assigned number):
 The per-ticket plan adds **implementation detail beyond the issue body**.
 Don't duplicate — point at the umbrella plan for arch context, then add file
 paths, code-level approach, and verification.
+
+### 6.5. Commit the plan files into the repo (REQUIRED — workers read from master)
+
+The **plans dir** (`~/.fleet/plans/`) is **local staging only** — it is
+visible solely on the host that filed the epic. The fleet runs across hosts
+(Linux/WSL + macOS), so a worker that claims a child on a *different* host
+reads its plan from the **repo-side plan path** (`<repo>/.fleet/plans/issue-<N>.md`,
+"synced from master" per the worker role docs). If the plan never lands in the
+repo, that worker finds nothing and falls back to the issue body — the
+per-ticket detail you just wrote is lost. So the producer (this skill) must
+commit the plans; there is **no** automatic queue-manager copy.
+
+Copy the umbrella plan **and** every per-ticket plan into the repo and open a
+small docs PR (never commit to the default branch directly):
+
+```bash
+mkdir -p <repo-root>/.fleet/plans
+cp <plans-dir>/issue-<umbrella>.md <repo-root>/.fleet/plans/issue-<umbrella>.md
+for N in <child-1> <child-2> ...; do
+    cp <plans-dir>/issue-$N.md <repo-root>/.fleet/plans/issue-$N.md
+done
+# branch + commit + PR via the commit-and-push skill (filenames keep the
+# issue-<N>.md form — there is NO T-<NNN> rename).
+```
+
+The PR is docs-only (reviews fast). It does **not** need to merge before the
+head child is claimable — same-host workers read local staging — but a
+cross-host worker needs it merged, so land it promptly. Naming stays
+`issue-<N>.md`; the obsolete `T-<NNN>` rename is retired.
 
 ### 7. Post the umbrella summary comment
 
@@ -271,8 +302,8 @@ auto-approve).
 | Location | Purpose | Lifecycle |
 |---|---|---|
 | **architect plans dir** (`<slug>.md`) | Architect's draft, approved by user. | Session-local; archive after the epic ships. |
-| **plans dir** (`issue-<N>.md`) | Worker-facing plan (umbrella or per-ticket). | Persists. Queue-manager copies per-ticket files into the repo at ingest. |
-| **repo-side plan path** (`T-<NNN>.md`) | Final repo-side plan, renamed at ingest. | Lives in the repo until the ticket closes. |
+| **plans dir** (`issue-<N>.md`) | Local staging, pre-commit (same-host only). | Written in step 6; copied into the repo in step 6.5. |
+| **repo-side plan path** (`issue-<N>.md`) | Committed, authoritative plan workers read from master. | Committed via the step-6.5 docs PR; lives in the repo until the ticket closes. |
 
 ## When the architect plan is rough
 


### PR DESCRIPTION
## Summary

The #174 convention put plans in the repo at `.fleet/plans/issue-<N>.md` ("repo copy, synced from master"), and the **worker role docs read from there** — but only the consumer side was refined. The **producer side** (`file-epic` + the architect protocol) still wrote plans to `~/.fleet/plans/` (local staging) and relied on a *"queue-manager copies them to `T-<NNN>` at ingest"* step that isn't automated and **last ran 2026-05-24**. Net: **zero `issue-<N>.md` plans ever reached the repo**, and a worker on a different host finds no plan and falls back to the issue body.

Surfaced when filing epic #1553 — its 7 plans were stranded in local `~/.fleet/`.

### Backfill
- Adds the live detached-re-voxelize epic plans: `.fleet/plans/issue-1553.md` (umbrella) + P1–P6 children `issue-1555`–`1560.md`, so cross-host workers can read them from master.

### Flow fix (the producer gap)
- `docs/agents/skills/file-epic.md` + `.claude/skills/file-epic/SKILL.md`: new **step 6.5** (commit the plans into the repo); repo-side plans are `issue-<N>.md`; the obsolete *"queue-manager copies to `T-<NNN>` at ingest"* wording is retired (no `T-<NNN>` rename).
- `docs/agents/architect-protocol.md`: the design-block (3a) and direct-planning steps now **commit** the plan into the repo, not just write local staging.

## Notes
- A separate sweep for the other ~82 stranded local plans is **out of scope** — many are already-merged/closed issues whose plans are moot. This PR fixes the mechanism + backfills the one live epic.
- #1551/#1552 (the cube stopgap) were closed as superseded by epic #1553; their plans are intentionally **not** backfilled (closed issues).

## Test plan
- [x] Docs + plans only — no build.
- [x] `fleet-validate-stack 1553` passes (the backfilled plans match the filed stack).
- [x] No stale `T-<NNN>`/"queue-manager copies at ingest" claims remain in the file-epic flow.
- [x] Info-isolation clean (no private game content in plans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)