### PR TITLE
creations: migrate editors to IREngine::init(argc, argv) (P5)

### DIFF
--- a/creations/editors/font_maker/main.cpp
+++ b/creations/editors/font_maker/main.cpp
@@ -41,7 +41,7 @@ void initEntities();
 void initCommands();
 
 int main(int argc, char **argv) {
-    IR_LOG_INFO("Starting creation: YOUR_CREATION_NAME_HERE");
+    IR_LOG_INFO("Starting creation: font_maker");
 
     IREngine::init(argc, argv, IREngine::kTestLuaConfig);
     initSystems();

--- a/creations/editors/font_maker/main.cpp
+++ b/creations/editors/font_maker/main.cpp
@@ -43,7 +43,7 @@ void initCommands();
 int main(int argc, char **argv) {
     IR_LOG_INFO("Starting creation: YOUR_CREATION_NAME_HERE");
 
-    IREngine::init(argv[0], IREngine::kTestLuaConfig);
+    IREngine::init(argc, argv, IREngine::kTestLuaConfig);
     initSystems();
     initCommands();
     initEntities();

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -364,8 +364,6 @@ void onGuiAssertFrame(int shotIndex, bool isCaptureFrame) {
     );
 }
 
-int g_autoWarmupFrames = 0;
-
 // Named-layer state for new placements. Commands below let the user create,
 // select, rename, and hide layers. Set g_sceneVoxelSetEntity after
 // allocating the scene's C_VoxelSetNew so visibility toggles can iterate
@@ -1099,7 +1097,6 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    IRVideo::parseAutoScreenshotArgv(argc, argv, &IRVoxelEditor::g_autoWarmupFrames);
     IR_LOG_INFO("Starting creation: voxel_editor");
     IR_LOG_INFO("  Left-drag: AABB box-fill between drag-start and drag-end");
     IR_LOG_INFO("  Shift + left-drag: line-fill along dominant axis");
@@ -1121,7 +1118,7 @@ int main(int argc, char **argv) {
     IR_LOG_INFO("  N: toggle bone-paint mode (click swatch in BONE panel to pick bone)");
     IR_LOG_INFO("  Joint arrows place (re-binds at release); rings FK-pose (live deform)");
     IR_LOG_INFO("  T: set current pose as bind (joint mode)");
-    IREngine::init(argv[0]);
+    IREngine::init(argc, argv);
     initSystems();
     initCommands();
     initEntities();
@@ -2089,9 +2086,9 @@ void initSystems() {
         }
     );
 
-    if (IRVoxelEditor::g_autoWarmupFrames > 0) {
+    if (IREngine::args().autoScreenshotWarmupFrames() > 0) {
         IRVideo::GuiTestConfig cfg{};
-        cfg.warmupFrames_ = IRVoxelEditor::g_autoWarmupFrames;
+        cfg.warmupFrames_ = IREngine::args().autoScreenshotWarmupFrames();
         cfg.settleFrames_ = 3;
         cfg.shots_ = IRVoxelEditor::kGuiTestShots;
         cfg.numShots_ =


### PR DESCRIPTION
## Summary
- Drop \`IRVideo::parseAutoScreenshotArgv\` and \`g_autoWarmupFrames\` from \`creations/editors/voxel_editor/main.cpp\`; read warmup frames via \`IREngine::args().autoScreenshotWarmupFrames()\` instead
- Switch \`IREngine::init(argv[0])\` → \`IREngine::init(argc, argv)\` in both \`voxel_editor/main.cpp\` and \`font_maker/main.cpp\`; both editors now get \`--help\` and all engine common args for free

_Engine-side (editors) half of #2062. Game-side changes (MIDI macro + game demos) ship in a companion game-repo PR._

## Test plan
- [x] \`IRVoxelEditor\` builds clean (macOS)
- [x] \`EditorFontMaker\` builds clean (macOS)

Closes #2062

🤖 Generated with [Claude Code](https://claude.com/claude-code)