### PR TITLE
fleet: ruff lint over scripts/fleet/ + CI gate, bootstraps, docs

### DIFF
--- a/.fleet/plans/issue-2047.md
+++ b/.fleet/plans/issue-2047.md
@@ -1,0 +1,132 @@
+## Plan: tooling/fleet — ruff lint over scripts/fleet/
+
+- **Issue:** #2047
+- **Model:** opus
+- **Date:** 2026-06-27
+
+### Verified current state (premise check)
+- **No Python lint exists anywhere** — confirmed: no `ruff` on PATH, no
+  `.pre-commit-config.yaml`, no `.githooks/`, no active git hooks, and no root
+  `pyproject.toml` / `ruff.toml` / `setup.cfg` / `.flake8`. The issue's "Python
+  gets nothing" premise holds.
+- **There is no `pre-commit` *framework* to hook into.** "Mirror how C++ gets
+  clang-format + simplify" is the right instinct, but the C++ quality surface is
+  *not* a git pre-commit hook. It is three things:
+  1. CMake custom targets `format` / `format-check` / `format-changed` defined in
+     `cmake/ir_quality_tools.cmake`, exposed as `*-format-check` / `*-lint`
+     presets in `CMakePresets.json`.
+  2. The **CI gate** `.github/workflows/quality.yml` runs `windows-format-check`
+     + `windows-lint` on every `pull_request` — this is the authoritative,
+     merge-affecting half.
+  3. The **author-side** `commit-and-push` flow runs `fleet-build --target
+     format-changed` + the `simplify` skill before the PR is opened — the
+     "fix before review" half.
+  So a faithful mirror = a **CI lint step** (the bite) + an **author-side
+  documented command** (the pre-review fix), not a new hook framework.
+- **Scope reality:** `scripts/fleet/` holds ~40 Python files (30 `*.py` + 10
+  python-shebang executables like `fleet-state-scout`, `fleet-dispatcher`,
+  `fleet-claim`) plus `scripts/fleet/tests/` (~23 `*.py`). A first `ruff check`
+  *will* surface a backlog, so the implementation PR must bring the tree clean,
+  not just add the gate (else CI is red on master immediately).
+- **Out of scope (note, do not lint in v1):** `scripts/*.py` outside fleet —
+  ~13 render/perf harnesses (`render-verify.py`, `gui-verify.py`,
+  `render_metric_util.py`, `scripts/perf/compare_perf_runs.py`, …). The issue
+  scopes explicitly to `scripts/fleet/`; widening now would balloon the
+  first-fix. File a v2 follow-up to extend the same `ruff.toml` to `scripts/`.
+- **Honesty on the comment policy:** ruff has **no native "comments must be one
+  line" rule.** ruff covers PEP8 (`E`/`W`), pyflakes (`F`), import-order (`I`),
+  and bare-`assert`-as-guard (`S101`, which retroactively covers the rejected
+  #1868 class). The engine one-line-comment policy is a *custom* convention; do
+  **not** promise mechanical enforcement of it in v1. Assert it in docs only.
+
+### Approach (single, picked)
+One PR. Order:
+
+1. **Add `ruff.toml` at repo root.** Pin a conservative initial rule set so the
+   first-fix is bounded and the gate is stable:
+   - `target-version` = the repo's Python floor (`py310` is safe; bump if a
+     module already uses newer syntax).
+   - `[lint] select = ["E", "F", "I", "S101"]` — pycodestyle errors, pyflakes,
+     isort (import-order, the nit the issue calls out), bare-assert.
+   - `line-length = 88` (ruff default; do not import the C++ 80-col rule).
+   - `extend-exclude = ["scripts/fleet/__pycache__", "scripts/fleet/completions"]`.
+   - Scope via `[lint.per-file-ignores]` only if a class of files needs it;
+     prefer fixing over ignoring.
+   The canonical invocation is **`ruff check scripts/fleet/`** (the config pins
+   rules; the path argument pins the v1 scope).
+2. **Clean the existing tree.** Run `ruff check --fix scripts/fleet/` for the
+   autofixable set (imports, spacing), then **hand-fix** the residue with
+   judgment — never blind-suppress. Resolve `fleet-state-scout:56-77` (the
+   issue's cited occurrence: function-between-imports `E402`, missing blanks
+   `E30x`, import order `I001`) so it passes; that doubles as an acceptance
+   check. Keep this diff reviewable — if the backlog is large, the *lint fixes*
+   are mechanical but must be a clearly separated, self-evident part of the PR.
+3. **Wire the CI gate** — add a `Python lint` step to the existing
+   `quality-checks` job in `.github/workflows/quality.yml`, mirroring the
+   `Format check` / `Lint` steps. Install ruff in that step
+   (`pipx install ruff` or `astral-sh/ruff-action`) and run
+   `ruff check scripts/fleet/`. This is the merge-affecting half.
+4. **Make the tool available locally** — add ruff to the three bootstraps so
+   workers can run it pre-commit, mirroring clang-format:
+   `scripts/bootstrap_linux.sh` (apt has no ruff → `pipx install ruff` or
+   `python3 -m pip install ruff`), `scripts/bootstrap_macos.sh`
+   (`brew install ruff`), `scripts/fleet/setup-windows.sh`
+   (`pacman -S` has `mingw-w64-x86_64-python-ruff`, else `pipx`).
+5. **Document the author-side step (NOT in the gated SKILL.md).** Add the
+   one-liner "run `ruff check scripts/fleet/` before committing fleet-script
+   changes" to `docs/agents/BUILD.md` (alongside the `format-changed` note) and
+   the shared flow `docs/agents/skills/commit-and-push.md`. Do **NOT** edit
+   `.claude/skills/commit-and-push/SKILL.md` — it is gated self-config a worker
+   cannot apply (see Gotchas).
+6. **Assert the policy for Python (docs only)** — one line in
+   `docs/agents/CLAUDE-BASELINE.md` stating the one-line-comment / WHY-not-
+   narration policy applies to Python too, with the caveat that ruff enforces
+   PEP8 + import-order mechanically and the comment policy is reviewer-enforced.
+
+### Affected files
+- `ruff.toml` (new) — rule set, scope, line length, excludes.
+- `.github/workflows/quality.yml` — new `Python lint` step in `quality-checks`.
+- `scripts/bootstrap_linux.sh`, `scripts/bootstrap_macos.sh`,
+  `scripts/fleet/setup-windows.sh` — install ruff.
+- `docs/agents/BUILD.md`, `docs/agents/skills/commit-and-push.md` — author-side
+  command.
+- `docs/agents/CLAUDE-BASELINE.md` — Python comment-policy assertion.
+- `scripts/fleet/**` (and `scripts/fleet/tests/**` if `select` covers them) —
+  lint fixes to make the gate green on master.
+
+### Acceptance criteria
+- `ruff check scripts/fleet/` exits 0 on the PR branch.
+- The CI `Python lint` step is present and green on the PR.
+- `ruff check` flags the pre-fix `fleet-state-scout:56-77` occurrence (verify by
+  checking out the pre-fix lines), and the PR fixes it.
+- ruff is installed by all three bootstrap scripts (or a clear `pipx` fallback
+  is documented where no native package exists).
+- No `# noqa` blanket-suppressions introduced to dodge real violations.
+
+### Gotchas
+- **Gated self-config:** `.claude/skills/commit-and-push/SKILL.md` and
+  `.claude/commands/role-*.md` are deterministically gated — a fleet worker
+  **cannot** edit them. Keep all author-side wiring in the non-gated docs
+  (`BUILD.md`, `docs/agents/skills/commit-and-push.md`). If the team later wants
+  the SKILL.md itself to call ruff, that is a separate human-applied change.
+- **Red-on-merge risk:** the CI step and the tree-clean fixes must land in the
+  **same** PR, or `quality.yml` goes red on master the moment the step merges.
+- **Shebang executables:** many fleet scripts are Python with no `.py`
+  extension (`fleet-claim`, `fleet-dispatcher`, …). `ruff check scripts/fleet/`
+  picks `.py` files by default; pass the directory and rely on ruff's shebang
+  detection, or explicitly include them — verify the chosen invocation actually
+  lints the extension-less executables (the largest, most-edited files).
+- **Don't blind `--fix`** the side-effecting scripts: review autofixes to
+  import blocks in files with import-time side effects / conditional imports.
+- **Scope creep:** resist linting `scripts/*.py` (render/perf) in this PR; the
+  first-fix is already non-trivial. v2 follow-up extends the config.
+
+### Decomposition + model
+One PR, **`[opus]`** — judgment in rule-set selection, the comment-policy
+stance, and fixing (not suppressing) the existing backlog; touches the CI gate
++ 3 bootstraps. Not a stack.
+
+### Follow-up to file after this lands (per TASK-FILING.md, no labels)
+- Extend `ruff.toml` scope from `scripts/fleet/` to all of `scripts/` (render /
+  perf / gui harnesses), with its own bounded lint-fix pass.
+

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Lint
         run: cmake --build --preset windows-lint
 
