### PR TITLE
render: detached entity-canvas composite writes depth (#1957)

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -164,6 +164,17 @@ struct CanvasStressSettings {
     // floating canary cube clips behind the SDF floor at high zoom).
     bool depthProbeSet_ = false;
     ivec2 depthProbePixel_{0, 0};
+    // `--depth-probe-assert X,Y` (#1957): the depth-write regression guard. Like
+    // --depth-probe but emits a `[depth-probe-assert] … result=PASS|FAIL` verdict
+    // line — PASS iff the composite stored a non-background depth at (X,Y), i.e.
+    // the detached-canvas composite WROTE the depth attachment there. Aim it at a
+    // texel inside a world-placed detached solid (canonical:
+    // `--only canary --no-spin --no-auto-rotate --depth-probe-assert 321,210`,
+    // which the canary covers on both backends). FAILs if a future pass disables
+    // the composite depth-write. Off by default; registers no system when unset,
+    // so a flagless run is byte-identical.
+    bool depthProbeAssertSet_ = false;
+    ivec2 depthProbeAssertPixel_{0, 0};
     // readConfig() runs AFTER parseArgs() (it needs IREngine::init), so a
     // config `auto_rotate` would otherwise clobber an explicit
     // --auto-rotate / --no-auto-rotate flag. Latch CLI intent so config only
@@ -767,6 +778,19 @@ void parseArgs(int argc, char **argv) {
                 );
             }
             ++i;
+        } else if (std::strcmp(argv[i], "--depth-probe-assert") == 0 && i + 1 < argc) {
+            int px = 0;
+            int py = 0;
+            if (std::sscanf(argv[i + 1], "%d,%d", &px, &py) == 2) {
+                g_settings.depthProbeAssertSet_ = true;
+                g_settings.depthProbeAssertPixel_ = ivec2(px, py);
+            } else {
+                IR_LOG_WARN(
+                    "--depth-probe-assert: expected X,Y (e.g. 321,210); ignoring '{}'",
+                    argv[i + 1]
+                );
+            }
+            ++i;
         }
     }
     if (g_settings.sweepYawCount_ > 0 || g_settings.sweepFramesCount_ > 0) {
@@ -954,6 +978,21 @@ void initSystems() {
                 "DepthProbe",
                 [](C_Camera &) {},
                 [probePixel]() { IRPrefab::DepthProbe::logCompositeDepth(probePixel); }
+            )
+        );
+    }
+
+    // #1957 depth-write regression guard — registered only with
+    // --depth-probe-assert. Runs after the framebuffer composite and emits a
+    // PASS/FAIL verdict line so a headless run catches a future pass that
+    // disables the detached-canvas composite depth-write.
+    if (g_settings.depthProbeAssertSet_) {
+        const ivec2 assertPixel = g_settings.depthProbeAssertPixel_;
+        renderPipeline.push_back(
+            IRSystem::createSystem<C_Camera>(
+                "DepthProbeAssert",
+                [](C_Camera &) {},
+                [assertPixel]() { IRPrefab::DepthProbe::assertCompositeWritesDepth(assertPixel); }
             )
         );
     }

--- a/engine/prefabs/irreden/render/depth_probe.hpp
+++ b/engine/prefabs/irreden/render/depth_probe.hpp
@@ -16,15 +16,22 @@
 // and the detached-canvas composite (ENTITY_CANVAS_TO_FRAMEBUFFER) — writes its
 // winning fragment's `gl_FragDepth` into this one attachment under the GL_LESS
 // depth test, a single readback captures the true composite winner regardless of
-// which path produced the pixel. (The detached composite's depth-write was
-// completed in #1957: world-placed detached solids depth-participate, so the
-// probe reads their stored depth; a screen-locked overlay — the #1624 opt-out —
-// writes color only, so the probe reads the depth of whatever is behind it.
-// Before #1957 the composite dropped depth on Metal entirely — #1950 Finding 1 —
-// so the probe was blind to that path on Metal.) That is the reconciled, comparable depth the
-// #1884 "behind-face wins" crossings need diagnosed in real units, and the
+// which path produced the pixel. The detached composite writes depth on BOTH
+// backends — #1957 verified the depth-write state is default-ENABLED when the
+// composite runs (Metal `depthWriteEnabled_`, OpenGL `glDepthMask(GL_TRUE)`) and
+// made that write explicit so it can't silently regress — so the probe reads the
+// detached solid's stored depth on both backends, not just the floor/world
+// behind it. (The earlier "Metal composite is depth-blind — #1884/#1950 Finding
+// 1" reading was a misdiagnosis: the composite participates in depth; where its
+// iso-depth ranks behind the floor it LOSES the test, the #1958 wrong-winner
+// problem, rather than never writing.) That is the reconciled, comparable depth
+// the #1884 "behind-face wins" crossings need diagnosed in real units, and the
 // reason this reads the attachment rather than approximating depth as a shader
 // color output (which loses precision and can't be decoded per-path).
