### PR TITLE
fleet: dispatcher serves the next claimable class when the elected one is covered

### DIFF
--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1212,6 +1212,9 @@ build_dispatch_command() {
 # fleet_task_class.py for the resolution rules and output protocol.
 resolve_worker_class() {
     local role="$1"
+    # $2 = optional comma-separated classes to exclude (the cross-class fan-out
+    # re-resolve in dispatch_role, after a class is found cap-saturated).
+    local exclude="${2:-}"
     DISPATCH_CLASS="" DISPATCH_MODEL="" DISPATCH_EFFORT=""
     DISPATCH_MORE=0 DISPATCH_DEFER=0 DISPATCH_COUNT=""
     local lane_default="${WORKER_LANE_DEFAULT_CLASS[$role]:-}"
@@ -1224,7 +1227,7 @@ resolve_worker_class() {
     fi
     local out
     out=$(python3 "$FLEET_LIB_DIR/fleet_task_class.py" \
-        "$slice" "$lane_default" "$fable_blocked" 2>/dev/null) || out=""
+        "$slice" "$lane_default" "$fable_blocked" "$exclude" 2>/dev/null) || out=""
     if [[ "$out" == "defer" ]]; then
         DISPATCH_DEFER=1
         return 0
@@ -1319,53 +1322,62 @@ dispatch_role() {
     # Per-task model class for worker lanes (no-op for other roles).
     # Resolved once per tick, not per pane — same slice, same answer;
     # multiple panes dispatched this tick race-claim within the class.
-    resolve_worker_class "$role"
-    if (( DISPATCH_DEFER )); then
-        # Nothing a fresh worker can claim right now: either the only
-        # actionable work is cap-blocked fable, or the queue's only items
-        # already have open implementation PRs (inflight_pr, #1726).
-        # Dispatching the lane default would burn an iteration on
-        # gate-refused claims; keep the trigger and wait (a freed fable
-        # slot or a resolved/merged PR re-fires the scout projection).
-        if [[ -z "${CAP_DEFER_LOGGED[$role-noclaim]+x}" ]]; then
-            log "$role: no claimable work (cap-blocked fable or in-flight PRs only); deferring trigger"
-            CAP_DEFER_LOGGED["$role-noclaim"]=1
-        fi
-        return
-    fi
-    unset "CAP_DEFER_LOGGED[$role-noclaim]"
-
-    # Claimable-count fan-out cap. The resolver reports how many items of the
-    # elected class are claimable right now (DISPATCH_COUNT — set only for a
-    # worker lane that routed a class). Launch at most that many workers, minus
-    # the ones already dispatched recently enough to still be racing for the
-    # same items (count_recent_active_for_class within the settle window). This
-    # is what stops the lane firing a worker into every idle pane when only one
-    # or two tasks are actually claimable — the surplus panes would iterate and
-    # exit on no-op claims, and a no-op opus iteration is not free. An empty
-    # DISPATCH_COUNT (older slice, the '' lane-default fallthrough, or a
-    # non-worker role) means uncapped: preserve the legacy fan-out-to-all-panes.
+    #
+    # Cross-class fan-out: the claimable-count cap (below) caps each class to one
+    # worker per claimable item. When the elected class is fully covered by
+    # racing workers but ANOTHER class is claimable (DISPATCH_MORE), re-resolve
+    # excluding the covered class and serve the next one — otherwise a slow or
+    # churning head of one class would defer the whole tick and starve the
+    # others. Bounded: each pass excludes one more class, and there are at most
+    # three (opus|fable|sonnet), so the loop runs a handful of times then either
+    # finds a class with headroom, hits the uncapped path, or defers.
     local claim_headroom=-1   # -1 = uncapped
-    if [[ -n "$DISPATCH_CLASS" && -n "$DISPATCH_COUNT" ]]; then
-        local class_racing
-        class_racing=$(count_recent_active_for_class "$DISPATCH_CLASS" "$CLAIM_SETTLE_SECONDS")
-        claim_headroom=$(( DISPATCH_COUNT - class_racing ))
-        if (( claim_headroom < 0 )); then
-            claim_headroom=0
-        fi
-        if (( claim_headroom == 0 )); then
-            # Every claimable item of this class already has a still-settling
-            # worker racing for it. Keep the trigger so a later tick re-evaluates
-            # once those workers claim (the tasks leave tasks_open and the count
-            # drops) or settle out of the race window; dispatch nothing now.
-            if [[ -z "${CAP_DEFER_LOGGED[$role-claimcap]+x}" ]]; then
-                log "$role: class=$DISPATCH_CLASS claimable=$DISPATCH_COUNT already covered by $class_racing in-flight; deferring trigger"
-                CAP_DEFER_LOGGED["$role-claimcap"]=1
+    local _excluded="" _passes=0
+    while : ; do
+        resolve_worker_class "$role" "$_excluded"
+        if (( DISPATCH_DEFER )); then
+            # Nothing a fresh worker can claim right now: cap-blocked fable only,
+            # the queue's only items already have open PRs (inflight_pr, #1726),
+            # or every claimable class is already saturated (excluded above).
+            # Dispatching the lane default would burn no-op claims; keep the
+            # trigger and wait (a freed slot / resolved PR re-fires the scout).
+            if [[ -z "${CAP_DEFER_LOGGED[$role-noclaim]+x}" ]]; then
+                log "$role: no claimable work (cap-blocked fable, in-flight PRs, or all classes covered); deferring trigger"
+                CAP_DEFER_LOGGED["$role-noclaim"]=1
             fi
             return
         fi
-        unset "CAP_DEFER_LOGGED[$role-claimcap]"
-    fi
+        # Uncapped (older slice / '' lane-default fallthrough / non-worker role):
+        # no per-class headroom gate — preserve the legacy fan-out-to-all-panes.
+        if [[ -z "$DISPATCH_CLASS" || -z "$DISPATCH_COUNT" ]]; then
+            claim_headroom=-1
+            break
+        fi
+        # Claimable-count cap: at most DISPATCH_COUNT workers of this class, minus
+        # the ones dispatched recently enough to still be racing for the same
+        # items (count_recent_active_for_class within the settle window).
+        local class_racing
+        class_racing=$(count_recent_active_for_class "$DISPATCH_CLASS" "$CLAIM_SETTLE_SECONDS")
+        claim_headroom=$(( DISPATCH_COUNT - class_racing ))
+        (( claim_headroom < 0 )) && claim_headroom=0
+        if (( claim_headroom > 0 )); then
+            break   # this class has room — dispatch it below
+        fi
+        # This class is saturated. Serve another claimable class if one exists.
+        if (( DISPATCH_MORE )) && (( _passes++ < 3 )); then
+            _excluded="${_excluded:+$_excluded,}$DISPATCH_CLASS"
+            log "$role: class=$DISPATCH_CLASS covered ($class_racing in-flight >= $DISPATCH_COUNT claimable); serving next class"
+            continue
+        fi
+        # Saturated with no other claimable class — keep the trigger; a later
+        # tick re-evaluates once the racing workers claim or settle out.
+        if [[ -z "${CAP_DEFER_LOGGED[$role-claimcap]+x}" ]]; then
+            log "$role: class=$DISPATCH_CLASS claimable=$DISPATCH_COUNT already covered by $class_racing in-flight; deferring trigger"
+            CAP_DEFER_LOGGED["$role-claimcap"]=1
+        fi
+        return
+    done
+    unset "CAP_DEFER_LOGGED[$role-noclaim]" "CAP_DEFER_LOGGED[$role-claimcap]"
 
     local dispatched=0
     local gap_blocked=""
@@ -1887,11 +1899,14 @@ case "${1:-}" in
         #   "class=<c> model=<m> effort=<e> more=<0|1> defer=<0|1> count=<n>"
         # Empty class means the lane-default fallthrough; count is the number of
         # claimable items of the elected class (empty when class is empty).
+        # Optional $3 = comma-separated classes to exclude (the cross-class
+        # fan-out re-resolve — serve another class when the elected one is
+        # cap-saturated).
         if [[ -z "${2:-}" ]]; then
-            echo "usage: fleet-dispatcher --resolve-class <role>" >&2
+            echo "usage: fleet-dispatcher --resolve-class <role> [exclude-classes]" >&2
             exit 2
         fi
-        resolve_worker_class "$2"
+        resolve_worker_class "$2" "${3:-}"
         echo "class=$DISPATCH_CLASS model=$DISPATCH_MODEL effort=$DISPATCH_EFFORT more=$DISPATCH_MORE defer=$DISPATCH_DEFER count=$DISPATCH_COUNT"
         exit 0
         ;;

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -223,16 +223,32 @@ def _candidates(slice_data, lane_default, host):
         yield "opus", CLASS_DEFAULT_EFFORT["opus"]
 
 
-def resolve(slice_data, lane_default, fable_blocked):
-    """Return 'cls effort more count', 'defer', or '' per the output protocol."""
+def resolve(slice_data, lane_default, fable_blocked, exclude=()):
+    """Return 'cls effort more count', 'defer', or '' per the output protocol.
+
+    `exclude` is a set of classes the caller has already served-and-saturated
+    this tick (the dispatcher's cross-class fan-out: when the elected class is
+    fully cap-covered but another class is claimable, it re-resolves excluding
+    the covered class to serve the next one instead of deferring the whole tick).
+    An excluded class is dropped from consideration entirely — not chosen, not
+    counted toward `more`. If excluding leaves nothing electable but a claimable
+    (excluded) class existed, the verdict is `defer`, NOT '' — there is real work,
+    just none the caller can serve right now, so it must not fall through to a
+    lane-default dispatch.
+    """
     if lane_default not in CLASS_DEFAULT_EFFORT:
         lane_default = "opus"
+    exclude = set(exclude or ())
     host = _current_host()
     chosen = None
     skipped_fable = False
+    excluded_any = False
     servable_classes = set()
     class_counts = {}
     for cls, effort in _candidates(slice_data, lane_default, host):
+        if cls in exclude:
+            excluded_any = True
+            continue
         if cls == "fable" and fable_blocked:
             # Cap-blocked fable is not currently servable: don't let it
             # hold the trigger open via `more` (that would re-dispatch
@@ -255,7 +271,7 @@ def resolve(slice_data, lane_default, fable_blocked):
         # free). `more` still drives the *other-class* follow-up dispatch.
         count = class_counts[chosen[0]]
         return f"{chosen[0]} {chosen[1]} {more} {count}"
-    if skipped_fable:
+    if skipped_fable or excluded_any:
         return "defer"
     # Nothing servable AND no cap-blocked fable. If the queue's only content is
     # tasks already implemented by an open PR (every tasks_open item carries
@@ -272,17 +288,20 @@ def resolve(slice_data, lane_default, fable_blocked):
 
 
 def main(argv):
-    if len(argv) != 4:
-        print("usage: fleet_task_class.py <slice.json> <lane-default> <fable-blocked 0|1>",
-              file=sys.stderr)
+    # Optional 4th arg: comma-separated classes to exclude (the dispatcher's
+    # cross-class fan-out re-resolve). Absent -> exclude nothing.
+    if len(argv) not in (4, 5):
+        print("usage: fleet_task_class.py <slice.json> <lane-default> "
+              "<fable-blocked 0|1> [exclude-classes]", file=sys.stderr)
         return 2
     slice_path, lane_default, fable_blocked = argv[1], argv[2], argv[3] == "1"
+    exclude = [c for c in (argv[4].split(",") if len(argv) == 5 else []) if c]
     try:
         with open(slice_path) as f:
             slice_data = json.load(f)
     except (OSError, json.JSONDecodeError):
         return 0  # empty output -> lane default
-    out = resolve(slice_data, lane_default, fable_blocked)
+    out = resolve(slice_data, lane_default, fable_blocked, exclude)
     if out:
         print(out)
     return 0

--- a/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
+++ b/scripts/fleet/tests/test_dispatcher_class_dispatch.sh
@@ -116,6 +116,20 @@ echo "T7: non-worker roles skip class resolution"
 assert_eq "$(resolve merger)" "class= model= effort= more=0 defer=0 count=" \
     "merger has no lane class; resolution is a no-op"
 
+# --- T8: cross-class exclude threads through resolve_worker_class -------------
+# The dispatcher's cross-class fan-out re-resolves excluding a cap-covered class.
+echo "T8: --resolve-class <role> <exclude> serves the next class"
+write_slice worker '{"tasks_open":[{"issue":"#10","model":"opus","effort":null,"owner":"free","blocked":false},{"issue":"#11","model":"sonnet","effort":null,"owner":"free","blocked":false}],"feedback_prs":[],"needs_plan":[]}'
+assert_eq "$("$DISPATCHER" --resolve-class worker)" \
+    "class=opus model=claude-opus-4-8[1m] effort=xhigh more=1 defer=0 count=1" \
+    "no exclude -> opus elected, sonnet is 'more'"
+assert_eq "$("$DISPATCHER" --resolve-class worker opus)" \
+    "class=sonnet model=sonnet effort=high more=0 defer=0 count=1" \
+    "exclude opus -> sonnet served (the cross-class fan-out)"
+assert_eq "$("$DISPATCHER" --resolve-class worker opus,sonnet)" \
+    "class= model= effort= more=0 defer=1 count=" \
+    "exclude both claimable classes -> defer (not lane-default)"
+
 echo
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -331,5 +331,39 @@ class GlHostGate(unittest.TestCase):
         self.assertEqual(out, "defer")
 
 
+class ExcludeClasses(unittest.TestCase):
+    """The dispatcher's cross-class fan-out: when an elected class is fully
+    cap-covered but another class is claimable, it re-resolves with the covered
+    class excluded to serve the next one instead of deferring the whole tick."""
+
+    def test_exclude_elects_the_next_class(self):
+        slice_data = {"tasks_open": [_task("#10", "opus"), _task("#11", "sonnet")]}
+        # No exclude: opus is the elected (oldest) class, sonnet is `more`.
+        self.assertEqual(resolve(slice_data, "opus", False), "opus xhigh 1 1")
+        # Exclude opus -> sonnet is elected, nothing else servable -> more=0.
+        self.assertEqual(resolve(slice_data, "opus", False, exclude=["opus"]),
+                         "sonnet high 0 1")
+
+    def test_exclude_all_claimable_defers_not_empty(self):
+        # Excluding every claimable class must DEFER (there is real work, just
+        # none the caller can serve now), never '' — '' would wrongly fall the
+        # dispatcher through to a lane-default no-op dispatch.
+        slice_data = {"tasks_open": [_task("#10", "opus"), _task("#11", "sonnet")]}
+        self.assertEqual(resolve(slice_data, "opus", False,
+                                 exclude=["opus", "sonnet"]), "defer")
+
+    def test_exclude_irrelevant_class_is_noop(self):
+        # Excluding a class with no claimable work changes nothing.
+        slice_data = {"tasks_open": [_task("#10", "opus")]}
+        self.assertEqual(resolve(slice_data, "opus", False, exclude=["fable"]),
+                         "opus xhigh 0 1")
+
+    def test_exclude_on_empty_slice_stays_empty(self):
+        # No claimable work at all + an exclude -> '' (lane-default), not defer:
+        # nothing was excluded, so the reservation-resume fallthrough stands.
+        self.assertEqual(resolve({"tasks_open": []}, "opus", False,
+                                 exclude=["opus"]), "")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The follow-up to the cap work — the general starvation guard.

The claimable-count fan-out cap (#2101) caps each class to one worker per claimable item. But when the elected class was fully covered by racing workers, `dispatch_role` deferred the **whole tick** — even if another class was claimable (`DISPATCH_MORE`). So a slow or churning head of one class (a batch of sonnet feedback PRs, an opus task taking minutes to claim) could defer the *other* class for the duration: **cross-class starvation**.

### Fix

Make the resolver exclusion-aware and loop in `dispatch_role`: when the elected class is cap-saturated and another class is claimable, **re-resolve excluding the covered class and serve the next one** instead of deferring. Bounded — each pass excludes one more class and there are at most three (opus|fable|sonnet), so the loop runs a handful of times then finds a class with headroom, hits the uncapped path, or defers.

`fleet_task_class.resolve` gains an `exclude` set: excluded classes are dropped from consideration (not chosen, not counted toward `more`). Crucially, if excluding leaves nothing electable **but a claimable (excluded) class existed**, the verdict is `defer`, **not `''`** — `''` would wrongly fall the dispatcher through to a lane-default no-op dispatch. `fleet_task_class.py` takes an optional 4th arg (comma-separated exclude); `resolve_worker_class` threads it; `--resolve-class` gains an optional exclude arg as the test seam.

## Test plan
- [x] `ExcludeClasses` (resolver): exclude→elect-next, exclude-all→defer-not-empty, exclude-irrelevant→noop, exclude-on-empty→stays-empty.
- [x] `class_dispatch` T8: exclude threads through the dispatcher (`opus` → sonnet served; `opus,sonnet` → defer, not lane-default).
- [x] All dispatcher/resolver suites green bar the pre-existing macOS `concurrency_cap` T4c host-flake. Backward-compatible (3-arg resolve still works).

Builds on #2101 (cap) and #2151 (re-arm via resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)