### PR TITLE
fleet: GitHub API quota headroom surfacing + dispatcher gate (Q3)

### DIFF
--- a/docs/agents/FLEET.md
+++ b/docs/agents/FLEET.md
@@ -888,12 +888,38 @@ pane from dispatch for `FLEET_DISPATCHER_LIMIT_DELAY` seconds (default
 `900` = 15 min). Other panes for the same role keep running. The
 marker file is removed automatically once the cooldown expires.
 
+**GitHub API quota** — same gate, a second sampler. Dispatched agents
+burn GitHub API quota too (every `gh pr/issue view`, `git push`, etc.),
+so a near-exhausted pool walks workers straight into the wall — the
+failure mode #1394 filed. `fleet-state-scout` samples the free,
+read-only `gh api /rate_limit` endpoint every tick (it does **not**
+consume the primary limit it reports on) and latches
+`~/.fleet/state/usage/github-{core,graphql,search}.json` in the same
+`{rateLimitType, utilization, resetsAt, observed_at}` shape the
+Anthropic-side sampler uses — the dispatcher's glob-and-evaluate loop
+picks these up with zero per-source special-casing. `github_core` and
+`github_graphql` gate at `≥ 90%` (override with
+`FLEET_DISPATCHER_USAGE_GATE_GITHUB_CORE` /
+`FLEET_DISPATCHER_USAGE_GATE_GITHUB_GRAPHQL`); `github_search` is
+surfaced but never gates (threshold `1.01`,
+`FLEET_DISPATCHER_USAGE_GATE_GITHUB_SEARCH` to change). GitHub pools
+refill fully at `resetsAt` (hourly for core/graphql, per-minute for
+search) rather than rolling like Anthropic's window, so a closed
+GitHub gate reopens within `≤ 1h + grace`. Once the fleet moves to a
+GitHub App token (tracked separately), `gh api /rate_limit` reports
+the App installation's larger pool automatically — no sampler change
+needed.
+
 **Visibility:** `fleet-gate-status` (read-only) prints the current
 gate state, breaching observation, ETA to reset, and active per-pane
