### PR TITLE
fleet: centralized cross-device polling — leader/follower (#2220)

### DIFF
--- a/.fleet/plans/issue-2220.md
+++ b/.fleet/plans/issue-2220.md
@@ -1,0 +1,71 @@
+# Plan: quota Q2 — centralized cross-device polling (one poller per account)
+
+- **Issue:** #2220
+- **Model:** opus
+- **Date:** 2026-07-03
+- **Epic:** #1394 — see `.fleet/plans/issue-1394.md` for full context
+- **Blocked by:** #2219
+
+## Scope
+
+Collapse N per-host `fleet-state-scout` daemons into **one authoritative GitHub poller per account** plus N−1 followers that consume the leader's already-fetched state over the LAN instead of calling `gh` themselves. In steady-state idle polling, only the leader's per-account REST/GraphQL counters move; followers make zero GitHub read calls yet keep a byte-identical `~/.fleet/state/` so every consumer (dispatcher, roles, `fleet-pr`/`fleet-issue` wrappers) stays oblivious.
+
+Out of scope (stays per-host, unchanged): all **mutations** — claim label add/remove, PR/issue comments, label transitions, `gh pr merge/edit/review`, ingest label writes. These are cheap and correctly host-scoped. This ticket touches only the **polling reads** in `collect_state()`. Depends on **Q1** (conditional-REST poller core + ETag cache); Q2 reuses that conditional-request helper for the intra-fleet LAN hop, which is why it is Blocked-by-Q1.
+
+## Verified current state (the shareable-vs-host-local split)
+
+The scout's per-tick snapshot is assembled in `collect_state()` and written atomically to `~/.fleet/state/state.json` in `tick_once()`.
+
+- **GitHub-derived → shareable, byte-identical on every host:** the eight `fetch_specs` per repo — `prs, needs_plan, plan_review, human_approved, closed_fleet_queued, recent_merged_prs, tasks, epics` — plus the per-item detail caches `prs/`, `diffs/`, `issues/` refreshed by `refresh_all_details()`. Every one is a `gh` call against the two repos. These are exactly the reads that multiply per host. Claim ownership is likewise **GitHub-derived**: it is parsed back out of the `fleet:claim-<host>-<agent>` labels in `fetch_task_queue`, not from any local tracker — so the *observation* of claims is shareable even though claim *writes* are host-local.
+- **Host-local → must stay per-host:** `repos.<key>.path`, the local clone path; `clone_freshness`, a `git rev-parse` of *this host's* checkout vs its own `origin/master`; and everything derived downstream per host — the projections/slices, `seen-hashes/`, and per-role `triggers/`, because each host must fire triggers for *its own* running roles.
+- **Reconcile locality (the sharp edge):** `tick_once` spawns three side-effects on projection change — `fleet-claim cleanup --gh` + `fleet-claim reconcile --apply` and `fleet-queue-ingest`. `cleanup` and `ingest` are **global** (stale-label reaping, human:approved→queued); running them on all N hosts multiplies mutation calls and races. `reconcile --apply` is conservative **host-local** + TTL-gated auto-fixes — it reconciles *this host's* own claim tracker, so it must keep firing per-host. These fire only on projection *change*, so they never move counters during idle polling.
+- **Existing scout-down signal to extend:** consumers already treat `generated_at` older than ~5 min as "scout is down" (`docs/agents/FLEET-CACHE.md`, `docs/agents/FLEET-RUNTIME.md`). The dispatcher watchdog, however, keys off **local file mtime** (`scout_unhealthy()` → `STATE_FILE.stat().st_mtime`, `SCOUT_STALENESS_SECONDS = 120`). Host identity is already canonical via `host_from_uname`/`derive_host` (`fleet-claim`); `~/.config/irreden/host.toml` is the established per-host config surface (`setup-windows.sh`).
+
+## Approach (single committed mechanism)
+
+**Follower-pull over a leader-served HTTP endpoint, conditional GET, static leader flag.**
+
+1. **Leader selection — static, boring.** Add `[fleet] poll_role = "leader" | "follower"` (default `"leader"`) and `poll_port` (default `8477`) to `~/.config/irreden/host.toml`. The scout reads it once at startup. No election, no heartbeat contest — one line per host, matching fleet's static-config conventions. Home desktop = leader; laptop/second host = follower.
+
+2. **Leader path — unchanged fetch + serve.** The leader runs `collect_state()` exactly as today and additionally starts a tiny stdlib `http.server` thread (daemon thread, torn down on the existing `SIGTERM`/`TERMINATE` path) bound to `0.0.0.0:poll_port`, serving a **read-only bundle of the whole `~/.fleet/state/` dir** (state.json + projections + `prs/`/`diffs/`/`issues/`) as one payload with an **ETag equal to the snapshot's `generated_at`**. Everything the followers' `fleet-pr`/`fleet-issue` wrappers read is included, so followers never fall back to `gh` on a per-item drill-in.
+
+3. **Follower path — consume, don't fetch.** On follower hosts, replace the `collect_state()` GitHub fan-out with a **conditional GET** (reusing Q1's ETag/If-None-Match helper) against `http://<leader-host>:<poll_port>`. A `304` (nothing changed) costs one tiny LAN round-trip and **zero GitHub quota**; a `200` yields the fresh bundle, which the follower unpacks and writes into its own `~/.fleet/state/` via the existing `write_atomic()` — **preserving the leader's `generated_at` verbatim** (do not restamp). The follower then still runs the local half of `tick_once` — projections, slices, `triggers/` — off the merged state, so consumers and local roles behave identically. `cleanup`/`ingest` spawns are guarded to run only when this host is the authoritative poller for the tick (leader, or a follower currently self-polling). `clone_freshness` and `repos.<key>.path` are recomputed locally (never taken from the bundle).
+
+4. **Leader failure / staleness — extend the existing generated_at signal.** Because the follower writes the leader's `generated_at` untouched, a dead leader means its `generated_at` stops advancing and every consumer's existing 5-min guard trips automatically — *provided staleness is judged by the in-file `generated_at`, not local mtime*. **The one required consumer change:** switch `fleet-dispatcher`'s `scout_unhealthy()` from `st_mtime` to reading the in-file `generated_at`, so a follower that keeps re-writing a *stale* bundle each tick can't mask the death by bumping mtime. Additionally the follower's own tick applies a `LEADER_STALE_SECONDS` threshold: if the leader is unreachable, or its `generated_at` is already stale beyond the window, the follower **self-polls GitHub directly for that tick** (identical to today's solo behavior). This handles both leader-crash and laptop-away-from-home with no election — a follower off-LAN is just a temporary N=1 solo poller, which is exactly the pre-Q2 behavior and introduces no multiplication (the home leader is typically offline when the laptop is away).
+
+**Why this mechanism over the alternatives:** shared FS (NFS/SMB) is fragile across mac + WSL2 + native-Windows path/permission/locking semantics and dies when the laptop leaves the LAN; **syncthing** adds a third-party daemon to babysit on three heterogeneous hosts; **committing state to a git ref every 30s** spends the very GitHub quota being conserved and pollutes history; **rsync-on-tick** needs SSH keys + reachable sshd across three OSes. The **leader-served HTTP + conditional-GET follower-pull** wins because it (a) reuses Q1's conditional-request machinery for a free `304` no-change poll — the reason Q2 sequences after Q1; (b) is pure Python stdlib, no new dependency or daemon; (c) is **follower-pull**, so the leader needs no follower inventory (zero-config to add a host) and only one inbound LAN port; (d) degrades cleanly to solo self-polling when off-LAN.
+
+## Affected files
+
+- `scripts/fleet/fleet_poll_topology.py` — **new** module (co-located with the scout like `fleet_gh_poll.py`): `read_poll_config()` (host.toml `[fleet]` section), `generated_at` staleness helpers, bundle build/serialize/apply, `LeaderServer` (stdlib `ThreadingHTTPServer`), and `fetch_from_leader()` (the LAN-hop conditional GET).
+- `scripts/fleet/fleet_gh_poll.py` — add a general `conditional_get_url()` (raw If-None-Match GET against an arbitrary URL, no gh token) so the LAN hop reuses Q1's conditional-request machinery verbatim.
+- `scripts/fleet/fleet-state-scout` — primary. Read `poll_role`/`poll_port` at startup; leader starts the daemon HTTP server thread serving the state-dir bundle with `generated_at` as ETag; follower replaces `collect_state()`'s GitHub fan-out with a conditional GET + local unpack (preserving `generated_at`), retains the local projection/slice/trigger half of `tick_once`, and self-polls on leader-unreachable/stale; guard `cleanup` + `ingest` spawns + `refresh_all_details` to the authoritative-poller tick.
+- `scripts/fleet/fleet-dispatcher` — change `scout_unhealthy()` to key staleness off in-file `generated_at` instead of `st_mtime` (mtime fallback when unparseable); the watchdog re-arm logic is unchanged.
+- `scripts/fleet/setup-windows.sh` and `scripts/fleet/fleet-up.conf.sample` — emit/document the new `[fleet] poll_role` / `poll_port` host.toml keys.
+- `scripts/fleet/fleet-up` — log leader-vs-follower mode at scout launch. Note the one inbound LAN port on the leader.
+- `docs/agents/FLEET-CACHE.md` / `docs/agents/FLEET-RUNTIME.md` — document the leader/follower model, the LAN-hop conditional GET, the "follower preserves leader `generated_at`" rule, and the staleness-via-`generated_at` clarification.
+- `scripts/fleet/tests/test_poll_topology.py` — follower with a mocked leader endpoint produces byte-identical `state.json`; a `304` yields zero `gh` invocations; leader-unreachable falls back to self-poll; a frozen leader `generated_at` trips the staleness guard.
+
+## Acceptance criteria
+
+- With 3 hosts up (1 leader + 2 followers) idling on unchanged repos, **only the leader's per-account REST/GraphQL counters advance**; both followers make **zero `gh` read calls** across a full poll interval.
+- Each follower's `~/.fleet/state/state.json` + `projections/*.json` + per-item caches stay fresh (`generated_at` within the window) and are schema-identical to the leader's; dispatcher, roles, and `fleet-pr`/`fleet-issue` wrappers run unchanged with no config awareness of leader/follower.
+- Killing the leader is detected by every host **within the existing ~5-min `generated_at` staleness window** (and the dispatcher's 120 s watchdog), surfacing the standard `scout cache stale or missing — run fleet-up` path — no new failure mode.
+- A follower taken off-LAN (laptop away) transparently self-polls GitHub and keeps working solo, with no multiplication when the leader is offline.
+
+## Gotchas
+
+- **mtime masks death.** If the follower's re-write bumps `state.json` mtime while `generated_at` is frozen, mtime-based staleness would report a healthy-but-lying scout. The dispatcher must switch to in-file `generated_at`; do not restamp `generated_at` on the follower's write.
+- **Don't over-centralize side-effects.** `reconcile --apply` is host-local claim hygiene and must stay per-host; only `cleanup --gh` + `ingest` go authoritative-poller-only. Getting this backwards either strands follower claims or re-multiplies mutation calls.
+- **Per-item cache warmth.** The served bundle must include `prs/`/`diffs/`/`issues/`, or follower `fleet-pr view`/`fleet-issue view` cache-misses fall back to live `gh` and quietly re-introduce per-host calls.
+- **Recompute, don't copy, host-local fields.** `repos.<key>.path` and `clone_freshness` must be regenerated locally after unpacking the bundle — the leader's clone path and git head are wrong on a follower.
+- **First-tick bootstrap.** `fleet-up` waits for the first `state.json`; a follower whose leader isn't up yet must self-poll on tick 1 so the wait doesn't hang. The self-poll fallback covers this.
+- **Two-leader misconfig.** If two hosts are both set `poll_role = "leader"`, quota multiplication silently returns. Log the mode loudly at startup.
+- **Bind scope + firewall.** Bind `0.0.0.0` (not `127.0.0.1`) or cross-host followers can't reach it; the endpoint is read-only state but is unauthenticated on the LAN — acceptable for a home LAN.
+
+## Sibling + in-flight reconciliation
+
+- **Q1 (conditional-REST poller core) is the hard dependency.** Q2 consumes Q1's ETag/conditional-GET helper for the LAN hop. This PR is stacked on Q1's branch (#2219 / PR #2227).
+- **No open PR currently touches the scout, `fleet-up`, or `fleet-dispatcher`** in these paths. #2197 (dispatcher-assigned planning) will edit `fleet-dispatcher` but in the class-routing/claim path, not `scout_unhealthy()` — disjoint surfaces.
+- **#1394 is the umbrella** (fleet:epic + fleet:needs-human). Q2 is pure polling-topology code — the human-owned identity/auth work stays out of scope.
+- **Shared FLEET-doc surface with Q3:** Q3 edits FLEET.md's rate-limit section; Q2 edits FLEET-CACHE/FLEET-RUNTIME — disjoint files, no conflict.

--- a/docs/agents/FLEET-CACHE.md
+++ b/docs/agents/FLEET-CACHE.md
@@ -112,6 +112,57 @@ missing or older than 5 minutes:
 the scout is genuinely down, the human can `fleet-up` to restart
 it.
 
+## Centralized cross-device polling (leader / follower)
+
+When more than one host runs the fleet on the **same GitHub account**
+(e.g. a home desktop + a laptop), each host's scout would otherwise
+poll GitHub independently, multiplying the per-account API quota drain
+by N (#1394). Q2 collapses that to **one authoritative poller** plus
+followers that consume its already-fetched cache over the LAN.
+
+Set the topology per host in `~/.config/irreden/host.toml`:
+
+```toml
+[fleet]
+poll_role  = "leader"    # polls GitHub; serves its ~/.fleet/state bundle on the LAN
+poll_port  = 8477        # the leader's one inbound TCP port
+# on every OTHER host on the same account:
+# poll_role   = "follower"
+# poll_port   = 8477              # must match the leader
+# leader_host = "192.168.1.10"    # the leader's LAN address (required on a follower)
+```
+
+Missing `[fleet]` / missing file ⇒ **leader**, so a single-host fleet
+is unchanged. Exactly one host per account should be the leader.
+
+- **Leader** — polls GitHub exactly as before and additionally serves
+  a read-only bundle (`state.json` + the `prs/` `diffs/` `issues/`
+  detail caches) at `http://0.0.0.0:<poll_port>/state`, with the
+  snapshot's `generated_at` as the ETag.
+- **Follower** — replaces its GitHub fan-out with a conditional GET of
+  the leader's bundle (reusing the Q1 If-None-Match machinery), writes
+  the caches to its own `~/.fleet/state/`, and **preserves the leader's
+  `generated_at` verbatim** — re-deriving only the host-local
+  `clone_freshness` and `repos.<key>.path`. It recomputes its own
+  projections + triggers, so every consumer (roles, dispatcher,
+  `fleet-pr`/`fleet-issue`) runs identically with no leader/follower
+  awareness. Followers make **zero GitHub read calls** while the leader
+  is reachable.
+- **Leader down / off-LAN** — a follower that can't reach the leader,
+  or that sees the leader's `generated_at` gone stale, transparently
+  **self-polls GitHub for that tick** (a temporary solo poller — the
+  pre-Q2 behavior). No election, no new failure mode.
+
+**Staleness is judged by the in-file `generated_at`, never file
+mtime.** A follower re-writes `state.json` every tick (bumping mtime)
+while copying the leader's `generated_at`, so a dead leader keeps mtime
+fresh while `generated_at` freezes; the dispatcher watchdog
+(`scout_unhealthy`) and every role's 5-minute guard key off
+`generated_at` so the death still surfaces. **Global mutations** —
+`fleet-claim cleanup --gh` and `fleet-queue-ingest` — run only on the
+authoritative poller (leader, or a self-polling follower); host-local
+`fleet-claim reconcile --apply` keeps running on every host.
+
 ## Degraded fetches — `degraded` field in state.json
 
 When a `gh` fetch fails (network error, auth failure, rate-limit exhaustion),

--- a/docs/agents/FLEET-RUNTIME.md
+++ b/docs/agents/FLEET-RUNTIME.md
@@ -31,6 +31,14 @@ that's the cost the cache exists to avoid (see
 [`FLEET-CACHE.md`](FLEET-CACHE.md)). The role file names the specific
 arrays it reads from the cache.
 
+Judge staleness by the in-file `generated_at`, **not** the file's mtime.
+Under multi-host centralized polling (#1394 Q2) a follower re-writes
+`state.json` every tick with the leader's `generated_at` preserved, so
+an mtime check would call a dead leader healthy. The dispatcher's
+`scout_unhealthy` watchdog keys off `generated_at` for the same reason
+(see [`FLEET-CACHE.md`](FLEET-CACHE.md) "Centralized cross-device
+polling").
+
 ---
 
 ## Heartbeat — step 0

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1632,6 +1632,8 @@ rearm_periodic_meta_triggers() {
     # stops. Re-fire merger as a one-shot so a scout crash doesn't
     # strand the merge queue indefinitely.
     python3 - <<'PY' || true
+import calendar
+import json
 import pathlib
 import time
 
@@ -1643,11 +1645,32 @@ TRIG.mkdir(parents=True, exist_ok=True)
 SCOUT_STALENESS_SECONDS = 120
 
 
+def _state_age_seconds():
+    # Age from the in-file `generated_at` (the true snapshot time), NOT file
+    # mtime. Under Q2 centralized polling (#1394) a follower re-writes
+    # state.json every tick with the LEADER's `generated_at` preserved — so a
+    # dead leader keeps the follower's mtime fresh while `generated_at` freezes,
+    # and mtime would report a healthy-but-lying scout. Fall back to mtime only
+    # when `generated_at` is missing/unparseable (a malformed snapshot), which
+    # preserves the pre-Q2 behavior for that case.
+    try:
+        gen = json.loads(STATE_FILE.read_text()).get("generated_at")
+    except (OSError, ValueError, AttributeError):
+        gen = None
+    if isinstance(gen, str):
+        try:
+            epoch = calendar.timegm(time.strptime(gen, "%Y-%m-%dT%H:%M:%SZ"))
+            return time.time() - epoch
+        except (ValueError, TypeError):
+            pass
+    return time.time() - STATE_FILE.stat().st_mtime
+
+
 def scout_unhealthy():
     if not STATE_FILE.is_file():
         return True
     try:
-        age = time.time() - STATE_FILE.stat().st_mtime
+        age = _state_age_seconds()
     except OSError:
         return True
     return age > SCOUT_STALENESS_SECONDS

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -1653,6 +1653,14 @@ def _state_age_seconds():
     # and mtime would report a healthy-but-lying scout. Fall back to mtime only
     # when `generated_at` is missing/unparseable (a malformed snapshot), which
     # preserves the pre-Q2 behavior for that case.
+    #
+    # This is an intentional stdlib-only inline mirror of
+    # fleet_poll_topology.state_age_seconds (the canonical, unit-tested copy).
+    # It is NOT imported here because this heredoc is the scout-dead watchdog:
+    # it must fire precisely when the fleet is unhealthy, so it stays free of
+    # any dependency on the fleet module tree resolving (the #1578 ~/bin
+    # symlink hazard) and of pulling the poll-topology HTTP-server module into
+    # a hot dispatcher path. Keep the two in sync if the parse logic changes.
     try:
         gen = json.loads(STATE_FILE.read_text()).get("generated_at")
     except (OSError, ValueError, AttributeError):

--- a/scripts/fleet/fleet-epic-status
+++ b/scripts/fleet/fleet-epic-status
@@ -26,6 +26,7 @@ Source: scripts/fleet/fleet-epic-status
 Installed to ~/bin/fleet-epic-status by scripts/fleet/install.sh.
 """
 import argparse
+import calendar
 import json
 import os
 import pathlib
@@ -94,13 +95,31 @@ def read_json_retry(path, attempts=3, backoff=0.05):
     raise last
 
 
+def _cache_age_seconds(data, mtime):
+    # Age from the in-file `generated_at` (the true snapshot time), NOT file
+    # mtime. Under Q2 centralized polling (#1394) a follower re-writes
+    # state.json every tick with the LEADER's `generated_at` preserved — so a
+    # dead leader keeps a follower's mtime fresh while `generated_at` freezes.
+    # Fall back to mtime only when `generated_at` is missing/unparseable (a
+    # malformed snapshot), which preserves the pre-Q2 behavior for that case.
+    # Mirrors fleet-dispatcher's `_state_age_seconds` (#2220 review nit).
+    gen = (data or {}).get("generated_at")
+    if isinstance(gen, str):
+        try:
+            epoch = calendar.timegm(time.strptime(gen, "%Y-%m-%dT%H:%M:%SZ"))
+            return time.time() - epoch
+        except (ValueError, TypeError):
+            pass
+    return time.time() - mtime
+
+
 def load_state_cache():
-    """Return (data, is_fresh). is_fresh=True when mtime < CACHE_MAX_AGE_S."""
+    """Return (data, is_fresh). is_fresh=True when cache age < CACHE_MAX_AGE_S."""
     try:
         p = pathlib.Path(STATE_JSON)
         mtime = p.stat().st_mtime
         data = read_json_retry(STATE_JSON)
-        return data, (time.time() - mtime) < CACHE_MAX_AGE_S
+        return data, (_cache_age_seconds(data, mtime) < CACHE_MAX_AGE_S)
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return None, False
 

--- a/scripts/fleet/fleet-epic-status
+++ b/scripts/fleet/fleet-epic-status
@@ -26,7 +26,6 @@ Source: scripts/fleet/fleet-epic-status
 Installed to ~/bin/fleet-epic-status by scripts/fleet/install.sh.
 """
 import argparse
-import calendar
 import json
 import os
 import pathlib
@@ -36,6 +35,7 @@ import sys
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from fleet_poll_topology import state_age_seconds  # noqa: E402
 from fleet_validate_stack import discover_children, validate_stack  # noqa: E402
 
 STATE_DIR = os.path.join(os.path.expanduser("~"), ".fleet", "state")
@@ -95,31 +95,20 @@ def read_json_retry(path, attempts=3, backoff=0.05):
     raise last
 
 
-def _cache_age_seconds(data, mtime):
-    # Age from the in-file `generated_at` (the true snapshot time), NOT file
-    # mtime. Under Q2 centralized polling (#1394) a follower re-writes
-    # state.json every tick with the LEADER's `generated_at` preserved — so a
-    # dead leader keeps a follower's mtime fresh while `generated_at` freezes.
-    # Fall back to mtime only when `generated_at` is missing/unparseable (a
-    # malformed snapshot), which preserves the pre-Q2 behavior for that case.
-    # Mirrors fleet-dispatcher's `_state_age_seconds` (#2220 review nit).
-    gen = (data or {}).get("generated_at")
-    if isinstance(gen, str):
-        try:
-            epoch = calendar.timegm(time.strptime(gen, "%Y-%m-%dT%H:%M:%SZ"))
-            return time.time() - epoch
-        except (ValueError, TypeError):
-            pass
-    return time.time() - mtime
-
-
 def load_state_cache():
-    """Return (data, is_fresh). is_fresh=True when cache age < CACHE_MAX_AGE_S."""
+    """Return (data, is_fresh). is_fresh=True when cache age < CACHE_MAX_AGE_S.
+
+    Freshness is judged from the snapshot's in-file `generated_at`, not file
+    mtime — see fleet_poll_topology.state_age_seconds for why (a follower
+    rewrites state.json every tick, keeping mtime fresh while `generated_at`
+    tracks the true leader snapshot age).
+    """
     try:
         p = pathlib.Path(STATE_JSON)
         mtime = p.stat().st_mtime
         data = read_json_retry(STATE_JSON)
-        return data, (_cache_age_seconds(data, mtime) < CACHE_MAX_AGE_S)
+        gen = (data or {}).get("generated_at")
+        return data, (state_age_seconds(gen, mtime) < CACHE_MAX_AGE_S)
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return None, False
 

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -51,6 +51,7 @@ if sys.platform == "win32" and not os.environ.get("PYTHONUTF8"):
 # python. Insert this script's own dir so the import resolves whether the
 # scout is run directly or loaded by-path in the unit tests (#1425).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import fleet_poll_topology
 from fleet_blocked_by import is_no_blocker_value, parse_blocked_by
 from fleet_branch_match import PARKED_PR_LABELS, branch_matches_issue
 
@@ -2462,30 +2463,122 @@ def _populate_review_plan(state):
         ]
 
 
+# --- Poll topology (#1394 Q2) — leader / follower state acquisition --------
+#
+# POLL_CFG is resolved once in main() from host.toml. A leader polls GitHub and
+# additionally serves its state bundle (LEADER_SERVER); a follower consumes the
+# leader's already-fetched bundle over the LAN instead of calling gh. Both live
+# here as module globals because tick_once (below) and main (bottom) are far
+# apart; Python binds them at call time so the definition site is immaterial.
+POLL_CFG = None
+LEADER_SERVER = None
+_FOLLOWER_ETAG = {"value": None}
+
+
+def build_state():
+    """Assemble this tick's fully-resolved state; return (state, served).
+
+    `served` is True only when a follower successfully consumed the leader's
+    bundle — in that case the state is ALREADY resolved (the leader ran the
+    resolve/enrich pipeline before serving) and the caller skips both that
+    pipeline and refresh_all_details. A leader — or a follower falling back to
+    self-poll because the leader is unreachable/stale — returns raw GitHub
+    state (served=False) that still needs the resolve pipeline.
+    """
+    cfg = POLL_CFG
+    if cfg is None or cfg.is_leader:
+        return collect_state(), False
+    follower_state = _fetch_follower_state(cfg)
+    if follower_state is not None:
+        return follower_state, True
+    log("poll: follower self-polling GitHub this tick (leader unreachable/stale)")
+    return collect_state(), False
+
+
+def _fetch_follower_state(cfg):
+    """Consume the leader's bundle → its resolved state overlaid with THIS
+    host's local fields, or None to signal the caller should self-poll (leader
+    unreachable, its generated_at stale, a malformed bundle, or no prior state
+    to reuse on a 304)."""
+    now = fleet_poll_topology.now_epoch()
+    status, etag, files = fleet_poll_topology.fetch_from_leader(
+        cfg, _FOLLOWER_ETAG["value"])
+    game_path = GAME if (GAME / ".git").exists() else None
+
+    if status == 200:
+        leader_text = files.get("state.json")
+        if leader_text is None:
+            return None
+        try:
+            leader_state = json.loads(leader_text)
+        except json.JSONDecodeError:
+            return None
+        # A leader that serves a stale snapshot (alive but wedged) is not
+        # trustworthy — self-poll rather than propagate a frozen timestamp.
+        if fleet_poll_topology.is_stale(
+                leader_state.get("generated_at"), now, cfg.leader_stale_seconds):
+            log("poll: leader bundle generated_at is stale — self-polling")
+            return None
+        # Mirror the leader's prs/ diffs/ issues/ caches so follower fleet-pr /
+        # fleet-issue drill-ins hit the cache, never a live gh call.
+        fleet_poll_topology.apply_bundle_detail_caches(STATE_DIR, files)
+        _FOLLOWER_ETAG["value"] = etag
+        # Preserve generated_at + all GitHub-derived data; re-derive only the
+        # host-local clone path + freshness (the leader's are wrong here).
+        return fleet_poll_topology.overlay_host_local(
+            leader_state, engine_path=ENGINE, game_path=game_path,
+            clone_freshness=clone_freshness(ENGINE))
+
+    if status == 304:
+        # Unchanged since our last consume — reuse the on-disk (already
+        # resolved + overlaid) state.json, but re-verify freshness so a wedged
+        # leader answering 304 with a frozen generated_at forces a self-poll.
+        try:
+            on_disk = read_json_retry(STATE_FILE)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+        if fleet_poll_topology.is_stale(
+                on_disk.get("generated_at"), now, cfg.leader_stale_seconds):
+            log("poll: leader frozen (304 + stale generated_at) — self-polling")
+            return None
+        # Only clone_freshness can drift between 304s (local git may advance).
+        on_disk["clone_freshness"] = clone_freshness(ENGINE)
+        return on_disk
+
+    return None  # unreachable / error → caller self-polls
+
+
 def tick_once():
-    state = collect_state()
-    if state.get("degraded"):
-        log(f"state degraded: {state['degraded']} — reconcile disabled this tick")
-    _populate_done_tasks(state)
-    _populate_review_plan(state)
-    resolve_blocked_by(state)
-    resolve_human_approved_blockers(state)
-    resolve_epic_children(state)
-    enrich_stackable_blocker_prs(state)
-    # Drop PR bodies now the only consumer (the Closes-#N stack-base match above)
-    # has run, so they don't bloat state.json or the per-role slices — mirrors
-    # resolve_human_approved_blockers popping issue bodies. No projector or slice
-    # needs pr body.
-    for _repo_state in state["repos"].values():
-        for _pr in _repo_state.get("prs", []):
-            _pr.pop("body", None)
-    enrich_inflight_pr_tasks(state)
+    state, served = build_state()
+    # A follower's bundle is already fully resolved (the leader ran the pipeline
+    # before serving); re-running it would double-process body-stripped data.
+    authoritative = not served
+    if authoritative:
+        if state.get("degraded"):
+            log(f"state degraded: {state['degraded']} — reconcile disabled this tick")
+        _populate_done_tasks(state)
+        _populate_review_plan(state)
+        resolve_blocked_by(state)
+        resolve_human_approved_blockers(state)
+        resolve_epic_children(state)
+        enrich_stackable_blocker_prs(state)
+        # Drop PR bodies now the only consumer (the Closes-#N stack-base match
+        # above) has run, so they don't bloat state.json or the per-role slices
+        # — mirrors resolve_human_approved_blockers popping issue bodies. No
+        # projector or slice needs pr body.
+        for _repo_state in state["repos"].values():
+            for _pr in _repo_state.get("prs", []):
+                _pr.pop("body", None)
+        enrich_inflight_pr_tasks(state)
     write_atomic(STATE_FILE, json.dumps(state, indent=2, sort_keys=True) + "\n")
 
-    try:
-        refresh_all_details(state)
-    except Exception as e:
-        log(f"refresh_all_details failed: {e}")
+    if authoritative:
+        # Detail caches (prs/ diffs/ issues/) come from GitHub only on the
+        # authoritative poller; a follower already mirrored the leader's caches.
+        try:
+            refresh_all_details(state)
+        except Exception as e:
+            log(f"refresh_all_details failed: {e}")
 
     triggers_fired = []
     for role, projector in PROJECTORS.items():
@@ -2512,23 +2605,27 @@ def tick_once():
                     log("queue-manager: skipping reconcile+cleanup (state degraded)")
                     triggers_fired.append("queue-manager(skipped-degraded)")
                     continue
-                sweep_cmds = [
-                    ["fleet-claim", "cleanup", "--gh",
-                     "--repo", "jakildev/IrredenEngine"],
-                ]
-                # Cross-surface reconcile is a SINGLE multi-repo pass (one
-                # drift report + one deduped tracker), so unlike per-repo
-                # cleanup it gets exactly one command with the reachable repos
-                # as --repo flags. --apply runs the conservative host-local +
-                # TTL-gated auto-fixes; backgrounded like cleanup so its gh
-                # calls never stall the 30s tick or race a live pane.
+                # cleanup --gh is GLOBAL stale-label reaping — run it only on
+                # the authoritative poller (leader, or a follower currently
+                # self-polling), else every follower re-multiplies the very
+                # mutation calls Q2 exists to collapse (#1394). reconcile
+                # --apply is conservative host-local + TTL-gated claim hygiene
+                # and runs on EVERY host (one multi-repo pass — one drift report
+                # + one deduped tracker — with the reachable repos as --repo
+                # flags). All backgrounded so their gh calls never stall the 30s
+                # tick or race a live pane.
+                sweep_cmds = []
+                if authoritative:
+                    sweep_cmds.append(
+                        ["fleet-claim", "cleanup", "--gh",
+                         "--repo", "jakildev/IrredenEngine"])
                 reconcile_cmd = ["fleet-claim", "reconcile", "--apply",
                                  "--repo", "jakildev/IrredenEngine"]
                 if (GAME / ".git").exists():
-                    sweep_cmds.append(
-                        ["fleet-claim", "--repo", "game", "cleanup",
-                         "--gh", "--repo", "jakildev/irreden"]
-                    )
+                    if authoritative:
+                        sweep_cmds.append(
+                            ["fleet-claim", "--repo", "game", "cleanup",
+                             "--gh", "--repo", "jakildev/irreden"])
                     reconcile_cmd += ["--repo", "jakildev/irreden"]
                 sweep_cmds.append(reconcile_cmd)
                 for sweep_cmd in sweep_cmds:
@@ -2541,9 +2638,17 @@ def tick_once():
                         )
                     except Exception as e:
                         log(f"queue-manager: sweep failed to spawn {sweep_cmd[0]}: {e}")
-                log("queue-manager: spawned claim cleanup + reconcile (projection changed)")
+                _swept = "cleanup + reconcile" if authoritative else "reconcile"
+                log(f"queue-manager: spawned {_swept} (projection changed)")
                 triggers_fired.append("queue-manager(claim-cleanup)")
         elif role == "queue-manager-ingest":
+            # ingest (human:approved → fleet:queued) is a GLOBAL label mutation
+            # — authoritative-poller-only, like cleanup above. A follower
+            # consuming the leader's bundle skips it entirely so N hosts don't
+            # race the same ingest (#1394 Q2); the leader (or a self-polling
+            # follower) owns it.
+            if not authoritative:
+                continue
             # Auto-fire ingestion when the human:approved-and-not-yet-queued
             # set changes. Same backgrounded-subprocess pattern as the
             # queue-manager claim-cleanup spawn above. Lockfile inside
@@ -2586,6 +2691,15 @@ def tick_once():
             json.dumps(sliced, indent=2, sort_keys=True) + "\n",
         )
 
+    # Refresh the served bundle (leader only) so followers see this tick's
+    # snapshot. Rebuilt from disk — state.json + the detail caches just written
+    # — so a follower always receives the last COMPLETE tick, never a mid-write
+    # splice. build_bundle returns (None, b"") until the first tick lands.
+    if LEADER_SERVER is not None:
+        _etag, _payload = fleet_poll_topology.build_bundle(STATE_DIR)
+        if _etag is not None:
+            LEADER_SERVER.update_bundle(_etag, _payload)
+
     if triggers_fired:
         log(f"triggered: {', '.join(triggers_fired)}")
     else:
@@ -2610,6 +2724,7 @@ def signal_handler(signum, _frame):
 
 
 def main():
+    global POLL_CFG, LEADER_SERVER
     parser = argparse.ArgumentParser(
         description="poll GitHub + git, write shared fleet state cache")
     parser.add_argument("--once", action="store_true",
@@ -2631,7 +2746,15 @@ def main():
         log(f"engine repo not found at {ENGINE}; aborting")
         sys.exit(1)
 
+    # Resolve leader/follower topology once from host.toml (#1394 Q2). Missing
+    # config → leader, so a single-host box is an unchanged solo poller.
+    POLL_CFG = fleet_poll_topology.read_poll_config()
+    log(f"poll topology: {POLL_CFG.describe()}")
+
     if args.once:
+        # One-shot (tests / manual): tick without standing up the HTTP server.
+        # A leader ticks + writes; a follower fetches the leader's bundle once
+        # (or self-polls if unreachable). No serving, no daemon loop.
         tick_once()
         return
 
@@ -2640,6 +2763,17 @@ def main():
 
     write_pid_file()
     log(f"started (pid={os.getpid()}, interval={args.interval}s)")
+
+    if POLL_CFG.is_leader:
+        # Serve the state bundle to followers on the LAN. A bind failure is a
+        # safe degradation: the leader still polls + writes locally; followers
+        # just can't reach it and self-poll. Never crash the scout for it.
+        LEADER_SERVER = fleet_poll_topology.start_leader_server(POLL_CFG, STATE_DIR)
+        if LEADER_SERVER is not None:
+            log(f"leader HTTP server listening on {POLL_CFG.bind_host}:{POLL_CFG.port}")
+        else:
+            log(f"leader HTTP server could not bind :{POLL_CFG.port} — "
+                "followers will self-poll (scout continues)")
 
     try:
         while not TERMINATE.is_set():
@@ -2655,6 +2789,8 @@ def main():
                     break
                 time.sleep(1)
     finally:
+        if LEADER_SERVER is not None:
+            LEADER_SERVER.stop()
         cleanup_pid_file()
         log("stopped")
 

--- a/scripts/fleet/fleet-up
+++ b/scripts/fleet/fleet-up
@@ -1100,6 +1100,23 @@ else
     disown
     echo "fleet-up: launched fleet-state-scout (pid $!, log $scout_log)"
 
+    # Surface the Q2 cross-device poll topology (#1394): leader polls GitHub +
+    # serves its state bundle on the LAN; follower consumes a leader's bundle
+    # (zero GitHub reads while reachable). The scout logs the authoritative
+    # value to $scout_log; this is the operator banner.
+    _host_toml="$HOME/.config/irreden/host.toml"
+    _poll_role="leader"
+    if [[ -f "$_host_toml" ]]; then
+        _r=$(sed -n "s/^[[:space:]]*poll_role[[:space:]]*=[[:space:]]*[\"']\{0,1\}\([a-zA-Z]*\).*/\1/p" "$_host_toml" | head -1)
+        [[ -n "$_r" ]] && _poll_role="$_r"
+    fi
+    if [[ "$_poll_role" == "follower" ]]; then
+        echo "fleet-up: scout poll role: follower (consumes a leader's LAN bundle; zero GitHub reads while the leader is reachable)"
+    else
+        echo "fleet-up: scout poll role: leader (polls GitHub; serves the state bundle to LAN followers on its poll_port)"
+    fi
+    unset _host_toml _r _poll_role
+
     # Wait for scout's first tick so panes find a populated state.json
     # on startup. Without this wait, every pane's "scout cache stale
     # or missing" diagnostic fires until the first tick lands.

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -22,6 +22,30 @@
 # /etc/nsswitch.conf, or `export HOME=/c/Users/you`). See docs/agents/FLEET.md
 # "Cross-platform parity".
 
+# --- Cross-device polling (host.toml, NOT this file) -------------------------
+#
+# Multi-host fleets (e.g. a home desktop + a laptop on the same GitHub account)
+# share one GitHub poller instead of N (#1394 Q2), so idle-fleet API quota drain
+# stays at 1×. This is configured in ~/.config/irreden/host.toml (per-host, read
+# by fleet-state-scout at startup), NOT here — documented here as the operator's
+# one config surface. Add a [fleet] section:
+#
+#   [fleet]
+#   poll_role = "leader"     # polls GitHub + serves its state bundle on the LAN
+#   poll_port = 8477         # the leader's one inbound TCP port
+#
+#   # on every OTHER host on the same account:
+#   [fleet]
+#   poll_role  = "follower"  # consumes the leader's bundle over the LAN, zero gh
+#   poll_port  = 8477        # must match the leader's
+#   leader_host = "192.168.1.10"   # the leader's LAN address/hostname (required)
+#
+# Exactly ONE host per account is the leader. Missing [fleet] / missing file =>
+# leader (a single-host fleet is unchanged). A follower that can't reach the
+# leader (off-LAN, or the leader is down) transparently self-polls GitHub for
+# that tick, so it always keeps working. See docs/agents/FLEET-CACHE.md
+# "Centralized cross-device polling".
+
 # --- Model classes -----------------------------------------------------------
 #
 # Work routes by model class — fable | opus | sonnet — carried on each task

--- a/scripts/fleet/fleet_gh_poll.py
+++ b/scripts/fleet/fleet_gh_poll.py
@@ -231,3 +231,43 @@ def _request(url, cache_path, cached_etag, cached_body, accept, token,
         return (True, None)
     except (urllib.error.URLError, TimeoutError, OSError):
         return (True, None)
+
+
+def conditional_get_url(url, *, etag=None, timeout=DEFAULT_TIMEOUT_SECONDS,
+                        headers=None):
+    """Plain If-None-Match GET against an arbitrary URL (no GitHub auth).
+
+    The Q2 centralized poller (#1394 phase 2) uses this for the intra-fleet LAN
+    hop: a follower conditional-GETs the leader's served state bundle, passing
+    the last-seen `generated_at` as the ETag. It reuses conditional_get's
+    machinery — If-None-Match, "an error is never 304" — but drops the two
+    GitHub-specific pieces (`gh auth token`, the api.github.com URL builder) and
+    the on-disk etag cache: the follower already tracks the last `generated_at`
+    in its own state.json, so a second cache would just duplicate it.
+
+    Returns (status, body, new_etag):
+      * (200, body_str, etag) — changed: fresh body + its response ETag.
+      * (304, None, sent_etag) — unchanged: caller keeps its cached copy (the
+                                 ETag it sent is echoed back for convenience).
+      * (None, None, None)     — network / HTTP error / unreachable: caller
+                                 degrades (self-poll). An error is never a 304.
+    """
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("User-Agent", USER_AGENT)
+    if headers:
+        for key, value in headers.items():
+            req.add_header(key, value)
+    if etag:
+        req.add_header("If-None-Match", etag)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8")
+            return (resp.status, body, resp.headers.get("ETag"))
+    except urllib.error.HTTPError as e:
+        code = e.code
+        e.close()
+        if code == 304:
+            return (304, None, etag)
+        return (None, None, None)
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return (None, None, None)

--- a/scripts/fleet/fleet_poll_topology.py
+++ b/scripts/fleet/fleet_poll_topology.py
@@ -219,6 +219,25 @@ def now_epoch():
     return calendar.timegm(time.gmtime())
 
 
+def state_age_seconds(generated_at, mtime, now=None):
+    """Seconds since a state.json snapshot was produced.
+
+    Prefer the in-file `generated_at` (the true snapshot time) over file
+    mtime. Under #1394 Q2 centralized polling a follower rewrites state.json
+    every tick while preserving the LEADER's `generated_at`, so a dead leader
+    keeps a follower's mtime fresh while `generated_at` freezes — judging by
+    mtime alone would report a healthy-but-lying scout. Fall back to `mtime`
+    only when `generated_at` is missing/unparseable (a malformed snapshot),
+    preserving the pre-Q2 behavior for that case. `now` is injectable for
+    tests (defaults to wall-clock epoch).
+    """
+    ref = now if now is not None else time.time()
+    epoch = parse_generated_at(generated_at)
+    if epoch is not None:
+        return ref - epoch
+    return ref - mtime
+
+
 # --- Bundle build / parse / apply ------------------------------------------
 
 

--- a/scripts/fleet/fleet_poll_topology.py
+++ b/scripts/fleet/fleet_poll_topology.py
@@ -1,0 +1,492 @@
+"""Centralized cross-device polling topology (#1394 Q2) — leader / follower.
+
+The fleet's steady-state GitHub quota drain is the scout's per-tick list
+fetches, multiplied by N hosts (#1394). Q1 (`fleet_gh_poll`) made each host's
+own polling conditional; Q2 collapses the N hosts into **one authoritative
+poller** (the *leader*) plus N-1 *followers* that consume the leader's
+already-fetched `~/.fleet/state/` over the LAN instead of calling `gh`
+themselves. Idle-fleet GitHub traffic drops from N× to 1×.
+
+Mechanism — follower-pull over a leader-served HTTP endpoint:
+  * The leader polls GitHub exactly as before and additionally serves a
+    read-only bundle of the shareable state artifacts (state.json + the
+    prs/ diffs/ issues/ detail caches) with the snapshot's `generated_at`
+    as the ETag.
+  * A follower conditional-GETs that endpoint (reusing Q1's If-None-Match
+    machinery via `fleet_gh_poll.conditional_get_url`), unpacks the bundle,
+    and re-derives only the host-local fields (`clone_freshness`,
+    `repos.<key>.path`) — **preserving the leader's `generated_at` verbatim**
+    so a dead leader's frozen timestamp trips every consumer's existing
+    staleness guard.
+  * A follower that can't reach the leader (off-LAN, or the leader is dead or
+    wedged with a stale `generated_at`) transparently self-polls GitHub for
+    that tick — a temporary N=1 solo poller, exactly the pre-Q2 behavior.
+
+Design invariants:
+  * **Only GitHub-derived data is shareable.** The bundle carries the exact
+    reads that multiply per host; host-local artifacts (clone path,
+    clone_freshness, seen-hashes/, triggers/) are recomputed on the follower,
+    never copied.
+  * **Never restamp `generated_at` on a follower.** It is the liveness signal;
+    the follower copies the leader's value so a frozen leader is detectable.
+  * stdlib-only (`http.server`, `urllib`, optional `tomllib`) — no new
+    dependency, runs in-process in the already-Python scout on mac / WSL2 /
+    native-Windows alike.
+
+Source of truth: scripts/fleet/fleet_poll_topology.py in the engine repo.
+Co-located with fleet-state-scout so the scout's `sys.path.insert(script dir)`
+import resolves (same proven path as fleet_gh_poll.py / fleet_blocked_by.py).
+"""
+import calendar
+import json
+import os
+import socketserver
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from fleet_gh_poll import conditional_get_url
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11 (defensive; the fleet runs 3.11+)
+    tomllib = None
+
+# Static config surface, shared with fleet-claim's host identity + setup-windows.
+HOST_TOML = Path.home() / ".config" / "irreden" / "host.toml"
+
+DEFAULT_POLL_PORT = 8477
+# A follower whose consumed `generated_at` ages past this self-polls GitHub for
+# that tick. Kept above the scout's 30 s interval and below the 120 s dispatcher
+# watchdog so a wedged (alive-but-not-ticking) leader is caught before the
+# dispatcher declares the whole scout dead.
+DEFAULT_LEADER_STALE_SECONDS = 90
+DEFAULT_BIND_HOST = "0.0.0.0"  # LAN-reachable; the endpoint is read-only state
+# The LAN hop is sub-second when the leader is up; a short timeout means an
+# unreachable leader (laptop off-LAN — no route, so the connect TIMES OUT rather
+# than refusing) fails fast into a self-poll instead of stalling the 30 s tick.
+LEADER_FETCH_TIMEOUT_SECONDS = 5
+
+# Shareable `~/.fleet/state/` artifacts the leader serves and the follower
+# mirrors. state.json rides separately (the follower overlays host-local fields
+# onto it). Projections are NOT bundled: they are a deterministic, host-agnostic
+# function of state.json, so the follower recomputes them via its own slicer
+# pass (which it must run anyway to fire its host-local triggers) rather than
+# shipping redundant copies. seen-hashes/ triggers/ scout.pid etag/ are
+# host-local and never shared.
+STATE_FILE_NAME = "state.json"
+SHAREABLE_SUBDIRS = ("prs", "diffs", "issues")
+
+
+# --- Poll config (host.toml [fleet] section) -------------------------------
+
+
+class PollConfig:
+    def __init__(self, role, port, leader_host, leader_stale_seconds,
+                 bind_host=DEFAULT_BIND_HOST):
+        self.role = role
+        self.port = port
+        self.leader_host = leader_host
+        self.leader_stale_seconds = leader_stale_seconds
+        self.bind_host = bind_host
+
+    @property
+    def is_leader(self):
+        return self.role == "leader"
+
+    @property
+    def is_follower(self):
+        return self.role == "follower"
+
+    def describe(self):
+        if self.is_leader:
+            return f"leader (serving :{self.port})"
+        return (f"follower (leader={self.leader_host or 'UNSET'}:{self.port}, "
+                f"stale>{self.leader_stale_seconds}s -> self-poll)")
+
+
+def _coerce(raw):
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+        return raw[1:-1]
+    if raw.lower() in ("true", "false"):
+        return raw.lower() == "true"
+    try:
+        return int(raw)
+    except ValueError:
+        return raw
+
+
+def _minimal_toml(text):
+    # Fallback for interpreters without tomllib (< 3.11). host.toml is flat
+    # `[section]` + `key = value`, so a line parser suffices — no arrays/nested
+    # tables. Naive `#`-comment stripping is fine here (values are bare words /
+    # numbers / simple quoted strings, never a `#` inside a string).
+    out, section = {}, None
+    for line in text.splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            out.setdefault(section, {})
+            continue
+        if section is None or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        out[section][key.strip()] = _coerce(value)
+    return out
+
+
+def _read_toml(path):
+    try:
+        raw = Path(path).read_bytes()
+    except (FileNotFoundError, OSError):
+        return {}
+    text = raw.decode("utf-8", "replace")
+    if tomllib is not None:
+        try:
+            return tomllib.loads(text)
+        except (tomllib.TOMLDecodeError, ValueError):
+            return {}
+    return _minimal_toml(text)
+
+
+def _as_int(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def read_poll_config(config_path=None):
+    """Parse the `[fleet]` section of host.toml into a PollConfig.
+
+    Missing file / missing section / unknown role all resolve to the safe
+    default: `leader`. A single-host box with no host.toml (the common case,
+    and every pre-Q2 install) is therefore an unchanged solo poller.
+    """
+    data = _read_toml(config_path or HOST_TOML)
+    fleet = data.get("fleet", {}) if isinstance(data, dict) else {}
+    if not isinstance(fleet, dict):
+        fleet = {}
+    role = str(fleet.get("poll_role", "leader")).strip().lower()
+    if role not in ("leader", "follower"):
+        role = "leader"
+    return PollConfig(
+        role=role,
+        port=_as_int(fleet.get("poll_port"), DEFAULT_POLL_PORT),
+        leader_host=(fleet.get("leader_host") or None),
+        leader_stale_seconds=_as_int(
+            fleet.get("leader_stale_seconds"), DEFAULT_LEADER_STALE_SECONDS),
+    )
+
+
+# --- generated_at staleness ------------------------------------------------
+
+
+def parse_generated_at(ts):
+    """Parse a scout `YYYY-MM-DDTHH:MM:SSZ` UTC stamp to epoch seconds.
+
+    None on missing/malformed input (callers treat None as "stale").
+    """
+    if not ts or not isinstance(ts, str):
+        return None
+    try:
+        return calendar.timegm(time.strptime(ts, "%Y-%m-%dT%H:%M:%SZ"))
+    except (ValueError, TypeError):
+        return None
+
+
+def generated_at_of(state_text):
+    try:
+        return json.loads(state_text).get("generated_at")
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        return None
+
+
+def is_stale(generated_at, now_epoch, window_seconds):
+    """True if `generated_at` is missing/unparseable or older than the window."""
+    epoch = parse_generated_at(generated_at)
+    if epoch is None:
+        return True
+    return (now_epoch - epoch) > window_seconds
+
+
+def now_epoch():
+    return calendar.timegm(time.gmtime())
+
+
+# --- Bundle build / parse / apply ------------------------------------------
+
+
+def _quote_etag(generated_at):
+    # A strong validator: the follower echoes it back verbatim in
+    # If-None-Match, and we compare raw strings on the leader, so the exact
+    # quoting only has to round-trip — not satisfy a strict cache.
+    return f'"{generated_at}"'
+
+
+def build_bundle(state_dir):
+    """Read the shareable state artifacts off disk into a serialized bundle.
+
+    Returns (etag, payload_bytes). etag is the state.json `generated_at`
+    (quoted); payload is `{"generated_at", "files": {relpath: text}}` JSON.
+    Returns (None, b"") when state.json is missing/unparseable (the leader
+    hasn't completed a tick yet) so the server answers 503 rather than lying.
+    """
+    state_dir = Path(state_dir)
+    try:
+        state_text = (state_dir / STATE_FILE_NAME).read_text()
+    except (FileNotFoundError, OSError):
+        return (None, b"")
+    generated_at = generated_at_of(state_text)
+    if not generated_at:
+        return (None, b"")
+
+    files = {STATE_FILE_NAME: state_text}
+    for sub in SHAREABLE_SUBDIRS:
+        root = state_dir / sub
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            try:
+                files[path.relative_to(state_dir).as_posix()] = path.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+    payload = json.dumps(
+        {"generated_at": generated_at, "files": files}).encode("utf-8")
+    return (_quote_etag(generated_at), payload)
+
+
+def parse_bundle(payload):
+    """Parse a served bundle body into {"generated_at", "files"}.
+
+    Raises ValueError / json.JSONDecodeError on a malformed payload so the
+    caller degrades to self-poll rather than unpacking garbage.
+    """
+    text = payload if isinstance(payload, str) else payload.decode("utf-8")
+    data = json.loads(text)
+    if not isinstance(data, dict) or not isinstance(data.get("files"), dict):
+        raise ValueError("bundle missing a 'files' object")
+    return {"generated_at": data.get("generated_at"), "files": data["files"]}
+
+
+def _atomic_write_text(path, text):
+    # Unique-temp + os.replace, mirroring fleet-state-scout.write_atomic. Kept
+    # inline (not imported from the scout) so this module stays standalone and
+    # unit-testable without loading the 2.6k-line scout.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent), prefix="." + path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def apply_bundle_detail_caches(state_dir, files):
+    """Sync the prs/ diffs/ issues/ detail caches from a bundle to disk.
+
+    Writes every bundled detail file and prunes local files the bundle no
+    longer carries, so a follower's caches stay byte-identical to the leader's
+    (mirroring the leader's own GC). state.json and projections are handled by
+    the caller's tick tail, not here.
+    """
+    state_dir = Path(state_dir)
+    wanted = {sub: set() for sub in SHAREABLE_SUBDIRS}
+    for rel, content in files.items():
+        top = rel.split("/", 1)[0]
+        if top in wanted:
+            wanted[top].add(rel)
+            _atomic_write_text(state_dir / rel, content)
+    for sub in SHAREABLE_SUBDIRS:
+        root = state_dir / sub
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and \
+                    path.relative_to(state_dir).as_posix() not in wanted[sub]:
+                path.unlink(missing_ok=True)
+
+
+def overlay_host_local(leader_state, *, engine_path, game_path, clone_freshness):
+    """Return the leader's resolved state with host-local fields swapped for
+    THIS host's. `generated_at` and every GitHub-derived field are preserved
+    verbatim (the follower must not restamp); only `repos.<key>.path` and
+    `clone_freshness` are re-derived locally (the leader's are wrong here).
+    """
+    state = dict(leader_state)
+    repos = {key: dict(val) for key, val in state.get("repos", {}).items()}
+    if "engine" in repos:
+        repos["engine"]["path"] = str(engine_path)
+    if "game" in repos and game_path is not None:
+        repos["game"]["path"] = str(game_path)
+    state["repos"] = repos
+    state["clone_freshness"] = clone_freshness
+    return state
+
+
+# --- Leader HTTP server -----------------------------------------------------
+
+
+class _BundleServer(ThreadingHTTPServer):
+    daemon_threads = True  # worker threads never block shutdown()
+    allow_reuse_address = True  # re-bind fast across scout restarts
+
+    def server_bind(self):
+        # Skip HTTPServer.server_bind's socket.getfqdn() reverse-DNS lookup: on
+        # a host whose resolver has no PTR for the bind address (observed
+        # binding 0.0.0.0 on macOS) it blocks ~30s, which would stall the whole
+        # scout startup. We never use server_name, so bind via the grandparent
+        # (TCPServer) and stamp the fields directly.
+        socketserver.TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = host
+        self.server_port = port
+
+    def __init__(self, addr, handler):
+        super().__init__(addr, handler)
+        self._lock = threading.Lock()
+        self._etag = None
+        self._payload = b""
+
+    def set_bundle(self, etag, payload):
+        with self._lock:
+            self._etag, self._payload = etag, payload
+
+    def get_bundle(self):
+        with self._lock:
+            return self._etag, self._payload
+
+
+class _BundleHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        etag, payload = self.server.get_bundle()
+        if etag is None:
+            self.send_response(503)  # leader hasn't produced a snapshot yet
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if self.headers.get("If-None-Match") == etag:
+            self.send_response(304)
+            self.send_header("ETag", etag)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("ETag", etag)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_HEAD(self):
+        # Cheap liveness probe (curl -I): headers only, same ETag semantics.
+        etag, payload = self.server.get_bundle()
+        code = 503 if etag is None else 200
+        self.send_response(code)
+        if etag is not None:
+            self.send_header("ETag", etag)
+            self.send_header("Content-Length", str(len(payload)))
+        else:
+            self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *_args):
+        # Silence per-request stderr spam; the scout logs its own tick lines.
+        return
+
+
+class LeaderServer:
+    """Daemon-thread HTTP server that serves the current state bundle.
+
+    `update_bundle` is called by the leader at the end of each tick with the
+    freshly-built snapshot; the handler serves whatever the latest update set,
+    so a mid-tick request always gets the last *complete* snapshot.
+    """
+
+    def __init__(self, port, bind_host=DEFAULT_BIND_HOST):
+        self._httpd = _BundleServer((bind_host, port), _BundleHandler)
+        self._thread = None
+
+    def update_bundle(self, etag, payload):
+        self._httpd.set_bundle(etag, payload)
+
+    def start(self):
+        self._thread = threading.Thread(
+            target=self._httpd.serve_forever,
+            name="fleet-leader-http", daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        try:
+            self._httpd.shutdown()
+        except Exception:
+            pass
+        try:
+            self._httpd.server_close()
+        except Exception:
+            pass
+
+
+def start_leader_server(cfg, state_dir):
+    """Build the initial bundle (if a snapshot already exists) and start the
+    server. Returns the LeaderServer, or None if the port can't be bound (the
+    leader still polls + writes locally; followers just can't reach it and
+    self-poll — a safe degradation, never a scout crash).
+    """
+    try:
+        server = LeaderServer(cfg.port, cfg.bind_host)
+    except OSError:
+        return None
+    etag, payload = build_bundle(state_dir)
+    if etag is not None:
+        server.update_bundle(etag, payload)
+    server.start()
+    return server
+
+
+# --- Follower fetch ---------------------------------------------------------
+
+
+def fetch_from_leader(cfg, prev_etag, *, getter=None):
+    """Conditional-GET the leader's bundle over the LAN.
+
+    `getter` is injectable for tests (defaults to conditional_get_url).
+    Returns (status, etag, files):
+      * (200, new_etag, files_dict) — fresh bundle.
+      * (304, prev_etag, None)      — unchanged; caller reuses its on-disk copy.
+      * (None, prev_etag, None)     — unreachable / error / no leader_host /
+                                      malformed bundle: caller self-polls.
+    """
+    if not cfg.leader_host:
+        return (None, prev_etag, None)
+    url = f"http://{cfg.leader_host}:{cfg.port}/state"
+    get = getter or conditional_get_url
+    status, body, etag = get(
+        url, etag=prev_etag, timeout=LEADER_FETCH_TIMEOUT_SECONDS)
+    if status == 200 and body is not None:
+        try:
+            bundle = parse_bundle(body)
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+            return (None, prev_etag, None)
+        return (200, etag or _quote_etag(bundle.get("generated_at")),
+                bundle["files"])
+    if status == 304:
+        return (304, prev_etag, None)
+    return (None, prev_etag, None)

--- a/scripts/fleet/setup-windows.sh
+++ b/scripts/fleet/setup-windows.sh
@@ -117,6 +117,18 @@ budget = $FLEET_CPU_BUDGET
 [concurrency]
 workers = $FLEET_BUILD_WORKERS
 queue_timeout_seconds = 600
+
+[fleet]
+# Centralized cross-device polling (#1394 Q2). "leader" polls GitHub and serves
+# its ~/.fleet/state bundle to followers on the LAN; "follower" consumes the
+# leader's bundle over the LAN instead of calling gh (set leader_host to the
+# leader's LAN address/hostname). Exactly ONE host per GitHub account should be
+# the leader; a single-host fleet is a leader. The leader opens one inbound TCP
+# port (poll_port) on the LAN.
+poll_role = "leader"
+poll_port = 8477
+# poll_role = "follower"
+# leader_host = "192.168.1.10"   # required on a follower
 EOF
 if [[ "$FLEET_CPU_BUDGET" == "auto" ]]; then
     echo "  cpu budget=auto (nproc=$(nproc))  workers=$FLEET_BUILD_WORKERS  (per_build_max=$(( $(nproc) / FLEET_BUILD_WORKERS )))"

--- a/scripts/fleet/tests/test_poll_topology.py
+++ b/scripts/fleet/tests/test_poll_topology.py
@@ -1,0 +1,309 @@
+"""Tests for the #1394 Q2 centralized-polling topology.
+
+Two layers:
+  * fleet_poll_topology unit tests — config parse, generated_at staleness,
+    bundle build/parse/apply, host-local overlay, and a real leader-server ↔
+    follower-fetch HTTP round-trip (200 / 304 / leader-down).
+  * fleet-state-scout integration — build_state()'s leader vs follower routing:
+    a follower serving a bundle makes ZERO GitHub calls (collect_state is never
+    invoked), preserves the leader's generated_at, swaps in host-local fields,
+    and falls back to a GitHub self-poll when the leader is unreachable or its
+    generated_at has gone stale.
+
+stdlib-only; the HTTP round-trip binds 127.0.0.1:0 (ephemeral) — no network.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_HERE = Path(__file__).resolve().parent
+_FLEET = _HERE.parent
+if str(_FLEET) not in os.sys.path:
+    os.sys.path.insert(0, str(_FLEET))
+
+import fleet_poll_topology as T  # noqa: E402
+
+
+def _load_scout():
+    loader = importlib.machinery.SourceFileLoader(
+        "fleet_state_scout", str(_FLEET / "fleet-state-scout"))
+    spec = importlib.util.spec_from_loader("fleet_state_scout", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+def _stamp(offset_seconds=0):
+    return time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(T.now_epoch() - offset_seconds))
+
+
+# --- fleet_poll_topology --------------------------------------------------
+
+
+class TestPollConfig(unittest.TestCase):
+
+    def test_missing_file_is_leader(self):
+        cfg = T.read_poll_config("/no/such/host.toml")
+        self.assertTrue(cfg.is_leader)
+        self.assertEqual(cfg.port, T.DEFAULT_POLL_PORT)
+
+    def test_follower_section_parsed(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as f:
+            f.write('[cpu]\nbudget = 8\n\n[fleet]\n'
+                    'poll_role = "follower"\npoll_port = 9001\n'
+                    'leader_host = "10.0.0.2"\nleader_stale_seconds = 45\n')
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        cfg = T.read_poll_config(path)
+        self.assertTrue(cfg.is_follower)
+        self.assertEqual(cfg.port, 9001)
+        self.assertEqual(cfg.leader_host, "10.0.0.2")
+        self.assertEqual(cfg.leader_stale_seconds, 45)
+
+    def test_unknown_role_falls_back_to_leader(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as f:
+            f.write('[fleet]\npoll_role = "captain"\n')
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        self.assertTrue(T.read_poll_config(path).is_leader)
+
+    def test_minimal_parser_matches_tomllib(self):
+        # Force the < 3.11 fallback path and confirm it parses identically.
+        with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as f:
+            f.write('[fleet]\npoll_role = "follower"\n'
+                    'poll_port = 8477  # inline comment\nleader_host = "host.lan"\n')
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        with patch.object(T, "tomllib", None):
+            cfg = T.read_poll_config(path)
+        self.assertTrue(cfg.is_follower)
+        self.assertEqual(cfg.port, 8477)
+        self.assertEqual(cfg.leader_host, "host.lan")
+
+
+class TestStaleness(unittest.TestCase):
+
+    def test_fresh_not_stale(self):
+        self.assertFalse(T.is_stale(_stamp(10), T.now_epoch(), 90))
+
+    def test_old_is_stale(self):
+        self.assertTrue(T.is_stale(_stamp(500), T.now_epoch(), 90))
+
+    def test_missing_or_garbage_is_stale(self):
+        now = T.now_epoch()
+        self.assertTrue(T.is_stale(None, now, 90))
+        self.assertTrue(T.is_stale("not-a-date", now, 90))
+
+    def test_parse_generated_at(self):
+        self.assertIsNone(T.parse_generated_at("garbage"))
+        self.assertIsInstance(T.parse_generated_at("2026-07-04T16:00:00Z"), int)
+
+
+class TestBundle(unittest.TestCase):
+
+    def _leader_dir(self, generated_at="2026-07-04T16:00:00Z"):
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        (d / "state.json").write_text(json.dumps(
+            {"generated_at": generated_at, "repos": {"engine": {"path": "/leader"}}}))
+        (d / "prs" / "engine").mkdir(parents=True)
+        (d / "prs" / "engine" / "2227.json").write_text('{"number": 2227}')
+        (d / "issues" / "engine").mkdir(parents=True)
+        (d / "issues" / "engine" / "2220.json").write_text('{"number": 2220}')
+        return d
+
+    def test_build_parse_roundtrip(self):
+        d = self._leader_dir()
+        etag, payload = T.build_bundle(d)
+        self.assertEqual(etag, '"2026-07-04T16:00:00Z"')
+        bundle = T.parse_bundle(payload)
+        self.assertEqual(bundle["generated_at"], "2026-07-04T16:00:00Z")
+        self.assertEqual(
+            sorted(bundle["files"]),
+            ["issues/engine/2220.json", "prs/engine/2227.json", "state.json"])
+
+    def test_missing_state_json_is_no_bundle(self):
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        self.assertEqual(T.build_bundle(d), (None, b""))
+
+    def test_apply_writes_and_prunes(self):
+        d = self._leader_dir()
+        _etag, payload = T.build_bundle(d)
+        files = T.parse_bundle(payload)["files"]
+        follower = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(follower, ignore_errors=True))
+        # A stale cache file the bundle no longer carries must be pruned.
+        (follower / "prs" / "engine").mkdir(parents=True)
+        (follower / "prs" / "engine" / "9999.json").write_text("{}")
+        T.apply_bundle_detail_caches(follower, files)
+        self.assertEqual(
+            sorted(p.name for p in (follower / "prs" / "engine").glob("*.json")),
+            ["2227.json"])
+        self.assertTrue((follower / "issues" / "engine" / "2220.json").exists())
+
+    def test_overlay_preserves_generated_at_swaps_host_local(self):
+        leader_state = {"generated_at": "2026-07-04T16:00:00Z",
+                        "repos": {"engine": {"path": "/leader/eng", "prs": [1]}}}
+        out = T.overlay_host_local(
+            leader_state, engine_path="/follower/eng", game_path=None,
+            clone_freshness={"fresh": True, "behind": 0})
+        self.assertEqual(out["generated_at"], "2026-07-04T16:00:00Z")
+        self.assertEqual(out["repos"]["engine"]["path"], "/follower/eng")
+        self.assertEqual(out["repos"]["engine"]["prs"], [1])  # data untouched
+        self.assertEqual(out["clone_freshness"]["fresh"], True)
+        # original leader_state must not be mutated in place
+        self.assertEqual(leader_state["repos"]["engine"]["path"], "/leader/eng")
+
+
+class TestLeaderFollowerHTTP(unittest.TestCase):
+
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.d, ignore_errors=True))
+        (self.d / "state.json").write_text(json.dumps(
+            {"generated_at": "2026-07-04T16:10:00Z", "repos": {"engine": {"path": "/l"}}}))
+        self.srv = T.LeaderServer(0, "127.0.0.1")
+        self.addCleanup(self.srv.stop)
+        self.port = self.srv._httpd.server_address[1]
+        self.srv.update_bundle(*T.build_bundle(self.d))
+        self.srv.start()
+        self.cfg = T.PollConfig("follower", self.port, "127.0.0.1", 90)
+
+    def test_200_then_304_then_200_after_tick(self):
+        status, etag, files = T.fetch_from_leader(self.cfg, None)
+        self.assertEqual(status, 200)
+        self.assertIn("state.json", files)
+
+        # Same etag → 304, no body (the zero-cost unchanged poll).
+        status2, _etag2, files2 = T.fetch_from_leader(self.cfg, etag)
+        self.assertEqual(status2, 304)
+        self.assertIsNone(files2)
+
+        # Leader ticks (new generated_at → new etag) → 200 again.
+        (self.d / "state.json").write_text(json.dumps(
+            {"generated_at": "2026-07-04T16:10:30Z", "repos": {"engine": {"path": "/l"}}}))
+        self.srv.update_bundle(*T.build_bundle(self.d))
+        status3, _etag3, files3 = T.fetch_from_leader(self.cfg, etag)
+        self.assertEqual(status3, 200)
+        self.assertEqual(
+            json.loads(files3["state.json"])["generated_at"], "2026-07-04T16:10:30Z")
+
+    def test_leader_down_returns_none(self):
+        self.srv.stop()
+        time.sleep(0.1)
+        status, _etag, files = T.fetch_from_leader(self.cfg, None)
+        self.assertIsNone(status)
+        self.assertIsNone(files)
+
+    def test_no_leader_host_returns_none(self):
+        cfg = T.PollConfig("follower", self.port, None, 90)
+        self.assertEqual(T.fetch_from_leader(cfg, None)[0], None)
+
+
+# --- fleet-state-scout build_state() routing ------------------------------
+
+
+class TestScoutBuildState(unittest.TestCase):
+
+    def setUp(self):
+        self.scout = _load_scout()
+        self.state_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(
+            lambda: __import__("shutil").rmtree(self.state_dir, ignore_errors=True))
+        # Redirect all scout state paths into the temp dir.
+        self.scout.STATE_DIR = self.state_dir
+        self.scout.STATE_FILE = self.state_dir / "state.json"
+        self.scout.ENGINE = self.state_dir / "engine"  # non-git → clone_freshness fresh
+        self.scout.GAME = self.state_dir / "game"       # no .git → game_path None
+        # A distinctive collect_state stand-in so we can assert whether GitHub
+        # was polled (its presence in the result == a self-poll / leader tick).
+        self._collect = MagicMock(return_value={"generated_at": _stamp(0),
+                                                 "repos": {"engine": {"path": "SELF"}}})
+        self.scout.collect_state = self._collect
+
+    def test_leader_polls_github(self):
+        self.scout.POLL_CFG = T.PollConfig("leader", 8477, None, 90)
+        state, served = self.scout.build_state()
+        self.assertFalse(served)
+        self._collect.assert_called_once()
+        self.assertEqual(state["repos"]["engine"]["path"], "SELF")
+
+    def test_none_cfg_polls_github(self):
+        self.scout.POLL_CFG = None
+        _state, served = self.scout.build_state()
+        self.assertFalse(served)
+        self._collect.assert_called_once()
+
+    def test_follower_consumes_bundle_zero_github(self):
+        self.scout.POLL_CFG = T.PollConfig("follower", 8477, "leader.lan", 90)
+        leader_state = {"generated_at": _stamp(5),
+                        "repos": {"engine": {"path": "/leader/eng", "prs": [{"number": 1}]}}}
+        files = {"state.json": json.dumps(leader_state),
+                 "prs/engine/1.json": '{"number": 1}'}
+        with patch.object(self.scout.fleet_poll_topology, "fetch_from_leader",
+                          return_value=(200, '"etag-a"', files)):
+            state, served = self.scout.build_state()
+        self.assertTrue(served)
+        self._collect.assert_not_called()  # ZERO GitHub reads on the follower
+        # generated_at preserved verbatim; host-local path re-derived locally.
+        self.assertEqual(state["generated_at"], leader_state["generated_at"])
+        self.assertEqual(state["repos"]["engine"]["path"], str(self.scout.ENGINE))
+        self.assertEqual(state["repos"]["engine"]["prs"], [{"number": 1}])
+        self.assertIn("clone_freshness", state)
+        # Detail cache mirrored to the follower's state dir.
+        self.assertTrue((self.state_dir / "prs" / "engine" / "1.json").exists())
+
+    def test_follower_unreachable_self_polls(self):
+        self.scout.POLL_CFG = T.PollConfig("follower", 8477, "leader.lan", 90)
+        with patch.object(self.scout.fleet_poll_topology, "fetch_from_leader",
+                          return_value=(None, None, None)):
+            state, served = self.scout.build_state()
+        self.assertFalse(served)  # fell back to self-poll
+        self._collect.assert_called_once()
+        self.assertEqual(state["repos"]["engine"]["path"], "SELF")
+
+    def test_follower_stale_leader_bundle_self_polls(self):
+        # A 200 whose generated_at is already past the leader-stale window must
+        # NOT be trusted — self-poll instead of propagating a frozen timestamp.
+        self.scout.POLL_CFG = T.PollConfig("follower", 8477, "leader.lan", 90)
+        stale = {"generated_at": _stamp(500), "repos": {"engine": {"path": "/l"}}}
+        files = {"state.json": json.dumps(stale)}
+        with patch.object(self.scout.fleet_poll_topology, "fetch_from_leader",
+                          return_value=(200, '"old"', files)):
+            _state, served = self.scout.build_state()
+        self.assertFalse(served)
+        self._collect.assert_called_once()
+
+    def test_follower_304_reuses_fresh_on_disk(self):
+        self.scout.POLL_CFG = T.PollConfig("follower", 8477, "leader.lan", 90)
+        on_disk = {"generated_at": _stamp(10),
+                   "repos": {"engine": {"path": str(self.scout.ENGINE)}}}
+        self.scout.STATE_FILE.write_text(json.dumps(on_disk))
+        with patch.object(self.scout.fleet_poll_topology, "fetch_from_leader",
+                          return_value=(304, '"etag-a"', None)):
+            state, served = self.scout.build_state()
+        self.assertTrue(served)
+        self._collect.assert_not_called()
+        self.assertEqual(state["generated_at"], on_disk["generated_at"])
+
+    def test_follower_304_stale_on_disk_self_polls(self):
+        self.scout.POLL_CFG = T.PollConfig("follower", 8477, "leader.lan", 90)
+        stale = {"generated_at": _stamp(500), "repos": {"engine": {"path": "/l"}}}
+        self.scout.STATE_FILE.write_text(json.dumps(stale))
+        with patch.object(self.scout.fleet_poll_topology, "fetch_from_leader",
+                          return_value=(304, '"etag-a"', None)):
+            _state, served = self.scout.build_state()
+        self.assertFalse(served)  # frozen leader → self-poll
+        self._collect.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fleet/tests/test_poll_topology.py
+++ b/scripts/fleet/tests/test_poll_topology.py
@@ -105,6 +105,24 @@ class TestStaleness(unittest.TestCase):
         self.assertIsNone(T.parse_generated_at("garbage"))
         self.assertIsInstance(T.parse_generated_at("2026-07-04T16:00:00Z"), int)
 
+    def test_state_age_prefers_generated_at_over_mtime(self):
+        # generated_at is 100s old; mtime claims 5s old (a follower that just
+        # rewrote a frozen leader snapshot). Age must follow generated_at.
+        now = T.now_epoch()
+        age = T.state_age_seconds(_stamp(100), now - 5, now=now)
+        self.assertAlmostEqual(age, 100, delta=1)
+
+    def test_state_age_falls_back_to_mtime_when_missing(self):
+        now = T.now_epoch()
+        self.assertAlmostEqual(
+            T.state_age_seconds(None, now - 42, now=now), 42, delta=1)
+        self.assertAlmostEqual(
+            T.state_age_seconds("not-a-date", now - 42, now=now), 42, delta=1)
+
+    def test_state_age_default_now_is_wall_clock(self):
+        # Omitting `now` uses time.time(); a fresh stamp reads as ~0s old.
+        self.assertLess(abs(T.state_age_seconds(_stamp(0), 0.0)), 5)
+
 
 class TestBundle(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- Collapse N per-host `fleet-state-scout` GitHub pollers into one authoritative **leader** plus **followers** that consume the leader's already-fetched `~/.fleet/state` bundle over the LAN (#1394 Q2). Idle-fleet GitHub quota drops from N× to 1×; every consumer stays oblivious.
- New `fleet_poll_topology.py`: host.toml `[fleet]` config, `generated_at` staleness, bundle build/parse/apply, a stdlib `ThreadingHTTPServer` leader endpoint (`generated_at` as ETag), and the follower's conditional-GET LAN hop.
- `fleet_gh_poll.py`: general `conditional_get_url()` for the LAN hop (reuses Q1's If-None-Match machinery, no gh token).
- `fleet-state-scout`: `build_state()` routes leader (poll GitHub) vs follower (consume bundle). A follower **preserves the leader's `generated_at` verbatim**, re-derives host-local `clone_freshness` + `repos.path`, recomputes its own projections + triggers, and **self-polls when the leader is unreachable/stale**. Global mutations (`cleanup --gh`, `queue-ingest`) run only on the authoritative poller; host-local `reconcile --apply` stays per-host.
- `fleet-dispatcher`: `scout_unhealthy()` keys staleness off the in-file `generated_at` (mtime fallback) so a follower re-writing a dead leader's frozen timestamp can't mask the death.
- Config + docs: host.toml `[fleet]` keys in `setup-windows.sh` / `fleet-up.conf.sample`, a scout-launch poll-role banner in `fleet-up`, and `FLEET-CACHE.md` / `FLEET-RUNTIME.md` sections.

## Test plan
- [x] `python3 -m unittest discover -s scripts/fleet/tests` — 578 tests green (22 new in `test_poll_topology.py`).
- [x] `ruff check scripts/` clean (CI gate).
- [x] Real leader↔follower HTTP round-trip: 200 → 304 → 200-after-tick → leader-down → self-poll.
- [x] Full `tick_once()` follower smoke on the live `state.json`: all projections written, `generated_at` preserved, caches mirrored, and only host-local `reconcile` spawned (never `cleanup`/`ingest`), with zero `collect_state`/`refresh_all_details` calls.
- [ ] Multi-host acceptance (1 leader + 2 followers): confirm only the leader's API counters move and followers make zero gh reads — requires the real 3-host fleet.

## Notes for reviewer
- Deviation from the plan's "bundle includes projections": projections are a deterministic, host-agnostic function of `state.json`, so the follower recomputes them via its own slicer pass (which it must run anyway for host-local triggers) rather than shipping redundant copies. Bundle carries `state.json` + `prs/`/`diffs/`/`issues/` only.
- `_BundleServer.server_bind` skips `HTTPServer`'s `socket.getfqdn()` reverse-DNS lookup — it blocks ~30 s binding `0.0.0.0` on macOS and would stall the leader's scout startup.
- The LAN hop reuses Q1's conditional-request helper (Q1 shipped as #2227; this PR was rebased onto master after it merged, so it is no longer stacked).

Closes #2220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
