### PR TITLE
fleet: empty-wake suppression, fable-preferred planning, validator citation fix

### DIFF
--- a/.claude/commands/role-epic-steward.md
+++ b/.claude/commands/role-epic-steward.md
@@ -1,0 +1,36 @@
+---
+name: role-epic-steward
+description: Epic steward — transient bookkeeper for fleet:epic umbrellas (ledger, plan amendments, close-out)
+---
+
+You are the **epic steward** agent for the Irreden Engine fleet.
+
+**The shared steward protocol lives in
+[`docs/agents/epic-steward-protocol.md`](../../docs/agents/epic-steward-protocol.md).**
+Read it first — it owns startup, per-epic claim etiquette, the four flows
+(design-block triage, post-merge follow-up, adoption, close-out), the ledger
+and amendment formats, the proposal package, escalation rules, iteration
+budget, modes, and the hard rules (docs artifacts only — never push code).
+This wrapper carries only the engine's deltas. See
+[`docs/design/role-sharing.md`](../../docs/design/role-sharing.md) for the
+delta-key mechanism.
+
+Mode (optional argument): $ARGUMENTS
+
+## Deltas (Irreden Engine)
+
+| Delta key | Engine value |
+|---|---|
+| **repo-slug** | `jakildev/IrredenEngine` |
+| **downstream-repo-slug** | `jakildev/irreden` |
+| **repo-root** | `~/src/IrredenEngine` |
+| **downstream-repo-root** | `~/src/IrredenEngine/creations/game` |
+| **worktree-path** | `~/src/IrredenEngine/.claude/worktrees/epic-steward` |
+| **downstream-worktree-path** | `~/src/IrredenEngine/creations/game/.claude/worktrees/game-epic-steward` |
+| **role-name** | `epic-steward` |
+| **role-banner** | `[epic-steward] Epic bookkeeper — umbrella checklists, semantic ledger, plan amendments, close-out. Transient (dispatcher-driven).` |
+| **claim-tool-flags** | engine repo: none; game repo: `--repo game` (global flag, BEFORE the subcommand) |
+| **plans-path** | repo copy `<repo>/.fleet/plans/issue-<N>.md` (synced from master); local staging `~/.fleet/plans/` |
+| **ledger-branch-prefix** | `claude/epic-steward-` |
+| **escalation-target** | `opus-architect` |
+| **feedback-file** | `~/.fleet/feedback/epic-steward.md` |

--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -379,20 +379,33 @@ bare alias can't silently upgrade it, while the sonnet class is the bare
 Sonnet 5) without a per-release edit. Pin classes with `FLEET_MODEL_FABLE`
 / `FLEET_MODEL_OPUS` / `FLEET_MODEL_SONNET` in `~/.fleet/fleet-up.conf`.
 
-**fable — opt-in, for the genuinely hard work.** Budget is the scarce
-resource; `FLEET_CONCURRENCY_MODEL_FABLE` (default 1) caps concurrent
-fable iterations fleet-wide. Tag `Model: fable` only for:
+**fable — design-tier work.** Budget is the scarce resource;
+`FLEET_CONCURRENCY_MODEL_FABLE` (default 1) caps concurrent fable
+iterations fleet-wide. Fable is the *default* for the fleet's design
+surfaces — the architect panes launch on it, and `fleet:needs-plan`
+planning elects it (falling back to opus while the cap is saturated) —
+and *opt-in* per task via `Model: fable` for:
 
