### PR TITLE
docs/fleet: plan files for the epic-steward epic (#1661)

### DIFF
--- a/.fleet/plans/issue-1661.md
+++ b/.fleet/plans/issue-1661.md
@@ -1,0 +1,267 @@
+# Epic-Steward: a durable epic-lifecycle role for the fleet
+
+## Context
+
+Epics are well-served at filing time (`file-epic`: umbrella + phased children +
+repo-committed plans + `fleet-validate-stack`) but nobody owns them afterward.
+Investigation confirmed the gaps:
+
+- **Epic auto-close does not exist.** Three doc surfaces claim it does
+  (`fleet-labels-reference.md`, `fleet-labels` line 105, `fleet-state-machine.json`)
+  naming two *different* owners — but `fleet:epic` appears in the scout only in
+  `_INGEST_SKIP_LABELS`. Closure has always been manual.
+- **Design blocks are manual one-at-a-time architect work** (see commit 24d50b92:
+  hand-written plan files, one docs PR, per-PR label flips). No aggregation, no
+  completion tracking.
+- **Plans go stale**: re-plans live in PR comment threads, not plan files; nobody
+  re-validates a downstream child's plan after a sibling merges or the merger
+  restacks it.
+- **Scope changes are invisible**: issues filed mid-epic with `**Part of epic:** #N`
+  are never adopted into the umbrella checklist; umbrella checklists have already
+  drifted (epic #1553 has no body checklist at all — children live only in a comment).
+
+The fix is a new autonomous role, **epic-steward**: transient, dispatcher-driven
+(like opus-worker, not the interactive architect), one pane, Opus/heavy tier,
+covering both repos. Durable state lives cross-host in GitHub (labels, umbrella
+body checklist) + repo-committed plan files — never in a session.
+
+**Decisions made with the user:**
+1. Merger keeps mechanical restacking; steward does the *semantic* follow-up
+   (ledger, plan re-validation, amendments).
+2. Steward resolves design blocks autonomously **when derivable** from the umbrella
+   plan/decision log; novel decisions aggregate into one proposal package for the
+   human/architect.
+3. Transient dispatcher-driven runtime; repo-committed ledger as memory.
+4. **Delivery: file as a fleet epic** (dogfood — this becomes the first epic the
+   steward shepherds once early phases land).
+
+## The design
+
+### Role responsibilities (four flows, priority order per epic)
+
+a. **Design-block triage** — for `fleet:design-blocked` PRs whose backing issue is
+   in a claimed epic's checklist: classify each question DERIVABLE (can cite the
+   deciding sentence in the umbrella plan/decision log/design doc) vs NOVEL.
+   All-derivable → amend the child plan (`## Amendments` entry), post
+   `## Steward direction` PR comment, atomic `design-unblock` transition.
+   Any-novel → swap PR label to `fleet:design-proposed`, post ONE aggregated
+   `## STEWARD PROPOSAL` comment on the umbrella, add `fleet:steward-proposal`
+   to the umbrella. Human/architect answers on the umbrella thread and removes
+   the label → projection re-fires → questions are now derivable → steward
+   distributes and unblocks. Non-epic design blocks remain the architect's lane.
+b. **Post-merge follow-up** — child merged: tick `- [x] #N` in the umbrella body,
+   update ledger, audit scope drift, re-validate every downstream child's plan
+   against what actually merged (stale = references a symbol/file/decision the
+   merge renamed/removed/superseded), amend stale plans. Never touches branches.
+c. **Adoption** — open issues matching `Part of epic: #U` absent from the
+   checklist: validate structured fields, append `- [ ] #K` to the checklist,
+   plan stub if missing, re-run `fleet-validate-stack`.
+d. **Close-out** — all checklist children closed: verify each closed via merged PR
+   or explicit rationale, audit umbrella closing criteria with evidence, post
+   closure-summary comment, close the umbrella. (Implements the promise the docs
+   already make.)
+
+Iteration budget: ≤2 epics, ≤3 triaged PRs, ≤1 proposal package per iteration;
+all plan/ledger writes batch into **one docs-only PR per repo per iteration**
+(branch `claude/epic-steward-<timestamp>`, via commit-and-push). Urgent signals
+don't wait on the PR: unblocks signal via label flip + PR comment, proposals via
+umbrella comment, close-outs via issue close.
+
+### Durable state
+
+- **Membership source of truth**: umbrella issue body `## Children` checklist
+  (`- [ ] #N` / `- [x] #N`). Steward heals it on first claim of pre-protocol
+  epics (union of checklist + `Part of epic` search + summary-comment table).
+  Umbrella-body editing is an explicit steward carve-out, claimed umbrellas only.
+- **Semantic ledger**: a `## Steward ledger` section appended to the umbrella's
+  own plan file `.fleet/plans/issue-<U>.md` (NOT a separate file — worker role
+  docs hard-rule `issue-<N>.md` as the only valid filename). Schema:
+  `reconciled-through:` marker, `### Children` table (state/PR/plan/last-validated),
+  `### Decisions` index, `### Events` log. `reconciled-through` makes fresh-context
+  iterations idempotent.
+- **Plan amendments**: append-only `## Amendments` section
+  (`### A1 — <date> — trigger: <event>` + decision/supersedes/criteria/by),
+  formalizing the existing ad-hoc "Architect RE-plan v3" pattern in issue-1457.md.
+
+### New labels (exactly two, each load-bearing)
+
+- `fleet:design-proposed` (PR scope) — steward queued this PR's question into a
+  proposal; removes the PR from the steward's design projection edge-cleanly,
+  joins `PARKED_PR_LABELS`, review-skip, merger-skip, and reconcile R2/R7
+  exclusions (without which reconcile auto-"heals" every proposal within ~3 ticks).
+- `fleet:steward-proposal` (umbrella issue scope) — proposal package pending;
+  human-facing queue; its **removal** is the edge that re-fires distribution.
+
+Transitions: new `design-propose` edge; `design-unblock` and `design-block` each
+gain `fleet:design-proposed` in their remove sets. Catalog + state-machine JSON +
+labels-reference must change in the same commit (`fleet-labels --check`).
+
+### Claims (multi-device safety)
+
+New `fleet:stewarding-<host>-<agent>` label class on the **umbrella issue** —
+`_cmd_pr_label_claim` is already prefix-parameterized and works on issues
+(fleet-claim:1196-1255). Per-epic granularity; same sole-holder tie-break as
+`fleet:reviewing-`. New `cmd_cleanup_gh` pass sweeping open `fleet:epic` issues,
+TTL `FLEET_CLAIM_STALE_SECS_STEWARD=3600`. Rejected: reusing `fleet:claim-*`
+(issue-lifecycle semantics mismatch a short stewardship session).
+
+### Scout projection (`project_epic_steward`)
+
+New `fetch_epics(repo)` (one `gh` list call per repo per tick, body parsed into
+`checklist` then popped); parse `Part of epic` where bodies already flow
+(`fetch_task_queue`, `resolve_human_approved_blockers`). Ops, all edge-triggered
+by the steward's own writes (no timestamps/transient labels in the hash — the
+documented `project_merger` lesson):
+
+- `normalize` — managed epic (plan file exists) with no body checklist → heal.
+  Legacy checklist-less epics *without* plan files emit nothing (no perma-trigger).
+- `rollup` — unchecked checklist child that is closed.
+- `adopt` — visible open issue declaring `Part of epic: #U` absent from checklist.
+- `design` — `fleet:design-blocked` PR branch-matched to a checklist child; plus
+  `fleet:design-proposed` PRs whose umbrella no longer carries
+  `fleet:steward-proposal` (= answered → distribute).
+- `closeout` — all checklist children closed, umbrella open.
+
+Closed-check uses already-fetched open/closed sets with rare
+`_resolve_ref_satisfied` fallback. Membership join beyond the checklist happens
+steward-side at iteration time (search is too expensive for the 30s tick).
+
+### Boundary contracts
+
+- **Merger** owns branches/re-targeting; steward never pushes to a child PR branch
+  and only touches the design label pair via `fleet-transition`. Role-doc skip:
+  defer plan re-validation while the next child's PR carries
+  `fleet:merger-cooldown`/`fleet:stacked-rebase`.
+- **Ingest** owns `fleet:queued`/`fleet:blocked`/model labels; steward's queue
+  hygiene = validate-stack + fixing the three machine-parsed body lines only.
+- **Architect** keeps non-epic design blocks + answers proposal packages
+  (architect-protocol.md gains a "steward-first for epic children" paragraph).
+- **Isolation**: game-epic ledgers/amendments commit only to the game repo;
+  engine artifacts reference downstream work as `game#N`, no feature names; the
+  canonical protocol says "downstream repo" throughout.
+
+### Cross-repo inheritance (the connection improvement)
+
+- New `docs/design/role-sharing.md` mirroring skill-sharing.md: canonical
+  `docs/agents/<role>-protocol.md` declares a `## Repo deltas this flow needs`
+  table; per-repo `.claude/commands/role-<name>.md` thin wrappers answer every
+  key. Baseline key set: repo-slug, repo-root, worktree-path, role-name,
+  role-banner, claim-tool-flags, feedback-file.
+- **New-role checklist**: a PR adding a canonical protocol must add the engine
+  wrapper in the same PR and file the downstream-wrapper follow-up issue on the
+  game repo before merge.
+- **New lint `fleet-validate-roles`** (pure file I/O, module + executable split
+  like fleet-validate-stack): every protocol with a delta table has a wrapper in
+  each fleet-enabled repo root; every wrapper answers every declared key. Alias
+  map for role-game-architect's legacy key names initially (defer rename).
+
+## The epic to file (execution = run `file-epic`)
+
+Umbrella: `fleet: epic-steward — autonomous epic-lifecycle role (adopt / follow-up / design-triage / close-out)`
+
+| Phase | Child | Model | Blocked by |
+|---|---|---|---|
+| P1 | docs: epic-steward canonical protocol, role-sharing.md, engine role wrapper, label catalog + transitions + doc fixes | opus | (none) |
+| P2 | fleet: steward claim class + cleanup pass + design-proposed parked/reconcile exclusions | opus | P1 |
+| P3 | fleet: scout epic fetch + project_epic_steward/slice + skip-set updates | opus | P1 |
+| P4 | fleet: dispatcher + fleet-up registration (pane, caps, worktrees, bootstrap trigger, conf sample) | sonnet | P3 |
+| P5 | fleet: `fleet-epic-status <N>` helper + install.sh | sonnet | P1 |
+| P6 | fleet: `fleet-validate-roles` lint + tests (+ validate-stack `--check-checklist`) | sonnet | P1 |
+| P7 | skills: file-epic initializes Children checklist + Steward ledger; anti-patterns | sonnet | P1 |
+
+Plus: game-wrapper follow-up issue filed on `jakildev/irreden` per the new-role
+checklist (the P1 PR files it — eating the dogfood).
+
+Burn-in: role ships opt-in (`FLEET_EPIC_STEWARD=1` in fleet-up.conf), flipped to
+default-on after a week of feedback entries. Heal-on-first-claim backfill only;
+no bulk backfill pass. Budget numbers (2/3/1) are tunable defaults.
+
+### Per-phase content anchors (verified)
+
+- **P1**: new `docs/agents/epic-steward-protocol.md` (full skeleton drafted in
+  planning — startup, claim etiquette, four flows, amendment format, proposal
+  format, escalation rules, modes, hard rules); new `docs/design/role-sharing.md`;
+  new `.claude/commands/role-epic-steward.md` (Deltas: repo-slug, downstream-repo
+  pair, worktree paths, escalation-target=opus-architect, ledger-branch-prefix
+  `claude/epic-steward-`, feedback file); edits to
+  `docs/agents/architect-protocol.md` (steward-first), `docs/agents/FLEET.md`
+  (design-escalation branch), `docs/agents/fleet-labels-reference.md` (fix
+  `fleet:epic` auto-close claim → steward; register both new labels),
+  `scripts/fleet/fleet-labels` (~line 99 LABELS + fix line 105 epic description),
+  `docs/agents/fleet-state-machine.json` (nodes + `design-propose` edge + edits
+  to `design-unblock`/`design-block` remove-sets).
+- **P2**: `scripts/fleet/fleet-claim` — `cmd_steward_claim/release` next to line
+  1250 wrappers; new cleanup pass after line ~1472 (open `fleet:epic` issues);
+  `scripts/fleet/fleet_branch_match.py:70` PARKED_PR_LABELS += design-proposed;
+  reconcile R2 (~2133), R7 (~2176), R4a (~2069) exclusions. Tests: clone of
+  test_fleet_claim_acquire + reconcile-heal regression.
+- **P3**: `scripts/fleet/fleet-state-scout` — `fetch_epics` after line 199 +
+  fetch_specs (~1601-1617); `_parse_epic_checklist` regex (first `#N` per
+  checkbox line, handles bold-wrapped refs); epic field in task/approved dicts;
+  `project_epic_steward` + `PROJECTORS` (1379), `slice_epic_steward` + `SLICERS`
+  (~1562); `fleet:design-proposed` added to REVIEW_SKIP_LABELS (782),
+  `_DESIGN_BLOCK_LABELS` (851), `_merger_action_signal` (1248); epics in detail
+  cache + gc keep-set. Tests: projection fixtures (quiescence, edge-consumption,
+  legacy-epic-emits-nothing), checklist parser.
+- **P4**: `scripts/fleet/fleet-dispatcher` — DISPATCHED_ROLES (285), env capture,
+  ROLE_CONCURRENCY=1 (105), ROLE_MODEL=$HEAVY_MODEL (318), ROLE_EFFORT=xhigh
+  (335); `scripts/fleet/fleet-up` — dual worktrees (engine + game, gated on
+  FLEET_EPIC_STEWARD), reset_worktree, settings loop, ops-window pane after
+  smoke-worker block (~1382), bootstrap trigger predicate (~1042);
+  fleet-up.conf.sample. No fleet-dispatch-wrap change needed.
+- **P5**: new `scripts/fleet/fleet-epic-status` (umbrella state, checklist-vs-
+  discovered drift rows, per-child state/PR/plan presence, embedded
+  validate_stack; `--json` for steward consumption); install.sh pairs.
+- **P6**: new `scripts/fleet/fleet_validate_roles.py` + executable + tests.
+- **P7**: `docs/agents/skills/file-epic.md` — step 2 seeds ledger section, new
+  step 3.5 writes the `## Children` body checklist, step 7 links ledger,
+  anti-pattern entry. Wrappers inherit automatically; no new delta keys.
+
+## Verification
+
+- After P1: `fleet-labels --check` passes; `fleet-transition design-propose <PR>`
+  dry-runs against the JSON; engine wrapper resolves the protocol path.
+- After P2: `scripts/fleet/tests/test_fleet_claim_steward.sh` green; reconcile
+  regression test proves a design-proposed PR is NOT healed.
+- After P3: projection tests green (same-state-twice → same hash; box-check
+  consumes rollup; checklist-less legacy epic emits nothing); run scout one tick
+  locally and inspect `~/.fleet/state/projections/epic-steward.json`.
+- After P4: `FLEET_EPIC_STEWARD=1 fleet-up` creates the pane; seed a trigger and
+  watch one dispatched iteration end-to-end on a test epic.
+- After P6: `fleet-validate-roles` passes on the tree and fails when a delta key
+  is deleted from the engine wrapper (negative test).
+- End-to-end dogfood: this epic itself — once P1-P4 land, the steward's first
+  live claims should be on *this* umbrella (rollup ticks as P5-P7 merge, and the
+  close-out flow closes it).
+
+---
+
+## Steward ledger
+
+- **reconciled-through:** 2026-06-10 (filed)
+- **proposal pending:** none
+
+### Children
+
+| Child | Phase | State | PR | Plan | Last validated |
+|---|---|---|---|---|---|
+| #1662 | P1 | open | — | ok | 2026-06-10 (filed) |
+| #1663 | P2 | open | — | ok | 2026-06-10 (filed) |
+| #1664 | P3 | open | — | ok | 2026-06-10 (filed) |
+| #1665 | P4 | open | — | ok | 2026-06-10 (filed) |
+| #1666 | P5 | open | — | ok | 2026-06-10 (filed) |
+| #1667 | P6 | open | — | ok | 2026-06-10 (filed) |
+| #1668 | P7 | open | — | ok | 2026-06-10 (filed) |
+
+### Decisions
+
+- Merger keeps mechanical restacking; the steward does semantic follow-up only (user decision, 2026-06-09).
+- Steward resolves design blocks autonomously when derivable from the umbrella plan/decision log; novel questions aggregate into one proposal package (user decision, 2026-06-09).
+- Transient dispatcher-driven runtime; durable state in GitHub + repo-committed plan files (user decision, 2026-06-09).
+- Exactly two new labels: `fleet:design-proposed` (PR scope) + `fleet:steward-proposal` (issue scope).
+- Ledger lives inside the umbrella's `issue-<N>.md` plan file — a separate filename would violate the worker role docs' plan-filename hard rule.
+- Role ships opt-in behind `FLEET_EPIC_STEWARD=1`; default-on flip decided after a week of feedback entries.
+
+### Events
+
+- 2026-06-10 — filed via file-epic; children #1662–#1668; ledger seeded manually (pre-dates P7 #1668, which automates this).

