### PR TITLE
docs: plan #1294 voxel occlusion-culling impl chain (3 children)

### DIFF
--- a/.fleet/plans/issue-1294.md
+++ b/.fleet/plans/issue-1294.md
@@ -1,0 +1,127 @@
+# Plan: render — voxel-pool solid-coverage occlusion culling
+
+- **Issue:** #1294 (umbrella/tracking; 3 child impl tasks filed under it)
+- **Design source of truth:** `docs/design/voxel-occlusion-culling.md` (#1290)
+- **Model:** opus (shader + hot-path render-system work)
+- **Date:** 2026-06-13
+
+## Scope
+
+Implement the third voxel-cull phase: drop voxels that are locally exposed and
+in-frustum but **globally occluded by closer geometry from a different object**
+(inter-object occlusion). Target = the `voxelStage1` GPU pass, the dominant frame
+cost at zoom-out.
+
+## Measurement gate — CLEARED (this session, 2026-06-13)
+
+The design deferred implementation behind three trigger conditions. All are now
+resolved:
+
+1. **Raster stages > ~25% of frame** — ✅ **MET.** Fresh profile (post-#1778,
+   M4 Max, 262K): `voxelStage1` GPU = 32.1ms = **73% of the zoom8 frame**.
+2. **In-flight rasterization rework settled** — ✅ **RESOLVED.** #1278
+   (exposed-face mask) + #1288 (cull-gated REBUILD_GRID_VOXELS) both
+   merged 2026-05-28; the cost baseline this cull optimizes is now stable.
+3. **`occludedExposedFraction` measured** — ✅ **CLEARED.** Measured directly via
+   a throwaway stage-2 win/attempt atomic counter (since reverted):
+
+| scene @ zoom8 | frame / FPS | voxelStage1 GPU | overdraw | **occludedExposedFraction** | cull helps? |
+|---|---|---|---|---|---|
+| **voxel_set** (the 32ms case) | 50ms / 21 | 32.1ms | 38× | **0.97** | ✅ massively |
+| **dense_set** (one solid set) | 52ms / 20 | 49.9ms | 1× | **0.00** | ❌ exposed-face mask already prunes |
+| **hollow_set** (sphere shell) | 8.7ms / 117 | 6.6ms | 2× | 0.50 | ⚠️ moderate, already fast |
+
+The design's analytical prior ("IRPerfGrid ≈ 0 occlusion") was **wrong** for the
+per-entity grid: `voxel_set` is 97% occluded (18M stage-2 taps, only 472K
+visible). So the cull is justified.
+
+### Scope caveats (carry into review, NOT blockers)
+
+- **Payoff is scene-shape-dependent.** 0.97 holds for **many-small-entity**
+  scenes (per-voxel/per-object grids: crowds, item fields, particles zoomed
+  out), where neighbors are different objects so the exposed-face mask can't
+  prune between them. For a **single merged solid** (`dense_set`) the residual is
+  **0** — the exposed-face mask already handles it.
+- **The hardest scene is the one this cull can't help.** `dense_set` is the
+  *slowest* (49.9ms) and 0% cullable. Solid-volume/terrain cost is a **separate**
+  problem (LOD / drawn-face reduction / raster resolution) — out of scope here.
+- **Granularity gap.** 0.97 is the *per-voxel* ceiling. v1 culls per **256-voxel
+  pool-chunk** (design's preferred start — only chunks whose entire iso AABB is
+  occluded). Realized capture will be < 97% and depends on pool-chunk spatial
+  coherence; **per-voxel culling is the documented follow-on** (design § 1) if
+  chunk capture proves weak. Task 3's verification measures the realized
+  `voxelStage1` delta — if it under-delivers, file the per-voxel follow-on rather
+  than forcing per-chunk.
+
+## Approach — three sequential bounded PRs (child issues, blocked_by chain)
+
+Strictly sequential, same surface, all `[opus]`. Each is a child of #1294 with a
+standalone `**Blocked by:** #<prior>` line so the stack claims in order.
+
+### Child 1 — Hi-Z build stage  [opus, blocked by: none]
+
+`COMPUTE_DISTANCE_HIZ` system + `c_build_distance_hiz.{glsl,metal}`:
+downsample-**max** mip chain of `triangleCanvasDistances` (binding 1, R32I) into a
+new mipped R32I texture on `C_TriangleCanvasTextures`. Runs after stage 2 + AO,
+before next frame's cull reads it. New `SystemName` enum entry. Per-canvas.
+
+### Child 2 — Chunk occlusion pre-pass  [opus, blocked by: Child 1]
+
+`COMPUTE_CHUNK_OCCLUSION` system + `c_chunk_occlusion_cull.{glsl,metal}`: one
+invocation per pool-chunk; projects the chunk's iso AABB
+(`C_VoxelPool::getChunkBounds`, **expanded by the shadow-feeder sweep**), picks
+the Hi-Z mip whose texel ≥ AABB footprint, samples max-depth, ANDs `0` into the
+chunk's `ChunkVisibility` bit (binding 24) iff the chunk's nearest depth is
+strictly behind the Hi-Z max. Conservative: expand footprint one texel; keep on
+partial coverage. Reads **last frame's** Hi-Z.
+
+### Child 3 — Gating + verification  [opus, blocked by: Child 2]
+
+`occlusionCullEnabled_` flag (default **false**) on `C_RenderCamera`/render
+option; one-frame disable after a camera-position delta over threshold. Pre-pass
+early-returns when off (zero cost in default config). `render-verify` baselines
+proving **pixel-identical** output cull-on vs cull-off (must be — fully-occluded
+voxels write nothing; any diff is a cull bug). **Measure and record the realized
+`voxelStage1` reduction on `voxel_set` zoom8** (the 0.97 ceiling); if weak, file
+the per-voxel follow-on. Document the one-frame-lag pop as intentional drift.
+
+## Affected files
+
+- `engine/render/src/shaders/c_build_distance_hiz.{glsl,metal}` — Child 1 (new)
+- `engine/render/src/shaders/c_chunk_occlusion_cull.{glsl,metal}` — Child 2 (new)
+- `engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp` — Child 1 Hi-Z texture
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp` — chunk-mask plumbing (already here); pre-pass wiring
+- `engine/system/include/irreden/system/ir_system_types.hpp` — `SystemName` entries (Children 1,2)
+- `C_RenderCamera` / render options — Child 3 flag
+
+## Cross-system audit (shared resources touched)
+
+- **`ChunkVisibility` SSBO (binding 24)** — produced by CPU
+  `buildChunkVisibilityMask`, consumed by `c_voxel_visibility_compact.glsl`. The
+  cull AND-s an occlusion bit in: **additive, no consumer migration.**
+- **`triangleCanvasDistances` (binding 1, R32I)** — Hi-Z downsample-max source;
+  also read by sun-shadow bake (binding 0) + AO. Hi-Z is a **new derived
+  texture**; the existing distance texture is unmodified — no consumer migration,
+  but the Hi-Z build must be ordered after stage2+AO and before next-frame cull.
+
+## Acceptance criteria
+
+- Child 1: Hi-Z mip chain built each frame from last frame's distances; renders
+  unchanged (Hi-Z is write-only-consumed-next-frame at this stage).
+- Child 2: occlusion bit ANDed into `ChunkVisibility`; with the flag forced on,
+  output still correct on `voxel_set`.
+- Child 3: cull-on vs cull-off **bit-identical** in `render-verify`; **measured
+  `voxelStage1` reduction recorded** on `voxel_set` zoom8; zero cost when
+  `occlusionCullEnabled_=false`.
+
+## Gotchas / hard constraints (design § Downstream-consumer matrix)
+
+- **Shadow-feeder coverage is the #1 hazard** — Hi-Z *and* chunk-AABB projection
+  must use the shadow-feeder-widened bounds, or sun shadows lose off-screen
+  casters.
+- **Lighting invariant 1** — NEVER wire the cull into
+  `system_build_light_occlusion_grid` (it must keep iterating the full pool).
+- **Conservative** — a false positive is a visible hole; a false negative is only
+  lost savings. When in doubt, keep the voxel.
+- Each shader PR runs `render-debug-loop` + `attach-screenshots` and carries both
+  cross-host smoke labels.

--- a/.fleet/plans/issue-1294.md
+++ b/.fleet/plans/issue-1294.md
@@ -71,7 +71,7 @@ before next frame's cull reads it. New `SystemName` enum entry. Per-canvas.
 invocation per pool-chunk; projects the chunk's iso AABB
 (`C_VoxelPool::getChunkBounds`, **expanded by the shadow-feeder sweep**), picks
 the Hi-Z mip whose texel ≥ AABB footprint, samples max-depth, ANDs `0` into the
-chunk's `ChunkVisibility` bit (binding 24) iff the chunk's nearest depth is
+chunk's `ChunkVisibility` entry (binding 24) iff the chunk's nearest depth is
 strictly behind the Hi-Z max. Conservative: expand footprint one texel; keep on
 partial coverage. Reads **last frame's** Hi-Z.
 
@@ -98,7 +98,7 @@ the per-voxel follow-on. Document the one-frame-lag pop as intentional drift.
 
 - **`ChunkVisibility` SSBO (binding 24)** — produced by CPU
   `buildChunkVisibilityMask`, consumed by `c_voxel_visibility_compact.glsl`. The
-  cull AND-s an occlusion bit in: **additive, no consumer migration.**
+  cull AND-s `0` into an occluded chunk's entry: **additive, no consumer migration.**
 - **`triangleCanvasDistances` (binding 1, R32I)** — Hi-Z downsample-max source;
   also read by sun-shadow bake (binding 0) + AO. Hi-Z is a **new derived
   texture**; the existing distance texture is unmodified — no consumer migration,
@@ -108,7 +108,7 @@ the per-voxel follow-on. Document the one-frame-lag pop as intentional drift.
 
 - Child 1: Hi-Z mip chain built each frame from last frame's distances; renders
   unchanged (Hi-Z is write-only-consumed-next-frame at this stage).
-- Child 2: occlusion bit ANDed into `ChunkVisibility`; with the flag forced on,
+- Child 2: occluded chunks' `ChunkVisibility` entries ANDed to `0`; with the flag forced on,
   output still correct on `voxel_set`.
 - Child 3: cull-on vs cull-off **bit-identical** in `render-verify`; **measured
   `voxelStage1` reduction recorded** on `voxel_set` zoom8; zero cost when

--- a/.fleet/plans/issue-1798.md
+++ b/.fleet/plans/issue-1798.md
@@ -1,0 +1,52 @@
+# Plan: render — Hi-Z (max-depth mip chain) build stage (occlusion cull child 1/3)
+
+- **Issue:** #1798 (child 1/3 of #1294)
+- **Parent plan:** `.fleet/plans/issue-1294.md` — shared design, measurement gate (0.97 cleared), cross-system audit, correctness constraints
+- **Design:** `docs/design/voxel-occlusion-culling.md` § Implementation sketch step 1
+- **Model:** opus
+- **Date:** 2026-06-13
+
+## Verified current state
+
+- `voxelStage1` GPU = 32.1ms = 73% of the IRPerfGrid `voxel_set` zoom8 frame
+  (post-#1778, measured this session). `occludedExposedFraction` = 0.97 (gate
+  cleared — see parent plan).
+- No Hi-Z buffer exists today; `triangleCanvasDistances` is a flat R32I image
+  (`component_triangle_canvas_textures.hpp`, binding 1). The voxel path runs in
+  `system_voxel_to_trixel.hpp` (stage 1 = atomicMin distance write, stage 2 =
+  color write where the voxel won).
+- #1278/#1288 merged — raster baseline stable.
+
+## Approach (single path)
+
+1. Add a mipped R32I "Hi-Z" texture to `C_TriangleCanvasTextures` (max-depth
+   pyramid; mip 0 = full-res copy or direct source of `triangleCanvasDistances`).
+2. New `COMPUTE_DISTANCE_HIZ` system + `c_build_distance_hiz.{glsl,metal}`:
+   downsample-**max** each level (a coarse texel = the farthest depth over its 4
+   children, so "anything strictly behind it is hidden"). New `SystemName` enum
+   entry. Per-canvas.
+3. Schedule it in the render pipeline **after stage 2 + AO** complete (the
+   distances are final) and before the next frame's cull (child 2) reads it. Use
+   last frame's Hi-Z as the cull source (one-frame lag, design § 3).
+
+## Affected files
+
+- `engine/render/src/shaders/c_build_distance_hiz.{glsl,metal}` — new
+- `engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp` — Hi-Z texture
+- `engine/system/include/irreden/system/ir_system_types.hpp` — `SystemName` entry
+- `engine/prefabs/irreden/render/systems/` — new system; pipeline registration in `creations/demos/perf_grid/main.cpp` render pipeline (after AO)
+
+## Acceptance criteria
+
+- Hi-Z mip chain built each frame; each coarser texel = max of its 4 children.
+- Renders unchanged (Hi-Z is consumed next frame by child 2; this PR only
+  produces it).
+- Builds clean; `render-debug-loop` + `attach-screenshots` on both hosts.
+
+## Gotchas
+
+- **Shadow-feeder coverage** — the Hi-Z must cover the shadow-feeder-widened
+  bounds that child 2 samples, not just the visible viewport, or sun shadows lose
+  off-screen casters (design's #1 hazard). Confirm the distance texture extent
+  already includes the swept region (it does — the sun-shadow bake reads it).
+- Max (not min) downsample — a min pyramid would cull visible voxels (holes).

--- a/.fleet/plans/issue-1799.md
+++ b/.fleet/plans/issue-1799.md
@@ -1,0 +1,70 @@
+# Plan: render — chunk occlusion pre-pass (occlusion cull child 2/3)
+
+- **Issue:** #1799 (child 2/3 of #1294)
+- **Blocked by:** #1798 (needs the Hi-Z depth pyramid)
+- **Parent plan:** `.fleet/plans/issue-1294.md` — shared design, measurement gate, cross-system audit, constraints
+- **Design:** `docs/design/voxel-occlusion-culling.md` § Implementation sketch step 2 + § Design space 1–2
+- **Model:** opus
+- **Date:** 2026-06-13
+
+## Verified current state
+
+- The frustum cull already writes a per-pool-chunk `0/1` mask into the
+  `ChunkVisibility` SSBO (binding 24) via CPU `buildChunkVisibilityMask`
+  (`system_voxel_to_trixel.hpp`). The GPU compact pass
+  (`c_voxel_visibility_compact.glsl`) reads binding 24, the active-mask bit
+  (binding 8), and a per-voxel iso-bounds test, then compacts survivors into
+  binding 25 + indirect dispatch params (binding 26). **The compact pass is the
+  natural place a per-chunk occlusion bit takes effect — it already reads the
+  chunk mask.**
+- Pool "chunks" are 256-consecutive-entry slices of the pool array, not spatial
+  cells; `C_VoxelPool::getChunkBounds` gives each chunk's iso AABB
+  (`rebuildChunkBounds`).
+- Child 1 (#1798) produces last frame's Hi-Z max-depth pyramid.
+
+## Approach (single path)
+
+New `COMPUTE_CHUNK_OCCLUSION` system + `c_chunk_occlusion_cull.{glsl,metal}`,
+one invocation per pool-chunk:
+1. Read the chunk's iso AABB (`getChunkBounds`), **expand it by the shadow-feeder
+   sweep** (`IRMath::shadowFeederIsoBounds`, same widening
+   `buildChunkVisibilityMask` uses).
+2. Project to iso, pick the Hi-Z mip whose texel ≥ the AABB footprint, expand the
+   footprint by one texel (conservative).
+3. Sample the **max** Hi-Z depth over that footprint; AND `0` into the chunk's
+   `ChunkVisibility` bit (binding 24) **iff** the chunk's *nearest* depth is
+   strictly behind the Hi-Z max over the *whole* footprint. On any partial
+   coverage, keep the chunk.
+4. Run before the compact pass; reads last frame's Hi-Z (#1798).
+
+Per-chunk is the design's preferred start (cheapest, reuses chunk-mask plumbing).
+Per-voxel is the documented follow-on if measurement (child 3) shows large
+residual.
+
+## Affected files
+
+- `engine/render/src/shaders/c_chunk_occlusion_cull.{glsl,metal}` — new
+- `engine/system/include/irreden/system/ir_system_types.hpp` — `SystemName` entry
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp` — pre-pass
+  wiring before the compact dispatch (or new system file + pipeline registration)
+
+## Acceptance criteria
+
+- Occlusion bit ANDed into `ChunkVisibility` (binding 24) upstream of the compact
+  pass — additive, no consumer migration.
+- Conservative: footprint +1 texel; keep on partial coverage. A false positive is
+  a visible hole; a false negative is only lost savings.
+- With the cull forced on, output still correct on `voxel_set` (full pixel-identical
+  verification is child 3).
+- Builds clean; `render-debug-loop` + `attach-screenshots` on both hosts.
+
+## Gotchas
+
+- **Shadow-feeder coverage** (design's #1 hazard) — both the chunk-AABB projection
+  and the Hi-Z footprint must use shadow-feeder-widened bounds, or off-screen sun
+  casters get culled and shadows drop.
+- **Lighting invariant 1** — do NOT wire the cull into
+  `system_build_light_occlusion_grid` (it must keep iterating the full pool,
+  independent of the visibility mask).
+- Chunk-bounds tightness is the dominant cull-rate lever; if rate is poor, the fix
+  is tighter spatial chunking (separate task), not forcing per-voxel here.

--- a/.fleet/plans/issue-1799.md
+++ b/.fleet/plans/issue-1799.md
@@ -32,7 +32,7 @@ one invocation per pool-chunk:
 2. Project to iso, pick the Hi-Z mip whose texel ≥ the AABB footprint, expand the
    footprint by one texel (conservative).
 3. Sample the **max** Hi-Z depth over that footprint; AND `0` into the chunk's
-   `ChunkVisibility` bit (binding 24) **iff** the chunk's *nearest* depth is
+   `ChunkVisibility` entry (binding 24) **iff** the chunk's *nearest* depth is
    strictly behind the Hi-Z max over the *whole* footprint. On any partial
    coverage, keep the chunk.
 4. Run before the compact pass; reads last frame's Hi-Z (#1798).
@@ -50,7 +50,7 @@ residual.
 
 ## Acceptance criteria
 
-- Occlusion bit ANDed into `ChunkVisibility` (binding 24) upstream of the compact
+- Occluded chunks' `ChunkVisibility` entries ANDed to `0` (binding 24) upstream of the compact
   pass — additive, no consumer migration.
 - Conservative: footprint +1 texel; keep on partial coverage. A false positive is
   a visible hole; a false negative is only lost savings.

--- a/.fleet/plans/issue-1800.md
+++ b/.fleet/plans/issue-1800.md
@@ -1,0 +1,58 @@
+# Plan: render — occlusion-cull gating + verification (occlusion cull child 3/3)
+
+- **Issue:** #1800 (child 3/3 of #1294)
+- **Blocked by:** #1799 (needs the pre-pass to gate and verify)
+- **Parent plan:** `.fleet/plans/issue-1294.md` — shared design, measurement gate, cross-system audit, constraints
+- **Design:** `docs/design/voxel-occlusion-culling.md` § Implementation sketch steps 3–4 + § Latency/correctness budget
+- **Model:** opus
+- **Date:** 2026-06-13
+
+## Verified current state
+
+- Children #1798 (Hi-Z) + #1799 (chunk occlusion pre-pass) produce + apply the
+  occlusion bit but it must ship **off by default** (design § Recommendation:
+  sparse/solid scenes get zero payoff — `dense_set` measured 0.00 this session —
+  so the default config must pay no cost).
+- The cull is *approximate* (coarse, one-frame-lagged Hi-Z); on a camera cut the
+  lag source is stale (design § 4). `C_RenderCamera` already tracks per-frame iso
+  position, so a delta threshold gates a one-frame disable.
+
+## Approach (single path)
+
+1. `occlusionCullEnabled_` flag (default **false**) on `C_RenderCamera` or a
+   render option. The pre-pass (#1799) early-returns when off → zero added cost
+   in the default configuration.
+2. One-frame disable after a camera-position delta over threshold (stale lag
+   source on cut/teleport/first frame).
+3. `render-verify` baselines proving **pixel-identical** output cull-on vs
+   cull-off (fully-occluded voxels write nothing, so any diff is a cull bug — see
+   parent plan / design § "load-bearing invariant").
+4. **Measure + record** the realized `voxelStage1` ms reduction on `voxel_set`
+   zoom8 (against the 0.97 ceiling) in the PR body.
+
+## Affected files
+
+- `engine/prefabs/irreden/render/components/component_camera_*.hpp` /
+  `C_RenderCamera` — the `occlusionCullEnabled_` flag + camera-delta gate
+- `engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp` (or the
+  pre-pass system) — honor the flag (early-return)
+- `render-verify` baseline fixtures
+- `creations/demos/perf_grid/main.cpp` — optional toggle + intentional-drift note
+
+## Acceptance criteria
+
+- Cull-on vs cull-off **bit-identical** in `render-verify`.
+- Realized `voxelStage1` reduction on `voxel_set` zoom8 recorded in the PR body.
+  **If weak** (per-chunk granularity captures little of the 0.97 ceiling), file
+  the **per-voxel** occlusion follow-on (design § 1) rather than forcing
+  per-chunk — do not over-engineer chunk culling.
+- Zero added cost when `occlusionCullEnabled_=false` (verify the default-config
+  profile is unchanged from baseline).
+- Builds clean; `render-debug-loop` + `attach-screenshots` on both hosts.
+
+## Gotchas
+
+- Document the one-frame-lag silhouette pop as **intentional drift** in the demo
+  note so reviewers don't read it as a regression.
+- The conservative-cull invariant (never cull a chunk whose shadow-feeder-widened
+  footprint isn't fully Hi-Z-covered) carries through from #1799.


### PR DESCRIPTION
## Summary
- Architect plan files for the #1294 voxel occlusion-culling work, committed so workers on other hosts read them from master (the `fleet-queue-ingest` plan gate requires `.fleet/plans/issue-<N>.md` to exist).
- **Measurement gate cleared this session:** `occludedExposedFraction` measured **0.97** on IRPerfGrid `voxel_set` zoom8 (38× overdraw; `voxelStage1` GPU = 32ms = 73% of frame, post-#1778). The design's deferred cull is justified for many-small-entity scenes (nil on single merged solids — scene-shape dependent; solid-volume cost is a separate lever).
- Files: `.fleet/plans/issue-1294.md` (tracking parent) + the three sequential `[opus]` children — `issue-1798.md` (Hi-Z build), `issue-1799.md` (chunk occlusion pre-pass), `issue-1800.md` (gating + pixel-identical verify + realized-delta).

## Test plan
- [x] All plan cross-references verified to resolve (`getChunkBounds`, `shadowFeederIsoBounds`, `buildChunkVisibilityMask`, `kBufferIndex_ChunkVisibility`, `component_triangle_canvas_textures.hpp`); new shaders/systems correctly absent.
- [x] Info-isolation scan clean (no game-repo leakage).
- [ ] Docs-only — no build/screenshots required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)