### PR TITLE
render: composite-depth readback probe for #1884 debugging (#1910)

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -52,12 +52,14 @@
 // Prefab helpers
 #include <irreden/render/camera.hpp>
 #include <irreden/render/camera_controls.hpp>
+#include <irreden/render/depth_probe.hpp>
 #include <irreden/render/entity_canvas.hpp>
 
 // Command suites
 #include <irreden/common/command_suite_capture.hpp>
 
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <cstdlib>
 #include <string>
@@ -149,6 +151,15 @@ struct CanvasStressSettings {
     // deferred to the structural-gate work (T-2/T-3). NONE leaves the live
     // pipeline untouched, so a flagless run is byte-identical.
     IRRender::DebugOverlayMode debugOverlay_ = IRRender::DebugOverlayMode::NONE;
+    // `--depth-probe X,Y` (#1910): each frame, read back and log the real
+    // composite depth-test value at main-framebuffer texture pixel (X,Y) —
+    // top-left origin, in framebuffer-texture space (the size logged at canvas
+    // creation), not window/screenshot pixels. Off by default; when off no probe
+    // system is registered, so a flagless run is byte-identical. Used to
+    // root-cause the #1884 detached-vs-floor depth crossing in this demo (the
+    // floating canary cube clips behind the SDF floor at high zoom).
+    bool depthProbeSet_ = false;
+    ivec2 depthProbePixel_{0, 0};
     // readConfig() runs AFTER parseArgs() (it needs IREngine::init), so a
     // config `auto_rotate` would otherwise clobber an explicit
     // --auto-rotate / --no-auto-rotate flag. Latch CLI intent so config only
@@ -697,6 +708,19 @@ void parseArgs(int argc, char **argv) {
         } else if (std::strcmp(argv[i], "--debug-overlay") == 0 && i + 1 < argc) {
             g_settings.debugOverlay_ = IRRender::debugOverlayModeFromString(argv[i + 1]);
             ++i;
+        } else if (std::strcmp(argv[i], "--depth-probe") == 0 && i + 1 < argc) {
+            int px = 0;
+            int py = 0;
+            if (std::sscanf(argv[i + 1], "%d,%d", &px, &py) == 2) {
+                g_settings.depthProbeSet_ = true;
+                g_settings.depthProbePixel_ = ivec2(px, py);
+            } else {
+                IR_LOG_WARN(
+                    "--depth-probe: expected X,Y (e.g. 960,540); ignoring '{}'",
+                    argv[i + 1]
+                );
+            }
+            ++i;
         }
     }
     if (g_settings.sweepYawCount_ > 0 || g_settings.sweepFramesCount_ > 0) {
@@ -827,6 +851,20 @@ void initSystems() {
     renderPipeline.push_back(IRSystem::createSystem<IRSystem::TRIXEL_TO_FRAMEBUFFER>());
     renderPipeline.push_back(IRSystem::createSystem<IRSystem::ENTITY_CANVAS_TO_FRAMEBUFFER>());
     renderPipeline.push_back(IRSystem::createSystem<IRSystem::FRAMEBUFFER_TO_SCREEN>());
+
+    // #1910 composite-depth probe — registered only with --depth-probe so a
+    // flagless run adds no system. Runs last (after the framebuffer composite is
+    // complete) and logs the depth-test winner at the requested pixel each frame.
+    if (g_settings.depthProbeSet_) {
+        const ivec2 probePixel = g_settings.depthProbePixel_;
+        renderPipeline.push_back(
+            IRSystem::createSystem<C_Camera>(
+                "DepthProbe",
+                [](C_Camera &) {},
+                [probePixel]() { IRPrefab::DepthProbe::logCompositeDepth(probePixel); }
+            )
+        );
+    }
 
     if (g_autoWarmupFrames > 0) {
         int settleFrames = 60;

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -34,6 +34,7 @@
 #include <irreden/render/systems/system_build_distance_hiz.hpp>
 #include <irreden/render/systems/system_build_light_occlusion_grid.hpp>
 #include <irreden/render/camera_controls.hpp>
+#include <irreden/render/depth_probe.hpp>
 #include <irreden/render/systems/system_compute_light_volume.hpp>
 #include <irreden/render/systems/system_compute_sun_shadow.hpp>
 #include <irreden/render/systems/system_compute_voxel_ao.hpp>
@@ -56,6 +57,7 @@
 #include <irreden/common/command_suite_capture.hpp>
 
 #include <algorithm>
+#include <cstdio>
 #include <cstring>
 #include <cstdlib>
 #include <numbers>
@@ -128,6 +130,13 @@ struct CliOverrides {
     // Accepted and recorded for manifest/cell-ID purposes; ignored until T-221.
     int workerThreads_ = 0;
     std::string configPreset_; // path from --config-preset, empty if absent
+    // `--depth-probe X,Y` (#1910): per-frame composite-depth readback + log at
+    // main-framebuffer texture pixel (X,Y), top-left origin (framebuffer-texture
+    // space, not window/screenshot pixels). Off by default → no probe system
+    // registered → flagless run byte-identical. Used to root-cause the #1884
+    // per-axis Y-over-X face-stripe depth crossing this demo exercises.
+    bool depthProbeSet_ = false;
+    ivec2 depthProbePixel_{0, 0};
 };
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
@@ -517,6 +526,19 @@ void parseArgs(int argc, char **argv) {
                 g_cliOverrides.workerThreads_ = wt;
             }
             ++i;
+        } else if (std::strcmp(argv[i], "--depth-probe") == 0 && i + 1 < argc) {
+            int px = 0;
+            int py = 0;
+            if (std::sscanf(argv[i + 1], "%d,%d", &px, &py) == 2) {
+                g_cliOverrides.depthProbeSet_ = true;
+                g_cliOverrides.depthProbePixel_ = ivec2(px, py);
+            } else {
+                IR_LOG_WARN(
+                    "--depth-probe: expected X,Y (e.g. 960,540); ignoring '{}'",
+                    argv[i + 1]
+                );
+            }
+            ++i;
         }
     }
 }
