### PR TITLE
lua: CODEGEN DSL — whitelisted side-effecting engine bindings (#1616)

### DIFF
--- a/cmake/lua_codegen/main.cpp
+++ b/cmake/lua_codegen/main.cpp
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -676,6 +677,46 @@ void writeOutput(
         os << "//   " << s.sourceFile_ << " (system " << s.name_ << ")\n";
     }
     os << "#pragma once\n\n";
+
+    // #1616: pre-emit the CODEGEN system bodies into a buffer first, so we can
+    // collect the set of engine-binding headers their whitelisted
+    // side-effecting calls (e.g. `IRRender.setSunIntensity`) require and emit
+    // those #includes alongside the static core set below. The buffer is
+    // flushed into the IRScript::CodegenRegistry namespace further down, in its
+    // original position — only the parse/emit timing moves, not the output
+    // order.
+    std::string systemsBuf;
+    std::set<std::string> extraIncludes;
+    const bool hasCodegenSystems = std::any_of(
+        cap.systems_.begin(), cap.systems_.end(),
+        [](const IRLuaCodegen::SystemRecord &r) {
+            return r.mode_ == IRLuaCodegen::SystemMode::CODEGEN;
+        }
+    );
+    if (hasCodegenSystems) {
+        const auto componentRegistry = toComponentSchemas(cap.components_);
+        for (auto &rec : cap.systems_) {
+            if (rec.mode_ != IRLuaCodegen::SystemMode::CODEGEN) {
+                continue;
+            }
+            int bodyStartLine = 0;
+            try {
+                rec.bodySource_ = IRLuaCodegen::sliceFunctionBody(
+                    rec.sourceFile_, rec.linedefined_, rec.lastlinedefined_, bodyStartLine
+                );
+                rec.bodyStartLine_ = bodyStartLine;
+                IRLuaCodegen::ParsedBody body = IRLuaCodegen::parseSystemBody(
+                    rec.sourceFile_, rec.bodyStartLine_, rec.bodySource_
+                );
+                IRLuaCodegen::emitSystem(systemsBuf, rec, body, componentRegistry, extraIncludes);
+            } catch (const IRLuaCodegen::ParseError &err) {
+                std::cerr << "lua_codegen: error in system '" << rec.name_ << "' at "
+                          << err.file_ << ":" << err.line_ << ": " << err.message_ << "\n";
+                std::exit(1);
+            }
+        }
+    }
+
     os << "#include <cstdint>\n";
     os << "#include <string>\n";
     os << "#include <vector>\n\n";
@@ -684,7 +725,14 @@ void writeOutput(
     os << "#include <irreden/ir_system.hpp>\n";
     os << "#include <irreden/script/lua_binding_traits.hpp>\n";
     os << "#include <irreden/script/lua_script.hpp>\n";
-    os << "#include <irreden/system/ir_system_types.hpp>\n\n";
+    os << "#include <irreden/system/ir_system_types.hpp>\n";
+    // #1616: engine-binding headers required by whitelisted side-effecting
+    // intrinsics used in this run's CODEGEN tick bodies (std::set → sorted,
+    // deduped). Empty unless a body calls an IRRender.* (or future) binding.
+    for (const auto &inc : extraIncludes) {
+        os << "#include <" << inc << ">\n";
+    }
+    os << "\n";
 
     os << "namespace IRComponents {\n\n";
     for (const auto &c : cap.components_) {
@@ -769,42 +817,18 @@ void writeOutput(
     // `inline IRSystem::SystemId createSystem_<NAME>()` that wraps a
     // typed `IRSystem::createSystem<...>` invocation with the translated
     // tick body. Component validation, intrinsic-whitelist enforcement, and
-    // strict DSL-violation errors all happen here — any reject surfaces as a
-    // codegen-time error pointing at file:line:feature.
+    // strict DSL-violation errors all happen in that emit pass — any reject
+    // surfaces as a codegen-time error pointing at file:line:feature.
     //
     // Systems with `mode = "eval"` are deliberately skipped here. Their
     // names are captured in `kEvalSystemNames` below as a prepared hook for
     // a future runtime verification loop — not yet consumed.
-    const bool hasCodegenSystems = std::any_of(
-        cap.systems_.begin(), cap.systems_.end(),
-        [](const IRLuaCodegen::SystemRecord &r) {
-            return r.mode_ == IRLuaCodegen::SystemMode::CODEGEN;
-        }
-    );
+    //
+    // #1616: the parse/emit pass ran earlier (so its required #includes could
+    // be hoisted into the include block above); `systemsBuf` already holds the
+    // emitted create-functions. Flush it here in its original output position.
     if (hasCodegenSystems) {
-        const auto componentRegistry = toComponentSchemas(cap.components_);
         os << "namespace IRScript::CodegenRegistry {\n\n";
-        std::string systemsBuf;
-        for (auto &rec : cap.systems_) {
-            if (rec.mode_ != IRLuaCodegen::SystemMode::CODEGEN) {
-                continue;
-            }
-            int bodyStartLine = 0;
-            try {
-                rec.bodySource_ = IRLuaCodegen::sliceFunctionBody(
-                    rec.sourceFile_, rec.linedefined_, rec.lastlinedefined_, bodyStartLine
-                );
-                rec.bodyStartLine_ = bodyStartLine;
-                IRLuaCodegen::ParsedBody body = IRLuaCodegen::parseSystemBody(
-                    rec.sourceFile_, rec.bodyStartLine_, rec.bodySource_
-                );
-                IRLuaCodegen::emitSystem(systemsBuf, rec, body, componentRegistry);
-            } catch (const IRLuaCodegen::ParseError &err) {
-                std::cerr << "lua_codegen: error in system '" << rec.name_ << "' at "
-                          << err.file_ << ":" << err.line_ << ": " << err.message_ << "\n";
-                std::exit(1);
-            }
-        }
         os << systemsBuf;
         os << "} // namespace IRScript::CodegenRegistry\n\n";
     }

--- a/cmake/lua_codegen/system_dsl.cpp
+++ b/cmake/lua_codegen/system_dsl.cpp
@@ -1108,7 +1108,7 @@ struct Emitter {
 
     // #1616: engine-binding headers required by whitelisted side-effecting
     // intrinsics emitted in this body (e.g. ir_render.hpp for IRRender.*).
-    // Drained by emitSystem into the generated header's #include block.
+    // Merged into outRequiredIncludes by emitSystem.
     std::set<std::string> requiredIncludes_;
 
     Emitter(const std::string &file, const std::vector<ComponentSchema> &registry)

--- a/cmake/lua_codegen/system_dsl.cpp
+++ b/cmake/lua_codegen/system_dsl.cpp
@@ -6,6 +6,7 @@
 
 #include <cctype>
 #include <fstream>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -35,6 +36,21 @@ const std::vector<Intrinsic> kIntrinsicRegistry = {
     {"math", "max",   "IRMath::max",   2},
     // --- IRMath.* ---
     {"IRMath", "clamp", "IRMath::clamp", 3},
+    // --- IRRender.* render-glue setters (#1616) ----------------------------
+    //
+    // Whitelisted side-effecting (void) engine bindings: allowed as a bare
+    // statement in a CODEGEN tick body (`IRRender.setSunIntensity(x)`), lowered
+    // to the C++ free function. These are pure pass-throughs to RenderManager —
+    // no new engine surface — so a system that *computes* a render parameter
+    // under CODEGEN can also *apply* it without falling back to EVAL / a C++
+    // bridge. Scalar args only (the DSL lowers each arg as a numeric
+    // expression). `true` marks statement-position-only; the trailing header
+    // is emitted as an #include in the generated header so the call compiles.
+    {"IRRender", "setSunIntensity", "IRRender::setSunIntensity", 1, true, "irreden/ir_render.hpp"},
+    {"IRRender", "setSunAmbient",   "IRRender::setSunAmbient",   1, true, "irreden/ir_render.hpp"},
+    {"IRRender", "setExposure",     "IRRender::setExposure",     1, true, "irreden/ir_render.hpp"},
+    {"IRRender", "setSkyIntensity", "IRRender::setSkyIntensity", 1, true, "irreden/ir_render.hpp"},
+    {"IRRender", "setCameraZoom",   "IRRender::setCameraZoom",   1, true, "irreden/ir_render.hpp"},
 };
 
 [[noreturn]] void fail(const std::string &file, int line, const std::string &msg) {
@@ -537,11 +553,16 @@ struct Parser {
             return stmt;
         }
 
-        // Anything else: parse the expression and reject it. Either:
-        //   - `var.field = ...` (unsupported assignment target — point at the actual
-        //     supported targets), or
-        //   - a bare expression statement like `pos.x` or `math.sin(0)` (no side
-        //     effect; almost certainly a typo).
+        // Anything else: parse the expression. It's accepted only as a bare
+        // call to a whitelisted side-effecting binding (#1616); otherwise
+        // reject it. Either:
+        //   - `var.field = ...` (unsupported assignment target — point at the
+        //     actual supported targets), or
+        //   - a bare INTRINSIC_CALL like `IRRender.setSunIntensity(x)` → an
+        //     expression statement (emission validates it's a statement-allowed
+        //     void binding; a value-returning one like `math.sin(0)` is rejected
+        //     there), or
+        //   - any other bare expression like `pos.x` (no side effect; a typo).
         ExprPtr e = parseExpr();
         if (check(TokenKind::ASSIGN)) {
             fail(file_, line,
@@ -549,9 +570,17 @@ struct Parser {
                  "bare locals (`x = expr`), column rows (`arch.Comp:setAt(i, val)`), "
                  "and column fields (`arch.Comp:setField(i, \"f\", val)`)");
         }
+        if (e->kind_ == ExprKind::INTRINSIC_CALL) {
+            auto stmt = std::make_unique<Stmt>();
+            stmt->kind_ = StmtKind::EXPR_STMT;
+            stmt->line_ = line;
+            stmt->exprStmt_ = std::move(e);
+            return stmt;
+        }
         fail(file_, line,
              "bare expression statements are not supported in CODEGEN bodies; valid "
-             "statements are `local`, assignment, `if`, `for`, and column-write calls");
+             "statements are `local`, assignment, `if`, `for`, column-write calls, and "
+             "whitelisted side-effecting engine bindings (e.g. `IRRender.setSunIntensity(x)`)");
     }
 
     // Precedence climbing for binary expressions. Lower number = lower precedence.
@@ -1077,10 +1106,46 @@ struct Emitter {
     // error — per-row form has no column vector to scatter-index into.
     std::string loopVarName_;
 
+    // #1616: engine-binding headers required by whitelisted side-effecting
+    // intrinsics emitted in this body (e.g. ir_render.hpp for IRRender.*).
+    // Drained by emitSystem into the generated header's #include block.
+    std::set<std::string> requiredIncludes_;
+
     Emitter(const std::string &file, const std::vector<ComponentSchema> &registry)
         : file_(file), registry_(registry) {}
 
     void writeIndent() { for (int i = 0; i < indent_; ++i) out_ << "    "; }
+
+    // #1616: resolve an INTRINSIC_CALL against the whitelist + arity. Fails
+    // (codegen error) on an unknown name or arity mismatch. Shared by
+    // expression-position (emitExpr) and statement-position (EXPR_STMT)
+    // lowering so the two paths agree on the diagnostic.
+    const Intrinsic &resolveIntrinsic(const Expr &e) const {
+        const Intrinsic *intr = findIntrinsic(e.intrinsicNamespace_, e.intrinsicName_);
+        if (!intr) {
+            fail(file_, e.line_,
+                 "intrinsic `" + e.intrinsicNamespace_ + "." + e.intrinsicName_ +
+                     "` is not in the CODEGEN whitelist (see cmake/lua_codegen/system_dsl.cpp)");
+        }
+        if (intr->arity_ >= 0 && static_cast<int>(e.args_.size()) != intr->arity_) {
+            fail(file_, e.line_,
+                 "intrinsic `" + e.intrinsicNamespace_ + "." + e.intrinsicName_ +
+                     "` expects " + std::to_string(intr->arity_) + " argument(s), got " +
+                     std::to_string(e.args_.size()));
+        }
+        return *intr;
+    }
+
+    // #1616: emit `cppExpression_(arg0, arg1, ...)` with no trailing
+    // punctuation. Shared by both intrinsic-call positions.
+    void emitIntrinsicCall(const Expr &e, const Intrinsic &intr) {
+        out_ << intr.cppExpression_ << "(";
+        for (size_t i = 0; i < e.args_.size(); ++i) {
+            if (i) out_ << ", ";
+            emitExpr(*e.args_[i]);
+        }
+        out_ << ")";
+    }
 
     // True when this expression is exactly the per-row loop variable
     // reference (used to validate column-op index args in per-row mode).
@@ -1284,30 +1349,18 @@ struct Emitter {
                 return fieldTypeToExprType(field->type_);
             }
             case ExprKind::INTRINSIC_CALL: {
-                const auto *intr = findIntrinsic(e.intrinsicNamespace_, e.intrinsicName_);
-                if (!intr) {
+                const Intrinsic &intr = resolveIntrinsic(e);
+                if (intr.isStatement_) {
+                    // #1616: a void side-effecting binding has no value to use.
                     fail(file_, e.line_,
-                         "intrinsic `" + e.intrinsicNamespace_ + "." + e.intrinsicName_ +
-                             "` is not in the CODEGEN whitelist (see cmake/lua_codegen/system_dsl.cpp)");
+                         "binding `" + e.intrinsicNamespace_ + "." + e.intrinsicName_ +
+                             "` returns void (side-effecting render-glue) and may only be used "
+                             "as a bare statement, not inside an expression");
                 }
-                if (intr->arity_ >= 0 && static_cast<int>(e.args_.size()) != intr->arity_) {
-                    fail(file_, e.line_,
-                         "intrinsic `" + e.intrinsicNamespace_ + "." + e.intrinsicName_ +
-                             "` expects " + std::to_string(intr->arity_) + " argument(s), got " +
-                             std::to_string(e.args_.size()));
-                }
-                out_ << intr->cppExpression_ << "(";
-                for (size_t i = 0; i < e.args_.size(); ++i) {
-                    if (i) out_ << ", ";
-                    emitExpr(*e.args_[i]);
-                }
-                out_ << ")";
-                // For now treat intrinsic results as float (the listed set returns
-                // float/int but we generally need to multiply with other floats).
-                if (e.intrinsicName_ == "min" || e.intrinsicName_ == "max" ||
-                    e.intrinsicName_ == "abs" || e.intrinsicName_ == "clamp") {
-                    return ExprType::FLOAT;     // generic — the actual arity respects template deduction
-                }
+                emitIntrinsicCall(e, intr);
+                // Treat value-returning intrinsic results as float (the listed
+                // set returns float/int; C++ template deduction handles the
+                // rest where we feed the result into further float math).
                 return ExprType::FLOAT;
             }
             case ExprKind::COLUMN_AT: {
@@ -1588,8 +1641,25 @@ struct Emitter {
                 return;
             }
             case StmtKind::EXPR_STMT: {
+                // #1616: the parser only builds EXPR_STMT for a bare
+                // INTRINSIC_CALL. Statement position is reserved for
+                // whitelisted side-effecting (void) bindings — a bare
+                // value-returning intrinsic is almost always a dropped
+                // assignment, so reject it with a pointed message.
+                const Expr &e = *s.exprStmt_;
+                const Intrinsic &intr = resolveIntrinsic(e);
+                if (!intr.isStatement_) {
+                    fail(file_, e.line_,
+                         "intrinsic `" + e.intrinsicNamespace_ + "." + e.intrinsicName_ +
+                             "` returns a value; a bare call statement is only valid for a "
+                             "whitelisted side-effecting binding (assign the result to a "
+                             "`local` or a column field instead)");
+                }
+                if (intr.requiredInclude_) {
+                    requiredIncludes_.insert(intr.requiredInclude_);
+                }
                 writeIndent();
-                emitExpr(*s.exprStmt_);
+                emitIntrinsicCall(e, intr);
                 out_ << ";\n";
                 return;
             }
@@ -1673,7 +1743,8 @@ void emitSystem(
     std::string &out,
     const SystemRecord &record,
     const ParsedBody &body,
-    const std::vector<ComponentSchema> &componentRegistry
+    const std::vector<ComponentSchema> &componentRegistry,
+    std::set<std::string> &outRequiredIncludes
 ) {
     // Validate components.
     for (const auto &compName : record.components_) {
@@ -1769,6 +1840,11 @@ void emitSystem(
     // copying it, before emitting the body.
     collectRefSafeColumnAtDecls(perRowLoop->forBody_, emitter.refSafeColumnAtDecls_);
     for (const auto &s : perRowLoop->forBody_) emitter.emitStmt(*s);
+
+    // #1616: surface the engine-binding headers this body's whitelisted
+    // side-effecting calls need, so main.cpp can #include them.
+    outRequiredIncludes.insert(emitter.requiredIncludes_.begin(),
+                               emitter.requiredIncludes_.end());
 
     out += emitter.str();
     out += "        }\n";

--- a/cmake/lua_codegen/system_dsl.hpp
+++ b/cmake/lua_codegen/system_dsl.hpp
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -288,11 +289,17 @@ ParsedBody parseSystemBody(
 // `componentRegistry` is the set of components captured during the same
 // codegen run (Lua-defined via `IRComponent.register`). The systems emitter
 // rejects any column-op against a name not in this registry.
+//
+// `outRequiredIncludes` is appended (not cleared) with the engine headers any
+// whitelisted side-effecting binding in this body needs (#1616) — main.cpp
+// unions these across all systems and emits them in the generated header's
+// #include block.
 void emitSystem(
     std::string &out,
     const SystemRecord &record,
     const ParsedBody &body,
-    const std::vector<ComponentSchema> &componentRegistry
+    const std::vector<ComponentSchema> &componentRegistry,
+    std::set<std::string> &outRequiredIncludes
 );
 
 // Slice the body source from a file given the `(arch)` parameter list end
@@ -312,10 +319,24 @@ std::string sliceFunctionBody(
 // Whitelisted intrinsic registry. Each entry maps a Lua call (namespace.name)
 // to a C++ emission template (e.g. `IRMath::sin`) and an arity.
 struct Intrinsic {
-    const char *luaNamespace_;     // "math", "IRMath"
-    const char *luaName_;           // "sin", "lerp"
-    const char *cppExpression_;     // "IRMath::sin"  (called as cppExpression_(arg0, arg1, ...))
+    const char *luaNamespace_;     // "math", "IRMath", "IRRender"
+    const char *luaName_;           // "sin", "lerp", "setSunIntensity"
+    const char *cppExpression_;     // "IRMath::sin" (called as cppExpression_(arg0, arg1, ...))
     int arity_;                     // -1 for variadic; v1 uses fixed arities only
+
+    // #1616: side-effecting (void-returning) engine bindings — the IRRender.*
+    // render-glue setters. Allowed ONLY in statement position (a bare call,
+    // e.g. `IRRender.setSunIntensity(x)`) and rejected inside an expression.
+    // The value-returning math.* / IRMath.* intrinsics keep isStatement_ ==
+    // false: usable inside expressions, rejected as a bare statement (a bare
+    // value-returning call is almost always a dropped assignment).
+    bool isStatement_ = false;
+
+    // #1616: engine header that declares cppExpression_, so the generated
+    // header can #include it when a body uses this binding. The emitter
+    // collects the union of these across a codegen run. nullptr → declared by
+    // an always-included core header (ir_math.hpp etc.).
+    const char *requiredInclude_ = nullptr;
 };
 
 const std::vector<Intrinsic> &intrinsicRegistry();

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -356,7 +356,23 @@ so creations / tests can register every codegen'd system in one call.
   `cmake/lua_codegen/system_dsl.cpp`'s `kIntrinsicRegistry`. Adding an
   entry is one line: Lua name, C++ expression head, arity. `math.*`
   routes to `IRMath::*` (the engine's math wrapper layer — the
-  CODEGEN-emitted code never calls `std::sin` etc. directly).
+  CODEGEN-emitted code never calls `std::sin` etc. directly). These are
+  value-returning — use them inside an expression (a `local`, a column
+  setter, a branch cond); a bare call statement is rejected.
+- Whitelisted **side-effecting engine bindings** (#1616) — a curated set
+  of void pass-through engine setters callable as a **bare statement**
+  (not inside an expression), e.g. `IRRender.setSunIntensity(x)` lowers
+  to `IRRender::setSunIntensity(...)`. The current set is the
+  `IRRender.*` render-glue setters (`setSunIntensity`, `setSunAmbient`,
+  `setExposure`, `setSkyIntensity`, `setCameraZoom`), marked
+  `isStatement_ = true` in `kIntrinsicRegistry`. This lets a system that
+  *computes* a render parameter under CODEGEN also *apply* it inline,
+  instead of stranding the application layer in EVAL or a C++ bridge.
+  Each statement-binding entry carries the engine header that declares
+  its C++ function (`requiredInclude_`); the codegen tool emits that
+  `#include` in the generated header only when a body actually uses the
+  binding. Adding a setter is one registry line + (if a new namespace)
+  its header. Scalar args only — each arg lowers as a numeric expression.
 
 **Forbidden in CODEGEN bodies (build-time error pointing at file:line):**
 
@@ -366,8 +382,16 @@ so creations / tests can register every codegen'd system in one call.
   to Lua.
 - Closures capturing external upvalues, metatables, dynamic dispatch
   (`arch.foo[name](...)`), `require`, table constructors beyond
-  `Comp.new`, varargs, `nil`, `_` length operator, side-effecting
-  bare expression statements.
+  `Comp.new`, varargs, `nil`, `_` length operator. A bare call
+  statement is rejected **unless** it targets a whitelisted
+  side-effecting binding (above); a bare value-returning intrinsic
+  (`math.sin(x)` as a statement) is still an error — it's a dropped
+  assignment.
+- **String formatting is not yet supported** — `string.format` / `..`
+  concatenation in a CODEGEN tick body is rejected. The string-building
+  half of #1616 is deferred; keep label/HUD systems that format strings
+  in EVAL (`mode = "eval"`) for now. (Sibling gap: the IREnum-in-tick
+  literal-folding limitation above.)
 
 **`excludes = { 'Tag' }`** at registration time materialises as
 `IRSystem::Exclude<C_Tag>` in the generated `IRSystem::createSystem<...>`

--- a/test/script/lua_system_codegen_fixtures.lua
+++ b/test/script/lua_system_codegen_fixtures.lua
@@ -177,3 +177,22 @@ IRSystem.registerSystem({
         end
     end,
 })
+
+-- #1616: whitelisted side-effecting engine binding in a CODEGEN tick body.
+-- `IRRender.setSunIntensity(x)` is a void render-glue setter — allowed as a
+-- bare statement (NOT inside an expression) and lowered to the C++ free
+-- function `IRRender::setSunIntensity(...)`. The generated header compiling +
+-- linking against the real symbol is the proof the bare-call lowering is valid
+-- C++; the sibling test registers the system but does not execute its tick
+-- against a matching entity (the render setter asserts on an absent
+-- RenderManager in the headless test harness, engine/render/src/ir_render.cpp).
+IRSystem.registerSystem({
+    name = 'CodegenRenderGlue',
+    components = { 'CodegenSysPos' },
+    tick = function(arch)
+        for i = 0, arch.length - 1 do
+            local pos = arch.CodegenSysPos:at(i)
+            IRRender.setSunIntensity(pos.x)
+        end
+    end,
+})

--- a/test/script/lua_system_codegen_test.cpp
+++ b/test/script/lua_system_codegen_test.cpp
@@ -198,6 +198,7 @@ TEST_F(LuaSystemCodegenTest, RegistryReturnsAllCodegenSystemIds) {
     EXPECT_NE(ids.CodegenDamage, ids.CodegenParallelInc);
     EXPECT_NE(ids.CodegenParallelInc, ids.CodegenReadAfterWrite);
     EXPECT_NE(ids.CodegenReadAfterWrite, ids.CodegenForNumericBackEdge);
+    EXPECT_NE(ids.CodegenForNumericBackEdge, ids.CodegenRenderGlue);
 }
 
 // ---- PARALLEL_FOR registers without FATAL and updates every row --------
@@ -269,6 +270,26 @@ TEST_F(LuaSystemCodegenTest, ForNumericBackEdgeKeepsCopySemantics) {
     // Copy semantics: each of the 3 iterations reads the original a.x (1.0)
     // and writes 1.0 + 1.0 = 2.0. An alias would accumulate to 4.0.
     EXPECT_FLOAT_EQ(IREntity::getComponent<C_CodegenSysPos>(e).x_, 2.0f);
+}
+
+// ---- #1616: whitelisted side-effecting engine binding as a bare statement --
+//
+// `CodegenRenderGlue`'s tick body calls `IRRender.setSunIntensity(pos.x)` as a
+// bare statement — a void render-glue setter that the DSL now lowers to
+// `IRRender::setSunIntensity(...)`. The strongest assertion is structural and
+// already paid: for this test to COMPILE and LINK, the generated
+// `createSystem_CodegenRenderGlue()` must contain valid C++ that resolves the
+// real `IRRender::setSunIntensity` symbol (the generated header `#include`s
+// `<irreden/ir_render.hpp>`). Here we confirm the system registers cleanly.
+//
+// We deliberately do NOT execute the tick against a matching entity: the
+// render-glue setter calls `getRenderManager()`, which IR_ASSERTs on the
+// absent RenderManager in this headless harness (engine/render/src/ir_render.cpp).
+// The lowering + link is the regression surface this test pins.
+TEST_F(LuaSystemCodegenTest, RenderGlueSideEffectLowersAndRegisters) {
+    const IRSystem::SystemId sys = IRScript::CodegenRegistry::createSystem_CodegenRenderGlue();
+    EXPECT_LT(sys, m_system_manager.getSystemCount());
+    EXPECT_STREQ(m_system_manager.getSystemName(sys).c_str(), "CodegenRenderGlue");
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Extends the build-time Lua→C++ CODEGEN system DSL (`cmake/lua_codegen/`) so a `tick` body can call a **whitelisted side-effecting engine binding** as a bare statement, lowered to the C++ free function. Previously every bare-call statement was rejected, which stranded the *application* layer of an otherwise-pure CODEGEN system in EVAL or a hand-written C++ bridge.

- New `Intrinsic::isStatement_` flag marks void, side-effecting pass-through bindings (statement-position only). The seed set is the `IRRender.*` render-glue setters: `setSunIntensity`, `setSunAmbient`, `setExposure`, `setSkyIntensity`, `setCameraZoom`.
- Parser turns a bare `INTRINSIC_CALL` into an `EXPR_STMT`; emission validates statement-vs-expression position: a value-returning intrinsic (`math.sin`) as a bare statement is still rejected (dropped-assignment guard), and a void binding inside an expression is rejected.
- New `Intrinsic::requiredInclude_` carries the engine header that declares each binding's C++ function. The codegen tool collects the union across the run and emits those `#include`s in the generated header **only when a body uses the binding** (the system-emit pass moved ahead of the include block to collect them; emitted output order is otherwise unchanged — byte-identical for runs with no side-effecting calls).
- Adds the value-returning vs statement-position contract + the deferred string-formatting note to `engine/script/CLAUDE.md`.
- Shared `resolveIntrinsic` / `emitIntrinsicCall` Emitter helpers consolidate the lookup + arity + lowering that both positions use.

Scope note: this is feature 1 of #1616. Feature 2 (basic `string.format` / `..` lowering) is explicitly optional in the issue and materially larger (string-type tracking, `..` lexing, a text binding to consume the result); it is deferred and documented as EVAL-only for now.

## Test plan
- [x] `ir_lua_codegen` host tool builds clean.
- [x] `IrredenEngineTest` builds + links — the test referencing `createSystem_CodegenRenderGlue` is itself proof the bare-call lowered to valid C++ that resolves `IRRender::setSunIntensity` at link time.
- [x] New fixture `CodegenRenderGlue` + test `RenderGlueSideEffectLowersAndRegisters` (registers + asserts; does not execute the tick — the render setter asserts on an absent `RenderManager` headlessly).
- [x] All 88 `*Codegen*` / `*Coexistence*` / `Lua*` tests pass (no regression from the `main.cpp` emit-order refactor).
- [x] Generated header verified: conditional `#include <irreden/ir_render.hpp>`, `IRRender::setSunIntensity(pos.x_);` bare statement, `pos` still `const auto&` (#1353 alias optimization composes with the new statement path).
- [ ] linux-debug / windows-debug cross-host build (codegen tool is platform-agnostic; flagging for smoke).

Closes #1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)