### PR TITLE
fleet: architect resume drops the startup nudge prompt

### DIFF
--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -437,11 +437,19 @@ run_with_heartbeat() {
 #     signal, not "agent is unhealthy, retry".
 
 launch_architect_first() {
+    local -a cmd
     if [[ -f "$SESSION_FILE" ]]; then
         SESSION_ID=$(cat "$SESSION_FILE")
         log "resuming architect session $SESSION_ID (preserved across fleet restart)"
-        claude --model "$MODEL" --effort "$EFFORT" --resume "$SESSION_ID" \
-            "fleet just restarted. resume our previous conversation; you don't need to re-run your startup banner. tell me what you were last working on so we can continue."
+        # Resume with NO trailing prompt: load the prior conversation and drop
+        # the human straight back into it, generating no model turn. The old
+        # behaviour fired a "tell me what you were last working on" nudge here,
+        # which cost a full model turn per architect on every fleet-up — pure
+        # cold-start token + request burn that fed the startup short-window 429
+        # burst — for nothing the human couldn't get by reading the resumed
+        # transcript. An interactive --resume with no prompt just waits for
+        # input.
+        cmd=(claude --model "$MODEL" --effort "$EFFORT" --resume "$SESSION_ID")
     else
         # Generate and persist a stable session ID so subsequent
         # fleet-ups can resume this conversation. Persist BEFORE
@@ -450,9 +458,19 @@ launch_architect_first() {
         SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())')
         echo "$SESSION_ID" > "$SESSION_FILE"
         log "starting architect session $SESSION_ID (saved to $SESSION_FILE)"
-        claude --model "$MODEL" --effort "$EFFORT" --session-id "$SESSION_ID" \
-            "/role-$ROLE $MODE"
+        cmd=(claude --model "$MODEL" --effort "$EFFORT" --session-id "$SESSION_ID" \
+            "/role-$ROLE $MODE")
     fi
+    if [[ -n "${FLEET_BABYSIT_PRINT_LAUNCH:-}" ]]; then
+        # Inspection hook (mirrors FLEET_BABYSIT_PRINT_EFFORT): print the
+        # resolved launch command and exit before spawning claude. Lets
+        # test_babysit_launch.sh assert the resume path carries no prompt.
+        # Safe to exit here — architects start no heartbeat keeper (see
+        # HEARTBEAT_FILE), so there's no background process to leak.
+        printf '%s\n' "${cmd[*]}"
+        exit 0
+    fi
+    "${cmd[@]}"
 }
 
 launch_worker_fresh() {

--- a/scripts/fleet/fleet-babysit
+++ b/scripts/fleet/fleet-babysit
@@ -520,6 +520,7 @@ resume_mid_task() {
     # "step 0.5"; reviewers are read-only and just re-review) and carries on.
     # The crashed session's in-context scratch is lost, but the task is not.
     if [[ "$ARCHITECT_RESUME" -eq 1 && -f "$SESSION_FILE" ]]; then
+        # Crash recovery — not fleet restart; the prompt signals mid-task continuity, not cold-start burn.
         claude --model "$MODEL" --effort "$EFFORT" --resume "$(cat "$SESSION_FILE")" \
             "resume your work from where you left off"
     else

--- a/scripts/fleet/solo-architect
+++ b/scripts/fleet/solo-architect
@@ -109,10 +109,13 @@ if [[ -s "$SESSION_FILE" && "$FRESH" -eq 0 ]]; then
   SID="$(cat "$SESSION_FILE")"
   echo "solo-architect: resuming $ROLE session $SID (cwd $WORKTREE)" >&2
   echo "  (if the session can't be resumed, re-run with --fresh)" >&2
+  # Resume with NO trailing prompt — load the conversation and wait for input,
+  # generating no model turn. The old "tell me what we were last working on"
+  # nudge bought nothing (the transcript is right there) and cost a full turn
+  # on every relaunch; same reasoning as fleet-babysit's launch_architect_first.
   exec claude --model "$MODEL" --effort "$EFFORT" \
     --append-system-prompt "$SOLO_PROMPT" \
-    --resume "$SID" "${PASSTHRU[@]+"${PASSTHRU[@]}"}" \
-    "resuming our solo session — you don't need to re-run the full startup banner. tell me what we were last working on so we can continue."
+    --resume "$SID" "${PASSTHRU[@]+"${PASSTHRU[@]}"}"
 else
   SID="$(uuidgen | tr 'A-Z' 'a-z')"
   echo "$SID" > "$SESSION_FILE"

--- a/scripts/fleet/tests/test_babysit_launch.sh
+++ b/scripts/fleet/tests/test_babysit_launch.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Tests for fleet-babysit's architect launch command (launch_architect_first),
+# exercised through the FLEET_BABYSIT_PRINT_LAUNCH=1 inspection hook — it prints
+# the resolved `claude ...` argv and exits before spawning claude.
+#
+# The invariant under test: an architect resume (a persisted session-id exists,
+# the fleet-down -> fleet-up case) launches `claude --resume <id>` with NO
+# trailing prompt, so the conversation reloads without generating a model turn.
+# The old behaviour fired a "tell me what you were last working on" prompt here,
+# costing one full model turn per architect on every fleet-up and feeding the
+# cold-start request burst. First-ever launch (no session-id yet) still
+# bootstraps via the role slash command.
+#
+# Covers:
+#   - resume launch carries --resume <id> and NO prompt argument
+#   - resume launch does NOT carry the old nudge text
+#   - first-ever launch carries --session-id and the /role-<role> command
+#   - first-ever launch persists the session-id file
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+BABYSIT="$SCRIPT_DIR/fleet-babysit"
+
+if [[ ! -x "$BABYSIT" ]]; then
+    echo "test setup: fleet-babysit not found at $BABYSIT" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        '$needle' not found in: $haystack"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        PASS=$((PASS + 1)); echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1)); echo "  FAIL: $msg"
+        echo "        '$needle' unexpectedly present in: $haystack"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+# Stub claude/tmux/gh so nothing real launches even if a path slips past the
+# inspection hook (the hook exits first; this is belt-and-suspenders).
+mkdir -p "$TMPROOT/bin"
+for c in claude tmux gh; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$TMPROOT/bin/$c"
+    chmod +x "$TMPROOT/bin/$c"
+done
+
+# Run launch resolution for <model> <role> against an isolated HOME (so the
+# session-id file at $HOME/.fleet/sessions/<role>.session-id is sandboxed).
+# Prints the resolved `claude ...` argv line only (drops babysit's log lines).
+launch_for() {
+    local home="$1" model="$2" role="$3"
+    env HOME="$home" PATH="$TMPROOT/bin:$PATH" FLEET_BABYSIT_PRINT_LAUNCH=1 \
+        "$BABYSIT" "$model" "$role" live 2>/dev/null | grep '^claude '
+}
+
+# --- T1: resume launch has --resume <id> and NO prompt ----------------------
+echo "T1: architect resume launches --resume with no prompt"
+H1="$TMPROOT/h1"; mkdir -p "$H1/.fleet/sessions"
+SID="11111111-2222-3333-4444-555555555555"
+echo "$SID" > "$H1/.fleet/sessions/opus-architect.session-id"
+out=$(launch_for "$H1" 'claude-opus-4-8[1m]' opus-architect)
+assert_eq "$out" "claude --model claude-opus-4-8[1m] --effort xhigh --resume $SID" \
+    "resume argv is exactly --model/--effort/--resume <id>, no trailing prompt"
+assert_not_contains "$out" "last working on" "resume carries no 'last working on' nudge"
+assert_not_contains "$out" "resume our previous" "resume carries no 'resume our previous' nudge"
+
+# --- T2: first-ever launch bootstraps via the role command ------------------
+echo "T2: first-ever architect launch uses --session-id + role command"
+H2="$TMPROOT/h2"; mkdir -p "$H2"
+out=$(launch_for "$H2" 'claude-opus-4-8[1m]' opus-architect)
+assert_contains "$out" "--session-id " "first launch passes --session-id"
+assert_contains "$out" "/role-opus-architect live" "first launch fires the role slash command"
+# the session-id file is now persisted for the next fleet-up to resume
+[[ -f "$H2/.fleet/sessions/opus-architect.session-id" ]] \
+    && { PASS=$((PASS + 1)); echo "  ok: first launch persisted the session-id file"; } \
+    || { FAIL=$((FAIL + 1)); echo "  FAIL: session-id file not written on first launch"; }
+
+# --- T3: game-architect resume path resolves the same way -------------------
+echo "T3: game-architect resume also drops the prompt"
+H3="$TMPROOT/h3"; mkdir -p "$H3/.fleet/sessions"
+GSID="99999999-8888-7777-6666-555555555555"
+echo "$GSID" > "$H3/.fleet/sessions/game-architect.session-id"
+out=$(launch_for "$H3" 'claude-opus-4-8[1m]' game-architect)
+assert_eq "$out" "claude --model claude-opus-4-8[1m] --effort xhigh --resume $GSID" \
+    "game-architect resume argv carries no prompt"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

On every `fleet-up`, each architect pane resumed its persisted session with a trailing prompt — *"fleet just restarted… tell me what you were last working on so we can continue."* That forced **one full model turn per architect at startup**: pure cold-start token + request burn that feeds the short-window 429 burst, for nothing the human couldn't get by reading the resumed transcript that's already on screen.

Resume now passes **no prompt** — an interactive `claude --resume <id>` loads the prior conversation and waits for input, generating no turn. First-ever launch (no persisted session-id) still bootstraps via the `/role-<role>` command.

Fixed in both architect launch paths:
- `fleet-babysit` `launch_architect_first` — the fleet panes (opus-architect, game-architect).
- `solo-architect` — the standalone manual launcher (same anti-pattern, same fix).

## Test plan

- [x] New `tests/test_babysit_launch.sh` (via a `FLEET_BABYSIT_PRINT_LAUNCH` inspection hook, mirroring `FLEET_BABYSIT_PRINT_EFFORT`):
  - resume argv is exactly `claude --model … --effort … --resume <id>` — no trailing prompt
  - resume carries none of the old nudge text
  - first-ever launch still passes `--session-id` + `/role-<role>` and persists the session-id file
  - game-architect resolves the same way
- [x] `tests/test_babysit_effort.sh` still green (10/10)
- [x] `bash -n` clean on both scripts; no remaining references to the old prompt text

## Deploy note

Architect panes pick this up on the next `fleet-down` → `fleet-up` cycle (the change is in the launch path, not the running session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)