### PR TITLE
creations: migrate auto-screenshot-only + no-arg demos to IRArgs (P2)

### DIFF
--- a/.fleet/plans/issue-2059.md
+++ b/.fleet/plans/issue-2059.md
@@ -1,0 +1,42 @@
+# Plan: #2059 — migrate auto-screenshot-only + no-arg demos to IRArgs (P2)
+
+- **Issue:** #2059
+- **Model:** sonnet
+- **Date:** 2026-06-26
+- **Epic:** #2057 — see `.fleet/plans/issue-2057.md`
+- **Blocked by:** #2058
+
+## Verified current state
+Each listed demo's `main()` calls
+`IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames)` then
+`IREngine::init(argv[0])`, and later gates a `createAutoScreenshotSystem`
+block on `g_autoWarmupFrames > 0` (canonical example:
+`creations/demos/day_cycle/main.cpp`). No other flags. Assumes P1 (#2058)
+landed `IREngine::init(argc,argv)` + `IREngine::args()`.
+
+## Affected files
+The 21 auto-screenshot-only `main*.cpp` + 3 no-arg `main*.cpp` listed in the
+issue body (one mechanical edit each). No shared headers.
+
+## Approach
+Per file: `init(argv[0])` → `init(argc, argv)`; delete the
+`parseAutoScreenshotArgv` line; assign warmup frames from
+`IREngine::args().autoScreenshotWarmupFrames()` after init (keep the local
+or global variable, assigned once). Keep every `createAutoScreenshotSystem`
+block intact.
+
+### Variable name variations
+Most demos use `g_autoWarmupFrames`; a few use `autoWarmupFrames` (local);
+some use namespace-qualified forms (`IRDockspaceDemo::g_autoWarmupFrames`,
+`IRWidgetsDemo::g_autoWarmupFrames`, `IRLuaWidgets::g_autoWarmupFrames`).
+Five demos use `init(argv[0], "config.lua")` → `init(argc, argv, "config.lua")`.
+
+## Sibling reconciliation
+Touches ONLY the 24 files listed — perf_grid/shape_debug (P3), lighting (P4),
+game/MIDI/editors (P5) are explicitly out of scope so the diffs don't overlap.
+Leaves `parseAutoScreenshotArgv` defined (P6 deletes it once all callers gone).
+
+## Verification
+- All 24 targets build clean.
+- `day_cycle --auto-screenshot 12` and `sprite_demo --auto-screenshot 12`
+  capture; `day_cycle --help` exits 0.

--- a/creations/demos/analytic_oracle/main.cpp
+++ b/creations/demos/analytic_oracle/main.cpp
@@ -109,10 +109,9 @@ void initSystems();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-
     IR_LOG_INFO("Starting creation: analytic_oracle");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initEntities();
     // SHADOW debug overlay (black = lit, magenta = shadowed). This demo exists

--- a/creations/demos/audio_playback/main.cpp
+++ b/creations/demos/audio_playback/main.cpp
@@ -62,15 +62,12 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: audio_playback");
 
     int autoWarmupFrames = 0;
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &autoWarmupFrames);
-
     // Wire the Lua-driven ECS surface, which now also exposes the IRAudio
     // file-playback table consumed by audio_demo.lua.
-    IREngine::registerLuaBindings([](IRScript::LuaScript &script) {
-        script.bindLuaDrivenEcs();
-    });
+    IREngine::registerLuaBindings([](IRScript::LuaScript &script) { script.bindLuaDrivenEcs(); });
 
-    IREngine::init(argv[0], "config.lua");
+    IREngine::init(argc, argv, "config.lua");
+    autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initEntities();
     IREngine::runScript("audio_demo.lua");

