### PR TITLE
fleet: re-scope fleet:human-deferred — feedback marker, not a merge-gate

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -114,9 +114,13 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
    diff is mid-rewrite and re-enters with `fleet:changes-made` when
    released) — those are
    either in-progress, human-owned, under active author fixes
-   (`fleet:human-amending` / `fleet:amending-*`), in DEFER mode where
-   the human decides to merge as-is or re-flag (`fleet:human-deferred`
-   — do NOT re-apply `fleet:needs-fix` for deferred concerns), queued
+   (`fleet:human-amending` / `fleet:amending-*`), in DEFER mode
+   (`fleet:human-deferred` — which parks the deferred concern on the
+   diff at defer time, NOT a merge-gate: skip only while that diff is
+   unchanged and never re-apply `fleet:needs-fix` for the deferred
+   concern; if new commits landed after the defer — the label was
+   dropped, `human:re-review` is set, or a conflict-resolution comment
+   is present — review the new diff, honoring the linked issue), queued
    for conflict resolution (diff against master is meaningless until
    the rebase lands), or forked from another open PR (diff includes
    inherited commits that don't belong to this PR's scope — skip

--- a/.claude/commands/role-opus-worker.md
+++ b/.claude/commands/role-opus-worker.md
@@ -377,6 +377,14 @@ Do the work, then exit cleanly:
        this PR matched the filter):
        `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:semantic-conflict" --add-label "fleet:changes-made"`
        `gh pr comment <N> --repo jakildev/IrredenEngine --body "Resolved semantic conflict: <one-line summary of what you reconciled>. Build clean. Reviewer please re-evaluate the rebased diff. — opus-worker"`
