### PR TITLE
fleet: stop dispatcher churn on a no-work standing trigger (empty-exit backoff)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -375,10 +375,11 @@ fi
 # The fix: treat a dispatch that returns to a shell in under EMPTY_EXIT_SECONDS
 # as "claimed nothing" (a genuine claim runs for minutes — build / test / PR).
 # Count consecutive empty exits per role; once the streak reaches
-# EMPTY_STREAK_CAP, consume the trigger after the tick's probe dispatch instead
-# of retaining it. The scout re-arms on the next real projection change, and a
-# genuine long-running claim resets the streak (cleanup_stale_dispatches). Net:
-# at most one wasted probe per armed trigger instead of an unbounded loop.
+# EMPTY_STREAK_CAP, consume the trigger after the tick's probe dispatches (all
+# idle panes for the role) instead of retaining it. The scout re-arms on the
+# next real projection change, and a genuine long-running claim resets the
+# streak (cleanup_stale_dispatches). Net: at most one wasted probe-fan-out per
+# armed trigger instead of an unbounded loop.
 EMPTY_EXIT_SECONDS="${FLEET_DISPATCHER_EMPTY_EXIT_SECONDS:-60}"
 EMPTY_STREAK_CAP="${FLEET_DISPATCHER_EMPTY_STREAK_CAP:-3}"
 EMPTY_STREAK_DIR="$STATE_DIR/empty-streak"
@@ -391,8 +392,12 @@ if ! [[ "$EMPTY_EXIT_SECONDS" =~ ^[0-9]+$ ]]; then
     EMPTY_EXIT_SECONDS=60
 fi
 if ! [[ "$EMPTY_STREAK_CAP" =~ ^[0-9]+$ ]]; then
-    printf '[%s dispatcher] EMPTY_STREAK_CAP=%q is not a non-negative integer; falling back to 3\n' \
+    printf '[%s dispatcher] EMPTY_STREAK_CAP=%q is not a positive integer; falling back to 3\n' \
         "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$EMPTY_STREAK_CAP" >&2
+    EMPTY_STREAK_CAP=3
+elif (( EMPTY_STREAK_CAP < 1 )); then
+    printf '[%s dispatcher] EMPTY_STREAK_CAP=0 stands down on every dispatch; falling back to 3\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >&2
     EMPTY_STREAK_CAP=3
 fi
 
