### PR TITLE
docs(fleet): conservative slim of role-merger.md / role-worker.md

### DIFF
--- a/.claude/commands/role-merger.md
+++ b/.claude/commands/role-merger.md
@@ -953,43 +953,31 @@ See [`docs/agents/CLAUDE-BASELINE.md §"Hard rules for autonomous fleet roles"`]
 The merger has TWO tiers of "don't touch this PR again":
 
 1. **Durable handoff labels** — `fleet:semantic-conflict`,
-   `fleet:awaiting-base`, `fleet:needs-info`,
-   `fleet:needs-base-update`. Once the merger sets one of these,
-   the PR is no longer the merger's responsibility. Only the role
-   that owns the next step (worker for semantic-conflict; the
-   merger itself for awaiting-base when the base merges/closes
-   and for needs-base-update on the same transition; the human or
-   author for needs-base-update via manual rebase; the human for
-   needs-info) removes the label. These are in step 3's skip list,
-   so the merger never re-runs rebase on a PR in this state — no
-   comment spam.
+   `fleet:awaiting-base`, `fleet:needs-info`, `fleet:needs-base-update`.
+   Once set, the PR is no longer the merger's responsibility; only the role
+   that owns the next step removes it (worker for semantic-conflict; the
+   merger itself for awaiting-base / needs-base-update when the base
+   merges/closes; human or author for a manual needs-base-update rebase;
+   human for needs-info). These are in step 3's skip list, so the merger
+   never re-runs rebase on a PR in this state — no comment spam.
 
-2. **`fleet:merger-cooldown`** — short-lived, self-managed.
-   The merger adds it after a *non-durable* outcome (clean
-   rebase, whitespace-only, or merged-base re-target with clean
-   rebase — all of which already pushed and don't need a handoff
-   label). Step 1 of the next
-   iteration clears all such labels unconditionally, so the
-   10-minute loop interval IS the cooldown — one iteration of
-   "skip this PR" is enough breathing room before re-checking.
-   (An earlier draft tried to gate on `updatedAt`, but reviewer
-   comments refresh that timestamp and prevented cooldowns from
-   clearing predictably.)
+2. **`fleet:merger-cooldown`** — short-lived, self-managed. Added after a
+   *non-durable* outcome (clean rebase, whitespace-only, or merged-base
+   re-target with clean rebase — all already pushed, no handoff needed).
+   Step 1 of the next iteration clears it unconditionally, so the 10-minute
+   loop interval IS the cooldown. Do NOT gate cooldown on `updatedAt`:
+   reviewer comments refresh that timestamp and prevent predictable clearing.
 
-The cooldown label is intentionally NOT used as the only stop
-sign for semantic conflicts — without a durable label, every
-iteration would re-classify and re-comment. The durable label
-is what holds the PR steady; the cooldown is a one-iteration
-nudge for the cases that already resolved.
+Semantic conflicts always need a **durable** label, never cooldown alone —
+without it every iteration re-classifies and re-comments.
 
 ## Observability
 
 Every action lands in TWO places:
 
-1. `~/.fleet/logs/merger-audit.log` — append-only audit trail.
-   One line per action with timestamp, PR number, branch, action,
-   outcome. Append-only so the audit history survives across iterations; pane output is ephemeral.
-2. The PR comment thread — human-visible. Always end with
-   `— fleet merger` so a human (or another agent) scanning the
-   thread can identify merger comments without parsing the
-   author field.
+1. `~/.fleet/logs/merger-audit.log` — append-only audit trail, one line per
+   action (timestamp, PR number, branch, action, outcome). Survives across
+   iterations; pane output is ephemeral.
+2. The PR comment thread — human-visible. Always end with `— fleet merger` so
+   a human or agent scanning the thread can identify merger comments without
+   parsing the author field.

--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -357,18 +357,16 @@ Do the work, then exit cleanly:
        `git rebase origin/<baseRefName>`
     d'. **Inherited-prefix shortcut — check before resolving by hand.** If
        every conflicted file is one your branch *inherited* from a parent PR
-       that has since merged (the conflict is your stale inherited copy vs
-       master's now-merged copy), do NOT resolve file-by-file. Drop the
-       inherited prefix instead:
+       that has since merged (stale inherited copy vs master's now-merged
+       copy), do NOT resolve file-by-file — drop the inherited prefix:
        `git rebase --onto origin/master <child-fork-point>`
-       where `<child-fork-point>` is the inherited commit on your branch —
-       `git merge-base HEAD origin/<parent-branch>` (the parent's *pre-merge*
-       head). That replays only your genuine commits; the inherited files
-       resolve to master automatically and the diff shrinks to your own
-       changes. `fleet-rebase`'s auto-drop normally does this for you; this
-       is the manual fallback for when it silently doesn't fire — e.g. the
-       parent branch was amended during review *after* you forked, so its
-       recorded `headRefOid` is no longer an ancestor of your head (#1791).
+       where `<child-fork-point>` = `git merge-base HEAD origin/<parent-branch>`
+       (the parent's *pre-merge* head). That replays only your genuine commits;
+       inherited files resolve to master and the diff shrinks to your own
+       changes. `fleet-rebase` auto-drops this normally; do it by hand when it
+       silently doesn't fire — e.g. the parent was amended during review after
+       you forked, so its recorded `headRefOid` is no longer an ancestor of
+       your head (#1791).
     d''. **Gated-conflict guard — check before resolving.** List the
        conflicted files (`git diff --name-only --diff-filter=U`). If **every**
        one is a gated self-config file (`.claude/commands/role-*.md`,


### PR DESCRIPTION
## What

Role docs (`role-worker.md` ~53KB, `role-merger.md` ~52KB) are reloaded into **every** transient agent dispatch, so their verbose prose is a recurring per-iteration token cost. This is a **first-pass, behavior-preserving** tightening.

## Guarantee

Every actionable rule, command, label transition, and guardrail is preserved — the cuts are war-story rationale and repetition only. Specifically:

- **role-merger.md "How the cooldown label works"** 33 → 19 lines. Kept: the two-tier model, the durable-label list, who removes each, the step-3 skip-list behavior, the *do-not-gate-cooldown-on-`updatedAt`* rule, and the semantic-conflict-needs-a-durable-label rule.
- **role-merger.md "Observability"** tightened; both audit channels + the `— fleet merger` attribution convention preserved.
- **role-worker.md step 1c d' (inherited-prefix shortcut)** tightened; the `git rebase --onto` command, the `<child-fork-point>` definition, and the #1791 when-to-use all preserved.

## Deliberately conservative

The slim analysis found ~300 more lines of *safe* reduction, but almost all of it is **relocating** self-contained rationale (the #1149 stacked-rebase ordering, the game-build setup block, the #1990 gated-conflict story) into referenced docs under `docs/agents|design/` — moving it out of the always-loaded prompt **without losing it**. That's a careful cross-doc refactor I did not want to rush on live gated docs governing running agents. Recommend it as a dedicated follow-up.

> Touches gated self-config — human merge. Non-overlapping with #2192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)