### PR TITLE
fleet: planning-claim --replan to race-guard stale re-plans (#1999)

### DIFF
--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -40,7 +40,8 @@ For each `fleet:needs-plan` issue:
    planners pass it before either posts a comment); the atomic claim does. (The
    claim/dedup enforcement is fleet tooling — `fleet-claim planning-claim`,
    landing with the re-scoped #1889; until it ships, honor this contract
-   manually.)
+   manually.) **Re-planning an already-planned task** that went stale has its
+   own guarded flow — see [§ Re-planning a stale queued plan](#re-planning-a-stale-queued-plan).
 
 1. **Read the full issue thread** — title, body, and every comment.
    The plan is often seeded in a comment, and the human may have left
@@ -227,6 +228,58 @@ For each `fleet:needs-plan` issue:
 **If you disagree with the issue's direction** (at planning time), comment with
 your concerns, leave `fleet:needs-plan` on, release the planning claim, and let
 the human decide.
+
+---
+
+## Re-planning a stale queued plan
+
+A first plan and its claim are guarded by step 0. **A re-plan is not** — and that
+gap is its own race. A `fleet:queued` task whose already-committed plan goes
+**stale post-approval** (its blocker shipped a *different* design during review,
+so the committed `.fleet/plans/issue-<N>.md` / `## Plan` comment now cites a
+renamed/removed symbol or a superseded decision) needs a fresh plan. The trigger
+to re-plan lives **outside** the first-plan lock, so without a guard two opus
+panes can both judge the same queued task stale and both deep-investigate the
+refresh — #1999: #1960 was re-derived by three panes after #1958/PR #1974 shipped
+a different encoding (no clobber, ~1 opus iteration wasted each).
+
+**The contract — re-flag and lock BEFORE any deep re-investigation.** The moment
+you judge a queued task's committed plan stale, and *before* spending an
+iteration re-deriving it:
+
+1. Flip the labels `fleet:queued → fleet:needs-plan`:
+   ```
+   gh issue edit <N> --repo <owner/repo> \
+     --remove-label "fleet:queued" --add-label "fleet:needs-plan"
+   ```
+2. Take the re-plan lock with the trailing `--replan` flag:
+   ```
+   fleet-claim planning-claim <N> <your-agent-name> --replan
+   ```
+   - **Exit 0** — you own the re-plan. Re-investigate, then post a **fresh**
+     `## Plan` comment that notes it supersedes the prior plan (the prior comment
+     stays as audit trail; the implementer reads the most-recent `## Plan`
+     comment as authoritative). Then proceed as a normal plan: swap
+     `fleet:needs-plan → fleet:plan-review` and `planning-release`.
+   - **Exit 1** — another pane already owns the re-plan. Back off immediately, do
+     **not** investigate, pick a different task (the losing label self-removes;
+     nothing to clean up).
+   - **Exit 2** — misuse: `fleet:needs-plan` isn't currently on the issue.
+     `--replan` requires it (step 1 sets it) so a re-plan can't grab a
+     freshly-planned or never-re-flagged issue. Re-check the label state.
+
+`--replan` exists because plain `planning-claim` would refuse a re-plan: a stale
+queued plan *has* a `## Plan` comment by definition, so the step-0 dedup early-out
+returns exit 3 to *every* planner — leaving the re-plan both unguarded **and**
+stranded until someone hand-deletes the old comment. `--replan` skips that
+comment-presence early-out (a re-plan expects a prior plan) and instead gates on
+the `fleet:needs-plan` label you set in step 1, so the lex-min lock arms for
+re-plans and guarantees a sole holder — exactly like a first plan.
+
+> The `role-worker.md` echo of this contract ("judge a queued plan stale → flip
+> `fleet:queued → fleet:needs-plan` + `planning-claim --replan` before
+> investigating") is **gated self-config** and is a human follow-up — this doc is
+> the worker-applicable half.
 
 ---
 

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1279,12 +1279,63 @@ _issue_has_plan_comment() {
         2>/dev/null || echo 0)
     [[ "${cnt:-0}" =~ ^[0-9]+$ && "${cnt:-0}" -gt 0 ]]
 }
+
+# True iff the issue currently carries fleet:needs-plan. The --replan re-plan
+# path gates on this: a worker flips fleet:queued -> fleet:needs-plan before
+# re-claiming, so its presence is the signal that a deliberate re-plan was
+# requested — and its absence stops --replan from grabbing a freshly-planned or
+# never-re-flagged issue nobody asked to re-plan (#1999).
+_issue_has_needs_plan() {
+    local repo="$1" issue="$2" present
+    present=$(gh issue view "$issue" --repo "$repo" --json labels \
+        --jq 'any(.labels[]; .name == "fleet:needs-plan")' 2>/dev/null || echo false)
+    [[ "$present" == "true" ]]
+}
 cmd_planning_claim() {
-    local issue="${1:-}" agent="${2:-unknown}" repo
-    if [[ "$issue" =~ ^[0-9]+$ ]] && command -v gh >/dev/null 2>&1; then
-        repo=$(repo_from_ns)
-        if [[ -n "$repo" ]] && _issue_has_plan_comment "$repo" "$issue"; then
-            echo "planning-claim: issue#$issue already has a ## Plan comment; skipping (already planned)"
+    # planning-claim <issue> <agent> [--replan]
+    #   --replan is a trailing boolean flag (mirrors cmd_claim's --stackable-on
+    #   arg-shift): issue first, agent the next non-flag positional, flags after.
+    local issue="${1:-}"
+    shift || true
+    local agent="unknown"
+    if [[ "${1:-}" != --* && $# -ge 1 ]]; then
+        agent="$1"
+        shift
+    fi
+    local replan=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --replan) replan=1; shift ;;
+            *) echo "fleet-claim planning-claim: unknown flag '$1'" >&2; return 2 ;;
+        esac
+    done
+
+    local repo
+    repo=$(repo_from_ns)
+
+    if [[ "$replan" -eq 1 ]]; then
+        # A deliberate RE-plan of a stale committed plan. SKIP the
+        # `## Plan`-comment dedup early-out — a re-plan EXPECTS a prior plan, so
+        # it must ACQUIRE the lock (not be refused) so two opus panes can't both
+        # deep-investigate the same stale-plan refresh (#1999). The lex-min
+        # label lock then guarantees a sole re-plan holder, exactly like a first
+        # plan; the comment-presence early-out would otherwise both leave the
+        # re-plan unguarded AND strand it (exit 3 for every planner) until a
+        # human hand-deletes the prior `## Plan` comment. GUARD: fleet:needs-plan
+        # must be CURRENTLY present (the worker flips fleet:queued ->
+        # fleet:needs-plan before claiming), so --replan can't grab a
+        # freshly-planned/queued issue nobody re-flagged.
+        if [[ "$issue" =~ ^[0-9]+$ ]] && command -v gh >/dev/null 2>&1 && [[ -n "$repo" ]]; then
+            if ! _issue_has_needs_plan "$repo" "$issue"; then
+                echo "planning-claim --replan: issue#$issue is not flagged fleet:needs-plan; flip fleet:queued -> fleet:needs-plan before re-planning (refusing)" >&2
+                return 2
+            fi
+        fi
+    else
+        # First-time plan claim: refuse an already-planned issue via the cheap
+        # `## Plan`-comment dedup early-out.
+        if [[ "$issue" =~ ^[0-9]+$ ]] && command -v gh >/dev/null 2>&1 && [[ -n "$repo" ]] && _issue_has_plan_comment "$repo" "$issue"; then
+            echo "planning-claim: issue#$issue already has a ## Plan comment; skipping (already planned). Pass --replan to race-guard a deliberate re-plan."
             return 3
         fi
     fi
@@ -3873,10 +3924,11 @@ case "${1:-}" in
         ;;
     planning-claim)
         if [[ -z "${3:-}" ]]; then
-            echo "usage: fleet-claim [--repo <ns>] planning-claim <needs-plan-issue> <agent>" >&2
+            echo "usage: fleet-claim [--repo <ns>] planning-claim <needs-plan-issue> <agent> [--replan]" >&2
             exit 2
         fi
-        cmd_planning_claim "$2" "$3"
+        shift  # drop subcommand; forward <issue> <agent> [--replan]
+        cmd_planning_claim "$@"
         ;;
     planning-release)
         if [[ -z "${3:-}" ]]; then
