### PR TITLE
fleet: ingest gate keys on the ## Plan comment, not a plan file (#1945)

### DIFF
--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -221,6 +221,12 @@ MODEL_RE = re.compile(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(.+?)(?:\n|$)', re.IGN
 # queues without a plan file (architect-protocol.md §"Carve-offs are unplanned
 # tickets" is where the phrase is defined).
 SPIKE_RE = re.compile(r'investigation\s+spike', re.IGNORECASE)
+# #1932 PR2: the `[no-plan]` opt-out tag — the label-light twin of the
+# human:no-plan label, honored the same way as the investigation-spike phrase.
+NO_PLAN_RE = re.compile(r'\[no-plan\]', re.IGNORECASE)
+# #1932 PR2: the canonical plan is now a `## Plan` issue comment (no longer a
+# committed/staged plan file). Match a Markdown heading line "## Plan…".
+PLAN_COMMENT_RE = re.compile(r'^\s{0,3}#{2,}\s+Plan\b', re.MULTILINE)
 PLANS_DIR = os.path.expanduser('~/.fleet/plans')
 
 
@@ -272,6 +278,17 @@ def _plan_exists(repo, n, cache):
     cache[key] = present
     return present
 
+
+def _has_plan_comment(comments):
+    """True when any issue comment is a `## Plan` comment — the canonical plan
+    in the redesigned flow (#1932 PR2). `comments` is the list returned by
+    `gh issue view --json comments` (each item a dict carrying a 'body')."""
+    for c in comments or []:
+        body = c.get('body', '') if isinstance(c, dict) else ''
+        if body and PLAN_COMMENT_RE.search(body):
+            return True
+    return False
+
 stamped = 0
 skipped_already = 0
 blocked_marked = 0
@@ -288,7 +305,7 @@ for issue in pending:
 
     r = subprocess.run(
         ['gh', 'issue', 'view', str(n), '--repo', repo,
-         '--json', 'title,body,labels'],
+         '--json', 'title,body,labels,comments'],
         capture_output=True, text=True, timeout=15,
     )
     if r.returncode != 0:
@@ -305,7 +322,11 @@ for issue in pending:
     labels = {(l['name'] if isinstance(l, dict) else l) for l in view.get('labels', [])}
 
     if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
-            or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels):
+            or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels
+            or 'fleet:plan-review' in labels):
+        # fleet:plan-review (#1932): the plan is posted but a reviewer hasn't
+        # vetted it yet — ingest holds off until the reviewer clears the label
+        # (sound → removed; not sound → swapped to fleet:needs-plan).
         skipped_already += 1
         continue
 
@@ -318,24 +339,32 @@ for issue in pending:
         print(f'INFO issue {repo}#{n}: human:owned — skipping ingest (human de-queued)', file=sys.stderr)
         continue
 
