### PR TITLE
fleet: enable game-side autonomous PR stacking (parity with engine)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -43,12 +43,13 @@ loop* for `repos.game.prs[]` — see "## Game-repo pass" after step 5.
 The 2-candidate-per-iteration cap is **shared** across both passes, so
 you rebase at most 2 PRs total per iteration regardless of repo.
 
-**Stacked-PR machinery is engine-only and that is correct, not a gap.**
-Steps 2.5, 2.6, a.5, and a.6 (stacked-base re-targeting, cascade
-rebase, fork detection) do not run in the game pass: game-side worker
-pickup skips stackable blockers (see FLEET.md "Cross-author stacking"),
-so game PRs are never stacked. The game pass is the plain conflict loop
-only.
+**Stacked-PR machinery runs in both passes.** Steps 2.5, 2.6, a.5, and
+a.6 (stacked-base re-targeting, cascade rebase, fork detection) run in
+the game pass too — game-side worker pickup now claims stackable
+blockers (see FLEET.md "Cross-author stacking"), so game PRs can be
+stacked and need the same maintenance as engine stacks. The game pass
+runs them over `repos.game.prs[]` with the game deltas (`--repo
+jakildev/irreden`, game merger worktree).
 
 You are conservative. The auto-resolution scope is intentionally narrow:
 
@@ -828,8 +829,18 @@ worktree, and `gh` target change.
 2g. **Gather + filter candidates** — same candidate rule and skip-label
     set as step 3 (CONFLICTING, or UNKNOWN updated >5m ago), over
     `repos.game.prs[]`.
+2.5g. **Reconcile + cascade-rebase stacked game PRs** — run steps 2.5
+    (reconcile stacked PRs whose base merged or closed — re-target to
+    `master` + `fleet:stacked`→`fleet:stacked-rebase`) and 2.6
+    (cascade-rebase stacked children whose still-open base force-pushed)
+    over `repos.game.prs[]`, exactly as the engine pass, with the game
+    deltas: cwd = game merger worktree, every `gh` call carries `--repo
+    jakildev/irreden`, and re-target/rebase run against the game
+    `origin`. Force-push rebases done here count toward the shared
+    ≤2-rebase budget.
 3g. **Resolve each candidate (within the shared cap)** — run step 5's
-    core resolution: **a** (detached checkout in the game worktree),
+    core resolution: **a** (detached checkout in the game worktree,
+    **including a.5 stacked-PR check and a.6 fork detection**),
     **b** (rebase guard pre-capture), **c** (`git rebase origin/master`),
     **d** (clean → push + comment + `fleet:merger-cooldown`;
     whitespace-only → resolve + push; semantic → `git rebase --abort`,
@@ -837,11 +848,11 @@ worktree, and `gh` target change.
     `fleet:merger-cooldown`, comment), **e** (post-rebase hunk check),
     **f** (reset the game worktree to scratch).
 
-    **Skip the stacked-PR steps entirely** — 2.5, 2.6, a.5 (stacked
-    re-target / cascade) and a.6 (fork detection). Game PRs are never
-    stacked (worker pickup skips game stackables), so `baseRefName` is
-    always `master` on game PRs; treat any game PR as the step-a.5
-    "base is `master`, proceed to step b" case without the lookup.
+    **Run the stacked-PR steps too** — game PRs can now be stacked
+    (`baseRefName != "master"`), so a.5's three sub-cases (base OPEN /
+    MERGED / CLOSED) and a.6's fork-of-other-PR check apply identically;
+    read `baseRefName` from `repos.game.prs[]` and do the base lookup
+    with `--repo jakildev/irreden`.
 
 Semantic game conflicts get `fleet:semantic-conflict` exactly like
 engine — **opus-worker covers game** (it has its own game worktree),

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -275,9 +275,10 @@ Do the work, then exit cleanly:
 
     For a game PR, `cd` into the game worktree before any git/gh op (the
     bash cwd persists across calls in the iteration), and reset *that*