@@ -841,6 +863,20 @@ void initSystems() {
             IRSystem::createSystem<IRSystem::FRAMEBUFFER_TO_SCREEN>(),
         }
     );
+
+    // #1910 composite-depth probe — registered only with --depth-probe so a
+    // flagless run adds no system. Runs after the framebuffer composite and logs
+    // the depth-test winner at the requested pixel each frame.
+    if (g_cliOverrides.depthProbeSet_) {
+        const ivec2 probePixel = g_cliOverrides.depthProbePixel_;
+        renderPipeline.push_back(
+            IRSystem::createSystem<C_Name>(
+                "DepthProbe",
+                [](C_Name &) {},
+                [probePixel]() { IRPrefab::DepthProbe::logCompositeDepth(probePixel); }
+            )
+        );
+    }
 
     if (g_autoProfileFrames > 0) {
         IRSystem::SystemId autoProfileId = IRSystem::createSystem<C_Name>(

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -14,6 +14,7 @@
 #include <irreden/common/components/component_modifiers.hpp>
 #include <irreden/common/components/component_name.hpp>
 #include <irreden/common/components/component_local_transform.hpp>
+#include <irreden/render/components/component_camera.hpp>
 #include <irreden/render/components/component_canvas_ao_texture.hpp>
 #include <irreden/render/components/component_canvas_fog_of_war.hpp>
 #include <irreden/render/components/component_canvas_light_volume.hpp>
@@ -870,9 +871,9 @@ void initSystems() {
     if (g_cliOverrides.depthProbeSet_) {
         const ivec2 probePixel = g_cliOverrides.depthProbePixel_;
         renderPipeline.push_back(
-            IRSystem::createSystem<C_Name>(
+            IRSystem::createSystem<C_Camera>(
                 "DepthProbe",
-                [](C_Name &) {},
+                [](C_Camera &) {},
                 [probePixel]() { IRPrefab::DepthProbe::logCompositeDepth(probePixel); }
             )
         );

--- a/engine/prefabs/irreden/render/components/component_trixel_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/components/component_trixel_framebuffer.hpp
@@ -45,6 +45,11 @@ struct C_TrixelCanvasFramebuffer {
         framebuffer_.second->getTextureDepth().bind(bindingDepth);
     }
 
+    // The composite depth attachment, for CPU readback (the #1910 depth probe).
+    const Texture2D &getTextureDepth() const {
+        return framebuffer_.second->getTextureDepth();
+    }
+
     const ivec2 getResolution() const {
         return framebuffer_.second->getResolution();
     }

--- a/engine/prefabs/irreden/render/depth_probe.hpp
+++ b/engine/prefabs/irreden/render/depth_probe.hpp
@@ -1,0 +1,123 @@
+#ifndef DEPTH_PROBE_H
+#define DEPTH_PROBE_H
+
+#include <irreden/ir_constants.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_platform.hpp>
+#include <irreden/ir_profile.hpp>
+
+#include <irreden/render/components/component_trixel_framebuffer.hpp>
+
+// GPU→CPU composite-depth probe (#1910). A debug-only readback that, for a
+// requested screen pixel, reads the REAL depth-test value stored in the main
+// framebuffer's depth attachment and decodes it to shared trixel-distance
+// units. Because every render path — the cardinal gather
+// (f_trixel_to_framebuffer), the per-axis forward scatter (f_per_axis_scatter),
+// and the detached-canvas composite (ENTITY_CANVAS_TO_FRAMEBUFFER) — writes its
+// winning fragment's `gl_FragDepth` into this one attachment under the GL_LESS
+// depth test, a single readback captures the true composite winner regardless of
+// which path produced the pixel. That is the reconciled, comparable depth the
+// #1884 "behind-face wins" crossings need diagnosed in real units, and the
+// reason this reads the attachment rather than approximating depth as a shader
+// color output (which loses precision and can't be decoded per-path).
+//
+// Pure readback: it touches no shader and no render state, so a scene with the
+// probe off — or even on — is byte-identical at the pixel level. The cost is a
+// full GPU flush per probed frame (device()->finish(): Metal commit+wait per
+// #1436, GL glFinish), so keep it strictly debug-gated and single-pixel.
+//
+// Lives in the prefab layer (not IRRender::) because it resolves the
+// "mainFramebuffer" prefab entity — engine/render/ owns graphics primitives, not
+// scene entities. The generic depth-texture readback primitive it builds on is
+// `Texture2D::getSubImage2D(..., PixelDataFormat::DEPTH_COMPONENT, FLOAT32, ...)`.
+namespace IRPrefab::DepthProbe {
+
+/// Result of a single-pixel composite-depth readback.
+/// @c normDepth_ is the raw window depth in [0, 1] read from the attachment (the
+/// depth-test winner across every render path). @c rawDist_ decodes it to the
+/// shared trixel-distance units via the exact inverse of
+/// @c f_trixel_to_framebuffer's @c normalizeDistance, using the same
+/// @c kTrixelDistance{Min,Max}Distance constants — so the same world point reads
+/// the same value regardless of which path produced it.
+struct CompositeDepthSample {
+    IRMath::ivec2 pixel_{-1, -1};
+    float normDepth_ = 1.0f;
+    float rawDist_ = 0.0f;
+    bool valid_ = false;
+};
+
+/// Read and decode the main framebuffer's composite depth at pixel @p px.
+/// Coordinates are in the MAIN FRAMEBUFFER's texture space (its
+/// resolution-plus-buffer, logged at canvas creation, e.g. 642x722), top-left
+/// origin — NOT window/screenshot pixels (FRAMEBUFFER_TO_SCREEN blits this
+/// texture to the window under camera pan/zoom, so the screenshot is a
+/// camera-dependent view of it). Call AFTER the framebuffer composite is
+/// complete (after @c ENTITY_CANVAS_TO_FRAMEBUFFER / @c FRAMEBUFFER_TO_SCREEN).
+/// Returns @c valid_ == false when @p px is outside the framebuffer.
+inline CompositeDepthSample readbackCompositeDepth(IRMath::ivec2 px) {
+    CompositeDepthSample sample;
+    sample.pixel_ = px;
+
+    const auto &framebuffer =
+        IREntity::getComponent<IRComponents::C_TrixelCanvasFramebuffer>("mainFramebuffer");
+    const IRMath::ivec2 resolution = framebuffer.getResolutionPlusBuffer();
+    if (px.x < 0 || px.y < 0 || px.x >= resolution.x || px.y >= resolution.y) {
+        return sample;
+    }
+
+    // The offscreen framebuffer depth texture is bottom-left origin on OpenGL,
+    // top-left on Metal; map the top-left screen pixel to the texel accordingly
+    // (mirrors readDefaultFramebuffer's GL row flip so a pixel picked from an
+    // auto-screenshot maps to the same texel on both backends).
+    const int texelY = IRPlatform::kIsOpenGL ? (resolution.y - 1 - px.y) : px.y;
+
+    // Flush so the readback sees this frame's committed composite. On Metal this
+    // is the mandatory commit+wait before getBytes (#1436); on OpenGL glFinish.
+    IRRender::device()->finish();
+
+    // gl_FragDepth is written directly as window depth in [0, 1] on both
+    // backends (the shader stores `normalizeDistance(...)`), so the value read
+    // back IS the normalized distance — no NDC depth-range conversion needed.
+    float windowDepth = 1.0f;
+    framebuffer.getTextureDepth().getSubImage2D(
+        px.x,
+        texelY,
+        1,
+        1,
+        IRRender::PixelDataFormat::DEPTH_COMPONENT,
+        IRRender::PixelDataType::FLOAT32,
+        &windowDepth
+    );
+
+    sample.normDepth_ = windowDepth;
+    sample.rawDist_ =
+        windowDepth * static_cast<float>(
+                          IRConstants::kTrixelDistanceMaxDistance -
+                          IRConstants::kTrixelDistanceMinDistance
+                      ) +
+        static_cast<float>(IRConstants::kTrixelDistanceMinDistance);
+    sample.valid_ = true;
+    return sample;
+}
+
+/// Convenience wrapper: read @p px and emit one machine-readable
+/// @c IR_LOG_INFO line a human or script can read the depth ordering directly
+/// from. Format: @c [depth-probe] pixel=(x,y) normDepth=… rawDist=…
+inline void logCompositeDepth(IRMath::ivec2 px) {
+    const CompositeDepthSample sample = readbackCompositeDepth(px);
+    if (!sample.valid_) {
+        IR_LOG_INFO("[depth-probe] pixel=({},{}) out-of-range (no framebuffer pixel)", px.x, px.y);
+        return;
+    }
+    IR_LOG_INFO(
+        "[depth-probe] pixel=({},{}) normDepth={:.6f} rawDist={:.1f}",
+        sample.pixel_.x,
+        sample.pixel_.y,
+        sample.normDepth_,
+        sample.rawDist_
+    );
+}
+
+} // namespace IRPrefab::DepthProbe
+
+#endif /* DEPTH_PROBE_H */

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -241,6 +241,20 @@ The output renders drifted pixels solid red against a desaturated
 baseline. Useful both for the agent's evaluation step and for
 reviewer-facing PR-body screenshots.
 
+For depth-ordering bugs (a near surface clipping behind a far one)
+where you need the **exact stored composite depth** rather than a
+visual cue, use the `--depth-probe X,Y` flag (#1910;
+`canvas_stress` + `perf_grid`). It reads back and logs the real
+depth-test value at main-framebuffer texture pixel (X,Y) each frame —
+the GL_LESS winner across every render path, since gather, per-axis
+scatter, and the detached-canvas composite all write `gl_FragDepth`
+into the one depth attachment — decoded to shared trixel-distance
+units. The probe lives in `IRPrefab::DepthProbe::` (a prefab-scoped
+Pattern-B namespace over the `Texture2D` /
+`PixelDataFormat::DEPTH_COMPONENT` readback primitive). Pure readback:
+no shader or pipeline change, so a flagless run is byte-identical. Use
+it when a screenshot can't disambiguate which surface won a pixel.
+
 For changes that touch only one graphics backend (GLSL without MSL
 counterpart, or vice versa), follow up with the **`backend-parity`**
 skill on the lagging-side host — the rule is in [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md)

--- a/engine/render/include/irreden/render/ir_render_enums.hpp
+++ b/engine/render/include/irreden/render/ir_render_enums.hpp
@@ -30,7 +30,10 @@ enum class TextureAccess : std::uint8_t {
 enum class TextureFormat : std::uint8_t { RGBA8, RGBA16F, RGBA32F, R32I, RG32UI, DEPTH24_STENCIL8 };
 
 /// CPU-side pixel format for @c glReadPixels / texture upload.
-enum class PixelDataFormat : std::uint8_t { RGBA, RED_INTEGER, RG_INTEGER };
+/// @c DEPTH_COMPONENT reads the depth plane of a @c DEPTH24_STENCIL8 attachment
+/// back to a single-channel @c FLOAT32 buffer (window depth in [0, 1]); the
+/// #1910 composite-depth probe is its only consumer today.
+enum class PixelDataFormat : std::uint8_t { RGBA, RED_INTEGER, RG_INTEGER, DEPTH_COMPONENT };
 
 /// CPU-side pixel data type for @c glReadPixels / texture upload.
 enum class PixelDataType : std::uint8_t { UNSIGNED_BYTE, INT32, UINT32, FLOAT32 };

--- a/engine/render/include/irreden/render/opengl/opengl_types.hpp
+++ b/engine/render/include/irreden/render/opengl/opengl_types.hpp
@@ -87,6 +87,8 @@ inline GLenum toGLPixelDataFormat(PixelDataFormat format) {
         return GL_RED_INTEGER;
     case PixelDataFormat::RG_INTEGER:
         return GL_RG_INTEGER;
+    case PixelDataFormat::DEPTH_COMPONENT:
+        return GL_DEPTH_COMPONENT;
     }
     return GL_RGBA;
 }

--- a/engine/render/src/metal/metal_texture.cpp
+++ b/engine/render/src/metal/metal_texture.cpp
@@ -45,6 +45,7 @@ std::size_t pixelSizeBytes(PixelDataFormat format, PixelDataType type) {
             case PixelDataFormat::RGBA:
                 return 4;
             case PixelDataFormat::RED_INTEGER:
+            case PixelDataFormat::DEPTH_COMPONENT:
                 return 1;
             case PixelDataFormat::RG_INTEGER:
                 return 2;

--- a/engine/render/src/opengl/opengl_texture.cpp
+++ b/engine/render/src/opengl/opengl_texture.cpp
@@ -27,6 +27,7 @@ GLsizei glTypeSize(GLenum type) {
 
 GLsizei glFormatComponents(GLenum format) {
     switch (format) {
+        case GL_DEPTH_COMPONENT:
         case GL_RED:
         case GL_RED_INTEGER:
             return 1;


### PR DESCRIPTION
## Summary
A debug-only GPU→CPU readback that logs the **real composite depth-test value** at a requested framebuffer pixel, decoded to shared trixel-distance units. Tooling prerequisite that unblocks #1884 (epic #1881).

Every render path — cardinal gather (`f_trixel_to_framebuffer`), per-axis scatter (`f_per_axis_scatter`), and the detached-canvas composite (`ENTITY_CANVAS_TO_FRAMEBUFFER`) — writes its winning `gl_FragDepth` into the **one** framebuffer depth attachment under the `GL_LESS` test. So a single readback of that attachment captures the true composite winner regardless of which path produced the pixel — that's why this reads the attachment rather than approximating depth as a shader color output (which loses precision and can't be decoded per-path).

### What landed
- **engine/render primitive:** `PixelDataFormat::DEPTH_COMPONENT`, wired through the OpenGL (`glGetTextureSubImage` + `GL_DEPTH_COMPONENT`) and Metal (`getBytes`) `Texture2D::getSubImage2D` readback paths. Reuses the existing readback machinery + `device()->finish()` (Metal commit+wait per #1436) rather than hand-rolling a new path.
- **prefab helper:** `IRPrefab::DepthProbe::readbackCompositeDepth / logCompositeDepth` (`engine/prefabs/irreden/render/depth_probe.hpp`) — resolves the `mainFramebuffer` entity, flushes, reads the depth attachment, decodes via the exact inverse of `normalizeDistance`, logs `[depth-probe] pixel=(x,y) normDepth=… rawDist=…`.
- **demos:** `--depth-probe X,Y` in `canvas_stress` (#1884 bug A: detached-vs-floor) and `perf_grid` (#1884 bug B: per-axis stripe).
- doc pointer in `engine/render/CLAUDE.md` alongside the other depth diagnostics.

### Design notes / deliberate deviations
- **API placement.** The plan named `IRRender::readbackCompositeDepth`, but the high-level probe resolves the `mainFramebuffer` *prefab entity* — reaching a prefab entity from `engine/render/` is a layering violation, and `engine/render/CLAUDE.md` forbids feature API on `IRRender::`. So the generic depth-texture readback is the `engine/render` primitive (`PixelDataFormat::DEPTH_COMPONENT`) and the framebuffer-resolving helper is a prefab-scoped Pattern-B namespace (`IRPrefab::DepthProbe::`), mirroring `fog_of_war.hpp`.
- **Coordinates** are main-framebuffer **texture** space (resolution+buffer, e.g. 642×722), top-left origin — not window/screenshot pixels (`FRAMEBUFFER_TO_SCREEN` blits under camera pan/zoom).
- **Stretch deferred.** Per-canvas R32I distance decode (per-path side-by-side) is deferred: #1640's scratch-buffer indirection makes a direct R32I CPU `getBytes` return the clear value on Metal — it would need a resolve pass. The framebuffer **depth** attachment works because it's a real depth-test buffer, not `imageAtomicMin` scratch.

### Why no screenshots
Pure readback — **no shader or pipeline-output change**. The probe system is registered only when `--depth-probe` is set, so a flagless run is byte-identical; even with the flag on it only reads, never writes render state. Evidence is the probe log, not a visual diff (render CLAUDE.md "provably no runtime effect" exception). The OpenGL path is compile/run-validated by Linux cross-host smoke (macOS does not compile the GL backend).

## Test plan
- [x] Builds on macOS/Metal (`IRCanvasStress`, `IRPerfGrid`).
- [x] Metal `getBytes` on the `Depth32Float_Stencil8` attachment returns sane decoded depth (no validation error).
- [x] Distinguishes surfaces from empty: `canvas_stress` center pixel → `rawDist=58`; corners → `rawDist=65535` (the `kTrixelDistanceMaxDistance` clear sentinel, `normDepth=1.0`). Decode verified exact: (−40+65535)/131070 = 0.49969.
- [x] `perf_grid --depth-probe` reads the grid surface (`rawDist=−429.5`).
- [ ] OpenGL/Linux cross-host smoke (`glGetTextureSubImage` + `GL_DEPTH_COMPONENT` depth path).

Closes #1910

🤖 Generated with [Claude Code](https://claude.com/claude-code)