### PR TITLE
fleet: planning-claim lock on needs-plan issues (#1946, re-scope of #1889)

### DIFF
--- a/.fleet/plans/issue-1889.md
+++ b/.fleet/plans/issue-1889.md
@@ -1,162 +1,61 @@
-# Plan: fleet — atomic claim on a needs-plan issue before planning (dedup duplicate plan PRs)
+# Plan: fleet — atomic planning claim on a needs-plan issue (re-scoped into #1946)
 
 - **Issue:** #1889
 - **Model:** opus
-- **Date:** 2026-06-17
-- **Blocked by:** #1890 (lands the PLANNING-PROTOCOL Step-0 *contract* prose this tooling implements; #1889 amends that same paragraph to name the concrete command, so they must serialize — editing it in parallel is the exact add/add conflict #1889 prevents)
+- **Status:** **re-scoped + implemented in #1946 (planning-flow redesign PR 3/5, #1932).**
+- **Date:** 2026-06-17 (re-scoped 2026-06-23)
 
-## Scope
+## What this was, and what changed
 
-Implement the atomic claim the new PLANNING-PROTOCOL **Step 0** describes: a
-`fleet-claim`-style lock on a `fleet:needs-plan` issue, acquired *before* a
-planner reads the thread, plus a skip-if-an-open-plan-PR-already-references-the-
-issue cross-check. Closes the same-tick race where two opus panes select the
-same oldest needs-plan issue, both see no plan PR yet, and both plan it (#1810
-produced **three** duplicate plan PRs → three add/add conflicts + review cycles).
+#1889 set out to close the same-tick double-plan race (#1810 produced **three**
+duplicate plan PRs → three add/add conflicts) with two pieces:
 
-The PR cross-check alone does NOT close the same-tick race (both planners pass it
-before either opens a PR); the atomic lex-min label claim does. Both are needed:
-the cross-check is the cheap early-out for the *already-planned-on-a-prior-tick*
-case; the claim is the race-closer for the *same-tick* case.
+1. an atomic `fleet-claim` label lock on a `fleet:needs-plan` issue, acquired
+   before a planner reads the thread; and
+2. a "skip if an open **plan-doc PR** already references the issue" cross-check
+   (the cheap early-out for the already-planned-on-a-prior-tick case).
 
