### PR TITLE
render: detached canvases composite at fixed depth — don't depth-sort/cast vs world geometry (#1582)

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -70,6 +70,16 @@
 // small cluster of GRID-mode cubes re-rasterizes via REBUILD_GRID_VOXELS
 // each frame, and the standard lighting pipeline (AO + sun + shadows)
 // runs so face orientation is visually perceptible.
+//
+// Rotation-mode contract (#1582): the DETACHED + DETACHED_REVOXELIZE
+// entities here (the orbit ring + the re-voxelize column) are SCREEN-LOCKED
+// overlays — ENTITY_CANVAS_TO_FRAMEBUFFER composites them at a fixed
+// framebuffer depth, so they do NOT cast shadows onto, receive shadows from,
+// or depth-sort against world geometry. Only the GRID-mode cubes are
+// world-integrated (they write world trixelDistances). So a world shadow
+// floor (#1587) reads shadows from the GRID cubes ONLY; the detached casters
+// not dropping shadows is by design, not a bug. World-integrating detached
+// canvases is tracked by P4b (#1576). See render/CLAUDE.md "Rotation modes".
 
 using namespace IRComponents;
 using namespace IREntity;

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -382,6 +382,45 @@ when extending or composing widgets:
   scrollable content by reading `scrollPos_` itself; it does not
   reparent into the scroll widget.
 
