### PR TITLE
engine/voxel: bind-pose on C_Skeleton + skin-matrix helper (#1602)

### DIFF
--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -126,6 +126,10 @@ equivalent and produces byte-identical results to the pre-yaw path.
 
 Stored as `vec4(qx, qy, qz, qw)` — `.w` is the scalar (identity: `(0,0,0,1)`). `quatMul(a, b)` applies `b` then `a` — in joint chains: `quatMul(parentWorld, local)`. `rotateVectorByQuat(v, q)` is equivalent to `glm::rotate(quat, vec3)`.
 
+## SQT transforms
+
+`IRMath::SQT` (scale / quat-rotation / translation) is the math-layer value type mirroring the prefab `C_LocalTransform` / `C_WorldTransform` layout (which `engine/math/` can't name). `sqtToMat4(sqt)` builds `T·R·S`; `sqtCompose(parent, child)` reproduces `SYSTEM_PROPAGATE_TRANSFORM`'s composition so a chain folded in math matches the propagated `C_WorldTransform`; `sqtInverse(sqt)` is the analytic inverse (exact for uniform/rigid scale — the bind-pose domain). Used by `IRPrefab::Skeleton::skinMatrix`. **`sqtCompose`/`sqtInverse` are matrix-exact only for uniform scale** — non-uniform scale isn't closed under TRS; reach for `mat4` directly there.
+
 ## Random
 
 `randomBool/Int/Float` and `randomVec<T>/randomColor` route through a

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -922,6 +922,62 @@ inline mat4 sqtToMat4(const vec3 &scaleVec, const vec4 &rotationQuat, const vec3
     return mat4(vec4(col0, 0.0f), vec4(col1, 0.0f), vec4(col2, 0.0f), vec4(translation, 1.0f));
 }
 
+/// Scale–Quaternion–Translation transform value. Mirrors the field layout of
+/// `C_LocalTransform` / `C_WorldTransform`, which live in the prefab layer and
+/// so can't be named from `engine/math/`; this is the math-layer value type
+/// those components and the skeletal-skinning helpers (`IRPrefab::Skeleton`)
+/// share. Quaternion layout is the engine canon `vec4(qx, qy, qz, qw)`,
+/// identity `(0, 0, 0, 1)`.
+struct SQT {
+    vec3 scale_{1.0f, 1.0f, 1.0f};
+    vec4 rotation_{0.0f, 0.0f, 0.0f, 1.0f};
+    vec3 translation_{0.0f, 0.0f, 0.0f};
+};
+
+/// SQT overload of @ref sqtToMat4 — same `T · R · S` ordering.
+inline mat4 sqtToMat4(const SQT &transform) {
+    return sqtToMat4(transform.scale_, transform.rotation_, transform.translation_);
+}
+
+/// Composes `parent ∘ child`, reproducing `SYSTEM_PROPAGATE_TRANSFORM`'s
+/// modifier-free composition so a chain folded here matches the
+/// `C_WorldTransform` the propagation system writes for the same locals:
+///
+///     scale       = parent.scale * child.scale
+///     rotation    = quatMul(parent.rotation, child.rotation)
+///     translation = parent.translation
+///                 + rotateVectorByQuat(parent.scale * child.translation,
+///                                      parent.rotation)
+///
+/// Matrix-exact (`sqtToMat4(compose) == sqtToMat4(parent) * sqtToMat4(child)`)
+/// for uniform scale; non-uniform scale isn't closed under TRS composition
+/// (the exact product needs shear). Joints and bind poses are rigid, so the
+/// rig path is exact.
+inline SQT sqtCompose(const SQT &parent, const SQT &child) {
+    SQT out;
+    out.scale_ = parent.scale_ * child.scale_;
+    out.rotation_ = quatMul(parent.rotation_, child.rotation_);
+    out.translation_ = parent.translation_ +
+                       rotateVectorByQuat(parent.scale_ * child.translation_, parent.rotation_);
+    return out;
+}
+
+/// Analytic inverse: the SQT whose matrix is `inverse(sqtToMat4(t))`. Exact
+/// for rigid / uniform-scale transforms — the skinning path inverts the
+/// constant bind SQT here rather than numerically inverting its 4×4, which
+/// keeps the result clean (the rotation inverse is the conjugate, not a
+/// general matrix solve). Non-uniform scale is not representable as a single
+/// inverse SQT; the rotation reorders relative to the per-axis scale. Pass
+/// uniform (or unit) scale, which every bind pose satisfies.
+inline SQT sqtInverse(const SQT &transform) {
+    SQT inv;
+    inv.scale_ =
+        vec3(1.0f / transform.scale_.x, 1.0f / transform.scale_.y, 1.0f / transform.scale_.z);
+    inv.rotation_ = quatInverse(transform.rotation_);
+    inv.translation_ = inv.scale_ * rotateVectorByQuat(-transform.translation_, inv.rotation_);
+    return inv;
+}
+
 /// Applies an SRT (or any affine) matrix @p transform to an integer voxel
 /// grid cell @p cell, returning the destination integer cell with half-up
 /// rounding. Use when GRID-mode rotation needs to re-rasterize a set of

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -247,11 +247,18 @@ target. File a follow-up ticket when `#605` Phase 2 unblocks.
 ### Bind pose
 
 Skinning math needs the bind-pose inverse to recover skinning matrices.
-`C_Skeleton` does **not** carry a `bindPose_` field yet — `IRMath::SQT` is
-available since `#731` Phase 1 landed (PR #749); a follow-up (#605 Phase 2)
-adds `std::vector<IRMath::SQT> bindPose_;` to `C_Skeleton` parallel to
-`joints_`. Until then, callers that need a bind pose load it from the `.rig`
-asset's BIND chunk via `IRPrefab::Rig::bindPose(rigRoot)`.
+`C_Skeleton.bindPose_` (`std::vector<IRMath::SQT>`, parallel to `joints_` —
+added in #605 Phase 2 / #1602) holds each joint's rest transform in
+rig-root-local space. Populate it from a `.rig` via
+`IRPrefab::Rig::bindPose(rig)` (`rig_bridge.hpp`), which folds the JNTS rest
+chain with `IRMath::sqtCompose` — **not** the `.rig` BIND chunk, which stores
+named attachment points (`C_BindPoints`), a separate concept despite the chunk
+name. `IRPrefab::Skeleton::skinMatrix(jointWorld, bindPose_[i])`
+(`skeleton.hpp`) returns `jointWorld × bindInverse`: identity at the bind pose,
+the joint's posed deformation otherwise. The bind SQT is inverted analytically
+(`IRMath::sqtInverse`) rather than via a 4×4 inverse. Under #605 Phase 2.3 the
+per-joint skin matrix feeds the binding-18 transform buffer the
+`c_update_voxel_positions` prepass already consumes.
 
 ### Optional follow-up: C_JointName
 

--- a/engine/prefabs/irreden/voxel/components/component_skeleton.hpp
+++ b/engine/prefabs/irreden/voxel/components/component_skeleton.hpp
@@ -46,13 +46,18 @@
 // ## Bind pose
 //
 // Skinning math needs the bind-pose inverse to recover skinning matrices.
-// `bindPose_` is intentionally NOT declared in this header yet — IRMath::SQT
-// is now available (since #731 Phase 1 landed — PR #749); a follow-up task
-// (#605 Phase 2) adds `std::vector<IRMath::SQT> bindPose_;` here, parallel
-// to `joints_`. Until then, callers that need a bind pose load it from the
-// `.rig` asset's BIND chunk via `IRPrefab::Rig::bindPose(rigRoot)`.
+// `bindPose_` (added in #605 Phase 2 / #1602) holds joint `i`'s rest transform
+// in rig-root-local space — the same space `C_WorldTransform` reports for a
+// joint left at rest, so `IRPrefab::Skeleton::skinMatrix(jointWorld, bindPose_[i])`
+// returns identity at the bind pose and the joint's posed motion otherwise.
+// Populate it from a `.rig` via `IRPrefab::Rig::bindPose(rig)`, which composes
+// the JNTS rest chain — NOT the `.rig` BIND chunk, which stores named
+// attachment points (`C_BindPoints`) unrelated to per-joint skinning despite
+// the chunk name. The slot order matches `joints_`, so a kNullEntity severance
+// hole keeps its (now-unused) bind slot.
 
 #include <irreden/entity/ir_entity_types.hpp>
+#include <irreden/ir_math.hpp>
 
 #include <vector>
 
@@ -60,6 +65,7 @@ namespace IRComponents {
 
 struct C_Skeleton {
     std::vector<IREntity::EntityId> joints_;
+    std::vector<IRMath::SQT> bindPose_;
 
     C_Skeleton() = default;
 };

--- a/engine/prefabs/irreden/voxel/rig_bridge.hpp
+++ b/engine/prefabs/irreden/voxel/rig_bridge.hpp
@@ -1,7 +1,8 @@
 #ifndef IR_PREFAB_VOXEL_RIG_BRIDGE_H
 #define IR_PREFAB_VOXEL_RIG_BRIDGE_H
 
-// IRAsset::Rig ↔ IRComponents::C_JointHierarchy bridge — keeps engine/asset/ free of prefab dependencies.
+// IRAsset::Rig ↔ IRComponents::C_JointHierarchy bridge — keeps engine/asset/ free of prefab
+// dependencies.
 
 #include <irreden/asset/rig_format.hpp>
 
@@ -16,6 +17,36 @@
 #include <vector>
 
 namespace IRPrefab::Rig {
+
+namespace detail {
+
+// Fills `chainOut` (cleared first) with the joint indices from `start` up to
+// the root, leaf-first / root-last. The (parent == current || parent >=
+// jointCount) sentinel stops a malformed chain instead of looping. `parentOf`
+// returns joint i's parentIndex_; the two callers hold different joint
+// containers (IRAsset::Rig vs C_JointHierarchy), so the accessor is a template
+// parameter rather than a fixed type. Caller-owned buffer so a per-joint loop
+// (bindPose) reuses one allocation across the whole skeleton.
+template <typename ParentOf>
+inline void collectJointChainToRoot(
+    std::uint32_t start,
+    std::size_t jointCount,
+    ParentOf parentOf,
+    std::vector<std::uint32_t> &chainOut
+) {
+    chainOut.clear();
+    std::uint32_t current = start;
+    for (std::size_t step = 0; step < jointCount; ++step) {
+        chainOut.push_back(current);
+        const std::uint32_t parent = parentOf(current);
+        if (parent == current || parent >= jointCount) {
+            break;
+        }
+        current = parent;
+    }
+}
+
+} // namespace detail
 
 inline IRComponents::C_JointHierarchy toComponent(const IRAsset::Rig &rig) {
     IRComponents::C_JointHierarchy hierarchy;
@@ -68,16 +99,12 @@ inline BindPointWorldTransform worldTransformForBindPoint(
 
     std::vector<std::uint32_t> chain;
     chain.reserve(hierarchy.joints_.size());
-    std::uint32_t current = point.boneId_;
-    const std::size_t maxDepth = hierarchy.joints_.size();
-    for (std::size_t step = 0; step < maxDepth; ++step) {
-        chain.push_back(current);
-        const std::uint32_t parent = hierarchy.joints_[current].parentIndex_;
-        if (parent == current || parent >= hierarchy.joints_.size()) {
-            break;
-        }
-        current = parent;
-    }
+    detail::collectJointChainToRoot(
+        point.boneId_,
+        hierarchy.joints_.size(),
+        [&](std::uint32_t i) { return hierarchy.joints_[i].parentIndex_; },
+        chain
+    );
 
     for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
         const auto &joint = hierarchy.joints_[*it];
@@ -95,6 +122,48 @@ inline BindPointWorldTransform worldTransformForBindPoint(
     world.offset_ = chainTranslation + IRMath::rotateVectorByQuat(point.offset_, chainRotation);
     world.rotation_ = IRMath::quatMul(chainRotation, point.rotation_);
     return world;
+}
+
+// Per-joint bind (rest) pose in rig-root-local space — one IRMath::SQT per
+// joint, in `joints_` order — exactly what populates C_Skeleton.bindPose_.
+// Each entry is joint i's JNTS local rest transform composed up its parent
+// chain with sqtCompose (the PROPAGATE_TRANSFORM convention), so a joint left
+// at rest has C_WorldTransform == bindPose[i] and IRPrefab::Skeleton::skinMatrix
+// returns identity at the bind pose.
+//
+// Source is the JNTS chunk, NOT the `.rig` BIND chunk: BIND stores named
+// attachment points (toBindPoints / C_BindPoints), a separate concept from the
+// per-joint skinning bind pose despite the chunk name. Shares the
+// detail::collectJointChainToRoot walk with worldTransformForBindPoint.
+inline std::vector<IRMath::SQT> bindPose(const IRAsset::Rig &rig) {
+    const std::size_t jointCount = rig.joints_.size();
+    std::vector<IRMath::SQT> pose(jointCount);
+
+    std::vector<std::uint32_t> chain;
+    chain.reserve(jointCount);
+    for (std::size_t j = 0; j < jointCount; ++j) {
+        detail::collectJointChainToRoot(
+            static_cast<std::uint32_t>(j),
+            jointCount,
+            [&](std::uint32_t i) { return rig.joints_[i].parentIndex_; },
+            chain
+        );
+
+        IRMath::SQT world; // identity
+        for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
+            const auto &assetJoint = rig.joints_[*it];
+            IRMath::SQT local;
+            local.rotation_ = assetJoint.rotation_;
+            local.translation_ = IRMath::vec3(
+                assetJoint.translation_.x,
+                assetJoint.translation_.y,
+                assetJoint.translation_.z
+            );
+            world = IRMath::sqtCompose(world, local);
+        }
+        pose[j] = world;
+    }
+    return pose;
 }
 
 inline IRAsset::Rig fromComponent(

--- a/engine/prefabs/irreden/voxel/skeleton.hpp
+++ b/engine/prefabs/irreden/voxel/skeleton.hpp
@@ -1,0 +1,40 @@
+#ifndef IR_PREFAB_VOXEL_SKELETON_H
+#define IR_PREFAB_VOXEL_SKELETON_H
+
+// IRPrefab::Skeleton — skinning helpers over C_Skeleton + its bind pose
+// (C_Skeleton.bindPose_). The transform algebra (SQT compose / inverse) lives
+// in IRMath; this prefab-layer free-function surface joins a joint's live
+// C_WorldTransform to its rest pose. The companion severJoint API documented
+// on C_Skeleton lands with a later #605 Phase 2+ ticket.
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <irreden/common/components/component_world_transform.hpp>
+
+namespace IRPrefab::Skeleton {
+
+// skinMatrix = jointWorld × bindInverse: the rigid motion that carries a voxel
+// from its bind-pose position to the joint's current world pose. At the bind
+// pose (jointWorld == bind) it is identity; under #605 Phase 2.3 the
+// per-joint result is written into the binding-18 transform buffer and the
+// existing c_update_voxel_positions prepass applies it to each skinned voxel.
+// The bind SQT is inverted analytically (IRMath::sqtInverse), not via a 4×4
+// inverse — see the gotcha on #1602.
+inline IRMath::mat4 skinMatrix(const IRMath::SQT &jointWorld, const IRMath::SQT &bind) {
+    return IRMath::sqtToMat4(jointWorld) * IRMath::sqtToMat4(IRMath::sqtInverse(bind));
+}
+
+// Convenience overload reading the joint entity's current C_WorldTransform.
+// Entry-point style: a one-time read (spawn, editor interaction), NOT a
+// per-frame tick. The joint-matrix uploader (#605 Phase 2.2 / #1603) iterates
+// joints with C_WorldTransform in its template params instead of calling this
+// per joint.
+inline IRMath::mat4 skinMatrix(IREntity::EntityId joint, const IRMath::SQT &bind) {
+    const auto &world = IREntity::getComponent<IRComponents::C_WorldTransform>(joint);
+    return skinMatrix(IRMath::SQT{world.scale_, world.rotation_, world.translation_}, bind);
+}
+
+} // namespace IRPrefab::Skeleton
+
+#endif /* IR_PREFAB_VOXEL_SKELETON_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(IrredenEngineTest
   ecs/sort_archetype_relational_test.cpp
   ecs/parallel_spawn_test.cpp
   ecs/skeleton_components_test.cpp
+  ecs/skeleton_skinning_test.cpp
   ecs/spatial_grid_test.cpp
   ecs/system_exclude_test.cpp
   ecs/voxel_set_target_canvas_test.cpp

--- a/test/ecs/skeleton_skinning_test.cpp
+++ b/test/ecs/skeleton_skinning_test.cpp
@@ -1,0 +1,131 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/entity/entity_manager.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <irreden/asset/rig_format.hpp>
+#include <irreden/voxel/components/component_joint.hpp>
+#include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/voxel/rig_bridge.hpp>
+#include <irreden/voxel/skeleton.hpp>
+
+// #1602 — bind-pose on C_Skeleton + skin-matrix helper.
+//
+// Geometry shared by the cases below: a straight 3-bone chain along +X. joint0
+// is the root at the origin; joint1 sits 2 units out; joint2 sits 3 units past
+// joint1. At rest every joint rotation is identity, so the rest world
+// translations are (0,0,0), (2,0,0), (5,0,0).
+
+namespace {
+
+constexpr float kTolerance = 1e-4f;
+
+IRAsset::Rig makeChainRig() {
+    IRAsset::Rig rig;
+    rig.joints_.resize(3);
+    // Root: parentIndex == own index is the chain-terminator sentinel.
+    rig.joints_[0].parentIndex_ = 0;
+    rig.joints_[0].translation_ = IRMath::vec4(0.0f, 0.0f, 0.0f, 0.0f);
+    rig.joints_[1].parentIndex_ = 0;
+    rig.joints_[1].translation_ = IRMath::vec4(2.0f, 0.0f, 0.0f, 0.0f);
+    rig.joints_[2].parentIndex_ = 1;
+    rig.joints_[2].translation_ = IRMath::vec4(3.0f, 0.0f, 0.0f, 0.0f);
+    return rig;
+}
+
+void expectVec3Near(const IRMath::vec3 &actual, const IRMath::vec3 &expected) {
+    EXPECT_NEAR(actual.x, expected.x, kTolerance);
+    EXPECT_NEAR(actual.y, expected.y, kTolerance);
+    EXPECT_NEAR(actual.z, expected.z, kTolerance);
+}
+
+// Applies a 4×4 affine transform to a point (w == 1, no perspective divide).
+IRMath::vec3 applyToPoint(const IRMath::mat4 &m, const IRMath::vec3 &p) {
+    return IRMath::vec3(m * IRMath::vec4(p, 1.0f));
+}
+
+TEST(SkeletonSkinningTest, BindPoseSizeMatchesJointsAndComposesChain) {
+    const IRAsset::Rig rig = makeChainRig();
+    const std::vector<IRMath::SQT> pose = IRPrefab::Rig::bindPose(rig);
+
+    ASSERT_EQ(pose.size(), rig.joints_.size());
+    expectVec3Near(pose[0].translation_, IRMath::vec3(0.0f, 0.0f, 0.0f));
+    expectVec3Near(pose[1].translation_, IRMath::vec3(2.0f, 0.0f, 0.0f));
+    // joint2 accumulates joint1's offset: (2,0,0) + (3,0,0).
+    expectVec3Near(pose[2].translation_, IRMath::vec3(5.0f, 0.0f, 0.0f));
+}
+
+TEST(SkeletonSkinningTest, SkinMatrixIsIdentityAtBindPose) {
+    const IRAsset::Rig rig = makeChainRig();
+    const std::vector<IRMath::SQT> pose = IRPrefab::Rig::bindPose(rig);
+
+    // A joint sitting exactly at its bind transform contributes no deformation.
+    for (const IRMath::SQT &bind : pose) {
+        const IRMath::mat4 skin = IRPrefab::Skeleton::skinMatrix(bind, bind);
+        expectVec3Near(applyToPoint(skin, IRMath::vec3(1.0f, 2.0f, 3.0f)),
+                       IRMath::vec3(1.0f, 2.0f, 3.0f));
+    }
+}
+
+TEST(SkeletonSkinningTest, RotatingMiddleJointSwingsChildByParentRotation) {
+    const IRAsset::Rig rig = makeChainRig();
+    const std::vector<IRMath::SQT> bind = IRPrefab::Rig::bindPose(rig);
+
+    // Pose: rotate the middle joint (joint1) +90° about Z. joint1's posed local
+    // is rest-translation with a quarter-turn; joint2 inherits it through the
+    // chain. Compose the posed world transforms with the same engine
+    // convention bindPose uses (sqtCompose).
+    IRMath::SQT posedLocal1;
+    posedLocal1.rotation_ = IRMath::quatAxisAngle(IRMath::vec3(0.0f, 0.0f, 1.0f), IRMath::kHalfPi);
+    posedLocal1.translation_ = IRMath::vec3(2.0f, 0.0f, 0.0f);
+
+    IRMath::SQT local2;
+    local2.translation_ = IRMath::vec3(3.0f, 0.0f, 0.0f);
+
+    const IRMath::SQT posedWorld1 = IRMath::sqtCompose(IRMath::SQT{}, posedLocal1);
+    const IRMath::SQT posedWorld2 = IRMath::sqtCompose(posedWorld1, local2);
+
+    // The child's offset (3,0,0) past joint1 swings to +Y about joint1's pivot.
+    expectVec3Near(posedWorld2.translation_, IRMath::vec3(2.0f, 3.0f, 0.0f));
+
+    const IRMath::mat4 skin = IRPrefab::Skeleton::skinMatrix(posedWorld2, bind[2]);
+
+    // A voxel authored at joint2's bind origin lands at joint2's posed origin.
+    expectVec3Near(applyToPoint(skin, bind[2].translation_),
+                   IRMath::vec3(2.0f, 3.0f, 0.0f));
+    // A voxel one unit further along +X in bind space lands one unit along +Y
+    // past the posed child origin — confirming the parent rotation propagated
+    // with the right handedness, not just the translation.
+    expectVec3Near(applyToPoint(skin, IRMath::vec3(6.0f, 0.0f, 0.0f)),
+                   IRMath::vec3(2.0f, 4.0f, 0.0f));
+}
+
+class SkeletonSkinningEntityTest : public testing::Test {
+  protected:
+    IREntity::EntityManager m_entity_manager;
+};
+
+TEST_F(SkeletonSkinningEntityTest, EntityOverloadReadsWorldTransform) {
+    const IRAsset::Rig rig = makeChainRig();
+    const std::vector<IRMath::SQT> bind = IRPrefab::Rig::bindPose(rig);
+
+    // Stand in for PROPAGATE_TRANSFORM: write joint2's posed world transform
+    // directly, then confirm the entity overload reproduces the SQT overload.
+    auto joint = IREntity::createEntity(IRComponents::C_Joint{});
+    auto &world = IREntity::getComponent<IRComponents::C_WorldTransform>(joint);
+    world.rotation_ = IRMath::quatAxisAngle(IRMath::vec3(0.0f, 0.0f, 1.0f), IRMath::kHalfPi);
+    world.translation_ = IRMath::vec3(2.0f, 3.0f, 0.0f);
+
+    const IRMath::SQT jointWorld{world.scale_, world.rotation_, world.translation_};
+    const IRMath::mat4 viaEntity = IRPrefab::Skeleton::skinMatrix(joint, bind[2]);
+    const IRMath::mat4 viaSqt = IRPrefab::Skeleton::skinMatrix(jointWorld, bind[2]);
+
+    for (int col = 0; col < 4; ++col) {
+        for (int row = 0; row < 4; ++row) {
+            EXPECT_NEAR(viaEntity[col][row], viaSqt[col][row], kTolerance);
+        }
+    }
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
Foundation for #605 Phase 2 skeletal voxels (P2.1) — the bind-pose data and skinning math that joint-matrix upload (2.2 / #1603) and per-voxel skinning (2.3 / #1605) build on.

- **`IRMath::SQT`** value type (scale / quat-rotation / translation), the math-layer mirror of the prefab `C_LocalTransform` / `C_WorldTransform` layout, plus `sqtToMat4(SQT)`, `sqtCompose` (reproduces `SYSTEM_PROPAGATE_TRANSFORM`'s composition so a chain folded in math matches the propagated `C_WorldTransform`), and `sqtInverse` (analytic — invert the bind SQT, not its 4×4; exact for the rigid bind-pose domain).
- **`C_Skeleton.bindPose_`** (`std::vector<IRMath::SQT>`, parallel to `joints_`).
- **`IRPrefab::Rig::bindPose(rig)`** derives each joint's rest transform by folding the JNTS chain (rig-root-local), one SQT per joint. Shares the chain-walk with `worldTransformForBindPoint` via a new `detail::collectJointChainToRoot`.
- **`IRPrefab::Skeleton::skinMatrix(jointWorld, bind)`** = `jointWorld × bindInverse`; identity at the bind pose, the joint's posed deformation otherwise. Convenience overload reads a joint entity's `C_WorldTransform`.
- New gtest **`test/ecs/skeleton_skinning_test.cpp`** (4 cases).

## Design note for reviewer
The issue says "load bind pose from the `.rig` BIND chunk", but the BIND chunk (`RigBindPoint{boneId, offset, rotation, name}`, #669) stores **named attachment points** — already consumed by `C_BindPoints` / `worldTransformForBindPoint` — and `bindPointCount` is unrelated to `jointCount`. Acceptance requires `bindPose_.size() == joints_.size()` (one entry per joint), so the per-joint rest pose is derived from the **JNTS** chain instead. The conflation is documented in the code + `voxel/CLAUDE.md`. No production rig→`C_Skeleton` spawn site exists yet (tickets 2.5 / 2.9), so `bindPose_` is populated by the helper + exercised in the test; the field and helper are the deliverable.

## Test plan
- [x] `macos-debug`: `IrredenEngineTest` builds clean; `SkeletonSkinning*` (4) + `RigFormat*` + `PrefabApi.BindPoint*` pass (61 in the affected suites; refactor of `worldTransformForBindPoint` regression-checked).
- [ ] `linux-debug` cross-host build + test.

Closes #1602

🤖 Generated with [Claude Code](https://claude.com/claude-code)