### PR TITLE
fleet: reflective feedback flow + fleet:coding-improvement label

### DIFF
--- a/.claude/skills/assess-coding-improvement/SKILL.md
+++ b/.claude/skills/assess-coding-improvement/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: assess-coding-improvement
+description: >-
+  After fixing PR review feedback, assess whether the fix reveals a
+  generalizable improvement to the fleet's development procedures (style
+  guide, coding rules, simplify checks, review criteria, worker direction) and,
+  if so, file or append to a fleet:coding-improvement ticket. Auto-invoked as
+  the last step of a feedback AMEND (see FLEET-FEEDBACK-HANDLING.md Step i).
+  Also use when the user asks "should this be a fleet rule?", "assess coding
+  improvement", or "file a coding-improvement". It is a reflection pass — it
+  never touches the PR's code, labels, or claim.
+---
+
+# assess-coding-improvement (Irreden Engine)
+
+**The flow lives in [`docs/agents/skills/assess-coding-improvement.md`](../../../docs/agents/skills/assess-coding-improvement.md).**
+Read it first, then apply the engine deltas below. This wrapper carries
+deltas only — see [`docs/design/skill-sharing.md`](../../../docs/design/skill-sharing.md)
+for why.
+
+## Deltas (Irreden Engine)
+
+| Delta key | Engine value |
+|---|---|
+| **repo** | `jakildev/IrredenEngine` (game PRs: `jakildev/irreden` — add `--repo jakildev/irreden` to every `gh` call, and read game comments with `fleet-pr comments <N> --repo game`) |
+| **comments tool** | `fleet-pr comments <N>` |
+| **convention surfaces** | searched in Step 3, in this order (see below) |
+| **automated-check surface** | the [`simplify`](../simplify/) skill + its `simplify-*` subagents in [`.claude/agents/`](../../agents/) |
+| **review checklist** | the engine checklist in [`.claude/skills/review-pr/SKILL.md`](../review-pr/SKILL.md) |
+
+## Engine convention surfaces (Step 3 search order)
+
+1. [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md)
+   — cross-cutting baseline: naming, the ECS footgun, style, ownership/lifetime,
+   IRMath. The authoritative home for a *missing* cross-cutting rule (Class A).
+2. `.claude/rules/cpp-*.md` — the C++ coding rules:
+   [`cpp-ecs.md`](../../rules/cpp-ecs.md) / [`cpp-ecs-smells.md`](../../rules/cpp-ecs-smells.md),
+   [`cpp-math.md`](../../rules/cpp-math.md), [`cpp-systems.md`](../../rules/cpp-systems.md),
+   [`cpp-lua-enums.md`](../../rules/cpp-lua-enums.md).
+3. The **nearest module `CLAUDE.md`** (under `engine/`, `engine/prefabs/`,
+   `creations/`) — the right home for a rule that's specific to one subsystem
+   rather than cross-cutting.
+4. The **automated-check surface** above — for a mechanically-detectable rule
+   that should be caught pre-commit (the strongest Class-B target).
+5. The **review checklist** above (+ [`docs/agents/skills/review-pr.md`](../../../docs/agents/skills/review-pr.md))
+   — the backstop enforcement surface.
+6. Worker direction: [`.claude/commands/role-*.md`](../../commands/) and
+   [`docs/agents/AUTHOR-PIPELINE.md`](../../../docs/agents/AUTHOR-PIPELINE.md).
+
+## Engine notes
+
+- The label `fleet:coding-improvement` is defined in
+  [`scripts/fleet/fleet-labels`](../../../scripts/fleet/fleet-labels) and
+  [`docs/agents/fleet-labels-reference.md`](../../../docs/agents/fleet-labels-reference.md);
+  `fleet-labels` creates it on the repo if missing.
+- Several surfaces (`.claude/commands/role-*.md`, `.claude/skills/**/SKILL.md`)
+  are **gated self-config** the fleet can't auto-edit — that's exactly why the
+  ticket is filed un-queued (no `human:approved`) for the human to triage.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Thumbs.db
 .review-body-*.md
 .pr-body.md
 .merger-body.md
