### PR TITLE
scripts/fleet: truncate label descriptions to GitHub's 100-char cap in fleet-labels

### DIFF
--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -189,6 +189,24 @@ ensure_label_for_repo() {
         local rest="${entry#*|}"
         local color="${rest%%|*}"
         local desc="${rest#*|}"
+        # GitHub's label API caps descriptions at 100 characters and 422s
+        # anything longer ("description is too long"). A rejected create
+        # falls through to the "failed to create" branch below, so every
+        # over-long catalog entry silently fails to sync on each run. The
+        # catalog keeps the full text as documentation (--check compares
+        # names only); trim a copy down to the limit before sending it.
+        # When the cut lands mid-word, back up to the previous space and
+        # append an ellipsis so the GitHub tooltip still reads cleanly —
+        # but only when a boundary is reasonably close, else hard-cut.
+        if (( ${#desc} > 100 )); then
+            local clipped="${desc:0:99}"        # room for a 1-char ellipsis
+            local at_boundary="${clipped% *}"   # drop the partial trailing word
+            if [[ "$at_boundary" != "$clipped" && ${#at_boundary} -ge 80 ]]; then
+                desc="${at_boundary}…"
+            else
+                desc="${desc:0:100}"            # no nearby space — hard cut
+            fi
+        fi
         if echo "$existing" | grep -qx "$name"; then
             existed=$((existed + 1))
             continue


### PR DESCRIPTION
## Problem

`scripts/fleet/fleet-labels` builds GitHub labels from a `"name|color|description"` catalog via `gh label create ... --description "$desc"`. GitHub's label API caps descriptions at **100 characters** and returns `HTTP 422 — description is too long (maximum is 100 characters)` for anything longer.

In `ensure_label_for_repo()` the rejected create runs under `>/dev/null 2>&1` and falls through to the parallel-run re-check branch, so every catalog entry whose description exceeds 100 chars **silently logged "failed to create" on every sync and never got created**. Confirmed currently-missing-on-repo examples: `fleet:fork-of-other-pr` and `human:owned`.

## Fix

Trim a copy of `$desc` down to the API limit right after it's extracted, before it reaches either the dry-run preview or `gh label create`:

- Back up to the previous word boundary and append an ellipsis when a boundary is reasonably close;
- otherwise hard-cut at 100 chars.

The catalog keeps the full-length text as documentation — `--check` compares **names only**, so the state-machine drift guard is unaffected. This is purely a creation-robustness fix; **no new labels were added**.

## Verification

- `bash -n` clean; longest truncated descriptions came out to 95 and 88 chars (both ≤ 100).
- **Live sync** against `jakildev/IrredenEngine`: `2 created, 45 already existed`, **0 "failed to create"** lines. `fleet:fork-of-other-pr` and `human:owned` now appear in `gh label list`.
- **Idempotent**: second run reports `0 created, 47 already existed`.
- `fleet-labels --check` still passes (47 labels agree with `fleet-state-machine.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)