### PR TITLE
fleet: sweep orphaned reviewing/resolving PR-label claims via a local marker

### DIFF
--- a/docs/agents/fleet-labels-reference.md
+++ b/docs/agents/fleet-labels-reference.md
@@ -328,6 +328,11 @@ Specifically, **never pass these via `--label` when filing**:
   holder (#1384), so two same-prefix holders never coexist.
   The scout's `fleet-claim cleanup --gh` pass sweeps labels older
   than 30 min and replays orphan sentinels from failed removals.
+  For the common same-host case, a local marker file lets the sweep
+  confirm the claim is orphaned (no local lock, marker missing or
+  mismatched) and clear it after a short grace period (120s default)
+  instead of waiting the full 30-min TTL; cross-host labels still need
+  the full TTL since a marker can only vouch for its own host.
   Don't add manually; don't add to issues.
 - `fleet:amending-<host>-<agent>` — owned by the **`fleet-claim`
   script** (atomic feedback-claim primitive; same sole-holder claim as

--- a/scripts/fleet/fleet-claim
+++ b/scripts/fleet/fleet-claim
@@ -1394,6 +1394,20 @@ _cmd_pr_label_claim() {
         return 1
     fi
 
+    # Same-host liveness marker for reviewing/resolving claims: lets the cleanup
+    # sweep distinguish a live claim from one orphaned by a dead/restarted
+    # session (whose GitHub label outlived the fleet-down wipe of ~/.fleet/claims).
+    # A file (not a dir) so it can't collide with the dir-based task-claim
+    # iteration. amending carries its own heartbeat liveness; steward/planning
+    # are out of scope.
+    case "$prefix" in
+        fleet:reviewing-|fleet:resolving-)
+            mkdir -p "$CLAIMS_DIR"
+            local _tag="${prefix#fleet:}"; _tag="${_tag%-}"
+            printf '%s\n' "$pr" > "$CLAIMS_DIR/_prlabel-${_tag}-${agent}" 2>/dev/null || true
+            ;;
+    esac
+
     echo "${cmd_name} acquired: $repo ${target_word}#$pr ($agent)"
     return 0
 }
@@ -1411,6 +1425,14 @@ _cmd_pr_label_release() {
     host=$(derive_host)
     label="${prefix}${host}-${agent}"
     repo=$(repo_from_ns)
+
+    # Drop the same-host liveness marker (paired with the claim-side write).
+    case "$prefix" in
+        fleet:reviewing-|fleet:resolving-)
+            local _tag="${prefix#fleet:}"; _tag="${_tag%-}"
+            rm -f "$CLAIMS_DIR/_prlabel-${_tag}-${agent}" 2>/dev/null || true
+            ;;
+    esac
 
     if [[ -z "$repo" ]] || ! command -v gh >/dev/null 2>&1; then
         echo "${cmd_name}: no gh / unknown namespace; nothing to do" >&2
@@ -1676,6 +1698,12 @@ cmd_cleanup_gh() {
     local now
     now=$(date +%s)
     local total_removed=0
+    # This host's key, for the confirmed-orphan fast paths below (PR-label sweep
+    # and the issue-claim sweep). A claim label names its owning host; only THIS
+    # host can vouch for its own local claim markers, so the fast path applies to
+    # our own claims and cross-host claims stay on the TTL.
+    local this_host
+    this_host=$(derive_host)
 
     for repo in "${repos[@]}"; do
         local prs_json pr_review_plan
@@ -1705,7 +1733,40 @@ for pr in prs:
             [[ "$added_epoch" -eq 0 ]] && continue
 
             local age=$(( now - added_epoch ))
-            if [[ $age -lt $stale_secs ]]; then
+
+            # Confirmed-orphan fast path for reviewing/resolving claims (the
+            # reviewer-side analog of the issue-claim fast path, #2111). These
+            # PR-label claims now drop a local marker ($CLAIMS_DIR/_prlabel-<tag>-
+            # <agent>, content = the PR number) on acquire and remove it on
+            # release; fleet-down wipes ~/.fleet/claims, so a same-host label with
+            # NO matching marker is a claim whose owning session died/restarted
+            # while the GitHub label survived (the #2137/#2138 stuck-reviewer
+            # shape). Sweep it after a short grace instead of the full TTL — the
+            # grace only spares the microsecond race between label-add and the
+            # marker write, and pre-fix claims during the one-time transition.
+            # amending keeps its own heartbeat liveness (below); cross-host labels
+            # can't be vouched for locally and stay on the full TTL.
+            local prlabel_orphan=0
+            case "$label_name" in
+                fleet:reviewing-*|fleet:resolving-*)
+                    local _rest="${label_name#fleet:}"        # <tag>-<host>-<agent>
+                    local _tag="${_rest%%-*}"                 # <tag>
+                    local _ha="${_rest#*-}"                   # <host>-<agent>
+                    local _chost="${_ha%%-*}"                 # <host>
+                    local _cagent="${_ha#*-}"                 # <agent>
+                    if [[ "$_chost" == "$this_host" ]]; then
+                        local _marker="$CLAIMS_DIR/_prlabel-${_tag}-${_cagent}"
+                        if [[ ! -f "$_marker" || "$(cat "$_marker" 2>/dev/null)" != "$pr_num" ]]; then
+                            prlabel_orphan=1
+                        fi
+                    fi
+                    ;;
+            esac
+
+            local _orphan_grace="${FLEET_CLAIM_PRLABEL_ORPHAN_GRACE_SECS:-120}"
+            if (( prlabel_orphan )); then
+                [[ $age -lt $_orphan_grace ]] && continue
+            elif [[ $age -lt $stale_secs ]]; then
                 continue
             fi
 
@@ -1722,9 +1783,11 @@ for pr in prs:
                 continue
             fi
 
+            local _sweep_note="age: $((age / 60))m"
+            (( prlabel_orphan )) && _sweep_note="orphaned: no local marker on $this_host, ${_sweep_note}"
             if gh issue edit "$pr_num" --repo "$repo" \
                     --remove-label "$label_name" >/dev/null 2>&1; then
-                echo "cleanup --gh: removed stale '$label_name' on $repo PR#$pr_num (age: $((age / 60))m)"
+                echo "cleanup --gh: removed stale '$label_name' on $repo PR#$pr_num ($_sweep_note)"
                 total_removed=$((total_removed + 1))
             else
                 write_orphan_sentinel "$repo" "$pr_num" "$label_name" \
@@ -1745,12 +1808,8 @@ for pr in prs:
     # like a no-PR abandon (#1488 Fix B). Only an active (non-parked) matching
     # WIP PR (head-branch claude/<N>-*) keeps the claim.
     local claim_issue_stale_secs="${FLEET_CLAIM_STALE_SECS_ISSUES:-7200}"
-    # This host's key, for the confirmed-orphan fast path below. A claim label
-    # names the owning host (fleet:claim-<host>-<agent>); only THIS host can
-    # vouch for its own local claim locks, so the fast path applies to our own
-    # claims and cross-host claims stay on the TTL.
-    local this_host
-    this_host=$(derive_host)
+    # this_host computed once at the top of cmd_cleanup_gh (shared with the
+    # PR-label orphan fast path).
     for repo in "${repos[@]}"; do
         local open_claim_plan open_pr_branches_json
         open_claim_plan=$(gh issue list --repo "$repo" --state open \

--- a/scripts/fleet/tests/test_fleet_claim_prlabel_orphan_sweep.sh
+++ b/scripts/fleet/tests/test_fleet_claim_prlabel_orphan_sweep.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tests for the confirmed-orphan fast path in `fleet-claim cleanup --gh`'s
+# PR-label sweep, for fleet:reviewing-* / fleet:resolving-* claims.
+#
+# These claims drop a local marker ($CLAIMS_DIR/_prlabel-<tag>-<agent>, content =
+# the PR number) on acquire and remove it on release. fleet-down wipes
+# ~/.fleet/claims, so a same-host reviewing/resolving label with NO matching
+# marker is a claim whose owning session died/restarted while the GitHub label
+# survived (the #2137/#2138 stuck-reviewer shape) — swept after a short grace
+# rather than the 30-min TTL. A marker that matches keeps the claim; cross-host
+# labels can't be vouched for locally and stay on the full TTL.
+#
+# The gh stub reports every label as added STUB_AGE seconds ago, so age alone
+# never trips the 1800s TTL — anything swept is the orphan fast path.
+
+set -uo pipefail
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+FLEET_CLAIM="$SCRIPT_DIR/fleet-claim"
+[[ -x "$FLEET_CLAIM" ]] || { echo "test setup: fleet-claim not found"; exit 1; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok: $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+removed_has()    { grep -qF "$1" "$REMOVED_FILE" 2>/dev/null; }
+TMPROOT=""; cleanup(){ [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+TMPROOT=$(mktemp -d)
+
+export FLEET_CLAIMS_DIR="$TMPROOT/claims"
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_ORPHANS_DIR="$TMPROOT/orphans"
+export FLEET_TEST_HOST="mac"
+mkdir -p "$FLEET_CLAIMS_DIR" "$FLEET_STATE_DIR" "$FLEET_ORPHANS_DIR"
+export PRS_JSON="$TMPROOT/prs.json"
+REMOVED_FILE="$TMPROOT/removed.log"; export REMOVED_FILE
+
+STUB_DIR="$TMPROOT/bin"; mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$1" in
+    pr) case "$2" in list) cat "$PRS_JSON"; exit 0 ;; *) exit 0 ;; esac ;;
+    issue)
+        case "$2" in
+            edit) shift 2; n="$1"; shift
+                while [[ $# -gt 0 ]]; do
+                    case "$1" in --remove-label) printf '%s\t%s\n' "$n" "$2" >> "$REMOVED_FILE"; shift 2 ;; *) shift ;; esac
+                done; exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    api)
+        printf '%s ' "$@" | grep -q 'events' && \
+          python3 -c "import time;print(time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(time.time()-${STUB_AGE:-600})))"
+        exit 0 ;;
+    *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$STUB_DIR/gh"
+export PATH="$STUB_DIR:$PATH"
+
+# --- Phase 1: aged labels (STUB_AGE=600 > grace 120, < TTL 1800) -----------
+: > "$REMOVED_FILE"
+# opus-reviewer's marker points at 901 (its live review). sonnet-reviewer and
+# merger have NO markers (dead/restarted sessions).
+printf '901\n' > "$FLEET_CLAIMS_DIR/_prlabel-reviewing-opus-reviewer"
+cat > "$PRS_JSON" <<'JSON'
+[
+  {"number":900,"labels":[{"name":"fleet:reviewing-mac-opus-reviewer"}]},
+  {"number":901,"labels":[{"name":"fleet:reviewing-mac-opus-reviewer"}]},
+  {"number":902,"labels":[{"name":"fleet:reviewing-mac-sonnet-reviewer"}]},
+  {"number":903,"labels":[{"name":"fleet:resolving-mac-merger"}]},
+  {"number":904,"labels":[{"name":"fleet:reviewing-linux-opus-reviewer"}]}
+]
+JSON
+echo "=== aged reviewing/resolving sweep (STUB_AGE=600) ==="
+STUB_AGE=600 "$FLEET_CLAIM" cleanup --gh --repo jakildev/IrredenEngine 2>&1 | sed 's/^/    /'
+removed_has $'900\tfleet:reviewing-mac-opus-reviewer'   && ok "same-host marker-mismatch (900 vs marker 901) swept" || bad "900 not swept"
+removed_has $'901\tfleet:reviewing-mac-opus-reviewer'   && bad "901 (marker matches) wrongly swept"            || ok "same-host live claim (marker matches 901) kept"
+removed_has $'902\tfleet:reviewing-mac-sonnet-reviewer' && ok "same-host no-marker orphan (902) swept"          || bad "902 not swept"
+removed_has $'903\tfleet:resolving-mac-merger'          && ok "resolving same-host no-marker orphan (903) swept" || bad "903 not swept"
+removed_has $'904\tfleet:reviewing-linux-opus-reviewer' && bad "cross-host (904) wrongly swept"                || ok "cross-host claim kept (TTL, can't vouch)"
+
+# --- Phase 2: fresh orphan (STUB_AGE=30 < grace 120) -> kept ---------------
+: > "$REMOVED_FILE"
+rm -f "$FLEET_CLAIMS_DIR"/_prlabel-*
+cat > "$PRS_JSON" <<'JSON'
+[ {"number":910,"labels":[{"name":"fleet:reviewing-mac-opus-reviewer"}]} ]
+JSON
+echo "=== fresh no-marker reviewing label (STUB_AGE=30) ==="
+STUB_AGE=30 "$FLEET_CLAIM" cleanup --gh --repo jakildev/IrredenEngine 2>&1 | sed 's/^/    /'
+removed_has $'910\tfleet:reviewing-mac-opus-reviewer' && bad "fresh no-marker label swept inside grace" || ok "fresh no-marker label spared by grace (claim/marker race)"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Interrupted reviewer/merger sessions leave `fleet:reviewing-*` / `fleet:resolving-*` labels **stuck** on PRs (live now: #2137 opus-reviewer, #2138 sonnet-reviewer). Unlike amending claims (heartbeat-gated), these were **age-only** — they recovered solely via the **30-min TTL**, and heartbeat-freshness can't help: a restarted reviewer reuses the same agent name (`opus-reviewer`), so its *fresh* heartbeat makes the *dead* session's label look live.

### Fix — the reviewer-side analog of #2111

Give reviewing/resolving claims a local marker (like the task-claim local lock):
- `_cmd_pr_label_claim` drops `$CLAIMS_DIR/_prlabel-<tag>-<agent>` (content = the PR number) on acquire; `_cmd_pr_label_release` removes it. A **file**, not a dir, so it can't collide with the dir-based task-claim iteration (`$CLAIMS_DIR/*/`).
- `fleet-down` wipes `~/.fleet/claims` by default, so after a restart a **same-host** reviewing/resolving label with **no matching marker** is a confirmed orphan (owning session gone, GitHub label survived).
- The `cleanup --gh` PR-label sweep removes it after a short **grace** (`FLEET_CLAIM_PRLABEL_ORPHAN_GRACE_SECS`, default 120s — covers the microsecond claim→marker-write race and the one-time pre-fix transition) instead of the full 30-min TTL.

Guards preserved:
- a marker that **matches** the PR keeps the claim;
- **amending** keeps its own heartbeat liveness (unchanged);
- **cross-host** labels can't be vouched for locally → stay on the 1800s TTL.

`this_host` is hoisted to the top of `cmd_cleanup_gh`, shared with the issue-claim fast path (#2111).

## Test plan

- [x] New `tests/test_fleet_claim_prlabel_orphan_sweep.sh`: marker-mismatch / no-marker (reviewing + resolving) swept; marker-matches kept; cross-host kept; fresh (<grace) spared.
- [x] All 15 `test_fleet_claim_*.sh` suites pass (incl. `amending_sweep` — amending path untouched).
- [x] `bash -n` clean.

## Relationship to #2141 (worker/reviewer session resume)

Complementary. With session-resume, an interrupted *reviewer* resumes and finishes its review, releasing the label naturally (the primary recovery). This sweep is the **backstop** for when resume isn't possible — and it's what actually clears already-orphaned labels like #2137/#2138 after deploy (they predate the marker, so the first post-deploy sweep treats them as orphans; an actively-reviewing reviewer simply re-claims with a marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)