### PR TITLE
fleet: scout epic fetch, project_epic_steward projection + slice, skip-set updates (P3) (#1664)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -200,6 +200,19 @@ def fetch_needs_plan(repo):
     return fetch_issues_by_label(repo, "fleet:needs-plan")
 
 
+def fetch_epics(repo):
+    # Open fleet:epic umbrellas for the epic-steward role (#1664). The body's
+    # `## Children` checklist is the steward's membership source of truth —
+    # parse it into `checklist` and pop the body before the state write (epic
+    # bodies are large; the per-issue detail cache keeps the full body for the
+    # role's drill-in).
+    epics = fetch_issues_by_label(repo, "fleet:epic", with_body=True)
+    for epic in epics:
+        body = epic.pop("body", "") or ""
+        epic["checklist"] = _parse_epic_checklist(body)
+    return epics
+
+
 def fetch_human_approved(repo):
     # Exclude already-ingested issues to avoid re-triggering queue-manager.
     # with_body=True so resolve_human_approved_blockers can parse the
@@ -292,6 +305,26 @@ def _parse_issue_field(body, field):
         return ""
     m = re.search(rf'\*\*(?:Suggested\s+)?{re.escape(field)}:\*\*\s*(.+?)(?:\n|$)', body)
     return m.group(1).strip() if m else ""
+
+
+# Umbrella-body `## Children` checklist rows: `- [ ] #N` / `- [x] #N`. The
+# first `#N` on a checkbox line is the child ref, so bold-wrapped forms like
+# `- [x] **#1527 — mechanism**` resolve to 1527 and later refs in the same
+# row's prose are ignored. `[ \t]` (not `\s`) after the box keeps the match on
+# one line — `\s` would let a ref-less checkbox row swallow a `#N` from the
+# next line. Non-checkbox `#N` lines never match.
+_EPIC_CHECKLIST_RE = re.compile(
+    r'^[ \t]*-[ \t]*\[( |x|X)\][ \t].*?#(\d+)', re.MULTILINE)
+
+
+def _parse_epic_checklist(body):
+    """[{number, checked}] for every `- [ ] #N` / `- [x] #N` row in an
+    umbrella body, in document order. Indented sub-bullets count; lines
+    without a checkbox or without a `#N` ref do not."""
+    return [
+        {"number": int(m.group(2)), "checked": m.group(1) in "xX"}
+        for m in _EPIC_CHECKLIST_RE.finditer(body or "")
+    ]
 
 
 # A dependency may be declared two ways: the canonical `**Blocked by:** #N`
@@ -464,6 +497,10 @@ def fetch_task_queue(repo_slug):
             # (see _ingest_unblock_candidates).
             "blocked": "fleet:blocked" in labels,
             "issue": task_id,
+            # `**Part of epic:** #U` back-ref (raw field value, e.g. "#1661").
+            # The epic-steward adoption projection joins this against open
+            # umbrellas' checklists (#1664).
+            "epic": _parse_issue_field(body, "Part of epic") or None,
         }
 
         if status == "~":
@@ -717,6 +754,8 @@ def refresh_all_details(state):
             jobs.append(("issue", repo_key, issue))
         for issue in repo_state.get("human_approved", []):
             jobs.append(("issue", repo_key, issue))
+        for issue in repo_state.get("epics", []):
+            jobs.append(("issue", repo_key, issue))
 
     pr_refreshed = 0
     diff_refreshed = 0
@@ -767,7 +806,9 @@ def refresh_all_details(state):
         gc_pr_caches(repo_key, pr_numbers, head_oids)
         issue_numbers = {
             i["number"]
-            for i in repo_state.get("needs_plan", []) + repo_state.get("human_approved", [])
+            for i in (repo_state.get("needs_plan", [])
+                      + repo_state.get("human_approved", [])
+                      + repo_state.get("epics", []))
         }
         gc_issue_caches(repo_key, issue_numbers)
 
@@ -801,6 +842,10 @@ REVIEW_SKIP_LABELS = frozenset({
     # the reviewer sees is in flux. Re-evaluate once fleet:changes-made
     # appears (which RECHECK_LABELS picks up).
     "fleet:human-amending",
+    # Parked in an epic-steward proposal package — the PR's open design
+    # question is queued on the umbrella for the human/architect; reviewing
+    # the in-flux diff is wasted work until design-unblock clears it (#1664).
+    "fleet:design-proposed",
 })
 # Dynamic per-host claim prefixes that also bar reviewer pickup. A worker
 # amending a fleet:needs-fix PR holds fleet:amending-<host>-<agent> (minted
@@ -866,7 +911,12 @@ def model_tags(task):
     return set(MODEL_TOKEN_RE.findall((task.get("model") or "").lower()))
 
 
-_DESIGN_BLOCK_LABELS = frozenset({"fleet:design-blocked", "fleet:design-escalated"})
+_DESIGN_BLOCK_LABELS = frozenset({
+    "fleet:design-blocked", "fleet:design-escalated",
+    # Steward-parked design question (proposal pending on the umbrella) —
+    # stacking on such a PR has the same hazard as a design-blocked one (#1664).
+    "fleet:design-proposed",
+})
 
 
 def _area_prefixes(area_str):
@@ -950,6 +1000,17 @@ def _resolve_ref_satisfied(repo_slug, ref_str, cache):
     return result
 
 
