### PR TITLE
docs: native-Windows (MSYS2) fleet setup section

### DIFF
--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -8,9 +8,9 @@ environment, auth, and process.
 Work through the list top-to-bottom. Each step is independent unless
 noted.
 
-## Fleet environment: tmux on WSL2 OR macOS
+## Fleet environment: tmux on WSL2, macOS, or native Windows
 
-The parallel-agent fleet runs inside **tmux**, on one of two hosts:
+The parallel-agent fleet runs inside **tmux**, on one of three hosts:
 
 - **WSL2 Ubuntu 24.04 on your Windows PC** — Linux shell, `linux-debug`
   CMake preset, OpenGL backend. Builds in `~/src/IrredenEngine` on the
@@ -18,10 +18,16 @@ The parallel-agent fleet runs inside **tmux**, on one of two hosts:
 - **macOS native (Apple Silicon or Intel)** — macOS shell, `macos-debug`
   CMake preset, Metal backend. Builds in `~/src/IrredenEngine` on the
   Mac filesystem.
+- **native Windows (MSYS2 bash + tmux)** — `windows-debug` CMake preset,
+  OpenGL backend, host key `windows`; the engine's ship platform. Setup
+  is one-shot via `scripts/fleet/setup-windows.sh` — see §1c. (This host
+  is the exception to the "no `cmd.exe` wrappers" note below: builds wrap
+  `cmake` in a `cmd.exe` PATH fix to dodge the `cc1plus` crash, applied
+  automatically by `ir-build`/`fleet-build`.)
 
-You can run the fleet on either host (or both, for parallel parity
-work — see step 11 and the `backend-parity` skill). The two hosts are
-independent clones of the engine repo; they share code through
+You can run the fleet on any of these hosts (or several at once, for
+parallel parity work — see step 11 and the `backend-parity` skill). The
+hosts are independent clones of the engine repo; they share code through
 `origin/master` on GitHub.
 
 Why tmux-on-unix either way:
@@ -257,6 +263,120 @@ ssh-keygen -t ed25519 -C "<email>"
 pbcopy < ~/.ssh/id_ed25519.pub   # paste into github.com/settings/keys
 ssh -T git@github.com            # should greet you
 ```
+
+---
+
+## 1c. native-Windows + MSYS2 + base tooling (Windows host)
+
+*Skip this section if you're setting up the fleet on WSL (§1a) or macOS
+(§1b) instead.*
+
+The native-Windows fleet runs from an **MSYS2 bash** shell (that's where
+`tmux` lives), builds with the `windows-debug` preset (MSYS2 mingw64 GCC,
+OpenGL), and derives the host key `windows`. It keeps the engine's ship
+platform continuously built and smoked. Claude Code's Bash tool inside
+each agent pane is **Git Bash**, which shares `$HOME` with MSYS2 (see the
+HOME note below), so the fleet's `~/.fleet` state is common to the
+orchestrator (MSYS2) and the panes (Git Bash).
+
+> **Not PowerShell.** `fleet-up`, `tmux`, and every `fleet-*` script are
+> bash. Launch the fleet from an MSYS2 shell — never PowerShell or
+> `cmd.exe`.
+
+### Install the toolchain
+
+Install [MSYS2](https://www.msys2.org/), then from an **MSYS2 MINGW64**
+shell:
+
+```bash
+pacman -Syu                       # then reopen the shell if it asks
+pacman -S --needed tmux jq \
+    mingw-w64-x86_64-toolchain \  # gcc/g++ >= 13 — the windows-debug compiler
+    mingw-w64-x86_64-gh \         # GitHub CLI
+    mingw-w64-x86_64-python       # fleet python helpers (scout, reconcile)
+```
+
+Install separately on the **Windows** side: **Git for Windows** (the
+`git` the panes use), **Node.js** (for Claude Code), **CMake** (the
+`windows-debug` preset uses the Windows CMake), and **Claude Code**
+itself (`claude`, installed to `~/.local/bin`). These add themselves to
+the *Windows* PATH, which MSYS2 does not inherit by default — see PATH
+below.
+
+### ⚠ Unify `$HOME` (MSYS2 ↔ Git Bash)
+
+By default MSYS2 sets `$HOME` to `/c/msys64/home/<user>` while Git Bash
+uses your Windows profile `/c/Users/<user>`. The fleet's shared-state
+design **requires they match** — otherwise the orchestrator and the
+agent panes read different `~/.fleet` (split-brain claims / usage-gate).
+Point MSYS2 at the Windows profile by editing
+`/c/msys64/etc/nsswitch.conf`:
+
+```
+db_home: windows cygwin desc     # was: db_home: cygwin desc
+```
+
+Open a fresh MSYS2 shell and confirm `echo $HOME` prints
+`/c/Users/<user>` — the same value Git Bash reports.
+
+### PATH (MSYS2 doesn't inherit the Windows user PATH)
+
+`setup-windows.sh` (below) puts `scripts/fleet` and `engine/tools/bin` on
+PATH via `~/.bashrc`. But the base MSYS2 PATH does **not** include the
+dirs where `git`, `node`, `cmake`, `claude` (Windows side) or `gh`,
+`python3`, the mingw64 toolchain (MSYS2 mingw64) live, so add them too
+(adjust to your install paths):
+
+```bash
+cat >> ~/.bashrc <<'EOF'
+export PATH="/c/msys64/mingw64/bin:/c/Program Files/Git/cmd:/c/Program Files/nodejs:/c/Program Files/CMake/bin:$HOME/.local/bin:$PATH"
+EOF
+```
+
+(`jq` and `tmux` come from MSYS2's `/usr/bin`, already on the base PATH.)
+
+### Run the setup script
+
+`scripts/fleet/setup-windows.sh` is the one-shot, idempotent installer:
+it clones the engine to `$HOME/src/IrredenEngine`, writes
+`~/.fleet/fleet-up.conf` and `~/.config/irreden/host.toml` sized for the
+box, puts the fleet tool dirs on PATH, and creates the worktrees off
+`origin/master`. From an MSYS2 bash shell:
+
+```bash
+bash "$HOME/src/IrredenEngine/scripts/fleet/setup-windows.sh"
+source ~/.bashrc                  # pick up PATH + HOME changes
+```
+
+Verify everything resolves from a fresh MSYS2 shell:
+
+```bash
+echo "$HOME"                                          # /c/Users/<user>
+for t in git gh jq tmux claude node python3 cmake fleet-up; do command -v "$t"; done
+fleet-claim host                                      # prints: windows
+```
+
+### Build the host tree once
+
+```bash
+cd "$HOME/src/IrredenEngine"
+cmake --preset windows-debug
+fleet-build --target IRShapeDebug
+```
+
+The native-Windows build needs a `cc1plus` PATH fix (Git's older mingw
+runtime DLLs must not shadow MSYS2's); `fleet-build` / `ir-build` apply
+it automatically, so prefer them over a raw `cmake --build` (which can
+crash `cc1plus` silently with no output). See
+[`docs/agents/BUILD.md`](agents/BUILD.md) "Windows-native build" for the
+root-cause writeup.
+
+### tmux prefix
+
+`setup-windows.sh` does not install a `~/.tmux.conf`, so the prefix is
+the tmux default **`Ctrl+b`** (detach = `Ctrl+b` then `d`). For the
+`Ctrl+a` remap + mouse the rest of this doc assumes, drop in the
+`~/.tmux.conf` from §5a.
 
 ---
 

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -290,10 +290,11 @@ shell:
 
 ```bash
 pacman -Syu                       # then reopen the shell if it asks
-pacman -S --needed tmux jq \
+pacman -S --needed tmux \
     mingw-w64-x86_64-toolchain \  # gcc/g++ >= 13 — the windows-debug compiler
     mingw-w64-x86_64-gh \         # GitHub CLI
-    mingw-w64-x86_64-python       # fleet python helpers (scout, reconcile)
+    mingw-w64-x86_64-python \     # fleet python helpers (scout, reconcile)
+    mingw-w64-x86_64-jq           # JSON — must be the mingw build (see note below)
 ```
 
 Install separately on the **Windows** side: **Git for Windows** (the
@@ -333,7 +334,13 @@ export PATH="/c/msys64/mingw64/bin:/c/Program Files/Git/cmd:/c/Program Files/nod
 EOF
 ```
 
