### PR TITLE
fleet: stack on frozen-design bases; filter find-stackable-blockers

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1097,12 +1097,17 @@ PYEOF
 import json, os, re, subprocess, sys
 sys.path.insert(0, os.environ["FLEET_LIB_DIR"])
 from fleet_branch_match import branch_matches_issue
+# Same reject-state predicate the scout's offer and the claim gate use (#1751),
+# so the finder doesn't advertise a base the gate would then refuse — a worker
+# would otherwise burn an iteration claiming a WIP/design-unblocked base only to
+# have --stackable-on bounce it.
+from fleet_stack_base import unsafe_base_reason
 blocker = os.environ["BLOCKER"]
 repo = os.environ["REPO"]
 try:
     r = subprocess.run(
         ["gh", "pr", "list", "--repo", repo, "--state", "open",
-         "--json", "url,headRefName,author,number,body",
+         "--json", "url,headRefName,author,number,body,labels",
          "--limit", "200"],
         capture_output=True, text=True, timeout=15,
     )
@@ -1126,6 +1131,12 @@ for pr in prs:
 if len(matches) != 1:
     sys.exit(0)
 pr = matches[0]
+# Reject a base whose head diff is in flux (WIP / amending / design-unblocked /
+# semantic-conflict / …). changed_files is unknown here (labels-only, like the
+# scout's cache-miss path); the claim gate re-checks live, including the diff.
+labels = [l.get("name", "") for l in (pr.get("labels") or []) if isinstance(l, dict)]
+if unsafe_base_reason(labels):
+    sys.exit(0)
 url = pr.get("url", "")
 head = pr.get("headRefName", "")
 author = (pr.get("author") or {}).get("login", "")

--- a/scripts/fleet/fleet_stack_base.py
+++ b/scripts/fleet/fleet_stack_base.py
@@ -34,17 +34,23 @@ Stdlib only — imported by `fleet-state-scout` (pure Python) and by
 exactly like `fleet_branch_match.py`.
 """
 
-# A base PR carrying any of these labels is in a non-stackable state: the diff
-# is in flux (WIP / amending), parked on a design question (design-*), not yet
-# rebaseable against master (awaiting-*), or not its own work (fork-of). This is
-# a SUPERSET of the scout's old `_DESIGN_BLOCK_LABELS` filter — widening the
-# rejection, never narrowing it.
+# A base PR carrying any of these labels is in a non-stackable state. The
+# discriminator is whether the base's HEAD DIFF is moving. A WIP, amending, or
+# design-UNBLOCKED PR is being actively rewritten, so a stack on it would fold
+# in or conflict against shifting code. The FROZEN-design states
+# (design-blocked / -proposed / -escalated) are the opposite: the worker hit a
+# question, escalated, and walked away, so the diff is parked and stable — a
+# fine base to stack on (a non-approved base is OK; only WIP/active-rework must
+# be gone). If the eventual design answer reworks the base, the merger
+# cascade-rebases the stack — the normal stacked-PR maintenance path. So the
+# frozen-design labels are deliberately NOT rejected here.
 NOT_STACKABLE_BASE_LABELS = frozenset({
     # Work-in-progress / mid-amend — the head diff will move under the stack.
     "fleet:wip", "human:wip", "fleet:human-amending", "fleet:merger-cooldown",
-    # Parked on a design question — same hazard as design-blocked.
-    "fleet:design-unblocked", "fleet:design-blocked", "fleet:design-escalated",
-    "fleet:design-proposed",
+    # Architect responded and the worker is resuming the rework — the head diff
+    # is about to move, like WIP. (The frozen design states — design-blocked /
+    # -proposed / -escalated — are intentionally absent: stable diff, stackable.)
+    "fleet:design-unblocked",
     # Pending merger rebase — diff against master is meaningless until resolved;
     # stacking would create a two-rebase chain when the conflict is resolved.
     "fleet:semantic-conflict",

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -290,10 +290,22 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         2026-06-06 empty-skeleton hazard)."""
         self._assert_no_offer(labels=["fleet:design-unblocked"])
 
-    def test_design_blocked_base_no_field(self):
-        """Regression: the old filter (b) design-block rejection still holds
-        through the unified predicate."""
-        self._assert_no_offer(labels=["fleet:design-blocked"])
+    def test_frozen_design_base_offered(self):
+        """Frozen-design bases (design-blocked / -proposed / -escalated) have a
+        parked, stable diff, so they ARE offered as stack bases — a non-approved
+        base is fine; only an actively-moving head (WIP / amending /
+        design-unblocked) disqualifies."""
+        for label in ("fleet:design-blocked", "fleet:design-proposed",
+                      "fleet:design-escalated"):
+            with self.subTest(label=label):
+                tasks = [_task("#1112", "#1111")]
+                prs = [_pr(536, "claude/1111-x", labels=[label])]
+                self._write_pr_cache("engine", 536, ["engine/render/x.cpp"])
+                state = _state(engine_tasks=tasks, engine_prs=prs)
+                enrich_stackable_blocker_prs(state)
+                task = state["repos"]["engine"]["tasks"]["open"][0]
+                self.assertIn("stackable_blocker_pr", task)
+                self.assertEqual(task["stackable_blocker_pr"]["number"], 536)
 
     def test_amending_base_no_field(self):
         """fleet:amending-<host>-<agent> (dynamic prefix) base is not offered."""

