### PR TITLE
docs: fold scout deploy-blockers into the #1810 plan-of-record

### DIFF
--- a/.fleet/plans/issue-1810.md
+++ b/.fleet/plans/issue-1810.md
@@ -172,8 +172,8 @@ instance of the stale-clone false-grant this very plan fixes (the planning
 gate fired 3× within seconds because the claim lock wasn't observed freshly).
 
 Steps 4–5, their matching affected-files / acceptance entries, and this
-correction were folded in from the closed #1825 plan + worker-3's #1810
-addendum, which caught two deploy-blockers the originally-merged plan omitted:
+correction were folded in from the closed #1825 plan + linux-worker-3's
+comment on issue #1810, which caught two deploy-blockers the originally-merged plan omitted:
 
 - **Root-cause correction:** the "Root cause" section above states scout
   imports from "the script's own (resolved-symlink) directory." That holds for

--- a/.fleet/plans/issue-1810.md
+++ b/.fleet/plans/issue-1810.md
@@ -71,13 +71,40 @@ assertion on the claim side + a fetch-free freshness annotation in state.json.
    **rev-parse only, no fetch** (respects the no-fetch-in-hot-path rule). Lets
    readers/dispatcher see staleness; dispatcher logs a warning when
    `fresh==false` persists.
+4. **Scout module-resolution fix — HARD PREREQUISITE (the #1578 miss).**
+   `fleet-state-scout:37` resolves its lib dir with
+   `os.path.dirname(os.path.abspath(__file__))` — `abspath` does **not**
+   dereference the `~/bin` symlink, so it yields `~/bin`, where
+   `fleet_blocked_by.py` is **absent** (`install.sh:182` symlinks the
+   executables only, not the `.py` helpers). The currently-running scout
+   survives solely because it predates #1783 (parser inlined, no import); the
+   moment the clone advances to the merged scout, `from fleet_blocked_by
+   import …` (`fleet-state-scout:40`) raises `ModuleNotFoundError` and the
+   daemon dies. Fix: change `:37` to `os.path.realpath(__file__)` — the same
+   symlink-deref #1578 applied to `fleet-claim:105-111` and
+   `fleet-dispatcher:74-78` but **missed** for the scout — so the lib dir
+   resolves to the main-clone `scripts/fleet/` where the module lives. This
+   step must land WITH the clone-advance, not after: advancing without it
+   trades a stale parser for a dead scout.
+5. **Long-running scout daemon must re-exec to pick up advanced code.** The
+   scout `import`s the parser **once at module load**; fast-forwarding the
+   clone on disk does not reload an already-running daemon, so the periodic
+   advance fixes the *files* while the live scout keeps projecting from stale
+   in-memory parser code until something restarts it — the mid-session
+   re-drift the issue observed. Fix: when the scout's own freshness rev-parse
+   (step 3) detects the clone advanced, re-exec **between ticks**:
+   `os.execv(sys.executable, [sys.executable, os.path.realpath(__file__)] +
+   sys.argv[1:])`. Same PID (so `scout.pid` stays valid); state.json is
+   written atomically per tick (`write_atomic`), so there is no torn state.
+   Use `realpath` (not `abspath`) so the re-exec targets the now-updated
+   main-clone file.
 
 ## Affected files
 - `scripts/fleet/fleet-clone-freshness.sh` — NEW guarded `advance_main_clone` + `assert_clone_fresh`.
-- `scripts/fleet/fleet-up` — source helper; advance after the engine/game fetches (:435/:466).
+- `scripts/fleet/fleet-up` — source helper; advance after the engine/game fetches (:435/:466); refresh the clone once before `nohup`-ing the scout so the daemon starts on fresh code (step 5).
 - `scripts/fleet/fleet-dispatcher` — source helper; periodic advance in the main loop.
 - `scripts/fleet/fleet-claim` — fail-loud freshness guard in the blocker-gate path (~:507-521).
-- `scripts/fleet/fleet-state-scout` — emit `clone_freshness` (rev-parse only).
+- `scripts/fleet/fleet-state-scout` — emit `clone_freshness` (rev-parse only); **fix `:37` `abspath`→`realpath`** (step 4, the #1578 miss); **re-exec via `os.execv` on detected advance** (step 5).
 - `scripts/fleet/install.sh` — symlink the new helper into ~/bin (by-dir source resolves through the symlink, like fleet-common.sh).
 
 ## Acceptance criteria
@@ -91,13 +118,20 @@ assertion on the claim side + a fetch-free freshness annotation in state.json.
 - Guard safety: off-master / dirty / diverged main clone → advance skipped
   with a warning, working tree untouched (no clobber of a checked-out branch).
 - state.json carries `clone_freshness.fresh`.
+- Clone-advance does not kill the scout: after `merge --ff-only` brings in a
+  scout that imports `fleet_blocked_by`, the daemon imports cleanly
+  (`fleet-state-scout:37` resolves to `scripts/fleet/` via `realpath`) — no
+  `ModuleNotFoundError`.
+- Mid-session reload: when the clone advances while the scout daemon is
+  running, the daemon re-execs (same PID) and its next state.json projection
+  reflects the now-fresh parser without a manual fleet-up restart.
 
 ## Gotchas
-- **Module-resolution fragility (#1750/#1578):** do NOT add a new
-  *scout-imported python module* — the scout resolves its lib dir via
-  abspath-of-symlink and a new module can silently fail to resolve. Keep the
-  scout's freshness read as a tiny inline `git rev-parse` (≤5 lines), not an
-  import. Bash consumers share `fleet-clone-freshness.sh` (sourced by-dir).
+- **Module-resolution fragility (#1750/#1578):** step 4 fixes the underlying
+  `abspath` bug so the **existing** `fleet_blocked_by` import resolves; even
+  so, do NOT add a *new* scout-imported python module — keep the scout's
+  freshness read as a tiny inline `git rev-parse` (≤5 lines), not an import.
+  Bash consumers share `fleet-clone-freshness.sh` (sourced by-dir).
 - **install.sh must symlink the new helper** into ~/bin — all fleet scripts
   are individually symlinked; a sibling sourced via `dirname` only resolves if
   it is symlinked there too (see the fleet-common.sh header).
@@ -129,3 +163,23 @@ gets the explicit fail-loud guard as defense-in-depth.
   families per the issue body; no surface overlap.
 - No open PR touches the fleet-up / dispatcher / fleet-claim clone-advance
   surface (engine PRs #1742, #1811 are render-only).
+
+## Reconciliation note (2026-06-14)
+
+This issue was planned **three times concurrently** in a claim race (#1821
+merged as this plan-of-record; #1822 and #1825 closed as superseded) — a live
+instance of the stale-clone false-grant this very plan fixes (the planning
+gate fired 3× within seconds because the claim lock wasn't observed freshly).
+
+Steps 4–5, their matching affected-files / acceptance entries, and this
+correction were folded in from the closed #1825 plan + worker-3's #1810
+addendum, which caught two deploy-blockers the originally-merged plan omitted:
+
+- **Root-cause correction:** the "Root cause" section above states scout
+  imports from "the script's own (resolved-symlink) directory." That holds for
+  `fleet-claim` (post-#1578) but **NOT** for the scout — `fleet-state-scout:37`
+  uses `abspath`, which does not deref the symlink. The scout is precisely the
+  spot #1578 missed; step 4 is the fix.
+- Without steps 4–5, advancing the clone trades a stale parser for a *crashed*
+  (ModuleNotFoundError) or *stale-in-memory* scout daemon — i.e. the fix as
+  originally written would not actually deploy.


### PR DESCRIPTION
## Summary

Amends the merged #1810 plan (`.fleet/plans/issue-1810.md`, from #1821) to add two **deploy-blocker** fixes it omitted. #1810 was planned three times concurrently in a claim race; #1821 merged as the plan-of-record while #1822 and #1825 were closed as superseded — but #1825 + worker-3's #1810 addendum had caught two things the merged plan missed. This folds them in so the implementation worker ships a plan that actually deploys.

Verified against live `origin/master`:
- `fleet-state-scout:37` uses `os.path.abspath(__file__)` (no symlink-deref) → imports `fleet_blocked_by` from `~/bin`, where `install.sh:182` never symlinks the `.py`. The running scout survives only because it predates #1783 (parser inlined).

## What this adds to the plan

- **Step 4 (hard prerequisite):** `fleet-state-scout:37` `abspath`→`realpath` — the spot #1578 fixed for `fleet-claim`/`fleet-dispatcher` but missed for the scout. Without it, advancing the clone to the merged scout `ModuleNotFoundError`s on `fleet_blocked_by`. Must land *with* the clone-advance.
- **Step 5:** the scout imports the parser once at module load, so a disk-level clone-advance doesn't reload a running daemon. Re-exec via `os.execv` (same PID, between atomic-written ticks) when the freshness rev-parse detects an advance.
- Matching affected-files + acceptance-criteria entries; a root-cause correction (the merged text claimed the scout resolves via a resolved-symlink dir — true for `fleet-claim`, not the scout); and a reconciliation note documenting the three-way claim race as a live instance of the false-grant this plan fixes.

## Test plan

- [ ] Plan-doc only — no build. Reviewer confirms steps 4–5 match the live source refs (`fleet-state-scout:37,40`, `install.sh:182`, the #1578 `fleet-claim`/`fleet-dispatcher` precedent).

Refs #1810. (No `Closes` — #1810 closes when the implementation PR lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