-    worktree to scratch in step k. Game stacked-PRs don't exist (game
-    worker pickup skips stackables), so the stack-aware filter above is a
-    no-op for game.
+    worktree to scratch in step k. For a game PR, the stack-aware filter
+    applies identically: if the candidate's `baseRefName != master` and its
+    base also has `fleet:semantic-conflict`, skip the child and resolve the
+    base first (use `--repo jakildev/irreden` for the base PR lookup).
 
     If the filtered list is empty, skip to step 2. Otherwise pick
     the oldest (smallest `number`) and:

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -488,14 +488,16 @@ Do the work, then exit cleanly:
    **If no unblocked tasks are available on either repo, try the
    fallback tier.**
 
-   **Fallback: stackable-blocked tasks (engine only, v1).** Look in
-   `repos.engine.tasks.open[]` for entries where `owner == "free"` (or
-   your worktree name), `model` contains `opus`, AND the entry has a
-   `stackable_blocker_pr` field. Only single-blocker tasks have this
-   field — the scout does not set it for tasks with multiple `Blocked by:`
-   entries (Q3 decision: multi-blocker not eligible in v1). Skip game-side
-   tasks — game stackable pickup is deferred to v2; engine only in
-   this tier. Pick the oldest eligible engine task by task ID.
+   **Fallback: stackable-blocked tasks (engine + game).** Look in
+   `repos.engine.tasks.open[]` AND `repos.game.tasks.open[]` for entries
+   where `owner == "free"` (or your worktree name), `model` contains
+   `opus`, AND the entry has a `stackable_blocker_pr` field. Only
+   single-blocker tasks have this field — the scout does not set it for
+   tasks with multiple `Blocked by:` entries (Q3 decision: multi-blocker
+   not eligible in v1). Pick the oldest eligible task by task ID. **For a
+   `repo == "game"` task, `cd` into your game worktree and prefix the
+   claim with `--repo game`** — the merger's game pass now cascade-
+   rebases stacked game PRs, so the stack is maintained.
 
    If a stackable-blocked task is found, claim it with `--stackable-on`:
    `fleet-claim claim "<task-id>" <your-worktree-name> --stackable-on <stackable_blocker_pr.number>`

--- a/.claude/commands/role-sonnet-author.md
+++ b/.claude/commands/role-sonnet-author.md
@@ -225,14 +225,17 @@ Each iteration:
 
    **If no matching unblocked task exists, try the fallback tier.**
 
-   **Fallback: stackable-blocked tasks (engine only, v1).** Look in
-   `repos.engine.tasks.open[]` for entries where `owner == "free"` (or
-   your worktree name), `model` contains `sonnet`, AND the entry has a
-   `stackable_blocker_pr` field. Only single-blocker tasks have this
-   field — the scout does not set it for tasks with multiple `Blocked by:`
-   entries (Q3 decision: multi-blocker not eligible in v1). Skip game-side
-   tasks — game stackable pickup is deferred to v2; check
-   `repo == "engine"` only. Pick the oldest eligible task by task ID.
+   **Fallback: stackable-blocked tasks (engine + game).** Look in
+   `repos.engine.tasks.open[]` AND `repos.game.tasks.open[]` for entries
+   where `owner == "free"` (or your worktree name), `model` contains
+   `sonnet`, AND the entry has a `stackable_blocker_pr` field. Only
+   single-blocker tasks have this field — the scout does not set it for
+   tasks with multiple `Blocked by:` entries (Q3 decision: multi-blocker
+   not eligible in v1). Pick the oldest eligible task by task ID. **For a
+   `repo == "game"` task, follow the Cross-repo model above: `cd` into
+   your game worktree and prefix the claim with `--repo game`** — the
+   merger's game pass now cascade-rebases stacked game PRs, so the stack
+   is maintained.
 
    If a stackable-blocked task is found, claim it with `--stackable-on`:
    `fleet-claim claim "<task-id>" <your-worktree-name> --stackable-on <stackable_blocker_pr.number>`

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -553,14 +553,17 @@ Two stacking modes exist in this fleet:
   from multiple blockers is a design call the v1 merger machinery
   does not handle.
 
