### PR TITLE
render: GUI hover/click/picking assertions + hovered-widget export (P3) (#1796)

### DIFF
--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -34,6 +34,9 @@
 // Widget framework (T-145 / T-177)
 #include <irreden/render/widgets.hpp>
 
+// GUI-test assertions (P3, #1796)
+#include <irreden/render/gui_test_assertions.hpp>
+
 // Systems
 #include <irreden/update/systems/system_propagate_transform.hpp>
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
@@ -293,14 +296,73 @@ constexpr IRVideo::GuiInputEvent kPaletteClickEvents[] = {
      IRInput::kMouseButtonLeft},
 };
 
-// GUI-test shot table covering stable render framings plus one scripted-click
-// shot. Superset of the previous kShots[] — render-verify labels still match.
+// Scripted GUI-assert click (P3, #1796): park the cursor over the LAYERS-panel
+// list, press, release. The cursor stays put through capture so the hover
+// assertion still reads it; the latch catches the one-frame click-fire. The
+// list is a large, child-free hover target so the small screen→GUI-trixel
+// offset can't push the cursor off it.
+constexpr IRVideo::GuiInputEvent kGuiAssertEvents[] = {
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(190, 284)},
+    {1,
+     IRVideo::GuiInputEvent::Type::PRESS,
+     IRMath::ivec2(190, 284),
+     IRMath::vec2(0.0f),
+     IRInput::kMouseButtonLeft},
+    {2,
+     IRVideo::GuiInputEvent::Type::RELEASE,
+     IRMath::ivec2(190, 284),
+     IRMath::vec2(0.0f),
+     IRInput::kMouseButtonLeft},
+};
+
+// Scripted scene-pick (P3, #1796): move the cursor over the 3D scene (right of
+// the left-column GUI panels), so PICKS_VOXEL casts a ray onto a scene voxel —
+// the regression net for the screen→world picking alignment.
+constexpr IRVideo::GuiInputEvent kPickVoxelEvents[] = {
+    {0, IRVideo::GuiInputEvent::Type::MOVE, IRMath::ivec2(800, 450)},
+};
+
+// GUI-test shot table covering stable render framings plus the scripted-click
+// shots. Superset of the previous kShots[] — render-verify labels still match.
+// kGuiAssertShotIndex / kPickVoxelShotIndex select the assertion-bearing shots.
 constexpr IRVideo::GuiTestShot kGuiTestShots[] = {
     {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_idle"}, nullptr, 0},
     {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_palette_click"}, kPaletteClickEvents, 3},
     {{0.75f, IRMath::vec2(0.0f), 0.0f, "editor_zoom_out"}, nullptr, 0},
     {{1.5f, IRMath::vec2(0.0f), 0.0f, "editor_zoom_in"}, nullptr, 0},
+    {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_gui_assert"}, kGuiAssertEvents, 3},
+    {{1.0f, IRMath::vec2(0.0f), 0.0f, "editor_pick_voxel"}, kPickVoxelEvents, 1},
 };
+constexpr int kNumGuiTestShots = static_cast<int>(sizeof(kGuiTestShots) / sizeof(kGuiTestShots[0]));
+constexpr int kGuiAssertShotIndex = 4;
+constexpr int kPickVoxelShotIndex = 5;
+
+// GUI-test assertion tables (P3, #1796). Filled in initEntities once the widget
+// entities exist — assertions reference runtime EntityIds, so unlike the shot
+// table they can't be constexpr. Index-aligned with kGuiTestShots.
+// g_guiAssertLatch is the caller-owned latch the harness's onAssertFrame_
+// callback threads through onFrame (CLICK_FIRES latches the one-frame pulse).
+IRPrefab::GuiTest::LatchState g_guiAssertLatch;
+std::vector<IRPrefab::GuiTest::Assertion> g_shotAssertions[kNumGuiTestShots];
+
+// Forwarder wired to IRVideo::GuiTestConfig::onAssertFrame_. The harness owns
+// input + capture timing in engine/video; this hands each frame to the prefab
+// evaluator with the shot's assertion table (engine/video can't see widgets).
+void onGuiAssertFrame(int shotIndex, bool isCaptureFrame) {
+    if (shotIndex < 0 || shotIndex >= kNumGuiTestShots)
+        return;
+    const auto &assertions = g_shotAssertions[shotIndex];
+    if (assertions.empty())
+        return; // shots without assertions (idle / zoom framings) skip latch+eval
+    IRPrefab::GuiTest::onFrame(
+        g_guiAssertLatch,
+        shotIndex,
+        isCaptureFrame,
+        kGuiTestShots[shotIndex].render_.label_,
+        assertions.data(),
+        static_cast<int>(assertions.size())
+    );
+}
 
 int g_autoWarmupFrames = 0;
 
@@ -2034,6 +2096,10 @@ void initSystems() {
         cfg.shots_ = IRVoxelEditor::kGuiTestShots;
         cfg.numShots_ =
             sizeof(IRVoxelEditor::kGuiTestShots) / sizeof(IRVoxelEditor::kGuiTestShots[0]);
+        // P3 (#1796): evaluate GUI assertions at each shot's capture frame. The
+        // assertion tables themselves are populated later in initEntities (once
+        // the widget entities exist), before the game loop fires this callback.
+        cfg.onAssertFrame_ = &IRVoxelEditor::onGuiAssertFrame;
         renderPipeline.push_back(IRVideo::createGuiTestSystem(cfg));
     }
 
@@ -3191,4 +3257,28 @@ void initEntities() {
     // by placeEraseSystem to show the active mode (BOX / LINE / FACE) and which
     // symmetry axes are active so the user can see modifier state at a glance.
     IRVoxelEditor::g_fillModeLabel = IRPrefab::Widget::makeLabel(ivec2(4, 4), "BOX");
+
+    // GUI-test assertions (P3, #1796) — populated here (not at the constexpr
+    // shot table) because they reference runtime widget EntityIds. The
+    // hover-export singleton (one per world) lets HOVERS read the topmost
+    // hovered widget via WIDGET_INPUT::endTick. The scripted GUI-assert shot
+    // parks the cursor on the layer list and clicks; the pick shot casts a ray
+    // onto the scene. PICKS_VOXEL's expected voxel is the regression baseline
+    // for screen→world picking alignment.
+    IRPrefab::Widget::makeGuiHoverState();
+    IRVoxelEditor::g_shotAssertions[IRVoxelEditor::kGuiAssertShotIndex] = {
+        IRPrefab::GuiTest::hovers(IRVoxelEditor::g_layerList, "layer_list_hover"),
+        IRPrefab::GuiTest::clickFires(IRVoxelEditor::g_layerList, "layer_list_click"),
+        IRPrefab::GuiTest::checkbox(IRVoxelEditor::g_layerVisCheckbox, true, "layer_visible"),
+        IRPrefab::GuiTest::sliderValue(
+            IRVoxelEditor::g_fpsSlider,
+            IRVoxelEditor::g_anim.fps_,
+            0.5f,
+            "fps_value"
+        ),
+    };
+    constexpr ivec3 kScenePickExpected{-1, -1, -1};
+    IRVoxelEditor::g_shotAssertions[IRVoxelEditor::kPickVoxelShotIndex] = {
+        IRPrefab::GuiTest::picksVoxel(kScenePickExpected, "scene_pick"),
+    };
 }

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -383,7 +383,25 @@ so its expanded item panel paints over any neighbor it overlaps.
 per-kind apply followers exist so the input system itself never calls
 `getComponent` on per-entity kind-specific data — slider value and
 checkbox toggle land on their own dedicated systems whose archetype
-filter already includes the kind-specific component.
+filter already includes the kind-specific component. Its `endTick`
+publishes the z-ordered topmost hovered widget (`topHoveredId_`) into the
+optional `C_GuiHoverState` singleton (#1796); create one per world with
+`IRPrefab::Widget::makeGuiHoverState()` and read it back with
+`hoveredWidget()`. No singleton → the publish is a no-op, so non-test
+creations pay nothing.
+
+**Headless GUI assertions (P3, #1796).** `gui_test_assertions.hpp`
+exposes `IRPrefab::GuiTest::` — capture-frame assertions
+(`hovers` / `clickFires` / `sliderValue` / `checkbox` / `picksVoxel`)
+over the introspectable widget + picking state, each emitting one
+machine-readable `GUI-ASSERT …` log line. Evaluation lives in the prefab
+layer (it needs widget / picking access engine/video lacks); the
+`engine/video` scripted-shot harness drives it through the type-erased
+`IRVideo::GuiTestConfig::onAssertFrame_` callback, threading a
+caller-owned `GuiTest::LatchState` (CLICK_FIRES latches the one-frame
+`fireAction_` pulse across the settle window). Reference wiring:
+`creations/editors/voxel_editor/main.cpp` (`editor_gui_assert` /
+`editor_pick_voxel` shots).
 
 `WIDGET_RENDER_*` is split per kind for the same reason. Each renders
 its own backgrounds, borders, and label text onto the **GUI canvas**

--- a/engine/prefabs/irreden/render/components/component_gui_hover_state.hpp
+++ b/engine/prefabs/irreden/render/components/component_gui_hover_state.hpp
@@ -1,0 +1,23 @@
+#ifndef COMPONENT_GUI_HOVER_STATE_H
+#define COMPONENT_GUI_HOVER_STATE_H
+
+#include <irreden/ir_entity.hpp>
+
+namespace IRComponents {
+
+// Singleton: the z-ordered topmost hovered widget, published once per frame
+// by System<WIDGET_INPUT>::endTick from its private topHoveredId_ routing
+// result. Lets a consumer — chiefly the headless GUI-test harness (P3,
+// #1796) — read "which widget is hovered" without re-scanning every hitbox.
+//
+// Create exactly one per world via IRPrefab::Widget::makeGuiHoverState() and
+// read it back with IRPrefab::Widget::hoveredWidget(). When no instance
+// exists, WIDGET_INPUT::endTick is a no-op and the accessor returns
+// kNullEntity, so non-test creations pay nothing.
+struct C_GuiHoverState {
+    IREntity::EntityId hoveredWidget_ = IREntity::kNullEntity;
+};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_GUI_HOVER_STATE_H */

--- a/engine/prefabs/irreden/render/gui_test_assertions.hpp
+++ b/engine/prefabs/irreden/render/gui_test_assertions.hpp
@@ -1,0 +1,232 @@
+#ifndef IRREDEN_GUI_TEST_ASSERTIONS_H
+#define IRREDEN_GUI_TEST_ASSERTIONS_H
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_profile.hpp>
+
+#include <irreden/render/components/component_widget.hpp>
+#include <irreden/render/picking.hpp>
+#include <irreden/render/widgets.hpp>
+
+#include <optional>
+#include <string>
+#include <unordered_set>
+
+// Phase 3 of the GUI + mouse verification harness (#1796). Capture-frame
+// assertions over the introspectable widget + picking state, driven by the
+// #1795 scripted-shot harness in engine/video. Evaluation lives here (the
+// prefab layer) rather than in engine/video because it needs widget / picking
+// components engine/video cannot see — the harness calls in through the
+// type-erased GuiTestConfig::onAssertFrame_ function pointer.
+//
+// Usage (a creation, after its widgets exist): build a per-shot
+// `Assertion` table, own one `LatchState`, and forward the harness's
+// onAssertFrame_ callback to `onFrame`. Each evaluated assertion emits one
+// machine-readable `GUI-ASSERT ...` log line the P4 gui-verify skill greps
+// the way render-verify parses image diffs.
+namespace IRPrefab::GuiTest {
+
+enum class AssertKind {
+    HOVERS,       // IRPrefab::Widget::hoveredWidget() == widget_
+    CLICK_FIRES,  // widget_ pulsed C_WidgetState::fireAction_ during the shot
+    SLIDER_VALUE, // |sliderValue(widget_) - expectedFloat_| <= tolerance_
+    CHECKBOX,     // checkboxState(widget_) == expectedBool_
+    PICKS_VOXEL,  // castVoxelRay() hits with voxelPos_ == expectedVoxel_
+};
+
+// One assertion evaluated at a shot's capture frame. Only the fields a given
+// kind reads are meaningful; the rest stay default.
+struct Assertion {
+    AssertKind kind_ = AssertKind::HOVERS;
+    IREntity::EntityId widget_ = IREntity::kNullEntity; // widget-target kinds
+    float expectedFloat_ = 0.0f;                        // SLIDER_VALUE
+    float tolerance_ = 0.001f;                          // SLIDER_VALUE
+    bool expectedBool_ = false;                         // CHECKBOX
+    IRMath::ivec3 expectedVoxel_ = IRMath::ivec3(0);    // PICKS_VOXEL
+    const char *label_ = "assert";                      // human-readable tag
+};
+
+// Factory helpers — readable, order-safe assertion construction at call sites
+// (a creation builds its per-shot tables from these).
+inline Assertion hovers(IREntity::EntityId widget, const char *label = "hovers") {
+    Assertion assertion;
+    assertion.kind_ = AssertKind::HOVERS;
+    assertion.widget_ = widget;
+    assertion.label_ = label;
+    return assertion;
+}
+
+inline Assertion clickFires(IREntity::EntityId widget, const char *label = "click_fires") {
+    Assertion assertion;
+    assertion.kind_ = AssertKind::CLICK_FIRES;
+    assertion.widget_ = widget;
+    assertion.label_ = label;
+    return assertion;
+}
+
+inline Assertion sliderValue(
+    IREntity::EntityId widget,
+    float expected,
+    float tolerance = 0.001f,
+    const char *label = "slider_value"
+) {
+    Assertion assertion;
+    assertion.kind_ = AssertKind::SLIDER_VALUE;
+    assertion.widget_ = widget;
+    assertion.expectedFloat_ = expected;
+    assertion.tolerance_ = tolerance;
+    assertion.label_ = label;
+    return assertion;
+}
+
+inline Assertion
+checkbox(IREntity::EntityId widget, bool expected, const char *label = "checkbox") {
+    Assertion assertion;
+    assertion.kind_ = AssertKind::CHECKBOX;
+    assertion.widget_ = widget;
+    assertion.expectedBool_ = expected;
+    assertion.label_ = label;
+    return assertion;
+}
+
+inline Assertion picksVoxel(IRMath::ivec3 expected, const char *label = "picks_voxel") {
+    Assertion assertion;
+    assertion.kind_ = AssertKind::PICKS_VOXEL;
+    assertion.expectedVoxel_ = expected;
+    assertion.label_ = label;
+    return assertion;
+}
+
+// Caller-owned latch. CLICK_FIRES needs it: C_WidgetState::fireAction_ is a
+// single-frame pulse on click-release, gone by the post-settle capture frame,
+// so we accumulate which widgets fired across the shot window. The creation
+// owns one instance and threads it through onFrame — system/harness-owned
+// state must never be a function-local static (.claude/rules/cpp-systems.md).
+struct LatchState {
+    std::unordered_set<IREntity::EntityId> firedWidgets_;
+};
+
+namespace detail {
+
+inline const char *kindName(AssertKind kind) {
+    switch (kind) {
+    case AssertKind::HOVERS:
+        return "HOVERS";
+    case AssertKind::CLICK_FIRES:
+        return "CLICK_FIRES";
+    case AssertKind::SLIDER_VALUE:
+        return "SLIDER_VALUE";
+    case AssertKind::CHECKBOX:
+        return "CHECKBOX";
+    case AssertKind::PICKS_VOXEL:
+        return "PICKS_VOXEL";
+    }
+    return "UNKNOWN";
+}
+
+// Record every widget whose fireAction_ pulsed this frame.
+inline void latchFires(LatchState &latch) {
+    IREntity::forEachComponent<IRComponents::C_WidgetState>(
+        [&latch](IREntity::EntityId &id, IRComponents::C_WidgetState &state) {
+            if (!state.fireAction_)
+                return;
+            latch.firedWidgets_.insert(id);
+        }
+    );
+}
+
+inline bool firedThisShot(const LatchState &latch, IREntity::EntityId widget) {
+    return latch.firedWidgets_.count(widget) != 0;
+}
+
+} // namespace detail
+
+// Evaluate one assertion at the capture frame. Returns true on pass and writes
+// a short description of the observed value into `actual` for the log line.
+inline bool evaluateOne(const Assertion &assertion, const LatchState &latch, std::string &actual) {
+    switch (assertion.kind_) {
+    case AssertKind::HOVERS: {
+        const IREntity::EntityId hovered = IRPrefab::Widget::hoveredWidget();
+        actual = "hovered=" + std::to_string(hovered);
+        return hovered == assertion.widget_;
+    }
+    case AssertKind::CLICK_FIRES: {
+        const bool fired = detail::firedThisShot(latch, assertion.widget_);
+        actual = fired ? "fired" : "no-fire";
+        return fired;
+    }
+    case AssertKind::SLIDER_VALUE: {
+        const float value = IRPrefab::Widget::sliderValue(assertion.widget_);
+        actual = "value=" + std::to_string(value);
+        return IRMath::abs(value - assertion.expectedFloat_) <= assertion.tolerance_;
+    }
+    case AssertKind::CHECKBOX: {
+        const bool checked = IRPrefab::Widget::checkboxState(assertion.widget_);
+        actual = checked ? "checked" : "unchecked";
+        return checked == assertion.expectedBool_;
+    }
+    case AssertKind::PICKS_VOXEL: {
+        const std::optional<IRPrefab::Picking::RayHit> hit = IRPrefab::Picking::castVoxelRay();
+        if (!hit) {
+            actual = "miss";
+            return false;
+        }
+        const IRMath::ivec3 v = hit->voxelPos_;
+        actual = "voxel=(" + std::to_string(v.x) + "," + std::to_string(v.y) + "," +
+                 std::to_string(v.z) + ")";
+        return v == assertion.expectedVoxel_;
+    }
+    }
+    actual = "unknown-kind";
+    return false;
+}
+
+// Evaluate every assertion for a shot, emitting one machine-readable line each:
+//   GUI-ASSERT shot=<i> label=<shot> kind=<KIND> target=<eid> name=<tag>
+//              result=PASS|FAIL actual=<observed>
+inline void evaluate(
+    const LatchState &latch,
+    int shotIndex,
+    const char *shotLabel,
+    const Assertion *assertions,
+    int count
+) {
+    for (int i = 0; i < count; ++i) {
+        const Assertion &assertion = assertions[i];
+        std::string actual;
+        const bool pass = evaluateOne(assertion, latch, actual);
+        IR_LOG_INFO(
+            "GUI-ASSERT shot={} label={} kind={} target={} name={} result={} actual={}",
+            shotIndex,
+            shotLabel != nullptr ? shotLabel : "",
+            detail::kindName(assertion.kind_),
+            assertion.widget_,
+            assertion.label_ != nullptr ? assertion.label_ : "",
+            pass ? "PASS" : "FAIL",
+            actual
+        );
+    }
+}
+
+// Per-frame driver wired to GuiTestConfig::onAssertFrame_. Latches one-frame
+// pulses every live frame; on the capture frame, evaluates + logs all of the
+// shot's assertions, then clears the latch so the next shot starts clean.
+inline void onFrame(
+    LatchState &latch,
+    int shotIndex,
+    bool isCaptureFrame,
+    const char *shotLabel,
+    const Assertion *assertions,
+    int count
+) {
+    detail::latchFires(latch);
+    if (!isCaptureFrame)
+        return;
+    evaluate(latch, shotIndex, shotLabel, assertions, count);
+    latch.firedWidgets_.clear();
+}
+
+} // namespace IRPrefab::GuiTest
+
+#endif /* IRREDEN_GUI_TEST_ASSERTIONS_H */

--- a/engine/prefabs/irreden/render/systems/system_widget_input.hpp
+++ b/engine/prefabs/irreden/render/systems/system_widget_input.hpp
@@ -9,6 +9,7 @@
 
 #include <irreden/render/components/component_widget.hpp>
 #include <irreden/render/components/component_gui_position.hpp>
+#include <irreden/render/components/component_gui_hover_state.hpp>
 #include <irreden/input/components/component_hitbox_2d_gui.hpp>
 #include <irreden/render/layout.hpp>
 #include <irreden/render/widget_hotkeys.hpp>
@@ -196,6 +197,21 @@ template <> struct System<WIDGET_INPUT> {
                     IRMath::clamp(dx / static_cast<float>(widget.size_.x), 0.0f, 1.0f);
             }
         }
+    }
+
+    // Publish the z-ordered topmost hovered widget (resolved in beginTick)
+    // into the C_GuiHoverState singleton, if a creation registered one. A
+    // once-per-frame singleton write (endTick is allowed to do bounded
+    // lookups, unlike the per-entity tick). No singleton → no-op, so
+    // non-test creations pay nothing. Read back via
+    // IRPrefab::Widget::hoveredWidget(); used by the headless GUI-test
+    // harness (#1796) to assert hover without re-scanning hitboxes.
+    void endTick() {
+        IREntity::forEachComponent<IRComponents::C_GuiHoverState>(
+            [this](IREntity::EntityId &, IRComponents::C_GuiHoverState &hoverState) {
+                hoverState.hoveredWidget_ = topHoveredId_;
+            }
+        );
     }
 
     static SystemId create() {

--- a/engine/prefabs/irreden/render/widgets.hpp
+++ b/engine/prefabs/irreden/render/widgets.hpp
@@ -6,6 +6,7 @@
 
 #include <irreden/render/components/component_widget.hpp>
 #include <irreden/render/components/component_gui_position.hpp>
+#include <irreden/render/components/component_gui_hover_state.hpp>
 #include <irreden/input/components/component_hitbox_2d_gui.hpp>
 #include <irreden/common/components/component_tags_all.hpp>
 #include <irreden/render/widget_theme.hpp>
@@ -143,6 +144,26 @@ inline float sliderValue(IREntity::EntityId widget) {
 
 inline bool checkboxState(IREntity::EntityId widget) {
     return IREntity::getComponent<IRComponents::C_WidgetCheckbox>(widget).checked_;
+}
+
+// Hovered-widget export (#1796). Create one C_GuiHoverState singleton per
+// world with makeGuiHoverState(); WIDGET_INPUT::endTick publishes the
+// z-ordered topmost hovered widget into it each frame. hoveredWidget()
+// reads it back — kNullEntity when nothing is hovered or no singleton
+// exists. Lets a headless GUI test assert "which widget is hovered"
+// without re-scanning every hitbox.
+inline IREntity::EntityId makeGuiHoverState() {
+    return IREntity::createEntity(IRComponents::C_GuiHoverState{});
+}
+
+inline IREntity::EntityId hoveredWidget() {
+    IREntity::EntityId result = IREntity::kNullEntity;
+    IREntity::forEachComponent<IRComponents::C_GuiHoverState>(
+        [&result](IREntity::EntityId &, IRComponents::C_GuiHoverState &hoverState) {
+            result = hoverState.hoveredWidget_;
+        }
+    );
+    return result;
 }
 
 inline void setSliderValue(IREntity::EntityId widget, float value) {

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -134,11 +134,21 @@ struct GuiTestShot {
 };
 
 /// Declarative config for @c createGuiTestSystem.
+///
+/// @c onAssertFrame_ is the Phase 3 (#1796) assertion hook. When set, the
+/// harness calls it once per frame while a shot is live (from the first frame
+/// after the camera is applied through the capture frame), passing the shot
+/// index and whether this is the capture frame. Assertion evaluation needs
+/// widget / picking state that engine/video cannot see, so it is injected as a
+/// type-erased callback the creation supplies (typically forwarding to
+/// @c IRPrefab::GuiTest::onFrame). @c nullptr keeps a pure-capture run — every
+/// existing GuiTest caller is unaffected.
 struct GuiTestConfig {
     int warmupFrames_ = 10;
     int settleFrames_ = 3;
     const GuiTestShot *shots_ = nullptr;
     int numShots_ = 0;
+    void (*onAssertFrame_)(int shotIndex, bool isCaptureFrame) = nullptr;
 };
 
 /// Create a system that fires scripted input events on scheduled frames,

--- a/engine/video/src/auto_screenshot.cpp
+++ b/engine/video/src/auto_screenshot.cpp
@@ -199,6 +199,15 @@ IRSystem::SystemId createGuiTestSystem(const GuiTestConfig &config) {
             // captureAt: settleFrames_ full settle frames follow the last event.
             const int captureAt = maxOffset + 1 + state->config_.settleFrames_;
 
+            // Phase 3 assertion hook (#1796): fire every live frame so the
+            // consumer can latch one-frame pulses (C_WidgetState::fireAction_);
+            // flag the capture frame for evaluation. Gated on
+            // !screenshotRequested_ so the capture frame fires it exactly once
+            // (the request tick), not again on the advance tick.
+            if (state->config_.onAssertFrame_ != nullptr && !state->screenshotRequested_) {
+                state->config_.onAssertFrame_(state->currentShot_, state->shotFrame_ == captureAt);
+            }
+
             // Event phase: dispatch any events scheduled for shotFrame_.
             if (state->shotFrame_ <= maxOffset) {
                 for (int i = 0; i < shot.numInputs_; ++i) {


### PR DESCRIPTION
Stacked on: https://github.com/jakildev/IrredenEngine/pull/1833

## Summary
P3 of the GUI + mouse verification harness epic (#1793), built on the #1795 scripted-shot harness. Adds deterministic capture-frame GUI assertions plus a hovered-widget export.

- **`C_GuiHoverState` singleton** — `WIDGET_INPUT::endTick` publishes the z-ordered topmost hovered widget (`topHoveredId_`) into it; read via `IRPrefab::Widget::hoveredWidget()`, created with `makeGuiHoverState()`. No singleton → no-op, so non-test creations pay nothing.
- **`IRPrefab::GuiTest` assertion module** (`gui_test_assertions.hpp`) — `HOVERS` / `CLICK_FIRES` / `SLIDER_VALUE` / `CHECKBOX` / `PICKS_VOXEL`, each emitting one machine-readable `GUI-ASSERT …` log line (the P4 `gui-verify` skill greps these like render-verify parses image diffs). Evaluation lives in the prefab layer because it needs widget/picking access `engine/video` cannot see. `CLICK_FIRES` latches the one-frame `fireAction_` pulse across the settle window via a caller-owned `LatchState` (no function-local static).
- **engine/video harness hook** — `GuiTestConfig::onAssertFrame_`, a type-erased per-frame callback the creation forwards to the evaluator; `nullptr` keeps existing GuiTest callers unchanged.
- **voxel_editor wiring** — two scripted shots (`editor_gui_assert`, `editor_pick_voxel`).

Non-rendering change (a singleton write read only by test code + capture-time assertions + an accessor): no pixel delta to existing shots, so no before/after screenshots. The headless run renders all 6 shots cleanly.

## Test plan
- [x] `fleet-build --target IRVoxelEditor` clean.
- [x] `fleet-run IRVoxelEditor --auto-screenshot` — all 5 assertion kinds PASS (HOVERS/CLICK_FIRES/CHECKBOX/SLIDER_VALUE on `editor_gui_assert`, PICKS_VOXEL on `editor_pick_voxel`).
- [x] PICKS_VOXEL stable across repeated runs (regression net for screen→world picking alignment).

Closes #1796