### PR TITLE
script: expose synthetic-input surface to Lua via bindLuaInput() (#1981)

### DIFF
--- a/engine/input/CLAUDE.md
+++ b/engine/input/CLAUDE.md
@@ -28,6 +28,32 @@ RENDER) so each stage sees the state relevant to its tick.
   calls assert if `beginSyntheticInput()` was not called first. Design:
   [`docs/design/gui-mouse-harness.md`](../../docs/design/gui-mouse-harness.md) §"Phase 1".
 
+#### Lua surface for synthetic input (#1981)
+
+`LuaScript::bindLuaInput()` (in `engine/script/include/irreden/script/lua_input_bindings.hpp`)
+exposes the synthetic-input API to Lua alongside two new enum tables:
+
+```lua
+-- Full C++ enum names for injectButton's button argument.
+-- Distinct from IRInput.Key (short-names); both map the same enum integers.
+IRInput.KeyMouseButtons.kKeyButtonSpace   -- == IRInput.Key.SPACE
+IRInput.KeyMouseButtons.kMouseButtonLeft
+
+-- Plural form, same ordinals as IRInput.ButtonStatus.
+IRInput.ButtonStatuses.NOT_HELD
+IRInput.ButtonStatuses.PRESSED
+
+IRInput.beginSyntheticInput()
+IRInput.isSyntheticInputActive()          -- → bool
+IRInput.injectButton(button, status)      -- integers from the tables above
+IRInput.injectMouseMove(x, y)            -- screen pixels
+IRInput.injectScroll(dx, dy)
+```
+
+`bindLuaInput()` is idempotent and extends the `IRInput` table created by
+`bindLuaCommands()` — call both. Acceptance test:
+`test/script/lua_input_bindings_test.cpp`.
+
 ### Gamepad
 
 - `checkGamepadButton(button, status, irGamepadId = 0)` — is this gamepad button in

