### PR TITLE
fleet: project_worker drops human-gated needs-plan from dispatch hash

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1429,6 +1429,19 @@ def project_worker(state):
                 items.append({"kind": "task", "repo": repo, "id": task["id"],
                               "blocked_by": task["blocked_by"]})
         for issue in repo_state.get("needs_plan", []):
+            # Mirror slice_worker's human-gate skip (#2114): a needs-plan issue
+            # carrying human:no-plan / owned / wip is not worker-plannable, so it
+            # must not flip the dispatch hash either. Without this, the late-opt-out
+            # window — human:no-plan added onto a still-needs-plan issue, before the
+            # edge-triggered ingest run strips the stale label — flips this hash and
+            # wakes a phantom worker dispatch that slice_worker then filters to a
+            # no-op (#2110 criterion 4). The slice fix alone stopped the woken worker
+            # from *claiming* the issue but not the wake itself, since the dispatcher
+            # diffs *this* projection to decide whether to fire. A merely fleet:blocked
+            # needs-plan issue is still plannable (planning is independent of the
+            # blocker), so it is NOT gated.
+            if set(issue.get("labels", [])) & _HUMAN_GATE_LABELS:
+                continue
             items.append({"kind": "needs_plan", "repo": repo,
                           "issue": issue["number"]})
         for pr in repo_state.get("prs", []):

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -297,6 +297,72 @@ class SliceWorkerSkipsGatedNeedsPlan(unittest.TestCase):
         )
 
 
+class ProjectWorkerSkipsGatedNeedsPlan(unittest.TestCase):
+    """project_worker is the hash-input that decides *whether* to wake the
+    dispatcher (distinct from slice_worker, the slice a woken worker reads).
+    It must mirror slice_worker's human-gate skip (#2110 criterion 4): a
+    needs-plan issue carrying human:no-plan / owned / wip must NOT flip the
+    projection hash, or the late-opt-out window (human:no-plan added onto a
+    still-needs-plan issue, before ingest strips the stale label) edge-triggers
+    a phantom worker dispatch that slice_worker then filters to a no-op. The
+    #2114 slice fix alone stopped the woken worker from claiming the issue but
+    not the wake itself, since the dispatcher diffs this projection."""
+
+    def _np(self, needs_plan):
+        items = project_worker(_state([], needs_plan=needs_plan))
+        return sorted(i["issue"] for i in items if i.get("kind") == "needs_plan")
+
+    def test_human_no_plan_does_not_surface(self):
+        self.assertEqual(
+            self._np([{"number": 222,
+                       "labels": ["fleet:needs-plan", "human:no-plan"]}]),
+            [],
+        )
+
+    def test_human_owned_and_wip_do_not_surface(self):
+        self.assertEqual(
+            self._np([
+                {"number": 301, "labels": ["fleet:needs-plan", "human:owned"]},
+                {"number": 302, "labels": ["fleet:needs-plan", "human:wip"]},
+            ]),
+            [],
+        )
+
+    def test_plain_needs_plan_still_surfaces(self):
+        self.assertEqual(
+            self._np([{"number": 222, "labels": ["fleet:needs-plan"]}]),
+            [222],
+        )
+
+    def test_blocked_needs_plan_still_surfaces(self):
+        # fleet:blocked is NOT a human gate — planning is independent of the
+        # blocker, so a blocked needs-plan issue still wakes the worker.
+        self.assertEqual(
+            self._np([{"number": 222,
+                       "labels": ["fleet:needs-plan", "fleet:blocked"]}]),
+            [222],
+        )
+
+    def test_gated_needs_plan_does_not_flip_hash(self):
+        # The dispatch consequence: a gated needs-plan issue appearing must
+        # leave the projection hash unchanged (no phantom wake), while a plain
+        # one flips it (existing test_needs_plan_issue_appears_flips_hash).
+        empty = stable_hash(project_worker(_state([])))
+        gated = stable_hash(project_worker(_state([], needs_plan=[
+            {"number": 222, "labels": ["fleet:needs-plan", "human:no-plan"]}])))
+        self.assertEqual(empty, gated)
+
+    def test_mixed_set_keeps_only_plannable(self):
+        self.assertEqual(
+            self._np([
+                {"number": 401, "labels": ["fleet:needs-plan", "human:no-plan"]},
+                {"number": 402, "labels": ["fleet:needs-plan"]},
+                {"number": 403, "labels": ["fleet:needs-plan", "human:owned"]},
+            ]),
+            [402],
+        )
+
+
 class OpusReviewerStableAcrossIrrelevantLabels(unittest.TestCase):
     """Opus-reviewer keys on fleet:has-nits / fleet:needs-fix (flag_labels).
     Other labels are either gating (REVIEW_SKIP_LABELS, removed from the


### PR DESCRIPTION
## Summary

Completes the scout-side half of #2110 (criterion 4: *"the scout's `needs_plan[]` projection no longer surfaces opted-out issues so they stop churning planners"*).

When #2110 was filed (2026-06-29), two prior PRs landed the same day and already covered the rest:
- **#2113** (`fleet-queue-ingest`) — criteria 1–3: a `human:approved` issue carrying both `fleet:needs-plan` and an opt-out (`human:no-plan` / `[no-plan]` / investigation spike) is reconciled by the next ingest pass (stale `fleet:needs-plan` stripped, queued directly).
- **#2114** (`slice_worker`) — added the `_HUMAN_GATE_LABELS` skip to the *slice a woken worker reads*, so the woken worker no longer **claims** an opted-out needs-plan issue.

The gap this PR closes: **`project_worker`** — the *projection the dispatcher diffs to decide whether to wake* — was still unfiltered. So in the late-opt-out window (human adds `human:no-plan` to a still-`needs-plan` issue, before the edge-triggered ingest run strips the label), the projection hash still flipped and **woke a phantom worker dispatch**; `slice_worker` then filtered the issue out → a no-op iteration. #2114's own "no phantom planner" title was only half-delivered because the wake decision keys on the projection, not the slice.

### Change
- `project_worker`'s `needs_plan` loop now skips `_HUMAN_GATE_LABELS` (`human:no-plan` / `human:owned` / `human:wip`), mirroring `slice_worker` exactly (reuses the constant #2114 factored out).
- **Intentionally left ungated:** `project_queue_manager` / `slice_queue_manager` — that projection is precisely what wakes `fleet-queue-ingest` to strip the stale label, so gating it would break the #2113 reconcile.
- A merely `fleet:blocked` needs-plan issue is still plannable (planning is independent of the blocker) and remains in the projection.

## Test plan
- [x] `python3 scripts/fleet/tests/test_worker_projection.py` — 51 tests pass, including new `ProjectWorkerSkipsGatedNeedsPlan` (no-plan/owned/wip don't surface and don't flip the hash; plain + blocked still surface) and the existing `test_needs_plan_issue_appears_flips_hash` (plain needs-plan still wakes — no regression).
- [x] Sibling scout suites green: `test_queue_manager_projection`, `test_scout_all_gated_self_config`, `test_epic_steward_projection`, `test_scout_degraded_fetch`.
- [x] `ruff check scripts/fleet/fleet-state-scout scripts/fleet/tests/test_worker_projection.py` — clean.
- [x] Scout imports cleanly (no syntax break).

Closes #2110

🤖 Generated with [Claude Code](https://claude.com/claude-code)