### PR TITLE
render: per-axis cardinal-180 geometric tiebreak (#1959)

### DIFF
--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -599,6 +599,50 @@ float scatterCompositeDepthKey(vec3 origin, float visualYaw, int slot) {
     return yawedSum * 4.0 + float(slot);
 }
 
+// Geometric tiebreak constants (#1959). At cardinal yaw 0/pi the X-face and
+// Y-face contributions to `yawedSum` use coefficients (c-s) and (s+c) that
+// become EQUAL (s == 0), so the exact cells along a shared front vertical edge
+// TIE on `yawedSum` and the old `+slot` arbiter deterministically picked X
+// regardless of true depth — the doubled `YXYX` face-stripe (#1950 Finding 3 /
+// Bug B). The orthogonal screen-horizontal projection `perp` is the dropped
+// axis of pos3DtoPos2DIsoYawed (its `-vx+vy` component): NON-degenerate exactly
+// where `yawedSum` collapses, so it separates the two faces by true screen
+// geometry. We map it into the [0,4) sub-iso budget the `+slot` term held, so
+// the tiebreak can only re-order WITHIN one iso unit, never across a real depth
+// boundary (which would re-open the #1457 wrong-quad bands).
+//   - kScatterTiebreakScale: fits the target demos' content extent (|perp| up
+//     to ~128 world units) under the clamp without saturating adjacent faces.
+//   - kScatterTiebreakClamp: < 2.0 so `2.0 + geom` stays in (0, 4).
+//   - kScatterSlotEpsilon: final deterministic nudge for exact-perp ties; kept
+//     far below the smallest geometric separation so geometry always dominates.
+const float kScatterTiebreakScale = 1.0 / 64.0;
+const float kScatterTiebreakClamp = 1.9;
+const float kScatterSlotEpsilon = 1.0e-4;
+
+// Composite depth key for a scattered face's CORNER (base) point: the same
+// linear iso depth as scatterCompositeDepthKey, but with the per-face `+slot`
+// arbiter replaced by the geometric X/Y tiebreak above. Kept SEPARATE from
+// scatterCompositeDepthKey (the linear gradient basis) on purpose: the caller
+// interpolates depth across the dilated quad as `corner + du*kU + dv*kV`, where
+// kU/kV are gradient calls into scatterCompositeDepthKey. The tiebreak's `perp`
+// term is position-dependent and its `clamp` is non-linear, so folding it into
+// scatterCompositeDepthKey would (a) leak the `2.0` constant into kU/kV via
+// `du*kU` and (b) kink the affine field — both breaking the planar interpolation
+// #1457/#1883 depend on. Applying it ONLY here makes it a per-quad CONSTANT that
+// shifts the whole face-quad's depth uniformly (gradient untouched), which is
+// exactly what breaks the X/Y tie without reordering genuine depth.
+float scatterCompositeCornerKey(vec3 origin, float visualYaw, int slot) {
+    float c = cos(visualYaw);
+    float s = sin(visualYaw);
+    // Same linear iso depth as scatterCompositeDepthKey (kept inline, not a call,
+    // so the FMA/reassociation matches the cardinal path bit-for-bit). The +slot
+    // arbiter is replaced by the geometric tiebreak; slot stays as the sub-nudge.
+    float yawedSum = origin.x * (c - s) + origin.y * (s + c) + origin.z;
+    float perp = origin.x * (-c - s) + origin.y * (c - s);
+    float geom = clamp(perp * kScatterTiebreakScale, -kScatterTiebreakClamp, kScatterTiebreakClamp);
+    return yawedSum * 4.0 + (2.0 + geom) + float(slot) * kScatterSlotEpsilon;
+}
+
 // Conservative XY growth of an axis-aligned half-extent swept under a Z-yaw of
 // (cosYaw, sinYaw): each in-plane axis grows to |c|*hX + |s|*hY, Z unchanged.
 // CPU mirror: IRMath::yawGrownIsoHalfExtent. Keeps the SDF/voxel iso-cull

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -559,6 +559,29 @@ inline float scatterCompositeDepthKey(float3 origin, float visualYaw, int slot) 
     return yawedSum * 4.0f + float(slot);
 }
 
