### PR TITLE
build+render: native-Windows demo build & smoke bring-up (LuaJIT mingw32-make + trixel UBO stage-match)

### DIFF
--- a/engine/render/src/shaders/v_trixel_to_framebuffer.glsl
+++ b/engine/render/src/shaders/v_trixel_to_framebuffer.glsl
@@ -24,6 +24,28 @@ layout (std140, binding = 3) uniform FrameDataIsoTriangles {
     vec2 effectiveSubdivisionsForHover;
     float showHoverHighlight;
     int distanceOffset;
+    // This block is ALSO declared in f_trixel_to_framebuffer.glsl, and a
+    // uniform block shared by name across stages MUST be member-identical or
+    // the GL spec makes the program link ill-formed. Lenient drivers
+    // (Linux/macOS) accepted the vertex-side head-only form; the stricter
+    // native-Windows driver rejects it with "members of uniform block (named
+    // FrameDataIsoTriangles) are not the same between shader stages" and the
+    // program-link assert crashes every demo at startup. The vertex stage
+    // consumes only mpMatrix + textureOffset, but it must still declare the
+    // full scatter UBO tail so the std140 layout matches BOTH the fragment
+    // stage and the shared C++ struct (FrameDataTrixelToFramebuffer,
+    // ir_render_types.hpp). Keep these two blocks in lockstep.
+    ivec2 perAxisBase;
+    float visualYaw;
+    int scatterDebugMode;
+    ivec4 visibleFaceIds;
+    vec4 _detachedResidualPad;
+    vec4 _detachedDepthAxisPad;
+    vec4 scatterFbResolution;
+    int depthColorMode;
+    float depthColorExtent;
+    float _depthColorPad0;
+    int depthPriorityMode;
 };
 
 void main() {

--- a/engine/script/third_party/luajit/CMakeLists.txt
+++ b/engine/script/third_party/luajit/CMakeLists.txt
@@ -70,10 +70,28 @@ endif()
 # before the populate step runs.
 file(MAKE_DIRECTORY ${LUAJIT_INCLUDE_DIR})
 
+# LuaJIT builds through its own Makefile, so this must invoke a *make*
+# program — and on native Windows that program is `mingw32-make`, not
+# `make`. The windows-debug preset uses MinGW Makefiles + MSYS2's mingw64
+# toolchain, which ships `mingw32-make.exe`; the Unix `make` lives in
+# MSYS2's /usr/bin, which is NOT on the build PATH (ir-build prepends only
+# mingw64/bin). A bare `make` there dies with "no such file or directory"
+# and breaks the whole native-Windows link — latent until the fleet first
+# built on real Windows, because WSL/macOS both have `make`.
+#
+# Deliberately NOT ${CMAKE_MAKE_PROGRAM}: under a Ninja generator that is
+# `ninja`, and `ninja BUILDMODE=static …` is nonsense — LuaJIT always
+# needs a make. Select by platform instead.
+if(WIN32)
+    set(LUAJIT_MAKE_PROGRAM mingw32-make)
+else()
+    set(LUAJIT_MAKE_PROGRAM make)
+endif()
+
 add_custom_command(
     OUTPUT ${LUAJIT_LIB_PATH}
     WORKING_DIRECTORY ${LUAJIT_SRC_DIR}
-    COMMAND ${CMAKE_COMMAND} -E env make ${LUAJIT_MAKE_ARGS}
+    COMMAND ${CMAKE_COMMAND} -E env ${LUAJIT_MAKE_PROGRAM} ${LUAJIT_MAKE_ARGS}
     COMMENT "Building LuaJIT 2.1 static library (${LUAJIT_LIB_NAME})"
     VERBATIM
 )


### PR DESCRIPTION
## Summary

First genuine **native-Windows** (MSYS2 mingw64, OpenGL) build of the fleet — not WSL. Two latent cross-platform bugs masked the platform, both invisible because the fleet only ever built on WSL/macOS. After both fixes the engine builds and renders natively on Windows.

### Fix 1 — LuaJIT vendor build (`engine/script/third_party/luajit/CMakeLists.txt`)
The vendor build invoked bare `make`, but MSYS2/mingw64 ships only `mingw32-make` (Unix `make` lives in `/usr/bin`, which is **not** on `ir-build`'s cmd.exe build PATH — it prepends only `mingw64/bin`). The build died at `libluajit.a` with `no such file or directory` and the whole link failed. Now selects `mingw32-make` on `WIN32`. Deliberately **not** `${CMAKE_MAKE_PROGRAM}` — that resolves to `ninja` under a Ninja generator, and LuaJIT always needs a *make*. Unblocks **all** native-Windows builds.

### Fix 2 — trixel→framebuffer UBO stage match (`engine/render/src/shaders/v_trixel_to_framebuffer.glsl`)
`FrameDataIsoTriangles` was declared with only the 8-member head in the **vertex** stage but the full scatter-tail layout in the **fragment** stage. GLSL requires a uniform block shared by name to be member-identical across stages; lenient Linux/macOS drivers tolerated the divergence, the stricter native-Windows driver rejected the program link (`members of uniform block ... are not the same between shader stages`) and the link-assert crashed **every demo** at startup. The vertex block now declares the identical full layout. **No-op on Linux/macOS** — byte-identical std140 layout; the extra tail members are declared-but-unused in the vertex stage. Unblocks **all** native-Windows runtime.

## Results (native Windows)

| Phase | Result |
|---|---|
| Build | **41/41** demo targets clean |
| Run (`--auto-screenshot`) | **35/38** render + screenshot clean — entire 15-demo lighting suite, rotation, particles, fog, sprites, widgets, audio, scene-reset |

`IRShapeDebug` verified rendering correctly (21 screenshots + ROI crops, clean exit).

## Render-verify note

The shader change can't follow the normal before/after screenshot flow: the **before** state on Windows is a hard crash (no frame to capture), and on Linux/macOS the change is a pure GLSL-spec-correctness no-op (identical std140 layout, so byte-identical output). Evidence is the build+run matrix above. Reviewers on Linux/macOS: please confirm no rendering delta (expected: none).

## Follow-ups (filed, NOT fixed here)

The 3 remaining run-pass failures are **pre-existing latent UB unrelated to these fixes**, root-caused via gdb and filed separately:
- #2031 — `GpuStageTimingObserver` dtor calls `glDeleteQueries` at process-exit static destruction → teardown segfault on `IRLuaPipelineDemo` / `IRCollisionOverlapDemo` (render fully validated; crash is on clean exit).
- #2032 — skeletal `seedVoxelBoneSlots` out-of-bounds `std::span` deref → first-frame segfault on `IRSkeletalDemo`.

## Test plan
- [ ] Linux/OpenGL: build + `IRShapeDebug --auto-screenshot` — confirm no rendering delta (shader change is a no-op).
- [ ] macOS/Metal: build (Metal shaders unaffected; CMake change is `WIN32`-gated).
- [ ] Native Windows: `ir-build` cohort + `ir-run --auto-screenshot` — 41/41 build, 35/38 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)