### PR TITLE
fleet: fleet:gated label — single human-only skip for gated-file blocks (#1990 thrash fix)

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -210,7 +210,7 @@ exit cleanly:
      `fleet:blocker`, `human:needs-fix`, `human:blocker`,
      `human:re-review`, `fleet:semantic-conflict`,
      `fleet:fork-of-other-pr`, `fleet:needs-base-update`,
-     `fleet:needs-info`, `fleet:merger-cooldown`.
+     `fleet:needs-info`, `fleet:gated`, `fleet:merger-cooldown`.
 
    `fleet:awaiting-base` is intentionally NOT in this skip list —
    those PRs are exactly the population whose upstream tip we
@@ -350,6 +350,14 @@ exit cleanly:
    - `fleet:needs-info` — set in stacked-PR case iii (orphaned base).
      Durable human-handoff signal; only the human clears it by
      re-targeting or closing.
+   - `fleet:gated` — the PR's conflict surface is a gated self-config file
+     (`role-*.md` / `.claude/agents/*` / `SKILL.md`) no agent can push. A
+     worker hit the gate and parked it human-only. **Do not re-flag it
+     `fleet:semantic-conflict`** — that is the exact loop fleet:gated
+     exists to break (a worker would re-claim, re-hit the gate, re-park;
+     #1990 thrashed 11× before this label existed). Only the human (or the
+     architect, who can push gated edits with a human in the loop) clears it
+     by resolving the conflict and dropping the label.
    - `fleet:fork-of-other-pr` — PR's branch forked from another open PR; skip until the human clears this label after the upstream PR merges
    - `fleet:needs-base-update` — set in step 2.6 when a stacked child's
      upstream tip moved and the cascade-rebase conflicted. Durable
@@ -695,6 +703,30 @@ exit cleanly:
 
       **ii. Anything else (semantic conflict).**
          - `git rebase --abort`
+         - **Gated short-circuit — check the conflicted file set FIRST.**
+           Get the conflicted files (`git diff --name-only --diff-filter=U`
+           from the aborted rebase, or `git rebase` then read the markers).
+           If **every** conflicted file is a gated self-config file —
+           `.claude/commands/role-*.md`, `.claude/agents/*`, or
+           `.claude/skills/**/SKILL.md` — then **no worker class can push a
+           resolution**, so labeling `fleet:semantic-conflict` only starts the
+           worker↔merger thrash (the worker re-claims, re-hits the commit
+           gate, re-parks — #1990 looped 11× this way). Skip the
+           semantic-conflict path entirely:
+             - `git switch claude/merger-scratch`
+             - `gh pr edit <N> --add-label "fleet:gated"`
+             - `gh pr edit <N> --remove-label "fleet:approved"` (best-effort;
+               the diff no longer represents a mergeable state)
+             - `gh pr comment <N> --body "Merger: conflict surface is entirely
+               gated self-config (no agent class can push the resolution).
+               Labeled \`fleet:gated\` — human-only resolution (or the
+               architect, who can push gated edits with a human in the loop).
+               Conflicted: <file list>. — fleet merger"`
+             - Log: `... gated-self-config conflict, labeled fleet:gated`
+             - Jump to step f. Do NOT label fleet:semantic-conflict.
+           A **partially** gated conflict (some gated files, some normal) is
+           still worker-resolvable for the normal part — fall through to the
+           semantic-conflict path below and let the worker handle it.
          - Reset to scratch. With detached HEAD (step a) this no
            longer matters for unblocking other agents — detached
            HEAD never claimed the branch — but the reset still
@@ -896,8 +928,8 @@ See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`]
   actions on your own PRs. Use `--comment` for status posts
   (already handled via `gh pr comment`).
 - **Never bypass labels.** A PR with `human:wip`, `fleet:wip`,
-  `fleet:blocker`, `human:needs-fix`, or `human:blocker` is off-
-  limits. Do not touch.
+  `fleet:blocker`, `human:needs-fix`, `human:blocker`, or `fleet:gated`
+  is off-limits. Do not touch.
 - **Never edit code mid-rebase to make a conflict resolve.** The
   only in-rebase resolutions you apply are mechanical
   whitespace-only diffs handled in case (i). Any other source-file

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -369,6 +369,22 @@ Do the work, then exit cleanly:
        is the manual fallback for when it silently doesn't fire — e.g. the
        parent branch was amended during review *after* you forked, so its
        recorded `headRefOid` is no longer an ancestor of your head (#1791).
+    d''. **Gated-conflict guard — check before resolving.** List the
+       conflicted files (`git diff --name-only --diff-filter=U`). If **every**
+       one is a gated self-config file (`.claude/commands/role-*.md`,
+       `.claude/agents/*`, `.claude/skills/**/SKILL.md`), you physically
+       cannot push the resolution — the commit gate blocks the role-doc/agent/
+       SKILL edit regardless of how cleanly you resolve it. Do **not** resolve
+       and do **not** escalate to `human:needs-fix` (that re-triggers step-1
+       worker pickup, and the next worker re-hits the same wall — this is the
+       #1990 thrash). Park it `fleet:gated`, which every picker skips:
+       - `git rebase --abort`
+       - `gh pr edit <N> --repo jakildev/IrredenEngine --remove-label "fleet:semantic-conflict" --add-label "fleet:gated"`
+       - `gh pr comment <N> --repo jakildev/IrredenEngine --body "Conflict surface is entirely gated self-config; no worker class can push the resolution. Parking \`fleet:gated\` for human-only resolution (or the architect, who can push gated edits with a human in the loop). Conflicted: <file list>. — worker"`
+       - Jump to step k (reset + release the resolving lock).
+       A **partially** gated conflict (some gated files, some normal) is still
+       worker-resolvable for the normal part — proceed to step e, resolve the
+       non-gated files, and comment the gated part for the human.
     e. For each conflicted file (`git diff --name-only --diff-filter=U`):
        - **Read the full file** (not just the conflict block) so you
          understand the surrounding code.

--- a/docs/agents/FLEET-FEEDBACK-HANDLING.md
+++ b/docs/agents/FLEET-FEEDBACK-HANDLING.md
@@ -208,24 +208,37 @@ analogue of role-worker.md step 8b. Take the DEFER path, **not** AMEND:
    gh pr comment <N> --repo jakildev/IrredenEngine \
      --body "Fix surface is entirely gated self-config; cannot amend. \
    Human fix needed: <exact file> — <what to change>. \
-   Parking fleet:human-deferred. — worker"
+   Parking fleet:gated. — worker"
    ```
-2. Atomically swap labels (`fleet:needs-fix` dropped → `fleet:human-deferred`
+2. Atomically swap labels (`fleet:needs-fix` dropped → `fleet:gated`
    added; keep `fleet:approved` if present — the diff is internally consistent):
    ```
    gh pr edit <N> --repo jakildev/IrredenEngine \
      --remove-label "fleet:needs-fix" \
-     --add-label "fleet:human-deferred"
+     --add-label "fleet:gated"
    ```
 3. Release the feedback claim and move on — do **not** amend, do **not** push:
    ```
    fleet-claim amending-release <N> <your-worktree-basename>
    ```
 
-This makes the park terminal: `fleet:needs-fix` is gone, so the PR is excluded
-from the worker dispatch trigger on the next tick. A partially-gated PR (some
-gated, some normal paths) should **not** take this path — amend the non-gated
-part normally and comment the gated part for the human.
+This makes the park terminal: `fleet:needs-fix` is gone and `fleet:gated` is in
+every picker's skip set (merger, all worker classes, reviewers — see
+fleet-state-scout `REVIEW_SKIP_LABELS` / `_merger_action_signal` /
+`project_worker`), so the PR is excluded from the worker dispatch trigger AND
+the merger sweep on the next tick — nothing re-grabs it until a human clears the
+label. A partially-gated PR (some gated, some normal paths) should **not** take
+this path — amend the non-gated part normally and comment the gated part for the
+human.
+
+> **Why `fleet:gated`, not `fleet:human-deferred`?** `fleet:human-deferred`
+> marks an *approved, still-mergeable* PR whose follow-up concern moved to a new
+> issue — the merger is meant to merge it, so it deliberately does **not** skip
+> that label. A gated block is the opposite: the PR is **not** mergeable as-is
+> (a human must apply the gated edit), so it needs a label every picker skips.
+> Overloading `fleet:human-deferred` for both is what made #1990 thrash 11×
+> (the merger kept treating the gated park as merge-ready and re-flagging
+> `fleet:semantic-conflict`). `fleet:gated` is the dedicated human-only state.
 
 ### AMEND (default)
 

--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -388,6 +388,29 @@ Specifically, **never pass these via `--label` when filing**:
     **Read as: "agent acknowledged your concerns, linked issue tracks
     them; the deferral covers the diff at defer time, not the PR
     forever."**
+- `fleet:gated` — owned by **whichever agent first hits the wall**: the
+  merger (when a conflict's whole surface is gated self-config — it labels
+  `fleet:gated` instead of `fleet:semantic-conflict`), or a worker (a
+  semantic-conflict whose conflicted files are all gated, role-worker.md step
+  1c d''; or a `fleet:needs-fix` PR whose entire fix surface is gated,
+  FLEET-FEEDBACK-HANDLING.md DEFER path). Means **the PR is blocked on an edit
+  to a gated self-config file** (`.claude/commands/role-*.md`,
+  `.claude/agents/*`, `.claude/skills/**/SKILL.md`) that the auto-mode
+  self-modification gate physically prevents any agent class from pushing.
+  **It is a hard, human-only stop:** it is in *every* picker's skip set —
+  the merger sweep, all worker-class dispatch, and reviewer pickup (see
+  fleet-state-scout `_merger_action_signal`, `project_worker`/`slice_worker`,
+  and `REVIEW_SKIP_LABELS`). Nothing automated touches it until a human (or
+  the architect, who can push gated edits with a human in the loop) resolves
+  the gated edit and drops the label.
+  **Why it exists, distinct from `fleet:human-deferred`:** human-deferred
+  marks an *approved, still-mergeable* PR (the merger deliberately does NOT
+  skip it). A gated block is the opposite — *not* mergeable until a human acts
+  — so it needs a label the merger skips. Overloading human-deferred for both
+  is what made #1990 thrash 11× (merger read the gated park as merge-ready and
+  re-flagged `fleet:semantic-conflict` every tick; no worker class could clear
+  it). **Read as: "an agent hit a permission wall it can't cross — a human
+  must make this edit."**
 - `fleet:design-blocked` / `fleet:design-unblocked` — paired
   state qualifiers for the mid-task design-escalation cycle (see
   [`FLEET.md`](FLEET.md) "Design-escalation flow"). `design-blocked` is set by the

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -282,7 +282,7 @@
       "name": "fleet:gated",
       "scope": "pr",
       "color": "b60205",
-      "description": "Conflict/fix surface is a gated self-config file no agent can push; human-only; merger + all worker classes + reviewers skip it"
+      "description": "Conflict/fix surface is gated self-config; human-only; merger + all workers + reviewers skip"
     },
     {
       "name": "fleet:human-amending",

--- a/docs/agents/fleet-state-machine.json
+++ b/docs/agents/fleet-state-machine.json
@@ -279,6 +279,12 @@
       "description": "Worker filed human:needs-fix concerns as a follow-up issue; PR is internally OK to merge if human accepts the deferral (fleet:approved kept)"
     },
     {
+      "name": "fleet:gated",
+      "scope": "pr",
+      "color": "b60205",
+      "description": "Conflict/fix surface is a gated self-config file no agent can push; human-only; merger + all worker classes + reviewers skip it"
+    },
+    {
       "name": "fleet:human-amending",
       "scope": "pr",
       "color": "c5def5",

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -143,6 +143,7 @@ LABELS=(
     "fleet:stacked-rebase|c5def5|Stacked PR; base just merged, re-targeted to master, awaiting reviewer re-eval"
     "fleet:awaiting-upstream-review|c5def5|Stacked PR; reviewer is holding verdict until upstream PR is approved"
     "fleet:human-deferred|fbca04|Worker deferred human:needs-fix concerns to a follow-up; OK to merge if human accepts the deferral"
+    "fleet:gated|b60205|Conflict/fix surface is a gated self-config file no agent can push; human-only; all agents skip"
     "fleet:human-amending|c5def5|Worker is amending this PR with the human:needs-fix fixes; hold merge until fleet:changes-made"
     "human:owned|5319e7|Human took this issue out of the queue; ingest never re-stamps fleet:queued (reconcile flags both)"
     "human:no-plan|5319e7|Human opt-out at filing: skip planning, queue directly; [no-plan] tag honored; agents never apply it"

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -143,7 +143,7 @@ LABELS=(
     "fleet:stacked-rebase|c5def5|Stacked PR; base just merged, re-targeted to master, awaiting reviewer re-eval"
     "fleet:awaiting-upstream-review|c5def5|Stacked PR; reviewer is holding verdict until upstream PR is approved"
     "fleet:human-deferred|fbca04|Worker deferred human:needs-fix concerns to a follow-up; OK to merge if human accepts the deferral"
-    "fleet:gated|b60205|Conflict/fix surface is a gated self-config file no agent can push; human-only; all agents skip"
+    "fleet:gated|b60205|Conflict/fix surface is gated self-config; human-only; merger + all workers + reviewers skip"
     "fleet:human-amending|c5def5|Worker is amending this PR with the human:needs-fix fixes; hold merge until fleet:changes-made"
     "human:owned|5319e7|Human took this issue out of the queue; ingest never re-stamps fleet:queued (reconcile flags both)"
     "human:no-plan|5319e7|Human opt-out at filing: skip planning, queue directly; [no-plan] tag honored; agents never apply it"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -871,6 +871,12 @@ REVIEW_SKIP_LABELS = frozenset({
     # _merger_action_signal does NOT skip fleet:human-deferred (an approved
     # deferred PR is still mergeable) — this skip is reviewer-only.
     "fleet:human-deferred", "fleet:needs-human",
+    # Blocked on a gated self-config edit no agent can push (role-*.md /
+    # .claude/agents/* / SKILL.md). Human-only; every picker skips it
+    # unconditionally — see _merger_action_signal and project_worker. Unlike
+    # fleet:human-deferred this is NOT mergeable-by-the-merger: the conflict
+    # itself sits in the gated file, so a human must resolve before merge.
+    "fleet:gated",
 })
 # Dynamic per-host claim prefixes that also bar reviewer pickup. A worker
 # amending a fleet:needs-fix PR holds fleet:amending-<host>-<agent> (minted
@@ -1363,9 +1369,17 @@ def project_worker(state):
             labels = set(pr["labels"])
             if "human:wip" in labels:
                 continue
+            # Blocked on a gated self-config edit no worker class can push;
+            # the worker that hit the gate parked it human-only. Exclude from
+            # dispatch unconditionally so no feedback/conflict label on the PR
+            # re-fans-out a pane that would just re-hit the same wall.
+            if "fleet:gated" in labels:
+                continue
             # #1997: an all-gated-self-config PR already parked human-deferred
             # cannot be amended by any worker class. Exclude from dispatch so
-            # a re-stamp of fleet:needs-fix doesn't re-fan-out N panes.
+            # a re-stamp of fleet:needs-fix doesn't re-fan-out N panes. (The
+            # explicit fleet:gated park above is the preferred signal; this
+            # heuristic stays as a safety net for legacy human-deferred parks.)
             if "fleet:human-deferred" in labels and _pr_all_gated_self_config(
                 repo, pr["number"]
             ):
@@ -1487,6 +1501,13 @@ def _merger_action_signal(labels, mergeable, base_ref):
         "fleet:design-proposed",
         "fleet:needs-info", "fleet:needs-linux-smoke",
         "fleet:needs-macos-smoke",
+        # Blocked on a gated self-config edit no agent can push. The
+        # conflict itself is in the gated file, so the merger can never
+        # resolve or merge it — skip unconditionally (human-only). This is
+        # the merger-side counterpart of fleet:human-deferred's deliberate
+        # NON-skip above: human-deferred marks an *approved, still-mergeable*
+        # PR; fleet:gated marks one a human must touch before it can merge.
+        "fleet:gated",
         # Human-owes-a-fix labels — mirror role-merger.md step 3. NOT
         # `FEEDBACK_LABELS`: that set carries `fleet:has-nits` (an
         # approved+has-nits PR is still merge-ready, so the merger must
@@ -1805,6 +1826,10 @@ def slice_worker(state):
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
             if "human:wip" in labels:
+                continue
+            # Gated, human-only — mirror the project_worker exclusion so a
+            # woken worker iteration doesn't even surface it as a candidate.
+            if "fleet:gated" in labels:
                 continue
             if labels & (FEEDBACK_LABELS | DESIGN_RESUME_LABELS):
                 out["feedback_prs"].append(_slice_pr_with_repo(repo_key, pr))

--- a/scripts/fleet/tests/test_merger_projection.py
+++ b/scripts/fleet/tests/test_merger_projection.py
@@ -182,6 +182,16 @@ class HumanOwesFixLabelsDropped(unittest.TestCase):
     def test_human_re_review_dropped(self):
         self._dropped("human:re-review")
 
+    def test_fleet_gated_dropped(self):
+        # A gated, human-only PR must never wake or be acted on by the merger.
+        self._dropped("fleet:gated")
+
+    def test_fleet_gated_conflicting_dropped(self):
+        # Even CONFLICTING (the #1990 case): the conflict is in a gated file
+        # the merger can't push, so it must skip rather than re-flag
+        # semantic-conflict — that was the 11-pass thrash.
+        self._dropped("fleet:gated", mergeable="CONFLICTING")
+
     def test_repo_agnostic_game_human_needs_fix_dropped(self):
         # The projection loops both repos; the skip must hold for game too
         # (game #144 was the live offender).
@@ -246,6 +256,20 @@ class SignalSemantics(unittest.TestCase):
             "fleet:approved", "fleet:human-deferred",
         ], mergeable="MERGEABLE")]))
         self.assertEqual(items[0]["signal"], "merge-ready")
