### PR TITLE
fleet: native-Windows python portability — UTF-8 mode + optional fcntl

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -50,6 +50,11 @@
 
 set -euo pipefail
 
+# Force UTF-8 Mode so the embedded python reconcile helpers don't crash decoding
+# UTF-8 gh/git output under native-Windows python's cp1252 default. No-op on
+# Linux/macOS. See fleet-up.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 CLAIMS_DIR="${FLEET_CLAIMS_DIR:-$HOME/.fleet/claims}"
 MOLECULES_DIR="${FLEET_MOLECULES_DIR:-$HOME/.fleet/molecules}"
 RESERVATIONS_DIR="${FLEET_RESERVATIONS_DIR:-$HOME/.fleet/reservations}"
@@ -2541,7 +2546,15 @@ reconcile_escalate_drift() {
     local persistent_count
     persistent_count=$(NOW="$now" THRESHOLD="$threshold" PERSIST="$persist_file" \
         BODY="$body_file" python3 - "$findings" <<'PYEOF'
-import sys, os, json, fcntl
+import sys, os, json
+try:
+    import fcntl  # POSIX-only; absent on native-Windows python
+    def _flock_ex(fh):
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+except ImportError:
+    # Best-effort advisory lock; the fleet is single-host, so a no-op is safe.
+    def _flock_ex(fh):
+        pass
 findings_path = sys.argv[1]
 now = int(os.environ["NOW"])
 threshold = int(os.environ["THRESHOLD"])
@@ -2571,7 +2584,7 @@ def key(f):
     return "%s:%s:%s:%s" % (f["rule"], f["repo"], f["target_kind"], f["target"])
 
 with open(persist_path + ".lock", "a") as _lock_fh:
-    fcntl.flock(_lock_fh.fileno(), fcntl.LOCK_EX)
+    _flock_ex(_lock_fh)
     state = load(persist_path, {})
     if not isinstance(state, dict):
         state = {}
@@ -2709,7 +2722,15 @@ reconcile_heal_design_unblock() {
     local healable
     healable=$(NOW="$now" THRESHOLD="$threshold" PERSIST="$persist_file" \
         python3 - "$findings" <<'PYEOF'
-import sys, os, json, fcntl
+import sys, os, json
+try:
+    import fcntl  # POSIX-only; absent on native-Windows python
+    def _flock_ex(fh):
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+except ImportError:
+    # Best-effort advisory lock; the fleet is single-host, so a no-op is safe.
+    def _flock_ex(fh):
+        pass
 findings_path = sys.argv[1]
 now = int(os.environ["NOW"])
 threshold = int(os.environ["THRESHOLD"])
@@ -2738,7 +2759,7 @@ def key(f):
     return "%s:%s" % (a["repo"], a["pr"])
 
 with open(persist_path + ".lock", "a") as _lock_fh:
-    fcntl.flock(_lock_fh.fileno(), fcntl.LOCK_EX)
+    _flock_ex(_lock_fh)
     state = load(persist_path, {})
     if not isinstance(state, dict):
         state = {}

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -54,6 +54,10 @@ fi
 
 set -euo pipefail
 
+# Force UTF-8 Mode so python helpers don't crash decoding UTF-8 gh/git output
+# under native-Windows python's cp1252 default. No-op on Linux/macOS. See fleet-up.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # --- Paths -----------------------------------------------------------------
 
 FLEET_SESSION="${FLEET_SESSION:-fleet}"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -41,6 +41,10 @@
 
 set -euo pipefail
 
+# Force UTF-8 Mode so python helpers don't crash decoding UTF-8 gh/git output
+# under native-Windows python's cp1252 default. No-op on Linux/macOS. See fleet-up.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 LOCK_DIR="${FLEET_QUEUE_INGEST_LOCK:-$HOME/.fleet/state/queue-ingest.lock}"
 LOG_FILE="$HOME/.fleet/logs/queue-ingest.log"
 PROJECTION_FILE="$HOME/.fleet/state/projections/queue-manager-ingest.json"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -31,6 +31,20 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+# Force UTF-8 Mode when this script is invoked directly on native-Windows
+# (cp1252 default) outside a fleet-up session. fleet-up's `export PYTHONUTF8`
+# already covers the daemon launch (and child processes inherit it), and
+# Linux/macOS default to UTF-8 text mode — so this only matters for a manual
+# `fleet-state-scout` run on Windows, where cp1252 would throw UnicodeDecodeError
+# decoding UTF-8 gh/git output (issue titles, emoji). UTF-8 Mode is fixed at
+# interpreter startup, so setting os.environ here is too late; re-exec once with
+# it set. The truthiness guard mirrors the bash `${PYTHONUTF8:-1}` idiom — force
+# UTF-8 when unset/empty, but respect an explicit PYTHONUTF8=0 opt-out (and skip
+# the re-exec when already "1"). See fleet-up.
+if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
+    os.environ["PYTHONUTF8"] = "1"
+    os.execv(sys.executable, [sys.executable, *sys.argv])
+
 # Shared branch<->issue matcher, also imported by fleet-claim's inline
 # python. Insert this script's own dir so the import resolves whether the
 # scout is run directly or loaded by-path in the unit tests (#1425).

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -18,6 +18,14 @@
 
 set -euo pipefail
 
+# Native-Windows mingw64 python is a Windows build that defaults to the cp1252
+# code page; reading UTF-8 gh/git output (issue titles, emoji) in text mode then
+# throws UnicodeDecodeError and crashes the daemons this launches
+# (fleet-state-scout projections, dispatcher/ingest helpers). UTF-8 Mode makes
+# locale.getpreferredencoding() — and thus subprocess/open text decoding — UTF-8,
+# which child python processes inherit. No-op on Linux/macOS.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # Engine main-clone location. Defaults to the Linux/macOS fleet layout
 # ($HOME/src/IrredenEngine); override with FLEET_ENGINE_ROOT for hosts that
 # clone elsewhere — e.g. the native-Windows fleet at


### PR DESCRIPTION
## Summary
Fixes two native-Windows fleet crashes observed bringing the windows host up. The mingw64 python is a Windows build: it defaults to the **cp1252** code page and lacks the POSIX-only **fcntl** module.

- `fleet-state-scout` (and other python helpers) threw `UnicodeDecodeError: 'charmap' codec can't decode byte ...` decoding UTF-8 `gh`/`git` output (issue titles, emoji) in subprocess text mode — crashing scout projection threads every tick.
- `fleet-claim`'s two reconcile heredocs did `import fcntl` for an advisory lock, raising `ModuleNotFoundError: No module named 'fcntl'` during drift reconcile.

## Changes
- **`export PYTHONUTF8=1`** (idempotent `${PYTHONUTF8:-1}`, no-op on Linux/macOS) in the scripts that launch or run python: `fleet-up` (covers the scout + dispatcher daemons it spawns and their children), `fleet-dispatcher`, `fleet-queue-ingest`, `fleet-claim`. UTF-8 Mode makes `locale.getpreferredencoding()` — and thus `subprocess`/`open` text decoding — UTF-8.
- Make the **`fcntl` import optional** in `fleet-claim`'s two reconcile heredocs, falling back to a no-op advisory lock (the fleet is single-host, so the lock is best-effort).

No behavior change on Linux/macOS: `PYTHONUTF8` defaults to UTF-8 there already, and `fcntl` imports normally so the real `flock` path is used.

## Test plan
Verified on the native-Windows (MSYS2) host:
- [x] `bash -n` clean on all four scripts
- [x] both edited heredocs `py_compile` (all 14 fleet-claim heredocs compile)
- [x] fcntl fallback runs without the module present (no-op path)
- [x] `PYTHONUTF8=1` flips `locale.getpreferredencoding(False)` from `cp1252` → `utf-8`