@@ -1312,10 +1317,11 @@ dispatch_role() {
 
     # Empty-exit backoff. If this role's recent dispatches kept returning to a
     # shell within EMPTY_EXIT_SECONDS (no task claimed) EMPTY_STREAK_CAP times
-    # running, stop re-arming on the standing trigger: this tick's dispatch was
-    # the probe, so consume the trigger now instead of retaining it via any of
-    # the paths below. Prevents a stale or false-actionable trigger from
-    # spinning the pane forever (every ~11s). The scout re-arms on the next
+    # running, stop re-arming on the standing trigger: this tick's dispatches
+    # (all idle panes for the role) were the probe, so consume the trigger now
+    # instead of retaining it via any of the paths below. Prevents a stale or
+    # false-actionable trigger from spinning the pane forever (every ~11s). The
+    # scout re-arms on the next
     # genuine projection change; a real long-running claim resets the streak in
     # cleanup_stale_dispatches. Guarded on dispatched>0 so a tick that sent
     # nothing leaves the existing min-gap/retry semantics untouched.

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -362,6 +362,40 @@ if ! [[ "$BOOT_FANOUT_WINDOW_SECONDS" =~ ^[0-9]+$ ]]; then
     BOOT_FANOUT_WINDOW_SECONDS=60
 fi
 
+# --- Empty-exit backoff ----------------------------------------------------
+#
+# A standing trigger whose role has no claimable work spins the pane: the
+# dispatcher fires a worker, the worker finds nothing to claim and returns to
+# the shell in ~10s, the trigger is retained (gap-blocked fan-out / boot
+# fan-out paths never reach consume-on-success), and the next tick re-fires —
+# every ~11s, indefinitely, each cycle burning a fresh `claude` cold start.
+# Observed on the native-Windows host with a stale boot trigger the scout
+# never re-armed (its projection had gone empty for this host's class).
+#
+# The fix: treat a dispatch that returns to a shell in under EMPTY_EXIT_SECONDS
+# as "claimed nothing" (a genuine claim runs for minutes — build / test / PR).
+# Count consecutive empty exits per role; once the streak reaches
+# EMPTY_STREAK_CAP, consume the trigger after the tick's probe dispatch instead
+# of retaining it. The scout re-arms on the next real projection change, and a
+# genuine long-running claim resets the streak (cleanup_stale_dispatches). Net:
+# at most one wasted probe per armed trigger instead of an unbounded loop.
+EMPTY_EXIT_SECONDS="${FLEET_DISPATCHER_EMPTY_EXIT_SECONDS:-60}"
+EMPTY_STREAK_CAP="${FLEET_DISPATCHER_EMPTY_STREAK_CAP:-3}"
+EMPTY_STREAK_DIR="$STATE_DIR/empty-streak"
+# Validate-and-clamp both overrides the same way BOOT_FANOUT_WINDOW_SECONDS is
+# guarded above — a non-numeric value would emit arithmetic errors every tick
+# or kill the daemon under `set -u`.
+if ! [[ "$EMPTY_EXIT_SECONDS" =~ ^[0-9]+$ ]]; then
+    printf '[%s dispatcher] EMPTY_EXIT_SECONDS=%q is not a non-negative integer; falling back to 60\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$EMPTY_EXIT_SECONDS" >&2
+    EMPTY_EXIT_SECONDS=60
+fi
+if ! [[ "$EMPTY_STREAK_CAP" =~ ^[0-9]+$ ]]; then
+    printf '[%s dispatcher] EMPTY_STREAK_CAP=%q is not a non-negative integer; falling back to 3\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$EMPTY_STREAK_CAP" >&2
+    EMPTY_STREAK_CAP=3
+fi
+
 # Roles this dispatcher is responsible for. Architects are excluded
 # (kept on fleet-babysit). Aligned with the worker / reviewer /
 # queue-mgr / merger roles in fleet-up.
@@ -621,11 +655,12 @@ write_dispatch_record() {
     # $3 = model class of the dispatch (fable|opus|sonnet) — counted by
     # count_active_for_class for the fable concurrency cap.
     local role="$1" pane_id="$2" class="${3:-}"
-    local ts
+    local ts epoch
     ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    epoch=$(date +%s)   # read back by cleanup_stale_dispatches for the empty-exit streak
     mkdir -p "$DISPATCH_DIR"
-    printf '{"role":"%s","pane":"%s","class":"%s","dispatched_at":"%s"}\n' \
-        "$role" "$pane_id" "$class" "$ts" >"$(dispatch_record "$pane_id")"
+    printf '{"role":"%s","pane":"%s","class":"%s","dispatched_at":"%s","dispatched_epoch":%s}\n' \
+        "$role" "$pane_id" "$class" "$ts" "$epoch" >"$(dispatch_record "$pane_id")"
 }
 
 # Map a concrete model string back to its class name, for stamping
@@ -655,11 +690,54 @@ count_active_for_class() {
     echo "$count"
 }
 
+# --- Empty-exit streak bookkeeping -----------------------------------------
+# Per-role counter of consecutive dispatches that returned to a shell without
+# claiming work (see the EMPTY_EXIT_SECONDS config block). One small file per
+# role under $EMPTY_STREAK_DIR holding a non-negative integer.
+
+empty_streak_file() {
+    printf '%s\n' "$EMPTY_STREAK_DIR/$1"
+}
+
+read_empty_streak() {
+    local f n
+    f=$(empty_streak_file "$1")
+    n=$(cat "$f" 2>/dev/null || printf '0')
+    [[ "$n" =~ ^[0-9]+$ ]] || n=0
+    printf '%s\n' "$n"
+}
+
+# 0 (true) when the role's streak has reached the cap — caller should consume
+# the trigger rather than retain it.
+empty_streak_over_cap() {
+    local n
+    n=$(read_empty_streak "$1")
+    (( n >= EMPTY_STREAK_CAP ))
+}
+
+reset_empty_streak() {
+    rm -f "$(empty_streak_file "$1")"
+}
+
+# Fold one completed dispatch's wall-clock duration into the role's streak: a
+# fast exit (no claim) bumps it, a long-running one (real work) resets it.
+# Shared by cleanup_stale_dispatches and the --record-outcome test hook.
+record_dispatch_outcome() {
+    local role="$1" duration="$2"
+    [[ "$duration" =~ ^[0-9]+$ ]] || return 0
+    if (( duration < EMPTY_EXIT_SECONDS )); then
+        mkdir -p "$EMPTY_STREAK_DIR"
+        printf '%s\n' "$(( $(read_empty_streak "$role") + 1 ))" > "$(empty_streak_file "$role")"
+    else
+        reset_empty_streak "$role"
+    fi
+}
+
 cleanup_stale_dispatches() {
     if [[ ! -d "$DISPATCH_DIR" ]]; then
         return
     fi
-    local file role pane
+    local file role pane dispatched_epoch
     for file in "$DISPATCH_DIR"/*.json; do
         [[ -e "$file" ]] || continue
         role=$(sed -n 's/.*"role":"\([^"]*\)".*/\1/p' "$file" | head -n 1)
@@ -670,6 +748,12 @@ cleanup_stale_dispatches() {
         fi
         if pane_is_occupied "$pane"; then
             continue
+        fi
+        # Fold the just-finished dispatch into the role's empty-exit streak.
+        # Legacy records (pre-upgrade, no dispatched_epoch) skip this silently.
+        dispatched_epoch=$(sed -n 's/.*"dispatched_epoch":\([0-9]*\).*/\1/p' "$file" | head -n 1)
+        if [[ -n "$dispatched_epoch" ]]; then
+            record_dispatch_outcome "$role" "$(( $(date +%s) - dispatched_epoch ))"
         fi
         log "dispatch for $role on $pane completed (pane returned to shell)"
         rm -f "$file"
@@ -1226,6 +1310,22 @@ dispatch_role() {
         dispatched=$((dispatched + 1))
     done <<< "$idle_panes"
 
+    # Empty-exit backoff. If this role's recent dispatches kept returning to a
+    # shell within EMPTY_EXIT_SECONDS (no task claimed) EMPTY_STREAK_CAP times
+    # running, stop re-arming on the standing trigger: this tick's dispatch was
+    # the probe, so consume the trigger now instead of retaining it via any of
+    # the paths below. Prevents a stale or false-actionable trigger from
+    # spinning the pane forever (every ~11s). The scout re-arms on the next
+    # genuine projection change; a real long-running claim resets the streak in
+    # cleanup_stale_dispatches. Guarded on dispatched>0 so a tick that sent
+    # nothing leaves the existing min-gap/retry semantics untouched.
+    if (( dispatched > 0 )) && empty_streak_over_cap "$role"; then
+        rm -f "$trigger_file"
+        reset_empty_streak "$role"
+        log "$role: ${EMPTY_STREAK_CAP} consecutive fast exits (<${EMPTY_EXIT_SECONDS}s, no claim) — standing down; scout re-arms on new work"
+        return
+    fi
+
     # If the global min-gap stopped us mid-fan-out (gap_blocked set on break),
     # keep the trigger so the remaining idle panes launch on later ticks — one
     # per gap — regardless of how many fired this tick or the boot-window
@@ -1634,6 +1734,38 @@ case "${1:-}" in
             echo "wait"
         else
             echo "ok"
+        fi
+        exit 0
+        ;;
+    --record-outcome)
+        # Test/debug: fold one dispatch outcome into a role's empty-exit
+        # streak. <duration> is the dispatch's wall-clock seconds; under
+        # EMPTY_EXIT_SECONDS bumps the streak, at/over it resets. Honors
+        # FLEET_DISPATCHER_EMPTY_EXIT_SECONDS / _EMPTY_STREAK_CAP and writes
+        # under FLEET_STATE_DIR, so tests drive it against a scratch dir.
+        if [[ -z "${2:-}" || -z "${3:-}" ]]; then
+            echo "usage: fleet-dispatcher --record-outcome <role> <duration-seconds>" >&2
+            exit 2
+        fi
+        if ! [[ "$3" =~ ^[0-9]+$ ]]; then
+            echo "fleet-dispatcher --record-outcome: <duration-seconds> must be a non-negative integer (got: $3)" >&2
+            exit 2
+        fi
+        record_dispatch_outcome "$2" "$3"
+        exit 0
+        ;;
+    --empty-streak-check)
+        # Test/debug: print `over` (streak >= cap → consume the trigger) or
+        # `under` (still retain) for a role, plus the current count. Reads the
+        # streak files under FLEET_STATE_DIR seeded by --record-outcome.
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-dispatcher --empty-streak-check <role>" >&2
+            exit 2
+        fi
+        if empty_streak_over_cap "$2"; then
+            echo "over $(read_empty_streak "$2")"
+        else
+            echo "under $(read_empty_streak "$2")"
         fi
         exit 0
         ;;

--- a/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
+++ b/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
@@ -72,6 +72,13 @@ assert_eq "$(disp "$S" --empty-streak-check worker)" "under 2" "2 < cap(3) -> re
 disp "$S" --record-outcome worker 1
 assert_eq "$(disp "$S" --empty-streak-check worker)" "over 3" "3 >= cap(3) -> consume (stand down)"
 
+echo "T2b: reset_empty_streak clears the streak file — post-consume reads 0"
+# Simulate the reset dispatch_role applies after consuming the trigger:
+# record_dispatch_outcome with a long-run duration calls reset_empty_streak
+# (same function, same rm -f path), so the next check should read 0.
+disp "$S" --record-outcome worker 600
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" "reset_empty_streak: streak file removed, reads 0"
+
 echo "T3: streaks are per-role (one role's churn doesn't trip another)"
 S=$(mktemp -d "$TMPROOT/s.XXXXXX")
 disp "$S" --record-outcome worker 1

--- a/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
+++ b/scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Tests for the dispatcher's empty-exit backoff (stale/false-actionable trigger
+# churn guard). A standing trigger whose role has no claimable work would
+# otherwise spin the pane forever: dispatch -> worker finds nothing -> returns
+# to shell in ~10s -> trigger retained -> re-dispatch every ~11s. The backoff
+# counts consecutive fast exits per role and, once the count reaches
+# EMPTY_STREAK_CAP, tells dispatch_role to consume the trigger instead of
+# retaining it. Exercised through two inspection subcommands:
+#
+#   --record-outcome <role> <duration>  fold one dispatch's wall-clock seconds
+#                                        into the role's streak (bump if fast,
+#                                        reset if long) — the unit that
+#                                        cleanup_stale_dispatches calls per
+#                                        completed dispatch.
+#   --empty-streak-check <role>          print `over <n>` / `under <n>` — the
+#                                        retain-vs-consume decision.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+
+if [[ ! -e "$DISPATCHER" ]]; then
+    echo "test setup: missing $DISPATCHER" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+
+# Each part runs against a fresh scratch state dir so streaks don't leak.
+disp() {
+    # usage: disp <state-dir> [env=val ...] -- <args...>
+    local state="$1"; shift
+    FLEET_STATE_DIR="$state" "$DISPATCHER" "$@"
+}
+
+echo "T1: a fast exit bumps the streak, a long run resets it"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" "fresh role starts at 0 (under cap)"
+disp "$S" --record-outcome worker 5
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 1" "one fast exit (5s) -> streak 1"
+disp "$S" --record-outcome worker 5
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 2" "two fast exits -> streak 2"
+disp "$S" --record-outcome worker 600
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" "a long run (600s) resets the streak"
+
+echo "T2: reaching the default cap (3) flips the decision to consume"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 1
+disp "$S" --record-outcome worker 1
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 2" "2 < cap(3) -> retain"
+disp "$S" --record-outcome worker 1
+assert_eq "$(disp "$S" --empty-streak-check worker)" "over 3" "3 >= cap(3) -> consume (stand down)"
+
+echo "T3: streaks are per-role (one role's churn doesn't trip another)"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 1
+disp "$S" --record-outcome worker 1
+disp "$S" --record-outcome worker 1
+assert_eq "$(disp "$S" --empty-streak-check worker)" "over 3"  "worker tripped"
+assert_eq "$(disp "$S" --empty-streak-check merger)" "under 0" "merger untouched"
+
+echo "T4: EMPTY_STREAK_CAP is configurable"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+disp "$S" --record-outcome worker 1
+assert_eq "$(FLEET_DISPATCHER_EMPTY_STREAK_CAP=1 disp "$S" --empty-streak-check worker)" \
+    "over 1" "cap=1: a single fast exit stands the role down"
+
+echo "T5: EMPTY_EXIT_SECONDS (the fast/long boundary) is configurable"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+# 600s counts as a *fast* exit when the threshold is 1000s -> bumps.
+FLEET_DISPATCHER_EMPTY_EXIT_SECONDS=1000 disp "$S" --record-outcome worker 600
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 1" "600s < thr(1000s) -> bump"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+# 30s counts as a *long* exit when the threshold is 10s -> resets (no bump).
+disp "$S" --record-outcome worker 5
+FLEET_DISPATCHER_EMPTY_EXIT_SECONDS=10 disp "$S" --record-outcome worker 30
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" "30s >= thr(10s) -> reset"
+
+echo "T6: a non-integer / garbage streak file is treated as 0, not a crash"
+S=$(mktemp -d "$TMPROOT/s.XXXXXX")
+mkdir -p "$S/empty-streak"
+printf 'not-a-number\n' > "$S/empty-streak/worker"
+assert_eq "$(disp "$S" --empty-streak-check worker)" "under 0" "corrupt streak file reads as 0"
+
+echo "T7: argument validation"
+if disp "$TMPROOT" --record-outcome worker >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: --record-outcome missing duration should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: --record-outcome missing duration exits non-zero"
+fi
+if disp "$TMPROOT" --record-outcome worker abc >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: --record-outcome non-integer duration should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: --record-outcome non-integer duration exits non-zero"
+fi
+if disp "$TMPROOT" --empty-streak-check >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: --empty-streak-check missing role should exit non-zero"
+else
+    PASS=$((PASS + 1)); echo "  ok: --empty-streak-check missing role exits non-zero"
+fi
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Problem

During a fleet validation on the native-Windows host, the dispatcher (pid from this session) was relaunching a worker into the same pane **every ~11 seconds, indefinitely** — confirmed from the dispatcher log:

```
dispatching worker -> %0
worker: dispatched 1; min-gap (8s) deferring remaining idle panes — trigger kept
dispatch for worker on %0 completed (pane returned to shell)   ← ~10s later, repeat forever
```

Root cause: a standing per-role trigger (`triggers/worker`, mtime frozen at boot — the scout never re-armed it because its projection had gone empty for this host's class) drove the loop. Each tick the dispatcher fired a worker, the worker found nothing claimable and returned to the shell in ~10s, and the retention paths (`gap_blocked` fan-out at `dispatch_role`, boot fan-out) **kept** the trigger — the consume-on-success branch was never reached. The pane *looked* busy (each relaunch re-read the smoke protocol and re-evaluated the queue) but never completed a claim, burning a fresh `claude` cold start every cycle.

The live churn was already stopped operationally by removing the stale trigger file; this PR is the durable guard so any future stale / false-actionable trigger can't churn the same way.

## Fix

Treat a dispatch that returns to a shell in under `EMPTY_EXIT_SECONDS` (default **60s**) as "claimed nothing" — a genuine claim runs for minutes (build / test / PR). Count consecutive fast exits per role; once the streak hits `EMPTY_STREAK_CAP` (default **3**), `dispatch_role` consumes the trigger after that tick's probe dispatch instead of retaining it.

- **Streak bookkeeping** in `cleanup_stale_dispatches`: when a pane returns to shell, the run duration (`now - dispatched_epoch`) bumps the streak if fast, resets it if long. New state under `$STATE_DIR/empty-streak/<role>`.
- **`write_dispatch_record`** now stamps `dispatched_epoch`; legacy records without it skip the streak update silently (safe rolling upgrade).
- **Consume-on-cap** guard added once, right after the dispatch loop in `dispatch_role`, pre-empting all retention paths. Guarded on `dispatched > 0` so a tick that sent nothing keeps the existing min-gap/retry semantics.

### Why a probe, not a hard block

When over cap the dispatcher still dispatches **once**, then consumes the trigger. That probe lets a freshly re-armed trigger carrying *real* work claim it (resetting the streak) rather than being stranded. A hard block would deadlock: the streak only resets on a successful long run, which can't happen if dispatch is suppressed. Interaction with `rearm_periodic_meta_triggers`' "worker safety rearm" is benign — that path only re-arms when the projection is genuinely actionable.

### Net behavior

At most one wasted probe per armed trigger instead of an unbounded loop. A stale trigger over an empty projection goes quiet after ~3 cycles; real fan-out of actual work is unaffected (those dispatches run long and reset the streak).

## Tests

`scripts/fleet/tests/test_dispatcher_empty_exit_backoff.sh` — 15 assertions via two new inspection subcommands (`--record-outcome`, `--empty-streak-check`) mirroring the existing `--dispatch-gap-check` / `--retain-trigger-check` hooks: bump/reset, cap boundary, per-role isolation, both env overrides, corrupt-file tolerance, arg validation. All pass.

Existing dispatcher tests unchanged. The 2 failures in `test_dispatcher_concurrency_cap.sh` are **pre-existing on master** (tmux-reservation env, verified by running master's copy in isolation), not introduced here.

## Operational note

A running dispatcher reads its script once at launch, so this takes effect on the **next `fleet-up` restart**. Both new thresholds are env-overridable (`FLEET_DISPATCHER_EMPTY_EXIT_SECONDS`, `FLEET_DISPATCHER_EMPTY_STREAK_CAP`) and validate-and-clamp like `BOOT_FANOUT_WINDOW_SECONDS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)