### PR TITLE
fleet: steward claim class, cleanup pass, design-proposed parked/reconcile exclusions (#1663)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1195,15 +1195,17 @@ cmd_release() {
     fi
 }
 
-# _cmd_pr_label_claim <prefix> <cmd-name> <pr-num> <agent>
-#   Shared implementation for review-claim, resolving-claim, and
-#   amending-claim. All use the same lex-min tie-break logic with
-#   different label prefixes; extract here to avoid 100% structural
-#   duplication.
+# _cmd_pr_label_claim <prefix> <cmd-name> <pr-num> <agent> [target-word]
+#   Shared implementation for review-claim, resolving-claim,
+#   amending-claim, and steward-claim. All use the same lex-min
+#   tie-break logic with different label prefixes; extract here to
+#   avoid 100% structural duplication. PRs and issues share GitHub's
+#   labels endpoint, so the target may be either; <target-word>
+#   (default "PR") only adjusts the messages.
 _cmd_pr_label_claim() {
-    local prefix="$1" cmd_name="$2" pr="$3" agent="${4:-unknown}"
+    local prefix="$1" cmd_name="$2" pr="$3" agent="${4:-unknown}" target_word="${5:-PR}"
     if [[ ! "$pr" =~ ^[0-9]+$ ]]; then
-        echo "fleet-claim ${cmd_name}: PR must be a number, got '$pr'" >&2
+        echo "fleet-claim ${cmd_name}: ${target_word} must be a number, got '$pr'" >&2
         return 2
     fi
     local host label repo
@@ -1224,17 +1226,17 @@ _cmd_pr_label_claim() {
         return 1
     fi
 
-    echo "${cmd_name} acquired: $repo PR#$pr ($agent)"
+    echo "${cmd_name} acquired: $repo ${target_word}#$pr ($agent)"
     return 0
 }
 
-# _cmd_pr_label_release <prefix> <cmd-name> <pr-num> <agent>
-#   Shared implementation for review-release, resolving-release, and
-#   amending-release.
+# _cmd_pr_label_release <prefix> <cmd-name> <pr-num> <agent> [target-word]
+#   Shared implementation for review-release, resolving-release,
+#   amending-release, and steward-release.
 _cmd_pr_label_release() {
-    local prefix="$1" cmd_name="$2" pr="$3" agent="${4:-unknown}"
+    local prefix="$1" cmd_name="$2" pr="$3" agent="${4:-unknown}" target_word="${5:-PR}"
     if [[ ! "$pr" =~ ^[0-9]+$ ]]; then
-        echo "fleet-claim ${cmd_name}: PR must be a number, got '$pr'" >&2
+        echo "fleet-claim ${cmd_name}: ${target_word} must be a number, got '$pr'" >&2
         return 2
     fi
     local host label repo
@@ -1255,6 +1257,14 @@ cmd_resolving_claim()   { _cmd_pr_label_claim   "fleet:resolving-" "resolving-cl
 cmd_resolving_release() { _cmd_pr_label_release "fleet:resolving-" "resolving-release" "$@"; }
 cmd_amending_claim()   { _cmd_pr_label_claim   "fleet:amending-" "amending-claim"   "$@"; }
 cmd_amending_release() { _cmd_pr_label_release "fleet:amending-" "amending-release" "$@"; }
+# Steward claims target the umbrella ISSUE, not a PR — same labels endpoint,
+# same sole-holder tie-break. Per-epic mutex for the epic-steward role; no FS
+# lock needed (the role runs one pane per host and the label is what the
+# other host sees). NOT fleet:claim-*: that class has issue-lifecycle
+# semantics (retained as audit trail, blocker/model gating in cmd_claim)
+# that mismatch a transient stewardship session (#1663).
+cmd_steward_claim()   { _cmd_pr_label_claim   "fleet:stewarding-" "steward-claim"   "${1:-}" "${2:-unknown}" "issue"; }
+cmd_steward_release() { _cmd_pr_label_release "fleet:stewarding-" "steward-release" "${1:-}" "${2:-unknown}" "issue"; }
 
 cmd_check() {
     # Exit 0 = free, exit 1 = claimed.
@@ -1338,8 +1348,9 @@ cmd_cleanup() {
     # merged "Closes #N" PR). Accepts zero or more --repo flags; defaults
     # to jakildev/IrredenEngine. With --gh, ALSO sweeps stale
     # fleet:reviewing-* / fleet:resolving-* / fleet:amending-* labels off
-    # open PRs and abandoned fleet:claim-* labels off OPEN issues (no matching
-    # claude/<N>-* PR + TTL). Claim labels on CLOSED issues are kept
+    # open PRs, abandoned fleet:claim-* labels off OPEN issues (no matching
+    # claude/<N>-* PR + TTL), and stale fleet:stewarding-* labels off open
+    # fleet:epic issues. Claim labels on CLOSED issues are kept
     # as a historical record.
     mkdir -p "$CLAIMS_DIR"
 
@@ -1437,24 +1448,8 @@ for pr in prs:
         while IFS=$'\t' read -r pr_num label_name; do
             [[ -z "$pr_num" || -z "$label_name" ]] && continue
 
-            local added_at
-            added_at=$(gh api "repos/${repo}/issues/${pr_num}/events" \
-                --paginate \
-                --jq '.[] | select(.event=="labeled" and .label.name=="'"$label_name"'") | .created_at' \
-                2>/dev/null | tail -n1 || true)
-
-            [[ -z "$added_at" ]] && continue
-
             local added_epoch
-            added_epoch=$(python3 -c "
-import sys, datetime
-try:
-    dt = datetime.datetime.strptime('$added_at', '%Y-%m-%dT%H:%M:%SZ')
-    print(int(dt.replace(tzinfo=datetime.timezone.utc).timestamp()))
-except Exception:
-    print(0)
-" 2>/dev/null || echo 0)
-
+            added_epoch=$(label_added_epoch "$repo" "$pr_num" "$label_name")
             [[ "$added_epoch" -eq 0 ]] && continue
 
             local age=$(( now - added_epoch ))
@@ -1512,22 +1507,8 @@ for issue in issues:
         while IFS=$'\t' read -r issue_num label_name; do
             [[ -z "$issue_num" || -z "$label_name" ]] && continue
 
-            local added_at
-            added_at=$(gh api "repos/${repo}/issues/${issue_num}/events" \
-                --paginate \
-                --jq '.[] | select(.event=="labeled" and .label.name=="'"$label_name"'") | .created_at' \
-                2>/dev/null | tail -n1 || true)
-            [[ -z "$added_at" ]] && continue
-
             local added_epoch
-            added_epoch=$(python3 -c "
-import datetime
-try:
-    dt = datetime.datetime.strptime('$added_at', '%Y-%m-%dT%H:%M:%SZ')
-    print(int(dt.replace(tzinfo=datetime.timezone.utc).timestamp()))
-except Exception:
-    print(0)
-" 2>/dev/null || echo 0)
+            added_epoch=$(label_added_epoch "$repo" "$issue_num" "$label_name")
             [[ "$added_epoch" -eq 0 ]] && continue
 
             local age=$(( now - added_epoch ))
@@ -1555,6 +1536,55 @@ except Exception:
                     "cleanup --gh: open-issue claim remove-label failed"
             fi
         done <<< "$open_claim_plan"
+    done
+
+    # Third pass: sweep stale `fleet:stewarding-*` labels off open
+    # fleet:epic issues. A stewardship session is one transient
+    # epic-steward iteration; the TTL is looser than the PR-label sweep
+    # because an iteration may end by opening a docs PR (#1663). This is
+    # a separate pass — the first pass scans open PRs only and umbrella
+    # claims live on issues.
+    local steward_stale_secs="${FLEET_CLAIM_STALE_SECS_STEWARD:-3600}"
+    for repo in "${repos[@]}"; do
+        local steward_plan
+        steward_plan=$(gh issue list --repo "$repo" --state open \
+            --label "fleet:epic" \
+            --json number,labels --limit 200 2>/dev/null \
+            | python3 -c '
+import json, sys
+try:
+    issues = json.load(sys.stdin)
+except Exception:
+    issues = []
+for issue in issues:
+    n = issue.get("number")
+    for l in (issue.get("labels") or []):
+        name = (l or {}).get("name", "") if isinstance(l, dict) else ""
+        if name.startswith("fleet:stewarding-"):
+            print(f"{n}\t{name}")
+' 2>/dev/null || echo "")
+
+        [[ -z "$steward_plan" ]] && continue
+
+        while IFS=$'\t' read -r issue_num label_name; do
+            [[ -z "$issue_num" || -z "$label_name" ]] && continue
+
+            local added_epoch
+            added_epoch=$(label_added_epoch "$repo" "$issue_num" "$label_name")
+            [[ "$added_epoch" -eq 0 ]] && continue
+
+            local age=$(( now - added_epoch ))
+            [[ $age -lt $steward_stale_secs ]] && continue
+
+            if gh issue edit "$issue_num" --repo "$repo" \
+                    --remove-label "$label_name" >/dev/null 2>&1; then
+                echo "cleanup --gh: removed stale '$label_name' on $repo issue#$issue_num (age: $((age / 60))m)"
+                total_removed=$((total_removed + 1))
+            else
+                write_orphan_sentinel "$repo" "$issue_num" "$label_name" \
+                    "cleanup --gh: steward remove-label failed"
+            fi
+        done <<< "$steward_plan"
     done
 
     if [[ $total_removed -eq 0 ]]; then
@@ -2065,6 +2095,11 @@ for r in reservations:
         apply={"type": "drop_reservation", "worktree": wt, "issue": issue})
 
 # ---- R4a: design-blocked + design-unblocked contradiction ----
+# fleet:design-proposed coexisting with either design sibling is also a
+# contradiction (a botched steward swap), but flag-only: the proposal
+# lifecycle is steward/human-owned and "keep most-recently-applied" could
+# silently un-park a proposal, so reconcile never auto-resolves it.
+DESIGN_SIBLINGS = {"fleet:design-blocked", "fleet:design-unblocked"}
 for repo in repos:
     d = repo_data[repo]
     for n, labs in d["issue_labels"].items():
@@ -2073,6 +2108,12 @@ for repo in repos:
                 "contradictory design-blocked + design-unblocked; keep "
                 "most-recently-applied, remove older", "both labels present",
                 apply={"type": "resolve_design_contradiction", "target": n, "repo": repo})
+        if "fleet:design-proposed" in labs and labs & DESIGN_SIBLINGS:
+            add("R4a", repo, n, "issue", ["label"],
+                "fleet:design-proposed coexists with a design sibling; "
+                "steward/human resolves which state wins (flag-only — "
+                "never auto-strip a steward signal)",
+                "flag-only (R4a)")
     for pr in d["prs"]:
         labs = labelset(pr)
         if "fleet:design-blocked" in labs and "fleet:design-unblocked" in labs:
@@ -2081,6 +2122,12 @@ for repo in repos:
                 "most-recently-applied, remove older", "both labels present",
                 apply={"type": "resolve_design_contradiction",
                        "target": pr.get("number"), "repo": repo})
+        if "fleet:design-proposed" in labs and labs & DESIGN_SIBLINGS:
+            add("R4a", repo, pr.get("number"), "pr", ["label"],
+                "fleet:design-proposed coexists with a design sibling; "
+                "steward/human resolves which state wins (flag-only — "
+                "never auto-strip a steward signal)",
+                "flag-only (R4a)")
 
 # ---- R4b: queued + in-progress, no claim (any host), no PR ----
 for repo in repos:
@@ -2131,8 +2178,11 @@ for repo in repos:
             # So "no claim / reservation / claim-label" here is the correct
             # parked state. (fleet:design-unblocked stays flaggable — it IS in
             # FEEDBACK above — because an unclaimed unblocked PR genuinely is
-            # awaiting re-adoption.)
-            if "fleet:design-blocked" in labs:
+            # awaiting re-adoption.) fleet:design-proposed parks the same way:
+            # the steward released its claim and re-adoption is gated on the
+            # umbrella's STEWARD PROPOSAL being answered, not a free pickup
+            # decision (#1663).
+            if "fleet:design-blocked" in labs or "fleet:design-proposed" in labs:
                 continue
             issue_labs = d["issue_labels"].get(issue_n, set())
             if (any(l.startswith("fleet:claim-") for l in issue_labs)
@@ -2175,7 +2225,13 @@ for repo in repos:
             labs = pr["labels"]
             if "fleet:wip" not in labs:
                 continue
-            if "fleet:design-blocked" in labs or "fleet:design-unblocked" in labs:
+            # fleet:design-proposed exempts the PR: it IS a routing signal
+            # (steward distribution, not worker resume) — healing it to
+            # design-unblocked would un-park every steward proposal within
+            # a few drift ticks (#1663).
+            if ("fleet:design-blocked" in labs
+                    or "fleet:design-unblocked" in labs
+                    or "fleet:design-proposed" in labs):
                 continue
             add("R7", repo, pr["number"], "pr", ["pr", "label"],
                 "stranded wip PR for #%d: no claim + neither design label on a "
@@ -2594,10 +2650,13 @@ PYEOF
 
     [[ -z "$healable" ]] && return 0
 
+    # PRs share the issues labels endpoint; `gh issue edit` on a PR number is
+    # the file-wide convention for PR label edits (gh_release_label, the
+    # cleanup --gh PR sweep).
     local repo pr issue
     while IFS=$'\t' read -r repo pr issue; do
         [[ -z "$repo" || -z "$pr" ]] && continue
-        if gh pr edit "$pr" --repo "$repo" \
+        if gh issue edit "$pr" --repo "$repo" \
             --add-label "fleet:design-unblocked" >/dev/null 2>&1; then
             echo "  reconcile --apply: R7 healed half-executed design-unblock — re-added fleet:design-unblocked on $repo #$pr (issue #$issue)"
         else
@@ -3561,8 +3620,9 @@ case "${1:-}" in
         ;;
     host)
         # Print this machine's canonical host key (mac|linux|windows), the
-        # token behind every fleet:claim-*/reviewing-*/resolving-*/amending-*
-        # label. With an explicit `uname -s` string as $2, map that instead —
+        # token behind every fleet:claim-*/reviewing-*/resolving-*/amending-*/
+        # stewarding-* label. With an explicit `uname -s` string as $2, map
+        # that instead —
         # the seam test_derive_host.sh uses to pin each mapping portably.
         if [[ -n "${2:-}" ]]; then
             host_from_uname "$2"
@@ -3658,6 +3718,20 @@ case "${1:-}" in
             exit 2
         fi
         cmd_amending_release "$2" "$3"
+        ;;
+    steward-claim)
+        if [[ -z "${3:-}" ]]; then
+            echo "usage: fleet-claim [--repo <ns>] steward-claim <umbrella-issue> <agent>" >&2
+            exit 2
+        fi
+        cmd_steward_claim "$2" "$3"
+        ;;
+    steward-release)
+        if [[ -z "${3:-}" ]]; then
+            echo "usage: fleet-claim [--repo <ns>] steward-release <umbrella-issue> <agent>" >&2
+            exit 2
+        fi
+        cmd_steward_release "$2" "$3"
         ;;
     clear-all)
         cmd_clear_all
@@ -3801,9 +3875,10 @@ commands:
                                 retained through the PR's review/merge
                                 lifecycle — EXCEPT when the issue's
                                 matching open PR is parked
-                                (fleet:design-blocked/-unblocked), in
-                                which case they are cleared so any
-                                worker can re-claim after the architect
+                                (fleet:design-blocked/-unblocked/
+                                -proposed), in which case they are
+                                cleared so any worker can re-claim
+                                after the architect (or steward)
                                 unblocks (#1488). The abandoned-claim
                                 sweep in `cleanup --gh` is the TTL
                                 safety net.
@@ -3829,7 +3904,7 @@ commands:
                                 (default: 7200).
   cleanup [--repo o/r] [--gh] ...
                                 Remove claims whose linked issue is
-                                CLOSED. With --gh also runs two
+                                CLOSED. With --gh also runs three
                                 GitHub sweeps:
                                 (1) stale fleet:reviewing-*,
                                     fleet:resolving-*, and
@@ -3840,10 +3915,15 @@ commands:
                                     abandoned — age > TTL (default
                                     7200s) AND no *active* matching PR
                                     exists. A matching PR that is parked
-                                    (fleet:design-blocked/-unblocked)
-                                    counts as abandoned, not active
-                                    (#1488). `fleet:in-progress` is
-                                    removed alongside the claim label.
+                                    (fleet:design-blocked/-unblocked/
+                                    -proposed) counts as abandoned, not
+                                    active (#1488). `fleet:in-progress`
+                                    is removed alongside the claim
+                                    label,
+                                (3) stale fleet:stewarding-* labels off
+                                    open fleet:epic issues (age >
+                                    FLEET_CLAIM_STALE_SECS_STEWARD,
+                                    default 3600s).
                                 `fleet:claim-*` labels on CLOSED
                                 issues are preserved as a historical
                                 "who worked on this" record.
@@ -3861,6 +3941,15 @@ commands:
                                 (reviewers skip the PR while held).
   amending-release <pr> <agent>
                                 release an amendment claim.
+  steward-claim <umbrella-issue> <agent>
+                                atomically claim an epic UMBRELLA ISSUE
+                                for a stewardship session via a
+                                fleet:stewarding-<host>-<agent> label
+                                (per-epic mutex for the epic-steward
+                                role; swept by cleanup --gh after
+                                FLEET_CLAIM_STALE_SECS_STEWARD).
+  steward-release <umbrella-issue> <agent>
+                                release a stewardship claim.
   clear-all                     wipe all claims (used by fleet-up on
                                 restart).
   reset-sweep-host-claims       unconditionally remove this host's
@@ -3889,9 +3978,10 @@ commands:
                                         (any host) + no open PR → remove the
                                         stale fleet:in-progress.
                                 R2 (orphaned WIP/feedback PR with no claim;
-                                fleet:design-blocked PRs exempt — their
-                                no-claim state is protocol-correct) is
-                                report-only. Cross-host is flag-only by
+                                fleet:design-blocked / fleet:design-proposed
+                                PRs exempt — their no-claim state is
+                                protocol-correct) is report-only. Cross-host
+                                is flag-only by
                                 construction — never auto-releases another
                                 host's FS state or claim label. Defaults to
                                 engine + game (when reachable); --repo

--- a/scripts/fleet/fleet_branch_match.py
+++ b/scripts/fleet/fleet_branch_match.py
@@ -62,12 +62,19 @@ def branch_matches_issue(head_ref, issue, repo):
     return any(head.startswith(p) for p in issue_branch_prefixes(repo, issue))
 
 
-# A PR carrying either of these is *parked*: a worker hit a design wall and
+# A PR carrying any of these is *parked*: a worker hit a design wall and
 # released its claim so ANY worker can resume once the architect responds.
 # Such a PR is NOT active work even though it is open and `fleet:wip` — its
 # lingering issue-side `fleet:claim-*` / `fleet:in-progress` labels would
 # otherwise wedge the issue as "in progress" and block re-claim (#1488).
-PARKED_PR_LABELS = frozenset({"fleet:design-blocked", "fleet:design-unblocked"})
+# `fleet:design-proposed` parks the same way: the epic-steward released its
+# claim and the PR waits on a STEWARD PROPOSAL answer on the umbrella issue;
+# re-adoption is gated on the steward's distribution pass (#1663).
+PARKED_PR_LABELS = frozenset({
+    "fleet:design-blocked",
+    "fleet:design-unblocked",
+    "fleet:design-proposed",
+})
 
 
 def issue_pr_state(prs, issue, repo):

--- a/scripts/fleet/tests/test_fleet_claim_reconcile_heal_design_unblock.sh
+++ b/scripts/fleet/tests/test_fleet_claim_reconcile_heal_design_unblock.sh
@@ -52,18 +52,25 @@ HEALPERSIST="$FLEET_STATE_DIR/design-unblock-heal-persistence.json"
 # --- canned label/PR surfaces ---------------------------------------------
 # #800: fleet:queued, no claim label. PR #850 (claude/800-*) is the stranded
 # wip PR: fleet:wip, no claim, NEITHER design label → the R7 target state.
+# #900/#950: same claimless-wip-on-queued-issue shape, but PR #950 carries
+# fleet:design-proposed — an epic-steward proposal park (#1663). It must be
+# INVISIBLE to both R7 (healing it would un-park the proposal) and R2 (its
+# no-claim state is protocol-correct), across every phase below.
 export ISSUES_JSON="$TMPROOT/issues.json"
 export PRS_JSON="$TMPROOT/prs.json"
 cat > "$ISSUES_JSON" <<'JSON'
 [
-  {"number":800,"state":"OPEN","labels":[{"name":"fleet:queued"}]}
+  {"number":800,"state":"OPEN","labels":[{"name":"fleet:queued"}]},
+  {"number":900,"state":"OPEN","labels":[{"name":"fleet:queued"}]}
 ]
 JSON
 wip_only_prs() {
     cat > "$PRS_JSON" <<'JSON'
 [
   {"number":850,"headRefName":"claude/800-stranded-wip","body":"Closes #800",
-   "labels":[{"name":"fleet:wip"}]}
+   "labels":[{"name":"fleet:wip"}]},
+  {"number":950,"headRefName":"claude/900-steward-proposed","body":"Closes #900",
+   "labels":[{"name":"fleet:wip"},{"name":"fleet:design-proposed"}]}
 ]
 JSON
 }
@@ -71,7 +78,9 @@ healed_prs() {
     cat > "$PRS_JSON" <<'JSON'
 [
   {"number":850,"headRefName":"claude/800-stranded-wip","body":"Closes #800",
-   "labels":[{"name":"fleet:wip"},{"name":"fleet:design-unblocked"}]}
+   "labels":[{"name":"fleet:wip"},{"name":"fleet:design-unblocked"}]},
+  {"number":950,"headRefName":"claude/900-steward-proposed","body":"Closes #900",
+   "labels":[{"name":"fleet:wip"},{"name":"fleet:design-proposed"}]}
 ]
 JSON
 }
@@ -170,6 +179,12 @@ assert all(f.get("apply") is None for f in r2), "R2 must remain flag-only"
 PY
 if [[ ! -f "$HEALPERSIST" ]]; then ok "report-only wrote no heal-persistence state"; else bad "report-only advanced heal persistence"; fi
 c=$(du_add_count); [[ "$c" == "0" ]] && ok "report-only added no design-unblocked label" || bad "report-only healed (add count=$c)"
+python3 - "$REPORT" <<'PY' && ok "design-proposed PR #950 invisible to R7 AND R2 (steward park respected)" || bad "R7/R2 fired on the design-proposed PR #950"
+import sys, json
+r = json.load(open(sys.argv[1]))
+hits = [f for f in r["findings"] if f["target"] == 950 and f["rule"] in ("R2", "R7")]
+assert not hits, f"design-proposed PR must be exempt, got: {hits}"
+PY
 
 echo "=== Phase 2: --apply ticks accrue; freshly-opened PR NOT healed below threshold ==="
 run_reconcile --apply
@@ -209,6 +224,23 @@ c=$(du_add_count); [[ "$c" == "1" ]] && ok "re-accrual below threshold does not 
 run_reconcile --apply   # count 3 == threshold → re-heal
 c=$(heal_count); [[ "$c" == "3" ]] && ok "re-stranded reaches threshold again (count 3)" || bad "re-accrual count=$c (want 3)"
 c=$(du_add_count); [[ "$c" == "2" ]] && ok "recurring stranded state heals again after threshold" || bad "no re-heal after recurrence (add count=$c)"
+
+echo "=== Phase 6: design-proposed PR #950 never healed across any apply tick ==="
+if grep -q '950' "$EDIT_LOG"; then
+    bad "an apply pass edited the design-proposed PR #950: $(grep '950' "$EDIT_LOG")"
+else
+    ok "no apply pass ever edited PR #950"
+fi
+c=$(python3 - "$HEALPERSIST" <<'PY'
+import sys, json
+try:
+    s = json.load(open(sys.argv[1]))
+except Exception:
+    print(0); raise SystemExit
+print(sum(1 for k in (s if isinstance(s, dict) else {}) if k.endswith(":950")))
+PY
+)
+[[ "$c" == "0" ]] && ok "no heal-persistence key accrued for PR #950" || bad "heal persistence tracked the design-proposed PR (#950 keys=$c)"
 
 echo
 echo "================================"

--- a/scripts/fleet/tests/test_fleet_claim_steward.sh
+++ b/scripts/fleet/tests/test_fleet_claim_steward.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Tests for the epic-steward claim class (#1663): steward-claim /
+# steward-release on an umbrella ISSUE via the fleet:stewarding-<host>-<agent>
+# label, and the cleanup --gh third pass that sweeps stale stewarding labels
+# off open fleet:epic issues after FLEET_CLAIM_STALE_SECS_STEWARD.
+#
+# The claim path reuses _acquire_label_on / _claim_decision, whose race
+# semantics are exhaustively covered by test_fleet_claim_acquire.sh — here we
+# pin the steward-specific wiring: the prefix, the issue-target wording, the
+# sole-holder win/yield through the wrappers, and the TTL sweep (separate
+# third pass over open fleet:epic issues; the PR pass never sees these
+# labels).
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        ok "$msg"
+    else
+        bad "$msg (expected '$expected', got '$actual')"
+    fi
+}
+
+assert_exit() {
+    local actual_exit="$1" expected_exit="$2" msg="$3"
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        ok "$msg"
+    else
+        bad "$msg (expected exit $expected_exit, got $actual_exit)"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+export FLEET_TEST_HOST="mac"
+export FLEET_CLAIM_NO_SLEEP=1
+export FLEET_CLAIM_ACQUIRE_RETRIES=2
+
+# Source fleet-claim as a library (defines helpers, skips the dispatch). Clear
+# positional args first so the script's top-level --repo parse is a no-op.
+set --
+FLEET_CLAIM_LIB=1 source "$FLEET_CLAIM"
+
+P="fleet:stewarding-mac-"
+MINE="${P}epic-steward"
+OTHER="fleet:stewarding-linux-epic-steward"
+
+echo "== steward-claim / steward-release wrappers (gh stub) =="
+
+# Stateful gh stub for the claim path. STUB_HOLDERS = stewarding labels
+# "already present" on the umbrella; the POST response echoes those plus the
+# just-posted label. remove-label calls are logged so yield-self-removal and
+# release are observable.
+STUB_HOLDERS=""
+REMOVE_LOG="$TMPROOT/remove.log"; : > "$REMOVE_LOG"
+gh() {
+    case "${1:-}" in
+        api)
+            local posted="" a
+            for a in "$@"; do
+                case "$a" in
+                    labels\[\]=*) posted="${a#labels[]=}" ;;
+                esac
+            done
+            local out='[' first=1 h
+            for h in $STUB_HOLDERS $posted; do
+                [[ $first -eq 1 ]] || out+=','
+                out+="{\"name\":\"$h\"}"
+                first=0
+            done
+            out+=']'
+            printf '%s\n' "$out"
+            return 0
+            ;;
+        issue)
+            if [[ "${2:-}" == "edit" ]]; then
+                printf '%s\n' "$*" >> "$REMOVE_LOG"
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+echo "T1: sole holder → steward-claim acquires (exit 0), issue-worded output"
+STUB_HOLDERS=""
+rc=0
+out=$(cmd_steward_claim 1661 epic-steward 2>&1) || rc=$?
+assert_exit "$rc" 0 "no existing stewarding holder → exit 0"
+case "$out" in
+    *"issue#1661"*) ok "acquire message names the umbrella as an issue" ;;
+    *) bad "acquire message should say issue#1661, got: $out" ;;
+esac
+
+echo "T2: another host already stewarding → yield (exit 1) + self-remove"
+STUB_HOLDERS="$OTHER"
+: > "$REMOVE_LOG"
+rc=0
+cmd_steward_claim 1661 epic-steward >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 1 "persistent stewarding holder → exit 1 (never a co-win)"
+if grep -q -- "--remove-label $MINE" "$REMOVE_LOG"; then
+    ok "losing claimant self-removed its stewarding label"
+else
+    bad "losing claimant did not self-remove (log: $(cat "$REMOVE_LOG"))"
+fi
+
+echo "T3: non-numeric umbrella rejected with issue wording (exit 2)"
+rc=0
+out=$(cmd_steward_claim not-a-number epic-steward 2>&1) || rc=$?
+assert_exit "$rc" 2 "non-numeric target → exit 2"
+case "$out" in
+    *"issue must be a number"*) ok "rejection message uses issue wording" ;;
+    *) bad "expected 'issue must be a number', got: $out" ;;
+esac
+
+echo "T4: steward-release removes the label"
+: > "$REMOVE_LOG"
+rc=0
+cmd_steward_release 1661 epic-steward >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 0 "release exits 0"
+if grep -q -- "--remove-label $MINE" "$REMOVE_LOG"; then
+    ok "release removed $MINE"
+else
+    bad "release did not remove $MINE (log: $(cat "$REMOVE_LOG"))"
+fi
+
+echo "T5: _claim_decision geometry holds for the stewarding prefix"
+# Lex order: ...-linux-... < ...-mac-... ('l' < 'm'), so MINE (mac) is the
+# lex-larger of the pair and must yield; OTHER (linux) retries as lex-min.
+assert_eq "$(_claim_decision "$MINE" "$MINE")" "win" \
+    "sole stewarding holder → win"
+assert_eq "$(_claim_decision "$MINE" "$MINE" "$OTHER")" "lose" \
+    "lex-larger stewarding claimant vs existing holder → lose"
+assert_eq "$(_claim_decision "$OTHER" "$MINE" "$OTHER")" "retry" \
+    "lex-min stewarding claimant amid contention → retry, never co-win"
+
+echo "== cleanup --gh third pass: stale stewarding sweep over fleet:epic =="
+
+# Fresh stub for the cleanup path. Surfaces:
+#   pr list                          → []   (first pass: nothing)
+#   issue list --search fleet:queued → []   (second pass: nothing)
+#   issue list --label fleet:epic    → two umbrellas, one stale stewarding
+#                                      label (#70, added 2h ago) and one
+#                                      fresh (#71, added 10s ago)
+#   api .../events                   → the canned labeled-event timestamp
+#                                      for whichever label is being aged
+# Removals are logged; only the stale one may be swept at the default TTL.
+NOW_EPOCH=$(date +%s)
+STALE_AT=$(python3 -c "
+import datetime
+print(datetime.datetime.fromtimestamp($NOW_EPOCH - 7200,
+      datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+FRESH_AT=$(python3 -c "
+import datetime
+print(datetime.datetime.fromtimestamp($NOW_EPOCH - 10,
+      datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+export STALE_AT FRESH_AT
+
+EPICS_JSON="$TMPROOT/epics.json"
+cat > "$EPICS_JSON" <<JSON
+[
+  {"number":70,"labels":[{"name":"fleet:epic"},{"name":"fleet:stewarding-mac-epic-steward"}]},
+  {"number":71,"labels":[{"name":"fleet:epic"},{"name":"fleet:stewarding-linux-epic-steward"}]}
+]
+JSON
+export EPICS_JSON
+
+gh() {
+    case "${1:-}" in
+        pr)
+            [[ "${2:-}" == "list" ]] && { echo "[]"; return 0; }
+            return 0
+            ;;
+        issue)
+            case "${2:-}" in
+                list)
+                    if printf '%s ' "$@" | grep -q -- "--label fleet:epic"; then
+                        cat "$EPICS_JSON"
+                    else
+                        echo "[]"
+                    fi
+                    return 0
+                    ;;
+                edit)
+                    printf '%s\n' "$*" >> "$REMOVE_LOG"
+                    return 0
+                    ;;
+                *) return 0 ;;
+            esac
+            ;;
+        api)
+            # label_added_epoch events lookup: stale timestamp for #70's
+            # label, fresh for #71's. The target number rides in the path arg.
+            if printf '%s ' "$@" | grep -q "issues/70/"; then
+                echo "$STALE_AT"
+            else
+                echo "$FRESH_AT"
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+echo "T6: default TTL (3600) sweeps the 2h-old label, keeps the fresh one"
+: > "$REMOVE_LOG"
+unset FLEET_CLAIM_STALE_SECS_STEWARD
+out=$(cmd_cleanup_gh "jakildev/IrredenEngine" 2>&1)
+if grep -q -- "--remove-label fleet:stewarding-mac-epic-steward" "$REMOVE_LOG"; then
+    ok "stale stewarding label on epic#70 swept"
+else
+    bad "stale label not swept (log: $(cat "$REMOVE_LOG"); out: $out)"
+fi
+if grep -q -- "--remove-label fleet:stewarding-linux-epic-steward" "$REMOVE_LOG"; then
+    bad "fresh stewarding label on epic#71 wrongly swept"
+else
+    ok "fresh stewarding label on epic#71 kept"
+fi
+case "$out" in
+    *"removed stale 'fleet:stewarding-mac-epic-steward'"*) ok "sweep reported the removal" ;;
+    *) bad "sweep output missing removal line: $out" ;;
+esac
+
+echo "T7: FLEET_CLAIM_STALE_SECS_STEWARD override keeps even the 2h-old label"
+: > "$REMOVE_LOG"
+export FLEET_CLAIM_STALE_SECS_STEWARD=999999
+cmd_cleanup_gh "jakildev/IrredenEngine" >/dev/null 2>&1
+if grep -q -- "--remove-label fleet:stewarding-" "$REMOVE_LOG"; then
+    bad "label swept despite TTL override (log: $(cat "$REMOVE_LOG"))"
+else
+    ok "TTL override respected; nothing swept"
+fi
+unset FLEET_CLAIM_STALE_SECS_STEWARD
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- `fleet-claim steward-claim / steward-release <umbrella-issue> <agent>`: per-epic umbrella-issue mutex for the epic-steward role via a `fleet:stewarding-<host>-<agent>` label — same sole-holder lex-min tie-break as `fleet:reviewing-*`, reusing the prefix-parameterized `_cmd_pr_label_claim` / `_cmd_pr_label_release` helpers (now taking an optional target-word so messages say "issue" for umbrella targets). No FS lock: one steward pane per host, and the label is what the other host sees. Deliberately NOT `fleet:claim-*` (issue-lifecycle semantics mismatch a transient stewardship session).
- `cleanup --gh` third sweep: stale `fleet:stewarding-*` labels off open `fleet:epic` issues after `FLEET_CLAIM_STALE_SECS_STEWARD` (default 3600s — looser than the PR-label TTL because a steward iteration may end by opening a docs PR), with the existing orphan-sentinel fallback.
- `fleet:design-proposed` joins `PARKED_PR_LABELS` (`fleet_branch_match.py`) — proposal-parked PRs get the same parked-claim semantics as design-blocked/-unblocked in `release` and the claim sweeps.
- Reconcile carve-outs: **R2** skips design-proposed PRs (their claim-less state is protocol-correct); **R7**'s auto-heal exempts them — without this, reconcile would re-add `fleet:design-unblocked` to every steward proposal within `FLEET_RECONCILE_DRIFT_TICKS` (the plan's highest-risk line, regression-tested); **R4a** flags (never auto-resolves) `design-proposed` coexisting with either design sibling.
- Fix: R7's heal now edits PR labels via `gh issue edit` — the file-wide convention (`gh_release_label`, the cleanup PR sweep). The committed heal test asserted exactly this path and had been red since authoring (its gh stub only logs `issue edit` calls); 5 pre-existing failures now pass.
- Reuse: cleanup passes 1+2 call `label_added_epoch` instead of inlining its body (the new pass 3 set the pattern).

## Stack context
This PR is part of a stack. Reviewers: review this PR on its own;
the base PR carries the label definitions + steward protocol docs.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/1672

## Test plan
- [x] `test_fleet_claim_steward.sh` (new): 15/15 — wrapper acquire / yield + self-remove / issue wording / release; cleanup TTL sweep keeps fresh labels, sweeps stale, honors the env override
- [x] `test_fleet_claim_reconcile_heal_design_unblock.sh` (extended): 21/21 — design-proposed PR #950 invisible to R7 AND R2 across every report/apply tick; pre-existing heal assertions (Phases 3–5) now green
- [x] Full fleet-claim battery green: acquire 10, reconcile 22, reconcile_c2 21, parked_release 12, blockers 18, model_gate 11, pr_claim_feedback 27, stackable_live_resolve 7, branch_matches.py 22 — 0 failures
- [x] `bash -n scripts/fleet/fleet-claim` clean

Closes #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
