### PR TITLE
Time service: deterministic sim-clock substrate + cycle/timer framework (#200)

### DIFF
--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -55,6 +55,47 @@ in `update/`.
 
 None. Position math is read-only in `common/` — write paths live in
 `update/systems/` (velocity, physics, animation, transform propagation).
+The sim-clock systems below are likewise registered from `update/systems/`.
+
+## Sim-clock substrate (#200)
+
+Deterministic simulation time + a generic cycle/timer framework.
+Two-clock model: the **engine tick** (`IRTime::tick()`, always advancing,
+`engine/time/`) drives wall-clock infra; the **sim tick** below pauses and
+scales so gameplay timers freeze on pause.
+
+- `C_SimClock` — singleton (`IREntity::singleton<C_SimClock>()`). Fields
+  `tickCount_` (sim ticks), `timeScale_` (0 = paused, N = fast, 1/N =
+  slow), `subTickAccum_` (sub-integer remainder for fractional scale).
+  `SYSTEM_SIM_CLOCK_ADVANCE` advances it once per UPDATE tick.
+- `C_Cycle` — a tick-aligned recurring period (`"day"`, `"boss_phase"`,
+  …). `SYSTEM_CYCLE_BOUNDARY_DETECT` recomputes the cycle index each tick
+  and raises the **embedded** boundary event (`boundaryCrossed_` +
+  `fromCycle_`/`toCycle_`) on the crossing tick — the
+  events-as-components pattern (cf. `C_ContactEvent`), self-clearing, no
+  separate clear system. `lastCycleNum_` defaults to a sentinel so a
+  cycle created mid-sim primes silently (no spurious boundary).
+- `C_Timer` — fires `fired_` when the sim reaches `targetTick_`. One-shot
+  (`intervalTicks_ == 0`, deactivates) or recurring (re-arms past every
+  crossed interval). `SYSTEM_TIMER_FIRE` drives it.
+- `C_Stopwatch` — count-up elapsed with pause/resume. **No system** —
+  elapsed is computed on read by `IRSim::stopwatchElapsed`; pause/resume/
+  reset are imperative `IRSim::` calls that snapshot the sim tick.
+
+`IRSim::` service ([`sim_clock.hpp`](sim_clock.hpp), header-only): clock
+control (`tick`, `timeScale`, `setTimeScale`, `pause`, `resume`,
+`isPaused`), name-keyed cycle/timer/stopwatch create + query
+(`cycleFraction`/`cycleNumber`/`cycleBoundaryCrossed`,
+`timerFraction`/`timerTicksRemaining`/`timerFired`/`timerActive`,
+`stopwatchElapsed`/`stopwatchRunning`/…), and `createCycle`/`createTimer`/
+`createStopwatch`. `cycleFraction("day")` is the load-bearing continuous
+primitive for time-driven values (sun angle, color temp). The service
+lives in `common/` (not `engine/time/`) because it reads ECS components,
+which `engine/time` must not depend on. Lua surface: the `IRSim` table
+(`engine/script/CLAUDE.md`). A consumer registers the three systems in
+its UPDATE pipeline (SIM_CLOCK_ADVANCE first) and touches the clock once
+at init so the singleton exists. Day-specific gameplay stays game-side
+(game #44) — the engine knows only generic cycles.
 
 ## SQT transform pair + propagation
 

--- a/engine/prefabs/irreden/common/CLAUDE.md
+++ b/engine/prefabs/irreden/common/CLAUDE.md
@@ -69,12 +69,20 @@ scales so gameplay timers freeze on pause.
   slow), `subTickAccum_` (sub-integer remainder for fractional scale).
   `SYSTEM_SIM_CLOCK_ADVANCE` advances it once per UPDATE tick.
 - `C_Cycle` — a tick-aligned recurring period (`"day"`, `"boss_phase"`,
-  …). `SYSTEM_CYCLE_BOUNDARY_DETECT` recomputes the cycle index each tick
-  and raises the **embedded** boundary event (`boundaryCrossed_` +
-  `fromCycle_`/`toCycle_`) on the crossing tick — the
+  …). `SYSTEM_CYCLE_BOUNDARY_DETECT` recomputes the cycle index and
+  intra-period segment each tick and raises the **embedded** boundary
+  event (`boundaryCrossed_` + `fromCycle_`/`toCycle_` +
+  `fromSegment_`/`toSegment_`/`segmentIndex_`) on the crossing tick — the
   events-as-components pattern (cf. `C_ContactEvent`), self-clearing, no
   separate clear system. `lastCycleNum_` defaults to a sentinel so a
   cycle created mid-sim primes silently (no spurious boundary).
+  **Multi-breakpoint support:** call `C_Cycle::addBreakpoint(fraction)` or
+  `IRSim::cycleAddBreakpoint(name, fraction)` to divide each period into
+  segments — the boundary event then fires on EVERY segment crossing, not
+  just the period wrap. Empty breakpoints = single period-wrap boundary
+  only (original behavior). `segmentIndex_` is updated every tick and
+  always reflects the current segment; query it via
+  `IRSim::cycleSegment(name)` by name.
 - `C_Timer` — fires `fired_` when the sim reaches `targetTick_`. One-shot
   (`intervalTicks_ == 0`, deactivates) or recurring (re-arms past every
   crossed interval). `SYSTEM_TIMER_FIRE` drives it.
@@ -85,11 +93,13 @@ scales so gameplay timers freeze on pause.
 `IRSim::` service ([`sim_clock.hpp`](sim_clock.hpp), header-only): clock
 control (`tick`, `timeScale`, `setTimeScale`, `pause`, `resume`,
 `isPaused`), name-keyed cycle/timer/stopwatch create + query
-(`cycleFraction`/`cycleNumber`/`cycleBoundaryCrossed`,
+(`cycleFraction`/`cycleNumber`/`cycleBoundaryCrossed`/`cycleSegment`,
 `timerFraction`/`timerTicksRemaining`/`timerFired`/`timerActive`,
-`stopwatchElapsed`/`stopwatchRunning`/…), and `createCycle`/`createTimer`/
-`createStopwatch`. `cycleFraction("day")` is the load-bearing continuous
-primitive for time-driven values (sun angle, color temp). The service
+`stopwatchElapsed`/`stopwatchRunning`/…), factory + breakpoint helpers
+(`createCycle`/`cycleAddBreakpoint`/`createTimer`/`createStopwatch`).
+`cycleFraction("day")` is the load-bearing continuous primitive for
+time-driven values (sun angle, color temp); `cycleSegment("day")` returns
+the current segment index (0 = before the first breakpoint). The service
 lives in `common/` (not `engine/time/`) because it reads ECS components,
 which `engine/time` must not depend on. Lua surface: the `IRSim` table
 (`engine/script/CLAUDE.md`). A consumer registers the three systems in

--- a/engine/prefabs/irreden/common/components/component_cycle.hpp
+++ b/engine/prefabs/irreden/common/components/component_cycle.hpp
@@ -15,7 +15,7 @@
 // system needed). For continuous time-driven values (sun angle, color temp),
 // read IRSim::cycleFraction(name) instead of waiting for the discrete boundary.
 //
-// Multi-breakpoint support: call addBreakpoint(fraction) (fraction in [0,1)) to
+// Multi-breakpoint support: call addBreakpoint(fraction) (fraction in (0,1)) to
 // divide each period into segments. With breakpoints at {0.25, 0.5, 0.75} the
 // period has four segments (0..3) and the boundary event fires on EVERY crossing,
 // not just the period wrap. Empty breakpoints = single period-wrap boundary (the
@@ -86,13 +86,15 @@ struct C_Cycle {
         return seg;
     }
 
-    // Add a breakpoint at a fraction of the period (fraction in [0, 1)).
+    // Add a breakpoint at a fraction of the period (fraction in (0, 1)).
     // The breakpoint is stored as an absolute tick offset within the period and
     // inserted in sorted order. Call before the cycle enters the pipeline — changing
     // breakpoints after priming leaves `lastSegmentIndex_` stale for one tick.
-    // Silently no-ops when: fraction is outside [0,1), periodTicks_ == 0, the
+    // Silently no-ops when: fraction is outside (0,1), periodTicks_ == 0, the
     // array is full (kMaxBreakpoints reached), or the fraction maps to a tick