-- Hard rendering/algorithmic problems — the kind that have burned
-  multiple opus/sonnet attempts or need novel algorithm design.
-- Epic decomposition and design-blocked resolutions (architect panes run
-  fable for the same reason).
+- Novel render-pipeline algorithm/stage design — a new compositing or
+  lighting stage, a coordinate-space change, cross-backend (GL↔Metal)
+  algorithm work. Tag these fable **at planning time**, not only after
+  they've burned multiple opus/sonnet attempts; render-algorithm rework
+  is the historically highest-re-attempt category in this repo.
+- Hard algorithmic problems elsewhere with the same shape — multiple
+  failed attempts, or the solution space is genuinely open.
+- Epic decomposition and design-blocked resolutions.
 - Gnarly cross-cutting refactors where long-range invariant reasoning is
   the whole job.
 - Feedback fixes where review found the *approach* wrong — the reviewer
   adds `fleet:fable` to the PR (or escalates `fleet:design-blocked`).
 
+Rendering is not automatically fable: implementing a render change
+against a vetted plan is opus (or sonnet when mechanical) — it's the
+*algorithm design* that goes fable.
+
 **opus — the default class.** Tasks with no `Model:` field land here.
+When planning a task, don't leave it here by omission — pick the class
+deliberately (the planner's `**Model:**` line is the routing signal).
 
 - Core engine implementation against an existing plan: ECS, ownership
   and lifetime rules, render pipeline work, `engine/render/`,
@@ -404,10 +417,22 @@ fable iterations fleet-wide. Tag `Model: fable` only for:
   the diff, so fable buys nothing there.
 - Blocking-feedback fixes (`fleet:needs-fix` / `human:needs-fix`).
 
-**sonnet — bounded work.**
+**sonnet — bounded work, and the default for well-planned
+implementation.** The bare `sonnet` alias tracks the latest Sonnet
+(currently Sonnet 5), which handles substantially more than the class
+did when these lists were first drawn — when a task has a vetted plan
+with concrete file-level steps and clear acceptance criteria, prefer
+`Model: sonnet` unless it touches the core-invariant surfaces in the
+opus list.
 
+- Implementation against a vetted `## Plan` whose steps are concrete
+  (files named, approach decided, acceptance runnable) and that stays
+  off core-invariant surfaces (ECS ownership/lifetime, GPU-buffer
+  lifetime, concurrency).
 - Unit tests against a clear spec, documentation passes, mechanical
   refactors (rename-across-codebase, extract-header, add-logging).
+- Backend parity ports with an existing recipe (the leading side landed
+  and the port is transliteration), render-verify reference refreshes.
 - **First-pass code review.** Style, obvious bugs, missing null checks.
 - Clearly-scoped queue tasks already thought through upstream.
 - Gameplay / creation-level work where mistakes are cheap to catch.

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -85,7 +85,9 @@ For each `fleet:needs-plan` issue:
      recorded conclusion (e.g. #1440 prescribed the approach #1420 had
      already proved wrong) wastes a full worker round.
    - Whether it should be **one task or broken into subtasks**
-   - Suggested model tag (`[opus]` or `[sonnet]`) for each piece
+   - Suggested model tag (`[fable]`, `[opus]`, or `[sonnet]`) for each
+     piece — same criteria as the plan's `**Model:**` line (FLEET.md
+     §"Model split")
    - Acceptance criteria
    - Known gotchas or pitfalls
    - **Cross-system audit (when planning a deletion or migration of a
@@ -103,7 +105,10 @@ For each `fleet:needs-plan` issue:
    ## Plan: <issue title>
 
    - **Issue:** #N
-   - **Model:** opus | sonnet
+   - **Model:** fable | opus | sonnet — pick deliberately per
+     FLEET.md §"Model split": fable for novel algorithm/stage design
+     (especially render-pipeline), sonnet when the plan above is concrete
+     enough that implementation is bounded, opus for the middle
    - **Date:** YYYY-MM-DD
 
    ### Scope

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -1511,9 +1511,10 @@ def project_opus_reviewer(state):
         # Plan-review issues (#1932): a posted `## Plan` awaiting a verdict.
         # Nothing else wakes the reviewer on issue (vs PR) state, so project them
         # here. Skip human-held ones. The reviewer's verdict removes
-        # fleet:plan-review, so the issue leaves this set — a terminal change
-        # (one trailing empty wake, exactly like a PR verdict label-swap), NOT a
-        # self-toggled label, so it can't self-trigger a loop.
+        # fleet:plan-review, so the issue leaves this set — a terminal change,
+        # NOT a self-toggled label, so it can't self-trigger a loop. (When the
+        # departure empties the whole projection, update_role_trigger
+        # swallows even the single trailing wake.)
         for issue in repo_state.get("plan_review", []):
             labels = set(issue.get("labels", []))
             if labels & _HUMAN_GATE_LABELS:
@@ -2166,6 +2167,23 @@ def update_role_trigger(role: str, projection) -> bool:
     if new_hash == old_hash:
         return False
     write_atomic(seen_file, new_hash + "\n")
+    # A hash change whose NEW projection is empty is a transition to
+    # nothing-to-do — the item left the set because someone handled it (a
+    # verdict label-swap, an amend claim, a merge). Waking the role to
+    # discover an empty slice is a guaranteed no-op iteration, and label
+    # churn across several PRs produces trains of them (observed
+    # 2026-07-01: opus-reviewer dispatched 4x in 5 min, every iteration
+    # "no actionable candidates"). Record the hash (so the next
+    # empty->non-empty flip still fires) but leave the trigger untouched.
+    # An already-pending trigger stays pending: a non-empty->non-empty
+    # change armed it and the remaining work may still need serving.
+    # The queue-manager / queue-manager-ingest branches in collect_state
+    # inline this same hash-compare WITHOUT the empty suppression on
+    # purpose: they spawn cheap non-LLM subprocesses, and both want the
+    # transition-to-empty edge (a post-drain cleanup sweep; ingest's
+    # edge-triggered no-rearm contract).
+    if not projection:
+        return False
     (TRIGGERS_DIR / role).touch()
     return True
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -1566,7 +1566,7 @@ attach with:  tmux attach -t ${SESSION}
 model classes (resolved this run — tasks route by class via the
 fleet:fable / fleet:opus / fleet:sonnet labels and Model:/Effort: fields;
 the dispatcher launches each worker iteration with its task's class):
-  fable  — ${FLEET_MODEL_FABLE}  (architects; fleet:fable tasks — opt-in hard work)
+  fable  — ${FLEET_MODEL_FABLE}  (architects; needs-plan planning; fleet:fable tasks)
            dispatched-iteration fallback: ${FLEET_FABLE_FALLBACK:-none}
   opus   — ${FLEET_MODEL_OPUS}  (default task class; final reviewer)
   sonnet — ${FLEET_MODEL_SONNET}  (sonnet tasks, first-pass review, smoke, merger)

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -57,7 +57,10 @@
 # FLEET_MODEL_FABLE_FALLBACK="claude-opus-4-8[1m]"
 #
 # Fleet-wide cap on concurrent fable-class iterations (the budget
-# throttle; counted across all panes, 0 disables fable dispatch):
+# throttle; counted across all panes, 0 disables fable dispatch).
+# needs-plan planning elects fable while this cap has headroom and
+# degrades to opus once it's saturated, so a cap of 0 also routes all
+# planning to opus:
 # FLEET_CONCURRENCY_MODEL_FABLE=1
 #
 # FLEET_MODEL_PROBE=0 skips the availability probe (offline / tests);

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -20,7 +20,11 @@ Resolution order mirrors the worker role docs' pickup priority:
   2. open tasks     — the oldest claimable task's class (slices are sorted
                       by issue number; ``model`` comes from the
                       fleet:fable/opus/sonnet labels via the scout).
-  3. needs_plan     — planning runs the opus class.
+  3. needs_plan     — planning prefers the fable class (planning IS the
+                      architect-tier design work — the same reason the
+                      architect panes run fable), falling back to opus when
+                      the fable cap is saturated so planning never stalls
+                      behind a long fable implementation iteration.
 
 Effort: the task's ``**Effort:**`` field when present (scout validates it),
 else the class default below.
@@ -188,7 +192,7 @@ def feedback_pr_class(labels):
     return "sonnet"
 
 
-def _candidates(slice_data, lane_default, host):
+def _candidates(slice_data, lane_default, host, fable_blocked=False):
     """Yield (class, effort) for each actionable item, pickup-priority order.
 
     Feedback PRs come first (the worker fixes review feedback before new work),
@@ -198,10 +202,14 @@ def _candidates(slice_data, lane_default, host):
     actually picks up, and one yield per item lets the caller count claimable
     work per class for the dispatcher's fan-out cap.
 
-    needs_plan yields once regardless of how many issues await planning:
-    planning has no claim lock (sibling panes would re-plan the same issue), so
-    the lane plans one at a time — the next planner fires after the first opens
-    its plan-doc PR.
+    needs_plan yields once regardless of how many issues await planning: the
+    lane plans one at a time — the next planner fires after the first posts its
+    `## Plan` comment (the planning-claim label lock plus the comment-presence
+    early-out make a same-tick sibling a cheap no-op, not a duplicate plan).
+    Planning is architect-tier design work, so it prefers fable and degrades
+    to opus when the fable cap is already saturated (`fable_blocked`) — the
+    downgrade is resolved here, at election time, so a capped fable never
+    leaves planning stuck behind the `skipped_fable` defer path.
     """
     def _class_effort(task):
         cls = (task.get("model") or lane_default).lower()
@@ -220,7 +228,8 @@ def _candidates(slice_data, lane_default, host):
         if _task_claimable(task, host) and task.get("blocked"):
             yield _class_effort(task)
     if slice_data.get("needs_plan"):
-        yield "opus", CLASS_DEFAULT_EFFORT["opus"]
+        cls = "opus" if fable_blocked else "fable"
+        yield cls, CLASS_DEFAULT_EFFORT[cls]
 
 
 def resolve(slice_data, lane_default, fable_blocked, exclude=()):
@@ -245,7 +254,7 @@ def resolve(slice_data, lane_default, fable_blocked, exclude=()):
     excluded_any = False
     servable_classes = set()
     class_counts = {}
-    for cls, effort in _candidates(slice_data, lane_default, host):
+    for cls, effort in _candidates(slice_data, lane_default, host, fable_blocked):
         if cls in exclude:
             excluded_any = True
             continue

--- a/scripts/fleet/fleet_validate_roles.py
+++ b/scripts/fleet/fleet_validate_roles.py
@@ -97,7 +97,17 @@ def extract_protocol_keys(protocol_path):
 
 
 def find_wrappers(repo_root, protocol_filename):
-    """Return .claude/commands/role-*.md files that reference protocol_filename."""
+    """Return .claude/commands/role-*.md files that WRAP protocol_filename.
+
+    A wrapper both references the protocol filename and carries a ``## Deltas``
+    section — the second condition is what separates a wrapper from a role doc
+    that merely *cites* the protocol in prose (e.g. role-opus-reviewer.md points
+    at architect-protocol.md §"plan reviewer"; validating it against the
+    architect's 10 delta keys produced 10 false errors). A citing-only file is
+    ignored here; a protocol with no true wrapper in the repo still surfaces via
+    the caller's no-wrapper WARN, which also covers the half-written-wrapper
+    case (referenced the protocol, never added its Deltas table).
+    """
     cmds_dir = Path(repo_root) / ".claude" / "commands"
     if not cmds_dir.is_dir():
         return []
@@ -105,10 +115,10 @@ def find_wrappers(repo_root, protocol_filename):
     results = []
     for f in sorted(cmds_dir.glob("role-*.md")):
         try:
-            text = f.read_text(encoding="utf-8", errors="replace")
+            text = _norm(f.read_text(encoding="utf-8", errors="replace"))
         except OSError:
             continue
-        if basename in text:
+        if basename in text and _WRAPPER_DELTAS_HDR_RE.search(text):
             results.append(f)
     return results
 

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -181,33 +181,48 @@ class TaskResolution(unittest.TestCase):
                       "opus", fable_blocked=False)
         self.assertEqual(out, "sonnet high 1 1")
 
