### PR TITLE
tooling: extend ruff lint from scripts/fleet/ to all of scripts/

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,14 +33,15 @@ jobs:
       - name: Lint
         run: cmake --build --preset windows-lint
 
-      # Python analogue of clang-format/clang-tidy for the fleet automation
-      # (scripts/fleet/). Pinned so the gate is stable across ruff releases;
-      # ruff.toml at the repo root pins the rules + the extension-less file set.
+      # Python analogue of clang-format/clang-tidy for the repo's Python
+      # surface (all of scripts/: fleet automation + render/perf/gui harnesses).
+      # Pinned so the gate is stable across ruff releases; ruff.toml at the repo
+      # root pins the rules + the extension-less file set.
       - name: Python lint (ruff)
         uses: astral-sh/ruff-action@v3
         with:
           version: "0.15.20"
-          args: "check scripts/fleet/"
+          args: "check scripts/"
 
       - name: Build tests
         run: cmake --build --preset windows-tests

--- a/docs/agents/BUILD.md
+++ b/docs/agents/BUILD.md
@@ -167,24 +167,26 @@ your branch has modified (committed vs `@{upstream}` plus working
 tree). The bare `format` target rewrites every formattable file in the
 repo and should only run on intentional cleanup PRs.
 
-### Python (fleet scripts)
+### Python (scripts)
 
-The fleet automation under `scripts/fleet/` is linted by **ruff** — the
-Python analogue of `clang-format`/`clang-tidy`. After touching any fleet
-script, run the canonical check before committing (the CI `Python lint`
-step in `.github/workflows/quality.yml` gates it on every PR):
+Everything under `scripts/` — the fleet automation plus the render / perf /
+gui harnesses — is linted by **ruff**, the Python analogue of
+`clang-format`/`clang-tidy`. After touching any Python script, run the
+canonical check before committing (the CI `Python lint` step in
+`.github/workflows/quality.yml` gates it on every PR):
 
 ```bash
-ruff check scripts/fleet/          # PEP8 + import-order + unused + bare-assert
-ruff check --fix scripts/fleet/    # autofix import-order / unused imports
+ruff check scripts/          # PEP8 + import-order + unused + bare-assert
+ruff check --fix scripts/    # autofix import-order / unused imports
 ```
 
 `ruff.toml` at the repo root pins the rules and the file set (it enumerates
 the extension-less Python executables explicitly, since the largest fleet
 scripts — `fleet-claim`, `fleet-dispatcher`, `fleet-up`, … — are bash, not
-Python). ruff is installed by the bootstrap scripts (`brew install ruff` on
-macOS, `pipx install ruff` on Linux, `pacman -S mingw-w64-x86_64-ruff` on
-Windows/MSYS2).
+Python; the non-fleet harnesses all carry a `.py` extension and are
+auto-discovered). ruff is installed by the bootstrap scripts (`brew install
+ruff` on macOS, `pipx install ruff` on Linux, `pacman -S
+mingw-w64-x86_64-ruff` on Windows/MSYS2).
 
 ---
 

--- a/docs/agents/CLAUDE-BASELINE.md
+++ b/docs/agents/CLAUDE-BASELINE.md
@@ -139,13 +139,13 @@ path, or the API keeps signalling "experimental" when it's the production code
   30-line block tracing a bug's forensic history is the same smell as a
   one-line `// now uses the deferred variant`, and is most common in render
   code.
-- **These style and comment rules apply to the fleet Python surface
-  (`scripts/fleet/`) too, not just C++.** PEP8 spacing, import-order, unused
-  imports, and bare-`assert`-as-guard are enforced mechanically by **ruff**
-  (`ruff check scripts/fleet/`, gated in CI — see BUILD.md § "Python (fleet
-  scripts)"). The one-line-comment / WHY-not-narration policy has no mechanical
-  ruff rule, so it stays **reviewer-enforced**: write comments that explain
-  intent, not code narration, in Python the same as in C++.
+- **These style and comment rules apply to the Python under `scripts/`
+  (fleet automation + render / perf / gui harnesses) too, not just C++.** PEP8
+  spacing, import-order, unused imports, and bare-`assert`-as-guard are enforced
+  mechanically by **ruff** (`ruff check scripts/`, gated in CI — see BUILD.md §
+  "Python (scripts)"). The one-line-comment / WHY-not-narration policy has no
+  mechanical ruff rule, so it stays **reviewer-enforced**: write comments that
+  explain intent, not code narration, in Python the same as in C++.
 
 ---
 

