### PR TITLE
fleet: periodic worker re-arm delegates to the resolver (no more divergence)

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1242,6 +1242,18 @@ resolve_worker_class() {
     [[ "$count" =~ ^[0-9]+$ ]] && DISPATCH_COUNT="$count"
 }
 
+# Returns 0 (should re-arm) iff the resolver would dispatch a CONCRETE class for
+# this worker lane — i.e. there is genuinely claimable work under the full
+# claimability gate (host capability, stackability, inflight_pr, owner, blocked).
+# The periodic safety re-arm uses this so it can never diverge from the actual
+# dispatch decision: a `defer` verdict (nothing claimable) or the '' lane-default
+# fallthrough (reservation resume / missing slice) does NOT re-arm; only a routed
+# class does. Sets DISPATCH_* as a side effect (resolve_worker_class).
+worker_rearm_should_fire() {
+    resolve_worker_class "$1"
+    (( DISPATCH_DEFER == 0 )) && [[ -n "$DISPATCH_CLASS" ]]
+}
+
 dispatch_role() {
     local role="$1"
     local trigger_file="$TRIGGERS_DIR/$role"
@@ -1671,61 +1683,17 @@ PY
         if [[ "$_active" -gt 0 ]]; then
             continue
         fi
-        # Read the role's projection and check the predicate.
-        TRIGGERS_DIR="$TRIGGERS_DIR" \
-        STATE_DIR="$STATE_DIR" \
-        ROLE="$_role" \
-        python3 - <<'PY' || true
-import json
-import os
-import pathlib
-
-trig_dir = pathlib.Path(os.environ["TRIGGERS_DIR"])
-state_dir = pathlib.Path(os.environ["STATE_DIR"])
-role = os.environ["ROLE"]
-
-# Classes the lane serves — the unified worker lane covers every class
-# (a fable-only or sonnet-only backlog must still re-arm it; keep in sync
-# with the scout's slice filters and WORKER_LANE_DEFAULT_CLASS).
-ROLE_MODELS = {"worker": {"opus", "fable", "sonnet"}}
-models = ROLE_MODELS.get(role)
-if not models:
-    raise SystemExit(0)
-
-proj_path = state_dir / "projections" / f"{role}.json"
-if not proj_path.is_file():
-    raise SystemExit(0)
-try:
-    proj = json.loads(proj_path.read_text())
-except (OSError, json.JSONDecodeError):
-    raise SystemExit(0)
-
-# Predicate: at least one task that is unowned, unblocked, NOT already covered
-# by an open implementation PR, and matches a class this lane serves. The
-# projection's `blocked_by` is rendered as "(none)" (literal) when there are no
-# blockers. The `inflight_pr` guard mirrors the dispatch-time claimability gate
-# (fleet_task_class._task_claimable): a queued task whose own issue already has
-# an open PR — typically a parked design-blocked one that released its issue
-# claim — looks owner-free + unblocked here but a fresh worker would refuse it
-# on sight. Without this guard the safety re-arm fires every interval on such a
-# task, fanning no-op iterations into every idle pane (the #1726 shape, surfaced
-# again by an inflight-only queue), which is exactly what this re-arm must not do.
-def is_actionable(task):
-    if task.get("owner") != "free":
-        return False
-    if task.get("inflight_pr"):
-        return False
-    blocked = (task.get("blocked_by") or "").strip()
-    if blocked and blocked != "(none)":
-        return False
-    return task.get("model") in models
-
-if any(is_actionable(t) for t in (proj.get("tasks_open") or [])):
-    trig = trig_dir / role
-    if not trig.exists():
-        trig.touch()
-        print(f"worker-rearm: re-armed {role} (projection has actionable free work, no active iteration)")
-PY
+        # Re-arm iff the resolver would dispatch a concrete class — genuinely
+        # claimable work under the FULL claimability gate. Delegating to
+        # resolve_worker_class keeps this safety re-arm in lock-step with the
+        # dispatch decision; the previous inline predicate had drifted (it
+        # excluded inflight_pr but not needs_gl_host, so it re-armed every
+        # interval on GL-host tasks a Metal pane can never claim — the #1969
+        # idle-churn shape).
+        if worker_rearm_should_fire "$_role"; then
+            touch "$TRIGGERS_DIR/$_role"
+            log "worker-rearm: re-armed $_role (class=$DISPATCH_CLASS claimable, no active iteration)"
+        fi
     done
 }
 
@@ -1893,6 +1861,22 @@ case "${1:-}" in
         fi
         resolve_worker_class "$2"
         echo "class=$DISPATCH_CLASS model=$DISPATCH_MODEL effort=$DISPATCH_EFFORT more=$DISPATCH_MORE defer=$DISPATCH_DEFER count=$DISPATCH_COUNT"
+        exit 0
+        ;;
+    --rearm-check)
+        # Test/debug: would the periodic safety re-arm fire for <role> against
+        # the current projection? Prints "rearm class=<c>" when the resolver
+        # would dispatch a concrete class, else "skip (defer=<0|1> class=<c>)".
+        # Does NOT touch the trigger. Mirrors the live re-arm condition exactly.
+        if [[ -z "${2:-}" ]]; then
+            echo "usage: fleet-dispatcher --rearm-check <role>" >&2
+            exit 2
+        fi
+        if worker_rearm_should_fire "$2"; then
+            echo "rearm class=$DISPATCH_CLASS"
+        else
+            echo "skip (defer=$DISPATCH_DEFER class=$DISPATCH_CLASS)"
+        fi
         exit 0
         ;;
     --gate-status)

