### PR TITLE
fleet: human:revise-plan — add-one-label re-plan request

### DIFF
--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -229,6 +229,32 @@ For each `fleet:needs-plan` issue:
 your concerns, leave `fleet:needs-plan` on, release the planning claim, and let
 the human decide.
 
+### Human: requesting plan changes (`human:revise-plan`)
+
+When the human reviewing a posted plan (step 4, while it sits in
+`fleet:plan-review` / `human:review-plan`) wants the **approach** reworked, they
+do **not** swap labels by hand. They **add one label, `human:revise-plan`**,
+plus a comment describing the change. On the next scout tick `fleet-queue-ingest`
+reconciles the issue for them:
+
+- adds `fleet:needs-plan` (so an opus+ planner re-plans, reading the new comment
+  per step 1),
+- strips the now-stale stage labels (`fleet:plan-review`, and any model /
+  `fleet:blocked` label),
+- consumes `human:revise-plan`,
+- **keeps** `human:approved` (the original triage) and `human:review-plan` (the
+  human's approach gate persists across the re-plan — the issue cannot queue
+  until the human clears it on the revised plan).
+
+The re-planner then revises the `## Plan` comment and swaps back to
+`fleet:plan-review` (re-asserting `human:review-plan` for high-stakes work). The
+human reviews the new plan and clears `human:review-plan` when satisfied. Net:
+the human only ever *adds* a label — the fleet manages every other transition.
+(The scout pulls a `human:revise-plan` issue back into the ingest set even though
+its stage labels would otherwise exclude it; see `_ingest_skipped`.) This affords
+the **pre-queue** stages only; an already-queued plan that has gone stale uses
+the race-guarded flow below.
+
 ---
 
 ## Re-planning a stale queued plan

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -124,6 +124,20 @@ Specifically, **never pass these via `--label` when filing**:
   or hard to reverse / changes a public contract (PLANNING-PROTOCOL.md step 3
   checklist); low-stakes worker-planned issues queue on agent plan-review alone.
   Architect-filed-with-plan work skips planning and never reaches this gate.
