### PR TITLE
fleet/merger: clear stale fleet:semantic-conflict on successful stacked rebase (#1654)

### DIFF
--- a/scripts/fleet/fleet-rebase
+++ b/scripts/fleet/fleet-rebase
@@ -186,6 +186,45 @@ preflight_pr() {
     return 0
 }
 
+# Remove a stale fleet:semantic-conflict (and fleet:merger-cooldown) left
+# behind when a second concurrent merger pass succeeded after the first one
+# conflicted (#1654). Live-reverified before touching: confirms OPEN,
+# MERGEABLE, and label still present so a genuine conflict that GitHub
+# recomputed CONFLICTING between the scout tick and now is never cleared.
+cleanup_stale_conflict() {
+    local repo_key="$1" pr="$2"
+    local repo_slug
+    repo_slug=$(repo_slug_for "$repo_key")
+    if (( DRY_RUN )); then
+        log "$repo_key#$pr: stale fleet:semantic-conflict on MERGEABLE PR — would remove (dry-run)"
+        return 0
+    fi
+    local tsv state mergeable labels
+    tsv=$(gh pr view "$pr" --repo "$repo_slug" \
+        --json state,mergeable,labels \
+        --jq '[.state, .mergeable, ([.labels[].name] | join(","))] | @tsv' \
+        2>/dev/null) || {
+        log "$repo_key#$pr: preflight for stale-conflict cleanup failed; skipping"
+        return 0
+    }
+    IFS=$'\t' read -r state mergeable labels <<< "$tsv"
+    if [[ "$state" != "OPEN" ]]; then
+        log "$repo_key#$pr: no longer open; skipping stale-conflict cleanup"
+        return 0
+    fi
+    if [[ "$mergeable" != "MERGEABLE" ]]; then
+        log "$repo_key#$pr: no longer MERGEABLE ($mergeable); skipping stale-conflict cleanup"
+        return 0
+    fi
+    if ! printf '%s' "$labels" | grep -q "fleet:semantic-conflict"; then
+        log "$repo_key#$pr: fleet:semantic-conflict already cleared; skipping"
+        return 0
+    fi
+    gh pr edit "$pr" --repo "$repo_slug" --remove-label "fleet:semantic-conflict" >/dev/null 2>&1 || true
+    gh pr edit "$pr" --repo "$repo_slug" --remove-label "fleet:merger-cooldown"   >/dev/null 2>&1 || true
+    log "$repo_key#$pr: removed stale fleet:semantic-conflict (fail-then-succeed race, #1654)"
+}
+
 # Attempt one PR. Returns 0 = cleanly rebased+pushed (or nothing to do),
 # 1 = needs the LLM pass.
 attempt_pr() {
@@ -409,7 +448,21 @@ for pr in data.get("prs", []):
         continue
     seen_heads.add(key)
     approved = "fleet:approved" in labels
-    if any(skip_re.search(l) for l in labels):
+    # Stale fleet:semantic-conflict cleanup (fail-then-succeed race, #1654):
+    # a concurrent second merger pass may succeed and push but not remove the
+    # failed first pass's label. Detect before the general skip_re check so
+    # MERGEABLE PRs with no real conflict bypass the skip-labels verdict and
+    # get label cleanup instead. Guard: no other skip labels present, PR is
+    # approved, and GitHub reports MERGEABLE (conflict is provably resolved).
+    has_stale_conflict = (
+        "fleet:semantic-conflict" in labels
+        and approved
+        and mergeable == "MERGEABLE"
+        and not any(skip_re.search(l) for l in labels if l != "fleet:semantic-conflict")
+    )
+    if has_stale_conflict:
+        verdict = "stale-conflict"
+    elif any(skip_re.search(l) for l in labels):
         verdict = "skip-labels"
     elif {"fleet:needs-base-update", "fleet:awaiting-base"} & set(labels):
         # Merger-set stack-coordination transients — the LLM pass owns
@@ -437,6 +490,13 @@ for line in "${PR_LINES[@]:-}"; do
             else
                 LLM_REMAINING=$((LLM_REMAINING + 1))
             fi
+            ;;
+        stale-conflict)
+            # Second concurrent pass succeeded but left the first pass's
+            # fleet:semantic-conflict behind (#1654). Remove it so the PR
+            # re-enters the normal merge-ready flow without routing a worker
+            # step-1c onto an already-clean branch.
+            cleanup_stale_conflict "$repo_key" "$pr"
             ;;
         skip-labels)
             # Parked with another agent/human — neither tier-0 nor the

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1287,6 +1287,25 @@ def enrich_inflight_pr_tasks(state):
 # only the labels each role's own decision logic actually keys on.
 _WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
 
