### PR TITLE
build: fix ir-build cmd.exe quoting for interactive MSYS2 terminals

### DIFF
--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -240,6 +240,17 @@ front when the child Win32 process is spawned. You need the `set PATH=`
 inside `cmd /c` to guarantee the DLL loader sees MSYS2's `mingw64\bin`
 first.
 
+> **Interactive-terminal caveat (`/c` vs `//c`):** the bare `cmd.exe /c`
+> above works under Claude's Bash tool, but in a real MSYS2 / Git-Bash
+> terminal POSIX path conversion rewrites the standalone `/c` argument into
+> `C:/`, so `cmd.exe /c "…"` becomes `cmd.exe C:/ "…"` — which opens `cmd`
+> **interactively** instead of running the command. When typing one of these
+> by hand in a terminal, use the conversion-proof `//c` idiom (it collapses
+> back to `/c` for cmd.exe and works in both contexts). `ir-build` already
+> uses `//c` internally for this reason; also avoid embedding `"…"` quotes
+> around a no-space path inside the `//c` string — the literal quotes leak
+> into the wrapped command's arguments.
+
 This whole section **does not apply in WSL** — WSL has a single clean
 Linux PATH, no Git-for-Windows mingw64 to fight. If you're running in
 the fleet, skip it.

--- a/engine/tools/bin/ir-build
+++ b/engine/tools/bin/ir-build
@@ -62,7 +62,7 @@ source "$HELPERS"
 # mingw64\bin precedes MSYS2's, so gcc spawns cc1plus.exe against Git's older
 # runtime DLLs and it dies *silently* on the ABI mismatch (zero output, exit 1).
 # See docs/agents/BUILD.md "cc1plus silent-crash root cause". The only reliable
-# fix is to run cmake inside `cmd.exe /c "set PATH=<msys2 mingw64>;%PATH% && ..."`
+# fix is to run cmake inside `cmd.exe //c "set PATH=<msys2 mingw64>;%PATH% && ..."`
 # so the Win32 DLL loader sees MSYS2's mingw64 first — a bash-side PATH export is
 # undone by MSYS path translation when the child Win32 process is spawned.
 # IR_MSYS2_MINGW overrides the prefix for non-default MSYS2 installs.
@@ -76,9 +76,15 @@ esac
 # the configure (cmake --preset) step, which also spawns cc1plus for its
 # compiler-ID checks. Args are joined for cmd.exe; the paths this repo passes
 # (build dir, source dir, -D defines) contain no spaces.
+#
+# `//c` (not `/c`): in an interactive MSYS2/Git-Bash terminal, POSIX path
+# conversion rewrites a bare `/c` arg into `C:/`, so `cmd.exe /c "..."` becomes
+# `cmd.exe C:/ "..."` — which opens cmd *interactively* instead of running the
+# command. The `//c` idiom collapses to `/c` for cmd.exe and is excluded from
+# conversion, so it works both in a real terminal and under Claude's Bash tool.
 ir_cmake() {
     if (( IR_IS_WINDOWS )); then
-        cmd.exe /c "set PATH=$IR_MSYS2_MINGW;%PATH% && cmake $*"
+        cmd.exe //c "set PATH=$IR_MSYS2_MINGW;%PATH% && cmake $*"
     else
         cmake "$@"
     fi
@@ -181,9 +187,12 @@ if (( IR_IS_WINDOWS )); then
     # The cc1plus PATH fix must wrap the actual compile, so the whole
     # `cmake --build` runs inside cmd.exe. ir-acquire still holds the CPU
     # slots for the duration. Target names and the build dir contain no
-    # spaces; the build dir is quoted defensively for cmd.exe.
-    exec "$IR_ACQUIRE" cpu "$JOBS" -- cmd.exe /c \
-        "set PATH=$IR_MSYS2_MINGW;%PATH% && cmake --build \"$BUILD_DIR\" -j$JOBS ${forward_args[*]}"
+    # spaces, so $BUILD_DIR is passed unquoted: embedding \"...\" inside the
+    # cmd.exe //c string leaks the literal quote characters into cmake's
+    # --build argument (cmake then treats the quoted path as relative and
+    # prepends the CWD). Unquoted is both correct and space-free here.
+    exec "$IR_ACQUIRE" cpu "$JOBS" -- cmd.exe //c \
+        "set PATH=$IR_MSYS2_MINGW;%PATH% && cmake --build $BUILD_DIR -j$JOBS ${forward_args[*]}"
 else
     exec "$IR_ACQUIRE" cpu "$JOBS" -- cmake --build "$BUILD_DIR" -j"$JOBS" "${forward_args[@]}"
 fi


### PR DESCRIPTION
## Summary
- `ir-build` configures/builds inside `cmd.exe /c "set PATH=…msys64… && cmake …"` for the mandatory cc1plus PATH fix. In a real MSYS2/Git-Bash terminal, POSIX path conversion rewrites the standalone `/c` arg into `C:/`, so `cmd.exe /c "…"` becomes `cmd.exe C:/ "…"` → cmd opens **interactively** (banner + prompt) and the configure/build never runs. Switched both call sites to the conversion-proof `//c` idiom (still works under Claude's Bash tool).
- Dropped the defensive `"$BUILD_DIR"` quoting in the build `exec`: the literal quotes leaked into cmake's `--build` argument, so cmake resolved the quoted path relative to the CWD (`… is not a directory`). The build dir has no spaces, so unquoted is correct and conversion-safe.
- Documented the `/c` vs `//c` interactive caveat in `docs/agents/BUILD.md`'s cc1plus section.

This is a shell-level bug in the build wrapper, **not** a regression in the recent Windows-build PRs — it only surfaces in an interactive MSYS2 terminal (the fleet Bash tool's bash build doesn't convert `/c`), which is why the fleet never hit it.

## Test plan
- [x] Native Windows MSYS2 (mingw64): `ir-build --target IRPerfGrid` from a clean tree — configure (107s) + full engine build to `[100%] Built target IRPerfGrid` (exit 0).
- [x] `ir-run IRPerfGrid --auto-screenshot 10` launches and renders; all 7 shots captured, clean exit.
- [x] `bash -n engine/tools/bin/ir-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)