-## Approach (one approach, picked)
+The **planning-flow redesign (#1932)** then collapsed the separate plan-doc PR
+into the implementation PR: the canonical plan is now a **`## Plan` issue
+comment**, not a committed/merged plan-doc PR. That makes piece (2)'s plan-doc-PR
+matcher obsolete — there is no plan-doc PR to match. So #1889 is **re-scoped and
+folded into #1946** (#1932 PR 3):
 
-The lock fabric already has the exact primitive: `_cmd_pr_label_claim`
-(`scripts/fleet/fleet-claim:1194`) — a sole-holder lex-min tie-break via
-`_acquire_label_on` / `_claim_decision` (#1384). It already serves four label
-classes (`fleet:reviewing-` / `fleet:resolving-` / `fleet:amending-` /
-`fleet:stewarding-`). **`steward-claim` is the precise template**: it targets the
-*issue* (not a PR), label-only (no FS lock), per-mutex — identical shape to what
-planning needs. Mirror it, then bolt the plan-PR cross-check onto the front.
+- **Piece 1 (the lock) — kept, implemented in #1946.** `fleet-claim
+  planning-claim` / `planning-release` mirror the `steward-claim` class: a
+  sole-holder lex-min `fleet:planning-<host>-<agent>` label on the issue
+  (`_cmd_pr_label_claim` / `_acquire_label_on` / `_claim_decision`), plus a
+  fourth `cleanup --gh` pass that sweeps stale `fleet:planning-*` labels off open
+  `fleet:needs-plan` issues after `FLEET_CLAIM_STALE_SECS_PLANNING` (default
+  3600s). This is the same-tick race-closer.
+- **Piece 2 (the early-out) — replaced.** Instead of the
+  `plan_pr_matches_issue` plan-doc-PR cross-check, `planning-claim` now
+  early-outs (return 3, "already planned") when a **`## Plan` comment already
+  exists** on the issue (`_issue_has_plan_comment`). Same purpose — cheap skip
+  for the already-planned case — keyed on the redesign's canonical artifact.
 
-Steps, in order:
+So `plan_pr_matches_issue` is **not** added to `fleet_branch_match.py` (the
+original #1889 step 1); the comment check supersedes it.
 
-1. **`fleet_branch_match.py` — add `plan_pr_matches_issue(head_ref, title, issue, repo)`.**
-   Returns True iff a PR is a *plan-doc* PR for `issue`. This is a DELIBERATELY
-   different matcher than the existing `branch_matches_issue`: that one is
-   tuned NOT to match `docs/plan-<N>-…` branches (so a plan-doc PR doesn't
-   strand task pickup — [[feedback_plan_doc_pr_strands_pickup]]). The planning
-   cross-check wants the opposite — to recognize plan-doc PRs and skip. Match on
-   the union of observed plan-PR shapes (from the #1810 incident:
-   `claude/1810-plan`, `claude/1810-plan-doc`, `claude/plan-1810`,
-   `docs/plan-1810-deploy-blocker-reconcile`):
-     - branch regex (anchored, `<N>` = the issue number, word-boundaried so #18
-       doesn't match #1810): `^docs/plan-<N>(-|$)`, `^claude/plan-<N>(-|$)`,
-       `^claude/<N>-plan(-doc)?(-|$)`, `^claude/<N>-plan$`.
-     - title fallback: case-insensitive `plan .*#?<N>\b` (covers
-       "docs: plan #1888 — …" / "Plan: <title> (#N)").
-   Add it as a *function on the existing module* — NOT a new module
-   ([[project_fleet_py_module_resolution]]: new scout-imported modules are
-   fragile; functions on an already-imported module are safe).
+## Status of the original blocker
 
-2. **`fleet-claim` — `cmd_planning_claim` (wrapper, not a one-liner).** Unlike
-   steward-claim it must run the cross-check first:
-     a. validate the issue number (reuse the numeric guard pattern).
-     b. fetch open PRs exactly as `cmd_claim`'s dedup guard does
-        (`fleet-claim:819`): `gh pr list --repo "$repo" --state open
-        --json number,headRefName,title` piped to an inline python3 block that
-        imports `plan_pr_matches_issue`. If ANY open PR matches → print
-        `planning-claim: #<N> already has an open plan PR #<M>; skip` and
-        `return 1` (do NOT POST a label).
-     c. otherwise delegate to the shared claimer:
-        `_cmd_pr_label_claim "fleet:planning-" "planning-claim" "$issue" "$agent" "issue"`.
-   Honor the global `--repo game` flag (resolve target repo via `repo_from_ns`,
-   same as steward-claim) so game-side needs-plan issues are supported.
-3. **`fleet-claim` — `cmd_planning_release`.** One-liner mirroring
-   `cmd_steward_release`:
-   `_cmd_pr_label_release "fleet:planning-" "planning-release" "${1:-}" "${2:-unknown}" "issue"`.
-4. **`fleet-claim` — dispatch + help + doc-comment inventory.** Add
-   `planning-claim` / `planning-release` case branches (next to the
-   `resolving-claim` / `steward-claim` branches, ~line 3734); add usage lines
-   (~line 3975); add to the top-of-file usage comment block (~line 29) and the
-   label-class inventory comment (~lines 192-194).
-5. **`fleet-claim` — `cmd_cleanup` first-pass TTL sweep (the safety net for a
-   planner that crashed before releasing).**
-     - `fleet-claim:1435`: add `or name.startswith("fleet:planning-")` to the
-       swept-prefix predicate.
-     - `fleet-claim:~1457-1479`: the heartbeat-fresh skip currently special-cases
-       only `fleet:amending-*`. Extend it to ALSO cover `fleet:planning-*`
-       (a heavy plan — read thread + write plan + open docs PR — can exceed the
-       30-min `FLEET_CLAIM_STALE_SECS` TTL; the planner touches its heartbeat at
-       role step 0, so a fresh heartbeat must keep the claim alive). Parse the
-       agent out of `fleet:planning-<host>-<agent>` the same way the amending
-       branch does.
-     - `fleet-claim:1342-1345`: extend the cleanup help text to mention
-       `fleet:planning-*`.
-6. **`docs/agents/PLANNING-PROTOCOL.md` — wire the concrete command** (this is
-   the paragraph #1890 adds, hence the block dependency):
-     - **Step 0**: replace the generic "Acquire a `fleet-claim`-style lock …
-       (tracked separately)" with the concrete invocation:
-       `fleet-claim planning-claim <N> <your-agent-name>` (engine) /
-       `fleet-claim --repo game planning-claim <N> <agent>` (game). State the
-       contract: exit 0 → you own the plan, proceed; exit 1 → skip (a plan PR
-       already exists OR you lost the same-tick race) — move to the next
-       needs-plan issue.
-     - **Step 4**: after `gh issue edit … --remove-label "fleet:needs-plan"`,
-       add `fleet-claim planning-release <N> <agent>`. Specify that the release
-       runs on EVERY exit path of the planning attempt — including the
-       "If you disagree with the issue's direction … leave fleet:needs-plan on"
-       branch — so the lock is never orphaned by a deliberate no-plan.
-7. **Test: `scripts/fleet/tests/test_fleet_claim_planning.sh`** (mirror
-   `test_fleet_claim_steward.sh`). Two cases, using the existing test knobs
-   (`FLEET_TEST_HOST`, `FLEET_CLAIM_NO_SLEEP=1`, mocked `gh`):
-     - **same-tick race**: two agents `planning-claim` the same issue with no
-       open plan PR → exactly one exit 0, the other exit 1 (lex-min).
-     - **cross-check**: with a mocked open PR on branch
-       `docs/plan-<N>-foo`, `planning-claim <N>` exits 1 without POSTing a label.
-   Also add a `plan_pr_matches_issue` unit assertion (#18 must NOT match a
-   `docs/plan-1810-…` branch — the word-boundary check).
+`Blocked by: #1890` (the PLANNING-PROTOCOL Step-0 contract prose) — merged. The
+contract the lock implements lives in PLANNING-PROTOCOL.md; #1946 names the
+concrete `planning-claim` / `planning-release` commands there (role-doc wiring is
+#1932 PR 5 / #1948).
 
-## Affected files
+## Tests
 
-- `scripts/fleet/fleet_branch_match.py` — new `plan_pr_matches_issue()` helper.
-- `scripts/fleet/fleet-claim` — `cmd_planning_claim` (+ cross-check),
-  `cmd_planning_release`, dispatch/help/doc-comment, cleanup first-pass sweep +
-  heartbeat guard extension.
-- `docs/agents/PLANNING-PROTOCOL.md` — Step 0 concrete command + Step 4 release
-  (amends the paragraph #1890 introduces → **Blocked by #1890**).
-- `scripts/fleet/tests/test_fleet_claim_planning.sh` — new race + cross-check test.
+`scripts/fleet/tests/test_fleet_claim_planning.sh` — acquire, the `## Plan`
+dedup early-out (exit 3), cross-host yield + self-remove, release, and the TTL
+sweep (stale swept / fresh kept / override respected). 13/13.
 
-## Acceptance criteria
+## Deferred (noted, not in #1946)
 
-- `fleet-claim planning-claim <N> <agent>` exits 0 and stamps
-  `fleet:planning-<host>-<agent>` when no plan PR exists and no competitor holds
-  a lower-lex planning label; exits 1 otherwise.
-- Two concurrent `planning-claim` calls on one issue → exactly one exit 0
-  (validated by the new test under `FLEET_CLAIM_NO_SLEEP=1`).
-- With an open `docs/plan-<N>-…` PR present, `planning-claim <N>` exits 1 and
-  POSTs no label.
-- `planning-release` removes the agent's `fleet:planning-*` label (idempotent).
-- `cleanup --gh` sweeps a stale `fleet:planning-*` label off an open issue past
-  TTL, but SKIPS it when the agent's heartbeat is fresh.
-- `--repo game` routes the label to `jakildev/irreden`.
-- PLANNING-PROTOCOL Step 0/Step 4 name the concrete command; both `role-worker`
-  and `role-opus-architect` inherit it by reference (no edits to those files).
-- All new + existing `scripts/fleet/tests/test_fleet_claim_*.sh` pass.
-
-## Gotchas
-
-- **Do NOT edit `.claude/commands/role-worker.md` or any `SKILL.md`.** Those are
-  gated self-config; a queue-sourced worker cannot ship edits to them
-  ([[feedback_role_config_self_edit_gated]]). The wiring goes entirely into the
-  shared `docs/agents/PLANNING-PROTOCOL.md` (non-gated), which both role files
-  already delegate to (role-worker step 2 "follow PLANNING-PROTOCOL.md";
-  architect-protocol.md:248). This keeps #1889 worker-shippable.
-- **Label-only, no FS lock** — mirror steward-claim, NOT cmd_claim. A
-  `$CLAIMS_DIR/$slug` mkdir would wrongly tie planning to the task-claim
-  lifecycle (blocker/model gating, in-progress audit). The cross-host label is
-  the lock; same-host two-pane races are still resolved because the agent name
-  (`worker-1` vs `worker-2`) makes the labels distinct and lex-min picks one.
-- **Plan-PR matcher must be the inverse of `branch_matches_issue`.** Reusing
-  `branch_matches_issue` for the cross-check would MISS `docs/plan-<N>-…`
-  branches (it's deliberately built not to match them). Write the separate
-  `plan_pr_matches_issue` and word-boundary the number so #18 ≠ #1810/#1889.
-- **The #1890 ordering.** #1890 (approved + human-deferred) adds the Step-0
-  paragraph; #1889 amends it. Honor `Blocked by: #1890`. If the human wants the
-  tooling before merging #1890, the conflict-free fallback is to land the
-  fleet-claim + test + helper now and defer ONLY the PLANNING-PROTOCOL.md edit
-  to a follow-up after #1890 merges — but the default recommended path is to
-  serialize behind #1890 so Step 0 is named in one place.
-- **Heartbeat guard parity.** If you add `fleet:planning-*` to the cleanup sweep
-  but forget the heartbeat-fresh skip, a long opus plan iteration will have its
-  own claim swept out from under it mid-plan (the #1650-class TTL-lapse bug).
+Retiring `_PLAN_DOC_TITLE` (the scope-shipped layer-4 plan-doc-title guard, #1932
+PR 3 scope) is **deferred** as orthogonal cleanup: it is one layer of a
+multi-layer guard with its own test suite, and removing it has a narrow
+regression risk on any lingering plan-doc PR that still references a still-open
+issue. The redesign stops *producing* plan-doc PRs, so the guard is harmless to
+keep; retire it in a small standalone follow-up rather than bundling a
+guard-removal into the claim-lock PR.

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1259,6 +1259,34 @@ cmd_amending_release() {
 cmd_steward_claim()   { _cmd_pr_label_claim   "fleet:stewarding-" "steward-claim"   "${1:-}" "${2:-unknown}" "issue"; }
 cmd_steward_release() { _cmd_pr_label_release "fleet:stewarding-" "steward-release" "${1:-}" "${2:-unknown}" "issue"; }
 
+# Planning claims target a fleet:needs-plan ISSUE before a planner reads the
+# thread (#1932 PR3, re-scope of #1889): a sole-holder lex-min label lock that
+# closes the same-tick double-plan race (#1810 produced three duplicate plan
+# PRs, three add/add conflicts). Same labels endpoint + tie-break as
+# steward-claim; targets the issue, label-only. The cheap already-planned
+# early-out is "a `## Plan` comment already exists" (the redesign's dedup,
+# replacing the old plan-doc-PR cross-check now that plan-doc PRs are gone): if
+# planning already happened on a prior tick, no claim is needed (return 3).
+_issue_has_plan_comment() {
+    local repo="$1" issue="$2" cnt
+    cnt=$(gh issue view "$issue" --repo "$repo" --json comments \
+        --jq '[.comments[] | select(.body | test("(?m)^#{2,} +Plan"))] | length' \
+        2>/dev/null || echo 0)
+    [[ "${cnt:-0}" =~ ^[0-9]+$ && "${cnt:-0}" -gt 0 ]]
+}
+cmd_planning_claim() {
+    local issue="${1:-}" agent="${2:-unknown}" repo
+    if [[ "$issue" =~ ^[0-9]+$ ]] && command -v gh >/dev/null 2>&1; then
+        repo=$(repo_from_ns)
+        if [[ -n "$repo" ]] && _issue_has_plan_comment "$repo" "$issue"; then
+            echo "planning-claim: issue#$issue already has a ## Plan comment; skipping (already planned)"
+            return 3
+        fi
+    fi
+    _cmd_pr_label_claim "fleet:planning-" "planning-claim" "$issue" "$agent" "issue"
+}
+cmd_planning_release() { _cmd_pr_label_release "fleet:planning-" "planning-release" "${1:-}" "${2:-unknown}" "issue"; }
+
 cmd_check() {
     # Exit 0 = free, exit 1 = claimed.
     local issue_num
@@ -1606,6 +1634,55 @@ for issue in issues:
                     "cleanup --gh: steward remove-label failed"
             fi
         done <<< "$steward_plan"
+    done
+
+    # Fourth pass: sweep stale `fleet:planning-*` labels off open
+    # fleet:needs-plan issues (#1932 PR3). A planning claim is held only while a
+    # planner reads the thread + posts the `## Plan` comment, then released; a
+    # crashed planner would otherwise strand the needs-plan issue (no other
+    # planner can claim it). Looser TTL, like the steward pass — a planning
+    # iteration is a transient session.
+    local planning_stale_secs="${FLEET_CLAIM_STALE_SECS_PLANNING:-3600}"
+    for repo in "${repos[@]}"; do
+        local planning_plan
+        planning_plan=$(gh issue list --repo "$repo" --state open \
+            --label "fleet:needs-plan" \
+            --json number,labels --limit 200 2>/dev/null \
+            | python3 -c '
+import json, sys
+try:
+    issues = json.load(sys.stdin)
+except Exception:
+    issues = []
+for issue in issues:
+    n = issue.get("number")
+    for l in (issue.get("labels") or []):
+        name = (l or {}).get("name", "") if isinstance(l, dict) else ""
+        if name.startswith("fleet:planning-"):
+            print(f"{n}\t{name}")
+' 2>/dev/null || echo "")
+
+        [[ -z "$planning_plan" ]] && continue
+
+        while IFS=$'\t' read -r issue_num label_name; do
+            [[ -z "$issue_num" || -z "$label_name" ]] && continue
+
+            local added_epoch
+            added_epoch=$(label_added_epoch "$repo" "$issue_num" "$label_name")
+            [[ "$added_epoch" -eq 0 ]] && continue
+
+            local age=$(( now - added_epoch ))
+            [[ $age -lt $planning_stale_secs ]] && continue
+
+            if gh issue edit "$issue_num" --repo "$repo" \
+                    --remove-label "$label_name" >/dev/null 2>&1; then
+                echo "cleanup --gh: removed stale '$label_name' on $repo issue#$issue_num (age: $((age / 60))m)"
+                total_removed=$((total_removed + 1))
+            else
+                write_orphan_sentinel "$repo" "$issue_num" "$label_name" \
+                    "cleanup --gh: planning remove-label failed"
+            fi
+        done <<< "$planning_plan"
     done
 
     if [[ $total_removed -eq 0 ]]; then
@@ -3772,6 +3849,20 @@ case "${1:-}" in
             exit 2
         fi
         cmd_steward_release "$2" "$3"
+        ;;
+    planning-claim)
+        if [[ -z "${3:-}" ]]; then
+            echo "usage: fleet-claim [--repo <ns>] planning-claim <needs-plan-issue> <agent>" >&2
+            exit 2
+        fi
+        cmd_planning_claim "$2" "$3"
+        ;;
+    planning-release)
+        if [[ -z "${3:-}" ]]; then
+            echo "usage: fleet-claim [--repo <ns>] planning-release <needs-plan-issue> <agent>" >&2
+            exit 2
+        fi
+        cmd_planning_release "$2" "$3"
         ;;
     clear-all)
         cmd_clear_all

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1270,7 +1270,7 @@ cmd_steward_release() { _cmd_pr_label_release "fleet:stewarding-" "steward-relea
 _issue_has_plan_comment() {
     local repo="$1" issue="$2" cnt
     cnt=$(gh issue view "$issue" --repo "$repo" --json comments \
-        --jq '[.comments[] | select(.body | test("(?m)^#{2,} +Plan"))] | length' \
+        --jq '[.comments[] | select(.body | test("(?m)^#{2,} +Plan\\b"))] | length' \
         2>/dev/null || echo 0)
     [[ "${cnt:-0}" =~ ^[0-9]+$ && "${cnt:-0}" -gt 0 ]]
 }
@@ -4035,7 +4035,7 @@ commands:
                                 (default: 7200).
   cleanup [--repo o/r] [--gh] ...
                                 Remove claims whose linked issue is
-                                CLOSED. With --gh also runs three
+                                CLOSED. With --gh also runs four
                                 GitHub sweeps:
                                 (1) stale fleet:reviewing-*,
                                     fleet:resolving-*, and
@@ -4055,6 +4055,10 @@ commands:
                                 (3) stale fleet:stewarding-* labels off
                                     open fleet:epic issues (age >
                                     FLEET_CLAIM_STALE_SECS_STEWARD,
+                                    default 3600s),
+                                (4) stale fleet:planning-* labels off
+                                    open fleet:needs-plan issues (age >
+                                    FLEET_CLAIM_STALE_SECS_PLANNING,
                                     default 3600s).
                                 `fleet:claim-*` labels on CLOSED
                                 issues are preserved as a historical
@@ -4082,6 +4086,16 @@ commands:
                                 FLEET_CLAIM_STALE_SECS_STEWARD).
   steward-release <umbrella-issue> <agent>
                                 release a stewardship claim.
+  planning-claim <needs-plan-issue> <agent>
+                                atomically claim a fleet:needs-plan ISSUE
+                                before planning via a
+                                fleet:planning-<host>-<agent> label
+                                (sole-holder lex-min; early-out exit 3
+                                when a ## Plan comment already exists;
+                                swept by cleanup --gh after
+                                FLEET_CLAIM_STALE_SECS_PLANNING).
+  planning-release <needs-plan-issue> <agent>
+                                release a planning claim.
   clear-all                     wipe all claims (used by fleet-up on
                                 restart).
   reset-sweep-host-claims       unconditionally remove this host's

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -221,6 +221,12 @@ MODEL_RE = re.compile(r'\*\*(?:Suggested\s+)?Model:\*\*\s*(.+?)(?:\n|$)', re.IGN
 # queues without a plan file (architect-protocol.md §"Carve-offs are unplanned
 # tickets" is where the phrase is defined).
 SPIKE_RE = re.compile(r'investigation\s+spike', re.IGNORECASE)
+# #1932 PR2: the `[no-plan]` opt-out tag — the label-light twin of the
+# human:no-plan label, honored the same way as the investigation-spike phrase.
+NO_PLAN_RE = re.compile(r'\[no-plan\]', re.IGNORECASE)
+# #1932 PR2: the canonical plan is now a `## Plan` issue comment (no longer a
+# committed/staged plan file). Match a Markdown heading line "## Plan…".
+PLAN_COMMENT_RE = re.compile(r'^\s{0,3}#{2,}\s+Plan\b', re.MULTILINE)
 PLANS_DIR = os.path.expanduser('~/.fleet/plans')
 
 
@@ -272,6 +278,17 @@ def _plan_exists(repo, n, cache):
     cache[key] = present
     return present
 
+
+def _has_plan_comment(comments):
+    """True when any issue comment is a `## Plan` comment — the canonical plan
+    in the redesigned flow (#1932 PR2). `comments` is the list returned by
+    `gh issue view --json comments` (each item a dict carrying a 'body')."""
+    for c in comments or []:
+        body = c.get('body', '') if isinstance(c, dict) else ''
+        if body and PLAN_COMMENT_RE.search(body):
+            return True
+    return False
+
 stamped = 0
 skipped_already = 0
 blocked_marked = 0
@@ -288,7 +305,7 @@ for issue in pending:
 
     r = subprocess.run(
         ['gh', 'issue', 'view', str(n), '--repo', repo,
-         '--json', 'title,body,labels'],
+         '--json', 'title,body,labels,comments'],
         capture_output=True, text=True, timeout=15,
     )
     if r.returncode != 0:
@@ -305,7 +322,11 @@ for issue in pending:
     labels = {(l['name'] if isinstance(l, dict) else l) for l in view.get('labels', [])}
 
     if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
-            or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels):
+            or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels
+            or 'fleet:plan-review' in labels):
+        # fleet:plan-review (#1932): the plan is posted but a reviewer hasn't
+        # vetted it yet — ingest holds off until the reviewer clears the label
+        # (sound → removed; not sound → swapped to fleet:needs-plan).
         skipped_already += 1
         continue
 
@@ -318,24 +339,32 @@ for issue in pending:
         print(f'INFO issue {repo}#{n}: human:owned — skipping ingest (human de-queued)', file=sys.stderr)
         continue
 
-    # Planning gate (#1456): refuse to queue an issue that never passed
-    # through planning. Carve-offs stamped human:approved directly carry a
-    # hypothesis, not a plan — without a plan file the claiming worker is
-    # the first to open the code and design-blocks. Bounce to
-    # fleet:needs-plan (routes through PLANNING-PROTOCOL.md; the label also
-    # drops the issue out of the ingest pending set via the live-label skip guard)
-    # unless the issue is an explicit investigation spike. Sits before the
-    # blocker probes so a bounced issue costs no per-blocker API calls.
-    if (not SPIKE_RE.search(title) and not SPIKE_RE.search(body)
-            and not _plan_exists(repo, n, plan_cache)):
+    # Planning gate (#1456, re-keyed by #1932): refuse to queue an issue that
+    # never passed through planning. The canonical plan is now a `## Plan`
+    # issue comment (#1932); a committed/staged plan file still counts
+    # (backward compat for pre-redesign issues). Opt-outs: an explicit
+    # investigation spike, the `[no-plan]` tag, or the human:no-plan label.
+    # Without a plan or an opt-out the claiming worker is the first to open the
+    # code and design-blocks, so bounce to fleet:needs-plan (routes through
+    # PLANNING-PROTOCOL.md; the label also drops the issue out of the ingest
+    # pending set via the live-label skip guard). Sits before the blocker probes
+    # so a bounced issue costs no per-blocker API calls.
+    opted_out = bool(
+        SPIKE_RE.search(title) or SPIKE_RE.search(body)
+        or NO_PLAN_RE.search(title) or NO_PLAN_RE.search(body)
+        or 'human:no-plan' in labels
+    )
+    has_plan = (_has_plan_comment(view.get('comments', []))
+                or _plan_exists(repo, n, plan_cache))
+    if not opted_out and not has_plan:
         comment = (
-            f"Planning gate: no plan file found for this issue — neither "
-            f"committed `.fleet/plans/issue-{n}.md` nor planner-host "
-            f"`~/.fleet/plans/issue-{n}.md` — and it is not an explicit "
-            "investigation spike. Unplanned carve-offs design-block on "
-            "claim (#1456), so adding `fleet:needs-plan` to route it "
-            "through PLANNING-PROTOCOL.md before it can queue. "
-            "— fleet-queue-ingest"
+            f"Planning gate: this issue has no `## Plan` comment (the canonical "
+            f"plan per #1932) and no committed/staged plan file "
+            f"(`.fleet/plans/issue-{n}.md`), and it is not opted out "
+            f"(`human:no-plan` / `[no-plan]` / investigation spike). Unplanned "
+            f"carve-offs design-block on claim (#1456), so adding "
+            f"`fleet:needs-plan` to route it through PLANNING-PROTOCOL.md before "
+            "it can queue. — fleet-queue-ingest"
         )
         subprocess.run(
             ['gh', 'issue', 'comment', str(n), '--repo', repo,

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -25,13 +25,13 @@
 # hand-built projection). Claimability is unchanged — fleet-claim's own
 # Blocked-by gate still refuses a plain claim; see docs/design/fleet-queue-stacking.md.
 #
-# Planning gate (#1456): an approved issue with no plan file — neither the
-# committed repo-side `.fleet/plans/issue-<N>.md` nor the planner-host
-# `~/.fleet/plans/issue-<N>.md` staging copy — is bounced to fleet:needs-plan
-# instead of stamped fleet:queued, unless its title/body names an explicit
-# "investigation spike". Carve-offs queued straight to human:approved without
-# ever passing through planning made the worker the first person to open the
-# code, and it design-blocked on claim (the #1370 → #1414/#1431/#1435 pattern).
+# Planning gate (#1456, re-keyed by #1932): an approved issue with no plan — no
+# `## Plan` issue comment (canonical since #1932), no committed/staged plan file
+# (.fleet/plans/issue-<N>.md or ~/.fleet/plans/issue-<N>.md) — is bounced to
+# fleet:needs-plan unless opted out (`[no-plan]` / `human:no-plan` / investigation
+# spike). fleet:plan-review holds ingest until a reviewer vets the posted plan.
+# Carve-offs queued without planning made the worker the first to open the code,
+# and it design-blocked on claim (the #1370 → #1414/#1431/#1435 pattern).
 #
 # Source of truth: scripts/fleet/fleet-queue-ingest in the engine repo.
 # Installed to ~/bin/fleet-queue-ingest by scripts/fleet/install.sh.
@@ -381,8 +381,8 @@ for issue in pending:
             print(f'WARN issue {repo}#{n}: add fleet:needs-plan failed: {er.stderr.strip()}', file=sys.stderr)
             continue
         plan_bounced += 1
-        print(f'WARN issue {repo}#{n}: no plan file and not an investigation '
-              f'spike — bounced to fleet:needs-plan (#1456)', file=sys.stderr)
+        print(f'WARN issue {repo}#{n}: no ## Plan comment, no plan file, and not '
+              f'opted out ([no-plan] / human:no-plan / spike) — bounced to fleet:needs-plan', file=sys.stderr)
         continue
 
     # Blocked-by handling (#1527): queue blocked tasks too. A task whose

--- a/scripts/fleet/tests/test_fleet_claim_planning.sh
+++ b/scripts/fleet/tests/test_fleet_claim_planning.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Tests for the planning claim class (#1932 PR3, re-scope of #1889):
+# planning-claim / planning-release on a fleet:needs-plan ISSUE via the
+# fleet:planning-<host>-<agent> label, the `## Plan`-comment dedup early-out
+# (return 3 when planning already happened), and the cleanup --gh fourth pass
+# that sweeps stale planning labels off open fleet:needs-plan issues after
+# FLEET_CLAIM_STALE_SECS_PLANNING.
+#
+# The claim path reuses _acquire_label_on / _claim_decision (exhaustively
+# covered by test_fleet_claim_acquire.sh) and mirrors steward-claim — here we
+# pin the planning-specific wiring: the prefix, the issue wording, the dedup
+# early-out, and the TTL sweep (separate pass over open fleet:needs-plan issues).
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+assert_exit() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" -eq "$expected" ]]; then ok "$msg"; else bad "$msg (expected exit $expected, got $actual)"; fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+export FLEET_TEST_HOST="mac"
+export FLEET_CLAIM_NO_SLEEP=1
+export FLEET_CLAIM_ACQUIRE_RETRIES=2
+
+# Source fleet-claim as a library (defines helpers, skips the dispatch).
+set --
+FLEET_CLAIM_LIB=1 source "$FLEET_CLAIM"
+
+P="fleet:planning-mac-"
+MINE="${P}worker"
+OTHER="fleet:planning-linux-worker"
+REMOVE_LOG="$TMPROOT/remove.log"; : > "$REMOVE_LOG"
+
+# Stateful gh stub. STUB_HOLDERS = planning labels already on the issue; the
+# POST echoes those + the just-posted label. STUB_PLAN_COMMENTS is the count
+# `_issue_has_plan_comment`'s --jq returns (the dedup probe). issue-edit calls
+# are logged for self-removal / release assertions.
+STUB_HOLDERS=""
+STUB_PLAN_COMMENTS=0
+gh() {
+    case "${1:-}" in
+        issue)
+            case "${2:-}" in
+                view) printf '%s\n' "${STUB_PLAN_COMMENTS:-0}"; return 0 ;;  # dedup probe
+                edit) printf '%s\n' "$*" >> "$REMOVE_LOG"; return 0 ;;
+                *) return 0 ;;
+            esac ;;
+        api)
+            local posted="" a
+            for a in "$@"; do case "$a" in labels\[\]=*) posted="${a#labels[]=}" ;; esac; done
+            local out='[' first=1 h
+            for h in $STUB_HOLDERS $posted; do
+                [[ $first -eq 1 ]] || out+=','
+                out+="{\"name\":\"$h\"}"; first=0
+            done
+            out+=']'; printf '%s\n' "$out"; return 0 ;;
+        *) return 0 ;;
+    esac
+}
+
+echo "== planning-claim / planning-release wrappers (gh stub) =="
+
+echo "T1: no ## Plan comment + sole holder → planning-claim acquires (exit 0), issue-worded"
+STUB_HOLDERS=""; STUB_PLAN_COMMENTS=0
+rc=0; out=$(cmd_planning_claim 740 worker 2>&1) || rc=$?
+assert_exit "$rc" 0 "no plan comment, no holder → exit 0"
+case "$out" in *"issue#740"*) ok "acquire message names the target as an issue" ;; *) bad "acquire message should say issue#740, got: $out" ;; esac
+
+echo "T2: a ## Plan comment already exists → dedup early-out (exit 3, already planned)"
+STUB_HOLDERS=""; STUB_PLAN_COMMENTS=1
+rc=0; out=$(cmd_planning_claim 740 worker 2>&1) || rc=$?
+assert_exit "$rc" 3 "## Plan comment present → exit 3 (skip, already planned)"
+case "$out" in *"already planned"*) ok "dedup message explains the skip" ;; *) bad "expected 'already planned', got: $out" ;; esac
+
+echo "T3: another host already planning (no plan comment) → yield (exit 1) + self-remove"
+STUB_HOLDERS="$OTHER"; STUB_PLAN_COMMENTS=0; : > "$REMOVE_LOG"
+rc=0; cmd_planning_claim 740 worker >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 1 "persistent planning holder → exit 1 (never a co-win)"
+if grep -q -- "--remove-label $MINE" "$REMOVE_LOG"; then ok "losing claimant self-removed its planning label"; else bad "losing claimant did not self-remove (log: $(cat "$REMOVE_LOG"))"; fi
+
+echo "T4: non-numeric issue rejected with issue wording (exit 2)"
+STUB_PLAN_COMMENTS=0
+rc=0; out=$(cmd_planning_claim not-a-number worker 2>&1) || rc=$?
+assert_exit "$rc" 2 "non-numeric target → exit 2"
+case "$out" in *"issue must be a number"*) ok "rejection uses issue wording" ;; *) bad "expected 'issue must be a number', got: $out" ;; esac
+
+echo "T5: planning-release removes the label"
+: > "$REMOVE_LOG"; rc=0
+cmd_planning_release 740 worker >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 0 "release exits 0"
+if grep -q -- "--remove-label $MINE" "$REMOVE_LOG"; then ok "release removed $MINE"; else bad "release did not remove $MINE (log: $(cat "$REMOVE_LOG"))"; fi
+
+echo "== cleanup --gh fourth pass: stale planning sweep over fleet:needs-plan =="
+NOW_EPOCH=$(date +%s)
+STALE_AT=$(python3 -c "import datetime;print(datetime.datetime.fromtimestamp($NOW_EPOCH-7200,datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+FRESH_AT=$(python3 -c "import datetime;print(datetime.datetime.fromtimestamp($NOW_EPOCH-10,datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+export STALE_AT FRESH_AT
+NP_JSON="$TMPROOT/needsplan.json"
+cat > "$NP_JSON" <<JSON
+[
+  {"number":80,"labels":[{"name":"fleet:needs-plan"},{"name":"fleet:planning-mac-worker"}]},
+  {"number":81,"labels":[{"name":"fleet:needs-plan"},{"name":"fleet:planning-linux-worker"}]}
+]
+JSON
+export NP_JSON
+gh() {
+    case "${1:-}" in
+        pr) [[ "${2:-}" == "list" ]] && { echo "[]"; return 0; }; return 0 ;;
+        issue)
+            case "${2:-}" in
+                list)
+                    if printf '%s ' "$@" | grep -q -- "--label fleet:needs-plan"; then cat "$NP_JSON"; else echo "[]"; fi; return 0 ;;
+                edit) printf '%s\n' "$*" >> "$REMOVE_LOG"; return 0 ;;
+                *) return 0 ;;
+            esac ;;
+        api)
+            if printf '%s ' "$@" | grep -q "issues/80/"; then echo "$STALE_AT"; else echo "$FRESH_AT"; fi; return 0 ;;
+        *) return 0 ;;
+    esac
+}
+
+echo "T6: default TTL (3600) sweeps the 2h-old planning label, keeps the fresh one"
+: > "$REMOVE_LOG"; unset FLEET_CLAIM_STALE_SECS_PLANNING
+out=$(cmd_cleanup_gh "jakildev/IrredenEngine" 2>&1)
+if grep -q -- "--remove-label fleet:planning-mac-worker" "$REMOVE_LOG"; then ok "stale planning label on needs-plan#80 swept"; else bad "stale label not swept (log: $(cat "$REMOVE_LOG"); out: $out)"; fi
+if grep -q -- "--remove-label fleet:planning-linux-worker" "$REMOVE_LOG"; then bad "fresh planning label on #81 wrongly swept"; else ok "fresh planning label on #81 kept"; fi
+
+echo "T7: FLEET_CLAIM_STALE_SECS_PLANNING override keeps even the 2h-old label"
+: > "$REMOVE_LOG"; export FLEET_CLAIM_STALE_SECS_PLANNING=999999
+cmd_cleanup_gh "jakildev/IrredenEngine" >/dev/null 2>&1
+if grep -q -- "--remove-label fleet:planning-" "$REMOVE_LOG"; then bad "label swept despite TTL override (log: $(cat "$REMOVE_LOG"))"; else ok "TTL override respected; nothing swept"; fi
+unset FLEET_CLAIM_STALE_SECS_PLANNING
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # Test the fleet-queue-ingest planning gate (#1456).
 #
