### PR TITLE
audio: multi-port MIDI I/O with per-port source identity

### DIFF
--- a/engine/audio/CLAUDE.md
+++ b/engine/audio/CLAUDE.md
@@ -18,23 +18,38 @@ functions:
 
 ## AudioManager owns
 
-- **`MidiIn`** — one `RtMidiIn`, populates per-channel maps of
-  `MidiMessage`s each `tick()`. Cleared and refilled every frame.
-- **`MidiOut`** — one `RtMidiOut`, fire-and-forget send.
+- **`MidiIn`** — one `RtMidiIn` per simultaneously-open input port, each
+  with its own callback queue. `tick()` drains every port's queue into a
+  `MidiInputFrameBuffer` (cleared and refilled each frame) that keeps both a
+  merged all-ports per-channel view and a per-port view.
+- **`MidiOut`** — one `RtMidiOut` per open output port; fire-and-forget send
+  to the default (first-opened) port, or to a specific port by index.
 - **`Audio`** — `RtAudio` wrapper for microphone/line-in. Implements
   `IAudioCaptureSource`. Used by `VideoManager` for recording soundtracks.
 
 ## MIDI model
 
-- **`MidiChannel`** is the map key. `MidiIn` exposes
-  `ccMessagesThisFrame(channel)`, `noteOnsThisFrame(channel)`, etc.
-- `MidiIn::tick()` is called by the INPUT pipeline; it drains the RtMidi
-  callback queue into per-frame containers. **State is cleared every
-  frame** — no history. Systems must read during their tick or they miss
-  the event.
+- **`MidiChannel`** is the map key. Query `IRAudio::checkCCMessage(channel,
+  cc)` / `getMidiNotesOnThisFrame(channel)` for the **merged** all-ports
+  view, or the port-scoped `checkCCMessage(portIndex, channel, cc)` /
+  `getMidiNotesOnThisFrame(portIndex, channel)` to disambiguate same-channel
+  traffic across ports. `openPortMidiIn`/`openPortMidiOut` return the RtMidi
+  port index — the stable handle used as the source-port id, the
+  `sendMidiMessage(portIndex, …)` target, and the per-port query key.
+  `midiInOpenPorts()` / `midiOutOpenPorts()` enumerate the open handles.
+- Inbound message entities carry `C_MidiSourcePort{portIndex}`; the
+  `InputMidiMessageIn` system reads it to route each message into both the
+  merged and per-port views. **Merged CC collapses same-channel+cc traffic
+  (last write wins)** — use the per-port query when two devices share a
+  channel.
+- `MidiIn::tick()` is called by the INPUT pipeline; it drains every open
+  port's RtMidi callback queue into the per-frame buffer. **State is cleared
+  every frame** — no history. Systems must read during their tick or they
+  miss the event.
 - Device names are substring-matched at `openPort()` time, with hardcoded
   fallback patterns for common devices (UMC1820, Focusrite, MPKmini2,
   OP-1). Edit `midi_in.cpp` / `midi_out.cpp` to add a new hardware match.
+  Opening an already-open port is a no-op that returns the existing handle.
 
 ## Audio capture model
 

--- a/engine/audio/include/irreden/audio/midi_in.hpp
+++ b/engine/audio/include/irreden/audio/midi_in.hpp
@@ -86,7 +86,7 @@ class MidiIn {
     void clearPreviousMessages();
 };
 
