### PR TITLE
fleet: architect file-with-plan default + human:review-plan gate

### DIFF
--- a/.fleet/plans/issue-2011.md
+++ b/.fleet/plans/issue-2011.md
@@ -1,0 +1,47 @@
+# Plan — issue #2011
+
+- **Issue:** fleet: architect file-with-plan default (skip worker re-plan) + human:review-plan gate for planless high-stakes
+- **Model:** opus
+- **Date:** 2026-06-24
+
+## Scope
+Make architect-filed-with-plan the default for substantial single tasks (leveraging the existing `## Plan`-comment skip in the ingest planning gate), and add a `human:review-plan` gate for high-stakes worker-planned (planless-filed) issues. Pure fleet-infra: protocol docs + two scripts + the label catalog. No engine/game source changes.
+
+## Approach
+1. **`docs/agents/TASK-FILING.md`** — add a "file with a plan" path for single tasks: when the task was planned with the human (or is substantial), post the structured `## Plan` comment at file time (point to PLANNING-PROTOCOL.md §plan structure). Clarify that this skips the planning gate (queues directly), and that plan-less filing remains valid for mechanical tasks / `human:no-plan` spikes. Today only `file-epic` posts `## Plan` comments — generalize the guidance to single tasks.
+2. **`docs/agents/architect-protocol.md`** (§Filing tasks) — make it explicit: if you planned a task with the human, **post the `## Plan` comment when you file it** (don't leave the plan in the body), so it skips worker re-planning and the human isn't re-looped. Cross-link the dogfood rationale.
+3. **`docs/agents/PLANNING-PROTOCOL.md`** — document the `human:review-plan` gate for the worker path: after a worker posts a `## Plan` for a **high-stakes** `fleet:needs-plan` issue, it adds `human:review-plan` (hold) alongside `fleet:plan-review`; a human clears it → queues. Define "high-stakes" via an explicit checklist (ambiguous approach / cross-cutting / expensive or hard to reverse / public-contract change). Low-stakes → queue as today.
+4. **`docs/agents/fleet-labels-reference.md`** — add `human:review-plan` (human-owned): applied to a worker-planned high-stakes issue to hold it for human approach-sign-off before implementation; human removes it to release to queue. Note the distinction from `fleet:plan-review` (agent vetting).
+5. **`scripts/fleet/fleet-queue-ingest`** — (a) confirm/keep: an approved issue with a `## Plan` comment skips `fleet:needs-plan` and queues; add a comment referencing the architect-file-with-plan flow. (b) treat `human:review-plan` as a queue-block (same as `fleet:needs-plan`/`fleet:plan-review`): do not stamp `fleet:queued` while present.
+6. **`scripts/fleet/fleet-state-scout`** — surface `human:review-plan` issues in the human projection (`repos.<repo>.review_plan`) so the human knows to review, and add it to `_INGEST_SKIP_LABELS` so it is never re-queued.
+7. **`.claude/commands/role-worker.md`** (§planning) — after posting a `## Plan` for a needs-plan issue, if high-stakes, add `human:review-plan` instead of swapping straight toward queue; document the high-stakes test. NOTE: this is gated self-config a queue-sourced worker cannot apply — the behavior is fully specified in PLANNING-PROTOCOL.md step 3 (which role-worker's planning step delegates to). Deferred to the human (see PR note).
+8. **`docs/agents/FLEET.md`** + **`docs/agents/fleet-state-machine.json`** — update the planning-gate narrative + label state machine to show both paths: architect-file-with-plan → queue; planless → needs-plan → (worker plan) → [high-stakes: human:review-plan] → queue. Add the `human:review-plan` label + `plan-propose-high-stakes` / `plan-human-approve` transitions.
+
+Also: add `human:review-plan` to the `scripts/fleet/fleet-labels` catalog (≤100-char GitHub-synced description) so the label syncs to both repos.
+
+## Affected files
+- `docs/agents/TASK-FILING.md`
+- `docs/agents/architect-protocol.md`
+- `docs/agents/PLANNING-PROTOCOL.md`
+- `docs/agents/fleet-labels-reference.md`
+- `docs/agents/FLEET.md`
+- `docs/agents/fleet-state-machine.json`
+- `scripts/fleet/fleet-queue-ingest`
+- `scripts/fleet/fleet-state-scout`
+- `scripts/fleet/fleet-labels`
+- `scripts/fleet/tests/test_fleet_queue_ingest_review_plan.sh` (new test)
+- `.claude/commands/role-worker.md` — gated; deferred to human (see PR note)
+- (create the `human:review-plan` GitHub label on both jakildev/IrredenEngine and jakildev/irreden — done via `fleet-labels`)
+
+## Acceptance criteria
+- An architect-filed issue with a `## Plan` comment is queued by ingest WITHOUT passing through `fleet:needs-plan` (covered by `test_fleet_queue_ingest_plan_gate.sh`'s plan-comment skip + the dogfood of this very issue).
+- An issue carrying `human:review-plan` is NOT stamped `fleet:queued` until the label is removed (`test_fleet_queue_ingest_review_plan.sh`).
+- A planless high-stakes issue, after worker planning, lands on `human:review-plan`; a planless low-stakes issue queues without it.
+- Docs across FLEET.md / architect-protocol.md / TASK-FILING.md / PLANNING-PROTOCOL.md / fleet-labels-reference.md describe one consistent two-path flow; the game architect inherits it via the shared protocol (no game-repo edit needed).
+
+## Gotchas
+- `human:review-plan` must survive re-ingest (mirror the `fleet:needs-human` pattern that keeps `human:approved` so the issue isn't dropped) — it is NOT in `_ALREADY_QUEUED_LABELS`, so `fetch_human_approved` still returns it, and `_INGEST_SKIP_LABELS` keeps it out of the pending set.
+- Don't break the existing `## Plan`-comment skip or the `human:no-plan` opt-out — extend, don't replace.
+- "High-stakes" needs a crisp, checkable definition — use the explicit four-item checklist over vibes.
+- The ingest already keys on the `## Plan` comment for BOTH repos via `--repo game`.
+- The `fleet-labels` GitHub-synced description must stay ≤100 chars (the full prose lives in `fleet-labels-reference.md` / `fleet-state-machine.json`, which are doc-only and not length-capped).

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -127,11 +127,26 @@ coordination mechanisms prevent duplicate work:
 - **Planning gate:** ingest only queues an issue once it has a plan — a
   `## Plan` issue comment (posted by an opus+ planner via
   [`PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md)) — or an explicit opt-out
-  (`human:no-plan`, a `[no-plan]` tag, or an "investigation spike"). An
-  unplanned `human:approved` issue is bounced to `fleet:needs-plan`; while its
-  plan is in review it carries `fleet:plan-review` and ingest skips it. There is
-  **no separate plan-doc PR** — the plan rides in the implementation PR as its
-  first commit, so plan + code land in one merge.
+  (`human:no-plan`, a `[no-plan]` tag, or an "investigation spike"). Two paths
+  reach the queue:
+  - **Architect files *with* a plan → queues directly.** When the architect
+    planned a task with the human, they post the `## Plan` comment at file time
+    (per [`TASK-FILING.md § File with a plan`](TASK-FILING.md)); the gate's
+    `## Plan`-comment check is satisfied, so it skips `fleet:needs-plan` and
+    queues with no worker re-plan and no return trip to the human (#2011).
+  - **Planless filing → worker plans (the fallback).** An unplanned
+    `human:approved` issue is bounced to `fleet:needs-plan`; an opus+ worker
+    plans it and swaps to `fleet:plan-review` (agent vetting), and ingest skips
+    it while that label is present. For a **high-stakes** worker-planned issue
+    (ambiguous / cross-cutting / expensive / public-contract — see
+    [`PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md) step 3) the planner also adds
+    `human:review-plan`, a human-owned hold for approach sign-off; the issue
+    queues only once **both** `fleet:plan-review` (agent) and `human:review-plan`
+    (human) are cleared. Low-stakes worker-planned issues queue on agent
+    plan-review alone.
+
+  There is **no separate plan-doc PR** — the plan rides in the implementation PR
+  as its first commit, so plan + code land in one merge.
 
 **Review claiming:**
 - Review claims use `fleet:reviewing-<host>-<agent>` labels on PRs via

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -159,6 +159,39 @@ For each `fleet:needs-plan` issue:
    the planning claim on **every** exit path — including the
    "disagree with the direction" branch below — so the lock is never orphaned.
 
+   **High-stakes? Also add `human:review-plan` (the human approach gate, #2011).**
+   When the issue is high-stakes (checklist below), add `human:review-plan` in
+   the **same** `gh issue edit` (alongside the `fleet:plan-review` swap). It is a
+   second, **human-owned** hold, distinct from `fleet:plan-review`: the agent
+   plan review (step 4) vets the plan's *rigor*; `human:review-plan` holds for a
+   human to sign off on the *approach* before implementation. Both are
+   queue-blocks (`fleet-queue-ingest` skips the issue while either is present),
+   so the issue queues only once the agent has cleared `fleet:plan-review` **and**
+   the human has removed `human:review-plan`. The order is independent. Use:
+   ```
+   gh issue edit <N> --repo <owner/repo> \
+     --remove-label "fleet:needs-plan" \
+     --add-label "fleet:plan-review" --add-label "human:review-plan"
+   ```
+   An issue is **high-stakes** if ANY of these hold — otherwise it is low-stakes
+   and queues on agent plan-review alone (no `human:review-plan`):
+   - **Ambiguous approach** — more than one materially different implementation
+     strategy is viable and the choice has lasting consequences.
+   - **Cross-cutting** — touches ≥3 modules, or changes a shared subsystem
+     (ECS core, the render pipeline, fleet infra/protocol).
+   - **Expensive or hard to reverse** — more than one PR's worth of work, or a
+     change that is costly to undo once shipped.
+   - **Changes a public contract** — the public `ir_*.hpp` API surface, a Lua
+     binding signature, an on-disk/serialized format, or fleet label/protocol
+     semantics.
+
+   Prefer the checklist over vibes: if none of the four apply, do not add
+   `human:review-plan` — the gate is for genuinely high-stakes work, not a
+   default hold. `human:review-plan` is a **fallback** that only applies on the
+   worker-planning path; architect-filed-with-plan work (see
+   [`architect-protocol.md § Filing tasks`](architect-protocol.md)) skips
+   planning entirely and never hits this gate.
+
    You may optionally stage a local copy at `~/.fleet/plans/issue-<N>.md` for
    your own reference, but it is not required and nothing reads it — the `## Plan`
    comment is the source of truth.
@@ -169,17 +202,22 @@ For each `fleet:needs-plan` issue:
    comment and judges it *as a plan* against the step-2 rigor — verified current
    state, a single committed approach, sibling/in-flight reconciliation, a
    cross-system audit where one is required:
-   - **Sound →** remove `fleet:plan-review`. The issue is now queue-ready and
-     the scout queues it on its next pass.
+   - **Sound →** remove `fleet:plan-review`. The issue is queue-ready **unless**
+     it also carries `human:review-plan` (a high-stakes hold) — in that case it
+     stays held for the human's approach sign-off; the scout queues it only once
+     the human removes that label too.
    - **Not sound →** swap `fleet:plan-review` → `fleet:needs-plan` and comment
      the specific gaps. The next planning pass revises the `## Plan` comment.
 
    This is a review of the *plan*, distinct from the code review the
-   implementation PR later gets.
+   implementation PR later gets. The plan reviewer does not add or remove
+   `human:review-plan` — that human-owned gate is the planner's to set (step 3)
+   and the human's to clear.
 
 5. **Queue and implement.** Once the issue is `human:approved`, carries a
-   `## Plan` comment, and has neither `fleet:needs-plan` nor `fleet:plan-review`,
-   the scout stamps `fleet:queued` + the model label. The implementing worker:
+   `## Plan` comment, and has none of `fleet:needs-plan`, `fleet:plan-review`, or
+   `human:review-plan` (the high-stakes human gate, when it was set), the scout
+   stamps `fleet:queued` + the model label. The implementing worker:
    - reads the plan from the `## Plan` comment (`fleet-issue view <N>`),
    - writes it to `.fleet/plans/issue-<N>.md` as the **first commit** of the
      implementation branch (an at-rest repo record that lands with the code),
@@ -226,9 +264,10 @@ the oldest unprocessed entry (smallest `number`) across both repos.
 This runs as a scout-triggered loop step — see the worker role file
 for where it sits in the iteration. Cross-repo: add `--repo game` to
 `fleet-issue` / `gh issue edit` for game-side issues. You post the
-`## Plan` comment and swap to `fleet:plan-review`; the implementation
-step (later, possibly a cheaper-class worker on another host) reads the
-comment and commits the plan file into its own PR.
+`## Plan` comment and swap to `fleet:plan-review`; for **high-stakes** issues
+(step 3 checklist) also add `human:review-plan` in the same edit. The
+implementation step (later, possibly a cheaper-class worker on another host)
+reads the comment and commits the plan file into its own PR.
 
 **[plan reviewer]** Scan open issues carrying `fleet:plan-review` and apply the
 step-4 verdict. The architect does this during a design conversation; the opus

--- a/docs/agents/TASK-FILING.md
+++ b/docs/agents/TASK-FILING.md
@@ -39,6 +39,42 @@ and `fleet-claim`'s blocker gate parse them):
 The issue sits in the backlog until the **human triages and adds
 `human:approved`**. Only then does the scout ingest it.
 
+### File with a plan (the architect default for substantial tasks)
+
+When you (the architect) **planned a task with the human** in a design
+conversation, or the task is substantial enough to need a plan, **post the
+structured `## Plan` comment at file time** — don't leave the plan in the issue
+body. The planning gate in `fleet-queue-ingest` keys on a `## Plan` *comment*
+(per #1932), not the body, so an issue whose plan lives only in the body gets
+bounced to `fleet:needs-plan` and a worker **re-plans work the human already
+shaped** (and may loop back to the human for plan review) — a wasted pass.
+Posting the `## Plan` comment makes the issue **queue directly**, skipping
+`fleet:needs-plan` entirely (the human was already in the planning loop, so no
+further sign-off is needed):
+
+```
+gh issue create --repo jakildev/IrredenEngine --title "<short title>" --body "<body>"
+gh issue comment <N> --repo jakildev/IrredenEngine --body "## Plan
+<structured plan per PLANNING-PROTOCOL.md §2 — Scope / Approach / Affected files /
+Acceptance criteria / Gotchas>"
+```
+
+The `## Plan` comment must follow the structure in
+[`PLANNING-PROTOCOL.md § The flow`](PLANNING-PROTOCOL.md) (its first heading
+starts with `## Plan` so the gate finds it). Today only the `file-epic` skill
+posts `## Plan` comments (for epic children); this generalizes the same
+mechanism to single tasks.
+
+**Plan-less filing is still valid** for mechanical or obvious tasks: file with
+no `## Plan` comment and the ingest bounces it to `fleet:needs-plan` for a
+worker to plan (the safety net). For a genuinely trivial change, the human can
+opt out at filing with `human:no-plan` / a `[no-plan]` tag and it queues with no
+plan at all. The choice: planned-with-the-human → post `## Plan` (queues
+directly); mechanical → leave it (worker plans, and if **high-stakes** the
+worker holds it on `human:review-plan` for your approach sign-off — see
+[`PLANNING-PROTOCOL.md § The flow`](PLANNING-PROTOCOL.md) step 3); trivial →
+`human:no-plan`.
+
 ### Escalation issues (scope-grew)
 
 When a worker hits a non-architectural blocker (scope grew, structural

--- a/docs/agents/architect-protocol.md
+++ b/docs/agents/architect-protocol.md
@@ -220,6 +220,19 @@ file it per [`docs/agents/TASK-FILING.md`](TASK-FILING.md): a GitHub issue with
 criteria / Context). The human stamps `human:approved` when they want it picked
 up; the scout ingests it on its next pass and adds the rest.
 
+**If you planned the task with the human, file it *with* a `## Plan` comment.**
+When the work came out of a design conversation (you and the human already
+shaped the approach), post the structured `## Plan` comment at file time per
+[`TASK-FILING.md § File with a plan`](TASK-FILING.md) — don't leave the plan in
+the body. The planning gate keys on the `## Plan` *comment*, so a plan-in-body
+issue is bounced to `fleet:needs-plan` and a worker re-plans what you already
+shaped, sometimes re-looping you for plan review (observed on #2008/#2009 and
+game #211). Posting the comment makes it **queue directly** — no worker re-plan,
+no return trip — since the human was already in the planning loop. Leave plan-less
+filing for mechanical tasks (the worker plans those; a high-stakes worker-planned
+issue then holds on `human:review-plan` for your sign-off — see
+[`PLANNING-PROTOCOL.md`](PLANNING-PROTOCOL.md) step 3).
+
 **Multi-issue stacks (epic decomposition).** When the work decomposes into a
 stack of N issues that each depend on the prior — the canonical smooth-yaw /
 SO(3) / rotation / streaming patterns — do NOT hand-file the children. Invoke

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -104,6 +104,21 @@ Specifically, **never pass these via `--label` when filing**:
   queues the issue on its next pass); not sound → swap back to
   `fleet:needs-plan` with a comment naming the gaps. Distinct from the code
   review the implementation PR later gets. Don't add at filing.
+- `human:review-plan` — owned by the **human** as a release gate; **set by an
+  opus+ planner** (worker or architect) when a worker-planned issue is
+  **high-stakes** (#2011). Added alongside `fleet:plan-review` in the same edit
+  (PLANNING-PROTOCOL.md step 3). It is a *second*, human-owned hold distinct from
+  `fleet:plan-review`: `fleet:plan-review` is the **agent** vetting the plan's
+  rigor; `human:review-plan` holds for a **human** to sign off on the *approach*
+  before implementation. Both are queue-blocks — `fleet-queue-ingest` skips the
+  issue while either is present and the scout surfaces it as
+  `repos.<repo>.review_plan` — so the issue queues only once the agent clears
+  `fleet:plan-review` **and** the human removes `human:review-plan`. Keeps
+  `human:approved` and survives re-ingest (like `fleet:needs-human`). Only the
+  human removes it. High-stakes = ambiguous approach / cross-cutting / expensive
+  or hard to reverse / changes a public contract (PLANNING-PROTOCOL.md step 3
+  checklist); low-stakes worker-planned issues queue on agent plan-review alone.
+  Architect-filed-with-plan work skips planning and never reaches this gate.
 - `human:no-plan` — owned by the **human**, applied at filing to a simple,
   self-contained issue to skip planning entirely. `fleet-queue-ingest` then
   stamps `fleet:queued` directly — no `## Plan` comment required — and the

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -291,6 +291,12 @@
       "description": "Human opt-out at filing: skip planning, queue directly with no ## Plan comment / plan file. Also honored as a [no-plan] title/body tag; a fleet agent never applies it"
     },
     {
+      "name": "human:review-plan",
+      "scope": "issue",
+      "color": "5319e7",
+      "description": "High-stakes worker-planned issue: planner adds it alongside fleet:plan-review so the issue holds for the HUMAN's approach sign-off before implementation (distinct from fleet:plan-review's agent vetting). Both are queue-blocks; keeps human:approved and survives re-ingest like fleet:needs-human; only the human removes it. PLANNING-PROTOCOL.md step 3"
+    },
+    {
       "name": "human:wip",
       "scope": "pr",
       "color": "5319e7",
@@ -458,6 +464,29 @@
         "fleet:plan-review"
       ],
       "note": "Planner posted the ## Plan comment and hands it to review. PLANNING-PROTOCOL.md step 3. Release the planning-claim lock after."
+    },
+    {
+      "name": "plan-propose-high-stakes",
+      "scope": "issue",
+      "owner": "planner",
+      "remove": [
+        "fleet:needs-plan"
+      ],
+      "add": [
+        "fleet:plan-review",
+        "human:review-plan"
+      ],
+      "note": "Like plan-propose, but the issue is high-stakes (ambiguous / cross-cutting / expensive / public-contract — PLANNING-PROTOCOL.md step 3 checklist), so the planner also adds human:review-plan to hold for the human's approach sign-off. Both labels are queue-blocks; the issue queues only once plan-approve clears fleet:plan-review AND plan-human-approve clears human:review-plan."
+    },
+    {
+      "name": "plan-human-approve",
+      "scope": "issue",
+      "owner": "human",
+      "remove": [
+        "human:review-plan"
+      ],
+      "add": [],
+      "note": "Human signed off on the approach for a high-stakes worker-planned issue. Once fleet:plan-review is also cleared (plan-approve), the issue is queue-ready and the scout stamps fleet:queued. PLANNING-PROTOCOL.md step 5."
     },
     {
       "name": "plan-approve",

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -145,6 +145,7 @@ LABELS=(
     "fleet:human-amending|c5def5|Worker is amending this PR with the human:needs-fix fixes; hold merge until fleet:changes-made"
     "human:owned|5319e7|Human took this issue out of the queue; ingest never re-stamps fleet:queued (reconcile flags both)"
     "human:no-plan|5319e7|Human opt-out at filing: skip planning, queue directly; [no-plan] tag honored; agents never apply it"
+    "human:review-plan|5319e7|High-stakes worker-planned issue held for human approach sign-off; human removes to queue"
     "human:wip|5319e7|Human is editing the PR directly; agents stand off"
     "human:approved|0e8a16|Human approved the PR (overrides agent verdict)"
     "human:needs-fix|d4c5f9|Human flagged a fix request; agent should address"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -30,6 +30,9 @@
 # (.fleet/plans/issue-<N>.md or ~/.fleet/plans/issue-<N>.md) — is bounced to
 # fleet:needs-plan unless opted out (`[no-plan]` / `human:no-plan` / investigation
 # spike). fleet:plan-review holds ingest until a reviewer vets the posted plan.
+# human:review-plan (#2011) is a second, human-owned hold: a worker-planned
+# HIGH-STAKES issue waits on the human's approach sign-off before it can queue
+# (kept alongside human:approved, like fleet:needs-human).
 # Carve-offs queued without planning made the worker the first to open the code,
 # and it design-blocked on claim (the #1370 → #1414/#1431/#1435 pattern).
 #
@@ -323,10 +326,16 @@ for issue in pending:
 
     if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
             or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels
-            or 'fleet:plan-review' in labels):
+            or 'fleet:plan-review' in labels or 'human:review-plan' in labels):
         # fleet:plan-review (#1932): the plan is posted but a reviewer hasn't
         # vetted it yet — ingest holds off until the reviewer clears the label
         # (sound → removed; not sound → swapped to fleet:needs-plan).
+        # human:review-plan (#2011): a worker-planned HIGH-STAKES issue holds
+        # for the human's approach sign-off before implementation (distinct from
+        # fleet:plan-review's agent vetting). It keeps human:approved (so it
+        # stays in the pending set and survives re-ingest, like fleet:needs-human)
+        # but ingest must NOT stamp fleet:queued while present — the human clears
+        # the label to release it. See PLANNING-PROTOCOL.md §"High-stakes".
         skipped_already += 1
         continue
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -170,6 +170,10 @@ _INGEST_SKIP_LABELS = frozenset({
     "fleet:scope-shipped", # scope landed under a different issue; human should close
     "fleet:needs-human",   # parked: fleet can't do it autonomously, human must act;
                            # keeps human:approved but must NOT be re-queued
+    "human:review-plan",   # #2011: worker-planned high-stakes issue holding for the
+                           # human's approach sign-off; keeps human:approved but must
+                           # NOT queue until the human clears it (surfaced separately
+                           # as repos.<repo>.review_plan, see _populate_review_plan).
 })
 
 
@@ -2054,11 +2058,27 @@ def _populate_done_tasks(state):
         tasks["done"] = _populate_tasks_done(repo_state)
 
 
+def _populate_review_plan(state):
+    """Surface human:review-plan issues to the human (#2011), parallel to how
+    needs_plan is surfaced. A worker-planned high-stakes issue holds on
+    human:review-plan for the human's approach sign-off before it can queue.
+    Derived from human_approved (no extra fetch): such issues keep
+    human:approved and human:review-plan is NOT in _ALREADY_QUEUED_LABELS, so
+    fetch_human_approved still returns them. _INGEST_SKIP_LABELS keeps them out
+    of the ingest pending set; this list is the human-facing read-out."""
+    for repo_key, repo_state in state["repos"].items():
+        repo_state["review_plan"] = [
+            issue for issue in repo_state.get("human_approved", [])
+            if "human:review-plan" in issue.get("labels", [])
+        ]
+
+
 def tick_once():
     state = collect_state()
     if state.get("degraded"):
         log(f"state degraded: {state['degraded']} — reconcile disabled this tick")
     _populate_done_tasks(state)
+    _populate_review_plan(state)
     resolve_blocked_by(state)
     resolve_human_approved_blockers(state)
     resolve_epic_children(state)

--- a/scripts/fleet/tests/test_fleet_queue_ingest_review_plan.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_review_plan.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Test that fleet-queue-ingest skips human:review-plan issues (#2011).
+#
+# A worker that plans a HIGH-STAKES needs-plan issue adds human:review-plan so
+# the issue holds for the human's approach sign-off before implementation
+# (distinct from fleet:plan-review's agent vetting). Because it keeps
+# human:approved, it stays in the ingest pending set — so ingest must explicitly
+# NOT re-stamp fleet:queued onto it until the human clears the label. A normal
+# human:approved issue in the same batch must still be stamped, which proves the
+# harness can stamp and the skip is meaningful (same shape as the human:owned
+# regression test).
+#
+# HOME is redirected to a temp dir so the script's hardcoded projection/log/lock
+# paths land in the sandbox, and `gh` is stubbed to canned issue/PR surfaces.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INGEST="$SCRIPT_DIR/fleet-queue-ingest"
+
+if [[ ! -x "$INGEST" ]]; then
+    echo "test setup: fleet-queue-ingest not found at $INGEST" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
+
+PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
+cat > "$PROJ" <<'JSON'
+{"pending_issues":[
+  {"number":820,"repo":"engine"},
+  {"number":821,"repo":"engine"}
+]}
+JSON
+
+# --- gh stub --------------------------------------------------------------
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    issue)
+        case "$2" in
+            view)
+                # #820 carries human:review-plan (held for human sign-off, has a
+                # ## Plan comment already); #821 is a normal approved issue.
+                case "$3" in
+                    820) echo '{"body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"human:review-plan"}],"comments":[{"body":"## Plan\nstep 1"}]}' ;;
+                    821) echo '{"body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}],"comments":[{"body":"## Plan\nstep 1"}]}' ;;
+                    *)   echo '{"body":"","labels":[],"comments":[]}' ;;
+                esac
+                exit 0 ;;
+            edit)
+                printf '%s\n' "$*" >> "$EDIT_LOG"
+                exit 0 ;;
+            comment) exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        case "$2" in
+            list) echo '[]'; exit 0 ;;   # scope-shipped: no merged coverage
+            *) exit 0 ;;
+        esac ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+echo "=== run fleet-queue-ingest over a batch with one human:review-plan issue ==="
+bash "$INGEST" >/dev/null 2>&1 || true
+
+# #821 (normal approved) must be stamped fleet:queued.
+if grep -qE '(^| )821( |$)' "$EDIT_LOG"; then
+    ok "normal approved #821 was stamped (harness can stamp)"
+else
+    bad "normal approved #821 was NOT stamped — harness broken, skip test would be vacuous"
+fi
+if grep -q 'fleet:queued' "$EDIT_LOG" && grep -qE '(^| )821( |$)' "$EDIT_LOG"; then
+    ok "#821 stamp carried fleet:queued"
+else
+    bad "#821 stamp missing fleet:queued"
+fi
+
+# #820 (human:review-plan) must NOT be touched at all.
+if grep -qE '(^| )820( |$)' "$EDIT_LOG"; then
+    bad "human:review-plan #820 was edited (should have been skipped): $(grep 820 "$EDIT_LOG")"
+else
+    ok "human:review-plan #820 was skipped — never re-stamped fleet:queued"
+fi
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- **(primary) Architect file-with-plan is now the documented default for substantial single tasks.** When the architect planned a task with the human, they post the structured `## Plan` comment at file time; the ingest planning gate's `## Plan`-comment check is satisfied, so the issue **queues directly** — no worker re-plan, no human round-trip. Generalizes the comment-skip that previously only `file-epic` used. (`TASK-FILING.md` new "File with a plan" path, `architect-protocol.md` §Filing tasks, `FLEET.md` two-path narrative.)
- **(secondary) New `human:review-plan` gate for the worker-planned fallback.** When a worker plans a HIGH-STAKES `fleet:needs-plan` issue (ambiguous / cross-cutting / expensive / public-contract — explicit four-item checklist), it adds `human:review-plan` alongside `fleet:plan-review` to hold for the human's *approach* sign-off, distinct from `fleet:plan-review`'s agent *rigor* vetting. Both are queue-blocks.
- `fleet-queue-ingest` skips `human:review-plan` issues (keeps `human:approved` so they survive re-ingest, like `fleet:needs-human`).
- `fleet-state-scout` adds it to `_INGEST_SKIP_LABELS` and surfaces held issues as `repos.<repo>.review_plan` for the human (derived from `human_approved`, no extra fetch).
- Label added to the `fleet-labels` catalog (≤100-char GitHub description) + `fleet-state-machine.json` (label + `plan-propose-high-stakes` / `plan-human-approve` transitions); full prose in `fleet-labels-reference.md` / `PLANNING-PROTOCOL.md`.
- New regression test `test_fleet_queue_ingest_review_plan.sh` proves ingest skips a `human:review-plan` issue while still stamping a normal approved one in the same batch.

## Dogfood
This issue (#2011) was filed **with** a `## Plan` comment and **queued directly** without a `fleet:needs-plan` bounce — demonstrating change #1 end-to-end.

## Deferred (gated self-config — human action)
Plan **step 7** edits `.claude/commands/role-worker.md` (add the high-stakes → `human:review-plan` instruction to the §planning step). That file is **gated self-config a queue-sourced worker cannot apply** (deterministic across workers/classes). It is **not** in the issue's acceptance criteria, and the behavior is **fully specified** in `PLANNING-PROTOCOL.md` step 3, which role-worker's planning step already delegates to ("follow PLANNING-PROTOCOL.md") — so the feature works without it. If you want the inline reinforcement, the suggested edit is: in role-worker step 2's planning bullet, after "swap `fleet:needs-plan` → `fleet:plan-review`", add "— and for a **high-stakes** issue (PLANNING-PROTOCOL.md step 3 checklist) also add `human:review-plan` in the same edit to hold for your approach sign-off."

## Verification
- `test_fleet_queue_ingest_review_plan.sh` — 3/3 pass (skips #820 `human:review-plan`, stamps normal #821 `fleet:queued`).
- Sibling ingest tests unregressed: `human_owned` 3/3, `plan_gate` 11/11, `blocked_by` 9/9.
- `fleet-state-scout` / `fleet-labels` syntax OK; `fleet-queue-ingest` `bash -n` OK.
- `fleet-labels --check` clean (catalog ≤100 chars, agrees with state-machine.json on 54 labels). `human:review-plan` label already synced to both repos.

## Test plan
- [ ] An architect-filed issue carrying a `## Plan` comment queues without `fleet:needs-plan` (both repos).
- [ ] A `human:review-plan` issue is not stamped `fleet:queued` until the human removes the label; a low-stakes worker-planned issue queues without it.
- [ ] Docs across FLEET / architect-protocol / TASK-FILING / PLANNING-PROTOCOL / fleet-labels-reference describe one consistent two-path flow.

Closes #2011

🤖 Generated with [Claude Code](https://claude.com/claude-code)