### PR TITLE
fleet: first-class downstream-creation worktree builds via IRREDEN_USER_PROJECTS (#1669)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.28.0)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 project(BuildCreation VERSION 0.1.0)
 
-option(IRREDEN_BUILD_CREATIONS "Build engine-owned creations" ${PROJECT_IS_TOP_LEVEL})
+option(IRREDEN_BUILD_CREATIONS "Build creations present in this tree (engine-owned creations/ and nested private checkouts)" ${PROJECT_IS_TOP_LEVEL})
 option(IRREDEN_BUILD_TESTS "Build engine test targets" ${PROJECT_IS_TOP_LEVEL})
 option(IRREDEN_BUILD_QUALITY_TARGETS "Build engine quality targets" ${PROJECT_IS_TOP_LEVEL})
 option(IRREDEN_BUILD_TOOLS "Build standalone tools (img_diff, etc.)" ${PROJECT_IS_TOP_LEVEL})
@@ -64,7 +64,10 @@ if(IRREDEN_BUILD_CREATIONS)
     add_subdirectory(${PROJECT_SOURCE_DIR}/creations)
 endif()
 
-if(EXISTS "${PROJECT_SOURCE_DIR}/creations/game/CMakeLists.txt")
+# Gated alongside creations/ so a build that injects a creation worktree
+# via IRREDEN_USER_PROJECTS (-DIRREDEN_BUILD_CREATIONS=OFF) can't collide
+# with the identically-named targets of the nested main checkout.
+if(IRREDEN_BUILD_CREATIONS AND EXISTS "${PROJECT_SOURCE_DIR}/creations/game/CMakeLists.txt")
     add_subdirectory(${PROJECT_SOURCE_DIR}/creations/game)
 endif()
 

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -47,9 +47,47 @@ In all three cases:
   (`git rev-parse --show-toplevel`) and uses `<worktree>/build/`. If
   the build hasn't been configured yet, `ir-build` runs `cmake
   --preset` automatically. Agents edit files in their own worktree and
-  build there — no need to touch the main clone.
+  build there — no need to touch the main clone. (Downstream-creation
+  worktrees route differently — see the next section.)
 - `CMAKE_CXX_STANDARD` is **23**; your compiler must support it.
   (gcc ≥ 13 on Linux/WSL, gcc ≥ 13 via MSYS2 on Windows.)
+
+### Downstream-creation worktree builds
+
+Downstream creations (gitignored repos nested under `creations/<name>/`)
+run their own agent worktrees at `creations/<name>/.claude/worktrees/
+<agent>/`. Those worktrees have **no CMake presets of their own** — their
+targets compile through the enclosing engine with the worktree added as a
+user project. `ir-build` / `ir-run` handle this automatically:
+
+- **Detection** — the invoker's git toplevel lacks `CMakePresets.json`
+  and sits under an engine root at `creations/<name>/…`.
+- **Build dir** — `<engine>/build-<creation>-<agent>/` (e.g.
+  `~/src/IrredenEngine/build-game-opus-worker-2/`), already covered by
+  the engine `.gitignore`'s `build-*/` pattern. Build output never lands
+  in the creation repo, and the engine's own build trees are untouched.
+- **Auto-configure** (first build only) — host preset against the
+  enclosing engine source with `-DIRREDEN_BUILD_CREATIONS=OFF` (so the
+  creation's *main* checkout can't collide with the worktree's
+  identically-named targets) and `-DIRREDEN_USER_PROJECTS=<worktree>`.
+- **Routing** — every later `fleet-build --target X` / `fleet-run X`
+  from that cwd resolves the same dedicated dir; `ir-run --targets`
+  lists from it too.
+
+So from a creation worktree, `fleet-build --target <T>` followed by
+`fleet-run <T>` Just Works with zero manual `cmake`. `IRREDEN_BUILD_DIR`
+still overrides the build dir everywhere (the escape hatch when you want
+the build against a specific engine worktree instead of the enclosing
+clone — configure that dir yourself once, then point the env var at it).
+
+Two things to know:
+
+- The engine **source** for the auto-configured tree is the enclosing
+  clone (the one physically containing `creations/<name>/`) at whatever
+  state it's checked out — keep it on `master` on fleet hosts.
+- The creation's **main** checkout (`creations/<name>/` itself, not a
+  worktree) builds through `<engine>/build/` via the engine root's
+  nested-checkout include.
 
 ### `ir-build` / `ir-run` (canonical) vs `fleet-build` / `fleet-run` (aliases)
 

--- a/engine/tools/bin/ir-build
+++ b/engine/tools/bin/ir-build
@@ -17,6 +17,12 @@
 # tree hasn't been configured yet, ir-build runs cmake --preset
 # automatically.
 #
+# Downstream-creation worktrees (creations/<name>/.claude/worktrees/
+# <agent>/) are first-class: they have no presets of their own, so the
+# build routes to <engine>/build-<creation>-<agent>/, auto-configured
+# against the enclosing engine with -DIRREDEN_USER_PROJECTS=<worktree>.
+# IRREDEN_BUILD_DIR still overrides the build dir in every case.
+#
 # Usage:
 #   ir-build --target IRShapeDebug
 #   ir-build --target IRCreationDefault
@@ -52,9 +58,10 @@ fi
 source "$HELPERS"
 
 # --- Build directory resolution ---
-# Priority: $IRREDEN_BUILD_DIR > <invoker-worktree-root>/build
+# Priority: $IRREDEN_BUILD_DIR > worktree default (engine worktree:
+# <root>/build; downstream-creation worktree: <engine>/build-<creation>-<agent>).
 WORKTREE_ROOT="$(ir_worktree_root)"
-BUILD_DIR="${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}"
+BUILD_DIR="${IRREDEN_BUILD_DIR:-$(ir_default_build_dir "$WORKTREE_ROOT")}"
 
 # --- Auto-configure if the build tree doesn't exist yet ---
 if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
@@ -68,8 +75,23 @@ if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
             ;;
     esac
     echo "ir-build: no build tree at $BUILD_DIR"
-    echo "ir-build: configuring with preset '$PRESET'..."
-    cmake --preset "$PRESET" -S "$WORKTREE_ROOT"
+    if CREATION_ENGINE_ROOT="$(ir_creation_worktree_engine_root "$WORKTREE_ROOT")"; then
+        # Downstream-creation worktree: the creation repo has no CMake
+        # presets — its targets compile through the enclosing engine with
+        # the worktree added as a user project. IRREDEN_BUILD_CREATIONS=OFF
+        # keeps the creation's main checkout (and engine-owned demos) out
+        # of this tree so the worktree's identically-named targets can't
+        # collide with the nested main-checkout include.
+        echo "ir-build: downstream-creation worktree; configuring with preset '$PRESET'"
+        echo "ir-build:   engine source: $CREATION_ENGINE_ROOT"
+        echo "ir-build:   user project:  $WORKTREE_ROOT"
+        cmake --preset "$PRESET" -S "$CREATION_ENGINE_ROOT" -B "$BUILD_DIR" \
+            -DIRREDEN_BUILD_CREATIONS=OFF \
+            -DIRREDEN_USER_PROJECTS="$WORKTREE_ROOT"
+    else
+        echo "ir-build: configuring with preset '$PRESET'..."
+        cmake --preset "$PRESET" -S "$WORKTREE_ROOT" -B "$BUILD_DIR"
+    fi
     echo "ir-build: configure done."
 fi
 

--- a/engine/tools/bin/ir-run
+++ b/engine/tools/bin/ir-run
@@ -86,17 +86,24 @@ while [[ $# -gt 0 ]]; do
             # the same worktree-root build-dir detection ir-run does, so
             # we hand off cleanly. Resolve from the invoker's worktree
             # (IR_ENGINE_ROOT is the script's source clone, which may be
-            # a different worktree when invoked via ~/bin symlink).
+            # a different worktree when invoked via ~/bin symlink). A
+            # downstream-creation worktree has no scripts/fleet/ — use the
+            # enclosing engine root's copy and point it at the creation's
+            # dedicated build dir.
             WORKTREE_ROOT="$(ir_worktree_root)"
-            HELPER="$WORKTREE_ROOT/scripts/fleet/fleet-run-targets"
-            if [[ ! -x "$HELPER" ]]; then
-                echo "ir-run: missing $HELPER (fleet-run-targets is currently engine-tooling-adjacent; expected under scripts/fleet/)" >&2
+            HELPER_ROOT="$WORKTREE_ROOT"
+            if [[ ! -x "$HELPER_ROOT/scripts/fleet/fleet-run-targets" ]]; then
+                HELPER_ROOT="$(ir_creation_worktree_engine_root "$WORKTREE_ROOT" || true)"
+            fi
+            HELPER="$HELPER_ROOT/scripts/fleet/fleet-run-targets"
+            if [[ -z "$HELPER_ROOT" || ! -x "$HELPER" ]]; then
+                echo "ir-run: missing $WORKTREE_ROOT/scripts/fleet/fleet-run-targets (fleet-run-targets is currently engine-tooling-adjacent; expected under scripts/fleet/)" >&2
                 exit 1
             fi
-            if [[ -n "$BUILD_DIR" ]]; then
-                exec "$HELPER" --build-dir "$BUILD_DIR" "$@"
+            if [[ -z "$BUILD_DIR" ]]; then
+                BUILD_DIR="${IRREDEN_BUILD_DIR:-$(ir_default_build_dir "$WORKTREE_ROOT")}"
             fi
-            exec "$HELPER" "$@"
+            exec "$HELPER" --build-dir "$BUILD_DIR" "$@"
             ;;
         --help|-h)
             cat <<'USAGE'
@@ -134,6 +141,9 @@ Run mode
   Build directory (when not using --build-dir):
     1. $IRREDEN_BUILD_DIR if set
     2. <git-worktree-root>/build from git rev-parse
+       (downstream-creation worktrees — creations/<name>/.claude/
+       worktrees/<agent>/ — resolve to the dedicated
+       <engine>/build-<creation>-<agent>/ tree instead)
     3. $IR_ENGINE_ROOT/build if not in a git worktree
 
 Target listing mode
@@ -203,9 +213,11 @@ for arg in "$@"; do
 done
 
 # Default build dir: invoker's worktree, not the script-source clone.
+# Downstream-creation worktrees resolve to the dedicated
+# <engine>/build-<creation>-<agent>/ tree ir-build configures for them.
 if [[ -z "$BUILD_DIR" ]]; then
     WORKTREE_ROOT="$(ir_worktree_root)"
-    BUILD_DIR="${IRREDEN_BUILD_DIR:-$WORKTREE_ROOT/build}"
+    BUILD_DIR="${IRREDEN_BUILD_DIR:-$(ir_default_build_dir "$WORKTREE_ROOT")}"
 fi
 
 if [[ ! -d "$BUILD_DIR" ]]; then

--- a/engine/tools/bin/ir-run
+++ b/engine/tools/bin/ir-run
@@ -93,7 +93,9 @@ while [[ $# -gt 0 ]]; do
             WORKTREE_ROOT="$(ir_worktree_root)"
             HELPER_ROOT="$WORKTREE_ROOT"
             if [[ ! -x "$HELPER_ROOT/scripts/fleet/fleet-run-targets" ]]; then
-                HELPER_ROOT="$(ir_creation_worktree_engine_root "$WORKTREE_ROOT" || true)"
+                if _eng_root="$(ir_creation_worktree_engine_root "$WORKTREE_ROOT")"; then
+                    HELPER_ROOT="$_eng_root"
+                fi
             fi
             HELPER="$HELPER_ROOT/scripts/fleet/fleet-run-targets"
             if [[ -z "$HELPER_ROOT" || ! -x "$HELPER" ]]; then

--- a/engine/tools/lib/concurrency_helpers.sh
+++ b/engine/tools/lib/concurrency_helpers.sh
@@ -24,12 +24,13 @@ _IR_HELPERS_LOADED=1
 # Path resolution
 # ---------------------------------------------------------------------------
 
-# Engine root: walk up from this file. Same approach as scripts/fleet/fleet-common.sh.
-_ir_helpers_resolve_engine_root() {
-    local here
-    here="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
-    # bin/ scripts source this from lib/; lib/ is at $engine/engine/tools/lib/.
-    # Walk up to find the marker file CMakeLists.txt at engine root.
+# ir_enclosing_engine_root <dir> — nearest ancestor (including <dir>) that
+# looks like an engine checkout (CMakePresets.json + engine/). Returns 1
+# when no ancestor matches.
+ir_enclosing_engine_root() {
+    local here="$1"
+    [[ -d "$here" ]] || return 1
+    here="$(cd "$here" && pwd)"
     while [[ "$here" != "/" ]]; do
         if [[ -f "$here/CMakePresets.json" && -d "$here/engine" ]]; then
             echo "$here"
@@ -37,11 +38,15 @@ _ir_helpers_resolve_engine_root() {
         fi
         here="$(dirname "$here")"
     done
-    echo "ir-tools: cannot resolve engine root from $(dirname "${BASH_SOURCE[1]}")" >&2
     return 1
 }
 
-IR_ENGINE_ROOT="$(_ir_helpers_resolve_engine_root)"
+# Engine root: walk up from this file (lib/ is at $engine/engine/tools/lib/).
+# Same approach as scripts/fleet/fleet-common.sh.
+IR_ENGINE_ROOT="$(ir_enclosing_engine_root "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")" || {
+    echo "ir-tools: cannot resolve engine root from ${BASH_SOURCE[0]}" >&2
+    return 1
+}
 IR_TOOLS_DIR="$IR_ENGINE_ROOT/engine/tools"
 IR_DEFAULTS_TOML="$IR_TOOLS_DIR/concurrency.toml"
 IR_HOST_TOML="${IR_HOST_TOML:-$HOME/.config/irreden/host.toml}"
@@ -66,6 +71,48 @@ ir_worktree_root() {
         fi
     fi
     echo "$root"
+}
+
+# ir_creation_worktree_engine_root <worktree-root> — when <worktree-root>
+# is a downstream-creation checkout nested under an engine root at
+# creations/<name>/... (the fleet layout puts agent worktrees at
+# creations/<name>/.claude/worktrees/<agent>/), echo the enclosing engine
+# root and return 0. Returns 1 for engine checkouts (they carry their own
+# CMakePresets.json) and for repos outside an engine tree.
+#
+# Note ir_worktree_root resolves a creation's MAIN checkout
+# (creations/<name>/, two levels below the engine root) to the engine
+# root via its ../../ walk-up, so only nested *worktrees* reach this
+# detection — the main checkout keeps building through <engine>/build.
+ir_creation_worktree_engine_root() {
+    local root="$1"
+    [[ -f "$root/CMakePresets.json" ]] && return 1
+    local eng
+    eng="$(ir_enclosing_engine_root "$root")" || return 1
+    case "$root" in
+        "$eng"/creations/*) echo "$eng"; return 0 ;;
+    esac
+    return 1
+}
+
+# ir_default_build_dir <worktree-root> — the build tree ir-build/ir-run
+# use when IRREDEN_BUILD_DIR is not set. Engine checkouts build in-tree
+# (<root>/build, the preset binaryDir). A downstream-creation worktree
+# has no presets of its own — its targets compile through the enclosing
+# engine with the worktree added as a user project — so it gets a
+# dedicated dir at <engine>/build-<creation>-<agent>/ (covered by the
+# engine .gitignore's build-*/ pattern), keeping build output out of the
+# creation repo and away from the engine's own build trees.
+ir_default_build_dir() {
+    local root="$1"
+    local eng
+    if eng="$(ir_creation_worktree_engine_root "$root")"; then
+        local rel="${root#"$eng"/creations/}"
+        local creation="${rel%%/*}"
+        echo "$eng/build-$creation-$(basename "$root")"
+    else
+        echo "$root/build"
+    fi
 }
 
 # Lock dir lives in a runtime-temp location so it survives across shells but

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -39,6 +39,11 @@ fleet-build — forwards to cmake --build with auto -j and worktree build/.
   fleet-build --target IRShapeDebug
   fleet-build --target IrredenEngineTest -- --clean-first   # extra cmake args
 
+Downstream-creation worktrees (creations/<name>/.claude/worktrees/<agent>/)
+are auto-configured against the enclosing engine via IRREDEN_USER_PROJECTS
+into <engine>/build-<creation>-<agent>/ — see docs/agents/BUILD.md
+"Downstream-creation worktree builds".
+
 No --help flag. List CMake targets:
   cmake --build <build-dir> --target help
 Or (curated demo names):

--- a/scripts/fleet/tests/test_ir_build_dir_resolution.sh
+++ b/scripts/fleet/tests/test_ir_build_dir_resolution.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Tests for the ir-build / ir-run build-dir resolution helpers
+# (engine/tools/lib/concurrency_helpers.sh).
+#
+# #1669 made downstream-creation worktree builds first-class: a git repo
+# rooted at creations/<name>/.claude/worktrees/<agent>/ has no CMake
+# presets of its own, so its build routes to the enclosing engine root at
+# build-<creation>-<agent>/ and ir-build auto-configures that dir with
+# -DIRREDEN_USER_PROJECTS=<worktree>. These tests pin the pure path
+# resolution (ir_enclosing_engine_root / ir_creation_worktree_engine_root /
+# ir_default_build_dir) against a fake directory layout — no git, no cmake.
+#
+# Covers:
+#   - engine checkout (presets at root) → <root>/build (unchanged)
+#   - engine nested worktree (own presets) → <worktree>/build (unchanged)
+#   - creation worktree under <engine>/creations/<name>/.claude/worktrees/
+#     <agent>/ → <engine>/build-<name>-<agent> (the #1669 behavior)
+#   - repo outside any engine tree → <root>/build (unchanged)
+#   - presets-less dir under the engine but NOT under creations/ →
+#     <root>/build (no false-positive creation detection)
+#   - ir_enclosing_engine_root walk-up and miss cases
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/../../.." && pwd)
+HELPERS="$SCRIPT_DIR/engine/tools/lib/concurrency_helpers.sh"
+
+if [[ ! -f "$HELPERS" ]]; then
+    echo "test setup: helpers not found at $HELPERS" >&2
+    exit 1
+fi
+# Isolate the helpers' lock-dir side effects from the host's live locks.
+IR_LOCK_ROOT="$(mktemp -d)/locks"
+export IR_LOCK_ROOT
+# shellcheck source=../../../engine/tools/lib/concurrency_helpers.sh
+source "$HELPERS"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+assert_rc() {
+    local rc="$1" expected="$2" msg="$3"
+    assert_eq "$rc" "$expected" "$msg"
+}
+
+# --- Fake layout -------------------------------------------------------------
+FAKE="$(mktemp -d)"
+trap 'rm -rf "$FAKE" "${IR_LOCK_ROOT%/locks}"' EXIT
+
+ENG="$FAKE/eng"
+mkdir -p "$ENG/engine"
+touch "$ENG/CMakePresets.json"
+
+ENG_WT="$ENG/.claude/worktrees/opus-worker-1"
+mkdir -p "$ENG_WT/engine"
+touch "$ENG_WT/CMakePresets.json"
+
+CREATION_WT="$ENG/creations/game/.claude/worktrees/agent-1"
+mkdir -p "$CREATION_WT"
+
+NON_CREATION="$ENG/.fleet/scratch-repo"
+mkdir -p "$NON_CREATION"
+
+OUTSIDE="$FAKE/elsewhere/repo"
+mkdir -p "$OUTSIDE"
+
+# --- T1: ir_enclosing_engine_root --------------------------------------------
+echo "T1: ir_enclosing_engine_root walk-up"
+assert_eq "$(ir_enclosing_engine_root "$CREATION_WT")" "$ENG" \
+    "creation worktree walks up to the engine root"
+assert_eq "$(ir_enclosing_engine_root "$ENG")" "$ENG" \
+    "engine root resolves to itself"
+rc=0; ir_enclosing_engine_root "$OUTSIDE" >/dev/null || rc=$?
+assert_rc "$rc" 1 "dir outside any engine tree returns 1"
+
+# --- T2: ir_creation_worktree_engine_root ------------------------------------
+echo "T2: ir_creation_worktree_engine_root detection"
+assert_eq "$(ir_creation_worktree_engine_root "$CREATION_WT")" "$ENG" \
+    "creation worktree detected, echoes enclosing engine root"
+rc=0; ir_creation_worktree_engine_root "$ENG" >/dev/null || rc=$?
+assert_rc "$rc" 1 "engine root (has presets) is not a creation worktree"
+rc=0; ir_creation_worktree_engine_root "$ENG_WT" >/dev/null || rc=$?
+assert_rc "$rc" 1 "engine nested worktree (own presets) is not a creation worktree"
+rc=0; ir_creation_worktree_engine_root "$NON_CREATION" >/dev/null || rc=$?
+assert_rc "$rc" 1 "presets-less repo under the engine but outside creations/ is not detected"
+rc=0; ir_creation_worktree_engine_root "$OUTSIDE" >/dev/null || rc=$?
+assert_rc "$rc" 1 "repo outside the engine tree is not detected"
+
+# --- T3: ir_default_build_dir ------------------------------------------------
+echo "T3: ir_default_build_dir routing"
+assert_eq "$(ir_default_build_dir "$ENG")" "$ENG/build" \
+    "engine checkout builds in-tree"
+assert_eq "$(ir_default_build_dir "$ENG_WT")" "$ENG_WT/build" \
+    "engine nested worktree builds in-tree"
+assert_eq "$(ir_default_build_dir "$CREATION_WT")" "$ENG/build-game-agent-1" \
+    "creation worktree routes to <engine>/build-<creation>-<agent>"
+assert_eq "$(ir_default_build_dir "$NON_CREATION")" "$NON_CREATION/build" \
+    "non-creation repo under the engine builds in-tree"
+assert_eq "$(ir_default_build_dir "$OUTSIDE")" "$OUTSIDE/build" \
+    "repo outside the engine tree builds in-tree"
+
+# --- Summary ------------------------------------------------------------------
+echo
+echo "pass: $PASS  fail: $FAIL"
+(( FAIL == 0 ))


### PR DESCRIPTION
## Summary
- `ir-build` / `ir-run` (and the `fleet-build` / `fleet-run` shims) now treat downstream-creation worktrees (`creations/<name>/.claude/worktrees/<agent>/`) as first-class: detection via missing `CMakePresets.json` under an engine root's `creations/` subtree, with new shared helpers `ir_enclosing_engine_root` / `ir_creation_worktree_engine_root` / `ir_default_build_dir` in `engine/tools/lib/concurrency_helpers.sh`.
- Auto-configure (first build only) targets a dedicated `<engine>/build-<creation>-<agent>/` dir — already gitignored via `build-*/` — against the enclosing engine source with `-DIRREDEN_BUILD_CREATIONS=OFF -DIRREDEN_USER_PROJECTS=<worktree>`. Subsequent `fleet-build` / `fleet-run` calls from that cwd route to the same dir. `IRREDEN_BUILD_DIR` still overrides everywhere (the role-doc manual recipe keeps working unchanged).
- Root `CMakeLists.txt`: the nested `creations/game` include is now gated behind `IRREDEN_BUILD_CREATIONS`, so the injected worktree's targets can't collide with the main checkout's identically-named ones (the failure mode that previously forced manual configuration against an engine worktree).
- `ir-run --targets` from a creation worktree falls back to the enclosing engine's `fleet-run-targets` and pins the resolved build dir.
- Docs: new "Downstream-creation worktree builds" section in `docs/agents/BUILD.md`; `fleet-help` build entry updated.
- New test `scripts/fleet/tests/test_ir_build_dir_resolution.sh` (13 assertions) pins the path-resolution behavior, including the unchanged engine-worktree and main-checkout paths.
- Reuse cleanup (simplify): `_ir_helpers_resolve_engine_root` was a ~90% structural duplicate of the new walk-up resolver — collapsed into `ir_enclosing_engine_root`.

## Test plan
- [x] `test_ir_build_dir_resolution.sh` — 13/13 pass (engine root, engine worktree, creation worktree, non-creation repo under engine, repo outside engine).
- [x] E2E on a fake creation worktree under the (patched) engine worktree: cold auto-configure into `build-<creation>-<agent>/`, build + run of the user-project target — **with a colliding fake main checkout present**, proving the `IRREDEN_BUILD_CREATIONS` gate prevents the duplicate-target configure failure.
- [x] Real-layout resolution check from `creations/game/.claude/worktrees/opus-worker-2` → `<engine>/build-game-opus-worker-2`; main game checkout still resolves to `<engine>/build` (unchanged).
- [x] Regression: warm `fleet-build --target IRShapeDebug` in an engine worktree builds clean; `format-changed` runs through the modified ir-build path.

## Notes for reviewer
- Deploy-order note: the full game-worktree flow engages once this lands on `master` and the enclosing clone pulls it (the auto-configure reads the enclosing clone's root `CMakeLists.txt`). Until then the manual `IRREDEN_BUILD_DIR` recipe keeps working.
- `fleet-run --targets` from a creation worktree resolves the right build dir but the unscoped built-exe scan in `fleet-run-targets` only walks `creations/` + `test/`, so `user_projects/` exes don't list yet — that's #1355's scope (commented there); `ir-run <name>` itself finds and runs them fine.
- Pre-existing (not bundled): `ir_worktree_root` ≈75% overlaps `detect_engine_root` in `scripts/fleet/fleet-common.sh` — flagged by the simplify pass, left for a separate consolidation since it crosses the engine-tools/fleet-scripts boundary.
- Downstream onboarding docs are tracked in the game repo's existing issue #168 — no new ticket needed.

Closes #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)