-    # Planning gate (#1456): refuse to queue an issue that never passed
-    # through planning. Carve-offs stamped human:approved directly carry a
-    # hypothesis, not a plan — without a plan file the claiming worker is
-    # the first to open the code and design-blocks. Bounce to
-    # fleet:needs-plan (routes through PLANNING-PROTOCOL.md; the label also
-    # drops the issue out of the ingest pending set via the live-label skip guard)
-    # unless the issue is an explicit investigation spike. Sits before the
-    # blocker probes so a bounced issue costs no per-blocker API calls.
-    if (not SPIKE_RE.search(title) and not SPIKE_RE.search(body)
-            and not _plan_exists(repo, n, plan_cache)):
+    # Planning gate (#1456, re-keyed by #1932): refuse to queue an issue that
+    # never passed through planning. The canonical plan is now a `## Plan`
+    # issue comment (#1932); a committed/staged plan file still counts
+    # (backward compat for pre-redesign issues). Opt-outs: an explicit
+    # investigation spike, the `[no-plan]` tag, or the human:no-plan label.
+    # Without a plan or an opt-out the claiming worker is the first to open the
+    # code and design-blocks, so bounce to fleet:needs-plan (routes through
+    # PLANNING-PROTOCOL.md; the label also drops the issue out of the ingest
+    # pending set via the live-label skip guard). Sits before the blocker probes
+    # so a bounced issue costs no per-blocker API calls.
+    opted_out = bool(
+        SPIKE_RE.search(title) or SPIKE_RE.search(body)
+        or NO_PLAN_RE.search(title) or NO_PLAN_RE.search(body)
+        or 'human:no-plan' in labels
+    )
+    has_plan = (_has_plan_comment(view.get('comments', []))
+                or _plan_exists(repo, n, plan_cache))
+    if not opted_out and not has_plan:
         comment = (
-            f"Planning gate: no plan file found for this issue — neither "
-            f"committed `.fleet/plans/issue-{n}.md` nor planner-host "
-            f"`~/.fleet/plans/issue-{n}.md` — and it is not an explicit "
-            "investigation spike. Unplanned carve-offs design-block on "
-            "claim (#1456), so adding `fleet:needs-plan` to route it "
-            "through PLANNING-PROTOCOL.md before it can queue. "
-            "— fleet-queue-ingest"
+            f"Planning gate: this issue has no `## Plan` comment (the canonical "
+            f"plan per #1932) and no committed/staged plan file "
+            f"(`.fleet/plans/issue-{n}.md`), and it is not opted out "
+            f"(`human:no-plan` / `[no-plan]` / investigation spike). Unplanned "
+            f"carve-offs design-block on claim (#1456), so adding "
+            f"`fleet:needs-plan` to route it through PLANNING-PROTOCOL.md before "
+            "it can queue. — fleet-queue-ingest"
         )
         subprocess.run(
             ['gh', 'issue', 'comment', str(n), '--repo', repo,

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -25,13 +25,13 @@
 # hand-built projection). Claimability is unchanged — fleet-claim's own
 # Blocked-by gate still refuses a plain claim; see docs/design/fleet-queue-stacking.md.
 #
-# Planning gate (#1456): an approved issue with no plan file — neither the
-# committed repo-side `.fleet/plans/issue-<N>.md` nor the planner-host
-# `~/.fleet/plans/issue-<N>.md` staging copy — is bounced to fleet:needs-plan
-# instead of stamped fleet:queued, unless its title/body names an explicit
-# "investigation spike". Carve-offs queued straight to human:approved without
-# ever passing through planning made the worker the first person to open the
-# code, and it design-blocked on claim (the #1370 → #1414/#1431/#1435 pattern).
+# Planning gate (#1456, re-keyed by #1932): an approved issue with no plan — no
+# `## Plan` issue comment (canonical since #1932), no committed/staged plan file
+# (.fleet/plans/issue-<N>.md or ~/.fleet/plans/issue-<N>.md) — is bounced to
+# fleet:needs-plan unless opted out (`[no-plan]` / `human:no-plan` / investigation
+# spike). fleet:plan-review holds ingest until a reviewer vets the posted plan.
+# Carve-offs queued without planning made the worker the first to open the code,
+# and it design-blocked on claim (the #1370 → #1414/#1431/#1435 pattern).
 #
 # Source of truth: scripts/fleet/fleet-queue-ingest in the engine repo.
 # Installed to ~/bin/fleet-queue-ingest by scripts/fleet/install.sh.
@@ -381,8 +381,8 @@ for issue in pending:
             print(f'WARN issue {repo}#{n}: add fleet:needs-plan failed: {er.stderr.strip()}', file=sys.stderr)
             continue
         plan_bounced += 1
-        print(f'WARN issue {repo}#{n}: no plan file and not an investigation '
-              f'spike — bounced to fleet:needs-plan (#1456)', file=sys.stderr)
+        print(f'WARN issue {repo}#{n}: no ## Plan comment, no plan file, and not '
+              f'opted out ([no-plan] / human:no-plan / spike) — bounced to fleet:needs-plan', file=sys.stderr)
         continue
 
     # Blocked-by handling (#1527): queue blocked tasks too. A task whose

--- a/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # Test the fleet-queue-ingest planning gate (#1456).
 #
-# An approved issue with no plan file — neither planner-host staging
-# (~/.fleet/plans/issue-<N>.md) nor the committed repo-side copy
-# (.fleet/plans/issue-<N>.md, probed via `gh api`) — must be bounced to
-# fleet:needs-plan (never stamped fleet:queued), with an explanatory comment.
-# Escape hatches: a local plan file, a committed repo-side plan file, an
-# explicit "investigation spike" in the title/body, and a non-404 probe
-# failure (fail open — a transient API error must never bounce a planned
-# issue).
+# An approved issue with no `## Plan` issue comment (canonical since #1932) and
+# no plan file (neither planner-host staging ~/.fleet/plans/issue-<N>.md nor the
+# committed repo-side copy .fleet/plans/issue-<N>.md, probed via `gh api`) must
+# be bounced to fleet:needs-plan (never stamped fleet:queued), with an explanatory
+# comment. Escape hatches: a `## Plan` comment, a local plan file, a committed
+# plan file, an explicit "investigation spike" in the title/body, the `[no-plan]`
+# tag, the `human:no-plan` label, the `fleet:plan-review` early-skip, and a
+# non-404 probe failure (fail open — a transient API error must never bounce a
+# planned issue).
 #
 # HOME is redirected to a temp dir so the script's hardcoded projection/log/lock
 # paths land in the sandbox, and `gh` is stubbed to canned issue/PR surfaces.

--- a/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
@@ -45,13 +45,21 @@ PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
 # #742 = committed repo-side plan (gh api 200)    → stamp
 # #743 = no plan, body declares investigation spike → stamp
 # #744 = plan probe fails WITHOUT a 404 (network) → fail open, stamp
+# #745 = `## Plan` issue comment, no file (#1932)  → stamp (the canonical path)
+# #746 = `[no-plan]` opt-out tag in title (#1932)  → stamp
+# #747 = human:no-plan opt-out label (#1932)       → stamp
+# #748 = fleet:plan-review (plan not yet vetted)    → early-skip (no stamp/bounce)
 cat > "$PROJ" <<'JSON'
 {"pending_issues":[
   {"number":740,"repo":"engine"},
   {"number":741,"repo":"engine"},
   {"number":742,"repo":"engine"},
   {"number":743,"repo":"engine"},
-  {"number":744,"repo":"engine"}
+  {"number":744,"repo":"engine"},
+  {"number":745,"repo":"engine"},
+  {"number":746,"repo":"engine"},
+  {"number":747,"repo":"engine"},
+  {"number":748,"repo":"engine"}
 ],"unblock_issues":[]}
 JSON
 
@@ -72,6 +80,10 @@ case "$1" in
                     742) echo '{"title":"render: epic child","body":"**Model:** sonnet\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
                     743) echo '{"title":"render: probe the culling path","body":"**Model:** opus\n**Blocked by:** (none)\n\nExplicit investigation spike: report findings, no fix expected.","labels":[{"name":"human:approved"}]}' ;;
                     744) echo '{"title":"render: planned elsewhere","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    745) echo '{"title":"render: planned via comment","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}],"comments":[{"body":"## Plan: do the thing\n\nstep one"}]}' ;;
+                    746) echo '{"title":"render: tiny tweak [no-plan]","body":"**Model:** sonnet\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    747) echo '{"title":"render: human said skip","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"human:no-plan"}]}' ;;
+                    748) echo '{"title":"render: plan under review","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"fleet:plan-review"}]}' ;;
                     *)   echo '{"title":"","body":"","labels":[]}' ;;
                 esac
                 exit 0 ;;
