### PR TITLE
engine/video: retire parseAutoScreenshotArgv (IRArgs epic P6)

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -50,9 +50,7 @@ count prints an error + usage and `exit(2)`. `creations/demos/fog_demo/main.cpp`
 is the reference adoption.
 
 Do **not** add a new `for (i…) std::strcmp(argv[i], "--foo")` parse loop to a
-target. The one remaining legacy helper (`IRVideo::parseAutoScreenshotArgv`)
-and the demos' hand-rolled loops are being migrated onto `IRArgs` and retired
-(epic #2057).
+target — every engine arg goes through `IRArgs`.
 
 ## `SystemName` enum is authoritative
 

--- a/engine/include/irreden/ir_args.hpp
+++ b/engine/include/irreden/ir_args.hpp
@@ -27,8 +27,7 @@
 namespace IRArgs {
 
 // The engine-common --auto-screenshot warmup default when the flag is given
-// without a trailing frame count. Mirrors the long-standing default in
-// IRVideo::parseAutoScreenshotArgv.
+// without a trailing frame count.
 inline constexpr int kDefaultAutoScreenshotWarmup = 10;
 
 // Kind of a registered argument. Drives both the parse rule and the value

--- a/engine/ir_args.cpp
+++ b/engine/ir_args.cpp
@@ -247,9 +247,8 @@ void Parser::parse(int argc, char **argv) {
         case Type::OPTIONAL_INT:
             // An inline value is taken verbatim; otherwise consume the next
             // token only when it reads as a positive integer, leaving it for the
-            // loop otherwise. Mirrors the historical parseAutoScreenshotArgv peek
-            // so existing command lines are byte-identical (the bare default
-            // stays in intValue_).
+            // loop otherwise (existing command lines are byte-identical; the bare
+            // default stays in intValue_).
             if (hasInline) {
                 e->intValue_ = std::atoi(inlineValue.c_str());
             } else if (i + 1 < argc) {

--- a/engine/video/CLAUDE.md
+++ b/engine/video/CLAUDE.md
@@ -74,20 +74,21 @@ plus five lines of wire-up. Used by the `render-debug-loop` and
   set (see [`docs/design/cull-validation-harness.md`](../../docs/design/cull-validation-harness.md)).
 - `AutoScreenshotConfig` — warmup/settle frame counts and a
   caller-owned `const AutoScreenshotShot *` table.
-- `parseAutoScreenshotArgv` — CLI parser for
-  `--auto-screenshot [frames]`.
 - `createAutoScreenshotSystem` — RENDER-pipeline system that cycles
   through shots, triggers one screenshot per shot, and calls
   `IRWindow::closeWindow()` when done.
 
 Wire-up order in `main.cpp`:
 
-1. Call `parseAutoScreenshotArgv(argc, argv, &warmupFrames)`.
+1. Call `IREngine::init(argc, argv)` — the engine parser handles
+   `--auto-screenshot [frames]` as a built-in. Read the warmup count
+   back via `IREngine::args().autoScreenshotWarmupFrames()`.
 2. Declare a `constexpr AutoScreenshotShot kShots[]` table at file scope
    (must outlive the game loop).
-3. When `warmupFrames > 0`, build an `AutoScreenshotConfig` and call
-   `createAutoScreenshotSystem(cfg)` — append the returned `SystemId` to
-   the **RENDER** pipeline list before `registerPipeline` fires.
+3. When `IREngine::args().autoScreenshotWarmupFrames() > 0`, build an
+   `AutoScreenshotConfig` and call `createAutoScreenshotSystem(cfg)` —
+   append the returned `SystemId` to the **RENDER** pipeline list before
+   `registerPipeline` fires.
 
 Reference callers: `creations/demos/shape_debug/main.cpp` and
 `creations/demos/metal_clear_test/main.cpp`.

--- a/engine/video/include/irreden/video/auto_screenshot.hpp
+++ b/engine/video/include/irreden/video/auto_screenshot.hpp
@@ -101,18 +101,6 @@ struct AutoScreenshotConfig {
     void (*onCaptureFrame_)(int shotIndex) = nullptr;
 };
 
-/// Parse @c --auto-screenshot<space>[frames] from argv. Returns @c true if
-/// the flag is present. When present and followed by a positive integer,
-/// @c *warmupFramesOut is set to that value; otherwise the default of 10 is
-/// written. @c warmupFramesOut may be @c nullptr.
-///
-/// This helper peeks at the token after @c --auto-screenshot but does not
-/// tell the caller whether it consumed one or two argv slots. Callers with
-/// subsequent argv loops must be aware that a bare positive integer may
-/// appear at the slot immediately after @c --auto-screenshot — if their
-/// own loop could interpret that token, skip past it explicitly.
-bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut);
-
 /// True once @c createAutoScreenshotSystem has been called this run — i.e. the
 /// process is doing a headless auto-screenshot capture. @c World reads this to
 /// switch the UPDATE loop to a deterministic fixed step (one tick per render

--- a/engine/video/src/auto_screenshot.cpp
+++ b/engine/video/src/auto_screenshot.cpp
@@ -9,8 +9,6 @@
 #include <irreden/render/camera.hpp>
 #include <irreden/render/cull_viewport_state.hpp>
 
-#include <cstdlib>
-#include <cstring>
 #include <memory>
 
 namespace IRVideo {
@@ -64,23 +62,6 @@ struct CyclingState {
 bool g_autoCaptureActive = false;
 
 } // namespace
-
-bool parseAutoScreenshotArgv(int argc, char **argv, int *warmupFramesOut) {
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--auto-screenshot") != 0)
-            continue;
-        int warmup = 10;
-        if (i + 1 < argc) {
-            int parsed = std::atoi(argv[i + 1]);
-            if (parsed > 0)
-                warmup = parsed;
-        }
-        if (warmupFramesOut != nullptr)
-            *warmupFramesOut = warmup;
-        return true;
-    }
-    return false;
-}
 
 bool isAutoCaptureActive() {
     return g_autoCaptureActive;


### PR DESCRIPTION
## Summary
- Delete `IRVideo::parseAutoScreenshotArgv` decl and impl — all P2–P5 callers migrated; grep confirms zero remaining callers anywhere in engine + creations.
- Drop now-unused `<cstdlib>` / `<cstring>` includes from `auto_screenshot.cpp`.
- Remove the "being migrated / retired (#2044 follow-ons)" hedge from `engine/CLAUDE.md`; rule now reads cleanly.
- Update `engine/video/CLAUDE.md` wire-up order: step 1 now cites `IREngine::init` + `args().autoScreenshotWarmupFrames()` instead of the retired helper.
- Remove stale cross-references to `parseAutoScreenshotArgv` in `ir_args.hpp` and `ir_args.cpp` comments.

## Test plan
- [x] `grep -rn parseAutoScreenshotArgv engine creations` → empty after this change
- [x] `fleet-build --target IRShapeDebug` clean on macOS/Metal
- [x] `format-changed` no-op (no formatting drift introduced)

Closes #2064

🤖 Generated with [Claude Code](https://claude.com/claude-code)