### PR TITLE
fleet: scout infers needs_gl_host from an explicit body host-requirement

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -401,6 +401,35 @@ _EPIC_CHECKLIST_RE = re.compile(
     r'^[ \t]*-[ \t]*\[( |x|X)\][ \t].*?#(\d+)', re.MULTILINE)
 
 
+# #1969: a task whose body explicitly declares it must run on a Linux / Windows
+# / OpenGL host, but is missing the fleet:needs-gl-host label, is invisible to
+# the label-based host gate (fetch_task_queue below). On a Metal-only (mac) host
+# the dispatcher then keeps electing it (oldest claimable) and a worker
+# claims -> can't build -> releases, churning the lane and starving other
+# classes (the #1969 incident: a "refresh linux-debug render-verify references"
+# task that can only run on Linux). Infer the gate from the body as a backstop so
+# the projection treats such a task as host-incompatible even when the label was
+# forgotten at filing. Deliberately PRECISION-first — only a strong requirement
+# phrasing ("must run on" / "must be run on" / "only runs/builds on" a
+# linux/windows/opengl host) matches, never a passing mention ("tested on a
+# Linux host"). A false positive would wrongly skip a mac-runnable task, which is
+# worse than a miss (a miss just churns like before), so recall is sacrificed for
+# precision; the explicit label remains the primary, recommended signal. macOS
+# host declarations don't match (the OS alternation is linux/windows/opengl), so
+# a mac-only task is never self-gated off its own host.
+_GL_HOST_REQUIRED_RE = re.compile(
+    r"\b(?:must\s+(?:be\s+)?run\s+on|only\s+(?:runs?|builds?)\s+on)\s+"
+    r"(?:an?\s+|the\s+)?(?:linux|windows|opengl)[\w/+-]*\s+host\b",
+    re.IGNORECASE,
+)
+
+
+def _body_requires_gl_host(body):
+    """True when the task body explicitly declares a Linux/Windows/OpenGL host
+    requirement — a backstop for a missing fleet:needs-gl-host label (#1969)."""
+    return bool(_GL_HOST_REQUIRED_RE.search(body or ""))
+
+
 def _parse_epic_checklist(body):
     """[{number, checked}] for every `- [ ] #N` / `- [x] #N` row in an
     umbrella body, in document order. Indented sub-bullets count; lines
@@ -530,8 +559,11 @@ def fetch_task_queue(repo_slug):
             # needs an OpenGL-4.5 host (linux/windows); macOS/Metal panes can't
             # build/run/verify it. Surfaced here so the dispatcher's claimability
             # filter (fleet_task_class.py) skips it on a Metal host instead of
-            # churning claim->refuse->release no-ops.
-            "needs_gl_host": "fleet:needs-gl-host" in labels,
+            # churning claim->refuse->release no-ops. #1969: also inferred from an
+            # explicit host-requirement declaration in the body, as a backstop
+            # for a label the filer forgot (see _GL_HOST_REQUIRED_RE).
+            "needs_gl_host": ("fleet:needs-gl-host" in labels
+                              or _body_requires_gl_host(body)),
             "issue": task_id,
             # `**Part of epic:** #U` back-ref (raw field value, e.g. "#1661").
             # The epic-steward adoption projection joins this against open

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -514,6 +514,39 @@ class NeedsGlHostAnnotation(unittest.TestCase):
         self.assertEqual(len(result["open"]), 1)
         self.assertFalse(result["open"][0]["needs_gl_host"])
 
+    def _issue_body(self, number, body):
+        iss = self._issue(number)
+        iss["body"] = body
+        return iss
+
+    def test_needs_gl_host_inferred_from_body_declaration(self):
+        # #1969: body explicitly requires a Linux host but the label was
+        # forgotten — inferred so a Metal pane skips it instead of churning.
+        for phrase in (
+            "This must run on a Linux host — references are per-backend.",
+            "must be run on a Windows host to refresh windows-debug refs.",
+            "Only runs on an OpenGL host.",
+            "must run on a Linux/Windows host",
+        ):
+            with self.subTest(phrase=phrase):
+                result = self._fetch([self._issue_body(1969, f"**Model:** sonnet\n{phrase}")])
+                self.assertTrue(result["open"][0]["needs_gl_host"],
+                                f"expected inferred gl-host for: {phrase}")
+
+    def test_needs_gl_host_not_inferred_from_passing_mention(self):
+        # Precision guard: a passing mention or a macOS requirement must NOT
+        # self-gate (over-gating would strand a mac-runnable task).
+        for phrase in (
+            "Tested on a Linux host previously.",
+            "The Linux build is faster than macOS.",
+            "must run on a macOS host",        # mac task — not a GL gate
+            "compare against the linux-debug references",
+        ):
+            with self.subTest(phrase=phrase):
+                result = self._fetch([self._issue_body(2000, f"**Model:** opus\n{phrase}")])
+                self.assertFalse(result["open"][0]["needs_gl_host"],
+                                 f"unexpected gl-host inference for: {phrase}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Hardens against the opus-starvation incident we just hit on the Mac fleet.

**#1969** ("refresh linux-debug render-verify references") declares in its body *"This must run on a Linux host"* but was missing `fleet:needs-gl-host`. So the label-based host gate saw it as claimable on Mac → the dispatcher kept electing it (oldest claimable → sonnet) → a worker claimed, couldn't build Linux refs on Metal, released → churn, and the queued **opus** tasks starved for ~13 min. (The filer labeled the macos sibling #1944 to run on Mac but forgot the gate here.)

### Fix

`fetch_task_queue` now also infers `needs_gl_host` from an explicit host-requirement declaration in the body — a backstop for a forgotten label:

```
needs_gl_host = "fleet:needs-gl-host" in labels OR _body_requires_gl_host(body)
```

**Precision-first by design.** A false positive would wrongly skip a *mac-runnable* task (strands it) — worse than a miss (a miss just churns as before) — so the regex matches only a strong requirement phrasing (`must run on` / `must be run on` / `only runs/builds on` **a linux/windows/opengl host**), never:
- a passing mention (`tested on a Linux host`, `the linux-debug references`)
- a **macOS** requirement (the OS alternation is linux/windows/opengl, so a mac-only task never self-gates off its own host)

The explicit label stays the primary, recommended signal; this is the safety net.

## Test plan

- [x] Real #1969 body → `_body_requires_gl_host` returns `True`
- [x] `NeedsGlHostAnnotation` gains: 4 requirement phrasings (inferred True) + 4 negatives (passing mention / macOS / `linux-debug` path → False)
- [x] Full `test_worker_projection.py` green; full fleet Python suite green except the pre-existing `test_fleet_validate_roles` drift

## Scope note

This stops a host-mismatched task from *entering* the election (the surgical fix for the recurring host-mismatch category: #1937, #1998, #1969). The deeper, more general guard — having the dispatcher serve another claimable class when the elected class is fully cap-covered, so no single slow/churning head can defer other classes — is a larger dispatcher change I left as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)