### PR TITLE
fleet: fleet-issue fallback shows body + comments via --json (#1677)

### DIFF
--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -48,7 +48,7 @@ gh` line on stderr so misses are visible in pane logs):
 | `fleet-pr view <N> [--repo engine\|game]` | `gh pr view <N> --comments` |
 | `fleet-pr diff <N> [--repo engine\|game]` | `gh pr diff <N>` |
 | `fleet-pr comments <N> [--repo engine\|game]` | `gh pr view <N> --comments` + `gh api repos/.../pulls/<N>/comments` + `gh api repos/.../pulls/<N>/reviews` (merged) |
-| `fleet-issue view <N> [--repo engine\|game]` | `gh issue view <N> --comments` |
+| `fleet-issue view <N> [--repo engine\|game]` | `gh issue view <N> --repo <slug> --json number,title,state,labels,body,comments` |
 
 ### What stays direct
 

--- a/scripts/fleet/fleet-issue
+++ b/scripts/fleet/fleet-issue
@@ -77,8 +77,8 @@ def cmd_view(args):
             return 1
         # gh returns labels as [{name, color, ...}]; normalize to strings
         detail["labels"] = [
-            (l["name"] if isinstance(l, dict) else l)
-            for l in detail.get("labels", [])
+            (la["name"] if isinstance(la, dict) else la)
+            for la in detail.get("labels", [])
         ]
 
     print(f"# Issue #{detail['number']}: {detail.get('title', '')}")

--- a/scripts/fleet/fleet-issue
+++ b/scripts/fleet/fleet-issue
@@ -59,10 +59,27 @@ def cmd_view(args):
         if slug is None:
             warn(f"unknown repo key: {args.repo}")
             return 2
-        return subprocess.run([
-            "gh", "issue", "view", str(args.issue_number),
-            "--repo", slug, "--comments",
-        ]).returncode
+        result = subprocess.run(
+            [
+                "gh", "issue", "view", str(args.issue_number),
+                "--repo", slug,
+                "--json", "number,title,state,labels,body,comments",
+            ],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            sys.stderr.write(result.stderr)
+            return result.returncode
+        try:
+            detail = json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            warn(f"gh json output is corrupt: {e}")
+            return 1
+        # gh returns labels as [{name, color, ...}]; normalize to strings
+        detail["labels"] = [
+            (l["name"] if isinstance(l, dict) else l)
+            for l in detail.get("labels", [])
+        ]
 
     print(f"# Issue #{detail['number']}: {detail.get('title', '')}")
     labels = detail.get("labels", [])


### PR DESCRIPTION
## Summary
- `fleet-issue view <N>` on cache miss was calling `gh issue view --comments` (gh 2.92.0), which shows only the comment thread — the issue body was never printed, and comment-less issues produced empty output (exit 0).
- Fallback now uses `--json number,title,state,labels,body,comments` and renders through the same formatting path as cache hits; output shape is identical whether the cache hits or misses.
- Also corrects the fallback command listed in `docs/agents/FLEET-CACHE.md`.

## Test plan
- [x] `fleet-issue view <N>` on a cache-missed, comment-less issue prints title/state/labels/body (verified against #1677 itself)
- [x] Cache-missed issue with comments: body AND comments appear (verified against game #164)
- [x] Cache-hit output unchanged (verified against cached #1307)

Closes #1677

🤖 Generated with [Claude Code](https://claude.com/claude-code)