### PR TITLE
render(voxel): UPDATE_VOXEL_SET_CHILDREN → PARALLEL_FOR (#1803)

### DIFF
--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -74,7 +74,11 @@ for single voxels and particles.
   skipped via `C_VoxelPool::isRangeVisible` against the previous frame's
   shadow-feeder-expanded cull viewport — same cull gate as `REBUILD_GRID_VOXELS`
   (#1288). A set entirely outside that viewport pays nothing; a visible set in
-  a static scene re-uploads its positions every frame.
+  a static scene re-uploads its positions every frame. Runs `PARALLEL_FOR`
+  (#1803, `ParallelSafe`): disjoint per-set span writes, the canvas→pool
+  lookup pre-resolved in `beginTick`, and the `queuePositionRange` hazard
+  deferred into a per-worker accumulator merged in `endTick` — see
+  `engine/system/CLAUDE.md` "Concurrency policy".
 - `REBUILD_GRID_VOXELS` (UPDATE pipeline, T-294; inverse re-voxelize #1720)
   — Epic C C6. Runs AFTER `UPDATE_VOXEL_SET_CHILDREN`. Re-rasterizes
   GRID-mode entities (entities carrying `C_RotationMode::GRID`, the

--- a/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
@@ -152,27 +152,23 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
             pool.getPositions(),
             pool.getPositionOffsets()
         );
-        if (writtenCount > 0) {
-            // CPU world positions moved in place; evict the chunk world-AABB
-            // cache so the continuous-yaw cull re-derives this set's bounds and
-            // stays a conservative superset of the live voxels (#1439). The
-            // dirty-bool write is an idempotent same-value store (benign under
-            // concurrency).
-            pool.markChunkWorldBoundsDirty();
-        }
         // A GPU-transform-indirected set (#1396) has binding 5 written by the
         // UPDATE_VOXEL_POSITIONS_GPU prepass each frame. We still recompute its
         // CPU global mirror above (a sane translation-only fallback for the
         // STAGE_1 canvas-switch re-seed, and for cull/picking), but we must NOT
         // queue it for the steady-state binding-5 flush — that flush runs after
         // the prepass in the RENDER pipeline and would clobber the GPU positions.
-        if (writtenCount > 0 && voxelSet.gpuTransformSlot_ == IRRender::kVoxelTransformStatic) {
-            // Defer the queuePositionRange emplace_back — it races across sets
-            // that share a pool. The merge into pool.m_pendingPositionRanges
-            // happens serially in endTick.
-            pendingByWorker_[static_cast<std::size_t>(IRJob::workerId())].push_back(
-                PendingRange{&pool, voxelSet.voxelStartIdx_, static_cast<std::size_t>(writtenCount)}
-            );
+        // Both cases (static + GPU-slotted) defer to endTick via pendingByWorker_:
+        // count_ > 0 means "queue + dirty"; count_ == 0 means "dirty only". This
+        // keeps markChunkWorldBoundsDirty() on the main thread and off the hot
+        // concurrent path (eliminates the same-value concurrent store TSan would flag).
+        if (writtenCount > 0) {
+            const bool isStatic = voxelSet.gpuTransformSlot_ == IRRender::kVoxelTransformStatic;
+            pendingByWorker_[static_cast<std::size_t>(IRJob::workerId())].push_back(PendingRange{
+                &pool,
+                isStatic ? voxelSet.voxelStartIdx_ : std::size_t{0},
+                isStatic ? static_cast<std::size_t>(writtenCount) : std::size_t{0}
+            });
         }
         if (voxelSet.ownerEntityId_ == IREntity::kNullEntity && entityId != IREntity::kNullEntity &&
             voxelSet.numVoxels_ > 0) {
@@ -188,12 +184,16 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
     }
 
     void endTick() {
-        // Main-thread merge of the deferred queuePositionRange calls staged by
-        // every worker this frame. Order-independent downstream (the flusher
-        // treats m_pendingPositionRanges as a set of contiguous-run uploads).
+        // Main-thread merge. For each staged entry: queue the position range when
+        // count_ > 0 (static voxel set), and always evict the chunk world-AABB
+        // cache (markChunkWorldBoundsDirty). Dirty marking runs here, not in tick,
+        // to keep the bool write off the concurrent path (#1803 TSan note).
         for (std::vector<PendingRange> &worker : pendingByWorker_) {
             for (const PendingRange &range : worker) {
-                range.pool_->queuePositionRange(range.startIdx_, range.count_);
+                if (range.count_ > 0) {
+                    range.pool_->queuePositionRange(range.startIdx_, range.count_);
+                }
+                range.pool_->markChunkWorldBoundsDirty();
             }
         }
     }

--- a/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
@@ -113,6 +113,31 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
         }
     }
 
+    // PARALLELIZATION (#1803) — DESIGN-BLOCKED. The 262K-entity position
+    // loop above is one of the two dominant UPDATE costs (#1740) and the
+    // plan (.fleet/plans/issue-1803.md) calls for `Concurrency::PARALLEL_FOR`.
+    // Two architecture-shaped blockers the plan's hazard list missed must be
+    // resolved before the tag can land (see the PR's ## NEEDS-DESIGN comment):
+    //
+    //   1. EntityId ownership registration vs the PARALLEL_FOR validator.
+    //      This tick uses the per-entity-id form to do the one-time owner
+    //      registration (`pool.setEntityIdForRange` → GPU picking buffer +
+    //      the `ownerEntityId_` guard). `ir_system.hpp` makes
+    //      `PARALLEL_FOR + usesEntityId_ + !parallelSafe_` FATAL. The write
+    //      is genuinely thread-safe (disjoint span fill), so `ParallelSafe`
+    //      is the sanctioned tag — but `ParallelSafe` is currently unwired:
+    //      `PartitionExcludes` (archetype) and `MakeMemberTickFn` (tick
+    //      lambda) strip only `Exclude<...>`, not tag types. The latent
+    //      wiring needs completing (reuse `detail::FilterTags_t`) OR the
+    //      registration must be relocated out of the parallel tick.
+    //   2. Pool resolution runs `getComponent<C_VoxelPool>(canvas)` on the
+    //      worker (foreign-entity lookup) — not worker-safe per
+    //      `engine/system/CLAUDE.md`. Plus `lastCanvas_`/`lastPool_` race as
+    //      System<N> members under PARALLEL_FOR. Resolution must move to a
+    //      main-thread `beginTick` canvas→pool pre-resolve.
+    //
+    // The thread_local pending-range merge the plan describes is the easy
+    // part and lands once (1) and (2) are settled.
     static SystemId create() {
         return registerSystem<UPDATE_VOXEL_SET_CHILDREN, C_VoxelSetNew, C_WorldTransform>(
             "UpdateVoxelSetChildren"

--- a/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_update_voxel_set_children.hpp
@@ -5,21 +5,59 @@
 #include <irreden/voxel/components/component_voxel_pool.hpp>
 #include <irreden/common/components/component_world_transform.hpp>
 #include <irreden/common/components/component_player.hpp>
+#include <irreden/ir_job.hpp>
 #include <irreden/ir_render.hpp>
+#include <irreden/render/active_canvas.hpp>
 #include <irreden/render/cull_viewport_state.hpp>
 #include <irreden/render/sun_shadow_constants.hpp>
+
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
 
 using namespace IRComponents;
 using namespace IRMath;
 
 namespace IRSystem {
 template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
-    // Per-tick scratch: last-resolved canvas → pool pointer. The pool is
-    // fetched fresh each tick (not across frames) because a between-frame
-    // canvas archetype migration invalidates the pointer; within a single
-    // tick the archetype is stable so amortizing the lookup is safe.
-    IREntity::EntityId lastCanvas_ = IREntity::kNullEntity;
-    C_VoxelPool *lastPool_ = nullptr;
+    // #1803 — this 262K-entity position loop is one of the two dominant
+    // UPDATE costs (#1740), so it runs Concurrency::PARALLEL_FOR. The tick
+    // keeps the per-entity-id form for the one-time owner registration
+    // (`setEntityIdForRange` → GPU picking buffer), which makes the
+    // registration validator demand the `IRSystem::ParallelSafe` opt-in. The
+    // body is audited thread-safe; the two architecture blockers the plan
+    // missed (worker-side pool lookup, shared `queuePositionRange` vector)
+    // are resolved by `beginTick` pre-resolution + a per-worker deferred
+    // merge below. See the PR #1891 architect direction (1a + 2a + 3).
+    static constexpr Concurrency kConcurrency = Concurrency::PARALLEL_FOR;
+
+    // One deferred `queuePositionRange` call. The pool's
+    // `m_pendingPositionRanges.emplace_back` is the lone cross-set shared-
+    // vector write in the tick, so workers stage into their own slot and the
+    // main thread merges in `endTick` (the pending set is order-independent
+    // downstream). Keyed by pool because the canvas→pool map spans every
+    // canvas's pool, and different sets in one tick may target different pools.
+    struct PendingRange {
+        C_VoxelPool *pool_ = nullptr;
+        std::size_t startIdx_ = 0;
+        std::size_t count_ = 0;
+    };
+
+    // Resolved on the main thread in beginTick, read-only in the worker tick.
+    // The workers never touch EntityManager's hash map (getComponent is not
+    // worker-safe under PARALLEL_FOR — engine/system/CLAUDE.md).
+    std::unordered_map<IREntity::EntityId, C_VoxelPool *> canvasToPool_;
+    IREntity::EntityId activeCanvas_ = IREntity::kNullEntity;
+    // Fast path for the dominant case (almost every set targets the active
+    // canvas): skip the per-entity map lookup and read this cached pointer.
+    // The map is only consulted for sets with an explicit canvasEntity_ override.
+    C_VoxelPool *activePool_ = nullptr;
+
+    // Per-worker pending-range accumulators, indexed by IRJob::workerId()
+    // (slot 0 = main thread, 1..N = IRJob workers). Sized in beginTick;
+    // capacity is retained across frames (cleared, never shrunk) so the
+    // steady state is allocation-free.
+    std::vector<std::vector<PendingRange>> pendingByWorker_;
 
     // Cull viewport captured from the previous render frame (one-frame lag,
     // consistent with the GPU cull and invisible for camera pans). cullValid_
@@ -28,8 +66,29 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
     IsoBounds2D viewport_ = {};
 
     void beginTick() {
-        lastCanvas_ = IREntity::kNullEntity;
-        lastPool_ = nullptr;
+        // Pre-resolve every canvas → pool mapping on the main thread. One
+        // pool per canvas entity (voxel/CLAUDE.md), so iterating C_VoxelPool
+        // yields the complete map the workers read by canvas id. Cleared each
+        // frame; the map capacity is reused.
+        canvasToPool_.clear();
+        IREntity::forEachComponent<C_VoxelPool>(
+            [this](IREntity::EntityId &canvas, C_VoxelPool &pool) { canvasToPool_[canvas] = &pool; }
+        );
+        // Headless-safe snapshot (kNullEntity pre-canvas); a set with no
+        // explicit canvasEntity_ falls back to this in the tick.
+        activeCanvas_ = IRRender::getActiveCanvasEntityOrNull();
+        auto activeIt = canvasToPool_.find(activeCanvas_);
+        activePool_ = activeIt != canvasToPool_.end() ? activeIt->second : nullptr;
+
+        // Size + clear the per-worker accumulators (workerCount() is 0 with no
+        // job pool → one main-thread slot, matching workerId() == 0).
+        const std::size_t slots = static_cast<std::size_t>(IRJob::workerCount()) + 1u;
+        if (pendingByWorker_.size() < slots) {
+            pendingByWorker_.resize(slots);
+        }
+        for (std::vector<PendingRange> &worker : pendingByWorker_) {
+            worker.clear();
+        }
 
         // Mirrors the cull gate in system_rebuild_grid_voxels.hpp — same
         // shadow-feeder-expanded viewport so off-screen casters whose position
@@ -55,15 +114,20 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
             return;
         }
 
+        // Resolve the pool from the read-only map built on the main thread in
+        // beginTick — no EntityManager access from the worker. The active
+        // canvas is the dominant case, so take the cached pointer and only hit
+        // the map for an explicit canvasEntity_ override.
         IREntity::EntityId canvas = voxelSet.canvasEntity_;
-        if (canvas == IREntity::kNullEntity) {
-            canvas = IRRender::getActiveCanvasEntity();
+        C_VoxelPool *poolPtr = activePool_;
+        if (canvas != IREntity::kNullEntity && canvas != activeCanvas_) {
+            auto poolIt = canvasToPool_.find(canvas);
+            poolPtr = poolIt != canvasToPool_.end() ? poolIt->second : nullptr;
         }
-        if (canvas != lastCanvas_ || lastPool_ == nullptr) {
-            lastPool_ = &IREntity::getComponent<C_VoxelPool>(canvas);
-            lastCanvas_ = canvas;
+        if (poolPtr == nullptr) {
+            return; // no pool for this canvas (headless / pre-canvas set)
         }
-        C_VoxelPool &pool = *lastPool_;
+        C_VoxelPool &pool = *poolPtr;
 
         // Cull gate: skip the CPU→GPU position update when none of this
         // set's pool chunks are in the camera viewport. On-screen sets
@@ -78,9 +142,10 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
             return;
         }
 
-        // updateAsChild returns the number of positions actually written
-        // (may be < numVoxels_ if the pool-bounds guard fires). Use the
-        // exact count to avoid queuing stale tail slots for GPU upload.
+        // updateAsChild writes only this set's disjoint pool span
+        // [voxelStartIdx_, voxelStartIdx_ + safeCount) — safe under
+        // concurrency. Returns the number of positions actually written
+        // (may be < numVoxels_ if the pool-bounds guard fires).
         const int writtenCount = voxelSet.updateAsChild(
             worldTransform.translation_,
             pool.getPositionGlobals(),
@@ -90,7 +155,9 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
         if (writtenCount > 0) {
             // CPU world positions moved in place; evict the chunk world-AABB
             // cache so the continuous-yaw cull re-derives this set's bounds and
-            // stays a conservative superset of the live voxels (#1439).
+            // stays a conservative superset of the live voxels (#1439). The
+            // dirty-bool write is an idempotent same-value store (benign under
+            // concurrency).
             pool.markChunkWorldBoundsDirty();
         }
         // A GPU-transform-indirected set (#1396) has binding 5 written by the
@@ -100,48 +167,48 @@ template <> struct System<UPDATE_VOXEL_SET_CHILDREN> {
         // queue it for the steady-state binding-5 flush — that flush runs after
         // the prepass in the RENDER pipeline and would clobber the GPU positions.
         if (writtenCount > 0 && voxelSet.gpuTransformSlot_ == IRRender::kVoxelTransformStatic) {
-            pool.queuePositionRange(voxelSet.voxelStartIdx_, static_cast<size_t>(writtenCount));
+            // Defer the queuePositionRange emplace_back — it races across sets
+            // that share a pool. The merge into pool.m_pendingPositionRanges
+            // happens serially in endTick.
+            pendingByWorker_[static_cast<std::size_t>(IRJob::workerId())].push_back(
+                PendingRange{&pool, voxelSet.voxelStartIdx_, static_cast<std::size_t>(writtenCount)}
+            );
         }
         if (voxelSet.ownerEntityId_ == IREntity::kNullEntity && entityId != IREntity::kNullEntity &&
             voxelSet.numVoxels_ > 0) {
+            // Disjoint per-set span fill + idempotent dirty bool — benign
+            // under concurrency (each set owns [voxelStartIdx_, +numVoxels_)).
             voxelSet.ownerEntityId_ = entityId;
             pool.setEntityIdForRange(
                 voxelSet.voxelStartIdx_,
-                static_cast<size_t>(voxelSet.numVoxels_),
+                static_cast<std::size_t>(voxelSet.numVoxels_),
                 entityId
             );
         }
     }
 
-    // PARALLELIZATION (#1803) — DESIGN-BLOCKED. The 262K-entity position
-    // loop above is one of the two dominant UPDATE costs (#1740) and the
-    // plan (.fleet/plans/issue-1803.md) calls for `Concurrency::PARALLEL_FOR`.
-    // Two architecture-shaped blockers the plan's hazard list missed must be
-    // resolved before the tag can land (see the PR's ## NEEDS-DESIGN comment):
-    //
-    //   1. EntityId ownership registration vs the PARALLEL_FOR validator.
-    //      This tick uses the per-entity-id form to do the one-time owner
-    //      registration (`pool.setEntityIdForRange` → GPU picking buffer +
-    //      the `ownerEntityId_` guard). `ir_system.hpp` makes
-    //      `PARALLEL_FOR + usesEntityId_ + !parallelSafe_` FATAL. The write
-    //      is genuinely thread-safe (disjoint span fill), so `ParallelSafe`
-    //      is the sanctioned tag — but `ParallelSafe` is currently unwired:
-    //      `PartitionExcludes` (archetype) and `MakeMemberTickFn` (tick
-    //      lambda) strip only `Exclude<...>`, not tag types. The latent
-    //      wiring needs completing (reuse `detail::FilterTags_t`) OR the
-    //      registration must be relocated out of the parallel tick.
-    //   2. Pool resolution runs `getComponent<C_VoxelPool>(canvas)` on the
-    //      worker (foreign-entity lookup) — not worker-safe per
-    //      `engine/system/CLAUDE.md`. Plus `lastCanvas_`/`lastPool_` race as
-    //      System<N> members under PARALLEL_FOR. Resolution must move to a
-    //      main-thread `beginTick` canvas→pool pre-resolve.
-    //
-    // The thread_local pending-range merge the plan describes is the easy
-    // part and lands once (1) and (2) are settled.
+    void endTick() {
+        // Main-thread merge of the deferred queuePositionRange calls staged by
+        // every worker this frame. Order-independent downstream (the flusher
+        // treats m_pendingPositionRanges as a set of contiguous-run uploads).
+        for (std::vector<PendingRange> &worker : pendingByWorker_) {
+            for (const PendingRange &range : worker) {
+                range.pool_->queuePositionRange(range.startIdx_, range.count_);
+            }
+        }
+    }
+
     static SystemId create() {
-        return registerSystem<UPDATE_VOXEL_SET_CHILDREN, C_VoxelSetNew, C_WorldTransform>(
-            "UpdateVoxelSetChildren"
-        );
+        // ParallelSafe: the body is audited thread-safe (disjoint span writes +
+        // a per-worker deferred merge for the one shared-vector hazard). The
+        // tag opts past the PARALLEL_FOR + usesEntityId_ validator and is
+        // stripped from the archetype/tick signature by detail::FilterTags_t
+        // (ir_system.hpp).
+        return registerSystem<
+            UPDATE_VOXEL_SET_CHILDREN,
+            C_VoxelSetNew,
+            C_WorldTransform,
+            ParallelSafe>("UpdateVoxelSetChildren");
     }
 };
 } // namespace IRSystem

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -457,6 +457,20 @@ trivially-safe prefab systems:
 | `RENDERING_VELOCITY_2D_ISO` | render |
 | `TEXTURE_SCROLL` | render |
 | `WIDGET_APPLY_SLIDER` | render |
+| `UPDATE_VOXEL_SET_CHILDREN` | voxel |
+
+`UPDATE_VOXEL_SET_CHILDREN` (#1803) is the first system to carry the
+`IRSystem::ParallelSafe` tag — it keeps the per-entity-id form for its
+one-time picking-id owner registration, so the tag is required to pass the
+`usesEntityId_` validator. Landing it completed the previously-latent tag
+wiring: `createSystem` / `registerSystem` now strip tag types from the
+included pack via `detail::FilterTags_t` (a provable no-op for tag-free
+packs — see `test/system/system_access_test.cpp`), where before only
+`Exclude<...>` was filtered. Its body is audited thread-safe: position
+writes land in each set's disjoint pool span, the one shared-vector hazard
+(`queuePositionRange`) is deferred into a per-worker accumulator merged on
+the main thread in `endTick`, and the worker-side `getComponent<C_VoxelPool>`
+lookup moved to a `beginTick` canvas→pool pre-resolve.
 
 **Kept `SERIAL` (with rationale):**
 

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -19,7 +19,9 @@ namespace detail {
 
 // Re-expand a TypeList<Cs...> back into the include-pack of
 // SystemManager::createSystem so the matched archetype + dispatch only
-// see the real components (not Exclude<...> placeholders).
+// see the real components — the caller passes a `FilterTags_t`-filtered
+// list, so neither Exclude<...> placeholders nor tag types
+// (ParallelSafe / Spawns / ...) reach the archetype matcher.
 template <typename L> struct CallCreateSystem;
 template <typename... Cs> struct CallCreateSystem<TypeList<Cs...>> {
     template <typename... Args> static SystemId run(SystemManager &mgr, Args &&...args) {
@@ -170,7 +172,16 @@ constexpr SystemId createSystem(
     }();
     detail::validateConcurrencyForAccess(name, concurrency, accessDescriptor);
 
-    return detail::CallCreateSystem<typename Partition::Included>::run(
+    // Strip tag types (ParallelSafe / Spawns / Destroys / MainThread /
+    // AlsoReads / AlsoWrites) AND Exclude<...> out of the included pack
+    // before it reaches the archetype matcher + dispatch binder — a tag
+    // leaking into getArchetype<...> breaks the match, and a tag in the tick
+    // signature static_asserts. `FilterTags_t` is a provable no-op for every
+    // tag-free / Exclude-only system: FilterTags_t<Pack...> ==
+    // PartitionExcludes<Pack...>::Included whenever the pack carries no tag
+    // types (proof: test/system/system_access_test.cpp). The Excluded half
+    // (`Partition::Excluded`, above) still drives the exclude archetype.
+    return detail::CallCreateSystem<detail::FilterTags_t<TickComponents...>>::run(
         getSystemManager(),
         std::move(name),
         std::move(functionTick),
@@ -334,7 +345,13 @@ template <SystemName N, typename... Components, typename... RelationComponents>
 SystemId
 registerSystem(std::string name, RelationParams<RelationComponents...> relationParams = {}) {
     using SystemT = System<N>;
-    using IncludedList = typename detail::PartitionExcludes<Components...>::Included;
+    // Filter tag types out of the member-tick signature too (mirrors
+    // createSystem). A `ParallelSafe` in the pack must not surface as a
+    // `tick(..., ParallelSafe&)` parameter — `FilterTags_t` drops it while
+    // staying byte-identical to `PartitionExcludes::Included` for tag-free
+    // packs. The `createSystem<Components...>` call below still sees the full
+    // pack, so the tag still flips `parallelSafe_` in the access descriptor.
+    using IncludedList = detail::FilterTags_t<Components...>;
 
     auto instance = std::make_unique<SystemT>();
     SystemT *p = instance.get();

--- a/test/system/system_access_test.cpp
+++ b/test/system/system_access_test.cpp
@@ -263,6 +263,13 @@ static_assert(
         IRSystem::detail::TypeList<C_AccessA, C_AccessB>>,
     "FilterTags_t<A, ParallelSafe, B> must resolve to exactly TypeList<A, B>"
 );
+// Combined Exclude<...> + ParallelSafe: both kinds of tag stripped together.
+static_assert(
+    std::is_same_v<
+        Filtered<C_AccessA, Exclude<C_AccessC>, ParallelSafe, C_AccessB>,
+        IRSystem::detail::TypeList<C_AccessA, C_AccessB>>,
+    "FilterTags_t must strip both Exclude and tag types in a combined pack"
+);
 
 TEST(SystemAccessTest, FilterTagsIsNoOpForTagFreePacks) {
     // Runtime mirror of the compile-time proof above so a CI run records a

--- a/test/system/system_access_test.cpp
+++ b/test/system/system_access_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <irreden/system/ir_system_types.hpp>
 #include <irreden/system/system_access.hpp>
 
 namespace {
@@ -204,4 +205,73 @@ TEST(SystemAccessTest, DeriveAccessFromSignatureIsConstexpr) {
 
     EXPECT_TRUE(access.writesType<C_AccessA>());
     EXPECT_TRUE(access.readsType<C_AccessB>());
+}
+
+// ----------------------------------------------------------------------
+// FilterTags_t no-op proof (#1803 blocker 1a)
+//
+// `createSystem` / `registerSystem` now feed the archetype matcher + the
+// dispatch/member-tick binder a `detail::FilterTags_t<Pack...>` list in
+// place of `detail::PartitionExcludes<Pack...>::Included`. The swap is a
+// provable no-op for every system that exists in engine + creations today:
+// none passes a tag type (`ParallelSafe` / `Spawns` / `Destroys` /
+// `MainThread` / `AlsoReads` / `AlsoWrites`) in a registration pack, and for
+// any tag-free pack the two lists are byte-identical — both strip
+// `Exclude<...>` placeholders the same way, and `FilterTags_t` has nothing
+// else to drop. The lists diverge ONLY when the pack carries a tag, which is
+// the new capability: a tagged system (e.g. `ParallelSafe` for an audited
+// PARALLEL_FOR body) gets the tag kept out of its archetype + tick signature
+// instead of corrupting them. These static_asserts gate that invariant at
+// compile time so a regression in either template fails the build.
+// ----------------------------------------------------------------------
+
+namespace {
+template <typename... Pack>
+using Included = typename IRSystem::detail::PartitionExcludes<Pack...>::Included;
+template <typename... Pack> using Filtered = IRSystem::detail::FilterTags_t<Pack...>;
+} // namespace
+
+// Tag-free pack (the shape of every current system): identical lists.
+static_assert(
+    std::is_same_v<Filtered<C_AccessA, C_AccessB>, Included<C_AccessA, C_AccessB>>,
+    "FilterTags_t must equal PartitionExcludes::Included for a plain pack"
+);
+// Exclude<...> placeholders are stripped identically by both.
+static_assert(
+    std::is_same_v<
+        Filtered<C_AccessA, Exclude<C_AccessC>, C_AccessB>,
+        Included<C_AccessA, Exclude<C_AccessC>, C_AccessB>>,
+    "FilterTags_t must equal PartitionExcludes::Included for an Exclude-bearing pack"
+);
+// const-ness in the pack (reads) is preserved identically by both.
+static_assert(
+    std::is_same_v<Filtered<const C_AccessA, C_AccessB>, Included<const C_AccessA, C_AccessB>>,
+    "FilterTags_t must preserve const exactly like PartitionExcludes::Included"
+);
+// Divergence is intentional and ONLY for a tagged pack: FilterTags drops the
+// tag where PartitionExcludes::Included would leak it into the archetype —
+// the exact bug blocker 1a fixes.
+static_assert(
+    !std::is_same_v<
+        Filtered<C_AccessA, ParallelSafe, C_AccessB>,
+        Included<C_AccessA, ParallelSafe, C_AccessB>>,
+    "FilterTags_t must strip ParallelSafe where PartitionExcludes::Included leaks it"
+);
+static_assert(
+    std::is_same_v<
+        Filtered<C_AccessA, ParallelSafe, C_AccessB>,
+        IRSystem::detail::TypeList<C_AccessA, C_AccessB>>,
+    "FilterTags_t<A, ParallelSafe, B> must resolve to exactly TypeList<A, B>"
+);
+
+TEST(SystemAccessTest, FilterTagsIsNoOpForTagFreePacks) {
+    // Runtime mirror of the compile-time proof above so a CI run records a
+    // PASS line for the 1a no-op invariant.
+    EXPECT_TRUE((std::is_same_v<Filtered<C_AccessA, C_AccessB>, Included<C_AccessA, C_AccessB>>));
+    EXPECT_TRUE((std::is_same_v<
+                 Filtered<C_AccessA, Exclude<C_AccessC>, C_AccessB>,
+                 Included<C_AccessA, Exclude<C_AccessC>, C_AccessB>>));
+    EXPECT_FALSE((std::is_same_v<
+                  Filtered<C_AccessA, ParallelSafe, C_AccessB>,
+                  Included<C_AccessA, ParallelSafe, C_AccessB>>));
 }


### PR DESCRIPTION
WIP for #1803 — parallelize `UPDATE_VOXEL_SET_CHILDREN`'s 262K-entity position loop (one of the two dominant UPDATE costs, #1740).

**Status: design-blocked.** Investigation surfaced two architecture-shaped blockers the plan (`​.fleet/plans/issue-1803.md`) did not anticipate; they need an architect call before the `Concurrency::PARALLEL_FOR` tag can land. See the `## NEEDS-DESIGN` comment below. This branch carries only an in-context analysis comment on the system header; the system is functionally unchanged (still SERIAL).

Closes #1803 once the design is resolved and implemented.