### PR TITLE
docs: umbrella plans + steward ledgers for epics #667 and #1394

### DIFF
--- a/.fleet/plans/issue-1394.md
+++ b/.fleet/plans/issue-1394.md
@@ -1,0 +1,74 @@
+# Plan — Epic #1394: fleet — GitHub API rate-limit exhaustion under multi-device polling
+
+- **Umbrella:** #1394 (fleet:epic + fleet:needs-human — the App creation is human-owned)
+- **Filed:** children filed 2026-07-04 from the 2026-07-03 architect triage session (human-ratified decisions)
+
+## Decisions (human-ratified 2026-07-03)
+
+- **Identity model: GitHub App** (`irreden-fleet`) — one clean bot identity with its
+  own separate rate-limit pool. Machine accounts reserved as last-resort per-device
+  multiplication; webhooks remain the unscheduled long-term target.
+- **All four code-side mitigations approved and filed** (ETag conditional polling and
+  REST-for-reads merged into one poller-core child — same code change).
+- Measured basis (2026-07-03): `graphql 3518/5000` with `core` idle at `4999/5000` —
+  the scout's 8 unconditional GraphQL list queries per repo per 30s tick are the
+  multiplier; REST 304s are rate-limit-free.
+
+## Decomposition
+
+| Child | Issue | Model | Blocked by | Scope |
+|---|---|---|---|---|
+| Q1 | #2219 | opus | — | conditional-REST polling core: `fleet_gh_poll.py` ETag cache + REST-for-reads + gated/batched GraphQL |
+| Q2 | #2220 | opus | #2219 | centralized cross-device polling: static leader serves `~/.fleet/state` over HTTP; followers conditional-GET |
+| Q3 | #2221 | sonnet | — | `/rate_limit` headroom surfacing (usage-gate mirror) + pre-emptive dispatcher gate |
+| Q4 | #2222 | sonnet | — | GitHub App token plumbing: `fleet-gh-token` (JWT → installation token, cached/locked) + guarded `GH_TOKEN` exports |
+
+Each child's canonical plan is its issue's `## Plan` comment (file-with-plan path).
+
+## Human-owned remainder (why the umbrella stays fleet:needs-human)
+
+Create the `irreden-fleet` GitHub App and install it on both repos — the full
+step-by-step lives in the umbrella's 2026-07-03 decisions comment: permissions
+Contents/Issues/PRs read-write + Metadata read, webhook OFF; note App ID +
+Installation ID; key at `~/.fleet/secrets/irreden-fleet.pem` (chmod 600); set
+`FLEET_GH_APP_ID` / `FLEET_GH_APP_INSTALLATION_ID` / `FLEET_GH_APP_KEY_PATH` in
+`~/.fleet/fleet-up.conf` per host. Q4's code lands regardless (personal-auth
+fallback when unset); only its live verification is gated on the App existing.
+
+## Cross-child notes
+
+- Q4's `GH_TOKEN` export composes with Q1 automatically (the poller reads
+  `gh auth token`, which honors `GH_TOKEN`) and with Q3 (the `/rate_limit` sampler
+  reports whatever identity gh is authed as — numbers jump to the App pool when Q4
+  lands).
+- Q2 switches dispatcher scout-staleness from file mtime to in-file `generated_at`;
+  follower hosts must never restamp the leader's `generated_at`.
+- One App installation = **one shared pool**, not per-device multiplication — the
+  Q1/Q2 reductions are what make a single pool sufficient.
+
+## Closing criteria
+
+All four children merged + the App created/configured + a full multi-device fleet
+session sustained without hitting either primary limit (umbrella acceptance #1),
+with headroom visible in `fleet-gate-status` (acceptance #3). Then #1394 closes.
+
+## Steward ledger
+
+reconciled-through: 2026-07-04
+proposal-pending: none
+
+### Children
+| Child | State | PR | Plan | Last validated |
+|---|---|---|---|---|
+| #2219 | open | — | plan | 2026-07-04 |
+| #2220 | open | — | plan | 2026-07-04 |
+| #2221 | open | — | plan | 2026-07-04 |
+| #2222 | open | — | plan | 2026-07-04 |
+
+### Decisions
+D1 (2026-07-03): identity model = GitHub App; machine accounts last-resort; webhooks long-term.
+D2 (2026-07-03): all four mitigations approved; ETag+REST-routing merged into Q1 (one poller change).
+D3 (2026-07-03): Q3 gates ON by default at 0.90 for core/graphql; search surface-only.
+
+### Events
+- 2026-07-04: children #2219–#2222 filed with plans; `fleet-validate-stack 1394` PASS (4/4); all children human:approved.

--- a/.fleet/plans/issue-667.md
+++ b/.fleet/plans/issue-667.md
@@ -1,0 +1,86 @@
+# Plan — Epic #667: persist — ECS world snapshot (generic archetype/component/relation serializer)
+
+- **Umbrella:** #667 (refines closed #199)
+- **Filed:** children filed 2026-07-04 from the 2026-07-03 architect triage session (human-ratified decomposition)
+- **Blocked by:** (none — #663 binary-I/O primitives landed)
+
+## Summary
+
+Generic ECS world snapshot: every archetype, every opted-in component column, every
+entity ID, every relation. Serializer lives in `engine/world/` (layering: asset is
+below entity/world); consumes the #663 `engine/asset/` primitives (`BinaryWriter`/
+`Reader`, `chunk_header`, `name_table`, `json_sidecar`). Format: `IRWS` magic +
+uint32 version + chunk table + JSON sidecar, obeying the #662 Save Format
+Extensibility Rules. Game-side save-slot metadata wraps this primitive in the game
+repo — never here.
+
+## Decomposition (7 chained single-PR children)
+
+| Phase | Issue | Model | Blocked by | Scope |
+|---|---|---|---|---|
+| P1 | #2212 | sonnet | — | `SaveTrait<C>` + `kSaveVersion` + 169-component audited inventory + compile-time completeness gate (W-1/W-2) |
+| P2 | #2213 | opus | #2212 | IRWS container + deterministic archetype walker + singleton chunk + type-erased save registry (W-3/W-6) |
+| P3 | #2214 | opus | #2213 | `RELN` relation chunk — CHILD_OF triples + name table (W-5) |
+| P4 | #2215 | sonnet | #2214 | round-trip + determinism test suite (W-7/W-8) |
+| P5 | #2216 | opus | #2215 | migration registry — `(ComponentId, oldVersion) → reader`, four-case dispatch (W-4) |
+| P6 | #2217 | opus | #2216 | GPU-resident state regeneration on load — the canvas-attach pass + `persist_roundtrip` demo (W-10) |
+| P7 | #2218 | sonnet | #2217 | Lua bindings (`IRPersist.saveWorld/loadWorld`) + `.json.txt` debug dump (W-9/W-11) |
+
+Chain is strictly linear — every child touches the same `engine/world/` surface.
+Each child's canonical plan is its issue's `## Plan` comment (file-with-plan path);
+the implementer commits it as `.fleet/plans/issue-<N>.md` in its own impl PR.
+
+## Cross-child decisions locked at planning
+
+- **Restore-exact entity IDs** — never remapped. Components embed raw `EntityId`
+  fields; IDs are monotonic/never recycled, so restore inserts saved IDs and
+  advances the watermark. Save-side exclusion set mirrors `resetGameplay`'s
+  preserve set (singletons, `C_Persistent`, component-backing entities).
+- **Relation state is owned solely by P3's chunk.** P2's walker skips
+  `kEntityFlagIsRelation` entities and never emits relation ids as columns; load
+  replays `setParent` as the final restore phase. Only `CHILD_OF` is materialized
+  today (`PARENT_TO`/`SIBLING_OF` verified unimplemented — `setRelation` asserts).
+- **`SaveTrait<C_VoxelSetNew>` round-trips into staged mode** (`pendingVoxels_` +
+  `pendingBoundsMin_`, `numVoxels_ == 0`); P6 owns the staged→pool canvas-attach
+  seed pass. Pool spans and `rotationSourceVoxels_` are never serialized.
+- **The live render context is never serialized or reconstructed** — GPU-handle
+  components are opt-out by default; loads reuse the live `C_Persistent` canvas
+  bundle exactly as `resetGameplay` does (scene_reset #1857 is the proven mirror).
+- **Component identity on disk is the stable stringized name** from P1's inventory
+  (CMPN name table, Rule #2) — never `typeid` (mangled) or raw ComponentIds
+  (session-local).
+- `kSaveVersion` is trait-carried `uint32_t` (epic-locked), distinct from the asset
+  records' `uint16_t` convention; a simplify-check follow-up for trait-version bump
+  detection is flagged in P1.
+
+## Acceptance (inherited from #199, preserved)
+
+Round-trip parity (100+ entities, multiple archetypes, relations, byte-for-byte);
+schema versioning with clear mismatch diagnostics; per-component opt-in/out;
+deterministic serialization (same world → same bytes); binary + readable debug
+dump; clean on `linux-debug` + `macos-debug`; Lua `saveWorld`/`loadWorld`.
+
+## Steward ledger
+
+reconciled-through: 2026-07-04
+proposal-pending: none
+
+### Children
+| Child | State | PR | Plan | Last validated |
+|---|---|---|---|---|
+| #2212 | open | — | plan | 2026-07-04 |
+| #2213 | open | — | plan | 2026-07-04 |
+| #2214 | open | — | plan | 2026-07-04 |
+| #2215 | open | — | plan | 2026-07-04 |
+| #2216 | open | — | plan | 2026-07-04 |
+| #2217 | open | — | plan | 2026-07-04 |
+| #2218 | open | — | plan | 2026-07-04 |
+
+### Decisions
+D1 (2026-07-03): 7 chained single-PR children, mixed model routing, queue-now — human-ratified in the triage session.
+D2 (2026-07-03): restore-exact entity IDs (never remap) — see P2 plan rationale.
+D3 (2026-07-03): CHILD_OF-only relation serialization; synthetic relation-entities excluded from the snapshot.
+D4 (2026-07-03): C_VoxelSetNew serializes into staged mode; P6 owns the canvas-attach pass; render context preserved, never serialized.
+
+### Events
+- 2026-07-04: children #2212–#2218 filed with plans via the adapted file-epic flow; `fleet-validate-stack 667` PASS (7/7); all children human:approved.


### PR DESCRIPTION
## Summary
- Commits the file-epic step-6.5 artifacts for the two epic decompositions filed in the 2026-07-03/04 architect triage session (human in the loop):
  - `.fleet/plans/issue-667.md` — persist ECS-world-snapshot epic: 7-child linear chain #2212→#2218, locked cross-child decisions (restore-exact entity IDs, CHILD_OF-only relation serialization, staged-mode `C_VoxelSetNew` + P6 canvas-attach pass, render context never serialized), steward ledger seeded.
  - `.fleet/plans/issue-1394.md` — GitHub API quota epic: children #2219–#2222 (conditional-REST poller core → centralized cross-device polling; headroom gate; App token plumbing), ratified GitHub App identity decision, human-setup remainder documented, steward ledger seeded.
- Per-child plans are `## Plan` comments on the children (file-with-plan path); each lands in-repo via the first commit of its own impl PR per #1932. Only the umbrella plans are committed here, per the file-epic flow.
- `fleet-validate-stack` passes on both umbrellas (7/7 and 4/4).

No `Closes` line on purpose — both umbrellas stay open until their chains ship.

## Test plan
- [ ] Docs-only; no build surface. Links/paths verified during the simplify pass (cited engine/asset headers, fleet scripts, demo paths all exist; child issue numbers cross-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)