### PR TITLE
tools/docs: jitter_probe + canonize temporal-stability (jitter) verification

### DIFF
--- a/.claude/skills/render-debug-loop/SKILL.md
+++ b/.claude/skills/render-debug-loop/SKILL.md
@@ -113,6 +113,18 @@ to `scripts/render-compare.py`, which gives aggregate metrics
 (PSNR, max delta, match%) — use the python tool for pass/fail gates
 and `img_diff` for "show me where the drift is".
 
+#### 4d. Check temporal stability (jitter) when the change touches motion
+
+`img_diff` and stills catch **spatial** drift; they **cannot** prove a moving
+scene is jitter-free. If the change touches the camera-offset decomposition,
+the per-axis scatter, the anti-vibration split, or the framebuffer/screen blit,
+also run the jitter check: capture a fine `--pan-sweep` / `--yaw-sweep` of an
+isolated shape and score it with **`tools/jitter_probe`** (SMOOTH vs JITTER,
+exit 0/1). Full recipe + the isolated-cylinder rotation probe live in
+[`engine/render/CLAUDE.md`](../../../engine/render/CLAUDE.md) §"Verifying
+temporal stability (per-frame jitter)". Jitter ≠ cardinal byte-identity —
+verify both.
+
 ### 5. Evaluate
 
 Check these **always-on** criteria across every screenshot AND every

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ endif()
 
 if(IRREDEN_BUILD_TOOLS)
     add_subdirectory(${PROJECT_SOURCE_DIR}/tools/img_diff)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/tools/jitter_probe)
 endif()
 
 if(IRREDEN_BUILD_QUALITY_TARGETS)

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -259,6 +259,60 @@ Pattern-B namespace over the `Texture2D` /
 no shader or pipeline change, so a flagless run is byte-identical. Use
 it when a screenshot can't disambiguate which surface won a pixel.
 
