### PR TITLE
fleet: scout degraded-fetch guard — preserve last-known-good + mark degraded (#1660)

### DIFF
--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -113,14 +113,48 @@ missing or older than 5 minutes:
 the scout is genuinely down, the human can `fleet-up` to restart
 it.
 
-## Degraded fetches must be marked — never silent-empty
+## Degraded fetches — `degraded` field in state.json
+
+When a `gh` fetch fails (network error, auth failure, rate-limit exhaustion),
+the scout preserves the **previous snapshot's data** for that section instead
+of writing an empty array. The state is still written with a fresh
+`generated_at` (so staleness checks pass), but a top-level `"degraded"` list
+is added:
+
+```json
+{
+  "generated_at": "2026-06-11T20:00:00Z",
+  "degraded": ["engine.prs", "engine.tasks"],
+  "repos": { ... }
+}
+```
+
+Each entry names a section that fell back to last-known-good data. When no
+previous snapshot exists for a failed section, the empty fallback is used and
+the section is still listed in `degraded`.
+
+**What roles should do when they see `degraded`:**
+
+- Treat listed sections as potentially stale (data is from the prior tick).
+- For **task pickup**, stale `prs[]` means the in-flight cross-check may miss
+  very recently opened PRs — rely on `fleet-claim`'s live duplicate-PR
+  backstop as usual.
+- For **feedback scans**, a degraded `prs[]` may cause flagged PRs to be
+  missed this tick; they will surface on the next successful tick.
+- **Do not** treat a `degraded`-marked snapshot as "no work" and exit — the
+  preserved data is still the best available picture of the world.
+
+The scout already suppresses `reconcile --apply` and `fleet-queue-ingest`
+auto-fires during degraded ticks to avoid comparing live claims against
+potentially incomplete issue lists.
+
+### Convention: degrade, never silent-empty
 
 Any fleet script that fetches GitHub data (the scout, `fleet-validate-stack`,
 ad-hoc `gh` wrappers) must surface a failed or degraded fetch: warn on
-stderr at minimum, and write an explicit error marker (e.g. a `"degraded":
-true` field) into any artifact it emits. Emitting empty results on failure
-is forbidden — an all-empty `state.json` with a fresh `generated_at` is
-indistinguishable from "no work anywhere", and every role treats a fresh
-cache as authoritative. This fired live during a GraphQL rate-limit
-exhaustion: the scout wrote an empty-but-fresh cache while 27 PRs were
-open, and the whole fleet would have idled on it.
+stderr at minimum, and write an explicit error marker into any artifact it
+emits. Emitting empty results on failure is forbidden — an all-empty
+`state.json` with a fresh `generated_at` is indistinguishable from "no work
+anywhere". This fired live during a GraphQL rate-limit exhaustion: the scout
+wrote an empty-but-fresh cache while 27 PRs were open, and the whole fleet
+would have idled on it.

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -128,12 +128,12 @@ def fetch_prs(repo):
         "isDraft,reviews,updatedAt",
     ])
     if out is None:
-        return []
+        return None
     try:
         prs = json.loads(out)
     except json.JSONDecodeError as e:
         log(f"gh pr list {repo}: bad JSON: {e}")
-        return []
+        return None
     for pr in prs:
         pr["labels"] = sorted(label["name"] for label in pr.get("labels", []))
         pr["author"] = pr.get("author", {}).get("login", "")
@@ -182,12 +182,12 @@ def fetch_issues_by_label(repo, filter_label, exclude_labels=None, with_body=Fal
         "--json", fields,
     ])
     if out is None:
-        return []
+        return None
     try:
         issues = json.loads(out)
     except json.JSONDecodeError as e:
         log(f"gh issue list {repo} --label {filter_label}: bad JSON: {e}")
-        return []
+        return None
     for issue in issues:
         issue["labels"] = sorted(lbl["name"] for lbl in issue.get("labels", []))
     if exclude_labels:
