### PR TITLE
tooling: add unit test coverage for IRArgs (numbers()/getFloats(), malformed-input branches) (#2149)

### DIFF
--- a/test/common/ir_args_test.cpp
+++ b/test/common/ir_args_test.cpp
@@ -4,137 +4,393 @@
 #include <string>
 #include <vector>
 
-// Coverage for the fixed-arity float-list (FLOAT_LIST) and validated-enum (ENUM)
-// IRArgs features. FLOAT_LIST shipped (#2143) with no unit tests, so these fill
-// that gap alongside the new ENUM type. The reject / --help paths call
-// std::exit, so they can't run in-process under gtest; these exercise the happy
-// paths + omitted-arg defaults, which is what the canvas_stress migration (and
-// any future consumer) relies on.
-
 namespace {
 
 using namespace IRArgs;
 
-// Parser::parse skips argv[0] (program path) and may advance the index, but does
-// not write through argv, so backing the pointers with a std::string vector is
-// safe. std::string::data() is non-const since C++17.
-std::vector<char *> makeArgv(std::vector<std::string> &storage) {
-    std::vector<char *> argv;
-    argv.reserve(storage.size());
-    for (std::string &s : storage) {
-        argv.push_back(s.data());
+// Turns a token list into the char** argv parse() expects. argv[0] is the
+// (skipped) program name; a trailing nullptr terminates the array. Storage
+// backs the pointers via std::string::data() (C++17 non-const overload) —
+// parse() never writes through them.
+struct Argv {
+    std::vector<std::string> store_;
+    std::vector<char *> ptrs_;
+
+    explicit Argv(std::vector<std::string> tokens)
+        : store_(std::move(tokens)) {
+        for (auto &s : store_) {
+            ptrs_.push_back(s.data());
+        }
+        ptrs_.push_back(nullptr);
     }
-    return argv;
+
+    int argc() const {
+        return static_cast<int>(store_.size());
+    }
+    char **argv() {
+        return ptrs_.data();
+    }
+};
+
+// ─────────────────────────────────────────────
+// numbers() / getFloats() — happy path
+// ─────────────────────────────────────────────
+
+TEST(IRArgsFloatListTest, SpaceSeparatedFormParsesInOrder) {
+    Parser p(nullptr, Common::NONE);
+    p.numbers("--sweep-yaw", "Yaw sweep", 3);
+    Argv a({"prog", "--sweep-yaw", "0", "360", "8"});
+    p.parse(a.argc(), a.argv());
+    const std::vector<float> &v = p.getFloats("--sweep-yaw");
+    ASSERT_EQ(v.size(), 3u);
+    EXPECT_FLOAT_EQ(v[0], 0.0f);
+    EXPECT_FLOAT_EQ(v[1], 360.0f);
+    EXPECT_FLOAT_EQ(v[2], 8.0f);
+    EXPECT_TRUE(p.wasProvided("--sweep-yaw"));
 }
 
-TEST(IRArgsNumbersTest, ParsesFixedArityFloatList) {
-    Parser parser("test", Common::NONE);
-    parser.numbers("--sweep-yaw", "from to count", 3);
-    std::vector<std::string> args{"prog", "--sweep-yaw", "0.0", "6.28", "17"};
-    std::vector<char *> argv = makeArgv(args);
-    parser.parse(static_cast<int>(argv.size()), argv.data());
-
-    EXPECT_TRUE(parser.wasProvided("--sweep-yaw"));
-    const std::vector<float> &values = parser.getFloats("--sweep-yaw");
-    ASSERT_EQ(values.size(), 3u);
-    EXPECT_FLOAT_EQ(values[0], 0.0f);
-    EXPECT_FLOAT_EQ(values[1], 6.28f);
-    EXPECT_FLOAT_EQ(values[2], 17.0f);
-    // Counts/indices represented as floats stay exact for these magnitudes.
-    EXPECT_EQ(static_cast<int>(values[2]), 17);
+TEST(IRArgsFloatListTest, InlineCommaFormParsesInOrder) {
+    Parser p(nullptr, Common::NONE);
+    p.numbers("--sweep-yaw", "Yaw sweep", 3);
+    Argv a({"prog", "--sweep-yaw=0,360,8"});
+    p.parse(a.argc(), a.argv());
+    const std::vector<float> &v = p.getFloats("--sweep-yaw");
+    ASSERT_EQ(v.size(), 3u);
+    EXPECT_FLOAT_EQ(v[0], 0.0f);
+    EXPECT_FLOAT_EQ(v[1], 360.0f);
+    EXPECT_FLOAT_EQ(v[2], 8.0f);
+    EXPECT_TRUE(p.wasProvided("--sweep-yaw"));
 }
 
-TEST(IRArgsNumbersTest, AcceptsInlineCommaSeparatedList) {
-    Parser parser("test", Common::NONE);
-    parser.numbers("--sweep-yaw", "from to count", 3);
-    std::vector<std::string> args{"prog", "--sweep-yaw=0,360,8"};
-    std::vector<char *> argv = makeArgv(args);
-    parser.parse(static_cast<int>(argv.size()), argv.data());
-
-    EXPECT_TRUE(parser.wasProvided("--sweep-yaw"));
-    const std::vector<float> &values = parser.getFloats("--sweep-yaw");
-    ASSERT_EQ(values.size(), 3u);
-    EXPECT_FLOAT_EQ(values[0], 0.0f);
-    EXPECT_FLOAT_EQ(values[1], 360.0f);
-    EXPECT_FLOAT_EQ(values[2], 8.0f);
+TEST(IRArgsFloatListTest, DefaultsToAllZeroWhenAbsent) {
+    Parser p(nullptr, Common::NONE);
+    p.numbers("--sweep-yaw", "Yaw sweep", 3);
+    Argv a({"prog"});
+    p.parse(a.argc(), a.argv());
+    const std::vector<float> &v = p.getFloats("--sweep-yaw");
+    ASSERT_EQ(v.size(), 3u);
+    EXPECT_FLOAT_EQ(v[0], 0.0f);
+    EXPECT_FLOAT_EQ(v[1], 0.0f);
+    EXPECT_FLOAT_EQ(v[2], 0.0f);
+    EXPECT_FALSE(p.wasProvided("--sweep-yaw"));
 }
 
-TEST(IRArgsNumbersTest, OmittedListIsZeroFilled) {
-    Parser parser("test", Common::NONE);
-    parser.numbers("--sweep-frames", "count settle", 2);
-    std::vector<std::string> args{"prog"};
-    std::vector<char *> argv = makeArgv(args);
-    parser.parse(static_cast<int>(argv.size()), argv.data());
+// ─────────────────────────────────────────────
+// Malformed input — death tests (parse() exits on these branches)
+// ─────────────────────────────────────────────
 
-    // getFloats returns the registered all-zero defaults (sized to the arity),
-    // not an empty vector, when the arg was omitted.
-    EXPECT_FALSE(parser.wasProvided("--sweep-frames"));
-    const std::vector<float> &values = parser.getFloats("--sweep-frames");
-    ASSERT_EQ(values.size(), 2u);
-    EXPECT_FLOAT_EQ(values[0], 0.0f);
-    EXPECT_FLOAT_EQ(values[1], 0.0f);
+TEST(IRArgsFloatListDeathTest, SpaceSeparatedTooFewValuesExitsWithCode2) {
+    Parser p(nullptr, Common::NONE);
+    p.numbers("--sweep-yaw", "Yaw sweep", 3);
+    Argv a({"prog", "--sweep-yaw", "0", "360"});
+    EXPECT_EXIT(
+        p.parse(a.argc(), a.argv()),
+        ::testing::ExitedWithCode(2),
+        "expects 3 float values"
+    );
 }
 
-TEST(IRArgsNumbersTest, ListCoexistsWithOtherFlags) {
-    Parser parser("test", Common::NONE);
-    parser.flag("--verbose", "a flag");
-    parser.numbers("--xy", "x y", 2);
-    parser.integer("--n", "count", 0);
-    std::vector<std::string> args{"prog", "--verbose", "--xy", "3", "4", "--n", "9"};
-    std::vector<char *> argv = makeArgv(args);
-    parser.parse(static_cast<int>(argv.size()), argv.data());
-
-    EXPECT_TRUE(parser.getFlag("--verbose"));
-    EXPECT_EQ(parser.getInt("--n"), 9);
-    const std::vector<float> &values = parser.getFloats("--xy");
-    ASSERT_EQ(values.size(), 2u);
-    EXPECT_FLOAT_EQ(values[0], 3.0f);
-    EXPECT_FLOAT_EQ(values[1], 4.0f);
+TEST(IRArgsFloatListDeathTest, InlineWrongCountExitsWithCode2) {
+    Parser p(nullptr, Common::NONE);
+    p.numbers("--sweep-yaw", "Yaw sweep", 3);
+    Argv a({"prog", "--sweep-yaw=0,360"});
+    EXPECT_EXIT(
+        p.parse(a.argc(), a.argv()),
+        ::testing::ExitedWithCode(2),
+        "expects 3 comma-separated float values"
+    );
 }
 
-TEST(IRArgsNumbersTest, ListAcceptsNegativeValues) {
-    Parser parser("test", Common::NONE);
-    parser.numbers("--range", "lo hi", 2);
-    std::vector<std::string> args{"prog", "--range", "-1.5", "2.5"};
-    std::vector<char *> argv = makeArgv(args);
-    parser.parse(static_cast<int>(argv.size()), argv.data());
-
-    const std::vector<float> &values = parser.getFloats("--range");
-    ASSERT_EQ(values.size(), 2u);
-    EXPECT_FLOAT_EQ(values[0], -1.5f);
-    EXPECT_FLOAT_EQ(values[1], 2.5f);
+TEST(IRArgsDeathTest, UnknownArgExitsWithCode2) {
+    Parser p(nullptr, Common::NONE);
+    Argv a({"prog", "--bogus"});
+    EXPECT_EXIT(p.parse(a.argc(), a.argv()), ::testing::ExitedWithCode(2), "Unknown argument");
 }
+
+TEST(IRArgsDeathTest, MissingValueExitsWithCode2) {
+    Parser p(nullptr, Common::NONE);
+    p.integer("--grid-size", "Grid edge in cells", 64);
+    Argv a({"prog", "--grid-size"});
+    EXPECT_EXIT(
+        p.parse(a.argc(), a.argv()),
+        ::testing::ExitedWithCode(2),
+        "expects an integer value"
+    );
+}
+
+// ─────────────────────────────────────────────
+// Accepted-as-malformed — trailing comma / garbage tokens (value assertions,
+// NOT death tests: arity still matches, so parse() accepts and coerces to 0.0).
+// ─────────────────────────────────────────────
+
+TEST(IRArgsFloatListTest, InlineTrailingCommaParsesEmptyTailAsZero) {
+    Parser p(nullptr, Common::NONE);
+    p.numbers("--sweep-yaw", "Yaw sweep", 2);
+    Argv a({"prog", "--sweep-yaw=8,"});
+    p.parse(a.argc(), a.argv());
+    const std::vector<float> &v = p.getFloats("--sweep-yaw");
+    ASSERT_EQ(v.size(), 2u);
+    EXPECT_FLOAT_EQ(v[0], 8.0f);
+    EXPECT_FLOAT_EQ(v[1], 0.0f);
+}
+
+TEST(IRArgsFloatListTest, SpaceSeparatedNonNumericTokenParsesAsZero) {
+    Parser p(nullptr, Common::NONE);
+    p.numbers("--sweep-yaw", "Yaw sweep", 2);
+    Argv a({"prog", "--sweep-yaw", "8", "xyz"});
+    p.parse(a.argc(), a.argv());
+    const std::vector<float> &v = p.getFloats("--sweep-yaw");
+    ASSERT_EQ(v.size(), 2u);
+    EXPECT_FLOAT_EQ(v[0], 8.0f);
+    EXPECT_FLOAT_EQ(v[1], 0.0f);
+}
+
+// ─────────────────────────────────────────────
+// Baseline regression — pre-existing types
+// ─────────────────────────────────────────────
+
+TEST(IRArgsFlagTest, DefaultsFalseAndSetsTrueWhenPresent) {
+    Parser p(nullptr, Common::NONE);
+    p.flag("--no-overlay", "Hide the debug overlay");
+    Argv absent({"prog"});
+    p.parse(absent.argc(), absent.argv());
+    EXPECT_FALSE(p.getFlag("--no-overlay"));
+    EXPECT_FALSE(p.wasProvided("--no-overlay"));
+
+    Parser p2(nullptr, Common::NONE);
+    p2.flag("--no-overlay", "Hide the debug overlay");
+    Argv present({"prog", "--no-overlay"});
+    p2.parse(present.argc(), present.argv());
+    EXPECT_TRUE(p2.getFlag("--no-overlay"));
+    EXPECT_TRUE(p2.wasProvided("--no-overlay"));
+}
+
+TEST(IRArgsIntTest, SpaceAndInlineFormsAndDefault) {
+    Parser p(nullptr, Common::NONE);
+    p.integer("--grid-size", "Grid edge in cells", 64);
+    Argv absent({"prog"});
+    p.parse(absent.argc(), absent.argv());
+    EXPECT_EQ(p.getInt("--grid-size"), 64);
+
+    Parser p2(nullptr, Common::NONE);
+    p2.integer("--grid-size", "Grid edge in cells", 64);
+    Argv spaceForm({"prog", "--grid-size", "128"});
+    p2.parse(spaceForm.argc(), spaceForm.argv());
+    EXPECT_EQ(p2.getInt("--grid-size"), 128);
+
+    Parser p3(nullptr, Common::NONE);
+    p3.integer("--grid-size", "Grid edge in cells", 64);
+    Argv inlineForm({"prog", "--grid-size=256"});
+    p3.parse(inlineForm.argc(), inlineForm.argv());
+    EXPECT_EQ(p3.getInt("--grid-size"), 256);
+}
+
+TEST(IRArgsFloatTest, SpaceAndInlineFormsAndDefault) {
+    Parser p(nullptr, Common::NONE);
+    p.number("--zoom", "Camera zoom", 4.0f);
+    Argv absent({"prog"});
+    p.parse(absent.argc(), absent.argv());
+    EXPECT_FLOAT_EQ(p.getFloat("--zoom"), 4.0f);
+
+    Parser p2(nullptr, Common::NONE);
+    p2.number("--zoom", "Camera zoom", 4.0f);
+    Argv spaceForm({"prog", "--zoom", "2.5"});
+    p2.parse(spaceForm.argc(), spaceForm.argv());
+    EXPECT_FLOAT_EQ(p2.getFloat("--zoom"), 2.5f);
+
+    Parser p3(nullptr, Common::NONE);
+    p3.number("--zoom", "Camera zoom", 4.0f);
+    Argv inlineForm({"prog", "--zoom=1.5"});
+    p3.parse(inlineForm.argc(), inlineForm.argv());
+    EXPECT_FLOAT_EQ(p3.getFloat("--zoom"), 1.5f);
+}
+
+TEST(IRArgsStringTest, SpaceAndInlineFormsAndDefault) {
+    Parser p(nullptr, Common::NONE);
+    p.string("--config-preset", "Path to a Lua config preset", "");
+    Argv absent({"prog"});
+    p.parse(absent.argc(), absent.argv());
+    EXPECT_EQ(p.getString("--config-preset"), "");
+
+    Parser p2(nullptr, Common::NONE);
+    p2.string("--config-preset", "Path to a Lua config preset", "");
+    Argv spaceForm({"prog", "--config-preset", "a.lua"});
+    p2.parse(spaceForm.argc(), spaceForm.argv());
+    EXPECT_EQ(p2.getString("--config-preset"), "a.lua");
+
+    Parser p3(nullptr, Common::NONE);
+    p3.string("--config-preset", "Path to a Lua config preset", "");
+    Argv inlineForm({"prog", "--config-preset=b.lua"});
+    p3.parse(inlineForm.argc(), inlineForm.argv());
+    EXPECT_EQ(p3.getString("--config-preset"), "b.lua");
+}
+
+TEST(IRArgsOptionalIntTest, BareSwitchResolvesToDefault) {
+    Parser p(nullptr, Common::NONE);
+    p.optionalInt("--auto-screenshot", "Headless capture", kDefaultAutoScreenshotWarmup);
+    Argv a({"prog", "--auto-screenshot"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_EQ(p.getInt("--auto-screenshot"), kDefaultAutoScreenshotWarmup);
+    EXPECT_TRUE(p.wasProvided("--auto-screenshot"));
+}
+
+TEST(IRArgsOptionalIntTest, SpaceSeparatedTrailingIntIsConsumed) {
+    Parser p(nullptr, Common::NONE);
+    p.optionalInt("--auto-screenshot", "Headless capture", kDefaultAutoScreenshotWarmup);
+    Argv a({"prog", "--auto-screenshot", "25"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_EQ(p.getInt("--auto-screenshot"), 25);
+}
+
+TEST(IRArgsOptionalIntTest, NonPositiveTrailingTokenIsNotConsumed) {
+    Parser p(nullptr, Common::NONE);
+    p.optionalInt("--auto-screenshot", "Headless capture", kDefaultAutoScreenshotWarmup);
+    p.positional("next", "Next positional");
+    Argv a({"prog", "--auto-screenshot", "0"});
+    p.parse(a.argc(), a.argv());
+    // "0" is not > 0, so it is left for the positional loop rather than
+    // consumed as the trailing int.
+    EXPECT_EQ(p.getInt("--auto-screenshot"), kDefaultAutoScreenshotWarmup);
+    EXPECT_EQ(p.getPositional("next"), "0");
+}
+
+TEST(IRArgsOptionalIntTest, AbsentTokenLeavesWarmupFramesZero) {
+    Parser p(nullptr, Common::ENGINE);
+    Argv a({"prog"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_EQ(p.autoScreenshotWarmupFrames(), 0);
+}
+
+// ─────────────────────────────────────────────
+// Positionals / standalone path
+// ─────────────────────────────────────────────
+
+TEST(IRArgsPositionalTest, FixedPositionalsReadBackByName) {
+    Parser p(nullptr, Common::NONE);
+    p.positional("baseline", "Baseline PNG");
+    p.positional("current", "Current PNG");
+    Argv a({"prog", "base.png", "cur.png"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_EQ(p.getPositional("baseline"), "base.png");
+    EXPECT_EQ(p.getPositional("current"), "cur.png");
+}
+
+TEST(IRArgsPositionalTest, VariadicTailCapturesRemainder) {
+    Parser p(nullptr, Common::NONE);
+    p.positional("out", "Output file");
+    p.variadic("inputs", "Input files", 1);
+    Argv a({"prog", "out.png", "a.png", "b.png", "c.png"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_EQ(p.getPositional("out"), "out.png");
+    const std::vector<std::string> &all = p.positionalArgs();
+    ASSERT_EQ(all.size(), 4u);
+    EXPECT_EQ(all[0], "out.png");
+    EXPECT_EQ(all[3], "c.png");
+}
+
+TEST(IRArgsPositionalDeathTest, TooFewPositionalsExitsWithCode2) {
+    Parser p(nullptr, Common::NONE);
+    p.positional("baseline", "Baseline PNG");
+    p.positional("current", "Current PNG");
+    Argv a({"prog", "base.png"});
+    EXPECT_EXIT(
+        p.parse(a.argc(), a.argv()),
+        ::testing::ExitedWithCode(2),
+        "Expected 2 positional argument"
+    );
+}
+
+TEST(IRArgsPositionalDeathTest, UnexpectedExtraPositionalExitsWithCode2) {
+    Parser p(nullptr, Common::NONE);
+    p.positional("baseline", "Baseline PNG");
+    Argv a({"prog", "base.png", "extra.png"});
+    EXPECT_EXIT(
+        p.parse(a.argc(), a.argv()),
+        ::testing::ExitedWithCode(2),
+        "Unexpected positional argument"
+    );
+}
+
+// ─────────────────────────────────────────────
+// --help / usage()
+// ─────────────────────────────────────────────
+
+TEST(IRArgsHelpDeathTest, HelpFlagExitsWithCode0) {
+    Parser p(nullptr, Common::NONE);
+    p.flag("--no-overlay", "Hide the debug overlay");
+    Argv a({"prog", "--help"});
+    EXPECT_EXIT(p.parse(a.argc(), a.argv()), ::testing::ExitedWithCode(0), "");
+}
+
+TEST(IRArgsUsageTest, ContainsRegisteredArgName) {
+    Parser p(nullptr, Common::NONE);
+    p.flag("--no-overlay", "Hide the debug overlay");
+    const std::string text = p.usage();
+    EXPECT_NE(text.find("--no-overlay"), std::string::npos);
+}
+
+// ─────────────────────────────────────────────
+// Multi-value list — coexistence + negative values. Folds in the two
+// numbers()/getFloats() cases unique to PR #2161's suite (its space/inline/
+// zero-fill happy paths are already covered above, so those are dropped to
+// keep this the single IRArgs suite rather than duplicating either side).
+// ─────────────────────────────────────────────
+
+TEST(IRArgsFloatListTest, CoexistsWithOtherFlags) {
+    Parser p(nullptr, Common::NONE);
+    p.flag("--verbose", "A flag");
+    p.numbers("--xy", "x y", 2);
+    p.integer("--n", "Count", 0);
+    Argv a({"prog", "--verbose", "--xy", "3", "4", "--n", "9"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_TRUE(p.getFlag("--verbose"));
+    EXPECT_EQ(p.getInt("--n"), 9);
+    const std::vector<float> &v = p.getFloats("--xy");
+    ASSERT_EQ(v.size(), 2u);
+    EXPECT_FLOAT_EQ(v[0], 3.0f);
+    EXPECT_FLOAT_EQ(v[1], 4.0f);
+}
+
+TEST(IRArgsFloatListTest, AcceptsNegativeValues) {
+    Parser p(nullptr, Common::NONE);
+    p.numbers("--range", "lo hi", 2);
+    Argv a({"prog", "--range", "-1.5", "2.5"});
+    p.parse(a.argc(), a.argv());
+    const std::vector<float> &v = p.getFloats("--range");
+    ASSERT_EQ(v.size(), 2u);
+    EXPECT_FLOAT_EQ(v[0], -1.5f);
+    EXPECT_FLOAT_EQ(v[1], 2.5f);
+}
+
+// ─────────────────────────────────────────────
+// enumValue() / getEnum() — validated-enum flag (the ENUM type added by
+// PR #2161; folded here so IRArgs has one unified suite)
+// ─────────────────────────────────────────────
 
 TEST(IRArgsEnumTest, AcceptsAllowedValue) {
-    Parser parser("test", Common::NONE);
-    parser.enumValue("--debug-overlay", "mode", {"none", "ao", "shadow"}, "none");
-    std::vector<std::string> args{"prog", "--debug-overlay", "shadow"};
-    std::vector<char *> argv = makeArgv(args);
-    parser.parse(static_cast<int>(argv.size()), argv.data());
-
-    EXPECT_TRUE(parser.wasProvided("--debug-overlay"));
-    EXPECT_EQ(parser.getEnum("--debug-overlay"), "shadow");
+    Parser p(nullptr, Common::NONE);
+    p.enumValue("--debug-overlay", "mode", {"none", "ao", "shadow"}, "none");
+    Argv a({"prog", "--debug-overlay", "shadow"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_TRUE(p.wasProvided("--debug-overlay"));
+    EXPECT_EQ(p.getEnum("--debug-overlay"), "shadow");
 }
 
 TEST(IRArgsEnumTest, OmittedReturnsDefault) {
-    Parser parser("test", Common::NONE);
-    parser.enumValue("--debug-overlay", "mode", {"none", "ao", "shadow"}, "none");
-    std::vector<std::string> args{"prog"};
-    std::vector<char *> argv = makeArgv(args);
-    parser.parse(static_cast<int>(argv.size()), argv.data());
-
-    EXPECT_FALSE(parser.wasProvided("--debug-overlay"));
-    EXPECT_EQ(parser.getEnum("--debug-overlay"), "none");
+    Parser p(nullptr, Common::NONE);
+    p.enumValue("--debug-overlay", "mode", {"none", "ao", "shadow"}, "none");
+    Argv a({"prog"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_FALSE(p.wasProvided("--debug-overlay"));
+    EXPECT_EQ(p.getEnum("--debug-overlay"), "none");
 }
 
-TEST(IRArgsEnumTest, InlineEqualsValueAccepted) {
-    Parser parser("test", Common::NONE);
-    parser.enumValue("--mode", "mode", {"a", "b", "c"}, "a");
-    std::vector<std::string> args{"prog", "--mode=b"};
-    std::vector<char *> argv = makeArgv(args);
-    parser.parse(static_cast<int>(argv.size()), argv.data());
-
-    EXPECT_EQ(parser.getEnum("--mode"), "b");
+TEST(IRArgsEnumTest, InlineEqualsFormAccepted) {
+    Parser p(nullptr, Common::NONE);
+    p.enumValue("--mode", "mode", {"a", "b", "c"}, "a");
+    Argv a({"prog", "--mode=b"});
+    p.parse(a.argc(), a.argv());
+    EXPECT_EQ(p.getEnum("--mode"), "b");
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
GTest suite for `IRArgs::Parser` (`engine/ir_args.cpp`) covering `numbers()`/`getFloats()` (the FLOAT_LIST type), the pre-existing `FLAG`/`INT`/`FLOAT`/`STRING`/`OPTIONAL_INT` types, positionals, `--help`/`usage()`, and the new `enumValue()`/`getEnum()` (ENUM) type.

- Malformed-input branches (`Parser::parse()` calls `std::exit()` on error) are covered via GTest death tests (`EXPECT_EXIT` + `ExitedWithCode(2)`) — the first death-test usage in `test/`.
- Trailing-comma (inline) and non-numeric (space-separated) tokens are documented as *accepted* (coerced to `0.0`), so those are value assertions rather than death tests.

## Collision resolution with #2161 (reviewer needs-fix)
Both this PR and #2161 branched off a `master` with no `test/common/ir_args_test.cpp`, so each showed it as a brand-new file — a hard add/add conflict, and the ENUM cases #2161's suite covers depend on the `enumValue()`/`getEnum()` API that **only** exists on #2161's branch (absent on `master`). Folding those cases into a `master`-based file is therefore impossible to compile.

Resolved per the reviewer's suggested path by **stacking this PR on #2161** (`fleet:stacked`, base `claude/irargs-multivalue-enum`) and producing the single unified suite:
- Kept this PR's broader structure (the `Argv` RAII helper + death-test coverage).
- Folded in #2161's unique cases, adapted to the `Argv` helper: the two distinct `numbers()` cases (`CoexistsWithOtherFlags`, `AcceptsNegativeValues`) and all three `IRArgsEnumTest` cases. #2161's three redundant `numbers()` happy-path cases (space/inline/zero-fill) are already covered here and were dropped to avoid duplication.
- `test/CMakeLists.txt` registers the file on the #2161 base already, so this PR's diff no longer touches it.

When #2161 merges, the merger re-targets this PR's base to `master` and cascade-rebases (standard `fleet:stacked` flow).

## Test plan
- [x] `fleet-build --target IrredenEngineTest` builds clean on the #2161 base.
- [x] `IrredenEngineTest --gtest_filter="IRArgs*"` — **28/28 pass** (23 original + 5 folded).
- [x] `fleet-build --target format-changed` applied canonical clang-format (the original PR's new *untracked* file had been silently skipped by `format-changed`; now tracked, the `Argv` helper's formatting was corrected).

Test-only change; `IRArgs` behavior is unmodified.

Closes #2149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
