### PR TITLE
render: remove dead in-plane per-axis store helpers + stale comments

### DIFF
--- a/docs/design/per-axis-sun-shadow-resolve.md
+++ b/docs/design/per-axis-sun-shadow-resolve.md
@@ -48,7 +48,7 @@ since Metal has no portable image-atomic syntax):
 
 1. **scatter** (`c_resolve_per_axis_screen_depth`, dispatched once per axis):
    read each face-local cell, recover the face origin
-   (`faceOriginFromInPlane`, the same exact integer inverse
+   (`isoPixelToPos3D`, the same exact iso inverse
    `perAxisCellToWorld3D` uses), rotate it into the cardinal view frame
    (`rotateCardinalZ` + `cardinalLowerCornerShift × subdivisionScale`,
    mirroring `c_voxel_to_trixel_stage_1`'s cardinal store), and
@@ -71,7 +71,7 @@ runs strictly before `BAKE` rebinds slot 28.
 `BAKE`'s per-axis dispatch recovers world-pos from the resolve texture via the
 cardinal `trixelCanvasPixelToWorld3D`. `COMPUTE_SUN_SHADOW`'s per-axis receive
 recovers world-pos via the face-local `perAxisCellToWorld3D`. Both derive from
-the **identical** `faceOriginFromInPlane` origin, so cast and receive agree on
+the **identical** `isoPixelToPos3D` origin, so cast and receive agree on
 world-pos by construction — no shadow acne at the cast/receive boundary.
 `COMPUTE_SUN_SHADOW` is therefore unchanged.
 

--- a/engine/prefabs/irreden/render/systems/system_bake_sun_shadow_map.hpp
+++ b/engine/prefabs/irreden/render/systems/system_bake_sun_shadow_map.hpp
@@ -283,7 +283,7 @@ template <> struct System<BAKE_SUN_SHADOW_MAP> {
         // #1380 cross-face self-occlusion: the per-screen-pixel flattening the
         // raw face-local store lacked. The per-axis RECEIVE
         // (COMPUTE_SUN_SHADOW, perAxisCellToWorld3D) recovers the same world
-        // origin (faceOriginFromInPlane), so cast and receive agree. If the
+        // origin (isoPixelToPos3D), so cast and receive agree. If the
         // resolve stage is not registered, resolveDepth_ stays cleared to the
         // empty sentinel (component allocate) so this dispatch casts nothing —
         // graceful no-op, not corruption. Cardinal (residualYaw == 0) is

--- a/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
+++ b/engine/prefabs/irreden/render/systems/system_compute_voxel_ao.hpp
@@ -116,7 +116,7 @@ template <> struct System<COMPUTE_VOXEL_AO> {
     // shared UBO's perAxisRoute selector so the shader reconstructs world-pos
     // face-locally (perAxisCellToWorld3D), then restores it to 0 so downstream
     // single-canvas passes are unaffected. The world AO band is per-axis-correct
-    // because the canvas is a same-axis in-plane lattice.
+    // because the canvas is a same-axis cardinal-iso lattice.
     void dispatchPerAxisAO(
         C_PerAxisTrixelCanvases &axes,
         const C_TriangleCanvasTextures &mainTextures,

--- a/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp
@@ -160,10 +160,10 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
     // `pos3DtoDistance`, so each non-empty cell is the occlusion winner on its
     // view ray). This pass forward-scatters each non-empty cell as its true
     // deformed face quad: instanced over the canvas grid (one instance per
-    // cell), the vertex shader recovers the face's world origin from
-    // (cell - perAxisBase, storedDepth>>2, visualYaw) — closed form, the
-    // denominator 2cos(yaw)+1 is the design doc's depth-monotonicity quantity,
-    // positive across the ±45° bracket — then projects the four cube-face
+    // cell), the vertex shader recovers the face's world origin from the
+    // un-yawed (cardinal) iso pixel `isoPixelToPos3D(cell - perAxisBase,
+    // storedDepth>>10)` — an exact integer inverse, non-singular at every yaw
+    // (the index is un-yawed) — then projects the four cube-face
     // corners with pos3DtoPos2DIsoYawed (which IS P(θ)·corner, the deform
     // implicit). The framebuffer GL_LESS depth test (enabled on bind) composites
     // the three canvases per pixel. No gather / parity inverse ⇒ the #1256
@@ -215,7 +215,7 @@ template <> struct System<TRIXEL_TO_FRAMEBUFFER> {
         const auto visibleFaces = IRMath::visibleFaceTripletCardinal(cardinalIndex);
         // perAxisBase MUST match the store's trixelFrameOffset, which uses the
         // #1431-capped density (in voxelRenderOptions.y) — so the scatter's
-        // face-origin recovery (faceLocalAnchor/faceLocalBase) is bit-consistent
+        // face-origin recovery (isoPixelToPos3D) is bit-consistent
         // with where the cells were written. NONE mode stores at world scale
         // (effectiveTrixelSubdivisionScale == 1 when renderMode == NONE).
         const int cappedDensity = IRPrefab::PerAxisCanvas::subdivisionDensity();

--- a/engine/render/include/irreden/render/ir_render_enums.hpp
+++ b/engine/render/include/irreden/render/ir_render_enums.hpp
@@ -108,7 +108,7 @@ enum class DrawMode : std::uint8_t { TRIANGLES, LINES };
 ///                        composite's winner (#1457 instrumentation).
 /// - @c PER_AXIS_ORIGIN — per-axis scatter recovered-origin field: scattered
 ///                        face color encodes the recovered un-yawed depth key
-///                        (@c rawDepth = x+y+z from @c faceOriginFromInPlane)
+///                        (@c rawDepth = x+y+z from @c isoPixelToPos3D)
 ///                        on a long-period hue wheel, so a clean face reads as
 ///                        a smooth hue progression and a wrong-cell winner as
 ///                        a hue discontinuity (#1457 instrumentation).

--- a/engine/render/src/shaders/c_compute_sun_shadow.glsl
+++ b/engine/render/src/shaders/c_compute_sun_shadow.glsl
@@ -64,7 +64,7 @@ void main() {
     int cardinalIndex = rasterYawCardinalIndex(rasterYaw);
 
     // Smooth camera Z-yaw (#1311): a per-axis canvas stores the world frame
-    // face-locally, so recover world-pos via faceOriginFromInPlane and read the
+    // face-locally, so recover world-pos via isoPixelToPos3D and read the
     // world-frame outward normal directly (no cardinal rotation — the store
     // already wrote world coords). The single canvas keeps its cardinal-snap
     // reconstruction + R_z(-rasterYaw) normal rotation, byte-identical at the

--- a/engine/render/src/shaders/c_compute_voxel_ao.glsl
+++ b/engine/render/src/shaders/c_compute_voxel_ao.glsl
@@ -125,7 +125,7 @@ void main() {
     int cardinalIndex = rasterYawCardinalIndex(rasterYaw);
     // Smooth camera Z-yaw (#1311): a per-axis canvas stores the world frame
     // face-locally (perAxisRoute != 0), so recover world-pos via
-    // faceOriginFromInPlane; the single canvas stores the cardinal-snapped iso
+    // isoPixelToPos3D; the single canvas stores the cardinal-snapped iso
     // pixel, recovered via trixelCanvasPixelToWorld3D. Per-axis canvases are
     // only allocated while rotating, so the single-canvas path stays byte-
     // identical at the cardinal fast path.

--- a/engine/render/src/shaders/c_lighting_to_trixel.glsl
+++ b/engine/render/src/shaders/c_lighting_to_trixel.glsl
@@ -235,7 +235,7 @@ void main() {
         // byte-identical; non-zero rasterYaw composes R(-rasterYaw)
         // afterward to recover world coordinates.
         // Smooth camera Z-yaw (#1311): a per-axis canvas stores the world frame
-        // face-locally, so recover world-pos via faceOriginFromInPlane; the single
+        // face-locally, so recover world-pos via isoPixelToPos3D; the single
         // canvas uses the cardinal-snap reconstruction. The shared world light
         // volume is then sampled the same way for both (per-axis canvases are only
         // allocated while rotating, so the cardinal fast path is byte-identical).

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -591,66 +591,6 @@ vec3 yawGrownIsoHalfExtent(vec3 halfExtent, float cosYaw, float sinYaw) {
                 halfExtent.z);
 }
 
-// --- Smooth camera Z-yaw forward-scatter: face-local in-plane store (#1310) ---
-//
-// The per-axis trixel canvas is a face-local in-plane G-buffer: each visible
-// face is stored at the integer lattice of its two in-plane world axes
-// (X-canvas -> (y,z), Y -> (x,z), Z -> (x,y)). That lattice is dense and
-// collision-free at every yaw — the design doc's recommended store
-// (docs/design/per-axis-trixel-canvas-rotation.md §"Recommended store"). The
-// iso-position store it replaces (roundHalfUp(pos3DtoPos2DIsoYawed(origin)))
-// collapsed distinct faces onto one cell on the compressed axis (atomicMin
-// dropped all but one -> the dropped faces' footprints showed background as
-// vertical cracks), and its scatter-side recovery divided by 2cos(yaw)+1, which
-// is singular at yaw = +/-120 deg (-> garbage origins, a speckled cube). The
-// face-local store has neither failure: storage is a plain lattice and recovery
-// is an exact integer subtraction.
-//
-// `worldPos` may be in world or subdivision (fixed-point) units; the matching
-// face-local base is computed in the same canvas-native units so the unit
-// cancels. `faceId` is 0..5; axis = faceId >> 1 (0=X, 1=Y, 2=Z).
-
-ivec2 faceInPlaneCoords(int faceId, ivec3 worldPos) {
-    int axis = faceId >> 1;
-    if (axis == 0) return ivec2(worldPos.y, worldPos.z);
-    if (axis == 1) return ivec2(worldPos.x, worldPos.z);
-    return ivec2(worldPos.x, worldPos.y);
-}
-
-// Inverse of faceInPlaneCoords: recover the integer origin from the stored
-// in-plane coords + iso depth (rawDepth = x + y + z). Exact, no trig, no
-// division — so it cannot misrecover or hit the old 2cos(yaw)+1 singularity.
-ivec3 faceOriginFromInPlane(int faceId, ivec2 inPlane, int rawDepth) {
-    int third = rawDepth - inPlane.x - inPlane.y;
-    int axis = faceId >> 1;
-    if (axis == 0) return ivec3(third, inPlane.x, inPlane.y);
-    if (axis == 1) return ivec3(inPlane.x, third, inPlane.y);
-    return ivec3(inPlane.x, inPlane.y, third);
-}
-
-// Camera-tracking anchor (canvas-native units) that centers the face-local
-// store on screen. The world point whose UN-yawed iso lands at canvas center;
-// isoPixelToPos3D never divides by 2cos(yaw)+1, so it is robust at every yaw.
-// Exact centering is not required — the (2W, W+H) worst-case canvas has ample
-// headroom — only that the store (stage 1/2) and the scatter recover compute it
-// identically, which holds because both pass the matching perAxisBase +
-// canvasSize (stage's trixelFrameOffset == the scatter's perAxisBase_ uniform).
-ivec3 faceLocalAnchor(ivec2 perAxisBase, ivec2 canvasSize) {
-    ivec2 isoCenter = canvasSize / ivec2(2) - perAxisBase;
-    return roundHalfUp(isoPixelToPos3D(isoCenter.x, isoCenter.y, 0.0));
-}
-
-// Face-local storage base for `axis` (faceId >> 1): the anchor's in-plane coords
-// land at canvas center, so cell = canvasSize/2 + inPlane(origin - anchor)
-// keeps the visible region inside the canvas.
-ivec2 faceLocalBase(int axis, ivec3 anchor, ivec2 canvasSize) {
-    ivec2 anchorInPlane;
-    if (axis == 0) anchorInPlane = ivec2(anchor.y, anchor.z);
-    else if (axis == 1) anchorInPlane = ivec2(anchor.x, anchor.z);
-    else anchorInPlane = ivec2(anchor.x, anchor.y);
-    return canvasSize / ivec2(2) - anchorInPlane;
-}
-
 // 2x2 deformation matrix that maps a face's un-yawed iso-pixel offset to the
 // offset under residual yaw `residualYaw` (in [-pi/4, pi/4]).
 //

--- a/engine/render/src/shaders/ir_per_axis_lighting.glsl
+++ b/engine/render/src/shaders/ir_per_axis_lighting.glsl
@@ -5,9 +5,8 @@
 // instruction scheduling and drift a few SDF-edge pixels at the cardinal fast
 // path (breaking the residualYaw == 0 byte-identity guarantee). Only the four
 // lighting compute shaders include this file, AFTER ir_iso_common.glsl (whose
-// helpers — trixelFrameOffset, trixelOriginOffsetZ1, faceLocalAnchor,
-// faceLocalBase, faceOriginFromInPlane, effectiveTrixelSubdivisionScale — this
-// builds on).
+// helpers — trixelFrameOffset, trixelOriginOffsetZ1, isoPixelToPos3D,
+// effectiveTrixelSubdivisionScale — this builds on).
 
 // Reconstruct the world-unit surface position of a per-axis trixel canvas cell.
 // The per-axis store (#1458: base-resolution encoding) keys each cell by its

--- a/engine/render/src/shaders/metal/c_compute_sun_shadow.metal
+++ b/engine/render/src/shaders/metal/c_compute_sun_shadow.metal
@@ -42,7 +42,7 @@ kernel void c_compute_sun_shadow(
     int cardinalIndex = rasterYawCardinalIndex(frameData.rasterYaw);
 
     // Smooth camera Z-yaw (#1311): a per-axis canvas stores the world frame
-    // face-locally — recover world-pos via faceOriginFromInPlane and read the
+    // face-locally — recover world-pos via isoPixelToPos3D and read the
     // world-frame outward normal directly. The single canvas keeps its
     // cardinal-snap reconstruction + R_z(-rasterYaw) normal rotation. Mirrors GLSL.
     bool perAxis = frameData.perAxisRoute != 0;

--- a/engine/render/src/shaders/metal/c_compute_voxel_ao.metal
+++ b/engine/render/src/shaders/metal/c_compute_voxel_ao.metal
@@ -77,7 +77,7 @@ kernel void c_compute_voxel_ao(
     int rawDepth = (frameData.perAxisRoute != 0) ? (encoded >> 10) : (encoded >> 2);
     int cardinalIndex = rasterYawCardinalIndex(frameData.rasterYaw);
     // Smooth camera Z-yaw (#1311): a per-axis canvas stores the world frame
-    // face-locally (perAxisRoute != 0), recovered via faceOriginFromInPlane; the
+    // face-locally (perAxisRoute != 0), recovered via isoPixelToPos3D; the
     // single canvas uses the cardinal-snap reconstruction. Mirrors GLSL.
     bool perAxis = frameData.perAxisRoute != 0;
     float3 pos3D = perAxis

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -555,46 +555,6 @@ inline float3 yawGrownIsoHalfExtent(float3 halfExtent, float cosYaw, float sinYa
                   halfExtent.z);
 }
 
-// --- Smooth camera Z-yaw forward-scatter: face-local in-plane store (#1310) ---
-// Mirror of shaders/ir_iso_common.glsl. See that file for the full rationale:
-// each visible face is stored at the dense, collision-free lattice of its two
-// in-plane world axes (X -> (y,z), Y -> (x,z), Z -> (x,y)), replacing the
-// iso-position store that dropped compressed-axis faces (cracks) and whose
-// recovery was singular at yaw = +/-120 deg (speckle). axis = faceId >> 1.
-
-inline int2 faceInPlaneCoords(int faceId, int3 worldPos) {
-    const int axis = faceId >> 1;
-    if (axis == 0) return int2(worldPos.y, worldPos.z);
-    if (axis == 1) return int2(worldPos.x, worldPos.z);
-    return int2(worldPos.x, worldPos.y);
-}
-
-// Inverse of faceInPlaneCoords: exact integer recovery (rawDepth = x + y + z).
-inline int3 faceOriginFromInPlane(int faceId, int2 inPlane, int rawDepth) {
-    const int third = rawDepth - inPlane.x - inPlane.y;
-    const int axis = faceId >> 1;
-    if (axis == 0) return int3(third, inPlane.x, inPlane.y);
-    if (axis == 1) return int3(inPlane.x, third, inPlane.y);
-    return int3(inPlane.x, inPlane.y, third);
-}
-
-// Camera-tracking anchor (canvas-native units) centering the store on screen;
-// uses the non-singular UN-yawed iso inverse. Store + scatter must compute it
-// identically (matching perAxisBase + canvasSize) — they do.
-inline int3 faceLocalAnchor(int2 perAxisBase, int2 canvasSize) {
-    const int2 isoCenter = canvasSize / int2(2) - perAxisBase;
-    return roundHalfUp(isoPixelToPos3D(isoCenter.x, isoCenter.y, 0.0f));
-}
-
-// Face-local storage base for `axis`: cell = canvasSize/2 + inPlane(origin - anchor).
-inline int2 faceLocalBase(int axis, int3 anchor, int2 canvasSize) {
-    int2 anchorInPlane;
-    if (axis == 0) anchorInPlane = int2(anchor.y, anchor.z);
-    else if (axis == 1) anchorInPlane = int2(anchor.x, anchor.z);
-    else anchorInPlane = int2(anchor.x, anchor.y);
-    return canvasSize / int2(2) - anchorInPlane;
-}
-
 // 2x2 deformation matrix per face for residual yaw. At residualYaw == 0 all
 // three return identity. `face` uses the kXFace / kYFace / kZFace convention;
 // other values return identity. CPU mirror: IRMath::faceDeformationMatrix.

--- a/engine/render/src/shaders/v_peraxis_scatter.glsl
+++ b/engine/render/src/shaders/v_peraxis_scatter.glsl
@@ -112,7 +112,7 @@ vec3 hueWheel(float t) {
 // via faceMicroPositionFixed6 — POS faces store the high-side plane, NEG faces
 // the low-side plane — so the recovered depth lands on the face plane and the
 // scatter only spans the face's two in-plane world axes (X->y,z  Y->x,z
-// Z->x,y, matching faceInPlaneCoords). Re-adding the polarity offset here (the
+// Z->x,y). Re-adding the polarity offset here (the
 // old per-faceId +1) double-shifts POS faces one cell past the plane: the
 // #1310 back-face seam (a ~1px dark gap between the POS face and its neighbors
 // at cardinals 1/2/3). cornerSel in {0,1}^2.


### PR DESCRIPTION
## Summary

Follow-up cleanup for the per-axis iso re-key (**stacked on #1875**). That change re-keyed the per-axis smooth-yaw store to the un-yawed (cardinal) iso pixel, leaving four helpers with zero callers:

- `faceInPlaneCoords` / `faceOriginFromInPlane` (in-plane key + its inverse)
- `faceLocalAnchor` / `faceLocalBase` (in-plane centering)

This removes all four from the shared `ir_iso_common.{glsl,metal}` (~100 lines) and fixes every comment across the render systems, shaders, `ir_render_enums.hpp`, and the `per-axis-sun-shadow-resolve.md` design doc that still named them as the recovery mechanism (now `isoPixelToPos3D`). The `per-axis-trixel-canvas-rotation.md` body keeps its historical in-plane description under the supersession banner added in #1875.

## Byte-identity validation (the documented risk)

Touching shared `ir_iso_common` is flagged as risky — recompiling the SDF/voxel/scatter shaders can drift cardinal-path pixels via FP scheduling. **It did not happen here:** removing the dead inline helpers produces output identical to keeping them. The only deltas vs. baseline are a pre-existing run-to-run non-determinism in the center cluster (a few px at y≈924/1120) that reproduces running *one build twice* — unrelated to this change.

## Not in scope (noted follow-up)

The `#1431` per-axis density cap (`perAxisSubdivisionCap`) may now be fully obsolete — with base-resolution iso keying the cell position no longer scales by `subPerAxis`, so the original "black-hole clip" mechanism can't recur. That's a functional change needing its own investigation + test; left for a focused follow-up rather than ripped out in a comment-cleanup pass.

## Test plan

- [x] Builds clean (Metal); per-axis path renders all 3 faces at every yaw
- [x] Byte-identity: dead-helper removal vs keep = identical (modulo pre-existing noise)
- [ ] **Linux/OpenGL smoke** — GLSL not compiled locally
- [ ] Merge after #1875

🤖 Generated with [Claude Code](https://claude.com/claude-code)