### PR TITLE
render: guard detached per-axis scatter against degenerate screen-fill (#1584 D)

### DIFF
--- a/engine/render/src/shaders/metal/peraxis_scatter_detached.metal
+++ b/engine/render/src/shaders/metal/peraxis_scatter_detached.metal
@@ -109,6 +109,16 @@ vertex VertexOut v_peraxis_scatter_detached(
     // gap (which scales with pitch) closes at every scale without blobbing small cubes.
     // One sqrt of the larger squared edge — not two length() calls.
     const float pitchPx = sqrt(max(dot(su, su), dot(sv, sv)));
+    // Degenerate-projection guard (#1584 D) — see the GLSL twin. A rare residual
+    // / placement pose can explode pitchPx (and the dilation margin it drives)
+    // into a screen-filling smear for a frame, or make clipCorner non-finite.
+    if (!(pitchPx < max(fbRes.x, fbRes.y)) ||
+        any(isnan(clipCorner)) || any(isinf(clipCorner))) {
+        out.position = float4(2.0, 2.0, 2.0, 1.0);
+        out.color = float4(0.0);
+        out.depth = 1.0;
+        return out;
+    }
     const float detachedMargin = max(kScatterDilateMarginPx, kScatterDetachedPitchFraction * pitchPx);
     clipCorner.xy += scatterConservativeDilation(su, sv, sign(in.position), detachedMargin, ndcPerPx);
     clipCorner.y = -clipCorner.y;

--- a/engine/render/src/shaders/v_peraxis_scatter_detached.glsl
+++ b/engine/render/src/shaders/v_peraxis_scatter_detached.glsl
@@ -125,6 +125,19 @@ void main() {
     // small ones (a fixed bump big enough for large cubes over-grows small).
     // One sqrt of the larger squared edge — not two length() calls.
     float pitchPx = sqrt(max(dot(su, su), dot(sv, sv)));
+    // Degenerate-projection guard (#1584 D). A single forward-scattered face cell
+    // can never legitimately project wider than the framebuffer; at a rare
+    // residual / placement pose `pitchPx` (and the conservative-dilation margin
+    // it drives) can explode and smear this quad across the whole screen for a
+    // frame, or `clipCorner` can come out non-finite. Drop the instance instead
+    // — same off-screen degenerate the empty-cell branch uses.
+    if (!(pitchPx < max(fbRes.x, fbRes.y)) ||
+        any(isnan(clipCorner)) || any(isinf(clipCorner))) {
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+        vColor = vec4(0.0);
+        vDepth = 1.0;
+        return;
+    }
     float detachedMargin = max(kScatterDilateMarginPx, kScatterDetachedPitchFraction * pitchPx);
     clipCorner.xy += scatterConservativeDilation(su, sv, sign(aPos), detachedMargin, ndcPerPx);
     gl_Position = clipCorner;


### PR DESCRIPTION
## Summary

Defensive fix for #1584 item D — the sporadic "a detached cube renders a large part of the screen for a frame or two" glitch.

**Root cause.** The detached SO(3) forward-scatter (`v_peraxis_scatter_detached`) grows each face quad by a conservative-coverage margin that **scales with the projected cell pitch**:
```
detachedMargin = max(kScatterDilateMarginPx, kScatterDetachedPitchFraction * pitchPx)
```
At a rare residual / placement pose the projected pitch (and thus the margin) can explode, so the seam-closing dilation **smears one cell's quad across the whole framebuffer** for a frame.

**Fix.** A single forward-scattered face cell can never legitimately project wider than the framebuffer, so degenerate the instance off-screen — the same `(2,2,2,1)` clip-out the empty-cell branch already uses — when `pitchPx` is NaN or `>=` the framebuffer extent, or when `clipCorner` came out non-finite. GLSL + Metal both guarded.

## Verification
- Normal detached entities render **identically** on macOS/Metal (the guard threshold — a cell wider than the whole framebuffer — is ~50× a normal cell pitch, so it can't false-trigger on real geometry). No shader-compile errors; demo runs clean.
- The triggering pose is **rare and not deterministically reproducible**, so this is a *provably-correct degenerate-output guard*, not a repro-confirmed root-cause fix. If the underlying pitch explosion is later pinned to a specific residual construction (`octahedralSnapResidual` / `pos3DtoPos2DIsoRotated`), it can be addressed upstream too — noted on #1584.

## Scope
GLSL + Metal scatter shader only; no CPU change. Addresses **#1584** (D). The other #1584 items (B snap, C non-rotating entity) remain to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
