### PR TITLE
fleet: fix cross-host amending-claim deadlock (#2099)

### DIFF
--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -318,6 +318,109 @@ except Exception:
 ' 2>/dev/null || echo 0
 }
 
+# _amending_heartbeat_fresh <label-name>
+#   True (exit 0) iff <label-name> is a fleet:amending-<host>-<agent> label
+#   whose <host> is THIS machine AND the owning agent's host-local heartbeat
+#   (~/.fleet/heartbeats/<agent>) is fresh (< FLEET_CLAIM_STALE_SECS). Used by
+#   the cleanup amending-sweep and the _acquire_label_on force-sweep as the
+#   "the owner is still alive, don't sweep its claim" guard.
+#
+#   Heartbeats are HOST-LOCAL: only the owning host's worker touches its own
+#   ~/.fleet/heartbeats/<agent>. A cross-host amending label's owner
+#   heartbeats on its OWN host, which the sweeping/claiming host cannot
+#   observe. Keying the freshness check by bare basename let a same-basename
+#   local worker (e.g. mac-worker-1) spoof freshness for a dead cross-host
+#   claim (windows-worker-1) and skip its sweep forever — the #2099 deadlock.
+#   So this returns false (exit 1) for cross-host amending labels, for
+#   non-amending labels (reviewing/resolving/claim carry no heartbeat
+#   semantics), and when the same-host heartbeat is missing or stale. Callers
+#   treat a false result as "fall through to label-age TTL".
+_amending_heartbeat_fresh() {
+    local label_name="$1"
+    [[ "$label_name" == fleet:amending-* ]] || return 1
+    local after="${label_name#fleet:amending-}"
+    local claim_host="" claim_agent="" hp
+    for hp in mac linux windows; do
+        if [[ "$after" == "${hp}-"* ]]; then
+            claim_host="$hp"
+            claim_agent="${after#${hp}-}"
+            break
+        fi
+    done
+    [[ -n "$claim_agent" ]] || return 1
+    # Cross-host: the owner's heartbeat lives on its host, not ours — we
+    # cannot vouch for it, so fall through to pure label-age TTL.
+    [[ "$claim_host" == "$(derive_host)" ]] || return 1
+    local hb_file="$HOME/.fleet/heartbeats/$claim_agent"
+    [[ -f "$hb_file" ]] || return 1
+    local hb_mtime
+    hb_mtime=$(python3 -c \
+        "import os,sys; print(int(os.path.getmtime(sys.argv[1])))" \
+        "$hb_file" 2>/dev/null || echo 0)
+    [[ "$hb_mtime" -gt 0 ]] || return 1
+    local stale_secs="${FLEET_CLAIM_STALE_SECS:-1800}"
+    local now
+    now=$(date +%s)
+    (( now - hb_mtime < stale_secs ))
+}
+
+# _sweep_stale_prefix_holders <repo> <target> <prefix> <mine>
+#   Defense-in-depth for _acquire_label_on: when the lex-min retry loop
+#   exhausts against a persistent <prefix>* holder that never yields — a dead
+#   or abandoned claimant, classically a cross-host one whose host can't sweep
+#   it and whose lex-larger name a live lex-smaller claimant keeps losing to
+#   (#2099) — force-remove any holder whose label is past TTL so the live
+#   claimant can take over instead of yielding forever. Returns 0 iff it
+#   removed >=1 holder (caller should re-attempt the claim), 1 otherwise.
+#
+#   Scoped to the transient PR-label claims (reviewing/resolving/amending).
+#   Issue `fleet:claim-*` locks have their own longer-TTL + PR-existence sweep
+#   in cmd_cleanup_gh and must not be second-guessed from the claim hot path.
+#   Reuses the cleanup sweep's host-qualified staleness predicate: a same-host
+#   amending label with a fresh heartbeat is never force-swept.
+_sweep_stale_prefix_holders() {
+    local repo="$1" target="$2" prefix="$3" mine="$4"
+    case "$prefix" in
+        fleet:reviewing-|fleet:resolving-|fleet:amending-) ;;
+        *) return 1 ;;
+    esac
+    command -v gh >/dev/null 2>&1 || return 1
+    local labels_json
+    labels_json=$(gh api "repos/${repo}/issues/${target}/labels" 2>/dev/null) || return 1
+    local holders
+    holders=$(echo "$labels_json" | python3 -c '
+import json, sys
+try:
+    labels = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+prefix = sys.argv[1]
+for name in sorted(
+        l["name"] for l in labels
+        if isinstance(l, dict) and l.get("name", "").startswith(prefix)):
+    print(name)
+' "$prefix" 2>/dev/null || echo "")
+    [[ -z "$holders" ]] && return 1
+    local stale_secs="${FLEET_CLAIM_STALE_SECS:-1800}"
+    local now
+    now=$(date +%s)
+    local swept=1   # 1 = nothing swept (false)
+    local h added
+    while IFS= read -r h; do
+        [[ -z "$h" || "$h" == "$mine" ]] && continue
+        added=$(label_added_epoch "$repo" "$target" "$h")
+        [[ "$added" -gt 0 ]] || continue            # unknown age — leave it
+        (( now - added < stale_secs )) && continue  # within TTL — legit holder
+        _amending_heartbeat_fresh "$h" && continue  # same-host live owner
+        if gh issue edit "$target" --repo "$repo" --remove-label "$h" >/dev/null 2>&1; then
+            echo "fleet-claim: force-swept TTL-stale '$h' on $repo#$target" \
+                 "(age $(( (now - added) / 60 ))m); re-acquiring" >&2
+            swept=0
+        fi
+    done <<< "$holders"
+    return "$swept"
+}
+
 # _claim_decision <mine> <matching-label>...
 #   PURE decision helper (no I/O) — the table-testable seam for the claim
 #   mutex. Given my just-POSTed label and the full set of <prefix>* labels
