### PR TITLE
fleet: unify worker lanes into one class-routed worker lane (P2.1)

### DIFF
--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -107,8 +107,11 @@ rm -f "$FLEET_THROTTLE_FLAG"
 # worktree and an active reservation, the session likely dropped the
 # commit-and-push flow mid-way (e.g. end_turn after simplify). Write a
 # trigger so the dispatcher re-fires the worker on the next tick; the
-# reservation gate at step 0.5 will resume the same task.
-if [[ "$rc" == "0" && ("$ROLE" == "opus-worker" || "$ROLE" == "sonnet-author") ]]; then
+# reservation gate at step 0.5 will resume the same task. `worker` is the
+# unified P2 lane; the legacy `opus-worker` / `sonnet-author` names are
+# kept so a still-running pre-P2 dispatcher mid-transition is handled too
+# (the new dispatcher folds triggers/<legacy> into triggers/worker).
+if [[ "$rc" == "0" && ("$ROLE" == "worker" || "$ROLE" == "opus-worker" || "$ROLE" == "sonnet-author") ]]; then
     worktree_name=$(basename "$PWD")
     reservation_issue=$(fleet-claim reservation-of "$worktree_name" 2>/dev/null || true)
     if [[ -n "$reservation_issue" ]]; then

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -519,6 +519,7 @@ pane_has_running_wrapper() {
 # lane also claims the legacy `opus-worker` / `sonnet-author` tags. This is
 # what lets the unified lane find, count, and dispatch into panes that
 # still carry their old tags during the transition.
+# Remove once P2-2 / P2-3 land (epic #1692).
 pane_role_matches_lane() {
     local pane_role="$1" lane="$2"
     [[ "$pane_role" == "$lane" ]] && return 0
@@ -1448,6 +1449,7 @@ PY
 # a partial restart, or an operator touching the old path) can drop a
 # triggers/opus-worker or triggers/sonnet-author file the new dispatcher no
 # longer reads — rename it to triggers/worker so the work isn't stranded.
+# Remove once P2-2 / P2-3 land (epic #1692).
 rename_legacy_lane_triggers() {
     local legacy
     for legacy in "opus-worker" "sonnet-author"; do

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -93,6 +93,10 @@ unset _fleet_dispatcher_self
 FLEET_CONF="${FLEET_CONF:-$HOME/.fleet/fleet-up.conf}"
 # Capture env-set values before sourcing the conf, so a `FLEET_CONCURRENCY_X`
 # in the caller's environment still wins over a value set inside conf.
+_env_worker="${FLEET_CONCURRENCY_WORKER:-}"
+# Deprecated per-lane caps (pre-P2). Summed into the unified worker cap
+# when FLEET_CONCURRENCY_WORKER is unset, so an operator's existing conf
+# keeps working through the transition. Drop once no conf sets them.
 _env_opus_worker="${FLEET_CONCURRENCY_OPUS_WORKER:-}"
 _env_sonnet_author="${FLEET_CONCURRENCY_SONNET_AUTHOR:-}"
 _env_sonnet_reviewer="${FLEET_CONCURRENCY_SONNET_REVIEWER:-}"
@@ -103,6 +107,8 @@ _env_smoke_worker="${FLEET_CONCURRENCY_SMOKE_WORKER:-}"
 _env_epic_steward="${FLEET_CONCURRENCY_EPIC_STEWARD:-}"
 # Same capture-before-source guard for per-role effort (FLEET_EFFORT_<ROLE>),
 # consumed by the ROLE_EFFORT map further down. Caller env wins over conf.
+_env_effort_worker="${FLEET_EFFORT_WORKER:-}"
+# Deprecated per-lane effort (pre-P2); fallthrough for the worker lane.
 _env_effort_opus_worker="${FLEET_EFFORT_OPUS_WORKER:-}"
 _env_effort_sonnet_author="${FLEET_EFFORT_SONNET_AUTHOR:-}"
 _env_effort_sonnet_reviewer="${FLEET_EFFORT_SONNET_REVIEWER:-}"
@@ -135,9 +141,22 @@ FLEET_MODEL_EPIC_STEWARD="${_env_model_epic_steward:-${FLEET_MODEL_EPIC_STEWARD:
 FABLE_CONCURRENCY_CAP="${_env_fable_cap:-${FLEET_CONCURRENCY_MODEL_FABLE:-1}}"
 unset _env_model_fable _env_model_opus _env_model_sonnet \
       _env_model_merger _env_model_opus_reviewer _env_model_epic_steward _env_fable_cap
+# Unified worker cap (P2). FLEET_CONCURRENCY_WORKER wins (env > conf); when
+# it's unset, sum the deprecated per-lane caps if an operator set either
+# (so a pre-P2 conf with OPUS_WORKER=2 + SONNET_AUTHOR=2 keeps a cap of 4);
+# otherwise default 4 (the four worker panes the unified layout runs).
+_worker_cap="${_env_worker:-${FLEET_CONCURRENCY_WORKER:-}}"
+if [[ -z "$_worker_cap" ]]; then
+    _dep_opus="${_env_opus_worker:-${FLEET_CONCURRENCY_OPUS_WORKER:-}}"
+    _dep_sonnet="${_env_sonnet_author:-${FLEET_CONCURRENCY_SONNET_AUTHOR:-}}"
+    if [[ -n "$_dep_opus" || -n "$_dep_sonnet" ]]; then
+        _worker_cap=$(( ${_dep_opus:-0} + ${_dep_sonnet:-0} ))
+    else
+        _worker_cap=4
+    fi
+fi
 declare -A ROLE_CONCURRENCY=(
-    ["opus-worker"]="${_env_opus_worker:-${FLEET_CONCURRENCY_OPUS_WORKER:-2}}"
-    ["sonnet-author"]="${_env_sonnet_author:-${FLEET_CONCURRENCY_SONNET_AUTHOR:-2}}"
+    ["worker"]="$_worker_cap"
     ["sonnet-reviewer"]="${_env_sonnet_reviewer:-${FLEET_CONCURRENCY_SONNET_REVIEWER:-1}}"
     ["opus-reviewer"]="${_env_opus_reviewer:-${FLEET_CONCURRENCY_OPUS_REVIEWER:-1}}"
     ["queue-manager"]="${_env_queue_manager:-${FLEET_CONCURRENCY_QUEUE_MANAGER:-1}}"
@@ -145,7 +164,8 @@ declare -A ROLE_CONCURRENCY=(
     ["smoke-worker"]="${_env_smoke_worker:-${FLEET_CONCURRENCY_SMOKE_WORKER:-1}}"
     ["epic-steward"]="${_env_epic_steward:-${FLEET_CONCURRENCY_EPIC_STEWARD:-1}}"
 )
-unset _env_opus_worker _env_sonnet_author _env_sonnet_reviewer \
+unset _env_worker _worker_cap _dep_opus _dep_sonnet \
+      _env_opus_worker _env_sonnet_author _env_sonnet_reviewer \
       _env_opus_reviewer _env_queue_manager _env_merger _env_smoke_worker \
       _env_epic_steward
 
@@ -318,8 +338,7 @@ fi
 # (kept on fleet-babysit). Aligned with the worker / reviewer /
 # queue-mgr / merger roles in fleet-up.
 DISPATCHED_ROLES=(
-    "sonnet-author"
-    "opus-worker"
+    "worker"
     "sonnet-reviewer"
     "opus-reviewer"
     "merger"
@@ -356,46 +375,45 @@ declare -A CLASS_MODEL=(
     ["opus"]="$OPUS_MODEL"
     ["sonnet"]="$SONNET_MODEL"
 )
-# Per-role models. Worker lanes route per-task: the ROLE_MODEL entry is
-# only the lane default when the projection slice has nothing
-# class-routable (see resolve_worker_class). "opus" in the role slugs is
-# the historical lane name, not a model pin. Merger runs sonnet — its LLM
-# pass only fires for conflicts fleet-rebase couldn't clear mechanically;
-# the final reviewer runs the opus class (reasoning bounded by the diff).
+# Per-role models. The worker lane routes per-task: its ROLE_MODEL entry is
+# only the fallthrough default when the projection slice has nothing
+# class-routable (see resolve_worker_class) — the opus model, since the
+# lane defaults to the opus class. Merger runs sonnet — its LLM pass only
+# fires for conflicts fleet-rebase couldn't clear mechanically; the final
+# reviewer runs the opus class (reasoning bounded by the diff).
 declare -A ROLE_MODEL=(
-    ["sonnet-author"]="$SONNET_MODEL"
-    ["opus-worker"]="$OPUS_MODEL"
+    ["worker"]="$OPUS_MODEL"
     ["sonnet-reviewer"]="$SONNET_MODEL"
     ["opus-reviewer"]="${FLEET_MODEL_OPUS_REVIEWER:-$OPUS_MODEL}"
     ["merger"]="${FLEET_MODEL_MERGER:-$SONNET_MODEL}"
     ["smoke-worker"]="$SONNET_MODEL"
     ["epic-steward"]="${FLEET_MODEL_EPIC_STEWARD:-$OPUS_MODEL}"
 )
-# Worker lanes that resolve a per-task class from their projection slice,
+# The worker lane resolves a per-task class from its projection slice,
 # mapped to the class assumed when a task carries no model tag.
 declare -A WORKER_LANE_DEFAULT_CLASS=(
-    ["opus-worker"]="opus"
-    ["sonnet-author"]="sonnet"
+    ["worker"]="opus"
 )
 
 # Per-role effort level. Override priority mirrors ROLE_CONCURRENCY:
 # caller env FLEET_EFFORT_<ROLE> > conf FLEET_EFFORT_<ROLE> > global
-# FLEET_EFFORT > built-in default. Defaults: the heavy-reasoning roles —
-# the opus-worker here, plus the architects (launched by fleet-babysit,
-# not dispatched) — run xhigh; everything else runs high. opus-reviewer
-# and merger run high (not xhigh): their reasoning is bounded by the diff
-# in front of them, so the extra budget buys little. Retune a default
-# here, or set FLEET_EFFORT_<ROLE> in ~/.fleet/fleet-up.conf.
+# FLEET_EFFORT > built-in default. The effort here is only the lane
+# fallthrough — per-task Effort: and class resolution override it in
+# resolve_worker_class. Defaults: the heavy-reasoning worker lane (plus
+# the architects, launched by fleet-babysit, not dispatched) runs xhigh;
+# everything else runs high. opus-reviewer and merger run high (not
+# xhigh): their reasoning is bounded by the diff in front of them, so the
+# extra budget buys little. The deprecated FLEET_EFFORT_OPUS_WORKER is
+# honored as a fallthrough so a pre-P2 conf still tunes the lane.
 declare -A ROLE_EFFORT=(
-    ["sonnet-author"]="${_env_effort_sonnet_author:-${FLEET_EFFORT_SONNET_AUTHOR:-${FLEET_EFFORT:-high}}}"
-    ["opus-worker"]="${_env_effort_opus_worker:-${FLEET_EFFORT_OPUS_WORKER:-${FLEET_EFFORT:-xhigh}}}"
+    ["worker"]="${_env_effort_worker:-${FLEET_EFFORT_WORKER:-${_env_effort_opus_worker:-${FLEET_EFFORT_OPUS_WORKER:-${FLEET_EFFORT:-xhigh}}}}}"
     ["sonnet-reviewer"]="${_env_effort_sonnet_reviewer:-${FLEET_EFFORT_SONNET_REVIEWER:-${FLEET_EFFORT:-high}}}"
     ["opus-reviewer"]="${_env_effort_opus_reviewer:-${FLEET_EFFORT_OPUS_REVIEWER:-${FLEET_EFFORT:-high}}}"
     ["merger"]="${_env_effort_merger:-${FLEET_EFFORT_MERGER:-${FLEET_EFFORT:-high}}}"
     ["smoke-worker"]="${_env_effort_smoke_worker:-${FLEET_EFFORT_SMOKE_WORKER:-${FLEET_EFFORT:-high}}}"
     ["epic-steward"]="${_env_effort_epic_steward:-${FLEET_EFFORT_EPIC_STEWARD:-${FLEET_EFFORT:-xhigh}}}"
 )
-unset _env_effort_opus_worker _env_effort_sonnet_author \
+unset _env_effort_worker _env_effort_opus_worker _env_effort_sonnet_author \
       _env_effort_sonnet_reviewer _env_effort_opus_reviewer \
       _env_effort_merger _env_effort_smoke_worker \
       _env_effort_epic_steward
@@ -466,11 +484,12 @@ list_pane_state() {
 # (empty output if no idle panes for the role).
 #
 # Plural so dispatch_role can fan out a single trigger across every
-# idle pane that's tagged with this role — that's how a role with
-# more than one pane (opus-worker has -1 and -2) gets concurrent
-# iterations. The previous singular form picked the first idle pane
-# and dropped the rest, which silently single-flighted multi-pane
-# roles.
+# idle pane that belongs to this lane (see pane_role_matches_lane) —
+# that's how a multi-pane lane gets concurrent iterations. The worker
+# lane spans every legacy opus-worker-* / sonnet-author-* pane until
+# P2-2 renames them, so it can fan out across all of them. The previous
+# singular form picked the first idle pane and dropped the rest, which
+# silently single-flighted multi-pane roles.
 # Returns 0 (true) when a fleet-dispatch-wrap is currently running as a
 # direct child of the pane's shell. Used to disambiguate tmux's
 # pane_current_command, which reports "bash" while fleet-dispatch-wrap
@@ -492,10 +511,29 @@ pane_has_running_wrapper() {
     pgrep -P "$pane_pid" -f fleet-dispatch-wrap >/dev/null 2>&1
 }
 
+# Whether a pane's @fleet-role tag (or a dispatch-record / reservation
+# role string) belongs to the given dispatcher lane. Normally an exact
+# match. The P2 unification renamed the two worker lanes into one `worker`
+# lane, but pane renames are a later phase (P2-2) and fleet-claim's
+# reservation-role still reports the pre-P2 lane names — so the `worker`
+# lane also claims the legacy `opus-worker` / `sonnet-author` tags. This is
+# what lets the unified lane find, count, and dispatch into panes that
+# still carry their old tags during the transition.
+pane_role_matches_lane() {
+    local pane_role="$1" lane="$2"
+    [[ "$pane_role" == "$lane" ]] && return 0
+    if [[ "$lane" == "worker" ]]; then
+        case "$pane_role" in
+            opus-worker|sonnet-author) return 0 ;;
+        esac
+    fi
+    return 1
+}
+
 find_idle_panes_for_role() {
     local role="$1"
     list_pane_state | while IFS='|' read -r pane_id pane_role pane_cmd; do
-        if [[ "$pane_role" != "$role" ]]; then
+        if ! pane_role_matches_lane "$pane_role" "$role"; then
             continue
         fi
         case "$pane_cmd" in
@@ -861,7 +899,7 @@ count_active_for_role() {
         have_tmux=1
         local pane_id pane_role pane_cmd wt_path wt_name
         while IFS='|' read -r pane_id pane_role pane_cmd; do
-            [[ "$pane_role" == "$role" ]] || continue
+            pane_role_matches_lane "$pane_role" "$role" || continue
             wt_path=$(tmux display-message -t "$pane_id" -p '#{pane_current_path}' 2>/dev/null || true)
             [[ -n "$wt_path" ]] || continue
             wt_name=$(basename "$wt_path")
@@ -887,7 +925,7 @@ count_active_for_role() {
         for f in "$DISPATCH_DIR"/*.json; do
             [[ -e "$f" ]] || continue
             r=$(sed -n 's/.*"role":"\([^"]*\)".*/\1/p' "$f" | head -n 1)
-            [[ "$r" == "$role" ]] || continue
+            pane_role_matches_lane "$r" "$role" || continue
             p=$(sed -n 's/.*"pane":"\([^"]*\)".*/\1/p' "$f" | head -n 1)
             [[ -n "$p" ]] || continue
             wt_path=""
@@ -909,7 +947,7 @@ count_active_for_role() {
             [[ -e "$rfile" ]] || continue
             wt_name=$(basename "$rfile" .json)
             rrole=$(fleet-claim reservation-role "$wt_name" 2>/dev/null || true)
-            [[ "$rrole" == "$role" ]] || continue
+            pane_role_matches_lane "$rrole" "$role" || continue
             # With tmux available, only count the reservation when its
             # worktree's pane is actually busy. An idle pane with a
             # leftover reservation is the resume-after-crash case and
@@ -1345,7 +1383,7 @@ PY
     # only fires when the fleet has work it forgot to dispatch — work
     # the fleet should be doing anyway. No idle-fleet token burn.
     local _role _active
-    for _role in "opus-worker" "sonnet-author"; do
+    for _role in "worker"; do
         # Skip if a trigger is already pending — scout's normal path
         # is doing its job and the dispatcher will fire on next tick.
         if [[ -f "$TRIGGERS_DIR/$_role" ]]; then
@@ -1369,10 +1407,10 @@ trig_dir = pathlib.Path(os.environ["TRIGGERS_DIR"])
 state_dir = pathlib.Path(os.environ["STATE_DIR"])
 role = os.environ["ROLE"]
 
-# Classes each lane serves — the heavy lane covers fable AND opus (a
-# fable-only backlog must still re-arm it; keep in sync with the scout's
-# slice filters and WORKER_LANE_DEFAULT_CLASS).
-ROLE_MODELS = {"opus-worker": {"opus", "fable"}, "sonnet-author": {"sonnet"}}
+# Classes the lane serves — the unified worker lane covers every class
+# (a fable-only or sonnet-only backlog must still re-arm it; keep in sync
+# with the scout's slice filters and WORKER_LANE_DEFAULT_CLASS).
+ROLE_MODELS = {"worker": {"opus", "fable", "sonnet"}}
 models = ROLE_MODELS.get(role)
 if not models:
     raise SystemExit(0)
@@ -1402,6 +1440,22 @@ if any(is_actionable(t) for t in (proj.get("tasks_open") or [])):
         trig.touch()
         print(f"worker-rearm: re-armed {role} (projection has actionable free work, no active iteration)")
 PY
+    done
+}
+
+# Fold any legacy per-lane trigger into the unified worker trigger. A
+# stale scout or fleet-dispatch-wrap (one still running pre-P2 code during
+# a partial restart, or an operator touching the old path) can drop a
+# triggers/opus-worker or triggers/sonnet-author file the new dispatcher no
+# longer reads — rename it to triggers/worker so the work isn't stranded.
+rename_legacy_lane_triggers() {
+    local legacy
+    for legacy in "opus-worker" "sonnet-author"; do
+        if [[ -f "$TRIGGERS_DIR/$legacy" ]]; then
+            mv -f "$TRIGGERS_DIR/$legacy" "$TRIGGERS_DIR/worker" 2>/dev/null || \
+                rm -f "$TRIGGERS_DIR/$legacy"
+            log "folded legacy $legacy trigger into worker"
+        fi
     done
 }
 
@@ -1436,6 +1490,7 @@ main() {
         fi
 
         cleanup_stale_dispatches
+        rename_legacy_lane_triggers
 
         # Scout-watchdog safety net + periodic worker safety rearm.
         # Runs first so any rearm-written triggers are picked up by

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -2109,9 +2109,11 @@ def cleanup_pid_file():
 # keys gone the old files would linger forever — a stale
 # projections/opus-worker.json reads as live to anything that still globs
 # the directory, and a leftover trigger could mis-fire. Sweep them on boot.
+# Remove once P2-2 / P2-3 land (epic #1692).
 _RETIRED_LANE_ROLES = ("opus-worker", "sonnet-author")
 
 
+# Remove once P2-2 / P2-3 land (epic #1692).
 def clean_retired_lane_artifacts():
     for role in _RETIRED_LANE_ROLES:
         for path in (

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -830,9 +830,9 @@ FEEDBACK_LABELS = frozenset({
     "human:needs-fix", "human:blocker", "fleet:needs-fix", "fleet:has-nits",
 })
 # Worker-only resume signal — a PR the worker escalated for architectural
-# input that the architect has now answered. Surfaced in project_opus_worker
+# input that the architect has now answered. Surfaced in project_worker
 # (and only there) so the worker iteration picks it up like any other
-# feedback PR; reviewers and authors do not act on it.
+# feedback PR; reviewers do not act on it.
 DESIGN_RESUME_LABELS = frozenset({"fleet:design-unblocked"})
 REVIEW_VERDICT_LABELS = frozenset({
     "fleet:approved", "fleet:needs-fix", "fleet:blocker", "fleet:has-nits",
@@ -1249,35 +1249,21 @@ def enrich_stackable_blocker_prs(state):
 # fleet:needs-linux-smoke), waking the role to find nothing actionable.
 # Same anti-pattern project_merger already documents and avoids — keep
 # only the labels each role's own decision logic actually keys on.
-_SONNET_AUTHOR_RELEVANT_LABELS = FEEDBACK_LABELS
-_OPUS_WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
+_WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
 
 
-def project_sonnet_author(state):
+def project_worker(state):
+    # Single generic-worker lane (P2): the per-class opus-worker /
+    # sonnet-author split was vestigial once model class became a
+    # property of the task (#1691), so this projector is the union of
+    # the two — every open task regardless of class, every needs-plan
+    # issue, and every feedback/design-resume PR. The dispatcher picks
+    # the concrete model per dispatch from the slice (resolve_worker_class
+    # / fleet_task_class.py); the lane no longer pins a model.
     items = []
     for repo, repo_state in state["repos"].items():
         for task in repo_state.get("tasks", {}).get("open", []):
-            if "sonnet" in model_tags(task):
-                items.append({"kind": "task", "repo": repo, "id": task["id"],
-                              "blocked_by": task["blocked_by"]})
-        for pr in repo_state.get("prs", []):
-            labels = set(pr["labels"])
-            if "human:wip" in labels:
-                continue
-            if labels & _SONNET_AUTHOR_RELEVANT_LABELS:
-                items.append({"kind": "pr", "repo": repo, "pr": pr["number"],
-                              "labels": sorted(labels & _SONNET_AUTHOR_RELEVANT_LABELS)})
-    return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
-
-
-def project_opus_worker(state):
-    items = []
-    for repo, repo_state in state["repos"].items():
-        for task in repo_state.get("tasks", {}).get("open", []):
-            # The opus-worker lane is the heavy lane: it serves both the
-            # opus and fable classes (the dispatcher picks the concrete
-            # model per dispatch from the slice).
-            if model_tags(task) & {"opus", "fable"}:
+            if model_tags(task) & {"opus", "fable", "sonnet"}:
                 items.append({"kind": "task", "repo": repo, "id": task["id"],
                               "blocked_by": task["blocked_by"]})
         for issue in repo_state.get("needs_plan", []):
@@ -1287,9 +1273,9 @@ def project_opus_worker(state):
             labels = set(pr["labels"])
             if "human:wip" in labels:
                 continue
-            if labels & _OPUS_WORKER_RELEVANT_LABELS:
+            if labels & _WORKER_RELEVANT_LABELS:
                 items.append({"kind": "pr", "repo": repo, "pr": pr["number"],
-                              "labels": sorted(labels & _OPUS_WORKER_RELEVANT_LABELS)})
+                              "labels": sorted(labels & _WORKER_RELEVANT_LABELS)})
     return sorted(items, key=lambda x: json.dumps(x, sort_keys=True))
 
 
@@ -1666,8 +1652,7 @@ def project_epic_steward(state):
 
 
 PROJECTORS = {
-    "sonnet-author": project_sonnet_author,
-    "opus-worker": project_opus_worker,
+    "worker": project_worker,
     "sonnet-reviewer": project_sonnet_reviewer,
     "opus-reviewer": project_opus_reviewer,
     "queue-manager": project_queue_manager,
@@ -1706,28 +1691,16 @@ def _slice_issue_with_repo(repo_key, issue):
     return out
 
 
-def slice_sonnet_author(state):
-    out = {"tasks_open": [], "feedback_prs": []}
-    for repo_key, repo_state in state["repos"].items():
-        for task in repo_state.get("tasks", {}).get("open", []):
-            if "sonnet" in model_tags(task):
-                out["tasks_open"].append(_slice_task_with_repo(repo_key, task))
-        for pr in repo_state.get("prs", []):
-            labels = set(pr["labels"])
-            if "human:wip" in labels:
-                continue
-            if labels & FEEDBACK_LABELS:
-                out["feedback_prs"].append(_slice_pr_with_repo(repo_key, pr))
-    return out
-
-
-def slice_opus_worker(state):
+def slice_worker(state):
+    # Unified worker slice (P2): all open tasks of every class, all
+    # needs-plan issues, and all feedback/design-resume PRs. The
+    # dispatcher's per-task class resolution (fleet_task_class.py)
+    # already handles a mixed-class tasks_open list, so a single slice
+    # serves fable / opus / sonnet work.
     out = {"tasks_open": [], "needs_plan": [], "feedback_prs": []}
     for repo_key, repo_state in state["repos"].items():
         for task in repo_state.get("tasks", {}).get("open", []):
-            # Heavy lane serves both opus- and fable-class tasks; see
-            # project_opus_worker.
-            if model_tags(task) & {"opus", "fable"}:
+            if model_tags(task) & {"opus", "fable", "sonnet"}:
                 out["tasks_open"].append(_slice_task_with_repo(repo_key, task))
         for issue in repo_state.get("needs_plan", []):
             out["needs_plan"].append(_slice_issue_with_repo(repo_key, issue))
@@ -1884,8 +1857,7 @@ def slice_epic_steward(state):
 
 
 SLICERS = {
-    "sonnet-author": slice_sonnet_author,
-    "opus-worker": slice_opus_worker,
+    "worker": slice_worker,
     "sonnet-reviewer": slice_sonnet_reviewer,
     "opus-reviewer": slice_opus_reviewer,
     "queue-manager": slice_queue_manager,
@@ -2132,6 +2104,30 @@ def cleanup_pid_file():
         pass
 
 
+# Lane names retired by the P2 worker-lane unification. The scout used to
+# write a projection slice, seen-hash, and trigger file per lane; with the
+# keys gone the old files would linger forever — a stale
+# projections/opus-worker.json reads as live to anything that still globs
+# the directory, and a leftover trigger could mis-fire. Sweep them on boot.
+_RETIRED_LANE_ROLES = ("opus-worker", "sonnet-author")
+
+
+def clean_retired_lane_artifacts():
+    for role in _RETIRED_LANE_ROLES:
+        for path in (
+            PROJECTIONS_DIR / f"{role}.json",
+            SEEN_DIR / role,
+            TRIGGERS_DIR / role,
+        ):
+            try:
+                path.unlink()
+                log(f"removed stale {role} artifact: {path.name}")
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                log(f"could not remove stale {role} artifact {path}: {e}")
+
+
 def signal_handler(signum, _frame):
     log(f"received signal {signum}; shutting down")
     TERMINATE.set()
@@ -2157,6 +2153,8 @@ def main():
     if not ENGINE.exists():
         log(f"engine repo not found at {ENGINE}; aborting")
         sys.exit(1)
+
+    clean_retired_lane_artifacts()
 
     if args.once:
         tick_once()

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -59,19 +59,24 @@
 # pane wakes up alongside a normal dispatch to a free pane.
 #
 # Defaults match each role's current pane count under stock fleet-up
-# layout (2x opus-worker, 2x sonnet-author, 1 each of the rest), so under
-# default values no role hits its cap during normal operation. Tune up to
-# allow more parallelism (requires adding panes); tune down to throttle a
-# role that's burning too much credit budget.
+# layout (the unified worker lane fans out across all worker panes, 1 each
+# of the rest), so under default values no role hits its cap during normal
+# operation. Tune up to allow more parallelism (requires adding panes);
+# tune down to throttle a role that's burning too much credit budget.
 
-# FLEET_CONCURRENCY_OPUS_WORKER=2
-# FLEET_CONCURRENCY_SONNET_AUTHOR=2
+# FLEET_CONCURRENCY_WORKER=4         # unified worker lane (any model class)
 # FLEET_CONCURRENCY_SONNET_REVIEWER=1
 # FLEET_CONCURRENCY_OPUS_REVIEWER=1
 # FLEET_CONCURRENCY_QUEUE_MANAGER=1
 # FLEET_CONCURRENCY_MERGER=1
 # FLEET_CONCURRENCY_SMOKE_WORKER=1   # concurrent cap for the smoke-only worker pane
 # FLEET_CONCURRENCY_EPIC_STEWARD=1   # concurrent cap for the epic-steward pane
+#
+# Deprecated (pre-P2 per-lane caps). Still honored: when
+# FLEET_CONCURRENCY_WORKER is unset, the worker cap is the sum of these
+# two. Remove once your conf sets FLEET_CONCURRENCY_WORKER directly.
+# FLEET_CONCURRENCY_OPUS_WORKER=2
+# FLEET_CONCURRENCY_SONNET_AUTHOR=2
 
 # --- Build parallelism (ir-build CPU budget) --------------------------------
 #
@@ -97,24 +102,27 @@
 #
 # Built-in defaults — the heavy design / render-reasoning roles run xhigh,
 # the rest run high (their work is bounded by the diff / task in front of
-# them, so xhigh buys little):
+# them, so xhigh buys little). The worker lane's value here is only the
+# fallthrough — per-task Effort: and model-class resolution override it:
 #   opus-architect   xhigh        opus-reviewer    high
 #   game-architect   xhigh        merger           high
-#   opus-worker      xhigh        sonnet-author    high
-#                                 sonnet-reviewer  high
+#   worker           xhigh        sonnet-reviewer  high
 #                                 smoke-worker     high
 #
 # Set FLEET_EFFORT (no role suffix) to force one level on every pane.
 
 # FLEET_EFFORT_OPUS_ARCHITECT=xhigh
 # FLEET_EFFORT_GAME_ARCHITECT=xhigh
-# FLEET_EFFORT_OPUS_WORKER=xhigh
+# FLEET_EFFORT_WORKER=xhigh
 # FLEET_EFFORT_OPUS_REVIEWER=high
 # FLEET_EFFORT_MERGER=high
-# FLEET_EFFORT_SONNET_AUTHOR=high
 # FLEET_EFFORT_SONNET_REVIEWER=high
 # FLEET_EFFORT_SMOKE_WORKER=high
 # FLEET_EFFORT_EPIC_STEWARD=xhigh
+#
+# Deprecated (pre-P2): FLEET_EFFORT_OPUS_WORKER is still honored as a
+# fallthrough for the worker lane when FLEET_EFFORT_WORKER is unset.
+# FLEET_EFFORT_OPUS_WORKER=xhigh
 
 # --- Usage gate (per-rate-limit-type thresholds) ----------------------------
 #

--- a/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
+++ b/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
@@ -69,46 +69,46 @@ resolve() {
 
 # --- T1: fable task -> fable model at xhigh ---------------------------------
 echo "T1: fable task resolves to fable model"
-write_slice opus-worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
-assert_eq "$(resolve opus-worker)" \
+write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
+assert_eq "$(resolve worker)" \
     "class=fable model=claude-fable-5[1m] effort=xhigh more=0 defer=0" \
     "uncapped fable task dispatches on fable at xhigh"
 
 # --- T2: fable cap reached -> next non-fable task ---------------------------
 echo "T2: fable cap diverts to the next class"
-write_slice opus-worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false},{"issue":"#11","model":"opus","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
-printf '{"role":"opus-worker","pane":"%%9","class":"fable","dispatched_at":"x"}\n' \
+write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false},{"issue":"#11","model":"opus","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
+printf '{"role":"worker","pane":"%%9","class":"fable","dispatched_at":"x"}\n' \
     > "$FLEET_STATE_DIR/dispatch/pane-9.json"
-assert_eq "$(resolve opus-worker)" \
+assert_eq "$(resolve worker)" \
     "class=opus model=claude-opus-4-8[1m] effort=xhigh more=0 defer=0" \
     "capped fable skipped; opus task served; cap-blocked fable does NOT hold the trigger (more=0)"
 
 # --- T3: only capped fable work -> defer -------------------------------------
 echo "T3: only cap-blocked fable work defers"
-write_slice opus-worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
-out=$(resolve opus-worker)
+write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
+out=$(resolve worker)
 assert_eq "$out" "class= model= effort= more=0 defer=1" \
     "cap-blocked fable-only slice -> defer (no lane-default burn)"
 rm -f "$FLEET_STATE_DIR/dispatch/pane-9.json"
 
 # --- T4: per-task effort override --------------------------------------------
 echo "T4: Effort: override threads through"
-write_slice opus-worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":"medium","owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
-assert_eq "$(resolve opus-worker)" \
+write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":"medium","owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
+assert_eq "$(resolve worker)" \
     "class=opus model=claude-opus-4-8[1m] effort=medium more=0 defer=0" \
     "task-level Effort: medium beats the class default"
 
 # --- T5: feedback severity routing -------------------------------------------
 echo "T5: nits-only feedback routes sonnet ahead of queued tasks"
-write_slice opus-worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false}],"feedback_prs":[{"number":50,"labels":["fleet:approved","fleet:has-nits"]}],"needs_plan":[]}'
-assert_eq "$(resolve opus-worker)" \
+write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false}],"feedback_prs":[{"number":50,"labels":["fleet:approved","fleet:has-nits"]}],"needs_plan":[]}'
+assert_eq "$(resolve worker)" \
     "class=sonnet model=sonnet effort=high more=1 defer=0" \
     "has-nits feedback dispatches sonnet; opus task keeps the trigger"
 
 # --- T6: empty slice -> lane default fallthrough ------------------------------
 echo "T6: empty slice falls through to lane default"
-write_slice opus-worker '{"tasks_open":[],"feedback_prs":[],"needs_plan":[]}'
-assert_eq "$(resolve opus-worker)" "class= model= effort= more=0 defer=0" \
+write_slice worker '{"tasks_open":[],"feedback_prs":[],"needs_plan":[]}'
+assert_eq "$(resolve worker)" "class= model= effort= more=0 defer=0" \
     "empty slice -> lane-default dispatch (reservation-resume path)"
 
 # --- T7: non-worker role is a no-op ------------------------------------------

--- a/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
+++ b/scripts/fleet/tests/test_dispatcher_concurrency_cap.sh
@@ -8,10 +8,15 @@
 #   - dedup when a worktree has both a dispatch record and a reservation
 #   - reservation on an idle pane does NOT count (resume-after-crash)
 #   - reservation on a busy pane DOES count (live iteration)
-#   - cap defaults (preserve current behavior at 2 for multi-pane roles)
+#   - cap defaults (unified worker lane = 4; deprecated per-lane caps sum)
 #   - env var override
 #   - conf file override
 #   - conf override beat by env var
+#
+# count-active queries the unified `worker` lane while the dispatch
+# records, pane tags, and reservations still carry the legacy
+# `opus-worker` strings — exercising pane_role_matches_lane's coexistence
+# aliasing (panes aren't renamed until P2-2).
 
 set -euo pipefail
 
@@ -89,26 +94,31 @@ chmod +x "$TMPROOT/bin/gh"
 ln -s "$FLEET_CLAIM" "$TMPROOT/bin/fleet-claim"
 export PATH="$TMPROOT/bin:$PATH"
 
+# The dispatch records and pane tags below deliberately use the legacy
+# `opus-worker` role string: P2-2 has not renamed the panes yet, so the
+# unified `worker` lane must count work that still carries the old tag
+# (pane_role_matches_lane). This is the coexistence path.
+
 # --- Test 1: no records, no reservations -----------------------------------
 echo "T1: empty state — count is 0"
-n=$("$DISPATCHER" --count-active opus-worker)
-assert_eq "$n" "0" "opus-worker count is 0 with empty state"
+n=$("$DISPATCHER" --count-active worker)
+assert_eq "$n" "0" "worker count is 0 with empty state"
 
 # --- Test 2: in-flight only ------------------------------------------------
-echo "T2: one in-flight dispatch record for opus-worker"
+echo "T2: one in-flight dispatch record (legacy opus-worker tag)"
 cat >"$FLEET_STATE_DIR/dispatch/pane-3.json" <<'JSON'
 {"role":"opus-worker","pane":"%3","dispatched_at":"2026-05-08T00:00:00Z"}
 JSON
-n=$("$DISPATCHER" --count-active opus-worker)
-assert_eq "$n" "1" "opus-worker count is 1 with one in-flight"
-n=$("$DISPATCHER" --count-active sonnet-author)
-assert_eq "$n" "0" "sonnet-author count is 0 (in-flight is opus-worker)"
+n=$("$DISPATCHER" --count-active worker)
+assert_eq "$n" "1" "worker count is 1 with one in-flight (legacy tag aliased)"
+n=$("$DISPATCHER" --count-active merger)
+assert_eq "$n" "0" "merger count is 0 (in-flight is a worker-lane record)"
 
 # --- Test 3: reservation only ----------------------------------------------
 echo "T3: a reservation for an opus task on a different worktree"
 "$FLEET_CLAIM" reserve 901 opus-worker-2 claude/901-something >/dev/null
-n=$("$DISPATCHER" --count-active opus-worker)
-assert_eq "$n" "2" "opus-worker count is 2 (1 in-flight + 1 reserved on different worktree)"
+n=$("$DISPATCHER" --count-active worker)
+assert_eq "$n" "2" "worker count is 2 (1 in-flight + 1 reserved on different worktree)"
 
 # --- Test 4: dedup when same worktree has both ------------------------------
 echo "T4: add second in-flight whose worktree matches the reservation"
@@ -166,8 +176,8 @@ JSON
 # With tmux stub: pane %3 → opus-worker-1, pane %5 → opus-worker-2,
 # both busy. Reservation is on opus-worker-2 → dedup with pane %5's
 # record. Total unique = 2 (opus-worker-1, opus-worker-2).
-PATH="$TMPROOT/bin-tmux:$PATH" n=$("$DISPATCHER" --count-active opus-worker)
-assert_eq "$n" "2" "opus-worker count dedups same-worktree dispatch+reservation"
+PATH="$TMPROOT/bin-tmux:$PATH" n=$("$DISPATCHER" --count-active worker)
+assert_eq "$n" "2" "worker count dedups same-worktree dispatch+reservation"
 
 # --- Test 4b: reservation on IDLE pane (resume case) does NOT count --------
 echo "T4b: reservation on idle pane does NOT count (resume case)"
@@ -224,7 +234,7 @@ exit 1
 PGREPEOF
 chmod +x "$TMPROOT/bin-tmux-idle/pgrep"
 
-n=$(PATH="$TMPROOT/bin-tmux-idle:$PATH" "$DISPATCHER" --count-active opus-worker)
+n=$(PATH="$TMPROOT/bin-tmux-idle:$PATH" "$DISPATCHER" --count-active worker)
 assert_eq "$n" "0" "reservation on idle pane is the resume signal — does not pin the cap"
 
 # --- Test 4c: reservation on BUSY pane DOES count --------------------------
@@ -262,43 +272,51 @@ esac
 TMUXEOF
 chmod +x "$TMPROOT/bin-tmux-busy/tmux"
 
-n=$(PATH="$TMPROOT/bin-tmux-busy:$PATH" "$DISPATCHER" --count-active opus-worker)
+n=$(PATH="$TMPROOT/bin-tmux-busy:$PATH" "$DISPATCHER" --count-active worker)
 assert_eq "$n" "1" "reservation on busy pane counts (live iteration)"
 
 # --- Test 5: cap defaults --------------------------------------------------
 echo "T5: cap defaults (no conf, no env)"
-unset FLEET_CONCURRENCY_OPUS_WORKER FLEET_CONCURRENCY_SONNET_AUTHOR \
+unset FLEET_CONCURRENCY_WORKER FLEET_CONCURRENCY_OPUS_WORKER \
+      FLEET_CONCURRENCY_SONNET_AUTHOR \
       FLEET_CONCURRENCY_SONNET_REVIEWER FLEET_CONCURRENCY_OPUS_REVIEWER \
       FLEET_CONCURRENCY_QUEUE_MANAGER FLEET_CONCURRENCY_MERGER
 rm -f "$FLEET_CONF"
-cap=$("$DISPATCHER" --print-cap opus-worker)
-assert_eq "$cap" "2" "default cap for opus-worker is 2"
-cap=$("$DISPATCHER" --print-cap sonnet-author)
-assert_eq "$cap" "2" "default cap for sonnet-author is 2"
+cap=$("$DISPATCHER" --print-cap worker)
+assert_eq "$cap" "4" "default cap for the worker lane is 4"
 cap=$("$DISPATCHER" --print-cap merger)
 assert_eq "$cap" "1" "default cap for merger is 1"
 
+# --- Test 5b: deprecated per-lane caps sum into the worker cap -------------
+echo "T5b: deprecated OPUS_WORKER + SONNET_AUTHOR sum when WORKER unset"
+cap=$(FLEET_CONCURRENCY_OPUS_WORKER=3 FLEET_CONCURRENCY_SONNET_AUTHOR=2 \
+    "$DISPATCHER" --print-cap worker)
+assert_eq "$cap" "5" "worker cap = deprecated OPUS_WORKER(3) + SONNET_AUTHOR(2)"
+cap=$(FLEET_CONCURRENCY_WORKER=6 FLEET_CONCURRENCY_OPUS_WORKER=3 \
+    FLEET_CONCURRENCY_SONNET_AUTHOR=2 "$DISPATCHER" --print-cap worker)
+assert_eq "$cap" "6" "FLEET_CONCURRENCY_WORKER wins over the deprecated sum"
+
 # --- Test 6: env var override ---------------------------------------------
 echo "T6: env var overrides default"
-cap=$(FLEET_CONCURRENCY_OPUS_WORKER=5 "$DISPATCHER" --print-cap opus-worker)
+cap=$(FLEET_CONCURRENCY_WORKER=5 "$DISPATCHER" --print-cap worker)
 assert_eq "$cap" "5" "env var overrides default cap"
 
 # --- Test 7: conf file override --------------------------------------------
 echo "T7: conf file overrides default"
 cat >"$FLEET_CONF" <<'CONFEOF'
-FLEET_CONCURRENCY_OPUS_WORKER=4
+FLEET_CONCURRENCY_WORKER=4
 FLEET_CONCURRENCY_MERGER=3
 CONFEOF
-cap=$("$DISPATCHER" --print-cap opus-worker)
-assert_eq "$cap" "4" "conf file sets opus-worker cap to 4"
+cap=$("$DISPATCHER" --print-cap worker)
+assert_eq "$cap" "4" "conf file sets worker cap to 4"
 cap=$("$DISPATCHER" --print-cap merger)
 assert_eq "$cap" "3" "conf file sets merger cap to 3"
-cap=$("$DISPATCHER" --print-cap sonnet-author)
-assert_eq "$cap" "2" "untouched roles keep their default"
+cap=$("$DISPATCHER" --print-cap sonnet-reviewer)
+assert_eq "$cap" "1" "untouched roles keep their default"
 
 # --- Test 8: env var beats conf --------------------------------------------
 echo "T8: env var has higher priority than conf"
-cap=$(FLEET_CONCURRENCY_OPUS_WORKER=7 "$DISPATCHER" --print-cap opus-worker)
+cap=$(FLEET_CONCURRENCY_WORKER=7 "$DISPATCHER" --print-cap worker)
 assert_eq "$cap" "7" "env var beats conf file"
 
 # --- Test 9: boot fan-out trigger retention --------------------------------
@@ -308,23 +326,23 @@ assert_eq "$cap" "7" "env var beats conf file"
 # (so the next tick can dispatch into a pane whose @fleet-role tag landed
 # late at fleet-up). Outside the window, the legacy consume-on-success
 # behavior applies regardless of cap headroom.
-# Clear the conf override so opus-worker is back at default cap=2 for T9+.
+# Clear the conf override so the worker lane is back at default cap=4 for T9+.
 rm -f "$FLEET_CONF"
 
 echo "T9: boot fan-out — active < cap inside window → retain"
 out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
-    "$DISPATCHER" --retain-trigger-check opus-worker 1)
-assert_eq "$out" "retain" "active=1 < cap=2 inside window → retain"
+    "$DISPATCHER" --retain-trigger-check worker 1)
+assert_eq "$out" "retain" "active=1 < cap=4 inside window → retain"
 
 echo "T10: boot fan-out — active == cap inside window → consume"
 out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
-    "$DISPATCHER" --retain-trigger-check opus-worker 2)
-assert_eq "$out" "consume" "active=2 == cap=2 inside window → consume"
+    "$DISPATCHER" --retain-trigger-check worker 4)
+assert_eq "$out" "consume" "active=4 == cap=4 inside window → consume"
 
 echo "T11: boot fan-out — window expired → consume even if under cap"
 out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=0 \
-    "$DISPATCHER" --retain-trigger-check opus-worker 1)
-assert_eq "$out" "consume" "active=1 < cap=2 but window expired → consume"
+    "$DISPATCHER" --retain-trigger-check worker 1)
+assert_eq "$out" "consume" "active=1 < cap=4 but window expired → consume"
 
 echo "T12: boot fan-out — single-pane role saturated → consume"
 # Merger has cap=1; in the real dispatch flow, a successful dispatch
@@ -336,14 +354,14 @@ assert_eq "$out" "consume" "merger cap=1 with active=1 → consume (cap saturate
 
 echo "T13: boot fan-out — cap=0 (unconfigured role) → consume"
 out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
-    FLEET_CONCURRENCY_OPUS_WORKER=0 \
-    "$DISPATCHER" --retain-trigger-check opus-worker 0)
+    FLEET_CONCURRENCY_WORKER=0 \
+    "$DISPATCHER" --retain-trigger-check worker 0)
 assert_eq "$out" "consume" "cap=0 short-circuits the retention check"
 
 # --- Test 14: numeric guard on --retain-trigger-check active arg -----------
 echo "T14: non-numeric active arg → usage error, no daemon crash"
 if FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS=9999 \