+- `human:revise-plan` — owned by the **human** as a re-plan request; **added by
+  the human** (and nothing else) to a posted plan in review when the *approach*
+  needs reworking, alongside a comment describing the change. The human never
+  swaps labels: on the next scout tick `fleet-queue-ingest` reconciles the issue
+  — adds `fleet:needs-plan` (an opus+ planner re-plans, reading the comment),
+  strips the now-stale stage labels (`fleet:plan-review`, any model /
+  `fleet:blocked` label), consumes `human:revise-plan`, and **keeps**
+  `human:approved` + any `human:review-plan` (the approach gate persists so the
+  issue can't queue behind the human's back). The scout pulls the issue back
+  into the ingest set via `_ingest_skipped` even though its stage labels would
+  otherwise exclude it, so adding the label both fires ingest and surfaces it in
+  `pending_issues`. Pre-queue stages only — an already-queued stale plan uses the
+  race-guarded re-plan flow (PLANNING-PROTOCOL.md §"Re-planning a stale queued
+  plan"). A fleet agent never applies it (`human:*` by convention).
 - `human:no-plan` — owned by the **human**, applied at filing to a simple,
   self-contained issue to skip planning entirely. `fleet-queue-ingest` then
   stamps `fleet:queued` directly — no `## Plan` comment required — and the

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -303,6 +303,12 @@
       "description": "High-stakes worker-planned issue: planner adds it alongside fleet:plan-review so the issue holds for the HUMAN's approach sign-off before implementation (distinct from fleet:plan-review's agent vetting). Both are queue-blocks; keeps human:approved and survives re-ingest like fleet:needs-human; only the human removes it. PLANNING-PROTOCOL.md step 3"
     },
     {
+      "name": "human:revise-plan",
+      "scope": "issue",
+      "color": "5319e7",
+      "description": "Human-added re-plan request on a plan in review: the human adds ONLY this label (plus a comment) and fleet-queue-ingest reconciles — adds fleet:needs-plan, strips stale stage labels (fleet:plan-review / model / fleet:blocked), consumes human:revise-plan, keeps human:approved + human:review-plan. Scout pulls it back into the ingest set via _ingest_skipped. Pre-queue stages only. PLANNING-PROTOCOL.md"
+    },
+    {
       "name": "human:wip",
       "scope": "pr",
       "color": "5319e7",

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -147,6 +147,7 @@ LABELS=(
     "human:owned|5319e7|Human took this issue out of the queue; ingest never re-stamps fleet:queued (reconcile flags both)"
     "human:no-plan|5319e7|Human opt-out at filing: skip planning, queue directly; [no-plan] tag honored; agents never apply it"
     "human:review-plan|5319e7|High-stakes worker-planned issue held for human approach sign-off; human removes to queue"
+    "human:revise-plan|5319e7|Human wants the posted plan changed; ingest resets to fleet:needs-plan for re-plan"
     "human:wip|5319e7|Human is editing the PR directly; agents stand off"
     "human:approved|0e8a16|Human approved the PR (overrides agent verdict)"
     "human:needs-fix|d4c5f9|Human flagged a fix request; agent should address"

--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -297,6 +297,7 @@ def _has_plan_comment(comments):
     return False
 
 stamped = 0
+revise_reconciled = 0
 skipped_already = 0
 blocked_marked = 0
 plan_bounced = 0
@@ -327,6 +328,40 @@ for issue in pending:
     title = view.get('title', '') or ''
     body = view.get('body', '') or ''
     labels = {(l['name'] if isinstance(l, dict) else l) for l in view.get('labels', [])}
+
+    # human:revise-plan: the human-added "I want the posted plan changed" gate.
+    # Rather than make the human swap labels by hand, ingest reconciles the
+    # issue back to the planning state and consumes the marker — the human only
+    # ever *adds* one label, the fleet manages the rest. Sits before the
+    # already-labeled skip below precisely because the issue it lands on is
+    # usually in fleet:plan-review / human:review-plan (which that block skips).
+    # We add fleet:needs-plan so an opus+ worker re-plans (reading the human's
+    # comment per PLANNING-PROTOCOL.md step 1), strip the now-stale stage labels,
+    # and remove human:revise-plan. We KEEP human:approved (original triage) and
+    # human:review-plan (the human's approach gate persists across the re-plan;
+    # the re-planner re-asserts it on high-stakes work anyway). Scope is the
+    # pre-queue stages (the pending set); an already-queued plan uses the
+    # race-guarded stale-replan flow (PLANNING-PROTOCOL.md §"Re-planning").
+    if 'human:revise-plan' in labels:
+        remove = ['human:revise-plan']
+        for lbl in ('fleet:plan-review', 'fleet:blocked',
+                    'fleet:fable', 'fleet:opus', 'fleet:sonnet'):
+            if lbl in labels:
+                remove.append(lbl)
+        cmd = ['gh', 'issue', 'edit', str(n), '--repo', repo,
+               '--add-label', 'fleet:needs-plan']
+        for lbl in remove:
+            cmd.extend(['--remove-label', lbl])
+        er = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if er.returncode != 0:
+            failed += 1
+            print(f'WARN issue {repo}#{n}: human:revise-plan reconcile failed: '
+                  f'{er.stderr.strip()}', file=sys.stderr)
+            continue
+        revise_reconciled += 1
+        print(f'INFO issue {repo}#{n}: human:revise-plan → reset to fleet:needs-plan '
+              f'for re-plan (kept human:approved + any human:review-plan)', file=sys.stderr)
+        continue
 
     if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
             or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels
@@ -498,13 +533,13 @@ for issue in data.get('unblock_issues', []):
         continue
     unblocked += 1
 
-print(f'{stamped},{skipped_already},{failed},{blocked_marked},{unblocked},{unblock_still},{plan_bounced}')
+print(f'{stamped},{skipped_already},{failed},{blocked_marked},{unblocked},{unblock_still},{plan_bounced},{revise_reconciled}')
 STAMP_PY
 )
 
 if [[ -n "$stamping_out" ]]; then
-    IFS=',' read -r stamped_count skipped_count failed_count blocked_count unblocked_count unblock_still_count plan_bounced_count <<< "$stamping_out"
-    log "stamped ${stamped_count:-0} issue(s) (${blocked_count:-0} marked fleet:blocked); skipped ${skipped_count:-0} already-labeled; bounced ${plan_bounced_count:-0} to fleet:needs-plan; unblocked ${unblocked_count:-0} (${unblock_still_count:-0} still blocked); ${failed_count:-0} failed"
+    IFS=',' read -r stamped_count skipped_count failed_count blocked_count unblocked_count unblock_still_count plan_bounced_count revise_reconciled_count <<< "$stamping_out"
+    log "stamped ${stamped_count:-0} issue(s) (${blocked_count:-0} marked fleet:blocked); skipped ${skipped_count:-0} already-labeled; bounced ${plan_bounced_count:-0} to fleet:needs-plan; re-plan requested ${revise_reconciled_count:-0} (human:revise-plan); unblocked ${unblocked_count:-0} (${unblock_still_count:-0} still blocked); ${failed_count:-0} failed"
 fi
 
 log "ingestion iteration complete"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -216,6 +216,24 @@ _INGEST_SKIP_LABELS = frozenset({
                            # as repos.<repo>.review_plan, see _populate_review_plan).
 })
 
+# Labels that PULL an issue back into the ingest set even though it also carries
+# a skip label. human:revise-plan is the human-added "change the posted plan"
+# gate: it lands on an issue that is mid-review (fleet:plan-review /
+# human:review-plan, both skip labels), so without this override adding it would
+# neither flip the membership hash (no ingest fire) nor surface the issue in
+# pending_issues (no reconcile). Letting it override both means the human only
+# ever ADDS one label — fleet-queue-ingest resets it to fleet:needs-plan.
+_INGEST_OVERRIDE_LABELS = frozenset({"human:revise-plan"})
+
+
+def _ingest_skipped(labels):
+    """True when an issue should stay OUT of the ingest set. A skip label keeps
+    it out — unless an override label (human:revise-plan) pulls it back in."""
+    lbls = set(labels)
+    if lbls & _INGEST_OVERRIDE_LABELS:
+        return False
+    return bool(lbls & _INGEST_SKIP_LABELS)
+
 
 def fetch_issues_by_label(repo, filter_label, exclude_labels=None, with_body=False):
     # with_body pulls the issue body too — the queue-manager-ingest projection
@@ -1559,7 +1577,7 @@ def project_queue_manager_ingest(state):
     items = []
     for repo, repo_state in state["repos"].items():
         for issue in repo_state.get("human_approved", []):
-            if set(issue.get("labels", [])) & _INGEST_SKIP_LABELS:
+            if _ingest_skipped(issue.get("labels", [])):
                 continue
             items.append({"repo": repo, "issue": issue["number"]})
         for num in _ingest_unblock_candidates(repo_state):
@@ -1857,7 +1875,7 @@ def slice_queue_manager_ingest(state):
     out = {"pending_issues": [], "unblock_issues": []}
     for repo_key, repo_state in state["repos"].items():
         for issue in repo_state.get("human_approved", []):
-            if set(issue.get("labels", [])) & _INGEST_SKIP_LABELS:
+            if _ingest_skipped(issue.get("labels", [])):
                 continue
             out["pending_issues"].append(_slice_issue_with_repo(repo_key, issue))
         for num in _ingest_unblock_candidates(repo_state):

--- a/scripts/fleet/tests/test_fleet_queue_ingest_revise_plan.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_revise_plan.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Test that fleet-queue-ingest reconciles human:revise-plan issues back to
+# fleet:needs-plan for a re-plan (the human-add-one-label affordance).
+#
+# A plan posted for a high-stakes issue sits in fleet:plan-review +
+# human:review-plan awaiting agent + human sign-off. When the human wants the
+# approach changed they add human:revise-plan (and a comment) — and NOTHING
+# else. ingest must then, in one edit: add fleet:needs-plan, remove
+# human:revise-plan and the now-stale fleet:plan-review, and KEEP human:approved
+# + human:review-plan (so the human's approach gate persists across the re-plan
+# and the issue can't queue behind the human's back). It must NOT stamp
+# fleet:queued. A normal human:approved issue in the same batch must still be
+# stamped, proving the harness can stamp and the reconcile is meaningful.
+#
+# HOME is redirected to a temp dir so the script's hardcoded projection/log/lock
+# paths land in the sandbox, and `gh` is stubbed to canned issue/PR surfaces.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INGEST="$SCRIPT_DIR/fleet-queue-ingest"
+
+if [[ ! -x "$INGEST" ]]; then
+    echo "test setup: fleet-queue-ingest not found at $INGEST" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
+
+PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
+# #830 carries human:revise-plan on top of a mid-review plan (the scout's
+# _ingest_skipped override is what lands it in pending_issues; here the
+# projection is hand-built, so we list it directly). #831 is a normal approved
+# issue (the stamp control).
+cat > "$PROJ" <<'JSON'
+{"pending_issues":[
+  {"number":830,"repo":"engine"},
+  {"number":831,"repo":"engine"}
+]}
+JSON
+
+# --- gh stub --------------------------------------------------------------
+STUB_DIR="$TMPROOT/bin"
+mkdir -p "$STUB_DIR"
+export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    issue)
+        case "$2" in
+            view)
+                case "$3" in
+                    830) echo '{"title":"t","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"fleet:task"},{"name":"human:approved"},{"name":"fleet:plan-review"},{"name":"human:review-plan"},{"name":"human:revise-plan"}],"comments":[{"body":"## Plan\nstep 1"}]}' ;;
+                    831) echo '{"title":"t","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"}],"comments":[{"body":"## Plan\nstep 1"}]}' ;;
+                    *)   echo '{"title":"","body":"","labels":[],"comments":[]}' ;;
+                esac
+                exit 0 ;;
+            edit)
+                printf '%s\n' "$*" >> "$EDIT_LOG"
+                exit 0 ;;
+            comment) exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        case "$2" in
+            list) echo '[]'; exit 0 ;;   # scope-shipped: no merged coverage
+            *) exit 0 ;;
+        esac ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+echo "=== run fleet-queue-ingest over a batch with one human:revise-plan issue ==="
+bash "$INGEST" >/dev/null 2>&1 || true
+
+# --- control: #831 normal approved must be stamped fleet:queued -----------
+line_831=$(grep -E '(^| )831( |$)' "$EDIT_LOG" || true)
+if [[ -n "$line_831" && "$line_831" == *"fleet:queued"* ]]; then
+    ok "control #831 stamped fleet:queued (harness can stamp)"
+else
+    bad "control #831 was not stamped fleet:queued — harness broken, test vacuous"
+fi
+
+# --- #830 reconcile assertions -------------------------------------------
+line_830=$(grep -E '(^| )830( |$)' "$EDIT_LOG" || true)
+if [[ -z "$line_830" ]]; then
+    bad "human:revise-plan #830 was never edited (reconcile didn't fire)"
+else
+    [[ "$line_830" == *"--add-label fleet:needs-plan"* ]] \
+        && ok "#830 added fleet:needs-plan" \
+        || bad "#830 did not add fleet:needs-plan: $line_830"
+    [[ "$line_830" == *"--remove-label human:revise-plan"* ]] \
+        && ok "#830 consumed human:revise-plan" \
+        || bad "#830 did not remove human:revise-plan: $line_830"
+    [[ "$line_830" == *"--remove-label fleet:plan-review"* ]] \
+        && ok "#830 stripped stale fleet:plan-review" \
+        || bad "#830 did not remove fleet:plan-review: $line_830"
+    [[ "$line_830" != *"fleet:queued"* ]] \
+        && ok "#830 never stamped fleet:queued" \
+        || bad "#830 was stamped fleet:queued (must not queue on re-plan): $line_830"
+    [[ "$line_830" != *"--remove-label human:review-plan"* ]] \
+        && ok "#830 kept human:review-plan (human's approach gate persists)" \
+        || bad "#830 removed human:review-plan (must persist): $line_830"
+    [[ "$line_830" != *"--remove-label human:approved"* ]] \
+        && ok "#830 kept human:approved (original triage)" \
+        || bad "#830 removed human:approved: $line_830"
+fi
+
+echo
+echo "================================"
+echo "  PASS: $PASS    FAIL: $FAIL"
+echo "================================"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_queue_manager_projection.py
+++ b/scripts/fleet/tests/test_queue_manager_projection.py
@@ -210,6 +210,33 @@ class IngestProjectionFiresOnNewApprovedIssue(unittest.TestCase):
         self.assertEqual(out["pending_issues"], [],
                          "needs-human issue must be absent from pending_issues slice")
 
