### PR TITLE
render: temporal-jitter rotation validation harness

### DIFF
--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -204,6 +204,21 @@ float g_spinYawDegPerSec = 0.0f;
 // which hits every cardinal (0/90/180/270°) and every rebracket (45/135/...).
 int g_spinYawShotCount = 24;
 
+// --spin-shape <name> (#1922): spawn a single shape centred at the origin (so
+// camera Z-yaw-about-origin keeps it screen-centred) instead of the full
+// side-by-side fixture scene — the per-shape isolation the temporal-jitter
+// sweep harness (scripts/dev/shape-rotate-jitter-sweep) needs. Empty = full
+// scene (default, byte-identical). --spin-shape-voxel renders the voxel-pool
+// twin instead of the SDF solver, so both render paths can be scored.
+std::string g_spinShapeType;
+bool g_spinShapeVoxel = false;
+// Centred ROI crop attached to every --spin-shape sweep shot so the jitter
+// metric decodes a small PNG per frame — a full-framebuffer 100+-frame sweep
+// is otherwise minutes of pure-Python PNG decode. Sized from the live
+// framebuffer at sweep-build time; one shared crop suffices because the single
+// shape stays screen-centred under yaw-about-origin.
+IRVideo::RoiCrop g_spinShapeCrop{};
+
 // Dynamic shot table populated at startup when --spin-yaw + --auto-screenshot
 // are both set. Lives at namespace scope so the pointer handed to
 // IRVideo::AutoScreenshotConfig outlives the game loop. The label strings
@@ -308,6 +323,13 @@ int main(int argc, char **argv) {
                     ++i;
                 }
             }
+        } else if (std::strcmp(argv[i], "--spin-shape") == 0) {
+            if (i + 1 < argc) {
+                g_spinShapeType = argv[i + 1];
+                ++i;
+            }
+        } else if (std::strcmp(argv[i], "--spin-shape-voxel") == 0) {
+            g_spinShapeVoxel = true;
         }
     }
 
@@ -568,11 +590,27 @@ void initSystems() {
             // g_spinYawShots.
             g_spinYawShotLabels.reserve(n);
             g_spinYawShots.reserve(n);
+            // In --spin-shape mode the single shape is screen-centred under
+            // yaw-about-origin, so attach a centred ROI crop sized to half the
+            // shorter framebuffer edge: the jitter sweep then scores small
+            // per-frame PNGs instead of the full retina framebuffer.
+            const bool useSpinShapeCrop = !g_spinShapeType.empty();
+            if (useSpinShapeCrop) {
+                ivec2 fb{0, 0};
+                IRWindow::getFramebufferSize(fb);
+                const int side = IRMath::max(64, IRMath::min(fb.x, fb.y) / 2);
+                g_spinShapeCrop = {(fb.x - side) / 2, (fb.y - side) / 2, side, side, "center"};
+            }
             for (int i = 0; i < n; ++i) {
                 const float yaw = (static_cast<float>(i) / static_cast<float>(n)) * IRMath::kTwoPi;
                 auto &label = g_spinYawShotLabels.emplace_back();
                 std::snprintf(label.data(), label.size(), "spin_yaw_%03d_of_%03d", i, n);
-                g_spinYawShots.push_back({sweepZoom, vec2(0, 0), yaw, label.data()});
+                IRVideo::AutoScreenshotShot shot{sweepZoom, vec2(0, 0), yaw, label.data()};
+                if (useSpinShapeCrop) {
+                    shot.crops_ = &g_spinShapeCrop;
+                    shot.numCrops_ = 1;
+                }
+                g_spinYawShots.push_back(shot);
             }
             cfg.shots_ = g_spinYawShots.data();
             cfg.numShots_ = static_cast<int>(g_spinYawShots.size());
@@ -925,6 +963,56 @@ void initPivotFocusScene() {
     }
 }
 
