### PR TITLE
fleet: absorb coding-improvement triage batch

### DIFF
--- a/.claude/agents/simplify-check-ecs.md
+++ b/.claude/agents/simplify-check-ecs.md
@@ -22,7 +22,7 @@ For each `.hpp`/`.cpp` file in the diff, scan for:
 
 3. **Mid-iteration structural changes:** `createEntity`, `setComponent`, `removeComponent`, `removeEntity` called inside a per-entity tick. Use the deferred variants (`deferredCreate`, etc.) and let `flushStructuralChanges` run.
 
-4. **New prefab system without `SystemName` enum entry.** A new `template <> struct IRSystem::System<X>` requires `X` in `engine/system/include/irreden/ir_system_types.hpp`. Missing → linker error.
+4. **New prefab system without `SystemName` enum entry.** A new `template <> struct IRSystem::System<X>` requires `X` in `engine/system/include/irreden/ir_system_types.hpp`. Missing → linker error. Also flag any **added** `SystemName` enum entry whose first token is `SYSTEM_` (e.g. `SYSTEM_FOO`): entries are action-first with no `SYSTEM_` prefix (`DISPATCH_LUA_OVERLAP`, not `SYSTEM_DISPATCH_LUA_OVERLAP`) — every existing entry follows this. `nit`.
 
 5. **Component method tier-c violations.** A component method that calls `IREntity::getComponent`, `setComponent`, `createEntity`, `setParent`, or `getEntity` on a *different* entity. Allowed exceptions are listed in `cpp-ecs.md` (GPU resource RAII, `onDestroy()` IO cleanup, constructor snapshots ambient state) — don't flag those.
 

--- a/.claude/rules/cpp-ecs-smells.md
+++ b/.claude/rules/cpp-ecs-smells.md
@@ -45,6 +45,11 @@ In any system `tick` function:
   `engine/system/include/irreden/system/ir_system_types.hpp`. Fix: add a
   `SCREAMING_SNAKE_CASE` entry under the appropriate group comment.
 
+- **`SystemName` entry carries a `SYSTEM_` prefix.** Entries are action-first
+  with no `SYSTEM_` prefix (`DISPATCH_LUA_OVERLAP`, not
+  `SYSTEM_DISPATCH_LUA_OVERLAP`) — every existing entry follows this shape.
+  A new enum line whose first token is `SYSTEM_` is the smell.
+
 ## Tick-function signatures
 
 - **`functionBeginTick` / `functionEndTick` with `Archetype&` or component

--- a/.claude/skills/attach-screenshots/SKILL.md
+++ b/.claude/skills/attach-screenshots/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   them to `docs/pr-screenshots/<branch>/` so the PR body can embed them
   via raw GitHub URLs. Runs an auto-screenshot-capable demo (default
   `IRShapeDebug`) once against origin/master and once against the dirty
-  working tree, pairs the outputs by shot label, and prints a markdown
+  working tree — or, in `--two-ref` mode, between two committed refs for the
+  feedback-AMEND path — pairs the outputs by shot label, and prints a markdown
   snippet the worker pastes into the PR body. Invoke when a PR touches
   `engine/render/`, `engine/prefabs/irreden/render/`, any `.glsl`/`.metal`
   shader, or `creations/demos/*/src/`, so reviewers can see the visual
@@ -39,9 +40,12 @@ negatives cost reviewer clarity — prefer asking.
 
 ## Preconditions
 
-1. **Dirty working tree** reflecting the PR's code change. The "before"
-   capture stashes this to roll back to `origin/master`. If the tree is
-   clean, stop — there is no "before vs after" to capture.
+1. **A capturable delta** — *either* a **dirty working tree** reflecting the
+   PR's code change (default mode: the "before" capture stashes it to roll
+   back to `origin/master`), *or* two distinct **committed refs** passed to
+   `--two-ref` (see "Two-ref mode" below — the feedback-AMEND path, where the
+   change is already committed on a clean detached HEAD). In default mode a
+   clean tree means stop — there is no "before vs after" to capture.
 2. **Build host with a usable display.** WSLg (Windows 11), native
    Linux with X/Wayland, or native macOS all work. Headless hosts
    cannot capture GLFW screenshots — the skill reports and exits.
