### PR TITLE
fleet: sonnet lightweight planning for mechanical (fleet:sonnet) tasks

### DIFF
--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -1,13 +1,14 @@
 ---
 name: role-worker
-description: Generic worker — class-routed (fable|opus|sonnet) task execution from the engine + game issue queues; plans fleet:needs-plan issues at opus class and above
+description: Generic worker — class-routed (fable|opus|sonnet) task execution from the engine + game issue queues; opus+ plans fleet:needs-plan issues, sonnet light-plans mechanical (fleet:sonnet) ones
 ---
 
 You are a **worker** agent for the Irreden Engine fleet, running in one
 of `~/src/IrredenEngine/.claude/worktrees/worker-*` (host can be WSL2
 Ubuntu or macOS). Your job is to **execute tasks of your class** from
-the GitHub issue queue (run `fleet-queue-list` to view), and — at opus
-class and above — **plan issues** flagged `fleet:needs-plan`.
+the GitHub issue queue (run `fleet-queue-list` to view), and **plan issues**
+flagged `fleet:needs-plan` — the opus+ classes plan design tasks, the sonnet
+class light-plans mechanical (`fleet:sonnet`-tagged) ones.
 
 The fleet runs **four worker panes** in parallel — they cooperate via
 `fleet-claim` (atomic locks) and open-PR cross-checks. Your job is
@@ -16,7 +17,8 @@ double-claiming the same task.
 
 You are NOT the architect. The architect is the human's interactive
 design partner. You handle the autonomous side: executing queued tasks,
-and (opus class and above) planning issues flagged `fleet:needs-plan`.
+and planning issues flagged `fleet:needs-plan` (opus+ for design tasks,
+sonnet for mechanical `fleet:sonnet`-tagged ones).
 
 Mode (optional argument): $ARGUMENTS
 
@@ -39,7 +41,7 @@ Class-conditional duties at a glance ("opus+" = opus or fable):
 | 1 — feedback tiers | `human:needs-fix` / `human:blocker` / `fleet:needs-fix` / `fleet:has-nits` | those + `fleet:design-unblocked` |
 | 1b — cross-host smoke | exit-code half (escalate visual judgment) | judgment half (inspect screenshots) |
 | 1c — semantic conflicts | skip | resolve one per iteration |
-| 2 — planning needs-plan | skip | plan the oldest entry |
+| 2 — planning needs-plan | light-plan the oldest `fleet:sonnet`-tagged entry | plan the oldest entry |
 | 3 — task pickup | `model` == `sonnet` | `model` == your class |
 | 8 — escalation | re-tag one class up | design-blocked flow / re-tag to fable |
 | 10 — optimize | only hot-path changes | almost always |
@@ -196,7 +198,8 @@ fleet-claim --repo game claim 45 worker-1
    in flight under another agent (the live "is this task already
    being worked" signal).
 5. Print a one-line summary: count of `fleet:needs-plan` entries
-   across both repos (opus+ classes only), count of unblocked
+   across both repos (all `fleet:sonnet`-tagged for the sonnet class; all
+   entries for opus+), count of unblocked
    unclaimed tasks of your class per repo (filter `tasks.open[]`
    where `model` contains your class, `owner == "free"`, and
    `blocked_by` resolves to merged work or `(none)`).
@@ -495,14 +498,24 @@ Do the work, then exit cleanly:
     push) and force-push retriggers CI — keep this step bounded to
     one PR per iteration.
 