@@ -4107,7 +4159,7 @@ commands:
                                 FLEET_CLAIM_STALE_SECS_STEWARD).
   steward-release <umbrella-issue> <agent>
                                 release a stewardship claim.
-  planning-claim <needs-plan-issue> <agent>
+  planning-claim <needs-plan-issue> <agent> [--replan]
                                 atomically claim a fleet:needs-plan ISSUE
                                 before planning via a
                                 fleet:planning-<host>-<agent> label
@@ -4115,6 +4167,12 @@ commands:
                                 when a ## Plan comment already exists;
                                 swept by cleanup --gh after
                                 FLEET_CLAIM_STALE_SECS_PLANNING).
+                                --replan skips the comment-presence
+                                early-out so a deliberate re-plan of a
+                                stale committed plan is race-guarded like
+                                a first plan; it requires fleet:needs-plan
+                                to be currently present (else exit 2)
+                                (#1999).
   planning-release <needs-plan-issue> <agent>
                                 release a planning claim.
   clear-all                     wipe all claims (used by fleet-up on

--- a/scripts/fleet/tests/test_fleet_claim_planning.sh
+++ b/scripts/fleet/tests/test_fleet_claim_planning.sh
@@ -50,15 +50,24 @@ REMOVE_LOG="$TMPROOT/remove.log"; : > "$REMOVE_LOG"
 
 # Stateful gh stub. STUB_HOLDERS = planning labels already on the issue; the
 # POST echoes those + the just-posted label. STUB_PLAN_COMMENTS is the count
-# `_issue_has_plan_comment`'s --jq returns (the dedup probe). issue-edit calls
-# are logged for self-removal / release assertions.
+# `_issue_has_plan_comment`'s --jq returns (the dedup probe). STUB_NEEDS_PLAN is
+# the literal true/false `_issue_has_needs_plan`'s --jq returns (the --replan
+# needs-plan-present guard). The two issue-view probes are disambiguated by
+# their --json arg. issue-edit calls are logged for self-removal / release.
 STUB_HOLDERS=""
 STUB_PLAN_COMMENTS=0
+STUB_NEEDS_PLAN=false
 gh() {
     case "${1:-}" in
         issue)
             case "${2:-}" in
-                view) printf '%s\n' "${STUB_PLAN_COMMENTS:-0}"; return 0 ;;  # dedup probe
+                view)
+                    if printf '%s ' "$@" | grep -q -- "--json labels"; then
+                        printf '%s\n' "${STUB_NEEDS_PLAN:-false}"   # needs-plan guard (--replan)
+                    else
+                        printf '%s\n' "${STUB_PLAN_COMMENTS:-0}"    # dedup probe (--json comments)
+                    fi
+                    return 0 ;;
                 edit) printf '%s\n' "$*" >> "$REMOVE_LOG"; return 0 ;;
                 *) return 0 ;;
             esac ;;