-void readMessageTestCallbackNew(
+void onRtMidiMessage(
     double deltaTime, std::vector<unsigned char> *message, void *userData
 );
 

--- a/engine/audio/include/irreden/audio/midi_in.hpp
+++ b/engine/audio/include/irreden/audio/midi_in.hpp
@@ -4,27 +4,32 @@
 #include <irreden/ir_profile.hpp>
 
 #include <irreden/audio/ir_audio_types.hpp>
-#include <irreden/audio/midi_messages.hpp>
+#include <irreden/audio/midi_input_frame_buffer.hpp>
 #include <irreden/audio/components/component_midi_message.hpp>
 
 #include <RtMidi.h>
 
-#include <set>
+#include <memory>
 #include <queue>
-#include <unordered_map>
+#include <string>
+#include <vector>
 
 using IRComponents::C_MidiMessage;
 
 namespace IRAudio {
 
-struct MidiMessageQueues {
-    std::queue<MidiMessage<kMidiStatus_NOTE_OFF>> m_messageQueueNoteOff;
-    std::queue<MidiMessage<kMidiStatus_NOTE_ON>> m_messageQueueNoteOn;
-    std::queue<MidiMessage<kMidiStatus_POLYPHONIC_KEY_PRESSURE>> m_messagePolyKeyPressure;
-    std::queue<MidiMessage<kMidiStatus_CONTROL_CHANGE>> m_messageQueueControlChange;
-    std::queue<MidiMessage<kMidiStatus_PROGRAM_CHANGE>> m_messageQueueProgramChange;
-    std::queue<MidiMessage<kMidiStatus_CHANNEL_PRESSURE>> m_messageQueueChannelPressure;
-    std::queue<MidiMessage<kMidiStatus_PITCH_BEND>> m_messageQueuePitchBend;
+// One simultaneously-open MIDI input port. Each port owns its own RtMidiIn and
+// a single-producer (its RtMidi callback thread) / single-consumer (the main
+// thread, in processMidiMessageQueue) message queue, so two devices can feed
+// the engine at once without one openPort replacing another.
+//
+// rtMidiIn_ is declared last so it destructs first: closing the port stops the
+// callback thread before queue_ (its write target) is torn down.
+struct MidiInPort {
+    std::queue<C_MidiMessage> queue_;
+    int portIndex_;
+    std::string name_;
+    std::unique_ptr<RtMidiIn> rtMidiIn_;
 };
 
 class MidiIn {
@@ -34,46 +39,55 @@ class MidiIn {
 
     void tick();
 
-    // void openPort(unsigned int portNumber);
-
+    // Opens an input port by hardcoded interface enum or by device-name
+    // substring. Returns the RtMidi port index (used as the stable port
+    // handle / source-port id) or -1 if no port matches. Opening an
+    // already-open port is a no-op that returns the existing handle.
     int openPort(MidiInInterfaces midiInInterface);
     int openPort(const std::string &deviceName);
+
     const std::vector<std::string> &getPortNames() const;
+    // RtMidi indices of every currently-open input port (one per device),
+    // in open order — lets a per-port consumer enumerate its lanes.
+    std::vector<int> getOpenPortIndices() const;
+
     void processMidiMessageQueue();
+
+    // Merged queries (all open ports folded together) — the back-compat
+    // surface for consumers that don't disambiguate by port.
     CCData checkCCMessageThisFrame(MidiChannel channel, CCMessage ccNumber) const;
     const std::vector<C_MidiMessage> &getMidiNotesOnThisFrame(MidiChannel channel) const;
     const std::vector<C_MidiMessage> &getMidiNotesOffThisFrame(MidiChannel channel) const;
 
+    // Per-port queries — one device's traffic in isolation.
+    CCData checkCCMessageThisFrame(int portIndex, MidiChannel channel, CCMessage ccNumber) const;
+    const std::vector<C_MidiMessage> &
+    getMidiNotesOnThisFrame(int portIndex, MidiChannel channel) const;
+    const std::vector<C_MidiMessage> &
+    getMidiNotesOffThisFrame(int portIndex, MidiChannel channel) const;
+
+    // Merged-view inserts (no port identity) — retained for the legacy API.
     void insertNoteOffMessage(MidiChannel channel, const C_MidiMessage &midiMessage);
     void insertNoteOnMessage(MidiChannel channel, const C_MidiMessage &midiMessage);
     void insertCCMessage(MidiChannel channel, const C_MidiMessage &midiMessage);
 
+    // Port-aware inserts — fold into both the merged view and the port view.
+    void insertNoteOffMessage(int portIndex, MidiChannel channel, const C_MidiMessage &midiMessage);
+    void insertNoteOnMessage(int portIndex, MidiChannel channel, const C_MidiMessage &midiMessage);
+    void insertCCMessage(int portIndex, MidiChannel channel, const C_MidiMessage &midiMessage);
+
   private:
-    RtMidiIn m_rtMidiIn;
-    std::unordered_map<MidiInInterfaces, RtMidiIn> m_rtMidiInMap;
+    RtMidiIn m_rtMidiIn; // enumeration probe only — never opened for input
     unsigned int m_numberPorts;
     std::vector<std::string> m_portNames;
-    std::vector<unsigned int> m_openPorts;
-    std::string m_portName;
-    MidiMessageQueues m_messageQueues;
-    std::queue<IRComponents::C_MidiMessage> m_messageQueue;
-
-    std::unordered_map<MidiChannel, std::unordered_map<CCMessage, CCData>> m_ccMessagesThisFrame;
-    std::unordered_map<MidiChannel, std::vector<C_MidiMessage>> m_midiNoteOnMessagesThisFrame;
-    std::unordered_map<MidiChannel, std::vector<C_MidiMessage>> m_midiNoteOffMessagesThisFrame;
+    std::vector<std::unique_ptr<MidiInPort>> m_ports;
+    MidiInputFrameBuffer m_frameBuffer;
 
     void clearPreviousMessages();
-
-    void setCallback(
-        RtMidiIn &rtMidiIn,
-        void (*midiInputCallback)(
-            double timeStamp, std::vector<unsigned char> *message, void *userData
-        )
-    );
 };
 
 void readMessageTestCallbackNew(
-    double deltaTime, std::vector<unsigned char> *message, void *userdata
+    double deltaTime, std::vector<unsigned char> *message, void *userData
 );
 
 } // namespace IRAudio

--- a/engine/audio/include/irreden/audio/midi_input_frame_buffer.hpp
+++ b/engine/audio/include/irreden/audio/midi_input_frame_buffer.hpp
@@ -1,0 +1,160 @@
+#ifndef MIDI_INPUT_FRAME_BUFFER_H
+#define MIDI_INPUT_FRAME_BUFFER_H
+
+#include <irreden/audio/ir_audio_types.hpp>
+#include <irreden/audio/components/component_midi_message.hpp>
+
+#include <unordered_map>
+#include <vector>
+
+namespace IRAudio {
+
+// Per-frame snapshot of inbound MIDI state, keyed for both a merged
+// (all-ports) view and a per-port view. MidiIn fills this once per frame from
+// the C_MidiMessage entity stream; consumers poll it during the same frame.
+//
+// Two read scopes:
+//   * Merged (channel only)        — every open input port folded together.
+//     Back-compat surface for consumers that don't care which port a message
+//     arrived on (the historical single-port behaviour).
+//   * Per-port (portIndex+channel) — one port's traffic in isolation, so two
+//     devices sending on the same channel can be told apart.
+//
+// Both scopes are populated by the same insert call; clear() wipes the whole
+// frame. No RtMidi/hardware dependency lives here, which keeps the routing
+// logic unit-testable in isolation from device I/O.
+class MidiInputFrameBuffer {
+  public:
+    // Insert into the merged view only (no port identity). Retained for the
+    // legacy port-less insert API; the entity drainer uses the port-aware
+    // overloads below.
+    void insertCC(MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+        m_merged.insertCC(channel, message);
+    }
+    void insertNoteOn(MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+        m_merged.insertNoteOn(channel, message);
+    }
+    void insertNoteOff(MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+        m_merged.insertNoteOff(channel, message);
+    }
+
+    // Insert into both the merged view and the originating port's view.
+    void insertCC(int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+        m_merged.insertCC(channel, message);
+        m_perPort[portIndex].insertCC(channel, message);
+    }
+    void
+    insertNoteOn(int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+        m_merged.insertNoteOn(channel, message);
+        m_perPort[portIndex].insertNoteOn(channel, message);
+    }
+    void
+    insertNoteOff(int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+        m_merged.insertNoteOff(channel, message);
+        m_perPort[portIndex].insertNoteOff(channel, message);
+    }
+
+    // Merged reads (all ports folded together).
+    CCData checkCC(MidiChannel channel, CCMessage ccNumber) const {
+        return m_merged.checkCC(channel, ccNumber);
+    }
+    const std::vector<IRComponents::C_MidiMessage> &notesOn(MidiChannel channel) const {
+        return m_merged.notesOn(channel);
+    }
+    const std::vector<IRComponents::C_MidiMessage> &notesOff(MidiChannel channel) const {
+        return m_merged.notesOff(channel);
+    }
+
+    // Per-port reads. An unopened/silent port returns kCCFalse / an empty list.
+    CCData checkCC(int portIndex, MidiChannel channel, CCMessage ccNumber) const {
+        const auto it = m_perPort.find(portIndex);
+        if (it == m_perPort.end()) {
+            return kCCFalse;
+        }
+        return it->second.checkCC(channel, ccNumber);
+    }
+    const std::vector<IRComponents::C_MidiMessage> &
+    notesOn(int portIndex, MidiChannel channel) const {
+        const auto it = m_perPort.find(portIndex);
+        if (it == m_perPort.end()) {
+            return kEmptyMessages;
+        }
+        return it->second.notesOn(channel);
+    }
+    const std::vector<IRComponents::C_MidiMessage> &
+    notesOff(int portIndex, MidiChannel channel) const {
+        const auto it = m_perPort.find(portIndex);
+        if (it == m_perPort.end()) {
+            return kEmptyMessages;
+        }
+        return it->second.notesOff(channel);
+    }
+
+    // Drop the whole frame. The per-port outer map keys persist (port set is
+    // stable across a session) — only the per-channel contents are wiped.
+    void clear() {
+        m_merged.clear();
+        for (auto &entry : m_perPort) {
+            entry.second.clear();
+        }
+    }
+
+  private:
+    inline static const std::vector<IRComponents::C_MidiMessage> kEmptyMessages{};
+
+    // One port's (or the merged) per-channel state for a single frame.
+    struct ChannelState {
+        std::unordered_map<MidiChannel, std::unordered_map<CCMessage, CCData>> cc_;
+        std::unordered_map<MidiChannel, std::vector<IRComponents::C_MidiMessage>> noteOn_;
+        std::unordered_map<MidiChannel, std::vector<IRComponents::C_MidiMessage>> noteOff_;
+
+        void insertCC(MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+            cc_[channel][message.getCCNumber()] = message.getCCValue();
+        }
+        void insertNoteOn(MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+            noteOn_[channel].push_back(message);
+        }
+        void insertNoteOff(MidiChannel channel, const IRComponents::C_MidiMessage &message) {
+            noteOff_[channel].push_back(message);
+        }
+
+        CCData checkCC(MidiChannel channel, CCMessage ccNumber) const {
+            const auto channelIt = cc_.find(channel);
+            if (channelIt == cc_.end()) {
+                return kCCFalse;
+            }
+            const auto ccIt = channelIt->second.find(ccNumber);
+            if (ccIt == channelIt->second.end()) {
+                return kCCFalse;
+            }
+            return ccIt->second;
+        }
+        const std::vector<IRComponents::C_MidiMessage> &notesOn(MidiChannel channel) const {
+            const auto it = noteOn_.find(channel);
+            return it == noteOn_.end() ? kEmptyMessages : it->second;
+        }
+        const std::vector<IRComponents::C_MidiMessage> &notesOff(MidiChannel channel) const {
+            const auto it = noteOff_.find(channel);
+            return it == noteOff_.end() ? kEmptyMessages : it->second;
+        }
+
+        void clear() {
+            for (auto &entry : cc_) {
+                entry.second.clear();
+            }
+            for (auto &entry : noteOn_) {
+                entry.second.clear();
+            }
+            for (auto &entry : noteOff_) {
+                entry.second.clear();
+            }
+        }
+    };
+
+    ChannelState m_merged;
+    std::unordered_map<int, ChannelState> m_perPort;
+};
+
+} // namespace IRAudio
+
+#endif /* MIDI_INPUT_FRAME_BUFFER_H */

--- a/engine/audio/include/irreden/audio/midi_out.hpp
+++ b/engine/audio/include/irreden/audio/midi_out.hpp
@@ -6,30 +6,47 @@
 
 #include <RtMidi.h>
 
-#include <set>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace IRAudio {
+
+// One simultaneously-open MIDI output port; each owns its own RtMidiOut so a
+// send can target a specific device.
+struct MidiOutPort {
+    std::unique_ptr<RtMidiOut> rtMidiOut_;
+    int portIndex_;
+    std::string name_;
+};
 
 class MidiOut {
   public:
     MidiOut();
     ~MidiOut();
 
-    void openPort(unsigned int portNumber);
-    // Opens the first device that matches substring name
-    int openPort(MidiOutInterfaces midiInInterface);
-
+    // Opens an output port by hardcoded interface enum or device-name
+    // substring. Returns the RtMidi port index (stable port handle) or -1 if
+    // no port matches. Opening an already-open port returns its handle. The
+    // first port opened becomes the default target for the port-less send.
+    int openPort(MidiOutInterfaces midiOutInterface);
     int openPort(std::string portNameSubstring);
+
     const std::vector<std::string> &getPortNames() const;
+    std::vector<int> getOpenPortIndices() const;
+
+    // Sends to the default port (the first one opened) — back-compat surface.
     void sendMessage(const std::vector<unsigned char> &message);
+    // Sends to a specific open port by its RtMidi port index.
+    void sendMessage(int portIndex, const std::vector<unsigned char> &message);
+
     void sendAllNotesOff();
 
   private:
-    RtMidiOut m_rtMidiOut;
+    RtMidiOut m_rtMidiOut; // enumeration probe only — never opened for output
     unsigned int m_numberPorts;
     std::vector<std::string> m_portNames;
-    std::set<unsigned int> m_openPorts;
-    std::string m_portName;
+    std::vector<std::unique_ptr<MidiOutPort>> m_ports;
 };
 
 } // namespace IRAudio

--- a/engine/audio/include/irreden/ir_audio.hpp
+++ b/engine/audio/include/irreden/ir_audio.hpp
@@ -30,6 +30,11 @@ IAudioCaptureSource &getAudioCaptureSource();
 std::vector<std::string> midiInPorts();
 /// Returns the names of all MIDI output ports discovered at startup.
 std::vector<std::string> midiOutPorts();
+/// Returns the RtMidi port indices of every currently-open MIDI input port,
+/// in open order — lets a per-port consumer enumerate its active lanes.
+std::vector<int> midiInOpenPorts();
+/// Returns the RtMidi port indices of every currently-open MIDI output port.
+std::vector<int> midiOutOpenPorts();
 /// Opens a MIDI input port by hardcoded interface index.
 int openPortMidiIn(MidiInInterfaces midiInInterface);
 /// Opens the first MIDI input port whose name contains @p deviceName (substring match).
@@ -40,23 +45,48 @@ int openPortMidiOut(MidiOutInterfaces midiOutInterface);
 /// Opens the first MIDI output port whose name contains @p deviceName (substring match).
 /// Returns the port index on success, or -1 if no port matches (logs a warning).
 int openPortMidiOut(const std::string &deviceName);
-/// Sends a raw MIDI message (fire-and-forget via `RtMidiOut`).
+/// Sends a raw MIDI message to the default output port (the first one opened).
 void sendMidiMessage(const std::vector<unsigned char> &message);
+/// Sends a raw MIDI message to a specific open output port by its RtMidi port
+/// index (the handle returned by @ref openPortMidiOut). Falls back to a warning
+/// if the port isn't open.
+void sendMidiMessage(int portIndex, const std::vector<unsigned char> &message);
 
-/// Returns the CC value for @p ccMessage on @p device received this frame,
-/// or @ref kCCFalse if no CC message arrived.
-CCData checkCCMessage(int device, CCMessage ccMessage);
-/// Returns the list of note-on messages received on @p device this frame.
-/// The list is cleared on the next `MidiIn::tick()` — read during INPUT/UPDATE only.
-const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOnThisFrame(int device);
-/// Returns the list of note-off messages received on @p device this frame.
-const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOffThisFrame(int device);
+/// Returns the CC value for @p ccMessage on @p channel received this frame
+/// across all open input ports, or @ref kCCFalse if no CC message arrived.
+CCData checkCCMessage(int channel, CCMessage ccMessage);
+/// Per-port variant: CC value for @p ccMessage on @p channel received on the
+/// input port @p portIndex this frame. Use to disambiguate same-channel CC
+/// traffic across simultaneously-open ports.
+CCData checkCCMessage(int portIndex, MidiChannel channel, CCMessage ccMessage);
+/// Returns the note-on messages received on @p channel this frame across all
+/// open input ports. The list is cleared on the next `MidiIn::tick()` — read
+/// during INPUT/UPDATE only.
+const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOnThisFrame(int channel);
+/// Returns the note-off messages received on @p channel this frame (all ports).
+const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOffThisFrame(int channel);
+/// Per-port variants: note-on / note-off messages received on @p portIndex /
+/// @p channel this frame.
+const std::vector<IRComponents::C_MidiMessage> &
+getMidiNotesOnThisFrame(int portIndex, MidiChannel channel);
+const std::vector<IRComponents::C_MidiMessage> &
+getMidiNotesOffThisFrame(int portIndex, MidiChannel channel);
 
 /// @name Low-level MIDI message insertion (used by prefab systems)
 /// @{
 void insertNoteOffMessage(MidiChannel channel, const IRComponents::C_MidiMessage &message);
 void insertNoteOnMessage(MidiChannel channel, const IRComponents::C_MidiMessage &message);
 void insertCCMessage(MidiChannel channel, const IRComponents::C_MidiMessage &message);
+/// Port-aware variants — fold into both the merged and the per-port views.
+void insertNoteOffMessage(
+    int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message
+);
+void insertNoteOnMessage(
+    int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message
+);
+void insertCCMessage(
+    int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message
+);
 /// @}
 
 /// Opens and starts an RtAudio input capture stream.

--- a/engine/audio/src/ir_audio.cpp
+++ b/engine/audio/src/ir_audio.cpp
@@ -24,6 +24,14 @@ std::vector<std::string> midiOutPorts() {
     return getAudioManager().getMidiOut().getPortNames();
 }
 
+std::vector<int> midiInOpenPorts() {
+    return getAudioManager().getMidiIn().getOpenPortIndices();
+}
+
+std::vector<int> midiOutOpenPorts() {
+    return getAudioManager().getMidiOut().getOpenPortIndices();
+}
+
 int openPortMidiIn(MidiInInterfaces port) {
     return getAudioManager().getMidiIn().openPort(port);
 }
@@ -44,16 +52,32 @@ void sendMidiMessage(const std::vector<unsigned char> &message) {
     getAudioManager().getMidiOut().sendMessage(message);
 }
 
-CCData checkCCMessage(int device, CCMessage ccMessage) {
-    return getAudioManager().getMidiIn().checkCCMessageThisFrame(device, ccMessage);
+void sendMidiMessage(int portIndex, const std::vector<unsigned char> &message) {
+    getAudioManager().getMidiOut().sendMessage(portIndex, message);
+}
+
+CCData checkCCMessage(int channel, CCMessage ccMessage) {
+    return getAudioManager().getMidiIn().checkCCMessageThisFrame(channel, ccMessage);
+}
+
+CCData checkCCMessage(int portIndex, MidiChannel channel, CCMessage ccMessage) {
+    return getAudioManager().getMidiIn().checkCCMessageThisFrame(portIndex, channel, ccMessage);
 }
 
 // Move some of this to IRInput
-const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOnThisFrame(int device) {
-    return getAudioManager().getMidiIn().getMidiNotesOnThisFrame(device);
+const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOnThisFrame(int channel) {
+    return getAudioManager().getMidiIn().getMidiNotesOnThisFrame(channel);
 }
-const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOffThisFrame(int device) {
-    return getAudioManager().getMidiIn().getMidiNotesOffThisFrame(device);
+const std::vector<IRComponents::C_MidiMessage> &getMidiNotesOffThisFrame(int channel) {
+    return getAudioManager().getMidiIn().getMidiNotesOffThisFrame(channel);
+}
+const std::vector<IRComponents::C_MidiMessage> &
+getMidiNotesOnThisFrame(int portIndex, MidiChannel channel) {
+    return getAudioManager().getMidiIn().getMidiNotesOnThisFrame(portIndex, channel);
+}
+const std::vector<IRComponents::C_MidiMessage> &
+getMidiNotesOffThisFrame(int portIndex, MidiChannel channel) {
+    return getAudioManager().getMidiIn().getMidiNotesOffThisFrame(portIndex, channel);
 }
 
 void insertNoteOffMessage(MidiChannel channel, const IRComponents::C_MidiMessage &message) {
@@ -64,6 +88,22 @@ void insertNoteOnMessage(MidiChannel channel, const IRComponents::C_MidiMessage 
 }
 void insertCCMessage(MidiChannel channel, const IRComponents::C_MidiMessage &message) {
     getAudioManager().getMidiIn().insertCCMessage(channel, message);
+}
+
+void insertNoteOffMessage(
+    int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message
+) {
+    getAudioManager().getMidiIn().insertNoteOffMessage(portIndex, channel, message);
+}
+void insertNoteOnMessage(
+    int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message
+) {
+    getAudioManager().getMidiIn().insertNoteOnMessage(portIndex, channel, message);
+}
+void insertCCMessage(
+    int portIndex, MidiChannel channel, const IRComponents::C_MidiMessage &message
+) {
+    getAudioManager().getMidiIn().insertCCMessage(portIndex, channel, message);
 }
 
 bool startAudioInputCapture(

--- a/engine/audio/src/midi_in.cpp
+++ b/engine/audio/src/midi_in.cpp
@@ -4,6 +4,7 @@
 #include <irreden/audio/midi_in.hpp>
 #include <irreden/update/components/component_lifetime.hpp>
 #include <irreden/audio/components/component_midi_message.hpp>
+#include <irreden/audio/components/component_midi_source_port.hpp>
 #include <irreden/common/components/component_tags_all.hpp>
 
 using namespace IRComponents;
@@ -15,23 +16,13 @@ MidiIn::MidiIn()
     : m_rtMidiIn{}
     , m_numberPorts(m_rtMidiIn.getPortCount())
     , m_portNames{}
-    , m_openPorts{}
-    , m_rtMidiInMap{}
-    , m_ccMessagesThisFrame{}
-    , m_midiNoteOffMessagesThisFrame{}
-    , m_midiNoteOnMessagesThisFrame{} {
+    , m_ports{}
+    , m_frameBuffer{} {
     IRE_LOG_INFO("Descovered {} MIDI input sources", m_numberPorts);
     for (int i = 0; i < m_numberPorts; i++) {
         m_portNames.push_back(m_rtMidiIn.getPortName(i));
         IRE_LOG_INFO("MIDI input source {}: {}", i, m_portNames[i].c_str());
     }
-
-    for (unsigned char i = 0; i < kNumMidiChannels; ++i) {
-        m_ccMessagesThisFrame.insert({i, std::unordered_map<CCMessage, CCData>{}});
-        m_midiNoteOffMessagesThisFrame.insert({i, std::vector<C_MidiMessage>{}});
-        m_midiNoteOnMessagesThisFrame.insert({i, std::vector<C_MidiMessage>{}});
-    }
-    setCallback(m_rtMidiIn, readMessageTestCallbackNew);
     IRE_LOG_INFO("Created MidiIn");
 }
 
@@ -43,46 +34,53 @@ void MidiIn::tick() {
 }
 
 void MidiIn::clearPreviousMessages() {
-    for (auto &channelMap : m_ccMessagesThisFrame) {
-        channelMap.second.clear();
-    }
-    for (auto &channelMap : m_midiNoteOnMessagesThisFrame) {
-        channelMap.second.clear();
-    }
-    for (auto &channelMap : m_midiNoteOffMessagesThisFrame) {
-        channelMap.second.clear();
-    }
+    m_frameBuffer.clear();
 }
 
 CCData MidiIn::checkCCMessageThisFrame(MidiChannel channel, CCMessage ccNumber) const {
-    if (!m_ccMessagesThisFrame.at(channel).contains(ccNumber)) {
-        return kCCFalse;
-    }
-    return m_ccMessagesThisFrame.at(channel).at(ccNumber);
+    return m_frameBuffer.checkCC(channel, ccNumber);
+}
+CCData
+MidiIn::checkCCMessageThisFrame(int portIndex, MidiChannel channel, CCMessage ccNumber) const {
+    return m_frameBuffer.checkCC(portIndex, channel, ccNumber);
 }
 
 const std::vector<C_MidiMessage> &MidiIn::getMidiNotesOnThisFrame(MidiChannel channel) const {
-    return m_midiNoteOnMessagesThisFrame.at(channel);
+    return m_frameBuffer.notesOn(channel);
 }
 const std::vector<C_MidiMessage> &MidiIn::getMidiNotesOffThisFrame(MidiChannel channel) const {
-    return m_midiNoteOffMessagesThisFrame.at(channel);
+    return m_frameBuffer.notesOff(channel);
 }
-
-// void MidiIn::openPort(unsigned int portNumber) {
-//     IRE_LOG_INFO("Opening MIDI In port {}", portNumber);
-//     m_rtMidiIn.openPort(portNumber);
-//     m_openPorts.push_back(portNumber);
-// }
+const std::vector<C_MidiMessage> &
+MidiIn::getMidiNotesOnThisFrame(int portIndex, MidiChannel channel) const {
+    return m_frameBuffer.notesOn(portIndex, channel);
+}
+const std::vector<C_MidiMessage> &
+MidiIn::getMidiNotesOffThisFrame(int portIndex, MidiChannel channel) const {
+    return m_frameBuffer.notesOff(portIndex, channel);
+}
 
 int MidiIn::openPort(const std::string &portNameSubstring) {
     for (int i = 0; i < m_numberPorts; i++) {
         const std::string_view portName{m_portNames[i]};
-        if (portName.find(portNameSubstring) != portName.npos) {
-            m_rtMidiIn.openPort(i);
-            m_openPorts.push_back(i);
-            IRE_LOG_INFO("Opened MIDI In port {}: {}", i, portName);
-            return i;
+        if (portName.find(portNameSubstring) == portName.npos) {
+            continue;
         }
+        for (const auto &port : m_ports) {
+            if (port->portIndex_ == i) {
+                IRE_LOG_INFO("MIDI In port {} ({}) already open", i, portName);
+                return i;
+            }
+        }
+        auto port = std::make_unique<MidiInPort>();
+        port->portIndex_ = i;
+        port->name_ = m_portNames[i];
+        port->rtMidiIn_ = std::make_unique<RtMidiIn>();
+        port->rtMidiIn_->openPort(i);
+        port->rtMidiIn_->setCallback(readMessageTestCallbackNew, &port->queue_);
+        m_ports.push_back(std::move(port));
+        IRE_LOG_INFO("Opened MIDI In port {}: {}", i, portName);
+        return i;
     }
     IRE_LOG_WARN(
         "No MIDI input port matching '{}' — {} port(s) available",
@@ -100,32 +98,52 @@ const std::vector<std::string> &MidiIn::getPortNames() const {
     return m_portNames;
 }
 
-void MidiIn::processMidiMessageQueue() {
+std::vector<int> MidiIn::getOpenPortIndices() const {
+    std::vector<int> indices;
+    indices.reserve(m_ports.size());
+    for (const auto &port : m_ports) {
+        indices.push_back(port->portIndex_);
+    }
+    return indices;
+}
 
-    while (!m_messageQueue.empty()) {
-        const C_MidiMessage &message = m_messageQueue.front();
-        IREntity::createEntity(C_MidiMessage{message}, C_MidiIn{}, C_Lifetime{1});
-        m_messageQueue.pop();
+void MidiIn::processMidiMessageQueue() {
+    for (auto &port : m_ports) {
+        while (!port->queue_.empty()) {
+            const C_MidiMessage &message = port->queue_.front();
+            IREntity::createEntity(
+                C_MidiMessage{message},
+                C_MidiIn{},
+                C_MidiSourcePort{port->portIndex_},
+                C_Lifetime{1}
+            );
+            port->queue_.pop();
+        }
     }
 }
 
 void MidiIn::insertNoteOffMessage(MidiChannel channel, const C_MidiMessage &midiMessage) {
-    m_midiNoteOffMessagesThisFrame[channel].push_back(midiMessage);
+    m_frameBuffer.insertNoteOff(channel, midiMessage);
 }
-
 void MidiIn::insertNoteOnMessage(MidiChannel channel, const C_MidiMessage &midiMessage) {
-    m_midiNoteOnMessagesThisFrame[channel].push_back(midiMessage);
+    m_frameBuffer.insertNoteOn(channel, midiMessage);
 }
-
 void MidiIn::insertCCMessage(MidiChannel channel, const C_MidiMessage &midiMessage) {
-    m_ccMessagesThisFrame[channel][midiMessage.getCCNumber()] = midiMessage.getCCValue();
+    m_frameBuffer.insertCC(channel, midiMessage);
 }
 
-void MidiIn::setCallback(
-    RtMidiIn &rtMidiIn,
-    void (*midiInputCallback)(double timeStamp, std::vector<unsigned char> *message, void *userData)
+void MidiIn::insertNoteOffMessage(
+    int portIndex, MidiChannel channel, const C_MidiMessage &midiMessage
 ) {
-    rtMidiIn.setCallback(midiInputCallback, &m_messageQueue);
+    m_frameBuffer.insertNoteOff(portIndex, channel, midiMessage);
+}
+void MidiIn::insertNoteOnMessage(
+    int portIndex, MidiChannel channel, const C_MidiMessage &midiMessage
+) {
+    m_frameBuffer.insertNoteOn(portIndex, channel, midiMessage);
+}
+void MidiIn::insertCCMessage(int portIndex, MidiChannel channel, const C_MidiMessage &midiMessage) {
+    m_frameBuffer.insertCC(portIndex, channel, midiMessage);
 }
 
 //-----------Callback---------//

--- a/engine/audio/src/midi_in.cpp
+++ b/engine/audio/src/midi_in.cpp
@@ -77,7 +77,7 @@ int MidiIn::openPort(const std::string &portNameSubstring) {
         port->name_ = m_portNames[i];
         port->rtMidiIn_ = std::make_unique<RtMidiIn>();
         port->rtMidiIn_->openPort(i);
-        port->rtMidiIn_->setCallback(readMessageTestCallbackNew, &port->queue_);
+        port->rtMidiIn_->setCallback(onRtMidiMessage, &port->queue_);
         m_ports.push_back(std::move(port));
         IRE_LOG_INFO("Opened MIDI In port {}: {}", i, portName);
         return i;
@@ -148,7 +148,7 @@ void MidiIn::insertCCMessage(int portIndex, MidiChannel channel, const C_MidiMes
 
 //-----------Callback---------//
 
-void readMessageTestCallbackNew(
+void onRtMidiMessage(
     double deltaTime, std::vector<unsigned char> *message, void *userdata
 ) {
     // Audio messages will be processed async
@@ -158,7 +158,7 @@ void readMessageTestCallbackNew(
     IR_ASSERT(messageSize > 0, "Received size 0 midi message");
 
     for (int i = 0; i < messageSize; i++) {
-        IRE_LOG_INFO("Message byte {}: {}", i, message->at(i));
+        IRE_LOG_DEBUG("Message byte {}: {}", i, message->at(i));
     }
 
     auto messageQueue = static_cast<std::queue<IRComponents::C_MidiMessage> *>(userdata);

--- a/engine/audio/src/midi_out.cpp
+++ b/engine/audio/src/midi_out.cpp
@@ -6,7 +6,7 @@ MidiOut::MidiOut()
     : m_rtMidiOut{}
     , m_numberPorts(m_rtMidiOut.getPortCount())
     , m_portNames{}
-    , m_openPorts{} {
+    , m_ports{} {
 
     IRE_LOG_INFO("Descovered {} MIDI output sources", m_numberPorts);
     for (int i = 0; i < m_numberPorts; i++) {
@@ -21,15 +21,17 @@ MidiOut::~MidiOut() {
 }
 
 void MidiOut::sendAllNotesOff() {
-    if (m_openPorts.empty()) {
+    if (m_ports.empty()) {
         return;
     }
-    for (unsigned char ch = 0; ch < kNumMidiChannels; ++ch) {
-        std::vector<unsigned char> msg =
-            {buildMidiStatus(kMidiStatus_CONTROL_CHANGE, ch), kMidiCC_ALL_NOTES_OFF, 0};
-        m_rtMidiOut.sendMessage(&msg);
+    for (auto &port : m_ports) {
+        for (unsigned char ch = 0; ch < kNumMidiChannels; ++ch) {
+            std::vector<unsigned char> msg =
+                {buildMidiStatus(kMidiStatus_CONTROL_CHANGE, ch), kMidiCC_ALL_NOTES_OFF, 0};
+            port->rtMidiOut_->sendMessage(&msg);
+        }
     }
-    IRE_LOG_INFO("Sent All Notes Off on all channels");
+    IRE_LOG_INFO("Sent All Notes Off on all channels of all open output ports");
 }
 
 int MidiOut::openPort(MidiOutInterfaces interface) {
@@ -39,12 +41,23 @@ int MidiOut::openPort(MidiOutInterfaces interface) {
 int MidiOut::openPort(std::string portNameSubstring) {
     for (int i = 0; i < m_numberPorts; i++) {
         const std::string_view portName{m_portNames[i]};
-        if (portName.find(portNameSubstring) != portName.npos) {
-            m_rtMidiOut.openPort(i);
-            m_openPorts.insert(i);
-            IRE_LOG_INFO("Opened MIDI Out port {}: {}", i, portName);
-            return i;
+        if (portName.find(portNameSubstring) == portName.npos) {
+            continue;
         }
+        for (const auto &port : m_ports) {
+            if (port->portIndex_ == i) {
+                IRE_LOG_INFO("MIDI Out port {} ({}) already open", i, portName);
+                return i;
+            }
+        }
+        auto port = std::make_unique<MidiOutPort>();
+        port->portIndex_ = i;
+        port->name_ = m_portNames[i];
+        port->rtMidiOut_ = std::make_unique<RtMidiOut>();
+        port->rtMidiOut_->openPort(i);
+        m_ports.push_back(std::move(port));
+        IRE_LOG_INFO("Opened MIDI Out port {}: {}", i, portName);
+        return i;
     }
     IRE_LOG_WARN(
         "No MIDI output port matching '{}' — {} port(s) available",
@@ -58,9 +71,33 @@ const std::vector<std::string> &MidiOut::getPortNames() const {
     return m_portNames;
 }
 
+std::vector<int> MidiOut::getOpenPortIndices() const {
+    std::vector<int> indices;
+    indices.reserve(m_ports.size());
+    for (const auto &port : m_ports) {
+        indices.push_back(port->portIndex_);
+    }
+    return indices;
+}
+
 void MidiOut::sendMessage(const std::vector<unsigned char> &message) {
-    m_rtMidiOut.sendMessage(&message);
+    if (m_ports.empty()) {
+        IRE_LOG_WARN("sendMessage called with no MIDI output port open");
+        return;
+    }
+    m_ports.front()->rtMidiOut_->sendMessage(&message);
     IRE_LOG_DEBUG("Sent MIDI message status={}", message.at(0));
+}
+
+void MidiOut::sendMessage(int portIndex, const std::vector<unsigned char> &message) {
+    for (auto &port : m_ports) {
+        if (port->portIndex_ == portIndex) {
+            port->rtMidiOut_->sendMessage(&message);
+            IRE_LOG_DEBUG("Sent MIDI message status={} to port {}", message.at(0), portIndex);
+            return;
+        }
+    }
+    IRE_LOG_WARN("sendMessage targeted unopened MIDI output port {}", portIndex);
 }
 
 } // namespace IRAudio

--- a/engine/prefabs/irreden/audio/CLAUDE.md
+++ b/engine/prefabs/irreden/audio/CLAUDE.md
@@ -8,6 +8,10 @@ creation composes MIDI behavior by adding components to entities.
 
 - `C_MidiMessage` — status + channel + data1/data2. Helpers for note
   number, velocity, CC value.
+- `C_MidiSourcePort` — RtMidi port index an inbound message arrived on
+  (-1 = unknown). Attached to in-message entities alongside `C_MidiMessage`
+  + `C_MidiIn` by `MidiIn::processMidiMessageQueue`; the `InputMidiMessageIn`
+  drainer matches it to route messages into the per-port query view.
 - `C_MidiSequence` — BPM, time signature, measures, tick-based playback,
   loop flag, message buffer.
 - `C_MidiNote` — note number, velocity, channel, hold duration.

--- a/engine/prefabs/irreden/audio/components/component_midi_source_port.hpp
+++ b/engine/prefabs/irreden/audio/components/component_midi_source_port.hpp
@@ -1,0 +1,23 @@
+#ifndef COMPONENT_MIDI_SOURCE_PORT_H
+#define COMPONENT_MIDI_SOURCE_PORT_H
+
+namespace IRComponents {
+
+// Source-port identity for an inbound MIDI message entity. Attached alongside
+// C_MidiMessage + C_MidiIn when a message enters the ECS from an open input
+// port, so consumers (per-port monitor lanes, port-scoped handlers) can
+// disambiguate same-channel traffic arriving on different ports. portIndex_
+// is the RtMidi port index returned by IRAudio::openPortMidiIn (-1 if unknown).
+struct C_MidiSourcePort {
+    int portIndex_;
+
+    C_MidiSourcePort(int portIndex)
+        : portIndex_(portIndex) {}
+
+    C_MidiSourcePort()
+        : portIndex_(-1) {}
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_MIDI_SOURCE_PORT_H */

--- a/engine/prefabs/irreden/audio/systems/system_audio_midi_message_in.hpp
+++ b/engine/prefabs/irreden/audio/systems/system_audio_midi_message_in.hpp
@@ -1,10 +1,12 @@
 #ifndef SYSTEM_AUDIO_MIDI_MESSAGE_IN_H
 #define SYSTEM_AUDIO_MIDI_MESSAGE_IN_H
 
+#include <irreden/ir_system.hpp>
 #include <irreden/ir_audio.hpp>
 
 #include <irreden/audio/components/component_midi_device.hpp>
 #include <irreden/audio/components/component_midi_message.hpp>
+#include <irreden/audio/components/component_midi_source_port.hpp>
 #include <irreden/audio/components/component_midi_channel.hpp>
 #include <irreden/common/components/component_name.hpp>
 #include <irreden/common/components/component_tags_all.hpp>
@@ -17,24 +19,32 @@ namespace IRSystem {
 
 template <> struct System<INPUT_MIDI_MESSAGE_IN> {
     static SystemId create() {
-        SystemId system =
-            createSystem<C_MidiMessage>("InputMidiMessageIn", [](C_MidiMessage &midiMessage) {
+        // Match C_MidiSourcePort so only genuine inbound messages (tagged with
+        // their source port by MidiIn::processMidiMessageQueue) are drained
+        // into the query buffer — outbound C_MidiMessage entities lack it and
+        // are left for the OUTPUT system. The port id routes each message into
+        // both the merged (all-ports) and per-port query views.
+        SystemId system = createSystem<C_MidiMessage, C_MidiSourcePort>(
+            "InputMidiMessageIn",
+            [](C_MidiMessage &midiMessage, C_MidiSourcePort &sourcePort) {
                 const MidiStatus statusBits = midiMessage.getStatusBits();
                 const MidiChannel channel = midiMessage.getChannelBits();
+                const int portIndex = sourcePort.portIndex_;
 
                 if (statusBits == IRAudio::kMidiStatus_NOTE_ON) {
                     IRE_LOG_INFO("Midi message note on!");
-                    IRAudio::insertNoteOnMessage(channel, midiMessage);
+                    IRAudio::insertNoteOnMessage(portIndex, channel, midiMessage);
                 }
                 if (statusBits == IRAudio::kMidiStatus_NOTE_OFF) {
                     IRE_LOG_INFO("Midi message note off!");
-                    IRAudio::insertNoteOffMessage(channel, midiMessage);
+                    IRAudio::insertNoteOffMessage(portIndex, channel, midiMessage);
                 }
                 if (statusBits == IRAudio::kMidiStatus_CONTROL_CHANGE) {
                     IRE_LOG_DEBUG("Midi message control change!");
-                    IRAudio::insertCCMessage(channel, midiMessage);
+                    IRAudio::insertCCMessage(portIndex, channel, midiMessage);
                 }
-            });
+            }
+        );
         addSystemTag<C_MidiIn>(system);
         return system;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(IrredenEngineTest
   asset/voxel_set_hybrid_test.cpp
   asset/voxel_set_rle_test.cpp
   asset/voxel_set_shapes_test.cpp
+  audio/midi_multiport_test.cpp
   audio/music_theory_test.cpp
   common/ir_platform_test.cpp
   ecs/entity_manager_test.cpp

--- a/test/audio/midi_multiport_test.cpp
+++ b/test/audio/midi_multiport_test.cpp
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+
+#include <irreden/audio/midi_input_frame_buffer.hpp>
+#include <irreden/audio/ir_audio_types.hpp>
+
+// Routing tests for the per-frame inbound MIDI buffer that backs multi-port
+// input (#1727). MidiInputFrameBuffer carries no RtMidi/hardware dependency,
+// so the merged-vs-per-port routing — the acceptance-critical "two input ports
+// open at once, each delivering with correct port identity" contract — is
+// verified deterministically without a MIDI device.
+
+namespace {
+
+using namespace IRAudio;
+using IRComponents::C_MidiMessage;
+
+C_MidiMessage ccMessage(MidiChannel channel, unsigned char ccNumber, unsigned char ccValue) {
+    return C_MidiMessage{buildMidiStatus(kMidiStatus_CONTROL_CHANGE, channel), ccNumber, ccValue};
+}
+
+C_MidiMessage noteOnMessage(MidiChannel channel, unsigned char note, unsigned char velocity) {
+    return C_MidiMessage{buildMidiStatus(kMidiStatus_NOTE_ON, channel), note, velocity};
+}
+
+constexpr int kPortA = 1;
+constexpr int kPortB = 3;
+constexpr MidiChannel kChannel = 0;
+
+TEST(MidiInputFrameBufferTest, PerPortCCIsolation) {
+    MidiInputFrameBuffer buffer;
+    buffer.insertCC(kPortA, kChannel, ccMessage(kChannel, 10, 64));
+    buffer.insertCC(kPortB, kChannel, ccMessage(kChannel, 10, 20));
+
+    // Same channel + CC number on two ports stays distinguishable per port.
+    EXPECT_EQ(buffer.checkCC(kPortA, kChannel, 10), 64);
+    EXPECT_EQ(buffer.checkCC(kPortB, kChannel, 10), 20);
+}
+
+TEST(MidiInputFrameBufferTest, UnopenedPortAndAbsentCcReturnFalse) {
+    MidiInputFrameBuffer buffer;
+    buffer.insertCC(kPortA, kChannel, ccMessage(kChannel, 10, 64));
+
+    EXPECT_EQ(buffer.checkCC(99, kChannel, 10), kCCFalse);      // port never seen
+    EXPECT_EQ(buffer.checkCC(kPortA, kChannel, 11), kCCFalse);  // cc never sent
+    EXPECT_EQ(buffer.checkCC(kPortA, 5, 10), kCCFalse);         // other channel
+}
+
+TEST(MidiInputFrameBufferTest, MergedCcFoldsAllPorts) {
+    MidiInputFrameBuffer buffer;
+    buffer.insertCC(kPortA, kChannel, ccMessage(kChannel, 10, 64));
+    buffer.insertCC(kPortB, kChannel, ccMessage(kChannel, 10, 20));
+
+    // The merged view collapses same-channel+cc traffic; last write wins. The
+    // per-port view (above) is how a consumer avoids that collision.
+    EXPECT_EQ(buffer.checkCC(kChannel, 10), 20);
+}
+
+TEST(MidiInputFrameBufferTest, PerPortNoteIsolationAndMergedFold) {
+    MidiInputFrameBuffer buffer;
+    buffer.insertNoteOn(kPortA, kChannel, noteOnMessage(kChannel, 60, 100));
+    buffer.insertNoteOn(kPortB, kChannel, noteOnMessage(kChannel, 64, 80));
+
+    const auto &portANotes = buffer.notesOn(kPortA, kChannel);
+    ASSERT_EQ(portANotes.size(), 1u);
+    EXPECT_EQ(portANotes[0].getMidiNoteNumber(), 60);
+
+    const auto &portBNotes = buffer.notesOn(kPortB, kChannel);
+    ASSERT_EQ(portBNotes.size(), 1u);
+    EXPECT_EQ(portBNotes[0].getMidiNoteNumber(), 64);
+
+    // Merged view sees both ports' notes on the same channel.
+    EXPECT_EQ(buffer.notesOn(kChannel).size(), 2u);
+}
+
+TEST(MidiInputFrameBufferTest, NoteOnAndNoteOffAreSeparate) {
+    MidiInputFrameBuffer buffer;
+    buffer.insertNoteOn(kPortA, kChannel, noteOnMessage(kChannel, 60, 100));
+    buffer.insertNoteOff(kPortA, kChannel, noteOnMessage(kChannel, 60, 0));
+
+    EXPECT_EQ(buffer.notesOn(kPortA, kChannel).size(), 1u);
+    EXPECT_EQ(buffer.notesOff(kPortA, kChannel).size(), 1u);
+}
+
+TEST(MidiInputFrameBufferTest, PortlessInsertStaysMergedOnly) {
+    MidiInputFrameBuffer buffer;
+    buffer.insertCC(kChannel, ccMessage(kChannel, 7, 99)); // legacy port-less insert
+
+    EXPECT_EQ(buffer.checkCC(kChannel, 7), 99);            // merged sees it
+    EXPECT_EQ(buffer.checkCC(kPortA, kChannel, 7), kCCFalse); // no port view written
+}
+
+TEST(MidiInputFrameBufferTest, ClearWipesMergedAndPerPort) {
+    MidiInputFrameBuffer buffer;
+    buffer.insertCC(kPortA, kChannel, ccMessage(kChannel, 10, 64));
+    buffer.insertNoteOn(kPortA, kChannel, noteOnMessage(kChannel, 60, 100));
+
+    buffer.clear();
+
+    EXPECT_EQ(buffer.checkCC(kChannel, 10), kCCFalse);
+    EXPECT_EQ(buffer.checkCC(kPortA, kChannel, 10), kCCFalse);
+    EXPECT_TRUE(buffer.notesOn(kChannel).empty());
+    EXPECT_TRUE(buffer.notesOn(kPortA, kChannel).empty());
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- `MidiIn`/`MidiOut` hold one RtMidi instance per simultaneously-open port (each input port with its own callback queue) instead of a single shared one. `openPortMidiIn`/`openPortMidiOut` return the RtMidi port index as a stable handle; re-opening an open port is an idempotent no-op.
- Inbound message entities carry `C_MidiSourcePort{portIndex}`; the `InputMidiMessageIn` drainer routes by port into a new hardware-free `MidiInputFrameBuffer` that keeps both a **merged** all-ports per-channel view and a **per-port** view.
- Port-scoped overloads added alongside the merged-view API: `checkCCMessage(port, ch, cc)`, `getMidiNotesOn/OffThisFrame(port, ch)`, `sendMidiMessage(port, msg)`, plus `midiInOpenPorts()`/`midiOutOpenPorts()` to enumerate open handles (per-port monitor lanes).
- **Back-compat:** existing single-port consumers (`command_manager`, the game `midi_input_dispatch`/`gear_model`, the `midi_keyboard` demo) call the unchanged merged-view API and are untouched. Default `sendMidiMessage(msg)` targets the first-opened output port.
- Stretch item from the issue (MIDI clock / Program Change into the per-frame queues) is deferred to a separate PR, as the issue allows.

## Test plan
- [x] New unit test `test/audio/midi_multiport_test.cpp` (7 cases): per-port CC/note isolation, merged fold, unopened-port/absent-CC → `kCCFalse`, port-less insert stays merged-only, `clear()` wipes both views. No MIDI hardware required (tests `MidiInputFrameBuffer` directly).
- [x] `fleet-build --target IrredenEngineTest` clean on **macos-debug**; all 12 MIDI tests pass (7 new + 5 existing `music_theory`).
- [ ] linux-debug build (cross-host smoke).

## Notes for review
- The `InputMidiMessageIn` drainer now matches `<C_MidiMessage, C_MidiSourcePort>`. This is a pure **narrowing**: `MidiIn::tick()` runs before `executePipeline(INPUT)` and inbound entities are `C_Lifetime{1}`, so the drainer never coexisted with outbound `C_MidiMessage` entities anyway. Net effect is correct port routing with no behavior change for the existing flow.
- `MidiInPort` declares `rtMidiIn_` last so it destructs first — the RtMidi callback thread stops before its target `queue_` is freed (the prior single-port code had the same latent teardown ordering).
- **Reuse, consciously kept:** `MidiIn`/`MidiOut` `getOpenPortIndices` + `openPort(string)` are near-duplicates. Left un-extracted because the only shared home is the widely-included audio types header, and the divergence (input callback wiring, distinct port structs) makes a template helper net-negative coupling for ~2 call sites. Worth revisiting if a third port type lands.
- **No `optimize` profile run:** MIDI input is event-bounded I/O (no per-frame compute hot loop), and there's no headless workload to drive MIDI messages. The per-frame buffer is allocation-free across frames — `clear()` wipes contents but reuses map/vector capacity.

Closes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)