+### Verifying temporal stability (per-frame jitter)
+
+**A single screenshot cannot prove a moving scene is jitter-free.** Pan/rotation
+jitter is content that *should* translate smoothly but instead oscillates ±1px
+(or worse) frame-to-frame — typically when an integer canvas anchor and its
+sub-pixel compensation disagree at a cell boundary (the #1944 per-axis class).
+Each individual frame looks correct; only the *sequence* reveals it. Any change
+to the camera-offset decomposition, the per-axis scatter, the anti-vibration
+split, or the framebuffer/screen blit MUST be checked this way, not just by
+before/after stills.
+
+Three checks, in order:
+
+1. **Static ("after the camera stops") — must be byte-identical run-to-run.**
+   Capture the same pose in two separate runs and `img_diff` them; expect 0
+   drift. A non-zero diff here is non-determinism / static jitter.
+
+2. **During pan / during rotation — sweep + `tools/jitter_probe`.** `shape_debug`
+   has two fine-step sweep harnesses that hold everything fixed except the swept
+   variable, capturing one frame per step:
+   - `--pan-sweep` — steps the camera position at a fixed (non-cardinal) yaw.
+   - `--yaw-sweep` — steps the camera yaw within ONE cardinal quadrant (constant
+     visible-face triplet) at a fixed position.
+
+   Drive them with an **isolated shape on a black field** so the centroid is
+   clean — `--spin-shape <shape> --spin-shape-voxel` (voxel → exercises the
+   per-axis path; omit `--spin-shape-voxel` for the SDF/cardinal path). For
+   rotation use a **vertical cylinder**: its silhouette is Z-yaw-invariant, so
+   any centroid wobble is jitter, not a legitimate face-triplet change (a cube's
+   silhouette changes under yaw and contaminates the metric).
+
+   ```bash
+   # pan jitter (voxel box, yaw 45, zoom 4):
+   IRShapeDebug --spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 \
+       --zoom 4 --auto-screenshot 6
+   # rotation jitter (voxel cylinder, Z-yaw-invariant probe):
+   IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep \
+       --zoom 4 --auto-screenshot 6
+   # then score the captured sequence (in order):
+   build/tools/jitter_probe/jitter_probe <save_files>/screenshots/screenshot_0*.png
+   ```
+
+3. **Read the verdict.** `jitter_probe` tracks the shape's centroid across the
+   sequence and reports `SMOOTH` (0 direction-reversals, sub-pixel residual off
+   the smooth-motion line, exit 0) vs `JITTER` (sign-reversing deltas + multi-px
+   residual, exit 1). A correct fix flips JITTER → SMOOTH; re-run at multiple
+   zooms (the per-axis class worsens with zoom/subdivision). For a multi-shape
+   scene with no isolation, pass `jitter_probe --color R,G,B,T` to lock onto one
+   shape. See `tools/jitter_probe/README.md`.
+
+**Jitter is NOT the same as cardinal byte-identity.** Confirm yaw-0 / static
+frames stay byte-identical (`img_diff`) *and* that motion is jitter-free
+(`jitter_probe`) — a change can pass one and fail the other.
+
 For changes that touch only one graphics backend (GLSL without MSL
 counterpart, or vice versa), follow up with the **`backend-parity`**
 skill on the lagging-side host — the rule is in [`docs/agents/FLEET.md`](../../docs/agents/FLEET.md)

--- a/tools/jitter_probe/CMakeLists.txt
+++ b/tools/jitter_probe/CMakeLists.txt
@@ -1,0 +1,16 @@
+include(FetchContent)
+
+# stb is already declared by engine/render/CMakeLists.txt (and tools/img_diff);
+# the duplicate FetchContent_Declare with the same name is a no-op (CMake reuses
+# the cache). Declared here too so jitter_probe can build standalone if a future
+# configure ever excludes the engine subdir. GIT_TAG master intentionally
+# matches engine/render/CMakeLists.txt — both track the same floating ref.
+FetchContent_Declare(
+    stbimage
+    GIT_REPOSITORY https://github.com/nothings/stb/
+    GIT_TAG master
+)
+FetchContent_MakeAvailable(stbimage)
+
+add_executable(jitter_probe main.cpp)
+target_include_directories(jitter_probe PRIVATE ${stbimage_SOURCE_DIR})

--- a/tools/jitter_probe/README.md
+++ b/tools/jitter_probe/README.md
@@ -1,0 +1,69 @@
+# jitter_probe
+
+Temporal-jitter detector for render-verification sweeps. The sibling of
+[`tools/img_diff`](../img_diff/README.md): `img_diff` catches **spatial** drift
+between two frames; `jitter_probe` catches **temporal** jitter across a
+**sequence** of frames captured while the camera moves smoothly.
+
+## Why it exists
+
+A correct render pipeline translates a shape **smoothly** as the camera pans or
+yaws: the shape's centroid follows a straight line, so the per-frame delta keeps
+one sign and the residual off that line stays sub-pixel. A jittering pipeline —
+e.g. an integer canvas anchor whose sub-pixel compensation is at the wrong
+screen scale (#1944) — makes the centroid **oscillate**: the delta reverses sign
+and the residual spikes, even though every individual frame looks fine. That
+oscillation is **invisible in any single screenshot**; it only shows up across
+the sequence. A still image can't prove temporal stability — this can.
+
+## Usage
+
+```
+jitter_probe <frame_0.png> <frame_1.png> ... <frame_N.png>   # >=3, in capture order
+    [--threshold L]      foreground = pixels with (R+G+B) > L (0..765, default 24)
+    [--color R,G,B,T]    instead, foreground = pixels within T of color R,G,B
+    [--reversal-eps PX]  per-frame deltas under this count as 0 (default 0.10)
+    [--max-residual PX]  SMOOTH verdict requires residual <= this (default 1.50)
+    [--verbose]          print the per-frame centroid + residual table
+```
+
+Exit code: `0` = SMOOTH, `1` = JITTER detected, `2` = argument / IO error (same
+convention as `img_diff`, so it drops into the same verification scripts).
+
+## Capturing a clean sweep
+
+Use an **isolated shape on a black field** so the centroid is uncontaminated.
+`shape_debug` has two sweep harnesses (see
+[`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md) §"Verifying temporal
+stability (jitter)"):
+
+```bash
+# Pan jitter — camera pans at a fixed non-cardinal yaw:
+IRShapeDebug --spin-shape box --spin-shape-voxel --pan-sweep --yaw 0.785 --zoom 4 \
+    --auto-screenshot 6
+# Rotation jitter — camera yaws within one cardinal quadrant (use a vertical
+# cylinder: its silhouette is Z-yaw-invariant, so any centroid wobble is jitter):
+IRShapeDebug --spin-shape cylinder --spin-shape-voxel --yaw-sweep --zoom 4 \
+    --auto-screenshot 6
+
+# Then point jitter_probe at the captured sequence (in order):
+build/tools/jitter_probe/jitter_probe save_files/screenshots/screenshot_0001*.png
+```
+
+For a multi-shape scene with no isolation, pass `--color R,G,B,T` to lock onto
+one shape. A static-determinism check ("does it jitter after the camera stops?")
+is a separate thing — capture the SAME pose twice and `img_diff` them (expect 0).
+
+## Interpreting output
+
+```
+jitter_probe: frames=24 (valid=24)  verdict=SMOOTH
+  x: reversals=0  max_residual=0.20px  delta_std=0.41  delta_max=1.00
+  y: reversals=0  max_residual=0.31px  delta_std=0.30  delta_max=0.51
+```
+
+`reversals` is the count of per-frame direction flips (the jitter signature);
+`max_residual` is the worst deviation from the smooth straight-line motion.
+SMOOTH requires `reversals == 0` on both axes and `max_residual <= --max-residual`.
+A clean fix flips a JITTER verdict (high reversals, multi-px residual) to SMOOTH
+(0 reversals, sub-px residual).

--- a/tools/jitter_probe/README.md
+++ b/tools/jitter_probe/README.md
@@ -35,7 +35,7 @@ convention as `img_diff`, so it drops into the same verification scripts).
 Use an **isolated shape on a black field** so the centroid is uncontaminated.
 `shape_debug` has two sweep harnesses (see
 [`engine/render/CLAUDE.md`](../../engine/render/CLAUDE.md) §"Verifying temporal
-stability (jitter)"):
+stability (per-frame jitter)"):
 
 ```bash
 # Pan jitter — camera pans at a fixed non-cardinal yaw:

--- a/tools/jitter_probe/main.cpp
+++ b/tools/jitter_probe/main.cpp
@@ -1,0 +1,292 @@
+// jitter_probe — temporal-jitter detector for render-verification sweeps.
+//
+// img_diff catches SPATIAL drift between two frames; jitter_probe catches
+// TEMPORAL jitter across a SEQUENCE of frames captured while the camera moves
+// smoothly (a pan or yaw sweep). A correct pipeline translates a shape SMOOTHLY:
+// its centroid follows a straight line, so the per-frame delta keeps one sign
+// and the residual off that line stays sub-pixel. A jittering pipeline (e.g. an
+// integer canvas anchor whose sub-pixel compensation is at the wrong scale)
+// makes the centroid oscillate — the delta reverses sign and the residual spikes
+// — even though each individual frame looks fine. That oscillation is invisible
+// in any single screenshot; it only shows up across the sequence.
+//
+// Usage:
+//   jitter_probe <frame_000.png> <frame_001.png> ... <frame_N.png>
+//     [--threshold L]      foreground = pixels with (R+G+B) > L (0..765, default 24)
+//     [--color R,G,B,T]    instead, foreground = pixels within T of color R,G,B
+//     [--reversal-eps PX]  per-frame deltas under this are treated as 0 (default 0.10)
+//     [--max-residual PX]  SMOOTH verdict requires residual <= this (default 1.50)
+//     [--verbose]          print the per-frame centroid + residual table
+//
+// Capture the sequence with an ISOLATED shape on a black field so the centroid
+// is clean — e.g. `shape_debug --spin-shape box --spin-shape-voxel --pan-sweep`
+// (pan jitter) or `--yaw-sweep` (rotation jitter). For a multi-shape scene pass
+// --color to lock onto one shape. Frames MUST be given in capture order.
+//
+// Exit: 0 = SMOOTH, 1 = JITTER detected, 2 = argument / IO error. (Mirrors
+// img_diff's 0/1/2 convention so it slots into the same verification scripts.)
+
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Args {
+    std::vector<std::string> frames_;
+    int threshold_ = 24;
+    bool useColor_ = false;
+    int colorR_ = 0, colorG_ = 0, colorB_ = 0, colorTol_ = 0;
+    double reversalEps_ = 0.10;
+    double maxResidual_ = 1.50;
+    bool verbose_ = false;
+};
+
+void usage(const char *exe) {
+    std::fprintf(
+        stderr,
+        "Usage: %s <frame_0.png> <frame_1.png> ... (>=3, in capture order)\n"
+        "  [--threshold L] [--color R,G,B,T] [--reversal-eps PX]\n"
+        "  [--max-residual PX] [--verbose]\n",
+        exe
+    );
+}
+
+bool parseArgs(int argc, char **argv, Args &out) {
+    for (int i = 1; i < argc; ++i) {
+        const std::string a = argv[i];
+        if (a == "--threshold" && i + 1 < argc) {
+            out.threshold_ = std::atoi(argv[++i]);
+        } else if (a == "--reversal-eps" && i + 1 < argc) {
+            out.reversalEps_ = std::atof(argv[++i]);
+        } else if (a == "--max-residual" && i + 1 < argc) {
+            out.maxResidual_ = std::atof(argv[++i]);
+        } else if (a == "--verbose") {
+            out.verbose_ = true;
+        } else if (a == "--color" && i + 1 < argc) {
+            out.useColor_ = true;
+            if (std::sscanf(
+                    argv[++i],
+                    "%d,%d,%d,%d",
+                    &out.colorR_,
+                    &out.colorG_,
+                    &out.colorB_,
+                    &out.colorTol_
+                ) != 4) {
+                std::fprintf(stderr, "jitter_probe: --color expects R,G,B,T\n");
+                return false;
+            }
+        } else if (!a.empty() && a[0] == '-') {
+            std::fprintf(stderr, "jitter_probe: unknown flag '%s'\n", a.c_str());
+            return false;
+        } else {
+            out.frames_.push_back(a);
+        }
+    }
+    if (out.frames_.size() < 3) {
+        std::fprintf(stderr, "jitter_probe: need >= 3 frames (got %zu)\n", out.frames_.size());
+        return false;
+    }
+    return true;
+}
+
+// Foreground centroid (mean x,y of matching pixels) for one frame.
+// Returns false if too few pixels match (shape off-screen / empty frame).
+bool centroid(const Args &args, const std::string &path, double &cx, double &cy, long &count) {
+    int w = 0, h = 0, channels = 0;
+    unsigned char *data = stbi_load(path.c_str(), &w, &h, &channels, 4);
+    if (!data) {
+        std::fprintf(
+            stderr,
+            "jitter_probe: failed to load '%s': %s\n",
+            path.c_str(),
+            stbi_failure_reason()
+        );
+        return false;
+    }
+    double sx = 0.0, sy = 0.0;
+    long n = 0;
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            const unsigned char *p = data + (static_cast<long>(y) * w + x) * 4;
+            bool fg;
+            if (args.useColor_) {
+                fg = std::abs(int(p[0]) - args.colorR_) <= args.colorTol_ &&
+                     std::abs(int(p[1]) - args.colorG_) <= args.colorTol_ &&
+                     std::abs(int(p[2]) - args.colorB_) <= args.colorTol_;
+            } else {
+                fg = (int(p[0]) + int(p[1]) + int(p[2])) > args.threshold_;
+            }
+            if (fg) {
+                sx += x;
+                sy += y;
+                ++n;
+            }
+        }
+    }
+    stbi_image_free(data);
+    count = n;
+    if (n < 50) {
+        return false;
+    }
+    cx = sx / double(n);
+    cy = sy / double(n);
+    return true;
+}
+
+// Least-squares line fit y = m*i + b over the valid samples; fills residual[].
+void detrend(
+    const std::vector<double> &v, const std::vector<bool> &valid, std::vector<double> &residual
+) {
+    double si = 0, sv = 0, sii = 0, siv = 0;
+    int n = 0;
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (!valid[i])
+            continue;
+        si += i;
+        sv += v[i];
+        sii += double(i) * i;
+        siv += double(i) * v[i];
+        ++n;
+    }
+    double m = 0, b = 0;
+    const double denom = n * sii - si * si;
+    if (n >= 2 && std::fabs(denom) > 1e-9) {
+        m = (n * siv - si * sv) / denom;
+        b = (sv - m * si) / n;
+    } else if (n > 0) {
+        b = sv / n;
+    }
+    residual.assign(v.size(), 0.0);
+    for (size_t i = 0; i < v.size(); ++i) {
+        residual[i] = valid[i] ? v[i] - (m * i + b) : 0.0;
+    }
+}
+
+struct AxisStats {
+    int reversals_ = 0;
+    double maxAbsResidual_ = 0.0;
+    double deltaStd_ = 0.0;
+    double deltaMaxAbs_ = 0.0;
+};
+
+AxisStats analyze(
+    const std::vector<double> &v,
+    const std::vector<bool> &valid,
+    double eps,
+    std::vector<double> &residual
+) {
+    detrend(v, valid, residual);
+    AxisStats s;
+    for (double r : residual)
+        s.maxAbsResidual_ = std::max(s.maxAbsResidual_, std::fabs(r));
+
+    // Per-frame delta sign reversals (jitter) + delta spread, over consecutive
+    // valid pairs.
+    std::vector<double> deltas;
+    int prevSign = 0;
+    for (size_t i = 1; i < v.size(); ++i) {
+        if (!valid[i] || !valid[i - 1])
+            continue;
+        const double d = v[i] - v[i - 1];
+        deltas.push_back(d);
+        const int sign = (d > eps) ? 1 : (d < -eps) ? -1 : 0;
+        if (sign != 0 && prevSign != 0 && sign != prevSign)
+            ++s.reversals_;
+        if (sign != 0)
+            prevSign = sign;
+    }
+    double mean = 0;
+    for (double d : deltas) {
+        mean += d;
+        s.deltaMaxAbs_ = std::max(s.deltaMaxAbs_, std::fabs(d));
+    }
+    if (!deltas.empty()) {
+        mean /= deltas.size();
+        double var = 0;
+        for (double d : deltas)
+            var += (d - mean) * (d - mean);
+        s.deltaStd_ = std::sqrt(var / deltas.size());
+    }
+    return s;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    Args args;
+    if (!parseArgs(argc, argv, args)) {
+        usage(argv[0]);
+        return 2;
+    }
+
+    const size_t n = args.frames_.size();
+    std::vector<double> cx(n, 0.0), cy(n, 0.0);
+    std::vector<bool> valid(n, false);
+    int validCount = 0;
+    for (size_t i = 0; i < n; ++i) {
+        long count = 0;
+        if (centroid(args, args.frames_[i], cx[i], cy[i], count)) {
+            valid[i] = true;
+            ++validCount;
+        } else {
+            std::fprintf(
+                stderr,
+                "jitter_probe: frame %zu '%s' has no usable foreground (%ld px)\n",
+                i,
+                args.frames_[i].c_str(),
+                count
+            );
+        }
+    }
+    if (validCount < 3) {
+        std::fprintf(stderr, "jitter_probe: < 3 frames had a usable foreground\n");
+        return 2;
+    }
+
+    std::vector<double> rx, ry;
+    const AxisStats sx = analyze(cx, valid, args.reversalEps_, rx);
+    const AxisStats sy = analyze(cy, valid, args.reversalEps_, ry);
+
+    if (args.verbose_) {
+        std::printf("frame    centroid_x  resid_x    centroid_y  resid_y\n");
+        for (size_t i = 0; i < n; ++i) {
+            if (!valid[i]) {
+                std::printf("%5zu    (empty)\n", i);
+                continue;
+            }
+            std::printf("%5zu    %9.2f  %+7.2f    %9.2f  %+7.2f\n", i, cx[i], rx[i], cy[i], ry[i]);
+        }
+    }
+
+    const bool smooth = sx.reversals_ == 0 && sy.reversals_ == 0 &&
+                        sx.maxAbsResidual_ <= args.maxResidual_ &&
+                        sy.maxAbsResidual_ <= args.maxResidual_;
+
+    std::printf(
+        "jitter_probe: frames=%zu (valid=%d)  verdict=%s\n"
+        "  x: reversals=%d  max_residual=%.2fpx  delta_std=%.2f  delta_max=%.2f\n"
+        "  y: reversals=%d  max_residual=%.2fpx  delta_std=%.2f  delta_max=%.2f\n"
+        "  (thresholds: reversals=0, max_residual<=%.2fpx)\n",
+        n,
+        validCount,
+        smooth ? "SMOOTH" : "JITTER",
+        sx.reversals_,
+        sx.maxAbsResidual_,
+        sx.deltaStd_,
+        sx.deltaMaxAbs_,
+        sy.reversals_,
+        sy.maxAbsResidual_,
+        sy.deltaStd_,
+        sy.deltaMaxAbs_,
+        args.maxResidual_
+    );
+    return smooth ? 0 : 1;
+}


### PR DESCRIPTION
## Why

Render **jitter** — content that should translate smoothly but oscillates ±1px frame-to-frame under pan/rotation (the #1944 per-axis class) — is **invisible in any single screenshot and in `img_diff`** (which compares two stills). It only shows up across a *sequence*, so it kept slipping through: a fix looked correct in before/after stills while still jittering in motion. This canonizes the catch so future render changes can't regress temporal stability silently.

## What

- **`tools/jitter_probe`** — new stb_image C++ tool, sibling of `tools/img_diff` (img_diff = spatial drift between two frames; jitter_probe = temporal jitter across a sequence). Tracks a shape's centroid across a smooth-sweep capture, linear-detrends it, and reports **SMOOTH** (0 direction-reversals + sub-pixel residual, exit 0) vs **JITTER** (sign-reversing deltas + multi-px residual, exit 1). `--color R,G,B,T` isolates one shape in a multi-shape scene. Wired into the build behind `IRREDEN_BUILD_TOOLS` next to img_diff.
- **`engine/render/CLAUDE.md`** — new "Verifying temporal stability (per-frame jitter)" subsection under *Verifying render changes*: the three checks (static = byte-identical run-to-run via `img_diff`; pan = `--pan-sweep`; rotation = `--yaw-sweep` with a Z-yaw-invariant cylinder probe), scored through `jitter_probe`, and the rule that **any camera-offset / per-axis-scatter / anti-vibration / blit change MUST run them** — jitter is a *different property* than cardinal byte-identity.
- **`render-debug-loop` skill** (step 4d) points at the same flow when a change touches motion.

## Validation

`jitter_probe` run on the #1944 before/after box-pan frames:
```
before (anchor-only bug): verdict=JITTER  x: reversals=11 max_residual=19.15px   exit 1
after  (fixed):           verdict=SMOOTH  x: reversals=0  max_residual=0.00px    exit 0
```

## Notes

- The `--pan-sweep` / `--yaw-sweep` capture harnesses the docs reference land via **#1944** (shape_debug) — this PR pairs with it. `jitter_probe` itself analyzes any frame sequence and is independent of #1944.
- Tooling/docs only; no engine runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)