### PR TITLE
render: fix rotated-frame profiling instrumentation — CULL VOX counter + per-axis GPU timing (#1856)

### DIFF
--- a/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
+++ b/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
@@ -286,6 +286,18 @@ template <> struct System<PERF_STATS_OVERLAY> {
 
         // CULL — visible/total counters. Not smoothed; integer counts read
         // fine as raw values, and smoothing would lag the diagnostic.
+        //
+        // VOX visible is the prior frame's voxel-cull survivor count. In the
+        // rotating (per-axis) path it sums the three axis regions, so a voxel
+        // exposed on N axes counts N times — a per-axis-work signal, not a 1:1
+        // voxel count (see VOXEL_TO_TRIXEL_STAGE_1's cull-diagnostic readback).
+        //
+        // Settled-vs-transient: these HUD counters and the GPU-stage rows above
+        // report the LAST sampled frame, so a single `--auto-screenshot` shot
+        // captures the unsettled camera-cut frame (per-axis chunk-bounds rebuild,
+        // one-frame occlusion self-disable) and reads low/zero. The settled
+        // `--auto-profile` run (its drained running avg/max) is the authoritative
+        // perf + cull source; the overlay is a live glance, not a measurement.
         std::snprintf(
             line,
             sizeof(line),

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -837,28 +837,6 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         }
         syncEntityIds(voxelPool, liveVoxelCount, voxelEntityIdBuf_);
 
-        // Cull diagnostic readback (gated by gpu_stage_timing.enabled_).
-        // The buffer still holds the prior frame's visibleCount; reading
-        // it here — before we zero it for this frame's compact pass —
-        // requires no explicit fence: the driver serializes the CPU read
-        // against the prior frame's already-retired compact write.
-        // Frame N+1 reads frame N's value; the first frame reports 0,
-        // contributing a 1/N bias to the running average — negligible
-        // over typical measurement runs.
-        if (gpuStageTiming().enabled_) {
-            VoxelIndirectDispatchParams previous{};
-            indirectBuf_->getSubData(0, sizeof(VoxelIndirectDispatchParams), &previous);
-            gpuStageTiming().visibleVoxelCount_ = previous.visibleCount;
-            gpuStageTiming().totalVoxelCount_ = static_cast<std::uint32_t>(effectiveVoxelCount);
-            voxelCullAccumulator().record(
-                previous.visibleCount,
-                static_cast<std::uint32_t>(effectiveVoxelCount)
-            );
-        }
-
-        const VoxelIndirectDispatchParams zeroed{};
-        indirectBuf_->subData(0, sizeof(VoxelIndirectDispatchParams), &zeroed);
-
         // Smooth camera Z-yaw (T3 / #1310): while the MAIN canvas's per-axis
         // canvases are active, SKIP the single-canvas voxel rasterization. The
         // per-axis dispatch below writes the voxels (smooth), and the framebuffer
@@ -870,10 +848,59 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // alongside the smooth voxels. The compact pass below still runs (the
         // per-axis dispatch reuses its compacted list). Detached entities (incl.
         // re-voxelize SO(3)) always take the single-canvas emit + blit, so this is
-        // false for them, byte-identical to master.
+        // false for them, byte-identical to master. Resolved before the cull
+        // diagnostic so it can pick the matching indirect-dispatch-params source.
         const bool skipSingleCanvasVoxels = entity == perAxisCanvasEntity_ &&
                                             perAxisCanvases_ != nullptr &&
                                             perAxisCanvases_->isAllocated();
+
+        // Cull diagnostic readback (gated by gpu_stage_timing.enabled_).
+        // The indirect buffer still holds the prior frame's visibleCount;
+        // reading it here — before we zero it for this frame's compact pass —
+        // requires no explicit fence: the driver serializes the CPU read
+        // against the prior frame's already-retired compact write.
+        // Frame N+1 reads frame N's value; the first frame reports 0,
+        // contributing a 1/N bias to the running average — negligible
+        // over typical measurement runs.
+        //
+        // The source depends on the path the prior frame's compact took. The
+        // single-canvas (cardinal) compact appends survivors into indirectBuf_,
+        // but the per-axis split (#1739, active iff skipSingleCanvasVoxels)
+        // routes its count into perAxisIndirectBuf_'s three axis regions and
+        // leaves indirectBuf_ zeroed. Reading indirectBuf_ unconditionally
+        // reported a spurious 0/total for every rotating (per-axis) frame
+        // (#1856) — sum the three axis regions when the split path is active.
+        // A voxel exposed on N axes is appended to N regions, so the per-axis
+        // sum counts face-routings (≥ the unique visible-voxel count): the
+        // "how much work the per-axis path does" cull-effectiveness signal the
+        // overlay wants, not a strict voxel count comparable 1:1 to cardinal.
+        if (gpuStageTiming().enabled_) {
+            std::uint32_t visible = 0;
+            if (skipSingleCanvasVoxels && perAxisIndirectBuf_ != nullptr) {
+                for (int axis = 0; axis < C_PerAxisTrixelCanvases::kAxisCount; ++axis) {
+                    VoxelIndirectDispatchParams region{};
+                    perAxisIndirectBuf_->getSubData(
+                        static_cast<std::ptrdiff_t>(axis) * kPerAxisSsboAlignBytes,
+                        sizeof(VoxelIndirectDispatchParams),
+                        &region
+                    );
+                    visible += region.visibleCount;
+                }
+            } else {
+                VoxelIndirectDispatchParams previous{};
+                indirectBuf_->getSubData(0, sizeof(VoxelIndirectDispatchParams), &previous);
+                visible = previous.visibleCount;
+            }
+            gpuStageTiming().visibleVoxelCount_ = visible;
+            gpuStageTiming().totalVoxelCount_ = static_cast<std::uint32_t>(effectiveVoxelCount);
+            voxelCullAccumulator().record(
+                visible,
+                static_cast<std::uint32_t>(effectiveVoxelCount)
+            );
+        }
+
+        const VoxelIndirectDispatchParams zeroed{};
+        indirectBuf_->subData(0, sizeof(VoxelIndirectDispatchParams), &zeroed);
 
         // Per-axis store list-walk split (#1739). For exactly the main-canvas-
         // rotating compact (whose voxels the per-axis dispatch consumes, and


### PR DESCRIPTION
## Summary
Fixes the `CULL VOX` overlay counter reporting a spurious `0/total` on every
rotating (per-axis) frame, verifies the per-axis GPU-timing attribution, and
documents the settled-vs-transient gap. **Pure instrumentation — no render
output change.** Plan of record: `.fleet/plans/issue-1856.md`.

### Item 1 — counter (the actual code fix)
The cull diagnostic read `visibleCount` from `indirectBuf_` unconditionally.
While the main canvas rotates, the per-axis store split (#1739) routes the
compact's survivor count into `perAxisIndirectBuf_`'s three axis regions and
leaves `indirectBuf_` zeroed — so the readback saw `0`. Fix: hoist the
per-axis-split predicate above the diagnostic and sum the three axis regions
when it's active. Cardinal frames are byte-identical.

Steady-state cull stats (dense_set, 262144 voxels, macOS/Metal,
`--auto-profile 60`, avg / max):

| Case | Before (master) | After |
|---|---|---|
| zoom1 cardinal | 257775 / 262144 | 257775 / 262144 (unchanged) |
| zoom1 rotated | **0** / 262144 | 24166 / 262144 |
| zoom8 cardinal | 210638 / 262144 | 210638 / 262144 (unchanged) |
| zoom8 rotated | **0** / 262144 | 16908 / 262144 |

The per-axis sum counts *face-routings* (a voxel exposed on N axes counts N
times), so it's a per-axis-work signal, not a 1:1 voxel count — noted in the
readback comment and the overlay.

### Item 2 — per-axis GPU timing: already fixed by #1778
The plan suspected the per-axis scatter dispatch was outside the `voxelStage1`
GPU timer scope. On current master that's no longer true: merged **#1778**
(span all Metal encoders) brackets the per-axis dispatch, which runs *inside*
`VOXEL_TO_TRIXEL_STAGE_1`'s tick. Confirmed empirically — rotated `voxelStage1`
GPU scales 1.16 ms (zoom1) → 6.77 ms (zoom8), which only happens if the
dispatch is timed. No timer change needed; this is the plan's **preferred**
option (per-axis folded into `voxelStage1`).

The architect's original screenshot anomalies (zoom8 cardinal `0`, zoom8
rotated `214208`) were **transient settling artifacts** — `--auto-screenshot`
captures the unsettled camera-cut frame. Steady-state `--auto-profile` reads
correctly. Documented in the overlay (item 3).

## Render-output verification
The new readback runs solely under `gpuStageTiming().enabled_` and writes only
overlay HUD globals — no render dispatch, texture, or buffer is touched.
**28/28 `IRShapeDebug --auto-screenshot` shots are byte-identical (`cmp`)
between origin/master and this branch.** Per `engine/render/CLAUDE.md`'s
no-runtime-effect exception, screenshots are omitted (provably zero visual
delta; the only intended behavior change is the overlay counter itself).

## Test plan
- [x] `fleet-build --target IRPerfGrid` clean (macOS/Metal)
- [x] CULL VOX nonzero & sensible across all 4 zoom×{cardinal,rotated} cases
- [x] Cardinal cull counts byte-identical pre/post fix
- [x] 28/28 IRShapeDebug shots byte-identical vs origin/master (no regression)
- [ ] Linux/OpenGL cross-host smoke (backend-agnostic C++; `getSubData` is in the `Buffer` interface)

Closes #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)