-    "$DISPATCHER" --retain-trigger-check opus-worker notanumber >/dev/null 2>&1; then
+    "$DISPATCHER" --retain-trigger-check worker notanumber >/dev/null 2>&1; then
     rc=0
 else
     rc=$?
@@ -356,7 +374,7 @@ echo "T15: non-numeric BOOT_FANOUT_WINDOW_SECONDS clamps to 60s default"
 # If the validate-and-clamp at startup fails, the bash arithmetic would either
 # emit a stderr error (silent flip to consume) or trip set -u (rc=1).
 out=$(FLEET_DISPATCHER_BOOT_FANOUT_WINDOW_SECONDS="9999s" \
-    "$DISPATCHER" --retain-trigger-check opus-worker 1 2>/dev/null)
+    "$DISPATCHER" --retain-trigger-check worker 1 2>/dev/null)
 assert_eq "$out" "retain" "non-numeric env override clamps to 60s → in-window retain"
 
 echo ""

--- a/scripts/fleet/tests/test_dispatcher_effort.sh
+++ b/scripts/fleet/tests/test_dispatcher_effort.sh
@@ -55,7 +55,9 @@ export FLEET_SESSION="fleet-test-$$"
 mkdir -p "$FLEET_STATE_DIR"
 
 # Start from a clean slate: no conf, no per-role env, no global override.