-    def test_needs_plan_runs_opus(self):
+    def test_needs_plan_prefers_fable(self):
+        # Planning is architect-tier design work: it elects fable while the
+        # fable cap has headroom (the same reasoning that puts the architect
+        # panes on the fable class).
         out = resolve({"needs_plan": [{"number": 99}]},
                       "opus", fable_blocked=False)
+        self.assertEqual(out, "fable xhigh 0 1")
+
+    def test_needs_plan_falls_back_to_opus_when_fable_capped(self):
+        # A saturated fable cap must DOWNGRADE planning to opus, not defer it —
+        # the downgrade happens at election time so planning never stalls
+        # behind a long fable implementation iteration.
+        out = resolve({"needs_plan": [{"number": 99}]},
+                      "opus", fable_blocked=True)
         self.assertEqual(out, "opus xhigh 0 1")
 
     def test_needs_plan_counts_once_regardless_of_backlog(self):
-        # Planning has no claim lock, so the lane plans one issue at a time:
-        # multiple needs_plan issues still yield a single opus candidate ->
+        # The lane plans one issue at a time (planning-claim lock + the
+        # comment-presence early-out make same-tick siblings a no-op):
+        # multiple needs_plan issues still yield a single candidate ->
         # count=1 (no fan-out of colliding planners).
         out = resolve({"needs_plan": [{"number": 99}, {"number": 100},
                                       {"number": 101}]},
                       "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 0 1")
