### PR TITLE
audio: Lua-observable hook for outbound MIDI (#1869)

### DIFF
--- a/engine/audio/CLAUDE.md
+++ b/engine/audio/CLAUDE.md
@@ -13,7 +13,11 @@ functions:
 - `getAudioManager()`, `getMidiIn()`, `getMidiOut()`, `getAudio()`.
 - MIDI device enumeration: list ports, open by index or substring.
 - MIDI query: per-channel, per-frame CC/note-on/note-off queues.
-- MIDI send: `sendNoteOn`, `sendNoteOff`, `sendCC`.
+- MIDI send: `sendMidiMessage(message)` (default port) / `sendMidiMessage(portIndex,
+  message)` — raw RtMidi bytes. (There are no `sendNoteOn`/`sendNoteOff`/`sendCC`
+  helpers; build the `C_MidiMessage` and call `sendMidiMessage`.)
+- MIDI send observer: `setOutboundMidiObserver(cb)` / `clearOutboundMidiObserver()`
+  — see "Outbound MIDI observer" below.
 - Audio input: open/start/stop a capture stream, register a float-sample
   callback.
 - File playback: `playSound` / `playMusic` / `playSoundAt`, `stopSound`,
@@ -103,6 +107,41 @@ Lua (`scripts/audio_demo.lua`).
   fallback patterns for common devices (UMC1820, Focusrite, MPKmini2,
   OP-1). Edit `midi_in.cpp` / `midi_out.cpp` to add a new hardware match.
   Opening an already-open port is a no-op that returns the existing handle.
+
+## Outbound MIDI observer (#1869)
+
+`IRAudio::sendMidiMessage` is the **sole outbound choke point** — every
+prefab path (`CONTACT_MIDI_TRIGGER`, `MIDI_SEQUENCE_OUT`,
+`PERIODIC_IDLE_MIDI_TRIGGER`, the `C_MidiNote::onDestroy` NOTE_OFF) routes
+through it; nothing calls `getMidiOut().sendMessage()` directly. So a single
+observer registered there sees **all** outbound traffic, including C++-emitted
+messages a Lua-only monitor would otherwise miss.
+
+```cpp
+IRAudio::setOutboundMidiObserver(
+    [](const IRComponents::C_MidiMessage &message, int portIndex) { /* ... */ }
+);
+IRAudio::clearOutboundMidiObserver();
+```
+
+- **Single observer, last-registration-wins** — matches the inbound
+  `AudioInputCallback` precedent; multiplex in the handler if you need fan-out.
+- **Fires unconditionally of an open port.** The observer runs even when no
+  hardware output port is open (headless monitor); the actual hardware send
+  no-ops below it. It fires *before* the hardware send.
+- **Main thread, synchronous.** `sendMidiMessage` runs on the UPDATE pipeline
+  (main thread), unlike the driver-thread inbound `MidiIn` callback. Don't move
+  the send to a worker thread.
+- **Storage + lifetime.** The callback is stored on `AudioManager`
+  (`m_outboundMidiObserver`), not a TU-local static. A captured `sol::function`
+  must outlive every send: `World` declares `m_audioManager` after `m_lua` so
+  it destructs first, dropping the function while the `sol::state` is still
+  alive. `clearOutboundMidiObserver()` is the explicit escape hatch.
+- **Lua surface.** `IRAudio.onMidiSent(fn)` registers `fn(status, channel,
+  data1, data2, portIndex)` (integers; `status` matches `IRAudio.MidiStatus.*`);
+  `IRAudio.clearMidiObserver()` detaches. A Lua handler error is logged and
+  swallowed so it can't abort the C++ send loop (bound by `bindLuaDrivenEcs()`
+  in `lua_audio_bindings.hpp`).
 
 ## Audio capture model
 