+.coding-improvement-body.md
 __pycache__/
 
 # creations: keep demos, voxel editor scaffold, and top-level CLAUDE.md; ignore private tools

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -145,9 +145,14 @@ fleet-pr comments <N>
 ```
 
 One wrapper call surfaces the timeline, review summaries, and
-inline comments. Address every comment — conversation-level,
-review summaries, and inline line-level comments are all in the
-output.
+inline comments. Build an explicit checklist with **one item per
+output line** — every `[comment …]`, `[review …]` summary, and
+`[path:line]` inline comment is a separate item. The human (or
+reviewer) may post several comments and several inline threads
+before tagging; ALL appear in this one output and none may be
+dropped. Address every item, then confirm in the step-e summary
+comment that each was covered. (Coverage is re-checked after the
+fix in Step i.)
 
 - **For `fleet:has-nits`**: focus on the latest review's `### Nits`
   section. Treat it like a checklist. Address every nit unless
@@ -434,6 +439,26 @@ safe to run unconditionally:
 ```
 fleet-claim release-worktree <your-worktree-basename>
 ```
+
+### Step i — reflect: assess for a coding-improvement
+
+Run on **every AMEND path that changed code** (`human:needs-fix` /
+`human:blocker`, `fleet:needs-fix`, `fleet:has-nits`):
+
+```
+Skill: assess-coding-improvement
+```
+
+It re-reads the PR comments, confirms every one was covered, then decides
+whether the fix reveals a **generalizable** improvement to the fleet's dev
+procedures — and, importantly, whether a rule *already exists* but wasn't
+surfaced where you'd have caught it at authoring time. If so it files (or
+appends to) a `fleet:coding-improvement` ticket, left un-queued for human
+triage. One-off domain fixes produce no ticket — the skill gates that.
+
+This is a read-only reflection — it never touches this PR's code, labels, or
+claim, so it's safe to run after the releases above. (On the ESCALATE path,
+run it only if the deferred concern is itself a recurring convention.)
 
 Then exit. Do NOT call `start-next-task` from the feedback path —
 the next dispatcher iteration will pick a fresh task and reset the

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -58,6 +58,20 @@ Specifically, **never pass these via `--label` when filing**:
   `human:approved` used to be the only way to defeat that re-stamp —
   this label replaces that workaround). Clears when the human applies
   the change (the ingest then re-queues the issue) or closes it.
