### PR TITLE
docs/fleet: sync epic #1881 plans to the #1885 re-scope (harness + per-axis)

### DIFF
--- a/.fleet/plans/issue-1881.md
+++ b/.fleet/plans/issue-1881.md
@@ -168,26 +168,40 @@ both backends.
 
 ## Dependency chain
 
-PR #1880 (harness, on master)
-  -> Child 1 (cardinal gather) -> Child 2 (per-axis seams) -> Child 3 (depth)
+PR #1880 (harness, merged)
+  -> Child 1 (#1882: HARNESS fix — isolate cardinals + zoom tier + near-cardinal sampling)
+  -> Child 2 (#1883: per-axis scatter defect — coverage bands + face-alignment seams)
+  -> Child 3 (#1884: depth/clipping unification)
 
-Serialized: the three share ir_iso_common + the framebuffer gather/scatter, so
-they are worked one-at-a-time to avoid parallel conflicts. Child 1 first
-(highest user impact + it touches the gather Child 3 also audits).
+Serialized: they share ir_iso_common + the framebuffer gather/scatter, so they are
+worked one-at-a-time to avoid parallel conflicts. Child 1 (the harness) first — it
+must distinguish the single-canvas vs per-axis render paths and surface the fine
+artifacts before Child 2's per-axis fix can be validated.
+
+**Re-scope (2026-06-17).** Child 1 was "fix the cardinal gather" until the #1885
+investigation proved the single-canvas cardinal path is correct and the real defect
+is the **per-axis** path (now Child 2 / #1883, which absorbed the coverage "bands").
+Child 1 became the harness-methodology fix the misdiagnosis exposed. See the
+per-ticket plans + the #1881 / #1885 comments.
 
 ## Steward ledger
 
-reconciled-through: 2026-06-16
+reconciled-through: 2026-06-17
 proposal-pending: none
 
 ### Children
 | Child | State | PR | Plan | Last validated |
 |---|---|---|---|---|
-| #1882 | filed | — | .fleet/plans/issue-1882.md | — |
-| #1883 | filed (blocked by #1882) | — | .fleet/plans/issue-1883.md | — |
+| #1882 | re-scoped → harness fix; design-unblocked, in progress | #1885 | .fleet/plans/issue-1882.md | — |
+| #1883 | broadened → per-axis defect (bands + alignment); blocked by #1882 | — | .fleet/plans/issue-1883.md | — |
 | #1884 | filed (blocked by #1883) | — | .fleet/plans/issue-1884.md | — |
 
 ### Decisions
+- 2026-06-17: #1882's original "single-canvas cardinal gather" premise was a
+  misdiagnosis (single-canvas path verified correct via static cardinals + an
+  early-return probe in #1885). Re-scoped #1882 → harness methodology fix; folded
+  the real coverage loss + the face-alignment seams into #1883 (per-axis path).
 
 ### Events
 - 2026-06-16: filed via file-epic; plans committed to repo retroactively (the stale global ~/.claude/skills/file-epic ran and skipped step 6.5).
+- 2026-06-17: #1885 worker design-blocked child 1; architect accepted the finding, re-scoped #1882 (harness) + broadened #1883 (per-axis bands + alignment, with human screenshots), unblocked #1885; synced the per-ticket plans to match.

--- a/.fleet/plans/issue-1882.md
+++ b/.fleet/plans/issue-1882.md
@@ -1,48 +1,54 @@
-# Plan: render — cardinal-gather coverage loss at non-start cardinals
+# Plan: render — rotated-solidity harness (isolate cardinals + zoom tier + near-cardinal sampling)
 
-- **Issue:** #1882
+- **Issue:** #1882 (**RE-SCOPED** — was "cardinal-gather coverage loss")
 - **Model:** opus
-- **Date:** 2026-06-16
-- **Epic:** #1881 — see .fleet/plans/issue-1881.md for full context + baseline numbers
-- **Gated on:** PR #1880 (harness) on master
+- **Date:** 2026-06-17
+- **Epic:** #1881 — see .fleet/plans/issue-1881.md for full context
+- **Gated on:** PR #1880 (harness) — merged. **Unblocks #1883.**
+
+## Re-scope rationale
+The #1885 investigation proved the original premise (single-canvas cardinal gather
+broken) was a **misdiagnosis**: held statically at each exact cardinal the
+single-canvas path renders coverage 1.0 / 0 holes, and an early-return probe in the
+cardinal store showed the ramp's broken "cardinal" rows are rendered by the
+**per-axis** path (90°/180° unchanged when the cardinal store early-returns; only
+270° vanishes). The ramp's coverage loss is the per-axis path (→ #1883), captured at
+near-cardinal *residual* frames because per-axis is still allocated (allocation /
+deadband lag, with a yaw-sign asymmetry). So #1882 becomes the harness-methodology
+fix the misdiagnosis exposed — the harness must distinguish render paths and surface
+the artifacts that zoom 0.8 hides.
 
 ## Scope
-Fix the single-canvas cardinal path so a solid 64^3 cube is dense at every
-cardinal (yaw 0, pi/2, pi, 3pi/2), not just the start one. Primary "density
-goes away" defect. Per-axis path is already correct — do not touch it.
+1. **Isolate the single-canvas path at the cardinals.** Settle/hold at each exact
+   cardinal so per-axis is released before capture; fix the 270°-vs-90°/180°
+   asymmetry (per-axis-release deadband / `computeYawSplit` residual sign at exact
+   cardinals). Settled cardinals must read clean (>= 0.99).
+2. **Add a zoomed tier on a small cube.** High zoom on a small cube (small
+   `--grid-size` + high `--zoom`, or drive canvas_stress) so the fine per-axis
+   face-alignment / seam / sliver artifacts are visible; zoom 0.8 on the 64^3 cube
+   under-resolves them.
+3. **Finer near-cardinal sampling.** Artifacts peak **approaching** 180°/270° (~±1–10°
+   residual), not at exact cardinals or the 45° flips. Sample densely there.
+4. **Report the render path** (single-canvas vs per-axis) per pose so a "cardinal"
+   row is unambiguous.
 
 ## Affected files
-- engine/render/src/shaders/c_voxel_to_trixel_stage_1.glsl:271-294 (+ _stage_2 + both metal twins)
-- engine/render/src/shaders/ir_iso_common.glsl ~L344-361 (de-tile), L423-446 (rotate+shift); metal/ir_iso_common.metal ~L327-360
-- engine/render/src/shaders/metal/trixel_to_framebuffer.metal:93 ; f_trixel_to_framebuffer.glsl:53
-- engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp:60-104 (cardinal fill)
-- engine/render/include/irreden/render/ir_render_types.hpp:84-208 (struct + static_asserts) if plumbing a field
-
-## Approach
-Compensate the gather for the full per-cardinal cardinalLowerCornerShift iso
-offset (k0:(0,0) k1:(-1,+1) k2:(0,+2) k3:(+1,+1)) — fold it into the gather's
-canvasOffset/de-tile origin per cardinal so store + gather agree at every k.
-The cardinal fill does not set visualYaw_/cardinalIndex on the gather frame
-data today; set it and derive the offset (FrameDataTrixelToFramebuffer field
-append, no new bind point; update CPU+GLSL+Metal struct + static_asserts in one
-change). Reconcile the #394 Metal sawtooth so 0 stays byte-identical.
-Alternative: reformulate cardinalLowerCornerShift to be iso offset/parity
-neutral at all cardinals (then the fixed-origin gather is correct everywhere).
+- `scripts/dev/perf-grid-rotate-sweep` — sampling set + settle + per-pose path label + zoom tier
+- `creations/demos/perf_grid/main.cpp` — `kYawRampShots`: near-cardinal + zoom-tier shots; expose per-axis-active state
+- (read) `engine/prefabs/irreden/render/per_axis_canvas.hpp` + `system_voxel_to_trixel` `beginTick` `syncAllocationToCameraYaw` (allocation/deadband lifecycle + the 270° asymmetry); `engine/prefabs/irreden/render/camera.hpp` `computeYawSplit` (residual sign)
 
 ## Acceptance criteria
-- scripts/dev/perf-grid-rotate-sweep build dense 60: all four cardinals
-  (steps 0/9/18/27) coverage >= 0.99 AND perim within ~2x of the 0 baseline
-  (~250); no regression at any per-axis pose or at 0.
-- Holds on BOTH Metal (macOS) and OpenGL (Linux).
-- Cardinal-0 fast path byte-identical to master.
-- Before/after ramp screenshots at 0/90/180/270 in the PR.
+- Per-pose render-path label; **settled exact cardinals read clean (>= 0.99) on BOTH backends.**
+- The zoomed near-cardinal tier surfaces the per-axis face-alignment/seam artifacts
+  as a measurable signal (coverage / silhouette raggedness) + ROI crops.
 
 ## Gotchas
-#394 Metal sawtooth must not return at 0; std140 silent-sync if plumbing (no new
-bind point, budget full 0-30); per-axis path is forward-scatter (no gather) —
-already correct, don't touch.
+- The per-axis-release deadband + `computeYawSplit` residual sign at exact cardinals
+  is the 270°-vs-90°/180° asymmetry; nudge the captured yaw within the deadband (or
+  hold long enough for the free-at-cardinal gate to fire).
+- **Do NOT change the cardinal store / single-canvas gather — it is verified correct.**
 
 ## Verification
-On macOS: bash scripts/dev/perf-grid-rotate-sweep build dense 60 (check the
-table). On Linux: fleet-build IRPerfGrid + the same sweep. Plus
-fleet-build/run IRShapeDebug --auto-screenshot for the cross-host smoke.
+macOS: `bash scripts/dev/perf-grid-rotate-sweep` with the new settle + zoom +
+near-cardinal sampling; confirm cardinals clean + the zoom tier surfaces the seams.
+Linux: same via fleet-build/run. Cross-host IRShapeDebug smoke.

--- a/.fleet/plans/issue-1883.md
+++ b/.fleet/plans/issue-1883.md
@@ -1,38 +1,67 @@
-# Plan: render — per-axis face seams / slivers / stray lines
+# Plan: render — per-axis scatter defect (coverage bands + face-alignment seams)
 
-- **Issue:** #1883
+- **Issue:** #1883 (**BROADENED** — was "per-axis face seams/slivers" only)
 - **Model:** opus
-- **Date:** 2026-06-16
+- **Date:** 2026-06-17
 - **Epic:** #1881 — see .fleet/plans/issue-1881.md
-- **Blocked by:** #1882 (shared ir_iso_common + framebuffer surface — serialized)
-- **Gated on:** PR #1880 (harness) on master
+- **Blocked by:** #1882 (the harness must isolate render paths + surface fine artifacts first)
 
-## Scope
-Fix the per-axis forward-scatter seams/slivers/stray-lines/staircase on zoomed
-small rotated cubes (canvas_stress 48-55), worst near a face-flip.
+## Scope — the whole per-axis forward-scatter defect (two related faces)
+The #1885 investigation moved the rotated-cube defect here: it is the per-axis
+forward-scatter path, **not** the single-canvas cardinal gather (#1882, re-scoped to
+the harness fix). Two symptoms, one root cause:
 
-## Affected files
-- engine/render/src/shaders/v_peraxis_scatter.glsl:165,199-222 + metal/peraxis_scatter.metal
-- engine/render/src/shaders/ir_iso_common.glsl scatterConservativeDilation ~L752-777 (+ metal)
-- engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl (+ metal) — rounding parity
+**A. Coverage "bands"** (IRPerfGrid `--mode dense` 64^3): see-through density loss
+across the residual band — whole diagonal bands of the solid read as background. The
+scatter fails to **fill** the rotated faces.
+
+**B. Face-alignment seams** (canvas_stress small cubes, zoomed; human screenshots):
+- a **vertical seam splitting a face into two slightly-offset panels**;
+- a **doubled sliver/ridge along the top↔side face edge** (the faces don't meet — a
+  few-px gap/overlap);
+- **stray thin diagonal lines** on faces;
+- **staircase/jagged edges** where a straight cube edge should be.
+Worst **approaching** a cardinal (small residual). The scatter quads fail to **tile**.
+
+## Root cause (shared)
+The per-axis scatter deform/dilation + placement math:
+- #1878's adaptive dilation margin is **anisotropic** (a single scalar across both
+  in-plane axes) + **discontinuous** (hard `degenSin` gate) → over-grows the
+  non-degenerate axis (stray lines) and under-fills near degeneracy (bands).
+  `v_peraxis_scatter.glsl:199-222` + `metal/peraxis_scatter.metal`.
+- **Float-ulp split**: the scatter consumes `isoPixelToPos3D` UN-rounded
+  (`v_peraxis_scatter.glsl:165`) while resolve/lighting consume it ROUNDED →
+  region-boundary shift (horizontal offsets / seams). `c_resolve_per_axis_screen_depth`.
+- Cross-canvas shared edges have **no deterministic geometric owner** (reconciled
+  only by planar depth + the 0.25 margin bias) → the top↔side sliver/ridge.
 
 ## Approach
-Make the dilation margin per-axis (grow each in-plane axis by its own collapse,
-not the max) and continuous (drop the hard degenSin gate). Unify the rounding:
-consume isoPixelToPos3D the same way (rounded) in scatter + resolve/lighting.
-Give the cross-canvas shared edge a deterministic owner (stable axis/slot tie)
-instead of an ulp-sensitive depth race.
+- Make the dilation margin **per-axis + continuous** (grow each in-plane axis by its
+  own collapse, drop the hard `degenSin` gate) — fixes both stray lines (B) and
+  under-fill bands (A).
+- **Unify the rounding**: consume `isoPixelToPos3D` the same way (rounded) in scatter
+  + resolve/lighting — fixes the region-offset seams.
+- Give the cross-canvas shared edge a **deterministic owner** (stable axis/slot tie)
+  instead of an ulp-sensitive depth race — fixes the top↔side sliver/ridge.
+
+## Affected files
+- `engine/render/src/shaders/v_peraxis_scatter.glsl:165,199-222` + `metal/peraxis_scatter.metal`
+- `engine/render/src/shaders/ir_iso_common.glsl` `scatterConservativeDilation` ~L752-777 (+ metal)
+- `engine/render/src/shaders/c_resolve_per_axis_screen_depth.glsl` (+ metal) — rounding parity
 
 ## Acceptance criteria
-- Add a zoomed shot tier (zoom 3-4) to the harness; per-axis-pose zoomed perim
-  drops near the cardinal-0 level; ROI crops show no slivers/stray-lines/offsets.
-- canvas_stress small cube reads clean through the residual band (ROI before/after).
+- **A:** IRPerfGrid dense — coverage stays solid across the residual band (no bands).
+- **B:** canvas_stress small cube — clean faces through the near-cardinal band: no
+  vertical seams, no top↔side sliver, no stray lines; bounded silhouette raggedness
+  (ROI before/after).
 - Both backends.
 
 ## Gotchas
-Margin-depth bias must still yield grown margin to a real exact footprint (don't
-bloat silhouette); don't regress #1878's band-clipping fix at large residual.
+- The margin-depth bias must still keep grown margin yielding to a real exact
+  footprint (don't bloat the silhouette).
+- Don't regress #1878's band-clipping fix at large residual.
 
 ## Verification
-bash scripts/dev/perf-grid-rotate-sweep with the new zoom tier on both hosts;
-canvas_stress ROI crops; cross-host IRShapeDebug smoke.
+`bash scripts/dev/perf-grid-rotate-sweep` (post-#1882 harness: residual-band coverage
+for A + the zoomed near-cardinal tier for B), both hosts; canvas_stress ROI crops
+before/after.


### PR DESCRIPTION
## Summary
Sync the committed epic-#1881 plan files to the re-scope that came out of the #1885 design-block, so a worker on any host reads the current scope (not the stale "cardinal gather" plan).

- **`issue-1882.md`** — re-scoped from "fix the cardinal gather" → **harness methodology fix** (isolate the single-canvas path at exact cardinals + fix the 270° sign asymmetry; add a zoomed small-cube tier; sample densely in the near-cardinal residual band; report the render path per pose).
- **`issue-1883.md`** — broadened from "per-axis seams" → **the whole per-axis defect**: (A) coverage bands (IRPerfGrid 64³) + (B) face-alignment seams/slivers/stray-lines (canvas_stress small cubes), same deform/placement root cause.
- **`issue-1881.md`** — re-attribution in the dependency chain + Steward-ledger decision/events.

## Why
The #1885 worker proved child 1's premise was a misdiagnosis (single-canvas cardinal path verified correct via static cardinals + an early-return probe). The issue bodies + the #1885 architect reply already carry the correct direction; this brings the committed plans (`.fleet/plans/`) in line so cross-host pickup is consistent.

Part of epic #1881; supports the now-unblocked #1885 (child 1 / #1882).

## Test plan
- [ ] Docs-only; no build impact.
- [ ] `.fleet/plans/issue-{1882,1883}.md` describe the re-scoped/broadened tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)