### PR TITLE
fleet: blocked-by parser honors the "(none — in parallel with #N)" sibling idiom

### DIFF
--- a/scripts/fleet/fleet_blocked_by.py
+++ b/scripts/fleet/fleet_blocked_by.py
@@ -76,6 +76,55 @@ _REF_RE = re.compile(r'(?:[A-Za-z0-9][\w.-]*/)?([A-Za-z0-9][\w.-]*)?#(\d+)')
 _REF_NAME_TO_SLUG = {'irredenengine': 'jakildev/IrredenEngine',
                      'irreden': 'jakildev/irreden'}
 
+# See-also / parallel-sibling qualifiers (#1910): a `#N` introduced by one of
+# these inside a leading-`none` value is a cross-reference, not a blocker — the
+# legitimate "(none — runs in parallel with #N)" idiom. Matched per-ref against
+# the clause leading up to the ref so a sibling note can't smuggle a real
+# dependency past the gate (see _ref_is_see_also).
+_SEE_ALSO_RE = re.compile(
+    r'\b(?:see[\s-]+also|related(?:\s+to)?|in\s+parallel(?:\s+with)?|'
+    r'parallel(?:\s+(?:with|to))?|sibling(?:\s+of)?|alongside|'
+    r'concurrent(?:ly)?(?:\s+with)?|cf\.?)\b',
+    re.IGNORECASE,
+)
+# Blocker verbs (#1910): a `#N` introduced by one of these is a real dependency
+# even inside a leading-`none` value — this is what keeps the anti-evasion guard
+# intact for "none, actually blocked by #5".
+_BLOCKER_VERB_RE = re.compile(
+    r'\b(?:blocked\s+by|blocks?|depends?\s+(?:on|upon)|requires?|needs?|'
+    r'waiting\s+(?:on|for)|gated\s+(?:on|by)|blocker)\b',
+    re.IGNORECASE,
+)
+# Clause boundaries used to isolate the text introducing a single `#N`.
+_CLAUSE_SPLIT_RE = re.compile(r'[;,—–(]')
+
+
+def _leads_with_none_sentinel(value):
+    """True when `value` opens with a no-blocker sentinel — `none`, `(none`,
+    `n/a`, `na`, `tbd`, or a lone leading dash/dot. This is the necessary
+    precondition for excusing any `#N` as a see-also reference: a value that
+    does not lead with `none` (e.g. a bare `#5`) is never excused."""
+    # Tolerate leading markdown emphasis / paren wrappers (`_(none …)_`,
+    # `*none*`, `` `(none)` ``) before the sentinel word — #1910's field was
+    # italicized, and the bare token check would otherwise see `_(none`.
+    head = (value or "").strip().lower().lstrip("_*`(").strip()
+    if not head or head[0] in "-–—.":
+        return True
+    token = re.split(r"[\s.,;:)\-–—]", head, maxsplit=1)[0]
+    return token in {"none", "n/a", "na", "tbd"}
+
+
+def _ref_is_see_also(value, ref_start):
+    """True when the `#N` starting at `ref_start` is introduced by a see-also /
+    parallel qualifier rather than a blocker verb. Scans only the clause leading
+    up to the ref (back to the previous `;,—–(` boundary): a blocker verb in
+    that clause disqualifies it, and a see-also keyword licenses it. A ref with
+    neither qualifier is conservatively treated as a blocker (returns False)."""
+    clause = _CLAUSE_SPLIT_RE.split(value[:ref_start])[-1]
+    if _BLOCKER_VERB_RE.search(clause):
+        return False
+    return bool(_SEE_ALSO_RE.search(clause))
+
 
 def is_no_blocker_value(value):
     """True when a `Blocked by:` value declares NO blocker.
@@ -83,20 +132,25 @@ def is_no_blocker_value(value):
     The canonical form is `(none)`, but agents also hand-write a bare `none`,
     `n/a`, `tbd`, a lone dash, or `(none) — prose`, all of which mean "nothing
     blocks this". A value that names a `#N` or describes a real blocker in
-    prose ("the auth redesign") is NOT a sentinel and must still gate. Ported
-    verbatim from the scout's historically-richest version so the other two
-    consumers inherit it.
+    prose ("the auth redesign") is NOT a sentinel and must still gate.
+
+    Exception (#1910): the "(none — … in parallel with #N)" idiom names a
+    *sibling*, not a blocker. Such a `#N` is excused only when (a) the value
+    leads with a `none`/`n-a`/`tbd` sentinel AND (b) every `#N` is introduced by
+    a see-also / parallel qualifier (not a blocker verb). So "none, actually
+    blocked by #5" still gates — the anti-evasion guard is preserved.
     """
     value = value or ""