+        self.assertEqual(out, "fable xhigh 0 1")
 
     def test_design_unblocked_feedback_resolves_opus(self):
         # The engine #1885 shape: a design-unblocked PR is the top feedback
         # item, every open task is parked/blocked, and opus needs_plan sits
         # behind it. The lane must dispatch opus (and clear it for tier 4),
         # not sonnet — pre-fix this resolved "sonnet ... 1" and starved both.
-        # count=2: the feedback fix plus the plannable issue are both opus work.
+        # count=1: the feedback fix is the only opus item; the plannable
+        # issue now elects fable (planning prefers fable), so it rides the
+        # `more` flag — the kept trigger serves the planning dispatch on a
+        # following tick.
         out = resolve({
             "feedback_prs": [{"labels": ["fleet:design-unblocked", "fleet:wip"]}],
             "tasks_open": [_task("#1882", "opus",
                                  inflight_pr={"number": 1885, "parked": True})],
             "needs_plan": [{"number": 1887}],
         }, "opus", fable_blocked=False)
-        self.assertEqual(out, "opus xhigh 0 2")
+        self.assertEqual(out, "opus xhigh 1 1")
 
 
 class FableCap(unittest.TestCase):

--- a/scripts/fleet/tests/test_fleet_validate_roles.py
+++ b/scripts/fleet/tests/test_fleet_validate_roles.py
@@ -218,6 +218,34 @@ class TestMissingDeltaKey(unittest.TestCase):
         self.assertEqual(result["n_errors"], 0)
         self.assertEqual(result["n_warnings"], 1)
 
