### PR TITLE
render/profile: warn on unknown tagGpuStage name (#2004)

### DIFF
--- a/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
+++ b/engine/prefabs/irreden/render/gpu_stage_timing_observer.hpp
@@ -2,6 +2,7 @@
 #define GPU_STAGE_TIMING_OBSERVER_H
 
 #include <irreden/ir_system.hpp>
+#include <irreden/ir_profile.hpp>
 #include <irreden/render/render_device.hpp>
 #include <irreden/render/gpu_stage_timing.hpp>
 #include <irreden/profile/scope_timer.hpp>
@@ -207,7 +208,8 @@ inline GpuStageTimingObserver *installAndGetObserver() {
 // Tag a system with a stage name from `gpuStageRegistry()`. The registry
 // is the single source of truth for the field pointer + budget share;
 // callers pass only the name. An unknown name is a silent no-op so a
-// future stage rename can't crash the engine at startup.
+// future stage rename can't crash the engine at startup, but it emits a
+// debug warning so registry/tag name drift is caught at tag time.
 inline void tagGpuStage(IRSystem::SystemId system, std::string_view stageName) {
     for (const auto &info : gpuStageRegistry()) {
         if (info.name_ == stageName) {
@@ -215,6 +217,11 @@ inline void tagGpuStage(IRSystem::SystemId system, std::string_view stageName) {
             return;
         }
     }
+    IRE_LOG_WARN(
+        "tagGpuStage: unknown stage name \"{}\" — stage will not be timed. "
+        "Check gpuStageRegistry() for the registered name.",
+        stageName
+    );
 }
 
 } // namespace IRRender


### PR DESCRIPTION
## Summary
- `tagGpuStage` silently dropped timing for any stage whose name didn't match `gpuStageRegistry()` — the footgun that caused #1965 (the `resolvePerAxisScreenDepth` tag mismatch that went unnoticed until a profiling audit).
- Adds `IRE_LOG_WARN` on the no-match exit path so a registry/tag drift surfaces at tag time in debug builds, while keeping the non-fatal no-op for release (startup-safety intent preserved).
- Adds `#include <irreden/ir_profile.hpp>` to the header (previously relied on transitive inclusion; now explicit).

## Test plan
- [x] Build clean: `fleet-build --target IRShapeDebug` exits 0 on macOS/Metal.
- [x] All 20 currently-registered stages tag without warning (no false positive on a clean run).
- [ ] On a future rename mismatch, a debug run should log: `tagGpuStage: unknown stage name "..." — stage will not be timed.`

Closes #2004

🤖 Generated with [Claude Code](https://claude.com/claude-code)