### PR TITLE
render: per-axis cap depth-range term — WIP/design-blocked (#1469)

### DIFF
--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -1553,25 +1553,36 @@ inline ivec2 perAxisTrixelCanvasWorstCaseSize(
 ///     subPerAxisCapped = min(effSub, floor( canvasHalf / maxOnScreenWorldDisp ))
 ///
 /// `maxOnScreenWorldDisp` is the largest in-plane world displacement of an
-/// on-screen voxel from the camera-tracked anchor: the visible cardinal-iso
-/// half-extent (`cardinalExtent / 2·zoom`) inverted to world on the depth-0
-/// plane (the `isoPixelToPos3D` closed form: `|wx|,|wy| ≤ isoHalf.x/2 +
-/// isoHalf.y/6`, `|wz| ≤ isoHalf.y/3`), grown by the √2 residual-yaw rotation
-/// footprint the canvas was sized for (@ref kSqrt2). The cap MUST be computed
-/// CPU-side: `effSub = clamp(m_vrs × round(zoom), 1, 16)` conflates subdivision
-/// and zoom, so a shader given only `effSub` + `canvasSize` cannot recover the
-/// zoom-dependent on-screen extent — the host knows `zoom` and feeds the capped
-/// value through `voxelRenderOptions.y` so the store, the framebuffer scatter,
-/// and the per-axis AO/lighting recovery all share one consistent world↔cell
-/// scale. Pass the same @p minOnScreenTrixelPx used to allocate the canvas
+/// on-screen voxel from the camera-tracked anchor. It has two terms:
+///   • the visible cardinal-iso half-extent (`cardinalExtent / 2·zoom`)
+///     inverted to world on the depth-0 plane (the `isoPixelToPos3D` closed
+///     form: `|wx|,|wy| ≤ isoHalf.x/2 + isoHalf.y/6`, `|wz| ≤ isoHalf.y/3`);
+///   • the depth-range term (#1469): a visible voxel at iso depth d = x+y+z
+///     sits at `world0(iso) + (d/3)·(1,1,1)`, which adds `d/3` to BOTH canvas
+///     axes of every face. d is scene-dependent and unbounded, so it is bounded
+///     here by the canvas-storable depth at the uncapped @p effSub —
+///     `canvasHalf.y / (√2·effSub)` — rather than read back from the depth
+///     texture; deeper cells clip to background harmlessly. See the body.
+/// Both terms are grown by the √2 residual-yaw rotation footprint the canvas was
+/// sized for (@ref kSqrt2). The cap MUST be computed CPU-side: `effSub =
+/// clamp(m_vrs × round(zoom), 1, 16)` conflates subdivision and zoom, so a
+/// shader given only `effSub` + `canvasSize` cannot recover the zoom-dependent
+/// on-screen extent — the host knows `zoom` and feeds the capped value through
+/// `voxelRenderOptions.y` so the store, the framebuffer scatter, and the
+/// per-axis AO/lighting recovery all share one consistent world↔cell scale.
+/// Pass the uncapped @p effSub (the requested density before this cap) and the
+/// same @p minOnScreenTrixelPx used to allocate the canvas
 /// (e.g. `kMinOnScreenTrixelSizePx`) so the cap is sized against the actual
 /// allocated canvas rather than the default. Returns ≥ 1.
 inline int perAxisSubdivisionCap(
-    const ivec2 cardinalExtent, const vec2 zoom, const float minOnScreenTrixelPx = 1.0f
+    const ivec2 cardinalExtent, const vec2 zoom, const int effSub,
+    const float minOnScreenTrixelPx = 1.0f
 ) {
     const float W = static_cast<float>(cardinalExtent.x);
     const float H = static_cast<float>(cardinalExtent.y);
     const ivec2 canvasSize = perAxisTrixelCanvasWorstCaseSize(cardinalExtent, minOnScreenTrixelPx);
+    const float canvasHalfX = 0.5f * static_cast<float>(canvasSize.x);
+    const float canvasHalfY = 0.5f * static_cast<float>(canvasSize.y);
     // Smaller zoom ⇒ larger visible extent ⇒ tighter cap; clamp away from 0.
     const float isoHalfX = W / (2.0f * max(zoom.x, 1e-3f));
     const float isoHalfY = H / (2.0f * max(zoom.y, 1e-3f));
@@ -1581,10 +1592,28 @@ inline int perAxisSubdivisionCap(
     // At depth=0 (x+y+z=0): iso.y=-x-y+2z=3z → z=iso.y/3, y=iso.x/2-iso.y/6.
     const float maxInPlaneXY = 0.5f * isoHalfX + isoHalfY / 6.0f;
     const float maxInPlaneZ = isoHalfY / 3.0f;
-    const float maxDispX = maxInPlaneXY;
-    const float maxDispY = max(maxInPlaneZ, maxInPlaneXY);
-    const float capX = (0.5f * static_cast<float>(canvasSize.x)) / (kSqrt2 * maxDispX);
-    const float capY = (0.5f * static_cast<float>(canvasSize.y)) / (kSqrt2 * maxDispY);
+    // Depth-range term (#1469). An on-screen voxel at iso depth d = x+y+z does
+    // NOT lie on the depth-0 plane: isoPixelToPos3D(iso, d) = world0(iso) +
+    // (d/3)·(1,1,1). faceInPlaneCoords selects two of three components, and the
+    // (1,1,1) shift has all-equal components, so it adds exactly d/3 to BOTH
+    // canvas axes of every face — an additive term the depth-0 spread above
+    // misses, so deep scenes still clip at non-cardinal yaw. d is scene-
+    // dependent and unbounded, and this cap is CPU-side with no depth read, so
+    // bound the depth contribution (world units) by the deepest cell the canvas
+    // can store at the uncapped effSub on the z→canvas-Y axis:
+    //   depthAllowance = canvasHalfY / (√2·effSub).
+    // Capping subPerAxis against (isoTerm + depthAllowance) makes exactly that
+    // depth band — d/3 ≤ depthAllowance — fit; cells deeper than depthAllowance·3
+    // still drop to background (isInsideCanvas — no corruption), the documented
+    // residual trade. As effSub grows the allowance shrinks, converging to the
+    // depth-0 cap. The tighter cap costs sub-voxel rotating detail; restoring
+    // that detail (fractional micro-offset, base-resolution lattice) is the
+    // separate end-state tracked by #1458 — #1469 only stops the clip.
+    const float depthAllowance = canvasHalfY / (kSqrt2 * static_cast<float>(max(effSub, 1)));
+    const float maxDispX = maxInPlaneXY + depthAllowance;
+    const float maxDispY = max(maxInPlaneZ, maxInPlaneXY) + depthAllowance;
+    const float capX = canvasHalfX / (kSqrt2 * maxDispX);
+    const float capY = canvasHalfY / (kSqrt2 * maxDispY);
     return max(static_cast<int>(floor(min(capX, capY))), 1);
 }
 

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -44,6 +44,12 @@ the ECS surface.
   store and the lighting/scatter recovery share that one scale through
   `voxelRenderOptions.y` so cells map back to world consistently. A new
   per-axis pass (e.g. the SDF-per-axis follow-up) must cap the same way.
+  The cap also folds in the **depth-range term (#1469):** a visible voxel at
+  iso depth `d = x+y+z` sits at `world0(iso) + (d/3)·(1,1,1)`, adding `d/3` to
+  both canvas axes, so deep scenes clip past the iso-rect spread; the cap bounds
+  that contribution by the canvas-storable depth at `effSub` (no depth readback).
+  The tighter cap costs sub-voxel rotating detail — restoring it (base-resolution
+  lattice + fractional micro-offset) is the separate end-state tracked by #1458.
 - `C_TrixelCanvasRenderBehavior` — toggles: use camera pan/zoom, run
   subdivisions, hover detection, pixel offset, etc.
 - `C_TrixelFramebuffer` — wraps a `Framebuffer` (color + depth). Also

--- a/engine/prefabs/irreden/render/per_axis_canvas.hpp
+++ b/engine/prefabs/irreden/render/per_axis_canvas.hpp
@@ -116,6 +116,7 @@ inline int subdivisionDensity() {
     const int cap = IRMath::perAxisSubdivisionCap(
         (*cardinal.value()).size_,
         IRRender::getCameraZoom(),
+        effSub,
         kMinOnScreenTrixelSizePx
     );
     return IRMath::clamp(effSub, 1, cap);

--- a/test/render/per_axis_canvas_size_test.cpp
+++ b/test/render/per_axis_canvas_size_test.cpp
@@ -11,7 +11,9 @@ namespace {
 
 using IRMath::ivec2;
 using IRMath::kSqrt2;
+using IRMath::perAxisSubdivisionCap;
 using IRMath::perAxisTrixelCanvasWorstCaseSize;
+using IRMath::vec2;
 
 // Helper: ceil(scale * extent) the same way the implementation does.
 int ceilScale(int extent, float scale) {
@@ -85,6 +87,95 @@ TEST(PerAxisCanvasSize, Deterministic) {
     EXPECT_EQ(
         perAxisTrixelCanvasWorstCaseSize(extent, 1.0f).y,
         perAxisTrixelCanvasWorstCaseSize(extent, 1.0f).y
+    );
+}
+
+// --- IRMath::perAxisSubdivisionCap (#1431 clip cap + #1469 depth-range term) ---
+//
+// The cap bounds the per-axis store's `subPerAxis` so the worst-case on-screen
+// face-local cell stays inside the bounded canvas. It accounts for two terms:
+// the depth-0 iso-rect spread (#1431) and the additive depth-range term (#1469)
+// — a voxel at iso depth d sits at world0(iso) + (d/3)·(1,1,1), adding d/3 to
+// both canvas axes, bounded by the canvas-storable depth at the uncapped effSub.
+
+// Always at least 1: the per-axis store must accept a single base cell even when
+// the visible extent is enormous (extreme zoom-out ⇒ tiny zoom ⇒ huge iso rect).
+TEST(PerAxisSubdivisionCap, NeverBelowOne) {
+    EXPECT_GE(perAxisSubdivisionCap(ivec2{480, 270}, vec2{0.01f, 0.01f}, 16), 1);
+    EXPECT_GE(perAxisSubdivisionCap(ivec2{64, 64}, vec2{1.0f, 1.0f}, 1), 1);
+}
+
+// The depth-range term only ever TIGHTENS the cap: adding the depth allowance
+// can never raise the cap above the depth-0-only bound. The depth-0 bound is the
+// limit as effSub → ∞ (depthAllowance = canvasHalfY/(√2·effSub) → 0), so a
+// finite-effSub cap must not exceed the large-effSub cap.
+TEST(PerAxisSubdivisionCap, DepthTermNeverLoosens) {
+    const ivec2 extent{480, 270};
+    const vec2 zoom{4.0f, 4.0f};
+    const int depth0Limit = perAxisSubdivisionCap(extent, zoom, 1 << 20);
+    EXPECT_LE(perAxisSubdivisionCap(extent, zoom, 2), depth0Limit);
+    EXPECT_LE(perAxisSubdivisionCap(extent, zoom, 8), depth0Limit);
+    EXPECT_LE(perAxisSubdivisionCap(extent, zoom, 16), depth0Limit);
+}
+
+// Cap is monotonic non-decreasing in effSub: a larger requested density shrinks
+// the depth allowance (canvasHalfY/(√2·effSub)), so the cap relaxes upward
+// toward the depth-0 bound. This is the #1469 self-consistency property — the
+// allowance assumes "as deep as effSub can store," which loosens as effSub rises.
+TEST(PerAxisSubdivisionCap, MonotonicNonDecreasingInEffSub) {
+    const ivec2 extent{640, 360};
+    const vec2 zoom{8.0f, 8.0f};
+    int prev = perAxisSubdivisionCap(extent, zoom, 1);
+    for (int effSub = 2; effSub <= 16; ++effSub) {
+        const int cap = perAxisSubdivisionCap(extent, zoom, effSub);
+        EXPECT_GE(cap, prev) << "effSub=" << effSub;
+        prev = cap;
+    }
+}
+
+// Higher zoom ⇒ smaller visible iso extent ⇒ the iso-rect term shrinks while the
+// depth allowance (zoom-independent at fixed effSub) is unchanged, so the cap
+// relaxes upward. Holding effSub fixed, the cap is non-decreasing in zoom.
+TEST(PerAxisSubdivisionCap, HigherZoomLoosensCap) {
+    const ivec2 extent{480, 270};
+    const int effSub = 16;
+    const int capZoom1 = perAxisSubdivisionCap(extent, vec2{1.0f, 1.0f}, effSub);
+    const int capZoom4 = perAxisSubdivisionCap(extent, vec2{4.0f, 4.0f}, effSub);
+    const int capZoom8 = perAxisSubdivisionCap(extent, vec2{8.0f, 8.0f}, effSub);
+    EXPECT_GE(capZoom4, capZoom1);
+    EXPECT_GE(capZoom8, capZoom4);
+}
+
+// The cap guarantees the depth band it claims fits: a face-local cell at the
+// worst-case iso displacement AND depth d/3 = depthAllowance, deformed by the √2
+// residual-yaw footprint, must land inside the canvas at subPerAxis = cap. We
+// reconstruct the bound the body uses and assert the cell is in-canvas.
+TEST(PerAxisSubdivisionCap, ClaimedDepthBandFitsCanvas) {
+    const ivec2 extent{640, 360};
+    const vec2 zoom{4.0f, 4.0f};
+    const int effSub = 16;
+    const int cap = perAxisSubdivisionCap(extent, zoom, effSub);
+
+    const ivec2 canvasSize = perAxisTrixelCanvasWorstCaseSize(extent, 1.0f);
+    const float canvasHalfY = 0.5f * static_cast<float>(canvasSize.y);
+    const float isoHalfX = static_cast<float>(extent.x) / (2.0f * zoom.x);
+    const float isoHalfY = static_cast<float>(extent.y) / (2.0f * zoom.y);
+    const float maxInPlaneXY = 0.5f * isoHalfX + isoHalfY / 6.0f;
+    const float maxInPlaneZ = isoHalfY / 3.0f;
+    const float depthAllowance = canvasHalfY / (kSqrt2 * static_cast<float>(effSub));
+    // Worst-case canvas-Y displacement (cells) of a stored voxel at the claimed
+    // depth band, grown by the √2 yaw footprint — must not exceed the half-canvas.
+    const float worstCellY =
+        static_cast<float>(cap) * kSqrt2 * (IRMath::max(maxInPlaneZ, maxInPlaneXY) + depthAllowance);
+    EXPECT_LE(worstCellY, canvasHalfY + 1.0f); // +1 slack for the floor() in cap
+}
+
+// Pure function of its inputs — no per-frame variance.
+TEST(PerAxisSubdivisionCap, Deterministic) {
+    const ivec2 extent{480, 270};
+    const vec2 zoom{2.0f, 2.0f};
+    EXPECT_EQ(
+        perAxisSubdivisionCap(extent, zoom, 8), perAxisSubdivisionCap(extent, zoom, 8)
     );
 }
 


### PR DESCRIPTION
WIP for #1469 — **design-blocked**, see the `## NEEDS-DESIGN` comment below.

## What this implements (Option 2)
Folds the depth-range term into `IRMath::perAxisSubdivisionCap` so the per-axis
store stops clipping deep scenes under camera Z-yaw. A visible voxel at iso depth
`d = x+y+z` sits at `world0(iso) + (d/3)·(1,1,1)`; `faceInPlaneCoords` selects two
of three equal components, so the shift adds `d/3` to **both** canvas axes of every
face — the additive term the depth-0-only cap missed (#1431 covered only the iso-rect
spread). `d` is scene-dependent/unbounded and the cap is CPU-side with no depth read,
so the depth contribution is bounded (readback-free) by the canvas-storable depth at
the uncapped `effSub`: `depthAllowance = canvasHalf.y / (√2·effSub)`.

- Pure CPU math; only active while rotating (residual yaw > deadband) → cardinal stays byte-identical.
- No shader/parity surface touched.
- Builds clean; **12/12** per-axis math tests pass (6 new `perAxisSubdivisionCap` cases).

## Why it's design-blocked
Computing Option 2's effect on the standard demo (`cardinalExtent ≈ 640×720`):

| shot | effSub | original cap | new cap | subPerAxis |
|---|---|---|---|---|
| `zoom4_yaw45` | 4 | 8 (no bite) | **2** | **4 → 2 (halved)** |

Option 2 **regresses the common case** (zoom4 rotating, where there is currently no
clip and full detail) because a readback-free depth bound is scene-blind — it must
assume worst-case depth and over-caps shallow/common scenes. This contradicts the
issue's premise ("not a regression," "the residual only appears in scenes with a
large visible depth range"). See the `## NEEDS-DESIGN` comment for the alternatives
and recommendation.

Closes #1469 (pending the design decision).