### PR TITLE
fleet: worker slice drops human-gated needs-plan issues (no phantom planner)

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -225,6 +225,13 @@ _INGEST_SKIP_LABELS = frozenset({
 # ever ADDS one label — fleet-queue-ingest resets it to fleet:needs-plan.
 _INGEST_OVERRIDE_LABELS = frozenset({"human:revise-plan"})
 
+# Human-gate labels that take an issue out of fleet *planning/dispatch* rotation:
+# human:owned (de-queued), human:wip (human is on it), human:no-plan (queue
+# directly, never plan). A needs-plan or plan-review issue carrying any of these
+# is not worker-actionable, so the worker slice and the review projections drop
+# it rather than waking a no-op iteration on it.
+_HUMAN_GATE_LABELS = frozenset({"human:owned", "human:wip", "human:no-plan"})
+
 
 def _ingest_skipped(labels):
     """True when an issue should stay OUT of the ingest set. A skip label keeps
@@ -1438,7 +1445,7 @@ def project_opus_reviewer(state):
         # self-toggled label, so it can't self-trigger a loop.
         for issue in repo_state.get("plan_review", []):
             labels = set(issue.get("labels", []))
-            if labels & {"human:owned", "human:wip", "human:no-plan"}:
+            if labels & _HUMAN_GATE_LABELS:
                 continue
             items.append({"repo": repo, "kind": "plan_review",
                           "issue": issue["number"]})
@@ -1844,6 +1851,16 @@ def slice_worker(state):
             if model_tags(task) & {"opus", "fable", "sonnet"}:
                 out["tasks_open"].append(_slice_task_with_repo(repo_key, task))
         for issue in repo_state.get("needs_plan", []):
+            # Skip human-gated issues (human:no-plan / owned / wip). They carry
+            # fleet:needs-plan but are not worker-plannable: human:no-plan must
+            # be queued directly (handled by ingest), and owned/wip belong to the
+            # human. Surfacing them here makes the dispatcher's class resolver
+            # count them as plannable and spin a no-op opus worker that finds
+            # nothing — the idle-fleet churn behind the needs-plan/no-plan limbo.
+            # A merely fleet:blocked needs-plan issue is still plannable, so it
+            # is NOT gated here.
+            if set(issue.get("labels", [])) & _HUMAN_GATE_LABELS:
+                continue
             out["needs_plan"].append(_slice_issue_with_repo(repo_key, issue))
         for pr in repo_state.get("prs", []):
             labels = set(pr["labels"])
@@ -1889,7 +1906,7 @@ def slice_opus_reviewer(state):
         # so a woken reviewer reads the same set that triggered it). #1932.
         for issue in repo_state.get("plan_review", []):
             labels = set(issue.get("labels", []))
-            if labels & {"human:owned", "human:wip", "human:no-plan"}:
+            if labels & _HUMAN_GATE_LABELS:
                 continue
             out["plan_review"].append(_slice_issue_with_repo(repo_key, issue))
     return out

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -244,6 +244,59 @@ class SliceWorkerSkipLabelsDropPR(unittest.TestCase):
         self.assertEqual(result[0]["number"], 101)
 
 
+class SliceWorkerSkipsGatedNeedsPlan(unittest.TestCase):
+    """slice_worker drops human-gated needs-plan issues so the dispatcher's
+    class resolver doesn't count them as plannable and spin a no-op worker
+    (the needs-plan/no-plan limbo behind an idle 'worker found no work' fleet).
+    A merely fleet:blocked needs-plan issue is still plannable and stays."""
+
+    def _np(self, needs_plan):
+        return [i["number"] for i in
+                slice_worker(_state([], needs_plan=needs_plan))["needs_plan"]]
+
+    def test_human_no_plan_dropped(self):
+        self.assertEqual(
+            self._np([{"number": 222,
+                       "labels": ["fleet:needs-plan", "human:no-plan"]}]),
+            [],
+        )
+
+    def test_human_owned_and_wip_dropped(self):
+        self.assertEqual(
+            self._np([
+                {"number": 301, "labels": ["fleet:needs-plan", "human:owned"]},
+                {"number": 302, "labels": ["fleet:needs-plan", "human:wip"]},
+            ]),
+            [],
+        )
+
+    def test_plain_needs_plan_surfaces(self):
+        # Regression: a genuinely plannable issue must still reach the worker.
+        self.assertEqual(
+            self._np([{"number": 222, "labels": ["fleet:needs-plan"]}]),
+            [222],
+        )
+
+    def test_blocked_needs_plan_still_plannable(self):
+        # fleet:blocked is NOT a human gate — planning is independent of the
+        # blocker, so a blocked needs-plan issue stays in the slice.
+        self.assertEqual(
+            self._np([{"number": 222,
+                       "labels": ["fleet:needs-plan", "fleet:blocked"]}]),
+            [222],
+        )
+
+    def test_mixed_set_keeps_only_plannable(self):
+        self.assertEqual(
+            self._np([
+                {"number": 401, "labels": ["fleet:needs-plan", "human:no-plan"]},
+                {"number": 402, "labels": ["fleet:needs-plan"]},
+                {"number": 403, "labels": ["fleet:needs-plan", "human:owned"]},
+            ]),
+            [402],
+        )
+
+
 class OpusReviewerStableAcrossIrrelevantLabels(unittest.TestCase):
     """Opus-reviewer keys on fleet:has-nits / fleet:needs-fix (flag_labels).
     Other labels are either gating (REVIEW_SKIP_LABELS, removed from the


### PR DESCRIPTION
## Summary

Stops the dispatcher spinning a no-op opus worker on `needs-plan` issues that a worker can't actually plan — the churn behind the idle "worker found no work" fleet (9 of 10 needs-plan issues were `human:no-plan`).

`slice_worker` surfaced **every** `fleet:needs-plan` issue to the dispatcher. The class resolver (`fleet_task_class`) counts any `needs_plan` entry as plannable opus work and dispatches a worker — but `human:no-plan` (queue directly, never plan), `human:owned` (de-queued), and `human:wip` (human is on it) issues aren't worker-plannable, so the worker finds nothing and exits.

### Fix

The worker slice now skips needs-plan issues carrying a human-gate label. A merely `fleet:blocked` needs-plan issue is still plannable (planning is independent of the blocker), so it is **not** gated.

This is the fast-acting complement to the ingest-side fix (#2113, which strips a stale `fleet:needs-plan` from an opted-out issue): the scout stops the phantom dispatch within a tick (~30s), even before ingest's edge-triggered run reconciles the label.

Also factors the `{human:owned, human:wip, human:no-plan}` set — already filtered inline at the two plan-review projections — into a shared `_HUMAN_GATE_LABELS` constant.

## Test plan

- [x] New `SliceWorkerSkipsGatedNeedsPlan` in `test_worker_projection.py`: no-plan / owned / wip dropped; plain and `fleet:blocked` needs-plan still surface; mixed set keeps only the plannable one.
- [x] Full `test_worker_projection.py` (43) green; the two refactored plan-review sites still pass their existing tests.
- [x] Full fleet Python suite green except the pre-existing `test_fleet_validate_roles` role-doc-drift failure (fails identically on master).

## Relationship to #2113

#2113 fixes the **source** (ingest queues opted-out issues instead of stranding them). This PR is **defense-in-depth** at the dispatch layer. They're complementary; either alone stops today's churn, both together close it at source and at dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)