### PR TITLE
docs/fleet: absorb coding-improvement triage batch

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -102,8 +102,11 @@ any `c_compute_*shadow*.glsl` / `.metal`)
   Add the annotation and set `kSaveVersion = 1` on the struct.
 
 **Naming / style** — follow the table in [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Naming.
-- `m_` on public members, trailing `_` on private members (backwards — the
-  single most common slip).
+- Private members take `m_`; public members take a trailing `_`. The reversed
+  form — `m_` on a *public* member, or a trailing `_` on a *private* member —
+  is the single most common slip. A private member that already carries `m_`
+  is correct; do **not** flag it (this inversion produced a false-positive nit
+  on PR #1706).
 
 **Tests / build**
 - Code change with no corresponding test change where a test existed.
@@ -139,6 +142,12 @@ verdict footer if any of these surfaces are touched)
   to** this engine checklist. The engine checklist is the baseline; the
   creation's `CLAUDE.md` is the delta. Apply both. If the subdirectory has a
   dedicated `REVIEW.md`, prefer it for review-specific rules.
+
+**Fleet scripts** (if the diff renames pane IDs, role names, or other
+identifiers in `scripts/fleet/`)
+- Inline comments — layout diagrams, role-list blocks, `--help` banners —
+  still naming the old identifiers. `grep` the renamed-from names across the
+  touched scripts; comment blocks drift silently because nothing compiles them.
 
 ## Verdict-label swap commands (shared-flow step 5b)
 

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -51,6 +51,11 @@ Use a lowercase `detail` namespace for header-only helpers under the owning
 namespace (`IRSystem::detail`, `IRRender::detail`). Don't use anonymous
 namespaces in headers; keep them in `.cpp`.
 
+No prototype-phase infixes (`Test`, `New`, `Tmp`) in production (non-test)
+function names — rename an experimental copy before it's wired into the real
+path, or the API keeps signalling "experimental" when it's the production code
+(`Debug` is fine when it names a real debug *feature*, not a leftover prototype).
+
 ---
 
 ## Style
@@ -501,6 +506,12 @@ rule** above. Removal of engine ECS surface (systems, components,
 entities) is forbidden without explicit human sign-off; deprecation
 markers are the slower-moving "this surface is going away eventually"
 signal that applies to any API the human has decided to phase out.
+
+**Transition shims** — code intentionally dead once a known milestone lands
+(compatibility aliases, legacy-artifact cleaners, deprecated-knob
+fallthrough) — carry a `// Remove once <phase> lands (epic #N)` tombstone at
+the declaration so the cleanup pass is self-guided instead of depending on
+whoever remembers which epic the shim was tied to.
 
 ---
 

--- a/engine/audio/CLAUDE.md
+++ b/engine/audio/CLAUDE.md
@@ -76,3 +76,8 @@ functions:
   — check `patches/` before debugging driver-level issues.
 - **Single-thread `tick()` assumption.** `MidiIn::tick()` has no mutex.
   Call it only from the main loop.
+- **Callback log level.** Use `IRE_LOG_DEBUG`, never `IRE_LOG_INFO`, for
+  per-message / per-event logging inside the RtMidi/RtAudio callbacks. They
+  fire on the driver thread hundreds of times per second under a real-time
+  clock (24 pps) or dense CC sweeps — `IRE_LOG_INFO` per message floods the
+  log (and costs frame time) while staying invisible in sparse-traffic dev.

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -118,6 +118,11 @@ _env_effort_smoke_worker="${FLEET_EFFORT_SMOKE_WORKER:-}"
 _env_effort_epic_steward="${FLEET_EFFORT_EPIC_STEWARD:-}"
 # Same guard for the model-class knobs (consumed by the class table and
 # ROLE_MODEL map further down) and the fable concurrency cap.
+# INVARIANT: every FLEET_MODEL_<ROLE> knob must appear in all THREE sites —
+# capture here (before `source`), restore below (after `source`), and unset at
+# the end of the block. Miss one and a conf-set value silently wins over the
+# caller's env for that role (reversed precedence, no error). The
+# FLEET_EFFORT_<ROLE> block above follows the identical three-site rule.
 _env_model_fable="${FLEET_MODEL_FABLE:-}"
 _env_model_opus="${FLEET_MODEL_OPUS:-}"
 _env_model_sonnet="${FLEET_MODEL_SONNET:-}"


### PR DESCRIPTION
## Summary

Drains the `fleet:coding-improvement` backlog in one bundle per the
`triage-coding-improvements` flow. Six tickets swept, clustered by target
surface, triaged with the human, applied as **convention-surface edits only**
(no engine/creation code touched). The diff maps 1:1 to the verdicts below.

**Verdict tally:** 3 ACCEPT · 1 RESCOPE · 1 ESCALATE PLACEMENT · 1 declined-but-root-caused · 0 DEFER.

| # | Verdict | Change |
|---|---|---|
| #1731 | ACCEPT | `engine/audio/CLAUDE.md` gotcha — use `IRE_LOG_DEBUG`, not `IRE_LOG_INFO`, for per-message RtMidi/RtAudio callback logging (24 pps clock / dense CC floods the log). Matches existing practice in `midi_out.cpp`. |
| #1730 | ACCEPT | `CLAUDE-BASELINE.md` §Naming — no `Test`/`New`/`Tmp` prototype infixes in production function names. (`Debug` carved out: it legitimately names debug *features* like `DebugOverlayMode`.) |
| #1711 | RESCOPE | `CLAUDE-BASELINE.md` §Deprecation markers — transition-shim tombstone (`// Remove once <phase> lands (epic #N)`), folded into the existing section instead of a new FLEET.md rule. |
| #1715 | ESCALATE PLACEMENT | Inline comment in `scripts/fleet/fleet-dispatcher` documenting the three-site `FLEET_MODEL_<ROLE>` capture/restore/unset invariant — **not** FLEET.md, which by design keeps script mechanics in the script ("…not here"). |
| #1714 | ACCEPT | `review-pr/SKILL.md` — new "Fleet scripts" checklist item: grep renamed-from identifiers in comment blocks during fleet-script rename refactors. |
| #1709 | DECLINED + ROOT-CAUSED | The proposed check ("flag new `m_`-prefixed private members") **inverts the convention** — private→`m_` is *correct* (confirmed across CLAUDE-BASELINE §Naming, `cpp-ecs.md`, `simplify-check-naming`, and the cited `render_manager.hpp:163-164`, which is correctly named). The PR #1706 nit that motivated it was a false positive. **Root cause:** the `review-pr/SKILL.md` naming line *led* with the inverted mapping and only parenthetically tagged it "(backwards)" — clarified so a skimming reviewer can't reproduce the false positive. Closing via the root-cause fix instead of adopting the inverted check. |

## Closed-loop check
No open ticket targeted the same artifact **and** rule as a closed-as-completed one — no "landed-then-recurred" cases. `review-pr/SKILL.md` is a frequently-targeted surface but each rule is distinct.

## Net line growth (surface budget)
- `review-pr/SKILL.md`: +11 / −2 (two distinct rules)
- `CLAUDE-BASELINE.md`: +11 (two sections, ≤5 lines each)
- `engine/audio/CLAUDE.md`: +5 (one gotcha bullet, narrow-audience doc)
- `scripts/fleet/fleet-dispatcher`: +5 (inline comment)

## Split-outs (Step 5)
None — every verdict was a convention-surface edit; no engine/creation code work to route out.

## Test plan
- [x] `simplify` clean — doc-side checks pass; cited `IRE_LOG_*` macros, paths, and PR refs all resolve
- [x] `fleet-dispatcher` `bash -n` syntax OK (comment-only change)
- [x] No build impact (docs + one shell comment)

Closes #1731
Closes #1730
Closes #1715
Closes #1714
Closes #1711
Closes #1709

🤖 Generated with [Claude Code](https://claude.com/claude-code)