### PR TITLE
fleet: dispatcher + fleet-up registration for epic-steward (#1665)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -100,6 +100,7 @@ _env_opus_reviewer="${FLEET_CONCURRENCY_OPUS_REVIEWER:-}"
 _env_queue_manager="${FLEET_CONCURRENCY_QUEUE_MANAGER:-}"
 _env_merger="${FLEET_CONCURRENCY_MERGER:-}"
 _env_smoke_worker="${FLEET_CONCURRENCY_SMOKE_WORKER:-}"
+_env_epic_steward="${FLEET_CONCURRENCY_EPIC_STEWARD:-}"
 # Same capture-before-source guard for per-role effort (FLEET_EFFORT_<ROLE>),
 # consumed by the ROLE_EFFORT map further down. Caller env wins over conf.
 _env_effort_opus_worker="${FLEET_EFFORT_OPUS_WORKER:-}"
@@ -116,6 +117,7 @@ _env_model_sonnet="${FLEET_MODEL_SONNET:-}"
 _env_model_merger="${FLEET_MODEL_MERGER:-}"
 _env_model_opus_reviewer="${FLEET_MODEL_OPUS_REVIEWER:-}"
 _env_fable_cap="${FLEET_CONCURRENCY_MODEL_FABLE:-}"
+_env_effort_epic_steward="${FLEET_EFFORT_EPIC_STEWARD:-}"
 if [[ -f "$FLEET_CONF" ]]; then
     # shellcheck disable=SC1090
     source "$FLEET_CONF"
@@ -139,9 +141,11 @@ declare -A ROLE_CONCURRENCY=(
     ["queue-manager"]="${_env_queue_manager:-${FLEET_CONCURRENCY_QUEUE_MANAGER:-1}}"
     ["merger"]="${_env_merger:-${FLEET_CONCURRENCY_MERGER:-1}}"
     ["smoke-worker"]="${_env_smoke_worker:-${FLEET_CONCURRENCY_SMOKE_WORKER:-1}}"
+    ["epic-steward"]="${_env_epic_steward:-${FLEET_CONCURRENCY_EPIC_STEWARD:-1}}"
 )
 unset _env_opus_worker _env_sonnet_author _env_sonnet_reviewer \
-      _env_opus_reviewer _env_queue_manager _env_merger _env_smoke_worker
+      _env_opus_reviewer _env_queue_manager _env_merger _env_smoke_worker \
+      _env_epic_steward
 
 # Tracks per-role "deferred-by-cap" log throttling so the at-cap message
 # doesn't spam every 10s tick while the cap is held. Cleared whenever a
@@ -318,6 +322,7 @@ DISPATCHED_ROLES=(
     "opus-reviewer"
     "merger"
     "smoke-worker"
+    "epic-steward"
 )
 # queue-manager is no longer LLM-dispatched. Maintenance (derived-field
 # rendering via fleet-queue-tick) was eliminated in #1229 — the queue is
@@ -362,6 +367,7 @@ declare -A ROLE_MODEL=(
     ["opus-reviewer"]="${FLEET_MODEL_OPUS_REVIEWER:-$OPUS_MODEL}"
     ["merger"]="${FLEET_MODEL_MERGER:-$SONNET_MODEL}"
     ["smoke-worker"]="$SONNET_MODEL"
+    ["epic-steward"]="$HEAVY_MODEL"
 )
 # Worker lanes that resolve a per-task class from their projection slice,
 # mapped to the class assumed when a task carries no model tag.
@@ -385,10 +391,12 @@ declare -A ROLE_EFFORT=(
     ["opus-reviewer"]="${_env_effort_opus_reviewer:-${FLEET_EFFORT_OPUS_REVIEWER:-${FLEET_EFFORT:-high}}}"
     ["merger"]="${_env_effort_merger:-${FLEET_EFFORT_MERGER:-${FLEET_EFFORT:-high}}}"
     ["smoke-worker"]="${_env_effort_smoke_worker:-${FLEET_EFFORT_SMOKE_WORKER:-${FLEET_EFFORT:-high}}}"
+    ["epic-steward"]="${_env_effort_epic_steward:-${FLEET_EFFORT_EPIC_STEWARD:-${FLEET_EFFORT:-xhigh}}}"
 )
 unset _env_effort_opus_worker _env_effort_sonnet_author \
       _env_effort_sonnet_reviewer _env_effort_opus_reviewer \
-      _env_effort_merger _env_effort_smoke_worker
+      _env_effort_merger _env_effort_smoke_worker \
+      _env_effort_epic_steward
 
 # Tracks which panes have already had their cooldown logged this cycle so
 # the "in rate-limit cooldown" message fires once per pane per cooldown

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -109,6 +109,7 @@ _env_effort_sonnet_reviewer="${FLEET_EFFORT_SONNET_REVIEWER:-}"
 _env_effort_opus_reviewer="${FLEET_EFFORT_OPUS_REVIEWER:-}"
 _env_effort_merger="${FLEET_EFFORT_MERGER:-}"
 _env_effort_smoke_worker="${FLEET_EFFORT_SMOKE_WORKER:-}"
+_env_effort_epic_steward="${FLEET_EFFORT_EPIC_STEWARD:-}"
 # Same guard for the model-class knobs (consumed by the class table and
 # ROLE_MODEL map further down) and the fable concurrency cap.
 _env_model_fable="${FLEET_MODEL_FABLE:-}"
@@ -117,7 +118,6 @@ _env_model_sonnet="${FLEET_MODEL_SONNET:-}"
 _env_model_merger="${FLEET_MODEL_MERGER:-}"
 _env_model_opus_reviewer="${FLEET_MODEL_OPUS_REVIEWER:-}"
 _env_fable_cap="${FLEET_CONCURRENCY_MODEL_FABLE:-}"
-_env_effort_epic_steward="${FLEET_EFFORT_EPIC_STEWARD:-}"
 if [[ -f "$FLEET_CONF" ]]; then
     # shellcheck disable=SC1090
     source "$FLEET_CONF"

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -1099,7 +1099,7 @@ def smoke_worker_actionable(p):
     return bool(p.get("smoke_pending_prs"))
 
 def epic_steward_actionable(p):
-    return bool(p.get("items"))
+    return bool(p.get("triggers"))
 
 for role, predicate in [
     ("merger", merger_actionable),

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -398,6 +398,13 @@ ensure_worktree "$ENGINE" .claude/worktrees/merger               fleet/merger
 if [[ "${FLEET_SMOKE_WORKER:-0}" == "1" ]]; then
     ensure_worktree "$ENGINE" .claude/worktrees/smoke-worker fleet/smoke-worker
 fi
+# epic-steward worktree is optional — only created when FLEET_EPIC_STEWARD=1.
+# The epic-steward is the fleet's epic bookkeeper (umbrella checklists, design-
+# block triage, proposal aggregation, close-out). Enable for active multi-epic
+# queues; omit when the queue is mostly single-task work.
+if [[ "${FLEET_EPIC_STEWARD:-0}" == "1" ]]; then
+    ensure_worktree "$ENGINE" .claude/worktrees/epic-steward fleet/epic-steward
+fi
 
 if [[ -d "$GAME/.git" ]]; then
     (cd "$GAME" && git fetch origin --quiet) || {
@@ -419,6 +426,11 @@ if [[ -d "$GAME/.git" ]]; then
     # rebases game PRs; the engine pass uses .claude/worktrees/merger under
     # the engine root above. Same dual-worktree model as the opus-workers.
     ensure_worktree "$GAME" .claude/worktrees/merger          fleet/game-merger
+    # epic-steward game worktree — only when FLEET_EPIC_STEWARD=1. Same
+    # dual-worktree model as opus-workers: engine pane cds here for game epics.
+    if [[ "${FLEET_EPIC_STEWARD:-0}" == "1" ]]; then
+        ensure_worktree "$GAME" .claude/worktrees/epic-steward fleet/game-epic-steward
+    fi
 else
     echo "fleet-up: game repo not found at $GAME — skipping game panes"
 fi
@@ -667,6 +679,7 @@ reset_worktree "$ENGINE/.claude/worktrees/queue-manager"        claude/queue-man
 reset_worktree "$ENGINE/.claude/worktrees/queue-manager-ingest" claude/queue-manager-ingest-scratch
 reset_worktree "$ENGINE/.claude/worktrees/merger"               claude/merger-scratch
 reset_worktree "$ENGINE/.claude/worktrees/smoke-worker"         claude/smoke-worker-scratch
+reset_worktree "$ENGINE/.claude/worktrees/epic-steward"         claude/epic-steward-scratch
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     reset_worktree "$GAME/.claude/worktrees/game-architect" claude/game-arch-scratch
@@ -682,6 +695,9 @@ if [[ -d "$GAME/.claude/worktrees/sonnet-fleet-1" ]]; then
 fi
 if [[ -d "$GAME/.claude/worktrees/sonnet-fleet-2" ]]; then
     reset_worktree "$GAME/.claude/worktrees/sonnet-fleet-2" claude/game-sonnet-fleet-2-scratch
+fi
+if [[ -d "$GAME/.claude/worktrees/epic-steward" ]]; then
+    reset_worktree "$GAME/.claude/worktrees/epic-steward" claude/game-epic-steward-scratch
 fi
 
 # ----------------------------------------------------------------------
@@ -845,6 +861,9 @@ done
 if [[ -d "$ENGINE/.claude/worktrees/smoke-worker" ]]; then
     write_worktree_settings "$ENGINE/.claude/worktrees/smoke-worker" "$ENGINE"
 fi
+if [[ -d "$ENGINE/.claude/worktrees/epic-steward" ]]; then
+    write_worktree_settings "$ENGINE/.claude/worktrees/epic-steward" "$ENGINE"
+fi
 
 if [[ -d "$GAME/.claude/worktrees/game-architect" ]]; then
     write_worktree_settings "$GAME/.claude/worktrees/game-architect" "$GAME"
@@ -866,6 +885,11 @@ if [[ -d "$GAME/.claude/worktrees/sonnet-fleet-1" ]]; then
 fi
 if [[ -d "$GAME/.claude/worktrees/sonnet-fleet-2" ]]; then
     write_worktree_settings "$GAME/.claude/worktrees/sonnet-fleet-2" "$ENGINE"
+fi
+# Game-side epic-steward worktree — allow access to both game tree and engine
+# helpers (same pattern as the game-side opus-worker and sonnet-fleet worktrees).
+if [[ -d "$GAME/.claude/worktrees/epic-steward" ]]; then
+    write_worktree_settings "$GAME/.claude/worktrees/epic-steward" "$ENGINE"
 fi
 
 # ----------------------------------------------------------------------
@@ -1074,6 +1098,9 @@ def opus_reviewer_actionable(p):
 def smoke_worker_actionable(p):
     return bool(p.get("smoke_pending_prs"))
 
+def epic_steward_actionable(p):
+    return bool(p.get("items"))
+
 for role, predicate in [
     ("merger", merger_actionable),
     ("sonnet-author", author_worker_actionable),
@@ -1081,6 +1108,7 @@ for role, predicate in [
     ("sonnet-reviewer", sonnet_reviewer_actionable),
     ("opus-reviewer", opus_reviewer_actionable),
     ("smoke-worker", smoke_worker_actionable),
+    ("epic-steward", epic_steward_actionable),
 ]:
     proj = proj_dir / f"{role}.json"
     if not proj.is_file():
@@ -1425,6 +1453,21 @@ if [[ -d "$ENGINE/.claude/worktrees/smoke-worker" ]]; then
     pane_stagger
 fi
 
+# Optional epic-steward pane — only launched when the worktree exists
+# (i.e. FLEET_EPIC_STEWARD=1 was set during ensure_worktree above).
+# Placed after the smoke-worker pane in the right column of the ops window;
+# if smoke-worker is absent, splits directly from the merger pane.
+if [[ -d "$ENGINE/.claude/worktrees/epic-steward" ]]; then
+    _epic_base="${OPS_SMOKE:-$OPS_TR}"
+    OPS_EPIC=$(tmux split-window -v -t "$_epic_base" -l 50% -P -F "#{pane_id}" \
+        -c "$ENGINE/.claude/worktrees/epic-steward" \
+        "$TRANSIENT_PANE_CMD")
+    label_pane_id "$OPS_EPIC" "epic-steward [$HEAVY_TAG]"
+    set_fleet_role "$OPS_EPIC" "epic-steward"
+    pane_stagger
+    unset _epic_base
+fi
+
 # Enable pane border labels using @role (immune to program overrides).
 # Apply at session level so it covers both windows.
 tmux set-option -t "$SESSION" pane-border-status top
@@ -1463,7 +1506,7 @@ layout (two windows):
 
 effort levels (per-role; override with FLEET_EFFORT_<ROLE> in env or
 ~/.fleet/fleet-up.conf, or FLEET_EFFORT=<level> to force all panes):
-  xhigh — opus-architect, game-architect, opus-worker
+  xhigh — opus-architect, game-architect, opus-worker, epic-steward
   high  — opus-reviewer, merger, sonnet-author, sonnet-reviewer, smoke-worker
 
 permission mode: auto (model decides when to ask vs proceed)

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -71,6 +71,7 @@
 # FLEET_CONCURRENCY_QUEUE_MANAGER=1
 # FLEET_CONCURRENCY_MERGER=1
 # FLEET_CONCURRENCY_SMOKE_WORKER=1   # concurrent cap for the smoke-only worker pane
+# FLEET_CONCURRENCY_EPIC_STEWARD=1   # concurrent cap for the epic-steward pane
 
 # --- Build parallelism (ir-build CPU budget) --------------------------------
 #
@@ -113,6 +114,7 @@
 # FLEET_EFFORT_SONNET_AUTHOR=high
 # FLEET_EFFORT_SONNET_REVIEWER=high
 # FLEET_EFFORT_SMOKE_WORKER=high
+# FLEET_EFFORT_EPIC_STEWARD=xhigh
 
 # --- Usage gate (per-rate-limit-type thresholds) ----------------------------
 #
@@ -219,3 +221,25 @@
 # secondary responsibility — this flag is opt-in extra dedicated capacity.
 
 # FLEET_SMOKE_WORKER=0
+
+# --- Epic-steward (umbrella bookkeeper) ------------------------------------
+#
+# FLEET_EPIC_STEWARD=1 tells fleet-up to create and launch a dedicated
+# epic-steward pane. The epic-steward is the fleet's epic bookkeeper: a
+# transient, dispatcher-driven role that maintains `fleet:epic` umbrella
+# `## Children` checklists, triages design-blocked epic children, aggregates
+# proposal packages for the architect, and drives epic close-out. It writes
+# only docs artifacts (plan files, umbrella comments, labels) — never pushes
+# code. Two worktrees are created: one under the engine clone and one under
+# the game clone (the pane's cwd is the engine worktree; it cds for game epics).
+#
+# When unset or 0, no epic-steward worktree or pane is created. The role's
+# epic-bookkeeping work simply doesn't run; umbrella issues accumulate until
+# the flag is enabled or the human triages them manually.
+#
+# Recommended: enable during active multi-epic queues; disable when the queue
+# is mostly single-task work to conserve credit budget.
+
+# FLEET_EPIC_STEWARD=0
+# FLEET_CONCURRENCY_EPIC_STEWARD=1  # matches the single pane
+# FLEET_EFFORT_EPIC_STEWARD=xhigh   # umbrella triage needs heavier reasoning


### PR DESCRIPTION
## Summary
- Register epic-steward in fleet-dispatcher: ROLE_CONCURRENCY, ROLE_MODEL (HEAVY_MODEL), ROLE_EFFORT (xhigh), DISPATCHED_ROLES — with env-capture-before-conf-source guard matching all other roles
- Add FLEET_EPIC_STEWARD gate to fleet-up: gated ensure_worktree (engine + game), unconditional reset_worktree, gated write_worktree_settings, bootstrap-trigger predicate on items list, gated ops-window pane that splits from OPS_SMOKE (or OPS_TR fallback)
- Document FLEET_EPIC_STEWARD / FLEET_CONCURRENCY_EPIC_STEWARD / FLEET_EFFORT_EPIC_STEWARD in fleet-up.conf.sample with a rationale block parallel to the smoke-worker section

## Test plan
- [ ] fleet-up with FLEET_EPIC_STEWARD=0 (default): no epic-steward worktree or pane created, existing roles unaffected
- [ ] fleet-up with FLEET_EPIC_STEWARD=1: epic-steward engine + game worktrees created, pane appears in ops window after smoke-worker (or merger if smoke absent)
- [ ] fleet-dispatcher picks up epic-steward pane: concurrency cap respected, HEAVY_MODEL dispatched, xhigh effort
- [ ] Bootstrap trigger: pane fires when epic-steward projection has items, stays idle when items empty

Stacked on: https://github.com/jakildev/IrredenEngine/pull/1678

Closes #1665

🤖 Generated with [Claude Code](https://claude.com/claude-code)