### PR TITLE
fleet: shared blocked_by parser — reconcile scout/ingest/claim + widen plain form (#1749)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -116,7 +116,7 @@ unset _fleet_claim_self
 # python3's ModuleNotFoundError propagating through a pipefail command substitution.
 # A missing module would otherwise fail OPEN in the --stackable-on guard below
 # (empty reason -> claim proceeds), so fail loud here instead.
-for _fleet_lib in fleet_branch_match.py fleet_stack_base.py; do
+for _fleet_lib in fleet_branch_match.py fleet_stack_base.py fleet_blocked_by.py; do
     if [[ ! -f "$FLEET_LIB_DIR/$_fleet_lib" ]]; then
         echo "fleet-claim: $_fleet_lib not found in FLEET_LIB_DIR=$FLEET_LIB_DIR" >&2
         echo "             Ensure fleet-claim's real script dir is scripts/fleet/ in the engine repo." >&2
@@ -504,84 +504,26 @@ check_blockers() {
     BODY_B64="$body_b64" SKIP_IDS="$skip_ids" REPO=$(repo_from_ns) ISSUE_NUM="$issue_num" \
     python3 <<'PYEOF'
 import os, re, subprocess, sys, base64
+sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
+# Shared blocker parser (#1749) — one routine for scout/ingest/claim so the
+# three can't disagree, and it catches the plain `Blocked by: #N` form the
+# bold-only copies skipped. parse_blocked_by handles canonical / inline-bold
+# (#1423) / plain / `Blocked on` header (#1326) + the rich no-blocker sentinel;
+# blocker_refs routes cross-repo `[owner/]Repo#N` qualifiers (#1522).
+from fleet_blocked_by import parse_blocked_by, blocker_refs
 
 issue_num = os.environ.get("ISSUE_NUM", "")
 body = base64.b64decode(os.environ["BODY_B64"]).decode("utf-8", errors="replace")
 skip_ids = set(os.environ.get("SKIP_IDS", "").split())
 repo = os.environ.get("REPO", "")
 
-# Parse the `**Blocked by:**` field. The line shape is markdown bold-key:
-#   **Blocked by:** #1234, #1235
-#   **Blocked by:** (none — explanatory text)
-# Accept either bare `**Blocked by:**` or list-bullet `- **Blocked by:**`.
-# Also handle inline-bold form: **Blocked by: #N (label)** mid-line where the
-# colon and value sit inside one bold span (#1423). The two patterns are
-# mutually exclusive: canonical has **Blocked by:** (bold closes at colon),
-# inline has **Blocked by: value** (space after colon, bold stays open).
-field_re = re.compile(r"^\s*-?\s*\*\*Blocked by:\*\*\s*(.+?)\s*$", re.IGNORECASE)
-inline_re = re.compile(r"\*\*Blocked by:\s+(.+?)\*\*", re.IGNORECASE)
-field_values = []
-for line in body.splitlines():
-    m = field_re.match(line)
-    if m:
-        field_values.append(m.group(1).strip())
-        continue
-    for m2 in inline_re.finditer(line):
-        val = m2.group(1).strip()
-        if val:
-            field_values.append(val)
-# Union every canonical line (multi-line + multi-ref); drop explicit (none)
-# declarations. If every **Blocked by:** line is (none), the task is unblocked.
-real = [v for v in field_values if not v.lower().startswith("(none")]
-if field_values and not real:
-    sys.exit(0)
-field_value = ", ".join(real) if real else None
-
-# Fall back to free-form header prose like `## Blocked on #1300` / `Blocked
-# on PR-x` when the canonical field is absent, so a header-only dependency
-# still gates the claim — #1301 slipped through as claimable because its
-# blocker lived in a `Blocked on #1300` header (#1326). Mirrors
-# fleet-state-scout._parse_blocked_by; #1296 covered #N refs INSIDE the
-# field, this covers the header-prose form. Only honor prose that names a #N
-# or PR so an incidental "blocked on the redesign" sentence isn't a gate.
-if field_value is None:
-    blocked_on_re = re.compile(
-        r"^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$",
-        re.IGNORECASE,
-    )
-    for line in body.splitlines():
-        m = blocked_on_re.match(line)
-        if m:
-            cand = m.group(1).strip().strip("*").strip()
-            if cand and ("#" in cand or re.search(r"\bPR\b", cand, re.IGNORECASE)):
-                field_value = cand
-                break
-
-if field_value is None:
+# `(none)` / absent / sentinel-only → no gate.
+field_value = parse_blocked_by(body)
+if not field_value:
     sys.exit(0)
 
-# `(none)` with optional parenthetical commentary means "no real blocker".
-# Treat anything starting with `(none` as a no-op.
-if field_value.lower().startswith("(none"):
-    sys.exit(0)
-
-# Extract referenced issue numbers and PR URLs. A `#N` may carry an optional
-# `[owner/]Repo#N` qualifier — route its live state check to the *referenced*
-# repo so a cross-repo dependency resolves against the right repo, not the
-# issue's own (#1522). Bare / unrecognized refs default to this issue's repo.
-_REF_NAME_TO_SLUG = {"irredenengine": "jakildev/IrredenEngine",
-                     "irreden": "jakildev/irreden"}
-
-
-def _ref_repo(name):
-    if name:
-        return _REF_NAME_TO_SLUG.get(name.lower(), repo)
-    return repo
-
-
-qual_ref_re = re.compile(r"(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)")
-issue_refs = [(_ref_repo(m.group(1)), m.group(2))
-              for m in qual_ref_re.finditer(field_value)]
+# Referenced issue numbers (qualifier-routed to the referenced repo) + PR URLs.
+issue_refs = blocker_refs(body, repo)
 pr_urls = re.findall(r"https://github\.com/[^\s,)]+/pull/\d+", field_value)
 
 failed = []
@@ -1011,27 +953,16 @@ cmd_find_stackable_blockers() {
 import base64, json, os, re, subprocess, sys
 sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
 from fleet_branch_match import branch_matches_issue
+# Shared blocker parser (#1749) — same value the scout / ingest /
+# check_blockers see, including the plain `Blocked by: #N` form.
+from fleet_blocked_by import parse_blocked_by
 
 body = base64.b64decode(os.environ["BODY_B64"]).decode("utf-8", errors="replace")
 repo = os.environ.get("REPO", "")
 
-field_re = re.compile(r"^\s*-?\s*\*\*Blocked by:\*\*\s*(.+?)\s*$", re.IGNORECASE)
-inline_re = re.compile(r"\*\*Blocked by:\s+(.+?)\*\*", re.IGNORECASE)
-field_values = []
-for line in body.splitlines():
-    m = field_re.match(line)
-    if m:
-        field_values.append(m.group(1).strip())
-        continue
-    for m2 in inline_re.finditer(line):
-        val = m2.group(1).strip()
-        if val:
-            field_values.append(val)
-# Union every canonical line (multi-line + multi-ref); drop (none).
-real = [v for v in field_values if not v.lower().startswith("(none")]
-if not real:
+value = parse_blocked_by(body)
+if not value:
     sys.exit(0)
-value = ", ".join(real)
 
 issue_refs = re.findall(r"#(\d+)", value)
 pr_urls = re.findall(r"https://github\.com/[^\s,)]+/pull/\d+", value)

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -191,8 +191,15 @@ if ! command -v gh >/dev/null 2>&1; then
     exit 1
 fi
 
-stamping_out=$(FLEET_PROJ_FILE="$PROJECTION_FILE" python3 - << 'STAMP_PY' 2>>"$LOG_FILE"
+stamping_out=$(FLEET_PROJ_FILE="$PROJECTION_FILE" INGEST_SELF="${BASH_SOURCE[0]}" python3 - << 'STAMP_PY' 2>>"$LOG_FILE"
 import json, os, re, subprocess, sys
+
+# Shared blocker parser (#1749) — one routine for scout/ingest/claim so the
+# three can't disagree, and it catches the plain `Blocked by: #N` form the
+# bold-only copies skipped. realpath resolves the ~/bin symlink back to the
+# scripts/fleet dir the module ships in (same pattern as the SCOPE_PY block).
+sys.path.insert(0, os.path.dirname(os.path.realpath(os.environ['INGEST_SELF'])))
+from fleet_blocked_by import blocker_refs, has_blocked_by_field
 
 REPO_SLUGS = {"engine": "jakildev/IrredenEngine", "game": "jakildev/irreden"}
 
@@ -205,78 +212,16 @@ except Exception:
     sys.exit(0)
 
 # Body-field parsers mirror fleet-state-scout._parse_issue_field so we
-# label issues by the same fields the scout reads back out.
+# label issues by the same fields the scout reads back out. (The `Blocked by:`
+# regexes + cross-repo ref routing now live in fleet_blocked_by.py — imported
+# above — so ingest, the scout, and fleet-claim share one parser; #1749.)
 MODEL_RE = re.compile(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
-BLOCKED_RE = re.compile(r'\*\*(?:Suggested\s+)?Blocked by:\*\*\s*(.+?)(?:\n|$)', re.IGNORECASE)
-# Inline-bold form `**Blocked by: #N (label)**` (#1423): colon + value inside
-# one bold span. Mutually exclusive with BLOCKED_RE (canonical bold closes at
-# the colon), so scanning both over the whole body never double-counts a line.
-BLOCKED_INLINE_RE = re.compile(r'\*\*(?:Suggested\s+)?Blocked by:\s+(.+?)\*\*', re.IGNORECASE)
-# Free-form header prose like `## Blocked on #1300` / `Blocked on PR-x` is an
-# alternate dependency declaration the scout's _parse_blocked_by also reads, so
-# don't warn "treat as unblocked" for an issue whose blocker lives only in a
-# header (#1326). Only count prose that names a #N or PR reference.
-BLOCKED_ON_RE = re.compile(r'(?im)^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$')
-# A blocker ref may carry an optional `[owner/]Repo#N` qualifier pointing at
-# another repo (game #125 → `jakildev/IrredenEngine#1476`). group(1) is the
-# repo name (None/empty for a bare same-repo ref); group(2) is the number.
-# Kept consistent with fleet-state-scout._parse_blocker_refs and fleet-claim's
-# check_blockers. (#1522)
-REF_RE = re.compile(r'(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)')
-# Repo-name qualifier (case-insensitive, owner stripped) → GitHub slug.
-_REF_NAME_TO_SLUG = {'irredenengine': 'jakildev/IrredenEngine',
-                     'irreden': 'jakildev/irreden'}
 # Planning-gate escape hatch (#1456): an issue whose title or body names an
 # explicit "investigation spike" is worker-investigates-first by design and
 # queues without a plan file (architect-protocol.md §"Carve-offs are unplanned
 # tickets" is where the phrase is defined).
 SPIKE_RE = re.compile(r'investigation\s+spike', re.IGNORECASE)
 PLANS_DIR = os.path.expanduser('~/.fleet/plans')
-
-
-def _ref_slug(name, default_repo):
-    if name:
-        return _REF_NAME_TO_SLUG.get(name.lower(), default_repo)
-    return default_repo
-
-
-def _qual_refs(text, default_repo):
-    """(slug, number) pairs for every #N in text, routing each cross-repo ref
-    to the slug named by its `[owner/]Repo#N` qualifier (#1522)."""
-    return [(_ref_slug(m.group(1), default_repo), m.group(2))
-            for m in REF_RE.finditer(text or '')]
-
-
-def _has_header_blocker(text):
-    for m in BLOCKED_ON_RE.finditer(text):
-        cand = m.group(1).strip().strip('*').strip()
-        if cand and ('#' in cand or re.search(r'\bPR\b', cand, re.IGNORECASE)):
-            return True
-    return False
-
-
-def _blocker_refs(body, default_repo):
-    """(slug, number) pairs for every `#N` predecessor — from canonical
-    `**Blocked by:** #N` lines, the inline-bold `**Blocked by: #N**` form, and
-    `Blocked on` header prose. Each ref is routed to the repo named by an
-    optional `[owner/]Repo#N` qualifier, defaulting to default_repo (the
-    child's own repo). Mirrors fleet-state-scout._parse_blocked_by so the gate
-    reads the same refs the scout and fleet-claim do. `(none)` values
-    contribute nothing."""
-    vals = [m.group(1) for m in BLOCKED_RE.finditer(body)]
-    vals += BLOCKED_INLINE_RE.findall(body)
-    real = [v.strip() for v in vals if not v.strip().lower().startswith('(none')]
-    refs = []
-    for v in real:
-        refs.extend(_qual_refs(v, default_repo))
-    if refs:
-        return refs
-    # No canonical/inline #N refs → fall back to a `Blocked on …` header.
-    for m in BLOCKED_ON_RE.finditer(body):
-        cand = m.group(1).strip().strip('*').strip()
-        if cand and ('#' in cand or re.search(r'\bPR\b', cand, re.IGNORECASE)):
-            refs.extend(_qual_refs(cand, default_repo))
-    return refs
 
 
 def _blocker_open(repo, ref, cache):
@@ -421,7 +366,7 @@ for issue in pending:
     # yet" signal that the unblock pass below removes once the last blocker
     # closes. The live re-check is authoritative — it's the only blocker gate
     # when ingest runs against a hand-built projection (tests, manual run).
-    open_blockers = [(slug, ref) for slug, ref in _blocker_refs(body, repo)
+    open_blockers = [(slug, ref) for slug, ref in blocker_refs(body, repo)
                      if _blocker_open(slug, ref, blocker_cache)]
 
     # Parse model from body. Classes are literal — fable | opus | sonnet —
@@ -440,7 +385,7 @@ for issue in pending:
         model_label = 'fleet:opus'
         print(f'WARN issue {repo}#{n}: **Model:** field missing or unrecognized; defaulting to fleet:opus', file=sys.stderr)
 
-    if not BLOCKED_RE.search(body) and not _has_header_blocker(body) and not BLOCKED_INLINE_RE.search(body):
+    if not has_blocked_by_field(body):
         print(f'WARN issue {repo}#{n}: **Blocked by:** field missing; scout will treat as unblocked', file=sys.stderr)
 
     add_labels = ['fleet:queued']
@@ -495,7 +440,7 @@ for issue in data.get('unblock_issues', []):
     if 'fleet:blocked' not in labels:
         continue
     body = view.get('body', '') or ''
-    open_blockers = [(slug, ref) for slug, ref in _blocker_refs(body, repo)
+    open_blockers = [(slug, ref) for slug, ref in blocker_refs(body, repo)
                      if _blocker_open(slug, ref, blocker_cache)]
     if open_blockers:
         unblock_still += 1

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -37,6 +37,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from fleet_branch_match import branch_matches_issue, PARKED_PR_LABELS
 from fleet_stack_base import unsafe_base_reason
+from fleet_blocked_by import parse_blocked_by, is_no_blocker_value
 
 ENGINE = Path.home() / "src" / "IrredenEngine"
 GAME = ENGINE / "creations" / "game"
@@ -331,75 +332,16 @@ def _parse_epic_checklist(body):
     ]
 
 
-# A dependency may be declared two ways: the canonical `**Blocked by:** #N`
-# field, or free-form header prose like `## Blocked on #1300` / `Blocked on
-# PR-x`. `_parse_blocked_by` prefers the field and falls back to the header
-# form so a header-only dependency still surfaces as blocked — #1301 was
-# mis-listed as claimable (owner=free, blocked_by=(none)) because its blocker
-# lived in a `Blocked on #1300` header the field parser never read (#1326).
-# Complements #1296, which handled #N refs that already live inside the field.
-_BLOCKED_ON_RE = re.compile(
-    r'^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$',
-    re.IGNORECASE | re.MULTILINE,
-)
-
-
-def _is_no_blocker_value(value):
-    """True when a **Blocked by:** value declares NO blocker.
-
-    The canonical form is `(none)`, but agents also hand-write a bare `none`,
-    `n/a`, `tbd`, a lone dash, or `(none) — prose`, all of which mean "nothing
-    blocks this". The old filter recognized only the parenthesized `(none)`
-    form, so a bare `none — first unblocked.` fell through to the prose-blocker
-    path and stranded the issue as permanently blocked — freezing the whole
-    downstream chain out of the queue (game #138 → #143). A value that names a
-    `#N` or describes a real blocker in prose ("the auth redesign") is NOT a
-    sentinel and must still gate.
-    """
-    # A concrete `#N` ref anywhere in the value means there IS a blocker —
-    # never let a leading "none" word swallow a real reference.
-    if re.search(r"#\d+", value):
-        return False
-    head = value.strip().lower().lstrip("(").strip()
-    if not head or head[0] in "-–—.":
-        return True
-    token = re.split(r"[\s.,;:)\-–—]", head, maxsplit=1)[0]
-    return token in {"none", "n/a", "na", "tbd"}
-
-
-def _parse_blocked_by(body):
-    # Union every standalone **Blocked by:** line (multi-line + multi-ref) so a
-    # child blocked by several refs surfaces all of them — check_blockers gates
-    # on the union and find-stackable-blockers live-resolves them (#1296). Falls
-    # back to a `Blocked on` header (#1326) only when no canonical line exists.
-    # Kept consistent with fleet-claim's check_blockers parser.
-    vals = re.findall(r'^\s*-?\s*\*\*Blocked by:\*\*\s*(.+?)\s*$',
-                      body or "", re.IGNORECASE | re.MULTILINE)
-    # Also handle inline-bold form: **Blocked by: #N (label)** mid-line where
-    # the colon and value are inside one bold span (#1423). The two patterns are
-    # mutually exclusive: canonical has **Blocked by:** (bold closes at colon),
-    # inline has **Blocked by: value** (space after colon, bold stays open).
-    inline_vals = re.findall(r'\*\*Blocked by:\s+(.+?)\*\*',
-                             body or "", re.IGNORECASE)
-    # No per-line `continue` guard needed (unlike fleet-claim's check_blockers
-    # loop): re.findall over the whole body is safe because canonical and inline
-    # are mutually exclusive — canonical bold closes at ":**", inline bold stays
-    # open past the value — so a single line cannot match both patterns.
-    all_vals = vals + inline_vals
-    real = [v.strip() for v in all_vals if not _is_no_blocker_value(v)]
-    if real:
-        return ", ".join(real)
-    if all_vals:
-        # Every matched form is a no-blocker sentinel → genuinely unblocked.
-        return ""
-    for m in _BLOCKED_ON_RE.finditer(body or ""):
-        cand = m.group(1).strip().strip("*").strip()
-        # Only treat header prose as a blocker when it actually names a #N
-        # issue or a PR; an incidental "Blocked on the redesign" sentence
-        # must not gate the task forever.
-        if cand and ("#" in cand or re.search(r'\bPR\b', cand, re.IGNORECASE)):
-            return cand
-    return ""
+# Blocker-declaration parsing — canonical `**Blocked by:** #N`, inline-bold
+# `**Blocked by: #N**` (#1423), the plain mid-line `Blocked by: #N` form
+# (#1749), the no-blocker sentinels, and the `Blocked on …` header fallback
+# (#1326) — is shared with fleet-queue-ingest and fleet-claim via
+# fleet_blocked_by.py so the three can't drift (the #1749 reconciliation;
+# the scout previously had the richest sentinel logic but ingest/claim lagged,
+# and all three missed the plain form). These aliases preserve the private
+# names the scout's call sites and unit tests reference.
+_parse_blocked_by = parse_blocked_by
+_is_no_blocker_value = is_no_blocker_value
 
 
 def fetch_task_queue(repo_slug):

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -893,8 +893,8 @@ def _blocker_pr_files(repo_key, pr_number):
 # A blocker ref may carry an optional `[owner/]Repo#N` qualifier pointing at
 # another repo (game #125 → `jakildev/IrredenEngine#1476`). group(1) is the
 # repo name (None / empty for a bare same-repo `#N`); group(2) is the number.
-# Kept consistent with fleet-claim's check_blockers and
-# fleet-queue-ingest._blocker_refs parsers. (#1522)
+# Kept consistent with fleet_blocked_by.blocker_refs; routing differs
+# (key vs slug) so this helper stays separate. (#1522)
 _BLOCKER_REF_RE = re.compile(r"(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)")
 _REPO_SLUG_MAP = {
     "engine": "jakildev/IrredenEngine",

--- a/scripts/fleet/fleet_blocked_by.py
+++ b/scripts/fleet/fleet_blocked_by.py
@@ -1,0 +1,174 @@
+"""Shared `Blocked by:` parsing for the fleet coordination scripts.
+
+`fleet-state-scout` (pure Python), `fleet-queue-ingest` (bash + inline
+`python3`), and `fleet-claim` (bash + inline `python3`) all answer the same
+question — "which predecessors does this issue declare as blockers, and is it
+genuinely unblocked?" — but each carried its own private copy of the regexes
+and sentinel logic. Those copies drifted, which is the #1749 incident:
+
+  * The scout had a rich no-blocker sentinel test (`is_no_blocker_value`:
+    bare `none`, `n/a`, `tbd`, a lone dash, `#N`-wins), while ingest and
+    claim only matched the parenthesized `(none)` form. A bare
+    `none — first unblocked.` gated in claim/ingest but not in the scout
+    (game #138 → #143 was this class of bug, fixed only in the scout).
+
+  * All three recognized only the **bold** field forms — canonical
+    `**Blocked by:** #N` and inline-bold `**Blocked by: #N**`. A plain,
+    non-bold, mid-line `Blocked by: #N` declaration — the degraded form
+    #174's children self-declared their deps in
+    (`Part of epic #174 (Phase D). [opus] Blocked by: #175, #176, #177.`) —
+    was skipped by every parser, so blocked children surfaced as claimable.
+
+This module is the single source of truth. The three scripts import it so they
+can never disagree again, and it adds the plain-form recognition that closes
+the #174 hole. The `Blocked on …` header form (#1326) and the cross-repo
+`[owner/]Repo#N` qualifier routing (#1522) are folded in here too.
+"""
+import re
+
+# --- recognized declaration forms -----------------------------------------
+# Precedence: the three field forms (canonical, inline-bold, plain) are
+# unioned — a body may carry several and a child blocked by multiple refs must
+# surface all of them. The `Blocked on` header is a lower-precedence fallback,
+# consulted only when NO field form appears at all (an explicit `**Blocked
+# by:** (none)` is authoritative over a stray header).
+
+# 1. canonical `**Blocked by:** #N` / `- **Blocked by:** #N` standalone line.
+#    Bold closes at the colon. Optional `Suggested ` prefix (file-epic ships
+#    the suggested-field template before a human approves it).
+_CANONICAL_RE = re.compile(
+    r'^\s*-?\s*\*\*(?:Suggested\s+)?Blocked by:\*\*\s*(.+?)\s*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+# 2. inline-bold `**Blocked by: #N (label)**` span (#1423): colon + value
+#    inside one bold span (space after the colon, bold stays open past the
+#    value). Mutually exclusive with the canonical form — canonical bold
+#    closes at `:**`, inline bold stays open — so scanning both over the whole
+#    body never double-counts a line.
+_INLINE_RE = re.compile(
+    r'\*\*(?:Suggested\s+)?Blocked by:\s+(.+?)\*\*',
+    re.IGNORECASE,
+)
+# 3. NEW (#1749): plain `Blocked by:` (bold optional, anywhere on a line)
+#    directly followed by a `#N` ref-list. `(?<!\*)` excludes the two bold
+#    forms above (so a canonical/inline line never also matches here); `\b`
+#    excludes "unblocked by:"; the `#\d+` anchor — a full issue number, not a
+#    lone `#` — is the false-positive guard: the value must START with a real
+#    ref, so "not blocked by: anything yet" never matches. `[^\n]*` absorbs the
+#    rest of the line, but ref extraction keeps only the `#N` tokens, so it
+#    cannot over-capture trailing prose into a blocker.
+_PLAIN_RE = re.compile(
+    r'(?<!\*)\bBlocked by:\s*(#\d+[^\n]*)',
+    re.IGNORECASE,
+)
+# 4. free-form header prose `## Blocked on #1300` / `Blocked on PR-x` (#1326):
+#    lowest-precedence fallback, honored only when it names a #N or PR so an
+#    incidental "Blocked on the redesign" sentence cannot gate a task forever.
+_BLOCKED_ON_RE = re.compile(
+    r'^\s{0,3}#{0,6}\s*\**\s*Blocked\s+on\b[:\s]*(.+?)\s*\**\s*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Cross-repo `[owner/]Repo#N` qualifier (#1522): group(1) is the repo name
+# (None/empty for a bare same-repo `#N`), group(2) is the number.
+_REF_RE = re.compile(r'(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)')
+# Repo-name qualifier (case-insensitive, owner stripped) → GitHub slug.
+_REF_NAME_TO_SLUG = {'irredenengine': 'jakildev/IrredenEngine',
+                     'irreden': 'jakildev/irreden'}
+
+
+def is_no_blocker_value(value):
+    """True when a `Blocked by:` value declares NO blocker.
+
+    The canonical form is `(none)`, but agents also hand-write a bare `none`,
+    `n/a`, `tbd`, a lone dash, or `(none) — prose`, all of which mean "nothing
+    blocks this". A value that names a `#N` or describes a real blocker in
+    prose ("the auth redesign") is NOT a sentinel and must still gate. Ported
+    verbatim from the scout's historically-richest version so the other two
+    consumers inherit it.
+    """
+    value = value or ""
+    # A concrete `#N` ref anywhere means there IS a blocker — never let a
+    # leading "none" word swallow a real reference.
+    if re.search(r"#\d+", value):
+        return False
+    head = value.strip().lower().lstrip("(").strip()
+    if not head or head[0] in "-–—.":
+        return True
+    token = re.split(r"[\s.,;:)\-–—]", head, maxsplit=1)[0]
+    return token in {"none", "n/a", "na", "tbd"}
+
+
+def _field_values(body):
+    """Every value declared by a field form (canonical, inline, plain), in no
+    particular order. The three forms are mutually non-overlapping by
+    construction (the plain form's `(?<!\\*)` lookbehind excludes both bold
+    forms), so a single line contributes at most one value."""
+    body = body or ""
+    return (_CANONICAL_RE.findall(body)
+            + _INLINE_RE.findall(body)
+            + _PLAIN_RE.findall(body))
+
+
+def _has_header_blocker(body):
+    """True when a `Blocked on …` header names a real #N / PR reference."""
+    for m in _BLOCKED_ON_RE.finditer(body or ""):
+        cand = m.group(1).strip().strip("*").strip()
+        if cand and ("#" in cand or re.search(r"\bPR\b", cand, re.IGNORECASE)):
+            return True
+    return False
+
+
+def has_blocked_by_field(body):
+    """True when the body carries ANY recognized blocker declaration — a field
+    form (canonical / inline / plain, sentinel or not) or a `Blocked on` header
+    naming a #N/PR. Drives ingest's "Blocked by field missing" WARN so the
+    presence check is sourced from this module's regexes and can't drift from
+    the parser. A degraded plain `Blocked by: #N` now counts as present, so the
+    WARN no longer false-fires on the #174-style children."""
+    body = body or ""
+    if (_CANONICAL_RE.search(body)
+            or _INLINE_RE.search(body)
+            or _PLAIN_RE.search(body)):
+        return True
+    return _has_header_blocker(body)
+
+
+def parse_blocked_by(body):
+    """Canonical comma-joined blocker value for `body`, or "" when genuinely
+    unblocked.
+
+    Unions every non-sentinel field-form value (canonical, inline, plain); if
+    every field form present is a no-blocker sentinel the task is unblocked
+    (an explicit `(none)` field wins over a stray header). Only when NO field
+    form appears at all does it fall back to a `Blocked on` header naming a
+    #N/PR. Downstream callers extract `#N` refs from the returned value.
+    """
+    body = body or ""
+    all_vals = _field_values(body)
+    real = [v.strip() for v in all_vals if not is_no_blocker_value(v)]
+    if real:
+        return ", ".join(real)
+    if all_vals:
+        return ""
+    for m in _BLOCKED_ON_RE.finditer(body):
+        cand = m.group(1).strip().strip("*").strip()
+        if cand and ("#" in cand or re.search(r"\bPR\b", cand, re.IGNORECASE)):
+            return cand
+    return ""
+
+
+def _ref_slug(name, default_repo):
+    if name:
+        return _REF_NAME_TO_SLUG.get(name.lower(), default_repo)
+    return default_repo
+
+
+def blocker_refs(body, default_repo):
+    """(slug, number) for every blocker `#N` declared in `body`, routing each
+    cross-repo `[owner/]Repo#N` qualifier to its GitHub slug (#1522) and
+    defaulting bare refs to `default_repo` (the issue's own repo). A
+    sentinel-only or unblocked body contributes nothing."""
+    value = parse_blocked_by(body)
+    return [(_ref_slug(m.group(1), default_repo), m.group(2))
+            for m in _REF_RE.finditer(value)]

--- a/scripts/fleet/tests/test_blocked_by.py
+++ b/scripts/fleet/tests/test_blocked_by.py
@@ -1,0 +1,184 @@
+"""Corpus + unit tests for the shared blocker parser fleet_blocked_by.py.
+
+This module is the single source of truth imported by fleet-state-scout,
+fleet-queue-ingest, and fleet-claim (#1749). Cross-parser agreement is
+structural once all three import it; this corpus documents and locks the
+contract, with one case per declaration form:
+
+  - canonical standalone `**Blocked by:** #N`
+  - inline-bold `**Blocked by: #N (label)**` (#1423)
+  - PLAIN mid-line `Blocked by: #N` (the #174-children mechanism, #1749)
+  - multi-line + multi-ref union
+  - `Blocked on #N` header fallback (#1326)
+  - no-blocker sentinels: `(none)`, bare `none`, `n/a`, `tbd`, lone dash
+  - cross-repo `[owner/]Repo#N` qualifier routing (#1522)
+  - false-positive guard: "not blocked by anything" → unblocked
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import fleet_blocked_by as fbb
+
+
+class IsNoBlockerValue(unittest.TestCase):
+    def test_sentinels(self):
+        for v in ("(none)", "none", "None", "  none  ", "(none) — first unblocked.",
+                  "none — first unblocked.", "n/a", "N/A", "na", "tbd", "TBD",
+                  "—", "-", "–", ".", ""):
+            self.assertTrue(fbb.is_no_blocker_value(v), f"{v!r} should be a sentinel")
+
+    def test_real_blockers(self):
+        for v in ("#138", "#138, #139", "#138 (migration)", "the auth redesign",
+                  "none, #138", "nonexistent #42 must land first"):
+            self.assertFalse(fbb.is_no_blocker_value(v), f"{v!r} should NOT be a sentinel")
+
+
+class ParseBlockedBy(unittest.TestCase):
+    def _body(self, line):
+        return ("**Model:** opus\n**Part of epic:** #137\n"
+                f"**Blocked by:** {line}\n\n## Scope\nstuff\n")
+
+    # --- canonical standalone form ---
+    def test_canonical_single(self):
+        self.assertEqual(fbb.parse_blocked_by(self._body("#138")), "#138")
+
+    def test_canonical_multi_ref(self):
+        self.assertEqual(fbb.parse_blocked_by(self._body("#138, #139")), "#138, #139")
+
+    def test_canonical_bullet_prefix(self):
+        self.assertEqual(fbb.parse_blocked_by("- **Blocked by:** #50\n"), "#50")
+
+    def test_suggested_prefix(self):
+        self.assertEqual(fbb.parse_blocked_by("**Suggested Blocked by:** #51\n"), "#51")
+
+    # --- inline-bold form (#1423) ---
+    def test_inline_bold(self):
+        body = "**Part of epic:** #104 · **Blocked by: #138 (Phase 2)** trailing\n"
+        self.assertIn("#138", fbb.parse_blocked_by(body))
+
+    # --- NEW plain form (#1749 / #174 children) ---
+    def test_plain_single_midline(self):
+        body = "Part of epic #174 (Phase E). [sonnet] Blocked by: #178.\n"
+        self.assertEqual(fbb.parse_blocked_by(body), "#178.")
+
+    def test_plain_multi_ref_midline(self):
+        # The verified #178 body shape.
+        body = "Part of epic #174 (Phase D). [opus] Blocked by: #175, #176, #177.\n"
+        self.assertEqual(
+            sorted(fbb.blocker_refs(body, "jakildev/IrredenEngine")),
+            [("jakildev/IrredenEngine", "175"),
+             ("jakildev/IrredenEngine", "176"),
+             ("jakildev/IrredenEngine", "177")],
+        )
+
+    def test_plain_does_not_match_bold(self):
+        # A canonical line must be captured by the canonical form, not
+        # double-counted by the plain form's `(?<!\*)` lookbehind.
+        self.assertEqual(fbb.parse_blocked_by("**Blocked by:** #5\n"), "#5")
+
+    # --- multi-line union ---
+    def test_multiline_union(self):
+        body = "**Blocked by:** #100\n**Blocked by:** #101\n"
+        self.assertEqual(
+            sorted(fbb.blocker_refs(body, "jakildev/IrredenEngine")),
+            [("jakildev/IrredenEngine", "100"),
+             ("jakildev/IrredenEngine", "101")],
+        )
+
+    # --- header fallback (#1326) ---
+    def test_header_fallback(self):
+        self.assertEqual(fbb.parse_blocked_by("## Blocked on #1300\n"), "#1300")
+
+    def test_header_only_when_no_field(self):
+        # An explicit `(none)` field is authoritative over a stray header.
+        body = "**Blocked by:** (none — independent)\n\n## Blocked on #101\n"
+        self.assertEqual(fbb.parse_blocked_by(body), "")
+
+    def test_canonical_wins_over_header(self):
+        body = "**Blocked by:** #50\n\n## Blocked on #99\n"
+        self.assertEqual(fbb.parse_blocked_by(body), "#50")
+
+    def test_header_refless_not_a_blocker(self):
+        self.assertEqual(fbb.parse_blocked_by("## Blocked on the redesign\n"), "")
+
+    # --- sentinels ---
+    def test_sentinel_variants_unblocked(self):
+        for line in ("none — first unblocked.", "none", "(none)",
+                     "(none) — first unblocked.", "n/a", "tbd", "—"):
+            self.assertEqual(fbb.parse_blocked_by(self._body(line)), "",
+                             f"{line!r} should parse as unblocked")
+
+    def test_mixed_sentinel_and_ref_keeps_ref(self):
+        self.assertEqual(fbb.parse_blocked_by(self._body("none, #138")), "none, #138")
+
+    def test_prose_blocker_still_gates(self):
+        self.assertEqual(fbb.parse_blocked_by(self._body("the auth redesign")),
+                         "the auth redesign")
+
+    # --- false-positive guard ---
+    def test_false_positive_guard(self):
+        for body in ("This task is not blocked by anything yet.\n",
+                     "Was blocked by: nothing in particular.\n",
+                     "unblocked by: #5 is a non-field substring\n"):
+            self.assertEqual(fbb.parse_blocked_by(body), "",
+                             f"{body!r} must not be read as a blocker")
+
+    def test_empty_body(self):
+        self.assertEqual(fbb.parse_blocked_by(""), "")
+        self.assertEqual(fbb.parse_blocked_by(None), "")
+
+
+class BlockerRefs(unittest.TestCase):
+    def test_bare_ref_defaults_to_repo(self):
+        self.assertEqual(
+            fbb.blocker_refs("**Blocked by:** #1214\n", "jakildev/IrredenEngine"),
+            [("jakildev/IrredenEngine", "1214")],
+        )
+
+    def test_cross_repo_owner_qualified(self):
+        self.assertEqual(
+            fbb.blocker_refs("**Blocked by:** jakildev/irreden#125\n", "jakildev/IrredenEngine"),
+            [("jakildev/irreden", "125")],
+        )
+
+    def test_cross_repo_bare_qualifier(self):
+        self.assertEqual(
+            fbb.blocker_refs("**Blocked by:** irreden#126\n", "jakildev/IrredenEngine"),
+            [("jakildev/irreden", "126")],
+        )
+
+    def test_unrecognized_qualifier_defaults(self):
+        self.assertEqual(
+            fbb.blocker_refs("**Blocked by:** foo#7\n", "jakildev/IrredenEngine"),
+            [("jakildev/IrredenEngine", "7")],
+        )
+
+    def test_plain_form_refs(self):
+        # The #179 replay: plain single ref surfaces.
+        self.assertEqual(
+            fbb.blocker_refs("Part of epic #174. [sonnet] Blocked by: #178.\n",
+                             "jakildev/IrredenEngine"),
+            [("jakildev/IrredenEngine", "178")],
+        )
+
+    def test_sentinel_no_refs(self):
+        self.assertEqual(fbb.blocker_refs("**Blocked by:** (none)\n", "jakildev/IrredenEngine"), [])
+
+
+class HasBlockedByField(unittest.TestCase):
+    def test_present_forms(self):
+        for body in ("**Blocked by:** #5\n", "**Blocked by:** (none)\n",
+                     "**Blocked by: #5 (x)**\n", "Blocked by: #5\n",
+                     "## Blocked on #5\n"):
+            self.assertTrue(fbb.has_blocked_by_field(body), f"{body!r} should count as present")
+
+    def test_absent(self):
+        for body in ("", "## Scope\nIndependent task.\n",
+                     "not blocked by anything yet\n", "## Blocked on the redesign\n"):
+            self.assertFalse(fbb.has_blocked_by_field(body), f"{body!r} should count as absent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fleet/tests/test_fleet_claim_blockers.sh
+++ b/scripts/fleet/tests/test_fleet_claim_blockers.sh
@@ -212,6 +212,22 @@ case "$1 $2" in
                 # the referenced repo → claim fails.
                 printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"**Blocked by:** irreden#126\n"}'
                 ;;
+            2019)
+                # #1749: PLAIN mid-line `Blocked by: #N` (the #174-children form
+                # every bold-only parser skipped), #101 OPEN → claim fails. Also
+                # guards that the epic ref #174 in the prose is NOT mistaken for
+                # a blocker — only the `Blocked by:` ref-list is captured.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"Part of epic #174 (Phase D). [opus] Blocked by: #101.\n"}'
+                ;;
+            2020)
+                # #1749: plain form, referenced issue #100 CLOSED → pass.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"Part of epic #174. Blocked by: #100.\n"}'
+                ;;
+            2021)
+                # #1749 false-positive guard: prose "not blocked by anything"
+                # has no `#N` after the colon → not a blocker → claim succeeds.
+                printf '%s' '{"state":"OPEN","labels":[{"name":"fleet:queued"}],"body":"## Scope\n\nThis task is not blocked by anything yet.\n"}'
+                ;;
             *)
                 printf '%s' '{"state":"OPEN","labels":[],"body":""}'
                 ;;
@@ -380,6 +396,26 @@ release_quiet 2017
 echo "T18: cross-repo 'irreden#126' OPEN in game → claim fails"
 actual=0; "$FLEET_CLAIM" claim 2018 test-agent 2>/dev/null || actual=$?
 assert_exit "$actual" 1 "cross-repo game#126 OPEN → exit 1"
+
+# --- T19: plain mid-line `Blocked by: #N` — #101 OPEN → fail (#1749) ---------
+# The #174-children mechanism: a non-bold `Blocked by: #N` declaration that
+# every bold-only parser skipped, so the blocked child surfaced as claimable.
+# The shared parser now gates it. The leading epic ref #174 must NOT gate.
+echo "T19: plain 'Blocked by: #101' (epic #174 prose) — #101 OPEN → claim fails"
+actual=0; "$FLEET_CLAIM" claim 2019 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "plain-form #101 OPEN → exit 1 (epic #174 not mistaken for blocker)"
+
+# --- T20: plain form — referenced issue CLOSED → pass (#1749) ----------------
+echo "T20: plain 'Blocked by: #100' — #100 CLOSED → claim succeeds"
+actual=0; "$FLEET_CLAIM" claim 2020 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "plain-form #100 CLOSED → exit 0"
+release_quiet 2020
+
+# --- T21: false-positive guard — "not blocked by anything" → pass (#1749) ----
+echo "T21: prose 'not blocked by anything yet' (no #N) → claim succeeds"
+actual=0; "$FLEET_CLAIM" claim 2021 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "ref-less 'blocked by' prose bypasses gate → exit 0"
+release_quiet 2021
 
 echo ""
 echo "PASS: $PASS  FAIL: $FAIL"

--- a/scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_blocked_by.sh
@@ -40,6 +40,9 @@ PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
 # Cross-repo (#1522): #735 = engine task blocked by a CLOSED game ref
 # (jakildev/irreden#777) → routed to game, not blocked; #736 = engine task
 # blocked by an OPEN game ref (jakildev/irreden#778) → blocked.
+# Plain form (#1749): #737 = engine task whose ONLY dep is a degraded plain
+# mid-line `Blocked by: #719` (the #174-children form) → blocked. Before the
+# shared parser, the bold-only ingest copy missed it and it queued unmarked.
 # Remove path: #733 = queued+fleet:blocked, blocker #717 now CLOSED (unblock);
 #              #734 = queued+fleet:blocked, blocker #719 still OPEN (stay).
 cat > "$PROJ" <<'JSON'
@@ -48,7 +51,8 @@ cat > "$PROJ" <<'JSON'
   {"number":731,"repo":"engine"},
   {"number":732,"repo":"engine"},
   {"number":735,"repo":"engine"},
-  {"number":736,"repo":"engine"}
+  {"number":736,"repo":"engine"},
+  {"number":737,"repo":"engine"}
 ],"unblock_issues":[
   {"number":733,"repo":"engine"},
   {"number":734,"repo":"engine"}
@@ -98,6 +102,7 @@ case "$1" in
                     734) echo '{"body":"**Blocked by:** #719","labels":[{"name":"fleet:queued"},{"name":"fleet:opus"},{"name":"fleet:blocked"}]}' ;;
                     735) echo '{"body":"**Model:** opus\n**Blocked by:** jakildev/irreden#777","labels":[{"name":"human:approved"}]}' ;;
                     736) echo '{"body":"**Model:** opus\n**Blocked by:** jakildev/irreden#778","labels":[{"name":"human:approved"}]}' ;;
+                    737) echo '{"body":"**Model:** opus\nPart of epic #174 (Phase D). [opus] Blocked by: #719.","labels":[{"name":"human:approved"}]}' ;;
                     *)   echo '{"body":"","labels":[]}' ;;
                 esac
                 exit 0 ;;
@@ -166,6 +171,18 @@ if [[ -n "$l736" && "$l736" == *"fleet:queued"* && "$l736" == *"fleet:blocked"* 
     ok "#736 cross-repo blocker (game#778 OPEN) → fleet:queued + fleet:blocked"
 else
     bad "#736 cross-repo open blocker not marked: '$l736'"
+fi
+
+# --- Plain mid-line form (#1749) ------------------------------------------
+# #737 declares its only dep as a degraded plain `Blocked by: #719` (the
+# #174-children form). The shared parser catches it → fleet:queued +
+# fleet:blocked. Before the fix the bold-only ingest copy missed it and the
+# child queued unmarked (surfacing as plainly claimable).
+l737=$(edit_line 737)
+if [[ -n "$l737" && "$l737" == *"fleet:queued"* && "$l737" == *"fleet:blocked"* ]]; then
+    ok "#737 plain 'Blocked by: #719' (epic #174 prose) → fleet:queued + fleet:blocked"
+else
+    bad "#737 plain-form blocker not marked: '$l737'"
 fi
 
 # --- Remove path ----------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extract one shared blocker parser `scripts/fleet/fleet_blocked_by.py` so the scout, queue-ingest, and fleet-claim stop carrying drifting private copies of the `**Blocked by:**` regexes + sentinel logic (the #1749 reconciliation).
- **Widen to the plain mid-line form** `Blocked by: #N` — the degraded shape #174's children self-declare their deps in (`Part of epic #174 (Phase D). [opus] Blocked by: #175, #176, #177.`) — which every bold-only parser skipped, surfacing blocked children as plainly claimable. The pattern is anchored on a real `#N` so `not blocked by anything yet` can't false-match.
- All consumers now share the rich no-blocker sentinel (bare `none` / `n/a` / `tbd` / `#N`-wins) and the cross-repo `[owner/]Repo#N` ref routing (#1522) — they can no longer disagree.
- `fleet-claim`'s lib guard now also requires the module, so a missing copy fails loud instead of failing OPEN (#1578) — a silent miss would make every claim look unblocked, worse than the bug.

## Test plan
- [x] `test_blocked_by.py` — new 28-case corpus (canonical / inline-bold / plain / multi-ref / `Blocked on` header / sentinels / cross-repo qualifier / false-positive guard).
- [x] `test_fleet_claim_blockers.sh` — +3 plain-form cases (gate fails on open ref, passes on closed ref, ignores ref-less prose). 21/21 pass.
- [x] `test_fleet_queue_ingest_blocked_by.sh` — +1 plain-form case (queued + `fleet:blocked`). 9/9 pass.
- [x] Existing scout suites unchanged: `test_parse_blocked_by_none_sentinel.py`, `test_issue_queue_parser.py`, `test_live_blocker_resolution.py` all green.
- [x] Real #178/#179 bodies replay through the shared parser → blockers {#175,#176,#177} and {#178}, routed to game.

Closes #1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)