-unset FLEET_EFFORT \
+# The deprecated FLEET_EFFORT_OPUS_WORKER / _SONNET_AUTHOR are fallthroughs
+# for the worker lane, so they must be cleared for the default test too.
+unset FLEET_EFFORT FLEET_EFFORT_WORKER \
       FLEET_EFFORT_OPUS_WORKER FLEET_EFFORT_OPUS_REVIEWER FLEET_EFFORT_MERGER \
       FLEET_EFFORT_SONNET_AUTHOR FLEET_EFFORT_SONNET_REVIEWER \
       FLEET_EFFORT_SMOKE_WORKER 2>/dev/null || true
@@ -63,10 +65,10 @@ unset FLEET_EFFORT \
 # --- Test 1: built-in defaults ---------------------------------------------
 echo "T1: effort defaults (no conf, no env)"
 rm -f "$FLEET_CONF"
-assert_eq "$("$DISPATCHER" --print-effort opus-worker)"     "xhigh" "opus-worker defaults to xhigh"
+assert_eq "$("$DISPATCHER" --print-effort worker)"          "xhigh" "worker lane defaults to xhigh"
 assert_eq "$("$DISPATCHER" --print-effort opus-reviewer)"   "high"  "opus-reviewer defaults to high"
 assert_eq "$("$DISPATCHER" --print-effort merger)"          "high"  "merger defaults to high"
