### PR TITLE
render: fix cardinal coverage holes via single-source yaw deadband + rotated-solidity harness (#1882)

### DIFF
--- a/.fleet/plans/issue-1882.md
+++ b/.fleet/plans/issue-1882.md
@@ -1,54 +1,100 @@
-# Plan: render — rotated-solidity harness (isolate cardinals + zoom tier + near-cardinal sampling)
+# Plan: render — cardinal-gather coverage loss at non-start cardinals
 
-- **Issue:** #1882 (**RE-SCOPED** — was "cardinal-gather coverage loss")
+- **Issue:** #1882
 - **Model:** opus
-- **Date:** 2026-06-17
-- **Epic:** #1881 — see .fleet/plans/issue-1881.md for full context
-- **Gated on:** PR #1880 (harness) — merged. **Unblocks #1883.**
+- **Date:** 2026-06-16 (re-scoped 2026-06-17, FINAL scope 2026-06-18)
+- **Epic:** #1881 — see .fleet/plans/issue-1881.md for full context + baseline
+- **Gated on:** PR #1880 (harness) on master
+- **PR:** #1885
 
-## Re-scope rationale
-The #1885 investigation proved the original premise (single-canvas cardinal gather
-broken) was a **misdiagnosis**: held statically at each exact cardinal the
-single-canvas path renders coverage 1.0 / 0 holes, and an early-return probe in the
-cardinal store showed the ramp's broken "cardinal" rows are rendered by the
-**per-axis** path (90°/180° unchanged when the cardinal store early-returns; only
-270° vanishes). The ramp's coverage loss is the per-axis path (→ #1883), captured at
-near-cardinal *residual* frames because per-axis is still allocated (allocation /
-deadband lag, with a yaw-sign asymmetry). So #1882 becomes the harness-methodology
-fix the misdiagnosis exposed — the harness must distinguish render paths and surface
-the artifacts that zoom 0.8 hides.
+## Scope history (read this — the ticket flipped twice)
 
