### PR TITLE
engine/update: PROPAGATE_TRANSFORM intra-node row-range parallelism

### DIFF
--- a/docs/perf-reports/threading_propagate_transform.md
+++ b/docs/perf-reports/threading_propagate_transform.md
@@ -39,21 +39,39 @@ transform from a pre-resolved vector instead of an inline
 
 ## Dispatch tuning
 
-`parallelFor` is called per-level with a heuristic grain size:
+> **Updated by #1804 (intra-node row-range parallelism).** The original
+> T-378 dispatch was per-archetype only — one parallelFor task per
+> archetype node. That degenerates when a single archetype holds the
+> whole scene (IRPerfGrid's 262K-entity node is one node at depth 0):
+> the level has `n = 1`, falls below `kMinForParallel`, and the 262K-row
+> `composeNode` runs serially on one worker. See the dedicated section
+> below for the row-splitting fix and its measurement.
 
-- **`kMinForParallel = 8`** — levels with fewer archetypes than this
-  fall back to a serial walk. The dispatch + wait overhead for a
-  parallelFor with only 1–7 tasks exceeds the savings.
-- **Grain size = `max(kGrainSize, (n + targetTasks - 1) / targetTasks)`**
-  where `targetTasks = max(1, workerCount * 2)`. The "2 tasks per
-  worker" target gives enkiTS room to load-balance without flooding
-  the queue with one-archetype tasks (each archetype already carries
-  hundreds-to-thousands of entities through the inner loop).
+Each level is flattened into a list of row-chunks and dispatched with a
+single `parallelFor`:
+
+- **`kMinForParallel = 8`** (node count) **OR `kMinRowsForParallel = 4096`**
+  (total entity rows) — a level parallelizes when it has at least this
+  many archetypes *or* this many total rows. Below both, the dispatch +
+  wait overhead exceeds the savings and the level composes serially.
+- **`kMinChunkRows = 2048`** — the minimum rows per chunk. A node smaller
+  than the chunk size stays whole (one chunk), preserving the original
+  per-archetype granularity for many-small-node levels; a node larger
+  than the chunk size splits into multiple row-range chunks. The chunk
+  size is `max(kMinChunkRows, ceil(totalRows / targetTasks))` with
+  `targetTasks = max(1, workerCount * 2)`, so a single dominant node
+  splits into ~`targetTasks` chunks (≈2 per worker).
+- **Grain = `max(1, ceil(numChunks / targetTasks))`** over the chunk
+  list — `1` when chunks already number ≤ `targetTasks` (single large
+  node), grouping when many small nodes produce more chunks than tasks.
 - **`g_jobManager == nullptr`** — unit-test and pre-`World` paths
-  short-circuit to the same serial walk as `kMinForParallel`.
+  short-circuit to the serial walk.
 
-The `kGrainSize = 1` member exists as the floor; the smart grain
-computation is the effective grain at runtime.
+`composeNode` became `composeNodeRows(node, parentWorld, rowBegin, rowEnd, …)`
+— same SQT body, now bounded to a row range. Disjoint row ranges are
+race-free (each entity writes only its own `C_WorldTransform[i]`), so
+output is bit-identical to the serial path regardless of chunk
+boundaries.
 
 ## Measurement
 
@@ -99,6 +117,40 @@ This PR keeps the structural correctness and cache invalidation work
 gated behind unit tests so the matrix run only needs to confirm the
 perf delta.
 
+## Intra-node row-range parallelism — measurement (#1804)
+
+The 262K scaling regime the T-378 report flagged but didn't exercise
+is exactly the single-node degeneracy #1804 fixes. With the whole grid
+in one depth-0 archetype, the per-archetype dispatch left the entire
+composition on one worker; row-splitting fans it across all workers.
+
+Method: `fleet-run IRPerfGrid --auto-profile 12 --auto-screenshot` on
+macOS (Metal, Apple Silicon, 10 enkiTS workers). `--auto-screenshot`
+enables fixed-step (one UPDATE tick per render frame) so the profiler's
+last-frame `update` sample reliably lands on a ticked frame; without it
+the fixed-step UPDATE pipeline may not tick the sampled render frame and
+reports `update: 0.000`. grid-size 64 (262,144 entities, one archetype).
+Three runs each; `update` is the whole UPDATE-pipeline stage, and since
+only `PROPAGATE_TRANSFORM` changed, the delta is its contribution.
+
+| Configuration | `update` stage / frame |
+|---|---|
+| `origin/master` (per-archetype dispatch → serial single node) | 4.32 / 4.42 / 4.61 ms |
+| This PR (intra-node row-chunks across 10 workers) | 2.25 / 2.27 / 2.56 ms |
+
+≈ **47% reduction (~2.1 ms)** on the UPDATE pipeline. Render still
+dominates frame time (~8 ms), so this is a secondary-axis win per the
+issue's own framing, but it closes the single-node degeneracy directly.
+
+Bit-identity check: `IRShapeDebug --auto-screenshot` is 28/28
+byte-identical to `origin/master` (deterministic path reading
+`C_WorldTransform`). IRPerfGrid screenshots are non-deterministic
+run-to-run (GPU rasterization speckle), so they can't be byte-compared;
+instead, per-shot pixel-diff magnitude (mine-vs-master) was confirmed to
+sit within the demo's own run-to-run noise floor (mine-vs-mine ≈
+master-vs-master ≈ mine-vs-master, MAE < 0.5/255, < 1% pixels touched,
+no structural region difference).
+
 ## Correctness coverage
 
 `test/ecs/propagate_transform_test.cpp` (13 tests, all green):