-assert_eq "$("$DISPATCHER" --print-effort sonnet-author)"   "high"  "sonnet-author defaults to high"
+assert_eq "$("$DISPATCHER" --print-effort sonnet-reviewer)" "high"  "sonnet-reviewer defaults to high"
 assert_eq "$("$DISPATCHER" --print-effort smoke-worker)"    "high"  "smoke-worker defaults to high"
 
 # --- Test 2: per-role env var override -------------------------------------
@@ -85,23 +87,30 @@ assert_eq "$("$DISPATCHER" --print-effort opus-reviewer)" "high"  "untouched rol
 # --- Test 4: env var beats conf --------------------------------------------
 echo "T4: env var has higher priority than conf"
 cat >"$FLEET_CONF" <<'CONFEOF'
-FLEET_EFFORT_OPUS_WORKER=high
+FLEET_EFFORT_WORKER=high
 CONFEOF
-assert_eq "$(FLEET_EFFORT_OPUS_WORKER=xhigh "$DISPATCHER" --print-effort opus-worker)" \
-    "xhigh" "env FLEET_EFFORT_OPUS_WORKER beats conf value"
+assert_eq "$(FLEET_EFFORT_WORKER=xhigh "$DISPATCHER" --print-effort worker)" \
+    "xhigh" "env FLEET_EFFORT_WORKER beats conf value"
 rm -f "$FLEET_CONF"