@@ -207,6 +207,8 @@ def fetch_epics(repo):
     # bodies are large; the per-issue detail cache keeps the full body for the
     # role's drill-in).
     epics = fetch_issues_by_label(repo, "fleet:epic", with_body=True)
+    if epics is None:
+        return None
     for epic in epics:
         body = epic.pop("body", "") or ""
         epic["checklist"] = _parse_epic_checklist(body)
@@ -235,12 +237,12 @@ def fetch_closed_fleet_queued(repo, limit=100):
         "--json", "number,title,labels,updatedAt",
     ])
     if out is None:
-        return []
+        return None
     try:
         issues = json.loads(out)
     except json.JSONDecodeError as e:
         log(f"gh issue list {repo} --label fleet:queued --state closed: bad JSON: {e}")
-        return []
+        return None
     for issue in issues:
         issue["labels"] = sorted(lbl["name"] for lbl in issue.get("labels", []))
     issues.sort(key=lambda issue: issue.get("number", 0))
@@ -275,12 +277,12 @@ def fetch_recent_merged_prs(repo, limit=30):
         "--json", "number,title,headRefName,baseRefName,mergedAt",
     ])
     if out is None:
-        return []
+        return None
     try:
         prs = json.loads(out)
     except json.JSONDecodeError as e:
         log(f"gh pr list {repo} --state merged: bad JSON: {e}")
-        return []
+        return None
     prs.sort(key=lambda pr: pr.get("number", 0))
     return prs
 
@@ -410,13 +412,13 @@ def fetch_task_queue(repo_slug):
     ])
 
     if not issues_out:
-        return {"open": [], "in_progress": [], "done": []}
+        return None
 
     try:
         issues = json.loads(issues_out)
     except json.JSONDecodeError as e:
         log(f"fetch_task_queue {repo_slug}: bad JSON: {e}")
-        return {"open": [], "in_progress": [], "done": []}
+        return None
 
     sections = {"open": [], "in_progress": [], "done": []}
 
@@ -1909,6 +1911,14 @@ def update_role_trigger(role: str, projection) -> bool:
 
 
 def collect_state():
+    # Load previous state so degraded fetches can fall back to last-known-good
+    # data instead of writing empty arrays into a fresh-timestamped snapshot.
+    _prev_repos = {}
+    try:
+        _prev_repos = json.loads(STATE_FILE.read_text()).get("repos", {})
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+
     repos = {"engine": {"path": str(ENGINE)}}
     if (GAME / ".git").exists():
         repos["game"] = {"path": str(GAME)}
@@ -1935,6 +1945,7 @@ def collect_state():
             ("game", "epics", lambda: fetch_epics("jakildev/irreden")),
         ]
 
+    _degraded = []
     with ThreadPoolExecutor(max_workers=FETCH_MAX_WORKERS) as ex:
         futures = {}
         for i, (repo_key, field, fn) in enumerate(fetch_specs):
@@ -1944,18 +1955,31 @@ def collect_state():
         for fut in as_completed(futures):
             repo_key, field = futures[fut]
             try:
-                repos[repo_key][field] = fut.result()
+                result = fut.result()
             except Exception as e:
                 log(f"fetch {repo_key}/{field} failed: {e}")
-                repos[repo_key][field] = (
-                    {"open": [], "in_progress": [], "done": []}
-                    if field == "tasks" else []
-                )
+                result = None
+            if result is None:
+                prev_value = _prev_repos.get(repo_key, {}).get(field)
+                if prev_value is not None:
+                    log(f"degraded: preserving last-known-good for {repo_key}.{field}")
+                    repos[repo_key][field] = prev_value
+                else:
+                    repos[repo_key][field] = (
+                        {"open": [], "in_progress": [], "done": []}
+                        if field == "tasks" else []
+                    )
+                _degraded.append(f"{repo_key}.{field}")
+            else:
+                repos[repo_key][field] = result
 