@@ -328,6 +332,58 @@ attach-screenshots: <demo-name> (<N> shots)
   markdown snippet printed above — paste into PR body
 ```
 
+## Two-ref mode (feedback-AMEND)
+
+The default flow assumes the PR change is **uncommitted** (the authoring flow:
+dirty tree = "after", stashed-away `origin/master` = "before"). The
+**feedback-AMEND** path is different — the change is already committed and the
+worker is on a clean **detached HEAD** (`fleet-pr-claim-feedback` /
+`fleet-pr-checkout-detached`), so there is no dirty tree to stash and the
+default flow exits at Precondition #1 / step 5. The "attach a screenshot pair"
+nit is a common render-PR nit *and* render PRs routinely finish via
+feedback-AMEND, so this path is first-class.
+
+Invoke explicitly:
+
+```bash
+attach-screenshots --two-ref [<before-ref>] [<after-ref>]
+```
+
+`<before-ref>` defaults to `origin/master`; `<after-ref>` defaults to the
+current `HEAD` (the detached PR-head commit). The mode runs the same
+build → run → pair → stage → snippet flow as steps 1–9, with these deltas:
+
+- **Capture refs up front, no stash.** Record `RETURN=$(git rev-parse HEAD)`
+  (the detached PR-head, to land back on) and resolve `AFTER` (`<after-ref>`,
+  default `$RETURN`) **before** any checkout. The tree is clean, so the whole
+  `git stash` dance — and the shared-`refs/stash` cross-worktree race it
+  guards against — is **skipped**.
+- **Step 1 (dir name).** On a detached HEAD `git rev-parse --abbrev-ref HEAD`
+  returns `HEAD`. Resolve the `docs/pr-screenshots/<DIR>/` name from the PR's
+  head ref instead (the feedback context records it) — never write under a
+  `HEAD/` directory.
+- **Step 5 (before).** `git checkout --detach <before-ref>` instead of
+  stash+detach; build, run, move PNGs to `<label>-before.png`.
+- **Step 6 (after).** `git checkout --detach "$AFTER"` instead of restoring a
+  stash; build, run, move PNGs to `<label>-after.png`.
+- **Restore.** `git checkout --detach "$RETURN"` to return to the PR-head the
+  feedback flow left you on. No `stash apply` / `drop`.
+- **Step 7 (stage).** PNGs are new untracked files — `git add` them as usual.
+  In feedback-AMEND the worker folds them into the amend commit (the AMEND
+  flow), not a fresh `commit-and-push`.
+
+If `<before-ref>` and `<after-ref>` resolve to the same commit, stop — there
+is no delta to capture.
+
+### Camera-yaw fixes need a non-cardinal shot
+
+The default `g_shots` cardinal sequence is **byte-identical before/after for
+yaw-only render fixes** — the delta only shows at non-cardinal camera yaw
+(e.g. 45°/30°). For a PR in the camera-yaw family, capture at a non-cardinal
+yaw (a demo yaw flag / yaw-sweep shot); a cardinal-only suite understates the
+change and reads as "no visual delta" (this compounded #1953: 8 of 10 base
+shots were identical — only the 45°/30° shots showed the fix).
+
 ## Failure modes
 
 Handle each cleanly — no partial commits, no orphan PNGs, no left-
@@ -335,7 +391,7 @@ over stash:
 
 | Failure                                | Response                                                                                               |
 |----------------------------------------|--------------------------------------------------------------------------------------------------------|
-| Clean working tree                     | Stop with `nothing to capture — tree is clean`. No stash, no capture.                                  |
+| Clean working tree (default mode)      | Stop with `nothing to capture — tree is clean`. No stash, no capture. (In `--two-ref` mode a clean tree is expected — the delta is the two refs.) |
 | On `master`/`main`                     | Refuse to run.                                                                                         |
 | Chosen demo lacks `--auto-screenshot`  | Report the gap; exit without capturing.                                                                |
 | `fleet-build` fails in either pass     | Restore stash if mid-before-pass, report the build error, exit. No PNGs staged.                        |
@@ -379,7 +435,8 @@ What this skill does:
 
 - Engine-demo support (default `IRShapeDebug`).
 - Single-demo capture per invocation.
-- Stash/run/restore flow against `origin/master`.
+- Stash/run/restore flow against `origin/master` (default), or a
+  checkout-based two-ref flow for the feedback-AMEND path (`--two-ref`).
 
 What this skill does **not** do:
 

--- a/scripts/fleet/fleet-common.sh
+++ b/scripts/fleet/fleet-common.sh
@@ -15,6 +15,13 @@
 # detect_engine_root — walk up from the git root to find the directory
 # that contains CMakePresets.json (handles linked worktrees where the
 # git root is a nested .claude/worktrees/… path).
+#
+# Engine-root fallback convention: any fleet script that needs the engine
+# root as a fallback must use `${FLEET_ENGINE_ROOT:-$HOME/src/IrredenEngine}`
+# (as on the next line), never a bare `$HOME/src/IrredenEngine` — non-standard
+# clone paths (e.g. the Windows fleet) override the location via
+# FLEET_ENGINE_ROOT. Prefer sourcing this helper and calling
+# detect_engine_root over hand-rolling the fallback.
 detect_engine_root() {
     local root
     root=$(git rev-parse --show-toplevel 2>/dev/null || echo "${FLEET_ENGINE_ROOT:-$HOME/src/IrredenEngine}")

--- a/scripts/fleet/install.sh
+++ b/scripts/fleet/install.sh
@@ -128,6 +128,19 @@ if [[ ! -f "$REPO_ROOT/.claude/commands/role-opus-architect.md" ]]; then
     exit 1
 fi
 
+# ----------------------------------------------------------------------
+# Tool registry — each fleet tool needs THREE coordinated edits below, or
+# its ~/bin symlink is silently never created (install reports success;
+# the tool only fails "command not found" later, when something invokes it):
+#   1. a `<NAME>_SRC` / `<NAME>_DEST` var pair here,
+#   2. `<NAME>_SRC` added to the chmod loop ("Ensure the sources are
+#      executable" below), and
+#   3. a matching `if [[ -f "$<NAME>_SRC" ]]; then ln -sf ... fi` install
+#      block under "Step 1: symlink fleet scripts".
+# Forgetting (3) — it lives ~100 lines below the var pair — is the easy
+# miss (PR #1990: FLEET_PLAN_LINT defined + chmod'd but never symlinked).
+# Keep all three in sync when adding or removing a tool.
+# ----------------------------------------------------------------------
 FLEET_UP_SRC="$SCRIPT_DIR/fleet-up"
 FLEET_UP_DEST="$HOME/bin/fleet-up"
 FLEET_DOWN_SRC="$SCRIPT_DIR/fleet-down"


### PR DESCRIPTION
## Summary

One `triage-coding-improvements` run over the 7 open `fleet:coding-improvement` tickets. Four land as convention-surface fixes in this PR; one rejected at triage, two stay deferred. Diff touches only convention surfaces (a simplify subagent, a rule doc, a skill, two fleet scripts) — no engine/creation code.

- **#1906 — ESCALATE.** `SystemName` entries are action-first with no `SYSTEM_` prefix. Added a grep-able scan item to `.claude/agents/simplify-check-ecs.md` (item 4) + a one-line rule in `.claude/rules/cpp-ecs-smells.md`. Validated the check fires on the cited `SYSTEM_DISPATCH_LUA_OVERLAP` occurrence (PR #1905) and not on clean entries; returns 0 against the real `ir_system_types.hpp`.
- **#1967 — ACCEPT.** Fleet scripts must use `${FLEET_ENGINE_ROOT:-$HOME/src/IrredenEngine}`, not a bare `$HOME` path. Documented the convention at the canonical `detect_engine_root` site in `scripts/fleet/fleet-common.sh`.
- **#1992 — RESCOPE.** `install.sh` tool-registration completeness. Rescoped from a proposed new test harness (single occurrence) to an inline invariant comment documenting the three coordinated edits per tool (SRC/DEST pair + chmod loop + `ln -sf` block), matching the #1715 / #1683 precedent for the same "N coordinated edits, silent if one missed" class.
- **#1956 — ACCEPT.** Added a `--two-ref` / committed-ref capture mode to `attach-screenshots/SKILL.md` so the feedback-AMEND path (clean detached HEAD) can use the skill instead of a manual master-vs-head capture, plus a camera-yaw non-cardinal-shot note (the optional secondary gap).

## Test plan

- [x] `bash -n` on `install.sh` and `fleet-common.sh` (comment-only edits parse)
- [x] `#1906` check validated against the cited occurrence (fires on `SYSTEM_*`, not on clean entries; 0 against the real enum)
- [x] doc cross-refs resolve (`fleet-pr-claim-feedback`, `fleet-pr-checkout-detached` exist; enum names valid)
- [ ] reviewer: confirm each diff hunk maps 1:1 to the triage verdict below

## Notes for reviewer

This is a `triage-coding-improvements` bundle — gated self-config files in the diff are expected. Verify the changes match the verdicts:

| Ticket | Verdict | Surface |
|---|---|---|
| #1906 | ESCALATE | `simplify-check-ecs.md` + `cpp-ecs-smells.md` |
| #1967 | ACCEPT | `fleet-common.sh` |
| #1992 | RESCOPE (test → inline comment) | `install.sh` |
| #1956 | ACCEPT | `attach-screenshots/SKILL.md` |
| #1941 | REJECT — closed not-planned at triage (too niche; one-line review catch; partly covered by #1735) | — |
| #1865 | DEFER — unblocks on a 2nd device-backend shipping without a degradation test | — |
| #1850 | DEFER — unblocks when #1816 lands the static-registry pattern | — |

No split-out code issues (the #1956 skill change was implemented inline per triage; #1992 was rescoped to a comment, not a new test script).

Net line growth on per-task convention surfaces is small: `cpp-ecs-smells.md` +5, `simplify-check-ecs.md` +1 net. The larger `attach-screenshots` addition (+62) is a skill loaded only for screenshot capture, not read on every task.

Closes #1906
Closes #1967
Closes #1992
Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)