+
+# --- Test 4b: deprecated per-lane effort is honored as a fallthrough -------
+echo "T4b: deprecated FLEET_EFFORT_OPUS_WORKER still tunes the worker lane"
+assert_eq "$(FLEET_EFFORT_OPUS_WORKER=high "$DISPATCHER" --print-effort worker)" \
+    "high"  "FLEET_EFFORT_OPUS_WORKER falls through to the worker lane"
+assert_eq "$(FLEET_EFFORT_WORKER=xhigh FLEET_EFFORT_OPUS_WORKER=high "$DISPATCHER" --print-effort worker)" \
+    "xhigh" "FLEET_EFFORT_WORKER wins over the deprecated fallthrough"
 
 # --- Test 5: global FLEET_EFFORT fallback ----------------------------------
 echo "T5: global FLEET_EFFORT applies when no per-role value is set"
 assert_eq "$(FLEET_EFFORT=xhigh "$DISPATCHER" --print-effort opus-reviewer)" \
     "xhigh" "global FLEET_EFFORT lifts opus-reviewer"
-assert_eq "$(FLEET_EFFORT=high "$DISPATCHER" --print-effort opus-worker)" \
-    "high"  "global FLEET_EFFORT lowers opus-worker"
+assert_eq "$(FLEET_EFFORT=high "$DISPATCHER" --print-effort worker)" \
+    "high"  "global FLEET_EFFORT lowers the worker lane"
 
 # --- Test 6: per-role beats global -----------------------------------------
 echo "T6: per-role value wins over global FLEET_EFFORT"
