### PR TITLE
fleet: don't dispatch workers for queued tasks with an open PR (#1726)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1107,16 +1107,19 @@ dispatch_role() {
     # multiple panes dispatched this tick race-claim within the class.
     resolve_worker_class "$role"
     if (( DISPATCH_DEFER )); then
-        # Only cap-blocked fable work is actionable. Dispatching the lane
-        # default would burn an iteration on gate-refused claims; keep
-        # the trigger and wait for a fable slot to free up.
-        if [[ -z "${CAP_DEFER_LOGGED[$role-fable]+x}" ]]; then
-            log "$role: only fable-class work actionable but fable cap ($FABLE_CONCURRENCY_CAP) is full; deferring trigger"
-            CAP_DEFER_LOGGED["$role-fable"]=1
+        # Nothing a fresh worker can claim right now: either the only
+        # actionable work is cap-blocked fable, or the queue's only items
+        # already have open implementation PRs (inflight_pr, #1726).
+        # Dispatching the lane default would burn an iteration on
+        # gate-refused claims; keep the trigger and wait (a freed fable
+        # slot or a resolved/merged PR re-fires the scout projection).
+        if [[ -z "${CAP_DEFER_LOGGED[$role-noclaim]+x}" ]]; then
+            log "$role: no claimable work (cap-blocked fable or in-flight PRs only); deferring trigger"
+            CAP_DEFER_LOGGED["$role-noclaim"]=1
         fi
         return
     fi
-    unset "CAP_DEFER_LOGGED[$role-fable]"
+    unset "CAP_DEFER_LOGGED[$role-noclaim]"
 
     local dispatched=0
     local gap_blocked=""

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -34,7 +34,7 @@ from pathlib import Path
 # python. Insert this script's own dir so the import resolves whether the
 # scout is run directly or loaded by-path in the unit tests (#1425).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from fleet_branch_match import branch_matches_issue
+from fleet_branch_match import branch_matches_issue, PARKED_PR_LABELS
 
 ENGINE = Path.home() / "src" / "IrredenEngine"
 GAME = ENGINE / "creations" / "game"
@@ -1242,6 +1242,42 @@ def enrich_stackable_blocker_prs(state):
             }
 
 
+def enrich_inflight_pr_tasks(state):
+    # A queued task whose OWN issue (#N) already has an open implementation PR
+    # (branch `claude/<N>-…`) is not something a fresh worker can claim off the
+    # queue: the PR is either active work or parked awaiting a design answer,
+    # and the resume path in both cases is the feedback / design-unblocked tier,
+    # not a fresh queue claim. The scout already routes actively-claimed tasks
+    # (fleet:in-progress) into tasks.in_progress, but a *parked* design-blocked
+    # PR releases its issue-side claim during the escalation flow — so its task
+    # drops back into tasks.open looking owner-free and claimable, while a fresh
+    # worker would (correctly) refuse it on sight. That projection/behaviour
+    # mismatch let the dispatch resolver keep electing such a task head-of-queue
+    # and churn no-op opus dispatches, starving fable work behind it (#1726 —
+    # the #1640 / PR #1700 incident). Tag the task with `inflight_pr` so
+    # fleet_task_class._task_claimable skips it; the projection item carried in
+    # the role trigger hash is unchanged (id + blocked_by), so this adds no
+    # spurious trigger churn — only the resolver's claimable filter sees it.
+    for repo_key, repo_state in state["repos"].items():
+        prs = repo_state.get("prs", [])
+        for task in repo_state.get("tasks", {}).get("open", []):
+            issue_num = (task.get("issue") or "").lstrip("#")
+            if not issue_num:
+                continue
+            match = next(
+                (pr for pr in prs
+                 if branch_matches_issue(pr.get("headRefName", ""), issue_num, repo_key)),
+                None,
+            )
+            if match is None:
+                continue
+            task["inflight_pr"] = {
+                "number": match.get("number"),
+                "headRefName": match.get("headRefName", ""),
+                "parked": bool(set(match.get("labels", [])) & PARKED_PR_LABELS),
+            }
+
+
 # Narrowed label sets stored in the per-role hash item. Storing the full
 # pr["labels"] list here re-flips the projection hash on every transient
 # label change (merger toggling fleet:merger-cooldown, reviewers swapping
