### PR TITLE
docs/fleet: absorb coding-improvement batch 1 — eleven tickets, ten surfaces

### DIFF
--- a/.claude/agents/simplify-check-math.md
+++ b/.claude/agents/simplify-check-math.md
@@ -12,7 +12,15 @@ Authoritative rule: [`.claude/rules/cpp-math.md`](../rules/cpp-math.md) — auto
 
 ## Scope
 
-For each `.hpp`/`.cpp` file in the diff, scan for:
+For each `.hpp`/`.cpp` file in the diff, scan the **entire file content**,
+not just the lines the diff introduced. `cpp-math.md`'s rule is two-sided:
+"don't add new violations; **do migrate when you're already touching one of
+the deviation files**" — a pre-existing `glm::min` in a touched file is a
+finding too, because the touch is the migration moment. Mark hits on lines
+the diff did not introduce with `[pre-existing]` so the parent can
+distinguish cleanup-along-the-way from a regression.
+
+Scan for:
 
 1. **`glm::*` calls** — any identifier in the `glm::` namespace, including types (`glm::vec3`, `glm::mat4`), functions (`glm::min`, `glm::clamp`, `glm::length`), and constants (`glm::pi<float>()`, `glm::half_pi<float>()`).
 
@@ -44,6 +52,7 @@ If the file path matches any of those, skip the file entirely.
 
 ```
 - [needs-fix] <path>:<line> — `<found-call>` — replace with `<IRMath-equivalent>`
+- [needs-fix][pre-existing] <path>:<line> — `<found-call>` — replace with `<IRMath-equivalent>` (predates this diff; file is touched, so migrate)
 ```
 
 All math violations are `needs-fix`. No `blocker` or `nit` from this scanner.

--- a/.claude/rules/cpp-ecs-smells.md
+++ b/.claude/rules/cpp-ecs-smells.md
@@ -32,6 +32,13 @@ In any system `tick` function:
   insertion. Fix: pre-size in `beginTick` (or at component construction for
   member buffers) and reuse across frames.
 
+- **Tick block scoped to one specific entity without an entity guard.** In a
+  system that iterates multiple entities, a block meant for only one of them
+  (a particular canvas, a singleton-ish entity) must carry
+  `entity == specificMember_ &&` in its condition -- a comment saying
+  "requires entity X" is not a guard. Mirror the guard the sibling blocks in
+  the same tick already use.
+
 ## System registration
 
 - **New prefab system not added to `SystemName`** in

--- a/.claude/skills/render-debug-loop/diagnosis/shapes-trixel-sdf.md
+++ b/.claude/skills/render-debug-loop/diagnosis/shapes-trixel-sdf.md
@@ -22,6 +22,7 @@ The original diagnosis surface — applies to anything in the `VOXEL_TO_TRIXEL_S
 | Half the scene clipped at yaw=0 after a render change | Distance-texture device-level clear regressed (#1217). Per-frame `clearTexture` on the distance buffer in `system_voxel_to_trixel.hpp` must run unconditionally; viewport-conditional clears mis-cull voxels at the cull-bounds boundary. |
 | Geometry pops in/out of view as camera yaw changes | Chunk visibility mask not rotation-aware (#1219). Check `system_voxel_chunk_visibility.hpp` AABB sweep uses world-space chunk bounds, not iso-space derived under yaw=0 only. |
 | Face colors swapped at exact 90° / 180° / 270° rotation | Cardinal face-index remapping bug. Check `rotateCardinalZ` permutation and `encodeDepthWithFace` face-priority encoding under non-zero `rasterYaw`. |
+| Front/back "occlusion scramble" at non-cardinal yaw under `--depth-color` | Likely the diagnostic's own artifact, not geometry (#1457 — three fix rounds chased it): the `--depth-color` palette quantizes hue in 4/3-world-unit bands that beat against the 1-unit voxel lattice as staircase moiré, while an SDF twin (continuous palette) looks smooth, making the side-by-side misleading. Re-shoot with `--checkerboard` — the canonical occlusion diagnostic for rotated voxel content; trust `--depth-color` only at cardinal poses or against a voxel (not SDF) reference. |
 
 ## The 2x3 trixel diamond
 

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -52,6 +52,15 @@ In all three cases:
 - `CMAKE_CXX_STANDARD` is **23**; your compiler must support it.
   (gcc ≥ 13 on Linux/WSL, gcc ≥ 13 via MSYS2 on Windows.)
 
+**Convention for doc snippets that cite a preset** (here and in any doc,
+including downstream creation/game repos): if the recipe's expected CWD is
+not the engine root, the snippet must pass `-S <engine-root>` explicitly —
+`cmake --preset macos-debug` alone fails anywhere without a
+`CMakePresets.json`. And a snippet that names one platform's preset should
+carry a hint comment (`# or linux-debug / windows-debug for your platform`)
+so a reader on another host doesn't hit "preset not found" following it
+literally.
+
 ### Downstream-creation worktree builds
 
 Downstream creations (gitignored repos nested under `creations/<name>/`)

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -443,7 +443,17 @@ Concrete forms:
   consteval-reachable.
 - **Runtime constraint on a function parameter → `IR_ASSERT(predicate,
   "diagnostic")` at function entry.** Use when the value is