--- a/scripts/fleet/tests/test_stack_base_guard.py
+++ b/scripts/fleet/tests/test_stack_base_guard.py
@@ -32,13 +32,14 @@ class TestUnsafeBaseReason(unittest.TestCase):
             with self.subTest(label=label):
                 self.assertEqual(unsafe_base_reason([label]), label)
 
-    def test_wip_and_design_states(self):
+    def test_wip_and_active_rework_states(self):
+        # WIP and design-UNBLOCKED (architect answered, worker resuming the
+        # rework) have a moving head diff -> rejected. Frozen design states are
+        # covered separately in test_frozen_design_states_are_stackable.
         self.assertEqual(unsafe_base_reason(["fleet:wip"]), "fleet:wip")
         self.assertEqual(unsafe_base_reason(["human:wip"]), "human:wip")
         self.assertEqual(unsafe_base_reason(["fleet:design-unblocked"]),
                          "fleet:design-unblocked")
-        self.assertEqual(unsafe_base_reason(["fleet:design-blocked"]),
-                         "fleet:design-blocked")
 
     def test_amending_prefix_matched(self):
         """The dynamic per-host amend claim is matched by prefix, not equality."""
@@ -71,13 +72,17 @@ class TestUnsafeBaseReason(unittest.TestCase):
         """Guard the amending prefix tuple so a refactor can't silently empty it."""
         self.assertIn("fleet:amending-", NOT_STACKABLE_BASE_PREFIXES)
 
-    def test_design_block_labels_still_covered(self):
-        """The old scout _DESIGN_BLOCK_LABELS members must remain in the
-        superset (no narrowing of the original design-block rejection)."""
+    def test_frozen_design_states_are_stackable(self):
+        """Frozen-design bases (worker escalated and walked away → diff parked
+        and stable) ARE valid stack bases. A non-approved base is fine to stack
+        on; only an actively-moving head (WIP / amending / design-unblocked)
+        disqualifies. So these must NOT be in the reject set and must return
+        None when paired with a real diff."""
         for label in ("fleet:design-blocked", "fleet:design-escalated",
                       "fleet:design-proposed"):
             with self.subTest(label=label):
-                self.assertIn(label, NOT_STACKABLE_BASE_LABELS)
+                self.assertNotIn(label, NOT_STACKABLE_BASE_LABELS)
+                self.assertIsNone(unsafe_base_reason([label], ["engine/x.cpp"]))
 
     def test_semantic_conflict_rejected(self):
         """A PR awaiting merger rebase is not a safe stack base — its diff


### PR DESCRIPTION
## Summary

Makes the **stackable-blocked tier actually fire** in this design-block-heavy backlog — the reason stacking had gone quiet.

### 1. Stack on frozen-design bases (`fleet_stack_base.py`)

A blocked task may now stack on a blocker PR that is `design-blocked` / `design-proposed` / `design-escalated`. The discriminator is whether the base's **head diff is moving**:
- **Rejected (in flux):** `fleet:wip`, `human:wip`, amending, **`design-unblocked`** (architect answered → worker resuming the rework), semantic-conflict, awaiting-*, fork.
- **Allowed (frozen):** `design-blocked` / `-proposed` / `-escalated` — the worker hit a question, escalated, and walked away, so the diff is parked and stable. A non-approved base is fine to stack on; only an actively-moving head disqualifies.

This matches your spec ("has a PR, doesn't need approval, just not WIP"). The old policy lumped `design-blocked` in with WIP, so in a backlog where blockers routinely sit design-blocked, nothing was ever stackable. If the eventual design answer reworks the base, the merger cascade-rebases the stack (normal stacked-PR maintenance).

Both surfaces that call the predicate — the scout's offer (`enrich_stackable_blocker_prs`) and the claim gate's `--stackable-on` re-verify — pick this up, so they stay in agreement.

### 2. `find-stackable-blockers` applies the predicate too

The #1751 centralization wired `unsafe_base_reason` into the offer and the accept but **missed this discovery helper** — it returned WIP / design-unblocked bases the claim gate would then bounce (a wasted worker iteration). It now fetches the candidate PR's labels and suppresses an unsafe base.

**Verified live:** `find-stackable-blockers` on #2082 (blocker PR #2109 is `fleet:wip`+`design-blocked`) now returns empty — it was returning the WIP PR.

## Test plan

- [x] `test_stack_base_guard.py` — frozen-design states stackable; WIP / design-unblocked rejected
- [x] `test_enrich_stackable_blocker_prs.py` — design-blocked flips from no-offer to offered (all three frozen labels)
- [x] `test_fleet_validate_stack.py`, `test_fleet_claim_stackable_live_resolve.sh`, `test_fleet_claim_blockers.sh` — all green (60+ tests)
- [x] Live: finder correctly filters a WIP base

## Follow-up (separate PR)

Broadening the scout's **offer coverage** — multi-blocker-resolve-to-one + `Closes #N` body matching — comes next so the offer finds every eligible base the live finder would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)