### PR TITLE
demos: register custom CLI flags on IRArgs to fix strict-init rejection (#2103)

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -61,8 +61,6 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <cstring>
-#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -918,95 +916,164 @@ void readConfig() {
         g_settings.autoRotate_ = autoRotate.as<bool>();
 }
 
-void parseArgs(int argc, char **argv) {
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--yaw") == 0 && i + 1 < argc) {
-            g_settings.cameraYaw_ = static_cast<float>(std::atof(argv[i + 1]));
-            ++i;
-        } else if (std::strcmp(argv[i], "--subdivisions") == 0 && i + 1 < argc) {
-            // Debug toggle (#2043 repro): force the base voxel-render subdivision
-            // factor so the detached small/low-zoom gap reproduces (needs > 1).
-            g_settings.subdivisions_ = std::atoi(argv[i + 1]);
-            ++i;
-        } else if (std::strcmp(argv[i], "--zoom") == 0 && i + 1 < argc) {
-            // Debug toggle (#2043 repro): override the interactive initial zoom.
-            // Auto-screenshot shots still drive their own per-shot zoom (the
-            // orbit shot table already includes orbit_overview @ 0.32).
-            g_settings.initialZoom_ = static_cast<float>(std::atof(argv[i + 1]));
-            ++i;
-        } else if (std::strcmp(argv[i], "--auto-rotate") == 0) {
-            g_settings.autoRotate_ = true;
-            g_settings.autoRotateSetByCli_ = true;
-        } else if (std::strcmp(argv[i], "--no-auto-rotate") == 0) {
-            g_settings.autoRotate_ = false;
-            g_settings.autoRotateSetByCli_ = true;
-        } else if (std::strcmp(argv[i], "--full-rotate") == 0) {
-            g_settings.fullRotate_ = true;
-        } else if (std::strcmp(argv[i], "--no-spin") == 0) {
-            g_settings.noSpin_ = true;
-        } else if (std::strcmp(argv[i], "--no-lighting") == 0) {
-            g_settings.noLighting_ = true;
-        } else if (
-            std::strcmp(argv[i], "--screen-lock-detached") == 0 ||
-            std::strcmp(argv[i], "--screen-lock-revox") == 0
-        ) {
-            g_settings.screenLockDetached_ = true;
-        } else if (std::strcmp(argv[i], "--solo-revox") == 0) {
-            g_settings.soloRevox_ = true;
-            // The solo harness spawns no floor to depth-sort against, and the
-            // #1619 step-0 GL evidence (committed crops) was captured on the
-            // screen-locked overlay path — keep the lone L-prism screen-locked
-            // rather than inheriting the world-place default.
-            g_settings.screenLockDetached_ = true;
-        } else if (std::strcmp(argv[i], "--only") == 0 && i + 1 < argc) {
-            g_settings.onlyGroups_ |= parseSpawnGroups(argv[i + 1]);
-            ++i;
-        } else if (std::strcmp(argv[i], "--sweep-yaw") == 0 && i + 3 < argc) {
-            g_settings.sweepYawFrom_ = static_cast<float>(std::atof(argv[i + 1]));
-            g_settings.sweepYawTo_ = static_cast<float>(std::atof(argv[i + 2]));
-            g_settings.sweepYawCount_ = std::atoi(argv[i + 3]);
-            i += 3;
-        } else if (std::strcmp(argv[i], "--sweep-frames") == 0 && i + 2 < argc) {
-            g_settings.sweepFramesCount_ = std::atoi(argv[i + 1]);
-            g_settings.sweepFramesSettle_ = std::atoi(argv[i + 2]);
-            i += 2;
-        } else if (std::strcmp(argv[i], "--auto-profile") == 0) {
-            g_settings.autoProfile_ = true;
-        } else if (std::strcmp(argv[i], "--debug-overlay") == 0 && i + 1 < argc) {
-            g_settings.debugOverlay_ = IRRender::debugOverlayModeFromString(argv[i + 1]);
-            ++i;
-        } else if (std::strcmp(argv[i], "--depth-probe") == 0 && i + 1 < argc) {
-            int px = 0;
-            int py = 0;
-            if (std::sscanf(argv[i + 1], "%d,%d", &px, &py) == 2) {
-                g_settings.depthProbeSet_ = true;
-                g_settings.depthProbePixel_ = ivec2(px, py);
-            } else {
-                IR_LOG_WARN(
-                    "--depth-probe: expected X,Y (e.g. 960,540); ignoring '{}'",
-                    argv[i + 1]
-                );
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--depth-probe-assert") == 0 && i + 1 < argc) {
-            int px = 0;
-            int py = 0;
-            if (std::sscanf(argv[i + 1], "%d,%d", &px, &py) == 2) {
-                g_settings.depthProbeAssertSet_ = true;
-                g_settings.depthProbeAssertPixel_ = ivec2(px, py);
-            } else {
-                IR_LOG_WARN(
-                    "--depth-probe-assert: expected X,Y (e.g. 321,210); ignoring '{}'",
-                    argv[i + 1]
-                );
-            }
-            ++i;
-        }
+// Parse a "--depth-probe[-assert] X,Y" value into (set, pixel), mirroring the
+// warn-on-malformed behaviour the hand-rolled parser had — a bad value leaves
+// `set` false so the probe stays off rather than reading a garbage pixel.
+void applyDepthProbe(const std::string &value, bool &set, ivec2 &pixel, const char *flag) {
+    int px = 0;
+    int py = 0;
+    if (std::sscanf(value.c_str(), "%d,%d", &px, &py) == 2) {
+        set = true;
+        pixel = ivec2(px, py);
+    } else {
+        IR_LOG_WARN("{}: expected X,Y (e.g. 960,540); ignoring '{}'", flag, value);
+    }
+}
+
+// Declare canvas_stress's custom flags on the engine-owned parser. Must run
+// before IREngine::init(argc, argv), which performs the single strict parse of
+// engine-common + these flags (see engine/CLAUDE.md "CLI args go through
+// IRArgs"). The registered defaults mirror g_settings's struct defaults so a
+// flagless run is byte-identical. Multi-value flags use the FLOAT_LIST type so
+// the established space-separated spellings (--sweep-yaw <from> <to> <n>) keep
+// working.
+void registerArgs() {
+    IRArgs::Parser &args = IREngine::args();
+    args.number("--yaw", "Initial camera yaw, radians", g_settings.cameraYaw_);
+    args.integer(
+        "--subdivisions",
+        "Force base voxel-render subdivision factor (#2043 repro; needs > 1)",
+        g_settings.subdivisions_
+    );
+    args.number("--zoom", "Override the interactive initial zoom", g_settings.initialZoom_);
+    args.flag("--auto-rotate", "Force camera auto-yaw on (overrides config.lua)");
+    args.flag("--no-auto-rotate", "Force camera auto-yaw off (overrides config.lua)");
+    args.flag(
+        "--full-rotate",
+        "Drive the camera with the full SO(3) X/Y/Z spin path, not Z-yaw only"
+    );
+    args.flag("--no-spin", "Freeze per-entity self-spin at quaternion identity");
+    args.flag("--no-lighting", "Disable world lighting");
+    args.flag(
+        "--screen-lock-detached",
+        "Opt every detached canvas into the screen-locked overlay placement (pre-#1624 scene)"
+    );
+    args.flag("--screen-lock-revox", "Legacy alias for --screen-lock-detached");
+    args.flag(
+        "--solo-revox",
+        "#1619 isolation: spawn exactly one rotated DETACHED_REVOXELIZE solid, screen-locked"
+    );
+    args.string(
+        "--only",
+        "Spawn only the named entity groups (comma-separated: maingrid,gridspin,canary,revox,"
+        "orbit,floor,compare,interpenetrate)",
+        ""
+    );
+    args.numbers(
+        "--sweep-yaw",
+        "Focused capture: interpolate camera yaw (radians) <from> <to> across <n> shots",
+        3
+    );
+    args.numbers(
+        "--sweep-frames",
+        "Focused capture: <n> identical-camera shots <settle> frames apart (self-spin phase sweep)",
+        2
+    );
+    args.flag(
+        "--auto-profile",
+        "Per-system frame timing; write save_files/profile_report.txt on the auto-screenshot exit"
+    );
+    args.string(
+        "--debug-overlay",
+        "Force a render debug overlay for the run "
+        "(none|ao|light_level|shadow|peraxis_id|peraxis_origin|unlit)",
+        ""
+    );
+    args.string(
+        "--depth-probe",
+        "Log composite depth each frame at framebuffer pixel X,Y (#1910)",
+        ""
+    );
+    args.string(
+        "--depth-probe-assert",
+        "Depth-write regression guard at framebuffer pixel X,Y; emits PASS|FAIL (#1957)",
+        ""
+    );
+}
+
+// Read the parsed flags back into g_settings after IREngine::init. Replaces the
+// retired hand-rolled parseArgs; the trailing sweep latch (disable auto-yaw)
+// must run before readConfig() so config.lua can't re-enable it.
+void applyArgs() {
+    IRArgs::Parser &args = IREngine::args();
+    g_settings.cameraYaw_ = args.getFloat("--yaw");
+    // #2043 repro: force base subdivisions when requested. 0 leaves the engine
+    // default (1) untouched, so a flagless run stays byte-identical.
+    g_settings.subdivisions_ = args.getInt("--subdivisions");
+    g_settings.initialZoom_ = args.getFloat("--zoom");
+    if (args.wasProvided("--auto-rotate")) {
+        g_settings.autoRotate_ = true;
+        g_settings.autoRotateSetByCli_ = true;
+    }
+    if (args.wasProvided("--no-auto-rotate")) {
+        g_settings.autoRotate_ = false;
+        g_settings.autoRotateSetByCli_ = true;
+    }
+    g_settings.fullRotate_ = args.getFlag("--full-rotate");
+    g_settings.noSpin_ = args.getFlag("--no-spin");
+    g_settings.noLighting_ = args.getFlag("--no-lighting");
+    if (args.getFlag("--screen-lock-detached") || args.getFlag("--screen-lock-revox")) {
+        g_settings.screenLockDetached_ = true;
+    }
+    if (args.getFlag("--solo-revox")) {
+        g_settings.soloRevox_ = true;
+        // The solo harness spawns no floor to depth-sort against, and the #1619
+        // step-0 GL evidence (committed crops) was captured on the screen-locked
+        // overlay path — keep the lone L-prism screen-locked rather than
+        // inheriting the world-place default.
+        g_settings.screenLockDetached_ = true;
+    }
+    // --only accepts the comma-separated group list in one token; the legacy
+    // repeated-flag form collapses to the last value under the single parse.
+    if (args.wasProvided("--only")) {
+        g_settings.onlyGroups_ |= parseSpawnGroups(args.getString("--only").c_str());
+    }
+    g_settings.autoProfile_ = args.getFlag("--auto-profile");
+    if (args.wasProvided("--debug-overlay")) {
+        g_settings.debugOverlay_ =
+            IRRender::debugOverlayModeFromString(args.getString("--debug-overlay").c_str());
+    }
+    if (args.wasProvided("--depth-probe")) {
+        applyDepthProbe(
+            args.getString("--depth-probe"),
+            g_settings.depthProbeSet_,
+            g_settings.depthProbePixel_,
+            "--depth-probe"
+        );
+    }
+    if (args.wasProvided("--depth-probe-assert")) {
+        applyDepthProbe(
+            args.getString("--depth-probe-assert"),
+            g_settings.depthProbeAssertSet_,
+            g_settings.depthProbeAssertPixel_,
+            "--depth-probe-assert"
+        );
+    }
+    if (args.wasProvided("--sweep-yaw")) {
+        const std::vector<float> &v = args.getFloats("--sweep-yaw");
+        g_settings.sweepYawFrom_ = v[0];
+        g_settings.sweepYawTo_ = v[1];
+        g_settings.sweepYawCount_ = static_cast<int>(v[2]);
+    }
+    if (args.wasProvided("--sweep-frames")) {
+        const std::vector<float> &v = args.getFloats("--sweep-frames");
+        g_settings.sweepFramesCount_ = static_cast<int>(v[0]);
+        g_settings.sweepFramesSettle_ = static_cast<int>(v[1]);
     }
     if (g_settings.sweepYawCount_ > 0 || g_settings.sweepFramesCount_ > 0) {
-        // Sweep captures isolate one moving variable; continuous camera
-        // auto-yaw would otherwise drift the pose during the settle frames and
-        // confound both sweep kinds.
+        // Sweep captures isolate one moving variable; continuous camera auto-yaw
+        // would otherwise drift the pose during the settle frames and confound
+        // both sweep kinds.
         g_settings.autoRotate_ = false;
         g_settings.autoRotateSetByCli_ = true;
     }
@@ -1019,9 +1086,10 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    parseArgs(argc, argv);
+    registerArgs();
     IR_LOG_INFO("Starting creation: canvas_stress");
     IREngine::init(argc, argv);
+    applyArgs();
     g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     readConfig();
     if (g_settings.autoProfile_) {

--- a/creations/demos/gpu_particles/main.cpp
+++ b/creations/demos/gpu_particles/main.cpp
@@ -22,8 +22,6 @@
 #include <irreden/common/command_suite_capture.hpp>
 
 #include <cstdint>
-#include <cstdlib>
-#include <cstring>
 #include <list>
 
 using namespace IRComponents;
@@ -44,16 +42,6 @@ constexpr IRVideo::AutoScreenshotShot kShots[] = {
 
 int g_autoWarmupFrames = 0;
 int g_spawnsPerFrame = 0; // T-159 continuous-emitter verification knob
-
-void parseArgs(int argc, char **argv) {
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--spawns-per-frame") == 0 && i + 1 < argc) {
-            const int n = std::atoi(argv[i + 1]);
-            g_spawnsPerFrame = n < 0 ? 0 : n;
-            ++i;
-        }
-    }
-}
 
 void seedParticles() {
     for (int i = 0; i < kInitialParticleCount; ++i) {
@@ -103,11 +91,20 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    parseArgs(argc, argv);
+    // Register the custom flag on the engine-owned parser before init, which
+    // runs the single strict parse (engine-common + this) — see engine/CLAUDE.md
+    // "CLI args go through IRArgs".
+    IREngine::args().integer(
+        "--spawns-per-frame",
+        "Continuous emitter: particles spawned per frame (T-159)",
+        0
+    );
 
     IR_LOG_INFO("Starting creation: gpu_particles");
     IREngine::init(argc, argv);
     g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
+    const int spawnsPerFrame = IREngine::args().getInt("--spawns-per-frame");
+    g_spawnsPerFrame = spawnsPerFrame < 0 ? 0 : spawnsPerFrame;
 
     initSystems();
     initCommands();

--- a/creations/demos/ir_voxel_yaw/main.cpp
+++ b/creations/demos/ir_voxel_yaw/main.cpp
@@ -36,8 +36,6 @@
 
 #include <array>
 #include <cstdio>
-#include <cstring>
-#include <cstdlib>
 #include <vector>
 
 // COMPONENTS
@@ -154,31 +152,40 @@ void initCommands();
 void initEntities();
 
 int main(int argc, char **argv) {
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--spin-yaw") == 0) {
-            g_spinYawDegPerSec = 30.0f;
-            if (i + 1 < argc) {
-                float v = static_cast<float>(std::atof(argv[i + 1]));
-                if (v > 0.0f) {
-                    g_spinYawDegPerSec = v;
-                    ++i;
-                }
-            }
-        } else if (std::strcmp(argv[i], "--zoom") == 0) {
-            if (i + 1 < argc) {
-                float z = static_cast<float>(std::atof(argv[i + 1]));
-                if (z > 0.0f) {
-                    g_initialZoom = z;
-                    ++i;
-                }
-            }
-        } else if (std::strcmp(argv[i], "--yaw") == 0) {
-            if (i + 1 < argc) {
-                g_initialYawRadians = static_cast<float>(std::atof(argv[i + 1]));
-                g_initialYawSet = true;
-                ++i;
-            }
+    // Register custom flags on the engine-owned parser before init, which runs
+    // the single strict parse of engine-common + these flags (see
+    // engine/CLAUDE.md "CLI args go through IRArgs"). --spin-yaw mirrors
+    // shape_debug: an optional-int rate, default 30 when bare. Values read back
+    // AFTER init so the warmup-reinterpret sees the parsed --auto-screenshot
+    // count.
+    IRArgs::Parser &args = IREngine::args();
+    args.optionalInt(
+        "--spin-yaw",
+        "Drive camera Z-yaw (deg/sec live, default 30; shot-count across one rotation when "
+        "combined with --auto-screenshot)",
+        30
+    );
+    args.number("--zoom", "Override the initial camera zoom (> 0)", 0.0f);
+    args.number("--yaw", "Park the camera at a fixed Z-yaw, radians", 0.0f);
+
+    IR_LOG_INFO("Starting creation: ir_voxel_yaw");
+    IREngine::init(argc, argv);
+
+    g_autoWarmupFrames = args.autoScreenshotWarmupFrames();
+    // --spin-yaw: 0 (disabled) when absent, else the rate (30 if bare); the
+    // optional value reads as an int, so fractional deg/sec is truncated.
+    if (args.wasProvided("--spin-yaw")) {
+        g_spinYawDegPerSec = static_cast<float>(args.getInt("--spin-yaw"));
+    }
+    if (args.wasProvided("--zoom")) {
+        const float zoom = args.getFloat("--zoom");
+        if (zoom > 0.0f) {
+            g_initialZoom = zoom;
         }
+    }
+    if (args.wasProvided("--yaw")) {
+        g_initialYawRadians = args.getFloat("--yaw");
+        g_initialYawSet = true;
     }
 
     // --spin-yaw + --auto-screenshot: reinterpret the screenshot value as
@@ -192,10 +199,6 @@ int main(int argc, char **argv) {
             g_spinYawShotCount
         );
     }
-
-    IR_LOG_INFO("Starting creation: ir_voxel_yaw");
-    IREngine::init(argc, argv);
-    g_autoWarmupFrames = IREngine::args().autoScreenshotWarmupFrames();
     initSystems();
     initCommands();
     initEntities();

--- a/creations/demos/lua_perf_grid/main_lua.cpp
+++ b/creations/demos/lua_perf_grid/main_lua.cpp
@@ -62,8 +62,6 @@
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
 
 #include <algorithm>
-#include <cstring>
-#include <cstdlib>
 #include <numbers>
 #include <string>
 
@@ -131,56 +129,75 @@ void applyCliOverrides() {
     }
 }
 
-void parseArgs(int argc, char **argv) {
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--auto-profile") == 0) {
-            g_autoProfileFrames = 300;
-            if (i + 1 < argc) {
-                int frames = std::atoi(argv[i + 1]);
-                if (frames > 0) {
-                    g_autoProfileFrames = frames;
-                    ++i;
-                }
-            }
-        } else if (std::strcmp(argv[i], "--grid-size") == 0 && i + 1 < argc) {
-            int gridSize = std::atoi(argv[i + 1]);
-            if (gridSize > 0) {
-                g_cliOverrides.gridSize_ = gridSize;
-                g_cliOverrides.gridSizeSet_ = true;
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--zoom") == 0 && i + 1 < argc) {
-            float zoom = static_cast<float>(std::atof(argv[i + 1]));
-            if (zoom > 0.0f) {
-                g_cliOverrides.zoom_ = zoom;
-                g_cliOverrides.zoomSet_ = true;
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--subdivision-mode") == 0 && i + 1 < argc) {
-            std::string mode = argv[i + 1];
-            if (mode == "none") {
-                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::NONE;
-                g_cliOverrides.subdivisionModeSet_ = true;
-            } else if (mode == "position_only") {
-                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::POSITION_ONLY;
-                g_cliOverrides.subdivisionModeSet_ = true;
-            } else if (mode == "full") {
-                g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::FULL;
-                g_cliOverrides.subdivisionModeSet_ = true;
-            } else {
-                IR_LOG_WARN(
-                    "Unknown --subdivision-mode '{}'; expected none|position_only|full",
-                    mode
-                );
-            }
-            ++i;
-        } else if (std::strcmp(argv[i], "--base-subdivisions") == 0 && i + 1 < argc) {
-            int sub = std::atoi(argv[i + 1]);
-            if (sub > 0) {
-                g_cliOverrides.baseSubdivisions_ = sub;
-                g_cliOverrides.baseSubdivisionsSet_ = true;
-            }
-            ++i;
+// Declare lua_perf_grid's custom flags on the engine-owned parser. Must run
+// before IREngine::init(argc, argv), which performs the single strict parse of
+// engine-common + these flags (see engine/CLAUDE.md "CLI args go through
+// IRArgs").
+void registerArgs() {
+    IRArgs::Parser &args = IREngine::args();
+    args.optionalInt(
+        "--auto-profile",
+        "Per-system frame timing for N frames (default 300 when bare); writes the profile report "
+        "on exit",
+        300
+    );
+    args.integer("--grid-size", "Override the grid edge in cells (> 0)", 0);
+    args.number("--zoom", "Override the initial camera zoom (> 0)", 0.0f);
+    args.string(
+        "--subdivision-mode",
+        "Voxel subdivision mode override (none|position_only|full)",
+        ""
+    );
+    args.integer(
+        "--base-subdivisions",
+        "Override the base voxel-render subdivision factor (> 0)",
+        0
+    );
+}
+
+// Read the parsed flags into g_autoProfileFrames + g_cliOverrides. Runs inside
+// the lua-bindings callback (which fires during init, after the parse) so
+// g_cliOverrides is populated before applyCliOverrides() consumes it. Replaces
+// the retired hand-rolled parseArgs.
+void applyArgs() {
+    const IRArgs::Parser &args = IREngine::args();
+    if (args.wasProvided("--auto-profile")) {
+        g_autoProfileFrames = args.getInt("--auto-profile");
+    }
+    if (args.wasProvided("--grid-size")) {
+        const int gridSize = args.getInt("--grid-size");
+        if (gridSize > 0) {
+            g_cliOverrides.gridSize_ = gridSize;
+            g_cliOverrides.gridSizeSet_ = true;
+        }
+    }
+    if (args.wasProvided("--zoom")) {
+        const float zoom = args.getFloat("--zoom");
+        if (zoom > 0.0f) {
+            g_cliOverrides.zoom_ = zoom;
+            g_cliOverrides.zoomSet_ = true;
+        }
+    }
+    if (args.wasProvided("--subdivision-mode")) {
+        const std::string mode = args.getString("--subdivision-mode");
+        if (mode == "none") {
+            g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::NONE;
+            g_cliOverrides.subdivisionModeSet_ = true;
+        } else if (mode == "position_only") {
+            g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::POSITION_ONLY;
+            g_cliOverrides.subdivisionModeSet_ = true;
+        } else if (mode == "full") {
+            g_cliOverrides.subdivisionMode_ = IRRender::SubdivisionMode::FULL;
+            g_cliOverrides.subdivisionModeSet_ = true;
+        } else {
+            IR_LOG_WARN("Unknown --subdivision-mode '{}'; expected none|position_only|full", mode);
+        }
+    }
+    if (args.wasProvided("--base-subdivisions")) {
+        const int sub = args.getInt("--base-subdivisions");
+        if (sub > 0) {
+            g_cliOverrides.baseSubdivisions_ = sub;
+            g_cliOverrides.baseSubdivisionsSet_ = true;
         }
     }
 }
@@ -377,6 +394,10 @@ void registerLuaBindings() {
         // the engine's WorldConfig-style table loader, separate Lua state).
         IRScript::LuaScript demoConfig{IREngine::resolveScriptPath("config.lua").c_str()};
         applyConfigTable(demoConfig);
+        // Read CLI flags into g_cliOverrides here — this callback fires during
+        // IREngine::init AFTER the parse, so the values are available and land
+        // before applyCliOverrides() (CLI wins over config.lua).
+        applyArgs();
         applyCliOverrides();
         validateSettings();
 
@@ -490,7 +511,7 @@ void registerLuaBindings() {
 } // namespace
 
 int main(int argc, char **argv) {
-    parseArgs(argc, argv);
+    registerArgs();
     IR_LOG_INFO(
         "Starting creation: lua_perf_grid (default mode={})",
         IRScript::CodegenRegistry::kDefaultEcsMode == IRScript::EcsMode::CODEGEN ? "CODEGEN"

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -31,10 +31,11 @@ GL / Metal init, so `--help` is instant and headless-safe.
   code at all, read back via `IREngine::args().autoScreenshotWarmupFrames()` /
   `IREngine::args().configPreset()`.
 - **Custom flags?** Register them on `IREngine::args()` (`.flag` / `.integer` /
-  `.number` / `.string` / `.optionalInt`) **before** `IREngine::init(argc,
-  argv)`, then read them back via `IREngine::args().getFlag(...)` etc. The
-  single engine parse covers common + custom flags, so `--help` aggregates
-  everything.
+  `.number` / `.string` / `.optionalInt` / `.numbers` for a fixed-count float
+  list like `--sweep-yaw <from> <to> <n>`) **before** `IREngine::init(argc,
+  argv)`, then read them back via `IREngine::args().getFlag(...)` /
+  `.getFloats(...)` etc. The single engine parse covers common + custom flags,
+  so `--help` aggregates everything.
 - **Standalone tool (no engine loop)?** Construct your own
   `IRArgs::Parser(desc, IRArgs::Common::NONE)` — that drops the engine-common
   args (so `--help` advertises only the tool's flags) and lets you declare

--- a/engine/include/irreden/ir_args.hpp
+++ b/engine/include/irreden/ir_args.hpp
@@ -38,6 +38,7 @@ enum class Type {
     FLOAT,        // takes a float value                (--zoom 4.0)
     STRING,       // takes a string value               (--config-preset path.lua)
     OPTIONAL_INT, // switch with an optional trailing int (--auto-screenshot [frames])
+    FLOAT_LIST,   // takes a fixed count of float values  (--sweep-yaw 0 360 8)
 };
 
 // Which built-in args the constructor pre-registers. ENGINE (the default) adds
@@ -81,6 +82,14 @@ class Parser {
     Parser &optionalInt(
         const char *name, const char *help, int defaultIfBare, const char *shortAlias = nullptr
     );
+    // A flag that consumes exactly `count` float values, given space-separated
+    // ("--sweep-yaw 0 360 8") or as one comma-separated inline token
+    // ("--sweep-yaw=0,360,8"). `count` must be positive; too few values (or a
+    // wrong inline count) is a parse error. Read back with getFloats(); each
+    // value defaults to 0 until provided. Integer-valued slots are recovered by
+    // the caller via static_cast<int> on the float.
+    Parser &
+    numbers(const char *name, const char *help, int count, const char *shortAlias = nullptr);
 
     // Positional arguments (ordered, no leading dash). Register one fixed
     // positional with `positional`; declare a trailing variable-count tail with
@@ -103,6 +112,10 @@ class Parser {
     int getInt(const char *name) const;
     float getFloat(const char *name) const;
     std::string getString(const char *name) const;
+    // The `count` floats bound to a FLOAT_LIST arg (registered via numbers()),
+    // in command-line order. Returns the registered all-zero defaults when the
+    // arg was not supplied.
+    const std::vector<float> &getFloats(const char *name) const;
 
     // True when the arg appeared on the command line (vs. resolved to its
     // default). The honest "present?" signal for OPTIONAL_INT switches such as
@@ -137,6 +150,8 @@ class Parser {
         int intValue_ = 0;
         float floatValue_ = 0.0f;
         std::string stringValue_;
+        std::vector<float> floatValues_; // FLOAT_LIST values (sized to listCount_)
+        int listCount_ = 0;              // FLOAT_LIST arity
         bool provided_ = false;
     };
 

--- a/engine/ir_args.cpp
+++ b/engine/ir_args.cpp
@@ -19,8 +19,9 @@ namespace IRArgs {
 
 namespace {
 
-// Per-type value placeholder shown after the arg name in --help.
-const char *placeholderFor(Type type) {
+// Per-type value placeholder shown after the arg name in --help. FLOAT_LIST
+// repeats " <float>" once per declared value so the arity is visible.
+std::string placeholderFor(Type type, int listCount) {
     switch (type) {
     case Type::FLAG:
         return "";
@@ -32,8 +33,32 @@ const char *placeholderFor(Type type) {
         return " <value>";
     case Type::OPTIONAL_INT:
         return " [int]";
+    case Type::FLOAT_LIST: {
+        std::string placeholder;
+        for (int k = 0; k < listCount; ++k) {
+            placeholder += " <float>";
+        }
+        return placeholder;
+    }
     }
     return "";
+}
+
+// Parse exactly `count` comma-separated floats from an inline "--name=a,b,c"
+// value into `out`. Returns false when the token count doesn't match.
+bool splitInlineFloatList(const std::string &value, int count, std::vector<float> &out) {
+    out.clear();
+    std::size_t start = 0;
+    while (start <= value.size()) {
+        const std::size_t comma = value.find(',', start);
+        const std::size_t end = comma == std::string::npos ? value.size() : comma;
+        out.push_back(static_cast<float>(std::atof(value.substr(start, end - start).c_str())));
+        if (comma == std::string::npos) {
+            break;
+        }
+        start = comma + 1;
+    }
+    return static_cast<int>(out.size()) == count;
 }
 
 // Split a "--name=value" long option into its name (before the first '=') and
@@ -128,6 +153,14 @@ Parser &
 Parser::optionalInt(const char *name, const char *help, int defaultIfBare, const char *shortAlias) {
     Entry &e = add(name, help, Type::OPTIONAL_INT, shortAlias);
     e.intValue_ = defaultIfBare;
+    return *this;
+}
+
+Parser &Parser::numbers(const char *name, const char *help, int count, const char *shortAlias) {
+    IR_ASSERT(count > 0, "IRArgs: numbers() requires a positive value count");
+    Entry &e = add(name, help, Type::FLOAT_LIST, shortAlias);
+    e.listCount_ = count;
+    e.floatValues_.assign(static_cast<std::size_t>(count), 0.0f);
     return *this;
 }
 
@@ -259,6 +292,37 @@ void Parser::parse(int argc, char **argv) {
                 }
             }
             break;
+        case Type::FLOAT_LIST:
+            // An inline value is one comma-separated token ("--name=a,b,c");
+            // otherwise consume the next listCount_ tokens space-separated. Too
+            // few tokens (or a wrong inline count) is a hard parse error so a
+            // malformed sweep can't silently run with zeroed values.
+            if (hasInline) {
+                if (!splitInlineFloatList(inlineValue, e->listCount_, e->floatValues_)) {
+                    std::fprintf(
+                        stderr,
+                        "Argument %s expects %d comma-separated float values\n\n",
+                        name.c_str(),
+                        e->listCount_
+                    );
+                    exitWithUsage(2);
+                }
+            } else {
+                for (int k = 0; k < e->listCount_; ++k) {
+                    if (i + 1 >= argc) {
+                        std::fprintf(
+                            stderr,
+                            "Argument %s expects %d float values\n\n",
+                            name.c_str(),
+                            e->listCount_
+                        );
+                        exitWithUsage(2);
+                    }
+                    e->floatValues_[static_cast<std::size_t>(k)] =
+                        static_cast<float>(std::atof(argv[++i]));
+                }
+            }
+            break;
         }
     }
 
@@ -328,6 +392,16 @@ std::string Parser::getString(const char *name) const {
     return e != nullptr ? e->stringValue_ : std::string{};
 }
 
+const std::vector<float> &Parser::getFloats(const char *name) const {
+    static const std::vector<float> empty;
+    const Entry *e = findByName(name);
+    IR_ASSERT(
+        e != nullptr && e->type_ == Type::FLOAT_LIST,
+        "IRArgs: getFloats on unregistered/non-float-list arg"
+    );
+    return e != nullptr ? e->floatValues_ : empty;
+}
+
 bool Parser::wasProvided(const char *name) const {
     const Entry *e = findByName(name);
     IR_ASSERT(e != nullptr, "IRArgs: wasProvided on unregistered arg");
@@ -382,7 +456,7 @@ std::string Parser::usage() const {
         if (!e->shortAlias_.empty()) {
             left += ", " + e->shortAlias_;
         }
-        left += placeholderFor(e->type_);
+        left += placeholderFor(e->type_, e->listCount_);
         if (left.size() > widest) {
             widest = left.size();
         }

--- a/engine/ir_args.cpp
+++ b/engine/ir_args.cpp
@@ -45,7 +45,10 @@ std::string placeholderFor(Type type, int listCount) {
 }
 
 // Parse exactly `count` comma-separated floats from an inline "--name=a,b,c"
-// value into `out`. Returns false when the token count doesn't match.
+// value into `out`. Returns false when the token count doesn't match. A
+// trailing comma (e.g. "8,") parses its empty tail as 0.0 rather than being
+// rejected — count still matches, so this is accepted as malformed input
+// (mirrors the equivalent pre-existing ambiguity in the space-separated form).
 bool splitInlineFloatList(const std::string &value, int count, std::vector<float> &out) {
     out.clear();
     std::size_t start = 0;


### PR DESCRIPTION
## Summary
The P2 IRArgs migration (#2076) switched four demos to `IREngine::init(argc, argv)` — which runs the engine `IRArgs` parser **strictly** (unknown arg → `exit(2)`) — without registering their hand-rolled custom flags. So each demo rejected its own debug flags:

- **canvas_stress** — `--only`, `--sweep-yaw`, `--sweep-frames`, `--debug-overlay`, `--depth-probe[-assert]`, `--yaw`, `--zoom`, `--subdivisions`, `--no-spin`, … (17 flags). Blocked every render-validation task driving it with a debug flag (#1970, #2122).
- **gpu_particles** — `--spawns-per-frame`
- **ir_voxel_yaw** — `--spin-yaw`, `--yaw`, `--zoom`
- **lua_perf_grid** — `--auto-profile`, `--grid-size`, `--zoom`, `--subdivision-mode`, `--base-subdivisions`

Each demo's flags are now registered on `IREngine::args()` before `init` and read back after, retiring the hand-rolled `strcmp`/`atoi` parsers (the canonical `fog_demo` / `shape_debug` adoption).

### IRArgs: new `FLOAT_LIST` type
canvas_stress's multi-value `--sweep-yaw <from> <to> <n>` / `--sweep-frames <n> <settle>` needed a fixed-arity float-list arg type, so I added `Parser::numbers(name, help, count)` / `getFloats()` (`Type::FLOAT_LIST`). This preserves the established **space-separated** spellings that `docs/design/jitter-validation-harness.md` and the planned #1954 jitter harness rely on (rather than forcing a comma-separated rewrite). Accepts both `--sweep-yaw 0 360 8` and `--sweep-yaw=0,360,8`; too few values is a clean `expects N float values` + exit(2).

### Incidental fix
ir_voxel_yaw's `--spin-yaw` adopts shape_debug's optional-int treatment, which also fixes a latent ordering bug: its `--spin-yaw + --auto-screenshot` reinterpret block read `g_autoWarmupFrames` **before** `init` had populated it (dead since the P2 migration, masked by the `exit(2)`).

## Test plan
- [x] `--help` on canvas_stress lists all 17 custom flags (incl. `--sweep-yaw <float> <float> <float>`)
- [x] Original repro `IRCanvasStress --only gridspin --debug-overlay shadow --no-auto-rotate --auto-screenshot 6` runs (was `exit 2: Unknown argument: --only`)
- [x] `--sweep-yaw 0 0.5 3` (space) + `--sweep-yaw=0,0.5,3` (inline) both produce 3 interpolated shots; malformed `--sweep-yaw 0 0.5` / `--sweep-frames=8` → `expects N … values` + exit 2
- [x] `IRGpuParticles --spawns-per-frame 50`, `IRVoxelYaw --spin-yaw --auto-screenshot 4` (sweep now fires), `IRLuaPerfGrid --grid-size 8 --subdivision-mode full --auto-profile 5` all run; `--subdivision-mode bogus` warns without exit(2)
- [x] All four demo targets build clean; flagless runs unchanged (defaults mirror the prior struct defaults)
- [x] `engine/CLAUDE.md` IRArgs registration-method list updated with `.numbers` / `.getFloats`

Verified on macOS / Metal.

Closes #2103

🤖 Generated with [Claude Code](https://claude.com/claude-code)