-# An approved issue with no plan file — neither planner-host staging
-# (~/.fleet/plans/issue-<N>.md) nor the committed repo-side copy
-# (.fleet/plans/issue-<N>.md, probed via `gh api`) — must be bounced to
-# fleet:needs-plan (never stamped fleet:queued), with an explanatory comment.
-# Escape hatches: a local plan file, a committed repo-side plan file, an
-# explicit "investigation spike" in the title/body, and a non-404 probe
-# failure (fail open — a transient API error must never bounce a planned
-# issue).
+# An approved issue with no `## Plan` issue comment (canonical since #1932) and
+# no plan file (neither planner-host staging ~/.fleet/plans/issue-<N>.md nor the
+# committed repo-side copy .fleet/plans/issue-<N>.md, probed via `gh api`) must
+# be bounced to fleet:needs-plan (never stamped fleet:queued), with an explanatory
+# comment. Escape hatches: a `## Plan` comment, a local plan file, a committed
+# plan file, an explicit "investigation spike" in the title/body, the `[no-plan]`
+# tag, the `human:no-plan` label, the `fleet:plan-review` early-skip, and a
+# non-404 probe failure (fail open — a transient API error must never bounce a
+# planned issue).
 #
 # HOME is redirected to a temp dir so the script's hardcoded projection/log/lock
 # paths land in the sandbox, and `gh` is stubbed to canned issue/PR surfaces.

