### PR TITLE
demos/chunk_streaming_smoke: fix stale ChunkDiskPersistence → ChunkVoxelDiskPersistence rename

### DIFF
--- a/creations/demos/chunk_streaming_smoke/main.cpp
+++ b/creations/demos/chunk_streaming_smoke/main.cpp
@@ -1,4 +1,4 @@
-// Chunk streaming smoke test — exercises the ChunkDiskPersistence +
+// Chunk streaming smoke test — exercises the ChunkVoxelDiskPersistence +
 // ChunkResidencyManager round-trip against a real voxel pool allocation.
 // Run with --auto-screenshot <N> for fleet-standard screenshot capture.
 
@@ -137,7 +137,7 @@ void initCommands() {
     IRCommand::registerCaptureCommands();
 }
 
-// Exercises ChunkDiskPersistence + ChunkResidencyManager against the real
+// Exercises ChunkVoxelDiskPersistence + ChunkResidencyManager against the real
 // voxel pool. Two test cases:
 //   1. Color round-trip: write → evict (saves) → reload → verify colors.
 //   2. Clean (never-dirtied) chunk must not produce a file on evict.
@@ -146,7 +146,7 @@ void runChunkSmokeTest() {
         IRConstants::kChunkSize.x * IRConstants::kChunkSize.y * IRConstants::kChunkSize.z;
     const std::string saveRoot = "save_files/chunk_smoke";
 
-    IRWorld::ChunkDiskPersistence persistence(saveRoot);
+    IRWorld::ChunkVoxelDiskPersistence persistence(saveRoot);
 
     IRWorld::ChunkResidencyManager::Config cfg{};
     cfg.voxelsPerChunk_ = kVolumeSize;


### PR DESCRIPTION
## Summary

`IRChunkStreamingSmoke` fails to build on master — `IRWorld::ChunkDiskPersistence` was renamed to `ChunkVoxelDiskPersistence`, but the demo's `main.cpp` still referenced the old name:

```
error: 'ChunkDiskPersistence' is not a member of 'IRWorld'; did you mean 'ChunkVoxelDiskPersistence'?
```

(The follow-on `'persistence' was not declared` error was a cascade of the failed type lookup.)

Pure rename — same constructor signature (`explicit ChunkVoxelDiskPersistence(std::string saveRoot)`), and `ChunkResidencyManager::Config::persistence_` is already typed `ChunkVoxelDiskPersistence*`. Two doc-comment references updated alongside the declaration.

## Test plan

- [x] `fleet-build --target IRChunkStreamingSmoke` — clean on `linux-debug`.
- [x] `fleet-run IRChunkStreamingSmoke --auto-screenshot 30` — exits cleanly, all three self-tests green:
  - `[chunk_smoke] PASS: dirty chunk written to disk`
  - `[chunk_smoke] PASS: color round-trip verified for 32768 voxels`
  - `[chunk_smoke] PASS: clean chunk not written to disk`
- [ ] macOS reviewer: trivial rename, no Metal surface touched.

Discovered during a platform-catchup cohort build on 2026-06-07. Not a rotation/backlog PR — a latent rename-drift break (same class as PR #1152's `command_close_window.hpp` include fix). The demo isn't in the smoke backlog, so it had no `needs-linux-smoke` label to catch it; the multi-target cohort build is what surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)