+    def test_revise_plan_overrides_skip_into_pending(self):
+        # human:revise-plan is the human-added "change the posted plan" gate. It
+        # lands on an issue mid-review (fleet:plan-review / human:review-plan,
+        # both skip labels), so it must OVERRIDE the skip — re-entering the
+        # ingest set so adding it flips the hash (fires ingest) and surfaces it
+        # in pending_issues for fleet-queue-ingest to reset to fleet:needs-plan.
+        revise = [{"number": 2043, "title": "revise me",
+                   "labels": ["human:approved", "fleet:plan-review",
+                              "human:review-plan", "human:revise-plan"]}]
+        h = stable_hash(project_queue_manager_ingest(_state(engine_human_approved=revise)))
+        self.assertNotEqual(h, stable_hash(project_queue_manager_ingest(_state())),
+                            "human:revise-plan must re-enter the ingest set so ingest fires")
+        out = slice_queue_manager_ingest(_state(engine_human_approved=revise))
+        nums = [i["number"] for i in out["pending_issues"]]
+        self.assertIn(2043, nums,
+                      "human:revise-plan issue must appear in pending_issues for reconcile")
+
+    def test_plan_review_without_revise_still_excluded(self):
+        # Guard the override is narrow: a plain mid-review plan (no revise-plan)
+        # stays out of the ingest set exactly as before.
+        review = [{"number": 2044, "title": "in review",
+                   "labels": ["human:approved", "fleet:plan-review",
+                              "human:review-plan"]}]
+        out = slice_queue_manager_ingest(_state(engine_human_approved=review))
+        self.assertEqual(out["pending_issues"], [],
+                         "plan-review issue without revise-plan must stay excluded")
+
 
 class IngestHonorsBlockedBy(unittest.TestCase):
     """resolve_human_approved_blockers() flags issues whose `**Blocked by:**`


### PR DESCRIPTION
## Motivation

Requesting changes to a posted plan currently means the human hand-swaps labels (`fleet:plan-review` → `fleet:needs-plan`). The ask was: **add one label, let the fleet manage the rest.**

## What this adds

A single human-owned label, **`human:revise-plan`**. The human adds it (plus a comment describing the change) to a plan in review; the fleet does every other label transition.

On the next scout tick `fleet-queue-ingest` reconciles the issue:
- adds `fleet:needs-plan` (an opus+ planner re-plans, reading the comment per PLANNING-PROTOCOL.md step 1)
- strips the now-stale stage labels (`fleet:plan-review`, any model / `fleet:blocked` label)
- consumes `human:revise-plan`
- **keeps** `human:approved` (original triage) and `human:review-plan` (the human's approach gate persists across the re-plan, so the issue can't queue behind the human's back)

Then the normal flow resumes: re-planner rewrites the `## Plan`, swaps back to `fleet:plan-review` (+ re-asserts `human:review-plan` on high-stakes work), human clears `human:review-plan` when satisfied, it queues.

## The non-obvious bit (scout)

The scout excludes `fleet:plan-review` / `human:review-plan` issues from the ingest set (`_INGEST_SKIP_LABELS`), so adding a label that doesn't change set membership would neither fire ingest nor land the issue in `pending_issues`. A new `_ingest_skipped()` helper lets `human:revise-plan` **override** the skip at both the projector and the slicer — so adding the label both flips the membership hash (fires ingest) and surfaces the issue for the reconcile.

Scope is the **pre-queue** stages. An already-queued plan that's gone stale keeps using the existing race-guarded re-plan flow (PLANNING-PROTOCOL.md §"Re-planning a stale queued plan").

## Files
- `scripts/fleet/fleet-queue-ingest` — reconcile block + counter
- `scripts/fleet/fleet-state-scout` — `_ingest_skipped()` override at projector + slicer
- `scripts/fleet/fleet-labels` — catalog entry (desc 82 chars, ≤100)
- `docs/agents/fleet-state-machine.json` — node (keeps `fleet-labels --check` green: 56 labels agree)
- `docs/agents/{PLANNING-PROTOCOL,fleet-labels-reference}.md` — human affordance + label prose

## Tests
- New `test_fleet_queue_ingest_revise_plan.sh` — 7 assertions on the reconcile edit (adds needs-plan; removes revise-plan + plan-review; keeps approved + review-plan; never queues).
- `test_queue_manager_projection.py` — +2 cases: override pulls the issue into the set & pending; narrow guard that a no-revise plan-review issue stays excluded.
- Existing ingest/scout/transition suites + `fleet-labels --check` all pass.

## ⚠️ Post-merge
The label must be created on GitHub before it can be used — run `fleet-labels` (the sync) after merge. Until then, adding `human:revise-plan` in the UI won't be possible (the label won't exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)