@@ -1976,6 +2012,7 @@ def tick_once():
     resolve_human_approved_blockers(state)
     resolve_epic_children(state)
     enrich_stackable_blocker_prs(state)
+    enrich_inflight_pr_tasks(state)
     write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
 
     try:

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -23,10 +23,11 @@ else the class default below.
 
 The fable concurrency cap is enforced here by *skipping* fable items when
 the cap is reached — the lane then serves its next non-fable item instead
-of idling. When fable items were skipped and nothing else is actionable,
-the verdict is ``defer`` (keep the trigger, dispatch nothing) rather than
-an empty result, so the dispatcher doesn't burn an iteration on a lane
-whose only work is gate-refused.
+of idling. When the only work left is non-actionable — cap-blocked fable,
+or tasks already covered by an open implementation PR (``inflight_pr``,
+#1726) — the verdict is ``defer`` (keep the trigger, dispatch nothing)
+rather than an empty result, so the dispatcher doesn't burn an iteration
+on a lane whose only work a fresh worker would refuse.
 
 Output protocol (one line on stdout, consumed by fleet-dispatcher):
 
@@ -34,7 +35,10 @@ Output protocol (one line on stdout, consumed by fleet-dispatcher):
                                   claimable items of a *different* class
                                   remain (keep the trigger so the next tick
                                   serves them), else 0.
-  ``defer``                     — only cap-blocked fable work right now.
+  ``defer``                     — queue isn't empty but nothing is claimable
+                                  right now (only cap-blocked fable, or tasks
+                                  with an open implementation PR). Keep the
+                                  trigger; dispatch nothing.
   (empty)                       — nothing class-routable in the slice; the
                                   dispatcher falls back to the lane default
                                   (this path covers reservation resumes and
@@ -52,7 +56,31 @@ FEEDBACK_BLOCKING_LABELS = {"human:needs-fix", "human:blocker", "fleet:needs-fix
 
 
 def _task_claimable(task):
-    return task.get("owner") in (None, "", "free") and not task.get("blocked")
+    # `inflight_pr` (set by the scout) means an open PR already implements this
+    # issue — parked on a design question or otherwise in flight — so a fresh
+    # worker can't start it off the queue. Skipping it here stops the dispatcher
+    # churning no-op iterations on a head-of-queue task every candidate refuses,
+    # which was starving lower-class work queued behind it (#1726, the #1640 /
+    # design-blocked PR #1700 incident).
+    return (
+        task.get("owner") in (None, "", "free")
+        and not task.get("blocked")
+        and not task.get("inflight_pr")
+    )
+
+
+def _only_inflight_pr_tasks(slice_data):
+    """True when tasks_open is non-empty and EVERY item is non-actionable
+    solely because an open PR already implements it (`inflight_pr`).
+
+    Used to pick 'go quiet' (defer) over the lane-default dispatch fallthrough:
+    in this shape a fresh worker can claim nothing, so a dispatch is a no-op.
+    Requiring *all* items to be inflight keeps a mixed slice (an inflight head
+    plus a stackable `blocked` task behind it) on the '' fallthrough so the
+    worker's stackable tier still gets its dispatch.
+    """
+    tasks = slice_data.get("tasks_open") or []
+    return bool(tasks) and all(t.get("inflight_pr") for t in tasks)
 
 
 def feedback_pr_class(labels):
@@ -105,10 +133,23 @@ def resolve(slice_data, lane_default, fable_blocked):
         servable_classes.add(cls)
         if chosen is None:
             chosen = (cls, effort)
-    if chosen is None:
-        return "defer" if skipped_fable else ""
-    more = 1 if servable_classes - {chosen[0]} else 0
-    return f"{chosen[0]} {chosen[1]} {more}"
+    if chosen is not None:
+        more = 1 if servable_classes - {chosen[0]} else 0
+        return f"{chosen[0]} {chosen[1]} {more}"
+    if skipped_fable:
+        return "defer"
+    # Nothing servable AND no cap-blocked fable. If the queue's only content is
+    # tasks already implemented by an open PR (every tasks_open item carries
+    # `inflight_pr`), a lane-default dispatch is a guaranteed no-op — a fresh
+    # worker refuses every one on sight — so the lane goes quiet (defer) instead
+    # of churning that no-op every tick (#1726). Any other shape (a claimable
+    # task would have been chosen above; a plain `blocked` task may still be
+    # stackable; an owned task, an empty/missing slice) returns '' so the
+    # dispatcher's lane-default fallthrough keeps covering the stackable tier,
+    # reservation resumes, and missing slices.
+    if _only_inflight_pr_tasks(slice_data):
+        return "defer"
+    return ""
 
 
 def main(argv):

--- a/scripts/fleet/tests/test_enrich_inflight_pr_tasks.py
+++ b/scripts/fleet/tests/test_enrich_inflight_pr_tasks.py
@@ -1,0 +1,133 @@
+"""Tests for enrich_inflight_pr_tasks() in fleet-state-scout.
+
+A queued task whose own issue already has an open implementation PR (branch
+`claude/<N>-…`) is non-actionable off the queue — a parked design-blocked PR
+releases its issue-side claim, so the task drops back into tasks.open looking
+free while a fresh worker would refuse it. The enrichment tags it `inflight_pr`
+so the dispatch resolver skips it (#1726, the #1640 / PR #1700 incident).
+
+Import the function via importlib because the script has no .py extension.
+"""
+import importlib.machinery
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+enrich_inflight_pr_tasks = _mod.enrich_inflight_pr_tasks
+
+
+def _state(engine_tasks=None, engine_prs=None, game_tasks=None, game_prs=None):
+    return {
+        "repos": {
+            "engine": {
+                "tasks": {"open": engine_tasks or []},
+                "prs": engine_prs or [],
+            },
+            "game": {
+                "tasks": {"open": game_tasks or []},
+                "prs": game_prs or [],
+            },
+        }
+    }
+
+
+def _task(id_):
+    # The enrichment keys on the task's OWN issue number; mirror the scout's
+    # fetch_task_queue shape where `issue` == `id` == "#N".
+    return {"id": id_, "issue": id_}
+
+
+def _pr(number, head_ref, labels=None):
+    return {"number": number, "headRefName": head_ref, "labels": labels or []}
+
+
+class TestEnrichInflightPrTasks(unittest.TestCase):
+
+    def test_parked_design_blocked_pr_tags_inflight(self):
+        # The #1640 case: open task whose own PR is fleet:wip + design-blocked.
+        tasks = [_task("#1640")]
+        prs = [_pr(1700, "claude/1640-metal-foreign-canvas-r32i-read",
+                   labels=["fleet:wip", "fleet:design-blocked", "fleet:opus"])]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_inflight_pr_tasks(state)
+        out = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("inflight_pr", out)
+        self.assertEqual(out["inflight_pr"]["number"], 1700)
+        self.assertEqual(out["inflight_pr"]["headRefName"],
+                         "claude/1640-metal-foreign-canvas-r32i-read")
+        self.assertTrue(out["inflight_pr"]["parked"])
+
+    def test_active_wip_pr_tags_inflight_not_parked(self):
+        # A plain fleet:wip PR (orphaned / mid-flight) is still in flight: a
+        # fresh queue claim is the wrong action, so it's tagged — parked False.
+        tasks = [_task("#1640")]
+        prs = [_pr(1700, "claude/1640-metal-foreign-canvas-r32i-read",
+                   labels=["fleet:wip"])]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_inflight_pr_tasks(state)
+        out = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("inflight_pr", out)
+        self.assertFalse(out["inflight_pr"]["parked"])
+
+    def test_no_matching_pr_no_field(self):
+        tasks = [_task("#1640")]
+        prs = [_pr(1700, "claude/9999-unrelated", labels=["fleet:wip"])]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_inflight_pr_tasks(state)
+        self.assertNotIn("inflight_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_empty_prs_no_field(self):
+        tasks = [_task("#1640")]
+        state = _state(engine_tasks=tasks, engine_prs=[])
+        enrich_inflight_pr_tasks(state)
+        self.assertNotIn("inflight_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_prefix_discrimination(self):
+        # #164's task must not match a claude/1640- branch (trailing dash).
+        tasks = [_task("#164")]
+        prs = [_pr(1700, "claude/1640-metal", labels=["fleet:wip"])]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_inflight_pr_tasks(state)
+        self.assertNotIn("inflight_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_cross_repo_isolation(self):
+        # An engine task must not match a same-numbered game PR.
+        tasks = [_task("#101")]
+        game_prs = [_pr(5, "claude/101-in-game-repo", labels=["fleet:wip"])]
+        state = _state(engine_tasks=tasks, engine_prs=[], game_prs=game_prs)
+        enrich_inflight_pr_tasks(state)
+        self.assertNotIn("inflight_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_game_legacy_branch_prefix_matches(self):
+        # Game accepts both claude/<N>- and the legacy claude/game-<N>- form.
+        tasks = [_task("#101")]
+        game_prs = [_pr(5, "claude/game-101-unit-movement", labels=["fleet:wip"])]
+        state = _state(game_tasks=tasks, game_prs=game_prs)
+        enrich_inflight_pr_tasks(state)
+        out = state["repos"]["game"]["tasks"]["open"][0]
+        self.assertIn("inflight_pr", out)
+        self.assertEqual(out["inflight_pr"]["number"], 5)
+
+    def test_multiple_tasks_independent(self):
+        tasks = [_task("#1640"), _task("#1726")]
+        prs = [_pr(1700, "claude/1640-metal", labels=["fleet:design-blocked"])]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_inflight_pr_tasks(state)
+        open_tasks = state["repos"]["engine"]["tasks"]["open"]
+        self.assertIn("inflight_pr", open_tasks[0])
+        # #1726 has no matching PR -> stays claimable.
+        self.assertNotIn("inflight_pr", open_tasks[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -25,9 +25,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from fleet_task_class import resolve, feedback_pr_class  # noqa: E402
 
 
-def _task(issue, model=None, effort=None, owner="free", blocked=False):
+def _task(issue, model=None, effort=None, owner="free", blocked=False,
+          inflight_pr=None):
     return {"issue": issue, "model": model, "effort": effort,
-            "owner": owner, "blocked": blocked}
+            "owner": owner, "blocked": blocked, "inflight_pr": inflight_pr}
 
 
 class FeedbackClassFromLabels(unittest.TestCase):
@@ -70,6 +71,47 @@ class TaskResolution(unittest.TestCase):
                                       _task("#12", "opus")]},
                       "opus", fable_blocked=False)
         self.assertEqual(out, "opus xhigh 0")
+
+    def test_inflight_pr_task_skipped_fable_behind_dispatches(self):
+        # #1726 / the #1640 incident: a head-of-queue opus task whose own issue
+        # already has an open (parked design-blocked) PR is non-actionable. The
+        # scout tags it `inflight_pr`; the resolver must skip it AND not count
+        # it toward `more`, so the fable task queued behind it dispatches
+        # instead of the lane churning no-op opus iterations on the parked head.
+        out = resolve({"tasks_open": [
+            _task("#1640", "opus", inflight_pr={"number": 1700, "parked": True}),
+            _task("#1695", "fable"),
+        ]}, "opus", fable_blocked=False)
+        self.assertEqual(out, "fable xhigh 0")
+
+    def test_inflight_pr_only_candidate_defers(self):
+        # The parked task is the ONLY queue item: nothing a fresh worker can
+        # claim, so the lane goes quiet (defer) rather than churning a
+        # lane-default no-op dispatch every tick (#1726 DoD: "goes quiet").
+        out = resolve({"tasks_open": [
+            _task("#1640", "opus", inflight_pr={"number": 1700, "parked": True}),
+        ]}, "opus", fable_blocked=False)
+        self.assertEqual(out, "defer")
+
+    def test_inflight_head_with_blocked_stackable_falls_through(self):
+        # Mixed slice: inflight head + a plain `blocked` task that may still be
+        # stackable. Must NOT defer — '' lets the dispatcher's lane-default
+        # fallthrough reach the worker's stackable tier for the blocked task.
+        out = resolve({"tasks_open": [
+            _task("#1640", "opus", inflight_pr={"number": 1700, "parked": True}),
+            _task("#1641", "opus", blocked=True),
+        ]}, "opus", fable_blocked=False)
+        self.assertEqual(out, "")
+
+    def test_inflight_pr_head_with_capped_fable_defers(self):
+        # Head parked (skipped), only remaining work is cap-blocked fable ->
+        # defer (keep trigger, dispatch nothing) rather than electing the
+        # parked opus head.
+        out = resolve({"tasks_open": [
+            _task("#1640", "opus", inflight_pr={"number": 1700, "parked": True}),
+            _task("#1695", "fable"),
+        ]}, "opus", fable_blocked=True)
+        self.assertEqual(out, "defer")
 
     def test_feedback_beats_tasks(self):
         out = resolve({"feedback_prs": [{"labels": ["fleet:has-nits"]}],


### PR DESCRIPTION
## Summary

A queued issue whose implementation PR is already open but parked on a design question (#1640 / PR #1700 — `fleet:wip` + `fleet:design-blocked`) projected as **claimable**: the scout's `blocked` slice is driven only by the `fleet:blocked` label, and a parked PR releases its issue-side claim during the design-escalation flow, so the task drops back into `tasks.open` looking owner-free. The dispatch resolver then re-elected it head-of-queue every tick, churning no-op `[opus]` iterations a fresh worker refuses on sight — and starving the fable-class task queued behind it (the resolver kept choosing the opus head, so the raised fable cap never engaged).

Fix is the issue's **first fix direction (projection-side)**, made lane-agnostic so it survives the worker-lane unification (#1707/#1710):

- **Scout** `enrich_inflight_pr_tasks` tags any open task whose **own** issue already has an open implementation PR (branch `claude/<N>-…`) with an `inflight_pr` field — reusing the existing `branch_matches_issue` join and `PARKED_PR_LABELS` classifier. The trigger-hash projection item (`id` + `blocked_by`) is unchanged, so this adds **no** spurious trigger churn; only the resolver's claimable filter sees the field.
- **Resolver** `_task_claimable` skips tasks carrying `inflight_pr`, so the fable task behind a parked head dispatches.
- **Resolver** returns `defer` (keep trigger, dispatch nothing) instead of falling through to a lane-default no-op when the queue's only items are *all* inflight. A mixed slice (inflight head + a stackable `blocked` task) still returns `''` so the worker's stackable tier keeps its lane-default dispatch.
- **Dispatcher** defer log generalized to name both defer reasons (cap-blocked fable / in-flight PRs).

### DoD mapping
- *Queued issue with an open design-blocked WIP PR → zero worker dispatches for it* — `inflight_pr` makes it non-claimable; the lane defers (or serves real work) instead of churning.
- *Lane whose only candidates are non-actionable goes quiet (defer), lower-class work behind it still dispatches* — both covered by the resolver changes.
- *Regression simulating the #1640 state in `tests/test_fleet_task_class.py`* — added.

## Test plan
- [x] `tests/test_fleet_task_class.py` — inflight head + fable behind → `fable xhigh 0`; inflight-only → `defer`; inflight + stackable-blocked → `''` fallthrough (17 tests pass).
- [x] `tests/test_enrich_inflight_pr_tasks.py` — new: parked/active PR tag, prefix discrimination, cross-repo isolation, legacy `game-` prefix, multi-task independence (8 tests pass).
- [x] `test_dispatcher_class_dispatch.sh` (7/7), full `scripts/fleet/tests/*.py` suite green (pre-existing `test_merger_projection` failure on master is unrelated — it references the removed `project_opus_worker` from the worker-lane unification).
- [x] `bash -n` + `py_compile` clean on the touched scripts.

Closes #1726

🤖 Generated with [Claude Code](https://claude.com/claude-code)