@@ -130,12 +182,14 @@ Full suite: 964 tests in IrredenEngineTest pass; IRShapeDebug
   is the authoritative source for the ≥2× target. Defer until the
   perf-CI hardware-fingerprinted baseline (#1100) is online so the
   comparison is hardware-stable.
-- **`kMinForParallel` and grain-size auto-tuning.** The current
-  `kMinForParallel = 8` and `workers × 2` task target are calibrated
-  for IRPerfGrid's shallow hierarchy. If future scenes exhibit deep
-  hierarchies with very small per-level archetype counts, a per-level
-  cost estimator (sum of `node->length_`) might choose better than
-  the archetype-count threshold alone.
+- **`kMinForParallel` and grain-size auto-tuning.** ✅ Addressed by
+  #1804: the per-level cost estimator (sum of `node->length_` →
+  `totalRows`) is now a parallelization trigger alongside the
+  archetype-count threshold, and large single nodes split across
+  workers by row range. Remaining tuning headroom: `kMinChunkRows`
+  (2048) and `kMinRowsForParallel` (4096) are calibrated for the
+  per-row quat/vec3 cost; revisit if a much heavier or lighter
+  per-entity composition lands.
 - **Foreign-component read declaration.** The system reads parent
   `C_WorldTransform` via a foreign-entity lookup, which the
   `SystemAccess` trait does not see from the `tick`/`beginTick`

--- a/engine/prefabs/irreden/update/CLAUDE.md
+++ b/engine/prefabs/irreden/update/CLAUDE.md
@@ -68,11 +68,17 @@ in the `UPDATE` pipeline unless explicitly noted.
   any consumer (render, gizmo, physics) that reads
   `C_WorldTransform`. T-378 partitions the archetype set into
   per-depth levels (cached across frames; the partition rebuilds only
-  on archetype-graph changes); within each level the per-archetype
-  composition fans out to IRJob workers via `IRJob::parallelFor`. Cost
-  is O(N) total compose work with O(passes × archetypes) topology
-  bookkeeping, where passes is bounded by the deepest parent chain.
-  See `docs/perf-reports/threading_propagate_transform.md`.
+  on archetype-graph changes); within each level composition fans out
+  to IRJob workers via `IRJob::parallelFor`. #1804 made the per-level
+  dispatch split by **row range**, not just by archetype: a level is
+  flattened into row-chunks so a single dominant archetype (e.g. a
+  262K-entity grid in one node) splits across workers instead of
+  composing serially on one. Output is bit-identical to the serial
+  path (disjoint rows, each entity writes only its own
+  `C_WorldTransform[i]`). Cost is O(N) total compose work with
+  O(passes × archetypes) topology bookkeeping, where passes is bounded
+  by the deepest parent chain. See
+  `docs/perf-reports/threading_propagate_transform.md`.
 
 ## Commands
 