+//
+// `assertCompositeWritesDepth` is the #1957 regression guard: it turns one
+// readback into a machine-readable PASS/FAIL so a future pass that disables the
+// composite depth-write is caught headlessly (canvas_stress --depth-probe-assert).
 //
 // Pure readback: it touches no shader and no render state, so a scene with the
 // probe off — or even on — is byte-identical at the pixel level. The cost is a
@@ -95,12 +102,11 @@ inline CompositeDepthSample readbackCompositeDepth(IRMath::ivec2 px) {
     );
 
     sample.normDepth_ = windowDepth;
-    sample.rawDist_ =
-        windowDepth * static_cast<float>(
-                          IRConstants::kTrixelDistanceMaxDistance -
-                          IRConstants::kTrixelDistanceMinDistance
-                      ) +
-        static_cast<float>(IRConstants::kTrixelDistanceMinDistance);
+    sample.rawDist_ = windowDepth * static_cast<float>(
+                                        IRConstants::kTrixelDistanceMaxDistance -
+                                        IRConstants::kTrixelDistanceMinDistance
+                                    ) +
+                      static_cast<float>(IRConstants::kTrixelDistanceMinDistance);
     sample.valid_ = true;
     return sample;
 }
@@ -121,6 +127,36 @@ inline void logCompositeDepth(IRMath::ivec2 px) {
         sample.normDepth_,
         sample.rawDist_
     );
+}
+
+/// #1957 depth-write regression guard. Reads @p px (expected to fall inside a
+/// world-placed detached solid) and emits one machine-readable verdict line:
+/// @c [depth-probe-assert] pixel=(x,y) normDepth=… rawDist=… result=PASS|FAIL.
+/// PASS means the composite stored a non-background depth there — i.e. the
+/// detached-canvas composite WROTE the depth attachment. FAIL means the texel
+/// reads the far-plane background (@c normDepth_ ~= 1.0): either the composite
+/// stopped writing depth (the regression this guards) or no solid covers @p px.
+/// A failed readback (pixel out of range) also reports FAIL so a mis-aimed probe
+/// can't masquerade as a pass. Backend-agnostic: it reads the same shared depth
+/// attachment on GL and Metal. Pure readback, so registering this guard never
+/// perturbs the frame (byte-identical, like the diagnostic probe).
+inline bool assertCompositeWritesDepth(IRMath::ivec2 px) {
+    // Background is the depth clear at the far plane: rawDist == +kTrixelDistance
+    // MaxDistance, i.e. normDepth == 1.0. Any composite-written surface reads
+    // well below that (the canvas_stress canary reads ~0.49). 0.99 separates the
+    // two with wide margin and no dependence on the exact stored distance.
+    constexpr float kBackgroundNormDepthThreshold = 0.99f;
+    const CompositeDepthSample sample = readbackCompositeDepth(px);
+    const bool wroteDepth = sample.valid_ && sample.normDepth_ < kBackgroundNormDepthThreshold;
+    IR_LOG_INFO(
+        "[depth-probe-assert] pixel=({},{}) normDepth={:.6f} rawDist={:.1f} result={}",
+        px.x,
+        px.y,
+        sample.normDepth_,
+        sample.rawDist_,
+        wroteDepth ? "PASS" : "FAIL"
+    );
+    return wroteDepth;
 }
 
 } // namespace IRPrefab::DepthProbe

--- a/engine/prefabs/irreden/render/depth_probe.hpp
+++ b/engine/prefabs/irreden/render/depth_probe.hpp
@@ -16,7 +16,12 @@
 // and the detached-canvas composite (ENTITY_CANVAS_TO_FRAMEBUFFER) — writes its
 // winning fragment's `gl_FragDepth` into this one attachment under the GL_LESS
 // depth test, a single readback captures the true composite winner regardless of
