### PR TITLE
fleet: worker blocked-skip (#1528) + sonnet-author game feedback parity (#1534)

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -451,6 +451,12 @@ Do the work, then exit cleanly:
    containing `opus` whose:
    - **Owner** is `free` (or your worktree name)
    - **Blocked by** is empty (or only references already-merged work)
+   - **Not `fleet:blocked`** — the entry's `blocked` flag is `false`.
+     A `blocked: true` task was queued with an unresolved blocker under
+     the queue-all model (#1527); it is **not** a normal-tier pick — it
+     belongs to the stackable fallback tier below (which stacks it on the
+     blocker's open PR). Skipping it here avoids a plain claim on a task
+     that has no mergeable base yet.
    - **Issue is NOT referenced in any open PR's title or branch name**
      in **the same repo** (cross-check against the same repo's
      `prs[]` array from the cache)

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -130,7 +130,8 @@ Each iteration:
 
 1. **Check for feedback labels on open PRs.** Re-Read
    `~/.fleet/state/state.json` if its contents are no longer in your
-   conversation context. From `repos.engine.prs[]`, pick PRs whose
+   conversation context. From `repos.engine.prs[]` **and**
+   `repos.game.prs[]`, pick PRs whose
    `labels` array contains any of `human:needs-fix`,
    `human:blocker`, `fleet:needs-fix`, `fleet:has-nits` — but **skip
    any PR already carrying a `fleet:amending-*` label** (another
@@ -141,13 +142,18 @@ Each iteration:
    it owns the priority order, the detached-HEAD checkout flow,
    AMEND-vs-ESCALATE decision, the AMEND-path step sequence (a–h),
    label cycles, and the `fleet-pr-clear-feedback-labels` wrapper.
-   Sonnet-author is
-   engine-only and does NOT handle `fleet:design-unblocked` (only
-   opus-worker originates design escalations). Sonnet-author also
-   does NOT handle `fleet:semantic-conflict` — that label is
-   opus-worker's lane via its step 1c rebase flow. Reserve the
-   worktree on the `human:needs-fix` / `human:blocker` AMEND paths
-   via the author-only `fleet-claim reserve` step.
+   Sonnet-author handles feedback in **both** repos (engine + game),
+   mirroring its task coverage — for a **game** feedback PR, `cd` into
+   the game worktree and add `--repo jakildev/irreden` to every gh/git
+   op (and `--repo game` to `fleet-claim`), the same pattern as game
+   task pickup above (`fleet-pr-claim-feedback <N> <wt> --repo jakildev/irreden`).
+   Sonnet-author does NOT handle `fleet:design-unblocked` (only
+   opus-worker originates design escalations) nor
+   `fleet:semantic-conflict` (opus-worker's lane via its step 1c
+   rebase flow) — those are **role-tier** restrictions, not repo
+   restrictions. Reserve the worktree on the `human:needs-fix` /
+   `human:blocker` AMEND paths via the author-only `fleet-claim
+   reserve` step.
 
    Address all flagged PRs before picking new work.
 
@@ -191,6 +197,12 @@ Each iteration:
    `sonnet` whose:
    - **Owner** is `free` (or your worktree name)
    - **Blocked by** is empty (or only references already-merged work)
+   - **Not `fleet:blocked`** — the entry's `blocked` flag is `false`.
+     A `blocked: true` task was queued with an unresolved blocker under
+     the queue-all model (#1527); it is **not** a normal-tier pick — it
+     belongs to the stackable fallback tier (which stacks it on the
+     blocker's open PR). Skipping it here avoids a plain claim on a task
+     that has no mergeable base yet.
    - **Issue is NOT referenced in any open PR's title or branch name**
      (cross-check against `repos.engine.prs[]` from the cache)
 

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -443,11 +443,14 @@ branch itself if no new feedback PR is waiting.
 
 ## Game-side feedback work
 
-`role-opus-worker.md` covers both repos; `role-sonnet-author.md` is
-engine-only.
+This protocol is **symmetric across both author roles and both repos**:
+`role-opus-worker.md` **and** `role-sonnet-author.md` each cover engine
+**and** game feedback (each within its own model tier — opus-worker the
+`[opus]` PRs, sonnet-author the `[sonnet]` PRs). There is no engine-only
+carve-out for either role.
 
-For game-side feedback (opus-worker only), **cd into the game
-opus-worker worktree** before any git/gh ops:
+For game-side feedback, **cd into your role's game worktree** before any
+git/gh ops:
 
 ```
 cd ~/src/IrredenEngine/creations/game/.claude/worktrees/<your-worktree-name>


### PR DESCRIPTION
## Summary

Two human-applied self-config refinements from epic #1526 (the auto-mode classifier blocks a queue worker from editing its own role config, so these are applied interactively — they carry `fleet:needs-human`).

**#1528 — worker normal-tier skips `fleet:blocked` tasks.** Both worker role docs' normal pickup criteria now require `blocked == false`. Under the queue-all model (#1527) a `blocked: true` task has an unresolved blocker and no mergeable base, so it belongs to the stackable fallback tier (stacks on the blocker's open PR), not a plain claim. Mirrored verbatim in `role-opus-worker.md` + `role-sonnet-author.md`.

**#1534 — feedback handling symmetric across both repos for sonnet-author.** `role-sonnet-author.md` now scans `repos.engine.prs[]` **and** `repos.game.prs[]` and cd's into the game worktree with `--repo` for game feedback PRs (mirroring opus-worker + its own game task pickup). `FLEET-FEEDBACK-HANDLING.md` drops the "`role-sonnet-author.md` is engine-only" carve-out → one symmetric both-roles/both-repos protocol. The `fleet:design-unblocked` / `fleet:semantic-conflict` exclusions remain (now explicitly **role-tier**, not repo, restrictions).

## Scope note
These are the engine-tracked config edits. #1534's plan names exactly these two files (no separate game-repo doc), so it's complete here. #1528 is "engine worker role docs only" per its plan — complete.

## Test plan
- [x] Docs only — no build.
- [x] `#1528` mirrored identically in both worker docs.
- [x] `#1534` no remaining "sonnet-author is engine-only" statement; cross-repo references are coordination config (not game content).

Closes #1528
Closes #1534

🤖 Generated with [Claude Code](https://claude.com/claude-code)