+      # Python analogue of clang-format/clang-tidy for the fleet automation
+      # (scripts/fleet/). Pinned so the gate is stable across ruff releases;
+      # ruff.toml at the repo root pins the rules + the extension-less file set.
+      - name: Python lint (ruff)
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.15.20"
+          args: "check scripts/fleet/"
+
       - name: Build tests
         run: cmake --build --preset windows-tests
 

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -167,6 +167,25 @@ your branch has modified (committed vs `@{upstream}` plus working
 tree). The bare `format` target rewrites every formattable file in the
 repo and should only run on intentional cleanup PRs.
 
+### Python (fleet scripts)
+
+The fleet automation under `scripts/fleet/` is linted by **ruff** — the
+Python analogue of `clang-format`/`clang-tidy`. After touching any fleet
+script, run the canonical check before committing (the CI `Python lint`
+step in `.github/workflows/quality.yml` gates it on every PR):
+
+```bash
+ruff check scripts/fleet/          # PEP8 + import-order + unused + bare-assert
+ruff check --fix scripts/fleet/    # autofix import-order / unused imports
+```
+
+`ruff.toml` at the repo root pins the rules and the file set (it enumerates
+the extension-less Python executables explicitly, since the largest fleet
+scripts — `fleet-claim`, `fleet-dispatcher`, `fleet-up`, … — are bash, not
+Python). ruff is installed by the bootstrap scripts (`brew install ruff` on
+macOS, `pipx install ruff` on Linux, `pacman -S mingw-w64-x86_64-ruff` on
+Windows/MSYS2).
+
 ---
 
 ## Windows-native build (original environment)

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -124,6 +124,13 @@ path, or the API keeps signalling "experimental" when it's the production code
   at the referenced site, not cross-referenced from here. Delete them; if
   the comment carried a genuine WHY, move it to the site it points at.
   (The `simplify` skill's Check 4 greps for these mechanically on new diffs.)
+- **These style and comment rules apply to the fleet Python surface
+  (`scripts/fleet/`) too, not just C++.** PEP8 spacing, import-order, unused
+  imports, and bare-`assert`-as-guard are enforced mechanically by **ruff**
+  (`ruff check scripts/fleet/`, gated in CI — see BUILD.md § "Python (fleet
+  scripts)"). The one-line-comment / WHY-not-narration policy has no mechanical
+  ruff rule, so it stays **reviewer-enforced**: write comments that explain
+  intent, not code narration, in Python the same as in C++.
 
 ---
 

--- a/docs/agents/skills/commit-and-push.md
+++ b/docs/agents/skills/commit-and-push.md
@@ -139,6 +139,18 @@ for this branch.
 draft for the cross-repo leakage tokens listed in the **info-isolation
 check** reference. Surface any match before committing.
 
+**Then**, if the diff touches `scripts/fleet/` (the fleet Python surface), run
+the **Python lint** — the analogue of the C++ `format-changed`/`lint` targets:
+
+```bash
+ruff check --fix scripts/fleet/   # autofix import-order / unused imports
+ruff check scripts/fleet/         # must exit 0 — gated in CI (quality.yml)
+```
+
+Resolve any remaining findings (line-length, ambiguous names, bare asserts)
+before committing; the CI `Python lint` step rejects the PR otherwise. See
+BUILD.md § "Python (fleet scripts)" for the rule set and install.
+
 **Then** invoke the **simplify skill** to review the dirty changes for
 reuse, quality, and efficiency issues. It reads the same diff and applies
 fixes directly. **Always run it, regardless of file types** — no doc-only or

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,60 @@
+# Ruff lint config for the fleet Python surface (scripts/fleet/).
+#
+# The fleet automation is a large, growing body of Python that the C++-only
+# quality surface (clang-format + the simplify-* subagents) never covered, so
+# PEP8 / import-order nits slipped through to review. Ruff is the Python
+# analogue: one fast single-binary pass over scripts/fleet/, gated in CI
+# (.github/workflows/quality.yml) and run author-side before commit.
+#
+# Canonical invocation: `ruff check scripts/fleet/` (this file pins the rules
+# and the file set; the path argument pins the v1 scope). v1 scope is
+# scripts/fleet/ only; extending to the rest of scripts/ (render / perf / gui
+# harnesses) is a tracked follow-up.
+
+# 100, not ruff's default 88: the existing fleet Python was written to a ~100-col
+# soft limit (96 of 106 pre-existing E501s were 89–99 chars), and PEP8 itself
+# blesses extending to 99. Enforcing 88 would force ~106 high-risk hand-wraps in
+# critical infra (fleet-state-scout, fleet-claim-adjacent logic) for near-zero
+# value; 100 matches the code and keeps the first-fix diff reviewable.
+target-version = "py310"
+line-length = 100
+
+# Many fleet scripts are Python executables with no .py extension. ruff's
+# directory scan only matches *.py / *.pyi by default, and a bare basename in
+# extend-include is root-anchored (won't match a nested file), so each Python
+# executable is listed by its repo-relative path. They are enumerated
+# explicitly — NOT via a `fleet-*` glob — because the largest fleet scripts
+# (fleet-claim, fleet-dispatcher, fleet-up, fleet-babysit, fleet-rebase) are
+# bash, and feeding bash to ruff yields thousands of false positives. Add a new
+# Python executable here when one is introduced.
+extend-include = [
+    "scripts/fleet/fleet-claude-stream",
+    "scripts/fleet/fleet-epic-status",
+    "scripts/fleet/fleet-feedback",
+    "scripts/fleet/fleet-issue",
+    "scripts/fleet/fleet-pr",
+    "scripts/fleet/fleet-reconcile-amendments",
+    "scripts/fleet/fleet-state-scout",
+    "scripts/fleet/fleet-validate-roles",
+    "scripts/fleet/fleet-validate-stack",
+    "scripts/fleet/review-fleet-feedback",
+]
+
+extend-exclude = [
+    "scripts/fleet/__pycache__",
+    "scripts/fleet/completions",
+    "scripts/fleet/tests/__pycache__",
+]
+
+[lint]
+# E/W  pycodestyle   — PEP8 errors + warnings (spacing, blank lines, E402)
+# F    pyflakes      — undefined names, unused imports, redefinitions
+# I    isort         — import ordering (the nit #2047 calls out)
+# S101 flake8-bandit — bare `assert` as a runtime guard (retroactively covers
+#                      the #1868 class; ignored in tests, where assert is the
+#                      test primitive)
+select = ["E", "W", "F", "I", "S101"]
+
+[lint.per-file-ignores]
+# pytest-style test modules use `assert` as their assertion primitive.
+"scripts/fleet/tests/**" = ["S101"]

--- a/scripts/bootstrap_linux.sh
+++ b/scripts/bootstrap_linux.sh
@@ -74,6 +74,19 @@ fi
 ${SUDO} apt-get install -y qtbase5-dev qttools5-dev-tools || \
     echo "[warn] qtbase5-dev not installed; easy_profiler GUI will be disabled."
 
+# ruff lints the fleet Python surface (scripts/fleet/) — the Python analogue of
+# clang-format/clang-tidy. apt has no ruff package, so install via pipx, which
+# isolates it from the system Python and sidesteps PEP 668. Best-effort: a
+# missing ruff only disables the local fleet Python lint, not the build.
+if command -v ruff >/dev/null 2>&1; then
+    echo "[ok] ruff already installed"
+elif ${SUDO} apt-get install -y pipx && pipx install ruff; then
+    echo "[ok] Installed ruff via pipx"
+else
+    echo "[warn] ruff not installed; run 'pipx install ruff' (or 'pip install" \
+         "--user ruff') to enable 'ruff check scripts/fleet/' before commit."
+fi
+
 verify_tool() {
     local label="$1"
     shift
@@ -96,6 +109,7 @@ verify_tool "pkg-config finds gl" pkg-config --exists gl
 verify_tool "pkg-config finds wayland-protocols" pkg-config --exists wayland-protocols
 verify_tool "clang-format available" clang-format --version
 verify_tool "clang-tidy available" clang-tidy --version
+verify_tool "ruff available (fleet Python lint)" ruff --version
 
 echo
 echo "Bootstrap complete."

--- a/scripts/bootstrap_macos.sh
+++ b/scripts/bootstrap_macos.sh
@@ -55,14 +55,17 @@ fi
 
 ensure_homebrew
 
+# ruff lints the fleet Python surface (scripts/fleet/) — the Python analogue of
+# clang-format/clang-tidy; available as a native brew formula.
 brew update
-brew install cmake ninja pkg-config ffmpeg llvm qt@5
+brew install cmake ninja pkg-config ffmpeg llvm qt@5 ruff
 
 echo
 echo "Verifying toolchain..."
 verify_tool "Homebrew ffmpeg pkg-config metadata found" pkg-config --exists libavcodec
 verify_tool "clang-format available" "$(brew --prefix llvm)/bin/clang-format" --version
 verify_tool "clang-tidy available" "$(brew --prefix llvm)/bin/clang-tidy" --version
+verify_tool "ruff available (fleet Python lint)" ruff --version
 verify_tool "Qt5 qmake available" "$(brew --prefix qt@5)/bin/qmake" --version
 
 if xcrun --find metal >/dev/null 2>&1 && xcrun --find metallib >/dev/null 2>&1; then

--- a/scripts/fleet/fleet-feedback
+++ b/scripts/fleet/fleet-feedback
@@ -196,7 +196,8 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--role", default=None,
-        help="Filter to one role (e.g. merger, worker). For multi-instance roles use the full per-worktree name (e.g. worker-1, worker-2).",
+        help="Filter to one role (e.g. merger, worker). For multi-instance "
+             "roles use the full per-worktree name (e.g. worker-1, worker-2).",
     )
     parser.add_argument(
         "--headlines", action="store_true",
@@ -204,7 +205,8 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--clear", action="store_true",
-        help="Archive ALL feedback files to ~/.fleet/feedback/.archive/<timestamp>/. Ignores --role; clears all agents.",
+        help="Archive ALL feedback files to ~/.fleet/feedback/.archive/"
+             "<timestamp>/. Ignores --role; clears all agents.",
     )
     args = parser.parse_args(argv)
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -23,8 +23,8 @@ import hashlib
 import json
 import os
 import re
-import signal
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -51,9 +51,9 @@ if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
 # python. Insert this script's own dir so the import resolves whether the
 # scout is run directly or loaded by-path in the unit tests (#1425).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from fleet_branch_match import branch_matches_issue, PARKED_PR_LABELS
+from fleet_blocked_by import is_no_blocker_value, parse_blocked_by
+from fleet_branch_match import PARKED_PR_LABELS, branch_matches_issue
 from fleet_stack_base import unsafe_base_reason
-from fleet_blocked_by import parse_blocked_by, is_no_blocker_value
 
 
 def _fleet_script_argv(cmd):
@@ -413,8 +413,8 @@ def fetch_task_queue(repo_slug):
     for issue in issues:
         raw_labels = issue.get("labels", [])
         labels = {
-            (l["name"] if isinstance(l, dict) else l)
-            for l in raw_labels
+            (label["name"] if isinstance(label, dict) else label)
+            for label in raw_labels
         }
         body = issue.get("body", "") or ""
         title = issue.get("title", "")
@@ -445,9 +445,9 @@ def fetch_task_queue(repo_slug):
         # Claim labels are `fleet:claim-<host>-<agent>`; agent half is what
         # roles see in `fleet-claim list`.
         owner = "free"
-        for l in labels:
-            if l.startswith("fleet:claim-"):
-                suffix = l[len("fleet:claim-"):]
+        for label in labels:
+            if label.startswith("fleet:claim-"):
+                suffix = label[len("fleet:claim-"):]
                 _, _, agent = suffix.partition("-")
                 owner = agent or suffix
                 break
@@ -468,7 +468,7 @@ def fetch_task_queue(repo_slug):
 
         blocked_by = _parse_blocked_by(body) or "(none)"
 
-        area_parts = [_AREA_LABEL_MAP[l] for l in labels if l in _AREA_LABEL_MAP]
+        area_parts = [_AREA_LABEL_MAP[label] for label in labels if label in _AREA_LABEL_MAP]
         area = (
             ", ".join(sorted(area_parts))
             if area_parts
@@ -885,7 +885,7 @@ def _review_skipped(labels):
     labels or any dynamic per-host claim prefix (e.g. fleet:amending-*)."""
     if labels & REVIEW_SKIP_LABELS:
         return True
-    return any(l.startswith(p) for l in labels for p in REVIEW_SKIP_PREFIXES)
+    return any(label.startswith(p) for label in labels for p in REVIEW_SKIP_PREFIXES)
 
 # Smoke-worker label sets. Windows smoke is excluded — cleared by
 # platform-catchup (#1093), not by fleet agents.
@@ -942,7 +942,8 @@ def _blocker_pr_files(repo_key, pr_number):
 
 def _is_gated_self_config(path):
     # Auto-mode self-edit gate (role-worker.md step 8b) — deterministic across
-    # all worker classes. Keep in sync with role-worker.md step 8b and FLEET-FEEDBACK-HANDLING.md § DEFER (gated-self-config).
+    # all worker classes. Keep in sync with role-worker.md step 8b and
+    # FLEET-FEEDBACK-HANDLING.md § DEFER (gated-self-config).
     return (
         fnmatch.fnmatch(path, ".claude/commands/role-*.md")
         or path.startswith(".claude/agents/")
@@ -1575,7 +1576,7 @@ def _smoke_pr_eligible(labels_set):
         return False
     if labels_set & _SMOKE_SKIP_LABELS:
         return False
-    if any(l.startswith("fleet:reviewing-") for l in labels_set):
+    if any(label.startswith("fleet:reviewing-") for label in labels_set):
         return False
     return True
 
@@ -2069,8 +2070,10 @@ def collect_state():
             ("engine", "prs", lambda: fetch_prs("jakildev/IrredenEngine")),
             ("engine", "needs_plan", lambda: fetch_needs_plan("jakildev/IrredenEngine")),
             ("engine", "human_approved", lambda: fetch_human_approved("jakildev/IrredenEngine")),
-            ("engine", "closed_fleet_queued", lambda: fetch_closed_fleet_queued("jakildev/IrredenEngine")),
-            ("engine", "recent_merged_prs", lambda: fetch_recent_merged_prs("jakildev/IrredenEngine")),
+            ("engine", "closed_fleet_queued",
+             lambda: fetch_closed_fleet_queued("jakildev/IrredenEngine")),
+            ("engine", "recent_merged_prs",
+             lambda: fetch_recent_merged_prs("jakildev/IrredenEngine")),
             ("engine", "tasks", lambda: fetch_task_queue("jakildev/IrredenEngine")),
             ("engine", "epics", lambda: fetch_epics("jakildev/IrredenEngine")),
         ]

--- a/scripts/fleet/fleet-validate-roles
+++ b/scripts/fleet/fleet-validate-roles
@@ -24,7 +24,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
-from fleet_validate_roles import validate_roles, DELTA_KEY_ALIASES  # noqa: E402
+from fleet_validate_roles import DELTA_KEY_ALIASES, validate_roles  # noqa: E402
 
 SCRIPT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 REPO_ROOT = SCRIPT_DIR.parent.parent

--- a/scripts/fleet/fleet-validate-stack
+++ b/scripts/fleet/fleet-validate-stack
@@ -40,7 +40,9 @@ import sys
 # cwd — same idiom fleet-queue-ingest uses for fleet_scope_shipped.
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from fleet_validate_stack import (  # noqa: E402
-    discover_children, is_epic_child, validate_stack, check_checklist,
+    check_checklist,
+    discover_children,
+    validate_stack,
 )
 
 STATE_DIR = os.path.join(os.path.expanduser("~"), ".fleet", "state")

--- a/scripts/fleet/review-fleet-feedback
+++ b/scripts/fleet/review-fleet-feedback
@@ -34,7 +34,7 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -61,7 +61,7 @@ ENTRY_HEAD_FILE = re.compile(
     r"^##\s+"
     r"(\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}(?::\d{2})?)?)"   # date, optional time
     r"(?:\s*(?:Z|UTC))?"                                      # optional Z / UTC suffix
-    r"(?:\s*(?:[—–:-]+\s*)?(.*?))?\s*$"                       # optional inline headline; separator optional
+    r"(?:\s*(?:[—–:-]+\s*)?(.*?))?\s*$"                 # optional inline headline (sep optional)
 )
 
 # Pattern bank — order matters; first match wins. Widen aggressively;
@@ -512,8 +512,11 @@ def cmd_digest(args: argparse.Namespace) -> int:
         "marker_note": marker_note,
         "now": now.strftime("%Y-%m-%dT%H:%M:%S"),
         "total_entries": len(entries),
-        "clusters": [c.to_dict() for c in clusters
-                     if c.signature != "uncategorized" and len(c.entries) >= MIN_CLUSTER_SIZE_FOR_PROPOSAL],
+        "clusters": [
+            c.to_dict() for c in clusters
+            if c.signature != "uncategorized"
+            and len(c.entries) >= MIN_CLUSTER_SIZE_FOR_PROPOSAL
+        ],
         "singletons": [
             {"ts": e.ts, "role": e.role, "headline": e.headline,
              "signature": signature_for(e)}

--- a/scripts/fleet/setup-windows.sh
+++ b/scripts/fleet/setup-windows.sh
@@ -70,6 +70,19 @@ if [[ ! -x "${IR_MSYS2_MINGW_DIR:-/c/msys64/mingw64/bin}/g++.exe" ]] \
     echo "  WARN: MSYS2 mingw64 toolchain not found at /c/msys64/mingw64/bin" >&2
     echo "        install with: pacman -S mingw-w64-x86_64-toolchain" >&2
 fi
+# ruff lints the fleet Python surface (scripts/fleet/) — run before committing
+# fleet-script changes. Soft dependency (needed for the local Python lint, not
+# to run the fleet), so install best-effort: MSYS2 package first, else pipx/pip.
+if command -v ruff >/dev/null 2>&1; then
+    echo "  ok: ruff ($(command -v ruff))"
+elif pacman -S --needed --noconfirm mingw-w64-x86_64-ruff >/dev/null 2>&1; then
+    echo "  ok: installed ruff via pacman"
+elif command -v pipx >/dev/null 2>&1 && pipx install ruff >/dev/null 2>&1; then
+    echo "  ok: installed ruff via pipx"
+else
+    echo "  WARN: ruff not installed — 'ruff check scripts/fleet/' (the fleet" >&2
+    echo "        Python lint) won't run locally. Try: pacman -S mingw-w64-x86_64-ruff" >&2
+fi
 case "$(uname -s)" in
     MINGW*|MSYS*) : ;;
     *) echo "  ERROR: not a Windows MSYS2/Git-Bash shell (uname=$(uname -s))." >&2; exit 1 ;;

--- a/scripts/fleet/tests/test_branch_matches_issue.py
+++ b/scripts/fleet/tests/test_branch_matches_issue.py
@@ -12,11 +12,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from fleet_branch_match import (
+    _is_game,
     branch_matches_issue,
     issue_branch_prefixes,
     issue_from_branch,
     issue_pr_state,
-    _is_game,
 )
 
 

--- a/scripts/fleet/tests/test_fleet_claude_stream_latch.py
+++ b/scripts/fleet/tests/test_fleet_claude_stream_latch.py
@@ -9,7 +9,6 @@ Covers:
 import importlib.machinery
 import importlib.util
 import json
-import os
 import pathlib
 import tempfile
 import unittest

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -26,7 +26,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from fleet_task_class import resolve, feedback_pr_class  # noqa: E402
+from fleet_task_class import feedback_pr_class, resolve  # noqa: E402
 
 
 def _task(issue, model=None, effort=None, owner="free", blocked=False,

--- a/scripts/fleet/tests/test_queue_manager_projection.py
+++ b/scripts/fleet/tests/test_queue_manager_projection.py
@@ -12,7 +12,6 @@ no .py extension, mirroring test_enrich_stackable_blocker_prs.py.
 """
 import importlib.machinery
 import importlib.util
-import json
 import unittest
 from pathlib import Path
 
@@ -188,7 +187,8 @@ class IngestProjectionFiresOnNewApprovedIssue(unittest.TestCase):
         # only the pending ones should appear in the slice.
         issues = [
             {"number": 9003, "title": "Pending", "labels": ["human:approved"]},
-            {"number": 9004, "title": "Shipped", "labels": ["human:approved", "fleet:scope-shipped"]},
+            {"number": 9004, "title": "Shipped",
+             "labels": ["human:approved", "fleet:scope-shipped"]},
         ]
         out = slice_queue_manager_ingest(_state(engine_human_approved=issues))
         nums = [i["number"] for i in out["pending_issues"]]

--- a/scripts/fleet/tests/test_review_feedback_parse_dt.py
+++ b/scripts/fleet/tests/test_review_feedback_parse_dt.py
@@ -1,4 +1,5 @@
-"""parse_dt Z-suffix regression: applied_at silently returned None, killing both mechanical transitions."""
+"""parse_dt Z-suffix regression: applied_at silently returned None, killing
+both mechanical transitions."""
 import importlib.machinery
 import importlib.util
 import sys

--- a/scripts/fleet/tests/test_state_json_atomic_write.py
+++ b/scripts/fleet/tests/test_state_json_atomic_write.py
@@ -24,7 +24,6 @@ import glob
 import importlib.machinery
 import importlib.util
 import json
-import os
 import subprocess
 import sys
 import tempfile

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -349,7 +349,7 @@ class PlanReviewExcludedFromTasksOpen(unittest.TestCase):
                 {"name": "fleet:queued"},
                 {"name": "fleet:sonnet"},
                 {"name": "human:approved"},
-            ] + [{"name": l} for l in extra_labels],
+            ] + [{"name": label} for label in extra_labels],
             "body": "**Model:** sonnet\n",
         }
 
