### PR TITLE
creations: migrate perf_grid + shape_debug flags to IRArgs (P3)

### DIFF
--- a/.fleet/plans/issue-2060.md
+++ b/.fleet/plans/issue-2060.md
@@ -1,0 +1,51 @@
+# Plan: P3 — migrate perf_grid + shape_debug custom flags
+
+- **Issue:** #2060
+- **Model:** opus
+- **Date:** 2026-06-26
+- **Epic:** #2057 — see `.fleet/plans/issue-2057.md`
+- **Blocked by:** #2058
+
+This plan mirrors the architect's `## Plan` comment posted on issue #2060;
+committed here as the implementer's first commit per #1932.
+
+## Verified current state
+- `creations/demos/perf_grid/main.cpp` — a `parseArgs()` strcmp loop over 14
+  flags + calls to BOTH `parseAutoScreenshotArgv` and `parseConfigPresetArg`.
+- `creations/demos/shape_debug/main.cpp` — inline strcmp parsing of ~18 flags
+  + `parseAutoScreenshotArgv`.
+Assumes P1 (#2058) landed `IREngine::args()`.
+
+## Sibling reconciliation
+P1 (#2058) already removes `parseConfigPresetArg` AND repoints perf_grid's
+preset read. So by the time P3 runs, perf_grid no longer calls it — P3 only
+removes the remaining strcmp loop + the `parseAutoScreenshotArgv` call and
+registers the 14 flags. Re-confirm at impl time that P1 landed the preset
+repoint (don't double-edit it).
+
+## Affected files
+- `creations/demos/perf_grid/main.cpp`
+- `creations/demos/shape_debug/main.cpp`
+
+## Approach — flag→type mapping (preserve defaults exactly)
+- counts (`--grid-size`, `--base-subdivisions`, `--worker-threads`) → integer
+- `--zoom`, `--yaw`, `--wave-amplitude` → number
+- `--auto-profile` (default 300!), `--spin-yaw` → optionalInt
+- string-valued (`--mode`, `--subdivision-mode`, `--debug-overlay`,
+  `--load-vxs`, `--spin-shape`, `--depth-probe "X,Y"`) → string (demo-side
+  parse for the comma pair)
+- the rest (`--yaw-ramp`, `--yaw-ramp-crops`, `--occlusion-cull`,
+  `--no-overlay`, `--depth-color`, `--checkerboard`, `--gpu-voxel-smoke`,
+  `--skin-smoke`, `--pivot-focus-demo`, `--pan-sweep`, `--yaw-sweep`,
+  `--pivot-origin`, `--cull-validate`, `--spin-shape-voxel`) → flag
+
+Register custom flags on `IREngine::args()` before `IREngine::init(argc,
+argv)`, then read them back via the typed getters; preserve the existing
+CLI-override precedence (defaults < config.lua < preset < CLI) by gating each
+override on `wasProvided()`.
+
+## Verification
+- `perf_grid --mode sdf --grid-size 128 --auto-profile` and `shape_debug
+  --yaw-sweep --zoom 4` behave identically to pre-migration.
+- `--help` on each lists all flags; `fleet-build` clean.
+- `grep -n strcmp creations/demos/{perf_grid,shape_debug}/main.cpp` → empty.

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -1,3 +1,4 @@
+#include <irreden/ir_args.hpp>
 #include <irreden/ir_engine.hpp>
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_entity.hpp>
@@ -59,8 +60,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <cstring>
-#include <cstdlib>
 #include <numbers>
 #include <string>
 #include <string_view>
@@ -443,110 +442,127 @@ void applyCliOverrides() {
     }
 }
 
-void parseArgs(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--config-preset") == 0 && i + 1 < argc) {
-            // Read locally for now: perf_grid still hand-rolls its argv loop
-            // and calls init(argv[0]), so it can't go through IREngine::args()
-            // until its full IRArgs migration (epic #2057 P3, #2060). This
-            // branch replaces the retired IREngine::parseConfigPresetArg helper
-            // with no behaviour change.
-            g_cliOverrides.configPreset_ = argv[i + 1];
-            ++i;
-        } else if (std::strcmp(argv[i], "--auto-profile") == 0) {
-            g_autoProfileFrames = 300;
-            if (i + 1 < argc) {
-                int frames = std::atoi(argv[i + 1]);
-                if (frames > 0) {
-                    g_autoProfileFrames = frames;
-                    ++i;
-                }
-            }
-        } else if (std::strcmp(argv[i], "--occlusion-cull") == 0) {
-            g_occlusionCull = true;
-        } else if (std::strcmp(argv[i], "--no-overlay") == 0) {
-            g_noOverlay = true;
-        } else if (std::strcmp(argv[i], "--mode") == 0 && i + 1 < argc) {
-            g_cliOverrides.mode_ = parseMode(argv[i + 1]);
-            g_cliOverrides.modeSet_ = true;
-            ++i;
-        } else if (std::strcmp(argv[i], "--grid-size") == 0 && i + 1 < argc) {
-            int gridSize = std::atoi(argv[i + 1]);
-            if (gridSize > 0) {
-                g_cliOverrides.gridSize_ = gridSize;
-                g_cliOverrides.gridSizeSet_ = true;
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--zoom") == 0 && i + 1 < argc) {
-            float zoom = static_cast<float>(std::atof(argv[i + 1]));
-            if (zoom > 0.0f) {
-                g_cliOverrides.zoom_ = zoom;
-                g_cliOverrides.zoomSet_ = true;
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--yaw") == 0 && i + 1 < argc) {
-            g_cliOverrides.yaw_ = static_cast<float>(std::atof(argv[i + 1]));
-            g_cliOverrides.yawSet_ = true;
-            ++i;
-        } else if (std::strcmp(argv[i], "--yaw-ramp") == 0) {
-            g_cliOverrides.yawRamp_ = true;
-        } else if (std::strcmp(argv[i], "--yaw-ramp-crops") == 0) {
-            // Attach a center ROI crop to each near-cardinal residual pose so
-            // the small-cube zoom pass dumps inspectable per-axis-seam crops.
-            g_cliOverrides.yawRampCrops_ = true;
-        } else if (std::strcmp(argv[i], "--wave-amplitude") == 0 && i + 1 < argc) {
-            // 0.0 = static scene (no per-frame voxel motion). Useful for
-            // isolating per-frame upload cost in profiler runs.
-            g_cliOverrides.waveAmplitude_ = static_cast<float>(std::atof(argv[i + 1]));
-            g_cliOverrides.waveAmplitudeSet_ = true;
-            ++i;
-        } else if (std::strcmp(argv[i], "--subdivision-mode") == 0 && i + 1 < argc) {
-            std::string mode = argv[i + 1];
-            if (mode == "none") {
-                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::NONE;
-                g_cliOverrides.subdivisionModeSet_ = true;
-            } else if (mode == "position_only") {
-                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::POSITION_ONLY;
-                g_cliOverrides.subdivisionModeSet_ = true;
-            } else if (mode == "full") {
-                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::FULL;
-                g_cliOverrides.subdivisionModeSet_ = true;
-            } else {
-                IR_LOG_WARN(
-                    "Unknown --subdivision-mode '{}'; expected none|position_only|full",
-                    mode
-                );
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--base-subdivisions") == 0 && i + 1 < argc) {
-            int sub = std::atoi(argv[i + 1]);
-            if (sub > 0) {
-                g_cliOverrides.baseSubdivisions_ = sub;
-                g_cliOverrides.baseSubdivisionsSet_ = true;
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--worker-threads") == 0 && i + 1 < argc) {
-            // Accepted for cell-ID purposes by perf_grid_matrix.sh; ignored
-            // until T-221 wires enkiTS thread-pool sizing.
-            int wt = std::atoi(argv[i + 1]);
-            if (wt >= 0) {
-                g_cliOverrides.workerThreads_ = wt;
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--depth-probe") == 0 && i + 1 < argc) {
-            int px = 0;
-            int py = 0;
-            if (std::sscanf(argv[i + 1], "%d,%d", &px, &py) == 2) {
-                g_cliOverrides.depthProbeSet_ = true;
-                g_cliOverrides.depthProbePixel_ = ivec2(px, py);
-            } else {
-                IR_LOG_WARN(
-                    "--depth-probe: expected X,Y (e.g. 960,540); ignoring '{}'",
-                    argv[i + 1]
-                );
-            }
-            ++i;
+// Register perf_grid's custom flags on the engine-owned parser. --help /
+// --auto-screenshot / --config-preset are pre-registered by the Parser ctor;
+// IREngine::init(argc, argv) parses common + these in one pass, so --help lists
+// every flag and exits before any window/GL/Metal init (epic #2057 P3, #2060).
+void registerCliArgs() {
+    IRArgs::Parser &args = IREngine::args();
+    args.optionalInt(
+        "--auto-profile",
+        "Run N frames (default 300) collecting CPU+GPU per-stage timing, then exit",
+        300
+    );
+    args.flag(
+        "--occlusion-cull",
+        "Force the voxel-pool chunk-occlusion HZB pre-pass ON (off by default)"
+    );
+    args.flag("--no-overlay", "Drop PERF_STATS_OVERLAY so a captured frame is deterministic");
+    args.string("--mode", "Scene mode: voxel_set | sdf | dense_set | hollow_set", "voxel_set");
+    args.integer("--grid-size", "Grid edge in cells", 64);
+    args.number("--zoom", "Initial camera zoom", 0.5f);
+    args.number("--yaw", "Initial camera Z-yaw in radians", 0.0f);
+    args.flag("--yaw-ramp", "Rotated-solidity validation sweep (#1882/#1883)");
+    args.flag(
+        "--yaw-ramp-crops",
+        "Attach a center ROI crop to each near-cardinal residual --yaw-ramp pose"
+    );
+    args.number("--wave-amplitude", "Per-frame idle wave amplitude (0 = static scene)", 0.0f);
+    args.string("--subdivision-mode", "Trixel subdivision: none | position_only | full", "full");
+    args.integer("--base-subdivisions", "Base trixel subdivision count", 1);
+    args.integer("--worker-threads", "Recorded for manifest/cell-ID; thread wiring is T-221", 0);
+    args.string("--depth-probe", "Per-frame composite-depth readback at framebuffer pixel X,Y", "");
+}
+
+// Read the parsed values back into the settings/override structs. Runs AFTER
+// IREngine::init(argc, argv) has parsed. The CLI-override precedence (defaults <
+// config.lua < preset < CLI) is unchanged: a flag only sets its `*Set_` gate
+// when actually provided, so config/preset values stand otherwise.
+void readCliArgs() {
+    const IRArgs::Parser &args = IREngine::args();
+
+    // Engine-common args now own these (P1 #2058 retired the local reads).
+    g_autoWarmupFrames = args.autoScreenshotWarmupFrames();
+    g_cliOverrides.configPreset_ = args.configPreset();
+
+    // --auto-profile: 0 when absent, else the frame count (300 if bare).
+    if (args.wasProvided("--auto-profile")) {
+        g_autoProfileFrames = args.getInt("--auto-profile");
+    }
+    g_occlusionCull = args.getFlag("--occlusion-cull");
+    g_noOverlay = args.getFlag("--no-overlay");
+
+    if (args.wasProvided("--mode")) {
+        g_cliOverrides.mode_ = parseMode(args.getString("--mode"));
+        g_cliOverrides.modeSet_ = true;
+    }
+    if (args.wasProvided("--grid-size")) {
+        const int gridSize = args.getInt("--grid-size");
+        if (gridSize > 0) {
+            g_cliOverrides.gridSize_ = gridSize;
+            g_cliOverrides.gridSizeSet_ = true;
+        }
+    }
+    if (args.wasProvided("--zoom")) {
+        const float zoom = args.getFloat("--zoom");
+        if (zoom > 0.0f) {
+            g_cliOverrides.zoom_ = zoom;
+            g_cliOverrides.zoomSet_ = true;
+        }
+    }
+    if (args.wasProvided("--yaw")) {
+        g_cliOverrides.yaw_ = args.getFloat("--yaw");
+        g_cliOverrides.yawSet_ = true;
+    }
+    g_cliOverrides.yawRamp_ = args.getFlag("--yaw-ramp");
+    g_cliOverrides.yawRampCrops_ = args.getFlag("--yaw-ramp-crops");
+    if (args.wasProvided("--wave-amplitude")) {
+        // 0.0 = static scene (no per-frame voxel motion). Useful for isolating
+        // per-frame upload cost in profiler runs.
+        g_cliOverrides.waveAmplitude_ = args.getFloat("--wave-amplitude");
+        g_cliOverrides.waveAmplitudeSet_ = true;
+    }
+    if (args.wasProvided("--subdivision-mode")) {
+        const std::string mode = args.getString("--subdivision-mode");
+        if (mode == "none") {
+            g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::NONE;
+            g_cliOverrides.subdivisionModeSet_ = true;
+        } else if (mode == "position_only") {
+            g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::POSITION_ONLY;
+            g_cliOverrides.subdivisionModeSet_ = true;
+        } else if (mode == "full") {
+            g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+            g_cliOverrides.subdivisionModeSet_ = true;
+        } else {
+            IR_LOG_WARN("Unknown --subdivision-mode '{}'; expected none|position_only|full", mode);
+        }
+    }
+    if (args.wasProvided("--base-subdivisions")) {
+        const int sub = args.getInt("--base-subdivisions");
+        if (sub > 0) {
+            g_cliOverrides.baseSubdivisions_ = sub;
+            g_cliOverrides.baseSubdivisionsSet_ = true;
+        }
+    }
+    if (args.wasProvided("--worker-threads")) {
+        // Accepted for cell-ID purposes by perf_grid_matrix.sh; ignored until
+        // T-221 wires enkiTS thread-pool sizing.
+        const int wt = args.getInt("--worker-threads");
+        if (wt >= 0) {
+            g_cliOverrides.workerThreads_ = wt;
+        }
+    }
+    if (args.wasProvided("--depth-probe")) {
+        // `--depth-probe X,Y` (#1910): IRArgs has no pair type, so register as a
+        // string and keep the demo-side comma split.
+        const std::string probe = args.getString("--depth-probe");
+        int px = 0;
+        int py = 0;
+        if (std::sscanf(probe.c_str(), "%d,%d", &px, &py) == 2) {
+            g_cliOverrides.depthProbeSet_ = true;
+            g_cliOverrides.depthProbePixel_ = ivec2(px, py);
+        } else {
+            IR_LOG_WARN("--depth-probe: expected X,Y (e.g. 960,540); ignoring '{}'", probe);
         }
     }
 }
@@ -739,10 +755,13 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    parseArgs(argc, argv);
+    // Register custom flags, then let init parse common + custom in one pass
+    // (--help exits here, pre-window). Read the parsed values back afterwards.
+    registerCliArgs();
+    IREngine::init(argc, argv);
+    readCliArgs();
 
     IR_LOG_INFO("Starting creation: perf_grid");
-    IREngine::init(argv[0]);
     applyConfigTable();
     applyConfigPreset(g_cliOverrides.configPreset_);
     applyCliOverrides();

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -1,3 +1,4 @@
+#include <irreden/ir_args.hpp>
 #include <irreden/ir_engine.hpp>
 #include <irreden/ir_system.hpp>
 #include <irreden/ir_entity.hpp>
@@ -12,8 +13,6 @@
 
 #include <array>
 #include <cstdio>
-#include <cstring>
-#include <cstdlib>
 #include <numbers>
 #include <string>
 #include <vector>
@@ -281,6 +280,105 @@ bool g_yawSweep = false;
 std::vector<IRVideo::AutoScreenshotShot> g_yawSweepShots;
 std::vector<std::array<char, 40>> g_yawSweepShotLabels;
 
+// Register shape_debug's custom flags on the engine-owned parser. --help /
+// --auto-screenshot / --config-preset are pre-registered by the Parser ctor;
+// IREngine::init(argc, argv) parses common + these in one pass, so --help lists
+// every flag and exits before any window/GL/Metal init (epic #2057 P3, #2060).
+void registerCliArgs() {
+    IRArgs::Parser &args = IREngine::args();
+    args.optionalInt(
+        "--auto-profile",
+        "Run N frames (default 300) with frame timing, then exit",
+        300
+    );
+    args.flag("--depth-color", "Tint each voxel by local iso-depth (front=red, back=blue)");
+    args.flag("--checkerboard", "Tint alternating voxels darker (flickers; off by default)");
+    args.flag(
+        "--occlusion-cull",
+        "Force the voxel-pool chunk-occlusion HZB pre-pass ON (off by default)"
+    );
+    args.flag("--gpu-voxel-smoke", "Spawn one cube routed through the GPU voxel-position prepass");
+    args.flag("--pivot-focus-demo", "Yaw sweep pinning the pivot on a tall pillar (#1921)");
+    args.flag("--skin-smoke", "Spawn one 2-bone rigged voxel bar skinned via binding-17 (#1605)");
+    args.flag("--pan-sweep", "Fine fixed-yaw camera-pan jitter sweep (#1944)");
+    args.flag("--yaw-sweep", "Fine fixed-position camera-yaw jitter sweep (#1944)");
+    args.number("--zoom", "Initial camera zoom (snapped to nearest power of two)", 0.0f);
+    args.string("--debug-overlay", "Debug overlay mode (e.g. none, depth, normals)", "none");
+    args.number("--yaw", "Initial camera Z-yaw in radians", 0.0f);
+    args.flag("--pivot-origin", "Force the legacy world-origin Z-yaw pivot (#1352 A/B)");
+    args.flag("--cull-validate", "Frozen-cull free-fly validation sweep (#1438)");
+    args.string(
+        "--load-vxs",
+        "Path to a DENSE-mode .vxs to load and render alongside fixtures",
+        ""
+    );
+    args.optionalInt(
+        "--spin-yaw",
+        "Drive camera Z-yaw (deg/sec live, default 30; shot-count across one rotation when "
+        "combined with --auto-screenshot)",
+        30
+    );
+    args.string(
+        "--spin-shape",
+        "Spawn a single named shape centred at origin instead of the full fixture scene (#1922)",
+        ""
+    );
+    args.flag("--spin-shape-voxel", "Render the --spin-shape via the voxel-pool twin, not the SDF");
+}
+
+// Read the parsed values back into the demo's globals. Runs AFTER
+// IREngine::init(argc, argv) has parsed. A value flag only writes its global
+// when actually provided, preserving each global's pre-parse default.
+void readCliArgs() {
+    const IRArgs::Parser &args = IREngine::args();
+
+    g_autoWarmupFrames = args.autoScreenshotWarmupFrames();
+
+    // --auto-profile: 0 when absent, else the frame count (300 if bare).
+    if (args.wasProvided("--auto-profile")) {
+        g_autoProfileFrames = args.getInt("--auto-profile");
+    }
+    g_depthColor = args.getFlag("--depth-color");
+    g_checkerboard = args.getFlag("--checkerboard");
+    g_occlusionCull = args.getFlag("--occlusion-cull");
+    g_gpuVoxelSmoke = args.getFlag("--gpu-voxel-smoke");
+    g_pivotFocusDemo = args.getFlag("--pivot-focus-demo");
+    g_skinSmoke = args.getFlag("--skin-smoke");
+    g_panSweep = args.getFlag("--pan-sweep");
+    g_yawSweep = args.getFlag("--yaw-sweep");
+
+    if (args.wasProvided("--zoom")) {
+        const float zoom = args.getFloat("--zoom");
+        if (zoom > 0.0f) {
+            g_initialZoom = zoom;
+        }
+    }
+    if (args.wasProvided("--debug-overlay")) {
+        g_debugOverlay =
+            IRRender::debugOverlayModeFromString(args.getString("--debug-overlay").c_str());
+    }
+    if (args.wasProvided("--yaw")) {
+        const float yaw = args.getFloat("--yaw");
+        g_initialYawRadians = yaw;
+        g_initialYaw = yaw;
+        g_initialYawSet = true;
+    }
+    g_pivotOrigin = args.getFlag("--pivot-origin");
+    g_cullValidate = args.getFlag("--cull-validate");
+    if (args.wasProvided("--load-vxs")) {
+        g_loadVxsPath = args.getString("--load-vxs");
+    }
+    // --spin-yaw: 0 (disabled) when absent, else the rate (30 if bare). The
+    // optional value reads as an int — fractional deg/sec is truncated.
+    if (args.wasProvided("--spin-yaw")) {
+        g_spinYawDegPerSec = static_cast<float>(args.getInt("--spin-yaw"));
+    }
+    if (args.wasProvided("--spin-shape")) {
+        g_spinShapeType = args.getString("--spin-shape");
+    }
+    g_spinShapeVoxel = args.getFlag("--spin-shape-voxel");
+}
+
 } // namespace
 
 void initSystems();
@@ -288,80 +386,11 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--auto-profile") == 0) {
-            g_autoProfileFrames = 300; // default
-            if (i + 1 < argc) {
-                int frames = std::atoi(argv[i + 1]);
-                if (frames > 0) {
-                    g_autoProfileFrames = frames;
-                    ++i;
-                }
-            }
-        } else if (std::strcmp(argv[i], "--depth-color") == 0) {
-            g_depthColor = true;
-        } else if (std::strcmp(argv[i], "--checkerboard") == 0) {
-            g_checkerboard = true;
-        } else if (std::strcmp(argv[i], "--occlusion-cull") == 0) {
-            g_occlusionCull = true;
-        } else if (std::strcmp(argv[i], "--gpu-voxel-smoke") == 0) {
-            g_gpuVoxelSmoke = true;
-        } else if (std::strcmp(argv[i], "--pivot-focus-demo") == 0) {
-            g_pivotFocusDemo = true;
-        } else if (std::strcmp(argv[i], "--skin-smoke") == 0) {
-            g_skinSmoke = true;
-        } else if (std::strcmp(argv[i], "--pan-sweep") == 0) {
-            g_panSweep = true;
-        } else if (std::strcmp(argv[i], "--yaw-sweep") == 0) {
-            g_yawSweep = true;
-        } else if (std::strcmp(argv[i], "--zoom") == 0) {
-            if (i + 1 < argc) {
-                float z = static_cast<float>(std::atof(argv[i + 1]));
-                if (z > 0.0f) {
-                    g_initialZoom = z;
-                    ++i;
-                }
-            }
-        } else if (std::strcmp(argv[i], "--debug-overlay") == 0) {
-            if (i + 1 < argc) {
-                g_debugOverlay = IRRender::debugOverlayModeFromString(argv[i + 1]);
-                ++i;
-            }
-        } else if (std::strcmp(argv[i], "--yaw") == 0) {
-            if (i + 1 < argc) {
-                g_initialYawRadians = static_cast<float>(std::atof(argv[i + 1]));
-                g_initialYaw = static_cast<float>(std::atof(argv[i + 1]));
-                g_initialYawSet = true;
-                ++i;
-            }
-        } else if (std::strcmp(argv[i], "--pivot-origin") == 0) {
-            g_pivotOrigin = true;
-        } else if (std::strcmp(argv[i], "--cull-validate") == 0) {
-            g_cullValidate = true;
-        } else if (std::strcmp(argv[i], "--load-vxs") == 0) {
-            if (i + 1 < argc) {
-                g_loadVxsPath = argv[i + 1];
-                ++i;
-            }
-        } else if (std::strcmp(argv[i], "--spin-yaw") == 0) {
-            g_spinYawDegPerSec = 30.0f; // default rotation rate
-            if (i + 1 < argc) {
-                float v = static_cast<float>(std::atof(argv[i + 1]));
-                if (v > 0.0f) {
-                    g_spinYawDegPerSec = v;
-                    ++i;
-                }
-            }
-        } else if (std::strcmp(argv[i], "--spin-shape") == 0) {
-            if (i + 1 < argc) {
-                g_spinShapeType = argv[i + 1];
-                ++i;
-            }
-        } else if (std::strcmp(argv[i], "--spin-shape-voxel") == 0) {
-            g_spinShapeVoxel = true;
-        }
-    }
+    // Register custom flags, then let init parse common + custom in one pass
+    // (--help exits here, pre-window). Read the parsed values back afterwards.
+    registerCliArgs();
+    IREngine::init(argc, argv);
+    readCliArgs();
 
     // --spin-yaw + --auto-screenshot: reinterpret the screenshot value as
     // "shots across one rotation", and use a small internal warmup. This is
@@ -378,7 +407,6 @@ int main(int argc, char **argv) {
     }
 
     IR_LOG_INFO("Starting creation: shape_debug");
-    IREngine::init(argv[0]);
     if (g_autoProfileFrames > 0) {
         IREngine::enableFrameTiming(true);
     }


### PR DESCRIPTION
## Summary
- Migrate `perf_grid` (14 custom flags) and `shape_debug` (~18 custom flags) off their hand-rolled `strcmp(argv...)` loops onto the engine-owned `IRArgs` parser (`IREngine::args()`), epic #2057 **P3**.
- Each demo now `registerCliArgs()` (declarative `.flag`/`.integer`/`.number`/`.string`/`.optionalInt`) **before** `IREngine::init(argc, argv)`, then `readCliArgs()` reads back via the typed getters. One engine parse covers common + custom flags, so `--help` aggregates everything and exits pre-window; an unknown arg exits(2).
- `--config-preset` / `--auto-screenshot` now come from the engine-common set (no local re-read; P1 #2058 owns them). `perf_grid`'s CLI-override precedence (config.lua < preset < CLI) is preserved by gating each override on `wasProvided()`.
- Defaults preserved exactly — `--auto-profile=300` (not the 10-frame screenshot default), `--depth-probe` keeps its demo-side `X,Y` comma split (IRArgs has no pair type).

## Behavior notes (intended, stricter validation)
- `--auto-profile` / `--spin-yaw` are `optionalInt`: the optional trailing value reads as an int, so a fractional `--spin-yaw` deg/sec truncates, and a `0`/negative optional value now errors instead of silently defaulting. Representative integer/bare invocations are byte-identical.
- Previously-ignored junk args now `exit(2)` — the point of the framework (matches `fog_demo`'s P1 adoption).

## Test plan
- [x] `fleet-build --target IRPerfGrid` + `IRShapeDebug` clean (before and after `format-changed`).
- [x] `--help` on each: exit 0, lists every flag (14+3 / 18+3), headless/pre-window.
- [x] `shape_debug --bogus` → exit 2 with usage.
- [x] Routing: `perf_grid --mode sdf --grid-size 128 --auto-profile 6` logs `mode=sdf grid_size=128` then exits after 6 frames; `shape_debug --yaw-sweep --zoom 4 --auto-screenshot 6` builds the 24-shot sweep at zoom=4 and captures.
- [x] `grep -n strcmp creations/demos/{perf_grid,shape_debug}/main.cpp` → empty.
- No render-path / `initSystems` change → equivalent invocations render byte-identical (screenshots skipped: mechanical CLI change).

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2069 (P1, engine owns the IRArgs parse). Base is its branch; the merger re-targets to master once #2069 lands.

Closes #2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)