### PR TITLE
engine/voxel: dedup GRID occupancy mask + depth-probe pixel parse

### DIFF
--- a/creations/demos/canvas_stress/main.cpp
+++ b/creations/demos/canvas_stress/main.cpp
@@ -1018,20 +1018,6 @@ void readConfig() {
         g_settings.autoRotate_ = autoRotate.as<bool>();
 }
 
-// Parse a "--depth-probe[-assert] X,Y" value into (set, pixel), mirroring the
-// warn-on-malformed behaviour the hand-rolled parser had — a bad value leaves
-// `set` false so the probe stays off rather than reading a garbage pixel.
-void applyDepthProbe(const std::string &value, bool &set, ivec2 &pixel, const char *flag) {
-    int px = 0;
-    int py = 0;
-    if (std::sscanf(value.c_str(), "%d,%d", &px, &py) == 2) {
-        set = true;
-        pixel = ivec2(px, py);
-    } else {
-        IR_LOG_WARN("{}: expected X,Y (e.g. 960,540); ignoring '{}'", flag, value);
-    }
-}
-
 // Parse "--depth-probe-assert X,Y" (depth-write guard, tier -1) or
 // "X,Y,tier=N" (per-trixel-priority tier guard, tier >= 0). The 3-field form is
 // tried first; a bad value leaves the assert off so the run stays byte-identical.
@@ -1182,12 +1168,15 @@ void applyArgs() {
             IRRender::debugOverlayModeFromString(args.getEnum("--debug-overlay").c_str());
     }
     if (args.wasProvided("--depth-probe")) {
-        applyDepthProbe(
-            args.getString("--depth-probe"),
-            g_settings.depthProbeSet_,
-            g_settings.depthProbePixel_,
-            "--depth-probe"
-        );
+        ivec2 pixel;
+        if (IRPrefab::DepthProbe::parsePixelArg(
+                args.getString("--depth-probe"),
+                pixel,
+                "--depth-probe"
+            )) {
+            g_settings.depthProbeSet_ = true;
+            g_settings.depthProbePixel_ = pixel;
+        }
     }
     if (args.wasProvided("--depth-probe-assert")) {
         applyDepthProbeAssert(args.getString("--depth-probe-assert"));

--- a/creations/demos/perf_grid/main.cpp
+++ b/creations/demos/perf_grid/main.cpp
@@ -59,7 +59,6 @@
 #include <irreden/common/command_suite_capture.hpp>
 
 #include <algorithm>
-#include <cstdio>
 #include <numbers>
 #include <string>
 #include <string_view>
@@ -553,16 +552,16 @@ void readCliArgs() {
         }
     }
     if (args.wasProvided("--depth-probe")) {
-        // `--depth-probe X,Y` (#1910): IRArgs has no pair type, so register as a
-        // string and keep the demo-side comma split.
-        const std::string probe = args.getString("--depth-probe");
-        int px = 0;
-        int py = 0;
-        if (std::sscanf(probe.c_str(), "%d,%d", &px, &py) == 2) {
+        // `--depth-probe X,Y` (#1910): IRArgs has no pair type, so the comma
+        // split lives demo-side (shared IRPrefab::DepthProbe::parsePixelArg).
+        ivec2 pixel;
+        if (IRPrefab::DepthProbe::parsePixelArg(
+                args.getString("--depth-probe"),
+                pixel,
+                "--depth-probe"
+            )) {
             g_cliOverrides.depthProbeSet_ = true;
-            g_cliOverrides.depthProbePixel_ = ivec2(px, py);
-        } else {
-            IR_LOG_WARN("--depth-probe: expected X,Y (e.g. 960,540); ignoring '{}'", probe);
+            g_cliOverrides.depthProbePixel_ = pixel;
         }
     }
 }

--- a/engine/prefabs/irreden/render/depth_probe.hpp
+++ b/engine/prefabs/irreden/render/depth_probe.hpp
@@ -10,6 +10,9 @@
 #include <irreden/render/components/component_trixel_framebuffer.hpp>
 #include <irreden/render/ir_render_types.hpp>
 
+#include <cstdio>
+#include <string>
+
 // GPU→CPU composite-depth probe. A debug-only readback that, for a requested
 // screen pixel, reads the REAL depth-test value stored in the main framebuffer's
 // depth attachment and decodes it to shared trixel-distance units. Because every
@@ -236,6 +239,26 @@ inline bool assertCompositeDepthTier(IRMath::ivec2 px, int expectedTier) {
         match ? "PASS" : "FAIL"
     );
     return match;