+- `fleet:coding-improvement` — owned by the **author worker**, applied by the
+  `assess-coding-improvement` skill at the end of a feedback AMEND. When a fix
+  reveals a *generalizable* convention or footgun (not a one-off), the worker
+  files a tracking issue proposing where to add or better-surface the rule
+  (style guide, `.claude/rules/cpp-*.md`, a `simplify` check, the `review-pr`
+  checklist, worker direction) so the same class of mistake is caught at
+  authoring time. This is the only label the filer applies — a deliberate
+  **exception** to the "file issues with no labels" rule below: it's a
+  *classification* tag, not a queue/verdict signal. The worker does **not**
+  add `human:approved` or `fleet:queued`, so the ticket stays out of the
+  pickup queue until the human triages it (most targets are gated self-config
+  the fleet can't auto-edit anyway). The skill dedups first — if an open
+  `fleet:coding-improvement` issue already targets the same artifact it
+  comments a new occurrence instead of filing a duplicate.
 - `fleet:queued` / `fleet:task` — owned by **`fleet-queue-ingest`**,
   set after `human:approved` has been observed. Adding it at filing
   time excludes the issue from the ingest search (which looks for
@@ -363,7 +377,11 @@ up. `fleet-queue-ingest` will add `fleet:queued` (and optionally a
 **Exception:** if you're operating in a role's own lane (e.g. you
 ARE a reviewer and you've just verdict'd a PR), then setting your
 role's labels is correct. The rule above is about ad-hoc issue/PR
-filing from human conversations.
+filing from human conversations. The `assess-coding-improvement`
+skill is another in-lane case: it files with exactly one
+*classification* label, `fleet:coding-improvement`, and deliberately
+withholds `human:approved` / `fleet:queued` so the ticket stays
+un-queued for human triage.
 
 ---
 

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -21,6 +21,12 @@
       "description": "reconcile surfaced unresolved/ambiguous claim-surface drift that persisted across N ticks; one deduped tracking issue, human resolves"
     },
     {
+      "name": "fleet:coding-improvement",
+      "scope": "issue",
+      "color": "c2e0c6",
+      "description": "Worker-filed: a fix revealed a generalizable rule for the fleet's dev procedures; human triages"
+    },
+    {
       "name": "fleet:task",
       "scope": "issue",
       "color": "0366d6",

--- a/docs/agents/skills/assess-coding-improvement.md
+++ b/docs/agents/skills/assess-coding-improvement.md
@@ -1,0 +1,193 @@
+# assess-coding-improvement — shared flow
+
+The canonical `assess-coding-improvement` flow: after a worker has fixed the
+feedback on a PR, confirm every comment was covered, then decide whether the
+fix reveals a **generalizable** improvement to the fleet's development
+procedures (style guide, coding rules, the `simplify` checks, the review
+checklist, worker direction). If so, file — or append to — a tracking issue
+tagged `fleet:coding-improvement` so the same class of mistake gets caught at
+authoring time instead of being re-flagged on the next PR.
+
+This is invoked at the **end of a feedback AMEND** (see
+[`FLEET-FEEDBACK-HANDLING.md`](../FLEET-FEEDBACK-HANDLING.md) Step i). It is a
+**reflection** pass, not a code change — the fix already landed. It never
+touches the PR's code, labels, or claim.
+
+Every repo that runs a fleet keeps its
+`.claude/skills/assess-coding-improvement/SKILL.md` as a thin wrapper that
+points here and supplies only its **deltas** — most importantly its
+**convention surfaces** (the docs/rules/checks that encode that repo's
+conventions). The *flow* is single-sourced here so the wrappers can't drift on
+mechanics. See [`docs/design/skill-sharing.md`](../../design/skill-sharing.md).
+
+Wherever a step needs a repo-specific value it names a **delta key** in bold.
+
+---
+
+## Repo deltas this flow needs
+
+| Delta key | What it is | Engine value |
+|---|---|---|
+| **repo** | The `gh --repo` slug for `gh issue list` / `create` / `comment`. | `jakildev/IrredenEngine` |
+| **comments tool** | The wrapper that surfaces all PR feedback in one call. | `fleet-pr comments <N>` |
+| **convention surfaces** | The ordered set of docs/rules/checks that encode this repo's conventions — searched in Step 3 to decide whether a rule already exists. | the engine surfaces listed in the wrapper |
+| **automated-check surface** | Where a mechanically-detectable rule is *enforced* pre-commit (so the worker gets it right the first time). | the `simplify` skill + its `simplify-*` subagents |
+| **review checklist** | The repo's review criteria — a fallback enforcement surface when authoring keeps missing what review catches. | the `review-pr` wrapper's checklist |
+
+The fleet label `fleet:coding-improvement` and the `gh issue` mechanics are
+shared fleet machinery and are used concretely below.
+
+---
+
+## When to run
+
+- Automatically, as the last step of a feedback AMEND on **any** path that
+  changed code: `human:needs-fix` / `human:blocker`, `fleet:needs-fix`,
+  `fleet:has-nits`. (Reviewer nits are the richest source — they are usually
+  an instance of a convention that already exists somewhere.)
+- On the ESCALATE path, only if the deferred concern is itself a convention
+  (rare); the PR's code didn't change, so there is usually nothing to reflect
+  on.
+- On explicit ask ("should this be a fleet rule?", "assess coding
+  improvement", "file a coding-improvement").
+
+Skip entirely if the only feedback was subjective preference or a pure
+one-off domain fix (Step 2 gates this).
+
+---
+
+## Step 1 — Enumerate the feedback and confirm coverage
+
+Re-run the **comments tool** for the PR:
+
+```
+fleet-pr comments <N>
+```
+
+(Add the repo flag for game PRs, per the wrapper.) Build an explicit
+checklist with **one item per output line** — every `[comment …]`,
+`[review … ]` summary, and `[path:line]` inline comment is a separate item.
+The human (or reviewer) may have posted several comments and several inline
+threads before tagging; none may be dropped.
+
+For each item, confirm the fix you just pushed actually addresses it (or that
+you explicitly accounted for it in the Step-e summary comment / ESCALATE
+issue). If any item is uncovered, **stop the reflection and go back and
+address it** — coverage comes before generalization.
+
+This is the comprehensive-reading guarantee, re-asserted after the fix: the
+same checklist that drives the fix drives the reflection.
+
+## Step 2 — Is each item generalizable?
+
+For every checklist item, decide: is this an instance of a **repeatable
+pattern** — a convention, an idiom, or a footgun that recurs across code — or
+a **one-off** specific to this code?
+
+Generalizable (worth reflecting on), e.g.:
+- a naming-convention slip,
+- a math primitive that should have gone through the engine math layer,
+- a per-entity component lookup in a tick / an allocation in a hot loop,
+- an ECS ordering or ownership footgun,
+- a doc-comment or test-coverage standard,
+- a render-pipeline invariant.
+
+One-off (skip — **no ticket**): a wrong magic number in one shader, an
+off-by-one in one entity's spawn math, a typo, a subjective wording tweak.
+**One-offs are the anti-spam gate** — most fixes are one-offs and produce
+nothing here.
+
+Carry forward only the generalizable items.
+
+## Step 3 — Does the convention already exist? Classify the improvement
+
+This is the heart of the pass. For each generalizable item, search the
+**convention surfaces** to find whether the rule is already written down
+somewhere. Then classify:
+
+- **(A) Missing** — no surface encodes this rule. The improvement is to
+  **add** it to the authoritative surface for its class (a naming rule to the
+  style guide / naming rule file; an ECS rule to the ECS rule file; a render
+  invariant to the render-review surface; etc.).
+
+- **(B) Exists but didn't fire** — a surface already states the rule, yet the
+  worker still shipped the mistake and a reviewer/human had to catch it. The
+  real defect is **surfacing / enforcement**, not the rule text. Propose
+  moving the rule to where the worker reliably hits it *at authoring time*:
+  - if it's **mechanically detectable**, add or extend a check on the
+    **automated-check surface** so the pre-commit pass flags it
+    automatically — this is the strongest "get it right the first time" lever;
+  - if it's buried in a rarely-read doc, **relocate / cross-link** it into the
+    surface the worker actually reads at the relevant moment (e.g. the nearest
+    module `CLAUDE.md`, or the author pipeline);
+  - if review keeps catching what authoring misses, add it to the **review
+    checklist** as a backstop (in addition to one of the above, not instead).
+
+The ticket must state which class (A or B) and name the **exact target
+artifact** (file path) plus the **one-line rule** to add or relocate.
+
+## Step 4 — Dedup, then comment-or-file
+
+Search open coding-improvement tickets first, so repeat occurrences accrue
+evidence on one issue instead of spawning duplicates:
+
+```
+gh issue list --repo <repo> --label fleet:coding-improvement --state open \
+  --json number,title,body
+```
+
+- **Match** (an open ticket targets the same artifact / rule) → add an
+  occurrence instead of filing a new one:
+  ```
+  gh issue comment <M> --repo <repo> --body "Recurred: PR #<N>, <file:line> — \
+  <one-line>. — <role-name>"
+  ```
+  A second occurrence is the signal this is a real pattern worth the human
+  prioritizing.
+
+- **No match** → file a new ticket, tagging **only** `fleet:coding-improvement`
+  (write the body to a temp file and pass `--body-file` to avoid
+  command-substitution hazards, mirroring `file-epic`):
+  ```
+  gh issue create --repo <repo> --label "fleet:coding-improvement" \
+    --title "<area>: <short rule> (coding-improvement)" \
+    --body-file <tmp>
+  ```
+  Body shape:
+  ```markdown
+  **Class:** A (missing rule) | B (exists but didn't fire)
+  **Target artifact:** `<path to the doc / rule / check to change>`
+  **Proposed change:** <the one-line rule to add or relocate>
+
+  ## Context
+  Surfaced fixing feedback on PR #<N>. The reviewer/human flagged
+  <one-line of the original concern> (<file:line>).
+
+  ## Why it generalizes
+  <one paragraph: the class of mistake this prevents across the fleet,
+  and — for Class B — why the existing surface didn't catch it at
+  authoring time>
+
+  ## Occurrences
+  - PR #<N>, <file:line> — <one-line>
+  ```
+
+**Do not** add `human:approved` or `fleet:queued` — `fleet:coding-improvement`
+is a *classification* tag (an explicit exception to the "file issues with no
+labels" rule), and the ticket is left **un-queued for human triage**. Many
+targets are gated self-config (role docs, skills) that no worker may
+auto-edit, so leaving it un-queued is what keeps the ticket safe: the human
+decides whether and how it gets worked.
+
+Then return to the feedback flow (there is nothing more to do on the PR).
+
+---
+
+## Report
+
+One short block back to the caller:
+- per checklist item: covered? generalizable?
+- for each generalizable item: class (A/B), target artifact, and whether you
+  filed `#<M>` or commented on an existing `#<M>`.
+- if nothing qualified, say so explicitly ("all feedback was one-off /
+  subjective; no coding-improvement filed").

--- a/docs/agents/skills/assess-coding-improvement.md
+++ b/docs/agents/skills/assess-coding-improvement.md
@@ -146,12 +146,14 @@ gh issue list --repo <repo> --label fleet:coding-improvement --state open \
   prioritizing.
 
 - **No match** → file a new ticket, tagging **only** `fleet:coding-improvement`
-  (write the body to a temp file and pass `--body-file` to avoid
-  command-substitution hazards, mirroring `file-epic`):
+  (write the body to a worktree-local file and pass `--body-file` to avoid
+  command-substitution hazards, mirroring `file-epic`; use
+  `.coding-improvement-body.md` in the worktree root — NOT `/tmp/` — Claude
+  Code's sandbox blocks writes outside the worktree):
   ```
   gh issue create --repo <repo> --label "fleet:coding-improvement" \
     --title "<area>: <short rule> (coding-improvement)" \
-    --body-file <tmp>
+    --body-file .coding-improvement-body.md
   ```
   Body shape:
   ```markdown

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -100,6 +100,7 @@ LABELS=(
     "fleet:scope-shipped|fbca04|Issue scope already landed under a different T-NNN; queue-manager skipped ingest; human should close"
     "fleet:needs-human|fbca04|Fleet can't complete this autonomously (e.g. a gated self-config edit); a human must act. Parks the issue out of the queue while KEEPING human:approved; clears when the human resolves it (ingest re-queues) or closes the issue"
     "fleet:state-drift|fbca04|reconcile surfaced unresolved/ambiguous claim-surface drift that persisted across N ticks; one deduped tracking issue, human resolves"
+    "fleet:coding-improvement|c2e0c6|Worker-filed: a fix revealed a generalizable rule for the fleet's dev procedures; human triages"
     "fleet:task|0366d6|Task from the fleet issue queue"
     "fleet:epic|cc317c|Parent issue tracking a set of child issues; queue-manager auto-closes when all children close"
     "fleet:queued|c5def5|Queued for fleet pickup (requires human:approved)"


### PR DESCRIPTION
## Summary

After a worker fixes PR review feedback, the AMEND flow now **reflects** on whether the fix reveals a *generalizable* improvement to the fleet's dev procedures — and files a `fleet:coding-improvement` ticket when it does.

- **New shared skill `assess-coding-improvement`** — canonical flow in [`docs/agents/skills/assess-coding-improvement.md`](docs/agents/skills/assess-coding-improvement.md) + thin engine wrapper. Re-enumerates every PR comment (coverage guarantee), gates one-off fixes out, then classifies each generalizable finding as **(A) rule missing** or **(B) rule exists but didn't fire** — where the fix targets *surfacing/enforcement* (promote into a `simplify` check, relocate to the doc read at authoring time, or add to the `review-pr` checklist) so the worker gets it right the first time.
- **Dedup, then comment-or-file** — appends an occurrence to an existing open ticket for the same artifact, else files new. Filed **un-queued** (only the classification tag, no `human:approved`) for human triage — safe because most targets are gated self-config.
- **Wired into [`FLEET-FEEDBACK-HANDLING.md`](docs/agents/FLEET-FEEDBACK-HANDLING.md)** as Step i of the AMEND path, applying to all code-changing feedback paths (human + fleet reviewer). The "Reading the feedback" step also gains an enumeration discipline so multi-comment / inline-thread feedback can't be partially missed.
- **Registers the `fleet:coding-improvement` label** across the three sources ([`fleet-labels`](scripts/fleet/fleet-labels) catalog, [`fleet-state-machine.json`](docs/agents/fleet-state-machine.json), [`fleet-labels-reference.md`](docs/agents/fleet-labels-reference.md)).

## Test plan

- [x] `fleet-labels --check` passes (catalog ↔ state-machine JSON agree, 48 labels)
- [x] `fleet:coding-improvement` created on the repo (GitHub-facing description ≤100 chars)
- [x] Skill wrapper loads (appears in the skills list) and all relative markdown links resolve
- [x] Skill's Step-4 dedup query (`gh issue list --label fleet:coding-improvement`) runs clean

## Notes

- Game-side thin wrapper + its feedback-doc Step i are a follow-up (separate private repo; the canonical flow is already repo-neutral).
- Surfaced a pre-existing `fleet-labels` bug while creating the label: it passes full catalog descriptions to GitHub, which caps them at 100 chars, so any long-description label silently fails to sync (`fleet:fork-of-other-pr`, `human:owned` are currently missing). Tracked separately — not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)