+// Geometric tiebreak constants + corner-key helper (#1959) — mirror of
+// ir_iso_common.glsl; see that file for the full rationale (Bug B: the X/Y-face
+// `yawedSum` tie at cardinal yaw 0/pi, broken by the orthogonal screen-
+// horizontal `perp` projection in the sub-iso budget the old `+slot` held). Kept
+// SEPARATE from scatterCompositeDepthKey so the caller's kU/kV gradient calls
+// stay pure-linear and the affine quad interpolation stays planar (#1457/#1883);
+// the tiebreak is a per-quad CONSTANT applied only at the corner.
+constant float kScatterTiebreakScale = 1.0f / 64.0f;
+constant float kScatterTiebreakClamp = 1.9f;
+constant float kScatterSlotEpsilon = 1.0e-4f;
+
+inline float scatterCompositeCornerKey(float3 origin, float visualYaw, int slot) {
+    const float c = cos(visualYaw);
+    const float s = sin(visualYaw);
+    // Same linear iso depth as scatterCompositeDepthKey (kept inline, not a call,
+    // so the FMA/reassociation matches the cardinal path bit-for-bit). The +slot
+    // arbiter is replaced by the geometric tiebreak; slot stays as the sub-nudge.
+    const float yawedSum = origin.x * (c - s) + origin.y * (s + c) + origin.z;
+    const float perp = origin.x * (-c - s) + origin.y * (c - s);
+    const float geom = clamp(perp * kScatterTiebreakScale, -kScatterTiebreakClamp, kScatterTiebreakClamp);
+    return yawedSum * 4.0f + (2.0f + geom) + float(slot) * kScatterSlotEpsilon;
+}
+
 // Conservative XY growth of an axis-aligned half-extent swept under a Z-yaw of
 // (cosYaw, sinYaw): each in-plane axis grows to |c|*hX + |s|*hY, Z unchanged.
 // CPU mirror: IRMath::yawGrownIsoHalfExtent; GLSL mirror in ir_iso_common.glsl.

