### PR TITLE
engine/asset: .irkv key/value persistence + IRSave Lua API (#1819)

### DIFF
--- a/engine/asset/CLAUDE.md
+++ b/engine/asset/CLAUDE.md
@@ -10,6 +10,9 @@ asset formats land here. Current formats:
   records and/or SDF shape-group composition; see editor-epic design doc).
 - **Rigs** — `.rig` binary + `.rig.json` sidecar (joint hierarchy + bind
   points + skeletal animation tracks).
+- **Key/value stores** — `.irkv` binary (flat named scalar / list values
+  for high scores + settings; Lua-reachable via `IRSave`). No sidecar —
+  not designer-diffed.
 
 The binary-I/O primitives (`BinaryWriter`/`Reader`, chunk-table header
 helpers, name-table encoding, JSON sidecar emitter) used by every new
@@ -36,6 +39,12 @@ snapshot (issue #199). It walks the archetype graph, so it lives in
 - `saveRig(name, path, rig)` / `loadRig(name, path)` — joints-first
   rig asset round-trip (see `.rig format` below). Buffer-mode
   `writeRig` / `readRig` are exposed for in-memory consumers.
+- `saveKeyValueStore(path, store)` / `loadKeyValueStore(path)` — flat
+  `.irkv` key/value round-trip (see `.irkv format` below). Takes a full
+  path (incl. extension), not the `(name, path)` split — callers compose
+  the path, typically `IRUtility::userDataDir("irreden")/<name>.irkv`.
+  Buffer-mode `writeKeyValueStore` / `readKeyValueStore` are exposed for
+  in-memory consumers + tests.
 
 The `name` is embedded in the trixel file header; the `path` is the
 output directory. For sprite sheets, `name` is the basename shared
@@ -99,6 +108,60 @@ The asset-side `IRAsset::Rig` is distinct from the runtime
 via `engine/prefabs/irreden/voxel/rig_bridge.hpp`
 (`IRPrefab::Rig::toComponent` / `fromComponent`). Splitting the two
 keeps `engine/asset/` independent of the prefab voxel component.
+
+## .irkv format
+
+`.irkv` v1 — a flat, named key/value store for high scores + settings
+(#1819). It is the lightweight, Lua-reachable alternative to the ECS world
+snapshot (#199 / epic #667): a flat map of string keys to typed values, NOT
+an archetype-graph walk. A store maps to one file (e.g. `highscores.irkv`,
+`settings.irkv`); gameplay reaches it from Lua via the `IRSave` table.
+
+```
+AssetHeader { magic = "IRKV", version = 1, chunkCount }
+ChunkTableEntry[chunkCount]
+KVPR chunk body:
+    varuint  entryCount
+    repeat entryCount times:
+        string  key              // varuint-prefixed UTF-8
+        uint8   valueTag         // ValueType: 0=NUMBER 1=BOOL 2=STRING 3=LIST
+        value payload, by tag:
+            NUMBER → float64
+            BOOL   → uint8 (0 / 1)
+            STRING → string
+            LIST   → varuint elemCount, then per element:
+                         uint8 elemTag (NUMBER | BOOL | STRING — no nesting)
+                         elem payload (float64 / uint8 / string)
+```
+
+- **Values are a tagged variant** (`IRAsset::Value`): `NUMBER` (float64),
+  `BOOL`, `STRING`, or `LIST` (a flat vector of scalar `ListElem`s — no
+  nested lists in v1). One mechanism covers a high-score table (list of
+  numbers) or a name list (list of strings) plus individual settings.
+- **Numbers are float64** because LuaJIT has no integer subtype (all Lua
+  numbers are doubles) and a double is exact for whole numbers to 2^53 —
+  far beyond any high score. No int64 value type until a real consumer
+  needs values above 2^53.
+- **Entries are written in sorted-key order** so the on-disk bytes are
+  reproducible regardless of hash-map iteration order.
+- **No sidecar** — settings/scores aren't designer-diffed (cf. `.rig.json`).
+  Add one via `json_sidecar.hpp` later if a use case appears; don't block on it.
+- **Recoverable, never fatal** (Extensibility Rule #5): bad magic,
+  truncation, a version above the loader's max, or an **unknown value tag**
+  (a future writer added a value type — its payload can't be length-skipped)
+  all surface as a recoverable `BinaryIOError`; the file-mode `loadKeyValueStore`
+  returns an empty store so a missing/corrupt save degrades to defaults. A
+  whole unknown *chunk*, by contrast, is silently skipped (Rule #1).
+- **Per-user data dir, not the exe dir.** Callers compose the path via
+  `IRUtility::userDataDir("irreden")` (resolves `$XDG_DATA_HOME` /
+  `~/Library/Application Support` / `%APPDATA%`) so a save survives a clean
+  reinstall of the game bundle. `saveKeyValueStore` runs
+  `std::filesystem::create_directories` on the parent first, since
+  `userDataDir` / `joinPath` do not create directories.
+
+The Lua `IRSave` surface (`engine/script/.../lua_persistence_bindings.hpp`)
+crosses values by `sol::type` inspection (number/string/bool/array-table),
+not a Lua-spelled enum, so the `cpp-lua-enums` rule does not apply.
 
 ## Typical usage
 

--- a/engine/asset/CMakeLists.txt
+++ b/engine/asset/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(IrredenEngineAsset STATIC
     src/json_sidecar.cpp
     src/voxel_set_format.cpp
     src/rig_format.cpp
+    src/key_value_store.cpp
 )
 
 target_compile_options(

--- a/engine/asset/include/irreden/asset/binary_io.hpp
+++ b/engine/asset/include/irreden/asset/binary_io.hpp
@@ -38,6 +38,7 @@ enum class BinaryIOError {
     InvalidString,    ///< string length prefix exceeded available bytes
     ChunkOutOfBounds, ///< chunk-table entry points outside the file
     WriteFailed,      ///< fwrite returned fewer bytes than requested
+    UnknownTag,       ///< unrecognized value/record discriminant byte (likely a newer writer)
 };
 
 /// Status payload returned by void-typed binary operations.

--- a/engine/asset/include/irreden/asset/key_value_store.hpp
+++ b/engine/asset/include/irreden/asset/key_value_store.hpp
@@ -1,0 +1,150 @@
+#ifndef IR_ASSET_KEY_VALUE_STORE_H
+#define IR_ASSET_KEY_VALUE_STORE_H
+
+/// `.irkv` v1 — a flat, named key/value persistence surface for high
+/// scores + settings (issue #1819). Built entirely on the shared
+/// `BinaryWriter` / `BinaryReader` + chunk-table primitives in this module
+/// — NOT the ECS world snapshot (#199 / epic #667), which walks the
+/// archetype graph and lives in `engine/world/`. A store is a flat map of
+/// string keys to typed scalar / list values; gameplay reaches it from Lua
+/// via the `IRSave` table (`engine/script/.../lua_persistence_bindings.hpp`).
+///
+/// On-disk layout
+/// --------------
+///
+///     AssetHeader  { magic = "IRKV", version = 1, chunkCount }
+///     ChunkTableEntry[chunkCount]
+///     KVPR chunk body:
+///         varuint  entryCount
+///         repeat entryCount times:
+///             string  key              // varuint-prefixed UTF-8
+///             uint8   valueTag         // ValueType: 0=NUMBER 1=BOOL 2=STRING 3=LIST
+///             value payload, by tag:
+///                 NUMBER → float64
+///                 BOOL   → uint8 (0 / 1)
+///                 STRING → string
+///                 LIST   → varuint elemCount, then per element:
+///                              uint8 elemTag (NUMBER | BOOL | STRING — no nesting)
+///                              elem payload (float64 / uint8 / string)
+///
+/// Forward compatibility: a future writer that adds a new top-level chunk
+/// is skipped silently by an older loader (Extensibility Rule #1). A value
+/// tag this loader doesn't recognize (e.g. a future writer adds a new
+/// value type) cannot be length-skipped, so the read stops with a
+/// recoverable `UnknownTag` error and the file-level loader returns an
+/// empty store (Rule #5) — never a crash.
+///
+/// Version history
+/// ---------------
+/// v1 (initial) — NUMBER / BOOL / STRING / LIST values in the KVPR chunk.
+///
+/// Numbers are stored as float64: LuaJIT has no integer subtype (all Lua
+/// numbers are doubles), and a double represents whole numbers exactly to
+/// 2^53 — far beyond any high score. No int64 value type until a real
+/// consumer needs values above 2^53.
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace IRAsset {
+
+/// On-disk value discriminant. The numeric values double as the variant
+/// alternative indices of `Value` / `ListElem` below (NUMBER=0, BOOL=1,
+/// STRING=2, LIST=3) so `static_cast<ValueType>(v.index())` is the tag.
+enum class ValueType : std::uint8_t {
+    NUMBER = 0,
+    BOOL = 1,
+    STRING = 2,
+    LIST = 3,
+};
+
+/// A scalar list element — number, bool, or string. Lists do not nest in
+/// v1, so a list element is exactly these three (the first three `Value`
+/// alternatives, in the same order).
+using ListElem = std::variant<double, bool, std::string>;
+
+/// A stored value: a scalar (number / bool / string) or a flat list of
+/// scalars. Alternative order matches `ValueType` so `index()` is the tag.
+using Value = std::variant<double, bool, std::string, std::vector<ListElem>>;
+
+/// The on-disk tag for @p value (its variant alternative index).
+inline ValueType valueType(const Value &value) {
+    return static_cast<ValueType>(value.index());
+}
+
+/// In-memory flat key/value store. One per logical save file (e.g.
+/// "highscores", "settings"). Persisted via `saveKeyValueStore` /
+/// `loadKeyValueStore` below.
+class KeyValueStore {
+  public:
+    void set(const std::string &key, Value value) {
+        m_entries[key] = std::move(value);
+    }
+
+    /// Returns a pointer to the stored value, or nullptr if @p key is absent.
+    const Value *get(const std::string &key) const {
+        const auto it = m_entries.find(key);
+        return it == m_entries.end() ? nullptr : &it->second;
+    }
+
+    /// Typed convenience reads — return @p fallback when the key is absent
+    /// or holds a different type.
+    double getNumber(const std::string &key, double fallback = 0.0) const;
+    bool getBool(const std::string &key, bool fallback = false) const;
+    std::string getString(const std::string &key, const std::string &fallback = "") const;
+
+    bool has(const std::string &key) const {
+        return m_entries.find(key) != m_entries.end();
+    }
+
+    /// Removes @p key. Returns true if it was present.
+    bool remove(const std::string &key) {
+        return m_entries.erase(key) > 0;
+    }
+
+    void clear() {
+        m_entries.clear();
+    }
+
+    std::size_t size() const {
+        return m_entries.size();
+    }
+
+    std::vector<std::string> keys() const;
+
+  private:
+    std::unordered_map<std::string, Value> m_entries;
+};
+
+constexpr std::array<char, 4> kKeyValueMagic{'I', 'R', 'K', 'V'};
+constexpr std::uint32_t kKeyValueFormatVersion = 1;
+
+/// Buffer-mode write — exposed so tests (and any future in-memory consumer)
+/// can exercise the format without touching disk. Mirrors `writeRig`.
+BinaryStatus writeKeyValueStore(BinaryWriter &w, const KeyValueStore &store);
+
+/// Buffer-mode read counterpart. Bad magic / truncation / a version above
+/// `kKeyValueFormatVersion` / an unknown value tag surface as recoverable
+/// errors (Rule #5); `value_` is an empty store on error.
+Result<KeyValueStore> readKeyValueStore(BinaryReader &r);
+
+/// File-mode save to @p path (a full path including the `.irkv` extension).
+/// Creates the parent directory via `std::filesystem::create_directories`
+/// first, since `userDataDir` / `joinPath` do not. Returns the writer's
+/// failure state.
+BinaryStatus saveKeyValueStore(const std::string &path, const KeyValueStore &store);
+
+/// File-mode load from @p path. A missing file returns `OpenFailed`; a
+/// corrupt / truncated / too-new file returns a recoverable error with an
+/// empty store (Rule #5) — callers treat either as "no save → defaults".
+Result<KeyValueStore> loadKeyValueStore(const std::string &path);
+
+} // namespace IRAsset
+
+#endif /* IR_ASSET_KEY_VALUE_STORE_H */

--- a/engine/asset/include/irreden/ir_asset.hpp
+++ b/engine/asset/include/irreden/ir_asset.hpp
@@ -1,6 +1,8 @@
 #ifndef IR_ASSET_H
 #define IR_ASSET_H
 
+#include <irreden/asset/key_value_store.hpp>
+
 #include <irreden/ir_math.hpp>
 
 #include <string>

--- a/engine/asset/src/key_value_store.cpp
+++ b/engine/asset/src/key_value_store.cpp
@@ -1,0 +1,342 @@
+#include <irreden/asset/key_value_store.hpp>
+
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/ir_profile.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <utility>
+
+namespace IRAsset {
+
+namespace {
+
+constexpr std::array<char, 4> kKvprTag{'K', 'V', 'P', 'R'};
+
+// ---- Scalar element encode / decode --------------------------------------
+
+// Writes one scalar (NUMBER | BOOL | STRING): a uint8 tag then its payload.
+void encodeScalar(MemoryBinaryWriter &body, const ListElem &elem) {
+    body.writeU8(static_cast<std::uint8_t>(elem.index()));
+    switch (static_cast<ValueType>(elem.index())) {
+    case ValueType::NUMBER:
+        body.writeF64(std::get<double>(elem));
+        break;
+    case ValueType::BOOL:
+        body.writeU8(std::get<bool>(elem) ? 1u : 0u);
+        break;
+    case ValueType::STRING:
+        body.writeString(std::get<std::string>(elem));
+        break;
+    case ValueType::LIST:
+        // ListElem can never hold a LIST (no nesting in v1) — the variant
+        // has only three alternatives, so this case is unreachable.
+        break;
+    }
+}
+
+// Reads one scalar value of the given @p tag into @p out. The tag has
+// already been read + validated as NUMBER | BOOL | STRING by the caller.
+BinaryStatus decodeScalar(BinaryReader &r, ValueType tag, ListElem &out) {
+    switch (tag) {
+    case ValueType::NUMBER: {
+        auto v = r.readF64();
+        if (!v.ok()) {
+            return v.status_;
+        }
+        out = v.value_;
+        return BinaryStatus::success();
+    }
+    case ValueType::BOOL: {
+        auto v = r.readU8();
+        if (!v.ok()) {
+            return v.status_;
+        }
+        out = (v.value_ != 0);
+        return BinaryStatus::success();
+    }
+    case ValueType::STRING: {
+        auto v = r.readString();
+        if (!v.ok()) {
+            return v.status_;
+        }
+        out = std::move(v.value_);
+        return BinaryStatus::success();
+    }
+    case ValueType::LIST:
+        break;
+    }
+    return BinaryStatus::error(
+        BinaryIOError::UnknownTag,
+        "list element tag " + std::to_string(static_cast<int>(tag)) + " is not a scalar in " +
+            r.sourceName()
+    );
+}
+
+// ---- KVPR chunk encode / decode ------------------------------------------
+
+BinaryStatus encodeKvprChunk(MemoryBinaryWriter &body, const KeyValueStore &store) {
+    // Sort keys so the on-disk byte order is stable regardless of hash-map
+    // iteration order — keeps saves reproducible (and diffable) across runs.
+    std::vector<std::string> keys = store.keys();
+    std::sort(keys.begin(), keys.end());
+
+    body.writeVarUInt(keys.size());
+    for (const std::string &key : keys) {
+        const Value *value = store.get(key);
+        body.writeString(key);
+        body.writeU8(static_cast<std::uint8_t>(value->index()));
+        switch (valueType(*value)) {
+        case ValueType::NUMBER:
+            body.writeF64(std::get<double>(*value));
+            break;
+        case ValueType::BOOL:
+            body.writeU8(std::get<bool>(*value) ? 1u : 0u);
+            break;
+        case ValueType::STRING:
+            body.writeString(std::get<std::string>(*value));
+            break;
+        case ValueType::LIST: {
+            const auto &list = std::get<std::vector<ListElem>>(*value);
+            body.writeVarUInt(list.size());
+            for (const ListElem &elem : list) {
+                encodeScalar(body, elem);
+            }
+            break;
+        }
+        }
+    }
+    if (body.failed()) {
+        return BinaryStatus::error(BinaryIOError::WriteFailed, body.failureMessage());
+    }
+    return BinaryStatus::success();
+}
+
+Result<KeyValueStore> decodeKvprChunk(const LoadedChunk &chunk, const std::string &sourceName) {
+    MemoryBinaryReader r(chunk.data_.data(), chunk.data_.size(), sourceName + ":KVPR");
+    KeyValueStore store;
+
+    auto countR = r.readVarUInt();
+    if (!countR.ok()) {
+        return Result<KeyValueStore>::error(
+            countR.status_.code_,
+            std::move(countR.status_.message_)
+        );
+    }
+
+    for (std::uint64_t i = 0; i < countR.value_; ++i) {
+        auto keyR = r.readString();
+        if (!keyR.ok()) {
+            return Result<KeyValueStore>::error(
+                keyR.status_.code_,
+                std::move(keyR.status_.message_)
+            );
+        }
+        auto tagR = r.readU8();
+        if (!tagR.ok()) {
+            return Result<KeyValueStore>::error(
+                tagR.status_.code_,
+                std::move(tagR.status_.message_)
+            );
+        }
+        const auto tag = static_cast<ValueType>(tagR.value_);
+        switch (tag) {
+        case ValueType::NUMBER: {
+            auto v = r.readF64();
+            if (!v.ok()) {
+                return Result<KeyValueStore>::error(v.status_.code_, std::move(v.status_.message_));
+            }
+            store.set(keyR.value_, Value{v.value_});
+            break;
+        }
+        case ValueType::BOOL: {
+            auto v = r.readU8();
+            if (!v.ok()) {
+                return Result<KeyValueStore>::error(v.status_.code_, std::move(v.status_.message_));
+            }
+            store.set(keyR.value_, Value{v.value_ != 0});
+            break;
+        }
+        case ValueType::STRING: {
+            auto v = r.readString();
+            if (!v.ok()) {
+                return Result<KeyValueStore>::error(v.status_.code_, std::move(v.status_.message_));
+            }
+            store.set(keyR.value_, Value{std::move(v.value_)});
+            break;
+        }
+        case ValueType::LIST: {
+            auto nR = r.readVarUInt();
+            if (!nR.ok()) {
+                return Result<KeyValueStore>::error(
+                    nR.status_.code_,
+                    std::move(nR.status_.message_)
+                );
+            }
+            std::vector<ListElem> list;
+            // Cap the reserve to the remaining bytes so a corrupted count
+            // claiming billions of elements can't pre-allocate.
+            const std::uint64_t cap = r.remaining();
+            list.reserve(static_cast<std::size_t>(nR.value_ < cap ? nR.value_ : cap));
+            for (std::uint64_t e = 0; e < nR.value_; ++e) {
+                auto elemTagR = r.readU8();
+                if (!elemTagR.ok()) {
+                    return Result<KeyValueStore>::error(
+                        elemTagR.status_.code_,
+                        std::move(elemTagR.status_.message_)
+                    );
+                }
+                const auto elemTag = static_cast<ValueType>(elemTagR.value_);
+                ListElem elem;
+                if (auto st = decodeScalar(r, elemTag, elem); !st.ok()) {
+                    return Result<KeyValueStore>::error(st.code_, std::move(st.message_));
+                }
+                list.push_back(std::move(elem));
+            }
+            store.set(keyR.value_, Value{std::move(list)});
+            break;
+        }
+        default:
+            // A value tag this loader doesn't know — likely written by a
+            // newer build that added a value type. We can't length-skip an
+            // unknown payload, so stop with a recoverable error (Rule #5).
+            return Result<KeyValueStore>::error(
+                BinaryIOError::UnknownTag,
+                "unknown value tag " + std::to_string(static_cast<int>(tagR.value_)) +
+                    " for key '" + keyR.value_ + "' in " + r.sourceName()
+            );
+        }
+    }
+    return Result<KeyValueStore>::success(std::move(store));
+}
+
+} // namespace
+
+// ---- KeyValueStore typed reads -------------------------------------------
+
+double KeyValueStore::getNumber(const std::string &key, double fallback) const {
+    const Value *v = get(key);
+    if (v != nullptr) {
+        if (const double *n = std::get_if<double>(v)) {
+            return *n;
+        }
+    }
+    return fallback;
+}
+
+bool KeyValueStore::getBool(const std::string &key, bool fallback) const {
+    const Value *v = get(key);
+    if (v != nullptr) {
+        if (const bool *b = std::get_if<bool>(v)) {
+            return *b;
+        }
+    }
+    return fallback;
+}
+
+std::string KeyValueStore::getString(const std::string &key, const std::string &fallback) const {
+    const Value *v = get(key);
+    if (v != nullptr) {
+        if (const std::string *s = std::get_if<std::string>(v)) {
+            return *s;
+        }
+    }
+    return fallback;
+}
+
+std::vector<std::string> KeyValueStore::keys() const {
+    std::vector<std::string> out;
+    out.reserve(m_entries.size());
+    for (const auto &[key, value] : m_entries) {
+        out.push_back(key);
+    }
+    return out;
+}
+
+// ---- Buffer-mode format --------------------------------------------------
+
+BinaryStatus writeKeyValueStore(BinaryWriter &w, const KeyValueStore &store) {
+    MemoryBinaryWriter kvprBody;
+    if (auto st = encodeKvprChunk(kvprBody, store); !st.ok()) {
+        return st;
+    }
+    std::vector<ChunkPayload> chunks;
+    chunks.push_back(ChunkPayload{kKvprTag, kvprBody.takeBuffer()});
+    return writeChunked(w, kKeyValueMagic, kKeyValueFormatVersion, chunks);
+}
+
+Result<KeyValueStore> readKeyValueStore(BinaryReader &r) {
+    AssetHeader header{};
+    auto chunksR = readChunks(r, kKeyValueMagic, kKeyValueFormatVersion, &header);
+    if (!chunksR.ok()) {
+        return Result<KeyValueStore>::error(
+            chunksR.status_.code_,
+            std::move(chunksR.status_.message_)
+        );
+    }
+    const LoadedChunk *kvpr = findChunk(chunksR.value_, kKvprTag);
+    if (kvpr == nullptr) {
+        // No KVPR chunk — treat as an empty store rather than corrupt, so a
+        // future file carrying only some other chunk loads as "no entries".
+        return Result<KeyValueStore>::success(KeyValueStore{});
+    }
+    return decodeKvprChunk(*kvpr, r.sourceName());
+}
+
+// ---- File-mode format ----------------------------------------------------
+
+BinaryStatus saveKeyValueStore(const std::string &path, const KeyValueStore &store) {
+    // userDataDir / joinPath do not create directories — make the parent
+    // exist before opening the file for write.
+    const std::filesystem::path parent = std::filesystem::path(path).parent_path();
+    if (!parent.empty()) {
+        std::error_code ec;
+        std::filesystem::create_directories(parent, ec);
+        if (ec) {
+            IRE_LOG_ERROR(
+                "Failed to create directory {} for key-value store: {}",
+                parent.string(),
+                ec.message()
+            );
+            return BinaryStatus::error(
+                BinaryIOError::OpenFailed,
+                "failed to create directory " + parent.string()
+            );
+        }
+    }
+
+    FileBinaryWriter w(path);
+    if (!w.ok()) {
+        IRE_LOG_ERROR("Failed to open key-value store for writing: {}", path);
+        return BinaryStatus::error(BinaryIOError::OpenFailed, "failed to open " + path);
+    }
+    if (auto st = writeKeyValueStore(w, store); !st.ok()) {
+        IRE_LOG_ERROR("Failed to write key-value store {}: {}", path, st.message_);
+        return st;
+    }
+    IRE_LOG_INFO("Saved key-value store with {} entr(ies) to {}", store.size(), path);
+    return BinaryStatus::success();
+}
+
+Result<KeyValueStore> loadKeyValueStore(const std::string &path) {
+    FileBinaryReader r(path);
+    if (!r.ok()) {
+        // Missing file is the common first-launch case — log at info, not
+        // error, so a fresh install doesn't look broken in the logs.
+        IRE_LOG_INFO("No key-value store at {} (using defaults)", path);
+        return Result<KeyValueStore>::error(BinaryIOError::OpenFailed, "failed to open " + path);
+    }
+    auto storeR = readKeyValueStore(r);
+    if (!storeR.ok()) {
+        IRE_LOG_ERROR("Failed to load key-value store {}: {}", path, storeR.status_.message_);
+    } else {
+        IRE_LOG_INFO(
+            "Loaded key-value store with {} entr(ies) from {}",
+            storeR.value_.size(),
+            path
+        );
+    }
+    return storeR;
+}
+
+} // namespace IRAsset

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -901,6 +901,39 @@ IRSim.stopwatchPause("run"); IRSim.stopwatchResume("run"); IRSim.stopwatchReset(
   pipeline assembly (same as most prefab systems). Coverage:
   `test/time/lua_sim_test.cpp`.
 
+## Persistence (`IRSave.*`)
+
+`bindLuaDrivenEcs()` exposes a flat key/value persistence surface as the
+`IRSave` table (engine #1819) so gameplay can save high scores + settings
+across launches — the lightweight, Lua-reachable alternative to the ECS
+world snapshot (#199). It wraps the `.irkv` format in `engine/asset/`
+(`key_value_store.hpp`); see `engine/asset/CLAUDE.md` "`.irkv` format" for
+the on-disk layout and value model.
+
+```lua
+IRSave.load("highscores")              -- read file into the in-proc store;
+                                       -- missing/corrupt -> empty. returns loaded?
+IRSave.set("highscores", "top1", 5000) -- number | string | bool | array-table
+IRSave.set("highscores", "names", { "ACE", "BEE" })
+IRSave.save("highscores")              -- write the in-proc store to disk. returns ok?
+local v = IRSave.get("highscores", "top1", 0)  -- stored value, or the default arg
+IRSave.has("highscores", "top1"); IRSave.remove("highscores", "top1"); IRSave.clear("highscores")
+```
+
+- **Stores are namespaced by basename** (`"highscores"`, `"settings"`); each
+  maps to `userDataDir("irreden")/<name>.irkv` (per-user dir, not the exe
+  dir — survives a clean bundle reinstall). `save` creates the directory.
+- **Per-`World` lifetime.** The store registry is captured in the binding
+  lambdas (shared_ptr), so it lives as long as the `LuaScript`'s sol::state.
+  Don't hold Lua handles across `World` shutdown.
+- **Values cross by `sol::type` inspection** (number/string/bool/array-table),
+  NOT a Lua-spelled enum, so the `cpp-lua-enums` rule does not apply. A
+  number/string/bool maps to a scalar; an array-style table (contiguous
+  `1..n`) maps to a LIST. A map-style table or a nested list raises a clear
+  Lua error rather than silently dropping the value. Lists do not nest in v1.
+- Coverage: `test/script/lua_persistence_test.cpp` (in-memory surface) +
+  `test/asset/key_value_store_test.cpp` (format round-trip + corruption).
+
 ## Prefab format (`Prefab.register`, `Prefab.spawn`)
 
 `bindLuaDrivenEcs()` also exposes the `Prefab` Lua table — the runtime

--- a/engine/script/include/irreden/script/lua_persistence_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_persistence_bindings.hpp
@@ -163,7 +163,11 @@ inline void bindPersistenceApi(LuaScript &script) {
     };
 
     save["save"] = [stores](const std::string &name) -> bool {
-        return IRAsset::saveKeyValueStore(keyValueStorePath(name), (*stores)[name]).ok();
+        const auto it = stores->find(name);
+        if (it == stores->end()) {
+            return false;
+        }
+        return IRAsset::saveKeyValueStore(keyValueStorePath(name), it->second).ok();
     };
 
     save["set"] = [stores](const std::string &name, const std::string &key, sol::object value) {

--- a/engine/script/include/irreden/script/lua_persistence_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_persistence_bindings.hpp
@@ -1,0 +1,205 @@
+#ifndef LUA_PERSISTENCE_BINDINGS_H
+#define LUA_PERSISTENCE_BINDINGS_H
+
+#include <irreden/asset/key_value_store.hpp>
+#include <irreden/ir_utility.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <sol/sol.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace IRScript::detail {
+
+// On-disk path for a named store: <userDataDir("irreden")>/<name>.irkv. The
+// per-user data dir (not the exe dir) is what makes a save survive a clean
+// reinstall of the game bundle. `saveKeyValueStore` creates the directory.
+inline std::string keyValueStorePath(const std::string &name) {
+    return IRUtility::joinPath(IRUtility::userDataDir("irreden"), name, "irkv");
+}
+
+// Convert a Lua scalar (number / bool / string) to a list element. Any other
+// type — including a nested table — throws a sol::error: lists do not nest
+// in v1. Lua booleans and numbers are distinct sol types, so there is no
+// double-vs-bool ambiguity here.
+inline IRAsset::ListElem luaToListElem(const sol::object &obj, const char *context) {
+    switch (obj.get_type()) {
+    case sol::type::number:
+        return IRAsset::ListElem{obj.as<double>()};
+    case sol::type::boolean:
+        return IRAsset::ListElem{obj.as<bool>()};
+    case sol::type::string:
+        return IRAsset::ListElem{obj.as<std::string>()};
+    default:
+        throw sol::error{
+            std::string{context} +
+            ": list elements must be number, string, or bool (no nested tables)"
+        };
+    }
+}
+
+// Convert a Lua value to an IRAsset::Value. number / bool / string map
+// directly; an array-style table (contiguous integer keys 1..n) becomes a
+// LIST. A non-array table (string/sparse keys), nil, or function throws a
+// sol::error with a clear diagnostic rather than silently no-op'ing.
+inline IRAsset::Value luaToValue(const sol::object &obj, const char *context) {
+    switch (obj.get_type()) {
+    case sol::type::number:
+        return IRAsset::Value{obj.as<double>()};
+    case sol::type::boolean:
+        return IRAsset::Value{obj.as<bool>()};
+    case sol::type::string:
+        return IRAsset::Value{obj.as<std::string>()};
+    case sol::type::table: {
+        sol::table tbl = obj.as<sol::table>();
+        const std::size_t n = tbl.size(); // array length via the `#` operator
+        std::size_t total = 0;
+        for (const auto &kv : tbl) {
+            (void)kv;
+            ++total;
+        }
+        if (total != n) {
+            throw sol::error{
+                std::string{context} +
+                ": only array-style tables (contiguous 1..n) are supported, not key maps"
+            };
+        }
+        std::vector<IRAsset::ListElem> list;
+        list.reserve(n);
+        for (std::size_t i = 1; i <= n; ++i) {
+            list.push_back(luaToListElem(tbl[i], context));
+        }
+        return IRAsset::Value{std::move(list)};
+    }
+    default:
+        throw sol::error{
+            std::string{context} + ": value must be a number, string, bool, or array table"
+        };
+    }
+}
+
+// Build a Lua object from a list element scalar.
+inline sol::object listElemToLua(sol::state_view lua, const IRAsset::ListElem &elem) {
+    switch (static_cast<IRAsset::ValueType>(elem.index())) {
+    case IRAsset::ValueType::NUMBER:
+        return sol::make_object(lua, std::get<double>(elem));
+    case IRAsset::ValueType::BOOL:
+        return sol::make_object(lua, std::get<bool>(elem));
+    case IRAsset::ValueType::STRING:
+        return sol::make_object(lua, std::get<std::string>(elem));
+    case IRAsset::ValueType::LIST:
+        break; // unreachable — ListElem has no LIST alternative
+    }
+    return sol::make_object(lua, sol::lua_nil);
+}
+
+// Build a Lua object from a stored Value. A LIST surfaces as a fresh
+// array table allocated in @p lua.
+inline sol::object luaFromValue(sol::state_view lua, const IRAsset::Value &value) {
+    switch (IRAsset::valueType(value)) {
+    case IRAsset::ValueType::NUMBER:
+        return sol::make_object(lua, std::get<double>(value));
+    case IRAsset::ValueType::BOOL:
+        return sol::make_object(lua, std::get<bool>(value));
+    case IRAsset::ValueType::STRING:
+        return sol::make_object(lua, std::get<std::string>(value));
+    case IRAsset::ValueType::LIST: {
+        const auto &list = std::get<std::vector<IRAsset::ListElem>>(value);
+        sol::table tbl = lua.create_table(static_cast<int>(list.size()), 0);
+        for (std::size_t i = 0; i < list.size(); ++i) {
+            tbl[i + 1] = listElemToLua(lua, list[i]);
+        }
+        return tbl;
+    }
+    }
+    return sol::make_object(lua, sol::lua_nil);
+}
+
+// Exposes a flat key/value persistence surface as the `IRSave` Lua table
+// (engine #1819) so gameplay can save high scores + settings across launches.
+// Mirrors the IR<Module> binding convention (IRSim, IRModifier, ...).
+//
+// Stores live in a per-LuaScript registry keyed by store basename, held in a
+// shared_ptr captured by the binding lambdas — so the map lives exactly as
+// long as this LuaScript's sol::state (process-registry pattern, like
+// IRPrefab::Prefab, but scoped to the World rather than process-global). Don't
+// hold Lua handles across World shutdown (script CLAUDE caveat). Files live at
+// userDataDir("irreden")/<name>.irkv.
+//
+// Surface:
+//   IRSave.load(name)             -- read file into the in-proc store;
+//                                    missing/corrupt -> empty. returns loaded?
+//   IRSave.save(name)             -- write in-proc store to disk. returns ok?
+//   IRSave.set(name, key, value)  -- value: number | string | bool | array-table
+//   IRSave.get(name, key[, def])  -- stored value, or def (nil if omitted)
+//   IRSave.has(name, key)
+//   IRSave.remove(name, key)      -- returns whether the key existed
+//   IRSave.clear(name)
+//
+// Values cross the boundary by sol::type inspection (number/string/bool/
+// array-table), NOT a Lua-spelled enum, so the cpp-lua-enums rule does not
+// apply here.
+inline void bindPersistenceApi(LuaScript &script) {
+    sol::state &lua = script.lua();
+    if (!lua["IRSave"].valid()) {
+        lua["IRSave"] = lua.create_table();
+    }
+    sol::table save = lua["IRSave"];
+
+    auto stores = std::make_shared<std::unordered_map<std::string, IRAsset::KeyValueStore>>();
+
+    save["load"] = [stores](const std::string &name) -> bool {
+        auto loaded = IRAsset::loadKeyValueStore(keyValueStorePath(name));
+        if (!loaded.ok()) {
+            (*stores)[name] = IRAsset::KeyValueStore{};
+            return false;
+        }
+        (*stores)[name] = std::move(loaded.value_);
+        return true;
+    };
+
+    save["save"] = [stores](const std::string &name) -> bool {
+        return IRAsset::saveKeyValueStore(keyValueStorePath(name), (*stores)[name]).ok();
+    };
+
+    save["set"] = [stores](const std::string &name, const std::string &key, sol::object value) {
+        (*stores)[name].set(key, luaToValue(value, "IRSave.set"));
+    };
+
+    // sol injects `ts` (this_state) without consuming a Lua arg, so the Lua
+    // call is IRSave.get(name, key[, default]).
+    save["get"] = [stores](
+                      const std::string &name,
+                      const std::string &key,
+                      sol::object def,
+                      sol::this_state ts
+                  ) -> sol::object {
+        const auto it = stores->find(name);
+        if (it != stores->end()) {
+            if (const IRAsset::Value *v = it->second.get(key)) {
+                return luaFromValue(sol::state_view{ts}, *v);
+            }
+        }
+        return def;
+    };
+
+    save["has"] = [stores](const std::string &name, const std::string &key) -> bool {
+        const auto it = stores->find(name);
+        return it != stores->end() && it->second.has(key);
+    };
+
+    save["remove"] = [stores](const std::string &name, const std::string &key) -> bool {
+        const auto it = stores->find(name);
+        return it != stores->end() && it->second.remove(key);
+    };
+
+    save["clear"] = [stores](const std::string &name) { (*stores)[name].clear(); };
+}
+
+} // namespace IRScript::detail
+
+#endif /* LUA_PERSISTENCE_BINDINGS_H */

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -10,6 +10,7 @@
 #include <irreden/script/lua_command_bindings.hpp>
 #include <irreden/script/lua_enum_def.hpp>
 #include <irreden/script/lua_modifier_bindings.hpp>
+#include <irreden/script/lua_persistence_bindings.hpp>
 #include <irreden/script/lua_pipeline_bindings.hpp>
 #include <irreden/script/lua_render_bindings.hpp>
 #include <irreden/script/lua_sim_bindings.hpp>
@@ -650,6 +651,7 @@ void LuaScript::bindLuaDrivenEcs() {
     detail::bindRenderGlue(*this);
     detail::bindSimApi(*this);
     detail::bindAudioApi(*this);
+    detail::bindPersistenceApi(*this);
 }
 
 void LuaScript::bindLuaCommands() {

--- a/engine/utility/CLAUDE.md
+++ b/engine/utility/CLAUDE.md
@@ -21,6 +21,11 @@ functions for reading files and composing paths. Used by `asset/`,
 - `IRUtility::formatNumberedFilename(prefix, index, width, ext)` — e.g.
   `("screenshot", 7, 4, "png") → "screenshot_0007.png"`. Used for
   screenshot/recording serial numbers.
+- `IRUtility::userDataDir(appName)` — resolve the platform per-user data
+  dir (`$XDG_DATA_HOME` / `~/Library/Application Support` / `%APPDATA%`)
+  for save files that must survive a clean reinstall. Like `joinPath`, it
+  composes the path only — it does **not** create the directory. Used by
+  the `.irkv` key/value store (`engine/asset/`).
 
 ## Gotchas
 

--- a/engine/utility/include/irreden/utility/path_utils.hpp
+++ b/engine/utility/include/irreden/utility/path_utils.hpp
@@ -13,6 +13,17 @@ std::string joinPath(
 
 std::string pathWithExtension(const std::string &path, const std::string &extension);
 
+/// Resolve the platform-appropriate per-user data directory for @p appName:
+///   - Linux:   `${XDG_DATA_HOME:-$HOME/.local/share}/<appName>`
+///   - macOS:   `$HOME/Library/Application Support/<appName>`
+///   - Windows: `%APPDATA%\<appName>` (fallback `%USERPROFILE%\<appName>`)
+/// Pure path composition — does NOT create the directory (same no-mkdir
+/// contract as `joinPath`). Callers that write into it create the directory
+/// in their save path via `std::filesystem::create_directories`. If the
+/// expected environment variables are absent the bare @p appName is
+/// returned as a last-resort relative path.
+std::string userDataDir(const std::string &appName);
+
 std::string formatNumberedFilename(
     const std::string &prefix,
     int index,

--- a/engine/utility/src/ir_utility.cpp
+++ b/engine/utility/src/ir_utility.cpp
@@ -1,6 +1,7 @@
 #include <irreden/ir_utility.hpp>
 #include <irreden/ir_profile.hpp>
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -49,6 +50,41 @@ std::string pathWithExtension(const std::string &path, const std::string &extens
     std::filesystem::path updatedPath(path);
     updatedPath.replace_extension(normalizedExtension(extension));
     return updatedPath.string();
+}
+
+namespace {
+
+// Returns the env var's value if it is set and non-empty, else nullptr.
+const char *nonEmptyEnv(const char *name) {
+    const char *value = std::getenv(name);
+    return (value != nullptr && value[0] != '\0') ? value : nullptr;
+}
+
+} // namespace
+
+std::string userDataDir(const std::string &appName) {
+#if defined(_WIN32)
+    if (const char *appData = nonEmptyEnv("APPDATA")) {
+        return (std::filesystem::path(appData) / appName).string();
+    }
+    if (const char *userProfile = nonEmptyEnv("USERPROFILE")) {
+        return (std::filesystem::path(userProfile) / appName).string();
+    }
+#elif defined(__APPLE__)
+    if (const char *home = nonEmptyEnv("HOME")) {
+        return (std::filesystem::path(home) / "Library" / "Application Support" / appName).string();
+    }
+#else
+    if (const char *xdg = nonEmptyEnv("XDG_DATA_HOME")) {
+        return (std::filesystem::path(xdg) / appName).string();
+    }
+    if (const char *home = nonEmptyEnv("HOME")) {
+        return (std::filesystem::path(home) / ".local" / "share" / appName).string();
+    }
+#endif
+    // No usable environment variable — fall back to a bare relative path so
+    // the caller's create_directories still has somewhere to write.
+    return appName;
 }
 
 std::string formatNumberedFilename(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 add_executable(IrredenEngineTest
   asset/binary_io_test.cpp
   asset/json_sidecar_test.cpp
+  asset/key_value_store_test.cpp
   asset/name_table_test.cpp
   asset/rig_format_test.cpp
   asset/sprite_sheet_test.cpp
@@ -61,6 +62,7 @@ add_executable(IrredenEngineTest
   script/lua_component_codegen_test.cpp
   script/lua_component_register_test.cpp
   script/lua_enum_register_test.cpp
+  script/lua_persistence_test.cpp
   script/lua_pipeline_register_test.cpp
   script/lua_render_bindings_test.cpp
   script/lua_rotation_target_lua_test.cpp

--- a/test/asset/key_value_store_test.cpp
+++ b/test/asset/key_value_store_test.cpp
@@ -1,0 +1,258 @@
+#include <gtest/gtest.h>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/key_value_store.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace IRAsset;
+
+const std::string kTmpDir = "/tmp";
+
+KeyValueStore makeSampleStore() {
+    KeyValueStore store;
+    store.set("highScore", Value{12345.0});
+    store.set("playerName", Value{std::string{"ACE"}});
+    store.set("soundOn", Value{true});
+    store.set("musicOn", Value{false});
+    store.set(
+        "topScores",
+        Value{std::vector<ListElem>{ListElem{5000.0}, ListElem{3000.0}, ListElem{1000.0}}}
+    );
+    store.set(
+        "recentPlayers",
+        Value{std::vector<ListElem>{ListElem{std::string{"ACE"}}, ListElem{std::string{"BEE"}}}}
+    );
+    return store;
+}
+
+// Compares two stores key-for-key, including value types + payloads.
+void expectStoresEqual(const KeyValueStore &a, const KeyValueStore &b) {
+    ASSERT_EQ(a.size(), b.size());
+    for (const std::string &key : a.keys()) {
+        const Value *va = a.get(key);
+        const Value *vb = b.get(key);
+        ASSERT_NE(va, nullptr) << key;
+        ASSERT_NE(vb, nullptr) << "missing key after round-trip: " << key;
+        ASSERT_EQ(valueType(*va), valueType(*vb)) << key;
+        EXPECT_EQ(*va, *vb) << key;
+    }
+}
+
+// ---- Buffer-mode round-trips ---------------------------------------------
+
+TEST(KeyValueStore, EmptyStoreRoundTrip) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeKeyValueStore(w, KeyValueStore{}).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readKeyValueStore(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    EXPECT_EQ(loaded.value_.size(), 0u);
+}
+
+TEST(KeyValueStore, AllValueTypesRoundTrip) {
+    const KeyValueStore original = makeSampleStore();
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeKeyValueStore(w, original).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readKeyValueStore(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    expectStoresEqual(original, loaded.value_);
+
+    // Spot-check typed accessors against the loaded copy.
+    EXPECT_EQ(loaded.value_.getNumber("highScore"), 12345.0);
+    EXPECT_EQ(loaded.value_.getString("playerName"), "ACE");
+    EXPECT_TRUE(loaded.value_.getBool("soundOn"));
+    EXPECT_FALSE(loaded.value_.getBool("musicOn"));
+    const Value *list = loaded.value_.get("topScores");
+    ASSERT_NE(list, nullptr);
+    ASSERT_EQ(valueType(*list), ValueType::LIST);
+    EXPECT_EQ(std::get<std::vector<ListElem>>(*list).size(), 3u);
+}
+
+TEST(KeyValueStore, EmptyListRoundTrip) {
+    KeyValueStore original;
+    original.set("noScoresYet", Value{std::vector<ListElem>{}});
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeKeyValueStore(w, original).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readKeyValueStore(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    const Value *list = loaded.value_.get("noScoresYet");
+    ASSERT_NE(list, nullptr);
+    ASSERT_EQ(valueType(*list), ValueType::LIST);
+    EXPECT_TRUE(std::get<std::vector<ListElem>>(*list).empty());
+}
+
+// ---- In-memory store semantics -------------------------------------------
+
+TEST(KeyValueStore, OverwriteRemoveClearAndTypedReads) {
+    KeyValueStore store;
+
+    store.set("score", Value{10.0});
+    EXPECT_EQ(store.getNumber("score"), 10.0);
+    store.set("score", Value{99.0}); // overwrite
+    EXPECT_EQ(store.getNumber("score"), 99.0);
+
+    // Typed read of a wrong-typed / absent key returns the fallback.
+    EXPECT_EQ(store.getString("score", "n/a"), "n/a"); // score is a number
+    EXPECT_EQ(store.getNumber("missing", -1.0), -1.0);
+    EXPECT_FALSE(store.getBool("missing", false));
+
+    EXPECT_TRUE(store.has("score"));
+    EXPECT_TRUE(store.remove("score"));
+    EXPECT_FALSE(store.has("score"));
+    EXPECT_FALSE(store.remove("score")) << "removing an absent key returns false";
+
+    store.set("a", Value{1.0});
+    store.set("b", Value{2.0});
+    EXPECT_EQ(store.size(), 2u);
+    store.clear();
+    EXPECT_EQ(store.size(), 0u);
+}
+
+// ---- Recoverable errors (Extensibility Rule #5) --------------------------
+
+TEST(KeyValueStore, BadMagicIsRecoverable) {
+    std::vector<std::uint8_t> bad(64, 0);
+    bad[0] = 'X';
+    bad[1] = 'X';
+    bad[2] = 'X';
+    bad[3] = 'X';
+    MemoryBinaryReader r(bad.data(), bad.size());
+    auto loaded = readKeyValueStore(r);
+    ASSERT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::BadMagic);
+    EXPECT_EQ(loaded.value_.size(), 0u);
+}
+
+TEST(KeyValueStore, VersionTooNewIsRecoverable) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeKeyValueStore(w, makeSampleStore()).ok());
+    auto buffer = w.takeBuffer();
+    // Patch the version dword (bytes 4..7) to a future value.
+    buffer[4] = 0xFF;
+    buffer[5] = 0xFF;
+    buffer[6] = 0xFF;
+    buffer[7] = 0xFF;
+    MemoryBinaryReader r(buffer.data(), buffer.size());
+    auto loaded = readKeyValueStore(r);
+    ASSERT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::VersionTooNew);
+}
+
+TEST(KeyValueStore, TruncatedMidChunkIsRecoverable) {
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeKeyValueStore(w, makeSampleStore()).ok());
+    auto buffer = w.takeBuffer();
+    // Lop off the back half of the file so a chunk body reads past EOF. The
+    // chunk-table offset/size validation or a value read surfaces the error;
+    // either way it must be recoverable, not a crash.
+    ASSERT_GT(buffer.size(), 20u);
+    buffer.resize(buffer.size() - (buffer.size() / 2));
+    MemoryBinaryReader r(buffer.data(), buffer.size());
+    auto loaded = readKeyValueStore(r);
+    EXPECT_FALSE(loaded.ok());
+}
+
+TEST(KeyValueStore, UnknownValueTagIsRecoverable) {
+    // Hand-roll a KVPR chunk with a single entry whose value tag is a future
+    // value (99). The loader can't length-skip an unknown payload, so it
+    // surfaces UnknownTag rather than crashing or mis-reading.
+    MemoryBinaryWriter body;
+    body.writeVarUInt(1u);       // entryCount
+    body.writeString("mystery"); // key
+    body.writeU8(99u);           // unknown value tag
+    body.writeF64(1.0);          // some payload bytes
+
+    std::vector<ChunkPayload> chunks;
+    chunks.push_back(ChunkPayload{makeTag("KVPR"), body.takeBuffer()});
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kKeyValueMagic, kKeyValueFormatVersion, chunks).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readKeyValueStore(r);
+    ASSERT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::UnknownTag);
+}
+
+TEST(KeyValueStore, UnknownChunkIsSilentlySkipped) {
+    // A KVPR chunk plus a truly-unknown future chunk: a v1 loader pulls KVPR
+    // through and ignores the unknown (Extensibility Rule #1).
+    const KeyValueStore original = makeSampleStore();
+    MemoryBinaryWriter kvprBody;
+    ASSERT_TRUE(writeKeyValueStore(kvprBody, original).ok());
+    // Re-extract just the KVPR chunk body by re-encoding through the public
+    // buffer path: read it back, then re-emit with an extra unknown chunk.
+    MemoryBinaryReader probe(kvprBody.buffer().data(), kvprBody.buffer().size());
+    AssetHeader header{};
+    auto chunksR = readChunks(probe, kKeyValueMagic, kKeyValueFormatVersion, &header);
+    ASSERT_TRUE(chunksR.ok());
+    const LoadedChunk *kvpr = findChunk(chunksR.value_, makeTag("KVPR"));
+    ASSERT_NE(kvpr, nullptr);
+
+    std::vector<ChunkPayload> chunks;
+    chunks.push_back(ChunkPayload{makeTag("FUTR"), {0xDE, 0xAD, 0xBE, 0xEF}});
+    chunks.push_back(ChunkPayload{makeTag("KVPR"), kvpr->data_});
+
+    MemoryBinaryWriter w;
+    ASSERT_TRUE(writeChunked(w, kKeyValueMagic, kKeyValueFormatVersion, chunks).ok());
+
+    MemoryBinaryReader r(w.buffer().data(), w.buffer().size());
+    auto loaded = readKeyValueStore(r);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    expectStoresEqual(original, loaded.value_);
+}
+
+// ---- File-mode round-trip ------------------------------------------------
+
+TEST(KeyValueStore, FileRoundTrip) {
+    const std::string path = kTmpDir + "/kv_store_test.irkv";
+    std::remove(path.c_str());
+
+    const KeyValueStore original = makeSampleStore();
+    ASSERT_TRUE(saveKeyValueStore(path, original).ok());
+
+    auto loaded = loadKeyValueStore(path);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    expectStoresEqual(original, loaded.value_);
+}
+
+TEST(KeyValueStore, MissingFileIsRecoverable) {
+    auto loaded = loadKeyValueStore(kTmpDir + "/definitely_not_a_real_kv_store.irkv");
+    ASSERT_FALSE(loaded.ok());
+    EXPECT_EQ(loaded.status_.code_, BinaryIOError::OpenFailed);
+    EXPECT_EQ(loaded.value_.size(), 0u);
+}
+
+TEST(KeyValueStore, SaveCreatesMissingParentDirectory) {
+    // The save path must mkdir -p its parent (userDataDir / joinPath don't),
+    // so a first-launch write into a never-created dir succeeds.
+    const std::string dir = kTmpDir + "/ir_kv_test_nested/deeper";
+    const std::string path = dir + "/settings.irkv";
+    std::remove(path.c_str());
+
+    KeyValueStore store;
+    store.set("volume", Value{0.8});
+    ASSERT_TRUE(saveKeyValueStore(path, store).ok());
+
+    auto loaded = loadKeyValueStore(path);
+    ASSERT_TRUE(loaded.ok()) << loaded.status_.message_;
+    EXPECT_EQ(loaded.value_.getNumber("volume"), 0.8);
+
+    std::remove(path.c_str());
+}
+
+} // namespace

--- a/test/script/lua_persistence_test.cpp
+++ b/test/script/lua_persistence_test.cpp
@@ -1,0 +1,127 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/script/lua_persistence_bindings.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <sol/sol.hpp>
+
+#include <string>
+
+namespace {
+
+// Owns the managers `bindLuaDrivenEcs()` touches. Exercises the IRSave
+// surface in-memory only — set/get/has/remove/clear + the Lua<->Value type
+// conversion. The file I/O path (IRSave.load/save) resolves to the real
+// per-user data dir, so it is covered by the hermetic C++ KeyValueStore
+// FileRoundTrip test (writing to /tmp) rather than here, to keep this test
+// from touching the developer's home directory.
+class LuaPersistenceTest : public testing::Test {
+  protected:
+    LuaPersistenceTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_system_manager{} {
+        m_lua.bindLuaDrivenEcs();
+    }
+
+    // Evaluates a Lua expression and returns whether it is truthy. Fails the
+    // test (returns false) if the script errors.
+    bool evalTrue(const std::string &expr) {
+        auto result = m_lua.lua().safe_script(
+            "return (" + expr + ") and true or false",
+            sol::script_pass_on_error
+        );
+        return result.valid() && result.get<bool>();
+    }
+
+    // Returns true if running @p stmt raises a Lua error (binding rejected it).
+    bool raisesError(const std::string &stmt) {
+        auto result = m_lua.lua().safe_script(stmt, sol::script_pass_on_error);
+        return !result.valid();
+    }
+
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+};
+
+TEST_F(LuaPersistenceTest, SurfaceBound) {
+    EXPECT_TRUE(evalTrue("type(IRSave) == 'table'"));
+    EXPECT_TRUE(evalTrue("type(IRSave.set) == 'function'"));
+    EXPECT_TRUE(evalTrue("type(IRSave.get) == 'function'"));
+    EXPECT_TRUE(evalTrue("type(IRSave.has) == 'function'"));
+    EXPECT_TRUE(evalTrue("type(IRSave.remove) == 'function'"));
+    EXPECT_TRUE(evalTrue("type(IRSave.clear) == 'function'"));
+    EXPECT_TRUE(evalTrue("type(IRSave.load) == 'function'"));
+    EXPECT_TRUE(evalTrue("type(IRSave.save) == 'function'"));
+}
+
+TEST_F(LuaPersistenceTest, ScalarRoundTrips) {
+    m_lua.lua().safe_script(R"(
+        IRSave.set("s", "score", 12345)
+        IRSave.set("s", "name", "ACE")
+        IRSave.set("s", "soundOn", true)
+        IRSave.set("s", "musicOn", false)
+    )");
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'score') == 12345"));
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'name') == 'ACE'"));
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'soundOn') == true"));
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'musicOn') == false"));
+}
+
+TEST_F(LuaPersistenceTest, ListRoundTrips) {
+    m_lua.lua().safe_script(R"(
+        IRSave.set("s", "topScores", { 5000, 3000, 1000 })
+        IRSave.set("s", "players", { "ACE", "BEE" })
+    )");
+    EXPECT_TRUE(evalTrue("#IRSave.get('s', 'topScores') == 3"));
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'topScores')[1] == 5000"));
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'topScores')[3] == 1000"));
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'players')[2] == 'BEE'"));
+}
+
+TEST_F(LuaPersistenceTest, GetReturnsDefaultWhenAbsent) {
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'nope', 42) == 42"));
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'nope') == nil"));
+    // Default is only used when the key is absent, never to mask a stored value.
+    m_lua.lua().safe_script("IRSave.set('s', 'present', 7)");
+    EXPECT_TRUE(evalTrue("IRSave.get('s', 'present', 42) == 7"));
+}
+
+TEST_F(LuaPersistenceTest, HasRemoveClear) {
+    m_lua.lua().safe_script(R"(
+        IRSave.set("s", "a", 1)
+        IRSave.set("s", "b", 2)
+    )");
+    EXPECT_TRUE(evalTrue("IRSave.has('s', 'a')"));
+    EXPECT_TRUE(evalTrue("IRSave.remove('s', 'a') == true"));
+    EXPECT_TRUE(evalTrue("IRSave.has('s', 'a') == false"));
+    EXPECT_TRUE(evalTrue("IRSave.remove('s', 'a') == false")); // already gone
+    EXPECT_TRUE(evalTrue("IRSave.has('s', 'b')"));
+    m_lua.lua().safe_script("IRSave.clear('s')");
+    EXPECT_TRUE(evalTrue("IRSave.has('s', 'b') == false"));
+}
+
+TEST_F(LuaPersistenceTest, StoresAreNamespacedByName) {
+    m_lua.lua().safe_script(R"(
+        IRSave.set("scores", "top", 100)
+        IRSave.set("settings", "top", 5)
+    )");
+    EXPECT_TRUE(evalTrue("IRSave.get('scores', 'top') == 100"));
+    EXPECT_TRUE(evalTrue("IRSave.get('settings', 'top') == 5"));
+}
+
+TEST_F(LuaPersistenceTest, NonArrayTableIsRejected) {
+    // A map-style table can't be represented (lists are arrays only) — the
+    // binding must raise a clear error rather than silently dropping it.
+    EXPECT_TRUE(raisesError("IRSave.set('s', 'bad', { a = 1, b = 2 })"));
+}
+
+TEST_F(LuaPersistenceTest, NestedListIsRejected) {
+    // Lists do not nest in v1.
+    EXPECT_TRUE(raisesError("IRSave.set('s', 'bad', { { 1, 2 }, { 3, 4 } })"));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Minimal, Lua-reachable save surface for an arcade build (GMTK jam-readiness): persist a high-score table + a few settings across launches. Deliberately **not** the ECS world snapshot (#199 / epic #667) — a flat key/value store built on the existing `engine/asset/` binary-I/O primitives.

- **`.irkv` format** (`IRAsset::KeyValueStore`, `engine/asset/`): magic `IRKV` v1, one `KVPR` chunk via the shared `writeChunked`/`readChunks` path — **no raw `fopen`/`fwrite`** (asset-module hard rule). Values are a tagged variant `NUMBER | BOOL | STRING | LIST` (flat scalar lists, no nesting in v1 — covers a high-score list or a name list in one mechanism). Numbers are `float64` (LuaJIT has no int subtype; exact to 2^53). Bad magic / truncation / version-too-new / unknown value tag all degrade to a recoverable empty store (Extensibility Rule #5); an unknown *chunk* is silently skipped (Rule #1). Added one `BinaryIOError::UnknownTag` code for the unrecognized-value-tag case.
- **`IRUtility::userDataDir()`** (`engine/utility/`): resolves the per-user data dir (`$XDG_DATA_HOME` / `~/Library/Application Support` / `%APPDATA%`) so saves survive a clean bundle reinstall. Pure composition — `saveKeyValueStore` runs `create_directories` on the parent first (matching `joinPath`'s no-mkdir contract).
- **`IRSave` Lua table** (`set`/`get`/`has`/`remove`/`clear`/`load`/`save`), wired into `bindLuaDrivenEcs()`. Stores are per-`World` (shared_ptr captured in the binding lambdas), keyed by basename → `userDataDir("irreden")/<name>.irkv`. Values cross by `sol::type` inspection (number/string/bool/array-table) — **no Lua-spelled enum**, so `cpp-lua-enums` doesn't apply; a map-style or nested table raises a clear error.
- Docs: `.irkv` format block in `engine/asset/CLAUDE.md` (Extensibility Rule #7) + `IRSave` section in `engine/script/CLAUDE.md` + `userDataDir` in `engine/utility/CLAUDE.md`.

**Deviation from the plan:** `saveKeyValueStore`/`loadKeyValueStore` return `BinaryStatus`/`Result<T>` (mirroring `saveRig`/`loadRig`) rather than the plan's `bool` — richer diagnostics + consistency with the sibling format; the Lua `IRSave.save`/`load` map to bool via `.ok()`.

## Test plan
- [x] `IrredenEngineTest` — full suite passes (1180 tests; 1 expected skip: `GpuComputeDispatchTest` on non-OpenGL/Metal).
- [x] `KeyValueStore.*` (12) — round-trip all value types incl. LIST, corrupt-magic / truncated / version-too-new / unknown-tag → recoverable, unknown-chunk skipped, missing file → defaults, file round-trip, save creates missing parent dir.
- [x] `LuaPersistenceTest.*` (8) — in-memory `IRSave` surface, scalar + list round-trips, default fallback, namespacing, map/nested-table rejection.
- [x] Built + run on macOS (Metal). Linux/Windows: no platform-specific code beyond the `userDataDir` `#if` (cross-host smoke labels apply).

Closes #1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)