### PR TITLE
render: headless per-trixel-priority tier gate for canvas_stress (#2122)

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -172,17 +172,31 @@ struct CanvasStressSettings {
     // floating canary cube clips behind the SDF floor at high zoom).
     bool depthProbeSet_ = false;
     ivec2 depthProbePixel_{0, 0};
-    // `--depth-probe-assert X,Y` (#1957): the depth-write regression guard. Like
-    // --depth-probe but emits a `[depth-probe-assert] … result=PASS|FAIL` verdict
-    // line — PASS iff the composite stored a non-background depth at (X,Y), i.e.
-    // the detached-canvas composite WROTE the depth attachment there. Aim it at a
-    // texel inside a world-placed detached solid (canonical:
-    // `--only canary --no-spin --no-auto-rotate --depth-probe-assert 321,210`,
-    // which the canary covers on both backends). FAILs if a future pass disables
-    // the composite depth-write. Off by default; registers no system when unset,
-    // so a flagless run is byte-identical.
+    // `--depth-probe-assert X,Y[,tier=N]` (#1957 / #1960): the composite
+    // regression guard. Two forms, both emitting a single
+    // `[depth-probe-assert] … result=PASS|FAIL` verdict line:
+    //   - `X,Y` (#1957) — DEPTH-WRITE guard: PASS iff the composite stored a
+    //     non-background depth at (X,Y), i.e. the detached-canvas composite WROTE
+    //     the depth attachment there. Aim it at a texel inside a world-placed
+    //     detached solid (canonical:
+    //     `--only canary --no-spin --no-auto-rotate --depth-probe-assert 321,210`,
+    //     which the canary covers on both backends). FAILs if a future pass
+    //     disables the composite depth-write.
+    //   - `X,Y,tier=N` (#1960) — per-trixel-priority TIER guard: PASS iff the
+    //     composite winner at (X,Y) decodes to the #1960 tier N. This is the
+    //     positive ENABLED-path gate the per-trixel carrier needs (the #2122
+    //     deterministic headless tier gate — byte-identity at default priority 0
+    //     cannot prove the carrier works). Canonical:
+    //     `--only interpenetrate --no-spin --no-auto-rotate --depth-probe-assert <overlap>,tier=2`,
+    //     where the far priority unit holds a fixed non-cardinal pose (MODE 1) so
+    //     the overlap reads a deterministic `tier=2`; without the #2023 carrier it
+    //     decodes `tier=0` and FAILs.
+    // `depthProbeAssertTier_` is -1 for the depth-write form, >= 0 for the tier
+    // form. Off by default; registers no system when unset, so a flagless run is
+    // byte-identical.
     bool depthProbeAssertSet_ = false;
     ivec2 depthProbeAssertPixel_{0, 0};
+    int depthProbeAssertTier_ = -1;
     // readConfig() runs AFTER parseArgs() (it needs IREngine::init), so a
     // config `auto_rotate` would otherwise clobber an explicit
     // --auto-rotate / --no-auto-rotate flag. Latch CLI intent so config only
@@ -930,6 +944,30 @@ void applyDepthProbe(const std::string &value, bool &set, ivec2 &pixel, const ch
     }
 }
 
+// Parse "--depth-probe-assert X,Y" (depth-write guard, tier -1) or
+// "X,Y,tier=N" (per-trixel-priority tier guard, tier >= 0). The 3-field form is
+// tried first; a bad value leaves the assert off so the run stays byte-identical.
+void applyDepthProbeAssert(const std::string &value) {
+    int px = 0;
+    int py = 0;
+    int tier = -1;
+    if (std::sscanf(value.c_str(), "%d,%d,tier=%d", &px, &py, &tier) == 3) {
+        g_settings.depthProbeAssertSet_ = true;
+        g_settings.depthProbeAssertPixel_ = ivec2(px, py);
+        g_settings.depthProbeAssertTier_ = tier;
+    } else if (std::sscanf(value.c_str(), "%d,%d", &px, &py) == 2) {
+        g_settings.depthProbeAssertSet_ = true;
+        g_settings.depthProbeAssertPixel_ = ivec2(px, py);
+        g_settings.depthProbeAssertTier_ = -1;
+    } else {
+        IR_LOG_WARN(
+            "--depth-probe-assert: expected X,Y or X,Y,tier=N (e.g. 321,210 or "
+            "321,210,tier=2); ignoring '{}'",
+            value
+        );
+    }
+}
+
 // Declare canvas_stress's custom flags on the engine-owned parser. Must run
 // before IREngine::init(argc, argv), which performs the single strict parse of
 // engine-common + these flags (see engine/CLAUDE.md "CLI args go through
@@ -996,7 +1034,8 @@ void registerArgs() {
     );
     args.string(
         "--depth-probe-assert",
-        "Depth-write regression guard at framebuffer pixel X,Y; emits PASS|FAIL (#1957)",
+        "Composite regression guard at framebuffer pixel: X,Y = depth-write guard "
+        "(#1957); X,Y,tier=N = per-trixel-priority tier guard (#1960). Emits PASS|FAIL",
         ""
     );
 }