-  user-supplied at runtime.
+  user-supplied at runtime. This includes *unwritten* invariants —
+  parallel containers that must agree in length get
+  `IR_ASSERT(parentIdx.size() == joints.size(), ...)` before iterating
+  both, even when no comment ever stated the constraint.
+- **Shared helper whose precondition violation is UB (div-by-zero, OOB
+  index) → the helper asserts its own precondition.** "Callers guard
+  `count > 0`" in a comment is not a guard, and UB is platform-divergent
+  (x86 traps integer div-by-zero; Apple Silicon silently returns 0). A
+  low-level helper called from many modules *is* a system boundary —
+  "only validate at system boundaries" licenses this check rather than
+  forbidding it.
 - **Hybrid → `if consteval` branch that `static_assert`s, falling
   through to a runtime `IR_ASSERT` at the non-consteval branch.** Use
   for helpers that are sometimes called from `constexpr` contexts and

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -112,3 +112,15 @@ missing or older than 5 minutes:
 `fleet-babysit` will relaunch the role on its normal cadence; if
 the scout is genuinely down, the human can `fleet-up` to restart
 it.
+
+## Degraded fetches must be marked — never silent-empty
+
+Any fleet script that fetches GitHub data (the scout, `fleet-validate-stack`,
+ad-hoc `gh` wrappers) must surface a failed or degraded fetch: warn on
+stderr at minimum, and write an explicit error marker (e.g. a `"degraded":
+true` field) into any artifact it emits. Emitting empty results on failure
+is forbidden — an all-empty `state.json` with a fresh `generated_at` is
+indistinguishable from "no work anywhere", and every role treats a fresh
+cache as authoritative. This fired live during a GraphQL rate-limit
+exhaustion: the scout wrote an empty-but-fresh cache while 27 PRs were
+open, and the whole fleet would have idled on it.

--- a/docs/agents/skills/commit-and-push.md
+++ b/docs/agents/skills/commit-and-push.md
@@ -287,6 +287,18 @@ non-blocking — proceed if the number is intentional (e.g. an umbrella).
 Skip when the body has no `Closes #N` line, or for the queue-manager role
 (its `Closes #` rows mean task IDs, not tracker issues).
 
+**Stale-diagnostic check (same trigger):** for each `Closes #N`, grep the
+branch for annotations that promise removal when that issue closes —
+
+```bash
+git grep -nE "(remove|delete|drop).{0,30}#${closes_n}\b|#${closes_n}\b.{0,30}(remove|delete|drop)" -- ':!docs'
+```
+
+A hit means a diagnostic block annotated "remove when #N closes" is about
+to ship to the default branch as dead code in the very PR that closes #N.
+Remove the block (new commit) before opening the PR; if it must outlive
+this PR, re-point the annotation at a live follow-up issue instead.
+
 ### 8b. Tag the host the PR was authored on
 
 See the **procedures** `host-label.md` for the shell snippet and scope

