### PR TITLE
render: opt-in full-resolution GUI canvas

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -1129,6 +1129,12 @@ void initSystems() {
                 Color{200, 200, 200, 180},
                 1
             );
+            // Inline dispatch (not deferred to endTick like the widget
+            // render systems): the loft overlay is a single-canvas system
+            // that runs its whole render once per frame in this tick body,
+            // so queuing and dispatching here is equivalent to the deferred
+            // pattern — there is no second tick that would append more glyphs
+            // before the dispatch.
             IRPrefab::GuiText::dispatchGuiText(lrp->textCmds_);
         }
     );

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -105,6 +105,7 @@
 // layout mouse-in-GUI-trixels helper).
 #include <irreden/render/trixel_rect.hpp>
 #include <irreden/render/trixel_text.hpp>
+#include <irreden/render/gui_text_batch.hpp>
 #include <irreden/render/mask_grid_painter.hpp>
 #include <irreden/render/layout.hpp>
 
@@ -1062,6 +1063,7 @@ void initSystems() {
     struct LoftRenderParams {
         C_TriangleCanvasTextures *canvas_ = nullptr;
         IRRender::MaskGridPaintScratch scratch_;
+        std::vector<IRRender::GlyphDrawCommand> textCmds_;
     };
     auto loftRenderData = std::make_unique<LoftRenderParams>();
     auto *lrp = loftRenderData.get();
@@ -1102,24 +1104,32 @@ void initSystems() {
                 lrp->scratch_
             );
             const int gridH = sz * IRVoxelEditor::kLoftCellPx;
-            IRRender::renderText(
-                *lrp->canvas_,
+            const ivec2 canvasSize = lrp->canvas_->size_;
+            IRPrefab::GuiText::queueGuiText(
+                lrp->textCmds_,
                 "XZ",
                 IRVoxelEditor::kLoftGridXZPos + ivec2(0, -12),
-                Color{200, 220, 200, 220}
+                canvasSize,
+                Color{200, 220, 200, 220},
+                1
             );
-            IRRender::renderText(
-                *lrp->canvas_,
+            IRPrefab::GuiText::queueGuiText(
+                lrp->textCmds_,
                 "YZ",
                 IRVoxelEditor::kLoftGridYZPos + ivec2(0, -12),
-                Color{200, 220, 200, 220}
+                canvasSize,
+                Color{200, 220, 200, 220},
+                1
             );
-            IRRender::renderText(
-                *lrp->canvas_,
+            IRPrefab::GuiText::queueGuiText(
+                lrp->textCmds_,
                 "LOFT  Shift=sym  C=clear  Enter=stamp  F=exit",
                 ivec2(IRVoxelEditor::kLoftGridXZPos.x, IRVoxelEditor::kLoftGridXZPos.y + gridH + 4),
-                Color{200, 200, 200, 180}
+                canvasSize,
+                Color{200, 200, 200, 180},
+                1
             );
+            IRPrefab::GuiText::dispatchGuiText(lrp->textCmds_);
         }
     );
     IRSystem::setSystemParams(loftRenderSystem, std::move(loftRenderData));
@@ -2647,8 +2657,10 @@ void initCommands() {
                 );
                 const bool atRigRoot = j.parentIndex_ == static_cast<std::uint32_t>(i) ||
                                        j.parentIndex_ >= static_cast<std::uint32_t>(count);
-                IR_ASSERT(atRigRoot || j.parentIndex_ < i,
-                    ".rig parentIndex forward-reference — not supported by linear reconstruction");
+                IR_ASSERT(
+                    atRigRoot || j.parentIndex_ < i,
+                    ".rig parentIndex forward-reference — not supported by linear reconstruction"
+                );
                 const IREntity::EntityId parentEntity =
                     atRigRoot ? rigRoot : newJoints[j.parentIndex_];
                 IREntity::setParent(joint, parentEntity);
@@ -2975,14 +2987,12 @@ void initEntities() {
             kBoneSwatchOriginX + col * (kBoneSwatchSize + kBoneSwatchGap),
             kBoneSwatchOriginY + row * (kBoneSwatchSize + kBoneSwatchGap)
         );
-        IRVoxelEditor::g_bonePaint.boneSwatches_.push_back(
-            IRPrefab::Widget::makeColorSwatch(
-                pos,
-                ivec2(kBoneSwatchSize, kBoneSwatchSize),
-                IRVoxelEditor::kBoneColors[i],
-                i == 0
-            )
-        );
+        IRVoxelEditor::g_bonePaint.boneSwatches_.push_back(IRPrefab::Widget::makeColorSwatch(
+            pos,
+            ivec2(kBoneSwatchSize, kBoneSwatchSize),
+            IRVoxelEditor::kBoneColors[i],
+            i == 0
+        ));
     }
 
     // Skeleton tree panel (F-2.6, #1607). Sits below the BONE selector in the

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -2825,6 +2825,11 @@ void initEntities() {
     IREntity::setComponent(mainCanvas, C_CanvasSunShadow{canvasSize});
     IREntity::setComponent(mainCanvas, C_CanvasLightVolume{});
 
+    // Render the GUI at native framebuffer resolution so panels/text are
+    // small and crisp instead of the coarse iso-canvas default. The editor
+    // lays its widgets out relative to the resulting GUI canvas size below.
+    IRRender::setGuiCanvasFullResolution();
+
     IRRender::setSunDirection(vec3(0.35f, 0.85f, -0.4f));
 
     // Palette panel — fixed top-left dock at 200×220 trixels. The 16

--- a/engine/prefabs/irreden/render/gui_text_batch.hpp
+++ b/engine/prefabs/irreden/render/gui_text_batch.hpp
@@ -1,5 +1,5 @@
-#ifndef GUI_TEXT_BATCH_H
-#define GUI_TEXT_BATCH_H
+#ifndef GUI_TEXT_BATCH_HPP
+#define GUI_TEXT_BATCH_HPP
 
 // Batched GUI text on the compute path.
 //
@@ -26,6 +26,7 @@
 
 #include <irreden/ir_render.hpp>
 #include <irreden/ir_entity.hpp>
+#include <irreden/ir_profile.hpp>
 
 #include <irreden/render/trixel_font.hpp>
 #include <irreden/render/trixel_text.hpp>
@@ -67,12 +68,24 @@ inline std::vector<std::uint32_t> buildFontBuffer() {
     return buf;
 }
 
-inline int glyphWidth(int fontSize) { return IRRender::kGlyphWidth * fontSize; }
-inline int glyphHeight(int fontSize) { return IRRender::kGlyphHeight * fontSize; }
-inline int glyphStepX(int fontSize) { return IRRender::kGlyphStepX * fontSize; }
-inline int glyphStepY(int fontSize) { return IRRender::kGlyphStepY * fontSize; }
-inline int glyphSpacingX(int fontSize) { return IRRender::kGlyphSpacingX * fontSize; }
-inline int glyphSpacingY(int fontSize) { return IRRender::kGlyphSpacingY * fontSize; }
+inline int glyphWidth(int fontSize) {
+    return IRRender::kGlyphWidth * fontSize;
+}
+inline int glyphHeight(int fontSize) {
+    return IRRender::kGlyphHeight * fontSize;
+}
+inline int glyphStepX(int fontSize) {
+    return IRRender::kGlyphStepX * fontSize;
+}
+inline int glyphStepY(int fontSize) {
+    return IRRender::kGlyphStepY * fontSize;
+}
+inline int glyphSpacingX(int fontSize) {
+    return IRRender::kGlyphSpacingX * fontSize;
+}
+inline int glyphSpacingY(int fontSize) {
+    return IRRender::kGlyphSpacingY * fontSize;
+}
 
 inline int nextWordWidth(const std::string &text, std::size_t i, int fontSize) {
     int width = 0;
@@ -229,7 +242,16 @@ inline void queueGuiText(
     if (text.empty())
         return;
     expandTextToCommands(
-        commands, text, pos, canvasSize, color, wrapWidth, alignH, alignV, boxWidth, boxHeight,
+        commands,
+        text,
+        pos,
+        canvasSize,
+        color,
+        wrapWidth,
+        alignH,
+        alignV,
+        boxWidth,
+        boxHeight,
         fontSize
     );
 }
@@ -254,17 +276,22 @@ inline void dispatchGuiText(std::vector<IRRender::GlyphDrawCommand> &commands) {
     auto &canvas = IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
 
     int count = static_cast<int>(commands.size());
-    if (count > kMaxGlyphCommands)
+    if (count > kMaxGlyphCommands) {
+        IRE_LOG_WARN(
+            "dispatchGuiText: {} glyph commands exceeds the {}-command "
+            "dispatch cap — truncating; some GUI text will not render.",
+            count,
+            kMaxGlyphCommands
+        );
         count = kMaxGlyphCommands;
+    }
 
     program->use();
     cmdBuf->subData(0, count * sizeof(IRRender::GlyphDrawCommand), commands.data());
-    canvas.getTextureColors()->bindAsImage(
-        0, IRRender::TextureAccess::WRITE_ONLY, IRRender::TextureFormat::RGBA8
-    );
-    canvas.getTextureDistances()->bindAsImage(
-        1, IRRender::TextureAccess::WRITE_ONLY, IRRender::TextureFormat::R32I
-    );
+    canvas.getTextureColors()
+        ->bindAsImage(0, IRRender::TextureAccess::WRITE_ONLY, IRRender::TextureFormat::RGBA8);
+    canvas.getTextureDistances()
+        ->bindAsImage(1, IRRender::TextureAccess::WRITE_ONLY, IRRender::TextureFormat::R32I);
     IRRender::device()->dispatchCompute(count, 1, 1);
     IRRender::device()->memoryBarrier(IRRender::BarrierType::ALL);
 
@@ -273,4 +300,4 @@ inline void dispatchGuiText(std::vector<IRRender::GlyphDrawCommand> &commands) {
 
 } // namespace IRPrefab::GuiText
 
-#endif /* GUI_TEXT_BATCH_H */
+#endif /* GUI_TEXT_BATCH_HPP */

--- a/engine/prefabs/irreden/render/gui_text_batch.hpp
+++ b/engine/prefabs/irreden/render/gui_text_batch.hpp
@@ -1,0 +1,276 @@
+#ifndef GUI_TEXT_BATCH_H
+#define GUI_TEXT_BATCH_H
+
+// Batched GUI text on the compute path.
+//
+// All GUI text — free-text overlays (TEXT_TO_TRIXEL) and widget
+// labels/values/titles — is laid out CPU-side into a vector of
+// GlyphDrawCommand, then rasterized by ONE compute dispatch that reads the
+// font-atlas SSBO and writes only lit glyph texels onto the GUI canvas.
+//
+// This replaces the per-glyph, per-pixel `setTrixel` path (IRRender::
+// renderText → renderGlyph) that issued two 1x1 subImage2D uploads per lit
+// glyph pixel — thousands of CPU→GPU micro-uploads per frame for a screen of
+// widget text. The compute path also scales by `fontSize` for free (the
+// shader upscales each glyph by the per-command styleFlags value).
+//
+// The font-atlas / command / program GPU resources are the named resources
+// created by System<TEXT_TO_TRIXEL>::create() ("FontDataBuffer",
+// "GlyphDrawCommandBuffer", "TextToTrixelProgram"). dispatchGuiText reuses
+// them, so TEXT_TO_TRIXEL must precede any widget render system in the RENDER
+// pipeline. That ordering is already mandatory: TEXT_TO_TRIXEL clears the GUI
+// canvas (and uploads the font buffer) in its beginTick, and widgets must
+// paint after the clear. Each text-bearing render system queues its glyphs in
+// its per-entity ticks and calls dispatchGuiText once in its endTick, so the
+// design needs no new pipeline stage and no creation-side pipeline edits.
+
+#include <irreden/ir_render.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <irreden/render/trixel_font.hpp>
+#include <irreden/render/trixel_text.hpp>
+#include <irreden/render/ir_render_types.hpp>
+#include <irreden/render/ir_render_enums.hpp>
+#include <irreden/render/buffer.hpp>
+#include <irreden/render/shader.hpp>
+#include <irreden/render/texture.hpp>
+#include <irreden/render/render_device.hpp>
+#include <irreden/render/components/component_text_style.hpp>
+#include <irreden/render/components/component_triangle_canvas_textures.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace IRPrefab::GuiText {
+
+// Max glyph commands rasterized by a single compute dispatch. Matches the
+// GlyphDrawCommandBuffer capacity created in System<TEXT_TO_TRIXEL>.
+constexpr int kMaxGlyphCommands = 8192;
+constexpr int kFontTableEntries = 128;
+constexpr int kFontRowsPerGlyph = IRRender::kGlyphHeight;
+constexpr int kFontBufferSize = kFontTableEntries * kFontRowsPerGlyph;
+constexpr IRMath::ivec2 kGuiOverlayPadding = IRMath::ivec2(24, 24);
+
+// Packs the fixed 7x11 glyph bitmaps into a flat uint32 SSBO (one row per
+// uint, low 7 bits used). Uploaded once into "FontDataBuffer".
+inline std::vector<std::uint32_t> buildFontBuffer() {
+    std::vector<std::uint32_t> buf(kFontBufferSize, 0);
+    for (int ascii = 0; ascii < kFontTableEntries; ++ascii) {
+        const IRRender::Glyph *g = IRRender::getGlyph(static_cast<char>(ascii));
+        if (!g)
+            continue;
+        for (int row = 0; row < kFontRowsPerGlyph; ++row) {
+            buf[ascii * kFontRowsPerGlyph + row] = static_cast<std::uint32_t>((*g)[row]);
+        }
+    }
+    return buf;
+}
+
+inline int glyphWidth(int fontSize) { return IRRender::kGlyphWidth * fontSize; }
+inline int glyphHeight(int fontSize) { return IRRender::kGlyphHeight * fontSize; }
+inline int glyphStepX(int fontSize) { return IRRender::kGlyphStepX * fontSize; }
+inline int glyphStepY(int fontSize) { return IRRender::kGlyphStepY * fontSize; }
+inline int glyphSpacingX(int fontSize) { return IRRender::kGlyphSpacingX * fontSize; }
+inline int glyphSpacingY(int fontSize) { return IRRender::kGlyphSpacingY * fontSize; }
+
+inline int nextWordWidth(const std::string &text, std::size_t i, int fontSize) {
+    int width = 0;
+    const int stepX = glyphStepX(fontSize);
+    while (i < text.size() && text[i] != ' ' && text[i] != '\n') {
+        width += stepX;
+        i++;
+    }
+    return width;
+}
+
+// CPU-side layout: appends one GlyphDrawCommand per visible glyph of `text`
+// to `commands`, handling newlines, word-wrap (wrapWidth), and H/V box
+// alignment (boxWidth/boxHeight, defaulting to the canvas extent). Each
+// command carries packed position, glyph index, packed color, the GUI-text
+// distance, and `fontSize` in styleFlags. This is the prior in-system layout
+// implementation, moved here unchanged so both TEXT_TO_TRIXEL and the widget
+// render systems share one code path.
+inline void expandTextToCommands(
+    std::vector<IRRender::GlyphDrawCommand> &commands,
+    const std::string &text,
+    IRMath::ivec2 position,
+    IRMath::ivec2 canvasSize,
+    IRMath::Color color,
+    int wrapWidth,
+    IRComponents::TextAlignH alignH = IRComponents::TextAlignH::LEFT,
+    IRComponents::TextAlignV alignV = IRComponents::TextAlignV::TOP,
+    int boxWidth = 0,
+    int boxHeight = 0,
+    int fontSize = 2
+) {
+    IRMath::ivec2 aligned = IRRender::parityAlignedPosition(position, canvasSize);
+    IRMath::ivec2 cursor = aligned;
+    const int gw = glyphWidth(fontSize);
+    const int stepX = glyphStepX(fontSize);
+    const int stepY = glyphStepY(fontSize);
+    const int spacX = glyphSpacingX(fontSize);
+    const int spacY = glyphSpacingY(fontSize);
+    const int effectiveWrap =
+        (wrapWidth > 0) ? aligned.x + wrapWidth : (wrapWidth < 0 ? canvasSize.x : 0);
+    std::uint32_t packed = color.toPackedRGBA();
+
+    const std::size_t firstCmd = commands.size();
+
+    struct LineInfo {
+        std::size_t firstIndex_;
+        std::size_t count_;
+        int width_;
+    };
+    std::vector<LineInfo> lines;
+    lines.push_back({firstCmd, 0, 0});
+
+    for (std::size_t i = 0; i < text.size(); ++i) {
+        char c = text[i];
+        if (c == '\n') {
+            lines.back().width_ = cursor.x - aligned.x;
+            if (lines.back().width_ > 0)
+                lines.back().width_ -= spacX;
+            cursor.x = aligned.x;
+            cursor.y += stepY;
+            lines.push_back({commands.size(), 0, 0});
+            continue;
+        }
+
+        if (effectiveWrap > 0 && c == ' ') {
+            int upcoming = nextWordWidth(text, i + 1, fontSize);
+            if (cursor.x + stepX + upcoming > effectiveWrap) {
+                lines.back().width_ = cursor.x - aligned.x;
+                if (lines.back().width_ > 0)
+                    lines.back().width_ -= spacX;
+                cursor.x = aligned.x;
+                cursor.y += stepY;
+                lines.push_back({commands.size(), 0, 0});
+                continue;
+            }
+        }
+
+        if (effectiveWrap > 0 && cursor.x + gw > effectiveWrap && c != ' ') {
+            lines.back().width_ = cursor.x - aligned.x;
+            if (lines.back().width_ > 0)
+                lines.back().width_ -= spacX;
+            cursor.x = aligned.x;
+            cursor.y += stepY;
+            lines.push_back({commands.size(), 0, 0});
+        }
+
+        const IRRender::Glyph *glyph = IRRender::getGlyph(c);
+        if (glyph) {
+            IRRender::GlyphDrawCommand cmd;
+            cmd.positionPacked = static_cast<std::uint32_t>(cursor.x & 0xFFFF) |
+                                 (static_cast<std::uint32_t>(cursor.y & 0xFFFF) << 16);
+            cmd.glyphIndex = static_cast<std::uint32_t>(static_cast<unsigned char>(c));
+            cmd.colorPacked = packed;
+            cmd.distance = static_cast<std::uint32_t>(IRRender::kGuiTextDistance);
+            cmd.styleFlags = static_cast<std::uint32_t>(fontSize);
+            commands.push_back(cmd);
+            lines.back().count_++;
+        }
+        cursor.x += stepX;
+    }
+
+    lines.back().width_ = cursor.x - aligned.x;
+    if (lines.back().width_ > 0)
+        lines.back().width_ -= spacX;
+
+    if (alignH == IRComponents::TextAlignH::LEFT && alignV == IRComponents::TextAlignV::TOP)
+        return;
+
+    const int refW = (boxWidth > 0) ? boxWidth : canvasSize.x;
+    const int refH = (boxHeight > 0) ? boxHeight : canvasSize.y;
+    const int totalTextH = static_cast<int>(lines.size()) * stepY - spacY;
+
+    int offsetY = 0;
+    if (alignV == IRComponents::TextAlignV::CENTER)
+        offsetY = (refH - totalTextH) / 2;
+    else if (alignV == IRComponents::TextAlignV::BOTTOM)
+        offsetY = refH - totalTextH;
+
+    for (auto &line : lines) {
+        int offsetX = 0;
+        if (alignH == IRComponents::TextAlignH::CENTER)
+            offsetX = (refW - line.width_) / 2;
+        else if (alignH == IRComponents::TextAlignH::RIGHT)
+            offsetX = refW - line.width_;
+
+        int roundedX = (offsetX / 2) * 2;
+        int roundedY = (offsetY / 2) * 2;
+
+        for (std::size_t j = 0; j < line.count_; ++j) {
+            auto &cmd = commands[line.firstIndex_ + j];
+            int cx = static_cast<int>(cmd.positionPacked & 0xFFFF) + roundedX;
+            int cy = static_cast<int>(cmd.positionPacked >> 16) + roundedY;
+            cmd.positionPacked = static_cast<std::uint32_t>(cx & 0xFFFF) |
+                                 (static_cast<std::uint32_t>(cy & 0xFFFF) << 16);
+        }
+    }
+}
+
+// Convenience append for call sites that already hold the GUI canvas size
+// (widget render systems, editor overlays). No-op for empty text.
+inline void queueGuiText(
+    std::vector<IRRender::GlyphDrawCommand> &commands,
+    const std::string &text,
+    IRMath::ivec2 pos,
+    IRMath::ivec2 canvasSize,
+    IRMath::Color color,
+    int fontSize,
+    IRComponents::TextAlignH alignH = IRComponents::TextAlignH::LEFT,
+    IRComponents::TextAlignV alignV = IRComponents::TextAlignV::TOP,
+    int boxWidth = 0,
+    int boxHeight = 0,
+    int wrapWidth = 0
+) {
+    if (text.empty())
+        return;
+    expandTextToCommands(
+        commands, text, pos, canvasSize, color, wrapWidth, alignH, alignV, boxWidth, boxHeight,
+        fontSize
+    );
+}
+
+// Uploads `commands` to the shared glyph-command SSBO and dispatches the text
+// compute shader once, rasterizing every queued glyph onto the GUI canvas,
+// then clears `commands`. No-op (and clears) when the shared text resources
+// or the GUI canvas are absent — e.g. a creation that runs widget systems
+// without TEXT_TO_TRIXEL, which would not show free text either. Call from a
+// render system's endTick, after queuing that system's text in its ticks.
+inline void dispatchGuiText(std::vector<IRRender::GlyphDrawCommand> &commands) {
+    if (commands.empty())
+        return;
+
+    auto *program = IRRender::getNamedResource<IRRender::ShaderProgram>("TextToTrixelProgram");
+    auto *cmdBuf = IRRender::getNamedResource<IRRender::Buffer>("GlyphDrawCommandBuffer");
+    const IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
+    if (program == nullptr || cmdBuf == nullptr || guiCanvas == IREntity::kNullEntity) {
+        commands.clear();
+        return;
+    }
+    auto &canvas = IREntity::getComponent<IRComponents::C_TriangleCanvasTextures>(guiCanvas);
+
+    int count = static_cast<int>(commands.size());
+    if (count > kMaxGlyphCommands)
+        count = kMaxGlyphCommands;
+
+    program->use();
+    cmdBuf->subData(0, count * sizeof(IRRender::GlyphDrawCommand), commands.data());
+    canvas.getTextureColors()->bindAsImage(
+        0, IRRender::TextureAccess::WRITE_ONLY, IRRender::TextureFormat::RGBA8
+    );
+    canvas.getTextureDistances()->bindAsImage(
+        1, IRRender::TextureAccess::WRITE_ONLY, IRRender::TextureFormat::R32I
+    );
+    IRRender::device()->dispatchCompute(count, 1, 1);
+    IRRender::device()->memoryBarrier(IRRender::BarrierType::ALL);
+
+    commands.clear();
+}
+
+} // namespace IRPrefab::GuiText
+
+#endif /* GUI_TEXT_BATCH_H */

--- a/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_text_to_trixel.hpp
@@ -9,6 +9,7 @@
 
 #include <irreden/render/trixel_font.hpp>
 #include <irreden/render/trixel_text.hpp>
+#include <irreden/render/gui_text_batch.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/components/component_text_segment.hpp>
 #include <irreden/render/components/component_gui_position.hpp>
@@ -25,174 +26,12 @@ using namespace IRMath;
 
 namespace IRSystem {
 
-constexpr int kMaxGlyphCommands = 8192;
-constexpr int kFontTableEntries = 128;
-constexpr int kFontRowsPerGlyph = IRRender::kGlyphHeight;
-constexpr int kFontBufferSize = kFontTableEntries * kFontRowsPerGlyph;
-constexpr ivec2 kGuiOverlayPadding = ivec2(24, 24);
-
-inline std::vector<uint32_t> buildFontBuffer() {
-    std::vector<uint32_t> buf(kFontBufferSize, 0);
-    for (int ascii = 0; ascii < kFontTableEntries; ++ascii) {
-        const IRRender::Glyph *g = IRRender::getGlyph(static_cast<char>(ascii));
-        if (!g)
-            continue;
-        for (int row = 0; row < kFontRowsPerGlyph; ++row) {
-            buf[ascii * kFontRowsPerGlyph + row] = static_cast<uint32_t>((*g)[row]);
-        }
-    }
-    return buf;
-}
-
-inline int glyphWidth(int fontSize) {
-    return IRRender::kGlyphWidth * fontSize;
-}
-inline int glyphHeight(int fontSize) {
-    return IRRender::kGlyphHeight * fontSize;
-}
-inline int glyphStepX(int fontSize) {
-    return IRRender::kGlyphStepX * fontSize;
-}
-inline int glyphStepY(int fontSize) {
-    return IRRender::kGlyphStepY * fontSize;
-}
-inline int glyphSpacingX(int fontSize) {
-    return IRRender::kGlyphSpacingX * fontSize;
-}
-inline int glyphSpacingY(int fontSize) {
-    return IRRender::kGlyphSpacingY * fontSize;
-}
-
-inline int nextWordWidth(const std::string &text, size_t i, int fontSize) {
-    int width = 0;
-    const int stepX = glyphStepX(fontSize);
-    while (i < text.size() && text[i] != ' ' && text[i] != '\n') {
-        width += stepX;
-        i++;
-    }
-    return width;
-}
-
-inline void expandTextToCommands(
-    std::vector<GlyphDrawCommand> &commands,
-    const std::string &text,
-    ivec2 position,
-    ivec2 canvasSize,
-    Color color,
-    int wrapWidth,
-    TextAlignH alignH = TextAlignH::LEFT,
-    TextAlignV alignV = TextAlignV::TOP,
-    int boxWidth = 0,
-    int boxHeight = 0,
-    int fontSize = 2
-) {
-    ivec2 aligned = IRRender::parityAlignedPosition(position, canvasSize);
-    ivec2 cursor = aligned;
-    const int gw = glyphWidth(fontSize);
-    const int stepX = glyphStepX(fontSize);
-    const int stepY = glyphStepY(fontSize);
-    const int spacX = glyphSpacingX(fontSize);
-    const int spacY = glyphSpacingY(fontSize);
-    const int effectiveWrap =
-        (wrapWidth > 0) ? aligned.x + wrapWidth : (wrapWidth < 0 ? canvasSize.x : 0);
-    uint32_t packed = color.toPackedRGBA();
-
-    const size_t firstCmd = commands.size();
-
-    struct LineInfo {
-        size_t firstIndex_;
-        size_t count_;
-        int width_;
-    };
-    std::vector<LineInfo> lines;
-    lines.push_back({firstCmd, 0, 0});
-
-    for (size_t i = 0; i < text.size(); ++i) {
-        char c = text[i];
-        if (c == '\n') {
-            lines.back().width_ = cursor.x - aligned.x;
-            if (lines.back().width_ > 0)
-                lines.back().width_ -= spacX;
-            cursor.x = aligned.x;
-            cursor.y += stepY;
-            lines.push_back({commands.size(), 0, 0});
-            continue;
-        }
-
-        if (effectiveWrap > 0 && c == ' ') {
-            int upcoming = nextWordWidth(text, i + 1, fontSize);
-            if (cursor.x + stepX + upcoming > effectiveWrap) {
-                lines.back().width_ = cursor.x - aligned.x;
-                if (lines.back().width_ > 0)
-                    lines.back().width_ -= spacX;
-                cursor.x = aligned.x;
-                cursor.y += stepY;
-                lines.push_back({commands.size(), 0, 0});
-                continue;
-            }
-        }
-
-        if (effectiveWrap > 0 && cursor.x + gw > effectiveWrap && c != ' ') {
-            lines.back().width_ = cursor.x - aligned.x;
-            if (lines.back().width_ > 0)
-                lines.back().width_ -= spacX;
-            cursor.x = aligned.x;
-            cursor.y += stepY;
-            lines.push_back({commands.size(), 0, 0});
-        }
-
-        const IRRender::Glyph *glyph = IRRender::getGlyph(c);
-        if (glyph) {
-            GlyphDrawCommand cmd;
-            cmd.positionPacked = static_cast<uint32_t>(cursor.x & 0xFFFF) |
-                                 (static_cast<uint32_t>(cursor.y & 0xFFFF) << 16);
-            cmd.glyphIndex = static_cast<uint32_t>(static_cast<unsigned char>(c));
-            cmd.colorPacked = packed;
-            cmd.distance = static_cast<uint32_t>(IRRender::kGuiTextDistance);
-            cmd.styleFlags = static_cast<uint32_t>(fontSize);
-            commands.push_back(cmd);
-            lines.back().count_++;
-        }
-        cursor.x += stepX;
-    }
-
-    lines.back().width_ = cursor.x - aligned.x;
-    if (lines.back().width_ > 0)
-        lines.back().width_ -= spacX;
-
-    if (alignH == TextAlignH::LEFT && alignV == TextAlignV::TOP)
-        return;
-
-    const int refW = (boxWidth > 0) ? boxWidth : canvasSize.x;
-    const int refH = (boxHeight > 0) ? boxHeight : canvasSize.y;
-    const int totalTextH = static_cast<int>(lines.size()) * stepY - spacY;
-
-    int offsetY = 0;
-    if (alignV == TextAlignV::CENTER)
-        offsetY = (refH - totalTextH) / 2;
-    else if (alignV == TextAlignV::BOTTOM)
-        offsetY = refH - totalTextH;
-
-    for (auto &line : lines) {
-        int offsetX = 0;
-        if (alignH == TextAlignH::CENTER)
-            offsetX = (refW - line.width_) / 2;
-        else if (alignH == TextAlignH::RIGHT)
-            offsetX = refW - line.width_;
-
-        int roundedX = (offsetX / 2) * 2;
-        int roundedY = (offsetY / 2) * 2;
-
-        for (size_t j = 0; j < line.count_; ++j) {
-            auto &cmd = commands[line.firstIndex_ + j];
-            int cx = static_cast<int>(cmd.positionPacked & 0xFFFF) + roundedX;
-            int cy = static_cast<int>(cmd.positionPacked >> 16) + roundedY;
-            cmd.positionPacked =
-                static_cast<uint32_t>(cx & 0xFFFF) | (static_cast<uint32_t>(cy & 0xFFFF) << 16);
-        }
-    }
-}
-
+// Glyph layout + the batched compute-dispatch helpers now live in
+// irreden/render/gui_text_batch.hpp (IRPrefab::GuiText) so the widget render
+// systems share the same path. This system owns the GPU resources
+// (TextToTrixelProgram / FontDataBuffer / GlyphDrawCommandBuffer) and renders
+// free-text entities + the GUI command-list overlay; dispatchGuiText reuses
+// those resources for widget text, which is why TEXT_TO_TRIXEL must run first.
 template <> struct System<TEXT_TO_TRIXEL> {
     ShaderProgram *textProgram_ = nullptr;
     Buffer *fontDataBuf_ = nullptr;
@@ -212,7 +51,7 @@ template <> struct System<TEXT_TO_TRIXEL> {
         const C_GuiElement &,
         const C_TextStyle &style
     ) {
-        expandTextToCommands(
+        IRPrefab::GuiText::expandTextToCommands(
             drawCommands_,
             text.text_,
             guiPos.pos_,
@@ -231,7 +70,7 @@ template <> struct System<TEXT_TO_TRIXEL> {
         textProgram_->use();
 
         if (!fontUploaded_) {
-            auto fontData = buildFontBuffer();
+            auto fontData = IRPrefab::GuiText::buildFontBuffer();
             fontDataBuf_->subData(0, fontData.size() * sizeof(uint32_t), fontData.data());
             fontUploaded_ = true;
         }
@@ -246,10 +85,10 @@ template <> struct System<TEXT_TO_TRIXEL> {
             if (commandList_.empty()) {
                 commandList_ = IRCommand::buildCommandListText();
             }
-            expandTextToCommands(
+            IRPrefab::GuiText::expandTextToCommands(
                 drawCommands_,
                 commandList_,
-                kGuiOverlayPadding,
+                IRPrefab::GuiText::kGuiOverlayPadding,
                 canvasTextures_->size_,
                 IRMath::IRColors::kWhite,
                 0
@@ -262,8 +101,8 @@ template <> struct System<TEXT_TO_TRIXEL> {
             return;
 
         int count = static_cast<int>(drawCommands_.size());
-        if (count > kMaxGlyphCommands) {
-            count = kMaxGlyphCommands;
+        if (count > IRPrefab::GuiText::kMaxGlyphCommands) {
+            count = IRPrefab::GuiText::kMaxGlyphCommands;
         }
 
         glyphCmdBuf_->subData(0, count * sizeof(GlyphDrawCommand), drawCommands_.data());
@@ -286,7 +125,7 @@ template <> struct System<TEXT_TO_TRIXEL> {
         IRRender::createNamedResource<Buffer>(
             "FontDataBuffer",
             nullptr,
-            kFontBufferSize * sizeof(uint32_t),
+            IRPrefab::GuiText::kFontBufferSize * sizeof(uint32_t),
             BUFFER_STORAGE_DYNAMIC,
             BufferTarget::SHADER_STORAGE,
             kBufferIndex_FontData
@@ -294,7 +133,7 @@ template <> struct System<TEXT_TO_TRIXEL> {
         IRRender::createNamedResource<Buffer>(
             "GlyphDrawCommandBuffer",
             nullptr,
-            kMaxGlyphCommands * sizeof(GlyphDrawCommand),
+            IRPrefab::GuiText::kMaxGlyphCommands * sizeof(GlyphDrawCommand),
             BUFFER_STORAGE_DYNAMIC,
             BufferTarget::SHADER_STORAGE,
             kBufferIndex_GlyphDrawCommands

--- a/engine/prefabs/irreden/render/systems/system_widget_render_button.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_button.hpp
@@ -17,6 +17,7 @@ namespace IRSystem {
 template <> struct System<WIDGET_RENDER_BUTTON> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
     IRRender::RectFillScratch scratch_;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
@@ -29,7 +30,8 @@ template <> struct System<WIDGET_RENDER_BUTTON> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
+        if (!canvas_)
+            return;
 
         const auto &theme = IRPrefab::Widget::defaultTheme();
         IRRender::fillRect(
@@ -49,13 +51,18 @@ template <> struct System<WIDGET_RENDER_BUTTON> {
             theme.borderThickness_,
             scratch_
         );
-        IRPrefab::Widget::detail::drawCenteredText(
-            *canvas_,
+        IRPrefab::Widget::detail::queueCenteredText(
+            textCmds_,
+            canvas_->size_,
             button.label_,
             guiPos.pos_,
             widget.size_,
             IRPrefab::Widget::detail::stateText(theme, widget)
         );
+    }
+
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
     }
 
     static SystemId create() {
@@ -64,8 +71,7 @@ template <> struct System<WIDGET_RENDER_BUTTON> {
             IRComponents::C_Widget,
             IRComponents::C_WidgetButton,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderButton");
+            IRComponents::C_GuiPosition>("WidgetRenderButton");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_checkbox.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_checkbox.hpp
@@ -17,6 +17,7 @@ namespace IRSystem {
 template <> struct System<WIDGET_RENDER_CHECKBOX> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
     IRRender::RectFillScratch scratch_;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
@@ -29,7 +30,8 @@ template <> struct System<WIDGET_RENDER_CHECKBOX> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
+        if (!canvas_)
+            return;
 
         const auto &theme = IRPrefab::Widget::defaultTheme();
         const int boxSize = theme.checkboxBoxSize_;
@@ -66,8 +68,9 @@ template <> struct System<WIDGET_RENDER_CHECKBOX> {
         }
 
         if (!checkbox.label_.empty()) {
-            IRPrefab::Widget::detail::drawLeftText(
-                *canvas_,
+            IRPrefab::Widget::detail::queueLeftText(
+                textCmds_,
+                canvas_->size_,
                 checkbox.label_,
                 IRMath::ivec2(guiPos.pos_.x + boxSize + theme.padding_ * 2, guiPos.pos_.y),
                 widget.size_.y,
@@ -76,14 +79,17 @@ template <> struct System<WIDGET_RENDER_CHECKBOX> {
         }
     }
 
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
+    }
+
     static SystemId create() {
         return registerSystem<
             WIDGET_RENDER_CHECKBOX,
             IRComponents::C_Widget,
             IRComponents::C_WidgetCheckbox,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderCheckbox");
+            IRComponents::C_GuiPosition>("WidgetRenderCheckbox");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_dropdown.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_dropdown.hpp
@@ -24,6 +24,7 @@ namespace IRSystem {
 template <> struct System<WIDGET_RENDER_DROPDOWN> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
     IRRender::RectFillScratch scratch_;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
@@ -36,8 +37,10 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
-        if (widget.size_.x <= 0 || widget.size_.y <= 0) return;
+        if (!canvas_)
+            return;
+        if (widget.size_.x <= 0 || widget.size_.y <= 0)
+            return;
 
         const auto &theme = IRPrefab::Widget::defaultTheme();
         const int itemH = IRMath::max(1, dd.itemHeight_);
@@ -63,12 +66,12 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
         );
 
         // Selected label (or placeholder dash when empty).
-        const std::string &headerText =
-            (dd.selectedIndex_ >= 0 && dd.selectedIndex_ < n)
-                ? dd.items_[static_cast<std::size_t>(dd.selectedIndex_)]
-                : std::string("---");
-        IRPrefab::Widget::detail::drawLeftText(
-            *canvas_,
+        const std::string &headerText = (dd.selectedIndex_ >= 0 && dd.selectedIndex_ < n)
+                                            ? dd.items_[static_cast<std::size_t>(dd.selectedIndex_)]
+                                            : std::string("---");
+        IRPrefab::Widget::detail::queueLeftText(
+            textCmds_,
+            canvas_->size_,
             headerText,
             IRMath::ivec2(guiPos.pos_.x + theme.padding_ * 2, guiPos.pos_.y),
             widget.size_.y,
@@ -99,7 +102,8 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
             scratch_
         );
 
-        if (!dd.isOpen_ || n == 0) return;
+        if (!dd.isOpen_ || n == 0)
+            return;
 
         // Expanded item panel. Painted in painter order over anything below it.
         const IRMath::ivec2 panelPos(guiPos.pos_.x, guiPos.pos_.y + widget.size_.y);
@@ -139,8 +143,9 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
                     scratch_
                 );
             }
-            IRPrefab::Widget::detail::drawLeftText(
-                *canvas_,
+            IRPrefab::Widget::detail::queueLeftText(
+                textCmds_,
+                canvas_->size_,
                 dd.items_[static_cast<std::size_t>(i)],
                 IRMath::ivec2(rowPos.x + theme.padding_ * 2, rowPos.y),
                 itemH,
@@ -159,14 +164,17 @@ template <> struct System<WIDGET_RENDER_DROPDOWN> {
         );
     }
 
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
+    }
+
     static SystemId create() {
         return registerSystem<
             WIDGET_RENDER_DROPDOWN,
             IRComponents::C_Widget,
             IRComponents::C_WidgetDropdown,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderDropdown");
+            IRComponents::C_GuiPosition>("WidgetRenderDropdown");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_label.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_label.hpp
@@ -16,6 +16,7 @@ namespace IRSystem {
 
 template <> struct System<WIDGET_RENDER_LABEL> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
@@ -27,14 +28,26 @@ template <> struct System<WIDGET_RENDER_LABEL> {
         const IRComponents::C_WidgetLabel &label,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
-        if (label.text_.empty()) return;
+        if (!canvas_)
+            return;
+        if (label.text_.empty())
+            return;
         const auto &theme = IRPrefab::Widget::defaultTheme();
-        const IRMath::Color color =
-            (label.colorOverride_.alpha_ == 0)
-                ? IRPrefab::Widget::detail::stateText(theme, widget)
-                : label.colorOverride_;
-        IRRender::renderText(*canvas_, label.text_, guiPos.pos_, color);
+        const IRMath::Color color = (label.colorOverride_.alpha_ == 0)
+                                        ? IRPrefab::Widget::detail::stateText(theme, widget)
+                                        : label.colorOverride_;
+        IRPrefab::GuiText::queueGuiText(
+            textCmds_,
+            label.text_,
+            guiPos.pos_,
+            canvas_->size_,
+            color,
+            IRPrefab::Widget::detail::kWidgetTextFontSize
+        );
+    }
+
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
     }
 
     static SystemId create() {
@@ -42,8 +55,7 @@ template <> struct System<WIDGET_RENDER_LABEL> {
             WIDGET_RENDER_LABEL,
             IRComponents::C_Widget,
             IRComponents::C_WidgetLabel,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderLabel");
+            IRComponents::C_GuiPosition>("WidgetRenderLabel");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_list.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_list.hpp
@@ -23,6 +23,7 @@ namespace IRSystem {
 template <> struct System<WIDGET_RENDER_LIST> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
     IRRender::RectFillScratch scratch_;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
@@ -35,8 +36,10 @@ template <> struct System<WIDGET_RENDER_LIST> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
-        if (widget.size_.x <= 0 || widget.size_.y <= 0) return;
+        if (!canvas_)
+            return;
+        if (widget.size_.x <= 0 || widget.size_.y <= 0)
+            return;
 
         const auto &theme = IRPrefab::Widget::defaultTheme();
         const int itemH = IRMath::max(1, list.itemHeight_);
@@ -54,13 +57,15 @@ template <> struct System<WIDGET_RENDER_LIST> {
 
         for (int row = 0; row < rows; ++row) {
             const int idx = list.scrollOffset_ + row;
-            if (idx < 0 || idx >= n) break;
+            if (idx < 0 || idx >= n)
+                break;
             const IRMath::ivec2 rowPos(guiPos.pos_.x, guiPos.pos_.y + row * itemH);
             const IRMath::ivec2 rowSize(widget.size_.x, itemH);
 
             const bool isSelected = (idx == list.selectedIndex_);
-            const bool isHoverRow = state.hovered_ && (state.dragValue_ >= static_cast<float>(row) &&
-                                                       state.dragValue_ < static_cast<float>(row + 1));
+            const bool isHoverRow =
+                state.hovered_ && (state.dragValue_ >= static_cast<float>(row) &&
+                                   state.dragValue_ < static_cast<float>(row + 1));
 
             if (isSelected) {
                 IRRender::fillRect(
@@ -82,8 +87,9 @@ template <> struct System<WIDGET_RENDER_LIST> {
                 );
             }
 
-            IRPrefab::Widget::detail::drawLeftText(
-                *canvas_,
+            IRPrefab::Widget::detail::queueLeftText(
+                textCmds_,
+                canvas_->size_,
                 list.items_[static_cast<std::size_t>(idx)],
                 IRMath::ivec2(rowPos.x + theme.padding_ * 2, rowPos.y),
                 itemH,
@@ -102,14 +108,17 @@ template <> struct System<WIDGET_RENDER_LIST> {
         );
     }
 
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
+    }
+
     static SystemId create() {
         return registerSystem<
             WIDGET_RENDER_LIST,
             IRComponents::C_Widget,
             IRComponents::C_WidgetList,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderList");
+            IRComponents::C_GuiPosition>("WidgetRenderList");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_panel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_panel.hpp
@@ -24,6 +24,7 @@ namespace IRSystem {
 template <> struct System<WIDGET_RENDER_PANEL> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
     IRRender::RectFillScratch scratch_;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
@@ -36,7 +37,8 @@ template <> struct System<WIDGET_RENDER_PANEL> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
+        if (!canvas_)
+            return;
 
         const auto &theme = IRPrefab::Widget::defaultTheme();
         IRRender::fillRect(
@@ -58,8 +60,9 @@ template <> struct System<WIDGET_RENDER_PANEL> {
                 IRRender::kWidgetBorderDistance,
                 scratch_
             );
-            IRPrefab::Widget::detail::drawCenteredText(
-                *canvas_,
+            IRPrefab::Widget::detail::queueCenteredText(
+                textCmds_,
+                canvas_->size_,
                 panel.title_,
                 guiPos.pos_,
                 IRMath::ivec2(widget.size_.x, titleBarH),
@@ -80,14 +83,17 @@ template <> struct System<WIDGET_RENDER_PANEL> {
         }
     }
 
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
+    }
+
     static SystemId create() {
         return registerSystem<
             WIDGET_RENDER_PANEL,
             IRComponents::C_Widget,
             IRComponents::C_WidgetPanel,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderPanel");
+            IRComponents::C_GuiPosition>("WidgetRenderPanel");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_radio.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_radio.hpp
@@ -25,6 +25,7 @@ namespace IRSystem {
 template <> struct System<WIDGET_RENDER_RADIO> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
     IRRender::RectFillScratch scratch_;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
@@ -37,7 +38,8 @@ template <> struct System<WIDGET_RENDER_RADIO> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
+        if (!canvas_)
+            return;
 
         const auto &theme = IRPrefab::Widget::defaultTheme();
         const int box = theme.radioBoxSize_;
@@ -74,8 +76,9 @@ template <> struct System<WIDGET_RENDER_RADIO> {
         }
 
         if (!radio.label_.empty()) {
-            IRPrefab::Widget::detail::drawLeftText(
-                *canvas_,
+            IRPrefab::Widget::detail::queueLeftText(
+                textCmds_,
+                canvas_->size_,
                 radio.label_,
                 IRMath::ivec2(guiPos.pos_.x + box + theme.padding_ * 2, guiPos.pos_.y),
                 widget.size_.y,
@@ -84,14 +87,17 @@ template <> struct System<WIDGET_RENDER_RADIO> {
         }
     }
 
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
+    }
+
     static SystemId create() {
         return registerSystem<
             WIDGET_RENDER_RADIO,
             IRComponents::C_Widget,
             IRComponents::C_WidgetRadio,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderRadio");
+            IRComponents::C_GuiPosition>("WidgetRenderRadio");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_slider.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_slider.hpp
@@ -21,6 +21,7 @@ namespace IRSystem {
 template <> struct System<WIDGET_RENDER_SLIDER> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
     IRRender::RectFillScratch scratch_;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
 
     void beginTick() {
         IREntity::EntityId guiCanvas = IRRender::getCanvas("gui");
@@ -33,12 +34,14 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
+        if (!canvas_)
+            return;
 
         const auto &theme = IRPrefab::Widget::defaultTheme();
         const int W = widget.size_.x;
         const int H = widget.size_.y;
-        if (W <= 0 || H <= 0) return;
+        if (W <= 0 || H <= 0)
+            return;
 
         // Top half is the optional label, bottom half is track + thumb.
         const int labelH = slider.label_.empty() ? 0 : IRRender::kGlyphStepY;
@@ -46,8 +49,9 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
         const int trackX = guiPos.pos_.x;
 
         if (!slider.label_.empty()) {
-            IRPrefab::Widget::detail::drawLeftText(
-                *canvas_,
+            IRPrefab::Widget::detail::queueLeftText(
+                textCmds_,
+                canvas_->size_,
                 slider.label_,
                 guiPos.pos_,
                 labelH,
@@ -66,19 +70,18 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
         );
 
         // Thumb
-        const float range =
-            (slider.maxValue_ - slider.minValue_) != 0.0f ? (slider.maxValue_ - slider.minValue_) : 1.0f;
-        const float t = IRMath::clamp(
-            (slider.currentValue_ - slider.minValue_) / range, 0.0f, 1.0f
-        );
+        const float range = (slider.maxValue_ - slider.minValue_) != 0.0f
+                                ? (slider.maxValue_ - slider.minValue_)
+                                : 1.0f;
+        const float t =
+            IRMath::clamp((slider.currentValue_ - slider.minValue_) / range, 0.0f, 1.0f);
         const int thumbW = theme.sliderThumbWidth_;
         const int thumbH = H - labelH;
         const int thumbX = guiPos.pos_.x + static_cast<int>(t * static_cast<float>(W - thumbW));
         const int thumbY = guiPos.pos_.y + labelH;
-        const IRMath::Color thumbColor =
-            widget.disabled_   ? theme.backgroundDisabled_
-            : state.hovered_   ? theme.sliderThumbHover_
-                               : theme.sliderThumbIdle_;
+        const IRMath::Color thumbColor = widget.disabled_ ? theme.backgroundDisabled_
+                                         : state.hovered_ ? theme.sliderThumbHover_
+                                                          : theme.sliderThumbIdle_;
         IRRender::fillRect(
             *canvas_,
             IRMath::ivec2(thumbX, thumbY),
@@ -88,22 +91,27 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
             scratch_
         );
 
-        // Value text at the right edge of the label row.
+        // Value text right-aligned within the label row [pos.x, pos.x + W).
         if (!slider.label_.empty()) {
             char buf[16];
             std::snprintf(buf, sizeof(buf), "%.2f", slider.currentValue_);
-            const std::string valueStr = buf;
-            const IRMath::ivec2 ts = IRPrefab::Widget::detail::measureSingleLine(valueStr);
-            const IRMath::ivec2 vpos =
-                IRMath::ivec2(guiPos.pos_.x + W - ts.x, guiPos.pos_.y);
-            IRPrefab::Widget::detail::drawLeftText(
-                *canvas_,
-                valueStr,
-                vpos,
-                labelH,
-                IRPrefab::Widget::detail::stateText(theme, widget)
+            IRPrefab::GuiText::queueGuiText(
+                textCmds_,
+                buf,
+                guiPos.pos_,
+                canvas_->size_,
+                IRPrefab::Widget::detail::stateText(theme, widget),
+                IRPrefab::Widget::detail::kWidgetTextFontSize,
+                IRComponents::TextAlignH::RIGHT,
+                IRComponents::TextAlignV::CENTER,
+                W,
+                labelH
             );
         }
+    }
+
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
     }
 
     static SystemId create() {
@@ -112,8 +120,7 @@ template <> struct System<WIDGET_RENDER_SLIDER> {
             IRComponents::C_Widget,
             IRComponents::C_WidgetSlider,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderSlider");
+            IRComponents::C_GuiPosition>("WidgetRenderSlider");
     }
 };
 

--- a/engine/prefabs/irreden/render/systems/system_widget_render_text_input.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_render_text_input.hpp
@@ -25,6 +25,7 @@ namespace IRSystem {
 template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
     IRComponents::C_TriangleCanvasTextures *canvas_ = nullptr;
     IRRender::RectFillScratch scratch_;
+    std::vector<IRRender::GlyphDrawCommand> textCmds_;
     int frameCounter_ = 0;
 
     void beginTick() {
@@ -39,7 +40,8 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
         const IRComponents::C_WidgetState &state,
         const IRComponents::C_GuiPosition &guiPos
     ) {
-        if (!canvas_) return;
+        if (!canvas_)
+            return;
 
         const auto &theme = IRPrefab::Widget::defaultTheme();
         IRRender::fillRect(
@@ -62,8 +64,9 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
 
         const int textX = guiPos.pos_.x + theme.padding_ * 2;
         if (!textInput.text_.empty()) {
-            IRPrefab::Widget::detail::drawLeftText(
-                *canvas_,
+            IRPrefab::Widget::detail::queueLeftText(
+                textCmds_,
+                canvas_->size_,
                 textInput.text_,
                 IRMath::ivec2(textX, guiPos.pos_.y),
                 widget.size_.y,
@@ -71,18 +74,19 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
             );
         }
 
-        if (!state.focused_ || widget.disabled_) return;
+        if (!state.focused_ || widget.disabled_)
+            return;
 
         // Blink: cursor visible during the first half of each blink
         // period, hidden during the second. textCursorBlinkPeriodFrames_
         // is the FULL period.
         const int period = IRMath::max(2, theme.textCursorBlinkPeriodFrames_);
         const bool cursorVisible = (frameCounter_ % period) < (period / 2);
-        if (!cursorVisible) return;
+        if (!cursorVisible)
+            return;
 
-        const int cursorChars = IRMath::clamp(
-            textInput.cursorPos_, 0, static_cast<int>(textInput.text_.size())
-        );
+        const int cursorChars =
+            IRMath::clamp(textInput.cursorPos_, 0, static_cast<int>(textInput.text_.size()));
         const int cursorX = IRMath::min(
             textX + cursorChars * IRRender::kGlyphStepX,
             guiPos.pos_.x + widget.size_.x - theme.textInputCursorWidth_
@@ -99,14 +103,17 @@ template <> struct System<WIDGET_RENDER_TEXT_INPUT> {
         );
     }
 
+    void endTick() {
+        IRPrefab::GuiText::dispatchGuiText(textCmds_);
+    }
+
     static SystemId create() {
         return registerSystem<
             WIDGET_RENDER_TEXT_INPUT,
             IRComponents::C_Widget,
             IRComponents::C_WidgetTextInput,
             IRComponents::C_WidgetState,
-            IRComponents::C_GuiPosition
-        >("WidgetRenderTextInput");
+            IRComponents::C_GuiPosition>("WidgetRenderTextInput");
     }
 };
 

--- a/engine/prefabs/irreden/render/widget_draw.hpp
+++ b/engine/prefabs/irreden/render/widget_draw.hpp
@@ -4,14 +4,24 @@
 #include <irreden/render/trixel_rect.hpp>
 #include <irreden/render/trixel_text.hpp>
 #include <irreden/render/trixel_font.hpp>
+#include <irreden/render/gui_text_batch.hpp>
+#include <irreden/render/ir_render_types.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 
 #include <irreden/render/widget_theme.hpp>
 #include <irreden/render/components/component_widget.hpp>
 
 #include <string>
+#include <vector>
 
 namespace IRPrefab::Widget::detail {
+
+// Widget text renders through the batched compute path (IRPrefab::GuiText)
+// at this base font size. 1 == the native 7x11 glyph (no upscale), matching
+// the legacy renderText path so the migration is visually identical. A
+// higher-resolution GUI canvas can raise this for larger body text without
+// touching call sites.
+constexpr int kWidgetTextFontSize = 1;
 
 // Picks the background color for a widget given its interactive state.
 // Centralized so every widget render system follows the same palette.
@@ -20,9 +30,12 @@ inline IRMath::Color stateBackground(
     const IRComponents::C_Widget &widget,
     const IRComponents::C_WidgetState &state
 ) {
-    if (widget.disabled_) return theme.backgroundDisabled_;
-    if (state.pressed_) return theme.backgroundPressed_;
-    if (state.hovered_) return theme.backgroundHover_;
+    if (widget.disabled_)
+        return theme.backgroundDisabled_;
+    if (state.pressed_)
+        return theme.backgroundPressed_;
+    if (state.hovered_)
+        return theme.backgroundHover_;
     return theme.backgroundIdle_;
 }
 
@@ -31,10 +44,14 @@ inline IRMath::Color stateBorder(
     const IRComponents::C_Widget &widget,
     const IRComponents::C_WidgetState &state
 ) {
-    if (widget.disabled_) return theme.borderDisabled_;
-    if (state.pressed_) return theme.borderPressed_;
-    if (state.hovered_) return theme.borderHover_;
-    if (state.focused_) return theme.borderFocused_;
+    if (widget.disabled_)
+        return theme.borderDisabled_;
+    if (state.pressed_)
+        return theme.borderPressed_;
+    if (state.hovered_)
+        return theme.borderHover_;
+    if (state.focused_)
+        return theme.borderFocused_;
     return theme.borderIdle_;
 }
 
@@ -42,49 +59,56 @@ inline IRMath::Color stateText(const WidgetTheme &theme, const IRComponents::C_W
     return widget.disabled_ ? theme.textDisabled_ : theme.textIdle_;
 }
 
-// Approximate text bounds for the trixel font. The font is fixed-width
-// 7x11 with 1-trixel spacing — measurement is `glyphCount * stepX -
-// spacing` horizontally, one line vertically (no \n support here; the
-// renderer in `renderText` handles wrapping itself).
-inline IRMath::ivec2 measureSingleLine(const std::string &text) {
-    if (text.empty()) return IRMath::ivec2(0, IRRender::kGlyphHeight);
-    int w = static_cast<int>(text.size()) * IRRender::kGlyphStepX - IRRender::kGlyphSpacingX;
-    return IRMath::ivec2(w, IRRender::kGlyphHeight);
-}
-
-// Render `text` centered horizontally inside `[pos, pos + size)` and
-// vertically aligned to the visual middle of the widget.
-inline void drawCenteredText(
-    IRComponents::C_TriangleCanvasTextures &canvas,
+// Queue `text` centered horizontally and vertically inside `[pos, pos +
+// size)` onto `cmds`. Appends glyph commands rather than rasterizing
+// immediately; the owning render system dispatches `cmds` once in its
+// endTick. `canvasSize` is the GUI canvas extent (for parity alignment).
+inline void queueCenteredText(
+    std::vector<IRRender::GlyphDrawCommand> &cmds,
+    IRMath::ivec2 canvasSize,
     const std::string &text,
     IRMath::ivec2 pos,
     IRMath::ivec2 size,
-    IRMath::Color color
+    IRMath::Color color,
+    int fontSize = kWidgetTextFontSize
 ) {
-    if (text.empty()) return;
-    const IRMath::ivec2 textSize = measureSingleLine(text);
-    IRMath::ivec2 textPos = pos + (size - textSize) / 2;
-    // Round down to even so parityAlignedPosition's adjustment never
-    // shifts visible glyphs left of the widget's interior padding.
-    textPos.x = (textPos.x / 2) * 2;
-    textPos.y = (textPos.y / 2) * 2;
-    IRRender::renderText(canvas, text, textPos, color);
+    IRPrefab::GuiText::queueGuiText(
+        cmds,
+        text,
+        pos,
+        canvasSize,
+        color,
+        fontSize,
+        IRComponents::TextAlignH::CENTER,
+        IRComponents::TextAlignV::CENTER,
+        size.x,
+        size.y
+    );
 }
 
-// Render `text` left-aligned, vertically centered.
-inline void drawLeftText(
-    IRComponents::C_TriangleCanvasTextures &canvas,
+// Queue `text` left-aligned, vertically centered within `height`, onto
+// `cmds`. See queueCenteredText for the deferred-dispatch contract.
+inline void queueLeftText(
+    std::vector<IRRender::GlyphDrawCommand> &cmds,
+    IRMath::ivec2 canvasSize,
     const std::string &text,
     IRMath::ivec2 pos,
     int height,
-    IRMath::Color color
+    IRMath::Color color,
+    int fontSize = kWidgetTextFontSize
 ) {
-    if (text.empty()) return;
-    const IRMath::ivec2 textSize = measureSingleLine(text);
-    IRMath::ivec2 textPos = IRMath::ivec2(pos.x, pos.y + (height - textSize.y) / 2);
-    textPos.x = (textPos.x / 2) * 2;
-    textPos.y = (textPos.y / 2) * 2;
-    IRRender::renderText(canvas, text, textPos, color);
+    IRPrefab::GuiText::queueGuiText(
+        cmds,
+        text,
+        pos,
+        canvasSize,
+        color,
+        fontSize,
+        IRComponents::TextAlignH::LEFT,
+        IRComponents::TextAlignV::CENTER,
+        0,
+        height
+    );
 }
 
 } // namespace IRPrefab::Widget::detail

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -593,9 +593,12 @@ parity with voxel-pool primary shapes.
 - **Canvas render order matters.** Multiple canvases write to the same
   framebuffer in registration order. Stage 2 must complete for a canvas
   before the next canvas reads from it.
-- **GUI canvas scaling.** GUI canvas is sized `mainCanvasSize / guiScale`.
-  Changing `guiScale` without resizing the GUI canvas entity breaks
-  coordinate mapping.
+- **GUI canvas scaling.** GUI canvas is sized `mainCanvasSize / guiScale`
+  by default; `IRRender::setGuiCanvasFullResolution()` instead sizes it to
+  the native framebuffer resolution (1 GUI trixel == 1 framebuffer pixel) so
+  GUI text/widgets render small and crisp — the calling creation owns laying
+  its GUI out for the finer coordinate space. Changing `guiScale` without
+  resizing the GUI canvas entity breaks coordinate mapping.
 - **CPU texture writes order via the command buffer on Metal.**
   `Texture2D::subImage2D` and `clear()` write canvas textures, but on Metal
   the per-frame work is deferred: `clear()` enqueues a GPU blit and the

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -310,6 +310,11 @@ bool isGuiVisible();
 /// mid-frame without understanding the coordinate-mapping consequences.
 void setGuiScale(int scale);
 int getGuiScale();
+/// Opt-in (default off): render the GUI canvas at the native framebuffer pixel
+/// resolution so GUI text / widgets are small and crisp instead of coarse. The
+/// calling creation owns laying its GUI out for the finer coordinate space;
+/// overrides guiScale-based sizing. Call once at init, before building widgets.
+void setGuiCanvasFullResolution();
 /// Enable / disable the trixel hover highlight (visual ring around the trixel under
 /// the cursor). Entity-id detection continues regardless of this flag.
 void setHoveredTrixelVisible(bool visible);

--- a/engine/render/include/irreden/render/render_manager.hpp
+++ b/engine/render/include/irreden/render/render_manager.hpp
@@ -61,6 +61,12 @@ class RenderManager {
 
     void setGuiScale(int scale);
     int getGuiScale() const;
+    // Opt-in (default off): resize the GUI canvas to the native framebuffer
+    // pixel resolution (1 GUI trixel == 1 framebuffer pixel) so GUI text /
+    // widgets render small and crisp instead of at the coarse iso-canvas
+    // resolution. A creation that enables this owns laying its GUI out for
+    // the finer coordinate space. Overrides guiScale-based sizing.
+    void setGuiCanvasFullResolution();
 
     void setHoveredTrixelVisible(bool visible);
     bool isHoveredTrixelVisible() const;
@@ -129,6 +135,7 @@ class RenderManager {
     EntityId m_mainCanvas;
     EntityId m_backgroundCanvas;
     int m_guiScale = 1;
+    bool m_guiFullResolution = false;
     EntityId m_guiCanvas;
     // EntityId m_playerCanvas;
     EntityId m_camera;
@@ -172,6 +179,10 @@ class RenderManager {
     void updateOutputResolution();
 
     ivec2 calcOutputScaleByMode();
+
+    // Destroy + recreate the GUI canvas textures at `newSize` and update its
+    // C_SizeTriangles. Shared by setGuiScale and setGuiCanvasFullResolution.
+    void resizeGuiCanvas(ivec2 newSize);
 };
 
 } // namespace IRRender

--- a/engine/render/src/ir_render.cpp
+++ b/engine/render/src/ir_render.cpp
@@ -238,6 +238,10 @@ int getGuiScale() {
     return getRenderManager().getGuiScale();
 }
 
+void setGuiCanvasFullResolution() {
+    getRenderManager().setGuiCanvasFullResolution();
+}
+
 void setHoveredTrixelVisible(bool visible) {
     getRenderManager().setHoveredTrixelVisible(visible);
 }

--- a/engine/render/src/render_manager.cpp
+++ b/engine/render/src/render_manager.cpp
@@ -512,9 +512,9 @@ void RenderManager::setGuiScale(int scale) {
     scale = std::clamp(scale, 1, 8);
     if (scale == m_guiScale)
         return;
-    m_guiScale = scale;
     if (m_guiFullResolution)
-        return; // full-resolution sizing overrides the scale divisor
+        return; // full-resolution sizing overrides the scale divisor; don't record the intent
+    m_guiScale = scale;
 
     ivec2 mainSize = IREntity::getComponent<C_SizeTriangles>(m_mainCanvas).size_;
     ivec2 newSize = mainSize / ivec2(scale);

--- a/engine/render/src/render_manager.cpp
+++ b/engine/render/src/render_manager.cpp
@@ -499,26 +499,40 @@ bool RenderManager::isGuiVisible() const {
     return m_guiVisible;
 }
 
+void RenderManager::resizeGuiCanvas(ivec2 newSize) {
+    if (IREntity::getComponent<C_SizeTriangles>(m_guiCanvas).size_ == newSize)
+        return;
+    auto &textures = IREntity::getComponent<C_TriangleCanvasTextures>(m_guiCanvas);
+    textures.onDestroy();
+    textures = C_TriangleCanvasTextures{newSize};
+    IREntity::getComponent<C_SizeTriangles>(m_guiCanvas).size_ = newSize;
+}
+
 void RenderManager::setGuiScale(int scale) {
     scale = std::clamp(scale, 1, 8);
     if (scale == m_guiScale)
         return;
     m_guiScale = scale;
+    if (m_guiFullResolution)
+        return; // full-resolution sizing overrides the scale divisor
 
     ivec2 mainSize = IREntity::getComponent<C_SizeTriangles>(m_mainCanvas).size_;
     ivec2 newSize = mainSize / ivec2(scale);
-
-    auto &textures = IREntity::getComponent<C_TriangleCanvasTextures>(m_guiCanvas);
-    textures.onDestroy();
-    textures = C_TriangleCanvasTextures{newSize};
-
-    IREntity::getComponent<C_SizeTriangles>(m_guiCanvas).size_ = newSize;
-
+    resizeGuiCanvas(newSize);
     IRE_LOG_INFO("GUI scale set to {}x (canvas {}x{})", scale, newSize.x, newSize.y);
 }
 
 int RenderManager::getGuiScale() const {
     return m_guiScale;
+}
+
+void RenderManager::setGuiCanvasFullResolution() {
+    m_guiFullResolution = true;
+    // The main framebuffer is sized gameResolution + buffer pixels; matching it
+    // makes one GUI trixel == one framebuffer pixel (1:1, no iso stretch).
+    const ivec2 fbSize = m_gameResolution + IRConstants::kSizeExtraPixelBuffer;
+    resizeGuiCanvas(fbSize);
+    IRE_LOG_INFO("GUI canvas set to full resolution ({}x{})", fbSize.x, fbSize.y);
 }
 
 void RenderManager::setHoveredTrixelVisible(bool visible) {


### PR DESCRIPTION
## Summary
- Add `IRRender::setGuiCanvasFullResolution()`: resize the GUI canvas from the coarse iso-canvas resolution (`mainCanvasSize / guiScale`) to the **native framebuffer pixel resolution** (1 GUI trixel == 1 framebuffer pixel). GUI text/widgets render small, crisp, and un-stretched instead of at the doubled-width iso scale.
- **Default off / opt-in.** A creation opts in and owns laying its GUI out for the finer coordinate space, so other creations (and the game repo) are unaffected. Factored the shared canvas-texture destroy/recreate into `resizeGuiCanvas` (reused by `setGuiScale`).
- No compositor/input changes: the trixel→framebuffer composite already UV-samples the GUI canvas, and the mouse→GUI-trixel hit mapping derives from the live canvas size.
- The **voxel editor opts in**. Before: panels/text were oversized and ran off the bottom edge. After (GUI canvas 1604×902): panels are compact, text is small and crisp, and the scene is clearly visible.

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/1774

When the parent PR merges, change this PR's base to `master`
(via the GitHub UI or `gh pr edit <N> --base master`).

## Test plan
- [x] Engine + `IRVoxelEditor` build clean.
- [x] `IRVoxelEditor --auto-screenshot` verified: GUI now renders at 1604×902, text small/crisp, all six panels fit on-screen (vs. the parent where they ate the bottom third and spilled).
- [x] Default path unchanged — `setGuiScale` still routes through `resizeGuiCanvas`; no creation except the editor calls the new API, so other creations are byte-identical.

## Notes for reviewer
- This is a GUI **resolution** change (no shader/voxel/silhouette change), verified by direct editor screenshot rather than a render-debug-loop ROI-crop pass. The visual delta is the dramatic GUI shrink described above.
- Editor **relayout polish** (panel placement to use the space, list-row `itemHeight` vs glyph height, body `fontSize`, the slight `CLICK A SWATCH` overflow) is the next stacked PR — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)