### PR TITLE
fleet: cut heavy tier over to fable 5 with opus 4.8 fallback

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -314,15 +314,26 @@ is in `role-opus-worker.md` (escalate + resume) and the shared
 ("Handling `fleet:design-blocked` PRs"), which `role-opus-architect.md`
 wraps.
 
-### Model split: Opus for core, Sonnet for the fleet
+### Model split: heavy tier for core, Sonnet for the fleet
 
-The user has much more Sonnet budget than Opus budget. Spend each where it
-pays off. Both tiers run the 1M-token context variant; the exact model
-versions are pinned in `scripts/fleet/fleet-up` (`OPUS_MODEL` /
-`SONNET_MODEL`), not here — bump there when moving the fleet to a new
-release.
+The user has much more light-tier budget than heavy-tier budget. Spend
+each where it pays off.
 
-**Opus 4.8** — use for:
+The tier *names* are historical: role slugs (`opus-worker`), labels
+(`fleet:opus` / `fleet:sonnet`), and issue `Model:` fields say "opus" /
+"sonnet" but mean **heavy tier** / **light tier** — they don't pin the
+literal model. The heavy tier currently runs **Fable 5**; `fleet-up`
+resolves it at boot from a candidate ladder (`HEAVY_MODEL_CANDIDATES`:
+Fable 5 [1m] → Fable 5 → Opus 4.8 [1m]) so the fleet falls back to Opus
+automatically once the plan no longer covers Fable. Dispatched heavy
+iterations also carry `--fallback-model` for mid-session resilience.
+The heavy tier runs the 1M-token context variant; exact strings live in
+`scripts/fleet/fleet-up`, not here — bump there when moving the fleet
+to a new release, or pin with `FLEET_HEAVY_MODEL` in
+`~/.fleet/fleet-up.conf`. When writing `Model:` fields in issues, keep
+using `opus` (the tier name); `fable` is accepted as an alias.
+
+**Heavy tier (Fable 5 → Opus 4.8 fallback)** — use for:
 
 - Core engine architecture. ECS design, ownership and lifetime rules,
   render pipeline decisions.
@@ -334,7 +345,7 @@ release.
 - **Final review** on any PR that touches core-engine invariants, even after
   a Sonnet first pass.
 
-**Sonnet 4.6** — use for:
+**Light tier (Sonnet 4.6)** — use for:
 
 - Writing unit tests against a clear spec (test generation is pattern-heavy
   and the compiler/tests are the oracle).
@@ -350,12 +361,12 @@ release.
 
 When labeling issues, apply `fleet:opus` or `fleet:sonnet`. If a
 Sonnet agent picks up an issue and it turns out to be subtler than
-expected, stop and escalate — the cost of running out your Opus
+expected, stop and escalate — the cost of running out your heavy-tier
 budget on routine work is much higher than the cost of one handoff.
 
 Two-tier review is legitimate and encouraged: Sonnet catches the obvious
-stuff cheaply, Opus looks at what's left. Don't skip the Opus second pass
-for anything in the "Opus" list above.
+stuff cheaply, the heavy tier looks at what's left. Don't skip the heavy
+second pass for anything in the heavy-tier list above.
 
 ### Cross-platform parity (OpenGL ↔ Metal)
 

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -67,10 +67,12 @@ LOOP_INTERVAL="${4:-}"
 # is set by fleet-up (architects) and fleet-dispatcher (dispatched roles),
 # which export FLEET_EFFORT_<ROLE>; the model-derived default below only
 # fires when babysit is run by hand without those exports in the env.
-# Opus defaults to xhigh — the architects babysit launches do the heavy
-# design / render reasoning, which is where xhigh earns its budget; sonnet
-# defaults to high (diminishing returns past that on its task mix).
+# Heavy-tier models (Fable, with Opus as its fallback) default to xhigh —
+# the architects babysit launches do the heavy design / render reasoning,
+# which is where xhigh earns its budget; sonnet defaults to high
+# (diminishing returns past that on its task mix).
 case "$MODEL" in
+    fable|claude-fable*) _effort_default="xhigh" ;;
     opus|claude-opus*) _effort_default="xhigh" ;;
     sonnet|claude-sonnet*) _effort_default="high" ;;
     *) _effort_default="high" ;;
@@ -371,15 +373,31 @@ stream_claude() {
     # reading like a fatal error even though claude actually exited 0.
     # The formatter recognizes a small allowlist of these and annotates
     # them as `⚠ [claude-warn]` instead of leaving them as raw red text.
+    #
+    # Heavy-tier runs (Fable, or Opus when pinned) carry the fallback
+    # chain fleet-up seeded into the tmux server env, so a print-mode
+    # iteration survives the primary model being overloaded or dropping
+    # off the plan. Gated to heavy model strings: handing the chain to a
+    # sonnet run would silently upgrade the light tier to a heavy model.
+    # (--fallback-model is print-only; the interactive architect launches
+    # below can't take it and rely on fleet-up's boot-time resolution.)
+    local _fallback_args=()
+    case "$MODEL" in
+        fable|claude-fable*|opus|claude-opus*)
+            if [[ -n "${HEAVY_MODEL_FALLBACK:-}" && "$HEAVY_MODEL_FALLBACK" != "$MODEL" ]]; then
+                _fallback_args=(--fallback-model "$HEAVY_MODEL_FALLBACK")
+            fi
+            ;;
+    esac
     if [[ -n "$STREAM_FORMATTER" ]]; then
