### PR TITLE
render: sweep _HPP include-guard outliers back to _H (#1823)

### DIFF
--- a/engine/prefabs/irreden/demo/components/component_example.hpp
+++ b/engine/prefabs/irreden/demo/components/component_example.hpp
@@ -1,5 +1,5 @@
-#ifndef COMPONENT_EXAMPLE_HPP
-#define COMPONENT_EXAMPLE_HPP
+#ifndef COMPONENT_EXAMPLE_H
+#define COMPONENT_EXAMPLE_H
 
 #include <string>
 
@@ -17,4 +17,4 @@ struct C_Example {
 
 } // namespace IRComponents
 
-#endif // COMPONENT_EXAMPLE_HPP
+#endif // COMPONENT_EXAMPLE_H

--- a/engine/prefabs/irreden/render/gui_text_batch.hpp
+++ b/engine/prefabs/irreden/render/gui_text_batch.hpp
@@ -1,5 +1,5 @@
-#ifndef GUI_TEXT_BATCH_HPP
-#define GUI_TEXT_BATCH_HPP
+#ifndef GUI_TEXT_BATCH_H
+#define GUI_TEXT_BATCH_H
 
 // Batched GUI text on the compute path.
 //
@@ -300,4 +300,4 @@ inline void dispatchGuiText(std::vector<IRRender::GlyphDrawCommand> &commands) {
 
 } // namespace IRPrefab::GuiText
 
-#endif /* GUI_TEXT_BATCH_HPP */
+#endif /* GUI_TEXT_BATCH_H */

--- a/engine/render/include/irreden/render/voxel_pool_config.hpp
+++ b/engine/render/include/irreden/render/voxel_pool_config.hpp
@@ -1,5 +1,5 @@
-#ifndef IR_RENDER_VOXEL_POOL_CONFIG_HPP
-#define IR_RENDER_VOXEL_POOL_CONFIG_HPP
+#ifndef IR_RENDER_VOXEL_POOL_CONFIG_H
+#define IR_RENDER_VOXEL_POOL_CONFIG_H
 
 #include <irreden/ir_math.hpp>
 
@@ -45,4 +45,4 @@ int getMaxAllocationSizeTotal();
 
 } // namespace IRRender::VoxelPoolConfig
 
-#endif // IR_RENDER_VOXEL_POOL_CONFIG_HPP
+#endif // IR_RENDER_VOXEL_POOL_CONFIG_H


### PR DESCRIPTION
## Summary
- Rename the three first-party headers whose include guard still used the `_HPP` suffix back to the engine-wide `_H` convention enforced by `simplify-check-naming`:
  - `engine/prefabs/irreden/demo/components/component_example.hpp` — `COMPONENT_EXAMPLE_HPP` → `COMPONENT_EXAMPLE_H`
  - `engine/render/include/irreden/render/voxel_pool_config.hpp` — `IR_RENDER_VOXEL_POOL_CONFIG_HPP` → `IR_RENDER_VOXEL_POOL_CONFIG_H`
  - `engine/prefabs/irreden/render/gui_text_batch.hpp` — `GUI_TEXT_BATCH_HPP` → `GUI_TEXT_BATCH_H`
- Each file: `#ifndef` / `#define` / trailing `#endif` comment renamed together. No other identifier, no logic change.

## Scope note — 3 files, not 2 (plan premise was stale)
The committed plan (`.fleet/plans/issue-1823.md`) scoped this to **2** files, asserting `gui_text_batch.hpp` was absent on master because PR #1774 "landed GUI-text batching without that header". That is not the case on current `origin/master`: PR #1774 (`c7b18b84`, merged 2026-06-13) **added** `engine/prefabs/irreden/render/gui_text_batch.hpp` with a `GUI_TEXT_BATCH_HPP` guard. The issue title says "3 outliers" and the acceptance criterion requires the `_HPP` grep to return empty, so all **three** extant outliers were swept (the issue's original premise, restored).

## Test plan
- [x] `grep -rEl '^#ifndef [A-Z0-9_]+_HPP[[:space:]]*$' engine | grep -v third_party` returns **empty** (zero first-party `_HPP` guard outliers remain).
- [x] Each renamed file's `#ifndef` / `#define` / `#endif`-comment tokens agree.
- [x] No stray references to the old or new guard macro names anywhere in `engine/` or `creations/` (guards are self-contained).
- [x] `fleet-build --target IRShapeDebug` builds clean.
- No screenshot / render-verify pass: pure preprocessor guard-token rename, provably no runtime or render-output effect.

Closes #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)