+def _closed_issue_numbers(repo_state):
+    """Issue numbers (as strings) known closed from the already-fetched
+    closed_fleet_queued window — the shared in-memory closed-set every
+    resolve_* pass checks before its live fallback."""
+    return {
+        str(i.get("number", ""))
+        for i in repo_state.get("closed_fleet_queued", [])
+        if i.get("number")
+    }
+
+
 def resolve_blocked_by(state):
     """Resolve blocked_by fields for all open tasks.
 
@@ -964,11 +1025,7 @@ def resolve_blocked_by(state):
         if not repo_slug:
             continue
 
-        closed_nums = {
-            str(i.get("number", ""))
-            for i in repo_state.get("closed_fleet_queued", [])
-            if i.get("number")
-        }
+        closed_nums = _closed_issue_numbers(repo_state)
         merged_heads = [
             pr.get("headRefName", "") or ""
             for pr in repo_state.get("recent_merged_prs", [])
@@ -1026,11 +1083,7 @@ def resolve_human_approved_blockers(state):
     never bloats state.json or the per-role slices.
     """
     for repo_key, repo_state in state["repos"].items():
-        closed_nums = {
-            str(i.get("number", ""))
-            for i in repo_state.get("closed_fleet_queued", [])
-            if i.get("number")
-        }
+        closed_nums = _closed_issue_numbers(repo_state)
         merged_heads = [
             pr.get("headRefName", "") or ""
             for pr in repo_state.get("recent_merged_prs", [])
@@ -1038,6 +1091,9 @@ def resolve_human_approved_blockers(state):
 
         for issue in repo_state.get("human_approved", []):
             body = issue.pop("body", "") or ""
+            # Same `Part of epic` back-ref the task records carry (#1664) —
+            # parsed here because this is where the body already flows.
+            issue["epic"] = _parse_issue_field(body, "Part of epic") or None
             issue["blocked"] = False
             raw = _parse_blocked_by(body)
             if not raw:
@@ -1061,6 +1117,70 @@ def resolve_human_approved_blockers(state):
                     continue
                 issue["blocked"] = True
                 break
+
+
+def resolve_epic_children(state):
+    """Annotate each epic for the steward projection (#1664). Mutates state
+    in place before the state write, mirroring resolve_blocked_by, so both
+    project_epic_steward and slice_epic_steward stay pure functions of the
+    annotated state (no live gh inside a projector).
+
+    Per epic: `plan_path` (repo-relative) and `plan_exists` (cheap local
+    Path.exists() against the repo checkout — staleness only delays the
+    normalize bootstrap by one pull; never add git fetches here). Per
+    checklist entry: `closed`, resolved from the already-fetched open/closed
+    sets:
+
+    - visible-open union (tasks open/in_progress, human_approved, needs_plan,
+      epics) → open
+    - closed_fleet_queued → closed
+    - already-checked entries → closed without the live fallback. The steward
+      only ticks a box after verifying closure (and flow d re-verifies live
+      before close-out), so trusting the tick avoids a per-tick gh call for
+      every checked child that has aged out of the closed_fleet_queued
+      window. A reopened child re-enters the visible-open union via its
+      surviving fleet:queued label, which takes precedence above.
+    - else the rare _resolve_ref_satisfied live fallback (per-tick cached) —
+      only unchecked children invisible to every list fetch land here (e.g.
+      filed but not yet approved/queued).
+    """
+    per_tick_cache: dict = {}
+    for repo_key, repo_state in state["repos"].items():
+        repo_slug = _REPO_SLUG_MAP.get(repo_key)
+        epics = repo_state.get("epics", [])
+        if not repo_slug or not epics:
+            continue
+
+        tasks = repo_state.get("tasks", {})
+        visible_open = set()
+        for section in ("open", "in_progress"):
+            for task in tasks.get(section, []):
+                num = (task.get("issue") or "").lstrip("#")
+                if num:
+                    visible_open.add(num)
+        for issue in (repo_state.get("human_approved", [])
+                      + repo_state.get("needs_plan", []) + epics):
+            if issue.get("number"):
+                visible_open.add(str(issue["number"]))
+        closed_nums = _closed_issue_numbers(repo_state)
+
+        repo_path = repo_state.get("path", "")
+        for epic in epics:
+            number = epic.get("number")
+            plan_rel = f".fleet/plans/issue-{number}.md"
+            epic["plan_path"] = plan_rel
+            epic["plan_exists"] = bool(
+                repo_path and (Path(repo_path) / plan_rel).exists()
+            )
+            for entry in epic.get("checklist", []):
+                child = str(entry.get("number", ""))
+                if child in visible_open:
+                    entry["closed"] = False
+                elif child in closed_nums or entry.get("checked"):
+                    entry["closed"] = True
+                else:
+                    entry["closed"] = _resolve_ref_satisfied(
+                        repo_slug, child, per_tick_cache)
 
 
 def enrich_stackable_blocker_prs(state):
@@ -1269,6 +1389,10 @@ def _merger_action_signal(labels, mergeable, base_ref):
     skip = labels & {
         "fleet:wip", "human:wip", "fleet:blocker",
         "fleet:fork-of-other-pr", "fleet:design-blocked",
+        # Parked by the epic-steward pending a proposal answer on the
+        # umbrella — same not-the-merger's-business semantics as
+        # design-blocked; design-unblock re-surfaces it (#1664).
+        "fleet:design-proposed",
         "fleet:needs-info", "fleet:needs-linux-smoke",
         "fleet:needs-macos-smoke",
         "fleet:human-deferred",
@@ -1397,6 +1521,142 @@ def project_smoke_worker(state):
     return sorted(items, key=lambda x: x["pr"])
 
 
+def _epic_design_prs(repo_key, repo_state):
+    """(pr, umbrella_number, child_number, op) for every open PR carrying a
+    design label that branch-matches a checklist child of an open epic.
+
+    op is "triage" for fleet:design-blocked, "distribute" for a
+    fleet:design-proposed PR whose umbrella no longer carries
+    fleet:steward-proposal (the proposal was answered — the label's removal
+    is the re-fire edge), and None for a design-proposed PR whose proposal
+    is still pending (visible in the slice, absent from the hash). A design
+    PR matching no checklist child is the architect's lane — not emitted.
+    """
+    epics = repo_state.get("epics", [])
+    if not epics:
+        return []
+    epics_by_number = {e.get("number"): e for e in epics}
+    child_to_umbrella = {}
+    for epic in epics:
+        for entry in epic.get("checklist", []):
+            child_to_umbrella.setdefault(
+                str(entry.get("number", "")), epic.get("number"))
+    out = []
+    for pr in repo_state.get("prs", []):
+        labels = set(pr.get("labels", []))
+        blocked = "fleet:design-blocked" in labels
+        proposed = "fleet:design-proposed" in labels
+        if not (blocked or proposed):
+            continue
+        head = pr.get("headRefName", "")
+        match = next(
+            ((child, umbrella) for child, umbrella in child_to_umbrella.items()
+             if branch_matches_issue(head, child, repo_key)),
+            None,
+        )
+        if match is None:
+            continue
+        child, umbrella = match
+        if blocked:
+            op = "triage"
+        elif "fleet:steward-proposal" not in set(
+                epics_by_number.get(umbrella, {}).get("labels", [])):
+            op = "distribute"
+        else:
+            op = None
+        out.append((pr, umbrella, int(child), op))
+    return out
+
+
+def _epic_adopt_candidates(repo_state):
+    """[{issue, epic, title}] for visible open issues (tasks open/in_progress
+    + human_approved) declaring `**Part of epic:** #U` where U is an open
+    epic whose checklist lacks them. A ref to a closed or non-epic umbrella
+    emits nothing — there is no checklist to adopt into."""
+    epics = repo_state.get("epics", [])
+    if not epics:
+        return []
+    member_sets = {
+        e.get("number"): {entry.get("number") for entry in e.get("checklist", [])}
+        for e in epics
+    }
+    candidates = []
+    tasks = repo_state.get("tasks", {})
+    for task in tasks.get("open", []) + tasks.get("in_progress", []):
+        candidates.append((task.get("epic"),
+                           (task.get("issue") or "").lstrip("#"),
+                           task.get("summary", "")))
+    for issue in repo_state.get("human_approved", []):
+        candidates.append((issue.get("epic"),
+                           str(issue.get("number", "")),
+                           issue.get("title", "")))
+    out = []
+    for epic_ref, num_str, title in candidates:
+        m = re.search(r"#(\d+)", epic_ref or "")
+        if not m or not num_str.isdigit():
+            continue
+        umbrella = int(m.group(1))
+        if umbrella not in member_sets or int(num_str) in member_sets[umbrella]:
+            continue
+        out.append({"issue": int(num_str), "epic": umbrella, "title": title})
+    return out
+
+
+def project_epic_steward(state):
+    """Hash-input projection for the epic-steward role (#1664).
+
+    Every op is edge-triggered by the steward's own writes — items carry
+    only stable fields (no label lists, no timestamps; the project_merger
+    lesson), and each disappears as a direct consequence of the steward
+    acting on it:
+
+    - normalize  — managed epic (repo-side plan file exists) with no body
+                   checklist; gone when the steward heals the checklist in.
+                   Legacy checklist-less epics without plan files emit
+                   nothing (no perma-trigger).
+    - rollup     — unchecked checklist child that is closed; gone when the
+                   steward ticks the box.
+    - adopt      — visible open issue declaring `Part of epic: #U` absent
+                   from that umbrella's checklist; gone when appended.
+    - design     — op=triage: fleet:design-blocked PR branch-matched to a
+                   checklist child; gone on design-unblock/design-propose.
+                   op=distribute: fleet:design-proposed PR whose umbrella
+                   dropped fleet:steward-proposal; gone on design-unblock.
+    - closeout   — checklist non-empty and every child closed, umbrella
+                   open; gone when the umbrella closes.
+    """
+    items = []
+    for repo, repo_state in state["repos"].items():
+        epics = repo_state.get("epics", [])
+        if not epics:
+            continue
+        for epic in epics:
+            number = epic.get("number")
+            checklist = epic.get("checklist", [])
+            if not checklist:
+                if epic.get("plan_exists"):
+                    items.append({"kind": "normalize", "repo": repo,
+                                  "epic": number})
+                continue
+            for entry in checklist:
+                if entry.get("closed") and not entry.get("checked"):
+                    items.append({"kind": "rollup", "repo": repo,
+                                  "epic": number,
+                                  "child": entry.get("number")})
+            if all(entry.get("closed") for entry in checklist):
+                items.append({"kind": "closeout", "repo": repo,
+                              "epic": number})
+        for cand in _epic_adopt_candidates(repo_state):
+            items.append({"kind": "adopt", "repo": repo,
+                          "epic": cand["epic"], "issue": cand["issue"]})
+        for pr, umbrella, _child, op in _epic_design_prs(repo, repo_state):
+            if op is None:
+                continue
+            items.append({"kind": "design", "op": op, "repo": repo,
+                          "epic": umbrella, "pr": pr["number"]})
+    return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
+
+
 PROJECTORS = {
     "sonnet-author": project_sonnet_author,
     "opus-worker": project_opus_worker,
@@ -1406,6 +1666,7 @@ PROJECTORS = {
     "queue-manager-ingest": project_queue_manager_ingest,
     "merger": project_merger,
     "smoke-worker": project_smoke_worker,
+    "epic-steward": project_epic_steward,
 }
 
 
@@ -1582,6 +1843,38 @@ def slice_smoke_worker(state):
     return out
 
 
+def slice_epic_steward(state):
+    """Full-record slice for the epic-steward role (#1664).
+
+    - `epics` — every open umbrella, repo-tagged, with its parsed checklist
+      (per-child `closed` from resolve_epic_children) and the umbrella plan
+      path/presence.
+    - `design_prs` — design-blocked / design-proposed PRs branch-matched to a
+      checklist child, repo-tagged, annotated with `epic`, `child`, and `op`
+      (`triage` / `distribute` / null while the proposal is still pending).
+    - `adoptable` — visible open issues declaring a `Part of epic` umbrella
+      whose checklist lacks them.
+    - `triggers` — the projector's items verbatim, so the role's startup
+      reads pending work by flow without recomputing the hash inputs.
+    """
+    out = {"epics": [], "design_prs": [], "adoptable": []}
+    for repo_key, repo_state in state["repos"].items():
+        for epic in repo_state.get("epics", []):
+            out["epics"].append(_slice_issue_with_repo(repo_key, epic))
+        for pr, umbrella, child, op in _epic_design_prs(repo_key, repo_state):
+            record = _slice_pr_with_repo(repo_key, pr)
+            record["epic"] = umbrella
+            record["child"] = child
+            record["op"] = op
+            out["design_prs"].append(record)
+        for cand in _epic_adopt_candidates(repo_state):
+            record = dict(cand)
+            record["repo"] = repo_key
+            out["adoptable"].append(record)
+    out["triggers"] = project_epic_steward(state)
+    return out
+
+
 SLICERS = {
     "sonnet-author": slice_sonnet_author,
     "opus-worker": slice_opus_worker,
@@ -1591,6 +1884,7 @@ SLICERS = {
     "queue-manager-ingest": slice_queue_manager_ingest,
     "smoke-worker": slice_smoke_worker,
     "merger": slice_merger,
+    "epic-steward": slice_epic_steward,
 }
 
 
@@ -1628,6 +1922,7 @@ def collect_state():
             ("engine", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/IrredenEngine")),
             ("engine", "recent_merged_prs", lambda: fetch_recent_merged_prs("jakildev/IrredenEngine")),
             ("engine", "tasks", lambda: fetch_task_queue("jakildev/IrredenEngine")),
+            ("engine", "epics", lambda: fetch_epics("jakildev/IrredenEngine")),
         ]
     if "game" in repos:
         fetch_specs += [
@@ -1637,6 +1932,7 @@ def collect_state():
             ("game", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/irreden")),
             ("game", "recent_merged_prs", lambda: fetch_recent_merged_prs("jakildev/irreden")),
             ("game", "tasks", lambda: fetch_task_queue("jakildev/irreden")),
+            ("game", "epics", lambda: fetch_epics("jakildev/irreden")),
         ]
 
     with ThreadPoolExecutor(max_workers=FETCH_MAX_WORKERS) as ex:
@@ -1674,6 +1970,7 @@ def tick_once():
     _populate_done_tasks(state)
     resolve_blocked_by(state)
     resolve_human_approved_blockers(state)
+    resolve_epic_children(state)
     enrich_stackable_blocker_prs(state)
     write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
 

--- a/scripts/fleet/tests/test_epic_steward_projection.py
+++ b/scripts/fleet/tests/test_epic_steward_projection.py
@@ -1,0 +1,448 @@
+"""Tests for project_epic_steward() / slice_epic_steward() /
+resolve_epic_children() in fleet-state-scout (#1664).
+
+The steward's hash-input projection must be strictly edge-triggered:
+every item disappears as a direct consequence of the steward's own
+write (tick a box, heal a checklist, append a child, flip a design
+label, close the umbrella). The quiescence invariant is the same one
+project_merger documents — a transient field in the items would
+self-trigger the role forever.
+"""
+import importlib.machinery
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+project_epic_steward = _mod.project_epic_steward
+slice_epic_steward = _mod.slice_epic_steward
+resolve_epic_children = _mod.resolve_epic_children
+project_sonnet_reviewer = _mod.project_sonnet_reviewer
+project_opus_reviewer = _mod.project_opus_reviewer
+project_merger = _mod.project_merger
+enrich_stackable_blocker_prs = _mod.enrich_stackable_blocker_prs
+stable_hash = _mod.stable_hash
+
+
+def _entry(num, *, checked=False, closed=False):
+    return {"number": num, "checked": checked, "closed": closed}
+
+
+def _epic(num, *, checklist=None, labels=None, plan_exists=False,
+          updated_at="2026-06-10T00:00:00Z"):
+    return {
+        "number": num,
+        "title": f"epic {num}",
+        "labels": sorted(labels or ["fleet:epic"]),
+        "updatedAt": updated_at,
+        "checklist": checklist if checklist is not None else [],
+        "plan_path": f".fleet/plans/issue-{num}.md",
+        "plan_exists": plan_exists,
+    }
+
+
+def _pr(num, *, labels=None, head="claude/1-feat", mergeable="MERGEABLE",
+        base="master", draft=False):
+    return {
+        "number": num,
+        "title": f"pr {num}",
+        "headRefName": head,
+        "baseRefName": base,
+        "labels": sorted(labels or []),
+        "mergeable": mergeable,
+        "isDraft": draft,
+        "author": "bot",
+    }
+
+
+def _task(num, *, epic=None, summary="task", in_progress=False, blocked_by="(none)"):
+    return {
+        "status": "~" if in_progress else " ",
+        "title": f"#{num}",
+        "summary": summary,
+        "id": f"#{num}",
+        "model": "opus",
+        "owner": "free",
+        "area": None,
+        "blocked_by": blocked_by,
+        "blocked": False,
+        "issue": f"#{num}",
+        "epic": epic,
+    }
+
+
+def _state(*, epics=None, prs=None, tasks_open=None, tasks_in_progress=None,
+           human_approved=None, needs_plan=None, closed_fleet_queued=None,
+           repo="engine", path=""):
+    return {"repos": {repo: {
+        "path": path,
+        "epics": epics or [],
+        "prs": prs or [],
+        "tasks": {"open": tasks_open or [],
+                  "in_progress": tasks_in_progress or [],
+                  "done": []},
+        "human_approved": human_approved or [],
+        "needs_plan": needs_plan or [],
+        "closed_fleet_queued": closed_fleet_queued or [],
+    }}}
+
+
+def _hash(state):
+    return stable_hash(project_epic_steward(state))
+
+
+class Quiescence(unittest.TestCase):
+    """Same durable state twice -> same hash; transient fields never leak
+    into the items."""
+
+    def _busy_state(self):
+        return _state(
+            epics=[_epic(10, checklist=[
+                _entry(11, checked=True, closed=True),
+                _entry(12, closed=True),
+                _entry(13),
+            ])],
+            prs=[_pr(101, labels=["fleet:design-blocked"], head="claude/13-x")],
+            tasks_open=[_task(14, epic="#10")],
+        )
+
+    def test_same_state_same_hash(self):
+        self.assertEqual(_hash(self._busy_state()), _hash(self._busy_state()))
+
+    def test_umbrella_updated_at_does_not_flip_hash(self):
+        before = _state(epics=[_epic(10, checklist=[_entry(11)])])
+        after = _state(epics=[_epic(10, checklist=[_entry(11)],
+                                    updated_at="2026-06-11T12:34:56Z")])
+        self.assertEqual(_hash(before), _hash(after))
+
+    def test_unrelated_pr_label_churn_does_not_flip_hash(self):
+        # Reviewer/merger label traffic on a non-design PR is invisible.
+        before = _state(epics=[_epic(10, checklist=[_entry(11)])],
+                        prs=[_pr(101, labels=["fleet:approved"])])
+        after = _state(epics=[_epic(10, checklist=[_entry(11)])],
+                       prs=[_pr(101, labels=["fleet:approved",
+                                             "fleet:merger-cooldown"])])
+        self.assertEqual(_hash(before), _hash(after))
+
+    def test_no_epics_projects_empty(self):
+        self.assertEqual(project_epic_steward(_state()), [])
+
+
+class NormalizeOp(unittest.TestCase):
+    def test_managed_checklist_less_epic_emits_normalize(self):
+        items = project_epic_steward(
+            _state(epics=[_epic(10, plan_exists=True)]))
+        self.assertEqual(items, [{"kind": "normalize", "repo": "engine",
+                                  "epic": 10}])
+
+    def test_healing_the_checklist_consumes_normalize(self):
+        before = _state(epics=[_epic(10, plan_exists=True)])
+        after = _state(epics=[_epic(10, plan_exists=True,
+                                    checklist=[_entry(11)])])
+        self.assertNotEqual(_hash(before), _hash(after))
+        self.assertEqual(project_epic_steward(after), [])
+
+    def test_legacy_epic_without_plan_file_emits_nothing(self):
+        # ~17 pre-protocol epics have neither checklist nor plan file; they
+        # must not hold the projection non-empty forever.
+        self.assertEqual(
+            project_epic_steward(_state(epics=[_epic(10)])), [])
+
+
+class RollupOp(unittest.TestCase):
+    def test_closed_unchecked_child_emits_rollup(self):
+        items = project_epic_steward(_state(epics=[
+            _epic(10, checklist=[_entry(11, closed=True), _entry(12)]),
+        ]))
+        self.assertEqual(items, [{"kind": "rollup", "repo": "engine",
+                                  "epic": 10, "child": 11}])
+
+    def test_checking_the_box_consumes_rollup(self):
+        before = _state(epics=[_epic(10, checklist=[
+            _entry(11, closed=True), _entry(12)])])
+        after = _state(epics=[_epic(10, checklist=[
+            _entry(11, checked=True, closed=True), _entry(12)])])
+        self.assertNotEqual(_hash(before), _hash(after))
+        self.assertEqual(project_epic_steward(after), [])
+
+    def test_open_unchecked_child_emits_nothing(self):
+        self.assertEqual(project_epic_steward(
+            _state(epics=[_epic(10, checklist=[_entry(11)])])), [])
+
+
+class AdoptOp(unittest.TestCase):
+    def test_declared_child_missing_from_checklist_emits_adopt(self):
+        items = project_epic_steward(_state(
+            epics=[_epic(10, checklist=[_entry(11)])],
+            tasks_open=[_task(14, epic="#10")],
+        ))
+        self.assertEqual(items, [{"kind": "adopt", "repo": "engine",
+                                  "epic": 10, "issue": 14}])
+
+    def test_appending_to_checklist_consumes_adopt(self):
+        before = _state(epics=[_epic(10, checklist=[_entry(11)])],
+                        tasks_open=[_task(14, epic="#10")])
+        after = _state(epics=[_epic(10, checklist=[_entry(11), _entry(14)])],
+                       tasks_open=[_task(14, epic="#10")])
+        self.assertNotEqual(_hash(before), _hash(after))
+        self.assertEqual(project_epic_steward(after), [])
+
+    def test_human_approved_issue_is_adoptable(self):
+        items = project_epic_steward(_state(
+            epics=[_epic(10, checklist=[_entry(11)])],
+            human_approved=[{"number": 15, "title": "new child",
+                             "labels": ["human:approved"], "epic": "#10"}],
+        ))
+        self.assertEqual(items, [{"kind": "adopt", "repo": "engine",
+                                  "epic": 10, "issue": 15}])
+
+    def test_ref_to_unknown_umbrella_emits_nothing(self):
+        # Closed or non-epic umbrella: no checklist to adopt into.
+        self.assertEqual(project_epic_steward(_state(
+            epics=[_epic(10, checklist=[_entry(11)])],
+            tasks_open=[_task(14, epic="#99")],
+        )), [])
+
+
+class DesignOp(unittest.TestCase):
+    def test_design_blocked_child_pr_emits_triage(self):
+        items = project_epic_steward(_state(
+            epics=[_epic(10, checklist=[_entry(13)])],
+            prs=[_pr(101, labels=["fleet:design-blocked", "fleet:wip"],
+                     head="claude/13-canvas")],
+        ))
+        self.assertEqual(items, [{"kind": "design", "op": "triage",
+                                  "repo": "engine", "epic": 10, "pr": 101}])
+
+    def test_non_epic_design_block_is_architects_lane(self):
+        self.assertEqual(project_epic_steward(_state(
+            epics=[_epic(10, checklist=[_entry(13)])],
+            prs=[_pr(101, labels=["fleet:design-blocked"],
+                     head="claude/77-unrelated")],
+        )), [])
+
+    def test_design_propose_with_pending_proposal_emits_nothing(self):
+        # Steward parked the PR and stamped the umbrella: no trigger until
+        # the responder removes fleet:steward-proposal.
+        self.assertEqual(project_epic_steward(_state(
+            epics=[_epic(10, checklist=[_entry(13)],
+                         labels=["fleet:epic", "fleet:steward-proposal"])],
+            prs=[_pr(101, labels=["fleet:design-proposed"],
+                     head="claude/13-canvas")],
+        )), [])
+
+    def test_proposal_answered_emits_distribute(self):
+        # Removing fleet:steward-proposal from the umbrella is the re-fire
+        # edge: the parked PR surfaces as a distribute item.
+        items = project_epic_steward(_state(
+            epics=[_epic(10, checklist=[_entry(13)])],
+            prs=[_pr(101, labels=["fleet:design-proposed"],
+                     head="claude/13-canvas")],
+        ))
+        self.assertEqual(items, [{"kind": "design", "op": "distribute",
+                                  "repo": "engine", "epic": 10, "pr": 101}])
+
+    def test_design_unblock_consumes_the_item(self):
+        before = _state(
+            epics=[_epic(10, checklist=[_entry(13)])],
+            prs=[_pr(101, labels=["fleet:design-proposed"],
+                     head="claude/13-canvas")])
+        after = _state(
+            epics=[_epic(10, checklist=[_entry(13)])],
+            prs=[_pr(101, labels=["fleet:design-unblocked"],
+                     head="claude/13-canvas")])
+        self.assertNotEqual(_hash(before), _hash(after))
+        self.assertEqual(project_epic_steward(after), [])
+
+    def test_game_branch_form_matches(self):
+        # Game checklists must match both claude/<N>- and claude/game-<N>-.
+        items = project_epic_steward(_state(
+            repo="game",
+            epics=[_epic(10, checklist=[_entry(13)])],
+            prs=[_pr(101, labels=["fleet:design-blocked"],
+                     head="claude/game-13-canvas")],
+        ))
+        self.assertEqual(items, [{"kind": "design", "op": "triage",
+                                  "repo": "game", "epic": 10, "pr": 101}])
+
+
+class CloseoutOp(unittest.TestCase):
+    def test_all_children_closed_emits_closeout(self):
+        items = project_epic_steward(_state(epics=[
+            _epic(10, checklist=[_entry(11, checked=True, closed=True),
+                                 _entry(12, checked=True, closed=True)]),
+        ]))
+        self.assertEqual(items, [{"kind": "closeout", "repo": "engine",
+                                  "epic": 10}])
+
+    def test_closing_the_umbrella_consumes_closeout(self):
+        # A closed umbrella leaves the open fleet:epic fetch entirely.
+        before = _state(epics=[
+            _epic(10, checklist=[_entry(11, checked=True, closed=True)])])
+        after = _state(epics=[])
+        self.assertNotEqual(_hash(before), _hash(after))
+        self.assertEqual(project_epic_steward(after), [])
+
+    def test_empty_checklist_never_emits_closeout(self):
+        self.assertEqual(project_epic_steward(
+            _state(epics=[_epic(10, plan_exists=True)])),
+            [{"kind": "normalize", "repo": "engine", "epic": 10}])
+
+    def test_closed_but_unchecked_emits_rollup_and_closeout(self):
+        # Both pending: the steward ticks (rollup) then closes (closeout).
+        kinds = sorted(i["kind"] for i in project_epic_steward(_state(epics=[
+            _epic(10, checklist=[_entry(11, closed=True)])])))
+        self.assertEqual(kinds, ["closeout", "rollup"])
+
+
+class ResolveEpicChildren(unittest.TestCase):
+    """Closed-state annotation uses the already-fetched open/closed sets;
+    the live gh fallback is reserved for unchecked children invisible to
+    every list fetch."""
+
+    def setUp(self):
+        self._orig = _mod._resolve_ref_satisfied
+        self.fallback_calls = []
+
+    def tearDown(self):
+        _mod._resolve_ref_satisfied = self._orig
+
+    def _stub_fallback(self, result):
+        def stub(repo_slug, ref, cache):
+            self.fallback_calls.append((repo_slug, ref))
+            return result
+        _mod._resolve_ref_satisfied = stub
+
+    def test_visible_open_child_is_open_without_fallback(self):
+        self._stub_fallback(True)
+        state = _state(epics=[_epic(10, checklist=[_entry(11)])],
+                       tasks_open=[_task(11)])
+        resolve_epic_children(state)
+        entry = state["repos"]["engine"]["epics"][0]["checklist"][0]
+        self.assertFalse(entry["closed"])
+        self.assertEqual(self.fallback_calls, [])
+
+    def test_closed_fleet_queued_child_is_closed_without_fallback(self):
+        self._stub_fallback(False)
+        state = _state(epics=[_epic(10, checklist=[_entry(11)])],
+                       closed_fleet_queued=[{"number": 11, "title": "t",
+                                             "labels": []}])
+        resolve_epic_children(state)
+        entry = state["repos"]["engine"]["epics"][0]["checklist"][0]
+        self.assertTrue(entry["closed"])
+        self.assertEqual(self.fallback_calls, [])
+
+    def test_checked_invisible_child_trusted_closed_without_fallback(self):
+        # A ticked child aged out of the closed_fleet_queued window must not
+        # cost a gh call every tick.
+        self._stub_fallback(False)
+        state = _state(epics=[_epic(10, checklist=[_entry(11, checked=True)])])
+        resolve_epic_children(state)
+        entry = state["repos"]["engine"]["epics"][0]["checklist"][0]
+        self.assertTrue(entry["closed"])
+        self.assertEqual(self.fallback_calls, [])
+
+    def test_unchecked_invisible_child_uses_fallback(self):
+        self._stub_fallback(True)
+        state = _state(epics=[_epic(10, checklist=[_entry(11)])])
+        resolve_epic_children(state)
+        entry = state["repos"]["engine"]["epics"][0]["checklist"][0]
+        self.assertTrue(entry["closed"])
+        self.assertEqual(self.fallback_calls,
+                         [("jakildev/IrredenEngine", "11")])
+
+    def test_plan_existence_annotated_from_repo_checkout(self):
+        self._stub_fallback(False)
+        with tempfile.TemporaryDirectory() as repo:
+            plans = Path(repo) / ".fleet" / "plans"
+            plans.mkdir(parents=True)
+            (plans / "issue-10.md").write_text("# plan\n")
+            state = _state(epics=[_epic(10), _epic(20)], path=repo)
+            resolve_epic_children(state)
+            epics = state["repos"]["engine"]["epics"]
+            self.assertTrue(epics[0]["plan_exists"])
+            self.assertEqual(epics[0]["plan_path"], ".fleet/plans/issue-10.md")
+            self.assertFalse(epics[1]["plan_exists"])
+
+
+class DesignProposedSkipSets(unittest.TestCase):
+    """fleet:design-proposed parks a PR off the review/merger/stacking
+    surfaces until the proposal resolves (#1664 acceptance criterion)."""
+
+    def test_absent_from_sonnet_reviewer_projection(self):
+        state = _state(prs=[_pr(101, labels=["fleet:design-proposed"])])
+        self.assertEqual(project_sonnet_reviewer(state), [])
+
+    def test_absent_from_opus_reviewer_projection(self):
+        state = _state(prs=[_pr(101, labels=["fleet:design-proposed",
+                                             "fleet:has-nits"])])
+        self.assertEqual(project_opus_reviewer(state), [])
+
+    def test_absent_from_merger_projection(self):
+        state = _state(prs=[_pr(101, labels=["fleet:design-proposed",
+                                             "fleet:approved"])])
+        self.assertEqual(project_merger(state), [])
+
+    def test_blocker_pr_not_stackable(self):
+        # enrich filter (b): a design-proposed blocker PR has the same
+        # stacking hazard as a design-blocked one.
+        state = _state(
+            prs=[_pr(101, labels=["fleet:design-proposed"],
+                     head="claude/11-base")],
+            tasks_open=[_task(12, blocked_by="#11")],
+        )
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertNotIn("stackable_blocker_pr", task)
+
+
+class Slice(unittest.TestCase):
+    def _state(self):
+        return _state(
+            epics=[_epic(10, checklist=[_entry(11, closed=True), _entry(13)])],
+            prs=[_pr(101, labels=["fleet:design-blocked"],
+                     head="claude/13-canvas")],
+            tasks_open=[_task(14, epic="#10", summary="late child")],
+        )
+
+    def test_slice_shape_and_repo_tags(self):
+        out = slice_epic_steward(self._state())
+        self.assertEqual([e["number"] for e in out["epics"]], [10])
+        self.assertEqual(out["epics"][0]["repo"], "engine")
+        self.assertEqual(out["epics"][0]["checklist"][0]["closed"], True)
+
+        self.assertEqual(len(out["design_prs"]), 1)
+        pr = out["design_prs"][0]
+        self.assertEqual((pr["repo"], pr["epic"], pr["child"], pr["op"]),
+                         ("engine", 10, 13, "triage"))
+
+        self.assertEqual(out["adoptable"],
+                         [{"issue": 14, "epic": 10, "title": "late child",
+                           "repo": "engine"}])
+
+    def test_triggers_mirror_projector(self):
+        state = self._state()
+        self.assertEqual(slice_epic_steward(state)["triggers"],
+                         project_epic_steward(state))
+
+    def test_pending_proposal_pr_visible_with_null_op(self):
+        # In the slice but not the hash: the steward can report it standing
+        # by without being woken for it.
+        state = _state(
+            epics=[_epic(10, checklist=[_entry(13)],
+                         labels=["fleet:epic", "fleet:steward-proposal"])],
+            prs=[_pr(101, labels=["fleet:design-proposed"],
+                     head="claude/13-canvas")],
+        )
+        out = slice_epic_steward(state)
+        self.assertEqual(out["design_prs"][0]["op"], None)
+        self.assertEqual(out["triggers"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fleet/tests/test_parse_epic_checklist.py
+++ b/scripts/fleet/tests/test_parse_epic_checklist.py
@@ -1,0 +1,93 @@
+"""Tests for _parse_epic_checklist() in fleet-state-scout (#1664).
+
+The umbrella body's `## Children` checklist is the epic-steward's
+membership source of truth. The parser must read every `- [ ] #N` /
+`- [x] #N` row (first ref per row wins, bold-wrapped refs included)
+and ignore everything else — a stray `#N` in prose adopted as a child
+would corrupt rollup/closeout for the whole epic.
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+_parse_epic_checklist = _mod._parse_epic_checklist
+
+
+class BasicRows(unittest.TestCase):
+    def test_unchecked_row(self):
+        self.assertEqual(_parse_epic_checklist("- [ ] #1662 — P1: docs"),
+                         [{"number": 1662, "checked": False}])
+
+    def test_checked_lower_x(self):
+        self.assertEqual(_parse_epic_checklist("- [x] #1663 — P2"),
+                         [{"number": 1663, "checked": True}])
+
+    def test_checked_upper_x(self):
+        self.assertEqual(_parse_epic_checklist("- [X] #1664 — P3"),
+                         [{"number": 1664, "checked": True}])
+
+    def test_document_order_preserved(self):
+        body = "- [x] #3 done\n- [ ] #1 first\n- [ ] #2 second"
+        self.assertEqual([e["number"] for e in _parse_epic_checklist(body)],
+                         [3, 1, 2])
+
+
+class RefExtraction(unittest.TestCase):
+    def test_bold_wrapped_ref(self):
+        self.assertEqual(_parse_epic_checklist("- [x] **#1527 — mechanism**"),
+                         [{"number": 1527, "checked": True}])
+
+    def test_first_ref_per_row_wins(self):
+        self.assertEqual(_parse_epic_checklist("- [ ] #10 supersedes #11 and #12"),
+                         [{"number": 10, "checked": False}])
+
+    def test_indented_sub_bullet_counts(self):
+        self.assertEqual(_parse_epic_checklist("  - [ ] #99 nested child"),
+                         [{"number": 99, "checked": False}])
+
+
+class NonRowsIgnored(unittest.TestCase):
+    def test_prose_ref_ignored(self):
+        self.assertEqual(_parse_epic_checklist("Blocked by #123, see also #124."),
+                         [])
+
+    def test_plain_bullet_ignored(self):
+        self.assertEqual(_parse_epic_checklist("- #124 plain bullet, no checkbox"),
+                         [])
+
+    def test_refless_checkbox_does_not_swallow_next_line(self):
+        # `[ \t]` after the box (not `\s`) keeps the match on one line — a
+        # ref-less checkbox row must not pair with a `#N` from the next line.
+        self.assertEqual(_parse_epic_checklist("- [ ] refless row\n#55 next line"),
+                         [])
+
+    def test_empty_and_none_bodies(self):
+        self.assertEqual(_parse_epic_checklist(""), [])
+        self.assertEqual(_parse_epic_checklist(None), [])
+
+
+class RealUmbrellaShape(unittest.TestCase):
+    def test_epic_1661_children_section_shape(self):
+        body = (
+            "## Scope\n\nA new autonomous role, see #1600 for context.\n\n"
+            "## Children\n\n"
+            "- [ ] #1662 — P1: canonical protocol, role-sharing doc\n"
+            "- [ ] #1663 — P2: steward claim class\n"
+            "- [x] #1664 — P3: scout epic fetch, projection + slice\n\n"
+            "## Closing criteria\n\n- All seven children merged.\n"
+        )
+        self.assertEqual(_parse_epic_checklist(body), [
+            {"number": 1662, "checked": False},
+            {"number": 1663, "checked": False},
+            {"number": 1664, "checked": True},
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on: https://github.com/jakildev/IrredenEngine/pull/1672

## Summary
- `fetch_epics` pulls open `fleet:epic` umbrellas (engine + game, +2 gh calls/tick inside the existing fetch pool) with the `## Children` checklist parsed into `checklist` and the body popped before the state write.
- `_parse_epic_checklist` handles `[ ]`/`[x]`/`[X]`, bold-wrapped refs (`- [x] **#1527 — mechanism**` → first ref wins), indented sub-bullets; non-checkbox `#N` lines never match.
- `resolve_epic_children` (new resolve pass in `tick_once`) annotates per-epic plan-file presence (cheap local `Path.exists()`, no git fetches) and per-child `closed` state from the already-fetched open/closed sets — checked boxes are trusted closed without a live call; only invisible unchecked children hit the per-tick-cached `_resolve_ref_satisfied` fallback.
- `project_epic_steward` emits strictly edge-triggered ops — `normalize` / `rollup` / `adopt` / `design` (triage + distribute) / `closeout` — carrying only stable fields (no labels, no timestamps; the `project_merger` lesson). Legacy checklist-less epics without plan files emit nothing (no perma-trigger).
- `slice_epic_steward` writes the full-record role slice: repo-tagged epics with checklists + closed state, design PRs annotated `epic`/`child`/`op`, adoptables, and the projector's items verbatim as `triggers`.
- `fleet:design-proposed` joins `REVIEW_SKIP_LABELS`, `_DESIGN_BLOCK_LABELS`, and the merger's action-signal skip set; epics join `refresh_all_details` + the issue-cache GC keep-set.
- `Part of epic` back-refs parsed where bodies already flow (`fetch_task_queue`, `resolve_human_approved_blockers`).
- Reuse: `_closed_issue_numbers` extracts the closed-set comprehension previously copied verbatim across the three `resolve_*` passes.

## Test plan
- [x] `python3 scripts/fleet/tests/test_epic_steward_projection.py` — 36 tests: quiescence (same state → same hash; updatedAt/label churn don't flip it), edge-consumption per op, legacy-epic silence, reviewer/merger skip-set, slice shape.
- [x] `python3 scripts/fleet/tests/test_parse_epic_checklist.py` — 12 parser tests (case, bold-wrapped refs, indentation, non-checkbox lines).
- [x] Full fleet suite: 298 tests pass.
- [x] Live read-only check (fetch + resolve + project + slice against live GitHub state, no state write, no triggers): identical projection hash across two runs minutes apart; epic #1661 emits zero items (checklist synced, 0/7 closed) exactly as planned; all ~20 legacy checklist-less epics emit nothing; real pending steward work surfaces (rollups/closeouts for fully-closed epics, normalize+adopt for #605 which has a plan file but no checklist yet).

## Notes
- Post-merge consolidation candidate: #1667 (PR #1676) adds a stricter `parse_checklist` to `fleet_validate_stack.py`; this PR's parser intentionally also accepts bold-wrapped refs (human-edited umbrella bodies). Two consumers today — possible future unification, out of scope here (cross-PR).
- Trigger files for the not-yet-registered epic-steward role are harmless; this merges before P4 (#1665).

Closes #1664

🤖 Generated with [Claude Code](https://claude.com/claude-code)
