### PR TITLE
fleet: ingest honors a late human:no-plan on a needs-plan issue

### DIFF
--- a/scripts/fleet/fleet-queue-ingest
+++ b/scripts/fleet/fleet-queue-ingest
@@ -363,6 +363,40 @@ for issue in pending:
               f'for re-plan (kept human:approved + any human:review-plan)', file=sys.stderr)
         continue
 
+    # Opt-out detection (computed here so the late-opt-out reconcile below and
+    # the planning gate further down share one source of truth): an explicit
+    # investigation spike, the `[no-plan]` body/title tag, or the human:no-plan
+    # label all mean "skip planning, queue directly".
+    opted_out = bool(
+        SPIKE_RE.search(title) or SPIKE_RE.search(body)
+        or NO_PLAN_RE.search(title) or NO_PLAN_RE.search(body)
+        or 'human:no-plan' in labels
+    )
+
+    # Late opt-out reconcile. human:no-plan / [no-plan] / spike means "queue
+    # directly, skip planning". But if that opt-out lands AFTER the issue already
+    # carries fleet:needs-plan (a human fast-tracking a backlog item that was
+    # earlier bounced to planning), the issue is stranded forever: the needs-plan
+    # skip guard just below drops it from ingest, while the opt-out means no
+    # planner will ever pick it up either — so it never reaches fleet:queued and
+    # no worker can claim it (the 9-issue limbo behind a "worker found no work"
+    # idle fleet). Strip the now-stale needs-plan so the issue falls through to
+    # the planning gate, which queues opted-out issues directly.
+    if opted_out and 'fleet:needs-plan' in labels:
+        er = subprocess.run(
+            ['gh', 'issue', 'edit', str(n), '--repo', repo,
+             '--remove-label', 'fleet:needs-plan'],
+            capture_output=True, text=True, timeout=15,
+        )
+        if er.returncode != 0:
+            failed += 1
+            print(f'WARN issue {repo}#{n}: strip stale fleet:needs-plan for opt-out '
+                  f'failed: {er.stderr.strip()}', file=sys.stderr)
+            continue
+        labels.discard('fleet:needs-plan')
+        print(f'INFO issue {repo}#{n}: opted out (human:no-plan / [no-plan] / spike) but '
+              f'still carried fleet:needs-plan — stripped it; queuing directly', file=sys.stderr)
+
     if ('fleet:queued' in labels or 'fleet:scope-shipped' in labels
             or 'fleet:needs-human' in labels or 'fleet:needs-plan' in labels
             or 'fleet:plan-review' in labels or 'human:review-plan' in labels):
@@ -390,18 +424,13 @@ for issue in pending:
     # Planning gate (#1456, re-keyed by #1932): refuse to queue an issue that
     # never passed through planning. The canonical plan is now a `## Plan`
     # issue comment (#1932); a committed/staged plan file still counts
-    # (backward compat for pre-redesign issues). Opt-outs: an explicit
-    # investigation spike, the `[no-plan]` tag, or the human:no-plan label.
-    # Without a plan or an opt-out the claiming worker is the first to open the
-    # code and design-blocks, so bounce to fleet:needs-plan (routes through
-    # PLANNING-PROTOCOL.md; the label also drops the issue out of the ingest
-    # pending set via the live-label skip guard). Sits before the blocker probes
-    # so a bounced issue costs no per-blocker API calls.
-    opted_out = bool(
-        SPIKE_RE.search(title) or SPIKE_RE.search(body)
-        or NO_PLAN_RE.search(title) or NO_PLAN_RE.search(body)
-        or 'human:no-plan' in labels
-    )
+    # (backward compat for pre-redesign issues). `opted_out` (computed above —
+    # investigation spike, the `[no-plan]` tag, or the human:no-plan label)
+    # skips the gate. Without a plan or an opt-out the claiming worker is the
+    # first to open the code and design-blocks, so bounce to fleet:needs-plan
+    # (routes through PLANNING-PROTOCOL.md; the label also drops the issue out of
+    # the ingest pending set via the live-label skip guard). Sits before the
+    # blocker probes so a bounced issue costs no per-blocker API calls.
     has_plan = (_has_plan_comment(view.get('comments', []))
                 or _plan_exists(repo, n, plan_cache))
     if not opted_out and not has_plan:

--- a/scripts/fleet/tests/test_fleet_queue_ingest_late_no_plan.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_late_no_plan.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Test the fleet-queue-ingest late-opt-out reconcile.
+#
+# human:no-plan / [no-plan] / "investigation spike" mean "skip planning, queue
+# directly". When that opt-out lands AFTER the issue already carries
+# fleet:needs-plan (a human fast-tracking a backlog item that was earlier
+# bounced to planning), the issue was stranded forever: the needs-plan skip
+# guard dropped it from ingest, while the opt-out meant no planner would pick it
+# up either — never reaching fleet:queued (the 9-issue limbo behind an idle
+# "worker found no work" fleet). Ingest now strips the stale needs-plan and
+# queues the issue directly.
+#
+# A plain fleet:needs-plan issue with NO opt-out must still be left for planning
+# (skip guard), never auto-stripped.
+#
+# HOME is redirected to a temp sandbox; gh is stubbed to canned surfaces and
+# every `gh issue edit` is logged for assertions.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INGEST="$SCRIPT_DIR/fleet-queue-ingest"
+if [[ ! -x "$INGEST" ]]; then
+    echo "test setup: fleet-queue-ingest not found at $INGEST" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+TMPROOT=$(mktemp -d)
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.fleet/state/projections" "$HOME/.fleet/logs"
+
+PROJ="$HOME/.fleet/state/projections/queue-manager-ingest.json"
+# #760 = human:no-plan label + fleet:needs-plan   → strip needs-plan, queue
+# #761 = fleet:needs-plan, NO opt-out             → left for planning (skip)
+# #762 = [no-plan] tag in title + fleet:needs-plan → strip needs-plan, queue
+cat > "$PROJ" <<'JSON'
+{"pending_issues":[
+  {"number":760,"repo":"engine"},
+  {"number":761,"repo":"engine"},
+  {"number":762,"repo":"engine"}
+],"unblock_issues":[]}
+JSON
+
+STUB_DIR="$TMPROOT/bin"; mkdir -p "$STUB_DIR"
+export EDIT_LOG="$TMPROOT/edit.log"; : > "$EDIT_LOG"
+export COMMENT_LOG="$TMPROOT/comment.log"; : > "$COMMENT_LOG"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    issue)
+        case "$2" in
+            view)
+                case "$3" in
+                    760) echo '{"title":"render: fast-track","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"fleet:needs-plan"},{"name":"human:no-plan"}]}' ;;
+                    761) echo '{"title":"render: genuinely needs a plan","body":"**Model:** opus\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"fleet:needs-plan"}]}' ;;
+                    762) echo '{"title":"render: tiny tweak [no-plan]","body":"**Model:** sonnet\n**Blocked by:** (none)","labels":[{"name":"human:approved"},{"name":"fleet:needs-plan"}]}' ;;
+                    *)   echo '{"title":"","body":"","labels":[]}' ;;
+                esac
+                exit 0 ;;
+            edit)    printf '%s\n' "$*" >> "$EDIT_LOG"; exit 0 ;;
+            comment) printf '%s\n' "$*" >> "$COMMENT_LOG"; exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    pr)
+        case "$2" in list) echo '[]'; exit 0 ;; *) exit 0 ;; esac ;;
+    api) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+# Does the edit log have a `gh issue edit <N> ... <pattern>` line?
+edit_has() { grep -qE "(^| )edit ${1}( .*)? ${2}( |$)|(^| )edit ${1} .*${2}" "$EDIT_LOG"; }
+
+echo "=== run fleet-queue-ingest ==="
+bash "$INGEST" >/dev/null 2>&1 || true
+
+# --- #760: late human:no-plan on a needs-plan issue → unstuck -----------------
+if grep -qE "(^| )edit 760 .*--remove-label fleet:needs-plan" "$EDIT_LOG"; then
+    ok "#760 stripped stale fleet:needs-plan (honoring late human:no-plan)"
+else
+    bad "#760 did NOT strip fleet:needs-plan: $(grep -E '(^| )edit 760' "$EDIT_LOG" | tr '\n' '|')"
+fi
+if grep -qE "(^| )edit 760 .*--add-label fleet:queued|(^| )edit 760 .*fleet:queued" "$EDIT_LOG"; then
+    ok "#760 stamped fleet:queued (queued directly)"
+else
+    bad "#760 did NOT reach fleet:queued: $(grep -E '(^| )edit 760' "$EDIT_LOG" | tr '\n' '|')"
+fi
+
+# --- #761: plain needs-plan, no opt-out → left for planning -------------------
+if grep -qE "(^| )edit 761 .*--remove-label fleet:needs-plan" "$EDIT_LOG"; then
+    bad "#761 wrongly stripped fleet:needs-plan (no opt-out present)"
+else
+    ok "#761 kept fleet:needs-plan (no opt-out — left for planning)"
+fi
+if grep -qE "(^| )edit 761 .*fleet:queued" "$EDIT_LOG"; then
+    bad "#761 wrongly queued an unplanned issue"
+else
+    ok "#761 not queued (correctly skipped at the needs-plan guard)"
+fi
+
+# --- #762: [no-plan] tag on a needs-plan issue → unstuck too ------------------
+if grep -qE "(^| )edit 762 .*--remove-label fleet:needs-plan" "$EDIT_LOG"; then
+    ok "#762 stripped fleet:needs-plan via the [no-plan] tag path"
+else
+    bad "#762 did NOT strip fleet:needs-plan: $(grep -E '(^| )edit 762' "$EDIT_LOG" | tr '\n' '|')"
+fi
+if grep -qE "(^| )edit 762 .*fleet:queued" "$EDIT_LOG"; then
+    ok "#762 stamped fleet:queued"
+else
+    bad "#762 did NOT reach fleet:queued"
+fi
+
+echo
+echo "================================"
+echo "PASS: $PASS    FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_fleet_queue_ingest_late_no_plan.sh
+++ b/scripts/fleet/tests/test_fleet_queue_ingest_late_no_plan.sh
@@ -78,9 +78,6 @@ GHSTUB
 chmod +x "$STUB_DIR/gh"
 export PATH="$STUB_DIR:$PATH"
 
