### PR TITLE
engine: own the IRArgs parse via IREngine::args() + init(argc, argv) (#2058)

### DIFF
--- a/.fleet/plans/issue-2058.md
+++ b/.fleet/plans/issue-2058.md
@@ -1,0 +1,65 @@
+# Plan: P1 — engine owns the IRArgs parser; retire parseConfigPresetArg
+
+- **Issue:** #2058
+- **Model:** opus
+- **Date:** 2026-06-26
+- **Epic:** #2057 — see `.fleet/plans/issue-2057.md` for full context
+- **Blocked by:** (none)
+
+### Verified current state (origin/master @ a870e1e3)
+- `IREngine::init(const char *argv0, const char *configFileName="config.lua")`
+  — `engine/include/irreden/ir_engine.hpp:62`. Body: `weakly_canonical(argv0)`
+  → set cwd → `applyPreInitLuaConfig` → construct `World` (window/GL/Metal) →
+  `setupLuaBindings`. Each `main()` parses common args BEFORE this via the
+  legacy helpers and threads results back by hand.
+- `IREngine::parseConfigPresetArg(argc, argv)` — inline `ir_engine.hpp:90`.
+- `IRArgs::Parser` ctor already pre-registers `--auto-screenshot`,
+  `--config-preset`, `--help`/`-h` and exposes `autoScreenshotWarmupFrames()`
+  / `configPreset()` (`engine/include/irreden/ir_args.hpp`).
+
+### Cross-system audit — every launch target calls `IREngine::init`
+Adding the `argc,argv` overload is additive, but the **old `init(argv0,...)`
+overload MUST keep working** so this child is non-breaking — the ~55 callers
+(demos, lighting via macro, game/irreden, MIDI via `IRMidi::run`, editors)
+move to `init(argc,argv)` in P2–P5, not here. So P1 adds, never removes, that
+overload. Re-grep `IREngine::init(` at impl time to confirm the count.
+
+`parseConfigPresetArg`'s only caller is `perf_grid` (migrated in P3). To keep
+P1 standalone, P1's diff also updates `perf_grid`'s single preset read to use
+the engine-owned parser while deleting the helper — otherwise perf_grid won't
+link until P3. **Confirm `grep -rn parseConfigPresetArg engine creations`
+returns only perf_grid before deleting.**
+
+### Affected files
+- `engine/include/irreden/ir_engine.hpp` — add `args()` + `init(argc,argv)`;
+  read preset via `args().configPreset()`; delete `parseConfigPresetArg`.
+- `creations/demos/perf_grid/main.cpp` — repoint its one preset read (minimal).
+- `creations/demos/fog_demo/main.cpp` — register `--moving-observer` on
+  `IREngine::args()`, call `init(argc,argv)`, drop the local `IRArgs::Parser`.
+- `engine/CLAUDE.md` — update the reference-adoption note + add the
+  "no-arg targets get IRArgs for free" sentence.
+
+### Approach
+Per the issue body. Load-bearing detail: `args().parse(argc, argv)` is the
+FIRST statement of `init(argc,argv)`, before cwd/Lua/World, so `--help` and
+unknown-arg `exit(2)` resolve pre-window/GL/Metal.
+
+### Implementation notes (recorded during execution)
+- The engine never consumed `--config-preset` internally; `perf_grid` is the
+  sole consumer (threads it into its own `applyConfigPreset`). So P1 adds no
+  internal engine preset read — `args().configPreset()` simply becomes
+  available to targets that adopt `init(argc,argv)`.
+- `init(int,char**,...)` parses then delegates to the existing
+  `init(const char*,...)` overload (no body duplication; argv0 path unchanged).
+- `perf_grid` is NOT migrated to `init(argc,argv)` in P1 (its 14 custom flags
+  would `exit(2)` against the common-args-only engine parse — that is P3). Its
+  `--config-preset` read is folded into its existing hand-rolled loop, so the
+  helper is deleted with zero behaviour change and no new standalone loop.
+
+### Verification
+- `fleet-build --target IRFogDemo` (macOS) clean; `IRFogDemo --help` exits 0
+  pre-init and lists `--moving-observer`.
+- `fleet-build --target IRPerfGrid` clean (proves the helper deletion links).
+- A throwaway demo calling only `init(argc,argv)` shows working `--help` /
+  `--auto-screenshot` / `--config-preset` with no parser code.
+- `grep -rn parseConfigPresetArg engine creations` → empty.

--- a/creations/demos/fog_demo/main.cpp
+++ b/creations/demos/fog_demo/main.cpp
@@ -206,30 +206,32 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRArgs::Parser args(
-        "fog_demo — fog-of-war render-pass demo (FOG_TO_TRIXEL) + cross-host smoke coverage."
-    );
-    args.flag(
+    // Register this demo's custom flags on the engine-owned parser BEFORE init;
+    // init parses (engine-common args + these flags) as its first action, so
+    // --help / --auto-screenshot / --config-preset come for free and --help
+    // exits before any window/GL/Metal init.
+    IREngine::args().flag(
         "--moving-observer",
         "Per-frame analytic vision circle orbiting the origin (smooth reveal) "
         "instead of the static grid reveal"
     );
-    args.flag(
+    IREngine::args().flag(
         "--player-walk",
         "Walking detached-player marker with a tracking analytic vision circle "
         "(sub-voxel crescent reveal proof); skips the static grid reveal"
     );
-    args.parse(argc, argv);
-    g_autoWarmupFrames = args.autoScreenshotWarmupFrames();
-    g_movingObserver = args.getFlag("--moving-observer");
-    g_playerWalk = args.getFlag("--player-walk");
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
+    g_movingObserver = IREngine::args().getFlag("--moving-observer");
+    g_playerWalk = IREngine::args().getFlag("--player-walk");
     if (g_playerWalk && g_movingObserver) {
-        IR_LOG_INFO("--player-walk and --moving-observer are mutually exclusive; ignoring --moving-observer");
+        IR_LOG_INFO(
+            "--player-walk and --moving-observer are mutually exclusive; ignoring --moving-observer"
+        );
         g_movingObserver = false;
     }
 
     IR_LOG_INFO("Starting creation: fog_demo");
-    IREngine::init(argv[0]);
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -445,9 +445,16 @@ void applyCliOverrides() {
 
 void parseArgs(int argc, char **argv) {
     IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-    g_cliOverrides.configPreset_ = IREngine::parseConfigPresetArg(argc, argv);
     for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--auto-profile") == 0) {
+        if (std::strcmp(argv[i], "--config-preset") == 0 && i + 1 < argc) {
+            // Read locally for now: perf_grid still hand-rolls its argv loop
+            // and calls init(argv[0]), so it can't go through IREngine::args()
+            // until its full IRArgs migration (epic #2057 P3, #2060). This
+            // branch replaces the retired IREngine::parseConfigPresetArg helper
+            // with no behaviour change.
+            g_cliOverrides.configPreset_ = argv[i + 1];
+            ++i;
+        } else if (std::strcmp(argv[i], "--auto-profile") == 0) {
             g_autoProfileFrames = 300;
             if (i + 1 < argc) {
                 int frames = std::atoi(argv[i + 1]);

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -19,21 +19,31 @@ Core engine static libraries. Everything here is shared by every creation.
 
 ## CLI args go through `IRArgs`, never a hand-rolled `strcmp` loop
 
-`engine/include/irreden/ir_args.hpp` is the declarative argument framework.
-A launch target constructs an `IRArgs::Parser` (which pre-registers the
-engine-common args — `--auto-screenshot`, `--config-preset` — plus a free
-`--help` / `-h`), declares its own args (`flag` / `integer` / `number` /
-`string` / `optionalInt`), then calls `parse(argc, argv)` at the **top of
-`main`, before any window / GL / Metal init** so `--help` is instant and
-headless-safe. `--help` prints the auto-generated usage and `exit(0)`; an
-unknown arg prints an error + usage and `exit(2)`. Read the common flags via
-`autoScreenshotWarmupFrames()` / `configPreset()`. `creations/demos/fog_demo/
-main.cpp` is the reference adoption.
+`engine/include/irreden/ir_args.hpp` is the declarative argument framework, and
+the engine **owns the parse**: `IREngine::args()` is a process-global
+`IRArgs::Parser` pre-loaded with the engine-common args (`--auto-screenshot`,
+`--config-preset`) plus a free `--help` / `-h`. `IREngine::init(argc, argv)`
+calls `args().parse(argc, argv)` as its **first action**, before any window /
+GL / Metal init, so `--help` is instant and headless-safe.
+
+- **No custom flags?** Just call `IREngine::init(argc, argv)` — the target gets
+  working `--help` / `--auto-screenshot` / `--config-preset` with no parser
+  code at all, read back via `IREngine::args().autoScreenshotWarmupFrames()` /
+  `IREngine::args().configPreset()`.
+- **Custom flags?** Register them on `IREngine::args()` (`.flag` / `.integer` /
+  `.number` / `.string` / `.optionalInt`) **before** `IREngine::init(argc,
+  argv)`, then read them back via `IREngine::args().getFlag(...)` etc. The
+  single engine parse covers common + custom flags, so `--help` aggregates
+  everything.
+
+`--help` prints the auto-generated usage and `exit(0)`; an unknown arg prints an
+error + usage and `exit(2)`. `creations/demos/fog_demo/main.cpp` is the
+reference adoption.
 
 Do **not** add a new `for (i…) std::strcmp(argv[i], "--foo")` parse loop to a
-target. The legacy scattered helpers (`IRVideo::parseAutoScreenshotArgv`,
-`IREngine::parseConfigPresetArg`) and the remaining demos' hand-rolled loops
-are being migrated onto `IRArgs` and retired (#2044 follow-ons).
+target. The one remaining legacy helper (`IRVideo::parseAutoScreenshotArgv`)
+and the demos' hand-rolled loops are being migrated onto `IRArgs` and retired
+(epic #2057).
 
 ## `SystemName` enum is authoritative
 

--- a/engine/include/irreden/ir_engine.hpp
+++ b/engine/include/irreden/ir_engine.hpp
@@ -1,8 +1,8 @@
 #ifndef IR_ENGINE_H
 #define IR_ENGINE_H
 
+#include <irreden/ir_args.hpp>
 #include <irreden/world.hpp>
-#include <cstring>
 #include <filesystem>
 #include <functional>
 #include <string>
@@ -56,6 +56,20 @@ void applyPreInitLuaConfig(const char *configFile);
 
 } // namespace detail
 
+// The process-global engine argument parser. Lazily constructed with the
+// engine-common args (--auto-screenshot, --config-preset) and --help/-h
+// pre-registered by the IRArgs::Parser ctor. A launch target registers its
+// own flags on this parser BEFORE calling init(argc, argv); init parses it as
+// its first action. A target with no custom flags gets --help /
+// --auto-screenshot / --config-preset for free with no parser code, then reads
+// the common flags back via args().autoScreenshotWarmupFrames() /
+// args().configPreset(). Inline so the function-local static is one shared
+// instance across every translation unit.
+inline IRArgs::Parser &args() {
+    static IRArgs::Parser parser;
+    return parser;
+}
+
 // Sets cwd to the executable's directory and resolves creation scripts
 // from a sibling scripts/ directory. All relative engine paths
 // (shaders/, data/) resolve from the exe directory.
@@ -67,6 +81,17 @@ inline void init(const char *argv0, const char *configFileName = "config.lua") {
     detail::applyPreInitLuaConfig(resolveScriptPath(configFileName).c_str());
     g_world = std::make_unique<World>(resolveScriptPath(configFileName).c_str());
     g_world->setupLuaBindings(g_luaBindingRegistrations);
+}
+
+// Parses the engine-common args (plus any the target pre-registered on args())
+// as its FIRST action — so --help and unknown-arg exit(2) resolve before the
+// cwd change and World (window/GL/Metal) construction — then runs the same
+// exe-dir setup as the argv0 overload. This is the entry point a no-custom-arg
+// target uses: IREngine::init(argc, argv) gives it --help / --auto-screenshot
+// / --config-preset with no parser code.
+inline void init(int argc, char **argv, const char *configFileName = "config.lua") {
+    args().parse(argc, argv);
+    init(argc > 0 ? argv[0] : "", configFileName);
 }
 
 inline void runScript(const char *scriptFileName) {
@@ -83,17 +108,6 @@ inline int entityCountOverride() {
 
 inline void gameLoop() {
     getWorld().gameLoop();
-}
-
-// Scans argv for the first --config-preset <path> pair and returns the
-// path string, or an empty string if the flag is absent.
-inline std::string parseConfigPresetArg(int argc, char **argv) {
-    for (int i = 1; i + 1 < argc; ++i) {
-        if (std::strcmp(argv[i], "--config-preset") == 0) {
-            return argv[i + 1];
-        }
-    }
-    return {};
 }
 
 } // namespace IREngine

--- a/engine/include/irreden/ir_engine.hpp
+++ b/engine/include/irreden/ir_engine.hpp
@@ -56,15 +56,13 @@ void applyPreInitLuaConfig(const char *configFile);
 
 } // namespace detail
 
-// The process-global engine argument parser. Lazily constructed with the
-// engine-common args (--auto-screenshot, --config-preset) and --help/-h
-// pre-registered by the IRArgs::Parser ctor. A launch target registers its
-// own flags on this parser BEFORE calling init(argc, argv); init parses it as
-// its first action. A target with no custom flags gets --help /
-// --auto-screenshot / --config-preset for free with no parser code, then reads
-// the common flags back via args().autoScreenshotWarmupFrames() /
-// args().configPreset(). Inline so the function-local static is one shared
-// instance across every translation unit.
+// The process-global engine argument parser, pre-loaded with the engine-common
+// args (--auto-screenshot, --config-preset, --help/-h) by the IRArgs::Parser
+// ctor. A launch target registers its own flags on this parser BEFORE calling
+// init(argc, argv) — init parses it as its first action — then reads results
+// back via args(). See engine/CLAUDE.md "CLI args go through IRArgs" for the
+// no-custom-flags / custom-flags patterns. Inline so the function-local static
+// is one shared instance across every translation unit.
 inline IRArgs::Parser &args() {
     static IRArgs::Parser parser;
     return parser;
@@ -90,6 +88,7 @@ inline void init(const char *argv0, const char *configFileName = "config.lua") {
 // target uses: IREngine::init(argc, argv) gives it --help / --auto-screenshot
 // / --config-preset with no parser code.
 inline void init(int argc, char **argv, const char *configFileName = "config.lua") {
+    IR_ASSERT(argc > 0, "init(argc, argv) needs argv[0] for exe-dir resolution");
     args().parse(argc, argv);
     init(argc > 0 ? argv[0] : "", configFileName);
 }


### PR DESCRIPTION
## Summary
- Epic #2057 **P1**: make the engine own the common-arg parse so a launch target with **no custom flags** gets `--help` / `--auto-screenshot` / `--config-preset` for free.
- `ir_engine.hpp`: add `IREngine::args()` — a process-global `IRArgs::Parser` pre-loaded with the engine-common args + `--help` — and an `init(int argc, char **argv, ...)` overload whose **first action** is `args().parse(argc, argv)`, before the cwd change and `World` (window/GL/Metal) construction, so `--help` / unknown-arg `exit(2)` resolve pre-init. The overload delegates to the existing `init(argv0, ...)`, which is **unchanged** — purely additive, so all existing `init(argv[0])` callers keep working (P2–P6 migrate them).
- Delete `IREngine::parseConfigPresetArg` (its only consumer was perf_grid); drop the now-unused `<cstring>`.
- `fog_demo`: register `--moving-observer` / `--player-walk` on `IREngine::args()` and call `init(argc, argv)`, dropping the local `IRArgs::Parser` — reference adoption of the engine-owned pattern.
- `perf_grid`: fold its one `--config-preset` read into its existing argv loop (it keeps `init(argv[0])` and its hand-rolled loop until its full IRArgs migration in **P3 / #2060** — going through the common-args-only engine parse now would `exit(2)` on its 14 custom flags), so the helper deletion links with **zero behaviour change**.
- `engine/CLAUDE.md`: document the engine-owned-parser pattern.

### Note
The engine never consumed `--config-preset` internally — perf_grid was the sole consumer, threading it into its own `applyConfigPreset`. So P1 adds no internal engine preset read; `args().configPreset()` simply becomes available to targets that adopt `init(argc, argv)`. fog_demo's per-target parser **description line** is dropped (the engine-owned parser is a single global); `--help` still lists every flag. A per-target description setter is a clean follow-up if wanted.

## Test plan
- [x] `fleet-build --target IRFogDemo` — clean (macOS/Metal); engine static lib rebuilt with the header change
- [x] `fleet-build --target IRPerfGrid` — clean (proves the `parseConfigPresetArg` deletion links)
- [x] `IRFogDemo --help` — exits 0 **before** any window/GL/Metal init; lists `--auto-screenshot`, `--config-preset`, `--help/-h` (free) + `--moving-observer` + `--player-walk`
- [x] `IRFogDemo --bogus` — prints error + usage, `exit(2)`
- [x] `grep -rn parseConfigPresetArg engine creations` — no callers (only an explanatory comment naming the retired helper)
- [ ] Linux/GL build (cross-host smoke) — platform-agnostic C++; pending fleet Linux validation

Closes #2058

🤖 Generated with [Claude Code](https://claude.com/claude-code)