+       **If the PR also carries `fleet:human-deferred`, drop it.** Your
+       push added new commits, so the deferral — which covered the diff
+       as it stood at defer time — no longer holds. Dropping it re-enters
+       the PR into normal review (which honors the linked issue and does
+       NOT re-raise the deferred concern); leaving it on would strand
+       your conflict resolution from review. The label may be absent, so
+       use the idempotent wrapper rather than a combined `--remove-label`:
+       `fleet-pr-clear-feedback-labels <N> --labels "fleet:human-deferred"`
        Also clear the merger's cooldown label if still present — prevents
        one unnecessary iteration delay before the PR can be re-evaluated
        (the merger clears it anyway on next tick, but this makes it

--- a/.claude/commands/role-sonnet-reviewer.md
+++ b/.claude/commands/role-sonnet-reviewer.md
@@ -94,9 +94,14 @@ treat it as a hard rule for this role.
      projection already excludes these, so you should never see one.
      Re-enters with `fleet:changes-made` when the claim releases.
    - `fleet:human-deferred` — author chose DEFER mode: acknowledged
-     concerns, filed a follow-up issue, and the human decides to
-     merge as-is or re-add `human:needs-fix` to force inline fixes.
-     Do NOT re-apply `fleet:needs-fix` for deferred concerns.
+     concerns, filed a follow-up issue. This parks the deferred
+     concern on the diff as it stood at defer time — it is NOT a
+     merge-gate. Skip *while the diff is unchanged*, and never
+     re-apply `fleet:needs-fix` for the deferred concern. But if new
+     commits landed after the defer (the label was dropped, or
+     `human:re-review` is set, or a conflict-resolution comment is
+     present), review the NEW diff on its merits — just don't re-raise
+     the deferred concern (the linked issue tracks it).
    - `fleet:semantic-conflict` — merger detected a non-mechanical
      rebase conflict; the opus-worker is queued to attempt
      resolution. The PR's diff against master is meaningless until
@@ -129,7 +134,9 @@ iteration of polling, reviewing, and exiting cleanly:
    - `fleet:human-amending` — author actively addressing human feedback
    - `fleet:amending-*` — author holds an amend claim on a `fleet:needs-fix`
      fix; scout already excludes these (re-enters with `fleet:changes-made`)
-   - `fleet:human-deferred` — DEFER mode; human decides to merge or re-flag
+   - `fleet:human-deferred` — DEFER mode: parks the deferred concern on
+     the unchanged diff (not a merge-gate). Skip only while unchanged;
+     review post-defer commits, honoring the linked issue
    - `fleet:semantic-conflict` — merger conflict pending resolution
    - `fleet:fork-of-other-pr` — inherited commits; skip until `rebase --onto`
    - any label starting with `fleet:reviewing-` — another reviewer

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -233,10 +233,13 @@ that needs justification in the linked issue.
      --add-label "fleet:changes-made"
    ```
 3. **Keep `fleet:approved`** — the PR is internally consistent;
-   the prior reviewer approval stands. `fleet:human-deferred`
-   signals: "agent acknowledged the concerns, linked issue tracks
-   them, human decides whether to merge as-is or re-add
-   `human:needs-fix` to force AMEND mode."
+   the prior reviewer approval stands. `fleet:human-deferred` parks
+   re-review of the deferred concern on the diff as it stands now —
+   it is NOT a merge-gate (every PR is human-merged). It holds only
+   while the diff is unchanged: if later commits land (a conflict
+   resolution, a human push), whoever pushes drops the label and the
+   PR re-enters normal review, which honors the linked issue and does
+   not re-raise the deferred concern.
 4. Comment on the PR linking the issue:
    ```
    gh pr comment <N> --body "Escalated — filed issue #<M> for the \
@@ -246,7 +249,8 @@ that needs justification in the linked issue.
    ```
 5. Release the step-a claim (the label swap above is complete, so the
    PR is in its terminal ESCALATE state — `fleet:human-deferred` keeps
-   reviewers off it independently):
+   reviewers off the now-static diff independently, until new commits
+   land and the pusher drops it):
    ```
    fleet-claim amending-release <N> <your-worktree-basename>
    ```
@@ -516,6 +520,10 @@ signals layered on top of it, not concurrency guards.
   KEEPS `fleet:approved`, then releases the claim. Human reviews the
   linked issue and either accepts the deferral (PR ready to merge) or
   re-adds `human:needs-fix` to force AMEND mode on the next iteration.
+  `fleet:human-deferred` parks the deferred concern on the diff at
+  defer time, not the PR forever — it is NOT a merge-gate. If new
+  commits land (e.g. a conflict resolution), the pusher drops the
+  label and review resumes on the new diff, honoring the linked issue.
 
 Human can add multiple comments before re-tagging; ALL are picked
 up when the tag appears.

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -294,15 +294,29 @@ Specifically, **never pass these via `--label` when filing**:
     a follow-up issue rather than amending this PR. Set atomically
     with `fleet:changes-made` when the worker removes `human:needs-fix`
     (both in one `gh pr edit` call to prevent a labeless gap where
-    the reviewer could re-apply `fleet:needs-fix`). **Kept** until
-    the human either accepts the deferral (PR merges with this label)
-    or re-adds `human:needs-fix` to force AMEND mode on the next
-    iteration. `fleet:approved` is kept (PR is internally OK).
-    **Reviewer agents skip PRs with this label** — the human is the
-    decision-maker; do NOT re-apply `fleet:needs-fix` for deferred
-    concerns.
-    **Read as: "agent acknowledged your concerns, linked issue
-    tracks them, you decide whether to merge as-is or re-flag."**
+    the reviewer could re-apply `fleet:needs-fix`). `fleet:approved`
+    is kept (PR is internally OK).
+    **Scope: it parks re-review of the deferred concern on the diff
+    as it stood at defer time. It is NOT a merge-gate.** Every PR is
+    human-merged, so "the human decides whether to merge" is true of
+    every approved PR and is *not* what this label is for. While the
+    diff is unchanged, reviewer agents leave it alone and never
+    re-apply `fleet:needs-fix` for the deferred concern — the human is
+    the decision-maker on it.
+    **New commits invalidate the deferral's scope.** If a semantic-
+    conflict resolution, a rebase, or a human/agent push lands after
+    the defer, whoever pushes drops `fleet:human-deferred` (a human can
+    instead set `human:re-review`) and the PR re-enters normal review.
+    On that pass the reviewer reviews the NEW diff but honors the
+    linked issue — it does not re-raise the deferred concern. Without
+    this, deferring one concern would strand unrelated new code
+    (e.g. a conflict fix) from review indefinitely.
+    Cleared when the human accepts the deferral and merges, re-adds
+    `human:needs-fix` to force AMEND, or a pusher drops it on new
+    commits.
+    **Read as: "agent acknowledged your concerns, linked issue tracks
+    them; the deferral covers the diff at defer time, not the PR
+    forever."**
 - `fleet:design-blocked` / `fleet:design-unblocked` — paired
   state qualifiers for the mid-task design-escalation cycle (see
   [`FLEET.md`](FLEET.md) "Design-escalation flow"). `design-blocked` is set by the

--- a/scripts/fleet/fleet-pr-clear-feedback-labels
+++ b/scripts/fleet/fleet-pr-clear-feedback-labels
@@ -19,9 +19,9 @@
 #
 # Note: fleet:human-deferred is NOT in the default set — it is an
 # ESCALATE-path outcome, not a feedback trigger. It is cleared
-# separately via --labels "fleet:human-deferred" only on the
-# human:needs-fix / human:blocker ESCALATE→AMEND path in
-# FLEET-FEEDBACK-HANDLING.md step b.
+# separately via --labels "fleet:human-deferred" on two paths:
+#   1. human:needs-fix / human:blocker ESCALATE→AMEND (FLEET-FEEDBACK-HANDLING.md step b)
+#   2. opus-worker step 1c.i (semantic-conflict resolution invalidates the prior deferral)
 #
 # Usage:
 #   fleet-pr-clear-feedback-labels <N> [--repo <slug>] [--labels <csv>]

--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -80,7 +80,7 @@ rearm_llm() {
 # smoke verification would be invalidated by a rebase; fork-of-other-pr
 # is coordinated manually.
 #
-# `fleet:human-deferred` is intentionally NOT skipped (re-scoped, #1643).
+# `fleet:human-deferred` is intentionally NOT skipped (re-scoped, #1712).
 # A deferred PR is approved and idle — its *review feedback* is parked in
 # a follow-up issue, but its branch is no one's active edit. A mechanical
 # rebase keeps it mergeable instead of letting it accumulate conflicts as

--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -73,15 +73,24 @@ rearm_llm() {
 # Labels that park a PR away from tier-0 entirely (no rebase, no LLM
 # re-arm on their account — another agent or the human owns the next
 # move). Mirrors role-merger.md step 3's skip set: semantic conflicts /
-# human-deferred / needs-info belong to other agents or the human;
-# wip/amending branches are being actively rewritten by their author; the
-# needs-fix/blocker family means a review owes a change and a surprise
-# force-push mid-fix is hostile; design-blocked PRs are parked under an
-# architect; a pending smoke verification would be invalidated by a
-# rebase; fork-of-other-pr is coordinated manually. Single source: the
-# python triage below reads this via FLEET_REBASE_SKIP_RE and the
-# pre-push re-verify greps it directly.
-SKIP_LABEL_RE='fleet:semantic-conflict|fleet:human-deferred|fleet:wip|human:wip|fleet:needs-fix|human:needs-fix|human:blocker|human:re-review|fleet:design-blocked|fleet:amending-|fleet:blocker|fleet:needs-info|fleet:fork-of-other-pr|fleet:needs-linux-smoke|fleet:needs-macos-smoke'
+# needs-info belong to other agents or the human; wip/amending branches
+# are being actively rewritten by their author; the needs-fix/blocker
+# family means a review owes a change and a surprise force-push mid-fix
+# is hostile; design-blocked PRs are parked under an architect; a pending
+# smoke verification would be invalidated by a rebase; fork-of-other-pr
+# is coordinated manually.
+#
+# `fleet:human-deferred` is intentionally NOT skipped (re-scoped, #1643).
+# A deferred PR is approved and idle — its *review feedback* is parked in
+# a follow-up issue, but its branch is no one's active edit. A mechanical
+# rebase keeps it mergeable instead of letting it accumulate conflicts as
+# master advances (the exact stranding that motivated this change); a
+# CONFLICTING one re-arms the LLM merger pass to resolve, and the
+# opus-worker drops the label on resolution.
+#
+# Single source: the python triage below reads this via
+# FLEET_REBASE_SKIP_RE and the pre-push re-verify greps it directly.
+SKIP_LABEL_RE='fleet:semantic-conflict|fleet:wip|human:wip|fleet:needs-fix|human:needs-fix|human:blocker|human:re-review|fleet:design-blocked|fleet:amending-|fleet:blocker|fleet:needs-info|fleet:fork-of-other-pr|fleet:needs-linux-smoke|fleet:needs-macos-smoke'
 export FLEET_REBASE_SKIP_RE="$SKIP_LABEL_RE"
 
 # Serialization: a second fleet-rebase against the same scratch worktree

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1367,11 +1367,18 @@ def _merger_action_signal(labels, mergeable, base_ref):
     a smoke-runner clears them. Including them as merger candidates
     just makes the merger fire repeatedly to find nothing to do.
 
-    `fleet:human-deferred` is a terminal handoff label — an opus-worker
-    diagnosed the conflict as not-agent-resolvable and filed a follow-up
-    issue; only the human decides (close-as-superseded / replace /
-    reconcile). Re-dispatching the merger just re-triggers the
-    opus-worker thrash cycle (observed game #101, three passes).
+    `fleet:human-deferred` is intentionally NOT skipped. It marks a PR
+    whose *human-review feedback* was deferred to a follow-up issue
+    (approved, internally OK) — NOT a conflict handoff (a failed
+    conflict resolution uses `human:needs-fix`, role-opus-worker.md
+    step j). So the merger treats it like any approved PR: a MERGEABLE
+    one projects merge-ready, a CONFLICTING one projects needs-resolve
+    and the opus-worker resolves it — and drops `fleet:human-deferred`,
+    since new commits invalidate the deferral (role-opus-worker.md step
+    1c.i). The old code skipped it on the theory that re-flagging caused
+    opus-worker thrash (game #101); the real fix is the worker dropping
+    the label on resolution, which breaks that loop without stranding
+    the PR's conflict from the merger.
 
     The human-owes-a-fix labels — `human:needs-fix`, `human:blocker`,
     `fleet:needs-fix`, `human:re-review` — are skipped to keep the
@@ -1395,7 +1402,6 @@ def _merger_action_signal(labels, mergeable, base_ref):
         "fleet:design-proposed",
         "fleet:needs-info", "fleet:needs-linux-smoke",
         "fleet:needs-macos-smoke",
-        "fleet:human-deferred",
         # Human-owes-a-fix labels — mirror role-merger.md step 3. NOT
         # `FEEDBACK_LABELS`: that set carries `fleet:has-nits` (an
         # approved+has-nits PR is still merge-ready, so the merger must

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -147,28 +147,6 @@ class SkipLabelsRemovedFromProjection(unittest.TestCase):
         ])])
         self.assertEqual(_hash(empty), _hash(with_blocker))
 
-    def test_human_deferred_conflicting_dropped(self):
-        # A fleet:human-deferred + CONFLICTING PR is at a terminal
-        # "human owns this decision" state. The merger re-applying
-        # fleet:semantic-conflict causes an opus-worker thrash loop
-        # (observed game #101, three identical passes). The projection
-        # must treat it as invisible so the merger is never dispatched.
-        empty = _state([])
-        deferred = _state([_pr(101, labels=[
-            "fleet:approved", "fleet:human-deferred",
-        ], mergeable="CONFLICTING")])
-        self.assertEqual(_hash(empty), _hash(deferred),
-                         "human-deferred PRs must be invisible to merger")
-
-    def test_human_deferred_mergeable_dropped(self):
-        # Even a MERGEABLE human-deferred PR is not the merger's business —
-        # the deferral label means a human decides the fate.
-        empty = _state([])
-        deferred = _state([_pr(101, labels=[
-            "fleet:approved", "fleet:human-deferred",
-        ], mergeable="MERGEABLE")])
-        self.assertEqual(_hash(empty), _hash(deferred))
-
 
 class HumanOwesFixLabelsDropped(unittest.TestCase):
     """An approved PR that also carries a human-owes-a-fix label must drop
@@ -249,14 +227,25 @@ class SignalSemantics(unittest.TestCase):
         items = project_merger(_state([_pr(101, labels=[])]))
         self.assertEqual(items, [])
 
-    def test_human_deferred_conflicting_not_needs_resolve(self):
-        # fleet:human-deferred marks a terminal handoff state; the merger
-        # must not classify it as needs-resolve and re-apply
-        # fleet:semantic-conflict (game #101 thrash).
+    def test_human_deferred_conflicting_is_needs_resolve(self):
+        # Re-scoped (PR #1643): fleet:human-deferred marks a deferred
+        # *review concern* tracked in a follow-up issue, NOT a conflict
+        # handoff. A conflicting deferred PR is flagged like any approved
+        # PR; the opus-worker resolves it and drops the label (new commits
+        # invalidate the deferral). The old "invisible to merger" behavior
+        # stranded the PR's conflict from resolution.
         items = project_merger(_state([_pr(101, labels=[
             "fleet:approved", "fleet:human-deferred",
         ], mergeable="CONFLICTING")]))
-        self.assertEqual(items, [])
+        self.assertEqual(items[0]["signal"], "needs-resolve")
+
+    def test_human_deferred_mergeable_is_merge_ready(self):
+        # A MERGEABLE deferred PR is just an approved PR awaiting the
+        # human's merge/re-flag decision — treated like any approved PR.
+        items = project_merger(_state([_pr(101, labels=[
+            "fleet:approved", "fleet:human-deferred",
+        ], mergeable="MERGEABLE")]))
+        self.assertEqual(items[0]["signal"], "merge-ready")
 
 
 class FailThenSucceedStackedRebase(unittest.TestCase):

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -228,7 +228,7 @@ class SignalSemantics(unittest.TestCase):
         self.assertEqual(items, [])
 
     def test_human_deferred_conflicting_is_needs_resolve(self):
-        # Re-scoped (PR #1643): fleet:human-deferred marks a deferred
+        # Re-scoped (PR #1712): fleet:human-deferred marks a deferred
         # *review concern* tracked in a follow-up issue, NOT a conflict
         # handoff. A conflicting deferred PR is flagged like any approved
         # PR; the opus-worker resolves it and drops the label (new commits


### PR DESCRIPTION
## Summary

`fleet:human-deferred` was being treated as a blanket *"reviewers and the merger stay off this PR forever"* switch. It is actually the **ESCALATE disposition of human review feedback**: the worker filed the human's concern as a follow-up issue and kept `fleet:approved`. Its only job is to stop reviewers re-raising that **one deferred concern** — it is **not** a merge-gate (every PR is human-merged) and it should not strand the whole PR.

This came out of **#1643**: a `fleet:human-deferred` PR hit a semantic conflict, but
- the **scout** excluded `fleet:human-deferred` from the merger projection — on a comment that *wrongly* described the label as a "conflict not-agent-resolvable handoff" (that handoff actually uses `human:needs-fix`), and
- **`fleet-rebase`** skipped it from tier-0 auto-rebase,

so it accumulated conflicts as `master` moved and no agent could pick it up. It only moved when a human pulled in an architect by hand.

## The re-scope (end to end)

| Surface | Change |
|---|---|
| `role-sonnet-reviewer.md`, `role-opus-reviewer.md` | Skip **only while the diff is unchanged** since the defer. Review post-defer commits (conflict resolutions, human pushes) on their merits, honoring the linked issue — never re-raise the deferred concern. |
| `role-opus-worker.md` | The semantic-conflict success path now **drops `fleet:human-deferred`** — new commits invalidate the deferral's scope. |
| `fleet-labels-reference.md`, `FLEET-FEEDBACK-HANDLING.md` | Reframe the label as a **concern-scoped parking marker**, explicitly **not a merge-gate**; new commits drop it. |
| `fleet-state-scout` | Stop excluding `fleet:human-deferred` from the merger projection; correct the misleading comment. A CONFLICTING deferred PR now projects `needs-resolve`, a MERGEABLE one `merge-ready` — like any approved PR. |
| `fleet-rebase` | Stop skipping `fleet:human-deferred` from tier-0 auto-rebase, so a deferred PR is kept mergeable instead of stranding. |
| `test_merger_projection.py` | Flip the three assertions to the new behavior. |

The old thrash the scout exclusion guarded against (game #101) is broken by the worker dropping the label on resolution, so re-flagging no longer loops.

## Test plan
- [x] `test_merger_projection.py` — 30 pass (deferred CONFLICTING → `needs-resolve`, MERGEABLE → `merge-ready`)
- [x] All 15 `scripts/fleet/tests/test_*.py` pass
- [x] `fleet-state-scout` parses (`ast.parse`)

Motivated by #1643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)