### PR TITLE
persist: SaveTrait<C> policy layer + component inventory (W-1/W-2) (P1) (#2212)

### DIFF
--- a/.fleet/plans/issue-2212.md
+++ b/.fleet/plans/issue-2212.md
@@ -1,0 +1,95 @@
+# Plan: persist P1 — SaveTrait<C> + kSaveVersion (W-1, W-2)
+
+- **Issue:** #2212
+- **Model:** sonnet
+- **Date:** 2026-07-03
+- **Epic:** #667 — see `.fleet/plans/issue-667.md` for full context
+- **Blocked by:** (none)
+
+### Scope
+
+Deliver the per-component persistence policy layer that every later persist phase consumes: a compile-time `SaveTrait<C>` trait (opt-in / opt-out) plus a `static constexpr uint32_t` save version for each opted-in component, and an explicit, audited decision stamped onto the entire engine component inventory (169 `C_*` types). No archetype walk, no IRWS writer, no serialize/deserialize functions, no Lua surface — those are P2+ (W-3..W-11). P1 is pure metadata + a build-time completeness gate.
+
+In scope:
+- `engine/world/save_trait.hpp` — the trait mechanism (opt-in/opt-out template, `kSaveVersion`, `shouldSave<C>()` / `saveVersion<C>()` helpers, `IR_SAVE_OPT_IN` / `IR_SAVE_OPT_OUT` macros).
+- A component-inventory header enumerating every engine component with its explicit decision, plus the compile-time fold that fails the build if any listed component lacks a decision.
+- A GoogleTest under `test/world/` that spot-checks the classification and backstops inventory completeness.
+
+Out of scope (do not build): the `ComponentId → serialize descriptor` runtime bridge (W-3), the CMPN name-table wiring (W-3/W-5), migration registry (W-4), GPU-handle regeneration pass (W-10). P1 only makes the decisions those phases read.
+
+### Verified current state
+
+- **#663 primitives landed in `engine/asset/`** (headers read directly): `binary_io.hpp` — abstract `IRAsset::BinaryWriter` / `BinaryReader` with `File*`/`Memory*` backends; `writeU8/16/32/64`, `writeI*`, `writeF32/F64`, `writeVarUInt(uint64)`, `writeString`, `writeTag`, `tell()/seek()`; reads return `Result<T>{ BinaryStatus status_; T value_; }`; errors via `BinaryIOError` enum, never throw (`binary_io.hpp:31-87`, `:95-153`, `:208-251`). `chunk_header.hpp` — `AssetHeader` (`kAssetHeaderSize=12`); `writeChunked`, `readChunks`, `findChunk`, `makeTag` (`chunk_header.hpp:33-121`). `name_table.hpp` — `writeNameTable`/`readNameTable` + bidirectional `NameTable` — the Rule #2 vehicle W-3 will use for CMPN (`name_table.hpp:38-85`). `json_sidecar.hpp`, `math_binary_io.hpp` also present. Existing `kSaveVersion` precedent is **`uint16_t`** on asset records (`rig_format.hpp:73,86`; `voxel_set_format.hpp:216,250`), guarded by the `// IRAsset: serialized` simplify check — conflicts with the epic's `uint32_t`; reconciled under Approach/Gotchas.
+- **`engine/world/` shape**: `world.cpp`, `chunk_residency.{hpp,cpp}`, `chunk_persistence.{hpp,cpp}`, `config.hpp`. `save_trait.hpp` is a **new sibling** header. `engine/world/CMakeLists.txt` **already links `IrredenEngineAsset`** — no CMake change needed.
+- **Component registration is lazy and type-erased**: `EntityManager::registerComponent<C>()` keys on `typeid(C).name()` (mangled) and stores an `IComponentDataImpl<C>` (`entity_manager.hpp:165-181`, `:226-232`; `i_component_data.hpp:49-93`). There is **no central list of engine components** anywhere — no X-macro, no registration table, purely first-use lazy. Consequence: (a) P1 must **create** the canonical component list itself, and (b) mangled `typeid` names are unstable across compilers, so the disk-stable component name must come from another source — the P1 inventory X-list stringizes the type token (`"C_Velocity3D"`) and gives W-3 a stable name for free.
+- **`ResourceId = uint32_t`** (`ir_render_types.hpp:17`); GPU components hold `std::pair<ResourceId, T*>` and free via `IRRender::destroyResource<T>` in `onDestroy()`.
+- **Test harness**: single GoogleTest exe `IrredenEngineTest`, sources in `test/CMakeLists.txt:4+`; `test/world/` exists.
+- **Inventory size**: 169 unique `struct C_*` across `engine/prefabs/**`, `engine/render/`, `engine/system/`.
+
+### Approach
+
+Single committed approach: **trait mechanism header + policy/inventory header + compile-time fold + backstop test.** Decisions live in one reviewable place, component structs stay untouched, and the build fails if any listed component has no decision.
+
+**Step 1 — `engine/world/include/irreden/world/save_trait.hpp` (mechanism).** Lightweight, no component includes.
+- Primary template encodes "no decision yet": `template <class C> struct SaveTrait { static constexpr bool kExplicit = false; static constexpr bool kSave = false; static constexpr std::uint32_t kSaveVersion = 0; };`
+- Two policy macros that specialize it, forcing `kExplicit = true`: `IR_SAVE_OPT_IN(Type, Version)` (version `>= 1`, `static_assert`ed) and `IR_SAVE_OPT_OUT(Type)`.
+- `constexpr bool shouldSave<C>()` / `constexpr std::uint32_t saveVersion<C>()` accessors.
+- **`kSaveVersion` is `uint32_t` and lives in the trait, not on the component struct.** The world-snapshot serializes a *schema* defined by the (P2) per-component serialize function, not the struct's in-memory layout; the schema's version belongs beside the policy. Also sidesteps the asset `uint16_t` simplify regex. Honors the epic's locked `uint32_t` decision. (See Gotchas for the version-bump-detection follow-up this creates.)
+
+**Step 2 — `engine/world/include/irreden/world/save_component_inventory.hpp` (policy + completeness gate).** Includes every component header (heavy — only pulled by world-snapshot TUs + the test), then: one `IR_SAVE_OPT_IN`/`IR_SAVE_OPT_OUT` line per component (the audit table below, transcribed into code); a canonical `using AllEngineComponents = std::tuple<...>;` listing all 169 types; and the compile-time completeness gate — `static_assert(detail::allExplicit<AllEngineComponents>(), "Every engine component must have an explicit IR_SAVE_OPT_IN/OPT_OUT decision.")`. Any listed component without a specialization uses the primary template (`kExplicit=false`) and **breaks the build**.
+
+**Step 3 — `test/world/save_trait_test.cpp` + register in `test/CMakeLists.txt`.** Spot-checks the safety-critical opt-outs and representative opt-ins; fold invariants (`shouldSave ⇒ version >= 1`; `!shouldSave ⇒ version == 0`); and the **completeness backstop**: `EXPECT_EQ(std::tuple_size_v<AllEngineComponents>, kExpectedEngineComponentCount)` (169) — adding a component without an inventory entry fails this test. Pair with a note in `engine/world/CLAUDE.md` and a grep sanity command in the test comment.
+
+**Step 4 — docs.** "Save-trait policy layer (persist P1)" section in `engine/world/CLAUDE.md`: where decisions live, opt-out-by-omission-is-forbidden, the "new component ⇒ add an inventory entry" contract.
+
+### Affected files
+
+New: `engine/world/include/irreden/world/save_trait.hpp`; `engine/world/include/irreden/world/save_component_inventory.hpp`; `test/world/save_trait_test.cpp`.
+Edited: `test/CMakeLists.txt`; `engine/world/CLAUDE.md`.
+Untouched deliberately: all 169 component headers; `engine/world/CMakeLists.txt`; `engine/asset/**`.
+
+### Cross-system audit (component inventory)
+
+Method: GPU-handle / `ResourceId` bearers and every ambiguous case **verified by reading the header** (per the #1814 lesson). Plain-data types classified by field shape + domain, confirmed line-by-line as the inventory file is written; the compile-time gate guarantees none is silently skipped.
+
+**Class A — GPU-handle / ResourceId-owning → OPT-OUT** (process-local handles; W-10 regenerates post-load), all verified: `C_TrixelCanvasFramebuffer` (`component_trixel_framebuffer.hpp:17,29`), `C_TriangleCanvasTextures` (3× texture pair + `hiZMips_`, `:86-89`), `C_CanvasAOTexture` (`:20,34`), `C_CanvasFogOfWar` (`:123,162`), `C_CanvasSunShadow` (`:22,36`), `C_CanvasLightVolume` (2× Texture3D, `:55-56,78-80`), `C_PerAxisTrixelCanvases` (`:60-64,78,126-129`), `C_GPUParticlePool` (`:79-80,182`), `C_StatelessParticleEmitters` (`:59-61,115-116`), `C_DetachedRevoxelizeBuffer` (`:44,61,82-88`), `C_SpriteSheet` (**owns** `textureHandle_`, frees in `onDestroy()`, `:54,72-74`), `C_Sprite` (references, does not free). Atlas reloads from the `.irsprite`/PNG asset, not the snapshot.
+
+**Class B — derived / rebuildable → OPT-OUT**: `C_VoxelPool` (canvas-scoped CPU mirror + free-span allocator; no ResourceId — verified; fully derived, lives on the `C_Persistent` canvas entity, `component_voxel_pool.hpp:676-726`), `C_SpatialIndex`, `C_RenderCache`, `C_ActiveLodLevel`, `C_ChunkVisibleThisFrame`, `C_FrameDataTrixelToFramebuffer`, `C_CanvasLocalRotation`, `C_LayoutState`, `C_LayoutLeaf`, `C_ResolvedFields`.
+
+**Class C — transient per-frame events / device input → OPT-OUT**: `C_ContactEvent`, `C_OverlapContactBatch`; input snapshots `C_CursorPosition`, `C_MousePosition`, `C_MouseScroll`, `C_KeyboardKey`, `C_KeyStatus`, `C_KeyPressed`, `C_KeyReleased`, `C_KeyMouseButton`, `C_GLFWGamepadState`, `C_GLFWJoystick`, `C_IsGamepad`; transient MIDI I/O `C_MidiMessage`, `C_MidiMessageData`, `C_MidiMessageStatus`, `C_MidiIn`, `C_MidiOut`.
+
+**Class D — engine/ECS-internal plumbing → OPT-OUT** (the archetype walk excludes system/relation/component-backing entities): `C_SystemEvent<…>`, `C_SystemRelation`, `C_IsNotPure`, `C_MarkedForDeletion`, `C_NoGlobalModifiers`, `C_GlobalModifiers`. `C_LambdaModifiers` — **hard** opt-out (`std::function`). `C_Modifiers` (+ vec3/quat variants) and `C_ResolvedFields` — OPT-OUT for v1 (source `EntityId`s + transient resolved fields, `component_modifiers.hpp:44-109,174-180`); revisit once entity-id remap + resolution ordering settle in W-3.
+
+**Class E — ambiguous, explicit calls with rationale:**
+- `C_VoxelSetNew` → **OPT-IN, flagged provisional**: authored voxel data is gameplay state, but the payload lives in the pool span + `pendingVoxels_` and load must re-allocate + round-trip `canvasEntity_`/`ownerEntityId_` EntityIds (`component_voxel_set.hpp:24-102,294`). Its serializer is custom and P2/W-3+, interacting with W-10 (P6 defines the staged-mode contract). If W-3's slice can't absorb it, flipping to OPT-OUT is a one-line inventory edit — by design.
+- `C_Skeleton` → **OPT-IN**: `joints_` (EntityId vector) + `bindPose_` are authored rig topology; EntityIds round-trip under the snapshot's id-stable contract (`component_skeleton.hpp:71-73`).
+- `C_JointHierarchy` → **OPT-OUT**: deprecated compile shim (superseded by `C_Skeleton`).
+
+**Class F — plain gameplay data → OPT-IN, kSaveVersion = 1** (each gets its own inventory line): transform/spatial (`C_LocalTransform`, `C_WorldTransform`, `C_Position2D`, `C_Position2DIso`, `C_PositionInt2D`, `C_PositionInt3D`, `C_SizeInt2D`, `C_SizeInt3D`, `C_SizeTriangles`, `C_Direction3D`, `C_Magnitude`, `C_RotationMode`, `C_RotationTarget`, `C_AutoSpin`, `C_ChunkMembership`); physics/motion (`C_Velocity3D`, `C_Velocity2DIso`, `C_VelocityDrag`, `C_Acceleration3D`, `C_Gravity3D`, `C_HasGravity`, `C_GotoEasing3D`, `C_ReactiveReturn3D`, `C_SpringPlatform`, `C_WallBounce`, `C_WallDeath`); colliders/hitboxes (`C_ColliderIso3DAABB`, `C_CollisionLayer`, `C_HitBox2D`, `C_HitBox2DGui`, `C_HitboxCircle`, `C_HitboxRect`, `C_ActiveHitbox`); lifetime/timers/sim (`C_Lifetime`, `C_Timer`, `C_Stopwatch`, `C_Cycle`, `C_Loop`, `C_Alarm`, `C_PeriodicIdle`, `C_SimClock` singleton); animation (`C_AnimationClip`, `C_ActionAnimation`, `C_AnimClipColorTrack`, `C_AnimColorState`, `C_AnimMotionColorShift`, `C_ProceduralAnimation`, `C_LerpEntity`, `C_VoxelSquashStretch`, `C_SpriteAnimation`, `C_TextureScrollPosition`, `C_TextureScrollVelocity`); effects params (`C_ParticleBurst`, `C_ParticleSpawner`, `C_SpawnGlow`, `C_TriggerGlow`, `C_RhythmicLaunch`); appearance/shape (`C_ColorHSV`, `C_GeometricShape`, `C_ShapeDescriptor`, `C_TriangleCanvasBackground`, `C_TrianglesOnlySet`, `C_LightSource`, `C_LightBlocker`); camera/viewport/canvas config (`C_Camera`, `C_CameraPosition2DIso`, `C_Viewport`, `C_ZoomLevel`, `C_TrixelCanvasOrigin`, `C_TrixelCanvasRenderBehavior`, `C_EntityCanvas`, `C_CanvasTarget`, `C_DetachedCanvas`, `C_MainCanvas`, `C_GuiCanvas`, `C_BackgroundCanvas`); voxel/rig authored (`C_Voxel`, `C_Joint`, `C_JointName`, `C_BindPoints`); authored MIDI (`C_MidiSequence`, `C_MidiNote`, `C_MidiChannel`, `C_MidiDevice`, `C_MidiDelay`, `C_MidiSourcePort`); text/GUI/editor (`C_TextSegment`, `C_TextStyle`, `C_GuiPosition`, `C_GuiElement`, `C_GuiHoverState` singleton, `C_Widget` + the 11 `C_Widget*` kinds, `C_WidgetState`, `C_Splitter`, `C_VoxelSelection`, `C_VoxelSelectionHighlight`, `C_GizmoHandle`); tags/markers as explicit opt-in identity (`C_Player`, `C_ControllableUnit`, `C_Selected`, `C_Persistent`, `C_Name`, `C_Example`, `C_HelpText`, `C_SpatialQueryable`, `C_EntityHoverDetectTag`, `C_PerfStatsOverlayTag`).
+
+Every one of the 169 names maps to exactly one class; the inventory file is that mapping in code.
+
+### Acceptance criteria
+
+1. **Compile-time completeness gate fires.** The inventory compiles clean; deleting any single `IR_SAVE_*` line makes `fleet-build --target IrredenEngineTest` fail with the "must have an explicit … decision" message.
+2. **Runtime spot-checks pass** (`IrredenEngineTest --gtest_filter=SaveTrait.*`): every Class A bearer → `shouldSave() == false`; `C_LambdaModifiers`/`C_ContactEvent`/`C_SpatialIndex`/`C_VoxelPool` → `false`; representative Class F (`C_Velocity3D`, `C_LocalTransform`, `C_Name`, `C_ShapeDescriptor`, `C_SimClock`) → `true` with `saveVersion() >= 1`.
+3. **Fold invariants** hold for every component (compile-time fold + runtime mirror).
+4. **Completeness backstop**: tuple size == documented count (169).
+5. Compiles + tests green on `linux-debug` and `macos-debug` (epic acceptance #7).
+6. **No behavioral change** — header-only additions + one test.
+
+### Gotchas
+
+- **`uint32_t` vs the asset `uint16_t kSaveVersion` convention.** Trait-carried `uint32_t` avoids the collision, but creates a coverage gap: the field-layout version-bump detector watches annotated structs, and trait-carried versions are invisible to it. Mitigation: document the bump rule in `engine/world/CLAUDE.md`; file a follow-up to teach `simplify` a version-bump warning keyed on opt-in component edits. Do not attempt the simplify change in P1.
+- **Heavy include in the inventory header** — pull it only into world-snapshot TUs + the test, never a widely-included header. `save_trait.hpp` stays include-light.
+- **Mangled `typeid` names are not disk-stable** — W-3 must take the stable stringized name from the P1 X-list, never `typeid(C).name()`.
+- **`kExplicit=false` is the trap, not a default policy.** The primary template is deliberately "no decision" (not "opt-out") so omission is a build error. Reviewers must reject making the primary default to `kSave=false`.
+- **`C_VoxelSetNew` opt-in is provisional** — records intent; its serializer is genuinely hard (pool re-allocation + EntityId round-trip + W-10 interplay); flipping is one line.
+- **Singletons need no special trait** — singleton-ness is W-6's concern; classify purely on data vs derived (SimClock opt-in; SpatialIndex/ActiveLodLevel opt-out).
+
+### Sibling + in-flight reconciliation
+
+- **First in the 7-child chain; nothing blocks P1.** #663's primitives are landed and verified; P1 doesn't consume them yet (P2 does).
+- **No open PR touches `engine/world/`, `engine/prefabs/**/components/`, or `engine/asset/`** (open PRs are render sun-shadow + tooling docs). No component header is in flight, so the inventory won't go stale between filing and implementation.
+- **Downstream contract for P2:** P2 consumes `shouldSave<C>()` / `saveVersion<C>()` and `AllEngineComponents`, adding the `ComponentId → serialize descriptor` runtime bridge P1 intentionally omits. Keep `save_trait.hpp` free of `EntityManager`/`ComponentId` includes so P2 layers without cycles — the trait is a pure compile-time fact table.
+- **New-component contract to advertise:** any component added after P1 must gain an inventory line + `AllEngineComponents` entry (enforced by count backstop + compile gate). Call out in the PR description + CLAUDE.md note so the epic steward holds later children to it.

--- a/engine/prefabs/irreden/audio/components/component_midi_sequence.hpp
+++ b/engine/prefabs/irreden/audio/components/component_midi_sequence.hpp
@@ -6,6 +6,7 @@
 
 #include <irreden/ir_math.hpp>
 #include <irreden/ir_constants.hpp>
+#include <irreden/ir_profile.hpp>
 
 #include <irreden/common/components/component_tags_all.hpp>
 #include <irreden/audio/components/component_midi_message.hpp>

--- a/engine/prefabs/irreden/common/components/component_position_int_3d.hpp
+++ b/engine/prefabs/irreden/common/components/component_position_int_3d.hpp
@@ -5,6 +5,8 @@
 
 using IRMath::ivec3;
 
+namespace IRComponents {
+
 struct C_PositionInt3D {
     ivec3 pos_;
 
@@ -17,5 +19,7 @@ struct C_PositionInt3D {
     C_PositionInt3D()
         : C_PositionInt3D{ivec3(0, 0, 0)} {}
 };
+
+} // namespace IRComponents
 
 #endif /* COMPONENT_POSITION_INT_3D_H */

--- a/engine/prefabs/irreden/input/components/component_glfw_gamepad_state.hpp
+++ b/engine/prefabs/irreden/input/components/component_glfw_gamepad_state.hpp
@@ -6,6 +6,8 @@
 #include <cstring>
 
 using IRInput::ButtonStatuses;
+using IRInput::GamepadAxes;
+using IRInput::GamepadButtons;
 
 namespace IRComponents {
 
@@ -56,9 +58,12 @@ struct C_GLFWGamepadState {
     }
 
     bool checkButton(GamepadButtons button, ButtonStatuses status) const {
-        if (status == ButtonStatuses::PRESSED)  return checkButtonPressed(button);
-        if (status == ButtonStatuses::HELD)     return checkButtonDown(button);
-        if (status == ButtonStatuses::RELEASED) return checkButtonReleased(button);
+        if (status == ButtonStatuses::PRESSED)
+            return checkButtonPressed(button);
+        if (status == ButtonStatuses::HELD)
+            return checkButtonDown(button);
+        if (status == ButtonStatuses::RELEASED)
+            return checkButtonReleased(button);
         return false;
     }
 

--- a/engine/prefabs/irreden/update/components/component_lerp_component.hpp
+++ b/engine/prefabs/irreden/update/components/component_lerp_component.hpp
@@ -2,8 +2,10 @@
 #define COMPONENT_LERP_COMPONENT_H
 
 #include <irreden/ir_math.hpp>
-#include <irreden/ir_ecs.hpp>
+#include <irreden/entity/ir_entity_types.hpp>
 #include <irreden/ir_constants.hpp>
+
+#include <functional>
 
 // LEFT OFF HERE, all this needs work.
 // do i need to also take in a min and max value,
@@ -16,16 +18,15 @@ using namespace IRMath;
 namespace IRComponents {
 
 struct C_LerpEntity {
-    EntityId boundEntity_;
-    std::function<void(EntityId)> func_;
+    IREntity::EntityId boundEntity_;
+    std::function<void(IREntity::EntityId)> func_;
 
     template <typename Function>
-    C_LerpComponent(EntityId entity, Function func)
-        : func_(func) {}
+    C_LerpEntity(IREntity::EntityId entity, Function func)
+        : boundEntity_(entity)
+        , func_(func) {}
 
-    // Default
-    C_LerpComponent()
-        : {}
+    C_LerpEntity() = default;
 
     void tick() {
         func_(boundEntity_);

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -130,6 +130,52 @@ Most code never touches `World` directly. It accesses managers via the
 header, which reach through the global pointers `World` sets up at
 construction time.
 
+## Save-trait policy layer (persist P1, #2212, epic #667)
+
+`engine/world/include/irreden/world/save_trait.hpp` declares
+`IRWorld::SaveTrait<C>` — a compile-time trait deciding whether component
+type `C` participates in a world snapshot, and if so, its schema
+`kSaveVersion` (`uint32_t`, lives on the trait, not the component struct —
+the snapshot serializes a *schema*, defined by the P2 per-component
+serialize function, not the struct's in-memory layout). The primary
+template means "no decision yet" (`kExplicit = false`), deliberately NOT
+"opt-out" — an engine component that never specializes the trait fails a
+compile-time completeness gate instead of silently being skipped by
+persistence. Two macros make the decision explicit:
+`IR_SAVE_OPT_IN(Type, Version)` and `IR_SAVE_OPT_OUT(Type)`.
+
+`engine/world/include/irreden/world/save_component_inventory.hpp` is the
+audited decision table — one `IR_SAVE_OPT_IN`/`IR_SAVE_OPT_OUT` line per
+engine component, plus `AllEngineComponents` (a `std::tuple` listing every
+one of them) and a `static_assert` that fails the build if any listed
+component lacks an explicit decision. It's a heavy include (pulls every
+component header) — only world-snapshot TUs and `test/world/save_trait_test.cpp`
+should include it, never a widely-included header.
+
+**Opt-out-by-omission is forbidden.** A component with no decision doesn't
+silently default to "don't save" — it breaks the build. This is enforced
+structurally: the primary `SaveTrait` template has `kExplicit = false`,
+and `save_component_inventory.hpp`'s `static_assert` walks
+`AllEngineComponents` checking every entry's `kExplicit`.
+
+**New-component contract.** Adding a new engine component requires adding
+a matching `IR_SAVE_OPT_IN`/`IR_SAVE_OPT_OUT` line (with its own include)
+and an `AllEngineComponents` tuple entry — both the compile-time gate and
+`test/world/save_trait_test.cpp`'s `InventoryIsComplete` count backstop
+depend on the tuple size matching the audited total. A templated
+component with more than one concrete instantiation (e.g.
+`C_SystemEvent<SystemEvent>`) gets ONE representative instantiation in
+the inventory, not one per specialization — see the inline comment beside
+`C_SystemEvent<IRSystem::TICK>` in `save_component_inventory.hpp` for the
+rationale (the archetype walk excludes those entities entirely, so the
+other specializations are never queried).
+
+P1 is pure metadata — no archetype walk, no IRWS writer, no serialize/
+deserialize functions, no Lua surface. P2+ (the `ComponentId → serialize
+descriptor` runtime bridge, migration registry, GPU-handle regeneration
+pass) consumes `shouldSave<C>()` / `saveVersion<C>()` / `AllEngineComponents`
+on top of this layer.
+
 ## Responsibilities
 
 `World(const char* configFileName)`:

--- a/engine/world/include/irreden/world/save_component_inventory.hpp
+++ b/engine/world/include/irreden/world/save_component_inventory.hpp
@@ -1,0 +1,526 @@
+#ifndef SAVE_COMPONENT_INVENTORY_H
+#define SAVE_COMPONENT_INVENTORY_H
+
+// The audited per-component save-policy decision table. Every engine
+// component gets exactly one IR_SAVE_OPT_IN / IR_SAVE_OPT_OUT line below;
+// AllEngineComponents lists all of them so the static_assert at the bottom
+// fails the build if any decision is missing. Heavy include list — pull
+// this header only into world-snapshot TUs and the SaveTrait test, never
+// into a widely-included header (see save_trait.hpp).
+
+#include <irreden/world/save_trait.hpp>
+
+#include <irreden/audio/components/component_midi_channel.hpp>
+#include <irreden/audio/components/component_midi_delay.hpp>
+#include <irreden/audio/components/component_midi_device.hpp>
+#include <irreden/audio/components/component_midi_message.hpp>
+#include <irreden/audio/components/component_midi_note.hpp>
+#include <irreden/audio/components/component_midi_sequence.hpp>
+#include <irreden/audio/components/component_midi_source_port.hpp>
+#include <irreden/common/components/component_auto_spin.hpp>
+#include <irreden/common/components/component_chunk_membership.hpp>
+#include <irreden/common/components/component_controllable_unit.hpp>
+#include <irreden/common/components/component_cycle.hpp>
+#include <irreden/common/components/component_local_transform.hpp>
+#include <irreden/common/components/component_modifiers.hpp>
+#include <irreden/common/components/component_name.hpp>
+#include <irreden/common/components/component_persistent.hpp>
+#include <irreden/common/components/component_player.hpp>
+#include <irreden/common/components/component_position_2d.hpp>
+#include <irreden/common/components/component_position_2d_iso.hpp>
+#include <irreden/common/components/component_position_int_2d.hpp>
+#include <irreden/common/components/component_position_int_3d.hpp>
+#include <irreden/common/components/component_rotation_mode.hpp>
+#include <irreden/common/components/component_selected.hpp>
+#include <irreden/common/components/component_sim_clock.hpp>
+#include <irreden/common/components/component_size_int_2d.hpp>
+#include <irreden/common/components/component_size_int_3d.hpp>
+#include <irreden/common/components/component_size_triangles.hpp>
+#include <irreden/common/components/component_stopwatch.hpp>
+#include <irreden/common/components/component_tags_all.hpp>
+#include <irreden/common/components/component_timer.hpp>
+#include <irreden/common/components/component_world_transform.hpp>
+#include <irreden/demo/components/component_example.hpp>
+#include <irreden/input/components/component_cursor_position.hpp>
+#include <irreden/input/components/component_glfw_gamepad_state.hpp>
+#include <irreden/input/components/component_glfw_joystick.hpp>
+#include <irreden/input/components/component_hitbox_2d.hpp>
+#include <irreden/input/components/component_hitbox_2d_gui.hpp>
+#include <irreden/input/components/component_key_mouse_button.hpp>
+#include <irreden/input/components/component_keyboard_key.hpp>
+#include <irreden/input/components/component_keyboard_key_status.hpp>
+#include <irreden/input/components/component_mouse_position.hpp>
+#include <irreden/input/components/component_mouse_scroll.hpp>
+#include <irreden/input/systems/system_entity_hover_detect.hpp>
+#include <irreden/render/components/component_active_lod_level.hpp>
+#include <irreden/render/components/component_camera.hpp>
+#include <irreden/render/components/component_camera_position_2d_iso.hpp>
+#include <irreden/render/components/component_canvas_ao_texture.hpp>
+#include <irreden/render/components/component_canvas_fog_of_war.hpp>
+#include <irreden/render/components/component_canvas_light_volume.hpp>
+#include <irreden/render/components/component_canvas_local_rotation.hpp>
+#include <irreden/render/components/component_canvas_sun_shadow.hpp>
+#include <irreden/render/components/component_canvas_target.hpp>
+#include <irreden/render/components/component_color_hsva.hpp>
+#include <irreden/render/components/component_detached_canvas.hpp>
+#include <irreden/render/components/component_detached_revoxelize_buffer.hpp>
+#include <irreden/render/components/component_entity_canvas.hpp>
+#include <irreden/render/components/component_frame_data_trixel_to_framebuffer.hpp>
+#include <irreden/render/components/component_geometric_shape.hpp>
+#include <irreden/render/components/component_gizmo_handle.hpp>
+#include <irreden/render/components/component_gpu_particle_pool.hpp>
+#include <irreden/render/components/component_gui_hover_state.hpp>
+#include <irreden/render/components/component_gui_position.hpp>
+#include <irreden/render/components/component_layout_leaf.hpp>
+#include <irreden/render/components/component_layout_state.hpp>
+#include <irreden/render/components/component_light_blocker.hpp>
+#include <irreden/render/components/component_light_source.hpp>
+#include <irreden/render/components/component_per_axis_trixel_canvases.hpp>
+#include <irreden/render/components/component_render_cache.hpp>
+#include <irreden/render/components/component_splitter.hpp>
+#include <irreden/render/components/component_sprite.hpp>
+#include <irreden/render/components/component_sprite_animation.hpp>
+#include <irreden/render/components/component_sprite_sheet.hpp>
+#include <irreden/render/components/component_stateless_particle_emitters.hpp>
+#include <irreden/render/components/component_text_segment.hpp>
+#include <irreden/render/components/component_text_style.hpp>
+#include <irreden/render/components/component_texture_scroll.hpp>
+#include <irreden/render/components/component_triangle_canvas_background.hpp>
+#include <irreden/render/components/component_triangle_canvas_textures.hpp>
+#include <irreden/render/components/component_triangles_only_set.hpp>
+#include <irreden/render/components/component_trixel_canvas_origin.hpp>
+#include <irreden/render/components/component_trixel_canvas_render_behavior.hpp>
+#include <irreden/render/components/component_trixel_framebuffer.hpp>
+#include <irreden/render/components/component_viewport.hpp>
+#include <irreden/render/components/component_voxel_selection.hpp>
+#include <irreden/render/components/component_widget.hpp>
+#include <irreden/render/components/component_zoom_level.hpp>
+#include <irreden/render/systems/system_perf_stats_overlay.hpp>
+#include <irreden/spatial/components/component_spatial_index.hpp>
+#include <irreden/system/components/component_system_event.hpp>
+#include <irreden/system/components/component_system_relation.hpp>
+#include <irreden/update/components/component_acceleration_3d.hpp>
+#include <irreden/update/components/component_action_animation.hpp>
+#include <irreden/update/components/component_anim_clip_color_track.hpp>
+#include <irreden/update/components/component_anim_color_state.hpp>
+#include <irreden/update/components/component_anim_motion_color_shift.hpp>
+#include <irreden/update/components/component_animation_clip.hpp>
+#include <irreden/update/components/component_collider_iso3d_aabb.hpp>
+#include <irreden/update/components/component_collision_layer.hpp>
+#include <irreden/update/components/component_contact_event.hpp>
+#include <irreden/update/components/component_direction.hpp>
+#include <irreden/update/components/component_goto_easing_3d.hpp>
+#include <irreden/update/components/component_gravity_3d.hpp>
+#include <irreden/update/components/component_hitbox_circle.hpp>
+#include <irreden/update/components/component_hitbox_rect.hpp>
+#include <irreden/update/components/component_lerp_component.hpp>
+#include <irreden/update/components/component_lifetime.hpp>
+#include <irreden/update/components/component_magnitude.hpp>
+#include <irreden/update/components/component_overlap_contact_batch.hpp>
+#include <irreden/update/components/component_particle_burst.hpp>
+#include <irreden/update/components/component_particle_spawner.hpp>
+#include <irreden/update/components/component_periodic_idle.hpp>
+#include <irreden/update/components/component_procedural_animation.hpp>
+#include <irreden/update/components/component_reactive_return_3d.hpp>
+#include <irreden/update/components/component_rhythmic_launch.hpp>
+#include <irreden/update/components/component_rotation_target.hpp>
+#include <irreden/update/components/component_spawn_glow.hpp>
+#include <irreden/update/components/component_spring_platform.hpp>
+#include <irreden/update/components/component_trigger_glow.hpp>
+#include <irreden/update/components/component_velocity_2d_iso.hpp>
+#include <irreden/update/components/component_velocity_3d.hpp>
+#include <irreden/update/components/component_velocity_drag.hpp>
+#include <irreden/voxel/components/component_bind_points.hpp>
+#include <irreden/voxel/components/component_joint.hpp>
+#include <irreden/voxel/components/component_joint_hierarchy.hpp>
+#include <irreden/voxel/components/component_joint_name.hpp>
+#include <irreden/voxel/components/component_shape_descriptor.hpp>
+#include <irreden/voxel/components/component_skeleton.hpp>
+#include <irreden/voxel/components/component_voxel.hpp>
+#include <irreden/voxel/components/component_voxel_pool.hpp>
+#include <irreden/voxel/components/component_voxel_set.hpp>
+#include <irreden/voxel/components/component_voxel_squash_stretch.hpp>
+#include <irreden/wip/components/component_alarm.hpp>
+
+#include <tuple>
+
+// Class A — GPU-handle / ResourceId-owning (process-local; W-10 regenerates post-load)
+IR_SAVE_OPT_OUT(IRComponents::C_TrixelCanvasFramebuffer)
+IR_SAVE_OPT_OUT(IRComponents::C_TriangleCanvasTextures)
+IR_SAVE_OPT_OUT(IRComponents::C_CanvasAOTexture)
+IR_SAVE_OPT_OUT(IRComponents::C_CanvasFogOfWar)
+IR_SAVE_OPT_OUT(IRComponents::C_CanvasSunShadow)
+IR_SAVE_OPT_OUT(IRComponents::C_CanvasLightVolume)
+IR_SAVE_OPT_OUT(IRComponents::C_PerAxisTrixelCanvases)
+IR_SAVE_OPT_OUT(IRComponents::C_GPUParticlePool)
+IR_SAVE_OPT_OUT(IRComponents::C_StatelessParticleEmitters)
+IR_SAVE_OPT_OUT(IRComponents::C_DetachedRevoxelizeBuffer)
+IR_SAVE_OPT_OUT(IRComponents::C_SpriteSheet)
+IR_SAVE_OPT_OUT(IRComponents::C_Sprite)
+
+// Class B — derived / rebuildable
+IR_SAVE_OPT_OUT(IRComponents::C_VoxelPool)
+IR_SAVE_OPT_OUT(IRComponents::C_SpatialIndex)
+IR_SAVE_OPT_OUT(IRComponents::C_RenderCache)
+IR_SAVE_OPT_OUT(IRComponents::C_ActiveLodLevel)
+IR_SAVE_OPT_OUT(IRComponents::C_ChunkVisibleThisFrame)
+IR_SAVE_OPT_OUT(IRComponents::C_FrameDataTrixelToFramebuffer)
+IR_SAVE_OPT_OUT(IRComponents::C_CanvasLocalRotation)
+IR_SAVE_OPT_OUT(IRComponents::C_LayoutState)
+IR_SAVE_OPT_OUT(IRComponents::C_LayoutLeaf)
+IR_SAVE_OPT_OUT(IRComponents::C_ResolvedFields)
+
+// Class C — transient per-frame events / device input
+IR_SAVE_OPT_OUT(IRComponents::C_ContactEvent)
+IR_SAVE_OPT_OUT(IRComponents::C_OverlapContactBatch)
+IR_SAVE_OPT_OUT(IRComponents::C_CursorPosition)
+IR_SAVE_OPT_OUT(IRComponents::C_MousePosition)
+IR_SAVE_OPT_OUT(IRComponents::C_MouseScroll)
+IR_SAVE_OPT_OUT(IRComponents::C_KeyboardKey)
+IR_SAVE_OPT_OUT(IRComponents::C_KeyStatus)
+IR_SAVE_OPT_OUT(IRComponents::C_KeyPressed)
+IR_SAVE_OPT_OUT(IRComponents::C_KeyReleased)
+IR_SAVE_OPT_OUT(IRComponents::C_KeyMouseButton)
+IR_SAVE_OPT_OUT(IRComponents::C_GLFWGamepadState)
+IR_SAVE_OPT_OUT(IRComponents::C_GLFWJoystick)
+IR_SAVE_OPT_OUT(IRComponents::C_MidiMessage)
+IR_SAVE_OPT_OUT(IRComponents::C_MidiMessageData)
+IR_SAVE_OPT_OUT(IRComponents::C_MidiMessageStatus)
+IR_SAVE_OPT_OUT(IRComponents::C_MidiIn)
+IR_SAVE_OPT_OUT(IRComponents::C_MidiOut)
+
+// Class D — engine/ECS-internal plumbing (archetype walk excludes these entities)
+IR_SAVE_OPT_OUT(IRComponents::C_SystemRelation)
+IR_SAVE_OPT_OUT(IRComponents::C_IsNotPure)
+IR_SAVE_OPT_OUT(IRComponents::C_MarkedForDeletion)
+IR_SAVE_OPT_OUT(IRComponents::C_NoGlobalModifiers)
+IR_SAVE_OPT_OUT(IRComponents::C_GlobalModifiers)
+IR_SAVE_OPT_OUT(IRComponents::C_LambdaModifiers)
+IR_SAVE_OPT_OUT(IRComponents::C_Modifiers)
+
+// C_LerpEntity holds a std::function member — same non-serializable shape
+// as C_LambdaModifiers above, so it opts out too.
+IR_SAVE_OPT_OUT(IRComponents::C_LerpEntity)
+
+// Class E — C_VoxelSetNew: OPT-IN, flagged provisional (custom serializer is P2/W-3+; flip to
+// OPT-OUT is one line if the slice can't absorb it)
+IR_SAVE_OPT_IN(IRComponents::C_VoxelSetNew, 1)
+
+// Class E — C_Skeleton: OPT-IN (authored rig topology; joint EntityIds round-trip under the
+// snapshot's id-stable contract)
+IR_SAVE_OPT_IN(IRComponents::C_Skeleton, 1)
+
+// Class E — C_JointHierarchy: OPT-OUT (deprecated compile shim, superseded by C_Skeleton)
+IR_SAVE_OPT_OUT(IRComponents::C_JointHierarchy)
+
+// Class F — plain gameplay data
+IR_SAVE_OPT_IN(IRComponents::C_LocalTransform, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WorldTransform, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Position2D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Position2DIso, 1)
+IR_SAVE_OPT_IN(IRComponents::C_PositionInt2D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_PositionInt3D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_SizeInt2D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_SizeInt3D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_SizeTriangles, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Direction3D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Magnitude, 1)
+IR_SAVE_OPT_IN(IRComponents::C_RotationMode, 1)
+IR_SAVE_OPT_IN(IRComponents::C_RotationTarget, 1)
+IR_SAVE_OPT_IN(IRComponents::C_AutoSpin, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ChunkMembership, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Velocity3D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Velocity2DIso, 1)
+IR_SAVE_OPT_IN(IRComponents::C_VelocityDrag, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Acceleration3D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Gravity3D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_HasGravity, 1)
+IR_SAVE_OPT_IN(IRComponents::C_GotoEasing3D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ReactiveReturn3D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_SpringPlatform, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WallBounce, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WallDeath, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ColliderIso3DAABB, 1)
+IR_SAVE_OPT_IN(IRComponents::C_CollisionLayer, 1)
+IR_SAVE_OPT_IN(IRComponents::C_HitBox2D, 1)
+IR_SAVE_OPT_IN(IRComponents::C_HitBox2DGui, 1)
+IR_SAVE_OPT_IN(IRComponents::C_HitboxCircle, 1)
+IR_SAVE_OPT_IN(IRComponents::C_HitboxRect, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ActiveHitbox, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Lifetime, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Timer, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Stopwatch, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Cycle, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Loop, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Alarm, 1)
+IR_SAVE_OPT_IN(IRComponents::C_PeriodicIdle, 1)
+IR_SAVE_OPT_IN(IRComponents::C_SimClock, 1)
+IR_SAVE_OPT_IN(IRComponents::C_AnimationClip, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ActionAnimation, 1)
+IR_SAVE_OPT_IN(IRComponents::C_AnimClipColorTrack, 1)
+IR_SAVE_OPT_IN(IRComponents::C_AnimColorState, 1)
+IR_SAVE_OPT_IN(IRComponents::C_AnimMotionColorShift, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ProceduralAnimation, 1)
+IR_SAVE_OPT_IN(IRComponents::C_VoxelSquashStretch, 1)
+IR_SAVE_OPT_IN(IRComponents::C_SpriteAnimation, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TextureScrollPosition, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TextureScrollVelocity, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ParticleBurst, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ParticleSpawner, 1)
+IR_SAVE_OPT_IN(IRComponents::C_SpawnGlow, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TriggerGlow, 1)
+IR_SAVE_OPT_IN(IRComponents::C_RhythmicLaunch, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ColorHSV, 1)
+// C_GeometricShape is a template with no primary definition — only
+// RECTANGULAR_PRISM and SPHERE specializations exist. SPHERE represents
+// the family (same one-representative-instantiation approach used for
+// any templated component with more than one concrete specialization).
+IR_SAVE_OPT_IN(IRComponents::C_GeometricShape<IRMath::Shape3D::SPHERE>, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ShapeDescriptor, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TriangleCanvasBackground, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TrianglesOnlySet, 1)
+IR_SAVE_OPT_IN(IRComponents::C_LightSource, 1)
+IR_SAVE_OPT_IN(IRComponents::C_LightBlocker, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Camera, 1)
+IR_SAVE_OPT_IN(IRComponents::C_CameraPosition2DIso, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Viewport, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ZoomLevel, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TrixelCanvasOrigin, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TrixelCanvasRenderBehavior, 1)
+IR_SAVE_OPT_IN(IRComponents::C_EntityCanvas, 1)
+IR_SAVE_OPT_IN(IRComponents::C_CanvasTarget, 1)
+IR_SAVE_OPT_IN(IRComponents::C_DetachedCanvas, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Voxel, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Joint, 1)
+IR_SAVE_OPT_IN(IRComponents::C_JointName, 1)
+IR_SAVE_OPT_IN(IRComponents::C_BindPoints, 1)
+IR_SAVE_OPT_IN(IRComponents::C_MidiSequence, 1)
+IR_SAVE_OPT_IN(IRComponents::C_MidiNote, 1)
+IR_SAVE_OPT_IN(IRComponents::C_MidiChannel, 1)
+IR_SAVE_OPT_IN(IRComponents::C_MidiDevice, 1)
+IR_SAVE_OPT_IN(IRComponents::C_MidiDelay, 1)
+IR_SAVE_OPT_IN(IRComponents::C_MidiSourcePort, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TextSegment, 1)
+IR_SAVE_OPT_IN(IRComponents::C_TextStyle, 1)
+IR_SAVE_OPT_IN(IRComponents::C_GuiPosition, 1)
+IR_SAVE_OPT_IN(IRComponents::C_GuiElement, 1)
+IR_SAVE_OPT_IN(IRComponents::C_GuiHoverState, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Widget, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetButton, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetCheckbox, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetColorSwatch, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetDropdown, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetLabel, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetList, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetPanel, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetRadio, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetScroll, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetSlider, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetTextInput, 1)
+IR_SAVE_OPT_IN(IRComponents::C_WidgetState, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Splitter, 1)
+IR_SAVE_OPT_IN(IRComponents::C_VoxelSelection, 1)
+IR_SAVE_OPT_IN(IRComponents::C_VoxelSelectionHighlight, 1)
+IR_SAVE_OPT_IN(IRComponents::C_GizmoHandle, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Player, 1)
+IR_SAVE_OPT_IN(IRComponents::C_ControllableUnit, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Selected, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Persistent, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Name, 1)
+IR_SAVE_OPT_IN(IRComponents::C_Example, 1)
+IR_SAVE_OPT_IN(IRComponents::C_HelpText, 1)
+IR_SAVE_OPT_IN(IRComponents::C_SpatialQueryable, 1)
+
+// C_EntityHoverDetectTag and C_PerfStatsOverlayTag are defined inline in
+// their owning system files (system_entity_hover_detect.hpp /
+// system_perf_stats_overlay.hpp) inside namespace IRSystem, not
+// IRComponents, despite the C_ naming convention.
+IR_SAVE_OPT_IN(IRSystem::C_EntityHoverDetectTag, 1)
+IR_SAVE_OPT_IN(IRSystem::C_PerfStatsOverlayTag, 1)
+
+// Class D (cont.) — C_SystemEvent<TICK> represents the C_SystemEvent<…>
+// family (BEGIN_TICK/TICK/END_TICK/RELATION_TICK); the archetype walk
+// excludes system-registration entities entirely (Class D), so the other
+// three specializations are never queried by the walker and do not need
+// their own tuple entries.
+IR_SAVE_OPT_OUT(IRComponents::C_SystemEvent<IRSystem::TICK>)
+
+namespace IRWorld {
+
+using AllEngineComponents = std::tuple<
+    IRComponents::C_TrixelCanvasFramebuffer,
+    IRComponents::C_TriangleCanvasTextures,
+    IRComponents::C_CanvasAOTexture,
+    IRComponents::C_CanvasFogOfWar,
+    IRComponents::C_CanvasSunShadow,
+    IRComponents::C_CanvasLightVolume,
+    IRComponents::C_PerAxisTrixelCanvases,
+    IRComponents::C_GPUParticlePool,
+    IRComponents::C_StatelessParticleEmitters,
+    IRComponents::C_DetachedRevoxelizeBuffer,
+    IRComponents::C_SpriteSheet,
+    IRComponents::C_Sprite,
+    IRComponents::C_VoxelPool,
+    IRComponents::C_SpatialIndex,
+    IRComponents::C_RenderCache,
+    IRComponents::C_ActiveLodLevel,
+    IRComponents::C_ChunkVisibleThisFrame,
+    IRComponents::C_FrameDataTrixelToFramebuffer,
+    IRComponents::C_CanvasLocalRotation,
+    IRComponents::C_LayoutState,
+    IRComponents::C_LayoutLeaf,
+    IRComponents::C_ResolvedFields,
+    IRComponents::C_ContactEvent,
+    IRComponents::C_OverlapContactBatch,
+    IRComponents::C_CursorPosition,
+    IRComponents::C_MousePosition,
+    IRComponents::C_MouseScroll,
+    IRComponents::C_KeyboardKey,
+    IRComponents::C_KeyStatus,
+    IRComponents::C_KeyPressed,
+    IRComponents::C_KeyReleased,
+    IRComponents::C_KeyMouseButton,
+    IRComponents::C_GLFWGamepadState,
+    IRComponents::C_GLFWJoystick,
+    IRComponents::C_MidiMessage,
+    IRComponents::C_MidiMessageData,
+    IRComponents::C_MidiMessageStatus,
+    IRComponents::C_MidiIn,
+    IRComponents::C_MidiOut,
+    IRComponents::C_SystemRelation,
+    IRComponents::C_IsNotPure,
+    IRComponents::C_MarkedForDeletion,
+    IRComponents::C_NoGlobalModifiers,
+    IRComponents::C_GlobalModifiers,
+    IRComponents::C_LambdaModifiers,
+    IRComponents::C_Modifiers,
+    IRComponents::C_VoxelSetNew,
+    IRComponents::C_Skeleton,
+    IRComponents::C_JointHierarchy,
+    IRComponents::C_LocalTransform,
+    IRComponents::C_WorldTransform,
+    IRComponents::C_Position2D,
+    IRComponents::C_Position2DIso,
+    IRComponents::C_PositionInt2D,
+    IRComponents::C_PositionInt3D,
+    IRComponents::C_SizeInt2D,
+    IRComponents::C_SizeInt3D,
+    IRComponents::C_SizeTriangles,
+    IRComponents::C_Direction3D,
+    IRComponents::C_Magnitude,
+    IRComponents::C_RotationMode,
+    IRComponents::C_RotationTarget,
+    IRComponents::C_AutoSpin,
+    IRComponents::C_ChunkMembership,
+    IRComponents::C_Velocity3D,
+    IRComponents::C_Velocity2DIso,
+    IRComponents::C_VelocityDrag,
+    IRComponents::C_Acceleration3D,
+    IRComponents::C_Gravity3D,
+    IRComponents::C_HasGravity,
+    IRComponents::C_GotoEasing3D,
+    IRComponents::C_ReactiveReturn3D,
+    IRComponents::C_SpringPlatform,
+    IRComponents::C_WallBounce,
+    IRComponents::C_WallDeath,
+    IRComponents::C_ColliderIso3DAABB,
+    IRComponents::C_CollisionLayer,
+    IRComponents::C_HitBox2D,
+    IRComponents::C_HitBox2DGui,
+    IRComponents::C_HitboxCircle,
+    IRComponents::C_HitboxRect,
+    IRComponents::C_ActiveHitbox,
+    IRComponents::C_Lifetime,
+    IRComponents::C_Timer,
+    IRComponents::C_Stopwatch,
+    IRComponents::C_Cycle,
+    IRComponents::C_Loop,
+    IRComponents::C_Alarm,
+    IRComponents::C_PeriodicIdle,
+    IRComponents::C_SimClock,
+    IRComponents::C_AnimationClip,
+    IRComponents::C_ActionAnimation,
+    IRComponents::C_AnimClipColorTrack,
+    IRComponents::C_AnimColorState,
+    IRComponents::C_AnimMotionColorShift,
+    IRComponents::C_ProceduralAnimation,
+    IRComponents::C_LerpEntity,
+    IRComponents::C_VoxelSquashStretch,
+    IRComponents::C_SpriteAnimation,
+    IRComponents::C_TextureScrollPosition,
+    IRComponents::C_TextureScrollVelocity,
+    IRComponents::C_ParticleBurst,
+    IRComponents::C_ParticleSpawner,
+    IRComponents::C_SpawnGlow,
+    IRComponents::C_TriggerGlow,
+    IRComponents::C_RhythmicLaunch,
+    IRComponents::C_ColorHSV,
+    IRComponents::C_GeometricShape<IRMath::Shape3D::SPHERE>,
+    IRComponents::C_ShapeDescriptor,
+    IRComponents::C_TriangleCanvasBackground,
+    IRComponents::C_TrianglesOnlySet,
+    IRComponents::C_LightSource,
+    IRComponents::C_LightBlocker,
+    IRComponents::C_Camera,
+    IRComponents::C_CameraPosition2DIso,
+    IRComponents::C_Viewport,
+    IRComponents::C_ZoomLevel,
+    IRComponents::C_TrixelCanvasOrigin,
+    IRComponents::C_TrixelCanvasRenderBehavior,
+    IRComponents::C_EntityCanvas,
+    IRComponents::C_CanvasTarget,
+    IRComponents::C_DetachedCanvas,
+    IRComponents::C_Voxel,
+    IRComponents::C_Joint,
+    IRComponents::C_JointName,
+    IRComponents::C_BindPoints,
+    IRComponents::C_MidiSequence,
+    IRComponents::C_MidiNote,
+    IRComponents::C_MidiChannel,
+    IRComponents::C_MidiDevice,
+    IRComponents::C_MidiDelay,
+    IRComponents::C_MidiSourcePort,
+    IRComponents::C_TextSegment,
+    IRComponents::C_TextStyle,
+    IRComponents::C_GuiPosition,
+    IRComponents::C_GuiElement,
+    IRComponents::C_GuiHoverState,
+    IRComponents::C_Widget,
+    IRComponents::C_WidgetButton,
+    IRComponents::C_WidgetCheckbox,
+    IRComponents::C_WidgetColorSwatch,
+    IRComponents::C_WidgetDropdown,
+    IRComponents::C_WidgetLabel,
+    IRComponents::C_WidgetList,
+    IRComponents::C_WidgetPanel,
+    IRComponents::C_WidgetRadio,
+    IRComponents::C_WidgetScroll,
+    IRComponents::C_WidgetSlider,
+    IRComponents::C_WidgetTextInput,
+    IRComponents::C_WidgetState,
+    IRComponents::C_Splitter,
+    IRComponents::C_VoxelSelection,
+    IRComponents::C_VoxelSelectionHighlight,
+    IRComponents::C_GizmoHandle,
+    IRComponents::C_Player,
+    IRComponents::C_ControllableUnit,
+    IRComponents::C_Selected,
+    IRComponents::C_Persistent,
+    IRComponents::C_Name,
+    IRComponents::C_Example,
+    IRComponents::C_HelpText,
+    IRComponents::C_SpatialQueryable,
+    IRSystem::C_EntityHoverDetectTag,
+    IRSystem::C_PerfStatsOverlayTag,
+    IRComponents::C_SystemEvent<IRSystem::TICK>>;
+
+inline constexpr std::size_t kExpectedEngineComponentCount = 165;
+
+static_assert(
+    detail::allExplicit<AllEngineComponents>(),
+    "Every engine component must have an explicit IR_SAVE_OPT_IN/OPT_OUT decision."
+);
+
+} // namespace IRWorld
+
+#endif /* SAVE_COMPONENT_INVENTORY_H */

--- a/engine/world/include/irreden/world/save_trait.hpp
+++ b/engine/world/include/irreden/world/save_trait.hpp
@@ -1,0 +1,73 @@
+#ifndef SAVE_TRAIT_H
+#define SAVE_TRAIT_H
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+#include <utility>
+
+// Per-component save-policy trait. Pure compile-time fact table: no
+// EntityManager/ComponentId includes, so a runtime serialize bridge can
+// layer on top without a dependency cycle.
+
+namespace IRWorld {
+
+// Primary template = "no decision yet". Deliberately NOT "opt-out" — an
+// engine component that never specializes this trait fails the
+// completeness gate in save_component_inventory.hpp instead of silently
+// being skipped by persistence.
+template <typename C> struct SaveTrait {
+    static constexpr bool kExplicit = false;
+    static constexpr bool kSave = false;
+    static constexpr std::uint32_t kSaveVersion = 0;
+};
+
+template <typename C> constexpr bool shouldSave() {
+    return SaveTrait<C>::kSave;
+}
+
+template <typename C> constexpr std::uint32_t saveVersion() {
+    return SaveTrait<C>::kSaveVersion;
+}
+
+namespace detail {
+
+template <typename Tuple, std::size_t... I>
+constexpr bool allExplicitImpl(std::index_sequence<I...>) {
+    return (... && SaveTrait<std::tuple_element_t<I, Tuple>>::kExplicit);
+}
+
+// True iff every type in Tuple has an explicit IR_SAVE_OPT_IN/OPT_OUT
+// specialization — the compile-time completeness gate.
+template <typename Tuple> constexpr bool allExplicit() {
+    return allExplicitImpl<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+}
+
+} // namespace detail
+
+} // namespace IRWorld
+
+// kSaveVersion lives on the trait, not the component struct: the
+// world-snapshot serializes a *schema* defined by the (P2) per-component
+// serialize function, not the struct's in-memory layout, so the schema's
+// version belongs beside the policy decision.
+#define IR_SAVE_OPT_IN(Type, Version)                                                              \
+    namespace IRWorld {                                                                            \
+    template <> struct SaveTrait<Type> {                                                           \
+        static constexpr bool kExplicit = true;                                                    \
+        static constexpr bool kSave = true;                                                        \
+        static constexpr std::uint32_t kSaveVersion = (Version);                                   \
+        static_assert(kSaveVersion >= 1, #Type " IR_SAVE_OPT_IN version must be >= 1");            \
+    };                                                                                             \
+    }
+
+#define IR_SAVE_OPT_OUT(Type)                                                                      \
+    namespace IRWorld {                                                                            \
+    template <> struct SaveTrait<Type> {                                                           \
+        static constexpr bool kExplicit = true;                                                    \
+        static constexpr bool kSave = false;                                                       \
+        static constexpr std::uint32_t kSaveVersion = 0;                                           \
+    };                                                                                             \
+    }
+
+#endif /* SAVE_TRAIT_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,6 +91,7 @@ add_executable(IrredenEngineTest
   world/chunk_membership_migration_test.cpp
   world/chunk_persistence_test.cpp
   world/chunk_residency_manager_test.cpp
+  world/save_trait_test.cpp
 )
 
 FetchContent_Declare(

--- a/test/world/save_trait_test.cpp
+++ b/test/world/save_trait_test.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+
+#include <irreden/world/save_component_inventory.hpp>
+#include <irreden/world/save_trait.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace {
+
+using namespace IRWorld;
+using namespace IRComponents;
+
+// Class A — GPU-handle / ResourceId-owning bearers must opt out; W-10
+// regenerates the handle post-load, so the pre-load value is never
+// meaningful to persist.
+TEST(SaveTrait, ClassABearersOptOut) {
+    EXPECT_FALSE(shouldSave<C_TrixelCanvasFramebuffer>());
+    EXPECT_FALSE(shouldSave<C_TriangleCanvasTextures>());
+    EXPECT_FALSE(shouldSave<C_CanvasAOTexture>());
+    EXPECT_FALSE(shouldSave<C_CanvasFogOfWar>());
+    EXPECT_FALSE(shouldSave<C_CanvasSunShadow>());
+    EXPECT_FALSE(shouldSave<C_CanvasLightVolume>());
+    EXPECT_FALSE(shouldSave<C_PerAxisTrixelCanvases>());
+    EXPECT_FALSE(shouldSave<C_GPUParticlePool>());
+    EXPECT_FALSE(shouldSave<C_StatelessParticleEmitters>());
+    EXPECT_FALSE(shouldSave<C_DetachedRevoxelizeBuffer>());
+    EXPECT_FALSE(shouldSave<C_SpriteSheet>());
+    EXPECT_FALSE(shouldSave<C_Sprite>());
+}
+
+// Safety-critical opt-outs called out by the plan: derived/rebuildable
+// state and engine-internal plumbing must never round-trip through a
+// world snapshot.
+TEST(SaveTrait, SafetyCriticalOptOuts) {
+    EXPECT_FALSE(shouldSave<C_LambdaModifiers>());
+    EXPECT_FALSE(shouldSave<C_ContactEvent>());
+    EXPECT_FALSE(shouldSave<C_SpatialIndex>());
+    EXPECT_FALSE(shouldSave<C_VoxelPool>());
+}
+
+// Representative Class F gameplay data opts in with a schema version >= 1.
+TEST(SaveTrait, RepresentativeGameplayDataOptsIn) {
+    EXPECT_TRUE(shouldSave<C_Velocity3D>());
+    EXPECT_GE(saveVersion<C_Velocity3D>(), 1u);
+
+    EXPECT_TRUE(shouldSave<C_LocalTransform>());
+    EXPECT_GE(saveVersion<C_LocalTransform>(), 1u);
+
+    EXPECT_TRUE(shouldSave<C_Name>());
+    EXPECT_GE(saveVersion<C_Name>(), 1u);
+
+    EXPECT_TRUE(shouldSave<C_ShapeDescriptor>());
+    EXPECT_GE(saveVersion<C_ShapeDescriptor>(), 1u);
+
+    EXPECT_TRUE(shouldSave<C_SimClock>());
+    EXPECT_GE(saveVersion<C_SimClock>(), 1u);
+}
+
+// Class E — the two explicit-call opt-ins and the deprecated shim opt-out.
+TEST(SaveTrait, ClassEExplicitCalls) {
+    EXPECT_TRUE(shouldSave<C_VoxelSetNew>());
+    EXPECT_GE(saveVersion<C_VoxelSetNew>(), 1u);
+
+    EXPECT_TRUE(shouldSave<C_Skeleton>());
+    EXPECT_GE(saveVersion<C_Skeleton>(), 1u);
+
+    EXPECT_FALSE(shouldSave<C_JointHierarchy>());
+}
+
+template <typename C> constexpr bool foldInvariantHolds() {
+    return SaveTrait<C>::kSave ? (SaveTrait<C>::kSaveVersion >= 1)
+                               : (SaveTrait<C>::kSaveVersion == 0);
+}
+
+template <typename Tuple, std::size_t... I>
+constexpr bool allFoldInvariantsHold(std::index_sequence<I...>) {
+    return (... && foldInvariantHolds<std::tuple_element_t<I, Tuple>>());
+}
+
+// Fold invariants across the entire inventory: shouldSave() implies
+// kSaveVersion >= 1, and !shouldSave() implies kSaveVersion == 0. Checked
+// at compile time (so a violation is a build break, not just a red test)
+// and mirrored here so it also shows up as a normal test result.
+static_assert(
+    allFoldInvariantsHold<AllEngineComponents>(
+        std::make_index_sequence<std::tuple_size_v<AllEngineComponents>>{}
+    ),
+    "shouldSave() must imply kSaveVersion >= 1, and !shouldSave() must imply kSaveVersion == 0"
+);
+
+TEST(SaveTrait, FoldInvariantsHoldAcrossInventory) {
+    EXPECT_TRUE((allFoldInvariantsHold<AllEngineComponents>(
+        std::make_index_sequence<std::tuple_size_v<AllEngineComponents>>{}
+    )));
+}
+
+// Completeness backstop — adding a component to the engine without adding
+// a matching IR_SAVE_OPT_IN/OPT_OUT + AllEngineComponents entry fails this
+// test (the compile-time gate in save_component_inventory.hpp would also
+// have caught a missing *decision*; this catches a missing *tuple entry*
+// for a component that does have one, e.g. a copy-paste line drop).
+TEST(SaveTrait, InventoryIsComplete) {
+    EXPECT_EQ(std::tuple_size_v<AllEngineComponents>, kExpectedEngineComponentCount);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- `engine/world/include/irreden/world/save_trait.hpp` — compile-time `SaveTrait<C>` (opt-in/opt-out + `kSaveVersion`, `shouldSave<C>()`/`saveVersion<C>()`, `IR_SAVE_OPT_IN`/`IR_SAVE_OPT_OUT` macros). Primary template means "no decision yet," not "opt-out."
- `engine/world/include/irreden/world/save_component_inventory.hpp` — an explicit, audited decision for all 165 real engine components (GPU-handle/derived/transient/ECS-plumbing → opt-out; gameplay data → opt-in v1; a few explicit-call cases), plus `AllEngineComponents` and a `static_assert` completeness gate that fails the build if any listed component lacks a decision. Verified the gate actually fires (temporarily deleted one decision line, confirmed the build breaks with the expected message, restored it).
- `test/world/save_trait_test.cpp` — spot-checks per class, fold-invariant check across the whole inventory, and a tuple-size backstop against the audited count (165).
- `engine/world/CLAUDE.md` — new "Save-trait policy layer" section documenting where decisions live, the opt-out-by-omission-is-forbidden invariant, and the new-component contract.

Pure metadata — no archetype walk, no writer, no Lua surface. P2+ builds the runtime serialize bridge on top of `shouldSave<C>()`/`saveVersion<C>()`/`AllEngineComponents`.

**Incidental fixes required to make the inventory's all-components include actually compile** (this is the first site that includes every component header together, so these were previously-latent, dead-or-untriggered bugs):
- `component_glfw_gamepad_state.hpp` / `component_midi_sequence.hpp` — each used a name (`GamepadButtons`/`GamepadAxes`, `IR_ASSERT`) that only resolved because of `using namespace` pollution from whichever TU happened to include it first; added the missing using-declarations/include so each header is self-contained.
- `component_position_int_3d.hpp` — was missing its `namespace IRComponents { ... }` wrapper entirely (every sibling file has it).
- `component_lerp_component.hpp` — dead code (zero includers before this PR) with a non-existent `#include <irreden/ir_ecs.hpp>` and constructor names that didn't match the class name; fixed to compile without changing its intended shape (entity id + `std::function` tick callback).
- Corrected 4 names that turned out to be commented-out, never-real components (`C_MainCanvas`, `C_GuiCanvas`, `C_BackgroundCanvas`, `C_IsGamepad` in `component_tags_all.hpp`) that a naive grep for `struct C_...` had picked up — dropped the audited total from the plan's assumed 169 to the verified 165.
- Reclassified `C_LerpEntity` from the plan's opt-in to opt-out after reading its body: it holds a `std::function` member, the same non-serializable shape as `C_LambdaModifiers`.

## Test plan
- [x] `fleet-build --target IrredenEngineTest` — clean build (macOS/Metal)
- [x] `./IrredenEngineTest` — full suite green: 1265 passed, 1 pre-existing skip (`GpuComputeDispatchTest.SkippedOnNonOpenGLBackend`, unrelated)
- [x] `./IrredenEngineTest --gtest_filter=SaveTrait.*` — all 6 new tests pass
- [x] Manually verified the completeness gate fails the build when a decision line is deleted (acceptance criterion #1)
- [ ] Linux (`linux-debug`) build — not verifiable from this macOS host; nothing in this PR is platform-specific (pure C++17 template metaprogramming, no shaders/backend code), so no reason to expect divergence, but flagging per epic acceptance criterion #5

Closes #2212

🤖 Generated with [Claude Code](https://claude.com/claude-code)