--- a/docs/agents/skills/review-pr.md
+++ b/docs/agents/skills/review-pr.md
@@ -163,6 +163,21 @@ Keep a running list ranked by severity. The boundary between **blocker** and
 - **Nit** — style, naming, minor simplification, docs. Truly optional.
 - **Praise** — a non-obvious good decision worth reinforcing.
 
+Two cross-cutting rules for the findings themselves:
+
+- **Verify cited precedents/APIs before asserting them as the fix
+  pattern.** A finding of the shape "X does this via Y; align with it"
+  requires checking the tree first — grep for the named API, read the
+  cited precedent. A miscited precedent is worse than a vague nit: an
+  author who trusts it implements against a phantom API or propagates the
+  misattribution into comments. If unverified, phrase the nit as a
+  question, not an assertion.
+- **Cross-check "remove when #X" annotations against the PR's `Closes`
+  list.** Grep the diff for `remove when #`, `TODO`, `FIXME` markers
+  referencing an issue this PR's body closes — those blocks must be gone
+  before merge, or they ship to the default branch as dead code. (The
+  author side has the same check at PR-open time; this is the backstop.)
+
 ### 4. Apply the repo's review checklist
 
 Go through the **review checklist** (in the wrapper) explicitly. For every

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -484,3 +484,11 @@ cell composite to the same depth (the `detached_world_depth_test` equivalence).
   `C_EntityCanvas` — which `ENTITY_CANVAS_TO_FRAMEBUFFER` already iterates — not on
   `C_TrixelCanvasRenderBehavior` (the child canvas entity), so the composite reads
   it with no per-tick foreign getComponent.
+- **Seed GPU-buffer sentinels GPU-side, never via a resource-sized CPU
+  staging vector + `subData`.** Metal's `fillBuffer` writes a repeating
+  single byte, so multi-byte sentinels like `kTrixelDistanceMaxDistance`
+  (`0x0000FFFF`) have no driver-side clear — reuse an already-owned
+  self-resetting kernel (e.g. one dispatch of the resolve blit) or a clear
+  dispatch instead of a multi-MB cold-path staging alloc + upload.
+  Live deviation to migrate when next touched:
+  `system_resolve_per_axis_screen_depth.hpp` seeds its scratch the old way.

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -213,6 +213,16 @@ If the PR intentionally changes silhouettes / lighting / shading
 model, call out the intentional drift in the description so reviewers
 know the new crop is the new baseline rather than a regression.
 
+**Occlusion diagnostics for rotated voxel content: use `--checkerboard`,
+not `--depth-color`.** `--depth-color` quantizes hue in 4/3-world-unit
+bands; at any non-cardinal yaw the bands beat against the 1-unit voxel
+lattice as staircase moiré that reads as front/back scramble — while an
+SDF twin (continuous per-pixel palette) looks smooth, making the
+side-by-side structurally misleading. `--depth-color` is only sound at
+cardinal poses or against a voxel (not SDF) reference; `--checkerboard`
+(alternating per-voxel colors) shows true geometry/occlusion in one
+capture. Three fix rounds on #1457 chased this artifact.
+
 The skill drives any creation that supports `--auto-screenshot`
 (today: `shape_debug`; reference implementation is
 `creations/demos/shape_debug/main.cpp`) and carries topic-indexed

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -1018,6 +1018,13 @@ proj_dir = pathlib.Path("~/.fleet/state/projections").expanduser()
 trig_dir = pathlib.Path("~/.fleet/state/triggers").expanduser()
 trig_dir.mkdir(parents=True, exist_ok=True)
 
+# Key-coupling invariant: each <role>_actionable(p) reads top-level keys
+# of the projection that the matching slice_<role>() in fleet-state-scout
+# emits. The names must match EXACTLY — p.get("wrong_key") returns None
+# silently, so a mismatch never errors; the role just never
+# bootstrap-triggers on fleet restart. When adding a role, diff the
+# predicate's keys against slice_<role>()'s emitted dict before landing.
+
 def merger_actionable(p):
     return bool(p.get("prs"))
 