--- a/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_plan_gate.sh
@@ -45,13 +45,21 @@ PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
 # #742 = committed repo-side plan (gh api 200)    → stamp
 # #743 = no plan, body declares investigation spike → stamp
 # #744 = plan probe fails WITHOUT a 404 (network) → fail open, stamp
+# #745 = `## Plan` issue comment, no file (#1932)  → stamp (the canonical path)
+# #746 = `[no-plan]` opt-out tag in title (#1932)  → stamp
+# #747 = human:no-plan opt-out label (#1932)       → stamp
+# #748 = fleet:plan-review (plan not yet vetted)    → early-skip (no stamp/bounce)
 cat > "$PROJ" <<'JSON'
 {"pending_issues":[
   {"number":740,"repo":"engine"},
   {"number":741,"repo":"engine"},
   {"number":742,"repo":"engine"},
   {"number":743,"repo":"engine"},
-  {"number":744,"repo":"engine"}
+  {"number":744,"repo":"engine"},
+  {"number":745,"repo":"engine"},
+  {"number":746,"repo":"engine"},
+  {"number":747,"repo":"engine"},
+  {"number":748,"repo":"engine"}
 ],"unblock_issues":[]}
 JSON
 
@@ -72,6 +80,10 @@ case "$1" in
                     742) echo '{"title":"render: epic child","body":"**Model:** sonnet\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
                     743) echo '{"title":"render: probe the culling path","body":"**Model:** opus\n**Blocked by:** (none)\n\nExplicit investigation spike: report findings, no fix expected.","labels":[{"name":"human:approved"}]}' ;;
                     744) echo '{"title":"render: planned elsewhere","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    745) echo '{"title":"render: planned via comment","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}],"comments":[{"body":"## Plan: do the thing\n\nstep one"}]}' ;;
+                    746) echo '{"title":"render: tiny tweak [no-plan]","body":"**Model:** sonnet\n**Blocked by:** (none)","labels":[{"name":"human:approved"}]}' ;;
+                    747) echo '{"title":"render: human said skip","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"human:no-plan"}]}' ;;
+                    748) echo '{"title":"render: plan under review","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"fleet:plan-review"}]}' ;;
                     *)   echo '{"title":"","body":"","labels":[]}' ;;
                 esac
                 exit 0 ;;
