### PR TITLE
fleet: wire the planning-flow redesign into the role docs (#1948)

### DIFF
--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -151,10 +151,16 @@ reconciliation, and a cross-system audit where one is required.
 
 - **Sound →** remove the label: `gh issue edit <N> --repo <repo> --remove-label
   "fleet:plan-review"`. The scout queues it on its next pass.
-- **Not sound →** swap it back and name the gaps: `gh issue edit <N> --repo
-  <repo> --remove-label "fleet:plan-review" --add-label "fleet:needs-plan"`,
-  then comment the specific gaps. The next planning pass revises the `## Plan`
-  comment.
+- **Not sound →** delete the existing `## Plan` comment **first**, then requeue.
+  `fleet-claim planning-claim` exit-3's on `## Plan` *comment presence* (not on
+  the `fleet:needs-plan` label), so swapping the label back while the stale plan
+  comment remains leaves the issue **un-plannable** — the next planning pass can't
+  re-claim it. Get the comment id from `fleet-issue view <N>` and delete it
+  (`gh api -X DELETE repos/<owner>/<repo>/issues/comments/<comment-id>`), then
+  swap the label: `gh issue edit <N> --repo <repo> --remove-label
+  "fleet:plan-review" --add-label "fleet:needs-plan"`, and comment the specific
+  gaps. The next planning pass can then claim afresh and post a corrected
+  `## Plan` comment.
 
 This is a review of the **plan**, distinct from the PR code review — and it's
 cheap (no build, no diff), so do it every iteration even when there are no PR

--- a/.claude/commands/role-opus-reviewer.md
+++ b/.claude/commands/role-opus-reviewer.md
@@ -126,6 +126,41 @@ Don't re-check these — wasted Opus budget. Spend the pass on the
    inherited commits that don't belong to this PR's scope — skip
    until the human runs `rebase --onto` and clears this label).
 