@@ -1052,12 +1091,7 @@ void applyArgs() {
         );
     }
     if (args.wasProvided("--depth-probe-assert")) {
-        applyDepthProbe(
-            args.getString("--depth-probe-assert"),
-            g_settings.depthProbeAssertSet_,
-            g_settings.depthProbeAssertPixel_,
-            "--depth-probe-assert"
-        );
+        applyDepthProbeAssert(args.getString("--depth-probe-assert"));
     }
     if (args.wasProvided("--sweep-yaw")) {
         const std::vector<float> &v = args.getFloats("--sweep-yaw");
@@ -1267,17 +1301,26 @@ void initSystems() {
         );
     }
 
-    // #1957 depth-write regression guard — registered only with
+    // #1957 / #1960 composite regression guard — registered only with
     // --depth-probe-assert. Runs after the framebuffer composite and emits a
-    // PASS/FAIL verdict line so a headless run catches a future pass that
-    // disables the detached-canvas composite depth-write.
+    // PASS/FAIL verdict line. tier < 0 is the #1957 depth-write guard (catches a
+    // future pass that disables the detached-canvas composite depth-write);
+    // tier >= 0 is the #1960 per-trixel-priority tier guard (catches a future pass
+    // that drops the carrier so the priority solid loses the depth contest).
     if (g_settings.depthProbeAssertSet_) {
         const ivec2 assertPixel = g_settings.depthProbeAssertPixel_;
+        const int assertTier = g_settings.depthProbeAssertTier_;
         renderPipeline.push_back(
             IRSystem::createSystem<C_Camera>(
                 "DepthProbeAssert",
                 [](C_Camera &) {},
-                [assertPixel]() { IRPrefab::DepthProbe::assertCompositeWritesDepth(assertPixel); }
+                [assertPixel, assertTier]() {
+                    if (assertTier >= 0) {
+                        IRPrefab::DepthProbe::assertCompositeDepthTier(assertPixel, assertTier);
+                    } else {
+                        IRPrefab::DepthProbe::assertCompositeWritesDepth(assertPixel);
+                    }
+                }
             )
         );
     }

--- a/engine/prefabs/irreden/render/depth_probe.hpp
+++ b/engine/prefabs/irreden/render/depth_probe.hpp
@@ -108,6 +108,44 @@ inline CompositeDepthSample readbackCompositeDepth(IRMath::ivec2 px) {
     return sample;
 }
 
+namespace detail {
+
+/// The @c [depth-probe] integer-encode decode, factored so the diagnostic probe
+/// and the tier-assert guard partition @c enc the same way (one source of truth
+/// for the #1960 N-tier layout). @c enc > kDepthForegroundCeil is WORLD content
+/// (tier 0), encoded as @c iso*4 + face; @c enc inside the reserved band is a
+/// FOREGROUND fragment whose disjoint sub-range names its priority tier (1..N-1).
+/// iso/face is the @c encodeDepthWithFace inverse, taken tier-center-relative for
+/// a foreground fragment so @c iso reads as the unit's local model-frame iso depth.
+struct DecodedComposite {
+    int enc_ = 0;
+    int tier_ = 0;
+    int iso_ = 0;
+    int face_ = 0;
+};
+
+inline DecodedComposite decodeComposite(const CompositeDepthSample &sample) {
+    DecodedComposite decoded;
+    decoded.enc_ = static_cast<int>(IRMath::roundHalfUp(sample.rawDist_));
+    if (decoded.enc_ <= IRRender::kDepthForegroundCeil) {
+        const int slot = (decoded.enc_ - IRConstants::kTrixelDistanceMinDistance) /
+                         IRRender::kDepthForegroundTierWidth;
+        decoded.tier_ = IRMath::clamp(
+            IRRender::kDepthForegroundTierCount - 1 - slot,
+            1,
+            IRRender::kDepthForegroundTierCount - 1
+        );
+    }
+    const int encRel = decoded.tier_ == 0
+                           ? decoded.enc_
+                           : decoded.enc_ - IRRender::depthForegroundTierCenter(decoded.tier_);
+    decoded.face_ = ((encRel % 4) + 4) % 4;
+    decoded.iso_ = (encRel - decoded.face_) / 4;
+    return decoded;
+}
+
+} // namespace detail
+
 /// Convenience wrapper: read @p px and emit one machine-readable
 /// @c IR_LOG_INFO line a human or script can read the depth ordering directly
 /// from. Format: @c [depth-probe] pixel=(x,y) normDepth=… rawDist=…
