### PR TITLE
render: add setCameraVisualYaw + perf_grid --yaw CLI flag

### DIFF
--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -97,6 +97,7 @@ struct PerfGridSettings {
     float wavePeriodSeconds_ = 4.0f;
     bool waveOffscreen_ = false;
     float initialZoom_ = 0.5f;
+    float initialYaw_ = 0.0f;
     // Subdivision — config/preset-settable; CLI overrides both.
     // Only applied if explicit_ is true so the engine's built-in default
     // is undisturbed when neither config nor CLI specifies these.
@@ -113,6 +114,8 @@ struct CliOverrides {
     int gridSize_ = 64;
     bool zoomSet_ = false;
     float zoom_ = 0.5f;
+    bool yawSet_ = false;
+    float yaw_ = 0.0f;
     bool waveAmplitudeSet_ = false;
     float waveAmplitude_ = 0.0f;
     bool subdivisionModeSet_ = false;
@@ -257,6 +260,9 @@ void applyCliOverrides() {
     if (g_cliOverrides.zoomSet_) {
         g_settings.initialZoom_ = g_cliOverrides.zoom_;
     }
+    if (g_cliOverrides.yawSet_) {
+        g_settings.initialYaw_ = g_cliOverrides.yaw_;
+    }
     if (g_cliOverrides.waveAmplitudeSet_) {
         g_settings.waveAmplitude_ = g_cliOverrides.waveAmplitude_;
     }
@@ -301,6 +307,10 @@ void parseArgs(int argc, char **argv) {
                 g_cliOverrides.zoom_ = zoom;
                 g_cliOverrides.zoomSet_ = true;
             }
+            ++i;
+        } else if (std::strcmp(argv[i], "--yaw") == 0 && i + 1 < argc) {
+            g_cliOverrides.yaw_ = static_cast<float>(std::atof(argv[i + 1]));
+            g_cliOverrides.yawSet_ = true;
             ++i;
         } else if (std::strcmp(argv[i], "--wave-amplitude") == 0 && i + 1 < argc) {
             // 0.0 = static scene (no per-frame voxel motion). Useful for
@@ -573,6 +583,7 @@ int main(int argc, char **argv) {
 
     IRRender::setCameraPosition2DIso(vec2(0.0f, 0.0f));
     IRRender::setCameraZoom(g_settings.initialZoom_);
+    IRRender::setCameraVisualYaw(g_settings.initialYaw_);
     IR_LOG_INFO(
         "Initial camera zoom: requested={}, actual={}",
         g_settings.initialZoom_,

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -271,9 +271,9 @@ IREntity::EntityId getEntityIdAtMouseTrixel();
 /// @name Camera setters
 void setCameraZoom(float zoom);
 void setCameraPosition2DIso(vec2 pos);
-/// Set the camera's continuous Z-yaw. @p degrees is in degrees; non-zero
-/// values switch the voxel rasterizer from the cardinal gather path to the
-/// per-axis scatter path.
+/// Set the camera's continuous Z-yaw. Takes @p degrees in degrees (converted
+/// to radians internally); non-zero values switch the voxel rasterizer from
+/// the cardinal gather path to the per-axis scatter path.
 void setCameraVisualYaw(float degrees);
 /// @}
 

--- a/engine/render/include/irreden/ir_render.hpp
+++ b/engine/render/include/irreden/ir_render.hpp
@@ -271,6 +271,10 @@ IREntity::EntityId getEntityIdAtMouseTrixel();
 /// @name Camera setters
 void setCameraZoom(float zoom);
 void setCameraPosition2DIso(vec2 pos);
+/// Set the camera's continuous Z-yaw. @p degrees is in degrees; non-zero
+/// values switch the voxel rasterizer from the cardinal gather path to the
+/// per-axis scatter path.
+void setCameraVisualYaw(float degrees);
 /// @}
 
 /// @{

--- a/engine/render/src/ir_render.cpp
+++ b/engine/render/src/ir_render.cpp
@@ -182,6 +182,10 @@ void setCameraPosition2DIso(vec2 pos) {
     getRenderManager().setCameraPosition2DIso(pos);
 }
 
+void setCameraVisualYaw(float degrees) {
+    IRPrefab::Camera::setYaw(degrees * IRMath::kPi / 180.0f);
+}
+
 void setSubdivisionMode(SubdivisionMode mode) {
     getRenderManager().setSubdivisionMode(mode);
 }


### PR DESCRIPTION
Closes #1807

## What

- Adds `IRRender::setCameraVisualYaw(float degrees)` to `ir_render.hpp` — public API for seeding the camera's continuous Z-yaw at startup. Implemented in `ir_render.cpp` via `IRPrefab::Camera::setYaw(degrees * π / 180)`.
- Wires `--yaw <degrees>` CLI override into `IRPerfGrid` (`CliOverrides::yawSet_` / `yaw_`, `PerfGridSettings::initialYaw_`, `applyCliOverrides`, call in `main()` after `setCameraZoom`).

## Why

All prior `--auto-profile` runs were at yaw=0 (cardinal gather path). Non-cardinal yaw switches the rasterizer to the per-axis scatter path. This flag lets the profiling matrix capture scatter-path cost at yaw ∈ {30, 45} degrees so the cardinal-vs-scatter delta can be quantified for epic #1808.

## Profiling results (macOS/Metal, zoom 8, 64³ grid, static)

| Mode | Yaw | FPS | Frame (ms) | GPU voxelStage1 |
|------|-----|-----|-----------|-----------------|
| voxel_set | 0° | 21 | 49.976 | 32.317ms |
| voxel_set | 30° | 8 | 135.376 | 92.511ms (+186%) |
| voxel_set | 45° | 7 | 157.338 | 81.515ms (+152%) |
| dense_set | 0° | 20 | 52.660 | 50.759ms |
| dense_set | 30° | 62 | 16.111 | 3.705ms (–93%) |
| dense_set | 45° | 66 | 15.302 | 3.322ms (–93%) |

Per-axis scatter confirmed active via `vs1_per_axis` CPU scope. Numbers are post-#1748 (list-walk optimization already merged). Full analysis posted to #1807.

## Test plan

- [x] `fleet-build --target IRPerfGrid` passes (macOS/Metal)
- [x] `--yaw 30` + `--auto-profile` confirms per-axis scatter path fires (`vs1_per_axis` scope present)
- [x] Profiling matrix (voxel_set + dense_set × yaw 0/30/45) run and posted to #1807
- [ ] Linux/GL smoke (fleet:needs-linux-smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)