### PR TITLE
render: fix stage-2 cardinal entity-id arg — uint→uvec2 breaks Windows GL compile

### DIFF
--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
@@ -281,5 +281,10 @@ void main() {
         : (microPositionFixed.x + microPositionFixed.y + microPositionFixed.z);
     const int voxelDistance = encodeDepthWithFace(depthBase, slot);
     const ivec2 base = frameOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
-    emitDeformedFace(base, D, voxelDistance, voxelColor, voxelIndex, faceId, reVoxelize);
+    // packedEntityId, NOT voxelIndex: emitDeformedFace's 5th param is the uvec2
+    // entity-id carrier (#1960). The per-trixel-priority change updated the
+    // per-axis call site (above) but missed this cardinal one, leaving a
+    // uint->uvec2 arg. Lenient GL drivers broadcast the scalar; native-Windows
+    // rejects the implicit cast (C7011) and the whole shader fails to compile.
+    emitDeformedFace(base, D, voxelDistance, voxelColor, packedEntityId, faceId, reVoxelize);
 }

--- a/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
+++ b/engine/render/src/shaders/c_voxel_to_trixel_stage_2.glsl
@@ -281,10 +281,6 @@ void main() {
         : (microPositionFixed.x + microPositionFixed.y + microPositionFixed.z);
     const int voxelDistance = encodeDepthWithFace(depthBase, slot);
     const ivec2 base = frameOffsetFixed + pos3DtoPos2DIso(microPositionFixed);
-    // packedEntityId, NOT voxelIndex: emitDeformedFace's 5th param is the uvec2
-    // entity-id carrier (#1960). The per-trixel-priority change updated the
-    // per-axis call site (above) but missed this cardinal one, leaving a
-    // uint->uvec2 arg. Lenient GL drivers broadcast the scalar; native-Windows
-    // rejects the implicit cast (C7011) and the whole shader fails to compile.
+    // packedEntityId, not voxelIndex — emitDeformedFace's 5th param is uvec2 (#1960 carrier).
     emitDeformedFace(base, D, voxelDistance, voxelColor, packedEntityId, faceId, reVoxelize);
 }


### PR DESCRIPTION
## Summary

`c_voxel_to_trixel_stage_2.glsl`'s **cardinal** emit path passed `voxelIndex` (a `uint`) to `emitDeformedFace`, whose 5th parameter is the `uvec2 packedEntityId` carrier (#1960). The per-trixel-priority change updated the **per-axis** call site (line 256) and the **Metal** twin's cardinal call, but missed this one GLSL cardinal call (line 284).

### Two consequences, both latent until native Windows

1. **Native-Windows GL compile break.** The NVIDIA driver rejects the implicit `uint→uvec2` with `error C7011: implicit cast from "uint" to "uvec2"` → "Shader stage compilation failed", crashing **every demo** at startup (36/38 on the platform-catchup re-validation run). Lenient Linux/macOS drivers broadcast the scalar, so the program compiled there and this slipped through.
2. **Latent correctness bug.** Where the scalar was broadcast, the cardinal path wrote the **voxel index** into the entity-id channel instead of the real packed entity id — wrong picking/hover id, and a corrupt per-trixel priority tier on that path.

### Fix

Pass `packedEntityId` — matching the per-axis GLSL call site (line 256) **and** the Metal cardinal call (already correct). One-token change + an explanatory comment. Metal needs no change (it was already right, which is why macOS smoke passed).

## Validation (native Windows)

`IRShapeDebug` now compiles cleanly (0 C7011), renders, saves 21 screenshots, and exits cleanly. Since `c_voxel_to_trixel_stage_2` is shared across the whole voxel pipeline, this unblocks every demo that was failing to compile it.

## Render-verify note

Same situation as the bring-up shader fix: the "before" on Windows is a compile crash (no frame to capture); on Linux/macOS the visible change is the corrected entity-id on the cardinal path (picking/priority correctness, not a silhouette change). Reviewers on Linux: please confirm picking/hover still resolve correct ids on a cardinal pose.

## Context

Found by re-validating current master on Windows during the platform-catchup sweep — caught a regression that 5 render PRs (merged since the bring-up, none Windows-validated) introduced. Companion to the bring-up #2034.

## Test plan
- [ ] Native Windows: `IRShapeDebug --auto-screenshot` compiles + renders (done: 21 shots, clean exit).
- [ ] Linux/OpenGL: build + run; confirm picking/hover entity ids correct on a cardinal pose (the corrected path).
- [ ] macOS/Metal: unaffected (Metal call site was already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)