@@ -106,6 +115,26 @@ echo "T5: planning-release removes the label"
 cmd_planning_release 740 worker >/dev/null 2>&1 || rc=$?
 assert_exit "$rc" 0 "release exits 0"
 if grep -q -- "--remove-label $MINE" "$REMOVE_LOG"; then ok "release removed $MINE"; else bad "release did not remove $MINE (log: $(cat "$REMOVE_LOG"))"; fi
+
+echo "== --replan re-plan path (#1999): bypass dedup, gate on needs-plan present =="
+
+echo "T8: --replan with a ## Plan comment AND fleet:needs-plan present → acquires (exit 0), bypassing dedup"
+STUB_HOLDERS=""; STUB_PLAN_COMMENTS=1; STUB_NEEDS_PLAN=true
+rc=0; out=$(cmd_planning_claim 740 worker --replan 2>&1) || rc=$?
+assert_exit "$rc" 0 "--replan + plan comment + needs-plan present → exit 0 (re-plan lock armed, not exit 3)"
+case "$out" in *"issue#740"*) ok "re-plan acquire names the target as an issue" ;; *) bad "expected acquire message naming issue#740, got: $out" ;; esac
+
+echo "T9: --replan WITHOUT fleet:needs-plan present → refuses (exit 2, misuse)"
+STUB_HOLDERS=""; STUB_PLAN_COMMENTS=1; STUB_NEEDS_PLAN=false
+rc=0; out=$(cmd_planning_claim 740 worker --replan 2>&1) || rc=$?
+assert_exit "$rc" 2 "--replan with needs-plan absent → exit 2"
+case "$out" in *"not flagged fleet:needs-plan"*) ok "refusal explains the missing needs-plan label" ;; *) bad "expected 'not flagged fleet:needs-plan', got: $out" ;; esac
+
+echo "T10: --replan loser path (another host already holds fleet:planning-*) → yield (exit 1) + self-remove"
+STUB_HOLDERS="$OTHER"; STUB_PLAN_COMMENTS=1; STUB_NEEDS_PLAN=true; : > "$REMOVE_LOG"
+rc=0; cmd_planning_claim 740 worker --replan >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 1 "--replan with a persistent planning holder → exit 1 (never a co-win)"
+if grep -q -- "--remove-label $MINE" "$REMOVE_LOG"; then ok "losing re-plan claimant self-removed its planning label"; else bad "losing re-plan claimant did not self-remove (log: $(cat "$REMOVE_LOG"))"; fi
 
 echo "== cleanup --gh fourth pass: stale planning sweep over fleet:needs-plan =="
 NOW_EPOCH=$(date +%s)


