### PR TITLE
engine/script: add VEC4/QUAT LuaFieldType for Lua-defined components

### DIFF
--- a/.fleet/plans/issue-2163.md
+++ b/.fleet/plans/issue-2163.md
@@ -1,0 +1,112 @@
+# Plan: lua-ecs — add VEC4/QUAT LuaFieldType so EVAL systems can write quaternion fields
+
+- **Issue:** #2163
+- **Model:** opus
+- **Date:** 2026-07-01
+- **Blocked by:** (none)
+
+### Scope
+
+Add a native `VEC4` column type to `LuaFieldType` so a **Lua-defined**
+component can declare a `vec4`/quaternion field that EVAL systems read and
+write with no C++ shim. Quaternions are stored as `IRMath::vec4(qx,qy,qz,qw)`
+engine-wide (there is no distinct `IRMath::quat` type — `IRMath::vec4 =
+glm::vec4`, and `C_LocalTransform.rotation_` is itself an `IRMath::vec4`), so
+`quat`/`quaternion` become **tag aliases for the same VEC4 column** with an
+identity default, not a second storage type.
+
+### Premise correction (authoritative reading, per architect sign-off)
+
+The issue's motivating example — writing `C_LocalTransform.rotation_` from a
+Lua EVAL tick — is served by a **different mechanism** than this task and is
+**not fixed by adding a LuaFieldType**:
+
+- `C_LocalTransform` is a **C++-defined** component. EVAL systems reach C++
+  components through `LuaCppColumnView` (`at`/`setAt`), built by `registerType<T>`
+  (`recordComponentLuaName` in `lua_script.hpp`). The `LuaFieldType` machinery
+  in `lua_component_data.hpp` only covers **Lua-defined** components
+  (`IComponentDataLuaTyped`).
+
+So this task delivers the literal title ask (a `vec4`/`quat` field type usable
+by **Lua-defined** components) and is independently valuable. It does **not**,
+by itself, make `C_LocalTransform.rotation_` writable from a Lua EVAL tick —
+that C++-component field is reached through a different binding path, so any
+downstream C++ facing→rotation shim is unaffected. Exposing
+`C_LocalTransform.rotation_` on the C++-component Lua binding is a **separate
+follow-up** (a `registerType`/`LuaCppColumnView` ergonomics question), filed
+unlabeled per TASK-FILING.md as part of the plan triage.
+
+### Approach (single, committed)
+
+**One `LuaFieldType::VEC4` column** storing `IRMath::vec4`. Accept the explicit
+tags `vec4`, `quat`, and `quaternion`, all resolving to `VEC4`. Use the
+existing `quatFromLua()` (identity `(0,0,0,1)` default for nil/partial input)
+as the uniform column converter — the primary consumer is rotation, so identity
+is the correct default.
+
+**Why not a distinct `QUAT` type/variant:** a quaternion and a `vec4` are the
+*same* C++ storage (`IRMath::vec4`). A second `std::visit` variant of an
+identical type can't be disambiguated by the `if constexpr
+(std::is_same_v<Elem, IRMath::vec4>)` dispatch the column machinery uses; the
+only behavioral difference (nil-default = identity vs zero) is resolvable at the
+shared column by choosing the quat-identity default. The `quat`/`quaternion`
+semantics live in the **tag** (register-time), not a redundant storage type.
+
+Steps, in order:
+
+1. `engine/script/include/irreden/script/lua_component_data.hpp` (7 sites)
+   - Add `VEC4` to the `LuaFieldType` enum (after `IVEC3`).
+   - `toString` case (`"vec4"`).
+   - Append `std::vector<IRMath::vec4>` as a new `LuaFieldColumn` variant
+     alternative (keep the 1:1 enum↔variant ordering).
+   - `detail::makeEmptyColumn`: `VEC4 → std::vector<IRMath::vec4>{}`.
+   - `detail::columnAppendDefault`: `if constexpr (std::is_same_v<Elem,
+     IRMath::vec4>)` → `v.push_back(quatFromLua(defaultValue))`.
+   - `writeFieldAt`: vec4 branch accepting an `{x,y,z,w}` table or
+     `IRMath::vec4` userdata via `quatFromLua`.
+   - `readFieldAt`: distinct vec4 branch surfacing `{ x, y, z, w }` (mirror the
+     vec3 `{x,y,z}` shape, add `w`).
+   - The generic move/copy/swap/size helpers are type-generic — no per-type case.
+2. `engine/script/src/lua_script.cpp`
+   - `parseExplicitTypeTag`: map `"vec4"`, `"quat"`, `"quaternion"` → `VEC4`.
+   - Update the unknown-tag error string to list `vec4`.
+   - `inferTypeFromDefault`: `if (value.is<IRMath::vec4>()) return VEC4;`
+     (symmetric with the vec3/ivec3 userdata branches; a bare `{x,y,z,w}` table
+     still requires the explicit tag).
+   - **Do not** add `VEC4` to `isModifierTargetable` — it stays
+     `INT32|FLOAT|BOOL`; `VEC4` falls through to `kInvalidFieldId` like vec3.
+3. `test/script/lua_component_register_test.cpp`
+   - Retarget the existing unknown-tag test: `type = 'quaternion'` is now valid,
+     so change the tag to a still-unknown one (`'mat4'`) and its assertion.
+   - Add a `Vec4AndQuatFieldsStoreAsNativeColumnAndRoundTrips` test mirroring
+     `Vec3AndIvec3FieldsStoreAsNativeColumnsAndRoundTrip`: `quat`/`vec4`/omitted
+     fields materialize as `std::vector<IRMath::vec4>`, round-trip through
+     write/read as `{x,y,z,w}`, and an omitted default resolves to identity
+     `(0,0,0,1)`. Add a not-modifier-targetable assertion for `quat`.
+4. `engine/script/CLAUDE.md` — document the `vec4`/`quat`/`quaternion` EVAL
+   field type; note it is EVAL-only (CODEGEN still errors on the tag, same
+   status as `vec2`).
+
+### Acceptance criteria
+
+- A Lua-defined component with `type = 'vec4'` / `'quat'` / `'quaternion'`
+  fields stores a native `std::vector<IRMath::vec4>` column (no `sol::table`
+  fallback).
+- Reads surface as `{x,y,z,w}` tables; writes accept an `{x,y,z,w}` /
+  `{1,2,3,4}` table or an `IRMath::vec4` userdata.
+- Omitted/partial default resolves to identity `(0,0,0,1)`.
+- Archetype move/copy/remove preserve vec4 column values (generic helpers).
+- The script test target builds; the new + retargeted tests pass. No change to
+  `isModifierTargetable`.
+
+### Gotchas
+
+- The `'quaternion'` unknown-tag test WILL silently false-pass if not
+  retargeted — it would assert an error that no longer occurs.
+- `columnAppendDefault` and `writeFieldAt` have `if constexpr` chains with no
+  final else: an unmatched `IRMath::vec4` element silently no-ops. The vec4
+  branch is mandatory in both.
+- Keep the enum↔variant ordering 1:1; append `VEC4` at the end of both.
+- `readFieldAt` needs a *distinct* vec4 branch (not folded into the vec3/ivec3
+  branch) — vec4 surfaces a 4-key `{x,y,z,w}` table.
+- Engine-public artifact: keep terminology engine-only (no game feature names).

--- a/engine/script/CLAUDE.md
+++ b/engine/script/CLAUDE.md
@@ -145,9 +145,10 @@ IREntity.setLuaField(rules, C_Hp, C_Hp.fields.current.index, 100)
   rejected. Use the explicit `{ type = "...", default = ... }` form to
   disambiguate (`current = { type = "float", default = 100 }`), to opt
   in to opaque table storage (`payload = { type = "table", default = {} }`),
-  or to declare a packed `vec3` / `ivec3` field (`pos = { type = "vec3",
-  default = { x = 0, y = 0, z = 0 } }` — see "Packed vec3 / ivec3 fields"
-  below).
+  or to declare a packed `vec3` / `ivec3` / `vec4` field (`pos = { type =
+  "vec3", default = { x = 0, y = 0, z = 0 } }` — see "Packed vec3 / ivec3 /
+  vec4 fields" below; `quat` / `quaternion` are register-time aliases for a
+  `vec4` column, EVAL-only for now).
 - **Identity rule:** registering the same `name` twice raises a Lua error.
   C++ and Lua share one `ComponentId` space (`EntityManager::registerComponentDynamic`
   goes through the same component-id allocator).
@@ -165,11 +166,11 @@ IREntity.setLuaField(rules, C_Hp, C_Hp.fields.current.index, 100)
   etc., per field type). Reading or writing a field is a typed vector index —
   never a per-frame `sol::table` lookup.
 
-### Packed vec3 / ivec3 fields (#1368, design G1a)
+### Packed vec3 / ivec3 / vec4 fields (#1368, design G1a; #2163 vec4/quat)
 
-A field can declare a packed `vec3` / `ivec3` kind instead of hand-flattening
-to `_x/_y/_z` scalars. Declared via the explicit-tag form with an `{ x, y, z }`
-(or positional `{ 1, 2, 3 }`) default:
+A field can declare a packed `vec3` / `ivec3` / `vec4` kind instead of
+hand-flattening to `_x/_y/_z` scalars. Declared via the explicit-tag form with
+an `{ x, y, z }` (or positional `{ 1, 2, 3 }`) default:
 
 ```lua
 local C_Body = IRComponent.register("Body", {
@@ -185,6 +186,19 @@ local C_Body = IRComponent.register("Body", {
   `{ x, y, z }` table **or** an `IRMath::vec3` userdata. The friendly read
   allocates a 3-key table per call — fine for setup/inspection, not a per-tick
   hot path; a zero-alloc hot path uses three scalar fields instead.
+- **`vec4` / `quat` / `quaternion` (EVAL, #2163).** All three tags declare one
+  `std::vector<IRMath::vec4>` column — a quaternion is a `vec4`
+  engine-wide (`IRMath::vec4 = glm::vec4(qx,qy,qz,qw)`, `.w` the scalar), so
+  `quat` / `quaternion` are register-time aliases of `vec4`, not a second
+  storage type. Reads surface as an `{ x, y, z, w }` table; writes accept an
+  `{ x, y, z, w }` / `{ 1, 2, 3, 4 }` table **or** an `IRMath::vec4` userdata.
+  An omitted or partial default resolves to the identity quat `(0, 0, 0, 1)`
+  via `quatFromLua` (not the zero-vec that `vec3` defaults to) — the correct
+  default for the primary rotation consumer; a plain-`vec4` author passes an
+  explicit 4-element default. **EVAL-only:** the CODEGEN tool does not yet emit
+  a `vec4` struct member, so a `vec4` / `quat` field in a CODEGEN `.lua` still
+  errors as an unknown tag (same status as `vec2`); keep such a component in
+  `mode = "eval"`.
 - **CODEGEN** emits a real `IRMath::vec3` / `ivec3` struct member. Inside a
   CODEGEN tick body, read a packed field's components with `.x` / `.y` / `.z`
   and build a fresh value with the `vec3.new(x, y, z)` / `ivec3.new(x, y, z)`
@@ -200,10 +214,10 @@ local C_Body = IRComponent.register("Body", {
   scalar `int32` / `float` / `bool` fields auto-register a modifier binding.
   For modifier-driven vec3 offsets use the modifier framework's typed vec3
   fields (`IRModifier.registerFieldVec3`), not a component field binding.
-- **Out of scope:** `vec2` / `quat` (same mechanism, deferred until needed)
-  and variable-length array fields (G1b: a bounded `"float[K]"` inline-array,
-  or engine-owned data for genuinely ragged lists — see
-  `docs/design/lua-driven-ecs.md`).
+- **Out of scope:** `vec2` (same mechanism, deferred until needed), CODEGEN
+  emission for `vec4` / `quat` (EVAL-only above), and variable-length array
+  fields (G1b: a bounded `"float[K]"` inline-array, or engine-owned data for
+  genuinely ragged lists — see `docs/design/lua-driven-ecs.md`).
 
 ### Two-tier accessor contract
 
@@ -302,7 +316,7 @@ field types and both the short form (`current = 100`) and the explicit-type
 form (`current = { type = "float", default = 100 }`). Packed `vec3` / `ivec3`
 fields require the explicit-tag form with an `{ x, y, z }` default (the codegen
 tool has no `vec3` usertype to infer from a short-form value) and lower to real
-`IRMath::vec3` / `ivec3` struct members — see "Packed vec3 / ivec3 fields"
+`IRMath::vec3` / `ivec3` struct members — see "Packed vec3 / ivec3 / vec4 fields"
 above for the tick-body `.x/.y/.z` + `vec3.new` DSL surface.
 
 **EVAL-only (codegen-time error if used in CODEGEN):** `table` and

--- a/engine/script/include/irreden/script/lua_component_data.hpp
+++ b/engine/script/include/irreden/script/lua_component_data.hpp
@@ -43,6 +43,7 @@ enum class LuaFieldType : std::uint8_t {
     TABLE,    // explicit opt-in only; pays per-access sol::table cost
     VEC3,     // IRMath::vec3 — packed 3-float field (G1a, docs/design/lua-driven-ecs.md)
     IVEC3,    // IRMath::ivec3 — packed 3-int field
+    VEC4,     // IRMath::vec4 — packed 4-float field; also the quat/quaternion tag alias
 };
 
 inline const char *toString(LuaFieldType t) {
@@ -63,6 +64,8 @@ inline const char *toString(LuaFieldType t) {
         return "vec3";
     case LuaFieldType::IVEC3:
         return "ivec3";
+    case LuaFieldType::VEC4:
+        return "vec4";
     }
     return "?";
 }
@@ -84,7 +87,8 @@ using LuaFieldColumn = std::variant<
     std::vector<sol::function>,
     std::vector<sol::table>,
     std::vector<IRMath::vec3>,
-    std::vector<IRMath::ivec3>>;
+    std::vector<IRMath::ivec3>,
+    std::vector<IRMath::vec4>>;
 
 namespace detail {
 
@@ -106,6 +110,8 @@ inline LuaFieldColumn makeEmptyColumn(LuaFieldType t) {
         return std::vector<IRMath::vec3>{};
     case LuaFieldType::IVEC3:
         return std::vector<IRMath::ivec3>{};
+    case LuaFieldType::VEC4:
+        return std::vector<IRMath::vec4>{};
     }
     return std::vector<std::int32_t>{};
 }
@@ -142,6 +148,11 @@ inline void columnAppendDefault(LuaFieldColumn &c, const sol::object &defaultVal
                 v.push_back(vec3FromLua(defaultValue));
             } else if constexpr (std::is_same_v<Elem, IRMath::ivec3>) {
                 v.push_back(ivec3FromLua(defaultValue));
+            } else if constexpr (std::is_same_v<Elem, IRMath::vec4>) {
+                // quatFromLua identity-defaults nil/partial to (0,0,0,1) — the
+                // correct default for the primary rotation consumer; a plain
+                // vec4 author passes an explicit 4-element default.
+                v.push_back(quatFromLua(defaultValue));
             }
         },
         c
@@ -315,6 +326,9 @@ class IComponentDataLuaTyped : public IREntity::IComponentData {
                 } else if constexpr (std::is_same_v<Elem, IRMath::ivec3>) {
                     if (value.is<sol::table>() || value.is<IRMath::ivec3>())
                         v[row] = ivec3FromLua(value);
+                } else if constexpr (std::is_same_v<Elem, IRMath::vec4>) {
+                    if (value.is<sol::table>() || value.is<IRMath::vec4>())
+                        v[row] = quatFromLua(value);
                 }
             },
             m_columns[fieldIdx]
@@ -338,6 +352,12 @@ class IComponentDataLuaTyped : public IREntity::IComponentData {
                     // zero-alloc per-component reads use three scalar fields.
                     const Elem &val = v[row];
                     return lua.create_table_with("x", val.x, "y", val.y, "z", val.z);
+                } else if constexpr (std::is_same_v<Elem, IRMath::vec4>) {
+                    // vec4 / quat surfaces as an { x, y, z, w } table — same
+                    // round-trip contract as vec3 (writeFieldAt's quatFromLua
+                    // accepts the same shape), with .w the quaternion scalar.
+                    const IRMath::vec4 &val = v[row];
+                    return lua.create_table_with("x", val.x, "y", val.y, "z", val.z, "w", val.w);
                 } else {
                     return sol::make_object(lua, v[row]);
                 }

--- a/engine/script/src/lua_script.cpp
+++ b/engine/script/src/lua_script.cpp
@@ -69,6 +69,10 @@ LuaFieldType inferTypeFromDefault(const sol::object &value) {
         return LuaFieldType::IVEC3;
     if (value.is<IRMath::vec3>())
         return LuaFieldType::VEC3;
+    // Only fires when the creation registered an IRMath::vec4 sol usertype; a
+    // bare { x, y, z, w } table still needs the explicit tag, as vec3 does.
+    if (value.is<IRMath::vec4>())
+        return LuaFieldType::VEC4;
     if (value.is<sol::function>())
         return LuaFieldType::FUNCTION;
     // Numeric values with a fractional part: under LuaJIT (Lua 5.1
@@ -102,6 +106,8 @@ LuaFieldType parseExplicitTypeTag(const std::string &tag, bool &ok) {
         return LuaFieldType::VEC3;
     if (tag == "ivec3")
         return LuaFieldType::IVEC3;
+    if (tag == "vec4" || tag == "quat" || tag == "quaternion")
+        return LuaFieldType::VEC4;
     ok = false;
     return LuaFieldType::TABLE;
 }
@@ -129,7 +135,7 @@ LuaFieldSchema buildFieldSchema(
                 throw sol::error{
                     "IRComponent.register: " + componentName + "." + fieldName +
                     " has unknown type tag '" + *tag +
-                    "' (expected one of int|float|bool|string|function|table|vec3|ivec3)"
+                    "' (expected one of int|float|bool|string|function|table|vec3|ivec3|vec4)"
                 };
             }
             s.type_ = inferred;

--- a/test/script/lua_component_register_test.cpp
+++ b/test/script/lua_component_register_test.cpp
@@ -132,7 +132,7 @@ TEST_F(LuaComponentTest, UnknownExplicitTypeTagFailsWithFieldName) {
     auto &lua = m_lua.lua();
     auto result = lua.safe_script(
         "local C = IRComponent.register('Bad', {\n"
-        "    weirdField = { type = 'quaternion', default = 0 }\n"
+        "    weirdField = { type = 'mat4', default = 0 }\n"
         "})",
         sol::script_pass_on_error
     );
@@ -140,7 +140,9 @@ TEST_F(LuaComponentTest, UnknownExplicitTypeTagFailsWithFieldName) {
     sol::error err = result;
     const std::string msg = err.what();
     EXPECT_NE(msg.find("weirdField"), std::string::npos);
-    EXPECT_NE(msg.find("quaternion"), std::string::npos);
+    // 'quat'/'quaternion'/'vec4' are now valid tags — 'mat4' keeps this
+    // exercising the unknown-tag error path.
+    EXPECT_NE(msg.find("mat4"), std::string::npos);
 }
 
 // ---- Identity rule ---------------------------------------------------------
@@ -330,6 +332,74 @@ TEST_F(LuaComponentTest, Vec3AndIvec3FieldsStoreAsNativeColumnsAndRoundTrip) {
     EXPECT_FLOAT_EQ(t["x"].get<float>(), 10.0f);
     EXPECT_FLOAT_EQ(t["y"].get<float>(), 20.0f);
     EXPECT_FLOAT_EQ(t["z"].get<float>(), 30.0f);
+}
+
+TEST_F(LuaComponentTest, Vec4AndQuatFieldsStoreAsNativeColumnAndRoundTrip) {
+    auto &lua = m_lua.lua();
+    ASSERT_TRUE(lua.safe_script(
+                       "C_Q = IRComponent.register('QuatBody', {\n"
+                       "    rot = { type = 'quat', default = { 0, 0, 0, 1 } },\n"
+                       "    dir = { type = 'vec4', default = { 1, 2, 3, 4 } },\n"
+                       "    spin = { type = 'quaternion' },\n" // omitted default -> identity
+                       "})"
+    )
+                    .valid());
+    const IREntity::ComponentId componentId = m_entity_manager.getComponentTypeByName("QuatBody");
+
+    IREntity::EntityId e = IREntity::createEntity();
+    m_entity_manager.addComponentDynamic(e, componentId);
+
+    auto [data, row] = m_entity_manager.getComponentDataAndRow(e, componentId);
+    ASSERT_NE(data, nullptr);
+    auto *typed = static_cast<IRScript::IComponentDataLuaTyped *>(data);
+
+    // quat / vec4 both materialise as one IRMath::vec4 column — a quat is a
+    // vec4, so the tag alias shares storage (no redundant QUAT variant).
+    const auto &rotCol = typed->columnAt(typed->findFieldIndex("rot"));
+    const auto *vec4Col = std::get_if<std::vector<IRMath::vec4>>(&rotCol);
+    ASSERT_NE(vec4Col, nullptr);
+    EXPECT_EQ((*vec4Col)[row], IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+
+    const auto &dirCol = typed->columnAt(typed->findFieldIndex("dir"));
+    const auto *dirVec4 = std::get_if<std::vector<IRMath::vec4>>(&dirCol);
+    ASSERT_NE(dirVec4, nullptr);
+    EXPECT_EQ((*dirVec4)[row], IRMath::vec4(1.0f, 2.0f, 3.0f, 4.0f)); // positional default
+
+    // Omitted default resolves to identity (0,0,0,1) via quatFromLua, NOT the
+    // zero-vec that vec3 fields default to.
+    const auto &spinCol = typed->columnAt(typed->findFieldIndex("spin"));
+    const auto *spinVec4 = std::get_if<std::vector<IRMath::vec4>>(&spinCol);
+    ASSERT_NE(spinVec4, nullptr);
+    EXPECT_EQ((*spinVec4)[row], IRMath::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+
+    // write→read round-trip: writeFieldAt accepts an { x, y, z, w } table,
+    // readFieldAt returns one (with .w the scalar).
+    typed->writeFieldAt(
+        row,
+        typed->findFieldIndex("rot"),
+        sol::make_object(lua, lua.create_table_with("x", 0.1, "y", 0.2, "z", 0.3, "w", 0.4))
+    );
+    EXPECT_FLOAT_EQ((*vec4Col)[row].w, 0.4f);
+
+    sol::object readBack = typed->readFieldAt(row, typed->findFieldIndex("rot"), lua);
+    ASSERT_TRUE(readBack.is<sol::table>());
+    sol::table t = readBack.as<sol::table>();
+    EXPECT_FLOAT_EQ(t["x"].get<float>(), 0.1f);
+    EXPECT_FLOAT_EQ(t["y"].get<float>(), 0.2f);
+    EXPECT_FLOAT_EQ(t["z"].get<float>(), 0.3f);
+    EXPECT_FLOAT_EQ(t["w"].get<float>(), 0.4f);
+}
+
+TEST_F(LuaComponentTest, Vec4FieldsAreNotModifierTargetable) {
+    auto &lua = m_lua.lua();
+    auto result = lua.safe_script(
+        "local C = IRComponent.register('QuatModTarget', {\n"
+        "    rot = { type = 'quat', default = { 0, 0, 0, 1 } },\n"
+        "})\n"
+        "return C.fields.rot.bindingId"
+    );
+    ASSERT_TRUE(result.valid());
+    EXPECT_EQ(result.get<lua_Integer>(), static_cast<lua_Integer>(IRComponents::kInvalidFieldId));
 }
 
 TEST_F(LuaComponentTest, Vec3FieldsAreNotModifierTargetable) {


### PR DESCRIPTION
## Summary
- Adds a native `VEC4` column type to `LuaFieldType` so a **Lua-defined** component can declare a `vec4`/quaternion field that EVAL systems read and write with no C++ shim.
- `quat` / `quaternion` are register-time tag aliases for the **same** `IRMath::vec4` column (a quat is a `vec4` engine-wide — no distinct `IRMath::quat`), reusing the existing `IRScript::quatFromLua` helper; nil/partial defaults resolve to the identity quat `(0,0,0,1)`.
- Reads surface as an `{x,y,z,w}` table; writes accept an `{x,y,z,w}` / `{1,2,3,4}` table **or** an `IRMath::vec4` userdata. Archetype move/copy/remove preserved by the existing generic column helpers.
- Not modifier-targetable (stays `INT32|FLOAT|BOOL`) and **EVAL-only** — the CODEGEN tool still errors on the tag, same status as `vec2`. Documented in `engine/script/CLAUDE.md`.
- Retargets the stale unknown-tag test (`quaternion` is now a valid tag → `mat4`) and adds vec4/quat round-trip + not-modifier-targetable coverage.

Scoped to the literal title ask (a field type for Lua-defined components). Making `C_LocalTransform.rotation_` writable from Lua is a separate C++-binding follow-up (a `registerType`/`LuaCppColumnView` ergonomics question), per the approved plan.

## Test plan
- [x] `IrredenEngineTest` builds clean (macOS/Metal).
- [x] `LuaComponentTest.*` — all 27 pass, incl. the new `Vec4AndQuatFieldsStoreAsNativeColumnAndRoundTrip`, `Vec4FieldsAreNotModifierTargetable`, and the retargeted `UnknownExplicitTypeTagFailsWithFieldName`.

Closes #2163

🤖 Generated with [Claude Code](https://claude.com/claude-code)