### PR TITLE
render: accumulate real per-stage GPU timing (fix Max==Avg)

### DIFF
--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -12,6 +12,10 @@ namespace IRRender {
 
 inline constexpr float kFrameTimeBudgetMs = 1000.0f / 60.0f;
 
+// Number of named GPU stages in `gpuStageRegistry()`. Single source of truth
+// for both the registry array and the parallel per-stage accumulator array.
+inline constexpr std::size_t kGpuStageCount = 20;
+
 struct GpuStageTiming {
     float canvasClearMs_ = 0.0f;
     float voxelCompactMs_ = 0.0f;
@@ -143,6 +147,47 @@ inline VoxelCullAccumulator &voxelCullAccumulator() {
     return instance;
 }
 
+// Per-stage running GPU-timing accumulator. The `gpu_stage_timing_observer`
+// records one sample per resolved timestamp pair per stage; the world's
+// profile-report builder drains the array (indexed parallel to
+// `gpuStageRegistry()` order) at shutdown for true avg / min / max across the
+// run. The single `GpuStageTiming::*Ms_` field only ever holds the *last*
+// frame's sample, so without this accumulator the report can only echo that
+// one value — which is why every stage previously reported Avg == Max (#1738).
+// `enableFrameTiming(true)` calls `resetGpuStageAccumulators()` so each
+// measurement run starts from zero.
+struct GpuStageAccumulator {
+    double sumMs_ = 0.0;
+    float maxMs_ = 0.0f;
+    float minMs_ = 0.0f;
+    std::uint32_t sampleCount_ = 0;
+
+    void record(float ms) {
+        sumMs_ += ms;
+        maxMs_ = IRMath::max(maxMs_, ms);
+        minMs_ = sampleCount_ == 0 ? ms : IRMath::min(minMs_, ms);
+        ++sampleCount_;
+    }
+
+    void reset() {
+        sumMs_ = 0.0;
+        maxMs_ = 0.0f;
+        minMs_ = 0.0f;
+        sampleCount_ = 0;
+    }
+};
+
+inline std::array<GpuStageAccumulator, kGpuStageCount> &gpuStageAccumulators() {
+    static std::array<GpuStageAccumulator, kGpuStageCount> instance{};
+    return instance;
+}
+
+inline void resetGpuStageAccumulators() {
+    for (auto &acc : gpuStageAccumulators()) {
+        acc.reset();
+    }
+}
+
 // Authoritative mapping name → field → budget. `gpu_stage_timing_observer`
 // resolves a system's tag against this table; pass the same name to
 // `IRRender::tagGpuStage(system, "<name>")` and the observer fills the
@@ -160,9 +205,10 @@ inline VoxelCullAccumulator &voxelCullAccumulator() {
 // above — `voxelStage2`'s dispatch now runs inside VOXEL_TO_TRIXEL_STAGE_1),
 // and `shapeCompact` (no system has ever written it; reserved for a
 // future shape-compaction pass). They stay in the registry to keep
-// the Lua API and perf overlay stable; their reported value is 0.0f.
-inline const std::array<GpuStageInfo, 20> &gpuStageRegistry() {
-    static const std::array<GpuStageInfo, 20> registry{{
+// the Lua API and perf overlay stable — the overlay still shows them at
+// 0.0f; the shutdown profile report omits them (sampleCount_ == 0).
+inline const std::array<GpuStageInfo, kGpuStageCount> &gpuStageRegistry() {
+    static const std::array<GpuStageInfo, kGpuStageCount> registry{{
         {"canvasClear", &GpuStageTiming::canvasClearMs_, 0.05f},
         {"voxelCompact", &GpuStageTiming::voxelCompactMs_, 0.10f},
         {"voxelStage1", &GpuStageTiming::voxelStage1Ms_, 0.20f},

--- a/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
@@ -42,6 +42,10 @@ class GpuStageTimingObserver : public IRSystem::TickObserver {
     void tagStage(IRSystem::SystemId system, const GpuStageInfo &info) {
         StageState state{};
         state.info_ = &info;
+        // Index into the parallel `gpuStageAccumulators()` array — `info` is a
+        // reference into the `gpuStageRegistry()` array, so pointer arithmetic
+        // against its base gives the matching accumulator slot.
+        state.registryIndex_ = static_cast<int>(&info - gpuStageRegistry().data());
         state.device_ = IRRender::device();
         if (state.device_ != nullptr && state.device_->supportsGpuTimestampPairs()) {
             const int pairsInFlight =
@@ -104,7 +108,9 @@ class GpuStageTimingObserver : public IRSystem::TickObserver {
             return;
         if (useLegacyTiming()) {
             IRRender::device()->finish();
-            gpuStageTiming().*(it->second.info_->field_) = elapsedMs(m_t0, SteadyClock::now());
+            const float ms = elapsedMs(m_t0, SteadyClock::now());
+            gpuStageTiming().*(it->second.info_->field_) = ms;
+            recordStageSample(it->second.registryIndex_, ms);
             return;
         }
 
@@ -122,6 +128,7 @@ class GpuStageTimingObserver : public IRSystem::TickObserver {
 
     struct StageState {
         const GpuStageInfo *info_ = nullptr;
+        int registryIndex_ = -1;
         std::array<GpuTimestampHandle, kSamplesInFlight> handles_{};
         std::array<bool, kSamplesInFlight> pending_{};
         RenderDevice *device_ = nullptr;
@@ -147,9 +154,21 @@ class GpuStageTimingObserver : public IRSystem::TickObserver {
                 continue;
             if (IRRender::device()->readTimestampPairMs(state.handles_[i], ms)) {
                 gpuStageTiming().*(state.info_->field_) = ms;
+                recordStageSample(state.registryIndex_, ms);
                 state.pending_[i] = false;
             }
         }
+    }
+
+    // Feed one resolved per-frame GPU sample into the running accumulator the
+    // profile report drains. The live `GpuStageTiming::*Ms_` field (read by the
+    // perf overlay) keeps only the last frame; this builds the avg/min/max.
+    static void recordStageSample(int registryIndex, float ms) {
+        if (registryIndex < 0 ||
+            static_cast<std::size_t>(registryIndex) >= gpuStageAccumulators().size()) {
+            return;
+        }
+        gpuStageAccumulators()[registryIndex].record(ms);
     }
 
     static int nextAvailableSlot(StageState &state) {

--- a/engine/profile/include/irreden/profile/profile_report.hpp
+++ b/engine/profile/include/irreden/profile/profile_report.hpp
@@ -22,6 +22,7 @@ struct SystemTimingEntry {
 struct GpuStageEntry {
     std::string name_;
     float totalMs_ = 0.0f;
+    float minMs_ = 0.0f;
     float maxMs_ = 0.0f;
     uint32_t sampleCount_ = 0;
 };

--- a/engine/profile/src/profile_report.cpp
+++ b/engine/profile/src/profile_report.cpp
@@ -156,13 +156,29 @@ void writeProfileReport(const ProfileReport &report, const char *outputPath) {
     // --- GPU stage timing ---
     if (!report.gpuStages_.empty()) {
         std::fprintf(f, "--- GPU stage timing ---\n");
-        std::fprintf(f, "%-36s %9s %9s\n", "Stage", "Avg(ms)", "Max(ms)");
+        std::fprintf(
+            f,
+            "%-36s %9s %9s %9s %7s\n",
+            "Stage",
+            "Avg(ms)",
+            "Min(ms)",
+            "Max(ms)",
+            "Samples"
+        );
 
         for (auto &stage : report.gpuStages_) {
             if (stage.sampleCount_ == 0)
                 continue;
             float avgMs = stage.totalMs_ / static_cast<float>(stage.sampleCount_);
-            std::fprintf(f, "%-36s %9.3f %9.3f\n", stage.name_.c_str(), avgMs, stage.maxMs_);
+            std::fprintf(
+                f,
+                "%-36s %9.3f %9.3f %9.3f %7u\n",
+                stage.name_.c_str(),
+                avgMs,
+                stage.minMs_,
+                stage.maxMs_,
+                stage.sampleCount_
+            );
         }
         std::fprintf(f, "\n");
     }

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -336,6 +336,7 @@ void World::enableFrameTiming(bool enabled) {
         m_systemManager.resetTimingStats();
         IRRender::computeLightVolumeTiming().reset();
         IRRender::voxelCullAccumulator().reset();
+        IRRender::resetGpuStageAccumulators();
     }
 }
 
@@ -411,18 +412,23 @@ void World::buildAndWriteProfileReport() {
 
     auto &gpu = IRRender::gpuStageTiming();
     if (gpu.enabled_ && report.totalFrames_ > 0) {
-        for (const auto &info : IRRender::gpuStageRegistry()) {
-            const float perFrameMs = gpu.*info.field_;
+        // Drain the per-stage accumulator filled by `gpu_stage_timing_observer`
+        // each frame (indexed parallel to `gpuStageRegistry()`). This is a real
+        // running sum / min / max across every sampled frame — not the old
+        // last-frame-snapshot approximation, which reported Avg == Max on every
+        // stage because `GpuStageTiming::*Ms_` only retains the latest sample
+        // (#1738). Stages with no resolved samples (no writer, or readback never
+        // ready) stay at sampleCount_ == 0 and are skipped by the report writer.
+        const auto &accumulators = IRRender::gpuStageAccumulators();
+        const auto &registry = IRRender::gpuStageRegistry();
+        for (std::size_t i = 0; i < registry.size(); ++i) {
+            const auto &acc = accumulators[i];
             IRProfile::GpuStageEntry stage;
-            stage.name_ = std::string(info.name_);
-            // totalMs_ is an approximation: the GpuStageTiming struct only
-            // keeps the last frame's sample, not a running sum across all
-            // frames. Multiplying by totalFrames_ estimates total GPU cost
-            // assuming steady-state — good enough for a summary report,
-            // not a true accumulator. Same snapshot is used for maxMs_.
-            stage.totalMs_ = perFrameMs * static_cast<float>(report.totalFrames_);
-            stage.maxMs_ = perFrameMs;
-            stage.sampleCount_ = report.totalFrames_;
+            stage.name_ = std::string(registry[i].name_);
+            stage.totalMs_ = static_cast<float>(acc.sumMs_);
+            stage.minMs_ = acc.minMs_;
+            stage.maxMs_ = acc.maxMs_;
+            stage.sampleCount_ = acc.sampleCount_;
             report.gpuStages_.push_back(std::move(stage));
         }
     }


### PR DESCRIPTION
## Summary
- The GPU-stage section of `save_files/profile_report.txt` reported **`Avg == Max` on every stage** (and undercounted vs frame time). Root cause: `World::buildAndWriteProfileReport` synthesized each stage's `totalMs_`/`maxMs_` from a **single last-frame** `GpuStageTiming::*Ms_` snapshot — `total = perFrameMs * totalFrames_`, `max = perFrameMs` — so `Avg = total / frames = perFrameMs = Max`. No per-frame variance ever reached the report.
- Add a real per-stage accumulator `GpuStageAccumulator` (sum / min / max / count) alongside the existing sibling accumulators in `gpu_stage_timing.hpp`. `gpu_stage_timing_observer` records one sample per resolved timestamp pair per frame (both the timestamp-pair and legacy-`finish()` paths); the report drains it truthfully at shutdown.
- Report gains **Min** and **Samples** columns; no-writer stages now drop out (`sampleCount_ == 0`) instead of printing fake `0.000` rows. `enableFrameTiming(true)` resets the accumulator so each measurement run starts clean.
- **Backend-agnostic** — helps OpenGL too. On OpenGL, where `glQueryCounter` already brackets the whole stage, the per-stage numbers are now fully trustworthy.

## Scope / follow-up
This fixes the titled symptom (single-sample-per-run → `Max == Avg`). On **Metal** the statistics are now real but still **per-encoder-scoped**: `createComputeEncoder` consumes the timestamp attachment on only the first encoder of a stage, so multi-encoder stages still undercount (stages sum to <1 ms vs a ~57 ms frame). That is a distinct *collection* bug (vs this *aggregation* fix) and is split out to **#1746** with a concrete candidate fix.

## Test plan
- [x] `fleet-build --target IRPerfGrid` clean (macOS/Metal).
- [x] `fleet-run IRPerfGrid --auto-profile 200 --zoom 8 --subdivision-mode full --base-subdivisions 1` — GPU stage section now shows distinct Avg / Min / Max with ~199 Samples per stage (e.g. `voxelStage1  avg=0.200 min=0.039 max=0.935`), vs the pre-fix `Avg == Max` on every row.
- [ ] Linux/OpenGL smoke (cross-host): real per-stage avg/min/max over the run.

Closes #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)