-    // offset already present (duplicate).
+    // offset already present (duplicate). fraction == 0.0 is rejected because
+    // offset 0 duplicates the implicit wrap boundary — segment 0 would become
+    // unreachable (every withinTick is >= 0).
     void addBreakpoint(float fraction) {
         if (numBreakpoints_ >= kMaxBreakpoints || periodTicks_ == 0) {
             return;
@@ -102,6 +104,9 @@ struct C_Cycle {
         }
         const std::uint64_t offset =
             static_cast<std::uint64_t>(fraction * static_cast<float>(periodTicks_));
+        if (offset == 0) {
+            return;
+        }
         std::uint8_t i = numBreakpoints_;
         while (i > 0 && breakpoints_[i - 1] > offset) {
             breakpoints_[i] = breakpoints_[i - 1];

--- a/engine/prefabs/irreden/common/components/component_cycle.hpp
+++ b/engine/prefabs/irreden/common/components/component_cycle.hpp
@@ -4,7 +4,8 @@
 // C_Cycle — a generic tick-aligned recurring period. Many can coexist (one per
 // "day", "season", "boss_phase", ...). SYSTEM_CYCLE_BOUNDARY_DETECT advances the
 // resolver state each UPDATE tick and, on the tick a period boundary is crossed,
-// raises the embedded boundary event (`boundaryCrossed_` + from/to cycle number).
+// raises the embedded boundary event (`boundaryCrossed_` + from/to cycle number
+// and segment index).
 //
 // Boundary events ride on the component itself rather than a separate event
 // component, matching the engine's events-as-components convention (cf.
@@ -14,9 +15,19 @@
 // system needed). For continuous time-driven values (sun angle, color temp),
 // read IRSim::cycleFraction(name) instead of waiting for the discrete boundary.
 //
+// Multi-breakpoint support: call addBreakpoint(fraction) (fraction in [0,1)) to
+// divide each period into segments. With breakpoints at {0.25, 0.5, 0.75} the
+// period has four segments (0..3) and the boundary event fires on EVERY crossing,
+// not just the period wrap. Empty breakpoints = single period-wrap boundary (the
+// original behavior). `segmentIndex_` always holds the current segment and is
+// updated every tick; `fromSegment_`/`toSegment_` are set alongside the other
+// event fields and are only meaningful when `boundaryCrossed_` is true.
+// IRSim::cycleSegment(name) is the name-keyed query form.
+//
 // `lastCycleNum_` defaults to the unprimed sentinel so a cycle created at any
 // sim tick (not just tick 0) does not fire a spurious boundary on its first
-// evaluation — the detector primes it silently, then fires on real crossings.
+// evaluation — the detector primes both the cycle number and segment index
+// silently, then fires on real crossings.
 
 #include <cstdint>
 #include <limits>
@@ -27,17 +38,33 @@ namespace IRComponents {
 
 struct C_Cycle {
     static constexpr std::uint64_t kUnprimed = std::numeric_limits<std::uint64_t>::max();
+    // Inline array — avoids a heap allocation in the archetype column.
+    // Seven breakpoints give eight segments, enough for dawn/noon/dusk-style use cases.
+    static constexpr std::uint8_t kMaxBreakpoints = 7;
 
     std::string name_;
-    std::uint64_t periodTicks_ = 1;       // length of one cycle in sim ticks (>= 1)
-    std::uint64_t phaseOffset_ = 0;       // shifts where the cycle boundary lands
+    std::uint64_t periodTicks_ = 1;   // length of one cycle in sim ticks (>= 1)
+    std::uint64_t phaseOffset_ = 0;   // shifts where the cycle boundary lands
 
-    std::uint64_t lastCycleNum_ = kUnprimed; // resolver state; kUnprimed until first detect
+    // Intra-period breakpoints: sorted tick offsets in [0, periodTicks_).
+    // Empty = single period-wrap boundary only.
+    std::uint64_t breakpoints_[kMaxBreakpoints] = {};
+    std::uint8_t numBreakpoints_ = 0;
 
-    // Embedded boundary event (valid only on the tick boundaryCrossed_ is true).
+    // Resolver state (kUnprimed until first detect).
+    std::uint64_t lastCycleNum_ = kUnprimed;
+    std::uint8_t lastSegmentIndex_ = 0;
+
+    // Embedded boundary event. `boundaryCrossed_` fires on EVERY segment crossing,
+    // including the period wrap. `fromCycle_`/`toCycle_` and `fromSegment_`/`toSegment_`
+    // are valid only on the tick `boundaryCrossed_` is true.
+    // `segmentIndex_` is updated every tick and always reflects the current segment.
     bool boundaryCrossed_ = false;
     std::uint64_t fromCycle_ = 0;
     std::uint64_t toCycle_ = 0;
+    std::uint8_t segmentIndex_ = 0;
+    std::uint8_t fromSegment_ = 0;
+    std::uint8_t toSegment_ = 0;
 
     C_Cycle() = default;
 
@@ -45,6 +72,43 @@ struct C_Cycle {
         : name_{std::move(name)}
         , periodTicks_{periodTicks}
         , phaseOffset_{phaseOffset} {}
+
+    // Which segment [0, numBreakpoints_] contains withinTick.
+    // Segment 0 = before the first breakpoint; segment i+1 starts at breakpoints_[i].
+    // Returns 0 when numBreakpoints_ == 0 (the no-breakpoint fast path).
+    std::uint8_t computeSegment(std::uint64_t withinTick) const {
+        std::uint8_t seg = 0;
+        for (std::uint8_t i = 0; i < numBreakpoints_; ++i) {
+            if (withinTick >= breakpoints_[i]) {
+                seg = static_cast<std::uint8_t>(i + 1);
+            }
+        }
+        return seg;
+    }
+
+    // Add a breakpoint at a fraction of the period (fraction in [0, 1)).
+    // The breakpoint is stored as an absolute tick offset within the period and
+    // inserted in sorted order. Call before the cycle enters the pipeline — changing
+    // breakpoints after priming leaves `lastSegmentIndex_` stale for one tick.
+    // Silently no-ops when: fraction is outside [0,1), periodTicks_ == 0, or the
+    // array is full (kMaxBreakpoints reached).
+    void addBreakpoint(float fraction) {
+        if (numBreakpoints_ >= kMaxBreakpoints || periodTicks_ == 0) {
+            return;
+        }
+        if (!(fraction >= 0.0f && fraction < 1.0f)) {
+            return;
+        }
+        const std::uint64_t offset =
+            static_cast<std::uint64_t>(fraction * static_cast<float>(periodTicks_));
+        std::uint8_t i = numBreakpoints_;
+        while (i > 0 && breakpoints_[i - 1] > offset) {
+            breakpoints_[i] = breakpoints_[i - 1];
+            --i;
+        }
+        breakpoints_[i] = offset;
+        ++numBreakpoints_;
+    }
 };
 
 } // namespace IRComponents

--- a/engine/prefabs/irreden/common/components/component_cycle.hpp
+++ b/engine/prefabs/irreden/common/components/component_cycle.hpp
@@ -1,0 +1,52 @@
+#ifndef COMPONENT_CYCLE_H
+#define COMPONENT_CYCLE_H
+
+// C_Cycle — a generic tick-aligned recurring period. Many can coexist (one per
+// "day", "season", "boss_phase", ...). SYSTEM_CYCLE_BOUNDARY_DETECT advances the
+// resolver state each UPDATE tick and, on the tick a period boundary is crossed,
+// raises the embedded boundary event (`boundaryCrossed_` + from/to cycle number).
+//
+// Boundary events ride on the component itself rather than a separate event
+// component, matching the engine's events-as-components convention (cf.
+// C_ContactEvent's entered_/exited_ flags): a consumer system ordered AFTER
+// CYCLE_BOUNDARY_DETECT reads `boundaryCrossed_` the same tick it fires, and the
+// detector recomputes it every tick so it is self-clearing (no separate clear
+// system needed). For continuous time-driven values (sun angle, color temp),
+// read IRSim::cycleFraction(name) instead of waiting for the discrete boundary.
+//
+// `lastCycleNum_` defaults to the unprimed sentinel so a cycle created at any
+// sim tick (not just tick 0) does not fire a spurious boundary on its first
+// evaluation — the detector primes it silently, then fires on real crossings.
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <utility>
+
+namespace IRComponents {
+
+struct C_Cycle {
+    static constexpr std::uint64_t kUnprimed = std::numeric_limits<std::uint64_t>::max();
+
+    std::string name_;
+    std::uint64_t periodTicks_ = 1;       // length of one cycle in sim ticks (>= 1)
+    std::uint64_t phaseOffset_ = 0;       // shifts where the cycle boundary lands
+
+    std::uint64_t lastCycleNum_ = kUnprimed; // resolver state; kUnprimed until first detect
+
+    // Embedded boundary event (valid only on the tick boundaryCrossed_ is true).
+    bool boundaryCrossed_ = false;
+    std::uint64_t fromCycle_ = 0;
+    std::uint64_t toCycle_ = 0;
+
+    C_Cycle() = default;
+
+    C_Cycle(std::string name, std::uint64_t periodTicks, std::uint64_t phaseOffset = 0)
+        : name_{std::move(name)}
+        , periodTicks_{periodTicks}
+        , phaseOffset_{phaseOffset} {}
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_CYCLE_H */

--- a/engine/prefabs/irreden/common/components/component_cycle.hpp
+++ b/engine/prefabs/irreden/common/components/component_cycle.hpp
@@ -43,8 +43,8 @@ struct C_Cycle {
     static constexpr std::uint8_t kMaxBreakpoints = 7;
 
     std::string name_;
-    std::uint64_t periodTicks_ = 1;   // length of one cycle in sim ticks (>= 1)
-    std::uint64_t phaseOffset_ = 0;   // shifts where the cycle boundary lands
+    std::uint64_t periodTicks_ = 1; // length of one cycle in sim ticks (>= 1)
+    std::uint64_t phaseOffset_ = 0; // shifts where the cycle boundary lands
 
     // Intra-period breakpoints: sorted tick offsets in [0, periodTicks_).
     // Empty = single period-wrap boundary only.
@@ -90,8 +90,9 @@ struct C_Cycle {
     // The breakpoint is stored as an absolute tick offset within the period and
     // inserted in sorted order. Call before the cycle enters the pipeline — changing
     // breakpoints after priming leaves `lastSegmentIndex_` stale for one tick.
-    // Silently no-ops when: fraction is outside [0,1), periodTicks_ == 0, or the
-    // array is full (kMaxBreakpoints reached).
+    // Silently no-ops when: fraction is outside [0,1), periodTicks_ == 0, the
+    // array is full (kMaxBreakpoints reached), or the fraction maps to a tick
+    // offset already present (duplicate).
     void addBreakpoint(float fraction) {
         if (numBreakpoints_ >= kMaxBreakpoints || periodTicks_ == 0) {
             return;
@@ -105,6 +106,9 @@ struct C_Cycle {
         while (i > 0 && breakpoints_[i - 1] > offset) {
             breakpoints_[i] = breakpoints_[i - 1];
             --i;
+        }
+        if (i > 0 && breakpoints_[i - 1] == offset) {
+            return;
         }
         breakpoints_[i] = offset;
         ++numBreakpoints_;

--- a/engine/prefabs/irreden/common/components/component_sim_clock.hpp
+++ b/engine/prefabs/irreden/common/components/component_sim_clock.hpp
@@ -1,0 +1,33 @@
+#ifndef COMPONENT_SIM_CLOCK_H
+#define COMPONENT_SIM_CLOCK_H
+
+// C_SimClock — the one canonical sim-time state for a world. Held as an ECS
+// singleton (IREntity::singleton<C_SimClock>()); exactly one record exists per
+// world. SYSTEM_SIM_CLOCK_ADVANCE advances `tickCount_` once per UPDATE tick at
+// the configured `timeScale_`, and the IRSim:: service
+// (engine/prefabs/irreden/common/sim_clock.hpp) reads/writes it.
+//
+// This is the "sim tick" half of the two-clock model: it pauses (timeScale_==0)
+// and scales, so gameplay timers/cycles built on it freeze when the game is
+// paused. The "engine tick" half (IRTime::tick(), always advancing) lives in
+// engine/time and drives profilers / wall-clock-aligned infrastructure.
+//
+// `subTickAccum_` carries the sub-integer remainder when `timeScale_` is not a
+// whole number (e.g. 0.5 advances `tickCount_` every other UPDATE tick). It is
+// part of the deterministic state and round-trips with the clock.
+
+#include <cstdint>
+
+namespace IRComponents {
+
+struct C_SimClock {
+    std::uint64_t tickCount_ = 0;     // sim ticks (NOT engine ticks)
+    float timeScale_ = 1.0f;          // 0 = paused, 1 = normal, N = fast, 1/N = slow
+    float subTickAccum_ = 0.0f;       // sub-integer remainder for non-whole timeScale_
+
+    C_SimClock() = default;
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_SIM_CLOCK_H */

--- a/engine/prefabs/irreden/common/components/component_stopwatch.hpp
+++ b/engine/prefabs/irreden/common/components/component_stopwatch.hpp
@@ -1,0 +1,42 @@
+#ifndef COMPONENT_STOPWATCH_H
+#define COMPONENT_STOPWATCH_H
+
+// C_Stopwatch — a generic count-up timer measuring elapsed sim ticks since
+// start/reset, with pause/resume. Many can coexist (HUD timers, "time in
+// region", combo windows). Unlike C_Cycle / C_Timer there is no per-frame
+// stopwatch system: elapsed is a pure function of the live sim tick, computed
+// on read by IRSim::stopwatchElapsed(name), and pause/resume/reset are
+// imperative IRSim:: calls that snapshot the sim tick. Keeping it
+// computed-on-read avoids a no-op per-frame system over every stopwatch entity.
+//
+//   elapsed = pausedElapsed_ + (running_ ? simTick - startTick_ : 0)
+//
+// `startTick_` is the sim tick captured at the last start/resume/reset, so a
+// stopwatch must be created through IRSim::createStopwatch (which snapshots the
+// current sim tick) rather than constructed inline if it starts after sim tick 0.
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace IRComponents {
+
+struct C_Stopwatch {
+    std::string name_;
+    std::uint64_t startTick_ = 0;      // sim tick at last start/resume/reset
+    std::uint64_t pausedElapsed_ = 0;  // elapsed accumulated before the current run segment
+    bool running_ = true;
+
+    C_Stopwatch() = default;
+
+    explicit C_Stopwatch(std::string name)
+        : name_{std::move(name)} {}
+
+    C_Stopwatch(std::string name, std::uint64_t startTick)
+        : name_{std::move(name)}
+        , startTick_{startTick} {}
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_STOPWATCH_H */

--- a/engine/prefabs/irreden/common/components/component_timer.hpp
+++ b/engine/prefabs/irreden/common/components/component_timer.hpp
@@ -1,0 +1,44 @@
+#ifndef COMPONENT_TIMER_H
+#define COMPONENT_TIMER_H
+
+// C_Timer — a generic sim-tick timer that fires when IRSim::tick() reaches
+// `targetTick_`. One-shot when `intervalTicks_ == 0` (deactivates after firing);
+// recurring when `intervalTicks_ > 0` (re-arms `targetTick_ += intervalTicks_`).
+// Many can coexist; SYSTEM_TIMER_FIRE drives them.
+//
+// The fired event rides on the component (`fired_`), matching the
+// events-as-components convention: a consumer system ordered AFTER TIMER_FIRE
+// reads `fired_` the same tick, and the detector recomputes it every tick so it
+// is self-clearing. A recurring timer that the sim overshoots by several
+// intervals in one tick (large timeScale_) re-arms past every crossed interval
+// and reports a single `fired_` for that tick.
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace IRComponents {
+
+struct C_Timer {
+    std::string name_;
+    std::uint64_t startTick_ = 0;      // sim tick the current countdown began (anchors timerFraction)
+    std::uint64_t targetTick_ = 0;     // sim tick at which the timer fires
+    std::uint64_t intervalTicks_ = 0;  // 0 = one-shot; > 0 = re-arm with this period
+    bool active_ = true;
+
+    bool fired_ = false;               // embedded event: true only on the firing tick
+
+    C_Timer() = default;
+
+    // startTick_ defaults to 0; IRSim::createTimer snapshots the live sim tick
+    // into it so timerFraction is anchored correctly for timers armed after
+    // sim tick 0. SYSTEM_TIMER_FIRE re-anchors it on each recurring re-arm.
+    C_Timer(std::string name, std::uint64_t targetTick, std::uint64_t intervalTicks = 0)
+        : name_{std::move(name)}
+        , targetTick_{targetTick}
+        , intervalTicks_{intervalTicks} {}
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_TIMER_H */

--- a/engine/prefabs/irreden/common/sim_clock.hpp
+++ b/engine/prefabs/irreden/common/sim_clock.hpp
@@ -74,10 +74,10 @@ inline bool isPaused() {
     return clock().timeScale_ == 0.0f;
 }
 
-/// Sets the sim time scale. Negative values are clamped to 0 (paused); the
-/// SYSTEM_SIM_CLOCK_ADVANCE fast path keys on an exact 1.0.
+/// Sets the sim time scale. Negative values and NaN are clamped to 0 (paused);
+/// the SYSTEM_SIM_CLOCK_ADVANCE fast path keys on an exact 1.0.
 inline void setTimeScale(float scale) {
-    clock().timeScale_ = scale < 0.0f ? 0.0f : scale;
+    clock().timeScale_ = !(scale > 0.0f) ? 0.0f : scale;
 }
 
 inline void pause() {

--- a/engine/prefabs/irreden/common/sim_clock.hpp
+++ b/engine/prefabs/irreden/common/sim_clock.hpp
@@ -123,13 +123,37 @@ inline float cycleFraction(std::string_view name) {
     return static_cast<float>(within) / static_cast<float>(c->periodTicks_);
 }
 
-/// True only on the tick SYSTEM_CYCLE_BOUNDARY_DETECT crossed a period boundary
-/// for this cycle. The poll form of the discrete boundary event (Lua polls it
-/// here in lieu of a callback; a C++ consumer ordered after the detector can
-/// read the same flag off the C_Cycle column directly).
+/// True only on the tick SYSTEM_CYCLE_BOUNDARY_DETECT crossed any segment or
+/// period boundary for this cycle. The poll form of the discrete boundary event
+/// (Lua polls it here; a C++ consumer ordered after the detector can read the
+/// same flag off the C_Cycle column directly).
 inline bool cycleBoundaryCrossed(std::string_view name) {
     const IRComponents::C_Cycle *c = detail::findByName<IRComponents::C_Cycle>(name);
     return c != nullptr && c->boundaryCrossed_;
+}
+
+/// Current intra-period segment index (0 = before the first breakpoint, i = after
+/// the i-th breakpoint). Returns 0 for cycles with no breakpoints. Computes from
+/// the live sim tick — same logic as SYSTEM_CYCLE_BOUNDARY_DETECT, safe to call
+/// between pipeline ticks.
+inline std::uint8_t cycleSegment(std::string_view name) {
+    const IRComponents::C_Cycle *c = detail::findByName<IRComponents::C_Cycle>(name);
+    if (c == nullptr || c->periodTicks_ == 0) {
+        return 0;
+    }
+    const std::uint64_t withinTick = (tick() + c->phaseOffset_) % c->periodTicks_;
+    return c->computeSegment(withinTick);
+}
+
+/// Add a breakpoint at a fraction of the period to the named cycle. See
+/// C_Cycle::addBreakpoint for the full contract (fraction in [0,1), sorted
+/// insertion, ignored when the array is full). Call after createCycle and before
+/// the pipeline starts advancing sim ticks.
+inline void cycleAddBreakpoint(std::string_view name, float fraction) {
+    IRComponents::C_Cycle *c = detail::findByName<IRComponents::C_Cycle>(name);
+    if (c != nullptr) {
+        c->addBreakpoint(fraction);
+    }
 }
 
 // ---- Timers (C_Timer, by name) ----------------------------------------------

--- a/engine/prefabs/irreden/common/sim_clock.hpp
+++ b/engine/prefabs/irreden/common/sim_clock.hpp
@@ -1,0 +1,249 @@
+#ifndef IR_SIM_CLOCK_H
+#define IR_SIM_CLOCK_H
+
+// IRSim:: — the sim-clock / cycle / timer / stopwatch service. Reads and writes
+// the C_SimClock singleton and queries the per-world C_Cycle / C_Timer /
+// C_Stopwatch entities by name.
+//
+// Lives in engine/prefabs (header-only) rather than engine/time, even though the
+// architect plan sketched it under engine/time: the service reads ECS components
+// (engine/entity + the C_* prefab headers), and engine/time is a foundational
+// static library that must not depend on the component layer. Only the raw
+// always-advancing engine tick (IRTime::tick()) stays in engine/time; the
+// pausable/scalable sim clock (IRSim::tick(), advanced by SYSTEM_SIM_CLOCK_ADVANCE
+// at C_SimClock::timeScale_) lives here next to the components it owns.
+//
+// Name lookups (cycleFraction("day"), timerActive("reload"), ...) scan the
+// matching component column linearly. Cycle/timer/stopwatch counts are small (a
+// handful per world), so these are a query convenience, not a hot path; a system
+// that needs per-frame cycle state reads the C_Cycle component directly via its
+// dense archetype column instead.
+//
+// The C_SimClock singleton is lazily created on first access; a consumer that
+// wants the clock to advance must (a) touch it once at init (any IRSim:: call
+// does) and (b) register SYSTEM_SIM_CLOCK_ADVANCE in its UPDATE pipeline.
+
+#include <irreden/common/components/component_cycle.hpp>
+#include <irreden/common/components/component_sim_clock.hpp>
+#include <irreden/common/components/component_stopwatch.hpp>
+#include <irreden/common/components/component_timer.hpp>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace IRSim {
+
+namespace detail {
+
+// First entity whose component of type C carries `name`; nullptr if none.
+template <typename C> C *findByName(std::string_view name) {
+    C *found = nullptr;
+    IREntity::forEachComponent<C>([&](C &c) {
+        if (found == nullptr && c.name_ == name) {
+            found = &c;
+        }
+    });
+    return found;
+}
+
+} // namespace detail
+
+// ---- Clock (C_SimClock singleton) -------------------------------------------
+
+inline IRComponents::C_SimClock &clock() {
+    return IREntity::singleton<IRComponents::C_SimClock>();
+}
+
+/// Current sim tick — the pausable/scalable simulation clock. Gameplay timers,
+/// cooldowns, and day clocks read this; profilers/wall-clock infra read
+/// IRTime::tick() instead.
+inline std::uint64_t tick() {
+    return clock().tickCount_;
+}
+
+inline float timeScale() {
+    return clock().timeScale_;
+}
+
+inline bool isPaused() {
+    return clock().timeScale_ == 0.0f;
+}
+
+/// Sets the sim time scale. Negative values are clamped to 0 (paused); the
+/// SYSTEM_SIM_CLOCK_ADVANCE fast path keys on an exact 1.0.
+inline void setTimeScale(float scale) {
+    clock().timeScale_ = scale < 0.0f ? 0.0f : scale;
+}
+
+inline void pause() {
+    setTimeScale(0.0f);
+}
+
+/// Resumes at normal (1x) speed. A caller that paused from a custom rate and
+/// wants it back should re-apply setTimeScale itself (v1 keeps no saved rate).
+inline void resume() {
+    setTimeScale(1.0f);
+}
+
+// ---- Cycles (C_Cycle, by name) ----------------------------------------------
+
+/// Which cycle index we are in (monotonic): (simTick + phaseOffset) / period.
+inline std::uint64_t cycleNumber(std::string_view name) {
+    const IRComponents::C_Cycle *c = detail::findByName<IRComponents::C_Cycle>(name);
+    if (c == nullptr || c->periodTicks_ == 0) {
+        return 0;
+    }
+    return (tick() + c->phaseOffset_) / c->periodTicks_;
+}
+
+/// Tick offset inside the current cycle: (simTick + phaseOffset) % period.
+inline std::uint64_t cycleTickWithin(std::string_view name) {
+    const IRComponents::C_Cycle *c = detail::findByName<IRComponents::C_Cycle>(name);
+    if (c == nullptr || c->periodTicks_ == 0) {
+        return 0;
+    }
+    return (tick() + c->phaseOffset_) % c->periodTicks_;
+}
+
+/// Progress through the current cycle in [0, 1). The load-bearing primitive for
+/// continuous time-driven values (sun angle, light color temp, shader uniforms):
+/// read it as `float t = IRSim::cycleFraction("day")` and drive anything on a
+/// [0, 1] parameterization. Wraps to 0 at each boundary.
+inline float cycleFraction(std::string_view name) {
+    const IRComponents::C_Cycle *c = detail::findByName<IRComponents::C_Cycle>(name);
+    if (c == nullptr || c->periodTicks_ == 0) {
+        return 0.0f;
+    }
+    const std::uint64_t within = (tick() + c->phaseOffset_) % c->periodTicks_;
+    return static_cast<float>(within) / static_cast<float>(c->periodTicks_);
+}
+
+/// True only on the tick SYSTEM_CYCLE_BOUNDARY_DETECT crossed a period boundary
+/// for this cycle. The poll form of the discrete boundary event (Lua polls it
+/// here in lieu of a callback; a C++ consumer ordered after the detector can
+/// read the same flag off the C_Cycle column directly).
+inline bool cycleBoundaryCrossed(std::string_view name) {
+    const IRComponents::C_Cycle *c = detail::findByName<IRComponents::C_Cycle>(name);
+    return c != nullptr && c->boundaryCrossed_;
+}
+
+// ---- Timers (C_Timer, by name) ----------------------------------------------
+
+inline bool timerActive(std::string_view name) {
+    const IRComponents::C_Timer *t = detail::findByName<IRComponents::C_Timer>(name);
+    return t != nullptr && t->active_;
+}
+
+/// Sim ticks until the timer fires; 0 once due or inactive.
+inline std::uint64_t timerTicksRemaining(std::string_view name) {
+    const IRComponents::C_Timer *t = detail::findByName<IRComponents::C_Timer>(name);
+    if (t == nullptr || !t->active_) {
+        return 0;
+    }
+    const std::uint64_t now = tick();
+    return t->targetTick_ > now ? t->targetTick_ - now : 0;
+}
+
+/// Progress toward the current target in [0, 1], anchored at the timer's
+/// countdown start (set at creation, re-anchored on each recurring re-arm).
+inline float timerFraction(std::string_view name) {
+    const IRComponents::C_Timer *t = detail::findByName<IRComponents::C_Timer>(name);
+    if (t == nullptr) {
+        return 0.0f;
+    }
+    if (t->targetTick_ <= t->startTick_) {
+        return 1.0f; // degenerate / already-due span reads as complete
+    }
+    const std::uint64_t now = tick();
+    const std::uint64_t span = t->targetTick_ - t->startTick_;
+    const std::uint64_t done = now > t->startTick_ ? now - t->startTick_ : 0;
+    return IRMath::clamp(static_cast<float>(done) / static_cast<float>(span), 0.0f, 1.0f);
+}
+
+/// True only on the tick SYSTEM_TIMER_FIRE fired this timer. The poll form of
+/// the discrete fired event (Lua polls it here in lieu of a callback).
+inline bool timerFired(std::string_view name) {
+    const IRComponents::C_Timer *t = detail::findByName<IRComponents::C_Timer>(name);
+    return t != nullptr && t->fired_;
+}
+
+// ---- Stopwatches (C_Stopwatch, by name) -------------------------------------
+
+/// Elapsed sim ticks since start/reset, excluding paused spans.
+inline std::uint64_t stopwatchElapsed(std::string_view name) {
+    const IRComponents::C_Stopwatch *s = detail::findByName<IRComponents::C_Stopwatch>(name);
+    if (s == nullptr) {
+        return 0;
+    }
+    if (!s->running_) {
+        return s->pausedElapsed_;
+    }
+    const std::uint64_t now = tick();
+    const std::uint64_t segment = now > s->startTick_ ? now - s->startTick_ : 0;
+    return s->pausedElapsed_ + segment;
+}
+
+inline bool stopwatchRunning(std::string_view name) {
+    const IRComponents::C_Stopwatch *s = detail::findByName<IRComponents::C_Stopwatch>(name);
+    return s != nullptr && s->running_;
+}
+
+inline void stopwatchPause(std::string_view name) {
+    IRComponents::C_Stopwatch *s = detail::findByName<IRComponents::C_Stopwatch>(name);
+    if (s == nullptr || !s->running_) {
+        return;
+    }
+    const std::uint64_t now = tick();
+    s->pausedElapsed_ += now > s->startTick_ ? now - s->startTick_ : 0;
+    s->running_ = false;
+}
+
+inline void stopwatchResume(std::string_view name) {
+    IRComponents::C_Stopwatch *s = detail::findByName<IRComponents::C_Stopwatch>(name);
+    if (s == nullptr || s->running_) {
+        return;
+    }
+    s->startTick_ = tick();
+    s->running_ = true;
+}
+
+inline void stopwatchReset(std::string_view name) {
+    IRComponents::C_Stopwatch *s = detail::findByName<IRComponents::C_Stopwatch>(name);
+    if (s == nullptr) {
+        return;
+    }
+    s->startTick_ = tick();
+    s->pausedElapsed_ = 0;
+}
+
+// ---- Factories (snapshot the live sim tick where it matters) -----------------
+
+inline IREntity::EntityId
+createCycle(std::string name, std::uint64_t periodTicks, std::uint64_t phaseOffset = 0) {
+    return IREntity::createEntity(
+        IRComponents::C_Cycle{std::move(name), periodTicks, phaseOffset}
+    );
+}
+
+/// `targetTick` is an absolute sim tick (the timer fires when IRSim::tick()
+/// reaches it). startTick_ is anchored to the current sim tick so timerFraction
+/// reports progress over the whole countdown.
+inline IREntity::EntityId
+createTimer(std::string name, std::uint64_t targetTick, std::uint64_t intervalTicks = 0) {
+    IRComponents::C_Timer timer{std::move(name), targetTick, intervalTicks};
+    timer.startTick_ = tick();
+    return IREntity::createEntity(timer);
+}
+
+inline IREntity::EntityId createStopwatch(std::string name) {
+    return IREntity::createEntity(IRComponents::C_Stopwatch{std::move(name), tick()});
+}
+
+} // namespace IRSim
+
+#endif /* IR_SIM_CLOCK_H */

--- a/engine/prefabs/irreden/update/systems/system_cycle_boundary_detect.hpp
+++ b/engine/prefabs/irreden/update/systems/system_cycle_boundary_detect.hpp
@@ -1,0 +1,64 @@
+#ifndef SYSTEM_CYCLE_BOUNDARY_DETECT_H
+#define SYSTEM_CYCLE_BOUNDARY_DETECT_H
+
+// SYSTEM_CYCLE_BOUNDARY_DETECT — for every C_Cycle, recomputes the current cycle
+// index from the sim tick and raises the embedded boundary event
+// (boundaryCrossed_ + fromCycle_/toCycle_) on the tick a period boundary is
+// crossed. Register AFTER SIM_CLOCK_ADVANCE so it reads the advanced tick.
+//
+// The sim tick is cached once per frame in beginTick (member-on-System<N> form,
+// not function-local static — see engine/system/CLAUDE.md). boundaryCrossed_ is
+// recomputed every tick, so it is self-clearing: a consumer system ordered after
+// this one reads the flag the same frame, and it resets next frame with no
+// separate clear system. A cycle is primed silently on its first evaluation
+// (lastCycleNum_ == kUnprimed) so one created mid-sim fires no spurious boundary.
+
+#include <irreden/common/components/component_cycle.hpp>
+#include <irreden/common/sim_clock.hpp>
+#include <irreden/ir_system.hpp>
+
+#include <cstdint>
+
+using namespace IRComponents;
+
+namespace IRSystem {
+
+template <> struct System<CYCLE_BOUNDARY_DETECT> {
+    std::uint64_t simTick_ = 0;
+
+    void beginTick() {
+        simTick_ = IRSim::tick();
+    }
+
+    void tick(C_Cycle &cycle) {
+        if (cycle.periodTicks_ == 0) {
+            cycle.boundaryCrossed_ = false;
+            return;
+        }
+        const std::uint64_t currentCycleNum =
+            (simTick_ + cycle.phaseOffset_) / cycle.periodTicks_;
+
+        if (cycle.lastCycleNum_ == C_Cycle::kUnprimed) {
+            cycle.lastCycleNum_ = currentCycleNum;
+            cycle.boundaryCrossed_ = false;
+            return;
+        }
+
+        if (currentCycleNum != cycle.lastCycleNum_) {
+            cycle.boundaryCrossed_ = true;
+            cycle.fromCycle_ = cycle.lastCycleNum_;
+            cycle.toCycle_ = currentCycleNum;
+            cycle.lastCycleNum_ = currentCycleNum;
+        } else {
+            cycle.boundaryCrossed_ = false;
+        }
+    }
+
+    static SystemId create() {
+        return registerSystem<CYCLE_BOUNDARY_DETECT, C_Cycle>("CycleBoundaryDetect");
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_CYCLE_BOUNDARY_DETECT_H */

--- a/engine/prefabs/irreden/update/systems/system_cycle_boundary_detect.hpp
+++ b/engine/prefabs/irreden/update/systems/system_cycle_boundary_detect.hpp
@@ -2,15 +2,17 @@
 #define SYSTEM_CYCLE_BOUNDARY_DETECT_H
 
 // SYSTEM_CYCLE_BOUNDARY_DETECT — for every C_Cycle, recomputes the current cycle
-// index from the sim tick and raises the embedded boundary event
-// (boundaryCrossed_ + fromCycle_/toCycle_) on the tick a period boundary is
-// crossed. Register AFTER SIM_CLOCK_ADVANCE so it reads the advanced tick.
+// index and intra-period segment from the sim tick and raises the embedded boundary
+// event (boundaryCrossed_ + fromCycle_/toCycle_ + fromSegment_/toSegment_) on the
+// tick any segment crossing occurs (including the period wrap). Register AFTER
+// SIM_CLOCK_ADVANCE so it reads the advanced tick.
 //
 // The sim tick is cached once per frame in beginTick (member-on-System<N> form,
 // not function-local static — see engine/system/CLAUDE.md). boundaryCrossed_ is
 // recomputed every tick, so it is self-clearing: a consumer system ordered after
 // this one reads the flag the same frame, and it resets next frame with no
-// separate clear system. A cycle is primed silently on its first evaluation
+// separate clear system. segmentIndex_ is updated every tick and always reflects
+// the current segment. A cycle is primed silently on its first evaluation
 // (lastCycleNum_ == kUnprimed) so one created mid-sim fires no spurious boundary.
 
 #include <irreden/common/components/component_cycle.hpp>
@@ -37,20 +39,31 @@ template <> struct System<CYCLE_BOUNDARY_DETECT> {
         }
         const std::uint64_t currentCycleNum =
             (simTick_ + cycle.phaseOffset_) / cycle.periodTicks_;
+        const std::uint64_t withinTick =
+            (simTick_ + cycle.phaseOffset_) % cycle.periodTicks_;
+
+        const std::uint8_t currentSegment = cycle.computeSegment(withinTick);
 
         if (cycle.lastCycleNum_ == C_Cycle::kUnprimed) {
             cycle.lastCycleNum_ = currentCycleNum;
+            cycle.lastSegmentIndex_ = currentSegment;
+            cycle.segmentIndex_ = currentSegment;
             cycle.boundaryCrossed_ = false;
             return;
         }
 
-        if (currentCycleNum != cycle.lastCycleNum_) {
+        if (currentCycleNum != cycle.lastCycleNum_ || currentSegment != cycle.lastSegmentIndex_) {
             cycle.boundaryCrossed_ = true;
             cycle.fromCycle_ = cycle.lastCycleNum_;
             cycle.toCycle_ = currentCycleNum;
+            cycle.fromSegment_ = cycle.lastSegmentIndex_;
+            cycle.toSegment_ = currentSegment;
+            cycle.segmentIndex_ = currentSegment;
             cycle.lastCycleNum_ = currentCycleNum;
+            cycle.lastSegmentIndex_ = currentSegment;
         } else {
             cycle.boundaryCrossed_ = false;
+            cycle.segmentIndex_ = currentSegment;
         }
     }
 

--- a/engine/prefabs/irreden/update/systems/system_sim_clock_advance.hpp
+++ b/engine/prefabs/irreden/update/systems/system_sim_clock_advance.hpp
@@ -1,0 +1,46 @@
+#ifndef SYSTEM_SIM_CLOCK_ADVANCE_H
+#define SYSTEM_SIM_CLOCK_ADVANCE_H
+
+// SYSTEM_SIM_CLOCK_ADVANCE — advances the C_SimClock singleton once per UPDATE
+// tick at the configured timeScale_. Register FIRST among the sim-clock systems
+// so CYCLE_BOUNDARY_DETECT / TIMER_FIRE observe the new tick the same frame.
+//
+// timeScale_ == 1.0 takes a no-float fast path (++tickCount_). Otherwise the
+// fractional rate accumulates in subTickAccum_ and only the whole-tick portion
+// commits, so scale 0.5 advances every other tick and scale 2.0 advances two per
+// tick — all with deterministic float ops (same inputs reproduce byte-identical
+// state, satisfying the sim-clock determinism gate). timeScale_ <= 0 is paused.
+
+#include <irreden/common/components/component_sim_clock.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_system.hpp>
+
+#include <cstdint>
+
+using namespace IRComponents;
+
+namespace IRSystem {
+
+template <> struct System<SIM_CLOCK_ADVANCE> {
+    void tick(C_SimClock &clock) {
+        if (clock.timeScale_ == 1.0f) {
+            ++clock.tickCount_;
+            return;
+        }
+        if (clock.timeScale_ <= 0.0f) {
+            return;
+        }
+        clock.subTickAccum_ += clock.timeScale_;
+        const float whole = IRMath::floor(clock.subTickAccum_);
+        clock.tickCount_ += static_cast<std::uint64_t>(whole);
+        clock.subTickAccum_ -= whole;
+    }
+
+    static SystemId create() {
+        return registerSystem<SIM_CLOCK_ADVANCE, C_SimClock>("SimClockAdvance");
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_SIM_CLOCK_ADVANCE_H */

--- a/engine/prefabs/irreden/update/systems/system_timer_fire.hpp
+++ b/engine/prefabs/irreden/update/systems/system_timer_fire.hpp
@@ -1,0 +1,56 @@
+#ifndef SYSTEM_TIMER_FIRE_H
+#define SYSTEM_TIMER_FIRE_H
+
+// SYSTEM_TIMER_FIRE — for every C_Timer, raises the embedded fired_ event on the
+// tick the sim reaches targetTick_. One-shot timers (intervalTicks_ == 0)
+// deactivate after firing; recurring timers re-arm by advancing targetTick_ past
+// every interval the sim crossed this tick (so a large timeScale_ overshoot
+// reports a single fired_ rather than falling behind), and re-anchor startTick_
+// to the current interval's start for timerFraction. Register AFTER
+// SIM_CLOCK_ADVANCE so it reads the advanced tick.
+//
+// Sim tick cached once per frame in beginTick (member-on-System<N> form).
+// fired_ is recomputed every tick (self-clearing); a consumer ordered after this
+// system reads it the same frame.
+
+#include <irreden/common/components/component_timer.hpp>
+#include <irreden/common/sim_clock.hpp>
+#include <irreden/ir_system.hpp>
+
+#include <cstdint>
+
+using namespace IRComponents;
+
+namespace IRSystem {
+
+template <> struct System<TIMER_FIRE> {
+    std::uint64_t simTick_ = 0;
+
+    void beginTick() {
+        simTick_ = IRSim::tick();
+    }
+
+    void tick(C_Timer &timer) {
+        timer.fired_ = false;
+        if (!timer.active_ || simTick_ < timer.targetTick_) {
+            return;
+        }
+        timer.fired_ = true;
+        if (timer.intervalTicks_ == 0) {
+            timer.active_ = false;
+            return;
+        }
+        do {
+            timer.startTick_ = timer.targetTick_;
+            timer.targetTick_ += timer.intervalTicks_;
+        } while (simTick_ >= timer.targetTick_);
+    }
+
+    static SystemId create() {
+        return registerSystem<TIMER_FIRE, C_Timer>("TimerFire");
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_TIMER_FIRE_H */

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -862,6 +862,45 @@ IRModifier.resolvedQuat(entity, fieldNameOrId, fallback) -- read quat slot
   engine assertion in debug and silently no-op in release. The compose
   pass normalizes the final resolved quat once at the end.
 
+## Sim clock (`IRSim.*`)
+
+`bindLuaDrivenEcs()` exposes the sim-clock / cycle / timer / stopwatch
+service (engine #200, `engine/prefabs/irreden/common/sim_clock.hpp`) as the
+`IRSim` table. The **sim tick** is pausable and scalable (distinct from the
+always-advancing engine tick); a creation composes `SIM_CLOCK_ADVANCE` /
+`CYCLE_BOUNDARY_DETECT` / `TIMER_FIRE` into its UPDATE pipeline C++-side.
+
+```lua
+IRSim.setTimeScale(0.5)            -- 0 = paused, N = fast, 1/N = slow
+IRSim.tick()                       -- current sim tick
+IRSim.pause(); IRSim.resume(); IRSim.isPaused()
+
+IRSim.createCycle("day", 24000)    -- name, periodTicks[, phaseOffset]
+local t = IRSim.cycleFraction("day")          -- [0,1) — drive sun/colour on this
+IRSim.cycleNumber("day"); IRSim.cycleTickWithin("day")
+IRSim.cycleBoundaryCrossed("day")             -- true the tick a boundary crossed
+
+IRSim.createTimer("reload", 50)    -- name, targetTick[, intervalTicks] (0 = one-shot)
+IRSim.timerFired("reload"); IRSim.timerActive("reload")
+IRSim.timerTicksRemaining("reload"); IRSim.timerFraction("reload")
+
+IRSim.createStopwatch("run")
+IRSim.stopwatchElapsed("run")
+IRSim.stopwatchPause("run"); IRSim.stopwatchResume("run"); IRSim.stopwatchReset("run")
+```
+
+- **Discrete events are polled, not callbacks.** `cycleBoundaryCrossed` /
+  `timerFired` read the embedded event flag (true only on the firing tick)
+  the same tick the C++ detector raised it — the events-as-components
+  model. A registered-callback (`onCycleBoundary`) form is a follow-up if a
+  real consumer needs it.
+- **Names are registry keys**, not enums — string lookups here are allowed
+  (cf. modifier `fieldNameOrId`); a handful of cycles/timers per world makes
+  the linear name scan a query convenience, not a hot path.
+- Service surface only — the advance systems are not exposed for Lua
+  pipeline assembly (same as most prefab systems). Coverage:
+  `test/time/lua_sim_test.cpp`.
+
 ## Prefab format (`Prefab.register`, `Prefab.spawn`)
 
 `bindLuaDrivenEcs()` also exposes the `Prefab` Lua table — the runtime

--- a/engine/script/include/irreden/script/lua_sim_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_sim_bindings.hpp
@@ -60,6 +60,12 @@ inline void bindSimApi(LuaScript &script) {
     sim["cycleBoundaryCrossed"] = [](const std::string &name) -> bool {
         return IRSim::cycleBoundaryCrossed(name);
     };
+    sim["cycleSegment"] = [](const std::string &name) -> lua_Integer {
+        return static_cast<lua_Integer>(IRSim::cycleSegment(name));
+    };
+    sim["cycleAddBreakpoint"] = [](const std::string &name, double fraction) {
+        IRSim::cycleAddBreakpoint(name, static_cast<float>(fraction));
+    };
 
     // Timers.
     sim["createTimer"] =

--- a/engine/script/include/irreden/script/lua_sim_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_sim_bindings.hpp
@@ -1,0 +1,104 @@
+#ifndef LUA_SIM_BINDINGS_H
+#define LUA_SIM_BINDINGS_H
+
+#include <irreden/common/sim_clock.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <sol/sol.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace IRScript::detail {
+
+// Exposes the sim-clock / cycle / timer / stopwatch service as the `IRSim` Lua
+// table, mirroring the IR<Module> convention (IRSpatial, IRModifier, IRSystem).
+// It is the service surface only — create + query + control. The advance
+// systems (SIM_CLOCK_ADVANCE / CYCLE_BOUNDARY_DETECT / TIMER_FIRE) are composed
+// into the UPDATE pipeline C++-side, the same way most prefab systems are not
+// individually exposed to Lua pipeline assembly.
+//
+// Discrete events (cycle boundary / timer fired) are exposed as POLL functions
+// (cycleBoundaryCrossed / timerFired) rather than registered callbacks: a Lua
+// system reads them the tick they fire, matching the engine's
+// events-as-components model. A callback/listener form is a follow-up if a
+// real consumer needs it.
+inline void bindSimApi(LuaScript &script) {
+    sol::state &lua = script.lua();
+    if (!lua["IRSim"].valid()) {
+        lua["IRSim"] = lua.create_table();
+    }
+    sol::table sim = lua["IRSim"];
+
+    // Clock.
+    sim["tick"] = []() -> lua_Integer { return static_cast<lua_Integer>(IRSim::tick()); };
+    sim["timeScale"] = []() -> double { return static_cast<double>(IRSim::timeScale()); };
+    sim["isPaused"] = []() -> bool { return IRSim::isPaused(); };
+    sim["setTimeScale"] = [](double scale) { IRSim::setTimeScale(static_cast<float>(scale)); };
+    sim["pause"] = []() { IRSim::pause(); };
+    sim["resume"] = []() { IRSim::resume(); };
+
+    // Cycles.
+    sim["createCycle"] =
+        [](const std::string &name, lua_Integer period, sol::optional<lua_Integer> phaseOffset)
+        -> lua_Integer {
+        const std::uint64_t offset =
+            phaseOffset ? static_cast<std::uint64_t>(*phaseOffset) : 0u;
+        return static_cast<lua_Integer>(
+            IRSim::createCycle(name, static_cast<std::uint64_t>(period), offset)
+        );
+    };
+    sim["cycleNumber"] = [](const std::string &name) -> lua_Integer {
+        return static_cast<lua_Integer>(IRSim::cycleNumber(name));
+    };
+    sim["cycleTickWithin"] = [](const std::string &name) -> lua_Integer {
+        return static_cast<lua_Integer>(IRSim::cycleTickWithin(name));
+    };
+    sim["cycleFraction"] = [](const std::string &name) -> double {
+        return static_cast<double>(IRSim::cycleFraction(name));
+    };
+    sim["cycleBoundaryCrossed"] = [](const std::string &name) -> bool {
+        return IRSim::cycleBoundaryCrossed(name);
+    };
+
+    // Timers.
+    sim["createTimer"] =
+        [](const std::string &name, lua_Integer targetTick, sol::optional<lua_Integer> interval)
+        -> lua_Integer {
+        const std::uint64_t intervalTicks =
+            interval ? static_cast<std::uint64_t>(*interval) : 0u;
+        return static_cast<lua_Integer>(
+            IRSim::createTimer(name, static_cast<std::uint64_t>(targetTick), intervalTicks)
+        );
+    };
+    sim["timerActive"] = [](const std::string &name) -> bool {
+        return IRSim::timerActive(name);
+    };
+    sim["timerTicksRemaining"] = [](const std::string &name) -> lua_Integer {
+        return static_cast<lua_Integer>(IRSim::timerTicksRemaining(name));
+    };
+    sim["timerFraction"] = [](const std::string &name) -> double {
+        return static_cast<double>(IRSim::timerFraction(name));
+    };
+    sim["timerFired"] = [](const std::string &name) -> bool {
+        return IRSim::timerFired(name);
+    };
+
+    // Stopwatches.
+    sim["createStopwatch"] = [](const std::string &name) -> lua_Integer {
+        return static_cast<lua_Integer>(IRSim::createStopwatch(name));
+    };
+    sim["stopwatchElapsed"] = [](const std::string &name) -> lua_Integer {
+        return static_cast<lua_Integer>(IRSim::stopwatchElapsed(name));
+    };
+    sim["stopwatchRunning"] = [](const std::string &name) -> bool {
+        return IRSim::stopwatchRunning(name);
+    };
+    sim["stopwatchPause"] = [](const std::string &name) { IRSim::stopwatchPause(name); };
+    sim["stopwatchResume"] = [](const std::string &name) { IRSim::stopwatchResume(name); };
+    sim["stopwatchReset"] = [](const std::string &name) { IRSim::stopwatchReset(name); };
+}
+
+} // namespace IRScript::detail
+
+#endif /* LUA_SIM_BINDINGS_H */

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -11,6 +11,7 @@
 #include <irreden/script/lua_modifier_bindings.hpp>
 #include <irreden/script/lua_pipeline_bindings.hpp>
 #include <irreden/script/lua_render_bindings.hpp>
+#include <irreden/script/lua_sim_bindings.hpp>
 #include <irreden/script/lua_spatial_bindings.hpp>
 #include <irreden/script/prefab_api.hpp>
 #include <irreden/voxel/components/component_bind_points.hpp>
@@ -637,6 +638,7 @@ void LuaScript::bindLuaDrivenEcs() {
     detail::bindPrefabApi(*this);
     detail::bindSpatialApi(*this);
     detail::bindRenderGlue(*this);
+    detail::bindSimApi(*this);
 }
 
 void LuaScript::bindLuaCommands() {

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -83,6 +83,14 @@ enum SystemName {
     PROPAGATE_TRANSFORM,
     AUTO_SPIN_LOCAL_TRANSFORM,
     ROTATION_TARGET_LOCAL_TRANSFORM,
+    // Sim-clock substrate (engine/prefabs/irreden/common/sim_clock.hpp).
+    // Order within UPDATE: SIM_CLOCK_ADVANCE first (advances the C_SimClock
+    // singleton), then CYCLE_BOUNDARY_DETECT / TIMER_FIRE read the new tick
+    // and raise their embedded boundary/fired events; place consumers after.
+    // Stopwatches have no system (elapsed is computed on read by IRSim::).
+    SIM_CLOCK_ADVANCE,
+    CYCLE_BOUNDARY_DETECT,
+    TIMER_FIRE,
     PROPAGATE_CHUNK_MEMBERSHIP,
     VOXEL_SQUASH_STRETCH,
     UPDATE_VOXEL_SET_CHILDREN,

--- a/engine/time/CLAUDE.md
+++ b/engine/time/CLAUDE.md
@@ -13,6 +13,13 @@ time to run another UPDATE tick, and reads `deltaTime(event)` for dt.
   returns the actual wall-clock duration of the last tick.
 - `renderFps()`, `updateFps()` — 1-second rolling averages.
 - `renderFrameTimeMs()`, `droppedFrames()`, `resetDroppedFrames()`.
+- `tick()` — raw engine UPDATE tick count (`EventProfiler<UPDATE>::
+  m_fixedStepCount`), always advancing one-per-UPDATE. This is the
+  wall-clock-aligned **engine tick**; the pausable/scalable **sim tick**
+  lives in `IRSim::tick()` (`engine/prefabs/irreden/common/sim_clock.hpp`).
+  See the two-clock split there. Asserts if the `TimeManager` isn't
+  initialised (unlike the sim clock, which is an ECS singleton usable in
+  isolation).
 
 ## `Events` enum
 

--- a/engine/time/include/irreden/ir_time.hpp
+++ b/engine/time/include/irreden/ir_time.hpp
@@ -3,6 +3,8 @@
 
 #include <irreden/time/ir_time_types.hpp>
 
+#include <cstdint>
+
 namespace IRTime {
 
 /// Global pointer to the active `TimeManager`; managed by the engine runtime.
@@ -22,6 +24,15 @@ double deltaTime(Events eventType);
 /// Returns `true` when the UPDATE accumulator has buffered at least one frame period
 /// (1 / @ref IRConstants::kFPS).  Call in a `while` loop to drain catch-up ticks.
 bool shouldUpdate();
+
+/// Raw engine UPDATE tick count: total fixed-step UPDATE ticks executed since
+/// startup, always advancing one-per-UPDATE regardless of sim pause/scale. This
+/// is the wall-clock-aligned "engine tick" half of the two-clock model; the
+/// pausable/scalable "sim tick" lives in `IRSim::tick()`
+/// (`engine/prefabs/irreden/common/sim_clock.hpp`). Asserts if the TimeManager
+/// is not initialised — engine-tick has no meaning without the running loop,
+/// unlike the sim clock, which is an ECS singleton usable in isolation.
+std::uint64_t tick();
 
 /// 1-second rolling average of RENDER ticks per second.
 double renderFps();

--- a/engine/time/include/irreden/time/event_profiler.hpp
+++ b/engine/time/include/irreden/time/event_profiler.hpp
@@ -104,6 +104,15 @@ template <> class EventProfiler<UPDATE> {
         return m_deltaTimeFixed;
     }
 
+    /// Total fixed-step UPDATE ticks executed since startup. Monotonic,
+    /// advances exactly once per UPDATE pipeline run (even while the sim
+    /// clock is paused), so it stays wall-clock-aligned. Backs
+    /// `IRTime::tick()`. Widened to 64 bits at the public boundary so the
+    /// engine-tick counter never wraps over a long-running session.
+    std::uint64_t fixedStepCount() const {
+        return m_fixedStepCount;
+    }
+
     double fps() const {
         if (m_fpsCount == 0)
             return 0.0;

--- a/engine/time/include/irreden/time/time_manager.hpp
+++ b/engine/time/include/irreden/time/time_manager.hpp
@@ -64,6 +64,12 @@ class TimeManager {
     template <Events event> double fps();
     template <Events event> double frameTimeMs();
 
+    /// Raw engine UPDATE tick count — see
+    /// `EventProfiler<UPDATE>::fixedStepCount`. Backs `IRTime::tick()`.
+    std::uint64_t fixedStepCount() const {
+        return m_profilerUpdate.fixedStepCount();
+    }
+
     unsigned int droppedFrames() const {
         return m_profilerRender.droppedFrames();
     }

--- a/engine/time/src/ir_time.cpp
+++ b/engine/time/src/ir_time.cpp
@@ -24,6 +24,10 @@ bool shouldUpdate() {
     return getTimeManager().shouldUpdate();
 }
 
+std::uint64_t tick() {
+    return getTimeManager().fixedStepCount();
+}
+
 double renderFps() {
     return getTimeManager().fps<RENDER>();
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(IrredenEngineTest
   math/ir_math_yaw_deformation_test.cpp
   math/sdf_test.cpp
   render/camera_yaw_test.cpp
+  render/detached_world_depth_test.cpp
   render/per_axis_canvas_size_test.cpp
   render/frame_data_sun_layout_test.cpp
   render/per_canvas_light_scope_test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,6 @@ add_executable(IrredenEngineTest
   math/ir_math_yaw_deformation_test.cpp
   math/sdf_test.cpp
   render/camera_yaw_test.cpp
-  render/detached_world_depth_test.cpp
   render/per_axis_canvas_size_test.cpp
   render/frame_data_sun_layout_test.cpp
   render/per_canvas_light_scope_test.cpp
@@ -67,6 +66,11 @@ add_executable(IrredenEngineTest
   system/register_system_test.cpp
   system/system_access_test.cpp
   system/system_concurrency_test.cpp
+  time/sim_clock_test.cpp
+  time/cycle_test.cpp
+  time/timer_test.cpp
+  time/stopwatch_test.cpp
+  time/lua_sim_test.cpp
   job/ir_job_test.cpp
   utility/ir_utility_test.cpp
   world/chunk_coord_test.cpp

--- a/test/time/cycle_test.cpp
+++ b/test/time/cycle_test.cpp
@@ -241,4 +241,15 @@ TEST_F(CycleTest, BreakpointDuplicateIgnored) {
     }
 }
 
+TEST_F(CycleTest, BreakpointAtZeroFractionIgnored) {
+    // fraction == 0.0 maps to offset 0, which duplicates the implicit wrap
+    // boundary — addBreakpoint must reject it so segment 0 stays reachable.
+    auto id = IRSim::createCycle("zero", 100);
+    IRSim::cycleAddBreakpoint("zero", 0.0f);
+    {
+        const C_Cycle &c = IREntity::getComponent<C_Cycle>(id);
+        EXPECT_EQ(c.numBreakpoints_, 0u);
+    }
+}
+
 } // namespace

--- a/test/time/cycle_test.cpp
+++ b/test/time/cycle_test.cpp
@@ -76,7 +76,7 @@ TEST_F(CycleTest, FractionProgressesAndWraps) {
     EXPECT_EQ(IRSim::cycleNumber("day"), 0u);
     EXPECT_EQ(IRSim::cycleTickWithin("day"), 25u);
 
-    advance(75); // now at sim tick 100
+    advance(75);                                           // now at sim tick 100
     EXPECT_NEAR(IRSim::cycleFraction("day"), 0.0f, 1e-5f); // wraps
     EXPECT_EQ(IRSim::cycleNumber("day"), 1u);
     EXPECT_EQ(IRSim::cycleTickWithin("day"), 0u);
@@ -217,6 +217,28 @@ TEST_F(CycleTest, CycleSegmentQueryMatchesComponent) {
 
     advance(1); // tick 100: wrap
     EXPECT_EQ(IRSim::cycleSegment("phase"), 0u);
+}
+
+TEST_F(CycleTest, BreakpointDuplicateIgnored) {
+    // Adding the same breakpoint fraction twice must insert only one entry.
+    auto id = IRSim::createCycle("dup", 100);
+    IRSim::cycleAddBreakpoint("dup", 0.5f); // offset 50
+    IRSim::cycleAddBreakpoint("dup", 0.5f); // duplicate — no-op
+    {
+        const C_Cycle &c = IREntity::getComponent<C_Cycle>(id);
+        EXPECT_EQ(c.numBreakpoints_, 1u);
+        EXPECT_EQ(c.breakpoints_[0], 50u);
+    }
+    // Behavioral: exactly one boundary fires at tick 50 (segment 0 → 1).
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // prime, tick 1
+    advance(49);                                              // tick 50: segment crossing
+    {
+        const C_Cycle &c = IREntity::getComponent<C_Cycle>(id);
+        EXPECT_TRUE(c.boundaryCrossed_);
+        EXPECT_EQ(c.segmentIndex_, 1u);
+        EXPECT_EQ(c.fromSegment_, 0u);
+        EXPECT_EQ(c.toSegment_, 1u);
+    }
 }
 
 } // namespace

--- a/test/time/cycle_test.cpp
+++ b/test/time/cycle_test.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <irreden/common/components/component_cycle.hpp>
+#include <irreden/common/sim_clock.hpp>
+#include <irreden/update/systems/system_cycle_boundary_detect.hpp>
+#include <irreden/update/systems/system_sim_clock_advance.hpp>
+
+namespace {
+
+using IRComponents::C_Cycle;
+
+// SIM_CLOCK_ADVANCE then CYCLE_BOUNDARY_DETECT, the real pipeline order: the
+// boundary detector reads the tick the advance system just produced.
+class CycleTest : public testing::Test {
+  protected:
+    CycleTest()
+        : m_entity_manager{}
+        , m_system_manager{} {
+        IRSim::clock();
+        m_system_manager.registerPipeline(
+            IRTime::Events::UPDATE,
+            {IRSystem::createSystem<IRSystem::SIM_CLOCK_ADVANCE>(),
+             IRSystem::createSystem<IRSystem::CYCLE_BOUNDARY_DETECT>()}
+        );
+    }
+
+    void advance(std::uint64_t ticks) {
+        for (std::uint64_t i = 0; i < ticks; ++i) {
+            m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        }
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(CycleTest, BoundaryFiresOncePerPeriod) {
+    auto id = IRSim::createCycle("day", 100);
+
+    int boundaries = 0;
+    std::uint64_t lastFrom = 0;
+    std::uint64_t lastTo = 0;
+    for (std::uint64_t i = 0; i < 250; ++i) {
+        m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        const C_Cycle &cycle = IREntity::getComponent<C_Cycle>(id);
+        if (cycle.boundaryCrossed_) {
+            ++boundaries;
+            lastFrom = cycle.fromCycle_;
+            lastTo = cycle.toCycle_;
+        }
+    }
+    EXPECT_EQ(boundaries, 2); // crossings at sim tick 100 and 200
+    EXPECT_EQ(lastFrom, 1u);
+    EXPECT_EQ(lastTo, 2u);
+}
+
+TEST_F(CycleTest, NoSpuriousBoundaryBeforeFirstPeriod) {
+    auto id = IRSim::createCycle("day", 100);
+    for (std::uint64_t i = 0; i < 99; ++i) {
+        m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        EXPECT_FALSE(IREntity::getComponent<C_Cycle>(id).boundaryCrossed_);
+    }
+}
+
+TEST_F(CycleTest, FractionProgressesAndWraps) {
+    IRSim::createCycle("day", 100);
+
+    advance(25);
+    EXPECT_NEAR(IRSim::cycleFraction("day"), 0.25f, 1e-5f);
+    EXPECT_EQ(IRSim::cycleNumber("day"), 0u);
+    EXPECT_EQ(IRSim::cycleTickWithin("day"), 25u);
+
+    advance(75); // now at sim tick 100
+    EXPECT_NEAR(IRSim::cycleFraction("day"), 0.0f, 1e-5f); // wraps
+    EXPECT_EQ(IRSim::cycleNumber("day"), 1u);
+    EXPECT_EQ(IRSim::cycleTickWithin("day"), 0u);
+}
+
+TEST_F(CycleTest, PhaseOffsetShiftsBoundary) {
+    // A 100-tick cycle offset by 40 crosses its boundary at sim tick 60, 160…
+    IRSim::createCycle("shifted", 100, 40);
+    advance(60);
+    EXPECT_EQ(IRSim::cycleNumber("shifted"), 1u); // (60 + 40) / 100 == 1
+    EXPECT_EQ(IRSim::cycleTickWithin("shifted"), 0u);
+}
+
+TEST_F(CycleTest, MidSimCreationDoesNotFireSpuriousBoundary) {
+    advance(150); // sim already past one period
+    auto id = IRSim::createCycle("late", 100);
+
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // sim tick 151: primes silently
+    EXPECT_FALSE(IREntity::getComponent<C_Cycle>(id).boundaryCrossed_);
+
+    int boundaries = 0;
+    for (std::uint64_t i = 0; i < 60; ++i) { // ticks 152..211
+        m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        if (IREntity::getComponent<C_Cycle>(id).boundaryCrossed_) {
+            ++boundaries;
+        }
+    }
+    EXPECT_EQ(boundaries, 1); // only the real tick-200 crossing
+}
+
+} // namespace

--- a/test/time/cycle_test.cpp
+++ b/test/time/cycle_test.cpp
@@ -107,4 +107,116 @@ TEST_F(CycleTest, MidSimCreationDoesNotFireSpuriousBoundary) {
     EXPECT_EQ(boundaries, 1); // only the real tick-200 crossing
 }
 
+TEST_F(CycleTest, BreakpointsFireOnSegmentTransition) {
+    // Period of 100 ticks, breakpoints at 25% and 75%: 3 segments.
+    // Segment 0: [0,25), segment 1: [25,75), segment 2: [75,100).
+    auto id = IRSim::createCycle("day", 100);
+    IRSim::cycleAddBreakpoint("day", 0.25f); // offset 25
+    IRSim::cycleAddBreakpoint("day", 0.75f); // offset 75
+
+    // Tick 1: primes silently (segment 0, cycle 0).
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    EXPECT_FALSE(IREntity::getComponent<C_Cycle>(id).boundaryCrossed_);
+    EXPECT_EQ(IREntity::getComponent<C_Cycle>(id).segmentIndex_, 0u);
+
+    advance(24); // sim tick 25 — crosses into segment 1
+    {
+        const C_Cycle &c = IREntity::getComponent<C_Cycle>(id);
+        EXPECT_TRUE(c.boundaryCrossed_);
+        EXPECT_EQ(c.fromSegment_, 0u);
+        EXPECT_EQ(c.toSegment_, 1u);
+        EXPECT_EQ(c.segmentIndex_, 1u);
+        EXPECT_EQ(c.fromCycle_, 0u);
+        EXPECT_EQ(c.toCycle_, 0u); // same cycle number, different segment
+    }
+
+    advance(50); // sim tick 75 — crosses into segment 2
+    {
+        const C_Cycle &c = IREntity::getComponent<C_Cycle>(id);
+        EXPECT_TRUE(c.boundaryCrossed_);
+        EXPECT_EQ(c.fromSegment_, 1u);
+        EXPECT_EQ(c.toSegment_, 2u);
+        EXPECT_EQ(c.segmentIndex_, 2u);
+    }
+
+    advance(25); // sim tick 100 — period wrap, back to segment 0
+    {
+        const C_Cycle &c = IREntity::getComponent<C_Cycle>(id);
+        EXPECT_TRUE(c.boundaryCrossed_);
+        EXPECT_EQ(c.fromSegment_, 2u);
+        EXPECT_EQ(c.toSegment_, 0u);
+        EXPECT_EQ(c.segmentIndex_, 0u);
+        EXPECT_EQ(c.fromCycle_, 0u);
+        EXPECT_EQ(c.toCycle_, 1u);
+    }
+}
+
+TEST_F(CycleTest, BreakpointNoBoundaryMidSegment) {
+    // Confirm no spurious boundary fires while staying inside one segment.
+    auto id = IRSim::createCycle("boss", 100);
+    IRSim::cycleAddBreakpoint("boss", 0.5f); // segment boundary at tick 50
+
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // prime at tick 1
+    advance(23); // ticks 2..24: still in segment 0 (withinTick 2..24, breakpoint at 50)
+    EXPECT_FALSE(IREntity::getComponent<C_Cycle>(id).boundaryCrossed_);
+    EXPECT_EQ(IREntity::getComponent<C_Cycle>(id).segmentIndex_, 0u);
+}
+
+TEST_F(CycleTest, MidSimCreationWithBreakpointsNoBogusEvent) {
+    advance(60); // sim tick 60, in the middle of a hypothetical period
+    auto id = IRSim::createCycle("wave", 100);
+    IRSim::cycleAddBreakpoint("wave", 0.5f); // segment boundary at tick 50 within period
+
+    // First detect: tick 61 puts us within the period at position 61 % 100 = 61 → segment 1.
+    // Should prime silently to segment 1, not fire.
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    EXPECT_FALSE(IREntity::getComponent<C_Cycle>(id).boundaryCrossed_);
+    EXPECT_EQ(IREntity::getComponent<C_Cycle>(id).segmentIndex_, 1u);
+
+    // Advance to tick 100: period wraps to segment 0.
+    advance(39); // ticks 62..100
+    {
+        const C_Cycle &c = IREntity::getComponent<C_Cycle>(id);
+        EXPECT_TRUE(c.boundaryCrossed_);
+        EXPECT_EQ(c.segmentIndex_, 0u);
+    }
+}
+
+TEST_F(CycleTest, NoBreakpointsSegmentAlwaysZero) {
+    // Without breakpoints the existing period-wrap event still fires and
+    // segment stays 0 throughout.
+    auto id = IRSim::createCycle("plain", 50);
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // prime
+
+    advance(49); // tick 50: period wrap
+    {
+        const C_Cycle &c = IREntity::getComponent<C_Cycle>(id);
+        EXPECT_TRUE(c.boundaryCrossed_);
+        EXPECT_EQ(c.segmentIndex_, 0u);
+        EXPECT_EQ(c.fromSegment_, 0u);
+        EXPECT_EQ(c.toSegment_, 0u);
+    }
+}
+
+TEST_F(CycleTest, CycleSegmentQueryMatchesComponent) {
+    IRSim::createCycle("phase", 100);
+    IRSim::cycleAddBreakpoint("phase", 0.25f);
+    IRSim::cycleAddBreakpoint("phase", 0.75f);
+
+    m_system_manager.executePipeline(IRTime::Events::UPDATE); // prime, tick 1
+    EXPECT_EQ(IRSim::cycleSegment("phase"), 0u);
+
+    advance(24); // tick 25
+    EXPECT_EQ(IRSim::cycleSegment("phase"), 1u);
+
+    advance(50); // tick 75
+    EXPECT_EQ(IRSim::cycleSegment("phase"), 2u);
+
+    advance(24); // tick 99
+    EXPECT_EQ(IRSim::cycleSegment("phase"), 2u);
+
+    advance(1); // tick 100: wrap
+    EXPECT_EQ(IRSim::cycleSegment("phase"), 0u);
+}
+
 } // namespace

--- a/test/time/lua_sim_test.cpp
+++ b/test/time/lua_sim_test.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <irreden/common/sim_clock.hpp>
+#include <irreden/script/lua_script.hpp>
+#include <irreden/script/lua_sim_bindings.hpp>
+#include <irreden/update/systems/system_cycle_boundary_detect.hpp>
+#include <irreden/update/systems/system_sim_clock_advance.hpp>
+#include <irreden/update/systems/system_timer_fire.hpp>
+
+namespace {
+
+// Fixture: a LuaScript with the IRSim service bound, plus the real
+// SIM_CLOCK_ADVANCE / CYCLE_BOUNDARY_DETECT / TIMER_FIRE pipeline so Lua can
+// drive and observe sim time. The advance is stepped C++-side (the pipeline);
+// Lua reads/writes through the IRSim table. Stands in for #199's full Lua
+// round-trip until save/load lands.
+class LuaSimTest : public testing::Test {
+  protected:
+    LuaSimTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_system_manager{} {
+        IRScript::detail::bindSimApi(m_lua);
+        IRSim::clock(); // materialize the singleton before SIM_CLOCK_ADVANCE runs
+        m_system_manager.registerPipeline(
+            IRTime::Events::UPDATE,
+            {IRSystem::createSystem<IRSystem::SIM_CLOCK_ADVANCE>(),
+             IRSystem::createSystem<IRSystem::CYCLE_BOUNDARY_DETECT>(),
+             IRSystem::createSystem<IRSystem::TIMER_FIRE>()}
+        );
+    }
+
+    void advance(std::uint64_t ticks) {
+        for (std::uint64_t i = 0; i < ticks; ++i) {
+            m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        }
+    }
+
+    // m_lua first so it is destroyed last (sol handles outlive ECS cleanup).
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(LuaSimTest, ClockTickReadableFromLua) {
+    EXPECT_EQ(m_lua.lua().script("return IRSim.tick()").get<int>(), 0);
+    advance(10);
+    EXPECT_EQ(m_lua.lua().script("return IRSim.tick()").get<int>(), 10);
+}
+
+TEST_F(LuaSimTest, SetTimeScaleFromLua) {
+    m_lua.lua().script("IRSim.setTimeScale(0.5)");
+    advance(10);
+    EXPECT_EQ(m_lua.lua().script("return IRSim.tick()").get<int>(), 5);
+    EXPECT_FALSE(m_lua.lua().script("return IRSim.isPaused()").get<bool>());
+    m_lua.lua().script("IRSim.pause()");
+    EXPECT_TRUE(m_lua.lua().script("return IRSim.isPaused()").get<bool>());
+}
+
+TEST_F(LuaSimTest, CreateCycleAndReadFraction) {
+    m_lua.lua().script("IRSim.createCycle('day', 100)");
+    advance(25);
+    EXPECT_NEAR(m_lua.lua().script("return IRSim.cycleFraction('day')").get<double>(), 0.25, 1e-5);
+    EXPECT_EQ(m_lua.lua().script("return IRSim.cycleNumber('day')").get<int>(), 0);
+    advance(75); // crosses the period boundary at sim tick 100
+    EXPECT_TRUE(m_lua.lua().script("return IRSim.cycleBoundaryCrossed('day')").get<bool>());
+    EXPECT_EQ(m_lua.lua().script("return IRSim.cycleNumber('day')").get<int>(), 1);
+}
+
+TEST_F(LuaSimTest, TimerCreateAndPollFromLua) {
+    m_lua.lua().script("IRSim.createTimer('reload', 50)");
+    EXPECT_TRUE(m_lua.lua().script("return IRSim.timerActive('reload')").get<bool>());
+    advance(49);
+    EXPECT_FALSE(m_lua.lua().script("return IRSim.timerFired('reload')").get<bool>());
+    advance(1); // sim tick 50: fires
+    EXPECT_TRUE(m_lua.lua().script("return IRSim.timerFired('reload')").get<bool>());
+    EXPECT_FALSE(m_lua.lua().script("return IRSim.timerActive('reload')").get<bool>());
+}
+
+TEST_F(LuaSimTest, StopwatchFromLua) {
+    m_lua.lua().script("IRSim.createStopwatch('run')");
+    advance(40);
+    EXPECT_EQ(m_lua.lua().script("return IRSim.stopwatchElapsed('run')").get<int>(), 40);
+    m_lua.lua().script("IRSim.stopwatchPause('run')");
+    advance(20);
+    EXPECT_EQ(m_lua.lua().script("return IRSim.stopwatchElapsed('run')").get<int>(), 40);
+    m_lua.lua().script("IRSim.stopwatchReset('run')");
+    EXPECT_EQ(m_lua.lua().script("return IRSim.stopwatchElapsed('run')").get<int>(), 0);
+}
+
+} // namespace

--- a/test/time/lua_sim_test.cpp
+++ b/test/time/lua_sim_test.cpp
@@ -73,6 +73,30 @@ TEST_F(LuaSimTest, CreateCycleAndReadFraction) {
     EXPECT_EQ(m_lua.lua().script("return IRSim.cycleNumber('day')").get<int>(), 1);
 }
 
+TEST_F(LuaSimTest, CycleBreakpointsAndSegmentFromLua) {
+    // Create a 100-tick cycle with two breakpoints (at 25% and 75%) from Lua.
+    m_lua.lua().script(R"(
+        IRSim.createCycle('phase', 100)
+        IRSim.cycleAddBreakpoint('phase', 0.25)
+        IRSim.cycleAddBreakpoint('phase', 0.75)
+    )");
+    // Prime silently.
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+    EXPECT_EQ(m_lua.lua().script("return IRSim.cycleSegment('phase')").get<int>(), 0);
+    EXPECT_FALSE(m_lua.lua().script("return IRSim.cycleBoundaryCrossed('phase')").get<bool>());
+
+    advance(24); // sim tick 25: crosses into segment 1
+    EXPECT_EQ(m_lua.lua().script("return IRSim.cycleSegment('phase')").get<int>(), 1);
+    EXPECT_TRUE(m_lua.lua().script("return IRSim.cycleBoundaryCrossed('phase')").get<bool>());
+
+    advance(50); // sim tick 75: crosses into segment 2
+    EXPECT_EQ(m_lua.lua().script("return IRSim.cycleSegment('phase')").get<int>(), 2);
+
+    advance(25); // sim tick 100: period wrap, back to segment 0
+    EXPECT_EQ(m_lua.lua().script("return IRSim.cycleSegment('phase')").get<int>(), 0);
+    EXPECT_TRUE(m_lua.lua().script("return IRSim.cycleBoundaryCrossed('phase')").get<bool>());
+}
+
 TEST_F(LuaSimTest, TimerCreateAndPollFromLua) {
     m_lua.lua().script("IRSim.createTimer('reload', 50)");
     EXPECT_TRUE(m_lua.lua().script("return IRSim.timerActive('reload')").get<bool>());

--- a/test/time/sim_clock_test.cpp
+++ b/test/time/sim_clock_test.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>
 
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_system.hpp>
@@ -82,6 +83,13 @@ TEST_F(SimClockTest, FastForwardDoubleRate) {
 
 TEST_F(SimClockTest, NegativeScaleClampsToPaused) {
     IRSim::setTimeScale(-3.0f);
+    EXPECT_TRUE(IRSim::isPaused());
+    advance(50);
+    EXPECT_EQ(IRSim::tick(), 0u);
+}
+
+TEST_F(SimClockTest, NaNScaleClampsToPaused) {
+    IRSim::setTimeScale(std::numeric_limits<float>::quiet_NaN());
     EXPECT_TRUE(IRSim::isPaused());
     advance(50);
     EXPECT_EQ(IRSim::tick(), 0u);

--- a/test/time/sim_clock_test.cpp
+++ b/test/time/sim_clock_test.cpp
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <irreden/common/components/component_sim_clock.hpp>
+#include <irreden/common/sim_clock.hpp>
+#include <irreden/update/systems/system_sim_clock_advance.hpp>
+
+namespace {
+
+using IRComponents::C_SimClock;
+
+// Exercises the sim clock in isolation: SIM_CLOCK_ADVANCE driving the
+// C_SimClock singleton at various time scales, plus pause/resume and a
+// determinism replay. The clock is the "sim tick" half of the two-clock model
+// (the engine-tick half, IRTime::tick(), is not exercised here — it needs a
+// live TimeManager, which the gtest harness does not boot).
+class SimClockTest : public testing::Test {
+  protected:
+    SimClockTest()
+        : m_entity_manager{}
+        , m_system_manager{} {
+        // Materialize the singleton so SIM_CLOCK_ADVANCE has a row to advance.
+        IRSim::clock();
+        m_system_manager.registerPipeline(
+            IRTime::Events::UPDATE,
+            {IRSystem::createSystem<IRSystem::SIM_CLOCK_ADVANCE>()}
+        );
+    }
+
+    void advance(std::uint64_t engineTicks) {
+        for (std::uint64_t i = 0; i < engineTicks; ++i) {
+            m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        }
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(SimClockTest, MonotonicAdvanceAtScaleOne) {
+    EXPECT_EQ(IRSim::tick(), 0u);
+    advance(1000);
+    EXPECT_EQ(IRSim::tick(), 1000u);
+}
+
+TEST_F(SimClockTest, PauseFreezesThenResumeAndScale) {
+    advance(100);
+    EXPECT_EQ(IRSim::tick(), 100u);
+
+    IRSim::pause();
+    EXPECT_TRUE(IRSim::isPaused());
+    advance(100);
+    EXPECT_EQ(IRSim::tick(), 100u); // frozen while paused
+
+    IRSim::resume();
+    EXPECT_FALSE(IRSim::isPaused());
+    advance(100);
+    EXPECT_EQ(IRSim::tick(), 200u);
+
+    IRSim::setTimeScale(0.5f);
+    advance(100);
+    EXPECT_EQ(IRSim::tick(), 250u); // +50 at half rate
+}
+
+TEST_F(SimClockTest, SlowMoHalfRate) {
+    IRSim::setTimeScale(0.5f);
+    advance(100);
+    EXPECT_EQ(IRSim::tick(), 50u);
+}
+
+TEST_F(SimClockTest, FastForwardDoubleRate) {
+    IRSim::setTimeScale(2.0f);
+    advance(100);
+    EXPECT_EQ(IRSim::tick(), 200u);
+}
+
+TEST_F(SimClockTest, NegativeScaleClampsToPaused) {
+    IRSim::setTimeScale(-3.0f);
+    EXPECT_TRUE(IRSim::isPaused());
+    advance(50);
+    EXPECT_EQ(IRSim::tick(), 0u);
+}
+
+// The scalar-only clock struct survives a raw byte round-trip unchanged — the
+// in-memory stand-in for #199 save/load until that integration lands.
+TEST_F(SimClockTest, ClockStateByteExactRoundTrip) {
+    IRSim::setTimeScale(0.5f);
+    advance(137);
+    const C_SimClock original = IRSim::clock();
+
+    unsigned char buffer[sizeof(C_SimClock)];
+    std::memcpy(buffer, &original, sizeof(C_SimClock));
+    C_SimClock restored{};
+    std::memcpy(&restored, buffer, sizeof(C_SimClock));
+
+    EXPECT_EQ(std::memcmp(&original, &restored, sizeof(C_SimClock)), 0);
+    EXPECT_EQ(restored.tickCount_, original.tickCount_);
+    EXPECT_FLOAT_EQ(restored.timeScale_, original.timeScale_);
+    EXPECT_FLOAT_EQ(restored.subTickAccum_, original.subTickAccum_);
+}
+
+// Restoring a snapshot and replaying the same span reproduces the same state —
+// advancement is a pure function of (snapshot, ticks), including the
+// fractional-scale sub-tick remainder.
+TEST_F(SimClockTest, ReplayFromSnapshotIsDeterministic) {
+    IRSim::setTimeScale(0.5f);
+    advance(137);
+    const C_SimClock snapshot = IRSim::clock();
+
+    advance(213);
+    const C_SimClock runA = IRSim::clock();
+
+    IRSim::clock() = snapshot; // restore in place
+    advance(213);
+    const C_SimClock runB = IRSim::clock();
+
+    EXPECT_EQ(runA.tickCount_, runB.tickCount_);
+    EXPECT_FLOAT_EQ(runA.timeScale_, runB.timeScale_);
+    EXPECT_FLOAT_EQ(runA.subTickAccum_, runB.subTickAccum_);
+}
+
+} // namespace

--- a/test/time/stopwatch_test.cpp
+++ b/test/time/stopwatch_test.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <irreden/common/components/component_stopwatch.hpp>
+#include <irreden/common/sim_clock.hpp>
+#include <irreden/update/systems/system_sim_clock_advance.hpp>
+
+namespace {
+
+// Stopwatch elapsed is computed-on-read from the live sim tick, so the only
+// system needed is SIM_CLOCK_ADVANCE — there is no per-frame stopwatch system
+// (by design; see component_stopwatch.hpp).
+class StopwatchTest : public testing::Test {
+  protected:
+    StopwatchTest()
+        : m_entity_manager{}
+        , m_system_manager{} {
+        IRSim::clock();
+        m_system_manager.registerPipeline(
+            IRTime::Events::UPDATE,
+            {IRSystem::createSystem<IRSystem::SIM_CLOCK_ADVANCE>()}
+        );
+    }
+
+    void advance(std::uint64_t ticks) {
+        for (std::uint64_t i = 0; i < ticks; ++i) {
+            m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        }
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(StopwatchTest, ElapsedAdvancesPausesResumesResets) {
+    IRSim::createStopwatch("run");
+    EXPECT_EQ(IRSim::stopwatchElapsed("run"), 0u);
+
+    advance(100);
+    EXPECT_EQ(IRSim::stopwatchElapsed("run"), 100u);
+    EXPECT_TRUE(IRSim::stopwatchRunning("run"));
+
+    IRSim::stopwatchPause("run");
+    EXPECT_FALSE(IRSim::stopwatchRunning("run"));
+    advance(50);
+    EXPECT_EQ(IRSim::stopwatchElapsed("run"), 100u); // frozen while paused
+
+    IRSim::stopwatchResume("run");
+    advance(30);
+    EXPECT_EQ(IRSim::stopwatchElapsed("run"), 130u);
+
+    IRSim::stopwatchReset("run");
+    EXPECT_EQ(IRSim::stopwatchElapsed("run"), 0u);
+    advance(10);
+    EXPECT_EQ(IRSim::stopwatchElapsed("run"), 10u);
+}
+
+TEST_F(StopwatchTest, CreatedAfterSimStartCountsFromCreation) {
+    advance(500); // sim tick 500
+    IRSim::createStopwatch("late"); // startTick_ snapshot == 500
+    EXPECT_EQ(IRSim::stopwatchElapsed("late"), 0u);
+    advance(40);
+    EXPECT_EQ(IRSim::stopwatchElapsed("late"), 40u);
+}
+
+} // namespace

--- a/test/time/timer_test.cpp
+++ b/test/time/timer_test.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <irreden/common/components/component_timer.hpp>
+#include <irreden/common/sim_clock.hpp>
+#include <irreden/update/systems/system_sim_clock_advance.hpp>
+#include <irreden/update/systems/system_timer_fire.hpp>
+
+namespace {
+
+using IRComponents::C_Timer;
+
+class TimerTest : public testing::Test {
+  protected:
+    TimerTest()
+        : m_entity_manager{}
+        , m_system_manager{} {
+        IRSim::clock();
+        m_system_manager.registerPipeline(
+            IRTime::Events::UPDATE,
+            {IRSystem::createSystem<IRSystem::SIM_CLOCK_ADVANCE>(),
+             IRSystem::createSystem<IRSystem::TIMER_FIRE>()}
+        );
+    }
+
+    int advanceCountingFires(IREntity::EntityId id, std::uint64_t ticks) {
+        int fires = 0;
+        for (std::uint64_t i = 0; i < ticks; ++i) {
+            m_system_manager.executePipeline(IRTime::Events::UPDATE);
+            if (IREntity::getComponent<C_Timer>(id).fired_) {
+                ++fires;
+            }
+        }
+        return fires;
+    }
+
+    void advance(std::uint64_t ticks) {
+        for (std::uint64_t i = 0; i < ticks; ++i) {
+            m_system_manager.executePipeline(IRTime::Events::UPDATE);
+        }
+    }
+
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(TimerTest, OneShotFiresExactlyOnce) {
+    auto id = IRSim::createTimer("reload", 50);
+    EXPECT_EQ(advanceCountingFires(id, 50), 1);
+    EXPECT_FALSE(IREntity::getComponent<C_Timer>(id).active_);
+    EXPECT_EQ(advanceCountingFires(id, 50), 0); // stays expired
+}
+
+TEST_F(TimerTest, RecurringFiresEachInterval) {
+    auto id = IRSim::createTimer("metronome", 20, 20);
+    EXPECT_EQ(advanceCountingFires(id, 100), 5); // 20, 40, 60, 80, 100
+    EXPECT_TRUE(IREntity::getComponent<C_Timer>(id).active_);
+}
+
+TEST_F(TimerTest, TicksRemainingCountsDown) {
+    IRSim::createTimer("reload", 50);
+    EXPECT_EQ(IRSim::timerTicksRemaining("reload"), 50u);
+    advance(30);
+    EXPECT_EQ(IRSim::timerTicksRemaining("reload"), 20u);
+    advance(20); // fires at tick 50
+    EXPECT_EQ(IRSim::timerTicksRemaining("reload"), 0u);
+    EXPECT_FALSE(IRSim::timerActive("reload"));
+}
+
+TEST_F(TimerTest, FractionProgressesLinearly) {
+    IRSim::createTimer("reload", 100);
+    advance(50);
+    EXPECT_NEAR(IRSim::timerFraction("reload"), 0.5f, 0.01f);
+    advance(50); // reaches target, fires
+    EXPECT_NEAR(IRSim::timerFraction("reload"), 1.0f, 0.01f);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Engine sim-clock substrate + generic cycle/timer framework, per the
architect plan (`~/.fleet/plans/issue-200.md`, **Task B**). Task A (the ECS
singleton infra) already landed as #646.

**Two-clock model.** `IRTime::tick()` exposes the always-advancing engine
UPDATE counter (`EventProfiler<UPDATE>::m_fixedStepCount`); the new
pausable/scalable **sim clock** drives gameplay timing and freezes on pause.

- `C_SimClock` (singleton) — `SIM_CLOCK_ADVANCE` advances `tickCount_` at
  `timeScale_` (no-float fast path at 1.0; fractional sub-tick accumulator
  otherwise, so 0.5/2.0 are deterministic).
- `C_Cycle` + `CYCLE_BOUNDARY_DETECT` — generic recurring period; raises an
  **embedded** boundary event (`boundaryCrossed_` + from/to) the crossing
  tick. Mid-sim-created cycles prime silently (no spurious boundary).
- `C_Timer` + `TIMER_FIRE` — one-shot or recurring; embedded `fired_` event,
  overshoot-safe re-arm.
- `C_Stopwatch` — count-up with pause/resume; **computed-on-read** (no
  per-frame system by design).

Events ride on the component (the engine's events-as-components pattern,
cf. `C_ContactEvent`), self-clearing — no separate clear system.

**`IRSim::` service** (header-only) wraps clock control + name-keyed
cycle/timer/stopwatch create/query. It lives in
`engine/prefabs/irreden/common/` (not `engine/time/` as the plan sketched)
because it reads ECS components, and the foundational `engine/time` lib must
not depend on the component layer — the only piece in `engine/time` is the
raw `IRTime::tick()` getter. Bound to Lua as the `IRSim` table.
`cycleFraction("day")` is the continuous primitive for time-driven values
(sun angle, colour temp); day-specific gameplay stays game-side (game #44).

### Plan deviations (worker decisions the plan delegated)
- `IRSim` service in `engine/prefabs` (layering — see above), not `engine/time`.
- Events embedded on components, not a `C_PendingEvents<T>` collector.
- No `STOPWATCH_UPDATE` system — elapsed is a pure function of the sim tick.
- Lua discrete events are **polled** (`cycleBoundaryCrossed`/`timerFired`),
  not registered callbacks (a listener form is a noted follow-up).

## Test plan
- [x] 23 gtests under `test/time/` (clock determinism + snapshot replay,
      cycle boundary/fraction wrap, one-shot+recurring timer fire/fraction,
      stopwatch pause/resume/reset, Lua round-trip) — all pass.
- [x] Full engine suite green (1111/1111).
- [x] Builds clean on `macos-debug`. No render-path changes (no screenshots).

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)