--- a/.fleet/plans/issue-1662.md
+++ b/.fleet/plans/issue-1662.md
@@ -1,0 +1,142 @@
+# Plan: fleet: epic-steward canonical protocol, role-sharing doc, engine wrapper, labels + transitions (P1)
+
+- **Issue:** #1662
+- **Model:** opus
+- **Date:** 2026-06-10
+- **Epic:** #1661 — see `.fleet/plans/issue-1661.md` for full context
+- **Blocked by:** (none)
+
+## Scope
+
+The all-docs phase: canonical role protocol, role-sharing design doc, engine
+role wrapper, label catalog + state machine + reference updates, and the
+hand-off edits in architect-protocol.md / FLEET.md. Docs-only PR — if any
+change wants to touch a script other than the `fleet-labels` catalog array,
+it is mis-scoped (that work is P2/P3).
+
+## Affected files
+
+- `docs/agents/epic-steward-protocol.md` (new — the centerpiece)
+- `docs/design/role-sharing.md` (new)
+- `.claude/commands/role-epic-steward.md` (new)
+- `scripts/fleet/fleet-labels` — `LABELS=(...)` array (~line 99): two new
+  entries; fix the stale `fleet:epic` description (~line 105) which credits
+  auto-close to the retired queue-manager
+- `docs/agents/fleet-state-machine.json` — two label nodes; new
+  `design-propose` edge; `design-unblock` (~line 394) and `design-block`
+  (~line 382) remove-sets gain `fleet:design-proposed`
+- `docs/agents/fleet-labels-reference.md` — register both labels next to the
+  design-blocked entry (~line 297); rewrite the `fleet:epic` bullet
+  (lines 27–37)
+- `docs/agents/architect-protocol.md` — steward-first paragraph in the
+  design-blocked handling section
+- `docs/agents/FLEET.md` — design-escalation flow gains the steward branch
+
+## Approach
+
+**Protocol doc structure** (full drafted skeleton in the planning record;
+key sections):
+
+1. Header: division of labor (merger = branches, workers = code, architect =
+   non-epic blocks + proposals, steward = epic bookkeeping; steward writes
+   only docs artifacts — plans, umbrella bodies/comments, labels).
+2. `## Repo deltas this flow needs` table: repo-slug, downstream-repo-slug,
+   repo-root / downstream-repo-root, worktree-path / downstream-worktree-path,
+   role-name, role-banner, claim-tool-flags, plans-path,
+   ledger-branch-prefix, escalation-target, feedback-file.
+3. Out-of-scope list: never push to a child PR branch; never claim child
+   tasks; never edit child scope prose (only the three machine-parsed lines
+   when validate-stack flags them); never commit to master; never touch
+   `human:*` labels; never answer non-epic design blocks.
+4. Startup: banner → pwd-confirm + fetch both repos → state.json stale-cache
+   guard → projection read → one-line summary → standing by.
+5. Membership: umbrella body `## Children` checklist is the source of truth;
+   heal-on-first-claim (union checklist + `Part of epic` search + summary-
+   comment table). Umbrella-body editing is an explicit steward carve-out,
+   claimed umbrellas only.
+6. Loop: heartbeat → per-epic claim (`fleet-claim <flags> steward-claim
+   <umbrella> <role-name>`; exit 1 → skip) → flows in order (a) design-block
+   triage, (b) post-merge follow-up, (c) adoption, (d) close-out → batch all
+   plan/ledger writes into ONE docs PR per repo per iteration → shutdown per
+   FLEET-RUNTIME.md. Budget: ≤2 epics, ≤3 triaged PRs, ≤1 proposal package.
+7. Flow a: classify each NEEDS-DESIGN question DERIVABLE (can cite the
+   deciding sentence — synthesizing a new position is NOT derivable) vs
+   NOVEL. All-derivable → plan amendment + `## Steward direction` PR comment
+   + single atomic label swap (one `gh pr edit` with both --remove-label and
+   --add-label, or `fleet-transition design-unblock`). Any-novel → swap to
+   `fleet:design-proposed`, one aggregated `## STEWARD PROPOSAL <date>`
+   comment on the umbrella, add `fleet:steward-proposal` to the umbrella.
+   Responder answers inline and removes the label; the projection re-fires;
+   formerly-novel questions are then derivable — no new machinery.
+8. Flow b: tick `- [x] #N`, ledger update, scope-drift audit on the merged
+   PR, re-validate downstream plans (stale = references a symbol/file/
+   decision the merge renamed/removed/superseded), amend stale plans.
+   Belt-and-suspenders skip: defer re-validation while the next child's PR
+   carries `fleet:merger-cooldown`/`fleet:stacked-rebase`.
+9. Flow c: validate structured fields via validate-stack, append `- [ ] #K`,
+   plan stub ("## Plan status: STUB — needs planning before claim") if
+   missing, re-run validate-stack; never adopt a stack the validator rejects.
+10. Flow d: gate = every checklist child closed (live check). Verify each
+    closed via merged PR or explicit rationale (neither → comment asking the
+    human, do NOT close). Audit umbrella closing criteria with evidence.
+    Closure summary comment (phase/child/PR/outcome table + criteria →
+    evidence + follow-ups). Close umbrella, release claim.
+11. `## Steward ledger` schema (reconciled-through / proposal pending /
+    Children table / Decisions / Events) and append-only `## Amendments`
+    format (`### A<n> — <date> — trigger: <event>` + Decision / Supersedes /
+    Acceptance criteria / By) — formalizes the existing "Architect RE-plan
+    v3" pattern in `.fleet/plans/issue-1457.md`.
+12. Escalation rules: umbrella-goal changes, contradicting recorded
+    decisions, beyond-epic-scope work (file an unlabeled issue), cross-epic
+    interference. Modes: live / dry-run / review-only (no adoption).
+
+**role-sharing.md**: mirror `docs/design/skill-sharing.md` section-for-
+section — problem, decision (canonical `docs/agents/<role>-protocol.md`
+declaring the delta table; thin wrappers answering every key), shared-vs-
+delta line, why runtime indirection, wrapper template, baseline delta-key
+set, **new-role checklist** (engine wrapper in same PR + downstream-wrapper
+follow-up issue filed on the game repo before merge), reference
+implementations (architect retrofit + epic-steward born canonical), future
+(lint auto-filing; protocol versioning).
+
+**Engine wrapper**: frontmatter (name/description) + pointer to the protocol
++ Deltas table (engine values: `jakildev/IrredenEngine` / game cache key,
+worktree `~/src/IrredenEngine/.claude/worktrees/epic-steward`,
+escalation-target `opus-architect`, ledger-branch-prefix
+`claude/epic-steward-`, feedback `~/.fleet/feedback/epic-steward.md`) +
+downstream-isolation section (read the game wrapper before acting on a game
+epic; reference downstream work as `game#N` only).
+
+**Hand-off edits**: architect-protocol gains "steward-first for epic
+children" (engage only on `fleet:steward-proposal` or human direction;
+check the umbrella for a steward claim before manually unblocking an
+epic-child PR). FLEET.md design-escalation flow gains the steward branch.
+
+## Acceptance criteria
+
+- `fleet-labels --check` passes (catalog ↔ JSON ↔ reference in sync — they
+  must change in the same commit).
+- `fleet-transition design-propose <PR>` resolves against the JSON.
+- Wrapper answers every key the protocol's delta table declares.
+- Downstream-wrapper follow-up issue filed on the game repo (per the
+  checklist this PR introduces), body naming only the protocol path and the
+  delta keys to answer.
+
+## Gotchas
+
+- Reuse `design-unblock` as the proposal-accept edge — delta semantics make
+  the extra `fleet:design-proposed` remove a no-op on plain unblocks. No
+  separate accept edge.
+- Protocol phrasing: "downstream repo", never game feature names.
+- The two-label split is deliberate: `fleet:design-proposed` (PR) gives the
+  projection a clean off-edge + reconcile exclusion; `fleet:steward-proposal`
+  (umbrella) is the human queue whose REMOVAL re-fires distribution. Don't
+  collapse them into one.
+
+## Verification
+
+- `scripts/fleet/fleet-labels --check` (offline check) passes.
+- `python3 -c` smoke: load `fleet-state-machine.json`, assert the
+  `design-propose` edge and both label nodes exist.
+- Grep the wrapper's Deltas keys against the protocol's table — every bold
+  key answered (manual until #1667 lands the lint).

--- a/.fleet/plans/issue-1663.md
+++ b/.fleet/plans/issue-1663.md
@@ -1,0 +1,76 @@
+# Plan: fleet: steward claim class, cleanup pass, design-proposed parked/reconcile exclusions (P2)
+
+- **Issue:** #1663
+- **Model:** opus
+- **Date:** 2026-06-10
+- **Epic:** #1661 — see `.fleet/plans/issue-1661.md` for full context
+- **Blocked by:** #1662
+
+## Scope
+
+`fleet-claim` support for the steward: umbrella-issue claim class, stale-claim
+cleanup, and the `fleet:design-proposed` exclusions in parked-claim and
+reconcile machinery.
+
+## Affected files
+
+- `scripts/fleet/fleet-claim`
+  - new `cmd_steward_claim` / `cmd_steward_release` next to the existing
+    wrappers (~line 1250): `_cmd_pr_label_claim "fleet:stewarding-"
+    "steward-claim" "$@"` etc. — `_acquire_label_on` (~line 356) already
+    notes PRs and issues share the labels endpoint, and
+    `_cmd_pr_label_claim` (~line 1201) is prefix-parameterized
+  - subcommand dispatcher + `--help` entries
+  - new `cmd_cleanup_gh` pass after the open-PR pass (~line 1472): scan
+    `gh issue list --state open --label fleet:epic --json number,labels`,
+    collect `fleet:stewarding-*`, reuse the `label_added_epoch` + TTL +
+    `gh_release_label`/`write_orphan_sentinel` skeleton with
+    `stale_secs="${FLEET_CLAIM_STALE_SECS_STEWARD:-3600}"`
+  - reconcile inline-python: `fleet:design-proposed` joins the R2 carve-out
+    (~line 2133) and the R7 neither-label test (~line 2176); R4a (~line 2069)
+    flags `design-proposed` coexisting with either design sibling
+- `scripts/fleet/fleet_branch_match.py` — `PARKED_PR_LABELS` (line 70) gains
+  `fleet:design-proposed`
+- `scripts/fleet/tests/` — `test_fleet_claim_steward.sh` (clone of
+  `test_fleet_claim_acquire.sh` for the new prefix + cleanup TTL); extend
+  `test_fleet_claim_reconcile_heal_design_unblock.sh` with a design-proposed
+  PR that must NOT be healed
+
+## Approach
+
+- The GH sole-holder label is the cross-host mutex — identical race
+  semantics to `fleet:reviewing-` (apply label → re-read full set → sole
+  holder wins, lex-min retries, others yield). No FS lock: cap=1 makes
+  within-host contention impossible, and the label is what the second host
+  sees.
+- `--repo game` routing flows through `repo_from_ns` unchanged.
+- The scout already spawns `fleet-claim cleanup --gh` on queue-manager
+  projection changes — no new invocation plumbing for the cleanup pass.
+
+## Acceptance criteria
+
+- `fleet-claim steward-claim <umbrella> epic-steward` / `steward-release`
+  work against an issue number on both repos; losing claimant self-removes.
+- Cleanup releases a stale `fleet:stewarding-*` after TTL with sentinel.
+- Reconcile regression: `fleet:wip` + `fleet:design-proposed` PR is NOT
+  auto-healed to `fleet:design-unblocked`.
+- All three test files green.
+
+## Gotchas
+
+- Do NOT reuse `fleet:claim-*` for umbrellas — that class is retained as
+  historical audit, swept against `claude/<N>-*` PR existence, and gated by
+  `check_blockers`/model-tag in `cmd_claim`; all three mismatch a transient
+  stewardship session.
+- The cleanup first pass scans open PRs only — the steward sweep is a
+  separate third pass over open `fleet:epic` issues.
+- Without the R7 exclusion, reconcile undoes every steward proposal within
+  `FLEET_RECONCILE_DRIFT_TICKS` — this is the highest-risk line in the PR;
+  the regression test is mandatory.
+
+## Verification
+
+- `bash scripts/fleet/tests/test_fleet_claim_steward.sh`
+- `bash scripts/fleet/tests/test_fleet_claim_reconcile_heal_design_unblock.sh`
+- Manual: steward-claim a scratch issue, verify lex-min tie-break by racing
+  two agents, verify cleanup after exporting a 1-second TTL.

--- a/.fleet/plans/issue-1664.md
+++ b/.fleet/plans/issue-1664.md
@@ -1,0 +1,106 @@
+# Plan: fleet: scout epic fetch, project_epic_steward projection + slice, skip-set updates (P3)
+
+- **Issue:** #1664
+- **Model:** opus
+- **Date:** 2026-06-10
+- **Epic:** #1661 — see `.fleet/plans/issue-1661.md` for full context
+- **Blocked by:** #1662
+
+## Scope
+
+Teach `fleet-state-scout` about epics and add the steward's projection +
+slice. Strictly edge-triggered: every projection item disappears as a direct
+consequence of the steward's own writes.
+
+## Affected files
+
+- `scripts/fleet/fleet-state-scout`
+  - `fetch_epics(repo)` after `fetch_needs_plan` (~line 199):
+    `fetch_issues_by_label(repo, "fleet:epic", with_body=True)`; register
+    engine + game in `collect_state()` fetch specs (~lines 1601–1617) —
+    +2 gh calls/tick inside the existing `FETCH_MAX_WORKERS=2` pool
+  - `_parse_epic_checklist(body)` near `_parse_blocked_by`:
+    `re.compile(r'^\s*-\s*\[( |x|X)\]\s.*?#(\d+)', re.MULTILINE)` → list of
+    `(child_number, checked)`; store as `issue["checklist"]`, pop the body
+    before the state write (epic bodies are large)
+  - `Part of epic` parsing where bodies already flow: `fetch_task_queue`
+    task dict (~line 436) gains `"epic": _parse_issue_field(body, "Part of
+    epic") or None`; same in `resolve_human_approved_blockers` before the
+    body pop (~line 1022)
+  - `project_epic_steward(state)` + `PROJECTORS` (~line 1379) — the generic
+    `update_role_trigger` branch in `tick_once()` (~line 1739) needs no
+    change. Ops: `normalize` / `rollup` / `adopt` / `design` / `closeout`
+    (full pseudocode in the umbrella plan § Scout projection and the
+    planning record); items carry only stable fields, sorted
+    deterministically
+  - `slice_epic_steward(state)` + `SLICERS` (~line 1562): per-item records
+    with epic title, checklist + per-child closed state, design PR records
+    via `_slice_pr_with_repo`, plan paths
+  - `fleet:design-proposed` joins `REVIEW_SKIP_LABELS` (~line 782),
+    `_DESIGN_BLOCK_LABELS` (~line 851), `_merger_action_signal` skip set
+    (~line 1248)
+  - epics join `refresh_all_details` jobs (~line 701) and the
+    `gc_issue_caches` keep-set (~line 753)
+- `scripts/fleet/tests/test_epic_steward_projection.py` (model:
+  `test_merger_projection.py`, loads the scout by path)
+- `scripts/fleet/tests/test_parse_epic_checklist.py`
+
+## Approach
+
+Op definitions (managed epic = has body checklist, or plan file exists for
+`normalize`):
+
+- `normalize` — plan file exists at `<repo>/.fleet/plans/issue-<N>.md` but
+  no body checklist. Legacy epics with neither emit NOTHING (~17 of them —
+  no perma-trigger).
+- `rollup` — unchecked checklist child that is closed (closed = not in the
+  visible-open union of tasks/human_approved/needs_plan/epics, in
+  closed_fleet_queued, or rare `_resolve_ref_satisfied` fallback).
+- `adopt` — visible open issue (tasks open/in_progress + human_approved)
+  whose `epic` field names an umbrella whose checklist lacks it.
+- `design` — `fleet:design-blocked` PR branch-matched
+  (`branch_matches_issue`) to a checklist child; PLUS `fleet:design-proposed`
+  PRs whose umbrella does NOT carry `fleet:steward-proposal` (proposal
+  answered → distribute).
+- `closeout` — checklist non-empty and every ref closed, umbrella open.
+
+Edge-consumption map: box checked → rollup gone; checklist line added →
+adopt/normalize gone; umbrella closed → closeout gone; design-unblock or
+design-propose → design gone; steward-proposal removed → distribute
+appears (exactly once, until the steward flips the PR labels).
+
+## Acceptance criteria
+
+- Quiescence: same state twice → identical projection hash.
+- Edge-consumption: each op disappears after its steward write (fixtures).
+- Legacy checklist-less epic without plan file → zero items.
+- `fleet:design-proposed` PR absent from sonnet-reviewer + merger
+  projections.
+- Checklist parser handles `[ ]`/`[x]`/`[X]`, bold-wrapped refs
+  (`- [x] **#1527 — mechanism**` → first ref wins), indented sub-bullets,
+  and ignores non-checkbox `#N` lines.
+- One live scout tick writes well-formed `projections/epic-steward.json`.
+
+## Gotchas
+
+- NOTHING transient in projection items — no label lists, no timestamps
+  (the documented `project_merger` self-trigger lesson, scout ~lines
+  1205–1247).
+- The plan-file existence check is a cheap local `Path.exists()` against the
+  repo checkout — staleness only delays normalize bootstrap by one pull;
+  acceptable. Do not add git fetches to the scout.
+- No per-tick `gh search` calls — membership beyond the checklist is the
+  steward's iteration-time job.
+- `_DESIGN_BLOCK_LABELS` already contains a `fleet:design-escalated` member
+  that is absent from the labels reference (vestigial) — leave it; just add
+  `fleet:design-proposed` alongside.
+- Trigger files for an unregistered role are harmless; this merges before
+  P4 (#1665).
+
+## Verification
+
+- `python3 scripts/fleet/tests/test_epic_steward_projection.py`
+- `python3 scripts/fleet/tests/test_parse_epic_checklist.py`
+- Run the scout one tick against live state; inspect
+  `~/.fleet/state/projections/epic-steward.json` — epic #1661 should emit
+  zero items (checklist synced, no closed children yet).

--- a/.fleet/plans/issue-1665.md
+++ b/.fleet/plans/issue-1665.md
@@ -1,0 +1,70 @@
+# Plan: fleet: dispatcher + fleet-up registration for epic-steward, FLEET_EPIC_STEWARD gate (P4)
+
+- **Issue:** #1665
+- **Model:** sonnet
+- **Date:** 2026-06-10
+- **Epic:** #1661 — see `.fleet/plans/issue-1661.md` for full context
+- **Blocked by:** #1664
+
+## Scope
+
+Wire the role into the runtime: dispatcher maps, fleet-up worktrees + pane +
+bootstrap trigger, config sample. Everything gated opt-in behind
+`FLEET_EPIC_STEWARD` (mirror the smoke-worker opt-in pattern).
+
+## Affected files
+
+- `scripts/fleet/fleet-dispatcher`
+  - `DISPATCHED_ROLES` (~line 285): append `"epic-steward"`
+  - env capture block (~lines 86–100): `_env_epic_steward` /
+    `_env_effort_epic_steward` pairs + matching `unset`s
+  - `ROLE_CONCURRENCY` (~line 105): default 1
+  - `ROLE_MODEL` (~line 318): `$HEAVY_MODEL` (fallback chain comes free via
+    `build_dispatch_command`'s heavy-model test, ~line 866)
+  - `ROLE_EFFORT` (~line 335): default `xhigh`
+  - NO `PERIODIC_REARM_INTERVAL_SECONDS` entry (fully edge-triggered)
+- `scripts/fleet/fleet-up`
+  - worktrees (~line 365): `ensure_worktree "$ENGINE"
+    .claude/worktrees/epic-steward fleet/epic-steward`; game twin inside the
+    game block (~line 374+), both gated on `FLEET_EPIC_STEWARD`
+  - `reset_worktree` entries (~line 641) + game guard (~lines 643–656)
+  - `write_worktree_settings` loop (~line 814) + game block (~line 828; game
+    worktree points at `$ENGINE` like other dual-worktree roles)
+  - ops-window pane after the smoke-worker block (~lines 1382–1389): same
+    `if [[ -d …/epic-steward ]]` pattern, `$TRANSIENT_PANE_CMD`, heavy-tier
+    pane label, `set_fleet_role`, `pane_stagger`
+  - bootstrap-trigger heredoc (~lines 1042–1049): `("epic-steward",
+    lambda p: bool(p.get(...)))` keyed on the slice's items key (crash-resume
+    seed)
+- `scripts/fleet/fleet-up.conf.sample`: `FLEET_EPIC_STEWARD=1` section
+  modeled on the smoke-worker block (~lines 198–209) +
+  `FLEET_CONCURRENCY_EPIC_STEWARD=1` + `FLEET_EFFORT_EPIC_STEWARD=xhigh`
+
+## Approach
+
+Mechanical registration following the smoke-worker precedent throughout.
+`fleet-dispatch-wrap` needs no change: `/role-epic-steward` resolves by name
+(~line 64) and heavy model maps to `FLEET_ROLE_MODEL=opus` (~line 39). The
+role stays OUT of the rc=0 dirty-worktree retrigger list (~line 90) — it
+doesn't run the commit-and-push reservation flow.
+
+## Acceptance criteria
+
+- `FLEET_EPIC_STEWARD=1 fleet-up` creates both worktrees and the pane;
+  unset → no change anywhere.
+- Seeded trigger dispatches one iteration; pane returns to bash; dispatch
+  record clears; `fleet-claim` lock releases.
+- `fleet-down` sweeps the pane (role-agnostic — verify only).
+
+## Gotchas
+
+- Check the slice's actual top-level key for the bootstrap predicate against
+  what #1664 shipped — don't guess `items`.
+- The pane label should carry the heavy-tier tag like the other heavy panes.
+
+## Verification
+
+- `FLEET_EPIC_STEWARD=1 fleet-up` on a quiet fleet; confirm pane + worktrees.
+- `touch ~/.fleet/state/triggers/epic-steward`; watch one dispatch cycle in
+  `~/.fleet/logs/dispatcher.log`.
+- Unset the flag, re-run fleet-up, confirm no steward artifacts appear.

--- a/.fleet/plans/issue-1666.md
+++ b/.fleet/plans/issue-1666.md
@@ -1,0 +1,63 @@
+# Plan: fleet: fleet-epic-status helper — epic health dashboard with drift rows (P5)
+
+- **Issue:** #1666
+- **Model:** sonnet
+- **Date:** 2026-06-10
+- **Epic:** #1661 — see `.fleet/plans/issue-1661.md` for full context
+- **Blocked by:** #1662
+
+## Scope
+
+One command (`fleet-epic-status <N>`) showing an epic's full health:
+umbrella state + steward claim, checklist-vs-discovered drift, per-child
+queue/PR/plan state, embedded stack validation. `--json` for the steward
+role; table for humans.
+
+## Affected files
+
+- `scripts/fleet/fleet-epic-status` (new executable, python; mirror
+  `fleet-validate-stack`'s structure: argparse, repo-slug resolution from
+  the fleet state config, sibling module import)
+- `scripts/fleet/fleet_validate_stack.py` — if child discovery currently
+  lives only in the `fleet-validate-stack` executable, factor
+  `discover_children` into the importable module (single-source it; do NOT
+  re-implement the search + `is_epic_child` filter)
+- `scripts/fleet/install.sh` — SRC/DEST pair (~line 123 area) + `ln -sf`
+  stanza (~line 311 area), same pattern as `fleet-gate-status`
+
+## Approach
+
+Output sections:
+1. Umbrella: state, labels, `fleet:stewarding-*` holder if any.
+2. Drift rows: authoritative children (module discovery) diffed against the
+   umbrella body checklist → `missing-from-checklist`, `checked-but-open`,
+   `unchecked-but-closed`.
+3. Per-child: state, model label, `**Blocked by:**`, open PR + design
+   labels — read from `~/.fleet/state/state.json` / projections when fresh
+   (same staleness threshold the roles use), live `gh` fallback otherwise.
+4. Plan-file presence for umbrella + each child at the repo-side plan path.
+5. Embedded `validate_stack()` result.
+
+`--repo game` routes slug + state cache key like the other fleet tools.
+
+## Acceptance criteria
+
+- `fleet-epic-status 1661` prints all five sections correctly against the
+  live epic; `--json` output is stable and documented in the protocol's
+  references.
+- Drift detection verified by hand-desyncing a scratch epic's checklist.
+- `fleet-help` lists it; `install.sh` links it.
+
+## Gotchas
+
+- Prefer the scout cache over live `gh` — this runs inside steward
+  iterations and must not burn API budget.
+- Discovery logic stays single-sourced with validate-stack; two diverging
+  child-discovery implementations is exactly the drift this epic kills.
+
+## Verification
+
+- `fleet-epic-status 1661` and `fleet-epic-status 1661 --json | python3 -m
+  json.tool`.
+- Desync test: uncheck a closed child's box on a scratch epic → drift row
+  appears.

--- a/.fleet/plans/issue-1667.md
+++ b/.fleet/plans/issue-1667.md
@@ -1,0 +1,67 @@
+# Plan: fleet: fleet-validate-roles lint for role-sharing contract + validate-stack checklist check (P6)
+
+- **Issue:** #1667
+- **Model:** sonnet
+- **Date:** 2026-06-10
+- **Epic:** #1661 — see `.fleet/plans/issue-1661.md` for full context
+- **Blocked by:** #1662
+
+## Scope
+
+Mechanize the role-sharing contract from `docs/design/role-sharing.md`:
+every canonical role protocol has a conforming thin wrapper in each
+fleet-enabled repo root, every wrapper answers every declared delta key.
+Plus `fleet-validate-stack --check-checklist`.
+
+## Affected files
+
+- `scripts/fleet/fleet_validate_roles.py` (new pure module — no `gh` calls,
+  file I/O only)
+- `scripts/fleet/fleet-validate-roles` (new executable wrapper)
+- `scripts/fleet/fleet_validate_stack.py` — `--check-checklist`: warn when
+  the umbrella body checklist disagrees with discovered children
+- `scripts/fleet/install.sh` — install/link pair
+- `scripts/fleet/tests/test_fleet_validate_roles.py` (new)
+- `docs/design/role-sharing.md` — document running the lint in the new-role
+  checklist (one line; the doc itself is P1's)
+
+## Approach
+
+- Opt-in marker: a `## Repo deltas this flow needs` table inside
+  `docs/agents/*-protocol.md`. Protocols without one (REVIEWER-PROTOCOL.md
+  etc., different casing, no delta tables) are naturally exempt.
+- Parse: protocol table rows → declared key set (bold `**key**` in column
+  one); wrapper `## Deltas` table rows → answered set.
+- Checks: (a) each marked protocol has, in every repo root from
+  `--repo-root` (default: engine root + `creations/game` when present on
+  disk), a `.claude/commands/role-*.md` whose body references the protocol
+  path; (b) missing key = error, extra key = warn; (c) wrapper pointing at a
+  nonexistent protocol = warn.
+- Severity split like validate-stack; `--strict` promotes warns.
+- Alias map for `role-game-architect.md`'s legacy key names (its
+  `game-repo-slug` carries an inverted meaning vs the engine wrapper) — the
+  breaking key rename in architect-protocol is deferred; lint passes via
+  aliases until then.
+
+## Acceptance criteria
+
+- Exits 0 on the current tree (with aliases).
+- Deleting a delta key from the engine epic-steward wrapper → non-zero,
+  names the key and the wrapper (negative test in the test file).
+- Absent game root → skipped gracefully, never an error.
+- `fleet-validate-stack 1661 --check-checklist` passes on the synced
+  umbrella; warns after hand-desyncing a scratch epic.
+
+## Gotchas
+
+- Game repo root is gitignored and absent on some hosts — absence is normal,
+  not a failure.
+- Don't lint addenda sections — wrappers may carry legitimate repo-specific
+  responsibilities beyond the delta table (the review-pr checklist
+  carve-out precedent).
+
+## Verification
+
+- `python3 scripts/fleet/tests/test_fleet_validate_roles.py`
+- `fleet-validate-roles` and `fleet-validate-roles --strict` on the tree.
+- `fleet-validate-stack 1661 --check-checklist`.

--- a/.fleet/plans/issue-1668.md
+++ b/.fleet/plans/issue-1668.md
@@ -1,0 +1,63 @@
+# Plan: skills: file-epic seeds Children checklist + Steward ledger at filing time (P7)
+
+- **Issue:** #1668
+- **Model:** sonnet
+- **Date:** 2026-06-10
+- **Epic:** #1661 — see `.fleet/plans/issue-1661.md` for full context
+- **Blocked by:** #1662
+
+## Scope
+
+New epics are born managed: the `file-epic` canonical flow writes the
+umbrella body `## Children` checklist and seeds the `## Steward ledger`
+section in the umbrella plan, so the steward's heal pass is only ever needed
+for pre-protocol epics.
+
+## Affected files
+
+- `docs/agents/skills/file-epic.md` — the ONLY file. Both repos'
+  `.claude/skills/file-epic/SKILL.md` wrappers inherit via runtime
+  indirection; the ledger is shared fleet infrastructure, so no new delta
+  keys (verify by diffing the wrappers' delta tables before/after — they
+  must not change).
+
+## Approach
+
+- Step 2 (save the umbrella plan): append the initial `## Steward ledger`
+  (schema verbatim from `docs/agents/epic-steward-protocol.md`:
+  `reconciled-through:` = filing date, `proposal pending: none`,
+  `### Children` rows seeded `open`, `### Decisions` empty or seeded from
+  the architect plan's user decisions, `### Events` = "filed via
+  file-epic").
+- New step 3.5 (after the epic label, before child filing — or as one body
+  edit after step 5; pick the single-edit form): write the `## Children`
+  checklist into the umbrella body, `- [ ] #N — <short title>` per child.
+  Row format stays plain: number immediately after the checkbox (the scout
+  regex from #1664 takes the first `#N` on the line).
+- Step 7 (summary comment): one added line pointing at the ledger section.
+- Step 7.5: reference `--check-checklist` (#1667) as the post-filing drift
+  assert.
+- Anti-patterns: add the "filing without checklist/ledger" entry.
+
+## Acceptance criteria
+
+- The flow's prescribed checklist and ledger formats agree VERBATIM with the
+  epic-steward protocol's schemas (heading text, table columns, row format).
+- Neither repo's SKILL.md wrapper needs any change.
+- A dry-run walk of the updated flow against epic #1661's actual filing
+  reproduces what was done manually there (the worked example).
+
+## Gotchas
+
+- #1661 itself was filed pre-P7 with the checklist and ledger added
+  manually — it is the worked example to validate against, not a format to
+  copy blindly (its plan file carries an architect-plan preamble new epics
+  won't have).
+- Keep `Blocked by:` machine-parseability warnings intact — this file is
+  load-bearing for queue ingestion; edit surgically.
+
+## Verification
+
+- Read-through against `docs/agents/epic-steward-protocol.md` schema
+  sections — exact heading + column match.
+- `git diff` shows zero changes outside `docs/agents/skills/file-epic.md`.


### PR DESCRIPTION
## Summary
- Umbrella plan + seven per-ticket plans for the **epic-steward** epic (#1661): a new transient, dispatcher-driven fleet role that owns the epic lifecycle after filing — adoption of mid-epic scope changes, post-merge plan re-validation, derivable design-block resolution (novel questions aggregate into one proposal package), and verified epic close-out.
- Plans carry verified line anchors into `fleet-claim`, `fleet-state-scout`, `fleet-dispatcher`, and `fleet-up` so each child (#1662–#1668) is implementable without re-deriving the integration surface.
- The umbrella plan (`issue-1661.md`) seeds the first `## Steward ledger` section manually; P7 (#1668) automates that for future epics.

## Test plan
- [ ] `fleet-validate-stack 1661` passes (run post-merge from any host; also run pre-merge from the filing host against local staging)
- [ ] Every cited path in the plans exists on master (verified at authoring time: 13/13)

## Notes for reviewer
Docs-only. Does NOT close #1661 — the umbrella stays open until all seven children land; the steward's own close-out flow (P1 protocol) is what eventually closes it.

Part of epic #1661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