@@ -117,30 +155,12 @@ inline void logCompositeDepth(IRMath::ivec2 px) {
         IR_LOG_INFO("[depth-probe] pixel=({},{}) out-of-range (no framebuffer pixel)", px.x, px.y);
         return;
     }
-    // Decode the integer composite enc into the #1960 N-tier partition so a
-    // debugger reads the depth ordering directly. enc > kDepthForegroundCeil is
-    // WORLD content (tier 0), encoded as iso*4 + face; enc inside the reserved band
-    // is a FOREGROUND fragment whose disjoint sub-range names its priority tier
-    // (1..N-1). Without this split the partitioned enc reads as an opaque rawDist
-    // (the Finding-1-style mis-read the plan flagged). Reporting the numeric tier
-    // makes Demo 2's per-trixel `tier = max(entity, trixel)` headlessly
-    // ground-truthable at an interpenetration pixel (#1960 acceptance G). iso/face
-    // is the encodeDepthWithFace inverse, taken tier-center-relative for a
-    // foreground fragment so `iso` reads as the unit's local model-frame iso depth.
-    const int enc = static_cast<int>(IRMath::roundHalfUp(sample.rawDist_));
-    int tier = 0;
-    if (enc <= IRRender::kDepthForegroundCeil) {
-        const int slot =
-            (enc - IRConstants::kTrixelDistanceMinDistance) / IRRender::kDepthForegroundTierWidth;
-        tier = IRMath::clamp(
-            IRRender::kDepthForegroundTierCount - 1 - slot,
-            1,
-            IRRender::kDepthForegroundTierCount - 1
-        );
-    }
-    const int encRel = tier == 0 ? enc : enc - IRRender::depthForegroundTierCenter(tier);
-    const int face = ((encRel % 4) + 4) % 4;
-    const int iso = (encRel - face) / 4;
+    // Decode the partitioned enc so a debugger reads the depth ordering directly;
+    // without it the partitioned enc reads as an opaque rawDist (the Finding-1-style
+    // mis-read the plan flagged). Reporting the numeric tier makes the per-trixel
+    // `tier = max(entity, trixel)` headlessly ground-truthable at an interpenetration
+    // pixel (#1960 acceptance G).
+    const detail::DecodedComposite decoded = detail::decodeComposite(sample);
     IR_LOG_INFO(
         "[depth-probe] pixel=({},{}) normDepth={:.6f} rawDist={:.1f} enc={} tier={} ({}) iso={} "
         "face={}",
@@ -148,11 +168,11 @@ inline void logCompositeDepth(IRMath::ivec2 px) {
         sample.pixel_.y,
         sample.normDepth_,
         sample.rawDist_,
-        enc,
-        tier,
-        tier == 0 ? "world" : "foreground",
-        iso,
-        face
+        decoded.enc_,
+        decoded.tier_,
+        decoded.tier_ == 0 ? "world" : "foreground",
+        decoded.iso_,
+        decoded.face_
     );
 }
 
@@ -184,6 +204,38 @@ inline bool assertCompositeWritesDepth(IRMath::ivec2 px) {
         wroteDepth ? "PASS" : "FAIL"
     );
     return wroteDepth;
