### PR TITLE
fleet: GL-vs-Metal host-capability gate for backend tasks

### DIFF
--- a/.fleet/plans/issue-1998.md
+++ b/.fleet/plans/issue-1998.md
@@ -1,0 +1,73 @@
+## Plan: fleet: GL-vs-Metal host-capability gate for backend-specific tasks
+
+- **Issue:** #1998
+- **Model:** opus
+- **Date:** 2026-06-25
+
+### Verified current state (source-checked)
+
+- **`fleet-claim` already has host detection** — `host_from_uname()` (`scripts/fleet/fleet-claim:207-225`) maps `uname -s` -> `mac | linux | windows | unknown`, and `derive_host()` (`:227-237`) wraps it with a `FLEET_TEST_HOST` override seam (test `tests/test_derive_host.sh`). The claim label is already host-stamped: `fleet:claim-${host}-${agent}` (`:860`). So host is known at claim time.
+- **The dispatcher and the scout have NO host detection.** Grepped `fleet-dispatcher` and `fleet-state-scout` for `uname|host|darwin|macos|FLEET_TEST_HOST` -- zero hits in the dispatch/projection paths. So the *churn-stopping* fix can't live only in `fleet-claim`.
+- **Backend<->host mapping is settled and one-directional** (`docs/agents/FLEET.md:414-425`, `FLEET-CROSS-HOST-SMOKE.md:3-7`): OpenGL `{linux, windows}` is one tier, Metal `{mac}` is the other. Shaders are `#version 450 core` -> **OpenGL 4.5 required**; macOS GL is 4.1, so a Metal host genuinely cannot build/run/verify the GL backend. => **GL-capable hosts = {linux, windows}; Metal-only = {mac}.**
+- **Why the churn happens (the real lever):** `project_worker()` (`fleet-state-scout:1245-1269`) is only the *trigger hash*. The actual "which task/class to dispatch" decision is `fleet_task_class.resolve()` -> `_candidates()` -> **`_task_claimable(task)`** (`scripts/fleet/fleet_task_class.py:62-73`), invoked by the dispatcher's `resolve_worker_class()` (`fleet-dispatcher:1008-1022`) as `python3 fleet_task_class.py <slice> <lane-default> <fable-blocked>`. This is the **same filter** #1726 used to skip `inflight_pr` tasks and go `defer` instead of churning. A GL-host gate belongs here.
+- **The slice carries full task dicts:** `slice_worker()` -> `_slice_task_with_repo()` does `dict(task)` (`fleet-state-scout:1672-1675, 1684-1703`), so any field added to the task in `fetch_task_queue()` flows straight into the dispatcher's slice (and into `state.json` `tasks.open[]`).
+- **Verified live churn:** `#1937` (epic #1933 C1, "analytic edge-aware coverage -- GL backend") is opus-tagged + `owner:free` + `blocked:false`, released 5+ times by mac panes. `#1726` is CLOSED and was a different scope (design-blocked-PR projection), per the issue NB -- confirmed; the GL-host gate was never filed before this.
+
+### Approach (single committed design)
+
+A **host-capability label** `fleet:needs-gl-host` is respected at two enforcement points -- the dispatcher's claimability filter (stops the *dispatch*, the load-bearing fix) and a `fleet-claim` backstop gate (catches manual/raced claims). The label is a **triage signal applied by the human/architect** (like the model labels), not auto-derived -- the scout cannot reliably infer "GL-only" from a render task.
+
+1. **Add the `fleet:needs-gl-host` label** (issue-scope, color `c5def5`). Per the `fleet-labels --check` drift guard, three files in one commit:
+   - `scripts/fleet/fleet-labels` -- add to the `LABELS=(...)` array near the smoke entries (~`:137`): `"fleet:needs-gl-host|c5def5|Task needs an OpenGL-4.5 host (Linux/Windows); macOS/Metal panes skip it"` (<=100-char desc).
+   - `docs/agents/fleet-state-machine.json` -- add a `labels[]` node `{"name":"fleet:needs-gl-host","scope":"issue","color":"c5def5","description":"<same <=100 desc>"}` (matches the `fleet:opus`/`fleet:blocked` issue-scope node shape at `:160-178`).
+   - `docs/agents/fleet-labels-reference.md` -- prose entry near the host-smoke section (~`:154`): who applies it (human triage), who respects it (dispatcher filter + claim gate), lifecycle.
+   - Run `fleet-labels --check` (must pass) then `fleet-labels` to sync both repos.
+
+2. **Scout annotation** -- `fleet-state-scout` `fetch_task_queue()` task dict (`:429-450`): add `"needs_gl_host": "fleet:needs-gl-host" in labels,` next to `"blocked"` (`:444`). Flows into the worker slice (`dict(task)`) and `state.json` `tasks.open[]`. No other scout change.
+
+3. **Dispatcher claimability filter (the fix)** -- `scripts/fleet/fleet_task_class.py`:
+   - Inline a tiny host helper (do **not** add a new imported shared module -- module resolution across the scout's `~/bin` symlink vs the dispatcher's `FLEET_LIB_DIR` is fragile, #1750/#1578; `fleet-claim`'s `host_from_uname` is bash and can't be imported): `_current_host()` = `os.environ.get("FLEET_TEST_HOST")` else `platform.system()` mapped (`Darwin->mac`, `Linux->linux`, `Windows->windows`, else `unknown`) -- mirror `fleet-claim:207-225` exactly, including the `FLEET_TEST_HOST` seam.
+   - `GL_CAPABLE_HOSTS = {"linux", "windows"}`.
+   - Thread host through: `resolve()` computes `host = _current_host()` once; `_candidates(slice, lane_default, host)`; `_task_claimable(task, host)` gains `... and not (task.get("needs_gl_host") and host not in GL_CAPABLE_HOSTS)`. (Fail-closed on `unknown` -- an unrecognized host shouldn't be trusted to run GL; the real dispatch host is always one of mac/linux/windows.)
+   - **Generalize the defer condition** so a host-incompatible task is *terminal* like `inflight_pr`: extend `_only_inflight_pr_tasks()` (rename to `_only_unclaimable_tasks(slice, host)`) to return True when every `tasks_open` item is `inflight_pr` **or** host-incompatible. This makes a mac slice whose only open task is GL-only return **`defer`** (go quiet -- no churn) instead of `''` (which falls through to a lane-default dispatch -> the claim->refuse->release churn we're killing). A plain `blocked`-but-GL-compatible task stays NON-terminal -> keeps the `''` stackable-tier fallthrough unchanged.
+
+4. **`fleet-claim` backstop gate** -- `check_host_capability()` mirroring `check_model_tag()` (`:589-656`): read labels via `fetch_issue_info` (already fetched), refuse when `fleet:needs-gl-host` present and `derive_host` not in `{linux, windows}`, with a host-capability diagnostic to stderr. Slot it in `cmd_claim` **immediately after the model-tag gate** (`:792-796`), before the reservation gate (`:798`). Runs unconditionally, so it also covers `--stackable-on` GL claims on a Metal host.
+
+5. **Tests** (mirror existing harnesses):
+   - `tests/test_fleet_task_class.py` -- GL-only task is skipped under `FLEET_TEST_HOST=mac` (alone -> `defer`; mixed with a claimable task -> that task is chosen, no defer); claimable under `linux`/`windows`.
+   - `tests/test_fleet_claim_host_gate.sh` (new, clone `test_fleet_claim_model_gate.sh`) -- `FLEET_TEST_HOST=mac` refuses a `fleet:needs-gl-host` claim (exit 1); `linux`/`windows` pass the host gate.
+   - `tests/test_worker_projection.py` -- assert `needs_gl_host` is present on the labeled task in the worker slice.
+
+### Affected files
+- `scripts/fleet/fleet-labels` -- catalog entry
+- `docs/agents/fleet-state-machine.json` -- label node (drift-guard parity)
+- `docs/agents/fleet-labels-reference.md` -- prose entry
+- `scripts/fleet/fleet-state-scout` -- `needs_gl_host` annotation in `fetch_task_queue` (~`:444`)
+- `scripts/fleet/fleet_task_class.py` -- inline host detection + `_task_claimable(task, host)` + defer generalization
+- `scripts/fleet/fleet-claim` -- `check_host_capability()` + gate slot after the model gate (~`:796`)
+- `scripts/fleet/tests/test_fleet_task_class.py`, `tests/test_fleet_claim_host_gate.sh` (new), `tests/test_worker_projection.py`
+
+### Consumer audit (label is *added*, nothing removed)
+`fleet:needs-gl-host` has exactly two respecters -- the dispatcher filter (#3) and the claim gate (#4) -- plus the scout annotation (#2) that feeds the filter. No existing consumer reads it; the new field on `tasks.open[]` is inert to every other projection (it's not in any role-trigger hash, so it adds no trigger churn -- same property #1726's `inflight_pr` relies on at `fleet-state-scout:1207-1209`).
+
+### How #1937 (and future GL tasks) get the label
+The label is a **human/architect triage signal**, applied like `human:approved`/model labels. The implementer must **not** edit #1937's labels (the worker out-of-scope rule forbids editing another issue's labels) -- instead, note for the human to stamp `fleet:needs-gl-host` on #1937 and the #1933 C-chain GL tasks once this lands. Verification uses the `FLEET_TEST_HOST` seam, not a live #1937 edit. Once #1937 carries the label, mac dispatchers go quiet on it and a Linux/Windows opus pane claims it; merging it unblocks #1938 (Metal port, mac-doable) / #1939 naturally -- **no special blocked-dependent handling is needed** (verified: dependents are correctly `blocked` and resolve when the parent merges on a GL host; the issue's part-2 "perpetually blocked" concern is a non-issue once routing works).
+
+### Acceptance criteria
+- `fleet-labels --check` passes with `fleet:needs-gl-host` present in `fleet-labels` **and** `fleet-state-machine.json`.
+- `fleet_task_class.resolve()` with `FLEET_TEST_HOST=mac`: a slice whose only open task carries `needs_gl_host` -> `defer`; same slice with `FLEET_TEST_HOST=linux` -> `opus <effort> ...`.
+- Mixed mac slice (GL-only #1937-shaped + a claimable opus task) -> dispatches the claimable task (no defer, no churn).
+- `FLEET_TEST_HOST=mac fleet-claim claim <gl-labeled-issue> worker-N` -> refused (exit 1) with a host-capability message; `FLEET_TEST_HOST=linux`/`windows` pass the host gate.
+- `needs_gl_host` appears on the labeled task in the worker slice + `state.json` `tasks.open[]`.
+- **No edit to any `.claude/commands/role-*.md` or other gated self-config is required** for the fix to take effect (enforcement is entirely in scripts + label catalog).
+
+### Gotchas
+- **Drift guard:** the label name must appear in BOTH the `fleet-labels` catalog and `fleet-state-machine.json`, or `fleet-labels --check` fails -- update both + the reference doc in the same commit. Description <=100 chars (GitHub hard limit).
+- **No new shared Python module** for host detection -- inline the mapping in `fleet_task_class.py` (#1750/#1578 module-resolution fragility). The bash side reuses `derive_host`.
+- **Defer, not `''`:** if the host-only slice returns `''` instead of `defer`, the dispatcher's lane-default fallthrough still fires a no-op dispatch -- the churn isn't fixed. The `_only_unclaimable_tasks` generalization is load-bearing.
+- **No GL host online => correct wait, not loss:** if no Linux/Windows pane is up, GL tasks stop churning and simply wait for a GL pane -- intended behavior, not a regression (a Metal-only host truly cannot do GL work).
+- **`unknown` host is fail-closed** (GL tasks skipped) -- document the choice; real dispatch hosts are always mac/linux/windows.
+- This is the GL-backend case only. The OS-pin generalization the body mentions parenthetically (`host:linux` for the game #202 Linux-only **package** smoke) and any ingest-stamp-from-`**Host:**`-body-field auto-application are **deferred** -- the same capability mechanism extends to them, but #202 isn't churning and shouldn't expand this PR. File as follow-ups if wanted.
+
+### One task or subtasks?
+**One task.** Five coordinated edits across tightly-coupled files (label + its two respecters + scout annotation + tests), one PR's worth. No epic decomposition.

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -199,6 +199,19 @@ Specifically, **never pass these via `--label` when filing**:
   **smoking agent** on a successful smoke run (Windows: a native-Windows
   smoke worker, or `platform-catchup` as fallback). Permanent audit trail;
   not used by the merge gate. Don't add to issues.
+- `fleet:needs-gl-host` — **issue/task** label marking a backend-specific
+  task that needs an OpenGL-4.5 host (`{linux, windows}`). macOS GL is 4.1, so
+  a Metal-only pane genuinely cannot build/run/verify the GL backend.
+  **Applied by the human/architect** as a triage signal (like the model
+  labels) — the scout can't reliably infer "GL-only" from a render task, so
+  it is never auto-derived. **Respected at two points:** the dispatcher's
+  claimability filter (`fleet_task_class.py`) skips the task on a macOS pane
+  (a slice whose only open task is GL-only → `defer`, no churn), and a
+  `fleet-claim claim` backstop gate refuses a GL-only claim from a non-GL
+  host (covers manual / raced / `--stackable-on` claims). No host online to
+  run it just means the task waits for a Linux/Windows pane — the correct
+  behavior, not a loss. Once the GL task merges on a GL host, its blocked
+  dependents resolve normally.
 - `fleet:in-progress` — generic "a worker has claimed this issue"
   marker. Today this is mostly superseded by the dynamic per-host
   `fleet:claim-<host>-<agent>` issue label (see below); the static

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -231,6 +231,12 @@
       "description": "Set by the native-Windows smoke worker (or platform-catchup) on a successful Windows smoke run; permanent audit trail, not used by merge gate. Don't add to issues."
     },
     {
+      "name": "fleet:needs-gl-host",
+      "scope": "issue",
+      "color": "c5def5",
+      "description": "Task needs an OpenGL-4.5 host (Linux/Windows); macOS/Metal panes skip it (dispatcher filter + claim gate). Human/architect triage signal."
+    },
+    {
       "name": "fleet:stacked",
       "scope": "pr",
       "color": "c5def5",

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -660,6 +660,49 @@ PYEOF
     return 0
 }
 
+# --- host-capability gate -------------------------------------------------
+
+check_host_capability() {
+    # Refuse the claim if the issue requires an OpenGL-4.5 host (label
+    # `fleet:needs-gl-host`) and this machine is not GL-capable. GL-capable
+    # hosts are {linux, windows}; macOS GL is 4.1 (< the shaders' required
+    # 4.5), so a Metal host cannot build/run/verify the GL backend. Mirrors
+    # check_model_tag: read the issue's labels, soft no-op when gh is
+    # unavailable or the issue can't be fetched.
+    #
+    # The dispatcher's claimability filter (fleet_task_class.py) is the
+    # load-bearing fix that stops the GL-on-Metal *dispatch*; this is the
+    # backstop for a manual or raced claim, and it runs unconditionally so it
+    # also covers --stackable-on GL claims. Fail-closed on an unrecognized
+    # host (refuse) — a real dispatch host is always mac/linux/windows.
+    local issue_num="$1"
+
+    local info
+    info=$(fetch_issue_info "$issue_num") || true
+    [[ -z "$info" ]] && return 0
+
+    local labels=""
+    while IFS=$'\t' read -r key value; do
+        case "$key" in
+            labels) labels="$value" ;;
+        esac
+    done <<< "$info"
+
+    case " $labels " in
+        *" fleet:needs-gl-host "*) ;;
+        *) return 0 ;;
+    esac
+
+    local host
+    host=$(derive_host)
+    case "$host" in
+        linux|windows) return 0 ;;
+    esac
+
+    echo "fleet-claim: refuse #${issue_num} — tagged [fleet:needs-gl-host], this host is [${host}]; needs an OpenGL-4.5 host (linux/windows)" >&2
+    return 1
+}
+
 # --- subcommands ----------------------------------------------------------
 
 cmd_claim() {
@@ -797,6 +840,12 @@ sys.stdout.write(unsafe_base_reason(labels, files) or "")
     # Model-tag gate: refuse when FLEET_ROLE_MODEL is set and doesn't
     # match the issue's model labels / body field.
     if ! check_model_tag "$issue_num"; then
+        return 1
+    fi
+
+    # Host-capability gate: refuse a fleet:needs-gl-host claim from a
+    # Metal-only (macOS) host — it can't build/run/verify the GL backend.
+    if ! check_host_capability "$issue_num"; then
         return 1
     fi
 

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -135,6 +135,7 @@ LABELS=(
     "fleet:verified-linux|0e8a16|Smoking agent set this on a successful Linux smoke run; audit trail, not a merge gate"
     "fleet:verified-macos|0e8a16|Smoking agent set this on a successful macOS smoke run; audit trail, not a merge gate"
     "fleet:verified-windows|0e8a16|Windows smoke worker or platform-catchup set this on a successful Windows smoke; audit trail"
+    "fleet:needs-gl-host|c5def5|Task needs an OpenGL-4.5 host (Linux/Windows); macOS/Metal panes skip it"
     "fleet:stacked|c5def5|PR's base is a feature branch (stacked PR)"
     "fleet:awaiting-base|c5def5|Stacked PR; merger is waiting for base PR to merge"
     "fleet:needs-base-update|fbca04|Stacked child PR; upstream force-pushed and cascade-rebase conflicted; author rebases manually"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -465,6 +465,12 @@ def fetch_task_queue(repo_slug):
             # projection can drive fleet:blocked removal once the blocker closes
             # (see _ingest_unblock_candidates).
             "blocked": "fleet:blocked" in labels,
+            # #1998: `fleet:needs-gl-host` marks a backend-specific task that
+            # needs an OpenGL-4.5 host (linux/windows); macOS/Metal panes can't
+            # build/run/verify it. Surfaced here so the dispatcher's claimability
+            # filter (fleet_task_class.py) skips it on a Metal host instead of
+            # churning claim->refuse->release no-ops.
+            "needs_gl_host": "fleet:needs-gl-host" in labels,
             "issue": task_id,
             # `**Part of epic:** #U` back-ref (raw field value, e.g. "#1661").
             # The epic-steward adoption projection joins this against open

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -28,10 +28,11 @@ else the class default below.
 The fable concurrency cap is enforced here by *skipping* fable items when
 the cap is reached — the lane then serves its next non-fable item instead
 of idling. When the only work left is non-actionable — cap-blocked fable,
-or tasks already covered by an open implementation PR (``inflight_pr``,
-#1726) — the verdict is ``defer`` (keep the trigger, dispatch nothing)
-rather than an empty result, so the dispatcher doesn't burn an iteration
-on a lane whose only work a fresh worker would refuse.
+tasks already covered by an open implementation PR (``inflight_pr``, #1726),
+or backend-specific tasks this host can't run (``needs_gl_host`` on a
+Metal-only host, #1998) — the verdict is ``defer`` (keep the trigger,
+dispatch nothing) rather than an empty result, so the dispatcher doesn't
+burn an iteration on a lane whose only work a fresh worker would refuse.
 
 Output protocol (one line on stdout, consumed by fleet-dispatcher):
 
@@ -40,9 +41,10 @@ Output protocol (one line on stdout, consumed by fleet-dispatcher):
                                   remain (keep the trigger so the next tick
                                   serves them), else 0.
   ``defer``                     — queue isn't empty but nothing is claimable
-                                  right now (only cap-blocked fable, or tasks
-                                  with an open implementation PR). Keep the
-                                  trigger; dispatch nothing.
+                                  right now (only cap-blocked fable, tasks with
+                                  an open implementation PR, or GL-only tasks on
+                                  a non-GL host). Keep the trigger; dispatch
+                                  nothing.
   (empty)                       — nothing class-routable in the slice; the
                                   dispatcher falls back to the lane default
                                   (this path covers reservation resumes and
@@ -50,6 +52,8 @@ Output protocol (one line on stdout, consumed by fleet-dispatcher):
 """
 
 import json
+import os
+import platform
 import sys
 
 CLASS_DEFAULT_EFFORT = {"fable": "xhigh", "opus": "xhigh", "sonnet": "high"}
@@ -58,33 +62,72 @@ CLASS_DEFAULT_EFFORT = {"fable": "xhigh", "opus": "xhigh", "sonnet": "high"}
 # feedback (fleet:has-nits) stays sonnet.
 FEEDBACK_BLOCKING_LABELS = {"human:needs-fix", "human:blocker", "fleet:needs-fix"}
 
+# Hosts that can build/run/verify the OpenGL backend. macOS GL is 4.1 < the
+# shaders' required 4.5, so a Metal-only host genuinely cannot do GL work; a
+# `fleet:needs-gl-host` task (scout field `needs_gl_host`) is unclaimable there
+# and dispatching to it is a guaranteed no-op (#1998).
+GL_CAPABLE_HOSTS = {"linux", "windows"}
 
-def _task_claimable(task):
+
+def _current_host():
+    # Canonical host key (mac | linux | windows | unknown), mirroring
+    # fleet-claim's host_from_uname/derive_host: the FLEET_TEST_HOST seam plus
+    # the same uname mapping (MINGW*/MSYS*/CYGWIN*/Windows* all = windows).
+    # Inlined rather than imported — module resolution across the scout's ~/bin
+    # symlink vs the dispatcher's FLEET_LIB_DIR is fragile (#1750/#1578), and
+    # fleet-claim's mapping is bash. Fail-closed: an unrecognized host is
+    # "unknown" (treated as not GL-capable); real dispatch hosts are always
+    # mac/linux/windows.
+    override = os.environ.get("FLEET_TEST_HOST")
+    if override:
+        return override
+    sysname = platform.system()
+    if sysname == "Darwin":
+        return "mac"
+    if sysname == "Linux":
+        return "linux"
+    if sysname.startswith(("Windows", "MINGW", "MSYS", "CYGWIN")):
+        return "windows"
+    return "unknown"
+
+
+def _host_incompatible(task, host):
+    # A `needs_gl_host` task on a non-GL host (macOS/Metal, or unknown) can
+    # never be built/run/verified here — terminally unclaimable, like inflight.
+    return bool(task.get("needs_gl_host")) and host not in GL_CAPABLE_HOSTS
+
+
+def _task_claimable(task, host):
     # `inflight_pr` (set by the scout) means an open PR already implements this
     # issue — parked on a design question or otherwise in flight — so a fresh
     # worker can't start it off the queue. Skipping it here stops the dispatcher
     # churning no-op iterations on a head-of-queue task every candidate refuses,
     # which was starving lower-class work queued behind it (#1726, the #1640 /
-    # design-blocked PR #1700 incident).
+    # design-blocked PR #1700 incident). The `needs_gl_host` clause does the
+    # same for backend-specific tasks a Metal-only host can't run (#1998).
     return (
         task.get("owner") in (None, "", "free")
         and not task.get("blocked")
         and not task.get("inflight_pr")
+        and not _host_incompatible(task, host)
     )
 
 
-def _only_inflight_pr_tasks(slice_data):
-    """True when tasks_open is non-empty and EVERY item is non-actionable
-    solely because an open PR already implements it (`inflight_pr`).
+def _only_unclaimable_tasks(slice_data, host):
+    """True when tasks_open is non-empty and EVERY item is non-actionable for a
+    *terminal* reason — an open PR already implements it (`inflight_pr`) or this
+    host can't build/run/verify it (`needs_gl_host` on a non-GL host, #1998).
 
     Used to pick 'go quiet' (defer) over the lane-default dispatch fallthrough:
     in this shape a fresh worker can claim nothing, so a dispatch is a no-op.
-    Requiring *all* items to be inflight keeps a mixed slice (an inflight head
-    plus a stackable `blocked` task behind it) on the '' fallthrough so the
-    worker's stackable tier still gets its dispatch.
+    Requiring *all* items to be terminally-unclaimable keeps a mixed slice (a
+    terminal head plus a stackable `blocked` but host-compatible task behind it)
+    on the '' fallthrough so the worker's stackable tier still gets its dispatch.
     """
     tasks = slice_data.get("tasks_open") or []
-    return bool(tasks) and all(t.get("inflight_pr") for t in tasks)
+    return bool(tasks) and all(
+        t.get("inflight_pr") or _host_incompatible(t, host) for t in tasks
+    )
 
 
 def feedback_pr_class(labels):
@@ -110,7 +153,7 @@ def feedback_pr_class(labels):
     return "sonnet"
 
 
-def _candidates(slice_data, lane_default):
+def _candidates(slice_data, lane_default, host):
     """Yield (class, effort) for each actionable item, pickup-priority order.
 
     Feedback PRs come first regardless of count — mirrors the worker role
@@ -120,7 +163,7 @@ def _candidates(slice_data, lane_default):
         cls = feedback_pr_class(pr.get("labels", []))
         yield cls, CLASS_DEFAULT_EFFORT[cls]
     for task in slice_data.get("tasks_open", []) or []:
-        if not _task_claimable(task):
+        if not _task_claimable(task, host):
             continue
         cls = (task.get("model") or lane_default).lower()
         if cls not in CLASS_DEFAULT_EFFORT:
@@ -135,10 +178,11 @@ def resolve(slice_data, lane_default, fable_blocked):
     """Return 'cls effort more', 'defer', or '' per the output protocol."""
     if lane_default not in CLASS_DEFAULT_EFFORT:
         lane_default = "opus"
+    host = _current_host()
     chosen = None
     skipped_fable = False
     servable_classes = set()
-    for cls, effort in _candidates(slice_data, lane_default):
+    for cls, effort in _candidates(slice_data, lane_default, host):
         if cls == "fable" and fable_blocked:
             # Cap-blocked fable is not currently servable: don't let it
             # hold the trigger open via `more` (that would re-dispatch
@@ -161,11 +205,11 @@ def resolve(slice_data, lane_default, fable_blocked):
     # `inflight_pr`), a lane-default dispatch is a guaranteed no-op — a fresh
     # worker refuses every one on sight — so the lane goes quiet (defer) instead
     # of churning that no-op every tick (#1726). Any other shape (a claimable
-    # task would have been chosen above; a plain `blocked` task may still be
-    # stackable; an owned task, an empty/missing slice) returns '' so the
-    # dispatcher's lane-default fallthrough keeps covering the stackable tier,
-    # reservation resumes, and missing slices.
-    if _only_inflight_pr_tasks(slice_data):
+    # task would have been chosen above; a plain `blocked` host-compatible task
+    # may still be stackable; an owned task, an empty/missing slice) returns ''
+    # so the dispatcher's lane-default fallthrough keeps covering the stackable
+    # tier, reservation resumes, and missing slices.
+    if _only_unclaimable_tasks(slice_data, host):
         return "defer"
     return ""
 

--- a/scripts/fleet/tests/test_fleet_claim_host_gate.sh
+++ b/scripts/fleet/tests/test_fleet_claim_host_gate.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Tests for fleet-claim's check_host_capability gate (issue-based, #1998).
+#
+# The gate refuses a `fleet:needs-gl-host` claim from a host that can't run
+# the OpenGL backend. GL-capable hosts are {linux, windows}; macOS GL is 4.1
+# (< the shaders' required 4.5), so a Metal host genuinely cannot build/run/
+# verify the GL backend. Host is resolved via derive_host (FLEET_TEST_HOST
+# seam); the label comes from `gh issue view`, stubbed here so the gate runs
+# without a live GitHub round-trip. The gate is the claim-side backstop for
+# the dispatcher's claimability filter (fleet_task_class.py).
+#
+# Covers:
+#   - mac host refuses a fleet:needs-gl-host claim (exit 1)
+#   - linux host passes the host gate (claim succeeds, exit 0)
+#   - windows host passes the host gate (claim succeeds, exit 0)
+#   - unknown host is fail-closed → refused (exit 1)
+#   - issue without the label passes on a mac host (gate is opt-in, exit 0)
+#   - gh failure soft-degrades to pass (exit 0)
+
+set -euo pipefail
+
+# This suite exercises cmd_claim against the real (possibly-stale) main clone but
+# does not care about clone freshness — disable the #1810 freshness gate.
+export FLEET_SKIP_CLONE_FRESHNESS=1
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_exit() {
+    local actual_exit="$1" expected_exit="$2" msg="$3"
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected exit: $expected_exit"
+        echo "        actual exit:   $actual_exit"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR"
+
+# Stub `gh` so check_host_capability reads canned JSON instead of hitting
+# GitHub. Dispatches on the issue number passed via `gh issue view <N>`.
+#   2001 — carries fleet:needs-gl-host (GL-only task)
+#   2002 — no host label (gate is opt-in)
+#   2003 — gh failure (soft-degrade contract)
+# The `api` arm emulates the cross-host fleet:claim-* lock acquire so a
+# gate-passing claim runs through to success (echo the requested label back
+# as the lex-min winner). All issues carry fleet:opus so a stray ambient
+# FLEET_ROLE_MODEL=opus still passes the model gate ahead of the host gate.
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+
+cat >"$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+    "issue view")
+        issue_num="$3"
+        case "$issue_num" in
+            2001)
+                echo '{"state":"OPEN","labels":[{"name":"fleet:needs-gl-host"},{"name":"fleet:opus"},{"name":"fleet:queued"}],"body":""}'
+                ;;
+            2002)
+                echo '{"state":"OPEN","labels":[{"name":"fleet:opus"},{"name":"fleet:queued"}],"body":""}'
+                ;;
+            2003)
+                exit 1
+                ;;
+            *)
+                echo '{"state":"OPEN","labels":[],"body":""}'
+                ;;
+        esac
+        exit 0
+        ;;
+    "api "*)
+        # gh api repos/.../issues/<N>/labels --method POST -f "labels[]=X" →
+        # echo the requested label back as a single-element JSON array so the
+        # lex-min winner is us.
+        label=""
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -f) shift
+                    case "$1" in
+                        labels\[\]=*) label="${1#labels[]=}" ;;
+                    esac
+                    ;;
+            esac
+            shift || true
+        done
+        if [[ -n "$label" ]]; then
+            printf '[{"name":"%s"}]\n' "$label"
+        else
+            echo '[]'
+        fi
+        exit 0
+        ;;
+    "issue edit"|"label "*|"pr "*)
+        exit 0
+        ;;
+esac
+exit 0
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+
+export PATH="$STUB_DIR:$PATH"
+
+release_quiet() {
+    "$FLEET_CLAIM" release "$1" >/dev/null 2>&1 || true
+}
+
+# --- T1: mac host refuses a fleet:needs-gl-host claim ------------------------
+echo "T1: mac host refuses fleet:needs-gl-host claim"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "mac + fleet:needs-gl-host → exit 1"
+release_quiet 2001
+
+# --- T2: linux host passes the host gate ------------------------------------
+echo "T2: linux host passes the host gate (claim succeeds)"
+actual=0; FLEET_TEST_HOST=linux FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "linux + fleet:needs-gl-host → exit 0"
+release_quiet 2001
+
+# --- T3: windows host passes the host gate ----------------------------------
+echo "T3: windows host passes the host gate (claim succeeds)"
+actual=0; FLEET_TEST_HOST=windows FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "windows + fleet:needs-gl-host → exit 0"
+release_quiet 2001
+
+# --- T4: unknown host is fail-closed ----------------------------------------
+echo "T4: unknown host is fail-closed (refused)"
+actual=0; FLEET_TEST_HOST=unknown FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" claim 2001 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 1 "unknown host + fleet:needs-gl-host → exit 1"
+release_quiet 2001
+
+# --- T5: issue without the label passes on a mac host (gate opt-in) ---------
+echo "T5: mac host passes an issue without fleet:needs-gl-host"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" claim 2002 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "mac + no host label → exit 0 (opt-in)"
+release_quiet 2002
+
+# --- T6: gh failure soft-degrades to pass -----------------------------------
+echo "T6: gh failure soft-degrades to pass"
+actual=0; FLEET_TEST_HOST=mac FLEET_ROLE_MODEL=opus "$FLEET_CLAIM" claim 2003 test-agent 2>/dev/null || actual=$?
+assert_exit "$actual" 0 "gh failure → soft-pass exit 0"
+release_quiet 2003
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -13,10 +13,14 @@ that matter:
     lane, and yields ``defer`` (keep trigger, dispatch nothing) when ONLY
     cap-blocked fable work remains — an empty result would dispatch the
     lane default, which the claim gate then refuses, burning an iteration;
+  - a GL-only task (``needs_gl_host``) is unclaimable on a Metal-only host —
+    skipped like ``inflight_pr``, and the lane defers when it's the only
+    work (#1998, the GL-vs-Metal host-capability gate);
   - per-task **Effort:** overrides beat class defaults;
   - an empty/unroutable slice falls through to the lane default (covers
     reservation resumes and missing slices).
 """
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -26,9 +30,10 @@ from fleet_task_class import resolve, feedback_pr_class  # noqa: E402
 
 
 def _task(issue, model=None, effort=None, owner="free", blocked=False,
-          inflight_pr=None):
+          inflight_pr=None, needs_gl_host=False):
     return {"issue": issue, "model": model, "effort": effort,
-            "owner": owner, "blocked": blocked, "inflight_pr": inflight_pr}
+            "owner": owner, "blocked": blocked, "inflight_pr": inflight_pr,
+            "needs_gl_host": needs_gl_host}
 
 
 class FeedbackClassFromLabels(unittest.TestCase):
@@ -178,6 +183,81 @@ class EmptySlice(unittest.TestCase):
         self.assertEqual(resolve({}, "opus", fable_blocked=False), "")
         self.assertEqual(resolve({"tasks_open": [], "feedback_prs": []},
                                  "sonnet", fable_blocked=False), "")
+
+
+class GlHostGate(unittest.TestCase):
+    """#1998: a `needs_gl_host` task can't be built/run/verified on a
+    Metal-only (macOS) host. The dispatcher's claimability filter skips it
+    there — so a mac slice whose only open work is GL-only defers (goes
+    quiet) instead of churning a lane-default no-op, while a Linux/Windows
+    slice claims it normally. Host comes from `_current_host()`, driven here
+    via the FLEET_TEST_HOST seam (same seam fleet-claim's derive_host uses)."""
+
+    def setUp(self):
+        self._saved_host = os.environ.get("FLEET_TEST_HOST")
+
+    def tearDown(self):
+        if self._saved_host is None:
+            os.environ.pop("FLEET_TEST_HOST", None)
+        else:
+            os.environ["FLEET_TEST_HOST"] = self._saved_host
+
+    def _resolve_on(self, host, slice_data, fable_blocked=False):
+        os.environ["FLEET_TEST_HOST"] = host
+        return resolve(slice_data, "opus", fable_blocked=fable_blocked)
+
+    def test_gl_only_task_alone_on_mac_defers(self):
+        # The #1937 churn shape: a GL-backend task is the only open work and
+        # the pane is Metal-only -> defer (go quiet), not a lane-default no-op.
+        out = self._resolve_on(
+            "mac", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
+        self.assertEqual(out, "defer")
+
+    def test_gl_only_task_claimable_on_linux(self):
+        out = self._resolve_on(
+            "linux", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
+        self.assertEqual(out, "opus xhigh 0")
+
+    def test_gl_only_task_claimable_on_windows(self):
+        out = self._resolve_on(
+            "windows", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
+        self.assertEqual(out, "opus xhigh 0")
+
+    def test_mixed_mac_slice_dispatches_claimable_no_churn(self):
+        # GL-only #1937-shaped head + a claimable opus task: the mac pane skips
+        # the GL task (not counted toward `more`) and dispatches the claimable
+        # one — no defer, no churn.
+        out = self._resolve_on("mac", {"tasks_open": [
+            _task("#1937", "opus", needs_gl_host=True),
+            _task("#1998", "opus"),
+        ]})
+        self.assertEqual(out, "opus xhigh 0")
+
+    def test_gl_only_plus_inflight_only_on_mac_defers(self):
+        # All-terminal mix on a mac pane: one GL-only (host-terminal) + one
+        # inflight (PR-terminal). Nothing claimable -> defer.
+        out = self._resolve_on("mac", {"tasks_open": [
+            _task("#1937", "opus", needs_gl_host=True),
+            _task("#1640", "opus", inflight_pr={"number": 1700}),
+        ]})
+        self.assertEqual(out, "defer")
+
+    def test_gl_only_head_with_blocked_compatible_falls_through(self):
+        # GL-only head (host-terminal on mac) + a plain `blocked` but
+        # host-compatible task that may still be stackable -> '' so the
+        # worker's stackable tier still gets its lane-default dispatch.
+        out = self._resolve_on("mac", {"tasks_open": [
+            _task("#1937", "opus", needs_gl_host=True),
+            _task("#1941", "opus", blocked=True),
+        ]})
+        self.assertEqual(out, "")
+
+    def test_unknown_host_is_fail_closed(self):
+        # Fail-closed: an unrecognized host is treated as not GL-capable, so a
+        # GL-only task is skipped (real dispatch hosts are always mac/linux/win).
+        out = self._resolve_on(
+            "unknown", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
+        self.assertEqual(out, "defer")
 
 
 if __name__ == "__main__":

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -371,5 +371,39 @@ class PlanReviewExcludedFromTasksOpen(unittest.TestCase):
         self.assertEqual(result["open"][0]["id"], "#55")
 
 
+class NeedsGlHostAnnotation(unittest.TestCase):
+    """fetch_task_queue stamps each task with needs_gl_host (#1998) so the
+    dispatcher's claimability filter (fleet_task_class.py) can skip GL-only
+    tasks on a Metal-only host. The flag flows into the worker slice via
+    dict(task) and into state.json tasks.open[]."""
+
+    def _fetch(self, issues_list):
+        payload = json.dumps(issues_list)
+        with patch.object(_mod, "run_capture", return_value=payload):
+            return _mod.fetch_task_queue("jakildev/IrredenEngine")
+
+    def _issue(self, number, extra_labels=()):
+        return {
+            "number": number,
+            "title": f"task #{number}",
+            "labels": [
+                {"name": "fleet:queued"},
+                {"name": "fleet:opus"},
+                {"name": "human:approved"},
+            ] + [{"name": l} for l in extra_labels],
+            "body": "**Model:** opus\n",
+        }
+
+    def test_needs_gl_host_true_when_labeled(self):
+        result = self._fetch([self._issue(1937, extra_labels=["fleet:needs-gl-host"])])
+        self.assertEqual(len(result["open"]), 1)
+        self.assertTrue(result["open"][0]["needs_gl_host"])
+
+    def test_needs_gl_host_false_when_absent(self):
+        result = self._fetch([self._issue(1998)])
+        self.assertEqual(len(result["open"]), 1)
+        self.assertFalse(result["open"][0]["needs_gl_host"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds `fleet:needs-gl-host` (issue-scope label) — a human/architect triage signal for tasks needing an OpenGL-4.5 host (Linux/Windows); macOS/Metal panes can't build/run/verify the GL backend.
- **Dispatcher claimability filter** (`fleet_task_class.py`) — the load-bearing churn fix: a mac slice whose only open task is GL-only now `defer`s (goes quiet) instead of falling through to a lane-default no-op dispatch. Generalizes `_only_inflight_pr_tasks` → `_only_unclaimable_tasks` (terminal = inflight **or** host-incompatible).
- **`fleet-claim` backstop gate** (`check_host_capability`) — refuses a GL-only claim from a non-GL host; slotted right after the model-tag gate so it also covers `--stackable-on` claims. Fail-closed on an unknown host.
- **Scout annotation** — `fetch_task_queue` stamps each task `needs_gl_host`; flows into the worker slice (`dict(task)`) and `state.json` `tasks.open[]`.
- Label-catalog parity (drift-guard): `fleet-labels` + `docs/agents/fleet-state-machine.json` + `docs/agents/fleet-labels-reference.md`.

## Test plan
- [x] `test_fleet_task_class.py` — **27 pass** (+7 GL-host cases: GL-only-alone → `defer` on mac; claimable on linux/windows; mixed slice dispatches the claimable task with no churn; all-terminal (GL + inflight) → `defer`; GL head + blocked-compatible → `''` fallthrough; unknown host → fail-closed).
- [x] `test_worker_projection.py` — **32 pass** (+2: `needs_gl_host` stamped true when labeled / false when absent).
- [ ] `test_fleet_claim_host_gate.sh` — **new**; structurally mirrors the known-good `test_fleet_claim_model_gate.sh`. **Not run locally** — bash-script execution is sandbox-gated on this native-Windows host (same host constraint that jams the build, #2027). Runs in CI / on a Linux fleet host.
- [x] `fleet-labels --check`: catalog↔state-machine drift is **empty** (verified independently — 55 labels each, `fleet:needs-gl-host` present in both). The `--check` wrapper itself reports a false full-set diff on this MSYS2 host (a `comm`/locale collation issue); it passes on Linux.

## Notes for reviewer
- **Follow-up (human triage):** stamp `fleet:needs-gl-host` on #1937 and the #1933 C-chain GL tasks once this lands. The worker out-of-scope rule forbids editing another issue's labels, so this PR applies the label to no live issue — verification uses the `FLEET_TEST_HOST` seam, not a live `#1937` edit.
- **Label sync deferred:** `fleet-up` auto-runs `fleet-labels` on startup, so the new label syncs to GitHub once this merges — deliberately not created pre-merge from the feature branch (avoids an orphan if review renames it).
- Host detection in `fleet_task_class.py` is **inlined** (not a shared import) per the plan — module resolution across the scout's `~/bin` symlink vs the dispatcher's `FLEET_LIB_DIR` is fragile (#1750/#1578); it mirrors `fleet-claim`'s `host_from_uname`/`derive_host`, including the `FLEET_TEST_HOST` seam, and is fail-closed on `unknown`.
- No gated self-config (`.claude/commands/role-*.md`) edit required — enforcement is entirely in scripts + the label catalog.

Closes #1998

🤖 Generated with [Claude Code](https://claude.com/claude-code)