-assert_eq "$(FLEET_EFFORT=high FLEET_EFFORT_OPUS_WORKER=xhigh "$DISPATCHER" --print-effort opus-worker)" \
-    "xhigh" "FLEET_EFFORT_OPUS_WORKER beats global FLEET_EFFORT=high"
+assert_eq "$(FLEET_EFFORT=high FLEET_EFFORT_WORKER=xhigh "$DISPATCHER" --print-effort worker)" \
+    "xhigh" "FLEET_EFFORT_WORKER beats global FLEET_EFFORT=high"
 
 # --- Test 7: usage error on missing role arg -------------------------------
 echo "T7: --print-effort with no role → usage error"

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -1,9 +1,9 @@
-"""Tests for project_sonnet_author / project_opus_worker / project_opus_reviewer
+"""Tests for project_worker / project_opus_reviewer / project_sonnet_reviewer
 in fleet-state-scout.
 
-The author/worker/reviewer hash-input projections MUST be stable across
-labels their role's decision logic does NOT key on (merger-toggled labels
-like fleet:merger-cooldown, smoke-gate labels like fleet:needs-linux-smoke,
+The worker / reviewer hash-input projections MUST be stable across labels
+their role's decision logic does NOT key on (merger-toggled labels like
+fleet:merger-cooldown, smoke-gate labels like fleet:needs-linux-smoke,
 authoring-host markers like fleet:authored-on-macos, recheck-cycle
 fleet:changes-made on a still-flagged PR, etc.). Without this invariant,
 every label flip on a PR that happens to also have a feedback label
