### PR TITLE
docs: design for the deterministic GUI/mouse verification harness

### DIFF
--- a/.fleet/plans/issue-1793.md
+++ b/.fleet/plans/issue-1793.md
@@ -1,0 +1,56 @@
+# Plan: deterministic GUI + mouse verification harness (epic)
+
+- **Umbrella:** #1793 (`fleet:epic`)
+- **Design:** `docs/design/gui-mouse-harness.md` (PR #1792) — authoritative cross-phase reference
+- **Date:** 2026-06-13
+
+## Context
+
+Headless, deterministic driving + assertion of the trixel GUI (mouse moves,
+hovers, clicks, widget state). The GUI sibling of `render-verify`. The render
+side is already scriptable + deterministic (`--auto-screenshot`, fixed-step sim,
+`render-compare.py`) and widget state is introspectable (`C_WidgetState`,
+`IRPrefab::Widget::isHovered/wasClicked`). The missing primitive is synthetic
+input — input is GLFW-only. This epic adds it and builds the harness + a
+`gui-verify` skill on top.
+
+## Phases / children
+
+| Phase | Issue | Model | Title |
+|---|---|---|---|
+| P1 | #1794 | opus | synthetic mouse/click injection (`InputManager`/`IRInput`) |
+| P2 | #1795 | sonnet | GUI-test shot tables (extend `AutoScreenshotShot`) |
+| P3 | #1796 | opus | hover/click/picking assertions + `C_GuiHoverState` export |
+| P4 | #1797 | sonnet | `gui-verify` skill |
+
+## Dependency chain
+
+```
+#1794 (P1 injection)  ->  #1795 (P2 shot tables)  ->  #1796 (P3 assertions)  ->  #1797 (P4 skill)
+```
+
+Linear: each phase needs the previous primitive. P1 is the only unblocked head.
+
+## Closing criteria
+
+All four children verified-closed; `gui-verify` runs an editor GUI test table
+headless with per-assertion pass/fail; the picking assertion (P3) provides a
+regression net for the reported mouse-vs-render alignment offset.
+
+## Steward ledger
+
+reconciled-through: 2026-06-13
+proposal-pending: none
+
+### Children
+| Child | State | PR | Plan | Last validated |
+|---|---|---|---|---|
+| #1794 | open | — | plan | 2026-06-13 |
+| #1795 | open | — | plan | 2026-06-13 |
+| #1796 | open | — | plan | 2026-06-13 |
+| #1797 | open | — | plan | 2026-06-13 |
+
+### Decisions
+
+### Events
+- 2026-06-13: filed via file-epic

--- a/.fleet/plans/issue-1794.md
+++ b/.fleet/plans/issue-1794.md
@@ -1,0 +1,59 @@
+# Plan: synthetic mouse/click injection (P1)
+
+- **Issue:** #1794
+- **Model:** opus
+- **Date:** 2026-06-13
+- **Epic:** #1793 — see `.fleet/plans/issue-1793.md` for full context
+- **Blocked by:** (none)
+
+## Verified current state
+
+`InputManager` (`engine/input/include/irreden/input/input_manager.hpp`) snapshots
+GLFW callbacks per pipeline event. `IRInput::getMousePosition` /
+`getMousePositionScreen` / `checkKeyMouseButton` are read-only; the button/scroll
+queues (`processKeyMouseButtons` / `processScrolls`) are private with no public
+inject entry point. So nothing outside GLFW can set the cursor or a button —
+confirmed by reading the manager surface during the epic's investigation. The
+fixed-step capture gate (`engine/world/src/world.cpp`,
+`IRVideo::isAutoCaptureActive()` → `m_timeManager.enableFixedStep()`) is the
+precedent for a run-scoped mode flip to mirror.
+
+## Affected files
+
+- `engine/input/include/irreden/input/input_manager.hpp` (+ `.cpp` impl) —
+  injected-event queue + the public inject entry points + the active-mode flag.
+- `engine/input/include/irreden/ir_input.hpp` (+ impl) — `IRInput::`
+  `beginSyntheticInput` / `injectMouseMove` / `injectButton` / `injectScroll`.
+
+## Approach
+
+- Add a `m_syntheticInputActive` flag + an injected-event queue to `InputManager`.
+  When active, the per-frame snapshot is built from the injected queue instead of
+  the GLFW callbacks (cursor pos, button presses, scrolls).
+- `injectMouseMove(screenPx)` sets the next frame's cursor; `injectButton` /
+  `injectScroll` enqueue into the existing internal queues via new public
+  forwarders.
+- Apply one batch of injected events per frame, before the INPUT-pipeline
+  snapshot, so `HITBOX_MOUSE_TEST_GUI` / picking / gizmo-hover read them
+  unchanged.
+- Inactive path is byte-identical to today (GLFW only) — gate every divergence on
+  the flag.
+
+## Acceptance criteria
+
+- Synthetic active: `injectMouseMove` + `injectButton` drive `getMousePosition`
+  and a widget's `wasClicked` headless.
+- Synthetic inactive: GLFW path unchanged.
+- Smoke system injects move+click and logs observed mouse pos + `wasClicked`.
+
+## Gotchas
+
+- Snapshot timing: inject before the INPUT-event snapshot, not after.
+- Screen-pixel coords only (GLFW's space); downstream code converts.
+- Don't store a manager pointer across frames (engine baseline).
+
+## Verification
+
+`fleet-build --target IRShapeDebug` (or a widget demo); run a temp smoke that
+injects a move+click and asserts the logged mouse pos / `wasClicked`. Confirm a
+plain `--auto-screenshot` run with synthetic input inactive is unchanged.

--- a/.fleet/plans/issue-1795.md
+++ b/.fleet/plans/issue-1795.md
@@ -1,0 +1,52 @@
+# Plan: GUI-test shot tables with scripted input (P2)
+
+- **Issue:** #1795
+- **Model:** sonnet
+- **Date:** 2026-06-13
+- **Epic:** #1793 — see `.fleet/plans/issue-1793.md` for full context
+- **Blocked by:** #1794
+
+## Verified current state
+
+`AutoScreenshotShot` (`engine/video/include/irreden/video/auto_screenshot.hpp`)
+carries per-shot zoom / camera / yaw / ROI-crop; `createAutoScreenshotSystem`
+(`engine/video/src/auto_screenshot.cpp`) cycles shots with warmup + settle frames
+then closes the window. There is no input scripting today. This phase assumes P1
+(#1794) has landed the `IRInput::inject*` API.
+
+## Affected files
+
+- `engine/video/include/irreden/video/auto_screenshot.hpp` — add `GuiInputEvent`
+  + `GuiTestShot`.
+- `engine/video/src/auto_screenshot.cpp` — fire a shot's scripted input events on
+  scheduled frames via `IRInput::inject*` before capture.
+- A creation (voxel editor) shot table as the demonstration.
+
+## Approach
+
+- `GuiInputEvent { int frameOffset_; enum {MOVE,PRESS,RELEASE,SCROLL} type_;
+  ivec2 screenPx_; vec2 scroll_; }`; `GuiTestShot { AutoScreenshotShot render_;
+  const GuiInputEvent* inputs_; int numInputs_; }` (superset of the existing
+  shot so camera/crop config carries over).
+- In the capture system, after a shot's camera is applied, fire each input event
+  on `settleStart + frameOffset_` via P1's inject API; ensure remaining settle
+  frames elapse after the last event before the screenshot.
+- Frame-scheduled only — no wall-clock.
+
+## Acceptance criteria
+
+- A `GuiTestShot[]` table moves the cursor to a scripted point, clicks, and
+  captures deterministically (identical across runs).
+- Demonstrated on the voxel editor (move to a palette swatch, click, capture).
+
+## Gotchas
+
+- Keep `GuiTestShot` a strict superset of `AutoScreenshotShot`.
+- Last-event-to-capture gap must be ≥ settle frames so the GUI reflects the
+  interaction.
+
+## Verification
+
+Build + run the editor (or a widget demo) with a `GuiTestShot[]` table via the
+auto-screenshot path twice; confirm the captured frames are byte-stable and the
+scripted click visibly affected the widget.

--- a/.fleet/plans/issue-1796.md
+++ b/.fleet/plans/issue-1796.md
@@ -1,0 +1,58 @@
+# Plan: GUI hover/click/picking assertions + hovered-widget export (P3)
+
+- **Issue:** #1796
+- **Model:** opus
+- **Date:** 2026-06-13
+- **Epic:** #1793 — see `.fleet/plans/issue-1793.md` for full context
+- **Blocked by:** #1795
+
+## Verified current state
+
+Widget state is per-widget on `C_WidgetState` (`hovered_`/`pressed_`/`focused_`/
+`fireAction_`) with readers `IRPrefab::Widget::isHovered/wasClicked/isPressed`
+(`widgets.hpp`). The z-ordered topmost hovered widget is computed in
+`System<WIDGET_INPUT>::topHoveredId_` but is **private** — no exported accessor.
+Picking exists (`VOXEL_PICKING` / `IRPrefab::Picking::castVoxelRay`). This phase
+assumes P2 (#1795) scripted shots can drive input.
+
+## Affected files
+
+- `engine/prefabs/irreden/render/components/component_widget.hpp` (or a new
+  `component_gui_hover_state.hpp`) — `C_GuiHoverState` singleton, OR a
+  `IRPrefab::Widget::hoveredWidget()` accessor in `widgets.hpp`.
+- `engine/prefabs/irreden/render/systems/system_widget_input.hpp` — publish
+  `topHoveredId_` into the chosen surface in `endTick`.
+- `engine/video/` (or a small assertion module) — assertion kinds + the
+  machine-readable result log writer.
+
+## Approach
+
+- Export the hovered widget: prefer a `C_GuiHoverState` singleton written by
+  `WIDGET_INPUT::endTick` (ECS-idiomatic, matches how singleton render state is
+  exposed); fall back to an accessor only if a singleton entity is awkward.
+- Assertion kinds evaluated at a shot's capture frame: `HOVERS(widget)`,
+  `CLICK_FIRES(widget)` (`wasClicked`), `SLIDER_VALUE(widget, v, tol)`,
+  `CHECKBOX(widget, b)`, `PICKS_VOXEL(worldCoord)` (compare `VOXEL_PICKING`
+  result).
+- Result log: one line per assertion (shot / kind / target / pass|fail /
+  actual), machine-parseable like the render-compare report.
+
+## Acceptance criteria
+
+- A scripted shot asserts hover + click-fires + a slider/checkbox value, emitting
+  one pass/fail line each.
+- `PICKS_VOXEL` resolves a click to the expected voxel (alignment regression net).
+- `C_GuiHoverState`/accessor returns the z-ordered topmost hovered widget.
+
+## Gotchas
+
+- Read post-tick state on a deterministic frame after a fixed settle.
+- Script in screen pixels; the picking assertion is where the
+  screen→iso/GUI-trixel mapping (and any reported alignment offset) surfaces —
+  this is the intended place to pin that bug.
+
+## Verification
+
+Build the editor with a scripted shot that hovers a panel + clicks a control +
+clicks a known scene voxel; confirm the result log shows the expected
+pass/fail and is stable across runs.

--- a/.fleet/plans/issue-1797.md
+++ b/.fleet/plans/issue-1797.md
@@ -1,0 +1,51 @@
+# Plan: gui-verify skill (P4)
+
+- **Issue:** #1797
+- **Model:** sonnet
+- **Date:** 2026-06-13
+- **Epic:** #1793 — see `.fleet/plans/issue-1793.md` for full context
+- **Blocked by:** #1796
+
+## Verified current state
+
+`render-verify` (`.claude/skills/render-verify/SKILL.md` + the shared flow +
+`scripts/render-verify.py` / `scripts/render-compare.py`) is the build → run →
+capture → compare → report pattern to mirror. After P1–P3 land, a creation can
+script GUI input and emit a per-assertion result log; this phase wraps that into
+a reusable skill.
+
+## Affected files
+
+- `.claude/skills/gui-verify/SKILL.md` (+ a shared flow under
+  `docs/agents/skills/` if mirroring the skill-sharing mechanism).
+- `scripts/` — a thin runner if needed (prefer reusing `render-compare.py` for
+  region image diffs; the assertion pass/fail comes from P3's result log).
+- A first editor GUI test table (worked example).
+
+## Approach
+
+- Skill flow: build the target, run it headless with the creation's
+  `GuiTestShot[]` table, parse P3's result log for per-assertion pass/fail, and
+  (optionally) region-diff a GUI canvas crop via `render-compare.py` for visual
+  regressions (e.g. the help panel).
+- Author `SKILL.md` as a thin wrapper over a shared flow (mirror `render-verify`
+  + the skill-sharing mechanism) so the game repo can adopt it without drift.
+- Add a first editor GUI test (hover a panel → assert help text; click a swatch →
+  assert selection).
+
+## Acceptance criteria
+
+- `gui-verify` runs a creation's GUI test table headless, prints per-assertion
+  pass/fail, exits non-zero on failure (agent/CI parseable).
+- At least one editor GUI test passes deterministically across runs.
+- Region image-diff path works on a GUI canvas crop.
+
+## Gotchas
+
+- Reuse `render-compare.py`; don't add a second comparator.
+- Keep the skill thin-wrapper + shared-flow per the skill-sharing mechanism.
+
+## Verification
+
+Run `gui-verify` on the editor test table twice; confirm stable pass and a
+deliberately-broken assertion produces a non-zero exit + a clear failing line.

--- a/docs/design/gui-mouse-harness.md
+++ b/docs/design/gui-mouse-harness.md
@@ -1,0 +1,181 @@
+# Deterministic GUI + mouse verification harness
+
+Design note for the GUI/mouse verification epic. It specs a deterministic,
+headless way to drive and assert the trixel GUI — mouse moves, hovers, clicks,
+and the resulting widget state — so an agent (or CI) can verify editor/GUI
+behavior without a human watching the screen. It is the GUI sibling of the
+existing render-regression harness (`render-verify` / `scripts/render-compare.py`)
+and the [cull-validation harness](cull-validation-harness.md), and a step toward
+the engine's broader goal: a **toolbox of deterministic verification skills**
+covering rendering, GUI, and game logic.
+
+This note is the authoritative cross-phase reference; the work lands as a fleet
+epic (umbrella + one child task per phase below). The harness is **not** built
+yet — this is the plan.
+
+## TL;DR
+
+- The render side is already deterministic and scriptable (`--auto-screenshot`
+  shot tables + fixed-step sim + a stdlib image comparator + per-backend
+  reference images). GUI widget **state** is already introspectable
+  (`C_WidgetState` + `IRPrefab::Widget::isHovered/wasClicked/isPressed`).
+- The **one missing primitive** is *synthetic input*: there is no way to inject
+  a mouse position or a click. Input comes only from GLFW callbacks, so a
+  headless run can never move the cursor or press a button.
+- Add synthetic input injection (Phase 1), drive it from per-shot input scripts
+  (Phase 2), assert hover/click outcomes against widget state (Phase 3), and
+  package the whole thing as a `gui-verify` skill (Phase 4).
+- Everything is frame-scheduled, not wall-clock — same determinism contract the
+  screenshot harness already relies on.
+
+## Why a GUI harness
+
+The IRVoxel editor (and any future widget-driven creation) has logic that only
+fires through mouse interaction: hover highlights, click-to-select, drag
+sliders, the hover help-text panel (#1790), gizmo drag, voxel picking. None of
+it is exercised by `--auto-screenshot` today, because that path renders frames
+but never touches the cursor. So:
+
+- An agent iterating on editor GUI cannot verify "clicking the BAKE button bakes
+  the shape" or "hovering the FPS slider shows its help" without a human.
+- Mouse-vs-rendered-object alignment bugs (the picking/selection offset the user
+  reported) have no regression net.
+- "Deterministic verification of game logic and rendering" is a stated engine
+  design goal; the GUI is the current blind spot.
+
+## What already exists (the foundation)
+
+| Capability | Where | Notes |
+|---|---|---|
+| Headless shot tables | `engine/video/include/irreden/video/auto_screenshot.hpp` (`AutoScreenshotShot`, `parseAutoScreenshotArgv`); `engine/video/src/auto_screenshot.cpp` | per-shot zoom / camera / yaw / ROI-crop; cycles shots then closes the window |
+| Fixed-step determinism | `engine/world/src/world.cpp` (`IRVideo::isAutoCaptureActive()` → `enableFixedStep()`) | one UPDATE tick per render frame during capture; per-tick animation is reproducible |
+| Image comparator | `scripts/render-compare.py` (+ `scripts/render-verify.py`) | stdlib-only; match% / max-delta / PSNR vs per-backend reference PNGs |
+| Reference images | `creations/demos/<demo>/test/references/<preset>/` + `manifest.json` | per-backend (`linux-debug` / `macos-debug` / `windows-debug`) |
+| Widget state introspection | `C_WidgetState` (`component_widget.hpp`); `IRPrefab::Widget::isHovered / wasClicked / isPressed` (`widgets.hpp`) | per-widget hovered / pressed / focused / fireAction |
+| Resolved hovered widget | `System<WIDGET_INPUT>::topHoveredId_` | the z-ordered topmost hovered hitbox (currently private) |
+
+## The gap: no synthetic input
+
+`InputManager` (`engine/input/include/irreden/input/input_manager.hpp`) snapshots
+GLFW callbacks each frame. `IRInput::getMousePosition` / `getMousePositionScreen`
+/ `checkKeyMouseButton` are **read-only**, and the button/scroll queues
+(`processKeyMouseButtons` / `processScrolls`) are private with no public inject
+path. There is no replay, no test-input mode, no way to set the cursor. So a
+headless run cannot hover or click anything — the harness's load-bearing missing
+piece.
+
+## Proposed design
+
+### Phase 1 — synthetic input injection (engine)
+
+Add a deterministic input-injection layer the harness owns and GLFW does not
+touch when active:
+
+- `IRInput::beginSyntheticInput()` — switch `InputManager` to consume an
+  injected event queue instead of (or in addition to) GLFW snapshots for this
+  run. Mirrors the `isAutoCaptureActive()` gate that already flips the sim into
+  fixed-step.
+- `IRInput::injectMouseMove(ivec2 screenPx)` — set the cursor for the next
+  frame; feeds the same `mousePosition` snapshot the GLFW path writes, so every
+  downstream consumer (`HITBOX_MOUSE_TEST_GUI`, picking, gizmo hover) sees it
+  with no per-consumer change.
+- `IRInput::injectButton(button, ButtonStatus)` — enqueue a press/release into
+  the existing private button queue via a new public entry point.
+- `IRInput::injectScroll(dx, dy)` — same for scroll.
+
+Injected events are applied at frame boundaries (one batch per render frame), so
+ordering is reproducible. When synthetic input is inactive, the path is
+byte-identical to today (GLFW only).
+
+### Phase 2 — GUI-test shot tables (engine/video)
+
+Extend the shot-table mechanism with scripted input per shot:
+
+```cpp
+struct GuiInputEvent {
+    int frameOffset_;            // frames after the shot's settle to fire
+    enum Type { MOVE, PRESS, RELEASE, SCROLL } type_;
+    IRMath::ivec2 screenPx_;     // for MOVE / PRESS / RELEASE
+    IRMath::vec2  scroll_;       // for SCROLL
+};
+struct GuiTestShot {
+    IRVideo::AutoScreenshotShot render_;     // existing camera/zoom/crop config
+    const GuiInputEvent *inputs_; int numInputs_;
+    // optional: assertions to evaluate at capture time (Phase 3)
+};
+```
+
+During capture the auto-screenshot system fires each shot's input events on the
+scheduled frames (via Phase 1), lets the GUI settle, then captures + (Phase 3)
+evaluates assertions. Reuses the existing settle-frame and screenshot plumbing.
+
+### Phase 3 — hover/click assertions (engine + harness)
+
+Assert GUI outcomes deterministically against the introspectable state:
+
+- Expose the resolved hovered widget: write `WIDGET_INPUT::topHoveredId_` into a
+  `C_GuiHoverState` singleton (or an `IRPrefab::Widget::hoveredWidget()`
+  accessor) so a harness can read "which widget is hovered" without scanning.
+- Assertion kinds, evaluated at a shot's capture frame:
+  - `HOVERS(widgetName)` — after a `MOVE` to a point, the named widget is the
+    topmost hovered.
+  - `CLICK_FIRES(widgetName)` — after `PRESS`+`RELEASE` over it, `wasClicked` is
+    true.
+  - `SLIDER_VALUE(widgetName, expected, tol)`, `CHECKBOX(widgetName, bool)`, etc.
+  - `PICKS_VOXEL(worldCoord)` — a click resolves to the expected picked voxel
+    (the harness for the mouse-vs-render alignment bug the user flagged).
+- Results stream to a machine-readable log (one line per assertion:
+  shot / kind / target / pass|fail / actual), so an agent or CI parses pass/fail
+  the way `render-verify` parses image diffs.
+
+### Phase 4 — `gui-verify` skill + the toolbox
+
+Package build → run-with-input-script → assert → report as a `gui-verify` skill,
+the GUI sibling of `render-verify`:
+
+- A creation declares a `GuiTestShot[]` table (camera + input script +
+  assertions), the skill runs it headless, and reports per-assertion pass/fail
+  plus optional GUI-canvas-region image diffs (reusing `render-compare.py` on a
+  cropped GUI region for visual regressions like the help panel).
+- Lands in the same verification toolbox as `render-verify` and the
+  cull-validation harness, advancing the "deterministic verification of
+  rendering and game logic" engine goal. A later `logic-verify` sibling can
+  reuse Phase 1's injection + the assertion-log format for non-GUI game logic.
+
+## Determinism contract
+
+- Input is **frame-scheduled** (events fire on integer frame offsets), never
+  wall-clock — matches the fixed-step capture mode.
+- Synthetic-input mode disables GLFW input for the run, so no stray real cursor
+  events perturb the script.
+- Assertions read post-tick widget state on a deterministic frame, after a fixed
+  settle count — the same reproducibility the screenshot harness already gives.
+- RNG seeding is the caller's responsibility (set before capture), as today.
+
+## Phased epic breakdown
+
+1. **Phase 1 — synthetic input injection.** `InputManager` inject queue +
+   `IRInput::beginSyntheticInput / injectMouseMove / injectButton / injectScroll`;
+   GLFW-gated; no behavior change when inactive. Smoke: a temp system that injects
+   a move+click and logs `getMousePosition` / a widget's `wasClicked`.
+2. **Phase 2 — GUI-test shot tables.** `GuiTestShot` + `GuiInputEvent`; auto-
+   screenshot fires scripted input per shot. Demonstrate on the voxel editor
+   (move to a swatch, click, capture).
+3. **Phase 3 — assertions + hovered-widget export.** `C_GuiHoverState`,
+   assertion kinds, machine-readable result log.
+4. **Phase 4 — `gui-verify` skill.** Wraps the flow; per-creation test tables;
+   region image-diff via `render-compare.py`. Add a first editor GUI test.
+
+## Open questions / risks
+
+- **Backend parity of input timing.** Injection is CPU-side and pre-GLFW, so it
+  should be backend-agnostic; confirm on Metal.
+- **Hovered-widget export shape.** `C_GuiHoverState` singleton vs accessor —
+  pick the one consistent with how other singleton render state is exposed.
+- **Screen vs iso coordinates.** Tests should script in **screen pixels**
+  (stable, what a user clicks); the harness converts via the existing
+  screen→iso/GUI-trixel mappings, which is also where the reported
+  mouse-vs-render alignment bug would surface and be pinned.
+- **Scope of v1 assertions.** Start with hover + click-fires + slider/checkbox
+  value; defer drag-path and gizmo-drag assertions to a follow-up once the
+  primitive is proven.


### PR DESCRIPTION
## Summary
- Design note for a **deterministic, headless GUI + mouse verification harness** — the GUI sibling of the render-regression harness (`render-verify`/`render-compare.py`) and the cull-validation harness. Advances the engine goal of a deterministic verification toolbox (rendering + GUI + game logic).
- Documents the existing foundation (`--auto-screenshot` shot tables, fixed-step sim, the stdlib image comparator, `C_WidgetState` introspection) and pinpoints the **one missing primitive**: synthetic input injection (input is GLFW-only — no way to script a hover/click headless).
- Lays out a four-phase build: (1) input injection API, (2) GUI-test shot tables, (3) hover/click + picking assertions with a machine-readable result log, (4) a `gui-verify` skill. Also frames the reported mouse-vs-render alignment bug as something the picking assertion (Phase 3) would pin.

## Stack context
Stacked on: https://github.com/jakildev/IrredenEngine/pull/1790

When the parent PR merges, change this PR's base to `master`
(via the GitHub UI or `gh pr edit <N> --base master`).

## Test plan
- [x] Doc-only; cross-references (cull-validation-harness.md, render-compare.py, auto_screenshot.*, world.cpp, component_widget.hpp, widgets.hpp, input_manager.hpp) verified against the tree.

## Notes for reviewer
- This is the **plan** for the harness (E in the editor-quality epic); the harness itself is filed as a separate fleet epic for staged build, per the agreed scope (design-doc-and-epic, not build-now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)