### PR TITLE
fleet: fix fleet-run-targets MSYS2/Windows path-scope mismatch

### DIFF
--- a/scripts/fleet/fleet-common.sh
+++ b/scripts/fleet/fleet-common.sh
@@ -34,3 +34,39 @@ detect_engine_root() {
     fi
     echo "$root"
 }
+
+# canonicalize_path_spelling — normalize a path to one spelling so the two ways
+# the same directory is spelled on native Windows/MSYS2 compare equal in a plain
+# string containment test. `git rev-parse --show-toplevel` yields a Windows drive
+# path (C:/Users/x) while an MSYS2 shell's $PWD yields the POSIX drive form
+# (/c/Users/x); byte-compared they differ, so a naive prefix check reports the
+# scope as "outside" the engine root even when it is the same tree (#2036).
+#
+# Canonical form: /<lowercase-drive>/<rest> with forward slashes, e.g. both
+# `C:/Users/x` and `/c/Users/x` map to `/c/Users/x`. On macOS/Linux every path
+# is returned byte-unchanged: no POSIX absolute path begins with a `<letter>:`
+# drive, and the single-letter-top-dir branch only rewrites an UPPERCASE drive
+# letter (`/C/…` → `/c/…`), a spelling MSYS2's realpath never emits and a real
+# POSIX mount effectively never uses — so the transforms are inert off-Windows.
+# Kept bash-3.2 compatible (tr, not ${var,,}) for the /bin/bash and MSYS2 hosts.
+canonicalize_path_spelling() {
+    local p=$1
+    p=${p//\\//} # backslashes -> forward slashes (C:\Users\x -> C:/Users/x)
+    if [[ $p =~ ^([A-Za-z]):(/.*)?$ ]]; then
+        # drive-letter form (C:/Users/x, c:) -> /c/Users/x, /c
+        local drive rest
+        drive=$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
+        rest=${BASH_REMATCH[2]}
+        printf '/%s%s' "$drive" "$rest"
+        return 0
+    fi
+    if [[ $p =~ ^/([A-Z])(/.*)?$ ]]; then
+        # uppercase POSIX drive form (/C/Users/x) -> /c/Users/x
+        local drive2 rest2
+        drive2=$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
+        rest2=${BASH_REMATCH[2]}
+        printf '/%s%s' "$drive2" "$rest2"
+        return 0
+    fi
+    printf '%s' "$p"
+}

--- a/scripts/fleet/fleet-run-targets
+++ b/scripts/fleet/fleet-run-targets
@@ -187,9 +187,14 @@ resolve_scope() {
     fi
 
     local root build scope rel
-    root=$(realpath_portable "$WORKTREE_ROOT")
-    build=$(realpath_portable "$BUILD_DIR")
-    scope=$(realpath_portable "$SCOPE_DIR")
+    # Canonicalize drive-path spelling before the containment test: on native
+    # Windows the root (git-style C:/…) and the scope (MSYS2 $PWD /c/…) name the
+    # same tree but differ byte-for-byte, which would otherwise trip the
+    # "outside" branch and fall back to a whole-tree scan (#2036). No-op on
+    # macOS/Linux.
+    root=$(canonicalize_path_spelling "$(realpath_portable "$WORKTREE_ROOT")")
+    build=$(canonicalize_path_spelling "$(realpath_portable "$BUILD_DIR")")
+    scope=$(canonicalize_path_spelling "$(realpath_portable "$SCOPE_DIR")")
 
     case "$scope" in
         "$build"/*)

--- a/scripts/fleet/tests/test_run_targets_path_scope.sh
+++ b/scripts/fleet/tests/test_run_targets_path_scope.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Tests for fleet-run-targets' Windows /c/… vs C:/… path-scope match — issue #2036.
+#
+# On native Windows the engine root comes from `git rev-parse --show-toplevel`
+# (drive spelling: C:/Users/x) while the scope is an MSYS2 shell's $PWD (POSIX
+# drive spelling: /c/Users/x). resolve_scope compares them with a bash `case`
+# string match, so the same directory in two spellings failed containment and
+# fell back to a whole-tree scan that found no executables.
+#
+# canonicalize_path_spelling (fleet-common.sh) normalizes both spellings to one
+# canonical form before the compare. These tests pin that helper against literal
+# path strings — reproducing the exact Windows scenario deterministically on any
+# host — plus a containment simulation mirroring resolve_scope's case block.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=../fleet-common.sh
+source "$SCRIPT_DIR/fleet-common.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+        echo "  ok: $msg"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $msg"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+    fi
+}
+
+# Mirror of resolve_scope's containment case block (fleet-run-targets), operating
+# on already-canonicalized root/build/scope. Prints the derived scope-relative
+# path, or the literal "OUTSIDE" sentinel when the scope escapes the tree.
+scope_rel() {
+    local root build scope
+    root=$(canonicalize_path_spelling "$1")
+    build=$(canonicalize_path_spelling "$2")
+    scope=$(canonicalize_path_spelling "$3")
+    case "$scope" in
+        "$build"/*) printf '%s' "${scope#"$build"/}" ;;
+        "$build")   printf '' ;;
+        "$root"/*)  printf '%s' "${scope#"$root"/}" ;;
+        "$root")    printf '' ;;
+        *)          printf 'OUTSIDE' ;;
+    esac
+}
+
+WT_WIN='C:/Users/evinj/src/IrredenEngine/.claude/worktrees/opus-architect'
+WT_MSYS='/c/Users/evinj/src/IrredenEngine/.claude/worktrees/opus-architect'
+CANON='/c/Users/evinj/src/IrredenEngine/.claude/worktrees/opus-architect'
+
+# --- Test 1: the two Windows spellings collapse to one canonical form -------
+echo "T1: MSYS2 /c/… and Windows C:/… of the same dir canonicalize equal"
+assert_eq "$(canonicalize_path_spelling "$WT_WIN")"  "$CANON" "C:/…  -> /c/…"
+assert_eq "$(canonicalize_path_spelling "$WT_MSYS")" "$CANON" "/c/… -> /c/… (unchanged)"
+assert_eq "$(canonicalize_path_spelling "$WT_WIN")" \
+          "$(canonicalize_path_spelling "$WT_MSYS")" "both spellings compare equal"
+
+# --- Test 2: spelling variants ----------------------------------------------
+echo "T2: backslashes, drive-letter case, and bare drive"
+assert_eq "$(canonicalize_path_spelling 'c:\Users\x\wt')" "/c/Users/x/wt" "backslash + lowercase drive"
+assert_eq "$(canonicalize_path_spelling 'C:\Users\x')"    "/c/Users/x"    "backslash + uppercase drive"
+assert_eq "$(canonicalize_path_spelling 'C:')"            "/c"           "bare drive C: -> /c"
+assert_eq "$(canonicalize_path_spelling '/C/Users/x')"    "/c/Users/x"   "uppercase POSIX drive -> lowercase"
+
+# --- Test 3: POSIX paths pass through byte-unchanged (macOS/Linux no-op) -----
+echo "T3: real POSIX paths are returned unchanged"
+assert_eq "$(canonicalize_path_spelling '/Users/evinjkill/src/IrredenEngine')" \
+          "/Users/evinjkill/src/IrredenEngine" "macOS home path unchanged"
+assert_eq "$(canonicalize_path_spelling '/home/u/wt')" "/home/u/wt" "linux path unchanged"
+assert_eq "$(canonicalize_path_spelling '/opt/homebrew/bin')" "/opt/homebrew/bin" "multi-char top dir unchanged"
+assert_eq "$(canonicalize_path_spelling '/e/data')" "/e/data" "lowercase single-letter top dir unchanged (not a drive)"
+
+# --- Test 4: containment survives mixed spellings (the #2036 regression) -----
+echo "T4: resolve_scope containment matches across mixed root/scope spellings"
+ROOT_WIN='C:/Users/evinj/src/IrredenEngine'
+SCOPE_MSYS='/c/Users/evinj/src/IrredenEngine/creations/demos/shape_debug'
+assert_eq "$(scope_rel "$ROOT_WIN" "$ROOT_WIN/build" "$SCOPE_MSYS")" \
+          "creations/demos/shape_debug" "win root + msys scope -> relative subpath (was OUTSIDE)"
+# reverse spelling (defensive symmetry): msys root + win scope
+assert_eq "$(scope_rel '/c/Users/evinj/src/IrredenEngine' '/c/Users/evinj/src/IrredenEngine/build' \
+                        'C:/Users/evinj/src/IrredenEngine/creations/demos/shape_debug')" \
+          "creations/demos/shape_debug" "msys root + win scope -> relative subpath"
+# scope inside the build tree wins over the root branch
+assert_eq "$(scope_rel "$ROOT_WIN" "$ROOT_WIN/build" "$ROOT_WIN/build/creations")" \
+          "creations" "scope under build tree -> build-relative subpath"
+# a genuinely outside scope still reports OUTSIDE
+assert_eq "$(scope_rel "$ROOT_WIN" "$ROOT_WIN/build" 'C:/somewhere/else')" \
+          "OUTSIDE" "unrelated scope still detected as outside"
+# POSIX-only hosts: root == scope collapses to empty rel (whole-tree scan)
+assert_eq "$(scope_rel '/Users/e/IrredenEngine' '/Users/e/IrredenEngine/build' \
+                        '/Users/e/IrredenEngine')" \
+          "" "posix root == scope -> whole tree"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- `resolve_scope` in `fleet-run-targets` compared the engine root (git-style `C:/Users/x` from `git rev-parse --show-toplevel`) against the scope (`/c/Users/x` from an MSYS2 `$PWD`) byte-for-byte, so the same worktree spelled two ways failed the containment `case` and fell back to a whole-tree scan that found no executables — `ir-run --targets` was unusable on native Windows.
- Added `canonicalize_path_spelling` to `fleet-common.sh` (the shared helper home) and run `root`/`build`/`scope` through it before the containment compare. It collapses `C:/Users/x`, `c:\Users\x`, and `/c/Users/x` to a single canonical `/c/Users/x`.
- The helper is a byte-identity no-op on macOS/Linux paths (no POSIX abs path starts with a `<letter>:` drive) and is bash-3.2 compatible (`tr`, not `${var,,}`) for the `/bin/bash` and MSYS2 hosts.
- Added `scripts/fleet/tests/test_run_targets_path_scope.sh` (16 assertions): the exact `/c/…` vs `C:/…` spelling pair, backslash/case/bare-drive variants, POSIX pass-through, and a `resolve_scope` containment simulation (mixed spellings match; genuinely-outside still reports OUTSIDE).

## Test plan
- [x] `scripts/fleet/tests/test_run_targets_path_scope.sh` — 16/16 pass under bash 5.3 and bash 3.2
- [x] `bash -n` clean on both scripts
- [x] macOS end-to-end no-op preserved: root scope → whole tree; `--scope creations/` scoped without false "outside"; `--scope test/` narrows correctly; `--scope /tmp` still reports "is outside"
- [ ] Windows: `ir-run --targets --plain` lists built executables from inside the worktree with no "scope … is outside …" false-positive (acceptance criteria; not runnable on the macOS author host)

## Notes for reviewer
Authored on macOS, so the Windows acceptance path is verified by the deterministic containment test (feeding the literal `/c/…` and `C:/…` strings) rather than a live Windows run. The fix is pure path-string logic, so the test reproduces the exact failing scenario on any host.

Closes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)