+## Rotation modes: GRID is world-integrated, DETACHED is a screen-locked overlay
+
+A rotating solid reaches the framebuffer through one of two `C_RotationMode`
+paths, and the choice determines whether it participates in world depth and
+lighting. This is a deliberate split, not an asymmetry to "fix" (#1582 decision):
+
+- **`GRID`** (the default) — `REBUILD_GRID_VOXELS` re-rasterizes the entity's
+  rotated voxels into the **shared world pool** every frame, so they write world
+  `trixelDistances` at their true iso depth (`x+y+z`). Consequence: GRID solids
+  **depth-sort against, cast shadows onto, and receive shadows from** world
+  geometry — they are fully world-integrated. Cost: per-frame world
+  re-rasterization + the documented round-to-cell aliasing (`voxel/CLAUDE.md`).
+
+- **`DETACHED` / `DETACHED_REVOXELIZE`** — the rotated solid renders on a
+  **private canvas** (camera-yaw-zeroed, at the camera origin) which
+  `ENTITY_CANVAS_TO_FRAMEBUFFER` (`system_entity_canvas_to_framebuffer.hpp`)
+  composites as a cheap **2D overlay at the iso screen position, at a FIXED
+  framebuffer depth** (`model` Z = 0, `distanceOffset_` = 0). This is the epic
+  #1553 decision-1 contract: cheap per-frame rotation with no world
+  re-rasterization. The deliberate cost: detached entities **do NOT** depth-sort
+  against, cast shadows onto, or receive shadows from world geometry — they never
+  write world `trixelDistances` at their world depth. `DETACHED_REVOXELIZE` only
+  changes *how* the private canvas is filled (GPU scatter bakes rotation into
+  integer cells, removing per-frame spin flicker); it is **still a screen-locked
+  overlay** — re-voxelize ≠ world-integrated.
+
+**Picking a mode:** need a rotating solid that casts/receives world shadows and
+sorts against world geometry (e.g. a grounded scene with a shadow floor) → use
+`GRID`. Need cheap, isolated rotation where world depth/shadow don't matter (HUD
+props, floating showcases) → use a `DETACHED` mode.
+
+**World-integrating detached canvases** (world-depth composite so detached
+entities depth-sort + cast/receive) is real future work, tracked by **P4b
+(#1576)** — it world-places the detached pool into the sun-shadow map / 128³
+light volume, and depth-composite falls out of that same placement. Do **not**
+bolt a per-entity world-depth Z onto the composite in isolation: it must land
+with the #1576 world-placement so the depth convention matches the GRID
+`trixelDistances` write.
+
 ## Gotchas
 
 - **SQT transition complete (T-299/T-300/T-301a/T-302).** All render-side, update-side, and voxel-side readers/writers use `C_LocalTransform` + `C_WorldTransform`. The voxel pool's per-voxel SoA arrays are a dedicated 16-byte `IRRender::VoxelGpuPosition` POD (std430 stride contract). The legacy `C_Position3D` / `C_PositionGlobal3D` / `C_Rotation` components and `SYSTEM_GLOBAL_POSITION_3D` were deleted in T-302; consumers read `C_WorldTransform.translation_` and the SQT quat directly.

--- a/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
@@ -126,6 +126,27 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
         // PROPAGATE_CANVAS_ROTATION → C_CanvasLocalRotation →
         // VOXEL_TO_TRIXEL_STAGE_1), so the composite TRS no longer
         // applies any rotation.
+        //
+        // SCREEN-LOCKED OVERLAY CONTRACT (#1582 decision, Option B).
+        // The model Z is a constant 0 and `distanceOffset_` (below) is 0,
+        // so every detached canvas — DETACHED and DETACHED_REVOXELIZE
+        // alike — composites at the SAME fixed framebuffer depth,
+        // regardless of the entity's world iso depth (x+y+z). This is
+        // intentional, the epic #1553 decision-1 contract: detached
+        // canvases render camera-yaw-zeroed at the camera origin and
+        // composite as a cheap 2D overlay at the iso screen position, so
+        // they pay no per-frame world re-rasterization. The deliberate
+        // cost: detached entities do NOT depth-sort against, cast shadows
+        // onto, or receive shadows from world geometry (they never write
+        // world `trixelDistances` at their world depth). GRID mode is the
+        // vehicle for world-integrated rotating solids — its voxels live
+        // in the world pool and sort/cast/receive correctly. World-depth
+        // composite for detached canvases (depth-sort + cast/receive) is
+        // tracked by P4b (#1576), which world-places the detached pool for
+        // the sun-shadow map / light-volume; depth-composite falls out of
+        // that same placement. Do not add a per-entity world-depth Z here
+        // in isolation — it must land with the #1576 world-placement so
+        // the depth convention matches the GRID `trixelDistances` write.
         mat4 model = translate(mat4(1.0f), vec3(entityFbCenter, 0.0f));
         model = scale(
             model,
@@ -141,7 +162,7 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
         fd.canvasZoomLevel_ = cameraZoom_;
         fd.cameraTrixelOffset_ = -entityIso;
         fd.textureOffset_ = vec2(0.0f);
-        fd.distanceOffset_ = 0;
+        fd.distanceOffset_ = 0; // fixed depth — screen-locked overlay (see contract above; #1582 / #1576)
         fd.mouseHoveredTriangleIndex_ = vec2(-1000000.0f);
         fd.effectiveSubdivisionsForHover_ = vec2(1.0f);
         fd.showHoverHighlight_ = 0.0f;


### PR DESCRIPTION
## Summary

Resolves #1582 as the **architect decision** it was filed to get: detached canvases (`RotationMode::DETACHED` and `DETACHED_REVOXELIZE`) are formally **screen-locked overlays** — they composite at a **fixed framebuffer depth** (`model` Z = 0, `distanceOffset_` = 0) and intentionally **do not** depth-sort against, cast shadows onto, or receive shadows from world geometry. This is the deliberate epic #1553 decision-1 contract (cheap per-frame rotation, no world re-rasterization). **GRID** mode is the vehicle for world-integrated rotating solids — its voxels live in the world pool and write world `trixelDistances`, so they sort/cast/receive correctly.

That fixed-depth placement was the shared root cause behind both symptoms the issue describes (detached cube floats vs the floor; detached cube drops no shadow): the composite sits at the iso 2D screen position with a constant depth, never the entity's world depth.

**Option A (world-depth composite) is real but is #1576's scope, not this task.** World-depth composite + cast/receive is the *same world-placement step* as P4b ("world sun-shadow + light-volume for detached solids"): once #1576 world-places the detached pool, depth-composite falls out of it. Folding it into #1582 would race the composite code with #1576. #1576 is annotated to subsume Option A.

So this PR is **docs only — no composite-code change**:
- `system_entity_canvas_to_framebuffer.hpp` — the screen-lock contract documented at the fixed-depth composite, with a pointer at `distanceOffset_`.
- `render/CLAUDE.md` — new **"Rotation modes: GRID is world-integrated, DETACHED is a screen-locked overlay"** section (when to pick which; how to world-integrate via #1576).
- `canvas_stress/main.cpp` — header note that the demo's detached casters (orbit + re-voxelize) don't drop world shadows by design (context for the #1587 shadow floor).

## Why Option B
You chose the "GRID-only shadow story" for the floor this session — that already accepted detached-as-screen-overlay. Reversing #1553 decision-1 (Option A) is a multi-PR world-placement effort that belongs with P4b, not a quick composite tweak. Documenting the contract now stops the next person from re-discovering it the hard way (as the floor demo did).

Closes #1582. Refs #1576 (subsumes Option A), #1587 (consumes the GRID-only contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