--- a/engine/prefabs/irreden/update/systems/system_propagate_transform.hpp
+++ b/engine/prefabs/irreden/update/systems/system_propagate_transform.hpp
@@ -36,9 +36,17 @@
 //   Pass 2 (parallel per level) — for each depth in order, resolve
 //   each archetype's parent C_WorldTransform on the main thread (the
 //   prior level finished its writes, so the lookup is safe), then
-//   dispatch the per-archetype composition to IRJob workers via
-//   parallelFor. The implicit barrier between levels guarantees the
-//   prior level's writes are visible.
+//   dispatch composition to IRJob workers via a single parallelFor.
+//   The level is flattened into a list of row-chunks: a small
+//   archetype contributes one chunk (its whole row range), while a
+//   large archetype is split into several row-range chunks so a
+//   single dominant node (e.g. IRPerfGrid's 262K-entity node) fans
+//   out across workers instead of running serially on one. Disjoint
+//   row ranges are race-free — each entity writes only its own
+//   C_WorldTransform[i] from its own C_LocalTransform[i] + a
+//   read-only parent — so the result is bit-identical to the serial
+//   path regardless of chunk boundaries. The implicit barrier between
+//   levels guarantees the prior level's writes are visible.
 //
 // The level partition only depends on the archetype graph (entity
 // spawn/destroy/reparent that introduces or removes archetype nodes,
