### PR TITLE
docs/fleet: commit epic #1881 plan files to repo (cross-host availability)

### DIFF
--- a/.fleet/plans/issue-1881.md
+++ b/.fleet/plans/issue-1881.md
@@ -1,0 +1,193 @@
+# Plan: render — rotated-voxel correctness under camera Z-yaw (epic)
+
+- **Issue:** #1881 (umbrella, `fleet:epic`)
+- **Model:** opus (all children)
+- **Date:** 2026-06-16
+
+## Scope
+
+A solid voxel cube must read as a solid cube at every camera Z-yaw. Today it
+does so only at the start cardinal (yaw 0). Three distinct defects in the
+rotated-voxel render path are diagnosed below. PR #1880 shipped the validation
+substrate that localizes and gates them; every child validates against it.
+
+## Validation substrate (PR #1880 — must be on master first)
+
+- `IRPerfGrid --mode dense --grid-size 64 --yaw-ramp --auto-screenshot <warmup>`
+  rotates a solid 64^3 cube slowly through 0..2pi in 36 fixed 10deg steps at a
+  fixed whole-cube zoom. The slow ramp keeps the iterative lighting (light
+  volume / AO / sun-shadow) converged frame-to-frame, so the metrics reflect
+  geometry/coverage, not a settling artifact from big discontinuous jumps.
+- `scripts/dev/perf-grid-rotate-sweep [build_dir] [mode] [warmup]` drives
+  build -> ramp -> per-frame score and prints step/yaw_deg/coverage/hole_ratio/
+  perim_ratio + worst-pose summary. Metrics: render-coverage-metric.py
+  (interior-hole ratio) and render-silhouette-metric.py (perimeter^2/area; a
+  clean iso cube ~250, a sparse stipple/shatter spikes to 100k+).
+
+Baseline (origin/master, Metal): cardinal 0 -> coverage 0.994 / perim 242;
+per-axis poses -> 0.95-0.99 / perim 50-2000; cardinals pi/2, pi, 3pi/2 ->
+coverage 0.61-0.71 / perim ~140000 (sparse see-through mesh).
+
+## Backend note (all children)
+
+macOS renders the Metal shaders (engine/render/src/shaders/metal/); Linux/
+Windows render the GLSL (engine/render/src/shaders/). Every shader fix lands on
+BOTH backends and is smoke-validated on both (fleet:needs-macos-smoke /
+fleet:needs-linux-smoke). Child 1 was confirmed on Metal; OpenGL likely shares
+it (de-tile is cardinal-blind on both) but verify.
+
+---
+
+## Child 1 [opus, primary] — Cardinal-gather coverage loss at non-start cardinals
+
+SYMPTOM: dense 64^3 cube is solid at yaw 0 but a sparse see-through dot-mesh at
+exact cardinals pi/2, pi, 3pi/2 (coverage 0.61-0.71; holes are 100% pure
+(0,0,0) = true background, NOT dark/unlit faces; perim explodes ~600x). The
+per-axis residual path renders the identical geometry fine, so geometry + voxel
+data are intact; only the single-canvas cardinal path (residualYaw==0,
+smoothYaw_ off) is broken.
+
+RULED OUT (by reading real shaders + instrumentation): old -X/-Y/-Z face model
+(cardinal store uses visibleFaceIds[slot] x faceIsExposed, #1278,
+c_voxel_to_trixel_stage_1.glsl:166-193); simple parity flip (pos3DtoPos2DIso of
+an integer is always even; rotateCardinalZ + cardinalLowerCornerShift preserve
+it); lighting (holes are pure black).
+
+ROOT CAUSE: the store applies cardinalLowerCornerShift(cardinalIndex)
+(ir_iso_common.{glsl,metal} ~L441) before pos3DtoPos2DIso. Its iso projection
+is per-cardinal: k0:(0,0) k1:(-1,+1) k2:(0,+2) k3:(+1,+1). The framebuffer
+gather's canvas->screen mapping (canvasOffset / trixelOriginModifier /
+trixelFramebufferSamplePosition) does NOT compensate that per-cardinal offset,
+so store + gather agree only at k0. On Metal additionally,
+trixel_to_framebuffer.metal:93 reads color/distance at the RAW origin (the
+de-tile row-shift is disabled there per #394 -- it caused a 1px sawtooth),
+correct only when the shift's iso-y parity is even. A/B (force the Metal
+de-tile) recovers 90/270 (0.69->0.94, 0.61->0.92) but 180 stays broken in both
+modes (raw 0.71, de-tile 0.67) and 0 regains the #394 sawtooth -- the de-tile
+only corrects a +-1 row, not k2's +2-cell offset. So this is a
+cardinalLowerCornerShift <-> gather DESYNC, not a parity bit.
+
+DIRECTION (recommended: store-side reformulation / gather compensation):
+- Preferred: compensate the gather for the full per-cardinal
+  cardinalLowerCornerShift iso offset -- fold its iso projection into the
+  gather's canvasOffset (or de-tile origin) per cardinal so the gather samples
+  the cell the store wrote at every k. Needs cardinalIndex (or the precomputed
+  iso offset) in the gather; the cardinal fill
+  (system_trixel_to_framebuffer.hpp:60-104) does NOT currently set
+  visualYaw_/cardinalIndex on the gather frame data -- set it and derive the
+  offset. (FrameDataTrixelToFramebuffer field append only -- no new bind point;
+  update CPU + GLSL + Metal struct + static_asserts together -- silent-sync
+  risk.)
+- Alternative: reformulate cardinalLowerCornerShift so its iso projection is
+  offset/parity-neutral at all cardinals while still aligning the 2x3 diamond
+  emit with the voxel footprint; then the fixed-origin gather is correct
+  everywhere.
+- Reconcile the #394 Metal sawtooth so 0 stays byte-identical.
+
+FILES: c_voxel_to_trixel_stage_1.glsl:271-294 (+ _stage_2 + both metal twins);
+ir_iso_common.glsl ~L344-361 (de-tile) / L423-446 (rotate+shift) + metal/
+ir_iso_common.metal ~L327-360; metal/trixel_to_framebuffer.metal:93 +
+f_trixel_to_framebuffer.glsl:53; system_trixel_to_framebuffer.hpp:60-104;
+ir_render_types.hpp:84-208 (FrameDataTrixelToFramebuffer + static_asserts) if
+plumbing a field.
+
+ACCEPTANCE: sweep shows all four cardinals (steps 0/9/18/27) at coverage >= 0.99
+AND perim within ~2x of the 0 baseline (~250); no regression at any per-axis
+pose or at 0; holds on BOTH Metal and OpenGL; cardinal-0 fast path
+byte-identical (no sawtooth); before/after ramp screenshots at 0/90/180/270.
+
+GOTCHAS: #394 Metal sawtooth must not return at 0; std140 silent-sync if
+plumbing (update CPU+GLSL+Metal+asserts in one change, no new bind point,
+budget full 0-30); per-axis path is unaffected (forward-scatter, no gather) --
+do not touch it.
+
+---
+
+## Child 2 [opus] — Per-axis face seams / slivers / stray lines
+
+SYMPTOM: zoomed small rotated cubes (canvas_stress 48-55) show thin sliver/gap
+bands at top<->side edges, horizontal region offsets within a face, stray thin
+diagonal/vertical bright lines, staircase edges; worst near a face-flip. This is
+the per-axis forward-scatter path (residual yaw).
+
+ROOT CAUSE: #1878 adaptive dilation (v_peraxis_scatter.glsl:199-222) is
+anisotropic (single scalar max(suLen,svLen) mitered across both edges) and
+discontinuous (hard degenSin gate swings 0.85px <-> full voxel step) -> stray
+lines; at close zoom every quad is in the grow arm (its own comment at
+ir_iso_common.glsl:716 says the camera path "isn't the small-cube regime this
+addresses"). Float-ulp split: scatter consumes isoPixelToPos3D un-rounded
+(v_peraxis_scatter.glsl:165) while resolve/lighting consume it rounded -> region
+offset. Cross-canvas shared edges have no geometric owner (depth + 0.25 bias
+only).
+
+DIRECTION: make the dilation margin per-axis (grow each in-plane axis by its own
+collapse, not the max) and continuous (drop the hard degenSin gate); unify the
+rounding (consume isoPixelToPos3D the same way in scatter + resolve/lighting);
+give the cross-canvas shared edge a deterministic owner (stable axis/slot tie
+rule) instead of an ulp-sensitive depth race.
+
+FILES: v_peraxis_scatter.glsl:165,199-222 + metal/peraxis_scatter.metal;
+ir_iso_common.glsl scatterConservativeDilation ~L752-777 (+ metal);
+c_resolve_per_axis_screen_depth.glsl (+ metal) rounding parity.
+
+ACCEPTANCE: add a zoomed shot tier (zoom 3-4) to the harness; at the per-axis
+poses the zoomed perim drops near the cardinal-0 level and ROI crops show no
+slivers / stray lines / region offsets; canvas_stress small cube reads clean in
+the residual band; both backends.
+
+GOTCHAS: margin-depth bias must still keep grown margin yielding to a real exact
+footprint (don't bloat silhouette); don't regress the band-clipping #1878 fixed
+at large residual (dense rotating solids must still fill).
+
+---
+
+## Child 3 [opus] — Depth / clipping unification across render types
+
+SYMPTOM: voxels disappear or appear behind things; overall canvas-bounds +
+distance mismatch between render types. Least-diagnosed of the three.
+
+DIRECTION: audit the depth ranges/units each render type writes to the shared
+framebuffer depth and unify them so cross-type compositing occludes correctly:
+per-axis scatter (scatterCompositeDepthKey yawed iso depth); single-canvas
+gather (pos3DtoDistance, encodeDepthWithFace x4); detached canvas
+(framebuffer-unit depth, #1872/#1624 world-placed); floor/other canvases. If
+not reproducible from a single audit, reframe as an investigation spike (the
+literal phrase in the issue) and produce a repro + unit table before
+prescribing the fix.
+
+FILES (audit start): system_entity_canvas_to_framebuffer.hpp;
+f_trixel_to_framebuffer.glsl (+ metal) depth normalize; v_peraxis_scatter.glsl
+composite depth key; ir_render_types.hpp depth encoding constants.
+
+ACCEPTANCE: a multi-render-type scene (voxel cube + detached canvas + floor)
+composites correct occlusion at all yaws -- no voxel vanishing, no wrong-order
+draw; a documented unit table of what each type writes to framebuffer depth;
+both backends.
+
+---
+
+## Dependency chain
+
+PR #1880 (harness, on master)
+  -> Child 1 (cardinal gather) -> Child 2 (per-axis seams) -> Child 3 (depth)
+
+Serialized: the three share ir_iso_common + the framebuffer gather/scatter, so
+they are worked one-at-a-time to avoid parallel conflicts. Child 1 first
+(highest user impact + it touches the gather Child 3 also audits).
+
+## Steward ledger
+
+reconciled-through: 2026-06-16
+proposal-pending: none
+
+### Children
+| Child | State | PR | Plan | Last validated |
+|---|---|---|---|---|
+| #1882 | filed | — | .fleet/plans/issue-1882.md | — |
+| #1883 | filed (blocked by #1882) | — | .fleet/plans/issue-1883.md | — |
+| #1884 | filed (blocked by #1883) | — | .fleet/plans/issue-1884.md | — |
+
+### Decisions
+
+### Events
+- 2026-06-16: filed via file-epic; plans committed to repo retroactively (the stale global ~/.claude/skills/file-epic ran and skipped step 6.5).

--- a/.fleet/plans/issue-1882.md
+++ b/.fleet/plans/issue-1882.md
@@ -1,0 +1,48 @@
+# Plan: render — cardinal-gather coverage loss at non-start cardinals
+
+- **Issue:** #1882
+- **Model:** opus
+- **Date:** 2026-06-16
+- **Epic:** #1881 — see .fleet/plans/issue-1881.md for full context + baseline numbers
+- **Gated on:** PR #1880 (harness) on master
+
+## Scope
+Fix the single-canvas cardinal path so a solid 64^3 cube is dense at every
+cardinal (yaw 0, pi/2, pi, 3pi/2), not just the start one. Primary "density
+goes away" defect. Per-axis path is already correct — do not touch it.
+
+## Affected files
+- engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl:271-294 (+ _stage_2 + both metal twins)
+- engine/render/src/shaders/ir_iso_common.glsl ~L344-361 (de-tile), L423-446 (rotate+shift); metal/ir_iso_common.metal ~L327-360
+- engine/render/src/shaders/metal/trixel_to_framebuffer.metal:93 ; f_trixel_to_framebuffer.glsl:53
+- engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp:60-104 (cardinal fill)
+- engine/render/include/irreden/render/ir_render_types.hpp:84-208 (struct + static_asserts) if plumbing a field
+
+## Approach
+Compensate the gather for the full per-cardinal cardinalLowerCornerShift iso
+offset (k0:(0,0) k1:(-1,+1) k2:(0,+2) k3:(+1,+1)) — fold it into the gather's
+canvasOffset/de-tile origin per cardinal so store + gather agree at every k.
+The cardinal fill does not set visualYaw_/cardinalIndex on the gather frame
+data today; set it and derive the offset (FrameDataTrixelToFramebuffer field
+append, no new bind point; update CPU+GLSL+Metal struct + static_asserts in one
+change). Reconcile the #394 Metal sawtooth so 0 stays byte-identical.
+Alternative: reformulate cardinalLowerCornerShift to be iso offset/parity
+neutral at all cardinals (then the fixed-origin gather is correct everywhere).
+
+## Acceptance criteria
+- scripts/dev/perf-grid-rotate-sweep build dense 60: all four cardinals
+  (steps 0/9/18/27) coverage >= 0.99 AND perim within ~2x of the 0 baseline
+  (~250); no regression at any per-axis pose or at 0.
+- Holds on BOTH Metal (macOS) and OpenGL (Linux).
+- Cardinal-0 fast path byte-identical to master.
+- Before/after ramp screenshots at 0/90/180/270 in the PR.
+
+## Gotchas
+#394 Metal sawtooth must not return at 0; std140 silent-sync if plumbing (no new
+bind point, budget full 0-30); per-axis path is forward-scatter (no gather) —
+already correct, don't touch.
+
+## Verification
+On macOS: bash scripts/dev/perf-grid-rotate-sweep build dense 60 (check the
+table). On Linux: fleet-build IRPerfGrid + the same sweep. Plus
+fleet-build/run IRShapeDebug --auto-screenshot for the cross-host smoke.

--- a/.fleet/plans/issue-1883.md
+++ b/.fleet/plans/issue-1883.md
@@ -1,0 +1,38 @@
+# Plan: render — per-axis face seams / slivers / stray lines
+
+- **Issue:** #1883
+- **Model:** opus
+- **Date:** 2026-06-16
+- **Epic:** #1881 — see .fleet/plans/issue-1881.md
+- **Blocked by:** #1882 (shared ir_iso_common + framebuffer surface — serialized)
+- **Gated on:** PR #1880 (harness) on master
+
+## Scope
+Fix the per-axis forward-scatter seams/slivers/stray-lines/staircase on zoomed
+small rotated cubes (canvas_stress 48-55), worst near a face-flip.
+
+## Affected files
+- engine/render/src/shaders/v_peraxis_scatter.glsl:165,199-222 + metal/peraxis_scatter.metal
+- engine/render/src/shaders/ir_iso_common.glsl scatterConservativeDilation ~L752-777 (+ metal)
+- engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl (+ metal) — rounding parity
+
+## Approach
+Make the dilation margin per-axis (grow each in-plane axis by its own collapse,
+not the max) and continuous (drop the hard degenSin gate). Unify the rounding:
+consume isoPixelToPos3D the same way (rounded) in scatter + resolve/lighting.
+Give the cross-canvas shared edge a deterministic owner (stable axis/slot tie)
+instead of an ulp-sensitive depth race.
+
+## Acceptance criteria
+- Add a zoomed shot tier (zoom 3-4) to the harness; per-axis-pose zoomed perim
+  drops near the cardinal-0 level; ROI crops show no slivers/stray-lines/offsets.
+- canvas_stress small cube reads clean through the residual band (ROI before/after).
+- Both backends.
+
+## Gotchas
+Margin-depth bias must still yield grown margin to a real exact footprint (don't
+bloat silhouette); don't regress #1878's band-clipping fix at large residual.
+
+## Verification
+bash scripts/dev/perf-grid-rotate-sweep with the new zoom tier on both hosts;
+canvas_stress ROI crops; cross-host IRShapeDebug smoke.

--- a/.fleet/plans/issue-1884.md
+++ b/.fleet/plans/issue-1884.md
@@ -1,0 +1,39 @@
+# Plan: render — unify depth/clipping across render types
+
+- **Issue:** #1884
+- **Model:** opus
+- **Date:** 2026-06-16
+- **Epic:** #1881 — see .fleet/plans/issue-1881.md
+- **Blocked by:** #1883 (shared framebuffer gather/scatter surface — serialized)
+- **Gated on:** PR #1880 (harness) on master
+
+## Scope
+Voxels disappear / occlude wrong due to depth-unit mismatch between render
+types. Least-diagnosed — likely an investigation spike first.
+
+## Affected files (audit start)
+- engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
+- engine/render/src/shaders/f_trixel_to_framebuffer.glsl (+ metal) depth normalize
+- engine/render/src/shaders/v_peraxis_scatter.glsl composite depth key
+- engine/render/include/irreden/render/ir_render_types.hpp depth-encoding constants
+
+## Approach
+Audit + unify the framebuffer depth units across: per-axis scatter
+(scatterCompositeDepthKey), single-canvas gather (pos3DtoDistance x4), detached
+canvas (framebuffer-unit, #1872/#1624), floor. If not reproducible from one
+audit, reframe as an investigation spike: produce a repro + a unit table before
+prescribing the fix.
+
+## Acceptance criteria
+- Multi-render-type scene (voxel cube + detached canvas + floor) composites
+  correct occlusion at all yaws — no vanishing, no wrong-order draw.
+- A documented unit table of what each type writes to framebuffer depth.
+- Both backends.
+
+## Gotchas
+Byte-identical fast paths (#1624 screenLocked_ overlay; cardinal-0) must stay
+intact; depth-encoding constants are shared across all render types.
+
+## Verification
+Author a multi-type repro scene/shot; sweep + visual occlusion check on both
+hosts.


### PR DESCRIPTION
## Summary
Commit the authoritative repo-side plan files for the rotated-voxel-correctness epic so workers (and `fleet-queue-ingest`) on **any** host can read them from master:
- `.fleet/plans/issue-1881.md` (umbrella #1881, with seeded Steward ledger)
- `.fleet/plans/issue-1882.md` / `1883.md` / `1884.md` (children)

## Why
The epic was filed via the **stale global** `~/.claude/skills/file-epic` (pre-#1563), which skips the step-6.5 docs PR and falsely assumes the queue-manager copies the plan at ingest. `fleet-queue-ingest` is pure label-stamping — it only *checks* for a plan (local staging **or** committed repo copy), it never pushes one. So the plans only landed in same-host `~/.fleet/plans/` staging; a worker or ingest on another host would 404 the committed copy and bounce the children to `fleet:needs-plan`.

Per `PLANNING-PROTOCOL.md` step 3 and `architect-protocol.md` ("the committed plan, not the issue body, is what workers read from master"), the planner commits the plan to the repo. This PR is that missing step-6.5 commit. (Internal `~/.fleet/` path refs rewritten to repo-relative `.fleet/`.)

Part of epic #1881; unblocks cross-host pickup of #1882–#1884.

## Test plan
- [ ] `gh api repos/jakildev/IrredenEngine/contents/.fleet/plans/issue-1882.md` resolves once merged (so `fleet-queue-ingest::_plan_exists` finds it on any host).
- [ ] Docs-only; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)