+
+    def test_gated_is_the_inverse_of_human_deferred(self):
+        # The whole point of fleet:gated: where a CONFLICTING human-deferred PR
+        # projects needs-resolve (merger acts), the same PR labeled fleet:gated
+        # projects NOTHING — the merger can't push the gated conflict, so it
+        # must stay hands-off (breaks the #1990 thrash at the source).
+        deferred = project_merger(_state([_pr(101, labels=[
+            "fleet:approved", "fleet:human-deferred",
+        ], mergeable="CONFLICTING")]))
+        gated = project_merger(_state([_pr(101, labels=[
+            "fleet:approved", "fleet:gated",
+        ], mergeable="CONFLICTING")]))
+        self.assertEqual(deferred[0]["signal"], "needs-resolve")
+        self.assertEqual(gated, [])
 
 
 class FailThenSucceedStackedRebase(unittest.TestCase):

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -36,6 +36,7 @@ _loader.exec_module(_mod)
 project_worker = _mod.project_worker
 project_opus_reviewer = _mod.project_opus_reviewer
 project_sonnet_reviewer = _mod.project_sonnet_reviewer
+slice_worker = _mod.slice_worker
 stable_hash = _mod.stable_hash
 
 
@@ -209,6 +210,38 @@ class WorkerSkipLabelsDropPR(unittest.TestCase):
             project_worker(_state([_pr(101, labels=["fleet:needs-fix", "fleet:gated"])])),
             [],
         )
