### PR TITLE
fleet: scout stack offer matches Closes-#N blocker PRs, not just branch

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -159,7 +159,7 @@ def fetch_prs(repo):
         "gh", "pr", "list", "--repo", repo, "--state", "open",
         "--json",
         "number,title,headRefName,baseRefName,author,labels,mergeable,"
-        "isDraft,reviews,updatedAt",
+        "isDraft,reviews,updatedAt,body",
     ])
     if out is None:
         return None
@@ -1246,21 +1246,30 @@ def resolve_epic_children(state):
 
 def enrich_stackable_blocker_prs(state):
     # Per T-110 PR 2: for each task whose blocked_by is exactly one issue
-    # number (`#NNN`) with exactly one matching open PR (head ref
-    # `claude/<NNN>-…`) in the same repo, attach a `stackable_blocker_pr`
-    # field carrying {number, headRefName, author}. Workers (T-114) read
-    # this to decide whether to fall through to a stackable claim when no
-    # unblocked tasks are free.
+    # number (`#NNN`) with exactly one matching open PR in the same repo,
+    # attach a `stackable_blocker_pr` field carrying {number, headRefName,
+    # author}. Workers (T-114) read this to decide whether to fall through to a
+    # stackable claim when no unblocked tasks are free. A multi-blocker task
+    # whose other blockers have all closed is already collapsed to a single
+    # `#NNN` by resolve_blocked_by() (runs first), so it reaches here eligible.
+    #
+    # A PR "matches" the blocker when its head branch is `claude/<NNN>-…` OR its
+    # body Closes/Fixes/Resolves #NNN — the same union fleet-claim's
+    # find-stackable-blockers uses, so the scout offers every base the live
+    # finder would (the Closes-#N form catches blocker PRs on non-standard /
+    # human branches).
     #
     # The field is always omitted when:
     #   - blocked_by doesn't reference exactly one issue (multi-blocker,
     #     free-text, URL, none) — see _single_blocker_issue; a single #NNN
     #     followed by explanatory prose still qualifies
-    #   - zero open PRs match the expected branch prefix (blocker not
-    #     yet started, or already merged and dropped from open list)
+    #   - zero open PRs match (blocker not yet started, or already merged and
+    #     dropped from the open list)
     #   - more than one open PR matches (rare but possible if a stale
     #     branch lingers — caller can't pick one safely)
-    #   - blocker PR has fleet:design-blocked or fleet:design-escalated (filter b)
+    #   - the blocker PR is in a non-stackable base state — unsafe_base_reason,
+    #     filter (b): WIP / amending / design-unblocked / etc. (frozen-design
+    #     bases ARE accepted; see fleet_stack_base)
     #   - downstream task's area files appear in the blocker PR diff (filter a)
     #
     # Engine and game tasks are both enriched; worker pickup only honors
@@ -1273,8 +1282,16 @@ def enrich_stackable_blocker_prs(state):
             issue_num = _single_blocker_issue(blocked_by)
             if not issue_num:
                 continue
-            matches = [pr for pr in prs
-                       if branch_matches_issue(pr.get("headRefName", ""), issue_num, repo_key)]
+            closes_re = re.compile(
+                r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#"
+                + re.escape(issue_num) + r"\b",
+                re.IGNORECASE,
+            )
+            matches = [
+                pr for pr in prs
+                if branch_matches_issue(pr.get("headRefName", ""), issue_num, repo_key)
+                or closes_re.search(pr.get("body", "") or "")
+            ]
             if len(matches) != 1:
                 continue
             pr = matches[0]
@@ -2251,6 +2268,13 @@ def tick_once():
     resolve_human_approved_blockers(state)
     resolve_epic_children(state)
     enrich_stackable_blocker_prs(state)
+    # Drop PR bodies now the only consumer (the Closes-#N stack-base match above)
+    # has run, so they don't bloat state.json or the per-role slices — mirrors
+    # resolve_human_approved_blockers popping issue bodies. No projector or slice
+    # needs pr body.
+    for _repo_state in state["repos"].values():
+        for _pr in _repo_state.get("prs", []):
+            _pr.pop("body", None)
     enrich_inflight_pr_tasks(state)
     write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
 

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -47,8 +47,9 @@ def _task(id_, blocked_by):
     return {"id": id_, "blocked_by": blocked_by}
 
 
-def _pr(number, head_ref, author="bot", labels=None):
-    pr = {"number": number, "headRefName": head_ref, "author": author}
+def _pr(number, head_ref, author="bot", labels=None, body=""):
+    pr = {"number": number, "headRefName": head_ref, "author": author,
+          "body": body}
     if labels is not None:
         pr["labels"] = labels
     return pr
@@ -315,6 +316,29 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         task = state["repos"]["engine"]["tasks"]["open"][0]
         self.assertIn("stackable_blocker_pr", task)
         self.assertEqual(task["stackable_blocker_pr"]["number"], 536)