--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -802,7 +802,6 @@ void readConfig() {
 }
 
 void parseArgs(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--yaw") == 0 && i + 1 < argc) {
             g_settings.cameraYaw_ = static_cast<float>(std::atof(argv[i + 1]));
@@ -894,7 +893,8 @@ void initEntities();
 int main(int argc, char **argv) {
     parseArgs(argc, argv);
     IR_LOG_INFO("Starting creation: canvas_stress");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     readConfig();
     if (g_settings.autoProfile_) {
         IREngine::enableFrameTiming(true);

--- a/creations/demos/chunk_streaming_smoke/main.cpp
+++ b/creations/demos/chunk_streaming_smoke/main.cpp
@@ -73,10 +73,9 @@ void initEntities();
 void runChunkSmokeTest();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-
     IR_LOG_INFO("Starting creation: chunk_streaming_smoke");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     // Run smoke test before initEntities so the 32768-voxel allocation is
@@ -215,7 +214,8 @@ void runChunkSmokeTest() {
             }
             if (ok) {
                 IR_LOG_INFO(
-                    "[chunk_smoke] PASS: color round-trip verified for {} voxels", kVolumeSize
+                    "[chunk_smoke] PASS: color round-trip verified for {} voxels",
+                    kVolumeSize
                 );
             }
         }
@@ -224,7 +224,10 @@ void runChunkSmokeTest() {
 
     // --- Test 2: clean (non-dirty) chunk must not produce a file ---
     auto cleanKey = IRPrefab::Chunk::pack(IRMath::ivec3{99, 99, 99});
-    IR_ASSERT(!persistence.chunkExists(cleanKey), "Pre-condition: clean chunk coord should have no file");
+    IR_ASSERT(
+        !persistence.chunkExists(cleanKey),
+        "Pre-condition: clean chunk coord should have no file"
+    );
     mgr.requestResident(cleanKey, IRWorld::RequestPriority::FORCED);
     // Intentionally omit markChunkDirty — eviction must skip the save.
     mgr.requestEvict(cleanKey);

--- a/creations/demos/collision_overlap_demo/main_lua.cpp
+++ b/creations/demos/collision_overlap_demo/main_lua.cpp
@@ -94,10 +94,9 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: collision_overlap_demo");
 
     int autoWarmupFrames = 0;
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &autoWarmupFrames);
-
     registerLuaBindings();
-    IREngine::init(argv[0], "config.lua");
+    IREngine::init(argc, argv, "config.lua");
+    autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     IREngine::runScript("main.lua");
 
     if (autoWarmupFrames > 0) {

--- a/creations/demos/day_cycle/main.cpp
+++ b/creations/demos/day_cycle/main.cpp
@@ -142,10 +142,9 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-
     IR_LOG_INFO("Starting creation: day_cycle");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     initEntities();
@@ -169,7 +168,8 @@ void initSystems() {
     );
 
     IRSystem::registerPipeline(
-        IRTime::Events::INPUT, {IRSystem::createSystem<IRSystem::INPUT_KEY_MOUSE>()}
+        IRTime::Events::INPUT,
+        {IRSystem::createSystem<IRSystem::INPUT_KEY_MOUSE>()}
     );
 
     std::list<IRSystem::SystemId> renderPipeline = IRPrefab::Camera::standardControlSystems();
@@ -193,7 +193,9 @@ void initSystems() {
     // Per-frame hook (once-per-frame beginTick form, cf. the lighting demos'
     // animated sun): runs first so the lighting passes pick up the new sun.
     IRSystem::SystemId sunTickId = IRSystem::createSystem<C_Name>(
-        "DayCycleSunTick", [](C_Name &) {}, []() { driveSunFromDayCycle(); }
+        "DayCycleSunTick",
+        [](C_Name &) {},
+        []() { driveSunFromDayCycle(); }
     );
     renderPipeline.push_front(sunTickId);
 

--- a/creations/demos/default/main.cpp
+++ b/creations/demos/default/main.cpp
@@ -37,7 +37,7 @@ void initCommands();
 int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: default");
 
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/default/main_lua.cpp
+++ b/creations/demos/default/main_lua.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: default");
 
     IRDefaultCreation::registerLuaBindings();
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
     initSystems();
     IREngine::runScript("commands.lua");
     IREngine::gameLoop();

--- a/creations/demos/gpu_particles/main.cpp
+++ b/creations/demos/gpu_particles/main.cpp
@@ -46,7 +46,6 @@ int g_autoWarmupFrames = 0;
 int g_spawnsPerFrame = 0; // T-159 continuous-emitter verification knob
 
 void parseArgs(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--spawns-per-frame") == 0 && i + 1 < argc) {
             const int n = std::atoi(argv[i + 1]);
@@ -107,7 +106,8 @@ int main(int argc, char **argv) {
     parseArgs(argc, argv);
 
     IR_LOG_INFO("Starting creation: gpu_particles");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
 
     initSystems();
     initCommands();

--- a/creations/demos/ir_voxel_yaw/main.cpp
+++ b/creations/demos/ir_voxel_yaw/main.cpp
@@ -154,7 +154,6 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--spin-yaw") == 0) {
             g_spinYawDegPerSec = 30.0f;
@@ -195,7 +194,8 @@ int main(int argc, char **argv) {
     }
 
     IR_LOG_INFO("Starting creation: ir_voxel_yaw");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/lowres_pan/main.cpp
+++ b/creations/demos/lowres_pan/main.cpp
@@ -56,10 +56,9 @@ void initEntities();
 void initSystems();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-
     IR_LOG_INFO("Starting creation: lowres_pan");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initEntities();
     IRPrefab::Camera::registerStandardKeyboardCommands();

--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -132,7 +132,6 @@ void applyCliOverrides() {
 }
 
 void parseArgs(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--auto-profile") == 0) {
             g_autoProfileFrames = 300;
@@ -336,9 +335,11 @@ IRSystem::SystemId resolveLuaWaveTickId(IRScript::LuaScript &script) {
     } else {
         const sol::object obj = script.lua()["LuaWaveTickSysId"];
         if (!obj.valid() || !obj.is<lua_Integer>()) {
-            IR_LOG_ERROR("lua_perf_grid: LuaWaveTickSysId missing after main.lua "
-                         "(EVAL build expects IRSystem.registerSystem to return a "
-                         "non-zero SystemId and main.lua to assign it to the global).");
+            IR_LOG_ERROR(
+                "lua_perf_grid: LuaWaveTickSysId missing after main.lua "
+                "(EVAL build expects IRSystem.registerSystem to return a "
+                "non-zero SystemId and main.lua to assign it to the global)."
+            );
             return IRSystem::SystemId{0};
         }
         return static_cast<IRSystem::SystemId>(obj.as<lua_Integer>());
@@ -399,9 +400,7 @@ void registerLuaBindings() {
         const IRSystem::SystemId luaWaveOffsetId =
             IRSystem::createSystem<C_LuaWaveState, C_Modifiers>(
                 "LuaWaveStateToOffset",
-                [](IREntity::EntityId entity,
-                   C_LuaWaveState &wave,
-                   C_Modifiers &mods) {
+                [](IREntity::EntityId entity, C_LuaWaveState &wave, C_Modifiers &mods) {
                     IRPrefab::Modifier::upsertBySourceInPlace(
                         mods,
                         IRPrefab::TransformModifier::translationField(),
@@ -498,7 +497,8 @@ int main(int argc, char **argv) {
                                                                                  : "EVAL"
     );
     registerLuaBindings();
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     if (g_autoProfileFrames > 0) {
         IREngine::enableFrameTiming(true);
     }

--- a/creations/demos/lua_pipeline_demo/main_lua.cpp
+++ b/creations/demos/lua_pipeline_demo/main_lua.cpp
@@ -89,10 +89,9 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: lua_pipeline_demo");
 
     int autoWarmupFrames = 0;
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &autoWarmupFrames);
-
     registerLuaBindings();
-    IREngine::init(argv[0], "config.lua");
+    IREngine::init(argc, argv, "config.lua");
+    autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     IREngine::runScript("main.lua");
 
     if (autoWarmupFrames > 0) {

--- a/creations/demos/lua_widgets/main_lua.cpp
+++ b/creations/demos/lua_widgets/main_lua.cpp
@@ -183,10 +183,9 @@ void initSystems();
 
 int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: lua_widgets");
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &IRLuaWidgets::g_autoWarmupFrames);
-
     registerLuaBindings();
-    IREngine::init(argv[0], "config.lua");
+    IREngine::init(argc, argv, "config.lua");
+    IRLuaWidgets::g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     IREngine::runScript("main.lua"); // builds widgets + registers onClick / poll system
     IREngine::gameLoop();

--- a/creations/demos/metal_clear_test/main.cpp
+++ b/creations/demos/metal_clear_test/main.cpp
@@ -9,9 +9,9 @@
 namespace {
 
 constexpr IRVideo::AutoScreenshotShot kShots[] = {
-    {1.0f, vec2(0, 0),  0.0f, "metal_clear_zoom1"},
-    {2.0f, vec2(0, 0),  0.0f, "metal_clear_zoom2"},
-    {4.0f, vec2(4, 4),  0.0f, "metal_clear_zoom4_offset"},
+    {1.0f, vec2(0, 0), 0.0f, "metal_clear_zoom1"},
+    {2.0f, vec2(0, 0), 0.0f, "metal_clear_zoom2"},
+    {4.0f, vec2(4, 4), 0.0f, "metal_clear_zoom4_offset"},
 };
 
 } // namespace
@@ -20,9 +20,8 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: metal_clear_test");
 
     int autoWarmupFrames = 0;
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &autoWarmupFrames);
-
-    IREngine::init(argv[0], "config.lua");
+    IREngine::init(argc, argv, "config.lua");
+    autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
 
     IRSystem::registerPipeline(
         IRTime::Events::INPUT,

--- a/creations/demos/modifier_demo/main.cpp
+++ b/creations/demos/modifier_demo/main.cpp
@@ -131,9 +131,9 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
     IR_LOG_INFO("Starting creation: modifier_demo");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/scene_reset/main.cpp
+++ b/creations/demos/scene_reset/main.cpp
@@ -109,10 +109,9 @@ void captureBaselines();
 void runResetCycles();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-
     IR_LOG_INFO("Starting creation: scene_reset");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
 
     setupSystemsOnce();
     initCommands();

--- a/creations/demos/skeletal_demo/main.cpp
+++ b/creations/demos/skeletal_demo/main.cpp
@@ -78,9 +78,9 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
     IR_LOG_INFO("Starting creation: skeletal_demo");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     initEntities();
@@ -157,16 +157,18 @@ void initCommands() {
 // Rig round-trip verification. Builds an IRAsset::Rig from the C_Skeleton,
 // writes it to memory, reads it back, and checks joint count.
 // ---------------------------------------------------------------------------
-static void verifyRigRoundTrip(
-    const C_Skeleton &skeleton, const std::string &label, int expectedJoints
-) {
+static void
+verifyRigRoundTrip(const C_Skeleton &skeleton, const std::string &label, int expectedJoints) {
     IRAsset::Rig rig;
     rig.joints_.reserve(skeleton.joints_.size());
     for (std::size_t i = 0; i < skeleton.joints_.size(); ++i) {
         IRAsset::RigJoint j;
         j.translation_ = vec4(skeleton.bindPose_[i].translation_, 0.0f);
         j.rotation_ = skeleton.bindPose_[i].rotation_;
-        j.parentIndex_ = (i == 0) ? 0u : static_cast<std::uint32_t>(i - 1); // linear chain; hierarchy not round-tripped
+        j.parentIndex_ =
+            (i == 0)
+                ? 0u
+                : static_cast<std::uint32_t>(i - 1); // linear chain; hierarchy not round-tripped
         rig.joints_.push_back(j);
     }
     IRAsset::MemoryBinaryWriter w;
@@ -184,7 +186,12 @@ static void verifyRigRoundTrip(
     }
     const int got = static_cast<int>(loaded.value_.joints_.size());
     if (got != expectedJoints) {
-        IR_LOG_ERROR("{}: round-trip joint count mismatch: expected={} got={}", label, expectedJoints, got);
+        IR_LOG_ERROR(
+            "{}: round-trip joint count mismatch: expected={} got={}",
+            label,
+            expectedJoints,
+            got
+        );
     } else {
         IR_LOG_INFO("{}: rig round-trip OK ({} joints)", label, got);
     }
@@ -196,14 +203,12 @@ static void verifyRigRoundTrip(
 // ---------------------------------------------------------------------------
 static void createSnake(vec3 worldPos) {
     constexpr int kNumJoints = 30;
-    constexpr int kSegLen = 3; // voxels per segment along Z
+    constexpr int kSegLen = 3;                    // voxels per segment along Z
     const ivec3 size{3, 3, kNumJoints * kSegLen}; // 3x3x90
     const Color baseColor{60, 200, 90, 255};
 
-    IREntity::EntityId rigRoot = IREntity::createEntity(
-        C_LocalTransform{worldPos},
-        C_VoxelSetNew{size, baseColor, false}
-    );
+    IREntity::EntityId rigRoot =
+        IREntity::createEntity(C_LocalTransform{worldPos}, C_VoxelSetNew{size, baseColor, false});
     auto &vs = IREntity::getComponent<C_VoxelSetNew>(rigRoot);
 
     for (int i = 0; i < vs.numVoxels_; ++i) {
@@ -224,9 +229,8 @@ static void createSnake(vec3 worldPos) {
 
     IREntity::EntityId prevJoint = IREntity::kNullEntity;
     for (int i = 0; i < kNumJoints; ++i) {
-        const vec3 localPos = (i == 0)
-            ? vec3(1.0f, 1.0f, 0.0f)
-            : vec3(0.0f, 0.0f, static_cast<float>(kSegLen));
+        const vec3 localPos =
+            (i == 0) ? vec3(1.0f, 1.0f, 0.0f) : vec3(0.0f, 0.0f, static_cast<float>(kSegLen));
         const vec4 rot = (i == kNumJoints / 2) ? kBendPose : kIdentity;
 
         IREntity::EntityId joint =
@@ -237,11 +241,9 @@ static void createSnake(vec3 worldPos) {
             IREntity::setParent(joint, prevJoint);
         }
         skeleton.joints_.push_back(joint);
-        skeleton.bindPose_.push_back(IRMath::SQT{
-            vec3(1.0f),
-            kIdentity,
-            vec3(1.0f, 1.0f, static_cast<float>(i * kSegLen))
-        });
+        skeleton.bindPose_.push_back(
+            IRMath::SQT{vec3(1.0f), kIdentity, vec3(1.0f, 1.0f, static_cast<float>(i * kSegLen))}
+        );
         prevJoint = joint;
     }
     const int snakeVoxels = vs.numVoxels_;
@@ -269,9 +271,9 @@ static void createDesk(vec3 worldPos) {
     const vec4 legParams{kR, kR, kH, 0.0f};
     const vec3 legOffsets[4] = {
         {-6.0f, kH * 0.5f + 0.5f, -3.0f},
-        { 6.0f, kH * 0.5f + 0.5f, -3.0f},
-        {-6.0f, kH * 0.5f + 0.5f,  3.0f},
-        { 6.0f, kH * 0.5f + 0.5f,  3.0f},
+        {6.0f, kH * 0.5f + 0.5f, -3.0f},
+        {-6.0f, kH * 0.5f + 0.5f, 3.0f},
+        {6.0f, kH * 0.5f + 0.5f, 3.0f},
     };
     for (const auto &off : legOffsets) {
         IREntity::createEntity(
@@ -288,14 +290,12 @@ static void createDesk(vec3 worldPos) {
 // ---------------------------------------------------------------------------
 static void createLamp(vec3 worldPos) {
     constexpr int kNumJoints = 4;
-    constexpr int kSegLen = 5; // voxels per segment along Y
+    constexpr int kSegLen = 5;                    // voxels per segment along Y
     const ivec3 size{2, kNumJoints * kSegLen, 2}; // 2x20x2
     const Color baseColor{220, 185, 50, 255};
 
-    IREntity::EntityId rigRoot = IREntity::createEntity(
-        C_LocalTransform{worldPos},
-        C_VoxelSetNew{size, baseColor, false}
-    );
+    IREntity::EntityId rigRoot =
+        IREntity::createEntity(C_LocalTransform{worldPos}, C_VoxelSetNew{size, baseColor, false});
     auto &vs = IREntity::getComponent<C_VoxelSetNew>(rigRoot);
 
     for (int i = 0; i < vs.numVoxels_; ++i) {
@@ -304,7 +304,12 @@ static void createLamp(vec3 worldPos) {
         // Lighten toward the top to simulate a warm glow gradient.
         const float t = static_cast<float>(seg) / static_cast<float>(kNumJoints - 1);
         const auto r = static_cast<std::uint8_t>(220u + static_cast<std::uint8_t>(35u * t));
-        vs.voxels_[i].color_ = Color{r, static_cast<std::uint8_t>(185u - static_cast<std::uint8_t>(40u * t)), 50u, 255u};
+        vs.voxels_[i].color_ = Color{
+            r,
+            static_cast<std::uint8_t>(185u - static_cast<std::uint8_t>(40u * t)),
+            50u,
+            255u
+        };
     }
 
     constexpr vec4 kIdentity{0.0f, 0.0f, 0.0f, 1.0f};
@@ -316,9 +321,8 @@ static void createLamp(vec3 worldPos) {
 
     IREntity::EntityId prevJoint = IREntity::kNullEntity;
     for (int i = 0; i < kNumJoints; ++i) {
-        const vec3 localPos = (i == 0)
-            ? vec3(0.5f, 0.0f, 0.5f)
-            : vec3(0.0f, static_cast<float>(kSegLen), 0.0f);
+        const vec3 localPos =
+            (i == 0) ? vec3(0.5f, 0.0f, 0.5f) : vec3(0.0f, static_cast<float>(kSegLen), 0.0f);
         const vec4 rot = (i == kNumJoints - 1) ? kHeadPose : kIdentity;
 
         IREntity::EntityId joint =
@@ -329,11 +333,9 @@ static void createLamp(vec3 worldPos) {
             IREntity::setParent(joint, prevJoint);
         }
         skeleton.joints_.push_back(joint);
-        skeleton.bindPose_.push_back(IRMath::SQT{
-            vec3(1.0f),
-            kIdentity,
-            vec3(0.5f, static_cast<float>(i * kSegLen), 0.5f)
-        });
+        skeleton.bindPose_.push_back(
+            IRMath::SQT{vec3(1.0f), kIdentity, vec3(0.5f, static_cast<float>(i * kSegLen), 0.5f)}
+        );
         prevJoint = joint;
     }
     const int lampVoxels = vs.numVoxels_;
@@ -359,10 +361,8 @@ static void createCross(vec3 worldPos) {
     const ivec3 size{10, 3, 10};
     const Color armColor{80, 140, 220, 255};
 
-    IREntity::EntityId rigRoot = IREntity::createEntity(
-        C_LocalTransform{worldPos},
-        C_VoxelSetNew{size, armColor, false}
-    );
+    IREntity::EntityId rigRoot =
+        IREntity::createEntity(C_LocalTransform{worldPos}, C_VoxelSetNew{size, armColor, false});
     auto &vs = IREntity::getComponent<C_VoxelSetNew>(rigRoot);
 
     // Classify each voxel into a body region and assign bone_id.
@@ -370,11 +370,11 @@ static void createCross(vec3 worldPos) {
     for (int i = 0; i < vs.numVoxels_; ++i) {
         const int x = static_cast<int>(vs.positions_[i].pos_.x);
         const int z = static_cast<int>(vs.positions_[i].pos_.z);
-        const bool inCenter  = (x >= 3 && x <= 6 && z >= 3 && z <= 6);
-        const bool inLeft    = (x >= 0 && x <= 2 && z >= 3 && z <= 6);
-        const bool inRight   = (x >= 7 && x <= 9 && z >= 3 && z <= 6);
-        const bool inFront   = (x >= 3 && x <= 6 && z >= 0 && z <= 2);
-        const bool inBack    = (x >= 3 && x <= 6 && z >= 7 && z <= 9);
+        const bool inCenter = (x >= 3 && x <= 6 && z >= 3 && z <= 6);
+        const bool inLeft = (x >= 0 && x <= 2 && z >= 3 && z <= 6);
+        const bool inRight = (x >= 7 && x <= 9 && z >= 3 && z <= 6);
+        const bool inFront = (x >= 3 && x <= 6 && z >= 0 && z <= 2);
+        const bool inBack = (x >= 3 && x <= 6 && z >= 7 && z <= 9);
 
         if (inCenter) {
             vs.voxels_[i].bone_id_ = 0;
@@ -420,15 +420,15 @@ static void createCross(vec3 worldPos) {
         vec3 bindPos_;  // rig-root-local rest position
     };
     const JointDef defs[9] = {
-        { vec3(4.5f, 1.0f, 4.5f), kIdentity,    -1, vec3(4.5f, 1.0f, 4.5f) },
-        { vec3(-2.5f, 0.0f, 0.0f), kIdentity,    0, vec3(2.0f, 1.0f, 4.5f) },
-        { vec3(-2.0f, 0.0f, 0.0f), kWristBendLR, 1, vec3(0.0f, 1.0f, 4.5f) },
-        { vec3(2.5f, 0.0f, 0.0f),  kIdentity,    0, vec3(7.0f, 1.0f, 4.5f) },
-        { vec3(2.0f, 0.0f, 0.0f),  kWristBendLR, 3, vec3(9.0f, 1.0f, 4.5f) },
-        { vec3(0.0f, 0.0f, -2.5f), kIdentity,    0, vec3(4.5f, 1.0f, 2.0f) },
-        { vec3(0.0f, 0.0f, -2.0f), kWristBendFB, 5, vec3(4.5f, 1.0f, 0.0f) },
-        { vec3(0.0f, 0.0f, 2.5f),  kIdentity,    0, vec3(4.5f, 1.0f, 7.0f) },
-        { vec3(0.0f, 0.0f, 2.0f),  kWristBendFB, 7, vec3(4.5f, 1.0f, 9.0f) },
+        {vec3(4.5f, 1.0f, 4.5f), kIdentity, -1, vec3(4.5f, 1.0f, 4.5f)},
+        {vec3(-2.5f, 0.0f, 0.0f), kIdentity, 0, vec3(2.0f, 1.0f, 4.5f)},
+        {vec3(-2.0f, 0.0f, 0.0f), kWristBendLR, 1, vec3(0.0f, 1.0f, 4.5f)},
+        {vec3(2.5f, 0.0f, 0.0f), kIdentity, 0, vec3(7.0f, 1.0f, 4.5f)},
+        {vec3(2.0f, 0.0f, 0.0f), kWristBendLR, 3, vec3(9.0f, 1.0f, 4.5f)},
+        {vec3(0.0f, 0.0f, -2.5f), kIdentity, 0, vec3(4.5f, 1.0f, 2.0f)},
+        {vec3(0.0f, 0.0f, -2.0f), kWristBendFB, 5, vec3(4.5f, 1.0f, 0.0f)},
+        {vec3(0.0f, 0.0f, 2.5f), kIdentity, 0, vec3(4.5f, 1.0f, 7.0f)},
+        {vec3(0.0f, 0.0f, 2.0f), kWristBendFB, 7, vec3(4.5f, 1.0f, 9.0f)},
     };
 
     C_Skeleton skeleton;
@@ -437,18 +437,15 @@ static void createCross(vec3 worldPos) {
     IREntity::EntityId jointIds[9] = {};
 
     for (int i = 0; i < 9; ++i) {
-        jointIds[i] = IREntity::createEntity(
-            C_Joint{}, C_LocalTransform{defs[i].localPos_, defs[i].rot_}
-        );
+        jointIds[i] =
+            IREntity::createEntity(C_Joint{}, C_LocalTransform{defs[i].localPos_, defs[i].rot_});
         if (defs[i].parentIdx_ < 0) {
             IREntity::setParent(jointIds[i], rigRoot);
         } else {
             IREntity::setParent(jointIds[i], jointIds[defs[i].parentIdx_]);
         }
         skeleton.joints_.push_back(jointIds[i]);
-        skeleton.bindPose_.push_back(
-            IRMath::SQT{vec3(1.0f), kIdentity, defs[i].bindPos_}
-        );
+        skeleton.bindPose_.push_back(IRMath::SQT{vec3(1.0f), kIdentity, defs[i].bindPos_});
     }
     const int crossVoxels = vs.numVoxels_;
     IREntity::setComponent(rigRoot, skeleton);

--- a/creations/demos/sprite_demo/main.cpp
+++ b/creations/demos/sprite_demo/main.cpp
@@ -39,11 +39,10 @@ void initSystems();
 void initCommands();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-
     IR_LOG_INFO("Starting creation: sprite_demo");
     IRSpriteDemoCreation::registerLuaBindings();
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     IREngine::runScript("main.lua");

--- a/creations/demos/stateless_particles/main.cpp
+++ b/creations/demos/stateless_particles/main.cpp
@@ -59,9 +59,7 @@ constexpr IRVideo::AutoScreenshotShot kShots[] = {
 
 int g_autoWarmupFrames = 0;
 
-void parseArgs(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
-}
+void parseArgs(int argc, char **argv) {}
 
 void configureCanvas() {
     const IREntity::EntityId mainCanvas = IRRender::getActiveCanvasEntity();
@@ -128,7 +126,8 @@ int main(int argc, char **argv) {
     parseArgs(argc, argv);
 
     IR_LOG_INFO("Starting creation: stateless_particles");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
 
     initSystems();
     initCommands();

--- a/creations/demos/stateless_particles/main.cpp
+++ b/creations/demos/stateless_particles/main.cpp
@@ -59,8 +59,6 @@ constexpr IRVideo::AutoScreenshotShot kShots[] = {
 
 int g_autoWarmupFrames = 0;
 
-void parseArgs(int argc, char **argv) {}
-
 void configureCanvas() {
     const IREntity::EntityId mainCanvas = IRRender::getActiveCanvasEntity();
     const ivec2 canvasSize = IREntity::getComponent<C_TriangleCanvasTextures>(mainCanvas).size_;
@@ -123,8 +121,6 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    parseArgs(argc, argv);
-
     IR_LOG_INFO("Starting creation: stateless_particles");
     IREngine::init(argc, argv);
     g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();

--- a/creations/demos/ui_dockspace/main.cpp
+++ b/creations/demos/ui_dockspace/main.cpp
@@ -68,9 +68,9 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &IRDockspaceDemo::g_autoWarmupFrames);
     IR_LOG_INFO("Starting creation: ui_dockspace");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    IRDockspaceDemo::g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/ui_widgets/main.cpp
+++ b/creations/demos/ui_widgets/main.cpp
@@ -101,9 +101,9 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &IRWidgetsDemo::g_autoWarmupFrames);
     IR_LOG_INFO("Starting creation: ui_widgets");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    IRWidgetsDemo::g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/z_yaw_rotation/main_mouse.cpp
+++ b/creations/demos/z_yaw_rotation/main_mouse.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: z_yaw_rotation/interactive");
     IR_LOG_INFO("  R — toggle mouse-driven yaw rotation");
     IR_LOG_INFO("  Left click on entity — sun-flash effect (proves per-voxel pick)");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/z_yaw_rotation/main_static.cpp
+++ b/creations/demos/z_yaw_rotation/main_static.cpp
@@ -50,9 +50,9 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &g_autoWarmupFrames);
     IR_LOG_INFO("Starting creation: z_yaw_rotation/static");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
+    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     initEntities();


### PR DESCRIPTION
## Summary
- Migrates 21 auto-screenshot-only demos + 3 no-arg demos from the old `IRVideo::parseAutoScreenshotArgv + IREngine::init(argv[0])` pattern to the unified `IREngine::init(argc, argv)` + `IREngine::args().autoScreenshotWarmupFrames()` API landed by P1 (#2058, PR #2069)
- Handles both `init(argv[0])` and `init(argv[0], "config.lua")` variants, and all variable name forms (`g_autoWarmupFrames`, `autoWarmupFrames`, namespace-qualified)
- P3 (perf_grid/shape_debug, PR #2072), P4 (lighting), and P5 (game/editors) intentionally not touched

## Test plan
- [x] All 24 targets build clean (macOS/Metal)
- [x] `day_cycle --auto-screenshot 12` and `sprite_demo --auto-screenshot 12` capture screenshots (exit 0)
- [x] `day_cycle --help` exits 0 with correct arg listing
- [x] No-arg demos (`default`, `z_yaw_rotation --mouse`) start + run normally

Closes #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)