+## Plan-review pass (#1932)
+
+Alongside the PR recheck, vet any issue carrying `fleet:plan-review` — a
+`## Plan` comment was posted but no reviewer has cleared it yet, and
+`fleet-queue-ingest` **skips** it until you do, so an un-vetted plan strands the
+issue out of the queue. You are the autonomous clearer of this gate (the
+architect also clears it during a design conversation; see
+[architect-protocol.md](../../docs/agents/architect-protocol.md) §"plan
+reviewer").
+
+Find candidates in both repos (cheap — issue labels, not a diff):
+
+```bash
+gh issue list --repo <repo> --label "fleet:plan-review" --json number,title --limit 50
+```
+
+For each, apply the [PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md)
+step-4 verdict — read the `## Plan` comment (`fleet-issue view <N>`; add
+`--repo game` for game) and judge it **as a plan** against step-2 rigor:
+verified current state (a confirmed repro for a defect), a single committed
+approach (no "decide during implementation" hand-off), sibling + in-flight
+reconciliation, and a cross-system audit where one is required.
+
+- **Sound →** remove the label: `gh issue edit <N> --repo <repo> --remove-label
+  "fleet:plan-review"`. The scout queues it on its next pass.
+- **Not sound →** swap it back and name the gaps: `gh issue edit <N> --repo
+  <repo> --remove-label "fleet:plan-review" --add-label "fleet:needs-plan"`,
+  then comment the specific gaps. The next planning pass revises the `## Plan`
+  comment.
+
+This is a review of the **plan**, distinct from the PR code review — and it's
+cheap (no build, no diff), so do it every iteration even when there are no PR
+candidates. Apply the standard skip set (don't touch a `fleet:plan-review` issue
+that also carries `human:owned`).
+
 ## Loop behavior
 
 `fleet-dispatcher` launches a fresh `claude` for this role when scout

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -69,9 +69,11 @@ See [docs/agents/FLEET-RUNTIME.md § Exit protocol](../../docs/agents/FLEET-RUNT
   queues. (game-architect is interactive only and does not autonomously
   claim tasks.)
 - **[opus+ classes]** Plan issues flagged with `fleet:needs-plan` on
-  either repo — read the issue thread, write a structured plan, post it
-  as an issue comment, save it to `~/.fleet/plans/`, and remove
-  `fleet:needs-plan` so the scout picks it up.
+  either repo — claim it (`fleet-claim planning-claim`), read the thread,
+  post the structured plan as a `## Plan` comment, then swap
+  `fleet:needs-plan` → `fleet:plan-review` for a reviewer to vet, and release
+  (`fleet-claim planning-release`). The plan lands in `.fleet/plans/` as the
+  first commit of the implementer's PR — not a separate plan-doc PR (#1932).
 - Handle tasks escalated from a lower class (look for an `escalated
   from <class>` note in the issue body or a recent issue comment).
 
@@ -487,9 +489,13 @@ Do the work, then exit cleanly:
    (smallest `number`) across both repos, then follow
    [docs/agents/PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md)
    — read the full thread (`fleet-issue view <N>`, add `--repo game`
-   for game), post the structured plan comment, save
-   `~/.fleet/plans/issue-<N>.md`, and remove `fleet:needs-plan`
-   (leaving `human:approved`). If the work decomposes into a stack,
+   for game), acquire the planning claim (`fleet-claim planning-claim <N>
+   <agent>` — exit 3 means a `## Plan` comment already exists, so skip it),
+   post the structured `## Plan` comment, swap `fleet:needs-plan` →
+   `fleet:plan-review` (leaving `human:approved`) for a reviewer to vet, and
+   release (`fleet-claim planning-release`). The plan file is committed by the
+   implementer as the first commit of its PR (#1932). If the work decomposes
+   into a stack,
    that doc routes you to `file-epic` via
    [docs/agents/TASK-FILING.md](../../docs/agents/TASK-FILING.md).
 

--- a/.claude/skills/file-epic/SKILL.md
+++ b/.claude/skills/file-epic/SKILL.md
@@ -28,7 +28,7 @@ for why.
 | **task label** | `fleet:task` |
 | **architect plans dir** | `~/.claude/plans/<slug>.md` |
 | **plans dir** | `~/.fleet/plans/issue-<N>.md` |
-| **repo-side plan path** | `<repo>/.fleet/plans/issue-<N>.md` (committed via the step-6.5 docs PR; no `T-<NNN>` rename) |
+| **repo-side plan path** | `<repo>/.fleet/plans/issue-<N>.md` — umbrella plan committed via the step-6.5 docs PR; each child plan committed as the first commit of its own impl PR (#1932); no `T-<NNN>` rename |
 | **validate-stack command** | `fleet-validate-stack <umbrella>` (add `--repo game` for the game repo) |
 | **title area vocabulary** | `engine`, `render`, `engine/voxel`, `game`, etc. (the same scope vocabulary `commit-and-push` uses) |
 
@@ -38,13 +38,15 @@ for why.
   command**; it auto-discovers children and fails loudly on a malformed
   body. It is the belt that the step-5 hand-filing convention is the
   suspenders for.
-- Per-child plan files (flow step 6) must meet
+- Per-child `## Plan` comments (flow step 6) must meet
   [`PLANNING-PROTOCOL.md`](../../../docs/agents/PLANNING-PROTOCOL.md)
   step-2 rigor — verified current state / confirmed repro, one picked
   approach, sibling + in-flight reconciliation — not a restated phase line
-  (#1456). The engine's `fleet-queue-ingest` plan gate only checks that
-  `.fleet/plans/issue-<N>.md` exists, so land the step-6.5 docs PR promptly
-  (it is also what makes a child pass the gate cross-host).
+  (#1456). The engine's `fleet-queue-ingest` plan gate (#1932 PR2) keys on the
+  `## Plan` comment, so a child is queue-ready as soon as its comment is posted;
+  its plan file lands cross-host as the first commit of the child's impl PR. The
+  step-6.5 docs PR carries only the umbrella plan (+ steward ledger) — land it
+  promptly so the steward reads it from master.
 - Engine-repo vs game-repo: most epics target `jakildev/IrredenEngine`.
   The cross-repo info-isolation rule (see
   [`docs/agents/CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md)


### PR DESCRIPTION
## Summary
PR **5/5** of the planning-flow redesign (#1932) — the gated self-config edits (architect-applied; `.claude/` targets the auto-mode classifier blocks for queue workers). **Stacked on #1979 (PR 4).**

- **`role-opus-reviewer.md` — add the plan-review pass** (the keystone of this PR): each iteration, scan `fleet:plan-review` issues and apply the PLANNING-PROTOCOL step-4 verdict — **sound** → remove the label (scout queues it); **not sound** → swap to `fleet:needs-plan` + name the gaps. This **staffs the gate** PR2 made ingest skip; without an autonomous clearer, vetted-pending plans strand (the exact backlog that started this whole thread).
- **`role-worker.md`** — the planning step now posts a `## Plan` comment, acquires the **planning-claim** lock (#1946), swaps `fleet:needs-plan` → `fleet:plan-review` (not remove), releases; the plan file lands as the **first commit of the implementer's PR**, not a separate plan-doc PR.
- **`file-epic/SKILL.md`** — child plans are `## Plan` comments (the queue gate keys on them); the step-6.5 docs PR carries only the umbrella plan + steward ledger.

## Completes the redesign
PR2 #1976 (ingest keys on comment) → PR3 #1978 (planning-claim lock) → PR4 #1979 (file-epic comments) → **this**. The `fleet:plan-review` gate now has an autonomous clearer, so the stranding that motivated #1932 stops recurring.

## Test plan
- [x] Doc/config-only; internally consistent with PLANNING-PROTOCOL.md (already redesigned) and PRs 2–4 in this stack.

> Full stack: #1980 → #1979 → #1978 → #1976 → master. Review/merge in order; bases re-target to master as upstreams land.

Closes #1948

🤖 Generated with [Claude Code](https://claude.com/claude-code)