+// Map a --spin-shape token to its ShapeType. Tokens match the lower-cased
+// fixture shapes below; returns false (leaving `out` untouched) on an unknown
+// name so the caller can diagnose it.
+bool spinShapeTypeFromName(const std::string &name, IRRender::ShapeType &out) {
+    struct SpinShapeName {
+        const char *token_;
+        IRRender::ShapeType type_;
+    };
+    static const SpinShapeName kSpinShapeNames[] = {
+        {"box", IRRender::ShapeType::BOX},
+        {"sphere", IRRender::ShapeType::SPHERE},
+        {"cylinder", IRRender::ShapeType::CYLINDER},
+        {"ellipsoid", IRRender::ShapeType::ELLIPSOID},
+        {"cone", IRRender::ShapeType::CONE},
+        {"torus", IRRender::ShapeType::TORUS},
+        {"wedge", IRRender::ShapeType::WEDGE},
+        {"curved_panel", IRRender::ShapeType::CURVED_PANEL},
+    };
+    for (const auto &entry : kSpinShapeNames) {
+        if (name == entry.token_) {
+            out = entry.type_;
+            return true;
+        }
+    }
+    return false;
+}
+
+// Canvas lighting setup shared by the full fixture scene and the --spin-shape
+// single-shape scene: the main (voxel-pool) canvas needs the AO / sun-shadow /
+// light-volume textures + C_TrixelCanvasRenderBehavior, or the lighting
+// systems' archetype filter skips it and the shapes render unlit.
+void setupCanvasLighting() {
+    EntityId mainCanvas = IRRender::getActiveCanvasEntity();
+    IR_LOG_INFO("Active canvas entity: {}", mainCanvas);
+
+    const ivec2 canvasSize = IREntity::getComponent<C_TriangleCanvasTextures>(mainCanvas).size_;
+    IREntity::setComponent(mainCanvas, C_CanvasAOTexture{canvasSize});
+    IREntity::setComponent(mainCanvas, C_CanvasSunShadow{canvasSize});
+    IREntity::setComponent(mainCanvas, C_CanvasLightVolume{});
+
+    // The voxel-pool canvas prefab doesn't include this component, so the
+    // AO / sun-shadow / light-volume / lighting systems' archetype filter
+    // wouldn't otherwise match the main canvas and they'd silently skip it.
+    IREntity::setComponent(mainCanvas, C_TrixelCanvasRenderBehavior{});
+
+    // Default sun direction: high and slightly off-axis so every demo
+    // shape casts a visible shadow without any further setup.
+    IRRender::setSunDirection(vec3(0.35f, 0.85f, -0.4f));
+}
+
 void initEntities() {
     if (g_pivotFocusDemo) {
         IR_LOG_INFO("--- Camera pivot-focus demo scene (#1921) ---");
@@ -994,6 +1082,48 @@ void initEntities() {
          Color{220, 100, 180, 255}},
     };
     constexpr int kNumCases = sizeof(cases) / sizeof(cases[0]);
+
+    // --spin-shape <name> (#1922): replace the side-by-side fixture scene with
+    // ONE shape centred at the origin. Under camera Z-yaw-about-origin the shape
+    // stays screen-centred, so the whole frame is that shape — clean per-shape
+    // isolation for the temporal-jitter sweep. No floor / point light: a black
+    // field maximises the metric's interior mask. The flag is absent in every
+    // normal run, so the fixture scene below stays byte-identical.
+    if (!g_spinShapeType.empty()) {
+        IRRender::ShapeType want;
+        if (spinShapeTypeFromName(g_spinShapeType, want)) {
+            for (const auto &tc : cases) {
+                if (tc.type_ != want) {
+                    continue;
+                }
+                if (g_spinShapeVoxel) {
+                    createVoxelPoolShape(
+                        vec3(0.0f, 0.0f, 0.0f),
+                        tc.type_,
+                        tc.params_,
+                        tc.color_,
+                        tc.halfExtent_
+                    );
+                } else {
+                    createSDFShape(vec3(0.0f, 0.0f, 0.0f), tc.type_, tc.params_, tc.color_);
+                }
+                IR_LOG_INFO(
+                    "Spin-shape single fixture: {} ({})",
+                    tc.label_,
+                    g_spinShapeVoxel ? "voxel-pool" : "SDF"
+                );
+                break;
+            }
+        } else {
+            IR_LOG_ERROR(
+                "--spin-shape: unknown shape '{}' "
+                "(box|sphere|cylinder|ellipsoid|cone|torus|wedge|curved_panel)",
+                g_spinShapeType
+            );
+        }
+        setupCanvasLighting();
+        return;
+    }
 
     for (int i = 0; i < kNumCases; ++i) {
         auto &tc = cases[i];
@@ -1150,22 +1280,7 @@ void initEntities() {
     );
     IREntity::setComponent(floorEntity, C_LightBlocker{false, false, 0.0f});
 
-    EntityId mainCanvas = IRRender::getActiveCanvasEntity();
-    IR_LOG_INFO("Active canvas entity: {}", mainCanvas);
-
-    const ivec2 canvasSize = IREntity::getComponent<C_TriangleCanvasTextures>(mainCanvas).size_;
-    IREntity::setComponent(mainCanvas, C_CanvasAOTexture{canvasSize});
-    IREntity::setComponent(mainCanvas, C_CanvasSunShadow{canvasSize});
-    IREntity::setComponent(mainCanvas, C_CanvasLightVolume{});
-
-    // The voxel-pool canvas prefab doesn't include this component, so the
-    // AO / sun-shadow / light-volume / lighting systems' archetype filter
-    // wouldn't otherwise match the main canvas and they'd silently skip it.
-    IREntity::setComponent(mainCanvas, C_TrixelCanvasRenderBehavior{});
-
-    // Default sun direction: high and slightly off-axis so every demo
-    // shape casts a visible shadow without any further setup.
-    IRRender::setSunDirection(vec3(0.35f, 0.85f, -0.4f));
+    setupCanvasLighting();
 
     // Emissive point light placed between the shape rows so its colored
     // falloff is visible across both the voxel-pool and SDF copies of the

--- a/docs/design/jitter-validation-harness.md
+++ b/docs/design/jitter-validation-harness.md
@@ -1,0 +1,178 @@
+# Temporal-jitter rotation validation harness (#1922, epic #1881)
+
+Engine-side procedure to **measure whether the rendered surface shimmers as the
+camera turns** — the core artifact of epic #1881 (rotated-voxel correctness
+under camera Z-yaw). The sibling solidity harness (`perf-grid-rotate-sweep`,
+#1882) scores per-frame *coverage* of one rotated cube — it catches see-through
+density loss but **not** temporal instability, and only on a single shape. This
+harness sweeps every SDF shape across a fine continuous yaw rotation and scores
+how much each pixel *crawls* frame-to-frame, so the epic's "no jitter" bar is a
+measured number rather than an eyeball judgment.
+
+The jitter children (#1920 round-to-cell depth bands, #1883 per-axis seams)
+validate their fixes against this harness: a shape that FAILs the gate on
+`origin/master` should pass once its fix lands.
+
+## What the metric measures, and why curvature not speed
+
+The artifact: under camera Z-yaw an interior pixel oscillates dark → light →
+dark while the camera turns, instead of ramping smoothly. Two crawl modes
+appear — per-axis trixel-scatter **seam crawl** on hard edges / flat faces at
+grazing iso angles (box, wedge), and a concentric **depth-band crawl** on curved
+SDF surfaces (#1920, a band flipping between adjacent integer depths) which is
+the *stronger* of the two on master (curved_panel and ellipsoid). The stated
+crux of the issue is separating either
+crawl from the *expected* smooth sub-pixel motion every pixel undergoes as the
+whole image rotates.
+
+The discriminator is the **second temporal difference** of per-pixel luminance —
+the discrete temporal Laplacian:
+
+    d2[p,t] = | L[p,t-1] - 2·L[p,t] + L[p,t+1] |
+
+A pixel whose luminance ramps *smoothly* with yaw has near-zero curvature
+(`d2 ≈ 0`); a pixel that *oscillates* across an integer boundary spikes `d2`
+every flip. The first difference `d1 = |L[p,t] - L[p,t-1]|` cannot tell them
+apart — smooth motion drives `d1` just as hard — which is why the metric keys on
+curvature. It is measured over the **interior** only (a pixel foreground in
+*every* frame of the sweep), so the moving silhouette boundary and the
+background don't contaminate the signal. Luminance curvature is the same
+property on Metal and OpenGL, so a single gate is a shared cross-backend oracle.
+
+`scripts/render-jitter-metric.py` implements the metric (pure stdlib, streaming
+3-frame window); its header documents every reported field. The headline number
+is `jitter_score` (mean interior `|d2|`); `flicker_p95` and `flicker_frac` catch
+localized crawl that barely moves the mean.
+
+## The automated sweep: `scripts/dev/shape-rotate-jitter-sweep`
+
+```bash
+bash scripts/dev/shape-rotate-jitter-sweep [build_dir] [shapes] [zoom] [steps]
+#   build_dir  CMake build dir            (default: build)
+#   shapes     space-separated subset     (default: all 8)
+#   zoom       sweep zoom                 (default: 8)
+#   steps      shots over one 360° turn   (default: 360 → 1°/step)
+# Env: SPIN_RATE (deg/s, 30) · MAX_JITTER (gate, 4.0) · RENDER (sdf|voxel|both, sdf)
+```
+
+It drives `IRShapeDebug --spin-shape <name>`, which spawns a **single** shape
+centred at the origin: under yaw-about-origin the shape stays screen-centred, so
+one centred ROI crop tracks it across the whole sweep (the default side-by-side
+fixture scene has shapes orbit off-centre, so no fixed crop would track one).
+Each sweep shot writes that centred crop and the metric scores the small crops —
+a full-framebuffer 360-frame sweep is otherwise minutes of pure-Python PNG
+decode. `--spin-shape-voxel` renders the voxel-pool twin instead of the SDF
+solver so both render paths can be scored (`RENDER=both`).
+
+**A fine sweep is mandatory.** At coarse yaw steps even a smoothly-shaded
+surface aliases into a high second-difference (sphere reads ~1.2 at 1°/step but
+climbs steeply by 2°/step), drowning the real crawl signal. 1°/step (the default
+360 steps) is the #1922 spec and the regime where smooth shapes settle to
+near-zero flicker.
+
+## Baseline (macOS / Metal, 2560×1440, origin/master renderer)
+
+Measured at the default zoom 8, 360 steps (1°/step), 30 deg/s, SDF render path,
+ROI = centred half of the tracking crop. Gate: `MAX_JITTER=4.0`.
+
+| shape         | jitter_score | flicker_p95 | flicker_frac | verdict |
+|---------------|--------------|-------------|--------------|---------|
+| box           | 6.74         | 16.07       | 0.575        | **FAIL** |
+| sphere        | 1.20         | 1.89        | 0.000        | PASS    |
+| cylinder      | 1.17         | 1.82        | 0.001        | PASS    |
+| ellipsoid     | 7.54         | 16.74       | 0.727        | **FAIL** |
+| cone          | 1.13         | 1.73        | 0.003        | PASS    |
+| torus         | 1.07         | 1.83        | 0.001        | PASS    |
+| wedge         | 6.26         | 18.18       | 0.459        | **FAIL** |
+| curved_panel  | 11.38        | 18.18       | 0.886        | **FAIL** |
+
+### What the split proves
+
+The gate cleanly separates two clusters with a ~5× margin: four shapes settle at
+`jitter_score` ≈ 1.1 (torus 1.07, cone 1.13, cylinder 1.17, sphere 1.20) and
+four spike to 6.3–11.4 (wedge 6.26, box 6.74, ellipsoid 7.54, curved_panel
+11.38). Both of the epic's crawl modes are live on master:
+
+- **Hard-edge seam crawl** (per-axis trixel-scatter): box and wedge — flat faces
+  and sharp seams toggle as the iso projection grazes them.
+- **Curved-surface depth-band crawl** (#1920): a concentric band flips between
+  adjacent integer depths. This is the *stronger* mode on master — curved_panel
+  crawls hardest (11.38, 89% of its interior flickering), ellipsoid next (7.54).
+  curved_panel is the canonical curved-SDF band crawl the issue calls "Bug-A",
+  reproduced here as the worst FAIL on origin/master.
+
+The decisive evidence that the metric flags genuine crawl and not merely shape
+class is that the **curved** family lands on *both* sides: sphere, cylinder,
+cone, and torus pass cleanly while ellipsoid and curved_panel fail hard. An
+edges-vs-curves classifier could not produce that split.
+
+That the metric isolates crawl from *motion* — the issue's stated crux — is
+proven separately and airtight by the unittest: a synthetic gradient sliding
+1px/frame has a large first difference yet a near-zero second difference, so it
+scores ≈0 jitter. On these master shapes motion and crawl happen to correlate
+(the crawling shapes also have the larger `mean_abs_d1`: box 3.66, ellipsoid 4.13
+vs sphere 0.82, cylinder 0.81), so the real-shape baseline alone cannot make the
+motion-vs-crawl point — the synthetic control does.
+
+> This corrects the original plan's offhand guess that box would be a stable
+> control. Box is not a control — it FAILs (6.74) — and it is not even the worst
+> case: the curved-SDF band crawl pushes curved_panel (11.38) and ellipsoid
+> (7.54) above it. The clean shapes are the *smooth analytic* surfaces, not
+> "curved shapes" as a class.
+
+### Choosing the gate
+
+`jitter_score = 4.0` sits in the wide empty band between the two clusters — the
+noisiest passing shape is sphere at 1.20, the cleanest failing one is wedge at
+6.26, leaving margin on both sides. It is a starting threshold for the fix
+children, not a final regression bar — once #1920 (depth-band) and #1883
+(per-axis seams) land, re-run this harness and tighten the gate to whatever
+headroom the fixed renderer leaves (the curved-band shapes should drop the most;
+every shape should fall well under 4.0).
+
+### Render-path coverage and deferred baselines
+
+`shape_debug --spin-shape` exercises the two render paths where the epic's crawl
+artifacts live: the **SDF analytical solver** (default) and the **voxel-pool**
+raster (`--spin-shape-voxel` / `RENDER=voxel|both`), which under camera yaw is the
+per-axis trixel-scatter path (#1883). Both are on the main canvas. The committed
+table above is the SDF path on Metal; the voxel-path numbers run from the same
+one command (`RENDER=both`) and are captured the same way — box on the voxel path
+already FAILs comparably to SDF (≈6.7), so the gate carries over, but the full
+per-shape voxel table is a follow-up (it belongs next to the OpenGL baseline,
+both being "run the harness on the other axis and paste the numbers").
+
+The **detached / world-placed entity-canvas** path (SO(3) re-voxelize) is *not*
+covered here: it carries its own round-to-cell sub-cell non-determinism (a few-
+percent speckle that is not frame-to-frame stable even on a corrected renderer),
+so a tight temporal-curvature gate would false-positive on it. That path is
+validated by its own render-verify manifest; this harness deliberately scopes to
+the deterministic single-shape main-canvas paths so the gate stays a hard oracle.
+
+### OpenGL / Linux
+
+The metric is backend-agnostic (luminance curvature), so the same gate applies
+to OpenGL. This table is the **Metal** baseline (the authoring host); the
+OpenGL/Linux baseline is captured by running the identical command on a Linux
+host (cross-host smoke or a Linux worker) and is a follow-up — the renderer
+behaviour, not the harness, is what differs between backends.
+
+## Reproducing
+
+1. `fleet-build --target IRShapeDebug`
+2. `bash scripts/dev/shape-rotate-jitter-sweep` (all 8 shapes, the baseline above)
+   - one shape: `bash scripts/dev/shape-rotate-jitter-sweep build box`
+   - voxel-pool twin: `RENDER=both bash scripts/dev/shape-rotate-jitter-sweep`
+3. Per-frame crops land in
+   `build/creations/demos/shape_debug/save_files/screenshots/`; per-shape run
+   logs in `/tmp/jitter-sweep-<shape>-<path>.log`. The script exits non-zero if
+   any shape exceeds the gate.
+4. To see *where* a shape crawls, score its crops directly with a heatmap:
+   ```bash
+   python3 scripts/render-jitter-metric.py <crops...> --roi X,Y,W,H --diff-out heat.png
+   ```
+
+The metric has a stdlib unittest (`scripts/tests/test_render_jitter_metric.py`)
+that proves the discrimination on synthetic frames — smooth motion scores
+near-zero, a crawling pattern scores an order of magnitude higher — so the
+metric's core claim is guarded without a GL/Metal context.

--- a/scripts/dev/shape-rotate-jitter-sweep
+++ b/scripts/dev/shape-rotate-jitter-sweep
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# shape-rotate-jitter-sweep — temporal-jitter validation harness (#1922, epic #1881).
+#
+# Sibling to scripts/dev/perf-grid-rotate-sweep (#1882). That harness scores the
+# *solidity* of a single rotated cube per frame; this one scores *temporal
+# stability* of a shape across a fine continuous yaw sweep — does the rendered
+# surface shimmer as the camera turns?
+#
+# It targets the epic #1881 crawl family: under camera Z-yaw the rendered
+# surface shimmers frame-to-frame instead of moving smoothly. Two distinct
+# artifacts show up (see docs/design/jitter-validation-harness.md for the
+# measured master baseline):
+#   * per-axis trixel-scatter SEAM crawl on hard edges + flat faces at grazing
+#     iso angles — box + wedge (this INVERTS the original plan's guess that box
+#     would be the stable control — box FAILs).
+#   * a concentric depth-band crawl on curved SDF surfaces (child #1920) — the
+#     STRONGER mode on master; curved_panel crawls hardest, ellipsoid next, while
+#     the smooth analytic surfaces (sphere/cylinder/cone/torus) stay clean.
+# The crux the metric solves is separating either crawl from the expected smooth
+# sub-pixel motion of the whole image rotating — handled by the second-temporal-
+# difference metric in scripts/render-jitter-metric.py (see its header).
+#
+# How it isolates one shape: IRShapeDebug --spin-shape <name> spawns a SINGLE
+# shape centred at the origin, so under yaw-about-origin it stays screen-centred
+# and a centred ROI crop tracks it across the whole sweep (the default
+# side-by-side fixture scene has shapes orbit off-centre, so no fixed crop would
+# track one). Each --spin-shape sweep shot writes that centred crop; the metric
+# decodes the small crops (a full-framebuffer 100-frame sweep would be minutes
+# of pure-Python PNG decode).
+#
+# Per shape it runs SDF and/or voxel-pool render paths. On origin/master both
+# crawl modes are live, so the hard-edge shapes (box, wedge) AND the curved
+# depth-band shapes (curved_panel worst, ellipsoid) FAIL the gate while the
+# smooth analytic surfaces (sphere, cylinder, cone, torus) pass — the curved
+# family landing on both sides is what proves the metric flags real crawl and
+# not shape class. The fix children (#1920 round-to-cell, #1883 per-axis seams)
+# should pull every shape under the gate.
+#
+# Usage:  bash scripts/dev/shape-rotate-jitter-sweep [build_dir] [shapes] [zoom] [steps]
+#   build_dir   CMake build dir                       (default: build)
+#   shapes      space-separated subset                (default: all 8)
+#               box sphere cylinder ellipsoid cone torus wedge curved_panel
+#   zoom        sweep zoom (4/8/16 per #1920)         (default: 8)
+#   steps       shots across one 360° rotation        (default: 360 → 1°/step)
+#               A FINE sweep is mandatory: at coarse steps even a smoothly-
+#               shaded surface aliases into a high second-difference (sphere
+#               reads ~1.2 at 1°/step but ~2.6 at 2°/step), drowning the real
+#               crawl signal. 1°/step is the issue-#1922 spec and the regime
+#               where smooth shapes settle to near-zero flicker.
+# Env overrides: SPIN_RATE (deg/sec, default 30), MAX_JITTER (gate, default 4.0),
+#   RENDER (sdf|voxel|both, default sdf).
+#
+# Repo tooling — cmake + python3 stdlib only. Long enough (build + one run per
+# shape + per-frame scoring) to launch in the background and read on completion.
+# Self-locating, so it works from any cwd / worktree.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT" || exit 1
+
+BUILD_DIR="${1:-build}"
+SHAPES="${2:-box sphere cylinder ellipsoid cone torus wedge curved_panel}"
+ZOOM="${3:-8}"
+STEPS="${4:-360}"
+RATE="${SPIN_RATE:-30}"
+MAX_JITTER="${MAX_JITTER:-4.0}"
+RENDER="${RENDER:-sdf}"
+
+EXE_DIR="$BUILD_DIR/creations/demos/shape_debug"
+SS_DIR="$EXE_DIR/save_files/screenshots"
+METRIC="$ROOT/scripts/render-jitter-metric.py"
+
+# nproc is Linux-only; macOS uses sysctl. Fall back to a safe default.
+JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+
+echo "[1/3] building IRShapeDebug ($BUILD_DIR) ..."
+cmake --build "$BUILD_DIR" --target IRShapeDebug -j "$JOBS" >/dev/null \
+    || { echo "BUILD FAILED"; exit 1; }
+
+worst_rc=0
+
+# run_one <shape> <voxel-flag-or-empty>
+run_one() {
+    local shape="$1" voxel="$2"
+    local path="sdf"; [ -n "$voxel" ] && path="voxel"
+    mkdir -p "$SS_DIR"
+    # Scoped find -delete, never an unguarded rm glob (the dir may be empty,
+    # which trips the dangerous-rm guard) — matches perf-grid-rotate-sweep.
+    find "$SS_DIR" -maxdepth 1 -type f -name '*.png' -delete
+    local log="/tmp/jitter-sweep-${shape}-${path}.log"
+    ( cd "$EXE_DIR" && ./IRShapeDebug --spin-shape "$shape" $voxel \
+        --spin-yaw "$RATE" --auto-screenshot "$STEPS" --zoom "$ZOOM" ) \
+        >"$log" 2>&1 \
+        || { echo "  $shape/$path: RUN FAILED (see $log)"; tail -3 "$log"; worst_rc=1; return; }
+
+    SS_DIR="$SS_DIR" METRIC="$METRIC" MAX_JITTER="$MAX_JITTER" \
+        SHAPE="$shape" RPATH="$path" python3 - <<'PY'
+import glob, json, os, struct, subprocess, sys
+ss, metric = os.environ["SS_DIR"], os.environ["METRIC"]
+crops = sorted(glob.glob(os.path.join(ss, "screenshot_*__crop_center.png")))
+shape, rpath = os.environ["SHAPE"], os.environ["RPATH"]
+if len(crops) < 3:
+    print(f"  {shape:<13}{rpath:<7}NO CROPS (got {len(crops)} — did the run capture?)")
+    sys.exit(1)
+# Score the centred half of the crop. The shape stays screen-centred under
+# yaw-about-origin, so the middle 50% contains it at the default zoom while
+# quartering the per-pixel pure-Python decode the full crop would cost (the
+# bottleneck at 360 frames). Read the crop's pixel size from the PNG IHDR so the
+# ROI tracks the framebuffer (zoom-robust); width @ byte 16, height @ 20.
+with open(crops[0], "rb") as fh:
+    w, h = struct.unpack(">II", fh.read(24)[16:24])
+roi = f"{w // 4},{h // 4},{w // 2},{h // 2}"
+out = subprocess.run(
+    [sys.executable, metric, *crops, "--roi", roi, "--max-jitter", os.environ["MAX_JITTER"]],
+    capture_output=True, text=True)
+# The metric prints a JSON object on success and {"error": ...} (exit 2) on an
+# I/O / format / empty-interior failure. Report either gracefully and mark the
+# shape failed — never let one shape's error KeyError-abort the whole sweep.
+try:
+    m = json.loads(out.stdout)
+except (ValueError, json.JSONDecodeError):
+    print(f"  {shape:<13}{rpath:<7}METRIC ERROR (no JSON; rc={out.returncode}): "
+          f"{(out.stderr or out.stdout or '').strip()[:120]}")
+    sys.exit(1)
+if "frames" not in m:
+    print(f"  {shape:<13}{rpath:<7}METRIC ERROR: {m.get('error', m)}")
+    sys.exit(1)
+verdict = "PASS" if m.get("pass") else "FAIL"
+print(f"  {shape:<13}{rpath:<7}frames={m['frames']:<4} interior={m['interior_px']:<7} "
+      f"jitter={m['jitter_score']:<8} p95={m['flicker_p95']:<8} "
+      f"frac={m['flicker_frac']:<7} {verdict}")
+sys.exit(0 if m.get("pass") else 1)
+PY
+    [ $? -ne 0 ] && worst_rc=1
+    return 0
+}
+
+echo "[2/3] sweep: shapes=[$SHAPES] zoom=$ZOOM steps=$STEPS rate=${RATE}deg/s render=$RENDER gate=max_jitter=$MAX_JITTER"
+echo "      (on origin/master both crawl modes are live: box/wedge + ellipsoid/curved_panel FAIL; sphere/cylinder/cone/torus pass)"
+for s in $SHAPES; do
+    case "$RENDER" in
+        sdf)   run_one "$s" "" ;;
+        voxel) run_one "$s" "--spin-shape-voxel" ;;
+        both)  run_one "$s" ""; run_one "$s" "--spin-shape-voxel" ;;
+        *)     echo "unknown RENDER='$RENDER' (sdf|voxel|both)"; exit 2 ;;
+    esac
+done
+
+echo "[3/3] done. Last shape's crops remain in $SS_DIR; full logs in /tmp/jitter-sweep-*.log"
+exit "$worst_rc"

--- a/scripts/render-jitter-metric.py
+++ b/scripts/render-jitter-metric.py
@@ -66,6 +66,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from array import array
 
@@ -172,7 +173,10 @@ def jitter_metrics(
         )
 
     per_pixel_d2.sort()
-    p95 = per_pixel_d2[min(interior_px - 1, int(0.95 * interior_px))]
+    # Nearest-rank 95th percentile: ceil(0.95 * N) - 1. For N >= 1 (N == 0 is
+    # rejected above) this lands in [0, N-1]. The old floor-based index
+    # collapsed to the max (interior_px - 1) for small N rather than the 95th.
+    p95 = per_pixel_d2[math.ceil(0.95 * interior_px) - 1]
 
     result = {
         "frames": n,

--- a/scripts/render-jitter-metric.py
+++ b/scripts/render-jitter-metric.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Temporal-jitter metric for the rotated-render validation suite (epic #1881).
+
+The structural sibling metrics (``render-silhouette-metric.py`` /
+``render-coverage-metric.py``, epic #1766) each score a *single* capture. This
+one is **temporal**: it scores a *sequence* of frames captured across a fine
+continuous camera Z-yaw sweep (consecutive frames ≈ a sub-degree yaw step) and
+quantifies how much the rendered surface *shimmers* frame-to-frame.
+
+The artifact it targets (epic #1881): under camera Z-yaw the rendered surface
+shimmers instead of moving smoothly. Two crawl modes appear — per-axis trixel-
+scatter SEAM crawl on hard edges and flat faces at grazing iso angles (box, wedge),
+and a concentric depth-band crawl on curved SDF surfaces (child #1920, where a
+band flips between adjacent integer depths frame-to-frame), the stronger of the
+two on master (curved_panel crawls hardest, ellipsoid next). Either way an
+interior pixel oscillates dark → light → dark while the camera turns. The
+challenge (the issue's stated crux) is separating that genuine jitter from the
+*expected* smooth sub-pixel motion every pixel undergoes as the whole image
+rotates — which is why the metric keys on curvature, not speed (below).
+
+The discriminator is the **second temporal difference** of per-pixel luminance:
+
+    d2[p,t] = | L[p,t-1] - 2·L[p,t] + L[p,t+1] |
+
+This is the discrete temporal Laplacian — a high-pass filter. A pixel whose
+luminance ramps *smoothly* with yaw (ordinary motion of a shaded gradient) has
+near-zero curvature, so ``d2 ≈ 0``. A pixel that *oscillates* (a crawling band
+toggling across an integer boundary) has large ``d2`` every time it flips. The
+first difference ``d1 = |L[p,t] - L[p,t-1]|`` cannot tell the two apart —
+smooth motion drives ``d1`` just as hard — which is why curvature, not speed,
+is the signal.
+
+Measured over the **interior** only: a pixel that is foreground (the solid, not
+the cleared field) in *every* frame of the sweep. AND-ing the per-frame masks
+drops the moving silhouette boundary (where a one-time bg→fg crossing would
+otherwise read as a spurious ``d2`` spike) and the background, leaving the
+stable surface where shading is supposed to vary smoothly — exactly where the
+band-crawl lives.
+
+Metrics (over the interior, ROI-scoped, default = whole image):
+  * frames          — sequence length N (need N ≥ 3 for a second difference).
+  * interior_px     — pixels foreground in all N frames (the measured set).
+  * jitter_score    — mean over interior of each pixel's mean |d2|. The
+                      headline number: ≈0 for a stable sweep, several luminance
+                      units for a crawling one.
+  * flicker_p95     — 95th-percentile per-pixel mean |d2|. A few crawling rings
+                      on an otherwise-stable sphere barely move the mean but
+                      spike the tail, so this catches localized jitter.
+  * flicker_frac    — fraction of interior pixels whose mean |d2| exceeds
+                      ``--flicker-pixel-tol`` (how much of the surface crawls).
+  * mean_abs_d1     — mean interior first difference (overall motion magnitude;
+                      diagnostic only — high for smooth motion too).
+
+Backend-agnostic and zoom-robust: luminance curvature measures the same
+property on Metal and OpenGL, so one threshold is a shared oracle. Requires a
+*fine* sweep — at coarse yaw steps even smooth motion is under-sampled and
+``d2`` rises, so feed it ≤~2° steps (see ``scripts/dev/shape-rotate-jitter-sweep``).
+
+Pure stdlib; reuses ``read_png`` / ``write_png`` (via ``render_metric_util``).
+
+Exit codes: 0 metrics within thresholds (or none given) · 1 a threshold was
+exceeded · 2 I/O or format error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from array import array
+
+import render_metric_util as util
+
+# Rec. 601 luma weights, scaled to /256 integer arithmetic so the whole metric
+# stays in stdlib ints (no float image buffers): luma = (77R + 150G + 29B) >> 8.
+_LR, _LG, _LB = 77, 150, 29
+
+
+def _luma_and_mask(
+    path: str,
+    roi: tuple[int, int, int, int] | None,
+    bg: tuple[int, int, int],
+    bg_tol: int,
+) -> tuple[array, bytearray, int, int, tuple[int, int, int, int]]:
+    """One decode → (luma over ROI, foreground mask over ROI, rw, rh, rect).
+
+    Mirrors ``util.foreground_mask``'s classification (a pixel is foreground
+    when any channel differs from ``bg`` by more than ``bg_tol``) but also
+    emits the integer luminance in the same pass, so the sequence is decoded
+    once per frame rather than twice.
+    """
+    w, h, bpp, pix = util.read_png(path)
+    px = array("B", pix)
+    rx, ry, rw, rh = util.resolve_roi(roi, w, h)
+    br, bgg, bb = bg
+    luma = array("h", bytes(2 * rw * rh))
+    mask = bytearray(rw * rh)
+    for j in range(rh):
+        row = (ry + j) * w
+        mbase = j * rw
+        for i in range(rw):
+            o = (row + rx + i) * bpp
+            r = px[o]
+            g = px[o + 1]
+            b = px[o + 2]
+            luma[mbase + i] = (_LR * r + _LG * g + _LB * b) >> 8
+            if abs(r - br) > bg_tol or abs(g - bgg) > bg_tol or abs(b - bb) > bg_tol:
+                mask[mbase + i] = 1
+    return luma, mask, rw, rh, (rx, ry, rw, rh)
+
+
+def jitter_metrics(
+    paths: list[str],
+    roi: tuple[int, int, int, int] | None = None,
+    bg: tuple[int, int, int] = util.DEFAULT_BG,
+    bg_tol: int = util.DEFAULT_BG_TOL,
+    flicker_pixel_tol: float = 3.0,
+    diff_out: str | None = None,
+) -> dict:
+    """Score temporal jitter over a yaw-sweep frame sequence.
+
+    Streams the sequence with a 3-frame sliding window so memory stays O(ROI
+    pixels) regardless of sequence length: per-pixel ``sum|d2|`` / ``sum|d1|``
+    accumulate as frames arrive, and the interior mask is AND-ed incrementally.
+    """
+    n = len(paths)
+    if n < 3:
+        raise ValueError(f"need at least 3 frames for a second difference, got {n}")
+
+    luma0, interior, rw, rh, rect = _luma_and_mask(paths[0], roi, bg, bg_tol)
+    npx = rw * rh
+    sum_d2 = array("d", bytes(8 * npx))  # per-pixel Σ|d2|
+    sum_d1 = array("d", bytes(8 * npx))  # per-pixel Σ|d1| (diagnostic)
+
+    prev2 = luma0
+    prev1, mask1, _, _, _ = _luma_and_mask(paths[1], roi, bg, bg_tol)
+    for i in range(npx):
+        interior[i] &= mask1[i]
+        sum_d1[i] += abs(prev1[i] - prev2[i])
+
+    for k in range(2, n):
+        cur, mask, _, _, _ = _luma_and_mask(paths[k], roi, bg, bg_tol)
+        for i in range(npx):
+            interior[i] &= mask[i]
+            c = cur[i]
+            sum_d1[i] += abs(c - prev1[i])
+            sum_d2[i] += abs(prev2[i] - 2 * prev1[i] + c)
+        prev2, prev1 = prev1, cur
+
+    # Per-pixel means: N-1 first differences, N-2 second differences.
+    inv_d1 = 1.0 / (n - 1)
+    inv_d2 = 1.0 / (n - 2)
+    per_pixel_d2: list[float] = []
+    sum_interior_d2 = 0.0
+    sum_interior_d1 = 0.0
+    crawling = 0
+    for i in range(npx):
+        if not interior[i]:
+            continue
+        m2 = sum_d2[i] * inv_d2
+        per_pixel_d2.append(m2)
+        sum_interior_d2 += m2
+        sum_interior_d1 += sum_d1[i] * inv_d1
+        if m2 > flicker_pixel_tol:
+            crawling += 1
+
+    interior_px = len(per_pixel_d2)
+    if interior_px == 0:
+        raise ValueError(
+            "no interior pixels (foreground in every frame) — check ROI / "
+            "background colour, or the shape left the ROI during the sweep"
+        )
+
+    per_pixel_d2.sort()
+    p95 = per_pixel_d2[min(interior_px - 1, int(0.95 * interior_px))]
+
+    result = {
+        "frames": n,
+        "roi": list(rect),
+        "interior_px": interior_px,
+        "jitter_score": round(sum_interior_d2 / interior_px, 4),
+        "flicker_p95": round(p95, 4),
+        "flicker_frac": round(crawling / interior_px, 4),
+        "mean_abs_d1": round(sum_interior_d1 / interior_px, 4),
+        "flicker_pixel_tol": flicker_pixel_tol,
+    }
+
+    if diff_out is not None:
+        _write_heatmap(diff_out, sum_d2, interior, rw, rh, inv_d2)
+        result["diff_out"] = diff_out
+
+    return result
+
+
+def _write_heatmap(
+    path: str, sum_d2: array, interior: bytearray, w: int, h: int, inv_d2: float
+) -> None:
+    """Grayscale RGBA heatmap of per-pixel mean |d2| (interior only).
+
+    Brightness ∝ jitter so a reviewer can see *where* the surface crawls — the
+    crawling rings light up, the stable interior stays dark. Scaled so a mean
+    |d2| of 32 luminance units saturates to white (heavy crawl reads clearly
+    without a long dim tail).
+    """
+    scale = 255.0 / 32.0
+    out = bytearray(4 * w * h)
+    for i in range(w * h):
+        v = 0
+        if interior[i]:
+            v = int(sum_d2[i] * inv_d2 * scale)
+            v = 255 if v > 255 else v
+        o = i * 4
+        out[o] = out[o + 1] = out[o + 2] = v
+        out[o + 3] = 255
+    util.write_png(path, w, h, bytes(out), 4)
+
+
+def _main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("images", nargs="+",
+                    help="PNG captures in yaw-sweep order (≥3, consecutive "
+                         "frames a sub-degree yaw step apart).")
+    ap.add_argument("--roi", type=util.parse_roi, default=None,
+                    help="x,y,w,h region of interest (default: whole image).")
+    ap.add_argument("--bg", type=util.parse_rgb, default=util.DEFAULT_BG,
+                    help="background/clear colour r,g,b (default: 0,0,0).")
+    ap.add_argument("--bg-tol", type=int, default=util.DEFAULT_BG_TOL,
+                    help="per-channel tolerance for the background match.")
+    ap.add_argument("--flicker-pixel-tol", type=float, default=3.0,
+                    help="a pixel counts as crawling when its mean |d2| exceeds "
+                         "this many luminance units (drives flicker_frac).")
+    ap.add_argument("--max-jitter", type=float, default=None,
+                    help="fail if jitter_score (mean interior |d2|) exceeds this.")
+    ap.add_argument("--max-flicker-frac", type=float, default=None,
+                    help="fail if flicker_frac (crawling interior fraction) "
+                         "exceeds this.")
+    ap.add_argument("--max-flicker-p95", type=float, default=None,
+                    help="fail if flicker_p95 (per-pixel |d2| tail) exceeds this.")
+    ap.add_argument("--diff-out", default=None,
+                    help="write a per-pixel jitter heatmap PNG here.")
+    args = ap.parse_args(argv)
+
+    try:
+        m = jitter_metrics(args.images, args.roi, args.bg, args.bg_tol,
+                           args.flicker_pixel_tol, args.diff_out)
+    except (OSError, ValueError) as e:
+        print(json.dumps({"error": str(e)}))
+        return 2
+
+    failed = []
+    if args.max_jitter is not None and m["jitter_score"] > args.max_jitter:
+        failed.append(f"jitter_score {m['jitter_score']} > {args.max_jitter}")
+    if args.max_flicker_frac is not None and m["flicker_frac"] > args.max_flicker_frac:
+        failed.append(f"flicker_frac {m['flicker_frac']} > {args.max_flicker_frac}")
+    if args.max_flicker_p95 is not None and m["flicker_p95"] > args.max_flicker_p95:
+        failed.append(f"flicker_p95 {m['flicker_p95']} > {args.max_flicker_p95}")
+
+    return util.emit(m, failed)
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/scripts/tests/test_render_jitter_metric.py
+++ b/scripts/tests/test_render_jitter_metric.py
@@ -155,7 +155,7 @@ class JitterMetricTest(unittest.TestCase):
             cp = _write_seq(Path(td), 16, _crawling_rings)
             self.assertEqual(_rc([*cp, "--max-jitter", "3.0"]), 1)
 
-    def test_too_few_frames_is_io_error(self):
+    def test_too_few_frames_is_format_error(self):
         with tempfile.TemporaryDirectory() as td:
             paths = _write_seq(Path(td), 2, _static)
             self.assertEqual(_rc(paths), 2)

--- a/scripts/tests/test_render_jitter_metric.py
+++ b/scripts/tests/test_render_jitter_metric.py
@@ -1,0 +1,179 @@
+"""Tests for render-jitter-metric.py — the temporal-jitter metric.
+
+Proves the core claim the metric exists to make: a frame sequence undergoing
+*smooth* motion (a gradient that ramps or pans frame-to-frame) scores a near-
+zero ``jitter_score``, while a sequence whose interior *oscillates* (a crawling-
+band pattern that toggles each frame — the epic #1881 / #1920 artifact) scores
+an order of magnitude higher and trips the ``--max-jitter`` gate. The second
+temporal difference is what separates the two; a first-difference metric would
+flag both. Synthetic PNGs only — no GL/Metal context. Import via importlib
+(dashed name), mirroring test_render_silhouette_metric.py.
+"""
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
+import math
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load(mod_name: str, file_name: str):
+    loader = importlib.machinery.SourceFileLoader(
+        mod_name, str(_SCRIPTS / file_name))
+    spec = importlib.util.spec_from_loader(mod_name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+_mod = _load("render_jitter_metric", "render-jitter-metric.py")
+jitter_metrics = _mod.jitter_metrics
+_util = _mod.util
+
+W, H = 48, 48
+# A centred 24x24 foreground square; its silhouette is identical in every frame
+# (only the interior shading varies), so the AND-of-masks interior is the whole
+# square — exactly the "stable surface" the metric measures.
+SQ_LO, SQ_HI = 12, 36
+
+
+def _rc(argv) -> int:
+    with contextlib.redirect_stdout(io.StringIO()), \
+            contextlib.redirect_stderr(io.StringIO()):
+        return _mod._main(argv)
+
+
+def _write_seq(d: Path, n: int, shade):
+    """Write n gray RGBA frames; ``shade(x, y, t)`` -> 0..255 luminance.
+
+    Background (outside the square) is black; the square carries the shade.
+    Returns the ordered list of paths.
+    """
+    paths = []
+    for t in range(n):
+        buf = bytearray(4 * W * H)
+        for y in range(H):
+            for x in range(W):
+                inside = SQ_LO <= x < SQ_HI and SQ_LO <= y < SQ_HI
+                v = int(shade(x, y, t)) if inside else 0
+                v = 0 if v < 0 else (255 if v > 255 else v)
+                o = (y * W + x) * 4
+                buf[o] = buf[o + 1] = buf[o + 2] = v
+                buf[o + 3] = 255
+        p = d / f"frame_{t:03d}.png"
+        _util.write_png(str(p), W, H, bytes(buf), 4)
+        paths.append(str(p))
+    return paths
+
+
+# Shade functions (all keep the square foreground: value >= ~60 > bg_tol).
+def _static(x, y, t):
+    return 140
+
+
+def _temporal_ramp(x, y, t):
+    # Uniform brightness rising linearly with the frame: per-pixel linear in t,
+    # so the second temporal difference is exactly zero.
+    return 80 + t
+
+
+def _moving_linear_gradient(x, y, t):
+    # A spatial gradient sliding 1px/frame: per pixel still linear in t -> d2=0.
+    return 90 + (x + t)
+
+
+def _moving_sinusoid(x, y, t):
+    # A sinusoidal gradient sliding with the frame — genuine curved smooth
+    # motion. Per pixel it is a low-frequency sinusoid in t, so d2 is small but
+    # nonzero (bounded by amplitude * angular_freq**2).
+    return 128 + 40.0 * math.sin((x + t) * 0.15)
+
+
+def _crawling_rings(x, y, t):
+    # The artifact: concentric shells (by Manhattan distance) whose parity flips
+    # every frame, so each interior pixel toggles 60<->200 — maximal curvature.
+    d = abs(x - 24) + abs(y - 24)
+    return 200 if (d + t) % 2 == 0 else 60
+
+
+class JitterMetricTest(unittest.TestCase):
+    def _score(self, shade, n=12, **kw):
+        with tempfile.TemporaryDirectory() as td:
+            paths = _write_seq(Path(td), n, shade)
+            return jitter_metrics(paths, **kw)
+
+    def test_static_sequence_is_zero(self):
+        m = self._score(_static)
+        self.assertEqual(m["jitter_score"], 0.0)
+        self.assertEqual(m["mean_abs_d1"], 0.0)
+        self.assertEqual(m["interior_px"], (SQ_HI - SQ_LO) ** 2)
+
+    def test_temporal_ramp_zero_jitter_but_moves(self):
+        m = self._score(_temporal_ramp)
+        # Linear-in-t -> second difference vanishes, but first difference does
+        # not (it moves). This is the crux: motion without jitter.
+        self.assertLess(m["jitter_score"], 0.01)
+        self.assertGreater(m["mean_abs_d1"], 0.5)
+
+    def test_moving_linear_gradient_zero_jitter(self):
+        m = self._score(_moving_linear_gradient)
+        self.assertLess(m["jitter_score"], 0.01)
+        self.assertGreater(m["mean_abs_d1"], 0.5)
+
+    def test_moving_sinusoid_small_jitter(self):
+        m = self._score(_moving_sinusoid, n=16)
+        # Smooth curved motion: bounded, well under a crawl.
+        self.assertLess(m["jitter_score"], 3.0)
+
+    def test_crawling_rings_high_jitter(self):
+        m = self._score(_crawling_rings)
+        self.assertGreater(m["jitter_score"], 50.0)
+        # Every interior pixel toggles, so essentially all of it crawls.
+        self.assertGreater(m["flicker_frac"], 0.9)
+        self.assertGreater(m["flicker_p95"], 50.0)
+
+    def test_discriminates_crawl_from_smooth(self):
+        smooth = self._score(_moving_sinusoid, n=16)
+        crawl = self._score(_crawling_rings, n=16)
+        # The headline property: an order of magnitude of separation.
+        self.assertGreater(crawl["jitter_score"], 10.0 * smooth["jitter_score"] + 10.0)
+
+    def test_threshold_gate_exit_codes(self):
+        # Smooth passes a 3.0 gate; crawl fails it. Run via _main for the
+        # exit-code contract (0 within thresholds, 1 exceeded).
+        with tempfile.TemporaryDirectory() as td:
+            sp = _write_seq(Path(td), 16, _moving_sinusoid)
+            self.assertEqual(_rc([*sp, "--max-jitter", "3.0"]), 0)
+        with tempfile.TemporaryDirectory() as td:
+            cp = _write_seq(Path(td), 16, _crawling_rings)
+            self.assertEqual(_rc([*cp, "--max-jitter", "3.0"]), 1)
+
+    def test_too_few_frames_is_io_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            paths = _write_seq(Path(td), 2, _static)
+            self.assertEqual(_rc(paths), 2)
+
+    def test_roi_scopes_measurement(self):
+        # An ROI fully inside the square keeps every ROI pixel interior.
+        m = self._score(_crawling_rings, roi=(16, 16, 8, 8))
+        self.assertEqual(m["roi"], [16, 16, 8, 8])
+        self.assertEqual(m["interior_px"], 64)
+
+    def test_diff_out_written_at_frame_dims(self):
+        with tempfile.TemporaryDirectory() as td:
+            paths = _write_seq(Path(td), 8, _crawling_rings)
+            out = str(Path(td) / "heat.png")
+            jitter_metrics(paths, diff_out=out)
+            w, h, _bpp, _pix = _util.read_png(out)
+            self.assertEqual((w, h), (W, H))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Acceptance-gate harness for **epic #1881** (rotated-voxel correctness under camera Z-yaw). The epic's existing solidity harness (`perf-grid-rotate-sweep`, #1882) scores per-frame *coverage* of one cube; this one scores *temporal stability* — does the rendered surface shimmer as the camera turns — across every SDF shape.

- **`scripts/render-jitter-metric.py`** — the discriminator is the **second temporal difference** (discrete Laplacian) of per-pixel luminance over a fine yaw sweep: smooth shading ramps → `d2 ≈ 0`; a crawling band oscillating across an integer boundary spikes `d2`. The first difference can't tell smooth motion from crawl, which is why the metric keys on curvature. Pure stdlib, streaming 3-frame window, interior-only mask, reuses `render_metric_util`.
- **`scripts/tests/test_render_jitter_metric.py`** — 10 synthetic-frame tests proving the core claim: a gradient sliding 1px/frame (high `d1`) scores ~0 jitter, a parity-flipping ring scores 50×+, and the gate exit-codes hold.
- **`scripts/dev/shape-rotate-jitter-sweep`** — one command sweeps all 8 SDF shapes × a 360-step (1°) yaw turn, SDF + voxel-pool render paths, with a documented `MAX_JITTER=4.0` gate.
- **`creations/demos/shape_debug`** — `--spin-shape` / `--spin-shape-voxel` spawn a single origin-centred shape with a centred ROI crop per shot (so the metric decodes small PNGs, not the full retina framebuffer). The default fixture scene is **byte-identical** — canvas-lighting setup was extracted to a shared helper with no behaviour change.
- **`docs/design/jitter-validation-harness.md`** — the measured macOS/Metal master baseline + gate rationale + render-path coverage scope.

### Master baseline (macOS/Metal, zoom 8, 360 steps, SDF path)
| shape | jitter | verdict |  | shape | jitter | verdict |
|---|---|---|---|---|---|---|
| torus | 1.07 | PASS |  | box | 6.74 | **FAIL** |
| cone | 1.13 | PASS |  | wedge | 6.26 | **FAIL** |
| cylinder | 1.17 | PASS |  | ellipsoid | 7.54 | **FAIL** |
| sphere | 1.20 | PASS |  | **curved_panel** | **11.38** | **FAIL** |

The gate (4.0) separates the two clusters with a ~5× margin. **curved_panel** is the worst — the canonical **Bug-A curved-SDF band crawl** reproduced as a FAIL on origin/master, exactly as the acceptance criteria require. The curved family lands on *both* sides (sphere/cylinder/cone/torus pass; ellipsoid/curved_panel fail), which proves the metric flags genuine crawl, not shape class.

## Test plan
- [x] `python3 scripts/tests/test_render_jitter_metric.py` — 10/10 pass (no GL/Metal context needed).
- [x] `fleet-build --target IRShapeDebug` clean; full 8-shape sweep runs end-to-end (table above); voxel-pool path validated (box-voxel ≈6.7, FAILs comparably).
- [x] **Default render output-neutral:** ran `render-verify` against the committed shape_debug references on both origin/master and this branch — identical 21/24 results (the references are stale vs current master, a pre-existing issue unrelated to this PR; see notes). The refactor changed no pixels.

## Notes for the reviewer
- **No screenshots attached:** the only render-path change is an opt-in `--spin-shape` mode (off in normal runs) + an output-neutral canvas-lighting refactor; the default cardinals are byte-identical, proven by the render-verify parity above. The harness's own crops/heatmaps are the relevant visual artifact.
- **Pre-existing, out of scope:** (1) the shape_debug render-verify references are stale on master (21/24 fail on a clean master build) — the gate is currently non-functional and wants a refresh; (2) the canvas-lighting setup block is duplicated inline in `analytic_oracle` and `fog_demo` (the latter comments that it copied shape_debug) — a shared demo helper would dedup all three.
- The full **voxel-path** and **OpenGL/Linux** baselines are scoped follow-ups (same one command on the other axis); the gate is backend-agnostic (luminance curvature).

Closes #1922

🤖 Generated with [Claude Code](https://claude.com/claude-code)