### PR TITLE
fleet: tier-0 merger drops squash-merged inherited prefix (#1690)

### DIFF
--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -16,7 +16,9 @@
 #   - PR carries fleet:approved and none of the skip labels below.
 #   - Stacked PRs (base != master): rebase onto the updated base branch;
 #     when the base branch is verifiably gone AND a merged PR with that
-#     head exists, retarget the PR to master and rebase onto it.
+#     head exists, retarget the PR to master and rebase --onto master from
+#     the base PR's pre-merge head, dropping the now-squashed inherited
+#     prefix so only the child's own commits replay (#1690).
 #   - Conflicting PRs on master: attempt the rebase anyway — it's free;
 #     an actual conflict aborts cleanly and goes to the LLM pass.
 #
@@ -208,6 +210,9 @@ attempt_pr() {
     # merging is a human handoff (role-merger.md case iii), and folding
     # its diff into the child via retarget would be wrong.
     local target="$base"
+    # Set when we retarget a squash-merged stacked child to master: the
+    # base PR's pre-merge head, i.e. the inherited-prefix boundary (#1690).
+    local rebase_boundary=""
     if [[ "$base" != "master" ]]; then
         if ! git -C "$wt" fetch origin "+refs/heads/$base:refs/remotes/origin/$base" 2>/dev/null; then
             if git -C "$wt" ls-remote --exit-code origin "refs/heads/$base" >/dev/null 2>&1; then
@@ -220,14 +225,26 @@ attempt_pr() {
                 log "$repo_key#$pr: remote unreachable; leaving for LLM"
                 return 1
             fi
-            local merged_count
-            merged_count=$(gh pr list --repo "$repo_slug" --head "$base" \
-                --state merged --json number --jq 'length' 2>/dev/null) || merged_count=0
-            if [[ "$merged_count" == "0" ]]; then
+            # The squash-merged base PR's pre-merge head (gh still reports
+            # headRefOid after merge+branch-delete) is the inherited-prefix
+            # boundary: the child branched from it, so every commit beyond
+            # it is the child's own work. Captured here, consumed by the
+            # rebase --onto drop below (#1690). `last` over the
+            # number-sorted matches takes the most recent merged PR from
+            # this head; an empty result means no merged PR — a closed-
+            # unmerged parent handoff, left for the LLM.
+            local merged_tsv base_pr
+            merged_tsv=$(gh pr list --repo "$repo_slug" --head "$base" \
+                --state merged --json number,headRefOid \
+                --jq '(sort_by(.number) | last) as $p
+                      | if $p == null then "" else "\($p.number)\t\($p.headRefOid)" end' \
+                2>/dev/null) || merged_tsv=""
+            if [[ -z "$merged_tsv" ]]; then
                 log "$repo_key#$pr: base '$base' gone but no merged PR has that head (closed-unmerged parent?); leaving for LLM"
                 return 1
             fi
-            log "$repo_key#$pr: base '$base' merged+deleted — retargeting PR to master"
+            IFS=$'\t' read -r base_pr rebase_boundary <<< "$merged_tsv"
+            log "$repo_key#$pr: base '$base' merged+deleted (PR #$base_pr) — retargeting PR to master"
             if (( ! DRY_RUN )); then
                 gh pr edit "$pr" --repo "$repo_slug" --base master >/dev/null 2>&1 || {
                     log "$repo_key#$pr: gh pr edit --base master failed; leaving for LLM"
@@ -269,17 +286,43 @@ attempt_pr() {
         return 1
     }
 
+    # Inherited-prefix drop (#1690): a stacked child we just retargeted to
+    # master still carries its base PR's pre-squash commits. Replaying them
+    # onto the squash that already holds their content is empty at best and
+    # a conflict at worst, and the changed-file-set guard below would read
+    # the dropped inherited files as drift — so today every such retarget
+    # bails to the (Opus) LLM pass even when the child's own commits are
+    # mechanically clean. Rebasing --onto the target from the inherited
+    # boundary replays only the child's own commits, exactly what the
+    # squash-merge lands. Guarded on the boundary being a real ancestor of
+    # the head we fetched; anything else falls back to the plain rebase.
+    local drop_boundary=""
+    if [[ -n "$rebase_boundary" ]] \
+        && git -C "$wt" merge-base --is-ancestor "$rebase_boundary" "$head_sha" 2>/dev/null; then
+        drop_boundary="$rebase_boundary"
+        log "$repo_key#$pr: dropping inherited prefix at ${drop_boundary:0:12} (rebase --onto origin/$target)"
+    fi
+
     # Changed-file-set snapshot: the PR's own files vs its target, before
     # and after. A clean rebase that changes WHICH files the PR touches
     # is not mechanical — bail to the LLM pass. (Residual risk: a 3-way
     # auto-merge can still mis-combine hunks WITHIN a file without
     # conflicting; that class of error is invisible to any mechanical
     # rebaser — including the LLM merger, which runs the same git rebase —
-    # and is caught by the build/CI gate before the human merges.)
-    local pre_files post_files
-    pre_files=$(git -C "$wt" diff --name-only "origin/$target...$head_sha" | sort)
+    # and is caught by the build/CI gate before the human merges.) When an
+    # inherited prefix is being dropped, the "before" snapshot is taken
+    # from the boundary so it reflects only the child's own files.
+    local pre_files post_files file_base
+    file_base="${drop_boundary:-origin/$target}"
+    pre_files=$(git -C "$wt" diff --name-only "$file_base...$head_sha" | sort)
 
-    if ! git -C "$wt" rebase "origin/$target" >/dev/null 2>&1; then
+    if [[ -n "$drop_boundary" ]]; then
+        if ! git -C "$wt" rebase --onto "origin/$target" "$drop_boundary" >/dev/null 2>&1; then
+            git -C "$wt" rebase --abort >/dev/null 2>&1 || true
+            log "$repo_key#$pr: rebase --onto origin/$target (inherited-prefix drop) conflicts; leaving for LLM"
+            return 1
+        fi
+    elif ! git -C "$wt" rebase "origin/$target" >/dev/null 2>&1; then
         git -C "$wt" rebase --abort >/dev/null 2>&1 || true
         log "$repo_key#$pr: rebase onto origin/$target conflicts; leaving for LLM"
         return 1

--- a/scripts/fleet/tests/test_fleet_rebase_inherited_drop.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_inherited_drop.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Tests for fleet-rebase's inherited-prefix drop (issue #1690).
+#
+# Reproduces the squash-merged-base stack shape that burned three Opus
+# semantic-conflict iterations in 24h (#1631, #1638, #1626): a stacked
+# child PR whose branch still carries its base PR's pre-squash commits.
+# After the base squash-merges and its branch is deleted, the merger
+# retargets the child to master. A plain `git rebase origin/master` then
+# replays the inherited commits onto the squash that already holds their
+# content — empty-or-conflicting — and even when git drops them the
+# changed-file-set guard reads the vanished inherited files as drift, so
+# tier-0 bails to the LLM pass. The fix rebases --onto master from the
+# inherited boundary (the base PR's pre-merge head), replaying only the
+# child's own commits.
+#
+#   T1: inherited-prefix conflicts with the squash, child's own commit is
+#       clean → tier-0 drops the prefix and clears it (cleared=1).
+#   T2: child's OWN commit conflicts with master → still bails to the LLM
+#       pass (cleared=0, llm_remaining=1) — genuine conflicts unaffected.
+#
+# Both run --auto --dry-run, so the rebase + changed-file-set guard run
+# fully but nothing is pushed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REBASE="$SCRIPT_DIR/fleet-rebase"
+
+if [[ ! -x "$REBASE" ]]; then
+    echo "test setup: fleet-rebase not executable at $REBASE" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    # Prune the linked scratch worktree before nuking the tree so git
+    # doesn't leave a dangling worktree registration in any shared object
+    # store (the sandbox repo is self-contained, but be tidy).
+    if [[ -n "$TMPROOT" && -d "$TMPROOT" ]]; then
+        rm -rf "$TMPROOT"
+    fi
+}
+trap cleanup EXIT
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        expected to find: $needle"
+        echo "        in log:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
+    fi
+}
+
+assert_absent() {
+    local haystack="$1" needle="$2" msg="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        did NOT expect: $needle"
+        echo "        in log:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
+    else
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    fi
+}
+
+# --- Sandbox ---------------------------------------------------------------
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT"          # fleet-rebase derives ENGINE from $HOME
+export FLEET_STATE_DIR="$TMPROOT/.fleet/state"
+export FLEET_REBASE_SCRATCH="$TMPROOT/.fleet/rebase-scratch"
+mkdir -p "$FLEET_STATE_DIR/projections" "$TMPROOT/bin" "$TMPROOT/merged" "$TMPROOT/log"
+
+# No global git identity under the fresh HOME — give the sandbox one.
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+git_q() { git "$@" >/dev/null 2>&1; }
+
+REMOTE="$TMPROOT/remote.git"
+AUTH="$TMPROOT/auth"
+ENGINE="$TMPROOT/src/IrredenEngine"
+
+git_q init --bare -b master "$REMOTE"
+
+# Authoring clone: build the topology and push it to the bare remote.
+git_q clone "$REMOTE" "$AUTH"
+git -C "$AUTH" config commit.gpgsign false
+
+# init commit on master.
+echo init > "$AUTH/readme.txt"
+git -C "$AUTH" add readme.txt
+git -C "$AUTH" commit -q -m "init"
+INIT=$(git -C "$AUTH" rev-parse HEAD)
+git_q -C "$AUTH" push origin master
+
+# T1 child: init -> B1 (inherited: add base.txt "v1") -> C1 (own: add child.txt)
+git_q -C "$AUTH" checkout -b feat-child "$INIT"
+echo "v1" > "$AUTH/base.txt"
+git -C "$AUTH" add base.txt
+git -C "$AUTH" commit -q -m "B1 inherited add base.txt"
+B1=$(git -C "$AUTH" rev-parse HEAD)
+echo "child work" > "$AUTH/child.txt"
+git -C "$AUTH" add child.txt
+git -C "$AUTH" commit -q -m "C1 own add child.txt"
+git_q -C "$AUTH" push origin feat-child
+
+# T2 child: init -> B1b (inherited: add base.txt "v1") -> C2 (own: EDIT base.txt)
+git_q -C "$AUTH" checkout -b feat-child2 "$INIT"
+echo "v1" > "$AUTH/base.txt"
+git -C "$AUTH" add base.txt
+git -C "$AUTH" commit -q -m "B1b inherited add base.txt"
+B1B=$(git -C "$AUTH" rev-parse HEAD)
+echo "own conflicting edit" > "$AUTH/base.txt"
+git -C "$AUTH" add base.txt
+git -C "$AUTH" commit -q -m "C2 own edit base.txt"
+git_q -C "$AUTH" push origin feat-child2
+
+# Squash the base PR's content onto master with a DIFFERENT body than the
+# inherited commit — this is the "merged with amendments" case that
+# defeats git's patch-id empty-commit dropping and forces the conflict.
+git_q -C "$AUTH" checkout master
+echo "v2 squashed-with-amendments" > "$AUTH/base.txt"
+git -C "$AUTH" add base.txt
+git -C "$AUTH" commit -q -m "S squash-merge of base PR (amended)"
+git_q -C "$AUTH" push origin master
+
+# feat-base / feat-base2 are never pushed: they are "merged + deleted", so
+# fleet-rebase sees the base branch as gone and takes the retarget path.
+
+# Engine clone fleet-rebase operates on (origin -> bare remote).
+git_q clone "$REMOTE" "$ENGINE"
+git -C "$ENGINE" config commit.gpgsign false
+
+# Merged-base lookups, keyed by head branch. The stub gh emulates the
+# net output of `gh pr list ... --json number,headRefOid --jq '<tsv>'`.
+printf '199\t%s\n' "$B1"  > "$TMPROOT/merged/feat-base.tsv"
+printf '198\t%s\n' "$B1B" > "$TMPROOT/merged/feat-base2.tsv"
+
+# --- Stub gh ---------------------------------------------------------------
+# Only the merged-base lookup is exercised in --dry-run (the retarget
+# `gh pr edit` and the pre-push `gh pr view` are gated behind non-dry-run).
+export MERGED_DIR="$TMPROOT/merged"
+cat > "$TMPROOT/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+# Test stub: emulate `gh pr list --head <h> --state merged` by echoing the
+# pre-baked "<number>\t<headRefOid>" tsv for that head. Everything else is
+# a silent success so set -e in fleet-rebase never trips on the stub.
+args="$*"
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    head=""
+    prev=""
+    for a in "$@"; do
+        [[ "$prev" == "--head" ]] && head="$a"
+        prev="$a"
+    done
+    f="$MERGED_DIR/$head.tsv"
+    [[ -f "$f" ]] && cat "$f"
+    exit 0
+fi
+exit 0
+GHEOF
+chmod +x "$TMPROOT/bin/gh"
+export PATH="$TMPROOT/bin:$PATH"
+
+write_slice() {
+    # $1 = JSON array literal of PR records
+    printf '{"prs": %s}\n' "$1" > "$FLEET_STATE_DIR/projections/merger.json"
+}
+
+run_rebase() {
+    # Echo combined stdout+stderr (fleet-rebase logs to stderr).
+    "$REBASE" --auto --dry-run 2>&1 || true
+}
+
+# === T1: inherited-prefix drop resolves a squash-merged stacked child =====
+echo "T1: inherited prefix conflicts with squash, own commit clean -> tier-0 drops + clears"
+write_slice '[{"repo":"engine","number":200,"headRefName":"feat-child","baseRefName":"feat-base","mergeable":"CONFLICTING","labels":["fleet:approved"]}]'
+T1=$(run_rebase)
+assert_contains "$T1" "retargeting PR to master" "T1 took the retarget path"
+assert_contains "$T1" "dropping inherited prefix at ${B1:0:12}" "T1 dropped the inherited prefix at the boundary"
+assert_contains "$T1" "attempted=1 cleared=1 llm_remaining=0" "T1 tier-0 cleared the PR (no LLM bail)"
+assert_absent   "$T1" "changed-file set drifted" "T1 no spurious file-set drift"
+assert_absent   "$T1" "conflicts; leaving for LLM" "T1 no conflict bail"
+
+# === T2: a genuine own-commit conflict still goes to the LLM pass ==========
+echo "T2: child's own commit conflicts with master -> still bails to LLM"
+write_slice '[{"repo":"engine","number":201,"headRefName":"feat-child2","baseRefName":"feat-base2","mergeable":"CONFLICTING","labels":["fleet:approved"]}]'
+T2=$(run_rebase)
+assert_contains "$T2" "dropping inherited prefix at ${B1B:0:12}" "T2 still attempts the prefix drop"
+assert_contains "$T2" "(inherited-prefix drop) conflicts; leaving for LLM" "T2 own-commit conflict bails to LLM"
+assert_contains "$T2" "attempted=1 cleared=0 llm_remaining=1" "T2 left for the LLM pass"
+
+# --- Summary ---------------------------------------------------------------
+echo ""
+echo "fleet-rebase inherited-drop tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
Three semantic-conflict escalations in 24h (#1631, #1638, #1626) shared one mechanical root cause: a stacked child PR's branch carries commits inherited from its base PR's pre-squash branch. After the base squash-merges and its branch is deleted, `fleet-rebase` retargets the child to master and runs a plain `git rebase origin/master`, which replays the now-squashed inherited commits onto the squash that already holds their content — empty when git's patch-id detection drops them, conflicting when the base merged **with amendments**. And even on the empty-drop case, tier-0's changed-file-set guard (3-dot `pre` vs 2-dot `post`) reads the vanished inherited files as drift. Either way the retarget bailed to the **Opus LLM merger pass**, burning an iteration on mechanically-resolvable work.

This fixes it at **tier-0** (the zero-token mechanical pass), so the cited cases never reach the LLM pass at all:

- Capture the squash-merged base PR's pre-merge head as the **inherited-prefix boundary** (`gh` still reports `headRefOid` after merge + branch-delete). The child branched from it, so every commit beyond it is the child's own work.
- `git rebase --onto origin/master <boundary>` replays only the child's own commits — exactly what the squash-merge lands.
- Snapshot the changed-file set **from the boundary** so the drift guard reflects own files, not the dropped inherited prefix.
- Guarded on the boundary being a real **ancestor** of the fetched head; anything else falls back to the existing plain rebase. The base==master path is untouched.

### Acceptance criteria
- ✅ *Resolves a squash-merged-with-amendments child without flagging `fleet:semantic-conflict`* — test T1 replays the #1638 shape; tier-0 clears it (`cleared=1`).
- ✅ *Genuine semantic conflicts still flagged* — test T2: the child's own commit conflicts with master, still bails to the LLM pass (`llm_remaining=1`).
- ⚠️ *Build-verify before push* — tier-0 deliberately does **not** build (its zero-token contract; the existing comment notes mis-merges are caught by the post-push build/CI gate). The auto-resolved path inherits the **same** safety as every other tier-0 push: the changed-file-set invariant (now computed from the boundary) + CI. Adding a compiler invocation to tier-0 would break its zero-token design; a literal pre-push compile belongs in the gated LLM merger pass (`role-merger.md`), out of scope for a queued worker. Flagging for reviewer awareness.

## Test plan
- [x] `bash scripts/fleet/tests/test_fleet_rebase_inherited_drop.sh` — 8/8 (T1 inherited-prefix drop resolves; T2 genuine own-commit conflict still bails to LLM)
- [x] `bash -n scripts/fleet/fleet-rebase` parses
- [x] adjacent `test_fleet_pr_claim_feedback.sh` still 27/27 (no regression)
- [x] validated the `--onto <boundary>` mechanics against the live #1674/#1672 stack (boundary is an ancestor; own-file set preserved)

## Notes
- The fix lives only in tier-0 (`fleet-rebase`), an ungated shell script — no `role-merger.md` edit needed. The cited instances were all squash-merge retargets, which tier-0 now owns end-to-end.
- The `fleet:fork-of-other-pr` label already describes "rebase --onto to drop them [inherited commits]" as the manual technique — this automates it for the squash-merge case.

Closes #1690

🤖 Generated with [Claude Code](https://claude.com/claude-code)