### PR TITLE
docs: plan #1052 update-parallelization carve-offs (#1802/#1803/#1804)

### DIFF
--- a/.fleet/plans/issue-1802.md
+++ b/.fleet/plans/issue-1802.md
@@ -1,0 +1,53 @@
+# Plan: PERIODIC_IDLE_POSITION_OFFSET → PARALLEL_FOR (cheap win)
+
+- **Issue:** #1802 (carve-off of #1052)
+- **Model:** sonnet
+- **Date:** 2026-06-13
+
+## Scope
+
+Tag `System<PERIODIC_IDLE_POSITION_OFFSET>` as `Concurrency::PARALLEL_FOR` so its
+262K-entity tick fans across the IRJob pool. The cheapest piece of #1052.
+
+## Verified current state
+
+- `engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp:24`
+  — SERIAL (no `kConcurrency`); per-entity tick form.
+- Its body calls `IRPrefab::Modifier::upsertBySourceInPlace(mods, ...)`
+  (`engine/prefabs/irreden/common/modifier.hpp:623-638`), which mutates **only
+  the passed-in entity's own `C_Modifiers::modifiersVec3_`** — no shared
+  allocator, global pool, static buffer, or singleton. Verified independent per
+  entity.
+- In `creations/demos/perf_grid/main.cpp` it already runs in its **own singleton
+  pipeline group**, satisfying the "PARALLEL_FOR must be a singleton group" rule
+  (`validateAllPipelineGroups`).
+
+## Approach (single path)
+
+1. Add `static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;`
+   to the `System<PERIODIC_IDLE_POSITION_OFFSET>` specialization. Optionally
+   `static constexpr int kGrainSize = 512;` (the default).
+2. Build + boot `validateAllPipelineGroups` (already a singleton group → passes).
+3. Confirm bit-identical output and record the `update` stage ms before/after.
+
+No thread-safety work needed (entity-local writes). No other call sites.
+
+## Affected files
+
+- `engine/prefabs/irreden/update/systems/system_periodic_idle_position_offset.hpp`
+  — the `kConcurrency` (+ optional `kGrainSize`) line.
+
+## Acceptance criteria
+
+- Builds clean (`fleet-build --target IRPerfGrid`); validator passes.
+- Output **bit-identical** to SERIAL (per-entity modifier upserts are independent).
+- `update` ms before/after recorded on IRPerfGrid `voxel_set` zoom8
+  (`--auto-profile 240`).
+
+## Gotchas
+
+- The per-entity tick form populates `prepareRangedTick` (required for
+  PARALLEL_FOR); only the per-archetype *batch* form is rejected — this system
+  uses the per-entity form, so it's eligible.
+- Priority note: update is secondary to render (voxelStage1 32ms) for FPS — this
+  is a free floor-lowering win, not a frame-gate fix.

