### PR TITLE
fleet: absorb coding-improvement triage batch

### DIFF
--- a/.claude/rules/cpp-math.md
+++ b/.claude/rules/cpp-math.md
@@ -56,6 +56,7 @@ The math library may itself wrap `glm::*` / `std::*` internally — that is the 
 - Anything in `engine/math/**` itself.
 - The graphics-backend interop layer at `engine/render/include/irreden/render/backend/**` — when wiring an actual `glm` value into a `glDrawElements`-shaped API, raw glm types are the surface.
 - Shader source: `*.glsl`, `*.metal`. These have their own native math; the rule is about C++ files.
+- Standalone tools under `tools/**` that do not link the engine library (`jitter_probe`, `img_diff`): IRMath lives in `engine/math/` and is genuinely unavailable there, so `std::`/`<cmath>` math is correct. (Also outside this rule's `paths:` scope — don't raise the nit from prose alone.)
 
 ## Live deviations (queue-manager-owned)
 

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -259,6 +259,61 @@ Fix: replace the block with `irreden_bundle_assets(<target> SCRIPTS <files>)`
 (+ `irreden_package_target` if a bundle is wanted). Report, don't auto-fix —
 the SCRIPTS / asset list needs a human eye.
 
+**Check 7: PR/issue-reference comments and motivation-prose blocks.**
+
+`CLAUDE-BASELINE.md` §Style bans comments that reference the current task or
+fix ("Reference adoption for #2044", "added for the #NNN flow") and
+block-level motivation prose explaining why a module was created ("Before
+this, every demo hand-rolled…") — both belong in the PR description and rot
+in source. §7's judgment pass missed this twice (PR #2045 C++, PR #2087
+GLSL), so grep the diff mechanically — **shaders included**:
+
+```
+Grep tool with:
+  pattern: '(//|/\*|\*).*#[0-9]{3,}\b'
+  glob:    '**/*.{hpp,cpp,h,cc,glsl,metal}'
+  output_mode: 'content'
+  -n: true
+```
+
+Cross-reference hits against added (`+`) lines only. A bare durable backref
+(`// see #N`, the §7-sanctioned form) is fine; anything narrating the task
+("for #N", "adoption for #N", "fix for #N", "added in #N") is the smell.
+For motivation prose, eyeball each added comment block of 3+ lines in the
+diff: if it explains the module's origin story or pre-change state rather
+than a durable invariant, cut it (keep at most a one-line WHY + `// see #N`).
+
+**Check 8: unreplaced scaffold placeholder sentinels.**
+
+`create-creation` templates require hand-replacing `YourCreation` /
+`YOUR_CREATION`, and older scaffolds emitted a `YOUR_CREATION_NAME_HERE` log
+string — a forgotten replacement compiles and runs silently (#2078's
+`font_maker` shipped one):
+
+```
+Grep tool with:
+  pattern: 'YOUR_CREATION_NAME_HERE|\bYourCreation\b|\bYOUR_CREATION\b'
+  glob:    '{engine,creations,test}/**'
+  output_mode: 'content'
+  -n: true
+```
+
+Any hit in real source is a leftover (the tokens only belong inside the
+`create-creation` skill's own template files). Auto-fix: substitute the real
+creation name.
+
+**Check 9: template functions added with no instantiation.**
+
+C++ only type-checks a template body at instantiation — an uninstantiated
+template member/free function is *parsed*, never semantically checked, so a
+wrong member access or stale API call in its body ships on a green build
+(PR #2170's `carve()`). For each `template <...>` function or member
+**added** in the diff, grep `engine/`, `creations/`, and `test/` for a call
+site (`<name><`, `<name>(`) outside the definition itself. No hit → flag:
+"uninstantiated template body — not type-checked; add a call site or
+headless test in this PR." Report, don't auto-fix — where the instantiation
+belongs is a design call.
+
 ### 2c. Serialized-struct version-bump check
 
 See `engine/asset/CLAUDE.md` §"Automated version-bump detection" for the full
@@ -427,7 +482,8 @@ Remove:
   verified…`, `was a misdiagnosis`, `Before #X / now Y`, `retired
   (T-323)`) is the same smell wearing rationale's clothing — most
   common in render code. Cut the forensic prose, keep the durable
-  invariant, and leave at most a `// see #N` backref.
+  invariant, and leave at most a `// see #N` backref. Task-reference
+  comments (`#NNN`) are mechanically caught by §2b Check 7.
 - Location-reference narration that points at other code instead of
   explaining why — `// ... (set above)`, `// see below`, `// called
   from X`. Mechanically caught by §2b Check 4; delete the

--- a/cmake/run_clang_format_changed.cmake
+++ b/cmake/run_clang_format_changed.cmake
@@ -68,6 +68,19 @@ list(APPEND _changed_files ${_committed})
 # working-tree edits in a single call.
 _collect_git_diff("HEAD" _working)
 list(APPEND _changed_files ${_working})
+# Neither diff form reports brand-new untracked files, so without this a
+# never-`git add`-ed source file silently skips formatting ("no diff").
+execute_process(
+    COMMAND git -C "${PROJECT_ROOT}" ls-files --others --exclude-standard
+    OUTPUT_VARIABLE _untracked_out
+    RESULT_VARIABLE _untracked_rc
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(_untracked_rc EQUAL 0 AND NOT _untracked_out STREQUAL "")
+    string(REPLACE "\n" ";" _untracked "${_untracked_out}")
+    list(APPEND _changed_files ${_untracked})
+endif()
 
 if(NOT _changed_files)
     message(STATUS "clang-format (changed): no diff vs ${_diff_base}; nothing to format.")

--- a/docs/agents/skills/file-epic.md
+++ b/docs/agents/skills/file-epic.md
@@ -111,6 +111,7 @@ proposal-pending: none
 |---|---|---|---|---|
 
 ### Decisions
+<!-- entries: D<n> (<YYYY-MM-DD>): <decision> — source: <link>  (numbered scheme per epic-steward-protocol.md §Decisions; escalation rules reference decisions by D-id) -->
 
 ### Events
 - <YYYY-MM-DD>: filed via file-epic

--- a/engine/prefabs/irreden/render/CLAUDE.md
+++ b/engine/prefabs/irreden/render/CLAUDE.md
@@ -512,6 +512,15 @@ overlay → any `DETACHED` mode with `screenLocked_ = true`.
 **World-integration mechanics (P4b / #1576; default since #1624).** How a
 world-placed re-voxelize solid integrates:
 
+- **Prerequisite — lighting-archetype membership.** A detached re-voxelize
+  canvas only participates in world lighting (AO + sun + sky + the RECEIVE
+  path below) if it carries `C_CanvasAOTexture` **and**
+  `C_TrixelCanvasRenderBehavior` — these put it in the `COMPUTE_VOXEL_AO` +
+  `LIGHTING_TO_TRIXEL` archetypes. Attach them **per spawn site** (not in the
+  shared `kVoxelPoolCanvas` builder, which also builds the main canvas). A
+  detached solid missing them matches neither pass and silently composites
+  **raw albedo** ("pasted-on"), regardless of `worldPlaced_` /
+  `detachedWorldReceive_` being set correctly.
 - **Depth (P4b-1):** the composite sets `distanceOffset_` to the entity's world
   iso depth, so the solid depth-sorts against world geometry on the shared GRID
   `trixelDistances` convention. The shared framebuffer depth runs at

--- a/scripts/fleet/fleet-labels
+++ b/scripts/fleet/fleet-labels
@@ -285,6 +285,9 @@ slug_from_remote() {
 # the two and fails on any difference so a forgotten edit to one side is
 # caught in CI / pre-commit rather than at runtime. Names only — color and
 # description are intentionally not compared (humans re-skin labels).
+# The JSON `description` fields are long-form documentation with NO length
+# cap and never sync to GitHub; only the catalog entries below sync, so the
+# ≤100-char GitHub limit is enforced on the catalog side alone.
 if [[ "$CHECK" -eq 1 ]]; then
     if ! command -v jq >/dev/null 2>&1; then
         echo "fleet-labels --check: jq not found." >&2


### PR DESCRIPTION
## Summary
Human-cued `triage-coding-improvements` run: swept all 10 open `fleet:coding-improvement` tickets, triaged each with the human, and bundled the accepted changes into this one PR. Diff maps 1:1 to the digest below.

## Triage digest

| Ticket | Verdict | Change |
|---|---|---|
| #2048 | ACCEPT | simplify §2b **Check 7**: PR/issue-reference comments + motivation-prose blocks, shaders included (2 occurrences: PR #2045 C++, PR #2087 GLSL) |
| #2079 | ACCEPT | simplify §2b **Check 8**: unreplaced scaffold sentinels (`YOUR_CREATION_NAME_HERE`, `YourCreation`/`YOUR_CREATION`) |
| #2172 | ACCEPT | simplify §2b **Check 9**: template functions added with no instantiation (parsed, never type-checked) |
| #2179 | ACCEPT | `run_clang_format_changed.cmake` also collects untracked files via `git ls-files --others --exclude-standard` — closes the brand-new-file false-clean |
| #2070 | REJECT (closed at triage) | Stale premise — JSON descriptions are doc-only/unsynced (20 intentional >100-char entries on master); landed a clarifying comment in `fleet-labels --check` instead |
| #2077 | ACCEPT | `cpp-math.md` allowlist bullet: standalone no-engine-link `tools/**` |
| #2096 | ACCEPT | render `CLAUDE.md`: detached-canvas lighting-archetype prerequisite (`C_CanvasAOTexture` + `C_TrixelCanvasRenderBehavior` per spawn site) |
| #2169 | ACCEPT | `file-epic.md` ledger template: `D<n> (<date>): … — source:` format cross-ref at point of authoring |
| #2160 | ROUTE OUT | Pure code work (face-occlusion + pixel-arg dedup) — `fleet:coding-improvement` label stripped, stands as a plain issue for queue approval |
| #1865 | DEFER (unchanged) | Device-backend graceful-degradation tests — parked since 2026-06-17, unblocks on a second occurrence |

## Test plan
- [x] #2179 validated old-vs-new: untracked misformatted probe file — old script reports "touches no formattable sources", new script formats it (probe deleted)
- [x] Checks 7–9 greps validated against reconstructed occurrences in a scratch file: Check 7 flags both cited patterns while the sanctioned `// see #N` form is distinguishable; Check 8 flags the sentinel with zero false hits tree-wide; Check 9 call-site grep correctly returns empty (fires)
- [x] `fleet-labels --check` exits 0 on the clean tree after the comment-only change
- [x] All cross-references in added doc text verified to resolve (`COMPUTE_VOXEL_AO`, `LIGHTING_TO_TRIXEL`, `kVoxelPoolCanvas`, `epic-steward-protocol.md §Decisions`, `tools/jitter_probe`)

## Notes for reviewer
Gated self-config files (`.claude/rules/`, `.claude/skills/simplify/SKILL.md`) in the diff are expected — this is the human-cued triage run; check the changes match the digest above.

Closes #2048
Closes #2079
Closes #2172
Closes #2179
Closes #2077
Closes #2096
Closes #2169

🤖 Generated with [Claude Code](https://claude.com/claude-code)