+}
+
+/// Parse a `--depth-probe`-style `"X,Y"` framebuffer-pixel flag value into
+/// @p pixelOut. Returns true and writes @p pixelOut on a well-formed pair; on a
+/// malformed value returns false, logs one warn line naming @p flag, and leaves
+/// @p pixelOut untouched — so a caller gates its probe off the return value and a
+/// bad value keeps the run byte-identical rather than probing a garbage pixel.
+/// Shared by the demos' `--depth-probe` handling (canvas_stress, perf_grid):
+/// IRArgs has no pair type, so the comma split lives demo-side against the string
+/// value. (The `--depth-probe-assert X,Y,tier=N` superset parse stays in
+/// canvas_stress — this covers only the plain X,Y form the two demos share.)
+inline bool parsePixelArg(const std::string &value, IRMath::ivec2 &pixelOut, const char *flag) {
+    int px = 0;
+    int py = 0;
+    if (std::sscanf(value.c_str(), "%d,%d", &px, &py) == 2) {
+        pixelOut = IRMath::ivec2(px, py);
+        return true;
+    }
+    IR_LOG_WARN("{}: expected X,Y (e.g. 960,540); ignoring '{}'", flag, value);
+    return false;
 }
 
 } // namespace IRPrefab::DepthProbe

--- a/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
+++ b/engine/prefabs/irreden/voxel/systems/system_rebuild_grid_voxels.hpp
@@ -55,8 +55,9 @@
 //  - `numVoxels_ <= 0` — headless / pre-canvas staging.
 //  - The voxel set's pool chunks are all outside the cull viewport.
 
-#include <algorithm>
 #include <cstdint>
+#include <span>
+#include <unordered_set>
 #include <vector>
 
 #include <irreden/common/components/component_rotation_mode.hpp>
@@ -71,6 +72,7 @@
 #include <irreden/voxel/components/component_voxel.hpp>
 #include <irreden/voxel/components/component_voxel_pool.hpp>
 #include <irreden/voxel/components/component_voxel_set.hpp>
+#include <irreden/voxel/face_occupancy.hpp>
 #include <irreden/voxel/grid_rotation.hpp>
 
 using namespace IRComponents;
