### PR TITLE
render: depth-only shadow-feeder path — skip stage 2 for off-screen feeders (#1740 item 1)

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -575,6 +575,17 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             IRPrefab::SunShadow::shadowFeederCullViewport(kGpuMargin, shadowFeederParams_);
         frameData_.cullIsoMin_ = ivec2(IRMath::floor(gpuVp.min_));
         frameData_.cullIsoMax_ = ivec2(IRMath::ceil(gpuVp.max_));
+        // Depth-only shadow-feeder path (#1740): the SAME viewport at the same
+        // margin BEFORE shadowFeederCullViewport widened it toward the sun. A
+        // voxel inside gpuVp (it passed the compact cull) but outside this is an
+        // off-screen shadow feeder — stage 2 skips its colour/entity-id taps.
+        // When sun shadows are off the sweep is zero, so gpuVp == this and stage
+        // 2 skips nothing (byte-identical). Same getCullViewport() the widened
+        // form reads above, so the two boxes are derived consistently.
+        const IsoBounds2D visibleVp = IRRender::getCullViewport().isoViewport(kGpuMargin);
+        frameData_.visibleIsoBounds_ = ivec4(
+            ivec2(IRMath::floor(visibleVp.min_)), ivec2(IRMath::ceil(visibleVp.max_))
+        );
         frameDataBuf_->subData(0, sizeof(FrameDataVoxelToCanvas), &frameData_);
 
         // Voxel positions are uploaded via the pending-range queue populated by

--- a/engine/render/include/irreden/render/ir_render_types.hpp
+++ b/engine/render/include/irreden/render/ir_render_types.hpp
@@ -285,6 +285,21 @@ struct FrameDataVoxelToCanvas {
     // offset is unchanged and shaders that read only the prefix need no update;
     // only c_lighting_to_trixel declares it.
     vec4 detachedWorldReceive_ = vec4(0.0f, 0.0f, 0.0f, 0.0f);
+    // Un-widened (no shadow-feeder sweep) iso cull viewport for the depth-only
+    // shadow-feeder path (#1740). `.xy` = floor(min), `.zw` = ceil(max) of the
+    // SAME viewport `cullIsoMin_/cullIsoMax_` derive from, but BEFORE
+    // IRMath::shadowFeederIsoBounds widens it toward the sun. A voxel whose
+    // cardinal iso position lies inside [cullIsoMin_, cullIsoMax_] (it passed
+    // the compact cull) but OUTSIDE this box is an off-screen shadow FEEDER —
+    // it only casts sun shadows via the stage-1 distance bake and is never
+    // displayed / lit / picked, so c_voxel_to_trixel_stage_2 skips its
+    // colour + entity-id taps (stage 1 still writes its full-resolution depth,
+    // which is all the bake + AO read). When sun shadows are off the sweep is
+    // zero, so this equals cullIsoMin_/cullIsoMax_ and stage 2 skips nothing —
+    // byte-identical. Read only by c_voxel_to_trixel_stage_2; std140-appended
+    // after detachedWorldReceive_ (offset 176) so every prior offset is
+    // unchanged and the gather shaders that read only the prefix need no update.
+    ivec4 visibleIsoBounds_ = ivec4(0, 0, 0, 0);
 };
 
 struct FrameDataTrixelToTrixel {
@@ -532,9 +547,16 @@ static_assert(
     "every existing offset — and the default screen-locked path — stays unchanged"
 );
 static_assert(
-    sizeof(FrameDataVoxelToCanvas) == 176,
+    offsetof(FrameDataVoxelToCanvas, visibleIsoBounds_) == 176,
+    "FrameDataVoxelToCanvas::visibleIsoBounds_ must land at offset 176 "
+    "(detachedWorldReceive_ at 160 + 16 B). Appended after the prior last field "
+    "so every existing offset — and the shadows-off byte-identical path — stays "
+    "unchanged"
+);
+static_assert(
+    sizeof(FrameDataVoxelToCanvas) == 192,
     "FrameDataVoxelToCanvas size must mirror its std140 GLSL block "
-    "(detachedWorldReceive_ vec4 append: 160 + 16 = 176)"
+    "(visibleIsoBounds_ ivec4 append: 176 + 16 = 192)"
 );
 
 struct FrameDataSun {

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
@@ -35,6 +35,16 @@ layout(std140, binding = 7) uniform FrameDataVoxelToTrixel {
     // so the GRID path stays byte-identical. Appended after visibleFaceIds
     // (offset 144) to match the CPU struct + stage 1's binding-7 layout.
     uniform vec4 voxelDepthAxis;
+    // detachedWorldReceive_ (offset 160) — declared as padding so the field
+    // below lands at its std140 offset; stage 2 doesn't read it (only
+    // c_lighting_to_trixel does).
+    uniform vec4 _detachedWorldReceivePad;
+    // Un-widened iso cull viewport for the depth-only feeder path (#1740):
+    // .xy = floor(min), .zw = ceil(max). A voxel inside [cullIsoMin, cullIsoMax]
+    // but OUTSIDE this box is an off-screen shadow feeder — stage 2 skips its
+    // colour/entity-id taps (stage 1 still wrote its full-res depth). Matches
+    // FrameDataVoxelToCanvas::visibleIsoBounds_ (offset 176).
+    uniform ivec4 visibleIsoBounds;
 };
 
 layout(std430, binding = 5) readonly buffer PositionBuffer {
@@ -196,6 +206,33 @@ void main() {
             voxelColor, voxelIndex
         );
         return;
+    }
+
+    // Depth-only shadow-feeder path (#1740). On the cardinal single-canvas world
+    // route (perAxisRoute == 0 guaranteed here; the per-axis / smooth / detached
+    // routes returned above), a voxel whose cardinal iso position lies outside
+    // the un-widened visible viewport but inside the shadow-feeder-widened cull
+    // is a SHADOW FEEDER: it exists only to cast sun shadows onto on-screen
+    // pixels through stage 1's distance bake, and is never displayed, lit, or
+    // picked. Stage 1 already wrote its full-resolution depth (the sun-shadow
+    // bake + AO read ONLY trixelDistances), so skipping its colour + entity-id
+    // taps here is byte-identical in rendered output and removes the feeder's
+    // entire stage-2 cost. The +4-iso-px margin baked into visibleIsoBounds
+    // covers the voxel face footprint, so no on-screen pixel is ever a feeder.
+    // When sun shadows are off visibleIsoBounds == cullIsoMin/Max, so nothing is
+    // skipped — byte-identical. Matches the compact cull's cardinal projection
+    // (c_voxel_visibility_compact.glsl) so the classification agrees.
+    if (residualYaw == 0.0 && isDetachedCanvas < 0.5) {
+        ivec3 feederPos = ivec3(round(voxelPosition.xyz));
+        if (cardinalIndex != 0) {
+            feederPos = rotateCardinalZ(feederPos, cardinalIndex);
+            feederPos += cardinalLowerCornerShift(cardinalIndex);
+        }
+        const ivec2 feederIso = pos3DtoPos2DIso(feederPos);
+        if (feederIso.x < visibleIsoBounds.x || feederIso.x > visibleIsoBounds.z ||
+            feederIso.y < visibleIsoBounds.y || feederIso.y > visibleIsoBounds.w) {
+            return;
+        }
     }
 
     if (voxelRenderOptions.x == 0) {

--- a/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
+++ b/engine/render/src/shaders/metal/c_voxel_to_trixel_stage_2.metal
@@ -219,6 +219,31 @@ kernel void c_voxel_to_trixel_stage_2(
         return;
     }
 
+    // Depth-only shadow-feeder path (#1740) — mirror of c_voxel_to_trixel_stage_2.glsl.
+    // On the cardinal single-canvas world route, a voxel whose cardinal iso
+    // position lies outside the un-widened visible viewport but inside the
+    // shadow-feeder-widened cull is an off-screen SHADOW FEEDER: it only casts
+    // sun shadows via stage 1's distance bake and is never displayed/lit/picked.
+    // Stage 1 wrote its full-res depth (the bake + AO read only trixelDistances),
+    // so skipping its colour/entity-id taps is byte-identical and removes the
+    // feeder's stage-2 cost. visibleIsoBounds carries a +4-iso-px margin covering
+    // the face footprint; with sun shadows off it equals cullIsoMin/Max so
+    // nothing is skipped.
+    if (frameData.residualYaw == 0.0f && frameData.isDetachedCanvas < 0.5f) {
+        int3 feederPos = int3(round(voxelPosition.xyz));
+        if (cardinalIndex != 0) {
+            feederPos = rotateCardinalZ(feederPos, cardinalIndex);
+            feederPos += cardinalLowerCornerShift(cardinalIndex);
+        }
+        const int2 feederIso = pos3DtoPos2DIso(feederPos);
+        if (feederIso.x < frameData.visibleIsoBounds.x ||
+            feederIso.x > frameData.visibleIsoBounds.z ||
+            feederIso.y < frameData.visibleIsoBounds.y ||
+            feederIso.y > frameData.visibleIsoBounds.w) {
+            return;
+        }
+    }
+
     if (frameData.voxelRenderOptions.x == 0) {
         int3 voxelPositionInt = int3(round(voxelPosition.xyz));
         if (cardinalIndex != 0) {

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -815,6 +815,13 @@ struct FrameDataVoxelToTrixel {
     // screen-locked path byte-identical. Mirrors
     // FrameDataVoxelToCanvas::detachedWorldReceive_. Other kernels never read it.
     float4 detachedWorldReceive;
+    // Un-widened (no shadow-feeder sweep) iso cull viewport for the depth-only
+    // shadow-feeder path (#1740). .xy = floor(min), .zw = ceil(max). A voxel
+    // inside [cullIsoMin, cullIsoMax] but OUTSIDE this box is an off-screen
+    // shadow feeder — c_voxel_to_trixel_stage_2 skips its colour/entity-id taps
+    // (stage 1 still wrote its full-res depth, all the bake + AO read). Mirrors
+    // FrameDataVoxelToCanvas::visibleIsoBounds_. Other kernels never read it.
+    int4 visibleIsoBounds;
 };
 
 #endif // IR_ISO_COMMON_METAL_INCLUDED


### PR DESCRIPTION
Part of #1740 (item 1 — the depth-only shadow-feeder path).

## What
Shadow-feeder voxels — those whose cardinal iso position lies inside the sun-shadow-widened cull (`cullIsoMin/Max`) but **outside** the un-widened visible viewport — exist only to cast sun shadows onto on-screen pixels via the stage-1 distance bake. They are never displayed, lit, or picked, so `VOXEL_TO_TRIXEL_STAGE_2`'s colour + entity-id taps are pure waste for them.

This skips stage 2 for feeders, keeping stage 1 (depth) full-resolution. New `FrameDataVoxelToCanvas::visibleIsoBounds_` (ivec4 @ std140 offset 176) carries the un-widened viewport; the shader early-returns when a voxel's cardinal iso pos falls outside it. Gated to the cardinal single-canvas world path (`perAxisRoute==0` / `residualYaw==0` / `!isDetachedCanvas`).

## Why it's byte-identical in rendered output
- Feeders are **off-screen** — their canvas colour/id pixels are never composited to the framebuffer, never lit (lighting reads own-pixel colour of on-screen pixels), never picked (entity-id is read only under the on-screen cursor).
- **Stage 1 (depth) is untouched.** The sun-shadow bake (`c_bake_sun_shadow_map`) and AO (`c_compute_voxel_ao`) read **only** `trixelDistances` — confirmed in source — so shadows + AO are bit-for-bit unchanged.
- A **+4-iso-px margin** on `visibleIsoBounds_` (the existing `kGpuMargin`) covers the voxel face footprint, so no on-screen pixel is ever classified as a feeder.
- When sun shadows are off, the cull isn't widened → `visibleIsoBounds_ == cullIsoMin/Max` → nothing is skipped.

## Verification (Metal / macOS)
- **shape_debug: 28/28 shots byte-identical** vs `origin/master` (normal voxel path — no shadows — fully unregressed; exercises the struct/UBO/Metal-mirror changes).
- **perf_grid (sun shadows on, 64³, zoomed so the grid extends off-screen → feeders present): structurally identical to master with clean screen edges and no feeder artifacts.** (perf_grid is non-deterministic — an animated wave — so a byte-compare is noise; verified visually instead.)

GLSL + Metal mirrors kept in lockstep; std140 layout asserts updated (`sizeof == 192`, `offsetof(visibleIsoBounds_) == 176`).

## ⚠️ Base / perf-validation caveat — please read before merging
#1740 is a **follow-up to #1737** (\"canvas-coverage cull clamp\"), and its framing (\"feeders **inside the canvas coverage**\") assumes that clamp. **#1737 is not in master** — it merged into the `fix/perfgrid-zoom-after-rotation` integration branch (no open PR to master). This change is **orthogonal to and correct independent of** the clamp (it skips stage 2 for *all* feeders), but:

- **On master the targeted feeders are not the render bottleneck.** Measured render-scope time is unchanged master-vs-branch (zoom 8: 32.8 vs 33.5 ms — within noise on a contended host). The win surfaces on the **#1737 base**, where the clamp removes the outside-coverage feeders and the remaining inside-coverage feeders' stage-2 cost dominates — exactly the case the issue describes.
- **Per-stage GPU time can't be isolated** on Metal: `voxelStage2` reads 0.000 (the open #1746 multi-encoder undercount).

So this is presented as a **byte-identical, zero-risk work-removal** that implements item 1's structural lever and **composes with #1737**, *not* as a measured frame-time win. **Recommendation:** merge as cleanup that lands ahead of #1737, **or** hold / rebase onto the `fix/perfgrid-zoom-after-rotation` base and re-measure there. Deliberately does **not** `Closes #1740` (the perf goal is unvalidated on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)