### PR TITLE
engine/voxel: migrate creation carve sites onto editVoxels/carve (#2166)

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -22,7 +22,6 @@
 #include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
-#include <irreden/voxel/face_occupancy.hpp>
 
 // Systems
 #include <irreden/input/systems/system_input_key_mouse.hpp>
@@ -603,20 +602,7 @@ void spawnDetachedReVoxelizeSolid(
 
     if (carveAsymmetric) {
         C_VoxelSetNew &voxelSet = IREntity::getComponent<C_VoxelSetNew>(solid);
-        for (int i = 0; i < voxelSet.numVoxels_; ++i) {
-            const vec3 pos = voxelSet.positions_[i].pos_;
-            if (pos.x > 0.0f && pos.y > 0.0f) {
-                voxelSet.voxels_[i].deactivate();
-            }
-        }
-        voxelSet.syncActiveMask();
-        // Seed the model-space face-occlusion bits for the carved shape. The
-        // re-voxelize raster no longer consults this mask: it is in the unrotated
-        // authoring frame, so gating the rotated cells against it dropped /
-        // mis-coloured faces, and `c_voxel_to_trixel_stage_{1,2}` now bypass it
-        // for re-voxelize (#1570). The seed is vestigial today, kept as the
-        // correct initial state for a future GPU rotated-cell mask recompute.
-        IRPrefab::Voxel::recomputeFaceOccupancy(voxelSet.voxels_, voxelSet.size_);
+        voxelSet.carve([](vec3 pos) { return pos.x > 0.0f && pos.y > 0.0f; });
     }
 
     if (multiColor) {
@@ -654,8 +640,7 @@ enum class OrbitShape { CUBE, SPHERE, OCTAHEDRON, PYRAMID, CROSS, FRAME };
 void carveOrbitShape(C_VoxelSetNew &vs, OrbitShape shape) {
     const vec3 half = vec3(vs.size_) * 0.5f;
     const float r = IRMath::min(half.x, IRMath::min(half.y, half.z));
-    for (int i = 0; i < vs.numVoxels_; ++i) {
-        const vec3 p = vs.positions_[i].pos_;
+    vs.carve([&](vec3 p) {
         const float ax = IRMath::abs(p.x);
         const float ay = IRMath::abs(p.y);
         const float az = IRMath::abs(p.z);
@@ -694,12 +679,8 @@ void carveOrbitShape(C_VoxelSetNew &vs, OrbitShape shape) {
             keep = true;
             break;
         }
-        if (!keep) {
-            vs.voxels_[i].deactivate();
-        }
-    }
-    vs.syncActiveMask();
-    IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, vs.size_);
+        return !keep;
+    });
 }
 
 // Spawn one orbit-ring shape at `worldPos`, carved to `shape`, spinning about

--- a/creations/demos/ir_voxel_yaw/main.cpp
+++ b/creations/demos/ir_voxel_yaw/main.cpp
@@ -322,23 +322,13 @@ static EntityId createHollowShell(vec3 position, ivec3 halfExtent, Color color) 
     EntityId e =
         IREntity::createEntity(C_LocalTransform{position}, C_VoxelSetNew{size, color, true});
     auto &vs = IREntity::getComponent<C_VoxelSetNew>(e);
-    for (int i = 0; i < vs.numVoxels_; ++i) {
+    vs.carve([&](vec3 pos) {
         // Positions are stored as exact integer-valued floats relative to the center.
-        ivec3 p(
-            static_cast<int>(vs.positions_[i].pos_.x),
-            static_cast<int>(vs.positions_[i].pos_.y),
-            static_cast<int>(vs.positions_[i].pos_.z)
-        );
+        ivec3 p(static_cast<int>(pos.x), static_cast<int>(pos.y), static_cast<int>(pos.z));
         bool onSurface = IRMath::abs(p.x) >= halfExtent.x || IRMath::abs(p.y) >= halfExtent.y ||
                          IRMath::abs(p.z) >= halfExtent.z;
-        if (!onSurface)
-            vs.voxels_[i].deactivate();
-    }
-    // Raw-span carve bypasses the C_VoxelSetNew helpers, so the exposed-face
-    // mask is stale: recompute it before syncing the active mask, or the
-    // shell's newly-interior-exposed faces stay occluded and render black.
-    IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, size);
-    vs.syncActiveMask();
+        return !onSurface;
+    });
     return e;
 }
 

