### PR TITLE
engine: audit string name lookups — all benign; annotate hot-path alternatives (#1687)

### DIFF
--- a/engine/entity/include/irreden/ir_entity.hpp
+++ b/engine/entity/include/irreden/ir_entity.hpp
@@ -233,6 +233,7 @@ template <typename Component> Component &getComponent(EntityId entity) {
     return getEntityManager().getComponent<Component>(entity);
 }
 
+// Delegates to getEntity — setup-time only, see above.
 template <typename Component> Component &getComponent(const std::string &name) {
     return getEntityManager().getComponent<Component>(getEntity(name));
 }

--- a/engine/entity/include/irreden/ir_entity.hpp
+++ b/engine/entity/include/irreden/ir_entity.hpp
@@ -25,6 +25,8 @@ smart_ComponentData createComponentData(ComponentId type);
 std::string makeComponentString(const Archetype &type);
 EntityId getRelatedEntityFromArchetype(Archetype type, Relation relation);
 EntityId getParentEntityFromArchetype(Archetype type);
+// Setup-time only: at most ~3 named entities ("camera", "mainFramebuffer",
+// "modifierGlobals"). Do not call inside a per-entity tick.
 void setName(EntityId entity, const std::string &name);
 EntityId getEntity(const std::string &name);
 EntityRecord getEntityRecord(EntityId entity);

--- a/engine/script/include/irreden/script/lua_modifier_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_modifier_bindings.hpp
@@ -90,6 +90,8 @@
 
 namespace IRScript::detail {
 
+// String branch calls findFieldId (O(n) linear scan over ~tens of registered
+// fields). For hot Lua loops, pass a cached FieldBindingId integer instead.
 inline IRComponents::FieldBindingId
 resolveFieldArg(const sol::object &arg, const std::string &caller) {
     if (arg.is<lua_Integer>()) {


### PR DESCRIPTION
## Summary
- Audited all string-keyed entity/resource/field lookups in the engine
- Confirmed no hot-path violations: all usages are init-time, setup, or command-event handlers
- Added doc notes at the two call sites without them: `IREntity::setName/getEntity` and `resolveFieldArg` in `lua_modifier_bindings.hpp`

## Audit findings

| Lookup | Location | Verdict |
|---|---|---|
| `IREntity::getEntity(name)` | `ir_entity.hpp` | Benign — 3 named entities total, all accessed at init/event time |
| `IRRender::getCanvas(name)` / `getNamed<T>` | `rendering_rm.hpp` | Benign — `unordered_map` O(1); resolved in `beginTick`/init and cached |
| `modifier_field_registry::findFieldId` | `modifier_field_registry.hpp` | Benign — O(n) linear scan over ~tens of fields; already documented; hot-loop callers use `FieldBindingId` integer |
| `C_BindPoints::points_` | `component_bind_points.hpp` | Benign — O(1) hash; documented as one-time spawn query |
| `C_JointName` | — | Not yet implemented; follow-up per `voxel/CLAUDE.md` |

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean

Closes #1687

🤖 Generated with [Claude Code](https://claude.com/claude-code)