@@ -93,13 +95,14 @@ template <> struct System<REBUILD_GRID_VOXELS> {
     IsoBounds2D chunkVp_{};
     bool cullValid_ = false;
 
-    // Identity-arm / fallback mask scratch: occupancy of the rotated world
-    // cells (sorted packed keys) for the exposed-mask recompute. Members so
-    // capacity persists across frames (no per-tick allocation, per
-    // cpp-ecs.md "Allocations in hot paths").
-    std::vector<std::int64_t> cellKeys_;
-    std::vector<ivec3> cellRoundedPositions_; // per-slot rounded positions, built with cellKeys_ to
-                                              // skip double-rounding
+    // Identity-arm / fallback exposed-mask scratch, shared with the detached
+    // path via IRPrefab::Voxel::recomputeFaceOccupancyOnCells. `cellsScratch_`
+    // holds this frame's rounded world destination cells (parallel to the pool
+    // sub-span); `occupancyScratch_` is the cell-occupancy set the neighbour
+    // probe reads. Members so capacity persists across frames (no per-tick
+    // allocation, per cpp-ecs.md "Allocations in hot paths").
+    std::vector<ivec3> cellsScratch_;
+    std::unordered_set<std::int64_t> occupancyScratch_;
 
     // Inverse-resample scratch (capacity reused across sets and frames).
     std::vector<std::int32_t> sourceSlotGrid_; // source cell → set-local slot, -1 empty
@@ -117,20 +120,6 @@ template <> struct System<REBUILD_GRID_VOXELS> {
     // volume. Past this many cells the set falls back to the forward map
     // for the frame (holes over a multi-ms CPU walk + a huge scratch grid).
     static constexpr std::int64_t kMaxDestWalkCells = 2'000'000;
-
-    // Pack an integer world cell into one sortable key. The ±2^20 bias keeps
-    // coordinates positive across the engine's working volume; a voxel further
-    // than 2^20 cells from origin would alias (far outside any real scene).
-    static std::int64_t packCell(const ivec3 &c) {
-        constexpr std::int64_t kBias = 1 << 20;
-        constexpr std::int64_t kSpan = 1 << 21;
-        return (static_cast<std::int64_t>(c.x) + kBias) +
-               (static_cast<std::int64_t>(c.y) + kBias) * kSpan +
-               (static_cast<std::int64_t>(c.z) + kBias) * kSpan * kSpan;
-    }
-    bool cellOccupied(const ivec3 &c) const {
-        return std::binary_search(cellKeys_.begin(), cellKeys_.end(), packCell(c));
-    }
 
     void beginTick() {
         lastCanvas_ = IREntity::kNullEntity;
@@ -567,38 +556,23 @@ template <> struct System<REBUILD_GRID_VOXELS> {
             poolGlobals.size() < baseIdx + static_cast<size_t>(safeCount)) {
             return;
         }
-        cellKeys_.clear();
-        cellRoundedPositions_.resize(static_cast<size_t>(safeCount));
+        // Round each slot's world global into its integer destination cell, then
+        // let the shared occupancy pass derive the six exposed-face bits — the
+        // same helper (and cell packing) system_rebuild_detached_voxels uses, so
+        // the GRID identity-arm and the detached re-voxelize path can't drift.
+        // Every slot is rounded so cellsScratch_ stays parallel to the pool
+        // sub-span [baseIdx, baseIdx + safeCount); inactive voxels contribute no
+        // occupancy and are skipped inside recomputeFaceOccupancyOnCells.
+        cellsScratch_.resize(static_cast<size_t>(safeCount));
         for (int i = 0; i < safeCount; ++i) {
-            if (poolColors[baseIdx + i].color_.alpha_ == 0) {
-                continue; // inactive voxel — not part of the rotated solid
-            }
-            const ivec3 rounded = IRMath::roundVec3HalfUp(poolGlobals[baseIdx + i].pos_);
-            cellRoundedPositions_[i] = rounded;
-            cellKeys_.push_back(packCell(rounded));
+            cellsScratch_[i] = IRMath::roundVec3HalfUp(poolGlobals[baseIdx + i].pos_);
         }
-        std::sort(cellKeys_.begin(), cellKeys_.end());
-        for (int i = 0; i < safeCount; ++i) {
-            C_Voxel &voxel = poolColors[baseIdx + i];
-            std::uint8_t face = 0u;
-            if (voxel.color_.alpha_ > 0) {
-                const ivec3 &cell = cellRoundedPositions_[i];
-                if (cellOccupied(cell + ivec3(-1, 0, 0)))
-                    face |= VoxelFlags::kFaceOccludedNegX;
-                if (cellOccupied(cell + ivec3(1, 0, 0)))
-                    face |= VoxelFlags::kFaceOccludedPosX;
-                if (cellOccupied(cell + ivec3(0, -1, 0)))
-                    face |= VoxelFlags::kFaceOccludedNegY;
-                if (cellOccupied(cell + ivec3(0, 1, 0)))
-                    face |= VoxelFlags::kFaceOccludedPosY;
-                if (cellOccupied(cell + ivec3(0, 0, -1)))
-                    face |= VoxelFlags::kFaceOccludedNegZ;
-                if (cellOccupied(cell + ivec3(0, 0, 1)))
-                    face |= VoxelFlags::kFaceOccludedPosZ;
-            }
-            voxel.flags_ =
-                static_cast<std::uint8_t>(voxel.flags_ & ~VoxelFlags::kFaceOccludedMask) | face;
-        }
+        IRPrefab::Voxel::recomputeFaceOccupancyOnCells(
+            std::span<const ivec3>(cellsScratch_.data(), static_cast<size_t>(safeCount)),
+            std::span<C_Voxel>(poolColors.data() + baseIdx, static_cast<size_t>(safeCount)),
+            safeCount,
+            occupancyScratch_
+        );
     }
 
     static SystemId create() {


### PR DESCRIPTION
## Summary
- `REBUILD_GRID_VOXELS::recomputeMaskFromGlobals` now calls the shared `IRPrefab::Voxel::recomputeFaceOccupancyOnCells` — pre-rounding pool globals into member `cellsScratch_`/`occupancyScratch_` and delegating (mirroring `system_rebuild_detached_voxels`), dropping the re-implemented `packCell` + sorted-vector + `binary_search` occupancy pass.
- Promoted a shared `IRPrefab::DepthProbe::parsePixelArg` into `depth_probe.hpp`; `canvas_stress` and `perf_grid` now call through it instead of each hand-rolling the `--depth-probe "X,Y"` `sscanf` parse.
- Dropped now-unused `<algorithm>` (grid system) and `<cstdio>` (perf_grid).

Both are pre-existing duplication surfaced by the simplify reuse fan-out; behavior-preserving.

## Verification (byte-identity)
- `canvas_stress` base-vs-dirty `--auto-screenshot` compare (`--no-spin --no-auto-rotate`): **10/12 shots byte-identical**. The 2 differing shots (01, 04) also differ **base-vs-base** (two origin/master runs) — pre-existing canvas_stress non-determinism, not this change (dirty-vs-base2 even matched 11/12).
- By construction: grid `packCell` ≡ the helper's `packCellKey` for any in-scene cell, and set-membership is identical (sorted-vector `binary_search` ≡ `unordered_set`), so the exposed-face bits are unchanged.
- Build: `IRCanvasStress` + `IRPerfGrid` clean (macOS/Metal).

## Test plan
- [ ] Confirm the GRID occupancy dedup preserves the exposed-face mask (packCell↔packCellKey equivalence; the identity arm + rotated arm both feed the shared helper).
- [ ] Confirm `parsePixelArg` placement in `depth_probe.hpp` + the two demo call-throughs; the `--depth-probe-assert X,Y,tier=N` superset parse deliberately stays local to canvas_stress.

## Follow-up (out of scope for #2160)
- simplify's call-sequence pass flagged that the ~10-line resize+round-loop *wrapper* still overlaps between the GRID and DETACHED systems (both already share the low-level `recomputeFaceOccupancyOnCells`). Pulling that wrapper into a position-callable helper would touch `face_occupancy.hpp` + the detached system (beyond this issue's grid-only scope) — left as a potential follow-up.

Closes #2160

🤖 Generated with [Claude Code](https://claude.com/claude-code)