@@ -162,6 +174,39 @@ if [[ -n "$l744" && "$l744" == *"fleet:queued"* && "$l744" != *"fleet:needs-plan
     ok "#744 (non-404 probe failure) failed open and stamped"
 else
     bad "#744 transient probe failure wrongly bounced: '$l744'"
+fi
+
+# --- #1932: comment-based plan + opt-outs -----------------------------------
+# #745 (`## Plan` issue comment, no file) → stamped (the canonical redesign path).
+l745=$(edit_line 745)
+if [[ -n "$l745" && "$l745" == *"fleet:queued"* && "$l745" != *"fleet:needs-plan"* ]]; then
+    ok "#745 (## Plan comment, no file) stamped fleet:queued"
+else
+    bad "#745 comment-based plan mis-handled: '$l745'"
+fi
+
+# #746 ([no-plan] tag in title) → stamped (opt-out).
+l746=$(edit_line 746)
+if [[ -n "$l746" && "$l746" == *"fleet:queued"* && "$l746" != *"fleet:needs-plan"* ]]; then
+    ok "#746 ([no-plan] opt-out tag) stamped without a plan"
+else
+    bad "#746 [no-plan] opt-out failed: '$l746'"
+fi
+
+# #747 (human:no-plan label) → stamped (opt-out).
+l747=$(edit_line 747)
+if [[ -n "$l747" && "$l747" == *"fleet:queued"* && "$l747" != *"fleet:needs-plan"* ]]; then
+    ok "#747 (human:no-plan opt-out label) stamped without a plan"
+else
+    bad "#747 human:no-plan opt-out failed: '$l747'"
+fi
+
+# #748 (fleet:plan-review) → early-skipped: neither queued nor bounced.
+l748=$(edit_line 748)
+if [[ -z "$l748" ]]; then
+    ok "#748 (fleet:plan-review) early-skipped — no stamp, no bounce"
+else
+    bad "#748 plan-review issue was not skipped: '$l748'"
 fi
 
 echo


### PR DESCRIPTION
## Summary
PR **2/5** of the planning-flow redesign (#1932). `fleet-queue-ingest`'s planning gate now passes when the issue has a **`## Plan` comment** (the canonical plan in the redesign) **or** is opted out (investigation spike / `[no-plan]` tag / `human:no-plan` label), instead of requiring a committed/staged plan **file**. A plan file still counts (backward compat for pre-redesign issues). Adds `fleet:plan-review` to the ingest early-skip set so a plan awaiting review is held until a reviewer clears the label.

- Comments fetched via the existing `gh issue view --json` → **no extra per-issue API call**.
- `_has_plan_comment()` matches a `## Plan` Markdown heading in any issue comment.

## Test plan
- [x] `test_fleet_queue_ingest_plan_gate.sh` extended (comment-based path, `[no-plan]`, `human:no-plan`, `fleet:plan-review` early-skip) — **11/11**.
- [x] Full fleet suite green (human_owned 3/3, blocked_by.sh 9/9, scope_shipped 47, blocked_by.py 33, queue_manager 30); `bash -n` clean.

## Note / deploy
The `human:no-plan` label does not exist on GitHub yet — the #1932 deploy step (`fleet-labels` sync) is still pending. The code tolerates its absence; the `[no-plan]` tag + spike opt-outs work regardless.

Closes #1945

🤖 Generated with [Claude Code](https://claude.com/claude-code)