### PR TITLE
docs/fleet: absorb coding-improvement triage batch

### DIFF
--- a/.claude/agents/simplify-check-ecs.md
+++ b/.claude/agents/simplify-check-ecs.md
@@ -18,6 +18,8 @@ For each `.hpp`/`.cpp` file in the diff, scan for:
 
    - **Allowed exception:** dynamically-determined foreign entities (contact pair `.otherEntity_`, parent lookups via stored `EntityId`). Note this case as "foreign-entity lookup" and recommend the batched-vector pattern from `cpp-ecs.md` §"Foreign-entity lookups".
 
+   - **Allowed exception:** per-canvas `getComponentOptional` in a render tick that must iterate *all* canvases while only *some* carry an optional per-canvas component (`C_CanvasFogOfWar`, `C_CanvasSunShadow`, `C_CanvasLightVolume`). This is O(canvases), not the O(voxels) footgun, and the template-param fix would wrongly drop the canvases without the component. Don't flag it. See the carve-out in `cpp-ecs-smells.md` §"Per-entity tick violations".
+
 2. **Allocations in hot tick paths:** `new`, `std::vector::push_back` on a hot vector, `std::string` concatenation, `std::map::operator[]` insertion, `std::make_unique` inside a tick. Reserve at `beginTick` or in `SystemParams` instead.
 
 3. **Mid-iteration structural changes:** `createEntity`, `setComponent`, `removeComponent`, `removeEntity` called inside a per-entity tick. Use the deferred variants (`deferredCreate`, etc.) and let `flushStructuralChanges` run.
@@ -31,6 +33,8 @@ For each `.hpp`/`.cpp` file in the diff, scan for:
 7. **`endTick` indexing `ids[0]` or similar without `ids.size() == 0` guard.** Both fire even when the archetype is empty.
 
 8. **Render system reading `C_Position3D` for visual placement** instead of `C_PositionGlobal3D` (`APPLY_POSITION_OFFSET` has already folded modifier-driven offsets into globalPos). Flag and confirm intent.
+
+9. **Raw-span voxel carve missing `recomputeFaceOccupancy`.** A function body that mutates a voxel set through the raw `voxels_` span — a loop calling `voxels_[i].deactivate()` (or writing `.color_.alpha_ = 0`) — followed by `syncActiveMask()` but with **no** `IRPrefab::Voxel::recomputeFaceOccupancy(...)` call in the same function. Flag it: the carve's newly-exposed surface faces stay occluded and the set renders black under the lit/rotated path while the active-mask half looks done. Fix: add `recomputeFaceOccupancy(vs.voxels_, size)` alongside the `syncActiveMask()`. (Set-level helpers — `reshape`/`fillPlane`/`activate/deactivateAll` — already do both; this only fires on raw-span bypass. See `engine/prefabs/irreden/voxel/CLAUDE.md`.) `needs-fix`.
 
 ## Output format
 

--- a/.claude/rules/cpp-ecs-smells.md
+++ b/.claude/rules/cpp-ecs-smells.md
@@ -21,6 +21,15 @@ In any system `tick` function:
   it arrives via dense-column iteration. Auto-fix when the call is
   unconditional and the component is small; flag when the call is conditional
   or the component may not exist on every entity in the archetype.
+  - *Carve-out — per-canvas `getComponentOptional` in a canvas-iterating
+    tick.* A render tick that must visit **all** canvas entities while only
+    **some** carry an optional per-canvas component (`C_CanvasFogOfWar`,
+    `C_CanvasSunShadow`, `C_CanvasLightVolume`) correctly uses
+    `getComponentOptional` on the iterating canvas — it is O(canvases), not
+    the O(voxels) per-voxel footgun, and the template-param fix does **not**
+    apply (it would restrict iteration to canvases that *have* the component,
+    dropping the rest). This is the accepted canvas-iteration pattern; don't
+    flag it.
 
 - **`createEntity`, `addComponent`, `removeComponent`, or `removeEntity`**
   mid-iteration without the deferred variant. Fix: use

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -176,6 +176,17 @@ fix in Step i.)
   file is the long-form version. If the two diverge, the comment wins
   for this PR.
 