-    # A concrete `#N` ref anywhere means there IS a blocker — never let a
-    # leading "none" word swallow a real reference.
-    if re.search(r"#\d+", value):
+    refs = list(re.finditer(r"#\d+", value))
+    if refs:
+        # A concrete `#N` normally means there IS a blocker. Excuse it only for
+        # the leading-`none` see-also idiom; any ref carried by a blocker verb
+        # (or with no qualifier at all) still gates.
+        if _leads_with_none_sentinel(value) and all(
+                _ref_is_see_also(value, m.start()) for m in refs):
+            return True
         return False
-    head = value.strip().lower().lstrip("(").strip()
-    if not head or head[0] in "-–—.":
-        return True
-    token = re.split(r"[\s.,;:)\-–—]", head, maxsplit=1)[0]
-    return token in {"none", "n/a", "na", "tbd"}
+    return _leads_with_none_sentinel(value)
 
 
 def _field_values(body):

--- a/scripts/fleet/fleet_blocked_by.py
+++ b/scripts/fleet/fleet_blocked_by.py
@@ -110,7 +110,7 @@ def _leads_with_none_sentinel(value):
     head = (value or "").strip().lower().lstrip("_*`(").strip()
     if not head or head[0] in "-–—.":
         return True
-    token = re.split(r"[\s.,;:)\-–—]", head, maxsplit=1)[0]
+    token = re.split(r"[\s.,;:)\-–—*]", head, maxsplit=1)[0]
     return token in {"none", "n/a", "na", "tbd"}
 
 