--- a/engine/render/src/shaders/metal/peraxis_scatter.metal
+++ b/engine/render/src/shaders/metal/peraxis_scatter.metal
@@ -237,11 +237,14 @@ vertex VertexOut v_peraxis_scatter(
     // the continuous yawed depth of its own (dilated) corner point via the
     // shared scatterCompositeDepthKey helper (ir_iso_common.metal), so linear
     // interpolation reproduces the face plane's affine depth field per
-    // fragment. Per-axis is residual-only -> cardinal fast path
-    // byte-identical.
+    // fragment. The corner base goes through scatterCompositeCornerKey, which
+    // folds the #1959 geometric X/Y tiebreak into the sub-iso budget the old
+    // `+slot` held (kills the Bug-B cardinal-180 stripe) as a per-quad constant,
+    // leaving the kU/kV gradients planar. Per-axis is residual-only -> cardinal
+    // fast path byte-identical.
     const float kU = scatterCompositeDepthKey(eu, frameData.visualYaw, 0);  // gradient only — slot term cancels
     const float kV = scatterCompositeDepthKey(ev, frameData.visualYaw, 0);  // gradient only — slot term cancels
-    const float cornerKey = scatterCompositeDepthKey(worldCorner, frameData.visualYaw, slot) +
+    const float cornerKey = scatterCompositeCornerKey(worldCorner, frameData.visualYaw, slot) +
                             dilParam.x * kU + dilParam.y * kV;
     const float depthRange =
         float(globals.kMaxTriangleDistance - globals.kMinTriangleDistance);

--- a/engine/render/src/shaders/v_peraxis_scatter.glsl
+++ b/engine/render/src/shaders/v_peraxis_scatter.glsl
@@ -254,9 +254,14 @@ void main() {
     // face-local origin-recovery KEY and must not change. Each corner emits
     // the continuous yawed camera-space depth of its own (dilated) corner
     // point via the shared scatterCompositeDepthKey helper
-    // (ir_iso_common.glsl) — *4 + slot scale, so it co-sorts with the SDF
-    // (c_shapes_to_trixel smoothYaw). Linear interpolation then reproduces
-    // the face plane's affine depth field at every fragment. The flat
+    // (ir_iso_common.glsl) — *4 scale, so it co-sorts with the SDF
+    // (c_shapes_to_trixel smoothYaw). The corner base goes through
+    // scatterCompositeCornerKey, which folds the #1959 geometric X/Y tiebreak
+    // into the sub-iso budget the old `+slot` held (kills the Bug-B cardinal-180
+    // stripe); the kU/kV gradients stay on scatterCompositeDepthKey so the
+    // tiebreak is a per-quad constant and the affine field stays planar.
+    // Linear interpolation then reproduces the face plane's affine depth field
+    // at every fragment. The flat
     // per-quad ROUNDED key this replaces had two failure modes at off-snap
     // residuals: integer quantization tied distinct planes (draw order picked
     // the farther quad on the sign-flip side of the bracket), and same-plane
@@ -266,7 +271,7 @@ void main() {
     // cardinal fast path is untouched (byte-identical).
     const float kU = scatterCompositeDepthKey(eu, visualYaw, 0);  // gradient only — slot term cancels
     const float kV = scatterCompositeDepthKey(ev, visualYaw, 0);  // gradient only — slot term cancels
-    const float cornerKey = scatterCompositeDepthKey(worldCorner, visualYaw, slot) +
+    const float cornerKey = scatterCompositeCornerKey(worldCorner, visualYaw, slot) +
                             dilParam.x * kU + dilParam.y * kV;
     const float depthRange = float(kMaxTriangleDistance - kMinTriangleDistance);
     vDepth = (cornerKey + float(distanceOffset - kMinTriangleDistance)) / depthRange;


### PR DESCRIPTION
Stacked on: https://github.com/jakildev/IrredenEngine/pull/1974 (#1958)

## Summary
- Implements #1959's plan: a geometric X/Y-face tiebreak (`scatterCompositeCornerKey`, GLSL + Metal twin) replacing the `+slot` arbiter in the per-axis scatter composite key.
- **Corrects a latent flaw in the plan's literal formula:** the plan folded the tiebreak into `scatterCompositeDepthKey`, but that function is also the affine-gradient basis (`kU`/`kV` calls); the `+2.0` constant + non-linear `clamp` would leak into `dilParam.x*kU` (up to ~2.0 sub-iso error) and kink the planar field #1457/#1883 depend on. Fix: a separate corner-key helper applied as a per-quad constant; gradients stay on the pure-linear key.

## ⚠ Escalating design-blocked — Bug B does not reproduce on the current base
**Repro-on-base failed.** Per `docs/design/depth-unification-1884-investigation.md`, Bug B is the ~20px doubled `YXYX` face-stripe at cardinal-180 via the per-axis scatter `+slot` tie. On the current base (#1958), it does **not** reproduce — see the `## NEEDS-DESIGN` comment for the full evidence (exact-180 is the clean single-canvas path; near-180 scatter is already clean; this change is a sub-visible no-op there). **Do not merge as-is.**

## Test plan
- [x] Builds clean (macOS/Metal). GL twin mirrored, unbuilt on this host.
- [x] `IRPerfGrid --mode dense --grid-size 64 --yaw-ramp` near180/card180 — base renders clean; this change perturbs ≤8 sub-visible px (max_delta 6), fixes no stripe.
- [ ] **Blocked:** needs an architect call on whether Bug B is subsumed (close #1959) or a live repro to target.

Closes #1959