--- a/docs/agents/skills/commit-and-push.md
+++ b/docs/agents/skills/commit-and-push.md
@@ -139,17 +139,18 @@ for this branch.
 draft for the cross-repo leakage tokens listed in the **info-isolation
 check** reference. Surface any match before committing.
 
-**Then**, if the diff touches `scripts/fleet/` (the fleet Python surface), run
-the **Python lint** — the analogue of the C++ `format-changed`/`lint` targets:
+**Then**, if the diff touches any Python under `scripts/` (the fleet
+automation or the render / perf / gui harnesses), run the **Python lint** —
+the analogue of the C++ `format-changed`/`lint` targets:
 
 ```bash
-ruff check --fix scripts/fleet/   # autofix import-order / unused imports
-ruff check scripts/fleet/         # must exit 0 — gated in CI (quality.yml)
+ruff check --fix scripts/   # autofix import-order / unused imports
+ruff check scripts/         # must exit 0 — gated in CI (quality.yml)
 ```
 
 Resolve any remaining findings (line-length, ambiguous names, bare asserts)
 before committing; the CI `Python lint` step rejects the PR otherwise. See
-BUILD.md § "Python (fleet scripts)" for the rule set and install.
+BUILD.md § "Python (scripts)" for the rule set and install.
 
 **Then** invoke the **simplify skill** to review the dirty changes for
 reuse, quality, and efficiency issues. It reads the same diff and applies

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,15 +1,17 @@
-# Ruff lint config for the fleet Python surface (scripts/fleet/).
+# Ruff lint config for the repo's Python surface (all of scripts/).
 #
-# The fleet automation is a large, growing body of Python that the C++-only
-# quality surface (clang-format + the simplify-* subagents) never covered, so
-# PEP8 / import-order nits slipped through to review. Ruff is the Python
-# analogue: one fast single-binary pass over scripts/fleet/, gated in CI
-# (.github/workflows/quality.yml) and run author-side before commit.
+# The fleet automation plus the render / perf / gui harnesses are a large,
+# growing body of Python that the C++-only quality surface (clang-format + the
+# simplify-* subagents) never covered, so PEP8 / import-order nits slipped
+# through to review. Ruff is the Python analogue: one fast single-binary pass
+# over scripts/, gated in CI (.github/workflows/quality.yml) and run
+# author-side before commit.
 #
-# Canonical invocation: `ruff check scripts/fleet/` (this file pins the rules
-# and the file set; the path argument pins the v1 scope). v1 scope is
-# scripts/fleet/ only; extending to the rest of scripts/ (render / perf / gui
-# harnesses) is a tracked follow-up.
+# Canonical invocation: `ruff check scripts/` (this file pins the rules and the
+# file set; the path argument pins the scope). The scope grew from the
+# scripts/fleet/ v1 (#2047) to the whole scripts/ tree in #2054 — the render /
+# perf / gui harnesses (render-verify.py, gui-verify.py, render_metric_util.py,
+# scripts/perf/compare_perf_runs.py, …) now lint under the same rule set.
 
 # 100, not ruff's default 88: the existing fleet Python was written to a ~100-col
 # soft limit (96 of 106 pre-existing E501s were 89–99 chars), and PEP8 itself
@@ -26,7 +28,10 @@ line-length = 100
 # explicitly — NOT via a `fleet-*` glob — because the largest fleet scripts
 # (fleet-claim, fleet-dispatcher, fleet-up, fleet-babysit, fleet-rebase) are
 # bash, and feeding bash to ruff yields thousands of false positives. Add a new