+Engine **and** game tasks are both stackable: the scout enriches
+blocked tasks in both repos, worker pickup claims `--stackable-on` in
+either (game with `--repo game`), and the merger's game pass runs the
+same stacked-base re-target / cascade-rebase / fork-detection (steps
+2.5/2.6/a.5/a.6) as the engine pass.
+
 **v1 limitations:**
 
-- Engine tasks only — the merger's game pass handles plain conflicts
-  but intentionally omits the stacked-PR cascade-rebase machinery
-  (steps 2.5/2.6/a.5/a.6), so a game stack would have no actor for the
-  cascade step. The scout may populate `stackable_blocker_pr` for game
-  tasks for visibility, but worker pickup skips them.
-- Single-blocker tasks only (see Q3).
+- Single-blocker tasks only (see Q3). A task blocked by 2+ open PRs is
+  never eligible for the fallback tier — the scout does not enrich it
+  with `stackable_blocker_pr`.
 
 For role-specific framing (when to stack, role-specific edge cases),
 see `role-sonnet-author.md` and `role-opus-worker.md`. For the

--- a/docs/design/fleet-queue-stacking.md
+++ b/docs/design/fleet-queue-stacking.md
@@ -101,11 +101,11 @@ the stackable tier and claims `--stackable-on <PR>`. This is the autonomous
 "feed stacking" half: the queue surfaces a blocked task *and* the PR it can
 stack on, in one record.
 
-Per-repo note: worker pickup honors `stackable_blocker_pr` for **engine** tasks
-only in v1 — the merger's cascade-rebase processes engine stacked PRs but the
-game pass does not yet. Game tasks are enriched in state but not picked up
-stackably (the gating lives in the role doc). Multi-blocker tasks are not
-eligible for stacking in v1 (`_single_blocker_issue` returns nothing for them).
+Per-repo note: worker pickup honors `stackable_blocker_pr` for tasks in **all
+repos** (engine and game) — the merger's cascade-rebase processes stacked PRs in
+both the engine pass and the game pass. A `repo == game` stackable task is
+claimed with `--repo game`. Multi-blocker tasks are not eligible for stacking in
+v1 (`_single_blocker_issue` returns nothing for them).
 
 ## Why reconcile leaves these alone
 


### PR DESCRIPTION
## Summary
Brings the game (downstream-creation) fleet to parity with the engine on autonomous PR stacking. #1527's queue-all + `fleet:blocked` + `stackable_blocker_pr` enrichment is already live for **both** repos, and `fleet-claim`/the scout already accept `--repo game` — so this is purely the role-doc self-config that was gated `fleet:needs-human`:

- **Merger game pass** (`role-merger.md`) now runs the stacked-PR machinery — steps 2.5/2.6 (stacked-base reconcile + cascade-rebase) and a.5/a.6 (stacked-PR check + fork detection) — over `repos.game.prs[]` with the game deltas (`--repo jakildev/irreden`, game merger worktree). The "engine-only and that is correct, not a gap" assertion is flipped.
- **Worker pickup** (`role-sonnet-author.md`, `role-opus-worker.md`) drops the engine-only guard so the stackable fallback tier claims `repo == game` tasks too (with `--repo game`).
- **Docs** (`FLEET.md`, `fleet-queue-stacking.md`) updated from "engine-only in v1" to "all repos."

Net effect: a game epic's blocked phases can stack on the predecessor's *open* PR and advance in parallel, instead of sitting `fleet:blocked` until the predecessor merges.

## Scope
Single-blocker parity only — matches engine behavior. Multi-blocker stacking (#1531) stays deferred. Part of epic #1526. Supersedes #1546 (closed as duplicate — the scout/`fleet-claim` "script side" it described is already game-capable).

## Test plan
- [ ] A `repo == game`, single-blocker task with an open blocker PR is claimed `--stackable-on` (with `--repo game`) and opens a `fleet:stacked` game PR based on `claude/<N>-…`.
- [ ] Merger game pass cascade-rebases the stacked child on blocker force-push (`--force-with-lease`).
- [ ] On blocker merge, merger re-targets the child base to `master` and swaps `fleet:stacked`→`fleet:stacked-rebase`.
- [ ] Doc-only change — no build impact.

Closes #1529
Closes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)