### PR TITLE
role-worker: re-check mergeable before rebasing a semantic-conflict PR

### DIFF
--- a/.claude/commands/role-worker.md
+++ b/.claude/commands/role-worker.md
@@ -342,11 +342,25 @@ Do the work, then exit cleanly:
        branch. This prevents a parallel worker on any host from
        starting the same rebase simultaneously:
        `fleet-claim resolving-claim <N> <your-worktree-basename>`
-       - Exit 0 — you own the lock. Proceed to step c.
+       - Exit 0 — you own the lock. Proceed to step b''.
        - Exit 1 — another agent already holds `fleet:resolving-*` on
          this PR. Skip it: go to step 2 (pick another conflict PR or
          new task) without touching the branch. No cleanup needed
          (the label was never added — the tie-break loser self-removes).
+    b''. **Re-check mergeable before spending on the rebase.** A
+       worker on another host may have resolved this conflict *after* the
+       scout cached the label, leaving `fleet:semantic-conflict` stale.
+       Confirm the conflict is still real before you checkout and rebase:
+       `gh pr view <N> --json mergeable --jq '.mergeable'`
+       (add `--repo jakildev/irreden` for game PRs).
+       - `MERGEABLE` — already resolved; the label is stale. Do **NOT**
+         rebase — re-rebasing an already-resolved PR near-clobbers the
+         resolver's work. Just clear the stale label and release, then go to
+         step 2: `gh pr edit <N> --remove-label "fleet:semantic-conflict"`
+         and `fleet-claim resolving-release <N> <your-worktree-basename>`.
+       - `CONFLICTING` — the conflict is real; proceed to step c.
+       - `UNKNOWN` — GitHub is still computing mergeability; proceed to
+         step c (the rebase in step d is authoritative either way).
     c. Check out the PR in detached HEAD (fetches head ref + writes
        the `.git/fleet-amend-ref` sentinel for the step h push):
        `fleet-pr-checkout-detached <N> --repo jakildev/IrredenEngine`


### PR DESCRIPTION
## What

Codifies a recurring operator snag from personal agent-memory into the shared repo (portable — every worker on every host gets it, not just the one agent that hit it).

**The snag:** a worker on another host can resolve a `fleet:semantic-conflict` PR *after* the scout caches the label. The label goes stale. A worker that then picks it up rebases an **already-resolved** PR and near-clobbers the resolver's work.

**The fix:** role-worker.md step 1c gains a `b''` — after winning the `resolving-*` lock and **before** the checkout/rebase, do a cheap `gh pr view <N> --json mergeable`:
- `MERGEABLE` → already resolved; clear the stale label, release, skip the rebase.
- `CONFLICTING` → real conflict; proceed.
- `UNKNOWN` → proceed (the rebase is authoritative).

Placed before the expensive checkout + rebase + build, so it costs one read on the happy path and saves a whole wasted (and clobbering) iteration on the stale-label path.

## Method note

This came out of a broader memory-audit pass. I verified each candidate against the docs before codifying — and dropped two the audit flagged because they were **already covered**: the amending-claim lex-min "winner proceeds" rule (handled by the atomic `fleet-pr-claim-feedback` exit-code contract) and the `--repo`-flag-position footgun (already at `FLEET.md:699`). Only genuine, verified gaps land here.

Follow-ups worth their own (tested) PRs — better as enforced script guards than doc rules: `fleet-claim claim` rejecting a **closed** issue, and rejecting a **trailing** `--repo` flag.

> Touches gated self-config — human merge. Non-overlapping with #2192 (step 2) and #2199 (step 1c d').

🤖 Generated with [Claude Code](https://claude.com/claude-code)