+    def test_citing_role_doc_without_deltas_is_not_a_wrapper(self):
+        # role-opus-reviewer.md cites architect-protocol.md in prose (the
+        # plan-review pass points at §"plan reviewer") without wrapping it.
+        # A protocol mention alone must NOT drag the file into delta
+        # validation — pre-fix this produced one false error per delta key.
+        keys = ["repo-slug", "role-name"]
+        _make_protocol(self.root, "test-protocol.md", keys)
+        _make_wrapper(self.root, "role-test.md", "test-protocol.md", keys)
+        _write(Path(self.root) / ".claude" / "commands" / "role-citer.md",
+               "---\nname: role-citer\n---\n\nSee test-protocol.md "
+               "\u00a7\"some section\" for the shared flow.\n")
+        result = validate_roles([(self.root, "engine")])
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["n_errors"], 0)
+        self.assertEqual(result["n_warnings"], 0)
+
+    def test_citing_only_repo_still_warns_no_wrapper(self):
+        # If the ONLY file mentioning the protocol lacks a ## Deltas section
+        # (citation, or a half-written wrapper), the repo has no wrapper —
+        # the no-wrapper WARN must fire rather than validating the citer.
+        _make_protocol(self.root, "test-protocol.md", ["repo-slug"])
+        _write(Path(self.root) / ".claude" / "commands" / "role-citer.md",
+               "---\nname: role-citer\n---\n\nSee test-protocol.md.\n")
+        result = validate_roles([(self.root, "engine")])
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["n_errors"], 0)
+        self.assertEqual(result["n_warnings"], 1)
+
 
 # ---------------------------------------------------------------------------
 # Group 3: checklist drift

