### PR TITLE
build: migrate 22 demo CMakeLists to irreden_bundle_assets

### DIFF
--- a/creations/demos/analytic_oracle/CMakeLists.txt
+++ b/creations/demos/analytic_oracle/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_ANALYTIC_ORACLE_RUNTIME_DIR})
 add_executable(IRAnalyticOracle main.cpp)
 target_link_libraries(IRAnalyticOracle PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRAnalyticOracle
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRAnalyticOracle> $<TARGET_RUNTIME_DLLS:IRAnalyticOracle>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_ANALYTIC_ORACLE_SCRIPTS_DIR ${IR_ANALYTIC_ORACLE_RUNTIME_DIR}/scripts)
-set(IR_ANALYTIC_ORACLE_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_ANALYTIC_ORACLE_CONFIG_LUA_DST ${IR_ANALYTIC_ORACLE_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_ANALYTIC_ORACLE_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_ANALYTIC_ORACLE_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_ANALYTIC_ORACLE_CONFIG_LUA_SRC} ${IR_ANALYTIC_ORACLE_CONFIG_LUA_DST}
-    DEPENDS ${IR_ANALYTIC_ORACLE_CONFIG_LUA_SRC}
-    COMMENT "Syncing analytic_oracle config.lua"
-)
-
-add_custom_target(IRAnalyticOracleAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_ANALYTIC_ORACLE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_ANALYTIC_ORACLE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_ANALYTIC_ORACLE_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_ANALYTIC_ORACLE_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRAnalyticOracle IRAnalyticOracleAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRAnalyticOracle SCRIPTS config.lua)
 
 add_custom_target(IRAnalyticOracleRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_ANALYTIC_ORACLE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_ANALYTIC_ORACLE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_ANALYTIC_ORACLE_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_ANALYTIC_ORACLE_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRAnalyticOracle>
-    DEPENDS IRAnalyticOracle
+    DEPENDS IRAnalyticOracle IRAnalyticOracleAssets
     WORKING_DIRECTORY ${IR_ANALYTIC_ORACLE_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/audio_playback/CMakeLists.txt
+++ b/creations/demos/audio_playback/CMakeLists.txt
@@ -3,74 +3,15 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_AUDIO_PLAYBACK_RUNTIME_DIR})
 add_executable(IRAudioPlayback main.cpp)
 target_link_libraries(IRAudioPlayback PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRAudioPlayback
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRAudioPlayback> $<TARGET_RUNTIME_DLLS:IRAudioPlayback>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_AUDIO_PLAYBACK_SCRIPTS_DIR ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}/scripts)
-set(IR_AUDIO_PLAYBACK_DEMO_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/scripts/audio_demo.lua)
-set(IR_AUDIO_PLAYBACK_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_AUDIO_PLAYBACK_DEMO_LUA_DST ${IR_AUDIO_PLAYBACK_SCRIPTS_DIR}/audio_demo.lua)
-set(IR_AUDIO_PLAYBACK_CONFIG_LUA_DST ${IR_AUDIO_PLAYBACK_SCRIPTS_DIR}/config.lua)
-set(IR_AUDIO_PLAYBACK_AUDIO_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data/audio)
-set(IR_AUDIO_PLAYBACK_AUDIO_DST_DIR ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}/data/audio)
-
-add_custom_command(
-    OUTPUT ${IR_AUDIO_PLAYBACK_DEMO_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_AUDIO_PLAYBACK_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_AUDIO_PLAYBACK_DEMO_LUA_SRC} ${IR_AUDIO_PLAYBACK_DEMO_LUA_DST}
-    DEPENDS ${IR_AUDIO_PLAYBACK_DEMO_LUA_SRC}
-    COMMENT "Syncing audio_playback audio_demo.lua"
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRAudioPlayback
+    SCRIPTS scripts/audio_demo.lua config.lua
+    EXTRA_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/data/audio data/audio
 )