+
+
+class SliceWorkerSkipLabelsDropPR(unittest.TestCase):
+    """slice_worker is the dispatch slice a woken worker reads (distinct from
+    project_worker, the hash-input that decides *whether* to wake). It must
+    mirror project_worker's human:wip / fleet:gated exclusions so a woken
+    worker never even surfaces a gated, human-only PR as a candidate."""
+
+    def _feedback(self, prs):
+        return slice_worker(_state(prs))["feedback_prs"]
+
+    def test_human_wip_drops_pr(self):
+        self.assertEqual(
+            self._feedback([_pr(101, labels=["fleet:needs-fix", "human:wip"])]),
+            [],
+        )
+
+    def test_fleet_gated_drops_pr(self):
+        # Mirror of WorkerSkipLabelsDropPR.test_fleet_gated_drops_pr for the
+        # slice: a gated PR carrying an otherwise-actionable feedback label
+        # (#1990: fleet:gated alongside fleet:needs-fix) must not reach the
+        # woken worker's candidate list. fleet:gated wins unconditionally.
+        self.assertEqual(
+            self._feedback([_pr(101, labels=["fleet:needs-fix", "fleet:gated"])]),
+            [],
+        )
+
+    def test_plain_feedback_pr_still_surfaces(self):
+        # Regression: a non-gated feedback PR must still reach the worker.
+        result = self._feedback([_pr(101, labels=["fleet:needs-fix"])])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["number"], 101)
 
 
 class OpusReviewerStableAcrossIrrelevantLabels(unittest.TestCase):

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -187,7 +187,7 @@ class WorkerCoversEveryTaskClass(unittest.TestCase):
 
 
 class WorkerSkipLabelsDropPR(unittest.TestCase):