--- a/scripts/fleet/tests/test_role_trigger_empty.py
+++ b/scripts/fleet/tests/test_role_trigger_empty.py
@@ -1,0 +1,86 @@
+"""Tests for update_role_trigger's empty-projection wake suppression.
+
+A projection-hash change whose NEW projection is empty is a transition to
+nothing-to-do (a verdict label-swap, an amend claim, a merge emptied the
+set). Waking the role then is a guaranteed no-op iteration — observed
+2026-07-01 as the opus-reviewer dispatching 4x in 5 minutes, every
+iteration "no actionable candidates". The invariants:
+
+  - non-empty -> non-empty change: hash recorded, trigger touched;
+  - non-empty -> EMPTY change: hash recorded, trigger NOT touched (the
+    trailing wake is swallowed);
+  - empty -> non-empty change: fires normally (the recorded empty hash
+    guarantees the flip back is seen as a change);
+  - unchanged projection: no hash write, no trigger (pre-existing).
+"""
+import importlib.machinery
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-state-scout"
+_loader = importlib.machinery.SourceFileLoader("fleet_state_scout", str(_SCRIPT))
+_spec = importlib.util.spec_from_loader("fleet_state_scout", _loader)
+_mod = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_mod)
+
+
+class UpdateRoleTriggerEmpty(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        base = Path(self._tmp.name)
+        self._orig_seen = _mod.SEEN_DIR
+        self._orig_triggers = _mod.TRIGGERS_DIR
+        _mod.SEEN_DIR = base / "seen-hashes"
+        _mod.TRIGGERS_DIR = base / "triggers"
+        _mod.SEEN_DIR.mkdir(parents=True)
+        _mod.TRIGGERS_DIR.mkdir(parents=True)
+
+    def tearDown(self):
+        _mod.SEEN_DIR = self._orig_seen
+        _mod.TRIGGERS_DIR = self._orig_triggers
+        self._tmp.cleanup()
+
+    def _trigger_exists(self, role):
+        return (_mod.TRIGGERS_DIR / role).exists()
+
+    def _seen(self, role):
+        return (_mod.SEEN_DIR / role).read_text().strip()
+
+    def test_non_empty_change_fires(self):
+        self.assertTrue(_mod.update_role_trigger("r", [{"pr": 1}]))
+        self.assertTrue(self._trigger_exists("r"))
+
+    def test_transition_to_empty_records_hash_without_wake(self):
+        _mod.update_role_trigger("r", [{"pr": 1}])
+        (_mod.TRIGGERS_DIR / "r").unlink()  # dispatcher consumed it
+        self.assertFalse(_mod.update_role_trigger("r", []))
+        self.assertFalse(self._trigger_exists("r"))
+        self.assertEqual(self._seen("r"), _mod.stable_hash([]))
+
+    def test_empty_to_non_empty_fires(self):
+        _mod.update_role_trigger("r", [{"pr": 1}])
+        (_mod.TRIGGERS_DIR / "r").unlink()
+        _mod.update_role_trigger("r", [])
+        self.assertTrue(_mod.update_role_trigger("r", [{"pr": 2}]))
+        self.assertTrue(self._trigger_exists("r"))
+
+    def test_transition_to_empty_leaves_pending_trigger_pending(self):
+        # A trigger armed by earlier non-empty work and not yet consumed
+        # must survive the empty transition — suppression only skips the
+        # touch, it never clears.
+        _mod.update_role_trigger("r", [{"pr": 1}])
+        self.assertTrue(self._trigger_exists("r"))
+        _mod.update_role_trigger("r", [])
+        self.assertTrue(self._trigger_exists("r"))
+
+    def test_unchanged_projection_is_inert(self):
+        _mod.update_role_trigger("r", [{"pr": 1}])
+        (_mod.TRIGGERS_DIR / "r").unlink()
+        self.assertFalse(_mod.update_role_trigger("r", [{"pr": 1}]))
+        self.assertFalse(self._trigger_exists("r"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **Scout: swallow transitions-to-empty projection wakes.** `update_role_trigger` records the new hash but no longer touches the trigger when the projection just went empty — each reviewer verdict/amend-claim/merge label-swap was waking the (opus) reviewer into a no-op iteration (4 dispatches in 5 minutes observed 2026-07-01, all "no actionable candidates"). Empty→non-empty still fires; pending triggers are never cleared; the queue-manager/ingest inline hash-compares intentionally keep the empty edge (cheap subprocesses, edge-triggered ingest contract).
- **Planning prefers fable.** `fleet:needs-plan` now elects the fable class while `FLEET_CONCURRENCY_MODEL_FABLE` has headroom and degrades to opus *at election time* when saturated (never defers planning). Planning is architect-tier design work — the architect panes already launch on the fable class.
- **Model-split criteria sharpened** (FLEET.md §"Model split", PLANNING-PROTOCOL): fable = design tier (architects, planning, novel render-algorithm/stage design tagged at planning time, design-blocked resolutions, cross-cutting refactors); opus = deliberate middle + final review; sonnet (bare alias → Sonnet 5) = default for implementation against a vetted concrete plan off core-invariant surfaces, parity ports with a recipe, tests/docs/mechanical work. Planners must pick `**Model:**` deliberately; `[fable]` added to the epic-decomposition tag vocabulary.
- **Validator: citation ≠ wrapper.** `fleet-validate-roles` was failing (10 errors, exit 1) because role-opus-reviewer.md *cites* architect-protocol.md §"plan reviewer" in prose; wrapper detection now additionally requires a `## Deltas` section. A protocol whose only referencing file lacks Deltas still surfaces via the no-wrapper WARN.
- **New `role-epic-steward.md`** wrapper answering all 13 epic-steward-protocol.md delta keys (engine side; the optional pane no longer lacks its role command). Game-side wrapper still absent (warn-level; game repo change, out of scope here).

## Test plan
- [x] `tests/test_role_trigger_empty.py` (new, 5 cases: non-empty fires, →empty records hash without wake, empty→non-empty fires, pending trigger survives empty transition, unchanged is inert)
- [x] `tests/test_fleet_task_class.py` (38 pass; needs-plan→fable, cap→opus fallback, design-unblocked shape re-derived)
- [x] `tests/test_fleet_validate_roles.py` (+2 citation-exemption cases; 25 pass)
- [x] All 24 python fleet test modules pass except `test_epic_steward_projection` (1 failure **pre-existing on master**, flagged separately)
- [x] Dispatcher shell tests: class_dispatch, rearm, claimable_cap, empty_exit_backoff, plan_lint — PASS
- [x] `fleet-validate-roles` on this tree: OK, exit 0 (was FAILED, exit 1)
- [x] `ruff check scripts/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)