--- a/engine/script/include/irreden/script/lua_input_bindings.hpp
+++ b/engine/script/include/irreden/script/lua_input_bindings.hpp
@@ -1,0 +1,242 @@
+#ifndef LUA_INPUT_BINDINGS_H
+#define LUA_INPUT_BINDINGS_H
+
+// Lua bindings for the IRInput synthetic-input surface — expose
+// IRInput.KeyMouseButtons, IRInput.ButtonStatuses, and the inject/query
+// functions (beginSyntheticInput, isSyntheticInputActive, injectButton,
+// injectMouseMove, injectScroll) so Lua behavior-smoke tests can drive
+// headless input without GLFW. The public `LuaScript::bindLuaInput()` calls
+// all three helpers below. Each guard checks for the bound-table key it owns
+// so a second call is a no-op (matching the bindInputEnums / bindCommandFunctions
+// pattern in lua_command_bindings.hpp).
+//
+// These tables are DISTINCT from the short-name tables in bindInputEnums():
+//   IRInput.KeyMouseButtons  — full C++ enum names (kKeyButtonSpace, ...)
+//   IRInput.ButtonStatuses   — plural form; same values as IRInput.ButtonStatus
+// The short-name IRInput.Key / IRInput.ButtonStatus tables remain available to
+// creation command-binding code after bindLuaCommands(); these additions extend
+// the namespace without displacing the existing entries.
+
+#define SOL_ALL_SAFETIES_ON 1
+#include <sol/sol.hpp>
+
+#include <irreden/ir_input.hpp>
+#include <irreden/script/lua_script.hpp>
+
+namespace IRScript::detail {
+
+// Populate `IRInput.KeyMouseButtons` with the full C++ enum names from
+// `IRInput::KeyMouseButtons` (kKeyButtonSpace, kMouseButtonLeft, etc.).
+// These literal names match the C++ constants so Lua callers and C++ callers
+// share the same surface without a name-mapping step.
+inline void bindKeyMouseButtonEnum(LuaScript &script) {
+    sol::state &lua = script.lua();
+    if (!lua["IRInput"].valid()) {
+        lua["IRInput"] = lua.create_table();
+    }
+    if (lua["IRInput"]["KeyMouseButtons"].valid()) {
+        return;
+    }
+    sol::table t = lua.create_table();
+#define IR_BIND_KEYBTN(name) t[#name] = static_cast<lua_Integer>(IRInput::name)
+    IR_BIND_KEYBTN(kNullButton);
+    // Control / whitespace / navigation
+    IR_BIND_KEYBTN(kKeyButtonMinus);
+    IR_BIND_KEYBTN(kKeyButtonEqual);
+    IR_BIND_KEYBTN(kKeyButtonLeftControl);
+    IR_BIND_KEYBTN(kKeyButtonRightControl);
+    IR_BIND_KEYBTN(kKeyButtonEnter);
+    IR_BIND_KEYBTN(kKeyButtonTab);
+    IR_BIND_KEYBTN(kKeyButtonBackspace);
+    IR_BIND_KEYBTN(kKeyButtonInsert);
+    IR_BIND_KEYBTN(kKeyButtonDelete);
+    IR_BIND_KEYBTN(kKeyButtonEscape);
+    IR_BIND_KEYBTN(kKeyButtonUp);
+    IR_BIND_KEYBTN(kKeyButtonDown);
+    IR_BIND_KEYBTN(kKeyButtonLeft);
+    IR_BIND_KEYBTN(kKeyButtonRight);
+    IR_BIND_KEYBTN(kKeyButtonPageUp);
+    IR_BIND_KEYBTN(kKeyButtonPageDown);
+    IR_BIND_KEYBTN(kKeyButtonHome);
+    IR_BIND_KEYBTN(kKeyButtonEnd);
+    IR_BIND_KEYBTN(kKeyButtonCapsLock);
+    IR_BIND_KEYBTN(kKeyButtonScrollLock);
+    IR_BIND_KEYBTN(kKeyButtonNumLock);
+    IR_BIND_KEYBTN(kKeyButtonPrintScreen);
+    IR_BIND_KEYBTN(kKeyButtonPause);
+    // Function keys
+    IR_BIND_KEYBTN(kKeyButtonF1);
+    IR_BIND_KEYBTN(kKeyButtonF2);
+    IR_BIND_KEYBTN(kKeyButtonF3);
+    IR_BIND_KEYBTN(kKeyButtonF4);
+    IR_BIND_KEYBTN(kKeyButtonF5);
+    IR_BIND_KEYBTN(kKeyButtonF6);
+    IR_BIND_KEYBTN(kKeyButtonF7);
+    IR_BIND_KEYBTN(kKeyButtonF8);
+    IR_BIND_KEYBTN(kKeyButtonF9);
+    IR_BIND_KEYBTN(kKeyButtonF10);
+    IR_BIND_KEYBTN(kKeyButtonF11);
+    IR_BIND_KEYBTN(kKeyButtonF12);
+    IR_BIND_KEYBTN(kKeyButtonF13);
+    IR_BIND_KEYBTN(kKeyButtonF14);
+    IR_BIND_KEYBTN(kKeyButtonF15);
+    IR_BIND_KEYBTN(kKeyButtonF16);
+    IR_BIND_KEYBTN(kKeyButtonF17);
+    IR_BIND_KEYBTN(kKeyButtonF18);
+    IR_BIND_KEYBTN(kKeyButtonF19);
+    IR_BIND_KEYBTN(kKeyButtonF20);
+    IR_BIND_KEYBTN(kKeyButtonF21);
+    IR_BIND_KEYBTN(kKeyButtonF22);
+    IR_BIND_KEYBTN(kKeyButtonF23);
+    IR_BIND_KEYBTN(kKeyButtonF24);
+    IR_BIND_KEYBTN(kKeyButtonF25);
+    // Keypad
+    IR_BIND_KEYBTN(kKeyButtonKP0);
+    IR_BIND_KEYBTN(kKeyButtonKP1);
+    IR_BIND_KEYBTN(kKeyButtonKP2);
+    IR_BIND_KEYBTN(kKeyButtonKP3);
+    IR_BIND_KEYBTN(kKeyButtonKP4);
+    IR_BIND_KEYBTN(kKeyButtonKP5);
+    IR_BIND_KEYBTN(kKeyButtonKP6);
+    IR_BIND_KEYBTN(kKeyButtonKP7);
+    IR_BIND_KEYBTN(kKeyButtonKP8);
+    IR_BIND_KEYBTN(kKeyButtonKP9);
+    IR_BIND_KEYBTN(kKeyButtonKPDecimal);
+    IR_BIND_KEYBTN(kKeyButtonKPDivide);
+    IR_BIND_KEYBTN(kKeyButtonKPMultiply);
+    IR_BIND_KEYBTN(kKeyButtonKPSubtract);
+    IR_BIND_KEYBTN(kKeyButtonKPAdd);
+    IR_BIND_KEYBTN(kKeyButtonKPEnter);
+    IR_BIND_KEYBTN(kKeyButtonKPEqual);
+    // Modifiers
+    IR_BIND_KEYBTN(kKeyButtonLeftShift);
+    IR_BIND_KEYBTN(kKeyButtonRightShift);
+    IR_BIND_KEYBTN(kKeyButtonLeftAlt);
+    IR_BIND_KEYBTN(kKeyButtonRightAlt);
+    IR_BIND_KEYBTN(kKeyButtonLeftSuper);
+    IR_BIND_KEYBTN(kKeyButtonRightSuper);
+    IR_BIND_KEYBTN(kKeyButtonMenu);
+    // Space and punctuation
+    IR_BIND_KEYBTN(kKeyButtonSpace);
+    IR_BIND_KEYBTN(kKeyButtonApostrophe);
+    IR_BIND_KEYBTN(kKeyButtonComma);
+    IR_BIND_KEYBTN(kKeyButtonPeriod);
+    IR_BIND_KEYBTN(kKeyButtonSlash);
+    IR_BIND_KEYBTN(kKeyButtonSemicolon);
+    IR_BIND_KEYBTN(kKeyButtonBackslash);
+    IR_BIND_KEYBTN(kKeyButtonLeftBracket);
+    IR_BIND_KEYBTN(kKeyButtonRightBracket);
+    IR_BIND_KEYBTN(kKeyButtonGraveAccent);
+    IR_BIND_KEYBTN(kKeyButtonWorld1);
+    IR_BIND_KEYBTN(kKeyButtonWorld2);
+    // Letters
+    IR_BIND_KEYBTN(kKeyButtonA);
+    IR_BIND_KEYBTN(kKeyButtonB);
+    IR_BIND_KEYBTN(kKeyButtonC);
+    IR_BIND_KEYBTN(kKeyButtonD);
+    IR_BIND_KEYBTN(kKeyButtonE);
+    IR_BIND_KEYBTN(kKeyButtonF);
+    IR_BIND_KEYBTN(kKeyButtonG);
+    IR_BIND_KEYBTN(kKeyButtonH);
+    IR_BIND_KEYBTN(kKeyButtonI);
+    IR_BIND_KEYBTN(kKeyButtonJ);
+    IR_BIND_KEYBTN(kKeyButtonK);
+    IR_BIND_KEYBTN(kKeyButtonL);
+    IR_BIND_KEYBTN(kKeyButtonM);
+    IR_BIND_KEYBTN(kKeyButtonN);
+    IR_BIND_KEYBTN(kKeyButtonO);
+    IR_BIND_KEYBTN(kKeyButtonP);
+    IR_BIND_KEYBTN(kKeyButtonQ);
+    IR_BIND_KEYBTN(kKeyButtonR);
+    IR_BIND_KEYBTN(kKeyButtonS);
+    IR_BIND_KEYBTN(kKeyButtonT);
+    IR_BIND_KEYBTN(kKeyButtonU);
+    IR_BIND_KEYBTN(kKeyButtonV);
+    IR_BIND_KEYBTN(kKeyButtonW);
+    IR_BIND_KEYBTN(kKeyButtonX);
+    IR_BIND_KEYBTN(kKeyButtonY);
+    IR_BIND_KEYBTN(kKeyButtonZ);
+    // Digits
+    IR_BIND_KEYBTN(kKeyButton0);
+    IR_BIND_KEYBTN(kKeyButton1);
+    IR_BIND_KEYBTN(kKeyButton2);
+    IR_BIND_KEYBTN(kKeyButton3);
+    IR_BIND_KEYBTN(kKeyButton4);
+    IR_BIND_KEYBTN(kKeyButton5);
+    IR_BIND_KEYBTN(kKeyButton6);
+    IR_BIND_KEYBTN(kKeyButton7);
+    IR_BIND_KEYBTN(kKeyButton8);
+    IR_BIND_KEYBTN(kKeyButton9);
+    // Mouse buttons
+    IR_BIND_KEYBTN(kMouseButtonNull);
+    IR_BIND_KEYBTN(kMouseButtonLeft);
+    IR_BIND_KEYBTN(kMouseButtonRight);
+    IR_BIND_KEYBTN(kMouseButtonMiddle);
+#undef IR_BIND_KEYBTN
+    lua["IRInput"]["KeyMouseButtons"] = t;
+}
+
+// Populate `IRInput.ButtonStatuses` with the full C++ enum names from
+// `IRInput::ButtonStatuses`. The plural name matches the C++ type; the
+// singular `IRInput.ButtonStatus` table (from bindInputEnums in
+// lua_command_bindings.hpp) remains available for command-trigger registration.
+// Both tables carry identical integer ordinals.
+inline void bindButtonStatusesEnum(LuaScript &script) {
+    sol::state &lua = script.lua();
+    if (!lua["IRInput"].valid()) {
+        lua["IRInput"] = lua.create_table();
+    }
+    if (lua["IRInput"]["ButtonStatuses"].valid()) {
+        return;
+    }
+    sol::table t = lua.create_table();
+#define IR_BIND_BTN_STS(name) t[#name] = static_cast<lua_Integer>(IRInput::name)
+    IR_BIND_BTN_STS(NOT_HELD);
+    IR_BIND_BTN_STS(PRESSED);
+    IR_BIND_BTN_STS(HELD);
+    IR_BIND_BTN_STS(RELEASED);
+    IR_BIND_BTN_STS(PRESSED_AND_RELEASED);
+#undef IR_BIND_BTN_STS
+    lua["IRInput"]["ButtonStatuses"] = t;
+}
+
+// Expose `IRInput.{beginSyntheticInput, isSyntheticInputActive, injectButton,
+// injectMouseMove, injectScroll}` as Lua functions. These forward to the
+// `IRInput::` free functions in `engine/input/include/irreden/ir_input.hpp`.
+// `injectButton` / `injectMouseMove` / `injectScroll` assert if
+// `beginSyntheticInput` was not called first (mirroring the C++ API contract).
+// Idempotent — the guard checks `IRInput.beginSyntheticInput`.
+inline void bindSyntheticInput(LuaScript &script) {
+    sol::state &lua = script.lua();
+    if (!lua["IRInput"].valid()) {
+        lua["IRInput"] = lua.create_table();
+    }
+    if (lua["IRInput"]["beginSyntheticInput"].valid()) {
+        return;
+    }
+
+    lua["IRInput"]["beginSyntheticInput"] = []() { IRInput::beginSyntheticInput(); };
+
+    lua["IRInput"]["isSyntheticInputActive"] = []() -> bool {
+        return IRInput::isSyntheticInputActive();
+    };
+
+    lua["IRInput"]["injectButton"] = [](lua_Integer button, lua_Integer status) {
+        IRInput::injectButton(
+            static_cast<IRInput::KeyMouseButtons>(button),
+            static_cast<IRInput::ButtonStatuses>(status)
+        );
+    };
+
+    lua["IRInput"]["injectMouseMove"] = [](lua_Integer x, lua_Integer y) {
+        IRInput::injectMouseMove(IRMath::ivec2{static_cast<int>(x), static_cast<int>(y)});
+    };
+
+    lua["IRInput"]["injectScroll"] = [](double xOffset, double yOffset) {
+        IRInput::injectScroll(xOffset, yOffset);
+    };
+}
+
+} // namespace IRScript::detail
+
+#endif /* LUA_INPUT_BINDINGS_H */

