### PR TITLE
fleet: resume interrupted worker/reviewer sessions by stored session-id

### DIFF
--- a/docs/agents/FLEET-RUNTIME.md
+++ b/docs/agents/FLEET-RUNTIME.md
@@ -165,7 +165,11 @@ this piece is a no-op at shutdown.
 
 Then exit cleanly. `fleet-dispatcher` launches a fresh `claude` for the
 role when the scout's projection sees new actionable state — no
-carry-over between iterations.
+carry-over between iterations, except when `fleet-dispatch-wrap`'s
+session-id sidecar resumes a worker/sonnet-reviewer/opus-reviewer
+session after a hard kill (the resumed session keeps its full prior
+context; see `fleet-dispatch-wrap`'s "Session-id persistence" comment
+block).
 
 ---
 

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -88,16 +88,91 @@ mkdir -p "$RATE_LIMIT_DIR"
 export FLEET_THROTTLE_FLAG="$RATE_LIMIT_DIR/$PANE_KEY.throttle-seen"
 rm -f "$FLEET_THROTTLE_FLAG"
 
-# --fallback-model only exists in print mode, which is exactly this path.
-# When the dispatcher hands us a chain, claude retries the iteration on
-# the fallback model(s) if $MODEL is overloaded or no longer available.
-CLAUDE_ARGS=(--model "$MODEL" --effort "$EFFORT" --print
-    --output-format stream-json --include-partial-messages --verbose)
-if [[ -n "$FALLBACK_MODEL" ]]; then
-    CLAUDE_ARGS+=(--fallback-model "$FALLBACK_MODEL")
+# --- Session-id persistence + interrupted-session resume (workers + reviewers) ---
+#
+# Each iteration normally launches a FRESH `claude --session-id <uuid>` running
+# `/role-<role>`. On an interruption (fleet-down/up, crash, a killed pane) the
+# next dispatch can instead `claude --resume <uuid>` to reload the exact prior
+# session — its in-context understanding of the task, the diff, the plan — rather
+# than re-deriving all of it from the claim/reservation (expensive + lossy). The
+# resume is gated by a per-worktree sidecar that is written at launch and cleared
+# on a clean, work-finished exit; a hard kill skips this script's post-claude
+# cleanup, so the sidecar survives and the next dispatch resumes. Verified
+# feasible on CLI 2.1.196 (the #1320 thinking-block 400 no longer reproduces).
+SESSIONS_DIR="${FLEET_SESSIONS_DIR:-$HOME/.fleet/sessions}"
+mkdir -p "$SESSIONS_DIR"
+worktree_name=$(basename "$PWD")
+SIDECAR="$SESSIONS_DIR/$worktree_name.session.json"
+# Roles worth resuming: workers (multi-step authoring; lost scratch is costly)
+# and reviewers (re-read a full diff). Short mechanical roles are not.
+_resume_role=0
+case "$ROLE" in worker|sonnet-reviewer|opus-reviewer) _resume_role=1 ;; esac
+
+# Is there genuine unfinished work in this worktree that a resumed session should
+# continue? A reservation (feedback-amend) OR a claude/<N>-* branch carrying
+# uncommitted or unpushed-vs-master commits (a normal task mid-flow). Reviewers
+# hold no branch/reservation work, so they're never "in flight" — they clear on
+# a clean exit and only persist a sidecar across a hard kill.
+worktree_in_flight() {
+    [[ "$ROLE" == worker ]] || return 1
+    local _resv; _resv=$(fleet-claim reservation-of "$worktree_name" 2>/dev/null || true)
+    [[ -n "$_resv" ]] && return 0
+    local _br; _br=$(git -C "$PWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    [[ "$_br" == claude/* ]] || return 1
+    [[ -n "$(git -C "$PWD" status --porcelain 2>/dev/null)" ]] && return 0
+    local _ahead; _ahead=$(git -C "$PWD" rev-list --count origin/master..HEAD 2>/dev/null || echo 0)
+    [[ "$_ahead" =~ ^[0-9]+$ && "$_ahead" -gt 0 ]] && return 0
+    return 1
+}
+
+_read_sidecar() { python3 -c "import json;print(json.load(open('$SIDECAR')).get('$1',''))" 2>/dev/null || true; }
+
+RESUMED=0
+RESUME_ID=""
+if (( _resume_role )) && [[ -f "$SIDECAR" ]]; then
+    RESUME_ID=$(_read_sidecar session_id)
+    if [[ -n "$RESUME_ID" ]]; then
+        RESUMED=1
+        # Resume with the ORIGINAL session's model/effort (stored at launch),
+        # never the dispatcher's freshly-resolved class — a thinking session must
+        # keep its launch config, and the resumed task's class is fixed.
+        _smodel=$(_read_sidecar model); _seffort=$(_read_sidecar effort)
+        [[ -n "$_smodel" ]] && MODEL="$_smodel"
+        [[ -n "$_seffort" ]] && EFFORT="$_seffort"
+    fi
 fi
 
-claude "${CLAUDE_ARGS[@]}" "/role-$ROLE $ROLE_MODE" | fleet-claude-stream
+# --fallback-model only exists in print mode, which is exactly this path. When
+# the dispatcher hands us a chain (fresh fable dispatch), claude retries on the
+# fallback model(s) if $MODEL is overloaded. Resume targets one specific session,
+# so it carries no fallback — a failed resume falls back to fresh (cleanup below).
+if (( RESUMED )); then
+    CLAUDE_ARGS=(--resume "$RESUME_ID" --model "$MODEL" --effort "$EFFORT" --print
+        --output-format stream-json --include-partial-messages --verbose)
+    PROMPT="Resume the task you were working on before the interruption; continue from where you left off."
+    echo "fleet-dispatch-wrap: resuming session $RESUME_ID for $worktree_name ($ROLE, $MODEL/$EFFORT)" >&2
+else
+    SESSION_ID=$(python3 -c 'import uuid;print(uuid.uuid4())')
+    CLAUDE_ARGS=(--session-id "$SESSION_ID" --model "$MODEL" --effort "$EFFORT" --print
+        --output-format stream-json --include-partial-messages --verbose)
+    if [[ -n "$FALLBACK_MODEL" ]]; then
+        CLAUDE_ARGS+=(--fallback-model "$FALLBACK_MODEL")
+    fi
+    PROMPT="/role-$ROLE $ROLE_MODE"
+    if (( _resume_role )); then
+        printf '{"session_id":"%s","role":"%s","model":"%s","effort":"%s","created_epoch":%s}\n' \
+            "$SESSION_ID" "$ROLE" "$MODEL" "$EFFORT" "$(date +%s)" > "$SIDECAR"
+    fi
+fi
+
+# Test hook: print the resolved launch decision + argv and exit before spawning
+# claude (mirrors fleet-babysit's FLEET_BABYSIT_PRINT_LAUNCH).
+if [[ -n "${FLEET_DISPATCH_PRINT_LAUNCH:-}" ]]; then
+    printf 'resumed=%s prompt=%s argv=claude %s\n' "$RESUMED" "$PROMPT" "${CLAUDE_ARGS[*]}"
+    exit 0
+fi
+
+claude "${CLAUDE_ARGS[@]}" "$PROMPT" | fleet-claude-stream
 
 rc="${PIPESTATUS[0]}"
 TRIGGERS_DIR="${FLEET_STATE_DIR:-$HOME/.fleet/state}/triggers"
@@ -124,7 +199,6 @@ rm -f "$FLEET_THROTTLE_FLAG"
 # trigger so the dispatcher re-fires the worker on the next tick; the
 # reservation gate at step 0.5 will resume the same task.
 if [[ "$rc" == "0" && "$ROLE" == "worker" ]]; then
-    worktree_name=$(basename "$PWD")
     reservation_issue=$(fleet-claim reservation-of "$worktree_name" 2>/dev/null || true)
     if [[ -n "$reservation_issue" ]]; then
         dirty=$(git -C "$PWD" status --porcelain 2>/dev/null || true)
@@ -134,5 +208,21 @@ if [[ "$rc" == "0" && "$ROLE" == "worker" ]]; then
             touch "$trigger_dir/$ROLE"
             echo "fleet-dispatch-wrap: dirty worktree '$worktree_name' + reservation #$reservation_issue after clean exit — wrote retrigger for $ROLE" >&2
         fi
+    fi
+fi
+
+# Session sidecar lifecycle. This runs only when claude EXITED (a hard kill skips
+# it, leaving the sidecar so the next dispatch resumes — the desired behavior):
+#   - a resume that itself failed (rc!=0) -> clear, so the next dispatch goes
+#     fresh and recovers via the claim/reservation path (breaks any resume loop);
+#   - genuine in-flight work remaining -> keep, so the next dispatch resumes;
+#   - otherwise (task finished + worktree reset, or a no-op iteration) -> clear.
+if (( _resume_role )); then
+    if (( RESUMED )) && [[ "$rc" != "0" ]]; then
+        rm -f "$SIDECAR"
+    elif worktree_in_flight; then
+        :   # keep the sidecar — resume on the next dispatch
+    else
+        rm -f "$SIDECAR"
     fi
 fi

--- a/scripts/fleet/tests/test_dispatch_wrap_session.sh
+++ b/scripts/fleet/tests/test_dispatch_wrap_session.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Tests for fleet-dispatch-wrap's session-id persistence + interrupted-session
+# resume (workers + reviewers).
+#
+# The launch DECISION (fresh vs resume, argv, stored-config) is checked via the
+# FLEET_DISPATCH_PRINT_LAUNCH inspection hook (prints + exits before claude).
+# The sidecar LIFECYCLE (keep on in-flight / clear on done / clear on failed
+# resume) is checked by running to completion with stubbed claude/git/fleet-claim.
+#
+# Covers:
+#   - fresh dispatch: --session-id, /role-<role>, sidecar written (worker+reviewer)
+#   - non-resume role (merger): no --session-id sidecar, no resume
+#   - resume: sidecar present -> --resume <id> with the STORED model/effort
+#     (not the dispatcher-passed class)
+#   - cleanup: failed resume clears the sidecar (no loop)
+#   - cleanup: in-flight work (claude/* branch + dirty) keeps the sidecar
+#   - cleanup: finished/no-op (clean master) clears the sidecar
+
+set -uo pipefail
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+WRAP="$SCRIPT_DIR/fleet-dispatch-wrap"
+[[ -x "$WRAP" ]] || { echo "test setup: $WRAP not found"; exit 1; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+TMPROOT=""; cleanup(){ [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+export FLEET_SESSIONS_DIR="$TMPROOT/sessions"
+export FLEET_STATE_DIR="$TMPROOT/state"
+mkdir -p "$FLEET_SESSIONS_DIR" "$FLEET_STATE_DIR"
+
+# --- stubs ---------------------------------------------------------------
+BIN="$TMPROOT/bin"; mkdir -p "$BIN"
+export CLAUDE_ARGV_LOG="$TMPROOT/claude-argv.log"; : > "$CLAUDE_ARGV_LOG"
+cat > "$BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CLAUDE_ARGV_LOG"
+exit "${STUB_CLAUDE_RC:-0}"
+EOF
+cat > "$BIN/fleet-claude-stream" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null 2>&1 || true
+EOF
+cat > "$BIN/fleet-claim" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "reservation-of" ]] && { [[ -n "${STUB_RESERVATION:-}" ]] && echo "$STUB_RESERVATION"; }
+exit 0
+EOF
+cat > "$BIN/git" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"rev-parse --abbrev-ref HEAD"*) echo "${STUB_BRANCH:-master}" ;;
+  *"status --porcelain"*) [[ -n "${STUB_DIRTY:-}" ]] && echo " M f" ;;
+  *"rev-list --count"*) echo "${STUB_AHEAD:-0}" ;;
+  *) : ;;
+esac
+exit 0
+EOF
+cat > "$BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$BIN"/*
+export PATH="$BIN:$PATH"
+
+# A worktree dir to run from (its basename is the worktree name / sidecar key).
+WT="$TMPROOT/worker-1"; mkdir -p "$WT"
+SIDECAR="$FLEET_SESSIONS_DIR/worker-1.session.json"
+
+run_wrap() {  # runs dispatch-wrap from the worktree dir; args: model effort role [fallback] [mode]
+  ( cd "$WT" && "$WRAP" "pane-3" "$1" "$2" "$3" "${4:-}" "${5:-live}" 2>>"$TMPROOT/stderr.log" )
+}
+
+# =========================================================================
+echo "T1: fresh worker dispatch — --session-id, /role-worker, sidecar written"
+rm -f "$SIDECAR"
+out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 "claude-opus-4-8[1m]" xhigh worker "" live 2>/dev/null)
+[[ "$out" == resumed=0* ]] && ok "fresh: resumed=0" || bad "fresh resumed flag: $out"
+[[ "$out" == *"--session-id "* ]] && ok "fresh: passes --session-id" || bad "fresh missing --session-id: $out"
+[[ "$out" == *"/role-worker live"* ]] && ok "fresh: runs /role-worker" || bad "fresh prompt: $out"
+[[ -f "$SIDECAR" ]] && ok "fresh: sidecar written" || bad "fresh: sidecar NOT written"
+python3 -c "import json;d=json.load(open('$SIDECAR'));assert d['role']=='worker' and d['model']=='claude-opus-4-8[1m]' and d['effort']=='xhigh'" 2>/dev/null \
+  && ok "fresh: sidecar records role/model/effort" || bad "fresh: sidecar fields wrong"
+
+echo "T2: non-resume role (merger) — no sidecar, no --session-id persistence"
+rm -f "$FLEET_SESSIONS_DIR/worker-1.session.json"
+out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 sonnet high merger "" live 2>/dev/null)
+[[ "$out" == resumed=0* ]] && ok "merger: resumed=0" || bad "merger resumed: $out"
+[[ ! -f "$SIDECAR" ]] && ok "merger: no sidecar written" || bad "merger wrote a sidecar"
+
+echo "T3: resume — sidecar present -> --resume <id> with STORED model/effort"
+printf '{"session_id":"SID-123","role":"worker","model":"claude-opus-4-8[1m]","effort":"xhigh","created_epoch":1}\n' > "$SIDECAR"
+# dispatcher passes a DIFFERENT class (sonnet/high) — resume must ignore it.
+out=$(cd "$WT" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-3 sonnet high worker "" live 2>/dev/null)
+[[ "$out" == resumed=1* ]] && ok "resume: resumed=1" || bad "resume flag: $out"
+[[ "$out" == *"--resume SID-123"* ]] && ok "resume: --resume <stored id>" || bad "resume id: $out"
+[[ "$out" == *"--model claude-opus-4-8[1m] --effort xhigh"* ]] && ok "resume: uses STORED model/effort" || bad "resume config: $out"
+[[ "$out" == *"--session-id"* ]] && bad "resume: should NOT pass --session-id" || ok "resume: no --session-id"
+
+echo "T4: reviewer fresh dispatch resumable + writes sidecar"
+rm -f "$FLEET_SESSIONS_DIR/opus-reviewer.session.json"
+WT2="$TMPROOT/opus-reviewer"; mkdir -p "$WT2"
+out=$(cd "$WT2" && FLEET_DISPATCH_PRINT_LAUNCH=1 "$WRAP" pane-7 "claude-opus-4-8[1m]" xhigh opus-reviewer "" review-only 2>/dev/null)
+[[ "$out" == *"/role-opus-reviewer review-only"* ]] && ok "reviewer: /role-opus-reviewer" || bad "reviewer prompt: $out"
+[[ -f "$FLEET_SESSIONS_DIR/opus-reviewer.session.json" ]] && ok "reviewer: sidecar written" || bad "reviewer: no sidecar"
+
+# --- cleanup lifecycle (full run, stubbed claude) ------------------------
+echo "T5: cleanup — failed resume clears the sidecar (no loop)"
+printf '{"session_id":"SID-9","role":"worker","model":"sonnet","effort":"high","created_epoch":1}\n' > "$SIDECAR"
+STUB_CLAUDE_RC=1 run_wrap sonnet high worker
+[[ ! -f "$SIDECAR" ]] && ok "failed resume cleared the sidecar" || bad "failed resume left the sidecar"
+
+echo "T6: cleanup — in-flight (claude/* branch + dirty) keeps the sidecar"
+rm -f "$SIDECAR"
+STUB_BRANCH="claude/123-foo" STUB_DIRTY=1 STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
+[[ -f "$SIDECAR" ]] && ok "in-flight worker kept the sidecar (resumes next dispatch)" || bad "in-flight: sidecar wrongly cleared"
+
+echo "T7: cleanup — finished/no-op (clean master) clears the sidecar"
+rm -f "$SIDECAR"
+STUB_BRANCH="master" STUB_DIRTY="" STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
+[[ ! -f "$SIDECAR" ]] && ok "done/no-op worker cleared the sidecar (fresh next)" || bad "done: sidecar wrongly kept"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_dispatch_wrap_session.sh
+++ b/scripts/fleet/tests/test_dispatch_wrap_session.sh
@@ -14,6 +14,8 @@
 #     (not the dispatcher-passed class)
 #   - cleanup: failed resume clears the sidecar (no loop)
 #   - cleanup: in-flight work (claude/* branch + dirty) keeps the sidecar
+#   - cleanup: in-flight work (reservation present, branch otherwise clean) keeps the sidecar
+#   - cleanup: in-flight work (claude/* branch, clean but ahead of master) keeps the sidecar
 #   - cleanup: finished/no-op (clean master) clears the sidecar
 
 set -uo pipefail
@@ -117,6 +119,16 @@ echo "T6: cleanup — in-flight (claude/* branch + dirty) keeps the sidecar"
 rm -f "$SIDECAR"
 STUB_BRANCH="claude/123-foo" STUB_DIRTY=1 STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
 [[ -f "$SIDECAR" ]] && ok "in-flight worker kept the sidecar (resumes next dispatch)" || bad "in-flight: sidecar wrongly cleared"
+
+echo "T6b: cleanup — in-flight (reservation present, branch otherwise clean) keeps the sidecar"
+rm -f "$SIDECAR"
+STUB_RESERVATION="163" STUB_BRANCH="master" STUB_DIRTY="" STUB_AHEAD=0 STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
+[[ -f "$SIDECAR" ]] && ok "reservation-only in-flight kept the sidecar" || bad "reservation-only: sidecar wrongly cleared"
+
+echo "T6c: cleanup — in-flight (claude/* branch, clean but ahead of master) keeps the sidecar"
+rm -f "$SIDECAR"
+STUB_BRANCH="claude/123-foo" STUB_DIRTY="" STUB_AHEAD=2 STUB_CLAUDE_RC=0 run_wrap "claude-opus-4-8[1m]" xhigh worker
+[[ -f "$SIDECAR" ]] && ok "ahead-only in-flight kept the sidecar" || bad "ahead-only: sidecar wrongly cleared"
 
 echo "T7: cleanup — finished/no-op (clean master) clears the sidecar"
 rm -f "$SIDECAR"


### PR DESCRIPTION
## Summary

When the fleet is interrupted (fleet-down/up, crash, a killed pane — e.g. last night's mass interruption), workers/reviewers relaunch **fresh** and re-derive the in-flight task's context from the claim/reservation: re-reading the issue, PR diff, plan, and partial branch work to reconstruct what the killed session already had in-context. The reservation lookup is cheap; the **context reconstruction is the expensive, lossy part**.

Architects already avoid this (`fleet-babysit` persists a session-id and `--resume`s). This brings the same to the dispatcher-driven transient path — **`fleet-dispatch-wrap`** (workers + reviewers).

### How it works

- Each iteration launches with `--session-id <uuid>` and records `{session_id, role, model, effort}` in a per-worktree sidecar `~/.fleet/sessions/<worktree>.session.json`.
- On the next dispatch, a **present sidecar** means the prior session was interrupted before completing-and-clearing (a hard kill skips the post-`claude` cleanup), so it `--resume`s that exact session at the **stored** model/effort — never the dispatcher's freshly-resolved class (a thinking session must keep its launch config; also addresses the "resume with the same effort" concern).
- **Sidecar lifecycle** (runs only when claude *exited*; a kill skips it, leaving the sidecar to resume):
  - resume that itself failed (`rc!=0`) → **clear** (break any loop; next goes fresh, recovers via claim/reservation)
  - genuine in-flight work remaining (reservation, or a `claude/<N>-*` branch with uncommitted/unpushed-vs-master commits) → **keep** (resume next dispatch)
  - finished+reset, or a no-op iteration → **clear** (fresh next)

### Feasibility (the gating spike)

The old blocker — #1320's `400 ... thinking blocks in the latest assistant message cannot be modified` — **no longer reproduces on CLI 2.1.196**. Verified empirically:
- resuming a **completed thinking-turn** session via `--resume` and `--continue` → succeeds
- a **mid-turn kill** leaves a clean transcript (partial turns aren't persisted to the JSONL until they complete) → resumes fine

So no transcript-rewind fallback is needed.

## Test plan

- [x] New `tests/test_dispatch_wrap_session.sh` (16 assertions): fresh-vs-resume decision via a new `FLEET_DISPATCH_PRINT_LAUNCH` hook (mirrors `FLEET_BABYSIT_PRINT_LAUNCH`), stored-config resume, non-resume role excluded, reviewer fresh, and the three cleanup outcomes (failed-resume clear / in-flight keep / done clear) with stubbed `claude`/`git`/`fleet-claim`.
- [x] `bash -n` clean; existing dispatcher tests (stagger, usage-gate) unaffected.

## Notes / follow-ups

- The dispatcher's per-class cap accounting is unchanged; a resume occupies a pane like any dispatch (it uses the stored class, which may differ from the tick's resolved class — negligible, noted for later if exact accounting is wanted).
- Companion (separate PR): `fleet:reviewing-*` orphan sweep — interrupted reviewer sessions leave stuck review labels (live: #2137/#2138) that only clear on a 30-min TTL; resume recovers the review, the sweep is the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)