### PR TITLE
docs: plan epic #1933 — analytic scatter coverage root fix (#1937–#1939)

### DIFF
--- a/.fleet/plans/issue-1933.md
+++ b/.fleet/plans/issue-1933.md
@@ -128,8 +128,8 @@ its predecessor). They also serialize against the sibling SDF-jitter work
 | Phase | Child | Model | Effort | Blocked by |
 |---|---|---|---|---|
 | C1 | render: analytic edge-aware coverage on the per-axis scatter (GL) | opus | high | (none) |
-| C2 | render: Metal parity port of analytic scatter coverage | opus | medium | #C1 |
-| C3 | render: retire the manual scatter dilation margin/miter/yield tower + full validation | opus | high | #C2, #1922 |
+| C2 | render: Metal parity port of analytic scatter coverage | opus | medium | #1937 |
+| C3 | render: retire the manual scatter dilation margin/miter/yield tower + full validation | opus | high | #1938, #1922 |
 
 - **C1 (GL, de-risk + impl):** add the edge-type-aware analytic coverage to
   `{v_,f_}peraxis_scatter.glsl` + the helper in `ir_iso_common.glsl`; keep a

--- a/.fleet/plans/issue-1933.md
+++ b/.fleet/plans/issue-1933.md
@@ -1,0 +1,240 @@
+# Plan: conservative rasterization / analytic coverage on the per-axis scatter pass — root fix for corner spikes + silhouette dashing
+
+- **Issue:** #1933 (epic umbrella)
+- **Model:** opus
+- **Date:** 2026-06-21
+
+## Scope
+
+The per-axis voxel scatter pass loses sub-pixel coverage on foreshortened /
+rotated faces. The current mitigation is a **manual conservative-dilation
+margin** in the scatter vertex shader that grows each cell's rhombus outward,
+plus a small tower of fragment-side heuristics to make that over-fill behave.
+This margin is fighting a sub-pixel-rasterization problem with a geometry hack,
+and it has a proven dead end: the near-cardinal **corner spikes** on coarse
+cubes have **no local fix** (#1883 / #1917) because crisp corners need
+`M·C ≲ 2px` while foreshortened coverage forces `C ≈ half-cell` — mutually
+exclusive under a *uniform* margin.
+
+This epic replaces the uniform-margin **coverage decision** with **portable
+per-fragment analytic coverage** so a face's coverage is correct at the source,
+eliminating corner spikes AND silhouette dashing together and removing the
+hot-path geometry-hack tower.
+
+## Verified current state (source-confirmed)
+
+The per-axis scatter is a **rasterized instanced draw**, not a compute scatter:
+`drawElementsInstanced(TRIANGLES, …)` in
+`engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp:279`,
+one instance per per-axis cell, three passes (X/Y/Z). Each instance emits a
+deformed face quad; the vertex stage dilates the quad corners; the fragment
+stage classifies margin-vs-interior and applies a depth bias.
+
+The coverage heuristics, all in `engine/render/src/shaders/ir_iso_common.glsl`
+(GLSL) mirrored in `engine/render/src/shaders/metal/ir_iso_common.metal`:
+
+| Symbol | Value | Line (GLSL) | Origin | Role |
+|---|---|---|---|---|
+| `scatterConservativeDilation()` | — | :768 | #1494/#1538/#1883 | grows each quad corner outward by a per-axis miter |
+| `kScatterDilateMarginPx` | 0.85 px | :691 | #1494 | fixed camera-path margin floor |
+| `kScatterDetachedPitchFraction` | 0.5·pitch | :738 | #1538 | pitch-proportional floor, **detached scatter only** |
+| `kScatterMiterLimit` | 2.0 | :723 | #1538 | caps acute-corner blow-out |
+| `kScatterMarginDepthBiasKey` | 0.25 key | :701 | #1457 | margin fragments yield to exact footprints (sub-pixel tie-break) |
+| `kScatterMarginYieldGradScale` | 3.0 | :717 | #1883 | margin yields harder the further it extrapolated the face plane |
+
+Per-axis margin = `max(floor, 0.5·|n|)` per edge (`:785`), mitered (not additive)
+so acute sliver tips don't cancel (`:791-808`). On foreshortened near-cardinal
+faces `0.5·|n|` reaches a cell-deep fraction — **that** is the corner spike, and
+why no single margin value works (the #1883 mutual-exclusion).
+
+**Confirmed repro path:** `scripts/dev/perf-grid-rotate-sweep` (the #1882
+rotated-solidity harness) on coarse GRID cubes shows the near-cardinal corner
+spikes the #1917 PR accepts as documented drift pending this root fix.
+
+## Approach decision — analytic coverage (the other two candidates ruled out)
+
+The issue title offers three candidate models (HW conservative rasterization /
+MSAA / analytic coverage). **Source-verified capability audit picks analytic
+coverage as the only portable, shared-contract option:**
+
+1. **Hardware conservative rasterization — OFF the table.**
+   - **Metal has no conservative-rasterization API at all** (metal-cpp exposes
+     only programmable sample positions + `MTLRasterizationRateMap` — neither is
+     conservative raster). macOS simply can't do it.
+   - **OpenGL's is a vendor extension** (`GL_NV_conservative_raster` /
+     `GL_INTEL_conservative_rasterization`), never core. The engine targets
+     **GL 4.5 core** with **WSLg Mesa-d3d12 as the floor** across the fleet's
+     primary build host (`engine/window/include/irreden/window/ir_glfw_window.hpp`),
+     where these extensions are not guaranteed. Zero references exist today.
+   - A GL-conservative-raster / Metal-something split has **no shared CPU
+     contract** — exactly what the issue asks to avoid.
+
+2. **MSAA — OFF the table.**
+   - The pass writes a **color (RGBA8) + an integer distance texture (R32I) +
+     depth**; the R32I distance and depth are the co-sort metric consumed
+     downstream. MSAA-resolving an *integer* distance / depth is not an average —
+     it needs per-sample storage + a custom min/max resolve compute pass.
+   - 4×/8× multisampled canvas textures = 4–8× memory on every canvas, on a hot
+     path, plus a per-frame resolve. Far heavier than the defect warrants.
+   - Nothing in either backend is multisampled today (all single-sample).
+
+3. **Analytic per-fragment coverage — PICKED.** Fully portable (no extension, no
+   new GPU resource, no multisample targets), identical on GL + Metal (the
+   shaders are mirrors), and it directly breaks the #1883 mutual-exclusion:
+   **decouple the rasterization footprint (the quad dilation, kept only as a
+   "visit enough pixels" bound) from the coverage decision (exact, per-fragment,
+   analytic).** With coverage computed analytically against the *true* footprint,
+   the dilation can be generous without spiking corners, because the analytic
+   term trims each fragment back to the true face.
+
+### The coverage model
+
+Make coverage **edge-type-aware** — this is what removes the mutual-exclusion
+that a *uniform* margin could not:
+
+- **Interior edges** (shared with an occupied same-plane neighbor cell): fill
+  **conservatively** (round outward ~half a pixel) so the inter-cell waffle /
+  cracks the #1494 margin was added to close stay closed.
+- **Boundary / silhouette edges** (the face's outer edge — no occupied
+  neighbor): use **exact sub-pixel analytic coverage** (a smooth
+  `coverage = clamp(0.5 - signedDist/fwidth, 0, 1)`-style edge term, hard-
+  thresholded for the R32I/depth co-sort write). No outward over-extension →
+  **corners no longer spike**; sub-pixel partial coverage along the silhouette →
+  **no dashing** (the binary pixel-center test that drops sub-pixel slivers is
+  gone).
+
+A corner is where two **boundary** edges meet, so it gets exact treatment on
+both edges → no spike. A foreshortened silhouette is a boundary edge → analytic
+sub-pixel coverage → solid. Interior shared edges → conservative fill → no
+cracks. The vertex stage already knows each cell's grid position (`gl_InstanceID`)
+and reads the per-axis canvas data, so the **occupied-neighbor tap** that
+classifies each edge interior-vs-boundary is an incremental read, and the true
+(undilated) edge equations are passed as varyings.
+
+With analytic coverage authoritative, the fragment-side **margin-vs-interior
+machinery becomes redundant** — every surviving fragment is interior, so the
+margin depth-bias (`kScatterMarginDepthBiasKey`) and yield-gradient
+(`kScatterMarginYieldGradScale`), and the dilation margin/miter/pitch-fraction
+constants, are retired or reduced to the minimal visit-bound (child 3).
+
+## Decomposition (serial chain — shared shaders, #1881 one-at-a-time rule)
+
+All three children touch `ir_iso_common.{glsl,metal}` +
+`{v_,f_}peraxis_scatter.glsl` / `peraxis_scatter.metal`, so per epic #1881's
+"one shader change at a time" rule they **must serialize** (each `Blocked by:`
+its predecessor). They also serialize against the sibling SDF-jitter work
+(#1920) which shares `ir_iso_common` — see Gotchas.
+
+| Phase | Child | Model | Effort | Blocked by |
+|---|---|---|---|---|
+| C1 | render: analytic edge-aware coverage on the per-axis scatter (GL) | opus | high | (none) |
+| C2 | render: Metal parity port of analytic scatter coverage | opus | medium | #C1 |
+| C3 | render: retire the manual scatter dilation margin/miter/yield tower + full validation | opus | high | #C2, #1922 |
+
+- **C1 (GL, de-risk + impl):** add the edge-type-aware analytic coverage to
+  `{v_,f_}peraxis_scatter.glsl` + the helper in `ir_iso_common.glsl`; keep a
+  minimal fixed dilation as the visit-bound. Prove corner spikes gone + no
+  dashing on coarse cubes (3³/12³) near-cardinal via `perf-grid-rotate-sweep`
+  + `shape_debug`; cardinal fast-path byte-identical; no coverage regression.
+  GL first (the leading backend; new render work lands GLSL first).
+- **C2 (Metal parity):** mirror C1 into `peraxis_scatter.metal` +
+  `ir_iso_common.metal`; run the `backend-parity` audit. Pure port — no new
+  design.
+- **C3 (retire + validate):** with analytic coverage authoritative on both
+  backends, retire/simplify the redundant heuristics (the six symbols in the
+  table above, across camera + detached regimes, plus the fragment
+  margin-vs-interior classification). Validate temporal stability under the
+  **#1922 jitter harness** + epic #1881 rotated-solidity gate on both backends;
+  update the `engine/render/CLAUDE.md` convex-corner drift note (the
+  #1917-accepted drift is now fixed). Gated on #1922 being on master because
+  "temporally stable" is unverifiable without that harness.
+
+## Cross-system audit (consumers of the symbols C3 retires)
+
+All consumers are **shader-side only** — the margin constants are compile-time
+`const`/`constant` in the shaders; there is **no CPU-side uniform plumbing** to
+migrate (`grep` over `engine/**/*.{hpp,cpp}` finds none). Consumers:
+
+- `engine/render/src/shaders/v_peraxis_scatter.glsl:211,217-218` — calls
+  `scatterConservativeDilation(…, kScatterDilateMarginPx, …)`.
+- `engine/render/src/shaders/f_peraxis_scatter.glsl` — margin-vs-interior
+  classification + margin depth bias / yield gradient.
+- `engine/render/src/shaders/metal/peraxis_scatter.metal:194,198-200` — Metal
+  mirror of the vertex call.
+- `engine/render/src/shaders/ir_iso_common.glsl:691,701,717,723,738,768` +
+  `…/metal/ir_iso_common.metal:636,654,663,678` — the definitions.
+
+No other shader, system, or CPU caller references these symbols. The detached
+regime (`kScatterDetachedPitchFraction`) and camera regime
+(`kScatterDilateMarginPx` floor) both route through the same
+`scatterConservativeDilation`, so both are covered by the same retirement.
+
+## Acceptance criteria (epic-level)
+
+- Coarse-cube (3³ / 12³) near-cardinal poses render **crisp corners (no spikes)
+  AND solid foreshortened faces (no dashing)** — without the manual dilation
+  margin deciding coverage.
+- Both backends (Metal + OpenGL) at parity.
+- Temporally stable under the #1922 jitter harness (validated in C3, once #1922
+  is on master).
+- No regression on the epic #1881 rotated-solidity baseline; **cardinal fast
+  path byte-identical**.
+- The manual margin/miter/yield tower is retired (or reduced to a documented
+  minimal visit-bound); `engine/render/CLAUDE.md` drift note updated.
+
+## Gotchas
+
+- **Shared shader with #1920 (SDF jitter).** `ir_iso_common.{glsl,metal}` holds
+  both `scatterConservativeDilation` (this epic) and `findSurfaceDepth`
+  (#1920/#1925, currently design-blocked on #1922). They are different functions,
+  but per #1881's one-at-a-time rule, coordinate so this epic's children and the
+  #1920 work don't land overlapping edits to the same file simultaneously.
+- **R32I / depth co-sort is a hard per-pixel write** — analytic coverage feeds a
+  **hard threshold + discard** (or equivalent), not alpha-blended partial
+  coverage, because the distance/depth metric must stay a single value that
+  co-sorts with the SDF path (`c_shapes_to_trixel.glsl` #1370 metric). Do not
+  desync the scatter depth from that metric.
+- **Cardinal fast path must stay byte-identical** — the cardinal scatter is the
+  zero-residual case; the analytic term must collapse to the current exact
+  footprint there (the spikes/dashing are an inter-cardinal-only artifact).
+- **Bind-point budget is full (0–30).** The analytic model is chosen partly
+  *because* it needs no new GPU buffer/texture; if an implementation reaches for
+  one, that is a design smell — re-derive from varyings + the existing per-axis
+  canvas reads instead (`engine/render/CLAUDE.md` §Gotchas).
+- **#1922 dependency is real for C3 only.** C1/C2 validate the static defect
+  (spikes/dashing) with the existing `perf-grid-rotate-sweep`; only the temporal-
+  stability gate needs #1922 (PR #1928, approved/landing).
+- **`backend-parity` skill for C2** — the GL and Metal scatter shaders are hand-
+  mirrored; use the skill's audit so the analytic logic doesn't drift.
+
+## References
+
+- #1883 / #1917 — the corner-spike no-local-fix proof; #1917 routes the root fix
+  to this epic and documents the accepted drift C3 removes.
+- #1907 (merged) — interim dilation iters (coverage bands + face-alignment seams).
+- epic #1881 — jitter/rotated-solidity epic; #1922 (PR #1928) the validation
+  harness; #1882 / `perf-grid-rotate-sweep` the solidity gate.
+- #935 / #937 — rasterization-quality epics.
+- `engine/render/CLAUDE.md` — convex-corner drift note (#1917) + bind-point
+  budget gotcha.
+
+## Steward ledger
+
+reconciled-through: 2026-06-21
+proposal-pending: none
+
+### Children
+| Child | State | PR | Plan | Last validated |
+|---|---|---|---|---|
+| #1937 | open | — | plan | 2026-06-21 |
+| #1938 | open | — | plan | 2026-06-21 |
+| #1939 | open | — | plan | 2026-06-21 |
+
+### Decisions
+- 2026-06-21: approach picked = portable analytic edge-aware coverage; HW
+  conservative raster (no Metal API; GL extension non-portable on the WSL 4.5
+  floor) and MSAA (integer R32I/depth resolve + 4–8× memory) ruled out by the
+  source-verified capability audit.
+
+### Events
+- 2026-06-21: filed via file-epic (planning of #1933)

--- a/.fleet/plans/issue-1933.md
+++ b/.fleet/plans/issue-1933.md
@@ -162,7 +162,8 @@ migrate (`grep` over `engine/**/*.{hpp,cpp}` finds none). Consumers:
 - `engine/render/src/shaders/metal/peraxis_scatter.metal:194,198-200` — Metal
   mirror of the vertex call.
 - `engine/render/src/shaders/ir_iso_common.glsl:691,701,717,723,738,768` +
-  `…/metal/ir_iso_common.metal:636,654,663,678` — the definitions.
+  `…/metal/ir_iso_common.metal:636,642,650,654,660,678` — the definitions
+  (all six mirror the GLSL; line 663 is a comment, not a symbol).
 
 No other shader, system, or CPU caller references these symbols. The detached
 regime (`kScatterDetachedPitchFraction`) and camera regime

--- a/.fleet/plans/issue-1937.md
+++ b/.fleet/plans/issue-1937.md
@@ -1,0 +1,86 @@
+# Plan: analytic edge-aware coverage on the per-axis scatter — GL backend (C1)
+
+- **Issue:** #1937
+- **Model:** opus
+- **Date:** 2026-06-21
+- **Epic:** #1933 — see `~/.fleet/plans/issue-1933.md` for full context (approach decision + capability audit + cross-system audit)
+- **Blocked by:** (none)
+
+## Scope
+
+The de-risking + first-implementation phase of epic #1933. Move the per-axis
+scatter coverage *decision* off the uniform conservative-dilation margin and onto
+per-fragment **edge-type-aware analytic coverage**, on the OpenGL backend only.
+Keep the quad dilation purely as a rasterization visit-bound.
+
+## Verified current state
+
+- The scatter is a rasterized instanced draw (`drawElementsInstanced(TRIANGLES,…)`,
+  `engine/prefabs/irreden/render/systems/system_trixel_to_framebuffer.hpp:279`),
+  one instance per per-axis cell, 3 passes (X/Y/Z).
+- `v_peraxis_scatter.glsl:133-280` recovers the face origin, projects its 4 corners
+  via `pos3DtoPos2DIsoYawed`, dilates them via `scatterConservativeDilation`
+  (`:217`, floor `kScatterDilateMarginPx=0.85`, per-axis `0.5·|n|`, mitered).
+- `f_peraxis_scatter.glsl:1-72` classifies margin-vs-interior via `vQuadParam`
+  [0,1]² and applies the margin depth-yield bias.
+- Corner spikes: on foreshortened near-cardinal faces `0.5·|n|` reaches a
+  cell-deep fraction → corner over-extension with no single working margin (the
+  #1883 `M·C ≲ 2px` vs `C ≈ half-cell` mutual-exclusion). Repro:
+  `scripts/dev/perf-grid-rotate-sweep` on coarse GRID cubes.
+
+## Affected files
+
+- `engine/render/src/shaders/v_peraxis_scatter.glsl` — reduce dilation to a
+  minimal fixed visit-bound; emit true (undilated) edge-equation varyings + a
+  per-edge interior/boundary flag from an occupied-same-plane-neighbor tap.
+- `engine/render/src/shaders/f_peraxis_scatter.glsl` — replace margin-vs-interior
+  classification with edge-type-aware analytic coverage + hard-threshold discard.
+- `engine/render/src/shaders/ir_iso_common.glsl` — add the analytic-coverage
+  helper (signed-distance / coverage math) next to the existing dilation helper.
+  **Do not yet retire** the margin/miter/yield constants (that is C3) — but the
+  analytic coverage must already be the authority removing spikes/dashing.
+
+## Approach
+
+1. **Visit-bound dilation:** shrink `scatterConservativeDilation`'s use at
+   `v_peraxis_scatter.glsl:217` to a minimal fixed outward grow (enough that the
+   rasterizer visits every pixel the true footprint could touch — ~1px is the
+   target), removing the coverage-deciding role from the geometry.
+2. **True-edge varyings:** pass the 4 true (undilated) corner positions (or the
+   4 edge half-plane equations) in framebuffer/clip space as flat/smooth
+   varyings.
+3. **Edge classification:** per the cell's grid position (`gl_InstanceID`) and an
+   occupied-neighbor tap of the per-axis canvas data, mark each of the 4 edges
+   interior (occupied same-plane neighbor) or boundary.
+4. **Fragment coverage:** per edge, signed distance d; interior edge →
+   conservative inclusion (`d > -0.5px`); boundary edge → analytic sub-pixel
+   coverage `clamp(0.5 - d/fwidth(d), 0, 1)`. Combine (min across edges);
+   **hard-threshold** the result for the R32I-distance / depth co-sort write
+   (`discard` below ~0.5), since the depth metric is a single per-pixel value.
+5. Finalize the exact thresholds/formula against `perf-grid-rotate-sweep`
+   (the safety net) — corner spikes gone, no dashing, cardinal byte-identical.
+
+## Acceptance criteria
+
+- Coarse-cube (3³/12³) near-cardinal: corner spikes gone AND foreshortened faces
+  solid (no dashing) — `perf-grid-rotate-sweep` + `shape_debug`.
+- Cardinal fast path byte-identical to master (analytic term collapses to the
+  exact footprint at zero residual).
+- No coverage regression on the epic #1881 rotated-solidity baseline.
+- GL only; Metal is #1938.
+
+## Gotchas
+
+- R32I/depth co-sort → hard threshold + discard, NOT alpha blend; keep depth
+  co-sorted with the SDF #1370 metric.
+- Bind-point budget full (0–30) — no new buffer/texture; varyings + existing
+  per-axis canvas reads only.
+- Shares `ir_iso_common.glsl` with #1920 — serialize per #1881.
+
+## Verification
+
+- `fleet-build --target IRShapeDebug` (and the perf_grid demo target).
+- `bash scripts/dev/perf-grid-rotate-sweep <build_dir>` — solidity/silhouette.
+- `attach-screenshots` + `render-debug-loop` on the affected demo (render-path
+  change) for before/after near-cardinal coarse-cube captures.
+- `render-verify` for the cardinal byte-identity gate.

--- a/.fleet/plans/issue-1938.md
+++ b/.fleet/plans/issue-1938.md
@@ -1,0 +1,67 @@
+# Plan: Metal parity port of analytic scatter coverage (C2)
+
+- **Issue:** #1938
+- **Model:** opus
+- **Date:** 2026-06-21
+- **Epic:** #1933 — see `~/.fleet/plans/issue-1933.md` for full context
+- **Blocked by:** #1937
+
+## Scope
+
+Faithfully port #1937's edge-type-aware analytic scatter coverage from the GL
+shaders into the Metal backend, keeping the two hand-mirrored scatter shaders at
+feature parity. No new design.
+
+## Verified current state
+
+- The Metal scatter shaders mirror the GL ones:
+  `engine/render/src/shaders/metal/peraxis_scatter.metal:118-258` (vertex,
+  `v_peraxis_scatter`) + `:269-296` (fragment, `f_peraxis_scatter`), calling
+  `scatterConservativeDilation` at `:198-200`.
+- The shared `kScatter*` constants + dilation helper live in
+  `engine/render/src/shaders/metal/ir_iso_common.metal:636-717` (mirror of the
+  GLSL helper).
+- Metal pipeline: single-sample, no conservative-raster API (metal-cpp exposes
+  only sample positions + rate maps — neither is conservative raster). Pipeline
+  built in `engine/render/src/metal/metal_pipeline.cpp`.
+
+## Affected files
+
+- `engine/render/src/shaders/metal/peraxis_scatter.metal` — mirror #1937's
+  vertex (visit-bound dilation, true-edge + interior/boundary varyings,
+  occupied-neighbor tap) and fragment (analytic coverage + hard discard) changes.
+- `engine/render/src/shaders/metal/ir_iso_common.metal` — mirror the analytic
+  coverage helper added to `ir_iso_common.glsl`.
+
+## Approach
+
+1. Diff #1937's final GL shader changes; translate each to Metal syntax
+   (`float2`/`float3`, `fwidth`, varying/stage-in struct fields, `discard_fragment()`).
+2. Keep the `kScatter*` constants in sync (do not retire — that is #1939).
+3. Run the `backend-parity` skill audit to confirm the analytic logic matches
+   the GL side and no drift slipped in.
+
+## Acceptance criteria
+
+- Metal renders coarse-cube near-cardinal poses with the same crisp-corner /
+  no-dashing result #1937 proved on GL.
+- `backend-parity` audit passes; cardinal fast path byte-identical on Metal.
+- Metal validation layer clean apart from the pre-existing stencil-attachment
+  assert on master.
+
+## Gotchas
+
+- Metal has no conservative-rasterization API — stay in the analytic /
+  fragment-discard model (the reason the epic chose it); no sample positions /
+  rate maps.
+- Don't half-retire constants — keep Metal `kScatter*` in lockstep with GL until
+  #1939 removes both together.
+- Metal-validation-layer stencil-attachment assert is pre-existing on master
+  (fleet memory) — not a regression from this port.
+
+## Verification
+
+- macOS host: build the engine with the affected demo, run with
+  `--auto-screenshot`; capture the same near-cardinal coarse-cube shots as #1937
+  and compare GL↔Metal.
+- `backend-parity` skill (the primary gate for this child).

--- a/.fleet/plans/issue-1939.md
+++ b/.fleet/plans/issue-1939.md
@@ -67,8 +67,13 @@ Consumers: `v_peraxis_scatter.glsl:211,217-218`, `f_peraxis_scatter.glsl`,
 
 ## Gotchas
 
-- Don't half-retire — the constants live in both `ir_iso_common.glsl` and
-  `ir_iso_common.metal`; remove from both in lockstep.
+- Don't half-retire — three symbols are GL-only (`kScatterDetachedPitchFraction`,
+  `kScatterMarginDepthBiasKey`, `kScatterMarginYieldGradScale`; see `—` in the
+  metal column above); the other three (`scatterConservativeDilation`,
+  `kScatterDilateMarginPx`, `kScatterMiterLimit`) live in both shaders.
+  Remove the GL-only symbols from `ir_iso_common.glsl` only, and remove the
+  shared symbols from both `ir_iso_common.glsl` and `ir_iso_common.metal` in
+  lockstep.
 - The depth-bias (#1457) + yield-gradient (#1883) exist because the margin
   over-fills; removing them is correct ONLY if analytic coverage left no
   over-fill. Validate before removing.

--- a/.fleet/plans/issue-1939.md
+++ b/.fleet/plans/issue-1939.md
@@ -1,0 +1,83 @@
+# Plan: retire the manual scatter dilation margin/miter/yield tower + full validation (C3)
+
+- **Issue:** #1939
+- **Model:** opus
+- **Date:** 2026-06-21
+- **Epic:** #1933 — see `~/.fleet/plans/issue-1933.md` for full context (incl. the cross-system audit of every retired symbol)
+- **Blocked by:** #1938, #1922
+
+## Scope
+
+With analytic coverage authoritative on both backends (#1937 GL, #1938 Metal),
+retire the now-redundant conservative-dilation margin/miter/yield heuristics
+from the per-axis scatter pass, then run the full temporal-stability + solidity
+validation and update the docs.
+
+## Verified current state
+
+The heuristics to retire (all shader-side `const`/`constant`; **no CPU-side
+uniform plumbing** — `grep` over `engine/**/*.{hpp,cpp}` finds none):
+
+| Symbol | Line (glsl / metal) | Role (post-#1937/#1938: redundant) |
+|---|---|---|
+| `scatterConservativeDilation()` | 768 / 678 | per-axis `0.5·|n|` + miter growth |
+| `kScatterDilateMarginPx` | 691 / 636 | fixed camera-path margin floor |
+| `kScatterDetachedPitchFraction` | 738 / — | detached pitch-proportional floor |
+| `kScatterMiterLimit` | 723 / 654 | acute-corner blow-out cap |
+| `kScatterMarginDepthBiasKey` | 701 / — | margin tie-break depth bias |
+| `kScatterMarginYieldGradScale` | 717 / — | margin yield gradient |
+
+Consumers: `v_peraxis_scatter.glsl:211,217-218`, `f_peraxis_scatter.glsl`,
+`metal/peraxis_scatter.metal:194,198-200`, and the definitions in
+`ir_iso_common.{glsl,metal}`. No other caller.
+
+## Affected files
+
+- `engine/render/src/shaders/ir_iso_common.glsl` + `…/metal/ir_iso_common.metal`
+  — remove/reduce the six symbols above (in lockstep across both backends).
+- `engine/render/src/shaders/v_peraxis_scatter.glsl` +
+  `…/metal/peraxis_scatter.metal` — drop the per-axis miter call; keep only the
+  minimal fixed visit-bound from #1937.
+- `engine/render/src/shaders/f_peraxis_scatter.glsl` +
+  `…/metal/peraxis_scatter.metal` — remove the margin-vs-interior classification
+  + depth-yield bias (every surviving fragment is now interior).
+- `engine/render/CLAUDE.md` — rewrite the convex-corner drift note (#1917): the
+  drift is fixed; describe the analytic coverage model.
+
+## Approach
+
+1. Confirm (via #1937/#1938 results) that the margin depth-bias and yield-gradient
+   are truly dead — no same-plane tie or ridge-bleed reappears with the margin
+   reduced to the visit-bound. If one does, the analytic coverage isn't fully
+   authoritative → fix coverage, do NOT re-add the bias.
+2. Remove the symbols from BOTH backends together; reduce
+   `scatterConservativeDilation` to the minimal visit-bound (or fold it inline).
+3. `grep` `engine/` clean for every retired `kScatter*` name.
+4. Update `engine/render/CLAUDE.md`.
+
+## Acceptance criteria
+
+- **Temporal stability** under the #1922 jitter harness on both backends (the
+  core bar; needs #1922 on master).
+- Coarse-cube near-cardinal: crisp corners + solid faces with the margin tower
+  removed (regression-free vs #1938).
+- `perf-grid-rotate-sweep` (epic #1881 solidity gate) passes; cardinal
+  byte-identical; both backends at parity.
+- No dangling references to retired symbols (`grep` clean).
+
+## Gotchas
+
+- Don't half-retire — the constants live in both `ir_iso_common.glsl` and
+  `ir_iso_common.metal`; remove from both in lockstep.
+- The depth-bias (#1457) + yield-gradient (#1883) exist because the margin
+  over-fills; removing them is correct ONLY if analytic coverage left no
+  over-fill. Validate before removing.
+- Keep scatter depth co-sorted with the SDF #1370 metric.
+- `ir_iso_common` shared with #1920 — serialize per #1881's one-at-a-time rule.
+
+## Verification
+
+- Both backends: `fleet-build`, run the affected demos with `--auto-screenshot`.
+- The #1922 jitter harness (once on master) — temporal-stability gate.
+- `scripts/dev/perf-grid-rotate-sweep` — solidity/silhouette.
+- `render-verify` — cardinal byte-identity; `backend-parity` — GL↔Metal.

--- a/.fleet/plans/issue-1939.md
+++ b/.fleet/plans/issue-1939.md
@@ -22,10 +22,10 @@ uniform plumbing** — `grep` over `engine/**/*.{hpp,cpp}` finds none):
 |---|---|---|
 | `scatterConservativeDilation()` | 768 / 678 | per-axis `0.5·|n|` + miter growth |
 | `kScatterDilateMarginPx` | 691 / 636 | fixed camera-path margin floor |
-| `kScatterDetachedPitchFraction` | 738 / — | detached pitch-proportional floor |
+| `kScatterDetachedPitchFraction` | 738 / 660 | detached pitch-proportional floor |
 | `kScatterMiterLimit` | 723 / 654 | acute-corner blow-out cap |
-| `kScatterMarginDepthBiasKey` | 701 / — | margin tie-break depth bias |
-| `kScatterMarginYieldGradScale` | 717 / — | margin yield gradient |
+| `kScatterMarginDepthBiasKey` | 701 / 642 | margin tie-break depth bias |
+| `kScatterMarginYieldGradScale` | 717 / 650 | margin yield gradient |
 
 Consumers: `v_peraxis_scatter.glsl:211,217-218`, `f_peraxis_scatter.glsl`,
 `metal/peraxis_scatter.metal:194,198-200`, and the definitions in
@@ -67,13 +67,11 @@ Consumers: `v_peraxis_scatter.glsl:211,217-218`, `f_peraxis_scatter.glsl`,
 
 ## Gotchas
 
-- Don't half-retire — three symbols are GL-only (`kScatterDetachedPitchFraction`,
-  `kScatterMarginDepthBiasKey`, `kScatterMarginYieldGradScale`; see `—` in the
-  metal column above); the other three (`scatterConservativeDilation`,
-  `kScatterDilateMarginPx`, `kScatterMiterLimit`) live in both shaders.
-  Remove the GL-only symbols from `ir_iso_common.glsl` only, and remove the
-  shared symbols from both `ir_iso_common.glsl` and `ir_iso_common.metal` in
-  lockstep.
+- Don't half-retire — all six symbols are defined in **both** backends (see the
+  glsl/metal columns above; the metal `constant` mirrors live at
+  `ir_iso_common.metal:636,642,650,654,660,678`). Remove all six from both
+  `ir_iso_common.glsl` and `ir_iso_common.metal` in lockstep; leaving any as a
+  dead `constant` in the Metal file trips the "`grep` clean" acceptance criterion.
 - The depth-bias (#1457) + yield-gradient (#1883) exist because the margin
   over-fills; removing them is correct ONLY if analytic coverage left no
   over-fill. Validate before removing.


### PR DESCRIPTION
## What

Plan files for epic **#1933** (per-axis scatter conservative-rasterization root
fix) and its 3 children, decomposed via PLANNING-PROTOCOL.md + file-epic.

- `.fleet/plans/issue-1933.md` — epic umbrella plan: approach decision, the
  source-verified backend-capability audit, and the cross-system audit of every
  symbol the final child retires.
- `.fleet/plans/issue-1937.md` — **C1** GL analytic edge-aware coverage (de-risk + impl).
- `.fleet/plans/issue-1938.md` — **C2** Metal parity port.
- `.fleet/plans/issue-1939.md` — **C3** retire the margin/miter/yield tower + full validation.

## Why

`#1933` asked for "conservative rasterization / MSAA on the per-axis scatter
pass". The capability audit (GL 4.5 core / WSLg Mesa-d3d12 floor; Metal has no
conservative-raster API; integer R32I/depth co-sort metric) rules both out and
picks **portable analytic edge-aware coverage**, which breaks the #1883
corner-spike mutual-exclusion by decoupling the rasterization visit-bound from
the per-fragment coverage decision.

Docs-only — no code, no build impact. Children are filed `fleet:task` without
`human:approved` (human triages each before they queue).

## Validation

`fleet-validate-stack 1933` → PASS (all 3 children carry the structured fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
