### PR TITLE
engine/job: hoist parallelization boilerplate into IRJob (#1900)

### DIFF
--- a/docs/perf-reports/threading_propagate_transform.md
+++ b/docs/perf-reports/threading_propagate_transform.md
@@ -47,20 +47,34 @@ transform from a pre-resolved vector instead of an inline
 > `composeNode` runs serially on one worker. See the dedicated section
 > below for the row-splitting fix and its measurement.
 
-Each level is flattened into a list of row-chunks and dispatched with a
-single `parallelFor`:
+> **Hoisted into `IRJob` by #1900.** The fan-out decision, chunk
+> sizing, and serial fallback below no longer live in the system —
+> they are `IRJob::parallelChunks`, tuned by an `IRJob::ParallelTuning`
+> struct. The old `kMin*` / `targetTasks` constants are now that
+> struct's **defaults**, so `PROPAGATE_TRANSFORM` passes a
+> default-constructed tuning and the numbers stay bit-identical. The
+> system now only mirrors each level's per-node row counts into a
+> reused buffer (`nodeLengths_`) and calls the planner with its
+> reusable `chunks_` scratch; `engine/job/` owns and unit-tests the
+> policy (`test/job/ir_job_test.cpp`). The field names below are the
+> `ParallelTuning` members.
 
-- **`kMinForParallel = 8`** (node count) **OR `kMinRowsForParallel = 4096`**
+Each level is flattened into a list of row-chunks (by
+`IRJob::parallelChunks`) and dispatched with a single internal
+`parallelFor`:
+
+- **`minNodes_ = 8`** (node count) **OR `minItemsToParallelize_ = 4096`**
   (total entity rows) — a level parallelizes when it has at least this
   many archetypes *or* this many total rows. Below both, the dispatch +
   wait overhead exceeds the savings and the level composes serially.
-- **`kMinChunkRows = 2048`** — the minimum rows per chunk. A node smaller
+- **`minChunk_ = 2048`** — the minimum rows per chunk. A node smaller
   than the chunk size stays whole (one chunk), preserving the original
   per-archetype granularity for many-small-node levels; a node larger
   than the chunk size splits into multiple row-range chunks. The chunk
-  size is `max(kMinChunkRows, ceil(totalRows / targetTasks))` with
-  `targetTasks = max(1, workerCount * 2)`, so a single dominant node
-  splits into ~`targetTasks` chunks (≈2 per worker).
+  size is `max(minChunk_, ceil(totalRows / targetTasks))` with
+  `targetTasks = max(1, workerCount * tasksPerWorker_)` (default
+  `tasksPerWorker_ = 2`), so a single dominant node splits into
+  ~`targetTasks` chunks (≈2 per worker).
 - **Grain = `max(1, ceil(numChunks / targetTasks))`** over the chunk
   list — `1` when chunks already number ≤ `targetTasks` (single large
   node), grouping when many small nodes produce more chunks than tasks.

--- a/engine/job/CLAUDE.md
+++ b/engine/job/CLAUDE.md
@@ -1,14 +1,17 @@
 # engine/job/ — IRJob worker pool
 
 Phase 1 of the multithreading epic (#226). The module stands up an
-enkiTS-backed worker pool that `World` owns for its lifetime; no
-engine system schedules on it yet — T-222 is the first consumer.
+enkiTS-backed worker pool that `World` owns for its lifetime.
+`PROPAGATE_TRANSFORM` and the `SystemManager` `PARALLEL_FOR` fan-out
+are the first consumers; the auto-grain dispatch helpers below (#1900)
+consolidate the boilerplate they share.
 
 ## Entry point
 
 `engine/job/include/irreden/ir_job.hpp` — `IRJob::parallelFor`,
-`IRJob::run`, `IRJob::pinTo`, `IRJob::isMainThread`,
-`IRJob::workerId`, `IRJob::workerCount`, `IRJob::workerRng`. The
+`IRJob::parallelForAutoGrain`, `IRJob::parallelChunks`, `IRJob::run`,
+`IRJob::pinTo`, `IRJob::isMainThread`, `IRJob::workerId`,
+`IRJob::workerCount`, `IRJob::workerRng`. The
 global pointer `g_jobManager` follows the same `g_*Manager` pattern
 as `g_entityManager` — set by `JobManager`'s ctor, cleared by its
 dtor, valid only between `World` construction and destruction.
@@ -16,6 +19,30 @@ dtor, valid only between `World` construction and destruction.
 The `JobManager` class itself lives at
 `engine/job/include/irreden/job/job_manager.hpp` — engine-internal
 shape. Creations only need the umbrella header.
+
+## Auto-grain dispatch helpers
+
+`parallelFor` is the raw primitive — the caller picks the grain.
+`parallelForAutoGrain(totalItems, fn, tuning)` and
+`parallelChunks(nodeLengths, scratch, fn, tuning)` (#1900) wrap it with
+the fan-out-vs-serial decision, a `~workerCount × tasksPerWorker` grain
+target, and a serial fallback so each consumer stops re-deriving that
+boilerplate. `parallelChunks` additionally splits a single dominant
+node across workers by row range while keeping small nodes whole — the
+generalized form of `PROPAGATE_TRANSFORM`'s per-level dispatch.
+
+- Tunables live in `IRJob::ParallelTuning`
+  (`minItemsToParallelize_`, `minNodes_`, `minChunk_`,
+  `tasksPerWorker_`); the defaults reproduce the original
+  PROPAGATE_TRANSFORM constants, so a default-constructed tuning is
+  bit-identical to the hand-rolled dispatch it replaced.
+- Both fall back to a single serial pass when `g_jobManager ==
+  nullptr` or the work-set is below threshold (the same null-pool
+  contract `parallelFor` asserts on — these helpers tolerate it
+  instead, since their whole job is the parallel-vs-serial decision).
+- Callers own write-disjointness across the dispatched ranges, and
+  own the reused `scratch` buffer (`std::vector<IRJob::RowChunk>`) so
+  per-frame planning stays allocation-free on the hot path.
 
 ## Worker count resolution
 

--- a/engine/job/include/irreden/ir_job.hpp
+++ b/engine/job/include/irreden/ir_job.hpp
@@ -5,7 +5,9 @@
 
 #include <functional>
 #include <random>
+#include <span>
 #include <string_view>
+#include <vector>
 
 namespace IRJob {
 
@@ -18,6 +20,79 @@ namespace IRJob {
 /// deadlock under enkiTS and is asserted.
 void parallelFor(
     int begin, int end, int grainSize, const std::function<void(int rangeBegin, int rangeEnd)> &fn
+);
+
+/// Tunables for the auto-grain / row-range chunk planner
+/// (`parallelForAutoGrain`, `parallelChunks`). Defaults match the
+/// hand-tuned PROPAGATE_TRANSFORM dispatch from #1804 — that system's
+/// inline heuristic is the prototype these helpers generalize, so the
+/// defaults reproduce its behavior exactly.
+struct ParallelTuning {
+    /// Fan out once the work-set reaches this many items (rows). Below
+    /// it (and, for `parallelChunks`, below `minNodes_`) the work runs
+    /// serially on the calling thread — per-task dispatch overhead isn't
+    /// worth it for small work-sets.
+    int minItemsToParallelize_ = 4096;
+    /// `parallelChunks` only: fan out once the node list reaches this
+    /// many nodes, even if the row total is under
+    /// `minItemsToParallelize_` (the many-small-node path). The flat
+    /// `parallelForAutoGrain` is the single-node case, so this never
+    /// trips there.
+    int minNodes_ = 8;
+    /// A node longer than the planned chunk size splits into several
+    /// row-range chunks; a shorter node stays whole (one chunk),
+    /// preserving node-granularity for many-small-node levels. Acts as
+    /// the floor on the auto-computed chunk size.
+    int minChunk_ = 2048;
+    /// Aim for ~`tasksPerWorker_ × workerCount()` tasks so enkiTS can
+    /// load-balance without flooding the queue.
+    int tasksPerWorker_ = 2;
+};
+
+/// One row-range of one node: rows `[rowBegin_, rowEnd_)` of the node at
+/// `nodeIndex_` in the caller's node list. `parallelChunks` fills the
+/// caller-owned scratch buffer with these and dispatches them across
+/// the pool.
+struct RowChunk {
+    int nodeIndex_;
+    int rowBegin_;
+    int rowEnd_;
+};
+
+/// Auto-grain flat parallel-for with serial fallback. Runs
+/// `fn(begin, end)` over disjoint partitions of `[0, totalItems)`, each
+/// at least `tuning.minChunk` rows, sized so the pool sees roughly
+/// `tuning.tasksPerWorker × workerCount()` tasks it can load-balance.
+/// Falls back to a single serial `fn(0, totalItems)` when there is no
+/// worker pool or `totalItems < tuning.minItemsToParallelize`. The
+/// caller owns write-disjointness across ranges.
+void parallelForAutoGrain(
+    int totalItems,
+    const std::function<void(int begin, int end)> &fn,
+    const ParallelTuning &tuning = {}
+);
+
+/// Row-range chunk planner with serial fallback — the generalized form
+/// of PROPAGATE_TRANSFORM's per-level dispatch (#1804). Splits a list of
+/// nodes (node `i` is `nodeLengths[i]` rows long) across the worker
+/// pool: a node longer than the planned chunk size fans out into
+/// several row-range chunks, while a shorter node stays whole, so a
+/// single dominant node parallelizes without the many-small-node case
+/// losing node-granularity. Runs `fn(nodeIndex, rowBegin, rowEnd)` per
+/// chunk on a worker.
+///
+/// Falls back to a serial pass — `fn(i, 0, nodeLengths[i])` for each
+/// node in order, on the calling thread — when there is no worker pool
+/// or the level is below BOTH `tuning.minNodes` and
+/// `tuning.minItemsToParallelize`. `scratch` is a caller-owned buffer
+/// the planner fills with the chunk list; pass the same vector every
+/// frame so the planning stays allocation-free on the hot path. Ranges
+/// are always disjoint; the caller owns write-disjointness across them.
+void parallelChunks(
+    std::span<const int> nodeLengths,
+    std::vector<RowChunk> &scratch,
+    const std::function<void(int nodeIndex, int rowBegin, int rowEnd)> &fn,
+    const ParallelTuning &tuning = {}
 );
 
 /// Fires a single named task on a worker and blocks until it finishes.

--- a/engine/job/src/ir_job.cpp
+++ b/engine/job/src/ir_job.cpp
@@ -55,6 +55,90 @@ void parallelFor(
     scheduler.WaitforTask(&task);
 }
 
+void parallelForAutoGrain(
+    int totalItems, const std::function<void(int begin, int end)> &fn, const ParallelTuning &tuning
+) {
+    if (totalItems <= 0) {
+        return;
+    }
+    // Serial when there's no pool or the work-set is too small to amortize
+    // dispatch overhead. Runs on the calling (main) thread — matches the
+    // contract `parallelChunks` and PROPAGATE_TRANSFORM use.
+    const bool runParallel = g_jobManager != nullptr && totalItems >= tuning.minItemsToParallelize_;
+    if (!runParallel) {
+        fn(0, totalItems);
+        return;
+    }
+
+    // Aim for ~tasksPerWorker_ tasks per worker, floored at minChunk_ rows,
+    // and let enkiTS partition [0, totalItems) at that grain.
+    const int workers = IRMath::max(1, workerCount());
+    const int targetTasks = IRMath::max(1, workers * tuning.tasksPerWorker_);
+    const int chunkRows = IRMath::max(
+        tuning.minChunk_,
+        static_cast<int>((static_cast<int64_t>(totalItems) + targetTasks - 1) / targetTasks)
+    );
+    parallelFor(0, totalItems, chunkRows, fn);
+}
+
+void parallelChunks(
+    std::span<const int> nodeLengths,
+    std::vector<RowChunk> &scratch,
+    const std::function<void(int nodeIndex, int rowBegin, int rowEnd)> &fn,
+    const ParallelTuning &tuning
+) {
+    const int n = static_cast<int>(nodeLengths.size());
+    if (n == 0) {
+        return;
+    }
+
+    int64_t totalRows = 0;
+    for (int len : nodeLengths) {
+        totalRows += len;
+    }
+
+    // Parallelize on either threshold: many nodes (the inter-node path)
+    // OR enough total rows (the intra-node path — a single large node
+    // still fans out). Below both, the level composes serially.
+    const bool runParallel = g_jobManager != nullptr &&
+                             (n >= tuning.minNodes_ || totalRows >= tuning.minItemsToParallelize_);
+
+    if (!runParallel) {
+        for (int i = 0; i < n; ++i) {
+            fn(i, 0, nodeLengths[i]);
+        }
+        return;
+    }
+
+    const int workers = IRMath::max(1, workerCount());
+    const int targetTasks = IRMath::max(1, workers * tuning.tasksPerWorker_);
+    // Chunk size derived from total work: nodes below it stay whole
+    // (preserving node-granularity for many-small-node levels); larger
+    // nodes split into several row-range chunks so one dominant node
+    // fans out across workers.
+    const int chunkRows = IRMath::max(
+        tuning.minChunk_,
+        static_cast<int>((totalRows + targetTasks - 1) / targetTasks)
+    );
+
+    scratch.clear();
+    for (int i = 0; i < n; ++i) {
+        const int len = nodeLengths[i];
+        for (int rowBegin = 0; rowBegin < len; rowBegin += chunkRows) {
+            scratch.push_back({i, rowBegin, IRMath::min(rowBegin + chunkRows, len)});
+        }
+    }
+
+    const int numChunks = static_cast<int>(scratch.size());
+    const int chunkGrain = IRMath::max(1, (numChunks + targetTasks - 1) / targetTasks);
+    parallelFor(0, numChunks, chunkGrain, [&scratch, &fn](int chunkBegin, int chunkEnd) {
+        for (int c = chunkBegin; c < chunkEnd; ++c) {
+            const RowChunk &chunk = scratch[c];
+            fn(chunk.nodeIndex_, chunk.rowBegin_, chunk.rowEnd_);
+        }
+    });
+}
+
 void run(std::string_view name, const std::function<void()> &fn) {
     IR_ASSERT(g_jobManager != nullptr, "IRJob::run: no active JobManager");
     IR_ASSERT(g_jobManager->isMainThread(), "IRJob::run: must be called from the main thread");

--- a/engine/prefabs/irreden/update/CLAUDE.md
+++ b/engine/prefabs/irreden/update/CLAUDE.md
@@ -69,15 +69,19 @@ in the `UPDATE` pipeline unless explicitly noted.
   `C_WorldTransform`. T-378 partitions the archetype set into
   per-depth levels (cached across frames; the partition rebuilds only
   on archetype-graph changes); within each level composition fans out
-  to IRJob workers via `IRJob::parallelFor`. #1804 made the per-level
-  dispatch split by **row range**, not just by archetype: a level is
-  flattened into row-chunks so a single dominant archetype (e.g. a
-  262K-entity grid in one node) splits across workers instead of
-  composing serially on one. Output is bit-identical to the serial
-  path (disjoint rows, each entity writes only its own
-  `C_WorldTransform[i]`). Cost is O(N) total compose work with
-  O(passes × archetypes) topology bookkeeping, where passes is bounded
-  by the deepest parent chain. See
+  to IRJob workers. #1804 made the per-level dispatch split by **row
+  range**, not just by archetype: a level is flattened into row-chunks
+  so a single dominant archetype (e.g. a 262K-entity grid in one node)
+  splits across workers instead of composing serially on one. #1900
+  hoisted that fan-out / chunk-sizing / serial-fallback policy out of
+  the system and into `IRJob::parallelChunks` (tuned via
+  `IRJob::ParallelTuning`, whose defaults *are* this system's original
+  hand-tuned constants); the system now just mirrors each level's
+  per-node row counts into a reused buffer and hands them to the
+  planner. Output is bit-identical to the serial path (disjoint rows,
+  each entity writes only its own `C_WorldTransform[i]`). Cost is O(N)
+  total compose work with O(passes × archetypes) topology bookkeeping,
+  where passes is bounded by the deepest parent chain. See
   `docs/perf-reports/threading_propagate_transform.md`.
 
 ## Commands

--- a/engine/prefabs/irreden/update/systems/system_propagate_transform.hpp
+++ b/engine/prefabs/irreden/update/systems/system_propagate_transform.hpp
@@ -69,7 +69,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -77,21 +76,13 @@
 namespace IRSystem {
 
 template <> struct System<PROPAGATE_TRANSFORM> {
-    // Parallelization thresholds. A level is dispatched in parallel
-    // when it holds at least kMinForParallel archetype nodes (the
-    // inter-node path) OR at least kMinRowsForParallel total entity
-    // rows (the intra-node path — a single large node still
-    // parallelizes). Below both, per-task dispatch overhead isn't
-    // worth it and the level composes serially.
-    //
-    // Within a parallelized level, work is split into row-chunks of
-    // ~max(kMinChunkRows, totalRows / targetTasks) rows. A node
-    // smaller than the chunk size stays whole (one chunk), so the
-    // many-small-node workload keeps its original node-granularity;
-    // only nodes larger than the chunk size split across workers.
-    static constexpr int kMinForParallel = 8;
-    static constexpr int kMinRowsForParallel = 4096;
-    static constexpr int kMinChunkRows = 2048;
+    // Per-level dispatch policy — fan out, chunk sizing, and serial
+    // fallback — lives in IRJob::parallelChunks (#1900). Its
+    // ParallelTuning defaults ARE this system's hand-tuned values
+    // (#1804): parallelize at ≥8 nodes OR ≥4096 rows; split a dominant
+    // node into ≥2048-row chunks targeting ~2 tasks/worker; small nodes
+    // stay whole. We pass a default-constructed tuning here, so the
+    // knobs live in one tested place instead of re-derived inline.
 
     // Cached level partition: levels_[d] holds archetype nodes whose
     // parent-chain depth is exactly d. parentWorlds_[d][i] is the
@@ -101,18 +92,14 @@ template <> struct System<PROPAGATE_TRANSFORM> {
     std::vector<std::vector<IREntity::ArchetypeNode *>> levels_;
     std::vector<std::vector<IRComponents::C_WorldTransform>> parentWorlds_;
 
-    // Flattened per-level work list (rebuilt for each level, capacity
-    // reused across frames). Each chunk is rows [rowBegin, rowEnd) of
-    // levels_[depth][nodeIndex], composed against
-    // parentWorlds_[depth][nodeIndex]. Large nodes contribute several
-    // chunks, small nodes exactly one. Built on the main thread before
-    // the level's parallelFor and read-only on workers during it.
-    struct RowChunk {
-        int nodeIndex;
-        int rowBegin;
-        int rowEnd;
-    };
-    std::vector<RowChunk> chunks_;
+    // Per-level scratch reused across frames so the planner stays
+    // allocation-free on the hot path. nodeLengths_ mirrors the current
+    // level's per-node row counts (the planner's input); chunks_ is the
+    // flattened row-range work list IRJob::parallelChunks fills and
+    // dispatches. Both are owned here, not by IRJob, precisely so the
+    // capacity carries over between frames.
+    std::vector<int> nodeLengths_;
+    std::vector<IRJob::RowChunk> chunks_;
 
     // Topology cache key: (nodeId, parentNodeId) pairs sorted by
     // nodeId. parentNodeId == 0 means "root archetype" (no CHILD_OF,
@@ -140,9 +127,8 @@ template <> struct System<PROPAGATE_TRANSFORM> {
             IREntity::getComponentType<IRComponents::C_ResolvedFields>();
         const auto modifiersComponentId = IREntity::getComponentType<IRComponents::C_Modifiers>();
 
-        const auto archetype =
-            IREntity::getArchetype<IRComponents::C_LocalTransform, IRComponents::C_WorldTransform>(
-            );
+        const auto archetype = IREntity::
+            getArchetype<IRComponents::C_LocalTransform, IRComponents::C_WorldTransform>();
         auto nodes = IREntity::queryArchetypeNodesSimple(archetype);
 
         buildSignature(nodes, scratchSignature_);
@@ -172,73 +158,38 @@ template <> struct System<PROPAGATE_TRANSFORM> {
                 levelParentWorlds[i] = parentWorld;
             }
 
-            const int n = static_cast<int>(levelNodes.size());
-
-            // Total entity rows across this level decides whether to
-            // split large nodes and how big each row-chunk should be.
-            std::int64_t totalRows = 0;
+            // Mirror this level's per-node row counts into the reusable
+            // buffer the planner consumes (capacity carries across
+            // frames). The planner reads only the lengths; the compose
+            // closure resolves nodeIndex back to the live node + parent.
+            nodeLengths_.clear();
+            nodeLengths_.reserve(levelNodes.size());
             for (auto *node : levelNodes) {
-                totalRows += node->length_;
+                nodeLengths_.push_back(node->length_);
             }
 
-            auto composeChunkRange = [&](int chunkBegin, int chunkEnd) {
-                for (int c = chunkBegin; c < chunkEnd; ++c) {
-                    const RowChunk &chunk = chunks_[c];
+            // Fan the level's composition out across the worker pool: a
+            // dominant node splits by row range, small nodes stay whole,
+            // and the level composes serially below threshold — all
+            // owned by IRJob::parallelChunks. Disjoint rows (each entity
+            // writes only its own C_WorldTransform[i]) keep the result
+            // bit-identical to the serial path regardless of chunking.
+            IRJob::parallelChunks(
+                nodeLengths_,
+                chunks_,
+                [&](int nodeIndex, int rowBegin, int rowEnd) {
                     composeNodeRows(
-                        levelNodes[chunk.nodeIndex],
-                        levelParentWorlds[chunk.nodeIndex],
-                        chunk.rowBegin,
-                        chunk.rowEnd,
+                        levelNodes[nodeIndex],
+                        levelParentWorlds[nodeIndex],
+                        rowBegin,
+                        rowEnd,
                         translationField,
                         scaleField,
                         resolvedFieldsComponentId,
                         modifiersComponentId
                     );
                 }
-            };
-
-            const bool runParallel = g_jobManager != nullptr &&
-                                     (n >= kMinForParallel || totalRows >= kMinRowsForParallel);
-
-            if (!runParallel) {
-                for (int i = 0; i < n; ++i) {
-                    composeNodeRows(
-                        levelNodes[i],
-                        levelParentWorlds[i],
-                        0,
-                        levelNodes[i]->length_,
-                        translationField,
-                        scaleField,
-                        resolvedFieldsComponentId,
-                        modifiersComponentId
-                    );
-                }
-                continue;
-            }
-
-            // Aim for ~2 tasks per worker so enkiTS can load-balance
-            // without flooding the queue. The chunk size is derived
-            // from total work: nodes below it stay whole (preserving
-            // node-granularity for many-small-node levels), larger
-            // nodes split into multiple row-range chunks.
-            const int workers = IRMath::max(1, IRJob::workerCount());
-            const int targetTasks = workers * 2;
-            const int chunkRows = IRMath::max(
-                kMinChunkRows,
-                static_cast<int>((totalRows + targetTasks - 1) / targetTasks)
             );
-
-            chunks_.clear();
-            for (int i = 0; i < n; ++i) {
-                const int len = levelNodes[i]->length_;
-                for (int rowBegin = 0; rowBegin < len; rowBegin += chunkRows) {
-                    chunks_.push_back({i, rowBegin, IRMath::min(rowBegin + chunkRows, len)});
-                }
-            }
-
-            const int numChunks = static_cast<int>(chunks_.size());
-            const int chunkGrain = IRMath::max(1, (numChunks + targetTasks - 1) / targetTasks);
-            IRJob::parallelFor(0, numChunks, chunkGrain, composeChunkRange);
         }
     }
 

--- a/engine/system/src/system_manager.cpp
+++ b/engine/system/src/system_manager.cpp
@@ -371,6 +371,14 @@ void SystemManager::executePipeline(IRTime::Events event) {
             // members, so any caller that needs per-system observer
             // brackets must put the observed system in its own
             // singleton group.
+            //
+            // #1900: deliberately NOT migrated to IRJob's auto-grain
+            // helper. This fans out *systems* at fixed grain=1 (one
+            // system per task) — auto-grain would batch the group onto
+            // ~tasksPerWorker tasks and collapse a small group onto a
+            // single worker, killing the parallelism. It shares only the
+            // null-pool serial guard with the helper, not the
+            // chunk-planning boilerplate the helper consolidates.
             if (g_jobManager != nullptr) {
                 IRJob::parallelFor(
                     0,
@@ -464,6 +472,16 @@ void SystemManager::executeSystem(SystemId system) {
             // PARALLEL_FOR members in multi-system groups at boot, so
             // this path is unreachable in well-formed programs; the
             // guard is kept as a release-build safety net.
+            // #1900: kept on raw parallelFor with the per-system
+            // grainSize, NOT IRJob's auto-grain helper. grainSize here
+            // is the system's *explicit* kGrainSize tuning knob (or
+            // kDefaultGrainSize) — an author-chosen value, not the
+            // re-derived chunk-planning boilerplate the helper folds
+            // away — and the main-thread binder resolve above must stay
+            // inline. Switching the grainSize-unset case to auto-grain
+            // (so one huge node fans out across ~workers×2 tasks instead
+            // of length/grain tasks) is a measurable per-system perf
+            // change, scoped to its own follow-up per the issue.
             auto rangedTick = tickEvent.prepareRangedTick_(node);
             IRJob::parallelFor(
                 0,

--- a/test/job/ir_job_test.cpp
+++ b/test/job/ir_job_test.cpp
@@ -5,6 +5,7 @@
 #include <irreden/job/job_manager.hpp>
 
 #include <atomic>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -222,4 +223,180 @@ TEST(IRJobManagerTest, FreeFunctionsAreSafeWithoutManager) {
     EXPECT_TRUE(IRJob::isMainThread());
     EXPECT_EQ(IRJob::workerCount(), 0);
     EXPECT_EQ(IRJob::workerId(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// parallelForAutoGrain (#1900) — flat auto-grain + serial fallback.
+// ---------------------------------------------------------------------------
+
+TEST_F(IRJobFixture, AutoGrainParallelCoversRangeExactlyOnce) {
+    // Above the default minItemsToParallelize (4096) -> fans out. Each
+    // item must be visited exactly once across all worker partitions.
+    constexpr int kCount = 10000;
+    std::vector<std::atomic<int>> hits(kCount);
+    for (auto &h : hits) {
+        h.store(0);
+    }
+    std::atomic<int> totalVisits{0};
+
+    IRJob::parallelForAutoGrain(kCount, [&](int begin, int end) {
+        for (int i = begin; i < end; ++i) {
+            hits[i].fetch_add(1, std::memory_order_relaxed);
+        }
+        totalVisits.fetch_add(end - begin, std::memory_order_relaxed);
+    });
+
+    EXPECT_EQ(totalVisits.load(), kCount);
+    for (int i = 0; i < kCount; ++i) {
+        EXPECT_EQ(hits[i].load(), 1) << "index " << i << " visited " << hits[i].load() << " times";
+    }
+}
+
+TEST_F(IRJobFixture, AutoGrainBelowThresholdRunsSerialSingleCall) {
+    // Below threshold with a live pool -> serial: one fn(0, total) call
+    // on the calling thread, no fan-out.
+    constexpr int kCount = 100;
+    int calls = 0;
+    int seenBegin = -1;
+    int seenEnd = -1;
+    IRJob::parallelForAutoGrain(kCount, [&](int begin, int end) {
+        ++calls;
+        seenBegin = begin;
+        seenEnd = end;
+    });
+    EXPECT_EQ(calls, 1);
+    EXPECT_EQ(seenBegin, 0);
+    EXPECT_EQ(seenEnd, kCount);
+}
+
+TEST_F(IRJobFixture, AutoGrainZeroAndNegativeAreNoOps) {
+    int calls = 0;
+    IRJob::parallelForAutoGrain(0, [&](int, int) { ++calls; });
+    IRJob::parallelForAutoGrain(-5, [&](int, int) { ++calls; });
+    EXPECT_EQ(calls, 0);
+}
+
+TEST(IRJobAutoGrainNoPool, RunsSerialWithoutManager) {
+    // No pool — even above the parallel threshold the work must run
+    // serially as a single fn(0, total) call rather than asserting.
+    ASSERT_EQ(g_jobManager, nullptr);
+    int calls = 0;
+    int seenEnd = -1;
+    IRJob::parallelForAutoGrain(10000, [&](int begin, int end) {
+        ++calls;
+        seenEnd = end;
+        EXPECT_EQ(begin, 0);
+    });
+    EXPECT_EQ(calls, 1);
+    EXPECT_EQ(seenEnd, 10000);
+}
+
+// ---------------------------------------------------------------------------
+// parallelChunks (#1900) — row-range planner + serial fallback.
+// ---------------------------------------------------------------------------
+
+TEST_F(IRJobFixture, ChunksSingleLargeNodeSplitsAndCoversExactlyOnce) {
+    // One node of 10000 rows: under minNodes (8) but over
+    // minItemsToParallelize (4096) -> the intra-node path splits it into
+    // several row-range chunks, covering every row exactly once.
+    constexpr int kLen = 10000;
+    std::vector<int> nodeLengths{kLen};
+    std::vector<IRJob::RowChunk> scratch;
+    std::vector<std::atomic<int>> hits(kLen);
+    for (auto &h : hits) {
+        h.store(0);
+    }
+    std::atomic<int> chunkCount{0};
+
+    IRJob::parallelChunks(nodeLengths, scratch, [&](int nodeIndex, int rowBegin, int rowEnd) {
+        EXPECT_EQ(nodeIndex, 0);
+        chunkCount.fetch_add(1, std::memory_order_relaxed);
+        for (int i = rowBegin; i < rowEnd; ++i) {
+            hits[i].fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    for (int i = 0; i < kLen; ++i) {
+        EXPECT_EQ(hits[i].load(), 1) << "row " << i << " visited " << hits[i].load() << " times";
+    }
+    EXPECT_GT(chunkCount.load(), 1)
+        << "a dominant node should split into multiple row-range chunks";
+}
+
+TEST_F(IRJobFixture, ChunksManySmallNodesEachStayWhole) {
+    // 10 nodes (>= minNodes 8) of 100 rows each: the inter-node path
+    // fans out, but each node is far below minChunk (2048) so it stays
+    // whole — exactly one chunk per node, full range.
+    constexpr int kNodes = 10;
+    constexpr int kLen = 100;
+    std::vector<int> nodeLengths(kNodes, kLen);
+    std::vector<IRJob::RowChunk> scratch;
+
+    std::mutex mu;
+    std::vector<int> chunksPerNode(kNodes, 0);
+    std::vector<std::vector<int>> rowHits(kNodes, std::vector<int>(kLen, 0));
+
+    IRJob::parallelChunks(nodeLengths, scratch, [&](int nodeIndex, int rowBegin, int rowEnd) {
+        std::lock_guard<std::mutex> lk(mu);
+        ++chunksPerNode[nodeIndex];
+        for (int i = rowBegin; i < rowEnd; ++i) {
+            ++rowHits[nodeIndex][i];
+        }
+    });
+
+    for (int n = 0; n < kNodes; ++n) {
+        EXPECT_EQ(chunksPerNode[n], 1) << "small node " << n << " should stay whole (one chunk)";
+        for (int i = 0; i < kLen; ++i) {
+            EXPECT_EQ(rowHits[n][i], 1) << "node " << n << " row " << i;
+        }
+    }
+}
+
+TEST_F(IRJobFixture, ChunksBelowBothThresholdsRunSerialOneCallPerNode) {
+    // 2 nodes (< minNodes 8) of 100 rows (200 total < minItems 4096) ->
+    // serial: fn(i, 0, len) per node on the calling thread.
+    std::vector<int> nodeLengths{100, 100};
+    std::vector<IRJob::RowChunk> scratch;
+    std::vector<int> chunksPerNode(2, 0);
+    std::vector<std::vector<int>> rowHits(2, std::vector<int>(100, 0));
+
+    IRJob::parallelChunks(nodeLengths, scratch, [&](int nodeIndex, int rowBegin, int rowEnd) {
+        ++chunksPerNode[nodeIndex]; // serial path -> main thread, no lock needed
+        for (int i = rowBegin; i < rowEnd; ++i) {
+            ++rowHits[nodeIndex][i];
+        }
+    });
+
+    for (int n = 0; n < 2; ++n) {
+        EXPECT_EQ(chunksPerNode[n], 1);
+        for (int i = 0; i < 100; ++i) {
+            EXPECT_EQ(rowHits[n][i], 1);
+        }
+    }
+}
+
+TEST_F(IRJobFixture, ChunksEmptyNodeListIsNoOp) {
+    std::vector<int> nodeLengths;
+    std::vector<IRJob::RowChunk> scratch;
+    int calls = 0;
+    IRJob::parallelChunks(nodeLengths, scratch, [&](int, int, int) { ++calls; });
+    EXPECT_EQ(calls, 0);
+}
+
+TEST(IRJobChunksNoPool, RunsSerialWithoutManager) {
+    // No pool — even with a row total above the parallel threshold, the
+    // planner must run serially: one fn(node, 0, len) call per node.
+    ASSERT_EQ(g_jobManager, nullptr);
+    std::vector<int> nodeLengths{10000};
+    std::vector<IRJob::RowChunk> scratch;
+    int calls = 0;
+    int seenEnd = -1;
+    IRJob::parallelChunks(nodeLengths, scratch, [&](int nodeIndex, int rowBegin, int rowEnd) {
+        ++calls;
+        seenEnd = rowEnd;
+        EXPECT_EQ(nodeIndex, 0);
+        EXPECT_EQ(rowBegin, 0);
+    });
+    EXPECT_EQ(calls, 1);
+    EXPECT_EQ(seenEnd, 10000);
 }


### PR DESCRIPTION
## Summary
- **Phase 1** — new `IRJob::parallelForAutoGrain` (flat auto-grain + serial fallback) and `IRJob::parallelChunks` (row-range planner: splits one dominant node across workers, keeps small nodes whole) alongside `parallelFor`. Tunables in `IRJob::ParallelTuning`; defaults reproduce the original PROPAGATE_TRANSFORM constants (≥8 nodes OR ≥4096 rows → parallel; ≥2048-row chunks; 2 tasks/worker), so a default-constructed tuning is bit-identical to the old inline dispatch.
- **Phase 2** — PROPAGATE_TRANSFORM `beginTick` rewritten onto `parallelChunks`; the inline `chunks_` / `targetTasks` / threshold arithmetic is gone. The system mirrors per-node row counts into a reused buffer and hands them to the planner (scratch stays owned by the system so planning is allocation-free on the hot path).
- **Phase 3** — both `system_manager.cpp` `parallelFor` sites evaluated and annotated for why they stay raw: the per-system path keeps its author-chosen `grainSize`; the multi-system group dispatch fans out *systems* at `grain=1` (auto-grain would collapse a small group onto one worker). The `grainSize`-unset auto-grain win is a scoped follow-up per the issue.
- Docs: `engine/job/CLAUDE.md` (new helpers + entry-point list), `engine/prefabs/irreden/update/CLAUDE.md`, and `docs/perf-reports/threading_propagate_transform.md` now point at the shared helper instead of per-system chunk math.

## Test plan
- [x] `IRShapeDebug --auto-screenshot` **28/28 byte-identical to origin/master** (captured both refs, `cmp` each shot — 0 diffs).
- [x] 9 new IRJob unit tests pass: serial fallback (no pool / below threshold), single-large-node row split, many-small-node node-granularity, empty/zero/negative no-op.
- [x] 21 `propagate_transform` correctness tests pass; full `IrredenEngineTest` builds.
- [x] `fleet-build --target IRShapeDebug` + `IrredenEngineTest` clean on macOS/Metal post-format.
- [ ] Linux/GL cross-host smoke (per the `needs-linux-smoke` lane).

Pure consolidation / no-behavior-change refactor; the #1804 ~47% UPDATE-pipeline win is retained by construction (dispatch arithmetic unchanged, no new per-frame allocation).

Closes #1900

🤖 Generated with [Claude Code](https://claude.com/claude-code)