### PR TITLE
fleet: scope-shipped must not trust range-endpoint refs in PR titles

### DIFF
--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -1,7 +1,7 @@
 """Genuine-ship predicate for fleet-queue-ingest's scope-shipped pre-flight.
 
 A merged PR is only evidence that an issue's scope "already landed" when the PR
-genuinely *ships* the issue — not when it merely names it. Two layers of
+genuinely *ships* the issue — not when it merely names it. Three layers of
 incidental match have to be rejected:
 
 1. No reference at all (#1304). GitHub's PR search (``gh pr list --search
@@ -16,11 +16,20 @@ incidental match have to be rejected:
    "pre-existing #1269" / "filed as #1269" (#1269 ← #1265), "Refs #N". These
    slipped past the layer-1 fix because the literal ``#N`` token is present.
 
+3. Range endpoint, not implemented (#1602 / #1612 ← #1614). An epic-planning PR
+   names the children it *files* as a range in its title — "docs: re-plan ...
+   — file children #1602-#1612". The title-trust below then matched the two
+   range *endpoints* (#1602 and #1612; the middle children #1603-#1611 were
+   untouched because only the endpoints are literally written with a ``#``). A
+   ``#N`` that is an endpoint of a ``#A-#B`` range is enumerating issues, never
+   shipping one, so range endpoints are rejected in both title and body.
+
 So a body ``#N`` counts only when a closing-action verb sits directly before it
 (``Closes #N``, ``fixes (#N)``, ``supersedes #N``). A ``#N`` in the *title* is
-trusted as-is: PRs in this repo are named ``#N: <desc>`` after the issue they
-implement, and every observed false positive came from the body, never the
-title. The asymmetry is deliberate.
+trusted as-is — PRs in this repo are named ``#N: <desc>`` after the issue they
+implement — EXCEPT when it is a range endpoint (layer 3): a planning PR names
+filed children in its title, and that is the one title shape that mentions
+without implementing. Every other observed false positive came from the body.
 """
 import re
 
@@ -39,19 +48,33 @@ _CLOSING_VERB = (
 _VERB_TO_REF_GAP = r'[\s:]*[(\[]?\s*'
 
 
+# Range dashes (hyphen-minus, en dash, em dash) — the separators an epic-planning
+# PR uses to name a span of filed children in its title: "file children #1602-#1612".
+_RANGE_DASH = r'[-–—]'
+
+
 def _ref_pattern(n):
     # ``(?<!\w)`` rejects ``abc#1300``; ``(?!\d)`` stops ``#13000`` / ``#21300``
-    # from satisfying ``n=1300``. Matches GitHub's own link-detection bounds.
-    return r'(?<!\w)#' + str(int(n)) + r'(?!\d)'
+    # from satisfying ``n=1300``. The two range guards reject a ``#N`` that is an
+    # endpoint of a ``#A-#B`` range (an epic-planning PR enumerating the children
+    # it FILES, not implementing one): the ``(?<!RANGE_DASH)`` lookbehind drops a
+    # range END (``...-#1612``) and the trailing ``(?!\s*RANGE_DASH\s*#?\d)``
+    # lookahead drops a range START (``#1602`` directly before ``-#1612``).
+    # Matches GitHub's own link-detection bounds, minus range endpoints.
+    return (
+        r'(?<!\w)(?<!' + _RANGE_DASH + r')#' + str(int(n))
+        + r'(?!\d)(?!\s*' + _RANGE_DASH + r'\s*#?\d)'
+    )
 
 
 def pr_references_issue(title, body, n):
     """True iff the PR genuinely ships issue ``n`` (see module docstring).
 
     Title: any word-boundary ``#n`` counts (the ``#N: <desc>`` PR-naming
-    convention). Body: ``#n`` counts only when immediately preceded by a
-    closing-action verb. A bare body mention ("downstream #n", "pre-existing
-    #n", "Refs #n") is rejected.
+    convention) UNLESS it is a range endpoint (``#1602-#1612`` — a planning PR
+    naming filed children). Body: ``#n`` counts only when immediately preceded
+    by a closing-action verb, and likewise never as a range endpoint. A bare
+    body mention ("downstream #n", "pre-existing #n", "Refs #n") is rejected.
     """
     if not n:
         return False

--- a/scripts/fleet/tests/test_scope_shipped_reference.py
+++ b/scripts/fleet/tests/test_scope_shipped_reference.py
@@ -114,6 +114,50 @@ class PrReferencesIssue(unittest.TestCase):
                      "closes #1300", "Fixes #1300"):
             self.assertTrue(pr_references_issue("", body, 1300), body)
 
