### PR TITLE
fleet: queue plan-reviewed issues — sync scout ingest skip-set

### DIFF
--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -97,11 +97,16 @@ Specifically, **never pass these via `--label` when filing**:
 - `fleet:plan-review` — owned by the **planner** (sets it, swapping out
   `fleet:needs-plan`, once the `## Plan` comment is posted) and the **plan
   reviewer** (the architect, or the opus-reviewer loop — clears it). While
-  present the issue is NOT queue-ready: `fleet-queue-ingest` skips it. The
+  present the issue is NOT queue-ready: it is in **both** the scout's
+  `_INGEST_SKIP_LABELS` and `fleet-queue-ingest`'s own stamping skip (the two
+  must stay in sync — if only ingest skips it, the issue counts as "in the
+  scout's ingest set" the whole time the label is on, so *removing* it is not a
+  set change and never fires ingest). The
   reviewer judges the `## Plan` comment *as a plan* (per PLANNING-PROTOCOL.md
   step-2 rigor — verified state, single committed approach, sibling
-  reconciliation, cross-system audit): sound → remove the label (the scout
-  queues the issue on its next pass); not sound → swap back to
+  reconciliation, cross-system audit): sound → remove the label (the membership
+  flips out→in, the scout fires ingest, and it queues on the next pass); not
+  sound → swap back to
   `fleet:needs-plan` with a comment naming the gaps. Distinct from the code
   review the implementation PR later gets. Don't add at filing.
 - `human:review-plan` — owned by the **human** as a release gate; **set by an

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -180,6 +180,15 @@ _INGEST_SKIP_LABELS = frozenset({
     "fleet:queued",        # pre-filtered by fetch_human_approved, included for explicitness
     "fleet:epic",
     "fleet:needs-plan",
+    "fleet:plan-review",   # #1932: plan posted, reviewer vetting before queue.
+                           # MUST mirror fleet-queue-ingest's own per-issue skip
+                           # (it also skips fleet:plan-review). Without it the issue
+                           # counts as "in the set" the whole time plan-review is on,
+                           # so the reviewer REMOVING plan-review — the queue trigger —
+                           # is not a membership change → no hash flip → no ingest fire
+                           # → the issue strands approved-but-unqueued until an unrelated
+                           # approval/unblock sweeps the set. Symmetric with the
+                           # human:review-plan hold below.
     "fleet:needs-info",
     "fleet:scope-shipped", # scope landed under a different issue; human should close
     "fleet:needs-human",   # parked: fleet can't do it autonomously, human must act;
@@ -1481,8 +1490,9 @@ def project_queue_manager_ingest(state):
     CHANGES, and each change spawns fleet-queue-ingest:
 
     - **Add path** — every `human:approved` issue not yet stamped
-      `fleet:queued` and not in a skip category (epic, needs-plan, needs-info,
-      needs-human, scope-shipped). Since #1527 a `**Blocked by:**`-blocked
+      `fleet:queued` and not in a skip category (epic, needs-plan, plan-review,
+      needs-info, needs-human, scope-shipped, human:review-plan). Since #1527 a
+      `**Blocked by:**`-blocked
       issue is NO LONGER excluded: it enters the set, ingest stamps
       `fleet:queued` + a model label + `fleet:blocked`, and it drops out
       (now carrying fleet:queued). The whole queue is visible immediately


### PR DESCRIPTION
## Summary
- The scout's queue-ingest projection (`project_queue_manager_ingest` / `slice_queue_manager_ingest`) is **edge-triggered**: it only spawns `fleet-queue-ingest` when the *set* of actionable `human:approved` issues changes (a hash flip). Set membership is gated by `_INGEST_SKIP_LABELS`.
- `fleet:plan-review` was in `fleet-queue-ingest`'s own per-issue stamping skip (its lines ~327–329) but **not** in the scout's `_INGEST_SKIP_LABELS`. So a plan-reviewed issue counted as "in the set" the entire time `fleet:plan-review` was present — and *removing* the label (the event that should queue it) was not a membership change → no hash flip → no ingest fire. The issue stranded `human:approved`-but-unqueued until an unrelated approval/unblock swept the set.
- Observed live: #1997, #1998, #1999, #2008, #2009 all sat approved + planned + unqueued after their `fleet:plan-review` labels cleared in one 17:04–17:05 batch (2026-06-25).

## Fix
- Add `fleet:plan-review` to `_INGEST_SKIP_LABELS` so the label's removal is a genuine out→in transition that fires ingest — symmetric with how `human:review-plan` (#2011) is already handled in the same set.
- Update the `project_queue_manager_ingest` docstring's skip-category enumeration.
- Update the `fleet:plan-review` entry in `docs/agents/fleet-labels-reference.md` to carry the skip-set sync invariant (the two skip lists must stay in sync) so a future edit can't silently re-break it.

The five stranded issues above were unstuck out-of-band by a manual `fleet-queue-ingest` run; this PR prevents recurrence.

## Test plan
- [x] `python3 -m py_compile scripts/fleet/fleet-state-scout`
- [x] `fleet:plan-review` and `human:review-plan` both present in `_INGEST_SKIP_LABELS`
- [ ] On next plan-review clear, confirm the issue queues within one scout tick without an unrelated set change

🤖 Generated with [Claude Code](https://claude.com/claude-code)