### PR TITLE
fleet: sonnet class tracks latest Sonnet (5); drop stale 4.6 tags

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -373,8 +373,11 @@ class resolves at boot from a probed ladder (Fable 5 [1m] → Fable 5 →
 Opus 4.8 [1m]), so when the plan stops covering Fable, `fleet:fable`
 tasks degrade to the Opus floor automatically; dispatched fable
 iterations also carry `--fallback-model` for mid-session resilience.
-Pin classes with `FLEET_MODEL_FABLE` / `FLEET_MODEL_OPUS` /
-`FLEET_MODEL_SONNET` in `~/.fleet/fleet-up.conf`.
+The opus class is pinned to a full version (`claude-opus-4-8[1m]`) so a
+bare alias can't silently upgrade it, while the sonnet class is the bare
+`sonnet` alias on purpose — it always tracks the latest Sonnet (currently
+Sonnet 5) without a per-release edit. Pin classes with `FLEET_MODEL_FABLE`
+/ `FLEET_MODEL_OPUS` / `FLEET_MODEL_SONNET` in `~/.fleet/fleet-up.conf`.
 
 **fable — opt-in, for the genuinely hard work.** Budget is the scarce
 resource; `FLEET_CONCURRENCY_MODEL_FABLE` (default 1) caps concurrent

--- a/scripts/fleet/fleet-dispatch-wrap
+++ b/scripts/fleet/fleet-dispatch-wrap
@@ -73,7 +73,7 @@ fi
 _tag="$MODEL"
 _tag="${_tag/claude-fable-5/fable}"
 _tag="${_tag/claude-opus-4-8/opus 4.8}"
-_tag="${_tag/claude-sonnet-4-6/sonnet 4.6}"
+_tag="${_tag/claude-sonnet-5/sonnet 5}"
 _tag="${_tag/\[1m\]/ 1m}"
 tmux set-option -t "%${PANE_KEY#pane-}" -p @role "$ROLE [$_tag]" 2>/dev/null || true
 unset _tag

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -79,7 +79,10 @@ unset _FLEET_CLONE_FRESHNESS_SH
 # fine. (If you ever want sonnet[1m], enable usage credits at
 # claude.ai/settings/usage and re-add the suffix.) fable/opus strings are
 # pinned to full versions (a bare "fable"/"opus" alias would silently
-# upgrade); sonnet stays an alias since its budget is cheap.
+# upgrade); sonnet stays the bare "sonnet" alias ON PURPOSE, so it always
+# tracks the latest Sonnet with no per-release edit here — currently
+# Sonnet 5 (claude-sonnet-5) on the 2.x CLI. Pin an explicit version via
+# FLEET_MODEL_SONNET only if you need to freeze it.
 FABLE_MODEL_CANDIDATES=(
     "claude-fable-5[1m]"
     "claude-fable-5"
@@ -394,7 +397,7 @@ model_tag() {
     local tag="$1"
     tag="${tag/claude-fable-5/fable}"
     tag="${tag/claude-opus-4-8/opus 4.8}"
-    tag="${tag/claude-sonnet-4-6/sonnet 4.6}"
+    tag="${tag/claude-sonnet-5/sonnet 5}"
     tag="${tag/\[1m\]/ 1m}"
     printf '%s' "$tag"
 }

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -35,10 +35,14 @@
 # claude call per rung (a few cents, ~5-15 s). When the plan loses Fable
 # access, re-running fleet-up lands the class on the Opus floor.
 #
+# The sonnet class stays the bare `sonnet` alias by default, so it always
+# tracks the latest Sonnet (currently Sonnet 5). Opus/fable are pinned to
+# full versions so a bare alias can't silently upgrade them.
+#
 # Pin a class verbatim (pinning fable skips the probe):
 # FLEET_MODEL_FABLE="claude-fable-5[1m]"
 # FLEET_MODEL_OPUS="claude-opus-4-8[1m]"
-# FLEET_MODEL_SONNET="sonnet"
+# FLEET_MODEL_SONNET="claude-sonnet-5"   # freeze sonnet; omit to track latest
 #
 # Per-role dispatch models for the bounded fixed-model roles:
 # FLEET_MODEL_MERGER="sonnet"


### PR DESCRIPTION
## Summary
- The fleet's **sonnet** model class already resolves through the bare `sonnet` alias, which the CLI documents as *"an alias for the latest model"* — currently **Sonnet 5** (`claude-sonnet-5`). This is by design: opus/fable are pinned to explicit versions so a bare alias can't silently upgrade them, while sonnet intentionally stays an alias so it always tracks the latest Sonnet. So the "always latest sonnet" behavior is already in effect — every sonnet consumer (worker sonnet-class tasks, `sonnet-reviewer`, `merger`, `smoke-worker`) runs Sonnet 5 today.
- This PR removes the only stale leftovers — retired `claude-sonnet-4-6` references — and documents the auto-track intent so nothing lags the model it describes.

## Changes
- `fleet-up` / `fleet-dispatch-wrap`: the `model_tag` pane-label prettifier now maps `claude-sonnet-5 → "sonnet 5"` (was `claude-sonnet-4-6 → "sonnet 4.6"`). Display-only; only fires when someone pins an explicit sonnet version (the default bare alias already tags as `sonnet`).
- `fleet-up`: expanded the class-table comment to state sonnet stays the bare alias on purpose so it always tracks the latest Sonnet.
- `fleet-up.conf.sample`: documented the auto-track default; the example pin is now `claude-sonnet-5`.
- `FLEET.md`: the model-split section now notes the sonnet class tracks the latest Sonnet.

No functional change to which model runs — the sonnet class already resolved to Sonnet 5 via the alias. `[1m]` is deliberately left off sonnet (documented: `sonnet[1m]` errors without 1M-context credits on this plan).

## Test plan
- [x] `bash -n scripts/fleet/fleet-up` and `scripts/fleet/fleet-dispatch-wrap` parse clean
- [x] repo-wide grep confirms no remaining `claude-sonnet-4-6` / `sonnet 4.6` references
- [ ] on next `fleet-up`, sonnet-class panes tag as `sonnet` and dispatch Sonnet 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)