### PR DESCRIPTION
## Summary

First run of the `triage-coding-improvements` flow (skill lands in #1684) over the 11 open `fleet:coding-improvement` tickets. Every ticket was triaged with the human; this diff maps 1:1 to the verdicts below — one bundled PR instead of eleven micro-PRs.

## Triage digest (verdict per ticket)

| Ticket | Verdict | Surface touched |
|---|---|---|
| #1648 | ACCEPT | `docs/agents/CLAUDE-BASELINE.md` — parallel-container size-assert example on the runtime-constraint bullet |
| #1649 | ACCEPT rule + SPLIT code | `CLAUDE-BASELINE.md` — new shared-helper-UB-precondition bullet; code work (IR_ASSERT in `voxelDispatchGridForCount` + audit) split to #1685 |
| #1659 | ACCEPT | `.claude/rules/cpp-ecs-smells.md` — entity-guard bullet for single-entity tick blocks |
| #1657 | ACCEPT | `engine/prefabs/irreden/render/CLAUDE.md` — GPU-side sentinel-seeding gotcha + live per-axis deviation note; skipped the ticket's optional cpp-ecs.md cross-link (net-growth) |
| #1651 | ACCEPT (rescoped) | `engine/render/CLAUDE.md` §Verifying render changes + `render-debug-loop` diagnosis table — `--checkerboard` canonical for rotated voxel occlusion, `--depth-color` moiré explained. The #1457 plan-file DoD re-expression stays with the architect resolving PR #1625 |
| #1658 | ACCEPT | `docs/agents/skills/review-pr.md` — verify-before-cite rule for review findings |
| #1655 | ESCALATE | mechanical stale-diagnostic grep in `docs/agents/skills/commit-and-push.md` step 8a (where the Closes list is born) + backstop line in `review-pr.md`; skipped the ticket's AUTHOR-PIPELINE target (8a *is* the author-side gate) |
| #1656 | ACCEPT | `.claude/agents/simplify-check-math.md` — whole-file scan of touched files, `[pre-existing]` marker. **Validated**: dispatched the agent against the cited occurrence (`component_voxel_pool.hpp:32-33` `glm::min`/`max`) and it flags both lines. Caveat: the marker formatting wasn't observable mid-session (agent definitions appear cached at session start); takes effect in fresh sessions |
| #1683 | ACCEPT (rescoped) | `scripts/fleet/fleet-up` — key-coupling invariant comment above the predicate block. Skipped the ticket's "list current mappings" sub-suggestion: the predicates immediately below are that list, and a duplicate table would drift |
| #1681 | ACCEPT | `docs/agents/FLEET-CACHE.md` — new "Degraded fetches must be marked — never silent-empty" section |
| #1679 | ACCEPT | `docs/agents/BUILD.md` — preset snippets need `-S <engine-root>` off-root + platform-hint comment |

Verdict tally: 9 accept (2 rescoped), 1 escalate-placement, 1 accept-rule + split-out, 0 reject, 0 defer. Net growth per surface ≤ ~10 lines, largest on the two surfaces that merged two tickets each.

## Split-outs

- #1685 — `render: assert UB preconditions inside shared helpers` (plain issue, un-queued, awaiting `human:approved`)

## Test plan

- [ ] `bash -n scripts/fleet/fleet-up` passes (comment-only change; verified pre-commit)
- [ ] All file paths / symbols cited in new prose verified against the tree pre-commit (`kTrixelDistanceMaxDistance`, `system_resolve_per_axis_screen_depth.hpp`, `--checkerboard`/`--depth-color` in `shape_debug`, `slice_<role>()`, `generated_at`)
- [ ] Reviewer: check each diff hunk against the digest row above — the diff should contain nothing the digest doesn't account for

Closes #1648
Closes #1649
Closes #1651
Closes #1655
Closes #1656
Closes #1657
Closes #1658
Closes #1659
Closes #1679
Closes #1681
Closes #1683

🤖 Generated with [Claude Code](https://claude.com/claude-code)
