### PR TITLE
ECS world-reset / teardown primitive for scene transitions (#1814)

### DIFF
--- a/engine/entity/CLAUDE.md
+++ b/engine/entity/CLAUDE.md
@@ -328,6 +328,13 @@ next scene's entities. Lua: `IRWorld.resetGameplay()` + `IRSystem.clearPipeline`
 - **Idempotency is a count, not ids.** Entity ids never recycle (atomic
   counter), so assert on live-entity *count* (and resource counters) returning
   to baseline across cycles, never on id values.
+- **CHILD_OF relation entities for preserved entities are destroyed.** A
+  `CHILD_OF` relation is itself an ECS entity and is NOT in any preserve
+  category, so `destroyAllExceptPreserved` destroys it even when both the
+  parent and child survive a reset. The relation remains functionally correct
+  because entity ids never recycle — the zombie relation id can never become a
+  real entity. Do not call `entityExists(relationId)` expecting `true` after a
+  reset; use `getParentEntityFromArchetype` to query the relationship instead.
 
 ## Position + transform components are automatic
 

--- a/engine/entity/CLAUDE.md
+++ b/engine/entity/CLAUDE.md
@@ -275,6 +275,60 @@ the loaded entity. Workers retrofitting #199 into the singleton API should
 verify the cache invalidates on load (typically a `destroyAllEntities`
 precedes the load, which already clears the cache).
 
+## Scene-transition reset (`resetGameplay`)
+
+`IREntity::resetGameplay()` (#1814) is the scene-transition teardown
+primitive: it destroys every live **gameplay** entity while preserving the
+engine's infrastructure entities, leaving the world immediately usable for the
+next scene (the contrast with `destroyAllEntities`, which tears down
+*everything* and is end-of-world / test-teardown only).
+
+**Preserve-by-default — three categories survive a reset:**
+
+1. **Singleton entities** — everything in the singleton cache
+   (`m_singletonEntityByComponent`). The cache IS the preserve registry, so the
+   common case ("global game state lives on a singleton component") needs zero
+   per-entity bookkeeping. Crucially the cache is **NOT cleared** (unlike
+   `destroyAllEntities`), so a surviving singleton keeps its entity id *and its
+   value* across the reset.
+2. **`C_Persistent`-tagged entities** — the opt-out for a non-singleton entity
+   that must outlive a reset. The RenderManager stamps `C_Persistent` on its
+   camera + framebuffer/canvas entities at construction
+   (`render_manager.cpp`), so the render context survives. Any engine- or
+   creation-created non-singleton entity that must persist needs this tag.
+3. **Component-type backing entities** — each registered component is itself
+   backed by an entity id; these stay alive so the next scene's
+   `createEntity<T>` keeps working.
+
+The low-level primitive is `EntityManager::destroyAllExceptPreserved(
+preserveMarkers)` — generic over a list of preserve-marker `ComponentId`s, so
+`engine/entity/` carries no dependency on the prefab-layer `C_Persistent`. The
+`C_Persistent` policy lives in the `IREntity::resetGameplay` facade.
+
+**Ordering contract.** Drive a scene swap at a **frame boundary** (not mid-tick
+— `resetGameplay` eager-destroys on a snapshot, mirroring `destroyAllEntities`;
+calling it inside a `forEachComponent` / parallel group is UB). The scene
+machine does, within one boundary: `resetGameplay()` → re-register the next
+scene's pipelines (`IRSystem::clearPipeline` / `registerPipeline`) → spawn the
+next scene's entities. Lua: `IRWorld.resetGameplay()` + `IRSystem.clearPipeline`.
+
+**Gotchas:**
+
+- **Dangling EntityIds.** A surviving singleton/persistent entity holding the
+  `EntityId` of a destroyed gameplay entity goes stale. The modifier
+  pre-destroy hook auto-sweeps *modifiers*; arbitrary id fields are not swept —
+  re-acquire ids after the next scene builds, or null them in a pre-destroy hook.
+- **Named entities are pruned.** `destroyEntity` does not remove `m_namedEntities`
+  entries, so `resetGameplay` prunes every name pointing at a now-dead id
+  (otherwise `getEntityByName` would assert on the corpse). Surviving entities
+  keep their names.
+- **System-internal / Lua-global state persists** — systems are never destroyed
+  and the Lua VM is not reset. Keep per-scene state in components (destroyed on
+  reset), not in system statics or Lua globals.
+- **Idempotency is a count, not ids.** Entity ids never recycle (atomic
+  counter), so assert on live-entity *count* (and resource counters) returning
+  to baseline across cycles, never on id values.
+
 ## Position + transform components are automatic
 
 `createEntity(...)` always adds `C_LocalTransform` and

--- a/engine/entity/include/irreden/entity/entity_manager.hpp
+++ b/engine/entity/include/irreden/entity/entity_manager.hpp
@@ -96,6 +96,17 @@ class EntityManager {
     void removeComponentById(EntityId entity, ComponentId componentType);
     void destroyEntity(EntityId entity);
     void destroyAllEntities();
+    /// Scene-transition teardown (#1814): destroy every live entity EXCEPT
+    /// (1) singleton entities (everything in `m_singletonEntityByComponent`)
+    /// and (2) entities holding any of the `preserveMarkers` component types.
+    /// Unlike `destroyAllEntities`, the singleton cache is NOT cleared — the
+    /// preserved singletons stay valid for the next scene. Eager + snapshot-
+    /// based (mirrors `destroyAllEntities`): main-thread only, must NOT run
+    /// mid-iteration (call it at a frame boundary). Stale `m_namedEntities`
+    /// entries pointing at destroyed ids are pruned. Generic by design — the
+    /// `C_Persistent` policy lives in the `IREntity::resetGameplay` facade so
+    /// this low-level module stays free of any prefab-component dependency.
+    void destroyAllExceptPreserved(const std::vector<ComponentId> &preserveMarkers);
     void markEntityForDeletion(EntityId &entity);
     void destroyMarkedEntities();
     NodeId getParentNodeFromRelation(RelationId relation);
@@ -104,6 +115,10 @@ class EntityManager {
     RelationId registerRelation(Relation relation, EntityId relatedEntity);
     void setName(EntityId entity, const std::string &name);
     EntityId getEntityByName(const std::string &name) const;
+    // Non-asserting existence check (getEntityByName asserts on a miss).
+    bool hasName(const std::string &name) const {
+        return m_namedEntities.contains(name);
+    }
 
     template <typename... Components> EntityId createEntity(const Components &...components) {
         IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
@@ -115,11 +130,9 @@ class EntityManager {
         if (!isMainThreadForDeferred()) {
             EntityId entity = allocateEntityIdAtomic();
             int slot = workerSlotForCurrentThread();
-            m_workerStaging[slot].structuralChanges_.push_back(
-                [this, entity, components...]() {
-                    insertReservedEntity(entity, components...);
-                }
-            );
+            m_workerStaging[slot].structuralChanges_.push_back([this, entity, components...]() {
+                insertReservedEntity(entity, components...);
+            });
             return entity;
         }
         EntityId entity = allocateEntity();

--- a/engine/entity/include/irreden/ir_entity.hpp
+++ b/engine/entity/include/irreden/ir_entity.hpp
@@ -9,6 +9,7 @@
 
 #include <irreden/common/components/component_local_transform.hpp>
 #include <irreden/common/components/component_world_transform.hpp>
+#include <irreden/common/components/component_persistent.hpp>
 
 #include <tuple>
 #include <type_traits>
@@ -176,6 +177,14 @@ template <PrefabTypes type, typename... Args> EntityId createEntity(Args &&...ar
 EntityId setParent(EntityId child, EntityId parent);
 void destroyEntity(EntityId entity);
 void destroyAllEntities();
+
+/// Scene-transition teardown (#1814): destroy every live gameplay entity,
+/// preserving singletons and any entity tagged `C_Persistent`. The renderer's
+/// camera + canvas entities are stamped `C_Persistent` at construction so the
+/// render context survives. Call at a frame boundary (eager + snapshot-based,
+/// like `destroyAllEntities`); the scene machine then re-registers pipelines
+/// and spawns the next scene. Lua: `IRWorld.resetGameplay()`.
+void resetGameplay();
 
 // Returns the first EntityId of the batch
 // Needs to guarentee that entities are ajacent for

--- a/engine/entity/src/entity_manager.cpp
+++ b/engine/entity/src/entity_manager.cpp
@@ -6,6 +6,7 @@
 #include <irreden/job/job_manager.hpp>
 
 #include <memory>
+#include <unordered_set>
 
 namespace IREntity {
 
@@ -369,6 +370,77 @@ void EntityManager::destroyAllEntities() {
     }
 
     m_singletonEntityByComponent.clear();
+}
+
+void EntityManager::destroyAllExceptPreserved(const std::vector<ComponentId> &preserveMarkers) {
+    IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
+
+    flushStructuralChanges();
+    destroyMarkedEntities();
+
+    // Build the preserve set (masked ids). (1) Every singleton entity — the
+    // cache is the authoritative singleton registry. (2) Every entity holding
+    // a preserve-marker component, found by scanning the archetype nodes that
+    // contain the marker's ComponentId (no per-entity getComponent).
+    std::unordered_set<EntityId> preserved;
+    // (0) Component-TYPE entities. Each registered component is itself backed
+    // by an entity id (registerComponentImpl -> createEntity), so it lives in
+    // m_entityIndex. Unlike destroyAllEntities (full teardown), resetGameplay
+    // continues into the next scene, so these infrastructure entities MUST
+    // survive — otherwise the next scene's createEntity<T> would reference a
+    // ComponentId whose backing entity was torn down.
+    for (const auto &[componentId, _impl] : m_pureComponentVectors) {
+        preserved.insert(componentId & IR_ENTITY_ID_BITS);
+    }
+    for (const auto &[componentId, singletonEntity] : m_singletonEntityByComponent) {
+        if (entityExists(singletonEntity)) {
+            preserved.insert(singletonEntity & IR_ENTITY_ID_BITS);
+        }
+    }
+    if (!preserveMarkers.empty()) {
+        for (const auto &nodePtr : m_archetypeGraph.getArchetypeNodes()) {
+            ArchetypeNode *node = nodePtr.get();
+            const bool hasMarker = std::any_of(
+                preserveMarkers.begin(),
+                preserveMarkers.end(),
+                [node](ComponentId marker) { return node->type_.contains(marker); }
+            );
+            if (!hasMarker) {
+                continue;
+            }
+            for (int i = 0; i < node->length_; ++i) {
+                preserved.insert(node->entities_[i] & IR_ENTITY_ID_BITS);
+            }
+        }
+    }
+
+    // Snapshot live ids, then destroy everything not in the preserve set.
+    std::vector<EntityId> entitiesToDestroy;
+    entitiesToDestroy.reserve(m_entityIndex.size());
+    for (const auto &[entityId, _record] : m_entityIndex) {
+        if (!preserved.contains(entityId & IR_ENTITY_ID_BITS)) {
+            entitiesToDestroy.push_back(entityId);
+        }
+    }
+    for (const EntityId entity : entitiesToDestroy) {
+        if (m_entityIndex.contains(entity & IR_ENTITY_ID_BITS)) {
+            destroyEntity(entity);
+        }
+    }
+
+    // Prune stale name->id entries — destroyEntity does not touch
+    // m_namedEntities, so a destroyed gameplay entity's name would otherwise
+    // resolve (and assert) on a dead id at the next getEntityByName.
+    for (auto it = m_namedEntities.begin(); it != m_namedEntities.end();) {
+        if (!m_entityIndex.contains(it->second & IR_ENTITY_ID_BITS)) {
+            it = m_namedEntities.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    // Deliberately do NOT clear m_singletonEntityByComponent — singletons
+    // survive a gameplay reset (the key difference from destroyAllEntities).
 }
 
 EntityId EntityManager::getOrCreateSingletonByComponentId(ComponentId componentType) {

--- a/engine/entity/src/ir_entity.cpp
+++ b/engine/entity/src/ir_entity.cpp
@@ -16,6 +16,16 @@ void destroyAllEntities() {
     getEntityManager().destroyAllEntities();
 }
 
+void resetGameplay() {
+    // The preserve policy lives here (not in EntityManager) so the low-level
+    // entity module stays free of the prefab-layer C_Persistent dependency.
+    // getComponentType lazily registers C_Persistent if no entity has ever
+    // been tagged — an empty preserve-marker scan, which is harmless.
+    const ComponentId persistentMarker =
+        getEntityManager().getComponentType<IRComponents::C_Persistent>();
+    getEntityManager().destroyAllExceptPreserved({persistentMarker});
+}
+
 smart_ComponentData createComponentData(ComponentId type) {
     return getEntityManager().createComponentDataVector(type);
 }

--- a/engine/prefabs/irreden/common/components/component_persistent.hpp
+++ b/engine/prefabs/irreden/common/components/component_persistent.hpp
@@ -1,0 +1,17 @@
+#ifndef COMPONENT_PERSISTENT_H
+#define COMPONENT_PERSISTENT_H
+
+namespace IRComponents {
+
+// Tag marking a non-singleton entity to survive `IREntity::resetGameplay()`
+// (the scene-transition teardown primitive, #1814). Singleton entities are
+// preserved automatically — the EntityManager's singleton cache IS the
+// preserve registry — so this tag is only needed for the rare engine- or
+// creation-created entity that is NOT a singleton yet must outlive a scene
+// reset (e.g. the RenderManager's camera + canvas entities). Empty tag: holds
+// no data, only group membership.
+struct C_Persistent {};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_PERSISTENT_H */

--- a/engine/render/src/render_manager.cpp
+++ b/engine/render/src/render_manager.cpp
@@ -18,6 +18,7 @@
 
 #include <irreden/common/components/component_position_2d_iso.hpp>
 #include <irreden/common/components/component_size_triangles.hpp>
+#include <irreden/common/components/component_persistent.hpp>
 #include <irreden/update/components/component_velocity_2d_iso.hpp>
 #include <irreden/render/components/component_camera.hpp>
 
@@ -122,6 +123,16 @@ RenderManager::RenderManager(
     );
     m_renderImpl->init();
     IREntity::setName(m_camera, "camera");
+
+    // #1814: the renderer's camera + framebuffer/canvas entities are normal
+    // (non-singleton) ECS entities. Tag them C_Persistent so a scene-transition
+    // IREntity::resetGameplay() spares them — without the tag they'd be torn
+    // down on the first reset and the render context would break.
+    IREntity::setComponent(m_camera, C_Persistent{});
+    IREntity::setComponent(m_mainFramebuffer, C_Persistent{});
+    IREntity::setComponent(m_mainCanvas, C_Persistent{});
+    IREntity::setComponent(m_backgroundCanvas, C_Persistent{});
+    IREntity::setComponent(m_guiCanvas, C_Persistent{});
     // IRECS::setComponent(
     //     m_backgroundCanvas,
     //     C_TextureScrollPosition{

--- a/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_pipeline_bindings.hpp
@@ -248,6 +248,16 @@ inline void bindRegisterPipelineAndSystemId(
         IRSystem::registerPipeline(static_cast<IRTime::Events>(event), std::move(pipeline));
     };
 
+    // #1814: clear an event's pipeline (no systems run for it). The scene-
+    // transition counterpart to registerPipeline — a Lua scene machine clears
+    // the previous scene's pipeline, then registers the next scene's.
+    //
+    //     IRSystem.clearPipeline(IRTime.UPDATE)
+    lua["IRSystem"]["clearPipeline"] = [](lua_Integer event) {
+        requireValidPipelineEvent("IRSystem.clearPipeline", event);
+        IRSystem::clearPipeline(static_cast<IRTime::Events>(event));
+    };
+
     // T-224: groups-aware variant. Outer table is the sequence of
     // groups, each inner table a parallel group. The cross-system
     // validator runs at `World::start()` (engine-side hook); a typo

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -498,6 +498,15 @@ void LuaScript::bindLuaDrivenEcs() {
         m_lua["IREntity"] = m_lua.create_table();
     }
 
+    // #1814: world-level scene-transition teardown. Destroys every gameplay
+    // entity, preserving singletons + C_Persistent-tagged entities (the
+    // renderer's camera/canvas survive). The scene machine pairs this with
+    // IRSystem.clearPipeline / registerPipeline at a frame boundary.
+    if (!m_lua["IRWorld"].valid()) {
+        m_lua["IRWorld"] = m_lua.create_table();
+    }
+    m_lua["IRWorld"]["resetGameplay"] = []() { IREntity::resetGameplay(); };
+
     m_lua["IREntity"]["addLuaComponent"] = [this](
                                                IRScript::LuaEntity entity,
                                                sol::table componentDef,

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -348,6 +348,25 @@ IRSystem::insertIntoPipelineAfter(IRTime::Events::UPDATE, sysId, anchor);
   `IRSystem.insertSystemAfter(event, sysId, anchor)` — see
   `engine/script/CLAUDE.md` "Pipeline composition".
 
+### Clearing a pipeline (#1814)
+
+`clearPipeline(event)` empties an event's pipeline (no systems run for it) —
+the scene-transition counterpart to `registerPipeline`. A scene machine clears
+the previous scene's pipeline, then registers the next scene's:
+
+```cpp
+IRSystem::clearPipeline(IRTime::Events::UPDATE);          // tear down scene A
+IRSystem::registerPipeline(IRTime::Events::UPDATE, {...}); // bring up scene B
+```
+
+Equivalent to `registerPipeline(event, {})`. Pair it with
+`IREntity::resetGameplay()` (the entity-side teardown — see
+`engine/entity/CLAUDE.md` "Scene-transition reset") at a frame boundary so no
+system ticks against destroyed entities. Lua: `IRSystem.clearPipeline(event)`.
+Systems themselves are never destroyed (they persist for the manager lifetime);
+dropping one from a pipeline just makes it inert, which is fine since the set is
+bounded.
+
 ## SystemAccess derivation (T-221)
 
 `engine/system/include/irreden/system/system_access.hpp` defines

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -467,6 +467,12 @@ void insertIntoPipelineAfter(IRTime::Events event, SystemId system, SystemId anc
 /// hand-built pipeline.
 void validateAllPipelineGroups();
 
+/// #1814: clear `event`'s pipeline (no systems run for it). The
+/// scene-transition counterpart to `registerPipeline` — a scene machine
+/// clears the previous scene's pipeline before registering the next scene's.
+/// Lua: `IRSystem.clearPipeline(event)`.
+void clearPipeline(IRTime::Events event);
+
 void executePipeline(IRTime::Events event);
 
 inline void setTimingEnabled(bool enabled) {

--- a/engine/system/include/irreden/system/system_manager.hpp
+++ b/engine/system/include/irreden/system/system_manager.hpp
@@ -185,6 +185,12 @@ class SystemManager {
 
     void registerPipeline(IRTime::Events event, std::list<SystemId> pipeline);
 
+    /// #1814: empty `event`'s pipeline (no systems run for it). The
+    /// scene-transition counterpart to `registerPipeline` — a scene machine
+    /// clears the previous scene's pipeline, then registers the next scene's.
+    /// Equivalent to `registerPipeline(event, {})`.
+    void clearPipeline(IRTime::Events event);
+
     /// T-224: pipeline-groups API. Each inner vector is a "parallel
     /// group" of systems that the cross-system validator (see
     /// `validateAllPipelineGroups`) has cleared to co-execute on the

--- a/engine/system/src/ir_system.cpp
+++ b/engine/system/src/ir_system.cpp
@@ -32,6 +32,10 @@ void validateAllPipelineGroups() {
     getSystemManager().validateAllPipelineGroups();
 }
 
+void clearPipeline(IRTime::Events event) {
+    getSystemManager().clearPipeline(event);
+}
+
 void executePipeline(IRTime::Events event) {
     getSystemManager().executePipeline(event);
 }

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -117,6 +117,13 @@ void SystemManager::registerPipeline(IRTime::Events event, std::list<SystemId> p
     registerPipelineGroups(event, std::move(groups));
 }
 
+void SystemManager::clearPipeline(IRTime::Events event) {
+    // Empties the event's pipeline (no groups). The scene-transition
+    // counterpart to registerPipeline: clear, then register the next
+    // scene's systems. Reuses the replace semantics of registerPipeline.
+    registerPipeline(event, {});
+}
+
 void SystemManager::registerPipelineGroups(
     IRTime::Events event, std::vector<std::vector<SystemId>> groups
 ) {

--- a/test/ecs/entity_manager_test.cpp
+++ b/test/ecs/entity_manager_test.cpp
@@ -264,4 +264,98 @@ TEST_F(IREntityTest, SetComponentSupportsNonDefaultConstructibleType) {
     IREntity::setComponent(entity, TestNonDefaultConstructible{42});
     EXPECT_EQ(IREntity::getComponent<TestNonDefaultConstructible>(entity).value_, 42);
 }
+
+// resetGameplay() (#1814): scene-transition teardown. Destroys every gameplay
+// entity but preserves singletons, C_Persistent-tagged entities, and the
+// component-type backing entities. The key contrast with destroyAllEntities is
+// that the singleton cache is NOT cleared and the world remains usable.
+
+TEST_F(IREntityTest, ResetGameplayDestroysGameplayPreservesTagged) {
+    auto keep = IREntity::createEntity(TestMarker{});
+    IREntity::setComponent(keep, IRComponents::C_Persistent{});
+    auto doomedA = IREntity::createEntity(TestMarker{});
+    auto doomedB = IREntity::createEntity(TestMarker{}, TestPayload{3});
+
+    IREntity::resetGameplay();
+
+    EXPECT_TRUE(IREntity::entityExists(keep));
+    EXPECT_FALSE(IREntity::entityExists(doomedA));
+    EXPECT_FALSE(IREntity::entityExists(doomedB));
+}
+
+TEST_F(IREntityTest, ResetGameplayPreservesSingletonValueUnlikeDestroyAll) {
+    IREntity::singleton<TestSingleton>().counter_ = 77;
+    auto singletonId = IREntity::singletonEntity<TestSingleton>();
+    IREntity::createEntity(TestMarker{}); // gameplay entity, should be destroyed
+
+    IREntity::resetGameplay();
+
+    // Unlike destroyAllEntities (which clears the cache + recreates with a
+    // default), the singleton entity and its value survive intact.
+    EXPECT_EQ(IREntity::singletonEntityOrNull<TestSingleton>(), singletonId);
+    EXPECT_EQ(IREntity::singleton<TestSingleton>().counter_, 77);
+}
+
+TEST_F(IREntityTest, ResetGameplayKeepsComponentTypesUsableInNextScene) {
+    // Scene A registers TestMarker + TestPayload (and their backing
+    // component-type entities).
+    IREntity::createEntity(TestMarker{}, TestPayload{1});
+
+    IREntity::resetGameplay();
+
+    // Scene B: the same component types must still create + read correctly —
+    // regression guard for component-type-entity preservation.
+    auto entity = IREntity::createEntity(TestMarker{}, TestPayload{99});
+    auto payload = IREntity::getComponentOptional<TestPayload>(entity);
+    ASSERT_TRUE(payload.has_value());
+    EXPECT_EQ((*payload)->value_, 99);
+}
+
+TEST_F(IREntityTest, ResetGameplayPrunesNamesOfDestroyedEntities) {
+    auto keep = IREntity::createEntity(TestMarker{});
+    IREntity::setComponent(keep, IRComponents::C_Persistent{});
+    IREntity::setName(keep, "keeper");
+
+    auto doomed = IREntity::createEntity(TestMarker{});
+    IREntity::setName(doomed, "doomed");
+
+    IREntity::resetGameplay();
+
+    // Preserved entity keeps its name; destroyed entity's stale name->id entry
+    // is pruned (otherwise getEntityByName would later assert on a dead id).
+    EXPECT_TRUE(m_entity_manager.hasName("keeper"));
+    EXPECT_FALSE(m_entity_manager.hasName("doomed"));
+    EXPECT_EQ(IREntity::getEntity("keeper"), keep);
+}
+
+TEST_F(IREntityTest, ResetGameplayLiveCountIsIdempotentAcrossCycles) {
+    IREntity::singleton<TestSingleton>().counter_ = 1;
+    auto persistent = IREntity::createEntity(TestMarker{});
+    IREntity::setComponent(persistent, IRComponents::C_Persistent{});
+
+    auto buildScene = [](int count) {
+        for (int i = 0; i < count; ++i) {
+            IREntity::createEntity(TestMarker{}, TestPayload{i});
+        }
+    };
+
+    // Warm up: register every component type used, then reset so the baseline
+    // reflects the post-registration steady state (ids never recycle, so the
+    // baseline is a count, not specific id values).
+    buildScene(5);
+    IREntity::resetGameplay();
+    const IREntity::EntityId baseline = IREntity::getLiveEntityCount();
+
+    for (int cycle = 0; cycle < 12; ++cycle) {
+        buildScene(7 + cycle); // vary the scene size each cycle
+        EXPECT_GT(IREntity::getLiveEntityCount(), baseline);
+        IREntity::resetGameplay();
+        EXPECT_EQ(IREntity::getLiveEntityCount(), baseline)
+            << "live entity count drifted at cycle " << cycle;
+    }
+
+    // Preserved entities survived every cycle.
+    EXPECT_EQ(IREntity::singleton<TestSingleton>().counter_, 1);
+    EXPECT_TRUE(IREntity::entityExists(persistent));
+}
 } // namespace

--- a/test/ecs/system_exclude_test.cpp
+++ b/test/ecs/system_exclude_test.cpp
@@ -137,4 +137,19 @@ TEST_F(SystemExcludeTest, AddSystemExcludeTagMatchesExcludeTemplateParam) {
     EXPECT_EQ(IREntity::getComponent<Counter>(idB).n_, 0);
 }
 
+TEST_F(SystemExcludeTest, ClearPipelineStopsTicksOnNextExecute) {
+    auto id = IREntity::createEntity(Counter{0});
+
+    auto sysId = IRSystem::createSystem<Counter>(
+        "IncrementForClearTest",
+        [](Counter &c) { c.n_++; }
+    );
+    m_system_manager.registerPipeline(IRTime::Events::UPDATE, {sysId});
+    m_system_manager.clearPipeline(IRTime::Events::UPDATE);
+    m_system_manager.executePipeline(IRTime::Events::UPDATE);
+
+    EXPECT_EQ(IREntity::getComponent<Counter>(id).n_, 0)
+        << "cleared pipeline must fire no ticks";
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
Adds `IREntity::resetGameplay()` — the scene-transition teardown primitive (#1814). It destroys every live **gameplay** entity while preserving the engine's infrastructure, so the world stays usable for the next scene (unlike `destroyAllEntities`, which is full end-of-world teardown).

Preserve-by-default keeps three categories alive:
- **Singletons** — the singleton cache is the preserve registry and is **not** cleared, so a survivor keeps its entity id *and value*.
- **`C_Persistent`-tagged entities** — a new empty marker; the RenderManager stamps it on its camera + framebuffer/canvas entities so the render context survives a reset.
- **Component-type backing entities** — so the next scene's `createEntity<T>` keeps working.

Stale `m_namedEntities` entries pointing at destroyed ids are pruned (otherwise `getEntityByName` would later assert on a corpse).

The core primitive `EntityManager::destroyAllExceptPreserved(preserveMarkers)` is generic over a list of preserve-marker `ComponentId`s, so `engine/entity/` carries **no** dependency on the prefab-layer `C_Persistent` — the policy lives in the `resetGameplay` facade. Also adds `SystemManager::clearPipeline` (the pipeline-side scene-transition counterpart to `registerPipeline`) and Lua glue: `IRWorld.resetGameplay()`, `IRSystem.clearPipeline(event)`. A non-asserting `hasName` accessor makes name-pruning observable.

Docs: `engine/entity/CLAUDE.md` ("Scene-transition reset") + `engine/system/CLAUDE.md` ("Clearing a pipeline").

## Scope split
Per the committed plan's sanctioned `[engine primitive] → [demo]` fault line, the **render-stack** idempotency demo (a `scene_reset` demo asserting no VoxelPool/GPU growth + render-survival across ≥10 reset/rebuild cycles — the acceptance items that need a live RenderManager) is filed as the stacked follow-up **#1857**. This PR delivers the engine primitive with full unit coverage.

## Render note
The only `engine/render/` change is the ctor stamping a `C_Persistent` tag on the camera/canvas entities — no shader, pipeline, binding, or output change. IRShapeDebug was verified to construct + render identically; no visual regression possible.

## Test plan
- [x] `IrredenEngineTest` — 21 `IREntityTest` cases pass (16 existing + 5 new: live-count idempotency across 12 cycles, singleton survival w/ value, `C_Persistent` survival, component-type reuse in the next scene, name pruning).
- [x] 132 entity + system + pipeline tests pass (no regressions).
- [x] `IRShapeDebug` builds + runs headless (`--auto-screenshot`), renders cleanly with the canvas/camera stamping.
- [x] `clang-format` (format-changed) clean.

Closes #1814

🤖 Generated with [Claude Code](https://claude.com/claude-code)