@@ -378,7 +481,9 @@ _acquire_jitter_sleep() {
 _acquire_label_on() {
     local repo="$1" target="$2" label="$3" prefix="$4"
     local retries="${FLEET_CLAIM_ACQUIRE_RETRIES:-3}"
+    local force_swept=0
     local attempt
+    while :; do
     for (( attempt = 1; attempt <= retries; attempt++ )); do
         local labels_json
         if ! labels_json=$(gh api "repos/${repo}/issues/${target}/labels" \
@@ -436,10 +541,20 @@ for name in sorted(
     done
 
     # Exhausted the retry budget while always lex-min: an earlier holder
-    # persists and never yielded (the non-simultaneous #1384 case). Our
-    # label was already removed by the final retry's release. Yield.
+    # persists and never yielded — the non-simultaneous #1384 case, or a
+    # dead/abandoned (classically cross-host) claimant that will never yield
+    # (#2099). Our label was already removed by the final retry's release.
+    # Before giving up, try ONCE to force-sweep any TTL-stale holder so a live
+    # claimant can take over; if that frees a slot, re-run the acquire loop.
+    if [[ "$force_swept" -eq 0 ]] \
+            && _sweep_stale_prefix_holders "$repo" "$target" "$prefix" "$label"; then
+        force_swept=1
+        continue
+    fi
+
     echo "fleet-claim: gave up after ${retries} attempt(s); an earlier ${prefix}* holder persists on $repo#$target" >&2
     return 1
+    done
 }
 
 # --- issue lookup ---------------------------------------------------------
@@ -1586,29 +1701,14 @@ for pr in prs:
             # For amending claims: skip the sweep when the claiming agent's
             # heartbeat is still fresh — an active heartbeat means the worker
             # is alive and TTL-sweeping its claim would cause duplicate dispatch
-            # by triggering the R7 heal (#1650).
-            if [[ "$label_name" == fleet:amending-* ]]; then
-                local _after_pfx="${label_name#fleet:amending-}"
-                local _claim_agent=""
-                for _host_pfx in "mac-" "linux-" "windows-"; do
-                    if [[ "$_after_pfx" == "${_host_pfx}"* ]]; then
-                        _claim_agent="${_after_pfx#${_host_pfx}}"
-                        break
-                    fi
-                done
-                if [[ -n "$_claim_agent" ]]; then
-                    local _hb_file="$HOME/.fleet/heartbeats/$_claim_agent"
-                    if [[ -f "$_hb_file" ]]; then
-                        local _hb_mtime
-                        _hb_mtime=$(python3 -c \
-                            "import os,sys; print(int(os.path.getmtime(sys.argv[1])))" \
-                            "$_hb_file" 2>/dev/null || echo 0)
-                        if [[ "$_hb_mtime" -gt 0 && $(( now - _hb_mtime )) -lt $stale_secs ]]; then
-                            echo "cleanup --gh: skipping '$label_name' on $repo PR#$pr_num — agent '$_claim_agent' heartbeat fresh ($(( now - _hb_mtime ))s ago)"
-                            continue
-                        fi
-                    fi
-                fi
+            # by triggering the R7 heal (#1650). The freshness check is
+            # host-qualified (#2099): heartbeats are host-local, so only a
+            # SAME-HOST amending label's heartbeat is observable here. A
+            # cross-host stale label ages out on pure TTL — never honor a
+            # same-basename local worker's heartbeat for it.
+            if _amending_heartbeat_fresh "$label_name"; then
+                echo "cleanup --gh: skipping '$label_name' on $repo PR#$pr_num — same-host owner heartbeat fresh"
+                continue
             fi
 
             if gh issue edit "$pr_num" --repo "$repo" \
@@ -4197,8 +4297,10 @@ commands:
                                 (1) stale fleet:reviewing-*,
                                     fleet:resolving-*, and
                                     fleet:amending-* labels off open
-                                    PRs (>30 min age; amending labels
-                                    skipped if agent heartbeat fresh),
+                                    PRs (>30 min age; a same-host
+                                    amending label is skipped if its
+                                    agent heartbeat is fresh — cross-
+                                    host ones age out on pure TTL),
                                 (2) fleet:claim-* labels off open
                                     issues where the claim is
                                     abandoned — age > TTL (default

--- a/scripts/fleet/tests/test_fleet_claim_acquire.sh
+++ b/scripts/fleet/tests/test_fleet_claim_acquire.sh
@@ -169,6 +169,98 @@ rc=0
 _acquire_label_on "owner/repo" 1 "$LARGE" "$P" >/dev/null 2>&1 || rc=$?
 assert_exit "$rc" 1 "earlier/lex-smaller holder remains → exit 1"
 
+echo "== _acquire_label_on force-sweep of a dead persistent holder (#2099) =="
+
+# When the lex-min retry loop exhausts against a holder that never yields — a
+# dead/abandoned (classically cross-host) claimant — a live lex-smaller
+# claimant would lose the tie-break forever. The exhaustion path now force-
+# sweeps any TTL-stale holder once, then re-acquires. Stateful gh stub: POST
+# echoes holders + posted; GET (labels, no --method POST) echoes holders;
+# events → STUB_EVENTS_TS for label_added_epoch; remove-label mutates holders.
+STUB_EVENTS_TS="2020-01-01T00:00:00Z"   # long past any TTL → holder is sweepable
+gh() {
+    case "${1:-}" in
+        api)
+            local a posted="" is_events=0
+            for a in "$@"; do
+                case "$a" in
+                    labels\[\]=*) posted="${a#labels[]=}" ;;
+                    *events*) is_events=1 ;;
+                esac
+            done
+            if [[ "$is_events" -eq 1 ]]; then
+                printf '%s\n' "$STUB_EVENTS_TS"
+                return 0
+            fi
+            local out='[' first=1 h
+            for h in $STUB_HOLDERS $posted; do
+                [[ $first -eq 1 ]] || out+=','
+                out+="{\"name\":\"$h\"}"
+                first=0
+            done
+            out+=']'
+            printf '%s\n' "$out"
+            return 0
+            ;;
+        issue|pr)
+            local args=("$@") i rl=""
+            for (( i = 0; i < ${#args[@]}; i++ )); do
+                [[ "${args[i]}" == "--remove-label" ]] && rl="${args[i+1]}"
+            done
+            if [[ -n "$rl" ]]; then
+                local newh="" h
+                for h in $STUB_HOLDERS; do
+                    [[ "$h" == "$rl" ]] || newh+=" $h"
+                done
+                STUB_HOLDERS="${newh# }"
+            fi
+            return 0
+            ;;
+        *) return 0 ;;
+    esac
+}
+
+export FLEET_TEST_HOST="mac"
+HBROOT=$(mktemp -d)
+export HOME="$HBROOT"
+mkdir -p "$HOME/.fleet/heartbeats"
+trap 'rm -rf "$HBROOT"' EXIT
+
+# T9: dead persistent reviewing holder, past TTL → force-swept, I re-acquire.
+# The acquire prefix is the canonical host-agnostic "fleet:reviewing-" (the
+# <host> is part of the label, not the prefix) — that's what the real
+# review-claim path passes, and what the force-sweep's prefix gate matches.
+RP="fleet:reviewing-"
+echo "T9: lex-min claimant vs TTL-stale persistent holder → force-sweep + win"
+STUB_HOLDERS="$LARGE"
+rc=0
+_acquire_label_on "owner/repo" 1 "$SMALL" "$RP" >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 0 "TTL-stale reviewing holder force-swept → exit 0 (took the lock)"
+
+# T10: dead cross-host amending holder, basename collides with a live local
+# worker — the exact #2099 geometry. Host-qualified heartbeat check does NOT
+# vouch for the cross-host owner, so the stale label is force-swept.
+echo "T10: cross-host dead amending holder (basename collision) → force-sweep + win"
+AP="fleet:amending-"
+AMINE="${AP}mac-worker-2"          # lex-smaller than windows-worker-1
+ADEAD="${AP}windows-worker-1"
+touch "$HOME/.fleet/heartbeats/worker-1"   # live LOCAL worker-1 (spoof bait)
+STUB_HOLDERS="$ADEAD"
+rc=0
+_acquire_label_on "owner/repo" 1 "$AMINE" "$AP" >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 0 "cross-host amending holder force-swept despite local same-basename heartbeat → exit 0"
+
+# T11: live SAME-HOST amending holder with a fresh heartbeat → NOT swept; the
+# lex-min claimant correctly yields rather than stealing an active amend.
+echo "T11: live same-host amending holder (fresh heartbeat) → not swept, yield"
+ALIVE="${AP}mac-worker-3"
+AMINE2="${AP}mac-worker-1"          # lex-smaller than mac-worker-3
+touch "$HOME/.fleet/heartbeats/worker-3"   # owner of the held label is alive
+STUB_HOLDERS="$ALIVE"
+rc=0
+_acquire_label_on "owner/repo" 1 "$AMINE2" "$AP" >/dev/null 2>&1 || rc=$?
+assert_exit "$rc" 1 "live same-host amending owner kept → exit 1 (yield, no theft)"
+
 echo
 echo "fleet-claim acquire tests: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_fleet_claim_amending_sweep.sh
+++ b/scripts/fleet/tests/test_fleet_claim_amending_sweep.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tests for the host-qualified amending-sweep in `fleet-claim cleanup --gh`'s
+# PR-label pass (#2099).
+#
+# The amending-sweep skips removing a past-TTL fleet:amending-<host>-<agent>
+# label when the owning agent's heartbeat is fresh — an active worker is mid
+# amend and sweeping its claim would trigger a duplicate dispatch (#1650). But
+# heartbeats are HOST-LOCAL: ~/.fleet/heartbeats/<agent> is touched only by the
+# worker on its own host. The old code keyed the freshness check by bare
+# basename, so when the sweep ran on host B (mac) over a host-A (windows)
+# amending label, it read *mac*'s heartbeat for the same basename. With a
+# same-basename mac worker alive, the sweep saw a fresh heartbeat and skipped
+# the stale cross-host label forever — the 32h #2089 deadlock.
+#
+# Fix: host-qualify the freshness skip. Only honor a fresh heartbeat for a
+# SAME-HOST amending label; a cross-host label ages out on pure TTL.
+#
+# Every label here is reported as added long ago (events stub → 2020), so the
+# age gate is always satisfied — the heartbeat host-qualification alone decides
+# what survives.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+
+if [[ ! -x "$FLEET_CLAIM" ]]; then
+    echo "test setup: fleet-claim not found at $FLEET_CLAIM" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+cleanup() { [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS + 1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+assert_removed_contains() {
+    if grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; then ok "$2"; else bad "$2 (not swept)"; fi
+}
+assert_removed_absent() {
+    if ! grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; then ok "$2"; else bad "$2 (unexpectedly swept)"; fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_RESERVATIONS_DIR="$TMPROOT/reservations"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+export FLEET_TEST_HOST="mac"
+# Heartbeats live under $HOME/.fleet/heartbeats/<agent> (host-local, no env
+# override) — isolate them in the sandbox.
+export HOME="$TMPROOT/home"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_RESERVATIONS_DIR" "$FLEET_STATE_DIR" \
+    "$FLEET_ORPHANS_DIR" "$HOME/.fleet/heartbeats"
+
+export PRS_JSON="$TMPROOT/prs.json"
+export ISSUES_JSON="$TMPROOT/issues.json"
+echo '[]' > "$ISSUES_JSON"   # no claim/steward labels to sweep in the later passes
+REMOVED_FILE="$TMPROOT/removed.log"; : > "$REMOVED_FILE"; export REMOVED_FILE
+
+STUB_DIR="$TMPROOT/bin"; mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    pr)
+        case "$2" in
+            list) cat "$PRS_JSON"; exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    issue)
+        case "$2" in
+            list) cat "$ISSUES_JSON"; exit 0 ;;
+            edit)
+                shift 2; issue="$1"; shift
+                while [[ $# -gt 0 ]]; do
+                    case "$1" in
+                        --remove-label) printf '%s\t%s\n' "$issue" "$2" >> "$REMOVED_FILE"; shift 2 ;;
+                        *) shift ;;
+                    esac
+                done
+                exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    api)
+        # events endpoint — report every label as added long ago so the age
+        # TTL is always elapsed; the heartbeat host-qualification alone decides.
+        printf '%s ' "$@" | grep -q 'events' && echo "2020-01-01T00:00:00Z"
+        exit 0 ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+# Live same-host workers. worker-1 collides (by basename) with the dead
+# cross-host windows-worker-1 amending label below — the exact spoof geometry.
+touch "$HOME/.fleet/heartbeats/worker-1"
+touch "$HOME/.fleet/heartbeats/worker-2"
+# (no heartbeat for worker-3 → its same-host claim is genuinely abandoned)
+
+# 800 cross-host (windows) amending, basename collides with live mac-worker-1
+#       -> swept (cannot observe windows's heartbeat; TTL governs) [the bug]
+# 801 same-host (mac) amending, owner worker-2 heartbeat fresh
+#       -> kept (live same-host owner)
+# 802 same-host (mac) amending, owner worker-3 has no heartbeat
+#       -> swept (abandoned)
+# 803 cross-host (windows) reviewing — no heartbeat semantics
+#       -> swept (pure TTL, unchanged)
+cat > "$PRS_JSON" <<'JSON'
+[
+  {"number":800,"labels":[{"name":"fleet:wip"},{"name":"fleet:amending-windows-worker-1"}]},
+  {"number":801,"labels":[{"name":"fleet:wip"},{"name":"fleet:amending-mac-worker-2"}]},
+  {"number":802,"labels":[{"name":"fleet:wip"},{"name":"fleet:amending-mac-worker-3"}]},
+  {"number":803,"labels":[{"name":"fleet:reviewing-windows-worker-1"}]}
+]
+JSON
+
+echo "=== cleanup --gh host-qualified amending sweep ==="
+OUT=$("$FLEET_CLAIM" cleanup --gh --repo jakildev/IrredenEngine 2>&1 || true)
+echo "$OUT" | sed 's/^/    /'
+
+assert_removed_contains $'800\tfleet:amending-windows-worker-1' \
+    "cross-host amending label swept despite a fresh same-basename local heartbeat (#2099)"
+assert_removed_absent   $'801\tfleet:amending-mac-worker-2' \
+    "same-host amending label with a fresh owner heartbeat kept"
+assert_removed_contains $'802\tfleet:amending-mac-worker-3' \
+    "same-host amending label with no owner heartbeat swept (abandoned)"
+assert_removed_contains $'803\tfleet:reviewing-windows-worker-1' \
+    "cross-host reviewing label swept on pure TTL (no heartbeat semantics)"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- A dead cross-host `fleet:amending-*` claim deadlocked PR #2089 for ~32h — unclaimable AND un-swept. Two interacting root causes, both fixed.
- **Bug 1 (un-swept):** `cmd_cleanup_gh`'s amending heartbeat-fresh skip was keyed by bare worktree basename, reading the *sweeping* host's `~/.fleet/heartbeats/<agent>`. Heartbeats are host-local, so a same-basename local worker (mac-worker-1) spoofed a fresh heartbeat for a dead cross-host claim (windows-worker-1) and the stale label survived forever. Now host-qualified via a new `_amending_heartbeat_fresh` helper — only a same-host amending label honors its heartbeat; cross-host labels age out on pure TTL.
- **Bug 2 (unclaimable):** `_acquire_label_on`'s lex-min retry loop assumed the lex-larger holder yields. A dead claimant never does, so a live lex-smaller claimant lost the tie-break forever. On exhaustion it now force-sweeps TTL-stale holders once (`reviewing`/`resolving`/`amending` only — `fleet:claim-*` keeps its own longer-TTL + PR-existence sweep) reusing the same host-qualified staleness predicate, then re-acquires. Bounded to a single sweep round.

## Test plan
- [x] `test_fleet_claim_amending_sweep.sh` — cross-host amending label swept despite a fresh same-basename local heartbeat; same-host live owner kept; same-host abandoned + cross-host reviewing swept (4/4).
- [x] `test_fleet_claim_acquire.sh` — existing T1–T8 unchanged + T9–T11 force-sweep matrix (reviewing TTL-stale → swept+win; cross-host dead amending → swept+win; same-host live amending → kept+yield) (13/13).
- [x] Full `test_fleet_claim_*.sh` + `test_reconcile_amendments.sh` + `test_fleet_pr_claim_feedback.sh` suite green (16/16).
- [x] `bash -n` clean; `ruff check scripts/fleet/` clean.

Closes #2099

🤖 Generated with [Claude Code](https://claude.com/claude-code)