### PR TITLE
fleet: don't treat a closing verb quoted in a code span as scope-shipped evidence (layer 5)

### DIFF
--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -91,7 +91,8 @@ _PLAN_DOC_TITLE = re.compile(
 )
 
 
-# Markdown code spans (layer 4 → layer 5). A closing verb inside a code span is
+# Markdown code spans — layer 5 (strips before the closing-verb scan; layer 4
+# stopped title refs, not body code spans). A closing verb inside a code span is
 # literal text being quoted — a plan PR documenting the ``Closes #N`` its future
 # impl PR will write — not an action. Fenced ``` blocks are stripped first (so an
 # inline backtick inside a fenced block can't desync the inline pass), then

--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -35,13 +35,27 @@ incidental match have to be rejected:
    body closing-verb says so (a doc PR whose deliverable genuinely IS the doc
    change still ships via ``Closes #N`` in the body).
 
+5. Closing verb inside a code span (#1824 ← #1854). Layer 4 stops a plan-doc
+   *title* from shipping, but a plan PR's *body* routinely quotes the closing
+   verb the future implementation PR will use: "the structured plan for #1824
+   (planning step output; impl PR will carry the code + ``Closes #1824``)" and
+   "Plan doc for #1824 — does not close the issue (the implementation PR
+   will)". That ``Closes #1824`` sits in an inline code span — it is *showing*
+   the literal text the impl PR will write, not performing a close — so the
+   layer-4 title guard fires while the body closing-verb check still matches.
+   Markdown code spans (fenced ```` ``` ```` blocks and inline `` `…` `` spans)
+   are therefore stripped from the body before the closing-verb scan: a verb
+   quoted in code is documentation, never an action. A genuine ship writes
+   ``Closes #N`` as prose, never in backticks, so the strip costs no true
+   positive.
+
 So a body ``#N`` counts only when a closing-action verb sits directly before it
-(``Closes #N``, ``fixes (#N)``, ``supersedes #N``). A ``#N`` in the *title* is
-trusted as-is — PRs in this repo are named ``#N: <desc>`` after the issue they
-implement — EXCEPT (layer 3) when it is a range endpoint, or (layer 4) when the
-title is a plan/design-doc title: both shapes name issues they enumerate or
-plan without implementing. Every other observed false positive came from the
-body.
+in prose (``Closes #N``, ``fixes (#N)``, ``supersedes #N``) — code spans are
+stripped first (layer 5), so a verb quoted in backticks does not count. A
+``#N`` in the *title* is trusted as-is — PRs in this repo are named
+``#N: <desc>`` after the issue they implement — EXCEPT (layer 3) when it is a
+range endpoint, or (layer 4) when the title is a plan/design-doc title: both
+shapes name issues they enumerate or plan without implementing.
 """
 import re
 
@@ -77,6 +91,19 @@ _PLAN_DOC_TITLE = re.compile(
 )
 
 
+# Markdown code spans (layer 4 → layer 5). A closing verb inside a code span is
+# literal text being quoted — a plan PR documenting the ``Closes #N`` its future
+# impl PR will write — not an action. Fenced ``` blocks are stripped first (so an
+# inline backtick inside a fenced block can't desync the inline pass), then
+# inline `…` spans. Both collapse to a space so adjacent words don't fuse.
+_FENCED_CODE = re.compile(r'```.*?```', re.DOTALL)
+_INLINE_CODE = re.compile(r'`[^`]*`')
+
+
+def _strip_code_spans(s):
+    return _INLINE_CODE.sub(' ', _FENCED_CODE.sub(' ', s))
+
+
 def _ref_pattern(n):
     # ``(?<!\w)`` rejects ``abc#1300``; ``(?!\d)`` stops ``#13000`` / ``#21300``
     # from satisfying ``n=1300``. The two range guards reject a ``#N`` that is an
@@ -100,7 +127,10 @@ def pr_references_issue(title, body, n):
     (``docs: plan …`` / ``docs/design: …`` / ``docs: design …`` — a PR that plans/designs ``n``,
     never ships it). Body: ``#n`` counts only when immediately preceded by a
     closing-action verb, and likewise never as a range endpoint. A bare body
-    mention ("downstream #n", "pre-existing #n", "Refs #n") is rejected.
+    mention ("downstream #n", "pre-existing #n", "Refs #n") is rejected, as is
+    a closing verb quoted inside a markdown code span (layer 5): code spans are
+    stripped before the body scan so ``... + `Closes #n` `` in a plan PR's body
+    does not read as a ship.
     """
     if not n:
         return False
@@ -119,7 +149,7 @@ def pr_references_issue(title, body, n):
         r'\b(?:' + _CLOSING_VERB + r')\b' + _VERB_TO_REF_GAP + ref,
         re.IGNORECASE,
     )
-    return bool(body_re.search(body or ''))
+    return bool(body_re.search(_strip_code_spans(body or '')))
 
 
 def select_shipped_pr(prs, n):

--- a/scripts/fleet/tests/test_scope_shipped_reference.py
+++ b/scripts/fleet/tests/test_scope_shipped_reference.py
@@ -208,6 +208,37 @@ class PrReferencesIssue(unittest.TestCase):
         self.assertTrue(pr_references_issue(
             "docs: #1679 cmake preset -S flag", "", 1679))
 
+    # --- closing verb inside a code span (#1824 ← #1854 — layer 5) ---
+
+    def test_closing_verb_in_inline_code_span_rejected(self):
+        # #1824 ← #1854: a plan PR's body quotes the `Closes #N` its FUTURE impl
+        # PR will write. Layer 4 suppresses the plan-doc title; layer 5 must stop
+        # the backtick-quoted closing verb in the body from shipping it.
+        body = ("Adds `.fleet/plans/issue-1824.md`: the structured plan for "
+                "#1824 (planning step output; impl PR will carry the code + "
+                "`Closes #1824`).\n\nPlan doc for #1824 — does not close the "
+                "issue (the implementation PR will).")
+        self.assertFalse(pr_references_issue(
+            "docs: plan #1824 — fleet-rebase fork-point inherited-prefix drop",
+            body, 1824))
+
+    def test_closing_verb_in_fenced_block_rejected(self):
+        # A `Closes #N` shown inside a fenced example block is documentation.
+        body = "Future impl PR body:\n```\nCloses #1300\n```\nThis PR only plans."
+        self.assertFalse(pr_references_issue("title", body, 1300))
+
+    def test_prose_close_with_adjacent_code_span_still_ships(self):
+        # Regression: stripping code spans must not drop a genuine prose close
+        # that merely sits near unrelated inline code.
+        self.assertTrue(pr_references_issue(
+            "title", "Closes #1300. Verified via `fleet-run IRShapeDebug`.", 1300))
+
+    def test_code_span_strip_collapses_to_space_not_empty(self):
+        # A code span between letters must collapse to a SPACE, never empty, so
+        # it can't fuse into a spurious closing verb: "clo`x`ses #1300" must not
+        # become "closes #1300".
+        self.assertFalse(pr_references_issue("title", "clo`x`ses #1300", 1300))
+
 
 class SelectShippedPr(unittest.TestCase):
     def test_empty_candidates(self):
@@ -262,6 +293,15 @@ class SelectShippedPr(unittest.TestCase):
         pr = _pr(1809, "docs: plan rotation-profiling task (#1807)",
                  "Plan doc committed for #1807.")
         self.assertIsNone(select_shipped_pr([pr], 1807))
+
+    def test_real_world_1824_planned_not_shipped_by_1854(self):
+        # #1824 ← #1854: plan-doc title (layer 4) AND a body that quotes the
+        # `Closes #1824` the future impl PR will write (layer 5). Ships nothing.
+        pr = _pr(1854,
+                 "docs: plan #1824 — fleet-rebase fork-point inherited-prefix drop",
+                 "Adds `.fleet/plans/issue-1824.md`: the structured plan for "
+                 "#1824 (impl PR will carry the code + `Closes #1824`).")
+        self.assertIsNone(select_shipped_pr([pr], 1824))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
`fleet-queue-ingest`'s scope-shipped pre-flight (`scripts/fleet/fleet_scope_shipped.py`) mislabels a **plan PR** as having shipped the issue it plans, when the plan's body *quotes* the `Closes #N` that the future implementation PR will write.

Real case found while auditing stale `fleet:scope-shipped` tickets: **#1824 ← PR #1854** (`docs: plan #1824 — fleet-rebase fork-point inherited-prefix drop`). Layer 4 correctly suppresses the plan-doc **title**, but #1854's **body** says:

> the structured plan for #1824 (planning step output; impl PR will carry the code + `` `Closes #1824` ``)
> Plan doc for #1824 — does not close the issue (the implementation PR will).

The body closing-verb check matched that backticked, forward-referenced `Closes #1824`, so the predicate returned `True` and the issue was wrongly parked as scope-shipped — **blocking a planned, approved task from the queue.** (Its sibling #1817 was the same false-positive *class* via a plan-doc title, already fixed by layer 4 in #1835; #1824 is the body-quote variant that still slipped through.)

## Fix — layer 5
Strip markdown code spans (fenced ```` ``` ```` blocks + inline `` `…` ``) from the body **before** the closing-verb scan. A verb quoted in code is documentation, not an action; a genuine ship writes `Closes #N` as prose, so the strip costs no true positive. Spans collapse to a **space** (not empty) so a span between letters can't fuse into a spurious verb (`` clo`x`ses `` is not `closes`).

## Verification
- Predicate now returns `False` against the **live #1854** body for #1824 (was `True`) — confirmed end-to-end, not just a fixture.
- New regression tests: inline-code-span reject, fenced-block reject, prose-close-near-code still ships, collapse-to-space (no verb fusion), and a real-world `select_shipped_pr(#1854) → None` case.
- `python3 -m unittest test_scope_shipped_reference` → **47 pass**; `test_queue_manager_projection` → **30 pass**.

## Related data cleanup (done out-of-band, not in this PR)
- #1824 — `fleet:scope-shipped` removed, re-classed `fleet:sonnet` for re-queue.
- #1817 — stale layer-4 leftover; same cleanup.
- #1739 — was a *genuine* ship (PR #1748 used `Refs` not `Closes`); closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)