-        claude --model "$MODEL" --effort "$EFFORT" \
+        claude --model "$MODEL" --effort "$EFFORT" ${_fallback_args[@]+"${_fallback_args[@]}"} \
             --output-format stream-json --include-partial-messages --verbose \
             "$@" 2>&1 | "$STREAM_FORMATTER"
     else
         # Fallback: plain claude with whatever the caller passed.
         # `--print` from the caller stays put, so worker exit semantics
         # are unchanged; only the live-pane visibility regresses.
-        claude --model "$MODEL" --effort "$EFFORT" "$@"
+        claude --model "$MODEL" --effort "$EFFORT" ${_fallback_args[@]+"${_fallback_args[@]}"} "$@"
     fi
 }
 

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -4,9 +4,11 @@
 #
 # Called by fleet-dispatcher via tmux send-keys. Arguments:
 #   $1  pane_key  e.g. "pane-3"
-#   $2  model     e.g. "sonnet[1m]" or "claude-opus-4-8[1m]"
+#   $2  model     e.g. "sonnet" or "claude-fable-5[1m]"
 #   $3  effort    e.g. "high" or "xhigh"
 #   $4  role      e.g. "sonnet-author"
+#   $5  fallback  optional --fallback-model chain (comma-separated) for
+#                 heavy-tier dispatches; empty for sonnet roles
 #
 # On usage-limit exit (exit code 2), writes a Unix-epoch timestamp to
 # ~/.fleet/state/rate-limit/<pane_key>.ts. fleet-dispatcher checks that
@@ -23,6 +25,7 @@ PANE_KEY="${1:?fleet-dispatch-wrap: missing pane_key}"
 MODEL="${2:?fleet-dispatch-wrap: missing model}"
 EFFORT="${3:?fleet-dispatch-wrap: missing effort}"
 ROLE="${4:?fleet-dispatch-wrap: missing role}"
+FALLBACK_MODEL="${5:-}"
 # Track fleet-dispatcher's STATE_DIR via the same env-var override so a
 # config change in one place propagates to both scripts.
 STATE_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}"
@@ -30,7 +33,10 @@ RATE_LIMIT_DIR="$STATE_DIR/rate-limit"
 
 # Expose the role's model tier so fleet-claim can enforce the model-tag gate.
 # fleet-claim refuses claims when FLEET_ROLE_MODEL != the task's Model: field.
-if [[ "$MODEL" == *opus* ]]; then
+# "opus" is the queue's historical name for the heavy tier — Fable serves
+# that tier now, so a fable model string must map to the opus tag or heavy
+# workers lose access to `Model: opus` tasks (and could claim sonnet ones).
+if [[ "$MODEL" == *opus* || "$MODEL" == *fable* ]]; then
     export FLEET_ROLE_MODEL=opus
 else
     export FLEET_ROLE_MODEL=sonnet
@@ -46,9 +52,16 @@ mkdir -p "$RATE_LIMIT_DIR"
 export FLEET_THROTTLE_FLAG="$RATE_LIMIT_DIR/$PANE_KEY.throttle-seen"
 rm -f "$FLEET_THROTTLE_FLAG"
 
