### PR TITLE
render: free GPU stage-timing observer in live-context teardown, not at static destruction (#2031)

### DIFF
--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -235,4 +235,12 @@ same `config = { ... }` table — there is one source of truth per file.
   video recording until the first input arrives — used to keep capture
   clips from starting mid-loading-screen. If video recording is not
   starting, check these flags first.
+- **Release GPU/GL resources in `end()`, never in `~World()`.** `g_world`
+  is a global `unique_ptr`, so `~World()` runs at process-exit static
+  destruction — past that point the GL driver/context may already be torn
+  down (MSYS2 unloads it first), and any `glDelete*` issued from a
+  member/observer dtor crashes against dead driver state (#2031). `end()`
+  runs during `gameLoop()` while the context is live and is the canonical
+  spot for device-resource teardown (it already drives `destroyAllEntities()`
+  for `onDestroy` GPU frees). The dtor stays a no-op safety net.
 

--- a/engine/world/src/world.cpp
+++ b/engine/world/src/world.cpp
@@ -94,6 +94,14 @@ World::World(const char *configFileName)
 }
 
 World::~World() {
+    // No-op after `end()` (which ran during `gameLoop()` while the GL context
+    // was still live and already cleared the observers). `g_world` is a global
+    // `unique_ptr`, so this dtor runs at process-exit static destruction — past
+    // that point the GL driver/context may already be torn down (MSYS2 unloads
+    // it first), and the GpuStageTimingObserver dtor's `glDeleteQueries` would
+    // crash against dead driver state (#2031). The live-context release in
+    // `end()` is the real cleanup; this stays idempotent as a safety net for any
+    // path that never ran the loop.
     m_systemManager.clearTickObservers();
     IRE_LOG_INFO("Clean shutdown complete.");
 }
@@ -279,6 +287,12 @@ void World::start() {
 
 void World::end() {
     buildAndWriteProfileReport();
+    // Release the GPU stage-timing observer's GL timestamp queries here, while
+    // the render context is guaranteed live. The observer is program-bound and
+    // only ~World() would otherwise destroy it — but that runs at static
+    // destruction, after the GL driver/context may already be gone (#2031).
+    // `clearTickObservers()` is idempotent, so the dtor's later call no-ops.
+    m_systemManager.clearTickObservers();
     m_videoManager.shutdown();
     // Ensure component onDestroy hooks run while managers are still valid
     // (e.g. MIDI cleanup that sends NOTE_OFF on shutdown).


### PR DESCRIPTION
## Summary
- `GpuStageTimingObserver`'s GL timestamp queries (`glDeleteQueries`) were freed only in `~World()`, which runs at process-exit **static destruction** (`g_world` is a global `unique_ptr`). On native Windows/MSYS2 the GL driver/context is already torn down by then, so the observer dtor segfaulted on otherwise-clean exit (exit 139) for `IRLuaPipelineDemo` and `IRCollisionOverlapDemo` after `--auto-screenshot`.
- Release the observer in `World::end()` — it runs during `gameLoop()` while the render context is guaranteed live, alongside the existing `destroyAllEntities()` `onDestroy` GPU frees. `clearTickObservers()` is idempotent, so the `~World()` call becomes a safe no-op.
- Documented the "release GPU/GL resources in `end()`, never in `~World()`" invariant in `engine/world/CLAUDE.md`.

## Test plan
- [x] macOS/Metal: `IRLuaPipelineDemo` and `IRCollisionOverlapDemo` build clean and exit 0 after `--auto-screenshot` (screenshots saved, clean shutdown).
- [ ] **Linux/Windows (GL) cross-host smoke**: confirm the exit-139 segfault on clean exit is gone (this is the path that actually crashed — see reviewer note).

## Notes for reviewer
The crash is **GL-backend, static-destruction-only** — macOS uses the Metal backend, so it never reproduced the segfault here; my macOS run confirms only *no regression* (demos still render + exit cleanly). The fix is correct by construction (the observer + its GL handles are now destroyed in `end()` while the context is live), but the actual exit-139 fix needs a **Linux or Windows GL** smoke to confirm. Scope note: the fix covers the `gameLoop()` path (all real demos); a target that constructs `World` but never runs the loop is unchanged (out of scope, same as before).

Closes #2031

🤖 Generated with [Claude Code](https://claude.com/claude-code)