### PR TITLE
fleet: fix fleet-queue-list on native Windows (argv length + cp1252)

### DIFF
--- a/scripts/fleet/fleet-queue-list
+++ b/scripts/fleet/fleet-queue-list
@@ -50,10 +50,24 @@ if [[ "$JSON_MODE" == "1" ]]; then
     exit 0
 fi
 
-python3 - "$raw" << 'PYEOF'
+# Hand the issue JSON to python via a temp file rather than argv. On native
+# Windows (MSYS2) a 200-issue payload with bodies overruns the command-line
+# length limit — `python3 - "$raw"` dies with "Argument list too long". A file
+# is bounded only by disk, so this works regardless of queue size or platform.
+queue_raw_file=$(mktemp "${TMPDIR:-/tmp}/fleet-queue-raw.XXXXXX")
+trap 'rm -f "$queue_raw_file"' EXIT
+printf '%s' "$raw" > "$queue_raw_file"
+
+# PYTHONIOENCODING forces UTF-8 stdout: python3 on native Windows defaults to
+# the cp1252 console codec, which raises UnicodeEncodeError on the table's
+# box-drawing / em-dash glyphs. Harmless on Linux/macOS (already UTF-8).
+PYTHONIOENCODING=utf-8 python3 - "$queue_raw_file" << 'PYEOF'
 import json, re, sys
 
-raw = json.loads(sys.argv[1]) if len(sys.argv) > 1 else []
+raw = []
+if len(sys.argv) > 1:
+    with open(sys.argv[1], encoding="utf-8") as raw_file:
+        raw = json.load(raw_file)
 
 def parse_field(body, field):
     if not body:


### PR DESCRIPTION
## Problem

`fleet-queue-list` is unusable on the native-Windows (MSYS2) fleet host. During the fleet validation it failed with:

```
/c/.../fleet-queue-list: line 53: /c/msys64/mingw64/bin/python3: Argument list too long
```

The full `gh issue list --limit 200` payload (issues **with bodies**) was passed as a command-line argument (`python3 - "$raw"`), which overruns the Windows command-line length limit before the renderer prints anything.

## Fix

- **argv → temp file:** write the JSON to a `mktemp` file and pass the *path* to python. Bounded only by disk, so it works at any queue size on every platform. `trap … EXIT` cleans it up.
- **stdout UTF-8:** `PYTHONIOENCODING=utf-8` — python3 on native Windows defaults to the cp1252 console codec and raised `UnicodeEncodeError` on the table's box-drawing / em-dash glyphs once the renderer ran.
- **input UTF-8:** `open(..., encoding="utf-8")` — `open()` also defaults to cp1252 on Windows, mis-decoding issue-body em-dashes into mojibake (`â€"`).

All three are no-ops on Linux/macOS (already UTF-8); `--json` mode is unaffected (it `echo`s before the python block).

## Verification

On the native-Windows host: full table renders (all 10 queued issues, Available/In-progress/Blocked sections), em-dashes display correctly, and `--json` still emits raw JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)