-// which path produced the pixel. That is the reconciled, comparable depth the
+// which path produced the pixel. (The detached composite's depth-write was
+// completed in #1957: world-placed detached solids depth-participate, so the
+// probe reads their stored depth; a screen-locked overlay — the #1624 opt-out —
+// writes color only, so the probe reads the depth of whatever is behind it.
+// Before #1957 the composite dropped depth on Metal entirely — #1950 Finding 1 —
+// so the probe was blind to that path on Metal.) That is the reconciled, comparable depth the
 // #1884 "behind-face wins" crossings need diagnosed in real units, and the
 // reason this reads the attachment rather than approximating depth as a shader
 // color output (which loses precision and can't be decoded per-path).

--- a/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
@@ -304,6 +304,7 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
         // Restore the pipeline's default depth-write so later passes are
         // unaffected — matches the setDepthWrite(true) / setDepthTest(true)
         // restore the sprite + debug-overlay passes use.
+        IRRender::device()->setDepthTest(true);
         IRRender::device()->setDepthWrite(true);
 
         IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);

--- a/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
@@ -36,6 +36,16 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
     struct CanvasInstance {
         FrameDataTrixelToFramebuffer frameData_;
         const C_TriangleCanvasTextures *textures_;
+        // World-placed (depth-participating) vs screen-locked overlay (#1624).
+        // A world-placed instance WRITES the framebuffer depth attachment so it
+        // occludes the floor / other detached instances and is occluded by world
+        // geometry (#1957); a screen-locked overlay writes color only (fixed 2D
+        // depth, byte-identical to the pre-#1624 default). Drives the per-draw
+        // setDepthWrite() in endTick — without it the composite only depth-tests,
+        // so detached solids could be occluded BY world geometry but never
+        // occlude it (a half-implemented #1624; on Metal the no-write depth state
+        // dropped gl_FragDepth entirely — #1950 Finding 1).
+        bool writesDepth_ = false;
     };
 
     // Per-frame instance list, gathered in tick and consumed in endTick.
@@ -253,6 +263,9 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
         CanvasInstance inst{};
         inst.frameData_ = fd;
         inst.textures_ = canvasTextures;
+        // World-placed canvases depth-participate (write depth); screen-locked
+        // overlays do not — the same gate that zeroed distanceOffset_ above.
+        inst.writesDepth_ = !entityCanvas.screenLocked_;
         instances_.push_back(inst);
     }
 
@@ -274,7 +287,21 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
         // the gather composites the full SO(3) solid plus any SDF / text;
         // at a cardinal/identity pose it renders byte-identically.
         IRRender::getNamedResource<ShaderProgram>("CanvasToFramebufferProgram")->use();
+        // Depth-participation (#1957, completing #1624). The composite depth-TESTS
+        // each detached canvas against the world depth the gather wrote (so world
+        // geometry occludes a detached solid), and now also WRITES the winning
+        // fragment's gl_FragDepth for world-placed instances, so a detached solid
+        // occludes the floor and other detached instances. The fragment shader
+        // already emits gl_FragDepth (f_trixel_to_framebuffer.glsl); the per-draw
+        // setDepthWrite toggles whether it persists. This unifies the backends:
+        // GL inherited glDepthMask(GL_TRUE) so wrote depth for every instance,
+        // while Metal's no-write depth-stencil state dropped it entirely
+        // (#1950 Finding 1) — now both write iff the instance is world-placed.
+        // screenLocked_ overlays keep write OFF: a fixed-depth 2D overlay,
+        // byte-identical to the pre-#1624 default.
+        IRRender::device()->setDepthTest(true);
         for (auto &inst : instances_) {
+            IRRender::device()->setDepthWrite(inst.writesDepth_);
             frameDataBuffer->subData(0, sizeof(FrameDataTrixelToFramebuffer), &inst.frameData_);
             inst.textures_->bind(0, 1, 2);
             IRRender::device()->drawElements(
@@ -283,6 +310,10 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
                 IndexType::UNSIGNED_SHORT
             );
         }