-2. **[opus+ classes only] Plan any `fleet:needs-plan` issues on either
-   repo.** Sonnet-class iterations skip to step 3 — planning sets the
-   approach every downstream class executes, so it runs at opus class
-   or higher (`FLEET_ROLE_MODEL` is the signal; the dispatcher also
-   routes needs-plan dispatches to the opus class). The cached
-   `repos.engine.needs_plan[]` and `repos.game.needs_plan[]` arrays
-   hold the open needs-plan issues. Pick the oldest unprocessed entry
-   (smallest `number`) across both repos, then follow
+2. **Plan `fleet:needs-plan` issues on either repo.** Which entries you plan
+   depends on your class:
+   - **[opus+ classes]** Plan the oldest unprocessed entry (smallest `number`)
+     across both repos — the default, architect-tier path. Planning sets the
+     approach every downstream class executes, so it runs at opus class or
+     higher (`FLEET_ROLE_MODEL` is the signal; the dispatcher routes untagged
+     needs-plan dispatches to the fable/opus class).
+   - **[sonnet class]** Plan only the oldest entry that carries `fleet:sonnet`
+     (a **mechanical** task the human/architect judged bounded enough for a
+     lightweight plan). Write a thin `## Plan` comment, run `fleet-plan-lint
+     <N>`, and on pass **remove `fleet:needs-plan`** to self-queue (no
+     plan-review); on fail swap to `fleet:plan-review` for the opus safety net.
+     If no needs-plan issue is `fleet:sonnet`-tagged, skip to step 3. Full flow:
+     [PLANNING-PROTOCOL.md § Lightweight plan for mechanical (`fleet:sonnet`)
+     tasks](../../docs/agents/PLANNING-PROTOCOL.md#lightweight-plan-for-mechanical-fleetsonnet-tasks).
+
+   For the opus+ path, the cached `repos.engine.needs_plan[]` and
+   `repos.game.needs_plan[]` arrays hold the open needs-plan issues. Follow
    [docs/agents/PLANNING-PROTOCOL.md](../../docs/agents/PLANNING-PROTOCOL.md)
    — read the full thread (`fleet-issue view <N>`, add `--repo game`
    for game), acquire the planning claim (`fleet-claim planning-claim <N>

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -2,12 +2,20 @@
 
 The shared procedure for turning a `fleet:needs-plan` issue into a
 queue-ready task with a plan. Used by `role-worker.md` (which plans
-these autonomously as a scout-triggered step, at opus class or higher)
-and `role-opus-architect.md` (which plans them on request during a
+these autonomously as a scout-triggered step) and
+`role-opus-architect.md` (which plans them on request during a
 design conversation). Both point here rather than restating the flow.
 
-Sonnet-class iterations do not plan — planning runs at opus class or
-higher (`FLEET_ROLE_MODEL` is the signal).
+**Which class plans depends on the issue.** By default planning is
+architect-tier design work and runs at **opus class or higher**
+(`FLEET_ROLE_MODEL` is the signal) — that is the flow described below. The
+exception is a **mechanical** task the human/architect has tagged
+`fleet:sonnet`: the sonnet lane authors a *lightweight* plan for it and
+self-queues, skipping both the opus/fable planning pass and the opus
+plan-review pass. See [§ Lightweight plan for mechanical (`fleet:sonnet`)
+tasks](#lightweight-plan-for-mechanical-fleetsonnet-tasks). Everything in
+"The flow" below is the default (opus+) path unless that section says
+otherwise.
 
 **The plan is a comment, not a PR.** The canonical plan artifact is a
 structured `## Plan` **comment on the issue** — host-independent, so a
@@ -337,6 +345,59 @@ approved issue unless a `## Plan` comment exists OR the issue is opted out
 (`human:no-plan` / `[no-plan]` / `investigation spike`), and otherwise bounces
 it to `fleet:needs-plan`. Labeling an unplanned build task `human:approved` no
 longer queues it.
+
+---
+
+## Lightweight plan for mechanical (`fleet:sonnet`) tasks
+
+Most planning is architect-tier design work and runs at opus class or higher.
+But a **mechanical** task — one whose plan "basically is the issue itself" (a
+localized rename, a well-scoped doc/test change, a mechanical refactor with no
+design choice to make) — does not need a fable/opus planning pass *or* an opus
+plan-review pass. For those, the **sonnet lane light-plans and self-queues**.
+
+**Eligibility is a human/architect signal, not a heuristic.** The issue must
+carry the `fleet:sonnet` label on top of `fleet:needs-plan`. Applying
+`fleet:sonnet` to a needs-plan issue is the human's (or architect's) judgment
+that the task is mechanical and bounded — the same judgment `human:review-plan`
+inverts for high-stakes work. Do **not** self-tag an issue `fleet:sonnet` to
+take this path; if it isn't already tagged, it plans on the default (opus+)
+flow. The dispatcher routes a `fleet:sonnet`-tagged needs-plan issue to the
+sonnet lane automatically (`fleet_task_class._plan_class`).
+
+**[worker, sonnet class]** For the oldest `fleet:sonnet`-tagged needs-plan
+issue:
+
+1. **Claim it** — `fleet-claim planning-claim <N> <your-agent-name>` (same lock
+   as the opus path; skip if a `## Plan` comment already exists or exit 3).
+2. **Read the thread** (`fleet-issue view <N>`). A mechanical task needs the
+   issue read, not a deep code investigation — if you find yourself needing a
+   cross-system audit or a repro spike to write the plan, it is **not**
+   mechanical: fall through to the lint-fail branch below.
+3. **Post a lightweight `## Plan` comment.** Same `## Plan:` heading the gate
+   keys on, but thin — `**Model:** sonnet`, a one-line **Scope**, an
+   **Approach** that is essentially "implement as the issue describes" plus the
+   concrete file(s)/edit, an **Affected files** list, and **Acceptance
+   criteria**. Skip the cross-system audit and the deep premise/repro section
+   unless the mechanical change obviously needs one.
+4. **Run `fleet-plan-lint <N>`** (deterministic; `--repo game` for game issues):
+   - **exit 0** → the plan is structurally sound. **Remove `fleet:needs-plan`**
+     (do **not** add `fleet:plan-review`) and release the claim. The scout's
+     ingest queues it on the next tick — the `## Plan` comment is present,
+     `human:approved` persists, and no gate label remains. The impl PR still
+     gets a normal **code** review; only the **plan** review is skipped.
+   - **exit 1** → the task wasn't mechanical enough to light-plan (a deferred
+     approach, missing core sections). Swap `fleet:needs-plan →
+     fleet:plan-review` and release the claim, handing it to the opus
+     plan-review safety net (step 4 of "The flow"), which either blesses the
+     thin plan or bounces it back to `fleet:needs-plan` with gaps for a proper
+     opus re-plan.
+
+This path never touches the fable or opus class: a genuinely mechanical task is
+planned and implemented entirely on the sonnet lane. If a `fleet:sonnet` task
+turns out to need design judgment, the lint-fail branch (or the implementing
+worker's own escalation, `fleet:design-blocked`) routes it back to opus+ — the
+tag is a starting hypothesis, not a one-way door.
 
 ---
 

--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -386,12 +386,23 @@ issue:
      ingest queues it on the next tick — the `## Plan` comment is present,
      `human:approved` persists, and no gate label remains. The impl PR still
      gets a normal **code** review; only the **plan** review is skipped.
+     ```
+     gh issue edit <N> --repo <owner/repo> --remove-label "fleet:needs-plan"
+     fleet-claim planning-release <N> <your-agent-name>
+     ```
    - **exit 1** → the task wasn't mechanical enough to light-plan (a deferred
      approach, missing core sections). Swap `fleet:needs-plan →
      fleet:plan-review` and release the claim, handing it to the opus
      plan-review safety net (step 4 of "The flow"), which either blesses the
      thin plan or bounces it back to `fleet:needs-plan` with gaps for a proper
      opus re-plan.
