### PR TITLE
engine/voxel: codify system-owned-invariants convention (P3, partial) (#2167)

### DIFF
--- a/.claude/rules/cpp-ecs.md
+++ b/.claude/rules/cpp-ecs.md
@@ -93,6 +93,52 @@ Worked example (#1288): `SYSTEM_REBUILD_GRID_VOXELS` cached `lastRebuildWorld{Ro
 
 - `engine/prefabs/irreden/render/components/component_canvas_fog_of_war.hpp` — `C_CanvasFogOfWar::dirty_` and `allUnexplored_` gate the per-frame `subImage2D` upload of the 256² fog texture. The upload is performed by `VOXEL_TO_TRIXEL_STAGE_1` (#2008), which both reads the fog to cull unexplored-column voxels and runs earlier in the pipeline; `FOG_TO_TRIXEL` is now a read-only consumer of the already-uploaded texture. Documented exception (CPU-authored, GPU-read-only, full-texture upload). T-161 evaluated migration to per-region `subImage2D` and deferred; see [`docs/design/fog-of-war-upload-strategy.md`](../../docs/design/fog-of-war-upload-strategy.md) for the analysis, the trigger conditions for revisiting, and the mechanical Strategy C migration sketch.
 
+## System-owned invariants: encapsulate, don't delegate to callers
+
+> When using a subsystem requires follow-up bookkeeping to keep its derived
+> state consistent, that bookkeeping is the subsystem's job — never a manual
+> step each creation replicates.
+
+This generalizes the "push at mutation" pattern above: the *subsystem*, not
+its callers, owns the invariant. Two routes, chosen by whether the derived
+state changes at mutation time or every frame (the same "no dirty flags"
+question decides which applies):
+
+1. **A component mutator that resyncs at mutation time.** When derived state
+   only needs to change in response to an explicit edit, expose a method that
+   performs the edit **and** the resync in one call, so there is no window
+   where a caller can apply the edit and forget the bookkeeping. Worked
+   example: `C_VoxelSetNew::editVoxels(fn)` / `::carve(shouldDeactivate)`
+   (#2165) — a custom carve applies `fn` across the voxel span, then the
+   method itself restores every derived invariant (rotation-source mirror →
+   pool active-mask → face occupancy) through a single private
+   `resyncDerivedState()`. Before this API, a raw `voxels_[i]` carve loop
+   required the caller to remember `syncActiveMask()` **and**
+   `IRPrefab::Voxel::recomputeFaceOccupancy(...)`, in that order — dropping
+   either silently rendered the carved set black under the lit/rotated path.
+   Centralizing the ordering in the mutator makes that class of bug
+   unrepresentable: there is no call shape that applies the edit without also
+   running the resync. `resyncAfterRawEdits()` remains the deliberate escape
+   hatch for a multi-pass raw edit that cannot route through `editVoxels`;
+   the low-level primitives (`syncActiveMask()`) stay public for pre-existing
+   raw-loop sites, but new code uses the mutator.
+2. **`beginTick`/`endTick` + pipeline ordering.** When the derived state must
+   track a live input every frame (not just at explicit edit points), a
+   system recomputes it unconditionally each tick rather than exposing a
+   caller-invoked resync. Worked example: `REBUILD_GRID_VOXELS` re-rasterizes
+   a GRID-mode entity's voxels from its live `C_WorldTransform` every frame
+   it's on-screen — no creation calls a "resync my rotation" method, because
+   the system already owns re-deriving that state on the pipeline's schedule.
+   The no-dirty-flags rule (above) is what rules out the alternative of a
+   cached "did the transform change" snapshot deciding whether to skip the
+   resync.
+
+Route 1 applies when the state only needs to change in reaction to a
+specific caller-driven edit; route 2 applies when the state must track a
+continuously-changing input regardless of whether any caller acted. Whichever
+route fits, the bookkeeping lives in exactly one place — the subsystem — not
+duplicated at every call site that needs it.
+
 ## Allocations in hot tick paths
 
 Allocating memory inside a per-entity tick (`new`, `std::vector::push_back`, `std::string` concatenation, `std::map::operator[]` insertion, `std::make_unique`) is a frame-time landmine. Reserve once at `beginTick`; reuse capacity across frames; clear without releasing.

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -32,24 +32,26 @@ for single voxels and particles.
   `activateAll()`, `changeVoxelColor(ivec3, Color)`, `changeVoxelColorAll(Color)`,
   `fillPlane(int axis, int planeIndex, Color)` (activates a single face slice),
   `reshape(Shape3D)` (box or sphere fill). All of these keep the pool's
-  active-mask in sync. **Custom carves/edits that these bulk mutators don't
+  active-mask in sync. Custom carves/edits that these bulk mutators don't
   cover go through the encapsulated raw-edit API (#2165), never a hand-rolled
-  `voxels_[i]` loop:** `editVoxels(fn)` applies `fn(index, voxel, localPos)`
+  `voxels_[i]` loop. `editVoxels(fn)` applies `fn(index, voxel, localPos)`
   to every voxel then resyncs once; `carve(shouldDeactivate)` is sugar over
   `editVoxels` for the common "deactivate voxels failing a predicate" case;
   `resyncAfterRawEdits()` is the escape hatch for a multi-pass edit that must
   still write the raw `voxels_` span directly across several loops — do all
   the writes, then call it once. Each entry point resyncs every derived
   invariant this set maintains (rotation-source mirror → pool active-mask →
-  face occupancy) internally, so callers must **not** hand-roll
-  `syncActiveMask()` + `IRPrefab::Voxel::recomputeFaceOccupancy(...)`
-  themselves — dropping that pairing renders the carved set black under the
-  lit/rotated path while the active-mask half looks done (the #2018/#2117/
-  #2146 footgun the API exists to close). `syncActiveMask()` stays public as
-  the low-level pool primitive for pre-existing raw-loop sites; prefer
-  `editVoxels`/`carve` for new code. `simplify-check-ecs` flags a hand-rolled
-  `voxels_[i].activate()/.deactivate()` carve loop followed by
-  `syncActiveMask()`/`recomputeFaceOccupancy()` and steers toward the API.
+  face occupancy) internally.
+
+  Callers must **not** hand-roll `syncActiveMask()` +
+  `IRPrefab::Voxel::recomputeFaceOccupancy(...)` themselves — dropping that
+  pairing renders the carved set black under the lit/rotated path while the
+  active-mask half looks done (the #2018/#2117/#2146 footgun the API exists
+  to close). `syncActiveMask()` stays public as the low-level pool primitive
+  for pre-existing raw-loop sites; prefer `editVoxels`/`carve` for new code.
+  `simplify-check-ecs` flags a hand-rolled `voxels_[i].activate()/.deactivate()`
+  carve loop followed by `syncActiveMask()`/`recomputeFaceOccupancy()` and
+  steers toward the API.
 - `C_ShapeDescriptor` — SDF shape type + params + color + flags (visible,
   hollow, mirror). Rendered directly by the GPU; **does not allocate voxels**.
 - `C_Skeleton` — rig-root component holding an ordered vector of joint

--- a/engine/prefabs/irreden/voxel/CLAUDE.md
+++ b/engine/prefabs/irreden/voxel/CLAUDE.md
@@ -24,27 +24,32 @@ for single voxels and particles.
   The mask is uploaded to slot `kBufferIndex_VoxelActiveMask` each frame
   and read by `c_voxel_visibility_compact.{glsl,metal}` in place of the
   per-voxel alpha test (T-287). Push-at-mutation: mutations through
-  `C_VoxelSetNew`'s helpers sync the mask automatically; raw `voxels_[i]`
-  span writes must follow with `vs.syncActiveMask()` **and**
-  `IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, size)` (see the
-  `C_VoxelSetNew` note below). **One pool per canvas entity.**
+  `C_VoxelSetNew`'s helpers sync the mask automatically. **One pool per
+  canvas entity.**
 - `C_VoxelSetNew` — owns a span of voxels from a pool; pushes local → global
   position updates; supports reshape (box/sphere SDF). Use the provided
   helpers instead of iterating voxels individually: `deactivateAll()`,
   `activateAll()`, `changeVoxelColor(ivec3, Color)`, `changeVoxelColorAll(Color)`,
   `fillPlane(int axis, int planeIndex, Color)` (activates a single face slice),
   `reshape(Shape3D)` (box or sphere fill). All of these keep the pool's
-  active-mask in sync. If a caller bypasses them and writes alpha through
-  the raw `voxels_` span (e.g. an SDF-carving loop calling
-  `voxels_[i].deactivate()` per slot), it must follow up with **both**
-  `syncActiveMask()` (so the GPU compaction stage sees the new active set)
-  **and** `IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, size)` (so
-  the carve's newly-exposed surface faces aren't left occluded). Dropping
-  the recompute renders the carved set black under the lit/rotated path
-  while the active-mask half looks done — an easy footgun because the
-  active-mask requirement is the loud one. `simplify-check-ecs` flags a
-  `.deactivate()` carve loop + `syncActiveMask()` with no
-  `recomputeFaceOccupancy` in the same function.
+  active-mask in sync. **Custom carves/edits that these bulk mutators don't
+  cover go through the encapsulated raw-edit API (#2165), never a hand-rolled
+  `voxels_[i]` loop:** `editVoxels(fn)` applies `fn(index, voxel, localPos)`
+  to every voxel then resyncs once; `carve(shouldDeactivate)` is sugar over
+  `editVoxels` for the common "deactivate voxels failing a predicate" case;
+  `resyncAfterRawEdits()` is the escape hatch for a multi-pass edit that must
+  still write the raw `voxels_` span directly across several loops — do all
+  the writes, then call it once. Each entry point resyncs every derived
+  invariant this set maintains (rotation-source mirror → pool active-mask →
+  face occupancy) internally, so callers must **not** hand-roll
+  `syncActiveMask()` + `IRPrefab::Voxel::recomputeFaceOccupancy(...)`
+  themselves — dropping that pairing renders the carved set black under the
+  lit/rotated path while the active-mask half looks done (the #2018/#2117/
+  #2146 footgun the API exists to close). `syncActiveMask()` stays public as
+  the low-level pool primitive for pre-existing raw-loop sites; prefer
+  `editVoxels`/`carve` for new code. `simplify-check-ecs` flags a hand-rolled
+  `voxels_[i].activate()/.deactivate()` carve loop followed by
+  `syncActiveMask()`/`recomputeFaceOccupancy()` and steers toward the API.
 - `C_ShapeDescriptor` — SDF shape type + params + color + flags (visible,
   hollow, mirror). Rendered directly by the GPU; **does not allocate voxels**.
 - `C_Skeleton` — rig-root component holding an ordered vector of joint


### PR DESCRIPTION
## Summary
- Rewrite `engine/prefabs/irreden/voxel/CLAUDE.md`'s raw-carve recipe to point at the encapsulated `editVoxels`/`carve`/`resyncAfterRawEdits` API (#2165) instead of prescribing the manual `syncActiveMask()` + `recomputeFaceOccupancy()` pairing.
- Add a new "System-owned invariants: encapsulate, don't delegate to callers" section to `.claude/rules/cpp-ecs.md` generalizing the principle behind the voxel edit API and citing `REBUILD_GRID_VOXELS` as the pipeline-ordering counterpart.
- **Not included — gated self-modification:** the third planned file, `.claude/agents/simplify-check-ecs.md` (upgrading item 9 from "missing recomputeFaceOccupancy" to "any hand-rolled raw-span carve loop, steer to editVoxels/carve"), could not be committed — staging it was blocked by the auto-mode classifier as protected agent-config. The exact diff is pasted in a comment on #2167 for a human (or the architect) to apply directly.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2170

## Test plan
- [x] Docs-only change; no build required.
- [x] Cross-referenced all three files for internal consistency (issue numbers, API names, section anchors) before committing.
- [ ] Human applies the `.claude/agents/simplify-check-ecs.md` diff from the issue comment to complete the acceptance criteria.

Partially addresses #2167 — do not auto-close; the gated file still needs a human hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)