-(`jq` and `tmux` come from MSYS2's `/usr/bin`, already on the base PATH.)
+`tmux` comes from MSYS2's `/usr/bin` (already on the base PATH) and only
+the orchestrator needs it. **`jq` must be the mingw build**
+(`mingw-w64-x86_64-jq`, in `mingw64/bin`), *not* the MSYS `jq` in
+`/usr/bin`: the agent panes run their Bash tool as **Git Bash**, whose
+PATH includes `mingw64/bin` (via the line above) but not the MSYS
+`/usr/bin`. An MSYS-only `jq` works for the orchestrator but the agents
+hit `jq: command not found`.
 
 ### Run the setup script
 

--- a/docs/AGENT_FLEET_SETUP.md
+++ b/docs/AGENT_FLEET_SETUP.md
@@ -338,10 +338,18 @@ EOF
 ### Run the setup script
 
 `scripts/fleet/setup-windows.sh` is the one-shot, idempotent installer:
-it clones the engine to `$HOME/src/IrredenEngine`, writes
-`~/.fleet/fleet-up.conf` and `~/.config/irreden/host.toml` sized for the
-box, puts the fleet tool dirs on PATH, and creates the worktrees off
-`origin/master`. From an MSYS2 bash shell:
+it clones the engine to `$HOME/src/IrredenEngine` (or fetches if already
+present), writes `~/.fleet/fleet-up.conf` and `~/.config/irreden/host.toml`
+sized for the box, puts the fleet tool dirs on PATH, and creates the
+worktrees off `origin/master`. To get the script itself, clone the repo first
+if you haven't already:
+
+```bash
+git clone https://github.com/jakildev/IrredenEngine.git "$HOME/src/IrredenEngine"
+```
+
+Then run the setup script from an MSYS2 bash shell (idempotent — safe to
+re-run if the clone already exists):
 
 ```bash
 bash "$HOME/src/IrredenEngine/scripts/fleet/setup-windows.sh"
@@ -1602,9 +1610,10 @@ logical boundary. That's the whole reason the skill exists.
 
 ## Recap
 
-**On each host you intend to run the fleet on (WSL and/or macOS):**
+**On each host you intend to run the fleet on (WSL, macOS, and/or native Windows):**
 
-- Host base toolchain installed (§1a for WSL, §1b for macOS). ✅
+- Host base toolchain installed (§1a for WSL, §1b for macOS, §1c for native
+  Windows). ✅
 - Engine cloned into `~/src/IrredenEngine` (on the host's native
   filesystem). ✅
 - GitHub CLI installed on this host and authed. ✅
@@ -1612,9 +1621,9 @@ logical boundary. That's the whole reason the skill exists.
 - Permanent worktrees created under this host's clone. ✅
 - tmux + `fleet-up` helper ready. ✅
 - Build tree configured with the right preset
-  (`linux-debug` on WSL / `macos-debug` on macOS) and `IRShapeDebug`
-  builds cleanly (or cross-platform-maturation tasks are filed for
-  whatever doesn't). ✅
+  (`linux-debug` on WSL / `macos-debug` on macOS / `windows-debug` on native
+  Windows) and `IRShapeDebug` builds cleanly (or cross-platform-maturation
+  tasks are filed for whatever doesn't). ✅
 - Reviewer worktrees parked on `claude/<role>-scratch`. ✅
 
 **Shared across hosts:**


### PR DESCRIPTION
## Summary
`docs/AGENT_FLEET_SETUP.md` (the external setup checklist) documented only **WSL (§1a)** and **macOS (§1b)**. The native-Windows path lived only in `scripts/fleet/setup-windows.sh`'s header comment, so anyone onboarding a Windows host via this doc never found it. This adds the missing **§1c** and makes the environment intro consistent.

Surfaced while bringing up the native-Windows fleet — the two gotchas documented here (HOME split, base-MSYS2-PATH gaps) each cost a real debugging round on a fresh host.

## Changes
- New **§1c "native-Windows + MSYS2 + base tooling (Windows host)"**:
  - toolchain install — MSYS2 `mingw64` (toolchain, `gh`, `python`) + Windows-side Git for Windows / Node.js / CMake / Claude Code
  - **⚠ `$HOME` unification** between MSYS2 (`/c/msys64/home/<user>`) and Git Bash (`/c/Users/<user>`) via `nsswitch.conf` `db_home: windows` — required so the orchestrator and agent panes share `~/.fleet`
  - **PATH** gaps: the base MSYS2 PATH doesn't include `git`/`gh`/`node`/`cmake`/`python3`/`claude`, with the one-line `~/.bashrc` fix
  - running `setup-windows.sh`, a verification snippet, the `windows-debug` build with the `cc1plus`/`cmd.exe` note (cross-ref `BUILD.md`), and the default `Ctrl+b` tmux prefix
- Environment intro updated from "two hosts" → three so it no longer contradicts the new section, with a note that native-Windows is the exception to the "no `cmd.exe` wrappers" rationale (handled by `ir-build`/`fleet-build`).

## Test plan
Docs-only; no code or behavior change. Steps mirror the actual native-Windows bring-up performed on the `windows` host.