+}
+
+/// #1960 per-trixel-priority tier regression guard. Reads @p px (expected to fall
+/// on an interpenetration overlap where a priority-tagged solid must win) and
+/// emits one machine-readable verdict line:
+/// @c [depth-probe-assert] pixel=(x,y) normDepth=… rawDist=… enc=… tier=N
+/// expected=M result=PASS|FAIL. PASS iff the composite winner at @p px decodes to
+/// the @p expectedTier (the #1960 N-tier partition; @c detail::decodeComposite).
+/// This is the positive ENABLED-path guard the per-trixel carrier needs (a
+/// default-off feature that byte-identity at default cannot prove works) — it
+/// catches a future pass that drops the carrier so the priority solid falls back
+/// to tier 0 and loses the depth contest. A failed readback (pixel out of range)
+/// decodes to tier 0 with @c valid_ == false, so an out-of-range probe reports
+/// FAIL for any non-default @p expectedTier rather than masquerading as a pass.
+/// Backend-agnostic, pure readback (byte-identical), like @c assertCompositeWritesDepth.
+inline bool assertCompositeDepthTier(IRMath::ivec2 px, int expectedTier) {
+    const CompositeDepthSample sample = readbackCompositeDepth(px);
+    const detail::DecodedComposite decoded = detail::decodeComposite(sample);
+    const bool match = sample.valid_ && decoded.tier_ == expectedTier;
+    IR_LOG_INFO(
+        "[depth-probe-assert] pixel=({},{}) normDepth={:.6f} rawDist={:.1f} enc={} tier={} "
+        "expected={} result={}",
+        px.x,
+        px.y,
+        sample.normDepth_,
+        sample.rawDist_,
+        decoded.enc_,
+        decoded.tier_,
+        expectedTier,
+        match ? "PASS" : "FAIL"
+    );
+    return match;
 }
 
 } // namespace IRPrefab::DepthProbe

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -265,14 +265,26 @@ Pattern-B namespace over the `Texture2D` /
 no shader or pipeline change, so a flagless run is byte-identical. Use
 it when a screenshot can't disambiguate which surface won a pixel.
 