-# Python executable here when one is introduced.
+# Python executable here when one is introduced. (The render / perf / gui
+# harnesses outside scripts/fleet/ all carry a .py extension, so ruff's
+# directory scan discovers them automatically — only extension-less Python
+# executables need listing here, and those all live under scripts/fleet/.)
 extend-include = [
     "scripts/fleet/fleet-claude-stream",
     "scripts/fleet/fleet-epic-status",
@@ -56,5 +61,8 @@ extend-exclude = [
 select = ["E", "W", "F", "I", "S101"]
 
 [lint.per-file-ignores]
-# pytest-style test modules use `assert` as their assertion primitive.
+# Test modules use `assert` as their assertion primitive (pytest-style under
+# scripts/fleet/tests/; the scripts/tests/ render-metric suite is unittest-based
+# today but carved out uniformly so a future bare-assert test isn't blocked).
 "scripts/fleet/tests/**" = ["S101"]
+"scripts/tests/**" = ["S101"]

--- a/scripts/cull-verify.py
+++ b/scripts/cull-verify.py
@@ -39,7 +39,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
 RENDER_COMPARE = SCRIPT_DIR / "render-compare.py"
@@ -236,7 +235,14 @@ def main(argv: list[str] | None = None) -> int:
     all_shots = _collect_shots(shots_dir)
     live_shots = all_shots[LIVE_START:LIVE_END]
     frozen_shots = all_shots[FROZEN_START:FROZEN_END]
-    assert len(live_shots) == len(frozen_shots) == POSES_PER_PHASE
+    if not (len(live_shots) == len(frozen_shots) == POSES_PER_PHASE):
+        print(
+            f"[cull-verify] expected {POSES_PER_PHASE} live and {POSES_PER_PHASE} frozen shots, "
+            f"got {len(live_shots)} live / {len(frozen_shots)} frozen "
+            f"(captured {len(all_shots)} total) — run did not produce the full pose set.",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.update_baselines:
         baseline_dir = demo_dir / "test" / "references" / backend / "cull-verify"

--- a/scripts/gui-verify.py
+++ b/scripts/gui-verify.py
@@ -12,10 +12,9 @@ Usage:
 
 import re
 import subprocess
-import sys
-from pathlib import Path
 
-# Pattern: GUI-ASSERT shot=<N> label=<lbl> kind=<K> target=<eid> name=<tag> result=PASS|FAIL actual=<val>
+# Pattern: GUI-ASSERT shot=<N> label=<lbl> kind=<K> target=<eid> name=<tag>
+#          result=PASS|FAIL actual=<val>
 _GUI_ASSERT_RE = re.compile(
     r"GUI-ASSERT\s+"
     r"shot=(\S+)\s+"

--- a/scripts/perf/compare_perf_runs.py
+++ b/scripts/perf/compare_perf_runs.py
@@ -21,13 +21,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
-
+from typing import Dict, Iterable, List, Optional
 
 # --- Parser --------------------------------------------------------------
 
@@ -297,10 +295,12 @@ def format_frame_row(
     p99_b, p99_h = base.frame.p99, head.frame.p99
     avg_delta = pct_delta(avg_b, avg_h)
     p99_delta = pct_delta(p99_b, p99_h)
+    avg_mark = mark(avg_delta, regress_pct, improve_pct)
+    p99_mark = mark(p99_delta, regress_pct, improve_pct)
     return (
         f"| `{cell_id}` "
-        f"| {avg_b:.2f} → {avg_h:.2f} ({avg_delta:+.1f}%){mark(avg_delta, regress_pct, improve_pct)} "
-        f"| {p99_b:.2f} → {p99_h:.2f} ({p99_delta:+.1f}%){mark(p99_delta, regress_pct, improve_pct)} |"
+        f"| {avg_b:.2f} → {avg_h:.2f} ({avg_delta:+.1f}%){avg_mark} "
+        f"| {p99_b:.2f} → {p99_h:.2f} ({p99_delta:+.1f}%){p99_mark} |"
     )
 
 
@@ -369,7 +369,9 @@ def render_markdown(
         out.append("| cell | avg | p99 |")
         out.append("|------|-----|-----|")
         for cell_id in matched:
-            out.append(format_frame_row(cell_id, base[cell_id], head[cell_id], regress_pct, improve_pct))
+            out.append(
+                format_frame_row(cell_id, base[cell_id], head[cell_id], regress_pct, improve_pct)
+            )
         out.append("")
 
     if not cpu_only:
@@ -413,9 +415,10 @@ def render_markdown(
                 sb = base_cell.system_by_name(s.name)
                 bv = sb.avg_ms if sb else 0.0
                 delta = pct_delta(bv, s.avg_ms)
+                row_mark = mark(delta, regress_pct, improve_pct)
                 out.append(
                     f"| {s.pipeline} | `{s.name}` "
-                    f"| {bv:.3f} → {s.avg_ms:.3f} ({delta:+.1f}%){mark(delta, regress_pct, improve_pct)} |"
+                    f"| {bv:.3f} → {s.avg_ms:.3f} ({delta:+.1f}%){row_mark} |"
                 )
             out.append("")
 

--- a/scripts/perf/perf_summary.py
+++ b/scripts/perf/perf_summary.py
@@ -42,7 +42,10 @@ def main() -> int:
     print(f"location: `{run_dir}`")
     print(f"cells: {len(cells)}")
     print()
-    print("| cell | frame avg | p99 | entities | cull (vis/total) | top UPDATE system | top GPU stage |")
+    print(
+        "| cell | frame avg | p99 | entities | cull (vis/total) "
+        "| top UPDATE system | top GPU stage |"
+    )
     print("|------|-----------|-----|----------|------------------|-------------------|---------------|")
     for cell_id in sorted(cells):
         c = cells[cell_id]

--- a/scripts/render-compare.py
+++ b/scripts/render-compare.py
@@ -31,7 +31,6 @@ import zlib
 from array import array
 from typing import Tuple
 
-
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 

--- a/scripts/render-verify.py
+++ b/scripts/render-verify.py
@@ -68,7 +68,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
 RENDER_COMPARE = SCRIPT_DIR / "render-compare.py"
@@ -634,7 +633,10 @@ def main(argv: list[str] | None = None) -> int:
     # CLI --warmup wins; manifest["warmup"] overrides the hardcoded default of 10.
     warmup: int = args.warmup if args.warmup is not None else manifest.get("warmup", 10)
 
-    print(f"[render-verify] target={args.target} demo={demo_name} backend={backend} warmup={warmup}")
+    print(
+        f"[render-verify] target={args.target} demo={demo_name} "
+        f"backend={backend} warmup={warmup}"
+    )
     print(f"[render-verify] {len(shot_labels)} shots: {', '.join(shot_labels)}")
 
     if extra_runs:


### PR DESCRIPTION
## Summary
- Widen ruff's canonical scope from `scripts/fleet/` to all of `scripts/` so the render / perf / gui harnesses lint under the same rule set (config/CI/doc surface: `ruff.toml`, CI `quality.yml`, `BUILD.md` / `CLAUDE-BASELINE.md` / `commit-and-push.md`). Adds a `scripts/tests/**` S101 carve-out matching the existing fleet-tests one.
- Lint-fix pass over the newly-covered harnesses, **file-disjoint** from the config changes above: `ruff --fix` sorted/pruned imports, 7 `E501` lines hand-wrapped, and `cull-verify.py`'s bare-`assert` pose-count guard → explicit `-O`-safe check that prints a diagnostic and returns non-zero. No `# noqa` suppressions.
- No `extend-include` additions: every non-fleet harness carries a `.py` extension, so ruff auto-discovers them (only the extension-less fleet executables need listing, and those are unchanged).

## Test plan
- [x] `ruff check scripts/` exits 0 (the widened acceptance gate)
- [x] `ruff check scripts/fleet/` still clean — no regression on the v1 scope
- [x] `python3 -m unittest discover -s scripts/tests` — all 81 tests pass

Closes #2054

🤖 Generated with [Claude Code](https://claude.com/claude-code)