+     ```
+     gh issue edit <N> --repo <owner/repo> \
+       --remove-label "fleet:needs-plan" --add-label "fleet:plan-review"
+     fleet-claim planning-release <N> <your-agent-name>
+     ```
+     (`<owner/repo>` and the `--repo game` variant for `fleet-claim` follow the
+     same convention as step 3 above.)
 
 This path never touches the fable or opus class: a genuinely mechanical task is
 planned and implemented entirely on the sonnet lane. If a `fleet:sonnet` task

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -233,11 +233,16 @@ def _candidates(slice_data, lane_default, host, fable_blocked=False):
     but a `fleet:sonnet`-tagged (mechanical) needs-plan issue is a light plan
     the sonnet lane authors, while everything else is architect-tier design
     planning (fable, or opus when the fable cap is saturated). Yielding one
-    per class, oldest-first, lets the dispatcher's cross-class fan-out serve a
-    mechanical light-plan on the sonnet lane at the same time the fable/opus
-    lane plans the heavy ones, without ever fanning out colliding planners of
-    the same class. See `_plan_class` and PLANNING-PROTOCOL.md §"Lightweight
-    plan for mechanical (fleet:sonnet) tasks".
+    per class lets the dispatcher's cross-class fan-out serve a mechanical
+    light-plan on the sonnet lane at the same time the fable/opus lane plans
+    the heavy ones, without ever fanning out colliding planners of the same
+    class. Iteration order is oldest-within-each-repo, engine-repo-first —
+    not a true global sort by issue number — because `slice_worker()` in
+    `fleet-state-scout` appends all of `repos.engine.needs_plan[]` before any
+    of `repos.game.needs_plan[]` (same pre-existing composition order
+    `tasks_open`/`feedback_prs` already inherit above). See `_plan_class` and
+    PLANNING-PROTOCOL.md §"Lightweight plan for mechanical (fleet:sonnet)
+    tasks".
     """
     def _class_effort(task):
         cls = (task.get("model") or lane_default).lower()

--- a/scripts/fleet/fleet_task_class.py
+++ b/scripts/fleet/fleet_task_class.py
@@ -20,11 +20,13 @@ Resolution order mirrors the worker role docs' pickup priority:
   2. open tasks     — the oldest claimable task's class (slices are sorted
                       by issue number; ``model`` comes from the
                       fleet:fable/opus/sonnet labels via the scout).
-  3. needs_plan     — planning prefers the fable class (planning IS the
-                      architect-tier design work — the same reason the
-                      architect panes run fable), falling back to opus when
-                      the fable cap is saturated so planning never stalls
-                      behind a long fable implementation iteration.
+  3. needs_plan     — a `fleet:sonnet`-tagged needs-plan issue is a MECHANICAL
+                      task the sonnet lane light-plans and self-queues (see
+                      `_plan_class`); every other needs-plan issue is
+                      architect-tier design work that prefers the fable class
+                      (the same reason the architect panes run fable), falling
+                      back to opus when the fable cap is saturated so planning
+                      never stalls behind a long fable implementation iteration.
 
 Effort: the task's ``**Effort:**`` field when present (scout validates it),
 else the class default below.
@@ -192,6 +194,28 @@ def feedback_pr_class(labels):
     return "sonnet"
 
 
+def _plan_class(issue, fable_blocked):
+    """Model class that should author this needs-plan issue's plan.
+
+    A `fleet:sonnet`-tagged needs-plan issue is a MECHANICAL task the
+    human/architect judged bounded enough for a lightweight plan — the sonnet
+    lane authors a thin `## Plan` comment ("basically the issue itself") and
+    self-queues on `fleet-plan-lint` pass (PLANNING-PROTOCOL.md §"Lightweight
+    plan for mechanical (fleet:sonnet) tasks"), skipping BOTH the fable/opus
+    planning pass and the opus plan-review pass. Stakes are a human signal —
+    `fleet:sonnet` on a needs-plan issue IS that signal — so there is nothing
+    to compute here; the label is authoritative.
+
+    Everything else is architect-tier design planning: fable while the cap has
+    headroom, degrading to opus when it is saturated (`fable_blocked`). The
+    downgrade is pre-resolved here (never yields a cap-blocked `fable`) exactly
+    as the prior single-class needs_plan election did.
+    """
+    if "fleet:sonnet" in (issue.get("labels") or []):
+        return "sonnet"
+    return "opus" if fable_blocked else "fable"
+
+
 def _candidates(slice_data, lane_default, host, fable_blocked=False):
     """Yield (class, effort) for each actionable item, pickup-priority order.
 
@@ -202,14 +226,18 @@ def _candidates(slice_data, lane_default, host, fable_blocked=False):
     actually picks up, and one yield per item lets the caller count claimable
     work per class for the dispatcher's fan-out cap.
 
-    needs_plan yields once regardless of how many issues await planning: the
-    lane plans one at a time — the next planner fires after the first posts its
+    needs_plan yields once PER PLANNING CLASS, not once per issue: the lane
+    plans one at a time — the next planner fires after the first posts its
     `## Plan` comment (the planning-claim label lock plus the comment-presence
-    early-out make a same-tick sibling a cheap no-op, not a duplicate plan).
-    Planning is architect-tier design work, so it prefers fable and degrades
-    to opus when the fable cap is already saturated (`fable_blocked`) — the
-    downgrade is resolved here, at election time, so a capped fable never
-    leaves planning stuck behind the `skipped_fable` defer path.
+    early-out make a same-tick sibling a cheap no-op, not a duplicate plan) —
+    but a `fleet:sonnet`-tagged (mechanical) needs-plan issue is a light plan
+    the sonnet lane authors, while everything else is architect-tier design
+    planning (fable, or opus when the fable cap is saturated). Yielding one
+    per class, oldest-first, lets the dispatcher's cross-class fan-out serve a
+    mechanical light-plan on the sonnet lane at the same time the fable/opus
+    lane plans the heavy ones, without ever fanning out colliding planners of
+    the same class. See `_plan_class` and PLANNING-PROTOCOL.md §"Lightweight
+    plan for mechanical (fleet:sonnet) tasks".
     """
     def _class_effort(task):
         cls = (task.get("model") or lane_default).lower()
@@ -227,9 +255,13 @@ def _candidates(slice_data, lane_default, host, fable_blocked=False):
     for task in tasks:
         if _task_claimable(task, host) and task.get("blocked"):
             yield _class_effort(task)
-    if slice_data.get("needs_plan"):
-        cls = "opus" if fable_blocked else "fable"
-        yield cls, CLASS_DEFAULT_EFFORT[cls]
+    seen_plan_classes = set()
+    for issue in slice_data.get("needs_plan") or []:
+        pcls = _plan_class(issue, fable_blocked)
+        if pcls in seen_plan_classes:
+            continue
+        seen_plan_classes.add(pcls)
+        yield pcls, CLASS_DEFAULT_EFFORT[pcls]
 
 
 def resolve(slice_data, lane_default, fable_blocked, exclude=()):

--- a/scripts/fleet/tests/test_fleet_task_class.py
+++ b/scripts/fleet/tests/test_fleet_task_class.py
@@ -207,6 +207,38 @@ class TaskResolution(unittest.TestCase):
                       "opus", fable_blocked=False)
         self.assertEqual(out, "fable xhigh 0 1")
 
+    def test_needs_plan_sonnet_tagged_routes_sonnet(self):
+        # A `fleet:sonnet`-tagged needs-plan issue is MECHANICAL: the sonnet
+        # lane light-plans it (PLANNING-PROTOCOL.md §"Lightweight plan") instead
+        # of burning fable/opus. Sonnet default effort (high), count=1.
+        out = resolve({"needs_plan": [{"number": 99, "labels": ["fleet:sonnet"]}]},
+                      "opus", fable_blocked=False)
+        self.assertEqual(out, "sonnet high 0 1")
+
+    def test_needs_plan_untagged_still_prefers_fable(self):
+        # No fleet:sonnet tag -> architect-tier design planning, unchanged.
+        out = resolve({"needs_plan": [{"number": 99, "labels": ["render"]}]},
+                      "opus", fable_blocked=False)
+        self.assertEqual(out, "fable xhigh 0 1")
+
+    def test_needs_plan_mixed_classes_elects_oldest_and_flags_more(self):
+        # Oldest plannable issue is the sonnet-tagged mechanical one, so the
+        # lane elects sonnet; the untagged (design-tier) issue keeps a fable
+        # candidate alive -> more=1 so the dispatcher's cross-class fan-out
+        # serves it on the fable/opus lane the same tick.
+        out = resolve({"needs_plan": [
+            {"number": 99, "labels": ["fleet:sonnet"]},
+            {"number": 100, "labels": ["render"]},
+        ]}, "opus", fable_blocked=False)
+        self.assertEqual(out, "sonnet high 1 1")
+
+    def test_needs_plan_sonnet_tagged_unaffected_by_fable_cap(self):
+        # A saturated fable cap downgrades DESIGN-tier planning to opus, but a
+        # mechanical sonnet light-plan is a sonnet-lane job regardless.
+        out = resolve({"needs_plan": [{"number": 99, "labels": ["fleet:sonnet"]}]},
+                      "opus", fable_blocked=True)
+        self.assertEqual(out, "sonnet high 0 1")
+
     def test_design_unblocked_feedback_resolves_opus(self):
         # The engine #1885 shape: a design-unblocked PR is the top feedback
         # item, every open task is parked/blocked, and opus needs_plan sits


### PR DESCRIPTION
## What

Lets the **sonnet lane light-plan mechanical tasks** instead of burning the two most expensive tiers on them.

Planning always ran at `fable`→`opus` at `xhigh` effort (`fleet_task_class.py` elected fable/opus for *every* `needs-plan` issue; `PLANNING-PROTOCOL.md` forbade sonnet from planning at all). So a mechanical task whose own plan concludes `Model: sonnet` still got a premium xhigh planning pass **and** an opus plan-review pass before any code — two premium passes for a task the fleet already judged bounded.

## How

A `fleet:needs-plan` issue tagged **`fleet:sonnet`** is the human/architect's "this is mechanical" signal (stakes are not computed in code — `human:review-plan` is the human's high-stakes hold, so `fleet:sonnet` is its low-stakes counterpart). For those:

1. `fleet_task_class._plan_class` routes the issue to the **sonnet** lane (default `high` effort) instead of fable/opus.
2. The sonnet worker writes a thin `## Plan` comment ("basically the issue itself"), runs the deterministic **`fleet-plan-lint`**, and:
   - **pass →** removes `fleet:needs-plan` to self-queue — **no** fable/opus planning pass, **no** opus plan-review pass. The impl PR still gets a normal *code* review; only *plan* review is skipped.
   - **fail →** swaps to `fleet:plan-review` (the task wasn't mechanical enough), handing it to the existing opus safety net.

Untagged needs-plan issues keep the fable→opus design-tier path **unchanged**.

## Design notes

- `_candidates` now yields **one candidate per planning class** (oldest-first), so the dispatcher's existing cross-class fan-out can serve a mechanical light-plan on the sonnet lane while fable/opus plans the heavy ones — no colliding same-class planners (the `planning-claim` lock still guards same-issue races).
- No `fleet-plan-lint` change needed: it already accepts thin plans (hard-fails only on missing `## Plan` / deferred-approach / ≥2 missing core sections).
- Eligibility is a deliberate human signal — a worker must **not** self-tag `fleet:sonnet` to take the cheap path.

## Files

- `scripts/fleet/fleet_task_class.py` — `_plan_class` + per-class needs_plan election
- `docs/agents/PLANNING-PROTOCOL.md` — new "Lightweight plan for mechanical (fleet:sonnet) tasks" section
- `.claude/commands/role-worker.md` — step-2 sonnet light-plan branch (gated self-config)
- `scripts/fleet/tests/test_fleet_task_class.py` — 4 new cases

## Test

`python3 -m unittest scripts.fleet.tests.test_fleet_task_class` → 42 pass (38 pre-existing unchanged = backward-compatible). `test_dispatcher_class_dispatch.sh` → 10/10.

> Touches gated self-config (`role-worker.md`) — human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)