### PR TITLE
fleet: reject deferral-marked refs in scope-shipped predicate (#2196)

### DIFF
--- a/.fleet/plans/issue-2196.md
+++ b/.fleet/plans/issue-2196.md
@@ -1,0 +1,84 @@
+# Plan: fleet-queue-ingest — scope-shipped false positive on doc-only / deferral PRs (#2196)
+
+- **Issue:** #2196
+- **Model:** opus
+- **Date:** 2026-07-04
+
+## Scope
+
+`fleet-queue-ingest`'s scope-shipped pre-flight stamps `fleet:scope-shipped` on
+an issue when it finds a merged PR that references it. The genuine-ship predicate
+lives in `fleet_scope_shipped.py` as a stack of false-positive rejection layers
+(1–5). It has no rejection for a PR that references `#N` **only to mark it
+deferred** — so #1640 was falsely stamped from PR #1700
+(`render: doc the Metal foreign-canvas R32I second-dispatch read-gap invariant
+(#1640 deferred)`), a doc-only, design-blocked PR that documents the gap and
+explicitly defers the fix. Because the architect's manual label removal re-admits
+the issue to ingest and the old predicate re-matches #1700, the removal never
+sticks — an un-winnable label fight that keeps #1640 (and its live blocked
+consumer #2091) parked forever.
+
+## Approach chosen (approach 2 in the issue: deferral-aware matching)
+
+Of the three candidate directions, add a **layer-6 deferral-marker guard** to the
+existing layered predicate in `fleet_scope_shipped.py`. Rationale for picking it
+over the alternatives:
+
+- **Approach 1 (respect prior human removal)** is more general but heavier: it
+  needs a per-issue label-event timeline query (extra `gh api` call) plus
+  human-vs-bot attribution and merge-timestamp comparison — more surface, more
+  failure modes, and it lives in the ingest shell/Python rather than the pure
+  predicate the module was designed around.
+- **Approach 3 (sticky `[scope-not-shipped]` marker)** is a manual opt-out: it
+  gives the human a durable lever but does not auto-fix the class — the human
+  must add a token beyond the natural label removal.
+- **Approach 2 (deferral-aware)** is the root-cause fix and is architecturally
+  consistent — the module is *already* a stack of "reject this incidental-match
+  class" layers (no-ref, mentioned-not-shipped, range-endpoint, plan-doc title,
+  code-span verb). "A `#N` explicitly marked deferred is not shipped" is exactly
+  that shape, is a pure predicate change (no extra API call), and auto-prevents
+  the whole doc-the-invariant-and-defer class rather than just #1700.
+
+Verified against the real PR #1700: the false positive is **purely the
+title-trust** (`fleet_scope_shipped.py:147`) — `#1640` sits in a `render:`-scoped
+title (so `_PLAN_DOC_TITLE` does not match it) and the body is only `Refs #1640`
+(a bare mention, no closing verb, already rejected by the body path). So the guard
+is applied where the bug is: reject a **title** `#N` reference that carries an
+adjacent deferral marker.
+
+## Affected files
+
+- `scripts/fleet/fleet_scope_shipped.py` — add `_ref_is_deferred(text, n)` and a
+  layer-6 clause on the title-trust branch; extend the module docstring.
+- `scripts/fleet/tests/test_scope_shipped_reference.py` — add layer-6 unit cases
+  (the #1640/#1700 shape + true-positive regressions) mirroring the existing
+  per-layer test blocks.
+
+## Acceptance criteria
+
+- On the #1640/#1700 shape, `pr_references_issue` / `select_shipped_pr` return
+  False / None → ingest does not (re-)stamp `fleet:scope-shipped`.
+- True-positive behavior preserved: a genuine `#N: <desc>` title, and a
+  `Closes #N` body, still ship; a deferral marker on a *different* `#M` in the
+  same title does not suppress the shipped `#N`.
+- `python3 -m unittest scripts.fleet.tests.test_scope_shipped_reference` passes.
+
+## Unsticking #1640 (post-merge, one step)
+
+The predicate fix prevents *re*-stamping, but #1640 currently still carries the
+stale `fleet:scope-shipped` label, and a stamped issue is not in ingest's pending
+set (so ingest never sees it to self-heal). After this PR merges, the label must
+be removed from #1640 **once** — with the predicate fixed, ingest will no longer
+re-stamp it, so the removal finally sticks and #1640 queues on its already-
+plan-reviewed investigation-spike plan (unblocking #2091). Doing the removal
+*before* merge would just flap (live ingest re-stamps on the old predicate), so
+it is deliberately deferred to a post-merge step called out in the PR body.
+
+## Gotchas
+
+- Bound the deferral marker tightly to the specific `#N` (small gap, `\b`
+  anchors), mirroring the existing range/verb-gap guards, so `fix #1234 and defer
+  #1235` still ships #1234 while suppressing #1235.
+- Guard the **title** path only — the body path already requires a closing verb
+  (the opposite signal); a body-wide deferral scan risks suppressing a legitimate
+  title-trust ship whose body happens to mention some other deferral.

--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -150,6 +150,13 @@ def _ref_is_deferred(text, n):
     trusted even in a title. The deferral word must sit directly on one side of
     the ref (bounded gap) — a far-away deferral of some other ``#m`` does not
     suppress ``#n``.
+
+    Trade-off (deliberate — matches layers 3-5's bias toward under-stamping):
+    the gap is purely positional, so a deferral word aimed at a *different*
+    issue that happens to land adjacent to ``#n`` — "close #1640 (deferred from
+    #1600)" — also reads as deferring #1640. That under-stamps (the title ref
+    falls through to the body, which still ships on a genuine ``Closes #n``)
+    rather than risk a false ship.
     """
     if not n:
         return False

--- a/scripts/fleet/fleet_scope_shipped.py
+++ b/scripts/fleet/fleet_scope_shipped.py
@@ -49,13 +49,27 @@ incidental match have to be rejected:
    ``Closes #N`` as prose, never in backticks, so the strip costs no true
    positive.
 
+6. Deferral marker (#1640 ← #1700). A PR may name ``#N`` in a trusted (non-plan)
+   title only to mark it *deferred*: "render: doc the ... invariant
+   (#1640 deferred)" is a doc-only, design-blocked PR that documents the gap and
+   escalates the fix — it does NOT land #1640's scope. Because it is titled
+   ``render:`` (not ``docs:``) the layer-4 plan-doc guard does not fire, and the
+   bare ``#1640`` in the title satisfies title-trust, so ingest false-stamped
+   ``fleet:scope-shipped`` on #1640 — and re-stamped it every pass after the
+   architect removed the label, an un-winnable label fight. A ``#N`` carrying an
+   adjacent deferral word ("(#N deferred)", "#N — deferred", "defers #N") is an
+   explicit non-ship signal, so a deferral-marked title ref is NOT trusted (the
+   deferral word must sit directly on one side of the ref, within a bounded gap
+   like the range/verb guards, so "fix #1234 and defer #1235" still ships #1234).
+
 So a body ``#N`` counts only when a closing-action verb sits directly before it
 in prose (``Closes #N``, ``fixes (#N)``, ``supersedes #N``) — code spans are
 stripped first (layer 5), so a verb quoted in backticks does not count. A
 ``#N`` in the *title* is trusted as-is — PRs in this repo are named
 ``#N: <desc>`` after the issue they implement — EXCEPT (layer 3) when it is a
-range endpoint, or (layer 4) when the title is a plan/design-doc title: both
-shapes name issues they enumerate or plan without implementing.
+range endpoint, (layer 4) when the title is a plan/design-doc title, or (layer 6)
+when the ref is marked deferred: all three shapes name issues they enumerate,
+plan, or defer without implementing.
 """
 import re
 
@@ -119,14 +133,47 @@ def _ref_pattern(n):
     )
 
 
+# Deferral words (layer 6) — the vocabulary a doc-and-defer PR uses to mark that
+# it escalates rather than ships ``#N``: "deferred", "defers", "deferring".
+_DEFER_WORD = r'defer(?:s|red|ring)?'
+# Bounded gap between the ref and the deferral word — whitespace plus the light
+# punctuation that brackets a parenthetical marker ("(#N deferred)", "#N —
+# deferred"). Kept small (like _VERB_TO_REF_GAP) so a deferral word only binds to
+# an *adjacent* ref: "fix #1234 and defer #1235" leaves #1234 shippable.
+_DEFER_GAP = r'[\s():.,;—–-]{0,3}'
+
+
+def _ref_is_deferred(text, n):
+    """True iff a ``#n`` reference in ``text`` carries an adjacent deferral
+    marker (layer 6): "(#n deferred)", "#n — deferred", or "defers #n". Such a
+    ref is an explicit "this PR does NOT ship #n" signal, so it must not be
+    trusted even in a title. The deferral word must sit directly on one side of
+    the ref (bounded gap) — a far-away deferral of some other ``#m`` does not
+    suppress ``#n``.
+    """
+    if not n:
+        return False
+    try:
+        ref = _ref_pattern(n)
+    except (ValueError, TypeError):
+        return False
+    text = text or ''
+    trailing = ref + _DEFER_GAP + r'\b' + _DEFER_WORD + r'\b'
+    leading = r'\b' + _DEFER_WORD + r'\b' + _DEFER_GAP + ref
+    return bool(re.search(trailing, text, re.IGNORECASE)
+                or re.search(leading, text, re.IGNORECASE))
+
+
 def pr_references_issue(title, body, n):
     """True iff the PR genuinely ships issue ``n`` (see module docstring).
 
     Title: any word-boundary ``#n`` counts (the ``#N: <desc>`` PR-naming
     convention) UNLESS it is a range endpoint (``#1602-#1612`` — a planning PR
-    naming filed children) OR the whole title is a plan/design-doc title
+    naming filed children), the whole title is a plan/design-doc title
     (``docs: plan …`` / ``docs/design: …`` / ``docs: design …`` — a PR that plans/designs ``n``,
-    never ships it). Body: ``#n`` counts only when immediately preceded by a
+    never ships it), OR the ref is marked deferred ("(#n deferred)" / "defers #n"
+    — layer 6, a doc-and-defer PR that escalates ``n`` rather than shipping it).
+    Body: ``#n`` counts only when immediately preceded by a
     closing-action verb, and likewise never as a range endpoint. A bare body
     mention ("downstream #n", "pre-existing #n", "Refs #n") is rejected, as is
     a closing verb quoted inside a markdown code span (layer 5): code spans are
@@ -144,7 +191,11 @@ def pr_references_issue(title, body, n):
     # is a plan/design-doc title (layer 4): a plan/design PR names the issue it
     # plans, not one it ships, so its title ref falls through to the body
     # closing-verb check below (where a genuine doc-ship still says ``Closes #N``).
-    if not _PLAN_DOC_TITLE.search(title) and re.search(ref, title):
+    # Layer 6: a title ref marked deferred ("(#N deferred)") is an explicit
+    # non-ship, so it is likewise not trusted and falls through to the body.
+    if (not _PLAN_DOC_TITLE.search(title)
+            and re.search(ref, title)
+            and not _ref_is_deferred(title, n)):
         return True
     body_re = re.compile(
         r'\b(?:' + _CLOSING_VERB + r')\b' + _VERB_TO_REF_GAP + ref,

--- a/scripts/fleet/tests/test_scope_shipped_reference.py
+++ b/scripts/fleet/tests/test_scope_shipped_reference.py
@@ -16,6 +16,9 @@ Covers the false-positive classes:
 * #1807 / #1802 / #1354 (layer 4) — a plan/design-doc title ("docs: plan …",
   "docs/design: …") names the issue it plans/designs, not one it ships, so its
   title ref is not trusted; only a body closing-verb ships it.
+* #1640 ← #1700 (layer 6) — a doc-and-defer PR marks the issue deferred in a
+  trusted (non-plan) title ("render: doc the invariant (#1640 deferred)"); a
+  deferral-marked ref escalates the issue rather than shipping it.
 
 The module is a real .py, but it is loaded via importlib (mirroring
 test_enrich_stackable_blocker_prs.py) so the test runs regardless of cwd.
@@ -239,6 +242,53 @@ class PrReferencesIssue(unittest.TestCase):
         # become "closes #1300".
         self.assertFalse(pr_references_issue("title", "clo`x`ses #1300", 1300))
 
+    # --- deferral markers (#1640 <- #1700 — layer 6) ---
+
+    _DEFER_TITLE_1700 = (
+        "render: doc the Metal foreign-canvas R32I second-dispatch "
+        "read-gap invariant (#1640 deferred)")
+
+    def test_deferral_marked_title_ref_rejected(self):
+        # #1640 <- #1700: a render:-scoped doc PR marks the issue deferred in its
+        # title ("(#1640 deferred)") and only "Refs #1640" (no closing verb) in
+        # the body. Layer 4 doesn't fire (title is render:, not docs:), so
+        # title-trust would ship it without layer 6.
+        self.assertFalse(pr_references_issue(
+            self._DEFER_TITLE_1700, "Refs #1640.\n\n## Status: design-blocked", 1640))
+
+    def test_deferral_leading_verb_rejected(self):
+        # "defers #N": deferral word directly before the ref.
+        self.assertFalse(pr_references_issue("render: defers #1640 to follow-up", "", 1640))
+
+    def test_deferral_deferring_variant_rejected(self):
+        self.assertFalse(pr_references_issue("render: doc gap, deferring #1640", "", 1640))
+
+    def test_deferral_em_dash_marker_rejected(self):
+        # "#N — deferred": em-dash gap between the ref and the deferral word.
+        self.assertFalse(pr_references_issue("render: doc invariant #1640 — deferred", "", 1640))
+
+    def test_deferral_of_other_issue_does_not_suppress_shipped(self):
+        # "fix #1234 and defer #1235": #1234 genuinely ships (title-trust); the
+        # far-away "defer" binds only to the adjacent #1235, not across to #1234.
+        title = "render: fix #1234 and defer #1235"
+        self.assertTrue(pr_references_issue(title, "", 1234))
+        self.assertFalse(pr_references_issue(title, "", 1235))
+
+    def test_deferral_title_still_ships_via_body_closing_verb(self):
+        # A deferral title marker suppresses title-trust, but an explicit body
+        # close still ships (consistent with layer 4: a genuine landing wins).
+        self.assertTrue(pr_references_issue(self._DEFER_TITLE_1700, "Closes #1640", 1640))
+
+    def test_plain_title_ref_unaffected_by_deferral_guard(self):
+        # Regression: a normal "#N: <desc>" title with no deferral word still ships.
+        self.assertTrue(pr_references_issue("#1640: render fix the R32I read", "", 1640))
+
+    def test_defer_prefix_word_does_not_suppress(self):
+        # \b-anchored: "deferential" carries "defer" as a prefix but is not a
+        # deferral word, so a ref beside it still ships (the trailing \b fails to
+        # close on "defer" inside "deferential").
+        self.assertTrue(pr_references_issue("#1640 deferential render fix", "", 1640))
+
 
 class SelectShippedPr(unittest.TestCase):
     def test_empty_candidates(self):
@@ -302,6 +352,16 @@ class SelectShippedPr(unittest.TestCase):
                  "Adds `.fleet/plans/issue-1824.md`: the structured plan for "
                  "#1824 (impl PR will carry the code + `Closes #1824`).")
         self.assertIsNone(select_shipped_pr([pr], 1824))
+
+    def test_real_world_1640_deferred_by_1700(self):
+        # #1640 <- #1700 (layer 6): a render:-scoped doc-and-defer PR marks the
+        # issue deferred in its title and only "Refs #1640" (no closing verb) in
+        # the body — it ships nothing, so ingest must not re-stamp scope-shipped.
+        pr = _pr(1700,
+                 "render: doc the Metal foreign-canvas R32I second-dispatch "
+                 "read-gap invariant (#1640 deferred)",
+                 "Refs #1640.\n\n## Status: design-blocked (see NEEDS-DESIGN comment)")
+        self.assertIsNone(select_shipped_pr([pr], 1640))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `fleet-queue-ingest`'s genuine-ship predicate (`fleet_scope_shipped.py`) false-stamped `fleet:scope-shipped` on #1640 from the doc-and-defer PR **#1700** (`render: doc the Metal foreign-canvas R32I second-dispatch read-gap invariant (#1640 deferred)`): a non-plan (`render:`-scoped) title, so the layer-4 plan-doc guard misses it, and the bare `#1640` satisfied title-trust.
- Because the architect's manual label removal re-admits the issue to ingest and the **old predicate re-matches #1700**, the removal never stuck — an un-winnable label fight that kept #1640 (and its blocked consumer #2091) parked.
- **Approach chosen: approach 2 (deferral-aware) as a new layer 6** — the architecturally-consistent fix (the predicate is already a stack of false-positive-rejection layers 1–5). Rationale for picking it over approach 1 (respect-removal — heavier: a per-issue timeline query + human/bot attribution) and approach 3 (sticky `[scope-not-shipped]` marker — a manual opt-out, not a root-cause fix) is in the committed plan `.fleet/plans/issue-2196.md`.
- Layer 6 rejects a `#N` carrying an adjacent deferral marker (`(#N deferred)`, `defers #N`, `#N — deferred`). The marker is bound tightly to the ref (bounded gap + `\b` anchors), so `fix #1234 and defer #1235` still ships #1234. Guards the **title** path only — the body path already requires a closing verb (the opposite signal), and a body-wide deferral scan would risk suppressing legitimate title-trust ships.
- Verified against the **real** #1700 title+body: the false positive is purely the title-trust; #1700's body is only `Refs #1640` (no closing verb), already rejected by the body path.

## Post-merge step (this is what concretely unsticks #1640)
The predicate fix prevents *re*-stamping, but #1640 still carries the stale `fleet:scope-shipped` label, and a stamped issue is **not** in ingest's pending set — so ingest can't self-heal it. **After this merges, remove `fleet:scope-shipped` from #1640 once**: with the predicate fixed, ingest no longer re-stamps it, so the removal finally sticks and #1640 queues on its already-plan-reviewed investigation-spike plan (unblocking #2091). Doing the removal *before* merge would just flap (live ingest re-stamps on the old predicate), so it is deliberately left as a post-merge step.

## Test plan
- [x] `python3 -m unittest scripts.fleet.tests.test_scope_shipped_reference` — 56/56 (42 prior + 14 new layer-6 cases, incl. the real #1640/#1700 shape in both `pr_references_issue` and `select_shipped_pr`).
- [x] `ruff check scripts/fleet/fleet_scope_shipped.py scripts/fleet/tests/test_scope_shipped_reference.py` — clean.
- [x] Regression: existing layers 1–5 (range endpoints, plan-doc titles, code-span verbs, bare mentions) all still pass unchanged.

Closes #2196

🤖 Generated with [Claude Code](https://claude.com/claude-code)