--- a/engine/script/include/irreden/script/lua_script.hpp
+++ b/engine/script/include/irreden/script/lua_script.hpp
@@ -56,6 +56,14 @@ class LuaScript {
     // for the surface contract.
     void bindLuaCommands();
 
+    // Bind the synthetic-input surface — IRInput.KeyMouseButtons,
+    // IRInput.ButtonStatuses, and IRInput.{beginSyntheticInput,
+    // isSyntheticInputActive, injectButton, injectMouseMove, injectScroll}.
+    // Idempotent. Extends the IRInput table without displacing the short-name
+    // tables populated by bindLuaCommands(). Used by behavior-smoke tests and
+    // headless harnesses. See engine/input/CLAUDE.md "Synthetic input".
+    void bindLuaInput();
+
     // Set the creation-default mode used by
     // `IRSystem.registerSystem({...})` when the call has no explicit
     // `mode = "..."` field. Mirrors the build-time

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -9,6 +9,7 @@
 #include <irreden/script/lua_audio_bindings.hpp>
 #include <irreden/script/lua_collision_bindings.hpp>
 #include <irreden/script/lua_command_bindings.hpp>
+#include <irreden/script/lua_input_bindings.hpp>
 #include <irreden/script/lua_enum_def.hpp>
 #include <irreden/script/lua_modifier_bindings.hpp>
 #include <irreden/script/lua_persistence_bindings.hpp>
@@ -660,6 +661,12 @@ void LuaScript::bindLuaCommands() {
     detail::bindCommandNameEnum(*this);
     detail::bindInputEnums(*this);
     detail::bindCommandFunctions(*this);
+}
+
+void LuaScript::bindLuaInput() {
+    detail::bindKeyMouseButtonEnum(*this);
+    detail::bindButtonStatusesEnum(*this);
+    detail::bindSyntheticInput(*this);
 }
 
 namespace {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(IrredenEngineTest
   script/lua_audio_midi_observer_test.cpp
   script/lua_collision_bindings_test.cpp
   script/lua_command_test.cpp
+  script/lua_input_bindings_test.cpp
   script/lua_component_codegen_test.cpp
   script/lua_component_register_test.cpp
   script/lua_enum_register_test.cpp

--- a/test/script/lua_input_bindings_test.cpp
+++ b/test/script/lua_input_bindings_test.cpp
@@ -1,0 +1,272 @@
+#include <gtest/gtest.h>
+
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+
+#include <irreden/ir_command.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_input.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_window.hpp>
+#include <irreden/script/lua_input_bindings.hpp>
+#include <irreden/script/lua_script.hpp>
+#include <irreden/time/ir_time_types.hpp>
+
+#include <sol/sol.hpp>
+
+#include <optional>
+
+namespace {
+
+// ---- Tier 1: binding-presence tests (no display required) ------------------
+//
+// Owns LuaScript + EntityManager + CommandManager — the same slice as
+// LuaCommandTest. bindLuaInput() extends the IRInput table created by
+// bindLuaCommands(); both calls are made here so the idempotency guards
+// exercise the cross-call path.
+//
+// Destruction order (reverse declaration): m_command_manager, m_entity_manager,
+// m_lua — keeps sol::protected_function refs alive until after CommandManager
+// is gone (same lifetime contract as lua_command_test.cpp).
+class LuaInputBindingsTest : public testing::Test {
+  protected:
+    LuaInputBindingsTest()
+        : m_lua{}
+        , m_entity_manager{}
+        , m_command_manager{} {
+        m_lua.bindLuaCommands();
+        m_lua.bindLuaInput();
+    }
+
+    bool isInteger(const char *expr) {
+        auto result = m_lua.lua().safe_script(
+            std::string("return type(") + expr + ") == 'number'",
+            sol::script_pass_on_error
+        );
+        return result.valid() && result.get<bool>();
+    }
+
+    bool isFunction(const char *expr) {
+        auto result = m_lua.lua().safe_script(
+            std::string("return type(") + expr + ") == 'function'",
+            sol::script_pass_on_error
+        );
+        return result.valid() && result.get<bool>();
+    }
+
+    lua_Integer evalInt(const char *expr) {
+        auto result = m_lua.lua().safe_script(
+            std::string("return ") + expr, sol::script_pass_on_error
+        );
+        EXPECT_TRUE(result.valid()) << expr;
+        return result.get<lua_Integer>();
+    }
+
+    IRScript::LuaScript m_lua;
+    IREntity::EntityManager m_entity_manager;
+    IRCommand::CommandManager m_command_manager;
+};
+
+// ---- KeyMouseButtons enum table -------------------------------------------
+
+TEST_F(LuaInputBindingsTest, KeyMouseButtonsTablePresent) {
+    EXPECT_TRUE(isInteger("IRInput.KeyMouseButtons.kKeyButtonSpace"));
+    EXPECT_TRUE(isInteger("IRInput.KeyMouseButtons.kKeyButtonEscape"));
+    EXPECT_TRUE(isInteger("IRInput.KeyMouseButtons.kMouseButtonLeft"));
+    EXPECT_TRUE(isInteger("IRInput.KeyMouseButtons.kNullButton"));
+}
+
+TEST_F(LuaInputBindingsTest, KeyMouseButtonsValuesMatchCpp) {
+    EXPECT_EQ(
+        evalInt("IRInput.KeyMouseButtons.kKeyButtonSpace"),
+        static_cast<lua_Integer>(IRInput::kKeyButtonSpace)
+    );
+    EXPECT_EQ(
+        evalInt("IRInput.KeyMouseButtons.kMouseButtonLeft"),
+        static_cast<lua_Integer>(IRInput::kMouseButtonLeft)
+    );
+    EXPECT_EQ(evalInt("IRInput.KeyMouseButtons.kNullButton"), 0);
+}
+
+// ---- ButtonStatuses enum table --------------------------------------------
+
+TEST_F(LuaInputBindingsTest, ButtonStatusesTablePresent) {
+    EXPECT_TRUE(isInteger("IRInput.ButtonStatuses.NOT_HELD"));
+    EXPECT_TRUE(isInteger("IRInput.ButtonStatuses.PRESSED"));
+    EXPECT_TRUE(isInteger("IRInput.ButtonStatuses.HELD"));
+    EXPECT_TRUE(isInteger("IRInput.ButtonStatuses.RELEASED"));
+    EXPECT_TRUE(isInteger("IRInput.ButtonStatuses.PRESSED_AND_RELEASED"));
+}
+
+TEST_F(LuaInputBindingsTest, ButtonStatusesValuesMatchCpp) {
+    EXPECT_EQ(
+        evalInt("IRInput.ButtonStatuses.NOT_HELD"),
+        static_cast<lua_Integer>(IRInput::NOT_HELD)
+    );
+    EXPECT_EQ(
+        evalInt("IRInput.ButtonStatuses.PRESSED"),
+        static_cast<lua_Integer>(IRInput::PRESSED)
+    );
+}
+
+// ButtonStatuses and ButtonStatus (singular) must agree on ordinals so
+// both tables can be used interchangeably as trigger status arguments.
+TEST_F(LuaInputBindingsTest, ButtonStatusesAgreesWithButtonStatus) {
+    EXPECT_EQ(
+        evalInt("IRInput.ButtonStatuses.PRESSED"),
+        evalInt("IRInput.ButtonStatus.PRESSED")
+    );
+    EXPECT_EQ(
+        evalInt("IRInput.ButtonStatuses.NOT_HELD"),
+        evalInt("IRInput.ButtonStatus.NOT_HELD")
+    );
+}
+
+// ---- Synthetic-input function presence ------------------------------------
+
+TEST_F(LuaInputBindingsTest, SyntheticInputFunctionsBound) {
+    EXPECT_TRUE(isFunction("IRInput.beginSyntheticInput"));
+    EXPECT_TRUE(isFunction("IRInput.isSyntheticInputActive"));
+    EXPECT_TRUE(isFunction("IRInput.injectButton"));
+    EXPECT_TRUE(isFunction("IRInput.injectMouseMove"));
+    EXPECT_TRUE(isFunction("IRInput.injectScroll"));
+}
+
+// ---- Idempotency: second bindLuaInput() call is a no-op ------------------
+
+TEST_F(LuaInputBindingsTest, BindLuaInputIdempotent) {
+    // A second call must not overwrite existing values or raise.
+    m_lua.bindLuaInput();
+    EXPECT_TRUE(isFunction("IRInput.beginSyntheticInput"));
+    EXPECT_TRUE(isInteger("IRInput.KeyMouseButtons.kKeyButtonSpace"));
+}
+
+// ---- Tier 2: full inject→dispatch path (requires GLFW) --------------------
+//
+// Constructs a real InputManager so the synthetic-inject→tick→command-dispatch
+// pipeline can run end-to-end. The SetUp() gates on glfwInit() and GTEST_SKIPs
+// when no display is available (e.g. headless CI without a GPU).
+//
+// InputManager::initJoystickEntities() asserts g_irglfwWindow != nullptr.
+// IRGLFWWindow::joystickPresent() wraps glfwJoystickPresent() with no 'this'
+// member access, so pointing g_irglfwWindow at a sentinel address is safe after
+// glfwInit(). No joystick is connected in a test environment, so the if-block
+// inside initJoystickEntities() never executes and no member of the sentinel
+// object is accessed.
+//
+// Destruction order (reverse of declaration): m_command_manager, m_input_manager,
+// m_entity_manager, m_lua — sol::protected_function refs released while the
+// sol::state is still alive.
+class LuaInputInjectionTest : public testing::Test {
+  protected:
+    void SetUp() override {
+        if (!glfwInit()) {
+            GTEST_SKIP() << "glfwInit failed — headless host, injection path skipped";
+        }
+        IRWindow::g_irglfwWindow =
+            reinterpret_cast<IRWindow::IRGLFWWindow *>(m_window_sentinel);
+        m_entity_manager.emplace();
+        m_input_manager.emplace();
+        m_command_manager.emplace();
+        m_lua.emplace();
+        m_lua->bindLuaCommands();
+        m_lua->bindLuaInput();
+    }
+
+    void TearDown() override {
+        // Destroy in the order that preserves the lua-outlives-command-manager
+        // lifetime contract: command manager first, lua state last.
+        m_command_manager.reset();
+        m_input_manager.reset();
+        m_entity_manager.reset();
+        m_lua.reset();
+        IRWindow::g_irglfwWindow = nullptr;
+        glfwTerminate();
+    }
+
+    // Declared in reverse-destruction order: lua last (outlives command manager).
+    std::optional<IRScript::LuaScript> m_lua;
+    std::optional<IREntity::EntityManager> m_entity_manager;
+    std::optional<IRInput::InputManager> m_input_manager;
+    std::optional<IRCommand::CommandManager> m_command_manager;
+
+    // Sentinel storage whose address satisfies the g_irglfwWindow != nullptr
+    // assert in IRWindow::getWindow(). No IRGLFWWindow members are accessed.
+    alignas(std::max_align_t) char m_window_sentinel[1];
+};
+
+// Pump one synthetic frame: tick() drains injected events, advanceInputState()
+// snapshots the INPUT-event state, executeUserKeyboardCommandsAll() fires
+// any command whose trigger matches the snapshot.
+void pumpInputFrame() {
+    IRInput::g_inputManager->tick();
+    IRInput::g_inputManager->advanceInputState(IRTime::Events::INPUT);
+    IRCommand::getCommandManager().executeUserKeyboardCommandsAll();
+}
+
+// A Lua command bound to kKeyButtonSpace PRESSED fires when SPACE is injected.
+TEST_F(LuaInputInjectionTest, InjectSpaceFiresCommand) {
+    auto &lua = m_lua->lua();
+    auto result = lua.safe_script(
+        R"(
+        flag = false
+        IRCommand.createCommand(
+            IRInput.InputType.KEY_MOUSE,
+            IRInput.ButtonStatus.PRESSED,
+            IRInput.KeyMouseButtons.kKeyButtonSpace,
+            function() flag = true end
+        )
+        IRInput.beginSyntheticInput()
+        IRInput.injectButton(
+            IRInput.KeyMouseButtons.kKeyButtonSpace,
+            IRInput.ButtonStatuses.PRESSED
+        )
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+
+    pumpInputFrame();
+
+    const bool flag = lua["flag"];
+    EXPECT_TRUE(flag) << "command body should have run after SPACE injection";
+}
+
+// With no command bound, injecting SPACE leaves all observable state unchanged.
+TEST_F(LuaInputInjectionTest, InjectWithNoCommandBoundLeavesStateClear) {
+    auto &lua = m_lua->lua();
+    auto result = lua.safe_script(
+        R"(
+        flag = false
+        IRInput.beginSyntheticInput()
+        IRInput.injectButton(
+            IRInput.KeyMouseButtons.kKeyButtonSpace,
+            IRInput.ButtonStatuses.PRESSED
+        )
+        )",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(result.valid()) << result.get<sol::error>().what();
+
+    pumpInputFrame();
+
+    const bool flag = lua["flag"];
+    EXPECT_FALSE(flag) << "flag must stay false when no command is wired to SPACE";
+}
+
+// isSyntheticInputActive() reflects the mode set by beginSyntheticInput().
+TEST_F(LuaInputInjectionTest, IsSyntheticInputActiveReflectsMode) {
+    auto &lua = m_lua->lua();
+    auto r1 = lua.safe_script("return IRInput.isSyntheticInputActive()", sol::script_pass_on_error);
+    ASSERT_TRUE(r1.valid());
+    EXPECT_FALSE(r1.get<bool>()) << "should be inactive before beginSyntheticInput";
+
+    auto r2 = lua.safe_script(
+        "IRInput.beginSyntheticInput() return IRInput.isSyntheticInputActive()",
+        sol::script_pass_on_error
+    );
+    ASSERT_TRUE(r2.valid());
+    EXPECT_TRUE(r2.get<bool>()) << "should be active after beginSyntheticInput";
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Adds `LuaScript::bindLuaInput()` — new Lua binding layer for the C++ synthetic-input surface so headless tests can inject button events and drive command dispatch without GLFW.
- Two new enum tables: `IRInput.KeyMouseButtons` (full C++ enum names, e.g. `kKeyButtonSpace`) and `IRInput.ButtonStatuses` (plural form) — distinct from but ordinal-compatible with the short-name tables from `bindLuaCommands()`.
- `IRInput.{beginSyntheticInput, isSyntheticInputActive, injectButton, injectMouseMove, injectScroll}` forwarded to the existing free functions in `ir_input.hpp`. All helpers are idempotent (matching the `bindCommandFunctions` guard pattern).
- Two-tier acceptance test: binding-presence tests (always run, no InputManager) and full inject→dispatch tests (gated on `glfwInit()`). Tier 2 constructs a real `InputManager` via a char-array sentinel for `g_irglfwWindow` (safe: `joystickPresent()` calls only `glfwJoystickPresent()` with no `this` access).
- Documents the Lua surface in `engine/input/CLAUDE.md` §"Synthetic input".

## Test plan
- [x] `IrredenEngineTest --gtest_filter="*LuaInput*"` — 10/10 pass (7 binding-presence + 3 injection tests on macOS/Metal)
- [x] `fleet-build --target IrredenEngineTest` — clean build, no warnings

Closes #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)