### PR TITLE
docs/fleet: absorb coding-improvement batch — planning + filing gate

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -239,6 +239,26 @@ done
 Auto-fix: append a single `\n`. Scope to files changed on this branch (the
 §10 `format-changed` set), not the whole tree.
 
+**Check 6: hand-rolled demo asset-copy blocks instead of `irreden_bundle_assets`.**
+
+`creations/CLAUDE.md` §"CMake boilerplate" mandates `irreden_bundle_assets(...)`
+for demo asset staging, but the rule is easy to miss when copy-pasting an older
+demo's `CMakeLists.txt`. The smell is a hand-rolled `add_custom_target(*Assets
+...)` / `add_custom_command(... copy_directory ...)` block in a changed
+`creations/demos/*/CMakeLists.txt` (#1870's fog_demo shipped 38 such lines):
+
+```bash
+git diff --name-only HEAD -- 'creations/demos/*/CMakeLists.txt' | while read -r f; do
+  grep -qE 'add_custom_(target|command)' "$f" \
+    && grep -qE 'copy_directory|copy_if_different' "$f" \
+    && echo "HAND-ROLLED asset copy (use irreden_bundle_assets): $f"
+done
+```
+
+Fix: replace the block with `irreden_bundle_assets(<target> SCRIPTS <files>)`
+(+ `irreden_package_target` if a bundle is wanted). Report, don't auto-fix —
+the SCRIPTS / asset list needs a human eye.
+
 ### 2c. Serialized-struct version-bump check
 
 See `engine/asset/CLAUDE.md` §"Automated version-bump detection" for the full

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -231,7 +231,7 @@ each changed file of those types, flag a missing trailing newline — a non-empt
 last byte (i.e. not `\n`) is the violation:
 
 ```bash
-for f in $(git diff --name-only HEAD -- '*.cmake' '*.md' '*.lua' '*.txt' '**/CMakeLists.txt'); do
+for f in $(git diff --name-only origin/master -- '*.cmake' '*.md' '*.lua' '*.txt'); do
   [ -s "$f" ] && [ -n "$(tail -c1 "$f")" ] && echo "MISSING final newline: $f"
 done
 ```
@@ -248,7 +248,7 @@ demo's `CMakeLists.txt`. The smell is a hand-rolled `add_custom_target(*Assets
 `creations/demos/*/CMakeLists.txt` (#1870's fog_demo shipped 38 such lines):
 
 ```bash
-git diff --name-only HEAD -- 'creations/demos/*/CMakeLists.txt' | while read -r f; do
+git diff --name-only origin/master -- 'creations/demos/*/CMakeLists.txt' | while read -r f; do
   grep -qE 'add_custom_(target|command)' "$f" \
     && grep -qE 'copy_directory|copy_if_different' "$f" \
     && echo "HAND-ROLLED asset copy (use irreden_bundle_assets): $f"

--- a/creations/CLAUDE.md
+++ b/creations/CLAUDE.md
@@ -55,12 +55,14 @@ is gitignored).
 
 ## CMake boilerplate
 
+> **Stage assets with `irreden_bundle_assets(<target> SCRIPTS ...)` — never a
+> hand-rolled `add_custom_target(*Assets ...)` / `add_custom_command(...
+> copy_directory ...)` block.** The helper (`cmake/ir_functions.cmake`) wires
+> the exe-relative `data/`/`shaders/`/`scripts/` layout + Windows DLLs;
+> `irreden_package_target(<target>)` adds the one-command distributable bundle.
+
 Use `creations/demos/shape_debug/CMakeLists.txt` as the canonical reference.
-It wires the exe-relative runtime layout (data/ shaders/ scripts/ + Windows
-DLLs) via `irreden_bundle_assets(<target> SCRIPTS ...)` and a one-command
-distributable bundle via `irreden_package_target(<target>)` — both in
-`cmake/ir_functions.cmake`; prefer them over hand-copied `add_custom_command`
-blocks. See [`docs/agents/BUILD.md`](../docs/agents/BUILD.md) §"Packaging a
+See [`docs/agents/BUILD.md`](../docs/agents/BUILD.md) §"Packaging a
 distributable bundle".
 
 Note: MinGW runtime DLLs (`libgcc_s_seh-1.dll`, etc.) are not copied by


### PR DESCRIPTION
## Summary
One-batch triage of the `fleet:coding-improvement` backlog (10 open tickets). Lands the accepted convention changes; the auditable per-ticket verdicts are below.

## Triage digest

| # | verdict | where it landed |
|---|---|---|
| #1837 | **ACCEPT** | PLANNING-PROTOCOL §2 — source-verify negative/gap claims before motivating new infra |
| #1834 | **ACCEPT** | PLANNING-PROTOCOL §Affected files — new-creation subdir must list parent `creations/CMakeLists.txt` |
| #1849 | **ACCEPT** (rescope) | PLANNING-PROTOCOL §Affected files — plan files are engine-public, no game jargon |
| #1830 | **ACCEPT** (doc) + route-out | PLANNING-PROTOCOL Step 0 (atomic needs-plan claim); tooling → #1889 |
| #1836 | **ACCEPT** | FLEET-FEEDBACK-HANDLING §Reading — verify cited file:line corrections via `git show` |
| #1871 | **ACCEPT** (doc) + route-out | creations/demos/CLAUDE.md — `IR*Run` must not repeat `IR*Assets` copies; shape_debug fix → #1888 |
| #1863 | **ACCEPT/escalate** | simplify §2b Check 5 — final-newline on non-clang-format files (validated it fires) |
| #1868 | **REJECT** | closed not-planned — single-occ, no Python surface, new-surface cost > the nit |
| #1850 | **DEFER** | pattern unimplemented (occurrence is the #1816 *plan*); unblocks when #1816 lands |
| #1865 | **DEFER** | single-occ, caught by review, partly covered by #1735; unblocks on recurrence |

## Filing-aggressiveness fix (the meta-ask)
History showed **23 `COMPLETED` vs 1 `NOT_PLANNED` (96% accept)** — triage was rubber-stamping, and the over-filing concentrates in **single-occurrence one-off nits with no existing surface and no automation** (#1868, #1850). So `assess-coding-improvement` gains a **single-occurrence filing gate**: a first occurrence files a standalone ticket only if it's (a) a near-miss correctness/safety bug, (b) mechanically detectable, or (c) tightening an existing surface — else fix-in-PR, file on the 2nd occurrence. Multi-occurrence / `Recurred:`-evidenced always files. This run rejected 1 + deferred 2 under it (vs the historical ~0).

## Net growth
PLANNING-PROTOCOL +33 (4 distinct rules at distinct points), simplify +19 (one check), FLEET-FEEDBACK +7, demos/CLAUDE +9, assess-coding-improvement +15. No new doc surfaces created (the #1868 reject specifically avoided one).

## Split-outs (code/tooling, filed plain for human approval)
- #1888 — migrate shape_debug asset staging to `irreden_bundle_assets` (the #1871 code remainder)
- #1889 — atomic needs-plan claim tooling (the #1830 enforcement)

## Test plan
- [ ] Docs + one simplify-check addition; no build impact.
- [ ] Reviewer confirms the landed text matches each verdict in the digest above.
- [ ] simplify Check 5 fires on a `.cmake`/`.md` file missing a trailing newline (validated locally against the #1861 pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)