### PR TITLE
tooling: gui-verify skill for deterministic GUI tests (P4, #1797)

### DIFF
--- a/.claude/skills/gui-verify/SKILL.md
+++ b/.claude/skills/gui-verify/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: gui-verify
+description: >-
+  Behavioral GUI test harness for Irreden Engine creations. Builds a creation,
+  runs it headless with the P3 GUI-test shot table, parses per-assertion
+  PASS/FAIL from the result log, and exits non-zero on failure. Use after any
+  GUI interaction change (hover routing, click dispatch, picking) to catch
+  behavioral regressions without a human in the loop.
+---
+
+# GUI Verify
+
+Thin wrapper over the shared flow at
+[`docs/agents/skills/gui-verify.md`](../../../docs/agents/skills/gui-verify.md).
+Read that doc for the full step sequence, anti-patterns, and image-comparison
+integration notes.
+
+## Deltas (engine repo)
+
+| Delta key | Engine value |
+|---|---|
+| **runner** | `scripts/gui-verify.py` |
+| **build tool** | `fleet-build` |
+| **run tool** | `fleet-run` |
+| **warmup default** | `10` |
+
+## Quick reference
+
+```
+# Run GUI tests for the voxel editor (builds first):
+python3 scripts/gui-verify.py IRVoxelEditor
+
+# Skip the build step:
+python3 scripts/gui-verify.py IRVoxelEditor --no-build
+
+# Increase warmup frames if assertions are timing-sensitive:
+python3 scripts/gui-verify.py IRVoxelEditor --warmup-frames 20
+```
+
+## Worked example: voxel editor
+
+`creations/editors/voxel_editor/main.cpp` ships two assertion shots (shots 4
+and 5 in the `kGuiTestShots[]` table):
+
+| Shot index | Label | Assertions |
+|---|---|---|
+| 4 | `editor_gui_assert` | HOVERS(layer_list), CLICK_FIRES(layer_list), CHECKBOX(layer_visible, true), SLIDER_VALUE(fps_slider, fps, 0.5) |
+| 5 | `editor_pick_voxel` | PICKS_VOXEL(ivec3(-1,-1,-1)) |
+
+Run:
+
+```
+python3 scripts/gui-verify.py IRVoxelEditor
+```
+
+Expected: all assertions PASS; non-zero exit and a failing-assertion list if
+any state is wrong after synthetic input injection.
+
+## Adding GUI tests to a new creation
+
+See [`docs/agents/skills/gui-verify.md`](../../../docs/agents/skills/gui-verify.md)
+§ "Adding a first GUI test to a creation".

--- a/docs/agents/skills/gui-verify.md
+++ b/docs/agents/skills/gui-verify.md
@@ -1,0 +1,182 @@
+# gui-verify — shared flow
+
+The canonical `gui-verify` flow: build a creation, run it headless with a
+scripted-input shot table, parse the per-assertion result log emitted by the
+P3 GUI-test harness, and report a pass/fail table. Exits non-zero when any
+assertion fails so CI and fleet agents get a parseable signal.
+
+Every repo that runs a fleet keeps its
+`.claude/skills/gui-verify/SKILL.md` as a thin wrapper that points here and
+supplies only its **deltas** (below) plus any repo-specific procedure files.
+See [`docs/design/skill-sharing.md`](../../design/skill-sharing.md) for the
+mechanism. Wherever a step needs a repo-specific value it names a **delta
+key** in bold.
+
+---
+
+## Repo deltas this flow needs
+
+| Delta key | What it is | Engine value |
+|---|---|---|
+| **runner** | Path to the runner script. | `scripts/gui-verify.py` |
+| **build tool** | Tool used to build the target. | `fleet-build` |
+| **run tool** | Tool used to run the target. | `fleet-run` |
+| **warmup default** | Default warmup frames passed to `--auto-screenshot`. | `10` |
+
+---
+
+## Prerequisites
+
+### Creation requirement: P3 GUI-test harness
+
+The creation must opt into the P3 assertion tables:
+
+1. Include `engine/prefabs/irreden/render/gui_test_assertions.hpp`.
+2. Populate `g_shotAssertions[i]` arrays for the shots under test.
+3. Call `createGuiTestSystem(cfg)` in `initSystems()` (done automatically
+   when `g_autoWarmupFrames > 0`, set by `--auto-screenshot`).
+
+When this is in place the binary emits one `GUI-ASSERT` log line per
+assertion per assertion-shot, in the format:
+
+```
+GUI-ASSERT shot=<N> label=<lbl> kind=<KIND> target=<eid> name=<tag> result=PASS|FAIL actual=<observed>
+```
+
+Assertion kinds: `HOVERS`, `CLICK_FIRES`, `SLIDER_VALUE`, `CHECKBOX`,
+`PICKS_VOXEL`.
+
+### Platform
+
+Works on any host that can run the creation headless. On macOS the Metal
+backend is used; on Linux the OpenGL backend. The assertion-log path is
+backend-agnostic (results come from CPU-side state, not pixel comparison).
+
+---
+
+## Running the harness
+
+```
+python3 <runner> <target>
+```
+
+Concrete engine example (voxel editor, all six shots including the two
+assertion shots):
+
+```
+python3 scripts/gui-verify.py IRVoxelEditor
+```
+
+Options:
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--warmup-frames N` | 10 | Warmup frames for `--auto-screenshot N`. |
+| `--no-build` | off | Skip the build step (assume binary is current). |
+| `--timeout S` | 120 | Watchdog: kill the process after S seconds. |
+
+---
+
+## What the runner does
+
+1. **Build** — `fleet-build --target <target>` (unless `--no-build`).
+2. **Run** — `fleet-run --timeout <S> <target> --auto-screenshot <N>`,
+   capturing combined stdout+stderr while streaming it to the terminal.
+3. **Parse** — scan the captured output for lines matching
+   `GUI-ASSERT ... result=PASS|FAIL ...`.
+4. **Report** — print a per-assertion table (shot / label / kind / name /
+   result / actual value).
+5. **Exit** — non-zero if any assertion is `FAIL` or if the binary itself
+   exits non-zero.
+
+### Typical pass output
+
+```
+shot   label                          kind           name                   result   actual
+-----------------------------------------------------------------------------------------------
+4      editor_gui_assert              HOVERS         layer_list_hover       PASS     widget=1234
+4      editor_gui_assert              CLICK_FIRES    layer_list_click       PASS     fired=true
+4      editor_gui_assert              CHECKBOX       layer_visible          PASS     checked=true
+4      editor_gui_assert              SLIDER_VALUE   fps_value              PASS     fps=24.0
+5      editor_pick_voxel              PICKS_VOXEL    scene_pick             PASS     voxel=(-1,-1,-1)
+
+[gui-verify] 5/5 assertions passed
+```
+
+### Typical fail output
+
+```
+shot   label                          kind           name                   result   actual
+-----------------------------------------------------------------------------------------------
+4      editor_gui_assert              HOVERS         layer_list_hover       FAIL     widget=none
+...
+
+[gui-verify] 0/5 assertions passed
+
+Failing assertions:
+  shot=4 name=layer_list_hover kind=HOVERS actual=widget=none
+```
+
+---
+
+## Adding a first GUI test to a creation
+
+1. In `main.cpp`, add shot entries to the shot table for the GUI-test and
+   pick-test scenarios (follow `creations/editors/voxel_editor/main.cpp`
+   shots 4–5 as a worked example).
+2. Populate `g_shotAssertions[<shot_index>]` with assertions from the
+   `IRPrefab::GuiTest` factory functions.
+3. Run once with the **runner** to confirm assertions pass:
+   `python3 <runner> <target> --no-build`
+4. Re-run a second time to confirm stable (no flake from timing/settle
+   windows).
+
+### Assertion stability
+
+`CLICK_FIRES` and `CHECKBOX` assertions have a settle window (`settleFrames_`
+in `GuiTestConfig`) after synthetic input before the capture frame. Increase
+the settle window if assertions flake (widen the gap between input injection
+and the assertion frame).
+
+---
+
+## Image-comparison integration
+
+For visual regressions on GUI regions (panel layout, text rendering), the
+`render-verify` harness handles pixel comparison via `scripts/render-compare.py`.
+The two harnesses are complementary:
+
+- **`gui-verify`** — behavioral assertions: "did the hover state update?
+  did the click fire the action?" No image reference needed.
+- **`render-verify`** — pixel assertions: "does the panel look the same as
+  the committed reference?" Requires committed PNGs.
+
+Use `render-verify` with a `crops` block in the creation's
+`test/references/manifest.json` when you want both behavioral and visual
+coverage. The behavioral assertions in `gui-verify` are the faster, backend-
+agnostic gate; pixel comparison is an opt-in overlay.
+
+---
+
+## Anti-patterns
+
+- Running on a non-headless host without a display. The binary needs a Metal
+  or OpenGL context even in `--auto-screenshot` mode.
+- Asserting world-space voxel positions that depend on camera state before
+  the camera settles. Gate picks on a deterministic initial camera pose.
+- Increasing `warmup-frames` indefinitely to mask flaky settle windows.
+  Fix the root cause (increase `settleFrames_` in the shot config) instead.
+- Checking PASS/FAIL only from the process exit code without reading the
+  assertion table. A binary that exits 0 but emits no `GUI-ASSERT` lines is
+  silently mis-wired; the runner warns on this case.
+
+---
+
+## Related
+
+- `.claude/skills/render-verify/SKILL.md` — pixel-level regression harness
+  (use alongside gui-verify for visual coverage).
+- `engine/prefabs/irreden/render/gui_test_assertions.hpp` — assertion
+  factory and per-frame driver (P3 of epic #1793).
+- `engine/video/include/irreden/video/auto_screenshot.hpp` — `GuiTestConfig`
+  and `GuiTestShot` types that drive the harness.

--- a/docs/agents/skills/gui-verify.md
+++ b/docs/agents/skills/gui-verify.md
@@ -33,8 +33,9 @@ The creation must opt into the P3 assertion tables:
 
 1. Include `engine/prefabs/irreden/render/gui_test_assertions.hpp`.
 2. Populate `g_shotAssertions[i]` arrays for the shots under test.
-3. Call `createGuiTestSystem(cfg)` in `initSystems()` (done automatically
-   when `g_autoWarmupFrames > 0`, set by `--auto-screenshot`).
+3. Call `IRVideo::createGuiTestSystem(cfg)` in `initSystems()`, guarded by
+   `if (g_autoWarmupFrames > 0)` so the harness only runs in screenshot mode
+   (follow `creations/editors/voxel_editor/main.cpp` as the worked example).
 
 When this is in place the binary emits one `GUI-ASSERT` log line per
 assertion per assertion-shot, in the format:

--- a/scripts/gui-verify.py
+++ b/scripts/gui-verify.py
@@ -41,7 +41,8 @@ def _run_capture(cmd: list[str]) -> tuple[int, str]:
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
     )
     lines: list[str] = []
-    assert proc.stdout is not None
+    if proc.stdout is None:
+        raise RuntimeError("stdout unavailable (Popen stdout=PIPE failed)")
     for line in proc.stdout:
         print(line, end="", flush=True)
         lines.append(line)

--- a/scripts/gui-verify.py
+++ b/scripts/gui-verify.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""gui-verify — build a creation, run it headless, parse GUI-ASSERT output, report pass/fail.
+
+Parses the per-assertion result log emitted by IRPrefab::GuiTest::evaluate()
+when a creation is run with --auto-screenshot. Exits non-zero on any FAIL.
+
+Usage:
+    python3 scripts/gui-verify.py IRVoxelEditor
+    python3 scripts/gui-verify.py IRVoxelEditor --warmup-frames 15 --timeout 60
+    python3 scripts/gui-verify.py IRVoxelEditor --no-build
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Pattern: GUI-ASSERT shot=<N> label=<lbl> kind=<K> target=<eid> name=<tag> result=PASS|FAIL actual=<val>
+_GUI_ASSERT_RE = re.compile(
+    r"GUI-ASSERT\s+"
+    r"shot=(\S+)\s+"
+    r"label=(\S+)\s+"
+    r"kind=(\S+)\s+"
+    r"target=(\S+)\s+"
+    r"name=(\S+)\s+"
+    r"result=(PASS|FAIL)\s+"
+    r"actual=(.*)"
+)
+
+
+def _run(cmd: list[str]) -> int:
+    """Run a command, streaming output to the terminal; return its exit code."""
+    print("+ " + " ".join(cmd), flush=True)
+    return subprocess.run(cmd).returncode
+
+
+def _run_capture(cmd: list[str]) -> tuple[int, str]:
+    """Run a command, tee output to the terminal, and return (exit_code, combined_text)."""
+    print("+ " + " ".join(cmd), flush=True)
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    lines: list[str] = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        print(line, end="", flush=True)
+        lines.append(line)
+    proc.wait()
+    return proc.returncode, "".join(lines)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run GUI tests headless and report per-assertion pass/fail."
+    )
+    parser.add_argument("target", help="CMake / ir-run executable name (e.g. IRVoxelEditor)")
+    parser.add_argument(
+        "--warmup-frames",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Warmup frames passed as --auto-screenshot N (default: 10)",
+    )
+    parser.add_argument(
+        "--no-build",
+        action="store_true",
+        help="Skip the fleet-build step (assume the binary is already built)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        metavar="S",
+        help="Watchdog timeout in seconds passed to fleet-run (default: 120)",
+    )
+    args = parser.parse_args()
+
+    if not args.no_build:
+        rc = _run(["fleet-build", "--target", args.target])
+        if rc != 0:
+            raise SystemExit(f"[gui-verify] fleet-build failed ({rc})")
+
+    run_cmd = [
+        "fleet-run",
+        "--timeout", str(args.timeout),
+        args.target,
+        "--auto-screenshot", str(args.warmup_frames),
+    ]
+    run_rc, output = _run_capture(run_cmd)
+
+    assertions = []
+    for m in _GUI_ASSERT_RE.finditer(output):
+        shot, label, kind, target, name, result, actual = m.groups()
+        assertions.append(
+            dict(shot=shot, label=label, kind=kind,
+                 target=target, name=name, result=result, actual=actual.strip())
+        )
+
+    print()
+
+    if not assertions:
+        msg = "[gui-verify] no GUI-ASSERT lines found in output"
+        if run_rc != 0:
+            print(msg)
+            raise SystemExit(1)
+        print(msg + " (run exited 0 — target may have no assertion tables)")
+        return
+
+    # Pass/fail table
+    C = dict(shot=6, label=30, kind=14, name=22, result=8)
+    header = (f"{'shot':<{C['shot']}} {'label':<{C['label']}} "
+              f"{'kind':<{C['kind']}} {'name':<{C['name']}} {'result':<{C['result']}} actual")
+    print(header)
+    print("-" * (sum(C.values()) + 4 + 30))
+    for a in assertions:
+        print(
+            f"{a['shot']:<{C['shot']}} {a['label']:<{C['label']}} "
+            f"{a['kind']:<{C['kind']}} {a['name']:<{C['name']}} "
+            f"{a['result']:<{C['result']}} {a['actual']}"
+        )
+
+    failures = [a for a in assertions if a["result"] == "FAIL"]
+    n = len(assertions)
+    passed = n - len(failures)
+    print(f"\n[gui-verify] {passed}/{n} assertions passed")
+
+    if failures:
+        print("\nFailing assertions:")
+        for a in failures:
+            print(f"  shot={a['shot']} name={a['name']} kind={a['kind']} actual={a['actual']}")
+
+    if failures or run_rc != 0:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/gui-verify.py` — headless runner: builds a creation, runs with `--auto-screenshot`, captures combined output, parses `GUI-ASSERT` log lines emitted by the P3 assertion harness, prints a per-assertion pass/fail table, exits non-zero on any FAIL
- Add `docs/agents/skills/gui-verify.md` — canonical shared flow following the skill-sharing mechanism (repo-neutral, with delta keys)
- Add `.claude/skills/gui-verify/SKILL.md` — thin engine wrapper pointing at the shared flow

## Stack context
This PR stacks on the P3 assertions harness and is part of epic #1793.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/1859

## Test plan
- [x] `fleet-build --target IRVoxelEditor` → clean build (picks up P3 assertion tables)
- [x] `python3 scripts/gui-verify.py IRVoxelEditor --no-build` → 5/5 PASS (HOVERS, CLICK_FIRES, CHECKBOX, SLIDER_VALUE, PICKS_VOXEL) — run twice, both stable
- [x] Confirmed exit code 0 on all-pass, would exit 1 on any FAIL
- [x] Cross-references in new docs verified (gui_test_assertions.hpp, auto_screenshot.hpp, skill-sharing paths all exist on base branch)

Closes #1797

🤖 Generated with [Claude Code](https://claude.com/claude-code)