### PR TITLE
docs/optimize: fix catalog numbering collision; record atomicMin dead end

### DIFF
--- a/.claude/skills/optimize/reference/big_wins.md
+++ b/.claude/skills/optimize/reference/big_wins.md
@@ -160,7 +160,7 @@ worst-case matrix cell) land here as part of the optimization PR.
 - **Win**: worst cell (zoom 8, FULL, yaw 0.35) **137 ms → ~13 ms**
   (~10×); cardinal zoom 8 FULL 48.5 → 25.7 ms; rotated NONE floor
   ~12 ms over cardinal → ~1 ms. Bottleneck-catalog entries 7
-  (updated), 12, 13.
+  (updated), 15, 16.
 - **Lesson**: rotation/zoom interactions need their own matrix axis —
   every cell of the pre-existing matrix was cardinal, so a 2.8× rotated
   multiplier shipped invisibly. When a flat per-path cost doesn't scale

--- a/.claude/skills/optimize/reference/common_bottlenecks.md
+++ b/.claude/skills/optimize/reference/common_bottlenecks.md
@@ -151,6 +151,14 @@ session uncovers lands here in the same PR as the fix.
   the invariant (`engine/render/CLAUDE.md` §"Lighting culling
   invariants") — feeder voxels still need `trixelDistances` writes for
   the sun-shadow bake; they just don't need color / AO / entity ID.
+- **Measured dead end (2026-06, Metal)**: a load-test-skip before
+  `writeDistanceTap`'s `imageAtomicMin` (plain load, atomic only when
+  the candidate is nearer — correctness holds because distances only
+  decrease within the frame) moved NOTHING on the 24-cell IRPerfGrid
+  matrix (zoom 8 FULL cardinal 26.1 → 26.4 ms, noise). The FULL-mode
+  zoom cost is not atomic-RMW-bound on Apple Silicon; don't re-try
+  without first profiling where the stage's time actually goes
+  (blocked on #1738 — Metal per-stage GPU timing is unreliable).
 
 ### 8. O(sub²) per-shape tile generation in SHAPES_TO_TRIXEL
 
@@ -183,7 +191,7 @@ session uncovers lands here in the same PR as the fix.
   `getVoxelRenderEffectiveSubdivisions` clamp to 16 keeps it under the
   limit, but the headroom is small.
 
-### 12. Reusing an indirect dispatch command whose Z the pass ignores
+### 15. Reusing an indirect dispatch command whose Z the pass ignores
 
 - **Pattern**: a pass dispatches `dispatchComputeIndirect` from a
   shared indirect-params buffer whose `numGroupsZ = subdivisions²`,
@@ -203,7 +211,7 @@ session uncovers lands here in the same PR as the fix.
   20) — and dispatch the z-ignoring pass from that offset.
   137 → 20.6 ms on the worst IRPerfGrid cell.
 
-### 13. Brute-force instanced draw over a mostly-empty grid
+### 16. Brute-force instanced draw over a mostly-empty grid
 
 - **Pattern**: `drawElementsInstanced(instanceCount = W*H)` over every
   cell of a canvas/grid, with the vertex shader degenerating empties


### PR DESCRIPTION
Stacked on: https://github.com/jakildev/IrredenEngine/pull/1737

## Summary
- The two bottleneck-catalog entries #1737 appended to the GPU section as 12/13 collided with the pre-existing CPU entry 12 (pending-range queue). Renumbered to 15/16; big-wins cross-reference updated.
- Records a measured dead end under entry 7: a load-test-skip before `writeDistanceTap`'s `imageAtomicMin` (correct under monotonic in-frame decrease) moved nothing on the 24-cell IRPerfGrid matrix on Apple Silicon — zoom 8 FULL cardinal 26.07 → 26.41 ms (noise). The FULL-mode zoom cost is not atomic-RMW-bound; the note points the next optimizer at profiling the stage first (blocked on #1738) instead of re-trying.

The shader experiment itself was reverted per the optimize skill's "a fix that doesn't move the needle isn't an optimization" — this PR is docs-only.

## Test plan
- [x] Docs-only diff; entry numbering verified unique (`grep '^### '`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)