### PR TITLE
render: span all encoders for Metal per-stage GPU timestamps (#1746)

### DIFF
--- a/engine/render/src/metal/metal_render_impl.cpp
+++ b/engine/render/src/metal/metal_render_impl.cpp
@@ -28,6 +28,13 @@ struct MetalTimestampSampleAttachment {
     MTL::CounterSampleBuffer *sampleBuffer_ = nullptr;
     NS::UInteger startSampleIndex_ = 0;
     NS::UInteger endSampleIndex_ = 1;
+    // Sticky across every encoder of a stage (the window between
+    // writeTimestamp START and END): the first encoder claims the start
+    // boundary; every encoder re-writes the end boundary. Sequential GPU
+    // execution makes the last encoder's end write win, so the resolved pair
+    // spans [first-encoder start, last-encoder end] — the whole stage, not
+    // just its first encoder (#1746).
+    bool firstEncoder_ = true;
 };
 
 MetalTimestampSampleAttachment g_nextComputeTimestampAttachment;
@@ -122,12 +129,18 @@ MTL::ComputeCommandEncoder *createComputeEncoder(MTL::CommandBuffer *commandBuff
     auto *descriptor = MTL::ComputePassDescriptor::alloc()->init();
     auto *attachment = descriptor->sampleBufferAttachments()->object(kTimestampAttachmentIndex);
     attachment->setSampleBuffer(g_nextComputeTimestampAttachment.sampleBuffer_);
-    attachment->setStartOfEncoderSampleIndex(g_nextComputeTimestampAttachment.startSampleIndex_);
+    attachment->setStartOfEncoderSampleIndex(
+        g_nextComputeTimestampAttachment.firstEncoder_
+            ? g_nextComputeTimestampAttachment.startSampleIndex_
+            : MTL::CounterDontSample
+    );
     attachment->setEndOfEncoderSampleIndex(g_nextComputeTimestampAttachment.endSampleIndex_);
     auto *encoder = commandBuffer->computeCommandEncoder(descriptor);
     descriptor->release();
 
-    g_nextComputeTimestampAttachment = {};
+    // Stay sticky for the rest of the stage's encoders (each re-writes the end
+    // boundary; the last one wins). writeTimestamp(END) clears the attachment.
+    g_nextComputeTimestampAttachment.firstEncoder_ = false;
     return encoder;
 }
 
@@ -138,9 +151,16 @@ void attachTimestampSamples(MTL::RenderPassDescriptor *descriptor) {
 
     auto *attachment = descriptor->sampleBufferAttachments()->object(kTimestampAttachmentIndex);
     attachment->setSampleBuffer(g_nextComputeTimestampAttachment.sampleBuffer_);
-    attachment->setStartOfVertexSampleIndex(g_nextComputeTimestampAttachment.startSampleIndex_);
+    attachment->setStartOfVertexSampleIndex(
+        g_nextComputeTimestampAttachment.firstEncoder_
+            ? g_nextComputeTimestampAttachment.startSampleIndex_
+            : MTL::CounterDontSample
+    );
     attachment->setEndOfFragmentSampleIndex(g_nextComputeTimestampAttachment.endSampleIndex_);
-    g_nextComputeTimestampAttachment = {};
+    // Sticky across the stage's encoders (the shared global means a stage that
+    // mixes compute + render encoders has its first-executed encoder claim the
+    // start boundary). writeTimestamp(END) clears the attachment.
+    g_nextComputeTimestampAttachment.firstEncoder_ = false;
 }
 
 MTL::RenderCommandEncoder *createRenderEncoder() {
@@ -786,11 +806,18 @@ metalCurrentDepthPixelFormat(),
             g_nextComputeTimestampAttachment = {
                 pair->sampleBuffer_,
                 0,
-                1
+                1,
+                /*firstEncoder_=*/true
             };
             pair->hasStart_ = true;
             pair->hasEnd_ = false;
         } else {
+            // Stop tagging once the stage ends: clear the sticky attachment so
+            // encoders created in the gap before the next START stay untracked
+            // (#1746). The end boundary was already attached to every encoder
+            // of the stage up to this point, so the last one's index-1 write
+            // bounds the pair.
+            g_nextComputeTimestampAttachment = {};
             pair->hasEnd_ = true;
         }
     }


### PR DESCRIPTION
## Summary
- Metal brackets a GPU timestamp sample pair to a **single** command encoder. A render stage that issues N encoders (e.g. `VOXEL_TO_TRIXEL_STAGE_1`'s per-axis canvas passes) only measured its first encoder, so the tracked GPU stages summed to <1 ms against a ~57 ms frame (#1738 fixed the aggregation half; this fixes collection accuracy).
- Make the sticky attachment (`g_nextComputeTimestampAttachment`) span the **whole stage**: a new `firstEncoder_` flag has the first encoder claim the start boundary and **every** encoder re-write the end boundary. Sequential GPU execution makes the last encoder's index-1 write win → the resolved pair spans `[first-encoder start, last-encoder end]`. Non-first encoders pass `MTL::CounterDontSample` for the start index.
- `writeTimestamp(END)` now clears the sticky state, so encoders created in the gap before the next `START` stay untracked (also closes a latent stale-attachment carry-over for zero-encoder windows that the old first-encoder-resets path relied on).
- Mirrored in both `createComputeEncoder` (compute encoders) and `attachTimestampSamples` (render encoders); the shared global means a stage mixing both encoder types has its first-executed encoder claim the start.
- **Single-encoder stages are byte-identical** to before (the one encoder claims both boundaries). **No OpenGL file is touched** — OpenGL already spans whole stages via `glQueryCounter` at the call sites.

## Verification (macOS / Metal, Apple Silicon)
- `IRPerfGrid --auto-profile 200 --zoom 8 --subdivision-mode full --base-subdivisions 1`: `voxelStage1` GPU jumped from <1 ms (first-encoder-only) to **34.945 ms** against a **52.307 ms** frame — a sane fraction, no ~100× undercount.
- **Metal validation layer** (`METAL_DEVICE_WRAPPER_TYPE=1`): the shared 2-sample CounterSampleBuffer multi-write at index 1 produces **no validation error**. (The one validation assertion that fires — a stencil-attachment pixel-format mismatch in `setRenderPipelineState` — is **pre-existing on master**; confirmed identical with this change reverted. It is a separate latent issue, out of scope for #1746, and does not affect normal non-validation runs.)
- Build clean: `fleet-build --target IRShapeDebug` / `IRPerfGrid`.

## Render-loop / screenshots
Skipped per the documented "internal refactor with provably no runtime effect" exception (`engine/render/CLAUDE.md` §Verifying render changes). This change only alters GPU counter-sample-buffer **attachment metadata** — it cannot change any rendered pixel; before/after captures would be byte-identical.

## Test plan
- [x] macOS/Metal: `voxelStage1` GPU is realistic multi-ms, sum within a sane fraction of frame time
- [x] No Metal validation-layer error from the counter-buffer multi-write
- [x] Build green (IRShapeDebug + IRPerfGrid)
- [ ] Linux/OpenGL smoke (no OpenGL file edited — no-edit guarantee)

Closes #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)