### PR TITLE
input: synthetic mouse/click injection for headless GUI tests (#1794)

### DIFF
--- a/engine/input/CLAUDE.md
+++ b/engine/input/CLAUDE.md
@@ -15,6 +15,19 @@ RENDER) so each stage sees the state relevant to its tick.
 - `getMousePositionScreen()` — cursor position in screen (pixel) space.
 - Per-button press/release frame counters.
 
+### Synthetic input (headless GUI/mouse verification, #1793)
+
+- `beginSyntheticInput()` — flip the `InputManager` to consume injected
+  events instead of GLFW for the rest of the run, so a headless run can move
+  the cursor and press buttons. Run-scoped (mirrors
+  `IRVideo::isAutoCaptureActive()`'s fixed-step flip); inactive path stays
+  byte-identical to GLFW-only. `isSyntheticInputActive()` reports the flag.
+- `injectMouseMove(screenPx)` / `injectButton(button, status)` /
+  `injectScroll(dx, dy)` — feed the same snapshot the GLFW path writes;
+  applied at the next frame boundary (one batch per `tick()`). The inject
+  calls assert if `beginSyntheticInput()` was not called first. Design:
+  [`docs/design/gui-mouse-harness.md`](../../docs/design/gui-mouse-harness.md) §"Phase 1".
+
 ### Gamepad
 
 - `checkGamepadButton(button, status, irGamepadId = 0)` — is this gamepad button in

--- a/engine/input/include/irreden/input/input_manager.hpp
+++ b/engine/input/include/irreden/input/input_manager.hpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <unordered_map>
 #include <queue>
+#include <utility>
 
 using namespace IRComponents;
 using namespace IREntity;
@@ -21,9 +22,7 @@ namespace IRInput {
 
 constexpr int kNumTrackedEvents = 3;
 constexpr std::array<IRTime::Events, kNumTrackedEvents> kTrackedEvents = {
-    IRTime::Events::INPUT,
-    IRTime::Events::UPDATE,
-    IRTime::Events::RENDER
+    IRTime::Events::INPUT, IRTime::Events::UPDATE, IRTime::Events::RENDER
 };
 
 struct EventInputState {
@@ -52,8 +51,26 @@ class InputManager {
     int getButtonPressesThisFrame(KeyMouseButtons button) const;
     int getButtonReleasesThisFrame(KeyMouseButtons button) const;
     bool hasAnyButtonPressedThisFrame() const;
-    bool checkGamepadButton(GamepadButtons button, ButtonStatuses status, int irGamepadId = 0) const;
+    bool
+    checkGamepadButton(GamepadButtons button, ButtonStatuses status, int irGamepadId = 0) const;
     float getGamepadAxis(GamepadAxes axis, int irGamepadId = 0) const;
+
+    // Synthetic input (#1794): deterministic injection so a headless run can
+    // drive the cursor and buttons without GLFW — the missing primitive the
+    // GUI/mouse verification harness (#1793) depends on. `beginSyntheticInput`
+    // flips the manager to consume injected events for the rest of the run,
+    // mirroring `IRVideo::isAutoCaptureActive()`'s run-scoped fixed-step flip.
+    // When inactive the GLFW path stays byte-identical to today.
+    void beginSyntheticInput();
+    bool isSyntheticInputActive() const {
+        return m_syntheticInputActive;
+    }
+    // Set the cursor (screen pixels, GLFW's space) for the next frame's snapshot.
+    void injectMouseMove(IRMath::ivec2 screenPx);
+    // Enqueue a button press/release, applied at the next frame boundary.
+    void injectButton(KeyMouseButtons button, ButtonStatuses status);
+    // Enqueue a scroll delta, applied at the next frame boundary.
+    void injectScroll(double xOffset, double yOffset);
 
   private:
     std::unordered_map<KeyMouseButtons, EntityId> m_keyMouseButtonEntities;
@@ -66,9 +83,29 @@ class InputManager {
     std::unordered_map<IRTime::Events, EventInputState> m_eventStates;
     IRTime::Events m_currentEvent = IRTime::Events::INPUT;
 
+    // Synthetic-input state (see the public inject API above). When
+    // `m_syntheticInputActive` is set, `tick()` drains these injected queues
+    // instead of the GLFW window queues and `advanceInputState` snapshots
+    // `m_syntheticCursorScreen` instead of the live GLFW cursor. The pending
+    // cursor is latched into the current one once per `tick()` so every
+    // pipeline-event snapshot in a frame reads the same position.
+    bool m_syntheticInputActive = false;
+    IRMath::dvec2 m_syntheticCursorScreen{0.0, 0.0};
+    IRMath::dvec2 m_syntheticCursorPending{0.0, 0.0};
+    std::queue<std::pair<KeyMouseButtons, ButtonStatuses>> m_injectedButtons;
+    std::queue<std::pair<double, double>> m_injectedScrolls;
+
     void processKeyMouseButtons(std::queue<int> &queueOfButtons, ButtonStatuses status);
 
     void processScrolls(std::queue<std::pair<double, double>> &queueOfScrolls);
+
+    // Records one button event into the per-event accumulators + frame counters.
+    // Shared by the GLFW drain (`processKeyMouseButtons`) and synthetic injection.
+    void applyButtonEvent(KeyMouseButtons button, ButtonStatuses status);
+
+    // Drains the injected queues into the same per-event state the GLFW path
+    // writes; the synthetic counterpart of the `tick()` GLFW drain.
+    void drainInjectedInput();
 
     void initKeyMouseButtonEntities();
     void initJoystickEntities();

--- a/engine/input/include/irreden/input/input_manager.hpp
+++ b/engine/input/include/irreden/input/input_manager.hpp
@@ -51,8 +51,7 @@ class InputManager {
     int getButtonPressesThisFrame(KeyMouseButtons button) const;
     int getButtonReleasesThisFrame(KeyMouseButtons button) const;
     bool hasAnyButtonPressedThisFrame() const;
-    bool
-    checkGamepadButton(GamepadButtons button, ButtonStatuses status, int irGamepadId = 0) const;
+    bool checkGamepadButton(GamepadButtons button, ButtonStatuses status, int irGamepadId = 0) const;
     float getGamepadAxis(GamepadAxes axis, int irGamepadId = 0) const;
 
     // Synthetic input (#1794): deterministic injection so a headless run can

--- a/engine/input/include/irreden/ir_input.hpp
+++ b/engine/input/include/irreden/ir_input.hpp
@@ -39,6 +39,23 @@ bool checkGamepadButton(GamepadButtons button, ButtonStatuses buttonStatus, int 
 /// Asserts if no gamepad was connected at engine startup.
 float getGamepadAxis(GamepadAxes axis, int irGamepadId = 0);
 
+/// @name Synthetic input (headless GUI/mouse verification harness, #1793)
+/// Flip the active `InputManager` to consume injected events instead of GLFW
+/// for the rest of the run, so a headless run can move the cursor and press
+/// buttons. Inject calls assert if @ref beginSyntheticInput() was not called.
+/// @{
+/// Activate synthetic input for the remainder of the run (GLFW input suppressed).
+void beginSyntheticInput();
+/// Returns `true` when synthetic input is active.
+bool isSyntheticInputActive();
+/// Set the cursor (screen pixels) for the next frame's snapshot.
+void injectMouseMove(IRMath::ivec2 screenPx);
+/// Enqueue a button press/release, applied at the next frame boundary.
+void injectButton(KeyMouseButtons button, ButtonStatuses status);
+/// Enqueue a scroll delta, applied at the next frame boundary.
+void injectScroll(double xOffset, double yOffset);
+/// @}
+
 /// @name Internal input counters (used by input systems, not for general use)
 /// @{
 int getNumButtonPressesThisFrame(KeyMouseButtons button);

--- a/engine/input/src/input_manager.cpp
+++ b/engine/input/src/input_manager.cpp
@@ -48,6 +48,11 @@ void InputManager::tick() {
     std::fill(m_buttonPressesThisFrame.begin(), m_buttonPressesThisFrame.end(), 0);
     std::fill(m_buttonReleasesThisFrame.begin(), m_buttonReleasesThisFrame.end(), 0);
 
+    if (m_syntheticInputActive) {
+        drainInjectedInput();
+        return;
+    }
+
     processKeyMouseButtons(
         IRWindow::getWindow().getKeysPressedToProcess(),
         ButtonStatuses::PRESSED
@@ -78,8 +83,9 @@ void InputManager::advanceInputState(IRTime::Events event) {
         ButtonStatuses current = state.buttonStates_[i];
         if (current == ButtonStatuses::PRESSED) {
             current = ButtonStatuses::HELD;
-        } else if (current == ButtonStatuses::RELEASED ||
-                   current == ButtonStatuses::PRESSED_AND_RELEASED) {
+        } else if (
+            current == ButtonStatuses::RELEASED || current == ButtonStatuses::PRESSED_AND_RELEASED
+        ) {
             current = ButtonStatuses::NOT_HELD;
         }
 
@@ -98,7 +104,11 @@ void InputManager::advanceInputState(IRTime::Events event) {
 
     std::fill(state.pressAccumulator_.begin(), state.pressAccumulator_.end(), false);
     std::fill(state.releaseAccumulator_.begin(), state.releaseAccumulator_.end(), false);
-    IRWindow::getCursorPosition(state.mousePosition_);
+    if (m_syntheticInputActive) {
+        state.mousePosition_ = m_syntheticCursorScreen;
+    } else {
+        IRWindow::getCursorPosition(state.mousePosition_);
+    }
 }
 
 ButtonStatuses InputManager::getButtonStatus(KeyMouseButtons button) const {
@@ -107,20 +117,17 @@ ButtonStatuses InputManager::getButtonStatus(KeyMouseButtons button) const {
 
 bool InputManager::checkButtonPressed(KeyMouseButtons button) const {
     ButtonStatuses status = getButtonStatus(button);
-    return status == ButtonStatuses::PRESSED ||
-           status == ButtonStatuses::PRESSED_AND_RELEASED;
+    return status == ButtonStatuses::PRESSED || status == ButtonStatuses::PRESSED_AND_RELEASED;
 }
 
 bool InputManager::checkButtonDown(KeyMouseButtons button) const {
     ButtonStatuses status = getButtonStatus(button);
-    return status == ButtonStatuses::PRESSED ||
-           status == ButtonStatuses::HELD;
+    return status == ButtonStatuses::PRESSED || status == ButtonStatuses::HELD;
 }
 
 bool InputManager::checkButtonReleased(KeyMouseButtons button) const {
     ButtonStatuses status = getButtonStatus(button);
-    return status == ButtonStatuses::RELEASED ||
-           status == ButtonStatuses::PRESSED_AND_RELEASED;
+    return status == ButtonStatuses::RELEASED || status == ButtonStatuses::PRESSED_AND_RELEASED;
 }
 
 bool InputManager::checkButton(KeyMouseButtons button, ButtonStatuses status) const {
@@ -162,42 +169,69 @@ bool InputManager::checkGamepadButton(
     GamepadButtons button, ButtonStatuses status, int irGamepadId
 ) const {
     IR_ASSERT(
-        status == ButtonStatuses::PRESSED ||
-        status == ButtonStatuses::HELD ||
-        status == ButtonStatuses::RELEASED,
+        status == ButtonStatuses::PRESSED || status == ButtonStatuses::HELD ||
+            status == ButtonStatuses::RELEASED,
         "Invalid button status to check"
     );
-    IR_ASSERT(irGamepadId >= 0 && irGamepadId < static_cast<int>(m_gamepadEntities.size()), "Gamepad {} not connected at startup", irGamepadId);
+    IR_ASSERT(
+        irGamepadId >= 0 && irGamepadId < static_cast<int>(m_gamepadEntities.size()),
+        "Gamepad {} not connected at startup",
+        irGamepadId
+    );
     return IREntity::getComponent<C_GLFWGamepadState>(m_gamepadEntities[irGamepadId])
         .checkButton(button, status);
 }
 
 float InputManager::getGamepadAxis(GamepadAxes axis, int irGamepadId) const {
-    IR_ASSERT(irGamepadId >= 0 && irGamepadId < static_cast<int>(m_gamepadEntities.size()), "Gamepad {} not connected at startup", irGamepadId);
+    IR_ASSERT(
+        irGamepadId >= 0 && irGamepadId < static_cast<int>(m_gamepadEntities.size()),
+        "Gamepad {} not connected at startup",
+        irGamepadId
+    );
     return IREntity::getComponent<C_GLFWGamepadState>(m_gamepadEntities[irGamepadId])
         .getAxisValue(axis);
+}
+
+void InputManager::applyButtonEvent(KeyMouseButtons irButton, ButtonStatuses status) {
+    if (status == ButtonStatuses::PRESSED) {
+        ++m_buttonPressesThisFrame[irButton];
+        for (auto &[event, eventState] : m_eventStates) {
+            eventState.pressAccumulator_[static_cast<int>(irButton)] = true;
+        }
+    }
+    if (status == ButtonStatuses::RELEASED) {
+        ++m_buttonReleasesThisFrame[irButton];
+        for (auto &[event, eventState] : m_eventStates) {
+            eventState.releaseAccumulator_[static_cast<int>(irButton)] = true;
+        }
+    }
 }
 
 void InputManager::processKeyMouseButtons(std::queue<int> &queueOfButtons, ButtonStatuses status) {
     while (!queueOfButtons.empty()) {
         int button = queueOfButtons.front();
         KeyMouseButtons irButton = kMapGLFWtoIRKeyMouseButtons.at(button);
-        if (status == ButtonStatuses::PRESSED) {
-            ++m_buttonPressesThisFrame[irButton];
-            for (auto &[event, eventState] : m_eventStates) {
-                eventState.pressAccumulator_[static_cast<int>(irButton)] = true;
-            }
-        }
-        if (status == ButtonStatuses::RELEASED) {
-            ++m_buttonReleasesThisFrame[irButton];
-            for (auto &[event, eventState] : m_eventStates) {
-                eventState.releaseAccumulator_[static_cast<int>(irButton)] = true;
-            }
-        }
+        applyButtonEvent(irButton, status);
         queueOfButtons.pop();
 
         IRE_LOG_DEBUG("Processed button={}, status={}", button, static_cast<int>(status));
     }
+}
+
+void InputManager::drainInjectedInput() {
+    // Latch the pending cursor once per frame so every pipeline-event snapshot
+    // this frame reads the same position (mirrors GLFW's per-frame cursor).
+    m_syntheticCursorScreen = m_syntheticCursorPending;
+
+    while (!m_injectedButtons.empty()) {
+        const auto &[button, status] = m_injectedButtons.front();
+        applyButtonEvent(button, status);
+        m_injectedButtons.pop();
+    }
+
+    // Scroll injection reuses the GLFW scroll path — same ephemeral C_MouseScroll
+    // entities, drained by the LIFETIME system.
+    processScrolls(m_injectedScrolls);
 }
 
 void InputManager::processScrolls(std::queue<std::pair<double, double>> &queueOfScrolls) {
@@ -240,6 +274,27 @@ EventInputState &InputManager::currentEventState() {
 
 const EventInputState &InputManager::currentEventState() const {
     return m_eventStates.at(m_currentEvent);
+}
+
+void InputManager::beginSyntheticInput() {
+    m_syntheticInputActive = true;
+    IRE_LOG_INFO("InputManager: synthetic input active (GLFW input suppressed)");
+}
+
+void InputManager::injectMouseMove(IRMath::ivec2 screenPx) {
+    IR_ASSERT(m_syntheticInputActive, "injectMouseMove requires beginSyntheticInput()");
+    m_syntheticCursorPending =
+        IRMath::dvec2(static_cast<double>(screenPx.x), static_cast<double>(screenPx.y));
+}
+
+void InputManager::injectButton(KeyMouseButtons button, ButtonStatuses status) {
+    IR_ASSERT(m_syntheticInputActive, "injectButton requires beginSyntheticInput()");
+    m_injectedButtons.push({button, status});
+}
+
+void InputManager::injectScroll(double xOffset, double yOffset) {
+    IR_ASSERT(m_syntheticInputActive, "injectScroll requires beginSyntheticInput()");
+    m_injectedScrolls.push({xOffset, yOffset});
 }
 
 } // namespace IRInput

--- a/engine/input/src/input_manager.cpp
+++ b/engine/input/src/input_manager.cpp
@@ -193,6 +193,11 @@ float InputManager::getGamepadAxis(GamepadAxes axis, int irGamepadId) const {
 }
 
 void InputManager::applyButtonEvent(KeyMouseButtons irButton, ButtonStatuses status) {
+    IR_ASSERT(
+        status == ButtonStatuses::PRESSED || status == ButtonStatuses::RELEASED,
+        "applyButtonEvent only accepts PRESSED or RELEASED, got {}",
+        static_cast<int>(status)
+    );
     if (status == ButtonStatuses::PRESSED) {
         ++m_buttonPressesThisFrame[irButton];
         for (auto &[event, eventState] : m_eventStates) {
@@ -227,6 +232,8 @@ void InputManager::drainInjectedInput() {
         const auto &[button, status] = m_injectedButtons.front();
         applyButtonEvent(button, status);
         m_injectedButtons.pop();
+
+        IRE_LOG_DEBUG("Processed button={}, status={}", static_cast<int>(button), static_cast<int>(status));
     }
 
     // Scroll injection reuses the GLFW scroll path — same ephemeral C_MouseScroll

--- a/engine/input/src/ir_input.cpp
+++ b/engine/input/src/ir_input.cpp
@@ -82,4 +82,24 @@ float getGamepadAxis(GamepadAxes axis, int irGamepadId) {
     return getInputManager().getGamepadAxis(axis, irGamepadId);
 }
 
+void beginSyntheticInput() {
+    getInputManager().beginSyntheticInput();
+}
+
+bool isSyntheticInputActive() {
+    return getInputManager().isSyntheticInputActive();
+}
+
+void injectMouseMove(IRMath::ivec2 screenPx) {
+    getInputManager().injectMouseMove(screenPx);
+}
+
+void injectButton(KeyMouseButtons button, ButtonStatuses status) {
+    getInputManager().injectButton(button, status);
+}
+
+void injectScroll(double xOffset, double yOffset) {
+    getInputManager().injectScroll(xOffset, yOffset);
+}
+
 } // namespace IRInput


### PR DESCRIPTION
## Summary
- New `IRInput` synthetic-input API — P1 of the GUI/mouse verification harness (#1793): `beginSyntheticInput` / `injectMouseMove` / `injectButton` / `injectScroll` / `isSyntheticInputActive`. This is the missing primitive the rest of the harness depends on (no way to move the cursor or press a button headless today).
- When active, `InputManager::tick` drains injected button/scroll queues instead of the GLFW window queues, and `advanceInputState` snapshots an injected cursor (screen px). The pending cursor latches once per `tick()` so every pipeline-event snapshot in a frame reads the same position — mirrors GLFW's per-frame cursor. Run-scoped flip, modeled on `IRVideo::isAutoCaptureActive()`.
- The GLFW path is gated on the flag and stays **byte-identical** when synthetic input is inactive. `injectButton` shares `applyButtonEvent` (extracted from `processKeyMouseButtons`) and `injectScroll` reuses `processScrolls`, so injected and GLFW paths produce identical state. Inject calls assert if `beginSyntheticInput()` was not called.

## Test plan
- [x] Builds clean (`IRShapeDebug`).
- [x] Functional smoke (temporary `ui_widgets` injection, logged, then reverted — not committed): `injectMouseMove(400,300)` → `getMousePosition`==(400,300); `injectButton(left, PRESSED)` → `checkKeyMouseButton(left, PRESSED)`==true the next frame; injected RELEASE observed the following frame; cursor persists across frames (correct level semantics).
- [x] GLFW/inactive path unregressed: `IRShapeDebug --auto-screenshot` runs clean (exit 0); inactive path is byte-identical by construction (gated on the flag; `applyButtonEvent` is a behavior-preserving extraction).
- [ ] Linux/OpenGL smoke (host-unvalidated; macOS-authored).
- [ ] Windows smoke (host-unvalidated).

## Notes / scope
- Widget-level click assertions (`wasClicked` against a GUI hitbox) require inverting the screen→framebuffer→GUI-trixel transform and are **Phase 2/3** of the harness — out of P1 scope. P1 proves the primitive drives the exact `IRInput` snapshot getters that `HITBOX_MOUSE_TEST_GUI` / `WIDGET_INPUT` consume.
- No committed unit test: `InputManager`'s ctor needs a live GLFW window (`initJoystickEntities`), so it isn't gtest-constructable headless; permanent coverage lands with the Phase 2/3 harness.

Closes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)