### PR TITLE
docs/fleet: architect direction for the three design-blocked render PRs (#1623/#1625/#1626)

### DIFF
--- a/.fleet/plans/issue-1457.md
+++ b/.fleet/plans/issue-1457.md
@@ -1,0 +1,155 @@
+# Plan: per-axis store occlusion key — decouple yawed winner from un-yawed recovery (#1457)
+
+- **Issue:** #1457   **Model:** opus   **Date:** 2026-06-09 (architect RE-plan, supersedes the 06-07 plan)
+- **Repro:** CONFIRMED live (macOS/Metal): `fleet-run IRShapeDebug --spin-yaw 30 --auto-screenshot 8 --zoom 8 --depth-color`, shot 2 (yaw 45°) + shot 4 (yaw 135°) — voxel-pool per-axis shape shows scrambled blocky depth (front/back confusion); SDF shape is a clean gradient.
+
+## ⚠️ The original lead is DISPROVEN — do not repeat it
+The 06-07 plan said "make the scatter composite depth per-fragment instead of flat-per-face."
+PR #1601 implemented exactly that and verified it is **byte-identical to master** (`img_diff
+drift=0`, `cmp` identical). The scatter composite depth is **not** the cause — forcing the scatter
+fragment to magenta paints a solid coherent square over the scrambled region, so placement/tiling
+is correct. The scramble is *which voxel is stored in each cell*, decided upstream at store time.
+The 06-07 "instrument-first / follow the data" caveat fired; this re-plan follows it.
+
+## Real root cause (re-diagnosed)
+`engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl` (per-axis store, ~line 260), twin
+`stage_2`, Metal twins. The per-cell occlusion winner is chosen by `atomicMin` on
+`encodeDepthWithFace(microWorld.x+microWorld.y+microWorld.z, slot)` = **un-yawed** `x+y+z`. But the
+canvas cell corresponds to a **yawed** screen position; the correct "nearest" along a face's fixed
+axis is the **yawed** depth:
+- X-faces: `depth_yaw ∝ coord·(cosθ − sinθ)` → coefficient `→ 0` at **θ = 45°** → rank-degenerate.
+- Y-faces: `depth_yaw ∝ coord·(sinθ + cosθ)` → coefficient `→ 0` at **θ = 135°** → rank-degenerate.
+Exactly the DoD's two worst poses (shots 2/4). Back voxels win `atomicMin` → speckled front/back.
+
+## The coupling that blocks the obvious swap
+The stored 30-bit value is **also** the scatter's origin-recovery key:
+`v_peraxis_scatter.glsl` does `faceOriginFromInPlane(faceId, inPlane, rawDepth)`
+(`ir_iso_common.glsl:538`), `third = rawDepth − inPlane.x − inPlane.y`. That recovery is exact,
+trig-free, division-free — robust at all yaws — **because** `rawDepth` is the un-yawed `x+y+z`.
+You cannot simply store yawed depth instead: recovering `third` from a yawed key needs
+`third = key / (cosθ − sinθ)`, which is the **same division that goes singular at 45°**. So the two
+roles genuinely need two different values; one 30-bit field can't serve both.
+
+## Key derivation insight (makes this bounded)
+Within a single cell the in-plane coords are **fixed**, so the in-plane terms of the yawed depth are
+constant per cell → ordering by full yawed depth ≡ ordering by the **fixed-axis term**
+`third·(cosθ−sinθ)` (X) / `third·(sinθ+cosθ)` (Y). So the occlusion sort key only needs a
+quantized scalar monotonic in `third` with the yaw-sign — cheap to compute at store time.
+
+## Approach (one) — repack a single 32-bit atomicMin word
+Keep one 32-bit `atomicMin` per cell (no 64-bit atomics → preserves GLSL↔Metal parity).
+Repack the word as **[ high bits: quantized yawed sort key | low bits: un-yawed recovery payload ]**:
+- High bits = `quantize(yawed fixed-axis depth)` so `atomicMin` selects the **yawed** winner.
+- Low bits = the un-yawed recovery payload (`rawDepth`/`third` + 2-bit `slot`), read at scatter so
+  `faceOriginFromInPlane` stays exact/trig-free/division-free.
+- **Derive the bit budget** (opus-tier closed form): bound `third`/`rawDepth` range from the world
+  extent along the depth diagonal and the visible canvas extent; confirm the quantized yawed key has
+  enough resolution to order adjacent voxels across the whole band. Document the budget.
+- **Fallback if 32 bits is too tight:** a parallel winner-select buffer using the standard
+  packed-key idiom (atomicMin the sort key into buffer A; the winning fragment writes its payload
+  into buffer B keyed by the same packed value). Note the extra-buffer cost + parity surface. Pick
+  the 32-bit repack first; only fall back if the bit budget genuinely doesn't close.
+
+## Accepted residual (intrinsic — do NOT chase it)
+At **exactly** θ = 45° (X) / 135° (Y) the fixed-axis coefficient is 0: the column is genuinely
+rank-degenerate and **no scalar depth key can pick a winner** — this is a property of the iso
+projection, not the store. Leave that knife-edge within the documented SDF-vs-voxel parity band
+(`engine/render/CLAUDE.md` §"SDF vs voxel-pool parity"). DoD targets "clean across the band," not
+"byte-clean at exactly 45°."
+
+## Constraints (hard)
+- **Cardinal byte-identity:** gate everything on `perAxisRoute != 0`; do not perturb the
+  single-canvas helpers (`encodeDepthWithFace`/`effectiveTrixelSubdivisionScale`/`trixelFrameOffset`).
+- **GLSL↔Metal parity in lockstep** — store shader + Metal twin in the same PR.
+- **Every reader of the stored value stays consistent** with the new payload layout: scatter
+  recovery (`v_peraxis_scatter`), AO (`c_compute_voxel_ao`), lighting (`c_lighting_to_trixel` via
+  `perAxisCellToWorld3D`), sun-shadow (`c_compute_sun_shadow`), `c_resolve_per_axis_screen_depth` —
+  each + Metal twin. Audit all before finalizing.
+
+## Reconcile with siblings
+- **#1458** (Blocked-by relationship: #1458 waits on this) reworks the SAME store to base/world
+  resolution + fractional winner offset. This PR establishes the **decoupled occlusion model**
+  (yawed winner / un-yawed recovery) that #1458 inherits — keep the payload layout extensible so
+  #1458 can add the fractional offset without re-deriving the key.
+- **#1469** is closed (subsumed by #1458).
+- **#1431** cap stays as-is (this PR doesn't touch resolution).
+
+## Definition of done
+- `IRShapeDebug --spin-yaw 30 --depth-color` shots 2/4: voxel-pool shape renders clean across the
+  band — no scrambled blocks except the documented exact-45°/135° knife-edge.
+- Off-cardinal yaw generally: no front/back confusion / z-fight on the voxel-pool shape.
+- Cardinal yaw byte-identical (fast path untouched).
+- GLSL + Metal parity; render-verify ROI crop (voxel shape, yaw 45°) committed.
+- **Durable design:** add a "per-axis store occlusion model (yawed winner / un-yawed recovery)"
+  section to `docs/design/per-axis-trixel-canvas-rotation.md` — this is an engine-level invariant,
+  not just task-local. Note the 32-bit packing layout + the accepted knife-edge.
+
+## Ownership
+Discard PR #1601's no-op diff; start a fresh branch. Root-cause-AND-fix in one PR. `[opus]`.
+
+---
+
+## Architect RE-plan v3 (design-unblock, 2026-06-09) — PR #1625: store-key lead ALSO disproven
+
+The worker implemented the v2 re-plan faithfully (repacked atomicMin word, yawed sort key /
+un-yawed recovery payload) and **measured it byte-identical to master** at the worst-case pose
+(yaw 67.5°, X coeff −0.54). The collision-free argument is accepted: the per-axis face-local
+store holds exactly ONE camera-visible exposed face-voxel per cell (keyed by its two in-plane
+world coords), so the atomicMin "winner" is uncontested and ANY store-time sort key is a no-op.
+The v2 root-cause section above is therefore WRONG — superseded by this entry.
+
+**Two faithful implementations have now been disproven byte-identical (#1601 composite-depth,
+#1625 store-key). New hard rule for this issue: NO third fix implementation lands until the
+failing mechanism is directly visualized.** Discard PR #1625's diff (commit `f2b37ed3` stays
+referenced in the thread as evidence); reset the branch.
+
+### What IS established (do not re-litigate)
+- Per-axis scatter placement/tiling is correct (forced-magenta probe → coherent solid silhouette).
+- The scramble = the WRONG voxel's authored depth-color per screen pixel, correct silhouette.
+- The per-axis store is collision-free → store-time keys cannot matter.
+- Remaining suspect: the **cross-axis framebuffer composite** — the three per-axis canvases
+  (X/Y/Z visible surfaces) scatter their face quads and depth-test against each other per screen
+  pixel via the scatter `vDepth`. Hypothesis: the three faces' flat per-face yawed depths
+  interleave instead of cleanly separating → pixels alternate between X/Y/Z faces → block scramble.
+
+### Mandatory instrumentation (in order; post results on the PR before any fix)
+1. **Axis-canvas-ID visualization**: a debug mode (flag- or compile-gated, mirroring
+   `--depth-color`) that colors each framebuffer pixel by WHICH axis canvas won the depth test
+   (X=red, Y=green, Z=blue). In the scrambled region:
+   - Interleaved IDs → cross-axis composite CONFIRMED as the locus.
+   - Coherent single ID → the scramble is INSIDE one canvas's scatter; go to (2).
+2. **Recovered-origin field visualization** per cell (colors from `faceOriginFromInPlane` output)
+   — rules the trig-free recovery in or out as the corruption point.
+
+Keep the instrumentation in-tree behind its debug flag — this surface has now consumed three
+diagnostic rounds; the tool stays.
+
+### Evidence-contingent fixes (pre-authorized — worker picks per the evidence, no re-escalation needed)
+- **Cross-axis interleave confirmed** → make all three scatters emit ONE shared exact depth key:
+  the true yawed camera-space depth of the **recovered voxel origin**. Recovery is exact and
+  trig-free per fragment, so each canvas can compute the identical world-space depth for the voxel
+  it recovered; one shared helper in `ir_iso_common.{glsl,metal}` used verbatim by all three
+  scatters (the formula must be literally shared, not three copies). Note: #1601 does NOT disprove
+  this — #1601 changed interpolation granularity of the EXISTING per-face key, not the ordering
+  function across canvases.
+- **Single-canvas scramble** → follow the recovered-origin evidence (scatter addressing/recovery
+  bug in that axis); post findings before fixing.
+
+### Re-escalate ONLY for the structural call
+If the evidence shows no scalar cross-axis depth key can order the three faces (a genuine
+forward-scatter-under-yaw limit, mirroring why detached SO(3) moved to re-voxelize in #1560),
+retiring forward-scatter for camera yaw is an architect+human decision — swap back to
+`fleet:design-blocked` with the visualizations attached. Do not make that call unilaterally.
+
+### Definition of done (unchanged in substance — the artifact, not the mechanism)
+- `IRShapeDebug --spin-yaw 30 --depth-color` shots 2/4: voxel-pool shape clean across the band —
+  no scrambled blocks except the documented exact-45°/135° knife-edge.
+- Off-cardinal yaw generally: no front/back confusion on the voxel-pool shape.
+- Cardinal yaw byte-identical. GLSL + Metal in lockstep. Render-verify ROI crop committed.
+- Instrumentation visualizations posted on the PR + the debug mode kept in-tree.
+- Durable design note in `docs/design/per-axis-trixel-canvas-rotation.md`: per-axis store is
+  collision-free (one face-voxel per cell) → occlusion is decided at the cross-axis composite,
+  plus whatever the confirmed fix establishes.
+
+Resume on PR #1625 (reset the branch first). Any heavy-tier worker can pick up from
+`fleet:design-unblocked`.

--- a/.fleet/plans/issue-1596.md
+++ b/.fleet/plans/issue-1596.md
@@ -1,0 +1,50 @@
+# Plan: P4b-3 — detached re-voxelize world sun-shadow CAST (#1596)
+
+- **Issue:** #1596 (epic #1553, P4b track #1576)   **Model:** opus   **Date:** 2026-06-09
+- **Canonical design:** `docs/design/detached-revoxelize-world-light.md` — this file is the task
+  pointer; the doc is the source of truth (Q2 mechanism revised 2026-06-09, see below).
+- **Resume on:** PR #1626 (WIP branch `claude/1596-revoxelize-world-shadow-cast`).
+
+## State (from PR #1626's NEEDS-DESIGN)
+Q2 → (a) "second bake dispatch per opt-in detached canvas" was implemented (C++ + GLSL + Metal,
+default path byte-identical) but does NOT render on Metal: the second in-tick bake dispatch reads
+the detached canvas's R32I distance texture as EMPTY. Localized to the Metal image-atomic
+scratch-buffer indirection (`metal_texture.cpp::bindImage` → scratch slot) not delivering a
+non-main canvas's distance data to a second in-tick compute dispatch. The cited per-axis
+precedent never did a foreign-texture bake read — it RESOLVES to a main-layout screen-space
+depth texture first, then bakes that.
+
+## Architect decision — Q2 mechanism revised: (a) → (a′) resolve-then-bake
+Mirror the per-axis precedent FAITHFULLY: resolve opt-in detached canvases' distances (model
+frame + `worldCellOffset`) into a **main-canvas-layout screen-space depth source**, then bake
+that through the proven main-bake path. Never bind a foreign model-frame R32I canvas texture as
+a bake source.
+
+- **Reuse before adding:** P4b-1 already composites detached depth for the framebuffer
+  depth-sort. FIRST check whether a main-layout texture containing detached caster depth already
+  exists at BAKE time (or can be cheaply made available there). If yes, bake that — zero new
+  resolve passes. If not, add ONE dedicated resolve: accumulate ALL opt-in detached casters into
+  ONE shared screen-layout caster-depth texture (min-depth), then ONE extra bake. N casters must
+  not mean N bakes.
+- **Q3 (GL might work with the direct read) is moot:** even if GL tolerates the foreign read,
+  backend-divergent cast paths are rejected. (a′) on both backends.
+- **The Metal backend gap is real but separate:** filed as its own issue (foreign R32I texture →
+  second in-tick compute dispatch scratch delivery), with the PR's diagnostics. Do not block the
+  feature on a backend fix.
+- Screen-space caveat is consistent with the engine's existing model: the sun bake already casts
+  from camera-visible surfaces only (`docs/design/screen-space-sun-shadow-map.md`); the resolve
+  inherits that, which is correct and not a regression.
+
+## Definition of done — the artifact, not the mechanism
+- A `worldPlaced_` detached re-voxelize solid casts a **visible sun shadow onto the #1587 SDF
+  floor** in `canvas_stress --world-place-revox`, on macOS/Metal AND Linux/GL. Screenshots in the
+  PR (before/after). This is the end-to-end proof the design doc names; code that builds clean
+  but casts nothing is not done.
+- Default (non-`worldPlaced_`) path stays byte-identical (the standing opt-in regression guard).
+- P4b-2 receive unregressed (world-placed solids still darken in world shadow).
+- GLSL + Metal in lockstep; render-verify references per the epic convention.
+
+## Ownership
+`[opus]`. Closes out the P4b stack (#1592 depth → #1617 receive → this). Resume from PR #1626;
+keep the gather/dispatch plumbing that survives the mechanism change, replace the foreign-texture
+bake read with the resolve.

--- a/.fleet/plans/issue-1619.md
+++ b/.fleet/plans/issue-1619.md
@@ -1,0 +1,147 @@
+# Plan: re-voxelize round-to-cell coverage holes (missing faces) (#1619)
+
+- **Issue:** #1619   **Model:** opus   **Date:** 2026-06-09 (architect plan)
+- **Status:** ROOT CAUSE CONFIRMED BY REPRODUCTION (architect built + ran IRCanvasStress
+  --auto-screenshot on macOS/Metal, 2026-06-09). The defect is visible on every
+  DETACHED_REVOXELIZE solid; clean solid orbit shapes of the same kind (GRID / plain-DETACHED)
+  next to them prove it is mode-specific. The `visibleTriplet` sign-flip theory is RULED OUT.
+
+## Symptom (confirmed)
+Banded / speckled coverage holes on DETACHED_REVOXELIZE solids — rows of cells round to the same
+line leaving gaps between rows. Severity scales INVERSELY with solid size: large solids show
+"patterns of gaps," small canary cubes lose what reads as a whole face (the gaps span it). NOT a
+`visibleTriplet`/face-selection bug (re-voxelize uses a FIXED cardinal triplet,
+`voxel_frame_data.hpp:85`, not `visibleTriplet`).
+
+## Root cause
+`engine/render/src/shaders/c_revoxelize_detached.glsl` (+ Metal twin + CPU mirror
+`IRPrefab::GridRotation::worldCellForGridVoxel`) is a **forward scatter**: one thread per *source*
+voxel writes `cell = roundHalfUp(rotateByQuat(local, quat))`. Forward rotation+round is **not
+surjective** onto the rotated-AABB lattice -> covered dest cells get no source voxel -> holes. The
+2D +/-1px raster dilation only closes sub-pixel seams, not whole missing cells. Shared with attached
+GRID re-voxelize (`REBUILD_GRID_VOXELS`) — same model; large GRID cubes hide it.
+
+## Approach (instrument-first — this surface mis-diagnosed twice already, cf. #1457 + the visibleTriplet red herring)
+1. Instrument: dump filled-cell set vs rotated-AABB lattice; classify holes surface-vs-interior;
+   confirm scaling with angle + inverse with size (the repro already shows the inverse-size scaling).
+2. Lead — INVERSE (backward) resampling: dispatch over DEST cells in the rotated AABB; fill `c` iff
+   `roundHalfUp(rotateByQuat(c, conj(quat)))` is in source occupancy. Surjective -> hole-free.
+   Needs a source-occupancy structure (hash/bitset), a matching CPU mirror (keep CPU<->GPU
+   bit-identity), and a dest-cell dispatch domain (the pool already sizes to the rotated AABB).
+3. Fallback — guaranteed 3D dilation in CELL space (close 1-cell gaps). Cheaper, approximate.
+
+## Constraints
+- CPU<->GPU bit-identity; GLSL<->Metal parity in lockstep; identity-rotation fast-path byte-identical.
+- Cover BOTH DETACHED_REVOXELIZE and GRID re-voxelize.
+
+## Definition of done
+- DETACHED_REVOXELIZE solids of all sizes render hole-free across a full spin in canvas_stress
+  (verify the center cluster + the gappy orbit shapes from the repro: blue/yellow/teal/green/red).
+- Small (<=4^3) canary cube: no whole-face dropout.
+- Re-enable a thin shape (frame/cross) on the re-voxelize path in canvas_stress as the standing guard.
+- GLSL+Metal parity; render-verify ROI crops committed.
+
+## Ownership
+`[opus]`. Correctness follow-up to the #1553 re-voxelize epic (coverage track; distinct from the
+P4b lighting track and from #1620 the floor-depth demo fix).
+
+---
+
+## Architect decision (design-unblock, 2026-06-09) — PR #1623
+
+Worker instrumented and surfaced the binding constraint: the raster reads position (b5),
+color+flags (b6), active (b8) all keyed by the SAME source-voxel slot, on bindings shared with the
+main-canvas raster; inverse resampling is dest-cell-indexed with count > source count. Decision:
+
+**Go with Option A (resize + resample-write). Reject B/C/D.**
+
+The win: A keeps the slot-indexed contract byte-identical and only **redefines what slot `i` holds**
+— "dest cell `i`" instead of "source voxel `i`". The shared compact/stage1/stage2 raster is
+**UNTOUCHED** (it still reads position[i]/color[i]/active[i] and rasterizes active slots). The entire
+change confines to the **fill** (`c_revoxelize_detached.{glsl,metal}`) + pool sizing + a source
+lookup. That's why A beats B (B branches the SHARED raster → main-canvas byte-identity + Metal
+parity risk). C (dilation) and D (supersampling) are approximate — they don't "solve it once and
+for all" (the user's explicit goal), so not the primary; keep C only as a fallback if A's sizing
+proves prohibitive.
+
+### Answers to the worker's three questions
+1. **Colors:** the fill authors dest-cell color per frame into the re-voxelize pool's OWN ColorBuffer
+   (`color[i] = srcColor(inverse(c_i))`). This is re-voxelize-only — the main canvas still seeds its
+   ColorBuffer once and is unchanged. Add a source-color lookup alongside occupancy (pack into
+   `residentLocals.w` or a parallel resident-colors buffer). stage1/2 just read `color[i]` — no
+   shared-shader change. Same for the active bit: the fill sets per-slot active so empty dest cells
+   (inverse miss) are inactive, in whatever representation the compact pass already consumes.
+2. **Pool sizing:** size to a **closed-form bound = occupied volume + one-cell boundary shell**
+   (≈ `N³ + C·N²`, C≈6), NOT the loose rotated-AABB cube (~5×) and NOT the source count. Rotation is
+   volume-preserving; only the discretization boundary grows. Derive the exact bound CPU-side
+   (opus-tier closed form). If the closed form proves fiddly, fall back to the AABB cell count
+   (accept the memory) — never a hard cap that silently drops cells (that reintroduces holes).
+3. **Shared bindings:** stay ON the shared contract via dest-cell slot semantics (Option A). Do NOT
+   add a re-voxelize branch to the shared raster shaders.
+
+### Constraints (unchanged, re-emphasized)
+- **CPU mirror** must replicate the inverse resampling bit-identically (`roundHalfUp` on `inverse(c)`).
+- **Identity rotation fast-path byte-identical**: at identity `inverse(c)=c` → dest cells = source
+  cells, color = seeded color, positions = source. Short-circuit to today's behavior.
+- GLSL↔Metal parity in lockstep. DoD unchanged (hole-free all sizes; no whole-face dropout on small
+  cubes; thin-shape guard re-enabled; render-verify ROI).
+
+Resume on PR #1623 (claim commit + this thread). Any opus-worker can pick up `fleet:design-unblocked`.
+
+---
+
+## Architect decision #2 (design-unblock, 2026-06-09) — PR #1623: rotated solids drop out entirely
+
+Option A's inverse resample is implemented and reviewed, but the human confirmed the artifact is
+NOT resolved: rotated DETACHED_REVOXELIZE solids show missing faces — and the worker's repro shows
+they in fact **render nothing at all** at non-identity rotation (non-deterministically: one smoke
+pass green, the next all-gone). Worker hypothesis: all ~11 re-voxelize canvases run the mode-1 fill
+into the SHARED single-voxel SSBOs (bindings 5/6/8); mode 1 GPU-authors position+color+active and
+needs them to survive until that canvas's own compact/raster, but across canvases they clobber.
+Mode 0 survives only because the CPU re-uploads color+active per canvas.
+
+### The goal — restated as the ONLY definition of finished
+
+**Every DETACHED_REVOXELIZE solid renders, hole-free, at every rotation pose and every size —
+including the small canary cubes (no missing faces) and the two center proof solids (no missing
+solids).** Code that builds clean and passes review but still shows the artifact is not done.
+
+### Direction
+
+1. **Step 0 (mandatory, cheap, decisive): single-canvas isolation repro.** Run a scene with exactly
+   ONE rotated DETACHED_REVOXELIZE solid. Renders correctly alone but breaks with neighbors →
+   cross-canvas clobber CONFIRMED. Breaks alone too → the bug is inside one canvas's own mode-1
+   chain (fill/pre-clear/compact/raster ordering) and private buffers alone will NOT cure it —
+   follow that evidence instead. Post the result on the PR either way before building the fix.
+   (This surface has burned two reviewed-and-approved no-fixes already — evidence before code.)
+2. **Structural fix (assuming clobber confirms): per-pool PRIVATE dest-domain buffer set** —
+   position / color / active-mask / chunk-vis / compacted — sized per pool to the dest domain
+   (closed-form bound from decision #1; rotated-AABB cell count is an acceptable fallback). This is
+   what "private pool" in decision #1 meant. It fixes the clobber by construction AND retires the
+   `IR_ASSERT(destCount <= maxSingleVoxels)` cap, which contradicts "hole-free at every size".
+   Mode 0 (identity) stays on the shared buffers untouched — byte-identity preserved. Mode 1 binds
+   the pool's private set at the same binding points; slot semantics unchanged; no shared-shader
+   branch.
+   - **Invariant (engine-level):** a re-voxelize canvas's GPU-authored fill output must be
+     guaranteed intact at that canvas's own compact/raster. Never alias GPU-authored state across
+     canvases through shared SSBOs unless the command stream provably serializes fill→raster per
+     canvas (if you take that route instead — single shared scratch sized to max dest-count —
+     the serialization must be demonstrated with barriers in the command stream, not assumed).
+3. **Un-bless the regressed reference.** This PR re-blessed `references/macos-debug/
+   revoxelize_solids.png` to the solids-missing state — render-verify would green-light the
+   regression. Restore from master; re-bless only from a verified-good build.
+4. **Pose-deterministic evidence.** The contradictory smoke verdicts came from canvas_stress pose
+   non-determinism. Canonical evidence = `--no-spin` shots (proof solids hold `initialRotation`,
+   a fixed rotated pose). Spin shots are supplementary only.
+
+### Definition of done (supersedes prior DoD where they differ)
+- Single-canvas isolation result posted (step 0).
+- All DETACHED_REVOXELIZE solids present + hole-free in `canvas_stress --no-spin` (proof solids,
+  canaries, orbit re-voxelize shapes) AND under spin, on macOS/Metal and Linux/GL.
+- Identity fast-path byte-identical; GRID re-voxelize and main canvas unaffected.
+- `IR_ASSERT(destCount <= maxSingleVoxels)` retired (private sizing) — no silent or loud size cap
+  on the dest domain.
+- References re-blessed from a verified-good build only; before/after screenshots in the PR.
+- GLSL + Metal in lockstep.
+
+Resume on PR #1623. Any heavy-tier worker can pick up from `fleet:design-unblocked`.

--- a/docs/design/detached-revoxelize-world-light.md
+++ b/docs/design/detached-revoxelize-world-light.md
@@ -112,6 +112,30 @@ How do model-frame detached voxels enter the world sun-shadow bake?
 > depth-sort + receive but cast no shadow — an honest, documented intermediate
 > state, not a regression (today they do none of the three).
 
+> **Decision REVISED (architect, 2026-06-09): (a) → (a′) resolve-then-bake.**
+> PR #1626 implemented (a) literally — binding each detached canvas's own
+> model-frame R32I distance texture as the source of a second in-tick bake
+> dispatch — and it does not work on Metal: the image-atomic scratch-buffer
+> indirection does not deliver a non-main canvas's distance data to a second
+> in-tick compute dispatch (the read returns the clear value). On inspection
+> the per-axis precedent never did a foreign-texture bake read either — it
+> **resolves** the per-axis canvases into a main-canvas-sized, main-layout
+> screen-space depth texture first, then bakes THAT through the proven main
+> path. (a′) mirrors that precedent faithfully: resolve opt-in detached
+> canvases' distances (model frame + `worldCellOffset`) into a main-layout
+> screen-space depth source, then bake via the main-bake path. **Invariant:
+> the sun-shadow bake only ever reads main-canvas-layout depth sources; a
+> foreign model-frame canvas texture is never a bake input.** Implementation
+> notes: reuse before adding — if a main-layout texture carrying detached
+> caster depth already exists at BAKE time (P4b-1's depth composite), bake
+> that; otherwise ONE shared resolve accumulating all opt-in casters
+> (min-depth) + ONE extra bake — N casters must not mean N bakes. This also
+> moots backend divergence (even if GL tolerates the foreign read, split
+> cast paths are rejected). The Metal scratch-delivery gap is tracked as its
+> own backend issue; the feature does not block on it. The screen-space
+> caveat (casts only from camera-visible surfaces) is the engine's existing
+> sun-bake model, inherited consistently.
+
 ### Q3 — Receive mechanism
 - **(a) Sample the SHARED world sun-shadow map + 128³ light volume** directly at
   each detached voxel's recovered **world** position. Requires plumbing the
@@ -198,11 +222,14 @@ Each phase is its own PR, stacks on the previous, and is independently verifiabl
    cast-shadow-on-a-detached-solid is awkward to frame in `canvas_stress` because its
    sun direction ≈ the iso camera direction, so cast shadows fall away from the camera;
    the end-to-end visual lands naturally with P4b-3 on the #1587 shadow floor.
-3. **P4b-3 — cast (Q2a).** Second bake dispatch per opt-in detached canvas into the
-   shared sun-shadow map (world-depth offset + translation recovery, per the per-axis
-   resolve-bake precedent). GL + Metal. Opt-in solids now cast onto the floor + world.
-   **Natural visual verification target: the #1587 shadow floor** — an opt-in detached
-   solid dropping a shadow on it is the end-to-end proof.
+3. **P4b-3 — cast (Q2a′, revised — see the Q2 REVISED decision above).** Resolve opt-in
+   detached canvases' distances (model frame + `worldCellOffset`) into a main-canvas-layout
+   screen-space depth source, then bake that through the proven main-bake path (the faithful
+   mirror of the per-axis resolve-bake precedent). GL + Metal. Opt-in solids now cast onto
+   the floor + world. **Natural visual verification target: the #1587 shadow floor** — an
+   opt-in detached solid dropping a shadow on it is the end-to-end proof; that visible
+   shadow on both backends IS the definition of done (task pointer:
+   `.fleet/plans/issue-1596.md`, resume on PR #1626).
 
 Each PR carries its own render-verify references (GL + Metal). Default-path
 (screen-locked) references must stay byte-identical through all three phases —


### PR DESCRIPTION
## Summary

Docs-only architect package unblocking the three `fleet:design-blocked` render PRs. Each gets a committed plan file (cross-host workers read plans from the repo copy) and the world-light design doc gets the revised Q2 cast mechanism. The companion PR comments + label swaps route the work back to the fleet.

- **`.fleet/plans/issue-1619.md`** (PR #1623 — re-voxelize inverse path drops every rotated solid): decision #2 — single-canvas isolation repro **before** any fix, then per-pool **private dest-domain buffers** (the original Option-A "private pool" intent; fixes the cross-canvas clobber by construction and retires the `destCount <= maxSingleVoxels` assert cap). Un-bless the regressed `revoxelize_solids` reference; pose-deterministic (`--no-spin`) evidence. **DoD: every DETACHED_REVOXELIZE solid renders hole-free at every pose and size — no missing faces, no missing solids.**
- **`.fleet/plans/issue-1457.md`** (PR #1625 — per-axis yaw depth scramble): re-plan v3 — the store-key lead is **disproven** (worker's byte-identical measurement + collision-free-store argument accepted; second disproven lead after #1601). Hard rule: no third fix until the failing mechanism is **visualized** (axis-canvas-ID + recovered-origin debug modes, kept in-tree). Evidence-contingent fixes pre-authorized (shared exact cross-axis depth key if interleave confirms); re-escalate only for the retire-forward-scatter structural call. **DoD: depth-color shots 2/4 clean across the band except the documented exact-45°/135° knife-edge; cardinal byte-identical.**
- **`.fleet/plans/issue-1596.md` + `docs/design/detached-revoxelize-world-light.md`** (PR #1626 — P4b-3 cast dead on Metal): Q2 revised **(a) → (a′) resolve-then-bake** — never bind a foreign model-frame R32I canvas texture as a bake input; resolve opt-in detached casters into a main-layout screen-space depth source and bake via the proven main path (the faithful per-axis precedent). Backend-unified; the Metal scratch-delivery gap is filed separately and does not block the feature. **DoD: a `worldPlaced_` solid casts a visible sun shadow onto the #1587 SDF floor on both backends.**

## Test plan

- [ ] Docs-only — no build impact. Review the three plan files + the Q2 REVISED block for consistency with the PR threads (#1623, #1625, #1626).

🤖 Generated with [Claude Code](https://claude.com/claude-code)