### PR TITLE
docs: planning-claim lock shipped — drop stale "until it ships" contract

### DIFF
--- a/docs/agents/PLANNING-PROTOCOL.md
+++ b/docs/agents/PLANNING-PROTOCOL.md
@@ -30,18 +30,18 @@ reviewed artifact.
 
 For each `fleet:needs-plan` issue:
 
-0. **Claim the issue before planning.** Acquire a `fleet-claim`-style lock on
-   the `fleet:needs-plan` issue, and **skip it if a `## Plan` comment already
-   exists on it** (someone planned it on a prior tick) or if an open PR already
-   names it. Without an atomic claim, two opus panes that select the same oldest
+0. **Claim the issue before planning.** Take the planning lock —
+   `fleet-claim planning-claim <N> <your-agent-name>` — and **skip the issue if
+   it exits non-zero**: exit 3 means a `## Plan` comment already exists (someone
+   planned it on a prior tick), and exit 1 means another pane holds the lock.
+   Without an atomic claim, two opus panes that select the same oldest
    needs-plan issue on one scout tick both see no plan yet and both plan it
    (#1810 produced **three** duplicate plans for one issue — three wasted plan
    rounds). A comment cross-check alone doesn't close the same-tick race (both
    planners pass it before either posts a comment); the atomic claim does. (The
-   claim/dedup enforcement is fleet tooling — `fleet-claim planning-claim`,
-   landing with the re-scoped #1889; until it ships, honor this contract
-   manually.) **Re-planning an already-planned task** that went stale has its
-   own guarded flow — see [§ Re-planning a stale queued plan](#re-planning-a-stale-queued-plan).
+   claim/dedup lock shipped in #1978/#2035 — the re-scope of #1889; use it, do
+   not hand-roll the check.) **Re-planning an already-planned task** that went
+   stale has its own guarded flow — see [§ Re-planning a stale queued plan](#re-planning-a-stale-queued-plan).
 
 1. **Read the full issue thread** — title, body, and every comment.
    The plan is often seeded in a comment, and the human may have left
@@ -157,7 +157,7 @@ For each `fleet:needs-plan` issue:
    ```
    gh issue edit <N> --repo <owner/repo> \
      --remove-label "fleet:needs-plan" --add-label "fleet:plan-review"
-   fleet-claim planning-release <N> <your-agent-name>   # once re-scoped #1889 lands
+   fleet-claim planning-release <N> <your-agent-name>
    ```
    (`<owner/repo>` is `jakildev/IrredenEngine` for engine issues or
    `jakildev/irreden` for game issues — the repo where the issue lives, not your


### PR DESCRIPTION
## What

`PLANNING-PROTOCOL.md` step 0 and step 3 still describe the `fleet-claim planning-claim` lock as unshipped:

> *"the claim/dedup enforcement is fleet tooling — `fleet-claim planning-claim`, landing with the re-scoped #1889; until it ships, honor this contract manually."*
> `fleet-claim planning-release <N> <agent>   # once re-scoped #1889 lands`

It **shipped** in #1978 / #2035 (`cmd_planning_claim` is live in `fleet-claim`).

## Why it matters

A planner reading "until it ships, honor this contract manually" may skip `planning-claim` and fall back to an eyeball `## Plan`-comment check — which does **not** close the same-tick race (both planners pass the check before either posts a comment). That is exactly the #1810 failure the lock exists to prevent (it produced three duplicate plans for one issue).

## Change

Doc-only. Step 0 now points at the real command and its exit codes (3 = plan already exists → skip; 1 = another pane holds the lock → skip); the step-3 release snippet drops the stale `# once #1889 lands` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)