### PR TITLE
IRArgs — standardized CLI argument framework + default --help/-h (#2044)

### DIFF
--- a/creations/demos/fog_demo/main.cpp
+++ b/creations/demos/fog_demo/main.cpp
@@ -138,10 +138,6 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    // Declarative arg parsing via the engine framework: fog_demo registers its
-    // own --moving-observer flag and inherits the engine-common args
-    // (--auto-screenshot, --config-preset) plus a free --help / -h. Reference
-    // adoption for #2044 — `IRFogDemo --help` lists every arg and exits.
     IRArgs::Parser args(
         "fog_demo — fog-of-war render-pass demo (FOG_TO_TRIXEL) + cross-host smoke coverage."
     );

--- a/creations/demos/fog_demo/main.cpp
+++ b/creations/demos/fog_demo/main.cpp
@@ -33,6 +33,7 @@
 // pre-removal shape_debug setup; the rest of the skeleton follows the smaller
 // day_cycle demo.
 
+#include <irreden/ir_args.hpp>
 #include <irreden/ir_engine.hpp>
 #include <irreden/ir_entity.hpp>
 #include <irreden/ir_math.hpp>
@@ -80,7 +81,6 @@
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
 
 #include <list>
-#include <string_view>
 
 using namespace IRComponents;
 using IRMath::Color;
@@ -138,12 +138,21 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-    for (int i = 1; i < argc; ++i) {
-        if (std::string_view(argv[i]) == "--moving-observer") {
-            g_movingObserver = true;
-        }
-    }
+    // Declarative arg parsing via the engine framework: fog_demo registers its
+    // own --moving-observer flag and inherits the engine-common args
+    // (--auto-screenshot, --config-preset) plus a free --help / -h. Reference
+    // adoption for #2044 — `IRFogDemo --help` lists every arg and exits.
+    IRArgs::Parser args(
+        "fog_demo — fog-of-war render-pass demo (FOG_TO_TRIXEL) + cross-host smoke coverage."
+    );
+    args.flag(
+        "--moving-observer",
+        "Per-frame analytic vision circle orbiting the origin (smooth reveal) "
+        "instead of the static grid reveal"
+    );
+    args.parse(argc, argv);
+    g_autoWarmupFrames = args.autoScreenshotWarmupFrames();
+    g_movingObserver = args.getFlag("--moving-observer");
 
     IR_LOG_INFO("Starting creation: fog_demo");
     IREngine::init(argv[0]);

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -17,6 +17,24 @@ Core engine static libraries. Everything here is shared by every creation.
   modules (`common/`, `math/`, `profile/`) do not depend on high-level
   ones (`render/`, `world/`).
 
+## CLI args go through `IRArgs`, never a hand-rolled `strcmp` loop
+
+`engine/include/irreden/ir_args.hpp` is the declarative argument framework.
+A launch target constructs an `IRArgs::Parser` (which pre-registers the
+engine-common args — `--auto-screenshot`, `--config-preset` — plus a free
+`--help` / `-h`), declares its own args (`flag` / `integer` / `number` /
+`string` / `optionalInt`), then calls `parse(argc, argv)` at the **top of
+`main`, before any window / GL / Metal init** so `--help` is instant and
+headless-safe. `--help` prints the auto-generated usage and `exit(0)`; an
+unknown arg prints an error + usage and `exit(2)`. Read the common flags via
+`autoScreenshotWarmupFrames()` / `configPreset()`. `creations/demos/fog_demo/
+main.cpp` is the reference adoption.
+
+Do **not** add a new `for (i…) std::strcmp(argv[i], "--foo")` parse loop to a
+target. The legacy scattered helpers (`IRVideo::parseAutoScreenshotArgv`,
+`IREngine::parseConfigPresetArg`) and the remaining demos' hand-rolled loops
+are being migrated onto `IRArgs` and retired (#2044 follow-ons).
+
 ## `SystemName` enum is authoritative
 
 Every prefab system that uses the `System<NAME>::create()` template pattern

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
 
 add_library(IrredenEngine STATIC
     engine.cpp
+    ir_args.cpp
 )
 
 # set(CMAKE_CXX_SCAN_FOR_MODULES ON)

--- a/engine/include/irreden/ir_args.hpp
+++ b/engine/include/irreden/ir_args.hpp
@@ -1,0 +1,132 @@
+#ifndef IR_ARGS_H
+#define IR_ARGS_H
+
+#include <string>
+#include <vector>
+
+// IRArgs — declarative command-line argument framework with a built-in
+// --help / -h for every launch target.
+//
+// Before this, every demo hand-rolled its own `for (i…) std::strcmp(...)`
+// parse loop, no target had a --help, and the two engine helpers
+// (IRVideo::parseAutoScreenshotArgv, IREngine::parseConfigPresetArg) lived
+// scattered apart. A target instead constructs an IRArgs::Parser (which
+// pre-registers the engine-common args + --help), declares its own args, then
+// calls parse():
+//
+//     IRArgs::Parser args("my_demo — what it does.");
+//     args.flag("--no-overlay", "Hide the debug overlay");
+//     args.integer("--grid-size", "Grid edge in cells", 64);
+//     args.parse(argc, argv);
+//     if (args.getFlag("--no-overlay")) ...
+//     int n = args.getInt("--grid-size");
+//
+// --help / -h prints the auto-generated usage (all registered args) and exits
+// 0; an unknown argument prints an error + usage and exits 2. parse() must run
+// before any heavy init (window / GL / Metal) so `MyDemo --help` is instant and
+// headless-safe.
+//
+// The header is intentionally light (only <string> / <vector>) because every
+// target includes it; all logic lives in ir_args.cpp.
+namespace IRArgs {
+
+// The engine-common --auto-screenshot warmup default when the flag is given
+// without a trailing frame count. Mirrors the long-standing default in
+// IRVideo::parseAutoScreenshotArgv.
+inline constexpr int kDefaultAutoScreenshotWarmup = 10;
+
+// Kind of a registered argument. Drives both the parse rule and the value
+// placeholder shown in --help.
+enum class Type {
+    FLAG,         // boolean switch, no value           (--no-overlay)
+    INT,          // takes an integer value             (--grid-size 64)
+    FLOAT,        // takes a float value                (--zoom 4.0)
+    STRING,       // takes a string value               (--config-preset path.lua)
+    OPTIONAL_INT, // switch with an optional trailing int (--auto-screenshot [frames])
+};
+
+class Parser {
+  public:
+    // `programDescription` is an optional one-line summary printed under the
+    // usage header. The constructor pre-registers the built-in --help / -h and
+    // the engine-common args (--auto-screenshot, --config-preset), so every
+    // target inherits them without re-declaring.
+    explicit Parser(const char *programDescription = nullptr);
+
+    // Declarative registration. All return *this so calls can chain.
+    // `name` must start with "--"; `shortAlias` is an optional single-dash
+    // alias such as "-z" (nullptr for none). Registering a duplicate name
+    // asserts in debug.
+    Parser &flag(const char *name, const char *help, const char *shortAlias = nullptr);
+    Parser &
+    integer(const char *name, const char *help, int defaultValue, const char *shortAlias = nullptr);
+    Parser &number(
+        const char *name, const char *help, float defaultValue, const char *shortAlias = nullptr
+    );
+    Parser &string(
+        const char *name,
+        const char *help,
+        const char *defaultValue,
+        const char *shortAlias = nullptr
+    );
+    // A switch that may carry an optional trailing positive integer; when the
+    // value is omitted the arg resolves to `defaultIfBare`. wasProvided() still
+    // reports whether the switch itself appeared.
+    Parser &optionalInt(
+        const char *name, const char *help, int defaultIfBare, const char *shortAlias = nullptr
+    );
+
+    // Parse argv (argv[0] is the program path and is skipped). On --help / -h:
+    // print usage to stdout and exit(0). On an unknown arg or a missing value:
+    // print the diagnostic + usage to stderr and exit(2).
+    void parse(int argc, char **argv);
+
+    // Typed access, valid after parse(). Each returns the registered default
+    // when the arg was not supplied. A name/type mismatch asserts in debug.
+    bool getFlag(const char *name) const;
+    int getInt(const char *name) const;
+    float getFloat(const char *name) const;
+    std::string getString(const char *name) const;
+
+    // True when the arg appeared on the command line (vs. resolved to its
+    // default). The honest "present?" signal for OPTIONAL_INT switches such as
+    // --auto-screenshot, where presence alone changes behavior.
+    bool wasProvided(const char *name) const;
+
+    // Engine-common convenience accessors — read the pre-registered common args
+    // with their canonical semantics so every target drives them identically:
+    //   - 0 when --auto-screenshot is absent (the established "not requested"
+    //     sentinel), else the warmup frame count.
+    //   - empty string when --config-preset is absent, else the path.
+    int autoScreenshotWarmupFrames() const;
+    std::string configPreset() const;
+
+    // The auto-generated usage text (exactly what --help prints).
+    std::string usage() const;
+
+  private:
+    struct Entry {
+        std::string name_;
+        std::string shortAlias_;
+        std::string help_;
+        Type type_;
+        bool boolValue_ = false;
+        int intValue_ = 0;
+        float floatValue_ = 0.0f;
+        std::string stringValue_;
+        bool provided_ = false;
+    };
+
+    Entry &add(const char *name, const char *help, Type type, const char *shortAlias);
+    Entry *find(const std::string &token);
+    const Entry *findByName(const char *name) const;
+    [[noreturn]] void exitWithUsage(int code) const;
+
+    std::string m_description;
+    std::string m_programName = "program";
+    std::vector<Entry> m_entries;
+};
+
+} // namespace IRArgs
+
+#endif /* IR_ARGS_H */

--- a/engine/include/irreden/ir_args.hpp
+++ b/engine/include/irreden/ir_args.hpp
@@ -4,15 +4,7 @@
 #include <string>
 #include <vector>
 
-// IRArgs — declarative command-line argument framework with a built-in
-// --help / -h for every launch target.
-//
-// Before this, every demo hand-rolled its own `for (i…) std::strcmp(...)`
-// parse loop, no target had a --help, and the two engine helpers
-// (IRVideo::parseAutoScreenshotArgv, IREngine::parseConfigPresetArg) lived
-// scattered apart. A target instead constructs an IRArgs::Parser (which
-// pre-registers the engine-common args + --help), declares its own args, then
-// calls parse():
+// IRArgs — declarative command-line argument framework.
 //
 //     IRArgs::Parser args("my_demo — what it does.");
 //     args.flag("--no-overlay", "Hide the debug overlay");
@@ -20,14 +12,6 @@
 //     args.parse(argc, argv);
 //     if (args.getFlag("--no-overlay")) ...
 //     int n = args.getInt("--grid-size");
-//
-// --help / -h prints the auto-generated usage (all registered args) and exits
-// 0; an unknown argument prints an error + usage and exits 2. parse() must run
-// before any heavy init (window / GL / Metal) so `MyDemo --help` is instant and
-// headless-safe.
-//
-// The header is intentionally light (only <string> / <vector>) because every
-// target includes it; all logic lives in ir_args.cpp.
 namespace IRArgs {
 
 // The engine-common --auto-screenshot warmup default when the flag is given

--- a/engine/ir_args.cpp
+++ b/engine/ir_args.cpp
@@ -1,0 +1,282 @@
+#include <irreden/ir_args.hpp>
+
+#include <irreden/ir_profile.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace IRArgs {
+
+namespace {
+
+// Per-type value placeholder shown after the arg name in --help.
+const char *placeholderFor(Type type) {
+    switch (type) {
+    case Type::FLAG:
+        return "";
+    case Type::INT:
+        return " <int>";
+    case Type::FLOAT:
+        return " <float>";
+    case Type::STRING:
+        return " <value>";
+    case Type::OPTIONAL_INT:
+        return " [int]";
+    }
+    return "";
+}
+
+} // namespace
+
+Parser::Parser(const char *programDescription)
+    : m_description(programDescription != nullptr ? programDescription : "") {
+    // Built-in help — owned by the parser, free for every target.
+    flag("--help", "Show this help and exit", "-h");
+    // Engine-common args: every target that constructs a Parser inherits these
+    // (and --help) without re-declaring. The canonical spellings are preserved
+    // so existing command lines keep working.
+    optionalInt(
+        "--auto-screenshot",
+        "Headless capture: cycle the shot table then exit; optional warmup frame count",
+        kDefaultAutoScreenshotWarmup
+    );
+    string("--config-preset", "Path to a Lua config preset applied before init", "");
+}
+
+Parser::Entry &Parser::add(const char *name, const char *help, Type type, const char *shortAlias) {
+    IR_ASSERT(
+        name != nullptr && std::strncmp(name, "--", 2) == 0,
+        "IRArgs: argument name must start with '--'"
+    );
+    IR_ASSERT(find(name) == nullptr, "IRArgs: duplicate argument registered");
+    Entry entry;
+    entry.name_ = name;
+    entry.shortAlias_ = shortAlias != nullptr ? shortAlias : "";
+    entry.help_ = help != nullptr ? help : "";
+    entry.type_ = type;
+    m_entries.push_back(std::move(entry));
+    return m_entries.back();
+}
+
+Parser &Parser::flag(const char *name, const char *help, const char *shortAlias) {
+    Entry &e = add(name, help, Type::FLAG, shortAlias);
+    e.boolValue_ = false;
+    return *this;
+}
+
+Parser &
+Parser::integer(const char *name, const char *help, int defaultValue, const char *shortAlias) {
+    Entry &e = add(name, help, Type::INT, shortAlias);
+    e.intValue_ = defaultValue;
+    return *this;
+}
+
+Parser &
+Parser::number(const char *name, const char *help, float defaultValue, const char *shortAlias) {
+    Entry &e = add(name, help, Type::FLOAT, shortAlias);
+    e.floatValue_ = defaultValue;
+    return *this;
+}
+
+Parser &Parser::string(
+    const char *name, const char *help, const char *defaultValue, const char *shortAlias
+) {
+    Entry &e = add(name, help, Type::STRING, shortAlias);
+    e.stringValue_ = defaultValue != nullptr ? defaultValue : "";
+    return *this;
+}
+
+Parser &
+Parser::optionalInt(const char *name, const char *help, int defaultIfBare, const char *shortAlias) {
+    Entry &e = add(name, help, Type::OPTIONAL_INT, shortAlias);
+    e.intValue_ = defaultIfBare;
+    return *this;
+}
+
+Parser::Entry *Parser::find(const std::string &token) {
+    for (Entry &e : m_entries) {
+        if (e.name_ == token || (!e.shortAlias_.empty() && e.shortAlias_ == token)) {
+            return &e;
+        }
+    }
+    return nullptr;
+}
+
+const Parser::Entry *Parser::findByName(const char *name) const {
+    for (const Entry &e : m_entries) {
+        if (e.name_ == name) {
+            return &e;
+        }
+    }
+    return nullptr;
+}
+
+void Parser::parse(int argc, char **argv) {
+    if (argc > 0 && argv[0] != nullptr) {
+        std::string path = argv[0];
+        const auto slash = path.find_last_of("/\\");
+        m_programName = (slash == std::string::npos) ? path : path.substr(slash + 1);
+    }
+
+    // --help / -h takes precedence regardless of position, and must run before
+    // any heavy init — so resolve it up front, before mutating any entry. This
+    // also keeps usage() reporting the registered defaults rather than values
+    // parsed from tokens that happened to precede --help on the line.
+    for (int i = 1; i < argc; ++i) {
+        const Entry *e = find(argv[i]);
+        if (e != nullptr && e->name_ == "--help") {
+            exitWithUsage(0);
+        }
+    }
+
+    for (int i = 1; i < argc; ++i) {
+        Entry *e = find(argv[i]);
+        if (e == nullptr) {
+            std::fprintf(stderr, "Unknown argument: %s\n\n", argv[i]);
+            exitWithUsage(2);
+        }
+        e->provided_ = true;
+        switch (e->type_) {
+        case Type::FLAG:
+            e->boolValue_ = true;
+            break;
+        case Type::INT:
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "Argument %s expects an integer value\n\n", argv[i]);
+                exitWithUsage(2);
+            }
+            e->intValue_ = std::atoi(argv[++i]);
+            break;
+        case Type::FLOAT:
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "Argument %s expects a float value\n\n", argv[i]);
+                exitWithUsage(2);
+            }
+            e->floatValue_ = static_cast<float>(std::atof(argv[++i]));
+            break;
+        case Type::STRING:
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "Argument %s expects a value\n\n", argv[i]);
+                exitWithUsage(2);
+            }
+            e->stringValue_ = argv[++i];
+            break;
+        case Type::OPTIONAL_INT:
+            // Consume the next token only when it reads as a positive integer,
+            // otherwise leave it for the loop. Mirrors the historical
+            // parseAutoScreenshotArgv peek so existing command lines are
+            // byte-identical (the bare default stays in intValue_).
+            if (i + 1 < argc) {
+                const int parsed = std::atoi(argv[i + 1]);
+                if (parsed > 0) {
+                    e->intValue_ = parsed;
+                    ++i;
+                }
+            }
+            break;
+        }
+    }
+}
+
+bool Parser::getFlag(const char *name) const {
+    const Entry *e = findByName(name);
+    IR_ASSERT(
+        e != nullptr && e->type_ == Type::FLAG,
+        "IRArgs: getFlag on unregistered/non-flag arg"
+    );
+    return e != nullptr && e->boolValue_;
+}
+
+int Parser::getInt(const char *name) const {
+    const Entry *e = findByName(name);
+    IR_ASSERT(
+        e != nullptr && (e->type_ == Type::INT || e->type_ == Type::OPTIONAL_INT),
+        "IRArgs: getInt on unregistered/non-int arg"
+    );
+    return e != nullptr ? e->intValue_ : 0;
+}
+
+float Parser::getFloat(const char *name) const {
+    const Entry *e = findByName(name);
+    IR_ASSERT(
+        e != nullptr && e->type_ == Type::FLOAT,
+        "IRArgs: getFloat on unregistered/non-float arg"
+    );
+    return e != nullptr ? e->floatValue_ : 0.0f;
+}
+
+std::string Parser::getString(const char *name) const {
+    const Entry *e = findByName(name);
+    IR_ASSERT(
+        e != nullptr && e->type_ == Type::STRING,
+        "IRArgs: getString on unregistered/non-string arg"
+    );
+    return e != nullptr ? e->stringValue_ : std::string{};
+}
+
+bool Parser::wasProvided(const char *name) const {
+    const Entry *e = findByName(name);
+    IR_ASSERT(e != nullptr, "IRArgs: wasProvided on unregistered arg");
+    return e != nullptr && e->provided_;
+}
+
+int Parser::autoScreenshotWarmupFrames() const {
+    return wasProvided("--auto-screenshot") ? getInt("--auto-screenshot") : 0;
+}
+
+std::string Parser::configPreset() const {
+    return getString("--config-preset");
+}
+
+std::string Parser::usage() const {
+    // Sort by name for stable, scannable output; the registration order is an
+    // implementation detail no reader should have to track.
+    std::vector<const Entry *> sorted;
+    sorted.reserve(m_entries.size());
+    for (const Entry &e : m_entries) {
+        sorted.push_back(&e);
+    }
+    std::sort(sorted.begin(), sorted.end(), [](const Entry *a, const Entry *b) {
+        return a->name_ < b->name_;
+    });
+
+    // Build each left column ("--name, -a <value>") and find the widest so the
+    // help text aligns into a second column.
+    std::vector<std::string> leftCols;
+    leftCols.reserve(sorted.size());
+    std::size_t widest = 0;
+    for (const Entry *e : sorted) {
+        std::string left = e->name_;
+        if (!e->shortAlias_.empty()) {
+            left += ", " + e->shortAlias_;
+        }
+        left += placeholderFor(e->type_);
+        if (left.size() > widest) {
+            widest = left.size();
+        }
+        leftCols.push_back(std::move(left));
+    }
+
+    std::string out = "Usage: " + m_programName + " [options]\n";
+    if (!m_description.empty()) {
+        out += "\n" + m_description + "\n";
+    }
+    out += "\nOptions:\n";
+    for (std::size_t i = 0; i < sorted.size(); ++i) {
+        out += "  " + leftCols[i];
+        out += std::string(widest - leftCols[i].size() + 2, ' ');
+        out += sorted[i]->help_;
+        out += "\n";
+    }
+    return out;
+}
+
+void Parser::exitWithUsage(int code) const {
+    const std::string text = usage();
+    std::fputs(text.c_str(), code == 0 ? stdout : stderr);
+    std::exit(code);
+}
+
+} // namespace IRArgs