+
+    def test_closes_n_body_match_offered(self):
+        """A blocker PR on a non-standard branch (no claude/<N>-*) that Closes
+        the blocker issue in its body is matched and offered — the scout offer
+        now mirrors find-stackable-blockers' branch-OR-Closes union."""
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(540, "feature/manual-fix", body="Implements the thing.\nCloses #1111")]
+        self._write_pr_cache("engine", 540, ["engine/render/x.cpp"])
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        task = state["repos"]["engine"]["tasks"]["open"][0]
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 540)
+
+    def test_closes_n_unrelated_issue_not_matched(self):
+        """A PR that Closes a DIFFERENT issue (#999) is not matched for #1111 —
+        the closes-regex is anchored to the exact blocker number."""
+        tasks = [_task("#1112", "#1111")]
+        prs = [_pr(541, "feature/other", body="Closes #999")]
+        state = _state(engine_tasks=tasks, engine_prs=prs)
+        enrich_stackable_blocker_prs(state)
+        self.assertNotIn("stackable_blocker_pr",
+                         state["repos"]["engine"]["tasks"]["open"][0])
 
     def test_cache_miss_unknown_files_still_enriched(self):
         """No cached PR detail (files unknown) + clean labels → still offered;

--- a/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
+++ b/scripts/fleet/tests/test_enrich_stackable_blocker_prs.py
@@ -318,17 +318,26 @@ class TestEnrichStackableBlockerPrs(unittest.TestCase):
         self.assertEqual(task["stackable_blocker_pr"]["number"], 536)
 
     def test_closes_n_body_match_offered(self):
-        """A blocker PR on a non-standard branch (no claude/<N>-*) that Closes
-        the blocker issue in its body is matched and offered — the scout offer
-        now mirrors find-stackable-blockers' branch-OR-Closes union."""
-        tasks = [_task("#1112", "#1111")]
-        prs = [_pr(540, "feature/manual-fix", body="Implements the thing.\nCloses #1111")]
-        self._write_pr_cache("engine", 540, ["engine/render/x.cpp"])
-        state = _state(engine_tasks=tasks, engine_prs=prs)
-        enrich_stackable_blocker_prs(state)
-        task = state["repos"]["engine"]["tasks"]["open"][0]
-        self.assertIn("stackable_blocker_pr", task)
-        self.assertEqual(task["stackable_blocker_pr"]["number"], 540)
+        """A blocker PR on a non-standard branch (no claude/<N>-*) that Closes,
+        Fixes, or Resolves the blocker issue in its body is matched and offered —
+        the scout offer now mirrors find-stackable-blockers' branch-OR-Closes
+        union.  One subTest per keyword family."""
+        keywords = [
+            ("Closes", "Closes #1111"),
+            ("Fixes",   "Fixes #1111"),
+            ("Resolves","Resolves #1111"),
+        ]
+        for family, body_line in keywords:
+            with self.subTest(keyword_family=family):
+                tasks = [_task("#1112", "#1111")]
+                prs = [_pr(540, "feature/manual-fix",
+                           body=f"Implements the thing.\n{body_line}")]
+                self._write_pr_cache("engine", 540, ["engine/render/x.cpp"])
+                state = _state(engine_tasks=tasks, engine_prs=prs)
+                enrich_stackable_blocker_prs(state)
+                task = state["repos"]["engine"]["tasks"]["open"][0]
+                self.assertIn("stackable_blocker_pr", task)
+                self.assertEqual(task["stackable_blocker_pr"]["number"], 540)
 
     def test_closes_n_unrelated_issue_not_matched(self):
         """A PR that Closes a DIFFERENT issue (#999) is not matched for #1111 —


### PR DESCRIPTION
## Summary

Closes the last coverage gap between the scout's stackable-blocker **offer** and the live finder, so the offer (now the sole stacking trigger) advertises every base the finder would.

The scout's `enrich_stackable_blocker_prs` matched a blocker's PR only by head branch (`claude/<N>-*`); `fleet-claim find-stackable-blockers` matched branch **OR** a `Closes/Fixes/Resolves #N` body reference. So a blocker PR on a non-standard / human branch that closes the issue in its body was never offered → its downstream task never stacked. This aligns the offer with the finder (branch OR closes-regex).

**The multi-blocker half of "broaden the offer" is already handled** — `resolve_blocked_by()` runs first and collapses a task whose other blockers have all closed down to the single remaining `#N`, which the offer then sees. So this PR is just the Closes-#N match.

### Mechanics
- `fetch_prs` now pulls `body` (needed for the match).
- `body` is **stripped from every PR right after enrich consumes it**, before slicing, so it never bloats state.json or the per-role slices (mirrors `resolve_human_approved_blockers` popping issue bodies).
- The trigger-hash projectors select explicit fields and none reference `body` → no projection churn.

## Test plan

- [x] `test_enrich_stackable_blocker_prs.py` — Closes-#N-on-a-non-standard-branch offered; wrong-issue-number (`Closes #999`) not matched for #1111; `_pr` gains a `body` field.
- [x] `test_worker_projection.py` green (slices unaffected by the body-strip).
- [x] Full fleet Python suite green except the pre-existing `test_fleet_validate_roles` role-doc-drift failure.

## Relationship to #2130

Independent feature (orthogonal to the predicate change), touches `test_enrich_stackable_blocker_prs.py` in non-overlapping hunks. Together: #2130 makes frozen-design bases eligible (the big lever); this makes the offer find every eligible base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)