### PR TITLE
fleet: carve-off planning gate — step-2 rigor, queue-ingest plan enforcement, epic-chain carve-offs (#1456)

### DIFF
--- a/.claude/skills/file-epic/SKILL.md
+++ b/.claude/skills/file-epic/SKILL.md
@@ -38,6 +38,13 @@ for why.
   command**; it auto-discovers children and fails loudly on a malformed
   body. It is the belt that the step-5 hand-filing convention is the
   suspenders for.
+- Per-child plan files (flow step 6) must meet
+  [`PLANNING-PROTOCOL.md`](../../../docs/agents/PLANNING-PROTOCOL.md)
+  step-2 rigor — verified current state / confirmed repro, one picked
+  approach, sibling + in-flight reconciliation — not a restated phase line
+  (#1456). The engine's `fleet-queue-ingest` plan gate only checks that
+  `.fleet/plans/issue-<N>.md` exists, so land the step-6.5 docs PR promptly
+  (it is also what makes a child pass the gate cross-host).
 - Engine-repo vs game-repo: most epics target `jakildev/IrredenEngine`.
   The cross-repo info-isolation rule (see
   [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md)

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -24,7 +24,26 @@ For each `fleet:needs-plan` issue:
 2. **Assess scope and post a structured plan as an issue comment**
    covering:
    - What files/modules are involved
-   - Step-by-step implementation approach
+   - **Verified current state + confirmed repro.** For a defect ticket,
+     name the repro you actually ran **against the actual code path** —
+     not the path the issue body guesses at. A body ending in "likely
+     suspects / confirm during investigation" is a hypothesis, not a
+     plan; verify the premise before writing the approach (every #1370
+     carve-off design-blocked because nobody had).
+   - **One approach, picked.** Step-by-step: which files, what order,
+     key decisions — and the plan **commits to a single approach**.
+     Deferring the choice to the worker ("confirm during
+     investigation/design", "option A or B, decide while implementing")
+     is forbidden: if the approach can't be picked yet, the issue isn't
+     plannable — keep `fleet:needs-plan` on and say what's missing, or
+     reframe it as an explicit **investigation spike** (the literal
+     phrase in the title/body; see
+     [`architect-protocol.md § Carve-offs`](architect-protocol.md)).
+   - **Sibling + in-flight reconciliation.** Check the parent ticket's
+     other carve-offs and every open PR touching the same surface — a
+     plan that duplicates or contradicts an active PR or a sibling's
+     recorded conclusion (e.g. #1440 prescribed the approach #1420 had
+     already proved wrong) wastes a full worker round.
    - Whether it should be **one task or broken into subtasks**
    - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
    - Acceptance criteria
@@ -42,9 +61,21 @@ For each `fleet:needs-plan` issue:
    (the `file-epic` skill enforces the structured `**Blocked by:** #N`
    chain the scout and `fleet-claim` parsers require).
 
+   The same rule applies to **carve-offs**: when more than one residual
+   is split out of an over-scoped or in-flight ticket and they touch
+   the same surface, file them as a `file-epic` **chain** (each child
+   `Blocked by:` its predecessor), not N flat siblings that all hang
+   off the parent. Flat siblings go claimable simultaneously the
+   moment the parent closes and get worked in parallel on the same
+   files — the #1370 trio produced three conflicting, all
+   design-blocked PRs exactly this way.
+
 3. **Save the plan locally** for workers to read later:
    `mkdir -p ~/.fleet/plans`, then use the **Write tool** to create
-   `~/.fleet/plans/issue-<N>.md` (where N is the issue number). Format:
+   `~/.fleet/plans/issue-<N>.md` (where N is the issue number), and
+   **commit it into the repo** at `.fleet/plans/issue-<N>.md` via a
+   small docs PR — `~/.fleet/plans/` is same-host staging only, and a
+   worker claiming on another host reads the plan from master. Format:
 
    ```markdown
    # Plan: <issue title>
@@ -82,6 +113,16 @@ For each `fleet:needs-plan` issue:
    without `fleet:needs-plan` (and without `fleet:needs-info`) is the
    signal that the issue is queue-ready. The plan file stays at
    `~/.fleet/plans/issue-<N>.md` for the lifetime of the task.
+
+   This gate is mechanically enforced (#1456): `fleet-queue-ingest`
+   refuses to stamp `fleet:queued` on an approved issue that has no
+   plan file — neither the committed `.fleet/plans/issue-<N>.md` nor
+   the planner-host staging copy — and bounces it back to
+   `fleet:needs-plan` with a comment. The only escape hatch is an
+   explicit **investigation spike**: the literal phrase "investigation
+   spike" in the issue's title or body, for tickets whose deliverable
+   *is* the investigation. Labeling an unplanned build task
+   `human:approved` no longer queues it.
 
 **If you disagree with the issue's direction**, comment with your
 concerns but leave `fleet:needs-plan` on — let the human decide.

--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -247,7 +247,13 @@ queue-ready**: file them unlabeled per Filing tasks (the human triages →
 [`PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md) and commit
 `~/.fleet/plans/issue-<N>.md`), or — if the residual is part of a dependent
 stack — file the whole stack via `file-epic` so each child gets its own plan
-file. The committed plan (not the issue body) is what must (1) name a
+file. When you carve **more than one** residual out of the same ticket and
+they touch the same surface, the `file-epic` chain is the required form: each
+child `Blocked by:` its predecessor, never N flat siblings hanging off the
+parent. Flat siblings all go claimable the moment the parent closes and get
+worked in parallel on the same files — the #1370 trio produced three
+conflicting, all design-blocked PRs exactly this way (#1456 Gap 2).
+The committed plan (not the issue body) is what must (1) name a
 **confirmed repro** of the symptom against the actual code path, (2) **pick one
 approach** rather than hand the choice to the worker, and (3) **reconcile
 siblings + in-flight PRs** on the same surface (a carve-off's fix often
@@ -256,7 +262,10 @@ conclusion — e.g. #1440's planned approach was the one #1420 had already prove
 wrong). A carve-off that cannot yet clear those three is not a queued task — it
 is either a `fleet:needs-plan` issue or, if you genuinely need a worker to
 investigate before the design exists, an explicit investigation spike, never a
-`human:approved` build task.
+`human:approved` build task. This is mechanically enforced (#1456):
+`fleet-queue-ingest` bounces an approved issue with no plan file back to
+`fleet:needs-plan` unless its title/body contains the literal phrase
+"investigation spike".
 
 **Fleet self-config changes are human-only — don't file them for autonomous
 pickup.** Edits to the role/command/agent configs the fleet loads

--- a/docs/agents/skills/file-epic.md
+++ b/docs/agents/skills/file-epic.md
@@ -269,6 +269,18 @@ The per-ticket plan adds **implementation detail beyond the issue body**.
 Don't duplicate — point at the umbrella plan for arch context, then add file
 paths, code-level approach, and verification.
 
+Each per-ticket plan must carry the **same rigor as a standalone plan**
+(PLANNING-PROTOCOL.md step 2): state the **verified current state** of the
+code this child touches (with a **confirmed repro against the actual code
+path** when the child fixes a defect), commit to **one approach** — never a
+"confirm during investigation/design" hand-off to the worker — and
+**reconcile siblings + in-flight PRs** on the same surface (including the
+epic's other children: say what this child assumes its predecessors have
+landed). A child plan that just restates the umbrella's phase line is a stub
+— #1440's 23-line stub prescribed an approach a sibling had already proved
+wrong (#1456). The queue's plan gate checks only that the file *exists*;
+the rigor is on the author.
+
 ### 6.5. Commit the plan files into the repo (REQUIRED — workers read from master)
 
 The **plans dir** (`~/.fleet/plans/`) is **local staging only** — it is
@@ -369,6 +381,10 @@ auto-approve).
   or several `**Blocked by:**` lines. The gate unions every ref.
 - ❌ Per-ticket plan files that duplicate the issue body verbatim. The plan
   adds implementation detail; the issue is the discussion surface.
+- ❌ Per-ticket plan files that restate the umbrella's phase line and stop.
+  Each child plan meets PLANNING-PROTOCOL.md step-2 rigor on its own:
+  verified current state / confirmed repro, one picked approach, sibling +
+  in-flight reconciliation (#1456).
 - ❌ Skipping the umbrella summary comment — the umbrella↔children
   cross-reference then isn't visible from the umbrella's own thread.
 - ❌ Filing an epic for changes that are really one ticket. If the scope

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -25,6 +25,14 @@
 # hand-built projection). Claimability is unchanged — fleet-claim's own
 # Blocked-by gate still refuses a plain claim; see docs/design/fleet-queue-stacking.md.
 #
+# Planning gate (#1456): an approved issue with no plan file — neither the
+# committed repo-side `.fleet/plans/issue-<N>.md` nor the planner-host
+# `~/.fleet/plans/issue-<N>.md` staging copy — is bounced to fleet:needs-plan
+# instead of stamped fleet:queued, unless its title/body names an explicit
+# "investigation spike". Carve-offs queued straight to human:approved without
+# ever passing through planning made the worker the first person to open the
+# code, and it design-blocked on claim (the #1370 → #1414/#1431/#1435 pattern).
+#
 # Source of truth: scripts/fleet/fleet-queue-ingest in the engine repo.
 # Installed to ~/bin/fleet-queue-ingest by scripts/fleet/install.sh.
 
@@ -218,6 +226,12 @@ REF_RE = re.compile(r'(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)')
 # Repo-name qualifier (case-insensitive, owner stripped) → GitHub slug.
 _REF_NAME_TO_SLUG = {'irredenengine': 'jakildev/IrredenEngine',
                      'irreden': 'jakildev/irreden'}
+# Planning-gate escape hatch (#1456): an issue whose title or body names an
+# explicit "investigation spike" is worker-investigates-first by design and
+# queues without a plan file (architect-protocol.md §"Carve-offs are unplanned
+# tickets" is where the phrase is defined).
+SPIKE_RE = re.compile(r'investigation\s+spike', re.IGNORECASE)
+PLANS_DIR = os.path.expanduser('~/.fleet/plans')
 
 
 def _ref_slug(name, default_repo):
@@ -283,11 +297,43 @@ def _blocker_open(repo, ref, cache):
     cache[key] = is_open
     return is_open
 
+
+def _plan_exists(repo, n, cache):
+    """True when a plan file exists for issue n — the planner-host staging
+    copy (~/.fleet/plans/issue-<n>.md) or the committed repo-side copy on the
+    default branch (live `gh api` contents probe, host-independent). Only a
+    confirmed 404 reads as missing; any other probe failure fails OPEN
+    (treated as present) so a transient API error never bounces a planned
+    issue back to fleet:needs-plan."""
+    if os.path.exists(os.path.join(PLANS_DIR, f'issue-{n}.md')):
+        return True
+    key = (repo, n)
+    if key in cache:
+        return cache[key]
+    r = subprocess.run(
+        ['gh', 'api', f'repos/{repo}/contents/.fleet/plans/issue-{n}.md',
+         '--jq', '.path'],
+        capture_output=True, text=True, timeout=15,
+    )
+    if r.returncode == 0:
+        present = True
+    elif '404' in (r.stderr or ''):
+        present = False
+    else:
+        present = True
+        print(f'WARN issue {repo}#{n}: plan probe failed '
+              f'({(r.stderr or "").strip()}); failing open as plan-present',
+              file=sys.stderr)
+    cache[key] = present
+    return present
+
 stamped = 0
 skipped_already = 0
 blocked_marked = 0
+plan_bounced = 0
 failed = 0
 blocker_cache = {}
+plan_cache = {}
 
 for issue in pending:
     n = issue.get('number', 0)
@@ -297,7 +343,7 @@ for issue in pending:
 
     r = subprocess.run(
         ['gh', 'issue', 'view', str(n), '--repo', repo,
-         '--json', 'body,labels'],
+         '--json', 'title,body,labels'],
         capture_output=True, text=True, timeout=15,
     )
     if r.returncode != 0:
@@ -309,11 +355,12 @@ for issue in pending:
     except Exception:
         failed += 1
         continue
+    title = view.get('title', '') or ''
     body = view.get('body', '') or ''
     labels = {(l['name'] if isinstance(l, dict) else l) for l in view.get('labels', [])}
 
     if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
-            or 'fleet:needs-human' in labels):
+            or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels):
         skipped_already += 1
         continue
 
@@ -324,6 +371,44 @@ for issue in pending:
     if 'human:owned' in labels:
         skipped_already += 1
         print(f'INFO issue {repo}#{n}: human:owned — skipping ingest (human de-queued)', file=sys.stderr)
+        continue
+
+    # Planning gate (#1456): refuse to queue an issue that never passed
+    # through planning. Carve-offs stamped human:approved directly carry a
+    # hypothesis, not a plan — without a plan file the claiming worker is
+    # the first to open the code and design-blocks. Bounce to
+    # fleet:needs-plan (routes through PLANNING-PROTOCOL.md; the label also
+    # drops the issue out of the ingest pending set via _INGEST_SKIP_LABELS)
+    # unless the issue is an explicit investigation spike. Sits before the
+    # blocker probes so a bounced issue costs no per-blocker API calls.
+    if (not SPIKE_RE.search(title) and not SPIKE_RE.search(body)
+            and not _plan_exists(repo, n, plan_cache)):
+        comment = (
+            f"Planning gate: no plan file found for this issue — neither "
+            f"committed `.fleet/plans/issue-{n}.md` nor planner-host "
+            f"`~/.fleet/plans/issue-{n}.md` — and it is not an explicit "
+            "investigation spike. Unplanned carve-offs design-block on "
+            "claim (#1456), so adding `fleet:needs-plan` to route it "
+            "through PLANNING-PROTOCOL.md before it can queue. "
+            "— fleet-queue-ingest"
+        )
+        subprocess.run(
+            ['gh', 'issue', 'comment', str(n), '--repo', repo,
+             '--body', comment],
+            capture_output=True, timeout=15,
+        )
+        er = subprocess.run(
+            ['gh', 'issue', 'edit', str(n), '--repo', repo,
+             '--add-label', 'fleet:needs-plan'],
+            capture_output=True, text=True, timeout=15,
+        )
+        if er.returncode != 0:
+            failed += 1
+            print(f'WARN issue {repo}#{n}: add fleet:needs-plan failed: {er.stderr.strip()}', file=sys.stderr)
+            continue
+        plan_bounced += 1
+        print(f'WARN issue {repo}#{n}: no plan file and not an investigation '
+              f'spike — bounced to fleet:needs-plan (#1456)', file=sys.stderr)
         continue
 
     # Blocked-by handling (#1527): queue blocked tasks too. A task whose
@@ -426,13 +511,13 @@ for issue in data.get('unblock_issues', []):
         continue
     unblocked += 1
 
-print(f'{stamped},{skipped_already},{failed},{blocked_marked},{unblocked},{unblock_still}')
+print(f'{stamped},{skipped_already},{failed},{blocked_marked},{unblocked},{unblock_still},{plan_bounced}')
 STAMP_PY
 )
 
 if [[ -n "$stamping_out" ]]; then
-    IFS=',' read -r stamped_count skipped_count failed_count blocked_count unblocked_count unblock_still_count <<< "$stamping_out"
-    log "stamped ${stamped_count:-0} issue(s) (${blocked_count:-0} marked fleet:blocked); skipped ${skipped_count:-0} already-labeled; unblocked ${unblocked_count:-0} (${unblock_still_count:-0} still blocked); ${failed_count:-0} failed"
+    IFS=',' read -r stamped_count skipped_count failed_count blocked_count unblocked_count unblock_still_count plan_bounced_count <<< "$stamping_out"
+    log "stamped ${stamped_count:-0} issue(s) (${blocked_count:-0} marked fleet:blocked); skipped ${skipped_count:-0} already-labeled; bounced ${plan_bounced_count:-0} to fleet:needs-plan; unblocked ${unblocked_count:-0} (${unblock_still_count:-0} still blocked); ${failed_count:-0} failed"
 fi
 
 log "ingestion iteration complete"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -378,7 +378,7 @@ for issue in pending:
     # hypothesis, not a plan — without a plan file the claiming worker is
     # the first to open the code and design-blocks. Bounce to
     # fleet:needs-plan (routes through PLANNING-PROTOCOL.md; the label also
-    # drops the issue out of the ingest pending set via _INGEST_SKIP_LABELS)
+    # drops the issue out of the ingest pending set via the live-label skip guard)
     # unless the issue is an explicit investigation spike. Sits before the
     # blocker probes so a bounced issue costs no per-blocker API calls.
     if (not SPIKE_RE.search(title) and not SPIKE_RE.search(body)

--- a/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Test the fleet-queue-ingest planning gate (#1456).
+#
+# An approved issue with no plan file — neither planner-host staging
+# (~/.fleet/plans/issue-<N>.md) nor the committed repo-side copy
+# (.fleet/plans/issue-<N>.md, probed via `gh api`) — must be bounced to
+# fleet:needs-plan (never stamped fleet:queued), with an explanatory comment.
+# Escape hatches: a local plan file, a committed repo-side plan file, an
+# explicit "investigation spike" in the title/body, and a non-404 probe
+# failure (fail open — a transient API error must never bounce a planned
+# issue).
+#
+# HOME is redirected to a temp dir so the script's hardcoded projection/log/lock
+# paths land in the sandbox, and `gh` is stubbed to canned issue/PR surfaces.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INGEST="$SCRIPT_DIR/fleet-queue-ingest"
+
+if [[ ! -x "$INGEST" ]]; then
+    echo "test setup: fleet-queue-ingest not found at $INGEST" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
+
+# Local staging plan for #741 only — the same-host fast path.
+mkdir -p "$HOME/.fleet/plans"
+echo "# Plan: stub" > "$HOME/.fleet/plans/issue-741.md"
+
+PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
+# #740 = no plan anywhere, not a spike            → bounce to fleet:needs-plan
+# #741 = local ~/.fleet/plans/issue-741.md exists → stamp
+# #742 = committed repo-side plan (gh api 200)    → stamp
+# #743 = no plan, body declares investigation spike → stamp
+# #744 = plan probe fails WITHOUT a 404 (network) → fail open, stamp
+cat > "$PROJ" <<'JSON'
+{"pending_issues":[
+  {"number":740,"repo":"engine"},
+  {"number":741,"repo":"engine"},
+  {"number":742,"repo":"engine"},
+  {"number":743,"repo":"engine"},
+  {"number":744,"repo":"engine"}
+],"unblock_issues":[]}
+JSON
+
+# --- gh stub --------------------------------------------------------------
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
+export COMMENT_LOG="$TMPROOT/comment.log"; : > "$COMMENT_LOG"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    issue)
+        case "$2" in
+            view)
+                case "$3" in
+                    740) echo '{"title":"render: fix residual","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    741) echo '{"title":"render: planned task","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    742) echo '{"title":"render: epic child","body":"**Model:** sonnet\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    743) echo '{"title":"render: probe the culling path","body":"**Model:** opus\n**Blocked by:** (none)\n\nExplicit investigation spike: report findings, no fix expected.","labels":[{"name":"human:approved"}]}' ;;
+                    744) echo '{"title":"render: planned elsewhere","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    *)   echo '{"title":"","body":"","labels":[]}' ;;
+                esac
+                exit 0 ;;
+            edit)
+                printf '%s\n' "$*" >> "$EDIT_LOG"
+                exit 0 ;;
+            comment)
+                printf '%s\n' "$*" >> "$COMMENT_LOG"
+                exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        case "$2" in
+            list) echo '[]'; exit 0 ;;   # scope-shipped: no merged coverage
+            *) exit 0 ;;
+        esac ;;
+    api)
+        # Repo-side plan probe: gh api repos/<slug>/contents/.fleet/plans/issue-<N>.md
+        case "$2" in
+            repos/jakildev/IrredenEngine/contents/.fleet/plans/issue-742.md)
+                echo '.fleet/plans/issue-742.md'; exit 0 ;;
+            repos/jakildev/IrredenEngine/contents/.fleet/plans/issue-744.md)
+                echo "connect: network is unreachable" >&2; exit 1 ;;
+            *)
+                echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+        esac ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+# Per-issue edit-log line (gh issue edit <N> ...) for assertions. Tolerates
+# no-match (empty) without tripping `set -e` / pipefail.
+edit_line() { grep -E "(^| )edit ${1}( |$)" "$EDIT_LOG" | head -1 || true; }
+
+echo "=== run fleet-queue-ingest over planned/unplanned approved issues ==="
+bash "$INGEST" >/dev/null 2>&1 || true
+
+# --- Bounce path -----------------------------------------------------------
+# #740 (no plan, not a spike) → fleet:needs-plan added, fleet:queued withheld.
+l740=$(edit_line 740)
+if [[ -n "$l740" && "$l740" == *"fleet:needs-plan"* && "$l740" != *"fleet:queued"* ]]; then
+    ok "unplanned #740 bounced to fleet:needs-plan without fleet:queued"
+else
+    bad "unplanned #740 mis-handled: '$l740'"
+fi
+# The bounce must not stamp a model label either — labeling is planning output.
+if [[ "$l740" != *"fleet:opus"* && "$l740" != *"fleet:sonnet"* && "$l740" != *"fleet:fable"* ]]; then
+    ok "#740 bounce carried no model label"
+else
+    bad "#740 bounce wrongly stamped a model label: '$l740'"
+fi
+if grep -qE '(^| )comment 740( |$)' "$COMMENT_LOG"; then
+    ok "#740 got an explanatory planning-gate comment"
+else
+    bad "#740 bounced silently — no comment posted"
+fi
+
+# --- Escape hatches --------------------------------------------------------
+# #741 (local staging plan) → stamped fleet:queued, no bounce.
+l741=$(edit_line 741)
+if [[ -n "$l741" && "$l741" == *"fleet:queued"* && "$l741" != *"fleet:needs-plan"* ]]; then
+    ok "#741 (local ~/.fleet/plans plan) stamped fleet:queued"
+else
+    bad "#741 mis-stamped despite local plan: '$l741'"
+fi
+
+# #742 (committed repo-side plan, api 200) → stamped.
+l742=$(edit_line 742)
+if [[ -n "$l742" && "$l742" == *"fleet:queued"* && "$l742" != *"fleet:needs-plan"* ]]; then
+    ok "#742 (committed repo-side plan) stamped fleet:queued"
+else
+    bad "#742 mis-stamped despite committed plan: '$l742'"
+fi
+
+# #743 (explicit investigation spike, no plan) → stamped.
+l743=$(edit_line 743)
+if [[ -n "$l743" && "$l743" == *"fleet:queued"* && "$l743" != *"fleet:needs-plan"* ]]; then
+    ok "#743 (explicit investigation spike) stamped without a plan"
+else
+    bad "#743 spike escape hatch failed: '$l743'"
+fi
+
+# #744 (probe failed without 404) → fail open, stamped.
+l744=$(edit_line 744)
+if [[ -n "$l744" && "$l744" == *"fleet:queued"* && "$l744" != *"fleet:needs-plan"* ]]; then
+    ok "#744 (non-404 probe failure) failed open and stamped"
+else
+    bad "#744 transient probe failure wrongly bounced: '$l744'"
+fi
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #1456