@@ -14,7 +14,12 @@ sonnet-author + opus-worker four times in 5 minutes while reviewers and
 the merger flipped labels around the PR, with each iteration exiting clean.
 
 Mirrors test_merger_projection.py — the merger's projection was already
-hardened against this; the author/worker/reviewer projections were not.
+hardened against this; the worker/reviewer projections were not.
+
+P2: the per-class project_sonnet_author / project_opus_worker pair was
+unified into a single project_worker (every task class + needs_plan +
+feedback/design-resume PRs), so the worker invariants below are tested
+against that one projector.
 """
 import importlib.machinery
 import importlib.util
@@ -26,8 +31,7 @@ _loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT)
 _spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
 _mod = importlib.util.module_from_spec(_spec)
 _loader.exec_module(_mod)
-project_sonnet_author = _mod.project_sonnet_author
-project_opus_worker = _mod.project_opus_worker
+project_worker = _mod.project_worker
 project_opus_reviewer = _mod.project_opus_reviewer
 project_sonnet_reviewer = _mod.project_sonnet_reviewer
 stable_hash = _mod.stable_hash
@@ -58,12 +62,16 @@ def _pr(num, *, labels=None, head="claude/feat", is_draft=False):
     }
 
 
-class SonnetAuthorStableAcrossIrrelevantLabels(unittest.TestCase):
-    """Labels the author's decision logic does NOT key on must not flip
+def _task(tid, *, model, owner="free", blocked_by="(none)"):
+    return {"id": tid, "model": model, "owner": owner, "blocked_by": blocked_by}
+
+
+class WorkerStableAcrossIrrelevantLabels(unittest.TestCase):
+    """Labels the worker's decision logic does NOT key on must not flip
     the projection hash on a PR that's already in the projection."""
 
     def _hash(self, prs):
-        return stable_hash(project_sonnet_author(_state(prs)))
+        return stable_hash(project_worker(_state(prs)))
 
     def test_merger_cooldown_does_not_flip_hash(self):
         before = self._hash([_pr(101, labels=["fleet:needs-fix"])])
@@ -71,12 +79,12 @@ class SonnetAuthorStableAcrossIrrelevantLabels(unittest.TestCase):
             "fleet:needs-fix", "fleet:merger-cooldown",
         ])])
         self.assertEqual(before, after,
-                         "merger-cooldown toggle must not re-fire sonnet-author")
+                         "merger-cooldown toggle must not re-fire the worker")
 
     def test_semantic_conflict_does_not_flip_hash(self):
