### PR TITLE
render: per-joint skin-matrix upload into binding-18 (#1603)

### DIFF
--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -105,6 +105,24 @@ the ECS surface.
   Shared substrate for per-entity SO(3) (#1272/#1299) and skeletal voxels
   (#605). The transform slot is bit-packed into the local-position `.w`
   lane (Metal has no free buffer index past 30).
+- `UPDATE_JOINT_MATRICES` — per-frame skeletal joint skin-matrix upload (#605
+  Phase 2.2 / #1603). For each `C_Skeleton` it writes every joint's
+  `IRPrefab::Skeleton::skinMatrix` (`jointWorld × bindInverse`) into a
+  contiguous block of the **same** binding-18 `EntityTransformBuffer` the
+  prepass consumes — no second buffer (binding-21 is retired for the voxel
+  path in Phase 2.4). Phase 2.3 then sets a skinned voxel's `.w` to
+  `slotBase + bone_id` so the existing `c_update_voxel_positions` prepass skins
+  it with no new shader. Iterates the `<C_Joint, C_WorldTransform>` archetype
+  (world transform via dense iteration, no per-joint `getComponent`); the rest
+  pose + target slot per joint are gathered once in `beginTick` from each
+  skeleton's own `bindPose_`. **The 4096-slot binding-18 budget is partitioned**
+  so the prepass's contiguous `[0, maxSlotUsed_]` re-upload can never clobber a
+  joint slot: dynamic voxel-set slots grow up from 0 (capped at
+  `kJointTransformSlotBase`); joint blocks are carved down from
+  `kMaxGpuVoxelTransforms` (the reserved `kMaxGpuJointTransforms`-slot high
+  region). Register **after** `PROPAGATE_TRANSFORM` and **before**
+  `UPDATE_VOXEL_POSITIONS_GPU`; a creation that authors skeletons must register
+  the prepass too (this system reuses its buffer).
 - `VOXEL_TO_TRIXEL_STAGE_1` — compute-shader voxel rasterization to the
   3 canvas textures. Runs compact + stage-1 + stage-2 dispatches in one
   per-canvas tick (the former separate `VOXEL_TO_TRIXEL_STAGE_2` system

--- a/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
@@ -176,6 +176,9 @@ template <> struct System<UPDATE_JOINT_MATRICES> {
                         releaseJointBlock(block.base_, block.count_);
                     }
                     block.base_ = acquireJointBlock(jointCount);
+                    // count_ = 0 on exhaustion so next-frame's count_ != jointCount
+                    // branch fires again and re-attempts the acquire. This is
+                    // intentional: exhaustion is exceptional and cheap to retry.
                     block.count_ = (block.base_ == kVoxelTransformStatic) ? 0 : jointCount;
                 }
                 if (block.base_ == kVoxelTransformStatic) {

--- a/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
@@ -210,8 +210,22 @@ template <> struct System<UPDATE_JOINT_MATRICES> {
             }
         );
 
-        // Sort by joint id so tick can binary-search (one O(N log N) pass here
-        // beats a per-joint hash map's per-frame node churn).
+        // Sort by joint entity id so tick can binary-search (O(N log N) once per
+        // frame, O(log N) per joint in tick). Chosen over an unordered_map because
+        // clear() keeps the vector's capacity, so the rebuild allocates nothing
+        // after warmup; a map would churn one heap node per joint per frame.
+        //
+        // Scalability: for large rigs (hundreds of joints across many skeletons)
+        // the sort cost is proportional to total joint count and the binary search
+        // is O(log N_total). If this becomes a bottleneck, the sort + search can be
+        // eliminated by adding (skeletonEntity_, boneIndex_) to C_Joint — tick
+        // would then compute the slot directly (skeletonBlocks_[skeletonEntity_].base_
+        // + boneIndex_) in O(1) per joint with a single unordered_map lookup.
+        //
+        // Hierarchy (topological) ordering: processing joints in parent-before-child
+        // order is not required here because PROPAGATE_TRANSFORM has already composed
+        // each joint's C_WorldTransform before this system runs. Sorting by entity id
+        // is a data-layout choice only, not a correctness constraint.
         std::sort(
             jointTargets_.begin(),
             jointTargets_.end(),
@@ -230,6 +244,8 @@ template <> struct System<UPDATE_JOINT_MATRICES> {
     }
 
     void tick(IREntity::EntityId joint, C_Joint &, const C_WorldTransform &world) {
+        // O(log N_total) lookup into the sorted jointTargets_ built each beginTick.
+        // See the sort comment above for the trade-off analysis and the upgrade path.
         const auto target = std::lower_bound(
             jointTargets_.begin(),
             jointTargets_.end(),

--- a/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_joint_matrices.hpp
@@ -1,0 +1,278 @@
+#ifndef SYSTEM_UPDATE_JOINT_MATRICES_H
+#define SYSTEM_UPDATE_JOINT_MATRICES_H
+
+// PURPOSE: per-frame skeletal joint skin-matrix upload (#605 Phase 2.2 / #1603).
+//   For every C_Skeleton, computes each joint's skin matrix
+//   (jointWorld × bindInverse, IRPrefab::Skeleton::skinMatrix) and writes it into
+//   the existing binding-18 EntityTransformBuffer that UPDATE_VOXEL_POSITIONS_GPU
+//   (#1396) already consumes. Cost is O(joints), not O(voxels). Phase 2.3 (#1605)
+//   then seeds each skinned voxel's transform slot (`.w`) to `slotBase + bone_id`
+//   so the existing c_update_voxel_positions prepass skins it with no new shader.
+//
+// WHY NO NEW BUFFER: the architect's #605 re-plan unifies skeletal skinning onto
+//   the #1396 prepass — a per-bone skin matrix is exactly the per-voxel transform
+//   indirection the prepass already does, with the slot pointing at a bone instead
+//   of an entity. So this writes into the SAME binding-18 buffer; the speculative
+//   binding-21 JointTransformBuffer is retired for the voxel path in Phase 2.4.
+//
+// SHARED-BUDGET PARTITION (no clobber by construction): binding-18's 4096 slots
+//   are shared between dynamic voxel-set transforms and joint blocks. To keep the
+//   prepass's contiguous `[0, maxSlotUsed_]` per-frame re-upload from ever
+//   clobbering a joint slot, the two allocators own disjoint regions:
+//     - voxel-set single slots grow UP from 0, capped at kJointTransformSlotBase
+//       (UPDATE_VOXEL_POSITIONS_GPU::acquireTransformSlot).
+//     - joint blocks are carved DOWN from kMaxGpuVoxelTransforms by this system's
+//       acquireJointBlock (a contiguous block per skeleton; bone_id is the offset
+//       within the block).
+//   Each system uploads only its own region, so the two never overwrite each
+//   other — and Metal's subData orphan copies head+tail, so the disjoint partial
+//   uploads compose on both backends.
+//
+// SCHEDULING: register in the RENDER pipeline AFTER PROPAGATE_TRANSFORM (so each
+//   joint's C_WorldTransform is the current posed transform) and BEFORE
+//   UPDATE_VOXEL_POSITIONS_GPU (so binding 18 holds the joint matrices when the
+//   prepass reads them in Phase 2.3). A creation that authors skeletons must
+//   register UPDATE_VOXEL_POSITIONS_GPU too — this system reuses its buffer.
+//
+// ITERATION: iterates joints via the <C_Joint, C_WorldTransform> archetype, so a
+//   joint's world transform arrives by dense-column iteration with NO per-entity
+//   getComponent. The per-skeleton rest pose (bindPose_) and target slot are
+//   gathered once per frame in beginTick (reading C_Skeleton's own fields, also
+//   no foreign getComponent) into a joint -> (bind, slot) map the tick looks up.
+//
+// DEPENDENCIES: C_Skeleton (+ bindPose_), C_Joint, C_WorldTransform,
+//   IRPrefab::Skeleton::skinMatrix (#1602), GpuVoxelTransform / binding-18 slot
+//   constants (ir_render_types.hpp). No shader, no new GPU resource of its own.
+
+#include <irreden/ir_render.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <irreden/common/components/component_world_transform.hpp>
+#include <irreden/voxel/components/component_joint.hpp>
+#include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/voxel/skeleton.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+using namespace IRComponents;
+using namespace IRMath;
+using namespace IRRender;
+
+namespace IRSystem {
+
+template <> struct System<UPDATE_JOINT_MATRICES> {
+    // binding 18 — the shared EntityTransformBuffer created by
+    // UPDATE_VOXEL_POSITIONS_GPU. Resolved lazily on first upload because this
+    // system's create() may run before the prepass's during pipeline setup, so
+    // the named resource need not exist yet at create() time.
+    Buffer *transformBuf_ = nullptr;
+
+    // Per-frame CPU staging for the reserved joint region, indexed by
+    // (absoluteSlot - kJointTransformSlotBase). Each active block is
+    // identity-filled in beginTick (so severance holes / un-bind-posed joints
+    // upload identity), occupied joints overwrite their slot in tick, and the
+    // touched range uploads once in endTick.
+    std::vector<GpuVoxelTransform> jointStaging_;
+
+    // joint entity -> (rest pose, absolute binding-18 slot), rebuilt each
+    // beginTick from the live C_Skeleton set. Only joints that have a bind-pose
+    // entry are present; everything else stays at the identity-filled slot.
+    // A vector (sorted by joint id at the end of beginTick, binary-searched in
+    // tick) rather than a hash map: clear() keeps its capacity, so the per-frame
+    // rebuild allocates nothing after warmup (a map churns a node per joint).
+    struct JointTarget {
+        IREntity::EntityId joint_ = IREntity::kNullEntity;
+        IRMath::SQT bind_;
+        std::uint32_t slot_ = 0;
+    };
+    std::vector<JointTarget> jointTargets_;
+
+    // Persistent per-skeleton slot block, so a skeleton keeps the same slots
+    // across frames (Phase 2.3 seeds voxels against this base once) and its
+    // block is released when the skeleton disappears. base_ is joint 0's slot.
+    struct SlotBlock {
+        std::uint32_t base_ = 0;
+        std::uint32_t count_ = 0;
+    };
+    std::unordered_map<IREntity::EntityId, SlotBlock> skeletonBlocks_;
+    // Reused across frames: rig roots seen this beginTick (for the release diff).
+    std::unordered_set<IREntity::EntityId> seenSkeletons_;
+
+    // Block allocator over the reserved joint region
+    // [kJointTransformSlotBase, kMaxGpuVoxelTransforms): a down-counter plus a
+    // free-list keyed by block size (a skeleton's joint count rarely changes, so
+    // exact-size recycling is the common path). Disjoint from the prepass's
+    // up-counter by the kJointTransformSlotBase partition, so the two cannot
+    // hand out the same slot.
+    std::uint32_t nextJointBlockSlot_ = static_cast<std::uint32_t>(kMaxGpuVoxelTransforms);
+    std::unordered_map<std::uint32_t, std::vector<std::uint32_t>> freeJointBlocks_;
+
+    // Local-slot range into jointStaging_ touched this frame, for a tight upload.
+    int usedLo_ = -1;
+    int usedHi_ = -1;
+
+    // Absolute base slot of a contiguous `count`-slot block, or
+    // kVoxelTransformStatic when the reserved joint region is exhausted (the
+    // skeleton then renders unskinned rather than aliasing another's slots).
+    std::uint32_t acquireJointBlock(std::uint32_t count) {
+        if (count == 0) {
+            return kVoxelTransformStatic;
+        }
+        auto recycled = freeJointBlocks_.find(count);
+        if (recycled != freeJointBlocks_.end() && !recycled->second.empty()) {
+            const std::uint32_t base = recycled->second.back();
+            recycled->second.pop_back();
+            return base;
+        }
+        if (nextJointBlockSlot_ < static_cast<std::uint32_t>(kJointTransformSlotBase) + count) {
+            return kVoxelTransformStatic; // reserved joint region exhausted
+        }
+        nextJointBlockSlot_ -= count;
+        return nextJointBlockSlot_;
+    }
+
+    void releaseJointBlock(std::uint32_t base, std::uint32_t count) {
+        if (count == 0) {
+            return;
+        }
+        freeJointBlocks_[count].push_back(base);
+    }
+
+    // jointStaging_ index for an absolute binding-18 slot.
+    static int localSlot(std::uint32_t absoluteSlot) {
+        return static_cast<int>(absoluteSlot) - kJointTransformSlotBase;
+    }
+
+    void beginTick() {
+        if (jointStaging_.size() != static_cast<std::size_t>(kMaxGpuJointTransforms)) {
+            jointStaging_.assign(kMaxGpuJointTransforms, GpuVoxelTransform{});
+        }
+        jointTargets_.clear();
+        seenSkeletons_.clear();
+        usedLo_ = -1;
+        usedHi_ = -1;
+
+        IREntity::forEachComponent<C_Skeleton>(
+            [this](IREntity::EntityId rigRoot, C_Skeleton &skeleton) {
+                const std::uint32_t jointCount =
+                    static_cast<std::uint32_t>(skeleton.joints_.size());
+                if (jointCount == 0) {
+                    return; // not yet rigged — nothing to upload
+                }
+                seenSkeletons_.insert(rigRoot);
+
+                // Reuse the skeleton's existing block; (re)allocate when it is
+                // new or its joint count changed (release-then-acquire).
+                SlotBlock &block = skeletonBlocks_[rigRoot];
+                if (block.count_ != jointCount) {
+                    if (block.count_ != 0) {
+                        releaseJointBlock(block.base_, block.count_);
+                    }
+                    block.base_ = acquireJointBlock(jointCount);
+                    block.count_ = (block.base_ == kVoxelTransformStatic) ? 0 : jointCount;
+                }
+                if (block.base_ == kVoxelTransformStatic) {
+                    return; // out of joint-slot budget — skeleton stays unskinned
+                }
+
+                const int loLocal = localSlot(block.base_);
+                const int hiLocal = loLocal + static_cast<int>(jointCount);
+                // Identity-fill the block so severance holes (kNullEntity) and
+                // not-yet-bind-posed joints upload identity (no deformation).
+                for (int s = loLocal; s < hiLocal; ++s) {
+                    jointStaging_[s].modelToWorld_ = IRMath::mat4(1.0f);
+                }
+                usedLo_ = (usedLo_ < 0) ? loLocal : IRMath::min(usedLo_, loLocal);
+                usedHi_ = IRMath::max(usedHi_, hiLocal);
+
+                // bindPose_ parallels joints_; a joint with no bind entry stays
+                // identity (handled by the fill above + the skip here).
+                const std::size_t bindCount = skeleton.bindPose_.size();
+                for (std::uint32_t i = 0; i < jointCount; ++i) {
+                    const IREntity::EntityId joint = skeleton.joints_[i];
+                    if (joint == IREntity::kNullEntity ||
+                        i >= static_cast<std::uint32_t>(bindCount)) {
+                        continue;
+                    }
+                    jointTargets_.push_back(
+                        JointTarget{joint, skeleton.bindPose_[i], block.base_ + i});
+                }
+            }
+        );
+
+        // Sort by joint id so tick can binary-search (one O(N log N) pass here
+        // beats a per-joint hash map's per-frame node churn).
+        std::sort(
+            jointTargets_.begin(),
+            jointTargets_.end(),
+            [](const JointTarget &a, const JointTarget &b) { return a.joint_ < b.joint_; }
+        );
+
+        // Release blocks for skeletons that disappeared since last frame.
+        for (auto it = skeletonBlocks_.begin(); it != skeletonBlocks_.end();) {
+            if (seenSkeletons_.count(it->first) == 0) {
+                releaseJointBlock(it->second.base_, it->second.count_);
+                it = skeletonBlocks_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    void tick(IREntity::EntityId joint, C_Joint &, const C_WorldTransform &world) {
+        const auto target = std::lower_bound(
+            jointTargets_.begin(),
+            jointTargets_.end(),
+            joint,
+            [](const JointTarget &entry, IREntity::EntityId id) { return entry.joint_ < id; }
+        );
+        if (target == jointTargets_.end() || target->joint_ != joint) {
+            return; // not a bind-posed joint of any current skeleton
+        }
+        jointStaging_[localSlot(target->slot_)].modelToWorld_ =
+            IRPrefab::Skeleton::skinMatrix(
+                IRMath::SQT{world.scale_, world.rotation_, world.translation_},
+                target->bind_
+            );
+    }
+
+    void endTick() {
+        if (usedHi_ < 0) {
+            return; // no skeletons this frame — nothing to upload
+        }
+        if (transformBuf_ == nullptr) {
+            // Asserts if absent: registering this system without
+            // UPDATE_VOXEL_POSITIONS_GPU (which creates the buffer) is a
+            // pipeline misconfiguration, not a silent no-op.
+            transformBuf_ = IRRender::getNamedResource<Buffer>("EntityTransformBuffer");
+        }
+        // One partial upload of the touched joint region. Slots in any
+        // freed-block gap inside [usedLo_, usedHi_) carry stale data but are
+        // referenced by no voxel, so re-uploading them is harmless.
+        const std::size_t offset =
+            static_cast<std::size_t>(kJointTransformSlotBase + usedLo_) * sizeof(GpuVoxelTransform);
+        const std::size_t size =
+            static_cast<std::size_t>(usedHi_ - usedLo_) * sizeof(GpuVoxelTransform);
+        transformBuf_->subData(static_cast<std::ptrdiff_t>(offset), size, &jointStaging_[usedLo_]);
+    }
+
+    static SystemId create() {
+        // No shader, no buffer of its own — the skin matrices land in
+        // UPDATE_VOXEL_POSITIONS_GPU's EntityTransformBuffer (resolved lazily in
+        // endTick) and the prepass's existing shader applies them per voxel.
+        return registerSystem<UPDATE_JOINT_MATRICES, C_Joint, C_WorldTransform>(
+            "UpdateJointMatrices"
+        );
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_UPDATE_JOINT_MATRICES_H */

--- a/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
@@ -111,7 +111,12 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
             recycledSlots_.pop_back();
             return slot;
         }
-        if (nextFreeSlot_ < static_cast<std::uint32_t>(kMaxGpuVoxelTransforms)) {
+        // Stop at kJointTransformSlotBase, not kMaxGpuVoxelTransforms: the
+        // reserved high region [kJointTransformSlotBase, kMaxGpuVoxelTransforms)
+        // belongs to UPDATE_JOINT_MATRICES (#1603). Partitioning the shared
+        // binding-18 budget keeps this system's contiguous `[0, maxSlotUsed_]`
+        // re-upload from ever clobbering a joint slot.
+        if (nextFreeSlot_ < static_cast<std::uint32_t>(kJointTransformSlotBase)) {
             return nextFreeSlot_++;
         }
         return kVoxelTransformStatic; // budget exhausted — caller stays CPU-direct

--- a/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
+++ b/engine/prefabs/irreden/render/systems/system_update_voxel_positions_gpu.hpp
@@ -123,7 +123,12 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
     }
 
     void releaseTransformSlot(std::uint32_t slot) {
-        if (slot < static_cast<std::uint32_t>(kMaxGpuVoxelTransforms)) {
+        // Guard at kJointTransformSlotBase: a joint-region slot passed here
+        // (corrupted caller) must not enter the voxel-set recycle stack and
+        // later be re-issued to a voxel set, which would quietly corrupt the
+        // partition. kVoxelTransformStatic (0xFFFFFFFF) is always > this bound
+        // so it is silently dropped as well.
+        if (slot < static_cast<std::uint32_t>(kJointTransformSlotBase)) {
             recycledSlots_.push_back(slot);
         }
     }
@@ -145,8 +150,14 @@ template <> struct System<UPDATE_VOXEL_POSITIONS_GPU> {
             return;
         }
         const std::uint32_t slot = voxelSet.gpuTransformSlot_;
-        if (slot >= static_cast<std::uint32_t>(kMaxGpuVoxelTransforms)) {
-            return; // out of transform-slot budget — set stays CPU-direct
+        // kJointTransformSlotBase, not kMaxGpuVoxelTransforms: a mis-seeded
+        // slot in the joint-reserved region [kJointTransformSlotBase,
+        // kMaxGpuVoxelTransforms) must not write transforms_[slot] here —
+        // that would drag maxSlotUsed_ into the joint region and the
+        // [0, maxSlotUsed_] re-upload would clobber freshly-written joint
+        // matrices from UPDATE_JOINT_MATRICES in the same tick.
+        if (slot >= static_cast<std::uint32_t>(kJointTransformSlotBase)) {
+            return; // sentinel or joint-reserved region — set stays CPU-direct
         }
         // CPU mirror of the GLSL/Metal `transform * localPos`: sqtToMat4 is
         // bit-identical to the shader-side helper, so the same operands classify

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -320,6 +320,20 @@ constexpr std::uint32_t kVoxelTransformStatic = 0xFFFFFFFFu;
 /// Matches the `GpuVoxelTransform` array size allocated by `UPDATE_VOXEL_POSITIONS_GPU`.
 constexpr int kMaxGpuVoxelTransforms = 4096;
 
+/// Skeletal joint transforms (#605 Phase 2.2 / #1603) share the same binding-18
+/// `EntityTransformBuffer`, NOT a second buffer — the #1396 prepass that consumes
+/// per-voxel transform slots is the same operation a per-bone skin matrix needs.
+/// The 4096-slot budget is partitioned so the two allocators can't collide and
+/// the prepass's contiguous `[0, maxSlotUsed_]` re-upload can never clobber a
+/// joint slot: dynamic voxel-set slots grow UP from 0 and stop at
+/// `kJointTransformSlotBase`; `UPDATE_JOINT_MATRICES` carves contiguous joint
+/// blocks DOWN from `kMaxGpuVoxelTransforms`. The reserved high region holds
+/// `kMaxGpuJointTransforms` slots — e.g. ~34 thirty-joint skeletons, or 1024
+/// single-joint rigs — leaving the low region for voxel-set transforms.
+constexpr int kMaxGpuJointTransforms = 1024;
+/// First slot of the reserved joint region; voxel-set transforms use `[0, this)`.
+constexpr int kJointTransformSlotBase = kMaxGpuVoxelTransforms - kMaxGpuJointTransforms;
+
 /// One per GPU-transformed voxel-set, indexed by `C_VoxelSetNew::gpuTransformSlot_`
 /// (and by each owned voxel's per-voxel transform index). The compute prepass
 /// computes `world = modelToWorld_ * vec4(localPos, 1)`, so this carries the full

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -144,6 +144,13 @@ enum SystemName {
     DEBUG_OVERLAY,
     RENDERING_VELOCITY_2D_ISO,
     TEXTURE_SCROLL,
+    // Per-frame skeletal joint skin-matrix upload (#605 Phase 2.2 / #1603).
+    // Writes each C_Skeleton joint's skinMatrix into the binding-18
+    // EntityTransformBuffer (a contiguous block per skeleton, from the shared
+    // #1396 budget). MUST run after PROPAGATE_TRANSFORM (joint world transforms
+    // current) and BEFORE UPDATE_VOXEL_POSITIONS_GPU (so binding 18 is filled
+    // when the prepass skins per-voxel bone slots in #605 Phase 2.3).
+    UPDATE_JOINT_MATRICES,
     UPDATE_VOXEL_POSITIONS_GPU,
     UPDATE_GPU_PARTICLES,
     RENDER_GPU_PARTICLES_TO_TRIXEL,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(IrredenEngineTest
   ecs/entity_manager_test.cpp
   ecs/grid_rotation_test.cpp
   ecs/hitbox_2d_gui_test.cpp
+  ecs/joint_matrix_upload_test.cpp
   ecs/modifier_quat_runtime_test.cpp
   ecs/modifier_runtime_test.cpp
   ecs/modifier_types_test.cpp

--- a/test/ecs/joint_matrix_upload_test.cpp
+++ b/test/ecs/joint_matrix_upload_test.cpp
@@ -1,0 +1,211 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/entity/entity_manager.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_render.hpp>
+
+#include <irreden/asset/rig_format.hpp>
+#include <irreden/common/components/component_world_transform.hpp>
+#include <irreden/render/systems/system_update_joint_matrices.hpp>
+#include <irreden/voxel/components/component_joint.hpp>
+#include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/voxel/rig_bridge.hpp>
+
+// #1603 — SYSTEM_UPDATE_JOINT_MATRICES (#605 Phase 2.2).
+//
+// These tests exercise the CPU side of the joint-matrix uploader without a GPU
+// device: the high-region block allocator, and the per-skeleton staging fill
+// (identity at bind pose, severance holes identity, correct bone->slot routing).
+// The actual binding-18 subData upload (endTick) needs a render device and is
+// covered at runtime by the skeletal demo (#1611); endTick is never called here.
+
+namespace {
+
+using JointMatrices = IRSystem::System<IRSystem::UPDATE_JOINT_MATRICES>;
+constexpr float kTolerance = 1e-4f;
+
+// Straight 3-bone chain along +X (shared with skeleton_skinning_test): rest
+// world translations are (0,0,0), (2,0,0), (5,0,0).
+IRAsset::Rig makeChainRig() {
+    IRAsset::Rig rig;
+    rig.joints_.resize(3);
+    rig.joints_[0].parentIndex_ = 0;
+    rig.joints_[0].translation_ = IRMath::vec4(0.0f, 0.0f, 0.0f, 0.0f);
+    rig.joints_[1].parentIndex_ = 0;
+    rig.joints_[1].translation_ = IRMath::vec4(2.0f, 0.0f, 0.0f, 0.0f);
+    rig.joints_[2].parentIndex_ = 1;
+    rig.joints_[2].translation_ = IRMath::vec4(3.0f, 0.0f, 0.0f, 0.0f);
+    return rig;
+}
+
+void expectMat4Near(const IRMath::mat4 &actual, const IRMath::mat4 &expected) {
+    for (int col = 0; col < 4; ++col) {
+        for (int row = 0; row < 4; ++row) {
+            EXPECT_NEAR(actual[col][row], expected[col][row], kTolerance)
+                << "mismatch at [" << col << "][" << row << "]";
+        }
+    }
+}
+
+// ---- Block allocator (no entity manager / GPU needed) --------------------
+
+TEST(JointBlockAllocator, BlocksAreContiguousInsideReservedRegion) {
+    JointMatrices sys;
+    const std::uint32_t a = sys.acquireJointBlock(30);
+    const std::uint32_t b = sys.acquireJointBlock(10);
+
+    ASSERT_NE(a, IRRender::kVoxelTransformStatic);
+    ASSERT_NE(b, IRRender::kVoxelTransformStatic);
+    // Both blocks live in the reserved high region and never reach into the
+    // voxel-set region [0, kJointTransformSlotBase).
+    EXPECT_GE(a, static_cast<std::uint32_t>(IRRender::kJointTransformSlotBase));
+    EXPECT_LE(a + 30, static_cast<std::uint32_t>(IRRender::kMaxGpuVoxelTransforms));
+    EXPECT_GE(b, static_cast<std::uint32_t>(IRRender::kJointTransformSlotBase));
+    // Disjoint blocks.
+    EXPECT_TRUE(a >= b + 10 || b >= a + 30);
+}
+
+TEST(JointBlockAllocator, ExactSizeBlocksRecycleAfterRelease) {
+    JointMatrices sys;
+    const std::uint32_t a = sys.acquireJointBlock(30);
+    sys.releaseJointBlock(a, 30);
+    // Same-size reacquire reuses the freed block rather than carving fresh.
+    EXPECT_EQ(sys.acquireJointBlock(30), a);
+}
+
+TEST(JointBlockAllocator, ExhaustionReturnsStaticSentinel) {
+    JointMatrices sys;
+    const std::uint32_t whole =
+        sys.acquireJointBlock(static_cast<std::uint32_t>(IRRender::kMaxGpuJointTransforms));
+    ASSERT_NE(whole, IRRender::kVoxelTransformStatic);
+    EXPECT_EQ(whole, static_cast<std::uint32_t>(IRRender::kJointTransformSlotBase));
+    // Region full — one more slot is denied (caller renders unskinned).
+    EXPECT_EQ(sys.acquireJointBlock(1), IRRender::kVoxelTransformStatic);
+}
+
+// ---- Staging fill (headless entity manager, no GPU) ----------------------
+
+class JointMatrixUploadTest : public testing::Test {
+  protected:
+    // Creates a rig-root entity carrying C_Skeleton + one C_Joint entity per
+    // pose entry, with each joint's C_WorldTransform set to `worlds[i]` (the
+    // stand-in for PROPAGATE_TRANSFORM's output). joints_[i] == kNullEntity for
+    // any i in `holes` (a severed slot). Returns the joint entity ids.
+    std::vector<IREntity::EntityId> buildSkeleton(
+        const std::vector<IRMath::SQT> &bind,
+        const std::vector<IRMath::SQT> &worlds,
+        const std::vector<int> &holes = {}
+    ) {
+        std::vector<IREntity::EntityId> joints;
+        for (std::size_t i = 0; i < bind.size(); ++i) {
+            const bool isHole =
+                std::find(holes.begin(), holes.end(), static_cast<int>(i)) != holes.end();
+            if (isHole) {
+                joints.push_back(IREntity::kNullEntity);
+                continue;
+            }
+            const IREntity::EntityId joint = IREntity::createEntity(IRComponents::C_Joint{});
+            auto &world = IREntity::getComponent<IRComponents::C_WorldTransform>(joint);
+            world.scale_ = worlds[i].scale_;
+            world.rotation_ = worlds[i].rotation_;
+            world.translation_ = worlds[i].translation_;
+            joints.push_back(joint);
+        }
+        IRComponents::C_Skeleton skeleton;
+        skeleton.joints_ = joints;
+        skeleton.bindPose_ = bind;
+        IREntity::createEntity(skeleton);
+        return joints;
+    }
+
+    // Runs one frame of the system over the live joints.
+    void runFrame(JointMatrices &sys, const std::vector<IREntity::EntityId> &joints) {
+        sys.beginTick();
+        for (const IREntity::EntityId joint : joints) {
+            if (joint == IREntity::kNullEntity) {
+                continue;
+            }
+            IRComponents::C_Joint tag;
+            auto &world = IREntity::getComponent<IRComponents::C_WorldTransform>(joint);
+            sys.tick(joint, tag, world);
+        }
+    }
+
+    IREntity::EntityManager m_entity_manager;
+};
+
+TEST_F(JointMatrixUploadTest, SlotsAreIdentityAtBindPose) {
+    const std::vector<IRMath::SQT> bind = IRPrefab::Rig::bindPose(makeChainRig());
+    const std::vector<IREntity::EntityId> joints = buildSkeleton(bind, bind); // posed == rest
+
+    JointMatrices sys;
+    runFrame(sys, joints);
+
+    ASSERT_EQ(sys.skeletonBlocks_.size(), 1u);
+    const std::uint32_t base = sys.skeletonBlocks_.begin()->second.base_;
+    EXPECT_EQ(sys.skeletonBlocks_.begin()->second.count_, bind.size());
+    for (std::uint32_t i = 0; i < bind.size(); ++i) {
+        expectMat4Near(
+            sys.jointStaging_[JointMatrices::localSlot(base + i)].modelToWorld_,
+            IRMath::mat4(1.0f)
+        );
+    }
+}
+
+TEST_F(JointMatrixUploadTest, BoneIndexMapsToBasePlusIndex) {
+    const std::vector<IRMath::SQT> bind = IRPrefab::Rig::bindPose(makeChainRig());
+
+    // Pose joint 1: 90° about +Z, away from its rest transform.
+    std::vector<IRMath::SQT> worlds = bind;
+    worlds[1].rotation_ = IRMath::quatAxisAngle(IRMath::vec3(0.0f, 0.0f, 1.0f), IRMath::kHalfPi);
+
+    const std::vector<IREntity::EntityId> joints = buildSkeleton(bind, worlds);
+    JointMatrices sys;
+    runFrame(sys, joints);
+
+    const std::uint32_t base = sys.skeletonBlocks_.begin()->second.base_;
+    // Each bone i lands at base + i and holds skinMatrix(world_i, bind_i).
+    for (std::uint32_t i = 0; i < bind.size(); ++i) {
+        expectMat4Near(
+            sys.jointStaging_[JointMatrices::localSlot(base + i)].modelToWorld_,
+            IRPrefab::Skeleton::skinMatrix(worlds[i], bind[i])
+        );
+    }
+    // The posed joint is genuinely non-identity (guards against a no-op fill).
+    const IRMath::mat4 posed =
+        sys.jointStaging_[JointMatrices::localSlot(base + 1)].modelToWorld_;
+    EXPECT_GT(IRMath::abs(posed[0][0] - 1.0f) + IRMath::abs(posed[1][1] - 1.0f), kTolerance);
+}
+
+TEST_F(JointMatrixUploadTest, SeveranceHoleStaysIdentity) {
+    const std::vector<IRMath::SQT> bind = IRPrefab::Rig::bindPose(makeChainRig());
+    // Pose every joint so an un-cleared slot would be visibly non-identity.
+    std::vector<IRMath::SQT> worlds = bind;
+    for (IRMath::SQT &w : worlds) {
+        w.rotation_ = IRMath::quatAxisAngle(IRMath::vec3(0.0f, 0.0f, 1.0f), IRMath::kHalfPi);
+    }
+    const std::vector<IREntity::EntityId> joints = buildSkeleton(bind, worlds, /*holes=*/{1});
+
+    JointMatrices sys;
+    runFrame(sys, joints);
+
+    const std::uint32_t base = sys.skeletonBlocks_.begin()->second.base_;
+    // The severed slot uploads identity even though its neighbours are posed.
+    expectMat4Near(
+        sys.jointStaging_[JointMatrices::localSlot(base + 1)].modelToWorld_,
+        IRMath::mat4(1.0f)
+    );
+    // The live neighbours (bones 0 and 2) are posed, so their slots are filled
+    // and non-identity — confirms the hole was skipped, not the whole block.
+    for (const std::uint32_t boneIndex : {0u, 2u}) {
+        const IRMath::mat4 &m =
+            sys.jointStaging_[JointMatrices::localSlot(base + boneIndex)].modelToWorld_;
+        EXPECT_GT(IRMath::abs(m[0][0] - 1.0f) + IRMath::abs(m[1][1] - 1.0f), kTolerance);
+    }
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- New render system `UPDATE_JOINT_MATRICES` (#605 Phase 2.2): per `C_Skeleton`, writes each joint's `IRPrefab::Skeleton::skinMatrix` (jointWorld × bindInverse) into the **existing** binding-18 `EntityTransformBuffer` the #1396 voxel-position prepass already consumes — no second buffer. Phase 2.3 (#1605) then seeds each skinned voxel's `.w` to `slotBase + bone_id` so the existing `c_update_voxel_positions` prepass skins it with no new shader.
- Iterates `<C_Joint, C_WorldTransform>` so joint world transforms arrive by dense iteration (no per-joint `getComponent`); the rest pose + target slot per joint are gathered once in `beginTick` from each skeleton's own `bindPose_` into a **reused, sorted vector** the tick binary-searches (allocation-free after warmup). Severance holes (`kNullEntity`) and not-yet-bind-posed joints upload identity.
- The shared 4096-slot binding-18 budget is **partitioned** so the prepass's contiguous `[0, maxSlotUsed_]` re-upload can never clobber a joint slot: voxel-set slots grow up from 0 (capped at `kJointTransformSlotBase`), joint blocks are carved down from `kMaxGpuVoxelTransforms`. Caps the prepass's `acquireTransformSlot` at the partition.
- Headless gtest: block allocator (contiguity / recycling / exhaustion), identity-at-bind-pose, bone→slot routing, severance holes.

## Test plan
- [x] `IrredenEngineTest` builds; `JointBlockAllocator.*` + `JointMatrixUploadTest.*` pass (6/6, macOS).
- [x] `IRShapeDebug` builds; `--gpu-voxel-smoke --auto-screenshot` runs clean (prepass slot-cap is a no-op below 3072 GPU-transformed sets).
- [ ] linux-debug cross-host build + smoke.

## Notes for reviewer
- **Render-loop / screenshots skipped deliberately:** provably no runtime effect on existing demos. The system is not yet registered in any pipeline (the skeletal demo #1611 wires it; it must run after `PROPAGATE_TRANSFORM` and before `UPDATE_VOXEL_POSITIONS_GPU`), and the prepass slot-cap (4096→3072) is a no-op below 3072 GPU-transformed voxel sets.
- **Slot base for Phase 2.3:** the per-skeleton block base is tracked system-locally (`skeletonBlocks_`); #1605 exposes it (a `C_Skeleton` field or an accessor) to seed per-voxel `.w`. Kept off `C_Skeleton` here to avoid putting render-slot state on the rig component and to avoid a textual conflict with #1604 (joint authoring).
- **Considered + deferred (dedup):** the joint block allocator shares ~80% of its shape with the prepass's `acquireTransformSlot`, but they differ (up single-slot vs down block, recycle stack vs size-keyed free-list, opposite regions). A shared `SlotAllocator` template would over-abstract for two callers and widen the change on the load-bearing #1396 system; cross-referenced by comment instead.
- **Stale doc owned by Phase 2.4 (#1606):** `voxel/CLAUDE.md` "Entity-based joints" still cites the binding-21 `kBufferIndex_JointTransforms`; the architect-locked direction is binding-18 (per the same file's "Bind pose" subsection + this PR). #1606 retires binding-21 and rewrites that prose — left untouched here to avoid conflicting with #1604.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/1632

Closes #1603

🤖 Generated with [Claude Code](https://claude.com/claude-code)