+- **Re-verify carried-over measurements before trusting or pushing them.**
+  When resuming an orphaned / `fleet:design-unblocked` PR, treat any
+  *uncommitted or unpushed* staged work left by a prior iteration — perf
+  numbers, benchmarks, measurements written into docs — as **unverified**.
+  Build/test gates catch carried-over *code*, but docs and measurements
+  aren't exercised by the build, so a prior iteration's wrong-but-confident
+  numbers (a stale baseline, a cold-start-contaminated run) ship unchecked
+  under your name. Independently re-run the measure / render-verify on your
+  own host and reconcile before pushing. The authoritative handoff is the
+  *pushed* PR head + the plan/comments, never the local working tree.
+
 ## AMEND vs ESCALATE (human-label paths only)
 
 For `human:needs-fix` / `human:blocker` only, choose a disposition.

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -25,8 +25,9 @@ for single voxels and particles.
   and read by `c_voxel_visibility_compact.{glsl,metal}` in place of the
   per-voxel alpha test (T-287). Push-at-mutation: mutations through
   `C_VoxelSetNew`'s helpers sync the mask automatically; raw `voxels_[i]`
-  span writes must follow with `vs.syncActiveMask()`. **One pool per
-  canvas entity.**
+  span writes must follow with `vs.syncActiveMask()` **and**
+  `IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, size)` (see the
+  `C_VoxelSetNew` note below). **One pool per canvas entity.**
 - `C_VoxelSetNew` — owns a span of voxels from a pool; pushes local → global
   position updates; supports reshape (box/sphere SDF). Use the provided
   helpers instead of iterating voxels individually: `deactivateAll()`,
@@ -35,8 +36,15 @@ for single voxels and particles.
   `reshape(Shape3D)` (box or sphere fill). All of these keep the pool's
   active-mask in sync. If a caller bypasses them and writes alpha through
   the raw `voxels_` span (e.g. an SDF-carving loop calling
-  `voxels_[i].deactivate()` per slot), it must follow up with
-  `syncActiveMask()` so the GPU compaction stage sees the new active set.
+  `voxels_[i].deactivate()` per slot), it must follow up with **both**
+  `syncActiveMask()` (so the GPU compaction stage sees the new active set)
+  **and** `IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, size)` (so
+  the carve's newly-exposed surface faces aren't left occluded). Dropping
+  the recompute renders the carved set black under the lit/rotated path
+  while the active-mask half looks done — an easy footgun because the
+  active-mask requirement is the loud one. `simplify-check-ecs` flags a
+  `.deactivate()` carve loop + `syncActiveMask()` with no
+  `recomputeFaceOccupancy` in the same function.
 - `C_ShapeDescriptor` — SDF shape type + params + color + flags (visible,
   hollow, mirror). Rendered directly by the GPU; **does not allocate voxels**.
 - `C_Skeleton` — rig-root component holding an ordered vector of joint
@@ -322,6 +330,13 @@ string.
 
 ## Gotchas
 
+- **Carving `reserved_` bits? Update the layout comment in the same change.**
+  When you repurpose sub-bits of a `reserved_` field in `C_Voxel` (or any
+  GPU-mirrored std430 struct with a layout comment), update that struct's
+  layout comment in the same commit. A stale "reserved for future fields"
+  comment leads the next allocator to believe the bits are free and silently
+  collide with the live encoding in the shader — no compile error, just
+  corrupted GPU decode.
 - **Never add `C_VoxelPool` to a non-canvas entity.** Pools are
   canvas-scoped. Only the canvas entity created by
   `IRRender::createCanvas` should own one.

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -274,6 +274,19 @@ at a texel inside a world-placed detached solid (canonical:
 so a future pass that disables the detached-canvas composite depth-write
 fails the run headlessly on either backend.
 
+**Default-off features need a positive enabled-path test, not just
+byte-identity at default.** Render features routinely default OFF (priority
+0, a mode flag off, an opt-in branch) precisely to preserve byte-identity —
+but byte-identity at default only proves the OFF path is a no-op, never that
+the feature works. Author a test that exercises the **ENABLED** path (a
+`--depth-probe`/`-assert` reading, a demo shot with the flag ON) and confirms
+the effect end-to-end (CPU author → GPU upload → shader output). A
+CPU-authored field uploaded only on a *specific* path (e.g. the per-frame
+binding-6 voxel upload, not a detached-revoxelize bake) can silently never
+reach the shader, and a "compiles + byte-identical at default" merge ships a
+feature that doesn't function in its actual use case (#1989 per-trixel
+priority caught exactly this on resume).
+
 ### Verifying temporal stability (per-frame jitter)
 
 **A single screenshot cannot prove a moving scene is jitter-free.** Pan/rotation


