### PR TITLE
demo(shape_debug): createVoxelPoolShape uses IRMath::SDF::evaluateGrid (#2120)

### DIFF
--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -877,11 +877,17 @@ EntityId createVoxelPoolShape(
     auto sdfType = static_cast<IRMath::SDF::ShapeType>(type);
     vec4 sdfParams = IRMath::SDF::effectiveParams(sdfType, shapeParams);
 
+    // Batch-evaluate the SDF over the whole grid via the shared helper rather
+    // than calling evaluate() per cell. evaluateGrid samples each cell at
+    // vec3(x,y,z) - size*0.5 + 0.5 in index3DtoIndex1D order — bit-identical to
+    // the centered positions C_VoxelSetNew laid out for centerAroundOrigin — so
+    // distances[i] lines up one-for-one with voxel i.
+    std::vector<float> distances(static_cast<std::size_t>(vs.numVoxels_));
+    IRMath::SDF::evaluateGrid(vs.size_, sdfType, sdfParams, distances);
+
     int activeCount = 0;
     for (int i = 0; i < vs.numVoxels_; ++i) {
-        vec3 localPos = vs.positions_[i].pos_;
-        float sdf = IRMath::SDF::evaluate(localPos, sdfType, sdfParams);
-        if (sdf > IRMath::SDF::kSurfaceThreshold) {
+        if (distances[i] > IRMath::SDF::kSurfaceThreshold) {
             vs.voxels_[i].deactivate();
         } else {
             ++activeCount;


### PR DESCRIPTION
## Summary
- `createVoxelPoolShape` (shape_debug) hand-rolled a per-cell `IRMath::SDF::evaluate` loop over the voxel volume. Replaced it with the existing batched `IRMath::SDF::evaluateGrid` helper + a single threshold pass.
- **Byte-identical:** `evaluateGrid` samples each cell at `vec3(x,y,z) - size*0.5 + 0.5` in `index3DtoIndex1D` order — bit-for-bit equal to the centered positions `C_VoxelSetNew` lays out for `centerAroundOrigin` (both reduce to exact multiples of 0.5), so every carve decision is preserved.

## Test plan
- [x] `fleet-build --target IRShapeDebug` — clean
- [x] `render-verify` (macos-debug / Metal): **all 21 shape_debug shots PASS** — 19 byte-identical (max_delta 0, PSNR inf); the only 2 with any delta are the non-cardinal-yaw shots (max_delta 22 / 7, threshold 64), the demo's known run-to-run scatter jitter, orthogonal to entity-creation-time SDF carving.

Found by `simplify-scan-render-leak` during PR #2117 review; pre-existing before that PR.

Closes #2120