### PR TITLE
fleet: usage gate honors future resetsAt over stale observed_at

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -251,10 +251,15 @@ LAST_DISPATCH_EPOCH=0
 #      five_hour=0.80; everything else falls to the global default)
 #   4. Final fallback 0.80
 #
-# Conservative against staleness: an observation older than
-# USAGE_STALE_SECONDS (default 1h) or whose resetsAt + RESET_GRACE_SECONDS
-# is in the past is ignored, so the gate doesn't latch closed forever
-# after a single high-watermark reading.
+# Conservative against staleness, but resetsAt is authoritative: an
+# observation whose resetsAt + RESET_GRACE_SECONDS is in the past is
+# ignored (window closed). A future resetsAt keeps the observation live
+# no matter how old observed_at is — utilization can't fall below the
+# wall until the window resets, so an old-but-still-bound reading must
+# keep the gate closed. The USAGE_STALE_SECONDS cutoff (default 1h)
+# only applies when resetsAt is absent/unparseable, so an orphaned
+# latch still ages out. (Earlier the stale cutoff ran first and blinded
+# the gate ~4h into a 5h window, re-triggering a worker into the wall.)
 #
 # RESET_GRACE_SECONDS pads the resetsAt boundary so the gate doesn't flip
 # open on the exact second the latched window expires. Anthropic's rolling
@@ -793,22 +798,42 @@ for path in sorted(usage_dir.glob("*.json")):
     util = data.get("utilization")
     if not isinstance(util, (int, float)):
         continue
-    observed_at = data.get("observed_at")
-    if isinstance(observed_at, (int, float)) and now - int(observed_at) > stale_s:
-        continue
     resets_at = data.get("resetsAt")
     # rate_limit_info ships resetsAt as either an ISO-8601 string or a
     # Unix epoch int/float depending on CLI version — handle both.
+    # resets_known: we parsed a reset boundary. window_open: that
+    # boundary (plus grace) is still in the future.
+    resets_known = False
+    window_open = False
     if isinstance(resets_at, str):
         try:
             # datetime.fromisoformat accepts +00:00 but not Z until 3.11.
             dt = datetime.fromisoformat(resets_at.replace("Z", "+00:00"))
-            if dt.timestamp() + reset_grace_s <= now:
-                continue
+            resets_known = True
+            window_open = dt.timestamp() + reset_grace_s > now
         except ValueError:
             pass
     elif isinstance(resets_at, (int, float)):
-        if resets_at + reset_grace_s <= now:
+        resets_known = True
+        window_open = resets_at + reset_grace_s > now
+
+    # A known reset boundary is authoritative: skip iff the window has
+    # already closed (resetsAt + grace passed); keep it otherwise no
+    # matter how old observed_at is. Utilization can't fall below the
+    # wall until the window resets, so an old observation with a future
+    # resetsAt is still live — discarding it on the observed_at
+    # staleness cutoff blinds the gate for the (window - stale) gap and
+    # lets a worker re-trigger straight into the wall. The 5h window is
+    # ~5x the 1h stale default, so that gap was ~4h wide. Only when
+    # resetsAt is absent/unparseable do we fall back to the observed_at
+    # cutoff so an orphaned latch (process that never refreshed) still
+    # ages out.
+    if resets_known:
+        if not window_open:
+            continue
+    else:
+        observed_at = data.get("observed_at")
+        if isinstance(observed_at, (int, float)) and now - int(observed_at) > stale_s:
             continue
     util_f = float(util)
     # Utilization comes back in [0,1]. Be defensive against a future

--- a/scripts/fleet/tests/test_dispatcher_usage_gate.sh
+++ b/scripts/fleet/tests/test_dispatcher_usage_gate.sh
@@ -5,7 +5,8 @@
 #   - empty usage dir => gate open
 #   - utilization >= threshold + fresh + future reset => gate closed
 #   - threshold override via env var (FLEET_DISPATCHER_USAGE_GATE)
-#   - stale observation (older than USAGE_STALE_SECONDS) => ignored
+#   - stale observation (older than USAGE_STALE_SECONDS) w/o resetsAt => ignored
+#   - stale observation but future resetsAt => still closed (window authoritative)
 #   - resetsAt well in the past (past grace) => observation ignored
 #   - resetsAt recently in the past, within RESET_GRACE_SECONDS => still active
 #   - RESET_GRACE_SECONDS=0 reverts to instant open at resetsAt
@@ -51,6 +52,17 @@ TMPROOT=$(mktemp -d)
 export FLEET_STATE_DIR="$TMPROOT/state"
 mkdir -p "$FLEET_STATE_DIR/usage"
 
