### PR TITLE
build: green & warning-free macOS clean build

### DIFF
--- a/cmake/lua_codegen/system_dsl.cpp
+++ b/cmake/lua_codegen/system_dsl.cpp
@@ -1601,9 +1601,19 @@ struct Emitter {
             case StmtKind::IF: {
                 for (size_t i = 0; i < s.ifBranches_.size(); ++i) {
                     writeIndent();
-                    if (i == 0) out_ << "if ("; else out_ << "} else if (";
-                    emitExpr(*s.ifBranches_[i].cond_);
-                    out_ << ") {\n";
+                    out_ << (i == 0 ? "if " : "} else if ");
+                    // emitExpr already parenthesizes BINARY_OP / UNARY_OP, so
+                    // wrapping those again here emits "((x == y))", which trips
+                    // -Wparentheses-equality. Let the self-parenthesizing kinds
+                    // supply the condition's grouping; wrap only the atoms that
+                    // emit no parens of their own.
+                    const Expr &cond = *s.ifBranches_[i].cond_;
+                    const bool selfParen = cond.kind_ == ExprKind::BINARY_OP ||
+                                           cond.kind_ == ExprKind::UNARY_OP;
+                    if (!selfParen) out_ << "(";
+                    emitExpr(cond);
+                    if (!selfParen) out_ << ")";
+                    out_ << " {\n";
                     ++indent_;
                     auto savedSymbols = symbols_;
                     for (const auto &bs : s.ifBranches_[i].body_) emitStmt(*bs);

--- a/engine/audio/CMakeLists.txt
+++ b/engine/audio/CMakeLists.txt
@@ -109,7 +109,7 @@ FetchContent_Declare(
 # as dylibs that reference the ma_* core symbols without linking them; that
 # links on Linux (undefined symbols resolved at load) but fails on macOS
 # arm64 (the linker requires every symbol resolved). Skip building them.
-set(MINIAUDIO_NO_EXTRA_NODES ON)
+set(MINIAUDIO_NO_EXTRA_NODES ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(miniaudio)
 target_include_directories(IrredenEngineAudio PRIVATE ${miniaudio_SOURCE_DIR})
 

--- a/engine/audio/CMakeLists.txt
+++ b/engine/audio/CMakeLists.txt
@@ -103,6 +103,13 @@ FetchContent_Declare(
     GIT_TAG 0.11.25
     UPDATE_DISCONNECTED TRUE
 )
+# We consume miniaudio as a single header (MINIAUDIO_IMPLEMENTATION lives in
+# src/audio_playback.cpp), so none of its CMake targets are linked. Its
+# extras/nodes/* example libraries (ma_reverb_node, ma_vocoder_node, …) build
+# as dylibs that reference the ma_* core symbols without linking them; that
+# links on Linux (undefined symbols resolved at load) but fails on macOS
+# arm64 (the linker requires every symbol resolved). Skip building them.
+set(MINIAUDIO_NO_EXTRA_NODES ON)
 FetchContent_MakeAvailable(miniaudio)
 target_include_directories(IrredenEngineAudio PRIVATE ${miniaudio_SOURCE_DIR})
 

--- a/engine/common/CMakeLists.txt
+++ b/engine/common/CMakeLists.txt
@@ -1,14 +1,16 @@
-add_library(IrredenEngineCommon STATIC
-    src/ir_constants.cpp
-)
+# Header-only module (constants + compile-time platform detection); see this
+# directory's CLAUDE.md. With no real translation unit, a STATIC build emitted
+# an empty archive ("ranlib: … table of contents is empty"). INTERFACE is the
+# honest shape: consumers get the include dir and IRMath transitively.
+add_library(IrredenEngineCommon INTERFACE)
 
 target_link_libraries(
-    IrredenEngineCommon PUBLIC
+    IrredenEngineCommon INTERFACE
     IrredenEngineMath
 )
 
 target_include_directories(
     IrredenEngineCommon
-    PUBLIC
+    INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/engine/profile/CMakeLists.txt
+++ b/engine/profile/CMakeLists.txt
@@ -90,6 +90,11 @@ set(EASY_PROFILER_NO_GUI ON CACHE BOOL "" FORCE)
 if(IRREDEN_PROFILE_ENABLE_EASY_PROFILER_GUI)
     set(EASY_PROFILER_NO_GUI OFF CACHE BOOL "" FORCE)
 endif()
+# We link only the easy_profiler core library. Its bundled sample/reader
+# executables are dead weight in our build and their link step adds a stale
+# `${CMAKE_SOURCE_DIR}/../bin` search path, which the macOS linker warns about
+# ("search path '…/../bin' not found"). Skip building them.
+set(EASY_PROFILER_NO_SAMPLES ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(easy_profiler)
 target_link_libraries(IrredenEngineProfile PUBLIC easy_profiler)
 target_include_directories(

--- a/engine/video/src/video_recorder.cpp
+++ b/engine/video/src/video_recorder.cpp
@@ -99,11 +99,29 @@ void writeFloat32WavFile(
 
 #if IR_VIDEO_HAS_FFMPEG
 [[maybe_unused]] AVSampleFormat chooseAudioSampleFormat(const AVCodec *codec) {
-    if (codec == nullptr || codec->sample_fmts == nullptr) {
+    if (codec == nullptr) {
+        return AV_SAMPLE_FMT_NONE;
+    }
+    // FFmpeg 7.1 (libavcodec 61.13.100) deprecated AVCodec::sample_fmts in
+    // favor of avcodec_get_supported_config(); both yield the encoder's
+    // NONE-terminated list of accepted sample formats. Older FFmpeg (the
+    // Linux/Windows fleet hosts) keeps the field.
+    const AVSampleFormat *sampleFmts = nullptr;
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+    if (avcodec_get_supported_config(
+            nullptr, codec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0,
+            reinterpret_cast<const void **>(&sampleFmts), nullptr
+        ) < 0) {
+        return AV_SAMPLE_FMT_NONE;
+    }
+#else
+    sampleFmts = codec->sample_fmts;
+#endif
+    if (sampleFmts == nullptr) {
         return AV_SAMPLE_FMT_NONE;
     }
     AVSampleFormat fallback = AV_SAMPLE_FMT_NONE;
-    for (const AVSampleFormat *fmt = codec->sample_fmts; *fmt != AV_SAMPLE_FMT_NONE; ++fmt) {
+    for (const AVSampleFormat *fmt = sampleFmts; *fmt != AV_SAMPLE_FMT_NONE; ++fmt) {
         if (*fmt == AV_SAMPLE_FMT_FLTP) {
             return *fmt;
         }


### PR DESCRIPTION
## Summary
- **audio:** disable miniaudio's unused `extras/nodes` example dylibs via `MINIAUDIO_NO_EXTRA_NODES`. They link a handful of `ma_*` core symbols without providing them, which the macOS arm64 linker rejects (Linux resolves undefined symbols at load) — the only build-breaking errors in a clean macOS/Metal build. We consume miniaudio as a single header, so none of its CMake targets are needed.
- **profile:** disable easy_profiler's bundled sample/reader executables via `EASY_PROFILER_NO_SAMPLES`. They injected a stale `${CMAKE_SOURCE_DIR}/../bin` link-search-path the linker kept warning about; we link only the core lib.
- **common:** make the header-only `IrredenEngineCommon` an `INTERFACE` library and drop the empty `ir_constants.cpp`. The `STATIC` build emitted an empty-archive `ranlib` warning. Matches the module's `CLAUDE.md` ("header-only, no src/").
- **video:** migrate `chooseAudioSampleFormat` off the deprecated `AVCodec::sample_fmts` to `avcodec_get_supported_config`, version-guarded (`LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)`) so older FFmpeg on the Linux/Windows hosts keeps using the field. Behavior is otherwise unchanged.
- **lua codegen:** stop the `IF` emitter double-wrapping conditions. `emitExpr` already parenthesizes `BINARY_OP`/`UNARY_OP`, so generated `if ((x == y))` tripped `-Wparentheses-equality`; it now emits `if (x == y)`.

## Test plan
- [x] Clean macOS/Metal build of all engine libraries, demos, tests, and tools (`ir-build --clean-first -- -k`) — previously exit 2 with 5 link errors and 4 warning classes; now builds error- and warning-free on Apple Clang.
- [x] Regenerated lua codegen header emits single-paren conditions; `IrredenEngineVideo` rebuilds clean with no deprecation warning.
- [ ] Linux/Windows (OpenGL) build stays green — the CMake dep-option flags are platform-neutral and only drop example/sample targets we never link; older FFmpeg keeps the `#else` field path.

## Notes for reviewer
- The two dependency-option flags only suppress example/sample targets that are never linked into any engine target, so there is no functional change on any platform.
- `video_recorder.cpp` is intentionally **not** whole-file reformatted — local clang-format (22.x) disagrees with the fleet's; only the logical hunk changed. A fleet `format-check` pass may want a different wrap on the multi-line call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
