### PR TITLE
fleet: task-boundary closeout in start-next-task + role re-hydrate

### DIFF
--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -127,6 +127,14 @@ fleet-claim --repo game claim 45 opus-worker-1
    steps below (game-side feedback, game-side needs-plan, game task
    pickup) and proceed with engine tasks only — do not abort the
    iteration.
+
+   **Then re-hydrate from your handoff file.** Each iteration runs in a fresh
+   context — if `~/.fleet/handoff/<your-agent-name>.md` exists and is newer than
+   your last iteration, read it: it is the previous task's closeout (shipped /
+   in-flight / durable decisions + pointers / drop-list) written by
+   `start-next-task`'s task-boundary closeout step. The fetch above restores the
+   *refs*; this restores the *context* (decisions just made, PRs in flight) the
+   fresh context dropped.
 3. **Read the shared fleet state cache** with the Read tool:
    `~/.fleet/state/state.json`. One Read replaces what used to be
    six `gh` / `git` calls here:

--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -101,11 +101,11 @@ prompt suggests:
    commit the last session left, which may be many merges behind.
 
    **Then re-hydrate from your handoff file.** If `~/.fleet/handoff/<role-name>.md`
-   exists and is newer than your last engagement, read it — it is the previous
-   task's closeout (shipped / in-flight / durable decisions + pointers / drop-list)
-   written by `start-next-task`'s task-boundary closeout step. The worktree sync
-   above restores the *code*; this restores the *context* a `/clear` dropped, so
-   you don't re-derive or contradict decisions just made or forget PRs in flight.
+   exists, read it — it is the previous task's closeout (shipped / in-flight /
+   durable decisions + pointers / drop-list) written by `start-next-task`'s
+   task-boundary closeout step. The worktree sync above restores the *code*; this
+   restores the *context* a `/clear` dropped, so you don't re-derive or contradict
+   decisions just made or forget PRs in flight.
 2. **Read the shared fleet state cache** with the Read tool:
    `~/.fleet/state/state.json`. Covers open PRs, the `fleet:design-blocked`
    filter, the feedback-label filter, and the issue-queue snapshot (open /

--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -99,6 +99,13 @@ prompt suggests:
    This step is non-negotiable because there is no `/loop` re-arming the role —
    a `/clear` drops you into a fresh context still checked out at whatever
    commit the last session left, which may be many merges behind.
+
+   **Then re-hydrate from your handoff file.** If `~/.fleet/handoff/<role-name>.md`
+   exists and is newer than your last engagement, read it — it is the previous
+   task's closeout (shipped / in-flight / durable decisions + pointers / drop-list)
+   written by `start-next-task`'s task-boundary closeout step. The worktree sync
+   above restores the *code*; this restores the *context* a `/clear` dropped, so
+   you don't re-derive or contradict decisions just made or forget PRs in flight.
 2. **Read the shared fleet state cache** with the Read tool:
    `~/.fleet/state/state.json`. Covers open PRs, the `fleet:design-blocked`
    filter, the feedback-label filter, and the issue-queue snapshot (open /

--- a/docs/agents/skills/start-next-task.md
+++ b/docs/agents/skills/start-next-task.md
@@ -93,6 +93,30 @@ gh pr list --head <old-branch-name> --state open --json number,url,title
   says what to do — un-PR'd work would be lost.
 - **Multiple PRs** → unusual. Note all of them and continue.
 
+### 2b. Task-boundary closeout (before the reset)
+
+Before switching branches, distill the task you just finished into a compact,
+high-signal handoff — so the next task starts lean but not amnesiac. Write it to
+`~/.fleet/handoff/<role-name>.md` (per-role, overwritten each boundary; shared
+`~/.fleet/` infra parameterized by your role name — it survives a `/clear` and is
+readable cross-host) AND keep a tight in-context copy. Four buckets:
+
+- **Shipped** — the PR(s) opened/merged this task, one-line outcome each.
+- **In flight / owed** — open PRs, follow-up issues filed, anything blocked-on.
+- **Durable decisions / lessons** — anything that should outlive the task, each
+  with a **pointer** to its durable home (a `docs/design/` doc, the feedback
+  file, or `~/.fleet/plans/issue-<N>.md`) — never duplicated inline.
+- **Drop list** — the prior context now safe to forget (tool dumps, resolved
+  escalations, superseded drafts).
+
+This **complements** the harness's automatic summarization, it does not replace
+it: the closeout is the agent-authored distillation the harness can't produce (it
+can't tell durable from droppable) and a re-hydration source the harness summary
+is not (re-read on the next task / after a `/clear` — see the role startup's
+"read your handoff file" step). Keep it lightweight by default and scale depth
+with context size — a long multi-task session warrants a fuller closeout, a quick
+two-task hop a one-liner. Always emit; scale the size, never skip.
+
 ### 3. Fetch latest remote default branch
 
 ```bash

--- a/docs/agents/skills/start-next-task.md
+++ b/docs/agents/skills/start-next-task.md
@@ -96,10 +96,12 @@ gh pr list --head <old-branch-name> --state open --json number,url,title
 ### 2b. Task-boundary closeout (before the reset)
 
 Before switching branches, distill the task you just finished into a compact,
-high-signal handoff — so the next task starts lean but not amnesiac. Write it to
-`~/.fleet/handoff/<role-name>.md` (per-role, overwritten each boundary; shared
-`~/.fleet/` infra parameterized by your role name — it survives a `/clear` and is
-readable cross-host) AND keep a tight in-context copy. Four buckets:
+high-signal handoff — so the next task starts lean but not amnesiac. Run
+`mkdir -p ~/.fleet/handoff/` first (other fleet steps create `~/.fleet/`
+subdirs explicitly; do the same here). Write the handoff to
+`~/.fleet/handoff/<role-name>.md` (per-role, overwritten each boundary;
+`~/.fleet/` survives a `/clear` on this host — and cross-host too if your
+`~/.fleet/` is synced) AND keep a tight in-context copy. Four buckets:
 
 - **Shipped** — the PR(s) opened/merged this task, one-line outcome each.
 - **In flight / owed** — open PRs, follow-up issues filed, anything blocked-on.


### PR DESCRIPTION
## Summary
Implements #1564 — a deliberate task-boundary context closeout so a long multi-task session (or a fresh `/clear`) starts lean but not amnesiac.

- **`start-next-task` (shared flow) — new step 2b "Task-boundary closeout"** (before the branch reset): distills the finished task into a four-bucket handoff — **shipped / in-flight-owed / durable-decisions (each with a pointer to its durable home) / drop-list** — written to `~/.fleet/handoff/<role-name>.md` **and** kept in-context. It **complements** the harness's automatic summarization (the agent-authored distillation the harness can't produce, and a re-hydration source it isn't), is **always emitted**, and **scales depth** with context size.
- **Consumption side — re-hydrate at startup:** the **architect** (`architect-protocol.md`) and **worker** (`role-opus-worker.md`) startups now read `~/.fleet/handoff/<role-name>.md` after the worktree sync, restoring the cross-task *context* the way the sync restores the *code*.

Design pass (4 decisions: written+in-context · complement · shared-structure/different-durable-home · always-emit-depth-scaled) recorded in `~/.fleet/plans/issue-1564.md`.

## Test plan
- [x] Cross-refs internally consistent — the closeout step and the two re-hydrate steps reference each other and both now exist; the delta-key row was removed (handoff path is shared `~/.fleet/` infra, referenced concretely).
- [ ] Reviewer spot-check: a `start-next-task` after this emits the closeout + writes the handoff, and the next role startup re-reads it.

Closes #1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)