### PR TITLE
render: assert count > 0 in voxelDispatchGridForCount + audit (#1685)

### DIFF
--- a/engine/prefabs/irreden/render/voxel_dispatch_grid.hpp
+++ b/engine/prefabs/irreden/render/voxel_dispatch_grid.hpp
@@ -2,6 +2,7 @@
 #define IR_RENDER_VOXEL_DISPATCH_GRID_H
 
 #include <irreden/ir_math.hpp>
+#include <irreden/ir_profile.hpp>
 
 namespace IRSystem {
 
@@ -15,10 +16,19 @@ namespace IRSystem {
 //
 // `count` is the number of work items to spread across the grid; for a
 // workgroup grid, callers divide their thread count by the shader's local
-// size first (e.g. `divCeil(liveCount, 64)`). Callers guard `count > 0`
-// before dispatching — `count == 0` divides by zero here, same as it always
-// has.
+// size first (e.g. `divCeil(liveCount, 64)`). Callers must guarantee
+// `count > 0`; the assert below enforces it. `count == 0` divides by zero
+// here — a SIGFPE on x86 Linux, but silently yields a (0,0) grid on Apple
+// Silicon (#1619), so the contract is asserted at entry rather than left to
+// each caller's discipline. The one legitimate empty-pool path
+// (`buildVoxelFrameData`, lighting on an empty canvas) clamps to 1 before
+// calling — see voxel_frame_data.hpp.
 inline IRMath::ivec2 voxelDispatchGridForCount(int count) {
+    IR_ASSERT(
+        count > 0,
+        "voxelDispatchGridForCount: count must be > 0 — division by zero "
+        "is UB (silent on Apple Silicon)"
+    );
     constexpr int kMaxDispatchGroupsX = 1024;
     const int groupsX = IRMath::min(count, kMaxDispatchGroupsX);
     const int groupsY = IRMath::divCeil(count, groupsX);

--- a/engine/prefabs/irreden/render/voxel_frame_data.hpp
+++ b/engine/prefabs/irreden/render/voxel_frame_data.hpp
@@ -46,12 +46,14 @@ inline void buildVoxelFrameData(
 
     const auto renderMode = IRRender::getSubdivisionMode();
     const int effectiveSubdivisions = IRRender::getVoxelRenderEffectiveSubdivisions();
-    // Clamp to 1: voxelDispatchGridForCount divides by the count, and the
-    // lighting passes author frame data for canvases whose pool is EMPTY
-    // (authorIteratingCanvasVoxelFrame / restoreMainCanvasVoxelFrame have no
-    // liveVoxelCount gate — observed as a SIGFPE on a lit scene whose main
-    // canvas holds zero voxels, #1619 step-0 harness). voxelCount_ below still
-    // carries the honest 0, which gates all shader-side work.
+    // Clamp to 1: voxelDispatchGridForCount divides by the count (and asserts
+    // count > 0 at entry), and the lighting passes author frame data
+    // for canvases whose pool is EMPTY (authorIteratingCanvasVoxelFrame /
+    // restoreMainCanvasVoxelFrame have no liveVoxelCount gate — observed as a
+    // SIGFPE on a lit scene whose main canvas holds zero voxels, #1619 step-0
+    // harness). This clamp is the one deliberate empty-pool exception to that
+    // contract; voxelCount_ below still carries the honest 0, which gates all
+    // shader-side work.
     const ivec2 dispatchGrid = voxelDispatchGridForCount(IRMath::max(liveVoxelCount, 1));
 
     frameData.cameraTrixelOffset_ = IRRender::getEffectiveCameraIso();


### PR DESCRIPTION
## Summary
- Add `IR_ASSERT(count > 0, ...)` at entry of the shared `voxelDispatchGridForCount()` helper (with `#include <irreden/ir_profile.hpp>`), turning the comment-only precondition into an enforced debug contract. `count == 0` is a SIGFPE on x86 Linux but silently yields a `(0,0)` grid on Apple Silicon (#1619) — the assert catches a future un-guarded caller loudly in debug; it compiles out in release (zero cost).
- Retain the `buildVoxelFrameData` `max(liveVoxelCount, 1)` clamp as the one deliberate empty-pool exception (empty-canvas lighting passes legitimately reach the helper with 0 live voxels). `voxelCount_` still carries the honest 0 to gate shader-side work.
- Reword the precondition comments in both headers so the contract reads as enforced-at-entry and the clamp reads as its deliberate exception.

## Why not fold the clamp away
Folding `max(count, 1)` into the helper and dropping the `buildVoxelFrameData` clamp was rejected: in release the assert compiles out, so the empty-canvas lit path would re-hit the #1619 SIGFPE; in debug it would fire on valid empty-canvas lit scenes. Option A (assert + keep clamp) is the issue's literal ask and keeps the one real 0-path release-safe.

## Item-2 audit (other shared-helper UB preconditions)
`git grep -inE "caller(s)? (guard|guarantee|must)" engine/prefabs engine/render`:
- `render/CLAUDE.md:66` — doc prose, not code.
- `render/camera_controls.hpp:43` — "register CAMERA_SCROLL_ZOOM separately": a registration requirement, not a function-entry precondition.
- `render/voxel_dispatch_grid.hpp:19` — this PR's new comment.
- `voxel/components/component_voxel_pool.hpp:602` — "Caller guarantees every index...": already enforced by the `IR_ASSERT` loop directly below it (lines 605-613).

No additional un-asserted function-entry UB precondition found.

## Test plan
- [x] `fleet-build --target IRShapeDebug` — green.
- [x] `IRShapeDebug --auto-screenshot` ran all 21 shots clean (exit 0); the assert never tripped, confirming `count > 0` holds in valid scenes (including the empty-canvas lit path via the retained clamp).
- [x] No visual regression: `IR_ASSERT` compiles out in release and is a pass-through for `count >= 1`, so rendered output is byte-identical to master for valid input. `attach-screenshots` / `render-debug-loop` skipped per the AUTHOR-PIPELINE "no visual effect" carve-out (debug-assert + comment + include only).

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)