@@ -390,7 +390,7 @@ class NeedsGlHostAnnotation(unittest.TestCase):
                 {"name": "fleet:queued"},
                 {"name": "fleet:opus"},
                 {"name": "human:approved"},
-            ] + [{"name": l} for l in extra_labels],
+            ] + [{"name": label} for label in extra_labels],
             "body": "**Model:** opus\n",
         }
 


### PR DESCRIPTION
## Summary
- **ruff.toml** at the repo root pins the rule set (`E`/`W`/`F`/`I`/`S101`) and the file scope for `ruff check scripts/fleet/`. The 10 extension-less Python executables are enumerated by repo-relative path — a `fleet-*` glob would wrongly feed the *bash* scripts (`fleet-claim`, `fleet-dispatcher`, `fleet-up`, `fleet-babysit`, `fleet-rebase`) to ruff, and bare-include basenames are root-anchored so they don't match nested files.
- **Cleaned the existing tree to green** (28 findings): import-order + unused-import autofixes, ambiguous `l`→`label` renames, and line wraps. This resolves the `fleet-state-scout` occurrence the issue cites (unsorted second import block).
- **CI gate**: a `Python lint (ruff)` step in `.github/workflows/quality.yml` (pinned ruff `0.15.20`), mirroring `Format check` / `Lint`. It and the tree-clean fixes land in the same PR so master never goes red.
- **Bootstraps**: ruff install added to all three (`brew install ruff` on macOS, `pipx install ruff` on Linux, `pacman -S mingw-w64-x86_64-ruff` on Windows/MSYS2) — all best-effort.
- **Docs**: author-side `ruff check scripts/fleet/` command in `BUILD.md` + the shared `commit-and-push` flow, and a Python comment-policy assertion in `CLAUDE-BASELINE.md`.

