### PR TITLE
fleet: scout GL-host inference also matches the "GL-host only" adjective form

### DIFF
--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -417,9 +417,18 @@ _EPIC_CHECKLIST_RE = re.compile(
 # precision; the explicit label remains the primary, recommended signal. macOS
 # host declarations don't match (the OS alternation is linux/windows/opengl), so
 # a mac-only task is never self-gated off its own host.
+#
+# Two requirement shapes are matched (both deliberate declarations, both
+# precision-safe): a verb form ("must run on a Linux host", "only builds on an
+# OpenGL host") and the very common "<GL|OpenGL|Linux|Windows>-host only" /
+# "GL host only" adjective form (#2107: "It is GL-host only and cannot be
+# authored/validated on a macOS/Metal host" — missed by the verb form alone).
 _GL_HOST_REQUIRED_RE = re.compile(
-    r"\b(?:must\s+(?:be\s+)?run\s+on|only\s+(?:runs?|builds?)\s+on)\s+"
-    r"(?:an?\s+|the\s+)?(?:linux|windows|opengl)[\w/+-]*\s+host\b",
+    r"\b(?:"
+    r"(?:must\s+(?:be\s+)?run\s+on|only\s+(?:runs?|builds?)\s+on)\s+"
+    r"(?:an?\s+|the\s+)?(?:linux|windows|opengl)[\w/+-]*\s+host"
+    r"|(?:gl|opengl|linux|windows)[\s-]?host[\s-]?only"
+    r")\b",
     re.IGNORECASE,
 )
 

--- a/scripts/fleet/tests/test_worker_projection.py
+++ b/scripts/fleet/tests/test_worker_projection.py
@@ -593,6 +593,11 @@ class NeedsGlHostAnnotation(unittest.TestCase):
             "must be run on a Windows host to refresh windows-debug refs.",
             "Only runs on an OpenGL host.",
             "must run on a Linux/Windows host",
+            # #2107: the "<GL|...>-host only" adjective form the verb pattern missed.
+            "It is GL-host only and cannot be authored/validated on a macOS host.",
+            "This is GL host only.",
+            "OpenGL-host-only GTEST harness.",
+            "Windows-host only — needs the native MSYS2 toolchain.",
         ):
             with self.subTest(phrase=phrase):
                 result = self._fetch([self._issue_body(1969, f"**Model:** sonnet\n{phrase}")])
@@ -607,6 +612,8 @@ class NeedsGlHostAnnotation(unittest.TestCase):
             "The Linux build is faster than macOS.",
             "must run on a macOS host",        # mac task — not a GL gate
             "compare against the linux-debug references",
+            "the host only accepts one connection",   # "host only" without a GL prefix
+            "macOS-host only",                         # mac adjective form — not a GL gate
         ):
             with self.subTest(phrase=phrase):
                 result = self._fetch([self._issue_body(2000, f"**Model:** opus\n{phrase}")])


### PR DESCRIPTION
## Summary

#2134's body-inference of `needs_gl_host` was precision-first but missed a common phrasing. #2107 said *"It is **GL-host only** and cannot be authored/validated on a macOS/Metal host"* — the adjective form, not the verb form the regex matched — so it was misrouted to a Metal pane and churned (a worker had to hand-apply the label and filed scout-regex feedback).

Adds a second, equally precision-safe alternation: `(gl|opengl|linux|windows)[-\s]?host[-\s]?only`. Both shapes are deliberate declarations; a passing mention still doesn't match.

## Test plan
- [x] Real #2107 body now infers `needs_gl_host=True`.
- [x] `NeedsGlHostAnnotation`: +4 adjective-form positives (`GL-host only`, `GL host only`, `OpenGL-host-only`, `Windows-host only`); +2 negatives (`the host only…`, `macOS-host only`). Existing verb-form positives + `tested on a Linux host` / `must run on a macOS host` / `linux-debug references` negatives unchanged.

Part of the "stop GL-host tasks churning Metal panes" thread (re-arm exclusion is a sibling PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)