### PR TITLE
render: document GLSL-vs-Metal trixel parity-shift asymmetry (#442)

### DIFF
--- a/docs/design/trixel-parity-shift-442-investigation.md
+++ b/docs/design/trixel-parity-shift-442-investigation.md
@@ -1,0 +1,80 @@
+# #442 — GL-vs-Metal trixel→framebuffer parity-shift asymmetry
+
+**Issue:** #442 (investigation spike). **Status:** RESOLVED — keep-and-document,
+no follow-up fix ticket filed (see ## Decision).
+
+**Host:** macOS / Metal + Linux / GL (both backends read against source; no
+runtime change — output is byte-identical to before the spike).
+
+Records *why* the `TRIXEL_TO_FRAMEBUFFER` gather applies the parity-row shift
+(`trixelFramebufferSamplePosition`) to its color/depth reads on **GL** but reads
+them **raw** on **Metal**, and the reconciliation decision. The in-source
+comments at the five sites below carry only the present-tense invariant plus a
+one-line backref to this file.
+
+## The parity shift
+
+`trixelFramebufferSamplePosition` (`ir_iso_common.{glsl,metal}`) resolves which
+of an iso texel-cell's two diagonal-split triangles a fragment covers, by
+conditionally decrementing **`origin.y`** one row (parity bit + a sub-pixel
+`fract` test). It only ever adjusts `.y`, never `.x`, and is byte-identical to
+CPU `IRMath::pos2DIsoToTriangleIndex` (`ir_math.cpp`) — the picking/hover path
+reuses it so GPU and CPU agree on which trixel the mouse is over.
+
+## The asymmetry (canonical why)
+
+Both backends build **identical** per-vertex `TexCoords`, but the vertex clip
+position differs: GLSL emits `mpMatrix * aPos` unflipped, while every Metal
+`*_to_*` pass negates `out.position.y`. That negate is the standard adapter for
+the opposite framebuffer-Y origins — OpenGL's default framebuffer is
+**bottom-left** (`gl_FragCoord.y` increases up), Metal's render target is
+**top-left** (`position.y` increases down) — so one GL-authored `mpMatrix`
+renders right-side-up on both (see `engine/render/CLAUDE.md` §"Metal negates
+clip `position.y`; GL does not").
+
+Under those opposite conventions the **same** screen pixel interpolates a
+`TexCoords.y` whose floor/fract land it on **opposite** sides of the cell's
+diagonal split — a one-row difference exactly at that boundary:
+
+- GL's raw sample lands on the row that needs the `-1` correction, so GL applies
+  the shift to all color/depth/id reads.
+- Metal's flipped raster already lands the raw sample on the correct row (its
+  raster supplies the equivalent one-row correction implicitly), so Metal reads
+  color/depth from the **raw** origin.
+
+Applying the GL shift on Metal over-corrects by one row → the 1px iso-diagonal
+sawtooth that **#394** introduced and **#438** reverted.
+
+### Ruled-out candidates
+
+- **X-axis / horizontal offset.** The shift touches only `.y`, never `.x`. A
+  cause in the horizontal indexing (or in the `originModifier` parity math,
+  which is symmetric in x/y) would have shown an `.x` component. The pure-`.y`
+  signature is the tell that the cause is the raster-Y origin.
+- **Float rounding at the cell boundary.** Both backends run the same
+  `floor`/`fract` on the same interpolated `TexCoords` in the same precision;
+  swapping the shift sign or the parity branch on Metal did not remove the
+  sawtooth (only reintroduced it elsewhere), which a rounding cause would not do.
+  The defect tracks the raster-Y convention, not the arithmetic.
+
+## Decision: keep-and-document, not reconcile
+
+Both backends read the **correct** trixel for their own raster convention;
+neither samples the wrong one, so this is **not a latent bug** — per the spike's
+acceptance criteria, no follow-up fix ticket is filed. Aligning both to one
+indexing convention would mean fighting one backend's native framebuffer-Y
+origin (re-opening the #394/#438 regression surface) for zero correctness gain.
+
+**Picking is the one shared exception.** Both backends apply the shift to the
+*hover* coordinate, because it must match CPU `mouseTrixelPositionWorld()` →
+`pos2DIsoToTriangleIndex` (computed independently of GPU raster-Y), even though
+only GL applies it to the color/depth gather. On Metal this is why the gather
+site computes `originRaw` (color/depth) and `originShifted` (hover id) separately.
+
+## In-source sites (trimmed to the invariant + backref)
+
+- `ir_iso_common.glsl` / `metal/ir_iso_common.metal` —
+  `trixelFramebufferSamplePosition` definition.
+- `f_trixel_to_framebuffer.glsl` / `metal/trixel_to_framebuffer.metal` — the two
+  gather call sites.
+- `engine/render/CLAUDE.md` §"Trixel→framebuffer parity shift (GL-only)".

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -116,6 +116,55 @@ header when you add or rename a shader.
 `RenderDevice` interfaces. `RenderManager` holds one via `unique_ptr`.
 Platform selection is compile-time (`IR_GRAPHICS_OPENGL` / `_METAL`).
 
+### Metal negates clip `position.y`; GL does not
+
+Every Metal `*_to_*` vertex stage (`trixel_to_framebuffer`,
+`framebuffer_to_screen`, `sprites_to_screen`, `debug_overlay`) computes
+`out.position = mpMatrix * aPos` and then `out.position.y = -out.position.y`.
+The GLSL twins emit `mpMatrix * aPos` unflipped. This is not a per-shader
+quirk — it is the single adapter that lets **one GL-authored projection
+matrix** render right-side-up on both backends despite their opposite
+framebuffer-Y origins: OpenGL's default framebuffer is **bottom-left** origin
+(`gl_FragCoord.y` increases upward), Metal's render target is **top-left**
+(`position.y` increases downward). When you add or port a full-screen /
+quad pass, mirror this negate on the Metal side or the image renders
+upside-down.
+
+## Trixel->framebuffer parity shift (GL-only)
+
+The `TRIXEL_TO_FRAMEBUFFER` gather samples the canvas at
+`origin = TexCoords * textureSize`. Each iso texel-cell holds two triangles
+split along a diagonal; `trixelFramebufferSamplePosition`
+(`ir_iso_common.{glsl,metal}`) resolves which half a fragment covers by
+conditionally decrementing **`origin.y`** by one row (parity bit + a sub-pixel
+`fract` test, byte-identical to CPU `IRMath::pos2DIsoToTriangleIndex`).
+
+**GL applies that shift to the color/depth/id reads; Metal reads color/depth
+from the raw origin (#442).** Both backends build identical per-vertex
+`TexCoords`, but per the "Metal negates clip `position.y`" note above they
+rasterize that quad under **opposite framebuffer-Y origins**. Under those
+opposite conventions the same on-screen pixel interpolates a `TexCoords.y`
+that floors to the *opposite* side of the cell's diagonal split — a one-row
+difference exactly at that boundary. GL's raw sample lands on the row that
+needs the `-1` correction (so GL shifts); Metal's flipped raster already lands
+the raw sample on the correct row (it supplies the equivalent one-row
+correction implicitly), so Metal reads raw — applying the GL shift on Metal
+over-corrects by one row, the 1px iso-diagonal sawtooth **#394** introduced and
+**#438** reverted. The shift touching only `.y` (never `.x`) is the tell that
+the cause is the raster-Y origin, not X or float-rounding.
+
+**Decision (spike #442): keep-and-document, not reconcile.** Both backends read
+the *correct* trixel for their own raster convention; neither samples the wrong
+one, so this is not a latent bug. Aligning both to one indexing convention
+would mean fighting one backend's native framebuffer-Y origin (re-opening the
+#394/#438 regression surface) for zero correctness gain. **Picking is the one
+shared exception:** both backends apply the shift to the *hover* coordinate,
+because it must match CPU `mouseTrixelPositionWorld()` -> `pos2DIsoToTriangleIndex`
+(computed independently of GPU raster-Y), even though only GL applies it to the
+color/depth gather. Before editing either `f_trixel_to_framebuffer` shader or
+`trixelFramebufferSamplePosition`, read the canonical note on the GLSL twin of
+that function.
+
 ## What belongs in engine/render/ vs engine/prefabs/irreden/render/
 
 `engine/render/` is a graphics primitive library. It owns what the pipeline

--- a/engine/render/CLAUDE.md
+++ b/engine/render/CLAUDE.md
@@ -130,7 +130,7 @@ framebuffer-Y origins: OpenGL's default framebuffer is **bottom-left** origin
 quad pass, mirror this negate on the Metal side or the image renders
 upside-down.
 
-## Trixel->framebuffer parity shift (GL-only)
+### Trixel→framebuffer parity shift (GL-only)
 
 The `TRIXEL_TO_FRAMEBUFFER` gather samples the canvas at
 `origin = TexCoords * textureSize`. Each iso texel-cell holds two triangles
@@ -140,30 +140,22 @@ conditionally decrementing **`origin.y`** by one row (parity bit + a sub-pixel
 `fract` test, byte-identical to CPU `IRMath::pos2DIsoToTriangleIndex`).
 
 **GL applies that shift to the color/depth/id reads; Metal reads color/depth
-from the raw origin (#442).** Both backends build identical per-vertex
-`TexCoords`, but per the "Metal negates clip `position.y`" note above they
-rasterize that quad under **opposite framebuffer-Y origins**. Under those
-opposite conventions the same on-screen pixel interpolates a `TexCoords.y`
-that floors to the *opposite* side of the cell's diagonal split — a one-row
-difference exactly at that boundary. GL's raw sample lands on the row that
-needs the `-1` correction (so GL shifts); Metal's flipped raster already lands
-the raw sample on the correct row (it supplies the equivalent one-row
-correction implicitly), so Metal reads raw — applying the GL shift on Metal
-over-corrects by one row, the 1px iso-diagonal sawtooth **#394** introduced and
-**#438** reverted. The shift touching only `.y` (never `.x`) is the tell that
-the cause is the raster-Y origin, not X or float-rounding.
+from the raw origin.** Both backends build identical per-vertex `TexCoords`, but
+per the "Metal negates clip `position.y`" note above they rasterize that quad
+under **opposite framebuffer-Y origins**: GL's raw sample lands on the row that
+needs the shift, while Metal's flipped raster already lands the raw sample on the
+correct row (the equivalent one-row correction, applied implicitly). Both read
+the *correct* trixel for their own raster convention — not a latent bug, so the
+asymmetry is kept, not reconciled. **Picking is the one shared exception:** both
+backends apply the shift to the *hover* coordinate, because it must match CPU
+`mouseTrixelPositionWorld()` → `pos2DIsoToTriangleIndex` (computed independently
+of GPU raster-Y), even though only GL applies it to the color/depth gather.
 
-**Decision (spike #442): keep-and-document, not reconcile.** Both backends read
-the *correct* trixel for their own raster convention; neither samples the wrong
-one, so this is not a latent bug. Aligning both to one indexing convention
-would mean fighting one backend's native framebuffer-Y origin (re-opening the
-#394/#438 regression surface) for zero correctness gain. **Picking is the one
-shared exception:** both backends apply the shift to the *hover* coordinate,
-because it must match CPU `mouseTrixelPositionWorld()` -> `pos2DIsoToTriangleIndex`
-(computed independently of GPU raster-Y), even though only GL applies it to the
-color/depth gather. Before editing either `f_trixel_to_framebuffer` shader or
-`trixelFramebufferSamplePosition`, read the canonical note on the GLSL twin of
-that function.
+Before editing either `f_trixel_to_framebuffer` shader or
+`trixelFramebufferSamplePosition`, read
+[`docs/design/trixel-parity-shift-442-investigation.md`](../../docs/design/trixel-parity-shift-442-investigation.md)
+— it carries the #394/#438/#442 timeline, the ruled-out X-axis/rounding
+candidates, and the keep-and-document decision.
 
 ## What belongs in engine/render/ vs engine/prefabs/irreden/render/
 

--- a/engine/render/src/shaders/f_trixel_to_framebuffer.glsl
+++ b/engine/render/src/shaders/f_trixel_to_framebuffer.glsl
@@ -71,6 +71,10 @@ void main() {
     ivec2 z1 = trixelOriginOffsetZ1(textureSize);
     vec2 origin = TexCoords * vec2(textureSize);
     int originModifier = trixelOriginModifier(z1, canvasOffset);
+    // Parity-row shift applied to ALL reads on GL (color/depth/id). #442: this is
+    // GL-only — Metal reads color/depth from the raw origin because its flipped
+    // raster (top-left target vs GL's bottom-left) already lands on the right
+    // row. Canonical why: trixelFramebufferSamplePosition in ir_iso_common.glsl.
     origin = trixelFramebufferSamplePosition(origin, originModifier);
 
     vec4 color = textureLod(triangleColors, origin / textureSize, 0);

--- a/engine/render/src/shaders/f_trixel_to_framebuffer.glsl
+++ b/engine/render/src/shaders/f_trixel_to_framebuffer.glsl
@@ -71,10 +71,11 @@ void main() {
     ivec2 z1 = trixelOriginOffsetZ1(textureSize);
     vec2 origin = TexCoords * vec2(textureSize);
     int originModifier = trixelOriginModifier(z1, canvasOffset);
-    // Parity-row shift applied to ALL reads on GL (color/depth/id). #442: this is
-    // GL-only — Metal reads color/depth from the raw origin because its flipped
-    // raster (top-left target vs GL's bottom-left) already lands on the right
-    // row. Canonical why: trixelFramebufferSamplePosition in ir_iso_common.glsl.
+    // Parity-row shift applied to ALL reads on GL (color/depth/id); GL-only —
+    // Metal reads color/depth from the raw origin because its flipped raster
+    // (top-left target vs GL's bottom-left) already lands on the right row. See
+    // trixelFramebufferSamplePosition in ir_iso_common.glsl; #442,
+    // docs/design/trixel-parity-shift-442-investigation.md.
     origin = trixelFramebufferSamplePosition(origin, originModifier);
 
     vec4 color = textureLod(triangleColors, origin / textureSize, 0);

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -425,32 +425,14 @@ int trixelOriginModifier(ivec2 trixelCanvasOffsetZ1, vec2 frameCanvasOffset) {
 // `pos2DIsoToTriangleIndex` (ir_math.cpp) — the picking/hover path reuses it so
 // GPU and CPU agree on which trixel the mouse is over.
 //
-// #442 — canonical reason GL applies this to the color/depth read while Metal
-// does not (the pre-#438 asymmetry). Both backends build IDENTICAL per-vertex
-// TexCoords, but the vertex clip position differs: GLSL emits `mpMatrix*aPos`
-// unflipped, while every Metal `*_to_*` pass negates `position.y`. That negate
-// is the standard adapter for the opposite framebuffer-Y origins — OpenGL's
-// default framebuffer is bottom-left (`gl_FragCoord.y` increases up), Metal's
-// render target is top-left (`position.y` increases down) — letting one
-// GL-authored `mpMatrix` render right-side-up on both. Under those opposite
-// conventions the SAME screen pixel interpolates a TexCoords.y whose floor/fract
-// land it on OPPOSITE sides of the diagonal split — a one-row difference exactly
-// at this boundary. GL's raw sample falls on the row that needs the -1
-// correction, so GL applies the shift to all reads; Metal's flipped raster
-// already lands the raw sample on the correct row (its raster supplies the
-// equivalent one-row correction implicitly), so Metal reads color/depth from the
-// RAW origin — applying this shift there over-corrects by one row (the 1px
-// iso-diagonal sawtooth #394 introduced, #438 reverted). The `.y`-only
-// adjustment is consistent with a pure raster-Y-origin cause and rules out any
-// X-axis or float-rounding explanation.
-//
-// Both backends therefore read the CORRECT trixel for their own raster; neither
-// samples the wrong one, so the asymmetry is convention-consistent and kept
-// (not reconciled to a shared convention) — see engine/render/CLAUDE.md
-// "Trixel->framebuffer parity shift (GL-only)". Picking is the shared exception:
-// BOTH backends apply the shift to the hover coordinate, because it must match
-// CPU `pos2DIsoToTriangleIndex` (raster-Y-independent), even though only GL
-// applies it to the color/depth gather.
+// GL applies this shift to the color/depth/id reads; Metal reads color/depth
+// from the raw origin, because its negated clip-Y (top-left target vs GL's
+// bottom-left framebuffer) already lands the raw sample on the correct row.
+// Both backends read the CORRECT trixel for their own raster convention.
+// Picking is the shared exception: BOTH backends shift the hover coordinate,
+// because it must match CPU `pos2DIsoToTriangleIndex` (raster-Y-independent),
+// even though only GL shifts the color/depth gather. See #442;
+// docs/design/trixel-parity-shift-442-investigation.md.
 vec2 trixelFramebufferSamplePosition(vec2 origin, int originModifier) {
     vec2 originFlooredComp = floor(origin);
     vec2 fractComp = fract(origin);

--- a/engine/render/src/shaders/ir_iso_common.glsl
+++ b/engine/render/src/shaders/ir_iso_common.glsl
@@ -416,6 +416,41 @@ int trixelOriginModifier(ivec2 trixelCanvasOffsetZ1, vec2 frameCanvasOffset) {
             int(canvasOffsetFloored.x) + int(canvasOffsetFloored.y)) & 1;
 }
 
+// --- Trixel-cell diagonal split: which of the two triangles does this cover? ---
+// The trixel->framebuffer gather (f_trixel_to_framebuffer) samples the canvas
+// at `origin = TexCoords * textureSize`. Each iso texel-cell holds two triangles
+// split along a diagonal; this resolves which half a fragment covers by
+// conditionally decrementing `origin.y` one row (parity bit + a sub-pixel
+// `fract` test). It only ever adjusts `.y`, and is byte-identical to CPU
+// `pos2DIsoToTriangleIndex` (ir_math.cpp) — the picking/hover path reuses it so
+// GPU and CPU agree on which trixel the mouse is over.
+//
+// #442 — canonical reason GL applies this to the color/depth read while Metal
+// does not (the pre-#438 asymmetry). Both backends build IDENTICAL per-vertex
+// TexCoords, but the vertex clip position differs: GLSL emits `mpMatrix*aPos`
+// unflipped, while every Metal `*_to_*` pass negates `position.y`. That negate
+// is the standard adapter for the opposite framebuffer-Y origins — OpenGL's
+// default framebuffer is bottom-left (`gl_FragCoord.y` increases up), Metal's
+// render target is top-left (`position.y` increases down) — letting one
+// GL-authored `mpMatrix` render right-side-up on both. Under those opposite
+// conventions the SAME screen pixel interpolates a TexCoords.y whose floor/fract
+// land it on OPPOSITE sides of the diagonal split — a one-row difference exactly
+// at this boundary. GL's raw sample falls on the row that needs the -1
+// correction, so GL applies the shift to all reads; Metal's flipped raster
+// already lands the raw sample on the correct row (its raster supplies the
+// equivalent one-row correction implicitly), so Metal reads color/depth from the
+// RAW origin — applying this shift there over-corrects by one row (the 1px
+// iso-diagonal sawtooth #394 introduced, #438 reverted). The `.y`-only
+// adjustment is consistent with a pure raster-Y-origin cause and rules out any
+// X-axis or float-rounding explanation.
+//
+// Both backends therefore read the CORRECT trixel for their own raster; neither
+// samples the wrong one, so the asymmetry is convention-consistent and kept
+// (not reconciled to a shared convention) — see engine/render/CLAUDE.md
+// "Trixel->framebuffer parity shift (GL-only)". Picking is the shared exception:
+// BOTH backends apply the shift to the hover coordinate, because it must match
+// CPU `pos2DIsoToTriangleIndex` (raster-Y-independent), even though only GL
+// applies it to the color/depth gather.
 vec2 trixelFramebufferSamplePosition(vec2 origin, int originModifier) {
     vec2 originFlooredComp = floor(origin);
     vec2 fractComp = fract(origin);

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -393,17 +393,27 @@ inline int trixelOriginModifier(int2 trixelCanvasOffsetZ1, float2 frameCanvasOff
 
 // Clamp a float canvas-pixel position into a valid `texture.read()` index.
 // Metal's `texture.read()` has no built-in edge handling, unlike GLSL's
-// `textureLod()` (implicit `clamp_to_edge` via sampler). See #442 for the
-// broader GLSL/Metal coord-shift reconciliation.
+// `textureLod()` (implicit `clamp_to_edge` via sampler). (This edge clamp is
+// separate from the #442 parity-shift asymmetry — that's answered on
+// `trixelFramebufferSamplePosition` below.)
 inline uint2 trixelCanvasReadCoord(float2 origin, float2 textureSize) {
     return uint2(clamp(origin, float2(0.0f), textureSize - float2(1.0f)));
 }
 
-// Mirror of `trixelFramebufferSamplePosition` in `ir_iso_common.glsl`. The
-// parity bit + fract sub-pixel test pick which row of the iso quad cell's
-// two trixels this fragment maps to. Identical math to GLSL/CPU
-// `pos2DIsoToTriangleIndex` so the same canvas data reads back the same
-// way on both backends.
+// Mirror of `trixelFramebufferSamplePosition` in `ir_iso_common.glsl` — the
+// parity bit + fract sub-pixel test pick which of the iso cell's two trixels
+// this fragment maps to, byte-identical to GLSL/CPU `pos2DIsoToTriangleIndex`.
+//
+// #442: unlike GLSL, the Metal gather (trixel_to_framebuffer.metal) reads
+// color/depth from the RAW (unshifted) origin; only the hover/pick coord is
+// shifted. Metal's vertex stage negates clip `position.y` (top-left
+// render-target origin) where GL does not (bottom-left framebuffer origin), so
+// Metal's raster already lands the raw sample on the correct trixel row — the
+// equivalent of GL's one-row shift, applied implicitly by the flipped raster.
+// Shifting again here re-introduces #394's 1px iso-diagonal sawtooth (#438
+// reverted it). Full canonical explanation lives on the GLSL twin of this
+// function in `ir_iso_common.glsl` + engine/render/CLAUDE.md
+// "Trixel->framebuffer parity shift (GL-only)".
 inline float2 trixelFramebufferSamplePosition(float2 origin, int originModifier) {
     const float2 originFloored = floor(origin);
     const float2 fractComp = fract(origin);

--- a/engine/render/src/shaders/metal/ir_iso_common.metal
+++ b/engine/render/src/shaders/metal/ir_iso_common.metal
@@ -404,16 +404,14 @@ inline uint2 trixelCanvasReadCoord(float2 origin, float2 textureSize) {
 // parity bit + fract sub-pixel test pick which of the iso cell's two trixels
 // this fragment maps to, byte-identical to GLSL/CPU `pos2DIsoToTriangleIndex`.
 //
-// #442: unlike GLSL, the Metal gather (trixel_to_framebuffer.metal) reads
-// color/depth from the RAW (unshifted) origin; only the hover/pick coord is
-// shifted. Metal's vertex stage negates clip `position.y` (top-left
-// render-target origin) where GL does not (bottom-left framebuffer origin), so
-// Metal's raster already lands the raw sample on the correct trixel row — the
-// equivalent of GL's one-row shift, applied implicitly by the flipped raster.
-// Shifting again here re-introduces #394's 1px iso-diagonal sawtooth (#438
-// reverted it). Full canonical explanation lives on the GLSL twin of this
-// function in `ir_iso_common.glsl` + engine/render/CLAUDE.md
-// "Trixel->framebuffer parity shift (GL-only)".
+// Unlike GLSL, the Metal gather (trixel_to_framebuffer.metal) reads color/depth
+// from the RAW (unshifted) origin; only the hover/pick coord is shifted. Metal's
+// vertex stage negates clip `position.y` (top-left render-target origin) where
+// GL does not (bottom-left framebuffer origin), so its raster already lands the
+// raw sample on the correct trixel row — the equivalent of GL's one-row shift,
+// applied implicitly by the flipped raster. Both read the correct trixel for
+// their own raster convention. See #442;
+// docs/design/trixel-parity-shift-442-investigation.md.
 inline float2 trixelFramebufferSamplePosition(float2 origin, int originModifier) {
     const float2 originFloored = floor(origin);
     const float2 fractComp = fract(origin);

--- a/engine/render/src/shaders/metal/trixel_to_framebuffer.metal
+++ b/engine/render/src/shaders/metal/trixel_to_framebuffer.metal
@@ -97,17 +97,14 @@ fragment FragmentOut f_trixel_to_framebuffer(
     const float2 textureSize = float2(triangleColors.get_width(), triangleColors.get_height());
     const int2 z1 = trixelOriginOffsetZ1(int2(textureSize));
 
-    // Color / depth read at the RAW interpolated canvas position — pre-#394
-    // Metal did this and rendered cleanly. Applying the GLSL-style
-    // `trixelFramebufferSamplePosition` row shift here introduced 1-pixel
-    // sawtooth notches along every iso diagonal under Metal regardless of
-    // shift sign or parity-branch swap. The shifted index is still computed
-    // and used for hover entity-id readback so it stays in lockstep with
-    // CPU-side `mouseTrixelPositionWorld()` (which routes through the same
-    // `pos2DIsoToTriangleIndex` formula). #442 canonical why the raw read is
-    // correct here (Metal's negated clip-Y / top-left target lands the raw
-    // sample on the right row): trixelFramebufferSamplePosition in
-    // ir_iso_common.metal + engine/render/CLAUDE.md.
+    // Color / depth read at the RAW interpolated canvas position: Metal's negated
+    // clip-Y (top-left target vs GL's bottom-left) already lands the raw sample on
+    // the correct trixel row, so — unlike GL — no parity-row shift is applied here.
+    // The shifted index IS still computed (`originShifted` below) and used for
+    // hover entity-id readback, so it stays in lockstep with CPU-side
+    // `mouseTrixelPositionWorld()` (same `pos2DIsoToTriangleIndex` formula). See
+    // trixelFramebufferSamplePosition in ir_iso_common.metal; #442,
+    // docs/design/trixel-parity-shift-442-investigation.md.
     const float2 originRaw = in.texCoords * textureSize;
     const int originModifier = trixelOriginModifier(z1, frameData.canvasOffset);
     const float2 originShifted =

--- a/engine/render/src/shaders/metal/trixel_to_framebuffer.metal
+++ b/engine/render/src/shaders/metal/trixel_to_framebuffer.metal
@@ -104,7 +104,10 @@ fragment FragmentOut f_trixel_to_framebuffer(
     // shift sign or parity-branch swap. The shifted index is still computed
     // and used for hover entity-id readback so it stays in lockstep with
     // CPU-side `mouseTrixelPositionWorld()` (which routes through the same
-    // `pos2DIsoToTriangleIndex` formula).
+    // `pos2DIsoToTriangleIndex` formula). #442 canonical why the raw read is
+    // correct here (Metal's negated clip-Y / top-left target lands the raw
+    // sample on the right row): trixelFramebufferSamplePosition in
+    // ir_iso_common.metal + engine/render/CLAUDE.md.
     const float2 originRaw = in.texCoords * textureSize;
     const int originModifier = trixelOriginModifier(z1, frameData.canvasOffset);
     const float2 originShifted =


### PR DESCRIPTION
## Summary

Investigation spike (#442) — **doc-only**. Explains *why* the trixel→framebuffer
gather applies the parity-row shift (`trixelFramebufferSamplePosition`) to its
color/depth reads on **GL** but reads them **raw** on **Metal** (the pre-#438
asymmetry), and records the reconciliation decision.

**Canonical reason.** Both backends build identical per-vertex `TexCoords`, but
the vertex clip position differs: every Metal `*_to_*` pass negates
`out.position.y` while GLSL does not. That negate is the standard adapter for
the opposite framebuffer-Y origins — OpenGL's default framebuffer is
**bottom-left** (`gl_FragCoord.y` up), Metal's render target is **top-left**
(`position.y` down) — so one GL-authored `mpMatrix` renders right-side-up on
both. Under those opposite conventions the same screen pixel interpolates a
`TexCoords.y` that floors to the *opposite* side of the trixel cell's diagonal
split — a one-row difference exactly at that boundary. GL's raw sample lands on
the row needing the `-1` correction (so GL shifts); Metal's flipped raster
already lands on the correct row (equivalent one-row correction, applied
implicitly), so Metal reads raw. Applying the GL shift on Metal over-corrects by
one row → the 1px iso-diagonal sawtooth **#394** introduced and **#438**
reverted. The shift touching only `.y` (never `.x`) is the tell that the cause
is the raster-Y origin, not X or float-rounding.

**Decision: keep-and-document, not reconcile.** Both backends read the *correct*
trixel for their own raster convention — not a latent bug — so per the
acceptance criteria **no follow-up fix ticket** is filed. Aligning both to one
indexing convention would mean fighting one backend's native framebuffer-Y
origin (re-opening the #394/#438 regression surface) for zero correctness gain.
Picking is the shared exception: both backends apply the shift to the *hover*
coord (it must match CPU `pos2DIsoToTriangleIndex`), even though only GL applies
it to the color/depth gather.

## Changes (all comments / markdown)

- `ir_iso_common.glsl` — canonical explanation on `trixelFramebufferSamplePosition`.
- `ir_iso_common.metal` — condensed twin + pointer; dropped the now-answered
  "#442 for the broader reconciliation" defer on `trixelCanvasReadCoord`.
- `f_trixel_to_framebuffer.glsl` / `metal/trixel_to_framebuffer.metal` — one-line
  back-references at the two gather call sites.
- `engine/render/CLAUDE.md` — new "Trixel→framebuffer parity shift (GL-only)"
  section + a "Metal negates clip position.y" backend note.

**Plan-note deviation:** the plan suggested `engine/prefabs/irreden/render/CLAUDE.md`
for the doc subsection; I placed it in `engine/render/CLAUDE.md` instead, since the
shaders live under `engine/render/src/shaders/` and that is the CLAUDE.md
auto-loaded when editing them (no CLAUDE.md exists under `render/src/`).

## Test plan

- [x] Zero code changes (comment/markdown only) → render output byte-identical to master.
- [x] Metal shaders compile at runtime + `IRShapeDebug --auto-screenshot 8` renders clean (macOS/Metal).
- [x] All cited paths / symbols / the new CLAUDE.md section anchor resolve.
- No before/after screenshots and reviewer can skip cross-host smoke: comment-only, no visual delta.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)