### PR TITLE
persist: IRWS world snapshot container + walker + loader (#2213)

### DIFF
--- a/.fleet/plans/issue-2213.md
+++ b/.fleet/plans/issue-2213.md
@@ -1,0 +1,90 @@
+## Plan: persist P2 — IRWS container + deterministic archetype walker + singleton chunk (W-3, W-6)
+
+- **Issue:** #2213
+- **Model:** opus
+- **Date:** 2026-07-03
+- **Epic:** #667 — see `.fleet/plans/issue-667.md` for full context
+- **Blocked by:** #2212
+
+### Scope
+
+Deliver `IRPersist::saveWorld(path)` / `IRPersist::loadWorld(path)` in `engine/world/`: the `IRWS` snapshot container (magic + uint32 version + chunk table + JSON sidecar via `engine/asset/` primitives), a deterministic archetype walker that writes opted-in component columns + entity IDs (epic item W-3), and the singleton chunk for `IREntity::singleton<T>()` instances (epic item W-6), plus the type-erased save registry that bridges P1's compile-time `SaveTrait<C>` to runtime archetype columns. Loads restore into a reset world.
+
+Out of scope: relations (P3 — relation pseudo-components are stripped, no relation chunk emitted here), migration registry (P5 — but every column carries the `kSaveVersion` + byte-length header P5 needs), GPU-handle regeneration (P6 — opted-out columns simply aren't written), Lua bindings (P7), full round-trip/determinism test matrix (P4 — this task ships one headless gtest proving the round-trip). Named-entity (`m_namedEntities`) persistence is not in the epic's W-list and is excluded.
+
+Blocked by P1 (`engine/world/save_trait.hpp` with opt-in/out traits + `kSaveVersion`) — verified absent on current master, so this task must not start until P1 merges.
+
+### Verified current state
+
+- **Entity IDs are monotonic and never recycled.** `m_nextEntityId` is an atomic counter starting at `IR_RESERVED_ENTITIES` (0xFF); destroy retires the ID permanently (`engine/entity/src/entity_manager.cpp:55-65`, `:99-105`). Raw ID = low 25 bits (`IR_ENTITY_ID_BITS`, `ir_entity_types.hpp:26-32`). No generation counter — an `EntityId` is index bits + flag bits only. The only flag ever set is `kEntityFlagIsRelation` (`entity_manager.cpp:518`); `IR_PURE_ENTITY_BIT` / `kEntityFlagIsSystem` are declared but never set (repo-wide grep).
+- **ComponentIds are session-local entity IDs.** `registerComponentImpl` allocates the ComponentId via `createEntity()` (`entity_manager.cpp:566-572`), keyed by `typeid(C).name()` (`entity_manager.hpp:165-181`) — both the numeric ID and the typeid key are unstable across sessions/compilers, so neither may be the on-disk identity. Rule #2 name tables are mandatory.
+- **Archetype walk surface exists.** `EntityManager::getArchetypeNodes()` returns all `smart_ArchetypeNode`s (`entity_manager.hpp:78-80`); each `ArchetypeNode` exposes `type_` (a `std::set<ComponentId>`, already sorted), `entities_`, `components_`, `length_` (`archetype_node.hpp:23-35`). Typed column access is `castComponentDataPointer<C>(...)->dataVector` (`i_component_data.hpp:49-98`). `findCreateArchetypeNode` is graph-public but not exposed through EntityManager (only `findArchetypeNode`, `entity_manager.hpp:75-77`).
+- **Singleton internals.** Cache is `m_singletonEntityByComponent` (private, `entity_manager.hpp:522`), lazily validated, cleared by `destroyAllEntities` (`entity_manager.cpp:352-373`) but **not** by `resetGameplay` (`entity_manager.cpp:442-443`). The untyped `getOrCreateSingletonByComponentId` path asserts on C++ components (`appendDefaultRow` returns false — `entity_manager.cpp:446-459`, `:596-599`); only the typed `getOrCreateSingleton<C>` (`entity_manager.hpp:453-466`) works generically. No public accessor for the cache map exists.
+- **#663 primitives.** `IRAsset::BinaryWriter/Reader` with file + memory backends, `Result<T>`/`BinaryStatus` recoverable errors (`binary_io.hpp:95-153`, `:208-251`); `writeChunked(w, magic, version, span<ChunkPayload>)` / `readChunks(r, expectedMagic, maxKnownVersion)` with unknown-chunk pass-through (`chunk_header.hpp:88-117`); `NameTableEntry{u32 id_, string name_}` + `NameTable` lookup (`name_table.hpp:38-85`); `JsonSidecarWriter` (write-only, Rule #6); `math_binary_io.hpp` for `IRMath` types. `IrredenEngineWorld` already links `IrredenEngineEntity` + `IrredenEngineAsset` (`engine/world/CMakeLists.txt:7-21`).
+- **Fresh-world / teardown interaction.** `resetGameplay` preserves three categories: singletons, `C_Persistent`-tagged entities (camera/framebuffer/canvas stamped at `render_manager.cpp:128-135`), and component-backing entities (`destroyAllExceptPreserved`, `entity_manager.cpp:375-444`); the `C_Persistent` policy lives in the `IREntity::resetGameplay` facade (`ir_entity.cpp:19-27`). `engine/entity/CLAUDE.md` "Save/load implications" already commits #199 to "the entity id round-trips" and notes the singleton cache must rebind on load.
+- **Headless test harness exists.** A bare `EntityManager` member is a valid world for gtest (ctor sets `g_entityManager`; `test/ecs/entity_manager_test.cpp:44-56`); world tests register at `test/CMakeLists.txt:90-93`.
+
+### Approach
+
+**Entity-ID decision: restore-exact (raw IDs preserved on load), not remap.** Rationale: (1) epic acceptance #1 explicitly says the serializer "restores … entity IDs" and `engine/entity/CLAUDE.md` already documents "the entity id round-trips" for #199; (2) components embed raw `EntityId` fields (e.g. `C_VoxelSetNew`'s canvas ID) and P2 has no reflection to remap inside opted-in blobs — restore-exact keeps them valid, remap silently breaks them all; (3) W-7 byte-for-byte round-trip parity and P3's relation triples both require stable IDs; (4) the mechanics are cheap because IDs never recycle: restore inserts saved raw IDs into `m_entityIndex`/nodes and advances `m_nextEntityId` past the saved watermark, so post-load allocations can never collide. Collision safety comes from a **save-side exclusion set that mirrors `resetGameplay`'s preserve set**: saveWorld skips (a) singleton entities (handled by the SNGL chunk as value overwrites), (b) `C_Persistent`-tagged entities, (c) relation-flagged and component-backing entities. The documented load contract is `IREntity::resetGameplay()` → `IRPersist::loadWorld(path)` at a frame boundary — everything the save wrote is exactly what the reset destroyed, so same-session load is collision-free *by construction*. Cross-session, load is two-phase (parse + validate everything, then apply): any saved ID colliding with a live entity returns a recoverable `BinaryStatus` error with zero world mutation (Rule #5). A whole-file ID-rebase fallback is left as P5 design space if cross-build infra-ID drift ever bites.
+
+**Singletons load by value, not by ID.** Singletons survive teardown by design, so the SNGL chunk loader resolves each entry by save-name, lazy-creates via the typed `IREntity::singletonEntity<C>()` captured in the registry, and overwrites the live row in place. The saved singleton entity ID is still written and surfaced in `LoadResult` as a `savedId → liveId` alias map (identity in the same-session case) so P3 relation triples referencing a singleton can translate.
+
+**Steps:**
+
+1. **Type-erased save registry** (`engine/world/include/irreden/world/save_registry.hpp` + src). `IRPersist::registerSaveComponent<C>()` — enabled only when P1's `SaveTrait<C>` opts in — captures per component: stable save-name, `kSaveVersion`, `ComponentId` resolver (lazy `getComponentType<C>()`), `writeRow(const IComponentData*, int row, BinaryWriter&)`, `readAppendRow(IComponentData*, BinaryReader&)` (default-construct + trait read; `static_assert` default-constructible), `readIntoEntity(EntityId, BinaryReader&)` and `getOrCreateSingletonEntity()` for the SNGL path. Keyed both by save-name and by resolved ComponentId. Reconcile at claim time: if P1 shipped a runtime registry or `kSaveName` member, consume it; if traits only, this shim is P2's to own.
+2. **Minimal EntityManager restore surface** (`engine/entity/`): `findCreateArchetypeNode(const Archetype&)` public wrapper; `restoreEntitiesBatch(ArchetypeNode*, std::span<const EntityId>)` (index emplace + record update + `length_`/`entities_` append + liveEntityCount, main-thread asserted — columns appended afterwards by the registry readers, with an end-of-node sync assert mirroring `entity_manager.hpp:271-275`); `const std::unordered_map<ComponentId, EntityId>& singletonEntityCache() const`; `EntityId entityIdWatermark() const` and `advanceEntityIdWatermark(EntityId)`.
+3. **Walker + writer** (`engine/world/include/irreden/world/world_snapshot.hpp` + `src/world_snapshot.cpp`, namespace `IRPersist`, `kWorldSnapshotMagic = "IRWS"`, `kWorldSnapshotVersion = 1`). `saveWorld` flushes structural changes + drains marked deletions first (frame-boundary, main-thread contract), builds the exclusion set, then for every archetype node with `length_ > 0` computes the **projection**: the subset of `type_` that is registered + opted-in (relation pseudo-components and unregistered components drop out here). Nodes with identical projections merge into one saved archetype; merged entity lists sort ascending by masked raw ID (locked order); archetype blocks sort lexicographically by projected sorted-ComponentId set (locked order). Chunks, composed in `MemoryBinaryWriter`s and emitted via one `writeChunked` to a `FileBinaryWriter`:
+   - `CMPN` — name table `(componentId as u32, saveName)` for every referenced component (Rule #2).
+   - `ARCH` — varuint archetypeCount; per archetype: varuint componentCount + sorted componentRefs; varuint entityCount + ascending varuint raw entity IDs; then per column (same component order): version (`kSaveVersion`, width per P1 — epic W-2 says u32) + varuint columnByteLength + rows written in entity order via `writeRow` (gathering per-entity `(node,row)` for merged groups). The byte-length prefix makes any unresolvable column skippable on load — the seam P5's migration registry plugs into.
+   - `SNGL` — varuint count; entries sorted by save-name (ComponentIds aren't cross-session stable; name order keeps the chunk deterministic): componentRef + saved raw entity ID + version + varuint byteLength + value blob. Only cache entries whose component is opted-in and whose entity is live.
+   - `META` — `nextEntityId` watermark + total saved entity count.
+   - JSON sidecar at `path + ".json"` (summary; write-only, Rule #6), mirroring the `.vxs` pattern.
+4. **Loader.** Phase 1: `readChunks` (bad magic / truncation / version-too-new → recoverable error), parse CMPN/ARCH/SNGL/META into staging structs. Phase 2 validate: resolve names against the registry (unresolvable column → counted skip, not fatal; the archetype an entity restores into is the *resolved* set), check every saved raw ID against `entityExists` → collision aborts with no mutation. Phase 3 apply: per archetype `findCreateArchetypeNode(resolvedSet)` → `restoreEntitiesBatch` → per-column `readAppendRow` in entity order (skip unresolvable columns by byte length) → sync assert; SNGL entries via `getOrCreateSingletonEntity()` + `readIntoEntity`, recording the alias map; finally `advanceEntityIdWatermark(savedWatermark)`. Return `LoadResult { status_, entitiesRestored_, columnsSkipped_, singletonsRestored_, singletonAliases_ }`.
+5. **Headless gtest** (`test/world/world_snapshot_test.cpp`) + CMake registration + `world_snapshot.hpp` header block documenting the chunk table (Rule #7) + `engine/world/CLAUDE.md` section distinguishing this from `chunk_persistence.hpp`'s per-chunk `.vxs` path.
+
+### Affected files
+
+- `engine/world/include/irreden/world/world_snapshot.hpp` — new: `IRPersist::saveWorld/loadWorld`, `LoadResult`, IRWS format doc block (Rule #7)
+- `engine/world/src/world_snapshot.cpp` — new: walker, chunk writers, two-phase loader
+- `engine/world/include/irreden/world/save_registry.hpp` + `engine/world/src/save_registry.cpp` — new: type-erased bridge over P1 `SaveTrait<C>` (subject to P1 reconciliation)
+- `engine/entity/include/irreden/entity/entity_manager.hpp` + `engine/entity/src/entity_manager.cpp` — restore surface: `restoreEntitiesBatch`, `findCreateArchetypeNode` wrapper, `singletonEntityCache()`, `entityIdWatermark()` / `advanceEntityIdWatermark()`
+- `engine/world/CMakeLists.txt` — add new sources (deps already present)
+- `test/world/world_snapshot_test.cpp` + `test/CMakeLists.txt` — new gtest
+- `engine/world/CLAUDE.md`, `engine/entity/CLAUDE.md` — document the surface + restore contract
+
+### Acceptance criteria
+
+In a headless gtest world (bare `EntityManager`, no window/GPU):
+
+1. **Round-trip:** ≥100 entities across ≥3 archetypes of opted-in test components (including two source archetypes that differ only by an opted-out component, proving projection-merge) → `saveWorld` → `destroyAllEntities` → `loadWorld` → every entity restores with its **exact original raw EntityId**, identical component values, identical resolved archetype membership; `LoadResult.entitiesRestored_` matches.
+2. **Singleton chunk:** mutate a singleton value → save → teardown → load → `IREntity::singleton<T>()` returns the saved value; cache stays bound to the live entity; alias map correct.
+3. **Opt-out:** a `SaveTrait`-opted-out component on a saved entity does not appear in the file (name absent from CMPN) and is absent after load.
+4. **Post-load allocation safety:** `createEntity` after load returns an ID above the saved watermark.
+5. **Recoverable failures (Rule #5):** bad magic, truncated-mid-chunk, version-too-new, and a live-ID collision each return a non-ok status with **zero world mutation**; unknown chunk tags and unknown component names are skipped with counts, not errors.
+6. **Determinism:** two consecutive `saveWorld` calls on the same world produce byte-identical files.
+7. Builds clean on `linux-debug` and `macos-debug`; test runs inside `IrredenEngineTest`.
+
+### Gotchas
+
+- **Never write `typeid` names or raw ComponentIds as identity** — both are session/compiler-local (`entity_manager.cpp:566-572`); the CMPN name table's numeric ID is fallback-only (Rule #2).
+- **Mask flags on save:** `entities_` rows carry high-bit flags; write masked 25-bit IDs, skip `kEntityFlagIsRelation` rows defensively (relation entities live in the base node, but belt-and-braces). **This is the P3 boundary contract: relation-entities and archetype-embedded relation ids must never ride the entity/component chunks — relation state is owned solely by P3's relation chunk.**
+- **The exclusion set must mirror `destroyAllExceptPreserved`** (`entity_manager.cpp:375-444`): singleton entities, `C_Persistent` entities, component-backing entities. A creation-tagged `C_Persistent` gameplay entity is deliberately *not* saved — document in the header block.
+- **`getOrCreateSingletonByComponentId` asserts for C++ components** (`entity_manager.cpp:596-599`) — the SNGL loader must go through the typed lazy-create captured at registration, never the untyped path.
+- **Auto-attached `C_LocalTransform`/`C_WorldTransform`:** the restore path bypasses the free `createEntity` wrapper, so nothing is auto-attached — entities restore with exactly the resolved saved archetype. If LT/WT are opted in they round-trip as columns; the walker must not special-case them.
+- **saveWorld/loadWorld are frame-boundary, main-thread-only**: flush structural changes + drain marked deletions before walking; assert via the existing `isMainThreadForDeferred` pattern.
+- **`kSaveVersion` width:** follow whatever P1 landed (u32 per the epic); don't fork widths in one file.
+- **IRMath fields serialize via `math_binary_io.hpp`** helpers, never inline byte-copies (`.claude/rules/cpp-math.md`).
+- **No linear searches in the load hot path** (simplify check): key staging lookups by hash maps; the per-node column sync assert catches drift early.
+- **Cross-session byte-determinism caveat for P4/W-8:** the locked archetype sort key is the ComponentId set, which is registration-order-dependent — same-session double-save is byte-identical (criterion 6), but a *different* session's re-save may order archetype blocks differently. Flagged to P4 rather than relitigating the locked ordering here.
+
+### Sibling + in-flight reconciliation
+
+- **No open PRs touch `engine/entity/`, `engine/world/`, or `engine/asset/`** (checked 2026-07-03; open PRs are render/tooling only). No merge hazards.
+- **P1 files ahead in this chain.** Hard dependency: at claim time, diff this plan against P1's actual surface — trait member names, `kSaveVersion` width, whether P1 shipped a stable save-name and/or a runtime registry. If P1 provides the registry, drop `save_registry.hpp` from this task and consume theirs; if P1 provides no stable name, extending the trait with one is a small additive change to negotiate in the P2 PR.
+- **P3 (relations):** this task strips relation pseudo-components from saved archetypes and reserves no tag — P3 adds its relation chunk additively (Rule #1, no version bump). `LoadResult.singletonAliases_` is the hand-off P3 needs for triples referencing singleton entities. P3 also depends on the walker exposing an entity-id resolver hook (identity under restore-exact).
+- **P5 (migration):** the per-column `(version, byteLength)` header is the migration seam; P5's `(ComponentId, oldVersion) → reader` registry plugs into the loader's column dispatch without format changes.
+- **P6 (GPU regen):** projection-merge means a restored entity may lack opted-out GPU-handle components its pre-save archetype had; P6's regen systems must detect-and-re-add, not assume presence. P6 also defines the `SaveTrait<C_VoxelSetNew>` staged-mode round-trip contract — coordinate.
+- **P7 (Lua):** keep `saveWorld/loadWorld` signatures `(const std::string&)` returning status/result structs so the binding is mechanical.
+- **`engine/world/chunk_persistence.hpp`** is the *parallel* per-chunk voxel `.vxs` path — no code overlap; the new CLAUDE.md section must keep the two save surfaces clearly distinguished.
+

--- a/engine/entity/CLAUDE.md
+++ b/engine/entity/CLAUDE.md
@@ -269,11 +269,40 @@ the specific row.
 
 ### Save/load implications
 
-Per-component save/load (#199) treats singleton entities like any other:
-the entity id round-trips and the cache rebuilds on first access against
-the loaded entity. Workers retrofitting #199 into the singleton API should
-verify the cache invalidates on load (typically a `destroyAllEntities`
-precedes the load, which already clears the cache).
+The world snapshot (`engine/world/world_snapshot.hpp`, persist P2 #2213)
+does **not** ride a singleton through the archetype chunk — it excludes
+singleton entities from the `ARCH` walk and persists each by value in the
+`SNGL` chunk instead, restoring it onto the live singleton via
+`getOrCreateSingleton<C>()` and overwriting the row. So on load the cache
+rebuilds against the (possibly freshly lazy-created) live entity, and the
+snapshot's `LoadResult.singletonAliases_` maps each saved singleton id to
+its live id (identity in the same-session `destroyAllEntities`-then-load
+case; a fresh id cross-session). The standard load contract still runs a
+teardown first, which clears the cache.
+
+## World-snapshot restore surface (persist P2, #2213)
+
+`EntityManager` exposes a small surface the snapshot **loader** needs and
+the normal ECS flow doesn't:
+
+- `findCreateArchetypeNode(type)` — public wrapper over the archetype
+  graph's node creation (the loader must materialize a restored archetype
+  no live entity currently occupies; `findArchetypeNode` only *finds*).
+- `restoreEntitiesBatch(node, span<EntityId>)` — insert a batch of entities
+  with their **exact saved ids** into `node` (records + `entities_` +
+  `length_` + live count). Columns are filled afterward by the caller's
+  per-column readers, in the same entity order — the caller asserts the
+  end-of-node column/`length_` sync, mirroring the eager insert path.
+- `singletonEntityCache()` / `isComponentBackingEntity(id)` — the two
+  read-only predicates the **save** walker uses to mirror
+  `destroyAllExceptPreserved`'s exclusion set.
+- `entityIdWatermark()` / `advanceEntityIdWatermark(w)` — read/advance the
+  monotonic allocator watermark. Load restores exact ids (ids never
+  recycle) then advances the watermark past every restored id; new
+  allocations can't collide. `advance` never moves the watermark backward.
+
+These are frame-boundary, main-thread-only (asserted), like the rest of the
+eager mutation API.
 
 ## Scene-transition reset (`resetGameplay`)
 

--- a/engine/entity/include/irreden/entity/entity_manager.hpp
+++ b/engine/entity/include/irreden/entity/entity_manager.hpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <initializer_list>
 #include <set>
+#include <span>
 
 // TODO: a component should be registered with a size so it
 // can be copied around generically just as data.
@@ -88,6 +89,54 @@ class EntityManager {
     [[nodiscard]] bool entityExists(EntityId entity) const {
         return m_entityIndex.contains(entity & IR_ENTITY_ID_BITS);
     }
+
+    // --- World-snapshot restore surface (persist P2, #2213) ---
+    // Public wrapper over the archetype graph's node creation. The loader
+    // must materialize the target node for a restored archetype that no
+    // live entity currently occupies — findArchetypeNode alone can only
+    // find an existing one.
+    inline ArchetypeNode *findCreateArchetypeNode(const Archetype &type) {
+        return m_archetypeGraph.findCreateArchetypeNode(type);
+    }
+
+    // Insert a batch of entities carrying their exact saved EntityIds into
+    // `node`, appending to its entity list and advancing length_ / the live
+    // count. Component columns are filled separately by the caller (the save
+    // registry's per-column readers) in the SAME entity order, so on return
+    // each column is one batch short of length_ until the caller appends —
+    // the caller mirrors the eager path's end-of-node sync assert. Ids go in
+    // masked (no flags): the snapshot walker excludes relation/system
+    // entities, so a restored gameplay id never carries flag bits.
+    // Main-thread only (load is a frame-boundary op).
+    void restoreEntitiesBatch(ArchetypeNode *node, std::span<const EntityId> entityIds);
+
+    // Read-only view of the singleton cache (ComponentId -> owning entity).
+    // The snapshot walker excludes these entities from the ARCH chunk (they
+    // ride the SNGL chunk by value) — one arm of the resetGameplay-mirroring
+    // save-exclusion set.
+    inline const std::unordered_map<ComponentId, EntityId> &singletonEntityCache() const {
+        return m_singletonEntityByComponent;
+    }
+
+    // True if `entity` is a component-TYPE backing entity (each registered
+    // component is itself an entity id). Another arm of the save-exclusion
+    // set mirroring destroyAllExceptPreserved.
+    inline bool isComponentBackingEntity(EntityId entity) const {
+        return m_pureComponentVectors.contains(entity & IR_ENTITY_ID_BITS);
+    }
+
+    // The next-EntityId watermark (the id a subsequent createEntity would
+    // allocate). Written to the snapshot META chunk; a load pushes the
+    // allocator past every restored id via advanceEntityIdWatermark. Ids
+    // never recycle, so this is the whole of restore collision safety.
+    inline EntityId entityIdWatermark() const {
+        return m_nextEntityId.load(std::memory_order_relaxed);
+    }
+
+    // Advance the allocator watermark to at least `watermark` — never
+    // backwards, since this session's infrastructure entities may already
+    // sit above a cross-session saved watermark. Main-thread only.
+    void advanceEntityIdWatermark(EntityId watermark);
     EntityRecord &getRecord(EntityId entity);
     EntityId setFlags(EntityId entity, EntityId flags);
     bool isPureComponent(ComponentId component);

--- a/engine/entity/src/entity_manager.cpp
+++ b/engine/entity/src/entity_manager.cpp
@@ -64,6 +64,31 @@ EntityId EntityManager::allocateEntityIdAtomic() {
     return id;
 }
 
+void EntityManager::restoreEntitiesBatch(ArchetypeNode *node, std::span<const EntityId> entityIds) {
+    IR_PROFILE_FUNCTION(IR_PROFILER_COLOR_ENTITY_OPS);
+    IR_ASSERT(
+        isMainThreadForDeferred(),
+        "restoreEntitiesBatch is a frame-boundary op — must run on the main thread"
+    );
+    for (const EntityId entity : entityIds) {
+        const EntityId masked = entity & IR_ENTITY_ID_BITS;
+        m_entityIndex.emplace(masked, EntityRecord{node, node->length_});
+        node->entities_.push_back(masked);
+        node->length_++;
+        ++m_liveEntityCount;
+    }
+}
+
+void EntityManager::advanceEntityIdWatermark(EntityId watermark) {
+    IR_ASSERT(
+        isMainThreadForDeferred(),
+        "advanceEntityIdWatermark is a frame-boundary op — must run on the main thread"
+    );
+    if (watermark > m_nextEntityId.load(std::memory_order_relaxed)) {
+        m_nextEntityId.store(watermark, std::memory_order_relaxed);
+    }
+}
+
 bool EntityManager::isMainThreadForDeferred() const {
     // No JobManager → unit tests + pre-`World` startup → always main.
     if (g_jobManager == nullptr) {

--- a/engine/world/CLAUDE.md
+++ b/engine/world/CLAUDE.md
@@ -176,6 +176,68 @@ descriptor` runtime bridge, migration registry, GPU-handle regeneration
 pass) consumes `shouldSave<C>()` / `saveVersion<C>()` / `AllEngineComponents`
 on top of this layer.
 
+P2 (#2213) added `SaveTrait<C>::kSaveName` (via the `IR_SAVE_OPT_IN/OPT_OUT`
+macros — the source spelling of the type, a compiler-stable on-disk key)
+and the `saveName<C>()` accessor. It's the CMPN name-table identity; nothing
+in P1's decision logic reads it.
+
+## World snapshot — the `IRWS` container (persist P2, #2213, epic #667)
+
+`engine/world/include/irreden/world/world_snapshot.hpp` declares
+`IRWorld::saveWorld(registry, path)` / `IRWorld::loadWorld(registry, path)`
+— the **entity-level** save path, distinct from `chunk_persistence.hpp`'s
+per-chunk `.vxs` **voxel-pool** save (that persists a streaming chunk's
+voxel slice, not entities/components; no code overlap). The file is a
+standard `engine/asset/` container (magic `IRWS`, `chunk_header.hpp`) with
+four chunks — `CMPN` (component name table, the local-index key space),
+`ARCH` (archetypes + entity ids + per-column data, each column carrying a
+`(saveVersion, byteLength)` header — the P5 migration seam), `SNGL`
+(singletons restored by value), `META` (nextEntityId watermark). A
+write-only `.json` sidecar (Rule #6) rides alongside.
+
+Three collaborating headers:
+
+- `save_serialize.hpp` — `IRWorld::SaveSerialize<C>`, the per-component
+  bytes customization point. The primary template is a trivially-copyable
+  raw-image fast path (`static_assert`s trivial-copyability); a component
+  owning heap storage (`std::string`/`std::vector`/handles) must specialize
+  it. P1 decides *whether*; this decides *how*.
+- `save_registry.hpp` — `IRWorld::SaveRegistry`, the type-erased bridge.
+  `registerComponent<C>()` is `if constexpr`-gated on `shouldSave<C>()`
+  (opted-out → no-op, and no `SaveSerialize<C>` instantiation), capturing
+  the save-name, version, session-local `ComponentId`, and the erased
+  row/singleton read-write hooks. The walker/loader compile once regardless
+  of how many components opt in.
+- `world_snapshot.hpp/.cpp` — the deterministic projection-merge walker,
+  chunk writers, and the two-phase loader.
+
+**Projection-merge + exclusion.** Only registered opt-in components are
+written; an entity's saved archetype is the projection of its live
+archetype onto them (two live archetypes differing only by a dropped
+component merge into one saved archetype). The walker excludes exactly what
+`resetGameplay`/`destroyAllExceptPreserved` preserves — singleton entities
+(they ride `SNGL`), `C_Persistent`-tagged entities, component-backing
+entities — so the load contract
+
+```
+IREntity::resetGameplay();          // frame boundary
+IRWorld::loadWorld(registry, path); // restores exact original EntityIds
+```
+
+is collision-free by construction. Entity IDs are restored **exact**
+(never remapped — they never recycle). Same-world double-save is
+byte-identical; every read is a recoverable `IRAsset::BinaryStatus` and a
+bad magic / truncation / version-too-new / live-id collision aborts with
+**zero** world mutation (Rule #5); unknown chunk tags and unresolvable
+component names skip with counts.
+
+**P2 scope is the mechanism.** It ships one headless gtest
+(`test/world/world_snapshot_test.cpp`) proving the round-trip with
+trivially-copyable *test* components. Registering every engine component in
+`AllEngineComponents` — each needs a `SaveSerialize<C>` specialization for
+its non-POD fields, and a `(path)`-only convenience wrapper over a
+process-default registry for the P7 Lua binding — is downstream work.
+
 ## Responsibilities
 
 `World(const char* configFileName)`:

--- a/engine/world/CMakeLists.txt
+++ b/engine/world/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(IrredenEngineWorld STATIC
     src/world.cpp
     src/chunk_residency.cpp
     src/chunk_persistence.cpp
+    src/world_snapshot.cpp
 )
 
 target_link_libraries(IrredenEngineWorld PUBLIC

--- a/engine/world/include/irreden/world/save_registry.hpp
+++ b/engine/world/include/irreden/world/save_registry.hpp
@@ -1,0 +1,161 @@
+#ifndef SAVE_REGISTRY_H
+#define SAVE_REGISTRY_H
+
+/// Type-erased bridge from P1's compile-time `SaveTrait<C>` fact table to
+/// the runtime archetype columns the world snapshot walks. Registration is
+/// the only place a concrete component type `C` is named; everything after
+/// works through `ComponentId` + these erased hooks, so the walker/loader
+/// in `world_snapshot.cpp` compile once regardless of how many components
+/// opt in.
+///
+/// One `SaveComponentEntry` per opted-in component captures:
+///   - `saveName_`  — stable on-disk identity (`SaveTrait<C>::kSaveName`).
+///   - `saveVersion_` — schema version (`saveVersion<C>()`).
+///   - `componentId_` — the session-local `ComponentId` (resolved lazily
+///     at registration; a fallback identity only, never the on-disk key).
+///   - `writeRow_` / `appendRow_` — one component instance ↔ bytes, via
+///     the `SaveSerialize<C>` customization point, against a live column.
+///   - the singleton hooks (`getOrCreateSingletonEntity_`, `writeSingleton_`,
+///     `readIntoEntity_`) for the SNGL chunk's by-value round-trip.
+///
+/// `registerComponent<C>()` is a no-op for an opted-out `C` (the body is
+/// `if constexpr`-gated on `shouldSave<C>()`), so a caller may hand it any
+/// component type without first checking the trait — and, crucially, an
+/// opted-out type never instantiates `SaveSerialize<C>`, so a component
+/// with no serializer only breaks the build if it actually opts in.
+///
+/// Scope note (P2): this layer is the *mechanism*. P2 proves it with
+/// trivially-copyable test components (see `test/world/world_snapshot_test.cpp`);
+/// wiring every engine component in `AllEngineComponents` — each of which
+/// needs a `SaveSerialize<C>` specialization for its non-POD fields — is
+/// downstream work, not this slice.
+
+#include <irreden/world/save_serialize.hpp>
+#include <irreden/world/save_trait.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/entity/i_component_data.hpp>
+#include <irreden/entity/ir_entity_types.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace IRWorld {
+
+/// One opted-in component's type-erased save/load hooks. Function objects
+/// are stateless (they close over the compile-time type only), so building
+/// the registry is a handful of small allocations done once per save/load
+/// session — never on a per-frame path.
+struct SaveComponentEntry {
+    std::string saveName_;
+    std::uint32_t saveVersion_ = 0;
+    IREntity::ComponentId componentId_ = IREntity::kNullComponent;
+
+    // Serialize the component at `row` of a live column.
+    std::function<void(IRAsset::BinaryWriter &, IREntity::IComponentData *, int)> writeRow_;
+    // Deserialize one instance and append it to a live column.
+    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &, IREntity::IComponentData *)>
+        appendRow_;
+
+    // Lazily get-or-create the singleton entity owning this component.
+    std::function<IREntity::EntityId()> getOrCreateSingletonEntity_;
+    // Serialize the component value held by a live entity (SNGL write).
+    std::function<void(IRAsset::BinaryWriter &, IREntity::EntityId)> writeSingleton_;
+    // Deserialize one instance and overwrite it onto a live entity (SNGL read).
+    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &, IREntity::EntityId)>
+        readIntoEntity_;
+};
+
+class SaveRegistry {
+  public:
+    /// Register component `C` if — and only if — it opts in. Opted-out
+    /// types (and unregistered-decision types) no-op without instantiating
+    /// `SaveSerialize<C>`. Re-registering the same save-name is ignored so
+    /// a caller can register defensively.
+    template <typename C> void registerComponent() {
+        if constexpr (shouldSave<C>()) {
+            const char *name = saveName<C>();
+            if (name == nullptr || m_byName.contains(name)) {
+                return;
+            }
+            SaveComponentEntry entry;
+            entry.saveName_ = name;
+            entry.saveVersion_ = saveVersion<C>();
+            entry.componentId_ = IREntity::getComponentType<C>();
+            entry.writeRow_ = [](IRAsset::BinaryWriter &w, IREntity::IComponentData *col, int row) {
+                SaveSerialize<C>::write(
+                    w,
+                    IREntity::castComponentDataPointer<C>(col)->dataVector[row]
+                );
+            };
+            entry.appendRow_ = [](IRAsset::BinaryReader &r,
+                                  IREntity::IComponentData *col) -> IRAsset::BinaryStatus {
+                IRAsset::Result<C> res = SaveSerialize<C>::read(r);
+                if (!res.ok()) {
+                    return res.status_;
+                }
+                IREntity::castComponentDataPointer<C>(col)->dataVector.push_back(
+                    std::move(res.value_)
+                );
+                return IRAsset::BinaryStatus::success();
+            };
+            entry.getOrCreateSingletonEntity_ = []() -> IREntity::EntityId {
+                return IREntity::singletonEntity<C>();
+            };
+            entry.writeSingleton_ = [](IRAsset::BinaryWriter &w, IREntity::EntityId entity) {
+                SaveSerialize<C>::write(w, IREntity::getComponent<C>(entity));
+            };
+            entry.readIntoEntity_ = [](IRAsset::BinaryReader &r,
+                                       IREntity::EntityId entity) -> IRAsset::BinaryStatus {
+                IRAsset::Result<C> res = SaveSerialize<C>::read(r);
+                if (!res.ok()) {
+                    return res.status_;
+                }
+                IREntity::setComponent<C>(entity, std::move(res.value_));
+                return IRAsset::BinaryStatus::success();
+            };
+
+            const std::size_t index = m_entries.size();
+            m_byName.emplace(entry.saveName_, index);
+            m_byComponentId.emplace(entry.componentId_, index);
+            m_entries.push_back(std::move(entry));
+        }
+    }
+
+    /// Registered entry for a session-local `ComponentId`, or nullptr if
+    /// the component is not opted in (used by the save-side walker, which
+    /// starts from an archetype's live ComponentIds).
+    const SaveComponentEntry *findByComponentId(IREntity::ComponentId id) const {
+        auto it = m_byComponentId.find(id);
+        return it == m_byComponentId.end() ? nullptr : &m_entries[it->second];
+    }
+
+    /// Registered entry for a stable save-name, or nullptr if unresolvable
+    /// (used by the load-side, which starts from the file's CMPN names — an
+    /// unresolvable name is a skipped column, not a fatal error).
+    const SaveComponentEntry *findByName(const std::string &saveName) const {
+        auto it = m_byName.find(saveName);
+        return it == m_byName.end() ? nullptr : &m_entries[it->second];
+    }
+
+    const std::vector<SaveComponentEntry> &entries() const {
+        return m_entries;
+    }
+
+    std::size_t size() const {
+        return m_entries.size();
+    }
+
+  private:
+    std::vector<SaveComponentEntry> m_entries;
+    std::unordered_map<std::string, std::size_t> m_byName;
+    std::unordered_map<IREntity::ComponentId, std::size_t> m_byComponentId;
+};
+
+} // namespace IRWorld
+
+#endif /* SAVE_REGISTRY_H */

--- a/engine/world/include/irreden/world/save_registry.hpp
+++ b/engine/world/include/irreden/world/save_registry.hpp
@@ -60,6 +60,13 @@ struct SaveComponentEntry {
     // Deserialize one instance and append it to a live column.
     std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &, IREntity::IComponentData *)>
         appendRow_;
+    // Decode one serialized instance and discard it, reporting only the
+    // status. The zero-mutation dry run the load's phase-2 gate runs over
+    // every column before phase 3 touches the live graph: it exercises the
+    // exact `SaveSerialize<C>::read` path `appendRow_` / `readIntoEntity_`
+    // take, so a length-valid-but-corrupt column fails validation rather than
+    // aborting mid-apply after entities are already spliced in.
+    std::function<IRAsset::BinaryStatus(IRAsset::BinaryReader &)> decodeRow_;
 
     // Lazily get-or-create the singleton entity owning this component.
     std::function<IREntity::EntityId()> getOrCreateSingletonEntity_;
@@ -102,6 +109,9 @@ class SaveRegistry {
                     std::move(res.value_)
                 );
                 return IRAsset::BinaryStatus::success();
+            };
+            entry.decodeRow_ = [](IRAsset::BinaryReader &r) -> IRAsset::BinaryStatus {
+                return SaveSerialize<C>::read(r).status_;
             };
             entry.getOrCreateSingletonEntity_ = []() -> IREntity::EntityId {
                 return IREntity::singletonEntity<C>();

--- a/engine/world/include/irreden/world/save_serialize.hpp
+++ b/engine/world/include/irreden/world/save_serialize.hpp
@@ -1,0 +1,61 @@
+#ifndef SAVE_SERIALIZE_H
+#define SAVE_SERIALIZE_H
+
+/// Per-component binary (de)serialization customization point for the ECS
+/// world snapshot (`world_snapshot.hpp`). P1 (`save_trait.hpp`) decides
+/// *whether* a component is saved and at what schema version; this header
+/// decides *how* one instance turns into bytes.
+///
+/// The primary template is a trivially-copyable fast path: any component
+/// that is `std::is_trivially_copyable` round-trips as a raw byte image,
+/// which covers the bulk of plain gameplay data (positions, velocities,
+/// timers, flags, small PODs). A component that owns heap storage
+/// (`std::string`, `std::vector`, resource handles) is NOT trivially
+/// copyable — a raw memcpy would persist dangling pointers — so it must
+/// provide an explicit `SaveSerialize<C>` specialization. The
+/// `static_assert` in the primary template turns "opted in but no
+/// serializer" into a compile error rather than a silent corrupt save.
+///
+/// Determinism note: the byte image of a trivially-copyable struct
+/// includes padding. Padding bytes are stable for a fixed in-memory value
+/// within a session, so a same-session double-save is byte-identical
+/// (world-snapshot criterion 6). Cross-session byte-stability of padding
+/// is a separate concern deferred to P4/W-8.
+
+#include <irreden/asset/binary_io.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+namespace IRWorld {
+
+/// Customization point: `write` serializes one `const C&`; `read` pulls
+/// one `C` back. Specialize for any component that is not trivially
+/// copyable. The default requires trivial-copyability and stores the raw
+/// byte image little-endian-agnostically (host layout — the snapshot is a
+/// same-machine round-trip contract; cross-endian is out of scope).
+template <typename C> struct SaveSerialize {
+    static_assert(
+        std::is_trivially_copyable_v<C>,
+        "SaveSerialize<C>: C is not trivially copyable — provide an explicit "
+        "SaveSerialize<C> specialization (e.g. for components owning std::string / "
+        "std::vector / resource handles). The primary template only handles PODs."
+    );
+
+    static void write(IRAsset::BinaryWriter &w, const C &value) {
+        w.writeBytes(&value, sizeof(C));
+    }
+
+    static IRAsset::Result<C> read(IRAsset::BinaryReader &r) {
+        C value{};
+        IRAsset::BinaryStatus status = r.readBytes(&value, sizeof(C));
+        if (!status.ok()) {
+            return IRAsset::Result<C>::error(status.code_, std::move(status.message_));
+        }
+        return IRAsset::Result<C>::success(value);
+    }
+};
+
+} // namespace IRWorld
+
+#endif /* SAVE_SERIALIZE_H */

--- a/engine/world/include/irreden/world/save_trait.hpp
+++ b/engine/world/include/irreden/world/save_trait.hpp
@@ -20,6 +20,10 @@ template <typename C> struct SaveTrait {
     static constexpr bool kExplicit = false;
     static constexpr bool kSave = false;
     static constexpr std::uint32_t kSaveVersion = 0;
+    // Stable on-disk identity (P2). The compile-time completeness gate
+    // makes the primary template unreachable for any real save decision,
+    // so `nullptr` here only ever surfaces if the macros are bypassed.
+    static constexpr const char *kSaveName = nullptr;
 };
 
 template <typename C> constexpr bool shouldSave() {
@@ -28,6 +32,15 @@ template <typename C> constexpr bool shouldSave() {
 
 template <typename C> constexpr std::uint32_t saveVersion() {
     return SaveTrait<C>::kSaveVersion;
+}
+
+// Stable, compiler-independent on-disk name for component C: the source
+// spelling captured by the IR_SAVE_OPT_IN/OPT_OUT macro at decision time.
+// The world snapshot's CMPN name table keys columns by this string (Save
+// Format Rule #2) so a file stays readable across sessions/compilers,
+// where `typeid(C).name()` and the numeric ComponentId are not.
+template <typename C> constexpr const char *saveName() {
+    return SaveTrait<C>::kSaveName;
 }
 
 namespace detail {
@@ -57,6 +70,7 @@ template <typename Tuple> constexpr bool allExplicit() {
         static constexpr bool kExplicit = true;                                                    \
         static constexpr bool kSave = true;                                                        \
         static constexpr std::uint32_t kSaveVersion = (Version);                                   \
+        static constexpr const char *kSaveName = #Type;                                            \
         static_assert(kSaveVersion >= 1, #Type " IR_SAVE_OPT_IN version must be >= 1");            \
     };                                                                                             \
     }
@@ -67,6 +81,7 @@ template <typename Tuple> constexpr bool allExplicit() {
         static constexpr bool kExplicit = true;                                                    \
         static constexpr bool kSave = false;                                                       \
         static constexpr std::uint32_t kSaveVersion = 0;                                           \
+        static constexpr const char *kSaveName = #Type;                                            \
     };                                                                                             \
     }
 

--- a/engine/world/include/irreden/world/world_snapshot.hpp
+++ b/engine/world/include/irreden/world/world_snapshot.hpp
@@ -56,6 +56,19 @@
 /// remapped) — they never recycle, so a component's embedded EntityId
 /// fields stay valid and P3 relation triples resolve.
 ///
+/// **Singleton save restriction (single-component only).** A singleton
+/// entity is persisted *only* by its singleton component type (the one keyed
+/// in `EntityManager::singletonEntityCache`): the walker excludes singleton
+/// entities from the `ARCH` walk wholesale, and `SNGL` writes just that one
+/// keyed component by value. So if a singleton entity ever carries an
+/// *additional* opted-in component beyond its singleton type, that extra
+/// component's data is silently dropped on save — it lands neither in `ARCH`
+/// (the entity is excluded) nor in `SNGL` (which serializes only the keyed
+/// type). Nothing in-tree does this today (see `engine/entity/CLAUDE.md`
+/// "Singleton components"); this documents it as an intentional restriction,
+/// not a latent bug. Keep singleton entities single-component, or promote the
+/// extra state onto a normal (non-singleton) gameplay entity.
+///
 /// ## Determinism, errors
 ///
 /// Same-world double-save is byte-identical (criterion W-8 subset): the

--- a/engine/world/include/irreden/world/world_snapshot.hpp
+++ b/engine/world/include/irreden/world/world_snapshot.hpp
@@ -1,0 +1,121 @@
+#ifndef WORLD_SNAPSHOT_H
+#define WORLD_SNAPSHOT_H
+
+/// ECS world snapshot — the `IRWS` container: save/load of the live entity
+/// world to a single binary file (persist P2, #2213, epic #667). This is
+/// the *entity-level* save path; it is distinct from
+/// `chunk_persistence.hpp`'s per-chunk `.vxs` voxel-pool save (which
+/// persists a streaming chunk's voxel slice, not entities/components).
+///
+/// ## File layout — `IRWS`
+///
+/// Standard `engine/asset/` container: 12-byte `AssetHeader`
+/// (`magic="IRWS"`, `version`, `chunkCount`) + a chunk table + chunk
+/// bodies (`chunk_header.hpp`). Unknown chunk tags are skipped on load
+/// (Rule #1), so later phases add chunks without a version bump. Four
+/// chunks, each built with the `binary_io.hpp` primitives:
+///
+///   - **`CMPN`** — component name table. `varuint count`, then `count`
+///     length-prefixed save-names ordered ascending. A component's index
+///     in this list is its *local index*, referenced compactly by `ARCH`
+///     and `SNGL`. Names (not the session-local ComponentId) are the
+///     on-disk identity — Rule #2.
+///   - **`ARCH`** — archetypes + entities + component columns. Per
+///     archetype: its projected component set (local indices), its entity
+///     IDs (ascending raw ids), then one column per component
+///     (`u32 saveVersion` + `varuint byteLength` + rows in entity order).
+///     The per-column `(version, byteLength)` header is the P5 migration
+///     seam: an unresolvable column is skipped by byte length, not fatal.
+///   - **`SNGL`** — singleton components, restored *by value* onto the
+///     live (post-reset preserved) singleton entity, not by re-inserting
+///     an archetype row. Per entry: local index + saved raw entity id +
+///     `u32 saveVersion` + `varuint byteLength` + value blob.
+///   - **`META`** — `varuint nextEntityId` watermark + `varuint`
+///     total saved entity count.
+///
+/// A `.json` sidecar (Rule #6, write-only) is emitted beside the binary
+/// for human inspection; it is never read back.
+///
+/// ## Save projection + exclusion
+///
+/// Only components with a `SaveRegistry` entry (opted in via
+/// `SaveTrait<C>` *and* registered) are written; an entity's saved
+/// archetype is the **projection** of its live archetype onto those
+/// components (opted-out and unregistered components drop out). Two live
+/// archetypes that differ only by a dropped component merge into one saved
+/// archetype. The walker excludes exactly what `resetGameplay`
+/// (`destroyAllExceptPreserved`) preserves — singleton entities (they ride
+/// `SNGL`), `C_Persistent`-tagged entities (recreated by their owner on
+/// load), and component-backing entities — so the documented load contract
+///
+///     IREntity::resetGameplay();   // frame boundary
+///     IRWorld::loadWorld(reg, path);
+///
+/// is collision-free by construction: everything the save wrote is exactly
+/// what the reset destroyed. Entity IDs are restored **exact** (never
+/// remapped) — they never recycle, so a component's embedded EntityId
+/// fields stay valid and P3 relation triples resolve.
+///
+/// ## Determinism, errors
+///
+/// Same-world double-save is byte-identical (criterion W-8 subset): the
+/// name table, archetype blocks, entities, and singletons are all sorted
+/// on stable keys. Every read returns `IRAsset::BinaryStatus` — bad magic,
+/// truncation, version-too-new, and a live-id collision all abort with a
+/// recoverable status and **zero** world mutation (Rule #5); unknown chunk
+/// tags and unknown component names are skipped with counts, not errors.
+///
+/// The `(SaveRegistry&, path)` signature is the honest P2 surface — a
+/// registry decides what participates. A `(path)`-only convenience wrapper
+/// over a process-default registry (for the P7 Lua binding) layers on once
+/// engine components carry serializers.
+
+#include <irreden/world/save_registry.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/entity/ir_entity_types.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace IRWorld {
+
+inline constexpr std::array<char, 4> kWorldSnapshotMagic{'I', 'R', 'W', 'S'};
+inline constexpr std::uint32_t kWorldSnapshotVersion = 1;
+
+/// Outcome of `loadWorld`. `status_.ok()` gates everything else; on a
+/// non-ok status the world is unmodified (Rule #5) and the counts are 0.
+struct LoadResult {
+    IRAsset::BinaryStatus status_;
+    std::uint64_t entitiesRestored_ = 0;
+    std::uint64_t singletonsRestored_ = 0;
+    // Columns / singletons whose save-name did not resolve in the registry
+    // (skipped by byte length, not an error — the file may predate a
+    // component's registration, or postdate its removal).
+    std::uint64_t columnsSkipped_ = 0;
+    std::uint64_t singletonsSkipped_ = 0;
+    // saved raw EntityId -> live EntityId for every restored singleton.
+    // Identity in the same-session contract; the hand-off P3 needs to
+    // translate relation triples that reference a singleton entity.
+    std::unordered_map<IREntity::EntityId, IREntity::EntityId> singletonAliases_;
+
+    bool ok() const {
+        return status_.ok();
+    }
+};
+
+/// Serialize the live entity world to `path` (+ `path + ".json"` sidecar).
+/// Flushes deferred structural changes first (frame-boundary contract).
+/// Returns the writer's failure status; `ok()` means the file is complete.
+IRAsset::BinaryStatus saveWorld(const SaveRegistry &registry, const std::string &path);
+
+/// Load an `IRWS` file into the live world. Two-phase: parse + validate
+/// everything (any collision or corruption aborts with zero mutation),
+/// then apply. Call after `IREntity::resetGameplay()` at a frame boundary.
+LoadResult loadWorld(const SaveRegistry &registry, const std::string &path);
+
+} // namespace IRWorld
+
+#endif /* WORLD_SNAPSHOT_H */

--- a/engine/world/src/world_snapshot.cpp
+++ b/engine/world/src/world_snapshot.cpp
@@ -1,0 +1,595 @@
+#include <irreden/world/world_snapshot.hpp>
+
+#include <irreden/ir_profile.hpp>
+
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/asset/json_sidecar.hpp>
+
+#include <irreden/entity/archetype_node.hpp>
+#include <irreden/entity/entity_manager.hpp>
+#include <irreden/entity/i_component_data.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <irreden/common/components/component_persistent.hpp>
+
+#include <algorithm>
+#include <map>
+#include <span>
+#include <typeinfo>
+#include <unordered_set>
+#include <vector>
+
+namespace IRWorld {
+
+using IREntity::ArchetypeNode;
+using IREntity::ComponentId;
+using IREntity::EntityId;
+
+namespace {
+
+const std::array<char, 4> kTagCmpn = IRAsset::makeTag("CMPN");
+const std::array<char, 4> kTagArch = IRAsset::makeTag("ARCH");
+const std::array<char, 4> kTagSngl = IRAsset::makeTag("SNGL");
+const std::array<char, 4> kTagMeta = IRAsset::makeTag("META");
+
+// One live (entity, column-source) reference gathered by the walker. A
+// merged saved archetype pulls its rows from several live nodes, so each
+// entity remembers which node/row its columns come from.
+struct SavedEntityRef {
+    EntityId maskedId_;
+    ArchetypeNode *node_;
+    int row_;
+};
+
+// A saved archetype block: one projection (set of opted-in ComponentIds)
+// and every gameplay entity that projects onto it, across all merged nodes.
+struct SavedArchetype {
+    IREntity::Archetype projection_;
+    std::vector<SavedEntityRef> entities_;
+};
+
+// A live singleton to persist by value in the SNGL chunk.
+struct SavedSingleton {
+    const SaveComponentEntry *entry_;
+    EntityId savedId_;
+};
+
+} // namespace
+
+IRAsset::BinaryStatus saveWorld(const SaveRegistry &registry, const std::string &path) {
+    IREntity::EntityManager &em = IREntity::getEntityManager();
+
+    // Frame-boundary contract: drain deferred structural changes + marked
+    // deletions so the archetype graph reflects exactly the live world.
+    em.flushStructuralChanges();
+    em.destroyMarkedEntities();
+
+    // --- Exclusion set (mirror resetGameplay's destroyAllExceptPreserved) ---
+    std::unordered_set<EntityId> singletonIds;
+    for (const auto &[componentId, singletonEntity] : em.singletonEntityCache()) {
+        if (em.entityExists(singletonEntity)) {
+            singletonIds.insert(singletonEntity & IREntity::IR_ENTITY_ID_BITS);
+        }
+    }
+    // C_Persistent id via the by-name lookup so an unregistered C_Persistent
+    // (no persistent entity exists yet) does NOT auto-register + mint a
+    // backing entity mid-save. kNullComponent never appears in a node type_.
+    const ComponentId cPersistentId =
+        em.getComponentTypeByName(typeid(IRComponents::C_Persistent).name());
+
+    // --- Walk archetype nodes, group by projection (projection-merge) ---
+    std::map<IREntity::Archetype, std::size_t> groupIndexByProjection;
+    std::vector<SavedArchetype> groups;
+    std::unordered_set<ComponentId> referenced;
+
+    for (const auto &nodePtr : em.getArchetypeNodes()) {
+        ArchetypeNode *node = nodePtr.get();
+        if (node->length_ <= 0) {
+            continue;
+        }
+        // Whole-node exclusion: C_Persistent entities are recreated by their
+        // owner on load, so persisting them would collide on restore.
+        if (cPersistentId != IREntity::kNullComponent && node->type_.contains(cPersistentId)) {
+            continue;
+        }
+        // Projection = opted-in + registered subset of this node's archetype.
+        IREntity::Archetype projection;
+        for (const ComponentId componentId : node->type_) {
+            if (registry.findByComponentId(componentId) != nullptr) {
+                projection.insert(componentId);
+            }
+        }
+        if (projection.empty()) {
+            continue;
+        }
+
+        auto [it, inserted] = groupIndexByProjection.try_emplace(projection, groups.size());
+        if (inserted) {
+            groups.push_back(SavedArchetype{projection, {}});
+            for (const ComponentId componentId : projection) {
+                referenced.insert(componentId);
+            }
+        }
+        SavedArchetype &group = groups[it->second];
+
+        for (int i = 0; i < node->length_; ++i) {
+            const EntityId rawId = node->entities_[i];
+            const EntityId maskedId = rawId & IREntity::IR_ENTITY_ID_BITS;
+            // Per-entity exclusions: singletons (SNGL chunk), component-
+            // backing entities, relation-flagged entities.
+            if (singletonIds.contains(maskedId) || em.isComponentBackingEntity(rawId) ||
+                (rawId & IREntity::kEntityFlagIsRelation)) {
+                continue;
+            }
+            group.entities_.push_back(SavedEntityRef{maskedId, node, i});
+        }
+    }
+
+    // Drop groups left empty after per-entity exclusion, and sort each
+    // group's entities ascending by id (locked write order).
+    groups.erase(
+        std::remove_if(
+            groups.begin(),
+            groups.end(),
+            [](const SavedArchetype &g) { return g.entities_.empty(); }
+        ),
+        groups.end()
+    );
+    for (SavedArchetype &group : groups) {
+        std::sort(
+            group.entities_.begin(),
+            group.entities_.end(),
+            [](const SavedEntityRef &a, const SavedEntityRef &b) {
+                return a.maskedId_ < b.maskedId_;
+            }
+        );
+    }
+
+    // --- Collect singletons (by value) ---
+    std::vector<SavedSingleton> singletons;
+    for (const auto &[componentId, singletonEntity] : em.singletonEntityCache()) {
+        const SaveComponentEntry *entry = registry.findByComponentId(componentId);
+        if (entry == nullptr || !em.entityExists(singletonEntity)) {
+            continue;
+        }
+        singletons.push_back(SavedSingleton{entry, singletonEntity & IREntity::IR_ENTITY_ID_BITS});
+        referenced.insert(componentId);
+    }
+
+    // --- Assign local indices: order referenced components by save-name ---
+    std::vector<const SaveComponentEntry *> orderedEntries;
+    orderedEntries.reserve(referenced.size());
+    for (const ComponentId componentId : referenced) {
+        orderedEntries.push_back(registry.findByComponentId(componentId));
+    }
+    std::sort(
+        orderedEntries.begin(),
+        orderedEntries.end(),
+        [](const SaveComponentEntry *a, const SaveComponentEntry *b) {
+            return a->saveName_ < b->saveName_;
+        }
+    );
+    std::unordered_map<ComponentId, std::uint32_t> localIndexByComponentId;
+    for (std::uint32_t i = 0; i < orderedEntries.size(); ++i) {
+        localIndexByComponentId[orderedEntries[i]->componentId_] = i;
+    }
+
+    // Deterministic archetype order: by ascending local-index list.
+    auto localIndexList = [&](const SavedArchetype &g) {
+        std::vector<std::uint32_t> out;
+        out.reserve(g.projection_.size());
+        for (const ComponentId componentId : g.projection_) {
+            out.push_back(localIndexByComponentId.at(componentId));
+        }
+        std::sort(out.begin(), out.end());
+        return out;
+    };
+    std::sort(groups.begin(), groups.end(), [&](const SavedArchetype &a, const SavedArchetype &b) {
+        return localIndexList(a) < localIndexList(b);
+    });
+    // Deterministic singleton order: by save-name.
+    std::sort(
+        singletons.begin(),
+        singletons.end(),
+        [](const SavedSingleton &a, const SavedSingleton &b) {
+            return a.entry_->saveName_ < b.entry_->saveName_;
+        }
+    );
+
+    // --- Build chunk bodies ---
+    std::uint64_t totalEntities = 0;
+
+    // CMPN
+    IRAsset::MemoryBinaryWriter cmpnW;
+    cmpnW.writeVarUInt(orderedEntries.size());
+    for (const SaveComponentEntry *entry : orderedEntries) {
+        cmpnW.writeString(entry->saveName_);
+    }
+
+    // ARCH
+    IRAsset::MemoryBinaryWriter archW;
+    archW.writeVarUInt(groups.size());
+    for (const SavedArchetype &group : groups) {
+        std::vector<std::uint32_t> indices = localIndexList(group);
+        archW.writeVarUInt(indices.size());
+        for (const std::uint32_t li : indices) {
+            archW.writeVarUInt(li);
+        }
+        archW.writeVarUInt(group.entities_.size());
+        for (const SavedEntityRef &ref : group.entities_) {
+            archW.writeVarUInt(ref.maskedId_);
+        }
+        totalEntities += group.entities_.size();
+        // One column per component, in the same (ascending local-index)
+        // order as the component list above.
+        for (const std::uint32_t li : indices) {
+            const SaveComponentEntry *entry = orderedEntries[li];
+            archW.writeU32(entry->saveVersion_);
+            IRAsset::MemoryBinaryWriter colW;
+            for (const SavedEntityRef &ref : group.entities_) {
+                IREntity::IComponentData *col =
+                    ref.node_->components_.at(entry->componentId_).get();
+                entry->writeRow_(colW, col, ref.row_);
+            }
+            const std::vector<std::uint8_t> colBytes = colW.takeBuffer();
+            archW.writeVarUInt(colBytes.size());
+            archW.writeBytes(colBytes.data(), colBytes.size());
+        }
+    }
+
+    // SNGL
+    IRAsset::MemoryBinaryWriter snglW;
+    snglW.writeVarUInt(singletons.size());
+    for (const SavedSingleton &singleton : singletons) {
+        const std::uint32_t li = localIndexByComponentId.at(singleton.entry_->componentId_);
+        snglW.writeVarUInt(li);
+        snglW.writeVarUInt(singleton.savedId_);
+        snglW.writeU32(singleton.entry_->saveVersion_);
+        const EntityId liveEntity = singleton.entry_->getOrCreateSingletonEntity_();
+        IRAsset::MemoryBinaryWriter valW;
+        singleton.entry_->writeSingleton_(valW, liveEntity);
+        const std::vector<std::uint8_t> valBytes = valW.takeBuffer();
+        snglW.writeVarUInt(valBytes.size());
+        snglW.writeBytes(valBytes.data(), valBytes.size());
+    }
+
+    // META
+    IRAsset::MemoryBinaryWriter metaW;
+    metaW.writeVarUInt(em.entityIdWatermark());
+    metaW.writeVarUInt(totalEntities);
+
+    std::vector<IRAsset::ChunkPayload> chunks;
+    chunks.push_back({kTagCmpn, cmpnW.takeBuffer()});
+    chunks.push_back({kTagArch, archW.takeBuffer()});
+    chunks.push_back({kTagSngl, snglW.takeBuffer()});
+    chunks.push_back({kTagMeta, metaW.takeBuffer()});
+
+    IRAsset::FileBinaryWriter fileW(path);
+    if (!fileW.ok()) {
+        return IRAsset::BinaryStatus::error(
+            IRAsset::BinaryIOError::OpenFailed,
+            "world snapshot: could not open " + path
+        );
+    }
+    IRAsset::BinaryStatus status =
+        IRAsset::writeChunked(fileW, kWorldSnapshotMagic, kWorldSnapshotVersion, chunks);
+    if (!status.ok()) {
+        return status;
+    }
+
+    // JSON sidecar (Rule #6, write-only). Best-effort — failure to write it
+    // never fails the save (the binary is the source of truth).
+    IRAsset::JsonSidecarWriter json;
+    json.beginObject();
+    json.key("magic");
+    json.valueString("IRWS");
+    json.key("version");
+    json.valueUInt(kWorldSnapshotVersion);
+    json.key("entities");
+    json.valueUInt(totalEntities);
+    json.key("archetypes");
+    json.valueUInt(groups.size());
+    json.key("singletons");
+    json.valueUInt(singletons.size());
+    json.key("components");
+    json.beginArray();
+    for (const SaveComponentEntry *entry : orderedEntries) {
+        json.valueString(entry->saveName_);
+    }
+    json.endArray();
+    json.endObject();
+    IRAsset::writeJsonSidecarToFile(path + ".json", json.str());
+
+    return IRAsset::BinaryStatus::success();
+}
+
+namespace {
+
+// Staged, world-mutation-free parse of one ARCH/SNGL column: where its
+// bytes live inside the chunk buffer, so phase 3 can re-read after the
+// phase-2 collision check clears.
+struct StagedColumn {
+    std::uint32_t version_ = 0;
+    std::uint64_t byteLength_ = 0;
+    std::uint64_t dataOffset_ = 0; // offset within the chunk buffer
+};
+struct StagedArchetype {
+    std::vector<std::uint32_t> localIndices_;
+    std::vector<EntityId> entityIds_;
+    std::vector<StagedColumn> columns_;
+};
+struct StagedSingleton {
+    std::uint32_t localIndex_ = 0;
+    EntityId savedId_ = 0;
+    StagedColumn column_;
+};
+
+// A failed load: the status, everything else zeroed (Rule #5 — no partial
+// counts on a non-ok result).
+LoadResult loadFail(IRAsset::BinaryStatus status) {
+    LoadResult result;
+    result.status_ = std::move(status);
+    return result;
+}
+LoadResult loadError(IRAsset::BinaryIOError code, std::string message) {
+    return loadFail(IRAsset::BinaryStatus::error(code, std::move(message)));
+}
+
+} // namespace
+
+LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
+    IREntity::EntityManager &em = IREntity::getEntityManager();
+
+    IRAsset::FileBinaryReader fileR(path);
+    if (!fileR.ok()) {
+        return loadError(
+            IRAsset::BinaryIOError::OpenFailed,
+            "world snapshot: could not open " + path
+        );
+    }
+
+    IRAsset::Result<std::vector<IRAsset::LoadedChunk>> chunksRes =
+        IRAsset::readChunks(fileR, kWorldSnapshotMagic, kWorldSnapshotVersion);
+    if (!chunksRes.ok()) {
+        return loadFail(chunksRes.status_);
+    }
+    const std::vector<IRAsset::LoadedChunk> &chunks = chunksRes.value_;
+    const IRAsset::LoadedChunk *cmpn = IRAsset::findChunk(chunks, kTagCmpn);
+    const IRAsset::LoadedChunk *arch = IRAsset::findChunk(chunks, kTagArch);
+    const IRAsset::LoadedChunk *sngl = IRAsset::findChunk(chunks, kTagSngl);
+    const IRAsset::LoadedChunk *meta = IRAsset::findChunk(chunks, kTagMeta);
+
+    // --- Phase 1: parse (zero world mutation) ---
+    // CMPN name table -> resolved registry entries (nullptr = unresolvable).
+    std::vector<const SaveComponentEntry *> localEntries;
+    if (cmpn != nullptr) {
+        IRAsset::MemoryBinaryReader r(cmpn->data_.data(), cmpn->data_.size(), "CMPN");
+        IRAsset::Result<std::uint64_t> count = r.readVarUInt();
+        if (!count.ok()) {
+            return loadFail(count.status_);
+        }
+        localEntries.reserve(count.value_);
+        for (std::uint64_t i = 0; i < count.value_; ++i) {
+            IRAsset::Result<std::string> name = r.readString();
+            if (!name.ok()) {
+                return loadFail(name.status_);
+            }
+            localEntries.push_back(registry.findByName(name.value_));
+        }
+    }
+    const std::uint64_t localCount = localEntries.size();
+
+    std::vector<StagedArchetype> stagedArchetypes;
+    if (arch != nullptr) {
+        IRAsset::MemoryBinaryReader r(arch->data_.data(), arch->data_.size(), "ARCH");
+        IRAsset::Result<std::uint64_t> archCount = r.readVarUInt();
+        if (!archCount.ok()) {
+            return loadFail(archCount.status_);
+        }
+        stagedArchetypes.reserve(archCount.value_);
+        for (std::uint64_t a = 0; a < archCount.value_; ++a) {
+            StagedArchetype staged;
+            IRAsset::Result<std::uint64_t> compCount = r.readVarUInt();
+            if (!compCount.ok()) {
+                return loadFail(compCount.status_);
+            }
+            staged.localIndices_.reserve(compCount.value_);
+            for (std::uint64_t c = 0; c < compCount.value_; ++c) {
+                IRAsset::Result<std::uint64_t> li = r.readVarUInt();
+                if (!li.ok()) {
+                    return loadFail(li.status_);
+                }
+                if (li.value_ >= localCount) {
+                    return loadError(
+                        IRAsset::BinaryIOError::Truncated,
+                        "world snapshot: ARCH local index out of range"
+                    );
+                }
+                staged.localIndices_.push_back(static_cast<std::uint32_t>(li.value_));
+            }
+            IRAsset::Result<std::uint64_t> entCount = r.readVarUInt();
+            if (!entCount.ok()) {
+                return loadFail(entCount.status_);
+            }
+            staged.entityIds_.reserve(entCount.value_);
+            for (std::uint64_t e = 0; e < entCount.value_; ++e) {
+                IRAsset::Result<std::uint64_t> id = r.readVarUInt();
+                if (!id.ok()) {
+                    return loadFail(id.status_);
+                }
+                staged.entityIds_.push_back(static_cast<EntityId>(id.value_));
+            }
+            staged.columns_.reserve(compCount.value_);
+            for (std::uint64_t c = 0; c < compCount.value_; ++c) {
+                StagedColumn column;
+                IRAsset::Result<std::uint32_t> version = r.readU32();
+                if (!version.ok()) {
+                    return loadFail(version.status_);
+                }
+                IRAsset::Result<std::uint64_t> byteLength = r.readVarUInt();
+                if (!byteLength.ok()) {
+                    return loadFail(byteLength.status_);
+                }
+                column.version_ = version.value_;
+                column.byteLength_ = byteLength.value_;
+                column.dataOffset_ = r.tell();
+                IRAsset::BinaryStatus skip = r.seek(column.dataOffset_ + column.byteLength_);
+                if (!skip.ok()) {
+                    return loadFail(skip);
+                }
+                staged.columns_.push_back(column);
+            }
+            stagedArchetypes.push_back(std::move(staged));
+        }
+    }
+
+    std::vector<StagedSingleton> stagedSingletons;
+    if (sngl != nullptr) {
+        IRAsset::MemoryBinaryReader r(sngl->data_.data(), sngl->data_.size(), "SNGL");
+        IRAsset::Result<std::uint64_t> count = r.readVarUInt();
+        if (!count.ok()) {
+            return loadFail(count.status_);
+        }
+        stagedSingletons.reserve(count.value_);
+        for (std::uint64_t s = 0; s < count.value_; ++s) {
+            StagedSingleton staged;
+            IRAsset::Result<std::uint64_t> li = r.readVarUInt();
+            if (!li.ok()) {
+                return loadFail(li.status_);
+            }
+            if (li.value_ >= localCount) {
+                return loadError(
+                    IRAsset::BinaryIOError::Truncated,
+                    "world snapshot: SNGL local index out of range"
+                );
+            }
+            staged.localIndex_ = static_cast<std::uint32_t>(li.value_);
+            IRAsset::Result<std::uint64_t> savedId = r.readVarUInt();
+            if (!savedId.ok()) {
+                return loadFail(savedId.status_);
+            }
+            staged.savedId_ = static_cast<EntityId>(savedId.value_);
+            IRAsset::Result<std::uint32_t> version = r.readU32();
+            if (!version.ok()) {
+                return loadFail(version.status_);
+            }
+            IRAsset::Result<std::uint64_t> byteLength = r.readVarUInt();
+            if (!byteLength.ok()) {
+                return loadFail(byteLength.status_);
+            }
+            staged.column_.version_ = version.value_;
+            staged.column_.byteLength_ = byteLength.value_;
+            staged.column_.dataOffset_ = r.tell();
+            IRAsset::BinaryStatus skip =
+                r.seek(staged.column_.dataOffset_ + staged.column_.byteLength_);
+            if (!skip.ok()) {
+                return loadFail(skip);
+            }
+            stagedSingletons.push_back(staged);
+        }
+    }
+
+    EntityId watermark = 0;
+    if (meta != nullptr) {
+        IRAsset::MemoryBinaryReader r(meta->data_.data(), meta->data_.size(), "META");
+        IRAsset::Result<std::uint64_t> w = r.readVarUInt();
+        if (!w.ok()) {
+            return loadFail(w.status_);
+        }
+        watermark = static_cast<EntityId>(w.value_);
+        // total-entity count is informational; skip if truncated.
+    }
+
+    // --- Phase 2: validate (still zero mutation) ---
+    // Every restored gameplay id must be free in the live world, and unique
+    // within the file. Singleton ids are NOT inserted (restored by value),
+    // so they are not collision-checked.
+    std::unordered_set<EntityId> seen;
+    for (const StagedArchetype &staged : stagedArchetypes) {
+        for (const EntityId id : staged.entityIds_) {
+            const EntityId masked = id & IREntity::IR_ENTITY_ID_BITS;
+            if (em.entityExists(masked)) {
+                return loadError(
+                    IRAsset::BinaryIOError::Truncated,
+                    "world snapshot: restored entity id collides with a live entity — "
+                    "call resetGameplay()/destroyAllEntities() before loadWorld()"
+                );
+            }
+            if (!seen.insert(masked).second) {
+                return loadError(
+                    IRAsset::BinaryIOError::Truncated,
+                    "world snapshot: duplicate entity id in file"
+                );
+            }
+        }
+    }
+
+    // --- Phase 3: apply ---
+    LoadResult result;
+    result.status_ = IRAsset::BinaryStatus::success();
+
+    for (const StagedArchetype &staged : stagedArchetypes) {
+        // Resolved archetype = live ComponentIds of the non-skipped columns.
+        IREntity::Archetype resolvedSet;
+        for (const std::uint32_t li : staged.localIndices_) {
+            const SaveComponentEntry *entry = localEntries[li];
+            if (entry != nullptr) {
+                resolvedSet.insert(entry->componentId_);
+            }
+        }
+        ArchetypeNode *node = em.findCreateArchetypeNode(resolvedSet);
+        em.restoreEntitiesBatch(node, staged.entityIds_);
+
+        for (std::size_t c = 0; c < staged.localIndices_.size(); ++c) {
+            const std::uint32_t li = staged.localIndices_[c];
+            const StagedColumn &column = staged.columns_[c];
+            const SaveComponentEntry *entry = localEntries[li];
+            if (entry == nullptr) {
+                ++result.columnsSkipped_; // unresolvable component — skipped by byte length
+                continue;
+            }
+            IRAsset::MemoryBinaryReader r(arch->data_.data(), arch->data_.size(), "ARCH");
+            IRAsset::BinaryStatus seek = r.seek(column.dataOffset_);
+            if (!seek.ok()) {
+                return loadFail(seek);
+            }
+            IREntity::IComponentData *col = node->components_.at(entry->componentId_).get();
+            for (std::size_t e = 0; e < staged.entityIds_.size(); ++e) {
+                IRAsset::BinaryStatus rowStatus = entry->appendRow_(r, col);
+                if (!rowStatus.ok()) {
+                    return loadFail(rowStatus);
+                }
+            }
+            IR_ASSERT(
+                static_cast<int>(col->size()) == node->length_,
+                "world snapshot restore: column out of sync with archetype row count"
+            );
+        }
+        result.entitiesRestored_ += staged.entityIds_.size();
+    }
+
+    for (const StagedSingleton &staged : stagedSingletons) {
+        const SaveComponentEntry *entry = localEntries[staged.localIndex_];
+        if (entry == nullptr) {
+            ++result.singletonsSkipped_;
+            continue;
+        }
+        const EntityId liveEntity = entry->getOrCreateSingletonEntity_();
+        IRAsset::MemoryBinaryReader r(sngl->data_.data(), sngl->data_.size(), "SNGL");
+        IRAsset::BinaryStatus seek = r.seek(staged.column_.dataOffset_);
+        if (!seek.ok()) {
+            return loadFail(seek);
+        }
+        IRAsset::BinaryStatus valueStatus = entry->readIntoEntity_(r, liveEntity);
+        if (!valueStatus.ok()) {
+            return loadFail(valueStatus);
+        }
+        result.singletonAliases_.emplace(staged.savedId_, liveEntity);
+        ++result.singletonsRestored_;
+    }
+
+    em.advanceEntityIdWatermark(watermark);
+    return result;
+}
+
+} // namespace IRWorld

--- a/engine/world/src/world_snapshot.cpp
+++ b/engine/world/src/world_snapshot.cpp
@@ -417,6 +417,16 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
                 if (!id.ok()) {
                     return loadFail(id.status_);
                 }
+                // Saved ids are written masked (`& IR_ENTITY_ID_BITS`). A value
+                // above that mask is corruption — reject it here rather than
+                // let the phase-2 `& IR_ENTITY_ID_BITS` silently alias it onto
+                // a low, possibly-live id.
+                if (id.value_ > IREntity::IR_ENTITY_ID_BITS) {
+                    return loadError(
+                        IRAsset::BinaryIOError::Truncated,
+                        "world snapshot: ARCH entity id out of range"
+                    );
+                }
                 staged.entityIds_.push_back(static_cast<EntityId>(id.value_));
             }
             staged.columns_.reserve(compCount.value_);
@@ -467,6 +477,12 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
             IRAsset::Result<std::uint64_t> savedId = r.readVarUInt();
             if (!savedId.ok()) {
                 return loadFail(savedId.status_);
+            }
+            if (savedId.value_ > IREntity::IR_ENTITY_ID_BITS) {
+                return loadError(
+                    IRAsset::BinaryIOError::Truncated,
+                    "world snapshot: SNGL entity id out of range"
+                );
             }
             staged.savedId_ = static_cast<EntityId>(savedId.value_);
             IRAsset::Result<std::uint32_t> version = r.readU32();
@@ -523,6 +539,67 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
             }
         }
     }
+
+    // --- Phase 2b: decode-validate every resolved column (still zero
+    // mutation) --- Phase 1 only recorded each column's byte span; a
+    // length-valid-but-corrupt column (disk corruption, a half-written file,
+    // hand-edited bytes) would otherwise not surface until phase 3's
+    // `appendRow_`, by which point `restoreEntitiesBatch` has already spliced
+    // this archetype's entities — and every earlier one — into the live
+    // graph, leaving a column short of `length_` with no way to unwind. That
+    // is the partial mutation the header's "zero world mutation on error"
+    // contract (Rule #5) forbids. Dry-run the exact `SaveSerialize<C>::read`
+    // decode here, discarding the values, so any failure aborts before the
+    // first live write. Unresolvable columns (`entry == nullptr`) are skipped
+    // by byte length in phase 3, so they are skipped here too.
+    for (const StagedArchetype &staged : stagedArchetypes) {
+        for (std::size_t c = 0; c < staged.localIndices_.size(); ++c) {
+            const SaveComponentEntry *entry = localEntries[staged.localIndices_[c]];
+            if (entry == nullptr) {
+                continue;
+            }
+            const StagedColumn &column = staged.columns_[c];
+            IRAsset::MemoryBinaryReader r(arch->data_.data(), arch->data_.size(), "ARCH");
+            IRAsset::BinaryStatus seek = r.seek(column.dataOffset_);
+            if (!seek.ok()) {
+                return loadFail(seek);
+            }
+            for (std::size_t e = 0; e < staged.entityIds_.size(); ++e) {
+                IRAsset::BinaryStatus rowStatus = entry->decodeRow_(r);
+                if (!rowStatus.ok()) {
+                    return loadFail(rowStatus);
+                }
+            }
+        }
+    }
+    for (const StagedSingleton &staged : stagedSingletons) {
+        const SaveComponentEntry *entry = localEntries[staged.localIndex_];
+        if (entry == nullptr) {
+            continue;
+        }
+        IRAsset::MemoryBinaryReader r(sngl->data_.data(), sngl->data_.size(), "SNGL");
+        IRAsset::BinaryStatus seek = r.seek(staged.column_.dataOffset_);
+        if (!seek.ok()) {
+            return loadFail(seek);
+        }
+        IRAsset::BinaryStatus valueStatus = entry->decodeRow_(r);
+        if (!valueStatus.ok()) {
+            return loadFail(valueStatus);
+        }
+    }
+
+    // Every id- and decode-validation has passed, so phase 3 is now
+    // guaranteed to complete — advance the allocator watermark HERE, before
+    // any mutation. It must precede the singleton loop: a fresh-session
+    // singleton lazy-create (`getOrCreateSingletonEntity_` -> `createEntity`)
+    // draws its id off `m_nextEntityId`, and if the watermark still sat at its
+    // stale pre-load value that draw would collide with a just-restored
+    // gameplay id (`allocateEntity`'s `m_entityIndex.emplace` silently no-ops
+    // on a dup, and the singleton value then cross-wires onto that gameplay
+    // entity's record — no error, no assert). The archetype loop plants
+    // explicit ids via `restoreEntitiesBatch` and never allocates, so
+    // advancing ahead of it is safe too.
+    em.advanceEntityIdWatermark(watermark);
 
     // --- Phase 3: apply ---
     LoadResult result;
@@ -588,7 +665,9 @@ LoadResult loadWorld(const SaveRegistry &registry, const std::string &path) {
         ++result.singletonsRestored_;
     }
 
-    em.advanceEntityIdWatermark(watermark);
+    // Watermark was advanced after phase-2 validation, before any phase-3
+    // mutation — advancing it here (after the singleton loop) would let a
+    // fresh-session singleton lazy-create draw a just-restored id. See #2213.
     return result;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable(IrredenEngineTest
   world/chunk_persistence_test.cpp
   world/chunk_residency_manager_test.cpp
   world/save_trait_test.cpp
+  world/world_snapshot_test.cpp
 )
 
 FetchContent_Declare(

--- a/test/world/world_snapshot_test.cpp
+++ b/test/world/world_snapshot_test.cpp
@@ -1,0 +1,374 @@
+#include <gtest/gtest.h>
+
+#include <irreden/world/save_registry.hpp>
+#include <irreden/world/save_trait.hpp>
+#include <irreden/world/world_snapshot.hpp>
+
+#include <irreden/asset/binary_io.hpp>
+#include <irreden/asset/chunk_header.hpp>
+#include <irreden/ir_entity.hpp>
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+// Stand-in "components" for the snapshot round-trip. All trivially
+// copyable, so the default SaveSerialize<C> (raw byte image) drives the
+// round-trip — this task ships the *mechanism*; real engine components get
+// their own SaveSerialize specializations downstream. C_WsTransient is the
+// opted-out projection-merge witness. Defined at namespace scope so the
+// IR_SAVE_* macros (which specialize IRWorld::SaveTrait) can name them.
+namespace WsSnap {
+struct C_WsPos {
+    std::int32_t x_ = 0;
+    std::int32_t y_ = 0;
+    std::int32_t z_ = 0;
+};
+struct C_WsVel {
+    float vx_ = 0.0f;
+    float vy_ = 0.0f;
+};
+struct C_WsTag {
+    std::int32_t marker_ = 0;
+};
+struct C_WsTransient {
+    std::int32_t scratch_ = 0;
+};
+struct C_WsSingletonState {
+    std::int32_t counter_ = 0;
+    float weight_ = 0.0f;
+};
+} // namespace WsSnap
+
+IR_SAVE_OPT_IN(WsSnap::C_WsPos, 1)
+IR_SAVE_OPT_IN(WsSnap::C_WsVel, 1)
+IR_SAVE_OPT_IN(WsSnap::C_WsTag, 1)
+IR_SAVE_OPT_OUT(WsSnap::C_WsTransient)
+IR_SAVE_OPT_IN(WsSnap::C_WsSingletonState, 2)
+
+namespace {
+
+using namespace WsSnap;
+using IREntity::EntityId;
+
+// A record of one created entity so the round-trip can assert exact
+// restoration (id, values, resolved archetype membership).
+struct Expected {
+    EntityId id_;
+    C_WsPos pos_;
+    bool hasVel_ = false;
+    C_WsVel vel_{};
+    bool hasTag_ = false;
+    C_WsTag tag_{};
+};
+
+class WorldSnapshotTest : public testing::Test {
+  protected:
+    WorldSnapshotTest() = default;
+
+    // Full registry: every opted-in test component. registerComponent is a
+    // no-op for the opted-out C_WsTransient.
+    IRWorld::SaveRegistry fullRegistry() {
+        IRWorld::SaveRegistry reg;
+        reg.registerComponent<C_WsPos>();
+        reg.registerComponent<C_WsVel>();
+        reg.registerComponent<C_WsTag>();
+        reg.registerComponent<C_WsTransient>(); // no-op (opted out)
+        reg.registerComponent<C_WsSingletonState>();
+        return reg;
+    }
+
+    std::string tempPath(const char *name) const {
+        return testing::TempDir() + "/ir_ws_" + name + ".irws";
+    }
+
+    IREntity::EntityManager m_em; // ctor sets g_entityManager -> this
+};
+
+std::vector<std::uint8_t> readFileBytes(const std::string &path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::vector<std::uint8_t>(
+        std::istreambuf_iterator<char>(in),
+        std::istreambuf_iterator<char>()
+    );
+}
+
+// Criterion 1: >=100 entities, >=3 saved archetypes (incl. a projection
+// merge of two live archetypes that differ only by an opted-out
+// component), exact id + value + membership round-trip.
+TEST_F(WorldSnapshotTest, RoundTripExactIdsValuesMembership) {
+    std::vector<Expected> expected;
+
+    // Archetype A: {C_WsPos} — 40 entities.
+    for (int i = 0; i < 40; ++i) {
+        C_WsPos pos{i, i * 2, i * 3};
+        EntityId id = m_em.createEntity(pos);
+        expected.push_back({id, pos});
+    }
+    // Archetype B: {C_WsPos, C_WsVel} — 30 entities.
+    for (int i = 0; i < 30; ++i) {
+        C_WsPos pos{100 + i, i, -i};
+        C_WsVel vel{static_cast<float>(i) * 0.5f, static_cast<float>(-i)};
+        EntityId id = m_em.createEntity(pos, vel);
+        expected.push_back({id, pos, true, vel});
+    }
+    // Archetype C: {C_WsPos, C_WsTag} — 20 entities.
+    for (int i = 0; i < 20; ++i) {
+        C_WsPos pos{200 + i, 0, i};
+        C_WsTag tag{1000 + i};
+        EntityId id = m_em.createEntity(pos, tag);
+        Expected e{id, pos};
+        e.hasTag_ = true;
+        e.tag_ = tag;
+        expected.push_back(e);
+    }
+    // Archetype D: {C_WsPos, C_WsTransient} — 15 entities. C_WsTransient is
+    // opted out, so D projects onto {C_WsPos} == A: proves projection-merge.
+    for (int i = 0; i < 15; ++i) {
+        C_WsPos pos{300 + i, i, i};
+        C_WsTransient transient{9999};
+        EntityId id = m_em.createEntity(pos, transient);
+        expected.push_back({id, pos});
+    }
+    ASSERT_EQ(expected.size(), 105u);
+
+    IRWorld::SaveRegistry reg = fullRegistry();
+    const std::string path = tempPath("roundtrip");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+
+    m_em.destroyAllEntities();
+    ASSERT_EQ(m_em.getLiveEntityCount(), 0u);
+
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+    EXPECT_EQ(result.entitiesRestored_, 105u);
+
+    for (const Expected &e : expected) {
+        ASSERT_TRUE(m_em.entityExists(e.id_)) << "missing id " << e.id_;
+        const C_WsPos &pos = m_em.getComponent<C_WsPos>(e.id_);
+        EXPECT_EQ(pos.x_, e.pos_.x_);
+        EXPECT_EQ(pos.y_, e.pos_.y_);
+        EXPECT_EQ(pos.z_, e.pos_.z_);
+
+        auto vel = m_em.getComponentOptional<C_WsVel>(e.id_);
+        EXPECT_EQ(vel.has_value(), e.hasVel_);
+        if (e.hasVel_) {
+            EXPECT_FLOAT_EQ((*vel)->vx_, e.vel_.vx_);
+            EXPECT_FLOAT_EQ((*vel)->vy_, e.vel_.vy_);
+        }
+        auto tag = m_em.getComponentOptional<C_WsTag>(e.id_);
+        EXPECT_EQ(tag.has_value(), e.hasTag_);
+        if (e.hasTag_) {
+            EXPECT_EQ((*tag)->marker_, e.tag_.marker_);
+        }
+        // Opted-out component never round-trips.
+        EXPECT_FALSE(m_em.getComponentOptional<C_WsTransient>(e.id_).has_value());
+    }
+}
+
+// Criterion 4: a createEntity after load lands above the saved watermark
+// (no collision with any restored id).
+TEST_F(WorldSnapshotTest, PostLoadAllocationClearsWatermark) {
+    EntityId maxId = 0;
+    for (int i = 0; i < 10; ++i) {
+        const EntityId id = m_em.createEntity(C_WsPos{i, i, i}) & IREntity::IR_ENTITY_ID_BITS;
+        if (id > maxId) {
+            maxId = id;
+        }
+    }
+    IRWorld::SaveRegistry reg = fullRegistry();
+    const std::string path = tempPath("watermark");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+    m_em.destroyAllEntities();
+    ASSERT_TRUE(IRWorld::loadWorld(reg, path).ok());
+
+    EntityId fresh = m_em.createEntity(C_WsPos{0, 0, 0}) & IREntity::IR_ENTITY_ID_BITS;
+    EXPECT_GT(fresh, maxId);
+    EXPECT_FALSE(m_em.entityExists(0)); // sanity: null id never live
+}
+
+// Criterion 2: singleton value round-trips by value; alias map records the
+// saved-id -> live-id mapping.
+TEST_F(WorldSnapshotTest, SingletonRoundTripByValue) {
+    EntityId savedSingletonId = m_em.getOrCreateSingleton<C_WsSingletonState>();
+    m_em.getComponent<C_WsSingletonState>(savedSingletonId) = C_WsSingletonState{42, 3.5f};
+    // Also a couple of gameplay entities so the SNGL path coexists with ARCH.
+    m_em.createEntity(C_WsPos{1, 2, 3});
+
+    IRWorld::SaveRegistry reg = fullRegistry();
+    const std::string path = tempPath("singleton");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+
+    m_em.destroyAllEntities(); // clears the singleton cache
+
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+    EXPECT_EQ(result.singletonsRestored_, 1u);
+
+    const C_WsSingletonState &restored = IREntity::singleton<C_WsSingletonState>();
+    EXPECT_EQ(restored.counter_, 42);
+    EXPECT_FLOAT_EQ(restored.weight_, 3.5f);
+
+    // Alias map: saved id -> the (freshly lazy-created) live singleton id.
+    ASSERT_EQ(result.singletonAliases_.size(), 1u);
+    auto it = result.singletonAliases_.find(savedSingletonId & IREntity::IR_ENTITY_ID_BITS);
+    ASSERT_NE(it, result.singletonAliases_.end());
+    EXPECT_EQ(it->second, IREntity::singletonEntityOrNull<C_WsSingletonState>());
+}
+
+// Criterion 3: an opted-out component's save-name never appears in the file
+// (CMPN table), while an opted-in one does.
+TEST_F(WorldSnapshotTest, OptOutComponentAbsentFromFile) {
+    m_em.createEntity(C_WsPos{1, 2, 3}, C_WsTransient{7});
+
+    IRWorld::SaveRegistry reg = fullRegistry();
+    const std::string path = tempPath("optout");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+
+    std::vector<std::uint8_t> bytes = readFileBytes(path);
+    std::string blob(bytes.begin(), bytes.end());
+    EXPECT_NE(blob.find("WsSnap::C_WsPos"), std::string::npos);
+    EXPECT_EQ(blob.find("WsSnap::C_WsTransient"), std::string::npos);
+}
+
+// Criterion 6: two consecutive saves of the same world are byte-identical.
+TEST_F(WorldSnapshotTest, DoubleSaveIsByteIdentical) {
+    for (int i = 0; i < 25; ++i) {
+        m_em.createEntity(C_WsPos{i, i, i}, C_WsVel{static_cast<float>(i), 0.0f});
+    }
+    for (int i = 0; i < 25; ++i) {
+        m_em.createEntity(C_WsPos{i, 0, 0}, C_WsTag{i});
+    }
+    m_em.getComponent<C_WsSingletonState>(m_em.getOrCreateSingleton<C_WsSingletonState>()) =
+        C_WsSingletonState{7, 1.0f};
+
+    IRWorld::SaveRegistry reg = fullRegistry();
+    const std::string pathA = tempPath("det_a");
+    const std::string pathB = tempPath("det_b");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, pathA).ok());
+    ASSERT_TRUE(IRWorld::saveWorld(reg, pathB).ok());
+
+    EXPECT_EQ(readFileBytes(pathA), readFileBytes(pathB));
+}
+
+// Criterion 5a: bad magic is a recoverable error, world untouched.
+TEST_F(WorldSnapshotTest, BadMagicRecoverable) {
+    const std::string path = tempPath("badmagic");
+    {
+        IRAsset::FileBinaryWriter w(path);
+        ASSERT_TRUE(w.ok());
+        std::vector<IRAsset::ChunkPayload> none;
+        ASSERT_TRUE(IRAsset::writeChunked(w, IRAsset::makeTag("XXXX"), 1, none).ok());
+    }
+    // Build the registry (which registers components -> backing entities)
+    // BEFORE the baseline, so the count reflects only the loader's effect.
+    IRWorld::SaveRegistry reg = fullRegistry();
+    m_em.createEntity(C_WsPos{1, 1, 1});
+    const EntityId before = m_em.getLiveEntityCount();
+
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.status_.code_, IRAsset::BinaryIOError::BadMagic);
+    EXPECT_EQ(m_em.getLiveEntityCount(), before); // zero mutation
+}
+
+// Criterion 5b: version-too-new is a recoverable error.
+TEST_F(WorldSnapshotTest, VersionTooNewRecoverable) {
+    const std::string path = tempPath("vtoonew");
+    {
+        IRAsset::FileBinaryWriter w(path);
+        ASSERT_TRUE(w.ok());
+        std::vector<IRAsset::ChunkPayload> none;
+        ASSERT_TRUE(
+            IRAsset::writeChunked(
+                w,
+                IRWorld::kWorldSnapshotMagic,
+                IRWorld::kWorldSnapshotVersion + 99,
+                none
+            )
+                .ok()
+        );
+    }
+    IRWorld::SaveRegistry reg = fullRegistry();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.status_.code_, IRAsset::BinaryIOError::VersionTooNew);
+}
+
+// Criterion 5c: truncation is a recoverable error.
+TEST_F(WorldSnapshotTest, TruncatedRecoverable) {
+    for (int i = 0; i < 20; ++i) {
+        m_em.createEntity(C_WsPos{i, i, i}, C_WsVel{1.0f, 2.0f});
+    }
+    IRWorld::SaveRegistry reg = fullRegistry();
+    const std::string path = tempPath("trunc");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+
+    std::vector<std::uint8_t> bytes = readFileBytes(path);
+    ASSERT_GT(bytes.size(), 16u);
+    {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out.write(reinterpret_cast<const char *>(bytes.data()), 16); // header only
+    }
+    m_em.destroyAllEntities();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(m_em.getLiveEntityCount(), 0u); // zero mutation
+}
+
+// Criterion 5d: a restored id colliding with a live entity aborts with zero
+// mutation (loading without a reset first).
+TEST_F(WorldSnapshotTest, LiveIdCollisionRecoverable) {
+    for (int i = 0; i < 10; ++i) {
+        m_em.createEntity(C_WsPos{i, i, i});
+    }
+    IRWorld::SaveRegistry reg = fullRegistry();
+    const std::string path = tempPath("collision");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+
+    const EntityId before = m_em.getLiveEntityCount();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path); // no reset -> collides
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(m_em.getLiveEntityCount(), before); // zero mutation
+}
+
+// Criterion 5e: a component whose save-name does not resolve in the load
+// registry is skipped (by byte length), not fatal — its entities restore
+// with only the resolvable columns.
+TEST_F(WorldSnapshotTest, UnknownComponentNameSkipped) {
+    std::vector<EntityId> ids;
+    for (int i = 0; i < 12; ++i) {
+        ids.push_back(m_em.createEntity(C_WsPos{i, i, i}, C_WsVel{static_cast<float>(i), 0.0f}));
+    }
+    IRWorld::SaveRegistry saveReg = fullRegistry(); // has C_WsVel
+    const std::string path = tempPath("skip");
+    ASSERT_TRUE(IRWorld::saveWorld(saveReg, path).ok());
+    m_em.destroyAllEntities();
+
+    IRWorld::SaveRegistry loadReg; // deliberately missing C_WsVel
+    loadReg.registerComponent<C_WsPos>();
+    IRWorld::LoadResult result = IRWorld::loadWorld(loadReg, path);
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+    EXPECT_EQ(result.entitiesRestored_, 12u);
+    EXPECT_GT(result.columnsSkipped_, 0u);
+
+    for (EntityId id : ids) {
+        ASSERT_TRUE(m_em.entityExists(id));
+        EXPECT_TRUE(m_em.getComponentOptional<C_WsPos>(id).has_value());
+        EXPECT_FALSE(m_em.getComponentOptional<C_WsVel>(id).has_value()); // skipped
+    }
+}
+
+// An empty world round-trips cleanly (no archetypes, no singletons).
+TEST_F(WorldSnapshotTest, EmptyWorldRoundTrips) {
+    IRWorld::SaveRegistry reg = fullRegistry();
+    const std::string path = tempPath("empty");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(result.entitiesRestored_, 0u);
+    EXPECT_EQ(result.singletonsRestored_, 0u);
+}
+
+} // namespace

--- a/test/world/world_snapshot_test.cpp
+++ b/test/world/world_snapshot_test.cpp
@@ -8,6 +8,8 @@
 #include <irreden/asset/chunk_header.hpp>
 #include <irreden/ir_entity.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <fstream>
 #include <string>
@@ -39,6 +41,14 @@ struct C_WsSingletonState {
     std::int32_t counter_ = 0;
     float weight_ = 0.0f;
 };
+// A component with a *fallible* serializer: `read` rejects a wrong sentinel,
+// so a length-valid-but-content-corrupt column fails to *decode* — unlike a
+// trivially-copyable raw image, which accepts any byte pattern. This is what
+// lets CorruptColumnAbortsWithZeroMutation exercise a decode failure the
+// loader's phase-2 gate must catch before it mutates the live world.
+struct C_WsChecked {
+    std::int32_t payload_ = 0;
+};
 } // namespace WsSnap
 
 IR_SAVE_OPT_IN(WsSnap::C_WsPos, 1)
@@ -46,6 +56,49 @@ IR_SAVE_OPT_IN(WsSnap::C_WsVel, 1)
 IR_SAVE_OPT_IN(WsSnap::C_WsTag, 1)
 IR_SAVE_OPT_OUT(WsSnap::C_WsTransient)
 IR_SAVE_OPT_IN(WsSnap::C_WsSingletonState, 2)
+IR_SAVE_OPT_IN(WsSnap::C_WsChecked, 1)
+
+namespace IRWorld {
+// Explicit specialization overriding the trivially-copyable raw-image default
+// with a sentinel-guarded encoding whose `read` can fail on bad content.
+template <> struct SaveSerialize<WsSnap::C_WsChecked> {
+    // A distinctive little-endian pattern (EF BE AD DE) the corruption test
+    // can locate and flip in the on-disk bytes without colliding with the
+    // small varuint headers / low component values elsewhere in the file.
+    static constexpr std::uint32_t kSentinel = 0xDEADBEEFu;
+
+    static void write(IRAsset::BinaryWriter &w, const WsSnap::C_WsChecked &value) {
+        w.writeU32(kSentinel);
+        w.writeU32(static_cast<std::uint32_t>(value.payload_));
+    }
+
+    static IRAsset::Result<WsSnap::C_WsChecked> read(IRAsset::BinaryReader &r) {
+        IRAsset::Result<std::uint32_t> tag = r.readU32();
+        if (!tag.ok()) {
+            return IRAsset::Result<WsSnap::C_WsChecked>::error(
+                tag.status_.code_,
+                tag.status_.message_
+            );
+        }
+        if (tag.value_ != kSentinel) {
+            return IRAsset::Result<WsSnap::C_WsChecked>::error(
+                IRAsset::BinaryIOError::UnknownTag,
+                "C_WsChecked: bad sentinel"
+            );
+        }
+        IRAsset::Result<std::uint32_t> payload = r.readU32();
+        if (!payload.ok()) {
+            return IRAsset::Result<WsSnap::C_WsChecked>::error(
+                payload.status_.code_,
+                payload.status_.message_
+            );
+        }
+        return IRAsset::Result<WsSnap::C_WsChecked>::success(
+            WsSnap::C_WsChecked{static_cast<std::int32_t>(payload.value_)}
+        );
+    }
+};
+} // namespace IRWorld
 
 namespace {
 
@@ -369,6 +422,122 @@ TEST_F(WorldSnapshotTest, EmptyWorldRoundTrips) {
     ASSERT_TRUE(result.ok());
     EXPECT_EQ(result.entitiesRestored_, 0u);
     EXPECT_EQ(result.singletonsRestored_, 0u);
+}
+
+// A length-valid-but-content-corrupt column must be caught by the load's
+// phase-2 decode gate and abort with ZERO world mutation (Rule #5) — not
+// surface mid-apply, after restoreEntitiesBatch has already spliced entities
+// into the live graph. Uses the fallible C_WsChecked serializer so a corrupt
+// row genuinely fails to decode (a trivially-copyable raw image accepts any
+// bytes and can't reproduce this). See #2213.
+TEST_F(WorldSnapshotTest, CorruptColumnAbortsWithZeroMutation) {
+    IRWorld::SaveRegistry reg;
+    reg.registerComponent<C_WsPos>();
+    reg.registerComponent<C_WsChecked>();
+    // A pure-{C_WsPos} archetype plus a {C_WsPos, C_WsChecked} one, so a
+    // decode failure in the checked column would (pre-fix) land after at least
+    // one archetype is already spliced — the partial mutation under test.
+    for (int i = 0; i < 5; ++i) {
+        m_em.createEntity(C_WsPos{i, i, i});
+    }
+    for (int i = 0; i < 5; ++i) {
+        m_em.createEntity(C_WsPos{i, i, i}, C_WsChecked{100 + i});
+    }
+    const std::string path = tempPath("corruptcol");
+    ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+
+    // Corrupt one C_WsChecked sentinel in place: same file length, valid
+    // per-column byteLength headers, but the row no longer decodes.
+    std::vector<std::uint8_t> bytes = readFileBytes(path);
+    const std::array<std::uint8_t, 4> needle{0xEF, 0xBE, 0xAD, 0xDE}; // 0xDEADBEEF LE
+    auto at = std::search(bytes.begin(), bytes.end(), needle.begin(), needle.end());
+    ASSERT_NE(at, bytes.end()) << "C_WsChecked sentinel not found in file";
+    *at ^= 0xFFu; // flip the low byte -> sentinel mismatch on decode
+    {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out.write(
+            reinterpret_cast<const char *>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size())
+        );
+    }
+
+    m_em.destroyAllEntities();
+    const EntityId before = m_em.getLiveEntityCount();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    EXPECT_FALSE(result.ok());                    // corrupt column rejected
+    EXPECT_EQ(result.entitiesRestored_, 0u);      // Rule #5: no partial counts
+    EXPECT_EQ(m_em.getLiveEntityCount(), before); // zero world mutation
+}
+
+} // namespace
+
+namespace {
+
+using namespace WsSnap;
+using IREntity::EntityId;
+
+// The allocator watermark must advance past every restored id BEFORE the
+// singleton loop, or a fresh-session singleton lazy-create draws a
+// just-restored gameplay id and cross-wires onto it. A same-manager reload
+// can't reproduce this (after a save the watermark already sits past the
+// saved ids), so this drives a genuine second session with a fresh
+// EntityManager whose watermark is back at the reserved base. See #2213.
+TEST(WorldSnapshotFreshSession, WatermarkAdvancesBeforeSingletonLazyCreate) {
+    const std::string path = testing::TempDir() + "/ir_ws_fresh_watermark.irws";
+    std::vector<EntityId> gameplayIds;
+    const C_WsSingletonState savedSingleton{1234, 5.5f};
+    {
+        IREntity::EntityManager em1; // ctor sets g_entityManager -> em1
+        IRWorld::SaveRegistry reg;
+        reg.registerComponent<C_WsPos>();
+        reg.registerComponent<C_WsSingletonState>();
+        // Gameplay entities first, so the lowest post-registration id belongs
+        // to a gameplay entity — exactly the id a fresh-session singleton
+        // lazy-create would otherwise draw.
+        for (int i = 0; i < 8; ++i) {
+            gameplayIds.push_back(
+                em1.createEntity(C_WsPos{i, i + 1, i + 2}) & IREntity::IR_ENTITY_ID_BITS
+            );
+        }
+        em1.getComponent<C_WsSingletonState>(em1.getOrCreateSingleton<C_WsSingletonState>()) =
+            savedSingleton;
+        ASSERT_TRUE(IRWorld::saveWorld(reg, path).ok());
+    } // em1 destructs, clearing the global
+
+    // A brand-new session: watermark back at the reserved base, the same two
+    // components registered in the same order (same backing-entity count), so
+    // without the pre-mutation advance the singleton lazy-create would draw
+    // exactly gameplayIds[0].
+    IREntity::EntityManager em2; // ctor sets g_entityManager -> em2
+    IRWorld::SaveRegistry reg;
+    reg.registerComponent<C_WsPos>();
+    reg.registerComponent<C_WsSingletonState>();
+    IRWorld::LoadResult result = IRWorld::loadWorld(reg, path);
+    ASSERT_TRUE(result.ok()) << result.status_.message_;
+
+    // The singleton restored by value...
+    const C_WsSingletonState &restored = IREntity::singleton<C_WsSingletonState>();
+    EXPECT_EQ(restored.counter_, savedSingleton.counter_);
+    EXPECT_FLOAT_EQ(restored.weight_, savedSingleton.weight_);
+
+    // ...onto a fresh id strictly above every restored gameplay id. This is
+    // the fix's invariant: without the pre-mutation watermark advance the
+    // lazy-create draws a low, already-restored id and this fails.
+    const EntityId liveSingleton =
+        IREntity::singletonEntityOrNull<C_WsSingletonState>() & IREntity::IR_ENTITY_ID_BITS;
+    const EntityId maxGameplay = *std::max_element(gameplayIds.begin(), gameplayIds.end());
+    EXPECT_GT(liveSingleton, maxGameplay);
+
+    // Every restored gameplay entity keeps its exact C_WsPos — the singleton
+    // value never cross-wired onto a gameplay record.
+    for (int i = 0; i < 8; ++i) {
+        ASSERT_TRUE(em2.entityExists(gameplayIds[i])) << "missing id " << gameplayIds[i];
+        auto pos = em2.getComponentOptional<C_WsPos>(gameplayIds[i]);
+        ASSERT_TRUE(pos.has_value());
+        EXPECT_EQ((*pos)->x_, i);
+        EXPECT_EQ((*pos)->y_, i + 1);
+        EXPECT_EQ((*pos)->z_, i + 2);
+    }
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- `IRWorld::saveWorld` / `loadWorld` — the **IRWS** entity-level snapshot container (persist P2, epic #667): `CMPN`/`ARCH`/`SNGL`/`META` chunks + JSON sidecar over `engine/asset/` primitives. Distinct from `chunk_persistence.hpp`'s per-chunk `.vxs` voxel save.
- `save_serialize.hpp` — `SaveSerialize<C>` per-component bytes customization point (trivially-copyable default; specialize for heap-owning components).
- `save_registry.hpp` — type-erased `SaveRegistry` bridging P1's compile-time `SaveTrait<C>` to runtime archetype columns; `registerComponent<C>()` is `if constexpr`-gated on `shouldSave<C>()`.
- `save_trait.hpp` — additively adds `SaveTrait<C>::kSaveName` (the type's source spelling via the opt-in/out macros) as the stable CMPN on-disk key. **P1 reconciliation** the plan flagged (P1 shipped no stable name); it's the only change to #2212's file.
- Deterministic **projection-merge** walker (two live archetypes differing only by an opted-out component merge into one saved archetype) + a **two-phase loader** (validate-then-apply, **zero world mutation on any error**, Rule #5) restoring **exact original EntityIds**.
- `EntityManager` restore surface: `findCreateArchetypeNode` wrapper, `restoreEntitiesBatch`, `singletonEntityCache`/`isComponentBackingEntity` (the `resetGameplay`-mirroring exclusion set), `entityIdWatermark`/`advanceEntityIdWatermark`.

### Scope / deviations from the plan
- Namespace is `IRWorld` (matches P1's `save_trait.hpp`), not the plan's `IRPersist` (which doesn't exist in-tree).
- `saveWorld/loadWorld` take an explicit `const SaveRegistry&` — the honest P2 surface, since a registry decides what participates. The `(path)`-only P7 convenience wrapper layers on once engine components carry serializers.
- P2 ships the **mechanism**, proven with trivially-copyable *test* components (per acceptance criterion #1 "test components"). Registering the 165 engine components — each non-POD one needs a `SaveSerialize<C>` specialization — is downstream.

## Test plan
- [x] `test/world/world_snapshot_test.cpp` — 11 tests covering all six acceptance criteria: 105-entity / 4-archetype round-trip with exact ids + projection-merge, singleton by-value + alias map, opt-out absence, post-load watermark, byte-identical double-save, and recoverable errors (bad magic / version-too-new / truncation / live-id collision zero-mutation / unknown-name skip).
- [x] Full entity/save/world regression green on `macos-debug` (256 tests), no regressions from the `entity_manager` + `save_trait` changes.
- [ ] Linux `linux-debug` build + gtest (acceptance criterion #7 requires both presets; macOS validated here, Linux pending a GL-host pane).

Stacked on: https://github.com/jakildev/IrredenEngine/pull/2225

Closes #2213

🤖 Generated with [Claude Code](https://claude.com/claude-code)