### PR TITLE
render: Hi-Z distance mip chain build stage (occlusion cull child 1/3) (#1798)

### DIFF
--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -30,6 +30,7 @@
 #include <irreden/render/fog_of_war.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/render/systems/system_bake_sun_shadow_map.hpp>
+#include <irreden/render/systems/system_build_distance_hiz.hpp>
 #include <irreden/render/systems/system_build_light_occlusion_grid.hpp>
 #include <irreden/render/camera_controls.hpp>
 #include <irreden/render/systems/system_compute_light_volume.hpp>
@@ -625,6 +626,10 @@ void initSystems() {
             IRSystem::createSystem<IRSystem::VOXEL_TO_TRIXEL_STAGE_1>(),
             IRSystem::createSystem<IRSystem::SHAPES_TO_TRIXEL>(),
             IRSystem::createSystem<IRSystem::COMPUTE_VOXEL_AO>(),
+            // Hi-Z max-depth mip chain over the (now final) distance texture,
+            // for next frame's voxel occlusion cull (#1294 child 1/3). Produces
+            // only — renders unchanged this PR.
+            IRSystem::createSystem<IRSystem::COMPUTE_DISTANCE_HIZ>(),
             IRSystem::createSystem<IRSystem::BAKE_SUN_SHADOW_MAP>(),
             IRSystem::createSystem<IRSystem::COMPUTE_SUN_SHADOW>(),
             IRSystem::createSystem<IRSystem::COMPUTE_LIGHT_VOLUME>(),

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -45,6 +45,7 @@
 #include <irreden/render/systems/system_update_joint_matrices.hpp>
 #include <irreden/common/rotation_mode.hpp>
 #include <irreden/render/systems/system_shapes_to_trixel.hpp>
+#include <irreden/render/systems/system_build_distance_hiz.hpp>
 #include <irreden/render/systems/system_build_light_occlusion_grid.hpp>
 #include <irreden/render/systems/system_compute_voxel_ao.hpp>
 #include <irreden/render/systems/system_resolve_per_axis_screen_depth.hpp>
@@ -335,10 +336,8 @@ int main(int argc, char **argv) {
         // on-screen effect as which voxels rasterize, so the diff isolates
         // voxel retention. (The interactive F10 path keeps shadows.)
         IRRender::setSunShadowsEnabled(false);
-        IR_LOG_INFO(
-            "Cull-validate: sun shadows disabled to isolate voxel retention from "
-            "shadow-feeder coupling"
-        );
+        IR_LOG_INFO("Cull-validate: sun shadows disabled to isolate voxel retention from "
+                    "shadow-feeder coupling");
     }
     IREngine::gameLoop();
     return 0;
@@ -399,6 +398,10 @@ void initSystems() {
             IRSystem::createSystem<IRSystem::VOXEL_TO_TRIXEL_STAGE_1>(),
             IRSystem::createSystem<IRSystem::SHAPES_TO_TRIXEL>(),
             IRSystem::createSystem<IRSystem::COMPUTE_VOXEL_AO>(),
+            // Hi-Z max-depth mip chain over the (now final) distance texture,
+            // for next frame's voxel occlusion cull (#1294 child 1/3). Produces
+            // only — renders unchanged this PR.
+            IRSystem::createSystem<IRSystem::COMPUTE_DISTANCE_HIZ>(),
             IRSystem::createSystem<IRSystem::RESOLVE_PER_AXIS_SCREEN_DEPTH>(),
             IRSystem::createSystem<IRSystem::BAKE_SUN_SHADOW_MAP>(),
             IRSystem::createSystem<IRSystem::COMPUTE_SUN_SHADOW>(),

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -8,10 +8,15 @@ the ECS surface.
 ## Key components
 
 - `C_TriangleCanvasTextures` — owns 3 GPU textures (color / distance /
-  entity-id). **Created in ctor, destroyed in `onDestroy()`.** The
-  color/distance/entity-id format triple is centralized in
+  entity-id) plus a Hi-Z max-depth mip chain over the distance texture
+  (`hiZMips_`, #1294). **All created in ctor, destroyed in `onDestroy()`.**
+  The color/distance/entity-id format triple is centralized in
   `detail::makeCanvas*Texture` factories in its header so other canvas
-  components can't drift from it.
+  components can't drift from it; `detail::makeHiZMipChain` builds the
+  downsampled R32I levels (conceptual level 0 is the distance texture).
+  `COMPUTE_DISTANCE_HIZ` downsample-maxes the chain each frame for the
+  voxel occlusion cull (`docs/design/voxel-occlusion-culling.md`); the
+  chain is produced-only until the chunk-occlusion pre-pass consumes it.
 - `C_PerAxisTrixelCanvases` — three per-axis (X/Y/Z) trixel texture sets
   for smooth rotation (#1308; `docs/design/per-axis-trixel-canvas-rotation.md`).
   Same GPU-RAII pattern as `C_TriangleCanvasTextures` but allocated

--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
@@ -6,6 +6,9 @@
 
 #include <irreden/render/texture.hpp>
 
+#include <utility>
+#include <vector>
+
 using namespace IRMath;
 using namespace IRRender;
 
@@ -50,6 +53,32 @@ inline std::pair<ResourceId, Texture2D *> makeCanvasEntityIdTexture(ivec2 size) 
     );
 }
 
+// Hi-Z (hierarchical max-depth) mip chain over the distance texture, for the
+// voxel-pool occlusion cull (#1294 / docs/design/voxel-occlusion-culling.md).
+// Returns the DOWNSAMPLED levels 1..N only — conceptual level 0 IS the
+// canvas's own R32I distance texture, so the full-res copy is avoided. Each
+// returned level is ceil(prev / 2) in each axis (ceil-division so every source
+// texel maps into exactly one destination texel's 2x2 footprint; see
+// c_build_distance_hiz.glsl), R32I to match the distance encoding, down to 1x1.
+// A 1x1-or-smaller canvas yields an empty chain.
+inline std::vector<std::pair<ResourceId, Texture2D *>> makeHiZMipChain(ivec2 size) {
+    std::vector<std::pair<ResourceId, Texture2D *>> mips;
+    ivec2 levelSize = size;
+    while (levelSize.x > 1 || levelSize.y > 1) {
+        levelSize =
+            ivec2(IRMath::max(1, (levelSize.x + 1) / 2), IRMath::max(1, (levelSize.y + 1) / 2));
+        mips.push_back(IRRender::createResource<IRRender::Texture2D>(
+            TextureKind::TEXTURE_2D,
+            levelSize.x,
+            levelSize.y,
+            TextureFormat::R32I,
+            TextureWrap::CLAMP_TO_EDGE,
+            TextureFilter::NEAREST
+        ));
+    }
+    return mips;
+}
+
 } // namespace detail
 
 struct C_TriangleCanvasTextures {
@@ -57,12 +86,22 @@ struct C_TriangleCanvasTextures {
     std::pair<ResourceId, Texture2D *> textureTriangleColors_;
     std::pair<ResourceId, Texture2D *> textureTriangleDistances_;
     std::pair<ResourceId, Texture2D *> textureTriangleEntityIds_;
+    // Hi-Z max-depth mip chain over textureTriangleDistances_ (#1294 child 1/3).
+    // Conceptual level 0 IS textureTriangleDistances_; these are the downsampled
+    // levels 1..N (each ceil(prev / 2), R32I), holding the per-texel MAX
+    // (farthest) encoded distance over the source footprint. Produced each frame
+    // by COMPUTE_DISTANCE_HIZ and consumed NEXT frame by the chunk-occlusion
+    // pre-pass (child 2). Empty/background texels carry the 65535 sentinel — the
+    // largest encoded value — so any footprint that still sees background keeps
+    // the max at 65535 = "never occlude", the conservative direction.
+    std::vector<std::pair<ResourceId, Texture2D *>> hiZMips_;
 
     C_TriangleCanvasTextures(ivec2 size)
         : size_{size}
         , textureTriangleColors_{detail::makeCanvasColorTexture(size)}
         , textureTriangleDistances_{detail::makeCanvasDistanceTexture(size)}
-        , textureTriangleEntityIds_{detail::makeCanvasEntityIdTexture(size)} {}
+        , textureTriangleEntityIds_{detail::makeCanvasEntityIdTexture(size)}
+        , hiZMips_{detail::makeHiZMipChain(size)} {}
 
     C_TriangleCanvasTextures() {}
 
@@ -70,6 +109,22 @@ struct C_TriangleCanvasTextures {
         IRRender::destroyResource<Texture2D>(textureTriangleColors_.first);
         IRRender::destroyResource<Texture2D>(textureTriangleDistances_.first);
         IRRender::destroyResource<Texture2D>(textureTriangleEntityIds_.first);
+        for (const auto &mip : hiZMips_) {
+            IRRender::destroyResource<Texture2D>(mip.first);
+        }
+    }
+
+    // Number of downsampled Hi-Z levels (levels 1..N). Level 0 is
+    // getTextureDistances(); the cull samples whichever level's texel footprint
+    // covers a pool-chunk's iso AABB.
+    int hiZMipCount() const {
+        return static_cast<int>(hiZMips_.size());
+    }
+
+    // Downsampled Hi-Z level `mip` (0-based over hiZMips_, i.e. conceptual mip
+    // level `mip + 1`). Level 0 of the pyramid is getTextureDistances().
+    const Texture2D *getHiZMip(int mip) const {
+        return hiZMips_[mip].second;
     }
 
     const Texture2D *getTextureColors() const {

--- a/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
+++ b/engine/prefabs/irreden/render/components/component_triangle_canvas_textures.hpp
@@ -124,6 +124,7 @@ struct C_TriangleCanvasTextures {
     // Downsampled Hi-Z level `mip` (0-based over hiZMips_, i.e. conceptual mip
     // level `mip + 1`). Level 0 of the pyramid is getTextureDistances().
     const Texture2D *getHiZMip(int mip) const {
+        IR_ASSERT(mip < hiZMipCount(), "getHiZMip: mip out of range");
         return hiZMips_[mip].second;
     }
 

--- a/engine/prefabs/irreden/render/systems/system_build_distance_hiz.hpp
+++ b/engine/prefabs/irreden/render/systems/system_build_distance_hiz.hpp
@@ -1,0 +1,101 @@
+#ifndef SYSTEM_BUILD_DISTANCE_HIZ_H
+#define SYSTEM_BUILD_DISTANCE_HIZ_H
+
+// Hi-Z (hierarchical max-depth) distance mip-chain build (#1294 child 1/3;
+// docs/design/voxel-occlusion-culling.md § Implementation sketch step 1).
+//
+// For each world canvas, downsample-max the R32I distance texture into the
+// canvas's hiZMips_ chain: one compute dispatch per level, reading the prior
+// level and writing the per-texel MAX (farthest) of its 2x2 source footprint.
+// Conceptual level 0 is the distance texture itself, so the chain holds the
+// downsampled levels 1..N. A max pyramid answers "the farthest visible surface
+// over this footprint"; next frame's chunk-occlusion pre-pass (child 2) culls a
+// pool-chunk only when its nearest depth is strictly behind that max.
+//
+// This PR PRODUCES the Hi-Z only — nothing consumes it yet, so render output is
+// byte-identical. The chunk-occlusion pre-pass (child 2) and the off-by-default
+// gate (child 3) follow in the blocked_by chain.
+//
+// Pipeline order: must run after every stage that writes trixelDistances
+// (VOXEL_TO_TRIXEL_STAGE_1, SHAPES_TO_TRIXEL) and after COMPUTE_VOXEL_AO, so the
+// distance texture is final — register it immediately after COMPUTE_VOXEL_AO.
+
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_profile.hpp>
+#include <irreden/ir_render.hpp>
+#include <irreden/ir_system.hpp>
+
+#include <irreden/render/components/component_triangle_canvas_textures.hpp>
+#include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
+
+#include <cstddef>
+
+using namespace IRComponents;
+using namespace IRMath;
+using namespace IRRender;
+
+namespace IRSystem {
+
+// Matches local_size_{x,y} in c_build_distance_hiz.glsl (and the Metal
+// threadgroup size registered in metal_pipeline.cpp).
+constexpr int kBuildDistanceHiZGroupSize = 16;
+
+template <> struct System<COMPUTE_DISTANCE_HIZ> {
+    ShaderProgram *program_ = nullptr;
+
+    void tick(
+        const C_TriangleCanvasTextures &canvasTextures, const C_TrixelCanvasRenderBehavior &behavior
+    ) {
+        // GUI canvases carry no world-space geometry and never feed the voxel
+        // occlusion cull, so a Hi-Z over their distances is wasted work — skip
+        // (mirrors COMPUTE_VOXEL_AO's guard). A 1x1 canvas yields no levels.
+        if (!behavior.useCameraPositionIso_)
+            return;
+        if (canvasTextures.hiZMips_.empty())
+            return;
+        IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_RENDER);
+
+        // Level 0 is the canvas distance texture; each subsequent level reads
+        // the previous level's output (a barrier per level enforces that RAW
+        // dependency — the chain is inherently sequential).
+        const Texture2D *src = canvasTextures.getTextureDistances();
+        for (std::size_t level = 0; level < canvasTextures.hiZMips_.size(); ++level) {
+            const Texture2D *dst = canvasTextures.hiZMips_[level].second;
+            src->bindAsImage(0, TextureAccess::READ_ONLY, TextureFormat::R32I);
+            dst->bindAsImage(1, TextureAccess::WRITE_ONLY, TextureFormat::R32I);
+
+            const uvec2 dstSize = dst->getSize();
+            const int groupsX =
+                IRMath::divCeil(static_cast<int>(dstSize.x), kBuildDistanceHiZGroupSize);
+            const int groupsY =
+                IRMath::divCeil(static_cast<int>(dstSize.y), kBuildDistanceHiZGroupSize);
+            IRRender::device()->dispatchCompute(groupsX, groupsY, 1);
+            IRRender::device()->memoryBarrier(BarrierType::SHADER_IMAGE_ACCESS);
+
+            src = dst;
+        }
+    }
+
+    void beginTick() {
+        program_->use();
+    }
+
+    static SystemId create() {
+        IRRender::createNamedResource<ShaderProgram>(
+            "BuildDistanceHiZProgram",
+            std::vector{ShaderStage{IRRender::kFileCompBuildDistanceHiZ, ShaderType::COMPUTE}}
+        );
+
+        SystemId systemId = registerSystem<
+            COMPUTE_DISTANCE_HIZ,
+            C_TriangleCanvasTextures,
+            C_TrixelCanvasRenderBehavior>("BuildDistanceHiZ");
+        auto *p = getSystemParams<System<COMPUTE_DISTANCE_HIZ>>(systemId);
+        p->program_ = IRRender::getNamedResource<ShaderProgram>("BuildDistanceHiZProgram");
+        return systemId;
+    }
+};
+
+} // namespace IRSystem
+
+#endif /* SYSTEM_BUILD_DISTANCE_HIZ_H */

--- a/engine/render/include/irreden/render/shader_names.hpp
+++ b/engine/render/include/irreden/render/shader_names.hpp
@@ -29,6 +29,9 @@ const char *const kFileCompShapesToTrixel = "shaders/c_shapes_to_trixel.glsl";
 const char *const kFileCompLightingToTrixel = "shaders/c_lighting_to_trixel.glsl";
 const char *const kFileCompFogToTrixel = "shaders/c_fog_to_trixel.glsl";
 const char *const kFileCompComputeVoxelAO = "shaders/c_compute_voxel_ao.glsl";
+// Hi-Z (max-depth) distance mip-chain build for voxel occlusion culling
+// (#1294 child 1/3). Metal mirror in metal/c_build_distance_hiz.metal.
+const char *const kFileCompBuildDistanceHiZ = "shaders/c_build_distance_hiz.glsl";
 // Smooth camera Z-yaw per-axis sun-shadow resolve (#1435): the scatter pass
 // re-projects the three face-local per-axis voxel canvases into a screen-space
 // front-most iso-depth scratch SSBO; the blit pass materializes that scratch

--- a/engine/render/src/metal/metal_pipeline.cpp
+++ b/engine/render/src/metal/metal_pipeline.cpp
@@ -57,6 +57,9 @@ MTL::Size threadgroupSizeForFunctionName(const std::string &functionName) {
     if (functionName == "c_compute_voxel_ao") {
         return MTL::Size(16, 16, 1);
     }
+    if (functionName == "c_build_distance_hiz") {
+        return MTL::Size(16, 16, 1);
+    }
     if (functionName == "c_compute_sun_shadow") {
         return MTL::Size(16, 16, 1);
     }

--- a/engine/render/src/shaders/c_build_distance_hiz.glsl
+++ b/engine/render/src/shaders/c_build_distance_hiz.glsl
@@ -1,0 +1,51 @@
+#version 450 core
+
+// Hi-Z (hierarchical max-depth) downsample for voxel occlusion culling
+// (#1294 child 1/3; docs/design/voxel-occlusion-culling.md § Implementation
+// sketch step 1). One dispatch per mip level: reads the previous level's
+// distance image and writes each destination texel the MAX (farthest) of its
+// (up to) 2x2 source footprint. Conceptual level 0 is the canvas
+// trixelDistances; this pass produces the downsampled levels on
+// C_TriangleCanvasTextures::hiZMips_.
+//
+// Why MAX: a coarse texel answers "the farthest visible surface over this
+// footprint". The chunk-occlusion pre-pass (child 2) culls a pool-chunk only
+// when its NEAREST depth is strictly behind that max — i.e. closer geometry
+// covers the whole footprint. The empty/background sentinel (65535) is the
+// largest encoded value, so any footprint still seeing background keeps the
+// max at 65535 = "never occlude" — the conservative direction (a false
+// positive is a visible hole; a false negative is only lost savings).
+//
+// The raw R32I encoded distance is max'd directly: the main-canvas encoding
+// packs depth in bits [31:2] (face slot in [1:0]), so larger encoded value
+// <=> farther, and an integer max over encoded values is a faithful max-depth
+// pyramid. Child 2 decodes (>> 2) consistently on both sides of its compare.
+//
+// Ceil-division destination sizing (CPU side, makeHiZMipChain) guarantees every
+// source texel maps into exactly one destination texel's 2x2 block, so the
+// clamp on the +1 taps only ever re-reads an in-bounds texel (harmless for max)
+// and no source texel is dropped from the reduction at odd source dimensions.
+//
+// Mirror: shaders/metal/c_build_distance_hiz.metal.
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(r32i, binding = 0) readonly uniform iimage2D srcDistances;
+layout(r32i, binding = 1) writeonly uniform iimage2D dstHiZ;
+
+void main() {
+    ivec2 dst = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 dstSize = imageSize(dstHiZ);
+    if (dst.x >= dstSize.x || dst.y >= dstSize.y) return;
+
+    ivec2 srcSize = imageSize(srcDistances);
+    ivec2 maxCoord = srcSize - ivec2(1);
+    ivec2 base = dst * 2;
+
+    int m = imageLoad(srcDistances, clamp(base, ivec2(0), maxCoord)).x;
+    m = max(m, imageLoad(srcDistances, clamp(base + ivec2(1, 0), ivec2(0), maxCoord)).x);
+    m = max(m, imageLoad(srcDistances, clamp(base + ivec2(0, 1), ivec2(0), maxCoord)).x);
+    m = max(m, imageLoad(srcDistances, clamp(base + ivec2(1, 1), ivec2(0), maxCoord)).x);
+
+    imageStore(dstHiZ, dst, ivec4(m, 0, 0, 0));
+}

--- a/engine/render/src/shaders/metal/c_build_distance_hiz.metal
+++ b/engine/render/src/shaders/metal/c_build_distance_hiz.metal
@@ -1,0 +1,30 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Mirrors shaders/c_build_distance_hiz.glsl. Hi-Z (hierarchical max-depth)
+// downsample for voxel occlusion culling (#1294 child 1/3). One dispatch per
+// mip level: reads the previous distance level, writes each destination texel
+// the MAX of its (up to) 2x2 source footprint. See the GLSL for the
+// conservative-max rationale, the raw-encoded-int max justification, and the
+// ceil-division coverage guarantee that makes the clamp on the +1 taps safe.
+
+kernel void c_build_distance_hiz(
+    texture2d<int, access::read> srcDistances [[texture(0)]],
+    texture2d<int, access::write> dstHiZ [[texture(1)]],
+    uint3 globalId [[thread_position_in_grid]]
+) {
+    int2 dst = int2(globalId.xy);
+    int2 dstSize = int2(int(dstHiZ.get_width()), int(dstHiZ.get_height()));
+    if (dst.x >= dstSize.x || dst.y >= dstSize.y) return;
+
+    int2 srcSize = int2(int(srcDistances.get_width()), int(srcDistances.get_height()));
+    int2 maxCoord = srcSize - int2(1);
+    int2 base = dst * 2;
+
+    int m = srcDistances.read(uint2(clamp(base, int2(0), maxCoord))).x;
+    m = max(m, srcDistances.read(uint2(clamp(base + int2(1, 0), int2(0), maxCoord))).x);
+    m = max(m, srcDistances.read(uint2(clamp(base + int2(0, 1), int2(0), maxCoord))).x);
+    m = max(m, srcDistances.read(uint2(clamp(base + int2(1, 1), int2(0), maxCoord))).x);
+
+    dstHiZ.write(int4(m, 0, 0, 0), uint2(dst));
+}

--- a/engine/system/include/irreden/system/ir_system_types.hpp
+++ b/engine/system/include/irreden/system/ir_system_types.hpp
@@ -166,6 +166,11 @@ enum SystemName {
     SHAPES_TO_TRIXEL,
     BUILD_LIGHT_OCCLUSION_GRID,
     COMPUTE_VOXEL_AO,
+    // Hi-Z (max-depth) distance mip-chain build for voxel occlusion culling
+    // (#1294 child 1/3). Runs after the geometry + AO passes (distances final)
+    // and produces C_TriangleCanvasTextures::hiZMips_ for next frame's
+    // chunk-occlusion pre-pass; produces only — no consumer this PR.
+    COMPUTE_DISTANCE_HIZ,
     RESOLVE_PER_AXIS_SCREEN_DEPTH,
     BAKE_SUN_SHADOW_MAP,
     COMPUTE_SUN_SHADOW,


### PR DESCRIPTION
## Summary

Child 1/3 of the voxel-pool occlusion-cull epic (#1294). Adds
`COMPUTE_DISTANCE_HIZ` — a downsample-max compute pass that builds a
hierarchical max-depth (Hi-Z) mip chain over each world canvas's R32I
distance texture.

- New `hiZMips_` chain on `C_TriangleCanvasTextures`: the downsampled
  R32I levels (conceptual level 0 IS the distance texture), ceil-halved
  down to 1×1, ctor-allocated + `onDestroy`-freed beside the existing
  canvas textures (`detail::makeHiZMipChain`).
- New `c_build_distance_hiz.{glsl,metal}`: per dest texel, the MAX of its
  2×2 source footprint. One dispatch per level, barrier between (the
  chain is inherently sequential). No uniforms — sizes via `imageSize` /
  `get_width`.
- `COMPUTE_DISTANCE_HIZ` system + `SystemName` entry; registered after
  `COMPUTE_VOXEL_AO` (distances final) in `perf_grid` + `shape_debug`.
- `metal_pipeline.cpp`: 16×16 threadgroup for the new kernel.

**Why max:** a coarse texel answers "the farthest visible surface over
this footprint"; the chunk-occlusion pre-pass (child 2) culls a chunk
only when its nearest depth is strictly behind that max. The 65535
empty/background sentinel is the largest encoded value, so any footprint
still seeing background keeps the max at "never occlude" — the
conservative direction (false positive = visible hole; false negative =
lost savings only). Raw R32I encoded distances (depth in bits [31:2])
are max'd directly, so an integer max is a faithful max-depth pyramid the
cull decodes consistently.

**Scope:** PRODUCES the Hi-Z only — nothing consumes it yet. Cost is
unconditional per-frame on world canvases until child 3 adds the
off-by-default gate (per the plan's blocked_by sequencing). Build is
`O(canvas pixels)` (≈ AO scale), no CPU allocations / `getComponent` in
the tick.

## Verification

- **Renders byte-identical to `origin/master`** — all 21 `IRShapeDebug`
  `--auto-screenshot` shots are **md5-identical** between the branch base
  and this branch (before/after pixel diff). No screenshots attached:
  the output is provably unchanged, so before/after pairs would be 28
  identical images. This is the stronger artifact for a produce-only PR.
- **Hi-Z actually builds** — a temporary diagnostic (since removed)
  confirmed the pass dispatches all 10 levels on `voxel_set` zoom8
  (canvas 642×722, top mip 321×361 = ⌈642/2⌉×⌈722/2⌉).
- Builds clean: `IRShapeDebug` + `IRPerfGrid` (Linux/OpenGL). Metal
  shader written for parity (validate on macOS via cross-host smoke).

## Test plan

- [ ] Reviewer: confirm the max-downsample + 65535-sentinel reasoning is
      conservative (no false-positive culls possible downstream).
- [ ] Cross-host: macOS/Metal smoke (reviewer adds `fleet:needs-macos-smoke`).

Closes #1798

🤖 Generated with [Claude Code](https://claude.com/claude-code)