+# Isolate from the operator's ~/.fleet/fleet-up.conf — the dispatcher sources
+# it on startup, so a host that sets e.g. FLEET_DISPATCHER_USAGE_GATE_FIVE_HOUR
+# would clobber the thresholds these cases assert (per-type beats the global
+# override T3 passes). Point FLEET_CONF at an empty file and clear any gate
+# vars already in the caller env so the suite tests the baked defaults.
+export FLEET_CONF=/dev/null
+for _v in $(compgen -A variable | grep '^FLEET_DISPATCHER_USAGE_GATE' || true); do
+    unset "$_v"
+done
+unset _v
+
 NOW=$(date +%s)
 # Future ISO-8601 timestamp; portable across BSD/GNU date.
 RESETS=$(python3 -c "import datetime,time; print(datetime.datetime.fromtimestamp(time.time()+3600,tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
@@ -69,11 +81,22 @@ echo "T3: same fixture, threshold 0.99 => open"
 out=$(FLEET_DISPATCHER_USAGE_GATE=0.99 "$DISPATCHER" --gate-status)
 assert_starts_with "$out" "open:five_hour util=85%" "raised threshold opens gate"
 
-echo "T4: stale observation (2h old) => open"
-printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$((NOW - 7200))" \
+echo "T4: stale observation (2h old) with NO resetsAt => open"
+# Staleness cutoff only applies when there's no reset boundary to trust.
+printf '{"rateLimitType":"five_hour","utilization":0.85,"observed_at":%s}\n' "$((NOW - 7200))" \
     > "$FLEET_STATE_DIR/usage/five_hour.json"
 out=$("$DISPATCHER" --gate-status)
-assert_starts_with "$out" "open" "stale observation ignored"
+assert_starts_with "$out" "open" "stale observation without resetsAt ages out"
+
+echo "T4b: stale observation (2h old) but future resetsAt => still closed"
+# Regression guard: a future resetsAt is authoritative. Utilization can't
+# fall below the wall until the window resets, so an old-but-still-bound
+# reading must keep the gate closed. Previously the stale cutoff ran first
+# and blinded the gate mid-window, re-triggering a worker into the wall.
+printf '{"rateLimitType":"five_hour","utilization":1,"resetsAt":"%s","observed_at":%s}\n' "$RESETS" "$((NOW - 7200))" \
+    > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:five_hour util=100%" "future resetsAt overrides stale observed_at"
 
 echo "T5: resetsAt in the past (well past grace) => open"
 printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":"2020-01-01T00:00:00Z","observed_at":%s}\n' "$NOW" \


### PR DESCRIPTION
## Problem

The dispatcher kept re-triggering a worker (observed as "keeps triggering an opus worker") while pinned at the 5-hour rate limit.

Root cause is in `fleet-dispatcher`'s `usage_gate_status`: it discarded any usage observation older than `USAGE_STALE_SECONDS` (default 1h) **before** consulting its `resetsAt`. But a five-hour-window observation stays bound until `resetsAt` — utilization cannot drop below the wall until the window resets. So for the ~4h between `observed_at + 1h` and `resetsAt`, the gate went blind and reported `open` even at **100% utilization**.

Confirmed live on this host: `five_hour.json` had `utilization: 1`, `observed_at` 82 min ago, `resetsAt` still 53s in the future — and `--gate-status` printed `open`.

### Why it loops
1. Observation crosses 1h of age → gate flips `open`.
2. Dispatcher fires a worker into the still-closed window.
3. Worker hits the 5h limit → exits code 2 → `fleet-claude-stream` re-latches the observation with a fresh `observed_at`.
4. Gate closes again for another hour → back to step 1.

Each cycle burns one worker dispatch. Unrelated to other in-flight PRs.

## Fix

Make `resetsAt` authoritative: skip an observation only when `resetsAt + grace` has passed. A future `resetsAt` keeps it live regardless of `observed_at` age. The `observed_at` staleness cutoff now applies **only** when `resetsAt` is absent/unparseable, so an orphaned latch still ages out.

## Tests

- `T4` retargeted to the staleness-fallback path (no `resetsAt` → ages out).
- New `T4b` guards the regression: stale `observed_at` + future `resetsAt` → **still closed**.
- Suite now isolates from the operator's `~/.fleet/fleet-up.conf` (`FLEET_CONF=/dev/null` + clears inherited `FLEET_DISPATCHER_USAGE_GATE*`), so a host with a per-type override (e.g. `FLEET_DISPATCHER_USAGE_GATE_FIVE_HOUR`) no longer false-fails `T3`.

All 18 cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)