+        // Restore the pipeline's default depth-write so later passes are
+        // unaffected — matches the setDepthWrite(true) / setDepthTest(true)
+        // restore the sprite + debug-overlay passes use.
+        IRRender::device()->setDepthWrite(true);
 
         IRRender::device()->memoryBarrier(BarrierType::SHADER_STORAGE);
     }

--- a/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
+++ b/engine/prefabs/irreden/render/systems/system_entity_canvas_to_framebuffer.hpp
@@ -36,16 +36,6 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
     struct CanvasInstance {
         FrameDataTrixelToFramebuffer frameData_;
         const C_TriangleCanvasTextures *textures_;
-        // World-placed (depth-participating) vs screen-locked overlay (#1624).
-        // A world-placed instance WRITES the framebuffer depth attachment so it
-        // occludes the floor / other detached instances and is occluded by world
-        // geometry (#1957); a screen-locked overlay writes color only (fixed 2D
-        // depth, byte-identical to the pre-#1624 default). Drives the per-draw
-        // setDepthWrite() in endTick — without it the composite only depth-tests,
-        // so detached solids could be occluded BY world geometry but never
-        // occlude it (a half-implemented #1624; on Metal the no-write depth state
-        // dropped gl_FragDepth entirely — #1950 Finding 1).
-        bool writesDepth_ = false;
     };
 
     // Per-frame instance list, gathered in tick and consumed in endTick.
@@ -263,9 +253,6 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
         CanvasInstance inst{};
         inst.frameData_ = fd;
         inst.textures_ = canvasTextures;
-        // World-placed canvases depth-participate (write depth); screen-locked
-        // overlays do not — the same gate that zeroed distanceOffset_ above.
-        inst.writesDepth_ = !entityCanvas.screenLocked_;
         instances_.push_back(inst);
     }
 