--- a/scripts/fleet/tests/test_dispatcher_rearm.sh
+++ b/scripts/fleet/tests/test_dispatcher_rearm.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tests for the periodic worker safety re-arm decision (fleet-dispatcher's
+# worker_rearm_should_fire), exercised through the --rearm-check hook.
+#
+# The re-arm now delegates to resolve_worker_class so it can never diverge from
+# the actual dispatch decision: it fires iff the resolver would dispatch a
+# CONCRETE class (genuinely claimable work under the full claimability gate), and
+# skips on `defer` (nothing claimable) or the '' lane-default fallthrough. The
+# old inline predicate excluded inflight_pr but NOT needs_gl_host, so it re-armed
+# every interval on GL-host tasks a Metal pane can never claim (#1969 churn) —
+# this pins that it no longer does.
+
+set -uo pipefail
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+[[ -x "$DISPATCHER" ]] || { echo "test setup: fleet-dispatcher not found"; exit 1; }
+
+PASS=0; FAIL=0
+TMPROOT=""; cleanup(){ [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then PASS=$((PASS+1)); echo "  ok: $3"
+    else FAIL=$((FAIL+1)); echo "  FAIL: $3"; echo "      expected: $2"; echo "      actual:   $1"; fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_STATE_DIR="$TMPROOT/state"
+export FLEET_SESSION="fleet-test-$$"
+mkdir -p "$FLEET_STATE_DIR/projections" "$FLEET_STATE_DIR/dispatch"
+
+write_slice() { printf '%s\n' "$2" > "$FLEET_STATE_DIR/projections/$1.json"; }
+rearm() { FLEET_TEST_HOST="$1" "$DISPATCHER" --rearm-check worker; }
+
+echo "T1: a free unblocked opus task -> rearm"
+write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
+assert_eq "$(rearm linux)" "rearm class=opus" "claimable opus task -> rearm class=opus"
+
+echo "T2: GL-host-only task on a Metal (mac) pane -> SKIP (the #1969 fix)"
+write_slice worker '{"tasks_open":[{"issue":"#1938","model":"opus","owner":"free","blocked":false,"needs_gl_host":true}],"feedback_prs":[],"needs_plan":[]}'
+assert_eq "$(rearm mac)" "skip (defer=1 class=)" "gl-host task on mac -> skip (defer)"
+
+echo "T3: same GL-host task on a Linux pane -> rearm (it IS claimable there)"
+assert_eq "$(rearm linux)" "rearm class=opus" "gl-host task on linux -> rearm class=opus"
+
+echo "T4: inflight-only task -> SKIP (no fresh-claimable work)"
+write_slice worker '{"tasks_open":[{"issue":"#1640","model":"opus","owner":"free","blocked":false,"inflight_pr":{"number":1700}}],"feedback_prs":[],"needs_plan":[]}'
+assert_eq "$(rearm linux)" "skip (defer=1 class=)" "inflight-only -> skip (defer)"
+
+echo "T5: empty slice -> SKIP (lane-default fallthrough must not re-arm)"
+write_slice worker '{"tasks_open":[],"feedback_prs":[],"needs_plan":[]}'
+assert_eq "$(rearm linux)" "skip (defer=0 class=)" "empty slice -> skip ('' fallthrough)"
+
+echo "T6: a sonnet feedback PR -> rearm (feedback work counts now)"
+write_slice worker '{"tasks_open":[],"feedback_prs":[{"number":50,"labels":["fleet:approved","fleet:has-nits"]}],"needs_plan":[]}'
+assert_eq "$(rearm mac)" "rearm class=sonnet" "feedback PR -> rearm class=sonnet"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

The "worker keeps spinning up and finding no work" churn traces partly to the dispatcher's **periodic safety re-arm** using its own inline `is_actionable` predicate that had **drifted** from the real dispatch decision. It excluded `inflight_pr` (the #2101 fix) but **not** `needs_gl_host` — so on a Metal pane it re-armed the worker trigger every interval on GL-host-only tasks (#1938/#1969/#2107) a fresh worker can never claim there, with a misleading *"projection has actionable free work"* log line.

### Fix: stop re-implementing claimability

Replace the inline predicate with `worker_rearm_should_fire()`, which calls `resolve_worker_class` and re-arms **iff the resolver would dispatch a concrete class** — genuinely claimable work under the *full* claimability gate (host capability, stackability, `inflight_pr`, owner, blocked). A `defer` verdict or the `''` lane-default fallthrough no longer re-arms. The safety re-arm is now in permanent lock-step with the dispatch decision, so this class of drift can't recur.

Side benefits:
- feedback PRs now correctly re-arm (the old predicate only scanned `tasks_open`);
- the re-arm log line names the class (`class=opus claimable …`) — better observability;
- ~55 lines of inline Python removed.

## Test plan
- [x] New `--rearm-check <role>` hook (test seam + operator tool, mirrors `--resolve-class`).
- [x] `test_dispatcher_rearm.sh`: claimable→rearm; **GL-host on mac→skip**, on linux→rearm; inflight-only→skip; empty→skip; feedback PR→rearm.
- [x] All dispatcher suites green except the pre-existing macOS `concurrency_cap` T4c host-flake.

Sibling of the GL-host inference recall PR (#2150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)