### PR TITLE
fleet: target the dispatch pane explicitly when re-tagging its label

### DIFF
--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -46,12 +46,21 @@ fi
 # Re-tag the pane border label with the model this iteration actually
 # runs (worker lanes flex per task), e.g. "opus-worker [fable 1m]".
 # Best-effort: a failure here must never block the dispatch.
+#
+# The target MUST be explicit. Without `-t`, tmux resolves `-p` against
+# TMUX_PANE — which does not reliably reach this process — and then
+# falls back to the attached client's ACTIVE pane, i.e. whatever pane
+# the human has focused. Observed live 2026-06-11: every dispatch
+# re-tagged the focused architect pane, cycling it through
+# "sonnet-reviewer"/"merger" labels. PANE_KEY is "pane-<N>" for tmux
+# pane id "%<N>" (see pane_id_to_key in fleet-dispatcher), so the exact
+# pane this dispatch landed in is reconstructible.
 _tag="$MODEL"
 _tag="${_tag/claude-fable-5/fable}"
 _tag="${_tag/claude-opus-4-8/opus 4.8}"
 _tag="${_tag/claude-sonnet-4-6/sonnet 4.6}"
 _tag="${_tag/\[1m\]/ 1m}"
-tmux set-option -p @role "$ROLE [$_tag]" 2>/dev/null || true
+tmux set-option -t "%${PANE_KEY#pane-}" -p @role "$ROLE [$_tag]" 2>/dev/null || true
 unset _tag
 
 # Short-window 429 detection. fleet-claude-stream touches this flag if it sees


### PR DESCRIPTION
## Summary
- The per-dispatch pane label re-tag (from #1691) wrote `tmux set-option -p @role` **without `-t`**. TMUX_PANE doesn't reliably reach the dispatched process, so tmux fell back to the attached client's **active pane** — every dispatch re-tagged whatever pane the human had focused. On the first post-#1691 boot that was the engine-architect pane (fleet-up focuses it on attach), which cycled through `sonnet-reviewer [sonnet]` / `merger [sonnet]` labels while running architect content.
- Fix: reconstruct the exact pane id from the dispatch's own `PANE_KEY` (`pane-<N>` ↔ `%<N>`, the `pane_id_to_key` mapping) and pass `-t` explicitly. Re-tag is unambiguous regardless of focus.

## Test plan
- [x] `bash -n` clean
- [x] Explicit-target reconstruction verified against the **live** tmux server (scratch option write landed on the named pane, not the focused one)
- [x] Mislabeled architect pane repaired live (`opus-architect [fable 1m]`)
- [ ] After merge + pull: labels stay correct across dispatches (architect panes never re-tagged; worker panes flex per class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)