### PR TITLE
fleet: scout spawns sibling scripts via bash on native Windows

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -51,18 +51,12 @@ if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
 # scout is run directly or loaded by-path in the unit tests (#1425).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from fleet_branch_match import branch_matches_issue, PARKED_PR_LABELS
+from fleet_stack_base import unsafe_base_reason
+from fleet_blocked_by import parse_blocked_by, is_no_blocker_value
 
 
 def _fleet_script_argv(cmd):
-    """Make a sibling fleet-script command spawnable on this platform.
-
-    The fleet scripts (fleet-claim, fleet-queue-ingest, ...) are bash with a
-    `#!/usr/bin/env bash` shebang. POSIX honors the shebang, so the bare name
-    on PATH works. Native-Windows python's CreateProcess cannot exec a shebang
-    script (`[WinError 2]`), so resolve cmd[0] to its absolute sibling path
-    (every fleet script lives in this script's dir) and route it through bash.
-    On POSIX this only resolves the bare name to that same absolute path.
-    """
+    """Resolve a bare fleet-script name to a spawnable argv (bash-wrapped on win32)."""
     name = cmd[0]
     if not os.path.isabs(name):
         sibling = os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
@@ -70,12 +64,10 @@ def _fleet_script_argv(cmd):
             name = sibling
     if sys.platform == "win32":
         bash = shutil.which("bash") or "bash"
-        # Forward slashes: bash on Windows execs "C:/path/script" reliably,
-        # backslash paths get mangled as escapes.
+        # bash on Windows needs forward-slashed path (backslashes are mangled as escapes).
         return [bash, name.replace("\\", "/"), *cmd[1:]]
     return [name, *cmd[1:]]
-from fleet_stack_base import unsafe_base_reason
-from fleet_blocked_by import parse_blocked_by, is_no_blocker_value
+
 
 ENGINE = Path.home() / "src" / "IrredenEngine"
 GAME = ENGINE / "creations" / "game"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -23,6 +23,7 @@ import json
 import os
 import re
 import signal
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -50,6 +51,29 @@ if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
 # scout is run directly or loaded by-path in the unit tests (#1425).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from fleet_branch_match import branch_matches_issue, PARKED_PR_LABELS
+
+
+def _fleet_script_argv(cmd):
+    """Make a sibling fleet-script command spawnable on this platform.
+
+    The fleet scripts (fleet-claim, fleet-queue-ingest, ...) are bash with a
+    `#!/usr/bin/env bash` shebang. POSIX honors the shebang, so the bare name
+    on PATH works. Native-Windows python's CreateProcess cannot exec a shebang
+    script (`[WinError 2]`), so resolve cmd[0] to its absolute sibling path
+    (every fleet script lives in this script's dir) and route it through bash.
+    On POSIX this only resolves the bare name to that same absolute path.
+    """
+    name = cmd[0]
+    if not os.path.isabs(name):
+        sibling = os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
+        if os.path.exists(sibling):
+            name = sibling
+    if sys.platform == "win32":
+        bash = shutil.which("bash") or "bash"
+        # Forward slashes: bash on Windows execs "C:/path/script" reliably,
+        # backslash paths get mangled as escapes.
+        return [bash, name.replace("\\", "/"), *cmd[1:]]
+    return [name, *cmd[1:]]
 from fleet_stack_base import unsafe_base_reason
 from fleet_blocked_by import parse_blocked_by, is_no_blocker_value
 
@@ -2152,7 +2176,7 @@ def tick_once():
                 for sweep_cmd in sweep_cmds:
                     try:
                         subprocess.Popen(
-                            sweep_cmd,
+                            _fleet_script_argv(sweep_cmd),
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL,
                             start_new_session=True,
@@ -2179,12 +2203,8 @@ def tick_once():
                     triggers_fired.append("queue-manager-ingest(skipped-degraded)")
                     continue
                 try:
-                    ingest_cmd = subprocess.run(
-                        ["which", "fleet-queue-ingest"],
-                        capture_output=True, text=True,
-                    ).stdout.strip() or str(ENGINE / "scripts" / "fleet" / "fleet-queue-ingest")
                     subprocess.Popen(
-                        [ingest_cmd],
+                        _fleet_script_argv(["fleet-queue-ingest"]),
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                         start_new_session=True,


### PR DESCRIPTION
## Summary
On the native-Windows host, `fleet-state-scout` (Python) silently failed to spawn its sibling fleet scripts:
```
queue-manager: sweep failed to spawn fleet-claim: [WinError 2] The system cannot find the file specified
queue-manager-ingest: failed to spawn fleet-queue-ingest: [WinError 2]
```
Windows Python's `CreateProcess` can't exec a `#!/usr/bin/env bash` shebang script by bare name. This **disabled task ingestion** (`human:approved` → `fleet:queued`) and the **stale-claim cleanup / reconcile sweep** on the `windows` host. (Workers are unaffected — they run `fleet-claim` from their Git Bash Bash tool, which honors the shebang.)

Observed live in `~/.fleet/logs/state-scout.log` right after a clean relaunch.

## Fix
New `_fleet_script_argv(cmd)` helper:
- resolves `cmd[0]` (a bare script name) to its absolute sibling path — every fleet script lives in the scout's own dir (consistent with the existing `sys.path.insert(dirname(__file__))`);
- on `win32`, routes it through `bash` (forward-slashed path, which Windows bash execs reliably);
- on POSIX, returns the resolved path unchanged — same script the shebang/PATH would have run, so no behavior change for the Linux/macOS fleet.

Both `subprocess.Popen` spawn sites (the `fleet-claim` cleanup/reconcile sweep and the `fleet-queue-ingest` spawn) now go through it; the prior `which`-based ingest resolution is replaced by the same helper.

## Test plan
Verified on the `windows` host:
- [x] `py_compile` clean
- [x] the wrapped argv runs `fleet-claim host` → `rc 0` / `windows` (previously `[WinError 2]`)
- [x] POSIX path returns the resolved sibling path with no `bash` wrapper (no behavior change)