@@ -61,6 +69,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -68,12 +77,21 @@
 namespace IRSystem {
 
 template <> struct System<PROPAGATE_TRANSFORM> {
-    // One archetype per parallelFor task. Each archetype is already a
-    // batch of entities the composeNode inner loop iterates serially,
-    // so per-task work is already substantial and finer-grained
-    // chunking would only add dispatch overhead.
-    static constexpr int kGrainSize = 1;
+    // Parallelization thresholds. A level is dispatched in parallel
+    // when it holds at least kMinForParallel archetype nodes (the
+    // inter-node path) OR at least kMinRowsForParallel total entity
+    // rows (the intra-node path — a single large node still
+    // parallelizes). Below both, per-task dispatch overhead isn't
+    // worth it and the level composes serially.
+    //
+    // Within a parallelized level, work is split into row-chunks of
+    // ~max(kMinChunkRows, totalRows / targetTasks) rows. A node
+    // smaller than the chunk size stays whole (one chunk), so the
+    // many-small-node workload keeps its original node-granularity;
+    // only nodes larger than the chunk size split across workers.
     static constexpr int kMinForParallel = 8;
+    static constexpr int kMinRowsForParallel = 4096;
+    static constexpr int kMinChunkRows = 2048;
 
     // Cached level partition: levels_[d] holds archetype nodes whose
     // parent-chain depth is exactly d. parentWorlds_[d][i] is the
@@ -82,6 +100,19 @@ template <> struct System<PROPAGATE_TRANSFORM> {
     // parallel composition.
     std::vector<std::vector<IREntity::ArchetypeNode *>> levels_;
     std::vector<std::vector<IRComponents::C_WorldTransform>> parentWorlds_;
+
+    // Flattened per-level work list (rebuilt for each level, capacity
+    // reused across frames). Each chunk is rows [rowBegin, rowEnd) of
+    // levels_[depth][nodeIndex], composed against
+    // parentWorlds_[depth][nodeIndex]. Large nodes contribute several
+    // chunks, small nodes exactly one. Built on the main thread before
+    // the level's parallelFor and read-only on workers during it.
+    struct RowChunk {
+        int nodeIndex;
+        int rowBegin;
+        int rowEnd;
+    };
+    std::vector<RowChunk> chunks_;
 
     // Topology cache key: (nodeId, parentNodeId) pairs sorted by
     // nodeId. parentNodeId == 0 means "root archetype" (no CHILD_OF,
@@ -142,11 +173,22 @@ template <> struct System<PROPAGATE_TRANSFORM> {
             }
 
             const int n = static_cast<int>(levelNodes.size());
-            auto composeRange = [&](int rangeBegin, int rangeEnd) {
-                for (int i = rangeBegin; i < rangeEnd; ++i) {
-                    composeNode(
-                        levelNodes[i],
-                        levelParentWorlds[i],
+
+            // Total entity rows across this level decides whether to
+            // split large nodes and how big each row-chunk should be.
+            std::int64_t totalRows = 0;
+            for (auto *node : levelNodes) {
+                totalRows += node->length_;
+            }
+
+            auto composeChunkRange = [&](int chunkBegin, int chunkEnd) {
+                for (int c = chunkBegin; c < chunkEnd; ++c) {
+                    const RowChunk &chunk = chunks_[c];
+                    composeNodeRows(
+                        levelNodes[chunk.nodeIndex],
+                        levelParentWorlds[chunk.nodeIndex],
+                        chunk.rowBegin,
+                        chunk.rowEnd,
                         translationField,
                         scaleField,
                         resolvedFieldsComponentId,
@@ -155,25 +197,57 @@ template <> struct System<PROPAGATE_TRANSFORM> {
                 }
             };
 
-            if (g_jobManager == nullptr || n < kMinForParallel) {
-                composeRange(0, n);
-            } else {
-                // Aim for ~2 tasks per worker to give enkiTS room to
-                // load-balance without flooding the queue with tiny
-                // tasks. Each archetype carries enough work
-                // (hundreds-to-thousands of entities) that a small
-                // task count is fine.
-                const int workers = IRJob::workerCount();
-                const int targetTasks = IRMath::max(1, workers * 2);
-                const int grain = IRMath::max(kGrainSize, (n + targetTasks - 1) / targetTasks);
-                IRJob::parallelFor(0, n, grain, composeRange);
+            const bool runParallel = g_jobManager != nullptr &&
+                                     (n >= kMinForParallel || totalRows >= kMinRowsForParallel);
+
+            if (!runParallel) {
+                for (int i = 0; i < n; ++i) {
+                    composeNodeRows(
+                        levelNodes[i],
+                        levelParentWorlds[i],
+                        0,
+                        levelNodes[i]->length_,
+                        translationField,
+                        scaleField,
+                        resolvedFieldsComponentId,
+                        modifiersComponentId
+                    );
+                }
+                continue;
             }
+
+            // Aim for ~2 tasks per worker so enkiTS can load-balance
+            // without flooding the queue. The chunk size is derived
+            // from total work: nodes below it stay whole (preserving
+            // node-granularity for many-small-node levels), larger
+            // nodes split into multiple row-range chunks.
+            const int workers = IRMath::max(1, IRJob::workerCount());
+            const int targetTasks = workers * 2;
+            const int chunkRows = IRMath::max(
+                kMinChunkRows,
+                static_cast<int>((totalRows + targetTasks - 1) / targetTasks)
+            );
+
+            chunks_.clear();
+            for (int i = 0; i < n; ++i) {
+                const int len = levelNodes[i]->length_;
+                for (int rowBegin = 0; rowBegin < len; rowBegin += chunkRows) {
+                    chunks_.push_back({i, rowBegin, IRMath::min(rowBegin + chunkRows, len)});
+                }
+            }
+
+            const int numChunks = static_cast<int>(chunks_.size());
+            const int chunkGrain = IRMath::max(1, (numChunks + targetTasks - 1) / targetTasks);
+            IRJob::parallelFor(0, numChunks, chunkGrain, composeChunkRange);
         }
     }
 
-    void
-    tick(const IREntity::Archetype &, std::vector<IREntity::EntityId> &, std::vector<IRComponents::C_LocalTransform> &, std::vector<IRComponents::C_WorldTransform> &) {
-    }
+    void tick(
+        const IREntity::Archetype &,
+        std::vector<IREntity::EntityId> &,
+        std::vector<IRComponents::C_LocalTransform> &,
+        std::vector<IRComponents::C_WorldTransform> &
+    ) {}
 
     static SystemId create() {
         return registerSystem<
@@ -275,9 +349,15 @@ template <> struct System<PROPAGATE_TRANSFORM> {
         }
     }
 
-    static void composeNode(
+    // Composes C_WorldTransform for rows [rowBegin, rowEnd) of node.
+    // The per-node column fetches and isRootArchetype check below are
+    // cheap relative to the row loop, so re-deriving them per chunk
+    // when a large node is split costs nothing meaningful.
+    static void composeNodeRows(
         IREntity::ArchetypeNode *node,
         const IRComponents::C_WorldTransform &parentWorld,
+        int rowBegin,
+        int rowEnd,
         IRComponents::FieldBindingId translationField,
         IRComponents::FieldBindingId scaleField,
         IREntity::ComponentId resolvedFieldsComponentId,
@@ -309,7 +389,7 @@ template <> struct System<PROPAGATE_TRANSFORM> {
         const bool isRootArchetype =
             (IREntity::getParentEntityFromArchetype(node->type_) == IREntity::kNullEntity);
 
-        for (int i = 0; i < node->length_; ++i) {
+        for (int i = rowBegin; i < rowEnd; ++i) {
             const auto &local = locals[i];
 
             IRMath::vec3 modTranslation(0.0f);


### PR DESCRIPTION
## Summary
- `PROPAGATE_TRANSFORM` parallelized **across archetype nodes** (T-378), so a single dominant archetype degenerated to serial: the 262K-entity IRPerfGrid `voxel_set` grid lives in one depth-0 node → `n=1` → one task → 262K rows composed on one worker.
- This PR adds **intra-node row-range splitting**. Each per-depth level is flattened into a row-chunk list: a small archetype stays whole (one chunk — preserves the prior per-node granularity for many-small-node levels), a node larger than the chunk size splits into row-range chunks. A single `parallelFor` + the existing per-level barrier still drive each depth in order.
- `composeNode` → `composeNodeRows(node, parentWorld, rowBegin, rowEnd, …)`. Per-row math unchanged; disjoint ranges are race-free (each entity writes only its own `C_WorldTransform[i]`), so output is **bit-identical** to the serial path regardless of chunk boundaries.
- Hybrid trigger: parallelize when a level has ≥ `kMinForParallel` (8) nodes **or** ≥ `kMinRowsForParallel` (4096) rows; chunk size `max(kMinChunkRows=2048, ceil(totalRows/targetTasks))`, `targetTasks = workers×2`. A single large node fans out to ~2 chunks/worker; many small nodes are grained to ~targetTasks tasks.

## Performance (IRPerfGrid `voxel_set`, grid-size 64 = 262,144 entities, macOS/Metal, 10 workers)
Method: `fleet-run IRPerfGrid --auto-profile 12 --auto-screenshot` (the `--auto-screenshot` fixed-step makes the profiler's last-frame `update` sample land on a ticked frame). `update` = whole UPDATE-pipeline stage; only `PROPAGATE_TRANSFORM` changed, so the delta is its contribution.

| Configuration | `update` / frame (3 runs) |
|---|---|
| `origin/master` (per-archetype → serial single node) | 4.32 / 4.42 / 4.61 ms |
| This PR (intra-node row-chunks) | 2.25 / 2.27 / 2.56 ms |

≈ **47% reduction (~2.1 ms)** on the UPDATE pipeline. Render still dominates frame time, so this is a secondary-axis win per the issue's framing — it closes the single-node degeneracy directly.

## Test plan
- [x] `fleet-build --target IRShapeDebug` / `IRPerfGrid` clean (both hosts: macOS here; Linux pending smoke)
- [x] **Bit-identity:** `IRShapeDebug --auto-screenshot` 28/28 byte-identical to `origin/master` (deterministic path reading `C_WorldTransform`)
- [x] **Bit-identity (parallel path):** IRPerfGrid screenshots are non-deterministic run-to-run (GPU rasterization speckle), so byte-compare is invalid; instead confirmed per-shot pixel-diff magnitude mine-vs-master sits within the demo's own noise floor (mine-vs-mine ≈ master-vs-master ≈ mine-vs-master; MAE < 0.5/255, < 1% pixels, no structural region difference)
- [x] `validateAllPipelineGroups` passes (runs every frame; 250-frame + screenshot runs clean)

Docs: updated `docs/perf-reports/threading_propagate_transform.md` (this implements the report's own "per-level cost estimator" follow-up) and `engine/prefabs/irreden/update/CLAUDE.md`.

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)