-claude --model "$MODEL" --effort "$EFFORT" --print \
-    --output-format stream-json --include-partial-messages --verbose \
-    "/role-$ROLE live" | fleet-claude-stream
+# --fallback-model only exists in print mode, which is exactly this path.
+# When the dispatcher hands us a chain, claude retries the iteration on
+# the fallback model(s) if $MODEL is overloaded or no longer available.
+CLAUDE_ARGS=(--model "$MODEL" --effort "$EFFORT" --print
+    --output-format stream-json --include-partial-messages --verbose)
+if [[ -n "$FALLBACK_MODEL" ]]; then
+    CLAUDE_ARGS+=(--fallback-model "$FALLBACK_MODEL")
+fi
+
+claude "${CLAUDE_ARGS[@]}" "/role-$ROLE live" | fleet-claude-stream
 
 rc="${PIPESTATUS[0]}"
 TRIGGERS_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}/triggers"

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -296,21 +296,31 @@ DISPATCHED_ROLES=(
 # scout-driven trigger when human:approved-not-yet-queued issues appear.
 
 # Per-role default claude model. Inherited from fleet-up's exported
-# OPUS_MODEL / SONNET_MODEL (the single source of truth — bump there).
-# The fallbacks apply only when the dispatcher is run standalone (e.g.
-# for debugging) without fleet-up in the environment; keep them in sync
-# with fleet-up. The "[1m]" suffix selects the 1M-token context variant:
-# kept for Opus, dropped for Sonnet — sonnet[1m] errors "Usage credits
-# required for 1M context" on this plan (see fleet-up's OPUS_MODEL /
-# SONNET_MODEL comment for the full rationale).
-OPUS_MODEL="${OPUS_MODEL:-claude-opus-4-8[1m]}"
+# HEAVY_MODEL / SONNET_MODEL (the single source of truth — fleet-up
+# resolves the heavy tier at boot: Fable 5 preferred, Opus 4.8 floor;
+# OPUS_MODEL is the back-compat name for the same value). "opus" in the
+# role slugs below is the historical heavy-tier name, not a model pin.
+# The env-var defaults apply only when the dispatcher is run standalone
+# (e.g. for debugging) without fleet-up in the environment; keep them in
+# sync with fleet-up. Standalone defaults to Fable unprobed — safe
+# because every heavy dispatch carries --fallback-model (see
+# build_dispatch_command), so a plan without Fable degrades to the
+# fallback chain per-iteration. The "[1m]" suffix selects the 1M-token
+# context variant: kept for the heavy tier, dropped for Sonnet —
+# sonnet[1m] errors "Usage credits required for 1M context" on this plan
+# (see fleet-up's model-tier comment for the full rationale).
+HEAVY_MODEL="${HEAVY_MODEL:-${OPUS_MODEL:-claude-fable-5[1m]}}"
 SONNET_MODEL="${SONNET_MODEL:-sonnet}"
+HEAVY_MODEL_FALLBACK="${HEAVY_MODEL_FALLBACK-claude-opus-4-8[1m]}"
+if [[ "$HEAVY_MODEL_FALLBACK" == "$HEAVY_MODEL" ]]; then
+    HEAVY_MODEL_FALLBACK=""
+fi
 declare -A ROLE_MODEL=(
     ["sonnet-author"]="$SONNET_MODEL"
-    ["opus-worker"]="$OPUS_MODEL"
+    ["opus-worker"]="$HEAVY_MODEL"
     ["sonnet-reviewer"]="$SONNET_MODEL"
-    ["opus-reviewer"]="$OPUS_MODEL"
-    ["merger"]="$OPUS_MODEL"
+    ["opus-reviewer"]="$HEAVY_MODEL"
+    ["merger"]="$HEAVY_MODEL"
     ["smoke-worker"]="$SONNET_MODEL"
 )
 
@@ -846,7 +856,17 @@ build_dispatch_command() {
     local role="$1" pane_key="$2"
     local model="${ROLE_MODEL[$role]:-sonnet}"
     local effort="${ROLE_EFFORT[$role]:-high}"
-    printf ' fleet-dispatch-wrap %q %q %q %q\n' "$pane_key" "$model" "$effort" "$role"
+    # Heavy-tier dispatches carry the fallback chain so claude degrades
+    # per-iteration (--fallback-model, print-mode only) if the resolved
+    # model stops being available mid-session — e.g. the plan loses
+    # Fable access. Sonnet dispatches get no fallback: silently
+    # upgrading the light tier to a heavy model would invert the budget
+    # split.
+    local fallback=""
+    if [[ "$model" == "$HEAVY_MODEL" ]]; then
+        fallback="$HEAVY_MODEL_FALLBACK"
+    fi
+    printf ' fleet-dispatch-wrap %q %q %q %q %q\n' "$pane_key" "$model" "$effort" "$role" "$fallback"
 }
 
 dispatch_role() {

--- a/scripts/fleet/fleet-queue-backfill-model-labels
+++ b/scripts/fleet/fleet-queue-backfill-model-labels
@@ -63,9 +63,11 @@ for issue in issues:
         skipped += 1
         continue
 
-    m = re.search(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(opus|sonnet)', body, re.IGNORECASE)
+    # 'fable' aliases to the heavy tier: fleet:opus is a tier label, not a
+    # literal model pin (mirrors fleet-queue-ingest).
+    m = re.search(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(opus|sonnet|fable)', body, re.IGNORECASE)
     model = m.group(1).lower() if m else "opus"
-    label = f"fleet:{model}"
+    label = f"fleet:{'opus' if model == 'fable' else model}"
 
     if dry_run:
         print(f"  would add {label} to #{num}")

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -340,10 +340,13 @@ for issue in pending:
                      if _blocker_open(slug, ref, blocker_cache)]
 
     # Parse model from body. Default to fleet:opus on ambiguity — mirrors
-    # the safer default when model intent is unclear.
+    # the safer default when model intent is unclear. fleet:opus is the
+    # heavy-tier label, not a literal model pin — 'fable' is an accepted
+    # alias since Fable serves that tier now (see fleet-up's model-tier
+    # comment).
     model_match = MODEL_RE.search(body)
     model_text = (model_match.group(1).strip().lower() if model_match else '')
-    if 'opus' in model_text:
+    if 'opus' in model_text or 'fable' in model_text:
         model_label = 'fleet:opus'
     elif 'sonnet' in model_text:
         model_label = 'fleet:sonnet'

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -22,24 +22,44 @@ ENGINE="$HOME/src/IrredenEngine"
 GAME="$ENGINE/creations/game"
 SESSION="fleet"
 
-# Model versions — change these when bumping the fleet to a new release.
-# This is the single source of truth: they're exported below so the
-# nohup'd fleet-dispatcher inherits them for its transient roles (workers,
-# reviewers, merger, smoke), and launch_cmd threads OPUS_MODEL into the
-# architect panes via fleet-babysit. Bump here and every role moves.
+# Model tiers — change these when bumping the fleet to a new release.
 #
-# The "[1m]" suffix selects the 1M-token context variant. On this Max plan the
-# 1M-context beta is covered for Opus but NOT for Sonnet: a sonnet[1m] dispatch
-# dies instantly with "API Error: Usage credits required for 1M context" (turn
-# 1, $0.00). So Opus keeps [1m] (real headroom for long architect/worker
-# iterations); Sonnet uses the standard 200K alias, which its bounded
-# review/author iterations fit fine. (If you ever want sonnet[1m], enable usage
-# credits at claude.ai/settings/usage and re-add the suffix.) Opus is pinned to
-# a full version (the bare "opus" alias would silently upgrade); sonnet stays an
-# alias since its budget is cheap.
-OPUS_MODEL="claude-opus-4-8[1m]"
+# The queue's tier vocabulary is historical: role slugs (opus-worker),
+# labels (fleet:opus / fleet:sonnet), and issue `Model:` fields say
+# "opus" / "sonnet" but mean HEAVY tier / LIGHT tier — they no longer
+# pin the literal model. HEAVY_MODEL is whatever serves the heavy tier
+# today (Fable 5 while the plan covers it, Opus 4.8 once it doesn't);
+# SONNET_MODEL serves the light tier and really is Sonnet.
+#
+# The candidate ladder below is probed in order at fleet boot (see
+# resolve_heavy_model further down, after the session-exists early exit)
+# and the first available model wins. The last entry is the floor and is
+# accepted unprobed. Pin a specific model with FLEET_HEAVY_MODEL (env or
+# ~/.fleet/fleet-up.conf) to skip the probe entirely.
+#
+# This is the single source of truth: the resolved HEAVY_MODEL is
+# exported below so the nohup'd fleet-dispatcher inherits it for its
+# transient roles (workers, reviewers, merger, smoke), and launch_cmd
+# threads it into the architect panes via fleet-babysit. Bump here and
+# every role moves.
+#
+# The "[1m]" suffix selects the 1M-token context variant. On this Max plan
+# the 1M-context beta is covered for the heavy tier but NOT for Sonnet: a
+# sonnet[1m] dispatch dies instantly with "API Error: Usage credits
+# required for 1M context" (turn 1, $0.00). So the heavy tier keeps [1m]
+# (real headroom for long architect/worker iterations); Sonnet uses the
+# standard 200K alias, which its bounded review/author iterations fit
+# fine. (If you ever want sonnet[1m], enable usage credits at
+# claude.ai/settings/usage and re-add the suffix.) Heavy candidates are
+# pinned to full versions (a bare "fable"/"opus" alias would silently
+# upgrade); sonnet stays an alias since its budget is cheap.
+HEAVY_MODEL_CANDIDATES=(
+    "claude-fable-5[1m]"
+    "claude-fable-5"
+    "claude-opus-4-8[1m]"
+)
 SONNET_MODEL="sonnet"
-export OPUS_MODEL SONNET_MODEL
+export SONNET_MODEL
 
 # Minimum seconds between opus-reviewer relaunches (cooldown floor).
 # fleet-babysit reads this via FLEET_MIN_BACKOFF; keep the two in sync.
@@ -120,6 +140,13 @@ _env_merger="${FLEET_CONCURRENCY_MERGER:-}"
 # the conf itself.
 _env_effort_opus_architect="${FLEET_EFFORT_OPUS_ARCHITECT:-}"
 _env_effort_game_architect="${FLEET_EFFORT_GAME_ARCHITECT:-}"
+# Same guard for the model knobs (FLEET_HEAVY_MODEL pins the heavy tier
+# and skips the probe; FLEET_HEAVY_MODEL_FALLBACK feeds --fallback-model
+# on dispatched print-mode iterations). The fallback capture uses `-`
+# (not `:-`) so an operator can disable the fallback chain entirely with
+# an explicit empty FLEET_HEAVY_MODEL_FALLBACK="".
+_env_heavy_model="${FLEET_HEAVY_MODEL:-}"
+_env_heavy_model_fallback="${FLEET_HEAVY_MODEL_FALLBACK-__unset__}"
 if [[ -f "$FLEET_CONF" ]]; then
     # shellcheck disable=SC1090
     source "$FLEET_CONF"
@@ -134,9 +161,14 @@ FLEET_CONCURRENCY_MERGER="${_env_merger:-${FLEET_CONCURRENCY_MERGER:-1}}"
 # the resolved value; it does not read the conf itself.
 FLEET_EFFORT_OPUS_ARCHITECT="${_env_effort_opus_architect:-${FLEET_EFFORT_OPUS_ARCHITECT:-${FLEET_EFFORT:-xhigh}}}"
 FLEET_EFFORT_GAME_ARCHITECT="${_env_effort_game_architect:-${FLEET_EFFORT_GAME_ARCHITECT:-${FLEET_EFFORT:-xhigh}}}"
+FLEET_HEAVY_MODEL="${_env_heavy_model:-${FLEET_HEAVY_MODEL:-}}"
+if [[ "$_env_heavy_model_fallback" != "__unset__" ]]; then
+    FLEET_HEAVY_MODEL_FALLBACK="$_env_heavy_model_fallback"
+fi
 unset _env_opus_worker _env_sonnet_author _env_sonnet_reviewer \
       _env_opus_reviewer _env_merger \
-      _env_effort_opus_architect _env_effort_game_architect
+      _env_effort_opus_architect _env_effort_game_architect \
+      _env_heavy_model _env_heavy_model_fallback
 export FLEET_CONCURRENCY_OPUS_WORKER FLEET_CONCURRENCY_SONNET_AUTHOR
 export FLEET_CONCURRENCY_SONNET_REVIEWER FLEET_CONCURRENCY_OPUS_REVIEWER
 export FLEET_CONCURRENCY_MERGER
@@ -213,6 +245,90 @@ if tmux has-session -t "$SESSION" 2>/dev/null; then
     echo "(kill with \`tmux kill-session -t $SESSION\` first if you want a fresh layout)"
     exit 0
 fi
+
+# ----------------------------------------------------------------------
+# Step 0: resolve the heavy-tier model
+# ----------------------------------------------------------------------
+#
+# Sits after the session-exists early exit so re-running fleet-up
+# against a live fleet never pays a probe call.
+
+# True when a minimal print-mode call to $1 succeeds. Costs one tiny
+# request (~a cent, ~5-15 s). Portable timeout: stock macOS has no
+# coreutils `timeout`, so background the probe and watchdog-kill it.
+probe_model() {
+    local model="$1" pid watchdog rc=1
+    claude --model "$model" -p 'Reply with exactly: ok' >/dev/null 2>&1 &
+    pid=$!
+    ( sleep "${FLEET_MODEL_PROBE_TIMEOUT:-90}"; kill "$pid" 2>/dev/null ) &
+    watchdog=$!
+    if wait "$pid"; then rc=0; fi
+    kill "$watchdog" 2>/dev/null || true
+    wait "$watchdog" 2>/dev/null || true
+    return "$rc"
+}
+
+# Walk HEAVY_MODEL_CANDIDATES; first model that answers wins. The probe
+# is what makes the Fable->Opus failover automatic when the plan loses
+# Fable access: re-run fleet-up and the fleet lands on the next rung.
+# Dispatched (print-mode) iterations additionally carry --fallback-model,
+# so a mid-session loss degrades per-iteration without a fleet-up rerun;
+# interactive architect panes can't take that flag (it's --print-only)
+# and rely on this launch-time resolution alone.
+HEAVY_MODEL=""
+if [[ -n "$FLEET_HEAVY_MODEL" ]]; then
+    HEAVY_MODEL="$FLEET_HEAVY_MODEL"
+    echo "fleet-up: heavy tier pinned via FLEET_HEAVY_MODEL -> $HEAVY_MODEL"
+elif [[ "${FLEET_MODEL_PROBE:-1}" == "0" ]]; then
+    HEAVY_MODEL="${HEAVY_MODEL_CANDIDATES[0]}"
+    echo "fleet-up: FLEET_MODEL_PROBE=0 -> $HEAVY_MODEL (unprobed)"
+else
+    _last_candidate="${HEAVY_MODEL_CANDIDATES[${#HEAVY_MODEL_CANDIDATES[@]}-1]}"
+    for _candidate in "${HEAVY_MODEL_CANDIDATES[@]}"; do
+        if [[ "$_candidate" == "$_last_candidate" ]]; then
+            HEAVY_MODEL="$_candidate"
+            echo "fleet-up: heavy tier -> $HEAVY_MODEL (fallback floor, unprobed)"
+            break
+        fi
+        printf 'fleet-up: probing %s ... ' "$_candidate"
+        if probe_model "$_candidate"; then
+            HEAVY_MODEL="$_candidate"
+            echo "ok — heavy tier -> $HEAVY_MODEL"
+            break
+        fi
+        echo "unavailable"
+    done
+    unset _candidate _last_candidate
+fi
+
+# Fallback chain for dispatched heavy iterations (claude --fallback-model;
+# comma-separated list accepted). Cleared when it would just repeat the
+# resolved model. FLEET_HEAVY_MODEL_FALLBACK="" disables it.
+HEAVY_MODEL_FALLBACK="${FLEET_HEAVY_MODEL_FALLBACK-claude-opus-4-8[1m]}"
+if [[ "$HEAVY_MODEL_FALLBACK" == "$HEAVY_MODEL" ]]; then
+    HEAVY_MODEL_FALLBACK=""
+fi
+
+# Back-compat: OPUS_MODEL is the pre-Fable name for the heavy-tier model.
+# fleet-dispatcher reads HEAVY_MODEL with an OPUS_MODEL fallthrough;
+# export both so older tooling and operator muscle memory keep working.
+OPUS_MODEL="$HEAVY_MODEL"
+export HEAVY_MODEL HEAVY_MODEL_FALLBACK OPUS_MODEL
+
+# Short human-readable tag for a model string, shown in pane labels next
+# to the role slug (e.g. "opus-worker-1 [fable 1m]"). Role slugs keep the
+# historical tier names; the bracket tag is what tells you which model
+# the tier is actually running this session.
+model_tag() {
+    local tag="$1"
+    tag="${tag/claude-fable-5/fable}"
+    tag="${tag/claude-opus-4-8/opus 4.8}"
+    tag="${tag/claude-sonnet-4-6/sonnet 4.6}"
+    tag="${tag/\[1m\]/ 1m}"
+    printf '%s' "$tag"
+}
+HEAVY_TAG="$(model_tag "$HEAVY_MODEL")"
+SONNET_TAG="$(model_tag "$SONNET_MODEL")"
 
 # ----------------------------------------------------------------------
 # Step 1: ensure all worktrees exist
@@ -1068,7 +1184,8 @@ pane_stagger() {
 }
 
 launch_cmd() {
-    # $1 = model alias (opus|sonnet), $2 = role slug (without role- prefix)
+    # $1 = model string (e.g. "$HEAVY_MODEL" / "$SONNET_MODEL"),
+    #      $2 = role slug (without role- prefix)
     # $3 = loop interval (optional — for polling roles like reviewers/queue-mgr)
     local model="$1"
     local role="$2"
@@ -1155,23 +1272,26 @@ tmux new-session -d -s "$SESSION" -n fleet \
 # can predate this process). Panes feed it to ir-build -> ir-acquire for
 # correct per-build CPU sizing.
 tmux set-environment -g IR_FLEET_WORKERS "$IR_FLEET_WORKERS"
+# Same treatment for the heavy-tier fallback chain: fleet-babysit panes
+# read it to pass --fallback-model on print-mode (worker) iterations.
+tmux set-environment -g HEAVY_MODEL_FALLBACK "$HEAVY_MODEL_FALLBACK"
 TOP_LEFT=$(tmux display-message -t "$SESSION:fleet" -p "#{pane_id}")
-label_pane_id "$TOP_LEFT" "sonnet-fleet-1 [sonnet]"
+label_pane_id "$TOP_LEFT" "sonnet-fleet-1 [$SONNET_TAG]"
 set_fleet_role "$TOP_LEFT" "sonnet-author"
 pane_stagger
 
 # Split bottom 2/3 off — that becomes the middle row's leftmost pane.
 MID_LEFT=$(tmux split-window -v -t "$TOP_LEFT" -l 67% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-architect" \
-    "$(launch_cmd "$OPUS_MODEL" opus-architect)")
-label_pane_id "$MID_LEFT" "opus-architect [opus 4.8]"
+    "$(launch_cmd "$HEAVY_MODEL" opus-architect)")
+label_pane_id "$MID_LEFT" "opus-architect [$HEAVY_TAG]"
 pane_stagger
 
 # Split bottom 1/2 of the middle off — that becomes bottom row leftmost.
 BOT_LEFT=$(tmux split-window -v -t "$MID_LEFT" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-1" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$BOT_LEFT" "opus-worker-1 [opus 4.8]"
+label_pane_id "$BOT_LEFT" "opus-worker-1 [$HEAVY_TAG]"
 set_fleet_role "$BOT_LEFT" "opus-worker"
 pane_stagger
 
@@ -1182,14 +1302,14 @@ pane_stagger
 TOP_MID=$(tmux split-window -h -t "$TOP_LEFT" -l 67% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/sonnet-fleet-2" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$TOP_MID" "sonnet-fleet-2 [sonnet]"
+label_pane_id "$TOP_MID" "sonnet-fleet-2 [$SONNET_TAG]"
 set_fleet_role "$TOP_MID" "sonnet-author"
 pane_stagger
 
 TOP_RIGHT=$(tmux split-window -h -t "$TOP_MID" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/sonnet-reviewer" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$TOP_RIGHT" "sonnet-reviewer [sonnet]"
+label_pane_id "$TOP_RIGHT" "sonnet-reviewer [$SONNET_TAG]"
 set_fleet_role "$TOP_RIGHT" "sonnet-reviewer"
 pane_stagger
 
@@ -1199,8 +1319,8 @@ pane_stagger
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     MID_RIGHT=$(tmux split-window -h -t "$MID_LEFT" -l 50% -P -F "#{pane_id}" \
         -c "$GAME/.claude/worktrees/game-architect" \
-        "$(launch_cmd "$OPUS_MODEL" game-architect)")
-    label_pane_id "$MID_RIGHT" "game-architect [opus 4.8]"
+        "$(launch_cmd "$HEAVY_MODEL" game-architect)")
+    label_pane_id "$MID_RIGHT" "game-architect [$HEAVY_TAG]"
     pane_stagger
 fi
 
@@ -1210,14 +1330,14 @@ fi
 BOT_MID=$(tmux split-window -h -t "$BOT_LEFT" -l 67% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-worker-2" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$BOT_MID" "opus-worker-2 [opus 4.8]"
+label_pane_id "$BOT_MID" "opus-worker-2 [$HEAVY_TAG]"
 set_fleet_role "$BOT_MID" "opus-worker"
 pane_stagger
 
 BOT_RIGHT=$(tmux split-window -h -t "$BOT_MID" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/opus-reviewer" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$BOT_RIGHT" "opus-reviewer [opus 4.8]"
+label_pane_id "$BOT_RIGHT" "opus-reviewer [$HEAVY_TAG]"
 set_fleet_role "$BOT_RIGHT" "opus-reviewer"
 pane_stagger
 
@@ -1244,7 +1364,7 @@ pane_stagger
 OPS_TR=$(tmux split-window -h -t "$OPS_TL" -l 50% -P -F "#{pane_id}" \
     -c "$ENGINE/.claude/worktrees/merger" \
     "$TRANSIENT_PANE_CMD")
-label_pane_id "$OPS_TR" "merger [opus 4.8]"
+label_pane_id "$OPS_TR" "merger [$HEAVY_TAG]"
 set_fleet_role "$OPS_TR" "merger"
 
 OPS_BL=$(tmux split-window -v -t "$OPS_TL" -l 50% -P -F "#{pane_id}" \
@@ -1263,7 +1383,7 @@ if [[ -d "$ENGINE/.claude/worktrees/smoke-worker" ]]; then
     OPS_SMOKE=$(tmux split-window -v -t "$OPS_TR" -l 50% -P -F "#{pane_id}" \
         -c "$ENGINE/.claude/worktrees/smoke-worker" \
         "$TRANSIENT_PANE_CMD")
-    label_pane_id "$OPS_SMOKE" "smoke-worker [sonnet]"
+    label_pane_id "$OPS_SMOKE" "smoke-worker [$SONNET_TAG]"
     set_fleet_role "$OPS_SMOKE" "smoke-worker"
     pane_stagger
 fi
@@ -1283,6 +1403,13 @@ cat <<EOF
 
 fleet session created — mode: ${MODE}.
 attach with:  tmux attach -t ${SESSION}
+
+model tiers (resolved this run — tier names in role slugs/labels are
+historical; "opus" means the heavy tier, whatever model serves it):
+  heavy — ${HEAVY_MODEL}  (architects, opus-worker, opus-reviewer, merger)
+          dispatched-iteration fallback: ${HEAVY_MODEL_FALLBACK:-none}
+  light — ${SONNET_MODEL}  (sonnet-author, sonnet-reviewer, smoke-worker)
+  pin with FLEET_HEAVY_MODEL in ~/.fleet/fleet-up.conf to skip the probe.
 
 layout (two windows):
   window 1 "fleet" (3x3 grid, ~33% per row):

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -8,6 +8,35 @@
 # Bash-sourceable. Comments start with `#`. Values without quotes work
 # for integers; quote any value containing spaces.
 
+# --- Model tiers -------------------------------------------------------------
+#
+# The fleet runs two model tiers. Role slugs and queue labels keep the
+# historical names ("opus" = heavy tier, "sonnet" = light tier); the model
+# that actually serves the heavy tier is resolved by fleet-up at boot from
+# a candidate ladder — claude-fable-5[1m] -> claude-fable-5 ->
+# claude-opus-4-8[1m] — by probing each with a one-token claude call (a few
+# cents, ~5-15 s per rung) and taking the first that answers. When the plan
+# loses Fable access, re-running fleet-up automatically lands the fleet on
+# the Opus floor.
+#
+# FLEET_HEAVY_MODEL pins the heavy tier verbatim and skips the probe.
+# FLEET_HEAVY_MODEL="claude-opus-4-8[1m]"
+#
+# FLEET_HEAVY_MODEL_FALLBACK is handed to dispatched (print-mode) heavy
+# iterations as `claude --fallback-model`, so a single iteration survives
+# the primary model being overloaded or dropping off the plan mid-session.
+# Comma-separated chain accepted; set to "" to disable. Interactive
+# architect panes can't take the flag (print-only) — they rely on the
+# boot-time resolution above. Sonnet dispatches never get a fallback.
+# FLEET_HEAVY_MODEL_FALLBACK="claude-opus-4-8[1m]"
+#
+# FLEET_MODEL_PROBE=0 skips the availability probe (offline / tests);
+# the first ladder candidate is used unprobed.
+# FLEET_MODEL_PROBE=1
+#
+# FLEET_MODEL_PROBE_TIMEOUT caps each probe call in seconds. Default 90.
+# FLEET_MODEL_PROBE_TIMEOUT=90
+
 # --- Per-role concurrency caps ----------------------------------------------
 #
 # Soft cap on simultaneous iterations per role. The dispatcher counts

--- a/scripts/fleet/solo-architect
+++ b/scripts/fleet/solo-architect
@@ -35,11 +35,22 @@ set -euo pipefail
 
 ENGINE="$HOME/src/IrredenEngine"
 GAME="$ENGINE/creations/game"
-# Keep in sync with fleet-up's OPUS_MODEL (the fleet's single source of truth)
-# and the opus xhigh default in fleet-babysit — a model/effort bump there must
-# be mirrored here.
-MODEL="claude-opus-4-8[1m]"
-EFFORT="xhigh"
+# Keep in sync with fleet-up's heavy-tier ladder (HEAVY_MODEL_CANDIDATES —
+# the fleet's single source of truth) and the heavy xhigh default in
+# fleet-babysit — a model/effort bump there must be mirrored here.
+# FLEET_HEAVY_MODEL (env or ~/.fleet/fleet-up.conf) pins the model, same
+# knob fleet-up honors. No availability probe here — this is an
+# interactive launch, so an unavailable model fails loudly on the first
+# turn; pin FLEET_HEAVY_MODEL="claude-opus-4-8[1m]" once the plan loses
+# Fable access.
+if [[ -z "${FLEET_HEAVY_MODEL:-}" && -f "$HOME/.fleet/fleet-up.conf" ]]; then
+  # shellcheck disable=SC1091
+  source "$HOME/.fleet/fleet-up.conf"
+fi
+MODEL="${FLEET_HEAVY_MODEL:-claude-fable-5[1m]}"
+# Global FLEET_EFFORT (env or conf) lowers solo sessions too; default
+# stays xhigh — heavy design work is where that budget earns its keep.
+EFFORT="${FLEET_EFFORT:-xhigh}"
 
 ROLE="opus-architect"
 WORKTREE="$ENGINE/.claude/worktrees/opus-architect"

--- a/scripts/fleet/tests/test_babysit_effort.sh
+++ b/scripts/fleet/tests/test_babysit_effort.sh
@@ -12,8 +12,8 @@
 # prints the resolved effort and exits before any claude launch.
 #
 # Covers:
-#   - model-derived defaults (opus -> xhigh, sonnet -> high) for manual runs
-#   - the full 1m model name still hits the opus glob
+#   - model-derived defaults (fable/opus -> xhigh, sonnet -> high) for manual runs
+#   - the full 1m model names still hit the heavy globs
 #   - per-role FLEET_EFFORT_<ROLE> override
 #   - role->varname mapping for a hyphenated role (game-architect)
 #   - global FLEET_EFFORT fallback when no per-role value is set
@@ -58,15 +58,18 @@ effort_for() {
 
 # --- Test 1: model-derived defaults (manual run, no env) -------------------
 echo "T1: model-derived defaults"
+assert_eq "$(effort_for fable opus-architect)"  "xhigh" "fable model -> xhigh default"
 assert_eq "$(effort_for opus opus-architect)"   "xhigh" "opus model -> xhigh default"
 assert_eq "$(effort_for sonnet sonnet-author)"  "high"  "sonnet model -> high default"
 # Manual run of a dispatched role keys on the model, not the dispatcher's
-# per-role policy — opus -> xhigh even for opus-reviewer (documented; the
-# real fleet launches reviewers via the dispatcher, not babysit).
+# per-role policy — heavy models -> xhigh even for opus-reviewer
+# (documented; the real fleet launches reviewers via the dispatcher, not
+# babysit).
 assert_eq "$(effort_for opus opus-reviewer)"    "xhigh" "manual opus opus-reviewer -> xhigh (model-derived)"
 
-# --- Test 2: full 1m model name still hits the opus glob -------------------
-echo "T2: full model name hits opus glob"
+# --- Test 2: full 1m model names still hit the heavy globs -----------------
+echo "T2: full model name hits heavy globs"
+assert_eq "$(effort_for 'claude-fable-5[1m]' opus-architect)"  "xhigh" "claude-fable-5[1m] -> xhigh"
 assert_eq "$(effort_for 'claude-opus-4-8[1m]' opus-architect)" "xhigh" "claude-opus-4-8[1m] -> xhigh"
 
 # --- Test 3: per-role override ---------------------------------------------


### PR DESCRIPTION
## Summary
- Heavy tier (architects, opus-worker, opus-reviewer, merger) now runs `claude-fable-5[1m]`. `fleet-up` resolves the model at boot from a probed candidate ladder — `claude-fable-5[1m]` → `claude-fable-5` → `claude-opus-4-8[1m]` — so the fleet lands on the Opus floor automatically once the plan stops covering Fable. `FLEET_HEAVY_MODEL` (conf/env) pins the model and skips the probe; `FLEET_MODEL_PROBE=0` skips probing for offline/tests.
- Dispatched print-mode iterations carry `claude --fallback-model` for mid-session resilience: new optional 5th arg to `fleet-dispatch-wrap` threaded from the dispatcher, and `fleet-babysit`'s `stream_claude` reads the chain from the tmux server env. Interactive architect panes can't take the flag (print-only) and rely on the boot-time resolution; `solo-architect` honors `FLEET_HEAVY_MODEL` for the same reason.
- Tier vocabulary unchanged by design: role slugs, `fleet:opus`/`fleet:sonnet` labels, and `Model:` fields keep the historical names. `fleet-dispatch-wrap` maps fable model strings to the `opus` tier tag so the fleet-claim model gate keeps working; queue ingest/backfill accept `fable` as a `Model:` alias.
- Pane labels derive the bracket tag from the resolved model (`opus-worker-1 [fable 1m]`); the fleet-up banner prints the resolved tiers. Effort defaults unchanged (heavy xhigh / light high) — fable strings hit the xhigh default in `fleet-babysit`.
- Docs: FLEET.md model-split section rewritten around heavy/light tiers; `fleet-up.conf.sample` documents the new knobs.

## Test plan
- [x] `bash -n` clean on all 7 touched shell scripts
- [x] `test_babysit_effort.sh` 10/10 (incl. new `fable` / `claude-fable-5[1m]` → xhigh cases)
- [x] `test_dispatcher_effort.sh` 13/13, `test_fleet_up_conf_bootstrap.sh` 5/5, `test_fleet_claim_model_gate.sh` 11/11, ingest tests 8/8 + 3/3
- [x] dispatch-wrap tier mapping + arg construction exercised verbatim: fable→`tier=opus` with `--fallback-model`, opus floor→no fallback flag, sonnet→`tier=sonnet` no fallback
- [x] fleet-up resolution block exercised in all three modes (probe-disabled, pinned, real probe — `claude-fable-5[1m]` answered ok on this plan)
- [ ] next `fleet-up live` on the fleet host shows `opus-* [fable 1m]` pane labels and the resolved-tier banner

## Notes for reviewer
The `opus`/`sonnet` names in role slugs, labels, claim gates, and issue `Model:` fields are deliberately untouched — they're tier names baked into the queue state machine across both repos, and renaming them is a separate epic if ever desired. `OPUS_MODEL` stays exported as a back-compat alias of the resolved `HEAVY_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)