-The sibling `--depth-probe-assert X,Y` flag (#1957; `canvas_stress`) is
-the composite depth-write **regression guard**: it turns one readback
-into a machine-readable `[depth-probe-assert] … result=PASS|FAIL` line
-— PASS iff the composite stored a non-background depth at (X,Y). Aim it
-at a texel inside a world-placed detached solid (canonical:
-`--only canary --no-spin --no-auto-rotate --depth-probe-assert 321,210`)
-so a future pass that disables the detached-canvas composite depth-write
-fails the run headlessly on either backend.
+The sibling `--depth-probe-assert` flag (`canvas_stress`) turns one
+readback into a machine-readable `[depth-probe-assert] … result=PASS|FAIL`
+line. Two forms:
+
+- `X,Y` (#1957) — composite **depth-write** guard: PASS iff the composite
+  stored a non-background depth at (X,Y). Aim it at a texel inside a
+  world-placed detached solid (canonical:
+  `--only canary --no-spin --no-auto-rotate --depth-probe-assert 321,210`)
+  so a future pass that disables the detached-canvas composite depth-write
+  fails the run headlessly on either backend.
+- `X,Y,tier=N` (#1960; #2122) — per-trixel-priority **tier** guard: PASS
+  iff the composite winner at (X,Y) decodes to the #1960 tier N. The
+  positive ENABLED-path gate the per-trixel carrier needs (byte-identity at
+  default priority 0 can't prove the carrier survives the rotating
+  re-voxelize MODE 1 fill). The `scripts/depth-tier-verify.py` harness wraps
+  the canonical run
+  (`--only interpenetrate --no-spin --no-auto-rotate --depth-probe-assert 639,362,tier=2`)
+  into a build → run → parse gate, exiting non-zero if the far priority unit
+  decodes `tier=0` (carrier dropped). Both forms are pure readback — a
+  flagless run is byte-identical.
 
 **Default-off features need a positive enabled-path test, not just
 byte-identity at default.** Render features routinely default OFF (priority

--- a/scripts/depth-tier-verify.py
+++ b/scripts/depth-tier-verify.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""depth-tier-verify — build canvas_stress, run it headless, gate the #1960
+per-trixel-priority tier at an interpenetration pixel.
+
+The deterministic headless tier gate for #2122 (the #2023 / #1960 residual): it
+drives ``canvas_stress --only interpenetrate`` (two world-placed detached units
+at the same screen position; the FAR one rotated to a fixed non-cardinal pose so
+its re-voxelize fill runs MODE 1, and tagged the top per-trixel priority tier)
+and asserts the composite winner at the overlap pixel decodes to that tier. This
+is the positive ENABLED-path guard the per-trixel carrier needs — byte-identity
+at default priority 0 only proves the OFF path is a no-op, never that the carrier
+survives the rotating re-voxelize fill. If a future pass drops the carrier the
+far unit decodes ``tier=0`` (the near unit wins) and the run FAILs.
+
+Parses the per-frame ``[depth-probe-assert] … tier=N expected=M result=PASS|FAIL``
+verdict emitted by ``IRPrefab::DepthProbe::assertCompositeDepthTier``. Exits
+non-zero on any FAIL or if no verdict line is found.
+
+Usage:
+    python3 scripts/depth-tier-verify.py
+    python3 scripts/depth-tier-verify.py --no-build --warmup-frames 8
+    python3 scripts/depth-tier-verify.py --pixel 639,362 --tier 2
+"""
+
+import argparse
+import re
+import subprocess
+
+# Pattern: [depth-probe-assert] pixel=(x,y) normDepth=… rawDist=… enc=…
+#          tier=N expected=M result=PASS|FAIL
+_ASSERT_RE = re.compile(
+    r"\[depth-probe-assert\]\s+"
+    r"pixel=\((-?\d+),(-?\d+)\)\s+"
+    r"normDepth=\S+\s+rawDist=\S+\s+enc=\S+\s+"
+    r"tier=(-?\d+)\s+expected=(-?\d+)\s+result=(PASS|FAIL)"
+)
+
+# The interpenetration overlap on canvas_stress's main framebuffer at the
+# deterministic --no-spin --no-auto-rotate --zoom 1 pose. The offscreen
+# framebuffer is camera-zoom-invariant (zoom magnifies only the window blit), and
+# at cam (0,0) the rotation pivots about the world-origin focus, so this pixel
+# stays on the far priority unit across the whole auto-screenshot suite.
+_DEFAULT_PIXEL = "639,362"
+_DEFAULT_TIER = 2
+
+
+def _run(cmd: list[str]) -> int:
+    """Run a command, streaming output to the terminal; return its exit code."""
+    print("+ " + " ".join(cmd), flush=True)
+    return subprocess.run(cmd).returncode
+
+
+def _run_capture(cmd: list[str]) -> tuple[int, str]:
+    """Run a command, tee output to the terminal, and return (exit_code, text)."""
+    print("+ " + " ".join(cmd), flush=True)
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, errors="replace",
+    )
+    lines: list[str] = []
+    if proc.stdout is None:
+        raise RuntimeError("stdout unavailable (Popen stdout=PIPE failed)")
+    for line in proc.stdout:
+        print(line, end="", flush=True)
+        lines.append(line)
+    proc.wait()
+    return proc.returncode, "".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Headless per-trixel-priority tier gate for canvas_stress."
+    )
+    parser.add_argument(
+        "--pixel",
+        default=_DEFAULT_PIXEL,
+        metavar="X,Y",
+        help=f"Framebuffer-texture pixel to probe (default: {_DEFAULT_PIXEL})",
+    )
+    parser.add_argument(
+        "--tier",
+        type=int,
+        default=_DEFAULT_TIER,
+        metavar="N",
+        help=f"Expected #1960 priority tier at the overlap (default: {_DEFAULT_TIER})",
+    )
+    parser.add_argument(
+        "--warmup-frames",
+        type=int,
+        default=8,
+        metavar="N",
+        help="Warmup frames passed as --auto-screenshot N (default: 8)",
+    )
+    parser.add_argument(
+        "--no-build",
+        action="store_true",
+        help="Skip the fleet-build step (assume the binary is already built)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        metavar="S",
+        help="Watchdog timeout in seconds passed to fleet-run (default: 120)",
+    )
+    args = parser.parse_args()
+
+    if not args.no_build:
+        rc = _run(["fleet-build", "--target", "IRCanvasStress"])
+        if rc != 0:
+            raise SystemExit(f"[depth-tier-verify] fleet-build failed ({rc})")
+
+    run_cmd = [
+        "fleet-run",
+        "--timeout", str(args.timeout),
+        "IRCanvasStress",
+        "--only", "interpenetrate",
+        "--no-spin", "--no-auto-rotate", "--zoom", "1",
+        "--auto-screenshot", str(args.warmup_frames),
+        "--depth-probe-assert", f"{args.pixel},tier={args.tier}",
+    ]
+    run_rc, output = _run_capture(run_cmd)
+
+    verdicts = []
+    for m in _ASSERT_RE.finditer(output):
+        px, py, tier, expected, result = m.groups()
+        verdicts.append(
+            dict(pixel=f"({px},{py})", tier=int(tier),
+                 expected=int(expected), result=result)
+        )
+
+    print()
+
+    if not verdicts:
+        print("[depth-tier-verify] no [depth-probe-assert] verdict line found in output")
+        raise SystemExit(1)
+
+    failures = [v for v in verdicts if v["result"] == "FAIL"]
+    passed = len(verdicts) - len(failures)
+    print(
+        f"[depth-tier-verify] {passed}/{len(verdicts)} frames PASS at "
+        f"{verdicts[-1]['pixel']} (tier={args.tier})"
+    )
+
+    if failures:
+        bad = failures[0]
+        print(
+            f"[depth-tier-verify] FAIL: composite winner decoded tier={bad['tier']}, "
+            f"expected {bad['expected']} — the per-trixel priority carrier was dropped."
+        )
+
+    if failures or run_rc != 0:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Delivers **#2122 item 1**: the deterministic headless gate for the #1960
per-trixel-priority carrier — the positive ENABLED-path test the carrier needs
(byte-identity at default priority 0 only proves the OFF path is a no-op, never
that the carrier survives the rotating re-voxelize MODE 1 fill — the #1989 /
#2023 trap; see `engine/render/CLAUDE.md` "Default-off features need a positive
enabled-path test").

- **`depth_probe.hpp`** — `assertCompositeDepthTier(px, N)` reads back the
  composite depth winner and emits `[depth-probe-assert] … tier=N expected=M
  result=PASS|FAIL`. The tier/iso/face decode is factored into
  `detail::decodeComposite`, shared with `logCompositeDepth` (one source of
  truth for the N-tier partition; no behavior change to the existing probe).
- **`canvas_stress`** — `--depth-probe-assert` grows the `X,Y,tier=N` form (the
  `X,Y` depth-write guard is unchanged); the `DepthProbeAssert` system
  dispatches to the tier guard when a tier is given. Pure readback — a flagless
  run is byte-identical.
- **`scripts/depth-tier-verify.py`** — build → run → parse gate over
  `--only interpenetrate --no-spin --no-auto-rotate --depth-probe-assert 639,362,tier=2`,
  exiting non-zero if the far priority unit decodes `tier=0` (carrier dropped).

Stacked on **#2143** (restores canvas_stress's custom flags, #2103) — this is
the part of #2122 that was `fleet:blocked` on the CLI gate. The other two #2122
items are filed as follow-ups: **#2154** (per-entity priority-swap orbit demo)
and **#2155** (no-priority perf fast-path). They were split out so each lands as
a focused PR — item 3 in particular touches the hot finalization shader on both
backends (GL/Metal parity + cross-host smoke) that this gate does not.

## Test plan

- [x] `fleet-build --target IRCanvasStress` + `IRPerfGrid` (both depth_probe
      consumers) clean on macOS/Metal.
- [x] `scripts/depth-tier-verify.py` → **750/750 frames PASS** at (639,362),
      exit 0; **FAIL + exit 1** at a background pixel (regression-catch path
      verified).
- [x] `simplify` clean (reuse fan-out: the new tier guard intentionally mirrors
      the existing #1957 depth-write sibling; shared logic already factored).
- No screenshots: the change is pure-readback debug tooling + a debug flag — the
  default render is byte-identical (the probe registers no system unless its flag
  is set, and the interpenetrate scene is unchanged), so before/after captures
  would be an identical pair. The meaningful verification is the enabled-path
  gate above.
- Cross-host smoke: not required — no shader/pipeline/render-output path changed
  (pure GPU→CPU depth readback, backend-agnostic).

Closes #2122

🤖 Generated with [Claude Code](https://claude.com/claude-code)