-
-add_custom_command(
-    OUTPUT ${IR_AUDIO_PLAYBACK_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_AUDIO_PLAYBACK_CONFIG_LUA_SRC} ${IR_AUDIO_PLAYBACK_CONFIG_LUA_DST}
-    DEPENDS ${IR_AUDIO_PLAYBACK_CONFIG_LUA_SRC}
-    COMMENT "Syncing audio_playback config.lua"
-)
-
-add_custom_target(IRAudioPlaybackAssets
-    # Engine data + shaders (runtime/data, runtime/shaders).
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}/shaders
-    # Demo audio assets (runtime/data/audio/*.wav) — after the engine data
-    # copy so they aren't clobbered.
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${IR_AUDIO_PLAYBACK_AUDIO_SRC_DIR} ${IR_AUDIO_PLAYBACK_AUDIO_DST_DIR}
-    DEPENDS
-        ${IR_AUDIO_PLAYBACK_DEMO_LUA_DST}
-        ${IR_AUDIO_PLAYBACK_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRAudioPlayback IRAudioPlaybackAssets)
 
 add_custom_target(IRAudioPlaybackRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${IR_AUDIO_PLAYBACK_AUDIO_SRC_DIR} ${IR_AUDIO_PLAYBACK_AUDIO_DST_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_AUDIO_PLAYBACK_DEMO_LUA_SRC} ${IR_AUDIO_PLAYBACK_DEMO_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_AUDIO_PLAYBACK_CONFIG_LUA_SRC} ${IR_AUDIO_PLAYBACK_CONFIG_LUA_DST}
     COMMAND $<TARGET_FILE:IRAudioPlayback>
-    DEPENDS IRAudioPlayback
+    DEPENDS IRAudioPlayback IRAudioPlaybackAssets
     WORKING_DIRECTORY ${IR_AUDIO_PLAYBACK_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/canvas_stress/CMakeLists.txt
+++ b/creations/demos/canvas_stress/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_CANVAS_STRESS_RUNTIME_DIR})
 add_executable(IRCanvasStress main.cpp)
 target_link_libraries(IRCanvasStress PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRCanvasStress
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRCanvasStress> $<TARGET_RUNTIME_DLLS:IRCanvasStress>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_CANVAS_STRESS_SCRIPTS_DIR ${IR_CANVAS_STRESS_RUNTIME_DIR}/scripts)
-set(IR_CANVAS_STRESS_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_CANVAS_STRESS_CONFIG_LUA_DST ${IR_CANVAS_STRESS_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_CANVAS_STRESS_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_CANVAS_STRESS_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_CANVAS_STRESS_CONFIG_LUA_SRC} ${IR_CANVAS_STRESS_CONFIG_LUA_DST}
-    DEPENDS ${IR_CANVAS_STRESS_CONFIG_LUA_SRC}
-    COMMENT "Syncing canvas_stress config.lua"
-)
-
-add_custom_target(IRCanvasStressAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_CANVAS_STRESS_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_CANVAS_STRESS_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_CANVAS_STRESS_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_CANVAS_STRESS_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRCanvasStress IRCanvasStressAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRCanvasStress SCRIPTS config.lua)
 
 add_custom_target(IRCanvasStressRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_CANVAS_STRESS_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_CANVAS_STRESS_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_CANVAS_STRESS_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_CANVAS_STRESS_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRCanvasStress>
-    DEPENDS IRCanvasStress
+    DEPENDS IRCanvasStress IRCanvasStressAssets
     WORKING_DIRECTORY ${IR_CANVAS_STRESS_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/chunk_streaming_smoke/CMakeLists.txt
+++ b/creations/demos/chunk_streaming_smoke/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR})
 add_executable(IRChunkStreamingSmoke main.cpp)
 target_link_libraries(IRChunkStreamingSmoke PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRChunkStreamingSmoke
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRChunkStreamingSmoke> $<TARGET_RUNTIME_DLLS:IRChunkStreamingSmoke>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_CHUNK_STREAMING_SMOKE_SCRIPTS_DIR ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR}/scripts)
-set(IR_CHUNK_STREAMING_SMOKE_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_CHUNK_STREAMING_SMOKE_CONFIG_LUA_DST ${IR_CHUNK_STREAMING_SMOKE_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_CHUNK_STREAMING_SMOKE_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_CHUNK_STREAMING_SMOKE_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_CHUNK_STREAMING_SMOKE_CONFIG_LUA_SRC} ${IR_CHUNK_STREAMING_SMOKE_CONFIG_LUA_DST}
-    DEPENDS ${IR_CHUNK_STREAMING_SMOKE_CONFIG_LUA_SRC}
-    COMMENT "Syncing chunk_streaming_smoke config.lua"
-)
-
-add_custom_target(IRChunkStreamingSmokeAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_CHUNK_STREAMING_SMOKE_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRChunkStreamingSmoke IRChunkStreamingSmokeAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRChunkStreamingSmoke SCRIPTS config.lua)
 
 add_custom_target(IRChunkStreamingSmokeRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_CHUNK_STREAMING_SMOKE_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRChunkStreamingSmoke>
-    DEPENDS IRChunkStreamingSmoke
+    DEPENDS IRChunkStreamingSmoke IRChunkStreamingSmokeAssets
     WORKING_DIRECTORY ${IR_CHUNK_STREAMING_SMOKE_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/day_cycle/CMakeLists.txt
+++ b/creations/demos/day_cycle/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_DAY_CYCLE_RUNTIME_DIR})
 add_executable(IRDayCycle main.cpp)
 target_link_libraries(IRDayCycle PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRDayCycle
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRDayCycle> $<TARGET_RUNTIME_DLLS:IRDayCycle>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_DAY_CYCLE_SCRIPTS_DIR ${IR_DAY_CYCLE_RUNTIME_DIR}/scripts)
-set(IR_DAY_CYCLE_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_DAY_CYCLE_CONFIG_LUA_DST ${IR_DAY_CYCLE_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_DAY_CYCLE_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_DAY_CYCLE_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_DAY_CYCLE_CONFIG_LUA_SRC} ${IR_DAY_CYCLE_CONFIG_LUA_DST}
-    DEPENDS ${IR_DAY_CYCLE_CONFIG_LUA_SRC}
-    COMMENT "Syncing day_cycle config.lua"
-)
-
-add_custom_target(IRDayCycleAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_DAY_CYCLE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_DAY_CYCLE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_DAY_CYCLE_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_DAY_CYCLE_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRDayCycle IRDayCycleAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRDayCycle SCRIPTS config.lua)
 
 add_custom_target(IRDayCycleRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_DAY_CYCLE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_DAY_CYCLE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_DAY_CYCLE_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_DAY_CYCLE_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRDayCycle>
-    DEPENDS IRDayCycle
+    DEPENDS IRDayCycle IRDayCycleAssets
     WORKING_DIRECTORY ${IR_DAY_CYCLE_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/default/CMakeLists.txt
+++ b/creations/demos/default/CMakeLists.txt
@@ -7,74 +7,15 @@ add_executable(IRCreationDefault
 # add_executable(IRCreationDefault main.cpp)
 target_link_libraries(IRCreationDefault PUBLIC IrredenEngine)
 
-# Lua scripts live beside the executable in scripts/.
-set(IR_DEFAULT_SCRIPTS_DIR ${IR_DEFAULT_RUNTIME_DIR}/scripts)
-set(IR_DEFAULT_MAIN_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/main.lua)
-set(IR_DEFAULT_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_DEFAULT_COMMANDS_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/commands.lua)
-set(IR_DEFAULT_MAIN_LUA_DST ${IR_DEFAULT_SCRIPTS_DIR}/main.lua)
-set(IR_DEFAULT_CONFIG_LUA_DST ${IR_DEFAULT_SCRIPTS_DIR}/config.lua)
-set(IR_DEFAULT_COMMANDS_LUA_DST ${IR_DEFAULT_SCRIPTS_DIR}/commands.lua)
-
-# Track script files as build dependencies so normal UI build/run workflows
-# refresh Lua assets without requiring a C++ recompile.
-add_custom_command(
-    OUTPUT ${IR_DEFAULT_MAIN_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_DEFAULT_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${IR_DEFAULT_MAIN_LUA_SRC} ${IR_DEFAULT_MAIN_LUA_DST}
-    DEPENDS ${IR_DEFAULT_MAIN_LUA_SRC}
-    COMMENT "Syncing default demo main.lua"
-)
-
-add_custom_command(
-    OUTPUT ${IR_DEFAULT_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${IR_DEFAULT_CONFIG_LUA_SRC} ${IR_DEFAULT_CONFIG_LUA_DST}
-    DEPENDS ${IR_DEFAULT_CONFIG_LUA_SRC}
-    COMMENT "Syncing default demo config.lua"
-)
-
-add_custom_command(
-    OUTPUT ${IR_DEFAULT_COMMANDS_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_DEFAULT_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${IR_DEFAULT_COMMANDS_LUA_SRC} ${IR_DEFAULT_COMMANDS_LUA_DST}
-    DEPENDS ${IR_DEFAULT_COMMANDS_LUA_SRC}
-    COMMENT "Syncing default demo commands.lua"
-)
-
-add_custom_target(IRCreationDefaultAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_DEFAULT_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_DEFAULT_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_DEFAULT_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_DEFAULT_MAIN_LUA_DST}
-        ${IR_DEFAULT_CONFIG_LUA_DST}
-        ${IR_DEFAULT_COMMANDS_LUA_DST}
-)
-
-add_dependencies(IRCreationDefault IRCreationDefaultAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRCreationDefault SCRIPTS main.lua config.lua commands.lua)
 
 # Run helper target:
-# - Copies the latest Lua/config files every run
 # - Launches the creation executable from the build directory
 # This lets script edits be picked up without rebuilding C++.
 add_custom_target(IRCreationDefaultRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_DEFAULT_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_DEFAULT_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_DEFAULT_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/main.lua ${IR_DEFAULT_SCRIPTS_DIR}/main.lua
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_DEFAULT_SCRIPTS_DIR}/config.lua
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/commands.lua ${IR_DEFAULT_SCRIPTS_DIR}/commands.lua
     COMMAND $<TARGET_FILE:IRCreationDefault>
-    DEPENDS IRCreationDefault
+    DEPENDS IRCreationDefault IRCreationDefaultAssets
     WORKING_DIRECTORY ${IR_DEFAULT_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/gpu_particles/CMakeLists.txt
+++ b/creations/demos/gpu_particles/CMakeLists.txt
@@ -3,51 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_GPU_PARTICLES_RUNTIME_DIR})
 add_executable(IRGpuParticles main.cpp)
 target_link_libraries(IRGpuParticles PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRGpuParticles
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRGpuParticles> $<TARGET_RUNTIME_DLLS:IRGpuParticles>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_GPU_PARTICLES_SCRIPTS_DIR ${IR_GPU_PARTICLES_RUNTIME_DIR}/scripts)
-set(IR_GPU_PARTICLES_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_GPU_PARTICLES_CONFIG_LUA_DST ${IR_GPU_PARTICLES_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_GPU_PARTICLES_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_GPU_PARTICLES_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_GPU_PARTICLES_CONFIG_LUA_SRC} ${IR_GPU_PARTICLES_CONFIG_LUA_DST}
-    DEPENDS ${IR_GPU_PARTICLES_CONFIG_LUA_SRC}
-    COMMENT "Syncing gpu_particles config.lua"
-)
-
-add_custom_target(IRGpuParticlesAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_GPU_PARTICLES_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_GPU_PARTICLES_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_GPU_PARTICLES_RUNTIME_DIR}/shaders
-    DEPENDS ${IR_GPU_PARTICLES_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRGpuParticles IRGpuParticlesAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRGpuParticles SCRIPTS config.lua)
 
 add_custom_target(IRGpuParticlesRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_GPU_PARTICLES_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_GPU_PARTICLES_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_GPU_PARTICLES_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_GPU_PARTICLES_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRGpuParticles>
-    DEPENDS IRGpuParticles
+    DEPENDS IRGpuParticles IRGpuParticlesAssets
     WORKING_DIRECTORY ${IR_GPU_PARTICLES_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/ir_voxel_yaw/CMakeLists.txt
+++ b/creations/demos/ir_voxel_yaw/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_VOXEL_YAW_RUNTIME_DIR})
 add_executable(IRVoxelYaw main.cpp)
 target_link_libraries(IRVoxelYaw PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRVoxelYaw
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRVoxelYaw> $<TARGET_RUNTIME_DLLS:IRVoxelYaw>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_VOXEL_YAW_SCRIPTS_DIR ${IR_VOXEL_YAW_RUNTIME_DIR}/scripts)
-set(IR_VOXEL_YAW_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_VOXEL_YAW_CONFIG_LUA_DST ${IR_VOXEL_YAW_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_VOXEL_YAW_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_VOXEL_YAW_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_VOXEL_YAW_CONFIG_LUA_SRC} ${IR_VOXEL_YAW_CONFIG_LUA_DST}
-    DEPENDS ${IR_VOXEL_YAW_CONFIG_LUA_SRC}
-    COMMENT "Syncing ir_voxel_yaw config.lua"
-)
-
-add_custom_target(IRVoxelYawAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_VOXEL_YAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_VOXEL_YAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_VOXEL_YAW_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_VOXEL_YAW_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRVoxelYaw IRVoxelYawAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRVoxelYaw SCRIPTS config.lua)
 
 add_custom_target(IRVoxelYawRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_VOXEL_YAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_VOXEL_YAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_VOXEL_YAW_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_VOXEL_YAW_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRVoxelYaw>
-    DEPENDS IRVoxelYaw
+    DEPENDS IRVoxelYaw IRVoxelYawAssets
     WORKING_DIRECTORY ${IR_VOXEL_YAW_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/lighting/CMakeLists.txt
+++ b/creations/demos/lighting/CMakeLists.txt
@@ -47,45 +47,17 @@ foreach(IR_LIGHTING_DEMO_INDEX RANGE ${IR_LIGHTING_DEMO_LAST})
     add_executable(${IR_LIGHTING_DEMO_TARGET} ${IR_LIGHTING_DEMO_SOURCE})
     target_link_libraries(${IR_LIGHTING_DEMO_TARGET} PUBLIC IrredenEngine)
     target_include_directories(${IR_LIGHTING_DEMO_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
-    if(WIN32)
-        add_custom_command(
-            TARGET ${IR_LIGHTING_DEMO_TARGET}
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy -t
-                $<TARGET_FILE_DIR:${IR_LIGHTING_DEMO_TARGET}>
-                $<TARGET_RUNTIME_DLLS:${IR_LIGHTING_DEMO_TARGET}>
-            COMMAND_EXPAND_LISTS
-        )
-    endif()
 endforeach()
 
-set(IR_LIGHTING_SCRIPTS_DIR ${IR_LIGHTING_RUNTIME_DIR}/scripts)
-set(IR_LIGHTING_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_LIGHTING_CONFIG_LUA_DST ${IR_LIGHTING_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_LIGHTING_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_LIGHTING_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_LIGHTING_CONFIG_LUA_SRC} ${IR_LIGHTING_CONFIG_LUA_DST}
-    DEPENDS ${IR_LIGHTING_CONFIG_LUA_SRC}
-    COMMENT "Syncing lighting demo config.lua"
-)
-
-add_custom_target(IRLightingDemoAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_LIGHTING_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_LIGHTING_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_LIGHTING_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_LIGHTING_CONFIG_LUA_DST}
-)
-
+# All lighting demos share one runtime dir, so stage assets ONCE (via the first
+# target's bundle) and have every demo depend on it. Preserves the original
+# single-IRLightingDemoAssets layout and avoids N copy_directory jobs racing into
+# the same dir under make -j.
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+list(GET IR_LIGHTING_DEMO_TARGETS 0 IR_LIGHTING_PRIMARY_TARGET)
+irreden_bundle_assets(${IR_LIGHTING_PRIMARY_TARGET} SCRIPTS config.lua)
 foreach(IR_LIGHTING_DEMO_TARGET IN LISTS IR_LIGHTING_DEMO_TARGETS)
-    add_dependencies(${IR_LIGHTING_DEMO_TARGET} IRLightingDemoAssets)
+    add_dependencies(${IR_LIGHTING_DEMO_TARGET} ${IR_LIGHTING_PRIMARY_TARGET}Assets)
 endforeach()
 
 add_custom_target(IRLightingDemos DEPENDS ${IR_LIGHTING_DEMO_TARGETS})

--- a/creations/demos/lowres_pan/CMakeLists.txt
+++ b/creations/demos/lowres_pan/CMakeLists.txt
@@ -3,50 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_LOWRES_PAN_RUNTIME_DIR})
 add_executable(IRLowresPan main.cpp)
 target_link_libraries(IRLowresPan PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRLowresPan
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRLowresPan> $<TARGET_RUNTIME_DLLS:IRLowresPan>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_LOWRES_PAN_SCRIPTS_DIR ${IR_LOWRES_PAN_RUNTIME_DIR}/scripts)
-set(IR_LOWRES_PAN_CONFIG_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_LOWRES_PAN_CONFIG_DST ${IR_LOWRES_PAN_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_LOWRES_PAN_CONFIG_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_LOWRES_PAN_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${IR_LOWRES_PAN_CONFIG_SRC} ${IR_LOWRES_PAN_CONFIG_DST}
-    DEPENDS ${IR_LOWRES_PAN_CONFIG_SRC}
-    COMMENT "Syncing lowres_pan config.lua"
-)
-
-add_custom_target(IRLowresPanAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_LOWRES_PAN_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_LOWRES_PAN_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_LOWRES_PAN_RUNTIME_DIR}/shaders
-    DEPENDS ${IR_LOWRES_PAN_CONFIG_DST}
-)
-
-add_dependencies(IRLowresPan IRLowresPanAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRLowresPan SCRIPTS config.lua)
 
 add_custom_target(IRLowresPanRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_LOWRES_PAN_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_LOWRES_PAN_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_LOWRES_PAN_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_LOWRES_PAN_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRLowresPan>
-    DEPENDS IRLowresPan
+    DEPENDS IRLowresPan IRLowresPanAssets
     WORKING_DIRECTORY ${IR_LOWRES_PAN_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/lua_perf_grid/CMakeLists.txt
+++ b/creations/demos/lua_perf_grid/CMakeLists.txt
@@ -16,65 +16,12 @@ irreden_lua_codegen(IRLuaPerfGrid
     OUTPUT_HPP ${CMAKE_CURRENT_BINARY_DIR}/codegen/lua_perf_grid_codegen.hpp
 )
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRLuaPerfGrid
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRLuaPerfGrid> $<TARGET_RUNTIME_DLLS:IRLuaPerfGrid>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_LUA_PERF_GRID_SCRIPTS_DIR ${IR_LUA_PERF_GRID_RUNTIME_DIR}/scripts)
-set(IR_LUA_PERF_GRID_MAIN_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/main.lua)
-set(IR_LUA_PERF_GRID_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_LUA_PERF_GRID_MAIN_LUA_DST ${IR_LUA_PERF_GRID_SCRIPTS_DIR}/main.lua)
-set(IR_LUA_PERF_GRID_CONFIG_LUA_DST ${IR_LUA_PERF_GRID_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_LUA_PERF_GRID_MAIN_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_LUA_PERF_GRID_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_LUA_PERF_GRID_MAIN_LUA_SRC} ${IR_LUA_PERF_GRID_MAIN_LUA_DST}
-    DEPENDS ${IR_LUA_PERF_GRID_MAIN_LUA_SRC}
-    COMMENT "Syncing lua_perf_grid main.lua"
-)
-
-add_custom_command(
-    OUTPUT ${IR_LUA_PERF_GRID_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_LUA_PERF_GRID_CONFIG_LUA_SRC} ${IR_LUA_PERF_GRID_CONFIG_LUA_DST}
-    DEPENDS ${IR_LUA_PERF_GRID_CONFIG_LUA_SRC}
-    COMMENT "Syncing lua_perf_grid config.lua"
-)
-
-add_custom_target(IRLuaPerfGridAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_LUA_PERF_GRID_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_LUA_PERF_GRID_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_LUA_PERF_GRID_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_LUA_PERF_GRID_MAIN_LUA_DST}
-        ${IR_LUA_PERF_GRID_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRLuaPerfGrid IRLuaPerfGridAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRLuaPerfGrid SCRIPTS main.lua config.lua)
 
 add_custom_target(IRLuaPerfGridRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_LUA_PERF_GRID_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_LUA_PERF_GRID_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_LUA_PERF_GRID_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/main.lua ${IR_LUA_PERF_GRID_SCRIPTS_DIR}/main.lua
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_LUA_PERF_GRID_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRLuaPerfGrid>
-    DEPENDS IRLuaPerfGrid
+    DEPENDS IRLuaPerfGrid IRLuaPerfGridAssets
     WORKING_DIRECTORY ${IR_LUA_PERF_GRID_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/lua_pipeline_demo/CMakeLists.txt
+++ b/creations/demos/lua_pipeline_demo/CMakeLists.txt
@@ -3,65 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR})
 add_executable(IRLuaPipelineDemo main_lua.cpp)
 target_link_libraries(IRLuaPipelineDemo PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRLuaPipelineDemo
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRLuaPipelineDemo> $<TARGET_RUNTIME_DLLS:IRLuaPipelineDemo>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_LUA_PIPELINE_DEMO_SCRIPTS_DIR ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR}/scripts)
-set(IR_LUA_PIPELINE_DEMO_MAIN_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/main.lua)
-set(IR_LUA_PIPELINE_DEMO_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_LUA_PIPELINE_DEMO_MAIN_LUA_DST ${IR_LUA_PIPELINE_DEMO_SCRIPTS_DIR}/main.lua)
-set(IR_LUA_PIPELINE_DEMO_CONFIG_LUA_DST ${IR_LUA_PIPELINE_DEMO_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_LUA_PIPELINE_DEMO_MAIN_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_LUA_PIPELINE_DEMO_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_LUA_PIPELINE_DEMO_MAIN_LUA_SRC} ${IR_LUA_PIPELINE_DEMO_MAIN_LUA_DST}
-    DEPENDS ${IR_LUA_PIPELINE_DEMO_MAIN_LUA_SRC}
-    COMMENT "Syncing lua_pipeline_demo main.lua"
-)
-
-add_custom_command(
-    OUTPUT ${IR_LUA_PIPELINE_DEMO_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_LUA_PIPELINE_DEMO_CONFIG_LUA_SRC} ${IR_LUA_PIPELINE_DEMO_CONFIG_LUA_DST}
-    DEPENDS ${IR_LUA_PIPELINE_DEMO_CONFIG_LUA_SRC}
-    COMMENT "Syncing lua_pipeline_demo config.lua"
-)
-
-add_custom_target(IRLuaPipelineDemoAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_LUA_PIPELINE_DEMO_MAIN_LUA_DST}
-        ${IR_LUA_PIPELINE_DEMO_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRLuaPipelineDemo IRLuaPipelineDemoAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRLuaPipelineDemo SCRIPTS main.lua config.lua)
 
 add_custom_target(IRLuaPipelineDemoRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/main.lua ${IR_LUA_PIPELINE_DEMO_SCRIPTS_DIR}/main.lua
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_LUA_PIPELINE_DEMO_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRLuaPipelineDemo>
-    DEPENDS IRLuaPipelineDemo
+    DEPENDS IRLuaPipelineDemo IRLuaPipelineDemoAssets
     WORKING_DIRECTORY ${IR_LUA_PIPELINE_DEMO_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/metal_clear_test/CMakeLists.txt
+++ b/creations/demos/metal_clear_test/CMakeLists.txt
@@ -3,41 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_MCT_RUNTIME_DIR})
 add_executable(IRMetalClearTest main.cpp)
 target_link_libraries(IRMetalClearTest PUBLIC IrredenEngine)
 
-set(IR_MCT_SCRIPTS_DIR ${IR_MCT_RUNTIME_DIR}/scripts)
-set(IR_MCT_CONFIG_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_MCT_CONFIG_DST ${IR_MCT_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_MCT_CONFIG_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_MCT_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${IR_MCT_CONFIG_SRC} ${IR_MCT_CONFIG_DST}
-    DEPENDS ${IR_MCT_CONFIG_SRC}
-    COMMENT "Syncing metal_clear_test config.lua"
-)
-
-add_custom_target(IRMetalClearTestAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_MCT_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_MCT_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_MCT_RUNTIME_DIR}/shaders
-    DEPENDS ${IR_MCT_CONFIG_DST}
-)
-
-add_dependencies(IRMetalClearTest IRMetalClearTestAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRMetalClearTest SCRIPTS config.lua)
 
 add_custom_target(IRMetalClearTestRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_MCT_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_MCT_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_MCT_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_MCT_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRMetalClearTest>
-    DEPENDS IRMetalClearTest
+    DEPENDS IRMetalClearTest IRMetalClearTestAssets
     WORKING_DIRECTORY ${IR_MCT_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/midi_keyboard/CMakeLists.txt
+++ b/creations/demos/midi_keyboard/CMakeLists.txt
@@ -3,27 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_MIDI_KEYBOARD_RUNTIME_DIR})
 add_executable(DemoMidiDevice main.cpp)
 target_link_libraries(DemoMidiDevice PUBLIC IrredenEngine)
 
-add_custom_target(DemoMidiDeviceAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_MIDI_KEYBOARD_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_MIDI_KEYBOARD_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_MIDI_KEYBOARD_RUNTIME_DIR}/shaders
-    COMMENT "Syncing midi_keyboard engine data and shaders"
-)
-
-add_dependencies(DemoMidiDevice DemoMidiDeviceAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(DemoMidiDevice)
 
 add_custom_target(DemoMidiDeviceRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_MIDI_KEYBOARD_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_MIDI_KEYBOARD_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_MIDI_KEYBOARD_RUNTIME_DIR}/shaders
     COMMAND $<TARGET_FILE:DemoMidiDevice>
-    DEPENDS DemoMidiDevice
+    DEPENDS DemoMidiDevice DemoMidiDeviceAssets
     WORKING_DIRECTORY ${IR_MIDI_KEYBOARD_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/modifier_demo/CMakeLists.txt
+++ b/creations/demos/modifier_demo/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_MODIFIER_DEMO_RUNTIME_DIR})
 add_executable(IRModifierDemo main.cpp)
 target_link_libraries(IRModifierDemo PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRModifierDemo
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRModifierDemo> $<TARGET_RUNTIME_DLLS:IRModifierDemo>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_MODIFIER_DEMO_SCRIPTS_DIR ${IR_MODIFIER_DEMO_RUNTIME_DIR}/scripts)
-set(IR_MODIFIER_DEMO_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_MODIFIER_DEMO_CONFIG_LUA_DST ${IR_MODIFIER_DEMO_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_MODIFIER_DEMO_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_MODIFIER_DEMO_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_MODIFIER_DEMO_CONFIG_LUA_SRC} ${IR_MODIFIER_DEMO_CONFIG_LUA_DST}
-    DEPENDS ${IR_MODIFIER_DEMO_CONFIG_LUA_SRC}
-    COMMENT "Syncing modifier_demo config.lua"
-)
-
-add_custom_target(IRModifierDemoAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_MODIFIER_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_MODIFIER_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_MODIFIER_DEMO_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_MODIFIER_DEMO_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRModifierDemo IRModifierDemoAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRModifierDemo SCRIPTS config.lua)
 
 add_custom_target(IRModifierDemoRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_MODIFIER_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_MODIFIER_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_MODIFIER_DEMO_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_MODIFIER_DEMO_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRModifierDemo>
-    DEPENDS IRModifierDemo
+    DEPENDS IRModifierDemo IRModifierDemoAssets
     WORKING_DIRECTORY ${IR_MODIFIER_DEMO_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/perf_grid/CMakeLists.txt
+++ b/creations/demos/perf_grid/CMakeLists.txt
@@ -3,56 +3,15 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_PERF_GRID_RUNTIME_DIR})
 add_executable(IRPerfGrid main.cpp)
 target_link_libraries(IRPerfGrid PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRPerfGrid
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRPerfGrid> $<TARGET_RUNTIME_DLLS:IRPerfGrid>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_PERF_GRID_SCRIPTS_DIR ${IR_PERF_GRID_RUNTIME_DIR}/scripts)
-set(IR_PERF_GRID_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_PERF_GRID_CONFIG_LUA_DST ${IR_PERF_GRID_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_PERF_GRID_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_PERF_GRID_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_PERF_GRID_CONFIG_LUA_SRC} ${IR_PERF_GRID_CONFIG_LUA_DST}
-    DEPENDS ${IR_PERF_GRID_CONFIG_LUA_SRC}
-    COMMENT "Syncing perf_grid config.lua"
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRPerfGrid
+    SCRIPTS config.lua
+    EXTRA_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/configs configs
 )
-
-add_custom_target(IRPerfGridAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_PERF_GRID_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_PERF_GRID_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_PERF_GRID_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/configs ${IR_PERF_GRID_RUNTIME_DIR}/configs
-    DEPENDS
-        ${IR_PERF_GRID_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRPerfGrid IRPerfGridAssets)
 
 add_custom_target(IRPerfGridRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_PERF_GRID_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_PERF_GRID_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_PERF_GRID_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_PERF_GRID_SCRIPTS_DIR}/config.lua
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/configs ${IR_PERF_GRID_RUNTIME_DIR}/configs
     COMMAND $<TARGET_FILE:IRPerfGrid>
-    DEPENDS IRPerfGrid
+    DEPENDS IRPerfGrid IRPerfGridAssets
     WORKING_DIRECTORY ${IR_PERF_GRID_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/skeletal_demo/CMakeLists.txt
+++ b/creations/demos/skeletal_demo/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_SKELETAL_DEMO_RUNTIME_DIR})
 add_executable(IRSkeletalDemo main.cpp)
 target_link_libraries(IRSkeletalDemo PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRSkeletalDemo
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRSkeletalDemo> $<TARGET_RUNTIME_DLLS:IRSkeletalDemo>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_SKELETAL_DEMO_SCRIPTS_DIR ${IR_SKELETAL_DEMO_RUNTIME_DIR}/scripts)
-set(IR_SKELETAL_DEMO_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_SKELETAL_DEMO_CONFIG_LUA_DST ${IR_SKELETAL_DEMO_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_SKELETAL_DEMO_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_SKELETAL_DEMO_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_SKELETAL_DEMO_CONFIG_LUA_SRC} ${IR_SKELETAL_DEMO_CONFIG_LUA_DST}
-    DEPENDS ${IR_SKELETAL_DEMO_CONFIG_LUA_SRC}
-    COMMENT "Syncing skeletal_demo config.lua"
-)
-
-add_custom_target(IRSkeletalDemoAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_SKELETAL_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_SKELETAL_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_SKELETAL_DEMO_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_SKELETAL_DEMO_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRSkeletalDemo IRSkeletalDemoAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRSkeletalDemo SCRIPTS config.lua)
 
 add_custom_target(IRSkeletalDemoRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_SKELETAL_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_SKELETAL_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_SKELETAL_DEMO_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_SKELETAL_DEMO_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRSkeletalDemo>
-    DEPENDS IRSkeletalDemo
+    DEPENDS IRSkeletalDemo IRSkeletalDemoAssets
     WORKING_DIRECTORY ${IR_SKELETAL_DEMO_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/sprite_demo/CMakeLists.txt
+++ b/creations/demos/sprite_demo/CMakeLists.txt
@@ -6,73 +6,15 @@ add_executable(IRSpriteDemo
 )
 target_link_libraries(IRSpriteDemo PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRSpriteDemo
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRSpriteDemo> $<TARGET_RUNTIME_DLLS:IRSpriteDemo>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_SPRITE_DEMO_SCRIPTS_DIR ${IR_SPRITE_DEMO_RUNTIME_DIR}/scripts)
-set(IR_SPRITE_DEMO_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_SPRITE_DEMO_CONFIG_LUA_DST ${IR_SPRITE_DEMO_SCRIPTS_DIR}/config.lua)
-set(IR_SPRITE_DEMO_MAIN_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/scripts/main.lua)
-set(IR_SPRITE_DEMO_MAIN_LUA_DST ${IR_SPRITE_DEMO_SCRIPTS_DIR}/main.lua)
-
-add_custom_command(
-    OUTPUT ${IR_SPRITE_DEMO_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_SPRITE_DEMO_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_SPRITE_DEMO_CONFIG_LUA_SRC} ${IR_SPRITE_DEMO_CONFIG_LUA_DST}
-    DEPENDS ${IR_SPRITE_DEMO_CONFIG_LUA_SRC}
-    COMMENT "Syncing sprite_demo config.lua"
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRSpriteDemo
+    SCRIPTS config.lua scripts/main.lua
+    EXTRA_DIRS ${PROJECT_SOURCE_DIR}/assets/demos/sprite_demo assets/sprite_demo
 )
-
-add_custom_command(
-    OUTPUT ${IR_SPRITE_DEMO_MAIN_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_SPRITE_DEMO_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_SPRITE_DEMO_MAIN_LUA_SRC} ${IR_SPRITE_DEMO_MAIN_LUA_DST}
-    DEPENDS ${IR_SPRITE_DEMO_MAIN_LUA_SRC}
-    COMMENT "Syncing sprite_demo main.lua"
-)
-
-set(IR_SPRITE_DEMO_ASSET_SRC ${PROJECT_SOURCE_DIR}/assets/demos/sprite_demo)
-set(IR_SPRITE_DEMO_ASSET_DST ${IR_SPRITE_DEMO_RUNTIME_DIR}/assets/sprite_demo)
-
-add_custom_target(IRSpriteDemoAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_SPRITE_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_SPRITE_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_SPRITE_DEMO_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${IR_SPRITE_DEMO_ASSET_SRC} ${IR_SPRITE_DEMO_ASSET_DST}
-    DEPENDS
-        ${IR_SPRITE_DEMO_CONFIG_LUA_DST}
-        ${IR_SPRITE_DEMO_MAIN_LUA_DST}
-)
-
-add_dependencies(IRSpriteDemo IRSpriteDemoAssets)
 
 add_custom_target(IRSpriteDemoRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_SPRITE_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_SPRITE_DEMO_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_SPRITE_DEMO_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${IR_SPRITE_DEMO_ASSET_SRC} ${IR_SPRITE_DEMO_ASSET_DST}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_SPRITE_DEMO_CONFIG_LUA_SRC} ${IR_SPRITE_DEMO_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_SPRITE_DEMO_MAIN_LUA_SRC} ${IR_SPRITE_DEMO_MAIN_LUA_DST}
     COMMAND $<TARGET_FILE:IRSpriteDemo>
-    DEPENDS IRSpriteDemo
+    DEPENDS IRSpriteDemo IRSpriteDemoAssets
     WORKING_DIRECTORY ${IR_SPRITE_DEMO_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/stateless_particles/CMakeLists.txt
+++ b/creations/demos/stateless_particles/CMakeLists.txt
@@ -3,51 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_STATELESS_PARTICLES_RUNTIME_DIR})
 add_executable(IRStatelessParticles main.cpp)
 target_link_libraries(IRStatelessParticles PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRStatelessParticles
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRStatelessParticles> $<TARGET_RUNTIME_DLLS:IRStatelessParticles>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_STATELESS_PARTICLES_SCRIPTS_DIR ${IR_STATELESS_PARTICLES_RUNTIME_DIR}/scripts)
-set(IR_STATELESS_PARTICLES_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_STATELESS_PARTICLES_CONFIG_LUA_DST ${IR_STATELESS_PARTICLES_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_STATELESS_PARTICLES_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_STATELESS_PARTICLES_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_STATELESS_PARTICLES_CONFIG_LUA_SRC} ${IR_STATELESS_PARTICLES_CONFIG_LUA_DST}
-    DEPENDS ${IR_STATELESS_PARTICLES_CONFIG_LUA_SRC}
-    COMMENT "Syncing stateless_particles config.lua"
-)
-
-add_custom_target(IRStatelessParticlesAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_STATELESS_PARTICLES_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_STATELESS_PARTICLES_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_STATELESS_PARTICLES_RUNTIME_DIR}/shaders
-    DEPENDS ${IR_STATELESS_PARTICLES_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRStatelessParticles IRStatelessParticlesAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRStatelessParticles SCRIPTS config.lua)
 
 add_custom_target(IRStatelessParticlesRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_STATELESS_PARTICLES_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_STATELESS_PARTICLES_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_STATELESS_PARTICLES_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_STATELESS_PARTICLES_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRStatelessParticles>
-    DEPENDS IRStatelessParticles
+    DEPENDS IRStatelessParticles IRStatelessParticlesAssets
     WORKING_DIRECTORY ${IR_STATELESS_PARTICLES_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/ui_dockspace/CMakeLists.txt
+++ b/creations/demos/ui_dockspace/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_UI_DOCKSPACE_RUNTIME_DIR})
 add_executable(IRUiDockspace main.cpp)
 target_link_libraries(IRUiDockspace PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRUiDockspace
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRUiDockspace> $<TARGET_RUNTIME_DLLS:IRUiDockspace>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_UI_DOCKSPACE_SCRIPTS_DIR ${IR_UI_DOCKSPACE_RUNTIME_DIR}/scripts)
-set(IR_UI_DOCKSPACE_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_UI_DOCKSPACE_CONFIG_LUA_DST ${IR_UI_DOCKSPACE_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_UI_DOCKSPACE_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_UI_DOCKSPACE_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_UI_DOCKSPACE_CONFIG_LUA_SRC} ${IR_UI_DOCKSPACE_CONFIG_LUA_DST}
-    DEPENDS ${IR_UI_DOCKSPACE_CONFIG_LUA_SRC}
-    COMMENT "Syncing ui_dockspace config.lua"
-)
-
-add_custom_target(IRUiDockspaceAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_UI_DOCKSPACE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_UI_DOCKSPACE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_UI_DOCKSPACE_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_UI_DOCKSPACE_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRUiDockspace IRUiDockspaceAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRUiDockspace SCRIPTS config.lua)
 
 add_custom_target(IRUiDockspaceRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_UI_DOCKSPACE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_UI_DOCKSPACE_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_UI_DOCKSPACE_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_UI_DOCKSPACE_CONFIG_LUA_SRC} ${IR_UI_DOCKSPACE_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRUiDockspace>
-    DEPENDS IRUiDockspace
+    DEPENDS IRUiDockspace IRUiDockspaceAssets
     WORKING_DIRECTORY ${IR_UI_DOCKSPACE_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/ui_widgets/CMakeLists.txt
+++ b/creations/demos/ui_widgets/CMakeLists.txt
@@ -3,52 +3,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IR_UI_WIDGETS_RUNTIME_DIR})
 add_executable(IRUIWidgetsDemo main.cpp)
 target_link_libraries(IRUIWidgetsDemo PUBLIC IrredenEngine)
 
-if(WIN32)
-    add_custom_command(
-        TARGET IRUIWidgetsDemo
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:IRUIWidgetsDemo> $<TARGET_RUNTIME_DLLS:IRUIWidgetsDemo>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
-
-set(IR_UI_WIDGETS_SCRIPTS_DIR ${IR_UI_WIDGETS_RUNTIME_DIR}/scripts)
-set(IR_UI_WIDGETS_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_UI_WIDGETS_CONFIG_LUA_DST ${IR_UI_WIDGETS_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_UI_WIDGETS_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_UI_WIDGETS_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_UI_WIDGETS_CONFIG_LUA_SRC} ${IR_UI_WIDGETS_CONFIG_LUA_DST}
-    DEPENDS ${IR_UI_WIDGETS_CONFIG_LUA_SRC}
-    COMMENT "Syncing ui_widgets config.lua"
-)
-
-add_custom_target(IRUIWidgetsDemoAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_UI_WIDGETS_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_UI_WIDGETS_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_UI_WIDGETS_RUNTIME_DIR}/shaders
-    DEPENDS
-        ${IR_UI_WIDGETS_CONFIG_LUA_DST}
-)
-
-add_dependencies(IRUIWidgetsDemo IRUIWidgetsDemoAssets)
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+irreden_bundle_assets(IRUIWidgetsDemo SCRIPTS config.lua)
 
 add_custom_target(IRUIWidgetsDemoRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_UI_WIDGETS_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_UI_WIDGETS_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_UI_WIDGETS_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_UI_WIDGETS_CONFIG_LUA_SRC} ${IR_UI_WIDGETS_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRUIWidgetsDemo>
-    DEPENDS IRUIWidgetsDemo
+    DEPENDS IRUIWidgetsDemo IRUIWidgetsDemoAssets
     WORKING_DIRECTORY ${IR_UI_WIDGETS_RUNTIME_DIR}
     USES_TERMINAL
 )

--- a/creations/demos/z_yaw_rotation/CMakeLists.txt
+++ b/creations/demos/z_yaw_rotation/CMakeLists.txt
@@ -20,74 +20,30 @@ foreach(IR_ZYAW_DEMO_INDEX RANGE ${IR_ZYAW_DEMO_LAST})
 
     add_executable(${IR_ZYAW_DEMO_TARGET} ${IR_ZYAW_DEMO_SOURCE})
     target_link_libraries(${IR_ZYAW_DEMO_TARGET} PUBLIC IrredenEngine)
-
-    if(WIN32)
-        add_custom_command(
-            TARGET ${IR_ZYAW_DEMO_TARGET}
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy -t
-                $<TARGET_FILE_DIR:${IR_ZYAW_DEMO_TARGET}>
-                $<TARGET_RUNTIME_DLLS:${IR_ZYAW_DEMO_TARGET}>
-            COMMAND_EXPAND_LISTS
-        )
-    endif()
 endforeach()
 
-set(IR_ZYAW_SCRIPTS_DIR ${IR_ZYAW_RUNTIME_DIR}/scripts)
-set(IR_ZYAW_CONFIG_LUA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/config.lua)
-set(IR_ZYAW_CONFIG_LUA_DST ${IR_ZYAW_SCRIPTS_DIR}/config.lua)
-
-add_custom_command(
-    OUTPUT ${IR_ZYAW_CONFIG_LUA_DST}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${IR_ZYAW_SCRIPTS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${IR_ZYAW_CONFIG_LUA_SRC} ${IR_ZYAW_CONFIG_LUA_DST}
-    DEPENDS ${IR_ZYAW_CONFIG_LUA_SRC}
-    COMMENT "Syncing z_yaw_rotation config.lua"
-)
-
-add_custom_target(IRZYawDemoAssets
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_ZYAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_ZYAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_ZYAW_RUNTIME_DIR}/shaders
-    DEPENDS ${IR_ZYAW_CONFIG_LUA_DST}
-)
-
+# Both demos share one runtime dir, so stage assets ONCE (via the first target's
+# bundle) and have every demo depend on it. Preserves the original
+# single-IRZYawDemoAssets layout and avoids parallel copies into the same dir.
+# Exe-relative runtime layout (data/ shaders/ scripts/ + Windows DLLs).
+list(GET IR_ZYAW_DEMO_TARGETS 0 IR_ZYAW_PRIMARY_TARGET)
+irreden_bundle_assets(${IR_ZYAW_PRIMARY_TARGET} SCRIPTS config.lua)
 foreach(IR_ZYAW_DEMO_TARGET IN LISTS IR_ZYAW_DEMO_TARGETS)
-    add_dependencies(${IR_ZYAW_DEMO_TARGET} IRZYawDemoAssets)
+    add_dependencies(${IR_ZYAW_DEMO_TARGET} ${IR_ZYAW_PRIMARY_TARGET}Assets)
 endforeach()
 
 add_custom_target(IRZYawDemos DEPENDS ${IR_ZYAW_DEMO_TARGETS})
 
 add_custom_target(IRZYawStaticRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_ZYAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_ZYAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_ZYAW_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_ZYAW_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRZYawStatic>
-    DEPENDS IRZYawStatic
+    DEPENDS IRZYawStatic ${IR_ZYAW_PRIMARY_TARGET}Assets
     WORKING_DIRECTORY ${IR_ZYAW_RUNTIME_DIR}
     USES_TERMINAL
 )
 
 add_custom_target(IRZYawInteractiveRun
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/data ${IR_ZYAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/data ${IR_ZYAW_RUNTIME_DIR}/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${PROJECT_SOURCE_DIR}/engine/render/src/shaders ${IR_ZYAW_RUNTIME_DIR}/shaders
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_CURRENT_SOURCE_DIR}/config.lua ${IR_ZYAW_SCRIPTS_DIR}/config.lua
     COMMAND $<TARGET_FILE:IRZYawInteractive>
-    DEPENDS IRZYawInteractive
+    DEPENDS IRZYawInteractive ${IR_ZYAW_PRIMARY_TARGET}Assets
     WORKING_DIRECTORY ${IR_ZYAW_RUNTIME_DIR}
     USES_TERMINAL
 )


### PR DESCRIPTION
## Summary
- Migrates the **22 demo `CMakeLists.txt`** under `creations/demos/` that still hand-rolled asset staging to the `irreden_bundle_assets(<target> ...)` helper (`cmake/ir_functions.cmake`), dropping the per-demo Windows-DLL block, the `copy_if_different` script vars/commands, the `<target>Assets` custom target, and the inline `copy_*` commands in each `IR*Run` target.
- **Byte-for-byte identical staged runtime layout** for 21 of 22 demos — the helper reproduces the hand-rolled `data/` / `shaders/` / `scripts/` (+ extra-dirs) exactly. One benign behavioral delta: `midi_keyboard`'s original `CMakeLists.txt` had no `if(WIN32)` POST_BUILD DLL block; the `irreden_bundle_assets(DemoMidiDevice)` call adds the standard `$<TARGET_RUNTIME_DLLS:DemoMidiDevice>` staging block. On macOS/Linux this block is inert; on Windows it now correctly stages runtime DLLs next to the exe (previously missing). Beneficial, not a regression. Pure CMake refactor: no C++/shader/lua/runtime change. Net **−998 / +83** lines.
- `shape_debug` was already migrated (#1815) and is the reference shape — left untouched. `irreden_package_target(...)` deliberately NOT added (packaging is #1815's per-demo concern, out of scope here).
- **Multi-target demos** (`lighting` = 15 targets, `z_yaw_rotation` = 2) keep their original **single shared** asset-staging target: staged once via the first target's bundle with every target depending on it, rather than N per-target `copy_directory` jobs racing into the one shared runtime dir under `make -j`.
- Extra-dirs preserved: `audio_playback` → `data/audio`, `perf_grid` → `configs`, `sprite_demo` → `assets/sprite_demo`. Multi-script demos (`default`, `audio_playback`, `lua_perf_grid`, `lua_pipeline_demo`, `sprite_demo`) and the no-script `midi_keyboard`/`DemoMidiDevice` handled. `lua_perf_grid`'s `irreden_lua_codegen(...)` block preserved.

## Test plan
- [x] `cmake --preset macos-debug` reconfigures clean (validates all 22 CMakeLists parse).
- [x] Built every variant: all 22 demo targets compile, incl. the 15-exe `IRLightingDemos` and `IRZYawDemos` (shared-Assets restructure).
- [x] Spot-checked staged layout for each variant — `data/`/`shaders/`/`scripts/` + extra-dirs (`data/audio`, `configs/perf`, `assets/sprite_demo`) staged identically to before; `midi_keyboard` `scripts/` correctly empty.
- [ ] Linux/Windows build parity (CMake is host-agnostic; the WIN32 DLL path is now the helper's, exercised by `shape_debug`).

Closes #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)