### PR TITLE
fleet: simplify Check 6 + doc callout — demos must use irreden_bundle_assets

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -239,6 +239,26 @@ done
 Auto-fix: append a single `\n`. Scope to files changed on this branch (the
 §10 `format-changed` set), not the whole tree.
 
+**Check 6: hand-rolled demo asset-copy blocks instead of `irreden_bundle_assets`.**
+
+`creations/CLAUDE.md` §"CMake boilerplate" mandates `irreden_bundle_assets(...)`
+for demo asset staging, but the rule is easy to miss when copy-pasting an older
+demo's `CMakeLists.txt`. The smell is a hand-rolled `add_custom_target(*Assets
+...)` / `add_custom_command(... copy_directory ...)` block in a changed
+`creations/demos/*/CMakeLists.txt` (#1870's fog_demo shipped 38 such lines):
+
+```bash
+git diff --name-only HEAD -- 'creations/demos/*/CMakeLists.txt' | while read -r f; do
+  grep -qE 'add_custom_(target|command)' "$f" \
+    && grep -qE 'copy_directory|copy_if_different' "$f" \
+    && echo "HAND-ROLLED asset copy (use irreden_bundle_assets): $f"
+done
+```
+
+Fix: replace the block with `irreden_bundle_assets(<target> SCRIPTS <files>)`
+(+ `irreden_package_target` if a bundle is wanted). Report, don't auto-fix —
+the SCRIPTS / asset list needs a human eye.
+
 ### 2c. Serialized-struct version-bump check
 
 See `engine/asset/CLAUDE.md` §"Automated version-bump detection" for the full

--- a/creations/CLAUDE.md
+++ b/creations/CLAUDE.md
@@ -55,12 +55,14 @@ is gitignored).
 
 ## CMake boilerplate
 
+> **Stage assets with `irreden_bundle_assets(<target> SCRIPTS ...)` — never a
+> hand-rolled `add_custom_target(*Assets ...)` / `add_custom_command(...
+> copy_directory ...)` block.** The helper (`cmake/ir_functions.cmake`) wires
+> the exe-relative `data/`/`shaders/`/`scripts/` layout + Windows DLLs;
+> `irreden_package_target(<target>)` adds the one-command distributable bundle.
+
 Use `creations/demos/shape_debug/CMakeLists.txt` as the canonical reference.
-It wires the exe-relative runtime layout (data/ shaders/ scripts/ + Windows
-DLLs) via `irreden_bundle_assets(<target> SCRIPTS ...)` and a one-command
-distributable bundle via `irreden_package_target(<target>)` — both in
-`cmake/ir_functions.cmake`; prefer them over hand-copied `add_custom_command`
-blocks. See [`docs/agents/BUILD.md`](../docs/agents/BUILD.md) §"Packaging a
+See [`docs/agents/BUILD.md`](../docs/agents/BUILD.md) §"Packaging a
 distributable bundle".
 
 Note: MinGW runtime DLLs (`libgcc_s_seh-1.dll`, etc.) are not copied by


### PR DESCRIPTION
## Summary
Closes the **#1887** coding-improvement (Class B — the "prefer `irreden_bundle_assets`" rule existed in `creations/CLAUDE.md` but was buried in prose; PR #1870 missed it and shipped a 38-line hand-rolled block).

- **`creations/CLAUDE.md` §CMake boilerplate** — promote the rule to a prominent blockquote callout (stage assets with `irreden_bundle_assets`, never a hand-rolled `add_custom_target(*Assets)` / `copy_directory` block).
- **`simplify` §2b Check 6** — flag a changed `creations/demos/*/CMakeLists.txt` that hand-rolls `add_custom_(target|command)` + `copy_directory`/`copy_if_different`. The mechanically-detectable enforcement (Class B's strongest lever); report, don't auto-fix.

## Validation
Ran Check 6 against every real demo CMakeLists: it **flags the 22 hand-rolled demos** and **passes `shape_debug`** (already on the helper via #1815) — no false positive on the canonical reference.

## Stacked on #1890
Based on the coding-improvement batch branch so Check 6 lands after Check 5 (both touch simplify §2b) without a merge conflict. **#1890 is untouched.** This PR retargets to `master` automatically when #1890 merges.

## Surfaced: a stale route-out
The validation revealed `shape_debug` is **already migrated** to `irreden_bundle_assets` (#1815) — so #1871's "shape_debug has redundant copies" premise is stale and route-out **#1888 is moot as written**. The real remaining work is the **22 other demos** Check 6 now flags (a low-priority cleanup sweep — the hand-rolled blocks work, they're just verbose). Repointing #1888 to that.

## Test plan
- [ ] Docs + one simplify check; no build impact.
- [ ] Check 6 fires on a demo CMakeLists with a hand-rolled `copy_directory` block, not on one using `irreden_bundle_assets` (validated against all 23 real demos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)