--- a/creations/demos/lighting/common/lighting_demo_scene.hpp
+++ b/creations/demos/lighting/common/lighting_demo_scene.hpp
@@ -41,7 +41,6 @@
 #include <irreden/update/systems/system_propagate_transform.hpp>
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
-#include <irreden/voxel/face_occupancy.hpp>
 #include <irreden/voxel/systems/system_update_voxel_set_children.hpp>
 
 #include <cstdint>
@@ -161,21 +160,9 @@ inline EntityId createVoxelPoolShape(
 
     auto sdfType = static_cast<IRMath::SDF::ShapeType>(type);
     vec4 sdfParams = IRMath::SDF::effectiveParams(sdfType, shapeParams);
-    for (int i = 0; i < voxelSet.numVoxels_; ++i) {
-        if (IRMath::SDF::evaluate(voxelSet.positions_[i].pos_, sdfType, sdfParams) >
-            IRMath::SDF::kSurfaceThreshold) {
-            voxelSet.voxels_[i].deactivate();
-        }
-    }
-    // The SDF-carving loop writes alpha directly through `voxels_[i].deactivate()`
-    // rather than a C_VoxelSetNew mutator, so both the exposed-face mask and the
-    // per-slot active mask stay pinned to the ctor's all-active grid. Recompute
-    // face occupancy first (newly-exposed surface faces otherwise stay wrongly
-    // occluded, rendering the carved shape black under the lit path), then sync
-    // the active mask so the compact shader skips carved-away interior slots.
-    // Mirrors shape_debug's createVoxelPoolShape (#2117).
-    IRPrefab::Voxel::recomputeFaceOccupancy(voxelSet.voxels_, voxelSet.size_);
-    voxelSet.syncActiveMask();
+    voxelSet.carve([&](vec3 pos) {
+        return IRMath::SDF::evaluate(pos, sdfType, sdfParams) > IRMath::SDF::kSurfaceThreshold;
+    });
     return entity;
 }
 

--- a/creations/demos/shape_debug/main.cpp
+++ b/creations/demos/shape_debug/main.cpp
@@ -23,7 +23,6 @@
 #include <irreden/voxel/components/component_shape_descriptor.hpp>
 #include <irreden/voxel/components/component_joint.hpp>
 #include <irreden/voxel/components/component_skeleton.hpp>
-#include <irreden/voxel/face_occupancy.hpp>
 #include <irreden/render/components/component_canvas_ao_texture.hpp>
 #include <irreden/render/components/component_canvas_light_volume.hpp>
 #include <irreden/render/components/component_canvas_sun_shadow.hpp>