--- a/engine/audio/include/irreden/audio/audio_manager.hpp
+++ b/engine/audio/include/irreden/audio/audio_manager.hpp
@@ -43,8 +43,14 @@ class AudioManager {
     inline void clearOutboundMidiObserver() {
         m_outboundMidiObserver = nullptr;
     }
-    inline const OutboundMidiObserver &getOutboundMidiObserver() const {
-        return m_outboundMidiObserver;
+    // Fire the registered observer (no-op if none). AudioManager fires its own
+    // observer rather than exposing the stored std::function, mirroring how
+    // Audio fires m_inputCallback internally — keeps the callable encapsulated.
+    inline void
+    fireOutboundMidiObserver(const IRComponents::C_MidiMessage &message, int portIndex) const {
+        if (m_outboundMidiObserver) {
+            m_outboundMidiObserver(message, portIndex);
+        }
     }
 
   private:

--- a/engine/audio/include/irreden/audio/audio_manager.hpp
+++ b/engine/audio/include/irreden/audio/audio_manager.hpp
@@ -7,10 +7,20 @@
 #include <irreden/audio/midi_in.hpp>
 #include <irreden/audio/midi_out.hpp>
 
+#include <irreden/audio/components/component_midi_message.hpp>
+
+#include <functional>
+#include <utility>
+
 namespace IRAudio {
 
 class AudioManager {
   public:
+    // Storage type for the outbound-MIDI observer; mirrors the namespace-scoped
+    // IRAudio::OutboundMidiCallback alias in ir_audio.hpp (same underlying
+    // std::function), the same split the inbound Audio::AudioInputCallback uses.
+    using OutboundMidiObserver = std::function<void(const IRComponents::C_MidiMessage &, int)>;
+
     AudioManager();
     ~AudioManager();
 
@@ -27,11 +37,27 @@ class AudioManager {
         return m_audioPlayback;
     }
 
+    inline void setOutboundMidiObserver(OutboundMidiObserver observer) {
+        m_outboundMidiObserver = std::move(observer);
+    }
+    inline void clearOutboundMidiObserver() {
+        m_outboundMidiObserver = nullptr;
+    }
+    inline const OutboundMidiObserver &getOutboundMidiObserver() const {
+        return m_outboundMidiObserver;
+    }
+
   private:
     Audio m_audio;
     MidiIn m_midiIn;
     MidiOut m_midiOut;
     AudioPlayback m_audioPlayback;
+    // Single observer fired on every outbound sendMidiMessage. Lives for this
+    // AudioManager's lifetime; a captured sol::function inside it must outlive
+    // any send, so the owning World declares m_audioManager AFTER m_lua (it
+    // then destructs first, dropping the function while the sol::state is still
+    // alive). See ir_audio.cpp / engine/audio/CLAUDE.md.
+    OutboundMidiObserver m_outboundMidiObserver;
 };
 
 } // namespace IRAudio

--- a/engine/audio/include/irreden/ir_audio.hpp
+++ b/engine/audio/include/irreden/ir_audio.hpp
@@ -54,6 +54,24 @@ void sendMidiMessage(const std::vector<unsigned char> &message);
 /// if the port isn't open.
 void sendMidiMessage(int portIndex, const std::vector<unsigned char> &message);
 
+/// Outbound-MIDI observer callback: `void(message, portIndex)`. Fired for every
+/// message passed to either @ref sendMidiMessage overload — including ones the
+/// C++ ECS audio path emits (`CONTACT_MIDI_TRIGGER` / `MIDI_SEQUENCE_OUT` /
+/// `PERIODIC_IDLE_MIDI_TRIGGER`, and the `C_MidiNote::onDestroy` NOTE_OFF) — so
+/// a monitor sees ALL outbound traffic, not just what it sent itself. It fires
+/// synchronously on the main thread (the UPDATE pipeline; unlike the driver-
+/// thread inbound `AudioInputCallback`) and **unconditionally of whether a
+/// hardware output port is open**, for the headless-monitor case. `portIndex`
+/// is -1 for the default-port overload.
+using OutboundMidiCallback =
+    std::function<void(const IRComponents::C_MidiMessage &message, int portIndex)>;
+/// Registers @p callback as the single outbound-MIDI observer
+/// (last-registration-wins). Pass a null callback or call @ref
+/// clearOutboundMidiObserver to remove it.
+void setOutboundMidiObserver(OutboundMidiCallback callback);
+/// Removes the outbound-MIDI observer if one is set.
+void clearOutboundMidiObserver();
+
 /// Returns the CC value for @p ccMessage on @p channel received this frame
 /// across all open input ports, or @ref kCCFalse if no CC message arrived.
 CCData checkCCMessage(int channel, CCMessage ccMessage);

--- a/engine/audio/src/ir_audio.cpp
+++ b/engine/audio/src/ir_audio.cpp
@@ -48,12 +48,49 @@ int openPortMidiOut(const std::string &deviceName) {
     return getAudioManager().getMidiOut().openPort(deviceName);
 }
 
+namespace {
+
+// Rebuilds a C_MidiMessage from the raw RtMidi wire bytes and fires the
+// outbound observer if one is registered. Shared by both sendMidiMessage
+// overloads so the byte unpack lives in one place. Each index is guarded:
+// 1-byte system real-time bytes (e.g. clock 0xF8) and 2-byte messages
+// (PROGRAM_CHANGE / CHANNEL_PRESSURE) must not read past the vector.
+// portIndex is -1 for the default-port send.
+void notifyOutboundObserver(
+    AudioManager &manager, const std::vector<unsigned char> &message, int portIndex
+) {
+    const AudioManager::OutboundMidiObserver &observer = manager.getOutboundMidiObserver();
+    if (!observer) {
+        return;
+    }
+    const unsigned char status = message.empty() ? 0 : message[0];
+    const unsigned char data1 = message.size() > 1 ? message[1] : 0;
+    const unsigned char data2 = message.size() > 2 ? message[2] : 0;
+    observer(IRComponents::C_MidiMessage{status, data1, data2}, portIndex);
+}
+
+} // namespace
+
 void sendMidiMessage(const std::vector<unsigned char> &message) {
-    getAudioManager().getMidiOut().sendMessage(message);
+    AudioManager &manager = getAudioManager();
+    // Fire before the hardware send so a headless monitor observes the message
+    // even with no output port open (the send below then no-ops).
+    notifyOutboundObserver(manager, message, -1);
+    manager.getMidiOut().sendMessage(message);
 }
 
 void sendMidiMessage(int portIndex, const std::vector<unsigned char> &message) {
-    getAudioManager().getMidiOut().sendMessage(portIndex, message);
+    AudioManager &manager = getAudioManager();
+    notifyOutboundObserver(manager, message, portIndex);
+    manager.getMidiOut().sendMessage(portIndex, message);
+}
+
+void setOutboundMidiObserver(OutboundMidiCallback callback) {
+    getAudioManager().setOutboundMidiObserver(std::move(callback));
+}
+
+void clearOutboundMidiObserver() {
+    getAudioManager().clearOutboundMidiObserver();
 }
 
 CCData checkCCMessage(int channel, CCMessage ccMessage) {

--- a/engine/audio/src/ir_audio.cpp
+++ b/engine/audio/src/ir_audio.cpp
@@ -59,14 +59,10 @@ namespace {
 void notifyOutboundObserver(
     AudioManager &manager, const std::vector<unsigned char> &message, int portIndex
 ) {
-    const AudioManager::OutboundMidiObserver &observer = manager.getOutboundMidiObserver();
-    if (!observer) {
-        return;
-    }
     const unsigned char status = message.empty() ? 0 : message[0];
     const unsigned char data1 = message.size() > 1 ? message[1] : 0;
     const unsigned char data2 = message.size() > 2 ? message[2] : 0;
-    observer(IRComponents::C_MidiMessage{status, data1, data2}, portIndex);
+    manager.fireOutboundMidiObserver(IRComponents::C_MidiMessage{status, data1, data2}, portIndex);
 }
 
 } // namespace

--- a/engine/script/include/irreden/script/lua_audio_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_audio_bindings.hpp
@@ -2,6 +2,7 @@
 #define LUA_AUDIO_BINDINGS_H
 
 #include <irreden/ir_audio.hpp>
+#include <irreden/ir_profile.hpp>
 #include <irreden/script/ir_script_utils.hpp>
 #include <irreden/script/lua_script.hpp>
 
@@ -9,6 +10,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace IRScript::detail {
 
@@ -104,6 +106,48 @@ inline void bindAudioApi(LuaScript &script) {
     audio["setListenerPosition"] = [](sol::object position) {
         IRAudio::setListenerPosition(vec3FromLua(position));
     };
+
+    // Outbound-MIDI observer (engine #1869). A Lua monitor sees EVERY outbound
+    // message, including ones the C++ ECS audio path emits — not just what Lua
+    // sent. `IRAudio.MidiStatus.*` is the message-type byte as an integer table
+    // (the cpp-lua-enums.md convention) so a handler compares the status arg
+    // against named values, not magic numbers.
+    sol::table midiStatus = lua.create_table();
+#define IR_BIND_MIDI_STATUS(name)                                                                  \
+    midiStatus[#name] = static_cast<lua_Integer>(IRAudio::kMidiStatus_##name)
+    IR_BIND_MIDI_STATUS(NOTE_OFF);
+    IR_BIND_MIDI_STATUS(NOTE_ON);
+    IR_BIND_MIDI_STATUS(POLYPHONIC_KEY_PRESSURE);
+    IR_BIND_MIDI_STATUS(CONTROL_CHANGE);
+    IR_BIND_MIDI_STATUS(PROGRAM_CHANGE);
+    IR_BIND_MIDI_STATUS(CHANNEL_PRESSURE);
+    IR_BIND_MIDI_STATUS(PITCH_BEND);
+#undef IR_BIND_MIDI_STATUS
+    audio["MidiStatus"] = midiStatus;
+
+    // IRAudio.onMidiSent(fn): fn(status, channel, data1, data2, portIndex) — all
+    // integers. `status` is the message-type byte (matches IRAudio.MidiStatus.*);
+    // `channel` is 0-15; `portIndex` is -1 for the default-port send. Last
+    // registration wins (single observer, like the inbound AudioInputCallback);
+    // multiplex in Lua if you need fan-out. A handler error is logged and
+    // swallowed so one bad Lua callback can't abort the C++ send loop.
+    audio["onMidiSent"] = [](sol::protected_function fn) {
+        IRAudio::setOutboundMidiObserver(
+            [fn = std::move(fn)](const IRComponents::C_MidiMessage &message, int portIndex) {
+                sol::protected_function_result result =
+                    fn(static_cast<lua_Integer>(message.getStatusBits()),
+                       static_cast<lua_Integer>(message.getChannelBits()),
+                       static_cast<lua_Integer>(message.data1_),
+                       static_cast<lua_Integer>(message.data2_),
+                       static_cast<lua_Integer>(portIndex));
+                if (!result.valid()) {
+                    sol::error err = result;
+                    IRE_LOG_ERROR("IRAudio.onMidiSent handler error: {}", err.what());
+                }
+            }
+        );
+    };
+    audio["clearMidiObserver"] = []() { IRAudio::clearOutboundMidiObserver(); };
 }
 
 } // namespace IRScript::detail

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(IrredenEngineTest
   render/sprite_animation_test.cpp
   render/sprite_components_test.cpp
   render/sprite_render_test.cpp
+  script/lua_audio_midi_observer_test.cpp
   script/lua_collision_bindings_test.cpp
   script/lua_command_test.cpp
   script/lua_component_codegen_test.cpp

--- a/test/script/lua_audio_midi_observer_test.cpp
+++ b/test/script/lua_audio_midi_observer_test.cpp
@@ -1,0 +1,186 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_audio.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/audio/audio_manager.hpp>
+#include <irreden/script/lua_script.hpp>
+
+#include <sol/sol.hpp>
+
+#include <vector>
+
+// Lua-observable outbound MIDI hook (engine #1869). The observer is registered
+// at the C++ `IRAudio::sendMidiMessage` choke point, so a Lua handler sees ALL
+// outbound traffic — including messages the C++ ECS audio path emits, not just
+// what Lua sent. These cases drive sends through the C++ free function (the
+// real choke point) and assert the Lua handler captured the reconciled fields.
+// No MIDI device is opened: the observer must fire regardless (headless monitor).
+
+namespace {
+
+using IRAudio::buildMidiStatus;
+using IRAudio::kMidiStatus_CONTROL_CHANGE;
+using IRAudio::kMidiStatus_NOTE_ON;
+using IRAudio::kMidiStatus_PROGRAM_CHANGE;
+
+// Owns an AudioManager (its ctor sets IRAudio::g_audioManager, so the
+// sendMidiMessage free functions resolve) plus a LuaScript with the IRAudio
+// bindings. m_audio_manager is declared LAST so it destructs FIRST — dropping
+// any captured sol::function while the sol::state is still alive (the same
+// member-order contract World uses; see ir_audio.cpp).
+class LuaAudioMidiObserverTest : public ::testing::Test {
+  protected:
+    LuaAudioMidiObserverTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_system_manager{}
+        , m_audio_manager{} {
+        m_lua.bindLuaDrivenEcs();
+    }
+
+    ~LuaAudioMidiObserverTest() override {
+        // Explicit even though member order already guarantees safety: clear the
+        // observer (a captured sol::function) before the sol::state tears down.
+        IRAudio::clearOutboundMidiObserver();
+    }
+
+    // Registers a Lua observer that records the last message into `captured`
+    // and counts invocations in `callCount`.
+    void registerCapturingObserver() {
+        auto result = m_lua.lua().safe_script(
+            R"(
+                captured = nil
+                callCount = 0
+                IRAudio.onMidiSent(function(status, channel, data1, data2, port)
+                    callCount = callCount + 1
+                    captured = {
+                        status = status, channel = channel,
+                        data1 = data1, data2 = data2, port = port,
+                    }
+                end)
+            )",
+            sol::script_pass_on_error
+        );
+        ASSERT_TRUE(result.valid());
+    }
+
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRSystem::SystemManager m_system_manager;
+    IRAudio::AudioManager m_audio_manager;
+};
+
+TEST_F(LuaAudioMidiObserverTest, OnMidiSentAndMidiStatusBound) {
+    auto isFunction = [&](const char *expr) {
+        auto r = m_lua.lua().safe_script(
+            std::string("return type(") + expr + ") == 'function'", sol::script_pass_on_error
+        );
+        return r.valid() && r.get<bool>();
+    };
+    EXPECT_TRUE(isFunction("IRAudio.onMidiSent"));
+    EXPECT_TRUE(isFunction("IRAudio.clearMidiObserver"));
+    // The status table mirrors the kMidiStatus_* constants so a handler compares
+    // against named values, not magic bytes.
+    EXPECT_EQ(m_lua.lua()["IRAudio"]["MidiStatus"]["NOTE_ON"].get<int>(), kMidiStatus_NOTE_ON);
+    EXPECT_EQ(
+        m_lua.lua()["IRAudio"]["MidiStatus"]["CONTROL_CHANGE"].get<int>(), kMidiStatus_CONTROL_CHANGE
+    );
+    EXPECT_EQ(
+        m_lua.lua()["IRAudio"]["MidiStatus"]["PITCH_BEND"].get<int>(),
+        static_cast<int>(IRAudio::kMidiStatus_PITCH_BEND)
+    );
+}
+
+TEST_F(LuaAudioMidiObserverTest, CapturesNoteOnDrivenThroughCppPath) {
+    registerCapturingObserver();
+
+    // NOTE_ON, channel 5, note 60, velocity 100 — emitted through the C++ choke
+    // point exactly as a prefab audio system would.
+    const std::vector<unsigned char> message{buildMidiStatus(kMidiStatus_NOTE_ON, 5), 60, 100};
+    IRAudio::sendMidiMessage(message);
+
+    sol::table captured = m_lua.lua()["captured"];
+    ASSERT_TRUE(captured.valid());
+    EXPECT_EQ(captured["status"].get<int>(), kMidiStatus_NOTE_ON); // type byte, channel stripped
+    EXPECT_EQ(captured["channel"].get<int>(), 5);
+    EXPECT_EQ(captured["data1"].get<int>(), 60);
+    EXPECT_EQ(captured["data2"].get<int>(), 100);
+    EXPECT_EQ(captured["port"].get<int>(), -1); // default-port overload
+    EXPECT_EQ(m_lua.lua()["callCount"].get<int>(), 1);
+}
+
+TEST_F(LuaAudioMidiObserverTest, FiresWithNoOutputPortOpen) {
+    registerCapturingObserver();
+    ASSERT_TRUE(IRAudio::midiOutOpenPorts().empty()); // headless: no device
+
+    IRAudio::sendMidiMessage({buildMidiStatus(kMidiStatus_CONTROL_CHANGE, 0), 7, 99});
+
+    // The observer fires even though the hardware send no-ops — the whole point
+    // of the headless-monitor use case.
+    EXPECT_EQ(m_lua.lua()["callCount"].get<int>(), 1);
+    sol::table captured = m_lua.lua()["captured"];
+    ASSERT_TRUE(captured.valid());
+    EXPECT_EQ(captured["status"].get<int>(), kMidiStatus_CONTROL_CHANGE);
+    EXPECT_EQ(captured["data1"].get<int>(), 7);
+    EXPECT_EQ(captured["data2"].get<int>(), 99);
+}
+
+TEST_F(LuaAudioMidiObserverTest, PortIndexOverloadForwardsPort) {
+    registerCapturingObserver();
+
+    // The port-targeted overload forwards the port even when it isn't open.
+    IRAudio::sendMidiMessage(7, {buildMidiStatus(kMidiStatus_NOTE_ON, 2), 64, 80});
+
+    sol::table captured = m_lua.lua()["captured"];
+    ASSERT_TRUE(captured.valid());
+    EXPECT_EQ(captured["port"].get<int>(), 7);
+    EXPECT_EQ(captured["channel"].get<int>(), 2);
+}
+
+TEST_F(LuaAudioMidiObserverTest, TwoByteMessageLeavesData2Zero) {
+    registerCapturingObserver();
+
+    // PROGRAM_CHANGE serializes to 2 bytes; data2 must reconstruct to 0 without
+    // reading past the vector.
+    IRAudio::sendMidiMessage({buildMidiStatus(kMidiStatus_PROGRAM_CHANGE, 3), 42});
+
+    sol::table captured = m_lua.lua()["captured"];
+    ASSERT_TRUE(captured.valid());
+    EXPECT_EQ(captured["status"].get<int>(), static_cast<int>(kMidiStatus_PROGRAM_CHANGE));
+    EXPECT_EQ(captured["data1"].get<int>(), 42);
+    EXPECT_EQ(captured["data2"].get<int>(), 0);
+}
+
+TEST_F(LuaAudioMidiObserverTest, ClearMidiObserverStopsCallbacks) {
+    registerCapturingObserver();
+    IRAudio::sendMidiMessage({buildMidiStatus(kMidiStatus_NOTE_ON, 0), 60, 100});
+    ASSERT_EQ(m_lua.lua()["callCount"].get<int>(), 1);
+
+    auto cleared = m_lua.lua().safe_script("IRAudio.clearMidiObserver()", sol::script_pass_on_error);
+    ASSERT_TRUE(cleared.valid());
+
+    IRAudio::sendMidiMessage({buildMidiStatus(kMidiStatus_NOTE_ON, 0), 62, 100});
+    EXPECT_EQ(m_lua.lua()["callCount"].get<int>(), 1); // no further callbacks
+}
+
+TEST_F(LuaAudioMidiObserverTest, LastRegistrationWins) {
+    registerCapturingObserver();
+    // A second registration replaces the first (single observer, like the
+    // inbound AudioInputCallback).
+    auto result = m_lua.lua().safe_script(
+        R"(
+            secondCount = 0
+            IRAudio.onMidiSent(function() secondCount = secondCount + 1 end)
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid());
+
+    IRAudio::sendMidiMessage({buildMidiStatus(kMidiStatus_NOTE_ON, 0), 60, 100});
+
+    EXPECT_EQ(m_lua.lua()["callCount"].get<int>(), 0);  // first observer detached
+    EXPECT_EQ(m_lua.lua()["secondCount"].get<int>(), 1); // second observer fires
+}
+
+} // namespace


### PR DESCRIPTION
Claiming issue. Work in progress.

Adds a single C++ observer at the `IRAudio::sendMidiMessage` outbound choke point so a Lua (or C++) monitor sees ALL outbound MIDI — including messages emitted by the C++ ECS audio path (`CONTACT_MIDI_TRIGGER` / `MIDI_SEQUENCE_OUT` / `PERIODIC_IDLE_MIDI_TRIGGER`, and the `C_MidiNote::onDestroy` NOTE_OFF), not just what Lua sent itself.

Closes #1869