--- a/scripts/fleet/tests/test_blocked_by.py
+++ b/scripts/fleet/tests/test_blocked_by.py
@@ -45,6 +45,7 @@ class SeeAlsoParallelIdiom(unittest.TestCase):
         for v in (
             "(none) — independent tooling; can start immediately, in parallel with #1883",
             "_(none — independent tooling; in parallel with #1883)_",  # #1910's italic field form
+            "*none* — in parallel with #1883",                          # bold form
             "(none — runs in parallel with #1883)",
             "none — see also #5",
             "none; sibling of #7",

--- a/scripts/fleet/tests/test_blocked_by.py
+++ b/scripts/fleet/tests/test_blocked_by.py
@@ -35,6 +35,56 @@ class IsNoBlockerValue(unittest.TestCase):
             self.assertFalse(fbb.is_no_blocker_value(v), f"{v!r} should NOT be a sentinel")
 
 
+class SeeAlsoParallelIdiom(unittest.TestCase):
+    """#1910: a `#N` introduced by a see-also / parallel qualifier inside a
+    leading-`none` value is a sibling cross-reference, not a blocker — while
+    the anti-evasion guard for `none, blocked by #5` stays intact."""
+
+    # --- excused: leading `none` + every ref is a see-also / parallel sibling ---
+    def test_parallel_idiom_excused(self):
+        for v in (
+            "(none) — independent tooling; can start immediately, in parallel with #1883",
+            "_(none — independent tooling; in parallel with #1883)_",  # #1910's italic field form
+            "(none — runs in parallel with #1883)",
+            "none — see also #5",
+            "none; sibling of #7",
+            "(none) — related to #9, alongside #10",
+            "n/a — cf. #12",
+        ):
+            self.assertTrue(fbb.is_no_blocker_value(v),
+                            f"{v!r} should be excused as a see-also sibling")
+
+    def test_parallel_idiom_parses_unblocked(self):
+        # The live #1910 field shape (the bug this hardening fixes at the source).
+        body = ("**Blocked by:** (none) — independent tooling; "
+                "in parallel with #1883\n")
+        self.assertEqual(fbb.parse_blocked_by(body), "")
+        self.assertEqual(fbb.blocker_refs(body, "jakildev/IrredenEngine"), [])
+
+    # --- anti-evasion: a blocker verb (or no qualifier at all) still gates ---
+    def test_evasion_blocker_verb_still_gates(self):
+        for v in (
+            "none, actually blocked by #5",        # the canonical evasion
+            "(none) — depends on #5",
+            "none — requires #6 first",
+            "none, #138",                          # no qualifier at all
+            "none — see also #5, blocked by #6",   # mixed: the blocker ref gates the whole value
+        ):
+            self.assertFalse(fbb.is_no_blocker_value(v), f"{v!r} must still gate")
+
+    def test_evasion_surfaces_real_ref(self):
+        body = "**Blocked by:** none, actually blocked by #5\n"
+        self.assertEqual(fbb.parse_blocked_by(body), "none, actually blocked by #5")
+        self.assertEqual(fbb.blocker_refs(body, "jakildev/IrredenEngine"),
+                         [("jakildev/IrredenEngine", "5")])
+
+    # --- a #N WITHOUT a leading `none` sentinel is never excused ---
+    def test_ref_without_leading_none_gates(self):
+        for v in ("#1883", "in parallel with #1883", "see also #5"):
+            self.assertFalse(fbb.is_no_blocker_value(v),
+                             f"{v!r} has no leading `none` → must gate")
+
+
 class ParseBlockedBy(unittest.TestCase):
     def _body(self, line):
         return ("**Model:** opus\n**Part of epic:** #137\n"


### PR DESCRIPTION
## Summary
Hardens the shared `Blocked by:` parser (`scripts/fleet/fleet_blocked_by.py`) so the legitimate **"see also / in parallel with #N"** sibling idiom no longer false-BLOCKs an otherwise-unblocked issue — while keeping the anti-evasion guard for `none, actually blocked by #5` fully intact.

## Why
`is_no_blocker_value()` had a blunt guard: *any* `#N` in the field value → treat as a real blocker (to stop `none, actually blocked by #5` evasion). That also catches the legitimate idiom where a `#N` is named as a **parallel sibling**, not a dependency.

Concrete incident — **#1910**: its field read `_(none — independent tooling; can start immediately, in parallel with #1883)_`. The parser extracted the parallel-sibling `#1883`, `fleet-claim` gate-refused every worker, and because the guard is *deliberate* it never self-healed — the issue stranded under `fleet:needs-human` (a worker had to park it). This is the inverse of the #1749 parser coverage work: a false-**BLOCK**, not a false-free.

## The fix (targeted — anti-evasion preserved)
A `#N` is excused as a sibling cross-reference **only when both** hold:
1. The value **leads with a `none`/`(none`/`n-a`/`tbd` sentinel** (now tolerant of leading markdown emphasis, so the italic `_(none …)_` form is recognized). A value that doesn't lead with `none` (a bare `#5`) is never excused.
2. **Every** `#N` is introduced by a see-also/parallel qualifier (`see also`, `related`, `in parallel with`, `parallel with`, `sibling of`, `alongside`, `concurrent with`, `cf.`), checked **per-ref** against the clause leading up to it.

Any ref carried by a **blocker verb** (`blocked by`, `depends on`, `requires`, `needs`, `waiting on`, `gated on`) — or with **no qualifier at all** — still gates. So:
- ✅ `(none — runs in parallel with #1883)` → unblocked
- ✅ `_(none — … in parallel with #1883)_` → unblocked (#1910's exact form)
- ⛔ `none, actually blocked by #5` → still a real blocker (#5 surfaces)
- ⛔ `none — see also #5, blocked by #6` → mixed → gates
- ⛔ `in parallel with #1883` (no leading `none`) → gates

Propagates to all three consumers (scout, ingest, claim) via the shared module — no per-script copies.

## Test plan
- [x] New `SeeAlsoParallelIdiom` test class in `test_blocked_by.py`: excused positives (incl. the italic form), anti-evasion negatives, mixed see-also+blocker, and the no-leading-`none` guard.
- [x] Full parser corpus green: `python3 -m unittest test_blocked_by test_parse_blocked_by_none_sentinel` → 40 tests OK.
- [x] Broader parser-dependent sweep green: + `test_issue_queue_parser test_live_blocker_resolution test_enrich_stackable_blocker_prs test_scout_degraded_fetch test_epic_steward_projection` → 157 tests OK.
- [x] Docs-adjacent / Python-only; no engine build impact.

## Related
Unblocks the parser-level recurrence behind #1910 (the issue itself is separately unblocked: field reworded + plan file in #1918). Companion to the #1749 shared-parser consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)