@@ -886,13 +885,13 @@ EntityId createVoxelPoolShape(
     IRMath::SDF::evaluateGrid(vs.size_, sdfType, sdfParams, distances);
 
     int activeCount = 0;
-    for (int i = 0; i < vs.numVoxels_; ++i) {
+    vs.editVoxels([&](int i, C_Voxel &voxel, vec3) {
         if (distances[i] > IRMath::SDF::kSurfaceThreshold) {
-            vs.voxels_[i].deactivate();
+            voxel.deactivate();
         } else {
             ++activeCount;
         }
-    }
+    });
     // Debug tint is opt-in: --depth-color visualizes z-bands; --checkerboard
     // distinguishes adjacent same-color voxels. Default is plain shape color
     // — the checkerboard path was flickering frame-to-frame and breaking
@@ -906,15 +905,6 @@ EntityId createVoxelPoolShape(
     } else if (g_checkerboard) {
         applyCheckerboard(vs, color);
     }
-    // The SDF-carving loop above writes alpha directly through
-    // `vs.voxels_[i].deactivate()` rather than going through a
-    // `C_VoxelSetNew` mutator method, so both the exposed-face mask and the
-    // per-slot active mask stay pinned to the ctor's all-active grid.
-    // Recompute face occupancy first (newly-exposed surface faces otherwise
-    // stay wrongly occluded), then sync the active mask so the compact shader
-    // skips carved-away interior slots. Mirrors createCustomVoxelFigure.
-    IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, size);
-    vs.syncActiveMask();
 
     IR_LOG_INFO(
         "VoxelPool shape entity={} canvas={} total={} active={}",
@@ -965,22 +955,13 @@ EntityId createCustomVoxelFigure(vec3 position, Color color) {
     };
 
     int activeCount = 0;
-    for (int i = 0; i < vs.numVoxels_; ++i) {
-        const vec3 p = vs.positions_[i].pos_;
+    vs.editVoxels([&](int, C_Voxel &voxel, vec3 p) {
         if (!solid(IRMath::round(p.x), IRMath::round(p.y), IRMath::round(p.z))) {
-            vs.voxels_[i].deactivate();
+            voxel.deactivate();
         } else {
             ++activeCount;
         }
-    }
-    // Per-voxel deactivate() does NOT update the exposed-face mask (it is keyed
-    // to the ctor's all-active grid), so the carved figure's true surface faces
-    // stay wrongly occluded and never emit — only static GRID/rotating sets get
-    // a per-frame mask rebuild. Recompute it from in-grid neighbour occupancy so
-    // every newly-exposed surface face renders. (face_occupancy.hpp §"callers
-    // invoke this from any set-level mutator that toggles voxel occupancy".)
-    IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, size);
-    vs.syncActiveMask();
+    });
     IR_LOG_INFO(
         "Custom voxel figure entity={} canvas={} size=({},{},{}) active={}",
         entity,

--- a/creations/demos/z_yaw_rotation/common.hpp
+++ b/creations/demos/z_yaw_rotation/common.hpp
@@ -5,17 +5,9 @@
 
 // Carve a voxel set to match an SDF sphere of the given radius.
 static void carveSphere(IRComponents::C_VoxelSetNew &vs, float radius) {
-    for (int i = 0; i < vs.numVoxels_; ++i) {
-        vec3 p = vs.positions_[i].pos_;
-        vec4 params{radius, radius, radius, 0.0f};
-        float sdf = IRMath::SDF::evaluate(p, IRMath::SDF::ShapeType::SPHERE, params);
-        if (sdf > IRMath::SDF::kSurfaceThreshold) {
-            vs.voxels_[i].deactivate();
-        }
-    }
-    // Raw-span carve bypasses the C_VoxelSetNew helpers, so the exposed-face
-    // mask is stale: recompute it before syncing the active mask, or the
-    // carved surface faces stay occluded and render black under the lit path.
-    IRPrefab::Voxel::recomputeFaceOccupancy(vs.voxels_, vs.size_);
-    vs.syncActiveMask();
+    vec4 params{radius, radius, radius, 0.0f};
+    vs.carve([&](vec3 p) {
+        return IRMath::SDF::evaluate(p, IRMath::SDF::ShapeType::SPHERE, params) >
+               IRMath::SDF::kSurfaceThreshold;
+    });
 }

--- a/creations/editors/voxel_editor/main.cpp
+++ b/creations/editors/voxel_editor/main.cpp
@@ -434,16 +434,14 @@ void applyLayerVisibility(std::uint8_t layerId, bool visible) {
     if (g_sceneVoxelSetEntity == IREntity::kNullEntity)
         return;
     auto &set = IREntity::getComponent<C_VoxelSetNew>(g_sceneVoxelSetEntity);
-    for (auto &v : set.voxels_) {
+    set.editVoxels([&](int, C_Voxel &v, vec3) {
         if (v.layer_id_ != layerId)
-            continue;
+            return;
         if (visible)
             v.activate();
         else
             v.deactivate();
-    }
-    set.syncActiveMask();
-    IRPrefab::Voxel::recomputeFaceOccupancy(set.voxels_, set.size_);
+    });
 }
 
 // Apply a single placement / erasure edit to the voxel set, appending
@@ -451,7 +449,10 @@ void applyLayerVisibility(std::uint8_t layerId, bool visible) {
 // the target index is out of bounds for the set. `flat` is the linear
 // pool index so the per-voxel mutation reuses the precomputed offset.
 // `boneId` defaults to 0 (identity) for normal color-paint; pass the
-// active bone index when in bone-paint mode (#1608).
+// active bone index when in bone-paint mode (#1608). Writes the raw
+// `voxels_` span directly — callers always finish a batch of these
+// (single edit, line, AABB, face-fill, or SDF bake) with one
+// `commitStroke()`, which resyncs derived state once for the whole batch.
 void applyEdit(
     IREntity::EntityId voxelSetEntity,
     C_VoxelSetNew &set,
@@ -476,7 +477,6 @@ void applyEdit(
         set.voxels_[flat].deactivate();
         set.voxels_[flat].layer_id_ = 0;
     }
-    set.syncActiveMask();
 }
 
 void commitStroke() {
@@ -497,7 +497,7 @@ void commitStroke() {
     }
     if (g_sceneVoxelSetEntity != IREntity::kNullEntity) {
         auto &set = IREntity::getComponent<C_VoxelSetNew>(g_sceneVoxelSetEntity);
-        IRPrefab::Voxel::recomputeFaceOccupancy(set.voxels_, set.size_);
+        set.resyncAfterRawEdits();
     }
 }
 
@@ -530,8 +530,7 @@ void undoOne() {
     }
     for (auto id : touchedSets) {
         auto &set = IREntity::getComponent<C_VoxelSetNew>(id);
-        set.syncActiveMask();
-        IRPrefab::Voxel::recomputeFaceOccupancy(set.voxels_, set.size_);
+        set.resyncAfterRawEdits();
     }
 }
 
@@ -1742,17 +1741,15 @@ void initSystems() {
                 if (delId != 0 && g_sceneVoxelSetEntity != IREntity::kNullEntity) {
                     const bool defaultVisible = g_layerManager.isVisible(0);
                     auto &set = IREntity::getComponent<C_VoxelSetNew>(g_sceneVoxelSetEntity);
-                    for (auto &v : set.voxels_) {
+                    set.editVoxels([&](int, C_Voxel &v, vec3) {
                         if (v.layer_id_ != delId)
-                            continue;
+                            return;
                         v.layer_id_ = 0;
                         if (defaultVisible)
                             v.activate();
                         else
                             v.deactivate();
-                    }
-                    set.syncActiveMask();
-                    IRPrefab::Voxel::recomputeFaceOccupancy(set.voxels_, set.size_);
+                    });
                     g_layerManager.deleteLayer(delId);
                 }
             }


### PR DESCRIPTION
## Stack context
This PR is part of a stack. Reviewers: review this PR on its own;
the chain is coordinated in the PR body's "Stacked on" line.

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2170

## Summary
- Migrated every raw-span voxel carve/edit site in `creations/` onto the
  `C_VoxelSetNew::editVoxels`/`carve`/`resyncAfterRawEdits` API from #2165,
  removing the hand-rolled `syncActiveMask()` + `recomputeFaceOccupancy()`
  pair everywhere outside the engine.
- `canvas_stress` (2 sites), `shape_debug` (2 sites), `lighting` (1 site),
  `z_yaw_rotation` (1 site), `ir_voxel_yaw` (1 site) — all 1:1 mechanical
  swaps onto `carve()`/`editVoxels()`, no behavior change.
- `voxel_editor` (4 sites) is the genuine multi-pass case: `applyEdit()`
  writes the raw `voxels_` span per edit, and every caller (single edit,
  line, AABB, face-fill, SDF bake) always finishes a batch with one
  `commitStroke()`. So `commitStroke()`/`undoOne()` now call
  `resyncAfterRawEdits()` once per batch instead of a hand-rolled pair, and
  `applyEdit()` drops its now-redundant per-edit `syncActiveMask()` call
  (previously called once per voxel in a batch instead of once per batch).
- Dropped now-unused `#include <irreden/voxel/face_occupancy.hpp>` from the
  three files that no longer call `IRPrefab::Voxel::recomputeFaceOccupancy`
  directly.

## Test plan
- [x] `grep -rn 'recomputeFaceOccupancy\|syncActiveMask' creations/`
      (excluding the game worktree) returns zero hand-rolled sequences.
- [x] `fleet-build` clean for `IRShapeDebug`, `IRCanvasStress`,
      `IRVoxelEditor`, `IRVoxelYaw`, `IRZYawStatic`, `IRLightingAO`.
- [x] `render-verify --target IRShapeDebug` — 24/24 PASS, byte-identical
      against committed references.
- [x] `render-verify --target IRCanvasStress` — pre-existing reference
      failures (#1944, stale baselines) reproduce with *identical*
      match%/max_delta/PSNR whether the migration is applied or stashed
      out, confirming they're unrelated to this change.
- [x] `z_yaw_rotation`, `ir_voxel_yaw`, `lighting` have no committed
      render-verify references — verified via manual `--auto-screenshot`
      MD5 comparison against a pre-migration build. Cardinal shots are
      byte-identical; the demos' own inherent non-determinism at
      non-cardinal yaw (confirmed present across two runs of the
      *unmodified* pre-migration build too) is unrelated to this change.

## Notes for reviewer
`voxel_editor`'s deferred-resync change (`applyEdit` no longer syncs the
active mask per-edit; `commitStroke`/`undoOne` resync once per batch) is
the one site that isn't a pure mechanical extraction — worth a close read.
Every `applyEdit` call site is followed by a `commitStroke()` in the same
event handler (no multi-frame drag between them), so the pool active-mask
staleness window that previously existed *within* a batch (mid-loop, before
that batch's own sync) is simply removed, not extended.

Closes #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)