### PR TITLE
render: canvas_stress temporal-jitter harness (#1954) — re-scoped to rotation-crawl (Option A)

### DIFF
--- a/.fleet/plans/issue-1954.md
+++ b/.fleet/plans/issue-1954.md
@@ -5,23 +5,46 @@
 - **Date:** 2026-06-21
 - **Part of:** epic #1881 (validation); follow-up to #1944 / #1953
 
-### Scope
-Add a `canvas_stress` sibling to the #1922 temporal-jitter harness so the
-DETACHED-vs-GRID camera-yaw rotation jitter (#1944, fixed in #1953 — caught only by
-manual observation; the multi-canvas-type coverage gap #1922 deferred) is gated by a
-one-command check. **Reuse `scripts/render-jitter-metric.py` unchanged**; add a
-`scripts/dev/canvas-stress-rotate-jitter-sweep` wrapper mirroring
-`scripts/dev/shape-rotate-jitter-sweep`; add a `canvas_stress` baseline + threshold
-section to `docs/design/jitter-validation-harness.md`.
+### Revision history
+- **2026-06-23 — re-scoped to Option A (architect ruling on PR #1972).** The
+  original plan assumed `render-jitter-metric.py` (temporal luminance-curvature)
+  would separate the #1942 build from the #1953-fixed build, so the acceptance
+  required the gate to **FAIL pre-#1953**. Implementer verify-before-implement
+  disproved that empirically: the temporal metric is **blind to #1942 by
+  construction** — #1942 is a *smooth* ~½-trixel world↔detached **spatial**
+  registration drift that lives at the moving silhouette boundary, and the metric
+  (a) keys on the *second* temporal difference precisely to ignore smooth sub-pixel
+  motion and (b) AND-masks the moving silhouette out of the interior. Measured Δ
+  (≤0.07 jitter_score) sat below the re-voxelize speckle floor's own run-to-run
+  variation. The #1942 spatial drift is already gated by **#1944's render-verify
+  reference refresh** (pixel-diff vs committed refs). Architect ruling: **Option A**
+  — re-scope this harness to the temporal rotation-**crawl** family (seam / band /
+  speckle shimmer) it actually measures, **drop the "#1942 must FAIL" acceptance**,
+  and **threshold against the measured master speckle floor (~4.4), not zero**. The
+  continuous-yaw spatial-drift metric (Option B) is a genuinely useful but *distinct*
+  tool; it is NOT filed now (static render-verify refs cover #1942 today) and would
+  belong in its own task under #1884/#1881 if a later regression slips between
+  committed shots. Task-local re-scope; no design doc.
 
-### PREREQUISITE — sequence after #1953
-Acceptance requires the gate to **FAIL pre-#1953** and **PASS post-#1953**. #1942
-(the jitter) is on master; #1953 (the fix) is an open PR (not merged). To land #1954
-green on `master`, #1953 must merge first — otherwise the dev tool would correctly
-report FAIL on master (the live bug), an awkward landing state. The implementer can
-validate both halves *now* without waiting (FAIL on current master, PASS via
-`gh pr checkout 1953`), but the PR should merge after #1953. Marked **Blocked by
-#1953** in the issue body for this reason.
+### Scope
+Add a `canvas_stress` sibling to the #1922 temporal-jitter harness so the per-entity
+rotation **temporal crawl** (seam / band / speckle shimmer) on the mixed
+DETACHED + GRID rotation sweep is gated by a one-command check — the multi-canvas-type
+temporal coverage gap #1922 deferred. **Reuse `scripts/render-jitter-metric.py`
+unchanged**; add a `scripts/dev/canvas-stress-rotate-jitter-sweep` wrapper mirroring
+`scripts/dev/shape-rotate-jitter-sweep`; add a `canvas_stress` baseline + threshold
+section to `docs/design/jitter-validation-harness.md`. The gate fails on temporal-crawl
+regressions **above** the measured master speckle floor and passes on current master.
+The #1942 *spatial*-registration drift is out of scope here — it is owned by #1944's
+render-verify reference gate, a different metric class.
+
+### Landing state
+No #1953 sequencing prerequisite remains (that was tied to the dropped "FAIL
+pre-#1953" acceptance). The re-scoped gate passes on **current master** by
+construction — it brackets temporal crawl above the inherent round-to-cell speckle
+floor, which is present on master regardless of #1953. The wrapper is a manual /
+on-demand gate, so a future temporal-crawl regression (e.g. a re-voxelize change that
+worsens the speckle) is what would turn it red.
 
 ### Verified current state
 - canvas_stress already has the sweep mode: `--sweep-yaw <from> <to> <count>`
@@ -52,24 +75,42 @@ validate both halves *now* without waiting (FAIL on current master, PASS via
    - Build: `cmake --build "$BUILD_DIR" --target IRCanvasStress`.
    - Capture: `./IRCanvasStress --sweep-yaw <from> <to> <steps> --auto-screenshot
      <warmup>` (sweep auto-disables auto-rotate). Default a **focused** range +
-     bounded steps so sub-degree per-frame jitter is sampled without 360 full-frame
-     decodes — e.g. `--sweep-yaw 0 30 60` (0.5°/step, 60 frames). Make
+     bounded steps so sub-degree per-frame jitter is sampled without minutes of
+     full-frame decode. `--sweep-yaw` interpolates yaw in **radians** and full-frame
+     decode is ~2.3 s/frame at 2560×1440, so keep steps bounded (~30–40) over a
+     focused range — e.g. `--sweep-yaw 0 0.2618 36` (15°, ~0.42°/step). Make
      from/to/steps/zoom overridable (positional args + env, like the sibling).
    - Score: feed the captured full frames to `render-jitter-metric.py` with a
      CENTRAL `--roi` (the detached+GRID column), deriving the ROI from a frame's
      IHDR size (zoom/host robust) like the sibling — e.g. central ~40-50%.
    - Gate on `MAX_JITTER` (env-overridable); exit non-zero on FAIL.
 3. Tune the threshold (mirror the doc's "Choosing the gate"): measure `jitter_score`
-   on the clean baseline (post-#1953 — the inherent round-to-cell scatter speckle
-   sets the floor) and on #1942 (the jitter). Set `MAX_JITTER` between them with
-   margin.
+   on **current master**. CRITICAL measurement correction (see Revision history /
+   Gotchas): the plan + the architect's escalation reply both assumed the sweep
+   *froze* the entities ("isolates pure camera-yaw motion, entities static"). It
+   does NOT — `--sweep-yaw` disables only the *camera* auto-yaw (`autoRotate_`,
+   main.cpp:841); the per-entity self-spin is gated by `noSpin_` (main.cpp:1228/
+   1407/1423) and keeps running ~30° between the 60-settle-frame shots. That coarse
+   self-spin aliases the metric (it needs a fine ≤~2°/step sweep) up to ~3.7–4.4 —
+   which is where the architect's ~4.4 "floor" came from, NOT speckle. Passing
+   `--no-spin` actually delivers the intended frozen-entity / pure-camera-yaw fine
+   sweep, and the true floor is **jitter_score = 1.19** (central-half ROI, 15°/
+   36-step), the same clean regime as the sibling's smooth shapes (~1.2). Run-to-run
+   is **byte-identical** (fixed poses + frozen entities + deterministic re-voxelize
+   bake → deterministic capture), so the gate is a hard oracle, not flaky. Set
+   `MAX_JITTER = 4.0` — mirrors the sibling's gate (same metric, same ~1.2 floor),
+   >3× margin above 1.19, below where a real crawl regression lands (the sibling's
+   failing shapes hit 6–11). Document the floor + the --no-spin requirement in the
+   wrapper so a future reader doesn't re-derive the false ~4.4.
 4. Add a "canvas_stress (mixed DETACHED + GRID)" section to
    `jitter-validation-harness.md`: measured pre/post-#1953 numbers, the chosen ROI +
    range/steps, the threshold + rationale, and an OpenGL/Linux note (Linux baseline
    captured by running the identical command on a Linux host — defer the number like
    the shape_debug doc does).
-5. Validate: wrapper exits non-zero on a pre-#1953 checkout (#1942) and zero on the
-   #1953 branch / post-#1953 master. Record both numbers for the PR body + doc.
+5. Validate: wrapper exits zero on current master with the chosen threshold, and a
+   deliberately tightened `MAX_JITTER` below the floor flips it to non-zero — proving
+   the gate has teeth (would catch a crawl regression that pushes the score above the
+   floor). Record the measured master numbers for the PR body + doc.
 6. `commit-and-push` (`Closes #1954`).
 
 ### Affected files
@@ -82,19 +123,33 @@ validate both halves *now* without waiting (FAIL on current master, PASS via
   the bounded-steps + ROI approach first.
 
 ### Acceptance criteria
-- `bash scripts/dev/canvas-stress-rotate-jitter-sweep` → one-command **PASS** on
-  post-#1953 master (or the #1953 branch).
-- The same command on a pre-#1953 checkout (#1942) → **FAIL** (non-zero),
-  demonstrating it would have caught the #1944 jitter.
-- `jitter-validation-harness.md` documents the canvas_stress baseline + threshold.
+- A one-command `canvas_stress` temporal-jitter gate over the mixed DETACHED + GRID
+  rotation sweep, using `render-jitter-metric.py`, that **fails on temporal-crawl
+  regressions above the measured master speckle floor and passes on current master**:
+  `bash scripts/dev/canvas-stress-rotate-jitter-sweep` → **PASS** (exit 0) on master.
+- The "#1942 must FAIL" criterion is **removed** (#1942 is a spatial-registration
+  artifact owned by #1944's render-verify gate, not a temporal one).
+- The wrapper documents the measured ~1.2 camera-yaw floor (and why the naive
+  no-freeze ~4.4 is wrong) + the `--no-spin` requirement + the radian / decode-cost
+  constraints; `jitter-validation-harness.md` documents the canvas_stress baseline +
+  threshold.
 
 ### Gotchas
-- **Ordering:** land after #1953 (PREREQUISITE) so the dev tool is green on master.
-- **Full-frame decode cost:** bound steps (~60); do NOT default to 360 full frames.
-- **Inherent scatter speckle** (documented round-to-cell sub-cell CPU↔GPU
-  divergence; it's why the zoom shot is excluded from pixel-diff) sets the clean
-  jitter floor — set `MAX_JITTER` above it but below the #1942 jitter; too-tight
-  fails the clean run.
+- **`--no-spin` is MANDATORY for a valid camera-yaw fine sweep.** `--sweep-yaw`
+  freezes only the camera auto-yaw (`autoRotate_`); the per-entity self-spin
+  (`noSpin_`) keeps running ~30° between the 60-settle-frame shots, which aliases the
+  metric to ~3.7–4.4. That is the false "floor" the original plan + architect cited
+  (both wrongly assumed the sweep froze entities). Freeze entities and the true
+  camera-yaw floor is **1.19**.
+- **`--sweep-yaw` is in radians** and full-frame decode is ~2.3 s/frame at 2560×1440 —
+  bound steps (~30–40) over a focused range; do NOT default to 360 full frames or to
+  the original plan's `0 30 60` (30 rad ≈ 4.7 revolutions).
+- **The floor is deterministic, not noisy.** With frozen entities + fixed camera
+  poses + the deterministic re-voxelize bake, the capture is byte-identical
+  run-to-run, so `jitter_score = 1.19` is a hard number. `MAX_JITTER = 4.0` mirrors
+  the sibling's gate (same metric, same ~1.2 clean floor) with >3× margin; the
+  inherent round-to-cell scatter speckle is sub-cell and per-pose-deterministic here,
+  so it does not push the gate.
 - **ROI stability:** the central ROI must stay foreground across ALL swept frames
   (the metric AND-s per-frame masks → `interior_px` shrinks if entities sweep out).
   Verify `interior_px` is non-trivial; narrow the yaw range if the central column

--- a/.fleet/plans/issue-1954.md
+++ b/.fleet/plans/issue-1954.md
@@ -49,10 +49,12 @@ worsens the speckle) is what would turn it red.
 ### Verified current state
 - canvas_stress already has the sweep mode: `--sweep-yaw <from> <to> <count>`
   (`main.cpp:743`) emits `count` evenly-spaced full-frame shots `sweep_yaw_0..N-1`
-  from `from`→`to` yaw. **Sweep mode auto-disables entity auto-rotation**
-  (`main.cpp:772-777`), so `--no-auto-rotate` is redundant-but-harmless — the sweep
-  isolates pure camera-yaw motion (entities static in world space, which is the
-  #1944 surface).
+  from `from`→`to` yaw. **Sweep mode disables only the _camera_ auto-yaw**
+  (`autoRotate_`, `main.cpp:841`) — NOT per-entity self-spin, which is gated
+  separately by `noSpin_`. So `--no-spin` IS required to isolate pure camera-yaw
+  motion; without it entity self-spin keeps running and aliases the metric (see
+  Gotchas / Revision history — this corrects the initial assumption that the sweep
+  froze entities outright).
 - Unlike shape_debug's `--spin-shape` (single centred shape → auto `__crop_center`
   PNG), the canvas_stress sweep emits **full frames, no auto crop**. The metric
   scopes via `--roi` but still decodes each full PNG, so the step count must be

--- a/.fleet/plans/issue-1954.md
+++ b/.fleet/plans/issue-1954.md
@@ -1,0 +1,107 @@
+## Plan: extend the jitter-validation harness to canvas_stress (mixed DETACHED + GRID rotation)
+
+- **Issue:** #1954
+- **Model:** opus
+- **Date:** 2026-06-21
+- **Part of:** epic #1881 (validation); follow-up to #1944 / #1953
+
+### Scope
+Add a `canvas_stress` sibling to the #1922 temporal-jitter harness so the
+DETACHED-vs-GRID camera-yaw rotation jitter (#1944, fixed in #1953 — caught only by
+manual observation; the multi-canvas-type coverage gap #1922 deferred) is gated by a
+one-command check. **Reuse `scripts/render-jitter-metric.py` unchanged**; add a
+`scripts/dev/canvas-stress-rotate-jitter-sweep` wrapper mirroring
+`scripts/dev/shape-rotate-jitter-sweep`; add a `canvas_stress` baseline + threshold
+section to `docs/design/jitter-validation-harness.md`.
+
+### PREREQUISITE — sequence after #1953
+Acceptance requires the gate to **FAIL pre-#1953** and **PASS post-#1953**. #1942
+(the jitter) is on master; #1953 (the fix) is an open PR (not merged). To land #1954
+green on `master`, #1953 must merge first — otherwise the dev tool would correctly
+report FAIL on master (the live bug), an awkward landing state. The implementer can
+validate both halves *now* without waiting (FAIL on current master, PASS via
+`gh pr checkout 1953`), but the PR should merge after #1953. Marked **Blocked by
+#1953** in the issue body for this reason.
+
+### Verified current state
+- canvas_stress already has the sweep mode: `--sweep-yaw <from> <to> <count>`
+  (`main.cpp:743`) emits `count` evenly-spaced full-frame shots `sweep_yaw_0..N-1`
+  from `from`→`to` yaw. **Sweep mode auto-disables entity auto-rotation**
+  (`main.cpp:772-777`), so `--no-auto-rotate` is redundant-but-harmless — the sweep
+  isolates pure camera-yaw motion (entities static in world space, which is the
+  #1944 surface).
+- Unlike shape_debug's `--spin-shape` (single centred shape → auto `__crop_center`
+  PNG), the canvas_stress sweep emits **full frames, no auto crop**. The metric
+  scopes via `--roi` but still decodes each full PNG, so the step count must be
+  bounded (pure-Python decode of 2560×1440 frames is the cost the sibling sidesteps
+  with small crops).
+- The detached re-voxelize solids + GRID spin cubes sit on the **screen-center
+  column** (`main.cpp` framing comments), so under yaw-about-center they stay near
+  center → a CENTRAL ROI has a stable all-frames interior holding the DETACHED +
+  GRID comparison.
+- Existing harness pieces: `render-jitter-metric.py` (second-temporal-difference of
+  luminance; backend-agnostic, zoom-robust; emits JSON + pass/fail), wrapper
+  `shape-rotate-jitter-sweep`, doc `jitter-validation-harness.md` (Metal baseline
+  table + "Choosing the gate" + OpenGL/Linux deferred-baseline section).
+
+### Approach
+1. Branch off `origin/master`; commit `.fleet/plans/issue-1954.md` first.
+2. Add `scripts/dev/canvas-stress-rotate-jitter-sweep` (chmod +x), mirroring the
+   sibling's structure (self-locating; cmake + python3 stdlib only;
+   nproc/macOS-sysctl fallback; `find -delete` not `rm` glob):
+   - Build: `cmake --build "$BUILD_DIR" --target IRCanvasStress`.
+   - Capture: `./IRCanvasStress --sweep-yaw <from> <to> <steps> --auto-screenshot
+     <warmup>` (sweep auto-disables auto-rotate). Default a **focused** range +
+     bounded steps so sub-degree per-frame jitter is sampled without 360 full-frame
+     decodes — e.g. `--sweep-yaw 0 30 60` (0.5°/step, 60 frames). Make
+     from/to/steps/zoom overridable (positional args + env, like the sibling).
+   - Score: feed the captured full frames to `render-jitter-metric.py` with a
+     CENTRAL `--roi` (the detached+GRID column), deriving the ROI from a frame's
+     IHDR size (zoom/host robust) like the sibling — e.g. central ~40-50%.
+   - Gate on `MAX_JITTER` (env-overridable); exit non-zero on FAIL.
+3. Tune the threshold (mirror the doc's "Choosing the gate"): measure `jitter_score`
+   on the clean baseline (post-#1953 — the inherent round-to-cell scatter speckle
+   sets the floor) and on #1942 (the jitter). Set `MAX_JITTER` between them with
+   margin.
+4. Add a "canvas_stress (mixed DETACHED + GRID)" section to
+   `jitter-validation-harness.md`: measured pre/post-#1953 numbers, the chosen ROI +
+   range/steps, the threshold + rationale, and an OpenGL/Linux note (Linux baseline
+   captured by running the identical command on a Linux host — defer the number like
+   the shape_debug doc does).
+5. Validate: wrapper exits non-zero on a pre-#1953 checkout (#1942) and zero on the
+   #1953 branch / post-#1953 master. Record both numbers for the PR body + doc.
+6. `commit-and-push` (`Closes #1954`).
+
+### Affected files
+- `scripts/dev/canvas-stress-rotate-jitter-sweep` — NEW wrapper (executable)
+- `docs/design/jitter-validation-harness.md` — add canvas_stress section
+- `.fleet/plans/issue-1954.md` — new (first commit)
+- **Not touched:** `render-jitter-metric.py` (reused as-is), `canvas_stress/main.cpp`
+  (sweep mode already exists), `manifest.json`. If decode cost proves intolerable,
+  emitting a centred crop from sweep mode is a `main.cpp` change — flag it, but try
+  the bounded-steps + ROI approach first.
+
+### Acceptance criteria
+- `bash scripts/dev/canvas-stress-rotate-jitter-sweep` → one-command **PASS** on
+  post-#1953 master (or the #1953 branch).
+- The same command on a pre-#1953 checkout (#1942) → **FAIL** (non-zero),
+  demonstrating it would have caught the #1944 jitter.
+- `jitter-validation-harness.md` documents the canvas_stress baseline + threshold.
+
+### Gotchas
+- **Ordering:** land after #1953 (PREREQUISITE) so the dev tool is green on master.
+- **Full-frame decode cost:** bound steps (~60); do NOT default to 360 full frames.
+- **Inherent scatter speckle** (documented round-to-cell sub-cell CPU↔GPU
+  divergence; it's why the zoom shot is excluded from pixel-diff) sets the clean
+  jitter floor — set `MAX_JITTER` above it but below the #1942 jitter; too-tight
+  fails the clean run.
+- **ROI stability:** the central ROI must stay foreground across ALL swept frames
+  (the metric AND-s per-frame masks → `interior_px` shrinks if entities sweep out).
+  Verify `interior_px` is non-trivial; narrow the yaw range if the central column
+  drifts out of a fixed ROI.
+- The wrapper is a **manual/on-demand** gate (the sibling is not auto-CI), matching
+  the issue's "one-command jitter gate." Auto-CI wiring is out of scope.
+- Use `cmake --build` / `./IRCanvasStress` directly in the wrapper (mirror the
+  sibling — these dev scripts are not the fleet-build/run wrappers).
+
+

--- a/docs/design/jitter-validation-harness.md
+++ b/docs/design/jitter-validation-harness.md
@@ -176,3 +176,78 @@ The metric has a stdlib unittest (`scripts/tests/test_render_jitter_metric.py`)
 that proves the discrimination on synthetic frames — smooth motion scores
 near-zero, a crawling pattern scores an order of magnitude higher — so the
 metric's core claim is guarded without a GL/Metal context.
+
+## canvas_stress (mixed DETACHED + GRID): `scripts/dev/canvas-stress-rotate-jitter-sweep`
+
+`shape-rotate-jitter-sweep` (above) scores a **single** centred shape on the main
+canvas. The `canvas_stress` sibling extends the same metric to the **mixed
+canvas-type** scene — detached re-voxelize SO(3) solids + GRID-spin cubes on the
+screen-center column — under a fine continuous **camera Z-yaw** sweep. This is the
+multi-canvas-type temporal coverage gap #1922 deferred (part of epic #1881), and the
+re-scoped deliverable of #1954 (originally aimed at the #1942 DETACHED-vs-GRID
+camera-yaw jitter, re-scoped to the general temporal-crawl family once #1942 was shown
+to be a *spatial*-registration artifact owned by the #1944 render-verify gate, invisible
+to this temporal metric by construction).
+
+```bash
+bash scripts/dev/canvas-stress-rotate-jitter-sweep [build_dir] [from_rad] [to_rad] [steps]
+#   build_dir  CMake build dir                 (default: build)
+#   from_rad   sweep start camera yaw, RADIANS (default: 0)
+#   to_rad     sweep end camera yaw, RADIANS   (default: 0.2618 = 15°)
+#   steps      sweep shots from→to             (default: 36 → ~0.42°/step)
+# Env: WARMUP (settle frames, 60) · MAX_JITTER (gate, 4.0) · ROI_FRAC (central ROI, 0.5)
+```
+
+It drives `IRCanvasStress --sweep-yaw <from> <to> <steps> --no-spin
+--auto-screenshot <warmup>`, which emits `steps` full-frame captures
+(`screenshot_NNNNNN.png`, capture order = yaw order) at a fixed zoom-1, camera-(0,0)
+framing with only the camera yaw advancing. The metric ROI-scopes to the central
+half — the screen-center column where the detached + GRID solids sit (derived from the
+frame's IHDR, zoom/host robust) — and the whole foreground column fits inside it, so
+the interior is stable across the whole sweep.
+
+**`--no-spin` is mandatory, not optional.** Two flags gate rotation in this demo:
+`--sweep-yaw` freezes the *camera* auto-yaw (`autoRotate_`), but the *per-entity*
+self-spin is gated separately by `noSpin_`. Without `--no-spin` the detached + GRID
+solids keep self-spinning ~30° between the 60-settle-frame shots, and the metric — which
+needs a fine ≤~2°/step sweep — aliases that coarse self-rotation into a high
+second-difference, reading **jitter_score ≈ 3.7–4.4**. That number is *not* a speckle
+floor; it is the entity self-spin confounding the camera-yaw measurement. Freezing the
+entities isolates the actual camera-yaw crawl — the #1944 surface, and the same variable
+`shape-rotate-jitter-sweep` measures.
+
+### Baseline (macOS / Metal, 2560×1440, origin/master renderer)
+
+Camera-yaw sweep 0→0.2618 rad (15°) across 36 shots (~0.42°/step), entities frozen
+(`--no-spin`), central-half ROI. Gate: `MAX_JITTER = 4.0`.
+
+| scene                         | jitter_score | flicker_p95 | flicker_frac | interior_px | verdict |
+|-------------------------------|--------------|-------------|--------------|-------------|---------|
+| canvas_stress (DETACHED+GRID) | 1.19         | 7.29        | 0.134        | 227 864     | PASS    |
+
+The clean floor (1.19) lands in the **same regime as the sibling's smooth analytic
+shapes** (sphere 1.20, cylinder 1.17) — the mixed scene's camera-yaw crawl on master is
+clean. The capture is **byte-identical run-to-run** (fixed camera poses + frozen
+entities + the deterministic re-voxelize bake), so 1.19 is a hard number, not a noisy
+mean: the inherent round-to-cell scatter speckle is sub-cell and per-pose deterministic
+here, so it does not lift the gate.
+
+### Choosing the gate
+
+`MAX_JITTER = 4.0` mirrors the sibling's gate — same metric, same ~1.2 clean floor — and
+gives a >3× margin above the measured 1.19 while staying below where a real crawl
+regression lands (the sibling's failing shapes hit 6–11 on the identical metric). With
+no live FAIL sample in the mixed scene (the #1942 spatial drift is a different artifact
+class, gated elsewhere), the gate's teeth are demonstrated by tightening it below the
+floor — `MAX_JITTER=1.0 bash scripts/dev/canvas-stress-rotate-jitter-sweep` exits
+non-zero — confirming it *would* fail on a crawl regression that pushes the score above
+the floor. Re-baseline and tighten once a future re-voxelize / per-axis change moves the
+clean number.
+
+### OpenGL / Linux
+
+As with the shape_debug baseline, this table is the **Metal** baseline (the authoring
+host). The metric is backend-agnostic (luminance curvature), so the same `MAX_JITTER`
+gate applies on OpenGL; the Linux baseline is captured by running the identical command
+on a Linux host (cross-host smoke or a Linux worker) and is a follow-up — the renderer
+behaviour, not the harness, is what differs between backends.

--- a/scripts/dev/canvas-stress-rotate-jitter-sweep
+++ b/scripts/dev/canvas-stress-rotate-jitter-sweep
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# canvas-stress-rotate-jitter-sweep — temporal-jitter validation harness for the
+# MIXED DETACHED + GRID scene (#1954, epic #1881).
+#
+# Sibling to scripts/dev/shape-rotate-jitter-sweep (#1922), which scores a SINGLE
+# centred SDF / voxel shape on the main canvas. This one scores the canvas_stress
+# demo's MIXED scene — detached re-voxelize SO(3) solids + GRID-spin cubes on the
+# screen-center column — under a fine continuous CAMERA Z-yaw sweep. That is the
+# multi-canvas-type temporal coverage gap #1922 deferred (the stated "Part of:
+# epic #1881").
+#
+# What it measures: as the CAMERA yaws, does the rendered surface shimmer
+# frame-to-frame instead of moving smoothly? Same second-temporal-difference
+# metric (scripts/render-jitter-metric.py), same curvature-not-speed
+# discriminator — see docs/design/jitter-validation-harness.md. Entities are
+# frozen with --no-spin so camera yaw is the ONLY moving variable (the #1944
+# surface: entities static in world space, camera turning). Without --no-spin the
+# detached + GRID solids keep self-spinning ~24-30 degrees between the 60-settle-
+# frame shots, and that gross self-rotation — not the camera-yaw crawl — would
+# dominate the metric.
+#
+# IMPORTANT — this gate brackets temporal CRAWL above a FLOOR, not zero. The mixed
+# scene's central interior reads jitter_score ~= 1.2 on clean master (camera-yaw
+# fine sweep, entities frozen) — the same clean regime as the sibling's smooth
+# shapes (sphere/cylinder ~1.2) — with the residual coming from the inherent
+# re-voxelize round-to-cell scatter speckle (the documented CPU<->GPU divergence
+# that already excludes revoxelize_solids_zoom from pixel-diff). That floor is NOT
+# a bug; MAX_JITTER sits ABOVE it with margin, so the gate catches a temporal-crawl
+# REGRESSION (a change that worsens the shimmer) and passes on current master.
+#
+# NB on the floor number: a careless sweep WITHOUT --no-spin reads ~3.7-4.4, but
+# that is NOT the speckle floor — it is metric aliasing from the entities self-
+# spinning ~30 degrees between the 60-settle-frame shots (the metric needs a fine
+# <~2 deg/step sweep; 30 deg/step aliases any surface into a high second-difference).
+# Freezing the entities isolates the actual camera-yaw crawl, which is the #1944
+# surface and what #1922's camera-yaw methodology measures. Hence --no-spin and a
+# floor of ~1.2, not ~4.4.
+#
+# The #1942 world<->detached spatial-registration drift is a DIFFERENT artifact
+# class — a smooth sub-pixel translation at the moving silhouette boundary,
+# invisible to this temporal metric by construction (it keys on the second temporal
+# difference to ignore smooth motion, and AND-masks the moving boundary out of the
+# interior). #1942 is owned by the #1944 render-verify reference gate, not this
+# harness.
+#
+# Usage:  bash scripts/dev/canvas-stress-rotate-jitter-sweep [build_dir] [from_rad] [to_rad] [steps]
+#   build_dir   CMake build dir                          (default: build)
+#   from_rad    sweep start camera yaw, RADIANS          (default: 0)
+#   to_rad      sweep end camera yaw, RADIANS            (default: 0.2618 = 15 deg)
+#   steps       sweep shots from->to                     (default: 36 -> ~0.42 deg/step)
+#               --sweep-yaw interpolates yaw in RADIANS, and full-frame decode is
+#               ~2.3 s/frame at 2560x1440, so keep steps bounded (~30-40). Do NOT
+#               pass a degree count as the range (e.g. "30" = ~4.7 revolutions).
+# Env overrides:
+#   WARMUP      settle frames before the sweep starts    (default: 60)
+#   MAX_JITTER  gate on jitter_score                     (default: see below)
+#   ROI_FRAC    central ROI as a fraction of the frame   (default: 0.5)
+#
+# Repo tooling — cmake + python3 stdlib only. Long enough (build + sweep + per-
+# frame scoring) to launch in the background and read on completion. Self-
+# locating, so it works from any cwd / worktree.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT" || exit 1
+
+BUILD_DIR="${1:-build}"
+FROM="${2:-0}"
+TO="${3:-0.2618}"
+STEPS="${4:-36}"
+WARMUP="${WARMUP:-60}"
+# Floor on clean master is jitter_score ~= 1.2 (central-half ROI, 15 deg / 36-step
+# camera-yaw sweep, --no-spin), with run-to-run variation in the hundredths. The
+# gate at 4.0 mirrors the sibling shape-rotate-jitter-sweep (#1922): same metric,
+# same ~1.2 clean floor, leaving a >3x margin so speckle variation passes while a
+# real crawl regression (the sibling's failing shapes hit 6-11) fails. See the
+# harness doc's canvas_stress baseline for the measured numbers.
+MAX_JITTER="${MAX_JITTER:-4.0}"
+ROI_FRAC="${ROI_FRAC:-0.5}"
+
+EXE_DIR="$BUILD_DIR/creations/demos/canvas_stress"
+SS_DIR="$EXE_DIR/save_files/screenshots"
+METRIC="$ROOT/scripts/render-jitter-metric.py"
+
+# nproc is Linux-only; macOS uses sysctl. Fall back to a safe default.
+JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+
+echo "[1/3] building IRCanvasStress ($BUILD_DIR) ..."
+cmake --build "$BUILD_DIR" --target IRCanvasStress -j "$JOBS" >/dev/null \
+    || { echo "BUILD FAILED"; exit 1; }
+
+mkdir -p "$SS_DIR"
+# Scoped find -delete, never an unguarded rm glob (the dir may be empty, which
+# trips the dangerous-rm guard) — matches the sibling harnesses.
+find "$SS_DIR" -maxdepth 1 -type f -name '*.png' -delete
+
+echo "[2/3] sweep: camera yaw ${FROM}->${TO} rad across $STEPS shots (entities frozen, --no-spin), warmup=$WARMUP gate=max_jitter=$MAX_JITTER"
+LOG="/tmp/canvas-stress-jitter-sweep.log"
+( cd "$EXE_DIR" && ./IRCanvasStress --sweep-yaw "$FROM" "$TO" "$STEPS" --no-spin \
+    --auto-screenshot "$WARMUP" ) >"$LOG" 2>&1 \
+    || { echo "  RUN FAILED (see $LOG)"; tail -5 "$LOG"; exit 1; }
+
+echo "[3/3] scoring central ${ROI_FRAC} ROI ..."
+SS_DIR="$SS_DIR" METRIC="$METRIC" MAX_JITTER="$MAX_JITTER" ROI_FRAC="$ROI_FRAC" python3 - <<'PY'
+import glob, json, os, struct, subprocess, sys
+ss, metric = os.environ["SS_DIR"], os.environ["METRIC"]
+# Full frames in capture order = yaw order (screenshot_NNNNNN.png, no per-shot
+# crop — unlike shape_debug's centred --spin-shape crops). The metric ROI-scopes
+# to the screen-center column where the detached + GRID solids sit; deriving the
+# ROI from the frame's IHDR size keeps it zoom / host robust.
+frames = sorted(glob.glob(os.path.join(ss, "screenshot_*.png")))
+if len(frames) < 3:
+    print(f"  NO SWEEP FRAMES (got {len(frames)} — did the run capture?)")
+    sys.exit(1)
+with open(frames[0], "rb") as fh:
+    w, h = struct.unpack(">II", fh.read(24)[16:24])
+frac = float(os.environ["ROI_FRAC"])
+rw, rh = int(w * frac), int(h * frac)
+rx, ry = (w - rw) // 2, (h - rh) // 2
+roi = f"{rx},{ry},{rw},{rh}"
+out = subprocess.run(
+    [sys.executable, metric, *frames, "--roi", roi, "--max-jitter", os.environ["MAX_JITTER"]],
+    capture_output=True, text=True)
+# The metric prints a JSON object on success and {"error": ...} (exit 2) on an
+# I/O / format / empty-interior failure. Report either gracefully.
+try:
+    m = json.loads(out.stdout)
+except (ValueError, json.JSONDecodeError):
+    print(f"  METRIC ERROR (no JSON; rc={out.returncode}): "
+          f"{(out.stderr or out.stdout or '').strip()[:160]}")
+    sys.exit(1)
+if "frames" not in m:
+    print(f"  METRIC ERROR: {m.get('error', m)}")
+    sys.exit(1)
+verdict = "PASS" if m.get("pass") else "FAIL"
+print(f"  roi={roi}  frames={m['frames']}  interior={m['interior_px']}  "
+      f"jitter={m['jitter_score']}  p95={m['flicker_p95']}  "
+      f"frac={m['flicker_frac']}  gate={os.environ['MAX_JITTER']}  {verdict}")
+sys.exit(0 if m.get("pass") else 1)
+PY
+rc=$?
+echo "done. Frames remain in $SS_DIR; run log in $LOG"
+exit "$rc"


### PR DESCRIPTION
Resolves #1954 — the `canvas_stress` temporal-jitter validation harness, re-scoped per the architect's **Option A** ruling.

## What
- `scripts/dev/canvas-stress-rotate-jitter-sweep` — new wrapper, a sibling to `shape-rotate-jitter-sweep` (#1922): scores the mixed **DETACHED + GRID** canvas_stress scene under a fine camera Z-yaw sweep, reusing `scripts/render-jitter-metric.py` **unchanged**.
- `docs/design/jitter-validation-harness.md` — adds the canvas_stress baseline + threshold + `--no-spin` rationale.
- `.fleet/plans/issue-1954.md` — folds the Option A re-scope (revision history + re-scoped acceptance).

## Re-scope (architect ruling on the NEEDS-DESIGN escalation)
- Re-scoped to the temporal rotation-**crawl** family; **dropped** the "#1942 must FAIL" acceptance. #1942 is a *spatial*-registration drift owned by #1944's render-verify gate — invisible to this temporal metric by construction (keys on the 2nd temporal difference to ignore smooth motion, AND-masks the moving boundary out of the interior).
- Threshold against the measured master **floor**, not zero.

## Measurement correction — please sanity-check
The plan + the escalation reply both assumed the sweep froze entities ("isolates pure camera-yaw motion, entities static"). It does **not**: `--sweep-yaw` disables only the *camera* auto-yaw (`autoRotate_`); the per-entity self-spin is gated separately by `noSpin_` and keeps running ~30° between the 60-settle-frame shots. So the cited **~4.4 "floor" was entity self-spin aliasing the metric** (which needs a fine ≤~2°/step sweep), not speckle. Passing `--no-spin` delivers the intended pure-camera-yaw fine sweep; the true floor is **jitter_score 1.19** — the same clean regime as the sibling's smooth shapes (~1.2) — and **byte-identical run-to-run** (fixed poses + frozen entities + deterministic re-voxelize bake = a hard oracle, not flaky).

## Validation (macOS / Metal, 2560×1440)
- `bash scripts/dev/canvas-stress-rotate-jitter-sweep` → jitter `1.191`, gate `4.0`, **PASS** (exit 0).
- Same frames, gate tightened below the floor (`--max-jitter 1.0`) → **FAIL** (exit 1) — the gate has teeth.
- `MAX_JITTER=4.0` mirrors the sibling's gate (>3× margin above 1.19; the sibling's failing shapes hit 6–11 on the identical metric).

Closes #1954.