--- a/.fleet/plans/issue-1803.md
+++ b/.fleet/plans/issue-1803.md
@@ -1,0 +1,63 @@
+# Plan: UPDATE_VOXEL_SET_CHILDREN → PARALLEL_FOR (thread-safe pool writes)
+
+- **Issue:** #1803 (carve-off of #1052) — **parked** until #1294 render chain lands
+- **Model:** opus
+- **Date:** 2026-06-13
+
+## Scope
+
+Make `UPDATE_VOXEL_SET_CHILDREN`'s 262K-entity tick `Concurrency::PARALLEL_FOR`
+by making its shared `C_VoxelPool` writes thread-safe. One of the two dominant
+UPDATE costs (#1740).
+
+## Verified current state
+
+- `engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp` —
+  SERIAL; per-entity-id tick form (`:49`). 262K `isRangeVisible`/position loop.
+- Shared-state hazards in the tick:
+  - **`pool.queuePositionRange(startIdx, count)`** (`component_voxel_pool.hpp:523-531`)
+    → `m_pendingPositionRanges.emplace_back` — **races under concurrent ticks**
+    (the real blocker).
+  - `markChunkWorldBoundsDirty()` (`:373`) → idempotent bool write (benign).
+  - `setEntityIdForRange(...)` (`:234-248`) → `std::fill` over **disjoint**
+    per-entity voxel spans (safe by allocation invariant) + idempotent
+    `m_entityIdsDirty` bool.
+- No unified per-worker-merge harness exists; precedent is the `thread_local`
+  buffer pattern in `system_voxel_to_trixel.hpp`.
+
+## Approach (single path)
+
+1. Per-worker `thread_local std::vector<std::pair<size_t,size_t>>` accumulates
+   pending position ranges during the parallelFor.
+2. After the implicit parallelFor barrier, a main-thread merge appends all worker
+   queues into `pool.m_pendingPositionRanges` (deterministic set; order-independent
+   downstream).
+3. Confirm the disjoint-span invariant for `setEntityIdForRange` (each entity owns
+   `[voxelStartIdx_, voxelStartIdx_+numVoxels_)`); if disjoint, the `std::fill` +
+   bool writes are safe under concurrency.
+4. Convert the tick to the ranged form and tag `PARALLEL_FOR` (singleton group).
+
+Aligns with epic #226 Phase 1 (per-worker deferred state); roll the `thread_local`
+pattern rather than blocking on a #226 primitive.
+
+## Affected files
+
+- `engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp` —
+  ranged-tick conversion, thread_local accumulator + merge, `kConcurrency`.
+- `engine/prefabs/irreden/voxel/components/component_voxel_pool.hpp` — if a
+  thread-safe `queuePositionRange` variant / merge helper is cleaner there.
+
+## Acceptance criteria
+
+- Output **bit-identical** (cull-on path); merged `m_pendingPositionRanges`
+  contains the same set of ranges as serial (order-independent).
+- Measured `update` ms reduction on IRPerfGrid `voxel_set` zoom8.
+- `validateAllPipelineGroups` passes; builds clean both hosts.
+
+## Gotchas
+
+- Verify the disjoint-span invariant before relying on it for
+  `setEntityIdForRange` — overlapping spans would make the `std::fill` a real race.
+- The cull-gate (`isRangeVisible`, #1740) stays — parallelize the loop, don't drop
+  the gate.
+- Priority: parked behind #1294; update is secondary to render for FPS.

--- a/.fleet/plans/issue-1804.md
+++ b/.fleet/plans/issue-1804.md
@@ -1,0 +1,59 @@
+# Plan: PROPAGATE_TRANSFORM intra-node row-range parallelism
+
+- **Issue:** #1804 (carve-off of #1052) — **parked** until #1294 render chain lands
+- **Model:** opus
+- **Date:** 2026-06-13
+
+## Scope
+
+Give `PROPAGATE_TRANSFORM` within-node row parallelism so a single large archetype
+node (IRPerfGrid's 262K-entity node) splits across workers. The other dominant
+UPDATE cost (#1740).
+
+## Verified current state
+
+- `engine/prefabs/irreden/update/systems/system_propagate_transform.hpp` — already
+  uses `IRJob::parallelFor` (`:169`) but with `kGrainSize=1` (`:75`), **one task
+  per archetype node** at each depth level. Two-pass: beginTick topo-sorts nodes
+  into `levels_[depth][]`; the dispatch loop (`:125-171`) resolves each level's
+  parent transforms on the main thread, then fans archetypes out.
+- **Confirmed single-node degeneracy:** when all 262K entities live in ONE
+  archetype node, that depth level has n=1 → `parallelFor(0, 1, 1, …)` → one task →
+  `composeNode` (`:278-355`) iterates 262K rows **serially** on one worker.
+- `composeNode` writes each entity's own `C_WorldTransform[i]` from its own
+  `C_LocalTransform[i]` + a read-only (already-composed) parent → **disjoint row
+  ranges are race-free**. No shared accumulator needed.
+
+## Approach (single path)
+
+1. Refactor `composeRange` (`:145-155`) to take `(ArchetypeNode* node, int rowBegin,
+   int rowEnd)` and iterate rows, instead of indexing archetypes.
+2. For each level, dispatch `parallelFor(0, node->length_, grainSize, …)` over the
+   node's **rows** (hybrid: when a level has many small nodes, keep node-granularity;
+   when a node is large, split its rows — pick by `node->length_` vs a threshold).
+3. **Preserve the per-level barrier** (`:130-141`): level d's `C_WorldTransform`
+   must be fully composed before level d+1's parent lookups. Keep level iteration
+   serial; only parallelize rows within a level.
+
+Aligns with epic #226 Phase 1.
+
+## Affected files
+
+- `engine/prefabs/irreden/update/systems/system_propagate_transform.hpp` —
+  `composeRange` signature + the per-level dispatch loop.
+
+## Acceptance criteria
+
+- Output **bit-identical** `C_WorldTransform` on BOTH single-archetype (IRPerfGrid)
+  and multi-archetype (parented hierarchy) workloads — the hybrid must not regress
+  the existing inter-node path.
+- Measured `update` ms reduction on IRPerfGrid `voxel_set` zoom8.
+- `validateAllPipelineGroups` passes; builds clean both hosts.
+
+## Gotchas
+
+- The per-level barrier is load-bearing — a child level's rows must never compose
+  before the parent level finishes. Parallelize rows *within* a level only.
+- Keep the inter-node parallelism for many-small-node workloads; this adds
+  intra-node splitting, it doesn't replace the level partition.
+- Priority: parked behind #1294; update is secondary to render for FPS.


### PR DESCRIPTION
## Summary
- Per-issue architect plans for the #1052 CPU update-parallelization decomposition, committed so the `fleet-queue-ingest` plan gate passes cross-host.
- Re-profiled UPDATE (post-#1778): **update = 14ms zoom8, secondary to render** (voxelStage1 32ms is the gate). Decomposed into:
  - `.fleet/plans/issue-1802.md` — PERIODIC_IDLE_POSITION_OFFSET → PARALLEL_FOR `[sonnet]` (cheap win, queue-ready).
  - `.fleet/plans/issue-1803.md` — UPDATE_VOXEL_SET_CHILDREN → PARALLEL_FOR `[opus]` (parked).
  - `.fleet/plans/issue-1804.md` — PROPAGATE_TRANSFORM intra-node row split `[opus]` (parked).

## Test plan
- [x] All cited symbols verified to resolve with file:line (`upsertBySourceInPlace`, `queuePositionRange`/`m_pendingPositionRanges`, `composeNode`/`composeRange`, `setEntityIdForRange`).
- [x] Info-isolation scan clean.
- [ ] Docs-only — no build/screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)