-# Does the edit log have a `gh issue edit <N> ... <pattern>` line?
-edit_has() { grep -qE "(^| )edit ${1}( .*)? ${2}( |$)|(^| )edit ${1} .*${2}" "$EDIT_LOG"; }
-
 echo "=== run fleet-queue-ingest ==="
 bash "$INGEST" >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## Summary

Unsticks issues caught in a `human:no-plan` + `fleet:needs-plan` contradiction — the limbo behind the idle "worker found no work" fleet (9 `human:approved` issues stranded: #1970, #2004, #2018, #2022, #2023, #2031, #2032, #2054, #2099).

`human:no-plan` (and the `[no-plan]` tag / "investigation spike") mean "skip planning, **queue directly**". But when that opt-out lands **after** an issue already carries `fleet:needs-plan`, the issue is stranded forever:
- the needs-plan skip guard ([fleet-queue-ingest:366](scripts/fleet/fleet-queue-ingest)) drops it from ingest, so it never reaches `fleet:queued`;
- the opt-out means no planner picks it up either.

So it's invisible to both the queuer and the planner — yet the resolver still counts it in `needs_plan` and spins a no-op worker on it.

### Fix

Ingest computes the opt-out once, up front, and when an opted-out issue still carries `fleet:needs-plan`, strips the stale label so the issue falls through to the planning gate (which queues opted-out issues directly). A plain `needs-plan` issue with **no** opt-out is untouched — still left for planning. The duplicate `opted_out` computation at the planning gate is removed (now shared).

## Test plan

- [x] New `tests/test_fleet_queue_ingest_late_no_plan.sh`:
  - `human:no-plan` + `needs-plan` → needs-plan stripped, `fleet:queued` stamped
  - `[no-plan]` tag + `needs-plan` → stripped + queued
  - plain `needs-plan`, no opt-out → kept, not queued (guard against over-stripping)
- [x] All 5 existing `test_fleet_queue_ingest_*.sh` suites pass
- [x] STAMP_PY block compiles; `bash -n` clean

## Deploy / unstick note

The currently-stranded 9 issues unstick on the next ingest run after this merges (ingest is edge-triggered on the human:approved set; it can also be run manually). They can also be unstuck immediately by removing `fleet:needs-plan` from each by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)