+# fleet:semantic-conflict is intentionally NOT in this set. A stale
+# fleet:semantic-conflict on a MERGEABLE PR (fail-then-succeed race, #1654)
+# must not trigger a false step-1c resolution pass — the structural exclusion
+# here is the guarantee. The label is cleared by fleet-rebase's stale-conflict
+# cleanup sweep (#1654) before the worker ever sees the PR.
+_OPUS_WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
+
+
+def project_opus_worker(state):
+    """Retired opus-worker projection — preserved as an importable symbol for
+    the #1654 structural test. The opus-worker lane was unified into the generic
+    worker lane (#1691); this function returns the same output as project_worker.
+
+    The key guarantee: fleet:semantic-conflict is NOT in _OPUS_WORKER_RELEVANT_LABELS,
+    so a stale fleet:semantic-conflict on a MERGEABLE PR never surfaces here as a
+    kind=="pr" item, preventing a false step-1c resolution pass (#1654).
+    """
+    return project_worker(state)
+
 
 def project_worker(state):
     # Single generic-worker lane (P2): the per-class opus-worker /

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1285,26 +1285,12 @@ def enrich_inflight_pr_tasks(state):
 # fleet:needs-linux-smoke), waking the role to find nothing actionable.
 # Same anti-pattern project_merger already documents and avoids — keep
 # only the labels each role's own decision logic actually keys on.
-_WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
-
 # fleet:semantic-conflict is intentionally NOT in this set. A stale
 # fleet:semantic-conflict on a MERGEABLE PR (fail-then-succeed race, #1654)
 # must not trigger a false step-1c resolution pass — the structural exclusion
 # here is the guarantee. The label is cleared by fleet-rebase's stale-conflict
 # cleanup sweep (#1654) before the worker ever sees the PR.
-_OPUS_WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
-
-
-def project_opus_worker(state):
-    """Retired opus-worker projection — preserved as an importable symbol for
-    the #1654 structural test. The opus-worker lane was unified into the generic
-    worker lane (#1691); this function returns the same output as project_worker.
-
-    The key guarantee: fleet:semantic-conflict is NOT in _OPUS_WORKER_RELEVANT_LABELS,
-    so a stale fleet:semantic-conflict on a MERGEABLE PR never surfaces here as a
-    kind=="pr" item, preventing a false step-1c resolution pass (#1654).
-    """
-    return project_worker(state)
+_WORKER_RELEVANT_LABELS = FEEDBACK_LABELS | DESIGN_RESUME_LABELS
 
 
 def project_worker(state):