-        # Sonnet-author explicitly does NOT handle semantic-conflict
-        # (that's opus-worker's lane), so flipping this label on a PR
-        # that's in the projection for some other reason should be a no-op.
+        # The worker handles semantic-conflict (step 1c), but the projector
+        # includes a PR via FEEDBACK_LABELS, not semantic-conflict. Flipping
+        # that label while the feedback label is unchanged must not re-fire.
         before = self._hash([_pr(101, labels=["fleet:needs-fix"])])
         after = self._hash([_pr(101, labels=[
             "fleet:needs-fix", "fleet:semantic-conflict",
@@ -109,11 +117,13 @@ class SonnetAuthorStableAcrossIrrelevantLabels(unittest.TestCase):
         self.assertEqual(before, after)
 
 
-class SonnetAuthorActionableTransitionsFlipHash(unittest.TestCase):
-    """Real changes the author should react to must still re-fire."""
+class WorkerActionableTransitionsFlipHash(unittest.TestCase):
+    """Real changes the worker should react to must still re-fire. The
+    unified lane keys on FEEDBACK_LABELS, DESIGN_RESUME_LABELS, every task
+    class, and needs_plan issues."""
 
-    def _hash(self, prs):
-        return stable_hash(project_sonnet_author(_state(prs)))
+    def _hash(self, prs, tasks=None, needs_plan=None):
+        return stable_hash(project_worker(_state(prs, tasks, needs_plan)))
 
     def test_needs_fix_appears_flips_hash(self):
         before = self._hash([_pr(101, labels=[])])
@@ -137,83 +147,53 @@ class SonnetAuthorActionableTransitionsFlipHash(unittest.TestCase):
         after = self._hash([_pr(101, labels=["fleet:has-nits"])])
         self.assertNotEqual(before, after)
 
-
-class SonnetAuthorSkipLabelsDropPR(unittest.TestCase):
-    """human:wip excludes a PR from the projection entirely."""
-
-    def _hash(self, prs):
-        return stable_hash(project_sonnet_author(_state(prs)))
-
-    def test_human_wip_drops_pr(self):
-        empty = self._hash([])
-        with_wip = self._hash([_pr(101, labels=["fleet:needs-fix", "human:wip"])])
-        self.assertEqual(empty, with_wip)
-
-
-class OpusWorkerStableAcrossIrrelevantLabels(unittest.TestCase):
-    """Same invariant as sonnet-author. opus-worker also keys on
-    fleet:design-unblocked (DESIGN_RESUME_LABELS) — that label IS
-    relevant and must flip the hash."""
-
-    def _hash(self, prs):
-        return stable_hash(project_opus_worker(_state(prs)))
-
-    def test_merger_cooldown_does_not_flip_hash(self):
-        before = self._hash([_pr(101, labels=["fleet:needs-fix"])])
-        after = self._hash([_pr(101, labels=[
-            "fleet:needs-fix", "fleet:merger-cooldown",
-        ])])
-        self.assertEqual(before, after)
-
-    def test_semantic_conflict_does_not_flip_hash_on_flagged_pr(self):
-        # Opus-worker step 1c handles semantic-conflict, but the
-        # current projector includes a PR via FEEDBACK_LABELS, not
-        # semantic-conflict. The semantic-conflict label flipping
-        # while the feedback label is unchanged should not re-fire
-        # the worker — the relevant trigger set hasn't changed.
-        before = self._hash([_pr(101, labels=["fleet:needs-fix"])])
-        after = self._hash([_pr(101, labels=[
-            "fleet:needs-fix", "fleet:semantic-conflict",
-        ])])
-        self.assertEqual(before, after)
-
-    def test_needs_linux_smoke_does_not_flip_hash(self):
-        before = self._hash([_pr(101, labels=["fleet:needs-fix"])])
-        after = self._hash([_pr(101, labels=[
-            "fleet:needs-fix", "fleet:needs-linux-smoke",
-        ])])
-        self.assertEqual(before, after)
-
-    def test_changes_made_on_still_flagged_pr_does_not_flip(self):
-        before = self._hash([_pr(101, labels=["fleet:needs-fix"])])
-        after = self._hash([_pr(101, labels=[
-            "fleet:needs-fix", "fleet:changes-made",
-        ])])
-        self.assertEqual(before, after)
-
-
-class OpusWorkerActionableTransitionsFlipHash(unittest.TestCase):
-    """Real changes must still re-fire opus-worker."""
-
-    def _hash(self, prs):
-        return stable_hash(project_opus_worker(_state(prs)))
-
     def test_design_unblocked_appears_flips_hash(self):
         before = self._hash([_pr(101, labels=[])])
         after = self._hash([_pr(101, labels=["fleet:design-unblocked"])])
         self.assertNotEqual(before, after)
 
-    def test_needs_fix_appears_flips_hash(self):
-        before = self._hash([_pr(101, labels=[])])
-        after = self._hash([_pr(101, labels=["fleet:needs-fix"])])
+    def test_needs_plan_issue_appears_flips_hash(self):
+        before = self._hash([])
+        after = self._hash([], needs_plan=[{"number": 222}])
         self.assertNotEqual(before, after)
 
-    def test_needs_plan_issue_appears_flips_hash(self):
-        before = stable_hash(project_opus_worker(_state([])))
-        after = stable_hash(project_opus_worker(
-            _state([], needs_plan=[{"number": 222}])
-        ))
-        self.assertNotEqual(before, after)
+
+class WorkerCoversEveryTaskClass(unittest.TestCase):
+    """The unified lane is the union of the old per-class lanes — a task of
+    any class (fable / opus / sonnet) appears in the projection, and a new
+    task flips the hash regardless of its class."""
+
+    def _hash(self, tasks):
+        return stable_hash(project_worker(_state([], tasks=tasks)))
+
+    def test_each_class_appears(self):
+        empty = self._hash({"open": []})
+        for cls in ("fable", "opus", "sonnet"):
+            with_task = self._hash({"open": [_task(f"#{cls}", model=cls)]})
+            self.assertNotEqual(empty, with_task,
+                                f"a {cls}-class task must enter the worker projection")
+
+    def test_class_retag_does_not_flip_hash(self):
+        # The projection item keys on task identity (id + blocked_by), not
+        # model class — the same as the pre-P2 projectors. A re-tag
+        # (sonnet->opus) doesn't change which lane must act (one unified
+        # lane) and the dispatcher re-resolves the class per dispatch from
+        # the slice, so it must NOT re-fire the worker.
+        opus = self._hash({"open": [_task("#10", model="opus")]})
+        sonnet = self._hash({"open": [_task("#10", model="sonnet")]})
+        self.assertEqual(opus, sonnet)
+
+
+class WorkerSkipLabelsDropPR(unittest.TestCase):
+    """human:wip excludes a PR from the projection entirely."""
+
+    def _hash(self, prs):
+        return stable_hash(project_worker(_state(prs)))
+
+    def test_human_wip_drops_pr(self):
+        empty = self._hash([])
+        with_wip = self._hash([_pr(101, labels=["fleet:needs-fix", "human:wip"])])
+        self.assertEqual(empty, with_wip)
 
 
 class OpusReviewerStableAcrossIrrelevantLabels(unittest.TestCase):


### PR DESCRIPTION
## Summary
- **P2.1 of epic #1692** — collapse the per-class `opus-worker` / `sonnet-author` lanes into a single generic `worker` lane in the scout and dispatcher. With model class now a per-task property (#1691), the per-lane split was vestigial; the unified lane lets capacity flow to the deepest queue and the dispatcher resolves the model per dispatch (`fleet_task_class.py`).
- **fleet-state-scout:** `project_worker` / `slice_worker` replace the two per-class projectors/slicers (union of every task class + `needs_plan` + feedback/design-resume PRs); `PROJECTORS`/`SLICERS` key on `worker`. On boot the scout sweeps orphaned `projections/{opus-worker,sonnet-author}.json`, `seen-hashes/*`, and `triggers/*` so stale per-lane artifacts can't linger or wedge the new lane.
- **fleet-dispatcher:** `DISPATCHED_ROLES`, `ROLE_MODEL`, `ROLE_EFFORT`, `WORKER_LANE_DEFAULT_CLASS` collapse to `worker`; `ROLE_CONCURRENCY` gains `FLEET_CONCURRENCY_WORKER` (default 4) and sums the deprecated `OPUS_WORKER`+`SONNET_AUTHOR` caps when it's unset. New `pane_role_matches_lane` helper lets the `worker` lane find/count/dispatch into panes still carrying the legacy `@fleet-role` tags **and** legacy `fleet-claim reservation-role` strings (the coexistence path until P2-2 renames panes). The main loop folds any stale `triggers/<legacy>` into `triggers/worker`; the worker-safety rearm covers all three classes.
- **fleet-dispatch-wrap:** auto-retrigger block accepts `worker` plus the legacy names.
- **fleet-up.conf.sample:** documents `FLEET_CONCURRENCY_WORKER` / `FLEET_EFFORT_WORKER`, marks the per-lane knobs deprecated-but-honored.
- Tests renamed/extended for the unified lane.

## Activation ordering (important for the merger / reviewer)
This change is **inert until the rest of the chain lands**: the new dispatcher dispatches `/role-worker` and the scout writes `projections/worker.json`, but `role-worker.md` is created in **P2-3 (#... )** and the panes are renamed in **P2-2**. A `fleet-up` restart with only P2.1 live would dispatch a non-existent `/role-worker` and the old role docs would read a now-missing slice. The merge gate (children edit the same scripts) means the chain lands together — do **not** restart the live fleet on P2.1 alone. The running daemons are unaffected until restart.

## Out of scope (deferred to P2-3)
The role-doc / FLEET.md / FLEET-RUNTIME.md sweep that renames the lane in prose (and `role-opus-worker.md` / `role-sonnet-author.md`, which are gated self-config) is **P2-3's** explicit deliverable, so this PR does not touch those docs — flagged by the simplify doc-drift pass.

## Test plan
- [x] `test_worker_projection.py` (22) — rewritten for `project_worker`; hash-stability + actionable-transition + all-class-coverage invariants green
- [x] `test_dispatcher_class_dispatch.sh` (7) — `--resolve-class worker` for fable/opus/sonnet incl. fable cap divert + defer
- [x] `test_dispatcher_concurrency_cap.sh` (23) — worker cap default 4, deprecated-sum fallthrough, legacy-tag coexistence counting, dedup, retain-trigger
- [x] `test_dispatcher_effort.sh` (15) — worker xhigh default + deprecated `FLEET_EFFORT_OPUS_WORKER` fallthrough
- [x] Full fleet suite green (one pre-existing failure: `test_dispatcher_usage_gate.sh` T3, a date-sensitive boundary test that fails identically on master — unrelated)
- [x] Isolated check: boot cleanup removes retired lane artifacts + keeps `worker.json`; `slice_worker` emits all three classes

Closes #1693

🤖 Generated with [Claude Code](https://claude.com/claude-code)