-    return {
+    state = {
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "repos": repos,
     }
+    if _degraded:
+        state["degraded"] = sorted(_degraded)
+    return state
 
 
 def _populate_done_tasks(state):
@@ -1967,6 +1991,8 @@ def _populate_done_tasks(state):
 
 def tick_once():
     state = collect_state()
+    if state.get("degraded"):
+        log(f"state degraded: {state['degraded']} — reconcile disabled this tick")
     _populate_done_tasks(state)
     resolve_blocked_by(state)
     resolve_human_approved_blockers(state)
@@ -1997,6 +2023,13 @@ def tick_once():
                 old_hash = ""
             if new_hash != old_hash:
                 write_atomic(seen_file, new_hash + "\n")
+                if state.get("degraded"):
+                    # Skip reconcile/cleanup when fetch data is stale — comparing
+                    # live claims against a potentially incomplete issue list would
+                    # produce false-positive drift reports or unsafe auto-fixes.
+                    log("queue-manager: skipping reconcile+cleanup (state degraded)")
+                    triggers_fired.append("queue-manager(skipped-degraded)")
+                    continue
                 sweep_cmds = [
                     ["fleet-claim", "cleanup", "--gh",
                      "--repo", "jakildev/IrredenEngine"],
@@ -2041,6 +2074,10 @@ def tick_once():
                 old_hash = ""
             if new_hash != old_hash:
                 write_atomic(seen_file, new_hash + "\n")
+                if state.get("degraded"):
+                    log("queue-manager-ingest: skipping fleet-queue-ingest (state degraded)")
+                    triggers_fired.append("queue-manager-ingest(skipped-degraded)")
+                    continue
                 try:
                     ingest_cmd = subprocess.run(
                         ["which", "fleet-queue-ingest"],

--- a/scripts/fleet/tests/test_scout_degraded_fetch.py
+++ b/scripts/fleet/tests/test_scout_degraded_fetch.py
@@ -1,0 +1,176 @@
+"""Tests for degraded-fetch handling in fleet-state-scout.
+
+Covers: failed fetch → last-known-good preserved + degraded marker;
+clean empty fetch → not degraded; no-previous-state first-run fallback.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+collect_state = _mod.collect_state
+STATE_FILE = _mod.STATE_FILE
+
+_SAMPLE_PR = {"number": 42, "title": "foo", "headRefName": "feat/foo",
+              "baseRefName": "master", "author": "bot", "labels": [],
+              "mergeable": "MERGEABLE", "isDraft": False, "reviews": [],
+              "updatedAt": "2026-06-11T00:00:00Z"}
+
+_SAMPLE_TASK_QUEUE = {
+    "open": [{"id": "#99", "title": "t", "status": " ", "model": "sonnet",
+              "owner": "free", "blocked_by": "(none)", "blocked": False,
+              "area": None, "effort": None, "issue": "#99"}],
+    "in_progress": [],
+    "done": [],
+}
+
+
+class TestScoutDegradedFetch(unittest.TestCase):
+
+    def _write_prev_state(self, tmp_dir, prs=None, tasks=None):
+        """Write a minimal previous state.json for fallback tests."""
+        state = {
+            "generated_at": "2026-06-11T19:00:00Z",
+            "repos": {
+                "engine": {
+                    "path": str(Path.home() / "src" / "IrredenEngine"),
+                    "prs": prs if prs is not None else [_SAMPLE_PR],
+                    "needs_plan": [],
+                    "human_approved": [],
+                    "closed_fleet_queued": [],
+                    "recent_merged_prs": [],
+                    "tasks": tasks if tasks is not None else _SAMPLE_TASK_QUEUE,
+                    "epics": [],
+                }
+            },
+        }
+        state_file = Path(tmp_dir) / "state.json"
+        state_file.write_text(json.dumps(state))
+        return state_file
+
+    def test_failed_pr_fetch_preserves_last_known_good(self):
+        """fetch_prs returns None → last-known-good prs[] preserved + degraded marked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            prev_file = self._write_prev_state(tmp)
+            with patch.object(_mod, "STATE_FILE", prev_file), \
+                 patch.object(_mod, "fetch_prs", return_value=None), \
+                 patch.object(_mod, "fetch_needs_plan", return_value=[]), \
+                 patch.object(_mod, "fetch_human_approved", return_value=[]), \
+                 patch.object(_mod, "fetch_closed_fleet_queued", return_value=[]), \
+                 patch.object(_mod, "fetch_recent_merged_prs", return_value=[]), \
+                 patch.object(_mod, "fetch_task_queue", return_value=_SAMPLE_TASK_QUEUE), \
+                 patch.object(_mod, "fetch_epics", return_value=[]), \
+                 patch.object(_mod, "GAME", Path(tmp) / "no-game"):
+                state = collect_state()
+
+        self.assertIn("degraded", state)
+        self.assertIn("engine.prs", state["degraded"])
+        # Data preserved from previous snapshot
+        self.assertEqual(state["repos"]["engine"]["prs"], [_SAMPLE_PR])
+
+    def test_clean_empty_pr_fetch_not_degraded(self):
+        """fetch_prs returns [] (genuine empty) → no degraded marker."""
+        with tempfile.TemporaryDirectory() as tmp:
+            prev_file = self._write_prev_state(tmp)
+            with patch.object(_mod, "STATE_FILE", prev_file), \
+                 patch.object(_mod, "fetch_prs", return_value=[]), \
+                 patch.object(_mod, "fetch_needs_plan", return_value=[]), \
+                 patch.object(_mod, "fetch_human_approved", return_value=[]), \
+                 patch.object(_mod, "fetch_closed_fleet_queued", return_value=[]), \
+                 patch.object(_mod, "fetch_recent_merged_prs", return_value=[]), \
+                 patch.object(_mod, "fetch_task_queue", return_value=_SAMPLE_TASK_QUEUE), \
+                 patch.object(_mod, "fetch_epics", return_value=[]), \
+                 patch.object(_mod, "GAME", Path(tmp) / "no-game"):
+                state = collect_state()
+
+        self.assertNotIn("degraded", state)
+        self.assertEqual(state["repos"]["engine"]["prs"], [])
+
+    def test_failed_task_fetch_preserves_last_known_good(self):
+        """fetch_task_queue returns None → last-known-good tasks preserved + degraded marked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            prev_file = self._write_prev_state(tmp)
+            with patch.object(_mod, "STATE_FILE", prev_file), \
+                 patch.object(_mod, "fetch_prs", return_value=[]), \
+                 patch.object(_mod, "fetch_needs_plan", return_value=[]), \
+                 patch.object(_mod, "fetch_human_approved", return_value=[]), \
+                 patch.object(_mod, "fetch_closed_fleet_queued", return_value=[]), \
+                 patch.object(_mod, "fetch_recent_merged_prs", return_value=[]), \
+                 patch.object(_mod, "fetch_task_queue", return_value=None), \
+                 patch.object(_mod, "fetch_epics", return_value=[]), \
+                 patch.object(_mod, "GAME", Path(tmp) / "no-game"):
+                state = collect_state()
+
+        self.assertIn("degraded", state)
+        self.assertIn("engine.tasks", state["degraded"])
+        self.assertEqual(
+            state["repos"]["engine"]["tasks"]["open"],
+            _SAMPLE_TASK_QUEUE["open"],
+        )
+
+    def test_no_previous_state_failed_fetch_uses_empty_fallback(self):
+        """First run + failed fetch → empty fallback used + degraded marked."""
+        missing = Path("/tmp/__fleet_state_missing_9999.json")
+        with patch.object(_mod, "STATE_FILE", missing), \
+             patch.object(_mod, "fetch_prs", return_value=None), \
+             patch.object(_mod, "fetch_needs_plan", return_value=[]), \
+             patch.object(_mod, "fetch_human_approved", return_value=[]), \
+             patch.object(_mod, "fetch_closed_fleet_queued", return_value=[]), \
+             patch.object(_mod, "fetch_recent_merged_prs", return_value=[]), \
+             patch.object(_mod, "fetch_task_queue", return_value=_SAMPLE_TASK_QUEUE), \
+             patch.object(_mod, "fetch_epics", return_value=[]), \
+             patch.object(_mod, "GAME", missing.parent / "no-game"):
+            state = collect_state()
+
+        self.assertIn("degraded", state)
+        self.assertIn("engine.prs", state["degraded"])
+        # No previous data → empty fallback
+        self.assertEqual(state["repos"]["engine"]["prs"], [])
+
+    def test_multiple_failed_sections_all_listed(self):
+        """Multiple failed sections all appear in degraded list."""
+        with tempfile.TemporaryDirectory() as tmp:
+            prev_file = self._write_prev_state(tmp)
+            with patch.object(_mod, "STATE_FILE", prev_file), \
+                 patch.object(_mod, "fetch_prs", return_value=None), \
+                 patch.object(_mod, "fetch_needs_plan", return_value=None), \
+                 patch.object(_mod, "fetch_human_approved", return_value=[]), \
+                 patch.object(_mod, "fetch_closed_fleet_queued", return_value=[]), \
+                 patch.object(_mod, "fetch_recent_merged_prs", return_value=[]), \
+                 patch.object(_mod, "fetch_task_queue", return_value=_SAMPLE_TASK_QUEUE), \
+                 patch.object(_mod, "fetch_epics", return_value=[]), \
+                 patch.object(_mod, "GAME", Path(tmp) / "no-game"):
+                state = collect_state()
+
+        self.assertIn("engine.prs", state["degraded"])
+        self.assertIn("engine.needs_plan", state["degraded"])
+
+    def test_no_failures_no_degraded_key(self):
+        """All fetches succeed → no 'degraded' key at all."""
+        with tempfile.TemporaryDirectory() as tmp:
+            prev_file = self._write_prev_state(tmp)
+            with patch.object(_mod, "STATE_FILE", prev_file), \
+                 patch.object(_mod, "fetch_prs", return_value=[_SAMPLE_PR]), \
+                 patch.object(_mod, "fetch_needs_plan", return_value=[]), \
+                 patch.object(_mod, "fetch_human_approved", return_value=[]), \
+                 patch.object(_mod, "fetch_closed_fleet_queued", return_value=[]), \
+                 patch.object(_mod, "fetch_recent_merged_prs", return_value=[]), \
+                 patch.object(_mod, "fetch_task_queue", return_value=_SAMPLE_TASK_QUEUE), \
+                 patch.object(_mod, "fetch_epics", return_value=[]), \
+                 patch.object(_mod, "GAME", Path(tmp) / "no-game"):
+                state = collect_state()
+
+        self.assertNotIn("degraded", state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- When `gh` fetch fails (network, auth 401, rate-limit), fetch functions return `None`; `collect_state` now loads the prior `state.json` and preserves the previous value for each failed section
- Adds a top-level `degraded: ["engine.prs", ...]` list to `state.json` so consumers can distinguish stale data from a genuinely-empty repo
- Skips `reconcile --apply` and `fleet-queue-ingest` auto-fires during degraded ticks to prevent unsafe cross-section comparisons
- Documents the `degraded` field in `docs/agents/FLEET-CACHE.md` with consumer guidance and the degrade-never-silent-empty convention
- Adds `test_scout_degraded_fetch.py` with 6 test cases covering: failed PR fetch → preserved + degraded; clean empty fetch → not degraded; failed tasks fetch → preserved; no-previous-state first-run; multiple sections; clean all-pass

## Test plan

- [x] `python3 scripts/fleet/tests/test_scout_degraded_fetch.py -v` — all 6 pass
- [x] Existing `test_enrich_stackable_blocker_prs.py`, `test_scope_shipped_reference.py`, `test_fleet_task_class.py` — all pass (no regression)

Closes #1660
Closes #1682

🤖 Generated with [Claude Code](https://claude.com/claude-code)