Carve-offs split out of over-scoped tickets bypassed both planning and stacking (the #1370 → #1414/#1431/#1435 pattern), producing design-blocked PRs. PR #1455 closed the architect-role half of Gap 1; this PR lands the three remaining deliverables plus Gap 2 option (a).

## 1. PLANNING-PROTOCOL.md step-2 rigor

`docs/agents/PLANNING-PROTOCOL.md` step 2 now requires a committed plan to:

- name a **verified current state + confirmed repro against the actual code path** (a "likely suspects / confirm during investigation" body is a hypothesis, not a plan),
- **commit to one approach** — "confirm during investigation/design" hand-offs to the worker are explicitly forbidden; an unpickable approach means the issue stays `fleet:needs-plan` or is reframed as an explicit investigation spike,
- **reconcile siblings + in-flight PRs** on the same surface (#1440 prescribed an approach #1420 had already proved wrong).

Step 3 now also requires committing the plan into the repo at `.fleet/plans/issue-<N>.md` via a docs PR (`~/.fleet/plans/` is same-host staging only), and documents the new mechanical gate + its spike escape hatch.

## 2. Mechanical enforcement in `fleet-queue-ingest`

Seam choice: **`fleet-queue-ingest`**, not `fleet-claim reconcile` — ingest is the single moment an approved issue becomes `fleet:queued`, so the gate sits where the bypass happened; reconcile is post-hoc healing and would only catch the gap after the queue already advertised the task.

In the stamping loop, before the blocker probes: an approved issue with **no plan file** — neither planner-host `~/.fleet/plans/issue-<N>.md` nor the committed repo-side `.fleet/plans/issue-<N>.md` (live `gh api` contents probe, host-independent, per-run cached) — and no explicit **"investigation spike"** phrase in its title/body is **bounced to `fleet:needs-plan`** with an explanatory comment instead of being stamped `fleet:queued`. The label drops it out of the ingest pending set (`_INGEST_SKIP_LABELS`) and routes it through PLANNING-PROTOCOL.md; once planned, the planner removes the label and the next ingest pass queues it normally.

Safety: only a confirmed 404 reads as plan-missing; any other probe failure **fails open** (a transient network/API error never bounces a planned issue). `fleet:needs-plan` joined the already-labeled skip set so a bounced issue isn't re-processed, and bounced issues cost zero blocker-probe API calls. The summary counts/log line gained a `bounced N to fleet:needs-plan` field.

Coverage: new `scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh` (follows the existing ingest-test harness exactly — sandboxed `$HOME`, stubbed `gh`, edit/comment logs): bounce path (no `fleet:queued`, no model label, comment posted) + all four escape hatches (local plan, committed repo-side plan, investigation spike, non-404 probe failure fail-open).

## 3. Per-child plan rigor in file-epic

`docs/agents/skills/file-epic.md` (the canonical shared flow — the repo `SKILL.md` is a deltas-only wrapper per `docs/design/skill-sharing.md`) step 6 now requires each per-ticket plan to meet PLANNING-PROTOCOL step-2 rigor on its own: verified current state / confirmed repro, one picked approach, sibling + in-flight reconciliation (including what the child assumes its predecessor children have landed) — not a restated phase line (#1440 was a 23-line stub). Matching anti-pattern entry added.

**Gated self-config note:** `.claude/skills/file-epic/SKILL.md` — the edit was **attempted and went through** in this human-paired session (one Engine-notes delta pointing at the step-2 rigor bar and noting that the engine's ingest plan gate checks `.fleet/plans/issue-<N>.md` existence, so the step-6.5 docs PR is what passes a child cross-host). No gated change was left unapplied; nothing for the "human application" section.

## Gap 2 — option (a) implemented as protocol language

PLANNING-PROTOCOL.md (step-2 stack note) and architect-protocol.md (carve-off paragraph) now require: when **more than one residual** is carved out of the same ticket and they touch the same surface, file them as a **`file-epic` chain** (each child `Blocked by:` its predecessor), never N flat siblings hanging off the parent — flat siblings go claimable simultaneously when the parent closes and get worked in parallel on the same files.

**Follow-up (not built here):** Gap 2 option (b), a queue-ingest/scout heuristic flagging queued issues that share an area/file-set as stack candidates for the architect. Deliberately deferred — the issue leaned toward (a), and (b) needs its own design (area inference, false-positive handling).

## Tests

```
cd scripts/fleet/tests && for t in test_*.sh; do bash "$t"; done   # 21/23 pass
for t in test_*.py; do python3 "$t"; done                          # 17/18 pass
```

- New `test_fleet_queue_ingest_plan_gate.sh`: **7/7 pass**.
- All other ingest/claim/rebase/transition tests pass.
- Pre-existing failures, **reproduced identically on clean `master`** (verified via `git stash`): `test_dispatcher_concurrency_cap.sh` and `test_dispatcher_usage_gate.sh` (known macOS host flakes) and `test_merger_projection.py` (`fleet_state_scout` no longer exports `project_opus_worker` — stale test on master). Not touched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