-cooldowns. `fleet-gate-status --json` for scripting. The transition
+cooldowns, plus a separate "GitHub API quota" section listing each
+pool's `remaining/limit`, threshold, and ETA-to-reset. `fleet-gate-status
+--json` for scripting (the `github` key groups just the GitHub-pool
+observations; `observations` still carries all of them). The transition
 log lines `usage gate closed:…` / `usage gate re-opened (…); resuming
 dispatch` are also emitted to the dispatcher log on each transition
-(once per transition — not per tick).
+(once per transition — not per tick); a GitHub-pool breach logs the
+same way (`rateLimitType` is `github_core` / `github_graphql`).
 
 The canonical implementation lives in
 [`scripts/fleet/fleet-dispatcher`](../../scripts/fleet/fleet-dispatcher)

--- a/scripts/fleet/fleet-dispatcher
+++ b/scripts/fleet/fleet-dispatcher
@@ -270,19 +270,27 @@ read_dispatch_mode() {
 #
 # Observations are written by fleet-claude-stream (one file per
 # rateLimitType under $USAGE_DIR), so the gate piggybacks on every
-# transient worker's stream — no separate poller needed.
+# transient worker's stream — no separate poller needed. GitHub API
+# pools flow through the same glob-and-evaluate loop: fleet-state-scout's
+# sample_github_rate_limit() latches github-{core,graphql,search}.json
+# into the same $USAGE_DIR every tick (#2221), so a near-exhausted
+# GitHub pool defers dispatch exactly like a near-exhausted Anthropic
+# window — no separate code path.
 #
 # Per-type thresholds let the operator distinguish a short-window
 # limit (5-hour, baked default 80% — leaves 20% headroom for
 # in-flight iterations to finish) from a long-window limit (7-day
 # all-models, baked default 95% — pre-emption only when very close
 # to the wall, so typical operation isn't gated by mid-week burn).
+# github_core/github_graphql gate at 90% (dispatched agents burn REST
+# calls too); github_search is surfaced but never gates (threshold 1.01).
 #
 # Threshold lookup order (per observation type, e.g. "seven_day"):
 #   1. FLEET_DISPATCHER_USAGE_GATE_<TYPE_UPPERCASE>  (per-type override)
 #   2. FLEET_DISPATCHER_USAGE_GATE                   (global override)
 #   3. BUILTIN_PER_TYPE_DEFAULTS in the Python below (seven_day=0.95,
-#      five_hour=0.80; everything else falls to the global default)
+#      five_hour=0.80, github_core=0.90, github_graphql=0.90,
+#      github_search=1.01; everything else falls to the global default)
 #   4. Final fallback 0.80
 #
 # Conservative against staleness, but resetsAt is authoritative: an
@@ -917,6 +925,9 @@ reset_grace_s = int(os.environ.get("RESET_GRACE_SECONDS", "600"))
 BUILTIN_PER_TYPE_DEFAULTS = {
     "seven_day": 0.95,   # all-models weekly window — pre-empt close to wall
     "five_hour": 0.80,   # short-window — leave 20% headroom for in-flight work
+    "github_core": 0.90,     # dispatched agents burn REST calls too — gate before the wall
+    "github_graphql": 0.90,  # same pool the #1394 exhaustion incident hit
+    "github_search": 1.01,   # surface-only — fleet usage of /search is negligible, never gate
 }
 # Final fallback for unknown types when the operator hasn't set a
 # global override either.

--- a/scripts/fleet/fleet-gate-status
+++ b/scripts/fleet/fleet-gate-status
@@ -46,8 +46,10 @@ fleet-gate-status — read-only view of fleet-dispatcher gating.
   fleet-gate-status --json     machine-readable JSON
   fleet-gate-status -h|--help  this help
 
-Reports both:
+Reports:
   • fleet-wide usage gate (5h / 7d / etc. rate-limit thresholds)
+  • GitHub API quota (core / graphql / search pools, gated at 90%; search is
+    surface-only and never gates)
   • per-pane cooldowns (15-min default after a pane exits with code 2)
 
 Auto-resume is automatic: the dispatcher re-opens the gate on its next
@@ -56,7 +58,8 @@ passed (default grace is 600s, so by default ~10 min after the actual
 reset). This command only visualises state — it does NOT trigger resume.
 
 State sources (read-only):
-  ~/.fleet/state/usage/*.json         (written by fleet-claude-stream)
+  ~/.fleet/state/usage/*.json         (Anthropic: fleet-claude-stream;
+                                        GitHub: fleet-state-scout)
   ~/.fleet/state/rate-limit/*.ts      (written by fleet-dispatch-wrap)
 
 Tunables (env, shared with fleet-dispatcher):
@@ -113,6 +116,9 @@ emit_json = os.environ.get("JSON") == "1"
 BUILTIN_PER_TYPE_DEFAULTS = {
     "seven_day": 0.95,
     "five_hour": 0.80,
+    "github_core": 0.90,
+    "github_graphql": 0.90,
+    "github_search": 1.01,
 }
 BUILTIN_FALLBACK = 0.80
 
@@ -226,12 +232,24 @@ if usage_dir.is_dir():
             # when the grace pad was introduced.
             "past_reset": is_past,
             "breaching": breaching,
+            # GitHub pools only (fleet-state-scout's sample_github_rate_limit);
+            # Anthropic observations never carry these. None lets the display
+            # code fall back to a percent-only rendering if they're absent.
+            "limit": data.get("limit"),
+            "remaining": data.get("remaining"),
         }
         observations.append(obs)
         if breaching:
             breaches.append(obs)
 
 gate_state = "closed" if breaches else "open"
+
+# GitHub pools are surfaced in their own section (below) rather than mixed
+# into the Anthropic "Fleet-wide usage gate" list — different unit (request
+# pools vs model-usage windows), different operator audience. A github
+# breach still flips gate_state above; it's the same shared dispatcher gate.
+github_obs = [o for o in observations if o["rateLimitType"].startswith("github_")]
+anthropic_obs = [o for o in observations if not o["rateLimitType"].startswith("github_")]
 
 # --- Per-pane cooldowns ---------------------------------------------------
 
@@ -260,10 +278,14 @@ if emit_json:
         "gate": gate_state,
         "breaching": breaches,
         "observations": observations,
+        "github": github_obs,
         "cooldowns": cooldowns,
         "thresholds_in_effect": {
             "five_hour": threshold_for("five_hour"),
             "seven_day": threshold_for("seven_day"),
+            "github_core": threshold_for("github_core"),
+            "github_graphql": threshold_for("github_graphql"),
+            "github_search": threshold_for("github_search"),
         },
         "limit_delay_seconds": limit_delay,
         "usage_stale_seconds": stale_s,
@@ -277,12 +299,11 @@ if emit_json:
 print("fleet-gate-status — read-only view of dispatcher gating")
 print()
 
-if not observations:
-    print("Fleet-wide usage gate: OPEN")
-    print("  no observations yet (no claude rate_limit_event seen since fleet started)")
+label = "CLOSED" if gate_state == "closed" else "OPEN"
+print(f"Fleet-wide usage gate: {label}")
+if not anthropic_obs:
+    print("  no claude observations yet (no rate_limit_event seen since fleet started)")
 else:
-    label = "CLOSED" if gate_state == "closed" else "OPEN"
-    print(f"Fleet-wide usage gate: {label}")
 
     def fmt_obs(o, prefix, threshold_text, suffix=""):
         pct = int(round(o["utilization"] * 100))
@@ -297,15 +318,16 @@ else:
             f"util={pct}% {threshold_text}{suffix}{resets_part}{eta}"
         )
 
-    for o in sorted(breaches, key=lambda x: x["utilization"], reverse=True):
+    anthropic_breaches = [o for o in anthropic_obs if o["breaching"]]
+    for o in sorted(anthropic_breaches, key=lambda x: x["utilization"], reverse=True):
         thr_pct = int(round(o["threshold"] * 100))
         print(fmt_obs(o, "breaching:", f"(>= {thr_pct}%)"))
-    for o in observations:
+    for o in anthropic_obs:
         if o["breaching"] or o["stale"] or o["past_reset"]:
             continue
         thr_pct = int(round(o["threshold"] * 100))
         print(fmt_obs(o, "other:", f"(< {thr_pct}%)"))
-    for o in observations:
+    for o in anthropic_obs:
         if not (o["stale"] or o["past_reset"]):
             continue
         past_label = "past-reset" if reset_grace_s == 0 else "past-reset+grace"
@@ -313,6 +335,44 @@ else:
             r for r, on in (("stale", o["stale"]), (past_label, o["past_reset"])) if on
         )
         print(fmt_obs(o, "pruned:", f"[{reasons}]"))
+
+print()
+
+# --- GitHub API quota -------------------------------------------------------
+# Separate section: different unit (request pools, not model-usage windows)
+# and a different operator question ("how close is the fleet to a GitHub
+# rate-limit wall" vs "is the Anthropic usage gate open"). A github breach
+# still flips the shared `gate_state` above to CLOSED — same dispatcher gate,
+# just displayed apart from the Anthropic observations.
+if not github_obs:
+    print("GitHub API quota: no observations yet (scout hasn't sampled /rate_limit)")
+else:
+    def fmt_github_obs(o):
+        pct = int(round(o["utilization"] * 100))
+        thr_pct = int(round(o["threshold"] * 100))
+        cmp_text = f"(>= {thr_pct}%)" if o["breaching"] else f"(< {thr_pct}%)"
+        prefix = "breaching:" if o["breaching"] else "other:"
+        pool = o["rateLimitType"].removeprefix("github_")
+        remaining, limit = o.get("remaining"), o.get("limit")
+        quota_text = f"remaining={remaining}/{limit}" if limit else f"util={pct}%"
+        eta = (
+            f" (in {fmt_duration(o['etaSeconds'])})"
+            if o["etaSeconds"] is not None and o["etaSeconds"] > 0
+            else ""
+        )
+        resets_part = f" resets={o['resetsAt']}" if o.get("resetsAt") else ""
+        stale_part = ""
+        if o["stale"] or o["past_reset"]:
+            past_label = "past-reset" if reset_grace_s == 0 else "past-reset+grace"
+            reasons = "/".join(
+                r for r, on in (("stale", o["stale"]), (past_label, o["past_reset"])) if on
+            )
+            stale_part = f" [{reasons}]"
+        return f"  {prefix:<10} {pool:<8} {quota_text} {cmp_text}{resets_part}{eta}{stale_part}"
+
+    print("GitHub API quota:")
+    for o in sorted(github_obs, key=lambda x: x["rateLimitType"]):
+        print(fmt_github_obs(o))
 
 print()
 if active_cooldowns:

--- a/scripts/fleet/fleet-help
+++ b/scripts/fleet/fleet-help
@@ -235,7 +235,8 @@ Parallel-agent fleet (tmux + Claude)
                                  stacked/conflicting PRs for zero tokens;
                                  conflicts or unhandled merger states re-arm
                                  the LLM merger pass
-  fleet-gate-status [--json]     show usage gate + per-pane cooldown state
+  fleet-gate-status [--json]     show usage gate (Anthropic + GitHub API
+                                 pools) + per-pane cooldown state
   fleet-claude-stream            format claude stream-json for tmux
   fleet-heartbeat <agent>        bump heartbeat mtime
   fleet-iteration-summary <agent> "<text>"

--- a/scripts/fleet/fleet-state-scout
+++ b/scripts/fleet/fleet-state-scout
@@ -91,6 +91,14 @@ PID_FILE = STATE_DIR / "scout.pid"
 STATE_FILE = STATE_DIR / "state.json"
 SHUTDOWN_FLAG = Path.home() / ".fleet" / "shutdown-in-progress"
 
+# Where GitHub API rate-limit observations are latched for the dispatcher's
+# usage gate — same directory + payload shape as fleet-claude-stream's
+# Anthropic-side USAGE_DIR (one file per rateLimitType, overwritten each
+# sample). fleet-dispatcher globs this whole dir with zero per-source
+# special-casing, so dropping github-<pool>.json files here is enough to
+# make GitHub quota gate dispatch the same way Anthropic quota does.
+USAGE_DIR = STATE_DIR / "usage"
+
 # Canonical short keys used in the cache layout. The keys match the
 # `repos.<key>` slots in state.json so consumers can read the per-PR
 # / per-issue files using the same name they already use for the
@@ -285,6 +293,58 @@ def fetch_prs(repo, prev=None):
     if not changed and prev is not None:
         return prev
     return _fetch_prs_graphql(repo)
+
+
+def sample_github_rate_limit():
+    """Latch `gh api /rate_limit` pool utilization into USAGE_DIR.
+
+    Writes one github-<pool>.json per pool (core, graphql, search). The
+    base {rateLimitType, utilization, resetsAt, observed_at} fields match
+    the shape fleet-claude-stream's latch_usage_observation writes for
+    Anthropic types, so fleet-dispatcher's usage-gate evaluator globs the
+    whole dir and gates on these with zero per-source special-casing.
+    `limit`/`remaining` are extra fields the evaluator ignores but
+    fleet-gate-status's GitHub display section reads (a bare utilization
+    fraction can't reconstruct "remaining=3527/5000"). Called at the top
+    of tick_once, before build_state, so quota stays fresh every tick
+    (leader or follower) even on a degraded tick. `/rate_limit` is a free
+    read-only REST GET — it does
+    not consume the primary limit it reports on.
+
+    Best-effort: a failed sample (gh error, bad JSON, unwritable state
+    dir) is logged and swallowed, leaving the prior file (if any) in
+    place — a wedged sampler must never crash the scout tick.
+    """
+    out = run_capture(["gh", "api", "/rate_limit"])
+    if out is None:
+        return
+    try:
+        resources = json.loads(out).get("resources", {})
+    except json.JSONDecodeError as e:
+        log(f"gh api /rate_limit: bad JSON: {e}")
+        return
+    now = int(time.time())
+    for pool in ("core", "graphql", "search"):
+        info = resources.get(pool)
+        if not info:
+            continue
+        limit = info.get("limit")
+        used = info.get("used")
+        if not limit:
+            continue
+        payload = {
+            "rateLimitType": f"github_{pool}",
+            "utilization": used / limit,
+            "resetsAt": info.get("reset"),
+            "observed_at": now,
+            "limit": limit,
+            "remaining": info.get("remaining", limit - used),
+        }
+        try:
+            USAGE_DIR.mkdir(parents=True, exist_ok=True)
+            write_atomic(USAGE_DIR / f"github-{pool}.json", json.dumps(payload))
+        except OSError as e:
+            log(f"github rate-limit latch failed for {pool}: {e}")
 
 
 _ALREADY_QUEUED_LABELS = frozenset({"fleet:queued", "fleet:scope-shipped", "fleet:needs-human"})
@@ -2564,8 +2624,15 @@ def _refresh_gh_token():
 def tick_once():
     # Refresh before build_state so the token is current on every gh-calling
     # path: a leader's collect_state poll, or a follower falling back to
-    # self-poll when the leader is unreachable (both route through gh).
+    # self-poll when the leader is unreachable (both route through gh). Must
+    # precede the quota sample below — that sample makes its own gh
+    # /rate_limit call, so the token has to be minted first.
     _refresh_gh_token()
+    # Runs before build_state so GitHub quota is captured every scout tick —
+    # leader or follower, and even when state collection degrades. Best-effort
+    # itself (see sample_github_rate_limit docstring); each host's dispatcher
+    # gate reads its own host-local quota sample, so followers sample too.
+    sample_github_rate_limit()
     state, served = build_state()
     # A follower's bundle is already fully resolved (the leader ran the pipeline
     # before serving); re-running it would double-process body-stripped data.

--- a/scripts/fleet/fleet-up.conf.sample
+++ b/scripts/fleet/fleet-up.conf.sample
@@ -197,7 +197,15 @@
 # Built-in defaults (apply with no override):
 #   five_hour:  0.80
 #   seven_day:  0.95
+#   github_core:    0.90  # GitHub REST pool — dispatched agents burn this too
+#   github_graphql: 0.90  # same pool the #1394 exhaustion incident hit
+#   github_search:  1.01  # surface-only — fleet usage is negligible, never gates
 #   (any other type): 0.80
+#
+# GitHub pools are sampled by fleet-state-scout (a free `gh api /rate_limit`
+# read each tick, latched into the same usage dir Anthropic types use) —
+# no separate poller or config needed to enable them; see FLEET.md
+# "GitHub API quota" under "Rate-limit handling".
 #
 # Threshold lookup order:
 #   1. FLEET_DISPATCHER_USAGE_GATE_<TYPE_UPPER>  (per-type override)
@@ -227,6 +235,9 @@
 # thresholds than the built-in defaults.
 # FLEET_DISPATCHER_USAGE_GATE_FIVE_HOUR=0.80
 # FLEET_DISPATCHER_USAGE_GATE_SEVEN_DAY=0.95
+# FLEET_DISPATCHER_USAGE_GATE_GITHUB_CORE=0.90
+# FLEET_DISPATCHER_USAGE_GATE_GITHUB_GRAPHQL=0.90
+# FLEET_DISPATCHER_USAGE_GATE_GITHUB_SEARCH=1.01
 
 # FLEET_DISPATCHER_USAGE_STALE_SECONDS=3600
 # FLEET_DISPATCHER_RESET_GRACE_SECONDS=600

--- a/scripts/fleet/tests/test_dispatcher_github_gate.sh
+++ b/scripts/fleet/tests/test_dispatcher_github_gate.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Tests for fleet-dispatcher's GitHub API quota gate (#2221, epic #1394 Q3).
+#
+# Mirrors test_dispatcher_usage_gate.sh's harness against the three
+# github_{core,graphql,search} entries in BUILTIN_PER_TYPE_DEFAULTS.
+# fleet-state-scout's sample_github_rate_limit() is the writer in
+# production; this test drops the fixture files directly so it exercises
+# only the dispatcher's evaluator, same as the Anthropic-side suite does.
+#
+# Covers:
+#   - github_graphql at 92% (>= 90% default) => closed
+#   - github_search at 100% => open (threshold 1.01, surface-only, never gates)
+#   - github_core below its 90% default => open with util reported
+#   - a github pool past resetsAt + grace => ignored (open)
+#   - github and five_hour observations coexist without cross-perturbing
+#     each other's evaluation (worst-of picks whichever actually breaches)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DISPATCHER="$SCRIPT_DIR/fleet-dispatcher"
+
+if [[ ! -x "$DISPATCHER" ]]; then
+    echo "test setup: fleet-dispatcher not found at $DISPATCHER" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+cleanup() {
+    [[ -n "$TMPROOT" && -d "$TMPROOT" ]] && rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+
+assert_starts_with() {
+    local actual="$1" prefix="$2" msg="$3"
+    if [[ "$actual" == "$prefix"* ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected prefix: $prefix"
+        echo "        actual:          $actual"
+    fi
+}
+
+TMPROOT=$(mktemp -d)
+export FLEET_STATE_DIR="$TMPROOT/state"
+mkdir -p "$FLEET_STATE_DIR/usage"
+
+# Isolate from the operator's ~/.fleet/fleet-up.conf, same rationale as
+# test_dispatcher_usage_gate.sh T-setup: a host-level per-type override
+# would clobber the baked-default assertions below.
+export FLEET_CONF=/dev/null
+for _v in $(compgen -A variable | grep '^FLEET_DISPATCHER_USAGE_GATE' || true); do
+    unset "$_v"
+done
+unset _v
+
+NOW=$(date +%s)
+FUTURE_RESET=$((NOW + 3600))
+
+echo "T1: github_graphql at 92% (>= builtin 90%) => closed"
+printf '{"rateLimitType":"github_graphql","utilization":0.92,"resetsAt":%s,"observed_at":%s,"limit":5000,"remaining":400}\n' \
+    "$FUTURE_RESET" "$NOW" > "$FLEET_STATE_DIR/usage/github-graphql.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:github_graphql util=92% (>= 90%)" "github_graphql trips default 90% threshold"
+rm -f "$FLEET_STATE_DIR/usage/github-graphql.json"
+
+echo "T2: github_search at 100% (threshold 1.01, surface-only) => open"
+printf '{"rateLimitType":"github_search","utilization":1.0,"resetsAt":%s,"observed_at":%s,"limit":30,"remaining":0}\n' \
+    "$FUTURE_RESET" "$NOW" > "$FLEET_STATE_DIR/usage/github-search.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open:github_search util=100%" "github_search never gates even at 100%"
+rm -f "$FLEET_STATE_DIR/usage/github-search.json"
+
+echo "T3: github_core at 60% (< builtin 90%) => open with util reported"
+printf '{"rateLimitType":"github_core","utilization":0.60,"resetsAt":%s,"observed_at":%s,"limit":5000,"remaining":2000}\n' \
+    "$FUTURE_RESET" "$NOW" > "$FLEET_STATE_DIR/usage/github-core.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open:github_core util=60%" "below-threshold github_core reports util"
+rm -f "$FLEET_STATE_DIR/usage/github-core.json"
+
+echo "T4: github_graphql past resetsAt + grace => ignored (open)"
+PAST_RESET=$((NOW - 7200))
+printf '{"rateLimitType":"github_graphql","utilization":0.99,"resetsAt":%s,"observed_at":%s,"limit":5000,"remaining":10}\n' \
+    "$PAST_RESET" "$NOW" > "$FLEET_STATE_DIR/usage/github-graphql.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "open" "expired github window ignored"
+rm -f "$FLEET_STATE_DIR/usage/github-graphql.json"
+
+echo "T5: github_core override via per-type env var"
+printf '{"rateLimitType":"github_core","utilization":0.60,"resetsAt":%s,"observed_at":%s,"limit":5000,"remaining":2000}\n' \
+    "$FUTURE_RESET" "$NOW" > "$FLEET_STATE_DIR/usage/github-core.json"
+out=$(FLEET_DISPATCHER_USAGE_GATE_GITHUB_CORE=0.50 "$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:github_core util=60% (>= 50%)" "per-type override applies to github pools"
+rm -f "$FLEET_STATE_DIR/usage/github-core.json"
+
+echo "T6: github and Anthropic observations coexist — worst-of wins"
+printf '{"rateLimitType":"github_graphql","utilization":0.70,"resetsAt":%s,"observed_at":%s,"limit":5000,"remaining":1500}\n' \
+    "$FUTURE_RESET" "$NOW" > "$FLEET_STATE_DIR/usage/github-graphql.json"
+printf '{"rateLimitType":"five_hour","utilization":0.85,"resetsAt":%s,"observed_at":%s}\n' \
+    "$FUTURE_RESET" "$NOW" > "$FLEET_STATE_DIR/usage/five_hour.json"
+out=$("$DISPATCHER" --gate-status)
+assert_starts_with "$out" "closed:five_hour util=85%" "five_hour breach wins when github pool is under its own threshold"
+rm -f "$FLEET_STATE_DIR/usage/github-graphql.json" "$FLEET_STATE_DIR/usage/five_hour.json"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- `fleet-state-scout` samples the free, read-only `gh api /rate_limit` endpoint once per tick (before `collect_state`, so it runs even on a degraded tick) and latches `core`/`graphql`/`search` into `~/.fleet/state/usage/github-<pool>.json`, in the same `{rateLimitType, utilization, resetsAt, observed_at}` shape `fleet-claude-stream` already writes for Anthropic types — the dispatcher's existing glob-and-evaluate loop gates on these with zero per-source special-casing.
- `github_core`/`github_graphql` gate at 90% (dispatched agents burn REST calls too); `github_search` is surfaced but never gates (threshold 1.01 — usage is negligible).
- `fleet-gate-status` now partitions observations into the existing "Fleet-wide usage gate" section (Anthropic-only) plus a new "GitHub API quota" section (remaining/limit, threshold, ETA-to-reset); `--json` gains a `github` grouping key.
- Docs (`FLEET.md` "Rate-limit handling", `fleet-up.conf.sample`) and `fleet-help` updated to describe the new pools + overrides.

## Test plan
- [x] New `scripts/fleet/tests/test_dispatcher_github_gate.sh` (mirrors `test_dispatcher_usage_gate.sh`'s harness) — 6/6 pass, covering: graphql breach at 92%, search never gating at 100%, core below-threshold reporting, past-reset+grace expiry, per-type env override, and worst-of coexistence with an Anthropic observation.
- [x] Existing `test_dispatcher_usage_gate.sh` — 18/18 pass, unperturbed by the github additions.
- [x] `ruff check scripts/` — clean.
- [x] Manual functional check of `fleet-gate-status` (human + `--json`) and `fleet-dispatcher --gate-status` against synthetic `github-*.json` fixtures, confirming a github breach flips the shared gate to CLOSED and `github_search` at 100% util stays open.

## Notes for reviewer
`limit`/`remaining` are extra fields on the github payload beyond the base Anthropic-mirroring shape — the dispatcher's evaluator ignores unknown keys, and `fleet-gate-status`'s new display section needs them to render `remaining=N/M` (a bare utilization fraction can't reconstruct that).

Closes #2221

🤖 Generated with [Claude Code](https://claude.com/claude-code)