### PR TITLE
render: structural shadow-hole metric for deterministic validation

### DIFF
--- a/scripts/render-shadow-metric.py
+++ b/scripts/render-shadow-metric.py
@@ -197,9 +197,16 @@ def _main(argv: list[str]) -> int:
     failed = []
     if args.max_hole_ratio is not None and m["hole_ratio"] > args.max_hole_ratio:
         failed.append(f"hole_ratio {m['hole_ratio']} > {args.max_hole_ratio}")
-    if (args.max_components is not None and m.get("components") is not None
-            and m["components"] > args.max_components):
-        failed.append(f"components {m['components']} > {args.max_components}")
+    if args.max_components is not None:
+        if m.get("components") is None:
+            print(
+                "warning: --max-components requested but component count was "
+                "skipped (roi too large; see components_note in output)",
+                file=sys.stderr,
+            )
+            failed.append("max-components check skipped (roi too large)")
+        elif m["components"] > args.max_components:
+            failed.append(f"components {m['components']} > {args.max_components}")
     m["pass"] = not failed
     if failed:
         m["reason"] = "; ".join(failed)

--- a/scripts/render-shadow-metric.py
+++ b/scripts/render-shadow-metric.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Structural sun-shadow metrics for deterministic render validation.
+
+Where ``render-compare.py`` does a pixel-diff against a committed reference,
+this measures a *structural* property of a single capture: how
+hole-ridden / fragmented a cast shadow is inside a region of interest. Two
+reasons that matters for the engine's render-validation:
+
+  * **Deterministic at zoom.** Pixel-diff is excluded above ~2x magnification
+    because CPU<->GPU float divergence drifts the match% run-to-run
+    (canvas_stress's ``revoxelize_solids_zoom`` shot is excluded for exactly
+    this). Occupancy classification + connected-component counts don't move
+    under sub-pixel jitter, so the zoom shots can be gated.
+  * **Backend-agnostic.** Metal and OpenGL produce pixel-different output, so
+    pixel-diff needs a per-backend reference set. A structural metric measures
+    the same property on both, so one threshold is a shared oracle.
+
+Built for SHADOW debug-overlay captures (engine render mode ``SHADOW``:
+black = lit, magenta = shadowed; see ``engine/render/CLAUDE.md``), where
+shadow occupancy is encoded directly as colour and the classification is
+exact. The swiss-cheese / cross-hatch-dithering failure mode (epic #1717
+items 3-4) shows up as a high ``hole_ratio`` and an exploded ``components``
+count; a clean shadow is ~0 holes and a handful of large components.
+
+Metrics (within the ROI, default = whole image):
+  * shadow_px / lit_px  — classified-pixel counts.
+  * hole_ratio          — lit_px / (lit_px + shadow_px): fraction of the
+                          cast-shadow region that reads as a lit hole.
+  * components          — 4-connected shadow components (cross-hatch shatters
+                          a clean blob into many tiny ones).
+  * largest_frac        — largest component / shadow_px (~1 clean, low when
+                          fragmented).
+
+Pure stdlib; reuses ``read_png()`` from ``render-compare.py``.
+
+Exit codes: 0 metrics within thresholds (or no thresholds given) · 1 a
+threshold was exceeded · 2 I/O or format error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import json
+import sys
+from array import array
+from collections import deque
+from pathlib import Path
+
+# read_png lives in the sibling render-compare.py (dashed name -> importlib).
+_CMP = Path(__file__).with_name("render-compare.py")
+_loader = importlib.machinery.SourceFileLoader("render_compare", str(_CMP))
+_spec = importlib.util.spec_from_loader("render_compare", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["render_compare"] = _mod
+_loader.exec_module(_mod)
+read_png = _mod.read_png
+
+# Classification thresholds, loose enough to absorb AA / FP jitter on the
+# debug-overlay's flat fills (magenta = vec3(1,0,1), lit = vec3(0)).
+SHADOW_MIN_RB = 180   # magenta: high red AND blue
+SHADOW_MAX_G = 90     # magenta: low green
+LIT_MAX = 70          # lit: all channels near zero
+
+# Flood fill is O(ROI pixels); a full 1280x720 frame is ~900k px which is fine,
+# but guard a pathological ROI so the tool never hangs silently.
+MAX_FLOOD_PX = 4_000_000
+
+
+def _classify(r: int, g: int, b: int) -> int:
+    """1 = shadowed (magenta), -1 = lit (black), 0 = neither (bg/entity)."""
+    if r >= SHADOW_MIN_RB and b >= SHADOW_MIN_RB and g <= SHADOW_MAX_G:
+        return 1
+    if r <= LIT_MAX and g <= LIT_MAX and b <= LIT_MAX:
+        return -1
+    return 0
+
+
+def shadow_metrics(
+    path: str,
+    roi: tuple[int, int, int, int] | None = None,
+    count_components: bool = True,
+) -> dict:
+    w, h, bpp, pix = read_png(path)
+    px = array("B", pix)
+
+    if roi is None:
+        rx, ry, rw, rh = 0, 0, w, h
+    else:
+        rx, ry, rw, rh = roi
+        if rx < 0 or ry < 0 or rx + rw > w or ry + rh > h or rw <= 0 or rh <= 0:
+            raise ValueError(f"roi {roi} out of bounds for {w}x{h} image")
+
+    # shadow mask over the ROI grid: True where shadowed.
+    mask = bytearray(rw * rh)
+    shadow_px = 0
+    lit_px = 0
+    for j in range(rh):
+        row = (ry + j) * w
+        mbase = j * rw
+        for i in range(rw):
+            o = (row + rx + i) * bpp
+            c = _classify(px[o], px[o + 1], px[o + 2])
+            if c == 1:
+                mask[mbase + i] = 1
+                shadow_px += 1
+            elif c == -1:
+                lit_px += 1
+
+    classified = shadow_px + lit_px
+    hole_ratio = (lit_px / classified) if classified else 0.0
+
+    result = {
+        "image": path,
+        "roi": [rx, ry, rw, rh],
+        "shadow_px": shadow_px,
+        "lit_px": lit_px,
+        "hole_ratio": round(hole_ratio, 4),
+    }
+
+    if count_components and shadow_px:
+        if rw * rh > MAX_FLOOD_PX:
+            result["components"] = None
+            result["components_note"] = "roi too large for component count"
+        else:
+            comps, largest = _components(mask, rw, rh)
+            result["components"] = comps
+            result["largest_frac"] = round(largest / shadow_px, 4)
+
+    return result
+
+
+def _components(mask: bytearray, w: int, h: int) -> tuple[int, int]:
+    """4-connected component count + largest size over the shadow mask."""
+    seen = bytearray(len(mask))
+    comps = 0
+    largest = 0
+    for start in range(len(mask)):
+        if not mask[start] or seen[start]:
+            continue
+        comps += 1
+        size = 0
+        q = deque((start,))
+        seen[start] = 1
+        while q:
+            idx = q.popleft()
+            size += 1
+            x = idx % w
+            y = idx // w
+            if x > 0 and mask[idx - 1] and not seen[idx - 1]:
+                seen[idx - 1] = 1
+                q.append(idx - 1)
+            if x < w - 1 and mask[idx + 1] and not seen[idx + 1]:
+                seen[idx + 1] = 1
+                q.append(idx + 1)
+            if y > 0 and mask[idx - w] and not seen[idx - w]:
+                seen[idx - w] = 1
+                q.append(idx - w)
+            if y < h - 1 and mask[idx + w] and not seen[idx + w]:
+                seen[idx + w] = 1
+                q.append(idx + w)
+        if size > largest:
+            largest = size
+    return comps, largest
+
+
+def _parse_roi(s: str | None) -> tuple[int, int, int, int] | None:
+    if not s:
+        return None
+    parts = [int(p) for p in s.split(",")]
+    if len(parts) != 4:
+        raise argparse.ArgumentTypeError("roi must be x,y,w,h")
+    return tuple(parts)  # type: ignore[return-value]
+
+
+def _main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("image", help="PNG capture (SHADOW debug-overlay mode).")
+    ap.add_argument("--roi", type=_parse_roi, default=None,
+                    help="x,y,w,h region of interest (default: whole image).")
+    ap.add_argument("--max-hole-ratio", type=float, default=None,
+                    help="fail if hole_ratio exceeds this.")
+    ap.add_argument("--max-components", type=int, default=None,
+                    help="fail if the shadow shatters into more than this many "
+                         "4-connected components.")
+    ap.add_argument("--no-components", action="store_true",
+                    help="skip the (slower) connected-component pass.")
+    args = ap.parse_args(argv)
+
+    try:
+        m = shadow_metrics(args.image, args.roi, not args.no_components)
+    except (OSError, ValueError) as e:
+        print(json.dumps({"error": str(e)}))
+        return 2
+
+    failed = []
+    if args.max_hole_ratio is not None and m["hole_ratio"] > args.max_hole_ratio:
+        failed.append(f"hole_ratio {m['hole_ratio']} > {args.max_hole_ratio}")
+    if (args.max_components is not None and m.get("components") is not None
+            and m["components"] > args.max_components):
+        failed.append(f"components {m['components']} > {args.max_components}")
+    m["pass"] = not failed
+    if failed:
+        m["reason"] = "; ".join(failed)
+
+    print(json.dumps(m, indent=2))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/scripts/tests/test_render_shadow_metric.py
+++ b/scripts/tests/test_render_shadow_metric.py
@@ -128,6 +128,27 @@ class TestShadowMetric(unittest.TestCase):
         b = shadow_metrics(p)
         self.assertEqual(a, b)
 
+    def test_max_components_cli_fails_when_roi_too_large(self):
+        """--max-components with an oversized ROI must warn to stderr + exit 1."""
+        import io
+        p = str(self.dir / "big_shadow.png")
+        _write(p, 8, 8, lambda x, y: MAGENTA)
+        orig_cap = _mod.MAX_FLOOD_PX
+        _mod.MAX_FLOOD_PX = 10  # 8*8=64 > 10 triggers the skip
+        try:
+            stderr_buf = io.StringIO()
+            stdout_buf = io.StringIO()
+            old_err, old_out = sys.stderr, sys.stdout
+            sys.stderr, sys.stdout = stderr_buf, stdout_buf
+            try:
+                rc = _mod._main([p, "--max-components", "5"])
+            finally:
+                sys.stderr, sys.stdout = old_err, old_out
+            self.assertEqual(rc, 1)
+            self.assertIn("warning", stderr_buf.getvalue())
+        finally:
+            _mod.MAX_FLOOD_PX = orig_cap
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_render_shadow_metric.py
+++ b/scripts/tests/test_render_shadow_metric.py
@@ -1,0 +1,133 @@
+"""Tests for render-shadow-metric.py — the structural sun-shadow metric.
+
+Proves the metric is deterministic and that it discriminates a clean
+contiguous shadow from the swiss-cheese / cross-hatch failure mode (epic
+#1717 items 3-4): a solid magenta blob reads ~0 holes / 1 component, a
+checkerboard reads ~50% holes / many components. Synthetic PNGs only — no
+GL/Metal context, no committed reference. Import via importlib (dashed name).
+"""
+import importlib.machinery
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+_loader = importlib.machinery.SourceFileLoader(
+    "render_shadow_metric", str(_SCRIPTS / "render-shadow-metric.py"))
+_spec = importlib.util.spec_from_loader("render_shadow_metric", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["render_shadow_metric"] = _mod
+_loader.exec_module(_mod)
+
+shadow_metrics = _mod.shadow_metrics
+
+# write_png lives in render-compare.py (used to synthesize fixture PNGs).
+_cmp_loader = importlib.machinery.SourceFileLoader(
+    "render_compare", str(_SCRIPTS / "render-compare.py"))
+_cmp_spec = importlib.util.spec_from_loader("render_compare", _cmp_loader)
+_cmp = importlib.util.module_from_spec(_cmp_spec)
+_cmp_loader.exec_module(_cmp)
+write_png = _cmp.write_png
+
+MAGENTA = (255, 0, 255)
+BLACK = (0, 0, 0)
+GRAY = (128, 128, 128)
+
+
+def _write(path: str, w: int, h: int, fn) -> None:
+    """fn(x, y) -> (r, g, b); written as RGB PNG."""
+    buf = bytearray(w * h * 3)
+    for y in range(h):
+        for x in range(w):
+            r, g, b = fn(x, y)
+            o = (y * w + x) * 3
+            buf[o], buf[o + 1], buf[o + 2] = r, g, b
+    write_png(path, w, h, bytes(buf), 3)
+
+
+class TestShadowMetric(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_solid_shadow_is_clean(self):
+        p = str(self.dir / "solid.png")
+        _write(p, 32, 32, lambda x, y: MAGENTA)
+        m = shadow_metrics(p)
+        self.assertEqual(m["lit_px"], 0)
+        self.assertEqual(m["shadow_px"], 32 * 32)
+        self.assertEqual(m["hole_ratio"], 0.0)
+        self.assertEqual(m["components"], 1)
+        self.assertEqual(m["largest_frac"], 1.0)
+
+    def test_checkerboard_is_swiss_cheese(self):
+        # The cross-hatch dithering signature: alternating lit/shadow.
+        p = str(self.dir / "checker.png")
+        _write(p, 32, 32, lambda x, y: MAGENTA if (x + y) % 2 == 0 else BLACK)
+        m = shadow_metrics(p)
+        self.assertAlmostEqual(m["hole_ratio"], 0.5, places=2)
+        # A clean blob is 1 component; a checkerboard shatters into one per cell.
+        self.assertGreater(m["components"], 100)
+        self.assertLess(m["largest_frac"], 0.05)
+
+    def test_all_lit_is_all_holes(self):
+        p = str(self.dir / "lit.png")
+        _write(p, 16, 16, lambda x, y: BLACK)
+        m = shadow_metrics(p)
+        self.assertEqual(m["shadow_px"], 0)
+        self.assertEqual(m["hole_ratio"], 1.0)
+
+    def test_gray_background_is_ignored(self):
+        # Neither lit nor shadowed: a clean shadow blob on a gray field reads
+        # 0 holes regardless of how much background surrounds it.
+        p = str(self.dir / "blob_on_gray.png")
+
+        def fn(x, y):
+            return MAGENTA if (8 <= x < 24 and 8 <= y < 24) else GRAY
+        _write(p, 32, 32, fn)
+        m = shadow_metrics(p)
+        self.assertEqual(m["shadow_px"], 16 * 16)
+        self.assertEqual(m["lit_px"], 0)
+        self.assertEqual(m["hole_ratio"], 0.0)
+        self.assertEqual(m["components"], 1)
+
+    def test_hole_inside_shadow_counts(self):
+        # A solid shadow with a punched-out lit hole — the interior-gap mode.
+        p = str(self.dir / "holed.png")
+
+        def fn(x, y):
+            if 14 <= x < 18 and 14 <= y < 18:
+                return BLACK  # a 4x4 lit hole inside...
+            return MAGENTA    # ...a 32x32 shadow
+        _write(p, 32, 32, fn)
+        m = shadow_metrics(p)
+        self.assertEqual(m["lit_px"], 16)
+        self.assertEqual(m["shadow_px"], 32 * 32 - 16)
+        self.assertGreater(m["hole_ratio"], 0.0)
+        # The shadow stays one connected ring around the hole.
+        self.assertEqual(m["components"], 1)
+
+    def test_roi_restricts_region(self):
+        p = str(self.dir / "split.png")
+        # Left half shadow, right half lit.
+        _write(p, 32, 16, lambda x, y: MAGENTA if x < 16 else BLACK)
+        left = shadow_metrics(p, roi=(0, 0, 16, 16))
+        self.assertEqual(left["hole_ratio"], 0.0)
+        right = shadow_metrics(p, roi=(16, 0, 16, 16))
+        self.assertEqual(right["hole_ratio"], 1.0)
+
+    def test_determinism_repeat_runs(self):
+        p = str(self.dir / "checker2.png")
+        _write(p, 24, 24, lambda x, y: MAGENTA if (x + y) % 2 == 0 else BLACK)
+        a = shadow_metrics(p)
+        b = shadow_metrics(p)
+        self.assertEqual(a, b)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
First brick of a deterministic render-validation framework (re: the shadow/lighting quality work tracked by #1717). Adds `scripts/render-shadow-metric.py` — a **structural** cast-shadow metric that complements `render-compare.py`'s pixel-diff:

- Classifies shadow occupancy in a **SHADOW debug-overlay** capture (magenta = shadowed, black = lit; `engine/render/CLAUDE.md`) and reports `hole_ratio` (lit pixels inside the shadow region) + connected-component `fragmentation` — the exact signature of the swiss-cheese / cross-hatch failure mode (#1717 items 3-4).
- **Zoom-stable:** measures structure, not exact pixels, so it's robust to the CPU↔GPU float divergence that forces `render-compare` to *exclude* high-zoom shots (canvas_stress's `revoxelize_solids_zoom`).
- **Backend-agnostic:** one threshold is a shared oracle across Metal and OpenGL (no per-backend reference set).

### Why this matters
Today a merged shadow fix can't be confirmed to hold without a manual eyeball recapture, and zoom/shadow conditions are unguarded by the pixel-diff gate. A structural occupancy metric turns "is the shadow swiss-cheese?" into a deterministic pass/fail. **Requires the demo to capture in SHADOW debug-overlay mode** (so shadows are magenta-classifiable) — wiring that shot into the demo shot lists + the `render-verify` harness is the next step (framework epic).

## Test plan
- [x] `python3 -m unittest scripts.tests.test_render_shadow_metric` — 7/7: determinism, solid→0 holes/1 component, checkerboard→~50% holes/100+ components, interior-hole ring, ROI restriction, gray-bg ignored.
- [x] Parses real 2560×1440 engine PNGs deterministically.
- [x] `py_compile` clean; pure stdlib (reuses `read_png` from `render-compare.py`).

Refs #1717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)