### PR TITLE
fleet: reject unsafe stackable-fallback bases at offer + accept (#1751)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -789,14 +789,17 @@ cmd_claim() {
                 fi
                 # gh exited 0 above, so an empty diff is a known-empty
                 # claim-commit base (not "unknown") -> the predicate rejects it.
-                stack_reject=$(PR_LABELS="$pr_labels" STACK_DIFF="$stack_diff" python3 -c '
+                if ! stack_reject=$(PR_LABELS="$pr_labels" STACK_DIFF="$stack_diff" python3 -c '
 import os, sys
 sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
 from fleet_stack_base import unsafe_base_reason
 labels = [l for l in os.environ.get("PR_LABELS", "").splitlines() if l]
 files = [f for f in os.environ.get("STACK_DIFF", "").splitlines() if f]
 sys.stdout.write(unsafe_base_reason(labels, files) or "")
-')
+'); then
+                    echo "fleet-claim claim: base-safety check failed (Python error) — refusing to stack on an unverifiable base" >&2
+                    return 1
+                fi
                 if [[ -n "$stack_reject" ]]; then
                     echo "fleet-claim claim: $stackable_pr is not a stackable base ($stack_reject) — refusing claim" >&2
                     return 1

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -114,11 +114,16 @@ unset _fleet_claim_self
 # Defensive check: catch a mis-resolved lib dir before any subcommand runs, so the
 # failure is visible (a clear stderr message) rather than a silent exit 1 from
 # python3's ModuleNotFoundError propagating through a pipefail command substitution.
-if [[ ! -f "$FLEET_LIB_DIR/fleet_branch_match.py" ]]; then
-    echo "fleet-claim: fleet_branch_match.py not found in FLEET_LIB_DIR=$FLEET_LIB_DIR" >&2
-    echo "             Ensure fleet-claim's real script dir is scripts/fleet/ in the engine repo." >&2
-    exit 1
-fi
+# A missing module would otherwise fail OPEN in the --stackable-on guard below
+# (empty reason -> claim proceeds), so fail loud here instead.
+for _fleet_lib in fleet_branch_match.py fleet_stack_base.py; do
+    if [[ ! -f "$FLEET_LIB_DIR/$_fleet_lib" ]]; then
+        echo "fleet-claim: $_fleet_lib not found in FLEET_LIB_DIR=$FLEET_LIB_DIR" >&2
+        echo "             Ensure fleet-claim's real script dir is scripts/fleet/ in the engine repo." >&2
+        exit 1
+    fi
+done
+unset _fleet_lib
 
 # --- input validation -----------------------------------------------------
 
@@ -750,7 +755,7 @@ cmd_claim() {
     local stackable_branch=""
     if [[ -n "$stackable_pr" ]]; then
         local pr_json pr_state pr_head
-        if ! pr_json=$(gh pr view "$stackable_pr" --json state,headRefName 2>/dev/null); then
+        if ! pr_json=$(gh pr view "$stackable_pr" --json state,headRefName,labels 2>/dev/null); then
             echo "fleet-claim claim: failed to fetch PR state for $stackable_pr" >&2
             return 1
         fi
@@ -766,6 +771,34 @@ cmd_claim() {
             OPEN)
                 if [[ -z "$pr_head" ]]; then
                     echo "fleet-claim claim: $stackable_pr returned empty headRefName — refusing claim" >&2
+                    return 1
+                fi
+                # Live base-state cross-check (#1751): an OPEN base may still be
+                # unsafe to stack on — WIP / design-unblocked / amending (head
+                # diff in flux), awaiting-rebase, a fork, or an empty
+                # claim-commit-only skeleton. Verify against LIVE labels + diff
+                # (not the cached projection the scout offered from) using the
+                # same predicate the scout's offer-time filter uses, so offer
+                # and accept can't disagree.
+                local pr_labels stack_diff stack_reject
+                pr_labels=$(printf '%s' "$pr_json" \
+                    | python3 -c 'import sys, json; print("\n".join(l.get("name","") for l in json.load(sys.stdin).get("labels", [])))')
+                if ! stack_diff=$(gh pr diff "$stackable_pr" --name-only 2>/dev/null); then
+                    echo "fleet-claim claim: could not fetch diff for $stackable_pr — refusing to stack on an unverifiable base" >&2
+                    return 1
+                fi
+                # gh exited 0 above, so an empty diff is a known-empty
+                # claim-commit base (not "unknown") -> the predicate rejects it.
+                stack_reject=$(PR_LABELS="$pr_labels" STACK_DIFF="$stack_diff" python3 -c '
+import os, sys
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+from fleet_stack_base import unsafe_base_reason
+labels = [l for l in os.environ.get("PR_LABELS", "").splitlines() if l]
+files = [f for f in os.environ.get("STACK_DIFF", "").splitlines() if f]
+sys.stdout.write(unsafe_base_reason(labels, files) or "")
+')
+                if [[ -n "$stack_reject" ]]; then
+                    echo "fleet-claim claim: $stackable_pr is not a stackable base ($stack_reject) — refusing claim" >&2
                     return 1
                 fi
                 stackable_branch="$pr_head"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -35,6 +35,7 @@ from pathlib import Path
 # scout is run directly or loaded by-path in the unit tests (#1425).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from fleet_branch_match import branch_matches_issue, PARKED_PR_LABELS
+from fleet_stack_base import unsafe_base_reason
 
 ENGINE = Path.home() / "src" / "IrredenEngine"
 GAME = ENGINE / "creations" / "game"
@@ -913,14 +914,6 @@ def model_tags(task):
     return set(MODEL_TOKEN_RE.findall((task.get("model") or "").lower()))
 
 
-_DESIGN_BLOCK_LABELS = frozenset({
-    "fleet:design-blocked", "fleet:design-escalated",
-    # Steward-parked design question (proposal pending on the umbrella) —
-    # stacking on such a PR has the same hazard as a design-blocked one (#1664).
-    "fleet:design-proposed",
-})
-
-
 def _area_prefixes(area_str):
     # Drops entries without '/' (meta-tags like 'tooling') that can't match diff paths.
     if not area_str:
@@ -1220,16 +1213,29 @@ def enrich_stackable_blocker_prs(state):
                 continue
             pr = matches[0]
 
-            # Filter (b): blocker PR is stalled on a design question — the
-            # downstream task can't make forward progress on it.
-            if set(pr.get("labels", [])) & _DESIGN_BLOCK_LABELS:
+            # Filter (b): blocker PR is in a non-stackable base state — parked
+            # on a design question (design-blocked/escalated/proposed/unblocked),
+            # WIP/amending (head diff in flux), awaiting rebase, a fork, or an
+            # empty claim-commit-only skeleton. One shared predicate with the
+            # claim gate (fleet_stack_base) so the offer and the accept can never
+            # disagree (#1751). blocker_files is the cached diff when the PR
+            # detail is cached, else None ("unknown" — don't suppress a
+            # not-yet-cached base; the claim gate re-checks live). A known-empty
+            # list ([]) is a claim-commit-only skeleton and IS rejected.
+            pr_cache_path = PRS_DIR / repo_key / f"{pr['number']}.json"
+            blocker_files = (
+                _blocker_pr_files(repo_key, pr["number"])
+                if pr_cache_path.exists()
+                else None
+            )
+            if unsafe_base_reason(set(pr.get("labels", [])), blocker_files):
                 continue
 
             # Filter (a): downstream task's area already overlaps with the
             # blocker PR's diff — a stackable claim would conflict at review.
+            # Reuse the file list fetched above (don't double-fetch).
             area_prefixes = _area_prefixes(task.get("area") or "")
-            if area_prefixes:
-                blocker_files = _blocker_pr_files(repo_key, pr["number"])
+            if area_prefixes and blocker_files:
                 if any(
                     f.startswith(p) for f in blocker_files for p in area_prefixes
                 ):

--- a/scripts/fleet/fleet_stack_base.py
+++ b/scripts/fleet/fleet_stack_base.py
@@ -1,0 +1,85 @@
+"""Shared "is this PR safe to stack a new task on?" predicate for the fleet.
+
+The stackable-blocked fallback tier lets a worker claim a task whose single
+blocker still has an open PR, basing the new branch on that PR's head so the
+diff stays isolated. Two surfaces decide which bases are eligible:
+
+  * `fleet-state-scout` OFFERS a base by attaching `stackable_blocker_pr`
+    to a queued task (`enrich_stackable_blocker_prs`).
+  * `fleet-claim claim --stackable-on <pr>` ACCEPTS a base, re-verifying it
+    live at claim time.
+
+Both must reject a base that isn't safe to stack on, and they must agree.
+Before #1751 each surface filtered a different (narrow) subset:
+
+  * the scout rejected only design-blocked bases + area-overlap;
+  * the claim gate re-checked only `state` / `headRefName` (MERGED / OPEN /
+    CLOSED), not labels and not the diff.
+
+So a base that was OPEN-but-WIP, OPEN-but-`design-unblocked`, OPEN-but-amending
+(`fleet:amending-<host>-<agent>`), or an OPEN empty claim-commit skeleton sailed
+through both and got stacked on — a half-built or in-flux base that the worker's
+diff then folded in or conflicted against (the 2026-06-06 empty-claim skeleton
+case; cf. the just-design-unblocked skeleton hazard, fleet memory
+`stackable_blocker_empty_skeleton`).
+
+Centralizing the reject-state predicate here means the offer and the accept
+can't drift: both call `unsafe_base_reason()`. The label vocabulary mirrors the
+scout's existing reviewer-skip / design-block sets (a base in any of those
+states is mid-flux for the same reasons a reviewer would skip it) but is kept
+purpose-named here so the two concerns can evolve independently.
+
+Stdlib only — imported by `fleet-state-scout` (pure Python) and by
+`fleet-claim` (bash, via an inline `python3` block through `FLEET_LIB_DIR`),
+exactly like `fleet_branch_match.py`.
+"""
+
+# A base PR carrying any of these labels is in a non-stackable state: the diff
+# is in flux (WIP / amending), parked on a design question (design-*), not yet
+# rebaseable against master (awaiting-*), or not its own work (fork-of). This is
+# a SUPERSET of the scout's old `_DESIGN_BLOCK_LABELS` filter — widening the
+# rejection, never narrowing it.
+NOT_STACKABLE_BASE_LABELS = frozenset({
+    # Work-in-progress / mid-amend — the head diff will move under the stack.
+    "fleet:wip", "human:wip", "fleet:human-amending", "fleet:merger-cooldown",
+    # Parked on a design question — same hazard as design-blocked.
+    "fleet:design-unblocked", "fleet:design-blocked", "fleet:design-escalated",
+    "fleet:design-proposed",
+    # Not yet rebaseable against its own base / not its own work.
+    "fleet:awaiting-base", "fleet:awaiting-upstream-review",
+    "fleet:fork-of-other-pr",
+})
+
+# Dynamic per-host amend claim (`fleet:amending-<host>-<agent>`) — a worker is
+# actively rewriting this PR for feedback, so the head is mid-flux. Matched by
+# prefix, mirroring the scout's `REVIEW_SKIP_PREFIXES`.
+NOT_STACKABLE_BASE_PREFIXES = ("fleet:amending-",)
+
+
+def unsafe_base_reason(labels, changed_files=None):
+    """Return a short human-readable reason a PR is NOT a safe stack base, or
+    None when it is safe.
+
+    `labels` — iterable of the base PR's label names.
+    `changed_files` — the base PR's changed-file paths when known, or None when
+        unknown (the caller couldn't determine them, e.g. a scout cache miss).
+        An empty *known* list ([]) is an empty claim-commit-only skeleton and is
+        rejected; None (unknown) is NOT treated as empty — the caller decides
+        how to handle an unverifiable base (the scout safely omits the offer;
+        the claim gate refuses before ever calling with None).
+    """
+    labels = set(labels or ())
+
+    hit = labels & NOT_STACKABLE_BASE_LABELS
+    if hit:
+        return sorted(hit)[0]
+
+    for label in sorted(labels):
+        for prefix in NOT_STACKABLE_BASE_PREFIXES:
+            if label.startswith(prefix):
+                return label
+
+    if changed_files is not None and len(changed_files) == 0:
+        return "empty claim-commit"
+
+    return None

--- a/scripts/fleet/fleet_stack_base.py
+++ b/scripts/fleet/fleet_stack_base.py
@@ -45,6 +45,9 @@ NOT_STACKABLE_BASE_LABELS = frozenset({
     # Parked on a design question — same hazard as design-blocked.
     "fleet:design-unblocked", "fleet:design-blocked", "fleet:design-escalated",
     "fleet:design-proposed",
+    # Pending merger rebase — diff against master is meaningless until resolved;
+    # stacking would create a two-rebase chain when the conflict is resolved.
+    "fleet:semantic-conflict",
     # Not yet rebaseable against its own base / not its own work.
     "fleet:awaiting-base", "fleet:awaiting-upstream-review",
     "fleet:fork-of-other-pr",

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -7,6 +7,8 @@ importlib because the script has no .py extension.
 """
 import importlib.machinery
 import importlib.util
+import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -45,8 +47,11 @@ def _task(id_, blocked_by):
     return {"id": id_, "blocked_by": blocked_by}
 
 
-def _pr(number, head_ref, author="bot"):
-    return {"number": number, "headRefName": head_ref, "author": author}
+def _pr(number, head_ref, author="bot", labels=None):
+    pr = {"number": number, "headRefName": head_ref, "author": author}
+    if labels is not None:
+        pr["labels"] = labels
+    return pr
 
 
 # ---------------------------------------------------------------------------
@@ -54,6 +59,30 @@ def _pr(number, head_ref, author="bot"):
 # ---------------------------------------------------------------------------
 
 class TestEnrichStackableBlockerPrs(unittest.TestCase):
+
+    def setUp(self):
+        # Point PRS_DIR at an empty temp dir so `pr_cache_path.exists()` (the
+        # empty-claim / known-files check, #1751) is deterministic and never
+        # leaks the live ~/.fleet cache. Tests that exercise the diff path write
+        # a fixture via _write_pr_cache; the rest leave it absent (files
+        # "unknown" → not treated as empty).
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_prs_dir = _mod.PRS_DIR
+        _mod.PRS_DIR = Path(self._tmp.name)
+
+    def tearDown(self):
+        _mod.PRS_DIR = self._orig_prs_dir
+        self._tmp.cleanup()
+
+    def _write_pr_cache(self, repo, number, files):
+        """Write a cached PR detail JSON (the shape `_blocker_pr_files` reads)
+        so a test can give a blocker PR a known diff (empty list = empty
+        claim-commit)."""
+        repo_dir = Path(self._tmp.name) / repo
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        (repo_dir / f"{number}.json").write_text(
+            json.dumps({"files": [{"path": p} for p in files]})
+        )
 
     def test_happy_path_single_match(self):
         """Exactly one PR matches the blocked_by prefix → field is written."""
@@ -234,6 +263,69 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         self.assertEqual(task["stackable_blocker_pr"]["number"], 1316)
         self.assertEqual(task["stackable_blocker_pr"]["headRefName"],
                          "claude/1308-per-axis-trixel-canvas-infra")
+
+    # ---- #1751: non-stackable base-state rejection (offer side) -----------
+
+    def _assert_no_offer(self, labels=None, cached_files="unset"):
+        """A single blocker PR with the given labels / cached diff yields NO
+        stackable_blocker_pr field."""
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(536, "claude/1111-x", labels=labels)]
+        if cached_files != "unset":
+            self._write_pr_cache("engine", 536, cached_files)
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
+
+    def test_wip_base_no_field(self):
+        """fleet:wip base (head diff in flux) is not offered."""
+        self._assert_no_offer(labels=["fleet:wip"])
+
+    def test_human_wip_base_no_field(self):
+        self._assert_no_offer(labels=["human:wip"])
+
+    def test_design_unblocked_base_no_field(self):
+        """A just-design-unblocked skeleton is not offered (#1751 / the
+        2026-06-06 empty-skeleton hazard)."""
+        self._assert_no_offer(labels=["fleet:design-unblocked"])
+
+    def test_design_blocked_base_no_field(self):
+        """Regression: the old filter (b) design-block rejection still holds
+        through the unified predicate."""
+        self._assert_no_offer(labels=["fleet:design-blocked"])
+
+    def test_amending_base_no_field(self):
+        """fleet:amending-<host>-<agent> (dynamic prefix) base is not offered."""
+        self._assert_no_offer(labels=["fleet:amending-mac-worker-2"])
+
+    def test_empty_claim_base_no_field(self):
+        """An OPEN base whose cached diff is empty (claim-commit-only skeleton)
+        is not offered — the 2026-06-06 empty-claim replay."""
+        self._assert_no_offer(labels=None, cached_files=[])
+
+    def test_clean_nonempty_open_base_enriched(self):
+        """A clean OPEN base with a real (non-empty) diff and no reject labels
+        is still offered."""
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(536, "claude/1111-x")]
+        self._write_pr_cache("engine", 536, ["engine/render/x.cpp"])
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 536)
+
+    def test_cache_miss_unknown_files_still_enriched(self):
+        """No cached PR detail (files unknown) + clean labels → still offered;
+        'unknown' is not treated as empty, so a not-yet-cached base isn't
+        suppressed. The claim gate re-checks the diff live."""
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(536, "claude/1111-x")]  # no cache fixture written
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertIn("stackable_blocker_pr",
+                      state["repos"]["engine"]["tasks"]["open"][0])
 
 
 if __name__ == "__main__":

--- a/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
+++ b/scripts/fleet/tests/test_fleet_claim_stackable_live_resolve.sh
@@ -162,6 +162,29 @@ case "$1 $2" in
         echo "[]"
         exit 0
         ;;
+    "pr view")
+        # claim --stackable-on base re-verify (#1751): state + head + labels.
+        # $3 is the PR id passed to --stackable-on.
+        case "$3" in
+            901) printf '%s' '{"state":"OPEN","headRefName":"claude/901-wip","labels":[{"name":"fleet:wip"}]}' ;;
+            902) printf '%s' '{"state":"OPEN","headRefName":"claude/902-empty","labels":[{"name":"fleet:queued"}]}' ;;
+            903) printf '%s' '{"state":"OPEN","headRefName":"claude/903-clean","labels":[{"name":"fleet:queued"}]}' ;;
+            904) printf '%s' '{"state":"OPEN","headRefName":"claude/904-difffail","labels":[{"name":"fleet:queued"}]}' ;;
+            *)   printf '%s' '{"state":"OPEN","headRefName":"claude/x","labels":[]}' ;;
+        esac
+        exit 0
+        ;;
+    "pr diff")
+        # claim --stackable-on live diff: empty output = empty claim-commit,
+        # non-empty = real diff, exit 1 = fetch failure (unverifiable base).
+        case "$3" in
+            902) : ;;                                  # empty diff (claim-commit only)
+            903) printf '%s\n' "engine/render/x.cpp" ;;  # real non-empty diff
+            904) exit 1 ;;                             # fetch failure
+            *)   printf '%s\n' "engine/x.cpp" ;;
+        esac
+        exit 0
+        ;;
     "api "*)
         label=""
         while [[ $# -gt 0 ]]; do
@@ -224,6 +247,36 @@ else
     FAIL=$((FAIL + 1))
     echo "  FAIL: multi-line result does not include claude/101-work-branch"
 fi
+
+# --- #1751: claim --stackable-on rejects an OPEN-but-unsafe base -------------
+# The base re-verify runs before any blocker/model/reservation gate, so an
+# unsafe base refuses the claim outright regardless of the rest of the flow.
+assert_refused() {
+    local pr_id="$1" reason="$2" msg="$3"
+    local err="$TMPROOT/refuse.err"
+    if "$FLEET_CLAIM" claim 3001 worker-test --stackable-on "$pr_id" >/dev/null 2>"$err"; then
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg — claim SUCCEEDED on an unsafe base"
+        return
+    fi
+    if grep -q "$reason" "$err"; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg (cited: $reason)"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg — refused but reason '$reason' not in stderr:"
+        sed 's/^/        /' "$err"
+    fi
+}
+
+echo "T6: claim --stackable-on an OPEN-but-WIP base (#901) → refused"
+assert_refused 901 "not a stackable base (fleet:wip)" "WIP base refused"
+
+echo "T7: claim --stackable-on an OPEN empty-claim base (#902, empty diff) → refused"
+assert_refused 902 "not a stackable base (empty claim-commit)" "empty-claim base refused"
+
+echo "T8: claim --stackable-on a base whose diff fetch fails (#904) → refused"
+assert_refused 904 "refusing to stack on an unverifiable base" "unverifiable base refused"
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_stack_base_guard.py
+++ b/scripts/fleet/tests/test_stack_base_guard.py
@@ -1,0 +1,89 @@
+"""Unit tests for fleet_stack_base.unsafe_base_reason (#1751).
+
+The shared reject-state predicate used by BOTH the scout's offer-time filter
+(enrich_stackable_blocker_prs) and fleet-claim's accept-time --stackable-on
+re-verify. If these two disagree the fallback can offer a base the claim then
+refuses (or vice versa), so the predicate is pinned here independently.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from fleet_stack_base import (  # noqa: E402
+    NOT_STACKABLE_BASE_LABELS,
+    NOT_STACKABLE_BASE_PREFIXES,
+    unsafe_base_reason,
+)
+
+
+class TestUnsafeBaseReason(unittest.TestCase):
+
+    def test_safe_base_returns_none(self):
+        """Clean OPEN base: no reject labels, a real (non-empty) diff → safe."""
+        self.assertIsNone(unsafe_base_reason(["fleet:approved"], ["engine/x.cpp"]))
+        self.assertIsNone(unsafe_base_reason([], ["engine/x.cpp"]))
+        self.assertIsNone(unsafe_base_reason(["IRRender", "fleet:changes-made"],
+                                             ["engine/render/y.cpp"]))
+
+    def test_each_reject_label(self):
+        """Every label in the set is reported by name."""
+        for label in NOT_STACKABLE_BASE_LABELS:
+            with self.subTest(label=label):
+                self.assertEqual(unsafe_base_reason([label]), label)
+
+    def test_wip_and_design_states(self):
+        self.assertEqual(unsafe_base_reason(["fleet:wip"]), "fleet:wip")
+        self.assertEqual(unsafe_base_reason(["human:wip"]), "human:wip")
+        self.assertEqual(unsafe_base_reason(["fleet:design-unblocked"]),
+                         "fleet:design-unblocked")
+        self.assertEqual(unsafe_base_reason(["fleet:design-blocked"]),
+                         "fleet:design-blocked")
+
+    def test_amending_prefix_matched(self):
+        """The dynamic per-host amend claim is matched by prefix, not equality."""
+        for host_agent in ("mac-worker-2", "linux-sonnet-fleet-1", "mac-opus-worker-1"):
+            label = f"fleet:amending-{host_agent}"
+            with self.subTest(label=label):
+                self.assertEqual(unsafe_base_reason([label]), label)
+
+    def test_empty_claim_commit_rejected(self):
+        """A known-empty diff ([]) is an empty claim-commit-only skeleton."""
+        self.assertEqual(unsafe_base_reason([], []), "empty claim-commit")
+        self.assertEqual(unsafe_base_reason(["fleet:approved"], []),
+                         "empty claim-commit")
+
+    def test_unknown_files_not_treated_as_empty(self):
+        """changed_files=None means 'unknown', NOT empty — a clean-labelled base
+        with unknown files is safe (the caller decides; the claim gate fetches
+        live). Distinguishing this from [] prevents suppressing a not-yet-cached
+        base at scout time."""
+        self.assertIsNone(unsafe_base_reason(["fleet:approved"], None))
+        self.assertIsNone(unsafe_base_reason([], None))
+        self.assertIsNone(unsafe_base_reason(["fleet:approved"]))  # default None
+
+    def test_label_reject_precedes_empty_check(self):
+        """A WIP base that also happens to have an empty diff reports the WIP
+        label (label states are checked before the empty-claim fallback)."""
+        self.assertEqual(unsafe_base_reason(["fleet:wip"], []), "fleet:wip")
+
+    def test_prefixes_constant_shape(self):
+        """Guard the amending prefix tuple so a refactor can't silently empty it."""
+        self.assertIn("fleet:amending-", NOT_STACKABLE_BASE_PREFIXES)
+
+    def test_design_block_labels_still_covered(self):
+        """The old scout _DESIGN_BLOCK_LABELS members must remain in the
+        superset (no narrowing of the original design-block rejection)."""
+        for label in ("fleet:design-blocked", "fleet:design-escalated",
+                      "fleet:design-proposed"):
+            with self.subTest(label=label):
+                self.assertIn(label, NOT_STACKABLE_BASE_LABELS)
+
+    def test_accepts_set_or_list(self):
+        """labels may arrive as a list (scout) or a set (claim block)."""
+        self.assertEqual(unsafe_base_reason({"fleet:wip"}), "fleet:wip")
+        self.assertEqual(unsafe_base_reason(("fleet:wip",)), "fleet:wip")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fleet/tests/test_stack_base_guard.py
+++ b/scripts/fleet/tests/test_stack_base_guard.py
@@ -79,6 +79,14 @@ class TestUnsafeBaseReason(unittest.TestCase):
             with self.subTest(label=label):
                 self.assertIn(label, NOT_STACKABLE_BASE_LABELS)
 
+    def test_semantic_conflict_rejected(self):
+        """A PR awaiting merger rebase is not a safe stack base — its diff
+        against master is meaningless until the conflict is resolved, and
+        stacking would create a two-rebase chain."""
+        self.assertEqual(unsafe_base_reason(["fleet:semantic-conflict"]),
+                         "fleet:semantic-conflict")
+        self.assertIn("fleet:semantic-conflict", NOT_STACKABLE_BASE_LABELS)
+
     def test_accepts_set_or_list(self):
         """labels may arrive as a list (scout) or a set (claim block)."""
         self.assertEqual(unsafe_base_reason({"fleet:wip"}), "fleet:wip")


### PR DESCRIPTION
## Summary
- The stackable-blocked fallback could **offer** (scout) and **accept** (`fleet-claim --stackable-on`) a base PR that isn't safe to stack on. The scout filtered only design-blocked bases + area overlap; the claim re-verify fetched only `state`/`headRefName`. So an OPEN base that was WIP, `design-unblocked`, mid-amend (`fleet:amending-<host>-<agent>`), awaiting-rebase, a fork, or an **empty claim-commit-only skeleton** passed both gates — a half-built / in-flux base the worker's diff then folded in or conflicted against (the 2026-06-06 empty-claim skeleton case; cf. the just-design-unblocked-skeleton hazard).
- New shared **`scripts/fleet/fleet_stack_base.py`** owns one reject-state predicate `unsafe_base_reason(labels, changed_files)`, used by **both** surfaces so offer and accept can't disagree — mirroring the `fleet_branch_match.py` module convention.
- **Scout** (`enrich_stackable_blocker_prs`) calls the predicate, reusing the cached diff and treating a PR-cache miss as `None` ("unknown", not "empty") so a not-yet-cached base isn't suppressed. The old `_DESIGN_BLOCK_LABELS` filter is subsumed by the (superset) predicate.
- **fleet-claim** extends the `--stackable-on` live re-verify to fetch `labels` + run `gh pr diff --name-only`, refusing on a non-None reason. A diff-fetch failure refuses (unverifiable base); the `FLEET_LIB_DIR` guard now also requires the new module (fail-loud, not fail-open).

## Test plan
- [x] `python3 -m unittest test_stack_base_guard` — new predicate unit test (10 cases: each reject label, amending prefix, empty-claim, unknown≠empty, label-precedes-empty).
- [x] `python3 -m unittest test_enrich_stackable_blocker_prs` — extended (WIP / human:wip / design-unblocked / design-blocked / amending / empty-claim → no offer; clean non-empty + cache-miss-unknown → offer). 23/23.
- [x] `bash test_fleet_claim_stackable_live_resolve.sh` — added T6/T7/T8: `claim --stackable-on` refuses OPEN-but-WIP, empty-diff, and diff-fetch-fail bases. 10/10.
- [x] Full `python3 -m unittest discover` (364) + `test_fleet_claim_blockers.sh` / `acquire` / `symlink_lib_dir` green (no regression).

Closes #1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)