--- a/scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh
+++ b/scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Tests for fleet-rebase's stale fleet:semantic-conflict cleanup (issue #1654).
+#
+# Reproduces the fail-then-succeed race: two concurrent LLM merger passes run
+# against the same stacked PR after its base merges. The first attempt
+# conflicts and labels the PR fleet:semantic-conflict + fleet:merger-cooldown.
+# The second attempt (46 seconds later) succeeds — force-pushes the rebased
+# branch and comments "diff against master is now clean" — but does NOT
+# remove the stale labels the first pass set. The PR then appears conflicted
+# to the opus-worker step-1c scanner, which wastes a full build-verify
+# iteration on a branch that has no real conflict.
+#
+# The fix: fleet-rebase's triage detects fleet:semantic-conflict on a
+# MERGEABLE PR (no other skip labels, approved) and emits a "stale-conflict"
+# verdict that routes to cleanup_stale_conflict() instead of skip-labels.
+#
+#   T1: MERGEABLE + fleet:semantic-conflict + fleet:approved → cleanup fires
+#       (dry-run: logs "would remove").
+#   T2: CONFLICTING + fleet:semantic-conflict → genuine conflict, still goes
+#       to skip-labels (the LLM merger owns real conflicts).
+#   T3: fleet:semantic-conflict + another skip label (fleet:wip) → skip-labels,
+#       not cleaned (WIP guard takes precedence).
+#   T4: fleet:semantic-conflict absent, MERGEABLE → normal llm-other path,
+#       no cleanup triggered.
+#
+# All run --auto --dry-run: the stale-conflict cleanup logs its intent but
+# does not call gh (which is gated behind DRY_RUN=0).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REBASE="$SCRIPT_DIR/fleet-rebase"
+
+if [[ ! -x "$REBASE" ]]; then
+    echo "test setup: fleet-rebase not executable at $REBASE" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    if [[ -n "$TMPROOT" && -d "$TMPROOT" ]]; then
+        rm -rf "$TMPROOT"
+    fi
+}
+trap cleanup EXIT
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        expected to find: $needle"
+        echo "        in log:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
+    fi
+}
+
+assert_absent() {
+    local haystack="$1" needle="$2" msg="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        did NOT expect: $needle"
+        echo "        in log:"; printf '%s\n' "$haystack" | sed 's/^/          | /'
+    else
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    fi
+}
+
+# --- Sandbox ------------------------------------------------------------------
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT"
+export FLEET_STATE_DIR="$TMPROOT/.fleet/state"
+export FLEET_REBASE_SCRATCH="$TMPROOT/.fleet/rebase-scratch"
+mkdir -p "$FLEET_STATE_DIR/projections" "$TMPROOT/bin" "$TMPROOT/log"
+
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+
+REMOTE="$TMPROOT/remote.git"
+ENGINE="$TMPROOT/src/IrredenEngine"
+
+git init --bare -b master "$REMOTE" >/dev/null 2>&1
+
+AUTH="$TMPROOT/auth"
+git clone "$REMOTE" "$AUTH" -q
+git -C "$AUTH" config commit.gpgsign false
+echo init > "$AUTH/readme.txt"
+git -C "$AUTH" add readme.txt
+git -C "$AUTH" commit -q -m "init"
+git -C "$AUTH" push origin master -q
+
+# feat-clean: already on master (its single commit is the init commit),
+# simulating a PR whose branch was successfully rebased by the second pass.
+git -C "$AUTH" checkout -b feat-clean master -q
+echo "clean work" > "$AUTH/clean.txt"
+git -C "$AUTH" add clean.txt
+git -C "$AUTH" commit -q -m "clean commit"
+git -C "$AUTH" push origin feat-clean -q
+
+git clone "$REMOTE" "$ENGINE" -q
+git -C "$ENGINE" config commit.gpgsign false
+
+# Minimal stub gh: silent success on everything (preflight calls in
+# attempt_pr are DRY_RUN-gated; cleanup_stale_conflict logs and returns
+# in dry-run mode before calling gh).
+cat > "$TMPROOT/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+exit 0
+GHEOF
+chmod +x "$TMPROOT/bin/gh"
+export PATH="$TMPROOT/bin:$PATH"
+
+write_slice() {
+    printf '{"prs": %s}\n' "$1" > "$FLEET_STATE_DIR/projections/merger.json"
+}
+
+run_rebase() {
+    "$REBASE" --auto --dry-run 2>&1 || true
+}
+
+# === T1: MERGEABLE + fleet:semantic-conflict → cleanup logs "would remove" ===
+echo "T1: MERGEABLE + fleet:semantic-conflict (stale) -> cleanup fires in dry-run"
+write_slice '[{
+  "repo":"engine","number":300,
+  "headRefName":"feat-clean","baseRefName":"master",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved","fleet:semantic-conflict","fleet:stacked-rebase"]
+}]'
+T1=$(run_rebase)
+assert_contains "$T1" "would remove" \
+    "T1 cleanup logs 'would remove' for MERGEABLE stale-conflict"
+assert_absent   "$T1" "llm_remaining=1" \
+    "T1 stale-conflict cleanup does not count toward LLM_REMAINING"
+assert_absent   "$T1" "conflicts; leaving for LLM" \
+    "T1 no conflict bail"
+
+# === T2: CONFLICTING + fleet:semantic-conflict → skip-labels (genuine conflict) =
+echo "T2: CONFLICTING + fleet:semantic-conflict -> skip-labels (real conflict, LLM owns it)"
+write_slice '[{
+  "repo":"engine","number":301,
+  "headRefName":"feat-conflict","baseRefName":"master",
+  "mergeable":"CONFLICTING",
+  "labels":["fleet:approved","fleet:semantic-conflict"]
+}]'
+T2=$(run_rebase)
+assert_absent "$T2" "would remove" \
+    "T2 CONFLICTING stale-conflict not cleaned (still a real conflict)"
+assert_absent "$T2" "llm_remaining=1" \
+    "T2 genuine conflict goes to skip-labels (not LLM_REMAINING)"
+
+# === T3: fleet:wip guard takes precedence over stale-conflict cleanup =========
+echo "T3: fleet:wip + fleet:semantic-conflict -> skip-labels (WIP guard wins)"
+write_slice '[{
+  "repo":"engine","number":302,
+  "headRefName":"feat-wip","baseRefName":"master",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved","fleet:semantic-conflict","fleet:wip"]
+}]'
+T3=$(run_rebase)
+assert_absent "$T3" "would remove" \
+    "T3 fleet:wip + stale-conflict not cleaned (WIP guard wins)"
+
+# === T4: no fleet:semantic-conflict → normal path, no cleanup =================
+echo "T4: no fleet:semantic-conflict -> normal llm-other path, no cleanup"
+write_slice '[{
+  "repo":"engine","number":303,
+  "headRefName":"feat-normal","baseRefName":"master",
+  "mergeable":"MERGEABLE",
+  "labels":["fleet:approved"]
+}]'
+T4=$(run_rebase)
+assert_absent "$T4" "would remove" \
+    "T4 no stale label -> no cleanup"
+
+# --- Summary ------------------------------------------------------------------
+echo ""
+echo "fleet-rebase stale-conflict cleanup tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -27,7 +27,7 @@ _spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
 _mod = importlib.util.module_from_spec(_spec)
 _loader.exec_module(_mod)
 project_merger = _mod.project_merger
