### PR TITLE
fleet: defer idle dispatch + cap worker fan-out to claimable work

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -401,6 +401,27 @@ elif (( EMPTY_STREAK_CAP < 1 )); then
     EMPTY_STREAK_CAP=3
 fi
 
+# Claimable-count fan-out cap (worker lane). The class resolver
+# (fleet_task_class.py) reports how many items of the elected class a fresh
+# worker could claim right now (`count`). The dispatcher caps its idle-pane
+# fan-out so it never launches more workers of a class than there is work to
+# claim — the surplus panes would only iterate-and-exit, and a no-op opus
+# iteration costs real tokens. A worker counts against that cap only while it
+# might still be racing to claim (its dispatch record is younger than the
+# settle window below); past it, the worker has settled onto a claimed task (or
+# a long iteration) and no longer competes for the remaining claimable items,
+# so it stops counting — that keeps the cap from serializing independent work
+# (a worker busy on task A must not block dispatching a worker for task B).
+# Sized to comfortably cover a claude cold start + state read + claim; the task
+# leaves tasks_open once claimed, which is the real signal, so this only has to
+# bridge the window before that projection update lands.
+CLAIM_SETTLE_SECONDS="${FLEET_DISPATCHER_CLAIM_SETTLE_SECONDS:-90}"
+if ! [[ "$CLAIM_SETTLE_SECONDS" =~ ^[0-9]+$ ]]; then
+    printf '[%s dispatcher] CLAIM_SETTLE_SECONDS=%q is not a non-negative integer; falling back to 90\n' \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$CLAIM_SETTLE_SECONDS" >&2
+    CLAIM_SETTLE_SECONDS=90
+fi
+
 # Roles this dispatcher is responsible for. Architects are excluded
 # (kept on fleet-babysit). Aligned with the worker / reviewer /
 # queue-mgr / merger roles in fleet-up.