-    """human:wip excludes a PR from the projection entirely."""
+    """human:wip / fleet:gated exclude a PR from the projection entirely."""
 
     def _hash(self, prs):
         return stable_hash(project_worker(_state(prs)))
@@ -196,6 +196,19 @@ class WorkerSkipLabelsDropPR(unittest.TestCase):
         empty = self._hash([])
         with_wip = self._hash([_pr(101, labels=["fleet:needs-fix", "human:wip"])])
         self.assertEqual(empty, with_wip)
+
+    def test_fleet_gated_drops_pr(self):
+        # A gated, human-only PR must never dispatch a worker, even when it
+        # also carries a normally-actionable feedback label (the #1990 case
+        # carried fleet:semantic-conflict; a DEFER park can keep fleet:needs-fix
+        # before the swap). fleet:gated wins unconditionally.
+        empty = self._hash([])
+        gated = self._hash([_pr(101, labels=["fleet:needs-fix", "fleet:gated"])])
+        self.assertEqual(empty, gated)
+        self.assertEqual(
+            project_worker(_state([_pr(101, labels=["fleet:needs-fix", "fleet:gated"])])),
+            [],
+        )
 
 
 class OpusReviewerStableAcrossIrrelevantLabels(unittest.TestCase):
@@ -318,6 +331,17 @@ class HumanDeferredDropsFromReviewers(unittest.TestCase):
     def test_needs_human_drops_from_opus_reviewer(self):
         result = self._opus([_pr(101, labels=[
             "fleet:needs-fix", "fleet:needs-human",
+        ])])
+        self.assertEqual(result, [])
+
+    def test_gated_drops_from_sonnet_reviewer(self):
+        result = self._sonnet([_pr(101, labels=["fleet:gated"])])
+        self.assertEqual(result, [])
+
+    def test_gated_drops_from_opus_reviewer(self):
+        # Even with a reviewer-relevant flag label, a gated PR is human-only.
+        result = self._opus([_pr(101, labels=[
+            "fleet:has-nits", "fleet:gated",
         ])])
         self.assertEqual(result, [])
 


