### PR TITLE
render: per-axis scatter depth (#1457) — WIP/design-blocked (lead is a no-op, real cause upstream)

### DIFF
--- a/engine/render/src/shaders/f_peraxis_scatter.glsl
+++ b/engine/render/src/shaders/f_peraxis_scatter.glsl
@@ -11,8 +11,10 @@
 
 #version 450 core
 
-flat in vec4 vColor;
-flat in float vDepth;
+flat   in vec4  vColor;
+smooth in float vYawedDepth;  // continuous yawed iso depth across the face (#1457)
+flat   in float vDepthBias;   // slot + distanceOffset - kMin
+flat   in float vDepthScale;  // 1 / (kMax - kMin)
 
 out vec4 FragColor;
 
@@ -21,5 +23,10 @@ void main() {
         discard;
     }
     FragColor = vColor;
-    gl_FragDepth = vDepth;
+    // Per-fragment composite depth (#1457): round the interpolated yawed depth
+    // to its integer iso band HERE (per pixel, matching the SDF path's
+    // per-pixel roundHalfUp), then fold in the *4 + slot SDF co-sort and
+    // normalize into the framebuffer depth range. floor(x + 0.5) is the inlined
+    // roundHalfUp (ir_iso_common.glsl) — ties round up, matching CPU/SDF.
+    gl_FragDepth = (floor(vYawedDepth + 0.5) * 4.0 + vDepthBias) * vDepthScale;
 }