## Test plan
- [x] `ruff check scripts/fleet/` exits 0 on the branch (40 files: 30 `*.py` + the 10 extension-less Python execs; no bash files scanned).
- [x] All edited Python files `py_compile` clean; affected unittest suites pass (`test_worker_projection`, `test_queue_manager_projection`, `test_review_feedback_parse_dt`, scout suites, …).
- [x] Edited shell scripts pass `bash -n`; `quality.yml` parses as valid YAML with the new step between `Lint` and `Build tests`.
- [ ] CI `Python lint (ruff)` step is green on this PR (verifies the gate end-to-end on the Windows runner).

## Notes for reviewer
- **Line-length is 100, not the plan's 88.** The existing fleet Python targets ~100 cols (96 of 106 pre-existing `E501`s were 89–99 chars). Enforcing 88 would force ~106 high-risk hand-wraps in critical infra (`fleet-state-scout`) for near-zero value, against the plan's own "keep the first-fix reviewable" goal. 100 is PEP8-defensible (PEP8 blesses up to 99) and matches the code — documented inline in `ruff.toml`.
- **`S101` (bare-assert) is ignored under `scripts/fleet/tests/`** — pytest/unittest use `assert` as the assertion primitive; it's still enforced for non-test code (covers the #1868 class).
- **Pre-existing, out of scope:** `test_fleet_validate_roles::test_current_engine_tree_passes` fails on master (the live `role-opus-reviewer.md` is missing delta keys vs `architect-protocol.md`). It's independent of this PR (confirmed by stashing the diff) — that file is partly gated self-config and not touched here.

Closes #2047

🤖 Generated with [Claude Code](https://claude.com/claude-code)