### PR DESCRIPTION
## Summary

Introduces **`fleet:gated`** — a dedicated label for "a PR is blocked on an edit to a gated self-config file (`role-*.md` / `.claude/agents/*` / `SKILL.md`) that the auto-mode self-modification gate physically prevents any agent class from pushing." It is in **every** picker's skip set, so one label stops the merger, all worker classes, and reviewers until a human resolves it.

## Root cause (the #1990 thrash)

`fleet:human-deferred` was overloaded with two contradictory meanings:
- **"approved, follow-up concern deferred to a new issue; still mergeable"** → the merger deliberately does **not** skip it (it should merge it).
- **"blocked on a gated edit no agent can push; hands off"** → the merger **must** skip it.

The merger can't tell them apart, so it read #1990's gated conflict as merge-ready, tried to merge, hit the conflict, and re-flagged `fleet:semantic-conflict` → a worker re-parked → **11 passes** of thrash. The `_pr_all_gated_self_config` disambiguator (#1997) was wired into the worker projection but never the merger. #1990 only stopped when parked at `fleet:needs-info` (a semantic misfit — "issue too vague"), discovered by trial.

## The fix

`fleet:gated` un-overloads the state. `fleet:human-deferred` keeps its single *approved-and-mergeable* meaning; `fleet:gated` is the human-only stop. Wired into:

- **scout** (`fleet-state-scout`): `REVIEW_SKIP_LABELS` (reviewers), `_merger_action_signal` (merger wake), `project_worker` + `slice_worker` (worker dispatch).
- **role-merger.md**: step-3 skip set, stacked-rebase skip list, "Never bypass labels"; **plus a short-circuit** — when every conflicted file is gated self-config, the merger labels `fleet:gated` instead of `fleet:semantic-conflict`, ending the loop at the source.
- **role-worker.md**: step 1c gated guard — if every conflicted file is gated, park `fleet:gated` and stop (do **not** escalate to `human:needs-fix`, which re-triggers worker pickup into the same wall).
- **FLEET-FEEDBACK-HANDLING.md**: DEFER (gated-self-config) path parks `fleet:gated` instead of `fleet:human-deferred`.
- **catalog + reference**: `fleet-labels` entry (desc 95 chars ≤ 100) + `fleet-labels-reference.md` documentation.

The legacy `_pr_all_gated_self_config` heuristic on `fleet:human-deferred` stays as a safety net for older parks.

## Test plan

- [x] `ruff check scripts/fleet/` (CI quality gate) — clean
- [x] `test_merger_projection.py` — 33/0, incl. a gated PR drops from the merger even when CONFLICTING, and the inverse-of-human-deferred contrast test
- [x] `test_worker_projection.py` — 35/0, incl. gated PR excluded from worker dispatch + both reviewers
- [x] Regression: queue-manager / opus-reviewer / epic-steward / scout-degraded / all-gated-self-config projection suites green

## Notes

- Architect-initiated fleet process fix (human-directed, interactive) — **no `Closes #N`** (no backing issue).
- This PR itself touches gated role docs, so per policy it is **human-merged** (the merger can't autonomously merge a gated-file PR — which `fleet:gated` now also encodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)