+    # --- range-endpoint refs (#1602 / #1612 <- #1614 epic-planning PR) ---
+
+    _FILE_CHILDREN_TITLE = (
+        "docs: re-plan entity-editor Phase 2 (#605) — file children #1602-#1612")
+
+    def test_title_range_start_endpoint_rejected(self):
+        # #1602 is the range START in "#1602-#1612": filed by #1614, not shipped.
+        self.assertFalse(pr_references_issue(self._FILE_CHILDREN_TITLE, "", 1602))
+
+    def test_title_range_end_endpoint_rejected(self):
+        # #1612 is the range END (the dash sits directly before it).
+        self.assertFalse(pr_references_issue(self._FILE_CHILDREN_TITLE, "", 1612))
+
+    def test_title_range_middle_child_never_matched(self):
+        # #1607 is inside the span but not literally written with a '#'.
+        self.assertFalse(pr_references_issue(self._FILE_CHILDREN_TITLE, "", 1607))
+
+    def test_title_range_hashless_second_endpoint_still_rejects_start(self):
+        # "#1602-1612" (second endpoint has no '#') still rejects the start.
+        self.assertFalse(pr_references_issue("file children #1602-1612", "", 1602))
+
+    def test_title_en_dash_range_rejected(self):
+        self.assertFalse(pr_references_issue("file #1602–#1612", "", 1602))
+
+    def test_title_em_dash_range_rejected(self):
+        self.assertFalse(pr_references_issue("file #1602—#1612", "", 1612))
+
+    def test_title_epic_ref_outside_range_still_trusted(self):
+        # The epic (#605) precedes the range and is not itself a range endpoint.
+        self.assertTrue(pr_references_issue(self._FILE_CHILDREN_TITLE, "", 605))
+
+    def test_plain_title_ref_unaffected_by_range_guard(self):
+        # Regression: the normal "#N: <desc>" convention still counts.
+        self.assertTrue(pr_references_issue("#1602: bind-pose on C_Skeleton", "", 1602))
+
+    def test_em_dash_then_word_is_not_a_range(self):
+        # "(#605) — phase 2": a dash followed by a WORD (no digit) is not a range.
+        self.assertTrue(pr_references_issue("re-plan (#605) — phase 2", "", 605))
+
+    def test_body_range_endpoint_rejected_even_with_verb(self):
+        # Conservative: "Closes #1602-#1612" closes a span, not #1602's individual
+        # scope. Reject — a scope-shipped false negative just leaves it queued.
+        self.assertFalse(pr_references_issue("title", "Closes #1602-#1612", 1602))
+
 
 class SelectShippedPr(unittest.TestCase):
     def test_empty_candidates(self):
@@ -151,6 +195,14 @@ class SelectShippedPr(unittest.TestCase):
                  "Closes #1258. The one failure is the pre-existing #1269.")
         self.assertEqual(select_shipped_pr([pr], 1258)["number"], 1265)
         self.assertIsNone(select_shipped_pr([pr], 1269))
+
+    def test_real_world_1614_files_children_ships_none(self):
+        # #1614 FILES the P2 children as a title range; it ships none of them.
+        pr = _pr(1614,
+                 "docs: re-plan entity-editor Phase 2 (#605) — file children #1602-#1612",
+                 "Files the P2 child tickets #1602-#1612 under epic #605.")
+        for child in (1602, 1607, 1612):
+            self.assertIsNone(select_shipped_pr([pr], child), child)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `fleet-queue-ingest`'s scope-shipped pre-flight trusted any `#N` in a merged PR's **title**. An epic-planning PR names the children it *files* as a range — PR #1614's title `docs: re-plan entity-editor Phase 2 (#605) — file children #1602-#1612` — so the title-match fired on the range **endpoints** #1602 and #1612 and wrongly labelled both `fleet:scope-shipped`, silently skipping their ingest. The middle children #1603–#1611 escaped only because a range writes just its endpoints with a literal `#`.
- Adds a **range-endpoint guard** to `_ref_pattern` — the third rejection layer (alongside no-reference #1304 and mentioned-but-not-shipped #1260/#1269): a `#N` that is the start (`#1602` directly before `-#1612`) or end (`...-#1612`) of a `#A-#B` range is enumerating filed issues, never implementing one. Rejected in both title and body. Handles hyphen / en-dash / em-dash and a hashless second endpoint; a dash followed by a non-digit word is still not a range.
- Already-affected issues #1602 and #1612 were manually re-queued out of band.

## Test plan
- [x] `python3 -m unittest scripts.fleet.tests.test_scope_shipped_reference` — 34/34 pass (24 prior + 10 new)
- [x] New tests assert the live #1614 title ships none of #1602 / #1607 / #1612, and that the normal `#N: <desc>` convention + epic `(#605)` ref are unaffected (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)