### PR TITLE
editor: .rig save/load — C_Skeleton + joints + bindPose (Ctrl+Shift+S/O) (#1609)

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -16,6 +16,7 @@
 #include <irreden/voxel/components/component_voxel_set.hpp>
 #include <irreden/voxel/components/component_joint.hpp>
 #include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/voxel/rig_bridge.hpp>
 #include <irreden/render/components/component_canvas_ao_texture.hpp>
 #include <irreden/render/components/component_canvas_light_volume.hpp>
 #include <irreden/render/components/component_canvas_sun_shadow.hpp>
@@ -90,6 +91,8 @@
 
 // Scene save/load
 #include "scene_io.hpp"
+// Rig save/load (joint entities ↔ .rig asset)
+#include "rig_scene_io.hpp"
 
 // Loft-tool mask rendering (trixel_rect fillRect, trixel_text renderText,
 // mask_grid_painter drawMaskGridOntoCanvas + hitTestGridCell,
@@ -783,7 +786,8 @@ struct JointToolState {
     IREntity::EntityId rigRoot_ = IREntity::kNullEntity;
     int activeJointIdx_ = -1;    // index into joints_ (-1 = rig root)
     std::vector<int> parentIdx_; // parallel to joints_; -1 = rig root
-    bool bindPoseRecaptured_ = false; // cleared each beginTick; prevents O(joints×archetypes) redundant recompute
+    bool bindPoseRecaptured_ =
+        false; // cleared each beginTick; prevents O(joints×archetypes) redundant recompute
 };
 JointToolState g_jointTool;
 
@@ -807,8 +811,10 @@ void recomputeJointBindPose() {
     if (g_jointTool.rigRoot_ == IREntity::kNullEntity)
         return;
     auto &skeleton = IREntity::getComponent<C_Skeleton>(g_jointTool.rigRoot_);
-    IR_ASSERT(g_jointTool.parentIdx_.size() == skeleton.joints_.size(),
-              "parentIdx_ / joints_ size mismatch");
+    IR_ASSERT(
+        g_jointTool.parentIdx_.size() == skeleton.joints_.size(),
+        "parentIdx_ / joints_ size mismatch"
+    );
     const std::size_t count = skeleton.joints_.size();
     skeleton.bindPose_.assign(count, IRMath::SQT{});
     for (std::size_t i = 0; i < count; ++i) {
@@ -1221,8 +1227,7 @@ void initSystems() {
             if (leftReleasedNow && IRVoxelEditor::g_fillTool.dragging_) {
                 IRVoxelEditor::g_fillTool.dragging_ = false;
                 if (IRVoxelEditor::g_fillTool.ghostEntity_ != IREntity::kNullEntity) {
-                    IREntity::getComponent<C_ShapeDescriptor>(
-                        IRVoxelEditor::g_fillTool.ghostEntity_
+                    IREntity::getComponent<C_ShapeDescriptor>(IRVoxelEditor::g_fillTool.ghostEntity_
                     )
                         .flags_ = IRMath::SDF::SHAPE_FLAG_NONE;
                 }
@@ -1932,8 +1937,7 @@ void initCommands() {
             if (IRVoxelEditor::g_fillTool.dragging_) {
                 IRVoxelEditor::g_fillTool.dragging_ = false;
                 if (IRVoxelEditor::g_fillTool.ghostEntity_ != IREntity::kNullEntity) {
-                    IREntity::getComponent<C_ShapeDescriptor>(
-                        IRVoxelEditor::g_fillTool.ghostEntity_
+                    IREntity::getComponent<C_ShapeDescriptor>(IRVoxelEditor::g_fillTool.ghostEntity_
                     )
                         .flags_ = IRMath::SDF::SHAPE_FLAG_NONE;
                 }
@@ -2092,7 +2096,10 @@ void initCommands() {
         IRInput::ButtonStatuses::PRESSED,
         IRInput::KeyMouseButtons::kKeyButtonS,
         []() {
-            if (!IRInput::checkKeyMouseModifiers(IRInput::kModifierControl, 0u))
+            if (!IRInput::checkKeyMouseModifiers(
+                    IRInput::kModifierControl,
+                    IRInput::kModifierShift
+                ))
                 return;
             auto &anim = IRVoxelEditor::g_anim;
             IRVoxelEditor::snapshotLiveToFrame(anim.activeFrame_);
@@ -2120,13 +2127,48 @@ void initCommands() {
         }
     );
 
+    // Ctrl+Shift+S — save skeleton to {kSceneSaveDir}/{kSceneBaseName}.rig.
+    IRCommand::createCommand(
+        IRInput::InputTypes::KEY_MOUSE,
+        IRInput::ButtonStatuses::PRESSED,
+        IRInput::KeyMouseButtons::kKeyButtonS,
+        []() {
+            if (!IRInput::checkKeyMouseModifiers(
+                    IRInput::kModifierControl | IRInput::kModifierShift,
+                    0u
+                ))
+                return;
+            if (IRVoxelEditor::g_jointTool.rigRoot_ == IREntity::kNullEntity) {
+                IR_LOG_WARN("No rig to save — author joints with J + B first.");
+                return;
+            }
+            auto res = IRVoxelEditor::saveRigScene(
+                std::string(IRVoxelEditor::kSceneSaveDir),
+                std::string(IRVoxelEditor::kSceneBaseName),
+                IRVoxelEditor::g_jointTool.rigRoot_,
+                IRVoxelEditor::g_jointTool.parentIdx_
+            );
+            if (res.ok_)
+                IR_LOG_INFO(
+                    "Rig saved to {}/{}",
+                    IRVoxelEditor::kSceneSaveDir,
+                    IRVoxelEditor::kSceneBaseName
+                );
+            else
+                IR_LOG_ERROR("Rig save failed: {}", res.errorMsg_);
+        }
+    );
+
     // Ctrl+O — load scene from disk, replacing all frames and layer state.
     IRCommand::createCommand(
         IRInput::InputTypes::KEY_MOUSE,
         IRInput::ButtonStatuses::PRESSED,
         IRInput::KeyMouseButtons::kKeyButtonO,
         []() {
-            if (!IRInput::checkKeyMouseModifiers(IRInput::kModifierControl, 0u))
+            if (!IRInput::checkKeyMouseModifiers(
+                    IRInput::kModifierControl,
+                    IRInput::kModifierShift
+                ))
                 return;
             auto loaded = IRVoxelEditor::loadEditorScene(
                 std::string(IRVoxelEditor::kSceneSaveDir),
@@ -2176,6 +2218,109 @@ void initCommands() {
                 IRVoxelEditor::kSceneSaveDir,
                 IRVoxelEditor::kSceneBaseName,
                 anim.frameCount()
+            );
+        }
+    );
+
+    // Ctrl+Shift+O — load skeleton from {kSceneSaveDir}/{kSceneBaseName}.rig.
+    // Destroys existing joint entities and their gizmo children, then
+    // reconstructs the skeleton from the saved .rig file.
+    IRCommand::createCommand(
+        IRInput::InputTypes::KEY_MOUSE,
+        IRInput::ButtonStatuses::PRESSED,
+        IRInput::KeyMouseButtons::kKeyButtonO,
+        []() {
+            if (!IRInput::checkKeyMouseModifiers(
+                    IRInput::kModifierControl | IRInput::kModifierShift,
+                    0u
+                ))
+                return;
+
+            auto loaded = IRVoxelEditor::loadRigScene(
+                std::string(IRVoxelEditor::kSceneSaveDir),
+                std::string(IRVoxelEditor::kSceneBaseName)
+            );
+            if (!loaded.ok_) {
+                IR_LOG_ERROR("Rig load failed: {}", loaded.errorMsg_);
+                return;
+            }
+
+            // Collect existing joint ids.
+            std::vector<IREntity::EntityId> oldJointIds;
+            IREntity::forEachComponent<IRComponents::C_Joint>(
+                [&](IREntity::EntityId id, IRComponents::C_Joint &) { oldJointIds.push_back(id); }
+            );
+
+            // Collect gizmo handles anchored to those joints, then destroy
+            // gizmos first so no child tries to read a destroyed parent.
+            {
+                std::vector<IREntity::EntityId> oldGizmoIds;
+                IREntity::forEachComponent<IRComponents::C_GizmoHandle>(
+                    [&](IREntity::EntityId id, IRComponents::C_GizmoHandle &h) {
+                        for (const auto jid : oldJointIds) {
+                            if (h.anchorEntity_ == jid) {
+                                oldGizmoIds.push_back(id);
+                                break;
+                            }
+                        }
+                    }
+                );
+                for (const auto id : oldGizmoIds)
+                    IREntity::destroyEntity(id);
+            }
+            for (const auto id : oldJointIds)
+                IREntity::destroyEntity(id);
+
+            // Reset skeleton and authoring tool state.
+            const IREntity::EntityId rigRoot = IRVoxelEditor::ensureRigRoot();
+            {
+                auto &skeleton = IREntity::getComponent<IRComponents::C_Skeleton>(rigRoot);
+                skeleton.joints_.clear();
+                skeleton.bindPose_.clear();
+            }
+            IRVoxelEditor::g_jointTool.parentIdx_.clear();
+            IRVoxelEditor::g_jointTool.activeJointIdx_ = -1;
+            IRVoxelEditor::g_jointTool.bindPoseRecaptured_ = false;
+
+            // Reconstruct joint entities from the loaded rig.
+            const auto &rig = loaded.rig_;
+            const std::size_t count = rig.joints_.size();
+            std::vector<IREntity::EntityId> newJoints;
+            newJoints.reserve(count);
+
+            for (std::size_t i = 0; i < count; ++i) {
+                const auto &j = rig.joints_[i];
+                const IRMath::vec3 t{j.translation_.x, j.translation_.y, j.translation_.z};
+                const IREntity::EntityId joint = IREntity::createEntity(
+                    IRComponents::C_LocalTransform{t, j.rotation_},
+                    IRComponents::C_Joint{}
+                );
+                const bool atRigRoot = j.parentIndex_ == static_cast<std::uint32_t>(i) ||
+                                       j.parentIndex_ >= static_cast<std::uint32_t>(count);
+                const IREntity::EntityId parentEntity =
+                    atRigRoot ? rigRoot : newJoints[j.parentIndex_];
+                IREntity::setParent(joint, parentEntity);
+                IRPrefab::Gizmo::createJointMarker(joint);
+                IRPrefab::Gizmo::createTranslateGizmoForAnchor(joint);
+                newJoints.push_back(joint);
+                IRVoxelEditor::g_jointTool.parentIdx_.push_back(
+                    atRigRoot ? -1 : static_cast<int>(j.parentIndex_)
+                );
+            }
+
+            // Re-fetch skeleton after all createEntity calls to avoid
+            // stale references, then populate joints and bind pose.
+            {
+                auto &skeleton = IREntity::getComponent<IRComponents::C_Skeleton>(rigRoot);
+                skeleton.joints_.insert(skeleton.joints_.end(), newJoints.begin(), newJoints.end());
+                skeleton.bindPose_ = IRPrefab::Rig::bindPose(rig);
+            }
+
+            IR_LOG_INFO(
+                "Rig loaded: {} joints from {}/{}",
+                count,
+                IRVoxelEditor::kSceneSaveDir,
+                IRVoxelEditor::kSceneBaseName
             );
         }
     );
@@ -2343,14 +2488,12 @@ void initEntities() {
             kSwatchOriginX + col * (kSwatchSize + kSwatchGap),
             kSwatchOriginY + row * (kSwatchSize + kSwatchGap)
         );
-        g_editor.paletteSwatches_.push_back(
-            IRPrefab::Widget::makeColorSwatch(
-                pos,
-                ivec2(kSwatchSize, kSwatchSize),
-                IRVoxelEditor::kPaletteColors[i],
-                i == 0
-            )
-        );
+        g_editor.paletteSwatches_.push_back(IRPrefab::Widget::makeColorSwatch(
+            pos,
+            ivec2(kSwatchSize, kSwatchSize),
+            IRVoxelEditor::kPaletteColors[i],
+            i == 0
+        ));
     }
 
     // Animation controls panel (T-214, F-1.4) — sits below the palette

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -2297,6 +2297,8 @@ void initCommands() {
                 );
                 const bool atRigRoot = j.parentIndex_ == static_cast<std::uint32_t>(i) ||
                                        j.parentIndex_ >= static_cast<std::uint32_t>(count);
+                IR_ASSERT(atRigRoot || j.parentIndex_ < i,
+                    ".rig parentIndex forward-reference — not supported by linear reconstruction");
                 const IREntity::EntityId parentEntity =
                     atRigRoot ? rigRoot : newJoints[j.parentIndex_];
                 IREntity::setParent(joint, parentEntity);

--- a/creations/editors/voxel_editor/rig_scene_io.hpp
+++ b/creations/editors/voxel_editor/rig_scene_io.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+// Save/load round-trip for the editor's entity-based skeleton.
+//
+// Ctrl+Shift+S: skeletonToRig() packs C_Skeleton joint transforms into an
+//   IRAsset::Rig (JNTS chunk), then writes to {dir}/{baseName}.rig.
+// Ctrl+Shift+O: loads the .rig as an IRAsset::Rig; the caller reconstructs
+//   joint entities, CHILD_OF relations, C_Skeleton, and bindPose_.
+//
+// Only the JNTS chunk is written — BIND (named attachment points managed
+// by C_BindPoints) is a separate concept outside the joint-authoring tool.
+//
+// parentIndex sentinel: joints parented to the rig root are stored on disk
+// with parentIndex == their own joint index (self-reference).  The load
+// path in main.cpp maps self-ref or out-of-range back to parentIdx = -1.
+
+#include <irreden/asset/rig_format.hpp>
+
+#include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/common/components/component_local_transform.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace IRVoxelEditor {
+
+struct RigSaveResult {
+    bool ok_ = false;
+    std::string errorMsg_;
+};
+
+struct RigLoadResult {
+    bool ok_ = false;
+    std::string errorMsg_;
+    IRAsset::Rig rig_;
+};
+
+// Build an IRAsset::Rig from the live entity skeleton.
+// parentIdx is parallel to C_Skeleton.joints_; -1 means the joint's parent
+// is the rig root, stored on disk as a self-reference sentinel.
+inline IRAsset::Rig skeletonToRig(
+    IREntity::EntityId rigRoot,
+    const std::vector<int> &parentIdx
+) {
+    const auto &skeleton =
+        IREntity::getComponent<IRComponents::C_Skeleton>(rigRoot);
+    const std::size_t count = skeleton.joints_.size();
+
+    IRAsset::Rig rig;
+    rig.joints_.reserve(count);
+
+    for (std::size_t i = 0; i < count; ++i) {
+        const auto &xform =
+            IREntity::getComponent<IRComponents::C_LocalTransform>(skeleton.joints_[i]);
+        IRAsset::RigJoint j;
+        j.rotation_ = xform.rotation_;
+        j.translation_ = IRMath::vec4{
+            xform.translation_.x, xform.translation_.y, xform.translation_.z, 0.0f};
+        j.parentIndex_ = (parentIdx[i] < 0)
+            ? static_cast<std::uint32_t>(i)
+            : static_cast<std::uint32_t>(parentIdx[i]);
+        rig.joints_.push_back(std::move(j));
+    }
+
+    return rig;
+}
+
+// Save the editor skeleton to {dir}/{baseName}.rig.
+// Creates the directory if it does not exist.
+inline RigSaveResult saveRigScene(
+    const std::string &dir,
+    const std::string &baseName,
+    IREntity::EntityId rigRoot,
+    const std::vector<int> &parentIdx
+) {
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    if (ec) {
+        RigSaveResult err;
+        err.errorMsg_ = "Could not create directory '" + dir + "': " + ec.message();
+        return err;
+    }
+
+    const IRAsset::Rig rig = skeletonToRig(rigRoot, parentIdx);
+    const IRAsset::BinaryStatus status = IRAsset::saveRig(baseName, dir, rig);
+    if (!status.ok()) {
+        RigSaveResult err;
+        err.errorMsg_ = "saveRig failed for '" + dir + "/" + baseName + ".rig'";
+        return err;
+    }
+
+    RigSaveResult success;
+    success.ok_ = true;
+    return success;
+}
+
+// Load a rig previously saved by saveRigScene.
+// Returns the asset-level IRAsset::Rig; the caller reconstructs joint entities.
+inline RigLoadResult loadRigScene(const std::string &dir, const std::string &baseName) {
+    auto r = IRAsset::loadRig(baseName, dir);
+    if (!r.ok()) {
+        RigLoadResult err;
+        err.errorMsg_ = "Could not load rig from '" + dir + "/" + baseName + ".rig'";
+        return err;
+    }
+
+    RigLoadResult result;
+    result.ok_ = true;
+    result.rig_ = std::move(r.value_);
+    return result;
+}
+
+} // namespace IRVoxelEditor

--- a/creations/editors/voxel_editor/rig_scene_io.hpp
+++ b/creations/editors/voxel_editor/rig_scene_io.hpp
@@ -48,6 +48,7 @@ inline IRAsset::Rig skeletonToRig(
     const auto &skeleton =
         IREntity::getComponent<IRComponents::C_Skeleton>(rigRoot);
     const std::size_t count = skeleton.joints_.size();
+    IR_ASSERT(parentIdx.size() == count, "parentIdx / skeleton.joints_ size mismatch in skeletonToRig");
 
     IRAsset::Rig rig;
     rig.joints_.reserve(count);


### PR DESCRIPTION
## Summary

- Adds `creations/editors/voxel_editor/rig_scene_io.hpp` with `saveRigScene` / `loadRigScene` free functions that convert between the entity-based skeleton and `IRAsset::Rig` (JNTS chunk via `IRAsset::saveRig` / `loadRig`)
- **Ctrl+Shift+S** — saves each joint's `C_LocalTransform` (rotation + translation) and parent-index chain into `{kSceneSaveDir}/{kSceneBaseName}.rig`; joints parented to the rig root use the self-reference sentinel
- **Ctrl+Shift+O** — destroys existing `C_Joint` entities and their `C_GizmoHandle` children (anchored to those joints), then reconstructs joint entities with `CHILD_OF` relations, `C_Skeleton.joints_`, and `bindPose_` derived via `IRPrefab::Rig::bindPose`
- **Ctrl+S / Ctrl+O** now explicitly block Shift (`kModifierShift` as second arg) so the two key-pairs don't fire together

Stacked on #1641 (joint authoring — `claude/1604-editor-joint-authoring`).
Closes #1609.

## Test plan

- [ ] Ctrl+Shift+S with active skeleton saves `data/editor_scene/scene.rig` + sidecar `.rig.json`
- [ ] Ctrl+Shift+O loads the saved rig, destroys old joints/gizmos, reconstructs joint entities at correct positions with CHILD_OF relations
- [ ] `C_Skeleton.bindPose_` populated (parallel to joints_, derived from JNTS local transforms)
- [ ] Ctrl+S / Ctrl+O (no Shift) still save/load the voxel scene only (no cross-fire)
- [ ] No rig root: Ctrl+Shift+S logs WARN and returns without crash
- [ ] Build clean, `fleet-run IRVoxelEditor --auto-screenshot 10` exits 0

🤖 Generated with [Claude Code](https://claude.ai/claude-code)