### PR TITLE
render: GUI-test shot tables with scripted input (P2, #1795)

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -277,14 +277,29 @@ struct LoftToolState {
 };
 LoftToolState g_loftTool;
 
-// Three auto-screenshot framings so the render-debug-loop / regression
-// harness records the palette panel and the editable scene from a
-// stable camera. Camera position is irrelevant to the GUI canvas but
-// it does anchor the world-space scene render.
-constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, IRMath::vec2(0.0f, 0.0f), 0.0f, "editor_idle"},
-    {0.75f, IRMath::vec2(0.0f, 0.0f), 0.0f, "editor_zoom_out"},
-    {1.5f, IRMath::vec2(0.0f, 0.0f), 0.0f, "editor_zoom_in"},
+// Scripted palette-click: move cursor to a palette swatch, press, release.
+// frameOffset_ = 0: move; 1: press; 2: release — settle then captures.
+constexpr IRVideo::GuiInputEvent kPaletteClickEvents[] = {
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(200, 300)},
+    {1,
+     IRVideo::GuiInputEvent::Type::PRESS,
+     IRMath::ivec2(200, 300),
+     IRMath::vec2(0.0f),
+     IRInput::kMouseButtonLeft},
+    {2,
+     IRVideo::GuiInputEvent::Type::RELEASE,
+     IRMath::ivec2(200, 300),
+     IRMath::vec2(0.0f),
+     IRInput::kMouseButtonLeft},
+};
+
+// GUI-test shot table covering stable render framings plus one scripted-click
+// shot. Superset of the previous kShots[] — render-verify labels still match.
+constexpr IRVideo::GuiTestShot kGuiTestShots[] = {
+    {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_idle"}, nullptr, 0},
+    {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_palette_click"}, kPaletteClickEvents, 3},
+    {{0.75f, IRMath::vec2(0.0f), 0.0f, "editor_zoom_out"}, nullptr, 0},
+    {{1.5f, IRMath::vec2(0.0f), 0.0f, "editor_zoom_in"}, nullptr, 0},
 };
 
 int g_autoWarmupFrames = 0;
@@ -1471,7 +1486,8 @@ void initSystems() {
             if (leftReleasedNow && IRVoxelEditor::g_fillTool.dragging_) {
                 IRVoxelEditor::g_fillTool.dragging_ = false;
                 if (IRVoxelEditor::g_fillTool.ghostEntity_ != IREntity::kNullEntity) {
-                    IREntity::getComponent<C_ShapeDescriptor>(IRVoxelEditor::g_fillTool.ghostEntity_
+                    IREntity::getComponent<C_ShapeDescriptor>(
+                        IRVoxelEditor::g_fillTool.ghostEntity_
                     )
                         .flags_ = IRMath::SDF::SHAPE_FLAG_NONE;
                 }
@@ -2012,12 +2028,13 @@ void initSystems() {
     );
 
     if (IRVoxelEditor::g_autoWarmupFrames > 0) {
-        IRVideo::AutoScreenshotConfig cfg{};
+        IRVideo::GuiTestConfig cfg{};
         cfg.warmupFrames_ = IRVoxelEditor::g_autoWarmupFrames;
         cfg.settleFrames_ = 3;
-        cfg.shots_ = IRVoxelEditor::kShots;
-        cfg.numShots_ = sizeof(IRVoxelEditor::kShots) / sizeof(IRVoxelEditor::kShots[0]);
-        renderPipeline.push_back(IRVideo::createAutoScreenshotSystem(cfg));
+        cfg.shots_ = IRVoxelEditor::kGuiTestShots;
+        cfg.numShots_ =
+            sizeof(IRVoxelEditor::kGuiTestShots) / sizeof(IRVoxelEditor::kGuiTestShots[0]);
+        renderPipeline.push_back(IRVideo::createGuiTestSystem(cfg));
     }
 
     IRSystem::registerPipeline(IRTime::Events::RENDER, renderPipeline);
@@ -2336,7 +2353,8 @@ void initCommands() {
             if (IRVoxelEditor::g_fillTool.dragging_) {
                 IRVoxelEditor::g_fillTool.dragging_ = false;
                 if (IRVoxelEditor::g_fillTool.ghostEntity_ != IREntity::kNullEntity) {
-                    IREntity::getComponent<C_ShapeDescriptor>(IRVoxelEditor::g_fillTool.ghostEntity_
+                    IREntity::getComponent<C_ShapeDescriptor>(
+                        IRVoxelEditor::g_fillTool.ghostEntity_
                     )
                         .flags_ = IRMath::SDF::SHAPE_FLAG_NONE;
                 }
@@ -2929,12 +2947,14 @@ void initEntities() {
             kSwatchOriginX + col * (kSwatchSize + kSwatchGap),
             kSwatchOriginY + row * (kSwatchSize + kSwatchGap)
         );
-        g_editor.paletteSwatches_.push_back(IRPrefab::Widget::makeColorSwatch(
-            pos,
-            ivec2(kSwatchSize, kSwatchSize),
-            IRVoxelEditor::kPaletteColors[i],
-            i == 0
-        ));
+        g_editor.paletteSwatches_.push_back(
+            IRPrefab::Widget::makeColorSwatch(
+                pos,
+                ivec2(kSwatchSize, kSwatchSize),
+                IRVoxelEditor::kPaletteColors[i],
+                i == 0
+            )
+        );
     }
 
     // Animation controls panel (T-214, F-1.4) — sits below the palette
@@ -3067,12 +3087,14 @@ void initEntities() {
             kBoneSwatchOriginX + col * (kBoneSwatchSize + kBoneSwatchGap),
             kBoneSwatchOriginY + row * (kBoneSwatchSize + kBoneSwatchGap)
         );
-        IRVoxelEditor::g_bonePaint.boneSwatches_.push_back(IRPrefab::Widget::makeColorSwatch(
-            pos,
-            ivec2(kBoneSwatchSize, kBoneSwatchSize),
-            IRVoxelEditor::kBoneColors[i],
-            i == 0
-        ));
+        IRVoxelEditor::g_bonePaint.boneSwatches_.push_back(
+            IRPrefab::Widget::makeColorSwatch(
+                pos,
+                ivec2(kBoneSwatchSize, kBoneSwatchSize),
+                IRVoxelEditor::kBoneColors[i],
+                i == 0
+            )
+        );
     }
 
     // Skeleton tree panel (F-2.6, #1607). Sits below the BONE selector in the

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -4,6 +4,7 @@
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_constants.hpp>
 #include <irreden/system/ir_system_types.hpp>
+#include <irreden/input/ir_input_types.hpp>
 
 namespace IRVideo {
 
@@ -108,6 +109,49 @@ bool isAutoCaptureActive();
 ///
 /// Requires @c IREngine::init() has run (so the system manager is live).
 IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config);
+
+// ---------------------------------------------------------------------------
+// GUI-test shot tables (P2, #1795)
+// ---------------------------------------------------------------------------
+
+/// One scripted input event within a @c GuiTestShot.
+///
+/// @c frameOffset_ is relative to the first frame after the camera is applied
+/// for this shot. Events at the same offset fire in array order. Settle frames
+/// begin after the highest @c frameOffset_ in the list, ensuring the GUI
+/// reflects the interaction before capture.
+struct GuiInputEvent {
+    int frameOffset_ = 0;
+    enum class Type { MOVE, PRESS, RELEASE, SCROLL } type_ = Type::MOVE;
+    ivec2 screenPx_ = ivec2(0);
+    vec2 scroll_ = vec2(0.0f);
+    IRInput::KeyMouseButtons button_ = IRInput::kNullButton;
+};
+
+/// Superset of @c AutoScreenshotShot — carries the same render config plus an
+/// optional scripted input sequence. @c inputs_ / @c numInputs_ must outlive
+/// the game loop. Pass @c nullptr / 0 for a pure render shot.
+struct GuiTestShot {
+    AutoScreenshotShot render_;
+    const GuiInputEvent *inputs_ = nullptr;
+    int numInputs_ = 0;
+};
+
+/// Declarative config for @c createGuiTestSystem.
+struct GuiTestConfig {
+    int warmupFrames_ = 10;
+    int settleFrames_ = 3;
+    const GuiTestShot *shots_ = nullptr;
+    int numShots_ = 0;
+};
+
+/// Create a system that fires scripted input events on scheduled frames,
+/// settles for @c settleFrames_ frames after the last event per shot, captures
+/// a screenshot, then calls @c IRWindow::closeWindow() when done.
+///
+/// Calls @c IRInput::beginSyntheticInput() at creation — the process is in
+/// synthetic-input mode for its lifetime. Requires @c IREngine::init() has run.
+IRSystem::SystemId createGuiTestSystem(const GuiTestConfig &config);
 
 } // namespace IRVideo
 

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -110,10 +110,6 @@ bool isAutoCaptureActive();
 /// Requires @c IREngine::init() has run (so the system manager is live).
 IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config);
 
-// ---------------------------------------------------------------------------
-// GUI-test shot tables (P2, #1795)
-// ---------------------------------------------------------------------------
-
 /// One scripted input event within a @c GuiTestShot.
 ///
 /// @c frameOffset_ is relative to the first frame after the camera is applied

--- a/engine/video/src/auto_screenshot.cpp
+++ b/engine/video/src/auto_screenshot.cpp
@@ -1,5 +1,6 @@
 #include <irreden/video/auto_screenshot.hpp>
 
+#include <irreden/ir_input.hpp>
 #include <irreden/ir_profile.hpp>
 #include <irreden/ir_render.hpp>
 #include <irreden/ir_system.hpp>
@@ -20,6 +21,7 @@ namespace {
 // runs zero times. engine/system/CLAUDE.md guarantees endTick fires even
 // when zero entities match — we only care about endTick here.
 struct C_AutoScreenshotAnchor {};
+struct C_GuiTestAnchor {};
 
 struct CyclingState {
     AutoScreenshotConfig config_;
@@ -129,6 +131,123 @@ IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config
             state->settleCounter_ = 0;
             state->screenshotPending_ = false;
             ++state->currentShot_;
+        }
+    );
+}
+
+IRSystem::SystemId createGuiTestSystem(const GuiTestConfig &config) {
+    g_autoCaptureActive = true;
+    IRInput::beginSyntheticInput();
+
+    struct GuiTestState {
+        GuiTestConfig config_;
+        int warmupRemaining_ = 0;
+        int currentShot_ = 0;
+        // -1 = camera not applied yet for this shot; 0+ = frames since camera apply
+        int shotFrame_ = -1;
+        bool screenshotRequested_ = false;
+    };
+
+    auto state = std::make_shared<GuiTestState>();
+    state->config_ = config;
+    state->warmupRemaining_ = config.warmupFrames_;
+
+    return IRSystem::createSystem<C_GuiTestAnchor>(
+        "GuiTest",
+        [](C_GuiTestAnchor &) {},
+        nullptr,
+        [state]() {
+            if (state->warmupRemaining_ > 0) {
+                --state->warmupRemaining_;
+                return;
+            }
+            if (state->currentShot_ >= state->config_.numShots_) {
+                IRWindow::closeWindow();
+                return;
+            }
+
+            const auto &shot = state->config_.shots_[state->currentShot_];
+
+            if (state->shotFrame_ < 0) {
+                IR_LOG_INFO(
+                    "GuiTest {}/{}: {} (zoom={}, cam=({},{}), yaw={}, inputs={})",
+                    state->currentShot_ + 1,
+                    state->config_.numShots_,
+                    shot.render_.label_,
+                    shot.render_.zoom_,
+                    shot.render_.cameraIso_.x,
+                    shot.render_.cameraIso_.y,
+                    shot.render_.yawRadians_,
+                    shot.numInputs_
+                );
+                IRRender::setCameraZoom(shot.render_.zoom_);
+                IRRender::setCameraPosition2DIso(shot.render_.cameraIso_);
+                IRPrefab::Camera::setYaw(shot.render_.yawRadians_);
+                if (shot.render_.cullAction_ == CullAction::FREEZE) {
+                    IRRender::setCullingFrozen(true);
+                } else if (shot.render_.cullAction_ == CullAction::UNFREEZE) {
+                    IRRender::setCullingFrozen(false);
+                }
+                state->shotFrame_ = 0;
+                return;
+            }
+
+            int maxOffset = -1;
+            for (int i = 0; i < shot.numInputs_; ++i)
+                maxOffset = IRMath::max(maxOffset, shot.inputs_[i].frameOffset_);
+
+            // captureAt: settleFrames_ full settle frames follow the last event.
+            const int captureAt = maxOffset + 1 + state->config_.settleFrames_;
+
+            // Event phase: dispatch any events scheduled for shotFrame_.
+            if (state->shotFrame_ <= maxOffset) {
+                for (int i = 0; i < shot.numInputs_; ++i) {
+                    const auto &ev = shot.inputs_[i];
+                    if (ev.frameOffset_ != state->shotFrame_)
+                        continue;
+                    switch (ev.type_) {
+                    case GuiInputEvent::Type::MOVE:
+                        IRInput::injectMouseMove(ev.screenPx_);
+                        break;
+                    case GuiInputEvent::Type::PRESS:
+                        IRInput::injectButton(ev.button_, IRInput::ButtonStatuses::PRESSED);
+                        break;
+                    case GuiInputEvent::Type::RELEASE:
+                        IRInput::injectButton(ev.button_, IRInput::ButtonStatuses::RELEASED);
+                        break;
+                    case GuiInputEvent::Type::SCROLL:
+                        IRInput::injectScroll(
+                            static_cast<double>(ev.scroll_.x),
+                            static_cast<double>(ev.scroll_.y)
+                        );
+                        break;
+                    }
+                }
+                ++state->shotFrame_;
+                return;
+            }
+
+            // Settle phase: wait until captureAt.
+            if (state->shotFrame_ < captureAt) {
+                ++state->shotFrame_;
+                return;
+            }
+
+            // Capture frame.
+            if (!state->screenshotRequested_) {
+                const auto &r = shot.render_;
+                if (r.numCrops_ > 0 && r.crops_ != nullptr)
+                    IRVideo::requestScreenshotWithCrops(r.label_, r.crops_, r.numCrops_);
+                else
+                    IRVideo::requestScreenshot();
+                state->screenshotRequested_ = true;
+                return;
+            }
+
+            // Advance to next shot.
+            ++state->currentShot_;
+            state->shotFrame_ = -1;
+            state->screenshotRequested_ = false;
         }
     );
 }


### PR DESCRIPTION
## Summary
- Add \`GuiInputEvent\`, \`GuiTestShot\`, \`GuiTestConfig\` to \`auto_screenshot.hpp\`; include \`ir_input_types.hpp\` for \`KeyMouseButtons\`
- Implement \`createGuiTestSystem\` in \`auto_screenshot.cpp\`: same shot-cycling state machine as \`createAutoScreenshotSystem\` plus a frame-scheduled event-injection phase (move/press/release/scroll via P1 \`inject*\` API)
- Settle begins after the highest \`frameOffset_\` in each shot so the GUI widget reflects the interaction before capture; shots with no events behave identically to \`AutoScreenshotShot\`
- Wire up in \`voxel_editor/main.cpp\` with a demo table including \`editor_palette_click\` (move+press+release) alongside the existing stable-render framings

## Stack context
This PR is part of a stack. Reviewers: review this PR on its own;
the chain is coordinated in the PR body's "Stacked on" line.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/1827
Full chain: #1827, #1795

## Test plan
- [x] Build \`IRVoxelEditor\` clean (macOS/Metal verified)
- [x] Run \`IRVoxelEditor --auto-screenshot 10\`; confirmed 4 shots captured: editor_idle, editor_palette_click, editor_zoom_out, editor_zoom_in
- [x] editor_palette_click shot differs from editor_idle by ~244K bytes (input injection visibly affects the widget); shot labels log correctly per-shot
- [x] Pre-existing Metal non-determinism in voxel editor (139K bytes idle-to-idle): confirmed pre-existing in the original \`createAutoScreenshotSystem\` path — NOT introduced by this PR. \`IRShapeDebug\` is byte-stable. Byte-stable GL verification + render-verify manifest integration is scope for later phases (#1796, #1797).
- [x] \`IRShapeDebug\` still builds clean with updated \`auto_screenshot.hpp\`

Closes #1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)