### PR DESCRIPTION
## Summary

One human-cued `triage-coding-improvements` run over the open
`fleet:coding-improvement` backlog (8 tickets). Convention-surface edits only —
code/tooling work is routed out per Step 5.

## Triage digest (verdict per ticket)

| # | Verdict | Disposition |
|---|---|---|
| **#2042** | ACCEPT + escalate | Carve-out in `cpp-ecs-smells.md` **and** `simplify-check-ecs`: per-canvas `getComponentOptional` in a canvas-iterating tick (`C_CanvasFogOfWar`/`SunShadow`/`LightVolume`) is the accepted pattern, not the per-voxel footgun; the template-param fix wrongly drops canvases without the component. Recurring `has-nits` round-trip (lighting precedent + fog repeat). |
| **#2025** | ACCEPT | `voxel/CLAUDE.md` gotcha: update the std430 layout comment in the same change when carving `reserved_` bits — a stale comment leads the next allocator to silently collide with the live shader encoding. |
| **#2024** | ACCEPT | `render/CLAUDE.md` §Verifying render changes: default-off features need a *positive enabled-path* test; byte-identity at default only proves the OFF path is a no-op. |
| **#2020** | ACCEPT | `FLEET-FEEDBACK-HANDLING.md` resume tier: re-verify carried-over measurements (perf tables, etc.) when resuming an orphaned/design-unblocked PR — build gates catch code, not staged doc numbers. |
| **#2019** | ACCEPT doc + ESCALATE | `voxel/CLAUDE.md` raw-span note now requires `recomputeFaceOccupancy` alongside `syncActiveMask` (drops → renders black). New `simplify-check-ecs` rule #9 flags the `.deactivate()` carve + `syncActiveMask()` with no recompute — **validated to fire** against the #2018 occurrence and not on the corrected sibling. |
| **#2028** | ROUTE OUT | Real tooling (a Python linter + hook), not a doc edit → filed #2047 (ruff lint over `scripts/fleet/`). Closed-loop: rejected #1868 was turned down *because* no Python surface existed; #2047 creates it. |
| **#1850** | REJECT (moot) | #1816 deliberately **avoided** the predicted function-local-static `sol::protected_function` registry (used a `System<N>` member per existing `cpp-systems.md`). Premise dead. Closed not-planned. |
| **#1865** | DEFER | Unblock condition (a 2nd device-backend shipping without a graceful-degradation test) not yet met. Left open. |

## Net line growth per surface
- `.claude/rules/cpp-ecs-smells.md` +9
- `.claude/agents/simplify-check-ecs.md` +4
- `engine/prefabs/irreden/voxel/CLAUDE.md` +19
- `engine/render/CLAUDE.md` +13
- `docs/agents/FLEET-FEEDBACK-HANDLING.md` +11

## Test plan
- [x] `simplify` doc-side checks clean (final-newline, cross-ref resolution, citation sanity).
- [x] New `simplify-check-ecs` rule #9 validated: fires on the bad carve, silent on the corrected sibling.
- [x] All `Closes` targets verified to exist during the sweep.

## Routing
- Split-out tooling issue: #2047 (ruff lint — unlabeled, awaiting human approval into the queue).
- Closed at triage: #1850 (reject), #2028 (routed to #2047).

Closes #2042
Closes #2025
Closes #2024
Closes #2020
Closes #2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)