### PR TITLE
render: reconcile docs after re-voxelize/forward-scatter churn (#1588)

### DIFF
--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -38,11 +38,14 @@ Helpers:
 - `IRMath::pos3DtoPos2DIsoYawed(worldPos, visualYaw)` /
   `IRMath::pos3DtoPos2DIsoRotated(modelPos, rotation)` — continuous-rotation
   iso reposition. The first is `iso(R_z(−yaw)·world)` (1-DOF, smooth camera
-  Z-yaw, #1308); the second is its SO(3) companion `iso(R·model)` for a
-  detached entity's octahedral-snap residual (#1463). At identity / zero yaw
-  both collapse to `pos3DtoPos2DIso`, and a pure-Z quaternion `qZ(θ)` makes the
-  rotated form equal `pos3DtoPos2DIsoYawed(·, −θ)`. GPU mirrors of both in
-  `ir_iso_common.{glsl,metal}`, kept CPU↔GPU bit-identical. See
+  Z-yaw, #1308) — **live**; the second is its SO(3) companion `iso(R·model)`,
+  originally for a detached entity's octahedral-snap residual (#1463). That
+  forward-scatter consumer was **retired in #1560** (re-voxelize is now the sole
+  detached SO(3) path), so `pos3DtoPos2DIsoRotated` has no production caller
+  today — retained as the SO(3) iso primitive (math tests only). At identity /
+  zero yaw both collapse to `pos3DtoPos2DIso`, and a pure-Z quaternion `qZ(θ)`
+  makes the rotated form equal `pos3DtoPos2DIsoYawed(·, −θ)`. GPU mirrors of both
+  in `ir_iso_common.{glsl,metal}`, kept CPU↔GPU bit-identical. See
   [`docs/design/per-axis-trixel-canvas-rotation.md`](../../docs/design/per-axis-trixel-canvas-rotation.md).
 
 **Never inline these equations in system code.** Always call the helpers

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -664,8 +664,12 @@ constexpr vec2 pos3DtoPos2DIsoYawed(const vec3 worldPos, float visualYaw) {
 /// Caller rounds the continuous result with @ref roundHalfUp at the canvas-cell
 /// write, exactly as the yaw path does. GPU mirror: `pos3DtoPos2DIsoRotated` in
 /// `shaders/ir_iso_common.glsl` / `.metal` — `rotateByQuat` then the same iso
-/// columns, so CPU and GPU agree bit-for-bit. Consumed by the detached SO(3)
-/// forward-scatter composite (#1463 P2 → #1464 P3).
+/// columns, so CPU and GPU agree bit-for-bit. Originally the reposition for the
+/// detached SO(3) forward-scatter composite (#1463 P2 → #1464 P3); that consumer
+/// was **retired in #1560** when re-voxelize became the sole detached SO(3) path,
+/// so this helper currently has no production caller (math tests only). Retained
+/// as the SO(3) iso-projection primitive (the full-rotation companion to
+/// @ref pos3DtoPos2DIsoYawed).
 ///
 /// The iso columns `(-x + y, -x - y + 2z)` are inlined (matching the sibling
 /// @ref pos3DtoPos2DIsoYawed and the GPU mirror) rather than calling
@@ -1036,10 +1040,7 @@ constexpr vec2 cameraMoveRelativeToYaw(const vec2 isoDelta, const float visualYa
         return isoDelta;
     const float dx = isoDelta.x;
     const float dy = isoDelta.y;
-    return vec2(
-        ((c + 2.0f) * dx - s * dy) / det,
-        3.0f * (s * dx + c * dy) / det
-    );
+    return vec2(((c + 2.0f) * dx - s * dy) / det, 3.0f * (s * dx + c * dy) / det);
 }
 
 /// Projects @p position to screen space by scaling the iso result by

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -626,6 +626,8 @@ vec3 rotateByInverseQuat(vec3 v, vec4 q) {
 // only). Feed the octahedral-snap residual as `rotation`; at identity this is
 // pos3DtoPos2DIso(modelPos). CPU mirror: IRMath::pos3DtoPos2DIsoRotated —
 // rotateByQuat then the same iso columns keep CPU/GPU bit-identical (#1463).
+// No shader caller since #1560 retired the detached forward-scatter; retained
+// primitive (re-voxelize is the sole detached SO(3) path).
 vec2 pos3DtoPos2DIsoRotated(vec3 modelPos, vec4 rotation) {
     vec3 r = rotateByQuat(modelPos, rotation);
     return vec2(-r.x + r.y, -r.x - r.y + 2.0 * r.z);

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -561,6 +561,8 @@ inline float3 rotateByInverseQuat(float3 v, float4 q) {
 // only). Feed the octahedral-snap residual as `rotation`; at identity this is
 // pos3DtoPos2DIso(modelPos). CPU mirror: IRMath::pos3DtoPos2DIsoRotated —
 // rotateByQuat then the same iso columns keep CPU/GPU bit-identical (#1463).
+// No shader caller since #1560 retired the detached forward-scatter; retained
+// primitive (re-voxelize is the sole detached SO(3) path).
 inline float2 pos3DtoPos2DIsoRotated(float3 modelPos, float4 rotation) {
     const float3 r = rotateByQuat(modelPos, rotation);
     return float2(-r.x + r.y, -r.x - r.y + 2.0f * r.z);


### PR DESCRIPTION
## Summary

Bounded consolidation slice for #1588 (render cleanup after the re-voxelize / detached SO(3) churn). Investigation found that **#1581 (the P6 forward-scatter retirement) already absorbed nearly all of #1588's scope** — the code is clean (zero dangling symbols, no dead helpers, no stale render TODOs; reserved std140 padding is intentional), and the design doc + both render/math `CLAUDE.md` files already carry `RETIRED (#1560)` / shipped banners.

The one genuine remaining drift: `IRMath::pos3DtoPos2DIsoRotated` is now **orphaned** — its only consumer was the detached SO(3) forward-scatter, retired in #1560 (re-voxelize is the sole detached SO(3) path). It has **zero production callers** (only the math unit tests), yet its docstring, the `engine/math/CLAUDE.md` helper note, and the GLSL/Metal mirror comments still described it as actively serving detached-entity reposition. This PR reconciles all four mirror sites so a future agent reads it correctly as a retained-but-unused primitive, not active render wiring.

- `engine/math/include/irreden/ir_math.hpp` — docstring (was "Consumed by the detached SO(3) forward-scatter composite")
- `engine/math/CLAUDE.md` — helper note
- `engine/render/src/shaders/ir_iso_common.glsl` + `.../metal/ir_iso_common.metal` — mirror comments
- (clang-format also normalized one pre-existing un-wrapped line in `ir_math.hpp`)

**What this deliberately does NOT do — flagged for architect.** The honest prune would be to *delete* `pos3DtoPos2DIsoRotated` (+ its 3 mirrors + math tests) since it has no production caller. But it lives on the public `ir_math.hpp` surface, and the [engine API-removal rule](../blob/master/docs/agents/CLAUDE-BASELINE.md) routes superseded-public-API removal to a human/architect decision (external creations may consume it; a local grep isn't authoritative). So this slice **documents rather than deletes**. If you want it removed, a tiny follow-up task does it cleanly.

## Test plan

- [x] Comment/doc-only diff — no code tokens changed (provably no runtime effect), so the render-debug-loop is skipped per `engine/render/CLAUDE.md`'s pure-header-doc exception.
- [x] `grep` confirmed `pos3DtoPos2DIsoRotated` has zero production callers (math tests + definitions + cross-mirror comments only).
- [x] `fleet-build --target format-changed` clean.
- [x] Doc claims cross-checked against shipped reality (#1560 retirement via PR #1581; re-voxelize sole-path via render/CLAUDE.md).

Closes #1588

🤖 Generated with [Claude Code](https://claude.com/claude-code)