-## Scope
-1. **Isolate the single-canvas path at the cardinals.** Settle/hold at each exact
-   cardinal so per-axis is released before capture; fix the 270°-vs-90°/180°
-   asymmetry (per-axis-release deadband / `computeYawSplit` residual sign at exact
-   cardinals). Settled cardinals must read clean (>= 0.99).
-2. **Add a zoomed tier on a small cube.** High zoom on a small cube (small
-   `--grid-size` + high `--zoom`, or drive canvas_stress) so the fine per-axis
-   face-alignment / seam / sliver artifacts are visible; zoom 0.8 on the 64^3 cube
-   under-resolves them.
-3. **Finer near-cardinal sampling.** Artifacts peak **approaching** 180°/270° (~±1–10°
-   residual), not at exact cardinals or the 45° flips. Sample densely there.
-4. **Report the render path** (single-canvas vs per-axis) per pose so a "cardinal"
-   row is unambiguous.
+1. **Original:** "the single-canvas cardinal path drops ~⅓ of the cube at the
+   non-start cardinals (π/2, π, 3π/2)." Correct symptom.
+2. **Re-scope #1 (WRONG, superseded):** "premise is a misdiagnosis; the
+   single-canvas path is clean at the cardinals; the loss is the per-axis path
+   (#1883); make this a harness-methodology fix." This rested on a static-yaw
+   test that used `--yaw <radians>` — but `setCameraVisualYaw` takes
+   **degrees** (`ir_render.cpp:185`, `deg * π/180`), so `--yaw 1.5708` held the
+   camera at **1.57°, not 90°**. All four "static cardinals" were within ~2° of
+   0° (clean by construction); 90/180/270 were never exercised. The
+   "misdiagnosis" verdict was itself the misdiagnosis.
+3. **FINAL (this plan):** the original premise is **vindicated** — the
+   single-canvas cardinal path really does lose coverage at 90°/180°. Root
+   cause is a residual-yaw **gate mismatch**, fixed at the source. Plus the
+   render-path-aware harness the investigation produced (it is what caught the
+   degrees/radians error and measures the real path per pose).
 
-## Affected files
-- `scripts/dev/perf-grid-rotate-sweep` — sampling set + settle + per-pose path label + zoom tier
-- `creations/demos/perf_grid/main.cpp` — `kYawRampShots`: near-cardinal + zoom-tier shots; expose per-axis-active state
-- (read) `engine/prefabs/irreden/render/per_axis_canvas.hpp` + `system_voxel_to_trixel` `beginTick` `syncAllocationToCameraYaw` (allocation/deadband lifecycle + the 270° asymmetry); `engine/prefabs/irreden/render/camera.hpp` `computeYawSplit` (residual sign)
+## Root cause (gate mismatch)
+
+Two predicates over the **same** `computeYawSplit(...).second` residual, with
+different thresholds:
+
+- per-axis **allocation** gate frees the textures at `|residual| <= 1e-4`
+  (`per_axis_canvas.hpp`, `kResidualYawDeadband`).
+- render **path-select** gate routes to the per-axis path at `residualYaw_ != 0`
+  exactly (`system_voxel_to_trixel.hpp:734`; source `voxel_frame_data.hpp:198`).
+
+A cardinal whose quat round-trip residual lands in `(0, 1e-4]` (90°, and 180°
+via the `wrapYaw` `-π + 1e-4` clamp) has its per-axis textures **freed** by the
+allocation gate while the render still **selects the per-axis path** → it reads
+freed/empty textures → see-through coverage holes. 0° and 270° round-trip to
+residual *exactly* 0 → both gates agree (single-canvas) → clean. That asymmetry
+is the whole "270 is fine, 90/180 are broken" signature.
+
+## Fix (single source of truth)
+
+Deadband the residual **at its one source** so every consumer agrees by
+construction. `IRPrefab::Camera::computeYawSplit` now snaps `residualYaw` to
+exactly 0 within `kResidualYawDeadband` (the constant moved into `camera.hpp`
+next to the split). Consequences:
+
+- allocation gate (`per_axis_canvas.hpp`) and render path-select gate
+  (`system_voxel_to_trixel.hpp:734`) both reduce to `residual != 0` over the
+  same deadbanded value — they cannot disagree.
+- the GPU `FrameDataVoxelToCanvas.residualYaw_` and the sun-shadow bake's frame
+  patch inherit the same snapped value (both go through `computeYawSplit`).
+- **byte-identical** for visible rotation (`|residual| > deadband`) and for an
+  exact cardinal (`residual` already 0). Only the broken `(0, 1e-4]` dead zone
+  changes — it now takes the clean single-canvas cardinal path, which is what a
+  settled cardinal should do.
+
+Files: `engine/prefabs/irreden/render/camera.hpp`,
+`engine/prefabs/irreden/render/per_axis_canvas.hpp`,
+`engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp` (doc).
+
+## Harness (the second deliverable, already on the branch)
+
+Render-path-aware tiers in `creations/demos/perf_grid/main.cpp` +
+`scripts/dev/perf-grid-rotate-sweep`:
+- cardinal-isolation tier — settled exact cardinals; demo MEASURES which path
+  drew each pose (`C_PerAxisTrixelCanvases::isAllocated`) and logs `RAMP-POSE`;
+  the sweep joins the path label to the scored frame so a "cardinal" row is
+  unambiguous (this is what kills the misdiagnosis class of error).
+- near-cardinal residual tier — dense ±1..10° sampling where the per-axis seams
+  / bands peak (#1883's signal).
+- zoom tier — small cube, high zoom, ROI crops for the fine seams.
 
 ## Acceptance criteria
-- Per-pose render-path label; **settled exact cardinals read clean (>= 0.99) on BOTH backends.**
-- The zoomed near-cardinal tier surfaces the per-axis face-alignment/seam artifacts
-  as a measurable signal (coverage / silhouette raggedness) + ROI crops.
+
+- `bash scripts/dev/perf-grid-rotate-sweep build dense 60`: all four settled
+  cardinals read `path=single` AND coverage >= 0.99 (90/180 were ~0.84 before).
+- No regression at yaw 0 or at any genuinely-rotating per-axis pose
+  (`|residual| > deadband` unchanged → byte-identical).
+- Holds on BOTH Metal (macOS) and OpenGL (Linux).
+- Before/after cardinal numbers in the PR.
 
 ## Gotchas
-- The per-axis-release deadband + `computeYawSplit` residual sign at exact cardinals
-  is the 270°-vs-90°/180° asymmetry; nudge the captured yaw within the deadband (or
-  hold long enough for the free-at-cardinal gate to fire).
-- **Do NOT change the cardinal store / single-canvas gather — it is verified correct.**
+
+- The fix is the per-axis/single-canvas SELECTION boundary — cross-check the
+  smooth-yaw path (#1308/#1310): snapping is a no-op above the deadband, so
+  visible rotation is untouched; verify the ramp's rotating poses are unchanged.
+- Cardinal-0 fast path must stay byte-identical (residual already 0 → no-op).
+- The cardinal coverage HOLES are this ticket; the per-axis **band** coverage
+  loss at genuinely-rotating poses + the **face seams** stay #1883.
 
 ## Verification
-macOS: `bash scripts/dev/perf-grid-rotate-sweep` with the new settle + zoom +
-near-cardinal sampling; confirm cardinals clean + the zoom tier surfaces the seams.
-Linux: same via fleet-build/run. Cross-host IRShapeDebug smoke.
+
+macOS: `bash scripts/dev/perf-grid-rotate-sweep build dense 60` (check the
+`path` + coverage columns at the four cardinals). Linux: `fleet-build IRPerfGrid`
++ same sweep. Cross-host `IRShapeDebug --auto-screenshot` smoke.

--- a/.fleet/plans/issue-1883.md
+++ b/.fleet/plans/issue-1883.md
@@ -6,10 +6,14 @@
 - **Epic:** #1881 — see .fleet/plans/issue-1881.md
 - **Blocked by:** #1882 (the harness must isolate render paths + surface fine artifacts first)
 
-## Scope — the whole per-axis forward-scatter defect (two related faces)
-The #1885 investigation moved the rotated-cube defect here: it is the per-axis
-forward-scatter path, **not** the single-canvas cardinal gather (#1882, re-scoped to
-the harness fix). Two symptoms, one root cause:
+## Scope — the per-axis forward-scatter defect at GENUINELY-ROTATING poses
+This ticket is the per-axis forward-scatter path at `|residual| > deadband`
+(the textures are allocated and the scatter actually draws). It is **distinct**
+from the cardinal coverage HOLES at 90°/180° — those were a residual-yaw gate
+mismatch in the SINGLE-CANVAS path, fixed under #1882 (the deadbanded
+`computeYawSplit`); do not re-attribute them here. Validate against the #1882
+harness, reading the near-cardinal *residual* tier (path=peraxis), not the
+settled cardinals (path=single, now clean). Two symptoms, one root cause:
 
 **A. Coverage "bands"** (IRPerfGrid `--mode dense` 64^3): see-through density loss
 across the residual band — whole diagonal bands of the solid read as background. The

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -19,6 +19,7 @@
 #include <irreden/render/components/component_canvas_light_volume.hpp>
 #include <irreden/render/components/component_canvas_sun_shadow.hpp>
 #include <irreden/render/components/component_light_source.hpp>
+#include <irreden/render/components/component_per_axis_trixel_canvases.hpp>
 #include <irreden/render/components/component_triangle_canvas_textures.hpp>
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/update/components/component_periodic_idle.hpp>
@@ -117,6 +118,7 @@ struct CliOverrides {
     bool yawSet_ = false;
     float yaw_ = 0.0f;
     bool yawRamp_ = false;
+    bool yawRampCrops_ = false;
     bool waveAmplitudeSet_ = false;
     float waveAmplitude_ = 0.0f;
     bool subdivisionModeSet_ = false;
@@ -149,34 +151,143 @@ constexpr IRVideo::AutoScreenshotShot kShots[] = {
     {4.0f, vec2(16, 8), 0.35f, "zoom4_rot_pan"},
 };
 
-// --yaw-ramp harness: the rotated-solidity validation set. Run with
-// `--mode dense --yaw-ramp --auto-screenshot` (driven by
-// scripts/dev/perf-grid-rotate-sweep). Rotates a solid 64^3 cube slowly through
-// the full camera-yaw circle (0 → 2pi) in small fixed steps at a constant
-// whole-cube zoom, capturing every step. The small per-step delta is the point:
-// the iterative lighting (light volume / AO / sun-shadow) accumulates across
-// frames on the live canvas, so a few large yaw jumps capture it mid-converge
-// and unlit faces read as spurious background "holes" — a slow ramp keeps it
-// converged frame-to-frame, isolating true geometry/coverage loss from that
-// settling artifact. A solid cube must stay a solid cube at every yaw. Each
-// capture is scored by scripts/render-coverage-metric.py (interior holes) +
-// scripts/render-silhouette-metric.py (edge raggedness).
+// --yaw-ramp harness: the rotated-solidity validation set (#1882 / #1883).
+// Run with `--mode dense --yaw-ramp --auto-screenshot` (driven by
+// scripts/dev/perf-grid-rotate-sweep). The original "uniform 36-step ramp"
+// labelled its rows by `i/n*360` and could not tell which render path drew a
+// pose, so a row called "cardinal" might secretly be a per-axis residual frame
+// (the #1882 misdiagnosis). This set fixes that with two tiers plus a measured
+// per-pose render-path label:
 //
-// Built at init (runtime, not constexpr) so the step count lives in one place;
-// the vector must outlive the game loop, so it is a file-scope global.
+//   * Cardinal-isolation tier — the four EXACT cardinals (0/90/180/270). At
+//     residual≈0 the per-axis textures release, so these capture the
+//     single-canvas cardinal path; the harness MEASURES that path per pose
+//     (logRampPose) and scores coverage so "is the single-canvas path clean at
+//     this cardinal?" is answered directly, not assumed.
+//   * Near-cardinal residual tier — dense sampling APPROACHING 90/180/270
+//     (±1..10°), where the per-axis face-alignment seams / coverage bands peak
+//     (#1883). These render through the per-axis path by design; the zoom pass
+//     (small --grid-size + high --zoom + --yaw-ramp-crops) makes the fine seams
+//     a measurable silhouette signal the whole-cube pass under-resolves.
+//
+// Each capture's render path (single-canvas vs per-axis) is MEASURED at the
+// settled frame via the onCaptureFrame_ hook (logRampPose below) so a sweep row
+// labelled "cardinal" is unambiguous. The vectors must outlive the game loop,
+// so they are file-scope globals; g_yawRampLabels backs the shots' label_
+// pointers (filled once, never grown, so the c_str() pointers stay valid).
 std::vector<IRVideo::AutoScreenshotShot> g_yawRampShots;
-
-void buildYawRampShots() {
-    constexpr int kRampSteps = 36; // 10deg per step around the full circle
-    g_yawRampShots.reserve(kRampSteps);
-    for (int i = 0; i < kRampSteps; ++i) {
-        const float yaw = (static_cast<float>(i) / static_cast<float>(kRampSteps)) * kTwoPi;
-        g_yawRampShots.push_back({0.8f, vec2(0, 0), yaw, "ramp"});
-    }
-}
+std::vector<std::string> g_yawRampLabels;
+IRVideo::RoiCrop g_yawRampCenterCrop{};
 
 PerfGridSettings g_settings{};
 CliOverrides g_cliOverrides{};
+
+void buildYawRampShots() {
+    // Every pose uses the run's camera zoom — the sweep drives a wide
+    // whole-cube coverage pass (default 0.8) and a tight small-cube zoom pass
+    // (high --zoom + small --grid-size) through the same shot table.
+    const float zoom = g_settings.initialZoom_;
+
+    struct RampPose {
+        float yawRadians_;
+        bool cardinal_;
+        std::string label_;
+    };
+    std::vector<RampPose> poses;
+
+    const float cardinals[4] = {0.0f, IRMath::kHalfPi, IRMath::kPi, 3.0f * IRMath::kHalfPi};
+    const char *cardinalLabels[4] = {"card000", "card090", "card180", "card270"};
+    for (int k = 0; k < 4; ++k) {
+        poses.push_back({cardinals[k], true, cardinalLabels[k]});
+    }
+
+    const int residualBases[3] = {90, 180, 270};
+    const float offsetsDeg[8] = {-10.0f, -6.0f, -3.0f, -1.0f, 1.0f, 3.0f, 6.0f, 10.0f};
+    for (int base : residualBases) {
+        for (float off : offsetsDeg) {
+            const float deg = static_cast<float>(base) + off;
+            const float rad = deg * IRMath::kPi / 180.0f;
+            const int absOff = static_cast<int>(IRMath::abs(off) + 0.5f);
+            std::string label = "near" + std::to_string(base) + "_" + (off < 0.0f ? "m" : "p") +
+                                (absOff < 10 ? "0" : "") + std::to_string(absOff);
+            poses.push_back({rad, false, std::move(label)});
+        }
+    }
+
+    // Order by yaw so consecutive shots are a small step apart, keeping the
+    // iterative lighting (light volume / AO / sun-shadow) converged frame to
+    // frame; a large jump captures it mid-converge and unlit faces read as
+    // spurious "holes". Only the three region gaps (~70°) jump far — the
+    // settle window absorbs them.
+    std::sort(poses.begin(), poses.end(), [](const RampPose &a, const RampPose &b) {
+        return a.yawRadians_ < b.yawRadians_;
+    });
+
+    const bool useCrops = g_cliOverrides.yawRampCrops_;
+    if (useCrops) {
+        ivec2 fb{0, 0};
+        IRWindow::getFramebufferSize(fb);
+        const int cw = IRMath::max(1, fb.x / 2);
+        const int ch = IRMath::max(1, fb.y / 2);
+        g_yawRampCenterCrop = {(fb.x - cw) / 2, (fb.y - ch) / 2, cw, ch, "center"};
+    }
+
+    g_yawRampLabels.clear();
+    g_yawRampLabels.reserve(poses.size());
+    for (const RampPose &p : poses) {
+        g_yawRampLabels.push_back(p.label_);
+    }
+
+    g_yawRampShots.clear();
+    g_yawRampShots.reserve(poses.size());
+    for (std::size_t i = 0; i < poses.size(); ++i) {
+        IRVideo::AutoScreenshotShot shot{};
+        shot.zoom_ = zoom;
+        shot.cameraIso_ = vec2(0, 0);
+        shot.yawRadians_ = poses[i].yawRadians_;
+        shot.label_ = g_yawRampLabels[i].c_str();
+        // Crops only on the residual-band poses (where the seams live) and only
+        // when the zoom pass asked for them.
+        if (useCrops && !poses[i].cardinal_) {
+            shot.crops_ = &g_yawRampCenterCrop;
+            shot.numCrops_ = 1;
+        }
+        g_yawRampShots.push_back(shot);
+    }
+}
+
+// onCaptureFrame_ hook: measure which render path actually drew this pose so
+// the sweep can label every row unambiguously. The main canvas's per-axis
+// textures are allocated only while a residual rotation is being smoothed, so
+// isAllocated() at the settled capture frame is the ground truth (a 'cardinal'
+// row that still reports peraxis is the #1882 failure). Reads live ECS the
+// harness cannot; emits one greppable line the sweep scorer joins by index.
+void logRampPose(int shotIndex) {
+    bool perAxisActive = false;
+    const IREntity::EntityId mainCanvas = IRRender::getCanvas("main");
+    if (mainCanvas != IREntity::kNullEntity) {
+        auto perAxis =
+            IREntity::getComponentOptional<IRComponents::C_PerAxisTrixelCanvases>(mainCanvas);
+        if (perAxis.has_value()) {
+            perAxisActive = perAxis.value()->isAllocated();
+        }
+    }
+    const float residualDeg = IRPrefab::Camera::getResidualYaw() * 180.0f / IRMath::kPi;
+    const float nominalDeg = (shotIndex >= 0 && shotIndex < static_cast<int>(g_yawRampShots.size()))
+                                 ? g_yawRampShots[shotIndex].yawRadians_ * 180.0f / IRMath::kPi
+                                 : 0.0f;
+    const char *label = (shotIndex >= 0 && shotIndex < static_cast<int>(g_yawRampLabels.size()))
+                            ? g_yawRampLabels[shotIndex].c_str()
+                            : "?";
+    IR_LOG_INFO(
+        "RAMP-POSE idx={} label={} yaw_deg={:.3f} path={} residual_deg={:.4f}",
+        shotIndex,
+        label,
+        nominalDeg,
+        perAxisActive ? "peraxis" : "single",
+        residualDeg
+    );
+}
 int g_autoProfileFrames = 0;
 int g_autoProfileCount = 0;
 int g_autoWarmupFrames = 0;
@@ -363,6 +474,10 @@ void parseArgs(int argc, char **argv) {
             ++i;
         } else if (std::strcmp(argv[i], "--yaw-ramp") == 0) {
             g_cliOverrides.yawRamp_ = true;
+        } else if (std::strcmp(argv[i], "--yaw-ramp-crops") == 0) {
+            // Attach a center ROI crop to each near-cardinal residual pose so
+            // the small-cube zoom pass dumps inspectable per-axis-seam crops.
+            g_cliOverrides.yawRampCrops_ = true;
         } else if (std::strcmp(argv[i], "--wave-amplitude") == 0 && i + 1 < argc) {
             // 0.0 = static scene (no per-frame voxel motion). Useful for
             // isolating per-frame upload cost in profiler runs.
@@ -634,9 +749,11 @@ int main(int argc, char **argv) {
 
     if (g_occlusionCull) {
         IRRender::setVoxelOcclusionCullEnabled(true);
-        IR_LOG_INFO("Voxel chunk-occlusion cull forced ON (--occlusion-cull, #1294 child 3/3). "
-                    "Output stays bit-identical to cull-off; one-frame silhouette pop on a "
-                    "discontinuous camera move is intentional drift (stale Hi-Z self-disable).");
+        IR_LOG_INFO(
+            "Voxel chunk-occlusion cull forced ON (--occlusion-cull, #1294 child 3/3). "
+            "Output stays bit-identical to cull-off; one-frame silhouette pop on a "
+            "discontinuous camera move is intentional drift (stale Hi-Z self-disable)."
+        );
     }
 
     IRRender::setCameraPosition2DIso(vec2(0.0f, 0.0f));
@@ -793,9 +910,14 @@ void initSystems() {
             buildYawRampShots();
             cfg.shots_ = g_yawRampShots.data();
             cfg.numShots_ = static_cast<int>(g_yawRampShots.size());
-            // Small per-step yaw delta + extra settle frames keep the iterative
-            // lighting converged across the ramp (see buildYawRampShots above).
-            cfg.settleFrames_ = 8;
+            // The tiered set steps a few degrees within each cardinal region but
+            // jumps ~70° between regions; a generous settle keeps the iterative
+            // lighting (light volume / AO / sun-shadow) converged across those
+            // jumps and lets the per-axis allocation gate settle to the pose's
+            // true render path before capture (see buildYawRampShots above).
+            cfg.settleFrames_ = 16;
+            // Measure each pose's actual render path at the settled frame.
+            cfg.onCaptureFrame_ = &logRampPose;
         } else {
             cfg.shots_ = kShots;
             cfg.numShots_ = sizeof(kShots) / sizeof(kShots[0]);

--- a/engine/prefabs/irreden/render/camera.hpp
+++ b/engine/prefabs/irreden/render/camera.hpp
@@ -21,15 +21,39 @@
 
 namespace IRPrefab::Camera {
 
+// Residual-yaw deadband. A residual at or below this magnitude counts as a
+// settled cardinal (not rotating): the renderer stays on the byte-identical
+// single-canvas fast path and the per-axis textures stay released. This is the
+// ONE place the threshold lives — `computeYawSplit` snaps the residual to
+// exactly 0 inside it, so every "rotating?" consumer (the per-axis allocation
+// gate in per_axis_canvas.hpp, the render path-select gate in
+// system_voxel_to_trixel.hpp, the FrameDataVoxelToCanvas UBO, the sun-shadow
+// bake's frame patch) derives the same predicate from the same value and
+// cannot disagree. Before #1882 the allocation gate used `|residual| > deadband`
+// while path-select used `residual != 0`; a cardinal whose quat round-trip
+// landed in (0, deadband] freed the per-axis textures yet still routed to the
+// per-axis path, reading freed textures → see-through coverage holes at
+// 90°/180°. Deadbanding at the source closes that gap.
+inline constexpr float kResidualYawDeadband = 1e-4f;
+
 /// Decompose a continuous Z-yaw value into (rasterYaw, residualYaw):
 ///   rasterYaw   = nearest cardinal multiple of π/2 to @p visualYaw
-///   residualYaw = visualYaw - rasterYaw, lies in [-π/4, π/4]
+///   residualYaw = visualYaw - rasterYaw, lies in [-π/4, π/4], reported as
+///                 exactly 0 within kResidualYawDeadband (see above)
 /// rasterYaw selects the cardinal-snap basis for the integer trixel
 /// rasterizer; residualYaw is the leftover angle the screen-space
 /// residual composite pass rotates the canvas by.
 inline std::pair<float, float> computeYawSplit(float visualYaw) {
     const float rasterYaw = IRMath::round(visualYaw / IRMath::kHalfPi) * IRMath::kHalfPi;
-    return {rasterYaw, visualYaw - rasterYaw};
+    const float residualYaw = visualYaw - rasterYaw;
+    // Single-source deadband (#1882): a residual within float-noise of a
+    // cardinal reports as exactly 0 so the allocation gate and the render
+    // path-select gate agree. No-op for visible rotation (|residual| >
+    // deadband) and for an exact cardinal (residual already 0) — byte-identical.
+    if (IRMath::abs(residualYaw) <= kResidualYawDeadband) {
+        return {rasterYaw, 0.0f};
+    }
+    return {rasterYaw, residualYaw};
 }
 
 namespace detail {

--- a/engine/prefabs/irreden/render/per_axis_canvas.hpp
+++ b/engine/prefabs/irreden/render/per_axis_canvas.hpp
@@ -27,12 +27,6 @@ namespace IRPrefab::PerAxisCanvas {
 // (T3) land.
 inline constexpr float kMinOnScreenTrixelSizePx = 1.0f;
 
-// Residual-yaw deadband for the allocation gate. |residualYaw| at or below this
-// counts as "cardinal" (not rotating): the per-axis textures stay released and
-// the renderer stays on the byte-identical single-canvas fast path. A small
-// deadband avoids allocate/release churn from float noise right at a cardinal.
-inline constexpr float kResidualYawDeadband = 1e-4f;
-
 namespace detail {
 // Allocate a canvas's three per-axis texture sets at the worst-case size for
 // its cardinal trixel canvas, plus the screen-space resolve-depth texture at
@@ -69,7 +63,12 @@ inline void syncAllocationToCameraYaw() {
     IRComponents::C_PerAxisTrixelCanvases &axes = *perAxis.value();
 
     const float residualYaw = IRPrefab::Camera::computeYawSplit(IRPrefab::Camera::getYaw()).second;
-    const bool rotating = IRMath::abs(residualYaw) > kResidualYawDeadband;
+    // computeYawSplit deadbands the residual to exactly 0 at a settled cardinal
+    // (Camera::kResidualYawDeadband, #1882), so this `!= 0` allocation gate and
+    // the render path-select gate in system_voxel_to_trixel share the identical
+    // predicate — they can never disagree about whether the per-axis textures
+    // should be live.
+    const bool rotating = residualYaw != 0.0f;
 
     if (rotating == axes.isAllocated()) {
         return; // already in the desired allocation state

--- a/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
+++ b/engine/prefabs/irreden/render/systems/system_voxel_to_trixel.hpp
@@ -730,7 +730,11 @@ template <> struct System<VOXEL_TO_TRIXEL_STAGE_1> {
         // i.e. the per-axis canvases are active), project the chunk-visibility
         // gate with the same continuous yaw the per-axis scatter raster uses, so
         // off-center chunks aren't dropped by the cardinal snap. residual == 0
-        // keeps the byte-identical cardinal path.
+        // keeps the byte-identical cardinal path. residualYaw_ is deadbanded at
+        // its source (Camera::computeYawSplit / kResidualYawDeadband, #1882), so
+        // this `!= 0` path-select predicate matches the per-axis allocation gate
+        // exactly — a near-cardinal residual can't free the textures while still
+        // routing here (the old gap that read freed textures as coverage holes).
         const bool rotating = frameData_.residualYaw_ != 0.0f;
         if (revoxInverse) {
             // Dest-cell domain (#1619): the rotated solid rasters in its own

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -75,11 +75,22 @@ struct AutoScreenshotShot {
 /// Declarative config for @c createAutoScreenshotSystem. @c shots_ /
 /// @c numShots_ point at a shot table owned by the caller — it must outlive
 /// the game loop.
+///
+/// @c onCaptureFrame_ is an optional per-shot hook fired exactly once per shot,
+/// on the settled capture frame, immediately after the screenshot is requested,
+/// passing the shot index. It lets a creation record render state that only the
+/// settled frame reflects — e.g. perf_grid's rotated-solidity harness samples
+/// which render path (single-canvas cardinal vs per-axis) actually drew the
+/// pose, so a "cardinal" row is unambiguous (#1882). State that engine/video
+/// cannot see is injected as a type-erased callback (same pattern as
+/// @c GuiTestConfig::onAssertFrame_). @c nullptr keeps every existing caller
+/// byte-identical.
 struct AutoScreenshotConfig {
     int warmupFrames_ = 10;
     int settleFrames_ = 3;
     const AutoScreenshotShot *shots_ = nullptr;
     int numShots_ = 0;
+    void (*onCaptureFrame_)(int shotIndex) = nullptr;
 };
 
 /// Parse @c --auto-screenshot<space>[frames] from argv. Returns @c true if

--- a/engine/video/src/auto_screenshot.cpp
+++ b/engine/video/src/auto_screenshot.cpp
@@ -124,6 +124,11 @@ IRSystem::SystemId createAutoScreenshotSystem(const AutoScreenshotConfig &config
                 } else {
                     IRVideo::requestScreenshot();
                 }
+                // Per-shot capture hook (#1882): fire once on the settled frame
+                // so the caller can record render state the capture reflects.
+                if (state->config_.onCaptureFrame_ != nullptr) {
+                    state->config_.onCaptureFrame_(state->currentShot_);
+                }
                 state->screenshotPending_ = true;
                 return;
             }

--- a/scripts/dev/perf-grid-rotate-sweep
+++ b/scripts/dev/perf-grid-rotate-sweep
@@ -55,7 +55,7 @@ EXE_DIR="$BUILD_DIR/creations/demos/perf_grid"
 SS_DIR="$EXE_DIR/save_files/screenshots"
 
 echo "[1/4] building IRPerfGrid ($BUILD_DIR) ..."
-cmake --build "$BUILD_DIR" --target IRPerfGrid -j 8 >/dev/null || { echo "BUILD FAILED"; exit 1; }
+cmake --build "$BUILD_DIR" --target IRPerfGrid -j "$(nproc)" >/dev/null || { echo "BUILD FAILED"; exit 1; }
 
 # Run the ramp once with the given extra args, capturing the demo log (the
 # RAMP-POSE render-path lines are parsed from it). Clears prior PNGs first.

--- a/scripts/dev/perf-grid-rotate-sweep
+++ b/scripts/dev/perf-grid-rotate-sweep
@@ -1,31 +1,46 @@
 #!/usr/bin/env bash
-# perf-grid-rotate-sweep — rotated-voxel solidity validation harness.
+# perf-grid-rotate-sweep — rotated-voxel solidity validation harness (#1882).
 #
-# Builds IRPerfGrid, rotates a solid 64^3 cube (--mode dense) slowly through the
-# full camera-yaw circle via the demo's --yaw-ramp mode, and scores every
-# captured frame with the structural-metric suite:
-#   * interior-hole ratio  — the cube must stay opaque (no background showing
-#     through it); render-coverage-metric.py's measure.
-#   * silhouette raggedness — perimeter^2 / area; a clean iso cube is a smooth
-#     hexagon, while a sheared "curtain" or scalloped edge spikes this even when
-#     the hole ratio is ~0; render-silhouette-metric.py's measure.
-# Both are computed from render_metric_util with one decode per frame.
+# Builds IRPerfGrid and drives its `--yaw-ramp` shot table, which is no longer a
+# uniform 36-step circle but a TIERED, render-path-aware set (see
+# `buildYawRampShots` in creations/demos/perf_grid/main.cpp):
 #
-# The slow ramp is the point: the iterative lighting (light volume / AO /
-# sun-shadow) accumulates across frames on the live canvas, so a few large yaw
-# jumps capture it mid-converge and unlit faces read as spurious "holes". A slow
-# ramp keeps lighting converged frame-to-frame, so a spike in either metric
-# localizes a true geometry/coverage break to its yaw rather than a settling
-# artifact.
+#   * Cardinal-isolation tier — the four EXACT cardinals (0/90/180/270). At
+#     residual≈0 the per-axis textures release, so these capture the
+#     single-canvas cardinal path. The demo MEASURES which path actually drew
+#     each pose (single-canvas vs per-axis) at the settled capture frame and
+#     logs it as a `RAMP-POSE` line; this harness joins that label to the
+#     scored frame so a row called "cardinal" is unambiguous (the original
+#     uniform ramp labelled rows by angle and could not distinguish the path,
+#     which is what produced the #1882 misdiagnosis). Cardinal poses are
+#     expected to read clean (coverage >= 0.99) AND report path=single.
+#   * Near-cardinal residual tier — dense sampling APPROACHING 90/180/270
+#     (±1..10°), where the per-axis face-alignment seams / coverage bands peak
+#     (#1883). These render through the per-axis path by design.
+#
+# Two passes:
+#   1. coverage  — 64³ cube, whole-cube zoom. Interior-hole / coverage metric
+#      catches see-through density loss; this is the primary cardinal + band
+#      signal.
+#   2. zoom      — small cube, high zoom, with center ROI crops. The fine
+#      per-axis face seams only resolve when each trixel is large on screen
+#      (zoom 0.8 on the 64³ cube under-resolves them). The silhouette
+#      raggedness metric (perimeter²/area) is the measurable seam signal; the
+#      crops are for visual inspection.
+#
+# Metrics (per frame, one decode, render_metric_util stdlib-only):
+#   * coverage / interior-hole ratio — the cube must stay opaque.
+#   * silhouette raggedness (perim²/area) — a clean iso cube is a smooth
+#     hexagon; seams / slivers / curtains spike this even when holes are ~0.
 #
 # Usage:  bash scripts/dev/perf-grid-rotate-sweep [build_dir] [mode] [warmup]
 #   build_dir   CMake build dir              (default: build)
 #   mode        dense|hollow|voxel_set|sdf   (default: dense)
-#   warmup      frames to converge lighting at yaw 0 before the ramp
-#                                            (default: 60)
+#   warmup      frames to converge lighting at the start pose
+#                                            (default: 80)
 #
-# Repo tooling — cmake + python3 stdlib only. Long enough (build + ~400-frame
-# run + per-frame scoring) that it should be launched in the background and its
+# Repo tooling — cmake + python3 stdlib only. Long enough (build + two runs +
+# per-frame scoring) that it should be launched in the background and its
 # output read on completion. Self-locating, so it works from any cwd / worktree.
 set -uo pipefail
 
@@ -34,37 +49,62 @@ cd "$ROOT" || exit 1
 
 BUILD_DIR="${1:-build}"
 MODE="${2:-dense}"
-WARMUP="${3:-60}"
+WARMUP="${3:-80}"
 
 EXE_DIR="$BUILD_DIR/creations/demos/perf_grid"
 SS_DIR="$EXE_DIR/save_files/screenshots"
 
-echo "[1/3] building IRPerfGrid ($BUILD_DIR) ..."
+echo "[1/4] building IRPerfGrid ($BUILD_DIR) ..."
 cmake --build "$BUILD_DIR" --target IRPerfGrid -j 8 >/dev/null || { echo "BUILD FAILED"; exit 1; }
 
-echo "[2/3] running yaw ramp (mode=$MODE, warmup=$WARMUP) ..."
-mkdir -p "$SS_DIR"
-# Scoped find -delete, never an unguarded `rm <dir>/*.png` glob (the dir may be
-# empty, which trips the dangerous-rm guard).
-find "$SS_DIR" -maxdepth 1 -type f -name '*.png' -delete
-( cd "$EXE_DIR" && ./IRPerfGrid --mode "$MODE" --grid-size 64 --yaw-ramp \
-    --no-overlay --auto-screenshot "$WARMUP" ) >/dev/null \
-    || { echo "RUN FAILED"; exit 1; }
+# Run the ramp once with the given extra args, capturing the demo log (the
+# RAMP-POSE render-path lines are parsed from it). Clears prior PNGs first.
+run_ramp() {
+    local logfile="$1"; shift
+    mkdir -p "$SS_DIR"
+    # Scoped find -delete, never an unguarded `rm <dir>/*.png` glob (the dir may
+    # be empty, which trips the dangerous-rm guard).
+    find "$SS_DIR" -maxdepth 1 -type f -name '*.png' -delete
+    ( cd "$EXE_DIR" && ./IRPerfGrid --mode "$MODE" --yaw-ramp --no-overlay \
+        --auto-screenshot "$WARMUP" "$@" ) >"$logfile" 2>&1 \
+        || { echo "RUN FAILED (see $logfile)"; tail -5 "$logfile"; exit 1; }
+}
 
-echo "[3/3] scoring captures ..."
-SCRIPTS_DIR="$ROOT/scripts" SS_DIR="$SS_DIR" python3 - <<'PY'
-import sys, os, glob
+# Score every full-frame PNG and join the demo's measured render-path labels.
+score_pass() {
+    SCRIPTS_DIR="$ROOT/scripts" SS_DIR="$SS_DIR" RUN_LOG="$1" TIER="$2" python3 - <<'PY'
+import sys, os, glob, re
 sys.path.insert(0, os.environ["SCRIPTS_DIR"])
 import render_metric_util as util
 
-shots = sorted(glob.glob(os.path.join(os.environ["SS_DIR"], "screenshot_*.png")))
+# Full-frame captures only — exclude the per-shot ROI crop PNGs
+# (screenshot_<n>_<label>__crop_<crop>.png) the zoom pass also writes.
+shots = sorted(
+    (f for f in glob.glob(os.path.join(os.environ["SS_DIR"], "screenshot_*.png"))
+     if re.search(r"screenshot_\d+\.png$", f)),
+    key=lambda f: int(re.search(r"screenshot_(\d+)\.png$", f).group(1)),
+)
 n = len(shots)
 if n == 0:
     sys.exit("no captures produced — the ramp run failed")
 
-print(f"{'step':<5}{'yaw_deg':<9}{'coverage':<10}{'hole_ratio':<12}{'perim_ratio':<12}")
-worst_hole = (0.0, -1)
-worst_perim = (0.0, -1)
+# Join the measured render path per shot index from the demo log.
+poses = {}
+pat = re.compile(
+    r"RAMP-POSE idx=(\d+) label=(\S+) yaw_deg=([\-\d.]+) path=(\w+) residual_deg=([\-\d.]+)")
+with open(os.environ["RUN_LOG"], encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        m = pat.search(line)
+        if m:
+            poses[int(m.group(1))] = {
+                "label": m.group(2), "yaw": float(m.group(3)),
+                "path": m.group(4), "residual": float(m.group(5)),
+            }
+
+print(f"=== {os.environ['TIER']} tier ({n} frames) ===")
+print(f"{'idx':<4}{'label':<13}{'yaw':<8}{'path':<9}{'coverage':<10}"
+      f"{'hole':<9}{'perim':<11}")
+cardinal_fail, worst_perim = [], (0.0, "")
 for i, f in enumerate(shots):
     mask, w, h, fg, _ = util.foreground_mask(f)
     hole_px = sum(util.enclosed_holes(mask, w, h))
@@ -72,16 +112,42 @@ for i, f in enumerate(shots):
     cov = (fg / sil) if sil else 1.0
     hr = (hole_px / sil) if sil else 0.0
     pr = (util.perimeter(mask, w, h) ** 2 / sil) if sil else 0.0
-    yaw_deg = i / n * 360.0
-    print(f"{i:<5}{yaw_deg:<9.1f}{cov:<10.4f}{hr:<12.4f}{pr:<12.2f}")
-    if hr > worst_hole[0]:
-        worst_hole = (hr, i)
-    if pr > worst_perim[0]:
-        worst_perim = (pr, i)
+    p = poses.get(i, {})
+    label = p.get("label", "?")
+    yaw = p.get("yaw", float(i))
+    path = p.get("path", "?")
+    is_card = label.startswith("card")
+    flag = ""
+    if is_card and (path != "single" or cov < 0.99):
+        flag = "  <-- CARDINAL NOT CLEAN"
+        cardinal_fail.append((label, path, cov))
+    print(f"{i:<4}{label:<13}{yaw:<8.1f}{path:<9}{cov:<10.4f}{hr:<9.4f}{pr:<11.2f}{flag}")
+    if not is_card and pr > worst_perim[0]:
+        worst_perim = (pr, label)
 
 print()
-print(f"worst hole_ratio : {worst_hole[0]:.4f} at step {worst_hole[1]} "
-      f"(yaw {worst_hole[1] / n * 360.0:.1f} deg)")
-print(f"worst perim_ratio: {worst_perim[0]:.2f} at step {worst_perim[1]} "
-      f"(yaw {worst_perim[1] / n * 360.0:.1f} deg)")
+print(f"worst residual-band perim_ratio (seam signal): {worst_perim[0]:.2f} "
+      f"at {worst_perim[1]}")
+if cardinal_fail:
+    print(f"CARDINAL CHECK: FAIL — {len(cardinal_fail)} cardinal pose(s) not "
+          f"clean single-canvas: "
+          + ", ".join(f"{lbl}(path={pa},cov={cv:.3f})"
+                      for lbl, pa, cv in cardinal_fail))
+else:
+    print("CARDINAL CHECK: PASS — all cardinals are clean single-canvas "
+          "(path=single, coverage >= 0.99)")
 PY
+}
+
+echo "[2/4] coverage pass — 64³ cube, whole-cube zoom (mode=$MODE) ..."
+run_ramp "/tmp/perf-grid-sweep-coverage.log" --grid-size 64 --zoom 0.8
+score_pass "/tmp/perf-grid-sweep-coverage.log" "coverage"
+
+echo
+echo "[3/4] zoom pass — small cube, high zoom + ROI crops (seam signal) ..."
+run_ramp "/tmp/perf-grid-sweep-zoom.log" --grid-size 12 --zoom 4 --yaw-ramp-crops
+score_pass "/tmp/perf-grid-sweep-zoom.log" "zoom"
+
+echo
+echo "[4/4] done. Full-frame + ROI-crop PNGs in: $SS_DIR"
+echo "      (ROI crops: screenshot_<n>_<label>__crop_center.png — residual-band poses)"


### PR DESCRIPTION
Fixes the single-canvas cardinal-path coverage loss at 90°/180° (the original #1882 defect) and ships the render-path-aware rotated-solidity harness that proves it.

**Root cause — residual-yaw gate mismatch.** The per-axis *allocation* gate frees the textures at `|residual| <= 1e-4` while the render *path-select* gate routed to the per-axis path at `residual != 0` exactly. A cardinal whose quat round-trip residual lands in `(0, 1e-4]` (90°, and 180° via the `wrapYaw -π+1e-4` clamp) freed the per-axis textures yet still drew the per-axis path → read freed textures as background → see-through hatch.

**Fix — single source of truth.** `Camera::computeYawSplit` now snaps `residualYaw` to exactly 0 within `kResidualYawDeadband` (moved into `camera.hpp`). Both gates, the `FrameDataVoxelToCanvas` UBO, and the sun-shadow bake derive the same predicate; both reduce to `residual != 0`. Byte-identical for visible rotation (`|residual| > deadband`) and exact cardinals (residual already 0); only the broken `(0, 1e-4]` dead zone changes.

**Harness.** Tiered, path-labeled `perf_grid --yaw-ramp` + `scripts/dev/perf-grid-rotate-sweep`: cardinal-isolation + near-cardinal (±1..10°) + zoom tiers, with the render path **measured** per pose so a "cardinal" row is unambiguous (this is what caught the degrees-vs-radians misdiagnosis).

**Validation (macOS / Metal):** all four cardinals `path=single`, coverage 1.0000 (90/180 were 0.84); `CARDINAL CHECK: PASS`; near-cardinal per-axis poses unchanged. Cross-host Linux/OpenGL sweep pending.

Closes #1882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