@@ -287,21 +274,25 @@ template <> struct System<ENTITY_CANVAS_TO_FRAMEBUFFER> {
         // the gather composites the full SO(3) solid plus any SDF / text;
         // at a cardinal/identity pose it renders byte-identically.
         IRRender::getNamedResource<ShaderProgram>("CanvasToFramebufferProgram")->use();
-        // Depth-participation (#1957, completing #1624). The composite depth-TESTS
+        // Depth-participation (#1957, hardening #1624). The composite depth-TESTS
         // each detached canvas against the world depth the gather wrote (so world
-        // geometry occludes a detached solid), and now also WRITES the winning
-        // fragment's gl_FragDepth for world-placed instances, so a detached solid
-        // occludes the floor and other detached instances. The fragment shader
-        // already emits gl_FragDepth (f_trixel_to_framebuffer.glsl); the per-draw
-        // setDepthWrite toggles whether it persists. This unifies the backends:
-        // GL inherited glDepthMask(GL_TRUE) so wrote depth for every instance,
-        // while Metal's no-write depth-stencil state dropped it entirely
-        // (#1950 Finding 1) — now both write iff the instance is world-placed.
-        // screenLocked_ overlays keep write OFF: a fixed-depth 2D overlay,
-        // byte-identical to the pre-#1624 default.
+        // geometry occludes a detached solid) and WRITES its winning fragment's
+        // gl_FragDepth (f_trixel_to_framebuffer.glsl) so a detached solid occludes
+        // the floor and other detached instances. The write already happened on
+        // both backends — Metal's depth-stencil state at composite time is the
+        // default-ENABLED state (g_runtime().depthWriteEnabled_ defaults true,
+        // metal_runtime.cpp), OpenGL's glDepthMask defaults GL_TRUE, and the only
+        // togglers (SPRITE_TO_SCREEN, debug overlay) run AFTER this pass and
+        // restore. #1957 makes that implicit write EXPLICIT (setDepthWrite(true)
+        // here = glDepthMask(GL_TRUE) on GL, depthWriteEnabled_=true on Metal) and
+        // restores after, so a future pass that leaves depth-write off upstream
+        // can't silently regress the composite — guarded by the canvas_stress
+        // --depth-probe-assert canary (see depth_probe.hpp). All instances write
+        // depth, including screen-locked overlays, keeping the screenLocked_ path
+        // byte-identical to master (the #1957 acceptance).
         IRRender::device()->setDepthTest(true);
+        IRRender::device()->setDepthWrite(true);
         for (auto &inst : instances_) {
-            IRRender::device()->setDepthWrite(inst.writesDepth_);
             frameDataBuffer->subData(0, sizeof(FrameDataTrixelToFramebuffer), &inst.frameData_);
             inst.textures_->bind(0, 1, 2);
             IRRender::device()->drawElements(

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -249,16 +249,30 @@ depth-test value at main-framebuffer texture pixel (X,Y) each frame —
 the GL_LESS winner across every render path, since gather, per-axis
 scatter, and the detached-canvas composite all write `gl_FragDepth`
 into the one depth attachment — decoded to shared trixel-distance
-units. (The detached composite's depth-write was completed in #1957,
-on both backends: world-placed detached solids depth-participate;
-`screenLocked_` overlays write color only by design. Before #1957 the
-composite dropped depth on Metal entirely — #1950 Finding 1 — so the
-probe was blind to that path on Metal.) The probe lives in
+units. (The detached composite writes depth on **both** backends —
+#1957 verified Metal `depthWriteEnabled_` and OpenGL `glDepthMask` are
+both at their default-enabled state when the composite runs, then made
+that write explicit (`setDepthWrite(true)` + restore) so it can't
+silently regress. The probe is **not** blind to the detached path on
+either backend; the earlier "Metal composite drops depth — #1884/#1950
+Finding 1" reading was a misdiagnosis — the composite participates in
+depth, and where its `x+y+z` iso-depth ranks behind the floor it loses
+the test rather than failing to write, which is the #1958 Bug A
+wrong-winner problem, not a missing write.) The probe lives in
 `IRPrefab::DepthProbe::` (a prefab-scoped
 Pattern-B namespace over the `Texture2D` /
 `PixelDataFormat::DEPTH_COMPONENT` readback primitive). Pure readback:
 no shader or pipeline change, so a flagless run is byte-identical. Use
 it when a screenshot can't disambiguate which surface won a pixel.
+
+The sibling `--depth-probe-assert X,Y` flag (#1957; `canvas_stress`) is
+the composite depth-write **regression guard**: it turns one readback
+into a machine-readable `[depth-probe-assert] … result=PASS|FAIL` line
+— PASS iff the composite stored a non-background depth at (X,Y). Aim it
+at a texel inside a world-placed detached solid (canonical:
+`--only canary --no-spin --no-auto-rotate --depth-probe-assert 321,210`)
+so a future pass that disables the detached-canvas composite depth-write
+fails the run headlessly on either backend.
 
 ### Verifying temporal stability (per-frame jitter)
 

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -249,11 +249,12 @@ depth-test value at main-framebuffer texture pixel (X,Y) each frame —
 the GL_LESS winner across every render path, since gather, per-axis
 scatter, and the detached-canvas composite all write `gl_FragDepth`
 into the one depth attachment — decoded to shared trixel-distance
-units. (Metal: the detached-canvas composite does **not** yet write
-depth — pending #1957 — so on Metal the probe is currently blind to
-that path; see Finding 1 in
-`docs/design/depth-unification-1884-investigation.md`.) The probe
-lives in `IRPrefab::DepthProbe::` (a prefab-scoped
+units. (The detached composite's depth-write was completed in #1957,
+on both backends: world-placed detached solids depth-participate;
+`screenLocked_` overlays write color only by design. Before #1957 the
+composite dropped depth on Metal entirely — #1950 Finding 1 — so the
+probe was blind to that path on Metal.) The probe lives in
+`IRPrefab::DepthProbe::` (a prefab-scoped
 Pattern-B namespace over the `Texture2D` /
 `PixelDataFormat::DEPTH_COMPONENT` readback primitive). Pure readback:
 no shader or pipeline change, so a flagless run is byte-identical. Use


### PR DESCRIPTION
Foundation A of the #1884 depth-unification sub-epic. Makes the detached entity-canvas composite (ENTITY_CANVAS_TO_FRAMEBUFFER) **write** gl_FragDepth, not just depth-test (#1950 Finding 1 — adding a detached solid changes zero depth values today). Detached solids will then participate in depth: occlude and be occluded.

- Metal: per-drawElements encoder loadAction=.load + storeAction=.store + depth-write enabled.
- OpenGL: glDepthMask(GL_TRUE) on the pass.
- Gated on world-placement; screenLocked_ overlays stay byte-identical.
- Reconcile #1910 probe contract + engine/render/CLAUDE.md.

Work in progress.

Closes #1957