### PR TITLE
fleet: sweep confirmed-orphan task claims immediately, not after the 2h TTL

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1634,6 +1634,12 @@ for pr in prs:
     # like a no-PR abandon (#1488 Fix B). Only an active (non-parked) matching
     # WIP PR (head-branch claude/<N>-*) keeps the claim.
     local claim_issue_stale_secs="${FLEET_CLAIM_STALE_SECS_ISSUES:-7200}"
+    # This host's key, for the confirmed-orphan fast path below. A claim label
+    # names the owning host (fleet:claim-<host>-<agent>); only THIS host can
+    # vouch for its own local claim locks, so the fast path applies to our own
+    # claims and cross-host claims stay on the TTL.
+    local this_host
+    this_host=$(derive_host)
     for repo in "${repos[@]}"; do
         local open_claim_plan open_pr_branches_json
         open_claim_plan=$(gh issue list --repo "$repo" --state open \
@@ -1661,23 +1667,48 @@ for issue in issues:
         while IFS=$'\t' read -r issue_num label_name; do
             [[ -z "$issue_num" || -z "$label_name" ]] && continue
 
+            # Confirmed-orphan fast path. A claim names the owning host
+            # (fleet:claim-<host>-<agent>); fleet-claim writes the local lock
+            # dir ($CLAIMS_DIR/<slug>) BEFORE adding the GitHub label and removes
+            # it on release, so a label naming THIS host with no local lock is a
+            # claim the owning host has no record of — the iteration died (swept,
+            # crashed, restarted) without releasing the issue-side labels. Such
+            # an orphan strands a claimable task as in_progress for the whole
+            # cross-host TTL (the #2102 / #1969 incident: ~2h each). Sweep it now
+            # instead of waiting the TTL out. Cross-host claims have no local lock
+            # here by definition, so they're left on the TTL + PR-state path —
+            # only the owning host can distinguish "dead" from "live elsewhere".
+            local claim_host="${label_name#fleet:claim-}"
+            claim_host="${claim_host%%-*}"
+            local same_host_orphan=0
+            if [[ "$claim_host" == "$this_host" \
+                  && ! -d "$CLAIMS_DIR/$(slugify "$issue_num")" ]]; then
+                same_host_orphan=1
+            fi
+
             local added_epoch
             added_epoch=$(label_added_epoch "$repo" "$issue_num" "$label_name")
             [[ "$added_epoch" -eq 0 ]] && continue
 
             local age=$(( now - added_epoch ))
-            [[ $age -lt $claim_issue_stale_secs ]] && continue
+            # Orphans skip the age TTL; cross-host / lock-present claims wait it out.
+            if (( same_host_orphan == 0 )) && (( age < claim_issue_stale_secs )); then
+                continue
+            fi
 
             local pr_state
             pr_state=$(_issue_pr_state_from "$open_pr_branches_json" "$issue_num" "$repo")
 
             # Keep the claim only while a matching PR is *active* work; a
             # parked (design-blocked/-unblocked) or absent matching PR falls
-            # through to the sweep below (#1488 Fix B).
+            # through to the sweep below (#1488 Fix B). Applies to orphans too —
+            # if a dead worker left an active open PR, the PR carries the work
+            # and re-claiming the issue would race it.
             [[ "$pr_state" == "active" ]] && continue
 
             local sweep_reason="no open PR"
             [[ "$pr_state" == "parked" ]] && sweep_reason="parked PR (design-blocked/unblocked)"
+            (( same_host_orphan == 1 )) && sweep_reason="orphaned claim (no local lock on $this_host), ${sweep_reason}"
 
             if gh issue edit "$issue_num" --repo "$repo" \
                     --remove-label "$label_name" >/dev/null 2>&1; then

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1686,14 +1686,18 @@ for issue in issues:
                 same_host_orphan=1
             fi
 
-            local added_epoch
-            added_epoch=$(label_added_epoch "$repo" "$issue_num" "$label_name")
-            [[ "$added_epoch" -eq 0 ]] && continue
-
-            local age=$(( now - added_epoch ))
-            # Orphans skip the age TTL; cross-host / lock-present claims wait it out.
-            if (( same_host_orphan == 0 )) && (( age < claim_issue_stale_secs )); then
-                continue
+            local added_epoch=0
+            local age=0
+            # Orphans skip the age TTL — skip the API call entirely for confirmed
+            # same-host orphans (label_added_epoch is irrelevant to the decision).
+            # Cross-host / lock-present claims wait out the TTL and do need it.
+            if (( same_host_orphan == 0 )); then
+                added_epoch=$(label_added_epoch "$repo" "$issue_num" "$label_name")
+                [[ "$added_epoch" -eq 0 ]] && continue
+                age=$(( now - added_epoch ))
+                if (( age < claim_issue_stale_secs )); then
+                    continue
+                fi
             fi
 
             local pr_state

--- a/scripts/fleet/tests/test_fleet_claim_orphan_sweep.sh
+++ b/scripts/fleet/tests/test_fleet_claim_orphan_sweep.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tests for the confirmed-orphan fast path in `fleet-claim cleanup --gh`'s
+# open-issue claim sweep.
+#
+# A claim names its owning host (fleet:claim-<host>-<agent>). fleet-claim writes
+# the local lock dir ($CLAIMS_DIR/<slug>) BEFORE adding the GitHub label, so a
+# label naming THIS host with no local lock is a claim the owning host has no
+# record of — an orphan from an iteration that died without releasing. Such a
+# claim strands a claimable task as in_progress for the whole cross-host TTL
+# (the #2102 / #1969 incident). The fast path sweeps it immediately; cross-host
+# claims and live (lock-present) claims keep the TTL.
+#
+# The TTL is set LARGE here and every claim is reported as freshly added, so the
+# age gate alone would sweep nothing — anything swept is the orphan fast path.
+#
+# Covers:
+#   - same-host claim, no local lock, no PR  -> swept now (orphan)
+#   - same-host claim, no local lock, ACTIVE PR -> kept (PR carries the work)
+#   - same-host claim, local lock present     -> kept (live worker, within TTL)
+#   - cross-host claim, no local lock         -> kept (TTL not elapsed; can't
+#                                                vouch for another host's locks)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+assert_removed_contains() {
+    if grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; then ok "$2"; else bad "$2 (not swept)"; fi
+}
+assert_removed_absent() {
+    if ! grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; then ok "$2"; else bad "$2 (unexpectedly swept)"; fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+export FLEET_TEST_HOST="mac"
+# Large TTL: the age gate would sweep nothing on its own (every label is fresh,
+# below). So anything removed proves the confirmed-orphan fast path fired.
+export FLEET_CLAIM_STALE_SECS_ISSUES=99999
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR" "$FLEET_STATE_DIR" "$FLEET_ORPHANS_DIR"
+
+export ISSUES_JSON="$TMPROOT/issues.json"
+export PRS_JSON="$TMPROOT/prs.json"
+REMOVED_FILE="$TMPROOT/removed.log"; : > "$REMOVED_FILE"; export REMOVED_FILE
+
+STUB_DIR="$TMPROOT/bin"; mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    issue)
+        case "$2" in
+            list) cat "$ISSUES_JSON"; exit 0 ;;
+            edit)
+                shift 2; issue="$1"; shift
+                while [[ $# -gt 0 ]]; do
+                    case "$1" in
+                        --remove-label) printf '%s\t%s\n' "$issue" "$2" >> "$REMOVED_FILE"; shift 2 ;;
+                        *) shift ;;
+                    esac
+                done
+                exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        case "$2" in
+            list) cat "$PRS_JSON"; exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    api)
+        # events endpoint — report every claim label as added JUST NOW so the
+        # age TTL never clears on its own. Only the orphan fast path can sweep.
+        printf '%s ' "$@" | grep -q 'events' && date -u +%Y-%m-%dT%H:%M:%SZ
+        exit 0 ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+mk_claim() {  # create a live local lock for <slug>
+    local slug="$1"
+    mkdir -p "$FLEET_CLAIMS_DIR/$slug"
+    echo "worker-1" > "$FLEET_CLAIMS_DIR/$slug/owner"
+    echo "$slug"    > "$FLEET_CLAIMS_DIR/$slug/title"
+    date +%s        > "$FLEET_CLAIMS_DIR/$slug/created"
+}
+
+# #900 same-host, NO local lock, no PR        -> orphan -> swept
+# #901 same-host, NO local lock, ACTIVE PR    -> kept (PR carries the work)
+# #902 same-host, local lock present, no PR    -> kept (live worker, within TTL)
+# #903 cross-host (linux), NO local lock, no PR -> kept (TTL not elapsed)
+cat > "$ISSUES_JSON" <<'JSON'
+[
+  {"number":900,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-worker-1"},{"name":"fleet:in-progress"}]},
+  {"number":901,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-worker-1"},{"name":"fleet:in-progress"}]},
+  {"number":902,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-mac-worker-1"},{"name":"fleet:in-progress"}]},
+  {"number":903,"state":"OPEN","labels":[{"name":"fleet:queued"},{"name":"fleet:claim-linux-worker-1"},{"name":"fleet:in-progress"}]}
+]
+JSON
+cat > "$PRS_JSON" <<'JSON'
+[
+  {"number":951,"headRefName":"claude/901-live","labels":[{"name":"fleet:wip"}]}
+]
+JSON
+mk_claim 902   # only #902 has a live local lock
+
+echo "=== cleanup --gh orphan fast path ==="
+OUT=$("$FLEET_CLAIM" cleanup --gh --repo jakildev/IrredenEngine 2>&1 || true)
+echo "$OUT" | sed 's/^/    /'
+
+assert_removed_contains $'900\tfleet:claim-mac-worker-1' "same-host orphan (no lock, no PR) swept now"
+assert_removed_contains $'900\tfleet:in-progress'        "orphan #900 fleet:in-progress cleared"
+assert_removed_absent   $'901\tfleet:claim-mac-worker-1' "same-host orphan with ACTIVE PR kept"
+assert_removed_absent   $'902\tfleet:claim-mac-worker-1' "same-host claim with live local lock kept"
+assert_removed_absent   $'903\tfleet:claim-linux-worker-1' "cross-host claim within TTL kept"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Fixes the root cause of a fleet-idle incident: two genuinely-claimable tasks (#2102 opus, #1969 sonnet) sat unworked while workers reported "no work", because each carried a stale `fleet:claim-mac-worker-1` + `fleet:in-progress` from a worker that died without releasing. The scout reads those labels → files the issues as `in_progress` → they vanish from the claimable `tasks_open`.

`cleanup --gh`'s open-issue claim sweep already handles this — but only after the cross-host TTL (`FLEET_CLAIM_STALE_SECS_ISSUES`, default **7200s / 2h**). So an orphaned claim strands a claimable task for up to 2 hours.

### Fix: confirmed-orphan fast path

fleet-claim writes the local lock dir (`$CLAIMS_DIR/<slug>`) **before** adding the GitHub label and removes it on release. So a claim label naming **this host** with **no local lock** is a claim the owning host has no record of — a confirmed orphan. Sweep it immediately instead of waiting out the TTL.

Guards preserved:
- An **active matching PR** still keeps the claim (the PR carries the work) — applies to orphans too.
- **Cross-host** claims have no local lock here by definition, so they stay on the TTL + PR-state path — only the owning host can distinguish "dead" from "live elsewhere".
- **Live same-host** claims keep their local lock → untouched.

## Test plan

- [x] New `tests/test_fleet_claim_orphan_sweep.sh` (large TTL, so the age gate sweeps nothing — anything swept is the fast path):
  - same-host, no lock, no PR → **swept now**
  - same-host, no lock, **active PR** → kept
  - same-host, **live local lock** → kept
  - **cross-host**, no lock, within TTL → kept
- [x] All 13 `test_fleet_claim_*.sh` suites pass (no regressions)

## Notes

This sidesteps the heartbeat-naming bug in #2099 (the PR-side `fleet:amending-*` sweep) for the issue-claim path by keying on local-lock presence rather than heartbeat. #2099 remains for the PR-amending path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)