### PR TITLE
docs: comment policy — durable why, not change history

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -107,6 +107,13 @@ any `c_compute_*shadow*.glsl` / `.metal`)
   is the single most common slip. A private member that already carries `m_`
   is correct; do **not** flag it (this inversion produced a false-positive nit
   on PR #1706).
+- Block comments that narrate change / investigation history — issue-by-issue
+  forensics, `Before #X / now Y`, `was a misdiagnosis`, `retired (T-323)` —
+  instead of stating a durable invariant. Durable *why* stays; history moves
+  to the commit / PR / a `docs/design/` doc with at most a one-line `// see #N`
+  backref. Single-sourced in
+  [`CLAUDE-BASELINE.md`](../../../docs/agents/CLAUDE-BASELINE.md) §Style; most
+  common in render-pipeline diffs.
 
 **Tests / build**
 - Code change with no corresponding test change where a test existed.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -421,7 +421,13 @@ Remove:
   for the new API`, `// Removed old approach (was X, now Y)`.
   These narrate the diff (which git already shows in the commit
   history) and age into noise once the change is the new normal.
-  Delete; let the commit message carry the change story.
+  Delete; let the commit message carry the change story. **This
+  applies at paragraph / block scale too**, not just one-liners: a
+  multi-line block that traces issue-by-issue history (`#1957
+  verified…`, `was a misdiagnosis`, `Before #X / now Y`, `retired
+  (T-323)`) is the same smell wearing rationale's clothing — most
+  common in render code. Cut the forensic prose, keep the durable
+  invariant, and leave at most a `// see #N` backref.
 - Location-reference narration that points at other code instead of
   explaining why — `// ... (set above)`, `// see below`, `// called
   from X`. Mechanically caught by §2b Check 4; delete the
@@ -431,8 +437,13 @@ Remove:
 - "Old code" markers next to deleted lines.
 
 Keep:
-- Comments that explain non-obvious **why** — rationale, gotchas,
-  cross-references to docs/papers/prior-art decisions.
+- Comments that explain non-obvious **why** — but only *durable*
+  rationale, gotchas, and cross-references that stay true of the code
+  *as it stands*. The test that separates kept rationale from the
+  change-history smell above: would you still write this sentence if
+  the code had always existed in its current form? If yes it's a
+  durable why (keep it); if it only makes sense as a record of how the
+  code changed, it's history (cut to a `// see #N` backref).
 - Doc comments on public surface where the function name alone
   doesn't capture the contract (preconditions, side effects, ranges).
 

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -124,6 +124,21 @@ path, or the API keeps signalling "experimental" when it's the production code
   at the referenced site, not cross-referenced from here. Delete them; if
   the comment carried a genuine WHY, move it to the site it points at.
   (The `simplify` skill's Check 4 greps for these mechanically on new diffs.)
+- **Comments capture durable *why*, not change history.** A comment states
+  what is true of the code *as it stands* — invariants, contracts,
+  conventions, and gotchas a reader needs regardless of how the code got
+  here. It does not narrate the investigation or the diff. Keep *"this is
+  the ONE place the threshold lives, so every consumer derives the same
+  predicate and can't disagree"*; cut *"Before #1882 the gate used
+  `|residual| > deadband`… now Y"*, *"#1957 verified… was a misdiagnosis"*,
+  *"retired (T-323)"*. The test: if the code had always existed in its
+  current form, would you still write this sentence? If no, it's history —
+  it belongs in the commit message, the PR body, or a design doc under
+  `docs/design/` (or `.fleet/plans/T-*.md`), not the source; leave at most a
+  one-token backref (`// see #1910`). This holds at paragraph scale — a
+  30-line block tracing a bug's forensic history is the same smell as a
+  one-line `// now uses the deferred variant`, and is most common in render
+  code.
 - **These style and comment rules apply to the fleet Python surface
   (`scripts/fleet/`) too, not just C++.** PEP8 spacing, import-order, unused
   imports, and bare-`assert`-as-guard are enforced mechanically by **ruff**

--- a/engine/prefabs/irreden/render/camera.hpp
+++ b/engine/prefabs/irreden/render/camera.hpp
@@ -28,12 +28,9 @@ namespace IRPrefab::Camera {
 // exactly 0 inside it, so every "rotating?" consumer (the per-axis allocation
 // gate in per_axis_canvas.hpp, the render path-select gate in
 // system_voxel_to_trixel.hpp, the FrameDataVoxelToCanvas UBO, the sun-shadow
-// bake's frame patch) derives the same predicate from the same value and
-// cannot disagree. Before #1882 the allocation gate used `|residual| > deadband`
-// while path-select used `residual != 0`; a cardinal whose quat round-trip
-// landed in (0, deadband] freed the per-axis textures yet still routed to the
-// per-axis path, reading freed textures → see-through coverage holes at
-// 90°/180°. Deadbanding at the source closes that gap.
+// bake's frame patch) derives the same predicate from the same value and cannot
+// disagree. A split predicate freed the per-axis textures while the per-axis
+// path still read them, causing see-through coverage holes at 90°/180° (#1882).
 inline constexpr float kResidualYawDeadband = 1e-4f;
 
 /// Decompose a continuous Z-yaw value into (rasterYaw, residualYaw):

--- a/engine/prefabs/irreden/render/depth_probe.hpp
+++ b/engine/prefabs/irreden/render/depth_probe.hpp
@@ -10,40 +10,35 @@
 #include <irreden/render/components/component_trixel_framebuffer.hpp>
 #include <irreden/render/ir_render_types.hpp>
 
-// GPU→CPU composite-depth probe (#1910). A debug-only readback that, for a
-// requested screen pixel, reads the REAL depth-test value stored in the main
-// framebuffer's depth attachment and decodes it to shared trixel-distance
-// units. Because every render path — the cardinal gather
-// (f_trixel_to_framebuffer), the per-axis forward scatter (f_per_axis_scatter),
-// and the detached-canvas composite (ENTITY_CANVAS_TO_FRAMEBUFFER) — writes its
-// winning fragment's `gl_FragDepth` into this one attachment under the GL_LESS
-// depth test, a single readback captures the true composite winner regardless of
-// which path produced the pixel. The detached composite writes depth on BOTH
-// backends — #1957 verified the depth-write state is default-ENABLED when the
-// composite runs (Metal `depthWriteEnabled_`, OpenGL `glDepthMask(GL_TRUE)`) and
-// made that write explicit so it can't silently regress — so the probe reads the
-// detached solid's stored depth on both backends, not just the floor/world
-// behind it. (The earlier "Metal composite is depth-blind — #1884/#1950 Finding
-// 1" reading was a misdiagnosis: the composite participates in depth; where its
-// iso-depth ranks behind the floor it LOSES the test, the #1958 wrong-winner
-// problem, rather than never writing.) That is the reconciled, comparable depth
-// the #1884 "behind-face wins" crossings need diagnosed in real units, and the
-// reason this reads the attachment rather than approximating depth as a shader
-// color output (which loses precision and can't be decoded per-path).
+// GPU→CPU composite-depth probe. A debug-only readback that, for a requested
+// screen pixel, reads the REAL depth-test value stored in the main framebuffer's
+// depth attachment and decodes it to shared trixel-distance units. Because every
+// render path — the cardinal gather (f_trixel_to_framebuffer), the per-axis
+// forward scatter (f_per_axis_scatter), and the detached-canvas composite
+// (ENTITY_CANVAS_TO_FRAMEBUFFER) — writes its winning fragment's `gl_FragDepth`
+// into this one attachment under the GL_LESS depth test, a single readback
+// captures the true composite winner regardless of which path produced the
+// pixel. The detached composite writes depth on BOTH backends (Metal
+// `depthWriteEnabled_`, OpenGL `glDepthMask(GL_TRUE)`), made explicit so it can't
+// silently regress — so the probe reads the detached solid's stored depth, not
+// just the floor/world behind it. Reading the attachment (rather than
+// approximating depth as a shader color output) keeps full precision and lets
+// each path decode its own range.
 //
-// `assertCompositeWritesDepth` is the #1957 regression guard: it turns one
-// readback into a machine-readable PASS/FAIL so a future pass that disables the
-// composite depth-write is caught headlessly (canvas_stress --depth-probe-assert).
+// `assertCompositeWritesDepth` turns one readback into a machine-readable
+// PASS/FAIL so a future pass that disables the composite depth-write is caught
+// headlessly (canvas_stress --depth-probe-assert).
 //
 // Pure readback: it touches no shader and no render state, so a scene with the
 // probe off — or even on — is byte-identical at the pixel level. The cost is a
-// full GPU flush per probed frame (device()->finish(): Metal commit+wait per
-// #1436, GL glFinish), so keep it strictly debug-gated and single-pixel.
+// full GPU flush per probed frame (device()->finish(): Metal commit+wait, GL
+// glFinish), so keep it strictly debug-gated and single-pixel.
 //
 // Lives in the prefab layer (not IRRender::) because it resolves the
 // "mainFramebuffer" prefab entity — engine/render/ owns graphics primitives, not
 // scene entities. The generic depth-texture readback primitive it builds on is
 // `Texture2D::getSubImage2D(..., PixelDataFormat::DEPTH_COMPONENT, FLOAT32, ...)`.
+// See #1910 (design), #1957 (depth-write guard).
 namespace IRPrefab::DepthProbe {
 
 /// Result of a single-pixel composite-depth readback.

--- a/engine/render/src/ir_render.cpp
+++ b/engine/render/src/ir_render.cpp
@@ -65,23 +65,10 @@ vec2 getEffectiveCameraIso() {
     // isoPixelToPos3D(canvasCenterIso - cameraIso, 0)`). `cameraYawPivotOffset`
     // then drift-cancels so screen(F) is yaw-independent. At visualYaw == 0 it
     // returns cameraIso, byte-identical to ORIGIN mode (the cardinal fast path).
-    //
-    // This is the #1942 "exact screen center" pivot. #1944 reverted it to the
-    // legacy #1352 point `isoPixelToPos3D(cameraIso, 0)`, which is the point
-    // MIRRORED across the true screen center (#1942's "~1 trixel off, mirrored"):
-    // the bare-yawed form #1944 paired with it swings the panned scene in an arc
-    // during yaw — the rotation "vibration" reported on shape_debug, which pans
-    // off-origin before yawing (canvas_stress never caught it: it is un-panned, so
-    // every form collapses to cameraIso == 0).
-    //
-    // #1944 reverted because the viewCenter focus is ~1 trixel off origin even
-    // UN-panned, so effective != raw, and the DETACHED entity-canvas composite
-    // (system_entity_canvas_to_framebuffer) placed entities with the RAW
-    // getCameraPosition2DIso() — so detached drifted vs the effective-offset GRID.
-    // That follow-up is now done: the composite consumes getEffectiveCameraIso()
-    // for placement (see system_entity_canvas_to_framebuffer.hpp), so detached and
-    // GRID pivot together and canvas_stress stays aligned through rotation. See
-    // docs/design/camera-yaw-pivot.md.
+    // The DETACHED entity-canvas composite must place entities with
+    // getEffectiveCameraIso() (not the raw camera pos) so detached and GRID pivot
+    // together — see system_entity_canvas_to_framebuffer.hpp. See
+    // docs/design/camera-yaw-pivot.md (#1352, #1942, #1944).
     const ivec2 canvasSize = getRenderManager().getMainCanvasSizeTriangles();
     const vec2 viewCenterIso = vec2(canvasSize) * 0.5f -
                                vec2(IRMath::trixelOriginOffsetZ1(canvasSize)) - cameraIso;
@@ -123,12 +110,11 @@ vec2 getMainCanvasSizeTrixels() {
 
 namespace {
 
-// Residual yaw is folded into faceDeform[] in the trixel emit shaders (T-293);
-// the screen-space residual-rotate stage has been fully retired (T-323). The
-// picking chain therefore needs no residualYaw inverse step. Iso-space picking
-// accuracy at non-cardinal yaws is bounded by the geometric trixel deformation,
-// which is a small per-face offset the picking math doesn't reverse-compose today
-// (follow-up).
+// The picking chain needs no residualYaw inverse step: residual yaw lives in the
+// trixel emit shaders' faceDeform[], not in a screen-space stage. Iso-space
+// picking accuracy at non-cardinal yaws is bounded by the geometric trixel
+// deformation — a small per-face offset the picking math doesn't reverse-compose
+// today (follow-up). See T-293, T-323.
 vec2 mouseCanvasIso() {
     return IRMath::pos2DScreenToPos2DIso(
                IRRender::getMousePositionOutputView(),
@@ -149,9 +135,7 @@ vec2 mousePosition2DIsoWorldRender() {
 
 vec3 mouseWorldPos3DAtIsoDepth(float canvasIsoDepth) {
     // Screen→world picking inverse per `.fleet/plans/T-054.md` (epic #310).
-    // After T-293 the screen-space residual bilinear is gone and residual
-    // yaw lives in the trixel emit shaders' faceDeform[] — the inverse
-    // chain therefore collapses to the rasterYaw half only:
+    // The inverse chain is the rasterYaw half only:
     //   world = R_z(-rasterYaw) · isoPixelToPos3D · screen
     // `mouseCanvasIso()` provides the canvas-frame iso pixel; isoPixelToPos3D
     // recovers the unique 3D point at the requested depth (= rotated.x +


### PR DESCRIPTION
## Summary
- Adds a **"durable why, not change history"** comment rule to `CLAUDE-BASELINE.md` §Style — it propagates by reference to the root `CLAUDE.md` and every creation. Keep invariants/contracts/conventions/gotchas true of the code *as it stands*; route the investigation/change narrative (`before #X / now Y`, `#N verified… misdiagnosis`, `retired (T-323)`) to git / PR / `docs/design`, leaving at most a one-token `// see #N` backref. **No length cap** — long durable rationale is fine.
- Sharpens `simplify` §7: the change-narration ban now explicitly covers **paragraph-scale** issue-traced history (it previously caught only one-liners), and the "keep the why" carve-out is narrowed to *durable* rationale — that carve-out was shielding the bloat.
- Adds one criterion to the `review-pr` engine checklist (backstop), single-sourced to §Style.
- Demonstrates the policy on the worst offenders — `depth_probe.hpp`, `camera.hpp`, `ir_render.cpp` — as **comment-only** edits that keep every durable invariant and cut only history.

## Why
The diagnosis (full write-up in the commit body): render-code comment blocks had grown into compiled-in change logs. ~85% of the text was load-bearing, but the issue-by-issue forensic history dressed in issue numbers was the bulk of the excess length, and it reads like rationale — so `simplify`'s existing change-narration check (one-liner-scoped) never caught it. This draws the line explicitly and threads it through write-time, catch-time, and review.

## Test plan
- [ ] Source edits are **comment-only** — `git diff` confirms zero non-comment lines changed in the three `.cpp`/`.hpp` files; no build or behavior impact.
- [ ] Doc cross-refs resolve — `CLAUDE-BASELINE.md` §Style heading exists; the `review-pr` relative link target resolves.
- [ ] Longest added comment line is 83 cols (≤ 100 `ColumnLimit`) — no clang-format drift.
- [ ] Spot-check: the sharpened `simplify` §7 would now flag the pre-cleanup `depth_probe.hpp` / `camera.hpp` history blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)