### PR TITLE
fleet: scout skips plan-review tasks + human-deferred PRs (#1996)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -414,6 +414,11 @@ def fetch_task_queue(repo_slug):
         if "fleet:needs-human" in labels:
             continue
 
+        # fleet:plan-review marks tasks whose plan is posted and awaiting
+        # human/architect approval — not yet pickable by autonomous workers.
+        if "fleet:plan-review" in labels:
+            continue
+
         in_progress = "fleet:in-progress" in labels or owner != "free"
         status = "~" if in_progress else " "
 
@@ -792,6 +797,12 @@ REVIEW_SKIP_LABELS = frozenset({
     # question is queued on the umbrella for the human/architect; reviewing
     # the in-flux diff is wasted work until design-unblock clears it (#1664).
     "fleet:design-proposed",
+    # A PR whose verdict was deferred to a follow-up issue, or that requires
+    # manual human action. Re-reviewing would re-flag needs-fix indefinitely;
+    # skip until the human acts and the label is cleared. Note: the merger's
+    # _merger_action_signal does NOT skip fleet:human-deferred (an approved
+    # deferred PR is still mergeable) — this skip is reviewer-only.
+    "fleet:human-deferred", "fleet:needs-human",
 })
 # Dynamic per-host claim prefixes that also bar reviewer pickup. A worker
 # amending a fleet:needs-fix PR holds fleet:amending-<host>-<agent> (minted

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -23,8 +23,10 @@ against that one projector.
 """
 import importlib.machinery
 import importlib.util
+import json
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 _SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
 _loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
@@ -282,6 +284,91 @@ class AmendingClaimBarsReviewerPickup(unittest.TestCase):
     def test_plain_needs_fix_unaffected(self):
         # No amend claim -> opus-reviewer still sees the flagged PR.
         self.assertEqual(len(self._opus([_pr(101, labels=["fleet:needs-fix"])])), 1)
+
+
+class HumanDeferredDropsFromReviewers(unittest.TestCase):
+    """fleet:human-deferred and fleet:needs-human PRs must not surface in
+    reviewer projections (#1996 Gap 2).
+
+    Without fleet:human-deferred in REVIEW_SKIP_LABELS, a no-verdict deferred
+    PR re-enters the sonnet-reviewer pool, gets re-flagged fleet:needs-fix,
+    and the worker re-escalates back to fleet:human-deferred indefinitely.
+    """
+
+    def _sonnet(self, prs):
+        return project_sonnet_reviewer(_state(prs))
+
+    def _opus(self, prs):
+        return project_opus_reviewer(_state(prs))
+
+    def test_human_deferred_drops_from_sonnet_reviewer(self):
+        result = self._sonnet([_pr(101, labels=["fleet:human-deferred"])])
+        self.assertEqual(result, [])
+
+    def test_human_deferred_drops_from_opus_reviewer(self):
+        result = self._opus([_pr(101, labels=[
+            "fleet:needs-fix", "fleet:human-deferred",
+        ])])
+        self.assertEqual(result, [])
+
+    def test_needs_human_drops_from_sonnet_reviewer(self):
+        result = self._sonnet([_pr(101, labels=["fleet:needs-human"])])
+        self.assertEqual(result, [])
+
+    def test_needs_human_drops_from_opus_reviewer(self):
+        result = self._opus([_pr(101, labels=[
+            "fleet:needs-fix", "fleet:needs-human",
+        ])])
+        self.assertEqual(result, [])
+
+    def test_plain_pr_without_defer_still_reviewed(self):
+        # Regression: PRs without a skip label still surface normally.
+        result = self._sonnet([_pr(101, labels=["fleet:changes-made"])])
+        self.assertEqual(len(result), 1)
+
+
+class PlanReviewExcludedFromTasksOpen(unittest.TestCase):
+    """fetch_task_queue must skip fleet:plan-review issues so they don't
+    appear in tasks.open[] as pickable by autonomous workers (#1996 Gap 1).
+
+    A plan-review task has its plan posted and awaits human/architect
+    approval — it must not trigger an autonomous dispatch that immediately
+    no-ops because the issue isn't claimable.
+    """
+
+    def _fetch(self, issues_list):
+        payload = json.dumps(issues_list)
+        with patch.object(_mod, "run_capture", return_value=payload):
+            return _mod.fetch_task_queue("jakildev/IrredenEngine")
+
+    def _issue(self, number, extra_labels=()):
+        return {
+            "number": number,
+            "title": f"task #{number}",
+            "labels": [
+                {"name": "fleet:queued"},
+                {"name": "fleet:sonnet"},
+                {"name": "human:approved"},
+            ] + [{"name": l} for l in extra_labels],
+            "body": "**Model:** sonnet\n",
+        }
+
+    def test_plan_review_task_not_in_open(self):
+        result = self._fetch([self._issue(42, extra_labels=["fleet:plan-review"])])
+        self.assertEqual(result["open"], [],
+                         "fleet:plan-review task must not enter tasks.open[]")
+        self.assertEqual(result["in_progress"], [])
+
+    def test_needs_human_task_still_excluded(self):
+        # Regression: existing fleet:needs-human skip must still work.
+        result = self._fetch([self._issue(99, extra_labels=["fleet:needs-human"])])
+        self.assertEqual(result["open"], [])
+
+    def test_normal_task_still_enters_open(self):
+        # Regression: ordinary sonnet task with no skip labels still projects.
+        result = self._fetch([self._issue(55)])
+        self.assertEqual(len(result["open"]), 1)
+        self.assertEqual(result["open"][0]["id"], "#55")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Gap 1**: `fetch_task_queue()` was projecting `fleet:plan-review` issues into `tasks.open[]` as owner:free, waking dispatchers for tasks whose plans await human approval (claim always fails). Fix: skip on `fleet:plan-review`, mirroring the existing `fleet:needs-human` skip.
- **Gap 2**: `REVIEW_SKIP_LABELS` lacked `fleet:human-deferred` and `fleet:needs-human`, causing deferred PRs to re-enter the reviewer pool, get re-flagged `fleet:needs-fix`, and workers re-escalate back to `fleet:human-deferred` indefinitely. Fix: add both labels (reviewer-only; merger's `_merger_action_signal` is unaffected).

## Test plan
- [x] `HumanDeferredDropsFromReviewers` — 5 tests: both labels drop from both reviewer projections; plain PR without skip label still surfaces
- [x] `PlanReviewExcludedFromTasksOpen` — 3 tests: plan-review excluded from `tasks.open[]`; existing `fleet:needs-human` skip regression; normal task still enters open
- [x] All 30 tests pass (`python3 scripts/fleet/tests/test_worker_projection.py`)

Closes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)