### PR TITLE
render: reconcile per-axis screen-depth GPU-stage name

### DIFF
--- a/.claude/skills/optimize/reference/gpu_profiling.md
+++ b/.claude/skills/optimize/reference/gpu_profiling.md
@@ -13,7 +13,7 @@ Registered stages (canvasClear, voxelCompact, voxelStage1, voxelStage2,
 shapeCompact, shapePass0, shapePass1, textToTrixel,
 buildLightOcclusionGrid, computeVoxelAO, bakeSunShadowMap,
 computeSunShadow, computeLightVolume, lightingToTrixel, fogToTrixel,
-trixelToTrixel, trixelToFb, entityCanvasToFb, screenSpaceResidualRotate,
+trixelToTrixel, trixelToFb, entityCanvasToFb, resolvePerAxisScreenDepth,
 fbToScreen) each carry a soft budget share (`GpuStageInfo::budgetShare_`).
 A pass exceeding its share is flagged via `overBudget` in the Lua surface.
 

--- a/docs/design/rotation-perf-cliff-1963-profile.md
+++ b/docs/design/rotation-perf-cliff-1963-profile.md
@@ -129,7 +129,10 @@ is *composite + resolve* combined; splitting them needs the infra fix.
    row (or vice versa). Fixing it (rename the registry row to
    `resolvePerAxisScreenDepth`, or retag the system) makes the resolve stage
    observable and lets #1961 separate composite cost from resolve cost. Filed
-   as #1965.
+   as #1965. **Resolved (#1965):** the dead `screenSpaceResidualRotate`
+   registry row (field + overlay label) was renamed to
+   `resolvePerAxisScreenDepth`, completing the half-done rename so the system's
+   existing tag now resolves and the stage records on both backends.
 
 ## Scoping #1961
 

--- a/docs/perf/metal_perf_grid_baseline.md
+++ b/docs/perf/metal_perf_grid_baseline.md
@@ -93,7 +93,7 @@ Metal GPU-stage snapshot from the final frame:
 | `computeLightVolume` | 0.000 ms | 0.000 ms |
 | `lightingToTrixel` | 0.050 ms | 0.082 ms |
 | `trixelToFb` | 0.123 ms | 0.125 ms |
-| `screenSpaceResidualRotate` | 0.155 ms | 0.176 ms |
+| `resolvePerAxisScreenDepth` | 0.155 ms | 0.176 ms |
 
 `ComputeLightVolume` CPU phase breakdown:
 

--- a/engine/prefabs/irreden/render/gpu_stage_timing.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing.hpp
@@ -35,7 +35,7 @@ struct GpuStageTiming {
     float trixelToTrixelMs_ = 0.0f;
     float trixelToFbMs_ = 0.0f;
     float entityCanvasToFbMs_ = 0.0f;
-    float screenSpaceResidualRotateMs_ = 0.0f;
+    float resolvePerAxisScreenDepthMs_ = 0.0f;
     float fbToScreenMs_ = 0.0f;
     std::uint32_t visibleShapeCount_ = 0;
     std::uint32_t shapeGroupsZ_ = 0;
@@ -227,7 +227,7 @@ inline const std::array<GpuStageInfo, kGpuStageCount> &gpuStageRegistry() {
         {"trixelToTrixel", &GpuStageTiming::trixelToTrixelMs_, 0.05f},
         {"trixelToFb", &GpuStageTiming::trixelToFbMs_, 0.15f},
         {"entityCanvasToFb", &GpuStageTiming::entityCanvasToFbMs_, 0.05f},
-        {"screenSpaceResidualRotate", &GpuStageTiming::screenSpaceResidualRotateMs_, 0.05f},
+        {"resolvePerAxisScreenDepth", &GpuStageTiming::resolvePerAxisScreenDepthMs_, 0.05f},
         {"fbToScreen", &GpuStageTiming::fbToScreenMs_, 0.05f},
     }};
     return registry;

--- a/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
+++ b/engine/prefabs/irreden/render/systems/system_perf_stats_overlay.hpp
@@ -199,7 +199,7 @@ template <> struct System<PERF_STATS_OVERLAY> {
         if (name == "trixelToTrixel") return "TRIX-COMP";
         if (name == "trixelToFb") return "TRIX-FB";
         if (name == "entityCanvasToFb") return "ENT-FB";
-        if (name == "screenSpaceResidualRotate") return "SCREEN-ROT";
+        if (name == "resolvePerAxisScreenDepth") return "PERAXIS-DEPTH";
         if (name == "fbToScreen") return "FB-SCREEN";
         return nullptr;
     }


### PR DESCRIPTION
## Summary
- `SYSTEM_RESOLVE_PER_AXIS_SCREEN_DEPTH` tags `tagGpuStage(systemId, "resolvePerAxisScreenDepth")`, but the GPU-stage registry had no row of that name — it carried a dead `screenSpaceResidualRotate` row no system tags. `tagGpuStage` is a silent no-op on an unknown name, so the stage's CPU+GPU time was **never recorded** on either backend (no observer install, no accumulator sample, omitted from the shutdown profile report).
- Completes the half-done rename: registry row + `GpuStageTiming` field + perf-overlay label → `resolvePerAxisScreenDepth` / `resolvePerAxisScreenDepthMs_` / `PERAXIS-DEPTH`. The descriptive name the system already uses wins; the orphaned legacy name retires.
- No Lua script keys the old name, so the `getPassTimings` / `getPassTiming` / `getCpuPassTiming` Lua surface is unaffected (renamed key was always a dead 0.0).
- Docs naming the same physical stage move to the canonical name: the #1963 profile write-up (marked resolved), the Metal perf baseline table, and the `optimize` skill's `gpu_profiling.md` reference.

## Test plan
- [x] `fleet-build --target IRShapeDebug` clean (registry consumer `world.cpp` + rendering lib recompiled).
- [x] Runtime acceptance: `IRShapeDebug --yaw 0.4 --auto-profile 150` (off-cardinal, `gpu_stage_timing` on) now lists `resolvePerAxisScreenDepth` in `save_files/profile_report.txt` with non-zero samples (avg 0.089 ms, 149 GPU samples) where it was previously absent entirely.
- [x] No pixel impact — the renamed field is read only by the perf-stats overlay (debug toggle, off by default) and the shutdown profile report, never by the framebuffer-writing render path; backend-agnostic CPU-side instrumentation.

Closes #1965

🤖 Generated with [Claude Code](https://claude.com/claude-code)