### PR TITLE
fleet: fix stale design-proposed-stackable test (post-#2130)

### DIFF
--- a/scripts/fleet/tests/test_epic_steward_projection.py
+++ b/scripts/fleet/tests/test_epic_steward_projection.py
@@ -371,8 +371,11 @@ class ResolveEpicChildren(unittest.TestCase):
 
 
 class DesignProposedSkipSets(unittest.TestCase):
-    """fleet:design-proposed parks a PR off the review/merger/stacking
-    surfaces until the proposal resolves (#1664 acceptance criterion)."""
+    """fleet:design-proposed parks a PR off the review/merger surfaces
+    until the proposal resolves (#1664 acceptance criterion). Note: as of
+    #2130 a frozen design-proposed diff IS a valid stack base — the
+    stacking surface is no longer skipped (see
+    test_design_proposed_blocker_is_stackable below)."""
 
     def test_absent_from_sonnet_reviewer_projection(self):
         state = _state(prs=[_pr(101, labels=["fleet:design-proposed"])])
@@ -388,9 +391,13 @@ class DesignProposedSkipSets(unittest.TestCase):
                                              "fleet:approved"])])
         self.assertEqual(project_merger(state), [])
 
-    def test_blocker_pr_not_stackable(self):
-        # enrich filter (b): a design-proposed blocker PR has the same
-        # stacking hazard as a design-blocked one.
+    def test_design_proposed_blocker_is_stackable(self):
+        # Post-#2130 (7fb58c6d): frozen-design labels were deliberately
+        # dropped from NOT_STACKABLE_BASE_LABELS, so a design-proposed
+        # blocker PR with a parked, stable diff IS offered as a stack
+        # base. This case writes no PR cache, so it covers the cache-miss
+        # (blocker_files=None) branch of unsafe_base_reason; the cache-hit
+        # branch is covered by test_frozen_design_base_offered.
         state = _state(
             prs=[_pr(101, labels=["fleet:design-proposed"],
                      head="claude/11-base")],
@@ -398,7 +405,8 @@ class DesignProposedSkipSets(unittest.TestCase):
         )
         enrich_stackable_blocker_prs(state)
         task = state["repos"]["engine"]["tasks"]["open"][0]
-        self.assertNotIn("stackable_blocker_pr", task)
+        self.assertIn("stackable_blocker_pr", task)
+        self.assertEqual(task["stackable_blocker_pr"]["number"], 101)
 
 
 class Slice(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `DesignProposedSkipSets.test_blocker_pr_not_stackable` in `scripts/fleet/tests/test_epic_steward_projection.py` failed on `origin/master` — it encoded the **pre-#2130** stacking policy.
- Root cause is a **stale test premise, not an enrichment regression**: #2130 (`7fb58c6d`) deliberately dropped the frozen-design labels from `NOT_STACKABLE_BASE_LABELS` in `fleet_stack_base.py`, so a `fleet:design-proposed` blocker PR with a parked, stable diff **is** now a valid stack base. The in-code comment states it outright, and `test_enrich_stackable_blocker_prs.test_frozen_design_base_offered` already asserts the new policy on the cache-hit path.
- Fix (test-only): flip + rename the case to `test_design_proposed_blocker_is_stackable` (asserts `stackable_blocker_pr` **is** set, `number == 101`) and correct the `DesignProposedSkipSets` docstring.
- Preserving the fixture (no PR cache written) keeps the **cache-miss (`blocker_files=None`) branch** covered — the sibling `test_frozen_design_base_offered` writes a cache and only exercises the cache-hit branch. No new regression case needed.
- The enrichment (`fleet_stack_base.py` / `fleet-state-scout`) is **unchanged** — a wrongly-stackable blocker was not blessed; the already-shipped #2130 policy is confirmed correct.

## Test plan
- [x] `cd scripts/fleet && python3 -m unittest tests.test_epic_steward_projection` → 36/36 pass
- [x] `python3 -m unittest tests.test_enrich_stackable_blocker_prs tests.test_stack_base_guard` → green (no policy drift)
- [x] `ruff check scripts/fleet/tests/test_epic_steward_projection.py` → clean

Closes #2183

🤖 Generated with [Claude Code](https://claude.com/claude-code)