### PR TITLE
engine: IRArgs positional + no-common-args modes; port standalone tools (#2063)

### DIFF
--- a/cmake/lua_codegen/CMakeLists.txt
+++ b/cmake/lua_codegen/CMakeLists.txt
@@ -7,13 +7,16 @@
 # engine/script/CMakeLists.txt). This subdir is added AFTER engine/ in the
 # top-level CMakeLists so both deps resolve.
 
-add_executable(ir_lua_codegen main.cpp system_dsl.cpp)
+# IRArgs (engine/ir_args.cpp) drives the CLI; it has no engine dependencies, so
+# the build-time tool compiles it directly without linking the engine library.
+add_executable(ir_lua_codegen main.cpp system_dsl.cpp ${PROJECT_SOURCE_DIR}/engine/ir_args.cpp)
 target_link_libraries(ir_lua_codegen PRIVATE lua sol2)
 target_compile_features(ir_lua_codegen PRIVATE cxx_std_20)
 
 # The IREnum shim shares engine/script's lua_enum_def.hpp so ordinals are identical at build time and runtime.
 target_include_directories(ir_lua_codegen PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../engine/script/include
+    ${PROJECT_SOURCE_DIR}/engine/include
 )
 
 # Codegen-time errors should surface verbatim; never strip the symbols

--- a/cmake/lua_codegen/main.cpp
+++ b/cmake/lua_codegen/main.cpp
@@ -27,6 +27,7 @@
 
 #include "system_dsl.hpp"
 
+#include <irreden/ir_args.hpp>
 #include <irreden/script/lua_enum_def.hpp>
 
 #include <algorithm>
@@ -914,12 +915,6 @@ void writeOutput(
     out << os.str();
 }
 
-void usage(const char *progName) {
-    std::cerr << "usage: " << progName
-              << " --out <output.hpp> [--default-mode=codegen|eval]"
-                 " <input1.lua> [input2.lua ...]\n";
-}
-
 bool parseModeArg(const std::string &val, IRLuaCodegen::SystemMode &out) {
     // Accept lowercase (helper's preferred form, see CMake CODEGEN-token
     // workaround in ir_functions.cmake) and uppercase for direct CLI use.
@@ -937,48 +932,33 @@ bool parseModeArg(const std::string &val, IRLuaCodegen::SystemMode &out) {
 } // namespace
 
 int main(int argc, char **argv) {
-    std::string outPath;
-    std::vector<std::string> inputs;
-    // Creation-default mode for systems without an explicit
-    // `mode = "..."` field. Threaded from the CMake helper's
-    // DEFAULT_MODE param (sourced from IR_LUA_ECS_DEFAULT_MODE cache var).
+    // Creation-default mode for systems without an explicit `mode = "..."`
+    // field. Threaded from the CMake helper's DEFAULT_MODE param (sourced from
+    // the IR_LUA_ECS_DEFAULT_MODE cache var). IRArgs accepts both
+    // `--default-mode codegen` and the `--default-mode=codegen` form the CMake
+    // helper passes (ir_functions.cmake's CODEGEN-token workaround).
+    IRArgs::Parser parser(
+        "ir_lua_codegen — emit C++ component/system definitions from Lua schemas.",
+        IRArgs::Common::NONE
+    );
+    parser.string("--out", "Output .hpp path (required)", "");
+    parser.string(
+        "--default-mode", "Default mode for schemas without an explicit mode: codegen | eval",
+        "codegen"
+    );
+    parser.variadic("inputs", "Lua schema files (.lua)", 1);
+    parser.parse(argc, argv);
+
+    const std::string outPath = parser.getString("--out");
+    const std::vector<std::string> inputs = parser.positionalArgs();
     IRLuaCodegen::SystemMode defaultMode = IRLuaCodegen::SystemMode::CODEGEN;
-    for (int i = 1; i < argc; ++i) {
-        const std::string arg = argv[i];
-        if (arg == "--out") {
-            if (i + 1 >= argc) {
-                usage(argv[0]);
-                return 1;
-            }
-            outPath = argv[++i];
-        } else if (arg.rfind("--default-mode=", 0) == 0) {
-            constexpr std::string_view kDefaultModePrefix = "--default-mode=";
-            const std::string val = arg.substr(kDefaultModePrefix.size());
-            if (!parseModeArg(val, defaultMode)) {
-                std::cerr << "lua_codegen: --default-mode must be codegen or eval (got '"
-                          << val << "')\n";
-                return 1;
-            }
-        } else if (arg == "--default-mode") {
-            if (i + 1 >= argc) {
-                usage(argv[0]);
-                return 1;
-            }
-            const std::string val = argv[++i];
-            if (!parseModeArg(val, defaultMode)) {
-                std::cerr << "lua_codegen: --default-mode must be codegen or eval (got '"
-                          << val << "')\n";
-                return 1;
-            }
-        } else if (arg == "-h" || arg == "--help") {
-            usage(argv[0]);
-            return 0;
-        } else {
-            inputs.push_back(arg);
-        }
+    if (!parseModeArg(parser.getString("--default-mode"), defaultMode)) {
+        std::cerr << "lua_codegen: --default-mode must be codegen or eval (got '"
+                  << parser.getString("--default-mode") << "')\n";
+        return 1;
     }
-    if (outPath.empty() || inputs.empty()) {
-        usage(argv[0]);
+    if (outPath.empty()) {
+        std::cerr << "lua_codegen: --out <output.hpp> is required\n";
         return 1;
     }
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -35,10 +35,19 @@ GL / Metal init, so `--help` is instant and headless-safe.
   argv)`, then read them back via `IREngine::args().getFlag(...)` etc. The
   single engine parse covers common + custom flags, so `--help` aggregates
   everything.
+- **Standalone tool (no engine loop)?** Construct your own
+  `IRArgs::Parser(desc, IRArgs::Common::NONE)` — that drops the engine-common
+  args (so `--help` advertises only the tool's flags) and lets you declare
+  ordered positionals with `.positional(name, help)` / `.variadic(name, help,
+  minCount)`, read back via `getPositional(...)` / `positionalArgs()`. The
+  parser has no engine dependencies, so the tool compiles `engine/ir_args.cpp`
+  directly and stays standalone (`tools/img_diff`, `tools/jitter_probe`,
+  `cmake/lua_codegen`).
 
-`--help` prints the auto-generated usage and `exit(0)`; an unknown arg prints an
-error + usage and `exit(2)`. `creations/demos/fog_demo/main.cpp` is the
-reference adoption.
+Value-taking args accept both `--name value` and `--name=value`. `--help`
+prints the auto-generated usage and `exit(0)`; an unknown arg or bad positional
+count prints an error + usage and `exit(2)`. `creations/demos/fog_demo/main.cpp`
+is the reference adoption.
 
 Do **not** add a new `for (i…) std::strcmp(argv[i], "--foo")` parse loop to a
 target. The one remaining legacy helper (`IRVideo::parseAutoScreenshotArgv`)

--- a/engine/include/irreden/ir_args.hpp
+++ b/engine/include/irreden/ir_args.hpp
@@ -12,6 +12,18 @@
 //     args.parse(argc, argv);
 //     if (args.getFlag("--no-overlay")) ...
 //     int n = args.getInt("--grid-size");
+//
+// Standalone tools that don't run the engine loop construct the parser in
+// no-common-args mode (so --help doesn't advertise --auto-screenshot /
+// --config-preset) and take positional arguments:
+//
+//     IRArgs::Parser args("img_diff — highlight PNG drift.", IRArgs::Common::NONE);
+//     args.integer("--threshold", "Per-channel tolerance", 0);
+//     args.positional("baseline", "Baseline PNG");
+//     args.positional("current", "Current PNG");
+//     args.positional("out_diff", "Output diff PNG");
+//     args.parse(argc, argv);
+//     std::string base = args.getPositional("baseline");
 namespace IRArgs {
 
 // The engine-common --auto-screenshot warmup default when the flag is given
@@ -29,13 +41,24 @@ enum class Type {
     OPTIONAL_INT, // switch with an optional trailing int (--auto-screenshot [frames])
 };
 
+// Which built-in args the constructor pre-registers. ENGINE (the default) adds
+// the engine-common args; NONE adds only --help / -h, for standalone tools that
+// don't run the engine loop and shouldn't advertise --auto-screenshot /
+// --config-preset.
+enum class Common {
+    ENGINE,
+    NONE,
+};
+
 class Parser {
   public:
     // `programDescription` is an optional one-line summary printed under the
-    // usage header. The constructor pre-registers the built-in --help / -h and
-    // the engine-common args (--auto-screenshot, --config-preset), so every
-    // target inherits them without re-declaring.
-    explicit Parser(const char *programDescription = nullptr);
+    // usage header. The constructor always pre-registers the built-in --help /
+    // -h. With Common::ENGINE (the default) it also pre-registers the
+    // engine-common args (--auto-screenshot, --config-preset) so every engine
+    // target inherits them without re-declaring; with Common::NONE it does not,
+    // for standalone tools (see the header example).
+    explicit Parser(const char *programDescription = nullptr, Common common = Common::ENGINE);
 
     // Declarative registration. All return *this so calls can chain.
     // `name` must start with "--"; `shortAlias` is an optional single-dash
@@ -60,9 +83,19 @@ class Parser {
         const char *name, const char *help, int defaultIfBare, const char *shortAlias = nullptr
     );
 
-    // Parse argv (argv[0] is the program path and is skipped). On --help / -h:
-    // print usage to stdout and exit(0). On an unknown arg or a missing value:
-    // print the diagnostic + usage to stderr and exit(2).
+    // Positional arguments (ordered, no leading dash). Register one fixed
+    // positional with `positional`; declare a trailing variable-count tail with
+    // `variadic` (which must be the last positional registered and captures all
+    // remaining positionals, requiring at least `minCount`). `name` is the
+    // placeholder shown in --help; access values after parse() via
+    // getPositional(name) (fixed) or positionalArgs() (all, in order).
+    Parser &positional(const char *name, const char *help);
+    Parser &variadic(const char *name, const char *help, int minCount = 0);
+
+    // Parse argv (argv[0] is the program path and is skipped). Value-taking args
+    // accept both "--name value" and "--name=value". On --help / -h: print usage
+    // to stdout and exit(0). On an unknown arg, a missing value, or too few /
+    // many positionals: print the diagnostic + usage to stderr and exit(2).
     void parse(int argc, char **argv);
 
     // Typed access, valid after parse(). Each returns the registered default
@@ -76,6 +109,13 @@ class Parser {
     // default). The honest "present?" signal for OPTIONAL_INT switches such as
     // --auto-screenshot, where presence alone changes behavior.
     bool wasProvided(const char *name) const;
+
+    // Positional access, valid after parse(). getPositional returns the value
+    // bound to a fixed positional by name (asserts in debug if `name` wasn't
+    // registered via positional()). positionalArgs returns every positional
+    // token in command-line order, including the variadic tail.
+    std::string getPositional(const char *name) const;
+    const std::vector<std::string> &positionalArgs() const;
 
     // Engine-common convenience accessors — read the pre-registered common args
     // with their canonical semantics so every target drives them identically:
@@ -101,6 +141,15 @@ class Parser {
         bool provided_ = false;
     };
 
+    // A declared positional argument. The `variadic_` tail captures all
+    // positionals past the fixed ones (>= minCount_).
+    struct Positional {
+        std::string name_;
+        std::string help_;
+        bool variadic_ = false;
+        int minCount_ = 0;
+    };
+
     Entry &add(const char *name, const char *help, Type type, const char *shortAlias);
     Entry *find(const std::string &token);
     const Entry *findByName(const char *name) const;
@@ -109,6 +158,8 @@ class Parser {
     std::string m_description;
     std::string m_programName = "program";
     std::vector<Entry> m_entries;
+    std::vector<Positional> m_positionals;       // declared, fixed then optional variadic tail
+    std::vector<std::string> m_positionalValues; // captured at parse, in order
 };
 
 } // namespace IRArgs

--- a/engine/ir_args.cpp
+++ b/engine/ir_args.cpp
@@ -1,11 +1,19 @@
 #include <irreden/ir_args.hpp>
 
-#include <irreden/ir_profile.hpp>
-
 #include <algorithm>
+#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+
+// IRArgs invariants are programmer errors (duplicate registration, typed-getter
+// mismatch). We assert on a dependency-free macro rather than the engine's
+// IR_ASSERT so the standalone tools — img_diff, jitter_probe, lua_codegen —
+// can compile this translation unit without linking the engine profiler. The
+// Release config defines NDEBUG alongside IR_RELEASE, so assert() and IR_ASSERT
+// share the same compiled-out-in-release behavior; in debug both abort/throw on
+// the same conditions.
+#define IR_ASSERT(cond, msg) assert((cond) && (msg))
 
 namespace IRArgs {
 
@@ -28,15 +36,39 @@ const char *placeholderFor(Type type) {
     return "";
 }
 
+// Split a "--name=value" long option into its name (before the first '=') and
+// inline value (after). Returns true when an inline value was present; for any
+// other token the whole token is the name and the value is empty. Splitting on
+// the first '=' only, so a value may itself contain '='.
+bool splitInlineValue(const char *token, std::string &name, std::string &value) {
+    std::string t = token != nullptr ? token : "";
+    if (t.rfind("--", 0) == 0) {
+        const auto eq = t.find('=');
+        if (eq != std::string::npos) {
+            name = t.substr(0, eq);
+            value = t.substr(eq + 1);
+            return true;
+        }
+    }
+    name = std::move(t);
+    value.clear();
+    return false;
+}
+
 } // namespace
 
-Parser::Parser(const char *programDescription)
+Parser::Parser(const char *programDescription, Common common)
     : m_description(programDescription != nullptr ? programDescription : "") {
     // Built-in help — owned by the parser, free for every target.
     flag("--help", "Show this help and exit", "-h");
-    // Engine-common args: every target that constructs a Parser inherits these
-    // (and --help) without re-declaring. The canonical spellings are preserved
-    // so existing command lines keep working.
+    if (common == Common::NONE) {
+        // Standalone tool: only --help. Caller declares its own flags /
+        // positionals; the engine-common args would be misleading noise.
+        return;
+    }
+    // Engine-common args: every engine target that constructs a Parser inherits
+    // these (and --help) without re-declaring. The canonical spellings are
+    // preserved so existing command lines keep working.
     optionalInt(
         "--auto-screenshot",
         "Headless capture: cycle the shot table then exit; optional warmup frame count",
@@ -99,6 +131,32 @@ Parser::optionalInt(const char *name, const char *help, int defaultIfBare, const
     return *this;
 }
 
+Parser &Parser::positional(const char *name, const char *help) {
+    IR_ASSERT(
+        m_positionals.empty() || !m_positionals.back().variadic_,
+        "IRArgs: a fixed positional cannot follow a variadic one"
+    );
+    Positional p;
+    p.name_ = name != nullptr ? name : "";
+    p.help_ = help != nullptr ? help : "";
+    m_positionals.push_back(std::move(p));
+    return *this;
+}
+
+Parser &Parser::variadic(const char *name, const char *help, int minCount) {
+    IR_ASSERT(
+        m_positionals.empty() || !m_positionals.back().variadic_,
+        "IRArgs: only one variadic positional, registered last"
+    );
+    Positional p;
+    p.name_ = name != nullptr ? name : "";
+    p.help_ = help != nullptr ? help : "";
+    p.variadic_ = true;
+    p.minCount_ = minCount;
+    m_positionals.push_back(std::move(p));
+    return *this;
+}
+
 Parser::Entry *Parser::find(const std::string &token) {
     for (Entry &e : m_entries) {
         if (e.name_ == token || (!e.shortAlias_.empty() && e.shortAlias_ == token)) {
@@ -129,50 +187,72 @@ void Parser::parse(int argc, char **argv) {
     // also keeps usage() reporting the registered defaults rather than values
     // parsed from tokens that happened to precede --help on the line.
     for (int i = 1; i < argc; ++i) {
-        const Entry *e = find(argv[i]);
+        std::string name;
+        std::string value;
+        splitInlineValue(argv[i], name, value);
+        const Entry *e = find(name);
         if (e != nullptr && e->name_ == "--help") {
             exitWithUsage(0);
         }
     }
 
+    m_positionalValues.clear();
     for (int i = 1; i < argc; ++i) {
-        Entry *e = find(argv[i]);
+        std::string name;
+        std::string inlineValue;
+        const bool hasInline = splitInlineValue(argv[i], name, inlineValue);
+        Entry *e = find(name);
         if (e == nullptr) {
-            std::fprintf(stderr, "Unknown argument: %s\n\n", argv[i]);
-            exitWithUsage(2);
+            // Not a registered named arg. A dash-led token is an unknown flag;
+            // anything else is a positional (its count is validated below).
+            if (!name.empty() && name[0] == '-') {
+                std::fprintf(stderr, "Unknown argument: %s\n\n", argv[i]);
+                exitWithUsage(2);
+            }
+            m_positionalValues.push_back(argv[i]);
+            continue;
         }
+
+        // The value for a value-taking arg comes inline ("--name=value") or as
+        // the next token ("--name value"); a missing next token is an error.
+        const auto valueFor = [&](const char *expects) -> std::string {
+            if (hasInline) {
+                return inlineValue;
+            }
+            if (i + 1 < argc) {
+                return argv[++i];
+            }
+            std::fprintf(stderr, "Argument %s expects %s\n\n", name.c_str(), expects);
+            exitWithUsage(2);
+        };
+
         e->provided_ = true;
         switch (e->type_) {
         case Type::FLAG:
+            if (hasInline) {
+                std::fprintf(stderr, "Argument %s takes no value\n\n", name.c_str());
+                exitWithUsage(2);
+            }
             e->boolValue_ = true;
             break;
         case Type::INT:
-            if (i + 1 >= argc) {
-                std::fprintf(stderr, "Argument %s expects an integer value\n\n", argv[i]);
-                exitWithUsage(2);
-            }
-            e->intValue_ = std::atoi(argv[++i]);
+            e->intValue_ = std::atoi(valueFor("an integer value").c_str());
             break;
         case Type::FLOAT:
-            if (i + 1 >= argc) {
-                std::fprintf(stderr, "Argument %s expects a float value\n\n", argv[i]);
-                exitWithUsage(2);
-            }
-            e->floatValue_ = static_cast<float>(std::atof(argv[++i]));
+            e->floatValue_ = static_cast<float>(std::atof(valueFor("a float value").c_str()));
             break;
         case Type::STRING:
-            if (i + 1 >= argc) {
-                std::fprintf(stderr, "Argument %s expects a value\n\n", argv[i]);
-                exitWithUsage(2);
-            }
-            e->stringValue_ = argv[++i];
+            e->stringValue_ = valueFor("a value");
             break;
         case Type::OPTIONAL_INT:
-            // Consume the next token only when it reads as a positive integer,
-            // otherwise leave it for the loop. Mirrors the historical
-            // parseAutoScreenshotArgv peek so existing command lines are
-            // byte-identical (the bare default stays in intValue_).
-            if (i + 1 < argc) {
+            // An inline value is taken verbatim; otherwise consume the next
+            // token only when it reads as a positive integer, leaving it for the
+            // loop otherwise. Mirrors the historical parseAutoScreenshotArgv peek
+            // so existing command lines are byte-identical (the bare default
+            // stays in intValue_).
+            if (hasInline) {
+                e->intValue_ = std::atoi(inlineValue.c_str());
+            } else if (i + 1 < argc) {
                 const int parsed = std::atoi(argv[i + 1]);
                 if (parsed > 0) {
                     e->intValue_ = parsed;
@@ -181,6 +261,35 @@ void Parser::parse(int argc, char **argv) {
             }
             break;
         }
+    }
+
+    // Validate positional count against the declarations.
+    std::size_t fixedCount = 0;
+    for (const Positional &p : m_positionals) {
+        if (!p.variadic_) {
+            ++fixedCount;
+        }
+    }
+    const bool hasVariadic = !m_positionals.empty() && m_positionals.back().variadic_;
+    const std::size_t minNeeded =
+        fixedCount + (hasVariadic ? static_cast<std::size_t>(m_positionals.back().minCount_) : 0);
+    if (m_positionalValues.size() < minNeeded) {
+        std::fprintf(
+            stderr,
+            "Expected %s%zu positional argument(s), got %zu\n\n",
+            hasVariadic ? "at least " : "",
+            minNeeded,
+            m_positionalValues.size()
+        );
+        exitWithUsage(2);
+    }
+    if (!hasVariadic && m_positionalValues.size() > fixedCount) {
+        std::fprintf(
+            stderr,
+            "Unexpected positional argument: %s\n\n",
+            m_positionalValues[fixedCount].c_str()
+        );
+        exitWithUsage(2);
     }
 }
 
@@ -226,6 +335,23 @@ bool Parser::wasProvided(const char *name) const {
     return e != nullptr && e->provided_;
 }
 
+std::string Parser::getPositional(const char *name) const {
+    // Fixed positionals fill the first slots of m_positionalValues in
+    // registration order (the variadic tail, if any, captures the rest), so a
+    // declaration's index doubles as its value index.
+    for (std::size_t i = 0; i < m_positionals.size(); ++i) {
+        if (!m_positionals[i].variadic_ && m_positionals[i].name_ == name) {
+            return i < m_positionalValues.size() ? m_positionalValues[i] : std::string{};
+        }
+    }
+    IR_ASSERT(false, "IRArgs: getPositional on unregistered positional");
+    return std::string{};
+}
+
+const std::vector<std::string> &Parser::positionalArgs() const {
+    return m_positionalValues;
+}
+
 int Parser::autoScreenshotWarmupFrames() const {
     return wasProvided("--auto-screenshot") ? getInt("--auto-screenshot") : 0;
 }
@@ -247,7 +373,8 @@ std::string Parser::usage() const {
     });
 
     // Build each left column ("--name, -a <value>") and find the widest so the
-    // help text aligns into a second column.
+    // help text aligns into a second column. Positional names share the same
+    // width so both sections line up.
     std::vector<std::string> leftCols;
     leftCols.reserve(sorted.size());
     std::size_t widest = 0;
@@ -262,8 +389,19 @@ std::string Parser::usage() const {
         }
         leftCols.push_back(std::move(left));
     }
+    for (const Positional &p : m_positionals) {
+        if (p.name_.size() > widest) {
+            widest = p.name_.size();
+        }
+    }
 
-    std::string out = "Usage: " + m_programName + " [options]\n";
+    // Usage line: positional placeholders trail the [options] marker, with the
+    // variadic tail shown as "<name>...".
+    std::string out = "Usage: " + m_programName + " [options]";
+    for (const Positional &p : m_positionals) {
+        out += " <" + p.name_ + (p.variadic_ ? ">..." : ">");
+    }
+    out += "\n";
     if (!m_description.empty()) {
         out += "\n" + m_description + "\n";
     }
@@ -273,6 +411,15 @@ std::string Parser::usage() const {
         out += std::string(widest - leftCols[i].size() + 2, ' ');
         out += sorted[i]->help_;
         out += "\n";
+    }
+    if (!m_positionals.empty()) {
+        out += "\nPositional arguments:\n";
+        for (const Positional &p : m_positionals) {
+            out += "  " + p.name_;
+            out += std::string(widest - p.name_.size() + 2, ' ');
+            out += p.help_;
+            out += "\n";
+        }
     }
     return out;
 }

--- a/tools/img_diff/CMakeLists.txt
+++ b/tools/img_diff/CMakeLists.txt
@@ -12,5 +12,11 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(stbimage)
 
-add_executable(img_diff main.cpp)
-target_include_directories(img_diff PRIVATE ${stbimage_SOURCE_DIR})
+# IRArgs lives in the engine tree but has no engine dependencies (see the
+# dependency-free assert note in engine/ir_args.cpp), so img_diff compiles the
+# source directly and stays standalone — no link against the engine library.
+add_executable(img_diff main.cpp ${PROJECT_SOURCE_DIR}/engine/ir_args.cpp)
+target_include_directories(img_diff PRIVATE
+    ${stbimage_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/engine/include
+)

--- a/tools/img_diff/main.cpp
+++ b/tools/img_diff/main.cpp
@@ -19,11 +19,11 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 
+#include <irreden/ir_args.hpp>
+
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
-#include <stdexcept>
 #include <string>
 
 namespace {
@@ -41,67 +41,6 @@ struct Args {
     int threshold_ = 0;
     bool ignoreAlpha_ = false;
 };
-
-void printUsage(const char *exe) {
-    std::fprintf(
-        stderr,
-        "Usage: %s <baseline.png> <current.png> <out_diff.png> "
-        "[--threshold N] [--ignore-alpha]\n"
-        "\n"
-        "Highlights pixels that drift between baseline and current. Drifted\n"
-        "pixels are written red; unchanged pixels are written as a desaturated\n"
-        "30%%-luminance copy of the baseline so context stays visible.\n"
-        "\n"
-        "Options:\n"
-        "  --threshold N    Per-channel delta tolerance (default: 0).\n"
-        "  --ignore-alpha   Compare RGB only; ignore the alpha channel.\n"
-        "\n"
-        "Exit code: 0 on zero drift, 1 on any drift, 2 on argument / IO error.\n",
-        exe
-    );
-}
-
-bool parseArgs(int argc, char **argv, Args &out) {
-    int positional = 0;
-    for (int i = 1; i < argc; ++i) {
-        const char *a = argv[i];
-        if (std::strcmp(a, "--threshold") == 0) {
-            if (i + 1 >= argc) {
-                std::fprintf(stderr, "img_diff: --threshold requires an argument\n");
-                return false;
-            }
-            try {
-                out.threshold_ = std::stoi(argv[++i]);
-            } catch (const std::exception &) {
-                std::fprintf(stderr, "img_diff: --threshold requires a numeric argument\n");
-                return false;
-            }
-            if (out.threshold_ < 0) {
-                std::fprintf(stderr, "img_diff: --threshold must be >= 0\n");
-                return false;
-            }
-        } else if (std::strcmp(a, "--ignore-alpha") == 0) {
-            out.ignoreAlpha_ = true;
-        } else if (a[0] == '-') {
-            std::fprintf(stderr, "img_diff: unknown option '%s'\n", a);
-            return false;
-        } else {
-            switch (positional++) {
-            case 0: out.baselinePath_ = a; break;
-            case 1: out.currentPath_ = a; break;
-            case 2: out.outputPath_ = a; break;
-            default:
-                std::fprintf(stderr, "img_diff: unexpected argument '%s'\n", a);
-                return false;
-            }
-        }
-    }
-    if (positional != 3) {
-        std::fprintf(stderr, "img_diff: expected 3 positional arguments, got %d\n", positional);
-        return false;
-    }
-    return true;
-}
 
 struct Image {
     unsigned char *data_ = nullptr;
@@ -133,15 +72,27 @@ bool loadRgba(const std::string &path, Image &out) {
 } // namespace
 
 int main(int argc, char **argv) {
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
-            printUsage(argv[0]);
-            return 0;
-        }
-    }
+    IRArgs::Parser parser(
+        "img_diff — highlight per-pixel drift between two PNGs. Drifted pixels are "
+        "written red; unchanged pixels become a 30%-luminance copy of the baseline "
+        "so context stays visible. Exit: 0 = no drift, 1 = drift, 2 = argument/IO error.",
+        IRArgs::Common::NONE
+    );
+    parser.integer("--threshold", "Per-channel delta tolerance (default 0)", 0);
+    parser.flag("--ignore-alpha", "Compare RGB only; ignore the alpha channel");
+    parser.positional("baseline", "Baseline PNG");
+    parser.positional("current", "Current PNG");
+    parser.positional("out_diff", "Output diff PNG");
+    parser.parse(argc, argv);
+
     Args args;
-    if (!parseArgs(argc, argv, args)) {
-        printUsage(argv[0]);
+    args.baselinePath_ = parser.getPositional("baseline");
+    args.currentPath_ = parser.getPositional("current");
+    args.outputPath_ = parser.getPositional("out_diff");
+    args.threshold_ = parser.getInt("--threshold");
+    args.ignoreAlpha_ = parser.getFlag("--ignore-alpha");
+    if (args.threshold_ < 0) {
+        std::fprintf(stderr, "img_diff: --threshold must be >= 0\n");
         return kExitArgError;
     }
 

--- a/tools/jitter_probe/CMakeLists.txt
+++ b/tools/jitter_probe/CMakeLists.txt
@@ -12,5 +12,11 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(stbimage)
 
-add_executable(jitter_probe main.cpp)
-target_include_directories(jitter_probe PRIVATE ${stbimage_SOURCE_DIR})
+# IRArgs lives in the engine tree but has no engine dependencies (see the
+# dependency-free assert note in engine/ir_args.cpp), so jitter_probe compiles
+# the source directly and stays standalone — no link against the engine library.
+add_executable(jitter_probe main.cpp ${PROJECT_SOURCE_DIR}/engine/ir_args.cpp)
+target_include_directories(jitter_probe PRIVATE
+    ${stbimage_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/engine/include
+)

--- a/tools/jitter_probe/main.cpp
+++ b/tools/jitter_probe/main.cpp
@@ -29,11 +29,12 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
+#include <irreden/ir_args.hpp>
+
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <string>
 #include <vector>
 
@@ -48,54 +49,6 @@ struct Args {
     double maxResidual_ = 1.50;
     bool verbose_ = false;
 };
-
-void usage(const char *exe) {
-    std::fprintf(
-        stderr,
-        "Usage: %s <frame_0.png> <frame_1.png> ... (>=3, in capture order)\n"
-        "  [--threshold L] [--color R,G,B,T] [--reversal-eps PX]\n"
-        "  [--max-residual PX] [--verbose]\n",
-        exe
-    );
-}
-
-bool parseArgs(int argc, char **argv, Args &out) {
-    for (int i = 1; i < argc; ++i) {
-        const std::string a = argv[i];
-        if (a == "--threshold" && i + 1 < argc) {
-            out.threshold_ = std::atoi(argv[++i]);
-        } else if (a == "--reversal-eps" && i + 1 < argc) {
-            out.reversalEps_ = std::atof(argv[++i]);
-        } else if (a == "--max-residual" && i + 1 < argc) {
-            out.maxResidual_ = std::atof(argv[++i]);
-        } else if (a == "--verbose") {
-            out.verbose_ = true;
-        } else if (a == "--color" && i + 1 < argc) {
-            out.useColor_ = true;
-            if (std::sscanf(
-                    argv[++i],
-                    "%d,%d,%d,%d",
-                    &out.colorR_,
-                    &out.colorG_,
-                    &out.colorB_,
-                    &out.colorTol_
-                ) != 4) {
-                std::fprintf(stderr, "jitter_probe: --color expects R,G,B,T\n");
-                return false;
-            }
-        } else if (!a.empty() && a[0] == '-') {
-            std::fprintf(stderr, "jitter_probe: unknown flag '%s'\n", a.c_str());
-            return false;
-        } else {
-            out.frames_.push_back(a);
-        }
-    }
-    if (out.frames_.size() < 3) {
-        std::fprintf(stderr, "jitter_probe: need >= 3 frames (got %zu)\n", out.frames_.size());
-        return false;
-    }
-    return true;
-}
 
 // Foreground centroid (mean x,y of matching pixels) for one frame.
 // Returns false if too few pixels match (shape off-screen / empty frame).
@@ -221,10 +174,36 @@ AxisStats analyze(
 } // namespace
 
 int main(int argc, char **argv) {
+    IRArgs::Parser parser(
+        "jitter_probe — temporal-jitter detector across a frame sequence captured "
+        "during a smooth camera sweep. Frames MUST be given in capture order. "
+        "Exit: 0 = SMOOTH, 1 = JITTER, 2 = argument/IO error.",
+        IRArgs::Common::NONE
+    );
+    parser.integer("--threshold", "Foreground = pixels with (R+G+B) > L (0..765)", 24);
+    parser.string("--color", "Foreground = pixels within T of color R,G,B (format: R,G,B,T)", "");
+    parser.number("--reversal-eps", "Per-frame deltas under this (px) are treated as 0", 0.10f);
+    parser.number("--max-residual", "SMOOTH verdict requires residual <= this (px)", 1.50f);
+    parser.flag("--verbose", "Print the per-frame centroid + residual table");
+    parser.variadic("frames", "Frame PNGs in capture order (>= 3)", 3);
+    parser.parse(argc, argv);
+
     Args args;
-    if (!parseArgs(argc, argv, args)) {
-        usage(argv[0]);
-        return 2;
+    args.threshold_ = parser.getInt("--threshold");
+    args.reversalEps_ = parser.getFloat("--reversal-eps");
+    args.maxResidual_ = parser.getFloat("--max-residual");
+    args.verbose_ = parser.getFlag("--verbose");
+    args.frames_ = parser.positionalArgs();
+    if (parser.wasProvided("--color")) {
+        args.useColor_ = true;
+        const std::string color = parser.getString("--color");
+        if (std::sscanf(
+                color.c_str(), "%d,%d,%d,%d", &args.colorR_, &args.colorG_, &args.colorB_,
+                &args.colorTol_
+            ) != 4) {
+            std::fprintf(stderr, "jitter_probe: --color expects R,G,B,T\n");
+            return 2;
+        }
     }
 
     const size_t n = args.frames_.size();


### PR DESCRIPTION
## Summary

Epic #2057 **P7** — bring the standalone tools (no engine loop) onto IRArgs, which needs two framework extensions first.

**IRArgs framework (`engine/ir_args.{hpp,cpp}`):**
- `IRArgs::Common::NONE` constructor mode — pre-registers only `--help`/`-h`, not the engine-common args, so a tool's `--help` advertises only its own flags.
- Positional args — `.positional(name, help)` (ordered fixed) and `.variadic(name, help, minCount)` (trailing variable tail); read via `getPositional()` / `positionalArgs()`, count-validated on parse and shown in the auto-generated usage.
- `--name=value` accepted alongside `--name value` for value-taking args (the form `cmake/ir_functions.cmake` passes lua_codegen — kept byte-identical).
- Decoupled from the engine profiler: `ir_args.cpp` uses a self-contained assert (same compiled-out-in-release semantics) instead of `IR_ASSERT`, so the engine-free tools compile the source directly and stay standalone — no engine-library link.

**Tool ports (hand-rolled `strcmp`/argv loops → `IRArgs::Common::NONE`):**
- `img_diff` — `--threshold` (int), `--ignore-alpha` (flag), 3 positionals.
- `jitter_probe` — `--threshold`/`--color`/`--reversal-eps`/`--max-residual`/`--verbose` + variadic frame list; **gains `--help`** (had none).
- `lua_codegen` — `--out`, `--default-mode` (`codegen|eval`, accepts `=`-form), N `.lua` positionals; the CMake CODEGEN invocation in `ir_functions.cmake` is **unchanged**.

## Notes
- `jitter_probe`'s `--reversal-eps`/`--max-residual` move double→float (IRArgs `number`): a sub-1e-8 shift on tolerance thresholds, no verdict impact.
- `lua_codegen` keeps exit-1 for semantic errors (bad mode / missing `--out`); IRArgs parse errors (unknown arg / bad positional count) exit 2. The CMake build only hits the success path, which is byte-identical.

## Test plan
- [x] `img_diff`/`jitter_probe`/`ir_lua_codegen` build clean (ir_args.cpp compiled in, no engine link).
- [x] Each `--help` lists only its real flags + positionals, no engine-common args, exit 0.
- [x] `img_diff` identical→0, too-few/too-many/unknown-flag→2, `--threshold=0` (=-form) parses.
- [x] `jitter_probe` 3+ frames→SMOOTH, `--color=`/`--reversal-eps=` parse, bad `--color`→2, <3 frames→2.
- [x] `lua_codegen` full CMake CODEGEN integration (`IRLuaPerfGrid` builds; `--default-mode=codegen` =-form), `=eval`→0, bad mode / missing --out→1.
- [x] `fog_demo` (engine-owned ENGINE mode) `--help` still shows engine-common + custom flags — backward compatible.
- [x] format-changed clean; engine lib + IRFogDemo + IRLuaPerfGrid build.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2069

Closes #2063

🤖 Generated with [Claude Code](https://claude.com/claude-code)