### PR TITLE
scripts/fleet: add fcntl mutex to reconcile persistence read-modify-write cycles (#1367)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -2349,7 +2349,7 @@ reconcile_escalate_drift() {
     local persistent_count
     persistent_count=$(NOW="$now" THRESHOLD="$threshold" PERSIST="$persist_file" \
         BODY="$body_file" python3 - "$findings" <<'PYEOF'
-import sys, os, json
+import sys, os, json, fcntl
 findings_path = sys.argv[1]
 now = int(os.environ["NOW"])
 threshold = int(os.environ["THRESHOLD"])
@@ -2378,27 +2378,29 @@ flag_only = [f for f in findings if not f.get("apply")]
 def key(f):
     return "%s:%s:%s:%s" % (f["rule"], f["repo"], f["target_kind"], f["target"])
 
-state = load(persist_path, {})
-if not isinstance(state, dict):
-    state = {}
+with open(persist_path + ".lock", "a") as _lock_fh:
+    fcntl.flock(_lock_fh.fileno(), fcntl.LOCK_EX)
+    state = load(persist_path, {})
+    if not isinstance(state, dict):
+        state = {}
 
-seen = {}
-for f in flag_only:
-    k = key(f)
-    prev = state.get(k) if isinstance(state.get(k), dict) else {}
-    seen[k] = {
-        "count": int(prev.get("count", 0)) + 1,
-        "first_seen": int(prev.get("first_seen", now)),
-        "last_seen": now,
-        "rule": f["rule"], "repo": f["repo"],
-        "target_kind": f["target_kind"], "target": f["target"],
-        "action": f["action"],
-    }
+    seen = {}
+    for f in flag_only:
+        k = key(f)
+        prev = state.get(k) if isinstance(state.get(k), dict) else {}
+        seen[k] = {
+            "count": int(prev.get("count", 0)) + 1,
+            "first_seen": int(prev.get("first_seen", now)),
+            "last_seen": now,
+            "rule": f["rule"], "repo": f["repo"],
+            "target_kind": f["target_kind"], "target": f["target"],
+            "action": f["action"],
+        }
 
-# Only this run's flag-only keys survive — keys absent this run reset to zero.
-with open(persist_path, "w") as fh:
-    json.dump(seen, fh, indent=2, sort_keys=True)
-    fh.write("\n")
+    # Only this run's flag-only keys survive — keys absent this run reset to zero.
+    with open(persist_path, "w") as fh:
+        json.dump(seen, fh, indent=2, sort_keys=True)
+        fh.write("\n")
 
 persistent = sorted(
     (v for v in seen.values() if v["count"] >= threshold),
@@ -2515,7 +2517,7 @@ reconcile_heal_design_unblock() {
     local healable
     healable=$(NOW="$now" THRESHOLD="$threshold" PERSIST="$persist_file" \
         python3 - "$findings" <<'PYEOF'
-import sys, os, json
+import sys, os, json, fcntl
 findings_path = sys.argv[1]
 now = int(os.environ["NOW"])
 threshold = int(os.environ["THRESHOLD"])
@@ -2543,27 +2545,29 @@ def key(f):
     a = f["apply"]
     return "%s:%s" % (a["repo"], a["pr"])
 
-state = load(persist_path, {})
-if not isinstance(state, dict):
-    state = {}
+with open(persist_path + ".lock", "a") as _lock_fh:
+    fcntl.flock(_lock_fh.fileno(), fcntl.LOCK_EX)
+    state = load(persist_path, {})
+    if not isinstance(state, dict):
+        state = {}
 
-seen = {}
-for f in heal:
-    k = key(f)
-    prev = state.get(k) if isinstance(state.get(k), dict) else {}
-    a = f["apply"]
-    seen[k] = {
-        "count": int(prev.get("count", 0)) + 1,
-        "first_seen": int(prev.get("first_seen", now)),
-        "last_seen": now,
-        "repo": a["repo"], "pr": a["pr"], "issue": a["issue"],
-    }
+    seen = {}
+    for f in heal:
+        k = key(f)
+        prev = state.get(k) if isinstance(state.get(k), dict) else {}
+        a = f["apply"]
+        seen[k] = {
+            "count": int(prev.get("count", 0)) + 1,
+            "first_seen": int(prev.get("first_seen", now)),
+            "last_seen": now,
+            "repo": a["repo"], "pr": a["pr"], "issue": a["issue"],
+        }
 
-# Only this run's keys survive — a finding absent this run resets to zero so a
-# transient one-tick blip (or a PR that just got claimed) never heals.
-with open(persist_path, "w") as fh:
-    json.dump(seen, fh, indent=2, sort_keys=True)
-    fh.write("\n")
+    # Only this run's keys survive — a finding absent this run resets to zero so a
+    # transient one-tick blip (or a PR that just got claimed) never heals.
+    with open(persist_path, "w") as fh:
+        json.dump(seen, fh, indent=2, sort_keys=True)
+        fh.write("\n")
 
 for v in sorted(seen.values(), key=lambda v: (v["repo"], str(v["pr"]))):
     if v["count"] >= threshold:


### PR DESCRIPTION
## Summary
- Both `reconcile_escalate_drift` and `reconcile_heal_design_unblock` had an unguarded read-increment-write cycle on their persistence JSON files; two concurrent `--apply` runs could race and lose one tick's increment on last-write-wins
- Fix wraps the critical section in `fcntl.flock(LOCK_EX)` on a sidecar `.lock` file (created lazily at the same path as the JSON + `.lock` suffix)
- Uses Python's `fcntl` module rather than the `flock(1)` CLI tool — `flock(1)` is absent on macOS, `fcntl` is available on both Linux and macOS

## Test plan
- [ ] Verify `fleet-claim reconcile --apply` still runs cleanly (dry run and live)
- [ ] Confirm the `.lock` sidecar files exist in `state_dir` and are zero-length; a separate process can immediately acquire `LOCK_EX` on them (no stale holder)
- [ ] Manual concurrent test: launch two `reconcile --apply` runs and confirm the final persistence JSON counts are consistent

Closes #1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)