@@ -689,6 +710,33 @@ count_active_for_class() {
     for record in "$DISPATCH_DIR"/*.json; do
         [[ -f "$record" ]] || continue
         if grep -q "\"class\":\"$class\"" "$record" 2>/dev/null; then
+            count=$((count + 1))
+        fi
+    done
+    echo "$count"
+}
+
+# Count in-flight dispatches of a model class that were launched within the
+# last $2 seconds — the subset still plausibly *racing to claim* (a freshly
+# dispatched worker hasn't read state / claimed yet). Older records belong to
+# workers that have already settled onto claimed work, so they're excluded.
+# Backing for the claimable-count fan-out cap: headroom = claimable - racing,
+# which bounds the per-task dispatch race without serializing independent work.
+# Reads dispatched_epoch from each record (written by write_dispatch_record).
+count_recent_active_for_class() {
+    local class="$1" max_age="$2" count=0 record epoch now age
+    [[ -d "$DISPATCH_DIR" ]] || { echo 0; return; }
+    now=$(date +%s)
+    for record in "$DISPATCH_DIR"/*.json; do
+        [[ -f "$record" ]] || continue
+        grep -q "\"class\":\"$class\"" "$record" 2>/dev/null || continue
+        # `|| true`: a record missing dispatched_epoch makes grep exit non-zero,
+        # which under the daemon's `set -e`/pipefail would abort the count
+        # mid-scan. Swallow it and let the regex guard below skip the record.
+        epoch=$(grep -o '"dispatched_epoch":[0-9]*' "$record" 2>/dev/null | grep -o '[0-9]*' || true)
+        [[ "$epoch" =~ ^[0-9]+$ ]] || continue
+        age=$(( now - epoch ))
+        if (( age < max_age )); then
             count=$((count + 1))
         fi
     done
@@ -1126,7 +1174,7 @@ build_dispatch_command() {
 resolve_worker_class() {
     local role="$1"
     DISPATCH_CLASS="" DISPATCH_MODEL="" DISPATCH_EFFORT=""
-    DISPATCH_MORE=0 DISPATCH_DEFER=0
+    DISPATCH_MORE=0 DISPATCH_DEFER=0 DISPATCH_COUNT=""
     local lane_default="${WORKER_LANE_DEFAULT_CLASS[$role]:-}"
     [[ -n "$lane_default" ]] || return 0
     local slice="$STATE_DIR/projections/$role.json"
@@ -1143,12 +1191,16 @@ resolve_worker_class() {
         return 0
     fi
     [[ -n "$out" ]] || return 0
-    local cls effort more
-    read -r cls effort more <<< "$out"
+    local cls effort more count
+    read -r cls effort more count <<< "$out"
     DISPATCH_CLASS="$cls"
     DISPATCH_MODEL="${CLASS_MODEL[$cls]:-}"
     DISPATCH_EFFORT="$effort"
     DISPATCH_MORE="${more:-0}"
+    # Claimable count of the elected class — caps the fan-out (see dispatch_role).
+    # Older slices / the '' fallthrough leave it empty (uncapped). Validate so a
+    # malformed value can't corrupt the cap arithmetic under `set -u`.
+    [[ "$count" =~ ^[0-9]+$ ]] && DISPATCH_COUNT="$count"
 }
 
 dispatch_role() {
@@ -1236,10 +1288,48 @@ dispatch_role() {
     fi
     unset "CAP_DEFER_LOGGED[$role-noclaim]"
 
+    # Claimable-count fan-out cap. The resolver reports how many items of the
+    # elected class are claimable right now (DISPATCH_COUNT — set only for a
+    # worker lane that routed a class). Launch at most that many workers, minus
+    # the ones already dispatched recently enough to still be racing for the
+    # same items (count_recent_active_for_class within the settle window). This
+    # is what stops the lane firing a worker into every idle pane when only one
+    # or two tasks are actually claimable — the surplus panes would iterate and
+    # exit on no-op claims, and a no-op opus iteration is not free. An empty
+    # DISPATCH_COUNT (older slice, the '' lane-default fallthrough, or a
+    # non-worker role) means uncapped: preserve the legacy fan-out-to-all-panes.
+    local claim_headroom=-1   # -1 = uncapped
+    if [[ -n "$DISPATCH_CLASS" && -n "$DISPATCH_COUNT" ]]; then
+        local class_racing
+        class_racing=$(count_recent_active_for_class "$DISPATCH_CLASS" "$CLAIM_SETTLE_SECONDS")
+        claim_headroom=$(( DISPATCH_COUNT - class_racing ))
+        if (( claim_headroom < 0 )); then
+            claim_headroom=0
+        fi
+        if (( claim_headroom == 0 )); then
+            # Every claimable item of this class already has a still-settling
+            # worker racing for it. Keep the trigger so a later tick re-evaluates
+            # once those workers claim (the tasks leave tasks_open and the count
+            # drops) or settle out of the race window; dispatch nothing now.
+            if [[ -z "${CAP_DEFER_LOGGED[$role-claimcap]+x}" ]]; then
+                log "$role: class=$DISPATCH_CLASS claimable=$DISPATCH_COUNT already covered by $class_racing in-flight; deferring trigger"
+                CAP_DEFER_LOGGED["$role-claimcap"]=1
+            fi
+            return
+        fi
+        unset "CAP_DEFER_LOGGED[$role-claimcap]"
+    fi
+
     local dispatched=0
     local gap_blocked=""
     while IFS= read -r pane_id; do
         [[ -n "$pane_id" ]] || continue
+        # Claimable-count cap: stop once this tick's launches have filled the
+        # class's remaining claimable headroom. Extra idle panes would only
+        # no-op claim. claim_headroom<0 is the uncapped (legacy) path.
+        if (( claim_headroom >= 0 && dispatched >= claim_headroom )); then
+            break
+        fi
         # Skip panes that already have an in-flight dispatch record.
         # This handles the case where a pane reports `zsh` transiently
         # between tool calls — the record says it's still busy and we
@@ -1559,11 +1649,20 @@ try:
 except (OSError, json.JSONDecodeError):
     raise SystemExit(0)
 
-# Predicate: at least one task that is unowned, unblocked, and matches
-# a class this lane serves. The projection's `blocked_by` is rendered as
-# "(none)" (literal) when there are no blockers.
+# Predicate: at least one task that is unowned, unblocked, NOT already covered
+# by an open implementation PR, and matches a class this lane serves. The
+# projection's `blocked_by` is rendered as "(none)" (literal) when there are no
+# blockers. The `inflight_pr` guard mirrors the dispatch-time claimability gate
+# (fleet_task_class._task_claimable): a queued task whose own issue already has
+# an open PR — typically a parked design-blocked one that released its issue
+# claim — looks owner-free + unblocked here but a fresh worker would refuse it
+# on sight. Without this guard the safety re-arm fires every interval on such a
+# task, fanning no-op iterations into every idle pane (the #1726 shape, surfaced
+# again by an inflight-only queue), which is exactly what this re-arm must not do.
 def is_actionable(task):
     if task.get("owner") != "free":
+        return False
+    if task.get("inflight_pr"):
         return False
     blocked = (task.get("blocked_by") or "").strip()
     if blocked and blocked != "(none)":
@@ -1662,6 +1761,18 @@ case "${1:-}" in
         count_active_for_role "$2"
         exit 0
         ;;
+    --count-recent-active-class)
+        # Print the count of in-flight dispatches of a model class launched
+        # within <max-age> seconds (the still-racing-to-claim subset that backs
+        # the claimable-count fan-out cap). Used by tests and operator
+        # inspection. Usage: --count-recent-active-class <class> <max-age-secs>
+        if [[ -z "${2:-}" || -z "${3:-}" ]]; then
+            echo "usage: fleet-dispatcher --count-recent-active-class <class> <max-age-secs>" >&2
+            exit 2
+        fi
+        count_recent_active_for_class "$2" "$3"
+        exit 0
+        ;;
     --print-cap)
         # Print configured cap for a role.
         if [[ -z "${2:-}" ]]; then
@@ -1683,14 +1794,15 @@ case "${1:-}" in
     --resolve-class)
         # Test/debug: run the per-task class resolution for a worker lane
         # against the current projection slice and print the verdict:
-        #   "class=<c> model=<m> effort=<e> more=<0|1> defer=<0|1>"
-        # Empty class means the lane-default fallthrough.
+        #   "class=<c> model=<m> effort=<e> more=<0|1> defer=<0|1> count=<n>"
+        # Empty class means the lane-default fallthrough; count is the number of
+        # claimable items of the elected class (empty when class is empty).
         if [[ -z "${2:-}" ]]; then
             echo "usage: fleet-dispatcher --resolve-class <role>" >&2
             exit 2
         fi
         resolve_worker_class "$2"
-        echo "class=$DISPATCH_CLASS model=$DISPATCH_MODEL effort=$DISPATCH_EFFORT more=$DISPATCH_MORE defer=$DISPATCH_DEFER"
+        echo "class=$DISPATCH_CLASS model=$DISPATCH_MODEL effort=$DISPATCH_EFFORT more=$DISPATCH_MORE defer=$DISPATCH_DEFER count=$DISPATCH_COUNT"
         exit 0
         ;;
     --gate-status)

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -203,6 +203,16 @@
 # disable (single-pane / test setups).
 # FLEET_DISPATCH_MIN_GAP_SECONDS=8
 #
+# FLEET_DISPATCHER_CLAIM_SETTLE_SECONDS bounds the claimable-count fan-out cap:
+# the worker lane launches at most one worker per claimable item of the elected
+# class, and a just-dispatched worker counts against that cap only until its
+# dispatch record is this many seconds old (after which it has settled onto
+# claimed work and stops competing for the remaining items). Sized to cover a
+# claude cold start + state read + claim. Raise it if workers routinely take
+# longer to claim (the fleet briefly under-dispatches to remaining slots);
+# lower it if you want freed slots refilled faster. Default 90.
+# FLEET_DISPATCHER_CLAIM_SETTLE_SECONDS=90
+#
 # FLEET_DISPATCHER_RATE429_DELAY is the per-pane cooldown applied after a
 # short-window 429 *failure* (claude exhausted its internal retries). It is
 # deliberately much shorter than FLEET_DISPATCHER_LIMIT_DELAY (the usage /

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -29,21 +29,30 @@ The fable concurrency cap is enforced here by *skipping* fable items when
 the cap is reached — the lane then serves its next non-fable item instead
 of idling. When the only work left is non-actionable — cap-blocked fable,
 tasks already covered by an open implementation PR (``inflight_pr``, #1726),
-or backend-specific tasks this host can't run (``needs_gl_host`` on a
-Metal-only host, #1998) — the verdict is ``defer`` (keep the trigger,
-dispatch nothing) rather than an empty result, so the dispatcher doesn't
-burn an iteration on a lane whose only work a fresh worker would refuse.
+a ``blocked`` task with no valid stackable base (the scout left off
+``stackable_blocker_pr`` because the blocker has no open PR or only a
+parked/conflicting one), or backend-specific tasks this host can't run
+(``needs_gl_host`` on a Metal-only host, #1998) — the verdict is ``defer``
+(keep the trigger, dispatch nothing) rather than an empty result, so the
+dispatcher doesn't burn an iteration on a lane whose only work a fresh
+worker would refuse.
 
 Output protocol (one line on stdout, consumed by fleet-dispatcher):
 
-  ``<class> <effort> <more>``  — dispatch this class; ``more`` is 1 when
+  ``<class> <effort> <more> <count>``
+                                  — dispatch this class; ``more`` is 1 when
                                   claimable items of a *different* class
                                   remain (keep the trigger so the next tick
-                                  serves them), else 0.
+                                  serves them), else 0; ``count`` is the number
+                                  of claimable items OF THIS CLASS right now, so
+                                  the dispatcher can cap its fan-out at one
+                                  worker per claimable item instead of one per
+                                  idle pane.
   ``defer``                     — queue isn't empty but nothing is claimable
                                   right now (only cap-blocked fable, tasks with
-                                  an open implementation PR, or GL-only tasks on
-                                  a non-GL host). Keep the trigger; dispatch
+                                  an open implementation PR, a `blocked` task
+                                  with no valid stackable base, or GL-only tasks
+                                  on a non-GL host). Keep the trigger; dispatch
                                   nothing.
   (empty)                       — nothing class-routable in the slice; the
                                   dispatcher falls back to the lane default
@@ -105,29 +114,55 @@ def _task_claimable(task, host):
     # which was starving lower-class work queued behind it (#1726, the #1640 /
     # design-blocked PR #1700 incident). The `needs_gl_host` clause does the
     # same for backend-specific tasks a Metal-only host can't run (#1998).
-    return (
-        task.get("owner") in (None, "", "free")
-        and not task.get("blocked")
-        and not task.get("inflight_pr")
-        and not _host_incompatible(task, host)
+    #
+    # A `blocked` task is claimable ONLY as a stack on its blocker's PR. The
+    # scout sets `stackable_blocker_pr` exactly when that blocker has a single
+    # open, non-parked, non-conflicting PR to base on — the same gate the
+    # worker's stackable tier would otherwise re-run live. So a blocked task
+    # WITH the field is claimable (stack it) and a blocked task WITHOUT it has
+    # no valid base: a fresh worker refuses it on sight, so it's terminally
+    # unclaimable like an inflight task. Electing it here (rather than dropping
+    # to the '' lane-default fallthrough on any blocked task) is what stops the
+    # dispatcher firing no-op iterations whose only "work" is re-deriving the
+    # not-stackable verdict the scout already reached.
+    if task.get("owner") not in (None, "", "free"):
+        return False
+    if task.get("inflight_pr") or _host_incompatible(task, host):
+        return False
+    if task.get("blocked"):
+        return bool(task.get("stackable_blocker_pr"))
+    return True
+
+
+def _terminally_unclaimable(task, host):
+    """True when no dispatch can ever let a fresh worker claim this task as it
+    stands: an open PR already implements it (`inflight_pr`), this host can't
+    build/run/verify it (`needs_gl_host` on a non-GL host, #1998), or it's
+    `blocked` with no valid stackable base (the scout omits
+    `stackable_blocker_pr` when the blocker has no open PR or only a
+    parked/conflicting one). Each clears only via a merge, a host change, or a
+    design answer — never via dispatching a worker — so a queue of only these is
+    a no-op to dispatch into."""
+    return bool(
+        task.get("inflight_pr")
+        or _host_incompatible(task, host)
+        or (task.get("blocked") and not task.get("stackable_blocker_pr"))
     )
 
 
 def _only_unclaimable_tasks(slice_data, host):
-    """True when tasks_open is non-empty and EVERY item is non-actionable for a
-    *terminal* reason — an open PR already implements it (`inflight_pr`) or this
-    host can't build/run/verify it (`needs_gl_host` on a non-GL host, #1998).
+    """True when tasks_open is non-empty and EVERY item is terminally
+    unclaimable (see `_terminally_unclaimable`).
 
     Used to pick 'go quiet' (defer) over the lane-default dispatch fallthrough:
     in this shape a fresh worker can claim nothing, so a dispatch is a no-op.
-    Requiring *all* items to be terminally-unclaimable keeps a mixed slice (a
-    terminal head plus a stackable `blocked` but host-compatible task behind it)
-    on the '' fallthrough so the worker's stackable tier still gets its dispatch.
-    """
+    Requiring *all* items to be terminal keeps a mixed slice — a terminal head
+    plus an owner-held or otherwise non-terminal task — on the '' fallthrough so
+    reservation resumes and the like still get their dispatch. A genuinely
+    stackable `blocked` task is NOT terminal (it carries `stackable_blocker_pr`)
+    and is elected as a candidate above, so it never reaches this gate."""
     tasks = slice_data.get("tasks_open") or []
-    return bool(tasks) and all(
-        t.get("inflight_pr") or _host_incompatible(t, host) for t in tasks
-    )
+    return bool(tasks) and all(_terminally_unclaimable(t, host) for t in tasks)
 
 
 def feedback_pr_class(labels):
@@ -156,32 +191,47 @@ def feedback_pr_class(labels):
 def _candidates(slice_data, lane_default, host):
     """Yield (class, effort) for each actionable item, pickup-priority order.
 
-    Feedback PRs come first regardless of count — mirrors the worker role
-    docs, which fix review feedback before claiming new queue work.
+    Feedback PRs come first (the worker fixes review feedback before new work),
+    then unblocked open tasks, then stackable `blocked` tasks (a fallback tier,
+    claimable only as a stack on the blocker's PR), then needs_plan. This
+    mirrors the worker role docs so the *elected* class matches what the worker
+    actually picks up, and one yield per item lets the caller count claimable
+    work per class for the dispatcher's fan-out cap.
+
+    needs_plan yields once regardless of how many issues await planning:
+    planning has no claim lock (sibling panes would re-plan the same issue), so
+    the lane plans one at a time — the next planner fires after the first opens
+    its plan-doc PR.
     """
-    for pr in slice_data.get("feedback_prs", []) or []:
-        cls = feedback_pr_class(pr.get("labels", []))
-        yield cls, CLASS_DEFAULT_EFFORT[cls]
-    for task in slice_data.get("tasks_open", []) or []:
-        if not _task_claimable(task, host):
-            continue
+    def _class_effort(task):
         cls = (task.get("model") or lane_default).lower()
         if cls not in CLASS_DEFAULT_EFFORT:
             cls = lane_default
-        effort = task.get("effort") or CLASS_DEFAULT_EFFORT[cls]
-        yield cls, effort
+        return cls, task.get("effort") or CLASS_DEFAULT_EFFORT[cls]
+
+    for pr in slice_data.get("feedback_prs", []) or []:
+        cls = feedback_pr_class(pr.get("labels", []))
+        yield cls, CLASS_DEFAULT_EFFORT[cls]
+    tasks = slice_data.get("tasks_open", []) or []
+    for task in tasks:
+        if _task_claimable(task, host) and not task.get("blocked"):
+            yield _class_effort(task)
+    for task in tasks:
+        if _task_claimable(task, host) and task.get("blocked"):
+            yield _class_effort(task)
     if slice_data.get("needs_plan"):
         yield "opus", CLASS_DEFAULT_EFFORT["opus"]
 
 
 def resolve(slice_data, lane_default, fable_blocked):
-    """Return 'cls effort more', 'defer', or '' per the output protocol."""
+    """Return 'cls effort more count', 'defer', or '' per the output protocol."""
     if lane_default not in CLASS_DEFAULT_EFFORT:
         lane_default = "opus"
     host = _current_host()
     chosen = None
     skipped_fable = False
     servable_classes = set()
+    class_counts = {}
     for cls, effort in _candidates(slice_data, lane_default, host):
         if cls == "fable" and fable_blocked:
             # Cap-blocked fable is not currently servable: don't let it
@@ -193,11 +243,18 @@ def resolve(slice_data, lane_default, fable_blocked):
             skipped_fable = True
             continue
         servable_classes.add(cls)
+        class_counts[cls] = class_counts.get(cls, 0) + 1
         if chosen is None:
             chosen = (cls, effort)
     if chosen is not None:
         more = 1 if servable_classes - {chosen[0]} else 0
-        return f"{chosen[0]} {chosen[1]} {more}"
+        # `count` = claimable items of the elected class right now. The
+        # dispatcher caps its idle-pane fan-out to this so it never spins up
+        # more workers of a class than there is work for them to claim (the
+        # surplus would only iterate-and-exit, a no-op opus iteration is not
+        # free). `more` still drives the *other-class* follow-up dispatch.
+        count = class_counts[chosen[0]]
+        return f"{chosen[0]} {chosen[1]} {more} {count}"
     if skipped_fable:
         return "defer"
     # Nothing servable AND no cap-blocked fable. If the queue's only content is

--- a/scripts/fleet/tests/test_dispatcher_claimable_cap.sh
+++ b/scripts/fleet/tests/test_dispatcher_claimable_cap.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Tests for the claimable-count fan-out cap's racing-worker counter,
+# fleet-dispatcher's count_recent_active_for_class (exposed via the
+# --count-recent-active-class hook).
+#
+# The dispatcher caps its idle-pane fan-out at one worker per claimable item of
+# the elected class. The headroom is `claimable - racing`, where `racing` is the
+# count of in-flight dispatches of that class young enough to still be competing
+# to claim (dispatch record younger than the settle window). A worker past the
+# window has settled onto claimed work and must NOT count — that's what keeps
+# the cap from serializing independent tasks. This file pins that age-window
+# behaviour:
+#   - no records -> 0
+#   - a just-dispatched worker counts (age < window)
+#   - a settled worker does NOT count (age >= window)
+#   - per-class isolation (opus racing count ignores sonnet/fable records)
+#   - a record missing dispatched_epoch is skipped (defensive, not crash)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+
+if [[ ! -x "$DISPATCHER" ]]; then
+    echo "test setup: fleet-dispatcher not found at $DISPATCHER" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_SESSION="fleet-test-$$"
+DISPATCH_DIR="$FLEET_STATE_DIR/dispatch"
+mkdir -p "$DISPATCH_DIR"
+
+NOW=$(date +%s)
+
+# Write a dispatch record for a pane with a given class and age (seconds ago).
+write_record() {
+    local pane="$1" class="$2" age="$3" epoch
+    epoch=$(( NOW - age ))
+    printf '{"role":"worker","pane":"%%%s","class":"%s","dispatched_at":"x","dispatched_epoch":%s}\n' \
+        "$pane" "$class" "$epoch" > "$DISPATCH_DIR/pane-$pane.json"
+}
+
+recent() {
+    "$DISPATCHER" --count-recent-active-class "$1" "$2"
+}
+
+# --- T1: no records -> 0 -----------------------------------------------------
+echo "T1: empty dispatch dir"
+assert_eq "$(recent opus 90)" "0" "no records -> 0 racing"
+
+# --- T2: a just-dispatched worker counts -------------------------------------
+echo "T2: fresh dispatch inside the window counts"
+write_record 0 opus 5
+assert_eq "$(recent opus 90)" "1" "age 5s < 90s window -> counts as racing"
+
+# --- T3: a settled worker (past window) does NOT count -----------------------
+echo "T3: settled dispatch past the window is excluded"
+write_record 1 opus 300
+assert_eq "$(recent opus 90)" "1" "age 300s >= 90s window -> excluded; only the fresh one counts"
+# At the boundary the older one is still out (300 != <90), proven above. Now a
+# wider window should sweep it back in:
+assert_eq "$(recent opus 600)" "2" "widen window to 600s -> both opus records count"
+
+# --- T4: per-class isolation -------------------------------------------------
+echo "T4: racing count is per class"
+write_record 2 sonnet 5
+write_record 3 fable 5
+assert_eq "$(recent opus 90)" "1" "sonnet/fable young records do not inflate opus racing"
+assert_eq "$(recent sonnet 90)" "1" "sonnet racing counted independently"
+assert_eq "$(recent fable 90)" "1" "fable racing counted independently"
+assert_eq "$(recent opus 0)" "0" "zero window -> nothing is 'recent'"
+
+# --- T5: malformed record (no dispatched_epoch) is skipped, not fatal --------
+echo "T5: record missing dispatched_epoch is skipped"
+printf '{"role":"worker","pane":"%%8","class":"opus","dispatched_at":"x"}\n' \
+    > "$DISPATCH_DIR/pane-8.json"
+assert_eq "$(recent opus 90)" "1" "epoch-less opus record skipped; fresh one still counts"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
+++ b/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
@@ -71,7 +71,7 @@ resolve() {
 echo "T1: fable task resolves to fable model"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
 assert_eq "$(resolve worker)" \
-    "class=fable model=claude-fable-5[1m] effort=xhigh more=0 defer=0" \
+    "class=fable model=claude-fable-5[1m] effort=xhigh more=0 defer=0 count=1" \
     "uncapped fable task dispatches on fable at xhigh"
 
 # --- T2: fable cap reached -> next non-fable task ---------------------------
@@ -80,14 +80,14 @@ write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,
 printf '{"role":"worker","pane":"%%9","class":"fable","dispatched_at":"x"}\n' \
     > "$FLEET_STATE_DIR/dispatch/pane-9.json"
 assert_eq "$(resolve worker)" \
-    "class=opus model=claude-opus-4-8[1m] effort=xhigh more=0 defer=0" \
+    "class=opus model=claude-opus-4-8[1m] effort=xhigh more=0 defer=0 count=1" \
     "capped fable skipped; opus task served; cap-blocked fable does NOT hold the trigger (more=0)"
 
 # --- T3: only capped fable work -> defer -------------------------------------
 echo "T3: only cap-blocked fable work defers"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"fable","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
 out=$(resolve worker)
-assert_eq "$out" "class= model= effort= more=0 defer=1" \
+assert_eq "$out" "class= model= effort= more=0 defer=1 count=" \
     "cap-blocked fable-only slice -> defer (no lane-default burn)"
 rm -f "$FLEET_STATE_DIR/dispatch/pane-9.json"
 
@@ -95,25 +95,25 @@ rm -f "$FLEET_STATE_DIR/dispatch/pane-9.json"
 echo "T4: Effort: override threads through"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":"medium","owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
 assert_eq "$(resolve worker)" \
-    "class=opus model=claude-opus-4-8[1m] effort=medium more=0 defer=0" \
+    "class=opus model=claude-opus-4-8[1m] effort=medium more=0 defer=0 count=1" \
     "task-level Effort: medium beats the class default"
 
 # --- T5: feedback severity routing -------------------------------------------
 echo "T5: nits-only feedback routes sonnet ahead of queued tasks"
 write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false}],"feedback_prs":[{"number":50,"labels":["fleet:approved","fleet:has-nits"]}],"needs_plan":[]}'
 assert_eq "$(resolve worker)" \
-    "class=sonnet model=sonnet effort=high more=1 defer=0" \
+    "class=sonnet model=sonnet effort=high more=1 defer=0 count=1" \
     "has-nits feedback dispatches sonnet; opus task keeps the trigger"
 
 # --- T6: empty slice -> lane default fallthrough ------------------------------
 echo "T6: empty slice falls through to lane default"
 write_slice worker '{"tasks_open":[],"feedback_prs":[],"needs_plan":[]}'
-assert_eq "$(resolve worker)" "class= model= effort= more=0 defer=0" \
+assert_eq "$(resolve worker)" "class= model= effort= more=0 defer=0 count=" \
     "empty slice -> lane-default dispatch (reservation-resume path)"
 
 # --- T7: non-worker role is a no-op ------------------------------------------
 echo "T7: non-worker roles skip class resolution"
-assert_eq "$(resolve merger)" "class= model= effort= more=0 defer=0" \
+assert_eq "$(resolve merger)" "class= model= effort= more=0 defer=0 count=" \
     "merger has no lane class; resolution is a no-op"
 
 echo

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -5,18 +5,26 @@ work it's serving (a claude process can't change model/effort after
 launch), so this resolution IS the per-task model routing. The invariants
 that matter:
 
-  - pickup priority mirrors the role docs: feedback PRs, then open tasks
-    (oldest first — slices arrive sorted), then needs_plan;
+  - pickup priority mirrors the role docs: feedback PRs, then unblocked open
+    tasks (oldest first — slices arrive sorted), then stackable `blocked`
+    tasks, then needs_plan;
   - feedback class derives from review severity labels (fable opt-in via
     fleet:fable on the PR, blocking labels -> opus, nits-only -> sonnet);
   - the fable concurrency cap skips fable items rather than idling the
     lane, and yields ``defer`` (keep trigger, dispatch nothing) when ONLY
     cap-blocked fable work remains — an empty result would dispatch the
     lane default, which the claim gate then refuses, burning an iteration;
+  - a `blocked` task is claimable ONLY as a stack on its blocker's PR: it
+    carries `stackable_blocker_pr` (set by the scout) when that base is valid,
+    and a blocked task WITHOUT it is terminally unclaimable like `inflight_pr`,
+    so a queue of only such tasks defers instead of falling through to a
+    lane-default no-op dispatch;
   - a GL-only task (``needs_gl_host``) is unclaimable on a Metal-only host —
-    skipped like ``inflight_pr``, and the lane defers when it's the only
+    terminal like `inflight_pr`, and the lane defers when it's the only
     work (#1998, the GL-vs-Metal host-capability gate);
   - per-task **Effort:** overrides beat class defaults;
+  - the output carries a trailing ``count`` = claimable items of the elected
+    class, which the dispatcher uses to cap its idle-pane fan-out;
   - an empty/unroutable slice falls through to the lane default (covers
     reservation resumes and missing slices).
 """
@@ -30,10 +38,11 @@ from fleet_task_class import feedback_pr_class, resolve  # noqa: E402
 
 
 def _task(issue, model=None, effort=None, owner="free", blocked=False,
-          inflight_pr=None, needs_gl_host=False):
+          inflight_pr=None, needs_gl_host=False, stackable_blocker_pr=None):
     return {"issue": issue, "model": model, "effort": effort,
             "owner": owner, "blocked": blocked, "inflight_pr": inflight_pr,
-            "needs_gl_host": needs_gl_host}
+            "needs_gl_host": needs_gl_host,
+            "stackable_blocker_pr": stackable_blocker_pr}
 
 
 class FeedbackClassFromLabels(unittest.TestCase):
@@ -69,27 +78,37 @@ class TaskResolution(unittest.TestCase):
         out = resolve({"tasks_open": [_task("#10", "sonnet"),
                                       _task("#11", "fable")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "sonnet high 1")  # fable still queued -> more=1
+        # fable still queued -> more=1; one claimable sonnet item -> count=1.
+        self.assertEqual(out, "sonnet high 1 1")
 
     def test_effort_override_beats_class_default(self):
         out = resolve({"tasks_open": [_task("#10", "opus", effort="medium")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "opus medium 0")
+        self.assertEqual(out, "opus medium 0 1")
 
     def test_untagged_task_uses_lane_default(self):
         out = resolve({"tasks_open": [_task("#10", None)]},
                       "sonnet", fable_blocked=False)
-        self.assertEqual(out, "sonnet high 0")
+        self.assertEqual(out, "sonnet high 0 1")
+
+    def test_count_reflects_claimable_items_of_class(self):
+        # Three unblocked opus tasks + one sonnet: the elected opus class
+        # reports count=3 (the dispatcher caps its fan-out at 3 opus workers),
+        # and more=1 because the sonnet item is a different servable class.
+        out = resolve({"tasks_open": [_task("#10", "opus"), _task("#11", "opus"),
+                                      _task("#12", "opus"), _task("#13", "sonnet")]},
+                      "opus", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 1 3")
 
     def test_owned_and_blocked_tasks_skipped(self):
         # Owned/blocked tasks are invisible: they don't dispatch AND they
-        # don't count toward `more` (an unclaimable class is no reason to
-        # hold the trigger open).
+        # don't count toward `more` or `count` (an unclaimable class is no
+        # reason to hold the trigger open or inflate the fan-out cap).
         out = resolve({"tasks_open": [_task("#10", "fable", owner="worker-1"),
                                       _task("#11", "opus", blocked=True),
                                       _task("#12", "opus")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 0")
+        self.assertEqual(out, "opus xhigh 0 1")
 
     def test_inflight_pr_task_skipped_fable_behind_dispatches(self):
         # #1726 / the #1640 incident: a head-of-queue opus task whose own issue
@@ -101,7 +120,7 @@ class TaskResolution(unittest.TestCase):
             _task("#1640", "opus", inflight_pr={"number": 1700, "parked": True}),
             _task("#1695", "fable"),
         ]}, "opus", fable_blocked=False)
-        self.assertEqual(out, "fable xhigh 0")
+        self.assertEqual(out, "fable xhigh 0 1")
 
     def test_inflight_pr_only_candidate_defers(self):
         # The parked task is the ONLY queue item: nothing a fresh worker can
@@ -112,15 +131,39 @@ class TaskResolution(unittest.TestCase):
         ]}, "opus", fable_blocked=False)
         self.assertEqual(out, "defer")
 
-    def test_inflight_head_with_blocked_stackable_falls_through(self):
-        # Mixed slice: inflight head + a plain `blocked` task that may still be
-        # stackable. Must NOT defer — '' lets the dispatcher's lane-default
-        # fallthrough reach the worker's stackable tier for the blocked task.
+    def test_inflight_head_with_nonstackable_blocked_defers(self):
+        # Mixed slice: an inflight head + a plain `blocked` task with NO valid
+        # stackable base (scout left off `stackable_blocker_pr`). Both are
+        # terminally unclaimable for a fresh worker, so the lane defers rather
+        # than firing a lane-default worker whose only "work" is re-deriving the
+        # not-stackable verdict the scout already reached (the idle-fleet churn
+        # this fix targets — opus panes dispatched with nothing to claim).
         out = resolve({"tasks_open": [
             _task("#1640", "opus", inflight_pr={"number": 1700, "parked": True}),
             _task("#1641", "opus", blocked=True),
         ]}, "opus", fable_blocked=False)
-        self.assertEqual(out, "")
+        self.assertEqual(out, "defer")
+
+    def test_stackable_blocked_task_is_elected(self):
+        # A `blocked` task WITH a scout-confirmed stackable base is claimable
+        # (stack it on the blocker's PR): elected as a candidate, with its own
+        # class and a count of 1 — not dropped to the '' fallthrough.
+        out = resolve({"tasks_open": [
+            _task("#1640", "opus", inflight_pr={"number": 1700, "parked": True}),
+            _task("#1641", "opus", blocked=True,
+                  stackable_blocker_pr={"number": 1638}),
+        ]}, "opus", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 0 1")
+
+    def test_unblocked_elected_before_stackable(self):
+        # Pickup priority: an unblocked task outranks a stackable `blocked` one
+        # for class election even when the blocked task appears first in the
+        # slice. Both opus here, so the distinction shows in count (2 claimable).
+        out = resolve({"tasks_open": [
+            _task("#10", "opus", blocked=True, stackable_blocker_pr={"number": 9}),
+            _task("#11", "opus"),
+        ]}, "opus", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 0 2")
 
     def test_inflight_pr_head_with_capped_fable_defers(self):
         # Head parked (skipped), only remaining work is cap-blocked fable ->
@@ -136,25 +179,35 @@ class TaskResolution(unittest.TestCase):
         out = resolve({"feedback_prs": [{"labels": ["fleet:has-nits"]}],
                        "tasks_open": [_task("#10", "opus")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "sonnet high 1")
+        self.assertEqual(out, "sonnet high 1 1")
 
     def test_needs_plan_runs_opus(self):
         out = resolve({"needs_plan": [{"number": 99}]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 0")
+        self.assertEqual(out, "opus xhigh 0 1")
+
+    def test_needs_plan_counts_once_regardless_of_backlog(self):
+        # Planning has no claim lock, so the lane plans one issue at a time:
+        # multiple needs_plan issues still yield a single opus candidate ->
+        # count=1 (no fan-out of colliding planners).
+        out = resolve({"needs_plan": [{"number": 99}, {"number": 100},
+                                      {"number": 101}]},
+                      "opus", fable_blocked=False)
+        self.assertEqual(out, "opus xhigh 0 1")
 
     def test_design_unblocked_feedback_resolves_opus(self):
         # The engine #1885 shape: a design-unblocked PR is the top feedback
         # item, every open task is parked/blocked, and opus needs_plan sits
         # behind it. The lane must dispatch opus (and clear it for tier 4),
         # not sonnet — pre-fix this resolved "sonnet ... 1" and starved both.
+        # count=2: the feedback fix plus the plannable issue are both opus work.
         out = resolve({
             "feedback_prs": [{"labels": ["fleet:design-unblocked", "fleet:wip"]}],
             "tasks_open": [_task("#1882", "opus",
                                  inflight_pr={"number": 1885, "parked": True})],
             "needs_plan": [{"number": 1887}],
         }, "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 0")
+        self.assertEqual(out, "opus xhigh 0 2")
 
 
 class FableCap(unittest.TestCase):
@@ -165,7 +218,7 @@ class FableCap(unittest.TestCase):
         out = resolve({"tasks_open": [_task("#10", "fable"),
                                       _task("#11", "opus")]},
                       "opus", fable_blocked=True)
-        self.assertEqual(out, "opus xhigh 0")
+        self.assertEqual(out, "opus xhigh 0 1")
 
     def test_only_capped_fable_defers(self):
         out = resolve({"tasks_open": [_task("#10", "fable")]},
@@ -175,7 +228,7 @@ class FableCap(unittest.TestCase):
     def test_uncapped_fable_dispatches_xhigh(self):
         out = resolve({"tasks_open": [_task("#10", "fable")]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "fable xhigh 0")
+        self.assertEqual(out, "fable xhigh 0 1")
 
 
 class EmptySlice(unittest.TestCase):
@@ -183,6 +236,14 @@ class EmptySlice(unittest.TestCase):
         self.assertEqual(resolve({}, "opus", fable_blocked=False), "")
         self.assertEqual(resolve({"tasks_open": [], "feedback_prs": []},
                                  "sonnet", fable_blocked=False), "")
+
+    def test_only_owned_task_falls_through(self):
+        # An owner-held task is non-terminal (a reservation resume may still
+        # need a lane-default dispatch), so it keeps the slice on '' rather
+        # than deferring — distinct from the terminal inflight/blocked cases.
+        out = resolve({"tasks_open": [_task("#10", "opus", owner="worker-1")]},
+                      "opus", fable_blocked=False)
+        self.assertEqual(out, "")
 
 
 class GlHostGate(unittest.TestCase):
@@ -216,12 +277,12 @@ class GlHostGate(unittest.TestCase):
     def test_gl_only_task_claimable_on_linux(self):
         out = self._resolve_on(
             "linux", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
-        self.assertEqual(out, "opus xhigh 0")
+        self.assertEqual(out, "opus xhigh 0 1")
 
     def test_gl_only_task_claimable_on_windows(self):
         out = self._resolve_on(
             "windows", {"tasks_open": [_task("#1937", "opus", needs_gl_host=True)]})
-        self.assertEqual(out, "opus xhigh 0")
+        self.assertEqual(out, "opus xhigh 0 1")
 
     def test_mixed_mac_slice_dispatches_claimable_no_churn(self):
         # GL-only #1937-shaped head + a claimable opus task: the mac pane skips
@@ -231,7 +292,7 @@ class GlHostGate(unittest.TestCase):
             _task("#1937", "opus", needs_gl_host=True),
             _task("#1998", "opus"),
         ]})
-        self.assertEqual(out, "opus xhigh 0")
+        self.assertEqual(out, "opus xhigh 0 1")
 
     def test_gl_only_plus_inflight_only_on_mac_defers(self):
         # All-terminal mix on a mac pane: one GL-only (host-terminal) + one
@@ -242,15 +303,25 @@ class GlHostGate(unittest.TestCase):
         ]})
         self.assertEqual(out, "defer")
 
-    def test_gl_only_head_with_blocked_compatible_falls_through(self):
-        # GL-only head (host-terminal on mac) + a plain `blocked` but
-        # host-compatible task that may still be stackable -> '' so the
-        # worker's stackable tier still gets its lane-default dispatch.
+    def test_gl_only_head_with_nonstackable_blocked_defers(self):
+        # GL-only head (host-terminal on mac) + a plain `blocked` host-compatible
+        # task with no stackable base. Both terminal -> defer (no lane-default
+        # no-op for the not-stackable blocked task).
         out = self._resolve_on("mac", {"tasks_open": [
             _task("#1937", "opus", needs_gl_host=True),
             _task("#1941", "opus", blocked=True),
         ]})
-        self.assertEqual(out, "")
+        self.assertEqual(out, "defer")
+
+    def test_gl_only_head_with_stackable_blocked_dispatches(self):
+        # GL-only head (host-terminal on mac) + a `blocked` host-compatible task
+        # WITH a stackable base -> the stackable task is claimable and elected.
+        out = self._resolve_on("mac", {"tasks_open": [
+            _task("#1937", "opus", needs_gl_host=True),
+            _task("#1941", "opus", blocked=True,
+                  stackable_blocker_pr={"number": 1900}),
+        ]})
+        self.assertEqual(out, "opus xhigh 0 1")
 
     def test_unknown_host_is_fail_closed(self):
         # Fail-closed: an unrecognized host is treated as not GL-capable, so a


### PR DESCRIPTION
## Summary

Stops the worker dispatcher from spinning up opus workers when there is nothing for them to claim, and caps the fan-out to the number of claimable tasks instead of the number of idle panes. Both were burning no-op opus iterations (each a full cold-start queue read).

**Symptom observed:** all worker panes idle, yet every ~5 min the dispatcher re-armed and fanned a worker into each pane; they read the queue, found nothing claimable, and returned to shell — repeat forever. The queue's only "open" tasks were all (a) already covered by an open implementation PR (`inflight_pr`) or (b) `blocked` with no genuinely stackable base.

### A. False-positive dispatch — two leaks

1. **Periodic re-arm** (`is_actionable`, `fleet-dispatcher`): ignored `inflight_pr`, so a queue of only tasks-with-open-PRs (which look `owner:free` + `blocked_by:(none)`) re-armed the trigger every interval. Now mirrors the dispatch-time claimability gate.
2. **Class resolver** (`fleet_task_class.py`): returned `''` (→ lane-default dispatch) whenever *any* `blocked` task was present, on the theory it might be stackable. But the scout already computes real stackability into `stackable_blocker_pr` (filtering parked / wip / design-blocked bases). The resolver now treats a blocked task as claimable **only** when that field is set, so an all-inflight / all-non-stackable queue **defers** instead of dispatching a worker just to re-derive "not stackable".

### B. Fan-out cap

The resolver now reports the claimable-item count of the elected class (4th output field). The dispatcher launches at most that many workers, minus those dispatched recently enough to still be racing to claim (`count_recent_active_for_class` within `FLEET_DISPATCHER_CLAIM_SETTLE_SECONDS`, default 90s). Age-aware: a worker already settled on claimed work stops counting, so the cap never serializes two independent tasks the way a plain active-count cap would.

## Test plan

- [x] `tests/test_fleet_task_class.py` — 33 tests (stackable-aware claimability, terminal-defer, `count` field) pass
- [x] `tests/test_dispatcher_claimable_cap.sh` — new; racing-window counter (age window, per-class isolation, malformed-record skip)
- [x] `tests/test_dispatcher_class_dispatch.sh` — updated for the `count=` field, 7/7 pass
- [x] Reproduced the original 8-task all-dead queue → resolver now returns `defer` (was `''`)
- [x] Full suite green except pre-existing flakes (`concurrency_cap` T4c macOS host-flake; `validate_roles` role-doc drift — both fail identically on master)

## Deploy note

The running dispatcher is a long-lived daemon executing the old script; it must be **restarted** after merge + clone-advance to pick up these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)