### PR TITLE
math: prune orphaned IRMath::pos3DtoPos2DIsoRotated

### DIFF
--- a/engine/math/CLAUDE.md
+++ b/engine/math/CLAUDE.md
@@ -35,18 +35,13 @@ Helpers:
   (1,1,1); at identity the axis is exactly (1,1,1) so it collapses to
   `pos3DtoDistance`. GPU mirror `isoDepthAlongAxis` in `ir_iso_common.{glsl,metal}`.
   See the design doc's entity-rotation carve-out (#1462).
-- `IRMath::pos3DtoPos2DIsoYawed(worldPos, visualYaw)` /
-  `IRMath::pos3DtoPos2DIsoRotated(modelPos, rotation)` — continuous-rotation
-  iso reposition. The first is `iso(R_z(−yaw)·world)` (1-DOF, smooth camera
-  Z-yaw, #1308) — **live**; the second is its SO(3) companion `iso(R·model)`,
-  originally for a detached entity's octahedral-snap residual (#1463). That
-  forward-scatter consumer was **retired in #1560** (re-voxelize is now the sole
-  detached SO(3) path), so `pos3DtoPos2DIsoRotated` has no production caller
-  today — retained as the SO(3) iso primitive (math tests only). At identity /
-  zero yaw both collapse to `pos3DtoPos2DIso`, and a pure-Z quaternion `qZ(θ)`
-  makes the rotated form equal `pos3DtoPos2DIsoYawed(·, −θ)`. GPU mirrors of both
-  in `ir_iso_common.{glsl,metal}`, kept CPU↔GPU bit-identical. See
+- `IRMath::pos3DtoPos2DIsoYawed(worldPos, visualYaw)` — continuous-rotation
+  iso reposition: `iso(R_z(−yaw)·world)` (1-DOF, smooth camera Z-yaw, #1308).
+  GPU mirror in `ir_iso_common.{glsl,metal}`, kept CPU↔GPU bit-identical. See
   [`docs/design/per-axis-trixel-canvas-rotation.md`](../../docs/design/per-axis-trixel-canvas-rotation.md).
+  (Its SO(3) companion `pos3DtoPos2DIsoRotated` — `iso(R·model)` for a detached
+  entity's octahedral-snap residual, #1463 — was removed in #2194 once #1560
+  retired its sole consumer, the forward-scatter composite.)
 
 **Never inline these equations in system code.** Always call the helpers
 so there's one place to fix a coordinate-system bug.

--- a/engine/math/include/irreden/ir_math.hpp
+++ b/engine/math/include/irreden/ir_math.hpp
@@ -648,37 +648,6 @@ constexpr vec2 pos3DtoPos2DIsoYawed(const vec3 worldPos, float visualYaw) {
     return vec2(-vx + vy, -vx - vy + 2.0f * worldPos.z);
 }
 
-/// Iso projection of a detached entity's model-space point under an arbitrary
-/// SO(3) rotation: `iso(R · modelPos)`. The full-rotation companion to the
-/// Z-yaw-only @ref pos3DtoPos2DIsoYawed — where camera yaw is a 1-DOF rotation
-/// about world Z, a detached entity rotates by any axis, so the continuous
-/// reposition rotates the model point by the entity quaternion before
-/// projecting. Feed the octahedral-snap *residual* (@ref octahedralSnapResidual)
-/// as @p rotation: the snap plays the cardinal-snap role and the residual is
-/// the continuous 3D reposition, the SO(3) generalization of the cardinal/
-/// residual yaw split. At identity rotation this is exactly
-/// @ref pos3DtoPos2DIso(modelPos), and for a pure-Z quaternion `qZ(θ)` it
-/// equals `pos3DtoPos2DIsoYawed(modelPos, -θ)` (the entity-rotation sign is
-/// opposite the camera-residual yaw sign, matching @ref faceDeformationMatrixSO3).
-///
-/// Caller rounds the continuous result with @ref roundHalfUp at the canvas-cell
-/// write, exactly as the yaw path does. GPU mirror: `pos3DtoPos2DIsoRotated` in
-/// `shaders/ir_iso_common.glsl` / `.metal` — `rotateByQuat` then the same iso
-/// columns, so CPU and GPU agree bit-for-bit. Originally the reposition for the
-/// detached SO(3) forward-scatter composite (#1463 P2 → #1464 P3); that consumer
-/// was **retired in #1560** when re-voxelize became the sole detached SO(3) path,
-/// so this helper currently has no production caller (math tests only). Retained
-/// as the SO(3) iso-projection primitive (the full-rotation companion to
-/// @ref pos3DtoPos2DIsoYawed).
-///
-/// The iso columns `(-x + y, -x - y + 2z)` are inlined (matching the sibling
-/// @ref pos3DtoPos2DIsoYawed and the GPU mirror) rather than calling
-/// @ref pos3DtoPos2DIso, which is defined later in this header.
-inline vec2 pos3DtoPos2DIsoRotated(const vec3 &modelPos, const vec4 &rotation) {
-    const vec3 r = rotateVectorByQuat(modelPos, rotation);
-    return vec2(-r.x + r.y, -r.x - r.y + 2.0f * r.z);
-}
-
 /// Conservative XY growth of an axis-aligned half-extent swept under a Z-yaw of
 /// `(cosYaw, sinYaw)`: each in-plane axis grows to `|c|·hX + |s|·hY` (the
 /// footprint the rotated box covers, up to the √2 extent at ±45°); Z is

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -740,18 +740,6 @@ vec3 rotateByInverseQuat(vec3 v, vec4 q) {
     return rotateByQuat(v, vec4(-q.xyz, q.w));
 }
 
-// Iso projection of a detached entity's model point under SO(3) rotation:
-// iso(R * modelPos). Full-rotation companion to pos3DtoPos2DIsoYawed (Z-yaw
-// only). Feed the octahedral-snap residual as `rotation`; at identity this is
-// pos3DtoPos2DIso(modelPos). CPU mirror: IRMath::pos3DtoPos2DIsoRotated —
-// rotateByQuat then the same iso columns keep CPU/GPU bit-identical (#1463).
-// No shader caller since #1560 retired the detached forward-scatter; retained
-// primitive (re-voxelize is the sole detached SO(3) path).
-vec2 pos3DtoPos2DIsoRotated(vec3 modelPos, vec4 rotation) {
-    vec3 r = rotateByQuat(modelPos, rotation);
-    return vec2(-r.x + r.y, -r.x - r.y + 2.0 * r.z);
-}
-
 // The two in-plane unit model axes (e_u, e_v) a face's scatter quad spans, by
 // axis = faceId >> 1 (0=X spans y,z; 1=Y spans x,z; 2=Z spans x,y) — matching
 // faceSpanCorner's cornerSel.x -> e_u, cornerSel.y -> e_v ordering. Returned in

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -668,18 +668,6 @@ inline float3 rotateByInverseQuat(float3 v, float4 q) {
     return rotateByQuat(v, float4(-q.xyz, q.w));
 }
 
-// Iso projection of a detached entity's model point under SO(3) rotation:
-// iso(R * modelPos). Full-rotation companion to pos3DtoPos2DIsoYawed (Z-yaw
-// only). Feed the octahedral-snap residual as `rotation`; at identity this is
-// pos3DtoPos2DIso(modelPos). CPU mirror: IRMath::pos3DtoPos2DIsoRotated —
-// rotateByQuat then the same iso columns keep CPU/GPU bit-identical (#1463).
-// No shader caller since #1560 retired the detached forward-scatter; retained
-// primitive (re-voxelize is the sole detached SO(3) path).
-inline float2 pos3DtoPos2DIsoRotated(float3 modelPos, float4 rotation) {
-    const float3 r = rotateByQuat(modelPos, rotation);
-    return float2(-r.x + r.y, -r.x - r.y + 2.0f * r.z);
-}
-
 // The two in-plane unit model axes (e_u, e_v) a face's scatter quad spans, by
 // axis = faceId >> 1 (0=X spans y,z; 1=Y spans x,z; 2=Z spans x,y) — matching
 // faceSpanCorner's cornerSel.x -> e_u, cornerSel.y -> e_v ordering. Mirror of

--- a/test/math/ir_math_yaw_deformation_test.cpp
+++ b/test/math/ir_math_yaw_deformation_test.cpp
@@ -238,69 +238,6 @@ TEST(Pos3DtoPos2DIsoYawedTest, CardinalsAgreeWithRotateCardinalZ) {
 }
 
 // ---------------------------------------------------------------------------
-// pos3DtoPos2DIsoRotated (#1463 — detached SO(3) per-voxel reposition)
-// ---------------------------------------------------------------------------
-
-// At identity rotation the SO(3) reposition is exactly the un-rotated iso
-// projection — the detached-entity fast path stays byte-identical when the
-// octahedral-snap residual is identity.
-TEST(Pos3DtoPos2DIsoRotatedTest, IdentityRotationMatchesUnrotatedProjection) {
-    const IRMath::vec3 samples[] = {
-        IRMath::vec3(0, 0, 0),
-        IRMath::vec3(1, 0, 0),
-        IRMath::vec3(0, 1, 0),
-        IRMath::vec3(0, 0, 1),
-        IRMath::vec3(3, -2, 4),
-        IRMath::vec3(-5, 7, -3)
-    };
-    const IRMath::vec4 identityQuat(0.0f, 0.0f, 0.0f, 1.0f);
-    for (const auto &p : samples) {
-        const IRMath::vec2 expected = IRMath::pos3DtoPos2DIso(p);
-        const IRMath::vec2 actual = IRMath::pos3DtoPos2DIsoRotated(p, identityQuat);
-        EXPECT_NEAR(actual.x, expected.x, kTolerance);
-        EXPECT_NEAR(actual.y, expected.y, kTolerance);
-    }
-}
-
-// A pure-Z entity rotation reduces to the Z-yaw companion with the sign
-// flipped: an entity rotating its own frame by +theta projects like a camera
-// yaw of -theta (same sign relationship as faceDeformationMatrixSO3).
-TEST(Pos3DtoPos2DIsoRotatedTest, PureZQuatMatchesYawedHelperWithFlippedSign) {
-    const IRMath::vec3 p(2.0f, -1.0f, 3.0f);
-    for (float theta : kResidualYaws) {
-        const IRMath::vec4 quat = quatRotateZ(theta);
-        const IRMath::vec2 expected = IRMath::pos3DtoPos2DIsoYawed(p, -theta);
-        const IRMath::vec2 actual = IRMath::pos3DtoPos2DIsoRotated(p, quat);
-        EXPECT_NEAR(actual.x, expected.x, kTolerance);
-        EXPECT_NEAR(actual.y, expected.y, kTolerance);
-    }
-}
-
-// The helper is exactly iso(R * modelPos): rotate the model point by the
-// quaternion, then project. The GLSL/Metal mirror (rotateByQuat + the same iso
-// columns) must reproduce this composition bit-for-bit, so pin it on the CPU.
-TEST(Pos3DtoPos2DIsoRotatedTest, MatchesRotateThenProject) {
-    const IRMath::vec4 rots[] = {
-        IRMath::quatAxisAngle(IRMath::vec3(0, 0, 1), IRMath::kPi / 5.0f),
-        IRMath::quatAxisAngle(IRMath::vec3(1, 0, 0), IRMath::kPi / 7.0f),
-        IRMath::quatAxisAngle(IRMath::vec3(0, 1, 0), -IRMath::kPi / 6.0f),
-        IRMath::quatAxisAngle(IRMath::vec3(1, 1, 1), IRMath::kPi / 9.0f),
-        IRMath::quatAxisAngle(IRMath::vec3(1, 2, 0), IRMath::kPi / 8.0f),
-    };
-    const IRMath::vec3 samples[] =
-        {IRMath::vec3(1, 0, 0), IRMath::vec3(0, 3, -2), IRMath::vec3(-4, 1, 5)};
-    for (const IRMath::vec4 &q : rots) {
-        for (const IRMath::vec3 &p : samples) {
-            const IRMath::vec3 rotated = IRMath::rotateVectorByQuat(p, q);
-            const IRMath::vec2 expected = IRMath::pos3DtoPos2DIso(rotated);
-            const IRMath::vec2 actual = IRMath::pos3DtoPos2DIsoRotated(p, q);
-            EXPECT_NEAR(actual.x, expected.x, kTolerance);
-            EXPECT_NEAR(actual.y, expected.y, kTolerance);
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // deformedTrixelIsoPixel
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Removed `IRMath::pos3DtoPos2DIsoRotated` (`engine/math/include/irreden/ir_math.hpp`) — its sole production consumer, the detached SO(3) forward-scatter composite, was retired in #1560 once re-voxelize became the sole detached SO(3) path. PR #1593 confirmed zero production callers remained.
- Removed the dead GLSL/Metal shader mirrors in `ir_iso_common.{glsl,metal}` (no shader call site either).
- Removed the three math tests written solely to pin the helper's behavior (`test/math/ir_math_yaw_deformation_test.cpp`).
- Updated `engine/math/CLAUDE.md`'s iso-projection helper list to drop the removed API, with a one-line pointer to this PR for context.

## Test plan
- [x] `./build/IrredenEngineTest` — 1257/1257 pass (1 GL-only test skipped on this Metal host, expected)
- [x] `fleet-build --target IrredenEngineTest` and `fleet-build --target IRShapeDebug` both build clean
- [x] Full-repo grep confirms zero remaining references to `pos3DtoPos2DIsoRotated` in source (only stale build-artifact copies under `build.stale-sonnetfleet1/` still mention it, untouched)

Closes #2194

🤖 Generated with [Claude Code](https://claude.com/claude-code)