--- a/engine/render/src/shaders/metal/peraxis_scatter.metal
+++ b/engine/render/src/shaders/metal/peraxis_scatter.metal
@@ -45,7 +45,15 @@ struct FrameDataIsoTriangles {
 struct VertexOut {
     float4 position [[position]];
     float4 color [[flat]];
-    float depth [[flat]];
+    // Per-fragment composite depth (#1457): the yawed iso depth interpolates
+    // SMOOTHLY across the face (default perspective interpolation, == linear
+    // here since w==1) and the fragment rounds it per-pixel, then folds in the
+    // *4 + slot SDF co-sort via the flat bias/scale. Mirror of v_/f_peraxis
+    // _scatter.glsl. The old flat per-face depth scrambled interleaved voxel
+    // faces (#1370 residual).
+    float yawedDepth;          // continuous yawed iso depth across the face
+    float depthBias [[flat]];  // slot + distanceOffset - kMin
+    float depthScale [[flat]]; // 1 / (kMax - kMin)
 };
 
 struct FragmentOut {
@@ -81,7 +89,9 @@ vertex VertexOut v_peraxis_scatter(
     if (color.a < 0.1f) {
         out.position = float4(2.0, 2.0, 2.0, 1.0);
         out.color = float4(0.0);
-        out.depth = 1.0;
+        out.yawedDepth = 0.0;
+        out.depthBias = 0.0;
+        out.depthScale = 0.0;
         return out;
     }
 
@@ -127,18 +137,22 @@ vertex VertexOut v_peraxis_scatter(
     out.position = clipCorner;
 
     out.color = color;
-    // Yaw-consistent composite depth (#1370) — mirror of v_peraxis_scatter.glsl.
-    // `rawDepth` is the origin-recovery key (unchanged); re-derive the composite
-    // depth from the recovered origin rotated by R_z(-visualYaw) so it matches
-    // the YAWED screen projection and co-sorts with the SDF. Keeps the *4 + slot
-    // encoding. Per-axis is residual-only -> cardinal fast path byte-identical.
+    // Per-fragment composite depth (#1370, #1457) — mirror of
+    // v_peraxis_scatter.glsl. `rawDepth` is the origin-recovery key (unchanged).
+    // Derive the yawed depth at THIS corner (worldCorner) and emit it SMOOTH so
+    // the fragment rounds it per-pixel (matching the SDF path) instead of one
+    // flat per-face value (the #1370 residual that scrambled interleaved voxel
+    // faces). The *4 + slot co-sort stays integer because the fragment rounds
+    // before the *4 (a continuous depth + a 0..3 slot offset would invert
+    // across the band boundary). Per-axis is residual-only -> cardinal fast
+    // path byte-identical.
     const float yc = cos(frameData.visualYaw);
     const float ys = sin(frameData.visualYaw);
-    const float dvx = origin.x * yc + origin.y * ys;
-    const float dvy = -origin.x * ys + origin.y * yc;
-    const int yawedDist = roundHalfUp(dvx + dvy + origin.z) * 4 + slot;
-    out.depth = float(yawedDist + frameData.distanceOffset - globals.kMinTriangleDistance) /
-                float(globals.kMaxTriangleDistance - globals.kMinTriangleDistance);
+    const float dvx = worldCorner.x * yc + worldCorner.y * ys;
+    const float dvy = -worldCorner.x * ys + worldCorner.y * yc;
+    out.yawedDepth = dvx + dvy + worldCorner.z;
+    out.depthBias = float(slot + frameData.distanceOffset - globals.kMinTriangleDistance);
+    out.depthScale = 1.0f / float(globals.kMaxTriangleDistance - globals.kMinTriangleDistance);
     return out;
 }
 
@@ -148,6 +162,10 @@ fragment FragmentOut f_peraxis_scatter(VertexOut in [[stage_in]]) {
         discard_fragment();
     }
     out.color = in.color;
-    out.depth = in.depth;
+    // Per-fragment composite depth (#1457): round the interpolated yawed depth
+    // to its integer iso band per-pixel (matching the SDF path), fold in the
+    // *4 + slot co-sort, normalize into framebuffer depth. floor(x + 0.5) is
+    // the inlined roundHalfUp (ties up, matching CPU/SDF).
+    out.depth = (floor(in.yawedDepth + 0.5f) * 4.0f + in.depthBias) * in.depthScale;
     return out;
 }

--- a/engine/render/src/shaders/v_peraxis_scatter.glsl
+++ b/engine/render/src/shaders/v_peraxis_scatter.glsl
@@ -51,7 +51,16 @@ layout (std140, binding = 3) uniform FrameDataIsoTriangles {
 };
 
 flat out vec4 vColor;
-flat out float vDepth;
+// Per-fragment composite depth (#1457). The yawed iso depth is interpolated
+// SMOOTHLY across the face (vYawedDepth) and the fragment shader rounds it
+// per-pixel, then folds in the *4 + slot SDF co-sort via the flat bias/scale.
+// The old flat per-face value (#1370) gave the whole face quad ONE quantized
+// depth, so interleaved faces of adjacent voxels collided in the roundHalfUp
+// bands -> scrambled front/back blocks; the SDF path is clean precisely
+// because it rounds depth per-pixel (c_shapes_to_trixel smoothYaw).
+smooth out float vYawedDepth;  // continuous yawed iso depth across the face
+flat   out float vDepthBias;   // slot + distanceOffset - kMin (the *4+slot co-sort offset)
+flat   out float vDepthScale;  // 1 / (kMax - kMin), normalize into framebuffer depth
 
 // In-plane corner of a face whose `origin` ALREADY sits at the face plane on
 // the fixed axis. The store (c_voxel_to_trixel_stage_{1,2}) bakes the polarity
@@ -79,7 +88,9 @@ void main() {
     if (color.a < 0.1) {
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
         vColor = vec4(0.0);
-        vDepth = 1.0;
+        vYawedDepth = 0.0;
+        vDepthBias = 0.0;
+        vDepthScale = 0.0;
         return;
     }
 
@@ -136,22 +147,30 @@ void main() {
     gl_Position = clipCorner;
 
     vColor = color;
-    // Yaw-consistent composite depth (#1370). The stored `rawDepth` (= un-yawed
-    // world x+y+z) is the face-local origin-recovery KEY and must not change.
-    // But the framebuffer depth test must order by the depth that matches the
-    // YAWED screen projection above (iso of R_z(-visualYaw)*world), not the
-    // un-yawed metric — otherwise the ordering diverges from the on-screen
-    // placement as residual yaw grows and a low/back surface (the ground
-    // platform) wins the depth test against geometry above it near +/-45 deg.
-    // Re-derive the composite depth from the recovered origin, rotated by
-    // R_z(-visualYaw); keep the *4 + slot encoding so it co-sorts with the SDF
-    // (c_shapes_to_trixel smoothYaw applies the identical transform). Per-axis
-    // is residual-only, so the cardinal fast path is untouched (byte-identical).
+    // Yaw-consistent composite depth (#1370, #1457). The stored `rawDepth`
+    // (= un-yawed world x+y+z) is the face-local origin-recovery KEY and must
+    // not change. The framebuffer depth test must order by the depth that
+    // matches the YAWED screen projection above (iso of R_z(-visualYaw)*world),
+    // not the un-yawed metric — otherwise the ordering diverges from the
+    // on-screen placement as residual yaw grows and a low/back surface (the
+    // ground platform) wins the depth test against geometry above it near
+    // +/-45 deg.
+    //
+    // #1457: derive the yawed depth at THIS corner (worldCorner, already
+    // computed for the position) and emit it as a SMOOTH varying so the
+    // fragment depth interpolates across the face. The fragment then rounds it
+    // per-pixel (roundHalfUp) and applies the *4 + slot co-sort — matching the
+    // SDF path's per-pixel rounding (c_shapes_to_trixel smoothYaw applies the
+    // identical R_z(-visualYaw) transform). Rounding must stay in the fragment
+    // (before the *4): a continuous depth plus a 0..3 slot offset would invert
+    // across the *4 band boundary, so the integer encoding is preserved by
+    // quantizing first. Per-axis is residual-only, so the cardinal fast path is
+    // untouched (byte-identical).
     float yc = cos(visualYaw);
     float ys = sin(visualYaw);
-    float dvx = origin.x * yc + origin.y * ys;
-    float dvy = -origin.x * ys + origin.y * yc;
-    int yawedDist = roundHalfUp(dvx + dvy + origin.z) * 4 + slot;
-    vDepth = float(yawedDist + distanceOffset - kMinTriangleDistance) /
-             float(kMaxTriangleDistance - kMinTriangleDistance);
+    float dvx = worldCorner.x * yc + worldCorner.y * ys;
+    float dvy = -worldCorner.x * ys + worldCorner.y * yc;
+    vYawedDepth = dvx + dvy + worldCorner.z;
+    vDepthBias = float(slot + distanceOffset - kMinTriangleDistance);
+    vDepthScale = 1.0 / float(kMaxTriangleDistance - kMinTriangleDistance);
 }


### PR DESCRIPTION
**WIP / design-blocked.** Implements the architect plan's lead but escalates: the lead does **not** fix #1457. See the `## NEEDS-DESIGN` comment below for the re-diagnosis.

## What this diff does
Changes the camera per-axis forward-scatter composite depth from a `flat` per-face value (computed once from the face `origin`) to a **smooth per-fragment** value: the yawed iso depth is computed at each face corner (`worldCorner`), interpolated across the face, and rounded **per-pixel** in the fragment (`floor(x+0.5)*4 + slot`) so the `*4 + slot` SDF co-sort stays integer. GLSL (`v_/f_peraxis_scatter.glsl`) + Metal (`peraxis_scatter.metal`), kept in parity. This is the plan's "match the SDF's per-pixel depth" lead.

## Why it's parked
The plan told me to confirm instrument-first and *follow the data if it diverges*. It diverged:

- **Byte-identical no-op.** Under the issue's exact repro (`IRShapeDebug --spin-yaw 30 --zoom 8 --depth-color`, shot 2 / yaw 45°), this diff is **byte-identical to master** — `img_diff drift=0 (0.0000%)` across the whole frame. Re-confirmed by swapping master's scatter shader into the build copy and `cmp` (identical).
- **Scatter placement is clean.** Forcing the scatter fragment to magenta paints a **solid, coherent square** exactly over the scrambled region — the silhouette and per-cell tiling are correct. So the front/back-face confusion is **not** in the composite depth this PR touches.

## Real cause (re-diagnosis)
The front/back confusion is upstream in the **per-axis store occlusion** (`c_voxel_to_trixel_stage_1.glsl`): each cell's winner is chosen by `encodeDepthWithFace(microWorld.x+microWorld.y+microWorld.z, slot)` — the **un-yawed** `x+y+z` depth — but under camera yaw the correct occlusion order is the *yawed* depth. Along a face's fixed axis the yawed depth scales as `coord·(cosθ−sinθ)` (X-faces) / `coord·(sinθ+cosθ)` (Y-faces), which **goes degenerate at θ=45° (X) and θ=135° (Y)** — exactly shots 2 and 4 the DoD calls out. And the stored depth is also the scatter's **origin-recovery key** (`faceOriginFromInPlane`, "must not change"), so occlusion and recovery are coupled in one value. This is a per-axis store redesign, not a scatter tweak — architect call. Full detail in the NEEDS-DESIGN comment.

Issue: #1457