### PR TITLE
docs: fix stale creations/demos/CMakeLists.txt reference in CLAUDE.md (#2001)

### DIFF
--- a/creations/demos/CLAUDE.md
+++ b/creations/demos/CLAUDE.md
@@ -19,8 +19,9 @@ reference, T-106..T-108 pattern). Use `Glob creations/demos/*/` to see the full 
 
 ## Adding a new demo
 
-Copy the closest demo, rename targets, add `add_subdirectory(your_name)` to
-`creations/demos/CMakeLists.txt`. See `shape_debug/CMakeLists.txt` for the
+Copy the closest demo, rename targets, add
+`add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/demos/your_name)` to
+`creations/CMakeLists.txt`. See `shape_debug/CMakeLists.txt` for the
 canonical CMake shape.
 
 ## Conventions
@@ -42,7 +43,7 @@ canonical CMake shape.
 - **Runtime DLL copying is not free.** Every demo that links against
   FFmpeg/sol2/GLFW gets a POST_BUILD copy. Large demos slow down their
   incremental builds. Keep demos minimal.
-- **Don't edit `creations/demos/CMakeLists.txt` to re-order
+- **Don't edit `creations/CMakeLists.txt` to re-order demo
   subdirectories.** Order doesn't affect build correctness, but some
   demos implicitly assume others have been built (tools/data pipelines
   especially). Append new entries; don't reshuffle.


### PR DESCRIPTION
## Summary
- Fixes two stale references in `creations/demos/CLAUDE.md` that pointed at `creations/demos/CMakeLists.txt`, which does not exist
- The correct file is `creations/CMakeLists.txt` one level up, using `add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/demos/<name>)`
- Updated the "Adding a new demo" `add_subdirectory` snippet and the "Gotchas" bullet to match the real registration pattern

## Test plan
- [x] Docs-only — no build required
- [x] Verified `creations/demos/CMakeLists.txt` does not exist; `creations/CMakeLists.txt` confirmed to contain all `add_subdirectory` demo entries
- [x] `shape_debug/CMakeLists.txt` reference in the "Adding a new demo" section still resolves correctly

Closes #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)