--- a/engine/ir_args.cpp
+++ b/engine/ir_args.cpp
@@ -51,6 +51,10 @@ Parser::Entry &Parser::add(const char *name, const char *help, Type type, const 
         "IRArgs: argument name must start with '--'"
     );
     IR_ASSERT(find(name) == nullptr, "IRArgs: duplicate argument registered");
+    IR_ASSERT(
+        shortAlias == nullptr || find(shortAlias) == nullptr,
+        "IRArgs: duplicate short alias registered"
+    );
     Entry entry;
     entry.name_ = name;
     entry.shortAlias_ = shortAlias != nullptr ? shortAlias : "";


### PR DESCRIPTION
## Summary
- New `IRArgs::Parser` — declarative CLI argument framework (`engine/include/irreden/ir_args.hpp` + `engine/ir_args.cpp`) with a built-in `--help` / `-h` for every launch target.
- Args are registered declaratively (`flag` / `integer` / `number` / `string` / `optionalInt`); `--help` prints auto-generated usage and exits 0; an unknown arg or a missing value prints a diagnostic + usage and exits 2; `--help` resolves **before any heavy init**, so `Target --help` is instant and headless-safe.
- `--auto-screenshot` and `--config-preset` fold in as engine-common args every target inherits (existing flag spellings preserved; the `--auto-screenshot` optional-int peek mirrors the legacy helper so command lines stay byte-identical).
- `fog_demo` is the reference adoption — it drops its hand-rolled `parseAutoScreenshotArgv` call **and** its `--moving-observer` strcmp loop, registering `--moving-observer` as an `IRArgs` flag instead, and gains `--help` for free. So it demonstrates both a custom flag and the inherited common args. Capture / reveal behavior is unchanged.
- `engine/CLAUDE.md` documents the "CLI args go through `IRArgs`, never a hand-rolled `strcmp` loop" convention.

**Scope (foundation):** the legacy scattered helpers (`IRVideo::parseAutoScreenshotArgv`, `IREngine::parseConfigPresetArg`) and the remaining demos' hand-rolled parse loops are left intact — migrating them onto `IRArgs` and retiring the helpers are #2044 follow-ons (filed after this lands). Backend-agnostic stdlib code (no GL/Metal divergence), so no cross-host smoke needed.

## Test plan
- [x] `IRFogDemo --help` and `-h` print the full arg list (incl. `--moving-observer`) and exit 0, before any window/GL/Metal init.
- [x] Unknown arg (`--bogus`) → "Unknown argument" + usage on stderr, exit 2; `--config-preset` with no value → "expects a value", exit 2.
- [x] `IRFogDemo --auto-screenshot 12` (static grid reveal) and `--auto-screenshot 12 --moving-observer` (analytic vision circle) both cycle all 3 shots and capture (behavior-preserving migration).
- [x] Builds clean on macOS/Metal (`fleet-build --target IRFogDemo`); clang-format clean.

Closes #2044

🤖 Generated with [Claude Code](https://claude.com/claude-code)