### PR DESCRIPTION
## Summary
- Add a trailing `--replan` flag to `fleet-claim planning-claim`. It **skips the `## Plan`-comment dedup early-out** (a re-plan of a stale committed plan expects a prior plan) and instead gates on `fleet:needs-plan` being currently present — so a deliberate re-plan acquires the lex-min planning lock (exit 0) instead of being refused (exit 3). With the label absent it refuses (exit 2), so `--replan` can't grab a freshly-planned/queued issue nobody re-flagged.
- Plain `planning-claim` (no flag) is byte-for-byte unchanged: first-plan dedup still returns exit 3 on an existing `## Plan` comment.
- Document the worker re-plan contract in `docs/agents/PLANNING-PROTOCOL.md` (new "Re-planning a stale queued plan" section): flip `fleet:queued → fleet:needs-plan`, then `planning-claim <N> <agent> --replan` **before** any deep re-investigation, so two opus panes can't both re-derive the same stale plan (the #1999 collision: #1960 was re-derived by three panes).
- Tests T8–T10 in `test_fleet_claim_planning.sh` (acquire-bypassing-dedup, refuse-when-no-needs-plan, loser-yields-and-self-removes) + a gh-stub `--json labels` arm for the needs-plan probe.

## Test plan
- [x] `test_fleet_claim_planning.sh` passes (19/19, incl. new T8–T10); T1–T7 unchanged.
- [x] All 12 `test_fleet_claim_*.sh` suites green (no regression in acquire/blockers/model-gate/reconcile/steward/stackable).
- [x] `bash -n scripts/fleet/fleet-claim` clean.
- [x] CLI: plain `planning-claim 1960 x` → exit 3 (dedup); `planning-claim 1960 x --replan` → exit 2 (no needs-plan on #1960); unknown flag → exit 2; usage on missing args. Read-only, no live labels mutated.

## Notes for reviewer
- **Same-file, no stack:** #1998 also edits `scripts/fleet/fleet-claim` but in a disjoint function (`cmd_claim`'s host gate vs `cmd_planning_claim`). No dependency either way — whichever lands second rebases cleanly (worst case a one-line usage/`--help` conflict the merger resolves).
- **Gated follow-up (not in this PR):** the `role-worker.md` step-3/5 echo of this contract is gated self-config; the deterministic self-edit gate refuses any worker, so it's flagged for a human to apply. `PLANNING-PROTOCOL.md` is the worker-applicable half and is sufficient for the acceptance criteria.

Closes #1999

🤖 Generated with [Claude Code](https://claude.com/claude-code)