### PR TITLE
engine: one-shot query-command primitive + Command<RANDOMIZE_VOXELS> (#17)

### DIFF
--- a/.fleet/plans/issue-17.md
+++ b/.fleet/plans/issue-17.md
@@ -1,0 +1,67 @@
+# Plan: add a one-shot query-command primitive (query-based command execution)
+
+- **Issue:** #17
+- **Model:** opus (label `fleet:opus`; plan's advisory `Model:` was sonnet, but the
+  task touches core `engine/system` + `engine/command` + ECS surface — opus lane)
+- **Date:** 2026-07-03 (planned by architect; implemented 2026-07-04)
+
+## Scope
+
+Add a run-once query-execution primitive to `IRSystem` — the run-now counterpart to
+`createSystemDynamic`: same archetype-node traversal, no `SystemId`, no pipeline
+registration, nothing persists. Then implement `Command<RANDOMIZE_VOXELS>` on top as
+the first consumer, honoring the enum's "exclude locked entities" note via a new
+`C_Locked` tag component. Lua exposure of the primitive itself is out of scope;
+`RANDOMIZE_VOXELS` becomes Lua-reachable for free through the existing `fireByName`
+binding.
+
+## Approach
+
+One-shot query surface in `IRSystem` (matches the issue's "running a system tick
+function one time" mental model), traversal shared via
+`IREntity::queryArchetypeNodesSimple` — the same call `executeSystem` makes.
+
+1. **`engine/system/include/irreden/ir_system.hpp`** — add `executeQueryDynamic`
+   (runtime-typed core: `IR_ASSERT_MAIN_THREAD()` + `queryArchetypeNodesSimple` +
+   `body(node)` per node, no SystemManager touch) and `executeQuery<Cs...>`
+   (compile-time-typed wrapper accepting `Exclude<...>`, resolving columns once per
+   node via `getComponentData<Cs>(node)` and row-iterating, dispatching `tick(Cs&...)`
+   or `tick(EntityId, Cs&...)` via `std::is_invocable_v`). Caller thread, serial,
+   main-thread-only. Bodies use `IREntity::deferred*` for structural changes;
+   `executeQuery` does not flush.
+2. **`engine/prefabs/irreden/common/components/component_locked.hpp`** (new) — empty
+   tag `struct C_Locked {};` mirroring `C_Persistent`.
+3. **`engine/prefabs/irreden/voxel/commands/command_randomize_voxels.hpp`** — implement
+   `Command<RANDOMIZE_VOXELS>::create()` running
+   `IRSystem::executeQuery<C_VoxelSetNew, IRSystem::Exclude<C_Locked>>(...)`; per set,
+   `set.editVoxels(...)`: skip alpha-0 voxels, otherwise `IRMath::randomColor()`
+   preserving the original alpha.
+4. **`engine/command/src/ir_command.cpp`** — include new header; promote
+   `RANDOMIZE_VOXELS` to real cases in `bindPrefabCommand` and `fireByName`.
+5. **`engine/command/CMakeLists.txt`** — PRIVATE-link `IrredenEngineSystem`.
+6. **`engine/command/include/irreden/command/ir_command_types.hpp`** — resolve the
+   2023 TODO comment.
+7. **`test/ecs/execute_query_test.cpp`** + **`test/ecs/command_randomize_voxels_test.cpp`**
+   (new) + register in `test/CMakeLists.txt`.
+8. **Docs** — `engine/system/CLAUDE.md` + `engine/command/CLAUDE.md`.
+
+## Acceptance criteria
+
+- `fleet-build --target IrredenEngineTest` green;
+  `IrredenEngineTest --gtest_filter='ExecuteQuery*:RandomizeVoxels*'` all pass.
+- `execute_query_test`: (a) visits entities across archetypes; (b) `Exclude` skips
+  tagged; (c) `EntityId`-form receives correct ids; (d) `executeQueryDynamic` fires
+  once per matched node; (e) no registration (system count unchanged, no re-run in
+  `executePipeline`).
+- `command_randomize_voxels_test` (headless pool + explicit `targetCanvas`): unlocked
+  set gets ≥1 RGB byte changed with every alpha preserved; carved voxel stays
+  inactive + mask unchanged; locked set byte-identical; fireByName no longer hits the
+  unimplemented log path.
+
+## Gotchas
+
+- `randomColor()` returns alpha 255 — preserve original alpha per voxel; skip alpha-0.
+- Use `editVoxels`, never raw `voxels_[i]` writes (GRID-rotation mirror resync, #2165).
+- Edit BOTH switches in ir_command.cpp (duplicate-case compile error guards one side).
+- Main-thread-only, no flush; zero matches is a silent no-op.
+- `IrredenEngineSystem` in engine/command's PRIVATE link block.

--- a/engine/command/CLAUDE.md
+++ b/engine/command/CLAUDE.md
@@ -27,6 +27,15 @@ struct IRCommand::Command<IRCommand::CommandNames::ZOOM_IN> {
 - `create()` returns a callable (often a lambda). No `SystemId`-like
   handle exists — the enum value *is* the identifier.
 
+A command body can run a one-shot ECS query rather than a plain side effect —
+the "act on every matching entity, once" shape. `Command<RANDOMIZE_VOXELS>`
+(`engine/prefabs/irreden/voxel/commands/`) uses
+`IRSystem::executeQuery<C_VoxelSetNew, Exclude<C_Locked>>(...)` to recolor
+every unlocked voxel set with no persistent system behind it — see
+`engine/system/CLAUDE.md` "One-shot queries (`executeQuery`)". A query-command
+header includes `ir_system.hpp`, so `engine/command` PRIVATE-links
+`IrredenEngineSystem`.
+
 A creation binds it to a trigger:
 
 ```cpp

--- a/engine/command/CMakeLists.txt
+++ b/engine/command/CMakeLists.txt
@@ -25,13 +25,15 @@ target_link_libraries(
 
 # PRIVATE: ir_command.cpp's fireByName dispatcher needs every prefab command
 # header in scope. Those headers reach into the IRRender / IRVideo / IRWindow
-# umbrellas, so the TU compiles against those include sets and the static
-# lib carries unresolved externals into them — both PRIVATE so the deps do
-# not leak through engine/command's PUBLIC interface (every downstream
-# consumer already links these libs via engine/world).
+# umbrellas (and IRSystem for query-driven commands like RANDOMIZE_VOXELS, #17),
+# so the TU compiles against those include sets and the static lib carries
+# unresolved externals into them — all PRIVATE so the deps do not leak through
+# engine/command's PUBLIC interface (every downstream consumer already links
+# these libs via engine/world).
 target_link_libraries(
     IrredenEngineCommand PRIVATE
     IrredenEngineRendering
     IrredenEngineVideo
     IrredenEngineWindow
+    IrredenEngineSystem
 )

--- a/engine/command/include/irreden/command/ir_command_types.hpp
+++ b/engine/command/include/irreden/command/ir_command_types.hpp
@@ -29,14 +29,14 @@ enum CommandNames {
     MOVE_CAMERA_DOWN_END,
     SCREENSHOT,        // captures the full screen output (debug overlay, HUD, etc.)
     SCREENSHOT_CANVAS, // captures the main canvas framebuffer only (no overlay)
-    RECORD_START, // todo
-    RECORD_STOP,  // todo
+    RECORD_START,      // todo
+    RECORD_STOP,       // todo
     RECORD_TOGGLE,
     STOP_VELOCITY,
     RESHAPE_SPHERE,
     RESHAPE_RECTANGULAR_PRISM,
-    RANDOMIZE_VOXELS, // TODO, should operate like a system with
-    // a query and stuff, and should exclude "locked entities"
+    RANDOMIZE_VOXELS, // one-shot IRSystem::executeQuery over C_VoxelSetNew,
+    // excluding C_Locked entities (#17) — see command_randomize_voxels.hpp
     LOCK_VOXEL_SCALE, // TODO: This will zoom in the rendered framebuffer,
     // and not change the on the canvas to framebuffer...
     UNLOCK_VOXEL_SCALE, // TODO: see above

--- a/engine/command/src/ir_command.cpp
+++ b/engine/command/src/ir_command.cpp
@@ -26,6 +26,7 @@
 #include <irreden/video/commands/command_take_screenshot.hpp>
 #include <irreden/video/commands/command_take_screenshot_canvas.hpp>
 #include <irreden/video/commands/command_toggle_recording.hpp>
+#include <irreden/voxel/commands/command_randomize_voxels.hpp>
 #include <irreden/voxel/commands/command_spawn_particle_mouse_position.hpp>
 
 namespace IRCommand {
@@ -225,6 +226,14 @@ CommandId bindPrefabCommand(
             requiredModifiers,
             blockedModifiers
         );
+    case RANDOMIZE_VOXELS:
+        return createCommand<RANDOMIZE_VOXELS>(
+            inputType,
+            triggerStatus,
+            button,
+            requiredModifiers,
+            blockedModifiers
+        );
     case NULL_COMMAND:
     case EXAMPLE:
     case RECORD_START:
@@ -232,7 +241,6 @@ CommandId bindPrefabCommand(
     case STOP_VELOCITY:
     case RESHAPE_SPHERE:
     case RESHAPE_RECTANGULAR_PRISM:
-    case RANDOMIZE_VOXELS:
     case LOCK_VOXEL_SCALE:
     case UNLOCK_VOXEL_SCALE:
     case SET_TRIXEL_COLOR:
@@ -315,6 +323,9 @@ void fireByName(CommandNames name) {
     case TOGGLE_CULLING_FREEZE:
         Command<TOGGLE_CULLING_FREEZE>::create()();
         return;
+    case RANDOMIZE_VOXELS:
+        Command<RANDOMIZE_VOXELS>::create()();
+        return;
     // The remaining CommandNames values are declared in the enum but have
     // no Command<NAME>::create() specialization. They exist as forward
     // declarations for systems that may someday land them; firing them
@@ -327,7 +338,6 @@ void fireByName(CommandNames name) {
     case STOP_VELOCITY:
     case RESHAPE_SPHERE:
     case RESHAPE_RECTANGULAR_PRISM:
-    case RANDOMIZE_VOXELS:
     case LOCK_VOXEL_SCALE:
     case UNLOCK_VOXEL_SCALE:
     case SET_TRIXEL_COLOR:

--- a/engine/prefabs/irreden/common/components/component_locked.hpp
+++ b/engine/prefabs/irreden/common/components/component_locked.hpp
@@ -1,0 +1,16 @@
+#ifndef COMPONENT_LOCKED_H
+#define COMPONENT_LOCKED_H
+
+namespace IRComponents {
+
+// Tag marking an entity as excluded from bulk query-driven mutation commands
+// (#17). The first consumer is `Command<RANDOMIZE_VOXELS>`, which runs
+// `IRSystem::executeQuery<C_VoxelSetNew, Exclude<C_Locked>>(...)` so a
+// locked voxel set keeps its colors when the rest of the scene randomizes.
+// Empty tag: holds no data, only group membership (the archetype matcher's
+// `Exclude<>` filter rejects nodes carrying it). Mirrors `C_Persistent`.
+struct C_Locked {};
+
+} // namespace IRComponents
+
+#endif /* COMPONENT_LOCKED_H */

--- a/engine/prefabs/irreden/voxel/commands/command_randomize_voxels.hpp
+++ b/engine/prefabs/irreden/voxel/commands/command_randomize_voxels.hpp
@@ -1,4 +1,42 @@
 #ifndef COMMAND_RANDOMIZE_VOXELS_H
 #define COMMAND_RANDOMIZE_VOXELS_H
 
+#include <irreden/ir_command.hpp>
+#include <irreden/ir_math.hpp>
+#include <irreden/ir_system.hpp>
+
+#include <irreden/common/components/component_locked.hpp>
+#include <irreden/voxel/components/component_voxel.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
+
+namespace IRCommand {
+
+// Randomize the RGB of every active voxel across all voxel sets, skipping any
+// entity tagged `C_Locked` (#17). Implemented as a one-shot query — the run-now
+// counterpart to a system tick — which is exactly what the enum's original note
+// asked for ("should operate like a system with a query ... exclude locked
+// entities"). The per-voxel alpha is preserved and alpha-0 (carved / inactive)
+// voxels are skipped, so `editVoxels`' resync leaves the pool's active-mask and
+// face occupancy unchanged — only visible colors move.
+template <> struct Command<RANDOMIZE_VOXELS> {
+    static auto create() {
+        return []() {
+            IRSystem::executeQuery<
+                IRComponents::C_VoxelSetNew,
+                IRSystem::Exclude<IRComponents::C_Locked>>([](IRComponents::C_VoxelSetNew &set) {
+                set.editVoxels([](int, IRComponents::C_Voxel &voxel, IRMath::vec3) {
+                    if (voxel.color_.alpha_ == 0) {
+                        return; // carved / inactive — keep it (mask stays stable)
+                    }
+                    IRMath::Color randomized = IRMath::randomColor();
+                    randomized.alpha_ = voxel.color_.alpha_; // preserve original alpha
+                    voxel.color_ = randomized;
+                });
+            });
+        };
+    }
+};
+
+} // namespace IRCommand
+
 #endif /* COMMAND_RANDOMIZE_VOXELS_H */

--- a/engine/system/CLAUDE.md
+++ b/engine/system/CLAUDE.md
@@ -29,6 +29,35 @@ resolves component vectors on the main thread and returns a
 the batch form and dynamic systems; row-iterating forms leave
 `functionTick_` empty.
 
+## One-shot queries (`executeQuery`)
+
+`executeQuery<Components...>(tick)` runs a tick body once over every entity
+matching the component set, **without registering a system** — the run-now
+counterpart to `createSystem` (the issue's "running a system tick function one
+time", #17). Same archetype-node traversal as `executeSystem`
+(`IREntity::queryArchetypeNodesSimple`, `Exclude<...>` filtering), same three
+tick shapes detected via `std::is_invocable_v`, but no `SystemId`, no pipeline
+slot, no timing / concurrency state — nothing persists.
+
+```cpp
+IRSystem::executeQuery<C_VoxelSetNew, IRSystem::Exclude<C_Locked>>(
+    [](C_VoxelSetNew& set) { set.editVoxels(...); });
+```
+
+`executeQueryDynamic(includeArchetype, excludeArchetype, body)` is the
+runtime-typed core (resolved `IREntity::Archetype` sets + a
+`void(ArchetypeNode*)` body, one call per matched node) — use it for
+whole-node / batch access. `executeQuery<Cs...>` composes on top, resolving
+columns once per node and dispatching per row.
+
+**Serial, main-thread-only** (`IR_ASSERT_MAIN_THREAD()`), same rationale as
+`createSystemDynamic`'s `PARALLEL_FOR` assert — never call from a worker body.
+It does **not** flush structural changes: bodies making structural edits must
+use the `IREntity::deferred*` API, and the pipeline's group boundary flushes.
+Zero matches is a silent no-op. The canonical consumer is
+`Command<RANDOMIZE_VOXELS>` (`engine/prefabs/irreden/voxel/commands/`), a
+query-driven command with no persistent system behind it.
+
 ## `replaceSystemBody` for hot-reload
 
 `replaceSystemBody(systemId, body)` swaps the per-archetype tick body of

--- a/engine/system/include/irreden/ir_system.hpp
+++ b/engine/system/include/irreden/ir_system.hpp
@@ -1,14 +1,17 @@
 #ifndef IR_SYSTEM_H
 #define IR_SYSTEM_H
 
+#include <irreden/ir_entity.hpp>
 #include <irreden/ir_time.hpp>
 
+#include <irreden/system/ir_assert_main_thread.hpp>
 #include <irreden/system/ir_system_types.hpp>
 #include <irreden/system/system_access.hpp>
 #include <irreden/system/system_manager.hpp>
 
 #include <functional>
 #include <optional>
+#include <tuple>
 #include <type_traits>
 
 namespace IRSystem {
@@ -403,6 +406,100 @@ inline SystemId createSystemDynamic(
         std::move(excludeArchetype),
         std::move(body),
         concurrency
+    );
+}
+
+// One-shot query execution — the run-now counterpart to `createSystemDynamic`
+// (#17). Runs `body` once per archetype node matching `(includeArchetype,
+// excludeArchetype)`, then returns. Nothing is registered: no `SystemId`, no
+// pipeline slot, no timing / concurrency state. The traversal shares
+// `IREntity::queryArchetypeNodesSimple` with `executeSystem`, so the node-match
+// semantics are identical, but the SystemManager never sees the call — this is
+// "run a system tick function one time" without the persistent machinery.
+//
+// Serial, main-thread-only (same rationale as `createSystemDynamic`'s
+// `PARALLEL_FOR` assert — `getComponentData`'s manager hash lookups aren't
+// worker-safe). Structural changes inside `body` must use the `IREntity::
+// deferred*` API; this primitive does NOT flush (the pipeline's group boundary
+// owns that). Zero matches is a silent no-op — correct for a command.
+template <typename PerNodeFn>
+void executeQueryDynamic(
+    const IREntity::Archetype &includeArchetype,
+    const IREntity::Archetype &excludeArchetype,
+    PerNodeFn &&body
+) {
+    IR_ASSERT_MAIN_THREAD();
+    auto nodes = IREntity::queryArchetypeNodesSimple(includeArchetype, excludeArchetype);
+    for (auto *node : nodes) {
+        body(node);
+    }
+}
+
+namespace detail {
+
+// Per-row dispatch for `executeQuery<Cs...>`. Resolves each component column
+// ONCE per node (`getComponentData` is a per-call manager lookup — hoisting it
+// out of the row loop is the same "no getComponent in a tick" discipline the
+// scheduler follows), then invokes the tick per row. Two forms, mirroring
+// `createSystem`'s per-component and per-entity-id signatures; whole-node batch
+// consumers call `executeQueryDynamic` directly.
+template <typename L> struct RunQueryRows;
+template <typename... Cs> struct RunQueryRows<TypeList<Cs...>> {
+    template <typename FunctionTick>
+    static void
+    run(const IREntity::Archetype &includeArchetype,
+        const IREntity::Archetype &excludeArchetype,
+        FunctionTick &&tick) {
+        executeQueryDynamic(
+            includeArchetype,
+            excludeArchetype,
+            [&tick](IREntity::ArchetypeNode *node) {
+                auto columns = std::tie(IREntity::getComponentData<Cs>(node)...);
+                if constexpr (InvocableWithComponents<FunctionTick, Cs...>) {
+                    for (int i = 0; i < node->length_; ++i) {
+                        std::apply([&](auto &...cols) { tick(cols[i]...); }, columns);
+                    }
+                } else if constexpr (InvocableWithEntityId<FunctionTick, Cs...>) {
+                    auto &entities = node->entities_;
+                    for (int i = 0; i < node->length_; ++i) {
+                        std::apply([&](auto &...cols) { tick(entities[i], cols[i]...); }, columns);
+                    }
+                } else {
+                    static_assert(
+                        false,
+                        "executeQuery<Cs...>: the tick must match tick(Cs&...) or "
+                        "tick(EntityId, Cs&...). For whole-archetype batch access, "
+                        "call executeQueryDynamic directly."
+                    );
+                }
+            }
+        );
+    }
+};
+
+} // namespace detail
+
+// Compile-time-typed one-shot query — the run-now counterpart to
+// `createSystem<Cs...>` (#17). `QueryComponents...` may include `Exclude<...>`
+// markers, partitioned out at compile time exactly like `createSystem` (so
+// tagged entities skip the query with no per-entity branching). Resolves the
+// include / exclude archetypes, then dispatches the tick per matched row via
+// `executeQueryDynamic`. See `executeQueryDynamic` for the threading +
+// deferred-ops contract.
+//
+//     IRSystem::executeQuery<C_VoxelSetNew, IRSystem::Exclude<C_Locked>>(
+//         [](C_VoxelSetNew &set) { set.editVoxels(...); });
+template <typename... QueryComponents, typename FunctionTick>
+void executeQuery(FunctionTick &&tick) {
+    using Partition = detail::PartitionExcludes<QueryComponents...>;
+    IREntity::Archetype excludeArchetype =
+        detail::ArchetypeFromList<typename Partition::Excluded>::value();
+    using IncludedList = detail::FilterTags_t<QueryComponents...>;
+    IREntity::Archetype includeArchetype = detail::ArchetypeFromList<IncludedList>::value();
+    detail::RunQueryRows<IncludedList>::run(
+        includeArchetype,
+        excludeArchetype,
+        std::forward<FunctionTick>(tick)
     );
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,9 @@ add_executable(IrredenEngineTest
   audio/music_theory_test.cpp
   common/ir_args_test.cpp
   common/ir_platform_test.cpp
+  ecs/command_randomize_voxels_test.cpp
   ecs/entity_manager_test.cpp
+  ecs/execute_query_test.cpp
   ecs/grid_rotation_test.cpp
   ecs/hitbox_2d_gui_test.cpp
   ecs/joint_matrix_upload_test.cpp

--- a/test/ecs/command_randomize_voxels_test.cpp
+++ b/test/ecs/command_randomize_voxels_test.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_command.hpp>
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_math.hpp>
+
+#include <irreden/common/components/component_locked.hpp>
+#include <irreden/voxel/components/component_voxel.hpp>
+#include <irreden/voxel/components/component_voxel_pool.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
+
+#include <vector>
+
+// Covers Command<RANDOMIZE_VOXELS> (#17), the first consumer of the one-shot
+// IRSystem::executeQuery primitive. The command randomizes every active voxel's
+// RGB across all voxel sets while (a) excluding C_Locked-tagged entities via the
+// Exclude<> archetype filter, (b) preserving each voxel's original alpha, and
+// (c) skipping alpha-0 (carved) voxels — so the pool's active-mask stays stable
+// through editVoxels' resync. Fired through IRCommand::fireByName, which also
+// proves the enum value now dispatches to a real specialization instead of the
+// unimplemented-log fall-through.
+//
+// Headless: the explicit targetCanvas arg on C_VoxelSetNew routes pool ops
+// through a specific canvas entity, bypassing the RenderManager active-canvas
+// lookup (same fixture as voxel_set_edit_api_test.cpp). RNG is seeded so the
+// randomization is deterministic run-to-run and independent of prior tests.
+
+namespace {
+
+using IRComponents::C_Locked;
+using IRComponents::C_Voxel;
+using IRComponents::C_VoxelPool;
+using IRComponents::C_VoxelSetNew;
+using IRComponents::kVoxelActiveMaskBits;
+using IRMath::Color;
+using IRMath::ivec3;
+
+class CommandRandomizeVoxelsTest : public ::testing::Test {
+  protected:
+    IREntity::EntityManager m_entityManager;
+
+    // Pool active-mask bit for the voxel at set-local flat index `localIndex`.
+    static bool maskBit(const C_VoxelSetNew &set, const C_VoxelPool &pool, int localIndex) {
+        const std::size_t slot = set.voxelStartIdx_ + static_cast<std::size_t>(localIndex);
+        return (pool.getActiveMask()[slot / kVoxelActiveMaskBits] >>
+                (slot % kVoxelActiveMaskBits)) &
+               1u;
+    }
+};
+
+TEST_F(CommandRandomizeVoxelsTest, RandomizesUnlockedPreservesAlphaSkipsLockedAndCarved) {
+    IRMath::seedThreadRng(12345u);
+
+    const IREntity::EntityId canvas = IREntity::createEntity(C_VoxelPool{ivec3(8, 8, 8)});
+
+    // Unlocked set: solid opaque; we carve one voxel to alpha 0 below.
+    const IREntity::EntityId unlocked = IREntity::createEntity(
+        C_VoxelSetNew{ivec3(3, 3, 3), Color{200, 100, 50, 255}, false, canvas}
+    );
+    // Locked set: solid opaque, tagged C_Locked so the query's Exclude<> skips it.
+    const IREntity::EntityId locked = IREntity::createEntity(
+        C_VoxelSetNew{ivec3(2, 2, 2), Color{10, 20, 30, 255}, false, canvas},
+        C_Locked{}
+    );
+
+    auto &unlockedSet = IREntity::getComponent<C_VoxelSetNew>(unlocked);
+    auto &lockedSet = IREntity::getComponent<C_VoxelSetNew>(locked);
+    ASSERT_EQ(unlockedSet.numVoxels_, 27);
+    ASSERT_EQ(lockedSet.numVoxels_, 8);
+
+    // Carve local voxel 0 (alpha -> 0), then resync so the pool mask reflects it.
+    unlockedSet.voxels_[0].deactivate();
+    unlockedSet.resyncAfterRawEdits();
+
+    const auto &pool = IREntity::getComponent<C_VoxelPool>(canvas);
+
+    // Snapshot colors + the carved voxel's mask bit before firing.
+    std::vector<Color> unlockedBefore;
+    std::vector<Color> lockedBefore;
+    for (int i = 0; i < unlockedSet.numVoxels_; ++i) {
+        unlockedBefore.push_back(unlockedSet.voxels_[i].color_);
+    }
+    for (int i = 0; i < lockedSet.numVoxels_; ++i) {
+        lockedBefore.push_back(lockedSet.voxels_[i].color_);
+    }
+    ASSERT_FALSE(maskBit(unlockedSet, pool, 0)) << "carved voxel starts inactive";
+
+    IRCommand::fireByName(IRCommand::RANDOMIZE_VOXELS);
+
+    // Unlocked set: alpha preserved on every voxel, and at least one active
+    // voxel's RGB changed (the randomization actually ran — proving fireByName
+    // dispatched to the specialization, not the unimplemented-log path).
+    bool anyRgbChanged = false;
+    for (int i = 0; i < unlockedSet.numVoxels_; ++i) {
+        const Color &before = unlockedBefore[i];
+        const Color &after = unlockedSet.voxels_[i].color_;
+        EXPECT_EQ(after.alpha_, before.alpha_) << "alpha preserved at voxel " << i;
+        if (after.red_ != before.red_ || after.green_ != before.green_ ||
+            after.blue_ != before.blue_) {
+            anyRgbChanged = true;
+        }
+    }
+    EXPECT_TRUE(anyRgbChanged) << "randomize should recolor the unlocked set";
+
+    // Carved voxel 0 is skipped entirely: color byte-identical, still inactive,
+    // pool mask unchanged.
+    EXPECT_EQ(unlockedSet.voxels_[0].color_.red_, unlockedBefore[0].red_);
+    EXPECT_EQ(unlockedSet.voxels_[0].color_.green_, unlockedBefore[0].green_);
+    EXPECT_EQ(unlockedSet.voxels_[0].color_.blue_, unlockedBefore[0].blue_);
+    EXPECT_EQ(unlockedSet.voxels_[0].color_.alpha_, 0);
+    EXPECT_FALSE(maskBit(unlockedSet, pool, 0)) << "carved voxel stays inactive";
+
+    // Locked set: byte-identical (excluded from the query).
+    for (int i = 0; i < lockedSet.numVoxels_; ++i) {
+        EXPECT_EQ(lockedSet.voxels_[i].color_.red_, lockedBefore[i].red_);
+        EXPECT_EQ(lockedSet.voxels_[i].color_.green_, lockedBefore[i].green_);
+        EXPECT_EQ(lockedSet.voxels_[i].color_.blue_, lockedBefore[i].blue_);
+        EXPECT_EQ(lockedSet.voxels_[i].color_.alpha_, lockedBefore[i].alpha_);
+    }
+}
+
+} // namespace

--- a/test/ecs/execute_query_test.cpp
+++ b/test/ecs/execute_query_test.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <irreden/ir_entity.hpp>
+#include <irreden/ir_system.hpp>
+#include <irreden/ir_time.hpp>
+
+#include <algorithm>
+#include <vector>
+
+// Covers the one-shot query primitive `IRSystem::executeQuery<Cs...>` /
+// `executeQueryDynamic` (#17) — the run-now counterpart to
+// `createSystem` / `createSystemDynamic`. The contract: same archetype-node
+// traversal as a system tick (include + Exclude<> filtering), but nothing is
+// registered — no SystemId, no pipeline slot, no persistent state. These tests
+// assert both the dispatch shapes (per-component, per-entity-id, per-node) and
+// the "leaves no trace on the SystemManager" invariant that separates this from
+// `createSystem`.
+
+namespace {
+
+// Plain data + tag types — TU-local so they don't pollute the engine's
+// component registry across test files.
+struct Counter {
+    int n_ = 0;
+};
+struct ExcludeTag {};
+
+class ExecuteQueryTest : public testing::Test {
+  protected:
+    ExecuteQueryTest()
+        : m_entityManager{}
+        , m_systemManager{} {}
+
+    IREntity::EntityManager m_entityManager;
+    IRSystem::SystemManager m_systemManager;
+};
+
+// (a) executeQuery<Counter> visits every entity carrying Counter, across the
+// two distinct archetypes (Counter-only vs Counter+ExcludeTag).
+TEST_F(ExecuteQueryTest, PerComponentVisitsAcrossArchetypes) {
+    auto idA = IREntity::createEntity(Counter{0});               // archetype 1
+    auto idB = IREntity::createEntity(Counter{0}, ExcludeTag{}); // archetype 2
+
+    IRSystem::executeQuery<Counter>([](Counter &c) { c.n_++; });
+
+    EXPECT_EQ(IREntity::getComponent<Counter>(idA).n_, 1);
+    EXPECT_EQ(IREntity::getComponent<Counter>(idB).n_, 1);
+}
+
+// (b) Exclude<> in the query params skips tagged entities via archetype
+// rejection — no per-entity branching in the body.
+TEST_F(ExecuteQueryTest, ExcludeSkipsTaggedEntities) {
+    auto idA = IREntity::createEntity(Counter{0});
+    auto idB = IREntity::createEntity(Counter{0}, ExcludeTag{});
+
+    IRSystem::executeQuery<Counter, IRSystem::Exclude<ExcludeTag>>([](Counter &c) { c.n_++; });
+
+    EXPECT_EQ(IREntity::getComponent<Counter>(idA).n_, 1) << "untagged runs";
+    EXPECT_EQ(IREntity::getComponent<Counter>(idB).n_, 0) << "tagged excluded";
+}
+
+// (c) The EntityId tick form receives the correct ids.
+TEST_F(ExecuteQueryTest, EntityIdFormReceivesCorrectIds) {
+    auto idA = IREntity::createEntity(Counter{0});
+    auto idB = IREntity::createEntity(Counter{0}, ExcludeTag{});
+
+    std::vector<IREntity::EntityId> visited;
+    IRSystem::executeQuery<Counter>([&visited](IREntity::EntityId id, Counter &c) {
+        visited.push_back(id);
+        c.n_++;
+    });
+
+    EXPECT_EQ(visited.size(), 2u);
+    EXPECT_NE(std::find(visited.begin(), visited.end(), idA), visited.end());
+    EXPECT_NE(std::find(visited.begin(), visited.end(), idB), visited.end());
+    EXPECT_EQ(IREntity::getComponent<Counter>(idA).n_, 1);
+    EXPECT_EQ(IREntity::getComponent<Counter>(idB).n_, 1);
+}
+
+// (d) executeQueryDynamic fires exactly once per matched archetype node.
+TEST_F(ExecuteQueryTest, DynamicFiresOncePerMatchedNode) {
+    IREntity::createEntity(Counter{0});               // node 1
+    IREntity::createEntity(Counter{0});               // same node 1
+    IREntity::createEntity(Counter{0}, ExcludeTag{}); // node 2
+
+    int nodeVisits = 0;
+    IRSystem::executeQueryDynamic(
+        IREntity::getArchetype<Counter>(),
+        IREntity::Archetype{},
+        [&nodeVisits](IREntity::ArchetypeNode *) { ++nodeVisits; }
+    );
+
+    EXPECT_EQ(nodeVisits, 2) << "one fire per archetype containing Counter";
+}
+
+// Zero matches is a silent no-op (correct for a command with nothing to act on).
+TEST_F(ExecuteQueryTest, ZeroMatchesIsNoOp) {
+    int bodyRuns = 0;
+    IRSystem::executeQuery<Counter>([&bodyRuns](Counter &) { ++bodyRuns; });
+    EXPECT_EQ(bodyRuns, 0);
+}
+
+// (e) No registration: the query leaves the SystemManager's system count
+// unchanged, and a subsequent executePipeline does NOT re-run the body (proof
+// it didn't secretly register a persistent system).
+TEST_F(ExecuteQueryTest, LeavesNoRegisteredSystem) {
+    auto id = IREntity::createEntity(Counter{0});
+
+    const IRSystem::SystemId countBefore = m_systemManager.getSystemCount();
+    IRSystem::executeQuery<Counter>([](Counter &c) { c.n_++; });
+    const IRSystem::SystemId countAfter = m_systemManager.getSystemCount();
+
+    EXPECT_EQ(countBefore, countAfter) << "executeQuery registers no system";
+    EXPECT_EQ(IREntity::getComponent<Counter>(id).n_, 1);
+
+    // An empty pipeline tick must not re-run the query body.
+    m_systemManager.executePipeline(IRTime::Events::UPDATE);
+    EXPECT_EQ(IREntity::getComponent<Counter>(id).n_, 1)
+        << "the one-shot query does not persist into the pipeline";
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Add `IRSystem::executeQuery<Cs...>` / `executeQueryDynamic` — the run-now
  counterpart to `createSystem` / `createSystemDynamic` (#17's "running a system
  tick function one time"): same archetype-node traversal + `Exclude<>` filtering,
  but nothing is registered (no `SystemId`, no pipeline slot, no persistent state).
  Serial + main-thread-only; does not flush structural changes.
- Implement `Command<RANDOMIZE_VOXELS>` as the first consumer — recolors every
  active voxel via `editVoxels`, excluding a new `C_Locked` tag component,
  preserving each voxel's alpha and skipping alpha-0 (carved) voxels so the pool
  active-mask stays stable. Promote `RANDOMIZE_VOXELS` out of both `fireByName` /
  `bindPrefabCommand` fall-throughs; `engine/command` PRIVATE-links `IrredenEngineSystem`.
- Docs: `engine/system/CLAUDE.md` "One-shot queries", `engine/command/CLAUDE.md`
  query-command note. Plan committed as the first commit (`.fleet/plans/issue-17.md`).

## Test plan
- [x] `fleet-build --target IrredenEngineTest` green (macOS/Metal).
- [x] New `ExecuteQuery*` (6) + `CommandRandomizeVoxels*` (1) suites pass — dispatch
      shapes, `Exclude<>`, once-per-node, no-registration, alpha-preserve, locked/carved.
- [x] Full suite: 1266 passed, 1 skipped (OpenGL-only GPU compute test).

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)