### PR TITLE
render: occlusion-cull gating + pixel-identical verification + realized-delta measurement (#1800)

### DIFF
--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -150,6 +150,24 @@ CliOverrides g_cliOverrides{};
 int g_autoProfileFrames = 0;
 int g_autoProfileCount = 0;
 int g_autoWarmupFrames = 0;
+// --occlusion-cull (#1294 child 3/3): force the voxel-pool chunk-occlusion HZB
+// pre-pass ON (off by default in the engine). This is the measurement + verify
+// toggle for the cull: pair `--mode voxel_set --auto-profile` runs with and
+// without it to read the realized `voxelStage1` reduction (the 0.97 ceiling on
+// the many-small-entity grid), and pair `--auto-screenshot` runs to prove the
+// output is bit-identical cull-on vs cull-off (fully-occluded voxels write
+// nothing, so any diff would be a cull bug). Intentional drift: on a
+// discontinuous camera move the cull self-disables for one frame (stale Hi-Z),
+// which can produce a one-frame silhouette pop — by design, not a regression.
+bool g_occlusionCull = false;
+// --no-overlay (#1294 child 3/3): drop PERF_STATS_OVERLAY from the render
+// pipeline. The overlay bakes live CPU/GPU timing text into every frame, which
+// is run-variant and defeats a bit-identical screenshot compare. Off (overlay
+// present) by default; pass it to capture a deterministic frame, e.g. to prove
+// cull-on renders pixel-identical to cull-off on the heavily-occluded voxel_set
+// scene. The --auto-profile path enables frame timing explicitly, so timing
+// still works under --no-overlay.
+bool g_noOverlay = false;
 
 PerfGridMode parseMode(const std::string &value) {
     if (value == "voxel_set" || value == "voxel") {
@@ -284,6 +302,10 @@ void parseArgs(int argc, char **argv) {
                     ++i;
                 }
             }
+        } else if (std::strcmp(argv[i], "--occlusion-cull") == 0) {
+            g_occlusionCull = true;
+        } else if (std::strcmp(argv[i], "--no-overlay") == 0) {
+            g_noOverlay = true;
         } else if (std::strcmp(argv[i], "--mode") == 0 && i + 1 < argc) {
             g_cliOverrides.mode_ = parseMode(argv[i + 1]);
             g_cliOverrides.modeSet_ = true;
@@ -571,6 +593,13 @@ int main(int argc, char **argv) {
     initCommands();
     initEntities();
 
+    if (g_occlusionCull) {
+        IRRender::setVoxelOcclusionCullEnabled(true);
+        IR_LOG_INFO("Voxel chunk-occlusion cull forced ON (--occlusion-cull, #1294 child 3/3). "
+                    "Output stays bit-identical to cull-off; one-frame silhouette pop on a "
+                    "discontinuous camera move is intentional drift (stale Hi-Z self-disable).");
+    }
+
     IRRender::setCameraPosition2DIso(vec2(0.0f, 0.0f));
     IRRender::setCameraZoom(g_settings.initialZoom_);
     IR_LOG_INFO(
@@ -635,12 +664,21 @@ void initSystems() {
             IRSystem::createSystem<IRSystem::COMPUTE_LIGHT_VOLUME>(),
             IRSystem::createSystem<IRSystem::LIGHTING_TO_TRIXEL>(),
             IRSystem::createSystem<IRSystem::FOG_TO_TRIXEL>(),
-            // PERF_STATS_OVERLAY mutates the C_TextSegment of its tracked entity;
-            // TEXT_TO_TRIXEL rasterizes the text onto the GUI canvas; the canvas
-            // is composited into the framebuffer by TRIXEL_TO_FRAMEBUFFER. Order
-            // must be overlay → text → trixel-to-fb for the HUD to land on
-            // screen — matches the lighting demo wiring.
-            IRSystem::createSystem<IRSystem::PERF_STATS_OVERLAY>(),
+        }
+    );
+    // PERF_STATS_OVERLAY mutates the C_TextSegment of its tracked entity;
+    // TEXT_TO_TRIXEL rasterizes the text onto the GUI canvas; the canvas
+    // is composited into the framebuffer by TRIXEL_TO_FRAMEBUFFER. Order
+    // must be overlay → text → trixel-to-fb for the HUD to land on
+    // screen — matches the lighting demo wiring. --no-overlay drops it so a
+    // captured frame is deterministic (the HUD's live timing text is otherwise
+    // run-variant, defeating a bit-identical cull-on vs cull-off compare).
+    if (!g_noOverlay) {
+        renderPipeline.push_back(IRSystem::createSystem<IRSystem::PERF_STATS_OVERLAY>());
+    }
+    renderPipeline.insert(
+        renderPipeline.end(),
+        {
             IRSystem::createSystem<IRSystem::TEXT_TO_TRIXEL>(),
             IRSystem::createSystem<IRSystem::TRIXEL_TO_FRAMEBUFFER>(),
             IRSystem::createSystem<IRSystem::FRAMEBUFFER_TO_SCREEN>(),

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -21,7 +21,14 @@ the ECS surface.
   last frame's chain and ANDing occluded chunks out of `ChunkVisibility`
   before the compact pass — but is gated off by default
   (`IRRender::setVoxelOcclusionCullEnabled`), so the chain stays produced-only
-  in the default pipeline.
+  in the default pipeline. When enabled it also self-disables for one frame
+  after a discontinuous camera move (#1294 child 3/3): `VOXEL_TO_TRIXEL_STAGE_1`
+  `beginTick` compares the camera iso to last frame's and, on a jump over half
+  the visible viewport (cut/teleport/first frame), keeps every chunk that frame
+  — last frame's Hi-Z is the cull's lag source and is stale across a cut. Output
+  is bit-identical cull-on vs cull-off (fully-occluded voxels write nothing); the
+  per-chunk realized payoff is weak vs the per-voxel ceiling (per-voxel follow-on
+  tracked separately).
 - `C_PerAxisTrixelCanvases` — three per-axis (X/Y/Z) trixel texture sets
   for smooth rotation (#1308; `docs/design/per-axis-trixel-canvas-rotation.md`).
   Same GPU-RAII pattern as `C_TriangleCanvasTextures` but allocated

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -239,6 +239,17 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
     Buffer *chunkOcclusionQueryBuf_ = nullptr;
     std::vector<ChunkOcclusionQuery> chunkOcclusionScratch_;
     int maxPoolChunks_ = 0;
+    // One-frame occlusion-cull disable on a discontinuous camera move (#1294
+    // child 3/3, design § 4). The chunk-occlusion pre-pass samples last frame's
+    // Hi-Z; on a camera cut/teleport/first frame that lag source belongs to a
+    // different view, so the projected chunk AABBs would test unrelated depths
+    // and could cull on-screen geometry. When this frame's camera iso jumps more
+    // than a fraction of the visible viewport, the cull is disabled for that one
+    // frame — always the safe direction (keeps every chunk). Resolved once per
+    // frame in beginTick; read by the per-canvas gate.
+    vec2 lastOcclusionCameraIso_ = vec2(0.0f);
+    bool hasLastOcclusionCameraIso_ = false;
+    bool occlusionLagSourceStale_ = false;
     // Per-axis store list-walk split (#1739). While the main canvas's per-axis
     // trixel canvases are active (smooth camera Z-yaw), the compact pass splits
     // its visible-voxel list into three axis-keyed regions — each voxel landing
@@ -757,14 +768,16 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
 
         // Chunk-occlusion HZB pre-pass (#1294 child 2/3, off by default). Gated to
         // the configuration whose distance encoding + shadow-feeder semantics are
-        // verified: enabled, NONE render mode (encodeDepthWithFace = rawDepth*4),
-        // cardinal yaw (!rotating → per-axis canvases are also inactive, so no
-        // split-list interaction), and a non-re-voxelize pool (the frustum mask is
-        // the real per-chunk mask, not the all-visible dest-cell scratch). Any
-        // other state keeps every chunk (conservative). The pass ANDs occluded
-        // chunks out of ChunkVisibility (24) before the compact pass reads it.
-        if (IRRender::getVoxelOcclusionCullEnabled() && frameData_.voxelRenderOptions_.x == 0 &&
-            !rotating && revoxBuffer == nullptr) {
+        // verified: enabled, NOT stale (no discontinuous camera move this frame —
+        // #1294 child 3/3, resolved in beginTick), NONE render mode
+        // (encodeDepthWithFace = rawDepth*4), cardinal yaw (!rotating → per-axis
+        // canvases are also inactive, so no split-list interaction), and a
+        // non-re-voxelize pool (the frustum mask is the real per-chunk mask, not
+        // the all-visible dest-cell scratch). Any other state keeps every chunk
+        // (conservative). The pass ANDs occluded chunks out of ChunkVisibility
+        // (24) before the compact pass reads it.
+        if (IRRender::getVoxelOcclusionCullEnabled() && !occlusionLagSourceStale_ &&
+            frameData_.voxelRenderOptions_.x == 0 && !rotating && revoxBuffer == nullptr) {
             dispatchChunkOcclusion(voxelPool, triangleCanvasTextures, visibleVp);
         }
 
@@ -991,6 +1004,29 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
             if (perAxis.has_value()) {
                 perAxisCanvases_ = perAxis.value();
             }
+        }
+
+        // Resolve the one-frame occlusion-cull disable (#1294 child 3/3, design
+        // § 4). The chunk-occlusion pre-pass tests last frame's Hi-Z, so on a
+        // discontinuous camera move (cut / teleport / first frame) that lag
+        // source is from an unrelated view and the cull is disabled for one
+        // frame. The threshold is half the visible viewport's smaller iso extent
+        // — larger than any single-frame smooth pan but far below a cut. Disabling
+        // is always safe (keeps every chunk); a smooth pan's one-frame-lag pop is
+        // the accepted intentional drift, not a discontinuity. Skipped entirely
+        // when the cull is off so the default config adds nothing — the gate
+        // short-circuits on getVoxelOcclusionCullEnabled() before reading the
+        // staleness flag, and the first enabled frame is treated as a cut.
+        if (IRRender::getVoxelOcclusionCullEnabled()) {
+            const vec2 cameraIso = IRRender::getEffectiveCameraIso();
+            const IsoBounds2D occlusionViewport = IRRender::getCullViewport().isoViewport();
+            const vec2 viewportExtent = occlusionViewport.max_ - occlusionViewport.min_;
+            const float cutThreshold = 0.5f * IRMath::min(viewportExtent.x, viewportExtent.y);
+            occlusionLagSourceStale_ =
+                !hasLastOcclusionCameraIso_ ||
+                IRMath::length(cameraIso - lastOcclusionCameraIso_) > cutThreshold;
+            lastOcclusionCameraIso_ = cameraIso;
+            hasLastOcclusionCameraIso_ = true;
         }
     }
 

--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -388,6 +388,13 @@ def main(argv: list[str] | None = None) -> int:
                     help="Skip the --update-references confirmation prompt.")
     ap.add_argument("--no-build", action="store_true",
                     help="Skip `fleet-build`; assume the target is already built.")
+    ap.add_argument("--demo-arg", action="append", default=[], metavar="ARG",
+                    help="Extra argument passed through to the demo after "
+                         "--auto-screenshot (repeatable). Use to prove a feature "
+                         "flag is output-neutral against the committed references "
+                         "— e.g. `--demo-arg --occlusion-cull` checks the voxel "
+                         "occlusion cull renders bit-identical to the cull-off "
+                         "baseline (#1294 child 3/3).")
     args = ap.parse_args(argv)
 
     worktree = _detect_worktree_root(Path.cwd())
@@ -442,6 +449,7 @@ def main(argv: list[str] | None = None) -> int:
 
     run_cmd = ["fleet-run", "--timeout", str(args.timeout), args.target,
                "--auto-screenshot", str(warmup)]
+    run_cmd.extend(args.demo_arg)
     print("+ " + " ".join(run_cmd), flush=True)
     proc = subprocess.run(run_cmd, cwd=str(worktree),
                           capture_output=True, text=True)


### PR DESCRIPTION
## Summary
Child 3/3 of the voxel-pool occlusion-cull chain (epic #1294; child 1 = #1798/#1806 merged, child 2 = #1799/#1811). Makes the cull shippable + proves it safe.

- **One-frame disable on a discontinuous camera move** (design § 4). `VOXEL_TO_TRIXEL_STAGE_1::beginTick` tracks the camera iso position and, when it jumps more than half the visible viewport in a frame (cut / teleport / first frame), keeps every chunk that frame — last frame's Hi-Z (the cull's lag source) is stale across a cut. Disabling is always the safe direction; a smooth pan's one-frame-lag pop is the accepted intentional drift. The staleness computation is **skipped entirely when the cull is off**, so the default config adds nothing and is byte-identical.
- **IRPerfGrid toggles:** `--occlusion-cull` forces the cull on (off by default in the engine); `--no-overlay` drops the `PERF_STATS_OVERLAY` HUD whose live timing text is run-variant and would defeat a bit-identical screenshot compare.
- **render-verify `--demo-arg`** (repeatable) passthrough so a feature flag can be checked output-neutral against the committed references — e.g. `render-verify --target IRShapeDebug --demo-arg --occlusion-cull`.

## Stacked on: https://github.com/jakildev/IrredenEngine/pull/1811
Reviewers: review this child diff only (4 files). It assumes #1811 (child 2) lands first; #1798 (child 1) already merged. When #1811 merges the merger re-targets this PR to master.

## Verification — bit-identical cull-on vs cull-off (the load-bearing invariant)
Fully-occluded voxels write nothing, so cull-on must be pixel-identical to cull-off; any diff is a cull bug.

| scene | shots | result |
|---|---|---|
| `voxel_set` (97%-occluded, cull fires heavily) | 7/7 | **bit-identical** (md5) |
| `shape_debug` (sparse, render-verify demo) | 28/28 | **bit-identical** (md5) |

`IRPerfGrid --mode voxel_set --no-overlay --wave-amplitude 0 --auto-screenshot` with vs without `--occlusion-cull`. (Linux/OpenGL has no committed shape_debug references yet, so the literal `render-verify --demo-arg --occlusion-cull` reference compare runs on a host that has them — macOS — via the new passthrough; here the equivalent A/B md5 is shown.)

## Realized voxelStage1 reduction — weak, per-voxel follow-on filed
`IRPerfGrid --mode voxel_set --auto-profile` (linux/OpenGL WSL2, single-frame GPU sample — noisy host):

| scene | voxelStage1 cull OFF | cull ON | realized |
|---|---|---|---|
| `voxel_set` zoom8 | 216.8 ms | 210.2 ms | **−6.6 ms (~3%)** |
| `voxel_set` zoom1 | 14.6 ms | 15.8 ms | +1.2 ms (overhead > savings) |

The per-256-voxel-chunk granularity captures only a sliver of the **0.97 per-voxel** ceiling (parent plan): a chunk spanning depth is rarely *fully* behind closer geometry, and the conservative "AABB fully inside the visible viewport" eligibility excludes most chunks at high zoom (where stage 1 is most expensive). Per the #1800 / #1294 acceptance — *"if weak, file the per-voxel follow-on rather than forcing per-chunk"* — filed as **#1812**. This is why the cull ships **off by default**.

## Test plan
- [x] `fleet-build --target IRShapeDebug` + `IRPerfGrid` clean (linux-debug)
- [x] Bit-identical cull-on vs cull-off: voxel_set 7/7, shape_debug 28/28 (md5)
- [x] voxelStage1 reduction measured + recorded (above); per-voxel follow-on #1812 filed
- [x] Zero added cost when `occlusionCullEnabled_=false` (staleness computation gated behind the enabled check; default pipeline byte-identical)
- [ ] macOS/Metal smoke (render path; no backend-specific code) — also run `render-verify --target IRShapeDebug --demo-arg --occlusion-cull` against the committed macOS references
- [ ] Windows smoke

## Notes for reviewer
No visual delta exists to screenshot — the change is provably output-neutral (default unchanged; cull-on bit-identical), so the md5 A/B above is the verification artifact in place of before/after PNGs. The camera-cut threshold (half the visible viewport extent) is a heuristic; disabling is always safe so it errs toward keeping chunks.

Closes #1800
