### PR TITLE
fleet: state.json non-atomic write race — atomic write_atomic + reader retry (#1750)

### DIFF
--- a/scripts/fleet/fleet-epic-status
+++ b/scripts/fleet/fleet-epic-status
@@ -77,12 +77,29 @@ def _gh_json(args):
         return None
 
 
+def read_json_retry(path, attempts=3, backoff=0.05):
+    # Near-twin of fleet-state-scout's helper: retry a torn/missing cache read a
+    # few times so a reader that loses the race against the scout's atomic
+    # os.replace recovers instead of raising spuriously. Raises the last error
+    # after `attempts` tries so callers keep their fallback. Kept local rather
+    # than shared — these scripts can't import a sibling module reliably under
+    # the ~/bin symlink resolution hazard (#1578); keep in sync. (#1750)
+    last = None
+    for i in range(attempts):
+        try:
+            return json.loads(pathlib.Path(path).read_text())
+        except (json.JSONDecodeError, FileNotFoundError) as exc:
+            last = exc
+            time.sleep(backoff * (i + 1))
+    raise last
+
+
 def load_state_cache():
     """Return (data, is_fresh). is_fresh=True when mtime < CACHE_MAX_AGE_S."""
     try:
         p = pathlib.Path(STATE_JSON)
         mtime = p.stat().st_mtime
-        data = json.loads(p.read_text())
+        data = read_json_retry(STATE_JSON)
         return data, (time.time() - mtime) < CACHE_MAX_AGE_S
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return None, False

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -25,6 +25,7 @@ import re
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -1910,9 +1911,51 @@ SLICERS = {
 
 
 def write_atomic(path: Path, payload: str) -> None:
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(payload)
-    os.replace(tmp, path)
+    # Replace `path` with `payload` so a concurrent reader only ever sees the
+    # complete prior file or the complete new one — never a half-written splice.
+    #
+    # #1750: a FIXED temp name (the old `path.with_suffix(".tmp")`) is the bug.
+    # os.replace is atomic, but two overlapping writers (the 30s fleet-up scout
+    # tick racing a manual / solo-architect scout run, or an overlong tick) shared
+    # one `<name>.tmp`: writer B could os.replace a temp that writer A was still
+    # mid-write into — the reader then json.loads a truncated file. A per-call
+    # unique temp gives each writer its own file; whichever renames last wins, and
+    # no reader ever sees a partial. The temp MUST live in path.parent: os.replace
+    # is only atomic within one filesystem, so a /tmp temp would silently degrade
+    # to a non-atomic cross-device copy. fsync is durability insurance — the rename
+    # is the reader-visibility barrier, not the fsync.
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix="." + path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def read_json_retry(path, attempts=3, backoff=0.05):
+    # Script-side cache readers can still lose the race against a concurrent
+    # os.replace on a slow filesystem; one short retry recovers instead of
+    # surfacing a spurious parse error. Raises the last error after `attempts`
+    # tries so callers keep their existing fallback semantics. (Workers read the
+    # cache out-of-band via the Read tool and can't call this, but the unique-temp
+    # write_atomic above already closes their torn-read window.) A near-twin lives
+    # in fleet-epic-status — the two scripts can't share a module without the
+    # ~/bin symlink module-resolution hazard (#1578), so keep them in sync.
+    last = None
+    for i in range(attempts):
+        try:
+            return json.loads(Path(path).read_text())
+        except (json.JSONDecodeError, FileNotFoundError) as exc:
+            last = exc
+            time.sleep(backoff * (i + 1))
+    raise last
 
 
 def update_role_trigger(role: str, projection) -> bool:
@@ -1934,7 +1977,7 @@ def collect_state():
     # data instead of writing empty arrays into a fresh-timestamped snapshot.
     _prev_repos = {}
     try:
-        _prev_repos = json.loads(STATE_FILE.read_text()).get("repos", {})
+        _prev_repos = read_json_retry(STATE_FILE).get("repos", {})
     except (FileNotFoundError, json.JSONDecodeError):
         pass
 

--- a/scripts/fleet/tests/test_state_json_atomic_write.py
+++ b/scripts/fleet/tests/test_state_json_atomic_write.py
@@ -1,0 +1,204 @@
+"""Tests for the atomic cache write + tolerant reader in fleet-state-scout (#1750).
+
+The bug: `write_atomic` used a FIXED temp name (`<name>.tmp`), so two concurrent
+writers on the same target (the 30s fleet-up scout tick racing a manual /
+solo-architect scout run, or an overlong tick) shared one temp — writer B could
+os.replace a file writer A was still mid-write into, exposing a truncated splice
+to a reader's json.loads. The fix gives each call a unique temp via
+`tempfile.mkstemp(dir=path.parent)` + fsync + os.replace.
+
+Covers:
+  - write_atomic round-trips and leaves no temp behind (success + error paths);
+  - the cross-PROCESS race: many writers hammering one target with distinct
+    complete payloads never expose a partial/spliced file to a raw reader;
+  - read_json_retry returns on valid input, recovers when the file becomes valid
+    mid-retry, and raises the last error (not a spurious one) when it never does.
+
+The race is cross-process, not cross-thread — Python's GIL serialises enough of a
+write_text that threads rarely interleave the way processes do (see the plan's
+gotcha). So the concurrency case uses subprocess writers, each loading the real
+write_atomic from the scout, with a large payload + many iterations tuned to
+exercise the interleave window the shared-temp bug exposed.
+"""
+import glob
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+
+
+def _load_scout():
+    loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+    spec = importlib.util.spec_from_loader("fleet_state_scout", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_scout()
+write_atomic = _mod.write_atomic
+read_json_retry = _mod.read_json_retry
+
+# A subprocess writer that drives the REAL write_atomic (loaded from the scout)
+# in a tight loop with one writer-unique, complete payload. argv:
+#   <scout-path> <target> <writer-id> <iters> <blob-bytes>
+_WRITER_SRC = r"""
+import importlib.machinery, importlib.util, json, sys
+from pathlib import Path
+
+scout_path, target, wid, iters, blob_bytes = (
+    sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5]))
+loader = importlib.machinery.SourceFileLoader("fleet_state_scout", scout_path)
+spec = importlib.util.spec_from_loader("fleet_state_scout", loader)
+mod = importlib.util.module_from_spec(spec)
+loader.exec_module(mod)
+
+# Distinct, complete payload for this writer. The blob makes the write big
+# enough to actually interleave; a spliced read is either invalid JSON or a
+# wrong/short blob, both of which the parent detects.
+payload = json.dumps(
+    {"writer": wid, "blob": str(wid) * blob_bytes}, sort_keys=True) + "\n"
+for _ in range(iters):
+    mod.write_atomic(Path(target), payload)
+"""
+
+
+def _expected_payload(wid, blob_bytes):
+    return json.dumps(
+        {"writer": wid, "blob": str(wid) * blob_bytes}, sort_keys=True) + "\n"
+
+
+class TestWriteAtomic(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._dir.name)
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def test_roundtrip_and_no_temp_left(self):
+        target = self.tmp / "state.json"
+        payload = json.dumps({"a": 1, "b": [2, 3]}, sort_keys=True) + "\n"
+        write_atomic(target, payload)
+        self.assertEqual(target.read_text(), payload)
+        # No leftover temp from the unique-name mkstemp path.
+        self.assertEqual(sorted(glob.glob(str(self.tmp / "*.tmp"))), [])
+
+    def test_replaces_existing_completely(self):
+        target = self.tmp / "state.json"
+        write_atomic(target, json.dumps({"old": True}) + "\n")
+        new_payload = json.dumps({"new": True, "n": 42}) + "\n"
+        write_atomic(target, new_payload)
+        self.assertEqual(json.loads(target.read_text()), {"new": True, "n": 42})
+
+    def test_error_path_cleans_up_temp_and_keeps_old_file(self):
+        target = self.tmp / "state.json"
+        write_atomic(target, json.dumps({"keep": "me"}) + "\n")
+        # os.replace blows up (target turned into a directory under it); the temp
+        # must be unlinked and the prior file left intact.
+        with patch.object(_mod.os, "replace", side_effect=OSError("boom")):
+            with self.assertRaises(OSError):
+                write_atomic(target, json.dumps({"lost": True}) + "\n")
+        self.assertEqual(json.loads(target.read_text()), {"keep": "me"})
+        self.assertEqual(sorted(glob.glob(str(self.tmp / "*.tmp"))), [])
+
+    def test_concurrent_writers_never_expose_a_partial(self):
+        target = self.tmp / "state.json"
+        writer_py = self.tmp / "_writer.py"
+        writer_py.write_text(_WRITER_SRC)
+
+        n_writers = 4
+        iters = 120
+        blob_bytes = 120_000  # ~120 KB payload — big enough to interleave
+        expected = {_expected_payload(w, blob_bytes) for w in range(n_writers)}
+
+        # Pre-seed so the target always exists for the reader (atomic replace
+        # never unlinks it, so it stays present for the whole run).
+        target.write_text(_expected_payload(0, blob_bytes))
+
+        procs = [
+            subprocess.Popen(
+                [sys.executable, str(writer_py), str(_SCRIPT), str(target),
+                 str(w), str(iters), str(blob_bytes)])
+            for w in range(n_writers)
+        ]
+
+        # Hammer the target with a RAW reader (no retry) while the writers run.
+        # The unique-temp + atomic-replace guarantee means a raw read must ALWAYS
+        # see one writer's complete payload — never a partial/spliced file.
+        partial_reads = 0
+        observed = set()
+        reads = 0
+        while any(p.poll() is None for p in procs):
+            try:
+                text = target.read_text()
+                json.loads(text)  # raises on a truncated/spliced file
+                observed.add(text)
+                reads += 1
+            except json.JSONDecodeError:
+                partial_reads += 1
+            except FileNotFoundError:
+                partial_reads += 1
+
+        for p in procs:
+            self.assertEqual(p.wait(), 0, "writer subprocess crashed")
+
+        self.assertEqual(partial_reads, 0,
+                         "raw reader saw a torn/partial state.json")
+        self.assertGreater(reads, 0, "reader never overlapped the writers")
+        # Every complete snapshot the reader saw is exactly one writer's payload.
+        self.assertTrue(observed.issubset(expected),
+                        "reader saw a payload that was not any writer's complete output")
+        # No temp files survive a clean run.
+        self.assertEqual(sorted(glob.glob(str(self.tmp / "*.tmp"))), [])
+
+
+class TestReadJsonRetry(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._dir.name)
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def test_returns_parsed_on_valid_file(self):
+        target = self.tmp / "state.json"
+        data = {"ok": True, "xs": [1, 2, 3]}
+        target.write_text(json.dumps(data))
+        self.assertEqual(read_json_retry(target), data)
+
+    def test_raises_last_error_when_never_valid(self):
+        target = self.tmp / "state.json"
+        target.write_text("{ not json")
+        with self.assertRaises(json.JSONDecodeError):
+            read_json_retry(target, attempts=3, backoff=0)
+
+    def test_raises_filenotfound_when_absent(self):
+        with self.assertRaises(FileNotFoundError):
+            read_json_retry(self.tmp / "nope.json", attempts=2, backoff=0)
+
+    def test_recovers_when_file_becomes_valid_mid_retry(self):
+        target = self.tmp / "state.json"
+        target.write_text("{ broken")  # invalid on the first attempt
+        good = {"recovered": True}
+        flipped = {"done": False}
+
+        def fake_sleep(_):
+            if not flipped["done"]:
+                target.write_text(json.dumps(good))
+                flipped["done"] = True
+
+        with patch.object(_mod.time, "sleep", fake_sleep):
+            self.assertEqual(read_json_retry(target, attempts=3, backoff=0.001), good)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `write_atomic` used a fixed `<name>.tmp` temp, so two overlapping scout writers (the 30s fleet-up daemon tick racing a manual/solo-architect scout run, or an overlong tick) could `os.replace` a temp the other was still mid-writing — exposing a truncated `state.json` to a reader's `json.loads`. Now each call uses a unique `mkstemp` temp in the target's own directory (keeps `os.replace` atomic — same filesystem), fsyncs, and unlinks on error. One change covers `state.json` plus every projection slice, per-PR/issue/diff cache, and seen-hash the scout writes via `write_atomic`.
- Added `read_json_retry` for the script-side cache readers — the scout's `_prev_repos` load and `fleet-epic-status`'s `load_state_cache` — so a reader that still loses the race recovers instead of raising a spurious parse error. Kept as a small local twin in each script (they can't share a sibling module under the `~/bin` symlink resolution hazard, #1578).
- Confirmed the rest of the cache surface is already covered: the dispatcher only `stat()`s `state.json` and delegates slice reads to `fleet_task_class.py`, which already guards `OSError`/`JSONDecodeError` and defers-and-retries via the dispatcher's `|| out=""`; `fleet-claude-stream` already uses this same unique-temp + fsync + replace pattern.

## Premise correction
- The issue body's "rewrites non-atomically" premise was partly stale — the scout already wrapped writes in an atomic `os.replace`. The real bug was the **shared temp filename**, not a missing rename. Fixed accordingly.
- The "partial-but-stable / empty snapshot" evidence is the degraded-fetch mirage (#1660 / #1682) — a separate root cause with its own last-known-good fallback in `collect_state`. Deliberately not folded in.

## Noted sibling (follow-up candidate, not in this PR)
- `fleet-queue-ingest:156` writes its ingest projection via a fixed `proj_path + '.tmp'` — the same latent fixed-temp pattern. Different subsystem (not `state.json`), lower concurrency, so out of #1750's scope; flagging for a possible follow-up rather than widening this PR.

## Test plan
- [x] New `scripts/fleet/tests/test_state_json_atomic_write.py`: cross-process stress (4 multiprocessing writers + a raw reader, ~120 KB payloads) asserts zero torn/partial reads and clean writer exits; unit cases for round-trip, complete replace, error-path temp cleanup, and `read_json_retry` (valid / missing / persistently-invalid / recovers-mid-retry). Verified it fails against the old shared-temp `write_atomic` (writers crash on the shared temp).
- [x] Existing scout/projection suite green (`test_scout_degraded_fetch`, `test_worker_projection`, `test_merger_projection`, `test_enrich_*`, `test_epic_steward_projection`, `test_queue_manager_projection`, `test_opus_reviewer_projection`, `test_live_blocker_resolution`, `test_issue_queue_parser`).
- [x] `fleet-epic-status` `load_state_cache` smoke-checked against valid/missing/invalid inputs.

Closes #1750

🤖 Generated with [Claude Code](https://claude.com/claude-code)