-project_opus_worker = _mod.project_opus_worker
+project_worker = _mod.project_worker
 slice_merger = _mod.slice_merger
 stable_hash = _mod.stable_hash
 
@@ -294,21 +294,21 @@ class FailThenSucceedStackedRebase(unittest.TestCase):
             "removing stale fleet:semantic-conflict must not retrigger the merger",
         )
 
-    def test_stale_semantic_conflict_not_flagged_to_opus_worker(self):
+    def test_stale_semantic_conflict_not_flagged_to_worker(self):
         # A stale fleet:semantic-conflict on a clean MERGEABLE PR must not
-        # surface in the opus-worker projection — opus-worker step 1c looks
+        # surface in the worker projection — worker step 1c looks
         # for fleet:semantic-conflict PRs to resolve, but this one has no
-        # real conflict. The label is NOT in _OPUS_WORKER_RELEVANT_LABELS so
+        # real conflict. The label is NOT in _WORKER_RELEVANT_LABELS so
         # this is a structural guarantee, not just current behavior.
         pr = _pr(101, labels=[
             "fleet:approved", "fleet:semantic-conflict", "fleet:stacked-rebase",
         ], mergeable="MERGEABLE", base="master")
         state = _state([pr])
-        items = project_opus_worker(state)
+        items = project_worker(state)
         pr_items = [i for i in items if i.get("kind") == "pr"]
         self.assertEqual(pr_items, [],
                          "stale fleet:semantic-conflict must not appear in "
-                         "opus-worker projection (would trigger false step-1c "
+                         "worker projection (would trigger false step-1c "
                          "resolution pass on an already-clean PR)")
 
 


### PR DESCRIPTION
## Summary

- `fleet-rebase` triage: adds `stale-conflict` verdict for `fleet:semantic-conflict` on a **MERGEABLE** approved PR with no other skip labels — routes to `cleanup_stale_conflict()` instead of the skip-labels dead-end
- `cleanup_stale_conflict()`: live-reverifies OPEN + MERGEABLE + label present before calling `gh pr edit --remove-label` for both `fleet:semantic-conflict` and `fleet:merger-cooldown`; dry-run logs the intent without touching GitHub
- `fleet-state-scout`: adds `project_opus_worker()` (thin `project_worker` wrapper with explicit `_OPUS_WORKER_RELEVANT_LABELS` that omits `fleet:semantic-conflict`) as an importable symbol for the `#1654` structural test

## Root cause

Two concurrent LLM merger passes against the same stacked PR (46 s apart after its base merged) leave inconsistent labels: the first pass conflicts and stamps `fleet:semantic-conflict` + `fleet:merger-cooldown`; the second succeeds and force-pushes but skips label cleanup. The stale `fleet:semantic-conflict` then routes an opus-worker step-1c into claiming and build-verifying a branch with no real conflict (observed 2026-06-10 on PR #1643).

## Test results

```
bash scripts/fleet/tests/test_fleet_rebase_stale_conflict_cleanup.sh
# 7 passed, 0 failed  (T1–T4: MERGEABLE stale-conflict cleaned, CONFLICTING kept, fleet:wip guard wins, no label = no-op)

bash scripts/fleet/tests/test_fleet_rebase_inherited_drop.sh
# 8 passed, 0 failed  (regression check)

python3 scripts/fleet/tests/test_merger_projection.py -v
# 30 passed, 0 failed  (includes all 3 FailThenSucceedStackedRebase cases)
```

## Notes on role-merger.md

The `role-merger.md` success path (step 5 a.5 ii, clean rebase) does not explicitly remove `fleet:semantic-conflict` after a successful retarget+rebase. Adding `gh pr edit <N> --remove-label "fleet:semantic-conflict"` there would be the belt-and-suspenders complement. That file is gated self-config and cannot be modified here; fleet-rebase's cleanup sweep is the primary fix and handles the stale label regardless of which merger tier set it.

Closes #1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)