### PR TITLE
tooling: fleet-debug triggers subcommand + scout empty-suppression marker

### DIFF
--- a/scripts/fleet/fleet-debug
+++ b/scripts/fleet/fleet-debug
@@ -22,10 +22,18 @@ BATCH=false
 usage() {
     cat <<'USAGE'
 usage: fleet-debug [options] <target-or-executable> [--] [program-args...]
+       fleet-debug triggers
 
 Builds <target-or-executable> with the current worktree's debug build tree,
 finds the built executable under build/, cd's beside it, and starts a debugger
 from that runtime directory.
+
+Subcommands
+  triggers            Read-only dump of per-role fleet dispatch state: pending
+                      trigger (+ mtime/content), last seen projection hash,
+                      projection slice size + generated_at, and whether the last
+                      hash write was an empty-projection suppression (#2181).
+                      Never mutates any ~/.fleet/state file.
 
 Options
   --batch             Non-interactive crash triage: run immediately, then print
@@ -47,12 +55,152 @@ Examples
   fleet-debug IRShapeDebug
   fleet-debug --batch IRLightingCombined
   fleet-debug --no-build --debugger lldb IRShapeDebug -- --auto-screenshot
+  fleet-debug triggers
 
 Notes
   The repo's fleet presets are already debug builds (CMAKE_BUILD_TYPE=Debug).
   This command builds via fleet-build unless --no-build is passed.
 USAGE
 }
+
+# `fleet-debug triggers` — read-only dump of per-role dispatch state
+# (pending trigger, last seen projection hash, projection slice size, and
+# whether the last hash write was an empty-projection suppression, #2181).
+# A subcommand, not a build target: every build target is IR*-named, so
+# `triggers` can't collide with one. Anything else falls through to the
+# debugger-launcher path below. State dir resolves from $HOME so tests can
+# point it at a fixture tree; the dump never writes.
+if [[ "${1:-}" == "triggers" ]]; then
+    exec python3 - <<'PYEOF'
+import json
+import time
+from pathlib import Path
+
+STATE = Path.home() / ".fleet" / "state"
+TRIGGERS_DIR = STATE / "triggers"
+SEEN_DIR = STATE / "seen-hashes"
+PROJECTIONS_DIR = STATE / "projections"
+
+# Canonical dispatch roles. Sync sources: fleet-state-scout PROJECTORS and
+# fleet-dispatcher DISPATCHED_ROLES. queue-manager / queue-manager-ingest
+# spawn inline non-LLM subprocesses and never get a trigger file or an
+# empty-suppression marker, so those two columns read n/a for them.
+CANONICAL = [
+    "worker",
+    "sonnet-reviewer",
+    "opus-reviewer",
+    "merger",
+    "smoke-worker",
+    "epic-steward",
+    "queue-manager",
+    "queue-manager-ingest",
+]
+NO_TRIGGER = {"queue-manager", "queue-manager-ingest"}
+
+SUPPRESS_SUFFIX = ".empty-suppressed"
+
+
+def _mtime(path):
+    try:
+        return time.strftime("%m-%d %H:%M:%S", time.localtime(path.stat().st_mtime))
+    except OSError:
+        return "?"
+
+
+def _discover_extra_roles():
+    # Union any basename the state dirs know about but the canonical list
+    # doesn't, so a future role shows up unlisted rather than hidden. Skip
+    # write_atomic temp files, dotfiles, and the suppression markers.
+    found = set()
+    for d in (TRIGGERS_DIR, SEEN_DIR):
+        try:
+            entries = list(d.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            name = entry.name
+            if name.startswith(".") or name.endswith(".tmp"):
+                continue
+            if name.endswith(SUPPRESS_SUFFIX):
+                continue
+            found.add(name)
+    try:
+        proj_entries = list(PROJECTIONS_DIR.iterdir())
+    except OSError:
+        proj_entries = []
+    for entry in proj_entries:
+        name = entry.name
+        if name.startswith(".") or not name.endswith(".json"):
+            continue
+        found.add(name[: -len(".json")])
+    return sorted(found - set(CANONICAL))
+
+
+def _trigger_col(role):
+    path = TRIGGERS_DIR / role
+    try:
+        content = path.read_text().strip()
+    except FileNotFoundError:
+        return "-"
+    except OSError:
+        return "unreadable"
+    stamp = _mtime(path)
+    if content:
+        return f'pending({stamp},"{content}")'
+    return f"pending({stamp})"
+
+
+def _seen_col(role):
+    path = SEEN_DIR / role
+    try:
+        h = path.read_text().strip()
+    except FileNotFoundError:
+        return "-"
+    except OSError:
+        return "unreadable"
+    return f"{h[:12]}({_mtime(path)})"
+
+
+def _projection_col(role):
+    path = PROJECTIONS_DIR / f"{role}.json"
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        return "-"
+    except (OSError, json.JSONDecodeError):
+        return "unreadable"
+    if isinstance(data, list):
+        return f"{len(data)} items @ ?"
+    if isinstance(data, dict):
+        generated = data.get("generated_at", "?")
+        count = sum(len(v) for v in data.values() if isinstance(v, list))
+        return f"{count} items @ {generated}"
+    return "unreadable"
+
+
+def _suppressed_col(role):
+    if role in NO_TRIGGER:
+        return "n/a"
+    marker = SEEN_DIR / f"{role}{SUPPRESS_SUFFIX}"
+    try:
+        exists = marker.exists()
+    except OSError:
+        return "unreadable"
+    return "yes" if exists else "no"
+
+
+roles = CANONICAL + _discover_extra_roles()
+width = max((len(r) for r in roles), default=0)
+for role in roles:
+    print(
+        f"{role:<{width}}  "
+        f"trigger={_trigger_col(role)}  "
+        f"seen={_seen_col(role)}  "
+        f"proj={_projection_col(role)}  "
+        f"empty-suppressed={_suppressed_col(role)}"
+    )
+PYEOF
+fi
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -176,6 +176,9 @@ Engine build / run (everyday dev)
   fleet-debug [--batch] <target-or-exe> [-- program-args...]
       Builds with fleet-build, cd's beside data/shaders/scripts, then starts
       lldb/gdb. Use --batch to run once and print all thread backtraces.
+  fleet-debug triggers
+      Read-only per-role dispatch-state dump (trigger / seen-hash / projection
+      slice / empty-suppression #2181). See "Parallel-agent fleet" below.
 
   fleet-run [--build-dir <dir>] [--timeout N] <exe-name> [args...]
       Finds the built binary under build/, cd's beside data/shaders/scripts.
@@ -212,6 +215,13 @@ Parallel-agent fleet (tmux + Claude)
                                  labels onto existing fleet:queued issues from
                                  their **Model:** body field
   fleet-state-scout              background GitHub/git poll → ~/.fleet/state/
+  fleet-debug triggers           read-only per-role dispatch-state dump: pending
+                                 trigger + mtime/content, last seen projection
+                                 hash, projection slice size + generated_at, and
+                                 whether the last hash write was an empty-
+                                 projection suppression (#2181). Diagnoses why a
+                                 role woke / didn't wake without hand-reading
+                                 ~/.fleet/state/{triggers,seen-hashes,projections}
   fleet-dispatcher               transient-claude dispatcher (worker panes)
   fleet-dispatch-wrap <pane> <model> <effort> <role> [fallback] [mode]
                                  runs one transient-role claude iteration;

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -2160,6 +2160,15 @@ def read_json_retry(path, attempts=3, backoff=0.05):
 def update_role_trigger(role: str, projection) -> bool:
     new_hash = stable_hash(projection)
     seen_file = SEEN_DIR / role
+    # Marker invariant: present iff the most recent hash *write* for this role
+    # was an empty-projection suppression. The on-disk state can't otherwise
+    # distinguish "suppressed" (hash advanced, trigger deliberately skipped)
+    # from "dispatched then consumed" (trigger touched, dispatcher rm'd it),
+    # so `fleet-debug triggers` reads this marker for its suppression column.
+    # Kept in SEEN_DIR beside the bare seen file; the ".empty-suppressed"
+    # suffix never collides with a role name, and nothing globs SEEN_DIR
+    # (roles are read by exact name).
+    suppressed_marker = SEEN_DIR / f"{role}.empty-suppressed"
     try:
         old_hash = seen_file.read_text().strip()
     except FileNotFoundError:
@@ -2183,8 +2192,14 @@ def update_role_trigger(role: str, projection) -> bool:
     # transition-to-empty edge (a post-drain cleanup sweep; ingest's
     # edge-triggered no-rearm contract).
     if not projection:
+        # This hash write was a suppression — record the marker. Never clear
+        # it on the hash-unchanged early return above (no hash was written
+        # there), or the "last hash write" semantics silently drift.
+        write_atomic(suppressed_marker, new_hash + "\n")
         return False
     (TRIGGERS_DIR / role).touch()
+    # A real (non-empty) fire supersedes any prior suppression.
+    suppressed_marker.unlink(missing_ok=True)
     return True
 
 

--- a/scripts/fleet/tests/test_fleet_debug_triggers.py
+++ b/scripts/fleet/tests/test_fleet_debug_triggers.py
@@ -1,0 +1,136 @@
+"""Tool-level tests for `fleet-debug triggers` (#2185).
+
+Runs the real bash script as a subprocess with HOME pointed at a fabricated
+~/.fleet/state tree, so the inline python heredoc reads the fixture instead of
+the live fleet state. Asserts: exit 0, one output line per role covering every
+column, graceful degradation on missing/torn projection files, and — the
+load-bearing property — that the dump writes NOTHING under the state tree.
+"""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "fleet-debug"
+
+
+def _snapshot(root):
+    # Map every file under root to (bytes, mtime_ns) so the test can prove the
+    # tool is read-only — a stray write, touch, or temp file all show up here.
+    out = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            st = path.stat()
+            out[str(path.relative_to(root))] = (path.read_bytes(), st.st_mtime_ns)
+    return out
+
+
+class FleetDebugTriggers(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+        self.state = self.home / ".fleet" / "state"
+        self.triggers = self.state / "triggers"
+        self.seen = self.state / "seen-hashes"
+        self.projections = self.state / "projections"
+        for d in (self.triggers, self.seen, self.projections):
+            d.mkdir(parents=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _run(self):
+        env = dict(os.environ)
+        env["HOME"] = str(self.home)
+        return subprocess.run(
+            ["bash", str(_SCRIPT), "triggers"],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+
+    def _write(self, path, text):
+        path.write_text(text)
+
+    def test_full_state_reports_every_role(self):
+        # A pending trigger with content, a suppressed role, a dict projection.
+        (self.triggers / "merger").write_text("llm\n")
+        self._write(self.seen / "worker", "caa618b4c02edc35\n")
+        self._write(self.seen / "merger", "69f1c07810ac0000\n")
+        self._write(self.seen / "worker.empty-suppressed", "caa618b4c02edc35\n")
+        self._write(
+            self.projections / "worker.json",
+            json.dumps({"tasks_open": [1, 2, 3], "needs_plan": [],
+                        "feedback_prs": [9], "generated_at": "2026-07-02T06:00:00Z"}),
+        )
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        lines = {ln.split()[0]: ln for ln in r.stdout.splitlines() if ln.strip()}
+        # All 8 canonical roles present.
+        for role in ("worker", "sonnet-reviewer", "opus-reviewer", "merger",
+                     "smoke-worker", "epic-steward", "queue-manager",
+                     "queue-manager-ingest"):
+            self.assertIn(role, lines)
+        # worker: suppressed marker present, 4 projection items, generated_at.
+        self.assertIn("empty-suppressed=yes", lines["worker"])
+        self.assertIn("4 items @ 2026-07-02T06:00:00Z", lines["worker"])
+        self.assertIn("caa618b4c02e", lines["worker"])
+        # merger: pending trigger with content, no suppression.
+        self.assertIn('pending(', lines["merger"])
+        self.assertIn('"llm"', lines["merger"])
+        self.assertIn("empty-suppressed=no", lines["merger"])
+        # queue-manager(-ingest): never get triggers/markers -> n/a.
+        self.assertIn("empty-suppressed=n/a", lines["queue-manager"])
+        self.assertIn("empty-suppressed=n/a", lines["queue-manager-ingest"])
+
+    def test_missing_and_torn_projections_degrade(self):
+        # worker projection absent; sonnet-reviewer projection is torn JSON.
+        self._write(self.projections / "sonnet-reviewer.json", "{ this is not json")
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        lines = {ln.split()[0]: ln for ln in r.stdout.splitlines() if ln.strip()}
+        self.assertIn("proj=-", lines["worker"])            # missing -> placeholder
+        self.assertIn("proj=unreadable", lines["sonnet-reviewer"])
+        self.assertIn("trigger=-", lines["worker"])          # missing trigger -> "-"
+        self.assertIn("seen=-", lines["worker"])             # missing seen -> "-"
+
+    def test_empty_state_tree_exits_zero(self):
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        # Still one line per canonical role even with an empty state tree.
+        roles = [ln.split()[0] for ln in r.stdout.splitlines() if ln.strip()]
+        self.assertEqual(len(roles), 8)
+
+    def test_discovers_unlisted_role(self):
+        # A future role's files should surface rather than hide.
+        self._write(self.seen / "future-role", "deadbeefdeadbeef\n")
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue(any(ln.startswith("future-role") for ln in r.stdout.splitlines()))
+
+    def test_marker_file_is_not_listed_as_a_role(self):
+        # `worker.empty-suppressed` must feed the worker's column, never appear
+        # as its own role line.
+        self._write(self.seen / "worker.empty-suppressed", "abc\n")
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        roles = [ln.split()[0] for ln in r.stdout.splitlines() if ln.strip()]
+        self.assertNotIn("worker.empty-suppressed", roles)
+
+    def test_read_only(self):
+        (self.triggers / "worker").write_text("\n")
+        self._write(self.seen / "worker", "caa618b4c02edc35\n")
+        self._write(self.seen / "worker.empty-suppressed", "caa618b4c02edc35\n")
+        self._write(
+            self.projections / "merger.json",
+            json.dumps({"prs": [1, 2], "generated_at": "2026-07-02T06:00:00Z"}),
+        )
+        before = _snapshot(self.state)
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        after = _snapshot(self.state)
+        self.assertEqual(before, after, "fleet-debug triggers mutated the state tree")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fleet/tests/test_role_trigger_empty.py
+++ b/scripts/fleet/tests/test_role_trigger_empty.py
@@ -12,6 +12,11 @@ iteration "no actionable candidates". The invariants:
   - empty -> non-empty change: fires normally (the recorded empty hash
     guarantees the flip back is seen as a change);
   - unchanged projection: no hash write, no trigger (pre-existing).
+
+An `<role>.empty-suppressed` marker in SEEN_DIR records whether the most
+recent hash write was such a suppression, so `fleet-debug triggers` (#2185)
+can report it — the on-disk state can't otherwise tell "suppressed" from
+"dispatched then consumed". The marker invariants are exercised below too.
 """
 import importlib.machinery
 import importlib.util
@@ -48,6 +53,9 @@ class UpdateRoleTriggerEmpty(unittest.TestCase):
     def _seen(self, role):
         return (_mod.SEEN_DIR / role).read_text().strip()
 
+    def _suppressed_marker(self, role):
+        return _mod.SEEN_DIR / f"{role}.empty-suppressed"
+
     def test_non_empty_change_fires(self):
         self.assertTrue(_mod.update_role_trigger("r", [{"pr": 1}]))
         self.assertTrue(self._trigger_exists("r"))
@@ -80,6 +88,39 @@ class UpdateRoleTriggerEmpty(unittest.TestCase):
         (_mod.TRIGGERS_DIR / "r").unlink()
         self.assertFalse(_mod.update_role_trigger("r", [{"pr": 1}]))
         self.assertFalse(self._trigger_exists("r"))
+
+    # --- empty-suppression marker (fleet-debug triggers reads it) ------------
+    # Invariant: the marker is present iff the most recent hash *write* for the
+    # role was an empty-projection suppression.
+
+    def test_non_empty_fire_leaves_no_marker(self):
+        _mod.update_role_trigger("r", [{"pr": 1}])
+        self.assertFalse(self._suppressed_marker("r").exists())
+
+    def test_transition_to_empty_writes_marker(self):
+        _mod.update_role_trigger("r", [{"pr": 1}])
+        (_mod.TRIGGERS_DIR / "r").unlink()  # dispatcher consumed it
+        _mod.update_role_trigger("r", [])
+        marker = self._suppressed_marker("r")
+        self.assertTrue(marker.exists())
+        self.assertEqual(marker.read_text().strip(), _mod.stable_hash([]))
+
+    def test_subsequent_non_empty_fire_clears_marker(self):
+        _mod.update_role_trigger("r", [{"pr": 1}])
+        (_mod.TRIGGERS_DIR / "r").unlink()
+        _mod.update_role_trigger("r", [])
+        self.assertTrue(self._suppressed_marker("r").exists())
+        _mod.update_role_trigger("r", [{"pr": 2}])
+        self.assertFalse(self._suppressed_marker("r").exists())
+
+    def test_unchanged_projection_leaves_marker_intact(self):
+        # The hash-unchanged early return writes no hash, so it must not touch
+        # the marker either — "last hash write" semantics would otherwise drift.
+        _mod.update_role_trigger("r", [{"pr": 1}])
+        (_mod.TRIGGERS_DIR / "r").unlink()
+        _mod.update_role_trigger("r", [])
+        self.assertFalse(_mod.update_role_trigger("r", []))  # unchanged empty
+        self.assertTrue(self._suppressed_marker("r").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a read-only `fleet-debug triggers` subcommand: one line per dispatch role (the 6 `DISPATCHED_ROLES` + queue-manager + queue-manager-ingest, plus any unlisted role discovered on disk) showing pending trigger (+ mtime/content), last seen projection hash + mtime, projection slice item-count + `generated_at`, and the empty-projection-suppression flag (#2181).
- Scout: `update_role_trigger` writes a `<role>.empty-suppressed` marker in `SEEN_DIR` on the suppression path and clears it on the next real (non-empty) fire — the one signal the on-disk state can't otherwise derive ("suppressed" vs "dispatched-then-consumed" look identical). queue-manager / queue-manager-ingest inline their own hash-compare with no suppression, so the tool reports `n/a` for them.
- The dump is read-only, degrades gracefully on missing/torn projection files (placeholder + exit 0), and lives inline in the bash script's `python3` heredoc — no new `fleet_*.py` module (module-resolution fragility, #1750/#1578).
- `fleet-help` index + `fleet-debug --help` document the subcommand.

## Notes
- The `## Plan` comment on #2185 tags Model: sonnet, but the issue's authoritative label is `fleet:opus`, which routed it to an opus iteration; implemented as opus.
- Marker kept in `SEEN_DIR` beside the bare seen file — the `.empty-suppressed` suffix never collides with a role name, and nothing globs `SEEN_DIR` (roles are read by exact name; verified across scout + dispatcher).

## Test plan
- [x] `python3 -m unittest scripts.fleet.tests.test_role_trigger_empty scripts.fleet.tests.test_fleet_debug_triggers` — 15/15 green (marker invariants: written on suppression, cleared on next fire, intact on hash-unchanged; tool-level: all-8-roles, missing/torn degradation, empty tree, unlisted-role discovery, marker-not-a-role, read-only state tree).
- [x] `fleet-debug triggers` run against live `~/.fleet/state` — one correct line per role.
- [x] `ruff check scripts/` clean; launcher path (`fleet-debug --help`, no-arg, build-target) unchanged.
- Pre-existing unrelated failure `test_epic_steward_projection.test_blocker_pr_not_stackable` reproduces on clean master; fixed by in-flight PR #2186.

Closes #2185

🤖 Generated with [Claude Code](https://claude.com/claude-code)