@@ -162,6 +174,39 @@ if [[ -n "$l744" && "$l744" == *"fleet:queued"* && "$l744" != *"fleet:needs-plan
     ok "#744 (non-404 probe failure) failed open and stamped"
 else
     bad "#744 transient probe failure wrongly bounced: '$l744'"
+fi
+
+# --- #1932: comment-based plan + opt-outs -----------------------------------
+# #745 (`## Plan` issue comment, no file) → stamped (the canonical redesign path).
+l745=$(edit_line 745)
+if [[ -n "$l745" && "$l745" == *"fleet:queued"* && "$l745" != *"fleet:needs-plan"* ]]; then
+    ok "#745 (## Plan comment, no file) stamped fleet:queued"
+else
+    bad "#745 comment-based plan mis-handled: '$l745'"
+fi
+
+# #746 ([no-plan] tag in title) → stamped (opt-out).
+l746=$(edit_line 746)
+if [[ -n "$l746" && "$l746" == *"fleet:queued"* && "$l746" != *"fleet:needs-plan"* ]]; then
+    ok "#746 ([no-plan] opt-out tag) stamped without a plan"
+else
+    bad "#746 [no-plan] opt-out failed: '$l746'"
+fi
+
+# #747 (human:no-plan label) → stamped (opt-out).
+l747=$(edit_line 747)
+if [[ -n "$l747" && "$l747" == *"fleet:queued"* && "$l747" != *"fleet:needs-plan"* ]]; then
+    ok "#747 (human:no-plan opt-out label) stamped without a plan"
+else
+    bad "#747 human:no-plan opt-out failed: '$l747'"
+fi
+
+# #748 (fleet:plan-review) → early-skipped: neither queued nor bounced.
+l748=$(edit_line 748)
+if [[ -z "$l748" ]]; then
+    ok "#748 (fleet:plan-review) early-skipped — no stamp, no bounce"
+else
+    bad "#748 plan-review issue was not skipped: '$l748'"
 fi
 
 echo


### PR DESCRIPTION
## Summary
PR **3/5** of the planning-flow redesign (#1932); the re-scope of #1889. **Stacked on #1976 (PR 2).**

Adds the same-tick double-plan race-closer, re-scoped for the comment-based flow:
- **`fleet-claim planning-claim` / `planning-release`** — a sole-holder lex-min `fleet:planning-<host>-<agent>` label lock on a `fleet:needs-plan` issue, mirroring the `steward-claim` class (`_cmd_pr_label_claim`/`_acquire_label_on`/`_claim_decision`). **Additive** — nothing invokes it until the role docs wire it (PR 5/#1948), so no existing claim flow changes.
- **Dedup early-out** — `planning-claim` returns `3` ("already planned") when a **`## Plan` comment already exists**, replacing #1889's now-obsolete plan-doc-PR cross-check (plan-doc PRs are gone in the redesign).
- **TTL sweep** — `cleanup --gh` fourth pass sweeps stale `fleet:planning-*` labels off open `fleet:needs-plan` issues (`FLEET_CLAIM_STALE_SECS_PLANNING`, default 3600s).

## Test plan
- [x] New `test_fleet_claim_planning.sh` — acquire, dedup early-out (exit 3), cross-host yield + self-remove, release, TTL sweep (stale swept / fresh kept / override). **13/13.**
- [x] Existing claim suite green on this branch: steward 15/15, reconcile 22/22, acquire 10/10; PR2 gate 11/11; `bash -n` clean.

## Scope note (deferred)
#1946 also lists retiring `_PLAN_DOC_TITLE` (a scope-shipped layer-4 guard). I **deferred** it: it's one layer of a multi-layer guard with its own tests, and removing it has a narrow regression risk on lingering plan-doc PRs that still reference still-open issues. The redesign stops *producing* plan-doc PRs, so the guard is harmless to keep — best retired in a small standalone follow-up. Recorded in `.fleet/plans/issue-1889.md`.

> Stacked on #1976 — review/merge that first; this PR's base re-targets to master once #1976 lands.

Closes #1946

🤖 Generated with [Claude Code](https://claude.com/claude-code)